### PR TITLE
[FIRRTL] Parse and lower Open Aggregates Wires

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3940,9 +3940,6 @@ ParseResult FIRStmtParser::parseWire() {
       parseType(type, "expected wire type") || parseOptionalInfo())
     return failure();
 
-  if (!type_isa<FIRRTLBaseType>(type))
-    return emitError(startTok.getLoc(), "wire must have base type");
-
   locationProcessor.setLoc(startTok.getLoc());
 
   auto annotations = getConstants().emptyArrayAttr;

--- a/test/Dialect/FIRRTL/lower-open-aggs-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs-errors.mlir
@@ -46,16 +46,12 @@ firrtl.circuit "MixedAnnotation" {
 }
 
 // -----
-// Reject unhandled ops w/open types in them.
+// As above, check that no annotations are seen.  This should never occur in
+// firtool.
 
-firrtl.circuit "UnhandledOp" {
-  firrtl.module @UnhandledOp(out %r : !firrtl.openbundle<p: probe<uint<1>>>) {
-    %zero = firrtl.constant 0 : !firrtl.uint<1>
-    %ref = firrtl.ref.send %zero : !firrtl.uint<1>
-    %r_p = firrtl.opensubfield %r[p] : !firrtl.openbundle<p: probe<uint<1>>>
-    firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>
-
-    // expected-error @below {{unhandled use or producer of types containing non-hw types}}
-    %x = firrtl.wire : !firrtl.openbundle<p : probe<uint<1>>>
+firrtl.circuit "WireAnnotations" {
+  firrtl.module @WireAnnotations() {
+    // expected-error @below {{annotations on open aggregates not handled yet}}
+    %a = firrtl.wire {annotations = [{class = "circt.test"}]} : !firrtl.openbundle<b: string, c: uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/lower-open-aggs.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs.mlir
@@ -233,3 +233,79 @@ firrtl.circuit "BundleOfProps" {
     firrtl.strictconnect %y_a, %x_b : !firrtl.uint<5>
   }
 }
+
+
+// -----
+
+// CHECK-LABEL: circuit "WireProperties"
+firrtl.circuit "WireProperties" {
+  // CHECK-LABEL: module{{.*}} @WireProperties
+  firrtl.module @WireProperties() {
+    %0 = firrtl.string "hello world"
+
+    // CHECK:      %b_c = firrtl.wire : !firrtl.string
+    // CHECK-NEXT: firrtl.propassign %b_c, %0
+    %b = firrtl.wire : !firrtl.openbundle<c: string>
+    %b_c = firrtl.opensubfield %b[c] : !firrtl.openbundle<c: string>
+    firrtl.propassign %b_c, %0 : !firrtl.string
+
+    // CHECK-NEXT: %d_0 = firrtl.wire : !firrtl.string
+    // CHECK-NEXT: firrtl.propassign %d_0, %b_c
+    %d = firrtl.wire : !firrtl.openvector<string, 1>
+    %d_0 = firrtl.opensubindex %d[0] : !firrtl.openvector<string, 1>
+    firrtl.propassign %d_0, %b_c : !firrtl.string
+  }
+}
+
+// -----
+
+// CHECK-LABEL: circuit "WirePropertyFlip"
+firrtl.circuit "WirePropertyFlip" {
+  // CHECK-LABEL: module{{.*}} @WirePropertyFlip
+  firrtl.module @WirePropertyFlip(out %a: !firrtl.integer) {
+    %0 = firrtl.integer 1
+
+    // CHECK:      %b_c = firrtl.wire : !firrtl.integer
+    // CHECK-NEXT: firrtl.propassign %b_c, %0
+    // CHECK-NEXT: firrtl.propassign %a, %b_c
+    %b = firrtl.wire : !firrtl.openbundle<c flip: integer>
+    %b_c = firrtl.opensubfield %b[c] : !firrtl.openbundle<c flip: integer>
+    firrtl.propassign %b_c, %0 : !firrtl.integer
+    firrtl.propassign %a, %b_c : !firrtl.integer
+  }
+}
+
+// -----
+
+// CHECK-LABEL: circuit "WireProbes"
+firrtl.circuit "WireProbes" {
+  // CHECK-LABEL: module{{.*}} @WireProbes
+  firrtl.module @WireProbes() {
+    // CHECK:      %b_c = firrtl.wire : !firrtl.probe<uint<1>>
+    // CHECK-NEXT: %b_d = firrtl.wire : !firrtl.rwprobe<uint<2>>
+    %b = firrtl.wire : !firrtl.openbundle<c: probe<uint<1>>, d: rwprobe<uint<2>>>
+    %b_c = firrtl.opensubfield %b[c] : !firrtl.openbundle<c: probe<uint<1>>, d: rwprobe<uint<2>>>
+    %b_d = firrtl.opensubfield %b[d] : !firrtl.openbundle<c: probe<uint<1>>, d: rwprobe<uint<2>>>
+
+    %x = firrtl.wire : !firrtl.uint<1>
+    %0 = firrtl.ref.send %x : !firrtl.uint<1>
+    // CHECK:      firrtl.ref.define %b_c, %0 : !firrtl.probe<uint<1>>
+    firrtl.ref.define %b_c, %0 : !firrtl.probe<uint<1>>
+
+    %y, %y_ref = firrtl.wire forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
+    // CHECK:      firrtl.ref.define %b_d, %y_ref : !firrtl.rwprobe<uint<2>>
+    firrtl.ref.define %b_d, %y_ref : !firrtl.rwprobe<uint<2>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: circuit "WireSymbols"
+firrtl.circuit "WireSymbols" {
+  // CHECK-LABEL: module{{.*}} @WireSymbols
+  firrtl.module @WireSymbols() {
+    // CHECk-NEXT: %a = firrtl.wire sym [<@sym_a_c, 1, public>] : !firrtl.bundle<c: uint<1>>
+    // CHECk-NEXT: %a_b = firrtl.wire : !firrtl.string
+    %a = firrtl.wire sym [<@sym_a_c, 2, public>] : !firrtl.openbundle<b: string, c: uint<1>>
+  }
+}

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1830,7 +1830,8 @@ FIRRTL version 3.1.0
 circuit BundleOfProps:
   module BundleOfProps:
     input x : {a : String}
-    ; CHECK: openbundle<a: string>
+    wire y : {a: String}
+    ; CHECK-COUNT-2: !firrtl.openbundle<a: string>
 
 ;// -----
 FIRRTL version 3.1.0
@@ -1839,5 +1840,5 @@ FIRRTL version 3.1.0
 circuit VecOfProps:
   module VecOfProps:
     input x : String[2]
-    ; CHECK: openvector<string, 2>
-
+    wire y : String[2]
+    ; CHECK-COUNT-2: openvector<string, 2>

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -669,12 +669,6 @@ circuit IllegalLiteral:
 
 ;// -----
 
-circuit WireProbe:
-  module WireProbe:
-    wire x : Probe<UInt<1>> ; expected-error {{wire must have base type}}
-
-;// -----
-
 circuit NodeProbe:
   extmodule Ref:
     output x : Probe<UInt<1>>


### PR DESCRIPTION
Add support for parsing and lowering open aggregate wires. This currently works in a `firtool` pipeline so long as you run IMCP. I'm thinking about how to make it such that this optimization is not required for correctness (in `LowerClasses`). Currently `LowerClasses` will error out if the wires aren't removed.

There is fortunately already checking from `firrtl.propassign` that there are not multiple drivers.

Full example:

```
FIRRTL version 4.0.0
circuit Foo :
  module Foo :
    output a : { b : Integer, c: UInt<1>}[1]

    wire d : { e : Integer, f: UInt<1> }[1]
    invalidate d[0].f

    propassign d[0].e, Integer(1)
    propassign a[0].b, d[0].e

    connect d[0].f, UInt<1>(0)
    connect a[0].c, d[0].f
```

Produces with this patch (`firtool -ir-hw`):

```mlir
module {
  hw.module @Foo() -> (a_0_c: i1) {
    %false = hw.constant false
    hw.output %false : i1
  }
  om.class @Foo_Class() {
    %0 = om.constant 1 : si4
    om.class.field @a_0_b, %0 : si4
  }
}
```