### PR TITLE
[FIRRTL, HW] Simplify FieldID support

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -205,12 +205,7 @@ public:
   /// Get the sub-type of a type for a field ID, and the subfield's ID. Strip
   /// off a single layer of this type and return the sub-type and a field ID
   /// targeting the same field, but rebased on the sub-type.
-  std::pair<circt::hw::FieldIDTypeInterface, uint64_t>
-  getSubTypeByFieldID(uint64_t fieldID);
-
-  /// Return the final type targeted by this field ID by recursively walking all
-  /// nested aggregate types. This is the identity function for ground types.
-  circt::hw::FieldIDTypeInterface getFinalTypeByFieldID(uint64_t fieldID);
+  std::pair<Type, uint64_t> getSubTypeByFieldID(uint64_t fieldID);
 
   /// Returns the effective field id when treating the index field as the
   /// root of the type.  Essentially maps a fieldID to a fieldID after a

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -44,7 +44,7 @@ def WidthQualifiedTypeTrait : NativeTypeTrait<"WidthQualifiedTypeTrait"> {
 //===----------------------------------------------------------------------===//
 
 def SIntImpl : FIRRTLImplType<"SInt",
-                              [WidthQualifiedTypeTrait, FieldIDTypeInterface],
+                              [WidthQualifiedTypeTrait],
                               "::circt::firrtl::IntType"> {
   let summary = "A signed integer type, whose width may not be known.";
   let parameters = (ins "int32_t":$widthOrSentinel, "bool":$isConst);
@@ -63,7 +63,7 @@ def SIntImpl : FIRRTLImplType<"SInt",
 }
 
 def UIntImpl : FIRRTLImplType<"UInt",
-                              [WidthQualifiedTypeTrait, FieldIDTypeInterface],
+                              [WidthQualifiedTypeTrait],
                               "::circt::firrtl::IntType"> {
   let summary = "An unsigned integer type, whose width may not be known.";
   let parameters = (ins "int32_t":$widthOrSentinel, "bool":$isConst);
@@ -81,7 +81,7 @@ def UIntImpl : FIRRTLImplType<"UInt",
   }];
 }
 
-def ClockTypeImpl : FIRRTLImplType<"Clock", [FieldIDTypeInterface]> {
+def ClockTypeImpl : FIRRTLImplType<"Clock", []> {
   let summary = "Clock signal";
   let parameters = (ins "bool":$isConst);
   let storageClass = "FIRRTLBaseTypeStorage";
@@ -95,7 +95,7 @@ def ClockTypeImpl : FIRRTLImplType<"Clock", [FieldIDTypeInterface]> {
   }];
 }
 
-def ResetTypeImpl : FIRRTLImplType<"Reset", [FieldIDTypeInterface]> {
+def ResetTypeImpl : FIRRTLImplType<"Reset", []> {
   let summary = "Reset Signal";
   let parameters = (ins "bool":$isConst);
   let storageClass = "FIRRTLBaseTypeStorage";
@@ -109,7 +109,7 @@ def ResetTypeImpl : FIRRTLImplType<"Reset", [FieldIDTypeInterface]> {
   }];
 }
 
