### PR TITLE
[FIRRTL][Emitter] Sync to use "latest", and bump that to 3.1.0.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -104,7 +104,7 @@ struct FIRVersion {
 
   static FIRVersion defaultFIRVersion() { return {1, 0, 0}; }
 
-  static FIRVersion latestFIRVersion() { return {3, 0, 0}; }
+  static FIRVersion latestFIRVersion() { return {3, 1, 0}; }
 
 }; // namespace firrtl
 

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -1344,7 +1344,8 @@ void circt::firrtl::registerToFIRFileTranslation() {
   static mlir::TranslateFromMLIRRegistration toFIR(
       "export-firrtl", "emit FIRRTL dialect operations to .fir output",
       [](ModuleOp module, llvm::raw_ostream &os) {
-        return exportFIRFile(module, os, targetLineLength, {3, 1, 0});
+        return exportFIRFile(module, os, targetLineLength,
+                             FIRVersion::latestFIRVersion());
       },
       [](mlir::DialectRegistry &registry) {
         registry.insert<chirrtl::CHIRRTLDialect>();

--- a/test/CAPI/firrtl.c
+++ b/test/CAPI/firrtl.c
@@ -42,7 +42,7 @@ void testExport(MlirContext ctx) {
   assert(mlirLogicalResultIsSuccess(
       mlirExportFIRRTL(module, exportCallback, NULL)));
 
-  // CHECK: FIRRTL version 3.0.0
+  // CHECK: FIRRTL version 3.1.0
   // CHECK-NEXT: circuit ExportTestSimpleModule :
   // CHECK-NEXT:   module ExportTestSimpleModule : @[- 2:3]
   // CHECK-NEXT:     input in_1 : UInt<32> @[- 2:44]


### PR DESCRIPTION
Match behavior of `mlirExportFIRRTL`.