### PR TITLE
[CI] Use macOS universal wheels for M-series, add Python 3.9 and 3.11 support

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -24,6 +24,8 @@ jobs:
             cibw_build: cp39-manylinux_x86_64
           - os: ubuntu-20.04
             cibw_build: cp310-manylinux_x86_64
+          - os: ubuntu-20.04
+            cibw_build: cp311-manylinux_x86_64
           - os: macos-latest
             cibw_build: cp37-macosx_universal2
           - os: macos-latest
@@ -32,6 +34,8 @@ jobs:
             cibw_build: cp39-macosx_universal2
           - os: macos-latest
             cibw_build: cp310-macosx_universal2
+          - os: macos-latest
+            cibw_build: cp311-macosx_universal2
 
     steps:
       - name: Get CIRCT

--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -21,11 +21,15 @@ jobs:
           - os: ubuntu-20.04
             cibw_build: cp38-manylinux_x86_64
           - os: ubuntu-20.04
+            cibw_build: cp39-manylinux_x86_64
+          - os: ubuntu-20.04
             cibw_build: cp310-manylinux_x86_64
           - os: macos-latest
             cibw_build: cp37-macosx_universal2
           - os: macos-latest
             cibw_build: cp38-macosx_universal2
+          - os: macos-latest
+            cibw_build: cp39-macosx_universal2
           - os: macos-latest
             cibw_build: cp310-macosx_universal2
 

--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -23,11 +23,11 @@ jobs:
           - os: ubuntu-20.04
             cibw_build: cp310-manylinux_x86_64
           - os: macos-latest
-            cibw_build: cp37-macosx_x86_64
+            cibw_build: cp37-macosx_universal2
           - os: macos-latest
-            cibw_build: cp38-macosx_x86_64
+            cibw_build: cp38-macosx_universal2
           - os: macos-latest
-            cibw_build: cp310-macosx_x86_64
+            cibw_build: cp310-macosx_universal2
 
     steps:
       - name: Get CIRCT
@@ -53,6 +53,8 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BUILD_FRONTEND: build
           SETUPTOOLS_SCM_DEBUG: True
+          CIBW_ARCHS_MACOS: universal2
+          CIBW_TEST_SKIP: '*universal2:arm64'
 
       - name: Upload (stage) wheels as artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
See https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon

Because github doesn't provide an apple silicon runner, we cross-compile from the intel macOS runner but skip running the tests.