### PR TITLE
[scf-to-calyx]Support for function call

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxHelpers.h
+++ b/include/circt/Dialect/Calyx/CalyxHelpers.h
@@ -34,6 +34,13 @@ hw::ConstantOp createConstant(Location loc, OpBuilder &builder,
                               ComponentOp component, size_t width,
                               size_t value);
 
+/// A helper function to create calyx.instance operation.
+calyx::InstanceOp createInstance(Location loc, OpBuilder &builder,
+                                 ComponentOp component,
+                                 SmallVectorImpl<Type> &resultTypes,
+                                 std::string &instanceName,
+                                 StringRef componentName);
+
 // Returns whether this operation is a leaf node in the Calyx control.
 // TODO(github.com/llvm/circt/issues/1679): Add Invoke.
 bool isControlLeafNode(Operation *op);

--- a/include/circt/Dialect/Calyx/CalyxHelpers.h
+++ b/include/circt/Dialect/Calyx/CalyxHelpers.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Support/LLVM.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 
 #include <memory>
 
@@ -40,6 +41,9 @@ calyx::InstanceOp createInstance(Location loc, OpBuilder &builder,
                                  SmallVectorImpl<Type> &resultTypes,
                                  std::string &instanceName,
                                  StringRef componentName);
+
+/// A helper function to get the instance name.
+std::string getInstanceName(mlir::func::CallOp callOp);
 
 // Returns whether this operation is a leaf node in the Calyx control.
 // TODO(github.com/llvm/circt/issues/1679): Add Invoke.

--- a/include/circt/Dialect/Calyx/CalyxHelpers.h
+++ b/include/circt/Dialect/Calyx/CalyxHelpers.h
@@ -39,7 +39,7 @@ hw::ConstantOp createConstant(Location loc, OpBuilder &builder,
 calyx::InstanceOp createInstance(Location loc, OpBuilder &builder,
                                  ComponentOp component,
                                  SmallVectorImpl<Type> &resultTypes,
-                                 std::string &instanceName,
+                                 StringRef instanceName,
                                  StringRef componentName);
 
 /// A helper function to get the instance name.

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -394,6 +394,12 @@ public:
   /// the original function maps to.
   unsigned getFuncOpResultMapping(unsigned funcReturnIdx);
 
+  /// The instance is obtained from the name of the callee.
+  InstanceOp getInstance(StringRef calleeName);
+
+  /// Put the name of the callee and the instance of the call into map.
+  void addInstance(StringRef calleeName, InstanceOp instanceOp);
+
   /// Return the group which evaluates the value v. Optionally, caller may
   /// specify the expected type of the group.
   template <typename TGroupOp = calyx::GroupInterface>
@@ -452,6 +458,9 @@ private:
   /// A mapping between the source funcOp result indices and the corresponding
   /// output port indices of this componentOp.
   DenseMap<unsigned, unsigned> funcOpResultMapping;
+
+  /// A mapping between the callee and the instance.
+  llvm::StringMap<calyx::InstanceOp> instanceMap;
 };
 
 /// An interface for conversion passes that lower Calyx programs. This handles
@@ -732,6 +741,17 @@ class BuildReturnRegs : public calyx::FuncOpPartialLoweringPattern {
   LogicalResult
   partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
                            PatternRewriter &rewriter) const override;
+};
+
+/// Builds instance for the calyx.invoke and calyx.group in order to initialize
+/// the instance.
+class BuildCallInstance : public calyx::FuncOpPartialLoweringPattern {
+  using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
+
+  LogicalResult
+  partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
+                           PatternRewriter &rewriter) const override;
+  ComponentOp getCallComponent(mlir::func::CallOp callOp) const;
 };
 
 } // namespace calyx

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1059,7 +1059,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
         funcOp.getLoc(), rewriter.getStringAttr(funcOp.getSymName()), ports);
 
     std::string funcName = "func_" + funcOp.getSymName().str();
-    funcOp.setSymName(funcName);
+    rewriter.updateRootInPlace(funcOp, [&]() { funcOp.setSymName(funcName); });
 
     /// Mark this component as the toplevel.
     compOp->setAttr("toplevel", rewriter.getUnitAttr());

