### PR TITLE
[circt-reduce] Add DropNames Preserving None Pass

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -947,6 +947,9 @@ void firrtl::FIRRTLReducePatternDialectInterface::populateReducePatterns(
   // prioritized). For example, things that can knock out entire modules while
   // being cheap should be tried first (and thus have higher benefit), before
   // trying to tweak operands of individual arithmetic ops.
+  patterns.add<PassReduction, 30>(
+      getContext(), firrtl::createDropNamesPass(PreserveValues::None), false,
+      true);
   patterns.add<PassReduction, 29>(getContext(),
                                   firrtl::createLowerCHIRRTLPass(), true, true);
   patterns.add<PassReduction, 28>(getContext(), firrtl::createInferWidthsPass(),


### PR DESCRIPTION
Add the DropNames pass to circt-reduce with the option to drop all names. This has the benefit of letting canonicalizers/folders go ham.  This was observed as a missed opportunity on a recent reduction that left many connections like the following:

    node b = a
    node c = b
    node d = c

Dropping names causes all of these to get folded away and dramatically reduced the final, already very small, reduced design (by 50%).