### PR TITLE
[CI] firtool release cleanup

### DIFF
--- a/.github/workflows/uploadFirrtlReleaseArtifacts.yml
+++ b/.github/workflows/uploadFirrtlReleaseArtifacts.yml
@@ -36,45 +36,99 @@ jobs:
           files: circt-full-sources.tar.gz*
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+  # This job sets up the build matrix.
+  choose-matrix:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Add Linux
+        id: add-linux
+        env:
+          os: linux
+          runner: ubuntu-20.04
+          arch: x64
+          tar: tar czf
+          archive: tar.gz
+          sha256: shasum -a 256
+          cont: '\'
+          setup:
+          cmake-args: -DCMAKE_C_COMPILER=clang-12 -DCMAKE_CXX_COMPILER=clang++-12
+        run: |
+          json=$(echo '${{ toJSON(env) }}' | jq -c)
+          echo $json
+          echo "out=$json" >> $GITHUB_OUTPUT
+      - name: Add macOS
+        id: add-macos
+        env:
+          os: macos
+          runner: macos-11
+          arch: x64
+          tar: gtar czf
+          archive: tar.gz
+          sha256: shasum -a 256
+          cont: '\'
+          setup:
+          cmake-args:
+        run: |
+          json=$(echo '${{ toJSON(env) }}' | jq -c)
+          echo $json
+          echo "out=$json" >> $GITHUB_OUTPUT
+      - name: Add Windows
+        id: add-windows
+        env:
+          os: windows
+          runner: windows-2019
+          arch: x64
+          tar: tar czf
+          archive: zip
+          sha256: sha256sum
+          cont: '`'
+          setup: ./utils/find-vs.ps1
+          cmake-args:
+        run: |
+          json=$(echo '${{ toJSON(env) }}' | jq -c)
+          echo $json
+          echo "out=$json" >> $GITHUB_OUTPUT
+      - name: Add Build Options
+        id: add-build-options
+        env:
+          mode: release
+          assert: OFF
+          shared: OFF
+          stats: ON
+        run: |
+          json=$(echo '${{ toJSON(env) }}' | jq -c)
+          echo $json
+          echo "out=$json" >> $GITHUB_OUTPUT
+      - name: Build JSON Payloads
+        id: build-json-payloads
+        run: |
+          echo '${{ steps.add-build-options.outputs.out }}' | jq -sc . > options.json
+          echo build_configs=`cat options.json` >> $GITHUB_OUTPUT
+
+          echo "Build Config Matrix" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          cat options.json | jq >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+          echo '${{ steps.add-linux.outputs.out }}' '${{ steps.add-macos.outputs.out }}' '${{ steps.add-windows.outputs.out }}' | jq -sc . > runners.json
+          echo runners=`cat runners.json` >> $GITHUB_OUTPUT
+
+          echo "Runner/Operating System Matrix:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          cat runners.json | jq >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+    outputs:
+      build_configs: ${{ steps.build-json-payloads.outputs.build_configs }}
+      runners: ${{ steps.build-json-payloads.outputs.runners }}
+
   publish:
+    needs:
+      - choose-matrix
     strategy:
       matrix:
-        build_config:
-          - mode: release
-            assert: OFF
-            shared: OFF
-            stats: ON
-        runner: [windows-2019, ubuntu-20.04, macos-11]
-        include:
-          - runner: ubuntu-20.04
-            os: linux
-            arch: x64
-            tar: tar czf
-            archive: tar.gz
-            sha256: shasum -a 256
-            cont: "\\"
-            setup: ""
-            # Default clang (11) is broken, see LLVM issue 59622.
-            cmake-args: "-DCMAKE_C_COMPILER=clang-12 -DCMAKE_CXX_COMPILER=clang++-12"
-          - runner: macos-11
-            os: macos
-            arch: x64
-            tar: gtar czf
-            archive: tar.gz
-            sha256: shasum -a 256
-            cont: "\\"
-            setup: ""
-            cmake-args: ""
-          - runner: windows-2019
-            os: windows
-            arch: x64
-            tar: tar czf # unused
-            archive: zip
-            sha256: sha256sum
-            cont: "`"
-            setup: ./utils/find-vs.ps1
-            cmake-args: ""
-    runs-on: ${{ matrix.runner }}
+        build_config: ${{ fromJSON(needs.choose-matrix.outputs.build_configs) }}
+        runner: ${{ fromJSON(needs.choose-matrix.outputs.runners) }}
+    runs-on: ${{ matrix.runner.runner }}
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
@@ -83,41 +137,40 @@ jobs:
         with:
           fetch-depth: 2
           submodules: "true"