--- a/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
@@ -39,7 +39,7 @@ hw::ConstantOp createConstant(Location loc, OpBuilder &builder,
 calyx::InstanceOp createInstance(Location loc, OpBuilder &builder,
                                  ComponentOp component,
                                  SmallVectorImpl<Type> &resultTypes,
-                                 std::string &instanceName,
+                                 StringRef instanceName,
                                  StringRef componentName) {
   OpBuilder::InsertionGuard g(builder);
   builder.setInsertionPointToStart(component.getBodyBlock());

--- a/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
@@ -48,7 +48,8 @@ calyx::InstanceOp createInstance(Location loc, OpBuilder &builder,
 }
 
 std::string getInstanceName(mlir::func::CallOp callOp) {
-  return callOp.getCallee().str() + "_instance";
+  SmallVector<StringRef, 2> strVet = {callOp.getCallee(), "instance"};
+  return llvm::join(strVet, "_");
 }
 
 bool isControlLeafNode(Operation *op) { return isa<calyx::EnableOp>(op); }

--- a/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
@@ -49,7 +49,7 @@ calyx::InstanceOp createInstance(Location loc, OpBuilder &builder,
 
 std::string getInstanceName(mlir::func::CallOp callOp) {
   SmallVector<StringRef, 2> strVet = {callOp.getCallee(), "instance"};
-  return llvm::join(strVet, "_");
+  return llvm::join(strVet, /*separator=*/"_");
 }
 
 bool isControlLeafNode(Operation *op) { return isa<calyx::EnableOp>(op); }

--- a/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
@@ -47,6 +47,10 @@ calyx::InstanceOp createInstance(Location loc, OpBuilder &builder,
                                     componentName);
 }
 
+std::string getInstanceName(mlir::func::CallOp callOp) {
+  return callOp.getCallee().str() + "_instance";
+}
+
 bool isControlLeafNode(Operation *op) { return isa<calyx::EnableOp>(op); }
 
 DictionaryAttr getMandatoryPortAttr(MLIRContext *ctx, StringRef name) {

--- a/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
@@ -36,6 +36,17 @@ hw::ConstantOp createConstant(Location loc, OpBuilder &builder,
                                         APInt(width, value, /*unsigned=*/true));
 }
 
+calyx::InstanceOp createInstance(Location loc, OpBuilder &builder,
+                                 ComponentOp component,
+                                 SmallVectorImpl<Type> &resultTypes,
+                                 std::string &instanceName,
+                                 StringRef componentName) {
+  OpBuilder::InsertionGuard g(builder);
+  builder.setInsertionPointToStart(component.getBodyBlock());
+  return builder.create<InstanceOp>(loc, resultTypes, instanceName,
+                                    componentName);
+}
+
 bool isControlLeafNode(Operation *op) { return isa<calyx::EnableOp>(op); }
 
 DictionaryAttr getMandatoryPortAttr(MLIRContext *ctx, StringRef name) {

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -770,7 +770,7 @@ BuildCallInstance::partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
       resultTypes.push_back(type);
     std::string instanceName = getInstanceName(callOp);
 
-    // Determines if an instance needs to be created.If the same function was
+    // Determines if an instance needs to be created. If the same function was
     // called by CallOp before, it doesn't need to be created, if not, the
     // instance is created.
     if (!getState().getInstance(instanceName)) {

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -397,6 +397,15 @@ unsigned ComponentLoweringStateInterface::getFuncOpResultMapping(
   return it->second;
 }
 
+InstanceOp ComponentLoweringStateInterface::getInstance(StringRef calleeName) {
+  return instanceMap[calleeName];
+}
+
+void ComponentLoweringStateInterface::addInstance(StringRef calleeName,
+                                                  InstanceOp instanceOp) {
+  instanceMap[calleeName] = instanceOp;
+}
+
 //===----------------------------------------------------------------------===//
 // CalyxLoweringState
 //===----------------------------------------------------------------------===//
@@ -633,7 +642,8 @@ void InlineCombGroups::recurseInlineCombGroups(
         isa<calyx::RegisterOp, calyx::MemoryOp, calyx::SeqMemoryOp,
             hw::ConstantOp, mlir::arith::ConstantOp, calyx::MultPipeLibOp,
             calyx::DivUPipeLibOp, calyx::DivSPipeLibOp, calyx::RemSPipeLibOp,
-            calyx::RemUPipeLibOp, mlir::scf::WhileOp>(src.getDefiningOp()))
+            calyx::RemUPipeLibOp, mlir::scf::WhileOp, calyx::InstanceOp>(
+            src.getDefiningOp()))
       continue;
 
     auto srcCombGroup = dyn_cast<calyx::CombGroupOp>(
@@ -742,6 +752,66 @@ BuildReturnRegs::partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
         reg.getOut());
   }
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// BuildCallInstance
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+BuildCallInstance::partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
+                                            PatternRewriter &rewriter) const {
+  funcOp.walk([&](mlir::func::CallOp callOp) {
+    ComponentOp componentOp = getCallComponent(callOp);
+    SmallVector<Type, 8> resultTypes;
+    for (auto type : componentOp.getArgumentTypes())
+      resultTypes.push_back(type);
+    for (auto type : componentOp.getResultTypes())
+      resultTypes.push_back(type);
+    std::string instanceName = callOp.getCallee().str() + "_instance";
+
+    // Determines if an instance needs to be created.If the same function was
+    // called by CallOp before, it doesn't need to be created, if not, the
+    // instance is created.
+    if (!getState().getInstance(instanceName)) {
+      InstanceOp instanceOp =
+          createInstance(callOp.getLoc(), rewriter, getComponent(), resultTypes,
+                         instanceName, componentOp.getName());
+      getState().addInstance(instanceName, instanceOp);
+      hw::ConstantOp constantOp =
+          createConstant(callOp.getLoc(), rewriter, getComponent(), 1, 1);
+      OpBuilder::InsertionGuard g(rewriter);
+      rewriter.setInsertionPointToStart(
+          getComponent().getWiresOp().getBodyBlock());
+
+      // Creates the group that initializes the instance.
+      calyx::GroupOp groupOp = rewriter.create<calyx::GroupOp>(
+          callOp.getLoc(), "init_" + instanceName);
+      rewriter.setInsertionPointToStart(groupOp.getBodyBlock());
+      auto portInfos = instanceOp.getReferencedComponent().getPortInfo();
+      auto results = instanceOp.getResults();
+      for (auto [portInfo, result] : llvm::zip(portInfos, results)) {
+        if (portInfo.hasAttribute("go"))
+          rewriter.create<calyx::AssignOp>(callOp.getLoc(), result, constantOp);
+        else if (portInfo.hasAttribute("reset"))
+          rewriter.create<calyx::AssignOp>(callOp.getLoc(), result, constantOp);
+        else if (portInfo.hasAttribute("done"))
+          rewriter.create<calyx::GroupDoneOp>(callOp.getLoc(), result);
+      }
+    }
+    WalkResult::advance();
+  });
+  return success();
+}
+
+ComponentOp
+BuildCallInstance::getCallComponent(mlir::func::CallOp callOp) const {
+  std::string callee = "func_" + callOp.getCallee().str();
+  for (auto [funcOp, componentOp] : functionMapping) {
+    if (funcOp.getSymName() == callee)
+      return componentOp;
+  }
+  return nullptr;
 }
 
 } // namespace calyx

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -768,7 +768,7 @@ BuildCallInstance::partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
       resultTypes.push_back(type);
     for (auto type : componentOp.getResultTypes())
       resultTypes.push_back(type);
-    std::string instanceName = callOp.getCallee().str() + "_instance";
+    std::string instanceName = getInstanceName(callOp);
 
     // Determines if an instance needs to be created.If the same function was
     // called by CallOp before, it doesn't need to be created, if not, the
@@ -790,10 +790,8 @@ BuildCallInstance::partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
       rewriter.setInsertionPointToStart(groupOp.getBodyBlock());
       auto portInfos = instanceOp.getReferencedComponent().getPortInfo();
       auto results = instanceOp.getResults();
