### PR TITLE
[FIRRTL][NFC] Drop use of AnnoTarget for getting inner symbols

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -426,10 +426,6 @@ struct AnnoTarget {
   /// Get the parent module of the target.
   FModuleLike getModule() const;
 
-  /// Get the inner_sym attribute of an op.  If there is no attached inner_sym,
-  /// then one will be created and attached to the op.
-  StringAttr getInnerSym(hw::InnerSymbolNamespace &moduleNamespace) const;
-
   /// Get a reference to this target suitable for use in an NLA.
   Attribute getNLAReference(hw::InnerSymbolNamespace &moduleNamespace) const;
 
@@ -450,7 +446,6 @@ struct OpAnnoTarget : public AnnoTarget {
 
   AnnotationSet getAnnotations() const;
   void setAnnotations(AnnotationSet annotations) const;
-  StringAttr getInnerSym(hw::InnerSymbolNamespace &moduleNamespace) const;
   Attribute getNLAReference(hw::InnerSymbolNamespace &moduleNamespace) const;
   FIRRTLType getType() const;
 
@@ -472,7 +467,6 @@ struct PortAnnoTarget : public AnnoTarget {
 
   AnnotationSet getAnnotations() const;
   void setAnnotations(AnnotationSet annotations) const;
-  StringAttr getInnerSym(hw::InnerSymbolNamespace &moduleNamespace) const;
   Attribute getNLAReference(hw::InnerSymbolNamespace &moduleNamespace) const;
   FIRRTLType getType() const;
 

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotations.cpp
@@ -553,14 +553,6 @@ void AnnoTarget::setAnnotations(AnnotationSet annotations) const {
       [&](auto target) { target.setAnnotations(annotations); });
 }
 
-StringAttr
-AnnoTarget::getInnerSym(hw::InnerSymbolNamespace &moduleNamespace) const {
-  return TypeSwitch<AnnoTarget, StringAttr>(*this)
-      .Case<OpAnnoTarget, PortAnnoTarget>(
-          [&](auto target) { return target.getInnerSym(moduleNamespace); })
-      .Default([](auto target) { return StringAttr(); });
-}
-
 Attribute
 AnnoTarget::getNLAReference(hw::InnerSymbolNamespace &moduleNamespace) const {
   return TypeSwitch<AnnoTarget, Attribute>(*this)
@@ -582,14 +574,6 @@ AnnotationSet OpAnnoTarget::getAnnotations() const {
 
 void OpAnnoTarget::setAnnotations(AnnotationSet annotations) const {
   annotations.applyToOperation(getOp());
-}
-
-StringAttr
-OpAnnoTarget::getInnerSym(hw::InnerSymbolNamespace &moduleNamespace) const {
-  return ::getOrAddInnerSym(
-      getOp(), [&moduleNamespace](auto _) -> hw::InnerSymbolNamespace & {
-        return moduleNamespace;
-      });
 }
 
 Attribute
@@ -643,19 +627,6 @@ void PortAnnoTarget::setAnnotations(AnnotationSet annotations) const {
     annotations.applyToPort(moduleOp, getPortNo());
   else
     llvm_unreachable("unknown port target");
-}
-
-StringAttr
-PortAnnoTarget::getInnerSym(hw::InnerSymbolNamespace &moduleNamespace) const {
-  // If this is not a module, we just need to get an inner_sym on the operation
-  // itself.
-  auto module = llvm::dyn_cast<FModuleLike>(getOp());
-  auto target = module ? hw::InnerSymTarget(getPortNo(), module)
-                       : hw::InnerSymTarget(getOp());
-  return ::getOrAddInnerSym(
-      target, [&moduleNamespace](auto _) -> hw::InnerSymbolNamespace & {
-        return moduleNamespace;
-      });
 }
 
 Attribute PortAnnoTarget::getNLAReference(

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1228,7 +1228,10 @@ private:
     // If the "from" operation has an inner_sym, we need to make sure the
     // "to" operation also has an `inner_sym` and then record the renaming.
     if (auto fromSym = getInnerSymName(from)) {
-      auto toSym = OpAnnoTarget(to).getInnerSym(getNamespace(toModule));
+      auto toSym =
+          getOrAddInnerSym(to, [&](auto _) -> hw::InnerSymbolNamespace & {
+            return getNamespace(toModule);
+          });
       renameMap[fromSym] = toSym;
     }
 


### PR DESCRIPTION
Move only user to directly call the function these wrap, and delete them from AnnoTarget family.