### PR TITLE
[FIRRTL][NFC] Add fir tests relating to probes, from spec.

### DIFF
--- a/test/firtool/spec/refs/define-flip-to-passive.fir
+++ b/test/firtool/spec/refs/define-flip-to-passive.fir
@@ -1,0 +1,15 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+FIRRTL version 3.0.0
+circuit Foo :
+  ; SPEC EXAMPLE BEGIN
+  module Foo :
+    input x : {a: UInt<3>, flip b: UInt} ; XXX: width on x.a
+    output y : {a: UInt, flip b: UInt<3>} ; XXX: width on y.b
+    output xp : Probe<{a: UInt, b: UInt}> ; passive
+
+    wire p : {a: UInt, flip b: UInt} ; p is not passive
+    define xp = probe(p)
+    connect p, x
+    connect y, p
+   ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/define-subelement.fir
+++ b/test/firtool/spec/refs/define-subelement.fir
@@ -1,0 +1,18 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+FIRRTL version 3.0.0
+circuit Foo:
+  ; SPEC EXAMPLE BEGIN
+  module Foo:
+    input x : UInt<3> ; XXX: width added
+    output y : {x: UInt, p: Probe<UInt>}
+    output z : Probe<UInt>[2]
+
+    wire w : UInt
+    connect w, x
+    connect y.x, w
+
+    define y.p = probe(w)
+    define z[0] = probe(w)
+    define z[1] = probe(w)
+   ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/define.fir
+++ b/test/firtool/spec/refs/define.fir
@@ -1,0 +1,22 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+FIRRTL version 3.0.0
+circuit Refs:
+  ; SPEC EXAMPLE BEGIN
+  module Refs:
+    input clock:  Clock
+    input p : {x: UInt<1>, flip y : UInt<3>} ; XXX: modified, for init
+    output a : Probe<{x: UInt, y: UInt}> ; read-only ref. to wire 'p'
+    output b : RWProbe<UInt> ; force-able ref. to node 'q', inferred width.
+    output c : Probe<UInt> ; read-only ref. to register 'r', inferred width. ; XXX: modified, needs width
+    output d : Probe<Clock> ; ref. to input clock port
+
+    connect p.y, UInt<3>(0) ; XXX: modified, for init
+    define a = probe(p) ; probe is passive
+    node q = p.x ; XXX: modified, workaround inability create non-const node w/literal initializer.
+    define b = rwprobe(q)
+    reg r: UInt, clock
+    connect r, p.x ; XXX: modified, initialize register
+    define c = probe(r)
+    define d = probe(clock)
+  ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/endpoints.fir
+++ b/test/firtool/spec/refs/endpoints.fir
@@ -1,0 +1,40 @@
+; RUN: firtool %s --verify-diagnostics
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false --verify-diagnostics
+FIRRTL version 3.0.0
+circuit Top :
+  ; expected-error @+3 {{input probes not yet supported}}
+  ; SPEC EXAMPLE BEGIN
+  module Consumer:
+    input in : {a: UInt, pref: Probe<UInt>, flip cref: Probe<UInt>}
+    ; ...
+    node n = in.a
+    define in.cref = probe(n)
+
+  module Producer:
+    output out : {a: UInt, pref: Probe<UInt>, flip cref: Probe<UInt>}
+    wire x : UInt
+    define out.pref = probe(x)
+    ; ...
+    connect out.a, x
+
+  module Connect:
+    output out : {pref: Probe<UInt>, cref: Probe<UInt>}
+
+    inst a of Consumer
+    inst b of Producer
+
+    ; Producer => Consumer
+    connect a.in.a, b.out.a
+    define a.in.pref = b.out.pref
+    define b.out.cref = a.in.cref
+
+    ; Send references out
+    define out.pref = b.out.pref
+    define out.cref = a.in.cref
+
+  module Top:
+    inst c of Connect
+
+    node producer_debug = read(c.out.pref); ; Producer-side signal
+    node consumer_debug = read(c.out.cref); ; Consumer-side signal
+  ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/ext.fir
+++ b/test/firtool/spec/refs/ext.fir
@@ -1,0 +1,11 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+circuit MyExternalModuleWithRefs :
+  ; SPEC EXAMPLE BEGIN
+  extmodule MyExternalModuleWithRefs :
+    input foo : UInt<2>
+    output mysignal : Probe<UInt<1>>
+    output myreg : RWProbe<UInt<8>>
+    ref mysignal is "a.b"
+    ref myreg is "x.y"
+  ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/force_and_release.fir
+++ b/test/firtool/spec/refs/force_and_release.fir
@@ -1,0 +1,36 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+FIRRTL version 3.0.0
+circuit ForceAndRelease:
+  ; SPEC EXAMPLE BEGIN
+  module ForceAndRelease:
+    input a: UInt<2>
+    input clock : Clock
+    input cond : UInt<1>
+    output o : UInt<3>
+
+    inst r of AddRefs
+    connect o, r.sum
+
+    force(clock, cond, r.a, a)
+    release(clock, not(cond), r.a)
+
+  ; SPEC EXAMPLE END
+  ; include "force_addrefs.fir"
+  module AddRefs:
+    output a : RWProbe<UInt<2>>
+    output b : RWProbe<UInt<2>>
+    output c : RWProbe<UInt<2>>
+    output sum : UInt<3>
+
+    ; XXX: modified, workaround inability create non-const node w/literal initializer.
+    wire w : UInt<2>
+    connect w, UInt<2>(0)
+    node x = w
+    node y = w
+    node z = w
+    connect sum, add(x, add(y, z))
+
+    define a = rwprobe(x)
+    define b = rwprobe(y)
+    define c = rwprobe(z)

