### PR TITLE
[ci] Add nightly `firtool` release build, options to workflow_dispatch

### DIFF
--- a/.github/workflows/uploadFirrtlReleaseArtifacts.yml
+++ b/.github/workflows/uploadFirrtlReleaseArtifacts.yml
@@ -4,6 +4,15 @@ on:
   release:
     types: [created]
   workflow_dispatch:
+    inputs:
+      os:
+        type: choice
+        description: Operating System target
+        default: linux
+        options:
+          - linux
+          - macos
+          - windows
   # Run every day at 0700 UTC which is:
   #   - 0000 PDT / 2300 PST
   #   - 0300 EDT / 0200 EST
@@ -47,6 +56,7 @@ jobs:
     steps:
       - name: Add Linux
         id: add-linux
+        if: github.event_name != 'workflow_dispatch' || inputs.os == 'linux'
         env:
           os: linux
           runner: ubuntu-20.04
@@ -63,7 +73,7 @@ jobs:
           echo "out=$json" >> $GITHUB_OUTPUT
       - name: Add macOS
         id: add-macos
-        if: github.event_name != 'schedule'
+        if: github.event_name == 'release' || ( github.event_name == 'workflow_dispatch' && inputs.os == 'macos' )
         env:
           os: macos
           runner: macos-11
@@ -80,7 +90,7 @@ jobs:
           echo "out=$json" >> $GITHUB_OUTPUT
       - name: Add Windows
         id: add-windows
-        if: github.event_name != 'schedule'
+        if: github.event_name == 'release' || ( github.event_name == 'workflow_dispatch' && inputs.os == 'windows' )
         env:
           os: windows
           runner: windows-2019

--- a/.github/workflows/uploadFirrtlReleaseArtifacts.yml
+++ b/.github/workflows/uploadFirrtlReleaseArtifacts.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [created]
   workflow_dispatch:
+  # Run every day at 0700 UTC which is:
+  #   - 0000 PDT / 2300 PST
+  #   - 0300 EDT / 0200 EST
+  schedule:
+    - cron: '0 7 * * *'
 
 jobs:
   publish-sources:
@@ -58,6 +63,7 @@ jobs:
           echo "out=$json" >> $GITHUB_OUTPUT
       - name: Add macOS
         id: add-macos
+        if: github.event_name != 'schedule'
         env:
           os: macos
           runner: macos-11
@@ -74,6 +80,7 @@ jobs:
           echo "out=$json" >> $GITHUB_OUTPUT
       - name: Add Windows
         id: add-windows
+        if: github.event_name != 'schedule'
         env:
           os: windows
           runner: windows-2019

--- a/.github/workflows/uploadFirrtlReleaseArtifacts.yml
+++ b/.github/workflows/uploadFirrtlReleaseArtifacts.yml
@@ -36,45 +36,99 @@ jobs:
           files: circt-full-sources.tar.gz*
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+  # This job sets up the build matrix.
+  choose-matrix:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Add Linux
+        id: add-linux
+        env:
+          os: linux
+          runner: ubuntu-20.04
+          arch: x64
+          tar: tar czf
+          archive: tar.gz
+          sha256: shasum -a 256
+          cont: '\'
+          setup:
+          cmake-args: -DCMAKE_C_COMPILER=clang-12 -DCMAKE_CXX_COMPILER=clang++-12
+        run: |
+          json=$(echo '${{ toJSON(env) }}' | jq -c)
+          echo $json
+          echo "out=$json" >> $GITHUB_OUTPUT
+      - name: Add macOS
+        id: add-macos
+        env:
+          os: macos
+          runner: macos-11
+          arch: x64
+          tar: gtar czf
+          archive: tar.gz
+          sha256: shasum -a 256
+          cont: '\'
+          setup:
+          cmake-args:
+        run: |
+          json=$(echo '${{ toJSON(env) }}' | jq -c)
+          echo $json
+          echo "out=$json" >> $GITHUB_OUTPUT
+      - name: Add Windows
+        id: add-windows
+        env:
+          os: windows
+          runner: windows-2019
+          arch: x64
+          tar: tar czf
+          archive: zip
+          sha256: sha256sum
+          cont: '`'
+          setup: ./utils/find-vs.ps1
+          cmake-args:
+        run: |
+          json=$(echo '${{ toJSON(env) }}' | jq -c)
+          echo $json
+          echo "out=$json" >> $GITHUB_OUTPUT
+      - name: Add Build Options
+        id: add-build-options
+        env:
+          mode: release
+          assert: OFF
+          shared: OFF
+          stats: ON
+        run: |
+          json=$(echo '${{ toJSON(env) }}' | jq -c)
+          echo $json
+          echo "out=$json" >> $GITHUB_OUTPUT
+      - name: Build JSON Payloads
+        id: build-json-payloads
+        run: |
+          echo '${{ steps.add-build-options.outputs.out }}' | jq -sc . > options.json
+          echo build_configs=`cat options.json` >> $GITHUB_OUTPUT
+
+          echo "Build Config Matrix" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          cat options.json | jq >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+          echo '${{ steps.add-linux.outputs.out }}' '${{ steps.add-macos.outputs.out }}' '${{ steps.add-windows.outputs.out }}' | jq -sc . > runners.json
+          echo runners=`cat runners.json` >> $GITHUB_OUTPUT
+
+          echo "Runner/Operating System Matrix:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          cat runners.json | jq >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+    outputs:
+      build_configs: ${{ steps.build-json-payloads.outputs.build_configs }}
+      runners: ${{ steps.build-json-payloads.outputs.runners }}
+
   publish:
