### PR TITLE
[FIRRTL][LowerClasses] Lower map types and map.create

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -323,6 +323,26 @@ struct ListCreateOpConversion
   }
 };
 
+struct MapCreateOpConversion : public OpConversionPattern<firrtl::MapCreateOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(firrtl::MapCreateOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto mapType = getTypeConverter()->convertType<om::MapType>(op.getType());
+    if (!mapType)
+      return failure();
+    auto keys = adaptor.getKeys();
+    auto values = adaptor.getValues();
+    SmallVector<Value> tuples;
+    for (auto [key, value] : llvm::zip(keys, values))
+      tuples.push_back(rewriter.create<om::TupleCreateOp>(
+          op.getLoc(), ArrayRef<Value>{key, value}));
+    rewriter.replaceOpWithNewOp<om::MapCreateOp>(op, mapType, tuples);
+    return success();
+  }
+};
+
 struct ClassFieldOpConversion : public OpConversionPattern<ClassFieldOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -437,6 +457,32 @@ static void populateTypeConverter(TypeConverter &converter) {
         return om::ListType::get(elementType);
       });
 
+  auto convertMapType = [&converter](auto type) -> std::optional<mlir::Type> {
+    auto keyType = converter.convertType(type.getKeyType());
+    // Reject key types that are not string or integer.
+    if (!isa_and_nonnull<om::StringType, mlir::IntegerType>(keyType))
+      return {};
+
+    auto valueType = converter.convertType(type.getValueType());
+    if (!valueType)
+      return {};
+
+    return om::MapType::get(keyType, valueType);
+  };
+
+  // Convert FIRRTL Map type to OM Map type.
+  converter.addConversion(
+      [&convertMapType](om::MapType type) -> std::optional<mlir::Type> {
+        // Convert any om.map<firrtl, firrtl> -> om.map<om, om>
+        return convertMapType(type);
+      });
+
+  converter.addConversion(
+      [&convertMapType](firrtl::MapType type) -> std::optional<mlir::Type> {
+        // Convert any firrtl.map<firrtl, firrtl> -> om.map<om, om>
+        return convertMapType(type);
+      });
+
   // Convert FIRRTL Bool type to OM
   converter.addConversion(
       [](BoolType type) { return IntegerType::get(type.getContext(), 1); });
