### PR TITLE
[Ibis] Add `ibis.this`

### DIFF
--- a/include/circt/Dialect/Ibis/IbisInterfaces.td
+++ b/include/circt/Dialect/Ibis/IbisInterfaces.td
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_IBIS_INTERFACES_TD
 
 include "mlir/IR/OpBase.td"
+include "mlir/IR/SymbolInterfaces.td"
 
 def PortOpInterface : OpInterface<"PortOpInterface"> {
   let cppNamespace = "circt::ibis";
@@ -27,7 +28,7 @@ def PortOpInterface : OpInterface<"PortOpInterface"> {
   ];
 }
 
-def ScopeOpInterface : OpInterface<"ScopeOpInterface"> {
+def ScopeOpInterface : OpInterface<"ScopeOpInterface", [Symbol]> {
   let cppNamespace = "circt::ibis";
   let description = [{
     An interface for operations which define Ibis scopes, that can be referenced
@@ -46,7 +47,7 @@ def ScopeOpInterface : OpInterface<"ScopeOpInterface"> {
     >,
     InterfaceMethod<
       "Returns `%this` of the scope",
-      "mlir::Value", "getThis",
+      "mlir::TypedValue<ScopeRefType>", "getThis",
       (ins), [{
         return *detail::getThisFromScope($_op);
       }]
@@ -55,8 +56,7 @@ def ScopeOpInterface : OpInterface<"ScopeOpInterface"> {
       "Returns the symbol name of the scope",
       "mlir::StringAttr", "getScopeName",
       (ins), [{
-        auto symbolOp = cast<mlir::SymbolOpInterface>(&*$_op);
-        return symbolOp.getNameAttr();
+        return $_op.getNameAttr();
       }]
     >
   ];

--- a/include/circt/Dialect/Ibis/IbisInterfaces.td
+++ b/include/circt/Dialect/Ibis/IbisInterfaces.td
@@ -27,4 +27,39 @@ def PortOpInterface : OpInterface<"PortOpInterface"> {
   ];
 }
 
+def ScopeOpInterface : OpInterface<"ScopeOpInterface"> {
+  let cppNamespace = "circt::ibis";
+  let description = [{
+    An interface for operations which define Ibis scopes, that can be referenced
+    by an `ibis.this` operation.
+  }];
+
+  let verify = "return detail::verifyScopeOpInterface($_op);";
+
+  let methods = [
+    InterfaceMethod<
+      "Returns the body of the scope",
+      "mlir::Block*", "getBodyBlock",
+      (ins), [{
+        return &$_op->getRegions().front().front();
+      }]
+    >,
+    InterfaceMethod<
+      "Returns `%this` of the scope",
+      "mlir::Value", "getThis",
+      (ins), [{
+        return *detail::getThisFromScope($_op);
+      }]
+    >,
+    InterfaceMethod<
+      "Returns the symbol name of the scope",
+      "mlir::StringAttr", "getScopeName",
+      (ins), [{
+        auto symbolOp = cast<mlir::SymbolOpInterface>(&*$_op);
+        return symbolOp.getNameAttr();
+      }]
+    >
+  ];
+}
+
 #endif // CIRCT_DIALECT_IBIS_INTERFACES_TD

--- a/include/circt/Dialect/Ibis/IbisOps.h
+++ b/include/circt/Dialect/Ibis/IbisOps.h
@@ -21,13 +21,25 @@
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 
-#include "circt/Dialect/Ibis/IbisInterfaces.h.inc"
-
 namespace circt {
 namespace ibis {
 class ContainerOp;
+class ThisOp;
+
+namespace detail {
+// Verify that `op` conforms to the ScopeOpInterface.
+LogicalResult verifyScopeOpInterface(Operation *op);
+
+// Returns the %this value of an ibis scope-defining operation. Implemented
+// here to hide the dependence on `ibis.this`, which is not defined before the
+// interface definition.
+mlir::FailureOr<Value> getThisFromScope(Operation *op);
+
+} // namespace detail
 } // namespace ibis
 } // namespace circt
+
+#include "circt/Dialect/Ibis/IbisInterfaces.h.inc"
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/Ibis/Ibis.h.inc"

--- a/include/circt/Dialect/Ibis/IbisOps.h
+++ b/include/circt/Dialect/Ibis/IbisOps.h
@@ -33,7 +33,7 @@ LogicalResult verifyScopeOpInterface(Operation *op);
 // Returns the %this value of an ibis scope-defining operation. Implemented
 // here to hide the dependence on `ibis.this`, which is not defined before the
 // interface definition.
-mlir::FailureOr<Value> getThisFromScope(Operation *op);
+mlir::FailureOr<mlir::TypedValue<ScopeRefType>> getThisFromScope(Operation *op);
 
 } // namespace detail
 } // namespace ibis

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -29,26 +29,27 @@ def HasCustomSSAName :
 def ClassOp : IbisOp<"class", [
     IsolatedFromAbove, RegionKindInterface,
     Symbol, SymbolTable, SingleBlock,
-    NoTerminator,
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>,
+    NoTerminator, ScopeOpInterface,
     HasParent<"mlir::ModuleOp">]> {
 
   let summary = "Ibis class";
   let description = [{
     Ibis has the notion of a class which can contain methods and member
     variables.
+
+    In the low-level Ibis representation, the ClassOp becomes a container for
+    `ibis.port`s and `ibis.container`s.
   }];
 
   let arguments = (ins SymbolNameAttr:$sym_name);
   let regions = (region SizedRegion<1>:$body);
-  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = [{
+    $sym_name attr-dict-with-keyword $body
+  }];
 
   let extraClassDeclaration = [{
     // Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph; }
-
-    // Returns the inner 'this' argument of the class.
-    BlockArgument getThis() { return getBody().front().getArgument(0); }
   }];
 }
 
@@ -62,10 +63,10 @@ def InstanceOp : IbisOp<"instance", [
   }];
 
   let arguments = (ins SymbolNameAttr:$sym_name, FlatSymbolRefAttr:$className);
-  let results = (outs ClassRefType:$classRef);
+  let results = (outs ScopeRefType:$scopeRef);
   let assemblyFormat = [{
     $sym_name `,` $className attr-dict
-    custom<ClassRefFromName>(type($classRef), ref($className))
+    custom<ScopeRefFromName>(type($scopeRef), ref($className))
   }];
 
   let extraClassDeclaration = [{
@@ -179,11 +180,11 @@ def GetParentOfRefOp : IbisOp<"get_parent_of_ref"> {
     any given Ibis class may be instantiated by multiple different parent classes.
   }];
 
-  let arguments = (ins AnyClassRefType:$src);
-  let results = (outs OpaqueClassRefType:$parent);
+  let arguments = (ins AnyScopeRefType:$src);
+  let results = (outs ScopeRefType:$parent);
 
   let assemblyFormat = [{
-    $src `:` qualified(type($src)) attr-dict
+    $src `:` qualified(type($src)) `->` qualified(type($parent)) attr-dict
   }];
 }
 
@@ -200,12 +201,25 @@ def GetInstanceInRefOp : IbisOp<"get_instance_in_ref"> {
   }];
 
   let arguments = (ins
-    AnyClassRefType:$src,
+    AnyScopeRefType:$src,
     FlatSymbolRefAttr:$instanceName,
     FlatSymbolRefAttr:$instanceSymbol);
