### PR TITLE
[Ibis] Add member variable ops

### DIFF
--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -189,6 +189,46 @@ def ReturnOp : IbisOp<"return", [
   ];
 }
 
+def MemRefTypeAttr : TypeAttrBase<"MemRefType", "any memref type">;
+def VarOp : IbisOp<"var", [
+  Symbol
+]> {
+  let summary = "Ibis variable definition";
+  let description = [{
+    Defines an Ibis class member variable. The variable is typed with a 
+    `memref.memref` type, and may define either a singleton or uni-dimensional
+    array of values.
+    `ibis.var` defines a symbol within the encompassing class scope which can
+    be dereferenced through a `!ibis.scoperef` value of the parent class.
+  }];
+
+  let arguments = (ins SymbolNameAttr:$sym_name, MemRefTypeAttr:$type);
+  let assemblyFormat = "$sym_name `:` $type attr-dict";
+}
+
+def GetVarOp : IbisOp<"get_var", [
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  HasCustomSSAName
+]> {
+  let summary = "Dereferences an ibis member variable through a scoperef";
+  let arguments = (ins ScopeRefType:$instance, FlatSymbolRefAttr:$varName);
+  let results = (outs AnyMemRef:$var);
+  let assemblyFormat = [{
+    $instance `,` $varName attr-dict `:` qualified(type($instance)) `->` qualified(type($var))
+  }];
+
+  let extraClassDeclaration = [{
+    // Return the `VarOp` that this operation is referencing.
+    FailureOr<VarOp> getTarget(SymbolTable* symbolTable = nullptr);
+  }];
+
+  let extraClassDefinition = [{
+    void $cppClass::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+      setNameFn(getResult(), getVarName());
+    }
+  }];
+}
+
 def CallOp : IbisOp<"call", [CallOpInterface]> {
   let summary = "Ibis method call";
   let description = [{

--- a/lib/Dialect/Ibis/IbisOps.cpp
+++ b/lib/Dialect/Ibis/IbisOps.cpp
@@ -277,6 +277,8 @@ FailureOr<VarOp> GetVarOp::getTarget(SymbolTable *symbolTable) {
 
   // Lookup the variable inside the class scope.
   auto varName = getVarName();
+  // @teqdruid TODO: make this more efficient using
+  // innersymtablecollection when that's available to non-firrtl dialects.
   auto var = dyn_cast_or_null<VarOp>(
       symbolTable->lookupSymbolIn(targetClass.getOperation(), varName));
   if (!var)

--- a/test/Dialect/Ibis/errors.mlir
+++ b/test/Dialect/Ibis/errors.mlir
@@ -99,3 +99,39 @@ ibis.class @PathStepChildMissingSymbol {
   // expected-error @+1 {{ibis.step 'child' must specify an instance name}}
   %p = ibis.path [#ibis.step<child : !ibis.scoperef<@A>>]
 }
+
+// -----
+
+ibis.class @InvalidVar {
+  %this = ibis.this @C
+  // expected-error @+1 {{'ibis.var' op attribute 'type' failed to satisfy constraint: any memref type}}
+  ibis.var @var : i32
+}
+
+// -----
+
+ibis.class @InvalidGetVar {
+  %this = ibis.this @InvalidGetVar
+  ibis.var @var : memref<i32>
+  ibis.method @foo()  {
+    %parent = ibis.path [
+      #ibis.step<parent : !ibis.scoperef<@InvalidGetVar>>
+    ]
+    // expected-error @+1 {{'ibis.get_var' op result #0 must be memref of any type values, but got 'i32'}}
+    %var = ibis.get_var %parent, @var : !ibis.scoperef<@InvalidGetVar> -> i32
+  }
+}
+
+// -----
+
+ibis.class @InvalidGetVar2 {
+  %this = ibis.this @InvalidGetVar2
+  ibis.var @var : memref<i32>
+  ibis.method @foo()  {
+    %parent = ibis.path [
+      #ibis.step<parent : !ibis.scoperef<@InvalidGetVar2>>
+    ]
+    // expected-error @+1 {{'ibis.get_var' op dereferenced type ('memref<i1>') must match variable type ('memref<i32>')}}
+    %var = ibis.get_var %parent, @var : !ibis.scoperef<@InvalidGetVar2> -> memref<i1>
+  }
+}

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -1,31 +1,58 @@
 // RUN: circt-opt %s | circt-opt | FileCheck %s
 
+// CHECK-LABEL:  ibis.class @HighLevel {
+// CHECK-NEXT:    %this = ibis.this @HighLevel 
+// CHECK-NEXT:    ibis.var @single : memref<i32>
+// CHECK-NEXT:    ibis.var @array : memref<10xi32>
+// CHECK-NEXT:    ibis.method @foo() {
+// CHECK-NEXT:      %parent = ibis.path [#ibis.step<parent : !ibis.scoperef<@HighLevel>> : !ibis.scoperef<@HighLevel>]
+// CHECK-NEXT:      %single = ibis.get_var %parent, @single : !ibis.scoperef<@HighLevel> -> memref<i32>
+// CHECK-NEXT:      %array = ibis.get_var %parent, @array : !ibis.scoperef<@HighLevel> -> memref<10xi32>
+// CHECK-NEXT:      ibis.return
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+
+ibis.class @HighLevel {
+  %this = ibis.this @HighLevel
+  ibis.var @single : memref<i32>
+  ibis.var @array : memref<10xi32>
+
+  ibis.method @foo()  {
+    %parent = ibis.path [
+      #ibis.step<parent : !ibis.scoperef<@HighLevel>>
+    ]
+    %single = ibis.get_var %parent, @single : !ibis.scoperef<@HighLevel> -> memref<i32>
+    %array = ibis.get_var %parent, @array : !ibis.scoperef<@HighLevel> -> memref<10xi32>
+  }
+}
+
+
 // CHECK-LABEL:  ibis.class @A {
 // CHECK-NEXT:    %this = ibis.this @A 
 // CHECK-NEXT:    %in = ibis.port.input @in : i1
 // CHECK-NEXT:    %out = ibis.port.output @out : i1
 // CHECK-NEXT:  }
 
-// CHECK-LABEL:  ibis.class @C {
-// CHECK-NEXT:    %this = ibis.this @C 
-// CHECK-NEXT:    %C_in = ibis.port.input @C_in : i1
-// CHECK-NEXT:    %C_out = ibis.port.output @C_out : i1
+// CHECK-LABEL:  ibis.class @LowLevel {
+// CHECK-NEXT:    %this = ibis.this @LowLevel 
+// CHECK-NEXT:    %LowLevel_in = ibis.port.input @LowLevel_in : i1
+// CHECK-NEXT:    %LowLevel_out = ibis.port.output @LowLevel_out : i1
 // CHECK-NEXT:    %in_wire, %in_wire.out = ibis.wire.input @in_wire : i1
 // CHECK-NEXT:    %true = hw.constant true
 // CHECK-NEXT:    %out_wire = ibis.wire.output @out_wire, %true : i1
 // CHECK-NEXT:    %a = ibis.instance @a, @A 
 // CHECK-NEXT:    ibis.container @D {
 // CHECK-NEXT:      %this_0 = ibis.this @D 
-// CHECK-NEXT:      %parent = ibis.path [#ibis.step<parent : !ibis.scoperef<@C>> : !ibis.scoperef<@C>]
-// CHECK-NEXT:      %parent.C_in.ref = ibis.get_port %parent, @C_in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
-// CHECK-NEXT:      %parent.C_out.ref = ibis.get_port %parent, @C_out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+// CHECK-NEXT:      %parent = ibis.path [#ibis.step<parent : !ibis.scoperef<@LowLevel>> : !ibis.scoperef<@LowLevel>]
+// CHECK-NEXT:      %parent.LowLevel_in.ref = ibis.get_port %parent, @LowLevel_in : !ibis.scoperef<@LowLevel> -> !ibis.portref<in i1>
+// CHECK-NEXT:      %parent.LowLevel_out.ref = ibis.get_port %parent, @LowLevel_out : !ibis.scoperef<@LowLevel> -> !ibis.portref<out i1>
 // CHECK-NEXT:      %true_1 = hw.constant true
-// CHECK-NEXT:      ibis.port.write %parent.C_in.ref, %true_1 : !ibis.portref<in i1>
-// CHECK-NEXT:      %parent.C_out.ref.val = ibis.port.read %parent.C_out.ref : !ibis.portref<out i1>
+// CHECK-NEXT:      ibis.port.write %parent.LowLevel_in.ref, %true_1 : !ibis.portref<in i1>
+// CHECK-NEXT:      %parent.LowLevel_out.ref.val = ibis.port.read %parent.LowLevel_out.ref : !ibis.portref<out i1>
 // CHECK-NEXT:      %parent.a = ibis.path [#ibis.step<parent : !ibis.scoperef> : !ibis.scoperef, #ibis.step<child, @a : !ibis.scoperef<@A>> : !ibis.scoperef<@A>]
 // CHECK-NEXT:      %parent.a.in.ref = ibis.get_port %parent.a, @in : !ibis.scoperef<@A> -> !ibis.portref<in i1>
 // CHECK-NEXT:      %parent.a.out.ref = ibis.get_port %parent.a, @out : !ibis.scoperef<@A> -> !ibis.portref<out i1>
-// CHECK-NEXT:      ibis.port.write %parent.a.in.ref, %parent.C_out.ref.val : !ibis.portref<in i1>
+// CHECK-NEXT:      ibis.port.write %parent.a.in.ref, %parent.LowLevel_out.ref.val : !ibis.portref<in i1>
 // CHECK-NEXT:      %parent.a.out.ref.val = ibis.port.read %parent.a.out.ref : !ibis.portref<out i1>
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
@@ -36,10 +63,10 @@ ibis.class @A {
   ibis.port.output @out : i1
 }
 
-ibis.class @C {
-  %this = ibis.this @C
-  ibis.port.input @C_in : i1
-  ibis.port.output @C_out : i1
+ibis.class @LowLevel {
+  %this = ibis.this @LowLevel
+  ibis.port.input @LowLevel_in : i1
+  ibis.port.output @LowLevel_out : i1
 
   %in_wire, %in_wire.val = ibis.wire.input @in_wire : i1
   %true = hw.constant 1 : i1
@@ -51,14 +78,14 @@ ibis.class @C {
   ibis.container @D {
     %this_d = ibis.this @D
     %parent_C = ibis.path [
-      #ibis.step<parent : !ibis.scoperef<@C>>
+      #ibis.step<parent : !ibis.scoperef<@LowLevel>>
     ]
     // Test local read/writes
-    %c_in_p = ibis.get_port %parent_C, @C_in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
-    %c_out_p = ibis.get_port %parent_C, @C_out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+    %LowLevel_in_p = ibis.get_port %parent_C, @LowLevel_in : !ibis.scoperef<@LowLevel> -> !ibis.portref<in i1>
+    %LowLevel_out_p = ibis.get_port %parent_C, @LowLevel_out : !ibis.scoperef<@LowLevel> -> !ibis.portref<out i1>
     %t = hw.constant true
-    ibis.port.write %c_in_p, %t : !ibis.portref<in i1>
-    %c_out = ibis.port.read %c_out_p : !ibis.portref<out i1>
+    ibis.port.write %LowLevel_in_p, %t : !ibis.portref<in i1>
+    %LowLevel_out = ibis.port.read %LowLevel_out_p : !ibis.portref<out i1>
 
     // Test cross-container read/writes
     %A.in_parent = ibis.path [
@@ -67,7 +94,7 @@ ibis.class @C {
     ]
     %A.in_p = ibis.get_port %A.in_parent, @in : !ibis.scoperef<@A> -> !ibis.portref<in i1>
     %A.out_p = ibis.get_port %A.in_parent, @out : !ibis.scoperef<@A> -> !ibis.portref<out i1>
-    ibis.port.write %A.in_p, %c_out : !ibis.portref<in i1>
+    ibis.port.write %A.in_p, %LowLevel_out : !ibis.portref<in i1>
     %A.out = ibis.port.read %A.out_p : !ibis.portref<out i1>
   }
 }


### PR DESCRIPTION
This PR adds a member variable defining operation (`ibis.var`) and a member variable dereferencing operation (`ibis.get_var`). `ibis.get_var` works by taking an ibis `scoperef` value alongside a symbol for the member variable name, and generates a `memref`-typed value. This value can then be used by `memref` ops to perform load/stores.