### PR TITLE
[FIRRTL] Clean up RWProbe's verifier

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -5126,15 +5126,13 @@ FIRRTLType RWProbeOp::inferReturnType(ValueRange operands,
 
 LogicalResult RWProbeOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
   auto targetRef = getTarget();
-  if (!targetRef)
-    return emitOpError("has invalid target reference");
   if (targetRef.getModule() !=
       (*this)->getParentOfType<FModuleLike>().getModuleNameAttr())
     return emitOpError() << "has non-local target";
 
   auto target = ns.lookup(targetRef);
   if (!target)
-    return emitOpError() << "has target that cannot be resolved: " << target;
+    return emitOpError() << "has target that cannot be resolved: " << targetRef;
 
   auto checkFinalType = [&](auto type, Location loc) -> LogicalResult {
     // Determine final type.

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1922,6 +1922,16 @@ firrtl.circuit "RWProbeRemote" {
 
 // -----
 
+firrtl.circuit "RWProbeBadTarget" {
+  firrtl.module @RWProbeBadTarget() {
+    // expected-error @below {{has target that cannot be resolved: #hw.innerNameRef<@RWProbeBadTarget::@x>}}
+    %rw = firrtl.ref.rwprobe <@RWProbeBadTarget::@x> : !firrtl.uint<1>
+  }
+}
+
+
+// -----
+
 firrtl.circuit "RWProbeNonBase" {
   firrtl.module @RWProbeNonBase() {
     // expected-error @below {{cannot force type '!firrtl.string'}}


### PR DESCRIPTION
Two changes:

1) The ODS generated verifier checks that the operation has a valid `targetRef` attribute, so there is no need to check it ourselves in the verifier.  This is currently an untestable code-path.
2) When the target is invalid, it prints as `<invalid target>`.  It makes more sense to print the original InnerRefAttr for this case. This change adds a test case for this.