### PR TITLE
[FIRRTL] getOrAddInnerSym: fix bug when targeting a field

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -761,10 +761,10 @@ StringAttr circt::firrtl::getOrAddInnerSym(
 StringAttr circt::firrtl::getOrAddInnerSym(const hw::InnerSymTarget &target,
                                            GetNamespaceCallback getNamespace) {
   FModuleLike module;
-  if (target.isOpOnly())
-    module = target.getOp()->getParentOfType<FModuleOp>();
-  else
+  if (target.isPort())
     module = cast<FModuleLike>(target.getOp());
+  else
+    module = target.getOp()->getParentOfType<FModuleOp>();
   assert(module);
 
   return getOrAddInnerSym(target, [&]() -> hw::InnerSymbolNamespace & {


### PR DESCRIPTION
When an `InnerSymbolTarget` targets a field, `target.isOpOnly()` returns false. `getOrAddInnerSym` was mistakenly using this function to determine if the target was a port or a regular operation, causing it to treat all targets with fieldIDs as port targets.  This crashes when casting the target operation to a module op.  This changes `getOrAddInnerSym` to use `!target.isPort()` instead of `target.isOpOnly()` to check if the target is a port.