-  let results = (outs ClassRefType:$instance);
+  let results = (outs ScopeRefType:$instance);
   let assemblyFormat = [{
-    $instanceName `:` $instanceSymbol `in` $src `:` qualified(type($src)) attr-dict custom<ClassRefFromName>(type($instance), ref($instanceSymbol))
+    $instanceName `:` $instanceSymbol `in` $src
+      `:`qualified(type($src)) attr-dict custom<ScopeRefFromName>(type($instance), ref($instanceSymbol))
+  }];
+}
+
+def ThisOp : IbisOp<"this", [
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "Return a handle to the current scope `!ibis.scoperef`";
+  let arguments = (ins FlatSymbolRefAttr:$scopeName);
+  let results = (outs ScopeRefType:$thisRef);
+
+  let assemblyFormat = [{
+    $scopeName attr-dict custom<ScopeRefFromName>(type($thisRef), ref($scopeName))
   }];
 }
 
@@ -216,7 +230,7 @@ def GetInstanceInRefOp : IbisOp<"get_instance_in_ref"> {
 def ContainerOp : IbisOp<"container", [
   Symbol, SymbolTable, SingleBlock,
   NoTerminator, NoRegionArguments,
-  HasParent<"ClassOp">
+  ScopeOpInterface, IsolatedFromAbove
 ]> {
   let summary = "Ibis container";
   let description = [{
@@ -258,7 +272,7 @@ def GetPortOp : IbisOp<"get_port", [
   }];
 
   let arguments = (ins
-    ClassRefType:$instance,
+    ScopeRefType:$instance,
     FlatSymbolRefAttr:$portSymbol);
   let results = (outs PortRefType:$port);
   let assemblyFormat = [{

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -28,7 +28,7 @@ def HasCustomSSAName :
 
 def ClassOp : IbisOp<"class", [
     IsolatedFromAbove, RegionKindInterface,
-    Symbol, SymbolTable, SingleBlock,
+    SymbolTable, SingleBlock,
     NoTerminator, ScopeOpInterface,
     HasParent<"mlir::ModuleOp">]> {
 
@@ -38,7 +38,7 @@ def ClassOp : IbisOp<"class", [
     variables.
 
     In the low-level Ibis representation, the ClassOp becomes a container for
-    `ibis.port`s and `ibis.container`s.
+    `ibis.port`s, `ibis.container`s, and contain logic for member variables.
   }];
 
   let arguments = (ins SymbolNameAttr:$sym_name);
@@ -228,7 +228,7 @@ def ThisOp : IbisOp<"this", [
 // ===---------------------------------------------------------------------===//
 
 def ContainerOp : IbisOp<"container", [
-  Symbol, SymbolTable, SingleBlock,
+  SymbolTable, SingleBlock,
   NoTerminator, NoRegionArguments,
   ScopeOpInterface, IsolatedFromAbove
 ]> {

--- a/include/circt/Dialect/Ibis/IbisTypes.h
+++ b/include/circt/Dialect/Ibis/IbisTypes.h
@@ -16,7 +16,7 @@
 namespace circt {
 namespace ibis {
 // Returns true if the given type is an opaque reference to an ibis class.
-bool isOpaqueClassRefType(mlir::Type type);
+bool isOpaqueScopeRefType(mlir::Type type);
 } // namespace ibis
 } // namespace circt
 

--- a/include/circt/Dialect/Ibis/IbisTypes.td
+++ b/include/circt/Dialect/Ibis/IbisTypes.td
@@ -16,13 +16,13 @@ class IbisTypeDef<string name> : TypeDef<IbisDialect, name> { }
 
 def ScopeRefType : IbisTypeDef<"ScopeRef"> {
   let mnemonic = "scoperef";
-  let parameters = (ins OptionalParameter<"mlir::FlatSymbolRefAttr">:$scopeRef);
-  let assemblyFormat = "(`<` $scopeRef^  `>`)?";
   let description = [{
     A reference to an Ibis scope. May be either a reference to a specific
     scope (given a `$scopeName` argument) or an opaque reference.
   }];
 
+  let parameters = (ins OptionalParameter<"mlir::FlatSymbolRefAttr">:$scopeRef);
+  let assemblyFormat = "(`<` $scopeRef^  `>`)?";
   let extraClassDeclaration = [{
     bool isOpaque() {
       return !getScopeRef();

--- a/include/circt/Dialect/Ibis/IbisTypes.td
+++ b/include/circt/Dialect/Ibis/IbisTypes.td
@@ -14,18 +14,18 @@ include "mlir/IR/AttrTypeBase.td"
 
 class IbisTypeDef<string name> : TypeDef<IbisDialect, name> { }
 
-def ClassRefType : IbisTypeDef<"ClassRef"> {
-  let mnemonic = "classref";
-  let parameters = (ins OptionalParameter<"mlir::FlatSymbolRefAttr">:$classRef);
-  let assemblyFormat = "(`<` $classRef^  `>`)?";
+def ScopeRefType : IbisTypeDef<"ScopeRef"> {
+  let mnemonic = "scoperef";
+  let parameters = (ins OptionalParameter<"mlir::FlatSymbolRefAttr">:$scopeRef);
+  let assemblyFormat = "(`<` $scopeRef^  `>`)?";
   let description = [{
-    A reference to an Ibis class. May be either a reference to a specific
-    class (given a `$classRef` argument) or an opaque reference.
+    A reference to an Ibis scope. May be either a reference to a specific
+    scope (given a `$scopeName` argument) or an opaque reference.
   }];
 
   let extraClassDeclaration = [{
     bool isOpaque() {
-      return !getClassRef();
+      return !getScopeRef();
     }
   }];
 
@@ -34,22 +34,22 @@ def ClassRefType : IbisTypeDef<"ClassRef"> {
     TypeBuilder<(ins), [{
       return $_get($_ctxt, nullptr);
     }]>,
-    TypeBuilder<(ins "StringAttr":$classRef), [{
-      return $_get($_ctxt, FlatSymbolRefAttr::get(classRef));
+    TypeBuilder<(ins "StringAttr":$scopeRef), [{
+      return $_get($_ctxt, FlatSymbolRefAttr::get(scopeRef));
     }]>
   ];
 }
 
-def AnyClassRefType : Type<
-  CPred<"$_self.isa<ibis::ClassRefType>()">,
+def AnyScopeRefType : Type<
+  CPred<"$_self.isa<ibis::ScopeRefType>()">,
   "must be a !dc.classref<T?> type",
-  "ibis::ClassRefType">{
+  "ibis::ScopeRefType">{
 }
 
-def OpaqueClassRefType : Type<
-  CPred<"ibis::isOpaqueClassRefType($_self)">,
+def OpaqueScopeRefType : Type<
+  CPred<"ibis::isOpaqueScopeRefType($_self)">,
   "must be a !dc.classref<> type">,
-  BuildableType<"$_builder.getType<ibis::ClassRefType>()"> {
+  BuildableType<"$_builder.getType<ibis::ScopeRefType>()"> {
 }
 
 def PortRefType : IbisTypeDef<"PortRef"> {

--- a/lib/Dialect/Ibis/IbisOps.cpp
+++ b/lib/Dialect/Ibis/IbisOps.cpp
@@ -20,10 +20,10 @@ using namespace circt;
 using namespace ibis;
 
 template <typename TSymAttr>
-ParseResult parseScopeRefFromName(OpAsmParser &parser, Type &ScopeRefType,
+ParseResult parseScopeRefFromName(OpAsmParser &parser, Type &scopeRefType,
                                   TSymAttr sym) {
   // Nothing to parse, since this is already encoded in the child symbol.
-  ScopeRefType = ScopeRefType::get(parser.getContext(), sym);
+  scopeRefType = ScopeRefType::get(parser.getContext(), sym);
   return success();
 }
 
@@ -38,7 +38,8 @@ void printScopeRefFromName(OpAsmPrinter &p, Operation *op, Type type,
 // ScopeOpInterface
 //===----------------------------------------------------------------------===//
 
-FailureOr<Value> circt::ibis::detail::getThisFromScope(Operation *op) {
+FailureOr<mlir::TypedValue<ScopeRefType>>
+circt::ibis::detail::getThisFromScope(Operation *op) {
   auto scopeOp = cast<ScopeOpInterface>(op);
   auto thisOps = scopeOp.getBodyBlock()->getOps<ibis::ThisOp>();
   if (thisOps.empty())

--- a/lib/Dialect/Ibis/IbisOps.cpp
+++ b/lib/Dialect/Ibis/IbisOps.cpp
@@ -20,69 +20,44 @@ using namespace circt;
 using namespace ibis;
 
 template <typename TSymAttr>
-ParseResult parseClassRefFromName(OpAsmParser &parser, Type &classRefType,
+ParseResult parseScopeRefFromName(OpAsmParser &parser, Type &ScopeRefType,
                                   TSymAttr sym) {
   // Nothing to parse, since this is already encoded in the child symbol.
-  classRefType = ClassRefType::get(parser.getContext(), sym);
+  ScopeRefType = ScopeRefType::get(parser.getContext(), sym);
   return success();
 }
 
 template <typename TSymAttr>
-void printClassRefFromName(OpAsmPrinter &p, Operation *op, Type type,
+void printScopeRefFromName(OpAsmPrinter &p, Operation *op, Type type,
                            TSymAttr sym) {
   // Nothing to print since this information is already encoded in the child
   // symbol.
 }
 
 //===----------------------------------------------------------------------===//
-// ClassOp
+// ScopeOpInterface
 //===----------------------------------------------------------------------===//
 
-ParseResult ClassOp::parse(OpAsmParser &parser, OperationState &result) {
-  // Parse signature
-  StringAttr className;
-  if (parser.parseSymbolName(className, mlir::SymbolTable::getSymbolAttrName(),
-                             result.attributes))
+FailureOr<Value> circt::ibis::detail::getThisFromScope(Operation *op) {
+  auto scopeOp = cast<ScopeOpInterface>(op);
+  auto thisOps = scopeOp.getBodyBlock()->getOps<ibis::ThisOp>();
+  if (thisOps.empty())
+    return op->emitOpError("must contain a 'ibis.this' operation");
+
+  if (std::next(thisOps.begin()) != thisOps.end())
+    return op->emitOpError("must contain only one 'ibis.this' operation");
+
+  return {*thisOps.begin()};
+}
+
+LogicalResult circt::ibis::detail::verifyScopeOpInterface(Operation *op) {
+  if (failed(getThisFromScope(op)))
     return failure();
 
-  // parse "this"
-  OpAsmParser::Argument thisArg;
-  if (parser.parseLParen() ||
-      parser.parseArgument(thisArg, /*allowType=*/false) ||
-      parser.parseRParen())
-    return failure();
-
-  thisArg.type = parser.getBuilder().getType<ClassRefType>(className);
-
-  // Parse the attribute dict.
-  if (failed(parser.parseOptionalAttrDictWithKeyword(result.attributes)))
-    return failure();
-
-  // Parse the class body.
-  auto *body = result.addRegion();
-  if (parser.parseRegion(*body, {thisArg}))
-    return failure();
+  if (!isa<SymbolOpInterface>(op))
+    return op->emitOpError("must implement 'SymbolOpInterface'");
 
   return success();
-}
-
-void ClassOp::print(OpAsmPrinter &p) {
-  p << " ";
-  p.printSymbolName(getSymName());
-  p << '(';
-  p.printRegionArgument(getThis(), {}, /*omitType*/ true);
-  p << ')';
-  llvm::SmallVector<::llvm::StringRef, 2> elidedAttrs;
-  elidedAttrs.push_back("sym_name");
-  p.printOptionalAttrDictWithKeyword((*this)->getAttrs(), elidedAttrs);
-  p << " ";
-  p.printRegion(getBody(), /*printEntryBlockArgs=*/false,
-                /*printBlockTerminators=*/true);
-}
-
-void ClassOp::getAsmBlockArgumentNames(mlir::Region &region,
-                                       OpAsmSetValueNameFn setNameFn) {
-  setNameFn(getThis(), "this");
 }
 
 //===----------------------------------------------------------------------===//
@@ -232,11 +207,11 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 LogicalResult GetPortOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // Lookup the target module type of the instance class reference.
   ModuleOp mod = getOperation()->getParentOfType<ModuleOp>();
-  ClassRefType crt = getInstance().getType().cast<ClassRefType>();
+  ScopeRefType crt = getInstance().getType().cast<ScopeRefType>();
   // @teqdruid TODO: make this more efficient using
   // innersymtablecollection when that's available to non-firrtl dialects.
   auto targetClass =
-      symbolTable.lookupSymbolIn<ClassOp>(mod, crt.getClassRef());
+      symbolTable.lookupSymbolIn<ClassOp>(mod, crt.getScopeRef());
   assert(targetClass && "should have been verified by the type system");
   // @teqdruid TODO: make this more efficient using
   // innersymtablecollection when that's available to non-firrtl dialects.
@@ -258,6 +233,26 @@ LogicalResult GetPortOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
     return emitOpError() << "symbol '" << getPortSymbolAttr()
                          << "' refers to a port of type " << targetPortType
                          << ", but this op has type " << thisPortType;
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ThisOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ThisOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  // A thisOp should always refer to the parent operation, which in turn should
+  // be an Ibis ScopeOpInterface.
+  auto parentScope =
+      dyn_cast_or_null<ScopeOpInterface>(getOperation()->getParentOp());
+  if (!parentScope)
+    return emitOpError() << "thisOp must be nested in a scope op";
+
+  if (parentScope.getScopeName() != getScopeName())
+    return emitOpError() << "thisOp refers to a parent scope of name "
+                         << getScopeName() << ", but the parent scope is named "
+                         << parentScope.getScopeName();
 
   return success();
 }

--- a/lib/Dialect/Ibis/IbisTypes.cpp
+++ b/lib/Dialect/Ibis/IbisTypes.cpp
@@ -17,12 +17,12 @@
 using namespace circt;
 using namespace ibis;
 
-bool circt::ibis::isOpaqueClassRefType(mlir::Type type) {
-  auto classRef = type.dyn_cast<ClassRefType>();
-  if (!classRef)
+bool circt::ibis::isOpaqueScopeRefType(mlir::Type type) {
+  auto scopeRef = type.dyn_cast<ScopeRefType>();
+  if (!scopeRef)
     return false;
 
-  return classRef.isOpaque();
+  return scopeRef.isOpaque();
 }
 
 #define GET_TYPEDEF_CLASSES

--- a/test/Dialect/Ibis/errors.mlir
+++ b/test/Dialect/Ibis/errors.mlir
@@ -1,6 +1,7 @@
 // RUN: circt-opt %s --split-input-file --verify-diagnostics
 
-ibis.class @C(%this) {
+ibis.class @C {
+  %this = ibis.this @C
   ibis.method @typeMismatch1() -> ui32 {
     // expected-error @+1 {{must return a value}}
     ibis.return
@@ -9,7 +10,8 @@ ibis.class @C(%this) {
 
 // -----
 
-ibis.class @C(%this) {
+ibis.class @C {
+  %this = ibis.this @C
   ibis.method @typeMismatch2() {
     %c = hw.constant 1 : i8
     // expected-error @+1 {{cannot return a value from a function with no result type}}
@@ -18,7 +20,8 @@ ibis.class @C(%this) {
 }
 
 // -----
-ibis.class @C(%this) {
+ibis.class @C {
+  %this = ibis.this @C
   ibis.method @typeMismatch3() -> ui32 {
     %c = hw.constant 1 : i8
     // expected-error @+1 {{return type ('i8') must match function return type ('ui32')}}
@@ -28,15 +31,31 @@ ibis.class @C(%this) {
 
 // -----
 
-ibis.class @MissingPort(%this) {
+ibis.class @MissingPort {
+  %this = ibis.this @MissingPort
   // expected-error @+1 {{'ibis.get_port' op port '@C_in' does not exist in MissingPort}}
-  %c_in = ibis.get_port %this, @C_in : !ibis.classref<@MissingPort> -> !ibis.portref<i1>
+  %c_in = ibis.get_port %this, @C_in : !ibis.scoperef<@MissingPort> -> !ibis.portref<i1>
 }
 
 // -----
 
-ibis.class @PortTypeMismatch(%this) {
+ibis.class @PortTypeMismatch {
+  %this = ibis.this @PortTypeMismatch
   ibis.port.input @in : i1
   // expected-error @+1 {{'ibis.get_port' op symbol '@in' refers to a port of type 'i1', but this op has type 'i2'}}
-  %c_in = ibis.get_port %this, @in : !ibis.classref<@PortTypeMismatch> -> !ibis.portref<i2>
+  %c_in = ibis.get_port %this, @in : !ibis.scoperef<@PortTypeMismatch> -> !ibis.portref<i2>
+}
+
+// -----
+
+// expected-error @+1 {{'ibis.class' op must contain only one 'ibis.this' operation}}
+ibis.class @MultipleThis {
+  %this = ibis.this @MultipleThis
+  %this2 = ibis.this @MultipleThis
+}
+
+// -----
+
+// expected-error @+1 {{'ibis.container' op must contain a 'ibis.this' operation}}
+ibis.container @NoThis {
 }

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -1,37 +1,44 @@
 // RUN: circt-opt %s | circt-opt | FileCheck %s
 
-// CHECK-LABEL:  ibis.class @A(%this) {
+// CHECK-LABEL:  ibis.class @A {
+// CHECK-NEXT:    %0 = ibis.this @A 
 // CHECK-NEXT:    ibis.port.input @A_in : i1
 // CHECK-NEXT:    ibis.port.output @A_out : i1
 // CHECK-NEXT:  }
 
-// CHECK-LABEL:  ibis.class @C(%this) {
+// CHECK-LABEL:  ibis.class @C {
+// CHECK-NEXT:    %0 = ibis.this @C 
 // CHECK-NEXT:    ibis.port.input @C_in : i1
 // CHECK-NEXT:    ibis.port.output @C_out : i1
-// CHECK-NEXT:    %0 = ibis.instance @a, @A 
-// CHECK-NEXT:    %1 = ibis.get_parent_of_ref %0 : !ibis.classref<@A>
-// CHECK-NEXT:    %2 = ibis.get_instance_in_ref @a : @A in %this : !ibis.classref<@C> 
-// CHECK-NEXT:    %3 = ibis.get_port %0, @A_in : !ibis.classref<@A> -> !ibis.portref<i1>
-// CHECK-NEXT:    %4 = ibis.get_instance_in_ref @a : @A in %1 : !ibis.classref 
+// CHECK-NEXT:    %1 = ibis.instance @a, @A 
+// CHECK-NEXT:    %2 = ibis.get_parent_of_ref %1 : !ibis.scoperef<@A> -> !ibis.scoperef
+// CHECK-NEXT:    %3 = ibis.get_instance_in_ref @a : @A in %0 : !ibis.scoperef<@C> 
+// CHECK-NEXT:    %4 = ibis.get_port %1, @A_in : !ibis.scoperef<@A> -> !ibis.portref<i1>
+// CHECK-NEXT:    %5 = ibis.get_instance_in_ref @a : @A in %2 : !ibis.scoperef 
 // CHECK-NEXT:    ibis.container @D {
-// CHECK-NEXT:      %5 = ibis.get_port %this, @C_in : !ibis.classref<@C> -> !ibis.portref<i1>
-// CHECK-NEXT:      %6 = ibis.get_port %this, @C_out : !ibis.classref<@C> -> !ibis.portref<i1>
+// CHECK-NEXT:      %6 = ibis.this @D 
+// CHECK-NEXT:      %7 = ibis.get_parent_of_ref %6 : !ibis.scoperef<@D> -> !ibis.scoperef<@C>
+// CHECK-NEXT:      %8 = ibis.get_port %7, @C_in : !ibis.scoperef<@C> -> !ibis.portref<i1>
+// CHECK-NEXT:      %9 = ibis.get_port %7, @C_out : !ibis.scoperef<@C> -> !ibis.portref<i1>
 // CHECK-NEXT:      %true = hw.constant true
-// CHECK-NEXT:      ibis.port.write %6, %true : i1
-// CHECK-NEXT:      %7 = ibis.port.read %5 : !ibis.portref<i1>
-// CHECK-NEXT:      %8 = ibis.get_port %0, @A_in : !ibis.classref<@A> -> !ibis.portref<i1>
-// CHECK-NEXT:      %9 = ibis.get_port %0, @A_out : !ibis.classref<@A> -> !ibis.portref<i1>
-// CHECK-NEXT:      ibis.port.write %8, %7 : i1
-// CHECK-NEXT:      %10 = ibis.port.read %9 : !ibis.portref<i1>
+// CHECK-NEXT:      ibis.port.write %9, %true : i1
+// CHECK-NEXT:      %10 = ibis.port.read %8 : !ibis.portref<i1>
+// CHECK-NEXT:      %11 = ibis.get_instance_in_ref @a : @A in %7 : !ibis.scoperef<@C> 
+// CHECK-NEXT:      %12 = ibis.get_port %11, @A_in : !ibis.scoperef<@A> -> !ibis.portref<i1>
+// CHECK-NEXT:      %13 = ibis.get_port %11, @A_out : !ibis.scoperef<@A> -> !ibis.portref<i1>
+// CHECK-NEXT:      ibis.port.write %12, %10 : i1
+// CHECK-NEXT:      %14 = ibis.port.read %13 : !ibis.portref<i1>
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
-ibis.class @A(%this) {
+ibis.class @A {
+  %this = ibis.this @A
   ibis.port.input @A_in : i1
   ibis.port.output @A_out : i1
 }
 
-ibis.class @C(%this) {
+ibis.class @C {
+  %this = ibis.this @C
   ibis.port.input @C_in : i1
   ibis.port.output @C_out : i1
 
@@ -39,24 +46,27 @@ ibis.class @C(%this) {
   %a = ibis.instance @a, @A
 
   // Test get parent/child
-  %parent = ibis.get_parent_of_ref %a : !ibis.classref<@A>
-  %child = ibis.get_instance_in_ref @a : @A in %this : !ibis.classref<@C>
-  %a_in_cp = ibis.get_port %a, @A_in : !ibis.classref<@A> -> !ibis.portref<i1>
+  %parent = ibis.get_parent_of_ref %a : !ibis.scoperef<@A> -> !ibis.scoperef
+  %child = ibis.get_instance_in_ref @a : @A in %this : !ibis.scoperef<@C>
+  %a_in_cp = ibis.get_port %a, @A_in : !ibis.scoperef<@A> -> !ibis.portref<i1>
 
   // Test siblings
-  %sibling = ibis.get_instance_in_ref @a : @A in %parent : !ibis.classref
+  %sibling = ibis.get_instance_in_ref @a : @A in %parent : !ibis.scoperef
 
   ibis.container @D {
+    %this_d = ibis.this @D
+    %parent_C = ibis.get_parent_of_ref %this_d : !ibis.scoperef<@D> -> !ibis.scoperef<@C>
     // Test local read/writes
-    %c_in_p = ibis.get_port %this, @C_in : !ibis.classref<@C> -> !ibis.portref<i1>
-    %c_out_p = ibis.get_port %this, @C_out : !ibis.classref<@C> -> !ibis.portref<i1>
+    %c_in_p = ibis.get_port %parent_C, @C_in : !ibis.scoperef<@C> -> !ibis.portref<i1>
+    %c_out_p = ibis.get_port %parent_C, @C_out : !ibis.scoperef<@C> -> !ibis.portref<i1>
     %true = hw.constant true
     ibis.port.write %c_out_p, %true : i1
     %c_out = ibis.port.read %c_in_p : !ibis.portref<i1>
 
     // Test cross-container read/writes
-    %a_in_p = ibis.get_port %a, @A_in : !ibis.classref<@A> -> !ibis.portref<i1>
-    %a_out_p = ibis.get_port %a, @A_out : !ibis.classref<@A> -> !ibis.portref<i1>
+    %a_in_parent = ibis.get_instance_in_ref @a : @A in %parent_C : !ibis.scoperef<@C>
+    %a_in_p = ibis.get_port %a_in_parent, @A_in : !ibis.scoperef<@A> -> !ibis.portref<i1>
+    %a_out_p = ibis.get_port %a_in_parent, @A_out : !ibis.scoperef<@A> -> !ibis.portref<i1>
     ibis.port.write %a_in_p, %c_out : i1
     %a_out = ibis.port.read %a_out_p : !ibis.portref<i1>
   }

--- a/test/Dialect/Ibis/structure.mlir
+++ b/test/Dialect/Ibis/structure.mlir
@@ -2,7 +2,7 @@
 // RUN: circt-opt %s --ibis-call-prep | circt-opt | FileCheck %s --check-prefix=PREP
 
 
-// CHECK-LABEL: ibis.class @C(%this) {
+// CHECK-LABEL: ibis.class @C {
 // CHECK:         ibis.method @getAndSet(%x: ui32) -> ui32 {
 // CHECK:           ibis.return %x : ui32
 // CHECK:         ibis.method @returnNothing() {
@@ -10,7 +10,7 @@
 // CHECK:         ibis.method @returnNothingWithRet() {
 // CHECK:           ibis.return
 
-// PREP-LABEL: ibis.class @C(%this) {
+// PREP-LABEL: ibis.class @C {
 // PREP:         ibis.method @getAndSet(%arg: !hw.struct<x: ui32>) -> ui32 {
 // PREP:           %x = hw.struct_explode %arg : !hw.struct<x: ui32>
 // PREP:           ibis.return %x : ui32
@@ -20,7 +20,8 @@
 // PREP:         ibis.method @returnNothingWithRet(%arg: !hw.struct<>) {
 // PREP:           hw.struct_explode %arg : !hw.struct<>
 // PREP:           ibis.return
-ibis.class @C(%this) {
+ibis.class @C {
+  %this = ibis.this @C
   ibis.method @getAndSet(%x: ui32) -> ui32 {
     ibis.return %x : ui32
   }
@@ -30,7 +31,7 @@ ibis.class @C(%this) {
   }
 }
 
-// CHECK-LABEL: ibis.class @User(%this) {
+// CHECK-LABEL: ibis.class @User {
 // CHECK:         [[c:%.+]] = ibis.instance @c, @C
 // CHECK:         ibis.method @getAndSetWrapper(%new_value: ui32) -> ui32 {
 // CHECK:           [[x:%.+]] = ibis.call @c::@getAndSet(%new_value) : (ui32) -> ui32
@@ -40,18 +41,19 @@ ibis.class @C(%this) {
 // CHECK:           ibis.return [[x]] : ui32
 
 
-// PREP-LABEL: ibis.class @User(%this) {
+// PREP-LABEL: ibis.class @User {
 // PREP:         [[c:%.+]] = ibis.instance @c, @C
 // PREP:         ibis.method @getAndSetWrapper(%arg: !hw.struct<new_value: ui32>) -> ui32 {
 // PREP:           %new_value = hw.struct_explode %arg : !hw.struct<new_value: ui32>
-// PREP:           %1 = hw.struct_create (%new_value) {sv.namehint = "getAndSet_args_called_from_getAndSetWrapper"} : !hw.struct<x: ui32>
-// PREP:           %2 = ibis.call @c::@getAndSet(%1) : (!hw.struct<x: ui32>) -> ui32
+// PREP:           [[STRUCT1:%.+]] = hw.struct_create (%new_value) {sv.namehint = "getAndSet_args_called_from_getAndSetWrapper"} : !hw.struct<x: ui32>
+// PREP:           [[CALLRES1:%.+]] = ibis.call @c::@getAndSet([[STRUCT1]]) : (!hw.struct<x: ui32>) -> ui32
 // PREP:         ibis.method @getAndSetDup(%arg: !hw.struct<new_value: ui32>) -> ui32 {
 // PREP:           %new_value = hw.struct_explode %arg : !hw.struct<new_value: ui32>
-// PREP:           %1 = hw.struct_create (%new_value) {sv.namehint = "getAndSet_args_called_from_getAndSetDup"} : !hw.struct<x: ui32>
-// PREP:           %2 = ibis.call @c::@getAndSet(%1) : (!hw.struct<x: ui32>) -> ui32
-// PREP:           ibis.return %2 : ui32
-ibis.class @User(%this) {
+// PREP:           [[STRUCT2:%.+]] = hw.struct_create (%new_value) {sv.namehint = "getAndSet_args_called_from_getAndSetDup"} : !hw.struct<x: ui32>
+// PREP:           [[CALLRES2:%.+]] = ibis.call @c::@getAndSet([[STRUCT2]]) : (!hw.struct<x: ui32>) -> ui32
+// PREP:           ibis.return [[CALLRES2]] : ui32
+ibis.class @User {
+  %this = ibis.this @User
   ibis.instance @c, @C
   ibis.method @getAndSetWrapper(%new_value: ui32) -> ui32 {
     %x = ibis.call @c::@getAndSet(%new_value): (ui32) -> ui32


### PR DESCRIPTION
- Adds an `ibis.this` operation to define the current scope.
- Renames `!ibis.classref` to `!ibis.scoperef` since this type must now be able to support both classes and containers
- Adds a `ScopeOpInterface`
- `ibis.get_parent_of_ref` now takes an explicit type to cast the parent ref to. In most `class` cases, this will be an opaque type, but for `container`s these will reference the explicit parent type. The obvious benefit of this is that you're able to perform `get_port` on resolved `scoperef` types.