+    needs:
+      - choose-matrix
     strategy:
       matrix:
-        build_config:
-          - mode: release
-            assert: OFF
-            shared: OFF
-            stats: ON
-        runner: [windows-2019, ubuntu-20.04, macos-11]
-        include:
-          - runner: ubuntu-20.04
-            os: linux
-            arch: x64
-            tar: tar czf
-            archive: tar.gz
-            sha256: shasum -a 256
-            cont: "\\"
-            setup: ""
-            # Default clang (11) is broken, see LLVM issue 59622.
-            cmake-args: "-DCMAKE_C_COMPILER=clang-12 -DCMAKE_CXX_COMPILER=clang++-12"
-          - runner: macos-11
-            os: macos
-            arch: x64
-            tar: gtar czf
-            archive: tar.gz
-            sha256: shasum -a 256
-            cont: "\\"
-            setup: ""
-            cmake-args: ""
-          - runner: windows-2019
-            os: windows
-            arch: x64
-            tar: tar czf # unused
-            archive: zip
-            sha256: sha256sum
-            cont: "`"
-            setup: ./utils/find-vs.ps1
-            cmake-args: ""
-    runs-on: ${{ matrix.runner }}
+        build_config: ${{ fromJSON(needs.choose-matrix.outputs.build_configs) }}
+        runner: ${{ fromJSON(needs.choose-matrix.outputs.runners) }}
+    runs-on: ${{ matrix.runner.runner }}
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
@@ -83,41 +137,40 @@ jobs:
         with:
           fetch-depth: 2
           submodules: "true"
-
       # We need unshallow CIRCT for later "git describe"
       - name: Unshallow CIRCT (but not LLVM)
         run: |
           git fetch --unshallow --no-recurse-submodules
 
       - name: Setup Linux
-        if: matrix.os == 'linux'
+        if: matrix.runner.os == 'linux'
         run: sudo apt-get install ninja-build
 
       - name: Setup Ninja and GNU Tar Mac
-        if: matrix.os == 'macos'
+        if: matrix.runner.os == 'macos'
         run: brew install ninja gnu-tar
 
       - name: Build LLVM
         run: |
-          ${{ matrix.setup }}
+          ${{ matrix.runner.setup }}
           mkdir -p llvm/build
           cd llvm/build
-          cmake -G Ninja ../llvm ${{ matrix.cont }}
-              ${{ matrix.cmake-args }} ${{ matrix.cont }}
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.cont }}
-              -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.cont }}
-              -DLLVM_BUILD_TOOLS=OFF ${{ matrix.cont }}
-              -DLLVM_BUILD_EXAMPLES=OFF ${{ matrix.cont }}
-              -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.cont }}
-              -DLLVM_ENABLE_BINDINGS=OFF ${{ matrix.cont }}
-              -DLLVM_ENABLE_OCAMLDOC=OFF ${{ matrix.cont }}
-              -DLLVM_ENABLE_PROJECTS="mlir" ${{ matrix.cont }}
-              -DLLVM_OPTIMIZED_TABLEGEN=ON ${{ matrix.cont }}
-              -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.cont }}
-              -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.cont }}
-              -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.cont }}
-              -DLLVM_TARGETS_TO_BUILD="host" ${{ matrix.cont }}
-              -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.cont }}
+          cmake -G Ninja ../llvm ${{ matrix.runner.cont }}
+              ${{ matrix.runner.cmake-args }} ${{ matrix.runner.cont }}
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.runner.cont }}
+              -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.runner.cont }}
+              -DLLVM_BUILD_TOOLS=OFF ${{ matrix.runner.cont }}
+              -DLLVM_BUILD_EXAMPLES=OFF ${{ matrix.runner.cont }}
+              -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.runner.cont }}
+              -DLLVM_ENABLE_BINDINGS=OFF ${{ matrix.runner.cont }}
+              -DLLVM_ENABLE_OCAMLDOC=OFF ${{ matrix.runner.cont }}
+              -DLLVM_ENABLE_PROJECTS="mlir" ${{ matrix.runner.cont }}
+              -DLLVM_OPTIMIZED_TABLEGEN=ON ${{ matrix.runner.cont }}
+              -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.runner.cont }}
+              -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.runner.cont }}
+              -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.runner.cont }}
+              -DLLVM_TARGETS_TO_BUILD="host" ${{ matrix.runner.cont }}
+              -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.runner.cont }}
               -DLLVM_ENABLE_ZSTD=OFF
           ninja
           ninja check-mlir
