### PR TITLE
[HW] Allow default builders for hw.wire.

### DIFF
--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -93,7 +93,6 @@ def WireOp : HWOp<"wire", [
 
   let hasFolder = true;
   let hasCanonicalizeMethod = 1;
-  let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "mlir::Value":$input,
                    CArg<"const StringAttrOrRef &", "{}">:$name,


### PR DESCRIPTION
This allows the generated Python bindings to generate a useful constructor, which is impossible otherwise.