### PR TITLE
Add DistinctAttr type constraints

### DIFF
--- a/include/circt/Support/LLVM.h
+++ b/include/circt/Support/LLVM.h
@@ -106,6 +106,7 @@ class Dialect;
 class DialectAsmParser;
 class DialectAsmPrinter;
 class DictionaryAttr;
+class DistinctAttr;
 class ElementsAttr;
 class FileLineColLoc;
 class FlatSymbolRefAttr;
@@ -214,6 +215,7 @@ using mlir::Dialect;                   // NOLINT(misc-unused-using-decls)
 using mlir::DialectAsmParser;          // NOLINT(misc-unused-using-decls)
 using mlir::DialectAsmPrinter;         // NOLINT(misc-unused-using-decls)
 using mlir::DictionaryAttr;            // NOLINT(misc-unused-using-decls)
+using mlir::DistinctAttr;              // NOLINT(misc-unused-using-decls)
 using mlir::ElementsAttr;              // NOLINT(misc-unused-using-decls)
 using mlir::failed;                    // NOLINT(misc-unused-using-decls)
 using mlir::failure;                   // NOLINT(misc-unused-using-decls)

--- a/include/circt/Types.td
+++ b/include/circt/Types.td
@@ -36,4 +36,11 @@ def ArrayRefAttr :
   let convertFromStorage = [{ $_self.getValue() }];
 }
 
+def DistinctAttr : Attr<CPred<"$_self.isa<::mlir::DistinctAttr>()">,
+                      "distinct attribute"> {
+  let storageType = [{ ::mlir::DistinctAttr }];
+  let returnType = [{ ::mlir::DistinctAttr }];
+  let convertFromStorage = "$_self";
+}
+
 #endif // CIRCT_TYPES


### PR DESCRIPTION
DistinctAttr does not have proper upstream exposure through OpBase.td as type constraint, so we have to declare it ourselves.  This should be a temporary workaround.