-
       # We need unshallow CIRCT for later "git describe"
       - name: Unshallow CIRCT (but not LLVM)
         run: |
           git fetch --unshallow --no-recurse-submodules
 
       - name: Setup Linux
-        if: matrix.os == 'linux'
+        if: matrix.runner.os == 'linux'
         run: sudo apt-get install ninja-build
 
       - name: Setup Ninja and GNU Tar Mac
-        if: matrix.os == 'macos'
+        if: matrix.runner.os == 'macos'
         run: brew install ninja gnu-tar
 
       - name: Build LLVM
         run: |
-          ${{ matrix.setup }}
+          ${{ matrix.runner.setup }}
           mkdir -p llvm/build
           cd llvm/build
-          cmake -G Ninja ../llvm ${{ matrix.cont }}
-              ${{ matrix.cmake-args }} ${{ matrix.cont }}
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.cont }}
-              -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.cont }}
-              -DLLVM_BUILD_TOOLS=OFF ${{ matrix.cont }}
-              -DLLVM_BUILD_EXAMPLES=OFF ${{ matrix.cont }}
-              -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.cont }}
-              -DLLVM_ENABLE_BINDINGS=OFF ${{ matrix.cont }}
-              -DLLVM_ENABLE_OCAMLDOC=OFF ${{ matrix.cont }}
-              -DLLVM_ENABLE_PROJECTS="mlir" ${{ matrix.cont }}
-              -DLLVM_OPTIMIZED_TABLEGEN=ON ${{ matrix.cont }}
-              -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.cont }}
-              -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.cont }}
-              -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.cont }}
-              -DLLVM_TARGETS_TO_BUILD="host" ${{ matrix.cont }}
-              -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.cont }}
+          cmake -G Ninja ../llvm ${{ matrix.runner.cont }}
+              ${{ matrix.runner.cmake-args }} ${{ matrix.runner.cont }}
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.runner.cont }}
+              -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.runner.cont }}
+              -DLLVM_BUILD_TOOLS=OFF ${{ matrix.runner.cont }}
+              -DLLVM_BUILD_EXAMPLES=OFF ${{ matrix.runner.cont }}
+              -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.runner.cont }}
+              -DLLVM_ENABLE_BINDINGS=OFF ${{ matrix.runner.cont }}
+              -DLLVM_ENABLE_OCAMLDOC=OFF ${{ matrix.runner.cont }}
+              -DLLVM_ENABLE_PROJECTS="mlir" ${{ matrix.runner.cont }}
+              -DLLVM_OPTIMIZED_TABLEGEN=ON ${{ matrix.runner.cont }}
+              -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.runner.cont }}
+              -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.runner.cont }}
+              -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.runner.cont }}
+              -DLLVM_TARGETS_TO_BUILD="host" ${{ matrix.runner.cont }}
+              -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.runner.cont }}
               -DLLVM_ENABLE_ZSTD=OFF
           ninja
           ninja check-mlir
@@ -128,24 +181,24 @@ jobs:
 
       - name: Build and Test CIRCT
         run: |
-          ${{ matrix.setup }}
+          ${{ matrix.runner.setup }}
           mkdir build
           cd build
