### PR TITLE
[ExtractInstances] Fix module prefix not being applied to NLA

### DIFF
--- a/test/Dialect/FIRRTL/extract-instances.mlir
+++ b/test/Dialect/FIRRTL/extract-instances.mlir
@@ -504,3 +504,21 @@ firrtl.circuit "InstSymConflict" {
   // CHECK-SAME: #hw.innerNameRef<@InstSymConflict::@bb>
   // CHECK-SAME: ]
 }
+
+// Module prefixing should not break extraction.
+// https://github.com/llvm/circt/issues/5961
+// CHECK-LABEL: firrtl.circuit "Plop_Foo"
+firrtl.circuit "Plop_Foo" attributes {annotations = [{class = "sifive.enterprise.firrtl.ExtractClockGatesFileAnnotation", filename = "ckgates.txt", group = "ClockGates"}]} {
+  // CHECK: firrtl.hierpath @nla_1 [@Plop_Foo::@ClockGates, @Plop_ClockGates::@ckg, @EICG_wrapper]
+  firrtl.hierpath @nla_1 [@Plop_Foo::@core, @Plop_Bar::@ckg, @EICG_wrapper]
+  firrtl.extmodule private @EICG_wrapper() attributes {defname = "EICG_wrapper"}
+  firrtl.module private @Plop_Bar() {
+    firrtl.instance ckg sym @ckg @EICG_wrapper()
+  }
+  // CHECK: firrtl.module @Plop_ClockGates()
+  // CHECK-LABEL: firrtl.module @Plop_Foo()
+  firrtl.module @Plop_Foo() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation", prefix = "Plop_"}]} {
+    // CHECK: firrtl.instance ClockGates sym @ClockGates @Plop_ClockGates()
+    firrtl.instance core sym @core @Plop_Bar()
+  }
+}


### PR DESCRIPTION
When instances are grouped after extraction, the group module would inherit the appropriate prefix from the DUT, but any hierarchical paths pointing to it would not include the prefix. Fix this by using the same name for the module and the hierarchical path.

Fixes #5961.