### PR TITLE
[LowerToHW] Emit errors instead of producing undriven wires

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1788,24 +1788,30 @@ LogicalResult FIRRTLLowering::run() {
   // are folded, which means we would have to scan the entire lowering table to
   // safely replace a backedge.
   for (auto &[backedge, value] : backedges) {
+    SmallVector<Location> driverLocs;
     // In the case where we have backedges connected to other backedges, we have
     // to find the value that actually drives the group.
     while (true) {
-      // If the we find the original backedge we have some undriven logic.
+      // If we find the original backedge we have some undriven logic or
+      // a combinatorial loop. Bail out and provide information on the nodes.
       if (backedge == value) {
-        // Create a wire with no driver and use that as the backedge value.
-        OpBuilder::InsertionGuard guard(builder);
-        builder.setInsertionPointAfterValue(backedge);
-        value = builder.create<sv::WireOp>(backedge.getLoc(),
-                                           backedge.getType(), "undriven");
-        value = builder.createOrFold<sv::ReadInOutOp>(value);
-        break;
+        Location edgeLoc = backedge.getLoc();
+        if (driverLocs.empty()) {
+          mlir::emitError(edgeLoc, "sink does not have a driver");
+        } else {
+          auto diag = mlir::emitError(edgeLoc, "sink in combinational loop");
+          for (auto loc : driverLocs)
+            diag.attachNote(loc) << "through driver here";
+        }
+        backedgeBuilder.abandon();
+        return failure();
       }
       // If the value is not another backedge, we have found the driver.
       auto it = backedges.find(value);
       if (it == backedges.end())
         break;
       // Find what is driving the next backedge.
+      driverLocs.push_back(value.getLoc());
       value = it->second;
     }
     if (auto *defOp = backedge.getDefiningOp())

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -192,3 +192,29 @@ firrtl.circuit "ConnectDestSubaccess" {
     firrtl.strictconnect %1, %value : !firrtl.uint<1>
   }
 }
+
+// -----
+
+firrtl.circuit "UndrivenInputPort" {
+  firrtl.extmodule private @Blackbox(in inst: !firrtl.uint<1>)
+
+  firrtl.module @UndrivenInputPort() {
+    // expected-error @below {{sink in combinational loop}}
+    %0 = firrtl.instance blackbox @Blackbox(in inst : !firrtl.uint<1>)
+    // expected-note @below {{through driver here}}
+    %1 = firrtl.instance blackbox @Blackbox(in inst : !firrtl.uint<1>)
+    firrtl.strictconnect %0, %1 : !firrtl.uint<1>
+    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+firrtl.circuit "InputSelfDriver" {
+  firrtl.module private @InputPorts(in %in : !firrtl.uint<1>) { }
+  firrtl.module @InputSelfDriver(in %in : !firrtl.uint<1>) {
+    // expected-error @below {{sink does not have a driver}}
+    %ip2_in = firrtl.instance ip2 @InputPorts(in in : !firrtl.uint<1>)
+    firrtl.connect %ip2_in, %ip2_in : !firrtl.uint<1>, !firrtl.uint<1>
+  }
+}

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -127,24 +127,11 @@ firrtl.circuit "Simple" {
   
   firrtl.module private @InputPorts(in %in : !firrtl.uint<1>) { }
   firrtl.module private @InputPortsParent(in %in : !firrtl.uint<1>) {
-    // Unconnected.
-    // CHECK: %undriven = sv.wire : !hw.inout<i1>
-    // CHECK: %0 = sv.read_inout %undriven : !hw.inout<i1>
-    // CHECK: hw.instance "ip0" @InputPorts(in: %0: i1) -> ()
-    %ip0_in = firrtl.instance ip0 @InputPorts(in in : !firrtl.uint<1>)
-    
     // Double connected.
     // CHECK: hw.instance "ip1" @InputPorts(in: %in: i1) -> ()
     %ip1_in = firrtl.instance ip1 @InputPorts(in in : !firrtl.uint<1>)
     firrtl.connect %ip1_in, %in : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %ip1_in, %in : !firrtl.uint<1>, !firrtl.uint<1>
-
-    // Combinational loop.
-    // CHECK: %undriven_0 = sv.wire name "undriven" : !hw.inout<i1>
-    // CHECK: %1 = sv.read_inout %undriven_0 : !hw.inout<i1>
-    // CHECK: hw.instance "ip2" @InputPorts(in: %1: i1) -> ()
-    %ip2_in = firrtl.instance ip2 @InputPorts(in in : !firrtl.uint<1>)
-    firrtl.connect %ip2_in, %ip2_in : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
   // CHECK-LABEL: hw.module private @Analog(%a1: !hw.inout<i1>) -> (outClock: i1) {
@@ -221,15 +208,14 @@ firrtl.circuit "Simple" {
   firrtl.module private @ZeroWidthInstance(in %iA: !firrtl.uint<4>,
                                    in %iB: !firrtl.uint<0>,
                                    in %iC: !firrtl.analog<0>,
+                                   in %iD: !firrtl.uint<1>,
+                                   in %iE: !firrtl.analog<1>,
                                    out %oA: !firrtl.uint<4>,
                                    out %oB: !firrtl.uint<0>) {
 
     // CHECK: %myinst.outa = hw.instance "myinst" @ZeroWidthPorts(inA: %iA: i4) -> (outa: i4)
     %myinst:5 = firrtl.instance myinst @ZeroWidthPorts(
       in inA: !firrtl.uint<4>, in inB: !firrtl.uint<0>, in inC: !firrtl.analog<0>, out outa: !firrtl.uint<4>, out outb: !firrtl.uint<0>)
-    // CHECK: = hw.instance "myinst" @SameNamePorts(inA: {{.+}}, inA: {{.+}}, inA: {{.+}}) -> (outa: i4, outa: i1)
-    %myinst_sameName:5 = firrtl.instance myinst @SameNamePorts(
-      in inA: !firrtl.uint<4>, in inA: !firrtl.uint<1>, in inA: !firrtl.analog<1>, out outa: !firrtl.uint<4>, out outa: !firrtl.uint<1>)
 
     // Output of the instance is fed into the input!
     firrtl.connect %myinst#0, %iA : !firrtl.uint<4>, !firrtl.uint<4>
@@ -237,6 +223,13 @@ firrtl.circuit "Simple" {
     firrtl.attach %myinst#2, %iC : !firrtl.analog<0>, !firrtl.analog<0>
     firrtl.connect %oA, %myinst#3 : !firrtl.uint<4>, !firrtl.uint<4>
     firrtl.connect %oB, %myinst#4 : !firrtl.uint<0>, !firrtl.uint<0>
+
+    // CHECK: = hw.instance "myinst" @SameNamePorts(inA: {{.+}}, inA: {{.+}}, inA: {{.+}}) -> (outa: i4, outa: i1)
+    %myinst_sameName:5 = firrtl.instance myinst @SameNamePorts(
+      in inA: !firrtl.uint<4>, in inA: !firrtl.uint<1>, in inA: !firrtl.analog<1>, out outa: !firrtl.uint<4>, out outa: !firrtl.uint<1>)
+    firrtl.connect %myinst_sameName#0, %iA : !firrtl.uint<4>, !firrtl.uint<4>
+    firrtl.connect %myinst_sameName#1, %iD : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.attach %myinst_sameName#2, %iE : !firrtl.analog<1>, !firrtl.analog<1>
 
     // CHECK: hw.output %myinst.outa
   }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1120,20 +1120,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.strictconnect %out, %b_inst : !firrtl.uint<1>
   }
 
-  // Check that combinational cycles with no outside driver are lowered to
-  // be driven from a wire.
-  // CHECK-LABEL: hw.module @UndrivenInputPort()
-  // CHECK-NEXT:    %undriven = sv.wire : !hw.inout<i1>
-  // CHECK-NEXT:    %0 = sv.read_inout %undriven : !hw.inout<i1>
-  // CHECK-NEXT:    hw.instance "blackbox" @Blackbox(inst: %0: i1) -> ()
-  // CHECK-NEXT:    hw.instance "blackbox" @Blackbox(inst: %0: i1) -> ()
-  firrtl.module @UndrivenInputPort() {
-    %0 = firrtl.instance blackbox @Blackbox(in inst : !firrtl.uint<1>)
-    %1 = firrtl.instance blackbox @Blackbox(in inst : !firrtl.uint<1>)
-    firrtl.strictconnect %0, %1 : !firrtl.uint<1>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
-  }
-
   // CHECK-LABEL: hw.module @LowerToFirReg(%clock: i1, %reset: i1, %value: i2)
   firrtl.module @LowerToFirReg(
     in %clock: !firrtl.clock,


### PR DESCRIPTION
Tested on a large internal core, no new errors produced.