### PR TITLE
[Pipeline] valid -> enable

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -140,7 +140,7 @@ def ScheduledPipelineOp : PipelineBase<"scheduled", [
     the clock-enable input of the stage-separating registers.
 
     The `go` input is used to start the pipeline. This value is fed through
-    the stages as the current stage valid/next stage enable signal.e
+    the stages as the current stage valid/next stage enable signal.
     Note: the op is currently only designed for pipelines with II=1. For
     pipelines with II>1, a user must themselves maintain state about when
     the pipeline is ready to accept new inputs. We plan to add support for

--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -140,7 +140,7 @@ def ScheduledPipelineOp : PipelineBase<"scheduled", [
     the clock-enable input of the stage-separating registers.
 
     The `go` input is used to start the pipeline. This value is fed through
-    the stages as the current stage enable/next stage valid signal.
+    the stages as the current stage valid/next stage enable signal.e
     Note: the op is currently only designed for pipelines with II=1. For
     pipelines with II>1, a user must themselves maintain state about when
     the pipeline is ready to accept new inputs. We plan to add support for

--- a/integration_test/Dialect/Ibis/end_to_end.mlir
+++ b/integration_test/Dialect/Ibis/end_to_end.mlir
@@ -50,13 +50,13 @@ ibis.class @C2 {
     %res, %done = pipeline.scheduled(%a0 : i32 = %sibling_out) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
         %0 = comb.mul %a0, %a0 : i32
         pipeline.stage ^bb1
-      ^bb1(%s1_valid : i1):
+      ^bb1(%s1_enable : i1):
         %1 = comb.mul %0, %a0 : i32
         pipeline.stage ^bb2
-      ^bb2(%s2_valid : i1):
+      ^bb2(%s2_enable : i1):
         %2 = comb.sub %1, %0 : i32
         pipeline.stage ^bb3
-      ^bb3(%s3_valid : i1):
+      ^bb3(%s3_enable : i1):
         pipeline.return %2 : i32
     }
 

--- a/integration_test/Dialect/Pipeline/simple/simple.mlir
+++ b/integration_test/Dialect/Pipeline/simple/simple.mlir
@@ -25,11 +25,11 @@ hw.module @simple(%arg0 : i32, %arg1 : i32, %go : i1, %clock : i1, %reset : i1) 
       %add0 = comb.add %a0, %a1 : i32
       pipeline.stage ^bb1
 
-    ^bb1(%s1_valid : i1):
+    ^bb1(%s1_enable : i1):
       %add1 = comb.add %add0, %a0 : i32
       pipeline.stage ^bb2
 
-    ^bb2(%s2_valid : i1):
+    ^bb2(%s2_enable : i1):
       %add2 = comb.add %add1, %add0 : i32
       pipeline.return %add2 : i32
   }

--- a/integration_test/Dialect/Pipeline/stall/stallTest.mlir
+++ b/integration_test/Dialect/Pipeline/stall/stallTest.mlir
@@ -25,11 +25,11 @@ hw.module @stallTest(%arg0 : i32, %arg1 : i32, %go : i1, %stall : i1, %clock : i
       %add0 = comb.add %a0, %a1 : i32
       pipeline.stage ^bb1
 
-    ^bb1(%s1_valid : i1):
+    ^bb1(%s1_enable : i1):
       %add1 = comb.add %add0, %a0 : i32
       pipeline.stage ^bb2
 
-    ^bb2(%s2_valid : i1):
+    ^bb2(%s2_enable : i1):
       %add2 = comb.add %add1, %add0 : i32
       pipeline.return %add2 : i32
   }

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -465,9 +465,9 @@ void ScheduledPipelineOp::getAsmBlockArgumentNames(
         setNameFn(arg, llvm::formatv("s{0}_pass{1}", i, passthroughI).str());
       }
 
-      // Last argument in any (non-entry) stage is the stage valid signal.
+      // Last argument in any (non-entry) stage is the stage enable signal.
       setNameFn(block.getArguments().back(),
-                llvm::formatv("s{0}_valid", i).str());
+                llvm::formatv("s{0}_enable", i).str());
     }
   }
 }

--- a/test/Conversion/PipelineToHW/test_ce.mlir
+++ b/test/Conversion/PipelineToHW/test_ce.mlir
@@ -17,7 +17,7 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
-  ^bb1(%6: i32, %7: i32, %s1_valid : i1):  // pred: ^bb1
+  ^bb1(%6: i32, %7: i32, %s1_enable : i1):  // pred: ^bb1
     %8 = comb.add %6, %7 : i32
     pipeline.return %8 : i32
   }

