### PR TITLE
[Pipeline] Remove `ext` input from pipelines

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineOps.h
+++ b/include/circt/Dialect/Pipeline/PipelineOps.h
@@ -24,6 +24,14 @@ namespace pipeline {
 class StageOp;
 class ScheduledPipelineOp;
 
+namespace detail {
+
+// Returns the set of values defined outside of the given region, and the
+// operation that defines the region. This will walk the entire region so
+// should be used with care (or cache the results).
+llvm::SmallVector<Value> getValuesDefinedOutsideRegion(Region &region);
+} // namespace detail
+
 // Determines the stage which 'op' resides in within the pipeline. This is
 // useful for analysis of the pipeline, wherein ops may reside in nested
 // regions within different stages of the pipeline.

--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -24,15 +24,14 @@ include "circt/Dialect/Pipeline/PipelineDialect.td"
 
 class PipelineBase<string mnemonic, list<Trait> traits = []> : 
   Op<Pipeline_Dialect, mnemonic, !listconcat(traits, [
-      IsolatedFromAbove,
       Pure,
       RegionKindInterface,
       AttrSizedOperandSegments])> {
 
   let arguments = (ins
-    OptionalAttr<StrAttr>:$name, Variadic<AnyType>:$inputs, Variadic<AnyType>:$extInputs, Optional<I1>:$stall,
+    OptionalAttr<StrAttr>:$name, Variadic<AnyType>:$inputs, Optional<I1>:$stall,
     I1:$clock, I1:$reset, I1:$go, StrArrayAttr:$inputNames,
-    OptionalAttr<StrArrayAttr>:$extInputNames, StrArrayAttr:$outputNames
+    StrArrayAttr:$outputNames
   );
   let results = (outs Variadic<AnyType>:$dataOutputs, I1:$done);
   let hasCustomAssemblyFormat = 1;
@@ -45,11 +44,10 @@ class PipelineBase<string mnemonic, list<Trait> traits = []> :
   // in the printer/parser.
   // Order:
   // 1. Inputs
-  // 2. External inputs (opt)
-  // 3. Stall (opt)
-  // 4. Clock
-  // 5. Reset
-  // 6. Go
+  // 2. Stall (opt)
+  // 3. Clock
+  // 4. Reset
+  // 5. Go
   let extraClassDeclaration = extraModuleClassDeclaration # [{
     // Returns the entry stage of this pipeline.
     Block* getEntryStage() {
@@ -91,10 +89,12 @@ class PipelineBase<string mnemonic, list<Trait> traits = []> :
       return getEntryStage()->getArguments().take_front(getInputs().size());
     }
 
-    llvm::ArrayRef<BlockArgument> getInnerExtInputs() {
-      return getEntryStage()->getArguments().slice(
-          getInputs().size(), getExtInputs().size()
-      );
+    // Returns a list of external inputs to the pipeline. These are defined
+    // as any value which is defined outside the inner pipeline region.
+    // This will walk the entire pipeline, so it is recommended to cache the
+    // result if it is used multiple times.
+    llvm::SmallVector<Value> getExtInputs() {
+      return detail::getValuesDefinedOutsideRegion(getRegion());
     }
   }];
 }
@@ -145,6 +145,9 @@ def ScheduledPipelineOp : PipelineBase<"scheduled", [
     pipelines with II>1, a user must themselves maintain state about when
     the pipeline is ready to accept new inputs. We plan to add support for
     head-of-pipeline backpressure in the future.
+
+    Any value defined outside the pipeline is considered an external input. An
+    external input will _not_ be registered.
   }];
 
   let regions = (region AnyRegion:$body);
