### PR TITLE
[FIRRTL][LowerClasses] Conversion support for Lists.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -298,6 +298,22 @@ struct StringConstantOpConversion
   }
 };
 
+struct ListCreateOpConversion
+    : public OpConversionPattern<firrtl::ListCreateOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(firrtl::ListCreateOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto listType = getTypeConverter()->convertType<om::ListType>(op.getType());
+    if (!listType)
+      return failure();
+    rewriter.replaceOpWithNewOp<om::ListCreateOp>(op, listType,
+                                                  adaptor.getElements());
+    return success();
+  }
+};
+
 struct ClassFieldOpConversion : public OpConversionPattern<ClassFieldOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -345,12 +361,21 @@ static void populateConversionTarget(ConversionTarget &target) {
 
   // OM dialect operations are legal if they don't use FIRRTL types.
   target.addDynamicallyLegalDialect<OMDialect>([](Operation *op) {
-    auto noFIRRTLOperands = llvm::none_of(op->getOperandTypes(), [](Type type) {
-      return isa<FIRRTLDialect>(type.getDialect());
-    });
-    auto noFIRRTLResults = llvm::none_of(op->getResultTypes(), [](Type type) {
-      return isa<FIRRTLDialect>(type.getDialect());
-    });
+    auto containsFIRRTLType = [](Type type) {
+      return type
+          .walk([](Type type) {
+            return failure(isa<FIRRTLDialect>(type.getDialect()));
+          })
+          .wasInterrupted();
+    };
+    auto noFIRRTLOperands =
+        llvm::none_of(op->getOperandTypes(), [&containsFIRRTLType](Type type) {
+          return containsFIRRTLType(type);
+        });
+    auto noFIRRTLResults =
+        llvm::none_of(op->getResultTypes(), [&containsFIRRTLType](Type type) {
+          return containsFIRRTLType(type);
+        });
     return noFIRRTLOperands && noFIRRTLResults;
   });
 
@@ -384,6 +409,25 @@ static void populateTypeConverter(TypeConverter &converter) {
     return om::ClassType::get(type.getContext(), type.getNameAttr());
   });
 
+  // Convert FIRRTL List type to OM List type.
+  converter.addConversion(
+      [&converter](om::ListType type) -> std::optional<mlir::Type> {
+        // Convert any om.list<firrtl> -> om.list<om>
+        auto elementType = converter.convertType(type.getElementType());
+        if (!elementType)
+          return {};
+        return om::ListType::get(elementType);
+      });
+
+  converter.addConversion(
+      [&converter](firrtl::ListType type) -> std::optional<mlir::Type> {
+        // Convert any firrtl.list<firrtl> -> om.list<om>
+        auto elementType = converter.convertType(type.getElementType());
+        if (!elementType)
+          return {};
+        return om::ListType::get(elementType);
+      });
+
   // Add a target materialization to fold away unrealized conversion casts.
   converter.addTargetMaterialization(
       [](OpBuilder &builder, Type type, ValueRange values, Location loc) {
@@ -398,6 +442,7 @@ static void populateRewritePatterns(RewritePatternSet &patterns,
   patterns.add<StringConstantOpConversion>(converter, patterns.getContext());
   patterns.add<ClassFieldOpConversion>(converter, patterns.getContext());
   patterns.add<ClassOpSignatureConversion>(converter, patterns.getContext());
+  patterns.add<ListCreateOpConversion>(converter, patterns.getContext());
 }
 
 // Convert to OM ops and types in Classes or Modules.

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -39,4 +39,46 @@ firrtl.circuit "Component" {
     firrtl.propassign %omir_out, %0 : !firrtl.class<@ClassEntrypoint(out obj_0_out: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>)>
     firrtl.strictconnect %output, %input : !firrtl.uint<1>
   }
+
+  // CHECK-LABEL: om.class @ClassTest
+  firrtl.class @ClassTest() {}
+
+  // CHECK-LABEL: om.class @ListTest(
+  // CHECK-SAME:    %s1: !om.string
+  // CHECK-SAME:    %s2: !om.string
+  // CHECK-SAME:    %c1: !om.class.type<@ClassTest>
+  // CHECK-SAME:    %c2: !om.class.type<@ClassTest>) {
+  firrtl.class @ListTest(in %s1: !firrtl.string,
+                         in %s2: !firrtl.string,
+                         in %c1: !firrtl.class<@ClassTest()>,
+                         in %c2: !firrtl.class<@ClassTest()>,
+                         out %out_strings: !firrtl.list<string>,
+                         out %out_empty: !firrtl.list<string>,
+                         out %out_nested: !firrtl.list<list<string>>,
+                         out %out_objs: !firrtl.list<class<@ClassTest()>>) {
+    // List of basic property types (strings)
+    // CHECK-NEXT: %[[STRINGS:.+]] = om.list_create %s1, %s2 : !om.string
+    %strings = firrtl.list.create %s1, %s2 : !firrtl.list<string>
+    firrtl.propassign %out_strings, %strings : !firrtl.list<string>
+
+    // Empty list
+    // CHECK-NEXT: %[[EMPTY:.+]] = om.list_create : !om.string
+    %empty = firrtl.list.create : !firrtl.list<string>
+    firrtl.propassign %out_empty, %empty : !firrtl.list<string>
+
+    // Nested list
+    // CHECK-NEXT: %[[NESTED:.+]] = om.list_create %[[STRINGS]], %[[EMPTY]] : !om.list<!om.string>
+    %nested = firrtl.list.create %strings, %empty : !firrtl.list<list<string>>
+    firrtl.propassign %out_nested, %nested: !firrtl.list<list<string>>
+
+    // List of objects
+    // CHECK-NEXT: %[[OBJS:.+]] = om.list_create %c1, %c2 : !om.class.type<@ClassTest>
+    %objs = firrtl.list.create %c1, %c2 : !firrtl.list<class<@ClassTest()>>
+    firrtl.propassign %out_objs, %objs : !firrtl.list<class<@ClassTest()>>
+
+    // CHECK-NEXT: om.class.field @out_strings, %[[STRINGS]] : !om.list<!om.string>
+    // CHECK-NEXT: om.class.field @out_empty, %[[EMPTY]] : !om.list<!om.string>
+    // CHECK-NEXT: om.class.field @out_nested, %[[NESTED]] : !om.list<!om.list<!om.string>>
+    // CHECK-NEXT: om.class.field @out_objs, %[[OBJS]] : !om.list<!om.class.type<@ClassTest>
+  }
 }


### PR DESCRIPTION
Builds on #5890, #5892.

Relevant commit: https://github.com/llvm/circt/commit/2a08e68f2681c0e742b06c4b28c3b9e69fb080ef .

1) **Altered the legality predicate of operations to recursively inspect the types for FIRRTL dialect**.  This seems right for now but maybe isn't always?  This doesn't help conversions occur for the included tests but it is needed to reject incomplete conversions I ran into while developing this.
2) Really unsure how recursive type conversion should work -- this may be a little redundant/overkill.
3) What are the no-op OM type conversions for? They don't appear to be necessary for our tests, at least not for Lists.  I implemented it anyway in case it helps.