### PR TITLE
[ESI][Cosim] Reducing MMIO data widths to 32 bit

### DIFF
--- a/include/circt/Dialect/ESI/cosim/CosimDpi.capnp
+++ b/include/circt/Dialect/ESI/cosim/CosimDpi.capnp
@@ -56,7 +56,7 @@ struct UntypedData @0xac6e64291027d47a {
 # cases, hardware errors become exceptions.
 interface EsiLowLevel @0xae716100ef82f6d6 {
   # Write to an MMIO register.
-  writeMMIO @0 (address :UInt64, data :UInt64) -> ();
+  writeMMIO @0 (address :UInt32, data :UInt32) -> ();
   # Read from an MMIO register.
-  readMMIO  @1 (address :UInt64) -> (data :UInt64);
+  readMMIO  @1 (address :UInt32) -> (data :UInt32);
 }

--- a/include/circt/Dialect/ESI/cosim/dpi.h
+++ b/include/circt/Dialect/ESI/cosim/dpi.h
@@ -51,12 +51,12 @@ DPI int sv2cCosimserverMMIORegister();
 
 /// Read MMIO function pair. Assumes that reads come back in the order in which
 /// they were requested.
-DPI int sv2cCosimserverMMIOReadTryGet(int *address);
-DPI void sv2cCosimserverMMIOReadRespond(long long data, char error);
+DPI int sv2cCosimserverMMIOReadTryGet(uint32_t *address);
+DPI void sv2cCosimserverMMIOReadRespond(uint32_t data, char error);
 
 /// Write MMIO function pair. Assumes that write errors come back in the order
 /// in which the writes were issued.
-DPI int sv2cCosimserverMMIOWriteTryGet(int *address, long long *data);
+DPI int sv2cCosimserverMMIOWriteTryGet(uint32_t *address, uint32_t *data);
 DPI void sv2cCosimserverMMIOWriteRespond(char error);
 
 #ifdef __cplusplus

--- a/integration_test/Dialect/ESI/cosim/lowlevel_cosim_only.sv
+++ b/integration_test/Dialect/ESI/cosim/lowlevel_cosim_only.sv
@@ -1,7 +1,7 @@
 // REQUIRES: esi-cosim
 // RUN: esi-cosim-runner.py --exec %s.py %s
 
-// Test the low level cosim MMIO functionality. This test has 1024 64-bit
+// Test the low level cosim MMIO functionality. This test has 1024 32-bit
 // registers as a memory. It is an error to write to register 0.
 
 import Cosim_DpiPkg::*;
@@ -19,7 +19,7 @@ module top(
   // MMIO read: data response channel.
   reg          rvalid;
   logic        rready;
-  reg   [63:0] rdata;
+  reg   [31:0] rdata;
   reg   [1:0]  rresp;
 
   // MMIO write: address channel.
@@ -30,7 +30,7 @@ module top(
   // MMIO write: data channel.
   logic        wvalid;
   reg          wready;
-  logic [63:0] wdata;
+  logic [31:0] wdata;
 
   // MMIO write: write response channel.
   reg          bvalid;
@@ -58,7 +58,7 @@ module top(
     .bresp(bresp)
   );
 
-  reg [63:0] regs [1023:0];
+  reg [31:0] regs [1023:0];
 
   assign arready = 1;
   assign rdata = regs[araddr >> 3];

--- a/lib/Dialect/ESI/cosim/Cosim_DpiPkg.sv
+++ b/lib/Dialect/ESI/cosim/Cosim_DpiPkg.sv
@@ -84,24 +84,24 @@ import "DPI-C" sv2cCosimserverMMIORegister =
 /// they were requested.
 import "DPI-C" sv2cCosimserverMMIOReadTryGet =
   function int cosim_mmio_read_tryget(
-    output int address
+    output int unsigned address
   );
 import "DPI-C" sv2cCosimserverMMIOReadRespond =
   function void cosim_mmio_read_respond(
-    input longint data,
-    input byte    error
+    input int unsigned data,
+    input byte         error
   );
 
 /// Write MMIO function pair. Assumes that write errors come back in the order
 /// in which the writes were issued.
 import "DPI-C" sv2cCosimserverMMIOWriteTryGet =
   function int cosim_mmio_write_tryget(
-    output int     address,
-    output longint data
+    output int unsigned address,
+    output int unsigned data
   );
 import "DPI-C" sv2cCosimserverMMIOWriteRespond =
   function void cosim_mmio_write_respond(
-    input byte    error
+    input byte  error
   );
 
 endpackage // Cosim_DpiPkg

--- a/lib/Dialect/ESI/cosim/Cosim_MMIO.sv
+++ b/lib/Dialect/ESI/cosim/Cosim_MMIO.sv
@@ -27,7 +27,7 @@ module Cosim_MMIO
   // MMIO read: data response channel.
   input  logic        rvalid,
   output reg          rready,
-  input  logic [63:0] rdata,
+  input  logic [31:0] rdata,
   input  logic [1:0]  rresp,
 
   // MMIO write: address channel.
@@ -38,7 +38,7 @@ module Cosim_MMIO
   // MMIO write: data channel.
   output reg          wvalid,
   input  logic        wready,
-  output reg   [63:0] wdata,
+  output reg   [31:0] wdata,
 
   // MMIO write: write response channel.
   input  logic        bvalid,

--- a/lib/Dialect/ESI/cosim/cosim_dpi_server/DpiEntryPoints.cpp
+++ b/lib/Dialect/ESI/cosim/cosim_dpi_server/DpiEntryPoints.cpp
@@ -269,7 +269,7 @@ DPI int sv2cCosimserverMMIORegister() {
   return 0;
 }
 
-DPI int sv2cCosimserverMMIOReadTryGet(int *address) {
+DPI int sv2cCosimserverMMIOReadTryGet(uint32_t *address) {
   assert(server);
   std::optional<int> reqAddress = server->lowLevelBridge.readReqs.pop();
   if (!reqAddress.has_value())
@@ -278,7 +278,7 @@ DPI int sv2cCosimserverMMIOReadTryGet(int *address) {
   return 0;
 }
 
-DPI void sv2cCosimserverMMIOReadRespond(long long data, char error) {
+DPI void sv2cCosimserverMMIOReadRespond(uint32_t data, char error) {
   assert(server);
   server->lowLevelBridge.readResps.push(data, error);
 }
@@ -288,7 +288,7 @@ DPI void sv2cCosimserverMMIOWriteRespond(char error) {
   server->lowLevelBridge.writeResps.push(error);
 }
 
-DPI int sv2cCosimserverMMIOWriteTryGet(int *address, long long *data) {
+DPI int sv2cCosimserverMMIOWriteTryGet(uint32_t *address, uint32_t *data) {
   assert(server);
   auto req = server->lowLevelBridge.writeReqs.pop();
   if (!req.has_value())


### PR DESCRIPTION
Some platforms only support 32 bit MMIO, so in accordance with the least common denominator rule...