### PR TITLE
[FIRRTL] Rework internal paths array, cover all ports, maintain.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -189,4 +189,26 @@ def MemoryInitAttr : AttrDef<FIRRTLDialect, "MemoryInit"> {
  let assemblyFormat = "`<` $filename `,` $isBinary `,` $isInline `>`";
 }
 
+/// An attribute holding internal path for ref-type ports.
+def InternalPathAttr : AttrDef<FIRRTLDialect, "InternalPath"> {
+  let summary = "Internal path for ref-type ports";
+  let mnemonic = "internalpath";
+  let parameters = (ins OptionalParameter<"::mlir::StringAttr">:$path);
+  let assemblyFormat = "(`<` $path^ `>`)?";
+  let builders = [
+     AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$path), [{
+       return $_get(path.getContext(), path);
+     }]>,
+     AttrBuilder<(ins "::llvm::StringRef":$path), [{
+       return $_get($_ctxt, ::mlir::StringAttr::get($_ctxt, path));
+     }]>,
+     AttrBuilder<(ins), [{
+       return $_get($_ctxt, ::mlir::StringAttr());
+     }]>
+  ];
+}
+
+def InternalPathArrayAttr
+  : TypedArrayAttrBase<InternalPathAttr, "InternalPath array attribute">;
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -193,7 +193,7 @@ def FExtModuleOp : FIRRTLModuleLike<"extmodule"> {
                    ParamDeclArrayAttr:$parameters,
                    DefaultValuedAttr<AnnotationArrayAttr,
                    "ArrayAttr()">:$annotations,
-                   DefaultValuedAttr<ArrayAttr, "{}">:$internalPaths
+                   OptionalAttr<InternalPathArrayAttr>:$internalPaths
                   );
   let results = (outs);
   let regions = (region AnyRegion:$body);
