### PR TITLE
[SV] Fix --hw-eliminate-inout-ports

### DIFF
--- a/include/circt/Dialect/HW/PortConverter.h
+++ b/include/circt/Dialect/HW/PortConverter.h
@@ -55,14 +55,7 @@ public:
                        Value output, hw::PortInfo &newPort);
 
 protected:
-  PortConverterImpl(igraph::InstanceGraphNode *moduleNode)
-      : moduleNode(moduleNode), b(moduleNode->getModule()->getContext()) {
-    mod = dyn_cast<hw::HWMutableModuleLike>(*moduleNode->getModule());
-    assert(mod && "PortConverter only works on HWMutableModuleLike");
-
-    if (mod->getNumRegions() == 1 && mod->getRegion(0).hasOneBlock())
-      body = &mod->getRegion(0).front();
-  }
+  PortConverterImpl(igraph::InstanceGraphNode *moduleNode);
 
   std::unique_ptr<PortConversionBuilder> ssb;
 
@@ -92,11 +85,10 @@ private:
   SmallVector<std::pair<unsigned, hw::PortInfo>, 0> newInputs;
   SmallVector<std::pair<unsigned, hw::PortInfo>, 0> newOutputs;
 
-  // Maintain the set of new output values as temporary operations. We do this,
-  // as opposed to keeping the Value's in an array, to ensure that any value
-  // replacements performed by other port conversion patterns will get properly
-  // reflected in the set of new output values.
-  SmallVector<Operation *> newOutputValues;
+  // Maintain a handle to the terminator of the body, if any. This will get
+  // continuously updated during port conversion whenever a new output is added
+  // to the module.
+  Operation *terminator = nullptr;
 };
 
 /// Base class for the port conversion of a particular port. Abstracts the

--- a/lib/Dialect/HW/PortConverter.cpp
+++ b/lib/Dialect/HW/PortConverter.cpp
@@ -179,7 +179,7 @@ LogicalResult PortConverterImpl::run() {
     llvm::transform(newOutputValues, std::back_inserter(outputOperands),
                     [](Operation *op) { return op->getOperand(0); });
     body->getTerminator()->setOperands(outputOperands);
-    for (auto op : llvm::make_early_inc_range(newOutputValues))
+    for (auto *op : llvm::make_early_inc_range(newOutputValues))
       op->erase();
   }
 

--- a/test/Dialect/SV/EliminateInOutPorts/hw-eliminate-inout-ports.mlir
+++ b/test/Dialect/SV/EliminateInOutPorts/hw-eliminate-inout-ports.mlir
@@ -69,3 +69,13 @@ hw.module @passthroughTwoLevels() {
   hw.instance "passthrough" @passthrough(a : %0 : !hw.inout<i42>) -> ()
 }
 
+// CHECK-LABEL:   hw.module @writeInput(
+// CHECK-SAME:                          %[[VAL_0:.*]]: i42) -> (a_wr: i42) {
+// CHECK:           hw.output %[[VAL_0]] : i42
+// CHECK:         }
+
+// Tests a bug where the inout was being eliminated which resulted in the
+// block argument list shifting, but the index of %in not being updated.
+hw.module @writeInput(%a: !hw.inout<i42>, %in : i42) {
+  sv.assign %a, %in : i42
+}


### PR DESCRIPTION
Fixes a bug where an inout input was being eliminated which resulted in the block argument list shifting, but input->output replacements were not being updated correctly.

Fixed by keeping to-be-output values as temporary operations instead of an in-memory array of values. By doing so, any value replacements performed by other patterns will also affect the temporary output operations. ... that pattern should maybe be factored out and given a name - seems like a generic thing where we want to store a value for later use, but that value may be replaced at any point in time.