### PR TITLE
[Seq] Add an inner symbol to permit references to clock gates

### DIFF
--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -282,7 +282,10 @@ def WritePortOp : SeqOp<"write", [
 // Clock Gate
 //===----------------------------------------------------------------------===//
 
-def ClockGateOp : SeqOp<"clock_gate", [Pure]> {
+def ClockGateOp : SeqOp<"clock_gate", [
+  Pure,
+  DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>
+]> {
   let summary = "Safely gates a clock with an enable signal";
   let description = [{
     The `seq.clock_gate` enables and disables a clock safely, without glitches,
@@ -297,18 +300,27 @@ def ClockGateOp : SeqOp<"clock_gate", [Pure]> {
     The `test_enable` operand is optional and if present is OR'd together with
     the `enable` operand to determine whether the output clock is gated or not.
 
+    The op can be referred to using an inner symbol. Upon translation, the
+    symbol will target the instance to the external module it lowers to.
+
     ```
     %gatedClock = seq.clock_gate %clock, %enable : i1
     %gatedClock = seq.clock_gate %clock, %enable, %test_enable : i1, i1
     ```
   }];
 
-  let arguments = (ins I1:$input, I1:$enable, Optional<I1>:$test_enable);
+  let arguments = (ins
+    I1:$input,
+    I1:$enable,
+    Optional<I1>:$test_enable,
+    OptionalAttr<InnerSymAttr>:$inner_sym
+  );
+
   let results = (outs I1:$output);
   let hasFolder = 1;
   let hasCanonicalizeMethod = 1;
   let assemblyFormat = [{
-    $input `,` $enable (`,` $test_enable^)? attr-dict
+    $input `,` $enable (`,` $test_enable^)? (`sym` $inner_sym^)? attr-dict
   }];
 }
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3640,9 +3640,9 @@ LogicalResult FIRRTLLowering::visitExpr(ClockGateIntrinsicOp op) {
   Value testEnable;
   if (op.getTestEnable())
     testEnable = getLoweredValue(op.getTestEnable());
-  return setLoweringTo<seq::ClockGateOp>(op, getLoweredValue(op.getInput()),
-                                         getLoweredValue(op.getEnable()),
-                                         testEnable);
+  return setLoweringTo<seq::ClockGateOp>(
+      op, getLoweredValue(op.getInput()), getLoweredValue(op.getEnable()),
+      testEnable, /*inner_sym=*/hw::InnerSymAttr{});
 }
 
 LogicalResult FIRRTLLowering::visitExpr(LTLAndIntrinsicOp op) {

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -160,7 +160,8 @@ public:
     if (this->clockGateRegs) {
       // Create the top-level clock gate.
       notStalledClockGate = builder.create<seq::ClockGateOp>(
-          loc, args.clock, stageValidAndNotStalled, /*test_enable=*/Value());
+          loc, args.clock, stageValidAndNotStalled, /*test_enable=*/Value(),
+          /*inner_sym=*/hw::InnerSymAttr());
     }
 
     for (auto it : llvm::enumerate(stageOp.getRegisters())) {
@@ -175,7 +176,8 @@ public:
         for (auto hierClockGateEnable : stageOp.getClockGatesForReg(regIdx)) {
           // Create clock gates for any hierarchically nested clock gates.
           currClockGate = builder.create<seq::ClockGateOp>(
-              loc, currClockGate, hierClockGateEnable, /*test_enable=*/Value());
+              loc, currClockGate, hierClockGateEnable, /*test_enable=*/Value(),
+              /*inner_sym=*/hw::InnerSymAttr());
         }
         dataReg = builder.create<seq::CompRegOp>(stageOp->getLoc(), regIn,
                                                  currClockGate, regName);

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -750,6 +750,10 @@ LogicalResult ClockGateOp::canonicalize(ClockGateOp op,
   return failure();
 }
 
+std::optional<size_t> ClockGateOp::getTargetResultIndex() {
+  return std::nullopt;
+}
+
 //===----------------------------------------------------------------------===//
 // FirMemOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Seq/Transforms/ExternalizeClockGate.cpp
+++ b/lib/Dialect/Seq/Transforms/ExternalizeClockGate.cpp
@@ -36,11 +36,12 @@ void ExternalizeClockGatePass::runOnOperation() {
   SymbolTable &symtbl = getAnalysis<SymbolTable>();
 
   // Collect all clock gate ops.
-  std::vector<ClockGateOp> clockGatesToReplace;
-  getOperation().walk(
-      [&](ClockGateOp op) { clockGatesToReplace.push_back(op); });
+  DenseMap<HWModuleOp, SmallVector<ClockGateOp>> gatesInModule;
+  for (auto module : getOperation().getOps<HWModuleOp>()) {
+    module.walk([&](ClockGateOp op) { gatesInModule[module].push_back(op); });
+  }
 
-  if (clockGatesToReplace.empty()) {
+  if (gatesInModule.empty()) {
     markAllAnalysesPreserved();
     return;
   }
@@ -61,43 +62,52 @@ void ExternalizeClockGatePass::runOnOperation() {
     modulePorts.push_back({{builder.getStringAttr(testEnableName), i1Type,
                             ModulePort::Direction::Input}});
 
-  auto moduleOp = builder.create<HWModuleExternOp>(
+  auto externModuleOp = builder.create<HWModuleExternOp>(
       getOperation().getLoc(), builder.getStringAttr(moduleName), modulePorts,
       moduleName);
-  symtbl.insert(moduleOp);
+  symtbl.insert(externModuleOp);
 
   // Replace all clock gates with an instance of the external module.
   SmallVector<Value, 4> instPorts;
-  for (auto ckgOp : clockGatesToReplace) {
-    ImplicitLocOpBuilder builder(ckgOp.getLoc(), ckgOp);
+  for (auto &[module, clockGatesToReplace] : gatesInModule) {
+    Value cstFalse;
+    for (auto ckgOp : clockGatesToReplace) {
+      ImplicitLocOpBuilder builder(ckgOp.getLoc(), ckgOp);
 
-    Value enable = ckgOp.getEnable();
-    Value testEnable = ckgOp.getTestEnable();
+      Value enable = ckgOp.getEnable();
+      Value testEnable = ckgOp.getTestEnable();
 
-    // If the clock gate has a test enable operand but the module does not, add
-    // a `comb.or` to merge the two enable conditions.
-    if (hasTestEnable && !testEnable)
-      testEnable = builder.create<ConstantOp>(i1Type, 0);
+      // If the clock gate has no test enable operand but the module does, add a
+      // constant 0 input.
+      if (hasTestEnable && !testEnable) {
+        if (!cstFalse) {
+          cstFalse = builder.create<ConstantOp>(i1Type, 0);
+        }
+        testEnable = cstFalse;
+      }
 
-    // If the clock gate has no test enable operand but the module does, add a
-    // constant 0 input.
-    if (!hasTestEnable && testEnable) {
-      enable = builder.createOrFold<comb::OrOp>(enable, testEnable, true);
-      testEnable = {};
+      // If the clock gate has a test enable operand but the module does not,
+      // add a `comb.or` to merge the two enable conditions.
+      if (!hasTestEnable && testEnable) {
+        enable = builder.createOrFold<comb::OrOp>(enable, testEnable, true);
+        testEnable = {};
+      }
+
+      instPorts.push_back(ckgOp.getInput());
+      instPorts.push_back(enable);
+      if (testEnable)
+        instPorts.push_back(testEnable);
+
+      auto instOp = builder.create<InstanceOp>(
+          externModuleOp, builder.getStringAttr(instName), instPorts,
+          builder.getArrayAttr({}), ckgOp.getInnerSymAttr());
+
+      ckgOp.replaceAllUsesWith(instOp);
+      ckgOp.erase();
+
+      instPorts.clear();
+      ++numClockGatesConverted;
     }
-
-    instPorts.push_back(ckgOp.getInput());
-    instPorts.push_back(enable);
-    if (testEnable)
-      instPorts.push_back(testEnable);
-
-    auto instOp = builder.create<InstanceOp>(
-        moduleOp, builder.getStringAttr(instName), instPorts);
-    ckgOp.replaceAllUsesWith(instOp);
-    ckgOp.erase();
-
-    instPorts.clear();
-    ++numClockGatesConverted;
   }
 }
 

--- a/test/Dialect/Seq/externalize-clock-gate.mlir
+++ b/test/Dialect/Seq/externalize-clock-gate.mlir
@@ -11,14 +11,18 @@ hw.module @Foo(%clock: i1, %enable: i1, %test_enable: i1) {
   // CHECK-NOT: seq.clock_gate
   %cg0 = seq.clock_gate %clock, %enable
   %cg1 = seq.clock_gate %clock, %enable, %test_enable
+  %cg2 = seq.clock_gate %clock, %enable sym @symbol
 
   // CHECK-DEFAULT: hw.instance "ckg" @CKG(I: %clock: i1, E: %enable: i1, TE: %false: i1) -> (O: i1)
   // CHECK-DEFAULT: hw.instance "ckg" @CKG(I: %clock: i1, E: %enable: i1, TE: %test_enable: i1) -> (O: i1)
+  // CHECK-DEFAULT: hw.instance "ckg" sym @symbol @CKG(I: %clock: i1, E: %enable: i1, TE: %false: i1) -> (O: i1)
 
   // CHECK-CUSTOM: hw.instance "gated" @SuchClock(CI: %clock: i1, EN: %enable: i1, TEN: %false: i1) -> (CO: i1)
   // CHECK-CUSTOM: hw.instance "gated" @SuchClock(CI: %clock: i1, EN: %enable: i1, TEN: %test_enable: i1) -> (CO: i1)
+  // CHECK-CUSTOM: hw.instance "gated" sym @symbol @SuchClock(CI: %clock: i1, EN: %enable: i1, TEN: %false: i1) -> (CO: i1)
 
   // CHECK-WITHOUT-TESTENABLE: hw.instance "ckg" @VeryGate(I: %clock: i1, E: %enable: i1) -> (O: i1)
   // CHECK-WITHOUT-TESTENABLE: [[COMBINED_ENABLE:%.+]] = comb.or bin %enable, %test_enable : i1
   // CHECK-WITHOUT-TESTENABLE: hw.instance "ckg" @VeryGate(I: %clock: i1, E: [[COMBINED_ENABLE]]: i1) -> (O: i1)
+  // CHECK-WITHOUT-TESTENABLE: hw.instance "ckg" sym @symbol @VeryGate(I: %clock: i1, E: %enable: i1) -> (O: i1)
 }

--- a/test/Dialect/Seq/round-trip.mlir
+++ b/test/Dialect/Seq/round-trip.mlir
@@ -51,8 +51,10 @@ hw.module @d0(%clk : i1, %rst : i1) -> () {
 hw.module @ClockGate(%clock: i1, %enable: i1, %test_enable: i1) {
   // CHECK-NEXT: seq.clock_gate %clock, %enable
   // CHECK-NEXT: seq.clock_gate %clock, %enable, %test_enable
+  // CHECK-NEXT: seq.clock_gate %clock, %enable, %test_enable sym @gate_sym
   %cg0 = seq.clock_gate %clock, %enable
   %cg1 = seq.clock_gate %clock, %enable, %test_enable
+  %cg2 = seq.clock_gate %clock, %enable, %test_enable sym @gate_sym
 }
 
 hw.module @fifo1(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> () {


### PR DESCRIPTION
The inner symbol of a clock gate translates to an inner symbol on the instance it lowers to. Also slightly adjusted the lowering to cache constants and produce more readable test output.