### PR TITLE
[PipelineToHW] Fix `PipelineToHW` TSAN issue

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -200,7 +200,14 @@ def LoopScheduleToCalyx : Pass<"lower-loopschedule-to-calyx", "mlir::ModuleOp"> 
 // PipelineTHW
 //===----------------------------------------------------------------------===//
 
-def PipelineToHW : Pass<"lower-pipeline-to-hw", "hw::HWModuleOp"> {
+// TODO: @mortbopet: There is a possible non-neglible speedup that can be achieved
+// here by allowing this pass to run on a per-hwmodule/whatever container the
+// pipeline is nested within-granularity. However, this conversion adds (and removes)
+// new modules to the top-level mlir::ModuleOp scope, which technically violates
+// hw::HWModuleLike's IsolatedFromAbove (and thus has previously caused
+// concurrency issues via. concurrent additions and removals to the mlir::ModuleOp
+// symboltable).
+def PipelineToHW : Pass<"lower-pipeline-to-hw", "mlir::ModuleOp"> {
   let summary = "Lower Pipeline to HW";
   let description = [{
     This pass lowers `pipeline.rtp` operations to HW.


### PR DESCRIPTION
Fixing a TSAN issue due to concurrent additions (and removals) to the top-level mlir::ModuleOp symbol table, whilst the pass is running at a hw::HWModuleOp granularity.

fixes #5815