### PR TITLE
[OM] Python bindings for om integer

### DIFF
--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -185,6 +185,19 @@ MLIR_CAPI_EXPORTED bool omAttrIsAReferenceAttr(MlirAttribute attr);
 MLIR_CAPI_EXPORTED MlirAttribute omReferenceAttrGetInnerRef(MlirAttribute attr);
 
 //===----------------------------------------------------------------------===//
+// IntegerAttr API
+//===----------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED bool omAttrIsAIntegerAttr(MlirAttribute attr);
+
+/// Given an om::IntegerAttr, return the mlir::IntegerAttr.
+MLIR_CAPI_EXPORTED MlirAttribute omIntegerAttrGetInt(MlirAttribute attr);
+
+/// If `attr` is an mlir::IntegerAttr, create and return the om::IntegerAttr,
+/// else return `attr` as is.
+MLIR_CAPI_EXPORTED MlirAttribute omCastIntAttrIfValid(MlirAttribute attr);
+
+//===----------------------------------------------------------------------===//
 // ListAttr API
 //===----------------------------------------------------------------------===//
 

--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -193,9 +193,8 @@ MLIR_CAPI_EXPORTED bool omAttrIsAIntegerAttr(MlirAttribute attr);
 /// Given an om::IntegerAttr, return the mlir::IntegerAttr.
 MLIR_CAPI_EXPORTED MlirAttribute omIntegerAttrGetInt(MlirAttribute attr);
 
-/// If `attr` is an mlir::IntegerAttr, create and return the om::IntegerAttr,
-/// else return `attr` as is.
-MLIR_CAPI_EXPORTED MlirAttribute omCastIntAttrIfValid(MlirAttribute attr);
+/// Get an om::IntegerAttr from mlir::IntegerAttr.
+MLIR_CAPI_EXPORTED MlirAttribute omIntegerAttrGet(MlirAttribute attr);
 
 //===----------------------------------------------------------------------===//
 // ListAttr API

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -36,16 +36,16 @@ with Context() as ctx, Location.unknown():
       %2 = om.object @Nest(%list_child) : (!om.list<!om.class.type<@Child>>) -> !om.class.type<@Nest>
       om.class.field @nest, %2 : !om.class.type<@Nest>
 
-      %3 = om.constant #om.map<i64, {a = 42, b = 32}> : !om.map<!om.string, i64>
-      om.class.field @map, %3 : !om.map<!om.string, i64>
+      %3 = om.constant #om.map<!om.integer, {a = #om.integer<42>, b = #om.integer<32>}> : !om.map<!om.string, !om.integer>
+      om.class.field @map, %3 : !om.map<!om.string, !om.integer>
 
       %x = om.constant "X" : !om.string
       %y = om.constant "Y" : !om.string
-      %entry1 = om.tuple_create %x, %c_14: !om.string, i64
-      %entry2 = om.tuple_create %y, %c_15: !om.string, i64
+      %entry1 = om.tuple_create %x, %c_14: !om.string, !om.integer
+      %entry2 = om.tuple_create %y, %c_15: !om.string, !om.integer
 
