### PR TITLE
[Seq] Introduce a clock type

### DIFF
--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -509,3 +509,29 @@ def FirMemReadWriteOp : SeqOp<"firmem.read_write_port", [
   let hasVerifier = 1;
   let hasCanonicalizeMethod = 1;
 }
+
+//===----------------------------------------------------------------------===//
+// Clock cast
+//===----------------------------------------------------------------------===//
+
+def ToClockOp : SeqOp<"to_clock", [Pure]> {
+  let summary = "Cast from a wire type to a clock type";
+
+  let arguments = (ins I1:$input);
+  let results = (outs ClockType:$output);
+
+  let assemblyFormat = "$input attr-dict";
+
+  let hasCanonicalizeMethod = 1;
+}
+
+def FromClockOp : SeqOp<"from_clock", [Pure]> {
+  let summary = "Cast from a clock type to a wire type";
+
+  let arguments = (ins ClockType:$input);
+  let results = (outs I1:$output);
+
+  let assemblyFormat = "$input attr-dict";
+
+  let hasCanonicalizeMethod = 1;
+}

--- a/include/circt/Dialect/Seq/SeqTypes.td
+++ b/include/circt/Dialect/Seq/SeqTypes.td
@@ -79,3 +79,12 @@ def FirMemType : SeqType<"FirMem"> {
   );
   let assemblyFormat = "`<` $depth `x` $width (`,` `mask` $maskWidth^)? `>`";
 }
+
+def ClockType : SeqType<"Clock"> {
+  let summary = "A type for clock-carrying wires";
+  let description = [{
+    The `!seq.clock` type represents signals which can be used to drive the
+    clock input of sequential operations.
+  }];
+  let mnemonic = "clock";
+}

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -885,6 +885,27 @@ LogicalResult FirMemReadWriteOp::canonicalize(FirMemReadWriteOp op,
 }
 
 //===----------------------------------------------------------------------===//
+// ToClockOp/FromClockOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ToClockOp::canonicalize(ToClockOp op, PatternRewriter &rewriter) {
+  if (auto fromClock = op.getInput().getDefiningOp<FromClockOp>()) {
+    rewriter.replaceOp(op, fromClock.getInput());
+    return success();
+  }
+  return failure();
+}
+
+LogicalResult FromClockOp::canonicalize(FromClockOp op,
+                                        PatternRewriter &rewriter) {
+  if (auto toClock = op.getInput().getDefiningOp<ToClockOp>()) {
+    rewriter.replaceOp(op, toClock.getInput());
+    return success();
+  }
+  return failure();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -189,3 +189,19 @@ hw.module @FirMem(%addr: i4, %clock: i1, %data: i42) -> (out: i42) {
   %9 = comb.xor %1, %2, %3, %4, %5, %6, %7, %8 : i42
   hw.output %9 : i42
 }
+
+// CHECK-LABEL: @through_clock
+hw.module @through_clock(%clock: !seq.clock) -> (out: !seq.clock) {
+  // CHECK: hw.output %clock : !seq.clock
+  %tmp = seq.from_clock %clock
+  %out = seq.to_clock %tmp
+  hw.output %out : !seq.clock
+}
+
+// CHECK-LABEL: @through_wire
+hw.module @through_wire(%clock: i1) -> (out: i1) {
+  // CHECK: hw.output %clock : i1
+  %tmp = seq.to_clock %clock
+  %out = seq.from_clock %tmp
+  hw.output %out : i1
+}

--- a/test/Dialect/Seq/clock-type.mlir
+++ b/test/Dialect/Seq/clock-type.mlir
@@ -1,0 +1,40 @@
+// RUN: circt-opt --lower-seq-to-sv %s | FileCheck %s
+
+hw.generator.schema @Some_schema, "Some_schema", ["dummy"]
+
+// CHECK-LABEL: hw.module.generated @generated, @Some_schema(%clock: i1, %other: i1) -> (out: i32)
+hw.module.generated @generated, @Some_schema(%clock: !seq.clock, %other: i1) -> (out: i32) attributes { dummy = 1 : i32 }
+
+// CHECK-LABEL: hw.module.extern @extern(%clock: i1, %other: i1) -> (out: i32)
+hw.module.extern @extern(%clock: !seq.clock, %other: i1) -> (out: i32)
+
+// CHECK-LABEL: hw.module @top(%clock: i1, %other: i1, %wire: i1) -> (out: i1)
+hw.module @top(%clock: !seq.clock, %other: i1, %wire: i1) -> (out: !seq.clock) {
+
+  // CHECK: %tap_generated = hw.wire %clock  : i1
+  %tap_generated = hw.wire %clock : !seq.clock
+
+  // CHECK: %generated.out = hw.instance "generated" @generated(clock: %tap_generated: i1, other: %other: i1) -> (out: i32)
+  %generated.out = hw.instance "generated" @generated(clock: %tap_generated: !seq.clock, other: %other: i1) -> (out: i32)
+
+  // CHECK: %extern.out = hw.instance "extern" @generated(clock: %clock: i1, other: %other: i1) -> (out: i32)
+  %extern.out = hw.instance "extern" @generated(clock: %clock: !seq.clock, other: %other: i1) -> (out: i32)
+
+  // CHECK: %inner.out = hw.instance "inner" @inner(clock: %clock: i1, other: %other: i1) -> (out: i32)
+  %out_inner = hw.instance "inner" @inner(clock: %clock: !seq.clock, other: %other: i1) -> (out: i32)
+
+  // CHECK: [[NEGATED:%.+]] = comb.xor %clock, %true : i1
+  %clock_wire = seq.from_clock %clock
+  %one = hw.constant 1 : i1
+  %tmp = comb.xor %clock_wire, %one : i1
+  %negated = seq.to_clock %tmp
+
+  // CHECK: hw.output [[NEGATED]] : i1
+  hw.output %negated : !seq.clock
+}
+
+// CHECK-LABEL: hw.module private @inner(%clock: i1, %other: i1) -> (out: i32)
+hw.module private @inner(%clock: !seq.clock, %other: i1) -> (out: i32) {
+  %cst = hw.constant 0 : i32
+  hw.output %cst : i32
+}


### PR DESCRIPTION
The clock type will be used to carry the clock signal in a design. This PR allows it to be placed on module ports and wires, without forcing its use on all ops. Subsequent PRs will switch `seq` ops over to use it and generate it from FIRRTL.

Added `from_clock` and `to_clock` ops to allow the types to be introduced into the design and to permit black-boxes while intrinsics are developed to cover most use cases.