### PR TITLE
Backport ETC and UNROnly fixes to firtool 1.37

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3977,8 +3977,23 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
     Value opEnable, StringAttr opMessageAttr, ValueRange opOperands,
     StringAttr opNameAttr, bool isConcurrent, EventControl opEventControl) {
   StringRef opName = op->getName().stripDialect();
+
+  // The attribute holding the compile guards
+  ArrayRef<Attribute> guards{};
+  if (auto guardsAttr = op->template getAttrOfType<ArrayAttr>("guards"))
+    guards = guardsAttr.getValue();
+
   auto isAssert = opName == "assert";
   auto isCover = opName == "cover";
+
+  // TODO : Need to figure out if there is a cleaner way to get the string which
+  // indicates the assert is UNR only. Or better - not rely on this at all -
+  // ideally there should have been some other attribute which indicated that
+  // this assert for UNR only.
+  auto isUnrOnlyAssert = llvm::any_of(guards, [](Attribute attr) {
+    StringAttr strAttr = dyn_cast<StringAttr>(attr);
+    return strAttr && strAttr.getValue() == "USE_UNR_ONLY_CONSTRAINTS";
+  });
 
   auto clock = getLoweredValue(opClock);
   auto enable = getLoweredValue(opEnable);
@@ -4098,19 +4113,27 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
         assumeLabel = StringAttr::get(builder.getContext(),
                                       "assume__" + label.getValue());
       addToIfDefBlock("USE_PROPERTY_AS_CONSTRAINT", [&]() {
-        builder.create<sv::AssumeConcurrentOp>(
-            circt::sv::EventControlAttr::get(builder.getContext(), event),
-            clock, predicate, assumeLabel);
+        if (!isUnrOnlyAssert) {
+          builder.create<sv::AssumeConcurrentOp>(
+              circt::sv::EventControlAttr::get(builder.getContext(), event),
+              clock, predicate, assumeLabel);
+        } else {
+          builder.create<sv::AlwaysOp>(
+              ArrayRef(sv::EventControl::AtEdge), ArrayRef(predicate), [&]() {
+                buildImmediateVerifOp(builder, "assume", predicate,
+                                      circt::sv::DeferAssertAttr::get(
+                                          builder.getContext(),
+                                          circt::sv::DeferAssert::Immediate),
+                                      assumeLabel);
+              });
+        }
       });
     }
   };
 
   // Wrap the verification statement up in the optional preprocessor
   // guards. This is a bit awkward since we want to translate an array of