--- a/test/firtool/spec/refs/force_initial.fir
+++ b/test/firtool/spec/refs/force_initial.fir
@@ -1,0 +1,37 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+FIRRTL version 3.0.0
+
+circuit ForceAndRelease:
+  ; SPEC EXAMPLE BEGIN
+  module ForceAndRelease:
+    output o : UInt<3>
+
+    inst r of AddRefs
+    connect o, r.sum
+
+    force_initial(r.a, UInt<2>(0))
+    force_initial(r.a, UInt<2>(1))
+    force_initial(r.b, UInt<2>(2))
+    force_initial(r.c, UInt<2>(3))
+    release_initial(r.c)
+  ; SPEC EXAMPLE END
+
+  ; include "force_addrefs.fir"
+  module AddRefs:
+    output a : RWProbe<UInt<2>>
+    output b : RWProbe<UInt<2>>
+    output c : RWProbe<UInt<2>>
+    output sum : UInt<3>
+
+    ; XXX: modified, workaround inability create non-const node w/literal initializer.
+    wire w : UInt<2>
+    connect w, UInt<2>(0)
+    node x = w
+    node y = w
+    node z = w
+    connect sum, add(x, add(y, z))
+
+    define a = rwprobe(x)
+    define b = rwprobe(y)
+    define c = rwprobe(z)