-          cmake -G Ninja .. ${{ matrix.cont }}
-            ${{ matrix.cmake-args }} ${{ matrix.cont }}
-            -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.cont }}
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.cont }}
-            -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.cont }}
-            -DMLIR_DIR="$(pwd)/../llvm/build/lib/cmake/mlir" ${{ matrix.cont }}
-            -DLLVM_DIR="$(pwd)/../llvm/build/lib/cmake/llvm" ${{ matrix.cont }}
-            -DVERILATOR_DISABLE=ON ${{ matrix.cont }}
-            -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.cont }}
-            -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.cont }}
-            -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.cont }}
-            -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.cont }}
-            -DCIRCT_RELEASE_TAG_ENABLED=ON ${{ matrix.cont }}
-            -DCIRCT_RELEASE_TAG=firtool ${{ matrix.cont }}
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF ${{ matrix.cont }}
+          cmake -G Ninja .. ${{ matrix.runner.cont }}
+            ${{ matrix.runner.cmake-args }} ${{ matrix.runner.cont }}
+            -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.runner.cont }}
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.runner.cont }}
+            -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.runner.cont }}
+            -DMLIR_DIR="$(pwd)/../llvm/build/lib/cmake/mlir" ${{ matrix.runner.cont }}
+            -DLLVM_DIR="$(pwd)/../llvm/build/lib/cmake/llvm" ${{ matrix.runner.cont }}
+            -DVERILATOR_DISABLE=ON ${{ matrix.runner.cont }}
+            -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.runner.cont }}
+            -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.runner.cont }}
+            -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.runner.cont }}
+            -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.runner.cont }}
+            -DCIRCT_RELEASE_TAG_ENABLED=ON ${{ matrix.runner.cont }}
+            -DCIRCT_RELEASE_TAG=firtool ${{ matrix.runner.cont }}
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF ${{ matrix.runner.cont }}
             -DCMAKE_INSTALL_PREFIX="$(pwd)/../install"
           ninja
           ninja check-circt check-circt-unit
@@ -170,18 +223,18 @@ jobs:
         id: name_archive
         shell: bash
         run: |
-          NAME=firrtl-bin-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.archive }}
+          NAME=firrtl-bin-${{ matrix.runner.os }}-${{ matrix.runner.arch }}.${{ matrix.runner.archive }}
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
 
       - name: Package Binaries Linux and MacOS
-        if: matrix.os == 'macos' || matrix.os == 'linux'
+        if: matrix.runner.os == 'macos' || matrix.runner.os == 'linux'
         run: |
           mv install ${{ steps.name_dir.outputs.value }}
-          ${{ matrix.tar }} ${{ steps.name_archive.outputs.name }} ${{ steps.name_dir.outputs.value }}
+          ${{ matrix.runner.tar }} ${{ steps.name_archive.outputs.name }} ${{ steps.name_dir.outputs.value }}
 
       # Not sure how to create a zip in bash on Windows so using powershell
       - name: Package Binaries Windows
-        if: matrix.os == 'windows'
+        if: matrix.runner.os == 'windows'
         shell: pwsh
         run: |
           mv install ${{ steps.name_dir.outputs.value }}
@@ -192,7 +245,7 @@ jobs:
         shell: bash
         run: |
           ls -l ${{ steps.name_archive.outputs.name }}
-          ${{ matrix.sha256 }} ${{ steps.name_archive.outputs.name }} | cut -d ' ' -f1 > ${{ steps.name_archive.outputs.name }}.sha256
+          ${{ matrix.runner.sha256 }} ${{ steps.name_archive.outputs.name }} | cut -d ' ' -f1 > ${{ steps.name_archive.outputs.name }}.sha256
 
       - name: Upload Binary (Non-Tag)
         uses: actions/upload-artifact@v3

--- a/.github/workflows/uploadFirrtlReleaseArtifacts.yml
+++ b/.github/workflows/uploadFirrtlReleaseArtifacts.yml
@@ -150,63 +150,45 @@ jobs:
         if: matrix.runner.os == 'macos'
         run: brew install ninja gnu-tar
 
-      - name: Build LLVM
-        run: |
-          ${{ matrix.runner.setup }}
-          mkdir -p llvm/build
-          cd llvm/build
-          cmake -G Ninja ../llvm ${{ matrix.runner.cont }}
-              ${{ matrix.runner.cmake-args }} ${{ matrix.runner.cont }}
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.runner.cont }}
-              -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.runner.cont }}
-              -DLLVM_BUILD_TOOLS=OFF ${{ matrix.runner.cont }}
-              -DLLVM_BUILD_EXAMPLES=OFF ${{ matrix.runner.cont }}
-              -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.runner.cont }}
-              -DLLVM_ENABLE_BINDINGS=OFF ${{ matrix.runner.cont }}
-              -DLLVM_ENABLE_OCAMLDOC=OFF ${{ matrix.runner.cont }}
-              -DLLVM_ENABLE_PROJECTS="mlir" ${{ matrix.runner.cont }}
-              -DLLVM_OPTIMIZED_TABLEGEN=ON ${{ matrix.runner.cont }}
-              -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.runner.cont }}
-              -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.runner.cont }}
-              -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.runner.cont }}
-              -DLLVM_TARGETS_TO_BUILD="host" ${{ matrix.runner.cont }}
-              -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.runner.cont }}
-              -DLLVM_ENABLE_ZSTD=OFF
-          ninja
-          ninja check-mlir
-
-      # --------
-      # Build and test CIRCT
-      # --------
-
-      - name: Build and Test CIRCT
+      - name: Configure CIRCT
         run: |
           ${{ matrix.runner.setup }}
           mkdir build
           cd build
