### PR TITLE
[Transform] Initialize a new pass - GenStateStruct pass in Transform

### DIFF
--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -29,6 +29,8 @@ std::unique_ptr<mlir::Pass> createFlattenMemRefPass();
 std::unique_ptr<mlir::Pass> createFlattenMemRefCallsPass();
 std::unique_ptr<mlir::Pass> createStripDebugInfoWithPredPass(
     const std::function<bool(mlir::Location)> &pred);
+std::unique_ptr<mlir::Pass>
+createStateStructGeneratePass(bool emitNoneInfo = false);
 
 //===----------------------------------------------------------------------===//
 // Utility functions.

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -53,6 +53,25 @@ def StripDebugInfoWithPred : Pass<"strip-debuginfo-with-pred", "::mlir::ModuleOp
            "intended to be used for testing."> ];
 }
 
+def StateStructGenerate : Pass<"state-struct-generate", "::mlir::ModuleOp"> {
+  let summary = "Generate struct to store signals and reg states";
+  let description = [{
+    This pass collects elements: output reg of module, local reg / mem  in
+    current module and signal with attribute of trigger. Form a struct with these
+    elements and their clone member which will be used to represent previous one
+    of the member state. The struct will be stored in the global variable and the
+    pointer of the struct will be passed to the module. The module will be
+    overrided with the new struct pointer.
+  }];
+  
+  let dependentDialects = ["mlir::LLVM::LLVMDialect"];
+  let constructor = "circt::createStateStructGeneratePass()";
+  let options = [
+    Option<"emitNoneInfo", "emit-none-info", "bool", "false",
+            "Not emit port & reg Info to generated struct">
+  ];
+}
+
 def MapArithToCombPass : InterfacePass<"map-arith-to-comb", "circt::hw::HWModuleLike"> {
   let summary = "Map arith ops to combinational logic";
   let description = [{

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_library(CIRCTTransforms
+  GenStateStruct.cpp
   FlattenMemRefs.cpp
   StripDebugInfoWithPred.cpp
   MapArithToComb.cpp
@@ -9,9 +10,11 @@ add_circt_library(CIRCTTransforms
   LINK_LIBS PUBLIC
   CIRCTComb
   CIRCTHW
+  CIRCTSV
   MLIRArithDialect
   MLIRControlFlowDialect
   MLIRFuncDialect
+  MLIRLLVMDialect
   MLIRIR
   MLIRMemRefDialect
   MLIRSupport

--- a/lib/Transforms/GenStateStruct.cpp
+++ b/lib/Transforms/GenStateStruct.cpp
@@ -6,12 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This pass collects elements: output reg of module, local reg / mem  in
-// current module and signal with attribute of trigger. Form a struct with these
-// elements and their clone member which will be used to represent previous one
-// of the member state. The struct will be stored in the global variable and the
-// pointer of the struct will be passed to the module. The module will be
-// overrided with the new struct pointer.
+// This pass collects elements: module ports, output reg of the module, local
+// register in the current module, signal with attribute of the trigger, and
+// instance pointer. Form a struct with these elements and their clone member
+// which will be used to represent previous one of the member state. The struct
+// will be stored in the global variable and the pointer of the struct will be
+// passed to the module. The module will be overridden with the new struct
+// pointer.
 //
 //===----------------------------------------------------------------------===//
 

--- a/lib/Transforms/GenStateStruct.cpp
+++ b/lib/Transforms/GenStateStruct.cpp
@@ -737,9 +737,7 @@ void GenStateStruct::overrideModule(
 
   // Modify ports list of the module to make the pointer of struct beacome the
   // only input value in the module.
-  op.modifyPorts(/*insertInputs*/ {}, /*insertOutputs*/ {},
-                 /*eraseInputs*/ arrEraseIn,
-                 /*eraseOutputs*/ arrEraseOut);
+  modifyModulePorts(op, {}, {}, arrEraseIn, arrEraseOut, op.getBodyBlock());
 
   // Remove the original outputOp and replace it with outputOp that do not
   // output any value.

--- a/lib/Transforms/GenStateStruct.cpp
+++ b/lib/Transforms/GenStateStruct.cpp
@@ -1,0 +1,1023 @@
+//===- GenStatesStruct.cpp - hw generate struct Pass ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass collects elements: output reg of module, local reg / mem  in
+// current module and signal with attribute of trigger. Form a struct with these
+// elements and their clone member which will be used to represent previous one
+// of the member state. The struct will be stored in the global variable and the
+// pointer of the struct will be passed to the module. The module will be
+// overrided with the new struct pointer.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "circt/Dialect/HW/HWInstanceGraph.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/SV/SVPasses.h"
+#include "circt/Support/LLVM.h"
+#include "circt/Transforms/Passes.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "llvm/Support/Casting.h"
+
+using namespace circt;
+using namespace mlir;
+using namespace sv;
+using namespace hw;
+
+//===----------------------------------------------------------------------===//
+// StateStructGenerate Pass
+//===----------------------------------------------------------------------===//
+/// The Structure stores the information of the port of the module.
+struct portInfo {
+  StringRef portName;
+  Type portType;
+  int direction;
+  bool isTrigger;
+};
+
+/// The Structure stores the information of the reg of the module.
+struct regInfo {
+  StringRef regName;
+  Type regType;
+  bool isOutputReg;
+};
+
+// Declare the class of GenStateStruct Pass.
+namespace {
+class GenStateStruct {
+  // The flag to decide whether to generate the information of the ports which
+  // will be packed as structs that stored in the global variable.
+  bool emitNoneInfo;
+
+  /// The function to check for the existence of the pair to be searched for
+  /// given the input.
+  template <typename T>
+  bool isIntInPairPart(SmallVector<std::pair<T, unsigned>> &vec, T target);
+
+  /// The function to find the type of the operation in the container if the
+  /// type is found by another value in the pair-vector.
+  template <typename T>
+  T findOperationType(SmallVector<std::pair<mlir::Operation *, T>> &opTypePairs,
+                      mlir::Operation *op);
+
+  /// The function to check whether the operation is a leaf module.
+  /// The leaf module is the module which does not have any instance that comes
+  /// from other modules. The leaf module will be the end of the instance graph.
+  bool isleafModule(Operation *op);
+
+  /// The function to convert the port direction to the integer data.
+  int convertPortDirection(PortDirection direction);
+
+  /// The function to check whether this register is connected to the output
+  /// port, which we call it output register.
+  bool isOutputReg(sv::RegOp op);
+
+  /// The function to override current module with the new struct pointer.
+  void overrideModule(
+      InstanceGraph &instanceGraph, HWModuleOp op, LLVM::LLVMStructType type,
+      SmallVector<std::pair<mlir::Operation *, LLVM::LLVMPointerType>>
+          &externTypeCollect);
+
+  /// The function to override extern module with the new struct pointer.
+  /// Its struct pointer is Opaque type which is used to solve cross-translation
+  /// unit problem
+  void overrideExternModule(
+      MLIRContext *ctx, HWModuleExternOp op,
+      SmallVector<std::pair<mlir::Operation *, LLVM::LLVMPointerType>>
+          &externTypeCollect);
+
+  /// The function to override instance relationship with the newly created
+  /// struct pointer for submodule of current module.
+  void overrideInstance(
+      OpBuilder builder, Value operand, InstanceGraph &instanceGraph,
+      SmallVector<std::pair<mlir::Operation *, LLVM::LLVMPointerType>>
+          &externTypeCollect,
+      hw::InstanceOp inst, LLVM::GEPOp gep, LLVM::ConstantOp zeroC);
+
+  /// The function to convert hw::InOutType to LLVM compatible type.
+  /// Attention: we support InOutType / nested ArrayType /nested
+  /// UnpackedArrayType to convert to LLVM compatible Type. Other nested
+  /// InOutType will hit the assertions in program and stop execution of
+  /// this pass.
+  Type convertInOutType(hw::InOutType type);
+  LLVM::LLVMStructType getExternModulePortTy(MLIRContext *ctx, bool noOpaqueTy,
+                                             HWModuleExternOp op);
+
+public:
+  GenStateStruct(bool emitNoneInfo) : emitNoneInfo(emitNoneInfo) {}
+  /// The function to add prefix to the given name and return the new name.
+  std::string addPrefixToName(StringRef name);
+
+  /// This function is used to generate the struct type based on the given
+  /// infomation of current module. The struct type is packed defaultly.
+  /// If the module is an extern module which only have a declaration, generate
+  /// opaque struct type for it.
+  LLVM::LLVMStructType createStructType(MLIRContext *ctx, HWModuleOp op,
+                                        unsigned secondaryTriggerNum,
+                                        SmallVector<portInfo> &pInfo,
+                                        SmallVector<regInfo> &rInfo);
+
+  /// The function to create the global struct that is used to store all state
+  /// values and ports infomation.
+  LLVM::GlobalOp createGlobalStruct(Location loc, OpBuilder &builder,
+                                    ModuleOp module, StringRef name,
+                                    LLVM::LLVMStructType type);
+
+  /// The function to initialize the global struct with default value 0, and
+  /// return initialized struct object.
+  void initializeGlobalStruct(OpBuilder &builder, HWModuleOp op,
+                              LLVM::GlobalOp globalOp,
+                              LLVM::LLVMStructType type,
+                              unsigned secondaryTriggerNum,
+                              SmallVector<portInfo> &pInfo,
+                              SmallVector<regInfo> &rInfo);
+
+  /// The function is used to collect all ports info above the given module.
+  /// The collected info: port name, port type, port direction and whether it is
+  /// trigger signal.
+  void collectPortInfo(HWModuleOp op, SmallVector<portInfo> &pInfo);
+
+  /// The function is used to collect all regs info in the given module.
+  /// The collected info: reg name, reg type and whether it is output reg.
+  void collectRegInfo(HWModuleOp op, SmallVector<regInfo> &rInfo);
+
+  /// The function to override all modules in InstanceGraph based on a
+  /// depth-first algorithm.
+  void dfsOverrideModules(
+      MLIRContext *ctx,
+      SmallVector<std::pair<mlir::Operation *, LLVM::LLVMStructType>>
+          &typeCollect,
+      SmallVector<std::pair<mlir::Operation *, LLVM::LLVMPointerType>>
+          &externTypeCollect,
+      InstanceGraph &instanceGraph, DenseSet<Operation *> &overrided,
+      Operation *topOp);
+
+  /// The function to get the number of secondary trigger signal.
+  unsigned getNumOfSecondaryTriggerNum(HWModuleOp op);
+};
+
+struct StateStructGeneratePass
+    : public StateStructGenerateBase<StateStructGeneratePass> {
+  void runOnOperation() override;
+
+  using StateStructGenerateBase<StateStructGeneratePass>::emitNoneInfo;
+};
+} // namespace
+
+bool GenStateStruct::isOutputReg(sv::RegOp op) {
+  bool outputReg = false;
+  for (auto *user : op->getUsers()) {
+    if (isa<hw::OutputOp>(user)) {
+      outputReg = true;
+      break;
+    }
+  }
+  return outputReg;
+}
+
+int GenStateStruct::convertPortDirection(PortDirection direction) {
+  // The value 0 is used to represent the port direction is unknown.
+  // when other function handle the value 0, it will hit the assertion.
+  int i = 0;
+  switch (direction) {
+  case (PortDirection::INPUT):
+    i = 1;
+    break;
+  case (PortDirection::OUTPUT):
+    i = 2;
+    break;
+  case (PortDirection::INOUT):
+    i = 3;
+    break;
+  }
+  return i;
+}
+
+// Check the value is stored in the Container or not.
+template <typename T>
+bool GenStateStruct::isIntInPairPart(SmallVector<std::pair<T, unsigned>> &vec,
+                                     T target) {
+  // Traverse all elements in contanier.
+  return std::any_of(vec.begin(), vec.end(),
+                     [&](const std::pair<T, unsigned> &p) {
+                       // Check if there is the target value, return result.
+                       return p.first == target;
+                     });
+}
+
+template <typename T>
+T GenStateStruct::findOperationType(
+    SmallVector<std::pair<mlir::Operation *, T>> &opTypePairs,
+    mlir::Operation *op) {
+  auto it = llvm::find_if(opTypePairs,
+                          [op](const std::pair<mlir::Operation *, T> &pair) {
+                            return pair.first == op;
+                          });
+  if (it != opTypePairs.end())
+    return it->second;
+  // throw an exception, if not find the type.
+  assert(it == opTypePairs.end() && "Can't find the type of the operation");
+  return nullptr;
+}
+
+bool GenStateStruct::isleafModule(Operation *op) {
+  if (isa<hw::HWModuleOp>(op))
+    return dyn_cast<hw::HWModuleOp>(op).getOps<hw::InstanceOp>().empty();
+  if (isa<hw::HWModuleExternOp>(op))
+    return true;
+
+  return false;
+}
+
+std::string GenStateStruct::addPrefixToName(StringRef name) {
+  std::string prefix = "_Struct_";
+  prefix.append(name.data(), name.size());
+  return prefix;
+}
+
+Type GenStateStruct::convertInOutType(hw::InOutType type) {
+  auto elementTy = getInOutElementType(type);
+  // Convert the element type to LLVM compatible type.
+  if (elementTy.isa<IntegerType>()) {
+    return IntegerType::get(type.getContext(),
+                            elementTy.getIntOrFloatBitWidth());
+  }
+  if (elementTy.isa<hw::ArrayType>()) {
+    return LLVM::LLVMArrayType::get(
+        getAnyHWArrayElementType(elementTy),
+        dyn_cast<hw::ArrayType>(elementTy).getSize());
+  }
+  if (elementTy.isa<hw::UnpackedArrayType>()) {
+    return LLVM::LLVMArrayType::get(
+        getAnyHWArrayElementType(elementTy),
+        dyn_cast<hw::UnpackedArrayType>(elementTy).getSize());
+  }
+  return elementTy;
+}
+
+LLVM::LLVMStructType
+GenStateStruct::getExternModulePortTy(MLIRContext *ctx, bool noOpaqueTy,
+                                      HWModuleExternOp op) {
+  SmallVector<Type> extModuleTy;
+  SmallVector<PortInfo> externPInfo = op.getAllPorts();
+
+  // The noOpaqueTy decides whether to create a opaque type or not.
+  if (noOpaqueTy) {
+    for (auto pInfo : externPInfo) {
+      extModuleTy.push_back(pInfo.type);
+    }
+    return LLVM::LLVMStructType::getLiteral(ctx, extModuleTy,
+                                            /*isPacked=*/true);
+  }
+
+  return LLVM::LLVMStructType::getOpaque(addPrefixToName(op.getName()), ctx);
+}
+
+LLVM::LLVMStructType GenStateStruct::createStructType(
+    MLIRContext *ctx, HWModuleOp op, unsigned secondaryTriggerNum,
+    SmallVector<portInfo> &pInfo, SmallVector<regInfo> &rInfo) {
+  auto i1Ty = IntegerType::get(ctx, 1);
+  auto i2Ty = IntegerType::get(ctx, 2);
+  auto i8Ty = IntegerType::get(ctx, 8);
+
+  // Create three container to store the type of 1. ports & regs, 2. triiger
+  // signal & delay regs. 3. packed struct for storing all critical information,
+  // the last struct pointer that is used to create instance relationships.
+  SmallVector<Type> clonedPortTy;
+  SmallVector<Type> delayedTy;
+  SmallVector<Type> packedStructTy;
+
+  LLVM::LLVMStructType innerStructTy;
+
+  // Generate the type of the port part.
+  for (portInfo pstruct : pInfo) {
+    if (pstruct.portType.isa<InOutType>())
+      pstruct.portType =
+          convertInOutType(dyn_cast<hw::InOutType>(pstruct.portType));
+
+    // Add emitNoneInfo to control generation of port-info type.
+    if (!emitNoneInfo) {
+      auto arrayTy = LLVM::LLVMArrayType::get(i8Ty, pstruct.portName.size());
+      if (pstruct.direction != 2)
+        innerStructTy = LLVM::LLVMStructType::getLiteral(
+            ctx, {arrayTy, pstruct.portType, i2Ty, i1Ty},
+            /*isPacked=*/true);
+      else
+        innerStructTy = LLVM::LLVMStructType::getLiteral(
+            ctx, {arrayTy, pstruct.portType, i2Ty},
+            /*isPacked=*/true);
+      packedStructTy.push_back(innerStructTy);
+    }
+    clonedPortTy.push_back(pstruct.portType);
+
+    if (pstruct.isTrigger)
+      delayedTy.push_back(pstruct.portType);
+  }
+
+  // Generate the type for the secondary trigger signal part.
+  for (size_t i = 0; i < secondaryTriggerNum; i++)
+    delayedTy.push_back(i1Ty);
+
+  // Generate the type for register part.
+  for (regInfo rstruct : rInfo) {
+    if (rstruct.regType.isa<InOutType>())
+      rstruct.regType =
+          convertInOutType(dyn_cast<hw::InOutType>(rstruct.regType));
+
+    // Add emitNoneInfo to control generation of reg-info type.
+    if (!emitNoneInfo) {
+      auto arrayTy = LLVM::LLVMArrayType::get(i8Ty, rstruct.regName.size());
+      innerStructTy = LLVM::LLVMStructType::getLiteral(
+          ctx, {arrayTy, rstruct.regType, i1Ty},
+          /*isPacked=*/true);
+      packedStructTy.push_back(innerStructTy);
+    }
+
+    clonedPortTy.push_back(rstruct.regType);
+    delayedTy.push_back(rstruct.regType);
+  }
+
+  // Generate the pointer type for the submodule part.
+  for (auto inst : llvm::make_early_inc_range(op.getOps<hw::InstanceOp>())) {
+    if (isa<HWModuleOp>(inst.getReferencedModule())) {
+      innerStructTy = LLVM::LLVMStructType::getIdentified(
+          ctx, addPrefixToName(
+                   dyn_cast<HWModuleOp>(inst.getReferencedModule()).getName()));
+    } else {
+      innerStructTy = getExternModulePortTy(
+          ctx, false, dyn_cast<HWModuleExternOp>(inst.getReferencedModule()));
+    }
+    packedStructTy.push_back(LLVM::LLVMPointerType::get(innerStructTy));
+  }
+
+  // Combine all container to create the final struct type.
+  clonedPortTy.insert(clonedPortTy.end(), delayedTy.begin(), delayedTy.end());
+  clonedPortTy.insert(clonedPortTy.end(), packedStructTy.begin(),
+                      packedStructTy.end());
+
+  // The NewIdentified struct type has an explicit name and type. If we want to
+  // change the struct type to add or remove some members,we need to remove the
+  // whole struct definition beacuse the Indentified Struct does not support
+  // modify structure directly.
+  return LLVM::LLVMStructType::getNewIdentified(
+      ctx, addPrefixToName(op.getName()), clonedPortTy,
+      /*isPacked=*/true);
+}
+
+LLVM::GlobalOp GenStateStruct::createGlobalStruct(Location loc,
+                                                  OpBuilder &builder,
+                                                  ModuleOp module,
+                                                  StringRef name,
+                                                  LLVM::LLVMStructType type) {
+  LLVM::GlobalOp global;
+
+  // Create an empty global struct which is uninitialized.
+  if (!(global = module.lookupSymbol<LLVM::GlobalOp>(name))) {
+    OpBuilder::InsertionGuard insertGuard(builder);
+    builder.setInsertionPointToStart(module.getBody());
+    global = builder.create<LLVM::GlobalOp>(loc, type, /*isConstant=*/false,
+                                            LLVM::Linkage::Internal, name,
+                                            Attribute(),
+                                            /*alignment=*/0, /*addrspace=*/0);
+  }
+  return global;
+}
+
+// TODO: initialize the global struct with completely random value. Maybe it is
+// a new option for this pass.
+void GenStateStruct::initializeGlobalStruct(OpBuilder &builder, HWModuleOp op,
+                                            LLVM::GlobalOp globalOp,
+                                            LLVM::LLVMStructType type,
+                                            unsigned secondaryTriggerNum,
+                                            SmallVector<portInfo> &pInfo,
+                                            SmallVector<regInfo> &rInfo) {
+  // Initialize the global struct with specified information.
+  Location loc = globalOp.getLoc();
+  MLIRContext *ctx = builder.getContext();
+  Region &region = globalOp.getInitializerRegion();
+  Block *block = builder.createBlock(&region);
+  builder.setInsertionPoint(block, block->begin());
+
+  LLVM::LLVMStructType innerStructTy;
+  IntegerType i1Ty = IntegerType::get(ctx, 1);
+  IntegerType i2Ty = IntegerType::get(ctx, 2);
+  IntegerType i8Ty = IntegerType::get(builder.getContext(), 8);
+
+  SmallVector<Value> allInfo;
+  SmallVector<Value> allDelayed;
+  SmallVector<Value> allPortReg;
+
+  // Create operations which initialize the port part.
+  for (portInfo pstruct : pInfo) {
+    if (pstruct.portType.isa<InOutType>())
+      pstruct.portType =
+          convertInOutType(dyn_cast<hw::InOutType>(pstruct.portType));
+
+    if (!emitNoneInfo) {
+      SmallVector<LLVM::ConstantOp> op;
+      SmallVector<Value> innerPacked;
+      LLVM::LLVMArrayType arrayTy =
+          LLVM::LLVMArrayType::get(i8Ty, pstruct.portName.size());
+
+      // Convert the port name to char array.
+      for (char c : pstruct.portName)
+        op.push_back(builder.create<LLVM::ConstantOp>(loc, i8Ty, int(c)));
+
+      Value array = builder.create<LLVM::UndefOp>(loc, arrayTy);
+      for (size_t i = 0, e = arrayTy.getNumElements(); i < e; ++i)
+        array = builder.create<LLVM::InsertValueOp>(loc, array, op[i], i);
+
+      innerPacked.push_back(array);
+
+      if (pstruct.direction != 2 && pstruct.direction != 0) {
+        innerStructTy = LLVM::LLVMStructType::getLiteral(
+            ctx, {arrayTy, pstruct.portType, i2Ty, i1Ty},
+            /*isPacked=*/true);
+
+        // If the data of port direction is invalid, throw an error and stop
+        // initialization.
+      } else if (pstruct.direction == 0) {
+        emitError(loc, "Failed to initialize this global struct beacuse of "
+                       "invalid port direction!");
+      } else {
+        innerStructTy = LLVM::LLVMStructType::getLiteral(
+            ctx, {arrayTy, pstruct.portType, i2Ty},
+            /*isPacked=*/true);
+      }
+
+      innerPacked.push_back(
+          builder.create<LLVM::ConstantOp>(loc, pstruct.portType, 0));
+      innerPacked.push_back(
+          builder.create<LLVM::ConstantOp>(loc, i2Ty, pstruct.direction));
+      innerPacked.push_back(
+          builder.create<LLVM::ConstantOp>(loc, i1Ty, pstruct.isTrigger));
+      Value packedStruct = builder.create<LLVM::UndefOp>(loc, innerStructTy);
+
+      for (size_t j = 0, e = innerStructTy.getBody().size(); j < e; ++j) {
+        packedStruct = builder.create<LLVM::InsertValueOp>(loc, packedStruct,
+                                                           innerPacked[j], j);
+      }
+      allInfo.push_back(packedStruct);
+    }
+
+    // If the port is a trigger, add it to the allDelayed vector.
+    allPortReg.push_back(
+        builder.create<LLVM::ConstantOp>(loc, pstruct.portType, 0));
+    if (pstruct.isTrigger)
+      allDelayed.push_back(
+          builder.create<LLVM::ConstantOp>(loc, pstruct.portType, 0));
+  }
+
+  // Create operations which initialize the register part.
+  for (size_t i = 0; i < secondaryTriggerNum; i++)
+    allDelayed.push_back(builder.create<LLVM::ConstantOp>(loc, i1Ty, 0));
+
+  // Create operations which initialize the register part.
+  for (regInfo rstruct : rInfo) {
+    if (rstruct.regType.isa<InOutType>())
+      rstruct.regType =
+          convertInOutType(dyn_cast<hw::InOutType>(rstruct.regType));
+
+    if (!emitNoneInfo) {
+      SmallVector<LLVM::ConstantOp> op;
+      SmallVector<Value> innerPacked;
+      LLVM::LLVMArrayType arrayTy =
+          LLVM::LLVMArrayType::get(i8Ty, rstruct.regName.size());
+
+      for (char c : rstruct.regName)
+        op.push_back(builder.create<LLVM::ConstantOp>(loc, i8Ty, int(c)));
+
+      Value array = builder.create<LLVM::UndefOp>(loc, arrayTy);
+      for (size_t i = 0, e = arrayTy.getNumElements(); i < e; ++i)
+        array = builder.create<LLVM::InsertValueOp>(loc, array, op[i], i);
+
+      innerPacked.push_back(array);
+
+      if (isa<IntegerType>(rstruct.regType))
+        innerPacked.push_back(
+            builder.create<LLVM::ConstantOp>(loc, rstruct.regType, 0));
+      else if (isa<LLVM::LLVMArrayType>(rstruct.regType)) {
+        auto regTy = dyn_cast<LLVM::LLVMArrayType>(rstruct.regType);
+        auto zeroC =
+            builder.create<LLVM::ConstantOp>(loc, regTy.getElementType(), 0);
+        Value array = builder.create<LLVM::UndefOp>(loc, regTy);
+
+        for (size_t i = 0; i < regTy.getNumElements(); i++)
+          array = builder.create<LLVM::InsertValueOp>(loc, array, zeroC, i);
+
+        innerPacked.push_back(array);
+      } else
+        emitError(loc, "Failed to initialize this global struct beacuse of "
+                       "invalid register type!");
+
+      innerPacked.push_back(
+          builder.create<LLVM::ConstantOp>(loc, i1Ty, rstruct.isOutputReg));
+
+      innerStructTy = LLVM::LLVMStructType::getLiteral(
+          ctx, {arrayTy, rstruct.regType, i1Ty},
+          /*isPacked=*/true);
+      Value packedStruct = builder.create<LLVM::UndefOp>(loc, innerStructTy);
+
+      for (size_t j = 0, e = innerStructTy.getBody().size(); j < e; ++j) {
+        packedStruct = builder.create<LLVM::InsertValueOp>(loc, packedStruct,
+                                                           innerPacked[j], j);
+      }
+      allInfo.push_back(packedStruct);
+    }
+
+    // If the register is an output register, add it to the allDelayed vector.
+    if (isa<IntegerType>(rstruct.regType)) {
+      allPortReg.push_back(
+          builder.create<LLVM::ConstantOp>(loc, rstruct.regType, 0));
+      allDelayed.push_back(
+          builder.create<LLVM::ConstantOp>(loc, rstruct.regType, 0));
+
+      // if the register is an array (one dimension or more), initialize
+      // it with inserting value 0 to every elements in it.
+    } else if (isa<LLVM::LLVMArrayType>(rstruct.regType)) {
+      auto regTy = dyn_cast<LLVM::LLVMArrayType>(rstruct.regType);
+      auto zeroC =
+          builder.create<LLVM::ConstantOp>(loc, regTy.getElementType(), 0);
+      Value array = builder.create<LLVM::UndefOp>(loc, regTy);
+
+      for (size_t k = 0, e = regTy.getNumElements(); k < e; k++)
+        array = builder.create<LLVM::InsertValueOp>(loc, array, zeroC, k);
+
+      allPortReg.push_back(array);
+      allDelayed.push_back(array);
+
+    } else {
+      emitError(loc, "Failed to initialize this global struct beacuse of "
+                     "invalid register type!");
+    }
+  }
+  // Create operations which initialize the submodule part.
+  for (auto inst : llvm::make_early_inc_range(op.getOps<hw::InstanceOp>())) {
+    if (isa<HWModuleOp>(inst.getReferencedModule()))
+      innerStructTy = LLVM::LLVMStructType::getIdentified(
+          ctx, addPrefixToName(
+                   dyn_cast<HWModuleOp>(inst.getReferencedModule()).getName()));
+    else
+      innerStructTy = getExternModulePortTy(
+          ctx, false, dyn_cast<HWModuleExternOp>(inst.getReferencedModule()));
+
+    Value nullPtr = builder.create<LLVM::NullOp>(
+        loc, LLVM::LLVMPointerType::get(innerStructTy));
+    allInfo.push_back(nullPtr);
+  }
+
+  // Combine all the operations that are used for initialization in order.
+  Value finalStruct = builder.create<LLVM::UndefOp>(loc, type);
+  allPortReg.insert(allPortReg.end(), allDelayed.begin(), allDelayed.end());
+  allPortReg.insert(allPortReg.end(), allInfo.begin(), allInfo.end());
+
+  for (size_t i = 0, e = type.getBody().size(); i < e; ++i) {
+    finalStruct =
+        builder.create<LLVM::InsertValueOp>(loc, finalStruct, allPortReg[i], i);
+  }
+  builder.create<LLVM::ReturnOp>(loc, finalStruct);
+}
+
+void GenStateStruct::collectPortInfo(HWModuleOp op,
+                                     SmallVector<portInfo> &pInfo) {
+  SmallVector<unsigned> triIndexCollect;
+  auto argSize = op.getNumInOrInoutPorts();
+  auto resSize = op.getResultTypes().size();
+  auto arrayAttr = cast_if_present<ArrayAttr>(op->getAttr("sv.trigger"));
+
+  if (arrayAttr)
+    for (auto triAttr : arrayAttr)
+      triIndexCollect.push_back(
+          cast<IntegerAttr>(triAttr).getValue().getZExtValue());
+
+  SmallVector<PortInfo> port = getAllModulePortInfos(op);
+  // Get and store the port information, if it is trigger signal, then duplicate
+  // it in the port list.
+  for (size_t i = 0; i < argSize; i++) {
+    bool isContain = false;
+
+    if (arrayAttr != nullptr)
+      isContain = std::find(triIndexCollect.begin(), triIndexCollect.end(),
+                            i) != triIndexCollect.end();
+
+    if (isContain)
+      pInfo.push_back({port[i].name, port[i].type,
+                       convertPortDirection(port[i].direction), true});
+    else
+      pInfo.push_back({port[i].name, port[i].type,
+                       convertPortDirection(port[i].direction), false});
+  }
+  for (size_t j = argSize; j < argSize + resSize; j++) {
+    pInfo.push_back({port[j].name, port[j].type,
+                     convertPortDirection(port[j].direction), false});
+  }
+}
+
+void GenStateStruct::collectRegInfo(HWModuleOp op,
+                                    SmallVector<regInfo> &rInfo) {
+  for (auto regOp : llvm::make_early_inc_range(op.getOps<sv::RegOp>())) {
+    bool outputReg = isOutputReg(regOp);
+    rInfo.push_back({regOp.getName(), regOp.getType(), outputReg});
+  }
+}
+
+unsigned GenStateStruct::getNumOfSecondaryTriggerNum(HWModuleOp op) {
+  unsigned secondaryTriggerNum = 0;
+  // First, check if there is any sv.trigger attribute in the operation.
+  for (auto &innerOp : op.getOps()) {
+    if (innerOp.hasAttr("sv.trigger")) {
+      // If there is ,convert the triiger attribute to ArrayAttr and get its
+      // size().
+      auto arrayAttr =
+          dyn_cast_or_null<ArrayAttr>(innerOp.getAttr("sv.trigger"));
+      secondaryTriggerNum += arrayAttr.size();
+    }
+  }
+  return secondaryTriggerNum;
+}
+
+void GenStateStruct::overrideModule(
+    InstanceGraph &instanceGraph, HWModuleOp op, LLVM::LLVMStructType type,
+    SmallVector<std::pair<mlir::Operation *, LLVM::LLVMPointerType>>
+        &externTypeCollect) {
+  auto loc = op.getLoc();
+
+  // Collect numbers of every parts in struct to calculate indexes for GEPOp
+  unsigned inputPortNum = op.getNumArguments();
+  unsigned outputPortNum = op.getNumResults();
+  unsigned regNum = 0;
+  unsigned triggerVNum = 0;
+  unsigned instanceNum = 0;
+
+  SmallVector<sv::RegOp> allReg;
+  ArrayRef<mlir::Type> typeList = type.getBody();
+
+  for (sv::RegOp regOp : llvm::make_early_inc_range(op.getOps<sv::RegOp>())) {
+    allReg.push_back(regOp);
+    regNum++;
+  }
+
+  if (auto arrayAttr = dyn_cast_or_null<ArrayAttr>(op->getAttr("sv.trigger")))
+    triggerVNum += arrayAttr.size();
+  triggerVNum += getNumOfSecondaryTriggerNum(op);
+
+  OpBuilder builder = OpBuilder::atBlockBegin(op.getBodyBlock());
+  // auto saveInPoint = builder.saveInsertionPoint();
+
+  // Prepare basic info for newly added input port in PortInfo form.
+  StringAttr strAttr =
+      StringAttr::get(builder.getContext(), "ptr_struct_" + op.getName());
+  SmallVector<unsigned> arrEraseIn, arrEraseOut;
+
+  // Insert the struct pointer that preserves all ports and states variables in
+  // current module, the insertion index is 0, and get the newly added arg as
+  // arg0 variable.
+  op.prependInput(strAttr, LLVM::LLVMPointerType::get(type));
+
+  // Create constantOp that is used in GEPOp as start index.
+  auto i32Ty = IntegerType::get(builder.getContext(), 32);
+  auto zeroC = builder.create<LLVM::ConstantOp>(loc, i32Ty,
+                                                builder.getI32IntegerAttr(0));
+  auto arg0 = op.getArgument(0);
+  // Replace uses of operations from original block arguments to newly added
+  // struct pointer argument.
+  for (size_t i = 1; i < inputPortNum + 1; i++) {
+    auto arg = op.getArgument(i);
+
+    // If this block argument has users, do replacement to its uses chain.
+    if (!arg.use_empty()) {
+      auto indexC = builder.create<LLVM::ConstantOp>(
+          loc, i32Ty, builder.getI32IntegerAttr(i - 1));
+      auto gep = builder.create<LLVM::GEPOp>(
+          loc, LLVM::LLVMPointerType::get(typeList[i - 1]), arg0,
+          ArrayRef<Value>({zeroC, indexC}), /*isInbounds=*/true);
+
+      auto load = builder.create<LLVM::LoadOp>(loc, gep);
+
+      // Update the usechain of argument to the member that is geted from newly
+      // added arg.
+      arg.replaceAllUsesWith(load);
+      indexC.erase();
+    }
+  }
+
+  // Reset Insertion point to the end of block.
+  auto output = cast<hw::OutputOp>(op.getBodyBlock()->getTerminator());
+  builder.setInsertionPointToEnd(op.getBodyBlock());
+  auto oldPoint = builder.saveInsertionPoint();
+
+  // Alter original output dataflow to update states of inner members in struct
+  for (unsigned j = 0; j < outputPortNum; j++) {
+    auto operand = output->getOperand(j);
+
+    // Create operations to store corresponding result values.
+    auto resIndexC = builder.create<LLVM::ConstantOp>(
+        loc, i32Ty, builder.getI32IntegerAttr(inputPortNum + j));
+    auto gep = builder.create<LLVM::GEPOp>(
+        loc, LLVM::LLVMPointerType::get(typeList[inputPortNum + j]), arg0,
+        ArrayRef<Value>({zeroC, resIndexC}), /*isInbounds=*/true);
+    builder.create<LLVM::StoreOp>(loc, operand, gep);
+    resIndexC.erase();
+  }
+
+  // Collect the ports indexes which are needed to be removed
+  for (size_t i = 1; i < inputPortNum + 1; i++)
+    arrEraseIn.push_back(i);
+
+  for (size_t j = 0; j < outputPortNum; j++)
+    arrEraseOut.push_back(j);
+
+  // Modify ports list of the module to make the pointer of struct beacome the
+  // only input value in the module.
+  op.modifyPorts(/*insertInputs*/ {}, /*insertOutputs*/ {},
+                 /*eraseInputs*/ arrEraseIn,
+                 /*eraseOutputs*/ arrEraseOut);
+
+  // Remove the original outputOp and replace it with outputOp that do not
+  // output any value.
+  builder.create<hw::OutputOp>(loc, std::nullopt);
+  output.erase();
+
+  // Overriding Instances in current module.
+  for (auto inst : llvm::make_early_inc_range(op.getOps<hw::InstanceOp>())) {
+    Value bitcast;
+    unsigned instIndex = 0;
+    builder.setInsertionPoint(inst);
+
+    // if disable emitNoneInfo, calculate the index of instance includes info
+    // elements members.
+    if (!emitNoneInfo)
+      instIndex = (inputPortNum + outputPortNum) * 2 + regNum * 3 +
+                  triggerVNum + instanceNum;
+    else
+      instIndex =
+          inputPortNum + outputPortNum + regNum * 2 + triggerVNum + instanceNum;
+
+    auto resIndexC = builder.create<LLVM::ConstantOp>(
+        loc, i32Ty, builder.getI32IntegerAttr(instIndex));
+    auto gep = builder.create<LLVM::GEPOp>(
+        loc, LLVM::LLVMPointerType::get(typeList[instIndex]), arg0,
+        ArrayRef<Value>({zeroC, resIndexC}), /*isInbounds=*/true);
+    auto load = builder.create<LLVM::LoadOp>(loc, gep);
+    resIndexC.erase();
+
+    auto loadTy = dyn_cast<LLVM::LLVMPointerType>(load.getType());
+    auto instStructTy = dyn_cast<LLVM::LLVMStructType>(loadTy.getElementType());
+
+    if (!instStructTy.isOpaque()) {
+      bitcast = load;
+    } else {
+      auto exPtrTy =
+          findOperationType(externTypeCollect, inst.getReferencedModule());
+      bitcast = builder.create<LLVM::BitcastOp>(loc, exPtrTy, load);
+    }
+
+    // Add logic of transfering states to instances.
+    for (size_t i = 0; i < inst.getNumOperands(); i++) {
+      auto operand = inst.getOperand(i);
+      auto type = operand.getType();
+
+      if (operand.getType().isa<hw::InOutType>())
+        type = convertInOutType(dyn_cast<hw::InOutType>(type));
+
+      auto operandIndexC = builder.create<LLVM::ConstantOp>(
+          loc, i32Ty, builder.getI32IntegerAttr(i));
+      auto state = builder.create<LLVM::GEPOp>(
+          loc, LLVM::LLVMPointerType::get(type), bitcast,
+          ArrayRef<Value>({zeroC, operandIndexC}), /*isInbounds=*/true);
+      builder.create<LLVM::StoreOp>(loc, operand, state);
+      operandIndexC.erase();
+    }
+
+    overrideInstance(builder, load, instanceGraph, externTypeCollect, inst, gep,
+                     zeroC);
+
+    builder.restoreInsertionPoint(oldPoint);
+    instanceNum++;
+  }
+}
+
+void GenStateStruct::overrideExternModule(
+    MLIRContext *ctx, hw::HWModuleExternOp op,
+    SmallVector<std::pair<mlir::Operation *, LLVM::LLVMPointerType>>
+        &externTypeCollect) {
+  auto inputPortNum = op.getNumArguments();
+  auto outputPortNum = op.getNumResults();
+
+  // Collect the extern module and its corresponding pointer type that will
+  // bitcast to.
+  std::pair<mlir::Operation *, LLVM::LLVMPointerType> pair = std::make_pair(
+      op.getOperation(),
+      LLVM::LLVMPointerType::get(getExternModulePortTy(ctx, true, op)));
+  externTypeCollect.push_back(pair);
+
+  // Prepare basic info for newly added input port in PortInfo form.
+  StringAttr strAttr = StringAttr::get(ctx, "ptr_struct_" + op.getName());
+  hw::PortInfo structPInfo = {
+      strAttr, hw::PortDirection::INPUT,
+      LLVM::LLVMPointerType::get(getExternModulePortTy(ctx, false, op)), 0};
+  std::pair<unsigned, PortInfo> arrInsertIn = {0, structPInfo};
+  SmallVector<unsigned> arrEraseIn, arrEraseOut;
+
+  for (size_t i = 0; i < inputPortNum; i++)
+    arrEraseIn.push_back(i);
+
+  for (size_t j = 0; j < outputPortNum; j++)
+    arrEraseOut.push_back(j);
+
+  op.modifyPorts(/*insertInputs*/ arrInsertIn, /*insertOutputs*/ {},
+                 /*eraseInputs*/ arrEraseIn, /*eraseOutputs*/ arrEraseOut);
+}
+
+void GenStateStruct::overrideInstance(
+    OpBuilder builder, Value operand, InstanceGraph &instanceGraph,
+    SmallVector<std::pair<mlir::Operation *, LLVM::LLVMPointerType>>
+        &externTypeCollect,
+    hw::InstanceOp inst, LLVM::GEPOp gep, LLVM::ConstantOp zeroC) {
+
+  // Get necessary info from the original instance
+  auto loc = inst.getLoc();
+  auto *ctx = builder.getContext();
+  auto *subModule = inst.getReferencedModule();
+  auto i32Ty = IntegerType::get(ctx, 32);
+  auto instName = StringAttr::get(ctx, inst.getInstanceName());
+  auto instArgNums = inst.getNumOperands();
+  auto nameAttr = StringAttr::get(ctx, "sv.trigger");
+
+  auto gepType = dyn_cast<LLVM::LLVMPointerType>(gep.getType());
+  auto refedPointerType =
+      dyn_cast<LLVM::LLVMPointerType>(gepType.getElementType());
+  auto refedStructType =
+      dyn_cast<LLVM::LLVMStructType>(refedPointerType.getElementType());
+  auto refedTypeList = refedStructType.getBody();
+
+  // Create new instance with new prototype
+  auto newInst = builder.create<hw::InstanceOp>(loc, subModule, instName,
+                                                operand, inst.getParameters());
+
+  if (auto triggerAttr = inst->getAttrOfType<ArrayAttr>(nameAttr))
+    newInst->setAttr(nameAttr, triggerAttr);
+
+  Value bitcast, subGep;
+  ArrayRef<mlir::Type> exPtrTypeList;
+  LLVM::LLVMPointerType ptrTy, exPtrTy;
+
+  if (refedStructType.isOpaque()) {
+    exPtrTy = findOperationType(externTypeCollect, subModule);
+    bitcast = builder.create<LLVM::BitcastOp>(loc, exPtrTy, operand);
+    exPtrTypeList =
+        dyn_cast<LLVM::LLVMStructType>(exPtrTy.getElementType()).getBody();
+  }
+
+  for (size_t i = 0; i < inst.getNumResults(); i++) {
+    auto resIndexC = builder.create<LLVM::ConstantOp>(
+        loc, i32Ty, builder.getI32IntegerAttr(instArgNums + i));
+
+    if (!refedStructType.isOpaque()) {
+      ptrTy = LLVM::LLVMPointerType::get(refedTypeList[instArgNums + i]);
+      subGep = builder.create<LLVM::GEPOp>(loc, ptrTy, operand,
+                                           ArrayRef<Value>({zeroC, resIndexC}),
+                                           /*isInbounds=*/true);
+    } else {
+      ptrTy = LLVM::LLVMPointerType::get(exPtrTypeList[instArgNums + i]);
+      subGep = builder.create<LLVM::GEPOp>(loc, ptrTy, bitcast,
+                                           ArrayRef<Value>({zeroC, resIndexC}),
+                                           /*isInbounds=*/true);
+    }
+
+    auto subLoad = builder.create<LLVM::LoadOp>(loc, subGep);
+    inst.getResult(i).replaceAllUsesWith(subLoad);
+  }
+
+  // Replace original instance with new one
+  instanceGraph.replaceInstance(inst, newInst);
+  inst.erase();
+}
+
+void GenStateStruct::dfsOverrideModules(
+    MLIRContext *ctx,
+    SmallVector<std::pair<mlir::Operation *, LLVM::LLVMStructType>>
+        &typeCollect,
+    SmallVector<std::pair<mlir::Operation *, LLVM::LLVMPointerType>>
+        &externTypeCollect,
+    InstanceGraph &instanceGraph, DenseSet<Operation *> &overrided,
+    Operation *op) {
+  // If the current module has been overrided, return.
+  if (overrided.count(op))
+    return;
+
+  // If the current module is a leaf module, do overriding and then return.
+  if (isleafModule(op)) {
+
+    // Override the current module.
+    if (isa<hw::HWModuleOp>(op)) {
+      auto leafModuleType = findOperationType(typeCollect, op);
+      overrideModule(instanceGraph, cast<hw::HWModuleOp>(op), leafModuleType,
+                     externTypeCollect);
+    }
+
+    if (isa<hw::HWModuleExternOp>(op)) {
+      overrideExternModule(ctx, dyn_cast<hw::HWModuleExternOp>(op),
+                           externTypeCollect);
+    }
+
+    // Mark the current module as overrided.
+    overrided.insert(op);
+    return;
+  }
+  // If the current module is not a leaf module, traverse all the instances in
+  // this module to ensure all its child modules have been overrided.
+  for (auto inst : llvm::make_early_inc_range(
+           cast<HWModuleOp>(op).getOps<hw::InstanceOp>())) {
+    // Get the child module of the current instance.
+    auto *childModule = inst.getReferencedModule();
+    dfsOverrideModules(ctx, typeCollect, externTypeCollect, instanceGraph,
+                       overrided, childModule);
+  }
+
+  // Process the current module overriding.
+  auto nonLeafModuleType = findOperationType(typeCollect, op);
+  overrideModule(instanceGraph, cast<hw::HWModuleOp>(op), nonLeafModuleType,
+                 externTypeCollect);
+  overrided.insert(op);
+}
+
+void StateStructGeneratePass::runOnOperation() {
+  // Intialize class entry.
+  GenStateStruct gstateStruct = {emitNoneInfo};
+
+  // Get the instance Graph for updating modules instances.
+  InstanceGraph &instGraph = getAnalysis<InstanceGraph>();
+
+  // Collect all struct type of the modules and store them in paired vector.
+  SmallVector<std::pair<mlir::Operation *, LLVM::LLVMStructType>> typeCollect;
+  SmallVector<std::pair<mlir::Operation *, LLVM::LLVMPointerType>>
+      externTypeCollect;
+
+  // Create a denseSet to store the modules that have been overrided
+  DenseSet<Operation *> overridedModules;
+
+  // Get builder and context.
+  OpBuilder builder(&getContext());
+  MLIRContext *ctx = builder.getContext();
+
+  // Generate struct to store state values.
+  getOperation().walk([&](HWModuleOp op) {
+    auto loc = op.getLoc();
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+
+    SmallVector<portInfo> pInfo;
+    SmallVector<regInfo> rInfo;
+
+    // Collect all the port and reg information.
+    gstateStruct.collectPortInfo(op, pInfo);
+    gstateStruct.collectRegInfo(op, rInfo);
+
+    // Collect the secondary trigger number.
+    unsigned secondaryTriggerNum = gstateStruct.getNumOfSecondaryTriggerNum(op);
+
+    // Create struct type for current module.
+    LLVM::LLVMStructType type = gstateStruct.createStructType(
+        ctx, op, secondaryTriggerNum, pInfo, rInfo);
+
+    // Deal with current module contents and create corresponding struct
+    LLVM::GlobalOp global = gstateStruct.createGlobalStruct(
+        loc, builder, module, gstateStruct.addPrefixToName(op.getName()), type);
+
+    // Initialize the global struct.
+    gstateStruct.initializeGlobalStruct(builder, op, global, type,
+                                        secondaryTriggerNum, pInfo, rInfo);
+
+    // Collect all struct types with their operation pointer.
+    std::pair<Operation *, LLVM::LLVMStructType> pairType =
+        std::make_pair(op.getOperation(), type);
+    typeCollect.push_back(pairType);
+  });
+
+  getOperation().walk([&](HWModuleOp op) {
+    // Execute DFS overrideModules function to override all modules
+    gstateStruct.dfsOverrideModules(ctx, typeCollect, externTypeCollect,
+                                    instGraph, overridedModules, op);
+  });
+}
+//===----------------------------------------------------------------------===//
+// Pass Creation
+//===----------------------------------------------------------------------===//
+namespace circt {
+std::unique_ptr<mlir::Pass> createStateStructGeneratePass(bool emitNoneInfo) {
+  auto pass = std::make_unique<StateStructGeneratePass>();
+  pass->emitNoneInfo = emitNoneInfo;
+  return pass;
+}
+} // namespace circt

--- a/lib/Transforms/PassDetail.h
+++ b/lib/Transforms/PassDetail.h
@@ -36,6 +36,10 @@ class ControlFlowDialect;
 namespace func {
 class FuncDialect;
 } // namespace func
+
+namespace LLVM {
+class LLVMDialect;
+} // namespace LLVM
 } // end namespace mlir
 
 namespace circt {

--- a/test/Transforms/state-struct-generate.mlir
+++ b/test/Transforms/state-struct-generate.mlir
@@ -1,0 +1,556 @@
+// RUN: circt-opt -state-struct-generate=emit-none-info %s | FileCheck %s
+// This test checks whether the state struct is generated correctly, and overrides module correctly. 
+
+module {
+// CHECK-LABEL: llvm.mlir.global internal @_Struct_always_inline_expr() {addr_space = 0 : i32} : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)> {
+// CHECK: %[[VAL_0:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_2:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_3:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_4:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_5:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_6:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_7:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_8:.*]] = llvm.mlir.constant(0 : i5) : i5
+// CHECK: %[[VAL_9:.*]] = llvm.mlir.constant(0 : i5) : i5
+// CHECK: %[[VAL_10:.*]] = llvm.mlir.constant(0 : i5) : i5
+// CHECK: %[[VAL_11:.*]] = llvm.mlir.undef : !llvm.array<2 x i5>
+// CHECK: %[[VAL_12:.*]] = llvm.insertvalue %[[VAL_10]], %[[VAL_11]][0] : !llvm.array<2 x i5>
+// CHECK: %[[VAL_13:.*]] = llvm.insertvalue %[[VAL_10]], %[[VAL_12]][1] : !llvm.array<2 x i5>
+// CHECK: %[[VAL_14:.*]] = llvm.mlir.undef : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: %[[VAL_15:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_14]][0] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: %[[VAL_16:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_15]][1] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: %[[VAL_17:.*]] = llvm.insertvalue %[[VAL_2]], %[[VAL_16]][2] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: %[[VAL_18:.*]] = llvm.insertvalue %[[VAL_3]], %[[VAL_17]][3] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: %[[VAL_19:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_18]][4] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: %[[VAL_20:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_19]][5] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: %[[VAL_21:.*]] = llvm.insertvalue %[[VAL_7]], %[[VAL_20]][6] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: %[[VAL_22:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_21]][7] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: %[[VAL_23:.*]] = llvm.insertvalue %[[VAL_9]], %[[VAL_22]][8] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: %[[VAL_24:.*]] = llvm.insertvalue %[[VAL_13]], %[[VAL_23]][9] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: %[[VAL_25:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_24]][10] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: %[[VAL_26:.*]] = llvm.insertvalue %[[VAL_13]], %[[VAL_25]][11] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: llvm.return %[[VAL_26]] : !llvm.struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>
+// CHECK: }
+
+// CHECK-LABEL: llvm.mlir.global internal @_Struct_Moduleshift() {addr_space = 0 : i32} : !llvm.struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)> {
+// CHECK: %[[VAL_0:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_2:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_3:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_4:.*]] = llvm.mlir.null : !llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>
+// CHECK: %[[VAL_5:.*]] = llvm.mlir.null : !llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>
+// CHECK: %[[VAL_6:.*]] = llvm.mlir.null : !llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>
+// CHECK: %[[VAL_7:.*]] = llvm.mlir.undef : !llvm.struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_8:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_7]][0] : !llvm.struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_9:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_8]][1] : !llvm.struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_10:.*]] = llvm.insertvalue %[[VAL_2]], %[[VAL_9]][2] : !llvm.struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_11:.*]] = llvm.insertvalue %[[VAL_3]], %[[VAL_10]][3] : !llvm.struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_12:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_11]][4] : !llvm.struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_13:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_12]][5] : !llvm.struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_14:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_13]][6] : !llvm.struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: llvm.return %[[VAL_14]] : !llvm.struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: }
+
+// CHECK-LABEL: llvm.mlir.global internal @_Struct_my_dff() {addr_space = 0 : i32} : !llvm.struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)> {
+// CHECK: %[[VAL_0:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_2:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_3:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_4:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_5:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_6:.*]] = llvm.mlir.undef : !llvm.struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: %[[VAL_7:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_6]][0] : !llvm.struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: %[[VAL_8:.*]] = llvm.insertvalue %[[VAL_2]], %[[VAL_7]][1] : !llvm.struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: %[[VAL_9:.*]] = llvm.insertvalue %[[VAL_3]], %[[VAL_8]][2] : !llvm.struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: %[[VAL_10:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_9]][3] : !llvm.struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: %[[VAL_11:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_10]][4] : !llvm.struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: %[[VAL_12:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_11]][5] : !llvm.struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: llvm.return %[[VAL_12]] : !llvm.struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: }
+
+// CHECK-LABEL: llvm.mlir.global internal @_Struct_test_case_3() {addr_space = 0 : i32} : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)> {
+// CHECK: %[[VAL_0:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_2:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_3:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_4:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_5:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_6:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_7:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_8:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_9:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_10:.*]] = llvm.mlir.constant(0 : i6) : i6
+// CHECK: %[[VAL_11:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_12:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_13:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_14:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_15:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_16:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_17:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_18:.*]] = llvm.mlir.constant(0 : i4) : i4
+// CHECK: %[[VAL_19:.*]] = llvm.mlir.constant(0 : i6) : i6
+// CHECK: %[[VAL_20:.*]] = llvm.mlir.constant(0 : i6) : i6
+// CHECK: %[[VAL_21:.*]] = llvm.mlir.undef : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_22:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_21]][0] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_23:.*]] = llvm.insertvalue %[[VAL_2]], %[[VAL_22]][1] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_24:.*]] = llvm.insertvalue %[[VAL_3]], %[[VAL_23]][2] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_25:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_24]][3] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_26:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_25]][4] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_27:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_26]][5] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_28:.*]] = llvm.insertvalue %[[VAL_7]], %[[VAL_27]][6] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_29:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_28]][7] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_30:.*]] = llvm.insertvalue %[[VAL_9]], %[[VAL_29]][8] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_31:.*]] = llvm.insertvalue %[[VAL_10]], %[[VAL_30]][9] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_32:.*]] = llvm.insertvalue %[[VAL_11]], %[[VAL_31]][10] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_33:.*]] = llvm.insertvalue %[[VAL_13]], %[[VAL_32]][11] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_34:.*]] = llvm.insertvalue %[[VAL_15]], %[[VAL_33]][12] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_35:.*]] = llvm.insertvalue %[[VAL_17]], %[[VAL_34]][13] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_36:.*]] = llvm.insertvalue %[[VAL_19]], %[[VAL_35]][14] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_37:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_36]][15] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_38:.*]] = llvm.insertvalue %[[VAL_12]], %[[VAL_37]][16] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_39:.*]] = llvm.insertvalue %[[VAL_14]], %[[VAL_38]][17] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_40:.*]] = llvm.insertvalue %[[VAL_16]], %[[VAL_39]][18] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_41:.*]] = llvm.insertvalue %[[VAL_18]], %[[VAL_40]][19] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: %[[VAL_42:.*]] = llvm.insertvalue %[[VAL_20]], %[[VAL_41]][20] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: llvm.return %[[VAL_42]] : !llvm.struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>
+// CHECK: }
+
+// CHECK-LABEL: llvm.mlir.global internal @_Struct_test_case_2() {addr_space = 0 : i32} : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)> {
+// CHECK: %[[VAL_0:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_2:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_3:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_4:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_5:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_6:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_7:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_8:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_9:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_10:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_11:.*]] = llvm.mlir.null : !llvm.ptr<struct<"_Struct_SimJTAG", opaque>>
+// CHECK: %[[VAL_12:.*]] = llvm.mlir.null : !llvm.ptr<struct<"_Struct_ClockDividerN", opaque>>
+// CHECK: %[[VAL_13:.*]] = llvm.mlir.undef : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_14:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_13]][0] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_15:.*]] = llvm.insertvalue %[[VAL_2]], %[[VAL_14]][1] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_16:.*]] = llvm.insertvalue %[[VAL_3]], %[[VAL_15]][2] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_17:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_16]][3] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_18:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_17]][4] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_19:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_18]][5] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_20:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_19]][6] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_21:.*]] = llvm.insertvalue %[[VAL_7]], %[[VAL_20]][7] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_22:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_21]][8] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_23:.*]] = llvm.insertvalue %[[VAL_9]], %[[VAL_22]][9] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_24:.*]] = llvm.insertvalue %[[VAL_10]], %[[VAL_23]][10] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_25:.*]] = llvm.insertvalue %[[VAL_11]], %[[VAL_24]][11] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: %[[VAL_26:.*]] = llvm.insertvalue %[[VAL_12]], %[[VAL_25]][12] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: llvm.return %[[VAL_26]] : !llvm.struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>
+// CHECK: }
+
+// CHECK-LABEL: llvm.mlir.global internal @_Struct_callee() {addr_space = 0 : i32} : !llvm.struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)> {
+// CHECK: %[[VAL_0:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_2:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_3:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_4:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_5:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_6:.*]] = llvm.mlir.undef : !llvm.struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: %[[VAL_7:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_6]][0] : !llvm.struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: %[[VAL_8:.*]] = llvm.insertvalue %[[VAL_2]], %[[VAL_7]][1] : !llvm.struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: %[[VAL_9:.*]] = llvm.insertvalue %[[VAL_3]], %[[VAL_8]][2] : !llvm.struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: %[[VAL_10:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_9]][3] : !llvm.struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: %[[VAL_11:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_10]][4] : !llvm.struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: %[[VAL_12:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_11]][5] : !llvm.struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: llvm.return %[[VAL_12]] : !llvm.struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>
+// CHECK: }
+
+// CHECK-LABEL: llvm.mlir.global internal @_Struct_test_case_1() {addr_space = 0 : i32} : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)> {
+// CHECK: %[[VAL_0:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_2:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_3:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_4:.*]] = llvm.mlir.constant(0 : i3) : i3
+// CHECK: %[[VAL_5:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_6:.*]] = llvm.mlir.constant(false) : i1
+// CHECK: %[[VAL_7:.*]] = llvm.mlir.null : !llvm.ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>
+// CHECK: %[[VAL_8:.*]] = llvm.mlir.undef : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_9:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_8]][0] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_10:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_9]][1] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_11:.*]] = llvm.insertvalue %[[VAL_2]], %[[VAL_10]][2] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_12:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_11]][3] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_13:.*]] = llvm.insertvalue %[[VAL_3]], %[[VAL_12]][4] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_14:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_13]][5] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_15:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_14]][6] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: %[[VAL_16:.*]] = llvm.insertvalue %[[VAL_7]], %[[VAL_15]][7] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: llvm.return %[[VAL_16]] : !llvm.struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>
+// CHECK: }
+
+// CHECK-LABEL: hw.module @test_case_1(
+// CHECK-SAME: %[[VAL_0:.*]]: !llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>>) attributes {sv.trigger = [2 : i8]} {
+  hw.module @test_case_1(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i3) attributes {sv.trigger = [2 : i8]} {
+    // CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 0] : (!llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 1] : (!llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 2] : (!llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 7] : (!llvm.ptr<struct<"_Struct_test_case_1", packed (i1, i1, i1, i3, i1, i1, i1, ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>)>>, i32) -> !llvm.ptr<ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>>
+    // CHECK: %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>>
+    // CHECK: %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_9]]{{\[}}%[[VAL_1]], 0] : (!llvm.ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_3]], %[[VAL_10]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_9]]{{\[}}%[[VAL_1]], 1] : (!llvm.ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_5]], %[[VAL_11]] : !llvm.ptr<i1>
+    // CHECK: hw.instance "Calleex" @callee(ptr_struct_callee: %[[VAL_9]]: !llvm.ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>) -> ()
+    %Calleex.out0, %Calleex.out1 = hw.instance "Calleex" @callee(arg0: %arg0: i1, arg1: %arg1: i1) -> (out0: i1, out1: i1) {sv.trigger = [0 : i8, 1 : i8]}
+
+    // CHECK: %[[VAL_12:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK: %[[VAL_13:.*]] = llvm.getelementptr inbounds %[[VAL_9]]{{\[}}%[[VAL_1]], 2] : (!llvm.ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_14:.*]] = llvm.load %[[VAL_13]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_15:.*]] = llvm.mlir.constant(3 : i32) : i32
+    // CHECK: %[[VAL_16:.*]] = llvm.getelementptr inbounds %[[VAL_9]]{{\[}}%[[VAL_1]], 3] : (!llvm.ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_17:.*]] = llvm.load %[[VAL_16]] : !llvm.ptr<i1>
+    // CHECK: sv.always posedge %[[VAL_14]], negedge %[[VAL_7]], edge %[[VAL_17]] {
+    // CHECK: }
+    sv.always posedge %Calleex.out0, negedge %arg2, edge %Calleex.out1 {
+    }
+    hw.output
+  }
+
+// CHECK-LABEL: hw.module @callee(
+// CHECK-SAME: %[[VAL_0:.*]]: !llvm.ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>) attributes {sv.trigger = [0 : i8]} {
+  hw.module @callee(%arg0: i1, %arg1: i1) -> (out0: i1, out1: i1) attributes {sv.trigger = [0 : i8]} {
+    // CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 0] : (!llvm.ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 1] : (!llvm.ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<i1>
+
+    // CHECK: %[[VAL_6:.*]] = llvm.mlir.constant(true) : i1
+    %0 = llvm.mlir.constant(true) : i1
+
+    // CHECK: %[[VAL_7:.*]] = comb.or %[[VAL_6]], %[[VAL_3]] : i1
+    // CHECK: %[[VAL_8:.*]] = comb.and %[[VAL_7]], %[[VAL_5]] {sv.trigger = [0 : i8]} : i1
+    %1 = comb.or %0, %arg0 : i1
+    %2 = comb.and %1, %arg1 {sv.trigger = [0 : i8]} : i1
+
+    // CHECK: sv.always posedge %[[VAL_3]], negedge %[[VAL_8]] {
+    // CHECK: }
+    sv.always posedge %arg0, negedge %2 {
+    }
+
+    // CHECK: %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 2] : (!llvm.ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_7]], %[[VAL_9]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 3] : (!llvm.ptr<struct<"_Struct_callee", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_8]], %[[VAL_10]] : !llvm.ptr<i1>
+    // CHECK: hw.output
+    // CHECK: }
+    hw.output %1, %2 : i1, i1
+  }
+
+// CHECK-LABEL: hw.module @test_case_2(
+// CHECK-SAME: %[[VAL_0:.*]]: !llvm.ptr<struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>>) attributes {sv.trigger = [0 : i8]} {
+  hw.module @test_case_2(%clock: i1, %reset: i1, %TDO: i1, %enable: i1) -> (out0: i1, out1: i1) attributes {sv.trigger = [0 : i8]} {
+    // CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 0] : (!llvm.ptr<struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 1] : (!llvm.ptr<struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 2] : (!llvm.ptr<struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 3] : (!llvm.ptr<struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<i1>
+
+    // CHECK: %[[VAL_10:.*]] = llvm.mlir.constant(false) : i1
+    // CHECK: %[[VAL_11:.*]] = llvm.mlir.constant(true) : i1
+    %0 = llvm.mlir.constant(false) : i1
+    %1 = llvm.mlir.constant(true) : i1
+    // CHECK: %[[VAL_12:.*]] = comb.and %[[VAL_10]], %[[VAL_11]] : i1
+    %2 = comb.and %0, %1 : i1
+
+    // CHECK: %[[VAL_13:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 11] : (!llvm.ptr<struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>>, i32) -> !llvm.ptr<ptr<struct<"_Struct_SimJTAG", opaque>>>
+    // CHECK: %[[VAL_14:.*]] = llvm.load %[[VAL_13]] : !llvm.ptr<ptr<struct<"_Struct_SimJTAG", opaque>>>
+    // CHECK: %[[VAL_15:.*]] = llvm.bitcast %[[VAL_14]] : !llvm.ptr<struct<"_Struct_SimJTAG", opaque>> to !llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>
+    // CHECK: %[[VAL_16:.*]] = llvm.getelementptr inbounds %[[VAL_15]]{{\[}}%[[VAL_1]], 0] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_3]], %[[VAL_16]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_15]]{{\[}}%[[VAL_1]], 1] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_5]], %[[VAL_17]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_18:.*]] = llvm.getelementptr inbounds %[[VAL_15]]{{\[}}%[[VAL_1]], 2] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_7]], %[[VAL_18]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_19:.*]] = llvm.getelementptr inbounds %[[VAL_15]]{{\[}}%[[VAL_1]], 3] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_11]], %[[VAL_19]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_20:.*]] = llvm.getelementptr inbounds %[[VAL_15]]{{\[}}%[[VAL_1]], 4] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_9]], %[[VAL_20]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_21:.*]] = llvm.getelementptr inbounds %[[VAL_15]]{{\[}}%[[VAL_1]], 5] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_10]], %[[VAL_21]] : !llvm.ptr<i1>
+    // CHECK: hw.instance "SimJTAG" @SimJTAG(ptr_struct_SimJTAG: %[[VAL_14]]: !llvm.ptr<struct<"_Struct_SimJTAG", opaque>>) -> ()
+    %SimJTAG.jtag_TRSTn, %SimJTAG.jtag_TCK, %SimJTAG.jtag_TMS, %SimJTAG.jtag_TDI, %SimJTAG.exit = hw.instance "SimJTAG" @SimJTAG(clock: %clock: i1, reset: %reset: i1, jtag_TDO_data: %TDO: i1, jtag_TDO_driven: %1: i1, enable: %enable: i1,
+                                                                                                                                init_done: %0: i1) -> (jtag_TRSTn: i1, jtag_TCK: i1, jtag_TMS: i1, jtag_TDI: i1, exit: i32) {sv.trigger = [1 : i8, 2 : i8, 3 : i8]}
+    // CHECK: %[[VAL_22:.*]] = llvm.bitcast %[[VAL_14]] : !llvm.ptr<struct<"_Struct_SimJTAG", opaque>> to !llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>
+    // CHECK: %[[VAL_23:.*]] = llvm.mlir.constant(6 : i32) : i32
+    // CHECK: %[[VAL_24:.*]] = llvm.getelementptr inbounds %[[VAL_22]]{{\[}}%[[VAL_1]], 6] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_25:.*]] = llvm.load %[[VAL_24]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_26:.*]] = llvm.mlir.constant(7 : i32) : i32
+    // CHECK: %[[VAL_27:.*]] = llvm.getelementptr inbounds %[[VAL_22]]{{\[}}%[[VAL_1]], 7] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_28:.*]] = llvm.load %[[VAL_27]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_29:.*]] = llvm.mlir.constant(8 : i32) : i32
+    // CHECK: %[[VAL_30:.*]] = llvm.getelementptr inbounds %[[VAL_22]]{{\[}}%[[VAL_1]], 8] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_31:.*]] = llvm.load %[[VAL_30]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_32:.*]] = llvm.mlir.constant(9 : i32) : i32
+    // CHECK: %[[VAL_33:.*]] = llvm.getelementptr inbounds %[[VAL_22]]{{\[}}%[[VAL_1]], 9] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_34:.*]] = llvm.load %[[VAL_33]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_35:.*]] = llvm.mlir.constant(10 : i32) : i32
+    // CHECK: %[[VAL_36:.*]] = llvm.getelementptr inbounds %[[VAL_22]]{{\[}}%[[VAL_1]], 10] : (!llvm.ptr<struct<packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i32)>>, i32) -> !llvm.ptr<i32>
+    // CHECK: %[[VAL_37:.*]] = llvm.load %[[VAL_36]] : !llvm.ptr<i32>
+
+    // CHECK: %[[VAL_38:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 12] : (!llvm.ptr<struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>>, i32) -> !llvm.ptr<ptr<struct<"_Struct_ClockDividerN", opaque>>>
+    // CHECK: %[[VAL_39:.*]] = llvm.load %[[VAL_38]] : !llvm.ptr<ptr<struct<"_Struct_ClockDividerN", opaque>>>
+    // CHECK: %[[VAL_40:.*]] = llvm.bitcast %[[VAL_39]] : !llvm.ptr<struct<"_Struct_ClockDividerN", opaque>> to !llvm.ptr<struct<packed (i1, i1)>>
+    // CHECK: %[[VAL_41:.*]] = llvm.getelementptr inbounds %[[VAL_40]]{{\[}}%[[VAL_1]], 0] : (!llvm.ptr<struct<packed (i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_3]], %[[VAL_41]] : !llvm.ptr<i1>
+    // CHECK: hw.instance "clockDividerN" @ClockDividerN(ptr_struct_ClockDividerN: %[[VAL_39]]: !llvm.ptr<struct<"_Struct_ClockDividerN", opaque>>) -> ()
+    %clockDividerN.clk_out = hw.instance "clockDividerN" @ClockDividerN(clk_in: %clock: i1) -> (clk_out: i1) {sv.trigger = [0 : i8]}
+
+    // CHECK: %[[VAL_42:.*]] = llvm.bitcast %[[VAL_39]] : !llvm.ptr<struct<"_Struct_ClockDividerN", opaque>> to !llvm.ptr<struct<packed (i1, i1)>>
+    // CHECK: %[[VAL_43:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK: %[[VAL_44:.*]] = llvm.getelementptr inbounds %[[VAL_42]]{{\[}}%[[VAL_1]], 1] : (!llvm.ptr<struct<packed (i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_45:.*]] = llvm.load %[[VAL_44]] : !llvm.ptr<i1>
+    // CHECK: sv.always posedge %[[VAL_3]], posedge %[[VAL_28]], posedge %[[VAL_45]] {
+    // CHECK:   sv.if %[[VAL_5]] {
+    // CHECK:   }
+    // CHECK: }
+    sv.always posedge %clock, posedge %SimJTAG.jtag_TCK, posedge %clockDividerN.clk_out {
+      sv.if %reset {
+      }
+    }
+
+    // CHECK: sv.always posedge %[[VAL_28]], negedge %[[VAL_34]], edge %[[VAL_31]] {
+    // CHECK:   sv.if %[[VAL_25]] {
+    // CHECK:   }
+    // CHECK: }
+    sv.always posedge %SimJTAG.jtag_TCK, negedge %SimJTAG.jtag_TDI, edge %SimJTAG.jtag_TMS {
+      sv.if %SimJTAG.jtag_TRSTn {
+      }
+    }
+
+    // CHECK: %[[VAL_46:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 4] : (!llvm.ptr<struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_31]], %[[VAL_46]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_47:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 5] : (!llvm.ptr<struct<"_Struct_test_case_2", packed (i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, ptr<struct<"_Struct_SimJTAG", opaque>>, ptr<struct<"_Struct_ClockDividerN", opaque>>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_34]], %[[VAL_47]] : !llvm.ptr<i1>
+    // CHECK: hw.output
+    // CHECK: }
+    hw.output %SimJTAG.jtag_TMS, %SimJTAG.jtag_TDI : i1, i1
+  }
+
+    // CHECK: hw.module.extern private @SimJTAG(%[[VAL_48:.*]]: !llvm.ptr<struct<"_Struct_SimJTAG", opaque>>)
+    // CHECK: hw.module.extern private @ClockDividerN(%[[VAL_49:.*]]: !llvm.ptr<struct<"_Struct_ClockDividerN", opaque>>)
+  hw.module.extern private @SimJTAG(%clock: i1, %reset: i1, %jtag_TDO_data: i1, %jtag_TDO_driven: i1, %enable: i1, %init_done: i1) -> (jtag_TRSTn: i1, jtag_TCK: i1, jtag_TMS: i1, jtag_TDI: i1, exit: i32)
+  hw.module.extern private @ClockDividerN(%clk_in: i1) -> (clk_out: i1)
+
+// CHECK-LABEL: hw.module @test_case_3(
+// CHECK-SAME: %[[VAL_0:.*]]: !llvm.ptr<struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>>) attributes {sv.trigger = [0 : i8]} {
+  hw.module @test_case_3(%clock: i1, %reset: i1, %enable: i1, %ureset: i1, %d: i4) -> (Q_0: i4, Q_1: i4, Q_2: i4, Q_3: i4, Q_4: i6) attributes {sv.trigger = [0 : i8]} {
+    // CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 0] : (!llvm.ptr<struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 3] : (!llvm.ptr<struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 4] : (!llvm.ptr<struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>>, i32) -> !llvm.ptr<i4>
+    // CHECK: %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<i4>
+
+    // CHECK: %[[VAL_8:.*]] = hw.constant 0 : i4
+    %c0_i4 = hw.constant 0 : i4
+
+    // CHECK: %[[VAL_9:.*]] = sv.reg  : !hw.inout<i4>
+    // CHECK: %[[VAL_10:.*]] = sv.read_inout %[[VAL_9]] : !hw.inout<i4>
+    // CHECK: %[[VAL_11:.*]] = sv.reg  : !hw.inout<i4>
+    // CHECK: %[[VAL_12:.*]] = sv.read_inout %[[VAL_11]] : !hw.inout<i4>
+    // CHECK: %[[VAL_13:.*]] = sv.reg  : !hw.inout<i4>
+    // CHECK: %[[VAL_14:.*]] = sv.read_inout %[[VAL_13]] : !hw.inout<i4>
+    // CHECK: %[[VAL_15:.*]] = sv.reg  : !hw.inout<i4>
+    // CHECK: %[[VAL_16:.*]] = sv.read_inout %[[VAL_15]] : !hw.inout<i4>
+    // CHECK: %[[VAL_17:.*]] = sv.reg  : !hw.inout<i6>
+    // CHECK: %[[VAL_18:.*]] = sv.read_inout %[[VAL_17]] : !hw.inout<i6>
+    %Q_out_reg_0 = sv.reg  : !hw.inout<i4>
+    %0 = sv.read_inout %Q_out_reg_0 : !hw.inout<i4>
+    %Q_out_reg_1 = sv.reg  : !hw.inout<i4>
+    %1 = sv.read_inout %Q_out_reg_1 : !hw.inout<i4>
+    %Q_out_reg_2 = sv.reg  : !hw.inout<i4>
+    %2 = sv.read_inout %Q_out_reg_2 : !hw.inout<i4>
+    %Q_out_reg_3 = sv.reg  : !hw.inout<i4>
+    %3 = sv.read_inout %Q_out_reg_3 : !hw.inout<i4>
+    %test_reg_4 = sv.reg  : !hw.inout<i6>
+    %4 = sv.read_inout %test_reg_4 : !hw.inout<i6>
+
+    // CHECK: sv.always posedge %[[VAL_3]] {
+    // CHECK:   sv.if %[[VAL_5]] {
+    // CHECK:     sv.passign %[[VAL_9]], %[[VAL_8]] : i4
+    // CHECK:     sv.passign %[[VAL_11]], %[[VAL_8]] : i4
+    // CHECK:     sv.passign %[[VAL_13]], %[[VAL_8]] : i4
+    // CHECK:     sv.passign %[[VAL_15]], %[[VAL_8]] : i4
+    // CHECK:   } else {
+    // CHECK:     sv.passign %[[VAL_9]], %[[VAL_7]] : i4
+    // CHECK:     sv.passign %[[VAL_11]], %[[VAL_7]] : i4
+    // CHECK:     sv.passign %[[VAL_13]], %[[VAL_7]] : i4
+    // CHECK:     sv.passign %[[VAL_15]], %[[VAL_7]] : i4
+    // CHECK:   }
+    // CHECK: }
+    sv.always posedge %clock {
+      sv.if %ureset {
+        sv.passign %Q_out_reg_0, %c0_i4 : i4
+        sv.passign %Q_out_reg_1, %c0_i4 : i4
+        sv.passign %Q_out_reg_2, %c0_i4 : i4
+        sv.passign %Q_out_reg_3, %c0_i4 : i4
+      } else {
+        sv.passign %Q_out_reg_0, %d : i4
+        sv.passign %Q_out_reg_1, %d : i4
+        sv.passign %Q_out_reg_2, %d : i4
+        sv.passign %Q_out_reg_3, %d : i4
+      }
+    }
+    // CHECK: %[[VAL_19:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 5] : (!llvm.ptr<struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>>, i32) -> !llvm.ptr<i4>
+    // CHECK: llvm.store %[[VAL_10]], %[[VAL_19]] : !llvm.ptr<i4>
+    // CHECK: %[[VAL_20:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 6] : (!llvm.ptr<struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>>, i32) -> !llvm.ptr<i4>
+    // CHECK: llvm.store %[[VAL_12]], %[[VAL_20]] : !llvm.ptr<i4>
+    // CHECK: %[[VAL_21:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 7] : (!llvm.ptr<struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>>, i32) -> !llvm.ptr<i4>
+    // CHECK: llvm.store %[[VAL_14]], %[[VAL_21]] : !llvm.ptr<i4>
+    // CHECK: %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 8] : (!llvm.ptr<struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>>, i32) -> !llvm.ptr<i4>
+    // CHECK: llvm.store %[[VAL_16]], %[[VAL_22]] : !llvm.ptr<i4>
+    // CHECK: %[[VAL_23:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 9] : (!llvm.ptr<struct<"_Struct_test_case_3", packed (i1, i1, i1, i1, i4, i4, i4, i4, i4, i6, i4, i4, i4, i4, i6, i1, i4, i4, i4, i4, i6)>>, i32) -> !llvm.ptr<i6>
+    // CHECK: llvm.store %[[VAL_18]], %[[VAL_23]] : !llvm.ptr<i6>
+    // CHECK: hw.output
+    // CHECK: }
+    hw.output %0, %1, %2, %3, %4 : i4, i4, i4, i4, i6
+  }
+
+// CHECK-LABEL: hw.module private @my_dff(
+// CHECK-SAME: %[[VAL_0:.*]]: !llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>) attributes {sv.trigger = [0 : i8]} {
+  hw.module private @my_dff(%clock: i1, %d: i1) -> (q: i1) attributes {sv.trigger = [0 : i8]} {
+    // CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 0] : (!llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 1] : (!llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<i1>
+
+    // CHECK: %[[VAL_6:.*]] = sv.reg  : !hw.inout<i1>
+    // CHECK: %[[VAL_7:.*]] = sv.read_inout %[[VAL_6]] : !hw.inout<i1>
+    %q_out_reg = sv.reg  : !hw.inout<i1>
+    %0 = sv.read_inout %q_out_reg : !hw.inout<i1>
+
+    // CHECK: sv.always posedge %[[VAL_3]] {
+    // CHECK:   sv.passign %[[VAL_6]], %[[VAL_5]] : i1
+    // CHECK: }
+    sv.always posedge %clock {
+      sv.passign %q_out_reg, %d : i1
+    }
+
+    // CHECK: %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 2] : (!llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_7]], %[[VAL_8]] : !llvm.ptr<i1>
+    // CHECK: hw.output
+    // CHECK: }
+    hw.output %0 : i1
+  }
+
+// CHECK-LABEL: hw.module @Moduleshift(
+// CHECK-SAME: %[[VAL_0:.*]]: !llvm.ptr<struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>>) {
+  hw.module @Moduleshift(%clock: i1, %reset: i1, %d: i1) -> (q: i1) {
+    // CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 0] : (!llvm.ptr<struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 2] : (!llvm.ptr<struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 4] : (!llvm.ptr<struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>>, i32) -> !llvm.ptr<ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>>
+    // CHECK: %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>>
+    // CHECK: %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_7]]{{\[}}%[[VAL_1]], 0] : (!llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_3]], %[[VAL_8]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_7]]{{\[}}%[[VAL_1]], 1] : (!llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_5]], %[[VAL_9]] : !llvm.ptr<i1>
+    // CHECK: hw.instance "dff0" @my_dff(ptr_struct_my_dff: %[[VAL_7]]: !llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>) -> ()
+    %dff0.q = hw.instance "dff0" @my_dff(clock: %clock: i1, d: %d: i1) -> (q: i1) {sv.namehint = "q_net_0"}
+
+    // CHECK: %[[VAL_10:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK: %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_7]]{{\[}}%[[VAL_1]], 2] : (!llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_12:.*]] = llvm.load %[[VAL_11]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_13:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 5] : (!llvm.ptr<struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>>, i32) -> !llvm.ptr<ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>>
+    // CHECK: %[[VAL_14:.*]] = llvm.load %[[VAL_13]] : !llvm.ptr<ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>>
+    // CHECK: %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_14]]{{\[}}%[[VAL_1]], 0] : (!llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_3]], %[[VAL_15]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_16:.*]] = llvm.getelementptr inbounds %[[VAL_14]]{{\[}}%[[VAL_1]], 1] : (!llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_12]], %[[VAL_16]] : !llvm.ptr<i1>
+    // CHECK: hw.instance "dff1" @my_dff(ptr_struct_my_dff: %[[VAL_14]]: !llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>) -> ()
+    %dff1.q = hw.instance "dff1" @my_dff(clock: %clock: i1, d: %dff0.q: i1) -> (q: i1) {sv.namehint = "q_net_1"}
+
+    // CHECK: %[[VAL_17:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK: %[[VAL_18:.*]] = llvm.getelementptr inbounds %[[VAL_14]]{{\[}}%[[VAL_1]], 2] : (!llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_19:.*]] = llvm.load %[[VAL_18]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_20:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 6] : (!llvm.ptr<struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>>, i32) -> !llvm.ptr<ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>>
+    // CHECK: %[[VAL_21:.*]] = llvm.load %[[VAL_20]] : !llvm.ptr<ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>>
+    // CHECK: %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_21]]{{\[}}%[[VAL_1]], 0] : (!llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_3]], %[[VAL_22]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_23:.*]] = llvm.getelementptr inbounds %[[VAL_21]]{{\[}}%[[VAL_1]], 1] : (!llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_19]], %[[VAL_23]] : !llvm.ptr<i1>
+    // CHECK: hw.instance "dff2" @my_dff(ptr_struct_my_dff: %[[VAL_21]]: !llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>) -> ()
+    %dff2.q = hw.instance "dff2" @my_dff(clock: %clock: i1, d: %dff1.q: i1) -> (q: i1)
+
+    // CHECK: %[[VAL_24:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK: %[[VAL_25:.*]] = llvm.getelementptr inbounds %[[VAL_21]]{{\[}}%[[VAL_1]], 2] : (!llvm.ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_26:.*]] = llvm.load %[[VAL_25]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_27:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 3] : (!llvm.ptr<struct<"_Struct_Moduleshift", packed (i1, i1, i1, i1, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>, ptr<struct<"_Struct_my_dff", packed (i1, i1, i1, i1, i1, i1)>>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: llvm.store %[[VAL_26]], %[[VAL_27]] : !llvm.ptr<i1>
+    // CHECK: hw.output
+    // CHECK: }
+    hw.output %dff2.q : i1
+  }
+
+// CHECK-LABEL: hw.module @always_inline_expr(
+// CHECK-SAME: %[[VAL_0:.*]]: !llvm.ptr<struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>>) attributes {sv.trigger = [3 : i8]} {
+  hw.module @always_inline_expr(%ro_clock_0: i1, %ro_en_0: i1, %ro_addr_0: i1, %wo_clock_0: i1, %wo_en_0: i1, %wo_addr_0: i1, %wo_mask_0: i1, %wo_data_0: i5) -> (ro_data_0: i5) attributes {sv.trigger = [3 : i8]} {
+    // CHECK: %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK: %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 1] : (!llvm.ptr<struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 2] : (!llvm.ptr<struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 3] : (!llvm.ptr<struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 4] : (!llvm.ptr<struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 5] : (!llvm.ptr<struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_11:.*]] = llvm.load %[[VAL_10]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 6] : (!llvm.ptr<struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>>, i32) -> !llvm.ptr<i1>
+    // CHECK: %[[VAL_13:.*]] = llvm.load %[[VAL_12]] : !llvm.ptr<i1>
+    // CHECK: %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 7] : (!llvm.ptr<struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>>, i32) -> !llvm.ptr<i5>
+    // CHECK: %[[VAL_15:.*]] = llvm.load %[[VAL_14]] : !llvm.ptr<i5>
+
+    // CHECK: %[[VAL_16:.*]] = sv.reg  : !hw.inout<uarray<2xi5>>
+    // CHECK: %[[VAL_17:.*]] = sv.array_index_inout %[[VAL_16]]{{\[}}%[[VAL_5]]] : !hw.inout<uarray<2xi5>>, i1
+    // CHECK: %[[VAL_18:.*]] = sv.read_inout %[[VAL_17]] : !hw.inout<i5>
+    // CHECK: %[[VAL_19:.*]] = sv.constantX : i5
+    // CHECK: %[[VAL_20:.*]] = comb.mux %[[VAL_3]], %[[VAL_18]], %[[VAL_19]] : i5
+    %Memory = sv.reg  : !hw.inout<uarray<2xi5>>
+    %0 = sv.array_index_inout %Memory[%ro_addr_0] : !hw.inout<uarray<2xi5>>, i1
+    %1 = sv.read_inout %0 : !hw.inout<i5>
+    %x_i5 = sv.constantX : i5
+    %2 = comb.mux %ro_en_0, %1, %x_i5 : i5
+
+    // CHECK: sv.always posedge %[[VAL_7]] {
+    // CHECK:   %[[VAL_21:.*]] = comb.and %[[VAL_9]], %[[VAL_13]] : i1
+    // CHECK:   sv.if %[[VAL_21]] {
+    // CHECK:     %[[VAL_22:.*]] = sv.array_index_inout %[[VAL_16]]{{\[}}%[[VAL_11]]] : !hw.inout<uarray<2xi5>>, i1
+    // CHECK:     sv.passign %[[VAL_22]], %[[VAL_15]] : i5
+    // CHECK:   }
+    // CHECK: }
+    sv.always posedge %wo_clock_0 {
+      %3 = comb.and %wo_en_0, %wo_mask_0 : i1
+      sv.if %3 {
+        %4 = sv.array_index_inout %Memory[%wo_addr_0] : !hw.inout<uarray<2xi5>>, i1
+        sv.passign %4, %wo_data_0 : i5
+      }
+    }
+
+    // CHECK: %[[VAL_23:.*]] = llvm.getelementptr inbounds %[[VAL_0]]{{\[}}%[[VAL_1]], 8] : (!llvm.ptr<struct<"_Struct_always_inline_expr", packed (i1, i1, i1, i1, i1, i1, i1, i5, i5, array<2 x i5>, i1, array<2 x i5>)>>, i32) -> !llvm.ptr<i5>
+    // CHECK: llvm.store %[[VAL_20]], %[[VAL_23]] : !llvm.ptr<i5>
+    // CHECK: hw.output
+    // CHECK: }
+    hw.output %2 : i5
+  }
+}


### PR DESCRIPTION
This pass collects elements: module ports, output reg of the module, local register in the current module, signal with attribute of the trigger, and instance pointer. Form a struct with these elements and their clone member which will be used to represent previous one of the member state. The struct will be stored in the global variable and the pointer of the struct will be passed to the module. The module will be overridden with the new struct pointer.

The state struct is used to be the core to store/transfer the state values in the circuit, which will be convenient to transform hw codes to a software model.

(The pass relays on trigger attributes to generate the correct state struct, execute the SVTriggerAttrGen pass first please.)