### PR TITLE
[Calyx] Support lowering of `arith.select`

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -267,8 +267,8 @@ def AndLibOp  : CombinationalArithBinaryLibraryOp<"and"> {}
 def OrLibOp   : CombinationalArithBinaryLibraryOp<"or"> {}
 def XorLibOp  : CombinationalArithBinaryLibraryOp<"xor"> {}
 
-def MuxLibOp : CalyxLibraryOp<"mux", [Combinational, SameTypeConstraint<"tru", "fal">]> {
-  let results = (outs AnyType:$sel, AnyType:$tru, AnyType:$fal, AnyType:$out);
+def MuxLibOp : CalyxLibraryOp<"mux", [Combinational, SameTypeConstraint<"tru", "fal">, SameTypeConstraint<"tru", "out">]> {
+  let results = (outs I1:$sel, AnyType:$tru, AnyType:$fal, AnyType:$out);
 }
 
 class ArithBinaryPipeLibraryOp<string mnemonic> : ArithBinaryLibraryOp<mnemonic # "_pipe", [

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -267,7 +267,9 @@ def AndLibOp  : CombinationalArithBinaryLibraryOp<"and"> {}
 def OrLibOp   : CombinationalArithBinaryLibraryOp<"or"> {}
 def XorLibOp  : CombinationalArithBinaryLibraryOp<"xor"> {}
 
-def MuxLibOp : CalyxLibraryOp<"mux", [Combinational, SameTypeConstraint<"tru", "fal">, SameTypeConstraint<"tru", "out">]> {
+def MuxLibOp : CalyxLibraryOp<"mux", [
+  Combinational, SameTypeConstraint<"tru", "fal">, SameTypeConstraint<"tru", "out">
+  ]> {
   let results = (outs I1:$sel, AnyType:$tru, AnyType:$fal, AnyType:$out);
 }
 

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -123,7 +123,7 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
 def SeqMemoryOp : CalyxPrimitive<"seq_mem", []> {
   let summary = "Defines a memory with sequential read";
   let description = [{
-    The "calyx.seq_mem" op defines a memory with sequential reads. Memories can 
+    The "calyx.seq_mem" op defines a memory with sequential reads. Memories can
     have any number of dimensions, as specified by the length of the `$sizes` and
     `$addrSizes` arrays. The `$addrSizes` specify the bitwidth of each dimension's
     address, and should be wide enough to address the range of the corresponding
@@ -266,6 +266,10 @@ def LshLibOp  : CombinationalArithBinaryLibraryOp<"lsh"> {}
 def AndLibOp  : CombinationalArithBinaryLibraryOp<"and"> {}
 def OrLibOp   : CombinationalArithBinaryLibraryOp<"or"> {}
 def XorLibOp  : CombinationalArithBinaryLibraryOp<"xor"> {}
+
+def MuxLibOp : CalyxLibraryOp<"mux", [Combinational, SameTypeConstraint<"tru", "fal">]> {
+  let results = (outs AnyType:$sel, AnyType:$tru, AnyType:$fal, AnyType:$out);
+}
 
 class ArithBinaryPipeLibraryOp<string mnemonic> : ArithBinaryLibraryOp<mnemonic # "_pipe", [
     SameTypeConstraint<"left", "out">

--- a/lib/Conversion/CalyxToHW/CalyxToHW.cpp
+++ b/lib/Conversion/CalyxToHW/CalyxToHW.cpp
@@ -237,6 +237,20 @@ private:
         .Case([&](XorLibOp op) {
           convertArithBinaryOp<XorLibOp, XorOp>(op, wires, b);
         })
+        .Case([&](MuxLibOp op) {
+          auto sel = wireIn(op.getSel(), op.instanceName(),
+                            op.portName(op.getSel()), b);
+          auto tru = wireIn(op.getTru(), op.instanceName(),
+                            op.portName(op.getTru()), b);
+          auto fal = wireIn(op.getFal(), op.instanceName(),
+                            op.portName(op.getFal()), b);
+
+          auto mux = b.create<MuxOp>(sel, tru, fal);
+
+          auto out =
+              wireOut(mux, op.instanceName(), op.portName(op.getOut()), b);
+          wires.append({sel.getInput(), tru.getInput(), fal.getInput(), out});
+        })
         // Pipelined arithmetic operations.
         .Case([&](MultPipeLibOp op) {
           convertPipelineOp<MultPipeLibOp, comb::MulOp>(op, wires, b);

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -235,6 +235,7 @@ private:
                         BranchOpInterface brOp) const;
   LogicalResult buildOp(PatternRewriter &rewriter,
                         arith::ConstantOp constOp) const;
+  LogicalResult buildOp(PatternRewriter &rewriter, SelectOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, AddIOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, SubIOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, MulIOp op) const;
@@ -787,6 +788,10 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                      XOrIOp op) const {
   return buildLibraryOp<calyx::CombGroupOp, calyx::XorLibOp>(rewriter, op);
+}
+LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
+                                     SelectOp op) const {
+  return buildLibraryOp<calyx::CombGroupOp, calyx::MuxLibOp>(rewriter, op);
 }
 
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
@@ -1557,10 +1562,11 @@ public:
     // Only accept std operations which we've added lowerings for
     target.addIllegalDialect<FuncDialect>();
     target.addIllegalDialect<ArithDialect>();
-    target.addLegalOp<AddIOp, SubIOp, CmpIOp, ShLIOp, ShRUIOp, ShRSIOp, AndIOp,
-                      XOrIOp, OrIOp, ExtUIOp, TruncIOp, CondBranchOp, BranchOp,
-                      MulIOp, DivUIOp, DivSIOp, RemUIOp, RemSIOp, ReturnOp,
-                      arith::ConstantOp, IndexCastOp, FuncOp, ExtSIOp>();
+    target.addLegalOp<AddIOp, SelectOp, SubIOp, CmpIOp, ShLIOp, ShRUIOp,
+                      ShRSIOp, AndIOp, XOrIOp, OrIOp, ExtUIOp, TruncIOp,
+                      CondBranchOp, BranchOp, MulIOp, DivUIOp, DivSIOp, RemUIOp,
+                      RemSIOp, ReturnOp, arith::ConstantOp, IndexCastOp, FuncOp,
+                      ExtSIOp>();
 
     RewritePatternSet legalizePatterns(&getContext());
     legalizePatterns.add<DummyPattern>(&getContext());

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -210,7 +210,7 @@ class BuildOpGroups : public calyx::FuncOpPartialLoweringPattern {
                              AddIOp, SubIOp, CmpIOp, ShLIOp, ShRUIOp, ShRSIOp,
                              AndIOp, XOrIOp, OrIOp, ExtUIOp, ExtSIOp, TruncIOp,
                              MulIOp, DivUIOp, DivSIOp, RemUIOp, RemSIOp,
-                             IndexCastOp>(
+                             SelectOp, IndexCastOp>(
                   [&](auto op) { return buildOp(rewriter, op).succeeded(); })
               .template Case<FuncOp, scf::ConditionOp>([&](auto) {
                 /// Skip: these special cases will be handled separately.

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -2855,7 +2855,7 @@ SmallVector<StringRef> MuxLibOp::portNames() {
   return {"sel", "tru", "fal", "out"};
 }
 SmallVector<Direction> MuxLibOp::portDirections() {
-  return {Input, Input, Output};
+  return {Input, Input, Input, Output};
 }
 void MuxLibOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   getCellAsmResultNames(setNameFn, *this, this->portNames());
@@ -2863,7 +2863,7 @@ void MuxLibOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 bool MuxLibOp::isCombinational() { return true; }
 SmallVector<DictionaryAttr> MuxLibOp::portAttributes() {
   return {DictionaryAttr::get(getContext()), DictionaryAttr::get(getContext()),
-          DictionaryAttr::get(getContext())};
+          DictionaryAttr::get(getContext()), DictionaryAttr::get(getContext())};
 }
 
 #define ImplBinPipeOpCellInterface(OpType, outName)                            \

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -2851,6 +2851,21 @@ LogicalResult SliceLibOp::verify() {
   return success();
 }
 
+SmallVector<StringRef> MuxLibOp::portNames() {
+  return {"sel", "tru", "fal", "out"};
+}
+SmallVector<Direction> MuxLibOp::portDirections() {
+  return {Input, Input, Output};
+}
+void MuxLibOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  getCellAsmResultNames(setNameFn, *this, this->portNames());
+}
+bool MuxLibOp::isCombinational() { return true; }
+SmallVector<DictionaryAttr> MuxLibOp::portAttributes() {
+  return {DictionaryAttr::get(getContext()), DictionaryAttr::get(getContext()),
+          DictionaryAttr::get(getContext())};
+}
+
 #define ImplBinPipeOpCellInterface(OpType, outName)                            \
   SmallVector<StringRef> OpType::portNames() {                                 \
     return {"clk", "reset", "go", "left", "right", outName, "done"};           \

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -628,6 +628,8 @@ void Emitter::emitComponent(ComponentInterface op) {
                 SubLibOp, ShruLibOp, RshLibOp, SrshLibOp, LshLibOp, AndLibOp,
                 NotLibOp, OrLibOp, XorLibOp, WireLibOp>(
               [&](auto op) { emitLibraryPrimTypedByFirstInputPort(op); })
+          .Case<MuxLibOp>(
+              [&](auto op) { emitLibraryPrimTypedByFirstOutputPort(op); })
           .Case<MultPipeLibOp>(
               [&](auto op) { emitLibraryPrimTypedByFirstOutputPort(op); })
           .Case<RemUPipeLibOp, DivUPipeLibOp>([&](auto op) {

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -128,11 +128,11 @@ private:
     return TypeSwitch<Operation *, FailureOr<StringRef>>(op)
         .Case<MemoryOp, RegisterOp, NotLibOp, AndLibOp, OrLibOp, XorLibOp,
               AddLibOp, SubLibOp, GtLibOp, LtLibOp, EqLibOp, NeqLibOp, GeLibOp,
-              LeLibOp, LshLibOp, RshLibOp, SliceLibOp, PadLibOp, WireLibOp>(
-            [&](auto op) -> FailureOr<StringRef> {
-              static constexpr std::string_view sCore = "core";
-              return {sCore};
-            })
+              LeLibOp, LshLibOp, RshLibOp, SliceLibOp, PadLibOp, WireLibOp,
+              MuxLibOp>([&](auto op) -> FailureOr<StringRef> {
+          static constexpr std::string_view sCore = "core";
+          return {sCore};
+        })
         .Case<SgtLibOp, SltLibOp, SeqLibOp, SneqLibOp, SgeLibOp, SleLibOp,
               SrshLibOp, MultPipeLibOp, RemUPipeLibOp, RemSPipeLibOp,
               DivUPipeLibOp, DivSPipeLibOp>(

--- a/test/Dialect/Calyx/emit-comb-component.mlir
+++ b/test/Dialect/Calyx/emit-comb-component.mlir
@@ -6,11 +6,16 @@ module attributes {calyx.entrypoint = "main"} {
     %0 = hw.constant 1 : i32
     // CHECK: add0 = std_add(32);
     %1:3 = calyx.std_add @add0 : i32, i32, i32
+    // CHECK = mux0 = std_mux(32);
+    %2:4 = calyx.std_mux @mux0 : i1, i32, i32, i32
+    %3 = hw.constant 1 : i1
     calyx.wires {
       // CHECK: add0.left = in;
       calyx.assign %1#0 = %in : i32
       // CHECK: add0.right = 32'd1;
       calyx.assign %1#1 = %0 : i32
+      // CHECK: mux0.sel = 1'd1;
+      calyx.assign %2#0 = %3 : i1
       // CHECK: out = add0.out;
       calyx.assign %out = %1#2 : i32
     }


### PR DESCRIPTION
Implements lowering for `arith.select` using Calyx's `std_mux` primitive.