--- a/test/Conversion/PipelineToHW/test_clockgates.mlir
+++ b/test/Conversion/PipelineToHW/test_clockgates.mlir
@@ -37,7 +37,7 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
     %true = hw.constant true
     %false = hw.constant false
     pipeline.stage ^bb1 regs(%1 : i32 gated by [%true, %false], %a0 : i32)
-  ^bb1(%6: i32, %7: i32, %s1_valid : i1):  // pred: ^bb1
+  ^bb1(%6: i32, %7: i32, %s1_enable : i1):  // pred: ^bb1
     %8 = comb.add %6, %7 : i32
     pipeline.return %8 : i32
   }

--- a/test/Conversion/PipelineToHW/test_inline.mlir
+++ b/test/Conversion/PipelineToHW/test_inline.mlir
@@ -33,13 +33,13 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
       pipeline.latency.return %6 : i32
     }
     pipeline.stage ^bb1 pass(%1 : i32)
-  ^bb1(%2: i32, %s1_valid: i1):  // pred: ^bb0
+  ^bb1(%2: i32, %s1_enable: i1):  // pred: ^bb0
     pipeline.stage ^bb2 pass(%2 : i32)
-  ^bb2(%3: i32, %s2_valid: i1):  // pred: ^bb1
+  ^bb2(%3: i32, %s2_enable: i1):  // pred: ^bb1
     pipeline.stage ^bb3 regs(%3 : i32)
-  ^bb3(%4: i32, %s3_valid: i1):  // pred: ^bb2
+  ^bb3(%4: i32, %s3_enable: i1):  // pred: ^bb2
     pipeline.stage ^bb4 regs(%4 : i32)
-  ^bb4(%5: i32, %s4_valid: i1):  // pred: ^bb3
+  ^bb4(%5: i32, %s4_enable: i1):  // pred: ^bb3
     pipeline.return %5 : i32
   }
   hw.output %out, %done : i32, i1
@@ -59,7 +59,7 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
-  ^bb1(%6: i32, %7: i32, %s1_valid : i1):  // pred: ^bb1
+  ^bb1(%6: i32, %7: i32, %s1_enable : i1):  // pred: ^bb1
     %8 = comb.add %6, %7 : i32
     pipeline.return %8 : i32
   }
@@ -96,10 +96,10 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
-  ^bb1(%2: i32, %3: i32, %s1_valid: i1):  // pred: ^bb0
+  ^bb1(%2: i32, %3: i32, %s1_enable: i1):  // pred: ^bb0
     %5 = comb.add %2, %3 : i32
     pipeline.stage ^bb2 regs(%5 : i32, %2 : i32)
-  ^bb2(%6: i32, %7: i32, %s2_valid: i1):  // pred: ^bb1
+  ^bb2(%6: i32, %7: i32, %s2_enable: i1):  // pred: ^bb1
     %8 = comb.mul %6, %7 : i32
     pipeline.return %8 : i32
   }
@@ -107,10 +107,10 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
   %1:2 = pipeline.scheduled(%a0 : i32 = %0#0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
-  ^bb1(%2: i32, %3: i32, %s1_valid: i1):  // pred: ^bb0
+  ^bb1(%2: i32, %3: i32, %s1_enable: i1):  // pred: ^bb0
     %5 = comb.add %2, %3 : i32
     pipeline.stage ^bb2 regs(%5 : i32, %2 : i32)
-  ^bb2(%6: i32, %7: i32, %s2_valid: i1):  // pred: ^bb1
+  ^bb2(%6: i32, %7: i32, %s2_enable: i1):  // pred: ^bb1
     %8 = comb.mul %6, %7 : i32
     pipeline.return %8 : i32
   }
@@ -137,12 +137,12 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
     %1 = comb.sub %a0, %a0 : i32
     pipeline.stage ^bb1 regs(%1 : i32)
 
-  ^bb1(%6: i32, %s1_valid: i1):
+  ^bb1(%6: i32, %s1_enable: i1):
     // Use the external value inside a stage
     %8 = comb.add %6, %ext1 : i32
     pipeline.stage ^bb2 regs(%8 : i32)
   
-  ^bb2(%9 : i32, %s2_valid: i1):
+  ^bb2(%9 : i32, %s2_enable: i1):
   // Use the external value in the exit stage.
     pipeline.return %9, %ext1 : i32, i32
   }
@@ -185,20 +185,20 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: 
     sv.assign %reg_out_wire, %out : i32
     pipeline.stage ^bb1 regs(%out : i32)
 
