### PR TITLE
[HW] Add InnerSymAttr python bindings

### DIFF
--- a/include/circt-c/Dialect/HW.h
+++ b/include/circt-c/Dialect/HW.h
@@ -114,6 +114,10 @@ MLIR_CAPI_EXPORTED MlirStringRef hwTypeAliasTypeGetScope(MlirType typeAlias);
 // Attribute API.
 //===----------------------------------------------------------------------===//
 
+MLIR_CAPI_EXPORTED bool hwAttrIsAInnerSymAttr(MlirAttribute);
+MLIR_CAPI_EXPORTED MlirAttribute hwInnerSymAttrGet(MlirAttribute symName);
+MLIR_CAPI_EXPORTED MlirAttribute hwInnerSymAttrGetSymName(MlirAttribute);
+
 MLIR_CAPI_EXPORTED bool hwAttrIsAInnerRefAttr(MlirAttribute);
 MLIR_CAPI_EXPORTED MlirAttribute hwInnerRefAttrGet(MlirAttribute moduleName,
                                                    MlirAttribute innerSym);

--- a/integration_test/Bindings/Python/dialects/hw.py
+++ b/integration_test/Bindings/Python/dialects/hw.py
@@ -95,7 +95,7 @@ with Context() as ctx, Location.unknown():
   print(pverbatim)
 
   inner_sym = hw.InnerSymAttr.get(StringAttr.get("some_sym"))
-  # CHECK: #hw.innerSym<@some_sym>
+  # CHECK: #hw<innerSym@some_sym>
   print(inner_sym)
   # CHECK: "some_sym"
   print(inner_sym.symName)

--- a/integration_test/Bindings/Python/dialects/hw.py
+++ b/integration_test/Bindings/Python/dialects/hw.py
@@ -94,6 +94,12 @@ with Context() as ctx, Location.unknown():
   # CHECK: #hw.param.verbatim<"this is verbatim">
   print(pverbatim)
 
+  inner_sym = hw.InnerSymAttr.get(StringAttr.get("some_sym"))
+  # CHECK: #hw.innerSym<@some_sym>
+  print(inner_sym)
+  # CHECK: "some_sym"
+  print(inner_sym.symName)
+
   inner_ref = hw.InnerRefAttr.get(StringAttr.get("some_module"),
                                   StringAttr.get("some_instance"))
   # CHECK: #hw.innerNameRef<@some_module::@some_instance>

--- a/lib/Bindings/Python/HWModule.cpp
+++ b/lib/Bindings/Python/HWModule.cpp
@@ -172,6 +172,15 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
         return cls(hwParamVerbatimAttrGet(text));
       });
 
+  mlir_attribute_subclass(m, "InnerSymAttr", hwAttrIsAInnerSymAttr)
+      .def_classmethod("get",
+                       [](py::object cls, MlirAttribute symName) {
+                         return cls(hwInnerSymAttrGet(symName));
+                       })
+      .def_property_readonly("symName", [](MlirAttribute self) {
+        return hwInnerSymAttrGetSymName(self);
+      });
+
   mlir_attribute_subclass(m, "InnerRefAttr", hwAttrIsAInnerRefAttr)
       .def_classmethod(
           "get",

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -143,7 +143,7 @@ MlirStringRef hwTypeAliasTypeGetScope(MlirType typeAlias) {
 //===----------------------------------------------------------------------===//
 // Attribute API.
 //===----------------------------------------------------------------------===//
-//
+
 bool hwAttrIsAInnerSymAttr(MlirAttribute attr) {
   return unwrap(attr).isa<InnerSymAttr>();
 }

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -143,6 +143,19 @@ MlirStringRef hwTypeAliasTypeGetScope(MlirType typeAlias) {
 //===----------------------------------------------------------------------===//
 // Attribute API.
 //===----------------------------------------------------------------------===//
+//
+bool hwAttrIsAInnerSymAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<InnerSymAttr>();
+}
+
+MlirAttribute hwInnerSymAttrGet(MlirAttribute symName) {
+  return wrap(InnerSymAttr::get(unwrap(symName).cast<StringAttr>()));
+}
+
+MlirAttribute hwInnerSymAttrGetSymName(MlirAttribute innerSymAttr) {
+  return wrap(
+      (Attribute)unwrap(innerSymAttr).cast<InnerSymAttr>().getSymName());
+}
 
 bool hwAttrIsAInnerRefAttr(MlirAttribute attr) {
   return unwrap(attr).isa<InnerRefAttr>();


### PR DESCRIPTION
These binding are very shallow and only support the use case of a single InnerSymProperties with a fieldID of 0.  Current use cases only require this limited functionality, and in the future we will probably be changing the underlying attributes, so it doesn't make sense to expose it all now.