### PR TITLE
[Ibis] Add tunneling pass

### DIFF
--- a/include/circt/Dialect/Ibis/IbisPasses.h
+++ b/include/circt/Dialect/Ibis/IbisPasses.h
@@ -19,6 +19,7 @@ namespace ibis {
 
 std::unique_ptr<Pass> createCallPrepPass();
 std::unique_ptr<Pass> createContainerizePass();
+std::unique_ptr<Pass> createTunnelingPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Ibis/IbisPasses.td
+++ b/include/circt/Dialect/Ibis/IbisPasses.td
@@ -27,4 +27,16 @@ def IbisContainerize : Pass<"ibis-containerize", "ModuleOp"> {
   let constructor = "circt::ibis::createContainerizePass()";
 }
 
+def IbisTunneling : Pass<"ibis-tunneling", "mlir::ModuleOp"> {
+  let summary = "Ibis tunneling pass";
+  let description = [{
+    Tunnels relative `get_port` ops through the module hierarchy, based on
+    `ibis.path` ops. The result of this pass is that various new in- and output
+    ports of `!ibis.portref<...>` type are created.
+    After this pass, `get_port` ops should only exist at the same scope of
+    container instantiations.
+  }];
+  let constructor = "circt::ibis::createTunnelingPass()";
+}
+
 #endif // CIRCT_DIALECT_IBIS_PASSES_TD

--- a/lib/Dialect/Ibis/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Ibis/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_dialect_library(CIRCTIbisTransforms
   IbisCallPrep.cpp
   IbisContainerize.cpp
+  IbisTunneling.cpp
 
   DEPENDS
   CIRCTIbisTransformsIncGen

--- a/lib/Dialect/Ibis/Transforms/IbisTunneling.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisTunneling.cpp
@@ -1,0 +1,362 @@
+//===- IbisTunneling.cpp - Implementation of tunneling --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+#include "circt/Dialect/Ibis/IbisDialect.h"
+#include "circt/Dialect/Ibis/IbisOps.h"
+#include "circt/Dialect/Ibis/IbisPasses.h"
+#include "circt/Dialect/Ibis/IbisTypes.h"
+
+#include "circt/Support/InstanceGraph.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace ibis;
+using namespace igraph;
+
+namespace {
+
+class TunnelingConversionPattern : public OpConversionPattern<PathOp> {
+public:
+  TunnelingConversionPattern(MLIRContext *context, igraph::InstanceGraph &ig)
+      : OpConversionPattern<PathOp>(context), ig(ig) {}
+
+  LogicalResult
+  matchAndRewrite(PathOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    return Tunneler(op, rewriter, ig).go();
+  }
+
+  struct Tunneler {
+    PathOp op;
+    ConversionPatternRewriter &rewriter;
+    igraph::InstanceGraph &ig;
+    mlir::StringAttr pathName;
+
+    // The PortInfo struct is used to keep track of the get_port ops that
+    // specify which ports needs to be tunneled through the hierarchy.
+    struct PortInfo {
+      // Name used for portrefs of this get_port in the instance hierarchy.
+      mlir::StringAttr portName;
+
+      // Source get_port op.
+      GetPortOp getPortOp;
+
+      PortRefType getType() {
+        return getPortOp.getPort().getType().cast<PortRefType>();
+      }
+      Type getInnerType() { return getType().getPortType(); }
+      ibis::Direction requestedDirection() { return getType().getDirection(); }
+    };
+
+    // MapVector to ensure determinism.
+    llvm::MapVector<StringAttr, PortInfo> portInfos;
+
+    // "Target" refers to the last step in the path which is the scoperef that
+    // all port requests are tunneling towards.
+    PathStepAttr target;
+    FlatSymbolRefAttr targetName;
+
+    Tunneler(PathOp op, ConversionPatternRewriter &rewriter,
+             igraph::InstanceGraph &ig)
+        : op(op), rewriter(rewriter), ig(ig) {}
+
+    // A mapping between requested port names from a ScopeRef and the actual
+    // portref SSA values that are used to replace the get_port ops.
+    // MapVector to ensure determinism.
+    using PortRefMapping = llvm::MapVector<StringAttr, Value>;
+
+    LogicalResult go() {
+      // Gather the required port accesses of the ScopeRef.
+      for (auto user : op.getResult().getUsers()) {
+        auto getPortOp = dyn_cast<GetPortOp>(user);
+        if (!getPortOp)
+          return user->emitOpError() << "unknown user of a PathOp result - "
+                                        "tunneling only supports ibis.get_port";
+        portInfos[getPortOp.getPortSymbolAttr().getAttr()].getPortOp =
+            getPortOp;
+      }
+
+      InstanceGraphNode *currentContainer =
+          ig.lookup(cast<ModuleOpInterface>(op.getOperation()->getParentOp()));
+
+      llvm::SmallVector<PathStepAttr> path;
+      llvm::copy(op.getPathAsRange(), std::back_inserter(path));
+      genPortNames();
+      target = path.back();
+      targetName = target.getChild();
+
+      assert(!path.empty() &&
+             "empty paths should never occur - illegal for ibis.path ops");
+      PortRefMapping mapping;
+      if (failed(tunnelDispatch(currentContainer, path, mapping)))
+        return failure();
+
+      // Replace the get_port ops with the target value.
+      for (auto [sym, portInfo] : portInfos) {
+        auto it = mapping.find(sym);
+        assert(it != mapping.end() &&
+               "expected to find a portref mapping for all get_port ops");
+        rewriter.replaceOp(portInfo.getPortOp, it->second);
+      }
+
+      // And finally erase the path.
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    // Dispatches tunneling in the current container and returns a value of the
+    // target scoperef inside the current container.
+    LogicalResult tunnelDispatch(InstanceGraphNode *currentContainer,
+                                 llvm::ArrayRef<PathStepAttr> path,
+                                 PortRefMapping &mapping) {
+      auto currentStep = path.front();
+      PortRefMapping targetValue;
+      path = path.drop_front();
+      if (currentStep.getDirection() == PathDirection::Parent) {
+        auto upRes = tunnelUp(currentContainer, path, mapping);
+        if (failed(upRes))
+          return failure();
+      } else {
+        auto tunnelInto = currentStep.getChild();
+        auto downRes = tunnelDown(currentContainer, tunnelInto, path, mapping);
+        if (failed(downRes))
+          return failure();
+      }
+      return success();
+    }
+
+    // "Port forwarding" check - ibis.get_port specifies the intended
+    // direction which a port is accessed by from within the hierarchy.
+    // If the intended direction is not the same as the actual port
+    // direction, we need to insert a wire to flip the direction of the
+    // mapped port.
+    Value portForwardIfNeeded(PortOpInterface actualPort, PortInfo &portInfo) {
+      ibis::Direction actualDir =
+          actualPort.getPort().getType().cast<PortRefType>().getDirection();
+      ibis::Direction requestedDir = portInfo.requestedDirection();
+
+      // Match - just return the port itself.
+      if (actualDir == requestedDir)
+        return actualPort.getPort();
+
+      // Mismatch...
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointAfter(actualPort);
+
+      // If the requested direction was an input, this means that someone tried
+      // to write to an output port. We need to insert an ibis.wire.input that
+      // provides a writeable input port, and assign the wire output to the
+      // output port.
+      if (requestedDir == Direction::Input) {
+        auto wireOp = rewriter.create<ibis::InputWireOp>(
+            op.getLoc(),
+            rewriter.getStringAttr(actualPort.getPortName().strref() + ".wr"),
+            portInfo.getInnerType());
+
+        rewriter.create<ibis::PortWriteOp>(op.getLoc(), actualPort.getPort(),
+                                           wireOp.getOutput());
+        return wireOp.getPort();
+      }
+
+      // If the requested direction was an output, this means that someone tried
+      // to read from an input port. We need to insert an ibis.wire.output that
+      // provides a readable output port, and read the input port as the value
+      // of the wire.
+      Value inputValue =
+          rewriter.create<ibis::PortReadOp>(op.getLoc(), actualPort.getPort());
+      auto wireOp = rewriter.create<ibis::OutputWireOp>(
+          op.getLoc(),
+          rewriter.getStringAttr(actualPort.getPortName().strref() + ".rd"),
+          inputValue);
+      return wireOp.getPort();
+    }
+
+    // Tunnels up relative to the current container. This will write to the
+    // target input port of the current container from any parent
+    // (instantiating) containers, and return the value of the target scoperef
+    // inside the current container.
+    LogicalResult tunnelUp(InstanceGraphNode *currentContainer,
+                           llvm::ArrayRef<PathStepAttr> path,
+                           PortRefMapping &portMapping) {
+      auto scopeOp = currentContainer->getModule<ScopeOpInterface>();
+      if (currentContainer->noUses())
+        return op->emitOpError()
+               << "cannot tunnel up from " << scopeOp.getScopeName()
+               << " because it has no uses";
+
+      for (auto use : currentContainer->uses()) {
+        auto parentScopeNode = ig.lookup(use->getParent()->getModule());
+        auto parentScope = parentScopeNode->getModule<ScopeOpInterface>();
+        PortRefMapping targetPortMapping;
+        if (path.empty()) {
+          // Tunneling ended with a 'parent' step - all of the requested ports
+          // should be available right here in the parent scope.
+          for (auto [sym, portInfo] : portInfos) {
+            auto portLikeOp = parentScope.lookupPort(sym.strref());
+            if (!portLikeOp)
+              return op->emitOpError()
+                     << "expected a port named " << sym << " in "
+                     << parentScope.getScopeName() << " but found none";
+
+            // "Port forwarding" check - see comment in portForwardIfNeeded.
+            targetPortMapping[sym] = portForwardIfNeeded(portLikeOp, portInfo);
+          }
+        } else {
+          // recurse into the parents, which will define the target value that
+          // we can write to the input port of the current container instance.
+          if (failed(tunnelDispatch(parentScopeNode, path, targetPortMapping)))
+            return failure();
+        }
+
+        auto instance = use->getInstance<ContainerInstanceOp>();
+        rewriter.setInsertionPointAfter(instance);
+        for (auto [sym, portInfo] : portInfos) {
+
+          auto getPortOp = rewriter.create<GetPortOp>(
+              op.getLoc(), instance, portInfo.portName, portInfo.getType(),
+              Direction::Input);
+          rewriter.create<PortWriteOp>(op.getLoc(), getPortOp,
+                                       targetPortMapping[sym]);
+        }
+      }
+
+      // Create input ports for the requested portrefs.
+      rewriter.setInsertionPointToEnd(scopeOp.getBodyBlock());
+      for (auto [sym, portInfo] : portInfos) {
+        auto inputPort = rewriter.create<InputPortOp>(
+            op.getLoc(), portInfo.portName, portInfo.getType());
+        // Read the input port of the current container to forward the portref.
+
+        portMapping[sym] =
+            rewriter.create<PortReadOp>(op.getLoc(), inputPort.getResult())
+                .getResult();
+      }
+
+      return success();
+    }
+
+    // Tunnels down relative to the current container, and returns the value of
+    // the target scoperef inside the current container.
+    LogicalResult tunnelDown(InstanceGraphNode *currentContainer,
+                             FlatSymbolRefAttr tunnelInto,
+                             llvm::ArrayRef<PathStepAttr> path,
+                             PortRefMapping &portMapping) {
+      // Locate the instance that we're tunneling into
+      auto scopeOp = currentContainer->getModule<ScopeOpInterface>();
+      auto tunnelInstanceOp = SymbolTable::lookupSymbolIn(scopeOp, tunnelInto);
+      if (!tunnelInstanceOp)
+        return op->emitOpError()
+               << "expected an instance named " << tunnelInto << " in "
+               << scopeOp.getScopeName() << " but found none";
+      auto tunnelInstance = cast<ContainerInstanceOp>(tunnelInstanceOp);
+
+      if (path.empty()) {
+        // Tunneling ended with a 'child' step - create get_ports of all of the
+        // requested ports.
+        rewriter.setInsertionPointAfter(tunnelInstance);
+        for (auto [sym, portInfo] : portInfos) {
+          auto targetGetPortOp = rewriter.create<GetPortOp>(
+              op.getLoc(), portInfo.getType(), tunnelInstance, sym);
+          portMapping[sym] = targetGetPortOp.getResult();
+        }
+        return success();
+      }
+
+      // We're not in the target, but tunneling into a child instance.
+      // Create output ports in the child instance for the requested ports.
+      auto tunnelScopeNode = ig.lookup(ig.getReferencedModule(
+          cast<InstanceOpInterface>(tunnelInstance.getOperation())));
+      auto tunnelScope = tunnelScopeNode->getModule<ScopeOpInterface>();
+
+      rewriter.setInsertionPointToEnd(tunnelScope.getBodyBlock());
+      llvm::DenseMap<StringAttr, OutputPortOp> outputPortOps;
+      for (auto [sym, portInfo] : portInfos) {
+        outputPortOps[sym] = rewriter.create<OutputPortOp>(
+            op.getLoc(), portInfo.portName, portInfo.getType());
+      }
+
+      // Recurse into the tunnel instance container.
+      PortRefMapping childMapping;
+      if (failed(tunnelDispatch(tunnelScopeNode, path, childMapping)))
+        return failure();
+
+      for (auto [sym, res] : childMapping) {
+        auto &portInfo = portInfos[sym];
+
+        // Write the target value to the output port.
+        rewriter.setInsertionPointToEnd(tunnelScope.getBodyBlock());
+        rewriter.create<PortWriteOp>(op.getLoc(), outputPortOps[sym], res);
+
+        // Back in the current container, read the new output port of the child
+        // instance and assign it to the port mapping.
+        rewriter.setInsertionPointAfter(tunnelInstance);
+        auto getPortOp = rewriter.create<GetPortOp>(
+            op.getLoc(), tunnelInstance, portInfo.portName, portInfo.getType(),
+            Direction::Output);
+        portMapping[sym] =
+            rewriter.create<PortReadOp>(op.getLoc(), getPortOp).getResult();
+      }
+
+      return success();
+    }
+
+    // Generates names for the port refs to be created.
+    void genPortNames() {
+      std::string pathName;
+      llvm::raw_string_ostream ss(pathName);
+      llvm::interleave(
+          op.getPathAsRange(), ss,
+          [&](PathStepAttr step) {
+            if (step.getDirection() == PathDirection::Parent)
+              ss << "p"; // use 'p' instead of 'parent' to avoid long SSA names.
+            else
+              ss << step.getChild().getValue();
+          },
+          "_");
+
+      for (auto &[sym, portInfo] : portInfos) {
+        portInfo.portName =
+            rewriter.getStringAttr(pathName + "_" + sym.getValue());
+      }
+    }
+  };
+
+protected:
+  igraph::InstanceGraph &ig;
+};
+
+struct TunnelingPass : public IbisTunnelingBase<TunnelingPass> {
+  void runOnOperation() override;
+};
+
+} // anonymous namespace
+
+void TunnelingPass::runOnOperation() {
+  auto &ig = getAnalysis<igraph::InstanceGraph>();
+  auto *ctx = &getContext();
+  ConversionTarget target(*ctx);
+  target.addIllegalOp<PathOp>();
+  target.addLegalOp<InputPortOp, OutputPortOp, PortReadOp, PortWriteOp,
+                    GetPortOp, InputWireOp, OutputWireOp>();
+
+  RewritePatternSet patterns(ctx);
+  patterns.add<TunnelingConversionPattern>(ctx, ig);
+
+  if (failed(
+          applyPartialConversion(getOperation(), target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<Pass> circt::ibis::createTunnelingPass() {
+  return std::make_unique<TunnelingPass>();
+}

--- a/lib/Dialect/Ibis/Transforms/IbisTunneling.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisTunneling.cpp
@@ -19,15 +19,335 @@
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
-using namespace circt;
-using namespace ibis;
-using namespace igraph;
+using namespace circt::ibis;
+using namespace circt::igraph;
 
 namespace {
+// The PortInfo struct is used to keep track of the get_port ops that
+// specify which ports needs to be tunneled through the hierarchy.
+struct PortInfo {
+  // Name used for portrefs of this get_port in the instance hierarchy.
+  mlir::StringAttr portName;
+
+  // Source get_port op.
+  GetPortOp getPortOp;
+
+  PortRefType getType() {
+    return getPortOp.getPort().getType().cast<PortRefType>();
+  }
+  Type getInnerType() { return getType().getPortType(); }
+  Direction requestedDirection() { return getType().getDirection(); }
+};
+
+struct Tunneler {
+public:
+  Tunneler(PathOp op, ConversionPatternRewriter &rewriter, InstanceGraph &ig);
+
+  // A mapping between requested port names from a ScopeRef and the actual
+  // portref SSA values that are used to replace the get_port ops.
+  // MapVector to ensure determinism.
+  using PortRefMapping = llvm::MapVector<StringAttr, Value>;
+
+  // Launch the tunneling process.
+  LogicalResult go();
+
+private:
+  // Dispatches tunneling in the current container and returns a value of the
+  // target scoperef inside the current container.
+  LogicalResult tunnelDispatch(InstanceGraphNode *currentContainer,
+                               llvm::ArrayRef<PathStepAttr> path,
+                               PortRefMapping &mapping);
+
+  // "Port forwarding" check - ibis.get_port specifies the intended
+  // direction which a port is accessed by from within the hierarchy.
+  // If the intended direction is not the same as the actual port
+  // direction, we need to insert a wire to flip the direction of the
+  // mapped port.
+  Value portForwardIfNeeded(PortOpInterface actualPort, PortInfo &portInfo);
+
+  // Tunnels up relative to the current container. This will write to the
+  // target input port of the current container from any parent
+  // (instantiating) containers, and return the value of the target scoperef
+  // inside the current container.
+  LogicalResult tunnelUp(InstanceGraphNode *currentContainer,
+                         llvm::ArrayRef<PathStepAttr> path,
+                         PortRefMapping &portMapping);
+
+  // Tunnels down relative to the current container, and returns the value of
+  // the target scoperef inside the current container.
+  LogicalResult tunnelDown(InstanceGraphNode *currentContainer,
+                           FlatSymbolRefAttr tunnelInto,
+                           llvm::ArrayRef<PathStepAttr> path,
+                           PortRefMapping &portMapping);
+
+  // Generates names for the port refs to be created.
+  void genPortNames(llvm::MapVector<StringAttr, PortInfo> &portInfos);
+
+  PathOp op;
+  ConversionPatternRewriter &rewriter;
+  InstanceGraph &ig;
+  mlir::StringAttr pathName;
+  llvm::SmallVector<PathStepAttr> path;
+
+  // MapVector to ensure determinism.
+  llvm::MapVector<StringAttr, PortInfo> portInfos;
+
+  // "Target" refers to the last step in the path which is the scoperef that
+  // all port requests are tunneling towards.
+  PathStepAttr target;
+  FlatSymbolRefAttr targetName;
+};
+
+Tunneler::Tunneler(PathOp op, ConversionPatternRewriter &rewriter,
+                   InstanceGraph &ig)
+    : op(op), rewriter(rewriter), ig(ig) {
+  llvm::copy(op.getPathAsRange(), std::back_inserter(path));
+  assert(!path.empty() &&
+         "empty paths should never occur - illegal for ibis.path ops");
+  target = path.back();
+  targetName = target.getChild();
+}
+
+void Tunneler::genPortNames(llvm::MapVector<StringAttr, PortInfo> &pis) {
+  std::string pathName;
+  llvm::raw_string_ostream ss(pathName);
+  llvm::interleave(
+      op.getPathAsRange(), ss,
+      [&](PathStepAttr step) {
+        if (step.getDirection() == PathDirection::Parent)
+          ss << "p"; // use 'p' instead of 'parent' to avoid long SSA names.
+        else
+          ss << step.getChild().getValue();
+      },
+      "_");
+
+  for (auto &[sym, portInfo] : pis)
+    portInfo.portName = rewriter.getStringAttr(pathName + "_" + sym.getValue());
+}
+
+LogicalResult Tunneler::go() {
+  // Gather the required port accesses of the ScopeRef.
+  for (auto *user : op.getResult().getUsers()) {
+    auto getPortOp = dyn_cast<GetPortOp>(user);
+    if (!getPortOp)
+      return user->emitOpError() << "unknown user of a PathOp result - "
+                                    "tunneling only supports ibis.get_port";
+    portInfos[getPortOp.getPortSymbolAttr().getAttr()].getPortOp = getPortOp;
+  }
+  genPortNames(portInfos);
+
+  InstanceGraphNode *currentContainer =
+      ig.lookup(cast<ModuleOpInterface>(op.getOperation()->getParentOp()));
+
+  PortRefMapping mapping;
+  if (failed(tunnelDispatch(currentContainer, path, mapping)))
+    return failure();
+
+  // Replace the get_port ops with the target value.
+  for (auto [sym, portInfo] : portInfos) {
+    auto *it = mapping.find(sym);
+    assert(it != mapping.end() &&
+           "expected to find a portref mapping for all get_port ops");
+    rewriter.replaceOp(portInfo.getPortOp, it->second);
+  }
+
+  // And finally erase the path.
+  rewriter.eraseOp(op);
+  return success();
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+LogicalResult Tunneler::tunnelDispatch(InstanceGraphNode *currentContainer,
+                                       llvm::ArrayRef<PathStepAttr> path,
+                                       PortRefMapping &mapping) {
+  PathStepAttr currentStep = path.front();
+  PortRefMapping targetValue;
+  path = path.drop_front();
+  if (currentStep.getDirection() == PathDirection::Parent) {
+    LogicalResult upRes = tunnelUp(currentContainer, path, mapping);
+    if (failed(upRes))
+      return failure();
+  } else {
+    FlatSymbolRefAttr tunnelInto = currentStep.getChild();
+    LogicalResult downRes =
+        tunnelDown(currentContainer, tunnelInto, path, mapping);
+    if (failed(downRes))
+      return failure();
+  }
+  return success();
+}
+
+Value Tunneler::portForwardIfNeeded(PortOpInterface actualPort,
+                                    PortInfo &portInfo) {
+  Direction actualDir =
+      actualPort.getPort().getType().cast<PortRefType>().getDirection();
+  Direction requestedDir = portInfo.requestedDirection();
+
+  // Match - just return the port itself.
+  if (actualDir == requestedDir)
+    return actualPort.getPort();
+
+  // Mismatch...
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointAfter(actualPort);
+
+  // If the requested direction was an input, this means that someone tried
+  // to write to an output port. We need to insert an ibis.wire.input that
+  // provides a writeable input port, and assign the wire output to the
+  // output port.
+  if (requestedDir == Direction::Input) {
+    auto wireOp = rewriter.create<InputWireOp>(
+        op.getLoc(),
+        rewriter.getStringAttr(actualPort.getPortName().strref() + ".wr"),
+        portInfo.getInnerType());
+
+    rewriter.create<PortWriteOp>(op.getLoc(), actualPort.getPort(),
+                                 wireOp.getOutput());
+    return wireOp.getPort();
+  }
+
+  // If the requested direction was an output, this means that someone tried
+  // to read from an input port. We need to insert an ibis.wire.output that
+  // provides a readable output port, and read the input port as the value
+  // of the wire.
+  Value inputValue =
+      rewriter.create<PortReadOp>(op.getLoc(), actualPort.getPort());
+  auto wireOp = rewriter.create<OutputWireOp>(
+      op.getLoc(),
+      rewriter.getStringAttr(actualPort.getPortName().strref() + ".rd"),
+      inputValue);
+  return wireOp.getPort();
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+LogicalResult Tunneler::tunnelDown(InstanceGraphNode *currentContainer,
+                                   FlatSymbolRefAttr tunnelInto,
+                                   llvm::ArrayRef<PathStepAttr> path,
+                                   PortRefMapping &portMapping) {
+  // Locate the instance that we're tunneling into
+  auto scopeOp = currentContainer->getModule<ScopeOpInterface>();
+  auto *tunnelInstanceOp = SymbolTable::lookupSymbolIn(scopeOp, tunnelInto);
+  if (!tunnelInstanceOp)
+    return op->emitOpError()
+           << "expected an instance named " << tunnelInto << " in "
+           << scopeOp.getScopeName() << " but found none";
+  auto tunnelInstance = cast<ContainerInstanceOp>(tunnelInstanceOp);
+
+  if (path.empty()) {
+    // Tunneling ended with a 'child' step - create get_ports of all of the
+    // requested ports.
+    rewriter.setInsertionPointAfter(tunnelInstance);
+    for (auto [sym, portInfo] : portInfos) {
+      auto targetGetPortOp = rewriter.create<GetPortOp>(
+          op.getLoc(), portInfo.getType(), tunnelInstance, sym);
+      portMapping[sym] = targetGetPortOp.getResult();
+    }
+    return success();
+  }
+
+  // We're not in the target, but tunneling into a child instance.
+  // Create output ports in the child instance for the requested ports.
+  auto *tunnelScopeNode = ig.lookup(ig.getReferencedModule(
+      cast<InstanceOpInterface>(tunnelInstance.getOperation())));
+  auto tunnelScope = tunnelScopeNode->getModule<ScopeOpInterface>();
+
+  rewriter.setInsertionPointToEnd(tunnelScope.getBodyBlock());
+  llvm::DenseMap<StringAttr, OutputPortOp> outputPortOps;
+  for (auto [sym, portInfo] : portInfos) {
+    outputPortOps[sym] = rewriter.create<OutputPortOp>(
+        op.getLoc(), portInfo.portName, portInfo.getType());
+  }
+
+  // Recurse into the tunnel instance container.
+  PortRefMapping childMapping;
+  if (failed(tunnelDispatch(tunnelScopeNode, path, childMapping)))
+    return failure();
+
+  for (auto [sym, res] : childMapping) {
+    auto &portInfo = portInfos[sym];
+
+    // Write the target value to the output port.
+    rewriter.setInsertionPointToEnd(tunnelScope.getBodyBlock());
+    rewriter.create<PortWriteOp>(op.getLoc(), outputPortOps[sym], res);
+
+    // Back in the current container, read the new output port of the child
+    // instance and assign it to the port mapping.
+    rewriter.setInsertionPointAfter(tunnelInstance);
+    auto getPortOp = rewriter.create<GetPortOp>(
+        op.getLoc(), tunnelInstance, portInfo.portName, portInfo.getType(),
+        Direction::Output);
+    portMapping[sym] =
+        rewriter.create<PortReadOp>(op.getLoc(), getPortOp).getResult();
+  }
+
+  return success();
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+LogicalResult Tunneler::tunnelUp(InstanceGraphNode *currentContainer,
+                                 llvm::ArrayRef<PathStepAttr> path,
+                                 PortRefMapping &portMapping) {
+  auto scopeOp = currentContainer->getModule<ScopeOpInterface>();
+  if (currentContainer->noUses())
+    return op->emitOpError()
+           << "cannot tunnel up from " << scopeOp.getScopeName()
+           << " because it has no uses";
+
+  for (auto *use : currentContainer->uses()) {
+    InstanceGraphNode *parentScopeNode =
+        ig.lookup(use->getParent()->getModule());
+    auto parentScope = parentScopeNode->getModule<ScopeOpInterface>();
+    PortRefMapping targetPortMapping;
+    if (path.empty()) {
+      // Tunneling ended with a 'parent' step - all of the requested ports
+      // should be available right here in the parent scope.
+      for (auto [sym, portInfo] : portInfos) {
+        PortOpInterface portLikeOp = parentScope.lookupPort(sym.strref());
+        if (!portLikeOp)
+          return op->emitOpError()
+                 << "expected a port named " << sym << " in "
+                 << parentScope.getScopeName() << " but found none";
+
+        // "Port forwarding" check - see comment in portForwardIfNeeded.
+        targetPortMapping[sym] = portForwardIfNeeded(portLikeOp, portInfo);
+      }
+    } else {
+      // recurse into the parents, which will define the target value that
+      // we can write to the input port of the current container instance.
+      if (failed(tunnelDispatch(parentScopeNode, path, targetPortMapping)))
+        return failure();
+    }
+
+    auto instance = use->getInstance<ContainerInstanceOp>();
+    rewriter.setInsertionPointAfter(instance);
+    for (auto [sym, portInfo] : portInfos) {
+
+      auto getPortOp =
+          rewriter.create<GetPortOp>(op.getLoc(), instance, portInfo.portName,
+                                     portInfo.getType(), Direction::Input);
+      rewriter.create<PortWriteOp>(op.getLoc(), getPortOp,
+                                   targetPortMapping[sym]);
+    }
+  }
+
+  // Create input ports for the requested portrefs.
+  rewriter.setInsertionPointToEnd(scopeOp.getBodyBlock());
+  for (auto [sym, portInfo] : portInfos) {
+    auto inputPort = rewriter.create<InputPortOp>(
+        op.getLoc(), portInfo.portName, portInfo.getType());
+    // Read the input port of the current container to forward the portref.
+
+    portMapping[sym] =
+        rewriter.create<PortReadOp>(op.getLoc(), inputPort.getResult())
+            .getResult();
+  }
+
+  return success();
+}
 
 class TunnelingConversionPattern : public OpConversionPattern<PathOp> {
 public:
-  TunnelingConversionPattern(MLIRContext *context, igraph::InstanceGraph &ig)
+  TunnelingConversionPattern(MLIRContext *context, InstanceGraph &ig)
       : OpConversionPattern<PathOp>(context), ig(ig) {}
 
   LogicalResult
@@ -36,306 +356,8 @@ public:
     return Tunneler(op, rewriter, ig).go();
   }
 
-  struct Tunneler {
-    PathOp op;
-    ConversionPatternRewriter &rewriter;
-    igraph::InstanceGraph &ig;
-    mlir::StringAttr pathName;
-
-    // The PortInfo struct is used to keep track of the get_port ops that
-    // specify which ports needs to be tunneled through the hierarchy.
-    struct PortInfo {
-      // Name used for portrefs of this get_port in the instance hierarchy.
-      mlir::StringAttr portName;
-
-      // Source get_port op.
-      GetPortOp getPortOp;
-
-      PortRefType getType() {
-        return getPortOp.getPort().getType().cast<PortRefType>();
-      }
-      Type getInnerType() { return getType().getPortType(); }
-      ibis::Direction requestedDirection() { return getType().getDirection(); }
-    };
-
-    // MapVector to ensure determinism.
-    llvm::MapVector<StringAttr, PortInfo> portInfos;
-
-    // "Target" refers to the last step in the path which is the scoperef that
-    // all port requests are tunneling towards.
-    PathStepAttr target;
-    FlatSymbolRefAttr targetName;
-
-    Tunneler(PathOp op, ConversionPatternRewriter &rewriter,
-             igraph::InstanceGraph &ig)
-        : op(op), rewriter(rewriter), ig(ig) {}
-
-    // A mapping between requested port names from a ScopeRef and the actual
-    // portref SSA values that are used to replace the get_port ops.
-    // MapVector to ensure determinism.
-    using PortRefMapping = llvm::MapVector<StringAttr, Value>;
-
-    LogicalResult go() {
-      // Gather the required port accesses of the ScopeRef.
-      for (auto *user : op.getResult().getUsers()) {
-        auto getPortOp = dyn_cast<GetPortOp>(user);
-        if (!getPortOp)
-          return user->emitOpError() << "unknown user of a PathOp result - "
-                                        "tunneling only supports ibis.get_port";
-        portInfos[getPortOp.getPortSymbolAttr().getAttr()].getPortOp =
-            getPortOp;
-      }
-
-      InstanceGraphNode *currentContainer =
-          ig.lookup(cast<ModuleOpInterface>(op.getOperation()->getParentOp()));
-
-      llvm::SmallVector<PathStepAttr> path;
-      llvm::copy(op.getPathAsRange(), std::back_inserter(path));
-      genPortNames();
-      target = path.back();
-      targetName = target.getChild();
-
-      assert(!path.empty() &&
-             "empty paths should never occur - illegal for ibis.path ops");
-      PortRefMapping mapping;
-      if (failed(tunnelDispatch(currentContainer, path, mapping)))
-        return failure();
-
-      // Replace the get_port ops with the target value.
-      for (auto [sym, portInfo] : portInfos) {
-        auto *it = mapping.find(sym);
-        assert(it != mapping.end() &&
-               "expected to find a portref mapping for all get_port ops");
-        rewriter.replaceOp(portInfo.getPortOp, it->second);
-      }
-
-      // And finally erase the path.
-      rewriter.eraseOp(op);
-      return success();
-    }
-
-    // Dispatches tunneling in the current container and returns a value of the
-    // target scoperef inside the current container.
-    // NOLINTNEXTLINE(misc-no-recursion)
-    LogicalResult tunnelDispatch(InstanceGraphNode *currentContainer,
-                                 llvm::ArrayRef<PathStepAttr> path,
-                                 PortRefMapping &mapping) {
-      auto currentStep = path.front();
-      PortRefMapping targetValue;
-      path = path.drop_front();
-      if (currentStep.getDirection() == PathDirection::Parent) {
-        auto upRes = tunnelUp(currentContainer, path, mapping);
-        if (failed(upRes))
-          return failure();
-      } else {
-        auto tunnelInto = currentStep.getChild();
-        auto downRes = tunnelDown(currentContainer, tunnelInto, path, mapping);
-        if (failed(downRes))
-          return failure();
-      }
-      return success();
-    }
-
-    // "Port forwarding" check - ibis.get_port specifies the intended
-    // direction which a port is accessed by from within the hierarchy.
-    // If the intended direction is not the same as the actual port
-    // direction, we need to insert a wire to flip the direction of the
-    // mapped port.
-    Value portForwardIfNeeded(PortOpInterface actualPort, PortInfo &portInfo) {
-      ibis::Direction actualDir =
-          actualPort.getPort().getType().cast<PortRefType>().getDirection();
-      ibis::Direction requestedDir = portInfo.requestedDirection();
-
-      // Match - just return the port itself.
-      if (actualDir == requestedDir)
-        return actualPort.getPort();
-
-      // Mismatch...
-      OpBuilder::InsertionGuard guard(rewriter);
-      rewriter.setInsertionPointAfter(actualPort);
-
-      // If the requested direction was an input, this means that someone tried
-      // to write to an output port. We need to insert an ibis.wire.input that
-      // provides a writeable input port, and assign the wire output to the
-      // output port.
-      if (requestedDir == Direction::Input) {
-        auto wireOp = rewriter.create<ibis::InputWireOp>(
-            op.getLoc(),
-            rewriter.getStringAttr(actualPort.getPortName().strref() + ".wr"),
-            portInfo.getInnerType());
-
-        rewriter.create<ibis::PortWriteOp>(op.getLoc(), actualPort.getPort(),
-                                           wireOp.getOutput());
-        return wireOp.getPort();
-      }
-
-      // If the requested direction was an output, this means that someone tried
-      // to read from an input port. We need to insert an ibis.wire.output that
-      // provides a readable output port, and read the input port as the value
-      // of the wire.
-      Value inputValue =
-          rewriter.create<ibis::PortReadOp>(op.getLoc(), actualPort.getPort());
-      auto wireOp = rewriter.create<ibis::OutputWireOp>(
-          op.getLoc(),
-          rewriter.getStringAttr(actualPort.getPortName().strref() + ".rd"),
-          inputValue);
-      return wireOp.getPort();
-    }
-
-    // Tunnels up relative to the current container. This will write to the
-    // target input port of the current container from any parent
-    // (instantiating) containers, and return the value of the target scoperef
-    // inside the current container.
-    // NOLINTNEXTLINE(misc-no-recursion)
-    LogicalResult tunnelUp(InstanceGraphNode *currentContainer,
-                           llvm::ArrayRef<PathStepAttr> path,
-                           PortRefMapping &portMapping) {
-      auto scopeOp = currentContainer->getModule<ScopeOpInterface>();
-      if (currentContainer->noUses())
-        return op->emitOpError()
-               << "cannot tunnel up from " << scopeOp.getScopeName()
-               << " because it has no uses";
-
-      for (auto *use : currentContainer->uses()) {
-        auto *parentScopeNode = ig.lookup(use->getParent()->getModule());
-        auto parentScope = parentScopeNode->getModule<ScopeOpInterface>();
-        PortRefMapping targetPortMapping;
-        if (path.empty()) {
-          // Tunneling ended with a 'parent' step - all of the requested ports
-          // should be available right here in the parent scope.
-          for (auto [sym, portInfo] : portInfos) {
-            auto portLikeOp = parentScope.lookupPort(sym.strref());
-            if (!portLikeOp)
-              return op->emitOpError()
-                     << "expected a port named " << sym << " in "
-                     << parentScope.getScopeName() << " but found none";
-
-            // "Port forwarding" check - see comment in portForwardIfNeeded.
-            targetPortMapping[sym] = portForwardIfNeeded(portLikeOp, portInfo);
-          }
-        } else {
-          // recurse into the parents, which will define the target value that
-          // we can write to the input port of the current container instance.
-          if (failed(tunnelDispatch(parentScopeNode, path, targetPortMapping)))
-            return failure();
-        }
-
-        auto instance = use->getInstance<ContainerInstanceOp>();
-        rewriter.setInsertionPointAfter(instance);
-        for (auto [sym, portInfo] : portInfos) {
-
-          auto getPortOp = rewriter.create<GetPortOp>(
-              op.getLoc(), instance, portInfo.portName, portInfo.getType(),
-              Direction::Input);
-          rewriter.create<PortWriteOp>(op.getLoc(), getPortOp,
-                                       targetPortMapping[sym]);
-        }
-      }
-
-      // Create input ports for the requested portrefs.
-      rewriter.setInsertionPointToEnd(scopeOp.getBodyBlock());
-      for (auto [sym, portInfo] : portInfos) {
-        auto inputPort = rewriter.create<InputPortOp>(
-            op.getLoc(), portInfo.portName, portInfo.getType());
-        // Read the input port of the current container to forward the portref.
-
-        portMapping[sym] =
-            rewriter.create<PortReadOp>(op.getLoc(), inputPort.getResult())
-                .getResult();
-      }
-
-      return success();
-    }
-
-    // Tunnels down relative to the current container, and returns the value of
-    // the target scoperef inside the current container.
-    // NOLINTNEXTLINE(misc-no-recursion)
-    LogicalResult tunnelDown(InstanceGraphNode *currentContainer,
-                             FlatSymbolRefAttr tunnelInto,
-                             llvm::ArrayRef<PathStepAttr> path,
-                             PortRefMapping &portMapping) {
-      // Locate the instance that we're tunneling into
-      auto scopeOp = currentContainer->getModule<ScopeOpInterface>();
-      auto *tunnelInstanceOp = SymbolTable::lookupSymbolIn(scopeOp, tunnelInto);
-      if (!tunnelInstanceOp)
-        return op->emitOpError()
-               << "expected an instance named " << tunnelInto << " in "
-               << scopeOp.getScopeName() << " but found none";
-      auto tunnelInstance = cast<ContainerInstanceOp>(tunnelInstanceOp);
-
-      if (path.empty()) {
-        // Tunneling ended with a 'child' step - create get_ports of all of the
-        // requested ports.
-        rewriter.setInsertionPointAfter(tunnelInstance);
-        for (auto [sym, portInfo] : portInfos) {
-          auto targetGetPortOp = rewriter.create<GetPortOp>(
-              op.getLoc(), portInfo.getType(), tunnelInstance, sym);
-          portMapping[sym] = targetGetPortOp.getResult();
-        }
-        return success();
-      }
-
-      // We're not in the target, but tunneling into a child instance.
-      // Create output ports in the child instance for the requested ports.
-      auto *tunnelScopeNode = ig.lookup(ig.getReferencedModule(
-          cast<InstanceOpInterface>(tunnelInstance.getOperation())));
-      auto tunnelScope = tunnelScopeNode->getModule<ScopeOpInterface>();
-
-      rewriter.setInsertionPointToEnd(tunnelScope.getBodyBlock());
-      llvm::DenseMap<StringAttr, OutputPortOp> outputPortOps;
-      for (auto [sym, portInfo] : portInfos) {
-        outputPortOps[sym] = rewriter.create<OutputPortOp>(
-            op.getLoc(), portInfo.portName, portInfo.getType());
-      }
-
-      // Recurse into the tunnel instance container.
-      PortRefMapping childMapping;
-      if (failed(tunnelDispatch(tunnelScopeNode, path, childMapping)))
-        return failure();
-
-      for (auto [sym, res] : childMapping) {
-        auto &portInfo = portInfos[sym];
-
-        // Write the target value to the output port.
-        rewriter.setInsertionPointToEnd(tunnelScope.getBodyBlock());
-        rewriter.create<PortWriteOp>(op.getLoc(), outputPortOps[sym], res);
-
-        // Back in the current container, read the new output port of the child
-        // instance and assign it to the port mapping.
-        rewriter.setInsertionPointAfter(tunnelInstance);
-        auto getPortOp = rewriter.create<GetPortOp>(
-            op.getLoc(), tunnelInstance, portInfo.portName, portInfo.getType(),
-            Direction::Output);
-        portMapping[sym] =
-            rewriter.create<PortReadOp>(op.getLoc(), getPortOp).getResult();
-      }
-
-      return success();
-    }
-
-    // Generates names for the port refs to be created.
-    void genPortNames() {
-      std::string pathName;
-      llvm::raw_string_ostream ss(pathName);
-      llvm::interleave(
-          op.getPathAsRange(), ss,
-          [&](PathStepAttr step) {
-            if (step.getDirection() == PathDirection::Parent)
-              ss << "p"; // use 'p' instead of 'parent' to avoid long SSA names.
-            else
-              ss << step.getChild().getValue();
-          },
-          "_");
-
-      for (auto &[sym, portInfo] : portInfos) {
-        portInfo.portName =
-            rewriter.getStringAttr(pathName + "_" + sym.getValue());
-      }
-    }
-  };
-
 protected:
-  igraph::InstanceGraph &ig;
+  InstanceGraph &ig;
 };
 
 struct TunnelingPass : public IbisTunnelingBase<TunnelingPass> {
@@ -345,7 +367,7 @@ struct TunnelingPass : public IbisTunnelingBase<TunnelingPass> {
 } // anonymous namespace
 
 void TunnelingPass::runOnOperation() {
-  auto &ig = getAnalysis<igraph::InstanceGraph>();
+  auto &ig = getAnalysis<InstanceGraph>();
   auto *ctx = &getContext();
   ConversionTarget target(*ctx);
   target.addIllegalOp<PathOp>();

--- a/test/Dialect/Ibis/Transforms/scoperef_tunneling.mlir
+++ b/test/Dialect/Ibis/Transforms/scoperef_tunneling.mlir
@@ -1,0 +1,191 @@
+// RUN: circt-opt --split-input-file --ibis-tunneling %s | FileCheck %s
+
+ibis.container @C {
+  %this = ibis.this @C
+  %in = ibis.port.input @in : i1
+%out = ibis.port.output @out : i1
+}
+
+// CHECK-LABEL:   ibis.container @AccessChild {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @AccessChild
+// CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c, @C
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.get_port %[[VAL_1]], @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
+// CHECK-NEXT:         }
+
+ibis.container @AccessChild {
+  %this = ibis.this @AccessChild
+  %c = ibis.container.instance @c, @C
+  %c_ref = ibis.path [
+    #ibis.step<child , @c : !ibis.scoperef<@C>>
+  ]
+  %c_in = ibis.get_port %c_ref, @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
+  %c_out = ibis.get_port %c_ref, @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+}
+
+// -----
+
+ibis.container @C {
+  %this = ibis.this @C
+  %in = ibis.port.input @in : i1
+  %out = ibis.port.output @out : i1
+}
+
+// CHECK-LABEL:   ibis.container @AccessSibling {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @AccessSibling
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_b_out : !ibis.portref<out i1>
+// CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.input @p_b_in : !ibis.portref<in i1>
+// CHECK:           %[[VAL_4:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:         }
+ibis.container @AccessSibling {
+  %this = ibis.this @AccessSibling
+  %sibling = ibis.path [
+    #ibis.step<parent : !ibis.scoperef>,
+    #ibis.step<child , @b : !ibis.scoperef<@C>>
+  ]
+  %c_in = ibis.get_port %sibling, @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
+  %c_out = ibis.get_port %sibling, @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+}
+
+// CHECK-LABEL:   ibis.container @Parent {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @Parent
+// CHECK:           %[[VAL_1:.*]] = ibis.container.instance @a, @AccessSibling
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_b_out : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_3:.*]] : !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @p_b_in : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_5:.*]] : !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           %[[VAL_6:.*]] = ibis.container.instance @b, @C
+// CHECK:           %[[VAL_3]] = ibis.get_port %[[VAL_6]], @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+// CHECK:           %[[VAL_5]] = ibis.get_port %[[VAL_6]], @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
+// CHECK:         }
+ibis.container @Parent {
+  %this = ibis.this @Parent
+  %a = ibis.container.instance @a, @AccessSibling
+  %b = ibis.container.instance @b, @C
+}
+
+// -----
+
+// "Full"/recursive case.
+// C1 child -> P1 parent -> P2 parent -> C2 child -> C3 child
+
+// CHECK-LABEL:   ibis.container @C1 {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @C1
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_p_c2_c3_out : !ibis.portref<out i1>
+// CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.input @p_p_c2_c3_in : !ibis.portref<in i1>
+// CHECK:           %[[VAL_4:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:         }
+ibis.container @C1 {
+  %this = ibis.this @C1
+  %c3 = ibis.path [
+    #ibis.step<parent : !ibis.scoperef>,
+    #ibis.step<parent : !ibis.scoperef>,
+    #ibis.step<child , @c2 : !ibis.scoperef>,
+    #ibis.step<child , @c3 : !ibis.scoperef<@C>>
+  ]
+  %c_in = ibis.get_port %c3, @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
+  %c_out = ibis.get_port %c3, @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+}
+
+// CHECK-LABEL:   ibis.container @C2 {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @C2
+// CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c3, @C
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.get_port %[[VAL_1]], @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
+// CHECK:           %[[VAL_4:.*]] = ibis.port.output @p_p_c2_c3_out : !ibis.portref<out i1>
+// CHECK:           %[[VAL_5:.*]] = ibis.port.output @p_p_c2_c3_in : !ibis.portref<in i1>
+// CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_2]] : !ibis.portref<out !ibis.portref<out i1>>
+// CHECK:           ibis.port.write %[[VAL_5]], %[[VAL_3]] : !ibis.portref<out !ibis.portref<in i1>>
+// CHECK:         }
+ibis.container @C2 {
+  %this = ibis.this @C2
+  %c3 = ibis.container.instance @c3, @C
+}
+
+ibis.container @C {
+  %this = ibis.this @C
+  %in = ibis.port.input @in : i1
+  %out = ibis.port.output @out : i1
+}
+
+// CHECK-LABEL:   ibis.container @P1 {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @P1
+// CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c1, @C1
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_out : !ibis.scoperef<@C1> -> !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_3:.*]] : !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_in : !ibis.scoperef<@C1> -> !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_5:.*]] : !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           %[[VAL_6:.*]] = ibis.port.input @p_p_c2_c3_out : !ibis.portref<out i1>
+// CHECK:           %[[VAL_3]] = ibis.port.read %[[VAL_6]] : !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           %[[VAL_7:.*]] = ibis.port.input @p_p_c2_c3_in : !ibis.portref<in i1>
+// CHECK:           %[[VAL_5]] = ibis.port.read %[[VAL_7]] : !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:         }
+ibis.container @P1 {
+  %this = ibis.this @P1
+  %c1 = ibis.container.instance @c1, @C1
+}
+
+// CHECK-LABEL:   ibis.container @P2 {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @P2
+// CHECK:           %[[VAL_1:.*]] = ibis.container.instance @p1, @P1
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_out : !ibis.scoperef<@P1> -> !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_3:.*]] : !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_in : !ibis.scoperef<@P1> -> !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_5:.*]] : !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           %[[VAL_6:.*]] = ibis.container.instance @c2, @C2
+// CHECK:           %[[VAL_7:.*]] = ibis.get_port %[[VAL_6]], @p_p_c2_c3_in : !ibis.scoperef<@C2> -> !ibis.portref<out !ibis.portref<in i1>>
+// CHECK:           %[[VAL_5]] = ibis.port.read %[[VAL_7]] : !ibis.portref<out !ibis.portref<in i1>>
+// CHECK:           %[[VAL_8:.*]] = ibis.get_port %[[VAL_6]], @p_p_c2_c3_out : !ibis.scoperef<@C2> -> !ibis.portref<out !ibis.portref<out i1>>
+// CHECK:           %[[VAL_3]] = ibis.port.read %[[VAL_8]] : !ibis.portref<out !ibis.portref<out i1>>
+// CHECK:         }
+ibis.container @P2 {
+  %this = ibis.this @P2
+  %p1 = ibis.container.instance @p1, @P1
+  %c2 = ibis.container.instance @c2, @C2
+}
+
+// -----
+
+// CHECK-LABEL:   ibis.container @AccessParent {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @AccessParent
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_out : !ibis.portref<in i1>
+// CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.input @p_in : !ibis.portref<out i1>
+// CHECK:           %[[VAL_4:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:         }
+ibis.container @AccessParent {
+  %this = ibis.this @AccessParent
+  %p = ibis.path [
+    #ibis.step<parent : !ibis.scoperef<@Parent>>
+  ]
+
+  // get_port states the intended usage of the port. Hence we should be able to
+  // request a parent input port as an output port (readable), and vice versa.
+  // This will insert wires in the target container to facilitate the direction
+  // flip.
+  %p_in_ref = ibis.get_port %p, @in : !ibis.scoperef<@Parent> -> !ibis.portref<out i1>
+  %p_out_ref = ibis.get_port %p, @out : !ibis.scoperef<@Parent> -> !ibis.portref<in i1>
+}
+
+// CHECK-LABEL:   ibis.container @Parent {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @Parent
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input @in : i1
+// CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.wire.output @in.rd, %[[VAL_2]] : i1
+// CHECK:           %[[VAL_4:.*]] = ibis.port.output @out : i1
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = ibis.wire.input @out.wr : i1
+// CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_6]] : !ibis.portref<out i1>
+// CHECK:           %[[VAL_7:.*]] = ibis.container.instance @c, @AccessParent
+// CHECK:           %[[VAL_8:.*]] = ibis.get_port %[[VAL_7]], @p_out : !ibis.scoperef<@AccessParent> -> !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           ibis.port.write %[[VAL_8]], %[[VAL_5]] : !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           %[[VAL_9:.*]] = ibis.get_port %[[VAL_7]], @p_in : !ibis.scoperef<@AccessParent> -> !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           ibis.port.write %[[VAL_9]], %[[VAL_3]] : !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:         }
+ibis.container @Parent {
+  %this = ibis.this @Parent
+  %in = ibis.port.input @in : i1
+  %out = ibis.port.output @out : i1
+  %c = ibis.container.instance @c, @AccessParent
+}

