### PR TITLE
[HW][IRN/IST] Make hw modules IST's, add verif pass.

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -224,7 +224,7 @@ LogicalResult verifyInnerRefNamespace(Operation *op);
 
 /// Classify operations that are InnerRefNamespace-like,
 /// until structure is in place to do this via Traits.
-/// Useful for getParentOfType<>, or scheudling passes.
+/// Useful for getParentOfType<>, or scheduling passes.
 /// Prefer putting the trait on operations here or downstream.
 struct InnerRefNamespaceLike {
   /// Return if this operation is explicitly an IRN or appears compatible.

--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -222,6 +222,17 @@ namespace detail {
 LogicalResult verifyInnerRefNamespace(Operation *op);
 } // namespace detail
 
+/// Classify operations that are InnerRefNamespace-like,
+/// until structure is in place to do this via Traits.
+/// Useful for getParentOfType<>, or scheudling passes.
+/// Prefer putting the trait on operations here or downstream.
+struct InnerRefNamespaceLike {
+  /// Return if this operation is explicitly an IRN or appears compatible.
+  static bool classof(mlir::Operation *op);
+  /// Return if this operation is explicitly an IRN or appears compatible.
+  static bool classof(const mlir::RegisteredOperationName *opInfo);
+};
+
 } // namespace hw
 } // namespace circt
 
@@ -261,7 +272,7 @@ public:
 
     // InnerSymbolTable's must be directly nested within an InnerRefNamespace.
     auto *parent = op->getParentOp();
-    if (!parent || !parent->hasTrait<InnerRefNamespace>())
+    if (!parent || !isa<circt::hw::InnerRefNamespaceLike>(parent))
       return op->emitError(
           "InnerSymbolTable must have InnerRefNamespace parent");
 

--- a/include/circt/Dialect/HW/HWPasses.h
+++ b/include/circt/Dialect/HW/HWPasses.h
@@ -25,6 +25,7 @@ std::unique_ptr<mlir::Pass> createPrintInstanceGraphPass();
 std::unique_ptr<mlir::Pass> createHWSpecializePass();
 std::unique_ptr<mlir::Pass> createPrintHWModuleGraphPass();
 std::unique_ptr<mlir::Pass> createFlattenIOPass();
+std::unique_ptr<mlir::Pass> createVerifyInnerRefNamespacePass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -33,7 +33,7 @@ class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
       DeclareOpInterfaceMethods<SymboledPortList>,
       DeclareOpInterfaceMethods<HWModuleLike>,
       DeclareOpInterfaceMethods<HWMutableModuleLike>,
-      Symbol, FunctionOpInterface,
+      Symbol, FunctionOpInterface, InnerSymbolTable,
       OpAsmOpInterface, HasParent<"mlir::ModuleOp">]> {
   /// Additional class declarations inside the module op.
   code extraModuleClassDeclaration = ?;

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -53,4 +53,9 @@ def HWSpecialize : Pass<"hw-specialize", "mlir::ModuleOp"> {
   }];
 }
 
+def VerifyInnerRefNamespace : Pass<"hw-verify-irn"> {
+  let summary = "Verify InnerRefNamespaceLike operations, if not self-verifying.";
+  let constructor =  "circt::hw::createVerifyInnerRefNamespacePass()";
+}
+
 #endif // CIRCT_DIALECT_HW_PASSES_TD

--- a/lib/Dialect/HW/InnerSymbolTable.cpp
+++ b/lib/Dialect/HW/InnerSymbolTable.cpp
@@ -242,5 +242,17 @@ LogicalResult verifyInnerRefNamespace(Operation *op) {
 }
 
 } // namespace detail
+
+bool InnerRefNamespaceLike::classof(mlir::Operation *op) {
+  return op->hasTrait<mlir::OpTrait::InnerRefNamespace>() ||
+         op->hasTrait<mlir::OpTrait::SymbolTable>();
+}
+
+bool InnerRefNamespaceLike::classof(
+    const mlir::RegisteredOperationName *opInfo) {
+  return opInfo->hasTrait<mlir::OpTrait::InnerRefNamespace>() ||
+         opInfo->hasTrait<mlir::OpTrait::SymbolTable>();
+}
+
 } // namespace hw
 } // namespace circt

