### PR TITLE
[FIRRTL] Add ListCreateOp.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1136,6 +1136,24 @@ def PathOp : FIRRTLOp<"path", [Pure,
   let assemblyFormat = "$target attr-dict";
 }
 
+def ListCreateOp : FIRRTLOp<"list.create", [Pure, SameTypeOperands]> {
+  let summary = "Produce a list value";
+  let description = [{
+    Produces a value of list type containing the provided elements.
+
+    Example:
+    ```mlir
+    %3 = firrtl.list.create %0, %1, %2 : !firrtl.list<string>
+    ```
+  }];
+
+  let arguments = (ins Variadic<PropertyType>:$elements);
+  let results = (outs ListType:$result);
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // RefOperations: Operations on the RefType.
 //

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1340,6 +1340,43 @@ firrtl.circuit "MapOfHW" {
 }
 
 // -----
+
+// Reject list.create with mixed element types.
+firrtl.circuit "MixedList" {
+  firrtl.module @MixedList(
+      in %s: !firrtl.string,
+      // expected-note @below {{prior use here}}
+      in %int: !firrtl.integer
+      ) {
+    // expected-error @below {{use of value '%int' expects different type than prior uses: '!firrtl.string' vs '!firrtl.integer'}}
+    firrtl.list.create %s, %int : !firrtl.list<string>
+  }
+}
+
+// -----
+
+// Reject list.create with elements of wrong type compared to result type.
+firrtl.circuit "ListCreateWrongType" {
+  firrtl.module @ListCreateWrongType(
+      // expected-note @below {{prior use here}}
+      in %int: !firrtl.integer
+      ) {
+    // expected-error @below {{use of value '%int' expects different type than prior uses: '!firrtl.string' vs '!firrtl.integer'}}
+    firrtl.list.create %int : !firrtl.list<string>
+  }
+}
+
+// -----
+
+// Reject list.create that doesn't create a list.
+firrtl.circuit "ListCreateNotList" {
+  firrtl.module @ListCreateNotList() {
+    // expected-error @below {{invalid kind of type specified}}
+    firrtl.list.create : !firrtl.string
+  }
+}
+
+// -----
 // Issue 4174-- handle duplicate module names.
 
 firrtl.circuit "hi" {

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -250,10 +250,45 @@ firrtl.module @BigIntTest(in %in: !firrtl.integer, out %out: !firrtl.integer) {
   %1 = firrtl.integer -4
 }
 
+// CHECK-LABEL: ClassTest()
+firrtl.class @ClassTest() {}
+
 // CHECK-LABEL: ListTest
-// CHECK-SAME:  (in %in: !firrtl.list<string>, out %out: !firrtl.list<string>)
-firrtl.module @ListTest(in %in: !firrtl.list<string>, out %out: !firrtl.list<string>) {
-  firrtl.propassign %out, %in : !firrtl.list<string>
+// CHECK-SAME:   out %out_strings: !firrtl.list<string>,
+// CHECK-SAME:   out %out_empty: !firrtl.list<string>,
+// CHECK-SAME:   out %out_nested: !firrtl.list<list<string>>,
+// CHECK-SAME:   out %out_objs: !firrtl.list<class<@ClassTest()>>) {
+firrtl.module @ListTest(in %s1: !firrtl.string,
+                        in %s2: !firrtl.string,
+                        in %c1: !firrtl.class<@ClassTest()>,
+                        in %c2: !firrtl.class<@ClassTest()>,
+                        out %out_strings: !firrtl.list<string>,
+                        out %out_empty: !firrtl.list<string>,
+                        out %out_nested: !firrtl.list<list<string>>,
+                        out %out_objs: !firrtl.list<class<@ClassTest()>>) {
+  // List of basic property types (strings)
+  // CHECK-NEXT: %[[STRINGS:.+]] = firrtl.list.create %s1, %s2 : !firrtl.list<string>
+  // CHECK-NEXT: firrtl.propassign %out_strings, %[[STRINGS]] : !firrtl.list<string>
+  %strings = firrtl.list.create %s1, %s2 : !firrtl.list<string>
+  firrtl.propassign %out_strings, %strings : !firrtl.list<string>
+  
+  // Empty list
+  // CHECK-NEXT: %[[EMPTY:.+]] = firrtl.list.create : !firrtl.list<string>
+  // CHECK-NEXT: firrtl.propassign %out_empty, %[[EMPTY]] : !firrtl.list<string>
+  %empty = firrtl.list.create : !firrtl.list<string>
+  firrtl.propassign %out_empty, %empty : !firrtl.list<string>
+
+  // Nested list
+  // CHECK-NEXT: %[[NESTED:.+]] = firrtl.list.create %[[STRINGS]], %[[EMPTY]] : !firrtl.list<list<string>>
+  // CHECK-NEXT: firrtl.propassign %out_nested, %[[NESTED]] : !firrtl.list<list<string>>
+  %nested = firrtl.list.create %strings, %empty : !firrtl.list<list<string>>
+  firrtl.propassign %out_nested, %nested: !firrtl.list<list<string>>
+
+  // List of objects
+  // CHECK-NEXT: %[[OBJS:.+]] = firrtl.list.create %c1, %c2 : !firrtl.list<class<@ClassTest()>>
+  // CHECK-NEXT: firrtl.propassign %out_objs, %[[OBJS]] : !firrtl.list<class<@ClassTest()>>
+  %objs = firrtl.list.create %c1, %c2 : !firrtl.list<class<@ClassTest()>>
+  firrtl.propassign %out_objs, %objs : !firrtl.list<class<@ClassTest()>>
 }
 
 // CHECK-LABEL: MapTest


### PR DESCRIPTION
Test creation of lists with elements of primitive, aggregate, and object/class types.

Parser support will be added separately.