-  // guards into a recursive call to `addToIfDefBlock`.
-  ArrayRef<Attribute> guards{};
-  if (auto guardsAttr = op->template getAttrOfType<ArrayAttr>("guards"))
-    guards = guardsAttr.getValue();
+  // guards  into a recursive call to `addToIfDefBlock`.
   bool anyFailed = false;
   std::function<void()> emitWrapped = [&]() {
     if (guards.empty()) {
@@ -4129,7 +4152,6 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
   emitWrapped();
   if (anyFailed)
     return failure();
-
   return success();
 }
 

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -18,6 +18,7 @@
 #include "circt/Dialect/HW/HWInstanceGraph.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWSymCache.h"
+#include "circt/Dialect/HW/Namespace.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/IRMapping.h"
@@ -426,13 +427,43 @@ static void addExistingBinds(Block *topLevelModule, BindTable &bindTable) {
 }
 
 // Inline any modules that only have inputs for test code.
-static void inlineInputOnly(hw::HWModuleOp oldMod,
-                            hw::InstanceGraph &instanceGraph,
-                            BindTable &bindTable,
-                            SmallPtrSetImpl<Operation *> &opsToErase) {
+static void
+inlineInputOnly(hw::HWModuleOp oldMod, hw::InstanceGraph &instanceGraph,
+                BindTable &bindTable, SmallPtrSetImpl<Operation *> &opsToErase,
+                llvm::DenseSet<hw::InnerRefAttr> &innerRefUsedByNonBindOp) {
+
   // Check if the module only has inputs.
   if (oldMod.getNumOutputs() != 0)
     return;
+
+  // Check if it's ok to inline. We cannot inline the module if there exists a
+  // declaration with an inner symbol referred by non-bind ops (e.g. hierpath).
+  for (auto port : oldMod.getAllPorts()) {
+    if (port.sym) {
+      // Reject if the inner sym is a per-field symbol, or its inner ref is used
+      // by non-bind op.
+      if (!port.sym.getSymName() || port.sym.size() != 1 ||
+          innerRefUsedByNonBindOp.count(hw::InnerRefAttr::get(
+              oldMod.getNameAttr(), port.sym.getSymName()))) {
+        oldMod.emitWarning() << "module " << oldMod.getName()
+                             << " is an input only module but cannot "
+                                "be inlined because a signal "
+                             << port.name << " is referred by name";
+        return;
+      }
+    }
+  }
+  for (auto &op : *oldMod.getBodyBlock()) {
+    if (auto innerSym = op.getAttrOfType<StringAttr>("inner_sym"))
+      if (innerRefUsedByNonBindOp.count(
+              hw::InnerRefAttr::get(oldMod.getNameAttr(), innerSym))) {
+        op.emitWarning()
+            << "module " << oldMod.getName()
+            << " is an input only module but cannot be inlined because signals "
+               "are referred by name";
+        return;
+      }
+  }
 
   // Get the instance graph node for the old module.
   hw::InstanceGraphNode *node = instanceGraph.lookup(oldMod);
@@ -454,6 +485,11 @@ static void inlineInputOnly(hw::HWModuleOp oldMod,
     hw::InstanceOp inst = cast<hw::InstanceOp>(instLike.getOperation());
     if (inst.getInnerSym().has_value()) {
       allInlined = false;
+      auto diag =
+          oldMod.emitWarning()
+          << "module " << oldMod.getName()
+          << " cannot be inlined because there is an instance with a symbol";
+      diag.attachNote(inst.getLoc());
       continue;
     }
 
@@ -470,10 +506,23 @@ static void inlineInputOnly(hw::HWModuleOp oldMod,
     hw::InstanceGraphNode *instParentNode = instanceGraph.lookup(instParent);
     SmallVector<Operation *, 16> lateBoundOps;
     b.setInsertionPoint(inst);
+    // Namespace that tracks inner symbols in the parent module.
+    hw::ModuleNamespace nameSpace(instParent);
+    // A map from old inner symbols to new ones.
+    DenseMap<mlir::StringAttr, mlir::StringAttr> symMapping;
+
     for (auto &op : *oldMod.getBodyBlock()) {
       // If the op was erased by instance extraction, don't copy it over.
       if (opsToErase.contains(&op))
         continue;
+
+      // If the op has an inner sym, first create a new inner sym for it.
+      if (auto innerSym = op.getAttrOfType<StringAttr>("inner_sym")) {
+        auto newName = b.getStringAttr(nameSpace.newName(innerSym.getValue()));
+        auto result = symMapping.insert({innerSym, newName});
+        (void)result;
+        assert(result.second && "inner symbols must be unique");
+      }
 
       // For instances in the bind table, update the bind with the new parent.
       if (auto innerInst = dyn_cast<hw::InstanceOp>(op)) {
@@ -482,9 +531,19 @@ static void inlineInputOnly(hw::HWModuleOp oldMod,
           if (it != bindTable[oldMod.getNameAttr()].end()) {
             sv::BindOp bind = it->second;
             auto oldInnerRef = bind.getInstanceAttr();
-            auto newInnerRef = hw::InnerRefAttr::get(
-                instParent.moduleNameAttr(), oldInnerRef.getName());
-            bind.setInstanceAttr(newInnerRef);
+            auto it = symMapping.find(oldInnerRef.getName());
+            assert(it != symMapping.end() &&
+                   "inner sym mapping must be already populated");
+            auto newName = it->second;
+            auto newInnerRef =
+                hw::InnerRefAttr::get(instParent.getNameAttr(), newName);
+            OpBuilder::InsertionGuard g(b);
+            // Clone bind operations.
+            b.setInsertionPoint(bind);
+            sv::BindOp clonedBind = cast<sv::BindOp>(b.clone(*bind, mapping));
+            clonedBind.setInstanceAttr(newInnerRef);
+            bindTable[instParent.getNameAttr()][newName] =
+                cast<sv::BindOp>(clonedBind);
           }
         }
       }
@@ -504,6 +563,10 @@ static void inlineInputOnly(hw::HWModuleOp oldMod,
               instanceGraph.lookup(innerInst.getModuleNameAttr().getAttr());
           instParentNode->addInstance(innerInst, innerInstModule);
         }
+
+        // If the op has an inner sym, then attach an updated inner sym.
+        if (auto innerSym = op.getAttrOfType<StringAttr>("inner_sym"))
+          clonedOp->setAttr("inner_sym", symMapping[innerSym]);
       }
     }
 
@@ -518,6 +581,10 @@ static void inlineInputOnly(hw::HWModuleOp oldMod,
 
   // If all instances were inlined, remove the module.
   if (allInlined) {
+    // Erase old bind statements.
+    for (auto [_, bind] : bindTable[oldMod.getNameAttr()])
+      bind.erase();
+    bindTable[oldMod.getNameAttr()].clear();
     instanceGraph.erase(node);
     opsToErase.insert(oldMod);
   }
@@ -646,6 +713,21 @@ void SVExtractTestCodeImplPass::runOnOperation() {
   this->instanceGraph = &getAnalysis<circt::hw::InstanceGraph>();
 
   auto top = getOperation();
+
+  // It takes extra effort to inline modules which contains inner symbols
+  // referred through hierpaths or unknown operations since we have to update
+  // inner refs users globally. However we do want to inline modules which
+  // contain bound instances so create a set of inner refs used by non bind op
+  // in order to allow bind ops.
+  DenseSet<hw::InnerRefAttr> innerRefUsedByNonBindOp;
+  top.walk([&](Operation *op) {
+    if (!isa<sv::BindOp>(op))
+      for (auto attr : op->getAttrs())
+        attr.getValue().walk([&](hw::InnerRefAttr attr) {
+          innerRefUsedByNonBindOp.insert(attr);
+        });
+  });
+
   auto *topLevelModule = top.getBody();
   auto assertDir =
       top->getAttrOfType<hw::OutputFileAttr>("firrtl.extract.assert");
@@ -738,7 +820,8 @@ void SVExtractTestCodeImplPass::runOnOperation() {
 
       // Inline any modules that only have inputs for test code.
       if (!disableModuleInlining && anyThingExtracted)
-        inlineInputOnly(rtlmod, *instanceGraph, bindTable, opsToErase);
+        inlineInputOnly(rtlmod, *instanceGraph, bindTable, opsToErase,
+                        innerRefUsedByNonBindOp);
 
       // Erase any instances that were extracted, and their forward dataflow.
       // Also erase old instances that were inlined and can now be cleaned up.

--- a/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
@@ -115,7 +115,8 @@ circuit Foo:
     ; CHECK-NEXT:   assert__verif_library_1: assert property (@(posedge clock) [[TMP4]])
     ; CHECK-SAME:     else $error("Assertion failed (verification library): Conditional compilation example for UNR-only assert");
     ; CHECK-NEXT:   `ifdef USE_PROPERTY_AS_CONSTRAINT
-    ; CHECK-NEXT:     assume__verif_library_1: assume property (@(posedge clock) [[TMP4]]);
+    ; CHECK-NEXT:     always @(edge [[TMP4]])
+    ; CHECK-NEXT:       assume__verif_library_1: assume([[TMP4]]);
     ; CHECK-NEXT:   `endif
     when not(or(predicate8, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"}],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): Conditional compilation example for UNR-only assert\"}</extraction-summary> bar")
@@ -144,7 +145,8 @@ circuit Foo:
     ; CHECK-NEXT:     assert__verif_library_2: assert property (@(posedge clock) [[TMP5]])
     ; CHECK-SAME:       else $error("Assertion failed (verification library): Conditional compilation example for UNR-only and formal-only assert");
     ; CHECK-NEXT:     `ifdef USE_PROPERTY_AS_CONSTRAINT
-    ; CHECK-NEXT:       assume__verif_library_2: assume property (@(posedge clock) [[TMP5]]);
+    ; CHECK-NEXT:       always @(edge [[TMP5]])
+    ; CHECK-NEXT:         assume__verif_library_2: assume([[TMP5]]);
     ; CHECK-NEXT:     `endif
     ; CHECK-NEXT:   `endif
     ; CHECK-NEXT: `endif

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -385,3 +385,54 @@ module attributes {
     }
   }
 }
+
+// -----
+// Check that input only modules are inlined properly.
+
+module {
+  // @ShouldNotBeInlined cannot be inlined because there is a wire with an inner sym
+  // that is referred by hierpath op.
+  hw.hierpath private @Foo [@ShouldNotBeInlined::@foo]
+  hw.module private @ShouldNotBeInlined(%clock: i1, %a: i1) {
+    %w = sv.wire sym @foo: !hw.inout<i1>
+    sv.always posedge %clock {
+      sv.if %a {
+        sv.assert %a, immediate message "foo"
+      }
+    }
+    hw.output
+  }
+  hw.module private @Assert(%clock: i1, %a: i1) {
+    sv.always posedge %clock {
+      sv.if %a {
+        sv.assert %a, immediate message "foo"
+      }
+    }
+    hw.output
+  }
+
+  // CHECK-LABEL: hw.module private @AssertWrapper(%clock: i1, %a: i1) -> (b: i1) {
+  // CHECK:  hw.instance "Assert_assert" sym @__ETC_Assert_assert @Assert_assert
+  // CHECK-SAME:  doNotPrint = true
+  hw.module private @AssertWrapper(%clock: i1, %a: i1) -> (b: i1) {
+    hw.instance "a3" @Assert(clock: %clock: i1, a: %a: i1) -> ()
+    hw.output %a: i1
+  }
+
+  // CHECK-LABEL: hw.module @Top(%clock: i1, %a: i1, %b: i1) {
+  // CHECK:  hw.instance "Assert_assert" sym @__ETC_Assert_assert_0 @Assert_assert
+  // CHECK-SAME:  doNotPrint = true
+  // CHECK:  hw.instance "Assert_assert" sym @__ETC_Assert_assert @Assert_assert
+  // CHECK-SAME:  doNotPrint = true
+  // CHECK:  hw.instance "should_not_be_inlined" @ShouldNotBeInlined
+  // CHECK-NOT: doNotPrint
+  hw.module @Top(%clock: i1, %a: i1, %b: i1) {
+    hw.instance "a1" @Assert(clock: %clock: i1, a: %a: i1) -> ()
+    hw.instance "a2" @Assert(clock: %clock: i1, a: %b: i1) -> ()
+    hw.instance "should_not_be_inlined" @ShouldNotBeInlined (clock: %clock: i1, a: %b: i1) -> ()
+    hw.output
+  }
+  // CHECK:       sv.bind <@Top::@__ETC_Assert_assert>
+  // CHECK-NEXT:  sv.bind <@Top::@__ETC_Assert_assert_0>
+  // CHECK-NEXT:  sv.bind <@AssertWrapper::@__ETC_Assert_assert>
+}


### PR DESCRIPTION
This PR adds two commits to 1.37 release branch.

* https://github.com/llvm/circt/pull/5679
* https://github.com/llvm/circt/pull/5561