### PR TITLE
[ci] Add restore-keys for ccache action, drop ccache stats (already printed!)

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -65,6 +65,9 @@ jobs:
         with:
           max-size: 300M
           key: nightly-${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}
+          append-timestamp: false
+          restore-keys: |
+            short-${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}
 
       # --------
       # Build and test CIRCT

--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -109,7 +109,3 @@ jobs:
         if: ${{ matrix.lit-flags == '' }}
         run: |
           ninja -C build check-circt-integration -j$(nproc)
-
-      - name: Ccache stats
-        run: |
-          ccache -s

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -48,6 +48,8 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: short-${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}
+          restore-keys: |
+            short-${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}
           max-size: 500M
 
       # --------

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -92,7 +92,3 @@ jobs:
       - name: Integration Test CIRCT
         run: |
           ninja -C build check-circt-integration -j$(nproc)
-
-      - name: Ccache stats
-        run: |
-          ccache -s


### PR DESCRIPTION
Start using `restore-keys` for the GitHub ccache action. This _should_ cause cache hits and updates when a cache matches everything, but the timestamp.

Remove an explicit step in nightly and short integration tests that print
the ccache stats.  This is already, conveniently, printing by the action
as part of the "Post ccache" step.

E.g., this can be viewed here: https://github.com/llvm/circt/actions/runs/5855412636/job/15873180187#step:16:3