### PR TITLE
[Ibis] Add instance/port references and related ops

### DIFF
--- a/include/circt/Dialect/Ibis/Ibis.td
+++ b/include/circt/Dialect/Ibis/Ibis.td
@@ -13,28 +13,7 @@ include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/FunctionInterfaces.td"
 
-def IbisDialect : Dialect {
-  let name = "ibis";
-  let cppNamespace = "::circt::ibis";
-
-  let summary = "Types and operations for Ibis dialect";
-  let description = [{
-    The `ibis` dialect is intended to support porting and eventual open sourcing
-    of an internal hardware development language.
-  }];
-
-  // TODO: uncomment this once we introduce some types. The default functions
-  // aren't generated without typedefs.
-  // let useDefaultTypePrinterParser = 1;
-}
-
-// Base class for the types in this dialect.
-class IbisType<string name> : TypeDef<IbisDialect, name> {}
-
-// Base class for the operations in this dialect.
-class IbisOp<string mnemonic, list<Trait> traits = []> :
-    Op<IbisDialect, mnemonic, traits>;
-
+include "circt/Dialect/Ibis/IbisDialect.td"
 include "circt/Dialect/Ibis/IbisTypes.td"
 include "circt/Dialect/Ibis/IbisOps.td"
 

--- a/include/circt/Dialect/Ibis/IbisDialect.td
+++ b/include/circt/Dialect/Ibis/IbisDialect.td
@@ -1,0 +1,30 @@
+//===- IbisDialect.td - Ibis dialect definition ----------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_IBIS_DIALECT_TD
+#define CIRCT_DIALECT_IBIS_DIALECT_TD
+
+include "mlir/IR/OpBase.td"
+
+def IbisDialect : Dialect {
+  let name = "ibis";
+  let cppNamespace = "::circt::ibis";
+
+  let summary = "Types and operations for Ibis dialect";
+  let description = [{
+    The `ibis` dialect is intended to support porting and eventual open sourcing
+    of an internal hardware development language.
+  }];
+  let useDefaultTypePrinterParser = 1;
+
+  let extraClassDeclaration = [{
+    void registerTypes();
+  }];
+}
+
+#endif // CIRCT_DIALECT_IBIS_DIALECT_TD

--- a/include/circt/Dialect/Ibis/IbisInterfaces.td
+++ b/include/circt/Dialect/Ibis/IbisInterfaces.td
@@ -21,6 +21,9 @@ def PortOpInterface : OpInterface<"PortOpInterface"> {
       [{"An interface for operations which describe ports."}];
 
   let methods = [
+    InterfaceMethod<
+      [{"Returns the data type of the port."}],
+      "mlir::Type", "getPortType">
   ];
 }
 

--- a/include/circt/Dialect/Ibis/IbisInterfaces.td
+++ b/include/circt/Dialect/Ibis/IbisInterfaces.td
@@ -18,11 +18,11 @@ include "mlir/IR/OpBase.td"
 def PortOpInterface : OpInterface<"PortOpInterface"> {
   let cppNamespace = "circt::ibis";
   let description =
-      [{"An interface for operations which describe ports."}];
+      "An interface for operations which describe ports.";
 
   let methods = [
     InterfaceMethod<
-      [{"Returns the data type of the port."}],
+      "Returns the data type of the port.",
       "mlir::Type", "getPortType">
   ];
 }

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -171,7 +171,8 @@ def GetParentOfRefOp : IbisOp<"get_parent_of_ref"> {
   let summary = "Ibis get classref parent op";
   let description = [{
     Given an Ibis class reference, returns a class reference to the parent of
-    said class. The returned `ibis.classref` will be an opaque type.
+    said class. The returned `ibis.classref` will be an opaque type, given that
+    any given Ibis class may be instantiated by multiple different parent classes.
   }];
 
   let arguments = (ins AnyClassRefType:$src);

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -167,11 +167,11 @@ def CallOp : IbisOp<"call", [CallOpInterface]> {
   }];
 }
 
-def GetParentOp : IbisOp<"get_parent"> {
-  let summary = "Ibis get parent";
+def GetParentOfRefOp : IbisOp<"get_parent_of_ref"> {
+  let summary = "Ibis get classref parent op";
   let description = [{
-    Given an Ibis class reference, returns the parent of said class. The
-    returned `ibis.classref` will be an opaque type.
+    Given an Ibis class reference, returns a class reference to the parent of
+    said class. The returned `ibis.classref` will be an opaque type.
   }];
 
   let arguments = (ins AnyClassRefType:$src);
@@ -182,25 +182,25 @@ def GetParentOp : IbisOp<"get_parent"> {
   }];
 }
 
-def GetChildOp : IbisOp<"get_child"> {
-  let summary = "Ibis get child";
+def GetInstanceInRefOp : IbisOp<"get_instance_in_ref"> {
+  let summary = "Ibis get instance";
   let description = [{
-    Given an Ibis class reference, returns a child of said class. The child
-    is specified by the symbol name of the instance of that child in the referenced
+    Given an Ibis class reference, returns a instance of said class. The instance
+    is specified by the symbol name of the instance of that instance in the referenced
     class. In case of an opaque reference to the containing class, no type
     validation is performed, and it is up to lowering passes to determine whether
-    the child of the given classref actually exists.
+    the instance of the given classref actually exists.
     The returned classref, however, is typed, given that one must specify the
-    symbol of the class which the child is an instance of.
+    symbol of the class which the instance is an instance of.
   }];
 
   let arguments = (ins
     AnyClassRefType:$src,
-    FlatSymbolRefAttr:$childName,
-    FlatSymbolRefAttr:$childSymbol);
-  let results = (outs ClassRefType:$child);
+    FlatSymbolRefAttr:$instanceName,
+    FlatSymbolRefAttr:$instanceSymbol);
+  let results = (outs ClassRefType:$instance);
   let assemblyFormat = [{
-    $childName `:` $childSymbol `in` $src `:` qualified(type($src)) attr-dict custom<ClassRefFromName>(type($child), ref($childSymbol))
+    $instanceName `:` $instanceSymbol `in` $src `:` qualified(type($src)) attr-dict custom<ClassRefFromName>(type($instance), ref($instanceSymbol))
   }];
 }
 

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -18,6 +18,10 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 
 include "circt/Dialect/HW/HWOpInterfaces.td"
 include "circt/Dialect/Ibis/IbisInterfaces.td"