@@ -152,8 +155,8 @@ def ScheduledPipelineOp : PipelineBase<"scheduled", [
   let skipDefaultBuilders = 1;
 
   let builders = [
-    OpBuilder<(ins "TypeRange":$dataOutputs, "ValueRange":$inputs, "ValueRange":$extInputs,
-      "ArrayAttr":$inputNames, "ArrayAttr":$outputNames, "ArrayAttr":$extInputNames,
+    OpBuilder<(ins "TypeRange":$dataOutputs, "ValueRange":$inputs,
+      "ArrayAttr":$inputNames, "ArrayAttr":$outputNames,
       "Value":$clock, "Value":$reset, "Value":$go, CArg<"Value", "{}">:$stall, CArg<"StringAttr", "{}">:$name)>
   ];
 

--- a/include/circt/Dialect/Pipeline/PipelinePasses.td
+++ b/include/circt/Dialect/Pipeline/PipelinePasses.td
@@ -16,7 +16,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def ExplicitRegs : Pass<"pipeline-explicit-regs", "pipeline::ScheduledPipelineOp"> {
+def ExplicitRegs : Pass<"pipeline-explicit-regs"> {
   let summary = "Makes stage registers explicit.";
   let description = [{
     Makes all stage-crossing def-use chains into explicit registers.

--- a/integration_test/Dialect/Pipeline/simple/simple.mlir
+++ b/integration_test/Dialect/Pipeline/simple/simple.mlir
@@ -2,7 +2,7 @@
 
 // Test 1: default lowering
 
-// RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs), lower-pipeline-to-hw{outline-stages}), lower-seq-to-sv, sv-trace-iverilog, export-verilog)' \
+// RUN: circt-opt %s -pipeline-explicit-regs -lower-pipeline-to-hw="outline-stages" -lower-seq-to-sv -sv-trace-iverilog -export-verilog \
 // RUN:     -o %t.mlir > %t.sv
 
 // RUN: circt-cocotb-driver.py --objdir=%T --topLevel=simple \
@@ -10,7 +10,7 @@
 
 // Test 2: Clock-gate implementation
 
-// RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs), lower-pipeline-to-hw{outline-stages clock-gate-regs}), lower-seq-to-sv, sv-trace-iverilog, export-verilog)' \
+// RUN: circt-opt %s -pipeline-explicit-regs -lower-pipeline-to-hw="outline-stages clock-gate-regs" -lower-seq-to-sv -sv-trace-iverilog -export-verilog \
 // RUN:     -o %t.mlir > %t_cg.sv
 
 // RUN: circt-cocotb-driver.py --objdir=%T --topLevel=simple \

--- a/integration_test/Dialect/Pipeline/stall/stallTest.mlir
+++ b/integration_test/Dialect/Pipeline/stall/stallTest.mlir
@@ -2,7 +2,7 @@
 
 // Test 1: default lowering (input muxing)
 
-// RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs), lower-pipeline-to-hw{outline-stages}), lower-seq-to-sv, sv-trace-iverilog, export-verilog)' \
+// RUN: circt-opt %s -pipeline-explicit-regs -lower-pipeline-to-hw="outline-stages" -lower-seq-to-sv -sv-trace-iverilog -export-verilog \
 // RUN:     -o %t.mlir > %t.sv
 
 // RUN: circt-cocotb-driver.py --objdir=%T --topLevel=stallTest \
@@ -10,7 +10,7 @@
 
 // Test 2: Clock-gate implementation
 
-// RUN: circt-opt %s -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs), lower-pipeline-to-hw{outline-stages clock-gate-regs}), lower-seq-to-sv, sv-trace-iverilog, export-verilog)' \
+// RUN: circt-opt %s -pipeline-explicit-regs -lower-pipeline-to-hw="outline-stages clock-gate-regs" -lower-seq-to-sv -sv-trace-iverilog -export-verilog \
 // RUN:     -o %t_clockgated.mlir > %t.sv
 
 // RUN: circt-cocotb-driver.py --objdir=%T --topLevel=stallTest \

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -337,11 +337,6 @@ public:
          llvm::zip(pipeline.getInputs(), pipeline.getInnerInputs()))
       inner.replaceAllUsesWith(outer);
 
-    // Replace uses of the external inputs with the inner external inputs.
-    for (auto [outer, inner] :
-         llvm::zip(pipeline.getExtInputs(), pipeline.getInnerExtInputs()))
-      inner.replaceAllUsesWith(outer);
-
     // All operations should go directly before the pipeline op, into the
     // parent module.
     builder.setInsertionPoint(pipeline);
@@ -460,7 +455,7 @@ public:
   // stages actually reference them. This will be used to generate the stage
   // module signatures.
   void gatherExtInputsToStages() {
-    for (auto extIn : pipeline.getInnerExtInputs()) {
+    for (auto extIn : pipelineExtInputs) {
       for (auto *user : extIn.getUsers())
         stageExtInputs[user->getBlock()].insert(extIn);
     }
@@ -472,22 +467,19 @@ public:
                                        getPipelineBaseName().strref());
     cloneConstantsToStages();
 
-    // Map external inputs to names - we use this to generate nicer names for
-    // the stage module arguments.
-    if (!pipeline.getExtInputs().empty()) {
-      for (auto [extIn, extName] :
-           llvm::zip(pipeline.getInnerExtInputs(),
-                     pipeline.getExtInputNames()->getAsRange<StringAttr>())) {
-        extInputNames[extIn] = extName;
-      }
-    }
+    // Cache the external inputs of the pipeline.
+    pipelineExtInputs = pipeline.getExtInputs();
+
+    // Generate names for the external inputs.
+    for (auto [i, extIn] : llvm::enumerate(pipelineExtInputs))
+      extInputNames[extIn] = builder.getStringAttr("e" + Twine(i));
 
     // Build the top-level pipeline module.
     bool withStall = static_cast<bool>(pipeline.getStall());
     pipelineMod = buildPipelineLike(
         pipelineName.strref(), pipeline.getInputs().getTypes(),
-        pipeline.getInnerExtInputs(), pipeline.getDataOutputs().getTypes(),
-        withStall, pipeline.getInputNames().getValue(),
+        pipelineExtInputs, pipeline.getDataOutputs().getTypes(), withStall,
+        pipeline.getInputNames().getValue(),
         pipeline.getOutputNames().getValue());
     auto portLookup = pipelineMod.getPortLookupInfo();
     pipelineClk = pipelineMod.getBody().front().getArgument(
@@ -501,13 +493,15 @@ public:
 
     if (!pipeline.getExtInputs().empty()) {
       // Maintain a mapping between external inputs and their corresponding
-      // block argument in the top-level pipeline.
+      // block argument in the top-level pipeline. This places some hard
+      // assumptions on the order which the external inputs are declared in the
+      // top-level module, as defined by buildPipelineLike.
       auto modInnerExtInputs =
           pipelineMod.getBody().front().getArguments().slice(
-              pipeline.getExtInputs().getBeginOperandIndex(),
-              pipeline.getExtInputs().size());
+              // External inputs start after the regular inputs.
+              pipeline.getInputs().size(), pipelineExtInputs.size());
       for (auto [extIn, barg] :
-           llvm::zip(pipeline.getInnerExtInputs(), modInnerExtInputs)) {
+           llvm::zip(pipelineExtInputs, modInnerExtInputs)) {
         toplevelExtInputs[extIn] = barg;
       }
     }
@@ -828,6 +822,9 @@ private:
 
   // Handle to the PipelineStageMod for the parent pipeline module.
   PipelineStageMod pipelineStageMod;
+
+  // Caching of the external inputs of the pipeline.
+  llvm::SmallVector<Value> pipelineExtInputs;
 
   // A mapping between stages and the external inputs which they reference.
   // A SetVector is used to ensure determinism in the order of the external

--- a/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
@@ -138,11 +138,9 @@ ScheduleLinearPipelinePass::schedulePipeline(UnscheduledPipelineOp pipeline) {
   b.setInsertionPoint(pipeline);
   auto schedPipeline = b.template create<pipeline::ScheduledPipelineOp>(
       pipeline.getLoc(), pipeline.getDataOutputs().getTypes(),
-      pipeline.getInputs(), pipeline.getExtInputs(), pipeline.getInputNames(),
-      pipeline.getOutputNames(),
-      pipeline.getExtInputNames().value_or(ArrayAttr()), pipeline.getClock(),
-      pipeline.getReset(), pipeline.getGo(), pipeline.getStall(),
-      pipeline.getNameAttr());
+      pipeline.getInputs(), pipeline.getInputNames(), pipeline.getOutputNames(),
+      pipeline.getClock(), pipeline.getReset(), pipeline.getGo(),
+      pipeline.getStall(), pipeline.getNameAttr());
 
   Block *currentStage = schedPipeline.getStage(0);
 

--- a/test/Conversion/PipelineToHW/test_inline.mlir
+++ b/test/Conversion/PipelineToHW/test_inline.mlir
@@ -132,19 +132,19 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_1]] : i32, i32
 // CHECK:         }
 hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
-  %0:3 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg0) ext (%e0 : i32 = %ext1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0: i32, out1: i32) {
+  %0:3 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0: i32, out1: i32) {
     %true = hw.constant true
     %1 = comb.sub %a0, %a0 : i32
     pipeline.stage ^bb1 regs(%1 : i32)
 
   ^bb1(%6: i32, %s1_valid: i1):
     // Use the external value inside a stage
-    %8 = comb.add %6, %e0 : i32
+    %8 = comb.add %6, %ext1 : i32
     pipeline.stage ^bb2 regs(%8 : i32)
   
   ^bb2(%9 : i32, %s2_valid: i1):
   // Use the external value in the exit stage.
-    pipeline.return %9, %e0 : i32, i32
+    pipeline.return %9, %ext1 : i32, i32
   }
   hw.output %0#0, %0#1 : i32, i32
 }

--- a/test/Conversion/PipelineToHW/test_outlined.mlir
+++ b/test/Conversion/PipelineToHW/test_outlined.mlir
@@ -58,11 +58,11 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 // CHECK:         }
 
 // CHECK-LABEL:   hw.module @testLatency1(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, done: i1) {
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, done: i1) {
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = hw.instance "testLatency1_p0" @testLatency1_p0(a0: %[[VAL_0]]: i32, enable: %[[VAL_2]]: i1, clk: %[[VAL_3]]: i1, rst: %[[VAL_4]]: i1) -> (out: i32, valid: i1)
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_6]] : i32, i1
 // CHECK:         }
-hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32, done: i1) {
+hw.module @testLatency1(%arg0: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32, done: i1) {
   %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     %1 = pipeline.latency 2 -> (i32) {
       %6 = comb.add %a0, %a0 : i32
@@ -252,19 +252,19 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // CHECK:           hw.output %[[VAL_5]], %[[VAL_6]] : i32, i32
 // CHECK:         }
 hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
-  %0:3 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg0) ext (%e0 : i32 = %ext1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0: i32, out1: i32) {
+  %0:3 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0: i32, out1: i32) {
     %true = hw.constant true
     %1 = comb.sub %a0, %a0 : i32
     pipeline.stage ^bb1 regs(%1 : i32)
 
   ^bb1(%6: i32, %s1_valid: i1):
     // Use the external value inside a stage
-    %8 = comb.add %6, %e0 : i32
+    %8 = comb.add %6, %ext1 : i32
     pipeline.stage ^bb2 regs(%8 : i32)
   
   ^bb2(%9 : i32, %s2_valid: i1):
   // Use the external value in the exit stage.
-    pipeline.return %9, %e0  : i32, i32
+    pipeline.return %9, %ext1  : i32, i32
   }
   hw.output %0#0, %0#1 : i32, i32
 }

--- a/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
+++ b/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt -pass-pipeline='builtin.module(hw.module(pipeline.scheduled(pipeline-explicit-regs)))' --allow-unregistered-dialect %s | FileCheck %s
+// RUN: circt-opt -pipeline-explicit-regs --allow-unregistered-dialect %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @testRegsOnly(
 // CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
@@ -223,23 +223,23 @@ hw.module @test_arbitrary_nesting(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1,
 
 // CHECK-LABEL:   hw.module @testExtInput(
 // CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = pipeline.scheduled(%[[VAL_8:.*]] : i32 = %[[VAL_0]]) ext(%[[VAL_9:.*]] : i32 = %[[VAL_1]]) clock(%[[VAL_10:.*]] = %[[VAL_3]]) reset(%[[VAL_11:.*]] = %[[VAL_4]]) go(%[[VAL_12:.*]] = %[[VAL_2]]) -> (out0 : i32, out1 : i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = pipeline.scheduled(%[[VAL_8:.*]] : i32 = %[[VAL_0]]) clock(%[[VAL_10:.*]] = %[[VAL_3]]) reset(%[[VAL_11:.*]] = %[[VAL_4]]) go(%[[VAL_12:.*]] = %[[VAL_2]]) -> (out0 : i32, out1 : i32) {
 // CHECK:             %[[VAL_13:.*]] = hw.constant true
-// CHECK:             %[[VAL_14:.*]] = comb.add %[[VAL_8]], %[[VAL_9]] : i32
+// CHECK:             %[[VAL_14:.*]] = comb.add %[[VAL_8]], %[[VAL_1]] : i32
 // CHECK:             pipeline.stage ^bb1 regs(%[[VAL_14]] : i32)
 // CHECK:           ^bb1(%[[VAL_15:.*]]: i32, %[[VAL_16:.*]]: i1):
-// CHECK:             pipeline.return %[[VAL_15]], %[[VAL_9]] : i32, i32
+// CHECK:             pipeline.return %[[VAL_15]], %[[VAL_1]] : i32, i32
 // CHECK:           }
 // CHECK:           hw.output %[[VAL_17:.*]], %[[VAL_18:.*]] : i32, i32
 // CHECK:         }
 hw.module @testExtInput(%arg0 : i32, %ext1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out0: i32, out1: i32) {
-  %out:3 = pipeline.scheduled(%a0 : i32 = %arg0) ext(%e0 : i32 = %ext1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0: i32, out1: i32) {
+  %out:3 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0: i32, out1: i32) {
       %true = hw.constant true
-      %add0 = comb.add %a0, %e0 : i32
+      %add0 = comb.add %a0, %ext1 : i32
       pipeline.stage ^bb1
 
     ^bb1(%s1_valid : i1):
-      pipeline.return %add0, %e0 : i32, i32
+      pipeline.return %add0, %ext1 : i32, i32
   }
   hw.output %out#0, %out#1 : i32, i32
 }


### PR DESCRIPTION
Instead, remove `IsolatedFromAbove` from the pipeline, and define any used value defined outside of the pipeline as an external input. The motiviation for this is to reduce the headache introduced by having to explicitly modify the `ext` input list of a pipeline if more external inputs are to be added into a pipeline (or hoisted out of).