### PR TITLE
[ExportVerilog] Fix Expr/PropertyEmitter token buffer crash

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1806,7 +1806,7 @@ public:
   /// of any emitted expressions in the specified set.
   ExprEmitter(ModuleEmitter &emitter,
               SmallPtrSetImpl<Operation *> &emittedExprs)
-      : ExprEmitter(emitter, emittedExprs, tokens) {}
+      : ExprEmitter(emitter, emittedExprs, localTokens) {}
 
   ExprEmitter(ModuleEmitter &emitter,
               SmallPtrSetImpl<Operation *> &emittedExprs,
@@ -1821,7 +1821,7 @@ public:
   /// already computed name.
   ///
   void emitExpression(Value exp, VerilogPrecedence parenthesizeIfLooserThan) {
-    assert(tokens.empty());
+    assert(localTokens.empty());
     // Wrap to this column.
     ps.scopedBox(PP::ibox0, [&]() {
       emitSubExpr(exp, parenthesizeIfLooserThan,
@@ -1831,7 +1831,7 @@ public:
     // If we are not using an external token buffer provided through the
     // constructor, but we're using the default `ExprEmitter`-scoped buffer,
     // flush it.
-    if (&buffer.tokens == &tokens)
+    if (&buffer.tokens == &localTokens)
       buffer.flush(state.pp);
   }
 
@@ -2088,7 +2088,7 @@ private:
   SmallPtrSetImpl<Operation *> &emittedExprs;
 
   /// Tokens buffered for inserting casts/parens after emitting children.
-  SmallVector<Token> tokens;
+  SmallVector<Token> localTokens;
 
   /// Stores tokens until told to flush.  Uses provided buffer (tokens).
   BufferingPP buffer;
@@ -2232,7 +2232,7 @@ SubExprInfo ExprEmitter::emitSubExpr(Value exp,
     return {Symbol, IsUnsigned};
   }
 
-  unsigned subExprStartIndex = tokens.size();
+  unsigned subExprStartIndex = buffer.tokens.size();
 
   // Inform the visit method about the preferred sign we want from the result.
   // It may choose to ignore this, but some emitters can change behavior based
@@ -2255,8 +2255,9 @@ SubExprInfo ExprEmitter::emitSubExpr(Value exp,
   // we know things about it.
   auto addPrefix = [&](StringToken &&t) {
     // insert {Prefix, ibox0}.
-    tokens.insert(tokens.begin() + subExprStartIndex, BeginToken(0));
-    tokens.insert(tokens.begin() + subExprStartIndex, t);
+    buffer.tokens.insert(buffer.tokens.begin() + subExprStartIndex,
+                         BeginToken(0));
+    buffer.tokens.insert(buffer.tokens.begin() + subExprStartIndex, t);
   };
   auto closeBoxAndParen = [&]() { ps << PP::end << ")"; };
   if (signRequirement == RequireSigned && expInfo.signedness == IsUnsigned) {
@@ -3019,7 +3020,7 @@ public:
   /// track of any emitted expressions in the specified set.
   PropertyEmitter(ModuleEmitter &emitter,
                   SmallPtrSetImpl<Operation *> &emittedOps)
-      : PropertyEmitter(emitter, emittedOps, tokens) {}
+      : PropertyEmitter(emitter, emittedOps, localTokens) {}
   PropertyEmitter(ModuleEmitter &emitter,
                   SmallPtrSetImpl<Operation *> &emittedOps,
                   BufferingPP::BufferVec &tokens)
@@ -3066,7 +3067,7 @@ private:
   SmallPtrSetImpl<Operation *> &emittedOps;
 
   /// Tokens buffered for inserting casts/parens after emitting children.
-  SmallVector<Token> tokens;
+  SmallVector<Token> localTokens;
 
   /// Stores tokens until told to flush.  Uses provided buffer (tokens).
   BufferingPP buffer;
@@ -3078,14 +3079,14 @@ private:
 
 void PropertyEmitter::emitProperty(
     Value property, PropertyPrecedence parenthesizeIfLooserThan) {
-  assert(tokens.empty());
+  assert(localTokens.empty());
   // Wrap to this column.
   ps.scopedBox(PP::ibox0,
                [&] { emitNestedProperty(property, parenthesizeIfLooserThan); });
   // If we are not using an external token buffer provided through the
   // constructor, but we're using the default `PropertyEmitter`-scoped buffer,
   // flush it.
-  if (&buffer.tokens == &tokens)
+  if (&buffer.tokens == &localTokens)
     buffer.flush(state.pp);
 }
 
@@ -3101,12 +3102,12 @@ EmittedProperty PropertyEmitter::emitNestedProperty(
   // `PropertyPrecedence::Symbol` and needs no parantheses, which is equivalent
   // to `VerilogPrecedence::LowestPrecedence`.
   if (!isa<ltl::SequenceType, ltl::PropertyType>(property.getType())) {
-    ExprEmitter(emitter, emittedOps, tokens)
+    ExprEmitter(emitter, emittedOps, buffer.tokens)
         .emitExpression(property, LowestPrecedence);
     return {PropertyPrecedence::Symbol};
   }
 
-  unsigned startIndex = tokens.size();
+  unsigned startIndex = buffer.tokens.size();
   auto info = dispatchLTLVisitor(property.getDefiningOp());
 
   // If this subexpression would bind looser than the expression it is bound
@@ -3114,8 +3115,8 @@ EmittedProperty PropertyEmitter::emitNestedProperty(
   // retroactively.
   if (info.precedence > parenthesizeIfLooserThan) {
     // Insert {"(", ibox0} before the subexpression.
-    tokens.insert(tokens.begin() + startIndex, BeginToken(0));
-    tokens.insert(tokens.begin() + startIndex, StringToken("("));
+    buffer.tokens.insert(buffer.tokens.begin() + startIndex, BeginToken(0));
+    buffer.tokens.insert(buffer.tokens.begin() + startIndex, StringToken("("));
     // Insert {end, ")" } after the subexpression.
     ps << PP::end << ")";
     // Reset the precedence level.

--- a/test/Conversion/ExportVerilog/verif.mlir
+++ b/test/Conversion/ExportVerilog/verif.mlir
@@ -259,3 +259,14 @@ hw.module @LivenessExample(%clock: i1, %reset: i1, %isLive: i1) {
   verif.assert %liveness_after_fall : !ltl.property
   verif.assume %liveness_after_fall : !ltl.property
 }
+
+// https://github.com/llvm/circt/issues/5763
+// CHECK-LABEL: module Issue5763
+hw.module @Issue5763(%a: i3) {
+  // CHECK: assert property ((&a) & a[0]);
+  %c-1_i3 = hw.constant -1 : i3
+  %0 = comb.extract %a from 0 : (i3) -> i1
+  %1 = comb.icmp bin eq %a, %c-1_i3 : i3
+  %2 = comb.and bin %1, %0 : i1
+  verif.assert %2 : i1
+}


### PR DESCRIPTION
Fix an issue in `ExportVerilog` where `ExprEmitter`s and `PropertyEmitter`s would not properly use a token buffer passed in as a constructor argument. The emitters have a local buffer of tokens that is used by default if no external one is provided. However, parts of the emitters failed to use `buffer.tokens` to access either the externally provided or the local buffer, and instead would always use the local `tokens` buffer. This caused parentheses and end tokens to be lost if an external buffer was provided, since the emitter would modify the unused local `tokens` buffer.

This fixes the issue by properly using `buffer.tokens` everywhere and renaming `tokens` to `localTokens` to make misuse more obvious.

Fixes #5763.