### PR TITLE
[HW] HierPathOp: support single-element path to modules

### DIFF
--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -3283,8 +3283,9 @@ LogicalResult HierPathOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
       return emitOpError() << "instance path is incorrect. Expected module: "
                            << expectedModuleName
                            << " instead found: " << innerRef.getModule();
-  } else if (expectedModuleName !=
-             leafRef.cast<FlatSymbolRefAttr>().getAttr()) {
+  } else if (expectedModuleName &&
+             expectedModuleName !=
+                 leafRef.cast<FlatSymbolRefAttr>().getAttr()) {
     // This is the case when the nla is applied to a module.
     return emitOpError() << "instance path is incorrect. Expected module: "
                          << expectedModuleName << " instead found: "

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -144,8 +144,14 @@ firrtl.module @TestNodeName(in %in1 : !firrtl.uint<8>) {
 }
 
 // Basic test for NLA operations.
-// CHECK: hw.hierpath private @nla [@Parent::@child, @Child]
-hw.hierpath private @nla [@Parent::@child, @Child]
+// CHECK: hw.hierpath private @nla0 [@Parent]
+// CHECK: hw.hierpath private @nla1 [@Parent::@child]
+// CHECK: hw.hierpath private @nla2 [@Parent::@child, @Child]
+// CHECK: hw.hierpath private @nla3 [@Parent::@child, @Child::@w]
+hw.hierpath private @nla0 [@Parent]
+hw.hierpath private @nla1 [@Parent::@child]
+hw.hierpath private @nla2 [@Parent::@child, @Child]
+hw.hierpath private @nla3 [@Parent::@child, @Child::@w]
 firrtl.module @Child() {
   %w = firrtl.wire sym @w : !firrtl.uint<1>
 }


### PR DESCRIPTION
This changes the HierPathVerifier to support single-element paths which point to modules.  HierPathOps already support single-length paths to InnerSymbols, and we just needed to copy the logic to skip checking that the module matches the expected module name when the path is a single element.  Missing support is most likely a bug in the initial implementation, as the error message printed a null attribute.