+include "circt/Dialect/Ibis/IbisTypes.td"
+
+class IbisOp<string mnemonic, list<Trait> traits = []> :
+    Op<IbisDialect, mnemonic, traits>;
 
 def HasCustomSSAName :
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>;
@@ -25,7 +29,8 @@ def HasCustomSSAName :
 def ClassOp : IbisOp<"class", [
     IsolatedFromAbove, RegionKindInterface,
     Symbol, SymbolTable, SingleBlock,
-    NoTerminator, NoRegionArguments,
+    NoTerminator,
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>,
     HasParent<"mlir::ModuleOp">]> {
 
   let summary = "Ibis class";
@@ -36,14 +41,14 @@ def ClassOp : IbisOp<"class", [
 
   let arguments = (ins SymbolNameAttr:$sym_name);
   let regions = (region SizedRegion<1>:$body);
-
-  let assemblyFormat = [{
-    $sym_name attr-dict-with-keyword $body
-  }];
+  let hasCustomAssemblyFormat = 1;
 
   let extraClassDeclaration = [{
     // Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph; }
+
+    // Returns the inner 'this' argument of the class.
+    BlockArgument getThis() { return getBody().front().getArgument(0); }
   }];
 }
 
@@ -57,8 +62,10 @@ def InstanceOp : IbisOp<"instance", [
   }];
 
   let arguments = (ins SymbolNameAttr:$sym_name, FlatSymbolRefAttr:$className);
+  let results = (outs ClassRefType:$classRef);
   let assemblyFormat = [{
     $sym_name `,` $className attr-dict
+    custom<ClassRefFromName>(type($classRef), ref($className))
   }];
 
   let extraClassDeclaration = [{
@@ -160,13 +167,48 @@ def CallOp : IbisOp<"call", [CallOpInterface]> {
   }];
 }
 
