### PR TITLE
[FIRRTL] RWProbeOp: Add requirement+verify def before use.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -5163,6 +5163,12 @@ LogicalResult RWProbeOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
     return emitOpError("has target that cannot be probed")
         .attachNote(symOp.getLoc())
         .append("target resolves here");
+  auto *ancestor =
+      symOp.getTargetResult().getParentBlock()->findAncestorOpInBlock(**this);
+  if (!ancestor || !symOp->isBeforeInBlock(ancestor))
+    return emitOpError("is not dominated by target")
+        .attachNote(symOp.getLoc())
+        .append("target here");
   return checkFinalType(symOp.getTargetResult().getType(), symOp.getLoc());
 }
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1975,7 +1975,6 @@ firrtl.circuit "RWProbeInstance" {
 // -----
 
 firrtl.circuit "RWProbeUseDef" {
-  firrtl.extmodule @Ext()
   firrtl.module @RWProbeUseDef(in %cond : !firrtl.uint<1>) {
     firrtl.when %cond : !firrtl.uint<1> {
       // expected-note @below {{target here}}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1974,6 +1974,21 @@ firrtl.circuit "RWProbeInstance" {
 
 // -----
 
+firrtl.circuit "RWProbeUseDef" {
+  firrtl.extmodule @Ext()
+  firrtl.module @RWProbeUseDef(in %cond : !firrtl.uint<1>) {
+    firrtl.when %cond : !firrtl.uint<1> {
+      // expected-note @below {{target here}}
+      %w = firrtl.wire sym @x : !firrtl.uint<1>
+    } else {
+      // expected-error @below {{not dominated by target}}
+      %rw = firrtl.ref.rwprobe <@RWProbeUseDef::@x> : !firrtl.uint<1>
+    }
+  }
+}
+
+// -----
+
 firrtl.circuit "MissingClassForObjectPortInModule" {
   // expected-error @below {{'firrtl.module' op target class 'Missing' not found}}
   firrtl.module @MissingClassForObjectPortInModule(out %o: !firrtl.class<@Missing()>) {}


### PR DESCRIPTION
This mostly matters because our passes like to assume this sort of thing, so explicitly verify it.