### PR TITLE
[ci] Use release/asserts=off for nightly shared

### DIFF
--- a/.github/workflows/uploadReleaseArtifacts.yml
+++ b/.github/workflows/uploadReleaseArtifacts.yml
@@ -129,9 +129,6 @@ jobs:
         id: add-build-config-circt-full-shared
         run: |
           json='{"name":"CIRCT-full shared","install_target":"install","package_name_prefix":"circt-full-shared","mode":"release","assert":"OFF","shared":"ON","stats":"ON"}'
-          if [[ ${{ github.event_name }} == 'schedule' ]] || [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
-            json=$(echo $json | jq -c '.assert = "ON" | .mode = "relwithdebinfo"')
-          fi
           echo "out=$json" >> $GITHUB_OUTPUT
       - name: Build JSON Payloads
         id: build-json-payloads


### PR DESCRIPTION
Use less resource intensive options for building nightly releases of CIRCT
full.  The GitHub runners will run out of disk space if using
"relwithdebinfo" and/or "asserts=on".  Use "release" and "asserts=off".

For context, nightlies are building shared libs and running out of disk space with the options provided: https://github.com/llvm/circt/actions/workflows/uploadReleaseArtifacts.yml (Original link was wrong.)