### PR TITLE
[DC] `dc.value` should only take one type

### DIFF
--- a/include/circt/Dialect/DC/DCOps.td
+++ b/include/circt/Dialect/DC/DCOps.td
@@ -66,9 +66,9 @@ def BufferOp : DCOp<"buffer",
 
   let extraClassDeclaration = [{
     // Returns the data type of this buffer, if any.
-    std::optional<TypeRange> getInnerTypes() {
+    std::optional<TypeRange> getInnerType() {
       if(auto type = getInput().getType().dyn_cast<ValueType>())
-        return type.getInnerTypes();
+        return type.getInnerType();
       return std::nullopt;
     }
 
@@ -184,9 +184,9 @@ def PackOp : DCOp<"pack", [InferTypeOpInterface]> {
         signal for either a `dc.branch` or `dc.select` operation.
     }];
 
-    let arguments = (ins TokenType:$token, Variadic<AnyType>:$inputs);
+    let arguments = (ins TokenType:$token, AnyType:$input);
     let results = (outs ValueType:$output);
-    let assemblyFormat = "$token `[` $inputs `]` attr-dict `:` type($inputs)";
+    let assemblyFormat = "$token `,` $input attr-dict `:` type($input)";
     let hasFolder = 1;
 
     let extraClassDeclaration = [{
@@ -209,7 +209,7 @@ def UnpackOp : DCOp<"unpack", [InferTypeOpInterface]> {
     }];
 
     let arguments = (ins ValueType:$input);
-    let results = (outs TokenType:$token, Variadic<AnyType>:$outputs);
+    let results = (outs TokenType:$token, AnyType:$output);
     let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
     let hasCanonicalizer = 1;
     let hasFolder = 1;

--- a/include/circt/Dialect/DC/DCTypes.td
+++ b/include/circt/Dialect/DC/DCTypes.td
@@ -23,15 +23,15 @@ def TokenType : DCTypeDef<"Token"> {
   }];
 }
 
-// A value type is a set of values which is wrapped with token semantics.
+// A value type is a value which is wrapped with token semantics.
 def ValueType : DCTypeDef<"Value"> {
   let mnemonic = "value";
-  let parameters = (ins ArrayRefParameter<"Type">:$innerTypes);
-  let assemblyFormat = "`<`$innerTypes`>`";
+  let parameters = (ins "Type":$innerType);
+  let assemblyFormat = "`<`$innerType`>`";
   let description = [{
-    A `!dc.value`-typed value represents a set of values which is wrapped with
+    A `!dc.value`-typed value represents a value which is wrapped with
     `!dc.token` semantics. This type is used to attach control semantics to
-    values. The inner values may be of any type.
+    values. The inner value may be of any type.
   }];
 }
 

--- a/integration_test/Dialect/DC/max/max.mlir
+++ b/integration_test/Dialect/DC/max/max.mlir
@@ -44,6 +44,6 @@ hw.module @top(%in0: !dc.value<i64>, %in1: !dc.value<i64>, %in2: !dc.value<i64>,
   %12 = comb.icmp sge %9, %11 : i64
   %14 = comb.mux %12, %9, %11 : i64
   %13 = dc.join %token, %token_0, %token_2, %token_4, %token_6, %token_8, %token_10, %token_12
-  %15 = dc.pack %13[%14] : i64
+  %15 = dc.pack %13, %14 : i64
   hw.output %15, %in8 : !dc.value<i64>, !dc.token
 }

--- a/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
+++ b/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
@@ -39,11 +39,11 @@ using ConvertedOps = DenseSet<Operation *>;
 
 struct DCTuple {
   DCTuple() = default;
-  DCTuple(Value token, ValueRange data) : token(token), data(data) {}
+  DCTuple(Value token, Value data) : token(token), data(data) {}
   DCTuple(dc::UnpackOp unpack)
-      : token(unpack.getToken()), data(unpack.getOutputs()) {}
+      : token(unpack.getToken()), data(unpack.getOutput()) {}
   Value token;
-  ValueRange data;
+  Value data;
 };
 
 // Unpack a !dc.value<...> into a DCTuple.
@@ -51,11 +51,11 @@ static DCTuple unpack(OpBuilder &b, Value v) {
   if (v.getType().isa<dc::ValueType>())
     return DCTuple(b.create<dc::UnpackOp>(v.getLoc(), v));
   assert(v.getType().isa<dc::TokenType>() && "Expected a dc::TokenType");
-  return DCTuple(v, ValueRange{});
+  return DCTuple(v, {});
 }
 
-static Value pack(OpBuilder &b, Value token, ValueRange data) {
-  if (data.empty())
+static Value pack(OpBuilder &b, Value token, Value data = {}) {
+  if (!data)
     return token;
   return b.create<dc::PackOp>(token.getLoc(), token, data);
 }
@@ -85,8 +85,8 @@ public:
 
           // Materialize !dc.token -> !dc.value<>
           auto vt = resultType.dyn_cast<dc::ValueType>();
-          if (vt && vt.getInnerTypes().empty())
-            return pack(builder, inputs.front(), ValueRange{});
+          if (vt && !vt.getInnerType())
+            return pack(builder, inputs.front());
 
           return inputs[0];
         });
@@ -105,8 +105,8 @@ public:
 
           // Materialize !dc.token -> !dc.value<>
           auto vt = resultType.dyn_cast<dc::ValueType>();
-          if (vt && vt.getInnerTypes().empty())
-            return pack(builder, inputs.front(), ValueRange{});
+          if (vt && !vt.getInnerType())
+            return pack(builder, inputs.front());
 
           return inputs[0];
         });
@@ -144,7 +144,7 @@ public:
         op.getLoc(), ValueRange{condition.token, data.token});
 
     // Pack that together with the condition data.