-def AsyncResetTypeImpl : FIRRTLImplType<"AsyncReset", [FieldIDTypeInterface]> {
+def AsyncResetTypeImpl : FIRRTLImplType<"AsyncReset", []> {
   let summary = "AsyncReset signal";
   let parameters = (ins "bool":$isConst);
   let storageClass = "FIRRTLBaseTypeStorage";
@@ -124,7 +124,7 @@ def AsyncResetTypeImpl : FIRRTLImplType<"AsyncReset", [FieldIDTypeInterface]> {
 }
 
 def AnalogTypeImpl : FIRRTLImplType<"Analog",
-  [WidthQualifiedTypeTrait, FieldIDTypeInterface]> {
+  [WidthQualifiedTypeTrait]> {
   let summary = "Analog signal";
   let parameters = (ins "int32_t":$widthOrSentinel, "bool":$isConst);
   let storageClass = "WidthTypeStorage";
@@ -139,7 +139,8 @@ def AnalogTypeImpl : FIRRTLImplType<"Analog",
   let genVerifyDecl = true;
 }
 
-class BaseVectorTypeImpl<string name, string ElementType, list<Trait> traits = [], string BaseType = ElementType> : FIRRTLImplType<name, traits, BaseType> {
+class BaseVectorTypeImpl<string name, string ElementType, list<Trait> traits = [], string BaseType = ElementType> 
+  : FIRRTLImplType<name, traits # [DeclareTypeInterfaceMethods<FieldIDTypeInterface>], BaseType> {
   let summary = "a fixed size collection of elements, like an array.";
   let parameters = (ins
       TypeParameter<ElementType, "Type of vector elements">:$elementType,
@@ -171,21 +172,16 @@ class BaseVectorTypeImpl<string name, string ElementType, list<Trait> traits = [
     /// Get an integer ID for the field. Field IDs start at 1, and are assigned
     /// to each field in a vector in a recursive depth-first walk of all
     /// elements. A field ID of 0 is used to reference the vector itself.
-    uint64_t getFieldID(uint64_t index);
+    uint64_t getFieldID(uint64_t index) const;
 
     /// Find the element index corresponding to the desired fieldID.  If the
     /// fieldID corresponds to a field in nested under an element, it will
     /// return the index of the parent element.
-    uint64_t getIndexForFieldID(uint64_t fieldID);
+    uint64_t getIndexForFieldID(uint64_t fieldID) const;
 
     /// Find the index of the element that contains the given fieldID.
     /// As well, rebase the fieldID to the element.
-    std::pair<uint64_t, uint64_t> getIndexAndSubfieldID(uint64_t fieldID);
-
-    /// Strip off a single layer of this type and return the sub-type and a
-    /// field ID targeting the same field, but rebased on the sub-type.
-    std::pair<circt::hw::FieldIDTypeInterface, uint64_t>
-    getSubTypeByFieldID(uint64_t fieldID);
+    std::pair<uint64_t, uint64_t> getIndexAndSubfieldID(uint64_t fieldID) const;
 
     /// Get the maximum field ID in this vector.  This is helpful for
     /// constructing field IDs when this VectorType is nested in another
@@ -207,7 +203,7 @@ class BaseVectorTypeImpl<string name, string ElementType, list<Trait> traits = [
   }] # firrtlExtraClassDeclaration;
 }
 
-def FVectorImpl : BaseVectorTypeImpl<"FVector","::circt::firrtl::FIRRTLBaseType", [FieldIDTypeInterface]> {
+def FVectorImpl : BaseVectorTypeImpl<"FVector","::circt::firrtl::FIRRTLBaseType", []> {
   let firrtlExtraClassDeclaration = [{
     /// Return this type with any flip types recursively removed from itself.
     FIRRTLBaseType getPassiveType();
@@ -220,11 +216,12 @@ def FVectorImpl : BaseVectorTypeImpl<"FVector","::circt::firrtl::FIRRTLBaseType"
   }];
 }
 
-def OpenVectorImpl : BaseVectorTypeImpl<"OpenVector","::circt::firrtl::FIRRTLType", [DeclareTypeInterfaceMethods<FieldIDTypeInterface>]> {
+def OpenVectorImpl : BaseVectorTypeImpl<"OpenVector","::circt::firrtl::FIRRTLType", []> {
   let genVerifyDecl = 1;
 }
 
-class BaseBundleTypeImpl<string name, string ElementType, list<Trait> traits = [], string BaseType = ElementType> : FIRRTLImplType<name, traits, BaseType> {
+class BaseBundleTypeImpl<string name, string ElementType, list<Trait> traits = [], string BaseType = ElementType>
+ : FIRRTLImplType<name, traits # [DeclareTypeInterfaceMethods<FieldIDTypeInterface>], BaseType> {
   let summary = "an aggregate of named elements. This is effectively a struct.";
   let parameters = (ins "ArrayRef<BundleElement>":$elements, "bool":$isConst);
   let storageClass = name # "TypeStorage";
@@ -262,7 +259,7 @@ class BaseBundleTypeImpl<string name, string ElementType, list<Trait> traits = [
 
     ArrayRef<BundleElement> getElements() const;
 
-    size_t getNumElements() { return getElements().size(); }
+    size_t getNumElements() const { return getElements().size(); }
 
     /// Look up an element's index by name.  This returns None on failure.
     std::optional<unsigned> getElementIndex(StringAttr name);
@@ -284,7 +281,7 @@ class BaseBundleTypeImpl<string name, string ElementType, list<Trait> traits = [
     ElementType getElementType(StringRef name);
 
     /// Look up an element type by index.
-    ElementType getElementType(size_t index);
+    ElementType getElementType(size_t index) const;
 
     /// Return the recursive properties of the type.
     RecursiveTypeProperties getRecursiveTypeProperties() const;
@@ -294,32 +291,16 @@ class BaseBundleTypeImpl<string name, string ElementType, list<Trait> traits = [
     /// visiting all nested bundle fields.  A field ID of 0 is used to reference
     /// the bundle itself. The ID can be used to uniquely identify any specific
     /// field in this bundle.
-    uint64_t getFieldID(uint64_t index);
+    uint64_t getFieldID(uint64_t index) const;
 
     /// Find the element index corresponding to the desired fieldID.  If the
     /// fieldID corresponds to a field in a nested bundle, it will return the
     /// index of the parent field.
-    uint64_t getIndexForFieldID(uint64_t fieldID);
+    uint64_t getIndexForFieldID(uint64_t fieldID) const;
 
     /// Find the index of the element that contains the given fieldID.
     /// As well, rebase the fieldID to the element.
-    std::pair<uint64_t, uint64_t> getIndexAndSubfieldID(uint64_t fieldID);
-
-    /// Strip off a single layer of this type and return the sub-type and a
-    /// field ID targeting the same field, but rebased on the sub-type.
-    std::pair<circt::hw::FieldIDTypeInterface, uint64_t>
-    getSubTypeByFieldID(uint64_t fieldID);
-
-    /// Get the maximum field ID in this bundle.  This is helpful for
-    /// constructing field IDs when this BundleType is nested in another
-    /// aggregate type.
-    uint64_t getMaxFieldID();
-
-    /// Returns the effective field id when treating the index field as the root
-    /// of the type.  Essentially maps a fieldID to a fieldID after a subfield
-    /// op. Returns the new id and whether the id is in the given child.
-    std::pair<uint64_t, bool> rootChildFieldID(uint64_t fieldID,
-                                               uint64_t index);
+    std::pair<uint64_t, uint64_t> getIndexAndSubfieldID(uint64_t fieldID) const;
 
     using iterator = ArrayRef<BundleElement>::iterator;
     iterator begin() const { return getElements().begin(); }
@@ -335,7 +316,7 @@ class BaseBundleTypeImpl<string name, string ElementType, list<Trait> traits = [
   }] # firrtlExtraClassDeclaration;
 }
 
-def BundleImpl : BaseBundleTypeImpl<"Bundle","::circt::firrtl::FIRRTLBaseType", [FieldIDTypeInterface]> {
+def BundleImpl : BaseBundleTypeImpl<"Bundle","::circt::firrtl::FIRRTLBaseType", []> {
   let firrtlExtraClassDeclaration = [{
     /// Return this type with any flip types recursively removed from itself.
     FIRRTLBaseType getPassiveType();
@@ -348,11 +329,11 @@ def BundleImpl : BaseBundleTypeImpl<"Bundle","::circt::firrtl::FIRRTLBaseType", 
   }];
 }
 
-def OpenBundleImpl : BaseBundleTypeImpl<"OpenBundle","::circt::firrtl::FIRRTLType", [DeclareTypeInterfaceMethods<FieldIDTypeInterface>]> {
+def OpenBundleImpl : BaseBundleTypeImpl<"OpenBundle","::circt::firrtl::FIRRTLType", []> {
   let genVerifyDecl = 1;
 }
 
-def FEnumImpl : FIRRTLImplType<"FEnum", [FieldIDTypeInterface]> {
+def FEnumImpl : FIRRTLImplType<"FEnum", [DeclareTypeInterfaceMethods<FieldIDTypeInterface>]> {
   let summary = "a sum type of named elements.";
   let parameters = (ins "ArrayRef<EnumElement>":$elements, "bool":$isConst);
   let storageClass = "FEnumTypeStorage";
@@ -384,7 +365,7 @@ def FEnumImpl : FIRRTLImplType<"FEnum", [FieldIDTypeInterface]> {
 
     ArrayRef<EnumElement> getElements() const;
 
-    size_t getNumElements() { return getElements().size(); }
+    size_t getNumElements() const { return getElements().size(); }
 
     FEnumType getConstType(bool isConst);
 
@@ -414,7 +395,7 @@ def FEnumImpl : FIRRTLImplType<"FEnum", [FieldIDTypeInterface]> {
     FIRRTLBaseType getElementType(StringRef name);
 
     /// Look up an element type by index.
-    FIRRTLBaseType getElementType(size_t index);
+    FIRRTLBaseType getElementType(size_t index) const;
     FIRRTLBaseType getElementTypePreservingConst(size_t index);
 
     /// Return the recursive properties of the type.
@@ -425,32 +406,16 @@ def FEnumImpl : FIRRTLImplType<"FEnum", [FieldIDTypeInterface]> {
     /// visiting all nested enum fields.  A field ID of 0 is used to reference
     /// the enum itself. The ID can be used to uniquely identify any specific
     /// field in this enum.
-    uint64_t getFieldID(uint64_t index);
+    uint64_t getFieldID(uint64_t index) const;
 
     /// Find the element index corresponding to the desired fieldID.  If the
     /// fieldID corresponds to a field in a nested enum, it will return the
     /// index of the parent field.
-    uint64_t getIndexForFieldID(uint64_t fieldID);
+    uint64_t getIndexForFieldID(uint64_t fieldID) const;
 
     /// Find the index of the element that contains the given fieldID.
     /// As well, rebase the fieldID to the element.
-    std::pair<uint64_t, uint64_t> getIndexAndSubfieldID(uint64_t fieldID);
-
-    /// Strip off a single layer of this type and return the sub-type and a
-    /// field ID targeting the same field, but rebased on the sub-type.
-    std::pair<circt::hw::FieldIDTypeInterface, uint64_t>
-    getSubTypeByFieldID(uint64_t fieldID);
-
-    /// Get the maximum field ID in this bundle.  This is helpful for
-    /// constructing field IDs when this FEnumType is nested in another
-    /// aggregate type.
-    uint64_t getMaxFieldID();
-
-    /// Returns the effective field id when treating the index field as the root
-    /// of the type.  Essentially maps a fieldID to a fieldID after a subfield
-    /// op. Returns the new id and whether the id is in the given child.
-    std::pair<uint64_t, bool> rootChildFieldID(uint64_t fieldID,
-                                               uint64_t index);
+    std::pair<uint64_t, uint64_t> getIndexAndSubfieldID(uint64_t fieldID) const;
 
     using iterator = ArrayRef<EnumElement>::iterator;
     iterator begin() const { return getElements().begin(); }
@@ -459,7 +424,7 @@ def FEnumImpl : FIRRTLImplType<"FEnum", [FieldIDTypeInterface]> {
 }
 
 def RefImpl : FIRRTLImplType<"Ref",
-                             [AtomicFieldIDTypeInterface],
+                             [],
                              "::circt::firrtl::FIRRTLType"> {
   let summary = "A reference to a signal elsewhere.";
   let description = [{
@@ -495,7 +460,7 @@ def RefImpl : FIRRTLImplType<"Ref",
   }];
 }
 
-def BaseTypeAliasImpl : FIRRTLImplType<"BaseTypeAlias", [FieldIDTypeInterface],
+def BaseTypeAliasImpl : FIRRTLImplType<"BaseTypeAlias", [DeclareTypeInterfaceMethods<FieldIDTypeInterface>],
                                         "::circt::firrtl::FIRRTLBaseType"> {
   let summary = "type alias for firrtl base types";
   let parameters =
@@ -517,21 +482,6 @@ def BaseTypeAliasImpl : FIRRTLImplType<"BaseTypeAlias", [FieldIDTypeInterface],
       // If a given `newInnerType` is identical to innerType, return `*this`
       // because we can reuse the type alias. Otherwise return `newInnerType`.
       FIRRTLBaseType getModifiedType(FIRRTLBaseType newInnerType);
-
-      /// Implement FieldIDTypeInterface.
-
-      /// Strip off a single layer of this type and return the sub-type and a
-      /// field ID targeting the same field, but rebased on the sub-type.
-      std::pair<circt::hw::FieldIDTypeInterface, uint64_t>
-      getSubTypeByFieldID(uint64_t fieldID);
-
-      /// Get the maximum field ID.
-      uint64_t getMaxFieldID();
-
-      /// Returns the effective field id when treating the index field as the root
-      /// of the type.  Essentially maps a fieldID to a fieldID after a subfield
-      /// op. Returns the new id and whether the id is in the given child.
-      std::pair<uint64_t, bool> rootChildFieldID(uint64_t fieldID, uint64_t index);
   }];
 
   let builders = [
@@ -547,7 +497,7 @@ def BaseTypeAliasImpl : FIRRTLImplType<"BaseTypeAlias", [FieldIDTypeInterface],
 class PropImplType<string name,
                    list<Trait> traits = [],
                    string baseCppClass = "::circt::firrtl::FIRRTLType">
-  : FIRRTLImplType<name, traits # [ AtomicFieldIDTypeInterface ], baseCppClass>;
+  : FIRRTLImplType<name, traits # [ ], baseCppClass>;
 
 def ClassImpl : PropImplType<"Class"> {
   let summary = [{

--- a/include/circt/Dialect/HW/HWTypeInterfaces.h
+++ b/include/circt/Dialect/HW/HWTypeInterfaces.h
@@ -16,6 +16,21 @@
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/Types.h"
 
+namespace circt {
+namespace hw {
+namespace FieldIdImpl {
+uint64_t getMaxFieldID(Type);
+
+std::pair<::mlir::Type, uint64_t> getSubTypeByFieldID(Type, uint64_t fieldID);
+
+::mlir::Type getFinalTypeByFieldID(Type type, uint64_t fieldID);
+
+std::pair<uint64_t, bool> rootChildFieldID(Type, uint64_t fieldID,
+                                           uint64_t index);
+} // namespace FieldIdImpl
+} // namespace hw
+} // namespace circt
+
 #include "circt/Dialect/HW/HWTypeInterfaces.h.inc"
 
 #endif // CIRCT_DIALECT_HW_HWTYPEINTERFACES_H

--- a/include/circt/Dialect/HW/HWTypeInterfaces.td
+++ b/include/circt/Dialect/HW/HWTypeInterfaces.td
@@ -29,14 +29,12 @@ def FieldIDTypeInterface : TypeInterface<"FieldIDTypeInterface"> {
       Get the sub-type of a type for a field ID, and the subfield's ID. Strip
       off a single layer of this type and return the sub-type and a field ID
       targeting the same field, but rebased on the sub-type.
-    }], "std::pair<circt::hw::FieldIDTypeInterface, uint64_t>",
-    "getSubTypeByFieldID", (ins "uint64_t":$fieldID)>,
 
-    InterfaceMethod<[{
-      Return the final type targeted by this field ID by recursively walking all
-      nested aggregate types. This is the identity function for ground types.
-    }], "circt::hw::FieldIDTypeInterface", "getFinalTypeByFieldID",
-    (ins "uint64_t":$fieldID)>,
+      The resultant type may not be a FieldIDTypeInterface if the resulting 
+      fieldID is zero.  This means that leaf types may be ground without 
+      implementing an interface.
+    }], "std::pair<::mlir::Type, uint64_t>",
+    "getSubTypeByFieldID", (ins "uint64_t":$fieldID)>,
 
     InterfaceMethod<[{
       Returns the effective field id when treating the index field as the
@@ -46,34 +44,6 @@ def FieldIDTypeInterface : TypeInterface<"FieldIDTypeInterface"> {
     }], "std::pair<uint64_t, bool>", "rootChildFieldID",
     (ins "uint64_t":$fieldID, "uint64_t":$index)>,
   ];
-}
-
-def AtomicFieldIDTypeInterface : TypeInterface<"AtomicFieldIDTypeInterface",[FieldIDTypeInterface]> {
-  let cppNamespace = "circt::hw";
-  let description = [{
-    FieldID-supporting type with no fields (other than itself).
-
-    Used to implement FieldIDTypeInterface methods automatically for this common case.
-  }];
-
-  let extraTraitClassDeclaration = [{
-
-    uint64_t getMaxFieldID() const { return 0; }
-
-    std::pair<circt::hw::FieldIDTypeInterface, uint64_t> getSubTypeByFieldID(uint64_t fieldID) const {
-      assert(fieldID == 0);
-      return {$_type, 0};
-    }
-
-    circt::hw::FieldIDTypeInterface getFinalTypeByFieldID(uint64_t fieldID) const {
-      assert(fieldID == 0);
-      return $_type;
-    }
-
-    std::pair<uint64_t, bool> rootChildFieldID(uint64_t fieldID, uint64_t index) const {
-      return {0, fieldID == 0};
-    }
-  }];
 }
 
 #endif // CIRCT_DIALECT_HW_HWTYPEINTERFACES_TD

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -610,7 +610,8 @@ LogicalResult circt::firrtl::applyGCTDataTaps(const AnnoPathValue &target,
           firrtl::type_cast<FIRRTLBaseType>(wireTarget->ref.getType());
       if (wireTarget->fieldIdx)
         targetType = firrtl::type_cast<FIRRTLBaseType>(
-            targetType.getFinalTypeByFieldID(wireTarget->fieldIdx));
+            hw::FieldIdImpl::getFinalTypeByFieldID(targetType,
+                                                   wireTarget->fieldIdx));
       sendVal = lowerInternalPathAnno(internalPathSrc, *moduleTarget, target,
                                       internalPathAttr, targetType, state);
       if (!sendVal)

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -5442,11 +5442,8 @@ LogicalResult RWProbeOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
 
   auto checkFinalType = [&](auto type, Location loc) -> LogicalResult {
     // Determine final type.
-    mlir::Type fType = type;
-    if (auto fieldIDType = type_dyn_cast<hw::FieldIDTypeInterface>(type))
-      fType = fieldIDType.getFinalTypeByFieldID(target.getField());
-    else
-      assert(target.getField() == 0);
+    mlir::Type fType =
+        hw::FieldIdImpl::getFinalTypeByFieldID(type, target.getField());
     // Check.
     auto baseType = type_dyn_cast<FIRRTLBaseType>(fType);
     if (!baseType || baseType.getPassiveType() != getType().getType()) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -973,12 +973,6 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
           if (parseType(type, "expected bundle field type"))
             return failure();
 
-          // We require that elements of aggregates themselves
-          // support notion of FieldID, reject if the type does not.
-          if (!isa<hw::FieldIDTypeInterface>(type))
-            return emitError(loc, "type ")
-                   << type << " cannot be used as field in a bundle";
-
           elements.push_back(
               {StringAttr::get(getContext(), fieldName), isFlipped, type});
           bundleCompatible &= isa<BundleType::ElementType>(type);
@@ -1082,12 +1076,6 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
 
     if (size < 0)
       return emitError(sizeLoc, "invalid size specifier"), failure();
-
-    // We require that elements of aggregates themselves
-    // support notion of FieldID, reject if the type does not.
-    if (!isa<hw::FieldIDTypeInterface>(result))
-      return emitError(sizeLoc, "type ")
-             << result << " cannot be used in a vector";
 
     auto baseType = type_dyn_cast<FIRRTLBaseType>(result);
     if (baseType)

--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -1408,9 +1408,8 @@ std::optional<TypeSum> GrandCentralPass::computeField(
             auto value = fieldRef.getValue();
             auto fieldID = fieldRef.getFieldID();
             auto tpe = firrtl::type_cast<FIRRTLBaseType>(
-                value.getType()
-                    .cast<circt::hw::FieldIDTypeInterface>()
-                    .getFinalTypeByFieldID(fieldID));
+                hw::FieldIdImpl::getFinalTypeByFieldID(value.getType(),
+                                                       fieldID));
             if (!tpe.isGround()) {
               value.getDefiningOp()->emitOpError()
                   << "cannot be added to interface with id '"

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -695,14 +695,15 @@ void IMConstPropPass::visitConnectLike(FConnectLike connect,
 
   if (auto srcOffset = getFieldIDOffset(changedFieldRef, baseType, fieldRefSrc))
     propagateElementLattice(
-        *srcOffset,
-        cast<FIRRTLBaseType>(baseType.getFinalTypeByFieldID(*srcOffset)));
+        *srcOffset, cast<FIRRTLBaseType>(hw::FieldIdImpl::getFinalTypeByFieldID(
+                        baseType, *srcOffset)));
 
   if (auto relativeDest =
           getFieldIDOffset(changedFieldRef, baseType, fieldRefDest))
     propagateElementLattice(
         *relativeDest,
-        cast<FIRRTLBaseType>(baseType.getFinalTypeByFieldID(*relativeDest)));
+        cast<FIRRTLBaseType>(
+            hw::FieldIdImpl::getFinalTypeByFieldID(baseType, *relativeDest)));
 }
 
 void IMConstPropPass::visitRefSend(RefSendOp send, FieldRef changedFieldRef) {

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -78,16 +78,13 @@ static FieldRef getRefForIST(const hw::InnerSymTarget &ist) {
 
 /// Calculate the "InferWidths-fieldID" equivalent for the given fieldID + type.
 static uint64_t convertFieldIDToOurVersion(uint64_t fieldID, FIRRTLType type) {
-  auto fType = getBaseOfType<hw::FieldIDTypeInterface>(type);
-  if (!fType)
-    return fieldID;
-
   uint64_t convertedFieldID = 0;
 
   auto curFID = fieldID;
-  auto curFType = fType;
+  Type curFType = type;
   while (curFID != 0) {
-    auto [child, subID] = curFType.getSubTypeByFieldID(curFID);
+    auto [child, subID] =
+        hw::FieldIdImpl::getSubTypeByFieldID(curFType, curFID);
     if (isa<FVectorType>(curFType))
       convertedFieldID++; // Vector fieldID is 1.
     else

--- a/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
@@ -145,7 +145,7 @@ struct PathResolver {
       if (!baseType)
         return emitError(loc, "unable to target non-hardware type ")
                << targetType;
-      targetType = baseType.getFinalTypeByFieldID(fieldId);
+      targetType = hw::FieldIdImpl::getFinalTypeByFieldID(baseType, fieldId);
       if (isa<BundleType, FVectorType>(targetType))
         return emitError(loc, "unable to target aggregate type ") << targetType;
     }

--- a/lib/Dialect/HW/HWTypeInterfaces.cpp
+++ b/lib/Dialect/HW/HWTypeInterfaces.cpp
@@ -12,4 +12,40 @@
 
 #include "circt/Dialect/HW/HWTypeInterfaces.h"
 
+using namespace mlir;
+using namespace circt;
+using namespace hw;
+using namespace FieldIdImpl;
+
+Type circt::hw::FieldIdImpl::getFinalTypeByFieldID(Type type,
+                                                   uint64_t fieldID) {
+  std::pair<Type, uint64_t> pair(type, fieldID);
+  while (pair.second) {
+    if (auto ftype = dyn_cast<FieldIDTypeInterface>(pair.first)) {
+      pair = ftype.getSubTypeByFieldID(pair.second);
+    } else {
+      assert(0 && "fieldID indexing into a non-aggregate type");
+      abort();
+    }
+  }
+  return pair.first;
+}
+
+std::pair<Type, uint64_t>
+circt::hw::FieldIdImpl::getSubTypeByFieldID(Type type, uint64_t fieldID) {
+  if (!fieldID)
+    return {type, 0};
+  if (auto ftype = dyn_cast<FieldIDTypeInterface>(type))
+    return ftype.getSubTypeByFieldID(fieldID);
+
+  assert(0 && "fieldID indexing into a non-aggregate type");
+  abort();
+}
+
+uint64_t circt::hw::FieldIdImpl::getMaxFieldID(Type type) {
+  if (auto ftype = dyn_cast<FieldIDTypeInterface>(type))
+    return ftype.getMaxFieldID();
+  return 0;
+}
+
 #include "circt/Dialect/HW/HWTypeInterfaces.cpp.inc"


### PR DESCRIPTION
Types which do not support FieldIDs are assumed to be atomic.