### PR TITLE
[FIRRTL][Inliner] Support inlining modules with property ports.

### DIFF
--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1114,6 +1114,31 @@ firrtl.circuit "Top" {
   }
 }
 
+// -----
+
+// Test for U-Turn in property ports. The inlined module propassign's and uses the property.
+// CHECK-LABEL: firrtl.circuit "PropertyUTurn"
+firrtl.circuit "PropertyUTurn" {
+  firrtl.module @PropertyUTurn() {
+    %c_in, %c_out = firrtl.instance child @Child(in in: !firrtl.string, out out: !firrtl.string)
+    firrtl.propassign %c_in, %c_out : !firrtl.string
+    // CHECK:  %child_s_out = firrtl.instance child_s sym @Out @OutStr(out out: !firrtl.string)
+    // CHECK:  %child_c_in = firrtl.instance child_c sym @C @Consume(in in: !firrtl.string)
+    // CHECK:  firrtl.propassign %child_c_in, %child_s_out : !firrtl.string
+  }
+  firrtl.module @Child(in %in: !firrtl.string, out %out: !firrtl.string) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %s_out = firrtl.instance s sym @Out @OutStr(out out: !firrtl.string)
+    firrtl.propassign %out, %s_out : !firrtl.string
+
+    %c_in = firrtl.instance c sym @C @Consume(in in : !firrtl.string)
+    firrtl.propassign %c_in, %in : !firrtl.string
+  }
+  firrtl.module @OutStr(out %out : !firrtl.string) {
+    %str = firrtl.string "hello"
+    firrtl.propassign %out, %str : !firrtl.string
+  }
+  firrtl.extmodule @Consume(in in : !firrtl.string)
+}
 
 // -----
 


### PR DESCRIPTION
For now, take same approach as with probes re:inserting backedges and fixing up after, as there's no wire or equivalent to put these in on-the-fly.

Fixes #5941.