--- a/test/Dialect/Ibis/Transforms/tunneling_errors.mlir
+++ b/test/Dialect/Ibis/Transforms/tunneling_errors.mlir
@@ -1,0 +1,40 @@
+// RUN: circt-opt --split-input-file --allow-unregistered-dialect --ibis-tunneling --verify-diagnostics %s
+
+ibis.container @Parent {
+  %this = ibis.this @Parent
+  %in = ibis.port.input @in : i1
+}
+
+ibis.container @Orphan {
+  %this = ibis.this @Orphan
+  // expected-error @+2 {{'ibis.path' op cannot tunnel up from "Orphan" because it has no uses}}
+  // expected-error @+1 {{failed to legalize operation 'ibis.path' that was explicitly marked illegal}}
+  %parent = ibis.path [
+    #ibis.step<parent : !ibis.scoperef<@Parent>>
+  ]
+
+  %p = ibis.get_port %parent, @in : !ibis.scoperef<@Parent> -> !ibis.portref<in i1>
+}
+
+// -----
+
+ibis.container @Parent {
+  %this = ibis.this @Parent
+  %mc = ibis.container.instance @mc, @MissingChild
+}
+
+ibis.container @Child {
+  %this = ibis.this @Child
+  %in = ibis.port.input @in : i1
+}
+
+ibis.container @MissingChild {
+  %this = ibis.this @MissingChild
+  // expected-error @+2 {{'ibis.path' op expected an instance named @c in "Parent" but found none}}
+  // expected-error @+1 {{failed to legalize operation 'ibis.path' that was explicitly marked illegal}}
+  %parent = ibis.path [
+    #ibis.step<parent : !ibis.scoperef>,
+    #ibis.step<child , @c : !ibis.scoperef<@Child>>
+  ]
+  %p = ibis.get_port %parent, @in : !ibis.scoperef<@Child> -> !ibis.portref<in i1>
+}


### PR DESCRIPTION
 Tunnels relative `get_port` ops through the module hierarchy, based on `ibis.path` ops. The result of this pass is that various new in- and output ports of `!ibis.portref<...>` type are created. After this pass, `get_port` ops should only exist at the same scope of container instantiations.