### PR TITLE
[OM] Restrict a map key type to a string

### DIFF
--- a/include/circt/Dialect/OM/OMTypes.td
+++ b/include/circt/Dialect/OM/OMTypes.td
@@ -52,22 +52,19 @@ def ListType : TypeDef<OMDialect, "List", []> {
 }
 
 def MapType : TypeDef<OMDialect, "Map", []> {
-  let summary = [{A type that represents a map. A key type must be either
-                  an integer or string type}];
+  let summary = [{A type that represents a string map}];
 
   let mnemonic = "map";
-  let parameters = (ins "mlir::Type": $keyType, "mlir::Type":$valueType);
+  let parameters = (ins "mlir::Type":$valueType);
   let assemblyFormat = [{
-    `<` $keyType `,` $valueType `>`
+    `<` $valueType `>`
   }];
 
   let builders = [
-    AttrBuilderWithInferredContext<(ins "::mlir::Type":$keyType, "::mlir::Type":$valueType), [{
-      return $_get(keyType.getContext(), keyType, valueType);
+    AttrBuilderWithInferredContext<(ins "::mlir::Type":$valueType), [{
+      return $_get(valueType.getContext(), valueType);
     }]>
   ];
-
-  let genVerifyDecl = 1;
 }
 
 def SymbolRefType : TypeDef<OMDialect, "SymbolRef", []> {

--- a/lib/Dialect/OM/OMTypes.cpp
+++ b/lib/Dialect/OM/OMTypes.cpp
@@ -26,12 +26,3 @@ void circt::om::OMDialect::registerTypes() {
 #include "circt/Dialect/OM/OMTypes.cpp.inc"
       >();
 }
-
-mlir::LogicalResult
-circt::om::MapType::verify(llvm::function_ref<mlir::InFlightDiagnostic()> diag,
-                           mlir::Type keyType, mlir::Type elementType) {
-  if (!llvm::isa<om::StringType, mlir::IntegerType>(keyType))
-    return diag() << "map key type must be either string or integer but got "
-                  << keyType;
-  return mlir::success();
-}

--- a/test/Dialect/OM/errors.mlir
+++ b/test/Dialect/OM/errors.mlir
@@ -96,9 +96,3 @@ om.class @ListCreate() {
   // expected-note @-2 {{prior use here}}
   %lst = om.list_create %0, %1 : i64
 }
-
-// -----
-
-// expected-error @+1 {{map key type must be either string or integer but got '!om.list<!om.string>'}}
-om.class @Map(%map: !om.map<!om.list<!om.string>, !om.string>) {
-}

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -167,7 +167,7 @@ om.class @StringConstant() {
 }
 
 // CHECK-LABEL: @Map
-// CHECK-SAME: !om.map<!om.string, !om.string>
-om.class @Map(%map: !om.map<!om.string, !om.string>) {
-  om.class.field @field, %map : !om.map<!om.string, !om.string>
+// CHECK-SAME: !om.map<!om.string>
+om.class @Map(%map: !om.map<!om.string>) {
+  om.class.field @field, %map : !om.map<!om.string>
 }


### PR DESCRIPTION
https://github.com/llvm/circt/pull/5852 introduced a map type to OM dialect but currently we don't need non-string key types. So just restrict a key type to string for now.