### PR TITLE
[NFC][ExportVerilog] Remove deadcode.

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4596,7 +4596,6 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
 
   ps << PP::nbsp << PPExtString(getSymOpName(op)) << " (";
 
-  auto instPortInfo = op.getPortList();
   auto modPortInfo =
       cast<PortList>(op.getReferencedModule(&state.symbolCache)).getPortList();
   // Get the max port name length so we can align the '('.
@@ -4616,7 +4615,7 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
 
   auto containingModule = cast<HWModuleOp>(emitter.currentModuleOp);
   auto containingPortList = containingModule.getPortList();
-  for (size_t portNum = 0, portEnd = instPortInfo.size(); portNum < portEnd;
+  for (size_t portNum = 0, portEnd = modPortInfo.size(); portNum < portEnd;
        ++portNum) {
     auto &modPort = modPortInfo.at(portNum);
     isZeroWidth = isZeroBitType(modPort.type);
@@ -4628,7 +4627,7 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
       bool shouldPrintComma = true;
       if (isZeroWidth) {
         shouldPrintComma = false;
-        for (size_t i = portNum + 1, e = instPortInfo.size(); i != e; ++i)
+        for (size_t i = portNum + 1, e = modPortInfo.size(); i != e; ++i)
           if (!isZeroBitType(modPortInfo.at(i).type)) {
             shouldPrintComma = true;
             break;


### PR DESCRIPTION
Remove computation of instance port list, which is not used.