### PR TITLE
[FIRRTL][LowerToHW] Fix race by processing ports before parallel, fix failure path.

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1107,8 +1107,7 @@ FIRRTLModuleLowering::lowerMemModule(FMemModuleOp oldModule,
   return newModule;
 }
 
-/// Run on each firrtl.module, transforming it from an firrtl.module into an
-/// hw.module, then deleting the old one.
+/// Run on each firrtl.module, creating a basic hw.module for the firrtl module.
 hw::HWModuleOp
 FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
                                   CircuitLoweringState &loweringState) {


### PR DESCRIPTION
Fixes #5816 .

Lowering of operations in body is still done in parallel.

Type aliases are used by the port lowering code (`tryEliminatingConnectsToValue`), but should already be populated for all ports+operations before call to `lowerPortsAndMoveBody`.