### PR TITLE
[FIRRTL] Support properties in aggregates, remove immediately.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -544,7 +544,12 @@ def BaseTypeAliasImpl : FIRRTLImplType<"BaseTypeAlias", [FieldIDTypeInterface],
 // Non-Hardware Type Definitions
 //===----------------------------------------------------------------------===//
 
-def ClassImpl : FIRRTLImplType<"Class", [], "circt::firrtl::FIRRTLType"> {
+class PropImplType<string name,
+                   list<Trait> traits = [],
+                   string baseCppClass = "::circt::firrtl::FIRRTLType">
+  : FIRRTLImplType<name, traits # [ AtomicFieldIDTypeInterface ], baseCppClass>;
+
+def ClassImpl : PropImplType<"Class"> {
   let summary = [{
     An instance of a class.
 
@@ -588,26 +593,26 @@ def ClassImpl : FIRRTLImplType<"Class", [], "circt::firrtl::FIRRTLType"> {
   }];
 }
 
-def StringImpl : FIRRTLImplType<"String", [], "circt::firrtl::FIRRTLType"> {
+def StringImpl : PropImplType<"String"> {
   let summary = "An unlimited length string type. Not representable in hardware.";
   let parameters = (ins);
   let genStorageClass = true;
 }
 
-def IntegerImpl : FIRRTLImplType<"FInteger", [], "circt::firrtl::FIRRTLType"> {
+def IntegerImpl : PropImplType<"FInteger"> {
   let summary = "An unlimited length signed integer type.  Not representable in hardware.";
   let parameters = (ins);
   let genStorageClass = true;
 }
 
-def ListImpl : FIRRTLImplType<"List", [], "circt::firrtl::FIRRTLType"> {
+def ListImpl : PropImplType<"List"> {
   let summary = "A typed property list of any length.  Not representable in hardware.";
   let parameters = (ins TypeParameter<"circt::firrtl::PropertyType", "element type">:$elementType);
   let genStorageClass = true;
   let genAccessors = true;
 }
 
-def MapImpl : FIRRTLImplType<"Map", [], "circt::firrtl::FIRRTLType"> {
+def MapImpl : PropImplType<"Map"> {
   let summary = "A typed map of properties.  Not representable in hardware.";
   let parameters = (ins TypeParameter<"circt::firrtl::PropertyType", "key type">:$keyType,
                     TypeParameter<"circt::firrtl::PropertyType", "value type">:$valueType);
@@ -615,14 +620,14 @@ def MapImpl : FIRRTLImplType<"Map", [], "circt::firrtl::FIRRTLType"> {
   let genAccessors = true;
 }
 
-def PathImpl : FIRRTLImplType<"Path", [], "circt::firrtl::FIRRTLType"> {
+def PathImpl : PropImplType<"Path"> {
   let summary = "A path to a hardware entity.  Not representable in hardware.";
   let parameters = (ins);
   let genStorageClass = true;
   let genAccessors = true;
 }
 
-def BoolImpl : FIRRTLImplType<"Bool", [], "circt::firrtl::FIRRTLType"> {
+def BoolImpl : PropImplType<"Bool"> {
   let summary = "A boolean property.  Not representable in hardware.";
   let parameters = (ins);
   let genStorageClass = true;

--- a/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
@@ -11,7 +11,7 @@
 // aggregate types with hardware aggregates, with non-hardware fields
 // expanded out as with LowerTypes.
 //
-// This pass is ref-specific for now.
+// This pass supports reference and property types.
 //
 //===----------------------------------------------------------------------===//
 
@@ -39,7 +39,7 @@ using namespace firrtl;
 
 namespace {
 
-/// Information on non-hw (ref) elements.
+/// Information on non-hw (ref/prop) elements.
 struct NonHWField {
   /// Type of the field, not a hardware type.
   FIRRTLType type;
@@ -176,7 +176,7 @@ public:
     if (!llvm::all_of(op->getOperandTypes(), notOpenAggType) ||
         !llvm::all_of(op->getResultTypes(), notOpenAggType))
       return op->emitOpError(
-          "unhandled use or producer of types containing references");
+          "unhandled use or producer of types containing non-hw types");
     return success();
   }
 
@@ -656,7 +656,7 @@ FailureOr<PortMappingInfo> Visitor::mapPortType(Type type, Location errorLoc,
               return FVectorType::get(convert, ovTy.getNumElements(),
                                       ovTy.isConst());
             })
-            .template Case<RefType>([&](auto ref) {
+            .template Case<RefType, PropertyType>([&](auto ref) {
               // Do this better, don't re-serialize so much?
               auto f = NonHWField{ref, fieldID, flip, {}};
               suffix.toVector(f.suffix);

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1842,27 +1842,11 @@ firrtl.circuit "ConstOpenVector" {
 }
 
 // -----
-// Elements must support FieldID's.
-
-firrtl.circuit "OpenVectorNotFieldID" {
-  // expected-error @below {{vector element type does not support fieldID's, type: '!firrtl.string'}}
-  firrtl.extmodule @OpenVectorNotFieldID(out out : !firrtl.openvector<string, 2>)
-}
-
-// -----
 // No const with probes within.
 
 firrtl.circuit "ConstOpenBundle" {
   // expected-error @below {{'const' bundle cannot have references, but element "x" has type '!firrtl.probe<uint<1>>'}}
   firrtl.extmodule @ConstOpenBundle(out out : !firrtl.const.openbundle<x: probe<uint<1>>>)
-}
-
-// -----
-// Elements must support FieldID's.
-
-firrtl.circuit "OpenBundleNotFieldID" {
-  // expected-error @below {{bundle element "a" has unsupported type that does not support fieldID's: '!firrtl.string'}}
-  firrtl.extmodule @OpenBundleNotFieldID(out out : !firrtl.openbundle<a: string>)
 }
 
 // -----

--- a/test/Dialect/FIRRTL/lower-open-aggs-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs-errors.mlir
@@ -55,7 +55,7 @@ firrtl.circuit "UnhandledOp" {
     %r_p = firrtl.opensubfield %r[p] : !firrtl.openbundle<p: probe<uint<1>>>
     firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>
 
-    // expected-error @below {{unhandled use or producer of types containing references}}
+    // expected-error @below {{unhandled use or producer of types containing non-hw types}}
     %x = firrtl.wire : !firrtl.openbundle<p : probe<uint<1>>>
   }
 }

--- a/test/Dialect/FIRRTL/lower-open-aggs.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs.mlir
@@ -207,3 +207,29 @@ firrtl.circuit "ManySymbols" {
                  <@x1,7,public>, <@x1_data,10,public>,
                <@b,11,public>])
 }
+
+// -----
+
+// CHECK-LABEL: circuit "BundleOfProps"
+firrtl.circuit "BundleOfProps" {
+  // CHECK: module @BundleOfProps
+  // CHECK-SAME: in %x: !firrtl.bundle<b: uint<5>>,
+  // CHECK-SAME: in %x_a: !firrtl.string,
+  // CHECK-SAME: out %y: !firrtl.bundle<a: uint<5>>,
+  // CHECK-SAME: out %y_b_c_l: !firrtl.list<string>)
+  firrtl.module @BundleOfProps(in %x: !firrtl.openbundle<a: string, b: uint<5>>,
+                               out %y: !firrtl.openbundle<a: uint<5>,
+                                                          b flip: openbundle<c flip: openbundle<l: list<string>>>>) {
+    %x_a = firrtl.opensubfield %x[a] : !firrtl.openbundle<a: string, b: uint<5>>
+    %x_b = firrtl.opensubfield %x[b] : !firrtl.openbundle<a: string, b: uint<5>>
+
+    %y_a = firrtl.opensubfield %y[a] : !firrtl.openbundle<a: uint<5>, b flip: openbundle<c flip: openbundle<l: list<string>>>>
+    %y_b = firrtl.opensubfield %y[b] : !firrtl.openbundle<a: uint<5>, b flip: openbundle<c flip: openbundle<l: list<string>>>>
+    %y_b_c = firrtl.opensubfield %y_b[c] : !firrtl.openbundle<c flip: openbundle<l: list<string>>>
+    %y_b_c_l = firrtl.opensubfield %y_b_c[l] : !firrtl.openbundle<l: list<string>>
+    %str = firrtl.string "test"
+    %list = firrtl.list.create %x_a, %str : !firrtl.list<string>
+    firrtl.propassign %y_b_c_l, %list : !firrtl.list<string>
+    firrtl.strictconnect %y_a, %x_b : !firrtl.uint<5>
+  }
+}

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1813,3 +1813,22 @@ circuit BasicProps :
     ; CHECK-NEXT: %[[EMPTY:.+]] = firrtl.map.create : !firrtl.map<integer, integer>
     ; CHECK-NEXT: firrtl.propassign %empty, %[[EMPTY]]
     propassign empty, Map<Integer, Integer>()
+
+;// -----
+FIRRTL version 3.1.0
+
+; CHECK-LABEL: circuit "BundleOfProps"
+circuit BundleOfProps:
+  module BundleOfProps:
+    input x : {a : String}
+    ; CHECK: openbundle<a: string>
+
+;// -----
+FIRRTL version 3.1.0
+
+; CHECK-LABEL: circuit "VecOfProps"
+circuit VecOfProps:
+  module VecOfProps:
+    input x : String[2]
+    ; CHECK: openvector<string, 2>
+

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -783,23 +783,6 @@ circuit KeywordTypeName:
   type module = UInt; expected-error {{cannot use keyword 'module' for type alias name}}
 
 ;// -----
-; https://github.com/llvm/circt/issues/5494
-FIRRTL version 3.1.0
-
-circuit BundleOfProps:
-  module BundleOfProps:
-    input x : {a : String}
-    ; expected-error @above {{type '!firrtl.string' cannot be used as field in a bundle}}
-
-;// -----
-FIRRTL version 3.1.0
-
-circuit VecOfProps:
-  module VecOfProps:
-    input x : String[2]
-    ; expected-error @above {{type '!firrtl.string' cannot be used in a vector}}
-
-;// -----
 
 FIRRTL version 3.0.0
 circuit UnsupportedVersionDeclGroups:


### PR DESCRIPTION
Similar to how RefTypes work, support properties in openbundles and immediately remove them into separate storage (ports).