--- a/test/firtool/spec/refs/force_nonpassive.fir
+++ b/test/firtool/spec/refs/force_nonpassive.fir
@@ -1,0 +1,32 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+FIRRTL version 3.0.0
+
+circuit Top :
+  ; SPEC EXAMPLE BEGIN
+  module Top:
+    input x : {a: UInt<2>, flip b: UInt<2>}
+    output y : {a: UInt<2>, flip b: UInt<2>}
+
+    inst d of DUT
+    connect d.x, x
+    connect y, d.y
+
+    wire val : {a: UInt<2>, b: UInt<2>}
+    connect val.a, UInt<2>(1)
+    connect val.b, UInt<2>(2)
+
+    ; Force takes a RWProbe and overrides the target with 'val'.
+    force_initial(d.xp, val)
+
+  module DUT :
+    input x : {a: UInt<2>, flip b: UInt<2>}
+    output y : {a: UInt<2>, flip b: UInt<2>}
+    output xp : RWProbe<{a: UInt<2>, b: UInt<2>}>
+
+    ; Force drives p.a, p.b, y.a, and x.b, but not y.b and x.a
+    wire p : {a: UInt<2>, flip b: UInt<2>}
+    define xp = rwprobe(p)
+    connect p, x
+    connect y, p
+  ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/forwarding_refs_upwards.fir
+++ b/test/firtool/spec/refs/forwarding_refs_upwards.fir
@@ -1,0 +1,14 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+circuit Forward:
+  ; SPEC EXAMPLE BEGIN
+  extmodule Foo : ; XXX: module -> extmodule
+    output p : Probe<UInt<3>> ; XXX: added width
+    ; ...
+
+  module Forward :
+    output p : Probe<UInt>
+
+    inst f of Foo
+    define p = f.p
+  ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/forwarding_refs_upwards_narrow.fir
+++ b/test/firtool/spec/refs/forwarding_refs_upwards_narrow.fir
@@ -1,0 +1,14 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+circuit Forward :
+  ; SPEC EXAMPLE BEGIN
+  extmodule Foo :
+    output p : Probe<UInt<3>[2]>[2]
+    ; ...
+
+  module Forward :
+    output p : Probe<UInt>
+
+    inst f of Foo
+    define p = f.p[0][1]
+  ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/in_ref_context.fir
+++ b/test/firtool/spec/refs/in_ref_context.fir
@@ -1,0 +1,35 @@
+; RUN: firtool %s -verify-diagnostics
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false -verify-diagnostics
+FIRRTL version 3.0.0
+; SPEC EXAMPLE BEGIN
+circuit Top:
+  module Top:
+    input in : UInt<4>
+    output out : UInt
+
+    inst ud1 of UpDown
+    connect ud1.in, in
+    define ud1.in_ref = ud1.r1
+
+    inst ud2 of UpDown
+    connect ud2.in, in
+    define ud2.in_ref = ud2.r2
+
+    connect out, add(ud1.out, ud2.out)
+
+  module UpDown:
+    input in : UInt<4>
+    ; expected-error @below {{input probes not yet supported}}
+    input in_ref : Probe<UInt<4>>
+    output r1 : Probe<UInt<4>>
+    output r2 : Probe<UInt<4>>
+    output out : UInt
+
+    ; In ud1, this is UpDown.n1, in ud2 this is UpDown.n2 .
+    ; However, this is not supported as it cannot be both at once.
+    connect out, read(in_ref)
+    node n1 = and(in, UInt<4>(1))
+    node n2 = and(in, UInt<4>(3))
+    define r1 = probe(n1)
+    define r2 = probe(n2)
+; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/inference_reset_bad.fir
+++ b/test/firtool/spec/refs/inference_reset_bad.fir
@@ -1,0 +1,13 @@
+; RUN: firtool %s -verify-diagnostics
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false -verify-diagnostics
+; XFAIL: *
+; https://github.com/llvm/circt/issues/4813
+FIRRTL version 3.0.0
+circuit ResetInferBad :
+  ; expected-error @+3 {{reset inference failed}}
+  ; SPEC EXAMPLE BEGIN
+  module ResetInferBad :
+    input in : Reset
+    output out : AsyncReset
+    connect out, read(probe(in))
+  ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/inference_reset_good.fir
+++ b/test/firtool/spec/refs/inference_reset_good.fir
@@ -1,0 +1,12 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+FIRRTL version 3.0.0
+circuit ResetInferGood :
+  ; SPEC EXAMPLE BEGIN
+  module ResetInferGood :
+    input in : Reset
+    output out : Reset
+    output out2 : AsyncReset
+    connect out, read(probe(in))
+    connect out2, in
+  ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/inference_works.fir
+++ b/test/firtool/spec/refs/inference_works.fir
@@ -1,0 +1,19 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+; NOT SPEC EXAMPLE
+FIRRTL version 3.0.0
+
+circuit MinimumWidth :
+  module Uninferred :
+    input x : UInt
+    output r : Probe<UInt>
+    define r = probe(x)
+
+  module MinimumWidth :
+    input x : UInt<4>
+    output y : UInt
+
+    inst u of Uninferred
+    connect u.x, x
+    connect y, read(u.r)
+

