### PR TITLE
[FIRRTL][CAPI] Fix undefined reference for `mlirExportFIRRTL`

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -104,6 +104,8 @@ struct FIRVersion {
 
   static FIRVersion defaultFIRVersion() { return {1, 0, 0}; }
 
+  static FIRVersion latestFIRVersion() { return {3, 0, 0}; }
+
 }; // namespace firrtl
 
 /// Method to enable printing of FIRVersions

--- a/lib/CAPI/ExportFIRRTL/ExportFIRRTL.cpp
+++ b/lib/CAPI/ExportFIRRTL/ExportFIRRTL.cpp
@@ -17,8 +17,8 @@ using namespace circt;
 using namespace firrtl;
 
 MlirLogicalResult mlirExportFIRRTL(MlirModule module,
-                                   MlirStringCallback callback, void *userData,
-                                   FIRVersion version) {
+                                   MlirStringCallback callback,
+                                   void *userData) {
   mlir::detail::CallbackOstream stream(callback, userData);
   return wrap(exportFIRFile(unwrap(module), stream, {}, {3, 0, 0}));
 }

--- a/lib/CAPI/ExportFIRRTL/ExportFIRRTL.cpp
+++ b/lib/CAPI/ExportFIRRTL/ExportFIRRTL.cpp
@@ -20,5 +20,6 @@ MlirLogicalResult mlirExportFIRRTL(MlirModule module,
                                    MlirStringCallback callback,
                                    void *userData) {
   mlir::detail::CallbackOstream stream(callback, userData);
-  return wrap(exportFIRFile(unwrap(module), stream, {}, {3, 0, 0}));
+  return wrap(exportFIRFile(unwrap(module), stream, {},
+                            FIRVersion::latestFIRVersion()));
 }

--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -28,3 +28,17 @@ target_link_libraries(circt-capi-om-test
   MLIRCAPIIR
   CIRCTCAPIOM
 )
+
+add_llvm_executable(circt-capi-firrtl-test
+  PARTIAL_SOURCES_INTENDED
+  firrtl.c
+)
+llvm_update_compile_flags(circt-capi-firrtl-test)
+
+target_link_libraries(circt-capi-firrtl-test
+  PRIVATE
+
+  MLIRCAPIIR
+  CIRCTCAPIFIRRTL
+  CIRCTCAPIExportFIRRTL
+)

--- a/test/CAPI/firrtl.c
+++ b/test/CAPI/firrtl.c
@@ -1,0 +1,60 @@
+/*===- firrtl.c - Simple test of FIRRTL C APIs ----------------------------===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+/* RUN: circt-capi-firrtl-test 2>&1 | FileCheck %s
+ */
+
+#include "circt-c/Dialect/FIRRTL.h"
+#include "circt-c/ExportFIRRTL.h"
+#include "mlir-c/BuiltinAttributes.h"
+#include "mlir-c/BuiltinTypes.h"
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void exportCallback(MlirStringRef message, void *userData) {
+  printf("%.*s", (int)message.length, message.data);
+}
+
+void testExport(MlirContext ctx) {
+  // clang-format off
+  const char *testFIR =
+    "firrtl.circuit \"ExportTestSimpleModule\" {\n"
+    "  firrtl.module @ExportTestSimpleModule(in %in_1: !firrtl.uint<32>,\n"
+    "                                        in %in_2: !firrtl.uint<32>,\n"
+    "                                        out %out: !firrtl.uint<32>) {\n"
+    "    %0 = firrtl.and %in_1, %in_2 : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>\n"
+    "    firrtl.connect %out, %0 : !firrtl.uint<32>, !firrtl.uint<32>\n"
+    "  }\n"
+    "}\n";
+  // clang-format on
+  MlirModule module =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(testFIR));
+
+  assert(mlirLogicalResultIsSuccess(
+      mlirExportFIRRTL(module, exportCallback, NULL)));
+
+  // CHECK: FIRRTL version 3.0.0
+  // CHECK-NEXT: circuit ExportTestSimpleModule :
+  // CHECK-NEXT:   module ExportTestSimpleModule : @[- 2:3]
+  // CHECK-NEXT:     input in_1 : UInt<32> @[- 2:44]
+  // CHECK-NEXT:     input in_2 : UInt<32> @[- 3:44]
+  // CHECK-NEXT:     output out : UInt<32> @[- 4:45]
+  // CHECK-EMPTY:
+  // CHECK-NEXT:     connect out, and(in_1, in_2) @[- 6:5]
+}
+
+int main() {
+  MlirContext ctx = mlirContextCreate();
+  mlirDialectHandleLoadDialect(mlirGetDialectHandle__firrtl__(), ctx);
+  testExport(ctx);
+  return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ set(CIRCT_TEST_DEPENDS
   arcilator
   circt-capi-ir-test
   circt-capi-om-test
+  circt-capi-firrtl-test
   circt-as
   circt-dis
   circt-opt

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -57,8 +57,8 @@ tool_dirs = [
 ]
 tools = [
     'arcilator', 'circt-as', 'circt-capi-ir-test', 'circt-capi-om-test',
-    'circt-dis', 'circt-opt', 'circt-reduce', 'circt-translate', 'esi-tester',
-    'firtool', 'hlstool', 'om-linker'
+    'circt-capi-firrtl-test', 'circt-dis', 'circt-opt', 'circt-reduce',
+    'circt-translate', 'esi-tester', 'firtool', 'hlstool', 'om-linker'
 ]
 
 # Enable Verilator if it has been detected.


### PR DESCRIPTION
Commit 172afc3277003468cc5fde3029e0f3f9421b9447 added a new argument `FIRVersion version` to the `mlirExportFIRRTL` function, but didn't update its declaration. It breaks the compile for this function.

This PR removed that argument to fix the problem, since `FIRVersion` does not have a CAPI yet, and added a simple test to prevent regression.