### PR TITLE
[OM] Fix symbol resolution for classes and path operations

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -713,7 +713,7 @@ def FinalizeIR : Pass<"firrtl-finalize-ir", "mlir::ModuleOp"> {
   let dependentDialects = ["hw::HWDialect", "sv::SVDialect"];
 }
 
-def LowerClasses : Pass<"firrtl-lower-classes", "mlir::ModuleOp"> {
+def LowerClasses : Pass<"firrtl-lower-classes", "firrtl::CircuitOp"> {
   let summary = "Lower FIRRTL classes and objects to OM classes and objects";
   let description = [{
     This pass walks all FIRRTL classes and creates OM classes. It also lowers

--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -33,8 +33,8 @@ class OMOp<string mnemonic, list<Trait> traits = []> :
 
 class OMClassLike<string mnemonic, list<Trait> traits = []> :
   OMOp<mnemonic, traits # [
-    SingleBlock, NoTerminator, Symbol, SymbolTable,
-    HasParent<"mlir::ModuleOp">, RegionKindInterface,
+    SingleBlock, NoTerminator, Symbol, RegionKindInterface,
+    HasParent<"mlir::ModuleOp">,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>,
     DeclareOpInterfaceMethods<ClassLike>]> {
 

--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -34,7 +34,6 @@ class OMOp<string mnemonic, list<Trait> traits = []> :
 class OMClassLike<string mnemonic, list<Trait> traits = []> :
   OMOp<mnemonic, traits # [
     SingleBlock, NoTerminator, Symbol, RegionKindInterface,
-    HasParent<"mlir::ModuleOp">,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>,
     DeclareOpInterfaceMethods<ClassLike>]> {
 

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -236,9 +236,6 @@ void circt::om::ObjectOp::build(::mlir::OpBuilder &odsBuilder,
 
 LogicalResult
 circt::om::ObjectOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  // Get the containing ModuleOp.
-  auto moduleOp = getOperation()->getParentOfType<ModuleOp>();
-
   // Verify the result type is the same as the referred-to class.
   StringAttr resultClassName = getResult().getType().getClassName().getAttr();
   StringAttr className = getClassNameAttr();
@@ -249,7 +246,7 @@ circt::om::ObjectOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
   // Verify the referred to ClassOp exists.
   auto classDef = dyn_cast_or_null<ClassLike>(
-      symbolTable.lookupSymbolIn(moduleOp, className));
+      symbolTable.lookupNearestSymbolFrom(*this, className));
   if (!classDef)
     return emitOpError("refers to non-existant class (") << className << ')';
 
@@ -284,13 +281,10 @@ circt::om::ObjectOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
 LogicalResult
 circt::om::ObjectFieldOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  // Get the containing ModuleOp.
-  auto moduleOp = getOperation()->getParentOfType<ModuleOp>();
-
   // Get the ObjectInstOp and the ClassLike it is an instance of.
   ObjectOp objectInst = getObject().getDefiningOp<ObjectOp>();
-  ClassLike classDef = cast<ClassLike>(
-      symbolTable.lookupSymbolIn(moduleOp, objectInst.getClassNameAttr()));
+  ClassLike classDef = cast<ClassLike>(symbolTable.lookupNearestSymbolFrom(
+      *this, objectInst.getClassNameAttr()));
 
   // Traverse the field path, verifying each field exists.
   ClassFieldLike finalField;
@@ -327,7 +321,7 @@ circt::om::ObjectFieldOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
       // The nested ClassOp must exist, since a field with ClassType must be
       // an ObjectInstOp, which already verifies the class exists.
       classDef = cast<ClassLike>(
-          symbolTable.lookupSymbolIn(moduleOp, classType.getClassName()));
+          symbolTable.lookupNearestSymbolFrom(*this, classType.getClassName()));
 
       // Proceed to the next field in the path.
       continue;
@@ -464,9 +458,8 @@ ParseResult circt::om::MapCreateOp::parse(OpAsmParser &parser,
 
 LogicalResult PathOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // Get the containing ModuleOp.
-  auto moduleOp = getOperation()->getParentOfType<ModuleOp>();
-  auto hierPath =
-      symbolTable.lookupSymbolIn<hw::HierPathOp>(moduleOp, getTargetAttr());
+  auto hierPath = symbolTable.lookupNearestSymbolFrom<hw::HierPathOp>(
+      *this, getTargetAttr());
   if (!hierPath)
     return emitOpError("invalid symbol reference");
   return success();

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -188,7 +188,7 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
   // RefType ports and ops.
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerXMRPass());
 
-  pm.addPass(firrtl::createLowerClassesPass());
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerClassesPass());
 
   pm.addPass(createLowerFIRRTLToHWPass(
       opt.enableAnnotationWarning.getValue(),


### PR DESCRIPTION
This PR has two changes which together are needed to have OM path operations work correctly. 

---

[OM] Class ops should not be symbol tables

Currently OM class operations are symbol tables and fields are symbols, which
is used to facilitate the lookup of fields.  The ObjectFieldOp verifier needs
to verify that it is accessing a legal field of the class, and does this by
first looking up the class in the MLIRModuleOp, and then the field in the
ClassOp.  This double lookup strategy is problematic because it does not follow
the normal rules of symbol resolution as defined by the SymbolTable.  This
means that anything that examines symbol uses (e.g. SymbolDCE) will be
incorrect.  We have faced this kind of problem before, which is why we invented
InnerSymbolTables and InnerSymbols.

This is also needed to properly support path operations: path ops will have a
references to HierPathOps and we need lookup to work correctly. For this, we
will need two things:
1. Since HierPathOps will live inside a FIRRTL circuit, and FIRRTL circuits are
   themselves symbol tables, we will need to put OM classes under the circuit
   as well.
2. When this happens, it will no longer be acceptable for the ObjectFieldOp
   verifier to "jump up" to the MLIRModule op's symbol table for lookup, since
   the classes will actually be under the FIRRTL circuit op.

By removing the SymbolTable interface from class operations, we can change
symbol resolution to use the normal rules, which enables both path operations
to reference NLAs and OM class operations to live in FIRRTL circuits.

This PR removes the SymbolTable op interface from ClassOps, and switches the
ObjectField verifier to perform a manual walk of the ClassOp to find the target
field. In the future, we should switch to InnerSymbols or invent something
totally new for these operations.

---

[FIRRTL][LowerClasses] Insert lowered ClassOps into the FIRRTL circuit

OM path operations use a hierarchical path operation to identify their target.
To facilitate this, it makes sense to insert OM classes under the FIRRTL
circuit, as HierPathOp should be under the same symbol table as the path
operation for lookup to work correctly. If they were not under the same symbol
table, it would be possible to craft a nested symbol reference, but that would
just complicate the LowerToHw pass.

This change removes the restriction that OM ClassOps have MLIRModuleOp as a
parent, changes LowerClasses from a MLIRModule pass to a FIRRTL CircuitOp pass,
and updates some logic to ensure that we are inserting the class operations in
to the correct location.

As a quick example of how this will look with path operations:

```mlir
module { // SymbolTable
  firrtl.circuit "Foo" { // SymbolTable
    hw.hierpath @Path [@foo::@wire]
    firrtl.module @foo {
        %wire = firrtl.wire sym @wire : !firrtl.uint<1>
    }
    om.class @Class() { // No longer a SymbolTable
      %0 = firrtl.path @Path
    }
  }
}
```