-      %map = om.map_create %entry1, %entry2: !om.string, i64
-      om.class.field @map_create, %map : !om.map<!om.string, i64>
+      %map = om.map_create %entry1, %entry2: !om.string, !om.integer
+      om.class.field @map_create, %map : !om.map<!om.string, !om.integer>
     }
 
     om.class @Child(%0: !om.integer) {

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -15,11 +15,11 @@ with Context() as ctx, Location.unknown():
   module {
     %sym = om.constant #om.ref<<@Root::@x>> : !om.ref
 
-    om.class @Test(%param: i64) {
-      om.class.field @field, %param : i64
+    om.class @Test(%param: !om.integer) {
+      om.class.field @field, %param : !om.integer
 
-      %c_14 = om.constant 14 : i64
-      %0 = om.object @Child(%c_14) : (i64) -> !om.class.type<@Child>
+      %c_14 = om.constant #om.integer<14> : !om.integer
+      %0 = om.object @Child(%c_14) : (!om.integer) -> !om.class.type<@Child>
       om.class.field @child, %0 : !om.class.type<@Child>
 
       om.class.field @reference, %sym : !om.ref
@@ -27,11 +27,11 @@ with Context() as ctx, Location.unknown():
       %list = om.constant #om.list<!om.string, ["X" : !om.string, "Y" : !om.string]> : !om.list<!om.string>
       om.class.field @list, %list : !om.list<!om.string>
 
-      %tuple = om.tuple_create %list, %c_14: !om.list<!om.string>, i64
-      om.class.field @tuple, %tuple : tuple<!om.list<!om.string>, i64>
+      %tuple = om.tuple_create %list, %c_14: !om.list<!om.string>, !om.integer
+      om.class.field @tuple, %tuple : tuple<!om.list<!om.string>, !om.integer>
 
-      %c_15 = om.constant 15 : i64
-      %1 = om.object @Child(%c_15) : (i64) -> !om.class.type<@Child>
+      %c_15 = om.constant #om.integer<15> : !om.integer
+      %1 = om.object @Child(%c_15) : (!om.integer) -> !om.class.type<@Child>
       %list_child = om.list_create %0, %1: !om.class.type<@Child>
       %2 = om.object @Nest(%list_child) : (!om.list<!om.class.type<@Child>>) -> !om.class.type<@Nest>
       om.class.field @nest, %2 : !om.class.type<@Nest>
@@ -48,8 +48,8 @@ with Context() as ctx, Location.unknown():
       om.class.field @map_create, %map : !om.map<!om.string, i64>
     }
 
-    om.class @Child(%0: i64) {
-      om.class.field @foo, %0 : i64
+    om.class @Child(%0: !om.integer) {
+      om.class.field @foo, %0 : !om.integer
     }
 
     om.class @Nest(%0: !om.list<!om.class.type<@Child>>) {

--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -26,6 +26,7 @@ struct List;
 struct Object;
 struct Tuple;
 struct Map;
+
 using PythonValue = std::variant<MlirAttribute, Object, List, Tuple, Map>;
 
 /// Map an opaque OMEvaluatorValue into a python value.
@@ -373,7 +374,7 @@ void circt::python::populateDialectOMSubmodule(py::module &m) {
   mlir_attribute_subclass(m, "OMIntegerAttr", omAttrIsAIntegerAttr)
       .def_classmethod("get",
                        [](py::object cls, MlirAttribute intVal) {
-                         return cls(omCastIntAttrIfValid(intVal));
+                         return cls(omIntegerAttrGet(intVal));
                        })
       .def_property_readonly("integer", [](MlirAttribute self) {
         return omIntegerAttrGetInt(self);

--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -308,7 +308,7 @@ PythonValue omEvaluatorValueToPythonValue(OMEvaluatorValue result) {
 
 OMEvaluatorValue pythonValueToOMEvaluatorValue(PythonValue result) {
   if (auto *attr = std::get_if<MlirAttribute>(&result))
-    return omEvaluatorValueFromPrimitive(*attr);
+    return omEvaluatorValueFromPrimitive(omCastIntAttrIfValid(*attr));
 
   if (auto *list = std::get_if<List>(&result))
     return list->getValue();
@@ -368,6 +368,12 @@ void circt::python::populateDialectOMSubmodule(py::module &m) {
   mlir_attribute_subclass(m, "ReferenceAttr", omAttrIsAReferenceAttr)
       .def_property_readonly("inner_ref", [](MlirAttribute self) {
         return omReferenceAttrGetInnerRef(self);
+      });
+
+  // Add the IntegerAttr definition
+  mlir_attribute_subclass(m, "OMIntegerAttr", omAttrIsAIntegerAttr)
+      .def_property_readonly("integer", [](MlirAttribute self) {
+        return omIntegerAttrGetInt(self);
       });
 
   // Add the OMListAttr definition

--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -26,7 +26,6 @@ struct List;
 struct Object;
 struct Tuple;
 struct Map;
-
 using PythonValue = std::variant<MlirAttribute, Object, List, Tuple, Map>;
 
 /// Map an opaque OMEvaluatorValue into a python value.
@@ -308,7 +307,7 @@ PythonValue omEvaluatorValueToPythonValue(OMEvaluatorValue result) {
 
 OMEvaluatorValue pythonValueToOMEvaluatorValue(PythonValue result) {
   if (auto *attr = std::get_if<MlirAttribute>(&result))
-    return omEvaluatorValueFromPrimitive(omCastIntAttrIfValid(*attr));
+    return omEvaluatorValueFromPrimitive(*attr);
 
   if (auto *list = std::get_if<List>(&result))
     return list->getValue();
@@ -372,6 +371,10 @@ void circt::python::populateDialectOMSubmodule(py::module &m) {
 
   // Add the IntegerAttr definition
   mlir_attribute_subclass(m, "OMIntegerAttr", omAttrIsAIntegerAttr)
+      .def_classmethod("get",
+                       [](py::object cls, MlirAttribute intVal) {
+                         return cls(omCastIntAttrIfValid(intVal));
+                       })
       .def_property_readonly("integer", [](MlirAttribute self) {
         return omIntegerAttrGetInt(self);
       });

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from ._om_ops_gen import *
-from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, Tuple as BaseTuple, Map as BaseMap, ClassType, ReferenceAttr, ListAttr, MapAttr
+from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, Tuple as BaseTuple, Map as BaseMap, ClassType, ReferenceAttr, ListAttr, MapAttr, OMIntegerAttr
 
 from ..ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr
 from ..support import attribute_to_var, var_to_attribute

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from ._om_ops_gen import *
 from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, Tuple as BaseTuple, Map as BaseMap, ClassType, ReferenceAttr, ListAttr, MapAttr, OMIntegerAttr
 
-from ..ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr
+from ..ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr, IntegerAttr, IntegerType
 from ..support import attribute_to_var, var_to_attribute
 
 import sys
@@ -38,11 +38,16 @@ def wrap_mlir_object(value):
   assert isinstance(value, BaseObject)
   return Object(value)
 
+def om_var_to_attribute(obj, none_on_fail: bool = False) -> ir.Attrbute:
+  if isinstance(obj, int):
+    return OMIntegerAttr.get(IntegerAttr.get(IntegerType.get_signless(64), obj))
+  return var_to_attribute(obj, none_on_fail)
+
 
 def unwrap_python_object(value):
   # Check if the value is a Primitive.
   try:
-    return var_to_attribute(value)
+    return om_var_to_attribute(value)
   except:
     pass
 

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -38,6 +38,7 @@ def wrap_mlir_object(value):
   assert isinstance(value, BaseObject)
   return Object(value)
 
+
 def om_var_to_attribute(obj, none_on_fail: bool = False) -> ir.Attrbute:
   if isinstance(obj, int):
     return OMIntegerAttr.get(IntegerAttr.get(IntegerType.get_signless(64), obj))

--- a/lib/Bindings/Python/support.py
+++ b/lib/Bindings/Python/support.py
@@ -186,6 +186,10 @@ def attribute_to_var(attr):
     return {name: attribute_to_var(value) for name, value in om.MapAttr(attr)}
   except ValueError:
     pass
+  try:
+    return attribute_to_var(om.OMIntegerAttr(attr).integer)
+  except ValueError:
+    pass
 
   raise TypeError(f"Cannot convert {repr(attr)} to python value")
 

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/OM/OMDialect.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Wrap.h"
+#include "llvm/Support/Casting.h"
 
 using namespace mlir;
 using namespace circt::om;
@@ -285,6 +286,26 @@ bool omAttrIsAReferenceAttr(MlirAttribute attr) {
 MlirAttribute omReferenceAttrGetInnerRef(MlirAttribute referenceAttr) {
   return wrap(
       (Attribute)unwrap(referenceAttr).cast<ReferenceAttr>().getInnerRef());
+}
+
+//===----------------------------------------------------------------------===//
+// IntegerAttr API.
+//===----------------------------------------------------------------------===//
+
+bool omAttrIsAIntegerAttr(MlirAttribute attr) {
+  return unwrap(attr).isa<circt::om::IntegerAttr>();
+}
+
+MlirAttribute omIntegerAttrGetInt(MlirAttribute attr) {
+  return wrap(
+      (Attribute)unwrap(attr).cast<circt::om::IntegerAttr>().getValue());
+}
+
+MlirAttribute omCastIntAttrIfValid(MlirAttribute attr) {
+  if (auto integerAttr = llvm::dyn_cast<mlir::IntegerAttr>(unwrap(attr)))
+    return wrap(
+        circt::om::IntegerAttr::get(integerAttr.getContext(), integerAttr));
+  return attr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -297,15 +297,13 @@ bool omAttrIsAIntegerAttr(MlirAttribute attr) {
 }
 
 MlirAttribute omIntegerAttrGetInt(MlirAttribute attr) {
-  return wrap(
-      (Attribute)unwrap(attr).cast<circt::om::IntegerAttr>().getValue());
+  return wrap(cast<circt::om::IntegerAttr>(unwrap(attr)).getValue());
 }
 
-MlirAttribute omCastIntAttrIfValid(MlirAttribute attr) {
-  if (auto integerAttr = llvm::dyn_cast<mlir::IntegerAttr>(unwrap(attr)))
-    return wrap(
-        circt::om::IntegerAttr::get(integerAttr.getContext(), integerAttr));
-  return attr;
+MlirAttribute omIntegerAttrGet(MlirAttribute attr) {
+  auto integerAttr = cast<mlir::IntegerAttr>(unwrap(attr));
+  return wrap(
+      circt::om::IntegerAttr::get(integerAttr.getContext(), integerAttr));
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/CAPI/om.c
+++ b/test/CAPI/om.c
@@ -57,7 +57,7 @@ void testEvaluator(MlirContext ctx) {
   // Test instantiation success.
 
   OMEvaluatorValue actualParam = omEvaluatorValueFromPrimitive(
-      omCastIntAttrIfValid(mlirIntegerAttrGet(mlirIntegerTypeGet(ctx, 8), 42)));
+      omIntegerAttrGet(mlirIntegerAttrGet(mlirIntegerTypeGet(ctx, 8), 42)));
 
   OMEvaluatorValue object =
       omEvaluatorInstantiate(evaluator, className, 1, &actualParam);

--- a/test/CAPI/om.c
+++ b/test/CAPI/om.c
@@ -20,8 +20,8 @@
 void testEvaluator(MlirContext ctx) {
   const char *testIR =
       "module {"
-      "  om.class @Test(%param: i8) {"
-      "    om.class.field @field, %param : i8"
+      "  om.class @Test(%param: !om.integer) {"
+      "    om.class.field @field, %param : !om.integer"
       "    %0 = om.object @Child() : () -> !om.class.type<@Child>"
       "    om.class.field @child, %0 : !om.class.type<@Child>"
       "  }"
@@ -57,7 +57,7 @@ void testEvaluator(MlirContext ctx) {
   // Test instantiation success.
 
   OMEvaluatorValue actualParam = omEvaluatorValueFromPrimitive(
-      mlirIntegerAttrGet(mlirIntegerTypeGet(ctx, 8), 42));
+      omCastIntAttrIfValid(mlirIntegerAttrGet(mlirIntegerTypeGet(ctx, 8), 42)));
 
   OMEvaluatorValue object =
       omEvaluatorInstantiate(evaluator, className, 1, &actualParam);
@@ -101,7 +101,7 @@ void testEvaluator(MlirContext ctx) {
 
   MlirAttribute fieldValue = omEvaluatorValueGetPrimitive(field);
 
-  // CHECK: 42 : i8
+  // CHECK: #om.integer<42 : i8> : !om.integer
   mlirAttributeDump(fieldValue);
 
   // Test get field success for child object.

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -7,8 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/OM/Evaluator/Evaluator.h"
+#include "circt/Dialect/OM/OMAttributes.h"
 #include "circt/Dialect/OM/OMDialect.h"
 #include "circt/Dialect/OM/OMOps.h"
+#include "circt/Dialect/OM/OMTypes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -67,8 +69,8 @@ TEST(EvaluatorTests, InstantiateInvalidParamSize) {
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
   auto cls = builder.create<ClassOp>("MyClass", params);
-  cls.getBody().emplaceBlock().addArgument(builder.getIntegerType(32),
-                                           cls.getLoc());
+  cls.getBody().emplaceBlock().addArgument(
+      circt::om::OMIntegerType::get(&context), cls.getLoc());
 
   Evaluator evaluator(mod);
 
@@ -100,8 +102,8 @@ TEST(EvaluatorTests, InstantiateNullParam) {
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
   auto cls = builder.create<ClassOp>("MyClass", params);
-  cls.getBody().emplaceBlock().addArgument(builder.getIntegerType(32),
-                                           cls.getLoc());
+  cls.getBody().emplaceBlock().addArgument(
+      circt::om::OMIntegerType::get(&context), cls.getLoc());
 
   Evaluator evaluator(mod);
 
@@ -131,8 +133,8 @@ TEST(EvaluatorTests, InstantiateInvalidParamType) {
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
   auto cls = builder.create<ClassOp>("MyClass", params);
-  cls.getBody().emplaceBlock().addArgument(builder.getIntegerType(32),
-                                           cls.getLoc());
+  cls.getBody().emplaceBlock().addArgument(
+      circt::om::OMIntegerType::get(&context), cls.getLoc());
 
   Evaluator evaluator(mod);
 
@@ -198,7 +200,7 @@ TEST(EvaluatorTests, InstantiateObjectWithParamField) {
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
   StringRef fields[] = {"field"};
-  Type types[] = {builder.getIntegerType(32)};
+  Type types[] = {circt::om::OMIntegerType::get(&context)};
   ClassOp::buildSimpleClassOp(builder, loc, "MyClass", params, fields, types);
 
   Evaluator evaluator(mod);
@@ -215,10 +217,10 @@ TEST(EvaluatorTests, InstantiateObjectWithParamField) {
                             ->getField(builder.getStringAttr("field"))
                             .value()
                             .get())
-                        ->getAs<IntegerAttr>();
+                        ->getAs<circt::om::IntegerAttr>();
 
   ASSERT_TRUE(fieldValue);
-  ASSERT_EQ(fieldValue.getValue(), 42);
+  ASSERT_EQ(fieldValue.getValue().getValue(), 42);
 }
 
 TEST(EvaluatorTests, InstantiateObjectWithConstantField) {
@@ -238,7 +240,8 @@ TEST(EvaluatorTests, InstantiateObjectWithConstantField) {
   auto cls = builder.create<ClassOp>("MyClass");
   auto &body = cls.getBody().emplaceBlock();
   builder.setInsertionPointToStart(&body);
-  auto constant = builder.create<ConstantOp>(builder.getI32IntegerAttr(42));
+  auto constant = builder.create<ConstantOp>(
+      circt::om::IntegerAttr::get(&context, builder.getI32IntegerAttr(42)));
   builder.create<ClassFieldOp>("field", constant);
 
   Evaluator evaluator(mod);
@@ -252,9 +255,9 @@ TEST(EvaluatorTests, InstantiateObjectWithConstantField) {
                             ->getField(builder.getStringAttr("field"))
                             .value()
                             .get())
-                        ->getAs<IntegerAttr>();
+                        ->getAs<circt::om::IntegerAttr>();
   ASSERT_TRUE(fieldValue);
-  ASSERT_EQ(fieldValue.getValue(), 42);
+  ASSERT_EQ(fieldValue.getValue().getValue(), 42);
 }
 
 TEST(EvaluatorTests, InstantiateObjectWithChildObject) {
@@ -273,24 +276,24 @@ TEST(EvaluatorTests, InstantiateObjectWithChildObject) {
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
   StringRef fields[] = {"field"};
-  Type types[] = {builder.getIntegerType(32)};
+  Type types[] = {circt::om::OMIntegerType::get(&context)};
   auto innerCls = ClassOp::buildSimpleClassOp(builder, loc, "MyInnerClass",
                                               params, fields, types);
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   auto cls = builder.create<ClassOp>("MyClass", params);
   auto &body = cls.getBody().emplaceBlock();
-  body.addArgument(builder.getIntegerType(32), cls.getLoc());
+  body.addArgument(circt::om::OMIntegerType::get(&context), cls.getLoc());
   builder.setInsertionPointToStart(&body);
   auto object = builder.create<ObjectOp>(innerCls, body.getArguments());
   builder.create<ClassFieldOp>("field", object);
 
   Evaluator evaluator(mod);
 
-  auto result =
-      evaluator.instantiate(builder.getStringAttr("MyClass"),
-                            {std::make_shared<evaluator::AttributeValue>(
-                                builder.getI32IntegerAttr(42))});
+  auto result = evaluator.instantiate(
+      builder.getStringAttr("MyClass"),
+      {std::make_shared<evaluator::AttributeValue>(circt::om::IntegerAttr::get(
+          &context, builder.getI32IntegerAttr(42)))});
 
   ASSERT_TRUE(succeeded(result));
 
@@ -302,9 +305,9 @@ TEST(EvaluatorTests, InstantiateObjectWithChildObject) {
   auto innerFieldValue =
       llvm::cast<evaluator::AttributeValue>(
           fieldValue->getField(builder.getStringAttr("field")).value().get())
-          ->getAs<IntegerAttr>();
+          ->getAs<circt::om::IntegerAttr>();
 
-  ASSERT_EQ(innerFieldValue.getValue(), 42);
+  ASSERT_EQ(innerFieldValue.getValue().getValue(), 42);
 }
 
 TEST(EvaluatorTests, InstantiateObjectWithFieldAccess) {
@@ -323,14 +326,14 @@ TEST(EvaluatorTests, InstantiateObjectWithFieldAccess) {
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   StringRef params[] = {"param"};
   StringRef fields[] = {"field"};
-  Type types[] = {builder.getIntegerType(32)};
+  Type types[] = {circt::om::OMIntegerType::get(&context)};
   auto innerCls = ClassOp::buildSimpleClassOp(builder, loc, "MyInnerClass",
                                               params, fields, types);
 
   builder.setInsertionPointToStart(&mod.getBodyRegion().front());
   auto cls = builder.create<ClassOp>("MyClass", params);
   auto &body = cls.getBody().emplaceBlock();
-  body.addArgument(builder.getIntegerType(32), cls.getLoc());
+  body.addArgument(circt::om::OMIntegerType::get(&context), cls.getLoc());
   builder.setInsertionPointToStart(&body);
   auto object = builder.create<ObjectOp>(innerCls, body.getArguments());
   auto field =
@@ -341,10 +344,10 @@ TEST(EvaluatorTests, InstantiateObjectWithFieldAccess) {
 
   Evaluator evaluator(mod);
 
-  auto result =
-      evaluator.instantiate(builder.getStringAttr("MyClass"),
-                            {std::make_shared<evaluator::AttributeValue>(
-                                builder.getI32IntegerAttr(42))});
+  auto result = evaluator.instantiate(
+      builder.getStringAttr("MyClass"),
+      {std::make_shared<evaluator::AttributeValue>(circt::om::IntegerAttr::get(
+          &context, builder.getI32IntegerAttr(42)))});
 
   ASSERT_TRUE(succeeded(result));
 
@@ -353,10 +356,10 @@ TEST(EvaluatorTests, InstantiateObjectWithFieldAccess) {
                             ->getField(builder.getStringAttr("field"))
                             .value()
                             .get())
-                        ->getAs<IntegerAttr>();
+                        ->getAs<circt::om::IntegerAttr>();
 
   ASSERT_TRUE(fieldValue);
-  ASSERT_EQ(fieldValue.getValue(), 42);
+  ASSERT_EQ(fieldValue.getValue().getValue(), 42);
 }
 
 TEST(EvaluatorTests, InstantiateObjectWithChildObjectMemoized) {

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -205,10 +205,11 @@ TEST(EvaluatorTests, InstantiateObjectWithParamField) {
 
   Evaluator evaluator(mod);
 
-  auto result =
-      evaluator.instantiate(builder.getStringAttr("MyClass"),
-                            getEvaluatorValuesFromAttributes(
-                                &context, {builder.getI32IntegerAttr(42)}));
+  auto result = evaluator.instantiate(
+      builder.getStringAttr("MyClass"),
+      getEvaluatorValuesFromAttributes(
+          &context, {circt::om::IntegerAttr::get(
+                        &context, builder.getI32IntegerAttr(42))}));
 
   ASSERT_TRUE(succeeded(result));
 
@@ -501,7 +502,7 @@ TEST(EvaluatorTests, AnyCastParam) {
   auto *innerFieldValue = llvm::cast<evaluator::AttributeValue>(
       fieldValue->getField(builder.getStringAttr("field")).value().get());
 
-  ASSERT_EQ(innerFieldValue->getAs<IntegerAttr>().getValue(), 42);
+  ASSERT_EQ(innerFieldValue->getAs<mlir::IntegerAttr>().getValue(), 42);
 }
 
 } // namespace


### PR DESCRIPTION
Implement the python bindings for the `om.integer` attribute. Also ensure all tests use `om::IntegerAttr` instead of `mlir::IntegerAttr`.