### PR TITLE
[OM] Add dedicated path attribute

### DIFF
--- a/include/circt/Dialect/OM/OMAttributes.td
+++ b/include/circt/Dialect/OM/OMAttributes.td
@@ -103,4 +103,22 @@ def MapAttr : AttrDef<OMDialect, "Map", [TypedAttrInterface]> {
   }];
 }
 
+def OMPathAttribute : AttrDef<OMDialect, "Path", [TypedAttrInterface]> {
+  let summary = "An attribute that represents a path";
+
+  let mnemonic = "path";
+
+  let parameters = (ins "::mlir::StringAttr":$path);
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$path)>
+  ];
+
+  let assemblyFormat = " `<` $path `>` ";
+
+  let extraClassDeclaration = [{
+    mlir::Type getType();
+  }];
+}
+
 #endif // CIRCT_DIALECT_OM_OMATTRIBUTES_TD

--- a/lib/Dialect/OM/OMAttributes.cpp
+++ b/lib/Dialect/OM/OMAttributes.cpp
@@ -91,6 +91,12 @@ circt::om::MapAttr::verify(function_ref<InFlightDiagnostic()> emitError,
   return success();
 }
 
+circt::om::PathAttr circt::om::PathAttr::get(mlir::StringAttr path) {
+  return om::PathAttr::get(path.getContext(), path);
+}
+
+Type circt::om::PathAttr::getType() { return PathType::get(getContext()); }
+
 void circt::om::OMDialect::registerAttributes() {
   addAttributes<
 #define GET_ATTRDEF_LIST


### PR DESCRIPTION
This attribute represents a value of Path type, and can be used with the OM constant operation. For now it holds a string encoding of the path, but this will probably change in the near future.