### PR TITLE
[FIRRTL] Add Path + List ops to visitor/emitter

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -62,7 +62,8 @@ public:
             UninferredResetCastOp, ConstCastOp, RefCastOp,
             mlir::UnrealizedConversionCastOp,
             // Property expressions.
-            StringConstantOp, FIntegerConstantOp, BoolConstantOp, MapCreateOp>(
+            StringConstantOp, FIntegerConstantOp, BoolConstantOp, ListCreateOp,
+            MapCreateOp, UnresolvedPathOp, PathOp>(
             [&](auto expr) -> ResultType {
               return thisCast->visitExpr(expr, args...);
             })
@@ -205,7 +206,10 @@ public:
   HANDLE(StringConstantOp, Unhandled);
   HANDLE(FIntegerConstantOp, Unhandled);
   HANDLE(BoolConstantOp, Unhandled);
+  HANDLE(ListCreateOp, Unhandled);
   HANDLE(MapCreateOp, Unhandled);
+  HANDLE(PathOp, Unhandled);
+  HANDLE(UnresolvedPathOp, Unhandled);
 #undef HANDLE
 };
 

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -39,6 +39,7 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT: input integer : Integer
     // CHECK-NEXT: input bool : Bool
     // CHECK-NEXT: input path : Path
+    // CHECK-NEXT: input list : List<List<Path>>
     in %a00: !firrtl.clock,
     in %a01: !firrtl.reset,
     in %a02: !firrtl.asyncreset,
@@ -56,7 +57,8 @@ firrtl.circuit "Foo" {
     in %string: !firrtl.string,
     in %integer: !firrtl.integer,
     in %bool : !firrtl.bool,
-    in %path : !firrtl.path
+    in %path : !firrtl.path,
+    in %list : !firrtl.list<list<path>>
   ) {}
 
   // CHECK-LABEL: module Simple :
@@ -644,7 +646,9 @@ firrtl.circuit "Foo" {
   // CHECK-LABEL: module Properties :
   firrtl.module @Properties(out %string : !firrtl.string,
                             out %integer : !firrtl.integer,
-                            out %bool : !firrtl.bool) {
+                            out %bool : !firrtl.bool,
+                            out %path : !firrtl.path,
+                            out %list : !firrtl.list<list<string>>) {
     // CHECK: propassign string, String("hello")
     %0 = firrtl.string "hello"
     firrtl.propassign %string, %0 : !firrtl.string
@@ -656,6 +660,18 @@ firrtl.circuit "Foo" {
     // CHECK: propassign bool, Bool(true)
     %true = firrtl.bool true
     firrtl.propassign %bool, %true : !firrtl.bool
+
+    // CHECK: propassign path, path("OMDeleted")
+    %p = firrtl.unresolved_path "OMDeleted"
+    firrtl.propassign %path, %p : !firrtl.path
+
+    // CHECK:      propassign list,
+    // CHECK-NEXT:   List<List<String>>(List<String>(String("hello"), String("hello")),
+    // CHECK-NEXT:                      List<String>())
+    %strings = firrtl.list.create %0, %0 : !firrtl.list<string>
+    %empty = firrtl.list.create : !firrtl.list<string>
+    %strings_and_empty = firrtl.list.create %strings, %empty : !firrtl.list<list<string>>
+    firrtl.propassign %list, %strings_and_empty : !firrtl.list<list<string>>
   }
 
   // Test optional group declaration and definition emission.


### PR DESCRIPTION
Only support emitting the unresolved (equivalent of FIRRTL textual form) path operation for now.