### PR TITLE
[HW] Make InnerRefNamespace an OpInterface

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -178,50 +178,35 @@ LogicalResult verifyInnerRefNamespace(Operation *op);
 
 namespace mlir {
 namespace OpTrait {
-
-/// This trait is for operations that define a scope for resolving InnerRef's,
-/// and provides verification for InnerRef users (via InnerRefUserOpInterface).
-template <typename ConcreteType>
-class InnerRefNamespace : public TraitBase<ConcreteType, InnerRefNamespace> {
-public:
-  static LogicalResult verifyRegionTrait(Operation *op) {
-    static_assert(
-        ConcreteType::template hasTrait<::mlir::OpTrait::SymbolTable>(),
-        "expected operation to be a SymbolTable");
-
-    if (op->getNumRegions() != 1)
-      return op->emitError("expected operation to have a single region");
-    if (!op->getRegion(0).hasOneBlock())
-      return op->emitError("expected operation to have a single block");
-
-    // Verify all InnerSymbolTable's and InnerRef users.
-    return ::circt::hw::detail::verifyInnerRefNamespace(op);
-  }
-};
-
 /// A trait for inner symbol table functionality on an operation.
 template <typename ConcreteType>
 class InnerSymbolTable : public TraitBase<ConcreteType, InnerSymbolTable> {
 public:
-  static LogicalResult verifyRegionTrait(Operation *op) {
-    // Insist that ops with InnerSymbolTable's provide a Symbol, this is
-    // essential to how InnerRef's work.
-    static_assert(
-        ConcreteType::template hasTrait<::mlir::SymbolOpInterface::Trait>(),
-        "expected operation to define a Symbol");
-
-    // InnerSymbolTable's must be directly nested within an InnerRefNamespace.
-    auto *parent = op->getParentOp();
-    if (!parent || !parent->hasTrait<InnerRefNamespace>())
-      return op->emitError(
-          "InnerSymbolTable must have InnerRefNamespace parent");
-
-    return success();
-  }
+  static LogicalResult verifyRegionTrait(Operation *op);
 };
 } // namespace OpTrait
 } // namespace mlir
 
 #include "circt/Dialect/HW/HWOpInterfaces.h.inc"
+
+namespace mlir {
+namespace OpTrait {
+template <typename ConcreteType>
+LogicalResult InnerSymbolTable<ConcreteType>::verifyRegionTrait(Operation *op) {
+  // Insist that ops with InnerSymbolTable's provide a Symbol, this is
+  // essential to how InnerRef's work.
+  static_assert(
+      ConcreteType::template hasTrait<::mlir::SymbolOpInterface::Trait>(),
+      "expected operation to define a Symbol");
+
+  // InnerSymbolTable's must be directly nested within an InnerRefNamespace.
+  auto *parent = op->getParentOp();
+  if (!isa_and_nonnull<::circt::hw::InnerRefNamespaceOpInterface>(parent))
+    return op->emitError("InnerSymbolTable must have InnerRefNamespace parent");
+
+  return success();
+}
+} // namespace OpTrait
+} // namespace mlir
 
 #endif // CIRCT_DIALECT_HW_HWOPINTERFACES_H

--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -215,6 +215,7 @@ LogicalResult InnerSymbolTable<ConcreteType>::verifyRegionTrait(Operation *op) {
 
   return success();
 }
+
 } // namespace OpTrait
 } // namespace mlir
 

--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -187,10 +187,19 @@ public:
 } // namespace OpTrait
 } // namespace mlir
 
+//===----------------------------------------------------------------------===//
+// ODS-generated code.
+//===----------------------------------------------------------------------===//
+
 #include "circt/Dialect/HW/HWOpInterfaces.h.inc"
