### PR TITLE
[OM][LinkModules] Ignore top-level definitions we don't care about

### DIFF
--- a/lib/Dialect/OM/Transforms/LinkModules.cpp
+++ b/lib/Dialect/OM/Transforms/LinkModules.cpp
@@ -54,11 +54,11 @@ struct LinkModulesPass : public LinkModulesBase<LinkModulesPass> {
 } // namespace
 
 LogicalResult ModuleInfo::initialize() {
-  for (auto &op : module.getOps()) {
+  for (auto &op : llvm::make_early_inc_range(module.getOps())) {
     if (auto classLike = dyn_cast<ClassLike>(op))
       symbolToClasses.insert({classLike.getSymNameAttr(), classLike});
     else
-      return op.emitError() << "unhandled top-level operation";
+      op.erase();
   }
   return success();
 }

--- a/test/Dialect/OM/link-modules.mlir
+++ b/test/Dialect/OM/link-modules.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --verify-diagnostics -pass-pipeline='builtin.module(om-link-modules)' --split-input-file | FileCheck %s
+// RUN: circt-opt %s --verify-diagnostics -pass-pipeline='builtin.module(om-link-modules)' --split-input-file -allow-unregistered-dialect | FileCheck %s
 
 module {
   // CHECK-LABEL: module
@@ -56,5 +56,22 @@ module {
      %0 = om.object @Conflict() : () -> !om.class.type<@Conflict>
      %1 = om.object.field %0, [@c] : (!om.class.type<@Conflict>) -> i1
     }
+  }
+}
+
+// -----
+
+// Check that OM ops are deleted.  Make the "delete-me" op a landmine that will
+// cause a symbol collision if it is _not_ deleted.
+module {
+  module {
+    // CHECK-NOT: delete-me
+    "delete-me"() {sym_name = "Bar"} : () -> ()
+    om.class @Foo() {
+   }
+  }
+  module {
+    om.class @Bar() {
+   }
   }
 }

--- a/test/Dialect/OM/link-modules.mlir
+++ b/test/Dialect/OM/link-modules.mlir
@@ -38,7 +38,7 @@ module {
       om.class.extern.field @a: i1
     }
     om.class @Conflict() {
-      %0 = om.constant 0 : i1 
+      %0 = om.constant 0 : i1
       om.class.field @c, %0: i1
     }
     om.class @UseConflict() {
@@ -49,7 +49,7 @@ module {
   }
   module {
     om.class @Conflict() {
-      %0 = om.constant 0 : i1 
+      %0 = om.constant 0 : i1
       om.class.field @c, %0: i1
     }
     om.class @UseConflict() {


### PR DESCRIPTION
Ignore top-level classes in the OM linker. This is a convenience that allows us to link the output of firtool without stripping any IR out. Perhaps a warning is better? What do you think?