### PR TITLE
[NFC] Make FIRRTL modules not implement hwmodulelike

### DIFF
--- a/include/circt/Dialect/ESI/ESIStructure.td
+++ b/include/circt/Dialect/ESI/ESIStructure.td
@@ -23,6 +23,8 @@ include "circt/Dialect/HW/HWOpInterfaces.td"
 def ESIPureModuleOp : ESI_Op<"pure_module",
       [Symbol, NoTerminator, RegionKindInterface, NoRegionArguments,
        SingleBlock, HasParent<"mlir::ModuleOp">,
+       DeclareOpInterfaceMethods<PortList>,
+       DeclareOpInterfaceMethods<SymboledPortList>,
        DeclareOpInterfaceMethods<HWModuleLike>]> {
   let summary = "ESI pure module";
   let description = [{
@@ -44,10 +46,6 @@ def ESIPureModuleOp : ESI_Op<"pure_module",
     // Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph;}
 
-    //===------------------------------------------------------------------===//
-    // PortList Methods
-    //===------------------------------------------------------------------===//
-    ::circt::hw::ModulePortInfo getPortList();
   }];
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -16,10 +16,11 @@
 include "mlir/IR/OpBase.td"
 include "circt/Dialect/HW/HWOpInterfaces.td"
 
-def FModuleLike : OpInterface<"FModuleLike", [HWModuleLike]> {
+def FModuleLike : OpInterface<"FModuleLike", [Symbol, SymboledPortList, InstanceGraphModuleOpInterface]> {
   let cppNamespace = "circt::firrtl";
   let description = "Provide common module information.";
   let methods = [
+
     //===------------------------------------------------------------------===//
     // Parameters
     //===------------------------------------------------------------------===//
@@ -339,9 +340,6 @@ def FModuleLike : OpInterface<"FModuleLike", [HWModuleLike]> {
     static_assert(
         ConcreteOp::template hasTrait<::mlir::SymbolOpInterface::Trait>(),
         "expected operation to be a symbol");
-    static_assert(
-        ConcreteOp::template hasTrait<::circt::hw::HWModuleLike::Trait>(),
-        "expected operation to be also be a hardware module");
     static_assert(
         ConcreteOp::template hasTrait<OpTrait::InnerSymbolTable>(),
         "expected operation to be an inner symbol table");

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -65,7 +65,9 @@ class FIRRTLModuleLike<string mnemonic, list<Trait> traits = []> :
   FIRRTLOp<mnemonic, traits # [
     IsolatedFromAbove, Symbol, HasParent<"CircuitOp">,
     DeclareOpInterfaceMethods<FModuleLike>,
-    DeclareOpInterfaceMethods<HWModuleLike>,
+    DeclareOpInterfaceMethods<PortList>,
+    DeclareOpInterfaceMethods<SymboledPortList>,
+    DeclareOpInterfaceMethods<InstanceGraphModuleOpInterface>,
     DeclareOpInterfaceMethods<SymbolUserOpInterface>,
     OpAsmOpInterface, InnerSymbolTable]> {
 
@@ -74,26 +76,9 @@ class FIRRTLModuleLike<string mnemonic, list<Trait> traits = []> :
   code extraModuleClassDeclaration = [{}];
 
   let extraClassDeclaration = extraModuleClassDeclaration # [{
-
-    //===------------------------------------------------------------------===//
-    // PortList Methods
-    //===------------------------------------------------------------------===//
-    ::circt::hw::ModulePortInfo getPortList();
   }];
 
   let extraClassDefinition = extraModuleClassDefinition # [{
-
-    circt::hw::ModuleType $cppClass::getHWModuleType() {
-      SmallVector<hw::ModulePort> newPorts;
-      auto num = getPortNames().size();
-      newPorts.reserve(num);
-      for (unsigned i = 0; i < num; ++i)
-        newPorts.push_back({getPortNameAttr(i), getPortType(i),
-                       getPortDirection(i) == Direction::In ? 
-                         hw::ModulePort::Direction::Input : 
-                         hw::ModulePort::Direction::Output});
-      return hw::ModuleType::get(getContext(), newPorts);
-    }
 
     circt::hw::InnerSymAttr $cppClass::getPortSymbolAttr(size_t portIndex) {
       auto syms = getPortSymbols();
@@ -103,22 +88,9 @@ class FIRRTLModuleLike<string mnemonic, list<Trait> traits = []> :
       return syms[portIndex].template cast<hw::InnerSymAttr>();
     }
 
-
-    SmallVector<Location> $cppClass::getAllPortLocs() {
-      SmallVector<Location> retval;
-        for (auto l : getPortLocations())
-          retval.push_back(cast<Location>(l));
-      return retval;
+    size_t $cppClass::getNumPorts() {
+      return getPortTypesAttr().size();
     }
-
-    // Don't count annotations as attributes
-    SmallVector<Attribute> $cppClass::getAllPortAttrs() {
-      SmallVector<Attribute> retval;
-      for (unsigned i = 0, e = getNumPorts(); i < e; ++i)
-          retval.push_back({});
-      return retval;
-    }
-
   }];
 
 }

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -22,20 +22,36 @@ def PortList : OpInterface<"PortList", []> {
   let description = "Operations which produce a unified port list representation";
   let methods = [
     InterfaceMethod<"Get port list",
-    "::circt::hw::ModulePortInfo", "getPortList", (ins)>
+    "::circt::hw::ModulePortInfo", "getPortList", (ins)>,
+
+    InterfaceMethod<"Get the number of ports",
+    "size_t", "getNumPorts", (ins)>,
   ];
 }
 
+def SymboledPortList : OpInterface<"SymboledPortList", [PortList]> {
+  let cppNamespace = "circt::hw";
+  let description = "Operations which produce a unified port list representation";
+  let methods = [
+    InterfaceMethod<"Get a port symbol attribute",
+    "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>,
+  ];
+
+  let extraSharedClassDeclaration = [{
+    /// Attribute name for port symbols.
+    static StringRef getPortSymbolAttrName() {
+      return "hw.exportPort";
+    }
+  }];
+}
+
+
 def HWModuleLike : OpInterface<"HWModuleLike", [
-  Symbol, PortList, InstanceGraphModuleOpInterface]> {
+  Symbol, SymboledPortList, InstanceGraphModuleOpInterface]> {
   let cppNamespace = "circt::hw";
   let description = "Provide common module information.";
 
   let methods = [
-
-    InterfaceMethod<"Get a port symbol attribute",
-    "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>,
-
     InterfaceMethod<"Get the module type",
     "::circt::hw::ModuleType", "getHWModuleType", (ins)>,
 
@@ -70,11 +86,6 @@ def HWModuleLike : OpInterface<"HWModuleLike", [
     /// Returns the entry block argument for the given port.  May be null.
     BlockArgument getArgumentForPort(unsigned idx) {
       return $_op.getModuleBody().getArgument($_op.getHWModuleType().getInputIdForPortId(idx));
-    }
-
-    /// Return the total number of ports in the module
-    size_t getNumPorts() {
-      return $_op.getHWModuleType().getNumPorts();
     }
 
     /// Return the total number of input and inout ports in the module

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -31,18 +31,11 @@ def PortList : OpInterface<"PortList", []> {
 
 def SymboledPortList : OpInterface<"SymboledPortList", [PortList]> {
   let cppNamespace = "circt::hw";
-  let description = "Operations which produce a unified port list representation";
+  let description = "Operations which produce a unified port list representation which includes port symbols";
   let methods = [
     InterfaceMethod<"Get a port symbol attribute",
     "::circt::hw::InnerSymAttr", "getPortSymbolAttr", (ins "size_t":$portIndex)>,
   ];
-
-  let extraSharedClassDeclaration = [{
-    /// Attribute name for port symbols.
-    static StringRef getPortSymbolAttrName() {
-      return "hw.exportPort";
-    }
-  }];
 }
 
 
@@ -73,6 +66,10 @@ def HWModuleLike : OpInterface<"HWModuleLike", [
   ];
 
   let extraSharedClassDeclaration = [{
+    /// Attribute name for port symbols.
+    static StringRef getPortSymbolAttrName() {
+      return "hw.exportPort";
+    }
 
     /// Return the region containing the body of this function.
     Region &getModuleBody() { return $_op->getRegion(0); }

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -30,6 +30,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
     HWOp<mnemonic, traits # [
       DeclareOpInterfaceMethods<PortList>,
+      DeclareOpInterfaceMethods<SymboledPortList>,
       DeclareOpInterfaceMethods<HWModuleLike>,
       DeclareOpInterfaceMethods<HWMutableModuleLike>,
       Symbol, FunctionOpInterface,
@@ -51,16 +52,12 @@ class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
       ArrayRef<unsigned> eraseOutputs
     );
 
-    /// Attribute name for port symbols.
-    static StringRef getPortSymbolAttrName() {
-      return "hw.exportPort";
-    }
-
     void setPortSymbolAttr(size_t portIndex, ::circt::hw::InnerSymAttr sym);
 
     StringAttr getArgName(size_t index) {
       return dyn_cast<StringAttr>(getArgNames()[index]);
     }
+
   }];
 
   /// Additional class definitions inside the module op.
@@ -84,11 +81,18 @@ class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
       auto portSymAttr = StringAttr::get(getContext(), getPortSymbolAttrName());
       setPortAttr(portIndex, portSymAttr, sym);
     }
+
+    size_t $cppClass::getNumPorts() {
+      auto fnty = getFunctionType();
+      return fnty.getNumInputs() + fnty.getNumResults();
+    }
   }];
 
 }
 