@@ -128,24 +181,24 @@ jobs:
 
       - name: Build and Test CIRCT
         run: |
-          ${{ matrix.setup }}
+          ${{ matrix.runner.setup }}
           mkdir build
           cd build
-          cmake -G Ninja .. ${{ matrix.cont }}
-            ${{ matrix.cmake-args }} ${{ matrix.cont }}
-            -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.cont }}
-            -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.cont }}
-            -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.cont }}
-            -DMLIR_DIR="$(pwd)/../llvm/build/lib/cmake/mlir" ${{ matrix.cont }}
-            -DLLVM_DIR="$(pwd)/../llvm/build/lib/cmake/llvm" ${{ matrix.cont }}
-            -DVERILATOR_DISABLE=ON ${{ matrix.cont }}
-            -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.cont }}
-            -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.cont }}
-            -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.cont }}
-            -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.cont }}
-            -DCIRCT_RELEASE_TAG_ENABLED=ON ${{ matrix.cont }}
-            -DCIRCT_RELEASE_TAG=firtool ${{ matrix.cont }}
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF ${{ matrix.cont }}
+          cmake -G Ninja .. ${{ matrix.runner.cont }}
+            ${{ matrix.runner.cmake-args }} ${{ matrix.runner.cont }}
+            -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.runner.cont }}
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.runner.cont }}
+            -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.runner.cont }}
+            -DMLIR_DIR="$(pwd)/../llvm/build/lib/cmake/mlir" ${{ matrix.runner.cont }}
+            -DLLVM_DIR="$(pwd)/../llvm/build/lib/cmake/llvm" ${{ matrix.runner.cont }}
+            -DVERILATOR_DISABLE=ON ${{ matrix.runner.cont }}
+            -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.runner.cont }}
+            -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.runner.cont }}
+            -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.runner.cont }}
+            -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.runner.cont }}
+            -DCIRCT_RELEASE_TAG_ENABLED=ON ${{ matrix.runner.cont }}
+            -DCIRCT_RELEASE_TAG=firtool ${{ matrix.runner.cont }}
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF ${{ matrix.runner.cont }}
             -DCMAKE_INSTALL_PREFIX="$(pwd)/../install"
           ninja
           ninja check-circt check-circt-unit
@@ -170,18 +223,18 @@ jobs:
         id: name_archive
         shell: bash
         run: |
-          NAME=firrtl-bin-${{ matrix.os }}-${{ matrix.arch }}.${{ matrix.archive }}
+          NAME=firrtl-bin-${{ matrix.runner.os }}-${{ matrix.runner.arch }}.${{ matrix.runner.archive }}
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
 
       - name: Package Binaries Linux and MacOS
-        if: matrix.os == 'macos' || matrix.os == 'linux'
+        if: matrix.runner.os == 'macos' || matrix.runner.os == 'linux'
         run: |
           mv install ${{ steps.name_dir.outputs.value }}
-          ${{ matrix.tar }} ${{ steps.name_archive.outputs.name }} ${{ steps.name_dir.outputs.value }}
+          ${{ matrix.runner.tar }} ${{ steps.name_archive.outputs.name }} ${{ steps.name_dir.outputs.value }}
 
       # Not sure how to create a zip in bash on Windows so using powershell
       - name: Package Binaries Windows
-        if: matrix.os == 'windows'
+        if: matrix.runner.os == 'windows'
         shell: pwsh
         run: |
           mv install ${{ steps.name_dir.outputs.value }}
@@ -192,7 +245,7 @@ jobs:
         shell: bash
         run: |
           ls -l ${{ steps.name_archive.outputs.name }}