-  ^bb1(%6: i32, %s1_valid: i1):
+  ^bb1(%6: i32, %s1_enable: i1):
     %reg1_out_wire = sv.wire : !hw.inout<i32>
     %reg1_out = sv.read_inout %reg1_out_wire : !hw.inout<i32>
     %add1 = comb.add %reg1_out, %6 : i32
-    %out1 = seq.compreg.ce %add1, %c, %s1_valid, %r, %zero : i32
+    %out1 = seq.compreg.ce %add1, %c, %s1_enable, %r, %zero : i32
     sv.assign %reg1_out_wire, %out1 : i32
 
     pipeline.stage ^bb2 regs(%out1 : i32)
   
-  ^bb2(%9 : i32, %s2_valid: i1):
+  ^bb2(%9 : i32, %s2_enable: i1):
     %reg2_out_wire = sv.wire : !hw.inout<i32>
     %reg2_out = sv.read_inout %reg2_out_wire : !hw.inout<i32>
     %add2 = comb.add %reg2_out, %9 : i32
-    %out2 = seq.compreg.ce %add2, %c, %s2_valid, %r, %zero : i32
+    %out2 = seq.compreg.ce %add2, %c, %s2_enable, %r, %zero : i32
     sv.assign %reg2_out_wire, %out2 : i32
     pipeline.return %out2  : i32
   }
@@ -220,7 +220,7 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: 
 hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     pipeline.stage ^bb1 regs(%a0 : i32)
-  ^bb1(%1: i32, %s1_valid : i1):  // pred: ^bb1
+  ^bb1(%1: i32, %s1_enable : i1):  // pred: ^bb1
     pipeline.return %1 : i32
   }
   hw.output %0#0, %0#1 : i32, i1

--- a/test/Conversion/PipelineToHW/test_outlined.mlir
+++ b/test/Conversion/PipelineToHW/test_outlined.mlir
@@ -69,13 +69,13 @@ hw.module @testLatency1(%arg0: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32, d
       pipeline.latency.return %6 : i32
     }
     pipeline.stage ^bb1 pass(%1 : i32)
-  ^bb1(%2: i32, %s1_valid: i1):  // pred: ^bb0
+  ^bb1(%2: i32, %s1_enable: i1):  // pred: ^bb0
     pipeline.stage ^bb2 pass(%2 : i32)
-  ^bb2(%3: i32, %s2_valid: i1):  // pred: ^bb1
+  ^bb2(%3: i32, %s2_enable: i1):  // pred: ^bb1
     pipeline.stage ^bb3 regs(%3 : i32)
-  ^bb3(%4: i32, %s3_valid: i1):  // pred: ^bb2
+  ^bb3(%4: i32, %s3_enable: i1):  // pred: ^bb2
     pipeline.stage ^bb4 regs(%4 : i32)
-  ^bb4(%5: i32, %s4_valid: i1):  // pred: ^bb3
+  ^bb4(%5: i32, %s4_enable: i1):  // pred: ^bb3
     pipeline.return %5 : i32
   }
   hw.output %out, %done : i32, i1
@@ -113,7 +113,7 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %1 = comb.sub %a0, %a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
-  ^bb1(%6: i32, %7: i32, %s1_valid : i1):  // pred: ^bb1
+  ^bb1(%6: i32, %7: i32, %s1_enable : i1):  // pred: ^bb1
     %8 = comb.add %6, %7 : i32
     pipeline.return %8 : i32
   }
@@ -198,10 +198,10 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
-  ^bb1(%2: i32, %3: i32, %s1_valid: i1):  // pred: ^bb0
+  ^bb1(%2: i32, %3: i32, %s1_enable: i1):  // pred: ^bb0
     %5 = comb.add %2, %3 : i32
     pipeline.stage ^bb2 regs(%5 : i32, %2 : i32)
-  ^bb2(%6: i32, %7: i32, %s2_valid: i1):  // pred: ^bb1
+  ^bb2(%6: i32, %7: i32, %s2_enable: i1):  // pred: ^bb1
     %8 = comb.mul %6, %7 : i32
     pipeline.return %8 : i32
   }
@@ -209,10 +209,10 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
   %1:2 = pipeline.scheduled(%a0 : i32 = %0#0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
-  ^bb1(%2: i32, %3: i32, %s1_valid: i1):  // pred: ^bb0
+  ^bb1(%2: i32, %3: i32, %s1_enable: i1):  // pred: ^bb0
     %5 = comb.add %2, %3 : i32
     pipeline.stage ^bb2 regs(%5 : i32, %2 : i32)
-  ^bb2(%6: i32, %7: i32, %s2_valid: i1):  // pred: ^bb1
+  ^bb2(%6: i32, %7: i32, %s2_enable: i1):  // pred: ^bb1
     %8 = comb.mul %6, %7 : i32
     pipeline.return %8 : i32
   }
