### PR TITLE
[FIRRTL][IMDCE] Declarations with annotations should not be removed.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -43,7 +43,7 @@ static bool isDeletableDeclaration(Operation *op) {
   if (auto name = dyn_cast<FNamableOp>(op))
     if (!name.hasDroppableName())
       return false;
-  return !hasDontTouch(op);
+  return !hasDontTouch(op) && AnnotationSet(op).empty();
 }
 
 /// Return true if the annotation is ok to drop when the target is dead.

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -467,3 +467,13 @@ firrtl.circuit "Issue5898" {
     firrtl.ref.define %p, %w_ref : !firrtl.rwprobe<uint<5>>
   }
 }
+
+// -----
+// Test that annotations keep declarations alive.
+// CHECK-LABEL: "AnnoAlive"
+firrtl.circuit "AnnoAlive" {
+  firrtl.module @AnnoAlive() {
+     // CHECK: firrtl.wire
+     firrtl.wire {annotations = [{class = "circt.test"}]} : !firrtl.uint
+  }
+}


### PR DESCRIPTION
This is the usual "can this be deleted" behavior observed elsewhere.