### PR TITLE
[FIRRTL] Add HierPathCache to reuse HierPathOps

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -16,6 +16,7 @@
 #include "circt/Dialect/FIRRTL/CHIRRTLDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -308,6 +309,26 @@ struct ModuleModifications {
   SmallVector<uturnPair> uturns;
 };
 
+/// A cache of existing HierPathOps, mostly used to facilitate HierPathOp reuse.
+struct HierPathCache {
+  HierPathCache(Operation *op, SymbolTable &symbolTable);
+
+  hw::HierPathOp getOpFor(ArrayAttr attr);
+
+  StringAttr getSymFor(ArrayAttr attr) {
+    return getOpFor(attr).getSymNameAttr();
+  }
+
+  FlatSymbolRefAttr getRefFor(ArrayAttr attr) {
+    return FlatSymbolRefAttr::get(getSymFor(attr));
+  }
+
+private:
+  OpBuilder builder;
+  DenseMap<ArrayAttr, hw::HierPathOp> cache;
+  SymbolTable &symbolTable;
+};
+
 /// State threaded through functions for resolving and applying annotations.
 struct ApplyState {
   using AddToWorklistFn = llvm::function_ref<void(DictionaryAttr)>;
@@ -315,14 +336,14 @@ struct ApplyState {
              AddToWorklistFn addToWorklistFn,
              InstancePathCache &instancePathCache)
       : circuit(circuit), symTbl(symTbl), addToWorklistFn(addToWorklistFn),
-        instancePathCache(instancePathCache) {}
+        instancePathCache(instancePathCache), hierPathCache(circuit, symTbl) {}
 
   CircuitOp circuit;
   SymbolTable &symTbl;
   CircuitTargetCache targetCaches;
   AddToWorklistFn addToWorklistFn;
   InstancePathCache &instancePathCache;
-  DenseMap<Attribute, FlatSymbolRefAttr> instPathToNLAMap;
+  HierPathCache hierPathCache;
   size_t numReusedHierPaths = 0;
 
   DenseSet<InstanceOp> wiringProblemInstRefs;

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -118,21 +118,7 @@ static FlatSymbolRefAttr buildNLA(const AnnoPathValue &target,
       FlatSymbolRefAttr::get(target.ref.getModule().getModuleNameAttr()));
 
   auto instAttr = ArrayAttr::get(state.circuit.getContext(), insts);
-
-  // Re-use NLA for this path if already created.
-  auto it = state.instPathToNLAMap.find(instAttr);
-  if (it != state.instPathToNLAMap.end()) {
-    ++state.numReusedHierPaths;
-    return it->second;
-  }
-
-  // Create the NLA
-  auto nla = b.create<hw::HierPathOp>(state.circuit.getLoc(), "nla", instAttr);
-  state.symTbl.insert(nla);
-  nla.setVisibility(SymbolTable::Visibility::Private);
-  auto sym = FlatSymbolRefAttr::get(nla);
-  state.instPathToNLAMap.insert({instAttr, sym});
-  return sym;
+  return state.hierPathCache.getRefFor(instAttr);
 }
 
 /// Scatter breadcrumb annotations corresponding to non-local annotations

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -461,8 +461,8 @@ circuit Top : %[[
     "target":"~Top|Top/a_:A_/b_:B_>bar"
   }
 ]]
