### PR TITLE
Bump LLVM

### DIFF
--- a/lib/Dialect/Interop/CMakeLists.txt
+++ b/lib/Dialect/Interop/CMakeLists.txt
@@ -14,6 +14,7 @@ add_circt_dialect_library(CIRCTInteropDialect
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRControlFlowInterfaces
 )
 
 add_dependencies(circt-headers MLIRInteropIncGen)

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -915,7 +915,7 @@ ParseResult llhd::RegOp::parse(OpAsmParser &parser, OperationState &result) {
   operandSizes.push_back(triggerOperands.size());
   operandSizes.push_back(delayOperands.size());
   operandSizes.push_back(gateOperands.size());
-  result.addAttribute("operand_segment_sizes",
+  result.addAttribute("operandSegmentSizes",
                       parser.getBuilder().getDenseI32ArrayAttr(operandSizes));
 
   return success();
@@ -938,7 +938,7 @@ void llhd::RegOp::print(OpAsmPrinter &printer) {
     printer << " : " << getValues()[i].getType() << ")";
   }
   printer.printOptionalAttrDict((*this)->getAttrs(),
-                                {"modes", "gateMask", "operand_segment_sizes"});
+                                {"modes", "gateMask", "operandSegmentSizes"});
   printer << " : " << getSignal().getType();
 }
 

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -268,7 +268,7 @@ static ParseResult parsePipelineOp(mlir::OpAsmParser &parser,
     return failure();
 
   result.addAttribute(
-      "operand_segment_sizes",
+      "operandSegmentSizes",
       parser.getBuilder().getDenseI32ArrayAttr(
           {static_cast<int32_t>(inputTypes.size()),
            static_cast<int32_t>(withStall ? 1 : 0),
@@ -316,7 +316,7 @@ static void printPipelineOp(OpAsmPrinter &p, TPipelineOp op) {
 
   // Print the optional attribute dict.
   p.printOptionalAttrDict(op->getAttrs(),
-                          /*elidedAttrs=*/{"name", "operand_segment_sizes",
+                          /*elidedAttrs=*/{"name", "operandSegmentSizes",
                                            "outputNames", "inputNames"});
   p << " ";
 
@@ -365,7 +365,7 @@ void ScheduledPipelineOp::build(OpBuilder &odsBuilder, OperationState &odsState,
     odsState.addAttribute("name", name);
 
   odsState.addAttribute(
-      "operand_segment_sizes",
+      "operandSegmentSizes",
       odsBuilder.getDenseI32ArrayAttr(
           {static_cast<int32_t>(inputs.size()),
            static_cast<int32_t>(stall ? 1 : 0), static_cast<int32_t>(1),
@@ -777,7 +777,7 @@ void StageOp::build(OpBuilder &odsBuilder, OperationState &odsState,
   odsState.addSuccessors(dest);
   odsState.addOperands(registers);
   odsState.addOperands(passthroughs);
-  odsState.addAttribute("operand_segment_sizes",
+  odsState.addAttribute("operandSegmentSizes",
                         odsBuilder.getDenseI32ArrayAttr(
                             {static_cast<int32_t>(registers.size()),
                              static_cast<int32_t>(passthroughs.size()),

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -115,7 +115,7 @@ ParseResult ReadPortOp::parse(OpAsmParser &parser, OperationState &result) {
   operandSizes.push_back(1); // memory handle
   operandSizes.push_back(addressOperands.size());
   operandSizes.push_back(hasRdEn ? 1 : 0);
-  result.addAttribute("operand_segment_sizes",
+  result.addAttribute("operandSegmentSizes",
                       parser.getBuilder().getDenseI32ArrayAttr(operandSizes));
   return success();
 }
@@ -124,7 +124,7 @@ void ReadPortOp::print(OpAsmPrinter &p) {
   p << " " << getMemory() << "[" << getAddresses() << "]";
   if (getRdEn())
     p << " rden " << getRdEn();
-  p.printOptionalAttrDict((*this)->getAttrs(), {"operand_segment_sizes"});
+  p.printOptionalAttrDict((*this)->getAttrs(), {"operandSegmentSizes"});
   p << " : " << getMemory().getType();
 }
 

--- a/test/Dialect/LLHD/IR/inst.mlir
+++ b/test/Dialect/LLHD/IR/inst.mlir
@@ -48,21 +48,21 @@ hw.module @hwModule(%arg0 : i32, %arg1 : i16) -> (arg2: i8) {
 // CHECK: llhd.entity @caller (%[[ARG0:.*]] : !llhd.sig<i32>, %[[ARG1:.*]] : !llhd.sig<i16>) -> (%[[OUT0:.*]] : !llhd.sig<i8>, %[[OUT1:.*]] : !llhd.sig<i4>) {
 llhd.entity @caller(%arg0 : !llhd.sig<i32>, %arg1 : !llhd.sig<i16>) -> (%out0 : !llhd.sig<i8>, %out1 : !llhd.sig<i4>) {
   // CHECK-NEXT: llhd.inst "empty_entity" @empty_entity() -> () : () -> ()
-  "llhd.inst"() {callee=@empty_entity, operand_segment_sizes=array<i32: 0,0>, name="empty_entity"} : () -> ()
+  "llhd.inst"() {callee=@empty_entity, operandSegmentSizes=array<i32: 0,0>, name="empty_entity"} : () -> ()
   // CHECK-NEXT: llhd.inst "empty_proc" @empty_proc() -> () : () -> ()
-  "llhd.inst"() {callee=@empty_proc, operand_segment_sizes=array<i32: 0,0>, name="empty_proc"} : () -> ()
+  "llhd.inst"() {callee=@empty_proc, operandSegmentSizes=array<i32: 0,0>, name="empty_proc"} : () -> ()
   // CHECK-NEXT: llhd.inst "one_in_entity" @one_input_entity(%[[ARG0]]) -> () : (!llhd.sig<i32>) -> ()
-  "llhd.inst"(%arg0) {callee=@one_input_entity, operand_segment_sizes=array<i32: 1,0>, name="one_in_entity"} : (!llhd.sig<i32>) -> ()
+  "llhd.inst"(%arg0) {callee=@one_input_entity, operandSegmentSizes=array<i32: 1,0>, name="one_in_entity"} : (!llhd.sig<i32>) -> ()
   // CHECK-NEXT: llhd.inst "one_in_proc" @one_input_proc(%[[ARG0]]) -> () : (!llhd.sig<i32>) -> ()
-  "llhd.inst"(%arg0) {callee=@one_input_proc, operand_segment_sizes=array<i32: 1,0>, name="one_in_proc"} : (!llhd.sig<i32>) -> ()
+  "llhd.inst"(%arg0) {callee=@one_input_proc, operandSegmentSizes=array<i32: 1,0>, name="one_in_proc"} : (!llhd.sig<i32>) -> ()
   // CHECK-NEXT: llhd.inst "one_out_entity" @one_output_entity() -> (%[[ARG0]]) : () -> !llhd.sig<i32>
-  "llhd.inst"(%arg0) {callee=@one_output_entity, operand_segment_sizes=array<i32: 0,1>, name="one_out_entity"} : (!llhd.sig<i32>) -> ()
+  "llhd.inst"(%arg0) {callee=@one_output_entity, operandSegmentSizes=array<i32: 0,1>, name="one_out_entity"} : (!llhd.sig<i32>) -> ()
   // CHECK-NEXT: llhd.inst "one_out_proc" @one_output_proc() -> (%[[ARG0]]) : () -> !llhd.sig<i32>
-  "llhd.inst"(%arg0) {callee=@one_output_proc, operand_segment_sizes=array<i32: 0,1>, name="one_out_proc"} : (!llhd.sig<i32>) -> ()
+  "llhd.inst"(%arg0) {callee=@one_output_proc, operandSegmentSizes=array<i32: 0,1>, name="one_out_proc"} : (!llhd.sig<i32>) -> ()
   // CHECK-NEXT: llhd.inst "entity" @entity(%[[ARG0]], %[[ARG1]]) -> (%[[OUT0]], %[[OUT1]]) : (!llhd.sig<i32>, !llhd.sig<i16>) -> (!llhd.sig<i8>, !llhd.sig<i4>)
-  "llhd.inst"(%arg0, %arg1, %out0, %out1) {callee=@entity, operand_segment_sizes=array<i32: 2,2>, name="entity"} : (!llhd.sig<i32>, !llhd.sig<i16>, !llhd.sig<i8>, !llhd.sig<i4>) -> ()
+  "llhd.inst"(%arg0, %arg1, %out0, %out1) {callee=@entity, operandSegmentSizes=array<i32: 2,2>, name="entity"} : (!llhd.sig<i32>, !llhd.sig<i16>, !llhd.sig<i8>, !llhd.sig<i4>) -> ()
   // CHECK-NEXT: llhd.inst "proc" @proc(%[[ARG0]], %[[ARG1]]) -> (%[[OUT0]], %[[OUT1]]) : (!llhd.sig<i32>, !llhd.sig<i16>) -> (!llhd.sig<i8>, !llhd.sig<i4>)
-  "llhd.inst"(%arg0, %arg1, %out0, %out1) {callee=@proc, operand_segment_sizes=array<i32: 2,2>, name="proc"} : (!llhd.sig<i32>, !llhd.sig<i16>, !llhd.sig<i8>, !llhd.sig<i4>) -> ()
+  "llhd.inst"(%arg0, %arg1, %out0, %out1) {callee=@proc, operandSegmentSizes=array<i32: 2,2>, name="proc"} : (!llhd.sig<i32>, !llhd.sig<i16>, !llhd.sig<i8>, !llhd.sig<i4>) -> ()
   // CHECK-NEXT: llhd.inst "module" @hwModule(%[[ARG0]], %[[ARG1]]) -> (%[[OUT0]]) : (!llhd.sig<i32>, !llhd.sig<i16>) -> !llhd.sig<i8>
   llhd.inst "module" @hwModule(%arg0, %arg1) -> (%out0) : (!llhd.sig<i32>, !llhd.sig<i16>) -> !llhd.sig<i8>
   // CHECK-NEXT: }

--- a/test/Dialect/LLHD/IR/reg.mlir
+++ b/test/Dialect/LLHD/IR/reg.mlir
@@ -11,13 +11,13 @@ llhd.entity @check_reg (%in64 : !llhd.sig<i64>) -> () {
   %time = llhd.constant_time #llhd.time<1ns, 0d, 0e>
   // one trigger with optional gate
   // CHECK-NEXT: llhd.reg %[[IN64]], (%[[C64]], "low" %[[C1]] after %[[TIME]] if %[[C1]] : i64) : !llhd.sig<i64>
-  "llhd.reg"(%in64, %c64, %c1, %time, %c1) {modes=[0], gateMask=[1], operand_segment_sizes=array<i32: 1,1,1,1,1>} : (!llhd.sig<i64>, i64, i1, !llhd.time, i1) -> ()
+  "llhd.reg"(%in64, %c64, %c1, %time, %c1) {modes=[0], gateMask=[1], operandSegmentSizes=array<i32: 1,1,1,1,1>} : (!llhd.sig<i64>, i64, i1, !llhd.time, i1) -> ()
   // two triggers with optional gates
   // CHECK-NEXT: llhd.reg %[[IN64]], (%[[C64]], "low" %[[C1]] after %[[TIME]] if %[[C1]] : i64), (%[[IN64]], "high" %[[C1]] after %[[TIME]] if %[[C1]] : !llhd.sig<i64>) : !llhd.sig<i64>
-  "llhd.reg"(%in64, %c64, %in64, %c1, %c1, %time, %time, %c1, %c1) {modes=[0,1], gateMask=[1,2], operand_segment_sizes=array<i32: 1,2,2,2,2>} : (!llhd.sig<i64>, i64, !llhd.sig<i64>, i1, i1, !llhd.time, !llhd.time, i1, i1) -> ()
+  "llhd.reg"(%in64, %c64, %in64, %c1, %c1, %time, %time, %c1, %c1) {modes=[0,1], gateMask=[1,2], operandSegmentSizes=array<i32: 1,2,2,2,2>} : (!llhd.sig<i64>, i64, !llhd.sig<i64>, i1, i1, !llhd.time, !llhd.time, i1, i1) -> ()
   // two triggers with only one optional gate
   // CHECK-NEXT: llhd.reg %[[IN64]], (%[[C64]], "low" %[[C1]] after %[[TIME]] : i64), (%[[IN64]], "high" %[[C1]] after %[[TIME]] if %[[C1]] : !llhd.sig<i64>) : !llhd.sig<i64>
-  "llhd.reg"(%in64, %c64, %in64, %c1, %c1, %time, %time, %c1) {modes=[0,1], gateMask=[0,1], operand_segment_sizes=array<i32: 1,2,2,2,1>} : (!llhd.sig<i64>, i64, !llhd.sig<i64>, i1, i1, !llhd.time, !llhd.time, i1) -> ()
+  "llhd.reg"(%in64, %c64, %in64, %c1, %c1, %time, %time, %c1) {modes=[0,1], gateMask=[0,1], operandSegmentSizes=array<i32: 1,2,2,2,1>} : (!llhd.sig<i64>, i64, !llhd.sig<i64>, i1, i1, !llhd.time, !llhd.time, i1) -> ()
 }
 
 // TODO: add verification tests in reg-errors.mlir (expected-error tests)

--- a/test/Dialect/LLHD/IR/wait.mlir
+++ b/test/Dialect/LLHD/IR/wait.mlir
@@ -9,7 +9,7 @@
 // CHECK-LABEL: @check_wait_0
 llhd.proc @check_wait_0 () -> () {
   // CHECK: llhd.wait ^[[BB:.*]]
-  "llhd.wait"() [^bb1] {operand_segment_sizes=array<i32: 0,0,0>} : () -> ()
+  "llhd.wait"() [^bb1] {operandSegmentSizes=array<i32: 0,0,0>} : () -> ()
   // CHECK-NEXT: ^[[BB]]
 ^bb1:
   llhd.halt
@@ -20,7 +20,7 @@ llhd.proc @check_wait_1 () -> () {
   // CHECK-NEXT: %[[TIME:.*]] = llhd.constant_time
   %time = llhd.constant_time #llhd.time<0ns, 0d, 0e>
   // CHECK-NEXT: llhd.wait for %[[TIME]], ^[[BB:.*]](%[[TIME]] : !llhd.time)
-  "llhd.wait"(%time, %time) [^bb1] {operand_segment_sizes=array<i32: 0,1,1>} : (!llhd.time, !llhd.time) -> ()
+  "llhd.wait"(%time, %time) [^bb1] {operandSegmentSizes=array<i32: 0,1,1>} : (!llhd.time, !llhd.time) -> ()
   // CHECK-NEXT: ^[[BB]](%[[T:.*]]: !llhd.time):
 ^bb1(%t: !llhd.time):
   llhd.halt
@@ -29,7 +29,7 @@ llhd.proc @check_wait_1 () -> () {
 // CHECK: llhd.proc @check_wait_2(%[[ARG0:.*]] : !llhd.sig<i64>, %[[ARG1:.*]] : !llhd.sig<i1>) -> () {
 llhd.proc @check_wait_2 (%arg0 : !llhd.sig<i64>, %arg1 : !llhd.sig<i1>) -> () {
   // CHECK-NEXT: llhd.wait (%[[ARG0]], %[[ARG1]] : !llhd.sig<i64>, !llhd.sig<i1>), ^[[BB:.*]](%[[ARG1]] : !llhd.sig<i1>)
-  "llhd.wait"(%arg0, %arg1, %arg1) [^bb1] {operand_segment_sizes=array<i32: 2,0,1>} : (!llhd.sig<i64>, !llhd.sig<i1>, !llhd.sig<i1>) -> ()
+  "llhd.wait"(%arg0, %arg1, %arg1) [^bb1] {operandSegmentSizes=array<i32: 2,0,1>} : (!llhd.sig<i64>, !llhd.sig<i1>, !llhd.sig<i1>) -> ()
   // CHECK: ^[[BB]](%[[A:.*]]: !llhd.sig<i1>):
 ^bb1(%a: !llhd.sig<i1>):
   llhd.halt
@@ -40,7 +40,7 @@ llhd.proc @check_wait_3 (%arg0 : !llhd.sig<i64>, %arg1 : !llhd.sig<i1>) -> () {
   // CHECK-NEXT: %[[TIME:.*]] = llhd.constant_time
   %time = llhd.constant_time #llhd.time<0ns, 0d, 0e>
   // CHECK-NEXT: llhd.wait for %[[TIME]], (%[[ARG0]], %[[ARG1]] : !llhd.sig<i64>, !llhd.sig<i1>), ^[[BB:.*]](%[[ARG1]], %[[ARG0]] : !llhd.sig<i1>, !llhd.sig<i64>)
-  "llhd.wait"(%arg0, %arg1, %time, %arg1, %arg0) [^bb1] {operand_segment_sizes=array<i32: 2,1,2>} : (!llhd.sig<i64>, !llhd.sig<i1>, !llhd.time, !llhd.sig<i1>, !llhd.sig<i64>) -> ()
+  "llhd.wait"(%arg0, %arg1, %time, %arg1, %arg0) [^bb1] {operandSegmentSizes=array<i32: 2,1,2>} : (!llhd.sig<i64>, !llhd.sig<i1>, !llhd.time, !llhd.sig<i1>, !llhd.sig<i64>) -> ()
   // CHECK: ^[[BB]](%[[A:.*]]: !llhd.sig<i1>, %[[B:.*]]: !llhd.sig<i64>):
 ^bb1(%a: !llhd.sig<i1>, %b: !llhd.sig<i64>):
   llhd.halt


### PR DESCRIPTION
Weekly LLVM bump. Changes required:
- Add a missing link library to the Interop Dialect (due to https://reviews.llvm.org/D157506)
- `operand_segment_sizes` renamed to `operandSegmentSizes` (due to https://reviews.llvm.org/D157173)