### PR TITLE
[ci] Cache unified build/test/install

### DIFF
--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -142,13 +142,31 @@ jobs:
         shell: bash
         run: |
           echo setup=./utils/find-vs.ps1 >> "$GITHUB_OUTPUT"
+# Setup Caching
+#
+# Use sccache as it works on Windows.  Disable caching for non-release Windows
+# builds due to a bug between cmake and sccache. See:
+#   - https://gitlab.kitware.com/cmake/cmake/-/issues/22529
+      - name: sccache
+        if: runner.os != 'Windows' || inputs.cmake_build_type == 'release'
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-${{ inputs.cmake_c_compiler }}-${{ inputs.cmake_cxx_compiler }}-${{ inputs.cmake_build_type }}-${{ inputs.build_shared_libs }}-${{ inputs.llvm_enable_assertions }}-${{ inputs.llvm_force_enable_stats}}
+          max-size: 500M
+          variant: sccache
+      - name: Configure sccache
+        id: configure-sccache
+        if: runner.os != 'Windows' || inputs.cmake_build_type == 'release'
+        shell: bash
+        run:
+          echo enable_sccache="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $GITHUB_OUTPUT
 # Configure
       - name: Configure CIRCT
         run: |
           ${{ steps.setup-windows.outputs.setup }}
           mkdir build
           cd build
-          cmake -G Ninja -S "$(pwd)/../llvm/llvm" $EXTRA_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install"
+          cmake -G Ninja -S "$(pwd)/../llvm/llvm" $EXTRA_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install"
 # Optionally test
       - name: Test CIRCT
         if: inputs.runTests == 'true'


### PR DESCRIPTION
Enable sccache-based caching for the unified build/test/install GitHub Workflow.  Use sccache as opposed to ccache because the former supports Windows (as suggested by the hendrikmuhs/ccache-action documentation).

Disable caching for Windows non-release builds as there is a bug involving cmake and sccache.

This commit is the last piece necessary to begin replacing existing build/test GitHub workflows used in CIRCT.

Examples of caching working:
  - Windows `relwithdebinfo` _skipping_ the caching step: https://github.com/llvm/circt/actions/runs/5909543298/job/16030240784#step:6:3 (This job was intentionally killed during the "Configure CIRCT" step as it doesn't need to finish to show the skip logic working.)
  - Linux `relwithdebinfo` cache hit: https://github.com/llvm/circt/actions/runs/5909543875/job/16030242315
  - Windows `release` build cache hit: https://github.com/llvm/circt/actions/runs/5909595734/job/16030351424