### PR TITLE
[FIRRTL] Add ObjectOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -587,4 +587,41 @@ def ClockGateIntrinsicOp : FIRRTLOp<"int.clock_gate", [Pure]> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Property Ops
+//===----------------------------------------------------------------------===//
+
+def ObjectOp :  FIRRTLOp<"object", [
+    ParentOneOf<["firrtl::FModuleOp, firrtl::ClassOp"]>,
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+]> {
+  let summary = "Instantiate a class to produce an object";
+  let description = [{
+    This represents an instance of a class.  The results is the instantiated
+    object.
+
+    Examples:
+    ```mlir
+    %0 = firrtl.object @Foo(in io: !firrtl.uint)
+    ```
+  }];
+  let arguments = (ins
+    // The className is so that SymbolUserOpInterface can find the referenced 
+    // symbol.
+    FlatSymbolRefAttr:$className
+  );
+  let results = (outs ClassType:$results);
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+  let builders = [
+    OpBuilder<(ins "ClassType":$type)>,
+    OpBuilder<(ins "ClassOp":$klass)>
+  ];
+  let extraClassDeclaration = [{
+    /// Lookup the module or extmodule for the symbol.  This returns null on
+    /// invalid IR.
+    ClassOp getReferencedClass(SymbolTable& symbolTable);
+  }];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLDECLARATIONS_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -275,8 +275,8 @@ public:
   ResultType dispatchDeclVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<InstanceOp, MemOp, NodeOp, RegOp, RegResetOp, WireOp,
-                       VerbatimWireOp>([&](auto opNode) -> ResultType {
+        .template Case<InstanceOp, ObjectOp, MemOp, NodeOp, RegOp, RegResetOp,
+                       WireOp, VerbatimWireOp>([&](auto opNode) -> ResultType {
           return thisCast->visitDecl(opNode, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -302,6 +302,7 @@ public:
   }
 
   HANDLE(InstanceOp);
+  HANDLE(ObjectOp);
   HANDLE(MemOp);
   HANDLE(NodeOp);
   HANDLE(RegOp);

--- a/lib/Dialect/FIRRTL/Transforms/ExtractClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractClasses.cpp
@@ -36,16 +36,16 @@ private:
                                     InstanceOp instance, OpBuilder &builder,
                                     IRMapping &mapping,
                                     SmallVectorImpl<Operation *> &opsToErase);
-  ObjectOp getOrCreateObject(InstanceOp instance, OpBuilder &builder,
-                             IRMapping &mapping,
-                             SmallVectorImpl<Operation *> &opsToErase);
+  om::ObjectOp getOrCreateObject(InstanceOp instance, OpBuilder &builder,
+                                 IRMapping &mapping,
+                                 SmallVectorImpl<Operation *> &opsToErase);
   void extractClass(FModuleOp moduleOp);
   void updateInstances(FModuleOp moduleOp);
 
   InstanceGraph *instanceGraph;
   DenseMap<Operation *, llvm::BitVector> portsToErase;
   DenseMap<OpResult, Value> cachedObjectValues;
-  DenseMap<InstanceOp, ObjectOp> cachedObjects;
+  DenseMap<InstanceOp, om::ObjectOp> cachedObjects;
 };
 } // namespace
 
@@ -118,7 +118,8 @@ Value ExtractClassesPass::getOrCreateObjectFieldValue(
   Type fieldType = instance.getResult(resultNum).getType();
 
   // Get the ObjectOp to extract a field from.
-  ObjectOp object = getOrCreateObject(instance, builder, mapping, opsToErase);
+  om::ObjectOp object =
+      getOrCreateObject(instance, builder, mapping, opsToErase);
 
   // Get the field path.
   StringAttr resultName = instance.getPortName(resultNum);
@@ -143,7 +144,7 @@ Value ExtractClassesPass::getOrCreateObjectFieldValue(
 /// Note that this is able to work locally with just the instance, and the rest
 /// of the pass ensures the correct ClassOp is created.
 /// NOLINTNEXTLINE(misc-no-recursion)
-ObjectOp ExtractClassesPass::getOrCreateObject(
+om::ObjectOp ExtractClassesPass::getOrCreateObject(
     InstanceOp instance, OpBuilder &builder, IRMapping &mapping,
     SmallVectorImpl<Operation *> &opsToErase) {
   // Check if this ObjectOp has already been created, and return it if so.
@@ -186,8 +187,8 @@ ObjectOp ExtractClassesPass::getOrCreateObject(
   auto objectClass = instance.getModuleNameAttr().getAttr();
 
   // Construct the ObjectOp.
-  auto object = builder.create<ObjectOp>(instance.getLoc(), objectType,
-                                         objectClass, actualParams);
+  auto object = builder.create<om::ObjectOp>(instance.getLoc(), objectType,
+                                             objectClass, actualParams);
 
   // Cache it for potential future lookups.
   cachedObjects[instance] = object;

--- a/test/Dialect/FIRRTL/classes.mlir
+++ b/test/Dialect/FIRRTL/classes.mlir
@@ -3,7 +3,7 @@
 firrtl.circuit "Classes" {
   firrtl.module @Classes() {}
 
-  // CHECK-LABEL: firrtl.class @StringPassThru(in %in_str: !firrtl.string, out %out_str: !firrtl.string) 
+  // CHECK-LABEL: firrtl.class @StringPassThru(in %in_str: !firrtl.string, out %out_str: !firrtl.string)
   firrtl.class @StringPassThru(in %in_str: !firrtl.string, out %out_str: !firrtl.string) {
     // CHECK: firrtl.propassign %out_str, %in_str : !firrtl.string
     firrtl.propassign %out_str, %in_str : !firrtl.string
@@ -11,4 +11,13 @@ firrtl.circuit "Classes" {
 
   // CHECK-LABEL: firrtl.module @ModuleWithObjectPort(in %in: !firrtl.class<@StringPassThru(in in_str: !firrtl.string, out out_str: !firrtl.string)>) 
   firrtl.module @ModuleWithObjectPort(in %in: !firrtl.class<@StringPassThru(in in_str: !firrtl.string, out out_str: !firrtl.string)>) {}
+
+  // CHECK-LABEL: firrtl.class @EmptyClass()
+  firrtl.class @EmptyClass() {}
+
+  // CHECK-LABEL: firrtl.module @ModuleWithOutputObject(out %out: !firrtl.class<@EmptyClass()>)
+  firrtl.module @ModuleWithOutputObject(out %out: !firrtl.class<@EmptyClass()>) {
+    %0 = firrtl.object @EmptyClass()
+    firrtl.propassign %out, %0 : !firrtl.class<@EmptyClass()>
+  }
 }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1966,6 +1966,15 @@ firrtl.circuit "MissingClassForObjectPortInClass" {
 
 // -----
 
+firrtl.circuit "MissingClassForObjectDeclaration" {
+  firrtl.module @ObjectClassMissing() {
+    // expected-error @below {{'firrtl.object' op target class 'Missing' not found}}
+    %0 = firrtl.object @Missing()
+  }
+}
+
+// -----
+
 firrtl.circuit "ClassTypeWrongPortName" {
   firrtl.class @MyClass(out %str: !firrtl.string) {}
   // expected-error @below {{'firrtl.module' op port #0 has wrong name, got "xxx", expected "str"}}


### PR DESCRIPTION
ObjectOp is a declaration of an object in firrtl, which in turn is an instance of a class. ObjectOp has a single return value, of type ClassType, which represents the instantiated object. Objects are moduel-like, in that they have input and output ports, but unlike modules, are not exploded into their ports.