### PR TITLE
[LowerXMR] iterate to handle ref.sub .

### DIFF
--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -984,3 +984,32 @@ firrtl.circuit "RWProbePort" {
   }
 }
 
+// -----
+// Test resolving through output ports through points that aren't handled by unification.
+// (ref.sub).
+
+// CHECK-LABEL: circuit "RefSubOutputPort"
+firrtl.circuit "RefSubOutputPort" {
+  // CHECK: hw.hierpath private @[[XMRPATH:.+]] [@RefSubOutputPort::@[[CHILD_SYM:.+]], @Child::@[[WIRE_SYM:.+]]]
+  // CHECK: sv.macro.def @ref_RefSubOutputPort_RefSubOutputPort_outElem
+  // CHECK-SAME{LITERAL}: "{{0}}.x[1]"
+  // CHECK-SAME: ([@[[XMRPATH]]]) {output_file = #hw.output_file<"ref_RefSubOutputPort_RefSubOutputPort.sv">}
+
+  // CHECK: module private @Child
+  // CHECK-NEXT: firrtl.wire sym @[[WIRE_SYM]] forceable
+  firrtl.module private @Child(out %bore_1: !firrtl.rwprobe<bundle<x: vector<uint<1>, 2>>>) {
+    %b, %b_ref = firrtl.wire forceable : !firrtl.bundle<x: vector<uint<1>, 2>>, !firrtl.rwprobe<bundle<x: vector<uint<1>, 2>>>
+    firrtl.ref.define %bore_1, %b_ref : !firrtl.rwprobe<bundle<x: vector<uint<1>, 2>>>
+  }
+  // CHECK: module @RefSubOutputPort
+  firrtl.module @RefSubOutputPort(out %outRWBundleProbe: !firrtl.rwprobe<bundle<x: vector<uint<1>, 2>>>,
+                                  out %outElem: !firrtl.rwprobe<uint<1>>) attributes {convention = #firrtl<convention scalarized>} {
+    %0 = firrtl.ref.sub %outRWBundleProbe[0] : !firrtl.rwprobe<bundle<x: vector<uint<1>, 2>>>
+    %1 = firrtl.ref.sub %0[1] : !firrtl.rwprobe<vector<uint<1>, 2>>
+    // CHECK-NEXT: instance child sym @[[CHILD_SYM]] @Child
+    // CHECK-NEXT: }
+    %child_bore_1 = firrtl.instance child @Child(out bore_1: !firrtl.rwprobe<bundle<x: vector<uint<1>, 2>>>)
+    firrtl.ref.define %outRWBundleProbe, %child_bore_1 : !firrtl.rwprobe<bundle<x: vector<uint<1>, 2>>>
+    firrtl.ref.define %outElem, %1 : !firrtl.rwprobe<uint<1>>
+  }
+}

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -1003,13 +1003,18 @@ firrtl.circuit "RefSubOutputPort" {
   }
   // CHECK: module @RefSubOutputPort
   firrtl.module @RefSubOutputPort(out %outRWBundleProbe: !firrtl.rwprobe<bundle<x: vector<uint<1>, 2>>>,
-                                  out %outElem: !firrtl.rwprobe<uint<1>>) attributes {convention = #firrtl<convention scalarized>} {
-    %0 = firrtl.ref.sub %outRWBundleProbe[0] : !firrtl.rwprobe<bundle<x: vector<uint<1>, 2>>>
-    %1 = firrtl.ref.sub %0[1] : !firrtl.rwprobe<vector<uint<1>, 2>>
+                                  out %outVec: !firrtl.rwprobe<vector<uint<1>, 2>>,
+                                  out %outElem: !firrtl.rwprobe<uint<1>>,
+                                  out %outElemDirect: !firrtl.rwprobe<uint<1>>) attributes {convention = #firrtl<convention scalarized>} {
+    %0 = firrtl.ref.sub %outVec[1] : !firrtl.rwprobe<vector<uint<1>, 2>>
+    %1 = firrtl.ref.sub %outRWBundleProbe[0] : !firrtl.rwprobe<bundle<x: vector<uint<1>, 2>>>
+    %2 = firrtl.ref.sub %1[1] : !firrtl.rwprobe<vector<uint<1>, 2>>
     // CHECK-NEXT: instance child sym @[[CHILD_SYM]] @Child
     // CHECK-NEXT: }
     %child_bore_1 = firrtl.instance child @Child(out bore_1: !firrtl.rwprobe<bundle<x: vector<uint<1>, 2>>>)
     firrtl.ref.define %outRWBundleProbe, %child_bore_1 : !firrtl.rwprobe<bundle<x: vector<uint<1>, 2>>>
-    firrtl.ref.define %outElem, %1 : !firrtl.rwprobe<uint<1>>
+    firrtl.ref.define %outElemDirect, %2 : !firrtl.rwprobe<uint<1>>
+    firrtl.ref.define %outVec, %1 : !firrtl.rwprobe<vector<uint<1>, 2>>
+    firrtl.ref.define %outElem, %0 : !firrtl.rwprobe<uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -991,7 +991,13 @@ firrtl.circuit "RWProbePort" {
 // CHECK-LABEL: circuit "RefSubOutputPort"
 firrtl.circuit "RefSubOutputPort" {
   // CHECK: hw.hierpath private @[[XMRPATH:.+]] [@RefSubOutputPort::@[[CHILD_SYM:.+]], @Child::@[[WIRE_SYM:.+]]]
+  // CHECK: sv.macro.def @ref_RefSubOutputPort_RefSubOutputPort_outVec
+  // CHECK-SAME{LITERAL}: "{{0}}.x"
+  // CHECK-SAME: ([@[[XMRPATH]]]) {output_file = #hw.output_file<"ref_RefSubOutputPort_RefSubOutputPort.sv">}
   // CHECK: sv.macro.def @ref_RefSubOutputPort_RefSubOutputPort_outElem
+  // CHECK-SAME{LITERAL}: "{{0}}.x[1]"
+  // CHECK-SAME: ([@[[XMRPATH]]]) {output_file = #hw.output_file<"ref_RefSubOutputPort_RefSubOutputPort.sv">}
+  // CHECK: sv.macro.def @ref_RefSubOutputPort_RefSubOutputPort_outElemDirect
   // CHECK-SAME{LITERAL}: "{{0}}.x[1]"
   // CHECK-SAME: ([@[[XMRPATH]]]) {output_file = #hw.output_file<"ref_RefSubOutputPort_RefSubOutputPort.sv">}
 


### PR DESCRIPTION
Continue to handle everything else in a single walk.

Walking the ref dataflow directly would eliminate the need for this iteration, but finding the "roots" requires an IR walk anyway so just handle everything we can during a single walk and for any ref.sub's encountered handle them separately.

The outer iteration loop is bounded by the number of ref.sub's chained through `backedges` to storage (`ref.define` to storage (ports/instance results)), which is expected to be very small in practice, at worst O(ports).