### PR TITLE
[sifive-1.5] Bump workflows from ubuntu-18.04 to 20.04

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -8,7 +8,7 @@ jobs:
   # JSON files in codeowners/.
   request_reviewer:
     name: "Request review from code owner"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Get CIRCT
         uses: actions/checkout@v2

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -119,7 +119,7 @@ jobs:
   # Configure CIRCT using LLVM's build system ("Unified" build). We do not actually build this configuration since it isn't as easy to cache LLVM artifacts in this mode.
   configure-circt-unified:
     name: Configure Unified Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.

--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -11,7 +11,7 @@ jobs:
   # integration testing prerequisite installed.
   build-circt:
     name: Build and Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
       image: ghcr.io/circt/images/circt-integration-test:v10.2
     strategy:

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -21,7 +21,7 @@ jobs:
   # integration testing prerequisite installed.
   build-circt:
     name: Build and Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
       image: ghcr.io/circt/images/circt-integration-test:v10.2
     strategy:


### PR DESCRIPTION
Ubuntu 18.04 runners were EOL end of last year.