### PR TITLE
[SV] Add optional `init` operand to `sv.reg`

### DIFF
--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -60,20 +60,25 @@ def RegOp : SVOp<"reg", [
      Declare a SystemVerilog Variable Declaration of 'reg' type.
      See SV Spec 6.8, pp100.
    }];
-  let arguments = (ins StrAttr:$name, OptionalAttr<InnerSymAttr>:$inner_sym);
+  let arguments = (ins
+    StrAttr:$name,
+    Optional<AnyType>:$init,
+    OptionalAttr<InnerSymAttr>:$inner_sym);
   let results = (outs InOutType:$result);
 
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,
                     CArg<"StringAttr", "StringAttr()">:$name,
-                    CArg<"hw::InnerSymAttr", "hw::InnerSymAttr()">:$innerSym)>
+                    CArg<"hw::InnerSymAttr", "hw::InnerSymAttr()">:$innerSym,
+                    CArg<"mlir::Value", "{}">:$init)>
   ];
 
   // We handle the name in a custom way, so we use a customer parser/printer.
   let assemblyFormat = [{
-    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>($name) attr-dict
+    (`init` $init^)? (`sym` $inner_sym^)? `` custom<ImplicitSSAName>($name) attr-dict
     `:` qualified(type($result))
+    custom<ImplicitInitType>(ref(type($result)),ref($init), type($init))
   }];
   let hasCanonicalizeMethod = true;
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -5012,6 +5012,14 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
       });
     }
 
+    if (auto regOp = dyn_cast<RegOp>(op)) {
+      if (auto initValue = regOp.getInit()) {
+        ps << PP::space << "=" << PP::space;
+        ps.scopedBox(PP::ibox0,
+                     [&]() { emitExpression(initValue, opsForLocation); });
+      }
+    }
+
     // Try inlining an assignment into declarations.
     if (isa<sv::WireOp, LogicOp>(op) &&
         !op->getParentOp()->hasTrait<ProceduralRegion>()) {

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -536,6 +536,17 @@ hw.module @reg_1(%in4: i4, %in8: i8) -> (a : i3, b : i5) {
   hw.output %c, %d : i3,i5
 }
 
+// CHECK-LABEL: module regWithInit(
+// CHECK:     reg        reg1 = 1'h0; 
+// CHECK:     reg [31:0] reg2 = 32'(arg + arg);
+hw.module @regWithInit(%arg : i32) {
+  %c0_i1 = hw.constant 0 : i1
+  %reg1 = sv.reg init %c0_i1 : !hw.inout<i1>
+  
+  %init = comb.add %arg, %arg : i32
+  %reg2 = sv.reg init %init : !hw.inout<i32>
+}
+
 // CHECK-LABEL: module struct_field_inout1(
 // CHECK-NEXT:   inout struct packed {logic b; } a
 // CHECK-NEXT:  );


### PR DESCRIPTION
Named the optional operand `init `instead of `reset` - i think that is more apt, to ensure that users don't mix the semantics of this operand with an actual (a)synchronous reset assignment.