-          ${{ matrix.sha256 }} ${{ steps.name_archive.outputs.name }} | cut -d ' ' -f1 > ${{ steps.name_archive.outputs.name }}.sha256
+          ${{ matrix.runner.sha256 }} ${{ steps.name_archive.outputs.name }} | cut -d ' ' -f1 > ${{ steps.name_archive.outputs.name }}.sha256
 
       - name: Upload Binary (Non-Tag)
         uses: actions/upload-artifact@v3

--- a/.github/workflows/uploadFirrtlReleaseArtifacts.yml
+++ b/.github/workflows/uploadFirrtlReleaseArtifacts.yml
@@ -150,63 +150,45 @@ jobs:
         if: matrix.runner.os == 'macos'
         run: brew install ninja gnu-tar
 
-      - name: Build LLVM
-        run: |
-          ${{ matrix.runner.setup }}
-          mkdir -p llvm/build
-          cd llvm/build
-          cmake -G Ninja ../llvm ${{ matrix.runner.cont }}
-              ${{ matrix.runner.cmake-args }} ${{ matrix.runner.cont }}
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.runner.cont }}
-              -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.runner.cont }}
-              -DLLVM_BUILD_TOOLS=OFF ${{ matrix.runner.cont }}
-              -DLLVM_BUILD_EXAMPLES=OFF ${{ matrix.runner.cont }}
-              -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.runner.cont }}
-              -DLLVM_ENABLE_BINDINGS=OFF ${{ matrix.runner.cont }}
-              -DLLVM_ENABLE_OCAMLDOC=OFF ${{ matrix.runner.cont }}
-              -DLLVM_ENABLE_PROJECTS="mlir" ${{ matrix.runner.cont }}
-              -DLLVM_OPTIMIZED_TABLEGEN=ON ${{ matrix.runner.cont }}
-              -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.runner.cont }}
-              -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.runner.cont }}
-              -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.runner.cont }}
-              -DLLVM_TARGETS_TO_BUILD="host" ${{ matrix.runner.cont }}
-              -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.runner.cont }}
-              -DLLVM_ENABLE_ZSTD=OFF
-          ninja
-          ninja check-mlir
-
-      # --------
-      # Build and test CIRCT
-      # --------
-
-      - name: Build and Test CIRCT
+      - name: Configure CIRCT
         run: |
           ${{ matrix.runner.setup }}
           mkdir build
           cd build
-          cmake -G Ninja .. ${{ matrix.runner.cont }}
+          echo $(pwd)
+          cmake -G Ninja -S "$(pwd)/../llvm/llvm" ${{ matrix.runner.cont }}
             ${{ matrix.runner.cmake-args }} ${{ matrix.runner.cont }}
-            -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.runner.cont }}
             -DCMAKE_BUILD_TYPE=${{ matrix.build_config.mode }} ${{ matrix.runner.cont }}
+            -DBUILD_SHARED_LIBS=${{ matrix.build_config.shared }} ${{ matrix.runner.cont }}
+            -DLLVM_BUILD_TOOLS=ON ${{ matrix.runner.cont }}
+            -DLLVM_BUILD_EXAMPLES=OFF ${{ matrix.runner.cont }}
             -DLLVM_ENABLE_ASSERTIONS=${{ matrix.build_config.assert }} ${{ matrix.runner.cont }}
-            -DMLIR_DIR="$(pwd)/../llvm/build/lib/cmake/mlir" ${{ matrix.runner.cont }}
-            -DLLVM_DIR="$(pwd)/../llvm/build/lib/cmake/llvm" ${{ matrix.runner.cont }}
-            -DVERILATOR_DISABLE=ON ${{ matrix.runner.cont }}
-            -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.runner.cont }}
+            -DLLVM_ENABLE_PROJECTS=mlir ${{ matrix.runner.cont }}
+            -DLLVM_EXTERNAL_PROJECTS=circt ${{ matrix.runner.cont }}
+            -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." ${{ matrix.runner.cont }}
+            -DLLVM_OPTIMIZED_TABLEGEN=ON ${{ matrix.runner.cont }}
             -DLLVM_STATIC_LINK_CXX_STDLIB=ON ${{ matrix.runner.cont }}
+            -DLLVM_ENABLE_TERMINFO=OFF ${{ matrix.runner.cont }}
             -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.runner.cont }}
+            -DLLVM_TARGETS_TO_BUILD="host" ${{ matrix.runner.cont }}
             -DLLVM_FORCE_ENABLE_STATS=${{ matrix.build_config.stats }} ${{ matrix.runner.cont }}
