### PR TITLE
[CI] Attempt to fix nightly cache evictions

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -64,7 +64,8 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           max-size: 300M
-          key: ${{ github.job }}-${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}
+          key: ${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}
+          append-timestamp: false
 
       # --------
       # Build and test CIRCT

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -47,8 +47,9 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: shortintegration-${{ matrix.build-assert }}-${{ matrix.build-type }}-${{ matrix.compiler.cc }} 
-          max-size: 1G
+          key: ${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}
+          append-timestamp: false
+          max-size: 500M
 
       # --------
       # Build and test CIRCT

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           mkdir build && cd build
+          # In order for ccache to be effective, these flags should be kept in sync with nighly.
           cmake -GNinja ../llvm/llvm \
             -DBUILD_SHARED_LIBS=$BUILD_SHARED \
             -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
@@ -75,6 +76,8 @@ jobs:
             -DLLVM_ENABLE_PROJECTS=mlir \
             -DLLVM_EXTERNAL_PROJECTS=circt \
             -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=.. \
+            -DLLVM_TARGETS_TO_BUILD="host" \
+            -DLLVM_USE_SPLIT_DWARF \
             -DLLVM_USE_LINKER=lld \
             -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
             -DCIRCT_BINDINGS_PYTHON_ENABLED=ON \

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -77,8 +77,8 @@ jobs:
             -DLLVM_EXTERNAL_PROJECTS=circt \
             -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=.. \
             -DLLVM_TARGETS_TO_BUILD="host" \
-            -DLLVM_USE_SPLIT_DWARF \
             -DLLVM_USE_LINKER=lld \
+            -DLLVM_USE_SPLIT_DWARF=ON \
             -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
             -DCIRCT_BINDINGS_PYTHON_ENABLED=ON \
             -DLLVM_LIT_ARGS="-v --show-unsupported"


### PR DESCRIPTION
Short integration tests are filling the cache. Hopefully not appending the timestamp will replace rather than add new ones. Also attempt to enable sharing cache between nightly and short.