-      for (auto [portInfo, result] : llvm::zip(portInfos, results)) {
-        if (portInfo.hasAttribute("go"))
-          rewriter.create<calyx::AssignOp>(callOp.getLoc(), result, constantOp);
-        else if (portInfo.hasAttribute("reset"))
+      for (const auto &[portInfo, result] : llvm::zip(portInfos, results)) {
+        if (portInfo.hasAttribute("go") || portInfo.hasAttribute("reset"))
           rewriter.create<calyx::AssignOp>(callOp.getLoc(), result, constantOp);
         else if (portInfo.hasAttribute("done"))
           rewriter.create<calyx::GroupDoneOp>(callOp.getLoc(), result);

--- a/test/Conversion/SCFToCalyx/convert_func.mlir
+++ b/test/Conversion/SCFToCalyx/convert_func.mlir
@@ -1,122 +1,28 @@
 // RUN: circt-opt %s --lower-scf-to-calyx="top-level-function=main" -canonicalize -split-input-file | FileCheck %s
 
-// CHECK:      calyx.component @main(%clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
-// CHECK-DAG:    %c1_i32 = hw.constant 1 : i32
-// CHECK-DAG:    %c2_i32 = hw.constant 2 : i32
-// CHECK-DAG:    %true = hw.constant true
-// CHECK-DAG:    %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:    %fun_instance.in0, %fun_instance.in1, %fun_instance.clk, %fun_instance.reset, %fun_instance.go, %fun_instance.out0, %fun_instance.done = calyx.instance @fun_instance of @fun : i32, i32, i1, i1, i1, i32, i1
-// CHECK-NEXT:   calyx.wires {
-// CHECK-NEXT:     calyx.assign %out0 = %ret_arg0_reg.out : i32
-// CHECK-NEXT:     calyx.group @init_fun_instance {
-// CHECK-NEXT:       calyx.assign %fun_instance.reset = %true : i1
-// CHECK-NEXT:       calyx.assign %fun_instance.go = %true : i1
-// CHECK-NEXT:       calyx.group_done %fun_instance.done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.group @ret_assign_0 {
-// CHECK-NEXT:       calyx.assign %ret_arg0_reg.in = %fun_instance.out0 : i32
-// CHECK-NEXT:       calyx.assign %ret_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:       calyx.group_done %ret_arg0_reg.done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-NEXT:   calyx.control {
-// CHECK-NEXT:     calyx.seq {
-// CHECK-NEXT:       calyx.enable @init_fun_instance
-// CHECK-NEXT:       calyx.invoke @fun_instance(%fun_instance.in0 = %c1_i32, %fun_instance.in1 = %c2_i32) -> (i32, i32)
-// CHECK-NEXT:       calyx.enable @ret_assign_0
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-NEXT: } {toplevel}
+// CHECK-LABEL:   calyx.enable @init_func_instance
+// CHECK:         calyx.invoke @func_instance(%[[VAL_0:.*]] = %[[VAL_1:.*]]) -> (i32)
 
 module {
-  func.func @fun(%a0 : i32, %a1 : i32) -> i32 {
-    %0 = arith.addi %a0, %a1 : i32
-    %1 = arith.shli %0, %a0 : i32
-    %2 = arith.subi %1, %0 : i32
-    return %2 : i32
+  func.func @func(%0 : i32) -> i32 {
+    return %0 : i32
   }
 
   func.func @main() -> i32 {
-    %0 = arith.constant 1 : i32
-    %1 = arith.constant 2 : i32
-    %ret = func.call @fun(%0, %1) : (i32, i32) -> i32 
-    func.return %ret : i32
+    %0 = arith.constant 0 : i32
+    %1 = func.call @func(%0) : (i32) -> i32 
+    func.return %1 : i32
   } 
 }
 
 // -----
 
-// CHECK:      calyx.component @main(%clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
-// CHECK-DAG:    %true = hw.constant true
-// CHECK-DAG:    %c64_i32 = hw.constant 64 : i32
-// CHECK-DAG:    %c1_i32 = hw.constant 1 : i32
-// CHECK-DAG:    %c0_i32 = hw.constant 0 : i32
-// CHECK-DAG:    %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i6
-// CHECK-DAG:    %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
-// CHECK-DAG:    %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
-// CHECK-DAG:    %std_lt_0.left, %std_lt_0.right, %std_lt_0.out = calyx.std_lt @std_lt_0 : i32, i32, i1
-// CHECK-DAG:    %mem_1.addr0, %mem_1.write_data, %mem_1.write_en, %mem_1.write_done, %mem_1.clk, %mem_1.read_data, %mem_1.read_en, %mem_1.read_done = calyx.seq_mem @mem_1 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
-// CHECK-DAG:    %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.write_done, %mem_0.clk, %mem_0.read_data, %mem_0.read_en, %mem_0.read_done = calyx.seq_mem @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
-// CHECK-DAG:    %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register @while_0_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:    %fun_instance.in0, %fun_instance.in1, %fun_instance.clk, %fun_instance.reset, %fun_instance.go, %fun_instance.out0, %fun_instance.done = calyx.instance @fun_instance of @fun : i32, i32, i1, i1, i1, i32, i1
-// CHECK-NEXT:   calyx.wires {
-// CHECK-NEXT:     calyx.group @init_fun_instance {
-// CHECK-NEXT:       calyx.assign %fun_instance.reset = %true : i1
-// CHECK-NEXT:       calyx.assign %fun_instance.go = %true : i1
-// CHECK-NEXT:       calyx.group_done %fun_instance.done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.group @assign_while_0_init_0 {
-// CHECK-NEXT:       calyx.assign %while_0_arg0_reg.in = %c0_i32 : i32
-// CHECK-NEXT:       calyx.assign %while_0_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:       calyx.group_done %while_0_arg0_reg.done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.comb_group @bb0_0 {
-// CHECK-NEXT:       calyx.assign %std_lt_0.left = %while_0_arg0_reg.out : i32
-// CHECK-NEXT:       calyx.assign %std_lt_0.right = %c64_i32 : i32
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.group @bb0_1 {
-// CHECK-NEXT:       calyx.assign %std_slice_1.in = %while_0_arg0_reg.out : i32
-// CHECK-NEXT:       calyx.assign %mem_0.addr0 = %std_slice_1.out : i6
-// CHECK-NEXT:       calyx.assign %mem_0.read_en = %true : i1
-// CHECK-NEXT:       calyx.group_done %mem_0.read_done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.group @bb0_2 {
-// CHECK-NEXT:       calyx.assign %std_slice_0.in = %while_0_arg0_reg.out : i32
-// CHECK-NEXT:       calyx.assign %mem_1.addr0 = %std_slice_0.out : i6
-// CHECK-NEXT:       calyx.assign %mem_1.write_data = %fun_instance.out0 : i32
-// CHECK-NEXT:       calyx.assign %mem_1.write_en = %true : i1
-// CHECK-NEXT:       calyx.group_done %mem_1.write_done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.group @assign_while_0_latch {
-// CHECK-NEXT:       calyx.assign %while_0_arg0_reg.in = %std_add_0.out : i32
-// CHECK-NEXT:       calyx.assign %while_0_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:       calyx.assign %std_add_0.left = %while_0_arg0_reg.out : i32
-// CHECK-NEXT:       calyx.assign %std_add_0.right = %c1_i32 : i32
-// CHECK-NEXT:       calyx.group_done %while_0_arg0_reg.done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-NEXT:   calyx.control {
-// CHECK-NEXT:     calyx.seq {
-// CHECK-NEXT:       calyx.enable @assign_while_0_init_0
-// CHECK-NEXT:       calyx.while %std_lt_0.out with @bb0_0 {
-// CHECK-NEXT:         calyx.seq {
-// CHECK-NEXT:           calyx.enable @bb0_1
-// CHECK-NEXT:           calyx.enable @init_fun_instance
-// CHECK-NEXT:           calyx.invoke @fun_instance(%fun_instance.in0 = %mem_0.read_data, %fun_instance.in1 = %mem_0.read_data) -> (i32, i32)
-// CHECK-NEXT:           calyx.enable @bb0_2
-// CHECK-NEXT:           calyx.enable @assign_while_0_latch
-// CHECK-NEXT:         }
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-NEXT: } {toplevel}
+// CHECK-LABEL:   calyx.enable @init_func_instance
+// CHECK:         calyx.invoke @func_instance(%[[VAL_0:.*]] = %[[VAL_1:.*]]) -> (i32)
 
 module {
-  func.func @fun(%a0 : i32, %a1 : i32) -> i32 {
-    %0 = arith.addi %a0, %a1 : i32
-    %1 = arith.shli %0, %a0 : i32
-    %2 = arith.subi %1, %0 : i32
-    return %2 : i32
+  func.func @func(%0 : i32) -> i32 {
+    return %0 : i32
   }
 
   func.func @main() {
@@ -125,15 +31,13 @@ module {
     %c64 = arith.constant 64 : index
     %0 = memref.alloc() : memref<64xi32>
     %1 = memref.alloc() : memref<64xi32>  
-    %c0i32 = arith.constant 1 : i32
-    %c1i32 = arith.constant 2 : i32
     scf.while(%arg0 = %c0) : (index) -> (index) {
       %cond = arith.cmpi ult, %arg0, %c64 : index
       scf.condition(%cond) %arg0 : index
     } do {
     ^bb0(%arg1: index):
       %v = memref.load %0[%arg1] : memref<64xi32>
-      %c = func.call @fun(%v, %v) : (i32, i32) -> i32
+      %c = func.call @func(%v) : (i32) -> i32
       memref.store %c, %1[%arg1] : memref<64xi32>
       %inc = arith.addi %arg1, %c1 : index
       scf.yield %inc : index
@@ -144,73 +48,12 @@ module {
 
 // -----
 
-// CHECK:      calyx.component @main(%clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
-// CHECK-DAG:    %true = hw.constant true
-// CHECK-DAG:    %c0_i32 = hw.constant 0 : i32
-// CHECK-DAG:    %c1_i32 = hw.constant 1 : i32
-// CHECK-DAG:    %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i6
-// CHECK-DAG:    %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
-// CHECK-DAG:    %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
-// CHECK-DAG:    %load_0_reg.in, %load_0_reg.write_en, %load_0_reg.clk, %load_0_reg.reset, %load_0_reg.out, %load_0_reg.done = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:    %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.write_done, %mem_0.clk, %mem_0.read_data, %mem_0.read_en, %mem_0.read_done = calyx.seq_mem @mem_0 <[40] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
-// CHECK-DAG:    %for_0_induction_var_reg.in, %for_0_induction_var_reg.write_en, %for_0_induction_var_reg.clk, %for_0_induction_var_reg.reset, %for_0_induction_var_reg.out, %for_0_induction_var_reg.done = calyx.register @for_0_induction_var_reg : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:    %fun_instance.in0, %fun_instance.in1, %fun_instance.clk, %fun_instance.reset, %fun_instance.go, %fun_instance.out0, %fun_instance.done = calyx.instance @fun_instance of @fun : i32, i32, i1, i1, i1, i32, i1
-// CHECK-NEXT:   calyx.wires {
-// CHECK-NEXT:     calyx.group @init_fun_instance {
-// CHECK-NEXT:       calyx.assign %fun_instance.reset = %true : i1
-// CHECK-NEXT:       calyx.assign %fun_instance.go = %true : i1
-// CHECK-NEXT:       calyx.group_done %fun_instance.done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.group @init_for_0_induction_var {
-// CHECK-NEXT:       calyx.assign %for_0_induction_var_reg.in = %c0_i32 : i32
-// CHECK-NEXT:       calyx.assign %for_0_induction_var_reg.write_en = %true : i1
-// CHECK-NEXT:       calyx.group_done %for_0_induction_var_reg.done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.group @bb0_0 {
-// CHECK-NEXT:       calyx.assign %std_slice_1.in = %for_0_induction_var_reg.out : i32
-// CHECK-NEXT:       calyx.assign %mem_0.addr0 = %std_slice_1.out : i6
-// CHECK-NEXT:       calyx.assign %mem_0.read_en = %true : i1
-// CHECK-NEXT:       calyx.assign %load_0_reg.in = %mem_0.read_data : i32
-// CHECK-NEXT:       calyx.assign %load_0_reg.write_en = %mem_0.read_done : i1
-// CHECK-NEXT:       calyx.group_done %load_0_reg.done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.group @bb0_1 {
-// CHECK-NEXT:       calyx.assign %std_slice_0.in = %for_0_induction_var_reg.out : i32
-// CHECK-NEXT:       calyx.assign %mem_0.addr0 = %std_slice_0.out : i6
-// CHECK-NEXT:       calyx.assign %mem_0.write_data = %fun_instance.out0 : i32
-// CHECK-NEXT:       calyx.assign %mem_0.write_en = %true : i1
-// CHECK-NEXT:       calyx.group_done %mem_0.write_done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.group @incr_for_0_induction_var {
-// CHECK-NEXT:       calyx.assign %std_add_0.left = %for_0_induction_var_reg.out : i32
-// CHECK-NEXT:       calyx.assign %std_add_0.right = %c1_i32 : i32
-// CHECK-NEXT:       calyx.assign %for_0_induction_var_reg.in = %std_add_0.out : i32
-// CHECK-NEXT:       calyx.assign %for_0_induction_var_reg.write_en = %true : i1
-// CHECK-NEXT:       calyx.group_done %for_0_induction_var_reg.done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-NEXT:   calyx.control {
-// CHECK-NEXT:     calyx.seq {
-// CHECK-NEXT:       calyx.enable @init_for_0_induction_var
-// CHECK-NEXT:       calyx.repeat 40 {
-// CHECK-NEXT:         calyx.seq {
-// CHECK-NEXT:           calyx.enable @bb0_0
-// CHECK-NEXT:           calyx.enable @init_fun_instance
-// CHECK-NEXT:           calyx.invoke @fun_instance(%fun_instance.in0 = %load_0_reg.out, %fun_instance.in1 = %load_0_reg.out) -> (i32, i32)
-// CHECK-NEXT:           calyx.enable @bb0_1
-// CHECK-NEXT:           calyx.enable @incr_for_0_induction_var
-// CHECK-NEXT:         }
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-NEXT: } {toplevel}
+// CHECK-LABEL:   calyx.enable @init_fun_instance
+// CHECK:         calyx.invoke @fun_instance(%[[VAL_0:.*]] = %[[VAL_1:.*]]) -> (i32)
 
 module {
-  func.func @fun(%a0 : i32, %a1 : i32) -> i32 {
-    %0 = arith.addi %a0, %a1 : i32
-    %1 = arith.shli %0, %a0 : i32
-    %2 = arith.subi %1, %0 : i32
-    return %2 : i32
+  func.func @fun(%0 : i32) -> i32 {
+    return %0 : i32
   }
 
   func.func @main() {
@@ -220,7 +63,7 @@ module {
     %c1 = arith.constant 1 : index
     scf.for %arg0 = %c0 to %c40 step %c1 {
       %0 = memref.load %alloca[%arg0] : memref<40xi32>
-      %1 = func.call @fun(%0, %0) : (i32, i32) -> i32 
+      %1 = func.call @fun(%0) : (i32) -> i32 
       memref.store %1, %alloca[%arg0] : memref<40xi32>
     }
     return
@@ -229,64 +72,14 @@ module {
 
 // -----
 
-// CHECK:      calyx.component @main(%in0: i32, %in1: i32, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
-// CHECK-DAG:    %true = hw.constant true
-// CHECK-DAG:    %std_ge_0.left, %std_ge_0.right, %std_ge_0.out = calyx.std_ge @std_ge_0 : i32, i32, i1
-// CHECK-DAG:    %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add @std_add_1 : i32, i32, i32
-// CHECK-DAG:    %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
-// CHECK-DAG:    %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK-DAG:    %func_instance.in0, %func_instance.in1, %func_instance.clk, %func_instance.reset, %func_instance.go, %func_instance.out0, %func_instance.done = calyx.instance @func_instance of @func : i32, i32, i1, i1, i1, i32, i1
-// CHECK-NEXT:   calyx.wires {
-// CHECK-NEXT:     calyx.assign %out0 = %ret_arg0_reg.out : i32
-// CHECK-NEXT:     calyx.group @init_func_instance {
-// CHECK-NEXT:       calyx.assign %func_instance.reset = %true : i1
-// CHECK-NEXT:       calyx.assign %func_instance.go = %true : i1
-// CHECK-NEXT:       calyx.group_done %func_instance.done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.comb_group @bb0_2 {
-// CHECK-NEXT:       calyx.assign %std_ge_0.left = %std_add_1.out : i32
-// CHECK-NEXT:       calyx.assign %std_ge_0.right = %in2 : i32
-// CHECK-NEXT:       calyx.assign %std_add_1.left = %std_add_0.out : i32
-// CHECK-NEXT:       calyx.assign %std_add_0.left = %in0 : i32
-// CHECK-NEXT:       calyx.assign %std_add_0.right = %in1 : i32
-// CHECK-NEXT:       calyx.assign %std_add_1.right = %in1 : i32
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.group @ret_assign_0 {
-// CHECK-NEXT:       calyx.assign %ret_arg0_reg.in = %func_instance.out0 : i32
-// CHECK-NEXT:       calyx.assign %ret_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:       calyx.group_done %ret_arg0_reg.done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:     calyx.group @ret_assign_1 {
-// CHECK-NEXT:       calyx.assign %ret_arg0_reg.in = %func_instance.out0 : i32
-// CHECK-NEXT:       calyx.assign %ret_arg0_reg.write_en = %true : i1
-// CHECK-NEXT:       calyx.group_done %ret_arg0_reg.done : i1
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-NEXT:   calyx.control {
-// CHECK-NEXT:     calyx.seq {
-// CHECK-NEXT:       calyx.if %std_ge_0.out with @bb0_2 {
-// CHECK-NEXT:         calyx.seq {
-// CHECK-NEXT:           calyx.enable @init_func_instance
-// CHECK-NEXT:           calyx.invoke @func_instance(%func_instance.in0 = %std_add_0.out, %func_instance.in1 = %std_add_1.out) -> (i32, i32)
-// CHECK-NEXT:           calyx.enable @ret_assign_0
-// CHECK-NEXT:         }
-// CHECK-NEXT:       } else {
-// CHECK-NEXT:         calyx.seq {
-// CHECK-NEXT:           calyx.enable @init_func_instance
-// CHECK-NEXT:           calyx.invoke @func_instance(%func_instance.in0 = %std_add_0.out, %func_instance.in1 = %std_add_1.out) -> (i32, i32)
-// CHECK-NEXT:           calyx.enable @ret_assign_1
-// CHECK-NEXT:         }
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-NEXT: } {toplevel}
+// CHECK-LABEL:   calyx.enable @init_func_instance
+// CHECK:         calyx.invoke @func_instance(%[[VAL_0:.*]] = %[[VAL_1:.*]]) -> (i32)
+// CHECK:         calyx.enable @init_func_instance
+// CHECK:         calyx.invoke @func_instance(%[[VAL_2:.*]] = %[[VAL_3:.*]]) -> (i32)
 
 module {
-  func.func @func(%a0 : i32, %a1 : i32) -> i32 {
-    %0 = arith.addi %a0, %a1 : i32
-    %1 = arith.shli %0, %a0 : i32
-    %2 = arith.subi %1, %0 : i32
-    return %2 : i32
+  func.func @func(%0 : i32) -> i32 { 
+    return %0 : i32
   }
 
   func.func @main(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 {
@@ -295,10 +88,10 @@ module {
     %b = arith.cmpi uge, %1, %a2 : i32
     cf.cond_br %b, ^bb1, ^bb2
   ^bb1:
-    %ret0 = func.call @func(%0, %1) : (i32, i32) -> i32
+    %ret0 = func.call @func(%0) : (i32) -> i32
     return %ret0 : i32
   ^bb2:
-    %ret1 = func.call @func(%0, %1) : (i32, i32) -> i32
+    %ret1 = func.call @func(%1) : (i32) -> i32
     return %ret1 : i32
   }
 }

--- a/test/Conversion/SCFToCalyx/convert_func.mlir
+++ b/test/Conversion/SCFToCalyx/convert_func.mlir
@@ -1,0 +1,304 @@
+// RUN: circt-opt %s --lower-scf-to-calyx="top-level-function=main" -canonicalize -split-input-file | FileCheck %s
+
+// CHECK:      calyx.component @main(%clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
+// CHECK-DAG:    %c1_i32 = hw.constant 1 : i32
+// CHECK-DAG:    %c2_i32 = hw.constant 2 : i32
+// CHECK-DAG:    %true = hw.constant true
+// CHECK-DAG:    %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:    %fun_instance.in0, %fun_instance.in1, %fun_instance.clk, %fun_instance.reset, %fun_instance.go, %fun_instance.out0, %fun_instance.done = calyx.instance @fun_instance of @fun : i32, i32, i1, i1, i1, i32, i1
+// CHECK-NEXT:   calyx.wires {
+// CHECK-NEXT:     calyx.assign %out0 = %ret_arg0_reg.out : i32
+// CHECK-NEXT:     calyx.group @init_fun_instance {
+// CHECK-NEXT:       calyx.assign %fun_instance.reset = %true : i1
+// CHECK-NEXT:       calyx.assign %fun_instance.go = %true : i1
+// CHECK-NEXT:       calyx.group_done %fun_instance.done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.group @ret_assign_0 {
+// CHECK-NEXT:       calyx.assign %ret_arg0_reg.in = %fun_instance.out0 : i32
+// CHECK-NEXT:       calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:       calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   calyx.control {
+// CHECK-NEXT:     calyx.seq {
+// CHECK-NEXT:       calyx.enable @init_fun_instance
+// CHECK-NEXT:       calyx.invoke @fun_instance(%fun_instance.in0 = %c1_i32, %fun_instance.in1 = %c2_i32) -> (i32, i32)
+// CHECK-NEXT:       calyx.enable @ret_assign_0
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: } {toplevel}
+
+module {
+  func.func @fun(%a0 : i32, %a1 : i32) -> i32 {
+    %0 = arith.addi %a0, %a1 : i32
+    %1 = arith.shli %0, %a0 : i32
+    %2 = arith.subi %1, %0 : i32
+    return %2 : i32
+  }
+
+  func.func @main() -> i32 {
+    %0 = arith.constant 1 : i32
+    %1 = arith.constant 2 : i32
+    %ret = func.call @fun(%0, %1) : (i32, i32) -> i32 
+    func.return %ret : i32
+  } 
+}
+
+// -----
+
+// CHECK:      calyx.component @main(%clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
+// CHECK-DAG:    %true = hw.constant true
+// CHECK-DAG:    %c64_i32 = hw.constant 64 : i32
+// CHECK-DAG:    %c1_i32 = hw.constant 1 : i32
+// CHECK-DAG:    %c0_i32 = hw.constant 0 : i32
+// CHECK-DAG:    %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i6
+// CHECK-DAG:    %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK-DAG:    %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK-DAG:    %std_lt_0.left, %std_lt_0.right, %std_lt_0.out = calyx.std_lt @std_lt_0 : i32, i32, i1
+// CHECK-DAG:    %mem_1.addr0, %mem_1.write_data, %mem_1.write_en, %mem_1.write_done, %mem_1.clk, %mem_1.read_data, %mem_1.read_en, %mem_1.read_done = calyx.seq_mem @mem_1 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
+// CHECK-DAG:    %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.write_done, %mem_0.clk, %mem_0.read_data, %mem_0.read_en, %mem_0.read_done = calyx.seq_mem @mem_0 <[64] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
+// CHECK-DAG:    %while_0_arg0_reg.in, %while_0_arg0_reg.write_en, %while_0_arg0_reg.clk, %while_0_arg0_reg.reset, %while_0_arg0_reg.out, %while_0_arg0_reg.done = calyx.register @while_0_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:    %fun_instance.in0, %fun_instance.in1, %fun_instance.clk, %fun_instance.reset, %fun_instance.go, %fun_instance.out0, %fun_instance.done = calyx.instance @fun_instance of @fun : i32, i32, i1, i1, i1, i32, i1
+// CHECK-NEXT:   calyx.wires {
+// CHECK-NEXT:     calyx.group @init_fun_instance {
+// CHECK-NEXT:       calyx.assign %fun_instance.reset = %true : i1
+// CHECK-NEXT:       calyx.assign %fun_instance.go = %true : i1
+// CHECK-NEXT:       calyx.group_done %fun_instance.done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.group @assign_while_0_init_0 {
+// CHECK-NEXT:       calyx.assign %while_0_arg0_reg.in = %c0_i32 : i32
+// CHECK-NEXT:       calyx.assign %while_0_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:       calyx.group_done %while_0_arg0_reg.done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.comb_group @bb0_0 {
+// CHECK-NEXT:       calyx.assign %std_lt_0.left = %while_0_arg0_reg.out : i32
+// CHECK-NEXT:       calyx.assign %std_lt_0.right = %c64_i32 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.group @bb0_1 {
+// CHECK-NEXT:       calyx.assign %std_slice_1.in = %while_0_arg0_reg.out : i32
+// CHECK-NEXT:       calyx.assign %mem_0.addr0 = %std_slice_1.out : i6
+// CHECK-NEXT:       calyx.assign %mem_0.read_en = %true : i1
+// CHECK-NEXT:       calyx.group_done %mem_0.read_done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.group @bb0_2 {
+// CHECK-NEXT:       calyx.assign %std_slice_0.in = %while_0_arg0_reg.out : i32
+// CHECK-NEXT:       calyx.assign %mem_1.addr0 = %std_slice_0.out : i6
+// CHECK-NEXT:       calyx.assign %mem_1.write_data = %fun_instance.out0 : i32
+// CHECK-NEXT:       calyx.assign %mem_1.write_en = %true : i1
+// CHECK-NEXT:       calyx.group_done %mem_1.write_done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.group @assign_while_0_latch {
+// CHECK-NEXT:       calyx.assign %while_0_arg0_reg.in = %std_add_0.out : i32
+// CHECK-NEXT:       calyx.assign %while_0_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:       calyx.assign %std_add_0.left = %while_0_arg0_reg.out : i32
+// CHECK-NEXT:       calyx.assign %std_add_0.right = %c1_i32 : i32
+// CHECK-NEXT:       calyx.group_done %while_0_arg0_reg.done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   calyx.control {
+// CHECK-NEXT:     calyx.seq {
+// CHECK-NEXT:       calyx.enable @assign_while_0_init_0
+// CHECK-NEXT:       calyx.while %std_lt_0.out with @bb0_0 {
+// CHECK-NEXT:         calyx.seq {
+// CHECK-NEXT:           calyx.enable @bb0_1
+// CHECK-NEXT:           calyx.enable @init_fun_instance
+// CHECK-NEXT:           calyx.invoke @fun_instance(%fun_instance.in0 = %mem_0.read_data, %fun_instance.in1 = %mem_0.read_data) -> (i32, i32)
+// CHECK-NEXT:           calyx.enable @bb0_2
+// CHECK-NEXT:           calyx.enable @assign_while_0_latch
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: } {toplevel}
+
+module {
+  func.func @fun(%a0 : i32, %a1 : i32) -> i32 {
+    %0 = arith.addi %a0, %a1 : i32
+    %1 = arith.shli %0, %a0 : i32
+    %2 = arith.subi %1, %0 : i32
+    return %2 : i32
+  }
+
+  func.func @main() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    %0 = memref.alloc() : memref<64xi32>
+    %1 = memref.alloc() : memref<64xi32>  
+    %c0i32 = arith.constant 1 : i32
+    %c1i32 = arith.constant 2 : i32
+    scf.while(%arg0 = %c0) : (index) -> (index) {
+      %cond = arith.cmpi ult, %arg0, %c64 : index
+      scf.condition(%cond) %arg0 : index
+    } do {
+    ^bb0(%arg1: index):
+      %v = memref.load %0[%arg1] : memref<64xi32>
+      %c = func.call @fun(%v, %v) : (i32, i32) -> i32
+      memref.store %c, %1[%arg1] : memref<64xi32>
+      %inc = arith.addi %arg1, %c1 : index
+      scf.yield %inc : index
+    }
+    return
+  }
+}
+
+// -----
+
+// CHECK:      calyx.component @main(%clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
+// CHECK-DAG:    %true = hw.constant true
+// CHECK-DAG:    %c0_i32 = hw.constant 0 : i32
+// CHECK-DAG:    %c1_i32 = hw.constant 1 : i32
+// CHECK-DAG:    %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i6
+// CHECK-DAG:    %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK-DAG:    %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK-DAG:    %load_0_reg.in, %load_0_reg.write_en, %load_0_reg.clk, %load_0_reg.reset, %load_0_reg.out, %load_0_reg.done = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:    %mem_0.addr0, %mem_0.write_data, %mem_0.write_en, %mem_0.write_done, %mem_0.clk, %mem_0.read_data, %mem_0.read_en, %mem_0.read_done = calyx.seq_mem @mem_0 <[40] x 32> [6] {external = true} : i6, i32, i1, i1, i1, i32, i1, i1
+// CHECK-DAG:    %for_0_induction_var_reg.in, %for_0_induction_var_reg.write_en, %for_0_induction_var_reg.clk, %for_0_induction_var_reg.reset, %for_0_induction_var_reg.out, %for_0_induction_var_reg.done = calyx.register @for_0_induction_var_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:    %fun_instance.in0, %fun_instance.in1, %fun_instance.clk, %fun_instance.reset, %fun_instance.go, %fun_instance.out0, %fun_instance.done = calyx.instance @fun_instance of @fun : i32, i32, i1, i1, i1, i32, i1
+// CHECK-NEXT:   calyx.wires {
+// CHECK-NEXT:     calyx.group @init_fun_instance {
+// CHECK-NEXT:       calyx.assign %fun_instance.reset = %true : i1
+// CHECK-NEXT:       calyx.assign %fun_instance.go = %true : i1
+// CHECK-NEXT:       calyx.group_done %fun_instance.done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.group @init_for_0_induction_var {
+// CHECK-NEXT:       calyx.assign %for_0_induction_var_reg.in = %c0_i32 : i32
+// CHECK-NEXT:       calyx.assign %for_0_induction_var_reg.write_en = %true : i1
+// CHECK-NEXT:       calyx.group_done %for_0_induction_var_reg.done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.group @bb0_0 {
+// CHECK-NEXT:       calyx.assign %std_slice_1.in = %for_0_induction_var_reg.out : i32
+// CHECK-NEXT:       calyx.assign %mem_0.addr0 = %std_slice_1.out : i6
+// CHECK-NEXT:       calyx.assign %mem_0.read_en = %true : i1
+// CHECK-NEXT:       calyx.assign %load_0_reg.in = %mem_0.read_data : i32
+// CHECK-NEXT:       calyx.assign %load_0_reg.write_en = %mem_0.read_done : i1
+// CHECK-NEXT:       calyx.group_done %load_0_reg.done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.group @bb0_1 {
+// CHECK-NEXT:       calyx.assign %std_slice_0.in = %for_0_induction_var_reg.out : i32
+// CHECK-NEXT:       calyx.assign %mem_0.addr0 = %std_slice_0.out : i6
+// CHECK-NEXT:       calyx.assign %mem_0.write_data = %fun_instance.out0 : i32
+// CHECK-NEXT:       calyx.assign %mem_0.write_en = %true : i1
+// CHECK-NEXT:       calyx.group_done %mem_0.write_done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.group @incr_for_0_induction_var {
+// CHECK-NEXT:       calyx.assign %std_add_0.left = %for_0_induction_var_reg.out : i32
+// CHECK-NEXT:       calyx.assign %std_add_0.right = %c1_i32 : i32
+// CHECK-NEXT:       calyx.assign %for_0_induction_var_reg.in = %std_add_0.out : i32
+// CHECK-NEXT:       calyx.assign %for_0_induction_var_reg.write_en = %true : i1
+// CHECK-NEXT:       calyx.group_done %for_0_induction_var_reg.done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   calyx.control {
+// CHECK-NEXT:     calyx.seq {
+// CHECK-NEXT:       calyx.enable @init_for_0_induction_var
+// CHECK-NEXT:       calyx.repeat 40 {
+// CHECK-NEXT:         calyx.seq {
+// CHECK-NEXT:           calyx.enable @bb0_0
+// CHECK-NEXT:           calyx.enable @init_fun_instance
+// CHECK-NEXT:           calyx.invoke @fun_instance(%fun_instance.in0 = %load_0_reg.out, %fun_instance.in1 = %load_0_reg.out) -> (i32, i32)
+// CHECK-NEXT:           calyx.enable @bb0_1
+// CHECK-NEXT:           calyx.enable @incr_for_0_induction_var
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: } {toplevel}
+
+module {
+  func.func @fun(%a0 : i32, %a1 : i32) -> i32 {
+    %0 = arith.addi %a0, %a1 : i32
+    %1 = arith.shli %0, %a0 : i32
+    %2 = arith.subi %1, %0 : i32
+    return %2 : i32
+  }
+
+  func.func @main() {
+    %alloca = memref.alloca() : memref<40xi32>
+    %c0 = arith.constant 0 : index
+    %c40 = arith.constant 40 : index
+    %c1 = arith.constant 1 : index
+    scf.for %arg0 = %c0 to %c40 step %c1 {
+      %0 = memref.load %alloca[%arg0] : memref<40xi32>
+      %1 = func.call @fun(%0, %0) : (i32, i32) -> i32 
+      memref.store %1, %alloca[%arg0] : memref<40xi32>
+    }
+    return
+  }
+}
+
+// -----
+
+// CHECK:      calyx.component @main(%in0: i32, %in1: i32, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
+// CHECK-DAG:    %true = hw.constant true
+// CHECK-DAG:    %std_ge_0.left, %std_ge_0.right, %std_ge_0.out = calyx.std_ge @std_ge_0 : i32, i32, i1
+// CHECK-DAG:    %std_add_1.left, %std_add_1.right, %std_add_1.out = calyx.std_add @std_add_1 : i32, i32, i32
+// CHECK-DAG:    %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK-DAG:    %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:    %func_instance.in0, %func_instance.in1, %func_instance.clk, %func_instance.reset, %func_instance.go, %func_instance.out0, %func_instance.done = calyx.instance @func_instance of @func : i32, i32, i1, i1, i1, i32, i1
+// CHECK-NEXT:   calyx.wires {
+// CHECK-NEXT:     calyx.assign %out0 = %ret_arg0_reg.out : i32
+// CHECK-NEXT:     calyx.group @init_func_instance {
+// CHECK-NEXT:       calyx.assign %func_instance.reset = %true : i1
+// CHECK-NEXT:       calyx.assign %func_instance.go = %true : i1
+// CHECK-NEXT:       calyx.group_done %func_instance.done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.comb_group @bb0_2 {
+// CHECK-NEXT:       calyx.assign %std_ge_0.left = %std_add_1.out : i32
+// CHECK-NEXT:       calyx.assign %std_ge_0.right = %in2 : i32
+// CHECK-NEXT:       calyx.assign %std_add_1.left = %std_add_0.out : i32
+// CHECK-NEXT:       calyx.assign %std_add_0.left = %in0 : i32
+// CHECK-NEXT:       calyx.assign %std_add_0.right = %in1 : i32
+// CHECK-NEXT:       calyx.assign %std_add_1.right = %in1 : i32
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.group @ret_assign_0 {
+// CHECK-NEXT:       calyx.assign %ret_arg0_reg.in = %func_instance.out0 : i32
+// CHECK-NEXT:       calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:       calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     calyx.group @ret_assign_1 {
+// CHECK-NEXT:       calyx.assign %ret_arg0_reg.in = %func_instance.out0 : i32
+// CHECK-NEXT:       calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-NEXT:       calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   calyx.control {
+// CHECK-NEXT:     calyx.seq {
+// CHECK-NEXT:       calyx.if %std_ge_0.out with @bb0_2 {
+// CHECK-NEXT:         calyx.seq {
+// CHECK-NEXT:           calyx.enable @init_func_instance
+// CHECK-NEXT:           calyx.invoke @func_instance(%func_instance.in0 = %std_add_0.out, %func_instance.in1 = %std_add_1.out) -> (i32, i32)
+// CHECK-NEXT:           calyx.enable @ret_assign_0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       } else {
+// CHECK-NEXT:         calyx.seq {
+// CHECK-NEXT:           calyx.enable @init_func_instance
+// CHECK-NEXT:           calyx.invoke @func_instance(%func_instance.in0 = %std_add_0.out, %func_instance.in1 = %std_add_1.out) -> (i32, i32)
+// CHECK-NEXT:           calyx.enable @ret_assign_1
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: } {toplevel}
+
+module {
+  func.func @func(%a0 : i32, %a1 : i32) -> i32 {
+    %0 = arith.addi %a0, %a1 : i32
+    %1 = arith.shli %0, %a0 : i32
+    %2 = arith.subi %1, %0 : i32
+    return %2 : i32
+  }
+
+  func.func @main(%a0 : i32, %a1 : i32, %a2 : i32) -> i32 {
+    %0 = arith.addi %a0, %a1 : i32
+    %1 = arith.addi %0, %a1 : i32
+    %b = arith.cmpi uge, %1, %a2 : i32
+    cf.cond_br %b, ^bb1, ^bb2
+  ^bb1:
+    %ret0 = func.call @func(%0, %1) : (i32, i32) -> i32
+    return %ret0 : i32
+  ^bb2:
+    %ret1 = func.call @func(%0, %1) : (i32, i32) -> i32
+    return %ret1 : i32
+  }
+}


### PR DESCRIPTION
Here's a few things about this PR.
* I set the sym_name property of func.func during the lower.
If you don't do this, it will crash the program when creating `calyx.instance` because `func.func` and `calyx.component` have the same `sym_name` attribute. There are two identical names in the symbol table .So the name of func.func during lower is "func_" + `sym_name`.If there's a better way to name it, let me know .
*  Code using scf-to-calyx may not convert to the calyx native compiler.
 This is because when creating calyx.invoke you can't get the specific names of the input and output ports (they can't be parsed in the pass).I apologize for this, to get the name of the port you have to go through parser.
* Currently I have not added integration tests
I noticed that calyx-to-hw doesn't appear to include an implementation of calyx.instance to HW dialect.
Feel free to let me know if you have any questions.Thanks!