@@ -257,12 +257,12 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
     %1 = comb.sub %a0, %a0 : i32
     pipeline.stage ^bb1 regs(%1 : i32)
 
-  ^bb1(%6: i32, %s1_valid: i1):
+  ^bb1(%6: i32, %s1_enable: i1):
     // Use the external value inside a stage
     %8 = comb.add %6, %ext1 : i32
     pipeline.stage ^bb2 regs(%8 : i32)
   
-  ^bb2(%9 : i32, %s2_valid: i1):
+  ^bb2(%9 : i32, %s2_enable: i1):
   // Use the external value in the exit stage.
     pipeline.return %9, %ext1  : i32, i32
   }
@@ -331,20 +331,20 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: 
     sv.assign %reg_out_wire, %out : i32
     pipeline.stage ^bb1 regs(%out : i32)
 
-  ^bb1(%6: i32, %s1_valid: i1):
+  ^bb1(%6: i32, %s1_enable: i1):
     %reg1_out_wire = sv.wire : !hw.inout<i32>
     %reg1_out = sv.read_inout %reg1_out_wire : !hw.inout<i32>
     %add1 = comb.add %reg1_out, %6 : i32
-    %out1 = seq.compreg.ce %add1, %c, %s1_valid, %r, %zero : i32
+    %out1 = seq.compreg.ce %add1, %c, %s1_enable, %r, %zero : i32
     sv.assign %reg1_out_wire, %out1 : i32
 
     pipeline.stage ^bb2 regs(%out1 : i32)
   
-  ^bb2(%9 : i32, %s2_valid: i1):
+  ^bb2(%9 : i32, %s2_enable: i1):
     %reg2_out_wire = sv.wire : !hw.inout<i32>
     %reg2_out = sv.read_inout %reg2_out_wire : !hw.inout<i32>
     %add2 = comb.add %reg2_out, %9 : i32
-    %out2 = seq.compreg.ce %add2, %c, %s2_valid, %r, %zero : i32
+    %out2 = seq.compreg.ce %add2, %c, %s2_enable, %r, %zero : i32
     sv.assign %reg2_out_wire, %out2 : i32
     pipeline.return %out2  : i32
   }
@@ -378,7 +378,7 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: 
 hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     pipeline.stage ^bb1 regs(%a0 : i32)
-  ^bb1(%1: i32, %s1_valid : i1):  // pred: ^bb1
+  ^bb1(%1: i32, %s1_enable : i1):  // pred: ^bb1
     pipeline.return %1 : i32
   }
   hw.output %0#0, %0#1 : i32, i1
@@ -419,10 +419,10 @@ hw.module @testNaming(%go: i1, %clk: i1, %rst: i1) -> (out: i1) {
     %add = comb.add %a0, %a0 : i1
     pipeline.stage ^bb1 regs("myReg" = %add : i1, %add : i1) pass("myPass" = %add : i1)
   
-  ^bb1(%1 : i1, %2 : i1, %3 : i1, %s1_valid: i1):
+  ^bb1(%1 : i1, %2 : i1, %3 : i1, %s1_enable: i1):
     pipeline.stage ^bb2 regs(%1 : i1, %2 : i1) pass(%3 : i1)
 
-  ^bb2(%4 : i1, %5 : i1, %6 : i1, %s2_valid: i1):
+  ^bb2(%4 : i1, %5 : i1, %6 : i1, %s2_enable: i1):
     pipeline.return %4 : i1
   
   }

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -25,7 +25,7 @@ hw.module @unscheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
 // CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:      pipeline.stage ^bb1 
-// CHECK-NEXT:    ^bb1(%s1_valid: i1):  // pred: ^bb0
+// CHECK-NEXT:    ^bb1(%s1_enable: i1):  // pred: ^bb0
 // CHECK-NEXT:      pipeline.return %0 : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
@@ -35,7 +35,7 @@ hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) 
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1
 
-   ^bb1(%s1_valid : i1):
+   ^bb1(%s1_enable : i1):
     pipeline.return %0 : i32
   }
   hw.output %0 : i32
@@ -46,7 +46,7 @@ hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) 
 // CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%0 : i32)
-// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_valid: i1):  // pred: ^bb0
+// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_enable: i1):  // pred: ^bb0
 // CHECK-NEXT:      pipeline.return %s1_reg0 : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
@@ -56,7 +56,7 @@ hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) 
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1 regs(%0 : i32)
 