-  ; CHECK: hw.hierpath private @[[nla_a_:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B]
-  ; CHECK: hw.hierpath private @[[nla_a:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B]
+  ; CHECK: hw.hierpath private @[[nla_a:[_a-zA-Z0-9]+]] [@Top::@[[aSym:[_a-zA-Z0-9]+]], @A::@[[bSym:[_a-zA-Z0-9]+]], @B]
+  ; CHECK: hw.hierpath private @[[nla_a_:[_a-zA-Z0-9]+]] [@Top::@[[a_Sym:[_a-zA-Z0-9]+]], @A::@[[bSym]], @B]
   ; CHECK: firrtl.module @Top
   module Top :
     ; CHECK-NEXT: firrtl.instance a sym @[[aSym]] @A()
@@ -520,14 +520,14 @@ circuit Top : %[[
     "target":"~Top|Top/a_:A_/b_:B_/c_:C_/d_:D_>bar"
   }
 ]]
-  ; CHECK:        hw.hierpath private @[[nla_a_:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [@Top::@[[a_Sym:[_a-zA-Z0-9]+]],
+  ; CHECK:        hw.hierpath private @[[nla_a:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:     [@Top::@[[aSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @A::@[[bSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @B::@[[cSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @C::@[[dSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @D]
-  ; CHECK-NEXT:   hw.hierpath private @[[nla_a:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [@Top::@[[aSym:[_a-zA-Z0-9]+]],
+  ; CHECK-NEXT:   hw.hierpath private @[[nla_a_:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:     [@Top::@[[a_Sym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @A::@[[bSym]],
   ; CHECK-SAME:      @B::@[[cSym]],
   ; CHECK-SAME:      @C::@[[dSym]],
@@ -645,19 +645,34 @@ circuit Top : %[[
     "target":"~Top|Top/a2:A/b:B/c:C"
   }
 ]]
-  ; CHECK:        hw.hierpath private @[[nla_12:[_a-zA-Z0-9]+]]
+  ; CHECK:        hw.hierpath private @[[nla_1:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:     [@Top::@[[TopbSym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @B]
+  ; CHECK:        hw.hierpath private @[[nla_2:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:     [@Top::@[[Topb_Sym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @B]
+  ; CHECK:        hw.hierpath private @[[nla_3:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:     [@Top::@[[Topa1Sym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @A::@[[Ab_Sym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @B]
+  ; CHECK:        hw.hierpath private @[[nla_4:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topa2Sym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @A::@[[Ab_Sym]],
+  ; CHECK-SAME:      @B]
+  ; CHECK:        hw.hierpath private @[[nla_5:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:     [@Top::@[[Topa1Sym]],
   ; CHECK-SAME:      @A::@[[AbSym:[_a-zA-Z0-9]+]],
+  ; CHECK-SAME:      @B]
+  ; CHECK:        hw.hierpath private @[[nla_6:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:     [@Top::@[[Topa2Sym]],
+  ; CHECK-SAME:      @A::@[[AbSym]],
+  ; CHECK-SAME:      @B]
+  ; CHECK:        hw.hierpath private @[[nla_7:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:     [@Top::@[[TopbSym]],
   ; CHECK-SAME:      @B::@[[BcSym:[_a-zA-Z0-9]+]],
   ; CHECK-SAME:      @C]
-  ; CHECK:        hw.hierpath private @[[nla_11:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [@Top::@[[Topa1Sym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:      @A::@[[AbSym]],
-  ; CHECK-SAME:      @B::@[[BcSym]],
-  ; CHECK-SAME:      @C]
-  ; CHECK:        hw.hierpath private @[[nla_10:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [@Top::@[[Topa2Sym]],
-  ; CHECK-SAME:      @A::@[[Ab_Sym:[_a-zA-Z0-9]+]],
+  ; CHECK:        hw.hierpath private @[[nla_8:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:     [@Top::@[[Topb_Sym]],
   ; CHECK-SAME:      @B::@[[BcSym]],
   ; CHECK-SAME:      @C]
   ; CHECK:        hw.hierpath private @[[nla_9:[_a-zA-Z0-9]+]]
@@ -665,36 +680,21 @@ circuit Top : %[[
   ; CHECK-SAME:      @A::@[[Ab_Sym]],
   ; CHECK-SAME:      @B::@[[BcSym]],
   ; CHECK-SAME:      @C]
-  ; CHECK:        hw.hierpath private @[[nla_8:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [@Top::@[[Topb_Sym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:      @B::@[[BcSym]],
-  ; CHECK-SAME:      @C]
-  ; CHECK:        hw.hierpath private @[[nla_7:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [@Top::@[[TopbSym:[_a-zA-Z0-9]+]],
-  ; CHECK-SAME:      @B::@[[BcSym]],
-  ; CHECK-SAME:      @C]
-  ; CHECK:        hw.hierpath private @[[nla_6:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [@Top::@[[Topa2Sym]],
-  ; CHECK-SAME:      @A::@[[AbSym]],
-  ; CHECK-SAME:      @B]
-  ; CHECK:        hw.hierpath private @[[nla_5:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [@Top::@[[Topa1Sym]],
-  ; CHECK-SAME:      @A::@[[AbSym]],
-  ; CHECK-SAME:      @B]
-  ; CHECK:        hw.hierpath private @[[nla_4:[_a-zA-Z0-9]+]]
+  ; CHECK:        hw.hierpath private @[[nla_10:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topa2Sym]],
   ; CHECK-SAME:      @A::@[[Ab_Sym]],
-  ; CHECK-SAME:      @B]
-  ; CHECK:        hw.hierpath private @[[nla_3:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:      @B::@[[BcSym]],
+  ; CHECK-SAME:      @C]
+  ; CHECK:        hw.hierpath private @[[nla_11:[_a-zA-Z0-9]+]]
   ; CHECK-SAME:     [@Top::@[[Topa1Sym]],
-  ; CHECK-SAME:      @A::@[[Ab_Sym]],
-  ; CHECK-SAME:      @B]
-  ; CHECK:        hw.hierpath private @[[nla_2:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [@Top::@[[Topb_Sym]],
-  ; CHECK-SAME:      @B]
-  ; CHECK:        hw.hierpath private @[[nla_1:[_a-zA-Z0-9]+]]
-  ; CHECK-SAME:     [@Top::@[[TopbSym]],
-  ; CHECK-SAME:      @B]
+  ; CHECK-SAME:      @A::@[[AbSym]],
+  ; CHECK-SAME:      @B::@[[BcSym]],
+  ; CHECK-SAME:      @C]
+  ; CHECK:        hw.hierpath private @[[nla_12:[_a-zA-Z0-9]+]]
+  ; CHECK-SAME:     [@Top::@[[Topa2Sym]],
+  ; CHECK-SAME:      @A::@[[AbSym]],
+  ; CHECK-SAME:      @B::@[[BcSym]],
+  ; CHECK-SAME:      @C]
   ; CHECK-NEXT:   firrtl.module @Top
   module Top :
     ; CHECK-NEXT:   firrtl.instance b sym @[[TopbSym]]

--- a/test/Dialect/FIRRTL/omir.mlir
+++ b/test/Dialect/FIRRTL/omir.mlir
@@ -263,8 +263,8 @@ firrtl.circuit "Foo"  attributes {rawAnnotations = [
 // CHECK-SAME:    e = {{{[^{}]+}} value = {id = [[eID:[0-9]+]] : i64, omir.tracker, path = {{"[a-zA-Z~|:/>]+"}}, type = [[E_TYPE:"OM[a-zA-Z]+"]]
 // CHECK-SAME:    f = {{{[^{}]+}} value = {id = [[fID:[0-9]+]] : i64, omir.tracker, path = {{"[a-zA-Z~|:/>]+"}}, type = [[F_TYPE:"OM[a-zA-Z]+"]]
 // CHECK-SAME:    g = {{{[^{}]+}} value = {id = [[gID:[0-9]+]] : i64, omir.tracker, path = {{"[a-zA-Z~|:/>]+"}}, type = [[G_TYPE:"OM[a-zA-Z]+"]]
-// CHECK:       hw.hierpath private @[[Foo_cC_C:nla[_0-9]*]]
 // CHECK-NEXT:  hw.hierpath private @[[Foo_eE_E:nla[_0-9]*]]
+// CHECK:       hw.hierpath private @[[Foo_cC_C:nla[_0-9]*]]
 // CHECK:       firrtl.module private @C
 // CHECK-SAME:    {circt.nonlocal = @[[Foo_cC_C]], class = "freechips.rocketchip.objectmodel.OMIRTracker", id = [[cID]] : i64, type = [[C_TYPE]]}
 // CHECK:       firrtl.module private @D


### PR DESCRIPTION
This change takes a common pattern in LowerAnnotations, which avoids creating
duplicate HierPathOps by maintaining a cache, and moves it into a dedicated
class for easier re-use.  Since the HierPathCache maintains an insertion point
instead of always inserting to the top of the circuit's block, HierPathOps are
now in reverse order after LowerAnnotations and EmitOMIR.