### PR TITLE
[FIRRTL] Support noRefTypePorts in applyGCTMemTaps

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -334,9 +334,10 @@ struct ApplyState {
   using AddToWorklistFn = llvm::function_ref<void(DictionaryAttr)>;
   ApplyState(CircuitOp circuit, SymbolTable &symTbl,
              AddToWorklistFn addToWorklistFn,
-             InstancePathCache &instancePathCache)
+             InstancePathCache &instancePathCache, bool noRefTypePorts)
       : circuit(circuit), symTbl(symTbl), addToWorklistFn(addToWorklistFn),
-        instancePathCache(instancePathCache), hierPathCache(circuit, symTbl) {}
+        instancePathCache(instancePathCache), hierPathCache(circuit, symTbl),
+        noRefTypePorts(noRefTypePorts) {}
 
   CircuitOp circuit;
   SymbolTable &symTbl;
@@ -345,6 +346,9 @@ struct ApplyState {
   InstancePathCache &instancePathCache;
   HierPathCache hierPathCache;
   size_t numReusedHierPaths = 0;
+
+  // Options that control annotation lowering.
+  bool noRefTypePorts;
 
   DenseSet<InstanceOp> wiringProblemInstRefs;
   DenseMap<StringAttr, LegacyWiringProblem> legacyWiringProblems;

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -1069,7 +1069,8 @@ void LowerAnnotationsPass::runOnOperation() {
     worklistAttrs.push_back(anno);
   };
   InstancePathCache instancePathCache(getAnalysis<InstanceGraph>());
-  ApplyState state{circuit, modules, addToWorklist, instancePathCache};
+  ApplyState state{circuit, modules, addToWorklist, instancePathCache,
+                   noRefTypePorts};
   LLVM_DEBUG(llvm::dbgs() << "Processing annotations:\n");
   while (!worklistAttrs.empty()) {
     auto attr = worklistAttrs.pop_back_val();

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -1,5 +1,6 @@
 ; RUN: firtool --verilog %s | FileCheck %s
 ; RUN: firtool --verilog -preserve-aggregate=1d-vec %s | FileCheck %s --check-prefix=AGGGREGATE
+; RUN: firtool --verilog -lower-annotations-no-ref-type-ports %s | FileCheck %s --check-prefix=NOREFS
 
 circuit Top : %[[
   {
@@ -72,3 +73,28 @@ circuit Top : %[[
 ; AGGGREGATE-NEXT:           {Top.dut.rf_ext.Memory[1]},
 ; AGGGREGATE-NEXT:           {Top.dut.rf_ext.Memory[0]}};
 ; CHECK:      endmodule
+
+; NOREFS:      module DUTModule(
+; NOREFS-NOT:  endmodule
+; NOREFS:        rf_8x8 rf_ext (
+; NOREFS:          .R1_data (memTap_7),
+; NOREFS-NEXT:     .R2_data (memTap_6),
+; NOREFS-NEXT:     .R3_data (memTap_5),
+; NOREFS-NEXT:     .R4_data (memTap_4),
+; NOREFS-NEXT:     .R5_data (memTap_3),
+; NOREFS-NEXT:     .R6_data (memTap_2),
+; NOREFS-NEXT:     .R7_data (memTap_1),
+; NOREFS-NEXT:     .R8_data (memTap_0)
+; NOREFS-NEXT:   )
+; NOREFS:      endmodule
+; NOREFS:      DUTModule dut (
+; NOREFS-NOT:  endmodule
+; NOREFS:        .memTap_0 (memTap_0),
+; NOREFS-NEXT:   .memTap_1 (memTap_1),
+; NOREFS-NEXT:   .memTap_2 (memTap_2),
+; NOREFS-NEXT:   .memTap_3 (memTap_3),
+; NOREFS-NEXT:   .memTap_4 (memTap_4),
+; NOREFS-NEXT:   .memTap_5 (memTap_5),
+; NOREFS-NEXT:   .memTap_6 (memTap_6),
+; NOREFS-NEXT:   .memTap_7 (memTap_7)
+; NOREFS-NEXT: )


### PR DESCRIPTION
Add logic for lowering Grand Central (GCT) memory taps to real ports.  Do
this by creating one port per memory item.  This is incredibly expensive.
However, this is the only way to actual synthesize this.

I reordered the `applyGCTMemTaps` function in https://github.com/llvm/circt/commit/e82e8263896890350484c9005467a4674d6d74aa to make this patch more straightforward.