### PR TITLE
[WIP, NFC] Use ModuleType as primary data structure for HW.*Module

### DIFF
--- a/include/circt/Dialect/ESI/ESIStructure.td
+++ b/include/circt/Dialect/ESI/ESIStructure.td
@@ -39,6 +39,7 @@ def ESIPureModuleOp : ESI_Op<"pure_module",
   let extraClassDeclaration = [{
     // Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph;}
+
   }];
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -90,6 +90,39 @@ class FIRRTLModuleLike<string mnemonic, list<Trait> traits = []> :
         return hw::InnerSymAttr();
       return syms[portIndex].template cast<hw::InnerSymAttr>();
     }
+
+    // satisify HWModuleLike
+    ArrayAttr $cppClass::getArgAttrsAttr() {
+      assert(false);
+      return {};
+    }    
+
+    // satisify HWModuleLike
+    ArrayAttr $cppClass::getResAttrsAttr() {
+      assert(false);
+      return {};
+    }    
+
+    // satisify HWModuleLike
+    void $cppClass::setArgAttrsAttr(ArrayAttr) {
+      assert(false);
+    }    
+    // satisify HWModuleLike
+    void $cppClass::setResAttrsAttr(ArrayAttr) {
+      assert(false);
+    }    
+    // satisify HWModuleLike
+    Attribute $cppClass::removeArgAttrsAttr() {
+      assert(false);
+      return {};
+    }    
+
+    // satisify HWModuleLike
+    Attribute $cppClass::removeResAttrsAttr() {
+      assert(false);
+      return {};
+    }    
+
   }];
 
 }

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -72,8 +72,15 @@ class FIRRTLModuleLike<string mnemonic, list<Trait> traits = []> :
   code extraModuleClassDefinition = [{}];
 
   let extraClassDefinition = extraModuleClassDefinition # [{
