### PR TITLE
[Pipeline] Propagate names in `-pipeline-explicit-regs`

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -312,10 +312,9 @@ def StageOp : Op<Pipeline_Dialect, "stage", [
 
   let builders = [
     OpBuilder<(ins "Block*":$dest, "ValueRange":$registers, "ValueRange":$passthroughs)>,
-    // Clock gate builder, which takes a mapping between the registers and
-    // and their clock gate hierarchy.
     OpBuilder<(ins "Block*":$dest, "ValueRange":$registers, "ValueRange":$passthroughs,
-      "const llvm::DenseMap<Value, llvm::SmallVector<Value>>&":$clockGates,
+      // Clock gates per register, in the order of the registers.
+      "llvm::ArrayRef<llvm::SmallVector<Value>>":$clockGates,
       CArg<"mlir::ArrayAttr", "{}">:$registerNames, CArg<"mlir::ArrayAttr", "{}">:$passthroughNames)>
   ];
 }
@@ -363,7 +362,7 @@ def LatencyOp : Op<Pipeline_Dialect, "latency", [
   let skipDefaultBuilders = 1;
 
   let assemblyFormat = [{
-    attr-dict $latency `->` `(` type($results) `)` $body
+    $latency `->` `(` type($results) `)` $body attr-dict
   }];
 
   let extraClassDeclaration = [{

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -46,8 +46,8 @@ hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) 
 // CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%0 : i32)
-// CHECK-NEXT:    ^bb1(%s1_arg0: i32, %s1_valid: i1):  // pred: ^bb0
-// CHECK-NEXT:      pipeline.return %s1_arg0 : i32
+// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_valid: i1):  // pred: ^bb0
+// CHECK-NEXT:      pipeline.return %s1_reg0 : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
@@ -66,8 +66,8 @@ hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) 
 // CHECK-NEXT:    %out0, %out1, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0 : i32, out1 : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%0 : i32) pass(%a1 : i32)
-// CHECK-NEXT:    ^bb1(%s1_arg0: i32, %s1_arg1: i32, %s1_valid: i1):  // pred: ^bb0
-// CHECK-NEXT:      pipeline.return %s1_arg0, %s1_arg1 : i32, i32
+// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_pass0: i32, %s1_valid: i1):  // pred: ^bb0
+// CHECK-NEXT:      pipeline.return %s1_reg0, %s1_pass0 : i32, i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out0 : i32
 // CHECK-NEXT:  }
@@ -98,8 +98,8 @@ hw.module @withStall(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : i1) -
 // CHECK-LABEL:  hw.module @withMultipleRegs(%arg0: i32, %stall: i1, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
 // CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%a0 : i32, %a0 : i32)
-// CHECK-NEXT:    ^bb1(%s1_arg0: i32, %s1_arg1: i32, %s1_valid: i1):  // pred: ^bb0
-// CHECK-NEXT:      pipeline.return %s1_arg0 : i32
+// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_reg1: i32, %s1_valid: i1):  // pred: ^bb0
+// CHECK-NEXT:      pipeline.return %s1_reg0 : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
@@ -119,8 +119,8 @@ hw.module @withMultipleRegs(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst 
 // CHECK-NEXT:      %true_0 = hw.constant true
 // CHECK-NEXT:      %true_1 = hw.constant true
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%a0 : i32 gated by [%true], %a0 : i32, %a0 : i32 gated by [%true_0, %true_1])
-// CHECK-NEXT:    ^bb1(%s1_arg0: i32, %s1_arg1: i32, %s1_arg2: i32, %s1_valid: i1):  // pred: ^bb0
-// CHECK-NEXT:      pipeline.return %s1_arg0 : i32
+// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_reg1: i32, %s1_reg2: i32, %s1_valid: i1):  // pred: ^bb0
+// CHECK-NEXT:      pipeline.return %s1_reg0 : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
@@ -137,15 +137,15 @@ hw.module @withClockGates(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : 
   hw.output %0 : i32
 }
 
-// CHECK-LABEL: hw.module @withNames(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
-// CHECK-NEXT:     %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
-// CHECK-NEXT:       %0 = comb.add %a0, %a1 : i32
-// CHECK-NEXT:       pipeline.stage ^bb1 regs("myAdd" = %0 : i32, %0 : i32, "myOtherAdd" = %0 : i32)
-// CHECK-NEXT:     ^bb1(%s1_arg0: i32, %s1_arg1: i32, %s1_arg2: i32, %s1_valid: i1):  // pred: ^bb0
-// CHECK-NEXT:       pipeline.return %s1_arg0 : i32
-// CHECK-NEXT:     }
-// CHECK-NEXT:     hw.output %out : i32
-// CHECK-NEXT:   }
+// CHECK-LABEL:  hw.module @withNames(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+// CHECK-NEXT:    %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
+// CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
+// CHECK-NEXT:      pipeline.stage ^bb1 regs("myAdd" = %0 : i32, %0 : i32, "myOtherAdd" = %0 : i32) 
+// CHECK-NEXT:    ^bb1(%myAdd: i32, %s1_reg1: i32, %myOtherAdd: i32, %s1_valid: i1):  // pred: ^bb0
+// CHECK-NEXT:      pipeline.return %myAdd : i32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    hw.output %out : i32
+// CHECK-NEXT:  }
 hw.module @withNames(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
   %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32


### PR DESCRIPTION
Detect `sv.namehint` or OpAsmOpInterface's when routing values, and use these as the basis for register/passthrough names.

e.g.:
```mlir
hw.module @testNaming(%myArg : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
  %out:2 = pipeline.scheduled(%A : i32 = %myArg) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
    %res = pipeline.latency 2 -> (i32) {
      %d = comb.add %A, %A : i32
      pipeline.latency.return %d : i32
    }  {"sv.namehint" = "foo"}
    pipeline.stage ^bb1
  ^bb1(%s1_valid : i1):
    pipeline.stage ^bb2
  ^bb2(%s2_valid : i1):
    %0 = comb.add %A, %res  {"sv.namehint" = "bar"} : i32
    pipeline.stage ^bb3
  ^bb3(%s3_valid : i1):
    pipeline.return %0 : i32
  }
  hw.output %out#0 : i32
}
```

eventually results in the following RTL:
```sv
module testNaming_p0(
  input  [31:0] A,
  input         enable,
                clk,
                rst,
  output [31:0] out,
  output        valid
);

  wire [31:0] _testNaming_p0_s1_A_out;
  wire [31:0] _testNaming_p0_s1_foo_out;
  wire        _testNaming_p0_s1_valid;
  wire [31:0] _testNaming_p0_s0_A_out;
  wire [31:0] _testNaming_p0_s0_foo_out;
  wire        _testNaming_p0_s0_valid;
  testNaming_p0_s0 testNaming_p0_s0 (
    .A       (A),
    .enable  (enable),
    .clk     (clk),
    .rst     (rst),
    .A_out   (_testNaming_p0_s0_A_out),
    .foo_out (_testNaming_p0_s0_foo_out),
    .valid   (_testNaming_p0_s0_valid)
  );
  testNaming_p0_s1 testNaming_p0_s1 (
    .A_in    (_testNaming_p0_s0_A_out),
    .foo_in  (_testNaming_p0_s0_foo_out),
    .enable  (_testNaming_p0_s0_valid),
    .clk     (clk),
    .rst     (rst),
    .A_out   (_testNaming_p0_s1_A_out),
    .foo_out (_testNaming_p0_s1_foo_out),
    .valid   (_testNaming_p0_s1_valid)
  );
  testNaming_p0_s2 testNaming_p0_s2 (
    .A_in    (_testNaming_p0_s1_A_out),
    .foo_in  (_testNaming_p0_s1_foo_out),
    .enable  (_testNaming_p0_s1_valid),
    .clk     (clk),
    .rst     (rst),
    .bar_out (out),
    .valid   (valid)
  );
endmodule

module testNaming_p0_s0(
  input  [31:0] A,
  input         enable,
                clk,
                rst,
  output [31:0] A_out,
                foo_out,
  output        valid
);

  reg [31:0] A_0;
  always_ff @(posedge clk)
    A_0 <= A;
  reg        stage0_valid;
  always_ff @(posedge clk) begin
    if (rst)
      stage0_valid <= 1'h0;
    else
      stage0_valid <= enable;
  end
  assign A_out = A_0;
  assign foo_out = {A[30:0], 1'h0};
  assign valid = stage0_valid;
endmodule

module testNaming_p0_s1(
  input  [31:0] A_in,
                foo_in,
  input         enable,
                clk,
                rst,
  output [31:0] A_out,
                foo_out,
  output        valid
);

  reg [31:0] A;
  always_ff @(posedge clk)
    A <= A_in;
  reg        stage1_valid;
  always_ff @(posedge clk) begin
    if (rst)
      stage1_valid <= 1'h0;
    else
      stage1_valid <= enable;
  end
  assign A_out = A;
  assign foo_out = foo_in;
  assign valid = stage1_valid;
endmodule

module testNaming_p0_s2(
  input  [31:0] A_in,
                foo_in,
  input         enable,
                clk,
                rst,
  output [31:0] bar_out,
  output        valid
);

  reg [31:0] bar;
  always_ff @(posedge clk)
    bar <= A_in + foo_in;
  reg        stage2_valid;
  always_ff @(posedge clk) begin
    if (rst)
      stage2_valid <= 1'h0;
    else
      stage2_valid <= enable;
  end
  assign bar_out = bar;
  assign valid = stage2_valid;
endmodule

module testNaming(
  input  [31:0] myArg,
  input         go,
                clk,
                rst,
  output [31:0] out
);

  testNaming_p0 testNaming_p0 (
    .A      (myArg),
    .enable (go),
    .clk    (clk),
    .rst    (rst),
    .out    (out),
    .valid  (/* unused */)
  );
endmodule
```