### PR TITLE
[CI] Upload full shared libs installation for Linux and macOS

### DIFF
--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -51,6 +51,11 @@ on:
         required: false
         type: string
         default: install-firtool
+      package_name_prefix:
+        description: "The prefix for package name"
+        required: false
+        type: string
+        default: firtool-bin
       cmake_c_compiler:
         description: "The C compiler to use"
         required: true
@@ -94,6 +99,10 @@ on:
       install:
         description: "Install steps to run"
         required: false
+        type: string
+      package_name_prefix:
+        description: "The prefix for package name"
+        required: true
         type: string
       cmake_c_compiler:
         description: "The C compiler to use"
@@ -196,7 +205,7 @@ jobs:
         if: inputs.install
         shell: bash
         run: |
-          NAME=firrtl-bin-${{ steps.name_dir.outputs.os }}-${{ steps.name_dir.outputs.arch }}.${{ steps.name_dir.outputs.archive }}
+          NAME=${{ inputs.package_name_prefix }}-${{ steps.name_dir.outputs.os }}-${{ steps.name_dir.outputs.arch }}.${{ steps.name_dir.outputs.archive }}
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
       - name: Package Binaries Linux and MacOS
         if: runner.os == 'macOS' || runner.os == 'Linux'

--- a/.github/workflows/uploadReleaseArtifacts.yml
+++ b/.github/workflows/uploadReleaseArtifacts.yml
@@ -1,4 +1,4 @@
-name: Upload Firrtl Release Artifacts
+name: Upload Release Artifacts
 
 on:
   release:
@@ -117,10 +117,18 @@ jobs:
           json=$(echo '${{ toJSON(env) }}' | jq -c)
           echo $json
           echo "out=$json" >> $GITHUB_OUTPUT
-      - name: Add Build Options
-        id: add-build-options
+      - name: Add Build Options for firtool
+        id: add-build-options-firtool
         run: |