-    auto packedCondition = pack(rewriter, join, ValueRange{condition.data});
+    auto packedCondition = pack(rewriter, join, condition.data);
 
     // Branch on the input data and the joined control input.
     auto branch = rewriter.create<dc::BranchOp>(op.getLoc(), packedCondition);
@@ -175,7 +175,7 @@ public:
     // Pack the fork result tokens with the input data, and replace the uses.
     llvm::SmallVector<Value, 4> packed;
     for (auto res : forkOut.getResults())
-      packed.push_back(pack(rewriter, res, ValueRange{input.data}));
+      packed.push_back(pack(rewriter, res, input.data));
 
     rewriter.replaceOp(op, packed);
     return success();
@@ -216,14 +216,14 @@ public:
     for (auto input : adaptor.getDataOperands()) {
       auto up = unpack(rewriter, input);
       tokens.push_back(up.token);
-      if (!up.data.empty())
-        data.push_back(up.data.front());
+      if (up.data)
+        data.push_back(up.data);
     }
 
     // control-side
     Value selectedIndex = rewriter.create<dc::MergeOp>(op.getLoc(), tokens);
     auto mergeOpUnpacked = unpack(rewriter, selectedIndex);
-    auto selValue = mergeOpUnpacked.data.front();
+    auto selValue = mergeOpUnpacked.data;
 
     Value dataSide = selectedIndex;
     if (!data.empty()) {
@@ -232,7 +232,7 @@ public:
                                                       data[0], data[1]);
       convertedOps->insert(dataMux);
       // Pack the data mux with the control token.
-      auto packed = pack(rewriter, mergeOpUnpacked.token, ValueRange{dataMux});
+      auto packed = pack(rewriter, mergeOpUnpacked.token, dataMux);
 
       dataSide = packed;
     }
@@ -243,8 +243,7 @@ public:
       selValue = rewriter.create<arith::IndexCastOp>(
           op.getLoc(), rewriter.getIndexType(), selValue);
       convertedOps->insert(selValue.getDefiningOp());
-      selectedIndex =
-          pack(rewriter, mergeOpUnpacked.token, ValueRange{selValue});
+      selectedIndex = pack(rewriter, mergeOpUnpacked.token, selValue);
     }
 
     rewriter.replaceOp(op, {dataSide, selectedIndex});
@@ -269,7 +268,7 @@ public:
     // Wrap all outputs with the synchronization token
     llvm::SmallVector<Value, 4> wrappedInputs;
     for (auto input : adaptor.getOperands())
-      wrappedInputs.push_back(pack(rewriter, syncToken, ValueRange{input}));
+      wrappedInputs.push_back(pack(rewriter, syncToken, input));
 
     rewriter.replaceOp(op, wrappedInputs);
 
@@ -291,8 +290,7 @@ public:
     auto cst =
         rewriter.create<arith::ConstantOp>(op.getLoc(), adaptor.getValue());
     convertedOps->insert(cst);
-    rewriter.replaceOp(op,
-                       pack(rewriter, token, llvm::SmallVector<Value>{cst}));
+    rewriter.replaceOp(op, pack(rewriter, token, cst));
     return success();
   }
 };
@@ -317,7 +315,7 @@ public:
     llvm::SmallVector<Value, 4> inputTokens;
     for (auto input : operands) {
       auto dct = unpack(rewriter, input);
-      inputData.append(dct.data.begin(), dct.data.end());
+      inputData.push_back(dct.data);
       inputTokens.push_back(dct.token);
     }
 
@@ -340,8 +338,8 @@ public:
     joinedOps->insert(newOp);
 
     // Pack the result token with the output data, and replace the use.
-    rewriter.replaceOp(
-        op, ValueRange{pack(rewriter, join.getResult(), newOp->getResults())});
+    rewriter.replaceOp(op, ValueRange{pack(rewriter, join.getResult(),
+                                           newOp->getResults().front())});
 
     return success();
   }
@@ -421,7 +419,7 @@ public:
   matchAndRewrite(handshake::MuxOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto select = unpack(rewriter, adaptor.getSelectOperand());
-    auto selectData = select.data.front();
+    auto selectData = select.data;
     auto selectToken = select.token;
     bool isIndexType = selectData.getType().isa<IndexType>();
 
@@ -437,7 +435,7 @@ public:
     // The data and control muxes are assumed one-hot and the base-case is set
     // as the first input.
     if (withData)
-      dataMux = inputs[0].data.front();
+      dataMux = inputs[0].data;
 
     llvm::SmallVector<Value> controlMuxInputs = {inputs.front().token};
     for (auto [i, input] :
@@ -446,7 +444,7 @@ public:
         continue;
 
       Value cmpIndex;
-      Value inputData = input.data.front();
+      Value inputData = input.data;
       Value inputControl = input.token;
       if (isIndexType) {
         cmpIndex = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), i);
@@ -467,16 +465,15 @@ public:
       // And similarly for the control mux, by muxing the input token with a
       // select value that has it's control from the original select token +
       // the inputSelected value.
-      auto inputSelectedControl =
-          pack(rewriter, selectToken, ValueRange{inputSelected});
+      auto inputSelectedControl = pack(rewriter, selectToken, inputSelected);
       controlMux = rewriter.create<dc::SelectOp>(
           op.getLoc(), inputSelectedControl, inputControl, controlMux);
       convertedOps->insert(controlMux.getDefiningOp());
     }
 
     // finally, pack the control and data side muxes into the output value.
-    rewriter.replaceOp(op, pack(rewriter, controlMux,
-                                withData ? ValueRange{dataMux} : ValueRange{}));
+    rewriter.replaceOp(
+        op, pack(rewriter, controlMux, withData ? dataMux : Value{}));
     return success();
   }
 };

