### PR TITLE
[Ibis] Add ibis.schedule op

### DIFF
--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -139,6 +139,7 @@ def InstanceOp : InstanceOpBase<"instance"> {
 def MethodOp : IbisOp<"method", [
       IsolatedFromAbove, RegionKindInterface,
       Symbol, FunctionOpInterface,
+      AutomaticAllocationScope,
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>,
       SingleBlockImplicitTerminator<"ReturnOp">,
       HasParent<"ClassOp">]> {
@@ -187,6 +188,29 @@ def ReturnOp : IbisOp<"return", [
   let builders = [
     OpBuilder<(ins)>,
   ];
+}
+
+def ScheduleOp : IbisOp<"schedule", [
+  HasParent<"MethodOp">,
+  SingleBlock,
+  NoRegionArguments,
+  NoTerminator
+]> {
+  let summary = "Ibis scheduling constraint block";
+  let description = [{
+    The `ibis.schedule` operation defines a block wherein a group of operations
+    can be placed wherein a limited number of Ibis threads can execute at once.
+    The operation is isolated from above and has no return types. References
+    to external values should be performed through SSA dominance or memrefs.
+  }];
+
+  let arguments = (ins
+    ConfinedAttr<I32Attr, [IntMinValue<1>]>:$limit
+  );
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = [{
+    $limit $body attr-dict
+  }];
 }
 
 def MemRefTypeAttr : TypeAttrBase<"MemRefType", "any memref type">;

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -200,7 +200,7 @@ def ScheduleOp : IbisOp<"schedule", [
   let description = [{
     The `ibis.schedule` operation defines a block wherein a group of operations
     can be placed wherein a limited number of Ibis threads can execute at once.
-    The operation is isolated from above and has no return types. References
+    The operation is not isolated from above and has no return types. References
     to external values should be performed through SSA dominance or memrefs.
   }];
 

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -8,6 +8,11 @@
 // CHECK-NEXT:      %parent = ibis.path [#ibis.step<parent : !ibis.scoperef<@HighLevel>> : !ibis.scoperef<@HighLevel>]
 // CHECK-NEXT:      %single = ibis.get_var %parent, @single : !ibis.scoperef<@HighLevel> -> memref<i32>
 // CHECK-NEXT:      %array = ibis.get_var %parent, @array : !ibis.scoperef<@HighLevel> -> memref<10xi32>
+// CHECK-NEXT:      %alloca = memref.alloca() : memref<i32>
+// CHECK-NEXT:      ibis.schedule 1 {
+// CHECK-NEXT:        %0 = memref.load %alloca[] : memref<i32>
+// CHECK-NEXT:        memref.store %0, %alloca[] : memref<i32>
+// CHECK-NEXT:      }
 // CHECK-NEXT:      ibis.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
@@ -23,6 +28,11 @@ ibis.class @HighLevel {
     ]
     %single = ibis.get_var %parent, @single : !ibis.scoperef<@HighLevel> -> memref<i32>
     %array = ibis.get_var %parent, @array : !ibis.scoperef<@HighLevel> -> memref<10xi32>
+    %local = memref.alloca() : memref<i32>
+    ibis.schedule 1 {
+      %v = memref.load %local[] : memref<i32>
+      memref.store %v, %local[] : memref<i32>
+    }
   }
 }
 


### PR DESCRIPTION
The `ibis.schedule` operation defines a block wherein a group of operations can be placed wherein a limited number of Ibis threads can execute at once. The operation is isolated from above and has no return types. References to external values should be performed through SSA dominance and memrefs.