### PR TITLE
[NFC] Explicitly opt-out of default use of MLIR properties for attributes for now.

### DIFF
--- a/include/circt/Dialect/Arc/ArcDialect.td
+++ b/include/circt/Dialect/Arc/ArcDialect.td
@@ -21,6 +21,9 @@ def ArcDialect : Dialect {
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
 
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let extraClassDeclaration = [{
     void registerTypes();
   }];

--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -39,6 +39,9 @@ def CalyxDialect : Dialect {
   // Depends on the HWDialect to support external primitives using hw.module.extern
   let dependentDialects = ["circt::hw::HWDialect"];
   let cppNamespace = "::circt::calyx";
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
 }
 
 class SameTypeConstraint<string lhs, string rhs>

--- a/include/circt/Dialect/Comb/Comb.td
+++ b/include/circt/Dialect/Comb/Comb.td
@@ -28,6 +28,10 @@ def CombDialect : Dialect {
   }];
   let hasConstantMaterializer = 1;
   let cppNamespace = "::circt::comb";
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
 }
 
 // Base class for the operation in this dialect.

--- a/include/circt/Dialect/DC/DCDialect.td
+++ b/include/circt/Dialect/DC/DCDialect.td
@@ -23,6 +23,9 @@ def DCDialect : Dialect {
   let useDefaultTypePrinterParser = 1;
   let dependentDialects = ["circt::esi::ESIDialect"];
 
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let extraClassDeclaration = [{
     void registerTypes();
   }];

--- a/include/circt/Dialect/ESI/ESIDialect.td
+++ b/include/circt/Dialect/ESI/ESIDialect.td
@@ -21,6 +21,9 @@ def ESI_Dialect : Dialect {
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
 
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let extraClassDeclaration = [{
     /// Register all ESI types.
     void registerTypes();

--- a/include/circt/Dialect/FIRRTL/CHIRRTL.td
+++ b/include/circt/Dialect/FIRRTL/CHIRRTL.td
@@ -38,6 +38,9 @@ def CHIRRTLDialect : Dialect {
   let dependentDialects = ["circt::firrtl::FIRRTLDialect"];
 
   let useDefaultTypePrinterParser = 1;
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLDialect.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDialect.td
@@ -34,6 +34,9 @@ def FIRRTLDialect : Dialect {
   let useDefaultTypePrinterParser = 0;
   let useDefaultAttributePrinterParser = 1;
 
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let dependentDialects = [
     "circt::hw::HWDialect",
     "circt::om::OMDialect"

--- a/include/circt/Dialect/FSM/FSM.td
+++ b/include/circt/Dialect/FSM/FSM.td
@@ -24,6 +24,9 @@ def FSMDialect : Dialect {
   }];
 
   let useDefaultTypePrinterParser = 1;
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
 }
 
 // Base class for the types in this dialect.

--- a/include/circt/Dialect/HW/HWDialect.td
+++ b/include/circt/Dialect/HW/HWDialect.td
@@ -28,6 +28,9 @@ def HWDialect : Dialect {
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
 
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let extraClassDeclaration = [{
     /// Register all HW types.
     void registerTypes();

--- a/include/circt/Dialect/HWArith/HWArithDialect.td
+++ b/include/circt/Dialect/HWArith/HWArithDialect.td
@@ -17,6 +17,9 @@ def HWArithDialect : Dialect {
   let name = "hwarith";
   let cppNamespace = "::circt::hwarith";
 
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let summary = "Types and operations for the HWArith dialect";
   let description = [{
     This dialect defines the `HWArith` dialect, modeling bit-width aware

--- a/include/circt/Dialect/Handshake/Handshake.td
+++ b/include/circt/Dialect/Handshake/Handshake.td
@@ -34,6 +34,9 @@ def Handshake_Dialect : Dialect {
   }];
 
   let useDefaultAttributePrinterParser = 1;
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
 }
 
 // Base class for Handshake dialect ops.

--- a/include/circt/Dialect/Ibis/IbisDialect.td
+++ b/include/circt/Dialect/Ibis/IbisDialect.td
@@ -23,6 +23,9 @@ def IbisDialect : Dialect {
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;
 
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let extraClassDeclaration = [{
     void registerTypes();
     void registerAttributes();

--- a/include/circt/Dialect/Interop/Interop.td
+++ b/include/circt/Dialect/Interop/Interop.td
@@ -32,6 +32,10 @@ def InteropDialect : Dialect {
     solutions.
   }];
   let cppNamespace = "::circt::interop";
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/LLHD/IR/LLHD.td
+++ b/include/circt/Dialect/LLHD/IR/LLHD.td
@@ -39,6 +39,9 @@ def LLHD_Dialect : Dialect {
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;
 
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let extraClassDeclaration = [{
     /// Register all LLHD types.
     void registerTypes();

--- a/include/circt/Dialect/LTL/LTLDialect.td
+++ b/include/circt/Dialect/LTL/LTLDialect.td
@@ -18,6 +18,9 @@ def LTLDialect : Dialect {
   let cppNamespace = "circt::ltl";
   let useDefaultTypePrinterParser = 1;
   let dependentDialects = ["hw::HWDialect", "comb::CombDialect"];
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
 }
 
 #endif // CIRCT_DIALECT_LTL_LTLDIALECT_TD

--- a/include/circt/Dialect/LoopSchedule/LoopSchedule.td
+++ b/include/circt/Dialect/LoopSchedule/LoopSchedule.td
@@ -16,6 +16,9 @@ def LoopSchedule_Dialect : Dialect {
   let name = "loopschedule";
   let cppNamespace = "::circt::loopschedule";
   let summary = "Representation of scheduled loops";
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
 }
 
 include "circt/Dialect/LoopSchedule/LoopScheduleOps.td"

--- a/include/circt/Dialect/MSFT/MSFT.td
+++ b/include/circt/Dialect/MSFT/MSFT.td
@@ -37,6 +37,9 @@ def MSFTDialect : Dialect {
   let hasConstantMaterializer = 1;
   let useDefaultAttributePrinterParser = 1;
 
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let extraClassDeclaration = [{
     /// Register all MSFT attributes.
     void registerAttributes();

--- a/include/circt/Dialect/Moore/MooreDialect.td
+++ b/include/circt/Dialect/Moore/MooreDialect.td
@@ -32,6 +32,9 @@ def MooreDialect : Dialect {
     void printType(Type, DialectAsmPrinter &) const override;
   }];
   let useDefaultTypePrinterParser = 0;
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
 }
 
 #endif // CIRCT_DIALECT_MOORE_MOOREDIALECT

--- a/include/circt/Dialect/OM/OMDialect.td
+++ b/include/circt/Dialect/OM/OMDialect.td
@@ -32,6 +32,9 @@ def OMDialect : Dialect {
   let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;
 
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let dependentDialects = [
     "circt::hw::HWDialect"
   ];

--- a/include/circt/Dialect/Pipeline/PipelineDialect.td
+++ b/include/circt/Dialect/Pipeline/PipelineDialect.td
@@ -14,6 +14,10 @@ include "mlir/IR/OpBase.td"
 def Pipeline_Dialect : Dialect {
   let name = "pipeline";
   let cppNamespace = "::circt::pipeline";
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
 }
 
 #endif // CIRCT_DIALECT_PIPELINE_DIALECT_TD

--- a/include/circt/Dialect/SSP/SSP.td
+++ b/include/circt/Dialect/SSP/SSP.td
@@ -31,6 +31,10 @@ def SSPDialect : Dialect {
   let cppNamespace = "::circt::ssp";
 
   let useDefaultAttributePrinterParser = true;
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let extraClassDeclaration = [{
     /// Register all SSP attributes.
     void registerAttributes();

--- a/include/circt/Dialect/SV/SVDialect.td
+++ b/include/circt/Dialect/SV/SVDialect.td
@@ -27,6 +27,9 @@ def SVDialect : Dialect {
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;
 
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let extraClassDeclaration = [{
     /// Register all SV types.
     void registerTypes();

--- a/include/circt/Dialect/Seq/SeqDialect.td
+++ b/include/circt/Dialect/Seq/SeqDialect.td
@@ -24,6 +24,10 @@ def SeqDialect : Dialect {
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
+
   let cppNamespace = "::circt::seq";
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/SystemC/SystemCDialect.td
+++ b/include/circt/Dialect/SystemC/SystemCDialect.td
@@ -35,6 +35,9 @@ def SystemCDialect : Dialect {
   }];
 
   let useDefaultTypePrinterParser = 0;
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
 }
 
 #endif // CIRCT_DIALECT_SYSTEMC_SYSTEMCDIALECT

--- a/include/circt/Dialect/Verif/VerifDialect.td
+++ b/include/circt/Dialect/Verif/VerifDialect.td
@@ -17,6 +17,9 @@ def VerifDialect : Dialect {
   // See `docs/Dialect/Verif.md` for detailed dialect documentation.
   let cppNamespace = "circt::verif";
   let hasConstantMaterializer = 1;
+
+  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
+  let usePropertiesForAttributes = 0;
 }
 
 #endif // CIRCT_DIALECT_VERIF_VERIFDIALECT_TD


### PR DESCRIPTION
Upstream switched the default, opt-out each dialect so we can update LLVM and start migrating dialects over individually.

cc #5273.