### PR TITLE
[ARC][Seq] Switch arc over to use seq.clock

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.h
+++ b/include/circt/Dialect/Arc/ArcOps.h
@@ -20,6 +20,7 @@
 
 #include "circt/Dialect/Arc/ArcDialect.h"
 #include "circt/Dialect/Arc/ArcTypes.h"
+#include "circt/Dialect/Seq/SeqTypes.h"
 
 #include "circt/Dialect/Arc/ArcInterfaces.h.inc"
 

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -11,6 +11,7 @@
 
 include "circt/Dialect/Arc/ArcDialect.td"
 include "circt/Dialect/Arc/ArcTypes.td"
+include "circt/Dialect/Seq/SeqTypes.td"
 include "circt/Dialect/Arc/ArcInterfaces.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/FunctionInterfaces.td"
@@ -53,7 +54,7 @@ def DefineOp : ArcOp<"define", [
       build($_builder, $_state, sym_name, function_type, mlir::ArrayAttr(),
             mlir::ArrayAttr());
     }]>,
-    OpBuilder<(ins "mlir::StringRef":$sym_name, 
+    OpBuilder<(ins "mlir::StringRef":$sym_name,
                    "mlir::FunctionType":$function_type), [{
       build($_builder, $_state, sym_name, function_type, mlir::ArrayAttr(),
             mlir::ArrayAttr());
@@ -141,7 +142,7 @@ def StateOp : ArcOp<"state", [
 
   let arguments = (ins
     FlatSymbolRefAttr:$arc,
-    Optional<I1>:$clock,
+    Optional<ClockType>:$clock,
     Optional<I1>:$enable,
     Optional<I1>:$reset,
     I32Attr:$latency,
@@ -265,8 +266,8 @@ def CallOp : ArcOp<"call", [
 
 def ClockGateOp : ArcOp<"clock_gate", [Pure]> {
   let summary = "Clock gate";
-  let arguments = (ins I1:$input, I1:$enable);
-  let results = (outs I1:$output);
+  let arguments = (ins ClockType:$input, I1:$enable);
+  let results = (outs ClockType:$output);
   let assemblyFormat = [{
     $input `,` $enable attr-dict
   }];
@@ -322,7 +323,7 @@ def MemoryWritePortOp : ArcOp<"memory_write_port", [
     MemoryType:$memory,
     FlatSymbolRefAttr:$arc,
     Variadic<AnyType>:$inputs,
-    Optional<I1>:$clock,
+    Optional<ClockType>:$clock,
     UnitAttr:$enable,
     UnitAttr:$mask,
     DefaultValuedAttr<I32Attr, "1">:$latency
@@ -412,7 +413,7 @@ def ClockDomainOp : ArcOp<"clock_domain", [
 ]> {
   let summary = "a clock domain";
 
-  let arguments = (ins Variadic<AnyType>:$inputs, I1:$clock);
+  let arguments = (ins Variadic<AnyType>:$inputs, ClockType:$clock);
   let results = (outs Variadic<AnyType>:$outputs);
   let regions = (region SizedRegion<1>:$body);
 

--- a/lib/Dialect/Arc/ArcTypes.cpp
+++ b/lib/Dialect/Arc/ArcTypes.cpp
@@ -8,6 +8,7 @@
 
 #include "circt/Dialect/Arc/ArcTypes.h"
 #include "circt/Dialect/Arc/ArcDialect.h"
+#include "circt/Dialect/Seq/SeqTypes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/TypeSwitch.h"

--- a/lib/Dialect/Arc/CMakeLists.txt
+++ b/lib/Dialect/Arc/CMakeLists.txt
@@ -26,6 +26,7 @@ add_circt_dialect_library(CIRCTArc
 
   LINK_LIBS PUBLIC
   CIRCTHW
+  CIRCTSeq
   MLIRIR
   MLIRInferTypeOpInterface
   MLIRSideEffectInterfaces

--- a/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
@@ -70,15 +70,15 @@ hw.module @SplitAtConstants() -> (z: i4) {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: hw.module @Pipeline
-hw.module @Pipeline(%clock: i1, %i0: i4, %i1: i4) -> (z: i4) {
+hw.module @Pipeline(%clock: !seq.clock, %i0: i4, %i1: i4) -> (z: i4) {
   // CHECK-NEXT: [[S0:%.+]] = arc.state @Pipeline_arc(%i0, %i1) clock %clock lat 1
   // CHECK-NEXT: [[S1:%.+]] = arc.state @Pipeline_arc_0([[S0]], %i0) clock %clock lat 1
   // CHECK-NEXT: [[S2:%.+]] = arc.state @Pipeline_arc_1([[S1]], %i1) lat 0
   // CHECK-NEXT: hw.output [[S2]]
   %0 = comb.add %i0, %i1 : i4
-  %1 = seq.compreg %0, %clock : i4
+  %1 = seq.compreg %0, %clock : i4, !seq.clock
   %2 = comb.xor %1, %i0 : i4
-  %3 = seq.compreg %2, %clock : i4
+  %3 = seq.compreg %2, %clock : i4, !seq.clock
   %4 = comb.mul %3, %i1 : i4
   hw.output %4 : i4
 }
@@ -94,16 +94,16 @@ hw.module @Pipeline(%clock: i1, %i0: i4, %i1: i4) -> (z: i4) {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: hw.module @Reshuffling
-hw.module @Reshuffling(%clockA: i1, %clockB: i1) -> (z0: i4, z1: i4, z2: i4, z3: i4) {
+hw.module @Reshuffling(%clockA: !seq.clock, %clockB: !seq.clock) -> (z0: i4, z1: i4, z2: i4, z3: i4) {
   // CHECK-NEXT: hw.instance "x" @Reshuffling2()
   // CHECK-NEXT: arc.state @Reshuffling_arc(%x.z0, %x.z1) clock %clockA lat 1
   // CHECK-NEXT: arc.state @Reshuffling_arc_0(%x.z2, %x.z3) clock %clockB lat 1
   // CHECK-NEXT: hw.output
   %x.z0, %x.z1, %x.z2, %x.z3 = hw.instance "x" @Reshuffling2() -> (z0: i4, z1: i4, z2: i4, z3: i4)
-  %4 = seq.compreg %x.z0, %clockA : i4
-  %5 = seq.compreg %x.z1, %clockA : i4
-  %6 = seq.compreg %x.z2, %clockB : i4
-  %7 = seq.compreg %x.z3, %clockB : i4
+  %4 = seq.compreg %x.z0, %clockA : i4, !seq.clock
+  %5 = seq.compreg %x.z1, %clockA : i4, !seq.clock
+  %6 = seq.compreg %x.z2, %clockB : i4, !seq.clock
+  %7 = seq.compreg %x.z3, %clockB : i4, !seq.clock
   hw.output %4, %5, %6, %7 : i4, i4, i4, i4
 }
 // CHECK-NEXT: }
@@ -127,15 +127,15 @@ hw.module.extern private @Reshuffling2() -> (z0: i4, z1: i4, z2: i4, z3: i4)
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: hw.module @FactorOutCommonOps
-hw.module @FactorOutCommonOps(%clock: i1, %i0: i4, %i1: i4) -> (o0: i4, o1: i4) {
+hw.module @FactorOutCommonOps(%clock: !seq.clock, %i0: i4, %i1: i4) -> (o0: i4, o1: i4) {
   // CHECK-DAG: [[T0:%.+]] = arc.state @FactorOutCommonOps_arc_1(%i0, %i1) lat 0
   %0 = comb.add %i0, %i1 : i4
   // CHECK-DAG: [[T1:%.+]] = arc.state @FactorOutCommonOps_arc([[T0]], %i0) clock %clock lat 1
   // CHECK-DAG: [[T2:%.+]] = arc.state @FactorOutCommonOps_arc_0([[T0]], %i1) clock %clock lat 1
   %1 = comb.xor %0, %i0 : i4
   %2 = comb.mul %0, %i1 : i4
-  %3 = seq.compreg %1, %clock : i4
-  %4 = seq.compreg %2, %clock : i4
+  %3 = seq.compreg %1, %clock : i4, !seq.clock
+  %4 = seq.compreg %2, %clock : i4, !seq.clock
   // CHECK-NEXT: hw.output [[T1]], [[T2]]
   hw.output %3, %4 : i4, i4
 }
@@ -169,14 +169,14 @@ hw.module.extern private @SplitAtInstance2(%a: i4) -> (z: i4)
 
 
 // CHECK-LABEL: hw.module @AbsorbNames
-hw.module @AbsorbNames(%clock: i1) -> () {
+hw.module @AbsorbNames(%clock: !seq.clock) -> () {
   // CHECK-NEXT: %x.z0, %x.z1 = hw.instance "x" @AbsorbNames2()
   // CHECK-NEXT: arc.state @AbsorbNames_arc(%x.z0, %x.z1) clock %clock lat 1
   // CHECK-SAME:   {names = ["myRegA", "myRegB"]}
   // CHECK-NEXT: hw.output
   %x.z0, %x.z1 = hw.instance "x" @AbsorbNames2() -> (z0: i4, z1: i4)
-  %myRegA = seq.compreg %x.z0, %clock : i4
-  %myRegB = seq.compreg %x.z1, %clock : i4
+  %myRegA = seq.compreg %x.z0, %clock : i4, !seq.clock
+  %myRegB = seq.compreg %x.z1, %clock : i4, !seq.clock
 }
 // CHECK-NEXT: }
 
@@ -187,11 +187,11 @@ hw.module.extern @AbsorbNames2() -> (z0: i4, z1: i4)
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: hw.module @Trivial(
-hw.module @Trivial(%clock: i1, %i0: i4, %reset: i1) -> (out: i4) {
+hw.module @Trivial(%clock: !seq.clock, %i0: i4, %reset: i1) -> (out: i4) {
   // CHECK: [[RES0:%.+]] = arc.state @[[TRIVIAL_ARC]](%i0) clock %clock reset %reset lat 1 {names = ["foo"]
   // CHECK-NEXT: hw.output [[RES0:%.+]]
   %0 = hw.constant 0 : i4
-  %foo = seq.compreg %i0, %clock, %reset, %0 : i4
+  %foo = seq.compreg %i0, %clock, %reset, %0 : i4, !seq.clock
   hw.output %foo : i4
 }
 // CHECK-NEXT: }
@@ -205,13 +205,13 @@ hw.module @Trivial(%clock: i1, %i0: i4, %reset: i1) -> (out: i4) {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: hw.module @NonTrivial(
-hw.module @NonTrivial(%clock: i1, %i0: i4, %reset1: i1, %reset2: i1) -> (out1: i4, out2: i4) {
+hw.module @NonTrivial(%clock: !seq.clock, %i0: i4, %reset1: i1, %reset2: i1) -> (out1: i4, out2: i4) {
   // CHECK: [[RES2:%.+]] = arc.state @[[NONTRIVIAL_ARC_0]](%i0) clock %clock reset %reset1 lat 1 {names = ["foo"]
   // CHECK-NEXT: [[RES3:%.+]] = arc.state @[[NONTRIVIAL_ARC_1]](%i0) clock %clock reset %reset2 lat 1 {names = ["bar"]
   // CHECK-NEXT: hw.output [[RES2]], [[RES3]]
   %0 = hw.constant 0 : i4
-  %foo = seq.compreg %i0, %clock, %reset1, %0 : i4
-  %bar = seq.compreg %i0, %clock, %reset2, %0 : i4
+  %foo = seq.compreg %i0, %clock, %reset1, %0 : i4, !seq.clock
+  %bar = seq.compreg %i0, %clock, %reset2, %0 : i4, !seq.clock
   hw.output %foo, %bar : i4, i4
 }
 // CHECK-NEXT: }

--- a/test/Dialect/Arc/Reduction/state-elimination.mlir
+++ b/test/Dialect/Arc/Reduction/state-elimination.mlir
@@ -3,7 +3,7 @@
 // RUN: circt-reduce %s --test /usr/bin/env --test-arg grep --test-arg -q --test-arg "DummyArc(%arg0)" --keep-best=0 --include arc-state-elimination | FileCheck %s
 
 // CHECK-LABEL: hw.module @Foo
-hw.module @Foo(%clk: i1, %en: i1, %rst: i1, %arg0: i32) -> (out: i32) {
+hw.module @Foo(%clk: !seq.clock, %en: i1, %rst: i1, %arg0: i32) -> (out: i32) {
   // CHECK-NEXT: [[V0:%.+]] = arc.call @DummyArc(%arg0) : (i32) -> i32
   %0 = arc.state @DummyArc(%arg0) clock %clk enable %en reset %rst lat 1 {name="reg1"} : (i32) -> (i32)
   // CHECK-NEXT: hw.output [[V0]]

--- a/test/Dialect/Arc/arc-canonicalizer.mlir
+++ b/test/Dialect/Arc/arc-canonicalizer.mlir
@@ -5,16 +5,16 @@
 //===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: hw.module @passthoughChecks
-hw.module @passthoughChecks(%in0: i1, %in1: i1) -> (out0: i1, out1: i1, out2: i1, out3: i1, out4: i1, out5: i1, out6: i1, out7: i1, out8: i1, out9: i1) {
+hw.module @passthoughChecks(%clock: !seq.clock, %in0: i1, %in1: i1) -> (out0: i1, out1: i1, out2: i1, out3: i1, out4: i1, out5: i1, out6: i1, out7: i1, out8: i1, out9: i1) {
   %0:2 = arc.call @passthrough(%in0, %in1) : (i1, i1) -> (i1, i1)
   %1:2 = arc.call @noPassthrough(%in0, %in1) : (i1, i1) -> (i1, i1)
   %2:2 = arc.state @passthrough(%in0, %in1) lat 0 : (i1, i1) -> (i1, i1)
   %3:2 = arc.state @noPassthrough(%in0, %in1) lat 0 : (i1, i1) -> (i1, i1)
-  %4:2 = arc.state @passthrough(%in0, %in1) clock %in0 lat 1 : (i1, i1) -> (i1, i1)
+  %4:2 = arc.state @passthrough(%in0, %in1) clock %clock lat 1 : (i1, i1) -> (i1, i1)
   hw.output %0#0, %0#1, %1#0, %1#1, %2#0, %2#1, %3#0, %3#1, %4#0, %4#1 : i1, i1, i1, i1, i1, i1, i1, i1, i1, i1
   // CHECK-NEXT: [[V0:%.+]]:2 = arc.call @noPassthrough(%in0, %in1) :
   // CHECK-NEXT: [[V1:%.+]]:2 = arc.state @noPassthrough(%in0, %in1) lat 0 :
-  // CHECK-NEXT: [[V2:%.+]]:2 = arc.state @passthrough(%in0, %in1) clock %in0 lat 1 :
+  // CHECK-NEXT: [[V2:%.+]]:2 = arc.state @passthrough(%in0, %in1) clock %clock lat 1 :
   // CHECK-NEXT: hw.output %in0, %in1, [[V0]]#0, [[V0]]#1, %in0, %in1, [[V1]]#0, [[V1]]#1, [[V2]]#0, [[V2]]#1 :
 }
 arc.define @passthrough(%arg0: i1, %arg1: i1) -> (i1, i1) {
@@ -38,7 +38,7 @@ arc.define @memArcTrue(%arg0: i1, %arg1: i32) -> (i1, i32, i1) {
 }
 
 // CHECK-LABEL: hw.module @memoryWritePortCanonicalizations
-hw.module @memoryWritePortCanonicalizations(%clk: i1, %addr: i1, %data: i32) {
+hw.module @memoryWritePortCanonicalizations(%clk: !seq.clock, %addr: i1, %data: i32) {
   // CHECK-NEXT: [[MEM:%.+]] = arc.memory <2 x i32, i1>
   %mem = arc.memory <2 x i32, i1>
   arc.memory_write_port %mem, @memArcFalse(%addr, %data) clock %clk enable lat 1 : <2 x i32, i1>, i1, i32
@@ -150,7 +150,7 @@ arc.define @OneOfThreeUsed(%arg0: i1, %arg1: i1, %arg2: i1) -> i1 {
 }
 
 // CHECK: @test1
-hw.module @test1 (%arg0: i1, %arg1: i1, %arg2: i1, %clock: i1) -> (out0: i1, out1: i1) {
+hw.module @test1 (%arg0: i1, %arg1: i1, %arg2: i1, %clock: !seq.clock) -> (out0: i1, out1: i1) {
   // CHECK-NEXT: arc.state @OneOfThreeUsed(%arg1) clock %clock lat 1 : (i1) -> i1
   %0 = arc.state @OneOfThreeUsed(%arg0, %arg1, %arg2) clock %clock lat 1 : (i1, i1, i1) -> i1
   // CHECK-NEXT: arc.state @NestedCall(%arg1)

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -13,7 +13,7 @@ arc.define @Bar(%arg0: i42) -> i42 {
 }
 
 // CHECK-LABEL: hw.module @Module
-hw.module @Module(%clock: i1, %enable: i1, %a: i42, %b: i9) {
+hw.module @Module(%clock: !seq.clock, %enable: i1, %a: i42, %b: i9) {
   // CHECK: arc.state @Foo(%a, %b) clock %clock lat 1 : (i42, i9) -> (i42, i9)
   arc.state @Foo(%a, %b) clock %clock lat 1 : (i42, i9) -> (i42, i9)
 
@@ -90,7 +90,7 @@ arc.define @dummyCallee2() {
 }
 
 // CHECK-LABEL: hw.module @clockDomainTest
-hw.module @clockDomainTest(%clk: i1, %in0: i32, %in1: i16) {
+hw.module @clockDomainTest(%clk: !seq.clock, %in0: i32, %in1: i16) {
   // CHECK-NEXT: %{{.+}} = arc.clock_domain (%in0, %in1) clock %clk {someattr} : (i32, i16) -> i32 {
   %0 = arc.clock_domain (%in0, %in1) clock %clk {someattr} : (i32, i16) -> i32 {
   // CHECK-NEXT: ^bb0(%arg0: i32, %arg1: i16):
@@ -108,7 +108,7 @@ hw.module @clockDomainTest(%clk: i1, %in0: i32, %in1: i16) {
 }
 
 // CHECK-LABEL: hw.module @memoryOps
-hw.module @memoryOps(%clk: i1, %en: i1, %mask: i32) {
+hw.module @memoryOps(%clk: !seq.clock, %en: i1, %mask: i32, %arg: i1) {
   %c0_i32 = hw.constant 0 : i32
   // CHECK: [[MEM:%.+]] = arc.memory <4 x i32, i32>
   %mem = arc.memory <4 x i32, i32>
@@ -125,7 +125,7 @@ hw.module @memoryOps(%clk: i1, %en: i1, %mask: i32) {
   arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32) clock %clk lat 4 : <4 x i32, i32>, i32, i32
 
   // CHECK-NEXT: arc.clock_domain
-  arc.clock_domain (%clk) clock %clk : (i1) -> () {
+  arc.clock_domain (%arg) clock %clk : (i1) -> () {
   ^bb0(%arg0: i1):
     %c1_i32 = hw.constant 1 : i32
     // CHECK: [[MEM2:%.+]] = arc.memory <4 x i32, i32>

--- a/test/Dialect/Arc/canonicalizers.mlir
+++ b/test/Dialect/Arc/canonicalizers.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt --canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: hw.module @stateOpCanonicalizer
-hw.module @stateOpCanonicalizer(%clk: i1, %in: i32, %en: i1, %rst: i1) -> (out0: i32, out1: i32, out2: i32, out3: i32, out4: i32, out5: i32, out6: i32, out7: i32, out8: i32, out9: i32, out10: i32, out11: i32, out12: i32, out13: i32, out14: i32, out15: i32) {
+hw.module @stateOpCanonicalizer(%clk: !seq.clock, %in: i32, %en: i1, %rst: i1) -> (out0: i32, out1: i32, out2: i32, out3: i32, out4: i32, out5: i32, out6: i32, out7: i32, out8: i32, out9: i32, out10: i32, out11: i32, out12: i32, out13: i32, out14: i32, out15: i32) {
   // CHECK-NEXT: %c0_i32 = hw.constant 0 : i32
   // CHECK-NEXT: %true = hw.constant true
   // CHECK-NEXT: %false = hw.constant false
@@ -58,7 +58,7 @@ arc.define @Passthrough2(%arg0: i32, %arg1: i32) -> (i32, i32) {
 }
 
 // CHECK-LABEL: hw.module @clockDomainDCE
-hw.module @clockDomainDCE(%clk: i1) {
+hw.module @clockDomainDCE(%clk: !seq.clock) {
   // CHECK-NOT: arc.clock_domain
   arc.clock_domain () clock %clk : () -> () {
   ^bb0:
@@ -77,7 +77,7 @@ hw.module @memoryOps(%clk: i1, %mem: !arc.memory<4 x i32, i32>, %addr: i32, %dat
 }
 
 // CHECK-LABEL: hw.module @clockDomainCanonicalizer
-hw.module @clockDomainCanonicalizer(%clk: i1, %data: i32) -> (out0: i32, out1: i1, out2: i32, out3: i32, out4: i32) { 
+hw.module @clockDomainCanonicalizer(%clk: !seq.clock, %data: i32) -> (out0: i32, out1: i1, out2: i32, out3: i32, out4: i32) {
   %c0_i32 = hw.constant 0 : i32
   %true = hw.constant true
   %mem = arc.memory <4 x i32, i32>

--- a/test/Dialect/Arc/dedup.mlir
+++ b/test/Dialect/Arc/dedup.mlir
@@ -13,7 +13,7 @@ arc.define @SimpleB(%arg0: i4, %arg1: i4) -> i4 {
 }
 
 // CHECK-LABEL: hw.module @Simple
-hw.module @Simple(%x: i4, %y: i4) {
+hw.module @Simple(%x: i4, %y: i4, %clock: !seq.clock) {
   // CHECK-NEXT: arc.state @SimpleA(%x, %y)
   // CHECK-NEXT: arc.state @SimpleA(%y, %x)
   %0 = arc.state @SimpleA(%x, %y) lat 0 : (i4, i4) -> i4

--- a/test/Dialect/Arc/infer-memories.mlir
+++ b/test/Dialect/Arc/infer-memories.mlir
@@ -4,20 +4,20 @@ hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numW
 
 
 // CHECK-LABEL: hw.module @TestWOMemory(
-hw.module @TestWOMemory(%clock: i1, %addr: i10, %enable: i1, %data: i8) {
+hw.module @TestWOMemory(%clock: !seq.clock, %addr: i10, %enable: i1, %data: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8, i10> {name = "foo"}
   // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %data, %enable) clock %clock enable lat 1 : <1024 x i8, i10>, i10, i8, i1
   // CHECK-NEXT: hw.output
-  hw.instance "foo" @WOMemory(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: i1, W0_data: %data: i8) -> ()
+  hw.instance "foo" @WOMemory(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: !seq.clock, W0_data: %data: i8) -> ()
 }
 // CHECK-NEXT: }
 // CHECK-NOT: hw.module.generated @WOMemory, @FIRRTLMem
-hw.module.generated @WOMemory, @FIRRTLMem(%W0_addr: i10, %W0_en: i1, %W0_clk: i1, %W0_data: i8) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+hw.module.generated @WOMemory, @FIRRTLMem(%W0_addr: i10, %W0_en: i1, %W0_clk: !seq.clock, %W0_data: i8) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
 
 // CHECK-LABEL: hw.module @TestWOMemoryWithMask(
-hw.module @TestWOMemoryWithMask(%clock: i1, %addr: i10, %enable: i1, %data: i16, %mask: i2) {
+hw.module @TestWOMemoryWithMask(%clock: !seq.clock, %addr: i10, %enable: i1, %data: i16, %mask: i2) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i16, i10> {name = "foo"}
   // CHECK-NEXT: [[MASK_BIT0:%.+]] = comb.extract %mask from 0 : (i2) -> i1
@@ -27,31 +27,31 @@ hw.module @TestWOMemoryWithMask(%clock: i1, %addr: i10, %enable: i1, %data: i16,
   // CHECK-NEXT: [[MASK:%.+]] = comb.concat [[MASK_BYTE1]], [[MASK_BYTE0]]
   // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %data, %enable, [[MASK]]) clock %clock enable mask lat 1 : <1024 x i16, i10>, i10, i16, i1, i16
   // CHECK-NEXT: hw.output
-  hw.instance "foo" @WOMemoryWithMask(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: i1, W0_data: %data: i16, W0_mask: %mask: i2) -> ()
+  hw.instance "foo" @WOMemoryWithMask(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: !seq.clock, W0_data: %data: i16, W0_mask: %mask: i2) -> ()
 }
 // CHECK-NEXT: }
 // CHECK-NOT: hw.module.generated @WOMemoryWithMask, @FIRRTLMem
-hw.module.generated @WOMemoryWithMask, @FIRRTLMem(%W0_addr: i10, %W0_en: i1, %W0_clk: i1, %W0_data: i16, %W0_mask: i2) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : ui32, width = 16 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+hw.module.generated @WOMemoryWithMask, @FIRRTLMem(%W0_addr: i10, %W0_en: i1, %W0_clk: !seq.clock, %W0_data: i16, %W0_mask: i2) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, readUnderWrite = 0 : ui32, width = 16 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
 
 // CHECK-LABEL: hw.module @TestROMemory(
-hw.module @TestROMemory(%clock: i1, %addr: i10, %enable: i1) -> (data: i8) {
+hw.module @TestROMemory(%clock: !seq.clock, %addr: i10, %enable: i1) -> (data: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8, i10> {name = "foo"}
   // CHECK-NEXT: [[RDATA:%.+]] = arc.memory_read_port [[FOO]][%addr] : <1024 x i8, i10>
   // CHECK-NEXT: [[ZERO:%.+]] = hw.constant 0 : i8
   // CHECK-NEXT: [[MUX:%.+]] = comb.mux %enable, [[RDATA]], [[ZERO]] : i8
   // CHECK-NEXT: hw.output [[MUX]]
-  %0 = hw.instance "foo" @ROMemory(R0_addr: %addr: i10, R0_en: %enable: i1, R0_clk: %clock: i1) -> (R0_data: i8)
+  %0 = hw.instance "foo" @ROMemory(R0_addr: %addr: i10, R0_en: %enable: i1, R0_clk: %clock: !seq.clock) -> (R0_data: i8)
   hw.output %0 : i8
 }
 // CHECK-NEXT: }
 // CHECK-NOT: hw.module.generated @ROMemory, @FIRRTLMem
-hw.module.generated @ROMemory, @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: i1) -> (R0_data: i8) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+hw.module.generated @ROMemory, @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: !seq.clock) -> (R0_data: i8) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
 
 // CHECK-LABEL: hw.module @TestROMemoryWithLatency(
-hw.module @TestROMemoryWithLatency(%clock: i1, %addr: i10, %enable: i1) -> (data: i8) {
+hw.module @TestROMemoryWithLatency(%clock: !seq.clock, %addr: i10, %enable: i1) -> (data: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8, i10> {name = "foo"}
   // CHECK-NEXT: [[ADDR0:%.+]] = seq.compreg %addr, %clock
@@ -64,16 +64,16 @@ hw.module @TestROMemoryWithLatency(%clock: i1, %addr: i10, %enable: i1) -> (data
   // CHECK-NEXT: [[ZERO:%.+]] = hw.constant 0 : i8
   // CHECK-NEXT: [[D1:%.+]] = comb.mux [[EN2]], [[D0]], [[ZERO]] : i8
   // CHECK-NEXT: hw.output [[D1]]
-  %0 = hw.instance "foo" @ROMemoryWithLatency(R0_addr: %addr: i10, R0_en: %enable: i1, R0_clk: %clock: i1) -> (R0_data: i8)
+  %0 = hw.instance "foo" @ROMemoryWithLatency(R0_addr: %addr: i10, R0_en: %enable: i1, R0_clk: %clock: !seq.clock) -> (R0_data: i8)
   hw.output %0 : i8
 }
 // CHECK-NEXT: }
 // CHECK-NOT: hw.module.generated @ROMemoryWithLatency, @FIRRTLMem
-hw.module.generated @ROMemoryWithLatency, @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: i1) -> (R0_data: i8) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 3 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+hw.module.generated @ROMemoryWithLatency, @FIRRTLMem(%R0_addr: i10, %R0_en: i1, %R0_clk: !seq.clock) -> (R0_data: i8) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 3 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
 
 // CHECK-LABEL: hw.module @TestRWMemory(
-hw.module @TestRWMemory(%clock: i1, %addr: i10, %enable: i1, %wmode: i1, %wdata: i8) -> (rdata: i8) {
+hw.module @TestRWMemory(%clock: !seq.clock, %addr: i10, %enable: i1, %wmode: i1, %wdata: i8) -> (rdata: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8, i10> {name = "foo"}
   // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
@@ -85,9 +85,9 @@ hw.module @TestRWMemory(%clock: i1, %addr: i10, %enable: i1, %wmode: i1, %wdata:
   // CHECK-NEXT: [[WENABLE:%.+]] = comb.and %enable, %wmode
   // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %wdata, [[WENABLE]]) clock %clock enable lat 1 : <1024 x i8, i10>, i10, i8, i1
   // CHECK-NEXT: hw.output [[MUX]]
-  %0 = hw.instance "foo" @RWMemory(RW0_addr: %addr: i10, RW0_en: %enable: i1, RW0_clk: %clock: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i8) -> (RW0_rdata: i8)
+  %0 = hw.instance "foo" @RWMemory(RW0_addr: %addr: i10, RW0_en: %enable: i1, RW0_clk: %clock: !seq.clock, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i8) -> (RW0_rdata: i8)
   hw.output %0 : i8
 }
 // CHECK-NEXT: }
 // CHECK-NOT: hw.module.generated @RWMemory, @FIRRTLMem
-hw.module.generated @RWMemory, @FIRRTLMem(%RW0_addr: i10, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i8) -> (RW0_rdata: i8) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+hw.module.generated @RWMemory, @FIRRTLMem(%RW0_addr: i10, %RW0_en: i1, %RW0_clk: !seq.clock, %RW0_wmode: i1, %RW0_wdata: i8) -> (RW0_rdata: i8) attributes {depth = 1024 : i64, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : ui32, width = 8 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}

--- a/test/Dialect/Arc/infer-state-properties.mlir
+++ b/test/Dialect/Arc/infer-state-properties.mlir
@@ -171,7 +171,7 @@ arc.define @onlyOneReset(%arg0: i1, %arg1: i1, %arg2: i1) -> (i1, i1) {
 }
 
 // CHECK-LABEL: hw.module @testModule
-hw.module @testModule (%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1, %clock: i1) {
+hw.module @testModule (%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1, %clock: !seq.clock) {
   // COM: Test: AND based reset pattern detected
   // CHECK: arc.state @ANDBasedReset(%arg0, %arg1, %arg2) clock %clock reset %arg0 lat 1 : (i1, i1, i1) -> i1
   %0 = arc.state @ANDBasedReset(%arg0, %arg1, %arg2) clock %clock lat 1 : (i1, i1, i1) -> i1

--- a/test/Dialect/Arc/inline-arcs.mlir
+++ b/test/Dialect/Arc/inline-arcs.mlir
@@ -4,7 +4,7 @@
 // RUN: circt-opt %t/default --arc-inline | FileCheck %t/default
 
 // CHECK-LABEL: func.func @Simple
-func.func @Simple(%arg0: i4, %arg1: i1) -> (i4, i4) {
+func.func @Simple(%arg0: i4, %arg1: !seq.clock) -> (i4, i4) {
   // CHECK-NEXT: %0 = comb.and %arg0, %arg0
   // CHECK-NEXT: %1 = arc.state @SimpleB(%arg0) clock %arg1 lat 1
   // CHECK-NEXT: return %0, %1
@@ -101,7 +101,7 @@ arc.define @sub5(%arg0: index, %arg1: i4) -> i4 {
 // CHECK-NEXT: hw.output [[RES]] : i4
 
 // CHECK-LABEL: hw.module @TopLevel
-hw.module @TopLevel(%clk: i1, %arg0: i32, %arg1: i32) -> (out0: i32, out1: i32, out2: i32, out3: i32) {
+hw.module @TopLevel(%clk: !seq.clock, %arg0: i32, %arg1: i32) -> (out0: i32, out1: i32, out2: i32, out3: i32) {
   %0:2 = arc.state @inlineIntoArc(%arg0, %arg1) clock %clk lat 1 : (i32, i32) -> (i32, i32)
   %1:2 = arc.state @inlineIntoArc2(%arg0, %arg1) clock %clk lat 1 : (i32, i32) -> (i32, i32)
   hw.output %0#0, %0#1, %1#0, %1#1 : i32, i32, i32, i32
@@ -168,7 +168,7 @@ arc.define @ToBeRemoved3(%arg0: i32) -> i32 {
 // RUN: circt-opt %t/onlyIntoArcs --arc-inline=into-arcs-only=1 | FileCheck %t/onlyIntoArcs
 
 // CHECK-LABEL: hw.module @onlyIntoArcs
-hw.module @onlyIntoArcs(%arg0: i4, %arg1: i4) -> (out0: i4) {
+hw.module @onlyIntoArcs(%arg0: i4, %arg1: i4, %arg2: !seq.clock) -> (out0: i4) {
   %0 = arc.state @sub1(%arg0, %arg1) lat 0 : (i4, i4) -> i4
   hw.output %0 : i4
 }

--- a/test/Dialect/Arc/isolate-clocks.mlir
+++ b/test/Dialect/Arc/isolate-clocks.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s --arc-isolate-clocks | FileCheck %s
 
 // CHECK-LABEL: hw.module @basics
-hw.module @basics(%clk0: i1, %clk1: i1, %clk2: i1, %c0: i1, %c1: i1, %in: i32) -> (out0: i32, out1: i32) {
+hw.module @basics(%clk0: !seq.clock, %clk1: !seq.clock, %clk2: !seq.clock, %c0: i1, %c1: i1, %in: i32) -> (out0: i32, out1: i32) {
   // COM: check the basic things: clocked ops are grouped properly, lat 0 states
   // COM: are not considered clocked, clock domain materialization
   %0 = comb.and %c0, %c1 : i1
@@ -45,7 +45,7 @@ arc.define @identity(%arg0: i1, %arg1: i32) -> (i1, i32) {
 }
 
 // CHECK-LABEL: hw.module @preexistingClockDomain
-hw.module @preexistingClockDomain(%clk0: i1, %clk1: i1, %in: i32) -> (out0: i32, out1: i32) {
+hw.module @preexistingClockDomain(%clk0: !seq.clock, %clk1: !seq.clock, %in: i32) -> (out0: i32, out1: i32) {
   // COM: the pass also works when there are already clock domains present, but
   // COM: it creates new clock domain ops for all clocks of clocked operations
   // COM: outside of the existing domains instead of merging them.

--- a/test/Dialect/Arc/latency-retiming.mlir
+++ b/test/Dialect/Arc/latency-retiming.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s --arc-latency-retiming | FileCheck %s
 
 // CHECK-LABEL: hw.module @Foo
-hw.module @Foo(%clk: i1, %clk2: i1, %en: i1, %rst: i1, %arg0: i32, %arg1: i32) -> (out0: i32, out1: i32, out2: i32, out3: i32, out4: i32, out5: i32, out6: i32, out7: i32, out8: i32, out9: i32, out10: i32, out11: i32) {
+hw.module @Foo(%clk: !seq.clock, %clk2: !seq.clock, %en: i1, %rst: i1, %arg0: i32, %arg1: i32) -> (out0: i32, out1: i32, out2: i32, out3: i32, out4: i32, out5: i32, out6: i32, out7: i32, out8: i32, out9: i32, out10: i32, out11: i32) {
   // COM: simple shift-register of depth 3 is merged to one arc.state
   %0 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
   %1 = arc.state @Bar(%0) clock %clk lat 1 : (i32) -> i32

--- a/test/Dialect/Arc/split-loops-errors.mlir
+++ b/test/Dialect/Arc/split-loops-errors.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s --arc-split-loops --verify-diagnostics --split-input-file
 
-hw.module @UnbreakableLoop(%a: i4) -> (x: i4) {
+hw.module @UnbreakableLoop(%clock: !seq.clock, %a: i4) -> (x: i4) {
   // expected-error @below {{loop splitting did not eliminate all loops; loop detected}}
   // expected-note @below {{through operand 1 here:}}
   %0, %1 = arc.state @UnbreakableLoopArc(%a, %0) lat 0 : (i4, i4) -> (i4, i4)

--- a/test/Dialect/Arc/split-loops.mlir
+++ b/test/Dialect/Arc/split-loops.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s --arc-split-loops | FileCheck %s
 
 // CHECK-LABEL: hw.module @Simple(
-hw.module @Simple(%a: i4, %b: i4) -> (x: i4, y: i4) {
+hw.module @Simple(%clock: !seq.clock, %a: i4, %b: i4) -> (x: i4, y: i4) {
   // CHECK-NEXT: %0 = arc.state @SimpleArc_split_0(%a, %b)
   // CHECK-NEXT: %1 = arc.state @SimpleArc_split_1(%0, %a)
   // CHECK-NEXT: %2 = arc.state @SimpleArc_split_2(%0, %b)

--- a/test/Dialect/Seq/lower-firmem.mlir
+++ b/test/Dialect/Seq/lower-firmem.mlir
@@ -5,15 +5,16 @@
 // CHECK: sv.macro.decl @SomeMacro
 sv.macro.decl @SomeMacro
 
-// CHECK: hw.module.generated @m0_mem1_12x42, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-// CHECK: hw.module.generated @m0_mem2_12x42, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42, %W0_mask: i2) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 21 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-// CHECK: hw.module.generated @m0_mem3_12x42, @FIRRTLMem(%RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i3) -> (RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 14 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-// CHECK: hw.module.generated @m0_mem4_12x42, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: i1, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: i1, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i6, %W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i42, %W0_mask: i6) -> (R0_data: i42, RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 7 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32, 0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @m0_mem1_12x42, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: !seq.clock) -> (R0_data: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 42 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @m0_mem2_12x42, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: !seq.clock, %W0_data: i42, %W0_mask: i2) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 21 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @m0_mem3_12x42, @FIRRTLMem(%RW0_addr: i4, %RW0_en: i1, %RW0_clk: !seq.clock, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i3) -> (RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 14 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @m0_mem4_12x42, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: !seq.clock, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: !seq.clock, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i6, %W0_addr: i4, %W0_en: i1, %W0_clk: !seq.clock, %W0_data: i42, %W0_mask: i6) -> (R0_data: i42, RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 7 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32, 0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
 // CHECK-LABEL: hw.module @Foo
 hw.module @Foo(%clk: i1, %en: i1, %addr: i4, %wdata: i42, %wmode: i1, %mask2: i2, %mask3: i3, %mask6: i6) {
-  // CHECK-NEXT: [[TMP0:%.+]] = hw.instance "m0_mem1A_ext" @m0_mem1_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1) -> (R0_data: i42)
-  // CHECK-NEXT: [[TMP1:%.+]] = hw.instance "m0_mem1B_ext" @m0_mem1_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1) -> (R0_data: i42)
+  // CHECK-NEXT: [[CLK:%.+]] = seq.to_clock %clk
+  // CHECK-NEXT: [[TMP0:%.+]] = hw.instance "m0_mem1A_ext" @m0_mem1_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: [[CLK]]: !seq.clock) -> (R0_data: i42)
+  // CHECK-NEXT: [[TMP1:%.+]] = hw.instance "m0_mem1B_ext" @m0_mem1_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: [[CLK]]: !seq.clock) -> (R0_data: i42)
   // CHECK-NEXT: comb.xor [[TMP0]], [[TMP1]]
   %m0_mem1A = seq.firmem 0, 1, undefined, port_order : <12 x 42>
   %m0_mem1B = seq.firmem 0, 1, undefined, port_order : <12 x 42>
@@ -21,17 +22,17 @@ hw.module @Foo(%clk: i1, %en: i1, %addr: i4, %wdata: i42, %wmode: i1, %mask2: i2
   %1 = seq.firmem.read_port %m0_mem1B[%addr], clock %clk enable %en : <12 x 42>, i1
   comb.xor %0, %1 : i42
 
-  // CHECK-NEXT: hw.instance "m0_mem2_ext" @m0_mem2_12x42(W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: %clk: i1, W0_data: %wdata: i42, W0_mask: %mask2: i2) -> ()
+  // CHECK-NEXT: hw.instance "m0_mem2_ext" @m0_mem2_12x42(W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: [[CLK]]: !seq.clock, W0_data: %wdata: i42, W0_mask: %mask2: i2) -> ()
   %m0_mem2 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 2>
   seq.firmem.write_port %m0_mem2[%addr] = %wdata, clock %clk enable %en mask %mask2 : <12 x 42, mask 2>, i1, i2
 
-  // CHECK-NEXT: [[TMP:%.+]] = hw.instance "m0_mem3_ext" @m0_mem3_12x42(RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: %clk: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask3: i3) -> (RW0_rdata: i42)
+  // CHECK-NEXT: [[TMP:%.+]] = hw.instance "m0_mem3_ext" @m0_mem3_12x42(RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: [[CLK]]: !seq.clock, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask3: i3) -> (RW0_rdata: i42)
   // CHECK-NEXT: comb.xor [[TMP]]
   %m0_mem3 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 3>
   %2 = seq.firmem.read_write_port %m0_mem3[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask3 : <12 x 42, mask 3>, i1, i3
   comb.xor %2 : i42
 
-  // CHECK-NEXT: [[TMP0:%.+]], [[TMP1:%.+]] = hw.instance "m0_mem4_ext" @m0_mem4_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: i1, RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: %clk: i1, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask6: i6, W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: %clk: i1, W0_data: %wdata: i42, W0_mask: %mask6: i6) -> (R0_data: i42, RW0_rdata: i42)
+  // CHECK-NEXT: [[TMP0:%.+]], [[TMP1:%.+]] = hw.instance "m0_mem4_ext" @m0_mem4_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: [[CLK]]: !seq.clock, RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: [[CLK]]: !seq.clock, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask6: i6, W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: [[CLK]]: !seq.clock, W0_data: %wdata: i42, W0_mask: %mask6: i6) -> (R0_data: i42, RW0_rdata: i42)
   // CHECK-NEXT: comb.xor [[TMP0]], [[TMP1]]
   %m0_mem4 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 6>
   %3 = seq.firmem.read_port %m0_mem4[%addr], clock %clk enable %en : <12 x 42, mask 6>, i1
@@ -67,8 +68,8 @@ hw.module @SeparatePrefices() {
   %m2_mem4 = seq.firmem 0, 1, undefined, port_order {prefix = "uwu_"} : <24 x 9001>
 }
 
-// CHECK: hw.module.generated @m3_mem_12x8, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: i1, %W1_data: i8) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32, 0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
-// CHECK: hw.module.generated @m3_mem2_12x8, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: i1, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: i1, %W1_data: i8) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32, 1 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @m3_mem_12x8, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: !seq.clock, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: !seq.clock, %W1_data: i8) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32, 0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+// CHECK: hw.module.generated @m3_mem2_12x8, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: !seq.clock, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: !seq.clock, %W1_data: i8) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32, 1 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
 // CHECK-LABEL: hw.module @MemoryWritePortBehavior
 hw.module @MemoryWritePortBehavior(%clock1: i1, %clock2: i1) {

--- a/test/arcilator/arcilator.mlir
+++ b/test/arcilator/arcilator.mlir
@@ -20,7 +20,7 @@
 // CHECK-NOT: hw.module @Top
 // CHECK-LABEL: arc.model "Top" {
 // CHECK-NEXT: ^bb0(%arg0: !arc.storage<6>):
-hw.module @Top(%clock: i1, %i0: i4, %i1: i4) -> (out: i4) {
+hw.module @Top(%clock: !seq.clock, %i0: i4, %i1: i4) -> (out: i4) {
   // CHECK-DAG: arc.root_input "clock", %arg0 {offset = 0
   // CHECK-DAG: arc.root_input "i0", %arg0 {offset = 1
   // CHECK-DAG: arc.root_input "i1", %arg0 {offset = 2
@@ -57,8 +57,8 @@ hw.module @Top(%clock: i1, %i0: i4, %i1: i4) -> (out: i4) {
   %0 = comb.add %i0, %i1 : i4
   %1 = comb.xor %0, %i0 : i4
   %2 = comb.xor %0, %i1 : i4
-  %foo = seq.compreg %1, %clock : i4
-  %bar = seq.compreg %2, %clock : i4
+  %foo = seq.compreg %1, %clock : i4, !seq.clock
+  %bar = seq.compreg %2, %clock : i4, !seq.clock
   %3 = comb.mul %foo, %bar : i4
   hw.output %3 : i4
 }


### PR DESCRIPTION
This PR enforces the use of the clock type in some `arc` ops.

Part of #5851