-def HWTestModuleOp : HWOp<"testmodule", [Symbol, PortList,
+def HWTestModuleOp : HWOp<"testmodule", [Symbol,
+                                         DeclareOpInterfaceMethods<PortList>,
+                                         DeclareOpInterfaceMethods<SymboledPortList>,
                                          OpAsmOpInterface, 
                                          HasParent<"mlir::ModuleOp">, 
                                          IsolatedFromAbove,
@@ -107,11 +111,6 @@ def HWTestModuleOp : HWOp<"testmodule", [Symbol, PortList,
                                   mlir::OpAsmSetValueNameFn setNameFn);
 
     Block *getBodyBlock() { return &getRegion().front(); }
-
-    //===------------------------------------------------------------------===//
-    // PortList Methods
-    //===------------------------------------------------------------------===//
-    ::circt::hw::ModulePortInfo getPortList();
   }];
 
 }
@@ -471,6 +470,7 @@ def HWModuleGeneratedOp : HWModuleOpBase<"module.generated", [
 
 def InstanceOp : HWOp<"instance", [
         DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+        DeclareOpInterfaceMethods<PortList>,
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
         DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>,
         DeclareOpInterfaceMethods<HWInstanceLike>]> {
@@ -548,11 +548,6 @@ def InstanceOp : HWOp<"instance", [
 
     /// An InstanceOp may optionally define a symbol.
     bool isOptionalSymbol() { return true; }
-
-    //===------------------------------------------------------------------===//
-    // PortList Methods
-    //===------------------------------------------------------------------===//
-    ::circt::hw::ModulePortInfo getPortList();
 
   }];
 

--- a/include/circt/Dialect/MSFT/MSFTOps.td
+++ b/include/circt/Dialect/MSFT/MSFTOps.td
@@ -13,6 +13,7 @@ def InstanceOp : MSFTOp<"instance", [
         DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
         DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+        DeclareOpInterfaceMethods<PortList>,
         DeclareOpInterfaceMethods<InstanceGraphInstanceOpInterface>
     ]> {
   let summary = "Instantiate a module";
@@ -40,11 +41,6 @@ def InstanceOp : MSFTOp<"instance", [
     // Update the results.
     InstanceOp getWithNewResults(MSFTModuleOp mod,
                                  ArrayRef<unsigned> newToOldMap);
-
-    //===------------------------------------------------------------------===//
-    // PortList Methods
-    //===------------------------------------------------------------------===//
-    ::circt::hw::ModulePortInfo getPortList();
   }];
 
   /// sym keyword for optional symbol simplifies parsing
@@ -110,17 +106,14 @@ class MSFTModuleOpBase<string mnemonic, list<Trait> traits = []> :
           setNameFn(block->getArgument(i), name);
       }
     }
