### PR TITLE
[FIRRTL][HW] Replace ModuleNamespace with InnerSymbol one. 

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -16,7 +16,7 @@
 #include "circt/Dialect/FIRRTL/CHIRRTLDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
-#include "circt/Dialect/FIRRTL/Namespace.h"
+#include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 namespace circt {
@@ -329,10 +329,10 @@ struct ApplyState {
   DenseMap<StringAttr, LegacyWiringProblem> legacyWiringProblems;
   SmallVector<WiringProblem> wiringProblems;
 
-  ModuleNamespace &getNamespace(FModuleLike module) {
+  hw::InnerSymbolNamespace &getNamespace(FModuleLike module) {
     auto &ptr = namespaces[module];
     if (!ptr)
-      ptr = std::make_unique<ModuleNamespace>(module);
+      ptr = std::make_unique<hw::InnerSymbolNamespace>(module);
     return *ptr;
   }
 
@@ -342,7 +342,7 @@ struct ApplyState {
   };
 
 private:
-  DenseMap<Operation *, std::unique_ptr<ModuleNamespace>> namespaces;
+  DenseMap<Operation *, std::unique_ptr<hw::InnerSymbolNamespace>> namespaces;
   unsigned annotationID = 0;
 };
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -19,6 +19,9 @@
 #include "llvm/Support/PointerLikeTypeTraits.h"
 
 namespace circt {
+namespace hw {
+struct InnerSymbolNamespace;
+} // namespace hw
 namespace firrtl {
 
 class AnnotationSetIterator;
@@ -26,7 +29,6 @@ class FModuleOp;
 class FModuleLike;
 class MemOp;
 class InstanceOp;
-struct ModuleNamespace;
 class FIRRTLType;
 
 /// Return the name of the attribute used for annotations on FIRRTL ops.
@@ -426,10 +428,10 @@ struct AnnoTarget {
 
   /// Get the inner_sym attribute of an op.  If there is no attached inner_sym,
   /// then one will be created and attached to the op.
-  StringAttr getInnerSym(ModuleNamespace &moduleNamespace) const;
+  StringAttr getInnerSym(hw::InnerSymbolNamespace &moduleNamespace) const;
 
   /// Get a reference to this target suitable for use in an NLA.
-  Attribute getNLAReference(ModuleNamespace &moduleNamespace) const;
+  Attribute getNLAReference(hw::InnerSymbolNamespace &moduleNamespace) const;
 
   /// Get the type of the target.
   FIRRTLType getType() const;
@@ -448,8 +450,8 @@ struct OpAnnoTarget : public AnnoTarget {
 
   AnnotationSet getAnnotations() const;
   void setAnnotations(AnnotationSet annotations) const;
-  StringAttr getInnerSym(ModuleNamespace &moduleNamespace) const;
-  Attribute getNLAReference(ModuleNamespace &moduleNamespace) const;
+  StringAttr getInnerSym(hw::InnerSymbolNamespace &moduleNamespace) const;
+  Attribute getNLAReference(hw::InnerSymbolNamespace &moduleNamespace) const;
   FIRRTLType getType() const;
 
   static bool classof(const AnnoTarget &annoTarget) {
@@ -470,8 +472,8 @@ struct PortAnnoTarget : public AnnoTarget {
 
   AnnotationSet getAnnotations() const;
   void setAnnotations(AnnotationSet annotations) const;
-  StringAttr getInnerSym(ModuleNamespace &moduleNamespace) const;
-  Attribute getNLAReference(ModuleNamespace &moduleNamespace) const;
+  StringAttr getInnerSym(hw::InnerSymbolNamespace &moduleNamespace) const;
+  Attribute getNLAReference(hw::InnerSymbolNamespace &moduleNamespace) const;
   FIRRTLType getType() const;
 
   static bool classof(const AnnoTarget &annoTarget) {

--- a/include/circt/Dialect/FIRRTL/Namespace.h
+++ b/include/circt/Dialect/FIRRTL/Namespace.h
@@ -36,25 +36,6 @@ struct CircuitNamespace : public Namespace {
   }
 };
 
-/// The namespace of a `FModuleLike` operation, generally inhabited by its ports
-/// and declarations.
-struct ModuleNamespace : public Namespace {
-  ModuleNamespace() {}
-  ModuleNamespace(FModuleLike module) : module(module) { add(module); }
-
-  /// Populate the namespace from a module-like operation. This namespace will
-  /// be composed of the `inner_sym`s of the module's ports and declarations.
-  void add(FModuleLike module) {
-    hw::InnerSymbolTable::walkSymbols(
-        module, [&](StringAttr name, const hw::InnerSymTarget &target) {
-          nextIndex.insert({name.getValue(), 0});
-        });
-  }
-
-  /// The module associated with this namespace.
-  FModuleLike module;
-};
-
 } // namespace firrtl
 } // namespace circt
 

--- a/include/circt/Dialect/HW/InnerSymbolNamespace.h
+++ b/include/circt/Dialect/HW/InnerSymbolNamespace.h
@@ -1,4 +1,4 @@
-//===- Namespace.h - A symbol table for HW ops ------------------*- C++ -*-===//
+//===- InnerSymbolNamespace.h - Inner Symbol Table Namespace ----*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,28 +6,27 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file implements HW namespace which are symbol tables for HW operations
-// that automatically resolve name collisions.
+// This file declares the InnerSymbolNamespace, which tracks the names
+// used by inner symbols within an InnerSymbolTable.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CIRCT_DIALECT_HW_NAMESPACE_H
-#define CIRCT_DIALECT_HW_NAMESPACE_H
+#ifndef CIRCT_DIALECT_HW_INNERSYMBOLNAMESPACE_H
+#define CIRCT_DIALECT_HW_INNERSYMBOLNAMESPACE_H
 
-#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/InnerSymbolTable.h"
 #include "circt/Support/Namespace.h"
 
 namespace circt {
 namespace hw {
 
-struct ModuleNamespace : Namespace {
-  ModuleNamespace() = default;
-  ModuleNamespace(hw::HWModuleOp module) { add(module); }
+struct InnerSymbolNamespace : Namespace {
+  InnerSymbolNamespace() = default;
+  InnerSymbolNamespace(Operation *module) { add(module); }
 
   /// Populate the namespace from a module-like operation. This namespace will
   /// be composed of the `inner_sym`s of the module's ports and declarations.
-  void add(hw::HWModuleOp module) {
+  void add(Operation *module) {
     hw::InnerSymbolTable::walkSymbols(
         module, [&](StringAttr name, const InnerSymTarget &target) {
           nextIndex.insert({name.getValue(), 0});
@@ -38,4 +37,4 @@ struct ModuleNamespace : Namespace {
 } // namespace hw
 } // namespace circt
 
-#endif // CIRCT_DIALECT_HW_NAMESPACE_H
+#endif // CIRCT_DIALECT_HW_INNERSYMBOLNAMESPACE_H

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -25,7 +25,7 @@
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWTypes.h"
-#include "circt/Dialect/HW/Namespace.h"
+#include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Dialect/LTL/LTLOps.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
@@ -1421,8 +1421,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
 
   FIRRTLLowering(hw::HWModuleOp module, CircuitLoweringState &circuitState)
       : theModule(module), circuitState(circuitState),
-        builder(module.getLoc(), module.getContext()),
-        moduleNamespace(hw::ModuleNamespace(module)),
+        builder(module.getLoc(), module.getContext()), moduleNamespace(module),
         backedgeBuilder(builder, module.getLoc()) {}
 
   LogicalResult run();
@@ -1727,7 +1726,7 @@ private:
 
   /// A namespace that can be used to generte new symbol names that are unique
   /// within this module.
-  hw::ModuleNamespace moduleNamespace;
+  hw::InnerSymbolNamespace moduleNamespace;
 
   /// A backedge builder to directly materialize values during the lowering
   /// without requiring temporary wires.

--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -13,6 +13,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Reduce/ReductionUtils.h"
+#include "circt/Support/Namespace.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/SmallSet.h"

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -707,9 +708,8 @@ void circt::firrtl::walkGroundTypes(
 }
 
 /// Returns an operation's `inner_sym`, adding one if necessary.
-StringAttr circt::firrtl::getOrAddInnerSym(
-    const hw::InnerSymTarget &target,
-    llvm::function_ref<ModuleNamespace &(FModuleOp)> getNamespace) {
+StringAttr circt::firrtl::getOrAddInnerSym(const hw::InnerSymTarget &target,
+                                           GetNamespaceCallback getNamespace) {
 
   // Return InnerSymAttr with sym on specified fieldID.
   auto getOrAdd = [&](auto mod, hw::InnerSymAttr attr,
@@ -764,9 +764,9 @@ StringAttr circt::firrtl::getOrAddInnerSym(
 
 /// Obtain an inner reference to an operation, possibly adding an `inner_sym`
 /// to that operation.
-hw::InnerRefAttr circt::firrtl::getInnerRefTo(
-    const hw::InnerSymTarget &target,
-    llvm::function_ref<ModuleNamespace &(FModuleOp)> getNamespace) {
+hw::InnerRefAttr
+circt::firrtl::getInnerRefTo(const hw::InnerSymTarget &target,
+                             GetNamespaceCallback getNamespace) {
   auto mod = target.isPort() ? dyn_cast<FModuleOp>(target.getOp())
                              : target.getOp()->getParentOfType<FModuleOp>();
   assert(mod &&

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -15,8 +15,8 @@
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
-#include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Support/Namespace.h"
 #include "llvm/ADT/PostOrderIterator.h"
@@ -40,16 +40,17 @@ struct AddSeqMemPortsPass : public AddSeqMemPortsBase<AddSeqMemPortsPass> {
   LogicalResult processModule(FModuleOp module, bool isDUT);
 
   /// Get the cached namespace for a module.
-  ModuleNamespace &getModuleNamespace(FModuleLike module) {
+  hw::InnerSymbolNamespace &getModuleNamespace(FModuleLike module) {
     return moduleNamespaces.try_emplace(module, module).first->second;
   }
 
   /// Obtain an inner reference to an operation, possibly adding an `inner_sym`
   /// to that operation.
   hw::InnerRefAttr getInnerRefTo(Operation *op) {
-    return ::getInnerRefTo(op, [&](FModuleOp mod) -> ModuleNamespace & {
-      return getModuleNamespace(mod);
-    });
+    return ::getInnerRefTo(op,
+                           [&](FModuleLike mod) -> hw::InnerSymbolNamespace & {
+                             return getModuleNamespace(mod);
+                           });
   }
 
   /// This represents the collected information of the memories in a module.
@@ -77,7 +78,7 @@ struct AddSeqMemPortsPass : public AddSeqMemPortsBase<AddSeqMemPortsPass> {
   ArrayAttr extraPortsAttr;
 
   /// Cached module namespaces.
-  DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
+  DenseMap<Operation *, hw::InnerSymbolNamespace> moduleNamespaces;
 
   bool anythingChanged;
 };

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -17,9 +17,9 @@
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
-#include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Dialect/OM/OMAttributes.h"
 #include "circt/Dialect/OM/OMDialect.h"
 #include "circt/Dialect/OM/OMOps.h"
@@ -173,13 +173,13 @@ class CreateSiFiveMetadataPass
   void runOnOperation() override;
 
   /// Get the cached namespace for a module.
-  ModuleNamespace &getModuleNamespace(FModuleLike module) {
+  hw::InnerSymbolNamespace &getModuleNamespace(FModuleLike module) {
     return moduleNamespaces.try_emplace(module, module).first->second;
   }
   // The set of all modules underneath the design under test module.
   DenseSet<Operation *> dutModuleSet;
   /// Cached module namespaces.
-  DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
+  DenseMap<Operation *, hw::InnerSymbolNamespace> moduleNamespaces;
   // The design under test module.
   FModuleOp dutMod;
   CircuitOp circuitOp;
@@ -216,8 +216,8 @@ CreateSiFiveMetadataPass::emitMemoryMetadata(ObjectModelIR &omir) {
     if (auto module = dyn_cast<FModuleLike>(op))
       symbol = FlatSymbolRefAttr::get(module);
     else
-      symbol =
-          firrtl::getInnerRefTo(op, [&](FModuleOp mod) -> ModuleNamespace & {
+      symbol = firrtl::getInnerRefTo(
+          op, [&](auto mod) -> hw::InnerSymbolNamespace & {
             return getModuleNamespace(mod);
           });
 

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -18,9 +18,9 @@
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/NLATable.h"
-#include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -783,10 +783,9 @@ struct Deduper {
 
 private:
   /// Get a cached namespace for a module.
-  ModuleNamespace &getNamespace(Operation *module) {
-    auto [it, inserted] =
-        moduleNamespaces.try_emplace(module, cast<FModuleLike>(module));
-    return it->second;
+  hw::InnerSymbolNamespace &getNamespace(Operation *module) {
+    return moduleNamespaces.try_emplace(module, cast<FModuleLike>(module))
+        .first->second;
   }
 
   /// For a specific annotation target, record all the unique NLAs which
@@ -1230,7 +1229,7 @@ private:
   StringAttr classString;
 
   /// A module namespace cache.
-  DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
+  DenseMap<Operation *, hw::InnerSymbolNamespace> moduleNamespaces;
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -20,6 +20,7 @@
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -120,12 +121,8 @@ private:
                   SmallVectorImpl<char> &result);
 
   /// Get the cached namespace for a module.
-  ModuleNamespace &getModuleNamespace(FModuleLike module) {
-    auto it = moduleNamespaces.find(module);
-    if (it != moduleNamespaces.end())
-      return it->second;
-    return moduleNamespaces.insert({module, ModuleNamespace(module)})
-        .first->second;
+  hw::InnerSymbolNamespace &getModuleNamespace(FModuleLike module) {
+    return moduleNamespaces.try_emplace(module, module).first->second;
   }
 
   /// Whether any errors have occurred in the current `runOnOperation`.
@@ -143,7 +140,7 @@ private:
   /// Temporary `firrtl.hierpath` operations to be deleted at the end of the
   /// pass. Vector elements are unique.
   SmallVector<hw::HierPathOp> removeTempNLAs;
-  DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
+  DenseMap<Operation *, hw::InnerSymbolNamespace> moduleNamespaces;
   /// Lookup table of instances by name and parent module.
   DenseMap<hw::InnerRefAttr, InstanceOp> instancesByName;
   /// Record to remove any temporary symbols added to instances.
@@ -1239,15 +1236,16 @@ void EmitOMIRPass::emitTrackedTarget(DictionaryAttr node,
 }
 
 hw::InnerRefAttr EmitOMIRPass::getInnerRefTo(Operation *op) {
-  return ::getInnerRefTo(op, [&](FModuleOp module) -> ModuleNamespace & {
-    return getModuleNamespace(module);
-  });
+  return ::getInnerRefTo(op,
+                         [&](FModuleLike module) -> hw::InnerSymbolNamespace & {
+                           return getModuleNamespace(module);
+                         });
 }
 
 hw::InnerRefAttr EmitOMIRPass::getInnerRefTo(FModuleLike module,
                                              size_t portIdx) {
   return ::getInnerRefTo(module, portIdx,
-                         [&](FModuleLike mod) -> ModuleNamespace & {
+                         [&](FModuleLike mod) -> hw::InnerSymbolNamespace & {
                            return getModuleNamespace(mod);
                          });
 }

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -15,7 +15,6 @@
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
-#include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -34,7 +33,6 @@ struct FlattenMemoryPass : public FlattenMemoryBase<FlattenMemoryPass> {
   void runOnOperation() override {
     LLVM_DEBUG(llvm::dbgs() << "\n Running lower memory on module:"
                             << getOperation().getName());
-    ModuleNamespace modNamespace(getOperation());
     SmallVector<Operation *> opsToErase;
     auto hasSubAnno = [&](MemOp op) -> bool {
       for (size_t portIdx = 0, e = op.getNumResults(); portIdx < e; ++portIdx)

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -21,6 +21,7 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/DepthFirstIterator.h"
@@ -677,7 +678,7 @@ private:
 
   /// The module namespaces. These are lazily constructed by
   /// `getModuleNamespace`.
-  DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
+  DenseMap<Operation *, hw::InnerSymbolNamespace> moduleNamespaces;
 
   /// Return a reference to the circuit namespace.  This will lazily construct a
   /// namespace if one does not exist.
@@ -688,12 +689,8 @@ private:
   }
 
   /// Get the cached namespace for a module.
-  ModuleNamespace &getModuleNamespace(FModuleLike module) {
-    auto it = moduleNamespaces.find(module);
-    if (it != moduleNamespaces.end())
-      return it->second;
-    return moduleNamespaces.insert({module, ModuleNamespace(module)})
-        .first->second;
+  hw::InnerSymbolNamespace &getModuleNamespace(FModuleLike module) {
+    return moduleNamespaces.try_emplace(module, module).first->second;
   }
 
   /// A symbol table associated with the circuit.  This is lazily constructed by

--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -20,6 +20,7 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "firrtl-inject-dut-hier"
@@ -189,7 +190,7 @@ void InjectDUTHierarchy::runOnOperation() {
 
   // Instantiate the wrapper inside the DUT and wire it up.
   b.setInsertionPointToStart(dut.getBodyBlock());
-  ModuleNamespace dutNS(dut);
+  hw::InnerSymbolNamespace dutNS(dut);
   auto wrapperInst = b.create<InstanceOp>(
       b.getUnknownLoc(), wrapper, wrapper.getModuleName(),
       NameKindEnum::DroppableName, ArrayRef<Attribute>{}, ArrayRef<Attribute>{},

--- a/lib/Dialect/FIRRTL/Transforms/LowerGroups.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerGroups.cpp
@@ -11,6 +11,7 @@
 
 #include "PassDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "llvm/Support/Debug.h"

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Dialect/Seq/SeqAttributes.h"
 #include "mlir/IR/Dominance.h"
 #include "llvm/ADT/DepthFirstIterator.h"
@@ -94,7 +95,7 @@ namespace {
 struct LowerMemoryPass : public LowerMemoryBase<LowerMemoryPass> {
 
   /// Get the cached namespace for a module.
-  ModuleNamespace &getModuleNamespace(FModuleLike module) {
+  hw::InnerSymbolNamespace &getModuleNamespace(FModuleLike module) {
     return moduleNamespaces.try_emplace(module, module).first->second;
   }
 
@@ -113,7 +114,7 @@ struct LowerMemoryPass : public LowerMemoryBase<LowerMemoryPass> {
   void runOnOperation() override;
 
   /// Cached module namespaces.
-  DenseMap<Operation *, ModuleNamespace> moduleNamespaces;
+  DenseMap<Operation *, hw::InnerSymbolNamespace> moduleNamespaces;
   CircuitNamespace circuitNamespace;
   SymbolTable *symbolTable;
 
@@ -287,7 +288,7 @@ void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
       SmallVector<Attribute> newNamepath(namepath.begin(), namepath.end());
       if (!nla.isComponent())
         newNamepath.back() =
-            getInnerRefTo(inst, [&](FModuleOp mod) -> ModuleNamespace & {
+            getInnerRefTo(inst, [&](auto mod) -> hw::InnerSymbolNamespace & {
               return getModuleNamespace(mod);
             });
       newNamepath.push_back(leafAttr);

--- a/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
@@ -140,8 +140,6 @@ private:
         path.isOpOfType<FModuleOp, FExtModuleOp, InstanceOp>())
       return;
 
-    std::optional<ModuleNamespace> moduleNamespace;
-
     newTarget.append(">");
     auto innerSymStr =
         TypeSwitch<AnnoTarget, StringAttr>(path.ref)
@@ -294,12 +292,12 @@ void ResolveTracesPass::runOnOperation() {
     SmallVector<std::pair<Annotation, AnnoPathValue>> outputAnnotations;
 
     // A lazily constructed module namespace.
-    std::optional<ModuleNamespace> moduleNamespace;
+    std::optional<hw::InnerSymbolNamespace> moduleNamespace;
 
     // Return a cached module namespace, lazily constructing it if needed.
-    auto getNamespace = [&](FModuleLike module) -> ModuleNamespace & {
+    auto getNamespace = [&](auto module) -> hw::InnerSymbolNamespace & {
       if (!moduleNamespace)
-        moduleNamespace = ModuleNamespace(module);
+        moduleNamespace = hw::InnerSymbolNamespace(module);
       return *moduleNamespace;
     };
 

--- a/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/SV/Transforms/HWMemSimImpl.cpp
@@ -16,7 +16,7 @@
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWSymCache.h"
-#include "circt/Dialect/HW/Namespace.h"
+#include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Dialect/Seq/SeqAttributes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -61,9 +61,9 @@ class HWMemSimImpl {
   SmallVector<sv::RegOp> registers;
 
   Value addPipelineStages(ImplicitLocOpBuilder &b,
-                          ModuleNamespace &moduleNamespace, size_t stages,
-                          Value clock, Value data, const Twine &name,
-                          Value gate = {});
+                          hw::InnerSymbolNamespace &moduleNamespace,
+                          size_t stages, Value clock, Value data,
+                          const Twine &name, Value gate = {});
   sv::AlwaysOp lastPipelineAlwaysOp;
 
 public:
@@ -173,7 +173,7 @@ static Value getMemoryRead(ImplicitLocOpBuilder &b, Value memory, Value addr,
 }
 
 Value HWMemSimImpl::addPipelineStages(ImplicitLocOpBuilder &b,
-                                      ModuleNamespace &moduleNamespace,
+                                      hw::InnerSymbolNamespace &moduleNamespace,
                                       size_t stages, Value clock, Value data,
                                       const Twine &name, Value gate) {
   if (!stages)
@@ -227,7 +227,7 @@ Value HWMemSimImpl::addPipelineStages(ImplicitLocOpBuilder &b,
 void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
   ImplicitLocOpBuilder b(op.getLoc(), op.getBody());
 
-  ModuleNamespace moduleNamespace(op);
+  InnerSymbolNamespace moduleNamespace(op);
 
   // Compute total number of mask bits.
   if (mem.maskGran == 0)

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -18,7 +18,7 @@
 #include "circt/Dialect/HW/HWInstanceGraph.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWSymCache.h"
-#include "circt/Dialect/HW/Namespace.h"
+#include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Dialect/Seq/SeqDialect.h"
 #include "circt/Dialect/Seq/SeqOps.h"
@@ -417,7 +417,7 @@ inlineInputOnly(hw::HWModuleOp oldMod, hw::InstanceGraph &instanceGraph,
     SmallVector<Operation *, 16> lateBoundOps;
     b.setInsertionPoint(inst);
     // Namespace that tracks inner symbols in the parent module.
-    hw::ModuleNamespace nameSpace(instParent);
+    hw::InnerSymbolNamespace nameSpace(instParent);
     // A map from old inner symbols to new ones.
     DenseMap<mlir::StringAttr, mlir::StringAttr> symMapping;
 

--- a/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqToSV.cpp
@@ -14,7 +14,6 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOps.h"
-#include "circt/Dialect/HW/Namespace.h"
 #include "circt/Dialect/SV/SVAttributes.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"


### PR DESCRIPTION
Combine identical "ModuleNamespaces" into a new common one
for anything with inner symbols.

First step towards dropping use of a "Namespace" for generating
inner symbols entirely, once other pieces are in place.

Also sets the stage for moving the utility functions that help
create inner symbols and inner refs out of FIRRTL.

NFCI.