### PR TITLE
[CI] Switch back to ccache action for nightlies

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -62,23 +62,10 @@ jobs:
           fetch-depth: 1
           submodules: true
 
-      # Setup Ccache
-      - name: Ccache setup
-        run: |
-          mkdir -p $GITHUB_WORKSPACE/${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}/.ccache
-          ccache --set-config=cache_dir=$GITHUB_WORKSPACE/${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}/.ccache
-          ccache --set-config=max_size=300M
-          ccache --set-config=compression=true
-          ccache -p
-          ccache -z
-
-      - name: Cache Ccache directory
-        uses: actions/cache@v3
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
-          path: ${{ github.workspace }}/${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}/.ccache
-          key: ${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}-${{ github.sha }}
-          restore-keys: |
-            ${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}-
+          key: ${{ github.job }}-${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}
 
       # --------
       # Build and test CIRCT

--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -65,6 +65,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
+          max-size: 300M
           key: ${{ github.job }}-${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}
 
       # --------


### PR DESCRIPTION
With our custom ccache stuff, cache hits don't update the ccache. This
is problematic since a the ccache might have a high miss rate. Switching
back to the ccache action as I'm assuming it's smarter than that.