-          json='{"mode":"release","assert":"OFF","shared":"OFF","stats":"ON"}'
+          json='{"name":"firtool","install_target":"install-firtool","package_name_prefix":"firtool-bin","mode":"release","assert":"OFF","shared":"OFF","stats":"ON"}'
+          if [[ ${{ github.event_name }} == 'schedule' ]] || [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
+            json=$(echo $json | jq -c '.assert = "ON" | .mode = "relwithdebinfo"')
+          fi
+          echo "out=$json" >> $GITHUB_OUTPUT
+      - name: Add Build Options for CIRCT-full shared libs
+        id: add-build-options-circt-full-shared-libs
+        run: |
+          json='{"name":"CIRCT-full shared libs","install_target":"install","package_name_prefix":"circt-full-shared-libs","mode":"release","assert":"OFF","shared":"ON","stats":"ON"}'
           if [[ ${{ github.event_name }} == 'schedule' ]] || [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             json=$(echo $json | jq -c '.assert = "ON" | .mode = "relwithdebinfo"')
           fi
@@ -128,7 +136,7 @@ jobs:
       - name: Build JSON Payloads
         id: build-json-payloads
         run: |
-          echo '${{ steps.add-build-options.outputs.out }}' | jq -sc . > options.json
+          echo '${{ steps.add-build-options-firtool.outputs.out }}' '${{ steps.add-build-options-circt-full-shared-libs.outputs.out }}' | jq -sc . > options.json
           echo build_configs=`cat options.json` >> $GITHUB_OUTPUT
 
           echo "Build Config Matrix" >> $GITHUB_STEP_SUMMARY
@@ -142,6 +150,17 @@ jobs:
           echo "Runner/Operating System Matrix:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
           cat runners.json | jq >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+          echo '${{ steps.add-build-options-circt-full-shared-libs.outputs.out }}' | jq -c . > exclude_1_build_config.json
+          echo '${{ steps.add-windows.outputs.out }}' | jq -c . > exclude_1_runner.json
+          echo exclude_1_build_config=`cat exclude_1_build_config.json` >> $GITHUB_OUTPUT
+          echo exclude_1_runner=`cat exclude_1_runner.json` >> $GITHUB_OUTPUT
+
+          echo "Exclude matrix 1:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          cat exclude_1_build_config.json | jq >> $GITHUB_STEP_SUMMARY
+          cat exclude_1_runner.json | jq >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
           case ${{ github.event_name }} in
@@ -164,6 +183,8 @@ jobs:
     outputs:
       build_configs: ${{ steps.build-json-payloads.outputs.build_configs }}
       runners: ${{ steps.build-json-payloads.outputs.runners }}
+      exclude_1_build_config: ${{ steps.build-json-payloads.outputs.exclude_1_build_config }}
+      exclude_1_runner: ${{ steps.build-json-payloads.outputs.exclude_1_runner }}
       environment: ${{ steps.build-json-payloads.outputs.environment }}
 
   publish:
@@ -174,6 +195,10 @@ jobs:
         build_config: ${{ fromJSON(needs.choose-matrix.outputs.build_configs) }}
         runner: ${{ fromJSON(needs.choose-matrix.outputs.runners) }}
         env: ${{ fromJSON(needs.choose-matrix.outputs.environment) }}
+        exclude:
+          # `BUILD_SHARED_LIBS` option is not supported on Windows
+          - build_config: ${{ fromJSON(needs.choose-matrix.outputs.exclude_1_build_config) }}
+            runner: ${{ fromJSON(needs.choose-matrix.outputs.exclude_1_runner) }}
     uses: ./.github/workflows/unifiedBuildTestAndInstall.yml
     with:
       runner: ${{ matrix.runner.runner }}
@@ -182,6 +207,7 @@ jobs:
       llvm_enable_assertions: ${{ matrix.build_config.assert }}
       llvm_force_enable_stats: ${{ matrix.build_config.stats }}
       runTests: ${{ matrix.env.runTests }}
-      install: install-firtool
+      install: ${{ matrix.build_config.install_target }}
+      package_name_prefix: ${{ matrix.build_config.package_name_prefix }}
       cmake_c_compiler: ${{ matrix.runner.cmake_c_compiler }}
       cmake_cxx_compiler: ${{ matrix.runner.cmake_cxx_compiler }}

--- a/.github/workflows/uploadReleaseArtifacts.yml
+++ b/.github/workflows/uploadReleaseArtifacts.yml
@@ -117,16 +117,16 @@ jobs:
           json=$(echo '${{ toJSON(env) }}' | jq -c)
           echo $json
           echo "out=$json" >> $GITHUB_OUTPUT
-      - name: Add Build Options for firtool
-        id: add-build-options-firtool
+      - name: Add Build Config for firtool
+        id: add-build-config-firtool
         run: |
           json='{"name":"firtool","install_target":"install-firtool","package_name_prefix":"firtool-bin","mode":"release","assert":"OFF","shared":"OFF","stats":"ON"}'
           if [[ ${{ github.event_name }} == 'schedule' ]] || [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             json=$(echo $json | jq -c '.assert = "ON" | .mode = "relwithdebinfo"')
           fi
           echo "out=$json" >> $GITHUB_OUTPUT
-      - name: Add Build Options for CIRCT-full shared libs
-        id: add-build-options-circt-full-shared-libs
+      - name: Add Build Config for CIRCT-full shared libs
+        id: add-build-config-circt-full-shared-libs
         run: |
           json='{"name":"CIRCT-full shared libs","install_target":"install","package_name_prefix":"circt-full-shared-libs","mode":"release","assert":"OFF","shared":"ON","stats":"ON"}'
           if [[ ${{ github.event_name }} == 'schedule' ]] || [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
@@ -136,42 +136,29 @@ jobs:
       - name: Build JSON Payloads
         id: build-json-payloads
         run: |
-          echo '${{ steps.add-build-options-firtool.outputs.out }}' '${{ steps.add-build-options-circt-full-shared-libs.outputs.out }}' | jq -sc . > options.json
-          echo build_configs=`cat options.json` >> $GITHUB_OUTPUT
-
-          echo "Build Config Matrix" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
-          cat options.json | jq >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-
+          echo '${{ steps.add-build-config-firtool.outputs.out }}' '${{ steps.add-build-config-circt-full-shared-libs.outputs.out }}' | jq -sc . > build_configs.json
           echo '${{ steps.add-linux.outputs.out }}' '${{ steps.add-macos.outputs.out }}' '${{ steps.add-windows.outputs.out }}' | jq -sc . > runners.json
-          echo runners=`cat runners.json` >> $GITHUB_OUTPUT
 
-          echo "Runner/Operating System Matrix:" >> $GITHUB_STEP_SUMMARY
+          cat runners.json build_configs.json | jq -sc '[combinations | add]' > matrix-raw.json
+
+          # Exclude job, `BUILD_SHARED_LIBS` option is not supported on Windows
+          cat matrix-raw.json | jq -c 'del(.[] | select(.os == "windows" and .shared == "ON"))' > matrix.json
+          echo matrix=`cat matrix.json` >> $GITHUB_OUTPUT
+
+          echo "Generated Matrix" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
-          cat runners.json | jq >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-
-          echo '${{ steps.add-build-options-circt-full-shared-libs.outputs.out }}' | jq -c . > exclude_1_build_config.json
-          echo '${{ steps.add-windows.outputs.out }}' | jq -c . > exclude_1_runner.json
-          echo exclude_1_build_config=`cat exclude_1_build_config.json` >> $GITHUB_OUTPUT
-          echo exclude_1_runner=`cat exclude_1_runner.json` >> $GITHUB_OUTPUT
-
-          echo "Exclude matrix 1:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
-          cat exclude_1_build_config.json | jq >> $GITHUB_STEP_SUMMARY
-          cat exclude_1_runner.json | jq >> $GITHUB_STEP_SUMMARY
+          cat matrix.json | jq >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
           case ${{ github.event_name }} in
             workflow_dispatch)
-              ENV='[{"runTests":${{ inputs.runTests }}}]'
+              ENV='{"runTests":${{ inputs.runTests }}}'
             ;;
             schedule)
-              ENV='[{"runTests":false}]'
+              ENV='{"runTests":false}'
             ;;
             *)
-              ENV='[{"runTests":true}]'
+              ENV='{"runTests":true}'
             ;;
           esac
           echo environment=$ENV >> $GITHUB_OUTPUT
@@ -181,10 +168,7 @@ jobs:
           echo $ENV | jq >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
     outputs:
-      build_configs: ${{ steps.build-json-payloads.outputs.build_configs }}
-      runners: ${{ steps.build-json-payloads.outputs.runners }}
-      exclude_1_build_config: ${{ steps.build-json-payloads.outputs.exclude_1_build_config }}
-      exclude_1_runner: ${{ steps.build-json-payloads.outputs.exclude_1_runner }}
+      matrix: ${{ steps.build-json-payloads.outputs.matrix }}
       environment: ${{ steps.build-json-payloads.outputs.environment }}
 
   publish:
@@ -192,22 +176,16 @@ jobs:
       - choose-matrix
     strategy:
       matrix:
-        build_config: ${{ fromJSON(needs.choose-matrix.outputs.build_configs) }}
-        runner: ${{ fromJSON(needs.choose-matrix.outputs.runners) }}
-        env: ${{ fromJSON(needs.choose-matrix.outputs.environment) }}
-        exclude:
-          # `BUILD_SHARED_LIBS` option is not supported on Windows
-          - build_config: ${{ fromJSON(needs.choose-matrix.outputs.exclude_1_build_config) }}
-            runner: ${{ fromJSON(needs.choose-matrix.outputs.exclude_1_runner) }}
+        generated: ${{ fromJSON(needs.choose-matrix.outputs.matrix) }}
     uses: ./.github/workflows/unifiedBuildTestAndInstall.yml
     with:
-      runner: ${{ matrix.runner.runner }}
-      cmake_build_type: ${{ matrix.build_config.mode }}
-      build_shared_libs: ${{ matrix.build_config.shared }}
-      llvm_enable_assertions: ${{ matrix.build_config.assert }}
-      llvm_force_enable_stats: ${{ matrix.build_config.stats }}
-      runTests: ${{ matrix.env.runTests }}
-      install: ${{ matrix.build_config.install_target }}
-      package_name_prefix: ${{ matrix.build_config.package_name_prefix }}
-      cmake_c_compiler: ${{ matrix.runner.cmake_c_compiler }}
-      cmake_cxx_compiler: ${{ matrix.runner.cmake_cxx_compiler }}
+      runner: ${{ matrix.generated.runner }}
+      cmake_build_type: ${{ matrix.generated.mode }}
+      build_shared_libs: ${{ matrix.generated.shared }}
+      llvm_enable_assertions: ${{ matrix.generated.assert }}
+      llvm_force_enable_stats: ${{ matrix.generated.stats }}
+      runTests: ${{ fromJSON(needs.choose-matrix.outputs.environment).runTests }}
+      install: ${{ matrix.generated.install_target }}
+      package_name_prefix: ${{ matrix.generated.package_name_prefix }}
+      cmake_c_compiler: ${{ matrix.generated.cmake_c_compiler }}
+      cmake_cxx_compiler: ${{ matrix.generated.cmake_cxx_compiler }}


### PR DESCRIPTION
Closes #5814.

Skip this on Windows since LLVM doesn't support `BUILD_SHARED_LIBS=ON` on Windows. (ref: https://github.com/llvm/llvm-project/blob/706e875da3a21f2d6ba612ca991dbdbccb339327/llvm/CMakeLists.txt#L767-L775)

You can preview the artifacts on https://github.com/SpriteOvO/circt/releases/tag/firtool-0.00.5, uploaded by https://github.com/SpriteOvO/circt/actions/runs/5839650661.