### PR TITLE
[Calyx][ESI[FIRRTL][SV] Use getAnalysis for SymbolTable and others.

### DIFF
--- a/lib/Dialect/Calyx/Transforms/CompileControl.cpp
+++ b/lib/Dialect/Calyx/Transforms/CompileControl.cpp
@@ -34,6 +34,7 @@ static size_t getNecessaryBitWidth(size_t numStates) {
 
 class CompileControlVisitor {
 public:
+  CompileControlVisitor(AnalysisManager am) : am(am){};
   void dispatch(Operation *op, ComponentOp component) {
     TypeSwitch<Operation *>(op)
         .template Case<SeqOp, EnableOp>(
@@ -49,6 +50,8 @@ private:
   void visit(EnableOp, ComponentOp &) {
     // nothing to do
   }
+
+  AnalysisManager am;
 };
 
 /// Generates a latency-insensitive FSM to realize a sequential operation.
@@ -88,7 +91,7 @@ void CompileControlVisitor::visit(SeqOp seq, ComponentOp &component) {
       builder.create<GroupOp>(wires->getLoc(), builder.getStringAttr("seq"));
 
   // Guarantees a unique SymbolName for the group.
-  SymbolTable symTable(wires);
+  auto &symTable = am.getChildAnalysis<SymbolTable>(wires);
   symTable.insert(seqGroup);
 
   size_t fsmIndex = 0;
@@ -184,7 +187,7 @@ struct CompileControlPass : public CompileControlBase<CompileControlPass> {
 
 void CompileControlPass::runOnOperation() {
   ComponentOp component = getOperation();
-  CompileControlVisitor CompileControlVisitor;
+  CompileControlVisitor CompileControlVisitor(getAnalysisManager());
   component.getControlOp().walk(
       [&](Operation *op) { CompileControlVisitor.dispatch(op, component); });
 

--- a/lib/Dialect/Calyx/Transforms/CompileControl.cpp
+++ b/lib/Dialect/Calyx/Transforms/CompileControl.cpp
@@ -187,9 +187,9 @@ struct CompileControlPass : public CompileControlBase<CompileControlPass> {
 
 void CompileControlPass::runOnOperation() {
   ComponentOp component = getOperation();
-  CompileControlVisitor CompileControlVisitor(getAnalysisManager());
+  CompileControlVisitor compileControlVisitor(getAnalysisManager());
   component.getControlOp().walk(
-      [&](Operation *op) { CompileControlVisitor.dispatch(op, component); });
+      [&](Operation *op) { compileControlVisitor.dispatch(op, component); });
 
   // A post-condition of this pass is that all undefined GroupGoOps, created
   // in the Go Insertion pass, are now defined.

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -339,7 +339,7 @@ static ServiceDeclOpInterface getServiceDecl(Operation *op,
                                              SymbolTableCollection &symbolTable,
                                              hw::InnerRefAttr servicePort) {
   ModuleOp top = op->getParentOfType<mlir::ModuleOp>();
-  SymbolTable topSyms = symbolTable.getSymbolTable(top);
+  SymbolTable &topSyms = symbolTable.getSymbolTable(top);
 
   StringAttr modName = servicePort.getModule();
   return topSyms.lookup<ServiceDeclOpInterface>(modName);
@@ -454,10 +454,10 @@ void CustomServiceDeclOp::getPortList(SmallVectorImpl<ServicePortInfo> &ports) {
 LogicalResult ServiceHierarchyMetadataOp::verifySymbolUses(
     SymbolTableCollection &symbolTable) {
   ModuleOp top = getOperation()->getParentOfType<mlir::ModuleOp>();
-  SymbolTable topSyms = symbolTable.getSymbolTable(top);
   auto sym = getServiceSymbol();
   if (!sym)
     return success();
+  SymbolTable &topSyms = symbolTable.getSymbolTable(top);
   auto serviceDeclOp = topSyms.lookup<ServiceDeclOpInterface>(*sym);
   if (!serviceDeclOp)
     return emitOpError("Could not find service declaration ") << *sym;

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1312,7 +1312,7 @@ class DedupPass : public DedupBase<DedupPass> {
     auto circuit = getOperation();
     auto &instanceGraph = getAnalysis<InstanceGraph>();
     auto *nlaTable = &getAnalysis<NLATable>();
-    SymbolTable symbolTable(circuit);
+    auto &symbolTable = getAnalysis<SymbolTable>();
     Deduper deduper(instanceGraph, symbolTable, nlaTable, circuit);
     Equivalence equiv(context, instanceGraph);
     auto anythingChanged = false;

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -698,14 +698,14 @@ private:
 
   /// A symbol table associated with the circuit.  This is lazily constructed by
   /// `getSymbolTable`.
-  std::optional<SymbolTable> symbolTable;
+  std::optional<SymbolTable *> symbolTable;
 
   /// Return a reference to a circuit-level symbol table.  Lazily construct one
   /// if such a symbol table does not already exist.
   SymbolTable &getSymbolTable() {
     if (!symbolTable)
-      symbolTable = SymbolTable(getOperation());
-    return *symbolTable;
+      symbolTable = &getAnalysis<SymbolTable>();
+    return **symbolTable;
   }
 
   // Utility that acts like emitOpError, but does _not_ include a note.  The

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -2284,8 +2284,7 @@ class InferWidthsPass : public InferWidthsBase<InferWidthsPass> {
 void InferWidthsPass::runOnOperation() {
   // Collect variables and constraints
   ConstraintSolver solver;
-  SymbolTable symtbl(getOperation());
-  InferenceMapping mapping(solver, symtbl);
+  InferenceMapping mapping(solver, getAnalysis<SymbolTable>());
   if (failed(mapping.map(getOperation()))) {
     signalPassFailure();
     return;

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1589,7 +1589,7 @@ void LowerTypesPass::runOnOperation() {
                       "------------------------------------------------===\n");
   std::vector<FModuleLike> ops;
   // Symbol Table
-  SymbolTable symTbl(getOperation());
+  auto &symTbl = getAnalysis<SymbolTable>();
   // Cached attr
   AttrCache cache(&getContext());
 

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -504,7 +504,7 @@ namespace {
 class Inliner {
 public:
   /// Initialize the inliner to run on this circuit.
-  Inliner(CircuitOp circuit);
+  Inliner(CircuitOp circuit, SymbolTable &symbolTable);
 
   /// Run the inliner.
   void run();
@@ -601,7 +601,7 @@ private:
   MLIRContext *context;
 
   // A symbol table with references to each module in a circuit.
-  SymbolTable symbolTable;
+  SymbolTable &symbolTable;
 
   /// The set of live modules.  Anything not recorded in this set will be
   /// removed by dead code elimination.
@@ -1296,8 +1296,9 @@ void Inliner::identifyNLAsTargetingOnlyModules() {
   }
 }
 
-Inliner::Inliner(CircuitOp circuit)
-    : circuit(circuit), context(circuit.getContext()), symbolTable(circuit) {}
+Inliner::Inliner(CircuitOp circuit, SymbolTable &symbolTable)
+    : circuit(circuit), context(circuit.getContext()),
+      symbolTable(symbolTable) {}
 
 void Inliner::run() {
   CircuitNamespace circuitNamespace(circuit);
@@ -1456,7 +1457,7 @@ class InlinerPass : public InlinerBase<InlinerPass> {
     LLVM_DEBUG(llvm::dbgs()
                << "===- Running Module Inliner Pass "
                   "--------------------------------------------===\n");
-    Inliner inliner(getOperation());
+    Inliner inliner(getOperation(), getAnalysis<SymbolTable>());
     inliner.run();
     LLVM_DEBUG(llvm::dbgs() << "===--------------------------------------------"
                                "------------------------------===\n");

--- a/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
+++ b/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
@@ -108,7 +108,7 @@ void HWExportModuleHierarchyPass::extractHierarchyFromTop(
 /// and if they exist, emit a verbatim op with the module hierarchy for each.
 void HWExportModuleHierarchyPass::runOnOperation() {
   mlir::ModuleOp mlirModule = getOperation();
-  std::optional<SymbolTable> symbolTable;
+  std::optional<SymbolTable *> symbolTable;
 
   for (auto op : mlirModule.getOps<hw::HWModuleOp>()) {
     auto attr = op->getAttrOfType<ArrayAttr>("firrtl.moduleHierarchyFile");
@@ -116,13 +116,13 @@ void HWExportModuleHierarchyPass::runOnOperation() {
       continue;
     for (auto file : attr.getAsRange<hw::OutputFileAttr>()) {
       if (!symbolTable)
-        symbolTable = SymbolTable(mlirModule);
+        symbolTable = &getAnalysis<SymbolTable>();
 
       std::string jsonBuffer;
       llvm::raw_string_ostream os(jsonBuffer);
       SmallVector<Attribute> symbols;
 
-      extractHierarchyFromTop(op, *symbolTable, os, symbols);
+      extractHierarchyFromTop(op, **symbolTable, os, symbols);
 
       auto builder = ImplicitLocOpBuilder::atBlockEnd(
           UnknownLoc::get(mlirModule.getContext()), mlirModule.getBody());

--- a/lib/Dialect/SV/Transforms/SVTraceIVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/SVTraceIVerilog.cpp
@@ -40,7 +40,7 @@ void SVTraceIVerilogPass::runOnOperation() {
   mlir::ModuleOp mod = getOperation();
 
   if (topOnly) {
-    auto graph = InstanceGraph(mod);
+    auto &graph = getAnalysis<InstanceGraph>();
     auto topLevelNodes = graph.getInferredTopLevelNodes();
     if (failed(topLevelNodes) || topLevelNodes->size() != 1) {
       mod.emitError("Expected exactly one top level node");


### PR DESCRIPTION
Let AnalysisManager provide cached copy if available,
and be open to it being preserved across passes.

Also unnecessary copying of SymbolTable (DenseMap).