--- a/lib/Dialect/HW/Transforms/CMakeLists.txt
+++ b/lib/Dialect/HW/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_dialect_library(CIRCTHWTransforms
   HWSpecialize.cpp
   PrintHWModuleGraph.cpp
   FlattenIO.cpp
+  VerifyInnerRefNamespace.cpp
 
   DEPENDS
   CIRCTHWTransformsIncGen

--- a/lib/Dialect/HW/Transforms/VerifyInnerRefNamespace.cpp
+++ b/lib/Dialect/HW/Transforms/VerifyInnerRefNamespace.cpp
@@ -1,0 +1,44 @@
+//===- VerifyInnerRefNamespace.cpp - InnerRefNamespace verification Pass --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a simple pass to drive verification of operations
+// that want to be InnerRefNamespace's but don't have the trait to verify
+// themselves.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/HW/HWOpInterfaces.h"
+#include "circt/Dialect/HW/HWPasses.h"
+
+/// VerifyInnerRefNamespace pass until have container operation.
+
+namespace {
+
+class VerifyInnerRefNamespacePass
+    : public circt::hw::VerifyInnerRefNamespaceBase<
+          VerifyInnerRefNamespacePass> {
+public:
+  void runOnOperation() override {
+    auto *irnLike = getOperation();
+    if (!irnLike->hasTrait<mlir::OpTrait::InnerRefNamespace>())
+      if (failed(circt::hw::detail::verifyInnerRefNamespace(irnLike)))
+        return signalPassFailure();
+
+    return markAllAnalysesPreserved();
+  };
+  bool canScheduleOn(mlir::RegisteredOperationName opInfo) const override {
+    return llvm::isa<circt::hw::InnerRefNamespaceLike>(opInfo);
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::Pass> circt::hw::createVerifyInnerRefNamespacePass() {
+  return std::make_unique<VerifyInnerRefNamespacePass>();
+}

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -10,6 +10,7 @@
 #include "circt/Conversion/Passes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/Support/Passes.h"
@@ -199,6 +200,9 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
     modulePM.addPass(createSimpleCanonicalizerPass());
   }
 
+  // Check inner symbols and inner refs.
+  pm.addPass(hw::createVerifyInnerRefNamespacePass());
+
   return success();
 }
 
@@ -231,5 +235,9 @@ LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
     modulePM.addPass(sv::createHWCleanupPass(
         /*mergeAlwaysBlocks=*/!opt.emitSeparateAlwaysBlocks));
   }
+
+  // Check inner symbols and inner refs.
+  pm.addPass(hw::createVerifyInnerRefNamespacePass());
+
   return success();
 }

--- a/test/Dialect/HW/verify-irn.mlir
+++ b/test/Dialect/HW/verify-irn.mlir
@@ -1,0 +1,22 @@
+// Check explicit verification pass.
+// RUN: circt-opt -hw-verify-irn -verify-diagnostics -split-input-file %s
+// Check verification occurs in firtool pipeline.
+// RUN: firtool -verify-diagnostics -split-input-file %s
+
+// #3526
+hw.module @B() {}
+
+hw.module @A() -> () {
+  // expected-note @below {{see existing inner symbol definition here}}
+  hw.instance "h" sym @A @B() -> () 
+  // expected-error @below {{redefinition of inner symbol named 'A'}}
+  hw.instance "h" sym @A @B() -> () 
+}
+
+// -----
+
+// expected-error @below {{operation with symbol: #hw.innerNameRef<@A::@invalid> was not found}}
+hw.hierpath private @test [@A::@invalid]
+
+hw.module @A() -> () {
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -22,6 +22,7 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Dialect/LTL/LTLDialect.h"
 #include "circt/Dialect/OM/OMDialect.h"
 #include "circt/Dialect/OM/OMOps.h"
@@ -380,6 +381,9 @@ static LogicalResult processBuffer(
     // Emit module and testbench hierarchy JSON files.
     if (exportModuleHierarchy)
       pm.addPass(sv::createHWExportModuleHierarchyPass(outputFilename));
+
+    // Check inner symbols and inner refs.
+    pm.addPass(hw::createVerifyInnerRefNamespacePass());
 
     // Emit a single file or multiple files depending on the output format.
     switch (outputFormat) {


### PR DESCRIPTION
Until have proper container op to put the trait on, add a dummy struct we can classof to classify IRN-like, and add a simple pass that drives verification on these if they aren't self-verifying.

Add verification pass to pipeline, basic test for duplicate inner symbols and invalid InnerRef user.

cc #3526 (nearly fixes), #4453.
cc #5716 .