--- a/test/firtool/spec/refs/invalid_in.fir
+++ b/test/firtool/spec/refs/invalid_in.fir
@@ -1,0 +1,20 @@
+; RUN: firtool %s --verify-diagnostics
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false --verify-diagnostics
+FIRRTL version 3.0.0
+circuit FooUser:
+  ; Invalid, per spec
+  ; expected-error @+3 {{input probes not yet supported}}
+  ; SPEC EXAMPLE BEGIN
+  module Foo:
+     input in : Probe<UInt>
+     output out : UInt
+
+     connect out, read(in)
+  ; SPEC EXAMPLE END
+  module FooUser:
+    output out : UInt
+
+    node n = UInt<2>(1)
+    inst f of Foo
+    connect f.in, probe(n)
+    connect out, f.out

--- a/test/firtool/spec/refs/nested_refproducer.fir
+++ b/test/firtool/spec/refs/nested_refproducer.fir
@@ -1,0 +1,16 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+FIRRTL version 3.0.0
+circuit RefProducer :
+  ; SPEC EXAMPLE BEGIN
+  module RefProducer :
+    input a : UInt<4>
+    input en : UInt<1>
+    input clk : Clock
+    output thereg : Probe<UInt>
+
+    when en :
+      reg myreg : UInt, clk
+      connect myreg, a
+      define thereg = probe(myreg)
+  ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/nosubaccess.fir
+++ b/test/firtool/spec/refs/nosubaccess.fir
@@ -1,0 +1,21 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+circuit NoSubAccessesWithProbes :
+  extmodule Ext :
+    output x : {a : Probe<UInt<2>[2]>, b : UInt<2>}[3]
+
+  ; XXX: Modified to not use input probes, get probe from ext, widths.
+  ; SPEC EXAMPLE BEGIN:
+  module NoSubAccessesWithProbes :
+    input i : UInt<5>
+    input c : const UInt<5>
+    output p : Probe<UInt>
+
+    inst e of Ext
+
+    ; Illegal: e.x[i], e.x[c]
+    ; Illegal: e.x[0].a[i], e.x[0].a[c]
+
+    ; Legal:
+    define p = e.x[0].a[1]
+   ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/probe_export_simple.fir
+++ b/test/firtool/spec/refs/probe_export_simple.fir
@@ -1,0 +1,11 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+circuit MyModule :
+  ; SPEC EXAMPLE BEGIN
+  module MyModule :
+    input in: UInt<5> ; XXX: Added width.
+    output r : Probe<UInt>
+
+    define r = probe(in)
+    ; SPEC EXAMPLE END
+

--- a/test/firtool/spec/refs/read.fir
+++ b/test/firtool/spec/refs/read.fir
@@ -1,0 +1,19 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+FIRRTL version 3.0.0
+
+circuit Foo :
+  ; SPEC EXAMPLE BEGIN
+  module Foo :
+    output p : Probe<UInt>
+    ; ...
+    wire x : UInt<4> ; XXX: ADDED
+    invalidate x ; XXX: ADDED
+    define p = probe(x) ; XXX: ADDED
+
+  module Bar :
+    output x : UInt
+
+    inst f of Foo
+    connect x, read(f.p) ; indirectly access the probed data
+  ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/read_subelement.fir
+++ b/test/firtool/spec/refs/read_subelement.fir
@@ -1,0 +1,20 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+FIRRTL version 3.0.0
+
+circuit Foo :
+  ; SPEC EXAMPLE BEGIN
+  module Foo :
+    output p : Probe<{a: UInt, b: UInt}>
+    ; ...
+    wire x : {a: UInt<5>, b: UInt<2>} ; XXX: ADDED
+    invalidate x ; XXX: ADDED
+    define p = probe(x) ; XXX: ADDED
+
+  module Bar :
+    output x : UInt
+
+    inst f of Foo
+    connect x, read(f.p.b) ; indirectly access the probed data
+  ; SPEC EXAMPLE END
+

