### PR TITLE
[FIRRTL][Seq] Lower `firrtl.clock` to `seq.clock`

### DIFF
--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -151,7 +151,7 @@ def FirRegOp : SeqOp<"firreg",
 
   let arguments = (ins
     AnyType:$next,
-    I1:$clk,
+    ClockType:$clk,
     StrAttr:$name,
     OptionalAttr<InnerSymAttr>:$inner_sym,
     OptionalAttr<APIntAttr>:$preset,
@@ -463,14 +463,14 @@ def FirMemReadOp : SeqOp<"firmem.read_port", [
   let arguments = (ins
     FirMemType:$memory,
     AnySignlessInteger:$address,
-    ClockOrI1Type:$clock,
+    ClockType:$clock,
     Optional<I1>:$enable
   );
   let results = (outs AnySignlessInteger:$data);
   let assemblyFormat = [{
     $memory `[` $address `]` `,` `clock` $clock
     (`enable` $enable^)?
-    attr-dict `:` type($memory) `,` type($clock)
+    attr-dict `:` type($memory)
   }];
   let hasCanonicalizeMethod = 1;
 }
@@ -496,7 +496,7 @@ def FirMemWriteOp : SeqOp<"firmem.write_port", [
   let arguments = (ins
     FirMemType:$memory,
     AnySignlessInteger:$address,
-    ClockOrI1Type:$clock,
+    ClockType:$clock,
     Optional<I1>:$enable,
     AnySignlessInteger:$data,
     Optional<AnySignlessInteger>:$mask
@@ -504,7 +504,7 @@ def FirMemWriteOp : SeqOp<"firmem.write_port", [
   let assemblyFormat = [{
     $memory `[` $address `]` `=` $data `,` `clock` $clock
     (`enable` $enable^)? (`mask` $mask^)?
-    attr-dict `:` type($memory) `,` type($clock) (`,` type($mask)^)?
+    attr-dict `:` type($memory) (`,` type($mask)^)?
   }];
   let hasVerifier = 1;
   let hasCanonicalizeMethod = 1;
@@ -533,7 +533,7 @@ def FirMemReadWriteOp : SeqOp<"firmem.read_write_port", [
   let arguments = (ins
     FirMemType:$memory,
     AnySignlessInteger:$address,
-    ClockOrI1Type:$clock,
+    ClockType:$clock,
     Optional<I1>:$enable,
     AnySignlessInteger:$writeData,
     I1:$mode,
@@ -543,7 +543,7 @@ def FirMemReadWriteOp : SeqOp<"firmem.read_write_port", [
   let assemblyFormat = [{
     $memory `[` $address `]` `=` $writeData `if` $mode `,` `clock` $clock
     (`enable` $enable^)? (`mask` $mask^)?
-    attr-dict `:` type($memory) `,` type($clock) (`,` type($mask)^)?
+    attr-dict `:` type($memory) (`,` type($mask)^)?
   }];
   let hasVerifier = 1;
   let hasCanonicalizeMethod = 1;

--- a/integration_test/Dialect/Seq/registers.mlir
+++ b/integration_test/Dialect/Seq/registers.mlir
@@ -11,7 +11,7 @@
 sv.macro.decl @INIT_RANDOM_PROLOG_
 sv.macro.def @INIT_RANDOM_PROLOG_ ""
 
-hw.module @top(%clk: i1, %rst: i1) {
+hw.module @top(%clk: !seq.clock, %rst: i1) {
   %cst0 = hw.constant 0 : i32
   %cst1 = hw.constant 1 : i32
 
@@ -25,7 +25,8 @@ hw.module @top(%clk: i1, %rst: i1) {
   %nextB = comb.add %rB, %rA : i32
   %nextC = comb.add %rC, %rB : i32
 
-  sv.alwaysff(posedge %clk) {
+  %clock = seq.from_clock %clk
+  sv.alwaysff(posedge %clock) {
     %fd = hw.constant 0x80000002 : i32
     sv.fwrite %fd, "%d %d %d\n"(%rA, %rB, %rC) : i32, i32, i32
   }

--- a/lib/Conversion/SeqToSV/FirMemLowering.cpp
+++ b/lib/Conversion/SeqToSV/FirMemLowering.cpp
@@ -318,17 +318,6 @@ void FirMemLowering::lowerMemoriesInModule(
   };
   auto valueOrOne = [&](Value value) { return value ? value : constOne(); };
 
-  DenseMap<Value, Value> clocks;
-  auto mapClock = [&](Value clock) {
-    auto it = clocks.try_emplace(clock, Value{});
-    if (it.second) {
-      ImplicitLocOpBuilder builder(clock.getLoc(), clock.getContext());
-      builder.setInsertionPointAfterValue(clock);
-      it.first->second = builder.createOrFold<seq::ToClockOp>(clock);
-    }
-    return it.first->second;
-  };
-
   for (auto [config, genOp, memOp] : mems) {
     LLVM_DEBUG(llvm::dbgs() << "- Lowering " << memOp.getName() << "\n");
     SmallVector<Value> inputs;
@@ -344,7 +333,7 @@ void FirMemLowering::lowerMemoriesInModule(
         continue;
       addInput(port.getAddress());
       addInput(valueOrOne(port.getEnable()));
-      addInput(mapClock(port.getClock()));
+      addInput(port.getClock());
       addOutput(port.getData());
     }
 
@@ -355,7 +344,7 @@ void FirMemLowering::lowerMemoriesInModule(
         continue;
       addInput(port.getAddress());
       addInput(valueOrOne(port.getEnable()));
-      addInput(mapClock(port.getClock()));
+      addInput(port.getClock());
       addInput(port.getMode());
       addInput(port.getWriteData());
       addOutput(port.getReadData());
@@ -370,7 +359,7 @@ void FirMemLowering::lowerMemoriesInModule(
         continue;
       addInput(port.getAddress());
       addInput(valueOrOne(port.getEnable()));
-      addInput(mapClock(port.getClock()));
+      addInput(port.getClock());
       addInput(port.getData());
       if (config->maskBits > 1)
         addInput(valueOrOne(port.getMask()));

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -13,6 +13,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/InnerSymbolNamespace.h"
+#include "circt/Dialect/Seq/SeqTypes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -969,6 +970,8 @@ Type circt::firrtl::lowerType(
         {StringAttr::get(type.getContext(), "body"), bodyTy}};
     return hw::StructType::get(type.getContext(), fields);
   }
+  if (type_isa<ClockType>(firType))
+    return seq::ClockType::get(firType.getContext());
 
   auto width = firType.getBitWidthOrSentinel();
   if (width >= 0) // IntType, analog with known width, clock, etc.

--- a/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
+++ b/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
@@ -8,12 +8,13 @@ firrtl.circuit "ifElseFatalToSVA" {
     in %enable: !firrtl.uint<1>
   ) {
     firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, format = "ifElseFatal"}
+    // CHECK-NEXT: [[CLK:%.+]] = seq.from_clock %clock
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor bin %enable, [[TRUE]]
     // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
-    // CHECK-NEXT: sv.assert.concurrent posedge %clock, [[TMP2]] message "assert0"
+    // CHECK-NEXT: sv.assert.concurrent posedge [[CLK]], [[TMP2]] message "assert0"
     // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
-    // CHECK-NEXT:   sv.assume.concurrent posedge %clock, [[TMP2]]
+    // CHECK-NEXT:   sv.assume.concurrent posedge [[CLK]], [[TMP2]]
     // CHECK-NEXT: }
   }
 

--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -4,10 +4,11 @@ firrtl.circuit "Intrinsics" {
   // CHECK-LABEL: hw.module @Intrinsics
   firrtl.module @Intrinsics(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>) {
     // CHECK-NEXT: %c0_i32 = hw.constant 0 : i32
-    // CHECK-NEXT: %false = hw.constant false 
+    // CHECK-NEXT: %false = hw.constant false
+    // CHECK-NEXT: [[CLK:%.+]] = seq.from_clock %clk
     // CHECK-NEXT: %x_i1 = sv.constantX : i1
     // CHECK-NEXT: [[T0:%.+]] = comb.icmp bin ceq %a, %x_i1
-    // CHECK-NEXT: [[T1:%.+]] = comb.icmp bin ceq %clk, %x_i1
+    // CHECK-NEXT: [[T1:%.+]] = comb.icmp bin ceq [[CLK]], %x_i1
     // CHECK-NEXT: %x0 = hw.wire [[T0]]
     // CHECK-NEXT: %x1 = hw.wire [[T1]]
     %0 = firrtl.int.isX %a : !firrtl.uint<1>
@@ -65,6 +66,7 @@ firrtl.circuit "Intrinsics" {
 
   // CHECK-LABEL: hw.module @LTLAndVerif
   firrtl.module @LTLAndVerif(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>) {
+    // CHECK-NEXT: [[CLK:%.+]] = seq.from_clock %clk
     // CHECK-NEXT: [[D0:%.+]] = ltl.delay %a, 42 : i1
     // CHECK-NEXT: [[D1:%.+]] = ltl.delay %b, 42, 1337 : i1
     %d0 = firrtl.int.ltl.delay %a, 42 : (!firrtl.uint<1>) -> !firrtl.uint<1>
@@ -87,7 +89,7 @@ firrtl.circuit "Intrinsics" {
     // CHECK-NEXT: [[E0:%.+]] = ltl.eventually [[I0]] : !ltl.property
     %e0 = firrtl.int.ltl.eventually %i0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 
-    // CHECK-NEXT: [[K0:%.+]] = ltl.clock [[I0]], posedge %clk : !ltl.property
+    // CHECK-NEXT: [[K0:%.+]] = ltl.clock [[I0]], posedge [[CLK]] : !ltl.property
     %k0 = firrtl.int.ltl.clock %i0, %clk : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
 
     // CHECK-NEXT: [[D2:%.+]] = ltl.disable [[K0]] if %b : !ltl.property
@@ -161,8 +163,9 @@ firrtl.circuit "Intrinsics" {
     out %hbr1: !firrtl.uint<1>,
     out %hbr2: !firrtl.uint<1>
   ) {
-    // CHECK-NEXT: [[TMP1:%.+]] = verif.has_been_reset %clock, sync %reset1
-    // CHECK-NEXT: [[TMP2:%.+]] = verif.has_been_reset %clock, async %reset2
+    // CHECK-NEXT: [[CLK:%.+]] = seq.from_clock %clock
+    // CHECK-NEXT: [[TMP1:%.+]] = verif.has_been_reset [[CLK]], sync %reset1
+    // CHECK-NEXT: [[TMP2:%.+]] = verif.has_been_reset [[CLK]], async %reset2
     // CHECK-NEXT: hw.output [[TMP1]], [[TMP2]]
     %0 = firrtl.int.has_been_reset %clock, %reset1 : !firrtl.uint<1>
     %1 = firrtl.int.has_been_reset %clock, %reset2 : !firrtl.asyncreset

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -50,6 +50,7 @@ firrtl.circuit "Simple" {
   firrtl.module private @TestInstance(in %u2: !firrtl.uint<2>, in %s8: !firrtl.sint<8>,
                               in %clock: !firrtl.clock,
                               in %reset: !firrtl.uint<1>) {
+    // CHECK-NEXT: [[CLK:%.+]] = seq.from_clock %clock
     // CHECK-NEXT: %c0_i2 = hw.constant
     // CHECK-NEXT: %xyz.out4 = hw.instance "xyz" @Simple(in1: [[ARG1:%.+]]: i4, in2: %u2: i2, in3: %s8: i8) -> (out4: i4)
     %xyz:4 = firrtl.instance xyz @Simple(in in1: !firrtl.uint<4>, in in2: !firrtl.uint<2>, in in3: !firrtl.sint<8>, out out4: !firrtl.uint<4>)
@@ -124,7 +125,7 @@ firrtl.circuit "Simple" {
     // CHECK: [[OUTE:%.+]] = comb.concat %false, %inE : i1, i3
     // CHECK: hw.output %inA, [[OUTB]], [[OUTC]], [[OUTD]], [[OUTE]]
   }
-  
+
   firrtl.module private @InputPorts(in %in : !firrtl.uint<1>) { }
   firrtl.module private @InputPortsParent(in %in : !firrtl.uint<1>) {
     // Double connected.
@@ -134,9 +135,10 @@ firrtl.circuit "Simple" {
     firrtl.connect %ip1_in, %in : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
-  // CHECK-LABEL: hw.module private @Analog(%a1: !hw.inout<i1>) -> (outClock: i1) {
-  // CHECK-NEXT:    %0 = sv.read_inout %a1 : !hw.inout<i1>
-  // CHECK-NEXT:    hw.output %0 : i1
+  // CHECK-LABEL: hw.module private @Analog(%a1: !hw.inout<i1>) -> (outClock: !seq.clock) {
+  // CHECK-NEXT:    [[READ:%.+]] = sv.read_inout %a1 : !hw.inout<i1>
+  // CHECK-NEXT:    [[CLK:%.+]] = seq.to_clock [[READ]]
+  // CHECK-NEXT:    hw.output [[CLK]] : !seq.clock
   firrtl.module private @Analog(in %a1: !firrtl.analog<1>,
                         out %outClock: !firrtl.clock) {
 
@@ -277,7 +279,7 @@ firrtl.circuit "Simple" {
   // Memory modules are lowered to plain external modules.
   // CHECK: hw.module.extern @MRead_ext(%R0_addr: i4, %R0_en: i1, %R0_clk: i1) -> (R0_data: i42) attributes {verilogName = "MRead_ext"}
   firrtl.memmodule @MRead_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.uint<1>, out R0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 0 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 0 : ui32, writeLatency = 1 : ui32}
-  
+
   // The following operations should be passed through without an error.
   // CHECK: sv.interface @SVInterface
   sv.interface @SVInterface { }

--- a/test/Dialect/Arc/strip-sv.mlir
+++ b/test/Dialect/Arc/strip-sv.mlir
@@ -8,7 +8,7 @@ sv.ifdef  "RANDOMIZE_REG_INIT" {
 }
 
 // CHECK-LABEL: hw.module @Foo(
-hw.module @Foo(%clock: i1, %a: i4) -> (z: i4) {
+hw.module @Foo(%clock: !seq.clock, %a: i4) -> (z: i4) {
   // CHECK-NEXT: [[REG:%.+]] = seq.compreg %a, %clock
   %0 = seq.firreg %a clock %clock : i4
   %1 = sv.wire : !hw.inout<i4>
@@ -20,12 +20,12 @@ hw.module @Foo(%clock: i1, %a: i4) -> (z: i4) {
 // CHECK-NEXT: }
 
 // CHECK-LABEL: hw.module.extern @PeripheryBus
-hw.module.extern @PeripheryBus() -> (clock: i1, reset: i1)
+hw.module.extern @PeripheryBus() -> (clock: !seq.clock, reset: i1)
 // CHECK: hw.module @Top
 hw.module @Top() {
   %c0_i7 = hw.constant 0 : i7
-  // CHECK: %subsystem_pbus.clock, %subsystem_pbus.reset = hw.instance "subsystem_pbus" @PeripheryBus() -> (clock: i1, reset: i1)
-  %subsystem_pbus.clock, %subsystem_pbus.reset = hw.instance "subsystem_pbus" @PeripheryBus() -> (clock: i1, reset: i1)
+  // CHECK: %subsystem_pbus.clock, %subsystem_pbus.reset = hw.instance "subsystem_pbus" @PeripheryBus() -> (clock: !seq.clock, reset: i1)
+  %subsystem_pbus.clock, %subsystem_pbus.reset = hw.instance "subsystem_pbus" @PeripheryBus() -> (clock: !seq.clock, reset: i1)
   // CHECK: [[RST:%.+]] = comb.mux %subsystem_pbus.reset, %c0_i7, %int_rtc_tick_value : i7
   // CHECK: %int_rtc_tick_value = seq.compreg [[RST]], %subsystem_pbus.clock : i7
   %int_rtc_tick_value = seq.firreg %int_rtc_tick_value clock %subsystem_pbus.clock reset sync %subsystem_pbus.reset, %c0_i7 : i7

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -429,7 +429,7 @@ module {
   // CHECK: %symbol = seq.firreg
   // CHECK: %designAndTestCode = seq.firreg
   // CHECK-NOT: seq.firreg
-  hw.module @RegExtracted(%clock: i1, %reset: i1, %in: i1) -> (out: i1) {
+  hw.module @RegExtracted(%clock: !seq.clock, %reset: i1, %in: i1) -> (out: i1) {
     %muxed = comb.mux bin %reset, %in, %testCode1 : i1
     %testCode1 = seq.firreg %muxed clock %clock : i1
     %testCode2 = seq.firreg %testCode1 clock %clock : i1
@@ -437,7 +437,8 @@ module {
     %designAndTestCode = seq.firreg %in clock %clock : i1
     %deadReg = seq.firreg %testCode1 clock %clock : i1
 
-    sv.always posedge %clock {
+    %clk = seq.from_clock %clock
+    sv.always posedge %clk {
       sv.cover %testCode1, immediate
       sv.cover %testCode2, immediate
       sv.cover %designAndTestCode, immediate

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -3,7 +3,7 @@
 hw.module.extern @Observe(%x: i32)
 
 // CHECK-LABEL: @FirReg
-hw.module @FirReg(%clk: i1, %in: i32) {
+hw.module @FirReg(%clk: !seq.clock, %in: i32) {
   %false = hw.constant false
   %true = hw.constant true
 
@@ -12,9 +12,12 @@ hw.module @FirReg(%clk: i1, %in: i32) {
   hw.instance "reg0" @Observe(x: %reg0: i32) -> ()
   // CHECK: hw.instance "reg0" @Observe(x: %c0_i32: i32) -> ()
 
+  %clk_true = seq.to_clock %true
+  %clk_false = seq.to_clock %false
+
   // Registers that are never clocked should be replaced with a constant 0.
-  %reg1a = seq.firreg %in clock %false : i32
-  %reg1b = seq.firreg %in clock %true : i32
+  %reg1a = seq.firreg %in clock %clk_false : i32
+  %reg1b = seq.firreg %in clock %clk_true : i32
   hw.instance "reg1a" @Observe(x: %reg1a: i32) -> ()
   hw.instance "reg1b" @Observe(x: %reg1b: i32) -> ()
   // CHECK: hw.instance "reg1a" @Observe(x: %c0_i32: i32) -> ()
@@ -23,7 +26,7 @@ hw.module @FirReg(%clk: i1, %in: i32) {
 
 // Should not optimize away the register if it has a symbol.
 // CHECK-LABEL: @FirRegSymbol
-hw.module @FirRegSymbol(%clk: i1) -> (out : i32) {
+hw.module @FirRegSymbol(%clk: !seq.clock) -> (out : i32) {
   // CHECK: %reg = seq.firreg %reg clock %clk sym @reg : i32
   // CHECK: hw.output %reg : i32
   %reg = seq.firreg %reg clock %clk sym @reg : i32
@@ -31,7 +34,7 @@ hw.module @FirRegSymbol(%clk: i1) -> (out : i32) {
 }
 
 // CHECK-LABEL: @FirRegReset
-hw.module @FirRegReset(%clk: i1, %in: i32, %r : i1, %v : i32) {
+hw.module @FirRegReset(%clk: !seq.clock, %in: i32, %r : i1, %v : i32) {
   %false = hw.constant false
   %true = hw.constant true
 
@@ -57,8 +60,10 @@ hw.module @FirRegReset(%clk: i1, %in: i32, %r : i1, %v : i32) {
   // CHECK: hw.instance "reg2b" @Observe(x: %v: i32) -> ()
 
   // Registers that are never clocked should be replaced with their reset value.
-  %reg3a = seq.firreg %in clock %false reset sync %r, %v : i32
-  %reg3b = seq.firreg %in clock %true reset sync %r, %v : i32
+  %clk_true = seq.to_clock %true
+  %clk_false = seq.to_clock %false
+  %reg3a = seq.firreg %in clock %clk_false reset sync %r, %v : i32
+  %reg3b = seq.firreg %in clock %clk_true reset sync %r, %v : i32
   hw.instance "reg3a" @Observe(x: %reg3a: i32) -> ()
   hw.instance "reg3b" @Observe(x: %reg3b: i32) -> ()
   // CHECK: hw.instance "reg3a" @Observe(x: %v: i32) -> ()
@@ -66,7 +71,7 @@ hw.module @FirRegReset(%clk: i1, %in: i32, %r : i1, %v : i32) {
 }
 
 // CHECK-LABEL: @FirRegAggregate
-hw.module @FirRegAggregate(%clk: i1) -> (out : !hw.struct<foo: i32>) {
+hw.module @FirRegAggregate(%clk: !seq.clock) -> (out : !hw.struct<foo: i32>) {
   // TODO: Use constant aggregate attribute once supported.
   // CHECK:      %c0_i32 = hw.constant 0 : i32
   // CHECK-NEXT: %0 = hw.bitcast %c0_i32 : (i32) -> !hw.struct<foo: i32>
@@ -76,7 +81,7 @@ hw.module @FirRegAggregate(%clk: i1) -> (out : !hw.struct<foo: i32>) {
 }
 
 // CHECK-LABEL: @UninitializedArrayElement
-hw.module @UninitializedArrayElement(%a: i1, %clock: i1) -> (b: !hw.array<2xi1>) {
+hw.module @UninitializedArrayElement(%a: i1, %clock: !seq.clock) -> (b: !hw.array<2xi1>) {
   // CHECK:      %false = hw.constant false
   // CHECK-NEXT: %0 = hw.array_create %false, %a : i1
   // CHECK-NEXT: %r = seq.firreg %0 clock %clock : !hw.array<2xi1>
@@ -146,45 +151,50 @@ hw.module @ClockMux(%cond: i1, %trueClock: !seq.clock, %falseClock: !seq.clock) 
 }
 
 // CHECK-LABEL: @FirMem
-hw.module @FirMem(%addr: i4, %clock: i1, %data: i42) -> (out: i42) {
+hw.module @FirMem(%addr: i4, %clock: !seq.clock, %data: i42) -> (out: i42) {
   %true = hw.constant true
   %false = hw.constant false
   %c0_i3 = hw.constant 0 : i3
   %c-1_i3 = hw.constant -1 : i3
 
+  // CHECK: [[CLK_TRUE:%.+]] = seq.to_clock %true
+  %clk_true = seq.to_clock %true
+  // CHECK: [[CLK_FALSE:%.+]] = seq.to_clock %false
+  %clk_false = seq.to_clock %false
+
   // CHECK: [[MEM:%.+]] = seq.firmem
   %0 = seq.firmem 0, 1, undefined, undefined : <12 x 42, mask 3>
 
   // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock %clock :
-  %1 = seq.firmem.read_port %0[%addr], clock %clock enable %true : <12 x 42, mask 3>, i1
+  %1 = seq.firmem.read_port %0[%addr], clock %clock enable %true : <12 x 42, mask 3>
 
-  // CHECK-NEXT: seq.firmem.write_port %0[%addr] = %data, clock %clock {w0}
-  seq.firmem.write_port %0[%addr] = %data, clock %clock enable %true {w0} : <12 x 42, mask 3>, i1
+  // CHECK-NEXT: seq.firmem.write_port [[MEM]][%addr] = %data, clock %clock {w0}
+  seq.firmem.write_port %0[%addr] = %data, clock %clock enable %true {w0} : <12 x 42, mask 3>
   // CHECK-NOT: {w1}
-  seq.firmem.write_port %0[%addr] = %data, clock %clock enable %false {w1} : <12 x 42, mask 3>, i1
-  // CHECK-NEXT: seq.firmem.write_port %0[%addr] = %data, clock %clock {w2}
-  seq.firmem.write_port %0[%addr] = %data, clock %clock mask %c-1_i3 {w2} : <12 x 42, mask 3>, i1, i3
+  seq.firmem.write_port %0[%addr] = %data, clock %clock enable %false {w1} : <12 x 42, mask 3>
+  // CHECK-NEXT: seq.firmem.write_port [[MEM]][%addr] = %data, clock %clock {w2}
+  seq.firmem.write_port %0[%addr] = %data, clock %clock mask %c-1_i3 {w2} : <12 x 42, mask 3>, i3
   // CHECK-NOT: {w3}
-  seq.firmem.write_port %0[%addr] = %data, clock %clock mask %c0_i3 {w3} : <12 x 42, mask 3>, i1, i3
+  seq.firmem.write_port %0[%addr] = %data, clock %clock mask %c0_i3 {w3} : <12 x 42, mask 3>, i3
   // CHECK-NOT: {w4}
-  seq.firmem.write_port %0[%addr] = %data, clock %true {w4} : <12 x 42, mask 3>, i1
+  seq.firmem.write_port %0[%addr] = %data, clock %clk_true {w4} : <12 x 42, mask 3>
   // CHECK-NOT: {w5}
-  seq.firmem.write_port %0[%addr] = %data, clock %false {w5} : <12 x 42, mask 3>, i1
+  seq.firmem.write_port %0[%addr] = %data, clock %clk_false {w5} : <12 x 42, mask 3>
 
   // CHECK-NEXT: seq.firmem.read_write_port [[MEM]][%addr] = %data if %true, clock %clock {rw0}
-  %2 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clock enable %true {rw0} : <12 x 42, mask 3>, i1
+  %2 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clock enable %true {rw0} : <12 x 42, mask 3>
   // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock %clock enable %false {rw1}
-  %3 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clock enable %false {rw1} : <12 x 42, mask 3>, i1
+  %3 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clock enable %false {rw1} : <12 x 42, mask 3>
   // CHECK-NEXT: seq.firmem.read_write_port [[MEM]][%addr] = %data if %true, clock %clock {rw2}
-  %4 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clock mask %c-1_i3 {rw2} : <12 x 42, mask 3>, i1, i3
+  %4 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clock mask %c-1_i3 {rw2} : <12 x 42, mask 3>, i3
   // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock %clock {rw3}
-  %5 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clock mask %c0_i3 {rw3} : <12 x 42, mask 3>, i1, i3
+  %5 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clock mask %c0_i3 {rw3} : <12 x 42, mask 3>, i3
   // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock %clock {rw4}
-  %6 = seq.firmem.read_write_port %0[%addr] = %data if %false, clock %clock {rw4} : <12 x 42, mask 3>, i1
-  // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock %true {rw5}
-  %7 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %true {rw5} : <12 x 42, mask 3>, i1
-  // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock %false {rw6}
-  %8 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %false {rw6} : <12 x 42, mask 3>, i1
+  %6 = seq.firmem.read_write_port %0[%addr] = %data if %false, clock %clock {rw4} : <12 x 42, mask 3>
+  // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock [[CLK_TRUE]] {rw5}
+  %7 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clk_true {rw5} : <12 x 42, mask 3>
+  // CHECK-NEXT: seq.firmem.read_port [[MEM]][%addr], clock [[CLK_FALSE]] {rw6}
+  %8 = seq.firmem.read_write_port %0[%addr] = %data if %true, clock %clk_false {rw6} : <12 x 42, mask 3>
 
   %9 = comb.xor %1, %2, %3, %4, %5, %6, %7, %8 : i42
   hw.output %9 : i42

--- a/test/Dialect/Seq/firmem.mlir
+++ b/test/Dialect/Seq/firmem.mlir
@@ -22,33 +22,33 @@ hw.module @Basic() {
 }
 
 // CHECK-LABEL: hw.module @Ports
-hw.module @Ports(%clock: i1, %enable: i1, %address: i4, %data: i20, %mode: i1, %mask: i4) {
+hw.module @Ports(%clock: !seq.clock, %enable: i1, %address: i4, %data: i20, %mode: i1, %mask: i4) {
   // CHECK-NEXT: %mem = seq.firmem 0, 1, undefined, undefined : <12 x 20>
   // CHECK-NEXT: %mem2 = seq.firmem 0, 1, undefined, undefined : <12 x 20, mask 4>
   %mem = seq.firmem 0, 1, undefined, undefined : <12 x 20>
   %mem2 = seq.firmem 0, 1, undefined, undefined : <12 x 20, mask 4>
 
   // Read ports
-  // CHECK-NEXT: [[R0:%.+]] = seq.firmem.read_port %mem[%address], clock %clock : <12 x 20>, i1
-  // CHECK-NEXT: [[R1:%.+]] = seq.firmem.read_port %mem[%address], clock %clock enable %enable : <12 x 20>, i1
-  %0 = seq.firmem.read_port %mem[%address], clock %clock : <12 x 20>, i1
-  %1 = seq.firmem.read_port %mem[%address], clock %clock enable %enable : <12 x 20>, i1
+  // CHECK-NEXT: [[R0:%.+]] = seq.firmem.read_port %mem[%address], clock %clock : <12 x 20>
+  // CHECK-NEXT: [[R1:%.+]] = seq.firmem.read_port %mem[%address], clock %clock enable %enable : <12 x 20>
+  %0 = seq.firmem.read_port %mem[%address], clock %clock : <12 x 20>
+  %1 = seq.firmem.read_port %mem[%address], clock %clock enable %enable : <12 x 20>
 
   // Write ports
-  // CHECK-NEXT: seq.firmem.write_port %mem[%address] = %data, clock %clock : <12 x 20>, i1
-  // CHECK-NEXT: seq.firmem.write_port %mem[%address] = %data, clock %clock enable %enable : <12 x 20>, i1
-  // CHECK-NEXT: seq.firmem.write_port %mem2[%address] = %data, clock %clock mask %mask : <12 x 20, mask 4>, i1, i4
-  seq.firmem.write_port %mem[%address] = %data, clock %clock : <12 x 20>, i1
-  seq.firmem.write_port %mem[%address] = %data, clock %clock enable %enable : <12 x 20>, i1
-  seq.firmem.write_port %mem2[%address] = %data, clock %clock mask %mask : <12 x 20, mask 4>, i1, i4
+  // CHECK-NEXT: seq.firmem.write_port %mem[%address] = %data, clock %clock : <12 x 20>
+  // CHECK-NEXT: seq.firmem.write_port %mem[%address] = %data, clock %clock enable %enable : <12 x 20>
+  // CHECK-NEXT: seq.firmem.write_port %mem2[%address] = %data, clock %clock mask %mask : <12 x 20, mask 4>, i4
+  seq.firmem.write_port %mem[%address] = %data, clock %clock : <12 x 20>
+  seq.firmem.write_port %mem[%address] = %data, clock %clock enable %enable : <12 x 20>
+  seq.firmem.write_port %mem2[%address] = %data, clock %clock mask %mask : <12 x 20, mask 4>, i4
 
   // Read-write ports
-  // CHECK-NEXT: [[R2:%.+]] = seq.firmem.read_write_port %mem[%address] = %data if %mode, clock %clock : <12 x 20>, i1
-  // CHECK-NEXT: [[R3:%.+]] = seq.firmem.read_write_port %mem[%address] = %data if %mode, clock %clock enable %enable : <12 x 20>, i1
-  // CHECK-NEXT: [[R4:%.+]] = seq.firmem.read_write_port %mem2[%address] = %data if %mode, clock %clock mask %mask : <12 x 20, mask 4>, i1, i4
-  %2 = seq.firmem.read_write_port %mem[%address] = %data if %mode, clock %clock : <12 x 20>, i1
-  %3 = seq.firmem.read_write_port %mem[%address] = %data if %mode, clock %clock enable %enable : <12 x 20>, i1
-  %4 = seq.firmem.read_write_port %mem2[%address] = %data if %mode, clock %clock mask %mask : <12 x 20, mask 4>, i1, i4
+  // CHECK-NEXT: [[R2:%.+]] = seq.firmem.read_write_port %mem[%address] = %data if %mode, clock %clock : <12 x 20>
+  // CHECK-NEXT: [[R3:%.+]] = seq.firmem.read_write_port %mem[%address] = %data if %mode, clock %clock enable %enable : <12 x 20>
+  // CHECK-NEXT: [[R4:%.+]] = seq.firmem.read_write_port %mem2[%address] = %data if %mode, clock %clock mask %mask : <12 x 20, mask 4>, i4
+  %2 = seq.firmem.read_write_port %mem[%address] = %data if %mode, clock %clock : <12 x 20>
+  %3 = seq.firmem.read_write_port %mem[%address] = %data if %mode, clock %clock enable %enable : <12 x 20>
+  %4 = seq.firmem.read_write_port %mem2[%address] = %data if %mode, clock %clock mask %mask : <12 x 20, mask 4>, i4
 
   // CHECK-NEXT: comb.xor [[R0]], [[R1]], [[R2]], [[R3]], [[R4]]
   comb.xor %0, %1, %2, %3, %4 : i20

--- a/test/Dialect/Seq/firreg-errors.mlir
+++ b/test/Dialect/Seq/firreg-errors.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s -verify-diagnostics --split-input-file
 
-hw.module @NeedsBothResetAndResetValue(%input: i1, %clk: i1) {
+hw.module @NeedsBothResetAndResetValue(%input: i1, %clk: !seq.clock) {
   // expected-error@+1 {{'seq.firreg' op must specify reset and reset value}}
-  "seq.firreg"(%input, %clk) { name = "reg", isAsync } : (i1, i1) -> i1
+  "seq.firreg"(%input, %clk) { name = "reg", isAsync } : (i1, !seq.clock) -> i1
 }

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -4,7 +4,7 @@
 
 // COMMON-LABEL: hw.module @lowering
 // SEPARATE-LABEL: hw.module @lowering
-hw.module @lowering(%clk: i1, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) {
+hw.module @lowering(%clk: !seq.clock, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) {
   %cst0 = hw.constant 0 : i32
 
   // CHECK: %rA = sv.reg sym @regA : !hw.inout<i32>
@@ -161,7 +161,7 @@ hw.module @lowering(%clk: i1, %rst: i1, %in: i32) -> (a: i32, b: i32, c: i32, d:
 }
 
 // COMMON-LABEL: hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
-hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
+hw.module private @UninitReg1(%clock: !seq.clock, %reset: i1, %cond: i1, %value: i2) {
   // CHECK: %c0_i2 = hw.constant 0 : i2
   %c0_i2 = hw.constant 0 : i2
   // CHECK-NEXT: %count = sv.reg sym @count : !hw.inout<i2>
@@ -216,7 +216,7 @@ hw.module private @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
   hw.output
 }
 // COMMON-LABEL: hw.module private @UninitReg1_nonbin(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
-hw.module private @UninitReg1_nonbin(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
+hw.module private @UninitReg1_nonbin(%clock: !seq.clock, %reset: i1, %cond: i1, %value: i2) {
   // CHECK: %c0_i2 = hw.constant 0 : i2
   %c0_i2 = hw.constant 0 : i2
   // CHECK-NEXT: %count = sv.reg sym @count : !hw.inout<i2>
@@ -249,7 +249,7 @@ hw.module private @UninitReg1_nonbin(%clock: i1, %reset: i1, %cond: i1, %value: 
 //     reg <= mux(io_en, io_d, reg)
 
 // COMMON-LABEL: hw.module private @InitReg1(
-hw.module private @InitReg1(%clock: i1, %reset: i1, %io_d: i32, %io_en: i1) -> (io_q: i32) {
+hw.module private @InitReg1(%clock: !seq.clock, %reset: i1, %io_d: i32, %io_en: i1) -> (io_q: i32) {
   %false = hw.constant false
   %c1_i32 = hw.constant 1 : i32
   %c0_i32 = hw.constant 0 : i32
@@ -333,7 +333,7 @@ hw.module private @InitReg1(%clock: i1, %reset: i1, %io_d: i32, %io_en: i1) -> (
 }
 
 // COMMON-LABEL: hw.module private @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
-hw.module private @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
+hw.module private @UninitReg42(%clock: !seq.clock, %reset: i1, %cond: i1, %value: i42) {
   %c0_i42 = hw.constant 0 : i42
   %count = seq.firreg %1 clock %clock sym @count : i42
   %0 = comb.mux %cond, %value, %count : i42
@@ -376,7 +376,7 @@ hw.module private @UninitReg42(%clock: i1, %reset: i1, %cond: i1, %value: i42) {
 }
 
 // COMMON-LABEL: hw.module private @init1DVector
-hw.module private @init1DVector(%clock: i1, %a: !hw.array<2xi1>) -> (b: !hw.array<2xi1>) {
+hw.module private @init1DVector(%clock: !seq.clock, %a: !hw.array<2xi1>) -> (b: !hw.array<2xi1>) {
   %r = seq.firreg %a clock %clock sym @__r__ : !hw.array<2xi1>
 
   // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
@@ -425,7 +425,7 @@ hw.module private @init1DVector(%clock: i1, %a: !hw.array<2xi1>) -> (b: !hw.arra
 }
 
 // COMMON-LABEL: hw.module private @init2DVector
-hw.module private @init2DVector(%clock: i1, %a: !hw.array<1xarray<1xi1>>) -> (b: !hw.array<1xarray<1xi1>>) {
+hw.module private @init2DVector(%clock: !seq.clock, %a: !hw.array<1xarray<1xi1>>) -> (b: !hw.array<1xarray<1xi1>>) {
   %r = seq.firreg %a clock %clock sym @__r__ : !hw.array<1xarray<1xi1>>
 
   // CHECK:      sv.always posedge %clock  {
@@ -467,7 +467,7 @@ hw.module private @init2DVector(%clock: i1, %a: !hw.array<1xarray<1xi1>>) -> (b:
 }
 
 // COMMON-LABEL: hw.module private @initStruct
-hw.module private @initStruct(%clock: i1) {
+hw.module private @initStruct(%clock: !seq.clock) {
   %r = seq.firreg %r clock %clock sym @__r__ : !hw.struct<a: i1>
 
   // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
@@ -497,7 +497,7 @@ hw.module private @initStruct(%clock: i1) {
 
 // COMMON-LABEL: issue1594
 // Make sure LowerToHW's merging of always blocks kicks in for this example.
-hw.module @issue1594(%clock: i1, %reset: i1, %a: i1) -> (b: i1) {
+hw.module @issue1594(%clock: !seq.clock, %reset: i1, %a: i1) -> (b: i1) {
   %true = hw.constant true
   %false = hw.constant false
   %reset_n = sv.wire sym @__issue1594__reset_n  : !hw.inout<i1>
@@ -514,7 +514,7 @@ hw.module @issue1594(%clock: i1, %reset: i1, %a: i1) -> (b: i1) {
 // Check that deeply nested if statement creation doesn't cause any issue.
 // COMMON-LABEL: @DeeplyNestedIfs
 // CHECK-COUNT-17: sv.if
-hw.module @DeeplyNestedIfs(%a_0: i1, %a_1: i1, %a_2: i1, %c_0_0: i1, %c_0_1: i1, %c_1_0: i1, %c_1_1: i1, %c_2_0: i1, %c_2_1: i1, %clock: i1) -> (out_0: i1, out_1: i1) {
+hw.module @DeeplyNestedIfs(%a_0: i1, %a_1: i1, %a_2: i1, %c_0_0: i1, %c_0_1: i1, %c_1_0: i1, %c_1_1: i1, %c_2_0: i1, %c_2_1: i1, %clock: !seq.clock) -> (out_0: i1, out_1: i1) {
   %r_0 = seq.firreg %25 clock %clock {firrtl.random_init_start = 0 : ui64} : i1
   %r_1 = seq.firreg %51 clock %clock {firrtl.random_init_start = 1 : ui64} : i1
   %0 = comb.mux bin %a_1, %c_1_0, %c_0_0 : i1
@@ -573,7 +573,7 @@ hw.module @DeeplyNestedIfs(%a_0: i1, %a_1: i1, %a_2: i1, %c_0_0: i1, %c_0_1: i1,
 }
 
 // COMMON-LABEL: @ArrayElements
-hw.module @ArrayElements(%a: !hw.array<2xi1>, %clock: i1, %cond: i1) -> (b: !hw.array<2xi1>) {
+hw.module @ArrayElements(%a: !hw.array<2xi1>, %clock: !seq.clock, %cond: i1) -> (b: !hw.array<2xi1>) {
   %false = hw.constant false
   %true = hw.constant true
   %0 = hw.array_get %a[%true] : !hw.array<2xi1>, i1
@@ -601,7 +601,7 @@ hw.module @ArrayElements(%a: !hw.array<2xi1>, %clock: i1, %cond: i1) -> (b: !hw.
 // inferred latches that would otherwise happen.
 //
 // COMMON-LABEL: @AsyncResetUndriven
-hw.module @AsyncResetUndriven(%clock: i1, %reset: i1) -> (q: i32) {
+hw.module @AsyncResetUndriven(%clock: !seq.clock, %reset: i1) -> (q: i32) {
   %c0_i32 = hw.constant 0 : i32
   %r = seq.firreg %r clock %clock sym @r reset async %reset, %c0_i32 {firrtl.random_init_start = 0 : ui64} : i32
   hw.output %r : i32
@@ -614,7 +614,7 @@ hw.module @AsyncResetUndriven(%clock: i1, %reset: i1) -> (q: i32) {
 }
 
 // CHECK-LABEL: @Subaccess
-hw.module @Subaccess(%clock: i1, %en: i1, %addr: i2, %data: i32) -> (out: !hw.array<3xi32>) {
+hw.module @Subaccess(%clock: !seq.clock, %en: i1, %addr: i2, %data: i32) -> (out: !hw.array<3xi32>) {
   %c0_i2 = hw.constant 0 : i2
   %c1_i2 = hw.constant 1 : i2
   %c-2_i2 = hw.constant -2 : i2
@@ -655,7 +655,7 @@ hw.module @Subaccess(%clock: i1, %en: i1, %addr: i2, %data: i32) -> (out: !hw.ar
 //  else:
 //    r[addr_3] <= data_3
 //
-hw.module @NestedSubaccess(%clock: i1, %en_0: i1, %en_1: i1, %en_2: i1, %addr_0: i2, %addr_1: i2, %addr_2: i2, %addr_3: i2, %data_0: i32, %data_1: i32, %data_2: i32, %data_3: i32) -> () {
+hw.module @NestedSubaccess(%clock: !seq.clock, %en_0: i1, %en_1: i1, %en_2: i1, %addr_0: i2, %addr_1: i2, %addr_2: i2, %addr_3: i2, %data_0: i32, %data_1: i32, %data_2: i32, %data_3: i32) -> () {
   %c0_i2 = hw.constant 0 : i2
   %c1_i2 = hw.constant 1 : i2
   %c-2_i2 = hw.constant -2 : i2
@@ -729,7 +729,7 @@ hw.module @NestedSubaccess(%clock: i1, %en_0: i1, %en_1: i1, %en_2: i1, %addr_0:
 }
 
 // CHECK-LABEL: @with_preset
-hw.module @with_preset(%clock: i1, %reset: i1, %next32: i32, %next16: i16) -> () {
+hw.module @with_preset(%clock: !seq.clock, %reset: i1, %next32: i32, %next16: i16) -> () {
   %preset_0 = seq.firreg %next32 clock %clock preset 0 : i32
   %preset_42 = seq.firreg %next16 clock %clock preset 42 : i16
 
@@ -744,7 +744,7 @@ hw.module @with_preset(%clock: i1, %reset: i1, %next32: i32, %next16: i16) -> ()
 }
 
 // CHECK-LABEL: @reg_of_clock_type
-hw.module @reg_of_clock_type(%clk: i1, %rst: i1, %i: !seq.clock) -> (out: !seq.clock) {
+hw.module @reg_of_clock_type(%clk: !seq.clock, %rst: i1, %i: !seq.clock) -> (out: !seq.clock) {
   // CHECK: [[REG0:%.+]] = sv.reg : !hw.inout<i1>
   // CHECK: [[REG0_READ:%.+]] = sv.read_inout [[REG0]] : !hw.inout<i1>
   %r0 = seq.firreg %i clock %clk : !seq.clock

--- a/test/Dialect/Seq/lower-firmem.mlir
+++ b/test/Dialect/Seq/lower-firmem.mlir
@@ -11,33 +11,32 @@ sv.macro.decl @SomeMacro
 // CHECK: hw.module.generated @m0_mem4_12x42, @FIRRTLMem(%R0_addr: i4, %R0_en: i1, %R0_clk: !seq.clock, %RW0_addr: i4, %RW0_en: i1, %RW0_clk: !seq.clock, %RW0_wmode: i1, %RW0_wdata: i42, %RW0_wmask: i6, %W0_addr: i4, %W0_en: i1, %W0_clk: !seq.clock, %W0_data: i42, %W0_mask: i6) -> (R0_data: i42, RW0_rdata: i42) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 7 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 42 : ui32, writeClockIDs = [0 : i32, 0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
 // CHECK-LABEL: hw.module @Foo
-hw.module @Foo(%clk: i1, %en: i1, %addr: i4, %wdata: i42, %wmode: i1, %mask2: i2, %mask3: i3, %mask6: i6) {
-  // CHECK-NEXT: [[CLK:%.+]] = seq.to_clock %clk
-  // CHECK-NEXT: [[TMP0:%.+]] = hw.instance "m0_mem1A_ext" @m0_mem1_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: [[CLK]]: !seq.clock) -> (R0_data: i42)
-  // CHECK-NEXT: [[TMP1:%.+]] = hw.instance "m0_mem1B_ext" @m0_mem1_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: [[CLK]]: !seq.clock) -> (R0_data: i42)
+hw.module @Foo(%clk: !seq.clock, %en: i1, %addr: i4, %wdata: i42, %wmode: i1, %mask2: i2, %mask3: i3, %mask6: i6) {
+  // CHECK-NEXT: [[TMP0:%.+]] = hw.instance "m0_mem1A_ext" @m0_mem1_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: !seq.clock) -> (R0_data: i42)
+  // CHECK-NEXT: [[TMP1:%.+]] = hw.instance "m0_mem1B_ext" @m0_mem1_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: !seq.clock) -> (R0_data: i42)
   // CHECK-NEXT: comb.xor [[TMP0]], [[TMP1]]
   %m0_mem1A = seq.firmem 0, 1, undefined, port_order : <12 x 42>
   %m0_mem1B = seq.firmem 0, 1, undefined, port_order : <12 x 42>
-  %0 = seq.firmem.read_port %m0_mem1A[%addr], clock %clk enable %en : <12 x 42>, i1
-  %1 = seq.firmem.read_port %m0_mem1B[%addr], clock %clk enable %en : <12 x 42>, i1
+  %0 = seq.firmem.read_port %m0_mem1A[%addr], clock %clk enable %en : <12 x 42>
+  %1 = seq.firmem.read_port %m0_mem1B[%addr], clock %clk enable %en : <12 x 42>
   comb.xor %0, %1 : i42
 
-  // CHECK-NEXT: hw.instance "m0_mem2_ext" @m0_mem2_12x42(W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: [[CLK]]: !seq.clock, W0_data: %wdata: i42, W0_mask: %mask2: i2) -> ()
+  // CHECK-NEXT: hw.instance "m0_mem2_ext" @m0_mem2_12x42(W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: %clk: !seq.clock, W0_data: %wdata: i42, W0_mask: %mask2: i2) -> ()
   %m0_mem2 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 2>
-  seq.firmem.write_port %m0_mem2[%addr] = %wdata, clock %clk enable %en mask %mask2 : <12 x 42, mask 2>, i1, i2
+  seq.firmem.write_port %m0_mem2[%addr] = %wdata, clock %clk enable %en mask %mask2 : <12 x 42, mask 2>, i2
 
-  // CHECK-NEXT: [[TMP:%.+]] = hw.instance "m0_mem3_ext" @m0_mem3_12x42(RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: [[CLK]]: !seq.clock, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask3: i3) -> (RW0_rdata: i42)
+  // CHECK-NEXT: [[TMP:%.+]] = hw.instance "m0_mem3_ext" @m0_mem3_12x42(RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: %clk: !seq.clock, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask3: i3) -> (RW0_rdata: i42)
   // CHECK-NEXT: comb.xor [[TMP]]
   %m0_mem3 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 3>
-  %2 = seq.firmem.read_write_port %m0_mem3[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask3 : <12 x 42, mask 3>, i1, i3
+  %2 = seq.firmem.read_write_port %m0_mem3[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask3 : <12 x 42, mask 3>, i3
   comb.xor %2 : i42
 
-  // CHECK-NEXT: [[TMP0:%.+]], [[TMP1:%.+]] = hw.instance "m0_mem4_ext" @m0_mem4_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: [[CLK]]: !seq.clock, RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: [[CLK]]: !seq.clock, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask6: i6, W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: [[CLK]]: !seq.clock, W0_data: %wdata: i42, W0_mask: %mask6: i6) -> (R0_data: i42, RW0_rdata: i42)
+  // CHECK-NEXT: [[TMP0:%.+]], [[TMP1:%.+]] = hw.instance "m0_mem4_ext" @m0_mem4_12x42(R0_addr: %addr: i4, R0_en: %en: i1, R0_clk: %clk: !seq.clock, RW0_addr: %addr: i4, RW0_en: %en: i1, RW0_clk: %clk: !seq.clock, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i42, RW0_wmask: %mask6: i6, W0_addr: %addr: i4, W0_en: %en: i1, W0_clk: %clk: !seq.clock, W0_data: %wdata: i42, W0_mask: %mask6: i6) -> (R0_data: i42, RW0_rdata: i42)
   // CHECK-NEXT: comb.xor [[TMP0]], [[TMP1]]
   %m0_mem4 = seq.firmem 0, 1, undefined, port_order : <12 x 42, mask 6>
-  %3 = seq.firmem.read_port %m0_mem4[%addr], clock %clk enable %en : <12 x 42, mask 6>, i1
-  %4 = seq.firmem.read_write_port %m0_mem4[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask6 : <12 x 42, mask 6>, i1, i6
-  seq.firmem.write_port %m0_mem4[%addr] = %wdata, clock %clk enable %en mask %mask6 : <12 x 42, mask 6>, i1, i6
+  %3 = seq.firmem.read_port %m0_mem4[%addr], clock %clk enable %en : <12 x 42, mask 6>
+  %4 = seq.firmem.read_write_port %m0_mem4[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask6 : <12 x 42, mask 6>, i6
+  seq.firmem.write_port %m0_mem4[%addr] = %wdata, clock %clk enable %en mask %mask6 : <12 x 42, mask 6>, i6
   comb.xor %3, %4 : i42
 }
 
@@ -72,7 +71,7 @@ hw.module @SeparatePrefices() {
 // CHECK: hw.module.generated @m3_mem2_12x8, @FIRRTLMem(%W0_addr: i4, %W0_en: i1, %W0_clk: !seq.clock, %W0_data: i8, %W1_addr: i4, %W1_en: i1, %W1_clk: !seq.clock, %W1_data: i8) attributes {depth = 12 : i64, initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 8 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 2 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 8 : ui32, writeClockIDs = [0 : i32, 1 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
 
 // CHECK-LABEL: hw.module @MemoryWritePortBehavior
-hw.module @MemoryWritePortBehavior(%clock1: i1, %clock2: i1) {
+hw.module @MemoryWritePortBehavior(%clock1: !seq.clock, %clock2: !seq.clock) {
   %z_i8 = sv.constantZ : i8
   %z_i1 = sv.constantZ : i1
   %z_i4 = sv.constantZ : i4
@@ -83,18 +82,18 @@ hw.module @MemoryWritePortBehavior(%clock1: i1, %clock2: i1) {
   //
   // CHECK: hw.instance "m3_mem1_ext" @m3_mem_12x8
   %m3_mem1 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
-  %cwire1 = hw.wire %clock1 : i1
-  %cwire2 = hw.wire %clock1 : i1
-  seq.firmem.write_port %m3_mem1[%z_i4] = %z_i8, clock %cwire1 enable %z_i1 : <12 x 8>, i1
-  seq.firmem.write_port %m3_mem1[%z_i4] = %z_i8, clock %cwire2 enable %z_i1 : <12 x 8>, i1
+  %cwire1 = hw.wire %clock1 : !seq.clock
+  %cwire2 = hw.wire %clock1 : !seq.clock
+  seq.firmem.write_port %m3_mem1[%z_i4] = %z_i8, clock %cwire1 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %m3_mem1[%z_i4] = %z_i8, clock %cwire2 enable %z_i1 : <12 x 8>
 
   // This memory has different clocks for each write port. It should be
   // lowered to an "ab" memory.
   //
   // CHECK: hw.instance "m3_mem2_ext" @m3_mem2_12x8
   %m3_mem2 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
-  seq.firmem.write_port %m3_mem2[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>, i1
-  seq.firmem.write_port %m3_mem2[%z_i4] = %z_i8, clock %clock2 enable %z_i1 : <12 x 8>, i1
+  seq.firmem.write_port %m3_mem2[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %m3_mem2[%z_i4] = %z_i8, clock %clock2 enable %z_i1 : <12 x 8>
 
   // This memory is the same as the first memory, but a node is used to alias
   // the second write port clock (e.g., this could be due to a dont touch
@@ -103,6 +102,6 @@ hw.module @MemoryWritePortBehavior(%clock1: i1, %clock2: i1) {
   //
   // CHECK: hw.instance "m3_mem3_ext" @m3_mem_12x8
   %m3_mem3 = seq.firmem 0, 1, undefined, port_order : <12 x 8>
-  seq.firmem.write_port %m3_mem3[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>, i1
-  seq.firmem.write_port %m3_mem3[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>, i1
+  seq.firmem.write_port %m3_mem3[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
+  seq.firmem.write_port %m3_mem3[%z_i4] = %z_i8, clock %clock1 enable %z_i1 : <12 x 8>
 }

--- a/test/Dialect/Seq/round-trip.mlir
+++ b/test/Dialect/Seq/round-trip.mlir
@@ -74,7 +74,7 @@ hw.module @fifo2(%clk : i1, %rst : i1, %in : i32, %rdEn : i1, %wrEn : i1) -> () 
 }
 
 
-hw.module @preset(%clock : i1, %reset : i1, %next : i32) -> () {
+hw.module @preset(%clock : !seq.clock, %reset : i1, %next : i32) -> () {
   // CHECK: %reg = seq.firreg %next clock %clock preset 0 : i32
   %reg = seq.firreg %next clock %clock preset 0 : i32
 }

--- a/test/firtool/has_been_reset.fir
+++ b/test/firtool/has_been_reset.fir
@@ -30,6 +30,7 @@ circuit Foo:
     hbr[1] <= int2.out
 
 ; CHECK-LABEL: hw.module @Foo
-; CHECK-NEXT: verif.has_been_reset %clock, sync %reset1
-; CHECK-NEXT: verif.has_been_reset %clock, async %reset2
+; CHECK-NEXT: [[CLOCK:%.+]] = seq.from_clock %clock
+; CHECK-NEXT: verif.has_been_reset [[CLOCK]], sync %reset1
+; CHECK-NEXT: verif.has_been_reset [[CLOCK]], async %reset2
 ; CHECK-NEXT: hw.output


### PR DESCRIPTION
This PR forces the use of the clock type with `seq.firreg` and `seq.firmem`.

The new `firtool` version was tested on a large internal core.

Part of #5851 