@@ -456,6 +502,7 @@ static void populateRewritePatterns(RewritePatternSet &patterns,
   patterns.add<ClassFieldOpConversion>(converter, patterns.getContext());
   patterns.add<ClassOpSignatureConversion>(converter, patterns.getContext());
   patterns.add<ListCreateOpConversion>(converter, patterns.getContext());
+  patterns.add<MapCreateOpConversion>(converter, patterns.getContext());
   patterns.add<BoolConstantOpConversion>(converter, patterns.getContext());
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -472,13 +472,13 @@ static void populateTypeConverter(TypeConverter &converter) {
 
   // Convert FIRRTL Map type to OM Map type.
   converter.addConversion(
-      [&convertMapType](om::MapType type) -> std::optional<mlir::Type> {
+      [convertMapType](om::MapType type) -> std::optional<mlir::Type> {
         // Convert any om.map<firrtl, firrtl> -> om.map<om, om>
         return convertMapType(type);
       });
 
   converter.addConversion(
-      [&convertMapType](firrtl::MapType type) -> std::optional<mlir::Type> {
+      [convertMapType](firrtl::MapType type) -> std::optional<mlir::Type> {
         // Convert any firrtl.map<firrtl, firrtl> -> om.map<om, om>
         return convertMapType(type);
       });

--- a/test/Dialect/FIRRTL/lower-classes-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-classes-errors.mlir
@@ -1,0 +1,7 @@
+// RUN: circt-opt -firrtl-lower-classes %s -verify-diagnostics
+
+firrtl.circuit "Component" {
+  firrtl.module @Component() {}
+  // expected-error @+1{{failed to legalize operation 'om.class' that was explicitly marked illegal}}
+  firrtl.class @Map(in %s1: !firrtl.map<list<string>, string>) {}
+}

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -89,4 +89,45 @@ firrtl.circuit "Component" {
     %true = firrtl.bool true
     firrtl.propassign %b, %true : !firrtl.bool
   }
+
+  // CHECK-LABEL: om.class @MapTest
+  firrtl.class @MapTest(in %s1: !firrtl.string,
+                         in %s2: !firrtl.string,
+                         in %c1: !firrtl.class<@ClassTest()>,
+                         in %c2: !firrtl.class<@ClassTest()>,
+                         out %out_strings: !firrtl.map<string, string>,
+                         out %out_empty: !firrtl.map<string, string>,
+                         out %out_nested: !firrtl.map<string, map<string, string>>,
+                         out %out_objs: !firrtl.map<string, class<@ClassTest()>>) {
+    // Map of basic property types (strings)
+    // CHECK-NEXT: %[[TUPLE1:.+]] = om.tuple_create %s1, %s1
+    // CHECK-NEXT: %[[TUPLE2:.+]] = om.tuple_create %s2, %s2
+    // CHECK-NEXT: %[[STRINGS:.+]] = om.map_create %[[TUPLE1]], %[[TUPLE2]]
+    %strings = firrtl.map.create (%s1 -> %s1, %s2 -> %s2) : !firrtl.map<string, string>
+    firrtl.propassign %out_strings, %strings : !firrtl.map<string, string>
+
+    // Empty map
+    // CHECK-NEXT: %[[EMPTY:.+]] = om.map_create : !om.string, !om.string
+    %empty = firrtl.map.create : !firrtl.map<string, string>
+    firrtl.propassign %out_empty, %empty : !firrtl.map<string, string>
+
+    // Nested map
+    // CHECK-NEXT: %[[TUPLE1:.+]] = om.tuple_create %s1, %[[STRINGS]]
+    // CHECK-NEXT: %[[TUPLE2:.+]] = om.tuple_create %s2, %[[EMPTY]]
+    // CHECK-NEXT: %[[NESTED:.+]] = om.map_create %[[TUPLE1]], %[[TUPLE2]]
+    %nested = firrtl.map.create (%s1 -> %strings, %s2 -> %empty) : !firrtl.map<string, map<string, string>>
+    firrtl.propassign %out_nested, %nested: !firrtl.map<string, map<string, string>>
+
+    // Map of objects
+    // CHECK-NEXT: %[[TUPLE1:.+]] = om.tuple_create %s1, %c1
+    // CHECK-NEXT: %[[TUPLE2:.+]] = om.tuple_create %s2, %c2
+    // CHECK-NEXT: %[[OBJS:.+]] = om.map_create %[[TUPLE1]], %[[TUPLE2]]
+    %objs = firrtl.map.create (%s1 -> %c1, %s2 -> %c2) : !firrtl.map<string, class<@ClassTest()>>
+    firrtl.propassign %out_objs, %objs : !firrtl.map<string, class<@ClassTest()>>
+
+    // CHECK-NEXT: om.class.field @out_strings, %[[STRINGS]] : !om.map<!om.string, !om.string>
+    // CHECK-NEXT: om.class.field @out_empty, %[[EMPTY]] : !om.map<!om.string, !om.string>
+    // CHECK-NEXT: om.class.field @out_nested, %[[NESTED]] : !om.map<!om.string, !om.map<!om.string, !om.string>>
+    // CHECK-NEXT: om.class.field @out_objs, %[[OBJS]] : !om.map<!om.string, !om.class.type<@ClassTest>>
+  }
 }

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -92,13 +92,13 @@ firrtl.circuit "Component" {
 
   // CHECK-LABEL: om.class @MapTest
   firrtl.class @MapTest(in %s1: !firrtl.string,
-                         in %s2: !firrtl.string,
-                         in %c1: !firrtl.class<@ClassTest()>,
-                         in %c2: !firrtl.class<@ClassTest()>,
-                         out %out_strings: !firrtl.map<string, string>,
-                         out %out_empty: !firrtl.map<string, string>,
-                         out %out_nested: !firrtl.map<string, map<string, string>>,
-                         out %out_objs: !firrtl.map<string, class<@ClassTest()>>) {
+                        in %s2: !firrtl.string,
+                        in %c1: !firrtl.class<@ClassTest()>,
+                        in %c2: !firrtl.class<@ClassTest()>,
+                        out %out_strings: !firrtl.map<string, string>,
+                        out %out_empty: !firrtl.map<string, string>,
+                        out %out_nested: !firrtl.map<string, map<string, string>>,
+                        out %out_objs: !firrtl.map<string, class<@ClassTest()>>) {
     // Map of basic property types (strings)
     // CHECK-NEXT: %[[TUPLE1:.+]] = om.tuple_create %s1, %s1
     // CHECK-NEXT: %[[TUPLE2:.+]] = om.tuple_create %s2, %s2


### PR DESCRIPTION
This implements Map type lowerings. Currently reject non-string or integer key types in type converter. 