### PR TITLE
[CMake] Implement add_circt_tool()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,14 +49,11 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
 # Options and settings
 #-------------------------------------------------------------------------------
 
-  option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
-  option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." ON)
-
-if (MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHs-c- /GR-")
-else ()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-rtti")
-endif ()
+  if (MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHs-c- /GR-")
+  else ()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-rtti")
+  endif ()
 
 #-------------------------------------------------------------------------------
 # MLIR/LLVM Configuration
@@ -172,6 +169,12 @@ set(CIRCT_LIBRARY_DIR ${CMAKE_BINARY_DIR}/lib)
 set(CIRCT_TOOLS_DIR ${CMAKE_BINARY_DIR}/bin)
 set(CIRCT_UTILS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/utils)
 set(CIRCT_PYTHON_PACKAGES_DIR ${CIRCT_BINARY_DIR}/python_packages)
+
+
+option(CIRCT_INCLUDE_TOOLS "Generate build targets for the CIRCT tools." ON)
+option(CIRCT_BUILD_TOOLS "Build the CIRCT tools. If OFF, just generate build targets." ON)
+set(CIRCT_TOOLS_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}" CACHE PATH
+    "Path for binary subdirectory (defaults to '${CMAKE_INSTALL_BINDIR}')")
 
 list(APPEND CMAKE_MODULE_PATH "${MLIR_MAIN_SRC_DIR}/cmake/modules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
@@ -563,7 +566,9 @@ endif()
 
 add_subdirectory(include/circt)
 add_subdirectory(lib)
-add_subdirectory(tools)
+if(CIRCT_INCLUDE_TOOLS)
+  add_subdirectory(tools)
+endif()
 if (CIRCT_GTEST_AVAILABLE)
   add_subdirectory(unittests)
 endif()

--- a/cmake/modules/AddCIRCT.cmake
+++ b/cmake/modules/AddCIRCT.cmake
@@ -37,6 +37,34 @@ function(add_circt_library name)
   add_circt_library_install(${name})
 endfunction()
 
+macro(add_circt_executable name)
+  add_llvm_executable(${name} ${ARGN})
+  set_target_properties(${name} PROPERTIES FOLDER "circt executables")
+endmacro()
+
+macro(add_circt_tool name)
+  if (NOT CIRCT_BUILD_TOOLS)
+    set(EXCLUDE_FROM_ALL ON)
+  endif()
+
+  add_circt_executable(${name} ${ARGN})
+
+  if (CIRCT_BUILD_TOOLS)
+    get_target_export_arg(${name} CIRCT export_to_circttargets)
+    install(TARGETS ${name}
+      ${export_to_circttargets}
+      RUNTIME DESTINATION "${CIRCT_TOOLS_INSTALL_DIR}"
+      COMPONENT ${name})
+
+    if(NOT CMAKE_CONFIGURATION_TYPES)
+      add_llvm_install_targets(install-${name}
+        DEPENDS ${name}
+        COMPONENT ${name})
+    endif()
+    set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS ${name})
+  endif()
+endmacro()
+
 # Adds a CIRCT library target for installation.  This should normally only be
 # called from add_circt_library().
 function(add_circt_library_install name)

--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(LLVM_LINK_COMPONENTS Support)
 
-add_llvm_tool(arcilator arcilator.cpp)
+add_circt_tool(arcilator arcilator.cpp)
 target_link_libraries(arcilator
   PRIVATE
   CIRCTArc

--- a/tools/circt-as/CMakeLists.txt
+++ b/tools/circt-as/CMakeLists.txt
@@ -15,7 +15,7 @@ set(LIBS
   MLIRSupport
 )
 
-add_llvm_tool(circt-as circt-as.cpp DEPENDS ${LIBS})
+add_circt_tool(circt-as circt-as.cpp DEPENDS ${LIBS})
 target_link_libraries(circt-as PRIVATE ${LIBS})
 
 llvm_update_compile_flags(circt-as)

--- a/tools/circt-dis/CMakeLists.txt
+++ b/tools/circt-dis/CMakeLists.txt
@@ -15,7 +15,7 @@ set(LIBS
   MLIRSupport
 )
 
-add_llvm_tool(circt-dis circt-dis.cpp DEPENDS ${LIBS})
+add_circt_tool(circt-dis circt-dis.cpp DEPENDS ${LIBS})
 target_link_libraries(circt-dis PRIVATE ${LIBS})
 
 llvm_update_compile_flags(circt-dis)

--- a/tools/circt-lec/CMakeLists.txt
+++ b/tools/circt-lec/CMakeLists.txt
@@ -1,6 +1,6 @@
 # circt-lec builds if a logic backend is found
 if(CIRCT_LEC_ENABLED)
-  add_llvm_tool(circt-lec
+  add_circt_tool(circt-lec
     circt-lec.cpp
   )
 

--- a/tools/circt-lsp-server/CMakeLists.txt
+++ b/tools/circt-lsp-server/CMakeLists.txt
@@ -42,7 +42,7 @@ set(LIBS
   MLIRIR
   )
 
-add_llvm_tool(circt-lsp-server
+add_circt_tool(circt-lsp-server
   circt-lsp-server.cpp
 
   DEPENDS

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -2,7 +2,7 @@ set(LLVM_LINK_COMPONENTS
   Support
 )
 
-add_llvm_tool(circt-opt
+add_circt_tool(circt-opt
   circt-opt.cpp
 )
 llvm_update_compile_flags(circt-opt)

--- a/tools/circt-reduce/CMakeLists.txt
+++ b/tools/circt-reduce/CMakeLists.txt
@@ -20,9 +20,9 @@ set(LIBS
   MLIRReduceLib
 )
 
-add_llvm_tool(circt-reduce
- circt-reduce.cpp
- DEPENDS ${LIBS}
+add_circt_tool(circt-reduce
+  circt-reduce.cpp
+  DEPENDS ${LIBS}
 )
 target_link_libraries(circt-reduce PRIVATE ${LIBS})
 

--- a/tools/circt-translate/CMakeLists.txt
+++ b/tools/circt-translate/CMakeLists.txt
@@ -5,9 +5,9 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_llvm_tool(circt-translate
+add_circt_tool(circt-translate
   circt-translate.cpp
-)
+  )
 
 llvm_update_compile_flags(circt-translate)
 

--- a/tools/firtool/CMakeLists.txt
+++ b/tools/firtool/CMakeLists.txt
@@ -2,7 +2,7 @@ set(LLVM_LINK_COMPONENTS
   Support
 )
 
-add_llvm_tool(firtool
+add_circt_tool(firtool
   firtool.cpp
 )
 llvm_update_compile_flags(firtool)

--- a/tools/hlstool/CMakeLists.txt
+++ b/tools/hlstool/CMakeLists.txt
@@ -2,9 +2,9 @@ set(LLVM_LINK_COMPONENTS
   Support
   )
 
-add_llvm_tool(hlstool
- hlstool.cpp
-)
+add_circt_tool(hlstool
+  hlstool.cpp
+  )
 llvm_update_compile_flags(hlstool)
 target_link_libraries(hlstool
   PRIVATE
@@ -23,7 +23,7 @@ target_link_libraries(hlstool
   CIRCTSV
   CIRCTSVTransforms
   CIRCTTransforms
-  
+
   MLIRIR
   MLIRLLVMDialect
   MLIRMemRefDialect

--- a/tools/llhd-sim/CMakeLists.txt
+++ b/tools/llhd-sim/CMakeLists.txt
@@ -8,9 +8,9 @@ set(LIBS
 
 # llhd-sim fails to link on Windows with MSVC.
 IF(CIRCT_LLHD_SIM_ENABLED)
-  add_llvm_tool(llhd-sim
+  add_circt_tool(llhd-sim
     llhd-sim.cpp)
-  
+
   llvm_update_compile_flags(llhd-sim)
   target_link_libraries(llhd-sim PRIVATE ${LIBS})
 endif()

--- a/tools/om-linker/CMakeLists.txt
+++ b/tools/om-linker/CMakeLists.txt
@@ -2,7 +2,7 @@ set(LLVM_LINK_COMPONENTS
   Support
 )
 
-add_llvm_tool(om-linker
+add_circt_tool(om-linker
   om-linker.cpp
 )
 llvm_update_compile_flags(om-linker)


### PR DESCRIPTION
Right now we use `add_llvm_tool()` to add tools, which is equivalent to `llvm_add_tool(LLVM ${ARGV})`. This puts packagers of CIRCT in the somewhat awkward situation of needing to use `LLVM_TOOLS_INSTALL_DIR` to specify where CIRCT tools should be placed in the install tree.

CIRCT is not LLVM.

This patch adds a specialization of `llvm_add_tool()`. This is the same approach used by MLIR and LLVM itself.

