### PR TITLE
Backport "[FIRRTL] Prefix for Seq Mem Group Extract (#4596)" to sifive-1.5

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
+++ b/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
@@ -2,7 +2,7 @@
 ; RUN: firtool --repl-seq-mem --repl-seq-mem-file=mems.conf --split-verilog --dedup --emit-omir -o=%t %s
 ; RUN: FileCheck %s --check-prefix=TESTHARNESS < %t/TestHarness.sv
 ; RUN: FileCheck %s --check-prefix=DUTMODULE < %t/Prefix_DUTModule.sv
-; RUN: FileCheck %s --check-prefix=SEQMEMSGROUP < %t/SeqMemsGroup.sv
+; RUN: FileCheck %s --check-prefix=SEQMEMSGROUP < %t/Prefix_SeqMemsGroup.sv
 ; RUN: FileCheck %s --check-prefix=INJECTEDSUBMODULE < %t/Prefix_InjectedSubmodule.sv
 ; RUN: FileCheck %s --check-prefix=SOMEMODULE < %t/Prefix_SomeModule.sv
 ; RUN: FileCheck %s --check-prefix=MEM < %t/Prefix_mem.sv
@@ -141,7 +141,7 @@ circuit TestHarness : %[[
   ; SOMEMODULE: module Prefix_SomeModule
   ; SOMEMODULE: Prefix_mem mem
 
-  ; SEQMEMSGROUP: module SeqMemsGroup
+  ; SEQMEMSGROUP: module Prefix_SeqMemsGroup
   ; SEQMEMSGROUP:   mem_wiring_1_R0_addr
   ; SEQMEMSGROUP:   mem_wiring_0_R0_addr
   ; SEQMEMSGROUP: Prefix_mem_ext mem_ext
@@ -157,7 +157,7 @@ circuit TestHarness : %[[
 
   ; OMIR:      "id": "OMID:0"
   ; OMIR:      "name": "finalPath"
-  ; OMIR-NEXT: "value": "OMMemberInstanceTarget:~Prefix_DUTModule|Prefix_DUTModule/SeqMemsGroup:SeqMemsGroup/mem_ext{{[^:]*}}:Prefix_mem_ext"
+  ; OMIR-NEXT: "value": "OMMemberInstanceTarget:~Prefix_DUTModule|Prefix_DUTModule/SeqMemsGroup:Prefix_SeqMemsGroup/mem_ext{{[^:]*}}:Prefix_mem_ext"
   ; OMIR:      "id": "OMID:1"
   ; OMIR:      "name": "finalPath"
-  ; OMIR-NEXT: "value": "OMMemberInstanceTarget:~Prefix_DUTModule|Prefix_DUTModule/SeqMemsGroup:SeqMemsGroup/mem_ext{{[^:]*}}:Prefix_mem_ext"
+  ; OMIR-NEXT: "value": "OMMemberInstanceTarget:~Prefix_DUTModule|Prefix_DUTModule/SeqMemsGroup:Prefix_SeqMemsGroup/mem_ext{{[^:]*}}:Prefix_mem_ext"

--- a/test/Dialect/FIRRTL/prefix-modules.mlir
+++ b/test/Dialect/FIRRTL/prefix-modules.mlir
@@ -370,3 +370,22 @@ firrtl.circuit "Test"   {
   // CHECK: firrtl.memmodule @B_Bar() attributes {annotations = [{circt.nonlocal = @nla_2, class = "test2"}]
   firrtl.memmodule @Bar() attributes {annotations = [{circt.nonlocal = @nla_1, class = "test1"}, {circt.nonlocal = @nla_2, class = "test2"}], dataWidth = 1 : ui32, depth = 16 : ui64, extraPorts = [], maskBits = 0 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32,  writeLatency = 1 : ui32}
 }
+
+// Test that the MarkDUTAnnotation receives a prefix.
+// CHECK-LABEL: firrtl.circuit "Prefix_MarkDUTAnnotationGetsPrefix"
+firrtl.circuit "MarkDUTAnnotationGetsPrefix" {
+  // CHECK-NEXT: firrtl.module @Prefix_MarkDUTAnnotationGetsPrefix
+  // CHECK-SAME:   class = "sifive.enterprise.firrtl.MarkDUTAnnotation", prefix = "Prefix_"
+  firrtl.module @MarkDUTAnnotationGetsPrefix() attributes {
+    annotations = [
+     {
+       class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+     },
+     {
+       class = "sifive.enterprise.firrtl.NestedPrefixModulesAnnotation",
+       prefix = "Prefix_",
+       inclusive = true
+     }
+    ]
+  } {}
+}


### PR DESCRIPTION
Fixes an issue where a prefix may not be applied to modules created by grouping, see discussion in https://github.com/llvm/circt/pull/4596.

Note that this backport was tricky because the code in `PrefixModules.cpp` had changed quite a bit in the meantime, please check this carefully @seldridge.