### PR TITLE
[FIRRTL] Add UnresolvedPathOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1119,6 +1119,21 @@ def FIntegerConstantOp : FIRRTLOp<"integer", [Pure, ConstantLike]> {
   let hasCustomAssemblyFormat = true;
 }
 
+def UnresolvedPathOp : FIRRTLOp<"unresolved_path", [Pure]> {
+  let summary = "Produce a path value";
+  let description = [{
+    Produces a value which represents a path to the target in a design.
+
+    Example:
+    ```mlir
+    0 = firrtl.unresolved_path "~Circuit|Module>w"
+    ```
+  }];
+  let arguments = (ins StrAttr:$target);
+  let results = (outs PathType:$result);
+  let assemblyFormat = "$target attr-dict";
+}
+
 def PathOp : FIRRTLOp<"path", [Pure,
                   DeclareOpInterfaceMethods<InnerRefUserOpInterface>]> {
   let summary = "Produce a path value";

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -307,6 +307,9 @@ firrtl.module @PropertyNestedTest(in %in: !firrtl.map<integer, list<map<string, 
 // CHECK-SAME: (in %in: !firrtl.path, out %out: !firrtl.path)
 firrtl.module @PathTest(in %in: !firrtl.path, out %out: !firrtl.path) {
   firrtl.propassign %out, %in : !firrtl.path
+  
+  // CHECK: firrtl.unresolved_path "target-string"
+  firrtl.unresolved_path "target-string"
 }
 
 // CHECK-LABEL: TypeAlias


### PR DESCRIPTION
This operation is meant to read in an encoded OM target string, with a pass later resolving the string target to a real target and validating the contents. This new operation purposefully does not contain much in the way of verification.