### PR TITLE
[HW/Support] Introduce InstanceGraph interface

### DIFF
--- a/include/circt/CMakeLists.txt
+++ b/include/circt/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Conversion)
 add_subdirectory(Dialect)
 add_subdirectory(Transforms)
+add_subdirectory(Support)

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -42,7 +42,11 @@ class HardwareDeclOp<string mnemonic, list <Trait> traits = []> :
 
 def InstanceOp : HardwareDeclOp<"instance", [
     DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-    DeclareOpInterfaceMethods<HWInstanceLike>]> {
+    DeclareOpInterfaceMethods<HWInstanceLike>,
+    // InstanceGraphInstanceOpInterface inherits from HWInstanceLike but
+    // DeclareOpInterfaceMethods doesn't currently consider inheritance.
+    DeclareOpInterfaceMethods<InstanceGraphInstanceOpInterface>
+    ]> {
   let summary = "Instantiate an instance of a module";
   let description = [{
     This represents an instance of a module.  The results are the modules inputs

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -102,10 +102,6 @@ def InstanceOp : HardwareDeclOp<"instance", [
   ];
 
   let extraClassDeclaration = [{
-    /// Lookup the module or extmodule for the symbol.  This returns null on
-    /// invalid IR.
-    FModuleLike getReferencedModule(SymbolTable& symtbl);
-
     /// Return the port direction for the specified result number.
     Direction getPortDirection(size_t resultNo) {
       return direction::get(getPortDirections()[resultNo]);

--- a/include/circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h
@@ -14,7 +14,7 @@
 #define CIRCT_DIALECT_FIRRTL_FIRRTLINSTANCEGRAPH_H
 
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
-#include "circt/Dialect/HW/InstanceGraphBase.h"
+#include "circt/Support/InstanceGraph.h"
 #include "circt/Support/LLVM.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/STLExtras.h"
@@ -22,9 +22,9 @@
 
 namespace circt {
 namespace firrtl {
-using InstanceRecord = hw::InstanceRecord;
-using InstanceGraphNode = hw::InstanceGraphNode;
-using InstancePathCache = hw::InstancePathCache;
+using InstanceRecord = igraph::InstanceRecord;
+using InstanceGraphNode = igraph::InstanceGraphNode;
+using InstancePathCache = igraph::InstancePathCache;
 
 /// This graph tracks modules and where they are instantiated. This is intended
 /// to be used as a cached analysis on FIRRTL circuits.  This class can be used
@@ -32,14 +32,14 @@ using InstancePathCache = hw::InstancePathCache;
 ///
 /// To use this class, retrieve a cached copy from the analysis manager:
 ///   auto &instanceGraph = getAnalysis<InstanceGraph>(getOperation());
-class InstanceGraph : public hw::InstanceGraphBase {
+class InstanceGraph : public igraph::InstanceGraph {
 public:
   /// Create a new module graph of a circuit.  This must be called on a FIRRTL
   /// CircuitOp or MLIR ModuleOp.
   explicit InstanceGraph(Operation *operation);
 
   /// Get the node corresponding to the top-level module of a circuit.
-  InstanceGraphNode *getTopLevelNode() override { return topLevelNode; }
+  igraph::InstanceGraphNode *getTopLevelNode() override { return topLevelNode; }
 
   /// Get the module corresponding to the top-level module of a circuit.
   FModuleLike getTopLevelModule() {
@@ -57,12 +57,12 @@ bool allUnder(ArrayRef<InstanceRecord *> nodes, InstanceGraphNode *top);
 
 template <>
 struct llvm::GraphTraits<circt::firrtl::InstanceGraph *>
-    : public llvm::GraphTraits<circt::hw::InstanceGraphBase *> {};
+    : public llvm::GraphTraits<circt::igraph::InstanceGraph *> {};
 
 template <>
 struct llvm::DOTGraphTraits<circt::firrtl::InstanceGraph *>
-    : public llvm::DOTGraphTraits<circt::hw::InstanceGraphBase *> {
-  using llvm::DOTGraphTraits<circt::hw::InstanceGraphBase *>::DOTGraphTraits;
+    : public llvm::DOTGraphTraits<circt::igraph::InstanceGraph *> {
+  using llvm::DOTGraphTraits<circt::igraph::InstanceGraph *>::DOTGraphTraits;
 };
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLINSTANCEGRAPH_H

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -184,6 +184,16 @@ def HWInstanceOp : FSMOp<"hw_instance", [
       return getMachineAttr();
     }
 
+    mlir::StringAttr getInstanceNameAttr() {
+      return getSymNameAttr();
+    }
+
+    llvm::StringRef getInstanceName() {
+      return getSymName();
+    }
+
+    Operation* getReferencedModule();
+
     //===------------------------------------------------------------------===//
     // PortList Methods
     //===------------------------------------------------------------------===//

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -192,7 +192,8 @@ def HWInstanceOp : FSMOp<"hw_instance", [
       return getSymName();
     }
 
-    Operation* getReferencedModule();
+    Operation* getReferencedModule(SymbolTable& tbl);
+    Operation* getReferencedModuleSlow();
 
     //===------------------------------------------------------------------===//
     // PortList Methods

--- a/include/circt/Dialect/HW/HWInstanceGraph.h
+++ b/include/circt/Dialect/HW/HWInstanceGraph.h
@@ -13,28 +13,30 @@
 #ifndef CIRCT_DIALECT_HW_HWINSTANCEGRAPH_H
 #define CIRCT_DIALECT_HW_HWINSTANCEGRAPH_H
 
-#include "circt/Dialect/HW/InstanceGraphBase.h"
+#include "circt/Dialect/HW/HWOpInterfaces.h"
+#include "circt/Support/InstanceGraph.h"
 
 namespace circt {
 namespace hw {
 
 /// HW-specific instance graph with a virtual entry node linking to
 /// all publicly visible modules.
-class InstanceGraph : public InstanceGraphBase {
+class InstanceGraph : public igraph::InstanceGraph {
 public:
   InstanceGraph(Operation *operation);
 
   /// Return the entry node linking to all public modules.
-  InstanceGraphNode *getTopLevelNode() override { return &entry; }
+  igraph::InstanceGraphNode *getTopLevelNode() override { return &entry; }
 
   /// Adds a module, updating links to entry.
-  InstanceGraphNode *addModule(HWModuleLike module) override;
+  igraph::InstanceGraphNode *addHWModule(HWModuleLike module);
 
   /// Erases a module, updating links to entry.
-  void erase(InstanceGraphNode *node) override;
+  void erase(igraph::InstanceGraphNode *node) override;
 
 private:
-  InstanceGraphNode entry;
+  using igraph::InstanceGraph::addModule;
+  igraph::InstanceGraphNode entry;
 };
 
 } // namespace hw
@@ -43,12 +45,12 @@ private:
 // Specialisation for the HW instance graph.
 template <>
 struct llvm::GraphTraits<circt::hw::InstanceGraph *>
-    : public llvm::GraphTraits<circt::hw::InstanceGraphBase *> {};
+    : public llvm::GraphTraits<circt::igraph::InstanceGraph *> {};
 
 template <>
 struct llvm::DOTGraphTraits<circt::hw::InstanceGraph *>
-    : public llvm::DOTGraphTraits<circt::hw::InstanceGraphBase *> {
-  using llvm::DOTGraphTraits<circt::hw::InstanceGraphBase *>::DOTGraphTraits;
+    : public llvm::DOTGraphTraits<circt::igraph::InstanceGraph *> {
+  using llvm::DOTGraphTraits<circt::igraph::InstanceGraph *>::DOTGraphTraits;
 };
 
 #endif // CIRCT_DIALECT_HW_HWINSTANCEGRAPH_H

--- a/include/circt/Dialect/HW/HWModuleGraph.h
+++ b/include/circt/Dialect/HW/HWModuleGraph.h
@@ -14,8 +14,8 @@
 #define CIRCT_DIALECT_HW_HWMODULEGRAPH_H
 
 #include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWInstanceGraph.h"
 #include "circt/Dialect/HW/HWOps.h"
-#include "circt/Dialect/HW/InstanceGraphBase.h"
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Support/LLVM.h"
 #include "llvm/ADT/GraphTraits.h"

--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -15,6 +15,7 @@
 
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/HW/InnerSymbolTable.h"
+#include "circt/Support/InstanceGraphInterface.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -15,6 +15,7 @@
 
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/IR/OpBase.td"
+include "circt/Support/InstanceGraphInterface.td"
 
 def PortList : OpInterface<"PortList", []> {
   let cppNamespace = "circt::hw";
@@ -25,22 +26,12 @@ def PortList : OpInterface<"PortList", []> {
   ];
 }
 
-def HWModuleLike : OpInterface<"HWModuleLike", [Symbol, PortList]> {
+def HWModuleLike : OpInterface<"HWModuleLike", [
+  Symbol, PortList, InstanceGraphModuleOpInterface]> {
   let cppNamespace = "circt::hw";
   let description = "Provide common module information.";
 
   let methods = [
-
-    InterfaceMethod<"Get the module name",
-    "::llvm::StringRef", "getModuleName", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{ return $_op.getName(); }]>,
-
-    InterfaceMethod<"Get the module name",
-    "::mlir::StringAttr", "getModuleNameAttr", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{ return $_op.getNameAttr(); }]>,
-
     InterfaceMethod<"Get the number of ports",
     "size_t", "getNumPorts">,
 
@@ -185,30 +176,10 @@ def HWMutableModuleLike : OpInterface<"HWMutableModuleLike", [HWModuleLike]> {
 }
 
 
-def HWInstanceLike : OpInterface<"HWInstanceLike", [PortList]> {
+def HWInstanceLike : OpInterface<"HWInstanceLike", [
+    PortList, InstanceGraphInstanceOpInterface]> {
   let cppNamespace = "circt::hw";
   let description = "Provide common  module information.";
-
-  let methods = [
-    InterfaceMethod<"Get the name of the instance",
-    "::llvm::StringRef", "getInstanceName", (ins)>,
-
-    InterfaceMethod<"Get the name of the instance",
-    "::mlir::StringAttr", "getInstanceNameAttr", (ins)>,
-
-    InterfaceMethod<"Get the name of the instantiated module",
-    "::llvm::StringRef", "getReferencedModuleName", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{ return $_op.getModuleName(); }]>,
-
-    InterfaceMethod<"Get the name of the instantiated module",
-    "::mlir::StringAttr", "getReferencedModuleNameAttr", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{ return $_op.getModuleNameAttr().getAttr(); }]>,
-
-    InterfaceMethod<"Get the referenced module",
-    "::mlir::Operation *", "getReferencedModule", (ins)>,
-  ];
 }
 
 def InnerRefNamespace : NativeOpTrait<"InnerRefNamespace">;

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -555,9 +555,8 @@ def InstanceOp : HWOp<"instance", [
     /// Lookup the module or extmodule for the symbol.  This returns null on
     /// invalid IR.
     Operation *getReferencedModule(const HWSymbolCache *cache);
-
-
-    Operation *getReferencedModule();
+    Operation *getReferencedModule(SymbolTable& tbl);
+    Operation *getReferencedModuleSlow();
 
     /// Return the value for a port in port order.
     Value getValue(size_t idx);

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -556,6 +556,9 @@ def InstanceOp : HWOp<"instance", [
     /// invalid IR.
     Operation *getReferencedModule(const HWSymbolCache *cache);
 
+
+    Operation *getReferencedModule();
+
     /// Return the value for a port in port order.
     Value getValue(size_t idx);
 

--- a/include/circt/Dialect/HW/PortConverter.h
+++ b/include/circt/Dialect/HW/PortConverter.h
@@ -55,7 +55,7 @@ public:
                        Value output, hw::PortInfo &newPort);
 
 protected:
-  PortConverterImpl(hw::InstanceGraphNode *moduleNode)
+  PortConverterImpl(igraph::InstanceGraphNode *moduleNode)
       : moduleNode(moduleNode) {
     mod = dyn_cast<hw::HWMutableModuleLike>(*moduleNode->getModule());
     assert(mod && "PortConverter only works on HWMutableModuleLike");
@@ -78,7 +78,7 @@ private:
   // non-null.
   Block *body = nullptr;
 
-  hw::InstanceGraphNode *moduleNode;
+  igraph::InstanceGraphNode *moduleNode;
   hw::HWMutableModuleLike mod;
 
   // Keep around a reference to the specific port conversion classes to

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -41,6 +41,20 @@ def InstanceOp : MSFTOp<"instance", [
     InstanceOp getWithNewResults(MSFTModuleOp mod,
                                  ArrayRef<unsigned> newToOldMap);
 
+    /// Instance name is the same as the symbol name. This may change in the
+    /// future.
+    mlir::StringAttr getInstanceNameAttr() {
+      return getInnerNameAttr();
+    }
+
+    llvm::StringRef getInstanceName() {
+      return *getInnerName();
+    }
+
+    /// Lookup the module or extmodule for the symbol.  This returns null on
+    /// invalid IR.
+    Operation *getReferencedModule();
+
     //===------------------------------------------------------------------===//
     // PortList Methods
     //===------------------------------------------------------------------===//

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -53,7 +53,8 @@ def InstanceOp : MSFTOp<"instance", [
 
     /// Lookup the module or extmodule for the symbol.  This returns null on
     /// invalid IR.
-    Operation *getReferencedModule();
+    Operation* getReferencedModule(SymbolTable& tbl);
+    Operation* getReferencedModuleSlow();
 
     //===------------------------------------------------------------------===//
     // PortList Methods

--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -96,6 +96,9 @@ def InstanceDeclOp : SystemCOp<"instance.decl", [
   DeclareOpInterfaceMethods<HWInstanceLike>,
   HasCustomSSAName,
   SystemCNameDeclOpInterface,
+  // InstanceGraphInstanceOpInterface inherits from HWInstanceLike but
+  // DeclareOpInterfaceMethods doesn't currently consider inheritance.
+  DeclareOpInterfaceMethods<InstanceGraphInstanceOpInterface>,
   HasParent<"SCModuleOp">
 ]> {
   let summary = "Declares a SystemC module instance.";

--- a/include/circt/Support/CMakeLists.txt
+++ b/include/circt/Support/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_mlir_interface(InstanceGraphInterface)

--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -194,7 +194,7 @@ class InstanceGraph {
   using NodeList = llvm::iplist<InstanceGraphNode>;
 
 public:
-  virtual ~InstanceGraph();
+  virtual ~InstanceGraph() = default;
 
   /// Look up an InstanceGraphNode for a module.
   InstanceGraphNode *lookup(ModuleOpInterface op);

--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -1,4 +1,4 @@
-//===- InstanceGraphBase.h - Instance graph ---------------------*- C++ -*-===//
+//===- InstanceGraph.h - Instance graph -------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,18 +10,22 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CIRCT_DIALECT_HW_INSTANCEGRAPHBASE_H
-#define CIRCT_DIALECT_HW_INSTANCEGRAPHBASE_H
+#ifndef CIRCT_SUPPORT_INSTANCEGRAPH_H
+#define CIRCT_SUPPORT_INSTANCEGRAPH_H
 
-#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Support/LLVM.h"
+#include "mlir/IR/OpDefinition.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/Support/DOTGraphTraits.h"
 
+/// The InstanceGraph op interface, see InstanceGraphInterface.td for more
+/// details.
+#include "circt/Support/InstanceGraphInterface.h"
+
 namespace circt {
-namespace hw {
+namespace igraph {
 
 namespace detail {
 /// This just maps a iterator of references to an iterator of addresses.
@@ -51,7 +55,12 @@ class InstanceRecord
     : public llvm::ilist_node_with_parent<InstanceRecord, InstanceGraphNode> {
 public:
   /// Get the instance-like op that this is tracking.
-  HWInstanceLike getInstance() const { return instance; }
+  template <typename TTarget = InstanceOpInterface>
+  auto getInstance() {
+    if constexpr (std::is_same<TTarget, InstanceOpInterface>::value)
+      return instance;
+    return dyn_cast_or_null<TTarget>(instance.getOperation());
+  }
 
   /// Get the module where the instantiation lives.
   InstanceGraphNode *getParent() const { return parent; }
@@ -64,10 +73,10 @@ public:
   void erase();
 
 private:
-  friend class InstanceGraphBase;
+  friend class InstanceGraph;
   friend class InstanceGraphNode;
 
-  InstanceRecord(InstanceGraphNode *parent, HWInstanceLike instance,
+  InstanceRecord(InstanceGraphNode *parent, InstanceOpInterface instance,
                  InstanceGraphNode *target)
       : parent(parent), instance(instance), target(target) {}
   InstanceRecord(const InstanceRecord &) = delete;
@@ -76,7 +85,7 @@ private:
   InstanceGraphNode *parent;
 
   /// The InstanceLike that this is tracking.
-  HWInstanceLike instance;
+  InstanceOpInterface instance;
 
   /// This is the module which the instance-like is instantiating.
   InstanceGraphNode *target;
@@ -96,7 +105,12 @@ public:
   InstanceGraphNode() : module(nullptr) {}
 
   /// Get the module that this node is tracking.
-  HWModuleLike getModule() const { return module; }
+  template <typename TTarget = ModuleOpInterface>
+  auto getModule() {
+    if constexpr (std::is_same<TTarget, ModuleOpInterface>::value)
+      return module;
+    return cast<TTarget>(module.getOperation());
+  }
 
   /// Iterate the instance records in this module.
   using iterator = detail::AddressIterator<InstanceList::iterator>;
@@ -143,7 +157,7 @@ public:
 
   /// Record a new instance op in the body of this module. Returns a newly
   /// allocated InstanceRecord which will be owned by this node.
-  InstanceRecord *addInstance(HWInstanceLike instance,
+  InstanceRecord *addInstance(InstanceOpInterface instance,
                               InstanceGraphNode *target);
 
 private:
@@ -155,7 +169,7 @@ private:
   void recordUse(InstanceRecord *record);
 
   /// The module.
-  HWModuleLike module;
+  ModuleOpInterface module;
 
   /// List of instance operations in this module.  This member owns the
   /// InstanceRecords, which may be pointed to by other InstanceGraphNode's use
@@ -166,7 +180,7 @@ private:
   InstanceRecord *firstUse = nullptr;
 
   // Provide access to the constructor.
-  friend class InstanceGraphBase;
+  friend class InstanceGraph;
 };
 
 /// This graph tracks modules and where they are instantiated. This is intended
@@ -175,29 +189,32 @@ private:
 ///
 /// To use this class, retrieve a cached copy from the analysis manager:
 ///   auto &instanceGraph = getAnalysis<InstanceGraph>(getOperation());
-class InstanceGraphBase {
+class InstanceGraph {
   /// This is the list of InstanceGraphNodes in the graph.
   using NodeList = llvm::iplist<InstanceGraphNode>;
 
 public:
-  virtual ~InstanceGraphBase();
+  virtual ~InstanceGraph();
 
   /// Look up an InstanceGraphNode for a module.
-  InstanceGraphNode *lookup(HWModuleLike op);
+  InstanceGraphNode *lookup(ModuleOpInterface op);
 
   /// Lookup an module by name.
   InstanceGraphNode *lookup(StringAttr name);
 
   /// Lookup an InstanceGraphNode for a module.
-  InstanceGraphNode *operator[](HWModuleLike op) { return lookup(op); }
+  InstanceGraphNode *operator[](ModuleOpInterface op) { return lookup(op); }
 
   /// Look up the referenced module from an InstanceOp. This will use a
   /// hashtable lookup to find the module, where
   /// InstanceOp.getReferencedModule() will be a linear search through the IR.
-  HWModuleLike getReferencedModule(HWInstanceLike op);
+  template <typename TTarget = ModuleOpInterface>
+  auto getReferencedModule(InstanceOpInterface op) {
+    return cast<TTarget>(getReferencedModuleImpl(op).getOperation());
+  }
 
   /// Check if child is instantiated by a parent.
-  bool isAncestor(HWModuleLike child, HWModuleLike parent);
+  bool isAncestor(ModuleOpInterface child, ModuleOpInterface parent);
 
   /// Get the node corresponding to the top-level module of a circuit.
   virtual InstanceGraphNode *getTopLevelNode() = 0;
@@ -210,8 +227,8 @@ public:
   Operation *getParent() { return parent; }
 
   /// Returns pointer to member of operation list.
-  static NodeList InstanceGraphBase::*getSublistAccess(Operation *) {
-    return &InstanceGraphBase::nodes;
+  static NodeList InstanceGraph::*getSublistAccess(Operation *) {
+    return &InstanceGraph::nodes;
   }
 
   /// Iterate through all modules.
@@ -228,7 +245,7 @@ public:
   // on a CircuitOp or a ModuleOp.
 
   /// Add a newly created module to the instance graph.
-  virtual InstanceGraphNode *addModule(HWModuleLike module);
+  virtual InstanceGraphNode *addModule(ModuleOpInterface module);
 
   /// Remove this module from the instance graph. This will also remove all
   /// InstanceRecords in this module.  All instances of this module must have
@@ -237,13 +254,16 @@ public:
 
   /// Replaces an instance of a module with another instance. The target module
   /// of both InstanceOps must be the same.
-  virtual void replaceInstance(HWInstanceLike inst, HWInstanceLike newInst);
+  virtual void replaceInstance(InstanceOpInterface inst,
+                               InstanceOpInterface newInst);
 
 protected:
   /// Create a new module graph of a circuit.  Must be called on the parent
-  /// operation of HWModuleLike ops.
-  InstanceGraphBase(Operation *parent);
-  InstanceGraphBase(const InstanceGraphBase &) = delete;
+  /// operation of ModuleOpInterface ops.
+  InstanceGraph(Operation *parent);
+  InstanceGraph(const InstanceGraph &) = delete;
+
+  ModuleOpInterface getReferencedModuleImpl(InstanceOpInterface op);
 
   /// Get the node corresponding to the module.  If the node has does not exist
   /// yet, it will be created.
@@ -263,7 +283,7 @@ protected:
 };
 
 /// An absolute instance path.
-using InstancePath = ArrayRef<HWInstanceLike>;
+using InstancePath = ArrayRef<InstanceOpInterface>;
 
 template <typename T>
 inline static T &formatInstancePath(T &into, const InstancePath &path) {
@@ -283,14 +303,14 @@ static T &operator<<(T &os, const InstancePath &path) {
 /// in the IR.
 struct InstancePathCache {
   /// The instance graph of the IR.
-  InstanceGraphBase &instanceGraph;
+  InstanceGraph &instanceGraph;
 
-  explicit InstancePathCache(InstanceGraphBase &instanceGraph)
+  explicit InstancePathCache(InstanceGraph &instanceGraph)
       : instanceGraph(instanceGraph) {}
-  ArrayRef<InstancePath> getAbsolutePaths(HWModuleLike op);
+  ArrayRef<InstancePath> getAbsolutePaths(ModuleOpInterface op);
 
   /// Replace an InstanceOp. This is required to keep the cache updated.
-  void replaceInstance(HWInstanceLike oldOp, HWInstanceLike newOp);
+  void replaceInstance(InstanceOpInterface oldOp, InstanceOpInterface newOp);
 
 private:
   /// An allocator for individual instance paths and entire path lists.
@@ -300,20 +320,20 @@ private:
   DenseMap<Operation *, ArrayRef<InstancePath>> absolutePathsCache;
 
   /// Append an instance to a path.
-  InstancePath appendInstance(InstancePath path, HWInstanceLike inst);
+  InstancePath appendInstance(InstancePath path, InstanceOpInterface inst);
 };
 
-} // namespace hw
+} // namespace igraph
 } // namespace circt
 
 // Graph traits for modules.
 template <>
-struct llvm::GraphTraits<circt::hw::InstanceGraphNode *> {
-  using NodeType = circt::hw::InstanceGraphNode;
+struct llvm::GraphTraits<circt::igraph::InstanceGraphNode *> {
+  using NodeType = circt::igraph::InstanceGraphNode;
   using NodeRef = NodeType *;
 
   // Helper for getting the module referenced by the instance op.
-  static NodeRef getChild(const circt::hw::InstanceRecord *record) {
+  static NodeRef getChild(const circt::igraph::InstanceRecord *record) {
     return record->getTarget();
   }
 
@@ -331,12 +351,12 @@ struct llvm::GraphTraits<circt::hw::InstanceGraphNode *> {
 
 // Provide graph traits for iterating the modules in inverse order.
 template <>
-struct llvm::GraphTraits<llvm::Inverse<circt::hw::InstanceGraphNode *>> {
-  using NodeType = circt::hw::InstanceGraphNode;
+struct llvm::GraphTraits<llvm::Inverse<circt::igraph::InstanceGraphNode *>> {
+  using NodeType = circt::igraph::InstanceGraphNode;
   using NodeRef = NodeType *;
 
   // Helper for getting the module containing the instance op.
-  static NodeRef getParent(const circt::hw::InstanceRecord *record) {
+  static NodeRef getParent(const circt::igraph::InstanceRecord *record) {
     return record->getParent();
   }
 
@@ -356,39 +376,39 @@ struct llvm::GraphTraits<llvm::Inverse<circt::hw::InstanceGraphNode *>> {
 
 // Graph traits for the common instance graph.
 template <>
-struct llvm::GraphTraits<circt::hw::InstanceGraphBase *>
-    : public llvm::GraphTraits<circt::hw::InstanceGraphNode *> {
-  using nodes_iterator = circt::hw::InstanceGraphBase::iterator;
+struct llvm::GraphTraits<circt::igraph::InstanceGraph *>
+    : public llvm::GraphTraits<circt::igraph::InstanceGraphNode *> {
+  using nodes_iterator = circt::igraph::InstanceGraph::iterator;
 
-  static NodeRef getEntryNode(circt::hw::InstanceGraphBase *graph) {
+  static NodeRef getEntryNode(circt::igraph::InstanceGraph *graph) {
     return graph->getTopLevelNode();
   }
   // NOLINTNEXTLINE(readability-identifier-naming)
-  static nodes_iterator nodes_begin(circt::hw::InstanceGraphBase *graph) {
+  static nodes_iterator nodes_begin(circt::igraph::InstanceGraph *graph) {
     return graph->begin();
   }
   // NOLINTNEXTLINE(readability-identifier-naming)
-  static nodes_iterator nodes_end(circt::hw::InstanceGraphBase *graph) {
+  static nodes_iterator nodes_end(circt::igraph::InstanceGraph *graph) {
     return graph->end();
   }
 };
 
 // Graph traits for DOT labeling.
 template <>
-struct llvm::DOTGraphTraits<circt::hw::InstanceGraphBase *>
+struct llvm::DOTGraphTraits<circt::igraph::InstanceGraph *>
     : public llvm::DefaultDOTGraphTraits {
   using DefaultDOTGraphTraits::DefaultDOTGraphTraits;
 
-  static std::string getNodeLabel(circt::hw::InstanceGraphNode *node,
-                                  circt::hw::InstanceGraphBase *) {
+  static std::string getNodeLabel(circt::igraph::InstanceGraphNode *node,
+                                  circt::igraph::InstanceGraph *) {
     // The name of the graph node is the module name.
     return node->getModule().getModuleName().str();
   }
 
   template <typename Iterator>
-  static std::string getEdgeAttributes(const circt::hw::InstanceGraphNode *node,
-                                       Iterator it,
-                                       circt::hw::InstanceGraphBase *) {
+  static std::string
+  getEdgeAttributes(const circt::igraph::InstanceGraphNode *node, Iterator it,
+                    circt::igraph::InstanceGraph *) {
     // Set an edge label that is the name of the instance.
     auto *instanceRecord = *it.getCurrent();
     auto instanceOp = instanceRecord->getInstance();
@@ -396,4 +416,4 @@ struct llvm::DOTGraphTraits<circt::hw::InstanceGraphBase *>
   }
 };
 
-#endif // CIRCT_DIALECT_HW_INSTANCEGRAPHBASE_H
+#endif // CIRCT_SUPPORT_INSTANCEGRAPH_H

--- a/include/circt/Support/InstanceGraphInterface.h
+++ b/include/circt/Support/InstanceGraphInterface.h
@@ -1,0 +1,23 @@
+//===- InstanceGraphInterface.h - Instance graph interface ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares stuff related to the instance graph interface.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_INSTANCEGRAPHINTERFACE_H
+#define CIRCT_SUPPORT_INSTANCEGRAPHINTERFACE_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/OpDefinition.h"
+
+/// The InstanceGraph op interface, see InstanceGraphInterface.td for more
+/// details.
+#include "circt/Support/InstanceGraphInterface.h.inc"
+
+#endif // CIRCT_SUPPORT_INSTANCEGRAPHINTERFACE_H

--- a/include/circt/Support/InstanceGraphInterface.td
+++ b/include/circt/Support/InstanceGraphInterface.td
@@ -40,8 +40,14 @@ def InstanceGraphInstanceOpInterface : OpInterface<"InstanceOpInterface"> {
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getModuleNameAttr().getAttr(); }]>,
 
-    InterfaceMethod<"Get the referenced module",
-    "::mlir::Operation *", "getReferencedModule", (ins)>,
+    InterfaceMethod<[{
+      Get the referenced module (slow, unsafe).  This function directly accesses 
+      the parent operation to lookup a symbol, which is unsafe in many contexts.
+    }],
+    "::mlir::Operation *", "getReferencedModuleSlow", (ins)>,
+
+    InterfaceMethod<"Get the referenced module via a symbol table.",
+    "::mlir::Operation *", "getReferencedModule", (ins "SymbolTable&":$symtbl)>,
   ];
 }
 

--- a/include/circt/Support/InstanceGraphInterface.td
+++ b/include/circt/Support/InstanceGraphInterface.td
@@ -1,0 +1,67 @@
+//===- InstanceGraphInterface.td - Interface for instance graphs --------*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains interfaces and other utilities for interacting with the
+// generic CIRCT instance graph.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_SUPPORT_INSTANCEGRAPH_INSTANCEGRAPHINTERFACE_TD
+#define CIRCT_SUPPORT_INSTANCEGRAPH_INSTANCEGRAPHINTERFACE_TD
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/OpBase.td"
+
+def InstanceGraphInstanceOpInterface : OpInterface<"InstanceOpInterface"> {
+  let description = [{
+    This interface provides hooks for an instance-like operation.
+  }];
+  let cppNamespace = "::circt::igraph";
+
+  let methods = [
+    InterfaceMethod<"Get the name of the instance",
+    "::llvm::StringRef", "getInstanceName", (ins)>,
+
+    InterfaceMethod<"Get the name of the instance",
+    "::mlir::StringAttr", "getInstanceNameAttr", (ins)>,
+
+    InterfaceMethod<"Get the name of the instantiated module",
+    "::llvm::StringRef", "getReferencedModuleName", (ins),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{ return $_op.getModuleName(); }]>,
+
+    InterfaceMethod<"Get the name of the instantiated module",
+    "::mlir::StringAttr", "getReferencedModuleNameAttr", (ins),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{ return $_op.getModuleNameAttr().getAttr(); }]>,
+
+    InterfaceMethod<"Get the referenced module",
+    "::mlir::Operation *", "getReferencedModule", (ins)>,
+  ];
+}
+
+def InstanceGraphModuleOpInterface : OpInterface<"ModuleOpInterface"> {
+  let description = [{
+    This interface provides hooks for a module-like operation.
+  }];
+  let cppNamespace = "::circt::igraph";
+
+  let methods = [
+    InterfaceMethod<"Get the module name",
+    "::llvm::StringRef", "getModuleName", (ins),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{ return $_op.getName(); }]>,
+
+    InterfaceMethod<"Get the module name",
+    "::mlir::StringAttr", "getModuleNameAttr", (ins),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{ return $_op.getNameAttr(); }]>,
+  ];
+}
+
+#endif // CIRCT_SUPPORT_INSTANCEGRAPH_INSTANCEGRAPHINTERFACE_TD

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Affine/IR/AffineMemoryOpInterfaces.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/Support/Debug.h"
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4616,7 +4616,8 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
   ps << PP::nbsp << PPExtString(getSymOpName(op)) << " (";
 
   auto instPortInfo = op.getPortList();
-  auto modPortInfo = cast<PortList>(op.getReferencedModule()).getPortList();
+  auto modPortInfo =
+      cast<PortList>(op.getReferencedModule(&state.symbolCache)).getPortList();
   // Get the max port name length so we can align the '('.
   size_t maxNameLength = 0;
   for (auto &elt : modPortInfo) {

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -322,7 +322,7 @@ static LogicalResult convertExtMemoryOps(HWModuleOp mod) {
     // Get the attached extmemory external module.
     auto extmemInstance = cast<hw::InstanceOp>(*arg.getUsers().begin());
     auto extmemMod =
-        cast<hw::HWModuleExternOp>(extmemInstance.getReferencedModule());
+        cast<hw::HWModuleExternOp>(extmemInstance.getReferencedModuleSlow());
     auto portInfo = extmemMod.getPortList();
 
     // The extmemory external module's interface is a direct wrapping of the

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -36,7 +36,7 @@ static constexpr std::string_view kValidPortName = "valid";
 // inlined module(!). Should probably implement some more generic inlining code
 // for this, but it's simple enough to do when we know that the module is empty.
 static void inlineAndEraseIfEmpty(hw::InstanceOp inst) {
-  auto mod = cast<hw::HWModuleLike>(inst.getReferencedModule());
+  auto mod = cast<hw::HWModuleLike>(inst.getReferencedModuleSlow());
   if (mod->getNumRegions() == 0)
     return; // Nothing to do.
 

--- a/lib/Dialect/Arc/Transforms/InlineModules.cpp
+++ b/lib/Dialect/Arc/Transforms/InlineModules.cpp
@@ -19,6 +19,7 @@
 using namespace circt;
 using namespace arc;
 using namespace hw;
+using namespace igraph;
 using mlir::InlinerInterface;
 
 namespace {
@@ -79,7 +80,7 @@ struct PrefixingInliner : public InlinerInterface {
 } // namespace
 
 void InlineModulesPass::runOnOperation() {
-  auto &instanceGraph = getAnalysis<InstanceGraph>();
+  auto &instanceGraph = getAnalysis<hw::InstanceGraph>();
   DenseSet<Operation *> handled;
 
   // Iterate over all instances in the instance graph. This ensures we visit

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -240,9 +240,9 @@ firrtl::resolveEntities(TokenAnnoTarget path, CircuitOp circuit,
   ArrayRef<TargetToken> component(path.component);
   if (auto instance = dyn_cast<InstanceOp>(ref.getOp())) {
     instances.push_back(instance);
-    auto target = instance.getReferencedModule(symTbl);
+    auto target = cast<FModuleLike>(instance.getReferencedModule(symTbl));
     if (component.empty()) {
-      ref = OpAnnoTarget(instance.getReferencedModule(symTbl));
+      ref = OpAnnoTarget(target);
     } else if (component.front().isIndex) {
       mlir::emitError(circuit.getLoc())
           << "illegal target '" << path.str() << "' indexes into an instance";

--- a/lib/Dialect/FIRRTL/FIRRTLInstanceGraph.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLInstanceGraph.cpp
@@ -21,7 +21,7 @@ static CircuitOp findCircuitOp(Operation *operation) {
 }
 
 InstanceGraph::InstanceGraph(Operation *operation)
-    : InstanceGraphBase(findCircuitOp(operation)) {
+    : igraph::InstanceGraph(findCircuitOp(operation)) {
   topLevelNode = lookup(cast<CircuitOp>(getParent()).getNameAttr());
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1635,7 +1635,7 @@ BlockArgument ClassOp::getArgument(size_t portNumber) {
 
 /// Lookup the module or extmodule for the symbol.  This returns null on
 /// invalid IR.
-Operation *InstanceOp::getReferencedModule() {
+Operation *InstanceOp::getReferencedModuleSlow() {
   auto circuit = (*this)->getParentOfType<CircuitOp>();
   if (!circuit)
     return nullptr;
@@ -1644,12 +1644,11 @@ Operation *InstanceOp::getReferencedModule() {
 }
 
 hw::ModulePortInfo InstanceOp::getPortList() {
-  return cast<hw::PortList>(getReferencedModule()).getPortList();
+  return cast<hw::PortList>(getReferencedModuleSlow()).getPortList();
 }
 
-FModuleLike InstanceOp::getReferencedModule(SymbolTable &symbolTable) {
-  return symbolTable.lookup<FModuleLike>(
-      getModuleNameAttr().getLeafReference());
+Operation *InstanceOp::getReferencedModule(SymbolTable &symbolTable) {
+  return symbolTable.lookup(getModuleNameAttr().getLeafReference());
 }
 
 void InstanceOp::build(OpBuilder &builder, OperationState &result,

--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -1034,7 +1034,7 @@ struct ModuleNameSanitizer : OpReduction<firrtl::CircuitOp> {
     circuitOp.setName(circuitName);
 
     for (auto *node : iGraph) {
-      auto module = node->getModule();
+      auto module = node->getModule<firrtl::FModuleLike>();
 
       bool shouldReplacePorts = false;
       SmallVector<Attribute> newNames;

--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -67,8 +67,7 @@ findInstantiatedModule(firrtl::InstanceOp instOp,
                        ::detail::SymbolCache &symbols) {
   auto *tableOp = SymbolTable::getNearestSymbolTable(instOp);
   auto moduleOp = dyn_cast<firrtl::FModuleOp>(
-      instOp.getReferencedModule(symbols.getSymbolTable(tableOp))
-          .getOperation());
+      instOp.getReferencedModule(symbols.getSymbolTable(tableOp)));
   return moduleOp ? std::optional(moduleOp) : std::nullopt;
 }
 
@@ -338,8 +337,8 @@ struct InstanceStubber : public OpReduction<firrtl::InstanceOp> {
       auto *op = worklist.pop_back_val();
       auto *tableOp = SymbolTable::getNearestSymbolTable(op);
       op->walk([&](firrtl::InstanceOp instOp) {
-        auto moduleOp =
-            instOp.getReferencedModule(symbols.getSymbolTable(tableOp));
+        auto moduleOp = cast<firrtl::FModuleLike>(
+            instOp.getReferencedModule(symbols.getSymbolTable(tableOp)));
         deadInsts.insert(instOp);
         if (llvm::all_of(
                 symbols.getSymbolUserMap(tableOp).getUsers(moduleOp),
@@ -385,7 +384,8 @@ struct InstanceStubber : public OpReduction<firrtl::InstanceOp> {
       result.replaceAllUsesWith(wire);
     }
     auto *tableOp = SymbolTable::getNearestSymbolTable(instOp);
-    auto moduleOp = instOp.getReferencedModule(symbols.getSymbolTable(tableOp));
+    auto moduleOp = cast<firrtl::FModuleLike>(
+        instOp.getReferencedModule(symbols.getSymbolTable(tableOp)));
     nlaRemover.markNLAsInOperation(instOp);
     erasedInsts.insert(instOp);
     if (llvm::all_of(
@@ -662,7 +662,8 @@ struct ExtmoduleInstanceRemover : public OpReduction<firrtl::InstanceOp> {
   }
   LogicalResult rewrite(firrtl::InstanceOp instOp) override {
     auto portInfo =
-        instOp.getReferencedModule(symbols.getNearestSymbolTable(instOp))
+        cast<firrtl::FModuleLike>(
+            instOp.getReferencedModule(symbols.getNearestSymbolTable(instOp)))
             .getPorts();
     ImplicitLocOpBuilder builder(instOp.getLoc(), instOp);
     SmallVector<Value> replacementWires;
@@ -895,7 +896,7 @@ struct EagerInliner : public OpReduction<firrtl::InstanceOp> {
   uint64_t match(firrtl::InstanceOp instOp) override {
     auto *tableOp = SymbolTable::getNearestSymbolTable(instOp);
     auto moduleOp = instOp.getReferencedModule(symbols.getSymbolTable(tableOp));
-    if (!isa<firrtl::FModuleOp>(moduleOp.getOperation()))
+    if (!isa<firrtl::FModuleOp>(moduleOp))
       return 0;
     return symbols.getSymbolUserMap(tableOp).getUsers(moduleOp).size() == 1;
   }
@@ -920,8 +921,7 @@ struct EagerInliner : public OpReduction<firrtl::InstanceOp> {
     }
     auto *tableOp = SymbolTable::getNearestSymbolTable(instOp);
     auto moduleOp = cast<firrtl::FModuleOp>(
-        instOp.getReferencedModule(symbols.getSymbolTable(tableOp))
-            .getOperation());
+        instOp.getReferencedModule(symbols.getSymbolTable(tableOp)));
     for (auto &op : llvm::make_early_inc_range(*moduleOp.getBodyBlock())) {
       op.remove();
       builder.insert(&op);

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -422,7 +422,7 @@ void AddSeqMemPortsPass::runOnOperation() {
 
   // If there is an output file, create it.
   if (outputFile)
-    createOutputFile(dutNode->getModule());
+    createOutputFile(dutNode->getModule<hw::HWModuleLike>());
 
   if (anythingChanged)
     markAnalysesPreserved<InstanceGraph>();

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -33,7 +33,7 @@
 
 using namespace circt;
 using namespace firrtl;
-using circt::hw::InstancePath;
+using circt::igraph::InstancePath;
 
 namespace {
 
@@ -337,7 +337,7 @@ CreateSiFiveMetadataPass::emitMemoryMetadata(ObjectModelIR &omir) {
           // situation where everything is deemed to be "in the DUT", i.e., when
           // the DUT is the top module or when no DUT is specified.
           if (everythingInDUT ||
-              llvm::any_of(p, [&](circt::hw::HWInstanceLike inst) {
+              llvm::any_of(p, [&](circt::igraph::InstanceOpInterface inst) {
                 return inst.getReferencedModule() == dutMod;
               }))
             jsonStream.value(hierName);
@@ -619,9 +619,10 @@ void CreateSiFiveMetadataPass::runOnOperation() {
     dutMod = dyn_cast<FModuleOp>(*it);
     auto &instanceGraph = getAnalysis<InstanceGraph>();
     auto *node = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
-    llvm::for_each(llvm::depth_first(node), [&](hw::InstanceGraphNode *node) {
-      dutModuleSet.insert(node->getModule());
-    });
+    llvm::for_each(llvm::depth_first(node),
+                   [&](igraph::InstanceGraphNode *node) {
+                     dutModuleSet.insert(node->getModule());
+                   });
   }
   ObjectModelIR omir(moduleOp);
 

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -338,7 +338,8 @@ CreateSiFiveMetadataPass::emitMemoryMetadata(ObjectModelIR &omir) {
           // the DUT is the top module or when no DUT is specified.
           if (everythingInDUT ||
               llvm::any_of(p, [&](circt::igraph::InstanceOpInterface inst) {
-                return inst.getReferencedModule() == dutMod;
+                return inst.getReferencedModuleNameAttr() ==
+                       dutMod.getNameAttr();
               }))
             jsonStream.value(hierName);
         }

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -720,7 +720,8 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
   // the memory.
   hw::HWModuleLike mod;
   if (tracker.nla)
-    mod = instanceGraph->lookup(tracker.nla.root())->getModule();
+    mod = instanceGraph->lookup(tracker.nla.root())
+              ->getModule<hw::HWModuleLike>();
   else
     mod = tracker.op->getParentOfType<FModuleOp>();
 
@@ -759,8 +760,8 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
       auto ref = attr.cast<hw::InnerRefAttr>();
       // Find the instance referenced by the NLA.
       auto *node = instanceGraph->lookup(ref.getModule());
-      auto it = llvm::find_if(*node, [&](hw::InstanceRecord *record) {
-        return getInnerSymName(cast<InstanceOp>(*record->getInstance())) ==
+      auto it = llvm::find_if(*node, [&](igraph::InstanceRecord *record) {
+        return getInnerSymName(record->getInstance<InstanceOp>()) ==
                ref.getName();
       });
       assert(it != node->end() &&

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1742,7 +1742,7 @@ void GrandCentralPass::runOnOperation() {
       i.skipChildren();
       continue;
     }
-    dutModules.insert(i->getModule());
+    dutModules.insert(i->getModule<hw::HWModuleLike>());
     // Manually increment the iterator to avoid walking off the end from
     // skipChildren.
     ++i;
@@ -1941,7 +1941,7 @@ void GrandCentralPass::runOnOperation() {
                 auto *modNode = instancePaths->instanceGraph.lookup(mod);
                 SmallVector<InstanceRecord *> instances(modNode->uses());
                 if (modNode != companionNode &&
-                    dutModules.count(modNode->getModule()))
+                    dutModules.count(modNode->getModule<hw::HWModuleLike>()))
                   continue;
 
                 LLVM_DEBUG({

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -10,6 +10,7 @@
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/InnerSymbolTable.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Threading.h"

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -26,6 +26,7 @@
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVAttributes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "llvm/ADT/APSInt.h"
@@ -930,11 +931,11 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
              << "\" must be passive (no flips) when using references";
 
     // Record module modifications related to adding ports to modules.
-    auto addPorts = [&](ArrayRef<hw::HWInstanceLike> insts, Value val, Type tpe,
-                        Direction dir) {
+    auto addPorts = [&](ArrayRef<igraph::InstanceOpInterface> insts, Value val,
+                        Type tpe, Direction dir) {
       StringRef name, instName;
       for (auto inst : llvm::reverse(insts)) {
-        auto mod = cast<FModuleOp>(instanceGraph.getReferencedModule(inst));
+        auto mod = instanceGraph.getReferencedModule<FModuleOp>(inst);
         if (name.empty()) {
           if (problem.newNameHint.empty())
             name = state.getNamespace(mod).newName(

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -20,6 +20,7 @@
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/StringExtras.h"

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Dialect/Seq/SeqAttributes.h"
 #include "mlir/IR/Dominance.h"
@@ -523,7 +524,7 @@ void LowerMemoryPass::runOnOperation() {
 
   // The set of all modules underneath the design under test module.
   DenseSet<Operation *> dutModuleSet;
-  llvm::for_each(llvm::depth_first(dut), [&](hw::InstanceGraphNode *node) {
+  llvm::for_each(llvm::depth_first(dut), [&](igraph::InstanceGraphNode *node) {
     dutModuleSet.insert(node->getModule());
   });
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1387,8 +1387,8 @@ bool TypeLoweringVisitor::visitDecl(InstanceOp op) {
   SmallVector<Direction> newDirs;
   SmallVector<Attribute> newNames;
   SmallVector<Attribute> newPortAnno;
-  PreserveAggregate::PreserveMode mode =
-      getPreservationModeForModule(op.getReferencedModule(symTbl));
+  PreserveAggregate::PreserveMode mode = getPreservationModeForModule(
+      cast<FModuleLike>(op.getReferencedModule(symTbl)));
 
   endFields.push_back(0);
   for (size_t i = 0, e = op.getNumResults(); i != e; ++i) {

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -49,9 +49,10 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     if (it != body->end()) {
       auto &instanceGraph = getAnalysis<InstanceGraph>();
       auto *node = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
-      llvm::for_each(llvm::depth_first(node), [&](hw::InstanceGraphNode *node) {
-        dutModuleSet.insert(node->getModule());
-      });
+      llvm::for_each(llvm::depth_first(node),
+                     [&](igraph::InstanceGraphNode *node) {
+                       dutModuleSet.insert(node->getModule());
+                     });
     } else {
       auto mods = circtOp.getOps<FModuleOp>();
       dutModuleSet.insert(mods.begin(), mods.end());

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -281,10 +281,6 @@ LogicalResult TriggerOp::verify() { return verifyCallerTypes(*this); }
 //===----------------------------------------------------------------------===//
 
 // HWInstanceLike interface
-StringRef HWInstanceOp::getInstanceName() { return getSymName(); }
-
-StringAttr HWInstanceOp::getInstanceNameAttr() { return getSymNameAttr(); }
-
 Operation *HWInstanceOp::getReferencedModule() { return getMachineOp(); }
 
 /// Lookup the machine for the symbol.  This returns null on invalid IR.

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -281,7 +281,11 @@ LogicalResult TriggerOp::verify() { return verifyCallerTypes(*this); }
 //===----------------------------------------------------------------------===//
 
 // HWInstanceLike interface
-Operation *HWInstanceOp::getReferencedModule() { return getMachineOp(); }
+Operation *HWInstanceOp::getReferencedModuleSlow() { return getMachineOp(); }
+
+Operation *HWInstanceOp::getReferencedModule(SymbolTable &symtbl) {
+  return symtbl.lookup(getMachineAttr().getValue());
+}
 
 /// Lookup the machine for the symbol.  This returns null on invalid IR.
 MachineOp HWInstanceOp::getMachineOp() {

--- a/lib/Dialect/HW/CMakeLists.txt
+++ b/lib/Dialect/HW/CMakeLists.txt
@@ -7,7 +7,6 @@ set(CIRCT_HW_Sources
   HWOps.cpp
   HWTypeInterfaces.cpp
   HWTypes.cpp
-  InstanceGraphBase.cpp
   InstanceImplementation.cpp
   ModuleImplementation.cpp
   InnerSymbolTable.cpp

--- a/lib/Dialect/HW/HWInstanceGraph.cpp
+++ b/lib/Dialect/HW/HWInstanceGraph.cpp
@@ -12,23 +12,24 @@ using namespace circt;
 using namespace hw;
 
 InstanceGraph::InstanceGraph(Operation *operation)
-    : InstanceGraphBase(operation) {
+    : igraph::InstanceGraph(operation) {
   for (auto &node : nodes)
-    if (node.getModule().isPublic())
+    if (cast<HWModuleLike>(node.getModule().getOperation()).isPublic())
       entry.addInstance({}, &node);
 }
 
-InstanceGraphNode *InstanceGraph::addModule(HWModuleLike module) {
-  auto *node = InstanceGraphBase::addModule(module);
+igraph::InstanceGraphNode *InstanceGraph::addHWModule(HWModuleLike module) {
+  auto *node = igraph::InstanceGraph::addModule(
+      cast<igraph::ModuleOpInterface>(module.getOperation()));
   if (module.isPublic())
     entry.addInstance({}, node);
   return node;
 }
 
-void InstanceGraph::erase(InstanceGraphNode *node) {
+void InstanceGraph::erase(igraph::InstanceGraphNode *node) {
   for (auto *instance : llvm::make_early_inc_range(entry)) {
     if (instance->getTarget() == node)
       instance->erase();
   }
-  InstanceGraphBase::erase(node);
+  igraph::InstanceGraph::erase(node);
 }

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1501,7 +1501,11 @@ Operation *InstanceOp::getReferencedModule(const HWSymbolCache *cache) {
                                                  getModuleNameAttr());
 }
 
-Operation *InstanceOp::getReferencedModule() {
+Operation *InstanceOp::getReferencedModule(SymbolTable &symtbl) {
+  return symtbl.lookup(getModuleNameAttr().getValue());
+}
+
+Operation *InstanceOp::getReferencedModuleSlow() {
   return getReferencedModule(/*cache=*/nullptr);
 }
 

--- a/lib/Dialect/HW/HWReductions.cpp
+++ b/lib/Dialect/HW/HWReductions.cpp
@@ -28,14 +28,15 @@ struct ModuleSizeCache {
   void clear() { moduleSizes.clear(); }
 
   uint64_t getModuleSize(HWModuleLike module,
-                         InstanceGraphBase &instanceGraph) {
+                         hw::InstanceGraph &instanceGraph) {
     if (auto it = moduleSizes.find(module); it != moduleSizes.end())
       return it->second;
     uint64_t size = 1;
     module->walk([&](Operation *op) {
       size += 1;
       if (auto instOp = dyn_cast<HWInstanceLike>(op))
-        if (auto instModule = instanceGraph.getReferencedModule(instOp))
+        if (auto instModule =
+                instanceGraph.getReferencedModule<hw::HWModuleLike>(instOp))
           size += getModuleSize(instModule, instanceGraph);
     });
     moduleSizes.insert({module, size});

--- a/lib/Dialect/HW/PortConverter.cpp
+++ b/lib/Dialect/HW/PortConverter.cpp
@@ -170,7 +170,7 @@ LogicalResult PortConverterImpl::run() {
 
   // Rewrite instances pointing to this module.
   for (auto *instance : moduleNode->uses()) {
-    hw::HWInstanceLike instanceLike = instance->getInstance();
+    auto instanceLike = instance->getInstance<hw::HWInstanceLike>();
     if (!instanceLike)
       continue;
     hw::InstanceOp hwInstance = dyn_cast_or_null<hw::InstanceOp>(*instanceLike);

--- a/lib/Dialect/HW/Transforms/FlattenIO.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenIO.cpp
@@ -98,7 +98,7 @@ struct InstanceOpConversion : public OpConversionPattern<hw::InstanceOp> {
 
     // Create the new instance...
     auto newInstance = rewriter.create<hw::InstanceOp>(
-        loc, op.getReferencedModule(), op.getInstanceName(), convOperands);
+        loc, op.getReferencedModuleSlow(), op.getInstanceName(), convOperands);
 
     // re-create any structs in the result.
     llvm::SmallVector<Value> convResults;
@@ -367,7 +367,7 @@ static LogicalResult flattenOpsOfType(ModuleOp module, bool recursive) {
 
     // And likewise with the converted instance ops.
     for (auto instanceOp : convertedInstances) {
-      Operation *targetModule = instanceOp.getReferencedModule();
+      Operation *targetModule = instanceOp.getReferencedModuleSlow();
       auto ioInfo = ioInfoMap[targetModule];
       updateNameAttribute(instanceOp, "argNames", ioInfo.argStructs);
       updateNameAttribute(instanceOp, "resultNames", ioInfo.resStructs);

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -387,13 +387,6 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return success();
 }
 
-/// Instance name is the same as the symbol name. This may change in the
-/// future.
-StringRef InstanceOp::getInstanceName() { return *getInnerName(); }
-StringAttr InstanceOp::getInstanceNameAttr() { return getInnerNameAttr(); }
-
-/// Lookup the module or extmodule for the symbol.  This returns null on
-/// invalid IR.
 Operation *InstanceOp::getReferencedModule() {
   auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
   if (!topLevelModuleOp)

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -387,19 +387,23 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return success();
 }
 
-Operation *InstanceOp::getReferencedModule() {
+Operation *InstanceOp::getReferencedModuleSlow() {
   auto topLevelModuleOp = (*this)->getParentOfType<ModuleOp>();
   if (!topLevelModuleOp)
     return nullptr;
   return topLevelModuleOp.lookupSymbol(getModuleName());
 }
 
+Operation *InstanceOp::getReferencedModule(SymbolTable &symtbl) {
+  return symtbl.lookup(getModuleNameAttr().getValue());
+}
+
 hw::ModulePortInfo InstanceOp::getPortList() {
-  return cast<hw::PortList>(getReferencedModule()).getPortList();
+  return cast<hw::PortList>(getReferencedModuleSlow()).getPortList();
 }
 
 StringAttr InstanceOp::getResultName(size_t idx) {
-  if (auto *refMod = getReferencedModule())
+  if (auto *refMod = getReferencedModuleSlow())
     return hw::getModuleResultNameAttr(refMod, idx);
   return StringAttr();
 }

--- a/lib/Dialect/MSFT/Transforms/MSFTPartition.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTPartition.cpp
@@ -588,7 +588,7 @@ void PartitionPass::bubbleUp(MSFTModuleOp mod, Block *partBlock) {
       Operation *newOp = b.insert(op.clone(map));
       newOps.push_back(newOp);
       setEntityName(newOp, oldInst.getInstanceName() + "." + ::getOpName(&op));
-      auto *oldInstMod = oldInst.getReferencedModule();
+      auto *oldInstMod = oldInst.getReferencedModuleSlow();
       assert(oldInstMod);
       auto oldModName = oldInstMod->getAttrOfType<StringAttr>("sym_name");
       bubbleUpGlobalRefs(newOp, oldModName, oldInst.getInstanceNameAttr(),

--- a/lib/Dialect/MSFT/Transforms/MSFTToHW.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTToHW.cpp
@@ -49,7 +49,7 @@ public:
 LogicalResult
 InstanceOpLowering::matchAndRewrite(InstanceOp msftInst, OpAdaptor adaptor,
                                     ConversionPatternRewriter &rewriter) const {
-  Operation *referencedModule = msftInst.getReferencedModule();
+  Operation *referencedModule = msftInst.getReferencedModuleSlow();
   if (!referencedModule)
     return rewriter.notifyMatchFailure(msftInst,
                                        "Could not find referenced module");

--- a/lib/Dialect/SV/Transforms/HWEliminateInOutPorts.cpp
+++ b/lib/Dialect/SV/Transforms/HWEliminateInOutPorts.cpp
@@ -18,6 +18,7 @@
 using namespace circt;
 using namespace sv;
 using namespace hw;
+using namespace igraph;
 
 namespace {
 

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -468,7 +468,11 @@ Operation *InstanceDeclOp::getReferencedModule(const hw::HWSymbolCache *cache) {
   return topLevelModuleOp.lookupSymbol(getModuleName());
 }
 
-Operation *InstanceDeclOp::getReferencedModule() {
+Operation *InstanceDeclOp::getReferencedModule(SymbolTable &symtbl) {
+  return symtbl.lookup(getModuleNameAttr().getValue());
+}
+
+Operation *InstanceDeclOp::getReferencedModuleSlow() {
   return getReferencedModule(/*cache=*/nullptr);
 }
 
@@ -536,7 +540,7 @@ InstanceDeclOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 hw::ModulePortInfo InstanceDeclOp::getPortList() {
-  return cast<hw::PortList>(getReferencedModule()).getPortList();
+  return cast<hw::PortList>(getReferencedModuleSlow()).getPortList();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/LogicalEquivalence/LogicExporter.cpp
+++ b/lib/LogicalEquivalence/LogicExporter.cpp
@@ -75,7 +75,7 @@ struct Visitor : public hw::StmtVisitor<Visitor, LogicalResult>,
 
   LogicalResult visitStmt(hw::InstanceOp op) {
     if (auto hwModule =
-            llvm::dyn_cast<hw::HWModuleOp>(op.getReferencedModule())) {
+            llvm::dyn_cast<hw::HWModuleOp>(op.getReferencedModuleSlow())) {
       circuit->addInstance(op.getInstanceName(), hwModule, op->getOperands(),
                            op->getResults());
       return success();

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -19,6 +19,7 @@ add_circt_library(CIRCTSupport
   PrettyPrinterHelpers.cpp
   SymCache.cpp
   ValueMapper.cpp
+  InstanceGraph.cpp
   "${VERSION_CPP}"
 
   LINK_LIBS PUBLIC

--- a/lib/Support/InstanceGraph.cpp
+++ b/lib/Support/InstanceGraph.cpp
@@ -119,8 +119,6 @@ InstanceGraph::getReferencedModuleImpl(InstanceOpInterface op) {
   return lookup(op.getReferencedModuleNameAttr())->getModule();
 }
 
-InstanceGraph::~InstanceGraph() {}
-
 void InstanceGraph::replaceInstance(InstanceOpInterface inst,
                                     InstanceOpInterface newInst) {
   assert(inst.getReferencedModuleName() == newInst.getReferencedModuleName() &&
@@ -224,6 +222,7 @@ InstanceGraph::getInferredTopLevelNodes() {
   return {inferredTopLevelNodes};
 }
 
+// NOLINTBEGIN(misc-no-recursion)
 ArrayRef<InstancePath>
 InstancePathCache::getAbsolutePaths(ModuleOpInterface op) {
   InstanceGraphNode *node = instanceGraph[op];
@@ -263,6 +262,7 @@ InstancePathCache::getAbsolutePaths(ModuleOpInterface op) {
   absolutePathsCache.insert({op, pathList});
   return pathList;
 }
+// NOLINTEND(misc-no-recursion)
 
 InstancePath InstancePathCache::appendInstance(InstancePath path,
                                                InstanceOpInterface inst) {

--- a/lib/Support/InstanceGraph.cpp
+++ b/lib/Support/InstanceGraph.cpp
@@ -1,4 +1,4 @@
-//===- InstanceGraphBase.cpp - Instance Graph -------------------*- C++ -*-===//
+//===- InstanceGraph.cpp - Instance Graph -----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "circt/Dialect/HW/InstanceGraphBase.h"
+#include "circt/Support/InstanceGraph.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Threading.h"
 
 using namespace circt;
-using namespace hw;
+using namespace igraph;
 
 void InstanceRecord::erase() {
   // Update the prev node to point to the next node.
@@ -25,7 +25,7 @@ void InstanceRecord::erase() {
   getParent()->instances.erase(this);
 }
 
-InstanceRecord *InstanceGraphNode::addInstance(HWInstanceLike instance,
+InstanceRecord *InstanceGraphNode::addInstance(InstanceOpInterface instance,
                                                InstanceGraphNode *target) {
   auto *instanceRecord = new InstanceRecord(this, instance, target);
   target->recordUse(instanceRecord);
@@ -40,7 +40,7 @@ void InstanceGraphNode::recordUse(InstanceRecord *record) {
   firstUse = record;
 }
 
-InstanceGraphNode *InstanceGraphBase::getOrAddNode(StringAttr name) {
+InstanceGraphNode *InstanceGraph::getOrAddNode(StringAttr name) {
   // Try to insert an InstanceGraphNode. If its not inserted, it returns
   // an iterator pointing to the node.
   auto *&node = nodeMap[name];
@@ -51,13 +51,14 @@ InstanceGraphNode *InstanceGraphBase::getOrAddNode(StringAttr name) {
   return node;
 }
 
-InstanceGraphBase::InstanceGraphBase(Operation *parent) : parent(parent) {
+InstanceGraph::InstanceGraph(Operation *parent) : parent(parent) {
   assert(parent->hasTrait<mlir::OpTrait::SingleBlock>() &&
          "top-level operation must have a single block");
-  SmallVector<std::pair<HWModuleLike, SmallVector<HWInstanceLike>>>
+  SmallVector<std::pair<ModuleOpInterface, SmallVector<InstanceOpInterface>>>
       moduleToInstances;
   // First accumulate modules inside the parent op.
-  for (auto module : parent->getRegion(0).front().getOps<hw::HWModuleLike>())
+  for (auto module :
+       parent->getRegion(0).front().getOps<igraph::ModuleOpInterface>())
     moduleToInstances.push_back({module, {}});
 
   // Populate instances in the module parallelly.
@@ -66,7 +67,7 @@ InstanceGraphBase::InstanceGraphBase(Operation *parent) : parent(parent) {
                       auto module = moduleToInstances[idx].first;
                       auto &instances = moduleToInstances[idx].second;
                       // Find all instance operations in the module body.
-                      module.walk([&](HWInstanceLike instanceOp) {
+                      module.walk([&](InstanceOpInterface instanceOp) {
                         instances.push_back(instanceOp);
                       });
                     });
@@ -84,7 +85,7 @@ InstanceGraphBase::InstanceGraphBase(Operation *parent) : parent(parent) {
   }
 }
 
-InstanceGraphNode *InstanceGraphBase::addModule(HWModuleLike module) {
+InstanceGraphNode *InstanceGraph::addModule(ModuleOpInterface module) {
   assert(!nodeMap.count(module.getModuleNameAttr()) && "module already added");
   auto *node = new InstanceGraphNode();
   node->module = module;
@@ -93,7 +94,7 @@ InstanceGraphNode *InstanceGraphBase::addModule(HWModuleLike module) {
   return node;
 }
 
-void InstanceGraphBase::erase(InstanceGraphNode *node) {
+void InstanceGraph::erase(InstanceGraphNode *node) {
   assert(node->noUses() &&
          "all instances of this module must have been erased.");
   // Erase all instances inside this module.
@@ -103,24 +104,25 @@ void InstanceGraphBase::erase(InstanceGraphNode *node) {
   nodes.erase(node);
 }
 
-InstanceGraphNode *InstanceGraphBase::lookup(StringAttr name) {
+InstanceGraphNode *InstanceGraph::lookup(StringAttr name) {
   auto it = nodeMap.find(name);
   assert(it != nodeMap.end() && "Module not in InstanceGraph!");
   return it->second;
 }
 
-InstanceGraphNode *InstanceGraphBase::lookup(HWModuleLike op) {
-  return lookup(cast<HWModuleLike>(op).getModuleNameAttr());
+InstanceGraphNode *InstanceGraph::lookup(ModuleOpInterface op) {
+  return lookup(cast<ModuleOpInterface>(op).getModuleNameAttr());
 }
 
-HWModuleLike InstanceGraphBase::getReferencedModule(HWInstanceLike op) {
+ModuleOpInterface
+InstanceGraph::getReferencedModuleImpl(InstanceOpInterface op) {
   return lookup(op.getReferencedModuleNameAttr())->getModule();
 }
 
-InstanceGraphBase::~InstanceGraphBase() {}
+InstanceGraph::~InstanceGraph() {}
 
-void InstanceGraphBase::replaceInstance(HWInstanceLike inst,
-                                        HWInstanceLike newInst) {
+void InstanceGraph::replaceInstance(InstanceOpInterface inst,
+                                    InstanceOpInterface newInst) {
   assert(inst.getReferencedModuleName() == newInst.getReferencedModuleName() &&
          "Both instances must be targeting the same module");
 
@@ -136,7 +138,8 @@ void InstanceGraphBase::replaceInstance(HWInstanceLike inst,
   (*it)->instance = newInst;
 }
 
-bool InstanceGraphBase::isAncestor(HWModuleLike child, HWModuleLike parent) {
+bool InstanceGraph::isAncestor(ModuleOpInterface child,
+                               ModuleOpInterface parent) {
   DenseSet<InstanceGraphNode *> seen;
   SmallVector<InstanceGraphNode *> worklist;
   auto *cn = lookup(child);
@@ -159,7 +162,7 @@ bool InstanceGraphBase::isAncestor(HWModuleLike child, HWModuleLike parent) {
 }
 
 FailureOr<llvm::ArrayRef<InstanceGraphNode *>>
-InstanceGraphBase::getInferredTopLevelNodes() {
+InstanceGraph::getInferredTopLevelNodes() {
   if (!inferredTopLevelNodes.empty())
     return {inferredTopLevelNodes};
 
@@ -221,7 +224,8 @@ InstanceGraphBase::getInferredTopLevelNodes() {
   return {inferredTopLevelNodes};
 }
 
-ArrayRef<InstancePath> InstancePathCache::getAbsolutePaths(HWModuleLike op) {
+ArrayRef<InstancePath>
+InstancePathCache::getAbsolutePaths(ModuleOpInterface op) {
   InstanceGraphNode *node = instanceGraph[op];
 
   // If we have reached the circuit root, we're done.
@@ -243,8 +247,8 @@ ArrayRef<InstancePath> InstancePathCache::getAbsolutePaths(HWModuleLike op) {
       auto instPaths = getAbsolutePaths(module);
       extendedPaths.reserve(instPaths.size());
       for (auto path : instPaths) {
-        extendedPaths.push_back(
-            appendInstance(path, cast<HWInstanceLike>(*inst->getInstance())));
+        extendedPaths.push_back(appendInstance(
+            path, cast<InstanceOpInterface>(*inst->getInstance())));
       }
     }
   }
@@ -261,22 +265,22 @@ ArrayRef<InstancePath> InstancePathCache::getAbsolutePaths(HWModuleLike op) {
 }
 
 InstancePath InstancePathCache::appendInstance(InstancePath path,
-                                               HWInstanceLike inst) {
+                                               InstanceOpInterface inst) {
   size_t n = path.size() + 1;
-  auto *newPath = allocator.Allocate<HWInstanceLike>(n);
+  auto *newPath = allocator.Allocate<InstanceOpInterface>(n);
   std::copy(path.begin(), path.end(), newPath);
   newPath[path.size()] = inst;
   return InstancePath(newPath, n);
 }
 
-void InstancePathCache::replaceInstance(HWInstanceLike oldOp,
-                                        HWInstanceLike newOp) {
+void InstancePathCache::replaceInstance(InstanceOpInterface oldOp,
+                                        InstanceOpInterface newOp) {
 
   instanceGraph.replaceInstance(oldOp, newOp);
 
-  // Iterate over all the paths, and search for the old HWInstanceLike. If
-  // found, then replace it with the new HWInstanceLike, and create a new copy
-  // of the paths and update the cache.
+  // Iterate over all the paths, and search for the old InstanceOpInterface. If
+  // found, then replace it with the new InstanceOpInterface, and create a new
+  // copy of the paths and update the cache.
   auto instanceExists = [&](const ArrayRef<InstancePath> &paths) -> bool {
     return llvm::any_of(
         paths, [&](InstancePath p) { return llvm::is_contained(p, oldOp); });
@@ -293,7 +297,7 @@ void InstancePathCache::replaceInstance(HWInstanceLike oldOp,
         updatedPaths.push_back(path);
         continue;
       }
-      auto *newPath = allocator.Allocate<HWInstanceLike>(path.size());
+      auto *newPath = allocator.Allocate<InstanceOpInterface>(path.size());
       llvm::copy(path, newPath);
       newPath[iter - path.begin()] = newOp;
       updatedPaths.push_back(InstancePath(newPath, path.size()));
@@ -305,3 +309,5 @@ void InstancePathCache::replaceInstance(HWInstanceLike oldOp,
     iter.getSecond() = ArrayRef<InstancePath>(paths, updatedPaths.size());
   }
 }
+
+#include "circt/Support/InstanceGraphInterface.cpp.inc"


### PR DESCRIPTION
This change moves InstanceGraphBase to support, and introduces an interface for driving the implementation, `InstanceGraphInterface`, which essentially is an extraction of the name and lookup related functions of `HWModuleLike/HWInstanceLike` (which now inherit from the `InstanceGraph` interfaces). The motivation for this is that multiple things in CIRCT may benefit from having graph iterators, and most/all of these will need an implementation exactly as what is given in `InstanceGraphBase`. My immediate usecase is to provide a graph interface for Ibis classes/containers (which don't have block argument/return values as ports, and thus aren't `HWModuleLike`), but things like handshake and FSM are other obvious users of this.

The interface is named `InstanceGraphInterface`, but in reality this is just introducing an even more generic module/instance interface than `HWModuleLike` - that is, instances and modules _without_ port info. Hence, we could name the interface something more appropriate, e.g. `CIRCTModuleInterface` or something - LMKWYT.

Implementing this change also performs some housekeeping which bloats the PR mainly by NFCs through:
- ensuring that all ops who inherit from the `HWModuleLike/HWInstanceLike` interfaces actually implements the name-related parts of the interface.
- Various missing includes exposed by removing `hw` includes from InstanceGraph.