### PR TITLE
[SV] Initialize a new pass - SVTriggerAttrGen pass in SV Transform

### DIFF
--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -24,6 +24,8 @@ std::unique_ptr<mlir::Pass> createHWCleanupPass(bool mergeAlwaysBlocks = true);
 std::unique_ptr<mlir::Pass> createHWStubExternalModulesPass();
 std::unique_ptr<mlir::Pass> createHWLegalizeModulesPass();
 std::unique_ptr<mlir::Pass> createSVTraceIVerilogPass();
+std::unique_ptr<mlir::Pass>
+createSVTriggerAttrGenPass(bool resetTriggerValue = false);
 std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();
 std::unique_ptr<mlir::Pass> createHWEliminateInOutPortsPass();
 std::unique_ptr<mlir::Pass> createHWMemSimImplPass(

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -117,6 +117,21 @@ def HWMemSimImpl : Pass<"hw-memory-sim", "ModuleOp"> {
    ];
 }
 
+def SVTriggerAttrGen : Pass<"sv-trigger-attr-gen", "ModuleOp"> {
+  let summary = "Generate trigger attributes of function arguments.";
+  let description = [{
+    This pass generates trigger attributes of arguments which will
+    be used by Trigger circuit like alwaysOp block.
+  }];
+  let constructor = "circt::sv::createSVTriggerAttrGenPass()";
+  let dependentDialects = ["circt::sv::SVDialect"];
+
+  let options = [
+    Option<"resetTriggerValue", "reset-trigger-value", "bool", "false",
+           "Reset the trigger attribute values with the setted order in module">,
+  ];
+}
+
 def SVExtractTestCode : Pass<"sv-extract-test-code", "ModuleOp"> {
   let summary = "Extract simulation only constructs to modules and bind";
   let description = [{

--- a/lib/Dialect/SV/Transforms/CMakeLists.txt
+++ b/lib/Dialect/SV/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_circt_dialect_library(CIRCTSVTransforms
   HWLegalizeModules.cpp
   HWMemSimImpl.cpp
   PrettifyVerilog.cpp
+  SVTriggerAttrGen.cpp
   SVExtractTestCode.cpp
   HWExportModuleHierarchy.cpp
   SVTraceIVerilog.cpp
@@ -21,5 +22,8 @@ add_circt_dialect_library(CIRCTSVTransforms
   CIRCTSV
   MLIRIR
   MLIRPass
+  MLIRSupport
   MLIRTransformUtils
+  MLIRFuncDialect
+  MLIRLLVMDialect
 )

--- a/lib/Dialect/SV/Transforms/SVTriggerAttrGen.cpp
+++ b/lib/Dialect/SV/Transforms/SVTriggerAttrGen.cpp
@@ -73,9 +73,8 @@ static void genTriggerAttribute(ModuleOp module, OpsToEventsMap &opsMap) {
         // whether the operation is hw::InstanceOp or not. If it is instanceOp
         // in hw dialect, additional offset will be added to the index from the
         // number of ports in referenced module.
-        if (isa<hw::InstanceOp>(signalOp)) {
-          auto *refedModule =
-              cast<hw::InstanceOp>(signalOp).getReferencedModule();
+        if (auto inst = dyn_cast<hw::InstanceOp>(signalOp)) {
+          auto *refedModule = inst.getReferencedModuleSlow();
 
           if (auto ref = dyn_cast<HWModuleOp>(refedModule))
             index += ref.getNumArguments();

--- a/lib/Dialect/SV/Transforms/SVTriggerAttrGen.cpp
+++ b/lib/Dialect/SV/Transforms/SVTriggerAttrGen.cpp
@@ -1,0 +1,307 @@
+//===- SVTriggerAttrGen.cpp -------- SV Trigger Attributes Generator-------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This generation pass will generate trigger attribute and attach it to
+// corresponding place if this blockArgument / operation is used as trigger
+// signal in sequential block.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/SV/SVPasses.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "sv-trigger-attr-gen"
+using namespace circt;
+using namespace mlir;
+using namespace sv;
+using namespace hw;
+
+using llvm::dbgs;
+
+// Define a type for representing the relations between trigger signals and
+// operations.
+using OpsToEventsMap = DenseMap<Operation *, SmallVector<IntegerAttr>>;
+
+//===----------------------------------------------------------------------===//
+// SVTriggerAttrGen Helpers
+//===----------------------------------------------------------------------===//
+namespace {
+/// The function to generate trigger attribute in module.
+static void genTriggerAttribute(ModuleOp module, OpsToEventsMap &opsMap) {
+  // Walk through the module to collect the info to generate trigger attributes.
+  module.walk([&](sv::AlwaysOp op) {
+    for (size_t i = 0, e = op.getNumConditions(); i != e; i++) {
+      unsigned index = 0;
+      auto *parent = op->getParentOp();
+      auto signal = op.getCondition(i).value;
+      auto *signalOp = signal.getDefiningOp();
+      // Do it when this signal comes from input argument of module.
+      // These signals come from sources that are not reachable in the
+      // current domain.
+      if (signal.getDefiningOp() == nullptr) {
+        index = cast<BlockArgument>(signal).getArgNumber();
+        opsMap[parent].push_back(
+            IntegerAttr::get(IntegerType::get(module.getContext(), 8), index));
+
+        // Do it when this signal comes from currently reacheable source
+        // such as results from callOp or from combinational logic part.
+      } else {
+        index = cast<OpResult>(signal).getResultNumber();
+
+        // When the operation waited to be added 'sv.trigger' attribute, judge
+        // whether the operation is hw::InstanceOp or not. If it is instanceOp
+        // in hw dialect, additional offset will be added to the index from the
+        // number of ports in referenced module.
+        if (isa<hw::InstanceOp>(signalOp)) {
+          auto *refedModule =
+              cast<hw::InstanceOp>(signalOp).getReferencedModule();
+
+          if (auto ref = dyn_cast<HWModuleOp>(refedModule))
+            index += ref.getNumArguments();
+          else
+            index += dyn_cast<HWModuleExternOp>(refedModule).getNumArguments();
+        }
+        opsMap[signalOp].push_back(
+            IntegerAttr::get(IntegerType::get(module.getContext(), 8), index));
+      }
+    }
+  });
+
+  StringAttr nameAttr = StringAttr::get(module.getContext(), "sv.trigger");
+
+  // Remove duplicate elements and reorder the value in container, then create
+  // trigger attribute and set it to corresponding operation.
+  for (auto &map : opsMap) {
+    auto *defineOp = map.first;
+
+    // Remove duplicates using SetVector and then create a SmallVector.
+    llvm::SetVector<IntegerAttr> setVector(map.second.begin(),
+                                           map.second.end());
+    llvm::SmallVector<IntegerAttr> sortedAttrs(setVector.begin(),
+                                               setVector.end());
+
+    // Sort the SmallVector of IntegerAttr elements in ascending order.
+    llvm::sort(sortedAttrs, [](mlir::IntegerAttr a, mlir::IntegerAttr b) {
+      return a.getValue().getSExtValue() < b.getValue().getSExtValue();
+    });
+
+    // Create an ArrayAttr from the sorted vector.
+    SmallVector<Attribute> attrVector(sortedAttrs.begin(), sortedAttrs.end());
+    ArrayAttr arrayAttr = ArrayAttr::get(module.getContext(), attrVector);
+
+    // Attach the trigger information to the corresponding operation.
+    defineOp->setAttr(nameAttr, arrayAttr);
+  }
+}
+
+/// Reset the place to set the value of trigger attribute on arguments.
+static void resetArgTriggerAttr(HWModuleOp hwModuleOp, unsigned &sequenceId,
+                                StringAttr &nameAttr) {
+  auto argType = hwModuleOp.getArgument(0).getType();
+  auto triAttr = cast<ArrayAttr>(hwModuleOp->getAttr("sv.trigger"));
+  auto argTriggerNum = triAttr.size();
+
+  for (auto attr : triAttr) {
+    auto triValue = attr.cast<IntegerAttr>().getValue().getZExtValue();
+
+    for (auto gep : hwModuleOp.getOps<LLVM::GEPOp>())
+      if (argType == gep.getOperand(0).getType()) {
+        auto indices = gep.getIndices();
+        auto offset = cast<IntegerAttr>(indices[1]).getValue().getZExtValue();
+        auto *load = *gep->getUsers().begin();
+
+        if (triValue == offset && isa<LLVM::LoadOp>(load)) {
+          auto integerAttr = IntegerAttr::get(
+              IntegerType::get(hwModuleOp.getContext(), 8), sequenceId);
+          auto arrayAttr =
+              ArrayAttr::get(hwModuleOp->getContext(), integerAttr);
+          load->setAttr(nameAttr, arrayAttr);
+          sequenceId++;
+        }
+      }
+  }
+
+  assert(
+      argTriggerNum == sequenceId &&
+      "Not all suitable operations were found to reset the trigger attribute! "
+      "You need to execute the GenStateStruct pass first with "
+      "'--state-struct-generate'.");
+
+  hwModuleOp->removeAttr(nameAttr);
+}
+
+/// Reset the place to set the value of trigger attribute on instances.
+static void resetInstTriggerAttr(hw::InstanceOp instanceOp,
+                                 unsigned &sequenceId, StringAttr &nameAttr) {
+  auto instOperandTy = instanceOp->getOperand(0).getType();
+  auto triAttr = cast<ArrayAttr>(instanceOp->getAttr("sv.trigger"));
+  auto instTriggerNum = triAttr.size() + sequenceId;
+
+  // Get the struct type in pointer to check whether is opaque type or not.
+  auto instOpElementTy =
+      cast<LLVM::LLVMPointerType>(instOperandTy).getElementType();
+  auto instOpStructTy = cast<LLVM::LLVMStructType>(instOpElementTy);
+
+  if (instOpStructTy.isOpaque())
+    for (auto bitcast :
+         cast<HWModuleOp>(instanceOp->getParentOp()).getOps<LLVM::BitcastOp>())
+      if (bitcast->getOperand(0).getType() == instOperandTy) {
+        instOperandTy = bitcast.getType();
+        break;
+      }
+
+  for (auto attr : triAttr) {
+    auto triValue = attr.cast<IntegerAttr>().getValue().getZExtValue();
+
+    for (auto gep :
+         cast<HWModuleOp>(instanceOp->getParentOp()).getOps<LLVM::GEPOp>()) {
+      if (instOperandTy == gep.getOperand(0).getType()) {
+        auto indices = gep.getIndices();
+        auto offset = cast<IntegerAttr>(indices[1]).getValue().getZExtValue();
+        auto *load = *gep->getUsers().begin();
+
+        if (triValue == offset && isa<LLVM::LoadOp>(load)) {
+          auto integerAttr = IntegerAttr::get(
+              IntegerType::get(instanceOp.getContext(), 8), sequenceId);
+          auto arrayAttr =
+              ArrayAttr::get(instanceOp->getContext(), integerAttr);
+          load->setAttr(nameAttr, arrayAttr);
+          sequenceId++;
+        }
+      }
+    }
+  }
+
+  assert(
+      instTriggerNum == sequenceId &&
+      "Not all suitable operations were found to reset the trigger attribute! "
+      "You need to execute the GenStateStruct pass first with "
+      "'--state-struct-generate'.");
+
+  instanceOp->removeAttr(nameAttr);
+}
+
+/// Reset the place to set the value of trigger attribute for ordinary
+/// operations.
+static void resetOpTriggerAttr(Operation *op, unsigned &sequenceId,
+                               StringAttr &nameAttr) {
+  auto triAttr = cast<ArrayAttr>(op->getAttr("sv.trigger"));
+
+  // FIXME: This might be an improvement if we could support more than one
+  // trigger attribute on the operations other than module or instance
+  // operation. Temporarily, there is no good solution when removing the
+  // original value. (equivalent to mapping relations) when the size is more
+  // than one, it would be difficult to find out the original mapping
+  // relations in subsequent passes.
+  assert(triAttr.size() == 1 && "Warning: not support to reset the trigger "
+                                "value if its size exceeds one!");
+
+  op->removeAttr(nameAttr);
+
+  auto integerAttr =
+      IntegerAttr::get(IntegerType::get(op->getContext(), 8), sequenceId);
+  auto arrayAttr = ArrayAttr::get(op->getContext(), integerAttr);
+  op->setAttr(nameAttr, arrayAttr);
+
+  sequenceId++;
+}
+
+/// The function to reset values of trigger attribute in module with the
+/// predefined rule.
+static void resetTriggerAttrValue(ModuleOp module) {
+  StringAttr nameAttr = StringAttr::get(module.getContext(), "sv.trigger");
+
+  module->walk([&](HWModuleOp hwModuleOp) {
+    unsigned sequenceId = 0;
+    LLVM_DEBUG(dbgs() << "Start to reset trigger attribute in the module: "
+                      << hwModuleOp.getModuleName() << "\n");
+
+    if (hwModuleOp->hasAttr("sv.trigger"))
+      resetArgTriggerAttr(hwModuleOp, sequenceId, nameAttr);
+
+    LLVM_DEBUG(
+        dbgs() << "Print the sequenceId (Phase #1 -- Trigger on arguments): "
+               << sequenceId << "\n");
+
+    for (Operation &op : *hwModuleOp.getBodyBlock()) {
+      if (op.hasAttr("sv.trigger")) {
+        if (isa<hw::InstanceOp>(op)) {
+          resetInstTriggerAttr(cast<hw::InstanceOp>(op), sequenceId, nameAttr);
+          LLVM_DEBUG(
+              dbgs()
+              << "Print the sequenceId (Phase #2 -- Trigger on instances): "
+              << sequenceId << "\n");
+          continue;
+        }
+
+        // Must exclude the loadOp， Why？ Beacuse the loadOp that has trigger
+        // attribute is formed by previously resetting behavior. For correctness
+        // after resetting the value, We must avoid double counting.
+        if (!isa<LLVM::LoadOp>(op)) {
+          resetOpTriggerAttr(&op, sequenceId, nameAttr);
+          LLVM_DEBUG(dbgs() << "Print the sequenceId (Phase #3 -- Trigger on "
+                               "oridinary operations): "
+                            << sequenceId << "\n");
+        }
+      }
+    }
+  });
+}
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// SVTriggerAttrGen Pass
+//===----------------------------------------------------------------------===//
+namespace {
+struct SVTriggerAttrGenPass
+    : public SVTriggerAttrGenBase<SVTriggerAttrGenPass> {
+  SVTriggerAttrGenPass(bool resetTriggerValue) {
+    this->resetTriggerValue = resetTriggerValue;
+  }
+  void runOnOperation() override;
+};
+} // end anonymous namespace
+
+void SVTriggerAttrGenPass::runOnOperation() {
+  OpsToEventsMap opsToEventsMap;
+  ModuleOp module = getOperation();
+
+  // The option '--reset-trigger-value' is to reset all values of trigger
+  // attributes in the current module in ascending order. Attention: please use
+  // this option after executing the GenStateStruct pass with
+  // '--state-struct-generate'.
+  if (!resetTriggerValue) {
+    genTriggerAttribute(module, opsToEventsMap);
+  } else {
+    resetTriggerAttrValue(module);
+  }
+}
+//===----------------------------------------------------------------------===//
+// Pass Creation
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<Pass>
+circt::sv::createSVTriggerAttrGenPass(bool resetTriggerValue) {
+  return std::make_unique<SVTriggerAttrGenPass>(resetTriggerValue);
+}

--- a/test/Dialect/SV/sv-trigger-attr-generation.mlir
+++ b/test/Dialect/SV/sv-trigger-attr-generation.mlir
@@ -1,0 +1,29 @@
+//RUN: circt-opt -sv-trigger-attr-gen %s | FileCheck %s
+
+// Test trigger attribute generation in the modules arguments.
+// CHECK-LABEL: hw.module @test_case_0(
+// CHECK-SAME: %[[VAL_0:.*]]: i1,
+// CHECK-SAME: %[[VAL_1:.*]]: i1) attributes {sv.trigger = [0 : i8, 1 : i8]} {
+hw.module @test_case_0(%arg0: i1, %arg1: i1){
+  sv.always posedge %arg0 {}
+  sv.always posedge %arg0, posedge %arg1 {}
+  hw.output
+}
+
+// Test secondary trigger attribute generation in the operations attributes part.
+// CHECK-LABEL: hw.module @test_case_1(
+hw.module @test_case_1(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1) {
+  // CHECK-NEXT: %[[VAL_4:.*]] = hw.instance "instance_0" @extern_module_1(arg0: %arg0: i1) -> (out0: i1) {sv.trigger = [1 : i8]}
+  %instance_0.out_0 = hw.instance "instance_0" @extern_module_1(arg0: %arg0: i1) -> (out0: i1)
+  
+  // CHECK-NEXT: %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = hw.instance "instance_1" @extern_module_0(arg0: %arg0: i1, arg1: %arg1: i1, arg2: %arg2: i1, arg3: %arg3: i1) -> (out0: i1, out1: i1, out2: i1) {sv.trigger = [4 : i8, 5 : i8, 6 : i8]}
+  %instance_1.out0, %instance_1.out1, %instance_1.out2 = hw.instance "instance_1" @extern_module_0(arg0: %arg0: i1, arg1: %arg1: i1, arg2: %arg2: i1, arg3: %arg3: i1) -> (out0: i1, out1: i1, out2: i1)
+
+  sv.always posedge %instance_0.out_0 {}
+  sv.always posedge %instance_1.out1, negedge %instance_0.out_0 {}
+  sv.always posedge %instance_1.out0, negedge %instance_1.out1, edge %instance_1.out2 {}
+  hw.output
+}
+
+hw.module.extern private @extern_module_1(%arg0: i1) -> (out0: i1)
+hw.module.extern private @extern_module_0(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1) -> (out0: i1, out1: i1, out2: i1)

--- a/test/Dialect/SV/sv-trigger-reset-attr-value.mlir
+++ b/test/Dialect/SV/sv-trigger-reset-attr-value.mlir
@@ -1,0 +1,143 @@
+//RUN: circt-opt -sv-trigger-attr-gen=reset-trigger-value %s | FileCheck %s
+
+// Test for resetting the trigger attribute in the module 
+
+llvm.mlir.global internal @_Struct_test_case_1() {addr_space = 0 : i32} : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)> {
+  %0 = llvm.mlir.constant(false) : i1
+  %1 = llvm.mlir.constant(false) : i1
+  %2 = llvm.mlir.constant(false) : i1
+  %3 = llvm.mlir.constant(false) : i1
+  %4 = llvm.mlir.constant(false) : i1
+  %5 = llvm.mlir.constant(false) : i1
+  %6 = llvm.mlir.constant(false) : i1
+  %7 = llvm.mlir.constant(false) : i1
+  %8 = llvm.mlir.null : !llvm.ptr<struct<"_Struct_extern_module_1", opaque>>
+  %9 = llvm.mlir.null : !llvm.ptr<struct<"_Struct_extern_module_0", opaque>>
+  %10 = llvm.mlir.undef : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)>
+  %11 = llvm.insertvalue %0, %10[0] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)> 
+  %12 = llvm.insertvalue %1, %11[1] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)> 
+  %13 = llvm.insertvalue %2, %12[2] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)> 
+  %14 = llvm.insertvalue %3, %13[3] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)> 
+  %15 = llvm.insertvalue %4, %14[4] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)> 
+  %16 = llvm.insertvalue %5, %15[5] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)> 
+  %17 = llvm.insertvalue %6, %16[6] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)> 
+  %18 = llvm.insertvalue %7, %17[7] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)> 
+  %19 = llvm.insertvalue %8, %18[8] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)> 
+  %20 = llvm.insertvalue %9, %19[9] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)> 
+  llvm.return %20 : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)>
+}
+llvm.mlir.global internal @_Struct_test_case_0() {addr_space = 0 : i32} : !llvm.struct<"_Struct_test_case_0", packed (i1, i1, i1, i1)> {
+  %0 = llvm.mlir.constant(false) : i1
+  %1 = llvm.mlir.constant(false) : i1
+  %2 = llvm.mlir.constant(false) : i1
+  %3 = llvm.mlir.constant(false) : i1
+  %4 = llvm.mlir.undef : !llvm.struct<"_Struct_test_case_0", packed (i1, i1, i1, i1)>
+  %5 = llvm.insertvalue %0, %4[0] : !llvm.struct<"_Struct_test_case_0", packed (i1, i1, i1, i1)> 
+  %6 = llvm.insertvalue %2, %5[1] : !llvm.struct<"_Struct_test_case_0", packed (i1, i1, i1, i1)> 
+  %7 = llvm.insertvalue %1, %6[2] : !llvm.struct<"_Struct_test_case_0", packed (i1, i1, i1, i1)> 
+  %8 = llvm.insertvalue %3, %7[3] : !llvm.struct<"_Struct_test_case_0", packed (i1, i1, i1, i1)> 
+  llvm.return %8 : !llvm.struct<"_Struct_test_case_0", packed (i1, i1, i1, i1)>
+}
+
+// CHECK-LABEL: hw.module @test_case_0(
+// CHECK-SAME: %[[VAL_0:.*]]: !llvm.ptr<struct<"_Struct_test_case_0", packed (i1, i1, i1, i1)>>) {
+hw.module @test_case_0(%ptr_struct_test_case_0: !llvm.ptr<struct<"_Struct_test_case_0", packed (i1, i1, i1, i1)>>) attributes {sv.trigger = [0 : i8, 1 : i8]} {
+
+  // CHECK: llvm.getelementptr inbounds %ptr_struct_test_case_0{{\[}}%0, 0] : (!llvm.ptr<struct<"_Struct_test_case_0", packed (i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+  %0 = llvm.mlir.constant(0 : i32) : i32
+  %1 = llvm.getelementptr inbounds %ptr_struct_test_case_0[%0, 0] : (!llvm.ptr<struct<"_Struct_test_case_0", packed (i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+
+  // CHECK: llvm.load %1 {sv.trigger = [0 : i8]} : !llvm.ptr<i1>
+  %2 = llvm.load %1 : !llvm.ptr<i1>
+
+  %3 = llvm.getelementptr inbounds %ptr_struct_test_case_0[%0, 1] : (!llvm.ptr<struct<"_Struct_test_case_0", packed (i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+  %4 = llvm.load %3 : !llvm.ptr<i1>
+  sv.always posedge %2 {
+  }
+  sv.always posedge %2, posedge %4 {
+  }
+  hw.output 
+}
+
+// CHECK-LABEL: hw.module @test_case_1(
+// CHECK-SAME: %[[VAL_0:.*]]: !llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)>>) {
+hw.module @test_case_1(%ptr_struct_test_case_1: !llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)>>) {
+  %0 = llvm.mlir.constant(0 : i32) : i32
+  %1 = llvm.getelementptr inbounds %ptr_struct_test_case_1[%0, 0] : (!llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)>>, i32) -> !llvm.ptr<i1>
+  %2 = llvm.load %1 : !llvm.ptr<i1>
+  %3 = llvm.getelementptr inbounds %ptr_struct_test_case_1[%0, 1] : (!llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)>>, i32) -> !llvm.ptr<i1>
+  %4 = llvm.load %3 : !llvm.ptr<i1>
+  %5 = llvm.getelementptr inbounds %ptr_struct_test_case_1[%0, 2] : (!llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)>>, i32) -> !llvm.ptr<i1>
+  %6 = llvm.load %5 : !llvm.ptr<i1>
+  %7 = llvm.getelementptr inbounds %ptr_struct_test_case_1[%0, 3] : (!llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)>>, i32) -> !llvm.ptr<i1>
+  %8 = llvm.load %7 : !llvm.ptr<i1>
+  %9 = llvm.getelementptr inbounds %ptr_struct_test_case_1[%0, 8] : (!llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)>>, i32) -> !llvm.ptr<ptr<struct<"_Struct_extern_module_1", opaque>>>
+  %10 = llvm.load %9 : !llvm.ptr<ptr<struct<"_Struct_extern_module_1", opaque>>>
+  %11 = llvm.bitcast %10 : !llvm.ptr<struct<"_Struct_extern_module_1", opaque>> to !llvm.ptr<struct<packed (i1, i1)>>
+  %12 = llvm.getelementptr inbounds %11[%0, 0] : (!llvm.ptr<struct<packed (i1, i1)>>, i32) -> !llvm.ptr<i1>
+  llvm.store %2, %12 : !llvm.ptr<i1>
+
+  // CHECK: hw.instance "instance_0" @extern_module_1(ptr_struct_extern_module_1: %10: !llvm.ptr<struct<"_Struct_extern_module_1", opaque>>) -> ()
+  hw.instance "instance_0" @extern_module_1(ptr_struct_extern_module_1: %10: !llvm.ptr<struct<"_Struct_extern_module_1", opaque>>) -> () {sv.trigger = [1 : i8]}
+
+
+  // CHECK: llvm.bitcast %10 : !llvm.ptr<struct<"_Struct_extern_module_1", opaque>> to !llvm.ptr<struct<packed (i1, i1)>>
+  %13 = llvm.bitcast %10 : !llvm.ptr<struct<"_Struct_extern_module_1", opaque>> to !llvm.ptr<struct<packed (i1, i1)>>
+
+  %14 = llvm.mlir.constant(1 : i32) : i32
+
+  // CHECK: llvm.getelementptr inbounds %13{{\[}}%0, 1] : (!llvm.ptr<struct<packed (i1, i1)>>, i32) -> !llvm.ptr<i1>
+  %15 = llvm.getelementptr inbounds %13[%0, 1] : (!llvm.ptr<struct<packed (i1, i1)>>, i32) -> !llvm.ptr<i1>
+
+  // CHECK: llvm.load %15 {sv.trigger = [0 : i8]} : !llvm.ptr<i1>
+  %16 = llvm.load %15 : !llvm.ptr<i1>
+
+  %17 = llvm.getelementptr inbounds %ptr_struct_test_case_1[%0, 9] : (!llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_extern_module_1", opaque>>, ptr<struct<"_Struct_extern_module_0", opaque>>)>>, i32) -> !llvm.ptr<ptr<struct<"_Struct_extern_module_0", opaque>>>
+  %18 = llvm.load %17 : !llvm.ptr<ptr<struct<"_Struct_extern_module_0", opaque>>>
+  %19 = llvm.bitcast %18 : !llvm.ptr<struct<"_Struct_extern_module_0", opaque>> to !llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>
+  %20 = llvm.getelementptr inbounds %19[%0, 0] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+  llvm.store %2, %20 : !llvm.ptr<i1>
+  %21 = llvm.getelementptr inbounds %19[%0, 1] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+  llvm.store %4, %21 : !llvm.ptr<i1>
+  %22 = llvm.getelementptr inbounds %19[%0, 2] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+  llvm.store %6, %22 : !llvm.ptr<i1>
+  %23 = llvm.getelementptr inbounds %19[%0, 3] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+  llvm.store %8, %23 : !llvm.ptr<i1>
+
+  // CHECK: hw.instance "instance_1" @extern_module_0(ptr_struct_extern_module_0: %18: !llvm.ptr<struct<"_Struct_extern_module_0", opaque>>) -> ()
+  hw.instance "instance_1" @extern_module_0(ptr_struct_extern_module_0: %18: !llvm.ptr<struct<"_Struct_extern_module_0", opaque>>) -> () {sv.trigger = [4 : i8, 5 : i8, 6 : i8]}
+
+  // CHECK: llvm.bitcast %18 : !llvm.ptr<struct<"_Struct_extern_module_0", opaque>> to !llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>
+  %24 = llvm.bitcast %18 : !llvm.ptr<struct<"_Struct_extern_module_0", opaque>> to !llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>
+  %25 = llvm.mlir.constant(4 : i32) : i32
+
+  // CHECK: llvm.getelementptr inbounds %24{{\[}}%0, 4] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+  // CHECK: llvm.load %26 {sv.trigger = [1 : i8]} : !llvm.ptr<i1>
+  %26 = llvm.getelementptr inbounds %24[%0, 4] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+  %27 = llvm.load %26 : !llvm.ptr<i1>
+
+  %28 = llvm.mlir.constant(5 : i32) : i32
+
+  // CHECK: llvm.getelementptr inbounds %24{{\[}}%0, 5] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+  // CHECK: llvm.load %29 {sv.trigger = [2 : i8]} : !llvm.ptr<i1>
+  %29 = llvm.getelementptr inbounds %24[%0, 5] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+  %30 = llvm.load %29 : !llvm.ptr<i1>
+
+  %31 = llvm.mlir.constant(6 : i32) : i32
+
+  // CHECK: llvm.getelementptr inbounds %24{{\[}}%0, 6] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+  // CHECK: llvm.load %32 {sv.trigger = [3 : i8]} : !llvm.ptr<i1>
+  %32 = llvm.getelementptr inbounds %24[%0, 6] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+  %33 = llvm.load %32 : !llvm.ptr<i1>
+
+  sv.always posedge %16 {
+  }
+  sv.always posedge %30, negedge %16 {
+  }
+  sv.always posedge %27, negedge %30, edge %33 {
+  }
+  hw.output
+}
+
+hw.module.extern private @extern_module_1(%ptr_struct_extern_module_1: !llvm.ptr<struct<"_Struct_extern_module_1", opaque>>)
+hw.module.extern private @extern_module_0(%ptr_struct_extern_module_0: !llvm.ptr<struct<"_Struct_extern_module_0", opaque>>)


### PR DESCRIPTION
First, the trigger attribute 'sv.trigger' is used to denote the signal that is trigger. The trigger signal is related to the sequential   block in IR. Use the attribute to represents whether the input value is comes from a trigger signal, will help us to handle sequential block. This pass will generate trigger attribute and attach it to corresponding place if this blockArgument / operation is used as trigger signal in sequential block.

The 'reset-trigger-value' option is used to reset the trigger values in each module, the resetting rule obey ascending order. It must be executed after the GenStateStruct pass (another pass to generate state struct around HW dialect).