### PR TITLE
[FIRRTL] Bump latest to 3.2.0 for use in emitter / round-trip.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -107,7 +107,7 @@ struct FIRVersion {
 };
 
 constexpr FIRVersion minimumFIRVersion(0, 2, 0);
-constexpr FIRVersion latestFIRVersion(3, 1, 0);
+constexpr FIRVersion latestFIRVersion(3, 2, 0);
 constexpr FIRVersion defaultFIRVersion(1, 0, 0);
 
 template <typename T>

--- a/test/CAPI/firrtl.c
+++ b/test/CAPI/firrtl.c
@@ -42,7 +42,7 @@ void testExport(MlirContext ctx) {
   MlirLogicalResult result = mlirExportFIRRTL(module, exportCallback, NULL);
   assert(mlirLogicalResultIsSuccess(result));
 
-  // CHECK: FIRRTL version 3.1.0
+  // CHECK: FIRRTL version 3.2.0
   // CHECK-NEXT: circuit ExportTestSimpleModule :
   // CHECK-NEXT:   module ExportTestSimpleModule : @[- 2:3]
   // CHECK-NEXT:     input in_1 : UInt<32> @[- 2:44]

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -12,7 +12,7 @@
 // Check if printing with very short line length, removing info locators (@[...]), no line is longer than 5x line length.
 // RUN: circt-translate --export-firrtl %s --target-line-length=10 | sed -e 's/ @\[.*\]//' | FileCheck %s --implicit-check-not "{{^(.{50})}}" --check-prefix PRETTY
 
-// CHECK-LABEL: FIRRTL version 3.1.0
+// CHECK-LABEL: FIRRTL version 3.2.0
 // CHECK-LABEL: circuit Foo :
 // PRETTY-LABEL: circuit Foo :
 firrtl.circuit "Foo" {


### PR DESCRIPTION
Give cover for emitter support for not-yet-released features, for testing purposes.

cc https://github.com/chipsalliance/chisel/pull/3517 .

Broken off from #5959 .