### PR TITLE
[WIP][HW] Add externalizeable interface and externalization pass

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -338,4 +338,32 @@ def InnerRefUserOpInterface : OpInterface<"InnerRefUserOpInterface"> {
   ];
 }
 
+def ExternalizeableOpInterface : OpInterface<"ExternalizeableOpInterface"> {
+  let description = [{
+    This interface describes an operation that may be replaced by an external
+    module instantiation.P
+  }];
+  let cppNamespace = "::circt::hw";
+  let methods = [
+    InterfaceMethod<"Returns a list of required port names which must be specified by the user, as well as their types.",
+      "llvm::SmallVector<hw::PortInfo>", "getRequiredPorts",
+      (ins)>,
+    InterfaceMethod<"Returns a list of optional port names which must be specified by the user, as well as their types.",
+      "llvm::SmallVector<hw::PortInfo>", "getOptionalPorts",
+      (ins)>,
+    InterfaceMethod<"Get the operands to an instance of the externalized module, and a list of result values of this op which are to be replaced by the instance results (in order). The provided op builder can be used to create any shim operations required for instantiation.",
+      "void", "doOperandAndResultMapping",
+      (ins "mlir::ImplicitLocOpBuilder&":$builder,
+           // A handle to the port lookup info of the module to allow inspection
+           // of what ports actually got included in the external module.
+           "const hw::ModulePortLookupInfo&":$portLookup,
+           // A handle to the user-provided port mapping
+           "const llvm::DenseMap<mlir::StringAttr, mlir::StringAttr>&":$portMap,
+           // Operands that should be provided to the instance op
+           "llvm::SmallVector<Value>&":$instanceOperands,
+           // Results of this op that should be placed with the instace op.
+           "llvm::SmallVector<Value>&":$instanceResults)>
+  ];
+}
+
 #endif

--- a/include/circt/Dialect/HW/HWPasses.h
+++ b/include/circt/Dialect/HW/HWPasses.h
@@ -21,10 +21,15 @@
 namespace circt {
 namespace hw {
 
+#define GEN_PASS_DECL_EXTERNALIZE
+#include "circt/Dialect/HW/Passes.h.inc"
+
 std::unique_ptr<mlir::Pass> createPrintInstanceGraphPass();
 std::unique_ptr<mlir::Pass> createHWSpecializePass();
 std::unique_ptr<mlir::Pass> createPrintHWModuleGraphPass();
 std::unique_ptr<mlir::Pass> createFlattenIOPass();
+std::unique_ptr<mlir::Pass>
+createExternalizePass(const ExternalizeOptions &options = {});
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -53,4 +53,25 @@ def HWSpecialize : Pass<"hw-specialize", "mlir::ModuleOp"> {
   }];
 }
 
+def Externalize: Pass<"hw-externalize", "mlir::ModuleOp"> {
+  let summary = "Run module externalization on the target op";
+  let constructor = "circt::hw::createExternalizePass()";
+  let dependentDialects = ["circt::hw::HWDialect"];
+  let options = [
+    Option<"opName", "op", "std::string", "",
+           "Name of the operation to externalize">,
+    Option<"moduleName", "module-name", "std::string", "",
+           "Name of the external module">,
+    Option<"instName", "instance-name", "std::string", "",
+           "Name of the generated instances">,
+    ListOption<"portNames", "port-names", "std::string",
+           "A 'id=name' list of interface-required ports (id) to provided external module port (name)s",
+           "llvm::cl::ZeroOrMore,">,
+  ];
+  let statistics = [
+    Statistic<"numOperationsCnverted", "num-ops-converted",
+      "Number of operations to external module instances">
+  ];
+}
+
 #endif // CIRCT_DIALECT_HW_PASSES_TD

--- a/include/circt/Dialect/Seq/SeqOps.h
+++ b/include/circt/Dialect/Seq/SeqOps.h
@@ -18,6 +18,7 @@
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
+#include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/Seq/SeqAttributes.h"
 #include "circt/Dialect/Seq/SeqDialect.h"

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 include "circt/Dialect/HW/HWTypes.td"
+include "circt/Dialect/HW/HWOpInterfaces.td"
 include "circt/Dialect/Seq/SeqAttributes.td"
 include "circt/Dialect/Seq/SeqOpInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -275,7 +276,10 @@ def WritePortOp : SeqOp<"write", [
 // Clock Gate
 //===----------------------------------------------------------------------===//
 
