### PR TITLE
[FIRRTL][HW] Add InnerSymbolNamespaceCollection

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -330,10 +330,7 @@ struct ApplyState {
   SmallVector<WiringProblem> wiringProblems;
 
   hw::InnerSymbolNamespace &getNamespace(FModuleLike module) {
-    auto &ptr = namespaces[module];
-    if (!ptr)
-      ptr = std::make_unique<hw::InnerSymbolNamespace>(module);
-    return *ptr;
+    return namespaces[module];
   }
 
   IntegerAttr newID() {
@@ -342,7 +339,7 @@ struct ApplyState {
   };
 
 private:
-  DenseMap<Operation *, std::unique_ptr<hw::InnerSymbolNamespace>> namespaces;
+  hw::InnerSymbolNamespaceCollection namespaces;
   unsigned annotationID = 0;
 };
 

--- a/include/circt/Dialect/HW/InnerSymbolNamespace.h
+++ b/include/circt/Dialect/HW/InnerSymbolNamespace.h
@@ -34,6 +34,18 @@ struct InnerSymbolNamespace : Namespace {
   }
 };
 
+struct InnerSymbolNamespaceCollection {
+
+  InnerSymbolNamespace &get(Operation *op) {
+    return collection.try_emplace(op, op).first->second;
+  }
+
+  InnerSymbolNamespace &operator[](Operation *op) { return get(op); }
+
+private:
+  DenseMap<Operation *, InnerSymbolNamespace> collection;
+};
+
 } // namespace hw
 } // namespace circt
 


### PR DESCRIPTION
It is a common pattern for passes to have a map from a modules to an InnerSymbolNamespace.  This captures the pattern for reuse in a InnerSymbolNamespaceCollection.