### PR TITLE
[FIRRTL] Clean up FIRVersion checking

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -78,41 +78,41 @@ void registerFromFIRFileTranslation();
 
 /// The FIRRTL specification version.
 struct FIRVersion {
-  uint32_t major, minor, patch;
+  constexpr FIRVersion(uint16_t major, uint16_t minor, uint16_t patch)
+      : major(major), minor(minor), patch(patch) {}
 
-  /// Three way compare of one FIRRTL version with another FIRRTL version.
-  /// Return 1 if the first version is greater than the second version, -1 if
-  /// the first version is less than the second version, and 0 if the versions
-  /// are equal.
-  static int compare(const FIRVersion &a, const FIRVersion &b) {
-    if (a.major > b.major)
-      return 1;
-    if (a.major < b.major)
-      return -1;
-    if (a.minor > b.minor)
-      return 1;
-    if (a.minor < b.minor)
-      return -1;
-    if (a.patch > b.patch)
-      return 1;
-    if (a.patch < b.patch)
-      return -1;
-    return 0;
+  explicit constexpr operator uint64_t() const {
+    return uint64_t(major) << 32 | uint64_t(minor) << 16 | uint64_t(patch);
   }
 
-  static FIRVersion minimumFIRVersion() { return {0, 2, 0}; }
+  constexpr bool operator<(FIRVersion rhs) const {
+    return uint64_t(*this) < uint64_t(rhs);
+  }
 
-  static FIRVersion defaultFIRVersion() { return {1, 0, 0}; }
+  constexpr bool operator>(FIRVersion rhs) const {
+    return uint64_t(*this) > uint64_t(rhs);
+  }
 
-  static FIRVersion latestFIRVersion() { return {3, 1, 0}; }
+  constexpr bool operator<=(FIRVersion rhs) const {
+    return uint64_t(*this) <= uint64_t(rhs);
+  }
 
-}; // namespace firrtl
+  constexpr bool operator>=(FIRVersion rhs) const {
+    return uint64_t(*this) >= uint64_t(rhs);
+  }
 
-/// Method to enable printing of FIRVersions
+  uint16_t major;
+  uint16_t minor;
+  uint16_t patch;
+};
+
+constexpr FIRVersion minimumFIRVersion(0, 2, 0);
+constexpr FIRVersion latestFIRVersion(3, 1, 0);
+constexpr FIRVersion defaultFIRVersion(1, 0, 0);
+
 template <typename T>
-static T &operator<<(T &os, const FIRVersion &version) {
-  os << version.major << "." << version.minor << "." << version.patch;
-  return os;
+T &operator<<(T &os, FIRVersion version) {
+  return os << version.major << "." << version.minor << "." << version.patch;
 }
 
 } // namespace firrtl

