### PR TITLE
[NFC] .clang-tidy: Disable misc-use-anonymous-namespace .

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >
         -misc-const-correctness,
         -misc-unused-parameters,
         -misc-non-private-member-variables-in-classes,
+        -misc-use-anonymous-namespace,
         readability-identifier-naming,
         bugprone-argument-comment,
         bugprone-assert-side-effect,


### PR DESCRIPTION
Conflicts with coding standard re:static methods,
see upstream's similar change:
4c9f1584ce2c373dc571068af5fd65f2e16d05d2 .