### PR TITLE
[FIRRTL][FIRParser] Gate properties on 3.1.0+.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -957,10 +957,18 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
   }
 
   case FIRToken::kw_String:
+    if (FIRVersion::compare(version, FIRVersion({3, 1, 0})) < 0)
+      return emitError() << "unexpected token: Properties are a FIRRTL 3.1.0+ "
+                            "feature, but the specified FIRRTL version was "
+                         << version;
     consumeToken(FIRToken::kw_String);
     result = StringType::get(getContext());
     break;
   case FIRToken::kw_Integer:
+    if (FIRVersion::compare(version, FIRVersion({3, 1, 0})) < 0)
+      return emitError() << "unexpected token: Integers are a FIRRTL 3.1.0+ "
+                            "feature, but the specified FIRRTL version was "
+                         << version;
     consumeToken(FIRToken::kw_Integer);
     result = BigIntType::get(getContext());
     break;
@@ -1710,6 +1718,10 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
       return failure();
     break;
   case FIRToken::kw_String: {
+    if (FIRVersion::compare(version, FIRVersion({3, 1, 0})) < 0)
+      return emitError() << "unexpected token: Properties are a FIRRTL 3.1.0+ "
+                            "feature, but the specified FIRRTL version was "
+                         << version;
     locationProcessor.setLoc(getToken().getLoc());
     consumeToken(FIRToken::kw_String);
     StringRef spelling;
@@ -1724,6 +1736,11 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
     break;
   }
   case FIRToken::kw_Integer: {
+    if (FIRVersion::compare(version, FIRVersion({3, 1, 0})) < 0)
+      return emitError() << "unexpected token: Integers are a FIRRTL 3.1.0+ "
+                            "feature, but the specified FIRRTL version was "
+                         << version;
+
     locationProcessor.setLoc(getToken().getLoc());
     consumeToken(FIRToken::kw_Integer);
     APInt value;
@@ -2274,6 +2291,10 @@ ParseResult FIRStmtParser::parseSimpleStmtImpl(unsigned stmtIndent) {
   case FIRToken::kw_connect:
     return parseConnect();
   case FIRToken::kw_propassign:
+    if (FIRVersion::compare(version, FIRVersion({3, 1, 0})) < 0)
+      return emitError() << "unexpected token: Properties are a FIRRTL 3.1.0+ "
+                            "feature, but the specified FIRRTL version was "
+                         << version;
     return parsePropAssign();
   case FIRToken::kw_invalidate:
     return parseInvalidate();

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1170,22 +1170,6 @@ circuit EnumTypes:
       ; CHECK: }
       None:
         o is invalid
-  ; CHECK-LABEL: module private @String
-
-  module String :
-    ; CHECK-SAME: out %a: !firrtl.string
-    output a : String
-    ; CHECK: %0 = firrtl.string "hello"
-    ; CHECK: firrtl.propassign %a, %0 : !firrtl.string
-    propassign a, String("hello")
-
-  ; CHECK-LABEL: module private @Integer
-  module Integer :
-    ; CHECK-SAME: out %a: !firrtl.bigint
-    output a : Integer
-    ; CHECK: %0 = firrtl.bigint -10
-    ; CHECK: firrtl.propassign %a, %0 : !firrtl.bigint
-    propassign a, Integer(-10)
 
   ; CHECK-LABEL: module private @RefsChild(
   ; CHECK-SAME: out %r: !firrtl.probe<uint<1>>
@@ -1410,6 +1394,10 @@ circuit EnumTypes:
     ; CHECK-NEXT: [[CAST:%.+]] = firrtl.constCast %s4 : (!firrtl.const.sint<4>) -> !firrtl.sint<4>
     ; CHECK-NEXT: firrtl.strictconnect %nonconst_w, [[CAST]] : !firrtl.sint<4>
     nonconst_w <= s4
+
+  ; CHECK-LABEL firrtl.class @SimpleClass() { }
+  ; Not version-gated yet, not in spec.
+  class SimpleClass:
 
 ;// -----
 
@@ -1671,10 +1659,32 @@ circuit Groups:
     ; CHECK-NEXT:   }
     ; CHECK-NEXT: }
 
-; CHECK-LABEL firrtl.class @SimpleClass(in %a: !firrtl.string, out %b: !firrtl.string) {
-; CHECK-NEXT    firrtl.propassign %b, %a : !firrtl.string
-; CHECK-NEXT  }
-class SimpleClass:
-  input a: String
-  output b: String
-  propassign b, a
+
+;// -----
+; CHECK-LABEL: firrtl.circuit "BasicProps"
+FIRRTL version 3.1.0
+circuit BasicProps :
+  module BasicProps :
+  ; CHECK-LABEL: module private @Integer
+  module Integer :
+    ; CHECK-SAME: out %a: !firrtl.bigint
+    output a : Integer
+    ; CHECK: %0 = firrtl.bigint -10
+    ; CHECK: firrtl.propassign %a, %0 : !firrtl.bigint
+    propassign a, Integer(-10)
+
+  ; CHECK-LABEL: module private @String
+  module String :
+    ; CHECK-SAME: out %a: !firrtl.string
+    output a : String
+    ; CHECK: %0 = firrtl.string "hello"
+    ; CHECK: firrtl.propassign %a, %0 : !firrtl.string
+    propassign a, String("hello")
+
+  ; CHECK-LABEL firrtl.class @SimpleClass(in %a: !firrtl.string, out %b: !firrtl.string) {
+  ; CHECK-NEXT    firrtl.propassign %b, %a : !firrtl.string
+  ; CHECK-NEXT  }
+  class SimpleClass:
+    input a: String
+    output b: String
+    propassign b, a

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -705,6 +705,7 @@ circuit DefinePromoteToRW:
     define rw = r.ro
 
 ;// -----
+FIRRTL version 3.1.0
 
 circuit PropAssignNonProperty:
   module PropAssignNonProperty:
@@ -781,6 +782,7 @@ circuit DuplicateAlias:
 
 ;// -----
 ; https://github.com/llvm/circt/issues/5494
+FIRRTL version 3.1.0
 
 circuit BundleOfProps:
   module BundleOfProps:
@@ -788,6 +790,7 @@ circuit BundleOfProps:
     ; expected-error @above {{type '!firrtl.string' cannot be used as field in a bundle}}
 
 ;// -----
+FIRRTL version 3.1.0
 
 circuit VecOfProps:
   module VecOfProps:
@@ -839,3 +842,21 @@ circuit Top:
   class Foo:
     ;; expected-error @below {{ports on classes must be properties}}
     input a: UInt<8>
+
+;// -----
+FIRRTL version 3.0.0
+
+circuit Top:
+  module Top:
+    output s : String
+    ; expected-error @above {{Properties are a FIRRTL 3.1.0+ feature, but the specified FIRRTL version was 3.0.0}}
+
+;// -----
+FIRRTL version 3.0.0
+
+circuit Top:
+  module Top:
+    ; expected-error @below {{Integers are a FIRRTL 3.1.0+ feature, but the specified FIRRTL version was 3.0.0}}
+    input in : Integer
+    output out : Integer
+    propassign out, in


### PR DESCRIPTION
Gate 3.1.0 features on that version, pull `String` as well since it doesn't make a lot of sense to leave behind w/o PropAssign.

"class" is kept ungated.