### PR TITLE
[FIRRTL][InferWidths] Fix handling of non-base ports in instances.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1598,12 +1598,14 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
 
           auto fml = cast<FModuleLike>(&*refdModule);
           auto ports = fml.getPorts();
-          for (auto &port : ports)
-            if (type_cast<FIRRTLBaseType>(port.type).hasUninferredWidth()) {
+          for (auto &port : ports) {
+            auto baseType = getBaseType(port.type);
+            if (baseType && baseType.hasUninferredWidth()) {
               diag.attachNote(op.getLoc()) << "Port: " << port.name;
-              if (!type_cast<FIRRTLBaseType>(port.type).isGround())
-                diagnoseUninferredType(diag, port.type, port.name.getValue());
+              if (!baseType.isGround())
+                diagnoseUninferredType(diag, baseType, port.name.getValue());
             }
+          }
 
           diag.attachNote(op.getLoc())
               << "Only non-extern FIRRTL modules may contain unspecified "

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -18,16 +18,25 @@ firrtl.circuit "Foo" {
 // -----
 firrtl.circuit "Foo" {
   // expected-note @+1 {{Module `Bar` defined here:}}
-  firrtl.extmodule @Bar(in in: !firrtl.uint, 
-    out out: !firrtl.bundle<a : uint, b: uint<4>, c: vector<bundle<c: uint>,4>>)
+  firrtl.extmodule @Bar(
+    in in: !firrtl.uint,
+    out out: !firrtl.bundle<a : uint, b: uint<4>, c: vector<bundle<c: uint>,4>>,
+    out ref: !firrtl.rwprobe<bundle<a: uint>>,
+    out string: !firrtl.string)
   firrtl.module @Foo(in %in: !firrtl.uint<42>, out %out: !firrtl.bundle<a : uint, b: uint<4>, c: vector<bundle<c: uint>,4>>) {
-    // expected-error @+6 {{extern module `Bar` has ports of uninferred width}}
-    // expected-note @+5 {{Port: "in"}}
-    // expected-note @+4 {{Port: "out"}}
-    // expected-note @+3 {{Field: "out.a"}}
-    // expected-note @+2 {{Field: "out.c[].c"}}
-    // expected-note @+1 {{Only non-extern FIRRTL modules may contain unspecified widths to be inferred automatically.}}
-    %inst_in, %inst_out = firrtl.instance inst @Bar(in in: !firrtl.uint, out out: !firrtl.bundle<a : uint, b: uint<4>, c: vector<bundle<c: uint>,4>>)
+    // expected-error @below {{extern module `Bar` has ports of uninferred width}}
+    // expected-note @below {{Port: "in"}}
+    // expected-note @below {{Port: "out"}}
+    // expected-note @below {{Field: "out.a"}}
+    // expected-note @below {{Field: "out.c[].c"}}
+    // expected-note @below {{Port: "ref"}}
+    // expected-note @below {{Field: "ref.a"}}
+    // expected-note @below {{Only non-extern FIRRTL modules may contain unspecified widths to be inferred automatically.}}
+    %inst_in, %inst_out, %inst_ref, %inst_string = firrtl.instance inst @Bar(
+                                                     in in: !firrtl.uint,
+                                                     out out: !firrtl.bundle<a : uint, b: uint<4>, c: vector<bundle<c: uint>,4>>,
+                                                     out ref: !firrtl.rwprobe<bundle<a: uint>>,
+                                                     out string: !firrtl.string)
     firrtl.connect %inst_in, %in : !firrtl.uint, !firrtl.uint<42>
     firrtl.connect %out, %inst_out : !firrtl.bundle<a : uint, b: uint<4>, c: vector<bundle<c: uint>,4>>, !firrtl.bundle<a : uint, b: uint<4>, c: vector<bundle<c: uint>,4>>
   }


### PR DESCRIPTION
Don't crash if encounter non-base type on instance op with uninferred widths.