--- a/test/firtool/spec/refs/read_subelement_add.fir
+++ b/test/firtool/spec/refs/read_subelement_add.fir
@@ -1,0 +1,19 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+FIRRTL version 3.0.0
+
+circuit Foo :
+  module Foo :
+    output p : Probe<{a: UInt, b: UInt}>
+    ; ...
+    wire x : {a: UInt<5>, b: UInt<2>} ; XXX: ADDED
+    invalidate x ; XXX: ADDED
+    define p = probe(x) ; XXX: ADDED
+
+  module Bar :
+    output x : UInt
+
+    inst f of Foo
+    ; SPEC EXAMPLE BEGIN
+    connect x, add(read(f.p).a, read(f.p.b))
+    ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/unused_in.fir
+++ b/test/firtool/spec/refs/unused_in.fir
@@ -1,0 +1,14 @@
+; RUN: firtool %s -verify-diagnostics
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false -verify-diagnostics
+circuit UnusedInputRef :
+  ; expected-error @+3 {{input probes not yet supported}}
+  ; SPEC EXAMPLE BEGIN
+  module UnusedInputRef :
+    input r : Probe<UInt<1>>
+
+  module ForwardDownwards :
+    input in : UInt<1>
+
+    inst u of UnusedInputRef
+    define u.r = probe(in)
+  ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/uturn.fir
+++ b/test/firtool/spec/refs/uturn.fir
@@ -1,0 +1,24 @@
+; RUN: firtool %s -verify-diagnostics
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false -verify-diagnostics
+FIRRTL version 3.0.0
+circuit UTurn:
+  ; expected-error @+3 {{input probes not yet supported}}
+  ; SPEC EXAMPLE BEGIN
+  module UTurn:
+    input in : Probe<UInt>
+    output out : Probe<UInt>
+    define out = in
+
+  module RefBouncing:
+    input x: UInt
+    output y: UInt
+
+    inst u1 of UTurn
+    inst u2 of UTurn
+
+    node n = x
+    define u1.in = probe(n)
+    define u2.in = u1.out
+
+    connect y, read(u2.out) ; = x
+  ; SPEC EXAMPLE END

--- a/test/firtool/spec/refs/when_c_force_initial.fir
+++ b/test/firtool/spec/refs/when_c_force_initial.fir
@@ -1,0 +1,21 @@
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
+FIRRTL version 3.0.0
+
+circuit WhenCForce :
+  module RefMe :
+    output p : RWProbe<UInt<4>>
+    wire x : UInt<4>
+    connect x, UInt(0)
+    define p = rwprobe(x)
+
+  module WhenCForce :
+    input c : UInt<1>
+    input x : UInt<4>
+
+
+; SPEC EXAMPLE:
+;   when c : force_initial(ref, x)
+; END SPEC EXAMPLE
+   inst r of RefMe
+   when c : force_initial(r.p, x)


### PR DESCRIPTION
Examples tweaked as-needed to make full examples,
portion from spec are marked as well as any modifications.

See comments in each, a few are modified to only test the demonstrated feature or to workaround spec issues (notably can't express non-const node with literal initializer).

Check these are parsed and make it through the pipeline, with and without aggregate preservation options.

Test invalid or unsupported examples are appropriately rejected.

Ensure the examples from spec are under test.