-    size_t $cppClass::getNumPorts() {
-      return getPortTypesAttr().size();
+
+    circt::hw::ModuleType $cppClass::getHWModuleType() {
+      SmallVector<hw::ModulePort> newPorts;
+      for (unsigned i = 0, e = getPortNames().size(); i < e; ++i)
+        newPorts.push_back({getPortNameAttr(i), getPortType(i),
+                       getPortDirection(i) == Direction::In ? 
+                         hw::ModulePort::Direction::Input : 
+                         hw::ModulePort::Direction::Output});
+      return hw::ModuleType::get(getContext(), newPorts);
     }
 
     circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -79,9 +79,9 @@ def MachineOp : FSMOp<"machine", [
   }];
 
   let extraClassDefinition = [{
-    size_t $cppClass::getNumPorts() {
-      auto machineType = getFunctionType();
-      return machineType.getNumInputs() + machineType.getNumResults();
+
+    ::circt::hw::ModuleType $cppClass::getHWModuleType() {
+      return ::circt::hw::detail::fnToMod(getFunctionType(), *getArgNames(), *getResNames());
     }
 
     circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {

--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -173,6 +173,88 @@ namespace detail {
 LogicalResult verifyInnerRefNamespace(Operation *op);
 } // namespace detail
 
+class HWModuleLike;
+namespace HWModuleLike_impl {
+
+/// Returns the dictionary attribute corresponding to the argument at 'index'.
+/// If there are no argument attributes at 'index', a null attribute is
+/// returned.
+DictionaryAttr getArgAttrDict(HWModuleLike op, unsigned index);
+
+/// Returns the dictionary attribute corresponding to the result at 'index'.
+/// If there are no result attributes at 'index', a null attribute is
+/// returned.
+DictionaryAttr getResultAttrDict(HWModuleLike op, unsigned index);
+
+/// Return all of the attributes for the argument at 'index'.
+ArrayRef<NamedAttribute> getArgAttrs(HWModuleLike op, unsigned index);
+
+/// Return all of the attributes for the result at 'index'.
+ArrayRef<NamedAttribute> getResultAttrs(HWModuleLike op, unsigned index);
+
+
+//===----------------------------------------------------------------------===//
+// Module Argument Attribute.
+//===----------------------------------------------------------------------===//
+
+/// Set the attributes held by the argument at 'index'.
+void setArgAttrs(HWModuleLike op, unsigned index,
+                 ArrayRef<NamedAttribute> attributes);
+void setArgAttrs(HWModuleLike op, unsigned index,
+                 DictionaryAttr attributes);
+
+/// If the an attribute exists with the specified name, change it to the new
+/// value. Otherwise, add a new attribute with the specified name/value.
+template <typename ConcreteType>
+void setArgAttr(ConcreteType op, unsigned index, StringAttr name,
+                Attribute value) {
+  NamedAttrList attributes(op.getArgAttrDict(index));
+  Attribute oldValue = attributes.set(name, value);
+
+  // If the attribute changed, then set the new arg attribute list.
+  if (value != oldValue)
+    op.setArgAttrs(index, attributes.getDictionary(value.getContext()));
+}
+
+/// Remove the attribute 'name' from the argument at 'index'. Returns the
+/// removed attribute, or nullptr if `name` was not a valid attribute.
+template <typename ConcreteType>
+Attribute removeArgAttr(ConcreteType op, unsigned index, StringAttr name) {
+  // Build an attribute list and remove the attribute at 'name'.
+  NamedAttrList attributes(op.getArgAttrDict(index));
+  Attribute removedAttr = attributes.erase(name);
+
+  // If the attribute was removed, then update the argument dictionary.
+  if (removedAttr)
+    op.setArgAttrs(index, attributes.getDictionary(removedAttr.getContext()));
+  return removedAttr;
+}
+
+//===----------------------------------------------------------------------===//
+// Module Result Attribute.
+//===----------------------------------------------------------------------===//
+
+/// Set the attributes held by the result at 'index'.
+void setResultAttrs(HWModuleLike op, unsigned index,
+                    ArrayRef<NamedAttribute> attributes);
+void setResultAttrs(HWModuleLike op, unsigned index,
+                    DictionaryAttr attributes);
+
+/// If the an attribute exists with the specified name, change it to the new
+/// value. Otherwise, add a new attribute with the specified name/value.
+template <typename ConcreteType>
+void setResultAttr(ConcreteType op, unsigned index, StringAttr name,
+                   Attribute value) {
+  NamedAttrList attributes(op.getResultAttrDict(index));
+  Attribute oldAttr = attributes.set(name, value);
+
+  // If the attribute changed, then set the new arg attribute list.
+  if (oldAttr != value)
+    op.setResultAttrs(index, attributes.getDictionary(value.getContext()));
+}
+
+
+} // namespace HWModuleLike_impl
 } // namespace hw
 } // namespace circt
 

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -32,78 +32,65 @@ def HWModuleLike : OpInterface<"HWModuleLike", [Symbol]> {
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getNameAttr(); }]>,
 
-    InterfaceMethod<"Get the number of ports",
-    "size_t", "getNumPorts">,
-
     InterfaceMethod<"Get a port symbol attribute",
     "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>,
 
     InterfaceMethod<"Get the module type",
-    "::circt::hw::ModuleType", "getHWModuleType", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{ return ::circt::hw::detail::fnToMod($_op, getInputNames(), getOutputNames()); }]>,
-
-    InterfaceMethod<"Return the names of the inputs to this module",
-    "mlir::ArrayAttr", "getInputNames", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{
-      return $_op->template getAttrOfType<ArrayAttr>("argNames");
-    }]>,
-
-    InterfaceMethod<"Return the names of the outputs this module",
-    "mlir::ArrayAttr", "getOutputNames", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{
-      return $_op->template getAttrOfType<ArrayAttr>("resultNames");
-    }]>,
-
-    InterfaceMethod<"Return the locations of the inputs to this module",
-    "mlir::ArrayAttr", "getInputLocs", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{
-      return $_op->template getAttrOfType<ArrayAttr>("argLocs");
-    }]>,
-
-    InterfaceMethod<"Return the locations of the outputs of this module",
-    "mlir::ArrayAttr", "getOutputLocs", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{
-      return $_op->template getAttrOfType<ArrayAttr>("resultLocs");
-    }]>,
-
+    "::circt::hw::ModuleType", "getHWModuleType", (ins)>,
   ];
 
   let extraSharedClassDeclaration = [{
 
-    // Return the number of inputs to this module
-    unsigned getNumInputs() {
-      return getInputNames().size();
+    size_t getNumPorts() {
+      return $_op.getHWModuleType().getPorts().size();
     }
 
-    // Return the number of outputs from this module
-    unsigned getNumOutputs() {
-      return getOutputNames().size();
+    size_t getNumInputs() {
+      return $_op.getHWModuleType().getNumInputs();
     }
 
-    // Return the name of an input.
-    mlir::StringRef getInputName(unsigned idx) {
-      return getInputNameAttr(idx).getValue();
+    size_t getNumOutputs() {
+      return $_op.getHWModuleType().getNumOutputs();
     }
 
-    // Return the name of an output
-    mlir::StringRef getOutputName(unsigned idx) {
-      return getOutputNameAttr(idx).getValue();
+    SmallVector<StringAttr> getInputNames() {
+      return $_op.getHWModuleType().getInputNames();
     }
 
-    // Return the name of an input to this module
-    mlir::StringAttr getInputNameAttr(unsigned idx) {
-      return cast<StringAttr>(getInputNames()[idx]);
+    SmallVector<StringAttr> getOutputNames() {
+      return $_op.getHWModuleType().getOutputNames();
     }
 
-    // Return the name of an output to this module
-    mlir::StringAttr getOutputNameAttr(unsigned idx) {
-      return cast<StringAttr>(getOutputNames()[idx]);
+    ArrayAttr getInputNamesAttr() {
+      auto ty = $_op.getHWModuleType();
+      auto names = ty.getInputNames();
+      SmallVector<Attribute> names_(names.begin(), names.end());
+      return ArrayAttr::get(ty.getContext(), names_);
     }
+
+    ArrayAttr getOutputNamesAttr() {
+      auto ty = $_op.getHWModuleType();
+      auto names = ty.getOutputNames();
+      SmallVector<Attribute> names_(names.begin(), names.end());
+      return ArrayAttr::get(ty.getContext(), names_);
+    }
+    
+    StringRef getInputName(size_t idx) {
+      return $_op.getHWModuleType().getInputName(idx);
+    }
+
+    StringRef getOutputName(size_t idx) {
+      return $_op.getHWModuleType().getOutputName(idx);
+    }
+
+    StringAttr getInputNameAttr(size_t idx) {
+      return $_op.getHWModuleType().getInputNameAttr(idx);
+    }
+
+    StringAttr getOutputNameAttr(size_t idx) {
+      return $_op.getHWModuleType().getOutputNameAttr(idx);
+    }
+
 
   }];
 

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -37,6 +37,44 @@ def HWModuleLike : OpInterface<"HWModuleLike", [Symbol]> {
 
     InterfaceMethod<"Get the module type",
     "::circt::hw::ModuleType", "getHWModuleType", (ins)>,
+
+    InterfaceMethod<[{
+      Get the array of argument attribute dictionaries. The method should return
+      an array attribute containing only dictionary attributes equal in number
+      to the number of function arguments. Alternatively, the method can return
+      null to indicate that the function has no argument attributes.
+    }],
+    "::mlir::ArrayAttr", "getArgAttrsAttr">,
+
+    InterfaceMethod<[{
+      Get the array of result attribute dictionaries. The method should return
+      an array attribute containing only dictionary attributes equal in number
+      to the number of function results. Alternatively, the method can return
+      null to indicate that the function has no result attributes.
+    }],
+    "::mlir::ArrayAttr", "getResAttrsAttr">,
+    InterfaceMethod<[{
+      Set the array of argument attribute dictionaries.
+    }],
+    "void", "setArgAttrsAttr", (ins "::mlir::ArrayAttr":$attrs)>,
+    InterfaceMethod<[{
+      Set the array of result attribute dictionaries.
+    }],
+    "void", "setResAttrsAttr", (ins "::mlir::ArrayAttr":$attrs)>,
+    InterfaceMethod<[{
+      Remove the array of argument attribute dictionaries. This is the same as
+      setting all argument attributes to an empty dictionary. The method should
+      return the removed attribute.
+    }],
+    "::mlir::Attribute", "removeArgAttrsAttr">,
+    InterfaceMethod<[{
+      Remove the array of result attribute dictionaries. This is the same as
+      setting all result attributes to an empty dictionary. The method should
+      return the removed attribute.
+    }],
+    "::mlir::Attribute", "removeResAttrsAttr">,
+
+
   ];
 
   let extraSharedClassDeclaration = [{
@@ -91,6 +129,13 @@ def HWModuleLike : OpInterface<"HWModuleLike", [Symbol]> {
       return $_op.getHWModuleType().getOutputNameAttr(idx);
     }
 
+    SmallVector<Type> getInputTypes() {
+      return $_op.getHWModuleType().getInputTypes();
+    }
+
+    SmallVector<Type> getOutputTypes() {
+      return $_op.getHWModuleType().getOutputTypes();
+    }
 
   }];
 

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -31,7 +31,7 @@ class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
     HWOp<mnemonic, traits # [
       DeclareOpInterfaceMethods<HWModuleLike>,
       DeclareOpInterfaceMethods<HWMutableModuleLike>,
-      FunctionOpInterface, Symbol,
+      Symbol,
       OpAsmOpInterface, HasParent<"mlir::ModuleOp">]> {
   /// Additional class declarations inside the module op.
   code extraModuleClassDeclaration = ?;
@@ -49,6 +49,25 @@ class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
       ArrayRef<unsigned> eraseInputs,
       ArrayRef<unsigned> eraseOutputs
     );
+
+    FunctionType getFunctionType();
+
+    /// Returns the dictionary attribute corresponding to the argument at
+    /// 'index'. If there are no argument attributes at 'index', a null
+    /// attribute is returned.
+    DictionaryAttr getArgAttrDict(unsigned index) {
+      assert(index < getNumInputs() && "invalid argument number");
+      return HWModuleLike_impl::getArgAttrDict(*this, index);
+    }
+
+    /// Returns the dictionary attribute corresponding to the result at 'index'.
+    /// If there are no result attributes at 'index', a null attribute is
+    /// returned.
+    DictionaryAttr getResultAttrDict(unsigned index) {
+      assert(index < getNumOutputs() && "invalid result number");
+      return HWModuleLike_impl::getResultAttrDict(*this, index);
+    }
+
   }];
 
   /// Additional class definitions inside the module op.
@@ -57,16 +76,21 @@ class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
   let extraClassDefinition = extraModuleClassDefinition # [{
 
     ModuleType $cppClass::getHWModuleType() {
-      return detail::fnToMod(getFunctionType(), getArgNames(), getResultNames());
+      return getModuleType();
+    }
+
+    FunctionType $cppClass::getFunctionType() {
+      return getModuleType().getFuncType();
     }
 
     ::circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {
       for (::mlir::NamedAttribute argAttr :
-           ::mlir::function_interface_impl::getArgAttrs(*this, portIndex))
+           HWModuleLike_impl::getArgAttrs(*this, portIndex))
         if (auto sym = argAttr.getValue().dyn_cast<::circt::hw::InnerSymAttr>())
           return sym;
       return ::circt::hw::InnerSymAttr();
     }
+
   }];
 
 }
