### PR TITLE
[FIRRTL] Put ODS enumerations in the FIRRTL namespace

### DIFF
--- a/include/circt/Dialect/FIRRTL/CHIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/CHIRRTL.td
@@ -140,7 +140,7 @@ def SeqMemOp : CHIRRTLOp<"seqmem", [HasCustomSSAName, DeclareOpInterfaceMethods<
                          custom<SeqMemOp>(attr-dict) `:` qualified(type($result))}];
   let builders = [
     OpBuilder<(ins "firrtl::FIRRTLBaseType":$elementType, "uint64_t":$numElements,
-                   "RUWAttr":$ruw, "mlir::StringRef":$name,
+                   "firrtl::RUWAttr":$ruw, "mlir::StringRef":$name,
                    "firrtl::NameKindEnum":$nameKind, "ArrayAttr":$annotations,
                    CArg<"StringAttr", "StringAttr()">:$innerSym,
                    CArg<"firrtl::MemoryInitAttr", "firrtl::MemoryInitAttr{}">:$init)>
@@ -174,7 +174,7 @@ def MemoryPortOp : CHIRRTLOp<"memoryport", [InferTypeOpInterface,
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$dataType, "::mlir::Value":$memory,
-                   "MemDirAttr":$direction, CArg<"StringRef", "{}">:$name,
+                   "firrtl::MemDirAttr":$direction, CArg<"StringRef", "{}">:$name,
                    CArg<"ArrayRef<Attribute>","{}">:$annotations)>
   ];
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
@@ -30,7 +30,6 @@ def InterestingName: I32EnumAttrCase<"InterestingName", 1, "interesting_name">;
 def NameKindEnumImpl: I32EnumAttr<"NameKindEnum", "name kind",
               [DroppableName, InterestingName]> {
   let genSpecializedAttr = 0;
-  let cppNamespace = "::circt::firrtl";
 }
 
 def NameKindAttr: EnumAttr<FIRRTLDialect, NameKindEnumImpl, "name_kind">;

--- a/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
@@ -16,6 +16,8 @@
 include "FIRRTLDialect.td"
 include "mlir/IR/EnumAttr.td"
 
+let cppNamespace = "::circt::firrtl" in {
+
 //===----------------------------------------------------------------------===//
 // Name Kinds
 //===----------------------------------------------------------------------===//
@@ -94,5 +96,7 @@ def AtEdge   : I32EnumAttrCase<"AtEdge", 2, "edge">;
 
 def EventControlAttr : I32EnumAttr<"EventControl", "edge control trigger",
                                    [AtPosEdge, AtNegEdge, AtEdge]>  {}
+
+}
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLENUMS_TD


### PR DESCRIPTION
These enumerations were being generated into the global namespace.  This change sets the `cppNamespace` field of all FIRRTL enumerations.