### PR TITLE
[FIRRTL] Add path op parsing

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -156,6 +156,8 @@ TOK_LPKEYWORD(assert)
 TOK_LPKEYWORD(assume)
 TOK_LPKEYWORD(cover)
 
+TOK_LPKEYWORD(path)
+
 TOK_LPKEYWORD(force)
 TOK_LPKEYWORD(force_initial)
 TOK_LPKEYWORD(release)

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1704,12 +1704,11 @@ circuit BasicProps :
 
   ; CHECK-LABEL: module private @Path
   module Path :
-    ; CHECK-SAME: in %a: !firrtl.path
-    ; CHECK-SAME: out %b: !firrtl.path
-    input a : Path
-    output b : Path
-    ; CHECK: firrtl.propassign %b, %a : !firrtl.path
-    propassign b, a
+    ; CHECK-SAME: out %path: !firrtl.path
+    output path : Path
+    ; CHECK: firrtl.unresolved_path "OMDeleted"
+    ; CHECK: firrtl.propassign %path, %0 : !firrtl.path
+    propassign path, path("OMDeleted")
 
   ; CHECK-LABEL: firrtl.class private @SimpleClass(in %a: !firrtl.string, out %b: !firrtl.string) {
   ; CHECK-NEXT:     firrtl.propassign %b, %a : !firrtl.string

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -947,3 +947,46 @@ circuit LeadingList:
   module LeadingList:
     ; expected-error @below {{unexpected List<>() as start of statement}}
     List<String>()
+
+;// -----
+; Path should not be leading a statement.
+FIRRTL version 3.2.0
+circuit LeadingPath:
+  module LeadingPath:
+    ; expected-error @below {{unexpected path() as start of statement}}
+    path("")
+
+;// -----
+FIRRTL version 3.1.0
+circuit PathVersion:
+  module PathVersion:
+    output path : Path
+    ; expected-error @below {{paths are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.1.0}}
+    propassign path, path("")
+
+;// -----
+; Path operation should have a single string argument.
+FIRRTL version 3.2.0
+circuit BadPathExpr:
+  module BadPathExp:
+    output path : Path
+    ; expected-error @below {{expected target string in path expression}}
+    propassign path, path()
+
+;// -----
+; Path operation should have a single string argument.
+FIRRTL version 3.2.0
+circuit BadPathExpr:
+  module BadPathExp:
+    output path : Path
+    ; expected-error @below {{expected ')' in path expression}}
+    propassign path, path("hello", "goodbye")
+
+;// -----
+; Path operation should have a single string argument.
+FIRRTL version 3.2.0
+circuit BadPathExpr:
+  module BadPathExp:
+    output path : Path
+    ; expected-error @below {{expected target string in path expression}}
+    propassign path, path(UInt<1>(1))


### PR DESCRIPTION
This adds parsing for path operations in to unresolved paths.