### PR TITLE
[FIRRTL] RWProbeOp: support width inference.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1233,20 +1233,23 @@ def RefSubOp : FIRRTLExprOp<"ref.sub"> {
      "$input `[` $index `]` attr-dict `:` qualified(type($input))";
 }
 
-def RWProbeOp : FIRRTLExprOp<"ref.rwprobe",
-                  [DeclareOpInterfaceMethods<InnerRefUserOpInterface>]> {
+def RWProbeOp : FIRRTLOp<"ref.rwprobe",
+                  [DeclareOpInterfaceMethods<InnerRefUserOpInterface>,
+                   HasCustomSSAName,
+                   Pure
+                  ]> {
   let summary = "FIRRTL RWProbe";
   let description = [{
     Create a RWProbe for the target.
     Target must be local.
     ```
-      %result = firrtl.ref.rwprobe @mod::@sym : t
+      %result = firrtl.ref.rwprobe @mod::@sym : firrtl.rwprobe<t>
     ```
   }];
 
-  let arguments = (ins InnerRefAttr:$target, TypeAttrOf<RWProbeTarget>:$type);
-  let results = (outs RefType:$result);
-  let assemblyFormat = "$target attr-dict `:` $type";
+  let arguments = (ins InnerRefAttr:$target);
+  let results = (outs RWProbeConcreteReset:$result);
+  let assemblyFormat = "$target attr-dict `:` type($result)";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -104,12 +104,11 @@ def RWProbe : FIRRTLDialectType<
   CPred<"type_isa<RefType>($_self) && type_cast<RefType>($_self).getForceable()">,
    "rwprobe type", "::circt::firrtl::RefType">;
 
-def RWProbeTarget : FIRRTLDialectType<
-    CPred<"type_isa<FIRRTLBaseType>($_self) && "
-          "!type_cast<FIRRTLBaseType>($_self).hasUninferredReset() &&"
-          "!type_cast<FIRRTLBaseType>($_self).hasUninferredWidth()">,
-    "RWProbeTarget type (a FIRRTL base type with a known width and not abstract reset)",
-    "::circt::firrtl::FIRRTLBaseType">;
+def RWProbeConcreteReset : FIRRTLDialectType<
+  CPred<[{type_isa<RefType>($_self) &&
+         type_cast<RefType>($_self).getForceable() &&
+         !type_cast<RefType>($_self).hasUninferredReset()}]>,
+   "rwprobe type (with concrete resets only)", "::circt::firrtl::RefType">;
 
 def ConnectableType : AnyTypeOf<[FIRRTLBaseType, ForeignType]>;
 def StrictConnectableType : AnyTypeOf<[SizedPassiveType, ForeignType]>;

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2989,10 +2989,10 @@ ParseResult FIRStmtParser::parseRWProbe(Value &result) {
 
   // Ports are handled differently, emit a RWProbeOp with inner symbol.
   if (auto arg = dyn_cast<BlockArgument>(target)) {
-    // Check target type.  Replicate inference/verification logic.
-    if (targetType.hasUninferredWidth() || targetType.hasUninferredReset())
+    // Check target type.
+    if (targetType.hasUninferredReset())
       return emitError(startTok.getLoc(),
-                       "must have known width or concrete reset type in type ")
+                       "must have concrete reset type in type ")
              << targetType;
     auto forceableType =
         firrtl::detail::getForceableResultType(true, targetType);
@@ -3005,7 +3005,7 @@ ParseResult FIRStmtParser::parseRWProbe(Value &result) {
     auto sym = getInnerRefTo(
         hw::InnerSymTarget(arg.getArgNumber(), mod, fieldRef.getFieldID()),
         [&](auto _) -> hw::InnerSymbolNamespace & { return modNameSpace; });
-    result = builder.create<RWProbeOp>(sym, targetType);
+    result = builder.create<RWProbeOp>(forceableType, sym);
     return success();
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -58,6 +58,47 @@ static void diagnoseUninferredType(InFlightDiagnostic &diag, Type t,
       diagnoseUninferredType(diag, elem.type, str + "." + elem.name.getValue());
 }
 
+/// Get FieldRef pointing to the specified inner symbol target, which must be
+/// valid. Returns null FieldRef if target points to something with no value,
+/// such as a port of an external module.
+static FieldRef getRefForIST(const hw::InnerSymTarget &ist) {
+  if (ist.isPort()) {
+    return TypeSwitch<Operation *, FieldRef>(ist.getOp())
+        .Case<FModuleOp>([&](auto fmod) {
+          return FieldRef(fmod.getArgument(ist.getPort()), ist.getField());
+        })
+        .Default({});
+  }
+
+  auto symOp = dyn_cast<hw::InnerSymbolOpInterface>(ist.getOp());
+  assert(symOp && symOp.getTargetResultIndex() &&
+         (symOp.supportsPerFieldSymbols() || ist.getField() == 0));
+  return FieldRef(symOp.getTargetResult(), ist.getField());
+}
+
+/// Calculate the "InferWidths-fieldID" equivalent for the given fieldID + type.
+static uint64_t convertFieldIDToOurVersion(uint64_t fieldID, FIRRTLType type) {
+  auto fType = getBaseOfType<hw::FieldIDTypeInterface>(type);
+  if (!fType)
+    return fieldID;
+
+  uint64_t convertedFieldID = 0;
+
+  auto curFID = fieldID;
+  auto curFType = fType;
+  while (curFID != 0) {
+    auto [child, subID] = curFType.getSubTypeByFieldID(curFID);
+    if (isa<FVectorType>(curFType))
+      convertedFieldID++; // Vector fieldID is 1.
+    else
+      convertedFieldID += curFID - subID; // Add consumed portion.
+    curFID = subID;
+    curFType = child;
+  }
+
+  return convertedFieldID;
+}
+
 //===----------------------------------------------------------------------===//
 // Constraint Expressions
 //===----------------------------------------------------------------------===//
@@ -1169,8 +1210,9 @@ namespace {
 /// variables and constraints to be solved later.
 class InferenceMapping {
 public:
-  InferenceMapping(ConstraintSolver &solver, SymbolTable &symtbl)
-      : solver(solver), symtbl(symtbl) {}
+  InferenceMapping(ConstraintSolver &solver, SymbolTable &symtbl,
+                   hw::InnerSymbolTableCollection &istc)
+      : solver(solver), symtbl(symtbl), irn{symtbl, istc} {}
 
   LogicalResult map(CircuitOp op);
   LogicalResult mapOperation(Operation *op);
@@ -1245,6 +1287,9 @@ private:
 
   /// Cache of module symbols
   SymbolTable &symtbl;
+
+  /// Full design inner symbol information.
+  hw::InnerRefNamespace irn;
 };
 
 } // namespace
@@ -1695,6 +1740,25 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       .Case<RefCastOp>([&](auto op) {
         declareVars(op.getResult(), op.getLoc());
         constrainTypes(op.getResult(), op.getInput(), true);
+      })
+      .Case<RWProbeOp>([&](auto op) {
+        declareVars(op.getResult(), op.getLoc());
+        auto ist = irn.lookup(op.getTarget());
+        if (!ist) {
+          op->emitError("target of rwprobe could not be resolved");
+          mappingFailed = true;
+          return;
+        }
+        auto ref = getRefForIST(ist);
+        if (!ref) {
+          op->emitError("target of rwprobe resolved to unsupported target");
+          mappingFailed = true;
+          return;
+        }
+        auto newFID = convertFieldIDToOurVersion(
+            ref.getFieldID(), type_cast<FIRRTLType>(ref.getValue().getType()));
+        unifyTypes(FieldRef(op.getResult(), 0),
+                   FieldRef(ref.getValue(), newFID), op.getType());
       })
       .Case<mlir::UnrealizedConversionCastOp>([&](auto op) {
         for (Value result : op.getResults()) {
@@ -2285,7 +2349,8 @@ class InferWidthsPass : public InferWidthsBase<InferWidthsPass> {
 void InferWidthsPass::runOnOperation() {
   // Collect variables and constraints
   ConstraintSolver solver;
-  InferenceMapping mapping(solver, getAnalysis<SymbolTable>());
+  InferenceMapping mapping(solver, getAnalysis<SymbolTable>(),
+                           getAnalysis<hw::InnerSymbolTableCollection>());
   if (failed(mapping.map(getOperation()))) {
     signalPassFailure();
     return;

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -142,7 +142,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             return success();
           })
           .Case<RWProbeOp>([&](RWProbeOp rwprobe) {
-            if (!isZeroWidth(rwprobe.getType()))
+            if (!isZeroWidth(rwprobe.getType().getType()))
               addReachingSendsEntry(rwprobe.getResult(), rwprobe.getTarget());
             markForRemoval(rwprobe);
             return success();

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1937,7 +1937,7 @@ firrtl.circuit "RWProbeRemote" {
   }
   firrtl.module @RWProbeRemote() {
     // expected-error @below {{op has non-local target}}
-    %rw = firrtl.ref.rwprobe <@Other::@x> : !firrtl.uint<1>
+    %rw = firrtl.ref.rwprobe <@Other::@x> : !firrtl.rwprobe<uint<1>>
   }
 }
 
@@ -1946,7 +1946,7 @@ firrtl.circuit "RWProbeRemote" {
 firrtl.circuit "RWProbeBadTarget" {
   firrtl.module @RWProbeBadTarget() {
     // expected-error @below {{has target that cannot be resolved: #hw.innerNameRef<@RWProbeBadTarget::@x>}}
-    %rw = firrtl.ref.rwprobe <@RWProbeBadTarget::@x> : !firrtl.uint<1>
+    %rw = firrtl.ref.rwprobe <@RWProbeBadTarget::@x> : !firrtl.rwprobe<uint<1>>
   }
 }
 
@@ -1955,8 +1955,8 @@ firrtl.circuit "RWProbeBadTarget" {
 
 firrtl.circuit "RWProbeNonBase" {
   firrtl.module @RWProbeNonBase() {
-    // expected-error @below {{cannot force type '!firrtl.string'}}
-    %rw = firrtl.ref.rwprobe <@RWProbeTypes::@invalid> : !firrtl.string
+    // expected-error @below {{expected base type, found '!firrtl.string'}}
+    %rw = firrtl.ref.rwprobe <@RWProbeTypes::@invalid> : !firrtl.rwprobe<string>
   }
 }
 
@@ -1967,17 +1967,7 @@ firrtl.circuit "RWProbeTypes" {
     // expected-note @below {{target resolves here}}
     %w = firrtl.wire sym @x : !firrtl.sint<1>
     // expected-error @below {{op has type mismatch: target resolves to '!firrtl.sint<1>' instead of expected '!firrtl.uint<1>'}}
-    %rw = firrtl.ref.rwprobe <@RWProbeTypes::@x> : !firrtl.uint<1>
-  }
-}
-
-// -----
-
-firrtl.circuit "RWProbeUninferred" {
-  firrtl.module @RWProbeUninferred() {
-    %w = firrtl.wire sym @x : !firrtl.uint
-    // expected-error @below {{op attribute 'type' failed to satisfy constraint: type attribute of RWProbeTarget type (a FIRRTL base type with a known width and not abstract reset)}}
-    %rw = firrtl.ref.rwprobe <@RWProbeUninferred::@x> : !firrtl.uint
+    %rw = firrtl.ref.rwprobe <@RWProbeTypes::@x> : !firrtl.rwprobe<uint<1>>
   }
 }
 
@@ -1986,8 +1976,8 @@ firrtl.circuit "RWProbeUninferred" {
 firrtl.circuit "RWProbeUninferredReset" {
   firrtl.module @RWProbeUninferredReset() {
     %w = firrtl.wire sym @x : !firrtl.bundle<a: reset>
-    // expected-error @below {{op attribute 'type' failed to satisfy constraint: type attribute of RWProbeTarget type (a FIRRTL base type with a known width and not abstract reset)}}
-    %rw = firrtl.ref.rwprobe <@RWProbeUninferred::@x> : !firrtl.bundle<a: reset>
+    // expected-error @below {{op result #0 must be rwprobe type (with concrete resets only), but got '!firrtl.rwprobe<bundle<a: reset>>}}
+    %rw = firrtl.ref.rwprobe <@RWProbeUninferredReset::@x> : !firrtl.rwprobe<bundle<a: reset>>
   }
 }
 
@@ -1999,7 +1989,7 @@ firrtl.circuit "RWProbeInstance" {
     // expected-note @below {{target resolves here}}
     firrtl.instance inst sym @inst @Ext()
     // expected-error @below {{op has target that cannot be probed}}
-    %rw = firrtl.ref.rwprobe <@RWProbeInstance::@inst> : !firrtl.uint<1>
+    %rw = firrtl.ref.rwprobe <@RWProbeInstance::@inst> : !firrtl.rwprobe<uint<1>>
   }
 }
 
@@ -2012,7 +2002,7 @@ firrtl.circuit "RWProbeUseDef" {
       %w = firrtl.wire sym @x : !firrtl.uint<1>
     } else {
       // expected-error @below {{not dominated by target}}
-      %rw = firrtl.ref.rwprobe <@RWProbeUseDef::@x> : !firrtl.uint<1>
+      %rw = firrtl.ref.rwprobe <@RWProbeUseDef::@x> : !firrtl.rwprobe<uint<1>>
     }
   }
 }

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -956,4 +956,36 @@ firrtl.circuit "Foo" {
     %1 = firrtl.int.mux4cell(%sel2, %c1_ui1, %c2_ui2, %c3_ui3, %c1) : (!firrtl.uint, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint
     firrtl.connect %out2, %1: !firrtl.uint, !firrtl.uint
   }
+
+  // CHECK-LABEL: module @RWProbePort
+  // CHECK-SAME: rwprobe<uint<1>>
+  // CHECK-SAME: rwprobe<uint<2>>
+  firrtl.module @RWProbePort(in %in: !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>,
+                             out %p: !firrtl.rwprobe<uint>,
+                             out %p2: !firrtl.rwprobe<uint>) {
+    // CHECK-NEXT: bundle<a: vector<uint<1>, 2>, b: uint<2>>
+    // CHECK-SAME: rwprobe<uint<1>>
+    // CHECK-SAME: rwprobe<uint<2>>
+    %c_in, %c_p, %c_p2 = firrtl.instance c @RWProbePortChild(in in: !firrtl.bundle<a: vector<uint, 2>, b: uint>, out p: !firrtl.rwprobe<uint>, out p2: !firrtl.rwprobe<uint>)
+    // CHECK-NEXT: !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
+   firrtl.connect %c_in, %in : !firrtl.bundle<a: vector<uint, 2>, b: uint>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
+    // CHECK-NEXT: rwprobe<uint<1>>
+    firrtl.ref.define %p, %c_p : !firrtl.rwprobe<uint>
+    // CHECK-NEXT: rwprobe<uint<2>>
+    firrtl.ref.define %p2, %c_p2 : !firrtl.rwprobe<uint>
+  }
+  // CHECK-LABEL: module private @RWProbePortChild(
+  // CHECK-SAME: %in: !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
+  // CHECK-SAME: %p: !firrtl.rwprobe<uint<1>>
+  // CHECK-SAME: %p2: !firrtl.rwprobe<uint<2>>
+  // CHECK-NEXT: ref.rwprobe {{.+}} : !firrtl.rwprobe<uint<1>>
+  // CHECK-NEXT: ref.rwprobe {{.+}} : !firrtl.rwprobe<uint<2>>
+  firrtl.module private @RWProbePortChild(in %in: !firrtl.bundle<a: vector<uint, 2>, b: uint> sym [<@in_a_1,3,public>,<@in_b,4,public>],
+                                          out %p: !firrtl.rwprobe<uint>,
+                                          out %p2: !firrtl.rwprobe<uint>) {
+    %0 = firrtl.ref.rwprobe <@RWProbePortChild::@in_a_1> : !firrtl.rwprobe<uint>
+    %1 = firrtl.ref.rwprobe <@RWProbePortChild::@in_b> : !firrtl.rwprobe<uint>
+    firrtl.ref.define %p, %0 : !firrtl.rwprobe<uint>
+    firrtl.ref.define %p2, %1 : !firrtl.rwprobe<uint>
+  }
 }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1202,7 +1202,7 @@ firrtl.circuit "RWProbePort" {
   firrtl.module private @Child(in %in: !firrtl.vector<uint<1>, 2>
                                  sym [<@sym,2,public>],
                                out %p: !firrtl.rwprobe<uint<1>>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
-    %0 = firrtl.ref.rwprobe <@Child::@sym> : !firrtl.uint<1>
+    %0 = firrtl.ref.rwprobe <@Child::@sym> : !firrtl.rwprobe<uint<1>>
     firrtl.ref.define %p, %0 : !firrtl.rwprobe<uint<1>>
   }
   // CHECK: module @RWProbePort
@@ -1244,9 +1244,9 @@ firrtl.circuit "CollidingSymbolsFields" {
   firrtl.module @Foo(in %x : !firrtl.bundle<a: uint<1>, b: uint<1>> sym [<@b_0,1,public>,<@foo,2,public>]) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
     %b = firrtl.wire sym [<@b,1,public>,<@bar_0,2,public>] : !firrtl.bundle<a: uint<1>, b: uint<1>>
     firrtl.instance bar sym @bar @Bar()
-    %1 = firrtl.ref.rwprobe <@Foo::@b_0> : !firrtl.uint<1>
-    %2 = firrtl.ref.rwprobe <@Foo::@bar_0> : !firrtl.uint<1>
-    %3 = firrtl.ref.rwprobe <@Foo::@foo> : !firrtl.uint<1>
+    %1 = firrtl.ref.rwprobe <@Foo::@b_0> : !firrtl.rwprobe<uint<1>>
+    %2 = firrtl.ref.rwprobe <@Foo::@bar_0> : !firrtl.rwprobe<uint<1>>
+    %3 = firrtl.ref.rwprobe <@Foo::@foo> : !firrtl.rwprobe<uint<1>>
   }
   // CHECK: module @CollidingSymbolsFields(
   // CHECK-SAME: sym [<@b_0

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -985,7 +985,7 @@ firrtl.circuit "RWProbePort" {
   // CHECK-NOT: firrtl.ref.rwprobe
   // CHECK-NEXT: }
   firrtl.module @RWProbePort(in %in: !firrtl.vector<uint<1>, 2> sym [<@target,2,public>], out %p: !firrtl.rwprobe<uint<1>>) {
-    %0 = firrtl.ref.rwprobe <@RWProbePort::@target> : !firrtl.uint<1>
+    %0 = firrtl.ref.rwprobe <@RWProbePort::@target> : !firrtl.rwprobe<uint<1>>
     firrtl.ref.define %p, %0 : !firrtl.rwprobe<uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1333,10 +1333,18 @@ circuit EnumTypes:
 
   ; CHECK-LABEL: @RWProbePort(
   module RWProbePort:
-    ; CHECK: in %in: !firrtl.vector<uint<1>, 2> sym [<@sym,2,public>],
+    ; CHECK: in %in: !firrtl.vector<uint<1>, 2> sym [<@[[IN_SYM:.+]],2,public>],
     input in : UInt<1>[2]
     output p : RWProbe<UInt<1>>
-    ; CHECK:  firrtl.ref.rwprobe <@RWProbePort::@sym> : !firrtl.uint<1>
+    ; CHECK:  firrtl.ref.rwprobe <@RWProbePort::@[[IN_SYM]]> : !firrtl.rwprobe<uint<1>>
+    define p = rwprobe(in[1])
+
+  ; CHECK-LABEL: @RWProbeUninferredPort(
+  module RWProbeUninferredPort:
+    ; CHECK: in %in: !firrtl.vector<uint, 2> sym [<@[[IN_SYM:.+]],2,public>],
+    input in : UInt[2]
+    output p : RWProbe<UInt>
+    ; CHECK:  firrtl.ref.rwprobe <@RWProbeUninferredPort::@[[IN_SYM]]> : !firrtl.rwprobe<uint>
     define p = rwprobe(in[1])
 
   ; CHECK-LABEL: module private @ProbeInvalidate

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -634,14 +634,6 @@ circuit RWProbeConstPort:
 
 ;// -----
 
-circuit RWProbeUninferredPort:
-  module RWProbeUninferredPort:
-    input in : UInt[2]
-    output p : RWProbe<UInt>
-    define p = rwprobe(in[1]) ; expected-error {{must have known width or concrete reset type in type}}
-
-;// -----
-
 FIRRTL version 2.0.0
 circuit PartialConnect_v2p0p0:
   module PartialConnect_v2p0p0:


### PR DESCRIPTION
Rework RWProbeOp to explicitly track result type,
don't "infer" from target type argument (removed).

This is a better fit for this op, particualrly in that no
useful "inference" is performed that way.
(not inferring through symbol target)

Teach InferWidths about the type constraint,
getting inner symbol analysis for resolution.

Loosen parsing, but still only use RWProbeOp
for ports.

With these changes, it's nearly possible to remove
"Forceable" entirely in favor of the one mechanism.