### PR TITLE
[ExportVerilog] Remove getValue for InstanceOp

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -495,6 +495,7 @@ def InstanceOp : HWOp<"instance", [
 
     /// Return the value for a port in port order.
     Value getValue(size_t idx);
+    Value getValue(size_t idx, ModulePortInfo &mpi);
 
     //===------------------------------------------------------------------===//
     // SymbolOpInterface Methods

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -494,9 +494,9 @@ def InstanceOp : HWOp<"instance", [
     Operation *getReferencedModuleSlow();
 
     /// Return the values for the port in port order.
-    /// Note: The module ports maynot be input,output ordered. This computes
+    /// Note: The module ports may not be input, output ordered. This computes
     /// the port index to instance result/input Value mapping.
-    void  getValues(SmallVectorImpl<Value> &values, const ModulePortInfo &mpi);
+    void getValues(SmallVectorImpl<Value> &values, const ModulePortInfo &mpi);
 
     //===------------------------------------------------------------------===//
     // SymbolOpInterface Methods

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -493,9 +493,10 @@ def InstanceOp : HWOp<"instance", [
     Operation *getReferencedModule(SymbolTable& tbl);
     Operation *getReferencedModuleSlow();
 
-    /// Return the value for a port in port order.
-    Value getValue(size_t idx);
-    Value getValue(size_t idx, ModulePortInfo &mpi);
+    /// Return the values for the port in port order.
+    /// Note: The module ports maynot be input,output ordered. This computes
+    /// the port index to instance result/input Value mapping.
+    void  getValues(SmallVectorImpl<Value> &values, const ModulePortInfo &mpi);
 
     //===------------------------------------------------------------------===//
     // SymbolOpInterface Methods

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4619,11 +4619,13 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
 
   auto containingModule = cast<HWModuleOp>(emitter.currentModuleOp);
   auto containingPortList = containingModule.getPortList();
+  SmallVector<Value> instPortValues(modPortInfo.size());
+  op.getValues(instPortValues, modPortInfo);
   for (size_t portNum = 0, portEnd = modPortInfo.size(); portNum < portEnd;
        ++portNum) {
     auto &modPort = modPortInfo.at(portNum);
     isZeroWidth = isZeroBitType(modPort.type);
-    Value portVal = op.getValue(portNum, modPortInfo);
+    Value portVal = instPortValues[portNum];
 
     // Decide if we should print a comma.  We can't do this if we're the first
     // port or if all the subsequent ports are zero width.
@@ -5175,10 +5177,12 @@ void ModuleEmitter::emitBind(BindOp op) {
       maxNameLength = std::max(maxNameLength, elt.getName().size());
     }
 
+    SmallVector<Value> instPortValues(childPortInfo.size());
+    inst.getValues(instPortValues, childPortInfo);
     // Emit the argument and result ports.
     for (auto [idx, elt] : llvm::enumerate(childPortInfo)) {
       // Figure out which value we are emitting.
-      Value portVal = inst.getValue(idx, childPortInfo);
+      Value portVal = instPortValues[idx];
       bool isZeroWidth = isZeroBitType(elt.type);
 
       // Decide if we should print a comma.  We can't do this if we're the

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4617,13 +4617,23 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
   bool isFirst = true; // True until we print a port.
   bool isZeroWidth = false;
 
+  auto instResults = op.getResults();
+  auto instInputs = op.getInputs();
+  size_t inputPort = 0, outputPort = 0;
   auto containingModule = cast<HWModuleOp>(emitter.currentModuleOp);
   auto containingPortList = containingModule.getPortList();
   for (size_t portNum = 0, portEnd = modPortInfo.size(); portNum < portEnd;
        ++portNum) {
     auto &modPort = modPortInfo.at(portNum);
     isZeroWidth = isZeroBitType(modPort.type);
-    Value portVal = op.getValue(portNum);
+    Value portVal;
+    if (modPort.isOutput()) {
+      portVal = instResults[outputPort];
+      ++outputPort;
+    } else {
+      portVal = instInputs[inputPort];
+      ++inputPort;
+    }
 
     // Decide if we should print a comma.  We can't do this if we're the first
     // port or if all the subsequent ports are zero width.

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4617,23 +4617,13 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
   bool isFirst = true; // True until we print a port.
   bool isZeroWidth = false;
 
-  auto instResults = op.getResults();
-  auto instInputs = op.getInputs();
-  size_t inputPort = 0, outputPort = 0;
   auto containingModule = cast<HWModuleOp>(emitter.currentModuleOp);
   auto containingPortList = containingModule.getPortList();
   for (size_t portNum = 0, portEnd = modPortInfo.size(); portNum < portEnd;
        ++portNum) {
     auto &modPort = modPortInfo.at(portNum);
     isZeroWidth = isZeroBitType(modPort.type);
-    Value portVal;
-    if (modPort.isOutput()) {
-      portVal = instResults[outputPort];
-      ++outputPort;
-    } else {
-      portVal = instInputs[inputPort];
-      ++inputPort;
-    }
+    Value portVal = op.getValue(portNum, modPortInfo);
 
     // Decide if we should print a comma.  We can't do this if we're the first
     // port or if all the subsequent ports are zero width.
@@ -5188,7 +5178,7 @@ void ModuleEmitter::emitBind(BindOp op) {
     // Emit the argument and result ports.
     for (auto [idx, elt] : llvm::enumerate(childPortInfo)) {
       // Figure out which value we are emitting.
-      Value portVal = inst.getValue(idx);
+      Value portVal = inst.getValue(idx, childPortInfo);
       bool isZeroWidth = isZeroBitType(elt.type);
 
       // Decide if we should print a comma.  We can't do this if we're the

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/CustomDirectiveImpl.h"
 #include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/HWSymCache.h"
 #include "circt/Dialect/HW/HWVisitors.h"
 #include "circt/Dialect/HW/InstanceImplementation.h"
@@ -1733,6 +1734,10 @@ size_t InstanceOp::getPortIdForOutputId(size_t idx) {
 
 Value InstanceOp::getValue(size_t idx) {
   auto mpi = getPortList();
+  return getValue(idx, mpi);
+}
+
+Value InstanceOp::getValue(size_t idx, ModulePortInfo &mpi) {
   size_t inputPort = 0, outputPort = 0;
   for (size_t x = 0; x < idx; ++x)
     if (mpi.at(x).isOutput())

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -14,7 +14,6 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/CustomDirectiveImpl.h"
 #include "circt/Dialect/HW/HWAttributes.h"
-#include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/HWSymCache.h"
 #include "circt/Dialect/HW/HWVisitors.h"
 #include "circt/Dialect/HW/InstanceImplementation.h"
@@ -1732,21 +1731,17 @@ size_t InstanceOp::getPortIdForOutputId(size_t idx) {
   return idx + getNumInputPorts();
 }
 
-Value InstanceOp::getValue(size_t idx) {
-  auto mpi = getPortList();
-  return getValue(idx, mpi);
-}
-
-Value InstanceOp::getValue(size_t idx, ModulePortInfo &mpi) {
-  size_t inputPort = 0, outputPort = 0;
-  for (size_t x = 0; x < idx; ++x)
-    if (mpi.at(x).isOutput())
-      ++outputPort;
+void InstanceOp::getValues(SmallVectorImpl<Value> &values,
+                           const ModulePortInfo &mpi) {
+  size_t inputPort = 0, resultPort = 0;
+  values.resize(mpi.size());
+  auto results = getResults();
+  auto inputs = getInputs();
+  for (auto [idx, port] : llvm::enumerate(mpi))
+    if (mpi.at(idx).isOutput())
+      values[idx] = results[resultPort++];
     else
-      ++inputPort;
-  if (mpi.at(idx).isOutput())
-    return getResults()[outputPort];
-  return getInputs()[inputPort];
+      values[idx] = inputs[inputPort++];
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Remove the usage of `getValue` since it recomputes the port list for every port. This is very expensive when there are huge number of ports.