### PR TITLE
[PrepareForEmission] Handle aggregate constants in disallowPackedStruc…

### DIFF
--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -214,19 +214,24 @@ module attributes {circt.loweringOptions = "maximumNumberOfTermsPerExpression=2"
 // -----
 
 // CHECK-LABEL:   hw.module @packed_struct_assignment(
-// CHECK-SAME:                                        %[[VAL_0:.*]]: i32) -> (out: !hw.struct<a: i32>, out2: !hw.struct<a: i32>) {
+// CHECK-SAME:                                        %[[VAL_0:.*]]: i32) -> (out: !hw.struct<a: i32>, out2: !hw.struct<a: i32>, out3: !hw.struct<a: i32>) {
 // CHECK:           %[[VAL_1:.*]] = sv.wire
-// CHECK:           %[[VAL_2:.*]] = sv.struct_field_inout %[[VAL_1]]["a"] : !hw.inout<struct<a: i32>>
-// CHECK:           sv.assign %[[VAL_2]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_3:.*]] = sv.read_inout %[[VAL_1]] : !hw.inout<struct<a: i32>>
-// CHECK:           %[[VAL_4:.*]] = sv.read_inout %[[VAL_1]] : !hw.inout<struct<a: i32>>
-// CHECK:           hw.output %[[VAL_4]], %[[VAL_3]] : !hw.struct<a: i32>, !hw.struct<a: i32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = sv.struct_field_inout %[[VAL_1]]["a"]
+// CHECK-NEXT:      sv.assign %[[VAL_2]], %[[VAL_0]]
+// CHECK-NEXT:      %[[VAL_3:.*]] = sv.read_inout %[[VAL_1]]
+// CHECK-NEXT:      %[[VAL_4:.*]] = sv.read_inout %[[VAL_1]]
+// CHECK:           %[[VAL_5:.*]] = sv.wire
+// CHECK-NEXT:      %[[VAL_6:.*]] = sv.struct_field_inout %[[VAL_5]]["a"]
+// CHECK-NEXT:      sv.assign %[[VAL_6]], %c1_i32
+// CHECK-NEXT:      %[[VAL_7:.*]] = sv.read_inout %[[VAL_5]]
+// CHECK-NEXT:      hw.output %[[VAL_4]], %[[VAL_3]], %[[VAL_7]]
 // CHECK:         }
 !T = !hw.struct<a: i32>
 module attributes { circt.loweringOptions = "disallowPackedStructAssignments"} {
-  hw.module @packed_struct_assignment(%in : i32) -> (out: !T, out2: !T)  {
+  hw.module @packed_struct_assignment(%in : i32) -> (out: !T, out2: !T, out3: !T)  {
       %0 = hw.struct_create (%in) : !T
-      hw.output %0, %0 : !T, !T
+      %1 = hw.aggregate_constant [1: i32] : !T
+      hw.output %0, %0, %1 : !T, !T, !T
   }
 }
 


### PR DESCRIPTION
…tAssignments

Fix https://github.com/llvm/circt/issues/5864. https://github.com/llvm/circt/issues/5864 was caused by an issue that aggregate constant is not legalized by disallowPackedStructAssignments. Instead of directly legalizing aggregate constatnt, this PR lowers struct aggregate_constant into hw.create_struct op so that we can reuse existing legalization. 