### PR TITLE
[Python] Handle inner symbols in attribute_to_var

### DIFF
--- a/integration_test/Bindings/Python/dialects/hw.py
+++ b/integration_test/Bindings/Python/dialects/hw.py
@@ -3,6 +3,7 @@
 
 import circt
 from circt.dialects import hw
+from circt.support import attribute_to_var
 
 from circt.ir import (Context, Location, InsertionPoint, IntegerType,
                       IntegerAttr, Module, StringAttr, TypeAttr)
@@ -99,6 +100,8 @@ with Context() as ctx, Location.unknown():
   print(inner_sym)
   # CHECK: "some_sym"
   print(inner_sym.symName)
+  # CHECK: some_sym
+  print(attribute_to_var(inner_sym))
 
   inner_ref = hw.InnerRefAttr.get(StringAttr.get("some_module"),
                                   StringAttr.get("some_instance"))

--- a/lib/Bindings/Python/support.py
+++ b/lib/Bindings/Python/support.py
@@ -144,6 +144,10 @@ def attribute_to_var(attr):
   except ValueError:
     pass
   try:
+    return ir.StringAttr(hw.InnerSymAttr(attr).symName).value
+  except ValueError:
+    pass
+  try:
     return ir.StringAttr(attr).value
   except ValueError:
     pass


### PR DESCRIPTION
InnerSymAttr cannot be directly representable in python value so just cast it into a string in a similar way as we have handled InnerRef, om.ListAttr or om.ReferenceAttr.