### PR TITLE
[firtool] Add LowerClasses for processing OMIR

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -73,7 +73,10 @@ void LowerClassesPass::runOnOperation() {
 
   // Get the CircuitOp.
   auto circuits = getOperation().getOps<CircuitOp>();
-  if (std::distance(circuits.begin(), circuits.end()) != 1) {
+  auto count = std::distance(circuits.begin(), circuits.end());
+  if (count == 0)
+    return;
+  if (count > 1) {
     getOperation().emitError("expected exactly one CircuitOp, but found ")
         << std::distance(circuits.begin(), circuits.end());
     return signalPassFailure();

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -188,6 +188,8 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
   // RefType ports and ops.
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerXMRPass());
 
+  pm.addPass(firrtl::createLowerClassesPass());
+
   pm.addPass(createLowerFIRRTLToHWPass(
       opt.enableAnnotationWarning.getValue(),
       opt.emitChiselAssertsAsSVA.getValue(),


### PR DESCRIPTION
This adds the LowerClasses pass right before LowerToHW.  With this change, we can get a lowering of FIRRTL with properties right through the pipeline with Verilog output.