### PR TITLE
[FIRRTL][LowerXMR] Always insert nodes for probes, don't block opts.

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -243,12 +243,12 @@ circuit Top :
     ; EXTRACT-NEXT:          .[[in_vecOfBundle_1_uint_port:[a-zA-Z0-9_]+]]               (in_vecOfBundle_1_uint),
     ; EXTRACT-NEXT:          .[[in_otherOther_other_sint_port:[a-zA-Z0-9_]+]]            (in_otherOther_other_sint),
     ; EXTRACT-NEXT:          .[[in_otherOther_other_uint_port:[a-zA-Z0-9_]+]]            (in_otherOther_other_uint),
-    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vec_0_port:[a-zA-Z0-9_]+]]              (DUT.submodule.in_vec_0),
-    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vec_1_port:[a-zA-Z0-9_]+]]              (DUT.submodule.in_vec_1),
-    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_0_sint_port:[a-zA-Z0-9_]+]] (DUT.submodule.in_vecOfBundle_0_sint),
-    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_0_uint_port:[a-zA-Z0-9_]+]] (DUT.submodule.in_vecOfBundle_0_uint),
-    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_1_sint_port:[a-zA-Z0-9_]+]] (DUT.submodule.in_vecOfBundle_1_sint),
-    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_1_uint_port:[a-zA-Z0-9_]+]] (DUT.submodule.in_vecOfBundle_1_uint),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vec_0_port:[a-zA-Z0-9_]+]]              (DUT.submodule.in_vec_0_probe),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vec_1_port:[a-zA-Z0-9_]+]]              (DUT.submodule.in_vec_1_probe),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_0_sint_port:[a-zA-Z0-9_]+]] (DUT.submodule.in_vecOfBundle_0_sint_probe),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_0_uint_port:[a-zA-Z0-9_]+]] (DUT.submodule.in_vecOfBundle_0_uint_probe),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_1_sint_port:[a-zA-Z0-9_]+]] (DUT.submodule.in_vecOfBundle_1_sint_probe),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_1_uint_port:[a-zA-Z0-9_]+]] (DUT.submodule.in_vecOfBundle_1_uint_probe),
     ; EXTRACT-NEXT:          .[[ExtModuleWithPort_source_1_port:[a-zA-Z0-9_]+]]          ([[ExtModuleWithPort_source_1_wire:[a-zA-Z0-9_]+]])
     ; EXTRACT-NEXT:        );
     ; EXTRACT-NEXT:     */
@@ -268,12 +268,12 @@ circuit Top :
     ; NOEXTRACT-NEXT:        .[[DUT_w_vecOfBundle_1_uint]]                 (w_vecOfBundle_1_uint),
     ; NOEXTRACT-NEXT:        .[[DUT_w_otherOther_other_sint]]              (w_otherOther_other_sint),
     ; NOEXTRACT-NEXT:        .[[DUT_w_otherOther_other_uint]]              (w_otherOther_other_uint),
-    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vec_0]]                    (DUT.submodule.w_vec_0),
-    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vec_1]]                    (DUT.submodule.w_vec_1),
-    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vecOfBundle_0_sint]]       (DUT.submodule.w_vecOfBundle_0_sint),
-    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vecOfBundle_0_uint]]       (DUT.submodule.w_vecOfBundle_0_uint),
-    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vecOfBundle_1_sint]]       (DUT.submodule.w_vecOfBundle_1_sint),
-    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vecOfBundle_1_uint]]       (DUT.submodule.w_vecOfBundle_1_uint)
+    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vec_0]]                    (DUT.submodule.w_vec_0_probe),
+    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vec_1]]                    (DUT.submodule.w_vec_1_probe),
+    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vecOfBundle_0_sint]]       (DUT.submodule.w_vecOfBundle_0_sint_probe),
+    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vecOfBundle_0_uint]]       (DUT.submodule.w_vecOfBundle_0_uint_probe),
+    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vecOfBundle_1_sint]]       (DUT.submodule.w_vecOfBundle_1_sint_probe),
+    ; NOEXTRACT-NEXT:        .[[DUT_submodule_w_vecOfBundle_1_uint]]       (DUT.submodule.w_vecOfBundle_1_uint_probe)
     ; NOEXTRACT-NEXT:        .[[ExtModuleWithPort_source_1:[a-zA-Z0-9_]+]] ([[ExtModuleWithPort_source_1_wire:[a-zA-Z0-9_]+]])
     ; NOEXTRACT-NEXT:      );
 
