### PR TITLE
[OM] Add map types

### DIFF
--- a/include/circt/Dialect/OM/OMTypes.td
+++ b/include/circt/Dialect/OM/OMTypes.td
@@ -51,6 +51,25 @@ def ListType : TypeDef<OMDialect, "List", []> {
   ];
 }
 
+def MapType : TypeDef<OMDialect, "Map", []> {
+  let summary = [{A type that represents a map. A key type must be either
+                  an integer or string type}];
+
+  let mnemonic = "map";
+  let parameters = (ins "mlir::Type": $keyType, "mlir::Type":$valueType);
+  let assemblyFormat = [{
+    `<` $keyType `,` $valueType `>`
+  }];
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "::mlir::Type":$keyType, "::mlir::Type":$valueType), [{
+      return $_get(keyType.getContext(), keyType, valueType);
+    }]>
+  ];
+
+  let genVerifyDecl = 1;
+}
+
 def SymbolRefType : TypeDef<OMDialect, "SymbolRef", []> {
   let summary = "A type that represents a reference to a flat symbol reference.";
 

--- a/lib/Dialect/OM/OMTypes.cpp
+++ b/lib/Dialect/OM/OMTypes.cpp
@@ -26,3 +26,12 @@ void circt::om::OMDialect::registerTypes() {
 #include "circt/Dialect/OM/OMTypes.cpp.inc"
       >();
 }
+
+mlir::LogicalResult
+circt::om::MapType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> diag,
+                           mlir::Type keyType, mlir::Type elementType) {
+  if (!llvm::isa<om::StringType, mlir::IntegerType>(keyType))
+    return diag() << "map key type must be either string or integer but got "
+                  << keyType;
+  return mlir::success();
+}

--- a/test/Dialect/OM/errors.mlir
+++ b/test/Dialect/OM/errors.mlir
@@ -96,3 +96,9 @@ om.class @ListCreate() {
   // expected-note @-2 {{prior use here}}
   %lst = om.list_create %0, %1 : i64
 }
+
+// -----
+
+// expected-error @+1 {{map key type must be either string or integer but got '!om.list<!om.string>'}}
+om.class @Map(%map: !om.map<!om.list<!om.string>, !om.string>) {
+}

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -165,3 +165,9 @@ om.class @StringConstant() {
   // CHECK: om.class.field @string, %[[const1]] : !om.string
   om.class.field @string, %0 : !om.string
 }
+
+// CHECK-LABEL: @Map
+// CHECK-SAME: !om.map<!om.string, !om.string>
+om.class @Map(%map: !om.map<!om.string, !om.string>) {
+  om.class.field @field, %map : !om.map<!om.string, !om.string>
+}


### PR DESCRIPTION
This commit adds `!om.map<key, element>` type and restrict a key type to be either integer or string.