### PR TITLE
[FIRRTL] Rework RefType FieldID's, passes

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -490,6 +490,9 @@ FieldRef circt::firrtl::getFieldRefFromValue(Value value) {
               value = subfieldOp.getInput();
               typename decltype(subfieldOp)::InputType bundleType =
                   subfieldOp.getInput().getType();
+              // Extra ID if indexing through ref.
+              if (id != 0 && type_isa<RefType>(subfieldOp.getType()))
+                ++id;
               // Rebase the current index on the parent field's
               // index.
               id += bundleType.getFieldID(subfieldOp.getFieldIndex());
@@ -499,6 +502,8 @@ FieldRef circt::firrtl::getFieldRefFromValue(Value value) {
               value = subindexOp.getInput();
               typename decltype(subindexOp)::InputType vecType =
                   subindexOp.getInput().getType();
+              if (id != 0 && type_isa<RefType>(subindexOp.getType()))
+                ++id;
               // Rebase the current index on the parent field's
               // index.
               id += vecType.getFieldID(subindexOp.getIndex());

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -642,9 +642,12 @@ Value circt::firrtl::getValueByFieldID(ImplicitLocOpBuilder builder,
         .Case<RefType>([&](auto reftype) {
           FIRRTLTypeSwitch<FIRRTLBaseType, void>(reftype.getType())
               .template Case<BundleType, FVectorType>([&](auto type) {
-                auto index = type.getIndexForFieldID(fieldID);
+                assert(fieldID >= 1);
+                auto index = type.getIndexForFieldID(fieldID - 1);
                 value = builder.create<RefSubOp>(value, index);
                 fieldID -= type.getFieldID(index);
+                if (fieldID == 1)
+                  fieldID = 0;
               })
               .Default([&](auto _) {
                 llvm::report_fatal_error(

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -578,10 +578,6 @@ circt::firrtl::getFieldName(const FieldRef &fieldRef, bool nameSafe) {
   auto type = value.getType();
   auto localID = fieldRef.getFieldID();
   while (localID) {
-    // Index directly into ref inner type.
-    if (auto refTy = type_dyn_cast<RefType>(type))
-      type = refTy.getType();
-
     if (auto bundleType = type_dyn_cast<BundleType>(type)) {
       auto index = bundleType.getIndexForFieldID(localID);
       // Add the current field string, and recurse into a subfield.
@@ -608,6 +604,10 @@ circt::firrtl::getFieldName(const FieldRef &fieldRef, bool nameSafe) {
       name += element.name.getValue();
       type = element.type;
       localID = localID - enumType.getFieldID(index);
+    } else if (auto refType = type_dyn_cast<RefType>(type)) {
+      // Index through refs, but account for fieldID.
+      localID--;
+      type = refType.getType();
     } else {
       // If we reach here, the field ref is pointing inside some aggregate type
       // that isn't a bundle or a vector. If the type is a ground type, then the

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -2215,7 +2215,7 @@ FailureOr<bool> InferenceTypeUpdate::updateValue(Value value) {
       for (auto &element : bundleType) {
         auto updatedBase = firrtl::type_dyn_cast_or_null<FIRRTLBaseType>(
             updateBase(type_cast<hw::FieldIDTypeInterface>(element.type)));
-        if (!updateBase)
+        if (!updatedBase)
           return {};
         elements.emplace_back(element.name, element.isFlip, updatedBase);
       }
@@ -2246,7 +2246,7 @@ FailureOr<bool> InferenceTypeUpdate::updateValue(Value value) {
             firrtl::type_dyn_cast_or_null<FIRRTLBaseType>(updateBase(
                 firrtl::type_cast<hw::FieldIDTypeInterface>(element.type)));
 
-        if (!updateBase)
+        if (!updatedBase)
           return {};
         elements.emplace_back(element.name, updatedBase);
       }

--- a/test/Dialect/FIRRTL/lower-open-aggs.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs.mlir
@@ -150,7 +150,7 @@ firrtl.circuit "SymbolOnField" {
   // CHECK: @SymbolOnField
   // CHECK-SAME: (out r: !firrtl.bundle<x: uint<1>> sym [<@sym,1,public>],
   // CHECK-SAME:  out r_p: !firrtl.probe<uint<1>>)
-  firrtl.extmodule @SymbolOnField(out r : !firrtl.openbundle<p: probe<uint<1>>, x: uint<1>> sym [<@sym,2,public>])
+  firrtl.extmodule @SymbolOnField(out r : !firrtl.openbundle<p: probe<uint<1>>, x: uint<1>> sym [<@sym,3,public>])
 }
 
 // -----
@@ -178,9 +178,9 @@ firrtl.circuit "ManySymbols" {
         sym [<@mixed,0,public>,
                <@a,1,public>,
                <@xvec,2,public>,
-                 <@x0,3,public>, <@x0_data,5,public>,
-                 <@x1,6,public>, <@x1_data,8,public>,
-               <@b,9,public>])
+                 <@x0,3,public>, <@x0_data,10,public>,
+                 <@x1,11,public>, <@x1_data,18,public>,
+               <@b,19,public>])
 
   // Similar but with a refs-only agg between HW elements.
   // Same HW-only contents as above.
@@ -203,7 +203,7 @@ firrtl.circuit "ManySymbols" {
         sym [<@mixed,0,public>,
                <@a,1,public>,
                <@xvec,2,public>,
-                 <@x0,3,public>, <@x0_data,6,public>,
-                 <@x1,7,public>, <@x1_data,10,public>,
-               <@b,11,public>])
+                 <@x0,3,public>, <@x0_data,11,public>,
+                 <@x1,12,public>, <@x1_data,20,public>,
+               <@b,21,public>])
 }


### PR DESCRIPTION
Let's see if we like the other design point better!

cc #5571 , which partly moves RefTypes to this indexing scheme .

In this world, FieldID does not mean what can be addressed/reached by value (see use of fieldID's in FieldRef's and general in methods for generating/chasing up indexing operations; FieldID type methods through a ref do not return types that would ever be obtained by indexing, so on), but rather simply the DFS numbering of all contained types.

Currently (before this PR), RefType's were essentially opaque to FieldID, requiring passes to explicitly know about them in order to index through them (and do something reasonable if they failed to do so-- treat the ref opaquely).
Since we run LOA essentially as part of parsing, there's less of a need to worry about meaning of fieldID's to passes when the ref is found within an aggregate (since that can't happen, so post-parsing RefTypes are their own thing).

Status: Ported various utilities and passes over (hopefully not too roughly), may have missed some.  Passes doing analysis (IMCP, InferWidths, so on) especially those based on traditional FIRRTL, are written to expect to be able to walk types in parallel at same fieldID, but most were amenable to this change.  

InferResets isn't updated presently, but isn't a show-stopper.  Mostly want to share to see if we want to pursue this further and revisit with fresh eyes.