### PR TITLE
[Ibis] Add portref lowering pass

### DIFF
--- a/docs/Dialects/Ibis/RationaleIbis.md
+++ b/docs/Dialects/Ibis/RationaleIbis.md
@@ -1,0 +1,27 @@
+# `ibis` Dialect Rationale
+
+## Lowering flow
+
+1. Containerization:
+  At this level, one may have relative references to ports `get_port` accesses
+  to `!ibis.scoperef`s
+2. Tunneling:
+  Relative `!ibis.scoperef` references are defined via `ibis.path` operations.
+  In this pass, we lower `ibis.path` operations by tunneling `portref`s through
+  the instance hierarchy, based on the `get_port` operations that were present
+  in the various containers. After this, various `portref<in portref<#dir, T>>`
+  ports are present in the design, which represents the actual ports that are
+  being passed around.
+3. `portref` lowering
+  Next, we need to convert `portref<in portref<#dir, T>>`-typed ports into
+  `T` typed in- or output ports. We do this by analyzing how a portref is used
+  inside a container, and then creating an in- or output port based on that.
+  That is:
+  - write to `portref<in portref<in, T>>` becomes `out T`
+  - read from `portref<in portref<out, T>>` becomes `in T`
+  - write to `portref<out portref<out, T>>` becomes `out T` (a port reference inside the module will be driven by a value from the outside)
+  - read from `portref<out portref<in, T>>` becomes `in T` (a port reference inside the module will be driven by a value from the outside)
+4. Removal of self-driving inputs:
+  In cases where children drive parent ports, the prior case may create situations where a container drives its own input ports (and by extension, no other instantiating container is expected to drive that port of the instance, if the IR is correct). We thus run `ibis-clean-selfdrivers` to replace these self-driven ports by the actual values that are being driven into them.
+5. HW lowering:
+  At this point, there no longer exist any relative references in the Ibis IR, and all instantiations should (if the IR is correct) have all of their inputs driven. This means that we can now lower the IR to `hw.module`s.

--- a/docs/Dialects/Ibis/RationaleIbis.md
+++ b/docs/Dialects/Ibis/RationaleIbis.md
@@ -19,9 +19,17 @@
   That is:
   - write to `portref<in portref<in, T>>` becomes `out T`
   - read from `portref<in portref<out, T>>` becomes `in T`
-  - write to `portref<out portref<out, T>>` becomes `out T` (a port reference inside the module will be driven by a value from the outside)
-  - read from `portref<out portref<in, T>>` becomes `in T` (a port reference inside the module will be driven by a value from the outside)
+  - write to `portref<out portref<out, T>>` becomes `out T` (a port reference
+    inside the module will be driven by a value from the outside)
+  - read from `portref<out portref<in, T>>` becomes `in T` (a port reference
+    inside the module will be driven by a value from the outside)
 4. Removal of self-driving inputs:
-  In cases where children drive parent ports, the prior case may create situations where a container drives its own input ports (and by extension, no other instantiating container is expected to drive that port of the instance, if the IR is correct). We thus run `ibis-clean-selfdrivers` to replace these self-driven ports by the actual values that are being driven into them.
+  In cases where children drive parent ports, the prior case may create
+  situations where a container drives its own input ports (and by extension, no
+  other instantiating container is expected to drive that port of the instance,
+  if the IR is correct). We thus run `ibis-clean-selfdrivers` to replace these
+  self-driven ports by the actual values that are being driven into them.
 5. HW lowering:
-  At this point, there no longer exist any relative references in the Ibis IR, and all instantiations should (if the IR is correct) have all of their inputs driven. This means that we can now lower the IR to `hw.module`s.
+  At this point, there no longer exist any relative references in the Ibis IR,
+  and all instantiations should (if the IR is correct) have all of their inputs
+  driven. This means that we can now lower the IR to `hw.module`s.

--- a/docs/Dialects/Ibis/_index.md
+++ b/docs/Dialects/Ibis/_index.md
@@ -1,0 +1,3 @@
+# 'ibis' Dialect
+
+[include "Dialects/Ibis.md"]

--- a/include/circt/Dialect/Ibis/IbisPasses.h
+++ b/include/circt/Dialect/Ibis/IbisPasses.h
@@ -20,6 +20,7 @@ namespace ibis {
 std::unique_ptr<Pass> createCallPrepPass();
 std::unique_ptr<Pass> createContainerizePass();
 std::unique_ptr<Pass> createTunnelingPass();
+std::unique_ptr<Pass> createPortrefLoweringPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Ibis/IbisPasses.td
+++ b/include/circt/Dialect/Ibis/IbisPasses.td
@@ -39,4 +39,32 @@ def IbisTunneling : Pass<"ibis-tunneling", "mlir::ModuleOp"> {
   let constructor = "circt::ibis::createTunnelingPass()";
 }
 
+def IbisPortrefLowering : Pass<"ibis-lower-portrefs", "mlir::ModuleOp"> {
+  let summary = "Ibis portref lowering pass";
+  let description = [{
+    Lower `ibis.portref<portref <T>>` to T (i.e. portref resolution).
+
+    We do this by analyzing how a portref is used
+    inside a container, and then creating an in- or output port based on that.
+    That is:
+    - write to `portref<in portref<in, T>>` becomes `out T`
+        i.e this container wants to write to an input of another container, hence
+        it will produce an output value that will drive that input port.
+    - read from `portref<in portref<out, T>>` becomes `in T`
+        i.e. this container wants to read from an output of another container,
+        hence it will have an input port that will be driven by that output port.
+    - write to `portref<out portref<out, T>>` becomes `out T`
+        i.e. a port reference inside the module will be driven by a value from
+        the outside.
+    - read from `portref<out portref<in, T>>` becomes `in T`
+        i.e. a port reference inside the module will be driven by a value from
+        the outside.
+
+    A benefit of having portref lowering separate from portref tunneling is that
+    portref lowering can be done on an `ibis.container` granularity, allowing
+    for a bit of parallelism in the flow.
+  }];
+  let constructor = "circt::ibis::createPortrefLoweringPass()";
+}
+
 #endif // CIRCT_DIALECT_IBIS_PASSES_TD

--- a/lib/Dialect/Ibis/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Ibis/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_circt_dialect_library(CIRCTIbisTransforms
   IbisCallPrep.cpp
   IbisContainerize.cpp
   IbisTunneling.cpp
+  IbisPortrefLowering.cpp
 
   DEPENDS
   CIRCTIbisTransformsIncGen

--- a/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
@@ -73,7 +73,7 @@ public:
           op.getLoc(), op.getPortName(), innerType);
 
       // Replace writes to the unwrapped port with writes to the new port.
-      for (auto unwrappedPortUser :
+      for (auto *unwrappedPortUser :
            llvm::make_early_inc_range(portUnwrapper.getResult().getUsers())) {
         PortWriteOp portWriter = dyn_cast<PortWriteOp>(unwrappedPortUser);
         if (!portWriter || portWriter.getPort() != portUnwrapper.getResult())
@@ -90,7 +90,7 @@ public:
       rewriter.replaceAllUsesWith(portUnwrapper.getResult(), rawInput);
 
       // Replace all ibis.port.read ops with a read of the new input.
-      for (auto portUser :
+      for (auto *portUser :
            llvm::make_early_inc_range(portUnwrapper.getResult().getUsers())) {
         PortReadOp portReader = dyn_cast<PortReadOp>(portUser);
         if (!portReader || portReader.getPort() != portUnwrapper.getResult())
@@ -123,7 +123,7 @@ public:
     // Locate the portwrapper - this is a writeOp with the output portref as
     // the portref value.
     PortWriteOp portWrapper;
-    for (auto user : op.getResult().getUsers()) {
+    for (auto *user : op.getResult().getUsers()) {
       portWrapper = dyn_cast<PortWriteOp>(user);
       if (portWrapper && portWrapper.getPort() == op.getResult())
         break;
@@ -184,7 +184,7 @@ class GetPortConversionPattern : public PortLoweringPattern<GetPortOp> {
       // Locate the get_port wrapper - this is a WriteOp with the get_port
       // result as the portref value.
       PortWriteOp getPortWrapper;
-      for (auto user : op.getResult().getUsers()) {
+      for (auto *user : op.getResult().getUsers()) {
         auto writeOp = dyn_cast<PortWriteOp>(user);
         if (!writeOp || writeOp.getPort() != op.getResult())
           continue;
@@ -218,7 +218,7 @@ class GetPortConversionPattern : public PortLoweringPattern<GetPortOp> {
       }
     } else {
       PortReadOp getPortUnwrapper;
-      for (auto user : op.getResult().getUsers()) {
+      for (auto *user : op.getResult().getUsers()) {
         auto readOp = dyn_cast<PortReadOp>(user);
         if (!readOp || readOp.getPort() != op.getResult())
           continue;
@@ -247,7 +247,7 @@ class GetPortConversionPattern : public PortLoweringPattern<GetPortOp> {
         // We then replace the whole structure above with simply writing the
         // driving value to the actual input port of the container.
         PortWriteOp portDriver;
-        for (auto user : getPortUnwrapper.getResult().getUsers()) {
+        for (auto *user : getPortUnwrapper.getResult().getUsers()) {
           auto writeOp = dyn_cast<PortWriteOp>(user);
           if (!writeOp || writeOp.getPort() != getPortUnwrapper.getResult())
             continue;

--- a/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
@@ -35,20 +35,19 @@ public:
     Type innerType = innerPortRefType.getPortType();
     Direction d = innerPortRefType.getDirection();
 
-    // Canonical form check - canonicalization should have ensured that only
-    // a single port unwrapper was present, so if this is not the case, the
-    // user should run canonicalization. This goes for other assumptions in the
-    // following code - we require a canonical form to avoid having to deal
-    // with a bunch of edge cases.
+    // CSE check - CSE should have ensured that only a single port unwrapper was
+    // present, so if this is not the case, the user should run
+    // CSE. This goes for other assumptions in the following code -
+    // we require a CSEd form to avoid having to deal with a bunch of edge
+    // cases.
     auto portrefUsers = op.getResult().getUsers();
     size_t nPortrefUsers =
         std::distance(portrefUsers.begin(), portrefUsers.end());
     if (nPortrefUsers != 1)
       return rewriter.notifyMatchFailure(
           op, "expected a single ibis.port.read as the only user of the input "
-              "port reference, but found multiple. This indicates that the IR "
-              "was not in a canonical form - please run canonicalization prior "
-              "to this pass");
+              "port reference, but found multiple readers - please run CSE "
+              "prior to this pass");
 
     // A single PortReadOp should be present, which unwraps the portref<portref>
     // into a portref.
@@ -278,7 +277,7 @@ class GetPortConversionPattern : public OpConversionPattern<GetPortOp> {
         // 1. a read op which unwraps the portref<out portref<in T>> into a
         //    portref<in T>
         //      %r = ibis.port.read %rr : !ibis.portref<out !ibis.portref<in T>>
-        // 2. one (or multiple, if not in canonical form)
+        // 2. one (or multiple, if not CSEd)
         //
         // We then replace the read op with the actual output port of the
         // container.

--- a/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
@@ -66,6 +66,7 @@ public:
               "port reference");
 
     // Replace the inner portref + port access with a "raw" port.
+    OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPoint(op);
     if (d == Direction::Input) {
       // references to inputs becomes outputs (write from this container)
@@ -133,6 +134,7 @@ public:
       return rewriter.notifyMatchFailure(
           op, "expected an ibis.port.write to wrap the output portref");
 
+    OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPoint(op);
     if (d == Direction::Input) {
       // Outputs of inputs are inputs (external driver into this container).
@@ -178,6 +180,7 @@ class GetPortConversionPattern : public PortLoweringPattern<GetPortOp> {
 
     StringAttr portName = op.getPortSymbolAttr().getAttr();
 
+    OpBuilder::InsertionGuard g(rewriter);
     rewriter.setInsertionPoint(op);
     Operation *wrapper;
     if (outerDirection == Direction::Input) {

--- a/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
@@ -1,0 +1,337 @@
+//===- IbisPortrefLowering.cpp - Implementation of PortrefLowering --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+#include "circt/Dialect/Ibis/IbisDialect.h"
+#include "circt/Dialect/Ibis/IbisOps.h"
+#include "circt/Dialect/Ibis/IbisPasses.h"
+#include "circt/Dialect/Ibis/IbisTypes.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace ibis;
+
+namespace {
+
+template <typename TPort>
+class PortLoweringPattern : public OpConversionPattern<TPort> {
+public:
+  PortLoweringPattern(MLIRContext *context)
+      : OpConversionPattern<TPort>(context) {}
+};
+
+class InputPortConversionPattern : public PortLoweringPattern<InputPortOp> {
+public:
+  using PortLoweringPattern::PortLoweringPattern;
+  using OpAdaptor = typename PortLoweringPattern<InputPortOp>::OpAdaptor;
+
+  LogicalResult
+  matchAndRewrite(InputPortOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    PortRefType innerPortRefType = op.getType().cast<PortRefType>();
+    Type innerType = innerPortRefType.getPortType();
+    Direction d = innerPortRefType.getDirection();
+
+    // Canonical form check - canonicalization should have ensured that only
+    // a single port unwrapper was present, so if this is not the case, the
+    // user should run canonicalization. This goes for other assumptions in the
+    // following code - we require a canonical form to avoid having to deal
+    // with a bunch of edge cases.
+    auto portrefUsers = op.getResult().getUsers();
+    size_t nPortrefUsers =
+        std::distance(portrefUsers.begin(), portrefUsers.end());
+    if (nPortrefUsers != 1)
+      return rewriter.notifyMatchFailure(
+          op, "expected a single ibis.port.read as the only user of the input "
+              "port reference, but found multiple. This indicates that the IR "
+              "was not in a canonical form - please run canonicalization prior "
+              "to this pass");
+
+    // A single PortReadOp should be present, which unwraps the portref<portref>
+    // into a portref.
+    PortReadOp portUnwrapper = dyn_cast<PortReadOp>(*portrefUsers.begin());
+    if (!portUnwrapper)
+      return rewriter.notifyMatchFailure(
+          op, "expected a single ibis.port.read as the only user of the input "
+              "port reference");
+
+    // Replace the inner portref + port access with a "raw" port.
+    rewriter.setInsertionPoint(op);
+    if (d == Direction::Input) {
+      // references to inputs becomes outputs (write from this container)
+      auto rawOutput = rewriter.create<OutputPortOp>(
+          op.getLoc(), op.getPortName(), innerType);
+
+      // Replace writes to the unwrapped port with writes to the new port.
+      for (auto unwrappedPortUser :
+           llvm::make_early_inc_range(portUnwrapper.getResult().getUsers())) {
+        PortWriteOp portWriter = dyn_cast<PortWriteOp>(unwrappedPortUser);
+        if (!portWriter || portWriter.getPort() != portUnwrapper.getResult())
+          continue;
+
+        // Replace the source port of the write op with the new port.
+        rewriter.replaceOpWithNewOp<PortWriteOp>(portWriter, rawOutput,
+                                                 portWriter.getValue());
+      }
+    } else {
+      // References to outputs becomes inputs (read from this container)
+      auto rawInput = rewriter.create<InputPortOp>(op.getLoc(),
+                                                   op.getPortName(), innerType);
+      rewriter.replaceAllUsesWith(portUnwrapper.getResult(), rawInput);
+
+      // Replace all ibis.port.read ops with a read of the new input.
+      for (auto portUser :
+           llvm::make_early_inc_range(portUnwrapper.getResult().getUsers())) {
+        PortReadOp portReader = dyn_cast<PortReadOp>(portUser);
+        if (!portReader || portReader.getPort() != portUnwrapper.getResult())
+          continue;
+
+        rewriter.replaceOpWithNewOp<PortReadOp>(portReader, rawInput);
+      }
+    }
+
+    // Finally, remove the port unwrapper and the original input port.
+    rewriter.eraseOp(portUnwrapper);
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+};
+
+class OutputPortConversionPattern : public PortLoweringPattern<OutputPortOp> {
+public:
+  using PortLoweringPattern::PortLoweringPattern;
+  using OpAdaptor = typename PortLoweringPattern<OutputPortOp>::OpAdaptor;
+
+  LogicalResult
+  matchAndRewrite(OutputPortOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    PortRefType innerPortRefType = op.getType().cast<PortRefType>();
+    Type innerType = innerPortRefType.getPortType();
+    Direction d = innerPortRefType.getDirection();
+
+    // Locate the portwrapper - this is a writeOp with the output portref as
+    // the portref value.
+    PortWriteOp portWrapper;
+    for (auto user : op.getResult().getUsers()) {
+      portWrapper = dyn_cast<PortWriteOp>(user);
+      if (portWrapper && portWrapper.getPort() == op.getResult())
+        break;
+    }
+
+    if (!portWrapper)
+      return rewriter.notifyMatchFailure(
+          op, "expected an ibis.port.write to wrap the output portref");
+
+    rewriter.setInsertionPoint(op);
+    if (d == Direction::Input) {
+      // Outputs of inputs are inputs (external driver into this container).
+      // Create the raw input port and write the input port reference with a
+      // read of the raw input port.
+      auto rawInput = rewriter.create<InputPortOp>(op.getLoc(),
+                                                   op.getPortName(), innerType);
+      rewriter.create<PortWriteOp>(
+          op.getLoc(), portWrapper.getValue(),
+          rewriter.create<PortReadOp>(op.getLoc(), rawInput));
+    } else {
+      // Outputs of outputs are outputs (external driver out of this container).
+      // Create the raw output port and do a read of the input port reference.
+      auto rawOutput = rewriter.create<OutputPortOp>(
+          op.getLoc(), op.getPortName(), innerType);
+      rewriter.create<PortWriteOp>(
+          op.getLoc(), rawOutput,
+          rewriter.create<PortReadOp>(op.getLoc(), portWrapper.getValue()));
+    }
+
+    // Finally, remove the port wrapper and the original output port.
+    rewriter.eraseOp(portWrapper);
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+};
+
+class GetPortConversionPattern : public PortLoweringPattern<GetPortOp> {
+  using PortLoweringPattern::PortLoweringPattern;
+  using OpAdaptor = typename PortLoweringPattern<GetPortOp>::OpAdaptor;
+
+  LogicalResult
+  matchAndRewrite(GetPortOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    PortRefType outerPortRefType = op.getType().cast<PortRefType>();
+    PortRefType innerPortRefType =
+        outerPortRefType.getPortType().cast<PortRefType>();
+    Type innerType = innerPortRefType.getPortType();
+
+    Direction outerDirection = outerPortRefType.getDirection();
+    Direction innerDirection = innerPortRefType.getDirection();
+
+    StringAttr portName = op.getPortSymbolAttr().getAttr();
+
+    rewriter.setInsertionPoint(op);
+    Operation *wrapper;
+    if (outerDirection == Direction::Input) {
+      // Locate the get_port wrapper - this is a WriteOp with the get_port
+      // result as the portref value.
+      PortWriteOp getPortWrapper;
+      for (auto user : op.getResult().getUsers()) {
+        auto writeOp = dyn_cast<PortWriteOp>(user);
+        if (!writeOp || writeOp.getPort() != op.getResult())
+          continue;
+
+        getPortWrapper = writeOp;
+        break;
+      }
+
+      if (!getPortWrapper)
+        return rewriter.notifyMatchFailure(
+            op, "expected an ibis.port.write to wrap the get_port result");
+      wrapper = getPortWrapper;
+
+      if (innerDirection == Direction::Input) {
+        // The portref<in portref<in T>> is now an output port.
+        auto newGetPort =
+            rewriter.create<GetPortOp>(op.getLoc(), op.getInstance(), portName,
+                                       innerType, Direction::Output);
+        auto newGetPortVal =
+            rewriter.create<PortReadOp>(op.getLoc(), newGetPort);
+        rewriter.create<PortWriteOp>(op.getLoc(), getPortWrapper.getValue(),
+                                     newGetPortVal);
+      } else {
+        // The portref<in portref<out T>> is now an input port.
+        auto newGetPort =
+            rewriter.create<GetPortOp>(op.getLoc(), op.getInstance(), portName,
+                                       innerType, Direction::Input);
+        auto writeValue =
+            rewriter.create<PortReadOp>(op.getLoc(), getPortWrapper.getValue());
+        rewriter.create<PortWriteOp>(op.getLoc(), newGetPort, writeValue);
+      }
+    } else {
+      PortReadOp getPortUnwrapper;
+      for (auto user : op.getResult().getUsers()) {
+        auto readOp = dyn_cast<PortReadOp>(user);
+        if (!readOp || readOp.getPort() != op.getResult())
+          continue;
+
+        getPortUnwrapper = readOp;
+        break;
+      }
+
+      if (!getPortUnwrapper)
+        return rewriter.notifyMatchFailure(
+            op, "expected an ibis.port.read to unwrap the get_port result");
+      wrapper = getPortUnwrapper;
+
+      if (innerDirection == Direction::Input) {
+        // In this situation, we're retrieving an input port that is sent as an
+        // output of the container: %rr = ibis.get_port %c %c_in :
+        // !ibis.scoperef<...> -> !ibis.portref<out !ibis.portref<in T>>
+        //
+        // Thus we expect two ops to be present:
+        // 1. a read op which unwraps the portref<out portref<in T>> into a
+        // portref<in T>
+        //    %r = ibis.port.read %rr : !ibis.portref<out !ibis.portref<in T>>
+        // 2. A write to %r which drives the input port
+        //    ibis.port.write %r, %someValue : !ibis.portref<in T>
+        //
+        // We then replace the whole structure above with simply writing the
+        // driving value to the actual input port of the container.
+        PortWriteOp portDriver;
+        for (auto user : getPortUnwrapper.getResult().getUsers()) {
+          auto writeOp = dyn_cast<PortWriteOp>(user);
+          if (!writeOp || writeOp.getPort() != getPortUnwrapper.getResult())
+            continue;
+
+          portDriver = writeOp;
+          break;
+        }
+
+        if (!portDriver)
+          return rewriter.notifyMatchFailure(
+              op, "expected an ibis.port.write to drive the unwrapped get_port "
+                  "result");
+
+        auto rawPort =
+            rewriter.create<GetPortOp>(op.getLoc(), op.getInstance(), portName,
+                                       innerType, Direction::Input);
+        rewriter.create<PortWriteOp>(op.getLoc(), rawPort,
+                                     portDriver.getValue());
+        rewriter.eraseOp(portDriver);
+      } else {
+        // In this situation, we're retrieving an output port that is sent as an
+        // output of the container: %rr = ibis.get_port %c %c_in :
+        // !ibis.scoperef<...> -> !ibis.portref<out !ibis.portref<out T>>
+        //
+        // Thus we expect two ops to be present:
+        // 1. a read op which unwraps the portref<out portref<in T>> into a
+        //    portref<in T>
+        //      %r = ibis.port.read %rr : !ibis.portref<out !ibis.portref<in T>>
+        // 2. one (or multiple, if not in canonical form)
+        //
+        // We then replace the read op with the actual output port of the
+        // container.
+        auto rawPort =
+            rewriter.create<GetPortOp>(op.getLoc(), op.getInstance(), portName,
+                                       innerType, Direction::Output);
+        rewriter.replaceAllUsesWith(getPortUnwrapper, rawPort);
+      }
+    }
+
+    // Finally, remove the get_port op.
+    rewriter.eraseOp(wrapper);
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+};
+
+struct PortrefLoweringPass
+    : public IbisPortrefLoweringBase<PortrefLoweringPass> {
+  void runOnOperation() override;
+};
+
+} // anonymous namespace
+
+void PortrefLoweringPass::runOnOperation() {
+  auto *ctx = &getContext();
+  ConversionTarget target(*ctx);
+  target.addIllegalOp<InputPortOp, OutputPortOp>();
+  target.addLegalDialect<IbisDialect>();
+
+  // Ports are legal when they do not have portref types anymore.
+  target.addDynamicallyLegalOp<InputPortOp, OutputPortOp>([&](auto op) {
+    PortRefType portType = cast<PortOpInterface>(op)
+                               .getPort()
+                               .getType()
+                               .template cast<PortRefType>();
+    return !portType.getPortType().isa<PortRefType>();
+  });
+
+  // get_port's are legal when they do not have portref types anymore.
+  target.addDynamicallyLegalOp<GetPortOp>([&](GetPortOp op) {
+    PortRefType portType = op.getPort().getType().cast<PortRefType>();
+    return !portType.getPortType().isa<PortRefType>();
+  });
+
+  RewritePatternSet patterns(ctx);
+  patterns.add<InputPortConversionPattern, OutputPortConversionPattern,
+               GetPortConversionPattern>(ctx);
+
+  if (failed(
+          applyPartialConversion(getOperation(), target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<Pass> circt::ibis::createPortrefLoweringPass() {
+  return std::make_unique<PortrefLoweringPass>();
+}

--- a/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
@@ -23,17 +23,10 @@ using namespace ibis;
 
 namespace {
 
-template <typename TPort>
-class PortLoweringPattern : public OpConversionPattern<TPort> {
+class InputPortConversionPattern : public OpConversionPattern<InputPortOp> {
 public:
-  PortLoweringPattern(MLIRContext *context)
-      : OpConversionPattern<TPort>(context) {}
-};
-
-class InputPortConversionPattern : public PortLoweringPattern<InputPortOp> {
-public:
-  using PortLoweringPattern::PortLoweringPattern;
-  using OpAdaptor = typename PortLoweringPattern<InputPortOp>::OpAdaptor;
+  using OpConversionPattern::OpConversionPattern;
+  using OpAdaptor = typename OpConversionPattern<InputPortOp>::OpAdaptor;
 
   LogicalResult
   matchAndRewrite(InputPortOp op, OpAdaptor adaptor,
@@ -109,10 +102,10 @@ public:
   }
 };
 
-class OutputPortConversionPattern : public PortLoweringPattern<OutputPortOp> {
+class OutputPortConversionPattern : public OpConversionPattern<OutputPortOp> {
 public:
-  using PortLoweringPattern::PortLoweringPattern;
-  using OpAdaptor = typename PortLoweringPattern<OutputPortOp>::OpAdaptor;
+  using OpConversionPattern::OpConversionPattern;
+  using OpAdaptor = typename OpConversionPattern<OutputPortOp>::OpAdaptor;
 
   LogicalResult
   matchAndRewrite(OutputPortOp op, OpAdaptor adaptor,
@@ -163,9 +156,9 @@ public:
   }
 };
 
-class GetPortConversionPattern : public PortLoweringPattern<GetPortOp> {
-  using PortLoweringPattern::PortLoweringPattern;
-  using OpAdaptor = typename PortLoweringPattern<GetPortOp>::OpAdaptor;
+class GetPortConversionPattern : public OpConversionPattern<GetPortOp> {
+  using OpConversionPattern::OpConversionPattern;
+  using OpAdaptor = typename OpConversionPattern<GetPortOp>::OpAdaptor;
 
   LogicalResult
   matchAndRewrite(GetPortOp op, OpAdaptor adaptor,

--- a/test/Dialect/Ibis/Transforms/portref_lowering.mlir
+++ b/test/Dialect/Ibis/Transforms/portref_lowering.mlir
@@ -1,0 +1,238 @@
+// RUN: circt-opt --split-input-file --ibis-lower-portrefs %s | FileCheck %s
+
+ibis.container @C {
+  %this = ibis.this @C 
+  %in = ibis.port.input @in : i1
+  %out = ibis.port.output @out : i1
+}
+
+// CHECK-LABEL:   ibis.container @AccessSibling {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @AccessSibling
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_b_out : i1
+// CHECK:           %[[VAL_2:.*]] = ibis.port.output @p_b_in : i1
+// CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_3:.*]] : !ibis.portref<out i1>
+// CHECK:           %[[VAL_3]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in i1>
+// CHECK:         }
+ibis.container @AccessSibling {
+  %this = ibis.this @AccessSibling 
+  %p_b_out = ibis.port.input @p_b_out : !ibis.portref<out i1>
+  %p_b_out_val = ibis.port.read %p_b_out : !ibis.portref<in !ibis.portref<out i1>>
+  %p_b_in = ibis.port.input @p_b_in : !ibis.portref<in i1>
+  %p_b_in_val = ibis.port.read %p_b_in : !ibis.portref<in !ibis.portref<in i1>>
+
+  // Loopback to ensure that value replacement is performed.
+  %v = ibis.port.read %p_b_out_val : !ibis.portref<out i1>
+  ibis.port.write %p_b_in_val, %v : !ibis.portref<in i1>
+}
+
+// CHECK-LABEL:   ibis.container @Parent {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @Parent
+// CHECK:           %[[VAL_1:.*]] = ibis.container.instance @a, @AccessSibling
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_b_out : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.read %[[VAL_4:.*]] : !ibis.portref<out i1>
+// CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_3]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_5:.*]] = ibis.get_port %[[VAL_1]], @p_b_in : !ibis.scoperef<@AccessSibling> -> !ibis.portref<out i1>
+// CHECK:           %[[VAL_6:.*]] = ibis.port.read %[[VAL_5]] : !ibis.portref<out i1>
+// CHECK:           ibis.port.write %[[VAL_7:.*]], %[[VAL_6]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_8:.*]] = ibis.container.instance @b, @C
+// CHECK:           %[[VAL_4]] = ibis.get_port %[[VAL_8]], @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+// CHECK:           %[[VAL_7]] = ibis.get_port %[[VAL_8]], @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
+// CHECK:         }
+ibis.container @Parent {
+  %this = ibis.this @Parent 
+  %a = ibis.container.instance @a, @AccessSibling 
+  %a.p_b_out = ibis.get_port %a, @p_b_out : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in !ibis.portref<out i1>>
+  ibis.port.write %a.p_b_out, %b.out : !ibis.portref<in !ibis.portref<out i1>>
+  %a.p_b_in = ibis.get_port %a, @p_b_in : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in !ibis.portref<in i1>>
+  ibis.port.write %a.p_b_in, %b.in : !ibis.portref<in !ibis.portref<in i1>>
+  %b = ibis.container.instance @b, @C 
+  %b.out = ibis.get_port %b, @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+  %b.in = ibis.get_port %b, @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
+}
+
+// -----
+
+// CHECK-LABEL:   ibis.container @ParentPortAccess {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @ParentPortAccess
+// CHECK:           %[[VAL_1:.*]] = ibis.port.output @p_in : i1
+// CHECK:           %[[VAL_2:.*]] = ibis.port.input @p_out : i1
+// CHECK:         }
+ibis.container @ParentPortAccess {
+  %this = ibis.this @ParentPortAccess 
+  %p_in = ibis.port.input @p_in : !ibis.portref<in i1>
+  %p_in_val = ibis.port.read %p_in : !ibis.portref<in !ibis.portref<in i1>>
+  %p_out = ibis.port.input @p_out : !ibis.portref<out i1>
+  %p_out_val = ibis.port.read %p_out : !ibis.portref<in !ibis.portref<out i1>>
+}
+
+// CHECK-LABEL:   ibis.container @Parent {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @Parent
+// CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c, @ParentPortAccess
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_in : !ibis.scoperef<@ParentPortAccess> -> !ibis.portref<out i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.read %[[VAL_2]] : !ibis.portref<out i1>
+// CHECK:           ibis.port.write %[[VAL_4:.*]], %[[VAL_3]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_5:.*]] = ibis.get_port %[[VAL_1]], @p_out : !ibis.scoperef<@ParentPortAccess> -> !ibis.portref<in i1>
+// CHECK:           %[[VAL_6:.*]] = ibis.port.read %[[VAL_7:.*]] : !ibis.portref<out i1>
+// CHECK:           ibis.port.write %[[VAL_5]], %[[VAL_6]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_4]] = ibis.port.input @in : i1
+// CHECK:           %[[VAL_7]] = ibis.port.output @out : i1
+// CHECK:         }
+ibis.container @Parent {
+  %this = ibis.this @Parent 
+  %c = ibis.container.instance @c, @ParentPortAccess 
+  %c.p_in = ibis.get_port %c, @p_in : !ibis.scoperef<@ParentPortAccess> -> !ibis.portref<in !ibis.portref<in i1>>
+  ibis.port.write %c.p_in, %in : !ibis.portref<in !ibis.portref<in i1>>
+  %c.p_out = ibis.get_port %c, @p_out : !ibis.scoperef<@ParentPortAccess> -> !ibis.portref<in !ibis.portref<out i1>>
+  ibis.port.write %c.p_out, %out : !ibis.portref<in !ibis.portref<out i1>>
+  %in = ibis.port.input @in : i1
+  %out = ibis.port.output @out : i1
+}
+
+// -----
+
+// C1 child -> P1 parent -> P2 parent -> C2 child -> C3 child
+
+// CHECK-LABEL:   ibis.container @C1 {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @C1
+// CHECK:           %[[VAL_1:.*]] = ibis.port.output @parent_parent_c2_c3_in : i1
+// CHECK:           ibis.port.write %[[VAL_1]], %[[VAL_2:.*]] : !ibis.portref<out i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.input @parent_parent_c2_c3_out : i1
+// CHECK:           %[[VAL_2]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in i1>
+// CHECK:         }
+ibis.container @C1 {
+  %this = ibis.this @C1 
+  %parent_parent_c2_c3_in = ibis.port.input @parent_parent_c2_c3_in : !ibis.portref<in i1>
+  %parent_parent_c2_c3_out = ibis.port.input @parent_parent_c2_c3_out : !ibis.portref<out i1>
+
+  // Assignment drivers - unwrap the ports and roundtrip read-write.
+  %parent_b_in_unwrapped = ibis.port.read %parent_parent_c2_c3_in : !ibis.portref<in !ibis.portref<in i1>>
+  %parent_b_out_unwrapped = ibis.port.read %parent_parent_c2_c3_out : !ibis.portref<in !ibis.portref<out i1>>
+  %parent_b_out_value = ibis.port.read %parent_b_out_unwrapped : !ibis.portref<out i1>
+  ibis.port.write %parent_b_in_unwrapped, %parent_b_out_value : !ibis.portref<in i1>
+}
+
+// CHECK-LABEL:   ibis.container @C2 {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @C2
+// CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c3, @C
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.get_port %[[VAL_1]], @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+// CHECK:           %[[VAL_4:.*]] = ibis.port.input @parent_parent_c2_c3_in : i1
+// CHECK:           %[[VAL_5:.*]] = ibis.port.read %[[VAL_4]] : !ibis.portref<in i1>
+// CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_5]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_6:.*]] = ibis.port.output @parent_parent_c2_c3_out : i1
+// CHECK:           %[[VAL_7:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<out i1>
+// CHECK:           ibis.port.write %[[VAL_6]], %[[VAL_7]] : !ibis.portref<out i1>
+// CHECK:         }
+ibis.container @C2 {
+  %this = ibis.this @C2 
+  %c3 = ibis.container.instance @c3, @C 
+  %c3.in = ibis.get_port %c3, @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
+  %c3.out = ibis.get_port %c3, @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+  %parent_parent_c2_c3_in = ibis.port.output @parent_parent_c2_c3_in : !ibis.portref<in i1>
+  %parent_parent_c2_c3_out = ibis.port.output @parent_parent_c2_c3_out : !ibis.portref<out i1>
+  ibis.port.write %parent_parent_c2_c3_in, %c3.in : !ibis.portref<out !ibis.portref<in i1>>
+  ibis.port.write %parent_parent_c2_c3_out, %c3.out : !ibis.portref<out !ibis.portref<out i1>>
+}
+ibis.container @C {
+  %this = ibis.this @C 
+  %in = ibis.port.input @in : i1
+  %out = ibis.port.output @out : i1
+}
+
+// CHECK-LABEL:   ibis.container @P1 {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @P1
+// CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c1, @C1
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @parent_parent_c2_c3_in : !ibis.scoperef<@C1> -> !ibis.portref<out i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.read %[[VAL_2]] : !ibis.portref<out i1>
+// CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @parent_parent_c2_c3_out : !ibis.scoperef<@C1> -> !ibis.portref<in i1>
+// CHECK:           %[[VAL_5:.*]] = ibis.port.read %[[VAL_6:.*]] : !ibis.portref<in i1>
+// CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_5]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_7:.*]] = ibis.port.output @parent_parent_c2_c3_in : i1
+// CHECK:           ibis.port.write %[[VAL_7]], %[[VAL_3]] : !ibis.portref<out i1>
+// CHECK:           %[[VAL_6]] = ibis.port.input @parent_parent_c2_c3_out : i1
+// CHECK:         }
+ibis.container @P1 {
+  %this = ibis.this @P1 
+  %c1 = ibis.container.instance @c1, @C1 
+  %c1.parent_parent_c2_c3_in = ibis.get_port %c1, @parent_parent_c2_c3_in : !ibis.scoperef<@C1> -> !ibis.portref<in !ibis.portref<in i1>>
+  ibis.port.write %c1.parent_parent_c2_c3_in, %0 : !ibis.portref<in !ibis.portref<in i1>>
+  %c1.parent_parent_c2_c3_out = ibis.get_port %c1, @parent_parent_c2_c3_out : !ibis.scoperef<@C1> -> !ibis.portref<in !ibis.portref<out i1>>
+  ibis.port.write %c1.parent_parent_c2_c3_out, %1 : !ibis.portref<in !ibis.portref<out i1>>
+  %parent_parent_c2_c3_in = ibis.port.input @parent_parent_c2_c3_in : !ibis.portref<in i1>
+  %0 = ibis.port.read %parent_parent_c2_c3_in : !ibis.portref<in !ibis.portref<in i1>>
+  %parent_parent_c2_c3_out = ibis.port.input @parent_parent_c2_c3_out : !ibis.portref<out i1>
+  %1 = ibis.port.read %parent_parent_c2_c3_out : !ibis.portref<in !ibis.portref<out i1>>
+}
+
+// CHECK-LABEL:   ibis.container @P2 {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @P2
+// CHECK:           %[[VAL_1:.*]] = ibis.container.instance @p1, @P1
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @parent_parent_c2_c3_in : !ibis.scoperef<@P1> -> !ibis.portref<out i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.read %[[VAL_2]] : !ibis.portref<out i1>
+// CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @parent_parent_c2_c3_out : !ibis.scoperef<@P1> -> !ibis.portref<in i1>
+// CHECK:           %[[VAL_5:.*]] = ibis.port.read %[[VAL_6:.*]] : !ibis.portref<out i1>
+// CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_5]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_7:.*]] = ibis.container.instance @c2, @C2
+// CHECK:           %[[VAL_6]] = ibis.get_port %[[VAL_7]], @parent_parent_c2_c3_out : !ibis.scoperef<@C2> -> !ibis.portref<out i1>
+// CHECK:           %[[VAL_8:.*]] = ibis.get_port %[[VAL_7]], @parent_parent_c2_c3_in : !ibis.scoperef<@C2> -> !ibis.portref<in i1>
+// CHECK:           ibis.port.write %[[VAL_8]], %[[VAL_3]] : !ibis.portref<in i1>
+// CHECK:         }
+ibis.container @P2 {
+  %this = ibis.this @P2 
+  %p1 = ibis.container.instance @p1, @P1 
+  %p1.parent_parent_c2_c3_in = ibis.get_port %p1, @parent_parent_c2_c3_in : !ibis.scoperef<@P1> -> !ibis.portref<in !ibis.portref<in i1>>
+  ibis.port.write %p1.parent_parent_c2_c3_in, %1 : !ibis.portref<in !ibis.portref<in i1>>
+  %p1.parent_parent_c2_c3_out = ibis.get_port %p1, @parent_parent_c2_c3_out : !ibis.scoperef<@P1> -> !ibis.portref<in !ibis.portref<out i1>>
+  ibis.port.write %p1.parent_parent_c2_c3_out, %0 : !ibis.portref<in !ibis.portref<out i1>>
+  %c2 = ibis.container.instance @c2, @C2 
+  %c2.parent_parent_c2_c3_out = ibis.get_port %c2, @parent_parent_c2_c3_out : !ibis.scoperef<@C2> -> !ibis.portref<out !ibis.portref<out i1>>
+  %0 = ibis.port.read %c2.parent_parent_c2_c3_out : !ibis.portref<out !ibis.portref<out i1>>
+  %c2.parent_parent_c2_c3_in = ibis.get_port %c2, @parent_parent_c2_c3_in : !ibis.scoperef<@C2> -> !ibis.portref<out !ibis.portref<in i1>>
+  %1 = ibis.port.read %c2.parent_parent_c2_c3_in : !ibis.portref<out !ibis.portref<in i1>>
+}
+
+// -----
+
+// CHECK-LABEL:   ibis.container @AccessParent {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @AccessParent
+// CHECK:           %[[VAL_1:.*]] = ibis.port.output @p_out : i1
+// CHECK:           %[[VAL_2:.*]] = ibis.port.input @p_in : i1
+// CHECK:         }
+ibis.container @AccessParent {
+  %this = ibis.this @AccessParent 
+  %p_out = ibis.port.input @p_out : !ibis.portref<in i1>
+  %p_out.val = ibis.port.read %p_out : !ibis.portref<in !ibis.portref<in i1>>
+  %p_in = ibis.port.input @p_in : !ibis.portref<out i1>
+  %p_in.val = ibis.port.read %p_in : !ibis.portref<in !ibis.portref<out i1>>
+}
+
+// CHECK-LABEL:   ibis.container @Parent {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @Parent
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input @in : i1
+// CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.wire.output @in.rd, %[[VAL_2]] : i1
+// CHECK:           %[[VAL_4:.*]] = ibis.port.output @out : i1
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = ibis.wire.input @out.wr : i1
+// CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_6]] : !ibis.portref<out i1>
+// CHECK:           %[[VAL_7:.*]] = ibis.container.instance @c, @AccessParent
+// CHECK:           %[[VAL_8:.*]] = ibis.get_port %[[VAL_7]], @p_out : !ibis.scoperef<@AccessParent> -> !ibis.portref<out i1>
+// CHECK:           %[[VAL_9:.*]] = ibis.port.read %[[VAL_8]] : !ibis.portref<out i1>
+// CHECK:           ibis.port.write %[[VAL_5]], %[[VAL_9]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_10:.*]] = ibis.get_port %[[VAL_7]], @p_in : !ibis.scoperef<@AccessParent> -> !ibis.portref<in i1>
+// CHECK:           %[[VAL_11:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<out i1>
+// CHECK:           ibis.port.write %[[VAL_10]], %[[VAL_11]] : !ibis.portref<in i1>
+// CHECK:         }
+ibis.container @Parent {
+  %this = ibis.this @Parent 
+  %in = ibis.port.input @in : i1
+  %in.val = ibis.port.read %in : !ibis.portref<in i1>
+  %in.rd = ibis.wire.output @in.rd, %in.val : i1
+  %out = ibis.port.output @out : i1
+  %out.wr, %out.wr.out = ibis.wire.input @out.wr : i1
+  ibis.port.write %out, %out.wr.out : !ibis.portref<out i1>
+  %c = ibis.container.instance @c, @AccessParent 
+  %c.p_out.ref = ibis.get_port %c, @p_out : !ibis.scoperef<@AccessParent> -> !ibis.portref<in !ibis.portref<in i1>>
+  ibis.port.write %c.p_out.ref, %out.wr : !ibis.portref<in !ibis.portref<in i1>>
+  %c.p_in.ref = ibis.get_port %c, @p_in : !ibis.scoperef<@AccessParent> -> !ibis.portref<in !ibis.portref<out i1>>
+  ibis.port.write %c.p_in.ref, %in.rd : !ibis.portref<in !ibis.portref<out i1>>
+}


### PR DESCRIPTION
We do this by analyzing how a portref is used inside a container, and then creating an in- or output port based on that. That is:
- write to `portref<in portref<in, T>>` becomes `out T` i.e this container wants to write to an input of another container, hence it will produce an output value that will drive that input port.
- read from `portref<in portref<out, T>>` becomes `in T` i.e. this container wants to read from an output of another container, hence it will have an input port that will be driven by that output port.
- write to `portref<out portref<out, T>>` becomes `out T` i.e. a port reference inside the module will be driven by a value from the outside.
- read from `portref<out portref<in, T>>` becomes `in T` i.e. a port reference inside the module will be driven by a value from the outside.

A benefit of having portref lowering separate from portref tunneling is that portref lowering can be done on an `ibis.container` granularity, allowing for a bit of parallelism in the flow.