-def ClockGateOp : SeqOp<"clock_gate", [Pure]> {
+def ClockGateOp : SeqOp<"clock_gate", [
+    Pure,
+    DeclareOpInterfaceMethods<ExternalizeableOpInterface>
+  ]> {
   let summary = "Safely gates a clock with an enable signal";
   let description = [{
     The `seq.clock_gate` enables and disables a clock safely, without glitches,

--- a/lib/Dialect/HW/Transforms/CMakeLists.txt
+++ b/lib/Dialect/HW/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_dialect_library(CIRCTHWTransforms
   HWSpecialize.cpp
   PrintHWModuleGraph.cpp
   FlattenIO.cpp
+  Externalize.cpp
 
   DEPENDS
   CIRCTHWTransformsIncGen

--- a/lib/Dialect/HW/Transforms/Externalize.cpp
+++ b/lib/Dialect/HW/Transforms/Externalize.cpp
@@ -1,0 +1,159 @@
+//===- Externalize.cpp - Externalize operations ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWPasses.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+
+#include "llvm/Support/Debug.h"
+
+namespace circt {
+namespace hw {
+#define GEN_PASS_DEF_EXTERNALIZE
+#include "circt/Dialect/HW/Passes.h.inc"
+} // namespace hw
+} // namespace circt
+
+using namespace circt;
+using namespace hw;
+
+namespace {
+struct ExternalizePass : public impl::ExternalizeBase<ExternalizePass> {
+  using ExternalizeBase<ExternalizePass>::ExternalizeBase;
+  void runOnOperation() override;
+};
+
+// A mapping between interface-published port names which are required to be
+// present in the provided external module, and the actual names that the
+// external module uses for said ports.
+using PortNameMap = llvm::DenseMap<mlir::StringAttr, mlir::StringAttr>;
+
+static LogicalResult parsePortNameMap(Location loc,
+                                      Pass::ListOption<std::string> &args,
+                                      PortNameMap &nameMap) {
+  std::string portId, portName;
+  auto *ctx = loc.getContext();
+  for (auto arg : args) {
+    auto argRef = llvm::StringRef(arg);
+    auto [id, name] = argRef.split('=');
+    if (name.empty())
+      return emitError(loc)
+             << "Error parsing port name mapping - '=' not found";
+
+    if (!nameMap
+             .try_emplace(StringAttr::get(ctx, id), StringAttr::get(ctx, name))
+             .second)
+      return emitError(loc) << "Duplicate entries of '" << id
+                            << "' in the provided port mapping";
+  }
+
+  return success();
+}
+} // anonymous namespace
+
+void ExternalizePass::runOnOperation() {
+  mlir::ModuleOp mod = getOperation();
+  auto *ctx = mod.getContext();
+  SymbolTable &symtbl = getAnalysis<SymbolTable>();
+
+  // Collect all target ops.
+  llvm::SmallVector<hw::ExternalizeableOpInterface> opsToReplace;
+  auto opNameAttr = StringAttr::get(ctx, opName);
+  auto res =
+      mod.walk([&](Operation *op) {
+        if (op->getName().getIdentifier() == opNameAttr) {
+          auto extIf = dyn_cast<hw::ExternalizeableOpInterface>(op);
+          if (!extIf) {
+            op->emitOpError()
+                << "Trying to run hw-externalizeable on operation '" << opName
+                << "' which does not implement the ExternalizeableOpInterface";
+            return WalkResult::interrupt();
+          }
+          opsToReplace.push_back(extIf);
+        }
+        return WalkResult::advance();
+      });
+
+  if (opsToReplace.empty()) {
+    markAllAnalysesPreserved();
+    return;
+  }
+
+  if (res.wasInterrupted())
+    return signalPassFailure();
+
+  // Parse and validate the user-provided port name list based on what's
+  // reported by the interface.
+  auto someOpHandle = opsToReplace.front();
+  llvm::SmallVector<hw::PortInfo> requiredPorts =
+      someOpHandle.getRequiredPorts();
+  PortNameMap providedPortNames;
+  if (failed(parsePortNameMap(mod.getLoc(), portNames, providedPortNames)))
+    return signalPassFailure();
+
+  for (auto &requiredPort : requiredPorts) {
+    auto it = providedPortNames.find(requiredPort.name);
+    if (it == providedPortNames.end()) {
+      mod.emitError() << "No port name mapping provided for required port "
+                      << requiredPort.name << " of the '" << opName
+                      << "' ExternalizeableOpInterface";
+      return signalPassFailure();
+    }
+
+    // Replace the port name with the user-provided mapping
+    requiredPort.name = it->second;
+  }
+
+  llvm::SmallVector<hw::PortInfo> optionalPorts =
+      someOpHandle.getOptionalPorts();
+  for (auto &optionalPort : optionalPorts) {
+    auto it = providedPortNames.find(optionalPort.name);
+    if (it == providedPortNames.end())
+      continue; // not provided.
+
+    // Replace the port name with the user-provided mapping and move it to
+    // the set of required ports.
+    optionalPort.name = it->second;
+    requiredPorts.push_back(optionalPort);
+  }
+
+  // All port names have been parsed.
+  auto builder = OpBuilder::atBlockBegin(getOperation().getBody());
+  auto moduleOp = builder.create<HWModuleExternOp>(
+      getOperation().getLoc(), builder.getStringAttr(moduleName), requiredPorts,
+      moduleName);
+  symtbl.insert(moduleOp);
+
+  // Fetch the port mapping of the module to allow the interface implementations
+  // a method of easily looking up the user-named ports.
+  hw::ModulePortLookupInfo modPortLookup = moduleOp.getPortLookupInfo();
+
+  // Replace all matched operations with an instance of the external module.
+  SmallVector<Value, 4> instPorts;
+  for (auto replOp : opsToReplace) {
+    ImplicitLocOpBuilder builder(replOp.getLoc(), replOp);
+    llvm::SmallVector<Value> instOperandMap, instResultMap;
+    replOp.doOperandAndResultMapping(builder, modPortLookup, providedPortNames,
+                                     instOperandMap, instResultMap);
+
+    auto instOp = builder.create<InstanceOp>(
+        moduleOp, builder.getStringAttr(instName), instOperandMap);
+    for (auto [opRes, instRes] : llvm::zip(instResultMap, instOp.getResults()))
+      opRes.replaceAllUsesWith(instRes);
+    replOp.erase();
+    ++numOperationsCnverted;
+  }
+}
+
+std::unique_ptr<Pass>
+circt::hw::createExternalizePass(const circt::hw::ExternalizeOptions &options) {
+  return std::make_unique<ExternalizePass>(options);
+}

--- a/test/Dialect/Seq/externalize-clock-gate.mlir
+++ b/test/Dialect/Seq/externalize-clock-gate.mlir
@@ -1,9 +1,11 @@
-// RUN: circt-opt %s --externalize-clock-gate --verify-diagnostics | FileCheck %s --check-prefixes=CHECK,CHECK-DEFAULT
-// RUN: circt-opt %s --externalize-clock-gate="name=SuchClock input=CI output=CO enable=EN test-enable=TEN instance-name=gated" --verify-diagnostics | FileCheck %s --check-prefixes=CHECK,CHECK-CUSTOM
+// RUN: circt-opt %s --externalize-clock-gate="name=SuchClock input=CI output=CO enable=EN test-enable=TEN instance-name=gated" --verify-diagnostics | FileCheck %s
 // RUN: circt-opt %s --externalize-clock-gate="name=VeryGate test-enable=" --verify-diagnostics | FileCheck %s --check-prefixes=CHECK,CHECK-WITHOUT-TESTENABLE
 
-// CHECK-DEFAULT: hw.module.extern @CKG(%I: i1, %E: i1, %TE: i1) -> (O: i1)
-// CHECK-CUSTOM: hw.module.extern @SuchClock(%CI: i1, %EN: i1, %TEN: i1) -> (CO: i1)
+// RUN: circt-opt --hw-externalize="op=seq.clock_gate module-name=SuchClock instance-name=gated port-names=input=CI,output=CO,enable=EN,test-enable=TEN" %s | FileCheck %s
+
+// RUN: circt-opt --hw-externalize="op=seq.clock_gate module-name=VeryGate instance-name=gated port-names=input=CI,output=CO,enable=EN" %s | FileCheck %s --check-prefix=WITHOUT-TESTENABLE
+
+// CHECK: hw.module.extern @SuchClock(%CI: i1, %EN: i1, %TEN: i1) -> (CO: i1)
 // CHECK-WITHOUT-TESTENABLE: hw.module.extern @VeryGate(%I: i1, %E: i1) -> (O: i1)
 
 // CHECK-LABEL: hw.module @Foo
@@ -12,11 +14,8 @@ hw.module @Foo(%clock: i1, %enable: i1, %test_enable: i1) {
   %cg0 = seq.clock_gate %clock, %enable
   %cg1 = seq.clock_gate %clock, %enable, %test_enable
 
-  // CHECK-DEFAULT: hw.instance "ckg" @CKG(I: %clock: i1, E: %enable: i1, TE: %false: i1) -> (O: i1)
-  // CHECK-DEFAULT: hw.instance "ckg" @CKG(I: %clock: i1, E: %enable: i1, TE: %test_enable: i1) -> (O: i1)
-
-  // CHECK-CUSTOM: hw.instance "gated" @SuchClock(CI: %clock: i1, EN: %enable: i1, TEN: %false: i1) -> (CO: i1)
-  // CHECK-CUSTOM: hw.instance "gated" @SuchClock(CI: %clock: i1, EN: %enable: i1, TEN: %test_enable: i1) -> (CO: i1)
+  // CHECK: hw.instance "gated" @SuchClock(CI: %clock: i1, EN: %enable: i1, TEN: %false: i1) -> (CO: i1)
+  // CHECK: hw.instance "gated" @SuchClock(CI: %clock: i1, EN: %enable: i1, TEN: %test_enable: i1) -> (CO: i1)
 
   // CHECK-WITHOUT-TESTENABLE: hw.instance "ckg" @VeryGate(I: %clock: i1, E: %enable: i1) -> (O: i1)
   // CHECK-WITHOUT-TESTENABLE: [[COMBINED_ENABLE:%.+]] = comb.or bin %enable, %test_enable : i1


### PR DESCRIPTION
## What is this
This is an attempt at adding a new interface to the HW dialect - the `ExternalizeableOpInterface`. Using this interface, an operation is able to interact with a new pass, named `hw-externalize` to replace itself with instances of a user-provided external module.

The interface requires an op to describe:
1. its set of required ports
2. its set of optional ports

This implies that:
1. it is the operation which dictates which ports it requires of its externalized module, by describing port identifiers and port types.
2. It is the user who decides the actual names of those ports by providing the mapping to the announced port identifiers.

the second part of the interface is then `doOperandAndResultMapping`, which, given the actual externalized module (that was realized by instantiating the module through the required and optional ports), is a method for the operation to instantiate the external module and do any shim logic to the operands and results of the instance.

We should be able to fairly easily extend this model to module parameters using an identical method as for ports. Didn't do that for now, since i'd like to land this first. However, given module parameters, i'd expect this interface/pass to then also be applicable to ops which may exist with many different in/out types in the IR (i.e. the FIFO op, which one probably wants to externalize to a parameterized SV module).

As an example, I implemented the interface for the `seq.clock_gate` op:

```mlir
hw.module @Foo(%clock: i1, %enable: i1, %test_enable: i1) {
  %cg0 = seq.clock_gate %clock, %enable
  %cg1 = seq.clock_gate %clock, %enable, %test_enable
}

// circt-opt --hw-externalize="op=seq.clock_gate module-name=SuchClock instance-name=gated port-names=input=CI,output=CO,enable=EN,test-enable=TEN" %s

hw.module.extern @SuchClock(%CI: i1, %EN: i1, %TEN: i1) -> (CO: i1) attributes {verilogName = "SuchClock"}
hw.module @Foo(%clock: i1, %enable: i1, %test_enable: i1) {
  %false = hw.constant false
  %gated.CO = hw.instance "gated" @SuchClock(CI: %clock: i1, EN: %enable: i1, TEN: %false: i1) -> (CO: i1)
  %gated.CO_0 = hw.instance "gated" @SuchClock(CI: %clock: i1, EN: %enable: i1, TEN: %test_enable: i1) -> (CO: i1)
  hw.output
}
```

## Is this the right approach?
Now, the next question is whether this is actually the right approach. What i like about this approach is that it's very straight forward to bring any external SV module as long as it provides matching ports for what's published by the operation. However, that might also be a big probem. As @teqdruid has pointed out in other discussions, externalizing an operation is a lowering, and as such, lowering logic shouldn't be embedded (re. dictated) by an operation.  The canonical example here would be that e.g. there's an operation A in CIRCT, you have your own module modA that implements the semantics of A, but it has a different interface than what op A publishes, meaning that there is a way to externalize A to modA given adequate shim logic is inserted - shim logic, which is dictated by modA and not operation A. The current model allows for shim logic insertion, but it's the operation that inserts shim logic based on the provided module, which, given that it is opA that dictates the interface of the externalized module, really isn't that powerful a capability. 

A counterargument to that could then be, that, you could implement said shim-logic manually in SV, such that it adheres to the published interface of A.

let me know what you think!