### PR TITLE
[Arc] Move LegalizeStateUpdate before StateAlloc

### DIFF
--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -247,9 +247,9 @@ static void populatePipeline(PassManager &pm) {
   }
 
   pm.addPass(arc::createGroupResetsAndEnablesPass());
+  pm.addPass(arc::createLegalizeStateUpdatePass());
   pm.addPass(createCSEPass());
   pm.addPass(arc::createArcCanonicalizerPass());
-  pm.addPass(arc::createLegalizeStateUpdatePass());
 
   // Allocate states.
   if (untilReached(UntilStateAlloc))

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -249,11 +249,11 @@ static void populatePipeline(PassManager &pm) {
   pm.addPass(arc::createGroupResetsAndEnablesPass());
   pm.addPass(createCSEPass());
   pm.addPass(arc::createArcCanonicalizerPass());
+  pm.addPass(arc::createLegalizeStateUpdatePass());
 
   // Allocate states.
   if (untilReached(UntilStateAlloc))
     return;
-  pm.addPass(arc::createLegalizeStateUpdatePass());
   pm.nest<arc::ModelOp>().addPass(arc::createAllocateStatePass());
   if (!stateFile.empty())
     pm.addPass(arc::createPrintStateInfoPass(stateFile));


### PR DESCRIPTION
Minor update that moves LegalizeStateUpdate earlier in the pass pipeline. This is useful for tools that might want to replace the normal backend with a custom one (useful for export-cpp). Right before StateAlloc the Arc representation contains all the operations for a simulator, but hasn't yet allocated the exact state representation -- but the state needs be to legalized first. Thanks!