### PR TITLE
[FIREmitter] support property types and expressions

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -59,7 +59,9 @@ public:
             RefResolveOp, RefSubOp,
             // Casts to deal with weird stuff
             UninferredResetCastOp, ConstCastOp, RefCastOp,
-            mlir::UnrealizedConversionCastOp>([&](auto expr) -> ResultType {
+            mlir::UnrealizedConversionCastOp,
+            // Property expressions.
+            BigIntConstantOp>([&](auto expr) -> ResultType {
           return thisCast->visitExpr(expr, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -193,6 +195,9 @@ public:
   HANDLE(mlir::UnrealizedConversionCastOp, Unhandled);
   HANDLE(BitCastOp, Unhandled);
   HANDLE(RefCastOp, Unhandled);
+
+  // Property expressions.
+  HANDLE(BigIntConstantOp, Unhandled);
 #undef HANDLE
 };
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -61,7 +61,7 @@ public:
             UninferredResetCastOp, ConstCastOp, RefCastOp,
             mlir::UnrealizedConversionCastOp,
             // Property expressions.
-            BigIntConstantOp>([&](auto expr) -> ResultType {
+            StringConstantOp, BigIntConstantOp>([&](auto expr) -> ResultType {
           return thisCast->visitExpr(expr, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -197,6 +197,7 @@ public:
   HANDLE(RefCastOp, Unhandled);
 
   // Property expressions.
+  HANDLE(StringConstantOp, Unhandled);
   HANDLE(BigIntConstantOp, Unhandled);
 #undef HANDLE
 };

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -1228,6 +1228,7 @@ void Emitter::emitType(Type type, bool includeConst) {
         emitType(type.getType());
         ps << ">";
       })
+      .Case<StringType>([&](StringType type) { ps << "String"; })
       .Case<BigIntType>([&](BigIntType type) { ps << "Integer"; })
       .Case<PathType>([&](PathType type) { ps << "Path"; })
       .Default([&](auto type) {

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -109,6 +109,7 @@ struct Emitter {
   void emitExpression(RefSubOp op);
   void emitExpression(UninferredResetCastOp op);
   void emitExpression(ConstCastOp op);
+  void emitExpression(StringConstantOp op);
   void emitExpression(BigIntConstantOp op);
 
   void emitPrimExpr(StringRef mnemonic, Operation *op,
@@ -1010,7 +1011,8 @@ void Emitter::emitExpression(Value value) {
           CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp, XorRPrimOp,
           // Miscellaneous
           BitsPrimOp, HeadPrimOp, TailPrimOp, PadPrimOp, MuxPrimOp, ShlPrimOp,
-          ShrPrimOp, UninferredResetCastOp, ConstCastOp, BigIntConstantOp,
+          ShrPrimOp, UninferredResetCastOp, ConstCastOp, StringConstantOp,
+          BigIntConstantOp,
           // Reference expressions
           RefSendOp, RefResolveOp, RefSubOp>([&](auto op) {
         ps.scopedBox(PP::ibox0, [&]() { emitExpression(op); });
@@ -1119,6 +1121,12 @@ void Emitter::emitExpression(UninferredResetCastOp op) {
 void Emitter::emitExpression(BigIntConstantOp op) {
   ps << "Integer(";
   ps.addAsString(op.getValue());
+  ps << ")";
+}
+
+void Emitter::emitExpression(StringConstantOp op) {
+  ps << "String(";
+  ps.writeQuotedEscaped(op.getValue());
   ps << ")";
 }
 

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -1210,6 +1210,7 @@ void Emitter::emitType(Type type, bool includeConst) {
         emitType(type.getType());
         ps << ">";
       })
+      .Case<BigIntType>([&](BigIntType type) { ps << "Integer"; })
       .Case<PathType>([&](PathType type) { ps << "Path"; })
       .Default([&](auto type) {
         llvm_unreachable("all types should be implemented");

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -502,10 +502,11 @@ void Emitter::emitStatementsInBlock(Block &block) {
     TypeSwitch<Operation *>(&bodyOp)
         .Case<WhenOp, WireOp, RegOp, RegResetOp, NodeOp, StopOp, SkipOp,
               PrintFOp, AssertOp, AssumeOp, CoverOp, ConnectOp, StrictConnectOp,
-              InstanceOp, AttachOp, MemOp, InvalidValueOp, SeqMemOp, CombMemOp,
-              MemoryPortOp, MemoryDebugPortOp, MemoryPortAccessOp, RefDefineOp,
-              RefForceOp, RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp,
-              GroupOp>([&](auto op) { emitStatement(op); })
+              PropAssignOp, InstanceOp, AttachOp, MemOp, InvalidValueOp,
+              SeqMemOp, CombMemOp, MemoryPortOp, MemoryDebugPortOp,
+              MemoryPortAccessOp, RefDefineOp, RefForceOp, RefForceInitialOp,
+              RefReleaseOp, RefReleaseInitialOp, GroupOp>(
+            [&](auto op) { emitStatement(op); })
         .Default([&](auto op) {
           startStatement();
           ps << "// operation " << PPExtString(op->getName().getStringRef());
@@ -727,6 +728,15 @@ void Emitter::emitStatement(StrictConnectOp op) {
           emitLHS, [&]() { emitExpression(op.getSrc()); }, PPExtString("<="));
     }
   }
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(PropAssignOp op) {
+  startStatement();
+  ps.scopedBox(PP::ibox2, [&]() {
+    ps << "propassign" << PP::space;
+    interleaveComma(op.getOperands());
+  });
   emitLocationAndNewLine(op);
 }
 

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -72,6 +72,7 @@ struct Emitter {
   void emitStatement(PrintFOp op);
   void emitStatement(ConnectOp op);
   void emitStatement(StrictConnectOp op);
+  void emitStatement(PropAssignOp op);
   void emitStatement(InstanceOp op);
   void emitStatement(AttachOp op);
   void emitStatement(MemOp op);
@@ -108,6 +109,7 @@ struct Emitter {
   void emitExpression(RefSubOp op);
   void emitExpression(UninferredResetCastOp op);
   void emitExpression(ConstCastOp op);
+  void emitExpression(BigIntConstantOp op);
 
   void emitPrimExpr(StringRef mnemonic, Operation *op,
                     ArrayRef<uint32_t> attrs = {});
@@ -1008,7 +1010,7 @@ void Emitter::emitExpression(Value value) {
           CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp, XorRPrimOp,
           // Miscellaneous
           BitsPrimOp, HeadPrimOp, TailPrimOp, PadPrimOp, MuxPrimOp, ShlPrimOp,
-          ShrPrimOp, UninferredResetCastOp, ConstCastOp,
+          ShrPrimOp, UninferredResetCastOp, ConstCastOp, BigIntConstantOp,
           // Reference expressions
           RefSendOp, RefResolveOp, RefSubOp>([&](auto op) {
         ps.scopedBox(PP::ibox0, [&]() { emitExpression(op); });
@@ -1112,6 +1114,12 @@ void Emitter::emitExpression(RefSubOp op) {
 
 void Emitter::emitExpression(UninferredResetCastOp op) {
   emitExpression(op.getInput());
+}
+
+void Emitter::emitExpression(BigIntConstantOp op) {
+  ps << "Integer(";
+  ps.addAsString(op.getValue());
+  ps << ")";
 }
 
 void Emitter::emitExpression(ConstCastOp op) { emitExpression(op.getInput()); }

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -640,10 +640,15 @@ firrtl.circuit "Foo" {
   }
   
   // CHECK-LABEL: module Properties :
-  firrtl.module @Properties(out %out : !firrtl.bigint) {
-    // CHECK: propassign out, Integer(99)
-    %0 = firrtl.bigint 99
-    firrtl.propassign %out, %0 : !firrtl.bigint
+  firrtl.module @Properties(out %string : !firrtl.string,
+                            out %integer : !firrtl.bigint) {
+    // CHECK: propassign string, String("hello")
+    %0 = firrtl.string "hello"
+    firrtl.propassign %string, %0 : !firrtl.string
+
+    // CHECK: propassign integer, Integer(99)
+    %1 = firrtl.bigint 99
+    firrtl.propassign %integer, %1 : !firrtl.bigint
   }
 
   // Test optional group declaration and definition emission.

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -35,6 +35,7 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT: output b0 : UInt
     // CHECK-NEXT: output b1 : Probe<UInt<1>>
     // CHECK-NEXT: output b2 : RWProbe<UInt<1>>
+    // CHECK-NEXT: input integer : Integer
     // CHECK-NEXT: input path : Path
     in %a00: !firrtl.clock,
     in %a01: !firrtl.reset,
@@ -50,6 +51,7 @@ firrtl.circuit "Foo" {
     out %b0: !firrtl.uint,
     out %b1: !firrtl.probe<uint<1>>,
     out %b2: !firrtl.rwprobe<uint<1>>,
+    in %integer: !firrtl.bigint,
     in %path : !firrtl.path
   ) {}
 

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -35,6 +35,7 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT: output b0 : UInt
     // CHECK-NEXT: output b1 : Probe<UInt<1>>
     // CHECK-NEXT: output b2 : RWProbe<UInt<1>>
+    // CHECK-NEXT: input string : String
     // CHECK-NEXT: input integer : Integer
     // CHECK-NEXT: input path : Path
     in %a00: !firrtl.clock,
@@ -51,6 +52,7 @@ firrtl.circuit "Foo" {
     out %b0: !firrtl.uint,
     out %b1: !firrtl.probe<uint<1>>,
     out %b2: !firrtl.rwprobe<uint<1>>,
+    in %string: !firrtl.string,
     in %integer: !firrtl.bigint,
     in %path : !firrtl.path
   ) {}

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -638,9 +638,10 @@ firrtl.circuit "Foo" {
   }
   
   // CHECK-LABEL: module Properties :
-  firrtl.module @Properties(in %in : !firrtl.bigint, out %out : !firrtl.bigint) {
-    // CHECK: propassign out, in
-    firrtl.propassign %out, %in : !firrtl.bigint
+  firrtl.module @Properties(out %out : !firrtl.bigint) {
+    // CHECK: propassign out, Integer(99)
+    %0 = firrtl.bigint 99
+    firrtl.propassign %out, %0 : !firrtl.bigint
   }
 
   // Test optional group declaration and definition emission.

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -636,6 +636,12 @@ firrtl.circuit "Foo" {
     firrtl.ref.define %_12, %18 : !firrtl.probe<uint<1>>
     firrtl.ref.define %_13, %_15_ref : !firrtl.rwprobe<uint<1>>
   }
+  
+  // CHECK-LABEL: module Properties :
+  firrtl.module @Properties(in %in : !firrtl.bigint, out %out : !firrtl.bigint) {
+    // CHECK: propassign out, in
+    firrtl.propassign %out, %in : !firrtl.bigint
+  }
 
   // Test optional group declaration and definition emission.
   //


### PR DESCRIPTION
This adds missing support for string and integer typed properties, as well as propassign, and constant string and integer expressions.