### PR TITLE
[SVExtractTestCode] Inline input only modules even when no operation …

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -790,8 +790,8 @@ void SVExtractTestCodeImplPass::runOnOperation() {
           doModule(rtlmod, isCover, "_cover", coverDir, coverBindFile,
                    bindTable, opsToErase, opsInDesign);
 
-      // If nothing is extracted, we are done.
-      if (!anyThingExtracted)
+      // If nothing is extracted and the module has an output, we are done.
+      if (!anyThingExtracted && rtlmod.getNumOutputs() != 0)
         continue;
 
       // Here, erase extracted operations as well as dead operations.
@@ -828,7 +828,7 @@ void SVExtractTestCodeImplPass::runOnOperation() {
       });
 
       // Inline any modules that only have inputs for test code.
-      if (!disableModuleInlining && anyThingExtracted)
+      if (!disableModuleInlining)
         inlineInputOnly(rtlmod, *instanceGraph, bindTable, opsToErase,
                         innerRefUsedByNonBindOp);
 

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -499,20 +499,29 @@ module {
     hw.output %a: i1
   }
 
+  // CHECK-NOT: @InputOnly
+  hw.module private @InputOnly(%clock: i1, %a: i1) -> () {
+    hw.instance "a4" @Assert(clock: %clock: i1, a: %a: i1) -> ()
+  }
+
   // CHECK-LABEL: hw.module @Top(%clock: i1, %a: i1, %b: i1) {
   // CHECK-NEXT:  hw.instance "Assert_assert" sym @__ETC_Assert_assert_0 @Assert_assert
   // CHECK-SAME:  doNotPrint = true
   // CHECK-NEXT:  hw.instance "Assert_assert" sym @__ETC_Assert_assert @Assert_assert
+  // CHECK-SAME:  doNotPrint = true
+  // CHECK-NEXT:  hw.instance "Assert_assert" sym @__ETC_Assert_assert_1 @Assert_assert
   // CHECK-SAME:  doNotPrint = true
   // CHECK-NEXT:  hw.instance "should_not_be_inlined" @ShouldNotBeInlined
   // CHECK-NOT: doNotPrint
   hw.module @Top(%clock: i1, %a: i1, %b: i1) {
     hw.instance "a1" @Assert(clock: %clock: i1, a: %a: i1) -> ()
     hw.instance "a2" @Assert(clock: %clock: i1, a: %b: i1) -> ()
+    hw.instance "a3" @InputOnly(clock: %clock: i1, a: %b: i1) -> ()
     hw.instance "should_not_be_inlined" @ShouldNotBeInlined (clock: %clock: i1, a: %b: i1) -> ()
     hw.output
   }
   // CHECK:       sv.bind <@Top::@__ETC_Assert_assert>
   // CHECK-NEXT:  sv.bind <@Top::@__ETC_Assert_assert_0>
+  // CHECK-NEXT:  sv.bind <@Top::@__ETC_Assert_assert_1>
   // CHECK-NEXT:  sv.bind <@AssertWrapper::@__ETC_Assert_assert>
 }


### PR DESCRIPTION
…is extracted

Currently we only inline input only modulse when op is extracted. However if a module only contains input only modules there might be no extraction and hence we might end up having input only modules.