@@ -80,11 +104,9 @@ def HWModuleOp : HWModuleOpBase<"module",
     name, a list of ports, a list of parameters, and a body that represents the
     connections within the module.
   }];
-  let arguments = (ins TypeAttrOf<FunctionType>:$function_type,
+  let arguments = (ins TypeAttrOf<ModuleType>:$module_type,
                        OptionalAttr<DictArrayAttr>:$arg_attrs,
                        OptionalAttr<DictArrayAttr>:$res_attrs,
-                       StrArrayAttr:$argNames,
-                       StrArrayAttr:$resultNames,
                        LocationArrayAttr:$argLocs,
                        LocationArrayAttr:$resultLocs,
                        ParamDeclArrayAttr:$parameters,
@@ -111,14 +133,29 @@ def HWModuleOp : HWModuleOpBase<"module",
   ];
 
   let extraModuleClassDeclaration = [{
-    using mlir::detail::FunctionOpInterfaceTrait<HWModuleOp>::front;
-    using mlir::detail::FunctionOpInterfaceTrait<HWModuleOp>::getFunctionBody;
+    /// Block list iterator types.
+    using BlockListType = Region::BlockListType;
+    using iterator = BlockListType::iterator;
+    using reverse_iterator = BlockListType::reverse_iterator;
+
+    /// Block argument iterator types.
+    using BlockArgListType = Region::BlockArgListType;
+    using args_iterator = BlockArgListType::iterator;
+
+    //===------------------------------------------------------------------===//
+    // Body Handling
+    //===------------------------------------------------------------------===//
+
+    /// Return the region containing the body of this function.
+    Region &getModuleBody() { return getRegion(); }
+
+    ///////
 
     // Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph;}
 
     /// Returns the number of in or inout ports.
-    size_t getNumInOrInoutPorts() { return getArgumentTypes().size(); }
+    size_t getNumInOrInoutPorts() { return getNumInputs(); }
 
     /// Return the PortInfo for the specified input or inout port.
     PortInfo getInOrInoutPort(size_t i) {
@@ -168,12 +205,12 @@ def HWModuleOp : HWModuleOpBase<"module",
     /// Append an output with a given name and type to the port list.
     /// If the name is not unique, a unique name is created.
     void appendOutput(StringAttr name, Value value) {
-      return insertOutputs(getResultTypes().size(), {{name, value}});
+      return insertOutputs(getNumOutputs(), {{name, value}});
     }
 
     void appendOutput(const Twine &name, Value value) {
       ::mlir::StringAttr nameAttr = ::mlir::StringAttr::get(getContext(), name);
-      return insertOutputs(getResultTypes().size(), {{nameAttr, value}});
+      return insertOutputs(getNumOutputs(), {{nameAttr, value}});
     }
 
     /// Prepend an output with a given name and type to the port list.
@@ -193,7 +230,7 @@ def HWModuleOp : HWModuleOpBase<"module",
     void insertOutputs(unsigned index,
                        ArrayRef<std::pair<StringAttr, Value>> outputs);
 
-    Block *getBodyBlock() { return &getFunctionBody().front(); }
+    Block *getBodyBlock() { return &getModuleBody().front(); }
 
     // Get the module's symbolic name as StringAttr.
     StringAttr getNameAttr() {
@@ -205,23 +242,100 @@ def HWModuleOp : HWModuleOpBase<"module",
     StringRef getName() {
       return getNameAttr().getValue();
     }
+
+
+    //===------------------------------------------------------------------===//
+    // Argument and Result Handling
+    //===------------------------------------------------------------------===//
+
     void getAsmBlockArgumentNames(mlir::Region &region,
                                   mlir::OpAsmSetValueNameFn setNameFn);
 
-    /// Returns the argument types of this function.
-    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+    BlockArgListType getArguments() { return getModuleBody().getArguments(); }
+    BlockArgument getArgument(size_t idx) { return getModuleBody().getArgument(idx); }
 
-    /// Returns the result types of this function.
-    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
 
-    /// Verify the type attribute of this function. Returns failure and emits
-    /// an error if the attribute is invalid.
-    LogicalResult verifyType() {
-      auto type = getFunctionTypeAttr().getValue();
-      if (!type.isa<FunctionType>())
-        return emitOpError("requires '" + getFunctionTypeAttrName().getValue() +
-                           "' attribute of function type");
-      return success();
+    //===------------------------------------------------------------------===//
+    // Argument Attributes
+    //===------------------------------------------------------------------===//
+
+    /// Return all of the attributes for the argument at 'index'.
+    ArrayRef<NamedAttribute> getArgAttrs(unsigned index) {
+      return HWModuleLike_impl::getArgAttrs(*this, index);
+    }
+
+    /// Return an ArrayAttr containing all argument attribute dictionaries of
+    /// this function, or nullptr if no arguments have attributes.
+    ArrayAttr getAllArgAttrs() { return getArgAttrsAttr(); }
+
+    /// If the an attribute exists with the specified name, change it to the new
+    /// value. Otherwise, add a new attribute with the specified name/value.
+    void setArgAttr(unsigned index, StringAttr name, Attribute value) {
+      HWModuleLike_impl::setArgAttr(*this, index, name, value);
+    }
+
+    void setArgAttr(unsigned index, StringRef name, Attribute value) {
+      setArgAttr(index,
+                 StringAttr::get(getContext(), name),
+                 value);
+    }
+
+    /// Set the attributes held by the argument at 'index'.
+    void setArgAttrs(unsigned index, ArrayRef<NamedAttribute> attributes) {
+      HWModuleLike_impl::setArgAttrs(*this, index, attributes);
+    }
+
+    /// Set the attributes held by the argument at 'index'. `attributes` may be
+    /// null, in which case any existing argument attributes are removed.
+    void setArgAttrs(unsigned index, DictionaryAttr attributes) {
+      HWModuleLike_impl::setArgAttrs(*this, index, attributes);
+    }
+
+    //===------------------------------------------------------------------===//
+    // Result Attributes
+    //===------------------------------------------------------------------===//
+
+    /// Return all of the attributes for the result at 'index'.
+    ArrayRef<NamedAttribute> getResultAttrs(unsigned index) {
+      return HWModuleLike_impl::getResultAttrs(*this, index);
+    }
+
+    /// Return an ArrayAttr containing all result attribute dictionaries of this
+    /// function, or nullptr if no result have attributes.
+    ArrayAttr getAllResultAttrs() { return getResAttrsAttr(); }
+
+    /// Return all result attributes of this function.
+    void getAllResultAttrs(SmallVectorImpl<DictionaryAttr> &result) {
+      if (ArrayAttr argAttrs = getAllResultAttrs()) {
+        auto argAttrRange = argAttrs.template getAsRange<DictionaryAttr>();
+        result.append(argAttrRange.begin(), argAttrRange.end());
+      } else {
+        result.append(getNumOutputs(),
+                      DictionaryAttr::get(getContext()));
+      }
+    }
+
+    /// If the an attribute exists with the specified name, change it to the new
+    /// value. Otherwise, add a new attribute with the specified name/value.
+    void setResultAttr(unsigned index, StringAttr name, Attribute value) {
+      HWModuleLike_impl::setResultAttr(*this, index, name, value);
+    }
+
+    void setResultAttr(unsigned index, StringRef name, Attribute value) {
+      setResultAttr(index,
+                    StringAttr::get(getContext(), name),
+                    value);
+    }
+
+    /// Set the attributes held by the result at 'index'.
+    void setResultAttrs(unsigned index, ArrayRef<NamedAttribute> attributes) {
+      HWModuleLike_impl::setResultAttrs(*this, index, attributes);
+    }
+
+    /// Set the attributes held by the result at 'index'. `attributes` may be
+    /// null, in which case any existing argument attributes are removed.
+    void setResultAttrs(unsigned index, DictionaryAttr attributes) {
+      HWModuleLike_impl::setResultAttrs(*this, index, attributes);
     }
 
     /// Verifies the body of the function.
@@ -243,10 +357,9 @@ def HWModuleExternOp : HWModuleOpBase<"module.extern"> {
     have proper parameterization in the hw.dialect.  We need a way to represent
     parameterized types instead of just concrete types.
   }];
-  let arguments = (ins TypeAttrOf<FunctionType>:$function_type,
+  let arguments = (ins TypeAttrOf<ModuleType>:$module_type,
 		       OptionalAttr<DictArrayAttr>:$arg_attrs,
                        OptionalAttr<DictArrayAttr>:$res_attrs,
-                       StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,
                        OptionalAttr<StrAttr>:$verilogName);
   let results = (outs);
@@ -299,24 +412,19 @@ def HWModuleExternOp : HWModuleOpBase<"module.extern"> {
       return getNameAttr().getValue();
     }
 
+    /// Return all of the attributes for the argument at 'index'.
+    ArrayRef<NamedAttribute> getArgAttrs(unsigned index) {
+      return HWModuleLike_impl::getArgAttrs(*this, index);
+    }
+
+    /// Return all of the attributes for the result at 'index'.
+    ArrayRef<NamedAttribute> getResultAttrs(unsigned index) {
+      return HWModuleLike_impl::getResultAttrs(*this, index);
+    }
+
     void getAsmBlockArgumentNames(mlir::Region &region,
                                   mlir::OpAsmSetValueNameFn setNameFn);
 
-    /// Returns the argument types of this function.
-    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
-
-    /// Returns the result types of this function.
-    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
-
-    /// Verify the type attribute of this function. Returns failure and emits
-    /// an error if the attribute is invalid.
-    LogicalResult verifyType() {
-      auto type = getFunctionTypeAttr().getValue();
-      if (!type.isa<FunctionType>())
-        return emitOpError("requires '" + getFunctionTypeAttrName().getValue() +
-                           "' attribute of function type");
-      return success();
-    }
   }];
 
   let hasCustomAssemblyFormat = 1;
@@ -359,10 +467,9 @@ def HWModuleGeneratedOp : HWModuleOpBase<"module.generated", [
     module name in Verilog we can use.  See hw.module for an explanation.
   }];
   let arguments = (ins FlatSymbolRefAttr:$generatorKind,
-                       TypeAttrOf<FunctionType>:$function_type,
+                       TypeAttrOf<ModuleType>:$module_type,
 		       OptionalAttr<DictArrayAttr>:$arg_attrs,
                        OptionalAttr<DictArrayAttr>:$res_attrs,
-                       StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,
                        OptionalAttr<StrAttr>:$verilogName);
   let results = (outs);
@@ -401,22 +508,6 @@ def HWModuleGeneratedOp : HWModuleOpBase<"module.generated", [
 
     void getAsmBlockArgumentNames(mlir::Region &region,
                                   mlir::OpAsmSetValueNameFn setNameFn);
-
-    /// Returns the argument types of this function.
-    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
-
-    /// Returns the result types of this function.
-    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
-
-    /// Verify the type attribute of this function. Returns failure and emits
-    /// an error if the attribute is invalid.
-    LogicalResult verifyType() {
-      auto type = getFunctionTypeAttr().getValue();
-      if (!type.isa<FunctionType>())
-        return emitOpError("requires '" + getFunctionTypeAttrName().getValue() +
-                           "' attribute of function type");
-      return success();
-    }
 
     TypeAttr getTypeAttr();
   }];

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -55,9 +55,9 @@ class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
   code extraModuleClassDefinition = [{}];
 
   let extraClassDefinition = extraModuleClassDefinition # [{
-    size_t $cppClass::getNumPorts() {
-      // This is wildly inefficient
-      return getModulePortInfo(*this).size();
+
+    ModuleType $cppClass::getHWModuleType() {
+      return detail::fnToMod(getFunctionType(), getArgNames(), getResultNames());
     }
 
     ::circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -170,10 +170,9 @@ def MSFTModuleOp : MSFTModuleOpBase<"module",
   }];
 
   let extraClassDefinition = [{
-    size_t $cppClass::getNumPorts() {
-      // This is excessively expensive
-      auto ports = getPorts();
-      return ports.size();
+
+    ::circt::hw::ModuleType $cppClass::getHWModuleType() {
+      return ::circt::hw::detail::fnToMod(getFunctionType(), getArgNames(), getResultNames());
     }
 
     circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {
@@ -217,6 +216,7 @@ def MSFTModuleExternOp : MSFTOp<"module.extern",
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
+
     /// Decode information about the input and output ports on this module.
     hw::ModulePortInfo getPorts();
 
@@ -225,6 +225,12 @@ def MSFTModuleExternOp : MSFTOp<"module.extern",
 
     /// Returns the result types of this function.
     ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+  }];
+
+  let extraClassDefinition = [{
+    ::circt::hw::ModuleType $cppClass::getHWModuleType() {
+      return ::circt::hw::detail::fnToMod(getFunctionType(), getArgNames(), getResultNames());
+    }
   }];
 }
 

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -105,8 +105,9 @@ def SCModuleOp : SystemCOp<"module", [
   }];
 
   let extraClassDefinition = [{
-    size_t $cppClass::getNumPorts() {
-      return getPortNames().size();
+
+    ::circt::hw::ModuleType $cppClass::getHWModuleType() {
+      return ::circt::hw::detail::fnToMod(getFunctionType(), getPortNames(), getPortNames());
     }
 
     circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -5575,18 +5575,16 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
   };
   /// Collect any port marked as being referenced via symbol.
   auto collectPorts = [&](auto moduleOp) {
-    auto numArgs = moduleOp.getNumArguments();
+    auto numArgs = moduleOp.getNumInputs();
     for (size_t p = 0; p != numArgs; ++p)
-      for (NamedAttribute argAttr :
-           mlir::function_interface_impl::getArgAttrs(moduleOp, p)) {
+      for (NamedAttribute argAttr : moduleOp.getArgAttrs(p)) {
         if (auto sym = argAttr.getValue().dyn_cast<InnerSymAttr>()) {
           symbolCache.addDefinition(moduleOp.getNameAttr(), sym.getSymName(),
                                     moduleOp, p);
         }
       }
-    for (size_t p = 0, e = moduleOp.getNumResults(); p != e; ++p)
-      for (NamedAttribute resultAttr :
-           mlir::function_interface_impl::getResultAttrs(moduleOp, p))
+    for (size_t p = 0, e = moduleOp.getNumOutputs(); p != e; ++p)
+      for (NamedAttribute resultAttr : moduleOp.getResultAttrs(p))
         if (auto sym = resultAttr.getValue().dyn_cast<InnerSymAttr>())
           symbolCache.addDefinition(moduleOp.getNameAttr(), sym.getSymName(),
                                     moduleOp, p + numArgs);

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -339,7 +339,7 @@ MachineOpConverter::moveOps(Block *block,
     if (op.hasTrait<OpTrait::IsTerminator>())
       return &op;
 
-    op.moveBefore(&hwModuleOp.front(), b.getInsertionPoint());
+    op.moveBefore(hwModuleOp.getBodyBlock(), b.getInsertionPoint());
   }
   return nullptr;
 }
@@ -412,19 +412,19 @@ LogicalResult MachineOpConverter::dispatch() {
   SmallVector<hw::PortInfo, 16> ports;
   auto clkRstIdxs = getMachinePortInfo(ports, machineOp, b);
   hwModuleOp = b.create<hw::HWModuleOp>(loc, machineOp.getSymNameAttr(), ports);
-  b.setInsertionPointToStart(&hwModuleOp.front());
+  b.setInsertionPointToStart(hwModuleOp.getBodyBlock());
 
   // Replace all uses of the machine arguments with the arguments of the
   // new created HW module.
   for (auto args :
-       llvm::zip(machineOp.getArguments(), hwModuleOp.front().getArguments())) {
+       llvm::zip(machineOp.getArguments(), hwModuleOp.getArguments())) {
     auto machineArg = std::get<0>(args);
     auto hwModuleArg = std::get<1>(args);
     machineArg.replaceAllUsesWith(hwModuleArg);
   }
 
-  auto clock = hwModuleOp.front().getArgument(clkRstIdxs.clockIdx);
-  auto reset = hwModuleOp.front().getArgument(clkRstIdxs.resetIdx);
+  auto clock = hwModuleOp.getArgument(clkRstIdxs.clockIdx);
+  auto reset = hwModuleOp.getArgument(clkRstIdxs.resetIdx);
 
   // 2) Build state and variable registers.
   encoding =
@@ -567,7 +567,7 @@ LogicalResult MachineOpConverter::dispatch() {
 
   // Delete the default created output op and replace it with the output
   // muxes.
-  auto *oldOutputOp = hwModuleOp.front().getTerminator();
+  auto *oldOutputOp = hwModuleOp.getBodyBlock()->getTerminator();
   b.create<hw::OutputOp>(loc, outputPortAssignments);
   oldOutputOp->erase();
 

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -317,7 +317,7 @@ static LogicalResult convertExtMemoryOps(HWModuleOp mod) {
 
   for (auto [i, arg] : memrefPorts) {
     // Insert ports into the module
-    auto memName = mod.getArgNames()[i].cast<StringAttr>();
+    auto memName = mod.getInputNameAttr(i);
 
     // Get the attached extmemory external module.
     auto extmemInstance = cast<hw::InstanceOp>(*arg.getUsers().begin());
@@ -341,12 +341,12 @@ static LogicalResult convertExtMemoryOps(HWModuleOp mod) {
     // Replace the extmemory submodule outputs with the newly created inputs.
     b.setInsertionPointToStart(mod.getBodyBlock());
     auto newInPortExploded = b.create<hw::StructExplodeOp>(
-        arg.getLoc(), extmemMod.getResultTypes(), newInPort);
+        arg.getLoc(), extmemMod.getOutputTypes(), newInPort);
     extmemInstance.replaceAllUsesWith(newInPortExploded.getResults());
 
     // Add memory output - this is the inputs of the extmemory op (without the
     // first argument);
-    unsigned outArgI = mod.getNumResults();
+    unsigned outArgI = mod.getNumOutputs();
     auto outPortInfo =
         getMemoryIOInfo(arg.getLoc(), memName.strref() + "_out", outArgI,
                         ArrayRef{portInfo.begin_input(), portInfo.end_input()},
@@ -707,8 +707,8 @@ addSequentialIOOperandsIfNeeded(Operation *op,
     // Parent should at this point be a hw.module and have clock and reset
     // ports.
     auto parent = cast<hw::HWModuleOp>(op->getParentOp());
-    operands.push_back(parent.getArgument(parent.getNumArguments() - 2));
-    operands.push_back(parent.getArgument(parent.getNumArguments() - 1));
+    operands.push_back(parent.getArgument(parent.getNumInputs() - 2));
+    operands.push_back(parent.getArgument(parent.getNumInputs() - 1));
   }
 }
 

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -296,7 +296,7 @@ LogicalResult ModuleLowering::lowerPrimaryInputs() {
     if (blockArg == storageArg)
       continue;
     auto name =
-        moduleOp.getArgNames()[blockArg.getArgNumber()].cast<StringAttr>();
+        moduleOp.getInputNameAttr(blockArg.getArgNumber());
     auto intType = blockArg.getType().dyn_cast<IntegerType>();
     if (!intType)
       return mlir::emitError(blockArg.getLoc(), "input ")
@@ -315,7 +315,7 @@ LogicalResult ModuleLowering::lowerPrimaryOutputs() {
   if (outputOp.getNumOperands() > 0) {
     auto &passThrough = getOrCreatePassThrough();
     for (auto [value, name] :
-         llvm::zip(outputOp.getOperands(), moduleOp.getResultNames())) {
+         llvm::zip(outputOp.getOperands(), moduleOp.getOutputNames())) {
       auto intType = value.getType().dyn_cast<IntegerType>();
       if (!intType)
         return mlir::emitError(outputOp.getLoc(), "output ")

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1822,11 +1822,11 @@ SmallVector<DictionaryAttr> PrimitiveOp::portAttributes() {
   SmallVector<DictionaryAttr> portAttributes;
   OpBuilder builder(getContext());
   hw::HWModuleExternOp prim = getReferencedPrimitive();
-  for (size_t i = 0, e = prim.getNumArguments(); i != e; ++i) {
+  for (size_t i = 0, e = prim.getNumInputs(); i != e; ++i) {
     DictionaryAttr dict = cleanCalyxPortAttrs(builder, prim.getArgAttrDict(i));
     portAttributes.push_back(dict);
   }
-  for (size_t i = 0, e = prim.getNumResults(); i != e; ++i) {
+  for (size_t i = 0, e = prim.getNumOutputs(); i != e; ++i) {
     DictionaryAttr dict =
         cleanCalyxPortAttrs(builder, prim.getResultAttrDict(i));
     portAttributes.push_back(dict);

--- a/lib/Dialect/ESI/ESIDialect.cpp
+++ b/lib/Dialect/ESI/ESIDialect.cpp
@@ -247,7 +247,7 @@ circt::esi::buildESIWrapper(OpBuilder &b, Operation *pearl,
   BackedgeBuilder bb(modBuilder, modBuilder.getLoc());
 
   // Hold the operands for `hw.output` here.
-  SmallVector<Value, 64> outputs(shell.getNumResults());
+  SmallVector<Value, 64> outputs(shell.getNumOutputs());
 
   // -----
   // Fourth, assemble the inputs for the pearl module AND build all the ESI wrap

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -534,8 +534,41 @@ hw::ModuleType ESIPureModuleOp::getHWModuleType() {
 }
 
 ::circt::hw::InnerSymAttr ESIPureModuleOp::getPortSymbolAttr(size_t) {
+  assert(false);
   return {};
 }
+
+    // satisify HWModuleLike
+    ArrayAttr ESIPureModuleOp::getArgAttrsAttr() {
+      assert(false);
+      return {};
+    }
+
+    // satisify HWModuleLike
+    ArrayAttr ESIPureModuleOp::getResAttrsAttr() {
+      assert(false);
+      return {};
+    }
+
+    // satisify HWModuleLike
+    void ESIPureModuleOp::setArgAttrsAttr(ArrayAttr) {
+      assert(false);
+    }    
+    // satisify HWModuleLike
+    void ESIPureModuleOp::setResAttrsAttr(ArrayAttr) {
+      assert(false);
+    }    
+    // satisify HWModuleLike
+    Attribute ESIPureModuleOp::removeArgAttrsAttr() {
+      assert(false);
+      return {};
+    }    
+
+    // satisify HWModuleLike
+    Attribute ESIPureModuleOp::removeResAttrsAttr() {
+      assert(false);
+      return {};
+    }    
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/ESI/ESI.cpp.inc"

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -529,9 +529,11 @@ LogicalResult ESIPureModuleOp::verify() {
   return success();
 }
 
-size_t ESIPureModuleOp::getNumPorts() { return 0; }
-hw::InnerSymAttr ESIPureModuleOp::getPortSymbolAttr(size_t portIndex) {
-  assert(false);
+hw::ModuleType ESIPureModuleOp::getHWModuleType() {
+  return hw::ModuleType::get(getContext(), {});
+}
+
+::circt::hw::InnerSymAttr ESIPureModuleOp::getPortSymbolAttr(size_t) {
   return {};
 }
 

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -615,10 +615,11 @@ ESIConnectServicesPass::surfaceReqs(hw::HWMutableModuleLike mod,
     SmallVector<NamedAttribute> newAttrs;
     for (auto attr : inst->getAttrs()) {
       if (attr.getName() == argsAttrName)
-        newAttrs.push_back(b.getNamedAttr(argsAttrName, mod.getInputNames()));
+        newAttrs.push_back(
+            b.getNamedAttr(argsAttrName, mod.getInputNamesAttr()));
       else if (attr.getName() == resultsAttrName)
         newAttrs.push_back(
-            b.getNamedAttr(resultsAttrName, mod.getOutputNames()));
+            b.getNamedAttr(resultsAttrName, mod.getOutputNamesAttr()));
       else
         newAttrs.push_back(attr);
     }

--- a/lib/Dialect/ESI/Passes/ESILowerPorts.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerPorts.cpp
@@ -357,7 +357,7 @@ bool ESIPortsPass::updateFunc(HWModuleExternOp mod) {
   // port is found.
   SmallVector<Type, 16> newArgTypes;
   size_t nextArgNo = 0;
-  for (auto argTy : mod.getArgumentTypes()) {
+  for (auto argTy : mod.getInputTypes()) {
     auto chanTy = argTy.dyn_cast<ChannelType>();
     newArgNames.push_back(getModuleArgumentNameAttr(mod, nextArgNo));
     newArgLocs.push_back(getModuleArgumentLocAttr(mod, nextArgNo));
@@ -381,7 +381,7 @@ bool ESIPortsPass::updateFunc(HWModuleExternOp mod) {
   SmallVector<Type, 8> newResultTypes;
   SmallVector<DictionaryAttr, 4> newResultAttrs;
   auto funcType = mod.getFunctionType();
-  for (size_t resNum = 0, numRes = mod.getNumResults(); resNum < numRes;
+  for (size_t resNum = 0, numRes = mod.getNumOutputs(); resNum < numRes;
        ++resNum) {
     Type resTy = funcType.getResult(resNum);
     auto chanTy = resTy.dyn_cast<ChannelType>();
@@ -410,7 +410,8 @@ bool ESIPortsPass::updateFunc(HWModuleExternOp mod) {
 
   // Set the new types.
   auto newFuncType = FunctionType::get(ctxt, newArgTypes, newResultTypes);
-  mod.setType(newFuncType);
+  auto newModType = hw::detail::fnToMod(newFuncType, ArrayAttr::get(&getContext(), newArgNames), ArrayAttr::get(&getContext(), newResultNames));
+  mod.setModuleType(newModType);
   setModuleArgumentNames(mod, newArgNames);
   setModuleArgumentLocs(mod, newArgLocs);
   setModuleResultNames(mod, newResultNames);

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -109,7 +109,7 @@ static bool applyToPort(AnnotationSet annos, Operation *op, size_t portCount,
 }
 
 bool AnnotationSet::applyToPort(FModuleLike op, size_t portNo) const {
-  return ::applyToPort(*this, op.getOperation(), getNumPorts(op), portNo);
+  return ::applyToPort(*this, op.getOperation(), op.getNumPorts(), portNo);
 }
 
 bool AnnotationSet::applyToPort(MemOp op, size_t portNo) const {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -221,7 +221,7 @@ DeclKind firrtl::getDeclarationKind(Value val) {
 }
 
 size_t firrtl::getNumPorts(Operation *op) {
-  if (auto module = dyn_cast<hw::HWModuleLike>(op))
+  if (auto module = dyn_cast<FModuleLike>(op))
     return module.getNumPorts();
   return op->getNumResults();
 }
@@ -458,7 +458,7 @@ Block *CircuitOp::getBodyBlock() { return &getBody().front(); }
 
 static SmallVector<PortInfo> getPorts(FModuleLike module) {
   SmallVector<PortInfo> results;
-  for (unsigned i = 0, e = getNumPorts(module); i < e; ++i) {
+  for (unsigned i = 0, e = module.getPortNames().size(); i < e; ++i) {
     results.push_back({module.getPortNameAttr(i), module.getPortType(i),
                        module.getPortDirection(i), module.getPortSymbolAttr(i),
                        module.getPortLocation(i),
@@ -495,7 +495,7 @@ static void insertPorts(FModuleLike op,
                         ArrayRef<std::pair<unsigned, PortInfo>> ports) {
   if (ports.empty())
     return;
-  unsigned oldNumArgs = getNumPorts(op);
+  unsigned oldNumArgs = op.getNumPorts();
   unsigned newNumArgs = oldNumArgs + ports.size();
 
   // Add direction markers and names for new ports.
@@ -576,7 +576,7 @@ static void erasePorts(FModuleLike op, const llvm::BitVector &portIndices) {
   ArrayRef<Attribute> portAnnos = op.getPortAnnotations();
   ArrayRef<Attribute> portSyms = op.getPortSymbols();
   ArrayRef<Attribute> portLocs = op.getPortLocations();
-  auto numPorts = getNumPorts(op);
+  auto numPorts = op.getNumPorts();
   (void)numPorts;
   assert(portDirections.size() == numPorts);
   assert(portNames.size() == numPorts);
@@ -1562,7 +1562,7 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
 
   // Gather the result types.
   SmallVector<Type> resultTypes;
-  resultTypes.reserve(getNumPorts(module));
+  resultTypes.reserve(module.getNumPorts());
   llvm::transform(
       module.getPortTypes(), std::back_inserter(resultTypes),
       [](Attribute typeAttr) { return cast<TypeAttr>(typeAttr).getValue(); });
@@ -1712,7 +1712,7 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // Check that all the attribute arrays are the right length up front.  This
   // lets us safely use the port name in error messages below.
   size_t numResults = getNumResults();
-  size_t numExpected = getNumPorts(referencedModule);
+  size_t numExpected = referencedModule.getNumPorts();
   if (numResults != numExpected) {
     return emitNote(emitOpError() << "has a wrong number of results; expected "
                                   << numExpected << " but got " << numResults);

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -775,7 +775,7 @@ void Inliner::mapPortsToWires(StringRef prefix, OpBuilder &b, IRMapping &mapper,
                               SmallVectorImpl<Value> &wires,
                               SmallVectorImpl<Backedge> &edges) {
   auto portInfo = target.getPorts();
-  for (unsigned i = 0, e = getNumPorts(target); i < e; ++i) {
+  for (unsigned i = 0, e = target.getNumPorts(); i < e; ++i) {
     auto arg = target.getArgument(i);
     // Get the type of the wire.
     auto type = type_cast<FIRRTLType>(arg.getType());
@@ -1254,7 +1254,7 @@ void Inliner::identifyNLAsTargetingOnlyModules() {
           referencedNLASyms.insert(sym.getAttr());
     };
     // Scan ports
-    for (unsigned i = 0, e = getNumPorts(mod); i != e; ++i)
+    for (unsigned i = 0, e = mod.getNumPorts(); i != e; ++i)
       scanAnnos(AnnotationSet::forPort(mod, i));
 
     // Scan operations (and not the module itself):

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -59,14 +59,14 @@ StringAttr MachineOp::getArgName(size_t i) {
   if (auto args = getArgNames())
     return (*args)[i].cast<StringAttr>();
   else
-    return StringAttr::get(getContext(), "in" + std::to_string(i));
+    return {};
 }
 
 StringAttr MachineOp::getResName(size_t i) {
   if (auto resNameAttrs = getResNames())
     return (*resNameAttrs)[i].cast<StringAttr>();
   else
-    return StringAttr::get(getContext(), "out" + std::to_string(i));
+    return {};
 }
 
 /// Get the port information of the machine.
@@ -76,6 +76,8 @@ void MachineOp::getHWPortInfo(SmallVectorImpl<hw::PortInfo> &ports) {
   for (unsigned i = 0, e = machineType.getNumInputs(); i < e; ++i) {
     hw::PortInfo port;
     port.name = getArgName(i);
+    if (!port.name)
+      port.name = StringAttr::get(getContext(), "in" + std::to_string(i));
     port.dir = circt::hw::ModulePort::Direction::Input;
     port.type = machineType.getInput(i);
     port.argNum = i;
@@ -85,6 +87,8 @@ void MachineOp::getHWPortInfo(SmallVectorImpl<hw::PortInfo> &ports) {
   for (unsigned i = 0, e = machineType.getNumResults(); i < e; ++i) {
     hw::PortInfo port;
     port.name = getResName(i);
+    if (!port.name)
+      port.name = StringAttr::get(getContext(), "out" + std::to_string(i));
     port.dir = circt::hw::ModulePort::Direction::Output;
     port.type = machineType.getResult(i);
     port.argNum = i;
@@ -94,9 +98,9 @@ void MachineOp::getHWPortInfo(SmallVectorImpl<hw::PortInfo> &ports) {
 
 ParseResult MachineOp::parse(OpAsmParser &parser, OperationState &result) {
   auto buildFuncType =
-      [](Builder &builder, ArrayRef<Type> argTypes, ArrayRef<Type> results,
-         function_interface_impl::VariadicFlag,
-         std::string &) { return builder.getFunctionType(argTypes, results); };
+      [&](Builder &builder, ArrayRef<Type> argTypes, ArrayRef<Type> results,
+          function_interface_impl::VariadicFlag,
+          std::string &) { return builder.getFunctionType(argTypes, results); };
 
   return function_interface_impl::parseFunctionOp(
       parser, result, /*allowVariadic=*/false,

--- a/lib/Dialect/HW/HWOpInterfaces.cpp
+++ b/lib/Dialect/HW/HWOpInterfaces.cpp
@@ -80,4 +80,143 @@ LogicalResult hw::verifyInnerSymAttr(InnerSymbolOpInterface op) {
   return success();
 }
 
+
+static bool isEmptyAttrDict(Attribute attr) {
+  return llvm::cast<DictionaryAttr>(attr).empty();
+}
+
+
+/// Get either the argument or result attributes array.
+template <bool isArg>
+static ArrayAttr getArgResAttrs(circt::hw::HWModuleLike op) {
+  if constexpr (isArg)
+    return op.getArgAttrsAttr();
+  else
+    return op.getResAttrsAttr();
+}
+
+/// Set either the argument or result attributes array.
+template <bool isArg>
+static void setArgResAttrs(circt::hw::HWModuleLike op, ArrayAttr attrs) {
+  if constexpr (isArg)
+    op.setArgAttrsAttr(attrs);
+  else
+    op.setResAttrsAttr(attrs);
+}
+
+/// Erase either the argument or result attributes array.
+template <bool isArg>
+static void removeArgResAttrs(circt::hw::HWModuleLike op) {
+  if constexpr (isArg)
+    op.removeArgAttrsAttr();
+  else
+    op.removeResAttrsAttr();
+}
+
+/// Update the given index into an argument or result attribute dictionary.
+template <bool isArg>
+static void setArgResAttrDict(circt::hw::HWModuleLike op, unsigned numTotalIndices,
+                              unsigned index, DictionaryAttr attrs) {
+  ArrayAttr allAttrs = getArgResAttrs<isArg>(op);
+  if (!allAttrs) {
+    if (attrs.empty())
+      return;
+
+    // If this attribute is not empty, we need to create a new attribute array.
+    SmallVector<Attribute, 8> newAttrs(numTotalIndices,
+                                       DictionaryAttr::get(op->getContext()));
+    newAttrs[index] = attrs;
+    setArgResAttrs<isArg>(op, ArrayAttr::get(op->getContext(), newAttrs));
+    return;
+  }
+  // Check to see if the attribute is different from what we already have.
+  if (allAttrs[index] == attrs)
+    return;
+
+  // If it is, check to see if the attribute array would now contain only empty
+  // dictionaries.
+  ArrayRef<Attribute> rawAttrArray = allAttrs.getValue();
+  if (attrs.empty() &&
+      llvm::all_of(rawAttrArray.take_front(index), isEmptyAttrDict) &&
+      llvm::all_of(rawAttrArray.drop_front(index + 1), isEmptyAttrDict))
+    return removeArgResAttrs<isArg>(op);
+
+  // Otherwise, create a new attribute array with the updated dictionary.
+  SmallVector<Attribute, 8> newAttrs(rawAttrArray.begin(), rawAttrArray.end());
+  newAttrs[index] = attrs;
+  setArgResAttrs<isArg>(op, ArrayAttr::get(op->getContext(), newAttrs));
+}
+
+
+
+
+DictionaryAttr circt::hw::HWModuleLike_impl::getArgAttrDict(HWModuleLike op,
+                                                       unsigned index) {
+  ArrayAttr attrs = op.getArgAttrsAttr();
+  DictionaryAttr argAttrs =
+      attrs ? llvm::cast<DictionaryAttr>(attrs[index]) : DictionaryAttr();
+  return argAttrs;
+}
+
+DictionaryAttr
+circt::hw::HWModuleLike_impl::getResultAttrDict(HWModuleLike op,
+                                           unsigned index) {
+  ArrayAttr attrs = op.getResAttrsAttr();
+  DictionaryAttr resAttrs =
+      attrs ? llvm::cast<DictionaryAttr>(attrs[index]) : DictionaryAttr();
+  return resAttrs;
+}
+
+ArrayRef<NamedAttribute>
+circt::hw::HWModuleLike_impl::getArgAttrs(HWModuleLike op, unsigned index) {
+  auto argDict = getArgAttrDict(op, index);
+  return argDict ? argDict.getValue() : std::nullopt;
+}
+
+ArrayRef<NamedAttribute>
+circt::hw::HWModuleLike_impl::getResultAttrs(HWModuleLike op,
+                                        unsigned index) {
+  auto resultDict = getResultAttrDict(op, index);
+  return resultDict ? resultDict.getValue() : std::nullopt;
+}
+
+
+void circt::hw::HWModuleLike_impl::setArgAttrs(HWModuleLike op,
+                                          unsigned index,
+                                          ArrayRef<NamedAttribute> attributes) {
+  assert(index < op.getNumInputs() && "invalid argument number");
+  return setArgResAttrDict</*isArg=*/true>(
+      op, op.getNumInputs(), index,
+      DictionaryAttr::get(op->getContext(), attributes));
+}
+
+void circt::hw::HWModuleLike_impl::setResultAttrs(
+    HWModuleLike op, unsigned index,
+    ArrayRef<NamedAttribute> attributes) {
+  assert(index < op.getNumOutputs() && "invalid result number");
+  return setArgResAttrDict</*isArg=*/false>(
+      op, op.getNumOutputs(), index,
+      DictionaryAttr::get(op->getContext(), attributes));
+}
+
+void circt::hw::HWModuleLike_impl::setArgAttrs(HWModuleLike op,
+                                          unsigned index,
+                                          DictionaryAttr attributes) {
+  return setArgResAttrDict</*isArg=*/true>(
+      op, op.getNumInputs(), index,
+      attributes ? attributes : DictionaryAttr::get(op->getContext()));
+}
+
+
+void circt::hw::HWModuleLike_impl::setResultAttrs(HWModuleLike op,
+                                             unsigned index,
+                                             DictionaryAttr attributes) {
+  assert(index < op.getNumOutputs() && "invalid result number");
+  return setArgResAttrDict</*isArg=*/false>(
+      op, op.getNumOutputs(), index,
+      attributes ? attributes : DictionaryAttr::get(op->getContext()));
+}
+
+
+
 #include "circt/Dialect/HW/HWOpInterfaces.cpp.inc"

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -950,10 +950,6 @@ hw::ModulePortInfo MSFTModuleExternOp::getPorts() {
   return hw::ModulePortInfo(inputs, outputs);
 }
 
-size_t MSFTModuleExternOp::getNumPorts() {
-  return getArgNames().size() + getResultNames().size();
-}
-
 hw::InnerSymAttr MSFTModuleExternOp::getPortSymbolAttr(size_t) { return {}; }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -135,7 +135,7 @@ getBackwardSlice(hw::HWModuleOp module,
   return getBackwardSlice(roots, filterFn);
 }
 
-static StringAttr getNameForPort(Value val, ArrayAttr modulePorts) {
+static StringAttr getNameForPort(Value val, ArrayRef<StringAttr> modulePorts) {
   if (auto bv = val.dyn_cast<BlockArgument>())
     return modulePorts[bv.getArgNumber()].cast<StringAttr>();
 
@@ -200,7 +200,7 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   // Construct the ports, this is just the input Values
   SmallVector<hw::PortInfo> ports;
   {
-    auto srcPorts = op.getArgNames();
+    auto srcPorts = op.getInputNames();
     for (auto port : llvm::enumerate(realInputs)) {
       auto name = getNameForPort(port.value(), srcPorts);
       ports.push_back(


### PR DESCRIPTION
This converse HWModules over to using ModuleType to store the port types and names.

This doesn't quite break the assumption that ports are stored in-order.

HWModules are moved away from FunctionOpInterface, necessitating the temproary implementation of some of that functionality.  This is temporary as the separation betwen argument and result in the side-arrays (loc, attrs, etc) will be eliminated in a future patch.
