### PR TITLE
[HW] InnerSymProperties: emit error when visibility is invalid

### DIFF
--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -21,6 +21,13 @@ func.func private @test_and() {
 
 // -----
 
+hw.module @InnerSymVisibility() {
+  // expected-error @+1 {{expected 'public', 'private', or 'nested'}}
+  %wire = hw.wire %wire sym [<@x, 1, oops>] : i1
+}
+
+// -----
+
 func.func private @notModule () {
   return
 }


### PR DESCRIPTION
There is no `parseKeyword` which takes a list of alternatives, so we have to emit the error ourselves.  This could be fixed with some better upstream functionality.

Fixes #5597