### PR TITLE
[HW] Use properties to store inherent attributes in HW ops.

### DIFF
--- a/include/circt/Dialect/HW/HWDialect.td
+++ b/include/circt/Dialect/HW/HWDialect.td
@@ -28,8 +28,8 @@ def HWDialect : Dialect {
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
 
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
+  // This will be the default after next LLVM bump.
+  let usePropertiesForAttributes = 1;
 
   let extraClassDeclaration = [{
     /// Register all HW types.

--- a/include/circt/Dialect/HW/HWDialect.td
+++ b/include/circt/Dialect/HW/HWDialect.td
@@ -28,9 +28,6 @@ def HWDialect : Dialect {
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
 
-  // This will be the default after next LLVM bump.
-  let usePropertiesForAttributes = 1;
-
   let extraClassDeclaration = [{
     /// Register all HW types.
     void registerTypes();

--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -19,6 +19,7 @@
 #include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Support/BuilderUtils.h"
+#include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/OpImplementation.h"

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2778,7 +2778,8 @@ LogicalResult UnionExtractOp::inferReturnTypes(
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
   UnionExtractOpAdaptor op(operands, attrs,
                            properties.as<UnionExtractOp::Properties *>());
-  auto unionElements = hw::type_cast<UnionType>(op.getInput().getType()).getElements();
+  auto unionElements =
+      hw::type_cast<UnionType>(op.getInput().getType()).getElements();
   auto fieldIndex = op.getFieldIndex();
   if (fieldIndex >= unionElements.size()) {
     if (loc)

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2776,8 +2776,7 @@ LogicalResult UnionExtractOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::OpaqueProperties properties,
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
-  UnionExtractOpAdaptor op(operands, attrs,
-                           properties.as<UnionExtractOp::Properties *>());
+  UnionExtractOpAdaptor op(operands, attrs, properties, regions);
   auto unionElements =
       hw::type_cast<UnionType>(op.getInput().getType()).getElements();
   auto fieldIndex = op.getFieldIndex();

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2776,10 +2776,10 @@ LogicalResult UnionExtractOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::OpaqueProperties properties,
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
-  auto unionElements =
-      hw::type_cast<UnionType>((operands[0].getType())).getElements();
-  unsigned fieldIndex =
-      attrs.getAs<IntegerAttr>("fieldIndex").getValue().getZExtValue();
+  UnionExtractOpAdaptor op(operands, attrs,
+                           properties.as<UnionExtractOp::Properties *>());
+  auto unionElements = hw::type_cast<UnionType>(op.getInput().getType()).getElements();
+  auto fieldIndex = op.getFieldIndex();
   if (fieldIndex >= unionElements.size()) {
     if (loc)
       mlir::emitError(*loc, "field index " + Twine(fieldIndex) +


### PR DESCRIPTION
Fix `inferReturnTypes` impl to use adaptor to fix with properties.