### PR TITLE
Enable default builders for pipeline.LatencyOp

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -356,11 +356,6 @@ def LatencyOp : Op<Pipeline_Dialect, "latency", [
   let regions = (region SizedRegion<1>:$body);
   let hasVerifier = 1;
 
-  let builders = [
-    OpBuilder<(ins "unsigned":$latency)>
-  ];
-  let skipDefaultBuilders = 1;
-
   let assemblyFormat = [{
     $latency `->` `(` type($results) `)` $body attr-dict
   }];


### PR DESCRIPTION
This fixes 2 problems with `pipeline.LatencyOp`:

1) `skipDefaultBuilders` is, but there was no corresponding C++ implementation of `LatencyOp::build`.
2) There is no way to specify the result type of a `pipeline.LatencyOp`

The fix is to enable the default builders to be generated.