### PR TITLE
[FIRRTL] Fix parsing connection between enum of uninferred width.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -106,7 +106,6 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     // Const-cast as needed, using widthless version of dest.
     // (dest is either widthless already, or source is and if the types
     //  can be const-cast'd, do so)
-    assert(srcType.isGround() && dstType.isGround());
     if (dstType != srcType && dstType.getWidthlessType() != srcType &&
         areTypesConstCastable(dstType.getWidthlessType(), srcType)) {
       src = builder.create<ConstCastOp>(dstType.getWidthlessType(), src);

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -96,7 +96,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     src = builder.create<UninferredResetCastOp>(srcType, src);
   }
 
-  // Handle ground types with possibly uninferred widths.
+  // Handle passive types with possibly uninferred widths.
   auto dstWidth = dstType.getBitWidthOrSentinel();
   auto srcWidth = srcType.getBitWidthOrSentinel();
   if (dstWidth < 0 || srcWidth < 0) {

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1146,7 +1146,6 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     module.in <= UInt(1)
 
   ; CHECK-LABEL: firrtl.module private @EnumTypes
-circuit EnumTypes:
   module EnumTypes:
     ; CHECK-SAME: in %i: !firrtl.enum<Some: uint<8>, None: uint<0>>
     input i : {| Some : UInt<8>, None |}
@@ -1170,6 +1169,14 @@ circuit EnumTypes:
       ; CHECK: }
       None:
         o is invalid
+
+  ; CHECK-LABEL: firrtl.module private @EnumInfer(
+  module EnumInfer:
+    input i : {| A: UInt<8>, None |}
+    output o : {| A: UInt, None |}
+
+    ; CHECK: connect %o, %i
+    o <= i
 
   ; CHECK-LABEL: module private @RefsChild(
   ; CHECK-SAME: out %r: !firrtl.probe<uint<1>>


### PR DESCRIPTION
Fixes #5322.

cc #5884 and #5886.