+def GetParentOp : IbisOp<"get_parent"> {
+  let summary = "Ibis get parent";
+  let description = [{
+    Given an Ibis class reference, returns the parent of said class. The
+    returned `ibis.classref` will be an opaque type.
+  }];
+
+  let arguments = (ins AnyClassRefType:$src);
+  let results = (outs OpaqueClassRefType:$parent);
+
+  let assemblyFormat = [{
+    $src `:` qualified(type($src)) attr-dict
+  }];
+}
+
+def GetChildOp : IbisOp<"get_child"> {
+  let summary = "Ibis get child";
+  let description = [{
+    Given an Ibis class reference, returns a child of said class. The child
+    is specified by the symbol name of the instance of that child in the referenced
+    class. In case of an opaque reference to the containing class, no type
+    validation is performed, and it is up to lowering passes to determine whether
+    the child of the given classref actually exists.
+    The returned classref, however, is typed, given that one must specify the
+    symbol of the class which the child is an instance of.
+  }];
+
+  let arguments = (ins
+    AnyClassRefType:$src,
+    FlatSymbolRefAttr:$childName,
+    FlatSymbolRefAttr:$childSymbol);
+  let results = (outs ClassRefType:$child);
+  let assemblyFormat = [{
+    $childName `:` $childSymbol `in` $src `:` qualified(type($src)) attr-dict custom<ClassRefFromName>(type($child), ref($childSymbol))
+  }];
+}
 
 // ===---------------------------------------------------------------------===//
 // Low-level Ibis operations
 // ===---------------------------------------------------------------------===//
 
 def ContainerOp : IbisOp<"container", [
-  IsolatedFromAbove,
   Symbol, SymbolTable, SingleBlock,
   NoTerminator, NoRegionArguments,
   HasParent<"ClassOp">
@@ -193,6 +235,30 @@ class PortLikeOp<string mnemonic, list<Trait> traits = []> :
   let assemblyFormat = [{
     $sym_name `:` $type attr-dict
   }];
+
+  let extraClassDeclaration = [{
+    Type getPortType() {
+      return getTypeAttr().getValue();
+    }
+  }];
+}
+
+def GetPortOp : IbisOp<"get_port", [
+      DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "Ibis get port";
+  let description = [{
+    Given an Ibis class reference, returns a port of said class. The port
+    is specified by the symbol name of the port in the referenced class.
+  }];
+
+  let arguments = (ins
+    ClassRefType:$instance,
+    FlatSymbolRefAttr:$portSymbol);
+  let results = (outs PortRefType:$port);
+  let assemblyFormat = [{
+    $instance `,` $portSymbol `:` qualified(type($instance)) `->` qualified(type($port)) attr-dict
+  }];
 }
 
 def InputPortOp : PortLikeOp<"port.input"> {
@@ -203,61 +269,40 @@ def OutputPortOp : PortLikeOp<"port.output"> {
   let summary = "Ibis output port";
 }
 
+class PortRefToInnerTypeConstraint<string lhs, string rhs>
+  : TypesMatchWith<"the lhs portref dictates the rhs type",
+    lhs, rhs, "$_self.cast<PortRefType>().getPortType()">;
+
 def PortReadOp : IbisOp<"port.read", [
-      DeclareOpInterfaceMethods<SymbolUserOpInterface>
+      PortRefToInnerTypeConstraint<"port", "output">
 ]> {
   let summary = "Ibis port read";
   let description = [{
     Read the value of a local port (i.e. a port of 'this' class).
   }];
 
-  let arguments = (ins FlatSymbolRefAttr:$sym_name);
+  let arguments = (ins PortRefType:$port);
   let results = (outs AnyType:$output);
   let assemblyFormat = [{
-    $sym_name attr-dict `:` type($output)
+    $port attr-dict `:` qualified(type($port))
   }];
 }
 
+class InnerTypeToPortRefTypeConstraint<string lhs, string rhs>
+  : TypesMatchWith<"the type of the lhs value dictates the rhs portref type",
+    lhs, rhs, "PortRefType::get($_ctxt, $_self)">;
+
 def PortWriteOp : IbisOp<"port.write", [
-      DeclareOpInterfaceMethods<SymbolUserOpInterface>
+      InnerTypeToPortRefTypeConstraint<"value", "port">
 ]> {
   let summary = "Ibis port write";
   let description = [{
     Write a value to a local port (i.e. a port of 'this' class).
   }];
 
-  let arguments = (ins FlatSymbolRefAttr:$sym_name, AnyType:$input);
+  let arguments = (ins PortRefType:$port, AnyType:$value);
   let assemblyFormat = [{
-    $sym_name `(` $input `)` attr-dict `:` type($input)
-  }];
-}
-
-def InstanceReadOp : IbisOp<"instance.port.read", [
-      DeclareOpInterfaceMethods<SymbolUserOpInterface>
-]> {
-  let summary = "Ibis instance read";
-  let description = [{
-    Read the value of an instance port.
-  }];
-
-  let arguments = (ins SymbolRefAttr:$sym_name);
-  let results = (outs AnyType:$output);
-  let assemblyFormat = [{
-    $sym_name attr-dict `:` type($output)
-  }];
-}
-
-def InstanceWriteOp : IbisOp<"instance.port.write", [
-      DeclareOpInterfaceMethods<SymbolUserOpInterface>
-]> {
-  let summary = "Ibis instance write";
-  let description = [{
-    Write a value to an instance port.
-  }];
-
-  let arguments = (ins SymbolRefAttr:$sym_name, AnyType:$input);
-  let assemblyFormat = [{
-    $sym_name `(` $input `)` attr-dict `:` type($input)
+    $port `,` $value attr-dict `:` type($value)
   }];
 }
 

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -186,8 +186,8 @@ def GetInstanceInRefOp : IbisOp<"get_instance_in_ref"> {
   let summary = "Ibis get instance";
   let description = [{
     Given an Ibis class reference, returns a instance of said class. The instance
-    is specified by the symbol name of the instance of that instance in the referenced
-    class. In case of an opaque reference to the containing class, no type
+    is specified by the symbol name of the target child instance in the referenced
+    class instance. In case of an opaque reference to the containing class, no type
     validation is performed, and it is up to lowering passes to determine whether
     the instance of the given classref actually exists.
     The returned classref, however, is typed, given that one must specify the

--- a/include/circt/Dialect/Ibis/IbisTypes.h
+++ b/include/circt/Dialect/Ibis/IbisTypes.h
@@ -10,7 +10,15 @@
 #define CIRCT_DIALECT_IBIS_IBISTYPES_H
 
 #include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Types.h"
+
+namespace circt {
+namespace ibis {
+// Returns true if the given type is an opaque reference to an ibis class.
+bool isOpaqueClassRefType(mlir::Type type);
+} // namespace ibis
+} // namespace circt
 
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/Ibis/IbisTypes.h.inc"

--- a/include/circt/Dialect/Ibis/IbisTypes.td
+++ b/include/circt/Dialect/Ibis/IbisTypes.td
@@ -17,7 +17,7 @@ class IbisTypeDef<string name> : TypeDef<IbisDialect, name> { }
 def ClassRefType : IbisTypeDef<"ClassRef"> {
   let mnemonic = "classref";
   let parameters = (ins OptionalParameter<"mlir::FlatSymbolRefAttr">:$classRef);
-  let assemblyFormat = "`<` ($classRef^)?  `>`";
+  let assemblyFormat = "(`<` $classRef^  `>`)?";
   let description = [{
     A reference to an Ibis class. May be either a reference to a specific
     class (given a `$classRef` argument) or an opaque reference.

--- a/include/circt/Dialect/Ibis/IbisTypes.td
+++ b/include/circt/Dialect/Ibis/IbisTypes.td
@@ -9,4 +9,68 @@
 #ifndef CIRCT_DIALECT_IBIS_IBISTYPES_TD
 #define CIRCT_DIALECT_IBIS_IBISTYPES_TD
 
+include "circt/Dialect/Ibis/IbisDialect.td"
+include "mlir/IR/AttrTypeBase.td"
+
+class IbisTypeDef<string name> : TypeDef<IbisDialect, name> { }
+
+def ClassRefType : IbisTypeDef<"ClassRef"> {
+  let mnemonic = "classref";
+  let parameters = (ins OptionalParameter<"mlir::FlatSymbolRefAttr">:$classRef);
+  let assemblyFormat = "`<` ($classRef^)?  `>`";
+  let description = [{
+    A reference to an Ibis class. May be either a reference to a specific
+    class (given a `$classRef` argument) or an opaque reference.
+  }];
+
+  let extraClassDeclaration = [{
+    bool isOpaque() {
+      return !getClassRef();
+    }
+  }];
+
+  let builders = [
+    // Builds an opaque (unresolved) class reference.
+    TypeBuilder<(ins), [{
+      return $_get($_ctxt, nullptr);
+    }]>,
+    TypeBuilder<(ins "StringAttr":$classRef), [{
+      return $_get($_ctxt, FlatSymbolRefAttr::get(classRef));
+    }]>
+  ];
+}
+
+def AnyClassRefType : Type<
+  CPred<"$_self.isa<ibis::ClassRefType>()">,
+  "must be a !dc.classref<T?> type",
+  "ibis::ClassRefType">{
+}
+
+def OpaqueClassRefType : Type<
+  CPred<"ibis::isOpaqueClassRefType($_self)">,
+  "must be a !dc.classref<> type">,
+  BuildableType<"$_builder.getType<ibis::ClassRefType>()"> {
+}
+
+def PortRefType : IbisTypeDef<"PortRef"> {
+  let mnemonic = "portref";
+  let parameters = (ins "TypeAttr":$portTypeAttr);
+  let assemblyFormat = "`<` $portTypeAttr  `>`";
+  let description = [{
+    A reference to an Ibis port.
+  }];
+
+  let extraClassDeclaration = [{
+    Type getPortType() {
+      return getPortTypeAttr().getValue();
+    }
+  }];
+
+  let builders = [
+    TypeBuilder<(ins "Type":$t), [{
+      return $_get($_ctxt, TypeAttr::get(t));
+    }]>
+  ];
+}
+
 #endif // CIRCT_DIALECT_IBIS_IBISTYPES_TD

--- a/lib/Dialect/Ibis/IbisDialect.cpp
+++ b/lib/Dialect/Ibis/IbisDialect.cpp
@@ -16,11 +16,7 @@ using namespace ibis;
 #include "circt/Dialect/Ibis/IbisDialect.cpp.inc"
 
 void IbisDialect::initialize() {
-  // Register types.
-  addTypes<
-#define GET_TYPEDEF_LIST
-#include "circt/Dialect/Ibis/IbisTypes.cpp.inc"
-      >();
+  registerTypes();
 
   // Register operations.
   addOperations<

--- a/lib/Dialect/Ibis/IbisOps.cpp
+++ b/lib/Dialect/Ibis/IbisOps.cpp
@@ -233,9 +233,13 @@ LogicalResult GetPortOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // Lookup the target module type of the instance class reference.
   ModuleOp mod = getOperation()->getParentOfType<ModuleOp>();
   ClassRefType crt = getInstance().getType().cast<ClassRefType>();
+  // @teqdruid TODO: make this more efficient using
+  // innersymtablecollection when that's available to non-firrtl dialects.
   auto targetClass =
       symbolTable.lookupSymbolIn<ClassOp>(mod, crt.getClassRef());
   assert(targetClass && "should have been verified by the type system");
+  // @teqdruid TODO: make this more efficient using
+  // innersymtablecollection when that's available to non-firrtl dialects.
   Operation *targetOp =
       symbolTable.lookupSymbolIn(targetClass, getPortSymbolAttr());
 

--- a/lib/Dialect/Ibis/IbisOps.cpp
+++ b/lib/Dialect/Ibis/IbisOps.cpp
@@ -13,10 +13,81 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/FunctionImplementation.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
 
 using namespace mlir;
 using namespace circt;
 using namespace ibis;
+
+template <typename TSymAttr>
+ParseResult parseClassRefFromName(OpAsmParser &parser, Type &classRefType,
+                                  TSymAttr sym) {
+  // Nothing to parse, since this is already encoded in the child symbol.
+  classRefType = ClassRefType::get(parser.getContext(), sym);
+  return success();
+}
+
+template <typename TSymAttr>
+void printClassRefFromName(OpAsmPrinter &p, Operation *op, Type type,
+                           TSymAttr sym) {
+  // Nothing to print since this information is already encoded in the child
+  // symbol.
+}
+
+//===----------------------------------------------------------------------===//
+// ClassOp
+//===----------------------------------------------------------------------===//
+
+ParseResult ClassOp::parse(OpAsmParser &parser, OperationState &result) {
+  // Parse signature
+  StringAttr className;
+  if (parser.parseSymbolName(className, mlir::SymbolTable::getSymbolAttrName(),
+                             result.attributes))
+    return failure();
+
+  // parse "this"
+  OpAsmParser::Argument thisArg;
+  if (parser.parseLParen() ||
+      parser.parseArgument(thisArg, /*allowType=*/false) ||
+      parser.parseRParen())
+    return failure();
+
+  thisArg.type = parser.getBuilder().getType<ClassRefType>(className);
+
+  // Parse the attribute dict.
+  if (failed(parser.parseOptionalAttrDictWithKeyword(result.attributes)))
+    return failure();
+
+  // Parse the class body.
+  auto *body = result.addRegion();
+  if (parser.parseRegion(*body, {thisArg}))
+    return failure();
+
+  return success();
+}
+
+void ClassOp::print(OpAsmPrinter &p) {
+  p << " ";
+  p.printSymbolName(getSymName());
+  p << '(';
+  p.printRegionArgument(getThis(), {}, /*omitType*/ true);
+  p << ')';
+  llvm::SmallVector<::llvm::StringRef, 2> elidedAttrs;
+  elidedAttrs.push_back("sym_name");
+  p.printOptionalAttrDictWithKeyword((*this)->getAttrs(), elidedAttrs);
+  p << " ";
+  p.printRegion(getBody(), /*printEntryBlockArgs=*/false,
+                /*printBlockTerminators=*/true);
+}
+
+void ClassOp::getAsmBlockArgumentNames(mlir::Region &region,
+                                       OpAsmSetValueNameFn setNameFn) {
+  setNameFn(getThis(), "this");
+}
+
+//===----------------------------------------------------------------------===//
+// MethodOp
+//===----------------------------------------------------------------------===//
 
 ParseResult MethodOp::parse(OpAsmParser &parser, OperationState &result) {
   // Parse the name as a symbol.
@@ -155,134 +226,43 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
-// PortReadOp
+// InstanceOp
 //===----------------------------------------------------------------------===//
 
-// Verifies that a given source operation (TSrcOp is a port access) access a
-// symbol defined by the expected target operation (TTargetOp).
-template <typename TSrcOp, typename TTargetOp>
-LogicalResult verifyPortSymbolUses(
-    TSrcOp op, StringAttr symName, llvm::function_ref<Type(TSrcOp)> getPortType,
-    SymbolTableCollection &symbolTable,
-    llvm::function_ref<FailureOr<TTargetOp>(Operation *)> getTargetOp) {
+LogicalResult GetPortOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  // Lookup the target module type of the instance class reference.
+  ModuleOp mod = getOperation()->getParentOfType<ModuleOp>();
+  ClassRefType crt = getInstance().getType().cast<ClassRefType>();
+  auto targetClass =
+      symbolTable.lookupSymbolIn<ClassOp>(mod, crt.getClassRef());
+  assert(targetClass && "should have been verified by the type system");
+  Operation *targetOp =
+      symbolTable.lookupSymbolIn(targetClass, getPortSymbolAttr());
 
-  ClassOp parentClass = op->template getParentOfType<ClassOp>();
-  assert(parentClass && " must be contained in a ClassOp");
-  // TODO @teqdruid: use innerSym when available.
-  Operation *rootAccessOp = symbolTable.lookupSymbolIn(parentClass, symName);
+  if (!targetOp)
+    return emitOpError() << "port '" << getPortSymbolAttr()
+                         << "' does not exist in " << targetClass.getName();
 
-  TTargetOp targetOp;
-  if (auto getTargetRes = getTargetOp(rootAccessOp); succeeded(getTargetRes))
-    targetOp = *getTargetRes;
-  else
-    return failure();
+  auto portOp = dyn_cast<PortOpInterface>(targetOp);
+  if (!portOp)
+    return emitOpError() << "symbol '" << getPortSymbolAttr()
+                         << "' does not refer to a port";
 
-  Type expectedType = getPortType(op);
-  Type actualType = targetOp.getType();
-  if (actualType != expectedType)
-    return op->emitOpError() << "Expected type '" << expectedType
-                             << "' does not match actual port type, which was '"
-                             << actualType << "'";
+  Type targetPortType = portOp.getPortType();
+  Type thisPortType = getType().getPortType();
+  if (targetPortType != thisPortType)
+    return emitOpError() << "symbol '" << getPortSymbolAttr()
+                         << "' refers to a port of type " << targetPortType
+                         << ", but this op has type " << thisPortType;
+
   return success();
-}
-
-// verifies that a local port access (non-nested symbol reference) is valid (the
-// target symbol exists) and that the types of the port and the access match.
-template <typename TSrcOp, typename TTargetOp>
-LogicalResult
-verifyLocalPortSymbolUse(TSrcOp op,
-                         llvm::function_ref<Type(TSrcOp)> getPortType,
-                         SymbolTableCollection &symbolTable) {
-  FlatSymbolRefAttr symName = op.getSymNameAttr();
-  auto getTargetOp = [&](Operation *rootAccessOp) -> FailureOr<TTargetOp> {
-    auto targetOp = dyn_cast_or_null<TTargetOp>(rootAccessOp);
-    if (!targetOp)
-      return op->emitOpError()
-             << "expected '" << symName << "' to refer to a '"
-             << TTargetOp::getOperationName() << "' operation";
-    return {targetOp};
-  };
-
-  return verifyPortSymbolUses<TSrcOp, TTargetOp>(
-      op, symName.getAttr(), getPortType, symbolTable, getTargetOp);
-}
-
-LogicalResult PortReadOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyLocalPortSymbolUse<PortReadOp, OutputPortOp>(
-      *this, [](PortReadOp op) { return op.getOutput().getType(); },
-      symbolTable);
-}
-
-//===----------------------------------------------------------------------===//
-// PortWriteOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult
-PortWriteOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyLocalPortSymbolUse<PortWriteOp, InputPortOp>(
-      *this, [](PortWriteOp op) { return op.getInput().getType(); },
-      symbolTable);
-}
-
-//===----------------------------------------------------------------------===//
-// InstanceReadOp
-//===----------------------------------------------------------------------===//
-
-// verifies that an instance port access (nested symbol reference) is valid
-// (the target instance exists, and the target port inside the referenced class
-// exists) and that the types of the port and the access match.
-template <typename TSrcOp, typename TTargetOp>
-LogicalResult
-verifyInstancePortSymbolUses(TSrcOp op,
-                             llvm::function_ref<Type(TSrcOp)> getPortType,
-                             SymbolTableCollection &symbolTable) {
-  auto symName = op.getSymNameAttr();
-  auto getTargetOp = [&](Operation *rootAccessOp) -> FailureOr<TTargetOp> {
-    auto targetInstance = dyn_cast_or_null<InstanceOp>(rootAccessOp);
-    if (!targetInstance)
-      return op->emitOpError()
-             << "expected " << symName.getRootReference() << " to refer to a '"
-             << InstanceOp::getOperationName() << "' operation";
-
-    // Lookup the port in the instance. For now, only allow top level accesses -
-    // can easily extend this to nested instances as well.
-    ClassOp referencedClass = targetInstance.getClass();
-    // @teqdruid TODO: make this more efficient using
-    // innersymtablecollection when that's available to non-firrtl dialects.
-    auto targetOp = symbolTable.lookupSymbolIn<TTargetOp>(
-        referencedClass, symName.getLeafReference());
-
-    if (!targetOp)
-      return op->emitOpError() << "'" << symName << "' does not exist";
-
-    return {targetOp};
-  };
-
-  return verifyPortSymbolUses<TSrcOp, TTargetOp>(
-      op, symName.getRootReference(), getPortType, symbolTable, getTargetOp);
-}
-
-LogicalResult
-InstanceReadOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyInstancePortSymbolUses<InstanceReadOp, OutputPortOp>(
-      *this, [](InstanceReadOp op) { return op.getOutput().getType(); },
-      symbolTable);
-}
-
-//===----------------------------------------------------------------------===//
-// InstanceWriteOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult
-InstanceWriteOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyInstancePortSymbolUses<InstanceWriteOp, InputPortOp>(
-      *this, [](InstanceWriteOp op) { return op.getInput().getType(); },
-      symbolTable);
 }
 
 //===----------------------------------------------------------------------===//
 // TableGen generated logic
 //===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Ibis/IbisInterfaces.cpp.inc"
 
 // Provide the autogenerated implementation guts for the Op classes.
 #define GET_OP_CLASSES

--- a/lib/Dialect/Ibis/IbisTypes.cpp
+++ b/lib/Dialect/Ibis/IbisTypes.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/Ibis/IbisTypes.h"
+#include "circt/Dialect/Ibis/IbisDialect.h"
 #include "circt/Dialect/Ibis/IbisOps.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/StringExtras.h"
@@ -16,5 +17,21 @@
 using namespace circt;
 using namespace ibis;
 
+bool circt::ibis::isOpaqueClassRefType(mlir::Type type) {
+  auto classRef = type.dyn_cast<ClassRefType>();
+  if (!classRef)
+    return false;
+
+  return classRef.isOpaque();
+}
+
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/Ibis/IbisTypes.cpp.inc"
+
+void IbisDialect::registerTypes() {
+  // Register types.
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "circt/Dialect/Ibis/IbisTypes.cpp.inc"
+      >();
+}

--- a/test/Dialect/Ibis/errors.mlir
+++ b/test/Dialect/Ibis/errors.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s --split-input-file --verify-diagnostics
 
-ibis.class @C {
+ibis.class @C(%this) {
   ibis.method @typeMismatch1() -> ui32 {
     // expected-error @+1 {{must return a value}}
     ibis.return
@@ -9,7 +9,7 @@ ibis.class @C {
 
 // -----
 
-ibis.class @C {
+ibis.class @C(%this) {
   ibis.method @typeMismatch2() {
     %c = hw.constant 1 : i8
     // expected-error @+1 {{cannot return a value from a function with no result type}}
@@ -18,10 +18,25 @@ ibis.class @C {
 }
 
 // -----
-ibis.class @C {
+ibis.class @C(%this) {
   ibis.method @typeMismatch3() -> ui32 {
     %c = hw.constant 1 : i8
     // expected-error @+1 {{return type ('i8') must match function return type ('ui32')}}
     ibis.return %c : i8
   }
+}
+
+// -----
+
+ibis.class @MissingPort(%this) {
+  // expected-error @+1 {{'ibis.get_port' op port '@C_in' does not exist in MissingPort}}
+  %c_in = ibis.get_port %this, @C_in : !ibis.classref<@MissingPort> -> !ibis.portref<i1>
+}
+
+// -----
+
+ibis.class @PortTypeMismatch(%this) {
+  ibis.port.input @in : i1
+  // expected-error @+1 {{'ibis.get_port' op symbol '@in' refers to a port of type 'i1', but this op has type 'i2'}}
+  %c_in = ibis.get_port %this, @in : !ibis.classref<@PortTypeMismatch> -> !ibis.portref<i2>
 }

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -9,18 +9,20 @@
 // CHECK-NEXT:    ibis.port.input @C_in : i1
 // CHECK-NEXT:    ibis.port.output @C_out : i1
 // CHECK-NEXT:    %0 = ibis.instance @a, @A 
-// CHECK-NEXT:    %1 = ibis.get_parent %0 : !ibis.classref<@A>
-// CHECK-NEXT:    %2 = ibis.get_child @a : @A in %this : !ibis.classref<@C> 
+// CHECK-NEXT:    %1 = ibis.get_parent_of_ref %0 : !ibis.classref<@A>
+// CHECK-NEXT:    %2 = ibis.get_instance_in_ref @a : @A in %this : !ibis.classref<@C> 
+// CHECK-NEXT:    %3 = ibis.get_port %0, @A_in : !ibis.classref<@A> -> !ibis.portref<i1>
+// CHECK-NEXT:    %4 = ibis.get_instance_in_ref @a : @A in %1 : !ibis.classref 
 // CHECK-NEXT:    ibis.container @D {
-// CHECK-NEXT:      %3 = ibis.get_port %this, @C_in : !ibis.classref<@C> -> !ibis.portref<i1>
-// CHECK-NEXT:      %4 = ibis.get_port %this, @C_out : !ibis.classref<@C> -> !ibis.portref<i1>
+// CHECK-NEXT:      %5 = ibis.get_port %this, @C_in : !ibis.classref<@C> -> !ibis.portref<i1>
+// CHECK-NEXT:      %6 = ibis.get_port %this, @C_out : !ibis.classref<@C> -> !ibis.portref<i1>
 // CHECK-NEXT:      %true = hw.constant true
-// CHECK-NEXT:      ibis.port.write %4, %true : i1
-// CHECK-NEXT:      %5 = ibis.port.read %3 : !ibis.portref<i1>
-// CHECK-NEXT:      %6 = ibis.get_port %0, @A_in : !ibis.classref<@A> -> !ibis.portref<i1>
-// CHECK-NEXT:      %7 = ibis.get_port %0, @A_out : !ibis.classref<@A> -> !ibis.portref<i1>
-// CHECK-NEXT:      ibis.port.write %6, %5 : i1
-// CHECK-NEXT:      %8 = ibis.port.read %7 : !ibis.portref<i1>
+// CHECK-NEXT:      ibis.port.write %6, %true : i1
+// CHECK-NEXT:      %7 = ibis.port.read %5 : !ibis.portref<i1>
+// CHECK-NEXT:      %8 = ibis.get_port %0, @A_in : !ibis.classref<@A> -> !ibis.portref<i1>
+// CHECK-NEXT:      %9 = ibis.get_port %0, @A_out : !ibis.classref<@A> -> !ibis.portref<i1>
+// CHECK-NEXT:      ibis.port.write %8, %7 : i1
+// CHECK-NEXT:      %10 = ibis.port.read %9 : !ibis.portref<i1>
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
@@ -33,9 +35,16 @@ ibis.class @C(%this) {
   ibis.port.input @C_in : i1
   ibis.port.output @C_out : i1
 
+  // Instantiation
   %a = ibis.instance @a, @A
-  %parent = ibis.get_parent %a : !ibis.classref<@A>
-  %child = ibis.get_child @a : @A in %this : !ibis.classref<@C>
+
+  // Test get parent/child
+  %parent = ibis.get_parent_of_ref %a : !ibis.classref<@A>
+  %child = ibis.get_instance_in_ref @a : @A in %this : !ibis.classref<@C>
+  %a_in_cp = ibis.get_port %a, @A_in : !ibis.classref<@A> -> !ibis.portref<i1>
+
+  // Test siblings
+  %sibling = ibis.get_instance_in_ref @a : @A in %parent : !ibis.classref
 
   ibis.container @D {
     // Test local read/writes

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -1,56 +1,54 @@
 // RUN: circt-opt %s | circt-opt | FileCheck %s
 
-// CHECK-LABEL:  ibis.class @A {
+// CHECK-LABEL:  ibis.class @A(%this) {
 // CHECK-NEXT:    ibis.port.input @A_in : i1
 // CHECK-NEXT:    ibis.port.output @A_out : i1
 // CHECK-NEXT:  }
 
-// CHECK-LABEL:  ibis.class @C {
+// CHECK-LABEL:  ibis.class @C(%this) {
 // CHECK-NEXT:    ibis.port.input @C_in : i1
 // CHECK-NEXT:    ibis.port.output @C_out : i1
-// CHECK-NEXT:    ibis.instance @a, @A
-// CHECK-NEXT:    %true = hw.constant true
-// CHECK-NEXT:    ibis.port.write @C_in(%true) : i1
-// CHECK-NEXT:    %0 = ibis.port.read @C_out : i1
-// CHECK-NEXT:    ibis.instance.port.write @a::@A_in(%0) : i1
-// CHECK-NEXT:    %1 = ibis.instance.port.read @a::@A_out : i1
+// CHECK-NEXT:    %0 = ibis.instance @a, @A 
+// CHECK-NEXT:    %1 = ibis.get_parent %0 : !ibis.classref<@A>
+// CHECK-NEXT:    %2 = ibis.get_child @a : @A in %this : !ibis.classref<@C> 
 // CHECK-NEXT:    ibis.container @D {
-// CHECK-NEXT:      %true_0 = hw.constant true
-// CHECK-NEXT:      ibis.port.write @C_in(%true_0) : i1
-// CHECK-NEXT:      %2 = ibis.port.read @C_out : i1
-// CHECK-NEXT:      ibis.instance.port.write @a::@A_in(%2) : i1
-// CHECK-NEXT:      %3 = ibis.instance.port.read @a::@A_out : i1
+// CHECK-NEXT:      %3 = ibis.get_port %this, @C_in : !ibis.classref<@C> -> !ibis.portref<i1>
+// CHECK-NEXT:      %4 = ibis.get_port %this, @C_out : !ibis.classref<@C> -> !ibis.portref<i1>
+// CHECK-NEXT:      %true = hw.constant true
+// CHECK-NEXT:      ibis.port.write %4, %true : i1
+// CHECK-NEXT:      %5 = ibis.port.read %3 : !ibis.portref<i1>
+// CHECK-NEXT:      %6 = ibis.get_port %0, @A_in : !ibis.classref<@A> -> !ibis.portref<i1>
+// CHECK-NEXT:      %7 = ibis.get_port %0, @A_out : !ibis.classref<@A> -> !ibis.portref<i1>
+// CHECK-NEXT:      ibis.port.write %6, %5 : i1
+// CHECK-NEXT:      %8 = ibis.port.read %7 : !ibis.portref<i1>
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
-ibis.class @A {
+ibis.class @A(%this) {
   ibis.port.input @A_in : i1
   ibis.port.output @A_out : i1
 }
 
-ibis.class @C {
+ibis.class @C(%this) {
   ibis.port.input @C_in : i1
   ibis.port.output @C_out : i1
 
-  ibis.instance @a, @A
-
-  // Test local read/writes
-  %true = hw.constant true
-  ibis.port.write @C_in(%true) : i1
-  %c_out = ibis.port.read @C_out : i1
-
-  // Test cross-container read/writes
-  ibis.instance.port.write @a::@A_in(%c_out) : i1
-  %a_out = ibis.instance.port.read @a::@A_out : i1
+  %a = ibis.instance @a, @A
+  %parent = ibis.get_parent %a : !ibis.classref<@A>
+  %child = ibis.get_child @a : @A in %this : !ibis.classref<@C>
 
   ibis.container @D {
-    // Test parent read/writes
-    %true_1 = hw.constant true
-    ibis.port.write @C_in(%true_1) : i1
-    %c_out_1 = ibis.port.read @C_out : i1
+    // Test local read/writes
+    %c_in_p = ibis.get_port %this, @C_in : !ibis.classref<@C> -> !ibis.portref<i1>
+    %c_out_p = ibis.get_port %this, @C_out : !ibis.classref<@C> -> !ibis.portref<i1>
+    %true = hw.constant true
+    ibis.port.write %c_out_p, %true : i1
+    %c_out = ibis.port.read %c_in_p : !ibis.portref<i1>
 
-    // Test parent instance read/writes
-    ibis.instance.port.write @a::@A_in(%c_out_1) : i1
-    %a_out_1 = ibis.instance.port.read @a::@A_out : i1
+    // Test cross-container read/writes
+    %a_in_p = ibis.get_port %a, @A_in : !ibis.classref<@A> -> !ibis.portref<i1>
+    %a_out_p = ibis.get_port %a, @A_out : !ibis.classref<@A> -> !ibis.portref<i1>
+    ibis.port.write %a_in_p, %c_out : i1
+    %a_out = ibis.port.read %a_out_p : !ibis.portref<i1>
   }
 }

--- a/test/Dialect/Ibis/structure.mlir
+++ b/test/Dialect/Ibis/structure.mlir
@@ -2,7 +2,7 @@
 // RUN: circt-opt %s --ibis-call-prep | circt-opt | FileCheck %s --check-prefix=PREP
 
 
-// CHECK-LABEL: ibis.class @C {
+// CHECK-LABEL: ibis.class @C(%this) {
 // CHECK:         ibis.method @getAndSet(%x: ui32) -> ui32 {
 // CHECK:           ibis.return %x : ui32
 // CHECK:         ibis.method @returnNothing() {
@@ -10,7 +10,7 @@
 // CHECK:         ibis.method @returnNothingWithRet() {
 // CHECK:           ibis.return
 
-// PREP-LABEL: ibis.class @C {
+// PREP-LABEL: ibis.class @C(%this) {
 // PREP:         ibis.method @getAndSet(%arg: !hw.struct<x: ui32>) -> ui32 {
 // PREP:           %x = hw.struct_explode %arg : !hw.struct<x: ui32>
 // PREP:           ibis.return %x : ui32
@@ -20,7 +20,7 @@
 // PREP:         ibis.method @returnNothingWithRet(%arg: !hw.struct<>) {
 // PREP:           hw.struct_explode %arg : !hw.struct<>
 // PREP:           ibis.return
-ibis.class @C {
+ibis.class @C(%this) {
   ibis.method @getAndSet(%x: ui32) -> ui32 {
     ibis.return %x : ui32
   }
@@ -30,8 +30,8 @@ ibis.class @C {
   }
 }
 
-// CHECK-LABEL: ibis.class @User {
-// CHECK:         ibis.instance @c, @C
+// CHECK-LABEL: ibis.class @User(%this) {
+// CHECK:         [[c:%.+]] = ibis.instance @c, @C
 // CHECK:         ibis.method @getAndSetWrapper(%new_value: ui32) -> ui32 {
 // CHECK:           [[x:%.+]] = ibis.call @c::@getAndSet(%new_value) : (ui32) -> ui32
 // CHECK:           ibis.return [[x]] : ui32
@@ -40,18 +40,18 @@ ibis.class @C {
 // CHECK:           ibis.return [[x]] : ui32
 
 
-// PREP-LABEL: ibis.class @User {
-// PREP:         ibis.instance @c, @C
+// PREP-LABEL: ibis.class @User(%this) {
+// PREP:         [[c:%.+]] = ibis.instance @c, @C
 // PREP:         ibis.method @getAndSetWrapper(%arg: !hw.struct<new_value: ui32>) -> ui32 {
 // PREP:           %new_value = hw.struct_explode %arg : !hw.struct<new_value: ui32>
-// PREP:           %0 = hw.struct_create (%new_value) {sv.namehint = "getAndSet_args_called_from_getAndSetWrapper"} : !hw.struct<x: ui32>
-// PREP:           %1 = ibis.call @c::@getAndSet(%0) : (!hw.struct<x: ui32>) -> ui32
+// PREP:           %1 = hw.struct_create (%new_value) {sv.namehint = "getAndSet_args_called_from_getAndSetWrapper"} : !hw.struct<x: ui32>
+// PREP:           %2 = ibis.call @c::@getAndSet(%1) : (!hw.struct<x: ui32>) -> ui32
 // PREP:         ibis.method @getAndSetDup(%arg: !hw.struct<new_value: ui32>) -> ui32 {
 // PREP:           %new_value = hw.struct_explode %arg : !hw.struct<new_value: ui32>
-// PREP:           %0 = hw.struct_create (%new_value) {sv.namehint = "getAndSet_args_called_from_getAndSetDup"} : !hw.struct<x: ui32>
-// PREP:           %1 = ibis.call @c::@getAndSet(%0) : (!hw.struct<x: ui32>) -> ui32
-// PREP:           ibis.return %1 : ui32
-ibis.class @User {
+// PREP:           %1 = hw.struct_create (%new_value) {sv.namehint = "getAndSet_args_called_from_getAndSetDup"} : !hw.struct<x: ui32>
+// PREP:           %2 = ibis.call @c::@getAndSet(%1) : (!hw.struct<x: ui32>) -> ui32
+// PREP:           ibis.return %2 : ui32
+ibis.class @User(%this) {
   ibis.instance @c, @C
   ibis.method @getAndSetWrapper(%new_value: ui32) -> ui32 {
     %x = ibis.call @c::@getAndSet(%new_value): (ui32) -> ui32


### PR DESCRIPTION
Since port reads/writes are now done at a classref-based level, this also means that there's no reason to have specific instance reads/writes.

A bit of an outstanding question - `ibis.container` was isolated from above, which i still think is the right descision. However, we need to be able to grab `%this` somehow...

Some options:
1. Add a block argument to containers, e.g. `ibis.container @D(%parent)` wherein %parent is implied to be %this of the class
2. Disallow IsolatedFromAbove (what's currently done).