### PR TITLE
[FIRRTL] Use symbols in ResolveTraces verbatims

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -72,6 +72,69 @@ struct AnnoPathValue {
   }
 };
 
+template <typename T>
+static T &operator<<(T &os, const AnnoPathValue &path) {
+  os << "~" << path.ref.getModule()->getParentOfType<CircuitOp>().getName()
+     << "|";
+
+  if (path.isLocal()) {
+    os << path.ref.getModule().getModuleName();
+  } else {
+    os << path.instances.front()
+              ->getParentOfType<FModuleLike>()
+              .getModuleName();
+  }
+  for (auto inst : path.instances)
+    os << "/" << inst.getName() << ":" << inst.getModuleName();
+  if (!path.isOpOfType<FModuleOp, FExtModuleOp, InstanceOp>()) {
+    os << ">" << path.ref;
+    auto type = dyn_cast<FIRRTLBaseType>(path.ref.getType());
+    if (!type)
+      return os;
+    auto targetFieldID = path.fieldIdx;
+    while (targetFieldID) {
+      FIRRTLTypeSwitch<FIRRTLBaseType>(type)
+          .Case<FVectorType>([&](FVectorType vector) {
+            auto index = vector.getIndexForFieldID(targetFieldID);
+            os << "[" << index << "]";
+            type = vector.getElementType();
+            targetFieldID -= vector.getFieldID(index);
+          })
+          .template Case<BundleType>([&](BundleType bundle) {
+            auto index = bundle.getIndexForFieldID(targetFieldID);
+            os << "." << bundle.getElementName(index);
+            type = bundle.getElementType(index);
+            targetFieldID -= bundle.getFieldID(index);
+          })
+          .Default([&](auto) { targetFieldID = 0; });
+    }
+  }
+  return os;
+}
+
+template <typename T>
+static T &operator<<(T &os, const OpAnnoTarget &target) {
+  os << target.getOp()->getAttrOfType<StringAttr>("name").getValue();
+  return os;
+}
+
+template <typename T>
+static T &operator<<(T &os, const PortAnnoTarget &target) {
+  os << target.getModule().getPortName(target.getPortNo());
+  return os;
+}
+
+template <typename T>
+static T &operator<<(T &os, const AnnoTarget &target) {
+  if (auto op = target.dyn_cast<OpAnnoTarget>())
+    os << op;
+  else if (auto port = target.dyn_cast<PortAnnoTarget>())
+    os << port;
+  else
+    os << "<<Unknown Anno Target>>";
+  return os;
+}
+
 /// Cache AnnoTargets for a module's named things.
 struct AnnoTargetCache {
   AnnoTargetCache() = delete;

--- a/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
@@ -75,49 +75,103 @@ private:
   /// runOnOperation.
   NLATable *nlaTable;
 
-  /// Internal implementation that updates an Annotation to add a "target" field
-  /// based on the current location of the annotation in the circuit.  The value
-  /// of the "target" will be a local target if the Annotation is local and a
-  /// non-local target if the Annotation is non-local.
-  bool updateTargetImpl(Annotation &anno, FModuleLike &module,
-                        FIRRTLBaseType type, StringRef name) {
-    if (!anno.isClass(traceAnnoClass))
-      return false;
+  /// Stores a pointer to an inner symbol table collection.
+  hw::InnerSymbolTableCollection *istc;
 
-    LLVM_DEBUG(llvm::dbgs() << "  - before: " << anno.getDict() << "\n");
+  /// Global symbol index used for substitutions, e.g., "{{42}}".  This value is
+  /// the _next_ index that will be used.
+  unsigned symbolIdx = 0;
 
-    SmallString<64> newTarget("~");
-    newTarget.append(module->getParentOfType<CircuitOp>().getName());
+  /// Map of symbol to symbol index.  This is used to reuse symbol
+  /// substitutions.
+  DenseMap<Attribute, unsigned> symbolMap;
+
+  /// Symbol substitutions for the JSON verbatim op.
+  SmallVector<Attribute> symbols;
+
+  /// Get a symbol index and update symbol datastructures.
+  unsigned getSymbolIndex(Attribute attr) {
+    auto iterator = symbolMap.find(attr);
+    if (iterator != symbolMap.end())
+      return iterator->getSecond();
+
+    auto idx = symbolIdx++;
+    symbolMap.insert({attr, idx});
+    symbols.push_back(attr);
+
+    return idx;
+  }
+
+  /// Convert an annotation path to a string with symbol substitutions.
+  void buildTarget(AnnoPathValue &path, SmallString<64> &newTarget) {
+
+    auto addSymbol = [&](Attribute attr) -> void {
+      newTarget.append("{{");
+      newTarget.append(std::to_string(getSymbolIndex(attr)));
+      newTarget.append("}}");
+    };
+
+    newTarget.append("~");
+    newTarget.append(
+        path.ref.getModule()->getParentOfType<CircuitOp>().getName());
     newTarget.append("|");
 
-    if (auto nla = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal")) {
-      hw::HierPathOp path = nlaTable->getNLA(nla.getAttr());
-      for (auto part : path.getNamepath().getValue().drop_back()) {
-        auto inst = cast<hw::InnerRefAttr>(part);
-        newTarget.append(inst.getModule());
-        newTarget.append("/");
-        newTarget.append(inst.getName());
-        newTarget.append(":");
-      }
+    if (path.isLocal()) {
+      addSymbol(
+          FlatSymbolRefAttr::get(path.ref.getModule().getModuleNameAttr()));
+    } else {
+      addSymbol(FlatSymbolRefAttr::get(path.instances.front()
+                                           ->getParentOfType<FModuleLike>()
+                                           .getModuleNameAttr()));
     }
-    newTarget.append(module.getModuleName());
+
+    for (auto inst : path.instances) {
+      newTarget.append("/");
+      addSymbol(hw::InnerRefAttr::get(
+          inst->getParentOfType<FModuleLike>().getModuleNameAttr(),
+          inst.getInnerSymAttr().getSymName()));
+      newTarget.append(":");
+      addSymbol(inst.getModuleNameAttr());
+    }
+
+    // If this targets a module or an instance, then we're done.  There is no
+    // "reference" part of the FIRRTL target.
+    if (path.ref.isa<OpAnnoTarget>() &&
+        path.isOpOfType<FModuleOp, FExtModuleOp, InstanceOp>())
+      return;
+
     newTarget.append(">");
+    auto innerSym =
+        TypeSwitch<AnnoTarget, hw::InnerSymAttr>(path.ref)
+            .Case<PortAnnoTarget>([&](PortAnnoTarget portTarget) {
+              return portTarget.getModule().getPortSymbolAttr(
+                  portTarget.getPortNo());
+            })
+            .Case<OpAnnoTarget>([&](OpAnnoTarget opTarget) {
+              return opTarget.getOp()->getAttrOfType<hw::InnerSymAttr>(
+                  "inner_sym");
+            })
+            .Default([](auto) {
+              assert(false && "unexpected annotation target type");
+              return hw::InnerSymAttr{};
+            });
+    addSymbol(hw::InnerRefAttr::get(path.ref.getModule().getModuleNameAttr(),
+                                    innerSym.getSymName()));
 
-    newTarget.append(name);
-
-    // Add information if this is an aggregate.
-    auto targetFieldID = anno.getFieldID();
+    auto type = dyn_cast<FIRRTLBaseType>(path.ref.getType());
+    assert(type && "expected a FIRRTLBaseType");
+    auto targetFieldID = path.fieldIdx;
     while (targetFieldID) {
       FIRRTLTypeSwitch<FIRRTLBaseType>(type)
           .Case<FVectorType>([&](FVectorType vector) {
             auto index = vector.getIndexForFieldID(targetFieldID);
             newTarget.append("[");
-            newTarget.append(Twine(index).str());
+            newTarget.append(std::to_string(index));
             newTarget.append("]");
             type = vector.getElementType();
             targetFieldID -= vector.getFieldID(index);
           })
-          .Case<BundleType>([&](BundleType bundle) {
+          .template Case<BundleType>([&](BundleType bundle) {
             auto index = bundle.getIndexForFieldID(targetFieldID);
             newTarget.append(".");
             newTarget.append(bundle.getElementName(index));
@@ -126,30 +180,57 @@ private:
           })
           .Default([&](auto) { targetFieldID = 0; });
     }
+  }
 
-    anno.setMember("target", StringAttr::get(module->getContext(), newTarget));
+  /// Internal implementation that updates an Annotation to add a "target" field
+  /// based on the current location of the annotation in the circuit.  The value
+  /// of the "target" will be a local target if the Annotation is local and a
+  /// non-local target if the Annotation is non-local.
+  AnnoPathValue updateTargetImpl(Annotation &anno, FModuleLike &module,
+                                 FIRRTLBaseType type, hw::InnerRefAttr name,
+                                 AnnoTarget target) {
+    SmallString<64> newTarget("~");
+    newTarget.append(module->getParentOfType<CircuitOp>().getName());
+    newTarget.append("|");
 
-    LLVM_DEBUG(llvm::dbgs() << "    after:  " << anno.getDict() << "\n");
+    SmallVector<InstanceOp> instances;
 
-    return true;
+    if (auto nla = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal")) {
+      hw::HierPathOp path = nlaTable->getNLA(nla.getAttr());
+      for (auto part : path.getNamepath().getValue().drop_back()) {
+        auto inst = cast<hw::InnerRefAttr>(part);
+        instances.push_back(dyn_cast<InstanceOp>(
+            istc->getInnerSymbolTable(nlaTable->getModule(inst.getModule()))
+                .lookupOp(inst.getName())));
+      }
+    }
+
+    AnnoPathValue path(instances, target, anno.getFieldID());
+
+    return path;
   }
 
   /// Add a "target" field to a port Annotation that indicates the current
   /// location of the port in the circuit.
-  bool updatePortTarget(FModuleLike &module, Annotation &anno,
-                        unsigned portIdx) {
+  std::optional<AnnoPathValue>
+  updatePortTarget(FModuleLike &module, Annotation &anno, unsigned portIdx) {
     auto type = getBaseType(type_cast<FIRRTLType>(module.getPortType(portIdx)));
-    return updateTargetImpl(anno, module, type, module.getPortName(portIdx));
+    return updateTargetImpl(
+        anno, module, type,
+        hw::InnerRefAttr::get(module.getModuleNameAttr(),
+                              module.getPortSymbolAttr(portIdx).getSymName()),
+        PortAnnoTarget(module, portIdx));
   }
 
   /// Add a "target" field to an Annotation that indicates the current location
   /// of a component in the circuit.
-  bool updateTarget(FModuleLike &module, Operation *op, Annotation &anno) {
+  std::optional<AnnoPathValue> updateTarget(FModuleLike &module, Operation *op,
+                                            Annotation &anno) {
 
     // If this operation doesn't have a name, then do nothing.
-    StringAttr name = op->getAttrOfType<StringAttr>("name");
-    if (!name)
-      return false;
+    auto innerSym = op->getAttrOfType<hw::InnerSymAttr>("inner_sym");
+    if (!innerSym)
+      return std::nullopt;
 
     // Get the type of the operation either by checking for the
     // result targeted by symbols on it (which are used to track the op)
@@ -160,59 +241,53 @@ private:
       type = is.getTargetResult().getType();
     else {
       if (op->getNumResults() != 1)
-        return false;
+        return std::nullopt;
       type = op->getResultTypes().front();
     }
 
     auto baseType = getBaseType(type_cast<FIRRTLType>(type));
-    return updateTargetImpl(anno, module, baseType, name);
+    return updateTargetImpl(anno, module, baseType,
+                            hw::InnerRefAttr::get(module.getModuleNameAttr(),
+                                                  innerSym.getSymName()),
+                            OpAnnoTarget(op));
   }
 
   /// Add a "target" field to an Annotation on a Module that indicates the
   /// current location of the module.  This will be local or non-local depending
   /// on the Annotation.
-  bool updateModuleTarget(FModuleLike &module, Annotation &anno) {
-
-    if (!anno.isClass(traceAnnoClass))
-      return false;
-
-    LLVM_DEBUG(llvm::dbgs() << "  - before: " << anno.getDict() << "\n");
-
-    SmallString<64> newTarget("~");
-    newTarget.append(module->getParentOfType<CircuitOp>().getName());
-    newTarget.append("|");
+  std::optional<AnnoPathValue> updateModuleTarget(FModuleLike &module,
+                                                  Annotation &anno) {
+    SmallVector<InstanceOp> instances;
 
     if (auto nla = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal")) {
       hw::HierPathOp path = nlaTable->getNLA(nla.getAttr());
       for (auto part : path.getNamepath().getValue().drop_back()) {
         auto inst = cast<hw::InnerRefAttr>(part);
-        newTarget.append(inst.getModule());
-        newTarget.append("/");
-        newTarget.append(inst.getName());
-        newTarget.append(":");
+        instances.push_back(cast<InstanceOp>(
+            istc->getInnerSymbolTable(nlaTable->getModule(inst.getModule()))
+                .lookupOp(inst.getName())));
       }
     }
-    newTarget.append(module.getModuleName());
 
-    anno.setMember("target", StringAttr::get(module->getContext(), newTarget));
+    AnnoPathValue path(instances, OpAnnoTarget(module), 0);
 
-    LLVM_DEBUG(llvm::dbgs() << "    after:  " << anno.getDict() << "\n");
-
-    return true;
+    return path;
   }
 };
 
 void ResolveTracesPass::runOnOperation() {
   LLVM_DEBUG(
       llvm::dbgs() << "==----- Running ResolveTraces "
-                      "-----------------------------------------------===\n");
-
-  // Populate the NLA Table.
-  nlaTable = &getAnalysis<NLATable>();
+                      "-----------------------------------------------===\n"
+                   << "Annotation Modifications:\n");
 
   // Grab the circuit (as this is used a few times below).
   CircuitOp circuit = getOperation();
   MLIRContext *context = circuit.getContext();
+
+  // Populate pointer datastructures.
+  nlaTable = &getAnalysis<NLATable>();
+  istc = &getAnalysis<hw::InnerSymbolTableCollection>();
 
   // Function to find all Trace Annotations in the circuit, add a "target" field
   // to them indicating the current local/non-local target of the operation/port
@@ -223,7 +298,7 @@ void ResolveTracesPass::runOnOperation() {
   // later optimization.
   auto onModule = [&](FModuleLike moduleLike) {
     // Output Trace Annotations from this module only.
-    SmallVector<Annotation> outputAnnotations;
+    SmallVector<std::pair<Annotation, AnnoPathValue>> outputAnnotations;
 
     // A lazily constructed module namespace.
     std::optional<ModuleNamespace> moduleNamespace;
@@ -237,32 +312,46 @@ void ResolveTracesPass::runOnOperation() {
 
     // Visit the module.
     AnnotationSet::removeAnnotations(moduleLike, [&](Annotation anno) {
-      if (!updateModuleTarget(moduleLike, anno))
+      if (!anno.isClass(traceAnnoClass))
         return false;
 
-      outputAnnotations.push_back(anno);
+      auto path = updateModuleTarget(moduleLike, anno);
+      if (!path)
+        return false;
+
+      outputAnnotations.push_back({anno, *path});
       return true;
     });
 
     // Visit port annotations.
     AnnotationSet::removePortAnnotations(
         moduleLike, [&](unsigned portIdx, Annotation anno) {
-          if (!updatePortTarget(moduleLike, anno, portIdx))
+          if (!anno.isClass(traceAnnoClass))
             return false;
 
           getOrAddInnerSym(moduleLike, portIdx, getNamespace);
-          outputAnnotations.push_back(anno);
+
+          auto path = updatePortTarget(moduleLike, anno, portIdx);
+          if (!path)
+            return false;
+
+          outputAnnotations.push_back({anno, *path});
           return true;
         });
 
     // Visit component annotations.
     moduleLike.walk([&](Operation *component) {
       AnnotationSet::removeAnnotations(component, [&](Annotation anno) {
-        if (!updateTarget(moduleLike, component, anno))
+        if (!anno.isClass(traceAnnoClass))
           return false;
 
         getOrAddInnerSym(component, getNamespace);
-        outputAnnotations.push_back(anno);
+
+        auto path = updateTarget(moduleLike, component, anno);
+        if (!path)
+          return false;
+
+        outputAnnotations.push_back({anno, *path});
         return true;
       });
     });
@@ -281,7 +370,8 @@ void ResolveTracesPass::runOnOperation() {
   // multithreading context.
   SmallVector<FModuleLike, 0> mods(circuit.getOps<FModuleLike>());
   auto outputAnnotations = transformReduce(
-      context, mods, SmallVector<Annotation>{}, appendVecs, onModule);
+      context, mods, SmallVector<std::pair<Annotation, AnnoPathValue>>{},
+      appendVecs, onModule);
 
   // Do not generate an output Annotation file if no Annotations exist.
   if (outputAnnotations.empty())
@@ -292,21 +382,37 @@ void ResolveTracesPass::runOnOperation() {
   llvm::raw_string_ostream jsonStream(jsonBuffer);
   llvm::json::OStream json(jsonStream, /*IndentSize=*/2);
   json.arrayBegin();
-  for (auto anno : outputAnnotations) {
+  for (auto &[anno, path] : outputAnnotations) {
     json.objectBegin();
     json.attribute("class", anno.getClass());
-    json.attribute("target", anno.getMember<StringAttr>("target").getValue());
+    SmallString<64> targetStr;
+    buildTarget(path, targetStr);
+    LLVM_DEBUG({
+      llvm::dbgs()
+          << "  - chiselTarget: "
+          << anno.getDict().getAs<StringAttr>("chiselTarget").getValue() << "\n"
+          << "    target:       " << targetStr << "\n"
+          << "    translated:   " << path << "\n";
+    });
+    json.attribute("target", targetStr);
     json.attribute("chiselTarget",
                    anno.getMember<StringAttr>("chiselTarget").getValue());
     json.objectEnd();
   }
   json.arrayEnd();
 
+  LLVM_DEBUG({
+    llvm::dbgs() << "Symbols:\n";
+    for (auto [id, symbol] : llvm::enumerate(symbols))
+      llvm::errs() << "  - " << id << ": " << symbol << "\n";
+  });
+
   // Write the JSON-encoded Trace Annotation to a file called
   // "$circuitName.anno.json".  (This is implemented via an SVVerbatimOp that is
   // inserted before the FIRRTL circuit.
-  OpBuilder b(circuit);
-  auto verbatimOp = b.create<sv::VerbatimOp>(b.getUnknownLoc(), jsonBuffer);
+  auto b = OpBuilder::atBlockBegin(circuit.getBodyBlock());
+  auto verbatimOp = b.create<sv::VerbatimOp>(
+      b.getUnknownLoc(), jsonBuffer, ValueRange{}, b.getArrayAttr(symbols));
   hw::OutputFileAttr fileAttr;
   if (this->outputAnnotationFilename.empty())
     fileAttr = hw::OutputFileAttr::getFromFilename(

--- a/test/Dialect/FIRRTL/SFCTests/trace-api.fir
+++ b/test/Dialect/FIRRTL/SFCTests/trace-api.fir
@@ -4,25 +4,33 @@
 circuit Foo: %[[
   {
     "class":"chisel3.experimental.Trace$TraceNameAnnotation",
-    "target":"~Foo|Foo/bar:Bar>_x",
-    "chiselTarget":"~Foo|Foo/bar:Bar>_x_v1"
+    "target":"~Foo|Foo/bar:Bar/baz:Baz>_x",
+    "chiselTarget":"~Foo|Foo/bar:Bar/baz:Baz>_x_v1"
   },
   {
     "class":"chisel3.experimental.Trace$TraceAnnotation",
-    "target":"~Foo|Foo/bar:Bar>_x",
-    "chiselTarget":"~Foo|Foo/bar:Bar>_x_v2"
+    "target":"~Foo|Foo/bar:Bar/baz:Baz>_x",
+    "chiselTarget":"~Foo|Foo/bar:Bar/baz:Baz>_x_v2"
   },
   {
     "class": "firrtl.passes.InlineAnnotation",
     "target": "~Foo|Bar"
   }
 ]]
-  module Bar:
+  module Baz:
     input a: UInt<1>
     output b: UInt<1>
 
     node _x = a
     b <= _x
+
+  module Bar:
+    input a: UInt<1>
+    output b: UInt<1>
+
+    inst baz of Baz
+    baz.a <= a
+    b <= baz.b
 
   module Foo:
     input a: UInt<1>
@@ -33,10 +41,14 @@ circuit Foo: %[[
     bar.a <= a
     b <= bar.b
 
+
 ; Wire "_x" should not be optimized away.
 ;
-; CHECK-LABEL: module Foo
+; CHECK-LABEL: module Baz
 ; CHECK:         wire [[_x:[A-Za-z0-9_]+]]
+
+; CHECK-LABEL: module Foo
+; CHECK:         Baz [[bar_baz:[a-zA-Z0-9_]+]]
 
 ; The final Annotation, in either the original TraceNameAnnotation or
 ; TraceAnnotation variant the wire name.  The former is serialized as a
@@ -46,8 +58,8 @@ circuit Foo: %[[
 ;
 ; CHECK-LABEL: FILE "Baz.anno.json"
 ; CHECK:         "class": "chisel3.experimental.Trace$TraceAnnotation",
-; CHECK-NEXT:    "target": "~Foo|Foo>[[_x]]",
-; CHECK-NEXT:    "chiselTarget": "~Foo|Foo/bar:Bar>_x_v1"
+; CHECK-NEXT:    "target": "~Foo|Foo/[[bar_baz]]:Baz>[[_x]]",
+; CHECK-NEXT:    "chiselTarget": "~Foo|Foo/bar:Bar/baz:Baz>_x_v1"
 ; CHECK:         "class": "chisel3.experimental.Trace$TraceAnnotation",
-; CHECK-NEXT:    "target": "~Foo|Foo>[[_x]]",
-; CHECK-NEXT:    "chiselTarget": "~Foo|Foo/bar:Bar>_x_v2"
+; CHECK-NEXT:    "target": "~Foo|Foo/[[bar_baz]]:Baz>[[_x]]",
+; CHECK-NEXT:    "chiselTarget": "~Foo|Foo/bar:Bar/baz:Baz>_x_v2"


### PR DESCRIPTION
Change the ResolveTraces pass to use symbols instead of hard-coded names. Previously, the pass used hard-coded names derived from the hierpath op symbols (which was mega-jank! I'm sorry!).  Correct all this by using symbols with substitutions.

Update the end-to-end test to use a test case which uncovered this error (because it uses an instance path).  Update the pass unit tests to use the new format.