+            -DLLVM_ENABLE_ZSTD=OFF ${{ matrix.runner.cont }}
+            -DVERILATOR_DISABLE=ON ${{ matrix.runner.cont }}
+            -DLLVM_PARALLEL_LINK_JOBS=1 ${{ matrix.runner.cont }}
             -DCIRCT_RELEASE_TAG_ENABLED=ON ${{ matrix.runner.cont }}
             -DCIRCT_RELEASE_TAG=firtool ${{ matrix.runner.cont }}
             -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF ${{ matrix.runner.cont }}
             -DCMAKE_INSTALL_PREFIX="$(pwd)/../install"
-          ninja
-          ninja check-circt check-circt-unit
-          ninja install-firtool
-          cd ..
 
-      - name: Display Files
+      - name: Build and Test CIRCT
         run: |
+          ${{ matrix.runner.setup }}
+          ninja -C build check-circt check-circt-unit
+
+      - name: Install firtool
+        run: |
+          ${{ matrix.runner.setup }}
+          ninja -C build install-firtool
           file install/*
           file install/bin/*
 

--- a/.github/workflows/uploadFirrtlReleaseArtifacts.yml
+++ b/.github/workflows/uploadFirrtlReleaseArtifacts.yml
@@ -13,6 +13,13 @@ on:
           - linux
           - macos
           - windows
+      runTests:
+        type: choice
+        description: Run CIRCT tests
+        default: false
+        options:
+          - true
+          - false
   # Run every day at 0700 UTC which is:
   #   - 0000 PDT / 2300 PST
   #   - 0300 EDT / 0200 EST
@@ -134,9 +141,25 @@ jobs:
           echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
           cat runners.json | jq >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+          case ${{ github.event_name }} in
+            workflow_dispatch)
+              ENV='{"runTests":${{ inputs.runTests }}}'
+            ;;
+            *)
+              ENV='{"runTests":true}'
+            ;;
+          esac
+          echo environment=$ENV >> $GITHUB_OUTPUT
+
+          echo "Environment Configuration:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          echo $ENV | jq >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
     outputs:
       build_configs: ${{ steps.build-json-payloads.outputs.build_configs }}
       runners: ${{ steps.build-json-payloads.outputs.runners }}
+      environment: ${{ steps.build-json-payloads.outputs.environment }}
 
   publish:
     needs:
@@ -146,6 +169,7 @@ jobs:
         build_config: ${{ fromJSON(needs.choose-matrix.outputs.build_configs) }}
         runner: ${{ fromJSON(needs.choose-matrix.outputs.runners) }}
     runs-on: ${{ matrix.runner.runner }}
+    env: ${{ fromJSON(needs.choose-matrix.outputs.environment) }}
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
@@ -197,7 +221,8 @@ jobs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF ${{ matrix.runner.cont }}
             -DCMAKE_INSTALL_PREFIX="$(pwd)/../install"
 
-      - name: Build and Test CIRCT
+      - name: Test CIRCT
+        if: env.runTests == 'true'
         run: |
           ${{ matrix.runner.setup }}
           ninja -C build check-circt check-circt-unit


### PR DESCRIPTION
Add a nightly scheduled build of `firtool`. This is intended for other projects to consume to do top-of-tree testing.

Add options to control the manually run workflow dispatch build. This enables building any of `[linux, macos, windows]` builds and with an optional to disable testing. I've been using this to test the build. The UI that GitHub gives you is shown below:

<img width="348" alt="Screenshot 2023-08-01 at 02 00 59" src="https://github.com/llvm/circt/assets/1018530/4bd5f7d8-44c0-4a9c-b9bb-2f76dd5577da">

This is stacked on #5741 until that lands.

Once the nightly build is running, any user can grab this through the GitHub API, substituting `$TOKEN` for a GitHub personal or app token. The following script will grab the latest nightly and extract it.

```shell
ARTIFACT_NAME=firrtl-bin-linux-x64.tar.gz
ARTIFACT_ID=$(
  curl -L \
       -H "Accept: application/vnd.github+json" \
       -H "Authorization: Bearer $TOKEN" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       "https://api.github.com/repos/llvm/circt/actions/artifacts?name=firrtl-bin-linux-x64.tar.gz&per_page=1" | \
    jq '.artifacts[0].id')
curl -L \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer $TOKEN" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     https://api.github.com/repos/llvm/circt/actions/artifacts/$ARTIFACT_ID/zip \
     --output download.zip
unzip -p download.zip | tar zxf -
rm download.zip
```