+
+//===----------------------------------------------------------------------===//
+// Code which needs the generated code declarations.
+//===----------------------------------------------------------------------===//
 
 namespace mlir {
 namespace OpTrait {
+
 template <typename ConcreteType>
 LogicalResult InnerSymbolTable<ConcreteType>::verifyRegionTrait(Operation *op) {
   // Insist that ops with InnerSymbolTable's provide a Symbol, this is

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -210,7 +210,27 @@ def HWInstanceLike : OpInterface<"HWInstanceLike"> {
   ];
 }
 
-def InnerRefNamespace : NativeOpTrait<"InnerRefNamespace">;
+def InnerRefNamespace : OpInterface<"InnerRefNamespaceOpInterface"> {
+  let cppNamespace = "circt::hw";
+  let description = [{
+    This trait is for operations that define a scope for resolving InnerRef's,
+    and provides verification for InnerRef users (via InnerRefUserOpInterface).
+  }];
+
+  let verify = [{
+    assert(
+        op->hasTrait<::mlir::OpTrait::SymbolTable>() &&
+        "expected operation to be a SymbolTable");
+
+    if (op->getNumRegions() != 1)
+      return op->emitError("expected operation to have a single region");
+    if (!op->getRegion(0).hasOneBlock())
+      return op->emitError("expected operation to have a single block");
+
+    // Verify all InnerSymbolTable's and InnerRef users.
+    return ::circt::hw::detail::verifyInnerRefNamespace(op);
+  }];
+}
 
 def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {
   let description = [{

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -218,8 +218,10 @@ def InnerRefNamespace : OpInterface<"InnerRefNamespaceOpInterface"> {
   }];
 
   let verify = [{
-    assert(
-        op->hasTrait<::mlir::OpTrait::SymbolTable>() &&
+    // Insist that ops with InnerSymbolTable's provide a SymbolTable, this is
+    // essential to how InnerRefNamespace's work.
+    static_assert(
+        ConcreteOp::template hasTrait<::mlir::OpTrait::SymbolTable>() &&
         "expected operation to be a SymbolTable");
 
     if (op->getNumRegions() != 1)

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -230,6 +230,7 @@ def InnerRefNamespace : OpInterface<"InnerRefNamespaceOpInterface"> {
     // Verify all InnerSymbolTable's and InnerRef users.
     return ::circt::hw::detail::verifyInnerRefNamespace(op);
   }];
+  let verifyWithRegions = 1;
 }
 
 def InnerSymbol : OpInterface<"InnerSymbolOpInterface"> {

--- a/include/circt/Dialect/Ibis/Ibis.td
+++ b/include/circt/Dialect/Ibis/Ibis.td
@@ -23,6 +23,8 @@ def IbisDialect : Dialect {
     of an internal hardware development language.
   }];
 
+  let dependentDialects = ["::circt::hw::HWDialect"];
+
   // TODO: uncomment this once we introduce some types. The default functions
   // aren't generated without typedefs.
   // let useDefaultTypePrinterParser = 1;

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -25,7 +25,7 @@ def ClassOp : IbisOp<"class", [
     IsolatedFromAbove, RegionKindInterface,
     Symbol, SymbolTable, SingleBlock,
     NoTerminator, NoRegionArguments,
-    InnerRefNamespace,
+    InnerSymbolTable,
     HasParent<"mlir::ModuleOp">]> {
 
   let summary = "Ibis class";

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -25,6 +25,7 @@ def ClassOp : IbisOp<"class", [
     IsolatedFromAbove, RegionKindInterface,
     Symbol, SymbolTable, SingleBlock,
     NoTerminator, NoRegionArguments,
+    InnerRefNamespace,
     HasParent<"mlir::ModuleOp">]> {
 
   let summary = "Ibis class";

--- a/lib/Dialect/HW/HWDialect.cpp
+++ b/lib/Dialect/HW/HWDialect.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWTypes.h"
 #include "mlir/IR/Builders.h"
@@ -79,6 +80,8 @@ void HWDialect::initialize() {
 
   // Register interface implementations.
   addInterfaces<HWOpAsmDialectInterface, HWInlinerInterface>();
+
+  mlir::ModuleOp::attachInterface<InnerRefNamespaceOpInterface>(*getContext());
 }
 
 // Registered hook to materialize a single constant operation from a given

--- a/lib/Dialect/HW/HWDialect.cpp
+++ b/lib/Dialect/HW/HWDialect.cpp
@@ -81,6 +81,8 @@ void HWDialect::initialize() {
   // Register interface implementations.
   addInterfaces<HWOpAsmDialectInterface, HWInlinerInterface>();
 
+  // Attach the InnerRefNamespace interface to the default top level container
+  // op so that children can contain InnerRefNamespaces.
   mlir::ModuleOp::attachInterface<InnerRefNamespaceOpInterface>(*getContext());
 }
 

--- a/lib/Dialect/HW/InnerSymbolTable.cpp
+++ b/lib/Dialect/HW/InnerSymbolTable.cpp
@@ -222,6 +222,7 @@ Operation *InnerRefNamespace::lookupOp(hw::InnerRefAttr inner) {
 namespace detail {
 
 LogicalResult verifyInnerRefNamespace(Operation *op) {
+  llvm::outs() << "Runing IRN verifier on " << op->getName() << "\n";
   // Construct the symbol tables.
   InnerSymbolTableCollection innerSymTables;
   if (failed(innerSymTables.populateAndVerifyTables(op)))


### PR DESCRIPTION
It was a trait. Making it an OpInterface means we can attach it to ops, like `mlir::ModuleOp`. This means that the InnerRefNamespace trait can be used outside of FIRRTL.