### PR TITLE
[HW][InnerSym] Use uint64_t for method names involving FieldID.

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -176,7 +176,7 @@ def InnerSymAttr : AttrDef<HWDialect, "InnerSym"> {
   ];
   let extraClassDeclaration = [{
     /// Get the inner sym name for fieldID, if it exists.
-    mlir::StringAttr getSymIfExists(unsigned fieldID) const;
+    mlir::StringAttr getSymIfExists(uint64_t fieldID) const;
 
     /// Get the inner sym name for fieldID=0, if it exists.
     mlir::StringAttr getSymName() const { return getSymIfExists(0); }
@@ -188,7 +188,7 @@ def InnerSymAttr : AttrDef<HWDialect, "InnerSym"> {
     bool empty() const { return getProps().empty(); }
 
     /// Return an InnerSymAttr with the inner symbol for the specified fieldID removed.
-    InnerSymAttr erase(unsigned fieldID) const;
+    InnerSymAttr erase(uint64_t fieldID) const;
 
     using iterator = mlir::ArrayRef<InnerSymPropertiesAttr>::iterator;
     /// Iterator begin for all the InnerSymProperties.

--- a/lib/Dialect/HW/HWAttributes.cpp
+++ b/lib/Dialect/HW/HWAttributes.cpp
@@ -265,7 +265,7 @@ void InnerSymPropertiesAttr::print(AsmPrinter &odsPrinter) const {
              << getSymVisibility().getValue() << ">";
 }
 
-StringAttr InnerSymAttr::getSymIfExists(unsigned fieldId) const {
+StringAttr InnerSymAttr::getSymIfExists(uint64_t fieldId) const {
   const auto *it =
       llvm::find_if(getImpl()->props, [&](const InnerSymPropertiesAttr &p) {
         return p.getFieldID() == fieldId;
@@ -275,7 +275,7 @@ StringAttr InnerSymAttr::getSymIfExists(unsigned fieldId) const {
   return {};
 }
 
-InnerSymAttr InnerSymAttr::erase(unsigned fieldID) const {
+InnerSymAttr InnerSymAttr::erase(uint64_t fieldID) const {
   SmallVector<InnerSymPropertiesAttr> syms(getProps());
   const auto *it = llvm::find_if(syms, [fieldID](InnerSymPropertiesAttr p) {
     return p.getFieldID() == fieldID;


### PR DESCRIPTION
Until standardize on a dedicated type, fix this.