### PR TITLE
[FIRRTL][HW] Add verbatim literal support

### DIFF
--- a/include/circt/Dialect/HW/HWAttributes.td
+++ b/include/circt/Dialect/HW/HWAttributes.td
@@ -208,10 +208,17 @@ def ParamVerbatimAttr : AttrDef<HWDialect, "ParamVerbatim",
   let parameters = (ins "::mlir::StringAttr":$value,
                         AttributeSelfTypeParameter<"">:$type);
   let mnemonic = "param.verbatim";
-
   let hasCustomAssemblyFormat = 1;
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$value), [{
+      return get(value, NoneType::get(value.getContext()));
+    }]>,
+    AttrBuilderWithInferredContext<
+      (ins "::mlir::StringAttr":$value, "::mlir::Type":$type), [{
+        return get(value.getContext(), value, type);
+    }]>,
+  ];
 }
-
 
 /// Parameter Expression Opcodes.
 let cppNamespace = "circt::hw" in {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1269,7 +1269,7 @@ LogicalResult FExtModuleOp::verify() {
   auto checkParmValue = [&](Attribute elt) -> bool {
     auto param = cast<ParamDeclAttr>(elt);
     auto value = param.getValue();
-    if (isa<IntegerAttr, StringAttr, FloatAttr>(value))
+    if (isa<IntegerAttr, StringAttr, FloatAttr, hw::ParamVerbatimAttr>(value))
       return true;
     emitError() << "has unknown extmodule parameter value '"
                 << param.getName().getValue() << "' = " << value;

--- a/lib/Dialect/FIRRTL/Import/FIRLexer.h
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.h
@@ -74,11 +74,11 @@ public:
   std::string getStringValue() const;
   static std::string getStringValue(StringRef spelling);
 
-  /// Given a token containing a raw string, return its value, including removing
-  /// the quote characters and unescaping the quotes of the string. The lexer has
-  /// already verified that this token is valid.
-  std::string getRawStringValue() const;
-  static std::string getRawStringValue(StringRef spelling);
+  /// Given a token containing a verbatim string, return its value, including
+  /// removing the quote characters and unescaping the quotes of the string. The
+  /// lexer has already verified that this token is valid.
+  std::string getVerbatimStringValue() const;
+  static std::string getVerbatimStringValue(StringRef spelling);
 
   // Location processing.
   llvm::SMLoc getLoc() const;
@@ -133,7 +133,7 @@ private:
   FIRToken lexIdentifierOrKeyword(const char *tokStart);
   FIRToken lexNumber(const char *tokStart);
   void skipComment();
-  FIRToken lexString(const char *tokStart, bool isRaw);
+  FIRToken lexString(const char *tokStart, bool isVerbatim);
 
   const llvm::SourceMgr &sourceMgr;
   const mlir::StringAttr bufferNameIdentifier;

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4160,7 +4160,7 @@ ParseResult FIRCircuitParser::skipToModuleEnd(unsigned indent) {
 /// parameter ::= 'parameter' id '=' intLit NEWLINE
 /// parameter ::= 'parameter' id '=' StringLit NEWLINE
 /// parameter ::= 'parameter' id '=' floatingpoint NEWLINE
-/// parameter ::= 'parameter' id '=' RawString NEWLINE
+/// parameter ::= 'parameter' id '=' VerbatimStringLit NEWLINE
 ParseResult FIRCircuitParser::parseParameter(StringAttr &resultName,
                                              TypedAttr &resultValue,
                                              SMLoc &resultLoc) {
@@ -4201,10 +4201,11 @@ ParseResult FIRCircuitParser::parseParameter(StringAttr &resultName,
     consumeToken(FIRToken::string);
     break;
   }
-  case FIRToken::raw_string: {
+  case FIRToken::verbatim_string: {
     // Drop the single quotes and unescape the ones inside.
-    value = builder.getStringAttr(getToken().getRawStringValue());
-    consumeToken(FIRToken::raw_string);
+    auto text = builder.getStringAttr(getToken().getVerbatimStringValue());
+    value = hw::ParamVerbatimAttr::get(text);
+    consumeToken(FIRToken::verbatim_string);
     break;
   }
   case FIRToken::floatingpoint:

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -55,7 +55,7 @@ TOK_LITERAL(radix_specified_integer) // 0b101010, 0o52, 0d42, 0h2a and negations
 TOK_LITERAL(floatingpoint)           // 42.0
 TOK_LITERAL(version)                 // 1.2.3
 TOK_LITERAL(string)                  // "foo"
-TOK_LITERAL(raw_string)              // 'foo'
+TOK_LITERAL(verbatim_string)         // 'foo'
 
 TOK_LITERAL(fileinfo)
 TOK_LITERAL(inlineannotation) // %[{"foo":"bar"}]

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -899,11 +899,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     c <= mux(sel, a, b)
     z <= mux(sel, x, y)
 
-  ; CHECK-LABEL: firrtl.extmodule private @RawStringParam
-  ; CHECK-SAME:    <TYPE: none = "bit",
-  ; CHECK-SAME:     FORMAT: none = "xyz_timeout=%d\\n",
-  ; CHECK-SAME:     MIXED_QUOTES: none = "\22'\\\22">
-  extmodule RawStringParam :
+  ; CHECK-LABEL: firrtl.extmodule private @VerbatimStringParam
+  ; CHECK-SAME:    <TYPE: none = #hw.param.verbatim<"bit">,
+  ; CHECK-SAME:     FORMAT: none = #hw.param.verbatim<"xyz_timeout=%d\\n">,
+  ; CHECK-SAME:     MIXED_QUOTES: none = #hw.param.verbatim<"\22'\\\22">>
+  extmodule VerbatimStringParam :
     parameter TYPE = 'bit'
     parameter FORMAT = 'xyz_timeout=%d\n'
     parameter MIXED_QUOTES = '"\'\"'

--- a/test/firtool/verbatim-parameter.fir
+++ b/test/firtool/verbatim-parameter.fir
@@ -1,0 +1,20 @@
+; RUN: firtool %s | FileCheck %s
+
+FIRRTL version 3.1.0
+
+circuit Top :
+  ; CHECK-LABEL module Top
+  module Top :
+    output o : UInt<8>
+    ; CHECK:       Blah #(
+    ; CHECK-NEXT:    .foo(test test test 123)
+    ; CHECK-NEXT:  ) e (
+    ; CHECK-NEXT:    .o (o)
+    ; CHECK-NEXT:  )
+    inst e of MyExt
+    connect o, e.o
+
+  extmodule MyExt :
+    output o : UInt<8>
+    defname = Blah
+    parameter foo = 'test test test 123'


### PR DESCRIPTION
Currently, FIRRTL params values wrapped in 'single-quotes' are emitted as string in the verilog output, but they should be emitted verbatim.

This PR corrects this behaviour in the FIRParser, by emitting hw::ParamVerbatimAttr instead of StringAttr for raw/verbatim string params.

Summary of changes:

- Rename "raw string" to "verbatim string" in the FIRRTL parser and lexer.
- Add new builder for ParamVerbatimAttr that sets the type to NoneType.
- Update the FIRRTL parser to emit a hw::ParamVerbatimAttr of type NoneType.

Fixes: #4584