### PR TITLE
[FIRRTL] Skirt around the GCC major/minor macros

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -79,7 +79,7 @@ void registerFromFIRFileTranslation();
 /// The FIRRTL specification version.
 struct FIRVersion {
   constexpr FIRVersion(uint16_t major, uint16_t minor, uint16_t patch)
-      : major(major), minor(minor), patch(patch) {}
+      : major{major}, minor{minor}, patch{patch} {}
 
   explicit constexpr operator uint64_t() const {
     return uint64_t(major) << 32 | uint64_t(minor) << 16 | uint64_t(patch);


### PR DESCRIPTION
GCC defines function-like macros major(x) and minor(x), for extracting information from device IDs. These macros conflict with, and cause compilation errors in, FIRVersion's constructor. This commit changes FIRVersion to initialize it's major and minor fields using brace-initialization, so that the initialization isn't mistaken for a macro invocation.

Tested in [godbolt](https://godbolt.org/z/n4e89EEaa).

Cc: @mortbopet
Fixes: #5868