### PR TITLE
[FIRRTL] re-work PathOp to use annotations

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1134,21 +1134,22 @@ def UnresolvedPathOp : FIRRTLOp<"unresolved_path", [Pure]> {
   let assemblyFormat = "$target attr-dict";
 }
 
-def PathOp : FIRRTLOp<"path", [Pure,
-                  DeclareOpInterfaceMethods<InnerRefUserOpInterface>]> {
+def PathOp : FIRRTLOp<"path", [Pure]> {
   let summary = "Produce a path value";
   let description = [{
     Produces a value which represents a path to the target in a design.
 
     Example:
     ```mlir
-    %w = firrtl.wire sym @wire : !firrtl.uint<1>
-    %0 = firrtl.path <@foo::@wire>
+    hw.hierpath @Path [@Foo::@bar, @Bar]
+    %wire = firrtl.wire {annotations = [ {class = "circt.tracker", id = distinct[0]<>, circt.nonlocal = @Path} ]} : !firrtl.uint<1>
+    %0 = firrtl.path reference distinct[0]<>
     ```
   }];
-  let arguments = (ins InnerRefAttr:$target);
+  let arguments = (ins TargetKind:$targetKind,
+                       DistinctAttr:$target);
   let results = (outs PathType:$result);
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat = "$targetKind $target attr-dict";
 }
 
 def ListCreateOp : FIRRTLOp<"list.create", [Pure, SameTypeOperands]> {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4757,26 +4757,6 @@ FIRRTLType TailPrimOp::inferReturnType(ValueRange operands,
 }
 
 //===----------------------------------------------------------------------===//
-// Properties
-//===----------------------------------------------------------------------===//
-
-LogicalResult PathOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
-  auto targetRef = getTarget();
-
-  // Check if the target is local.
-  if (targetRef.getModule() !=
-      (*this)->getParentOfType<FModuleLike>().getModuleNameAttr())
-    return emitOpError() << "has non-local target";
-
-  // Check that the target exists.
-  auto target = ns.lookup(targetRef);
-  if (!target)
-    return emitOpError() << "has target that cannot be resolved: " << targetRef;
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // VerbatimExprOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1842,27 +1842,6 @@ firrtl.circuit "TopModuleIsClass" {
 }
 
 // -----
-
-firrtl.circuit "PathNonLocalTarget" {
-  firrtl.module @Other() {
-    %w = firrtl.wire sym @x : !firrtl.uint<1>
-  }
-  firrtl.module @PathNonLocalTarget() {
-    // expected-error @below {{op has non-local target}}
-    %rw = firrtl.path <@Other::@x>
-  }
-}
-
-// -----
-
-firrtl.circuit "PathBadTarget" {
-  firrtl.module @PathBadTarget() {
-    // expected-error @below {{has target that cannot be resolved: #hw.innerNameRef<@PathBadTarget::@x>}}
-    %rw = firrtl.path <@PathBadTarget::@x>
-  }
-}
-
-// -----
 // Classes cannot have hardware ports.
 
 firrtl.circuit "ClassCannotHaveHardwarePorts" {

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -310,6 +310,10 @@ firrtl.module @PathTest(in %in: !firrtl.path, out %out: !firrtl.path) {
   
   // CHECK: firrtl.unresolved_path "target-string"
   firrtl.unresolved_path "target-string"
+  
+  // CHECK: firrtl.path reference distinct[0]<>
+  %0 = firrtl.path reference distinct[0]<>
+  
 }
 
 // CHECK-LABEL: TypeAlias


### PR DESCRIPTION
The PathOp is being re-worked to remotely reference hardware objects using (possibly non-local) annotations.  The hardware target recieves an annotation with class `circt.tracker` and an identifier.  The Path operation tracks the original target kind and the target identifier. It is legal to optimize away the hardware target, which will leave the Path op with a dangling identifier reference. A later pass will lower this FIRRTL PathOp to an OM specific Path operation, which will not use annotations.  See the example in FIRRTLExpressions.td for what this looks like in FIRRTL.