--- a/lib/CAPI/ExportFIRRTL/ExportFIRRTL.cpp
+++ b/lib/CAPI/ExportFIRRTL/ExportFIRRTL.cpp
@@ -20,6 +20,5 @@ MlirLogicalResult mlirExportFIRRTL(MlirModule module,
                                    MlirStringCallback callback,
                                    void *userData) {
   mlir::detail::CallbackOstream stream(callback, userData);
-  return wrap(exportFIRFile(unwrap(module), stream, {},
-                            FIRVersion::latestFIRVersion()));
+  return wrap(exportFIRFile(unwrap(module), stream, {}, latestFIRVersion));
 }

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -597,7 +597,7 @@ void Emitter::emitStatement(RegResetOp op) {
   auto legalName = legalize(op.getNameAttr());
   addForceable(op, legalName);
   startStatement();
-  if (FIRVersion::compare(version, {3, 0, 0}) >= 0) {
+  if (FIRVersion(3, 0, 0) <= version) {
     ps.scopedBox(PP::ibox2, [&]() {
       ps << "regreset " << legalName;
       emitTypeWithColon(op.getResult().getType());
@@ -704,7 +704,7 @@ void Emitter::emitVerifStatement(T op, StringRef mnemonic) {
 
 void Emitter::emitStatement(ConnectOp op) {
   startStatement();
-  if (FIRVersion::compare(version, {3, 0, 0}) >= 0) {
+  if (FIRVersion(3, 0, 0) <= version) {
     ps.scopedBox(PP::ibox2, [&]() {
       if (op.getSrc().getDefiningOp<InvalidValueOp>()) {
         ps << "invalidate" << PP::space;
@@ -731,7 +731,7 @@ void Emitter::emitStatement(ConnectOp op) {
 
 void Emitter::emitStatement(StrictConnectOp op) {
   startStatement();
-  if (FIRVersion::compare(version, {3, 0, 0}) >= 0) {
+  if (FIRVersion(3, 0, 0) <= version) {
     ps.scopedBox(PP::ibox2, [&]() {
       if (op.getSrc().getDefiningOp<InvalidValueOp>()) {
         ps << "invalidate" << PP::space;
@@ -988,7 +988,7 @@ void Emitter::emitStatement(InvalidValueOp op) {
   emitType(op.getType());
   emitLocationAndNewLine(op);
   startStatement();
-  if (FIRVersion::compare(version, {3, 0, 0}) >= 0)
+  if (FIRVersion(3, 0, 0) <= version)
     ps << "invalidate " << PPExtString(name);
   else
     ps << PPExtString(name) << " is invalid";
@@ -1344,8 +1344,7 @@ void circt::firrtl::registerToFIRFileTranslation() {
   static mlir::TranslateFromMLIRRegistration toFIR(
       "export-firrtl", "emit FIRRTL dialect operations to .fir output",
       [](ModuleOp module, llvm::raw_ostream &os) {
-        return exportFIRFile(module, os, targetLineLength,
-                             FIRVersion::latestFIRVersion());
+        return exportFIRFile(module, os, targetLineLength, latestFIRVersion);
       },
       [](mlir::DialectRegistry &registry) {
         registry.insert<chirrtl::CHIRRTLDialect>();

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -711,7 +711,7 @@ FIRRTL version 2.3.9
 circuit UnsupportedRadixSpecifiedIntegerLiterals:
   module UnsupportedRadixSpecifiedIntegerLiterals:
     output foo: UInt<8>
-    ; expected-error @below {{Radix-specified integer literals are a FIRRTL 2.4.0 feature, but the specified FIRRTL version was 2.3.9}}
+    ; expected-error @below {{radix-specified integer literals are a FIRRTL 2.4.0+ feature, but the specified FIRRTL version was 2.3.9}}
     foo <= UInt(0b101010)
 
 ;// -----
@@ -803,7 +803,7 @@ circuit VecOfProps:
 
 FIRRTL version 3.0.0
 circuit UnsupportedVersionDeclGroups:
-  ; expected-error @below {{unexpected token}}
+  ; expected-error @below {{optional groups are a FIRRTL 3.1.0+ feature, but the specified FIRRTL version was 3.0.0}}
   declgroup A, bind:
 
 ;// -----
@@ -811,7 +811,7 @@ circuit UnsupportedVersionDeclGroups:
 FIRRTL version 3.0.0
 circuit UnsupportedVersionGroups:
   module UnsupportedVersionGroups:
-    ; expected-error @below {{unexpected token}}
+    ; expected-error @below {{optional groups are a FIRRTL 3.1.0+ feature, but the specified FIRRTL version was 3.0.0}}
     group A:
 
 ;// -----
@@ -851,7 +851,7 @@ FIRRTL version 3.0.0
 circuit Top:
   module Top:
     output s : String
-    ; expected-error @above {{Properties are a FIRRTL 3.1.0+ feature, but the specified FIRRTL version was 3.0.0}}
+    ; expected-error @above {{Strings are a FIRRTL 3.1.0+ feature, but the specified FIRRTL version was 3.0.0}}
 
 ;// -----
 FIRRTL version 3.0.0
@@ -900,7 +900,7 @@ circuit Top:
     skip
 
   module Top:
-    ; expected-error @below {{unexpected token: objects are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.0.0}}
+    ; expected-error @below {{object statements are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.0.0}}
     object x of MyClass
 
 ;// -----
@@ -911,7 +911,7 @@ circuit Top:
     skip
 
   module Top:
-    ; expected-error @below {{unexpected token: Inst types are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.0.0}}
+    ; expected-error @below {{Inst types are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.0.0}}
     output o: Inst<MyClass>
     object x of MyClass
     propassign o, x


### PR DESCRIPTION
changes:
- `FIRVersion`:
  - compress FIRVersion into a 64bit value (when padded), and pass it around by value.
  - add comparison operators and remove `FIRVersion::compare`
  - make min, default, latestVersion constexpr values, not functions
  - minor cleanup to operator<<: it doesn't need to be marked static, it is implicitly inline because it is templated.
- `FIRParser`:
  - pass FIRVersion to subparsers by value
  - add new `requireFeature` helper, to ease boilerplate for checking the FIRRTL language version
  - use `requireFeature` and the new FIRVersion comparison operators throughout the parser