### PR TITLE
[LowerToHW] Avoid creating undriven wires for 0-width seq mems

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -179,6 +179,9 @@ def MemOp : HardwareDeclOp<"mem"> {
 
     using NamedPort = std::pair<StringAttr, MemOp::PortKind>;
 
+    /// Return the address width of the memory.
+    size_t getAddrBits();
+
     /// Return the type of a port given the memory depth, type, and kind
     static FIRRTLType getTypeForPort(uint64_t depth, FIRRTLBaseType dataType,
                                      PortKind portKind, size_t maskBits = 0);

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2286,6 +2286,12 @@ LogicalResult MemOp::verify() {
   return success();
 }
 
+static size_t getAddressWidth(size_t depth) {
+  return std::max(1U, llvm::Log2_64_Ceil(depth));
+}
+
+size_t MemOp::getAddrBits() { return getAddressWidth(getDepth()); }
+
 FIRRTLType MemOp::getTypeForPort(uint64_t depth, FIRRTLBaseType dataType,
                                  PortKind portKind, size_t maskBits) {
 
@@ -2305,8 +2311,7 @@ FIRRTLType MemOp::getTypeForPort(uint64_t depth, FIRRTLBaseType dataType,
 
   SmallVector<BundleType::BundleElement, 7> portFields;
 
-  auto addressType =
-      UIntType::get(context, std::max(1U, llvm::Log2_64_Ceil(depth)));
+  auto addressType = UIntType::get(context, getAddressWidth(depth));
 
   portFields.push_back({getId("addr"), false, addressType});
   portFields.push_back({getId("en"), false, UIntType::get(context, 1)});

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-memories.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-memories.mlir
@@ -107,8 +107,9 @@ firrtl.circuit "Foo" {
 
   // CHECK-LABEL: hw.module @ZeroDataWidth
   firrtl.module @ZeroDataWidth(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>, in %addr: !firrtl.uint<4>, in %data: !firrtl.uint<0>, in %mask: !firrtl.uint<1>) {
+    // CHECK: [[CONST_X:%.+]] = sv.constantX : i1
     // CHECK: %mem = seq.firmem 0, 1, undefined, port_order : <12 x 0>
-    // CHECK: seq.firmem.write_port %mem[{{%.+}}] = {{%.+}}, clock {{.+}} enable {{%.+}} : <12 x 0>
+    // CHECK: seq.firmem.write_port %mem[{{%.+}}] = [[CONST_X]], clock {{.+}} enable {{%.+}} : <12 x 0>
     %mem_w = firrtl.mem Undefined {depth = 12 : i64, name = "mem", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>
 
     %mem_w.clk = firrtl.subfield %mem_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>


### PR DESCRIPTION
Instead, a constant X is materialized to drive the dummy port of the `seq` memory. A subsequent PR should consider whether these memories can be removed altogether.