### PR TITLE
[NFC] Narrow trait used for InstanceGraph

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -42,7 +42,7 @@ class HardwareDeclOp<string mnemonic, list <Trait> traits = []> :
 
 def InstanceOp : HardwareDeclOp<"instance", [
     DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-    DeclareOpInterfaceMethods<HWInstanceLike>]> {
+    DeclareOpInterfaceMethods<InstanceLike>]> {
   let summary = "Instantiate an instance of a module";
   let description = [{
     This represents an instance of a module.  The results are the modules inputs

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -16,7 +16,7 @@
 include "mlir/IR/OpBase.td"
 include "circt/Dialect/HW/HWOpInterfaces.td"
 
-def FModuleLike : OpInterface<"FModuleLike", [HWModuleLike]> {
+def FModuleLike : OpInterface<"FModuleLike", [ModuleLike, HWModuleLike]> {
   let cppNamespace = "circt::firrtl";
   let description = "Provide common module information.";
   let methods = [

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -62,7 +62,7 @@ def CircuitOp : FIRRTLOp<"circuit",
 }
 
 class FIRRTLModuleLike<string mnemonic, list<Trait> traits = []> :
-  FIRRTLOp<mnemonic, traits # [
+  FIRRTLOp<mnemonic, traits # [ModuleLike,
     IsolatedFromAbove, Symbol, HasParent<"CircuitOp">,
     DeclareOpInterfaceMethods<FModuleLike>,
     DeclareOpInterfaceMethods<HWModuleLike>,

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -143,7 +143,7 @@ def TriggerOp : FSMOp<"trigger", []> {
 
 def HWInstanceOp : FSMOp<"hw_instance", [
     Symbol,
-    DeclareOpInterfaceMethods<HWInstanceLike>
+    DeclareOpInterfaceMethods<InstanceLike>
   ]> {
   let summary = "Create a hardware-style instance of a state machine";
   let description = [{

--- a/include/circt/Dialect/HW/HWInstanceGraph.h
+++ b/include/circt/Dialect/HW/HWInstanceGraph.h
@@ -28,7 +28,7 @@ public:
   InstanceGraphNode *getTopLevelNode() override { return &entry; }
 
   /// Adds a module, updating links to entry.
-  InstanceGraphNode *addModule(HWModuleLike module) override;
+  InstanceGraphNode *addModule(ModuleLike module) override;
 
   /// Erases a module, updating links to entry.
   void erase(InstanceGraphNode *node) override;

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -15,6 +15,22 @@
 
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/IR/OpBase.td"
+def ModuleLike : OpInterface<"ModuleLike", []> {
+  let cppNamespace = "circt::hw";
+  let description = "Provide common module information.";
+
+  let methods = [
+    InterfaceMethod<"Get the module name",
+    "::llvm::StringRef", "getModuleLikeName", (ins),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{ return $_op.getName(); }]>,
+
+    InterfaceMethod<"Get the module name",
+    "::mlir::StringAttr", "getModuleLikeNameAttr", (ins),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{ return $_op.getNameAttr(); }]>,
+  ];
+}
 
 def HWModuleLike : OpInterface<"HWModuleLike", [Symbol]> {
   let cppNamespace = "circt::hw";
@@ -184,7 +200,7 @@ def HWMutableModuleLike : OpInterface<"HWMutableModuleLike", [HWModuleLike]> {
 }
 
 
-def HWInstanceLike : OpInterface<"HWInstanceLike"> {
+def InstanceLike : OpInterface<"InstanceLike"> {
   let cppNamespace = "circt::hw";
   let description = "Provide common  module information.";
 

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -28,7 +28,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 /// Base class factoring out some of the additional class declarations common to
 /// the module-like operations.
 class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
-    HWOp<mnemonic, traits # [
+    HWOp<mnemonic, traits # [ModuleLike,
       DeclareOpInterfaceMethods<HWModuleLike>,
       DeclareOpInterfaceMethods<HWMutableModuleLike>,
       FunctionOpInterface, Symbol,
@@ -428,7 +428,7 @@ def HWModuleGeneratedOp : HWModuleOpBase<"module.generated", [
 def InstanceOp : HWOp<"instance", [
         DeclareOpInterfaceMethods<SymbolUserOpInterface>,
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-        DeclareOpInterfaceMethods<HWInstanceLike>]> {
+        DeclareOpInterfaceMethods<InstanceLike>]> {
   let summary = "Create an instance of a module";
   let description = [{
     This represents an instance of a module. The inputs and results are

--- a/include/circt/Dialect/HW/PortConverter.h
+++ b/include/circt/Dialect/HW/PortConverter.h
@@ -174,7 +174,7 @@ template <typename PortConversionBuilderImpl>
 class PortConverter : public PortConverterImpl {
 public:
   PortConverter(hw::InstanceGraph &graph, hw::HWMutableModuleLike mod)
-      : PortConverterImpl(graph.lookup(cast<hw::HWModuleLike>(*mod))) {
+      : PortConverterImpl(graph.lookup(cast<hw::ModuleLike>(*mod))) {
     ssb = std::make_unique<PortConversionBuilderImpl>(*this);
   }
 };

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -12,7 +12,7 @@ def InstanceOp : MSFTOp<"instance", [
         Symbol,
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-        DeclareOpInterfaceMethods<HWInstanceLike>
+        DeclareOpInterfaceMethods<InstanceLike>
     ]> {
   let summary = "Instantiate a module";
 

--- a/include/circt/Dialect/MSFT/MSFTPasses.h
+++ b/include/circt/Dialect/MSFT/MSFTPasses.h
@@ -34,7 +34,7 @@ std::unique_ptr<mlir::Pass> createDiscoverAppIDsPass();
 struct PassCommon {
 protected:
   SymbolCache topLevelSyms;
-  DenseMap<Operation *, SmallVector<hw::HWInstanceLike, 1>>
+  DenseMap<Operation *, SmallVector<hw::InstanceLike, 1>>
       moduleInstantiations;
 
   LogicalResult verifyInstances(ModuleOp topMod);

--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -93,7 +93,7 @@ def SensitiveOp : SystemCOp<"sensitive", [HasParent<"CtorOp">]> {
 
 def InstanceDeclOp : SystemCOp<"instance.decl", [
   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-  DeclareOpInterfaceMethods<HWInstanceLike>,
+  DeclareOpInterfaceMethods<InstanceLike>,
   HasCustomSSAName,
   SystemCNameDeclOpInterface,
   HasParent<"SCModuleOp">

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -140,7 +140,7 @@ void InferTopModulePass::runOnOperation() {
 
   llvm::SmallVector<Attribute, 4> attrs;
   for (auto *node : *res)
-    attrs.push_back(node->getModule().getModuleNameAttr());
+    attrs.push_back(node->getModule().getModuleLikeNameAttr());
 
   analysis.getParent()->setAttr("test.top",
                                 ArrayAttr::get(&getContext(), attrs));

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -284,8 +284,8 @@ struct CircuitLoweringState {
 
   // Return true if this module is the DUT or is instantiated by the DUT.
   // Returns false if the module is not instantiated by the DUT.
-  bool isInDUT(hw::HWModuleLike child) {
-    if (auto parent = dyn_cast<hw::HWModuleLike>(*dut))
+  bool isInDUT(hw::ModuleLike child) {
+    if (auto parent = dyn_cast<hw::ModuleLike>(*dut))
       return getInstanceGraph()->isAncestor(child, parent);
     return dut == child;
   }
@@ -295,7 +295,7 @@ struct CircuitLoweringState {
   // Return true if this module is instantiated by the Test Harness.  Returns
   // false if the module is not instantiated by the Test Harness or if the Test
   // Harness is not known.
-  bool isInTestHarness(hw::HWModuleLike mod) { return !isInDUT(mod); }
+  bool isInTestHarness(hw::ModuleLike mod) { return !isInDUT(mod); }
 
   InstanceGraph *getInstanceGraph() { return instanceGraph; }
 

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -130,7 +130,7 @@ static bool shouldMaterialize(Operation *op) {
 
   if (isa<MemoryOp, AllocStateOp, AllocMemoryOp, AllocStorageOp, ClockTreeOp,
           PassThroughOp, RootInputOp, RootOutputOp, StateWriteOp,
-          MemoryWritePortOp, HWInstanceLike>(op))
+          MemoryWritePortOp, InstanceLike>(op))
     return false;
 
   return true;

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -484,7 +484,7 @@ LogicalResult ESIPureModuleOp::verify() {
   DenseMap<StringAttr, std::tuple<hw::ModulePort::Direction, Type, Operation *>>
       ports;
   for (Operation &op : body.getOperations()) {
-    if (hw::HWInstanceLike inst = dyn_cast<hw::HWInstanceLike>(op)) {
+    if (hw::InstanceLike inst = dyn_cast<hw::InstanceLike>(op)) {
       if (llvm::any_of(op.getOperands(), [](Value v) {
             return !(v.getType().isa<ChannelType>() ||
                      isa<ESIPureModuleInputOp>(v.getDefiningOp()));

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -580,7 +580,7 @@ ESIConnectServicesPass::surfaceReqs(hw::HWMutableModuleLike mod,
   };
 
   // Update the module instantiations.
-  SmallVector<hw::HWInstanceLike, 1> newModuleInstantiations;
+  SmallVector<hw::InstanceLike, 1> newModuleInstantiations;
   StringAttr argsAttrName = StringAttr::get(ctxt, "argNames");
   StringAttr resultsAttrName = StringAttr::get(ctxt, "resultNames");
   for (auto inst : moduleInstantiations[mod]) {
@@ -626,7 +626,7 @@ ESIConnectServicesPass::surfaceReqs(hw::HWMutableModuleLike mod,
         inst->getLoc(), inst->getName(), newResultTypes, newOperands,
         b.getDictionaryAttr(newAttrs), inst->getPropertiesStorage(),
         inst->getSuccessors(), inst->getRegions()));
-    newModuleInstantiations.push_back(cast<hw::HWInstanceLike>(newInst));
+    newModuleInstantiations.push_back(cast<hw::InstanceLike>(newInst));
 
     // Replace all uses of the instance being replaced.
     for (auto [newV, oldV] :

--- a/lib/Dialect/ESI/Passes/ESILowerTypes.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerTypes.cpp
@@ -72,7 +72,7 @@ void ESILowerTypesPass::runOnOperation() {
   // We need to lower instances, modules, and outputs with data windows.
   target.markUnknownOpDynamicallyLegal([](Operation *op) {
     return TypeSwitch<Operation *, bool>(op)
-        .Case([](hw::HWInstanceLike inst) {
+        .Case([](hw::InstanceLike inst) {
           return !(
               llvm::any_of(inst->getOperandTypes(), hw::type_isa<WindowType>) ||
               llvm::any_of(inst->getResultTypes(), hw::type_isa<WindowType>));

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -34,7 +34,7 @@ struct AddSeqMemPortsPass : public AddSeqMemPortsBase<AddSeqMemPortsPass> {
   LogicalResult processFileAnno(Location loc, StringRef metadataDir,
                                 Annotation anno);
   LogicalResult processAnnos(CircuitOp circuit);
-  void createOutputFile(hw::HWModuleLike module);
+  void createOutputFile(hw::ModuleLike module);
   InstanceGraphNode *findDUT();
   void processMemModule(FMemModuleOp mem);
   LogicalResult processModule(FModuleOp module, bool isDUT);
@@ -273,7 +273,7 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp module, bool isDUT) {
   return success();
 }
 
-void AddSeqMemPortsPass::createOutputFile(hw::HWModuleLike module) {
+void AddSeqMemPortsPass::createOutputFile(hw::ModuleLike module) {
   // Insert the verbatim at the bottom of the circuit.
   auto circuit = getOperation();
   auto builder = OpBuilder::atBlockEnd(circuit.getBodyBlock());
@@ -305,7 +305,7 @@ void AddSeqMemPortsPass::createOutputFile(hw::HWModuleLike module) {
 
   // The current sram we are processing.
   unsigned sramIndex = 0;
-  auto dutSymbol = FlatSymbolRefAttr::get(module.getModuleNameAttr());
+  auto dutSymbol = FlatSymbolRefAttr::get(module.getModuleLikeNameAttr());
   auto &instancePaths = memInfoMap[module].instancePaths;
   for (auto instancePath : instancePaths) {
     os << sramIndex++ << " -> ";

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -392,7 +392,7 @@ bool BlackBoxReaderPass::isDut(Operation *module) {
     dutModuleMap[module] = true;
     return true;
   }
-  auto *node = instanceGraph->lookup(cast<hw::HWModuleLike>(module));
+  auto *node = instanceGraph->lookup(cast<hw::ModuleLike>(module));
   bool anyParentIsDut = false;
   if (node)
     for (auto *u : node->uses()) {

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -337,7 +337,7 @@ CreateSiFiveMetadataPass::emitMemoryMetadata(ObjectModelIR &omir) {
           // situation where everything is deemed to be "in the DUT", i.e., when
           // the DUT is the top module or when no DUT is specified.
           if (everythingInDUT ||
-              llvm::any_of(p, [&](circt::hw::HWInstanceLike inst) {
+              llvm::any_of(p, [&](circt::hw::InstanceLike inst) {
                 return inst.getReferencedModule() == dutMod;
               }))
             jsonStream.value(hierName);
@@ -618,7 +618,7 @@ void CreateSiFiveMetadataPass::runOnOperation() {
   if (it != body->end()) {
     dutMod = dyn_cast<FModuleOp>(*it);
     auto &instanceGraph = getAnalysis<InstanceGraph>();
-    auto *node = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
+    auto *node = instanceGraph.lookup(cast<hw::ModuleLike>(*it));
     llvm::for_each(llvm::depth_first(node), [&](hw::InstanceGraphNode *node) {
       dutModuleSet.insert(node->getModule());
     });

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -722,7 +722,7 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
   // Get all the paths instantiating this module. If there is an NLA already
   // attached to this tracker, we use it as a base to disambiguate the path to
   // the memory.
-  hw::HWModuleLike mod;
+  hw::ModuleLike mod;
   if (tracker.nla)
     mod = instanceGraph->lookup(tracker.nla.root())->getModule();
   else

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -321,12 +321,12 @@ void ExtractInstancesPass::collectAnnos() {
   LLVM_DEBUG(llvm::dbgs() << "Marking DUT hierarchy\n");
   SmallVector<InstanceGraphNode *> worklist;
   for (Operation *op : dutModules)
-    worklist.push_back(instanceGraph->lookup(cast<hw::HWModuleLike>(op)));
+    worklist.push_back(instanceGraph->lookup(cast<hw::ModuleLike>(op)));
   while (!worklist.empty()) {
     auto *module = worklist.pop_back_val();
-    dutModuleNames.insert(module->getModule().getModuleNameAttr());
+    dutModuleNames.insert(module->getModule().getModuleLikeNameAttr());
     LLVM_DEBUG(llvm::dbgs()
-               << "- " << module->getModule().getModuleName() << "\n");
+               << "- " << module->getModule().getModuleLikeName() << "\n");
     for (auto *instRecord : *module) {
       auto *target = instRecord->getTarget();
       if (dutModules.insert(target->getModule()).second)
@@ -584,7 +584,7 @@ void ExtractInstancesPass::extractInstances() {
     // the instances of the parent module, and wire the instance ports up to
     // the newly added parent module ports.
     auto *instParentNode =
-        instanceGraph->lookup(cast<hw::HWModuleLike>(*parent));
+        instanceGraph->lookup(cast<hw::ModuleLike>(*parent));
     for (auto *instRecord : instParentNode->uses()) {
       auto oldParentInst = cast<InstanceOp>(*instRecord->getInstance());
       auto newParent = oldParentInst->getParentOfType<FModuleLike>();

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -33,7 +33,7 @@
 
 using namespace circt;
 using namespace firrtl;
-using hw::HWModuleLike;
+using hw::ModuleLike;
 
 //===----------------------------------------------------------------------===//
 // Collateral for generating a YAML representation of a SystemVerilog interface
@@ -647,7 +647,7 @@ private:
                  SmallVector<InterfaceElemsBuilder> &interfaceBuilder);
 
   /// Return the module associated with this value.
-  HWModuleLike getEnclosingModule(Value value, FlatSymbolRefAttr sym = {});
+  ModuleLike getEnclosingModule(Value value, FlatSymbolRefAttr sym = {});
 
   /// Inforamtion about how the circuit should be extracted.  This will be
   /// non-empty if an extraction annotation is found.
@@ -1267,7 +1267,7 @@ bool GrandCentralPass::traverseField(
         assert(leafValue && "leafValue not found");
 
         auto companionModule = companionIDMap.lookup(id).companion;
-        HWModuleLike enclosing = getEnclosingModule(leafValue, sym);
+        ModuleLike enclosing = getEnclosingModule(leafValue, sym);
 
         auto tpe = type_cast<FIRRTLBaseType>(leafValue.getType());
 
@@ -1526,17 +1526,17 @@ std::optional<StringAttr> GrandCentralPass::traverseBundle(
 
 /// Return the module that is associated with this value.  Use the cached/lazily
 /// constructed symbol table to make this fast.
-HWModuleLike GrandCentralPass::getEnclosingModule(Value value,
+ModuleLike GrandCentralPass::getEnclosingModule(Value value,
                                                   FlatSymbolRefAttr sym) {
   if (auto blockArg = dyn_cast<BlockArgument>(value))
-    return cast<HWModuleLike>(blockArg.getOwner()->getParentOp());
+    return cast<ModuleLike>(blockArg.getOwner()->getParentOp());
 
   auto *op = value.getDefiningOp();
   if (InstanceOp instance = dyn_cast<InstanceOp>(op))
-    return getSymbolTable().lookup<HWModuleLike>(
+    return getSymbolTable().lookup<ModuleLike>(
         instance.getModuleNameAttr().getValue());
 
-  return op->getParentOfType<HWModuleLike>();
+  return op->getParentOfType<ModuleLike>();
 }
 
 /// This method contains the business logic of this pass.
@@ -1732,7 +1732,7 @@ void GrandCentralPass::runOnOperation() {
   /// module as if it were the DUT.  This works by doing a depth-first walk of
   /// the instance graph, starting from the "effective" DUT and stopping the
   /// search at any modules which are known companions.
-  DenseSet<hw::HWModuleLike> dutModules;
+  DenseSet<hw::ModuleLike> dutModules;
   FModuleOp effectiveDUT = dut;
   if (!effectiveDUT)
     effectiveDUT = cast<FModuleOp>(
@@ -1929,7 +1929,7 @@ void GrandCentralPass::runOnOperation() {
               LLVM_DEBUG({
                 llvm::dbgs()
                     << "Found companion module: "
-                    << companionNode->getModule().getModuleName() << "\n"
+                    << companionNode->getModule().getModuleLikeName() << "\n"
                     << "  submodules exclusively instantiated "
                        "(including companion):\n";
               });
@@ -1949,7 +1949,7 @@ void GrandCentralPass::runOnOperation() {
 
                 LLVM_DEBUG({
                   llvm::dbgs()
-                      << "    - module: " << mod.getModuleName() << "\n";
+                      << "    - module: " << mod.getModuleLikeName() << "\n";
                 });
 
                 if (auto extmodule = dyn_cast<FExtModuleOp>(*mod)) {

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -45,7 +45,7 @@ using namespace firrtl;
 //===----------------------------------------------------------------------===//
 
 /// An absolute instance path.
-using InstanceLike = circt::hw::HWInstanceLike;
+using InstanceLike = circt::hw::InstanceLike;
 using InstancePathRef = ArrayRef<InstanceLike>;
 using InstancePathVec = SmallVector<InstanceLike>;
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -928,7 +928,7 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
              << "\" must be passive (no flips) when using references";
 
     // Record module modifications related to adding ports to modules.
-    auto addPorts = [&](ArrayRef<hw::HWInstanceLike> insts, Value val, Type tpe,
+    auto addPorts = [&](ArrayRef<hw::InstanceLike> insts, Value val, Type tpe,
                         Direction dir) {
       StringRef name, instName;
       for (auto inst : llvm::reverse(insts)) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -517,7 +517,7 @@ void LowerMemoryPass::runOnOperation() {
     return AnnotationSet(&op).hasAnnotation(dutAnnoClass);
   });
   if (it != body->end())
-    dut = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
+    dut = instanceGraph.lookup(cast<hw::ModuleLike>(*it));
 
   // The set of all modules underneath the design under test module.
   DenseSet<Operation *> dutModuleSet;

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -48,7 +48,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     });
     if (it != body->end()) {
       auto &instanceGraph = getAnalysis<InstanceGraph>();
-      auto *node = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
+      auto *node = instanceGraph.lookup(cast<hw::ModuleLike>(*it));
       llvm::for_each(llvm::depth_first(node), [&](hw::InstanceGraphNode *node) {
         dutModuleSet.insert(node->getModule());
       });

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -188,7 +188,7 @@ void PrefixModulesPass::renameModuleBody(std::string prefix, StringRef oldName,
         } else {
           auto target = instanceGraph->lookup(moduleName)->getModule();
           newTarget = StringAttr::get(context, prefix + getPrefix(target) +
-                                                   target.getModuleName());
+                                                   target.getModuleLikeName());
         }
         return {hw::InnerRefAttr::get(newTarget, symName), WalkResult::skip()};
       });

--- a/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/WireDFT.cpp
@@ -222,7 +222,7 @@ void WireDFTPass::runOnOperation() {
       instanceGraph.lookup(dut), [&](InstanceRecord *node) {
         auto module = node->getTarget()->getModule();
         // If this is a clock gate, record the module and return true.
-        if (module.getModuleName().startswith("EICG_wrapper")) {
+        if (module.getModuleLikeName().startswith("EICG_wrapper")) {
           clockGates.insert(node);
           return true;
         }

--- a/lib/Dialect/HW/HWInstanceGraph.cpp
+++ b/lib/Dialect/HW/HWInstanceGraph.cpp
@@ -14,13 +14,13 @@ using namespace hw;
 InstanceGraph::InstanceGraph(Operation *operation)
     : InstanceGraphBase(operation) {
   for (auto &node : nodes)
-    if (node.getModule().isPublic())
+    if (cast<mlir::SymbolOpInterface>(node.getModule().getOperation()).isPublic())
       entry.addInstance({}, &node);
 }
 
-InstanceGraphNode *InstanceGraph::addModule(HWModuleLike module) {
+InstanceGraphNode *InstanceGraph::addModule(ModuleLike module) {
   auto *node = InstanceGraphBase::addModule(module);
-  if (module.isPublic())
+  if (cast<mlir::SymbolOpInterface>(module.getOperation()).isPublic())
     entry.addInstance({}, node);
   return node;
 }

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -3068,7 +3068,7 @@ LogicalResult HierPathOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
       return emitOpError() << "instance path is incorrect. Expected module: "
                            << expectedModuleName
                            << " instead found: " << innerRef.getModule();
-    HWInstanceLike instOp = ns.lookupOp<HWInstanceLike>(innerRef);
+    InstanceLike instOp = ns.lookupOp<InstanceLike>(innerRef);
     if (!instOp)
       return emitOpError() << " module: " << innerRef.getModule()
                            << " does not contain any instance with symbol: "

--- a/lib/Dialect/HW/HWReductions.cpp
+++ b/lib/Dialect/HW/HWReductions.cpp
@@ -27,14 +27,14 @@ using namespace hw;
 struct ModuleSizeCache {
   void clear() { moduleSizes.clear(); }
 
-  uint64_t getModuleSize(HWModuleLike module,
+  uint64_t getModuleSize(ModuleLike module,
                          InstanceGraphBase &instanceGraph) {
     if (auto it = moduleSizes.find(module); it != moduleSizes.end())
       return it->second;
     uint64_t size = 1;
     module->walk([&](Operation *op) {
       size += 1;
-      if (auto instOp = dyn_cast<HWInstanceLike>(op))
+      if (auto instOp = dyn_cast<InstanceLike>(op))
         if (auto instModule = instanceGraph.getReferencedModule(instOp))
           size += getModuleSize(instModule, instanceGraph);
     });

--- a/lib/Dialect/HW/PortConverter.cpp
+++ b/lib/Dialect/HW/PortConverter.cpp
@@ -171,7 +171,7 @@ LogicalResult PortConverterImpl::run() {
 
   // Rewrite instances pointing to this module.
   for (auto *instance : moduleNode->uses()) {
-    hw::HWInstanceLike instanceLike = instance->getInstance();
+    hw::InstanceLike instanceLike = instance->getInstance();
     if (!instanceLike)
       continue;
     hw::InstanceOp hwInstance = dyn_cast_or_null<hw::InstanceOp>(*instanceLike);

--- a/lib/Dialect/MSFT/Transforms/MSFTPassCommon.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTPassCommon.cpp
@@ -137,9 +137,9 @@ SmallVector<InstanceOp, 1> MSFTPassCommon::updateInstances(
     llvm::function_ref<void(InstanceOp, InstanceOp, SmallVectorImpl<Value> &)>
         getOperandsFunc) {
 
-  SmallVector<hw::HWInstanceLike, 1> newInstances;
+  SmallVector<hw::InstanceLike, 1> newInstances;
   SmallVector<InstanceOp, 1> newMsftInstances;
-  for (hw::HWInstanceLike instLike : moduleInstantiations[mod]) {
+  for (hw::InstanceLike instLike : moduleInstantiations[mod]) {
     assert(instLike->getParentOp());
     auto inst = dyn_cast<InstanceOp>(instLike.getOperation());
     if (!inst) {

--- a/lib/Dialect/MSFT/Transforms/PassCommon.cpp
+++ b/lib/Dialect/MSFT/Transforms/PassCommon.cpp
@@ -98,7 +98,7 @@ void PassCommon::getAndSortModulesVisitor(
     return;
   modsSeen.insert(mod);
 
-  mod.walk([&](hw::HWInstanceLike inst) {
+  mod.walk([&](hw::InstanceLike inst) {
     Operation *modOp =
         topLevelSyms.getDefinition(inst.getReferencedModuleNameAttr());
     assert(modOp);

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -314,7 +314,7 @@ static void migrateOps(hw::HWModuleOp oldMod, hw::HWModuleOp newMod,
 }
 
 // Check if the module has already been bound.
-static bool isBound(hw::HWModuleLike op, hw::InstanceGraph &instanceGraph) {
+static bool isBound(hw::ModuleLike op, hw::InstanceGraph &instanceGraph) {
   auto *node = instanceGraph.lookup(op);
   return llvm::any_of(node->uses(), [](hw::InstanceRecord *a) {
     auto inst = a->getInstance();
@@ -381,7 +381,7 @@ inlineInputOnly(hw::HWModuleOp oldMod, hw::InstanceGraph &instanceGraph,
   bool allInlined = true;
   for (hw::InstanceRecord *use : llvm::make_early_inc_range(node->uses())) {
     // If there is no instance, move on.
-    hw::HWInstanceLike instLike = use->getInstance();
+    hw::InstanceLike instLike = use->getInstance();
     if (!instLike) {
       allInlined = false;
       continue;

--- a/unittests/Dialect/HW/InstanceGraphTest.cpp
+++ b/unittests/Dialect/HW/InstanceGraphTest.cpp
@@ -64,13 +64,13 @@ TEST(InstanceGraphTest, PostOrderTraversal) {
   auto range = llvm::post_order(&graph);
 
   auto it = range.begin();
-  ASSERT_EQ("Cat", it->getModule().getModuleName());
+  ASSERT_EQ("Cat", it->getModule().getModuleLikeName());
   ++it;
-  ASSERT_EQ("Bear", it->getModule().getModuleName());
+  ASSERT_EQ("Bear", it->getModule().getModuleLikeName());
   ++it;
-  ASSERT_EQ("Alligator", it->getModule().getModuleName());
+  ASSERT_EQ("Alligator", it->getModule().getModuleLikeName());
   ++it;
-  ASSERT_EQ("Top", it->getModule().getModuleName());
+  ASSERT_EQ("Top", it->getModule().getModuleLikeName());
   ++it;
   ASSERT_EQ(graph.getTopLevelNode(), *it);
   ++it;


### PR DESCRIPTION
Lots of dialects grab HWModuleLike and don't implement most of it.  Much of use seems to be from wanting to use instance graph.  So this splits out a minimal interface for that use to allow less dependencies on big HW-specific interfaces.

ModuleLike should inherit from Symbol, but this angers table gen.