### PR TITLE
Add Calyx flow to `hlstool`

### DIFF
--- a/integration_test/Dialect/Calyx/custom_port_name.mlir
+++ b/integration_test/Dialect/Calyx/custom_port_name.mlir
@@ -1,12 +1,5 @@
 // This test checks that the custom port name gets propagated all the way down to Verilog
-// RUN: circt-opt %s \
-// RUN:     --lower-scf-to-calyx -canonicalize \
-// RUN:     --calyx-remove-comb-groups --canonicalize \
-// RUN:     --lower-calyx-to-fsm --canonicalize \
-// RUN:     --materialize-calyx-to-fsm --canonicalize \
-// RUN:     --calyx-remove-groups-fsm --canonicalize \
-// RUN:     --lower-calyx-to-hw --canonicalize \
-// RUN:     --convert-fsm-to-sv | FileCheck %s
+// RUN: hlstool --calyx-hw --ir --ir-output-level=3 %s | FileCheck %s
 
 // CHECK: hw.module @control
 // CHECK: hw.module @main(%a: i32, %b: i32, %clk: i1, %reset: i1, %go: i1) -> (out: i1, done: i1)

--- a/integration_test/Dialect/Calyx/memory_loop.mlir
+++ b/integration_test/Dialect/Calyx/memory_loop.mlir
@@ -1,11 +1,6 @@
 // This test lowers an SCF construct through Calyx, FSM and (TODO)
 // to RTL.
-// RUN: circt-opt %s \
-// RUN:     --lower-scf-to-calyx -canonicalize \
-// RUN:     --calyx-remove-comb-groups --canonicalize \
-// RUN:     --lower-calyx-to-fsm --canonicalize \
-// RUN:     --materialize-calyx-to-fsm --canonicalize \
-// RUN:     --calyx-remove-groups-fsm --canonicalize | FileCheck %s
+// RUN: hls-tool --calyx-hw --ir-output-level=2 %s | FileCheck %s
 
 // This is the end of the road for this example since there (as of writing)
 // does not yet exist a lowering for calyx.memory operations.

--- a/integration_test/Dialect/Calyx/memory_loop.mlir
+++ b/integration_test/Dialect/Calyx/memory_loop.mlir
@@ -1,6 +1,6 @@
 // This test lowers an SCF construct through Calyx, FSM and (TODO)
 // to RTL.
-// RUN: hls-tool --calyx-hw --ir-output-level=2 %s | FileCheck %s
+// RUN: hlstool --calyx-hw --ir-output-level=2 %s | FileCheck %s
 
 // This is the end of the road for this example since there (as of writing)
 // does not yet exist a lowering for calyx.memory operations.

--- a/integration_test/Dialect/Calyx/memory_loop.mlir
+++ b/integration_test/Dialect/Calyx/memory_loop.mlir
@@ -1,6 +1,6 @@
 // This test lowers an SCF construct through Calyx, FSM and (TODO)
 // to RTL.
-// RUN: hlstool --calyx-hw --ir-output-level=1 %s | FileCheck %s
+// RUN: hlstool --calyx-hw --ir-output-level=1 --ir %s | FileCheck %s
 
 // This is the end of the road for this example since there (as of writing)
 // does not yet exist a lowering for calyx.memory operations.

--- a/integration_test/Dialect/Calyx/memory_loop.mlir
+++ b/integration_test/Dialect/Calyx/memory_loop.mlir
@@ -1,6 +1,6 @@
 // This test lowers an SCF construct through Calyx, FSM and (TODO)
 // to RTL.
-// RUN: hlstool --calyx-hw --ir-output-level=2 %s | FileCheck %s
+// RUN: hlstool --calyx-hw --ir-output-level=1 %s | FileCheck %s
 
 // This is the end of the road for this example since there (as of writing)
 // does not yet exist a lowering for calyx.memory operations.

--- a/integration_test/Dialect/Calyx/simple_arith.mlir
+++ b/integration_test/Dialect/Calyx/simple_arith.mlir
@@ -1,13 +1,6 @@
 // This test lowers an SCF construct through Calyx, FSM and (TODO)
 // to RTL.
-// RUN: circt-opt %s \
-// RUN:     --lower-scf-to-calyx -canonicalize \
-// RUN:     --calyx-remove-comb-groups --canonicalize \
-// RUN:     --lower-calyx-to-fsm --canonicalize \
-// RUN:     --materialize-calyx-to-fsm --canonicalize \
-// RUN:     --calyx-remove-groups-fsm --canonicalize \
-// RUN:     --lower-calyx-to-hw --canonicalize \
-// RUN:     --convert-fsm-to-sv | FileCheck %s
+// RUN: hlstool %s --calyx-hw --ir | FileCheck %s
 
 // TODO: ... simulate the hardware!
 