-
-    //===------------------------------------------------------------------===//
-    // PortList Methods
-    //===------------------------------------------------------------------===//
-    ::circt::hw::ModulePortInfo getPortList();
   }];
 }
 
 def MSFTModuleOp : MSFTModuleOpBase<"module",
       [RegionKindInterface, HasParent<"mlir::ModuleOp">,
        SingleBlockImplicitTerminator<"OutputOp">,
+       DeclareOpInterfaceMethods<PortList>,
+       DeclareOpInterfaceMethods<SymboledPortList>,
        DeclareOpInterfaceMethods<HWMutableModuleLike>]>{
   let summary = "MSFT HW Module";
   let description = [{
@@ -198,7 +191,10 @@ def MSFTModuleOp : MSFTModuleOpBase<"module",
 }
 
 def MSFTModuleExternOp : MSFTOp<"module.extern",
-      [Symbol, FunctionOpInterface, HasParent<"mlir::ModuleOp">, DeclareOpInterfaceMethods<HWModuleLike>]> {
+      [Symbol, FunctionOpInterface, HasParent<"mlir::ModuleOp">, 
+      DeclareOpInterfaceMethods<PortList>,
+      DeclareOpInterfaceMethods<SymboledPortList>,
+      DeclareOpInterfaceMethods<HWModuleLike>]> {
   let summary = "MSFT external Module";
   let description = [{
     Identical to `hw.module.extern`, and trivially lowers to that. This op
@@ -234,11 +230,6 @@ def MSFTModuleExternOp : MSFTOp<"module.extern",
 
     /// Returns the result types of this function.
     ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
-
-    //===------------------------------------------------------------------===//
-    // PortList Methods
-    //===------------------------------------------------------------------===//
-    ::circt::hw::ModulePortInfo getPortList();
   }];
 
   let extraClassDefinition = [{

--- a/include/circt/Support/InstanceGraphInterface.td
+++ b/include/circt/Support/InstanceGraphInterface.td
@@ -61,13 +61,14 @@ def InstanceGraphModuleOpInterface : OpInterface<"ModuleOpInterface"> {
     InterfaceMethod<"Get the module name",
     "::llvm::StringRef", "getModuleName", (ins),
     /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{ return $_op.getName(); }]>,
+    /*defaultImplementation=*/[{ return $_op.getModuleNameAttr().getValue(); }]>,
 
     InterfaceMethod<"Get the module name",
     "::mlir::StringAttr", "getModuleNameAttr", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getNameAttr(); }]>,
   ];
+  
 }
 
 #endif // CIRCT_SUPPORT_INSTANCEGRAPH_INSTANCEGRAPHINTERFACE_TD

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -284,8 +284,8 @@ struct CircuitLoweringState {
 
   // Return true if this module is the DUT or is instantiated by the DUT.
   // Returns false if the module is not instantiated by the DUT.
-  bool isInDUT(hw::HWModuleLike child) {
-    if (auto parent = dyn_cast<hw::HWModuleLike>(*dut))
+  bool isInDUT(igraph::ModuleOpInterface child) {
+    if (auto parent = dyn_cast<igraph::ModuleOpInterface>(*dut))
       return getInstanceGraph()->isAncestor(child, parent);
     return dut == child;
   }
@@ -295,7 +295,7 @@ struct CircuitLoweringState {
   // Return true if this module is instantiated by the Test Harness.  Returns
   // false if the module is not instantiated by the Test Harness or if the Test
   // Harness is not known.
-  bool isInTestHarness(hw::HWModuleLike mod) { return !isInDUT(mod); }
+  bool isInTestHarness(igraph::ModuleOpInterface mod) { return !isInDUT(mod); }
 
   InstanceGraph *getInstanceGraph() { return instanceGraph; }
 

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -534,12 +534,15 @@ hw::ModuleType ESIPureModuleOp::getHWModuleType() {
   return hw::ModuleType::get(getContext(), {});
 }
 
-::circt::hw::InnerSymAttr ESIPureModuleOp::getPortSymbolAttr(size_t) {
-  return {};
-}
-
 ::circt::hw::ModulePortInfo ESIPureModuleOp::getPortList() {
   return hw::ModulePortInfo(ArrayRef<hw::PortInfo>{});
+}
+
+size_t ESIPureModuleOp::getNumPorts() { return 0; }
+
+hw::InnerSymAttr ESIPureModuleOp::getPortSymbolAttr(size_t portIndex) {
+  emitError("No ports for port locations");
+  return nullptr;
 }
 
 SmallVector<Location> ESIPureModuleOp::getAllPortLocs() {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -511,66 +511,6 @@ hw::ModulePortInfo FMemModuleOp::getPortList() {
   return ::getPortListImpl(*this);
 }
 
-void FModuleOp::setAllPortAttrs(ArrayRef<Attribute> attrs) {
-  emitError("HWModuleLike not implemented completely (setAllPortAttrs)");
-}
-
-void FIntModuleOp::setAllPortAttrs(ArrayRef<Attribute> attrs) {
-  emitError("HWModuleLike not implemented completely (setAllPortAttrs)");
-}
-
-void FMemModuleOp::setAllPortAttrs(ArrayRef<Attribute> attrs) {
-  emitError("HWModuleLike not implemented completely (setAllPortAttrs)");
-}
-
-void FExtModuleOp::setAllPortAttrs(ArrayRef<Attribute> attrs) {
-  emitError("HWModuleLike not implemented completely (setAllPortAttrs)");
-}
-
-void ClassOp::setAllPortAttrs(ArrayRef<Attribute> attrs) {
-  emitError("HWModuleLike not implemented completely (setAllPortAttrs)");
-}
-
-void FModuleOp::removeAllPortAttrs() {
-  emitError("HWModuleLike not implemented completely (removeAllPortAttrs)");
-}
-
-void FIntModuleOp::removeAllPortAttrs() {
-  emitError("HWModuleLike not implemented completely (removeAllPortAttrs)");
-}
-
-void FMemModuleOp::removeAllPortAttrs() {
-  emitError("HWModuleLike not implemented completely (removeAllPortAttrs)");
-}
-
-void FExtModuleOp::removeAllPortAttrs() {
-  emitError("HWModuleLike not implemented completely (removeAllPortAttrs)");
-}
-
-void ClassOp::removeAllPortAttrs() {
-  emitError("HWModuleLike not implemented completely (removeAllPortAttrs)");
-}
-
-void FModuleOp::setAllPortLocs(ArrayRef<Location> locs) {
-  emitError("HWModuleLike not implemented completely (setAllPortLocs)");
-}
-
-void FIntModuleOp::setAllPortLocs(ArrayRef<Location> locs) {
-  emitError("HWModuleLike not implemented completely (setAllPortLocs)");
-}
-
-void FMemModuleOp::setAllPortLocs(ArrayRef<Location> locs) {
-  emitError("HWModuleLike not implemented completely (setAllPortLocs)");
-}
-
-void FExtModuleOp::setAllPortLocs(ArrayRef<Location> locs) {
-  emitError("HWModuleLike not implemented completely (setAllPortLocs)");
-}
-
-void ClassOp::setAllPortLocs(ArrayRef<Location> locs) {
-  emitError("HWModuleLike not implemented completely (setAllPortLocs)");
-}
-
 // Return the port with the specified name.
 BlockArgument FModuleOp::getArgument(size_t portNumber) {
   return getBodyBlock()->getArgument(portNumber);

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -34,7 +34,7 @@ struct AddSeqMemPortsPass : public AddSeqMemPortsBase<AddSeqMemPortsPass> {
   LogicalResult processFileAnno(Location loc, StringRef metadataDir,
                                 Annotation anno);
   LogicalResult processAnnos(CircuitOp circuit);
-  void createOutputFile(hw::HWModuleLike module);
+  void createOutputFile(igraph::ModuleOpInterface module);
   InstanceGraphNode *findDUT();
   void processMemModule(FMemModuleOp mem);
   LogicalResult processModule(FModuleOp module, bool isDUT);
@@ -274,7 +274,7 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp module, bool isDUT) {
   return success();
 }
 
-void AddSeqMemPortsPass::createOutputFile(hw::HWModuleLike module) {
+void AddSeqMemPortsPass::createOutputFile(igraph::ModuleOpInterface module) {
   // Insert the verbatim at the bottom of the circuit.
   auto circuit = getOperation();
   auto builder = OpBuilder::atBlockEnd(circuit.getBodyBlock());
@@ -422,7 +422,7 @@ void AddSeqMemPortsPass::runOnOperation() {
 
   // If there is an output file, create it.
   if (outputFile)
-    createOutputFile(dutNode->getModule<hw::HWModuleLike>());
+    createOutputFile(dutNode->getModule<igraph::ModuleOpInterface>());
 
   if (anythingChanged)
     markAnalysesPreserved<InstanceGraph>();

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -392,7 +392,7 @@ bool BlackBoxReaderPass::isDut(Operation *module) {
     dutModuleMap[module] = true;
     return true;
   }
-  auto *node = instanceGraph->lookup(cast<hw::HWModuleLike>(module));
+  auto *node = instanceGraph->lookup(cast<igraph::ModuleOpInterface>(module));
   bool anyParentIsDut = false;
   if (node)
     for (auto *u : node->uses()) {

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -619,7 +619,7 @@ void CreateSiFiveMetadataPass::runOnOperation() {
   if (it != body->end()) {
     dutMod = dyn_cast<FModuleOp>(*it);
     auto &instanceGraph = getAnalysis<InstanceGraph>();
-    auto *node = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
+    auto *node = instanceGraph.lookup(cast<igraph::ModuleOpInterface>(*it));
     llvm::for_each(llvm::depth_first(node),
                    [&](igraph::InstanceGraphNode *node) {
                      dutModuleSet.insert(node->getModule());

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -815,7 +815,8 @@ private:
   /// of the "toModule".
   void replaceInstances(FModuleLike toModule, Operation *fromModule) {
     // Replace all instances of the other module.
-    auto *fromNode = instanceGraph[::cast<hw::HWModuleLike>(fromModule)];
+    auto *fromNode =
+        instanceGraph[::cast<igraph::ModuleOpInterface>(fromModule)];
     auto *toNode = instanceGraph[toModule];
     auto toModuleRef = FlatSymbolRefAttr::get(toModule.getModuleNameAttr());
     for (auto *oldInstRec : llvm::make_early_inc_range(fromNode->uses())) {
@@ -843,7 +844,7 @@ private:
     namepath.append(baseNamepath.begin(), baseNamepath.end());
 
     auto loc = fromModule->getLoc();
-    auto *fromNode = instanceGraph[cast<hw::HWModuleLike>(fromModule)];
+    auto *fromNode = instanceGraph[cast<igraph::ModuleOpInterface>(fromModule)];
     SmallVector<FlatSymbolRefAttr> nlas;
     for (auto *instanceRecord : fromNode->uses()) {
       auto parent = cast<FModuleOp>(*instanceRecord->getParent()->getModule());

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -718,10 +718,10 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
   // Get all the paths instantiating this module. If there is an NLA already
   // attached to this tracker, we use it as a base to disambiguate the path to
   // the memory.
-  hw::HWModuleLike mod;
+  igraph::ModuleOpInterface mod;
   if (tracker.nla)
     mod = instanceGraph->lookup(tracker.nla.root())
-              ->getModule<hw::HWModuleLike>();
+              ->getModule<igraph::ModuleOpInterface>();
   else
     mod = tracker.op->getParentOfType<FModuleOp>();
 

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -319,7 +319,8 @@ void ExtractInstancesPass::collectAnnos() {
   LLVM_DEBUG(llvm::dbgs() << "Marking DUT hierarchy\n");
   SmallVector<InstanceGraphNode *> worklist;
   for (Operation *op : dutModules)
-    worklist.push_back(instanceGraph->lookup(cast<hw::HWModuleLike>(op)));
+    worklist.push_back(
+        instanceGraph->lookup(cast<igraph::ModuleOpInterface>(op)));
   while (!worklist.empty()) {
     auto *module = worklist.pop_back_val();
     dutModuleNames.insert(module->getModule().getModuleNameAttr());
@@ -582,7 +583,7 @@ void ExtractInstancesPass::extractInstances() {
     // the instances of the parent module, and wire the instance ports up to
     // the newly added parent module ports.
     auto *instParentNode =
-        instanceGraph->lookup(cast<hw::HWModuleLike>(*parent));
+        instanceGraph->lookup(cast<igraph::ModuleOpInterface>(*parent));
     for (auto *instRecord : instParentNode->uses()) {
       auto oldParentInst = cast<InstanceOp>(*instRecord->getInstance());
       auto newParent = oldParentInst->getParentOfType<FModuleLike>();

--- a/lib/Dialect/FIRRTL/Transforms/InnerSymbolDCE.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InnerSymbolDCE.cpp
@@ -33,7 +33,7 @@ static void dropSymbol(const InnerSymTarget &target) {
   assert(InnerSymbolTable::getInnerSymbol(target));
 
   if (target.isPort()) {
-    auto mod = cast<HWModuleLike>(target.getOp());
+    auto mod = cast<FModuleLike>(target.getOp());
     assert(target.getPort() < mod.getNumPorts());
     auto base = mod.getPortSymbolAttr(target.getPort());
     cast<firrtl::FModuleLike>(*mod).setPortSymbolsAttr(

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -520,7 +520,7 @@ void LowerMemoryPass::runOnOperation() {
     return AnnotationSet(&op).hasAnnotation(dutAnnoClass);
   });
   if (it != body->end())
-    dut = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
+    dut = instanceGraph.lookup(cast<igraph::ModuleOpInterface>(*it));
 
   // The set of all modules underneath the design under test module.
   DenseSet<Operation *> dutModuleSet;

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -48,7 +48,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     });
     if (it != body->end()) {
       auto &instanceGraph = getAnalysis<InstanceGraph>();
-      auto *node = instanceGraph.lookup(cast<hw::HWModuleLike>(*it));
+      auto *node = instanceGraph.lookup(cast<igraph::ModuleOpInterface>(*it));
       llvm::for_each(llvm::depth_first(node),
                      [&](igraph::InstanceGraphNode *node) {
                        dutModuleSet.insert(node->getModule());

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1736,6 +1736,12 @@ void InstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 
 ModulePortInfo InstanceOp::getPortList() { return getOperationPortList(*this); }
 
+size_t InstanceOp::getNumPorts() {
+  SmallVector<Type> inputs(getOperandTypes());
+  SmallVector<Type> results(getResultTypes());
+  return inputs.size() + results.size();
+}
+
 Value InstanceOp::getValue(size_t idx) {
   auto mpi = getPortList();
   size_t inputPort = 0, outputPort = 0;
@@ -3495,6 +3501,15 @@ ModulePortInfo HWTestModuleOp::getPortList() {
     ports.push_back({{port}, i, sym, attr, loc});
   }
   return ModulePortInfo(ports);
+}
+
+size_t HWTestModuleOp::getNumPorts() { return getModuleType().getNumPorts(); }
+
+hw::InnerSymAttr HWTestModuleOp::getPortSymbolAttr(size_t portIndex) {
+  auto pa = getPortAttrs();
+  if (pa)
+    return cast<hw::InnerSymAttr>((*pa)[portIndex]);
+  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/InnerSymbolTable.cpp
+++ b/lib/Dialect/HW/InnerSymbolTable.cpp
@@ -87,7 +87,7 @@ LogicalResult InnerSymbolTable::walkSymbols(Operation *op,
                  return WalkResult::interrupt();
 
            // Check for ports
-           if (auto mod = dyn_cast<HWModuleLike>(curOp)) {
+           if (auto mod = dyn_cast<SymboledPortList>(curOp)) {
              for (size_t i = 0, e = mod.getNumPorts(); i < e; ++i) {
                if (auto symAttr = mod.getPortSymbolAttr(i))
                  if (failed(walkSyms(symAttr, InnerSymTarget(i, curOp))))
@@ -135,7 +135,7 @@ StringAttr InnerSymbolTable::getInnerSymbol(const InnerSymTarget &target) {
   // Obtain the base InnerSymAttr for the specified target.
   auto getBase = [](auto &target) -> hw::InnerSymAttr {
     if (target.isPort()) {
-      if (auto mod = dyn_cast<HWModuleLike>(target.getOp())) {
+      if (auto mod = dyn_cast<SymboledPortList>(target.getOp())) {
         assert(target.getPort() < mod.getNumPorts());
         return mod.getPortSymbolAttr(target.getPort());
       }

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -367,6 +367,8 @@ ArrayAttr DynamicInstanceOp::globalRefPath() {
 // InstanceOp
 //===----------------------------------------------------------------------===//
 
+size_t InstanceOp::getNumPorts() { return getNumOperands() + getNumResults(); }
+
 std::optional<size_t> InstanceOp::getTargetResultIndex() {
   // Inner symbols on instance operations target the op not any result.
   return std::nullopt;
@@ -503,6 +505,10 @@ hw::ModulePortInfo MSFTModuleOp::getPortList() {
                        resultLocs[i].cast<LocationAttr>()});
   }
   return hw::ModulePortInfo(inputs, outputs);
+}
+
+size_t MSFTModuleOp::getNumPorts() {
+  return getArgumentTypes().size() + getResultTypes().size();
 }
 
 SmallVector<BlockArgument>
@@ -1024,6 +1030,15 @@ hw::ModulePortInfo MSFTModuleExternOp::getPortList() {
   }
 
   return hw::ModulePortInfo(inputs, outputs);
+}
+
+size_t MSFTModuleExternOp::getNumPorts() {
+  auto typeAttr =
+      getOperation()->getAttrOfType<TypeAttr>(getFunctionTypeAttrName());
+  auto moduleType = typeAttr.getValue().cast<FunctionType>();
+  auto argTypes = moduleType.getInputs();
+  auto resultTypes = moduleType.getResults();
+  return argTypes.size() + resultTypes.size();
 }
 
 hw::InnerSymAttr MSFTModuleExternOp::getPortSymbolAttr(size_t) { return {}; }


### PR DESCRIPTION
HWModuleLike provides almost no value to firrtl and is a a relic of instancegraph.  Remove it and move required functionality.