### PR TITLE
[FIRRTL] Fix crash resolving annotations through operations w/o "type".

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -83,13 +83,17 @@ static FailureOr<unsigned> findFieldID(AnnoTarget &ref,
   auto *op = ref.getOp();
   auto fieldIdx = 0;
   // The first field for some ops refers to expanded return values.
-  if (isa<MemOp>(ref.getOp())) {
+  if (isa<MemOp>(op)) {
     if (failed(updateExpandedPort(tokens.front().name, ref)))
       return {};
     tokens = tokens.drop_front();
   }
 
   auto type = ref.getType();
+  if (!type)
+    return op->emitError(tokens.front().isIndex ? "index" : "field")
+           << " access in annotation not supported for this operation";
+
   for (auto token : tokens) {
     if (token.isIndex) {
       auto result = findVectorElement(op, type, token.name);

--- a/test/Dialect/FIRRTL/annotations-errors.mlir
+++ b/test/Dialect/FIRRTL/annotations-errors.mlir
@@ -379,3 +379,41 @@ firrtl.circuit "Component"
   // expected-error @+1 {{annotations cannot target classes}}
   firrtl.class @Class(in %port: !firrtl.string) {}
 }
+
+// -----
+// Don't crash trying to annotate-subindex through targets that don't name a result.
+
+// expected-error @below {{Unable to resolve target of annotation: {class = "circt.test", target = "~Issue5947|Issue5947>mem[0]"}}}
+firrtl.circuit "Issue5947"
+  attributes {
+    rawAnnotations = [
+      {
+        class = "circt.test",
+        target = "~Issue5947|Issue5947>mem[0]"
+      }
+    ]
+} {
+  firrtl.module @Issue5947() {
+    // expected-error @below {{index access in annotation not supported for this operation}}
+    %mem = chirrtl.combmem : !chirrtl.cmemory<uint<1>, 2>
+  }
+}
+
+// -----
+// Don't crash trying to annotate-subfield through targets that don't name a result.
+
+// expected-error @below {{Unable to resolve target of annotation: {class = "circt.test", target = "~Issue5947|Issue5947>mem.a"}}}
+firrtl.circuit "Issue5947"
+  attributes {
+    rawAnnotations = [
+      {
+        class = "circt.test",
+        target = "~Issue5947|Issue5947>mem.a"
+      }
+    ]
+} {
+  firrtl.module @Issue5947() {
+    // expected-error @below {{field access in annotation not supported for this operation}}
+    %mem = chirrtl.combmem : !chirrtl.cmemory<uint<1>, 2>
+  }
+}


### PR DESCRIPTION
Some operations don't have a value/type named when they are the target of an annotation or symbol.  Don't crash when attempting to resolve index or field accesses through refs to these.

Fixes #5947.