### PR TITLE
[CombFolds] Optimize OrOp whose operands are mux of the same value and a zero.

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1180,6 +1180,31 @@ LogicalResult OrOp::canonicalize(OrOp op, PatternRewriter &rewriter) {
     return success();
   }
 
+  // or(mux(c_1, a, 0), mux(c_2, a, 0), ..., mux(c_n, a, 0)) -> mux(or(c_1, c_2,
+  // .., c_n), a, 0)
+  if (auto firstMux = op.getOperand(0).getDefiningOp<comb::MuxOp>()) {
+    APInt value;
+    SmallVector<Value> conditions;
+    auto check = [&](Value v) {
+      auto mux = v.getDefiningOp<comb::MuxOp>();
+      if (!mux)
+        return false;
+      conditions.push_back(mux.getCond());
+      return firstMux.getTwoState() &&
+             firstMux.getTrueValue() == mux.getTrueValue() &&
+             matchPattern(mux.getFalseValue(), m_ConstantInt(&value)) &&
+             value.isZero();
+    };
+
+    if (op.getTwoState() && llvm::all_of(op.getOperands(), check)) {
+      auto cond = rewriter.create<comb::OrOp>(op.getLoc(), conditions, true);
+      replaceOpWithNewOpAndCopyName<comb::MuxOp>(
+          rewriter, op, cond, firstMux.getTrueValue(), firstMux.getFalseValue(),
+          true);
+      return success();
+    }
+  }
+
   /// TODO: or(..., x, not(x)) -> or(..., '1) -- complement
   return failure();
 }

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -1184,24 +1184,26 @@ LogicalResult OrOp::canonicalize(OrOp op, PatternRewriter &rewriter) {
   // .., c_n), a, 0)
   if (auto firstMux = op.getOperand(0).getDefiningOp<comb::MuxOp>()) {
     APInt value;
-    SmallVector<Value> conditions;
-    auto check = [&](Value v) {
-      auto mux = v.getDefiningOp<comb::MuxOp>();
-      if (!mux)
-        return false;
-      conditions.push_back(mux.getCond());
-      return firstMux.getTwoState() &&
-             firstMux.getTrueValue() == mux.getTrueValue() &&
-             matchPattern(mux.getFalseValue(), m_ConstantInt(&value)) &&
-             value.isZero();
-    };
-
-    if (op.getTwoState() && llvm::all_of(op.getOperands(), check)) {
-      auto cond = rewriter.create<comb::OrOp>(op.getLoc(), conditions, true);
-      replaceOpWithNewOpAndCopyName<comb::MuxOp>(
-          rewriter, op, cond, firstMux.getTrueValue(), firstMux.getFalseValue(),
-          true);
-      return success();
+    if (op.getTwoState() && firstMux.getTwoState() &&
+        matchPattern(firstMux.getFalseValue(), m_ConstantInt(&value)) &&
+        value.isZero()) {
+      SmallVector<Value> conditions{firstMux.getCond()};
+      auto check = [&](Value v) {
+        auto mux = v.getDefiningOp<comb::MuxOp>();
+        if (!mux)
+          return false;
+        conditions.push_back(mux.getCond());
+        return mux.getTwoState() &&
+               firstMux.getTrueValue() == mux.getTrueValue() &&
+               firstMux.getFalseValue() == mux.getFalseValue();
+      };
+      if (llvm::all_of(op.getOperands().drop_front(), check)) {
+        auto cond = rewriter.create<comb::OrOp>(op.getLoc(), conditions, true);
+        replaceOpWithNewOpAndCopyName<comb::MuxOp>(
+            rewriter, op, cond, firstMux.getTrueValue(),
+            firstMux.getFalseValue(), true);
+        return success();
+      }
     }
   }
 

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -1517,3 +1517,18 @@ hw.module @Issue5531(%arg0: i64, %arg1: i64) -> (out: i32) {
   %3 = comb.extract %2 from 0 : (i64) -> i32
   hw.output %3 : i32
 }
+
+// or(mux(c_1, a, 0), mux(c_2, a, 0), ..., mux(c_n, a, 0)) -> mux(or(c_1, c_2, .., c_n), a, 0)
+// CHECK-LABEL: OrMuxSameTrueValueAndZero
+// CHECK:      %[[OR:.+]] = comb.or bin %tag_0, %tag_1, %tag_2, %tag_3 : i1
+// CHECK-NEXT: %[[RESULT:.+]] = comb.mux bin %[[OR]], %in, %c0_i4 : i4
+// CHECK-NEXT: hw.output %[[RESULT]]
+hw.module @OrMuxSameTrueValueAndZero(%tag_0: i1, %tag_1: i1, %tag_2: i1, %tag_3: i1, %in: i4) -> (out: i4) {
+  %c0_i4 = hw.constant 0 : i4
+  %0 = comb.mux bin %tag_0, %in, %c0_i4 : i4
+  %1 = comb.mux bin %tag_1, %in, %c0_i4 : i4
+  %2 = comb.mux bin %tag_2, %in, %c0_i4 : i4
+  %3 = comb.mux bin %tag_3, %in, %c0_i4 : i4
+  %4 = comb.or bin %0, %1, %2, %3 : i4
+  hw.output %4 : i4
+}


### PR DESCRIPTION
This implements a canonicalizer 
`or(mux(c_1, a, 0), mux(c_2, a, 0), ..., mux(c_n, a, 0)) -> mux(or(c_1, c_2, .., c_n), a, 0)`