--- a/lib/Conversion/LoopScheduleToCalyx/CMakeLists.txt
+++ b/lib/Conversion/LoopScheduleToCalyx/CMakeLists.txt
@@ -11,6 +11,12 @@ add_circt_conversion_library(CIRCTLoopScheduleToCalyx
   LINK_LIBS PUBLIC
   CIRCTCalyx
   CIRCTCalyxTransforms
+  CIRCTCalyxToHW
+  CIRCTCalyxToFSM
+  CIRCTFSM
+  CIRCTFSMTransforms
+  CIRCTFSMToSV
+  CIRCTSCFToCalyx
   CIRCTLoopSchedule
   MLIRIR
   MLIRPass

--- a/lib/Conversion/LoopScheduleToCalyx/CMakeLists.txt
+++ b/lib/Conversion/LoopScheduleToCalyx/CMakeLists.txt
@@ -11,12 +11,6 @@ add_circt_conversion_library(CIRCTLoopScheduleToCalyx
   LINK_LIBS PUBLIC
   CIRCTCalyx
   CIRCTCalyxTransforms
-  CIRCTCalyxToHW
-  CIRCTCalyxToFSM
-  CIRCTFSM
-  CIRCTFSMTransforms
-  CIRCTFSMToSV
-  CIRCTSCFToCalyx
   CIRCTLoopSchedule
   MLIRIR
   MLIRPass

--- a/tools/hlstool/CMakeLists.txt
+++ b/tools/hlstool/CMakeLists.txt
@@ -22,6 +22,14 @@ target_link_libraries(hlstool
   CIRCTStandardToHandshake
   CIRCTSV
   CIRCTSVTransforms
+  CIRCTSCFToCalyx
+  CIRCTCalyx
+  CIRCTCalyxTransforms
+  CIRCTCalyxToHW
+  CIRCTCalyxToFSM
+  CIRCTFSM
+  CIRCTFSMTransforms
+  CIRCTFSMToSV
   CIRCTTransforms
 
   MLIRIR

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -385,18 +385,25 @@ static LogicalResult doHLSFlowCalyx(
   pm.addPass(createSimpleCanonicalizerPass());
 
   // Eliminate Calyx's comb group abstraction
-  pm.nest<calyx::ComponentOp>().addPass(
+  pm.addNestedPass<calyx::ComponentOp>(
       circt::calyx::createRemoveCombGroupsPass());
+  pm.addPass(createSimpleCanonicalizerPass());
 
   // Compile to FSM
-  pm.addPass(circt::createCalyxToFSMPass());
-  pm.addPass(circt::createMaterializeCalyxToFSMPass());
+  pm.addNestedPass<calyx::ComponentOp>(circt::createCalyxToFSMPass());
+  pm.addPass(createSimpleCanonicalizerPass());
+  pm.addNestedPass<calyx::ComponentOp>(
+      circt::createMaterializeCalyxToFSMPass());
+  pm.addPass(createSimpleCanonicalizerPass());
 
   // Eliminate Calyx's group abstraction
-  pm.addPass(circt::calyx::createRemoveGroupsPass());
+  pm.addNestedPass<calyx::ComponentOp>(circt::createRemoveGroupsFromFSMPass());
+  pm.addPass(createSimpleCanonicalizerPass());
 
   // Compile to HW
   pm.addPass(circt::createCalyxToHWPass());
+  pm.addPass(createSimpleCanonicalizerPass());
+
   pm.addPass(circt::createConvertFSMToSVPass());
 
   if (failed(pm.run(module)))

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -266,19 +266,19 @@ static void loadHWLoweringPipeline(OpPassManager &pm) {
 // Tool driver code
 // --------------------------------------------------------------------------
 
-enum HLSFlowDynamicIRLevel {
+enum HLSFlowIRLevel {
   High,
-  Handshake,
+  Mid,
   Rtl,
   Sv,
 };
 
 static void printHLSFlowDynamic() {
   llvm::errs() << "Valid levels are:\n";
-  llvm::errs() << HLSFlowDynamicIRLevel::High << ": 'cf/scf/affine' level IR\n";
-  llvm::errs() << HLSFlowDynamicIRLevel::Handshake << ": 'handshake' IR\n";
-  llvm::errs() << HLSFlowDynamicIRLevel::Rtl << ": 'hw/comb/seq' IR\n";
-  llvm::errs() << HLSFlowDynamicIRLevel::Sv << ": 'hw/comb/sv' IR\n";
+  llvm::errs() << HLSFlowIRLevel::High << ": 'cf/scf/affine' level IR\n";
+  llvm::errs() << HLSFlowIRLevel::Mid << ": 'handshake/calyx' IR\n";
+  llvm::errs() << HLSFlowIRLevel::Rtl << ": 'hw/comb/seq' IR\n";
+  llvm::errs() << HLSFlowIRLevel::Sv << ": 'hw/comb/sv' IR\n";
 }
 
 static LogicalResult doHLSFlowDynamic(
@@ -286,18 +286,18 @@ static LogicalResult doHLSFlowDynamic(
     std::optional<std::unique_ptr<llvm::ToolOutputFile>> &outputFile) {
 
   if (irInputLevel < 0)
-    irInputLevel = HLSFlowDynamicIRLevel::High; // Default to highest level
+    irInputLevel = HLSFlowIRLevel::High; // Default to highest level
 
   if (irOutputLevel < 0)
-    irOutputLevel = HLSFlowDynamicIRLevel::Sv; // Default to lowest level
+    irOutputLevel = HLSFlowIRLevel::Sv; // Default to lowest level
 
-  if (irInputLevel > HLSFlowDynamicIRLevel::Sv) {
+  if (irInputLevel > HLSFlowIRLevel::Sv) {
     llvm::errs() << "Invalid IR input level: " << irInputLevel << "\n";
     printHLSFlowDynamic();
     return failure();
   }
 
-  if (outputFormat == OutputIR && (irOutputLevel > HLSFlowDynamicIRLevel::Sv)) {
+  if (outputFormat == OutputIR && (irOutputLevel > HLSFlowIRLevel::Sv)) {
     llvm::errs() << "Invalid IR output level: " << irOutputLevel << "\n";
     printHLSFlowDynamic();
     return failure();
@@ -324,20 +324,20 @@ static LogicalResult doHLSFlowDynamic(
     });
   };
 
-  addIRLevel(HLSFlowDynamicIRLevel::High, [&]() { loadDHLSPipeline(pm); });
-  addIRLevel(HLSFlowDynamicIRLevel::Handshake,
+  addIRLevel(HLSFlowIRLevel::High, [&]() { loadDHLSPipeline(pm); });
+  addIRLevel(HLSFlowIRLevel::Mid,
              [&]() { loadHandshakeTransformsPipeline(pm); });
 
   // HW path.
 
-  addIRLevel(HLSFlowDynamicIRLevel::Rtl, [&]() {
+  addIRLevel(HLSFlowIRLevel::Rtl, [&]() {
     pm.nest<handshake::FuncOp>().addPass(createSimpleCanonicalizerPass());
     pm.addPass(circt::createHandshakeToHWPass());
     pm.addPass(createSimpleCanonicalizerPass());
     loadESILoweringPipeline(pm);
   });
 
-  addIRLevel(HLSFlowDynamicIRLevel::Sv, [&]() { loadHWLoweringPipeline(pm); });
+  addIRLevel(HLSFlowIRLevel::Sv, [&]() { loadHWLoweringPipeline(pm); });
 
   if (traceIVerilog)
     pm.addPass(circt::sv::createSVTraceIVerilogPass());
@@ -365,46 +365,93 @@ static LogicalResult doHLSFlowCalyx(
     std::optional<std::unique_ptr<llvm::ToolOutputFile>> &outputFile) {
 
   if (irInputLevel < 0) {
-    irInputLevel = HLSFlowDynamicIRLevel::High; // Default to highest level
+    irInputLevel = HLSFlowIRLevel::High; // Default to highest level
   }
+
   if (irOutputLevel < 0) {
-    irOutputLevel = HLSFlowDynamicIRLevel::Sv; // Default to lowest level
+    irOutputLevel = HLSFlowIRLevel::Sv; // Default to lowest level
   }
 
-  if (irInputLevel != HLSFlowDynamicIRLevel::High) {
-    llvm::errs() << "Error: Calyx flow only supports 'high' IR input\n";
+  // Lower than SV cannot be the input
+  if (irInputLevel > HLSFlowIRLevel::Sv) {
+    llvm::errs() << "Invalid IR input level: " << irInputLevel << "\n";
+    printHLSFlowDynamic();
     return failure();
   }
 
-  if (irOutputLevel != HLSFlowDynamicIRLevel::Sv) {
-    llvm::errs() << "Error: Calyx flow only supports 'sv' IR output\n";
+  // Lower than SV cannot be an output
+  if (outputFormat == OutputIR && (irOutputLevel > HLSFlowIRLevel::Sv)) {
+    llvm::errs() << "Invalid IR output level: " << irOutputLevel << "\n";
+    printHLSFlowDynamic();
     return failure();
   }
 
-  pm.addPass(circt::createSCFToCalyxPass());
-  pm.addPass(createSimpleCanonicalizerPass());
+  // XXX(rachitnigam): Duplicated from doHLSFlowDynamic. We should probably
+  // abstract this pattern. The only problem is that addIRLevel captures this
+  // mutable variable.
+  bool suppressLaterPasses = false;
+  auto notSuppressed = [&]() { return !suppressLaterPasses; };
+  auto addIfNeeded = [&](llvm::function_ref<bool()> predicate,
+                         llvm::function_ref<void()> passAdder) {
+    if (predicate())
+      passAdder();
+  };
 
-  // Eliminate Calyx's comb group abstraction
-  pm.addNestedPass<calyx::ComponentOp>(
-      circt::calyx::createRemoveCombGroupsPass());
-  pm.addPass(createSimpleCanonicalizerPass());
+  auto addIRLevel = [&](int level, llvm::function_ref<void()> passAdder) {
+    addIfNeeded(notSuppressed, [&]() {
+      // Add the pass if the input IR level is at least the current
+      // abstraction.
+      if (irInputLevel <= level)
+        passAdder();
+      // Suppresses later passes if we're emitting IR and the output IR level is
+      // the current level.
+      if (outputFormat == OutputIR && irOutputLevel == level)
+        suppressLaterPasses = true;
+    });
+  };
 
-  // Compile to FSM
-  pm.addNestedPass<calyx::ComponentOp>(circt::createCalyxToFSMPass());
-  pm.addPass(createSimpleCanonicalizerPass());
-  pm.addNestedPass<calyx::ComponentOp>(
-      circt::createMaterializeCalyxToFSMPass());
-  pm.addPass(createSimpleCanonicalizerPass());
+  addIRLevel(HLSFlowIRLevel::High, [&]() {
+    pm.addPass(circt::createSCFToCalyxPass());
+    pm.addPass(createSimpleCanonicalizerPass());
+  });
 
-  // Eliminate Calyx's group abstraction
-  pm.addNestedPass<calyx::ComponentOp>(circt::createRemoveGroupsFromFSMPass());
-  pm.addPass(createSimpleCanonicalizerPass());
+  addIRLevel(HLSFlowIRLevel::Mid, [&]() {
+    // Eliminate Calyx's comb group abstraction
+    pm.addNestedPass<calyx::ComponentOp>(
+        circt::calyx::createRemoveCombGroupsPass());
+    pm.addPass(createSimpleCanonicalizerPass());
 
-  // Compile to HW
-  pm.addPass(circt::createCalyxToHWPass());
-  pm.addPass(createSimpleCanonicalizerPass());
+    // Compile to FSM
+    pm.addNestedPass<calyx::ComponentOp>(circt::createCalyxToFSMPass());
+    pm.addPass(createSimpleCanonicalizerPass());
+    pm.addNestedPass<calyx::ComponentOp>(
+        circt::createMaterializeCalyxToFSMPass());
+    pm.addPass(createSimpleCanonicalizerPass());
 
-  pm.addPass(circt::createConvertFSMToSVPass());
+    // Eliminate Calyx's group abstraction
+    pm.addNestedPass<calyx::ComponentOp>(
+        circt::createRemoveGroupsFromFSMPass());
+    pm.addPass(createSimpleCanonicalizerPass());
+  });
+
+  // HW path.
+
+  addIRLevel(HLSFlowIRLevel::Rtl, [&]() {
+    // Compile to HW
+    pm.addPass(circt::createCalyxToHWPass());
+    pm.addPass(createSimpleCanonicalizerPass());
+  });
+
+  addIRLevel(HLSFlowIRLevel::Sv, [&]() {
+    pm.addPass(circt::createConvertFSMToSVPass());
+    loadHWLoweringPipeline(pm);
+  });
+
+  if (outputFormat == OutputVerilog) {
+    pm.addPass(createExportVerilogPass((*outputFile)->os()));
+  } else if (outputFormat == OutputSplitVerilog) {
+    pm.addPass(createExportSplitVerilogPass(outputFilename));
+  }
 
   if (failed(pm.run(module)))
     return failure();


### PR DESCRIPTION
Fixes #5844. Attempting to add a simple `scf` to `hw` lowering flow using `calyx` to `hlstool`. Once this lands, I can work on adding the `affine` to `loopschedule` to `calyx` flow as well.