@@ -229,7 +229,7 @@ def FIntModuleOp : FIRRTLModuleLike<"intmodule"> {
                    ParamDeclArrayAttr:$parameters,
                    DefaultValuedAttr<AnnotationArrayAttr,
                    "ArrayAttr()">:$annotations,
-                   DefaultValuedAttr<ArrayAttr, "{}">:$internalPaths
+                   OptionalAttr<InternalPathArrayAttr>:$internalPaths
                   );
   let results = (outs);
   let regions = (region AnyRegion:$body);

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -455,8 +455,12 @@ static Value lowerInternalPathAnno(AnnoPathValue &srcTarget,
   if (auto extMod = dyn_cast<FExtModuleOp>((Operation *)mod)) {
     // The extern module can have other internal paths attached to it,
     // append this to them.
-    SmallVector<Attribute> paths(extMod.getInternalPathsAttr().getValue());
-    paths.push_back(internalPathAttr);
+    SmallVector<Attribute> paths;
+    if (auto internalPaths = extMod.getInternalPaths())
+      llvm::append_range(paths, internalPaths->getValue());
+    else
+      paths.resize(extMod.getNumPorts(), builder.getAttr<InternalPathAttr>());
+    paths.back() = builder.getAttr<InternalPathAttr>(internalPathAttr);
     extMod.setInternalPathsAttr(builder.getArrayAttr(paths));
   } else if (auto intMod = dyn_cast<FModuleOp>((Operation *)mod)) {
     auto builder = ImplicitLocOpBuilder::atBlockEnd(

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -453,8 +453,8 @@ static Value lowerInternalPathAnno(AnnoPathValue &srcTarget,
   // Now set the instance as the source for the final datatap xmr.
   srcTarget = AnnoPathValue(modInstance);
   if (auto extMod = dyn_cast<FExtModuleOp>((Operation *)mod)) {
-    // The extern module can have other internal paths attached to it,
-    // append this to them.
+    // Set the internal path for the new port, creating the paths array
+    // if not already present.
     SmallVector<Attribute> paths;
     if (auto internalPaths = extMod.getInternalPaths())
       llvm::append_range(paths, internalPaths->getValue());

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -520,7 +520,8 @@ BlockArgument FModuleOp::getArgument(size_t portNumber) {
 /// Insertion occurs in-order, such that ports with the same insertion index
 /// appear in the module in the same order they appeared in the list.
 static void insertPorts(FModuleLike op,
-                        ArrayRef<std::pair<unsigned, PortInfo>> ports) {
+                        ArrayRef<std::pair<unsigned, PortInfo>> ports,
+                        bool supportsInternalPaths = false) {
   if (ports.empty())
     return;
   unsigned oldNumArgs = op.getNumPorts();
@@ -536,15 +537,25 @@ static void insertPorts(FModuleLike op,
   assert(existingNames.size() == oldNumArgs);
   assert(existingTypes.size() == oldNumArgs);
   assert(existingLocs.size() == oldNumArgs);
+  SmallVector<Attribute> internalPaths;
+  auto emptyInternalPath = InternalPathAttr::get(op.getContext());
+  if (supportsInternalPaths) {
+    if (auto internalPathsAttr = op->getAttrOfType<ArrayAttr>("internalPaths"))
+      llvm::append_range(internalPaths, internalPathsAttr);
+    else
+      internalPaths.resize(oldNumArgs, emptyInternalPath);
+  }
 
   SmallVector<Direction> newDirections;
-  SmallVector<Attribute> newNames, newTypes, newAnnos, newSyms, newLocs;
+  SmallVector<Attribute> newNames, newTypes, newAnnos, newSyms, newLocs,
+      newInternalPaths;
   newDirections.reserve(newNumArgs);
   newNames.reserve(newNumArgs);
   newTypes.reserve(newNumArgs);
   newAnnos.reserve(newNumArgs);
   newSyms.reserve(newNumArgs);
   newLocs.reserve(newNumArgs);
+  newInternalPaths.reserve(newNumArgs);
 
   auto emptyArray = ArrayAttr::get(op.getContext(), {});
 
@@ -557,6 +568,8 @@ static void insertPorts(FModuleLike op,
       newAnnos.push_back(op.getAnnotationsAttrForPort(oldIdx));
       newSyms.push_back(op.getPortSymbolAttr(oldIdx));
       newLocs.push_back(existingLocs[oldIdx]);
+      if (supportsInternalPaths)
+        newInternalPaths.push_back(internalPaths[oldIdx]);
       ++oldIdx;
     }
   };
@@ -571,6 +584,8 @@ static void insertPorts(FModuleLike op,
     newAnnos.push_back(annos ? annos : emptyArray);
     newSyms.push_back(port.sym);
     newLocs.push_back(port.loc);
+    if (supportsInternalPaths)
+      newInternalPaths.push_back(emptyInternalPath);
   }
   migrateOldPorts(oldNumArgs);
 
@@ -589,6 +604,17 @@ static void insertPorts(FModuleLike op,
   op->setAttr("portAnnotations", ArrayAttr::get(op.getContext(), newAnnos));
   op.setPortSymbols(newSyms);
   op->setAttr("portLocations", ArrayAttr::get(op.getContext(), newLocs));
+  if (supportsInternalPaths) {
+    // Clear if no internal paths, otherwise ensure no null entries.
+    auto empty = llvm::all_of(newInternalPaths, [](Attribute attr) {
+      return !attr || !cast<InternalPathAttr>(attr).getPath();
+    });
+    if (empty)
+      op->removeAttr("internalPaths");
+    else
+      op->setAttr("internalPaths",
+                  ArrayAttr::get(op.getContext(), newInternalPaths));
+  }
 }
 
 /// Erases the ports that have their corresponding bit set in `portIndices`.
@@ -634,10 +660,26 @@ static void erasePorts(FModuleLike op, const llvm::BitVector &portIndices) {
 
 void FExtModuleOp::erasePorts(const llvm::BitVector &portIndices) {
   ::erasePorts(cast<FModuleLike>((Operation *)*this), portIndices);
+
+  // Fixup internalPaths array.
+  auto internalPaths = getInternalPaths();
+  if (internalPaths) {
+    auto newPaths =
+        removeElementsAtIndices(internalPaths->getValue(), portIndices);
+    setInternalPathsAttr(ArrayAttr::get(getContext(), newPaths));
+  }
 }
 
 void FIntModuleOp::erasePorts(const llvm::BitVector &portIndices) {
   ::erasePorts(cast<FModuleLike>((Operation *)*this), portIndices);
+
+  // Fixup internalPaths array.
+  auto internalPaths = getInternalPaths();
+  if (internalPaths) {
+    auto newPaths =
+        removeElementsAtIndices(internalPaths->getValue(), portIndices);
+    setInternalPathsAttr(ArrayAttr::get(getContext(), newPaths));
+  }
 }
 
 void FMemModuleOp::erasePorts(const llvm::BitVector &portIndices) {
@@ -666,11 +708,13 @@ void FModuleOp::insertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports) {
 }
 
 void FExtModuleOp::insertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports) {
-  ::insertPorts(cast<FModuleLike>((Operation *)*this), ports);
+  ::insertPorts(cast<FModuleLike>((Operation *)*this), ports,
+                /*supportsInternalPaths=*/true);
 }
 
 void FIntModuleOp::insertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports) {
-  ::insertPorts(cast<FModuleLike>((Operation *)*this), ports);
+  ::insertPorts(cast<FModuleLike>((Operation *)*this), ports,
+                /*supportsInternalPaths=*/true);
 }
 
 /// Inserts the given ports. The insertion indices are expected to be in order.
@@ -1054,13 +1098,6 @@ static void printFModuleLikeOp(OpAsmPrinter &p, FModuleLike op) {
   if (op->getAttrOfType<ArrayAttr>("annotations").empty())
     omittedAttrs.push_back("annotations");
 
-  // If there are no internal paths attributes we can omit the empty array.
-  if (op->hasAttr("internalPaths")) {
-    if (auto paths = op->getAttrOfType<ArrayAttr>("internalPaths"))
-      if (paths.empty())
-        omittedAttrs.push_back("internalPaths");
-  }
-
   p.printOptionalAttrDictWithKeyword(op->getAttrs(), omittedAttrs);
 }
 
@@ -1265,6 +1302,14 @@ LogicalResult FModuleOp::verify() {
 }
 
 LogicalResult FExtModuleOp::verify() {
+  // If internal paths are present, should cover all ports.
+  if (auto internalPaths = getInternalPaths()) {
+    if (internalPaths->size() != getNumPorts())
+      return emitError("has inconsistent internal path array with ")
+             << internalPaths->size() << " entries for " << getNumPorts()
+             << " ports";
+  }
+
   auto params = getParameters();
   if (params.empty())
     return success();
@@ -1286,6 +1331,14 @@ LogicalResult FExtModuleOp::verify() {
 }
 
 LogicalResult FIntModuleOp::verify() {
+  // If internal paths are present, should cover all ports.
+  if (auto internalPaths = getInternalPaths()) {
+    if (internalPaths->size() != getNumPorts())
+      return emitError("has inconsistent internal path array with ")
+             << internalPaths->size() << " entries for " << getNumPorts()
+             << " ports";
+  }
+
   auto params = getParameters();
   if (params.empty())
     return success();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1321,10 +1321,10 @@ verifyInternalPaths(FModuleLike op,
            << " ports";
 
   // No internal paths for non-ref-type ports.
-  for (auto [idx, path, type] :
-       llvm::enumerate(internalPaths->getValue(), op.getPortTypes())) {
-    if (cast<InternalPathAttr>(path).getPath() &&
-        !type_isa<RefType>(cast<TypeAttr>(type).getValue())) {
+  for (auto [idx, path, typeattr] : llvm::enumerate(
+           internalPaths->getAsRange<InternalPathAttr>(), op.getPortTypes())) {
+    if (path.getPath() &&
+        !type_isa<RefType>(cast<TypeAttr>(typeattr).getValue())) {
       auto diag =
           op.emitError("module has internal path for non-ref-type port ")
           << op.getPortNameAttr(idx);

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -78,6 +78,13 @@ struct FlatBundleFieldEntry {
                  << isOutput << ">}\n";
   }
 };
+
+/// Extended PortInfo including the (optional) internalPath attribute.
+struct PortInfoWithIP {
+  PortInfo pi;
+  std::optional<InternalPathAttr> internalPath;
+};
+
 } // end anonymous namespace
 
 /// Return true if the type has more than zero bitwidth.
@@ -343,12 +350,12 @@ struct TypeLoweringVisitor : public FIRRTLVisitor<TypeLoweringVisitor, bool> {
   void lowerModule(FModuleLike op);
 
   bool lowerArg(FModuleLike module, size_t argIndex, size_t argsRemoved,
-                SmallVectorImpl<PortInfo> &newArgs,
+                SmallVectorImpl<PortInfoWithIP> &newArgs,
                 SmallVectorImpl<Value> &lowering);
-  std::pair<Value, PortInfo> addArg(Operation *module, unsigned insertPt,
-                                    unsigned insertPtOffset, FIRRTLType srcType,
-                                    FlatBundleFieldEntry field,
-                                    PortInfo &oldArg, hw::InnerSymAttr newSym);
+  std::pair<Value, PortInfoWithIP>
+  addArg(Operation *module, unsigned insertPt, unsigned insertPtOffset,
+         FIRRTLType srcType, FlatBundleFieldEntry field, PortInfoWithIP &oldArg,
+         hw::InnerSymAttr newSym);
 
   // Helpers to manage state.
   bool visitDecl(FExtModuleOp op);
@@ -754,48 +761,50 @@ void TypeLoweringVisitor::lowerModule(FModuleLike op) {
 // Creates and returns a new block argument of the specified type to the
 // module. This also maintains the name attribute for the new argument,
 // possibly with a new suffix appended.
-std::pair<Value, PortInfo>
+std::pair<Value, PortInfoWithIP>
 TypeLoweringVisitor::addArg(Operation *module, unsigned insertPt,
                             unsigned insertPtOffset, FIRRTLType srcType,
-                            FlatBundleFieldEntry field, PortInfo &oldArg,
+                            FlatBundleFieldEntry field, PortInfoWithIP &oldArg,
                             hw::InnerSymAttr newSym) {
   Value newValue;
   FIRRTLType fieldType = mapBaseType(srcType, [&](auto) { return field.type; });
   if (auto mod = llvm::dyn_cast<FModuleOp>(module)) {
     Block *body = mod.getBodyBlock();
     // Append the new argument.
-    newValue = body->insertArgument(insertPt, fieldType, oldArg.loc);
+    newValue = body->insertArgument(insertPt, fieldType, oldArg.pi.loc);
   }
 
   // Save the name attribute for the new argument.
-  auto name = builder->getStringAttr(oldArg.name.getValue() + field.suffix);
+  auto name = builder->getStringAttr(oldArg.pi.name.getValue() + field.suffix);
 
   // Populate the new arg attributes.
   auto newAnnotations = filterAnnotations(
-      context, oldArg.annotations.getArrayAttr(), srcType, field);
+      context, oldArg.pi.annotations.getArrayAttr(), srcType, field);
   // Flip the direction if the field is an output.
-  auto direction = (Direction)((unsigned)oldArg.direction ^ field.isOutput);
+  auto direction = (Direction)((unsigned)oldArg.pi.direction ^ field.isOutput);
 
-  return std::make_pair(newValue,
-                        PortInfo{name, fieldType, direction, newSym, oldArg.loc,
-                                 AnnotationSet(newAnnotations)});
+  return std::make_pair(
+      newValue,
+      PortInfoWithIP{PortInfo{name, fieldType, direction, newSym, oldArg.pi.loc,
+                              AnnotationSet(newAnnotations)},
+                     oldArg.internalPath});
 }
 
 // Lower arguments with bundle type by flattening them.
 bool TypeLoweringVisitor::lowerArg(FModuleLike module, size_t argIndex,
                                    size_t argsRemoved,
-                                   SmallVectorImpl<PortInfo> &newArgs,
+                                   SmallVectorImpl<PortInfoWithIP> &newArgs,
                                    SmallVectorImpl<Value> &lowering) {
 
   // Flatten any bundle types.
   SmallVector<FlatBundleFieldEntry> fieldTypes;
-  auto srcType = type_cast<FIRRTLType>(newArgs[argIndex].type);
+  auto srcType = type_cast<FIRRTLType>(newArgs[argIndex].pi.type);
   if (!peelType(srcType, fieldTypes, getPreservationModeForModule(module)))
     return false;
 
   SmallVector<hw::InnerSymAttr> fieldSyms(fieldTypes.size());
-  if (failed(partitionSymbols(newArgs[argIndex].sym, srcType, fieldSyms,
-                              newArgs[argIndex].loc))) {
+  if (failed(partitionSymbols(newArgs[argIndex].pi.sym, srcType, fieldSyms,
+                              newArgs[argIndex].pi.loc))) {
     encounteredError = true;
     return false;
   }
@@ -1022,9 +1031,18 @@ bool TypeLoweringVisitor::visitDecl(FExtModuleOp extModule) {
   // Top level builder
   OpBuilder builder(context);
 
+  auto internalPaths = extModule.getInternalPaths();
+
   // Lower the module block arguments.
   SmallVector<unsigned> argsToRemove;
-  auto newArgs = extModule.getPorts();
+  SmallVector<PortInfoWithIP> newArgs;
+  for (auto [idx, pi] : llvm::enumerate(extModule.getPorts())) {
+    std::optional<InternalPathAttr> internalPath;
+    if (internalPaths)
+      internalPath = cast<InternalPathAttr>(internalPaths->getValue()[idx]);
+    newArgs.push_back({pi, internalPath});
+  }
+
   for (size_t argIndex = 0, argsRemoved = 0; argIndex < newArgs.size();
        ++argIndex) {
     SmallVector<Value> lowering;
@@ -1036,9 +1054,8 @@ bool TypeLoweringVisitor::visitDecl(FExtModuleOp extModule) {
   }
 
   // Remove block args that have been lowered
-  for (auto ii = argsToRemove.rbegin(), ee = argsToRemove.rend(); ii != ee;
-       ++ii)
-    newArgs.erase(newArgs.begin() + *ii);
+  for (auto toRemove : llvm::reverse(argsToRemove))
+    newArgs.erase(newArgs.begin() + toRemove);
 
   SmallVector<NamedAttribute, 8> newModuleAttrs;
 
@@ -1057,14 +1074,18 @@ bool TypeLoweringVisitor::visitDecl(FExtModuleOp extModule) {
   SmallVector<Attribute, 8> newArgSyms;
   SmallVector<Attribute, 8> newArgLocations;
   SmallVector<Attribute, 8> newArgAnnotations;
+  SmallVector<Attribute, 8> newInternalPaths;
 
+  auto emptyInternalPath = InternalPathAttr::get(context);
   for (auto &port : newArgs) {
-    newArgDirections.push_back(port.direction);
-    newArgNames.push_back(port.name);
-    newArgTypes.push_back(TypeAttr::get(port.type));
-    newArgSyms.push_back(port.sym);
-    newArgLocations.push_back(port.loc);
-    newArgAnnotations.push_back(port.annotations.getArrayAttr());
+    newArgDirections.push_back(port.pi.direction);
+    newArgNames.push_back(port.pi.name);
+    newArgTypes.push_back(TypeAttr::get(port.pi.type));
+    newArgSyms.push_back(port.pi.sym);
+    newArgLocations.push_back(port.pi.loc);
+    newArgAnnotations.push_back(port.pi.annotations.getArrayAttr());
+    if (internalPaths)
+      newInternalPaths.push_back(port.internalPath.value_or(emptyInternalPath));
   }
 
   newModuleAttrs.push_back(
@@ -1086,6 +1107,9 @@ bool TypeLoweringVisitor::visitDecl(FExtModuleOp extModule) {
   // Update the module's attributes.
   extModule->setAttrs(newModuleAttrs);
   extModule.setPortSymbols(newArgSyms);
+  if (internalPaths)
+    extModule.setInternalPathsAttr(builder.getArrayAttr(newInternalPaths));
+
   return false;
 }
 
@@ -1100,7 +1124,9 @@ bool TypeLoweringVisitor::visitDecl(FModuleOp module) {
 
   // Lower the module block arguments.
   llvm::BitVector argsToRemove;
-  auto newArgs = module.getPorts();
+  auto newArgs = llvm::map_to_vector(module.getPorts(), [](auto pi) {
+    return PortInfoWithIP{pi, std::nullopt};
+  });
   for (size_t argIndex = 0, argsRemoved = 0; argIndex < newArgs.size();
        ++argIndex) {
     SmallVector<Value> lowerings;
@@ -1138,12 +1164,12 @@ bool TypeLoweringVisitor::visitDecl(FModuleOp module) {
   SmallVector<Attribute> newArgLocations;
   SmallVector<Attribute, 8> newArgAnnotations;
   for (auto &port : newArgs) {
-    newArgDirections.push_back(port.direction);
-    newArgNames.push_back(port.name);
-    newArgTypes.push_back(TypeAttr::get(port.type));
-    newArgSyms.push_back(port.sym);
-    newArgLocations.push_back(port.loc);
-    newArgAnnotations.push_back(port.annotations.getArrayAttr());
+    newArgDirections.push_back(port.pi.direction);
+    newArgNames.push_back(port.pi.name);
+    newArgTypes.push_back(TypeAttr::get(port.pi.type));
+    newArgSyms.push_back(port.pi.sym);
+    newArgLocations.push_back(port.pi.loc);
+    newArgAnnotations.push_back(port.pi.annotations.getArrayAttr());
   }
 
   newModuleAttrs.push_back(

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -802,6 +802,14 @@ bool TypeLoweringVisitor::lowerArg(FModuleLike module, size_t argIndex,
   if (!peelType(srcType, fieldTypes, getPreservationModeForModule(module)))
     return false;
 
+  // Ports with internalPath set cannot be lowered.
+  if (auto ip = newArgs[argIndex].internalPath; ip && ip->getPath()) {
+    ::mlir::emitError(newArgs[argIndex].pi.loc,
+                      "cannot lower port with internal path");
+    encounteredError = true;
+    return false;
+  }
+
   SmallVector<hw::InnerSymAttr> fieldSyms(fieldTypes.size());
   if (failed(partitionSymbols(newArgs[argIndex].pi.sym, srcType, fieldSyms,
                               newArgs[argIndex].pi.loc))) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -705,10 +705,9 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
     for (auto iter : refPortsToRemoveMap)
       if (auto mod = dyn_cast<FModuleOp>(iter.getFirst()))
         mod.erasePorts(iter.getSecond());
-      else if (auto mod = dyn_cast<FExtModuleOp>(iter.getFirst())) {
+      else if (auto mod = dyn_cast<FExtModuleOp>(iter.getFirst()))
         mod.erasePorts(iter.getSecond());
-        mod.removeInternalPathsAttr();
-      } else if (auto inst = dyn_cast<InstanceOp>(iter.getFirst())) {
+      else if (auto inst = dyn_cast<InstanceOp>(iter.getFirst())) {
         ImplicitLocOpBuilder b(inst.getLoc(), inst);
         inst.erasePorts(b, iter.getSecond());
         inst.erase();

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -513,15 +513,17 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
       // attribute which specifies the internal path into the extern module.
       // This string attribute will be used to generate the final xmr.
       auto internalPaths = extRefMod.getInternalPaths();
-      size_t pathsIndex = 0;
       auto numPorts = inst.getNumResults();
       SmallString<128> circuitRefPrefix;
 
       /// Get the resolution string for this ref-type port.
       auto getPath = [&](size_t portNo) {
-        // If there's an internalPaths array, grab the next element.
-        if (!internalPaths.empty())
-          return cast<StringAttr>(internalPaths[pathsIndex++]);
+        // If there's an internal path specified (with path), use that.
+        if (internalPaths)
+          if (auto path =
+                  cast<InternalPathAttr>(internalPaths->getValue()[portNo])
+                      .getPath())
+            return path;
 
         // Otherwise, we're using the ref ABI.  Generate the prefix string
         // and return the macro for the specified port.
@@ -703,9 +705,10 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
     for (auto iter : refPortsToRemoveMap)
       if (auto mod = dyn_cast<FModuleOp>(iter.getFirst()))
         mod.erasePorts(iter.getSecond());
-      else if (auto mod = dyn_cast<FExtModuleOp>(iter.getFirst()))
+      else if (auto mod = dyn_cast<FExtModuleOp>(iter.getFirst())) {
         mod.erasePorts(iter.getSecond());
-      else if (auto inst = dyn_cast<InstanceOp>(iter.getFirst())) {
+        mod.removeInternalPathsAttr();
+      } else if (auto inst = dyn_cast<InstanceOp>(iter.getFirst())) {
         ImplicitLocOpBuilder b(inst.getLoc(), inst);
         inst.erasePorts(b, iter.getSecond());
         inst.erase();

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-xmr.fir
@@ -55,7 +55,7 @@ circuit Top : %[[
     skip
 
   extmodule BlackBox :
-
+    output existing : Probe<{a: UInt<5>, b: UInt<5>}[3]>
     defname = BlackBox
 
   module Child :

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -1229,7 +1229,7 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
     }
   ]
 }]} {
-  firrtl.extmodule private @BlackBox() attributes {defname = "BlackBox"}
+  firrtl.extmodule private @BlackBox(out probe: !firrtl.rwprobe<uint<5>>) attributes {defname = "BlackBox"}
   firrtl.module private @InnerMod() {
     %w = firrtl.wire : !firrtl.uint<1>
   }
@@ -1244,15 +1244,16 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
     %tap_5 = firrtl.wire : !firrtl.vector<uint<1>, 1>
     %tap_6 = firrtl.wire : !firrtl.uint<1>
 
-    firrtl.instance BlackBox @BlackBox()
+    %bb_probe = firrtl.instance BlackBox @BlackBox(out probe: !firrtl.rwprobe<uint<5>>)
     firrtl.instance im @InnerMod()
   }
 }
 
 // CHECK-LABEL: firrtl.extmodule private @BlackBox
+// CHECK-SAME:    out {{[a-zA-Z0-9_]+}}: !firrtl.rwprobe<uint<5>>
 // CHECK-SAME:    out {{[a-zA-Z0-9_]+}}: !firrtl.probe<uint<1>>
 // CHECK-SAME:    out {{[a-zA-Z0-9_]+}}: !firrtl.probe<uint<1>>
-// CHECK-SAME:    internalPaths = ["baz.qux", "baz.quz"]
+// CHECK-SAME:    internalPaths = [#firrtl.internalpath, #firrtl.internalpath<"baz.qux">, #firrtl.internalpath<"baz.quz">]
 
 // CHECK-LABEL: firrtl.module private @InnerMod
 // CHECK-SAME:    out %[[tap_6:[a-zA-Z0-9_]+]]: !firrtl.probe<uint<1>>
@@ -1504,7 +1505,7 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [
     ]}]} {
   firrtl.extmodule private @ExtBar()
   // CHECK: firrtl.extmodule private @ExtBar(out random_something_external: !firrtl.probe<uint<1>>)
-  // CHECK-SAME: internalPaths = ["random.something.external"]
+  // CHECK-SAME: internalPaths = [#firrtl.internalpath<"random.something.external">]
   // CHECK:  firrtl.module private @Bar(out %[[_gen_ref2:.+]]: !firrtl.probe<uint<1>>)
   // CHECK:  %[[random:.+]] = firrtl.verbatim.expr "random.something" : () -> !firrtl.uint<1>
   // CHECK:  %0 = firrtl.ref.send %[[random]] : !firrtl.uint<1>
@@ -1796,7 +1797,7 @@ firrtl.circuit "Top"  attributes {rawAnnotations = [{
   firrtl.extmodule private @BlackBox() attributes {defname = "BlackBox"}
   // CHECK:  firrtl.extmodule private @BlackBox
   // CHECK-SAME:  out [[gen_ref:.+]]: !firrtl.probe<uint<1>>)
-  // CHECK-SAME: attributes {defname = "BlackBox", internalPaths = ["random.something"]}
+  // CHECK-SAME: attributes {defname = "BlackBox", internalPaths = [#firrtl.internalpath<"random.something">]}
   firrtl.module @Top(in %in: !firrtl.uint<1>) {
     %tap2 = firrtl.wire : !firrtl.bundle<wid: uint<1>>
     firrtl.instance localparam @BlackBox()

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -2073,3 +2073,20 @@ firrtl.circuit "ObjectFieldDoesntExist" {
     %1 = firrtl.object.subfield %0[bad_field] : !firrtl.class<@MyClass(out str: !firrtl.string)>
   }
 }
+
+// -----
+
+firrtl.circuit "WrongInternalPathCount" {
+  // expected-error @below {{module has inconsistent internal path array with 1 entries for 0 ports}}
+  firrtl.extmodule @WrongInternalPathCount() attributes { internalPaths = [ #firrtl.internalpath ] }
+}
+
+// -----
+
+firrtl.circuit "InternalPathForNonRefType" {
+  // expected-error @below {{module has internal path for non-ref-type port "in"}}
+  firrtl.extmodule @WrongInternalPathCount(
+    // expected-note @below {{this port}}
+    in in : !firrtl.uint<1>
+    ) attributes { internalPaths = [ #firrtl.internalpath<"x.y"> ] }
+}

--- a/test/Dialect/FIRRTL/lower-types-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-types-errors.mlir
@@ -1,0 +1,20 @@
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types))' %s --verify-diagnostics --split-input-file
+
+// Check diagnostic when attempting to lower something with symbols on it.
+firrtl.circuit "InnerSym" {
+  firrtl.module @InnerSym(
+  // expected-error @below {{unable to lower due to symbol "x" with target not preserved by lowering}}
+    in %x: !firrtl.bundle<a: uint<5>, b: uint<3>>
+      sym @x
+    ) { }
+}
+
+// -----
+
+// Check diagnostic when attempting to lower something with internalPath.
+firrtl.circuit "InternalPath" {
+  firrtl.extmodule @InternalPath(
+  // expected-error @below {{cannot lower port with internal path}}
+      in x: !firrtl.probe<bundle<a: uint<5>, b: uint<3>>>
+    ) attributes { internalPaths = [#firrtl.internalpath<"a.b.c">] }
+}

--- a/test/Dialect/FIRRTL/lower-types-sym-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-types-sym-errors.mlir
@@ -1,7 +1,0 @@
-// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-types))' %s --verify-diagnostics
-
-// Check diagnostic when attempting to lower something with symbols on it.
-firrtl.circuit "InnerSym" {
-  // expected-error @below {{unable to lower due to symbol "x" with target not preserved by lowering}}
-  firrtl.module @InnerSym(in %x: !firrtl.bundle<a: uint<5>, b: uint<3>> sym @x) { }
-}

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -797,7 +797,7 @@ firrtl.circuit "InternalPaths" {
   firrtl.extmodule private @RefExtMore(in in: !firrtl.uint<1>,
                                        out r: !firrtl.probe<uint<1>>,
                                        out data: !firrtl.uint<3>,
-                                       out r2: !firrtl.probe<vector<bundle<a: uint<3>>, 3>>) attributes {convention = #firrtl<convention scalarized>, internalPaths = ["path.to.internal.signal", "in"]}
+                                       out r2: !firrtl.probe<vector<bundle<a: uint<3>>, 3>>) attributes {convention = #firrtl<convention scalarized>, internalPaths = [#firrtl.internalpath, #firrtl.internalpath<"path.to.internal.signal">, #firrtl.internalpath, #firrtl.internalpath<"in">]}
   // CHECK: hw.hierpath private @xmrPath [@InternalPaths::@[[EXT_SYM:.+]]] 
   // CHECK: module public @InternalPaths(
   firrtl.module public @InternalPaths(in %in: !firrtl.uint<1>) {

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1302,7 +1302,7 @@ circuit EnumTypes:
 
   ; CHECK-LABEL: extmodule private @RefExt(
   ; CHECK-SAME:  in in: !firrtl.uint<1>, out r: !firrtl.probe<uint<1>>
-  ; CHECK-SAME: internalPaths = ["in"]
+  ; CHECK-SAME: internalPaths = [#firrtl.internalpath, #firrtl.internalpath<"in">]
   extmodule RefExt :
     input in : UInt<1>
     output r : Probe<UInt<1>>
@@ -1313,7 +1313,7 @@ circuit EnumTypes:
   ; CHECK-SAME: out r: !firrtl.probe<uint<1>>
   ; CHECK-SAME: out data: !firrtl.uint<3>
   ; CHECK-SAME: out r2: !firrtl.probe<vector<bundle<a: uint<3>>, 3>>
-  ; CHECK-SAME: internalPaths = ["path.to.internal.signal", "in"]
+  ; CHECK-SAME: internalPaths = [#firrtl.internalpath, #firrtl.internalpath<"path.to.internal.signal">, #firrtl.internalpath, #firrtl.internalpath<"in">]
   extmodule RefExtMore :
     input in : UInt<1>
     output r : Probe<UInt<1>>


### PR DESCRIPTION
We need to support having paths for some ref-type ports but not others (ABI + GCT's internalPath mechanism) so change to have entry per port, with empty entries for non-ref and ref ports that should use ABI.

Add verifier for internalPaths, drop entirely if all entries are empty.

Fixes #5859 .