### PR TITLE
[FIRRTL] Implement InstanceGraphInstanceOpInterface for ObjectOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -594,6 +594,13 @@ def ClockGateIntrinsicOp : FIRRTLOp<"int.clock_gate", [Pure]> {
 def ObjectOp :  FIRRTLOp<"object", [
     ParentOneOf<["firrtl::FModuleOp, firrtl::ClassOp"]>,
     DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+    DeclareOpInterfaceMethods<InstanceGraphInstanceOpInterface, [
+      "getReferencedModuleName",
+      "getReferencedModuleNameAttr"
+    ]>,
+    DeclareOpInterfaceMethods<OpAsmOpInterface, [
+      "getAsmResultNames"
+    ]>
 ]> {
   let summary = "Instantiate a class to produce an object";
   let description = [{
@@ -605,22 +612,22 @@ def ObjectOp :  FIRRTLOp<"object", [
     %0 = firrtl.object @Foo(in io: !firrtl.uint)
     ```
   }];
-  let arguments = (ins
-    // The className is so that SymbolUserOpInterface can find the referenced 
-    // symbol.
-    FlatSymbolRefAttr:$className
-  );
-  let results = (outs ClassType:$results);
-  let hasCustomAssemblyFormat = 1;
+  let arguments = (ins StrAttr:$name);
+  let results = (outs ClassType:$result);
   let hasVerifier = 1;
   let builders = [
-    OpBuilder<(ins "ClassType":$type)>,
-    OpBuilder<(ins "ClassLike":$klass)>
+    OpBuilder<(ins "ClassLike":$klass, "StringRef":$name)>
   ];
   let extraClassDeclaration = [{
     /// Lookup the module or extmodule for the symbol.  This returns null on
     /// invalid IR.
     ClassLike getReferencedClass(SymbolTable& symbolTable);
+
+    StringAttr getClassNameAttr();
+    StringRef getClassName();
+  }];
+  let assemblyFormat = [{
+    `` custom<ImplicitSSAName>(attr-dict) custom<ClassInterface>(type($result))
   }];
 }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3660,7 +3660,7 @@ ParseResult FIRStmtParser::parseObject() {
   if (!referencedClass)
     return emitError(startTok.getLoc(), "use of undefined class name '" +
                                             className + "' in object");
-  auto result = builder.create<ObjectOp>(referencedClass);
+  auto result = builder.create<ObjectOp>(referencedClass, id);
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -448,14 +448,14 @@ void LowerClassesPass::updateInstances(Operation *op) {
               actualParameters.push_back(propassign.getSrc());
 
     // Convert the FIRRTL Class type to an OM Class type.
-    auto classType =
-        om::ClassType::get(op->getContext(), firrtlObject.getClassNameAttr());
+    auto className = firrtlObject.getType().getNameAttr();
+    auto classType = om::ClassType::get(op->getContext(), className);
 
     // Create the new Object op.
     builder.setInsertionPoint(firrtlObject);
-    auto object = builder.create<om::ObjectOp>(
-        firrtlObject.getLoc(), classType,
-        firrtlObject.getClassNameAttr().getAttr(), actualParameters);
+    auto object =
+        builder.create<om::ObjectOp>(firrtlObject.getLoc(), classType,
+                                     className.getAttr(), actualParameters);
 
     // Replace uses of the FIRRTL Object with the OM Object. The later dialect
     // conversion will take care of converting the types.

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1734,9 +1734,9 @@ circuit BasicProps :
   ; CHECK-LABEL: firrtl.class private @Client(out %a: !firrtl.class<@SimpleClass(in a: !firrtl.string, out b: !firrtl.string)>)
   class Client:
     output a: Inst<SimpleClass>
-    ; CHECK-NEXT:  %0 = firrtl.object @SimpleClass(in a: !firrtl.string, out b: !firrtl.string)
+    ; CHECK-NEXT:  %b = firrtl.object @SimpleClass(in a: !firrtl.string, out b: !firrtl.string)
     object b of SimpleClass
-    ; CHECK-NEXT: firrtl.propassign %a, %0 : !firrtl.class<@SimpleClass(in a: !firrtl.string, out b: !firrtl.string)>
+    ; CHECK-NEXT: firrtl.propassign %a, %b : !firrtl.class<@SimpleClass(in a: !firrtl.string, out b: !firrtl.string)>
     propassign a, b
 
   ; CHECK-LABEL firrtl.class private @OtherClient(in %a: !firrtl.string, out %b: !firrtl.string)


### PR DESCRIPTION
- Implement InstanceGraphInstanceOpInterface for object op
- Needed so that objects and classes will be tracked in the instance-graph
- InstanceOpInterface requires that we start tracking a name for each object
- In the IR printed format, the object's name is inferred from the name of it's result
- Switch to a custom asm format string
  -  use the ImplicitSSAName custom directive to print/parse the attributes
  - add a custom directive for printing a class's interface
- Drop the className attribute from the op
  - we don't need it because classes don't let themselves be erased by symbol-dce anymore.
  - this lets us use ImplicitSSAName without always printing an attribute dict.