### PR TITLE
[FIRRTL] Rename BigIntType to FIntegerType

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1045,18 +1045,18 @@ def StringConstantOp : FIRRTLOp<"string", [Pure, ConstantLike]> {
   let assemblyFormat = "$value attr-dict";
 }
 
-def BigIntConstantOp : FIRRTLOp<"bigint", [Pure, ConstantLike]> {
-  let summary = "Produce a constant bigint value";
+def IntegerConstantOp : FIRRTLOp<"integer", [Pure, ConstantLike]> {
+  let summary = "Produce a constant integer value";
   let description = [{
-    Produces a constant value of bigint type.
+    Produces a constant value of integer type.
 
     Example:
     ```mlir
-    %0 = firrtl.bigint 42
+    %0 = firrtl.integer 42
     ```
   }];
   let arguments = (ins APSIntAttr:$value);
-  let results = (outs BigIntType:$result);
+  let results = (outs FIntegerType:$result);
   let hasCustomAssemblyFormat = true;
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1045,7 +1045,7 @@ def StringConstantOp : FIRRTLOp<"string", [Pure, ConstantLike]> {
   let assemblyFormat = "$value attr-dict";
 }
 
-def IntegerConstantOp : FIRRTLOp<"integer", [Pure, ConstantLike]> {
+def FIntegerConstantOp : FIRRTLOp<"integer", [Pure, ConstantLike]> {
   let summary = "Produce a constant integer value";
   let description = [{
     Produces a constant value of integer type.

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -51,7 +51,7 @@ class FEnumType;
 class RefType;
 class PropertyType;
 class StringType;
-class BigIntType;
+class FIntegerType;
 class ListType;
 class MapType;
 class PathType;
@@ -340,7 +340,7 @@ class PropertyType : public FIRRTLType {
 public:
   /// Support method to enable LLVM-style type casting.
   static bool classof(Type type) {
-    return llvm::isa<ClassType, StringType, BigIntType, ListType, MapType,
+    return llvm::isa<ClassType, StringType, FIntegerType, ListType, MapType,
                      PathType>(type);
   }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -207,8 +207,8 @@ def ClassType : FIRRTLDialectTypeHelper<"ClassType", "class type">;
 def StringType : FIRRTLDialectTypeHelper<"StringType", "string type">,
   BuildableType<"::circt::firrtl::StringType::get($_builder.getContext())">;
 
-def BigIntType : FIRRTLDialectTypeHelper<"BigIntType", "big integer type">,
-  BuildableType<"::circt::firrtl::BigIntType::get($_builder.getContext())">;
+def FIntegerType : FIRRTLDialectTypeHelper<"FIntegerType", "integer type">,
+  BuildableType<"::circt::firrtl::FIntegerType::get($_builder.getContext())">;
 
 def ListType : FIRRTLDialectTypeHelper<"ListType", "list type">;
 def MapType : FIRRTLDialectTypeHelper<"MapType", "map type">;

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -596,7 +596,7 @@ def StringImpl : FIRRTLImplType<"String", [], "circt::firrtl::FIRRTLType"> {
   let genStorageClass = true;
 }
 
-def BigIntImpl : FIRRTLImplType<"BigInt", [], "circt::firrtl::FIRRTLType"> {
+def IntegerImpl : FIRRTLImplType<"FInteger", [], "circt::firrtl::FIRRTLType"> {
   let summary = [{
     An unlimited length signed integer type.  Not representable in hardware.
   }];

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -61,7 +61,7 @@ public:
             UninferredResetCastOp, ConstCastOp, RefCastOp,
             mlir::UnrealizedConversionCastOp,
             // Property expressions.
-            StringConstantOp, BigIntConstantOp>([&](auto expr) -> ResultType {
+            StringConstantOp, IntegerConstantOp>([&](auto expr) -> ResultType {
           return thisCast->visitExpr(expr, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -198,7 +198,7 @@ public:
 
   // Property expressions.
   HANDLE(StringConstantOp, Unhandled);
-  HANDLE(BigIntConstantOp, Unhandled);
+  HANDLE(IntegerConstantOp, Unhandled);
 #undef HANDLE
 };
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -61,7 +61,7 @@ public:
             UninferredResetCastOp, ConstCastOp, RefCastOp,
             mlir::UnrealizedConversionCastOp,
             // Property expressions.
-            StringConstantOp, IntegerConstantOp>([&](auto expr) -> ResultType {
+            StringConstantOp, FIntegerConstantOp>([&](auto expr) -> ResultType {
           return thisCast->visitExpr(expr, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -198,7 +198,7 @@ public:
 
   // Property expressions.
   HANDLE(StringConstantOp, Unhandled);
-  HANDLE(IntegerConstantOp, Unhandled);
+  HANDLE(FIntegerConstantOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -110,7 +110,7 @@ struct Emitter {
   void emitExpression(UninferredResetCastOp op);
   void emitExpression(ConstCastOp op);
   void emitExpression(StringConstantOp op);
-  void emitExpression(IntegerConstantOp op);
+  void emitExpression(FIntegerConstantOp op);
 
   void emitPrimExpr(StringRef mnemonic, Operation *op,
                     ArrayRef<uint32_t> attrs = {});
@@ -1012,7 +1012,7 @@ void Emitter::emitExpression(Value value) {
           // Miscellaneous
           BitsPrimOp, HeadPrimOp, TailPrimOp, PadPrimOp, MuxPrimOp, ShlPrimOp,
           ShrPrimOp, UninferredResetCastOp, ConstCastOp, StringConstantOp,
-          IntegerConstantOp,
+          FIntegerConstantOp,
           // Reference expressions
           RefSendOp, RefResolveOp, RefSubOp>([&](auto op) {
         ps.scopedBox(PP::ibox0, [&]() { emitExpression(op); });
@@ -1118,7 +1118,7 @@ void Emitter::emitExpression(UninferredResetCastOp op) {
   emitExpression(op.getInput());
 }
 
-void Emitter::emitExpression(IntegerConstantOp op) {
+void Emitter::emitExpression(FIntegerConstantOp op) {
   ps << "Integer(";
   ps.addAsString(op.getValue());
   ps << ")";

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -110,7 +110,7 @@ struct Emitter {
   void emitExpression(UninferredResetCastOp op);
   void emitExpression(ConstCastOp op);
   void emitExpression(StringConstantOp op);
-  void emitExpression(BigIntConstantOp op);
+  void emitExpression(IntegerConstantOp op);
 
   void emitPrimExpr(StringRef mnemonic, Operation *op,
                     ArrayRef<uint32_t> attrs = {});
@@ -1012,7 +1012,7 @@ void Emitter::emitExpression(Value value) {
           // Miscellaneous
           BitsPrimOp, HeadPrimOp, TailPrimOp, PadPrimOp, MuxPrimOp, ShlPrimOp,
           ShrPrimOp, UninferredResetCastOp, ConstCastOp, StringConstantOp,
-          BigIntConstantOp,
+          IntegerConstantOp,
           // Reference expressions
           RefSendOp, RefResolveOp, RefSubOp>([&](auto op) {
         ps.scopedBox(PP::ibox0, [&]() { emitExpression(op); });
@@ -1118,7 +1118,7 @@ void Emitter::emitExpression(UninferredResetCastOp op) {
   emitExpression(op.getInput());
 }
 
-void Emitter::emitExpression(BigIntConstantOp op) {
+void Emitter::emitExpression(IntegerConstantOp op) {
   ps << "Integer(";
   ps.addAsString(op.getValue());
   ps << ")";
@@ -1237,7 +1237,7 @@ void Emitter::emitType(Type type, bool includeConst) {
         ps << ">";
       })
       .Case<StringType>([&](StringType type) { ps << "String"; })
-      .Case<BigIntType>([&](BigIntType type) { ps << "Integer"; })
+      .Case<FIntegerType>([&](FIntegerType type) { ps << "Integer"; })
       .Case<PathType>([&](PathType type) { ps << "Path"; })
       .Default([&](auto type) {
         llvm_unreachable("all types should be implemented");

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3355,14 +3355,14 @@ Attribute AggregateConstantOp::getAttributeFromFieldID(uint64_t fieldID) {
   return value;
 }
 
-void IntegerConstantOp::print(OpAsmPrinter &p) {
+void FIntegerConstantOp::print(OpAsmPrinter &p) {
   p << " ";
   p.printAttributeWithoutType(getValueAttr());
   p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{"value"});
 }
 
-ParseResult IntegerConstantOp::parse(OpAsmParser &parser,
-                                     OperationState &result) {
+ParseResult FIntegerConstantOp::parse(OpAsmParser &parser,
+                                      OperationState &result) {
   auto *context = parser.getContext();
   APInt value;
   if (parser.parseInteger(value) ||

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3355,20 +3355,20 @@ Attribute AggregateConstantOp::getAttributeFromFieldID(uint64_t fieldID) {
   return value;
 }
 
-void BigIntConstantOp::print(OpAsmPrinter &p) {
+void IntegerConstantOp::print(OpAsmPrinter &p) {
   p << " ";
   p.printAttributeWithoutType(getValueAttr());
   p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{"value"});
 }
 
-ParseResult BigIntConstantOp::parse(OpAsmParser &parser,
-                                    OperationState &result) {
+ParseResult IntegerConstantOp::parse(OpAsmParser &parser,
+                                     OperationState &result) {
   auto *context = parser.getContext();
   APInt value;
   if (parser.parseInteger(value) ||
       parser.parseOptionalAttrDict(result.attributes))
     return failure();
-  result.addTypes(BigIntType::get(context));
+  result.addTypes(FIntegerType::get(context));
   auto intType =
       IntegerType::get(context, value.getBitWidth(), IntegerType::Signed);
   auto valueAttr = parser.getBuilder().getIntegerAttr(intType, value);

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -113,7 +113,7 @@ static LogicalResult customTypePrinter(Type type, AsmPrinter &os) {
         os << '>';
       })
       .Case<StringType>([&](auto stringType) { os << "string"; })
-      .Case<BigIntType>([&](auto bigIntType) { os << "bigint"; })
+      .Case<FIntegerType>([&](auto integerType) { os << "integer"; })
       .Case<ListType>([&](auto listType) {
         os << "list<";
         printNestedType(listType.getElementType(), os);
@@ -377,12 +377,12 @@ static OptionalParseResult customTypeParser(AsmParser &parser, StringRef name,
     result = StringType::get(parser.getContext());
     return success();
   }
-  if (name.equals("bigint")) {
+  if (name.equals("integer")) {
     if (isConst) {
       parser.emitError(parser.getNameLoc(), "bigints cannot be const");
       return failure();
     }
-    result = BigIntType::get(parser.getContext());
+    result = FIntegerType::get(parser.getContext());
     return success();
   }
   if (name.equals("list")) {
@@ -2669,7 +2669,7 @@ void FIRRTLDialect::registerTypes() {
            // References and open aggregates
            RefType, OpenBundleType, OpenVectorType,
            // Non-Hardware types
-           ClassType, StringType, BigIntType, ListType, MapType, PathType>();
+           ClassType, StringType, FIntegerType, ListType, MapType, PathType>();
 }
 
 // Get the bit width for this type, return None  if unknown. Unlike

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -970,7 +970,7 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
                             "feature, but the specified FIRRTL version was "
                          << version;
     consumeToken(FIRToken::kw_Integer);
-    result = BigIntType::get(getContext());
+    result = FIntegerType::get(getContext());
     break;
   case FIRToken::kw_Path:
     if (FIRVersion::compare(version, FIRVersion({3, 1, 0})) < 0)
@@ -1757,7 +1757,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
         parseToken(FIRToken::r_paren, "expected ')' in Integer expression"))
       return failure();
     result =
-        builder.create<BigIntConstantOp>(APSInt(value, /*isUnsigned=*/false));
+        builder.create<IntegerConstantOp>(APSInt(value, /*isUnsigned=*/false));
     break;
   }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1757,7 +1757,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
         parseToken(FIRToken::r_paren, "expected ')' in Integer expression"))
       return failure();
     result =
-        builder.create<IntegerConstantOp>(APSInt(value, /*isUnsigned=*/false));
+        builder.create<FIntegerConstantOp>(APSInt(value, /*isUnsigned=*/false));
     break;
   }
 

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -53,7 +53,7 @@ firrtl.circuit "Foo" {
     out %b1: !firrtl.probe<uint<1>>,
     out %b2: !firrtl.rwprobe<uint<1>>,
     in %string: !firrtl.string,
-    in %integer: !firrtl.bigint,
+    in %integer: !firrtl.integer,
     in %path : !firrtl.path
   ) {}
 
@@ -641,14 +641,14 @@ firrtl.circuit "Foo" {
   
   // CHECK-LABEL: module Properties :
   firrtl.module @Properties(out %string : !firrtl.string,
-                            out %integer : !firrtl.bigint) {
+                            out %integer : !firrtl.integer) {
     // CHECK: propassign string, String("hello")
     %0 = firrtl.string "hello"
     firrtl.propassign %string, %0 : !firrtl.string
 
     // CHECK: propassign integer, Integer(99)
-    %1 = firrtl.bigint 99
-    firrtl.propassign %integer, %1 : !firrtl.bigint
+    %1 = firrtl.integer 99
+    firrtl.propassign %integer, %1 : !firrtl.integer
   }
 
   // Test optional group declaration and definition emission.

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1984,8 +1984,8 @@ firrtl.circuit "ClassTypeWrongPortDir" {
 
 firrtl.circuit "ClassTypeWrongPortType" {
   firrtl.class @MyClass(out %str: !firrtl.string) {}
-  // expected-error @below {{'firrtl.module' op port "str" has wrong type, got '!firrtl.bigint', expected '!firrtl.string'}}
-  firrtl.module @ClassTypeWrongPortType(out %port: !firrtl.class<@MyClass(out str: !firrtl.bigint)>) {}
+  // expected-error @below {{'firrtl.module' op port "str" has wrong type, got '!firrtl.integer', expected '!firrtl.string'}}
+  firrtl.module @ClassTypeWrongPortType(out %port: !firrtl.class<@MyClass(out str: !firrtl.integer)>) {}
 }
 
 // -----

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1667,10 +1667,10 @@ circuit BasicProps :
   module BasicProps :
   ; CHECK-LABEL: module private @Integer
   module Integer :
-    ; CHECK-SAME: out %a: !firrtl.bigint
+    ; CHECK-SAME: out %a: !firrtl.integer
     output a : Integer
-    ; CHECK: %0 = firrtl.bigint -10
-    ; CHECK: firrtl.propassign %a, %0 : !firrtl.bigint
+    ; CHECK: %0 = firrtl.integer -10
+    ; CHECK: firrtl.propassign %a, %0 : !firrtl.integer
     propassign a, Integer(-10)
 
   ; CHECK-LABEL: module private @String

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -252,14 +252,14 @@ firrtl.module @StringTest(in %in: !firrtl.string, out %out: !firrtl.string) {
 }
 
 // CHECK-LABEL: BigIntTest
-// CHECK-SAME:  (in %in: !firrtl.bigint, out %out: !firrtl.bigint)
-firrtl.module @BigIntTest(in %in: !firrtl.bigint, out %out: !firrtl.bigint) {
-  firrtl.propassign %out, %in : !firrtl.bigint
+// CHECK-SAME:  (in %in: !firrtl.integer, out %out: !firrtl.integer)
+firrtl.module @BigIntTest(in %in: !firrtl.integer, out %out: !firrtl.integer) {
+  firrtl.propassign %out, %in : !firrtl.integer
 
-  // CHECK: %0 = firrtl.bigint 4
-  %0 = firrtl.bigint 4
-  // CHECK: %1 = firrtl.bigint -4
-  %1 = firrtl.bigint -4
+  // CHECK: %0 = firrtl.integer 4
+  %0 = firrtl.integer 4
+  // CHECK: %1 = firrtl.integer -4
+  %1 = firrtl.integer -4
 }
 
 // CHECK-LABEL: ListTest
@@ -269,15 +269,15 @@ firrtl.module @ListTest(in %in: !firrtl.list<string>, out %out: !firrtl.list<str
 }
 
 // CHECK-LABEL: MapTest
-// CHECK-SAME:  (in %in: !firrtl.map<bigint, string>, out %out: !firrtl.map<bigint, string>)
-firrtl.module @MapTest(in %in: !firrtl.map<bigint, string>, out %out: !firrtl.map<bigint, string>) {
-  firrtl.propassign %out, %in : !firrtl.map<bigint, string>
+// CHECK-SAME:  (in %in: !firrtl.map<integer, string>, out %out: !firrtl.map<integer, string>)
+firrtl.module @MapTest(in %in: !firrtl.map<integer, string>, out %out: !firrtl.map<integer, string>) {
+  firrtl.propassign %out, %in : !firrtl.map<integer, string>
 }
 
 // CHECK-LABEL: PropertyNestedTest
-// CHECK-SAME:  (in %in: !firrtl.map<bigint, list<map<string, bigint>>>, out %out: !firrtl.map<bigint, list<map<string, bigint>>>)
-firrtl.module @PropertyNestedTest(in %in: !firrtl.map<bigint, list<map<string, bigint>>>, out %out: !firrtl.map<bigint, list<map<string, bigint>>>) {
-  firrtl.propassign %out, %in : !firrtl.map<bigint, list<map<string, bigint>>>
+// CHECK-SAME:  (in %in: !firrtl.map<integer, list<map<string, integer>>>, out %out: !firrtl.map<integer, list<map<string, integer>>>)
+firrtl.module @PropertyNestedTest(in %in: !firrtl.map<integer, list<map<string, integer>>>, out %out: !firrtl.map<integer, list<map<string, integer>>>) {
+  firrtl.propassign %out, %in : !firrtl.map<integer, list<map<string, integer>>>
 }
 
 // CHECK-LABEL: firrtl.module @PathTest


### PR DESCRIPTION
Since Integer is already an MLIR type, this change renames BigIntType to FIntegerType, and BigIntConstantOp to FIntegerConstantOp.