### PR TITLE
[CI] Use a consistent key for ccache caching in Short Integration Tests

### DIFF
--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -45,8 +45,9 @@ jobs:
           submodules: true
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
+          key: shortintegration-${{ matrix.build-assert }}-${{ matrix.build-type }}-${{ matrix.compiler.cc }} 
           max-size: 1G
 
       # --------


### PR DESCRIPTION
The ccache action by default uses the current date and time as part of the key for caching. The main problem with this is that it can create too many different cache entries, and can eject entries we don't want to be ejected.  There isn't a reason to keep more than one copy of this cache around, so using a consistent key will cause it to eject itself.  I put the name of the job in the key so that we can identify which entries belong to what jobs when we examine the cache.  This change also updates to a newer version of the ccache action.