### PR TITLE
[FIRRTL] Add has_been_reset intrinsic

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -888,6 +888,22 @@ def PlusArgsValueIntrinsicOp : FIRRTLOp<"int.plusargs.value",
   let assemblyFormat = "$formatString attr-dict `:` type($result)";
 }
 
+def HasBeenResetIntrinsicOp : FIRRTLOp<"int.has_been_reset", [Pure]> {
+  let summary = "Check that a proper reset has been seen.";
+  let description = [{
+    The result of `verif.has_been_reset` reads as 0 immediately after simulation
+    startup and after each power-cycle in a power-aware simulation. The result
+    remains 0 before and during reset and only switches to 1 after the reset is
+    deasserted again.
+
+    See the corresponding `verif.has_been_reset` operation.
+  }];
+  let arguments = (ins NonConstClockType:$clock, AnyResetType:$reset);
+  let results = (outs NonConstUInt1Type:$result);
+  let hasFolder = 1;
+  let assemblyFormat = "$clock `,` $reset attr-dict `:` type($reset)";
+}
+
 //===----------------------------------------------------------------------===//
 // Verbatim
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -891,7 +891,7 @@ def PlusArgsValueIntrinsicOp : FIRRTLOp<"int.plusargs.value",
 def HasBeenResetIntrinsicOp : FIRRTLOp<"int.has_been_reset", [Pure]> {
   let summary = "Check that a proper reset has been seen.";
   let description = [{
-    The result of `verif.has_been_reset` reads as 0 immediately after simulation
+    The result of `firrtl.int.has_been_reset` reads as 0 immediately after simulation
     startup and after each power-cycle in a power-aware simulation. The result
     remains 0 before and during reset and only switches to 1 after the reset is
     deasserted again.

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -53,6 +53,7 @@ public:
             LTLNotIntrinsicOp, LTLImplicationIntrinsicOp,
             LTLEventuallyIntrinsicOp, LTLClockIntrinsicOp,
             LTLDisableIntrinsicOp, Mux2CellIntrinsicOp, Mux4CellIntrinsicOp,
+            HasBeenResetIntrinsicOp,
             // Miscellaneous.
             BitsPrimOp, HeadPrimOp, MuxPrimOp, PadPrimOp, ShlPrimOp, ShrPrimOp,
             TailPrimOp, VerbatimExprOp, HWStructCastOp, BitCastOp, RefSendOp,
@@ -173,6 +174,7 @@ public:
   HANDLE(LTLDisableIntrinsicOp, Unhandled);
   HANDLE(Mux4CellIntrinsicOp, Unhandled);
   HANDLE(Mux2CellIntrinsicOp, Unhandled);
+  HANDLE(HasBeenResetIntrinsicOp, Unhandled);
 
   // Miscellaneous.
   HANDLE(BitsPrimOp, Unhandled);

--- a/include/circt/Dialect/Verif/VerifOps.h
+++ b/include/circt/Dialect/Verif/VerifOps.h
@@ -12,6 +12,7 @@
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/Verif/VerifDialect.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/Verif/Verif.h.inc"

--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -12,6 +12,7 @@
 include "circt/Dialect/Verif/VerifDialect.td"
 include "circt/Dialect/LTL/LTLTypes.td"
 include "circt/Dialect/HW/HWTypes.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 class VerifOp<string mnemonic, list<Trait> traits = []> :

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -3234,3 +3234,24 @@ void RefReleaseInitialOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.add(eraseIfPredFalse<RefReleaseInitialOp>);
 }
+
+//===----------------------------------------------------------------------===//
+// HasBeenResetIntrinsicOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult HasBeenResetIntrinsicOp::fold(FoldAdaptor adaptor) {
+  // The folds in here should reflect the ones for `verif::HasBeenResetOp`.
+
+  // Fold to zero if the reset is a constant. In this case the op is either
+  // permanently in reset or never resets. Both mean that the reset never
+  // finishes, so this op never returns true.
+  if (adaptor.getReset())
+    return getIntZerosAttr(UIntType::get(getContext(), 1));
+
+  // Fold to zero if the clock is a constant and the reset is synchronous. In
+  // that case the reset will never be started.
+  if (isUInt1(getReset().getType()) && adaptor.getClock())
+    return getIntZerosAttr(UIntType::get(getContext(), 1));
+
+  return {};
+}

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -88,6 +88,21 @@ static ParseResult sizedPort(StringRef name, FModuleLike mod, unsigned n,
   return success();
 }
 
+static ParseResult resetPort(StringRef name, FModuleLike mod, unsigned n) {
+  auto ports = mod.getPorts();
+  if (n >= ports.size()) {
+    mod.emitError(name) << " missing port " << n;
+    return failure();
+  }
+  if (isa<ResetType, AsyncResetType>(ports[n].type))
+    return success();
+  if (auto uintType = dyn_cast<UIntType>(ports[n].type))
+    if (uintType.getWidth() == 1)
+      return success();
+  mod.emitError(name) << " port " << n << " not of correct type";
+  return failure();
+}
+
 static ParseResult hasNParam(StringRef name, FModuleLike mod, unsigned n,
                              unsigned c = 0) {
   unsigned num = 0;
@@ -560,6 +575,33 @@ static bool lowerCirctVerif(InstanceGraph &ig, FModuleLike mod) {
   return true;
 }
 
+static bool lowerCirctHasBeenReset(InstanceGraph &ig, FModuleLike mod) {
+  if (hasNPorts("circt.has_been_reset", mod, 3) ||
+      namedPort("circt.has_been_reset", mod, 0, "clock") ||
+      namedPort("circt.has_been_reset", mod, 1, "reset") ||
+      namedPort("circt.has_been_reset", mod, 2, "out") ||
+      typedPort<ClockType>("circt.has_been_reset", mod, 0) ||
+      resetPort("circt.has_been_reset", mod, 1) ||
+      sizedPort<UIntType>("circt.has_been_reset", mod, 2, 1) ||
+      hasNParam("circt.has_been_reset", mod, 0))
+    return false;
+
+  for (auto *use : ig.lookup(mod)->uses()) {
+    auto inst = cast<InstanceOp>(use->getInstance().getOperation());
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto clock =
+        builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    auto reset =
+        builder.create<WireOp>(inst.getResult(1).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(clock);
+    inst.getResult(1).replaceAllUsesWith(reset);
+    auto out = builder.create<HasBeenResetIntrinsicOp>(clock, reset);
+    inst.getResult(2).replaceAllUsesWith(out);
+    inst.erase();
+  }
+  return true;
+}
+
 std::pair<const char *, std::function<bool(InstanceGraph &, FModuleLike)>>
     intrinsics[] = {
         {"circt.sizeof", lowerCirctSizeof},
@@ -599,7 +641,9 @@ std::pair<const char *, std::function<bool(InstanceGraph &, FModuleLike)>>
         {"circt.mux2cell", lowerCirctMuxCell<true>},
         {"circt_mux2cell", lowerCirctMuxCell<true>},
         {"circt.mux4cell", lowerCirctMuxCell<false>},
-        {"circt_mux4cell", lowerCirctMuxCell<false>}};
+        {"circt_mux4cell", lowerCirctMuxCell<false>},
+        {"circt.has_been_reset", lowerCirctHasBeenReset},
+        {"circt_has_been_reset", lowerCirctHasBeenReset}};
 
 // This is the main entrypoint for the lowering pass.
 void LowerIntrinsicsPass::runOnOperation() {

--- a/test/Conversion/FIRRTLToHW/intrinsics-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics-errors.mlir
@@ -21,3 +21,15 @@ firrtl.circuit "Foo" {
     firrtl.strictconnect %0, %2 : !firrtl.uint<1>
   }
 }
+
+// -----
+
+firrtl.circuit "Foo" {
+  firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.reset, out %hbr: !firrtl.uint<1>) {
+    // expected-error @below {{uninferred reset passed to 'has_been_reset'; requires sync or async reset}}
+    // expected-note @below {{reset is of type '!firrtl.reset', should be '!firrtl.uint<1>' or '!firrtl.asyncreset'}}
+    // expected-error @below {{couldn't handle this operation}}
+    %0 = firrtl.int.has_been_reset %clock, %reset : !firrtl.reset
+    firrtl.strictconnect %hbr, %0 : !firrtl.uint<1>
+  }
+}

--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -152,4 +152,21 @@ firrtl.circuit "Intrinsics" {
     %0 = firrtl.int.ltl.delay %a, 42 : (!firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.strictconnect %c, %0 : !firrtl.uint<1>
   }
+
+  // CHECK-LABEL: hw.module @HasBeenReset
+  firrtl.module @HasBeenReset(
+    in %clock: !firrtl.clock,
+    in %reset1: !firrtl.uint<1>,
+    in %reset2: !firrtl.asyncreset,
+    out %hbr1: !firrtl.uint<1>,
+    out %hbr2: !firrtl.uint<1>
+  ) {
+    // CHECK-NEXT: [[TMP1:%.+]] = verif.has_been_reset %clock, sync %reset1
+    // CHECK-NEXT: [[TMP2:%.+]] = verif.has_been_reset %clock, async %reset2
+    // CHECK-NEXT: hw.output [[TMP1]], [[TMP2]]
+    %0 = firrtl.int.has_been_reset %clock, %reset1 : !firrtl.uint<1>
+    %1 = firrtl.int.has_been_reset %clock, %reset2 : !firrtl.asyncreset
+    firrtl.strictconnect %hbr1, %0 : !firrtl.uint<1>
+    firrtl.strictconnect %hbr2, %1 : !firrtl.uint<1>
+  }
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3097,4 +3097,61 @@ firrtl.module @Issue5650(in %io_y: !firrtl.uint<1>, out %io_x: !firrtl.uint<1>) 
   firrtl.strictconnect %3, %2 : !firrtl.uint<1>
 }
 
+// CHECK-LABEL: @HasBeenReset
+firrtl.module @HasBeenReset(in %clock: !firrtl.clock, in %reset1: !firrtl.uint<1>, in %reset2: !firrtl.asyncreset, in %reset3: !firrtl.reset) {
+  // CHECK-NEXT: %c0_ui1 = firrtl.constant 0
+  // CHECK-NEXT: %c0_clock = firrtl.specialconstant 0
+  // CHECK-NEXT: %c1_clock = firrtl.specialconstant 1
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+  %c0_asyncreset = firrtl.specialconstant 0 : !firrtl.asyncreset
+  %c1_asyncreset = firrtl.specialconstant 1 : !firrtl.asyncreset
+  %c0_reset = firrtl.specialconstant 0 : !firrtl.reset
+  %c1_reset = firrtl.specialconstant 1 : !firrtl.reset
+  %c0_clock = firrtl.specialconstant 0 : !firrtl.clock
+  %c1_clock = firrtl.specialconstant 1 : !firrtl.clock
+
+  // CHECK-NEXT: firrtl.node sym @constResetS0 %c0_ui1
+  // CHECK-NEXT: firrtl.node sym @constResetS1 %c0_ui1
+  // CHECK-NEXT: firrtl.node sym @constResetA0 %c0_ui1
+  // CHECK-NEXT: firrtl.node sym @constResetA1 %c0_ui1
+  // CHECK-NEXT: firrtl.node sym @constResetR0 %c0_ui1
+  // CHECK-NEXT: firrtl.node sym @constResetR1 %c0_ui1
+  %r0 = firrtl.int.has_been_reset %clock, %c0_ui1 : !firrtl.uint<1>
+  %r1 = firrtl.int.has_been_reset %clock, %c1_ui1 : !firrtl.uint<1>
+  %r2 = firrtl.int.has_been_reset %clock, %c0_asyncreset : !firrtl.asyncreset
+  %r3 = firrtl.int.has_been_reset %clock, %c1_asyncreset : !firrtl.asyncreset
+  %r4 = firrtl.int.has_been_reset %clock, %c0_reset : !firrtl.reset
+  %r5 = firrtl.int.has_been_reset %clock, %c1_reset : !firrtl.reset
+  %constResetS0 = firrtl.node sym @constResetS0 %r0 : !firrtl.uint<1>
+  %constResetS1 = firrtl.node sym @constResetS1 %r1 : !firrtl.uint<1>
+  %constResetA0 = firrtl.node sym @constResetA0 %r2 : !firrtl.uint<1>
+  %constResetA1 = firrtl.node sym @constResetA1 %r3 : !firrtl.uint<1>
+  %constResetR0 = firrtl.node sym @constResetR0 %r4 : !firrtl.uint<1>
+  %constResetR1 = firrtl.node sym @constResetR1 %r5 : !firrtl.uint<1>
+
+  // CHECK-NEXT: [[TMP1:%.+]] = firrtl.int.has_been_reset %c0_clock, %reset2
+  // CHECK-NEXT: [[TMP2:%.+]] = firrtl.int.has_been_reset %c1_clock, %reset2
+  // CHECK-NEXT: [[TMP3:%.+]] = firrtl.int.has_been_reset %c0_clock, %reset3
+  // CHECK-NEXT: [[TMP4:%.+]] = firrtl.int.has_been_reset %c1_clock, %reset3
+  // CHECK-NEXT: firrtl.node sym @constClockS0 %c0_ui1
+  // CHECK-NEXT: firrtl.node sym @constClockS1 %c0_ui1
+  // CHECK-NEXT: firrtl.node sym @constClockA0 [[TMP1]]
+  // CHECK-NEXT: firrtl.node sym @constClockA1 [[TMP2]]
+  // CHECK-NEXT: firrtl.node sym @constClockR0 [[TMP3]]
+  // CHECK-NEXT: firrtl.node sym @constClockR1 [[TMP4]]
+  %c0 = firrtl.int.has_been_reset %c0_clock, %reset1 : !firrtl.uint<1>
+  %c1 = firrtl.int.has_been_reset %c1_clock, %reset1 : !firrtl.uint<1>
+  %c2 = firrtl.int.has_been_reset %c0_clock, %reset2 : !firrtl.asyncreset
+  %c3 = firrtl.int.has_been_reset %c1_clock, %reset2 : !firrtl.asyncreset
+  %c4 = firrtl.int.has_been_reset %c0_clock, %reset3 : !firrtl.reset
+  %c5 = firrtl.int.has_been_reset %c1_clock, %reset3 : !firrtl.reset
+  %constClockS0 = firrtl.node sym @constClockS0 %c0 : !firrtl.uint<1>
+  %constClockS1 = firrtl.node sym @constClockS1 %c1 : !firrtl.uint<1>
+  %constClockA0 = firrtl.node sym @constClockA0 %c2 : !firrtl.uint<1>
+  %constClockA1 = firrtl.node sym @constClockA1 %c3 : !firrtl.uint<1>
+  %constClockR0 = firrtl.node sym @constClockR0 %c4 : !firrtl.uint<1>
+  %constClockR1 = firrtl.node sym @constClockR1 %c5 : !firrtl.uint<1>
+}
+
 }

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -194,4 +194,30 @@ firrtl.circuit "Foo" {
     %sel_0, %high, %low, %out_0 = firrtl.instance "mux2" @Mux2Cell(in sel: !firrtl.uint<1>, in high: !firrtl.uint, in low: !firrtl.uint, out out: !firrtl.uint)
     %sel_1, %v4, %v3, %v2, %v1, %out_1 = firrtl.instance "mux4" @Mux4Cell(in sel: !firrtl.uint<2>, in v3: !firrtl.uint, in v2: !firrtl.uint, in v1: !firrtl.uint, in v0: !firrtl.uint, out out: !firrtl.uint)
   }
