### PR TITLE
[LegalizeNames] Update all port attributes together

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -221,22 +221,20 @@ def HWModuleLike : OpInterface<"HWModuleLike", [
       }
     }
 
-    void setPortAttrs(StringAttr attrName,
-        llvm::function_ref<Attribute(size_t, Attribute)> updateAttrCallback) {
+    void setPortAttrs(StringAttr attrName, ArrayRef<Attribute> newAttrs) {
       auto attrs = $_op.getAllPortAttrs();
-      bool updated = false;
       auto ctxt = $_op.getContext();
+      assert(newAttrs.size() == attrs.size());
       for (size_t idx = 0, e = attrs.size(); idx != e; ++idx) {
         NamedAttrList pattr(cast<mlir::DictionaryAttr>(attrs[idx]));
-        auto newAttr = updateAttrCallback(idx, pattr.get(attrName));
-        if (newAttr) {
+        auto newAttr = newAttrs[idx];
+        if (newAttr)
           pattr.set(attrName, newAttr);
-          attrs[idx] = pattr.getDictionary(ctxt);
-          updated = true;
-        }
+        else
+          pattr.erase(attrName);
+        attrs[idx] = pattr.getDictionary(ctxt);
       }
-      if (updated)
-        $_op.setAllPortAttrs(attrs);
+      $_op.setAllPortAttrs(attrs);
     }
 
     Location getPortLoc(size_t idx) {

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -221,6 +221,24 @@ def HWModuleLike : OpInterface<"HWModuleLike", [
       }
     }
 
+    void setPortAttrs(StringAttr attrName,
+        llvm::function_ref<Attribute(size_t, Attribute)> updateAttrCallback) {
+      auto attrs = $_op.getAllPortAttrs();
+      bool updated = false;
+      auto ctxt = $_op.getContext();
+      for (size_t idx = 0, e = attrs.size(); idx != e; ++idx) {
+        NamedAttrList pattr(cast<mlir::DictionaryAttr>(attrs[idx]));
+        auto newAttr = updateAttrCallback(idx, pattr.get(attrName));
+        if (newAttr) {
+          pattr.set(attrName, newAttr);
+          attrs[idx] = pattr.getDictionary(ctxt);
+          updated = true;
+        }
+      }
+      if (updated)
+        $_op.setAllPortAttrs(attrs);
+    }
+
     Location getPortLoc(size_t idx) {
       return $_op.getAllPortLocs()[idx];
     }

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -681,6 +681,13 @@ hw.module @BindEmission2() -> () {
   hw.output
 }
 
+hw.module @rename_port(%r: i1 {hw.verilogName = "w"}) {
+// CHECK-LABEL: module rename_port
+// CHECK:  input w
+// CHECK:  wire [3:0] w_0;
+    %w = sv.wire : !hw.inout<i4>
+    hw.output
+}
 
 hw.module @bind_rename_port(%.io_req_ready.output: i1, %reset: i1 { hw.verilogName = "resetSignalName" }, %clock: i1) {
   // CHECK-LABEL: module bind_rename_port


### PR DESCRIPTION
Update the attribute for all the ports and set it together, instead of updating each individually.
This also fixes a bug with `LegalizeNames`, that was ignoring `verilogName` attribute when renaming ports.
Fixes: https://github.com/llvm/circt/issues/5986