-          cmake -G Ninja .. ${{ matrix.runner.cont }}
+          echo $(pwd)
+          cmake -G Ninja -S "$(pwd)/../llvm/llvm" ${{ matrix.runner.cont }}
             ${{ matrix.runner.cmake-args }} ${{ matrix.runner.cont }}
-            -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.runner.cont }}
             -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.runner.cont }}
+            -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.runner.cont }}
+            -DLLVM_BUILD_TOOLS=ON ${{ matrix.runner.cont }}
+            -DLLVM_BUILD_EXAMPLES=OFF ${{ matrix.runner.cont }}
             -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.runner.cont }}
-            -DMLIR_DIR="$(pwd)/../llvm/build/lib/cmake/mlir" ${{ matrix.runner.cont }}
-            -DLLVM_DIR="$(pwd)/../llvm/build/lib/cmake/llvm" ${{ matrix.runner.cont }}
-            -DVERILATOR_DISABLE=ON ${{ matrix.runner.cont }}
-            -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.runner.cont }}
+            -DLLVM_ENABLE_PROJECTS=mlir ${{ matrix.runner.cont }}
+            -DLLVM_EXTERNAL_PROJECTS=circt ${{ matrix.runner.cont }}
+            -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." ${{ matrix.runner.cont }}
+            -DLLVM_OPTIMIZED_TABLEGEN=ON ${{ matrix.runner.cont }}
             -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.runner.cont }}
+            -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.runner.cont }}
             -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.runner.cont }}
+            -DLLVM_TARGETS_TO_BUILD="host" ${{ matrix.runner.cont }}
             -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.runner.cont }}
+            -DLLVM_ENABLE_ZSTD=OFF ${{ matrix.runner.cont }}
+            -DVERILATOR_DISABLE=ON ${{ matrix.runner.cont }}
+            -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.runner.cont }}
             -DCIRCT_RELEASE_TAG_ENABLED=ON ${{ matrix.runner.cont }}
             -DCIRCT_RELEASE_TAG=firtool ${{ matrix.runner.cont }}
             -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF ${{ matrix.runner.cont }}
             -DCMAKE_INSTALL_PREFIX="$(pwd)/../install"
-          ninja
-          ninja check-circt check-circt-unit
-          ninja install-firtool
-          cd ..
 
-      - name: Display Files
+      - name: Build and Test CIRCT
         run: |
+          ${{ matrix.runner.setup }}
+          ninja -C build check-circt check-circt-unit
+
+      - name: Install firtool
+        run: |
+          ${{ matrix.runner.setup }}
+          ninja -C build install-firtool
           file install/*
           file install/bin/*
 


### PR DESCRIPTION
This PR does to refactors/cleanups of the `firtool` release CI workflow.  These are organized into two commits:

1. The build matrix is no longer hard-coded.  Instead, this is dynamically created by passing a JSON description of the build matrix (technically matrices as there is a "build_config" dimension and a "runner" dimension).  This is done to enable programmability of the build matrix.
2. The CI workflow is switched to use a unified build.

This is the first part of a larger change to this workflow to enable more cross-repo CI/CD pipelines.  Specifically, I want to automate the CI/CD flow for bumping `firtool` internally at SiFive and externally on Chisel. The first piece of this is having a nightly binary build of `firtool`. I am constrained in that Docker cannot be a solution here. I also do not want to replicate any step in another CI/CD pipeline unless I have to. (I don't want to build CIRCT anywhere else!)

I am trying to re-use the existing release pipeline, but this requires the ability to only build what I need. I don't need macOS and Windows builds (and the former are extremely expensive anyway!). However, this requires adding some programmability to what workflow is building.

Configuration of the build flow will come in later PRs. E.g., for the nightly build I will disable macOS and Windows. Eventually, this configuration can be exposed to a human via [`workflow_dispatch` inputs](https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows/) or to a machine via [`repository_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch).