### PR TITLE
[FIRRTL][LowerToHW] Copy InnerSymAttrs to lowered ops

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -109,9 +109,23 @@ Value getValueByFieldID(ImplicitLocOpBuilder builder, Value value,
 /// leaf ground type.
 void walkGroundTypes(FIRRTLType firrtlType,
                      llvm::function_ref<void(uint64_t, FIRRTLBaseType)> fn);
+
 //===----------------------------------------------------------------------===//
 // Inner symbol and InnerRef helpers.
 //===----------------------------------------------------------------------===//
+
+/// Ensure that the the InnerSymAttr has a symbol on the field specified.
+/// Returns the updated InnerSymAttr as well as the name of the symbol attached
+/// to the specified field.
+std::pair<hw::InnerSymAttr, StringAttr>
+getOrAddInnerSym(MLIRContext *context, hw::InnerSymAttr attr, uint64_t fieldID,
+                 llvm::function_ref<hw::InnerSymbolNamespace &()> getNamespace);
+
+/// Returns an inner symbol identifier for the specified target (op or port),
+/// adding one if necessary.
+StringAttr
+getOrAddInnerSym(const hw::InnerSymTarget &target,
+                 llvm::function_ref<hw::InnerSymbolNamespace &()> getNamespace);
 
 using GetNamespaceCallback =
     llvm::function_ref<hw::InnerSymbolNamespace &(FModuleLike mod)>;

--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -98,14 +98,13 @@ def WireOp : HWOp<"wire", [
   let builders = [
     OpBuilder<(ins "mlir::Value":$input,
                    CArg<"const StringAttrOrRef &", "{}">:$name,
-                   CArg<"const StringAttrOrRef &", "{}">:$innerSym), [{
+                   CArg<"hw::InnerSymAttr", "{}">:$innerSym), [{
       auto *context = odsBuilder.getContext();
       odsState.addOperands(input);
       if (auto attr = name.get(context))
         odsState.addAttribute(getNameAttrName(odsState.name), attr);
-      if (auto attr = innerSym.get(context))
-        odsState.addAttribute(getInnerSymAttrName(odsState.name),
-                              InnerSymAttr::get(attr));
+      if (innerSym)
+        odsState.addAttribute(getInnerSymAttrName(odsState.name), innerSym);
       odsState.addTypes(input.getType());
     }]>
   ];


### PR DESCRIPTION
This change ensures that when lowering InnerSymbol operations, we copy the existing inner symbol to the target, as well as properly adding a symbol on fieldID 0 when required.  This fixes an assumption of symbol name uniqueness, and they are now uniqued in the module's symbol namespace. A side effect of this change is that the used symbol names are always of the form `@sym_1`. This also fixes a bug where an InnerSymAttr was assumed to target field ID 0, and could result in an inccorect lowering of the DontTouch annotation.