-   ^bb1(%s0_0 : i32, %s1_valid : i1):
+   ^bb1(%s0_0 : i32, %s1_enable : i1):
     pipeline.return %s0_0 : i32
   }
   hw.output %0 : i32
@@ -66,7 +66,7 @@ hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) 
 // CHECK-NEXT:    %out0, %out1, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0 : i32, out1 : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%0 : i32) pass(%a1 : i32)
-// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_pass0: i32, %s1_valid: i1):  // pred: ^bb0
+// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_pass0: i32, %s1_enable: i1):  // pred: ^bb0
 // CHECK-NEXT:      pipeline.return %s1_reg0, %s1_pass0 : i32, i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out0 : i32
@@ -76,7 +76,7 @@ hw.module @scheduledWithPassthrough(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1 regs(%0 : i32) pass(%a1 : i32)
 
-   ^bb1(%s0_0 : i32, %s0_pass_a1 : i32, %s1_valid : i1):
+   ^bb1(%s0_0 : i32, %s0_pass_a1 : i32, %s1_enable : i1):
     pipeline.return %s0_0, %s0_pass_a1 : i32, i32
   }
   hw.output %0#0 : i32
@@ -98,7 +98,7 @@ hw.module @withStall(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : i1) -
 // CHECK-LABEL:  hw.module @withMultipleRegs(%arg0: i32, %stall: i1, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
 // CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%a0 : i32, %a0 : i32)
-// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_reg1: i32, %s1_valid: i1):  // pred: ^bb0
+// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_reg1: i32, %s1_enable: i1):  // pred: ^bb0
 // CHECK-NEXT:      pipeline.return %s1_reg0 : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
@@ -107,7 +107,7 @@ hw.module @withMultipleRegs(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst 
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     pipeline.stage ^bb1 regs(%a0 : i32, %a0 : i32)
 
-   ^bb1(%0 : i32, %1 : i32, %s1_valid : i1):
+   ^bb1(%0 : i32, %1 : i32, %s1_enable : i1):
     pipeline.return %0 : i32
   }
   hw.output %0 : i32
@@ -119,7 +119,7 @@ hw.module @withMultipleRegs(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst 
 // CHECK-NEXT:      %true_0 = hw.constant true
 // CHECK-NEXT:      %true_1 = hw.constant true
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%a0 : i32 gated by [%true], %a0 : i32, %a0 : i32 gated by [%true_0, %true_1])
-// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_reg1: i32, %s1_reg2: i32, %s1_valid: i1):  // pred: ^bb0
+// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_reg1: i32, %s1_reg2: i32, %s1_enable: i1):  // pred: ^bb0
 // CHECK-NEXT:      pipeline.return %s1_reg0 : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
@@ -131,7 +131,7 @@ hw.module @withClockGates(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : 
     %true3 = hw.constant true
     pipeline.stage ^bb1 regs(%a0 : i32 gated by [%true1], %a0 : i32, %a0 : i32 gated by [%true2, %true3])
 
-   ^bb1(%0 : i32, %1 : i32, %2 : i32, %s1_valid : i1):
+   ^bb1(%0 : i32, %1 : i32, %2 : i32, %s1_enable : i1):
     pipeline.return %0 : i32
   }
   hw.output %0 : i32
@@ -141,7 +141,7 @@ hw.module @withClockGates(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : 
 // CHECK-NEXT:    %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:      pipeline.stage ^bb1 regs("myAdd" = %0 : i32, %0 : i32, "myOtherAdd" = %0 : i32) 
-// CHECK-NEXT:    ^bb1(%myAdd: i32, %s1_reg1: i32, %myOtherAdd: i32, %s1_valid: i1):  // pred: ^bb0
+// CHECK-NEXT:    ^bb1(%myAdd: i32, %s1_reg1: i32, %myOtherAdd: i32, %s1_enable: i1):  // pred: ^bb0
 // CHECK-NEXT:      pipeline.return %myAdd : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
@@ -151,7 +151,7 @@ hw.module @withNames(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1 regs("myAdd" = %0 : i32, %0 : i32, "myOtherAdd" = %0 : i32)
 
-   ^bb1(%r1 : i32, %r2 : i32, %r3 : i32, %s1_valid : i1):
+   ^bb1(%r1 : i32, %r2 : i32, %r3 : i32, %s1_enable : i1):
     pipeline.return %r1 : i32
   }
   hw.output %0 : i32


### PR DESCRIPTION
Be a little bit more strict about naming here - the `i1` block argument of any given stage represents the stage **enable** signal - stage **valid** is reserved for the **output** signal/register of a stage, that is fed to its successor stage (as the successor stage enable signal).