### PR TITLE
[HW] Fold extracts of constant structs

### DIFF
--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2606,7 +2606,15 @@ void StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
   build(builder, odsState, resultType, input, fieldAttr);
 }
 
-OpFoldResult StructExtractOp::fold(FoldAdaptor) {
+OpFoldResult StructExtractOp::fold(FoldAdaptor adaptor) {
+  if (auto constOperand = adaptor.getInput()) {
+    // Fold extract from aggregate constant
+    auto operandType = type_cast<StructType>(getOperand().getType());
+    auto fieldIdx = operandType.getFieldIndex(getField());
+    auto operandAttr = llvm::cast<ArrayAttr>(constOperand);
+    return operandAttr.getValue()[*fieldIdx];
+  }
+
   if (auto foldResult =
           foldStructExtract(getInput().getDefiningOp(), getField()))
     return foldResult;

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -141,7 +141,7 @@ func.func @convertConstStruct() {
   // CHECK-NEXT: [[V0:%.+]] = llvm.mlir.addressof @[[GLOB4]] : !llvm.ptr<struct<(i2, i32)>>
   // CHECK-NEXT: [[V1:%.+]] = llvm.load [[V0]] : !llvm.ptr<struct<(i2, i32)>>
   %0 = hw.aggregate_constant [0 : i32, 1 : i2] : !hw.struct<a: i32, b: i2>
-  // CHECK-NEXT: {{%.+}} = llvm.extractvalue [[V1]][1] : !llvm.struct<(i2, i32)>
+  // CHECK-NEXT: {{%.+}} = llvm.mlir.constant(0 : i32) : i32
   %1 = hw.struct_extract %0["a"] : !hw.struct<a: i32, b: i2>
   return
 }

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -1113,6 +1113,18 @@ hw.module @struct_extract1(%a0: i3, %a1: i5) -> (r0: i3) {
   hw.output %r0 : i3
 }
 
+// CHECK-LABEL: hw.module @struct_extract2() -> (r0: i3, r1: i7)
+// CHECK-NEXT:    %c3_i7 = hw.constant 3 : i7
+// CHECK-NEXT:    %c1_i3 = hw.constant 1 : i3
+// CHECK-NEXT:    hw.output %c1_i3, %c3_i7 : i3, i7
+hw.module @struct_extract2() -> (r0: i3, r1: i7) {
+  %s = hw.aggregate_constant [1 : i3, [3 : i7]] : !hw.struct<foo: i3, bar: !hw.struct<baz: i7>>
+  %r0 = hw.struct_extract %s["foo"] : !hw.struct<foo: i3, bar: !hw.struct<baz: i7>>
+  %nested =  hw.struct_extract %s["bar"] : !hw.struct<foo: i3, bar: !hw.struct<baz: i7>>
+  %r1 = hw.struct_extract %nested["baz"] : !hw.struct<baz: i7>
+  hw.output %r0, %r1 : i3, i7
+}
+
 // CHECK-LABEL: hw.module @struct_explode0(%a0: i3, %a1: i5) -> (r0: i2)
 // CHECK-NEXT:    %c0_i2 = hw.constant 0 : i2
 // CHECK-NEXT:    hw.output %c0_i2 : i2


### PR DESCRIPTION
Fold `hw.struct_extract` operations of `hw.aggregate_constant` to the constant value of their respective field.

This breaks a test in HWtoLLVM, which checks correct conversion of the `extract(constant)` pattern. Since dialect conversion inevitably performs a fold on the input operations before converting, the extract operation will always end up as  `hw.constant`. There does not appear to be a dedicated test for converting constants, so I opted to just keep it in and adapt the expected output.