### PR TITLE
[OM] Change evaluator value representation and evaluate ListCreateOp.

### DIFF
--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -53,27 +53,14 @@ typedef struct OMEvaluator OMEvaluator;
 
 /// A value type for use in C APIs that just wraps a pointer to an Object.
 /// This is in line with the usual MLIR DEFINE_C_API_STRUCT.
-struct OMObject {
+struct OMEvaluatorValue {
   void *ptr;
 };
 
 // clang-tidy doesn't respect extern "C".
 // see https://github.com/llvm/llvm-project/issues/35272.
 // NOLINTNEXTLINE(modernize-use-using)
-typedef struct OMObject OMObject;
-
-/// A value type for use in C APIs that represents an ObjectValue.
-/// Because ObjectValue is a std::variant, which doesn't work well with C APIs,
-/// we use a struct with both fields, one of which will always be null.
-struct OMObjectValue {
-  MlirAttribute primitive;
-  OMObject object;
-};
-
-// clang-tidy doesn't respect extern "C".
-// see https://github.com/llvm/llvm-project/issues/35272.
-// NOLINTNEXTLINE(modernize-use-using)
-typedef struct OMObjectValue OMObjectValue;
+typedef struct OMEvaluatorValue OMEvaluatorValue;
 
 //===----------------------------------------------------------------------===//
 // Evaluator API.
@@ -84,9 +71,9 @@ MLIR_CAPI_EXPORTED OMEvaluator omEvaluatorNew(MlirModule mod);
 
 /// Use the Evaluator to Instantiate an Object from its class name and actual
 /// parameters.
-MLIR_CAPI_EXPORTED OMObject omEvaluatorInstantiate(
-    OMEvaluator evaluator, MlirAttribute className, intptr_t nActualParams,
-    MlirAttribute const *actualParams);
+MLIR_CAPI_EXPORTED OMEvaluatorValue
+omEvaluatorInstantiate(OMEvaluator evaluator, MlirAttribute className,
+                       intptr_t nActualParams, OMEvaluatorValue *actualParams);
 
 /// Get the Module the Evaluator is built from.
 MLIR_CAPI_EXPORTED MlirModule omEvaluatorGetModule(OMEvaluator evaluator);
@@ -96,42 +83,54 @@ MLIR_CAPI_EXPORTED MlirModule omEvaluatorGetModule(OMEvaluator evaluator);
 //===----------------------------------------------------------------------===//
 
 /// Query if the Object is null.
-MLIR_CAPI_EXPORTED bool omEvaluatorObjectIsNull(OMObject object);
+MLIR_CAPI_EXPORTED bool omEvaluatorObjectIsNull(OMEvaluatorValue object);
 
 /// Get the Type from an Object, which will be a ClassType.
-MLIR_CAPI_EXPORTED MlirType omEvaluatorObjectGetType(OMObject object);
+MLIR_CAPI_EXPORTED MlirType omEvaluatorObjectGetType(OMEvaluatorValue object);
 
 /// Get a field from an Object, which must contain a field of that name.
-MLIR_CAPI_EXPORTED OMObjectValue omEvaluatorObjectGetField(OMObject object,
-                                                           MlirAttribute name);
+MLIR_CAPI_EXPORTED OMEvaluatorValue
+omEvaluatorObjectGetField(OMEvaluatorValue object, MlirAttribute name);
 
 /// Get all the field names from an Object, can be empty if object has no
 /// fields.
 MLIR_CAPI_EXPORTED MlirAttribute
-omEvaluatorObjectGetFieldNames(OMObject object);
+omEvaluatorObjectGetFieldNames(OMEvaluatorValue object);
 
 //===----------------------------------------------------------------------===//
-// ObjectValue API.
+// EvaluatorValue API.
 //===----------------------------------------------------------------------===//
 
-// Query if the ObjectValue is null.
-MLIR_CAPI_EXPORTED bool omEvaluatorObjectValueIsNull(OMObjectValue objectValue);
+// Query if the EvaluatorValue is null.
+MLIR_CAPI_EXPORTED bool omEvaluatorValueIsNull(OMEvaluatorValue evaluatorValue);
 
-/// Query if the ObjectValue is an Object.
+/// Query if the EvaluatorValue is an Object.
 MLIR_CAPI_EXPORTED bool
-omEvaluatorObjectValueIsAObject(OMObjectValue objectValue);
+omEvaluatorValueIsAObject(OMEvaluatorValue evaluatorValue);
 
-/// Get the Object from an  ObjectValue, which must contain an Object.
-MLIR_CAPI_EXPORTED OMObject
-omEvaluatorObjectValueGetObject(OMObjectValue objectValue);
-
-/// Query if the ObjectValue is a Primitive.
+/// Query if the EvaluatorValue is a Primitive.
 MLIR_CAPI_EXPORTED bool
-omEvaluatorObjectValueIsAPrimitive(OMObjectValue objectValue);
+omEvaluatorValueIsAPrimitive(OMEvaluatorValue evaluatorValue);
 
-/// Get the Primitive from an  ObjectValue, which must contain a Primitive.
+/// Get the Primitive from an EvaluatorValue, which must contain a Primitive.
 MLIR_CAPI_EXPORTED MlirAttribute
-omEvaluatorObjectValueGetPrimitive(OMObjectValue objectValue);
+omEvaluatorValueGetPrimitive(OMEvaluatorValue evaluatorValue);
+
+/// Get the EvaluatorValue from a Primitive value.
+MLIR_CAPI_EXPORTED OMEvaluatorValue
+omEvaluatorValueFromPrimitive(MlirAttribute primitive);
+
+/// Query if the EvaluatorValue is an Object.
+MLIR_CAPI_EXPORTED bool
+omEvaluatorValueIsAList(OMEvaluatorValue evaluatorValue);
+
+/// Get the length of the list.
+MLIR_CAPI_EXPORTED intptr_t
+omListGetNumElements(OMEvaluatorValue evaluatorValue);
+
+/// Get an element of the list.
+MLIR_CAPI_EXPORTED OMEvaluatorValue
+omListGetElement(OMEvaluatorValue evaluatorValue, intptr_t pos);
 
 //===----------------------------------------------------------------------===//
 // ReferenceAttr API

--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -126,11 +126,11 @@ omEvaluatorValueIsAList(OMEvaluatorValue evaluatorValue);
 
 /// Get the length of the list.
 MLIR_CAPI_EXPORTED intptr_t
-omListGetNumElements(OMEvaluatorValue evaluatorValue);
+omEvaluatorListGetNumElements(OMEvaluatorValue evaluatorValue);
 
 /// Get an element of the list.
 MLIR_CAPI_EXPORTED OMEvaluatorValue
-omListGetElement(OMEvaluatorValue evaluatorValue, intptr_t pos);
+omEvaluatorListGetElement(OMEvaluatorValue evaluatorValue, intptr_t pos);
 
 //===----------------------------------------------------------------------===//
 // ReferenceAttr API

--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -23,13 +23,94 @@
 namespace circt {
 namespace om {
 
+namespace evaluator {
+struct ObjectValue;
+struct EvaluatorValue;
+
 /// A value of an object in memory. It is either a composite Object, or a
 /// primitive Attribute. Further refinement is expected.
-using ObjectValue = std::variant<std::shared_ptr<struct Object>, Attribute>;
+using EvaluatorValuePtr = std::shared_ptr<EvaluatorValue>;
 
 /// The fields of a composite Object, currently represented as a map. Further
 /// refinement is expected.
-using ObjectFields = SmallDenseMap<StringAttr, ObjectValue>;
+using ObjectFields = SmallDenseMap<StringAttr, EvaluatorValuePtr>;
+
+/// Base class for evaluator runtime values.
+/// Enables the shared_from_this functionality so Object pointers can be passed
+/// through the CAPI and unwrapped back into C++ smart pointers with the
+/// appropriate reference count.
+struct EvaluatorValue : std::enable_shared_from_this<EvaluatorValue> {
+  enum class Kind { Attr, Object, List };
+  EvaluatorValue(Kind kind) : kind(kind) {}
+  Kind getKind() const { return kind; }
+
+private:
+  const Kind kind;
+};
+
+struct AttributeValue : EvaluatorValue {
+  AttributeValue(Attribute attr) : EvaluatorValue(Kind::Attr), attr(attr) {}
+  Attribute getAttr() const { return attr; }
+  template <typename AttrTy>
+  AttrTy getAs() const {
+    return dyn_cast<AttrTy>(attr);
+  }
+  static bool classof(const EvaluatorValue *e) {
+    return e->getKind() == Kind::Attr;
+  }
+
+private:
+  Attribute attr;
+};
+
+struct ListValue : EvaluatorValue {
+  ListValue(mlir::Type elementType, SmallVector<EvaluatorValuePtr> elements)
+      : EvaluatorValue(Kind::List), elementType(elementType),
+        elements(std::move(elements)) {}
+  const auto &getElements() const { return elements; }
+  static bool classof(const EvaluatorValue *e) {
+    return e->getKind() == Kind::List;
+  }
+
+  Type getType() { return ListType::get(elementType); }
+
+private:
+  Type elementType;
+  SmallVector<EvaluatorValuePtr> elements;
+};
+
+/// A composite Object, which has a type and fields.
+struct ObjectValue : EvaluatorValue {
+  ObjectValue(om::ClassOp cls, ObjectFields fields)
+      : EvaluatorValue(Kind::Object), cls(cls), fields(std::move(fields)) {}
+  om::ClassOp getClassOp() const { return cls; }
+  const auto &getFields() const { return fields; }
+  static bool classof(const EvaluatorValue *e) {
+    return e->getKind() == Kind::Object;
+  }
+
+  Type getType() {
+    return ClassType::get(cls.getContext(),
+                          FlatSymbolRefAttr::get(cls.getNameAttr()));
+  }
+
+  FailureOr<EvaluatorValuePtr> getField(StringAttr field);
+
+  /// Get all the field names of the Object.
+  ArrayAttr getFieldNames();
+
+private:
+  circt::om::ClassOp cls;
+  llvm::SmallDenseMap<StringAttr, EvaluatorValuePtr> fields;
+};
+
+} // namespace evaluator
+
+using Object = evaluator::ObjectValue;
+using EvaluatorValuePtr = evaluator::EvaluatorValuePtr;
+
+SmallVector<EvaluatorValuePtr>
+getEvaluatorValuesFromAttributes(ArrayRef<Attribute> attributes);
 
 /// An Evaluator, which is constructed with an IR module and can instantiate
 /// Objects. Further refinement is expected.
@@ -39,7 +120,7 @@ struct Evaluator {
 
   /// Instantiate an Object with its class name and actual parameters.
   FailureOr<std::shared_ptr<Object>>
-  instantiate(StringAttr className, ArrayRef<ObjectValue> actualParams);
+  instantiate(StringAttr className, ArrayRef<EvaluatorValuePtr> actualParams);
 
   /// Get the Module this Evaluator is built from.
   mlir::ModuleOp getModule();
@@ -48,18 +129,23 @@ private:
   /// Evaluate a Value in a Class body according to the small expression grammar
   /// described in the rationale document. The actual parameters are the values
   /// supplied at the current instantiation of the Class being evaluated.
-  FailureOr<ObjectValue> evaluateValue(Value value,
-                                       ArrayRef<ObjectValue> actualParams);
+  FailureOr<EvaluatorValuePtr>
+  evaluateValue(Value value, ArrayRef<EvaluatorValuePtr> actualParams);
 
   /// Evaluator dispatch functions for the small expression grammar.
-  FailureOr<ObjectValue> evaluateParameter(BlockArgument formalParam,
-                                           ArrayRef<ObjectValue> actualParams);
-  FailureOr<ObjectValue> evaluateConstant(ConstantOp op,
-                                          ArrayRef<ObjectValue> actualParams);
-  FailureOr<ObjectValue>
-  evaluateObjectInstance(ObjectOp op, ArrayRef<ObjectValue> actualParams);
-  FailureOr<ObjectValue>
-  evaluateObjectField(ObjectFieldOp op, ArrayRef<ObjectValue> actualParams);
+  FailureOr<EvaluatorValuePtr>
+  evaluateParameter(BlockArgument formalParam,
+                    ArrayRef<EvaluatorValuePtr> actualParams);
+
+  FailureOr<EvaluatorValuePtr>
+  evaluateConstant(ConstantOp op, ArrayRef<EvaluatorValuePtr> actualParams);
+  FailureOr<EvaluatorValuePtr>
+  evaluateObjectInstance(ObjectOp op, ArrayRef<EvaluatorValuePtr> actualParams);
+  FailureOr<EvaluatorValuePtr>
+  evaluateObjectField(ObjectFieldOp op,
+                      ArrayRef<EvaluatorValuePtr> actualParams);
+  FailureOr<EvaluatorValuePtr>
+  evaluateListCreate(ListCreateOp op, ArrayRef<EvaluatorValuePtr> actualParams);
 
   /// The symbol table for the IR module the Evaluator was constructed with.
   /// Used to look up class definitions.
@@ -67,46 +153,21 @@ private:
 
   /// Object storage. Currently used for memoizing calls to evaluateValue.
   /// Further refinement is expected.
-  mlir::DenseMap<Value, std::shared_ptr<Object>> objects;
-};
-
-/// A composite Object, which has a type and fields.
-/// Enables the shared_from_this functionality so Object pointers can be passed
-/// through the CAPI and unwrapped back into C++ smart pointers with the
-/// appropriate reference count.
-struct Object : std::enable_shared_from_this<Object> {
-  /// Get the type of the Object.
-  mlir::Type getType();
-
-  /// Get a field of the Object by name.
-  FailureOr<ObjectValue> getField(StringAttr name);
-
-  /// Get all the field names of the Object.
-  ArrayAttr getFieldNames();
-
-private:
-  /// Allow the instantiate method as a friend to construct Objects.
-  friend FailureOr<std::shared_ptr<Object>>
-      Evaluator::instantiate(StringAttr, ArrayRef<ObjectValue>);
-
-  /// Construct an Object of the given Class with the given fields.
-  Object(ClassOp cls, ObjectFields &fields);
-
-  /// The Class of the Object.
-  ClassOp cls;
-
-  /// The fields of the Object.
-  ObjectFields fields;
+  mlir::DenseMap<Value, std::shared_ptr<evaluator::ObjectValue>> objects;
 };
 
 /// Helper to enable printing objects in Diagnostics.
-static inline mlir::Diagnostic &operator<<(mlir::Diagnostic &diag,
-                                           const ObjectValue &objectValue) {
-  if (auto *object = std::get_if<std::shared_ptr<Object>>(&objectValue))
-    diag << *object;
-  if (auto *attribute = std::get_if<Attribute>(&objectValue))
-    diag << *attribute;
+static inline mlir::Diagnostic &
+operator<<(mlir::Diagnostic &diag,
+           const evaluator::EvaluatorValue &objectValue) {
+  // TODO:
   return diag;
+}
+
+/// Helper to enable printing objects in Diagnostics.
+static inline mlir::Diagnostic &
+operator<<(mlir::Diagnostic &diag, const EvaluatorValuePtr &objectValue) {
+  return diag << *objectValue.get();
 }
 
 } // namespace om

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -18,18 +18,28 @@ with Context() as ctx, Location.unknown():
     om.class @Test(%param: i64) {
       om.class.field @field, %param : i64
 
-      %0 = om.object @Child() : () -> !om.class.type<@Child>
+      %c_14 = om.constant 14 : i64
+      %0 = om.object @Child(%c_14) : (i64) -> !om.class.type<@Child>
       om.class.field @child, %0 : !om.class.type<@Child>
 
       om.class.field @reference, %sym : !om.ref
 
       %list = om.constant #om.list<!om.string, ["X" : !om.string, "Y" : !om.string]> : !om.list<!om.string>
       om.class.field @list, %list : !om.list<!om.string>
+
+      %c_15 = om.constant 15 : i64
+      %1 = om.object @Child(%c_15) : (i64) -> !om.class.type<@Child>
+      %list_child = om.list_create %0, %1: !om.class.type<@Child>
+      %2 = om.object @Nest(%list_child) : (!om.list<!om.class.type<@Child>>) -> !om.class.type<@Nest>
+      om.class.field @nest, %2 : !om.class.type<@Nest>
     }
 
-    om.class @Child() {
-      %0 = om.constant 14 : i64
+    om.class @Child(%0: i64) {
       om.class.field @foo, %0 : i64
+    }
+
+    om.class @Nest(%0: !om.list<!om.class.type<@Child>>) {
+      om.class.field @list_child, %0 : !om.list<!om.class.type<@Child>>
     }
 
     hw.module @Root(%clock: i1) -> () {
@@ -81,3 +91,7 @@ for (name, field) in obj:
 
 # CHECK: ['X', 'Y']
 print(obj.list)
+for child in obj.nest.list_child:
+  # CHECK: 14
+  # CHECK-NEXT: 15
+  print(child.foo)

--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -36,7 +36,7 @@ struct List {
   List(OMEvaluatorValue value) : value(value) {}
 
   /// Return the number of elements.
-  intptr_t getNumElements() { return omListGetNumElements(value); }
+  intptr_t getNumElements() { return omEvaluatorListGetNumElements(value); }
 
   PythonValue getElement(intptr_t i);
   OMEvaluatorValue getValue() const { return value; }
@@ -150,7 +150,7 @@ private:
 };
 
 PythonValue List::getElement(intptr_t i) {
-  return omEvaluatorValueToPythonValue(omListGetElement(value, i));
+  return omEvaluatorValueToPythonValue(omEvaluatorListGetElement(value, i));
 }
 
 PythonValue omEvaluatorValueToPythonValue(OMEvaluatorValue result) {

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -33,7 +33,6 @@ def wrap_mlir_object(value):
   return Object(value)
 
 
-# Wrap a base mlir object with high-level object.
 def unwrap_python_object(value):
   # Check if the value is a Primitive.
   try:
@@ -54,7 +53,7 @@ class List(BaseList):
   def __init__(self, obj: BaseList) -> None:
     super().__init__(obj)
 
-  # Support iterating over an Object by yielding its fields.
+  # Support iterating over a List by yielding its fields.
   def __getitem__(self, i):
     val = super().__getitem__(i)
     return wrap_mlir_object(val)
@@ -114,7 +113,6 @@ class Evaluator(BaseEvaluator):
       # Get the actual parameter Values from the supplied variadic
       # arguments.
       actual_params = [unwrap_python_object(arg) for arg in args]
-      print(actual_params)
 
     # Call the base instantiate method.
     obj = super().instantiate(class_name, actual_params)

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -53,11 +53,11 @@ class List(BaseList):
   def __init__(self, obj: BaseList) -> None:
     super().__init__(obj)
 
-  # Support iterating over a List by yielding its fields.
   def __getitem__(self, i):
     val = super().__getitem__(i)
     return wrap_mlir_object(val)
 
+  # Support iterating over a List by yielding its elements.
   def __iter__(self):
     for i in range(0, self.__len__()):
       yield self.__getitem__(i)

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from ._om_ops_gen import *
-from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, ClassType, ReferenceAttr, ListAttr
+from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, ClassType, ReferenceAttr, ListAttr
 
 from ..ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr
 from ..support import attribute_to_var, var_to_attribute
@@ -19,6 +19,51 @@ if TYPE_CHECKING:
   from _typeshed.stdlib.dataclass import DataclassInstance
 
 
+# Wrap a base mlir object with high-level object.
+def wrap_mlir_object(value):
+  # For primitives, return a Python value.
+  if isinstance(value, Attribute):
+    return attribute_to_var(value)
+
+  if isinstance(value, BaseList):
+    return List(value)
+
+  # For objects, return an Object, wrapping the base implementation.
+  assert isinstance(value, BaseObject)
+  return Object(value)
+
+
+# Wrap a base mlir object with high-level object.
+def unwrap_python_object(value):
+  # Check if the value is a Primitive.
+  try:
+    return var_to_attribute(value)
+  except:
+    pass
+
+  if isinstance(value, List):
+    return BaseList(value)
+
+  # Otherwise, it must be an Object. Cast to the mlir object.
+  assert isinstance(value, Object)
+  return BaseObject(value)
+
+
+class List(BaseList):
+
+  def __init__(self, obj: BaseList) -> None:
+    super().__init__(obj)
+
+  # Support iterating over an Object by yielding its fields.
+  def __getitem__(self, i):
+    val = super().__getitem__(i)
+    return wrap_mlir_object(val)
+
+  def __iter__(self):
+    for i in range(0, self.__len__()):
+      yield self.__getitem__(i)
+
+
 # Define the Object class by inheriting from the base implementation in C++.
 class Object(BaseObject):
 
@@ -28,14 +73,7 @@ class Object(BaseObject):
   def __getattr__(self, name: str):
     # Call the base method to get a field.
     field = super().__getattr__(name)
-
-    # For primitives, return a Python value.
-    if isinstance(field, Attribute):
-      return attribute_to_var(field)
-
-    # For objects, return an Object, wrapping the base implementation.
-    assert isinstance(field, BaseObject)
-    return Object(field)
+    return wrap_mlir_object(field)
 
   # Support iterating over an Object by yielding its fields.
   def __iter__(self):
@@ -73,10 +111,10 @@ class Evaluator(BaseEvaluator):
       # Get the class name from the class name.
       class_name = StringAttr.get(cls)
 
-      # Get the actual parameter Attributes from the supplied variadic
-      # arguments. This relies on the circt.support helpers to convert from
-      # Python objects to Attributes.
-      actual_params = var_to_attribute(list(args))
+      # Get the actual parameter Values from the supplied variadic
+      # arguments.
+      actual_params = [unwrap_python_object(arg) for arg in args]
+      print(actual_params)
 
     # Call the base instantiate method.
     obj = super().instantiate(class_name, actual_params)

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -41,18 +41,18 @@ DEFINE_C_API_PTR_METHODS(OMEvaluator, circt::om::Evaluator)
 
 /// Define our own wrap and unwrap instead of using the usual macro. This is To
 /// handle the std::shared_ptr reference counts appropriately. We want to always
-/// create *new* shared pointers to the Object when we wrap it for C, to
+/// create *new* shared pointers to the EvaluatorValue when we wrap it for C, to
 /// increment the reference count. We want to use the shared_from_this
 /// functionality to ensure it is unwrapped into C++ with the correct reference
 /// count.
 
-static inline OMObject wrap(std::shared_ptr<Object> object) {
-  return OMObject{static_cast<void *>(
-      (new std::shared_ptr<Object>(std::move(object)))->get())};
+static inline OMEvaluatorValue wrap(EvaluatorValuePtr object) {
+  return OMEvaluatorValue{
+      static_cast<void *>((new EvaluatorValuePtr(std::move(object)))->get())};
 }
 
-static inline std::shared_ptr<Object> unwrap(OMObject c) {
-  return static_cast<Object *>(c.ptr)->shared_from_this();
+static inline EvaluatorValuePtr unwrap(OMEvaluatorValue c) {
+  return static_cast<evaluator::EvaluatorValue *>(c.ptr)->shared_from_this();
 }
 
 //===----------------------------------------------------------------------===//
@@ -67,28 +67,29 @@ OMEvaluator omEvaluatorNew(MlirModule mod) {
 
 /// Use the Evaluator to Instantiate an Object from its class name and actual
 /// parameters.
-OMObject omEvaluatorInstantiate(OMEvaluator evaluator, MlirAttribute className,
-                                intptr_t nActualParams,
-                                MlirAttribute const *actualParams) {
+OMEvaluatorValue omEvaluatorInstantiate(OMEvaluator evaluator,
+                                        MlirAttribute className,
+                                        intptr_t nActualParams,
+                                        OMEvaluatorValue *actualParams) {
   // Unwrap the Evaluator.
   Evaluator *cppEvaluator = unwrap(evaluator);
 
   // Unwrap the className, which the client must supply as a StringAttr.
   StringAttr cppClassName = unwrap(className).cast<StringAttr>();
 
-  // Unwrap the actual parameters, which the client must supply as Attributes.
-  SmallVector<Attribute> actualParamsTmp;
-  SmallVector<ObjectValue> cppActualParams(
-      unwrapList(nActualParams, actualParams, actualParamsTmp));
+  // Unwrap the actual parameters.
+  SmallVector<std::shared_ptr<evaluator::EvaluatorValue>> cppActualParams;
+  for (unsigned i = 0; i < nActualParams; i++)
+    cppActualParams.push_back(unwrap(actualParams[i]));
 
   // Invoke the Evaluator to instantiate the Object.
-  FailureOr<std::shared_ptr<Object>> result =
+  FailureOr<std::shared_ptr<evaluator::ObjectValue>> result =
       cppEvaluator->instantiate(cppClassName, cppActualParams);
 
   // If instantiation failed, return a null Object. A Diagnostic will be emitted
   // in this case.
   if (failed(result))
-    return OMObject();
+    return OMEvaluatorValue();
 
   // Wrap and return the Object.
   return wrap(result.value());
@@ -105,81 +106,100 @@ MlirModule omEvaluatorGetModule(OMEvaluator evaluator) {
 //===----------------------------------------------------------------------===//
 
 /// Query if the Object is null.
-bool omEvaluatorObjectIsNull(OMObject object) {
+bool omEvaluatorObjectIsNull(OMEvaluatorValue object) {
   // Just check if the Object shared pointer is null.
   return !object.ptr;
 }
 
 /// Get the Type from an Object, which will be a ClassType.
-MlirType omEvaluatorObjectGetType(OMObject object) {
-  return wrap(unwrap(object)->getType());
+MlirType omEvaluatorObjectGetType(OMEvaluatorValue object) {
+  return wrap(llvm::cast<Object>(unwrap(object).get())->getType());
 }
 
 /// Get an ArrayAttr with the names of the fields in an Object.
-MlirAttribute omEvaluatorObjectGetFieldNames(OMObject object) {
-  return wrap(unwrap(object)->getFieldNames());
+MlirAttribute omEvaluatorObjectGetFieldNames(OMEvaluatorValue object) {
+  return wrap(llvm::cast<Object>(unwrap(object).get())->getFieldNames());
 }
 
 /// Get a field from an Object, which must contain a field of that name.
-OMObjectValue omEvaluatorObjectGetField(OMObject object, MlirAttribute name) {
+OMEvaluatorValue omEvaluatorObjectGetField(OMEvaluatorValue object,
+                                           MlirAttribute name) {
   // Unwrap the Object and get the field of the name, which the client must
   // supply as a StringAttr.
-  FailureOr<ObjectValue> result =
-      unwrap(object)->getField(unwrap(name).cast<StringAttr>());
+  FailureOr<EvaluatorValuePtr> result =
+      llvm::cast<Object>(unwrap(object).get())
+          ->getField(unwrap(name).cast<StringAttr>());
 
-  // If getField failed, return a null ObjectValue. A Diagnostic will be emitted
-  // in this case.
+  // If getField failed, return a null EvaluatorValue. A Diagnostic will be
+  // emitted in this case.
   if (failed(result))
-    return OMObjectValue();
+    return OMEvaluatorValue();
 
-  // If the field is an Object, return an ObjectValue with the Object set.
-  if (auto *object = std::get_if<std::shared_ptr<Object>>(&result.value()))
-    return OMObjectValue{MlirAttribute(), wrap(*object)};
-
-  // If the field is an Attribute, return an ObjectValue with the Primitive set.
-  if (auto *primitive = std::get_if<Attribute>(&result.value()))
-    return OMObjectValue{wrap(*primitive), OMObject()};
-
-  // This case should never be hit, but return a null ObjectValue that is
-  // neither an Object nor a Primitive.
-  return OMObjectValue();
+  return OMEvaluatorValue{wrap(result.value())};
 }
 
 //===----------------------------------------------------------------------===//
-// ObjectValue API.
+// EvaluatorValue API.
 //===----------------------------------------------------------------------===//
 
-// Query if the ObjectValue is null.
-bool omEvaluatorObjectValueIsNull(OMObjectValue objectValue) {
-  // Check if both Object and Attribute are null.
-  return !omEvaluatorObjectValueIsAObject(objectValue) &&
-         !omEvaluatorObjectValueIsAPrimitive(objectValue);
+// Query if the EvaluatorValue is null.
+bool omEvaluatorValueIsNull(OMEvaluatorValue evaluatorValue) {
+  // Check if the pointer is null.
+  return !evaluatorValue.ptr;
 }
 
-/// Query if the ObjectValue is an Object.
-bool omEvaluatorObjectValueIsAObject(OMObjectValue objectValue) {
+/// Query if the EvaluatorValue is an Object.
+bool omEvaluatorValueIsAObject(OMEvaluatorValue evaluatorValue) {
   // Check if the Object is non-null.
-  return !omEvaluatorObjectIsNull(objectValue.object);
+  return isa<evaluator::ObjectValue>(unwrap(evaluatorValue).get());
 }
 
-/// Get the Object from an  ObjectValue, which must contain an Object.
-OMObject omEvaluatorObjectValueGetObject(OMObjectValue objectValue) {
-  // Assert the Object is non-null, and return it.
-  assert(omEvaluatorObjectValueIsAObject(objectValue));
-  return objectValue.object;
-}
-
-/// Query if the ObjectValue is a Primitive.
-bool omEvaluatorObjectValueIsAPrimitive(OMObjectValue objectValue) {
+/// Query if the EvaluatorValue is a Primitive.
+bool omEvaluatorValueIsAPrimitive(OMEvaluatorValue evaluatorValue) {
   // Check if the Attribute is non-null.
-  return !mlirAttributeIsNull(objectValue.primitive);
+  return isa<evaluator::AttributeValue>(unwrap(evaluatorValue).get());
 }
 
-/// Get the Primitive from an  ObjectValue, which must contain a Primitive.
-MlirAttribute omEvaluatorObjectValueGetPrimitive(OMObjectValue objectValue) {
+/// Get the Primitive from an EvaluatorValue, which must contain a Primitive.
+MlirAttribute omEvaluatorValueGetPrimitive(OMEvaluatorValue evaluatorValue) {
   // Assert the Attribute is non-null, and return it.
-  assert(omEvaluatorObjectValueIsAPrimitive(objectValue));
-  return objectValue.primitive;
+  assert(omEvaluatorValueIsAPrimitive(evaluatorValue));
+  return wrap(
+      llvm::cast<evaluator::AttributeValue>(unwrap(evaluatorValue).get())
+          ->getAttr());
+}
+
+/// Get the Primitive from an EvaluatorValue, which must contain a Primitive.
+OMEvaluatorValue omEvaluatorValueFromPrimitive(MlirAttribute primitive) {
+  // Assert the Attribute is non-null, and return it.
+  return wrap(std::make_shared<evaluator::AttributeValue>(unwrap(primitive)));
+}
+
+/// Query if the EvaluatorValue is a List.
+bool omEvaluatorValueIsAList(OMEvaluatorValue evaluatorValue) {
+  return isa<evaluator::ListValue>(unwrap(evaluatorValue).get());
+}
+
+/// Get the List from an EvaluatorValue, which must contain a List.
+/// TODO: This can be removed.
+OMEvaluatorValue omEvaluatorValueGetList(OMEvaluatorValue evaluatorValue) {
+  // Assert the List is non-null, and return it.
+  assert(omEvaluatorValueIsAList(evaluatorValue));
+  return evaluatorValue;
+}
+
+/// Get the length of the List.
+intptr_t omListGetNumElements(OMEvaluatorValue evaluatorValue) {
+  return cast<evaluator::ListValue>(unwrap(evaluatorValue).get())
+      ->getElements()
+      .size();
+}
+
+/// Get an element of the List.
+OMEvaluatorValue omListGetElement(OMEvaluatorValue evaluatorValue,
+                                  intptr_t pos) {
+  return wrap(cast<evaluator::ListValue>(unwrap(evaluatorValue).get())
+                  ->getElements()[pos]);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -189,15 +189,15 @@ OMEvaluatorValue omEvaluatorValueGetList(OMEvaluatorValue evaluatorValue) {
 }
 
 /// Get the length of the List.
-intptr_t omListGetNumElements(OMEvaluatorValue evaluatorValue) {
+intptr_t omEvaluatorListGetNumElements(OMEvaluatorValue evaluatorValue) {
   return cast<evaluator::ListValue>(unwrap(evaluatorValue).get())
       ->getElements()
       .size();
 }
 
 /// Get an element of the List.
-OMEvaluatorValue omListGetElement(OMEvaluatorValue evaluatorValue,
-                                  intptr_t pos) {
+OMEvaluatorValue omEvaluatorListGetElement(OMEvaluatorValue evaluatorValue,
+                                           intptr_t pos) {
   return wrap(cast<evaluator::ListValue>(unwrap(evaluatorValue).get())
                   ->getElements()[pos]);
 }

--- a/test/CAPI/om.c
+++ b/test/CAPI/om.c
@@ -141,7 +141,8 @@ void testEvaluator(MlirContext ctx) {
           omEvaluatorValueIsAList(bar));
 
   // CHECK: 15 : i64
-  mlirAttributeDump(omEvaluatorValueGetPrimitive(omListGetElement(bar, 1)));
+  mlirAttributeDump(
+      omEvaluatorValueGetPrimitive(omEvaluatorListGetElement(bar, 1)));
 }
 
 int main(void) {


### PR DESCRIPTION
This is a PR for new representation of Evaluator and list_create support.

`std::variant` has been used as runtime representation of Evaluator but it's difficult to use it as
data structure for more structured values such as list or map. So this PR instead introduces a base class `EvaluatorValue ` and derived classes, `AttributeValue`, `ListValue` and `ObjectValue`, as runtime representation of values.

Also terminology `ObjectValue` is changed to `EvaluatorValue` since runtime values will not be limited to Object.
Python and C bindings are changed accordingly. 