+
+  // CHECK-NOT: HBRInt1
+  // CHECK-NOT: HBRInt2
+  // CHECK-NOT: HBRInt3
+  firrtl.intmodule @HBRInt1(in clock: !firrtl.clock, in reset: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.has_been_reset"}
+  firrtl.intmodule @HBRInt2(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.has_been_reset"}
+  firrtl.intmodule @HBRInt3(in clock: !firrtl.clock, in reset: !firrtl.reset, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.has_been_reset"}
+
+  // CHECK: HasBeenReset
+  firrtl.module @HasBeenReset(in %clock: !firrtl.clock, in %reset1: !firrtl.uint<1>, in %reset2: !firrtl.asyncreset, in %reset3: !firrtl.reset) {
+    // CHECK-NOT: firrtl.instance
+    // CHECK: firrtl.int.has_been_reset {{%.+}}, {{%.+}} : !firrtl.uint<1>
+    // CHECK-NOT: firrtl.instance
+    // CHECK: firrtl.int.has_been_reset {{%.+}}, {{%.+}} : !firrtl.asyncreset
+    // CHECK-NOT: firrtl.instance
+    // CHECK: firrtl.int.has_been_reset {{%.+}}, {{%.+}} : !firrtl.reset
+    %in_clock1, %in_reset1, %hbr1 = firrtl.instance "" @HBRInt1(in clock: !firrtl.clock, in reset: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+    %in_clock2, %in_reset2, %hbr2 = firrtl.instance "" @HBRInt2(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out out: !firrtl.uint<1>)
+    %in_clock3, %in_reset3, %hbr3 = firrtl.instance "" @HBRInt3(in clock: !firrtl.clock, in reset: !firrtl.reset, out out: !firrtl.uint<1>)
+    firrtl.strictconnect %in_clock1, %clock : !firrtl.clock
+    firrtl.strictconnect %in_clock2, %clock : !firrtl.clock
+    firrtl.strictconnect %in_clock3, %clock : !firrtl.clock
+    firrtl.strictconnect %in_reset1, %reset1 : !firrtl.uint<1>
+    firrtl.strictconnect %in_reset2, %reset2 : !firrtl.asyncreset
+    firrtl.strictconnect %in_reset3, %reset3 : !firrtl.reset
+  }
 }

--- a/test/firtool/has_been_reset.fir
+++ b/test/firtool/has_been_reset.fir
@@ -1,0 +1,35 @@
+; RUN: firtool --ir-hw %s | FileCheck %s
+
+circuit Foo:
+  intmodule HasBeenReset:
+    input clock: Clock
+    input reset: Reset
+    output out: UInt<1>
+    intrinsic = circt_has_been_reset
+
+  module Foo:
+    input clock: Clock
+    input reset1: UInt<1>
+    input reset2: AsyncReset
+    output hbr: UInt<1>[2]
+
+    wire resetWire1 : Reset
+    wire resetWire2 : Reset
+
+    resetWire1 <= reset1
+    resetWire2 <= reset2
+
+    inst int1 of HasBeenReset
+    int1.clock <= clock
+    int1.reset <= resetWire1
+    hbr[0] <= int1.out
+
+    inst int2 of HasBeenReset
+    int2.clock <= clock
+    int2.reset <= resetWire2
+    hbr[1] <= int2.out
+
+; CHECK-LABEL: hw.module @Foo
+; CHECK-NEXT: verif.has_been_reset %clock, sync %reset1
+; CHECK-NEXT: verif.has_been_reset %clock, async %reset2
+; CHECK-NEXT: hw.output


### PR DESCRIPTION
Add the `circt.has_been_reset` FIRRTL intrinsic. More specifically:

- Add the `firrtl::HasBeenResetIntrinsicOp`
- Add support for the op in the FIRRTL visitor
- Add support for the op in `LowerIntrinsics`
- Lower the op to `verif::HasBeenResetOp`, inferring the sync/async-ness from the reset's FIRRTL type
- Add tests for `LowerIntrinsics`, `LowerToHW`, and the canonicalizer
- Add a firtool end-to-end test to check that this interacts properly with the `InferResets` pass