### PR TITLE
[OM] Add TargetKind attribute for path operations

### DIFF
--- a/include/circt/Dialect/OM/CMakeLists.txt
+++ b/include/circt/Dialect/OM/CMakeLists.txt
@@ -9,6 +9,10 @@
 add_circt_dialect(OM om)
 add_circt_dialect_doc(OM om)
 
+set(LLVM_TARGET_DEFINITIONS OMEnums.td)
+mlir_tablegen(OMEnums.h.inc -gen-enum-decls)
+mlir_tablegen(OMEnums.cpp.inc -gen-enum-defs)
+
 set(LLVM_TARGET_DEFINITIONS OM.td)
 mlir_tablegen(OMAttributes.h.inc -gen-attrdef-decls)
 mlir_tablegen(OMAttributes.cpp.inc -gen-attrdef-defs)

--- a/include/circt/Dialect/OM/OMDialect.h
+++ b/include/circt/Dialect/OM/OMDialect.h
@@ -16,5 +16,6 @@
 #include "mlir/IR/Dialect.h"
 
 #include "circt/Dialect/OM/OMDialect.h.inc"
+#include "circt/Dialect/OM/OMEnums.h.inc"
 
 #endif // CIRCT_DIALECT_OM_OMDIALECT_H

--- a/include/circt/Dialect/OM/OMDialect.td
+++ b/include/circt/Dialect/OM/OMDialect.td
@@ -13,6 +13,8 @@
 #ifndef CIRCT_DIALECT_OM_OMDIALECT
 #define CIRCT_DIALECT_OM_OMDIALECT
 
+include "mlir/IR/OpBase.td"
+
 def OMDialect : Dialect {
   let name = "om";
   let cppNamespace = "::circt::om";

--- a/include/circt/Dialect/OM/OMEnums.td
+++ b/include/circt/Dialect/OM/OMEnums.td
@@ -1,0 +1,34 @@
+//===- OMEnums.td - OM Enum Definition ---------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Definitions of OM enum attributes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_OM_OMENUMS_TD
+#define CIRCT_DIALECT_OM_OMENUMS_TD
+
+include "circt/Dialect/OM/OMDialect.td"
+include "mlir/IR/EnumAttr.td"
+
+let cppNamespace = "::circt::om" in {
+
+//===----------------------------------------------------------------------===//
+// Target Kinds
+//===----------------------------------------------------------------------===//
+
+def DontTouch : I32EnumAttrCase<"DontTouch", 0, "dont_touch">;
+def MemberInstance: I32EnumAttrCase<"MemberInstance", 1, "member_instance">;
+def MemberReference: I32EnumAttrCase<"MemberReference", 2, "member_reference">;
+def Reference: I32EnumAttrCase<"Reference", 3, "reference">;
+def TargetKind : I32EnumAttr<"TargetKind", "object model target kind",
+  [DontTouch, MemberInstance, MemberReference, Reference]>  {}
+
+}
+
+#endif // CIRCT_DIALECT_OM_OMENUMS_TD

--- a/lib/Dialect/OM/OMDialect.cpp
+++ b/lib/Dialect/OM/OMDialect.cpp
@@ -25,3 +25,6 @@ void circt::om::OMDialect::initialize() {
   registerTypes();
   registerAttributes();
 }
+
+// Provide implementations for the enums we use.
+#include "circt/Dialect/OM/OMEnums.cpp.inc"


### PR DESCRIPTION
This attribute encodes the different kinds of targets used by OMIR.  These will be used by the Path operation.