--- a/lib/Dialect/DC/DCOps.cpp
+++ b/lib/Dialect/DC/DCOps.cpp
@@ -19,10 +19,9 @@ using namespace mlir;
 
 bool circt::dc::isI1ValueType(Type t) {
   auto vt = t.dyn_cast<ValueType>();
-  if (!vt || vt.getInnerTypes().size() != 1)
+  if (!vt)
     return false;
-
-  auto innerWidth = vt.getInnerTypes()[0].getIntOrFloatBitWidth();
+  auto innerWidth = vt.getInnerType().getIntOrFloatBitWidth();
   return innerWidth == 1;
 }
 
@@ -203,8 +202,7 @@ struct EliminateRedundantUnpackPattern : public OpRewritePattern<UnpackOp> {
   LogicalResult matchAndRewrite(UnpackOp unpack,
                                 PatternRewriter &rewriter) const override {
     // Is the value-side of the unpack used?
-    if (!llvm::all_of(unpack.getOutputs(),
-                      [](auto output) { return output.use_empty(); }))
+    if (!unpack.getOutput().use_empty())
       return failure();
 
     auto pack = unpack.getInput().getDefiningOp<PackOp>();
@@ -228,7 +226,7 @@ LogicalResult UnpackOp::fold(FoldAdaptor adaptor,
   // Unpack of a pack is a no-op.
   if (auto pack = getInput().getDefiningOp<PackOp>()) {
     results.push_back(pack.getToken());
-    results.append(pack.getInputs().begin(), pack.getInputs().end());
+    results.push_back(pack.getInput());
     return success();
   }
 
@@ -241,8 +239,7 @@ LogicalResult UnpackOp::inferReturnTypes(
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
   auto inputType = operands.front().getType().cast<ValueType>();
   results.push_back(TokenType::get(context));
-  results.append(inputType.getInnerTypes().begin(),
-                 inputType.getInnerTypes().end());
+  results.push_back(inputType.getInnerType());
   return success();
 }
 
@@ -252,19 +249,12 @@ LogicalResult UnpackOp::inferReturnTypes(
 
 OpFoldResult PackOp::fold(FoldAdaptor adaptor) {
   auto token = getToken();
-  auto inputs = getInputs();
 
   // Pack of an unpack is a no-op.
   if (auto unpack = token.getDefiningOp<UnpackOp>()) {
-    llvm::SmallVector<Value> unpackResults = unpack.getResults();
-    if (unpackResults.size() == inputs.size() &&
-        llvm::all_of(llvm::zip(getInputs(), unpackResults), [&](auto it) {
-          return std::get<0>(it) == std::get<1>(it);
-        })) {
+    if (unpack.getOutput() == getInput())
       return unpack.getInput();
-    }
   }
-
   return {};
 }
 
@@ -273,9 +263,8 @@ LogicalResult PackOp::inferReturnTypes(
     DictionaryAttr attrs, mlir::OpaqueProperties properties,
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
   llvm::SmallVector<Type> inputTypes;
-  for (auto t : operands.drop_front().getTypes())
-    inputTypes.push_back(t);
-  auto valueType = dc::ValueType::get(context, inputTypes);
+  Type inputType = operands.back().getType();
+  auto valueType = dc::ValueType::get(context, inputType);
   results.push_back(valueType);
   return success();
 }

--- a/test/Conversion/DCToHW/basic.mlir
+++ b/test/Conversion/DCToHW/basic.mlir
@@ -4,9 +4,9 @@
 // CHECK-SAME:          %[[VAL_0:.*]]: !esi.channel<i0>, %[[VAL_1:.*]]: !esi.channel<i64>, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: !esi.channel<!hw.struct<field0: i1, field1: i2>>) -> (out0: !esi.channel<i0>, out1: !esi.channel<i64>, out2: i1, out3: !esi.channel<!hw.struct<field0: i1, field1: i2>>) attributes {argNames = ["", "", "", ""]} {
 // CHECK:           hw.output %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : !esi.channel<i0>, !esi.channel<i64>, i1, !esi.channel<!hw.struct<field0: i1, field1: i2>>
 // CHECK:         }
-hw.module @simple(%0 : !dc.token, %1 : !dc.value<i64>, %2 : i1, %3 : !dc.value<i1, i2>)
-        -> (out0: !dc.token, out1: !dc.value<i64>, out2: i1, out3: !dc.value<i1, i2>) {
-    hw.output %0, %1, %2, %3 : !dc.token, !dc.value<i64>, i1, !dc.value<i1, i2>
+hw.module @simple(%0 : !dc.token, %1 : !dc.value<i64>, %2 : i1, %3 : !dc.value<i1>)
+        -> (out0: !dc.token, out1: !dc.value<i64>, out2: i1, out3: !dc.value<i1>) {
+    hw.output %0, %1, %2, %3 : !dc.token, !dc.value<i64>, i1, !dc.value<i1>
 }
 
 // CHECK-LABEL:   hw.module @pack(
@@ -16,9 +16,9 @@ hw.module @simple(%0 : !dc.token, %1 : !dc.value<i64>, %2 : i1, %3 : !dc.value<i
 // CHECK:           %[[VAL_7]] = hw.struct_create (%[[VAL_1]], %[[VAL_2]]) : !hw.struct<field0: i64, field1: i1>
 // CHECK:           hw.output %[[VAL_6]] : !esi.channel<!hw.struct<field0: i64, field1: i1>>
 // CHECK:         }
-hw.module @pack(%token : !dc.token, %v1 : i64, %v2 : i1) -> (out0: !dc.value<i64, i1>) {
-    %out = dc.pack %token [%v1, %v2] : i64, i1
-    hw.output %out : !dc.value<i64, i1>
+hw.module @pack(%token : !dc.token, %v1 : i64) -> (out0: !dc.value<i64>) {
+    %out = dc.pack %token, %v1 : i64
+    hw.output %out : !dc.value<i64>
 }
 
 // CHECK-LABEL:   hw.module @unpack(
@@ -29,9 +29,9 @@ hw.module @pack(%token : !dc.token, %v1 : i64, %v2 : i1) -> (out0: !dc.value<i64
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.struct_explode %[[VAL_1]] : !hw.struct<field0: i64, field1: i1>
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_6]], %[[VAL_7]] : !esi.channel<i0>, i64, i1
 // CHECK:         }
-hw.module @unpack(%v : !dc.value<i64, i1>) -> (out0: !dc.token, out1: i64, out2: i1) {
-    %out:3 = dc.unpack %v : !dc.value<i64, i1>
-    hw.output %out#0, %out#1, %out#2 : !dc.token, i64, i1
+hw.module @unpack(%v : !dc.value<i64>) -> (out0: !dc.token, out1: i64) {
+    %out:2 = dc.unpack %v : !dc.value<i64>
+    hw.output %out#0, %out#1 : !dc.token, i64
 }
 
 // CHECK-LABEL:   hw.module @join(

--- a/test/Conversion/DCToHW/basic.mlir
+++ b/test/Conversion/DCToHW/basic.mlir
@@ -1,8 +1,8 @@
 // RUN: circt-opt --lower-dc-to-hw %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @simple(
-// CHECK-SAME:          %[[VAL_0:.*]]: !esi.channel<i0>, %[[VAL_1:.*]]: !esi.channel<i64>, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: !esi.channel<!hw.struct<field0: i1, field1: i2>>) -> (out0: !esi.channel<i0>, out1: !esi.channel<i64>, out2: i1, out3: !esi.channel<!hw.struct<field0: i1, field1: i2>>) attributes {argNames = ["", "", "", ""]} {
-// CHECK:           hw.output %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : !esi.channel<i0>, !esi.channel<i64>, i1, !esi.channel<!hw.struct<field0: i1, field1: i2>>
+// CHECK-SAME:             %[[VAL_0:.*]]: !esi.channel<i0>, %[[VAL_1:.*]]: !esi.channel<i64>, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: !esi.channel<i1>) -> (out0: !esi.channel<i0>, out1: !esi.channel<i64>, out2: i1, out3: !esi.channel<i1>) attributes {argNames = ["", "", "", ""]} {
+// CHECK:           hw.output %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]] : !esi.channel<i0>, !esi.channel<i64>, i1, !esi.channel<i1>
 // CHECK:         }
 hw.module @simple(%0 : !dc.token, %1 : !dc.value<i64>, %2 : i1, %3 : !dc.value<i1>)
         -> (out0: !dc.token, out1: !dc.value<i64>, out2: i1, out3: !dc.value<i1>) {
@@ -10,25 +10,21 @@ hw.module @simple(%0 : !dc.token, %1 : !dc.value<i64>, %2 : i1, %3 : !dc.value<i
 }
 
 // CHECK-LABEL:   hw.module @pack(
-// CHECK-SAME:         %[[VAL_0:.*]]: !esi.channel<i0>, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i1) -> (out0: !esi.channel<!hw.struct<field0: i64, field1: i1>>) {
-// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_5:.*]] : i0
-// CHECK:           %[[VAL_6:.*]], %[[VAL_5]] = esi.wrap.vr %[[VAL_7:.*]], %[[VAL_4]] : !hw.struct<field0: i64, field1: i1>
-// CHECK:           %[[VAL_7]] = hw.struct_create (%[[VAL_1]], %[[VAL_2]]) : !hw.struct<field0: i64, field1: i1>
-// CHECK:           hw.output %[[VAL_6]] : !esi.channel<!hw.struct<field0: i64, field1: i1>>
-// CHECK:         }
+// CHECK-SAME:                    %[[VAL_0:.*]]: !esi.channel<i0>, %[[VAL_1:.*]]: i64) -> (out0: !esi.channel<i64>) {
+// CHECK:           %[[VAL_2:.*]], %[[VAL_3:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_4:.*]] : i0
+// CHECK:           %[[VAL_5:.*]], %[[VAL_4]] = esi.wrap.vr %[[VAL_1]], %[[VAL_3]] : i64
+// CHECK:           hw.output %[[VAL_5]] : !esi.channel<i64>
 hw.module @pack(%token : !dc.token, %v1 : i64) -> (out0: !dc.value<i64>) {
     %out = dc.pack %token, %v1 : i64
     hw.output %out : !dc.value<i64>
 }
 
 // CHECK-LABEL:   hw.module @unpack(
-// CHECK-SAME:              %[[VAL_0:.*]]: !esi.channel<!hw.struct<field0: i64, field1: i1>>) -> (out0: !esi.channel<i0>, out1: i64, out2: i1) {
-// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_3:.*]] : !hw.struct<field0: i64, field1: i1>
+// CHECK-SAME:                      %[[VAL_0:.*]]: !esi.channel<i64>) -> (out0: !esi.channel<i0>, out1: i64) {
+// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_3:.*]] : i64
 // CHECK:           %[[VAL_4:.*]] = hw.constant 0 : i0
 // CHECK:           %[[VAL_5:.*]], %[[VAL_3]] = esi.wrap.vr %[[VAL_4]], %[[VAL_2]] : i0
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.struct_explode %[[VAL_1]] : !hw.struct<field0: i64, field1: i1>
-// CHECK:           hw.output %[[VAL_5]], %[[VAL_6]], %[[VAL_7]] : !esi.channel<i0>, i64, i1
-// CHECK:         }
+// CHECK:           hw.output %[[VAL_5]], %[[VAL_1]] : !esi.channel<i0>, i64
 hw.module @unpack(%v : !dc.value<i64>) -> (out0: !dc.token, out1: i64) {
     %out:2 = dc.unpack %v : !dc.value<i64>
     hw.output %out#0, %out#1 : !dc.token, i64

--- a/test/Conversion/HandshakeToDC/basic.mlir
+++ b/test/Conversion/HandshakeToDC/basic.mlir
@@ -14,13 +14,13 @@ handshake.func @test_fork(%arg0: none) -> (none, none) {
 // CHECK-SAME:                              %[[VAL_0:.*]]: !dc.value<i32>) -> (out0: !dc.value<i32>) {
 // CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = dc.unpack %[[VAL_0]] : !dc.value<i32>
 // CHECK:           %[[VAL_3:.*]]:2 = dc.fork [2] %[[VAL_1]]
-// CHECK:           %[[VAL_4:.*]] = dc.pack %[[VAL_3]]#0{{\[}}%[[VAL_2]]] : i32
-// CHECK:           %[[VAL_5:.*]] = dc.pack %[[VAL_3]]#1{{\[}}%[[VAL_2]]] : i32
+// CHECK:           %[[VAL_4:.*]] = dc.pack %[[VAL_3]]#0, %[[VAL_2]] : i32
+// CHECK:           %[[VAL_5:.*]] = dc.pack %[[VAL_3]]#1, %[[VAL_2]] : i32
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = dc.unpack %[[VAL_4]] : !dc.value<i32>
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = dc.unpack %[[VAL_5]] : !dc.value<i32>
 // CHECK:           %[[VAL_10:.*]] = dc.join %[[VAL_6]], %[[VAL_8]]
 // CHECK:           %[[VAL_11:.*]] = arith.addi %[[VAL_7]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_12:.*]] = dc.pack %[[VAL_10]]{{\[}}%[[VAL_11]]] : i32
+// CHECK:           %[[VAL_12:.*]] = dc.pack %[[VAL_10]], %[[VAL_11]] : i32
 // CHECK:           hw.output %[[VAL_12]] : !dc.value<i32>
 // CHECK:         }
 handshake.func @test_fork_data(%arg0: i32) -> (i32) {
@@ -35,13 +35,13 @@ handshake.func @test_fork_data(%arg0: i32) -> (i32) {
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = dc.unpack %[[VAL_1]] : !dc.value<i64>
 // CHECK:           %[[VAL_7:.*]] = dc.join %[[VAL_3]], %[[VAL_5]]
 // CHECK:           %[[VAL_8:.*]] = arith.cmpi slt, %[[VAL_4]], %[[VAL_6]] : i64
-// CHECK:           %[[VAL_9:.*]] = dc.pack %[[VAL_7]]{{\[}}%[[VAL_8]]] : i1
+// CHECK:           %[[VAL_9:.*]] = dc.pack %[[VAL_7]], %[[VAL_8]] : i1
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = dc.unpack %[[VAL_9]] : !dc.value<i1>
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = dc.unpack %[[VAL_1]] : !dc.value<i64>
 // CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = dc.unpack %[[VAL_0]] : !dc.value<i64>
 // CHECK:           %[[VAL_16:.*]] = dc.join %[[VAL_10]], %[[VAL_12]], %[[VAL_14]]
 // CHECK:           %[[VAL_17:.*]] = arith.select %[[VAL_11]], %[[VAL_13]], %[[VAL_15]] : i64
-// CHECK:           %[[VAL_18:.*]] = dc.pack %[[VAL_16]]{{\[}}%[[VAL_17]]] : i64
+// CHECK:           %[[VAL_18:.*]] = dc.pack %[[VAL_16]], %[[VAL_17]] : i64
 // CHECK:           hw.output %[[VAL_18]], %[[VAL_2]] : !dc.value<i64>, !dc.token
 // CHECK:         }
 handshake.func @top(%arg0: i64, %arg1: i64, %arg8: none, ...) -> (i64, none) {
@@ -58,9 +58,9 @@ handshake.func @top(%arg0: i64, %arg1: i64, %arg8: none, ...) -> (i64, none) {
 // CHECK:           %[[VAL_9:.*]] = arith.constant false
 // CHECK:           %[[VAL_10:.*]] = arith.cmpi eq, %[[VAL_4]], %[[VAL_9]] : i1
 // CHECK:           %[[VAL_11:.*]] = arith.select %[[VAL_10]], %[[VAL_8]], %[[VAL_6]] : i64
-// CHECK:           %[[VAL_12:.*]] = dc.pack %[[VAL_3]]{{\[}}%[[VAL_10]]] : i1
+// CHECK:           %[[VAL_12:.*]] = dc.pack %[[VAL_3]], %[[VAL_10]] : i1
 // CHECK:           %[[VAL_13:.*]] = dc.select %[[VAL_12]], %[[VAL_7]], %[[VAL_5]]
-// CHECK:           %[[VAL_14:.*]] = dc.pack %[[VAL_13]]{{\[}}%[[VAL_11]]] : i64
+// CHECK:           %[[VAL_14:.*]] = dc.pack %[[VAL_13]], %[[VAL_11]] : i64
 // CHECK:           hw.output %[[VAL_14]] : !dc.value<i64>
 // CHECK:         }
 handshake.func @mux(%select : i1, %a : i64, %b : i64) -> i64{
@@ -78,19 +78,19 @@ handshake.func @mux(%select : i1, %a : i64, %b : i64) -> i64{
 // CHECK:           %[[VAL_15:.*]] = arith.constant 0 : i2
 // CHECK:           %[[VAL_16:.*]] = arith.cmpi eq, %[[VAL_6]], %[[VAL_15]] : i2
 // CHECK:           %[[VAL_17:.*]] = arith.select %[[VAL_16]], %[[VAL_10]], %[[VAL_8]] : i64
-// CHECK:           %[[VAL_18:.*]] = dc.pack %[[VAL_5]]{{\[}}%[[VAL_16]]] : i1
+// CHECK:           %[[VAL_18:.*]] = dc.pack %[[VAL_5]], %[[VAL_16]] : i1
 // CHECK:           %[[VAL_19:.*]] = dc.select %[[VAL_18]], %[[VAL_9]], %[[VAL_7]]
 // CHECK:           %[[VAL_20:.*]] = arith.constant 1 : i2
 // CHECK:           %[[VAL_21:.*]] = arith.cmpi eq, %[[VAL_6]], %[[VAL_20]] : i2
 // CHECK:           %[[VAL_22:.*]] = arith.select %[[VAL_21]], %[[VAL_12]], %[[VAL_17]] : i64
-// CHECK:           %[[VAL_23:.*]] = dc.pack %[[VAL_5]]{{\[}}%[[VAL_21]]] : i1
+// CHECK:           %[[VAL_23:.*]] = dc.pack %[[VAL_5]], %[[VAL_21]] : i1
 // CHECK:           %[[VAL_24:.*]] = dc.select %[[VAL_23]], %[[VAL_11]], %[[VAL_19]]
 // CHECK:           %[[VAL_25:.*]] = arith.constant -2 : i2
 // CHECK:           %[[VAL_26:.*]] = arith.cmpi eq, %[[VAL_6]], %[[VAL_25]] : i2
 // CHECK:           %[[VAL_27:.*]] = arith.select %[[VAL_26]], %[[VAL_14]], %[[VAL_22]] : i64
-// CHECK:           %[[VAL_28:.*]] = dc.pack %[[VAL_5]]{{\[}}%[[VAL_26]]] : i1
+// CHECK:           %[[VAL_28:.*]] = dc.pack %[[VAL_5]], %[[VAL_26]] : i1
 // CHECK:           %[[VAL_29:.*]] = dc.select %[[VAL_28]], %[[VAL_13]], %[[VAL_24]]
-// CHECK:           %[[VAL_30:.*]] = dc.pack %[[VAL_29]]{{\[}}%[[VAL_27]]] : i64
+// CHECK:           %[[VAL_30:.*]] = dc.pack %[[VAL_29]], %[[VAL_27]] : i64
 // CHECK:           hw.output %[[VAL_30]] : !dc.value<i64>
 // CHECK:         }
 handshake.func @mux4(%select : i2, %a : i64, %b : i64, %c : i64, %d : i64) -> i64{
@@ -103,10 +103,10 @@ handshake.func @mux4(%select : i2, %a : i64, %b : i64, %c : i64, %d : i64) -> i6
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = dc.unpack %[[VAL_0]] : !dc.value<i1>
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = dc.unpack %[[VAL_1]] : !dc.value<index>
 // CHECK:           %[[VAL_7:.*]] = dc.join %[[VAL_3]], %[[VAL_5]]
-// CHECK:           %[[VAL_8:.*]] = dc.pack %[[VAL_7]]{{\[}}%[[VAL_4]]] : i1
+// CHECK:           %[[VAL_8:.*]] = dc.pack %[[VAL_7]], %[[VAL_4]] : i1
 // CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = dc.branch %[[VAL_8]]
-// CHECK:           %[[VAL_11:.*]] = dc.pack %[[VAL_9]]{{\[}}%[[VAL_6]]] : index
-// CHECK:           %[[VAL_12:.*]] = dc.pack %[[VAL_10]]{{\[}}%[[VAL_6]]] : index
+// CHECK:           %[[VAL_11:.*]] = dc.pack %[[VAL_9]], %[[VAL_6]] : index
+// CHECK:           %[[VAL_12:.*]] = dc.pack %[[VAL_10]], %[[VAL_6]] : index
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_12]], %[[VAL_2]] : !dc.value<index>, !dc.value<index>, !dc.token
 // CHECK:         }
 handshake.func @test_conditional_branch(%arg0: i1, %arg1: index, %arg2: none, ...) -> (index, index, none) {
@@ -118,7 +118,7 @@ handshake.func @test_conditional_branch(%arg0: i1, %arg1: index, %arg2: none, ..
 // CHECK-SAME:               %[[VAL_0:.*]]: !dc.value<i1>,  %[[VAL_1:.*]]: !dc.token) -> (out0: !dc.token, out1: !dc.token) {
 // CHECK:           %[[VAL_2:.*]], %[[VAL_3:.*]] = dc.unpack %[[VAL_0]] : !dc.value<i1>
 // CHECK:           %[[VAL_4:.*]] = dc.join %[[VAL_2]], %[[VAL_1]]
-// CHECK:           %[[VAL_5:.*]] = dc.pack %[[VAL_4]]{{\[}}%[[VAL_3]]] : i1
+// CHECK:           %[[VAL_5:.*]] = dc.pack %[[VAL_4]], %[[VAL_3]] : i1
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = dc.branch %[[VAL_5]]
 // CHECK:           hw.output %[[VAL_6]], %[[VAL_7]] : !dc.token, !dc.token
 // CHECK:         }
@@ -131,7 +131,7 @@ handshake.func @test_conditional_branch_none(%arg0: i1, %arg1: none) -> (none, n
 // CHECK-SAME:                             %[[VAL_0:.*]]: !dc.token) -> (out0: !dc.value<i32>) {
 // CHECK:           %[[VAL_1:.*]] = dc.source
 // CHECK:           %[[VAL_2:.*]] = arith.constant 42 : i32
-// CHECK:           %[[VAL_3:.*]] = dc.pack %[[VAL_1]]{{\[}}%[[VAL_2]]] : i32
+// CHECK:           %[[VAL_3:.*]] = dc.pack %[[VAL_1]], %[[VAL_2]] : i32
 // CHECK:           hw.output %[[VAL_3]] : !dc.value<i32>
 // CHECK:         }
 handshake.func @test_constant(%arg0: none) -> (i32) {
@@ -145,7 +145,7 @@ handshake.func @test_constant(%arg0: none) -> (i32) {
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = dc.unpack %[[VAL_2]] : !dc.value<i1>
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = dc.unpack %[[VAL_2]] : !dc.value<i1>
 // CHECK:           %[[VAL_7:.*]] = arith.index_cast %[[VAL_6]] : i1 to index
-// CHECK:           %[[VAL_8:.*]] = dc.pack %[[VAL_5]]{{\[}}%[[VAL_7]]] : index
+// CHECK:           %[[VAL_8:.*]] = dc.pack %[[VAL_5]], %[[VAL_7]] : index
 // CHECK:           hw.output %[[VAL_3]], %[[VAL_8]] : !dc.token, !dc.value<index>
 // CHECK:         }
 handshake.func @test_control_merge(%arg0 : none, %arg1 : none) -> (none, index) {
@@ -160,9 +160,9 @@ handshake.func @test_control_merge(%arg0 : none, %arg1 : none) -> (none, index) 
 // CHECK:           %[[VAL_6:.*]] = dc.merge %[[VAL_2]], %[[VAL_4]]
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = dc.unpack %[[VAL_6]] : !dc.value<i1>
 // CHECK:           %[[VAL_9:.*]] = arith.select %[[VAL_8]], %[[VAL_3]], %[[VAL_5]] : i2
-// CHECK:           %[[VAL_10:.*]] = dc.pack %[[VAL_7]]{{\[}}%[[VAL_9]]] : i2
+// CHECK:           %[[VAL_10:.*]] = dc.pack %[[VAL_7]], %[[VAL_9]] : i2
 // CHECK:           %[[VAL_11:.*]] = arith.index_cast %[[VAL_8]] : i1 to index
-// CHECK:           %[[VAL_12:.*]] = dc.pack %[[VAL_7]]{{\[}}%[[VAL_11]]] : index
+// CHECK:           %[[VAL_12:.*]] = dc.pack %[[VAL_7]], %[[VAL_11]] : index
 // CHECK:           hw.output %[[VAL_10]], %[[VAL_12]] : !dc.value<i2>, !dc.value<index>
 // CHECK:         }
 handshake.func @test_control_merge_data(%arg0 : i2, %arg1 : i2) -> (i2, index) {
@@ -176,10 +176,10 @@ handshake.func @test_control_merge_data(%arg0 : i2, %arg1 : i2) -> (i2, index) {
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = dc.unpack %[[VAL_2]] : !dc.value<i1>
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = dc.unpack %[[VAL_2]] : !dc.value<i1>
 // CHECK:           %[[VAL_9:.*]] = arith.index_cast %[[VAL_8]] : i1 to index
-// CHECK:           %[[VAL_10:.*]] = dc.pack %[[VAL_7]]{{\[}}%[[VAL_9]]] : index
+// CHECK:           %[[VAL_10:.*]] = dc.pack %[[VAL_7]], %[[VAL_9]] : index
 // CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]] = dc.unpack %[[VAL_0]] : !dc.value<i1>
 // CHECK:           %[[VAL_13:.*]] = dc.join %[[VAL_11]], %[[VAL_1]]
-// CHECK:           %[[VAL_14:.*]] = dc.pack %[[VAL_13]]{{\[}}%[[VAL_12]]] : i1
+// CHECK:           %[[VAL_14:.*]] = dc.pack %[[VAL_13]], %[[VAL_12]] : i1
 // CHECK:           %[[VAL_3]], %[[VAL_4]] = dc.branch %[[VAL_14]]
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_10]] : !dc.token, !dc.value<index>
 // CHECK:         }

--- a/test/Dialect/DC/canonicalization.mlir
+++ b/test/Dialect/DC/canonicalization.mlir
@@ -45,39 +45,36 @@ func.func @fork(%a: !dc.token) -> (!dc.token) {
 
 // CHECK-LABEL:   func.func @packUnpack(
 // CHECK-SAME:                          %[[VAL_0:.*]]: !dc.token,
-// CHECK-SAME:                          %[[VAL_1:.*]]: i32,
-// CHECK-SAME:                          %[[VAL_2:.*]]: i1) -> (!dc.token, i32, i1) {
-// CHECK:           return %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] : !dc.token, i32, i1
+// CHECK-SAME:                          %[[VAL_1:.*]]: i32) -> (!dc.token, i32) {
+// CHECK:           return %[[VAL_0]], %[[VAL_1]] : !dc.token, i32
 // CHECK:         }
-func.func @packUnpack(%a: !dc.token, %b : i32, %c : i1) -> (!dc.token, i32, i1) {
-    %0 = dc.pack %a [%b,%c] : i32, i1
-    %1:3 = dc.unpack %0 : !dc.value<i32, i1>
-    return %1#0, %1#1, %1#2 : !dc.token, i32, i1
+func.func @packUnpack(%a: !dc.token, %b : i32) -> (!dc.token, i32) {
+    %0 = dc.pack %a, %b : i32
+    %1:2 = dc.unpack %0 : !dc.value<i32>
+    return %1#0, %1#1 : !dc.token, i32
 }
 
 // CHECK-LABEL:   func.func @redundantPack(
 // CHECK-SAME:                             %[[VAL_0:.*]]: !dc.token,
-// CHECK-SAME:                             %[[VAL_1:.*]]: i32,
-// CHECK-SAME:                             %[[VAL_2:.*]]: i1) -> !dc.token {
+// CHECK-SAME:                             %[[VAL_1:.*]]: i32) -> !dc.token {
 // CHECK:           return %[[VAL_0]] : !dc.token
 // CHECK:         }
-func.func @redundantPack(%a: !dc.token, %b : i32, %c : i1) -> (!dc.token) {
-    %0 = dc.pack %a [%b,%c] : i32, i1 
-    %1:3 = dc.unpack %0 : !dc.value<i32, i1>
+func.func @redundantPack(%a: !dc.token, %b : i32) -> (!dc.token) {
+    %0 = dc.pack %a, %b : i32 
+    %1:2 = dc.unpack %0 : !dc.value<i32>
     return %1#0 : !dc.token
 }
 
 // CHECK-LABEL:   func.func @csePack(
 // CHECK-SAME:                       %[[VAL_0:.*]]: !dc.token,
-// CHECK-SAME:                       %[[VAL_1:.*]]: i32,
-// CHECK-SAME:                       %[[VAL_2:.*]]: i1) -> (!dc.value<i32, i1>, !dc.value<i32, i1>) {
-// CHECK:           %[[VAL_3:.*]] = dc.pack %[[VAL_0]]{{\[}}%[[VAL_1]], %[[VAL_2]]] : i32, i1
-// CHECK:           return %[[VAL_3]], %[[VAL_3]] : !dc.value<i32, i1>, !dc.value<i32, i1>
+// CHECK-SAME:                       %[[VAL_1:.*]]: i32) -> (!dc.value<i32>, !dc.value<i32>) {
+// CHECK:           %[[VAL_3:.*]] = dc.pack %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           return %[[VAL_3]], %[[VAL_3]] : !dc.value<i32>, !dc.value<i32>
 // CHECK:         }
-func.func @csePack(%a: !dc.token, %b : i32, %c : i1) -> (!dc.value<i32, i1>, !dc.value<i32, i1>) {
-    %0 = dc.pack %a [%b,%c] : i32, i1
-    %1 = dc.pack %a [%b,%c] : i32, i1
-    return %0, %1 : !dc.value<i32, i1>, !dc.value<i32, i1>
+func.func @csePack(%a: !dc.token, %b : i32) -> (!dc.value<i32>, !dc.value<i32>) {
+    %0 = dc.pack %a, %b : i32
+    %1 = dc.pack %a, %b : i32
+    return %0, %1 : !dc.value<i32>, !dc.value<i32>
 }
 
 

--- a/test/Dialect/DC/roundtrip.mlir
+++ b/test/Dialect/DC/roundtrip.mlir
@@ -1,22 +1,20 @@
 // RUN: circt-opt %s | circt-opt | FileCheck %s
 
-// CHECK-LABEL:   hw.module @foo(
-// CHECK-SAME:                   %[[VAL_0:.*]]: !dc.token,
-// CHECK-SAME:                   %[[VAL_1:.*]]: !dc.value<i1>,
-// CHECK-SAME:                   %[[VAL_2:.*]]: i32) attributes {argNames = ["", "", ""]} {
-// CHECK:           %[[VAL_3:.*]] = dc.buffer[2] %[[VAL_0]] : !dc.token
-// CHECK:           %[[VAL_4:.*]] = dc.buffer[2] %[[VAL_1]] [1, 2] : !dc.value<i1>
-// CHECK:           %[[VAL_5:.*]]:2 = dc.fork [2] %[[VAL_0]]
-// CHECK:           %[[VAL_6:.*]] = dc.pack %[[VAL_0]]{{\[}}%[[VAL_2]]] : i32
-// CHECK:           %[[VAL_7:.*]] = dc.merge %[[VAL_3]], %[[VAL_0]]
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = dc.unpack %[[VAL_1]] : !dc.value<i1>
-// CHECK:           hw.output
-// CHECK:         }
+// CHECK:       hw.module @foo(%arg0: !dc.token, %arg1: !dc.value<i1>, %arg2: i32) attributes {argNames = ["", "", ""]} {
+// CHECK-NEXT:    %0 = dc.buffer[2] %arg0 : !dc.token
+// CHECK-NEXT:    %1 = dc.buffer[2] %arg1 [1, 2] : !dc.value<i1>
+// CHECK-NEXT:    %2:2 = dc.fork [2] %arg0 
+// CHECK-NEXT:    %3 = dc.pack %arg0, %arg2 : i32
+// CHECK-NEXT:    %4 = dc.merge %0, %arg0
+// CHECK-NEXT:    %token, %output = dc.unpack %arg1 : !dc.value<i1>
+// CHECK-NEXT:    hw.output
+// CHECK-NEXT:  }
+
 hw.module @foo(%0 : !dc.token, %1 : !dc.value<i1>, %2 : i32) {
   %buffer = dc.buffer [2] %0 : !dc.token
   %bufferInit = dc.buffer [2] %1 [1, 2] : !dc.value<i1>
   %f1, %f2 = dc.fork [2] %0
-  %pack = dc.pack %0 [%2] : i32
+  %pack = dc.pack %0, %2 : i32
   %merge = dc.merge %buffer, %0
   %unpack_token, %unpack_value = dc.unpack %1 : !dc.value<i1>
 }


### PR DESCRIPTION
- accepting multiple types is data semantics encroaching the control-only land of DC.