@@ -344,12 +344,12 @@ circuit Top :
     ; EXTRACT-NEXT:          .[[in_vecOfBundle_1_uint_port]]               (in_vecOfBundle_1_uint),
     ; EXTRACT-NEXT:          .[[in_otherOther_other_sint_port]]            (in_otherOther_other_sint),
     ; EXTRACT-NEXT:          .[[in_otherOther_other_uint_port]]            (in_otherOther_other_uint),
-    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vec_0_port]]              (DUT.submodule.in_vec_0),
-    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vec_1_port]]              (DUT.submodule.in_vec_1),
-    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_0_sint_port]] (DUT.submodule.in_vecOfBundle_0_sint),
-    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_0_uint_port]] (DUT.submodule.in_vecOfBundle_0_uint),
-    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_1_sint_port]] (DUT.submodule.in_vecOfBundle_1_sint),
-    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_1_uint_port]] (DUT.submodule.in_vecOfBundle_1_uint),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vec_0_port]]              (DUT.submodule.in_vec_0_probe),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vec_1_port]]              (DUT.submodule.in_vec_1_probe),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_0_sint_port]] (DUT.submodule.in_vecOfBundle_0_sint_probe),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_0_uint_port]] (DUT.submodule.in_vecOfBundle_0_uint_probe),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_1_sint_port]] (DUT.submodule.in_vecOfBundle_1_sint_probe),
+    ; EXTRACT-NEXT:          .[[DUT_submodule_in_vecOfBundle_1_uint_port]] (DUT.submodule.in_vecOfBundle_1_uint_probe),
     ; EXTRACT-NEXT:          .[[ExtModuleWithPort_source_1_port]]          ([[ExtModuleWithPort_source_1_wire]])
     ; );
     ; NOEXTRACT-NOT:  FILE "Wire{{[/\]}}firrtl{{[/\]}}bindings.sv"

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
@@ -111,7 +111,7 @@ circuit Top : %[[
 
 ; CHECK-LABEL: module Top(
 ; CHECK-NOT:   endmodule
-; CHECK:         tap = Top.foo.b.inv;
+; CHECK:         tap = Top.foo.b.inv_probe;
 ; CHECK-NEXT:    tap2 = Top.unsigned_0.signed_0.localparam_0.random.something;
 ; CHECK-NEXT:    tap3 = Top.unsigned_0.signed_0.localparam_0.random.something_else;
 ; CHECK:         ChildWrapper unsigned_0 (

--- a/test/Dialect/FIRRTL/SFCTests/data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps.fir
@@ -200,8 +200,8 @@ circuit Top : %[[
     io.d <= d
 
     ; CHECK:      module Top
-    ; CHECK:        io_b = Top.foo.f;
-    ; CHECK-NEXT:   io_c = Top.foo.g;
+    ; CHECK:        io_b = Top.foo.f_probe;
+    ; CHECK-NEXT:   io_c = Top.foo.g_probe;
     ; CHECK-NEXT:   io_d = inv;
 
 ; // -----
@@ -246,7 +246,7 @@ circuit TestHarness : %[[
 ; CHECK:       module Top(
 ; CHECK-NOT:   endmodule
 ; CHECK:         Companion Companion (
-; CHECK-NEXT:    .[[bore:[a-zA-Z0-9_]+]] (Top.test.signal)
+; CHECK-NEXT:    .[[bore:[a-zA-Z0-9_]+]] (Top.test.signal_probe)
 ; CHECK:       endmodule
 
 ; CHECK:       module Companion(
@@ -495,7 +495,7 @@ circuit Top : %[[
 ; CHECK-NEXT:          [[Submodule_tap_2_port:[a-zA-Z0-9_]+]]
 ; CHECK-NEXT:          [[Submodule_tap_5_port:[a-zA-Z0-9_]+]]
 ;
-; CHECK-DAG:     tap_0 = wire_Submodule;
+; CHECK-DAG:     tap_0 = inv;
 ; CHECK-DAG:     tap_1 = [[Submodule_tap_1_port]];
 ; CHECK-DAG:     tap_2 = [[Submodule_tap_2_port]];
 ; CHECK-DAG:     tap_3 = 1'h0;
@@ -508,15 +508,15 @@ circuit Top : %[[
 ; CHECK-NEXT:          [[DUT_tap_8_port:[a-zA-Z0-9_]+]]
 ; CHECK-NEXT:          [[DUT_tap_11_port:[a-zA-Z0-9_]+]]
 ;
-; CHECK-DAG:     tap_6 = DUT.submodule.wire_Submodule;
-; CHECK-DAG:     tap_7 = wire_DUT;
+; CHECK-DAG:     tap_6 = DUT.submodule.wire_Submodule_probe;
+; CHECK-DAG:     tap_7 = inv;
 ; CHECK-DAG:     tap_8 = [[DUT_tap_8_port]];
 ; CHECK-DAG:     tap_9 = 1'h0;
 ; CHECK-DAG:     tap_10 = 1'h0;
 ; CHECK-DAG:     tap_11 = [[DUT_tap_11_port]];
 ;
 ; CHECK:         Submodule submodule (
-; CHECK-DAG:       .[[Submodule_tap_1_port]] (wire_DUT)
+; CHECK-DAG:       .[[Submodule_tap_1_port]] (inv)
 ; CHECK-DAG:       .[[Submodule_tap_2_port]] ([[DUT_tap_2_port]])
 ; CHECK-DAG:       .[[Submodule_tap_5_port]] ([[DUT_tap_5_port]])
 

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
@@ -54,12 +54,12 @@ circuit Top : %[[
 
 ; CHECK:      module Top(
 ; CHECK-NOT:  module
-; CHECK:        wire [7:0] memTap_0 = Top.dut.rf_0;
-; CHECK-NEXT:   wire [7:0] memTap_1 = Top.dut.rf_1;
-; CHECK-NEXT:   wire [7:0] memTap_2 = Top.dut.rf_2;
-; CHECK-NEXT:   wire [7:0] memTap_3 = Top.dut.rf_3;
-; CHECK-NEXT:   wire [7:0] memTap_4 = Top.dut.rf_4;
-; CHECK-NEXT:   wire [7:0] memTap_5 = Top.dut.rf_5;
-; CHECK-NEXT:   wire [7:0] memTap_6 = Top.dut.rf_6;
-; CHECK-NEXT:   wire [7:0] memTap_7 = Top.dut.rf_7;
+; CHECK:        wire [7:0] memTap_0 = Top.dut.rf_0_probe;
+; CHECK-NEXT:   wire [7:0] memTap_1 = Top.dut.rf_1_probe;
+; CHECK-NEXT:   wire [7:0] memTap_2 = Top.dut.rf_2_probe;
+; CHECK-NEXT:   wire [7:0] memTap_3 = Top.dut.rf_3_probe;
+; CHECK-NEXT:   wire [7:0] memTap_4 = Top.dut.rf_4_probe;
+; CHECK-NEXT:   wire [7:0] memTap_5 = Top.dut.rf_5_probe;
+; CHECK-NEXT:   wire [7:0] memTap_6 = Top.dut.rf_6_probe;
+; CHECK-NEXT:   wire [7:0] memTap_7 = Top.dut.rf_7_probe;
 ; CHECK:      endmodule

--- a/test/firtool/export-ref.fir
+++ b/test/firtool/export-ref.fir
@@ -1,9 +1,9 @@
 ; RUN: firtool %s -split-verilog -o %t
 ; RUN: cat %t/ref_Top_Top.sv | FileCheck %s
 
-; CHECK:      `define ref_Top_Top_direct_probe direct
-; CHECK-NEXT: `define ref_Top_Top_inner_probe inner.x
-; CHECK-NEXT: `define ref_Top_Top_keyword_probe always_0
+; CHECK:      `define ref_Top_Top_direct_probe direct_probe
+; CHECK-NEXT: `define ref_Top_Top_inner_probe inner.x_probe
+; CHECK-NEXT: `define ref_Top_Top_keyword_probe always_probe
 
 FIRRTL version 3.0.0
 circuit Top:


### PR DESCRIPTION
Reading a value shouldn't cause it to be blocked,
there are other mechanisms for that.

Split dataflow for read-only probes into dedicated nodes.

Try to name through indexing operations,
fallback to current strategy of "name".

Append "_probe" so if/when there's a conflict
it's clear what's going on (vs "_0").