### PR TITLE
[NFC] Replace isAnyModule with an isa test.

### DIFF
--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -55,9 +55,6 @@ void modifyModulePorts(Operation *op,
 
 // Helpers for working with modules.
 
-/// Return true if this is an hw.module, external module, generated module etc.
-bool isAnyModule(Operation *module);
-
 /// Return true if isAnyModule or instance.
 bool isAnyModuleOrInstance(Operation *module);
 

--- a/include/circt/Dialect/HW/InstanceImplementation.h
+++ b/include/circt/Dialect/HW/InstanceImplementation.h
@@ -30,8 +30,7 @@ namespace instance_like_impl {
 using EmitErrorFn =
     std::function<void(std::function<bool(InFlightDiagnostic &)>)>;
 
-/// Convenience function to query the input and result names of a HW module (as
-/// determined by 'hw::isAnyModule').
+/// Convenience function to query the input and result names of a HW module.
 std::pair<ArrayAttr, ArrayAttr> getHWModuleArgAndResultNames(Operation *module);
 
 /// Return a pointer to the referenced module operation.
@@ -39,8 +38,7 @@ Operation *getReferencedModule(const HWSymbolCache *cache,
                                Operation *instanceOp,
                                mlir::FlatSymbolRefAttr moduleName);
 
-/// Verify that the instance refers to a valid HW module as determined by the
-/// 'hw::isAnyModule' function.
+/// Verify that the instance refers to a valid HW module.
 LogicalResult verifyReferencedModule(Operation *instanceOp,
                                      SymbolTableCollection &symbolTable,
                                      mlir::FlatSymbolRefAttr moduleName,

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -13,20 +13,6 @@
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
 
-/// Ensure symbol is one of the hw module.* types
-def isModuleSymbol : AttrConstraint<
-  CPred<
-    "hw::isAnyModule(::mlir::SymbolTable::lookupNearestSymbolFrom("
-      "&$_op, $_self.cast<::mlir::FlatSymbolRefAttr>().getValue()))"
-  >, "is module like">;
-
-/// Ensure symbol is one of the sv macro.* types
-def isMacroSymbol : AttrConstraint<
-  CPred<
-    "sv::isAnyMacro(::mlir::SymbolTable::lookupNearestSymbolFrom("
-      "&$_op, $_self.cast<::mlir::FlatSymbolRefAttr>().getValue()))"
-  >, "is macro like">;
-
 //===----------------------------------------------------------------------===//
 // Control flow like-operations
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -498,14 +498,9 @@ OpFoldResult ParamValueOp::fold(FoldAdaptor adaptor) {
 // HWModuleOp
 //===----------------------------------------------------------------------===/
 
-/// Return true if this is an hw.module, external module, generated module etc.
-bool hw::isAnyModule(Operation *module) {
-  return isa<HWModuleOp, HWModuleExternOp, HWModuleGeneratedOp>(module);
-}
-
 /// Return true if isAnyModule or instance.
 bool hw::isAnyModuleOrInstance(Operation *moduleOrInstance) {
-  return isAnyModule(moduleOrInstance) || isa<InstanceOp>(moduleOrInstance);
+  return isa<HWModuleLike, InstanceOp>(moduleOrInstance);
 }
 
 /// Return the signature for a module as a function type from the module itself
@@ -523,8 +518,6 @@ FunctionType hw::getModuleType(Operation *moduleOrInstance) {
   if (auto mod = dyn_cast<HWModuleLike>(moduleOrInstance))
     return mod.getHWModuleType().getFuncType();
 
-  assert(isAnyModule(moduleOrInstance) &&
-         "must be called on instance or module");
   return cast<mlir::FunctionOpInterface>(moduleOrInstance)
       .getFunctionType()
       .cast<FunctionType>();
@@ -1149,7 +1142,7 @@ void HWModuleOp::print(OpAsmPrinter &p) {
 }
 
 static LogicalResult verifyModuleCommon(HWModuleLike module) {
-  assert(isAnyModule(module) &&
+  assert(isa<HWModuleLike>(module) &&
          "verifier hook should only be called on modules");
 
   auto moduleType = module.getHWModuleType();

--- a/lib/Dialect/HW/InstanceImplementation.cpp
+++ b/lib/Dialect/HW/InstanceImplementation.cpp
@@ -15,10 +15,9 @@ using namespace circt::hw;
 
 std::pair<ArrayAttr, ArrayAttr>
 instance_like_impl::getHWModuleArgAndResultNames(Operation *module) {
-  assert(isAnyModule(module) && "Can only reference a module");
-
-  return {module->getAttrOfType<ArrayAttr>("argNames"),
-          module->getAttrOfType<ArrayAttr>("resultNames")};
+  auto mod = cast<HWModuleLike>(module);
+  return {ArrayAttr::get(module->getContext(), mod.getInputNames()),
+          ArrayAttr::get(module->getContext(), mod.getOutputNames())};
 }
 
 Operation *
@@ -42,7 +41,7 @@ LogicalResult instance_like_impl::verifyReferencedModule(
            << moduleName.getValue() << "'";
 
   // It must be some sort of module.
-  if (!hw::isAnyModule(module))
+  if (!isa<HWModuleLike>(module))
     return instanceOp->emitError("symbol reference '")
            << moduleName.getValue() << "' isn't a module";
 

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -390,8 +390,7 @@ LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
            << getModuleName() << "'";
 
   // It must be some sort of module.
-  if (!hw::isAnyModule(module) &&
-      !isa<MSFTModuleOp, MSFTModuleExternOp>(module))
+  if (!isa<hw::HWModuleLike>(module))
     return emitError("symbol reference '")
            << getModuleName() << "' isn't a module";
   return success();

--- a/lib/Dialect/MSFT/Transforms/MSFTPartition.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTPartition.cpp
@@ -305,7 +305,7 @@ static StringRef getOperandName(OpOperand &oper, const SymbolCache &syms,
   if (auto inst = dyn_cast<InstanceOp>(op)) {
     Operation *modOp = syms.getDefinition(inst.getModuleNameAttr());
     if (modOp) { // If modOp isn't in the cache, it's probably a new module;
-      assert(isAnyModule(modOp) && "Instance must point to a module");
+      assert(isa<hw::HWModuleLike>(modOp) && "Instance must point to a module");
       auto mod = cast<hw::HWModuleLike>(modOp);
       return mod.getInputName(oper.getOperandNumber());
     }

--- a/lib/Dialect/MSFT/Transforms/MSFTToHW.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTToHW.cpp
@@ -53,7 +53,7 @@ InstanceOpLowering::matchAndRewrite(InstanceOp msftInst, OpAdaptor adaptor,
   if (!referencedModule)
     return rewriter.notifyMatchFailure(msftInst,
                                        "Could not find referenced module");
-  if (!hw::isAnyModule(referencedModule))
+  if (!isa<hw::HWModuleLike>(referencedModule))
     return rewriter.notifyMatchFailure(
         msftInst, "Referenced module was not an HW module");
 

--- a/lib/Dialect/MSFT/Transforms/PassDetails.h
+++ b/lib/Dialect/MSFT/Transforms/PassDetails.h
@@ -26,9 +26,6 @@
 namespace circt {
 namespace msft {
 
-/// TODO: Migrate these to some sort of OpInterface shared with hw.
-bool isAnyModule(Operation *module);
-
 /// Utility for creating {0, 1, 2, ..., size}.
 SmallVector<unsigned> makeSequentialRange(unsigned size);
 


### PR DESCRIPTION
This accepts slightly different operations in a couple places (more permissive), but I don't think this is a problem for any of the pipelines.