### PR TITLE
[HW][FIRRTL][NFC] Add AtomicFieldIDTypeInterface for no-field types.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -459,7 +459,7 @@ def FEnumImpl : FIRRTLImplType<"FEnum", [FieldIDTypeInterface]> {
 }
 
 def RefImpl : FIRRTLImplType<"Ref",
-                             [DeclareTypeInterfaceMethods<FieldIDTypeInterface>],
+                             [AtomicFieldIDTypeInterface],
                              "::circt::firrtl::FIRRTLType"> {
   let summary = "A reference to a signal elsewhere.";
   let description = [{

--- a/include/circt/Dialect/HW/HWTypeInterfaces.td
+++ b/include/circt/Dialect/HW/HWTypeInterfaces.td
@@ -48,4 +48,32 @@ def FieldIDTypeInterface : TypeInterface<"FieldIDTypeInterface"> {
   ];
 }
 
+def AtomicFieldIDTypeInterface : TypeInterface<"AtomicFieldIDTypeInterface",[FieldIDTypeInterface]> {
+  let cppNamespace = "circt::hw";
+  let description = [{
+    FieldID-supporting type with no fields (other than itself).
+
+    Used to implement FieldIDTypeInterface methods automatically for this common case.
+  }];
+
+  let extraTraitClassDeclaration = [{
+
+    uint64_t getMaxFieldID() const { return 0; }
+
+    std::pair<circt::hw::FieldIDTypeInterface, uint64_t> getSubTypeByFieldID(uint64_t fieldID) const {
+      assert(fieldID == 0);
+      return {$_type, 0};
+    }
+
+    circt::hw::FieldIDTypeInterface getFinalTypeByFieldID(uint64_t fieldID) const {
+      assert(fieldID == 0);
+      return $_type;
+    }
+
+    std::pair<uint64_t, bool> rootChildFieldID(uint64_t fieldID, uint64_t index) const {
+      return {0, fieldID == 0};
+    }
+  }];
+}
+
 #endif // CIRCT_DIALECT_HW_HWTYPEINTERFACES_TD

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -2495,28 +2495,6 @@ auto RefType::verify(function_ref<InFlightDiagnostic()> emitErrorFn,
   return success();
 }
 
-//- RefType implementations of FieldIDTypeInterface --------------------------//
-// Needs to be implemented to be used in a FIRRTL aggregate.
-
-uint64_t RefType::getMaxFieldID() const { return 0; }
-
-circt::hw::FieldIDTypeInterface
-RefType::getFinalTypeByFieldID(uint64_t fieldID) const {
-  assert(fieldID == 0);
-  return *this;
-}
-
-std::pair<circt::hw::FieldIDTypeInterface, uint64_t>
-RefType::getSubTypeByFieldID(uint64_t fieldID) const {
-  assert(fieldID == 0);
-  return {*this, 0};
-}
-
-std::pair<uint64_t, bool> RefType::rootChildFieldID(uint64_t fieldID,
-                                                    uint64_t index) const {
-  return {0, fieldID == 0};
-}
-
 RecursiveTypeProperties RefType::getRecursiveTypeProperties() const {
   auto rtp = getType().getRecursiveTypeProperties();
   rtp.containsReference = true;


### PR DESCRIPTION
Demonstrate using RefTypes.

Arguably should be a trait that adds the FieldIDTypeInterface trait and these methods, but simpler to do this by describing this as an "Interface" in ODS (and using interface inheritance is a bit clearer).