### PR TITLE
[FirParser][Typealias] Reject keyword as type alias name

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4384,6 +4384,14 @@ ParseResult FIRCircuitParser::parseTypeDecl() {
   FIRRTLType type;
   consumeToken();
   auto loc = getToken().getLoc();
+
+  if (getToken().isKeyword())
+    // The parseId will always succeed. Its required for parsing the name to
+    // print with error message.
+    if (parseId(id, "expected type name").succeeded())
+      return emitError(loc)
+             << "cannot use keyword '" << id << "' for type alias name";
+
   if (parseId(id, "expected type name") ||
       parseToken(FIRToken::equal, "expected '=' in type decl") ||
       parseType(type, "expected a type"))

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4386,11 +4386,8 @@ ParseResult FIRCircuitParser::parseTypeDecl() {
   auto loc = getToken().getLoc();
 
   if (getToken().isKeyword())
-    // The parseId will always succeed. Its required for parsing the name to
-    // print with error message.
-    if (parseId(id, "expected type name").succeeded())
-      return emitError(loc)
-             << "cannot use keyword '" << id << "' for type alias name";
+    return emitError(loc) << "cannot use keyword '" << getToken().getSpelling()
+                          << "' for type alias name";
 
   if (parseId(id, "expected type name") ||
       parseToken(FIRToken::equal, "expected '=' in type decl") ||

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -780,6 +780,16 @@ circuit DuplicateAlias:
   module DuplicateAlias:
 
 ;// -----
+
+circuit KeywordTypeName:
+  type Clock = UInt; expected-error {{cannot use keyword 'Clock' for type alias name}}
+
+;// -----
+
+circuit KeywordTypeName:
+  type module = UInt; expected-error {{cannot use keyword 'module' for type alias name}}
+
+;// -----
 ; https://github.com/llvm/circt/issues/5494
 
 circuit BundleOfProps:


### PR DESCRIPTION
Keywords cannot be used for type alias name. Reject them during parsing.
In practice, only built-in types are a problem if used as type alias name, but it seems reasonable to reject any firrtl keyword.
For example, this must be rejected.
```
circuit Top:
  type Clock = UInt<32>

  module Top:
    input in : Clock
```