### PR TITLE
[Seq] Add a clock multiplexer op

### DIFF
--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -325,6 +325,32 @@ def ClockGateOp : SeqOp<"clock_gate", [
 }
 
 //===----------------------------------------------------------------------===//
+// Clock Multiplexer
+//===----------------------------------------------------------------------===//
+
+def ClockMuxOp : SeqOp<"clock_mux", [Pure]> {
+  let summary = "Safely selects a clock based on a condition";
+  let description = [{
+    The `seq.clock_mux` op selects a clock from two options. If `cond` is 
+    true, the first clock operand is selected to drive downstream logic. 
+    Otherwise, the second clock is used.
+
+    ```
+    %clock = seq.clock_mux %cond, %trueClock, %falseClock
+    ```
+  }];
+
+  let arguments = (ins I1:$cond, I1:$trueClock, I1:$falseClock);
+  let results = (outs I1:$result);
+
+  let hasFolder = 1;
+
+  let assemblyFormat = [{
+    $cond `,` $trueClock `,` $falseClock attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // FIRRTL-flavored memory
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -755,6 +755,18 @@ std::optional<size_t> ClockGateOp::getTargetResultIndex() {
 }
 
 //===----------------------------------------------------------------------===//
+// ClockMuxOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult ClockMuxOp::fold(FoldAdaptor adaptor) {
+  if (isConstantOne(adaptor.getCond()))
+    return getTrueClock();
+  if (isConstantZero(adaptor.getCond()))
+    return getFalseClock();
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
 // FirMemOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -135,6 +135,16 @@ hw.module @ClockGate(%clock: i1, %enable: i1, %enable2 : i1, %testEnable: i1) {
   %transitiveClock2 = hw.wire %11 sym @transitiveClock2 : i1
 }
 
+// CHECK-LABEL: hw.module @ClockMux
+hw.module @ClockMux(%cond: i1, %trueClock: i1, %falseClock: i1) -> (clk0: i1, clk1: i1){
+  %false = hw.constant false
+  %true = hw.constant true
+  %clock_true = seq.clock_mux %true, %trueClock, %falseClock
+  %clock_false = seq.clock_mux %false, %trueClock, %falseClock
+  // CHECK: hw.output %trueClock, %falseClock : i1, i1
+  hw.output %clock_true, %clock_false : i1, i1
+}
+
 // CHECK-LABEL: @FirMem
 hw.module @FirMem(%addr: i4, %clock: i1, %data: i42) -> (out: i42) {
   %true = hw.constant true

--- a/test/Dialect/Seq/clock-mux.mlir
+++ b/test/Dialect/Seq/clock-mux.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt --lower-seq-to-sv %s | FileCheck %s
+
+// CHECK-LABEL: hw.module @clock_mux
+hw.module @clock_mux(%cond : i1, %trueClock: i1, %falseClock: i1) -> (out: i1) {
+  // CHECK: [[MUX:%.+]] = comb.mux bin %cond, %trueClock, %falseClock
+  // CHECK: hw.output [[MUX]] : i1
+  %0 = seq.clock_mux %cond, %trueClock, %falseClock
+  hw.output %0 : i1
+}

--- a/test/Dialect/Seq/round-trip.mlir
+++ b/test/Dialect/Seq/round-trip.mlir
@@ -57,6 +57,12 @@ hw.module @ClockGate(%clock: i1, %enable: i1, %test_enable: i1) {
   %cg2 = seq.clock_gate %clock, %enable, %test_enable sym @gate_sym
 }
 
+// CHECK-LABEL: hw.module @ClockMux
+hw.module @ClockMux(%cond: i1, %trueClock: i1, %falseClock: i1) -> (clock: i1) {
+  %clock = seq.clock_mux %cond, %trueClock, %falseClock
+  hw.output %clock : i1
+}
+
 hw.module @fifo1(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> () {
   // CHECK: %out, %full, %empty = seq.fifo depth 3 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
   %out, %full, %empty = seq.fifo depth 3 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32


### PR DESCRIPTION
As part of the introduction of a clock type (#5851), this PR adds a clock multiplexer which later will operate on `seq.clock`.