### PR TITLE
[FIRRTL] Keep classes around

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -299,8 +299,8 @@ def ClassOp : FIRRTLModuleLike<"class", [
   DeclareOpInterfaceMethods<FModuleLike, [
     // Class Ops do not support port annotations.
     // Override this method to return an empty array attr.
-    "getPortAnnotationsAttr"]>
-]> {
+    "getPortAnnotationsAttr"]>,
+  DeclareOpInterfaceMethods<Symbol, ["canDiscardOnUseEmpty"]>]> {
   let summary = "FIRRTL Class";
   let description = [{
     The "firrtl.class" operation defines a class of property-only objects,

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1631,6 +1631,13 @@ BlockArgument ClassOp::getArgument(size_t portNumber) {
   return getBodyBlock()->getArgument(portNumber);
 }
 
+bool ClassOp::canDiscardOnUseEmpty() {
+  // ClassOps are referenced by ClassTypes, and these uses are not
+  // discovereable by the symbol infrastructure. Return false here to prevent
+  // passes like symbolDCE from removing our classes.
+  return false;
+}
+
 //===----------------------------------------------------------------------===//
 // Declarations
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -1395,7 +1395,7 @@ void Inliner::run() {
 
   // Mark the top module as live, so it doesn't get deleted.
   for (auto module : circuit.getOps<FModuleLike>()) {
-    if (!module.isPublic())
+    if (module.canDiscardOnUseEmpty())
       continue;
     liveModules.insert(module);
     if (isa<FModuleOp>(module))

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1265,3 +1265,12 @@ firrtl.circuit "CollidingSymbolsFields" {
     %collision_bar = firrtl.wire sym [<@bar,1,public>,<@bar_0,2,public>] : !firrtl.bundle<a: uint<1>, b: uint<1>>
   }
 }
+
+// -----
+// Test that unused classes are NOT deleted.
+
+firrtl.circuit "Top" {
+  firrtl.module @Top () {}
+  // CHECK: firrtl.class private @MyClass()
+  firrtl.class private @MyClass() {}
+}


### PR DESCRIPTION
Uses of classes are not always discoverable, this PR makes two changes to prevent the firtool pass pipeline from removing classes that appear dead.