### PR TITLE
[ESI] Channel bundle type and pack/unpack ops

### DIFF
--- a/include/circt/Dialect/ESI/ESIChannels.td
+++ b/include/circt/Dialect/ESI/ESIChannels.td
@@ -15,6 +15,7 @@
 
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
+include "mlir/IR/OpAsmInterface.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 
 include "circt/Dialect/HW/HWTypes.td"
@@ -211,7 +212,7 @@ def UnitParameter : AttrOrTypeParameter<"::mlir::UnitAttr", "boolean flag"> {
 }
 
 def ChannelDirection : I32EnumAttr<"ChannelDirection",
-  "Direction of channel", [
+  "Direction of channel (see ChannelBundleImpl for details)", [
     I32EnumAttrCase<"to", 1>,
     I32EnumAttrCase<"from", 2>,
   ]>;
@@ -245,7 +246,9 @@ def ChannelBundleImpl : ESI_Type<"ChannelBundle"> {
 }
 
 
-def PackBundleOp : ESI_Op<"bundle.pack", []> {
+def PackBundleOp : ESI_Op<"bundle.pack", [
+      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+    ]> {
   let summary = "pack channels into a bundle";
 
   let arguments = (ins Variadic<ChannelType>:$toChannels);
@@ -257,7 +260,9 @@ def PackBundleOp : ESI_Op<"bundle.pack", []> {
   }];
 }
 
-def UnpackBundleOp : ESI_Op<"bundle.unpack", []> {
+def UnpackBundleOp : ESI_Op<"bundle.unpack", [
+      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+    ]> {
   let summary = "unpack channels from a bundle";
 
   let arguments = (ins ChannelBundleImpl:$bundle,

--- a/include/circt/Dialect/ESI/ESIChannels.td
+++ b/include/circt/Dialect/ESI/ESIChannels.td
@@ -198,6 +198,78 @@ def UnwrapSVInterfaceOp : ESI_Op<"unwrap.iface", [
 }
 
 //===----------------------------------------------------------------------===//
+// Channel bundles
+//===----------------------------------------------------------------------===//
+
+// Used to indicate the presence of a keyword in asm. Should be used within
+// optional parens in the declarative assembly format.
+// Upstreaming: https://github.com/llvm/llvm-project/pull/65438
+def UnitParameter : AttrOrTypeParameter<"::mlir::UnitAttr", "boolean flag"> {
+  let printer = "";
+  let parser = "::mlir::UnitAttr::get($_parser.getContext())";
+  let defaultValue = "::mlir::UnitAttr()";
+}
+
+def ChannelDirection : I32EnumAttr<"ChannelDirection",
+  "Direction of channel", [
+    I32EnumAttrCase<"to", 1>,
+    I32EnumAttrCase<"from", 2>,
+  ]>;
+
+def ChannelBundleImpl : ESI_Type<"ChannelBundle"> {
+  let summary = "a group of related channels";
+
+  let description = [{
+    A channel bundle (sometimes referred to as just "bundle") is a set of
+    channels of associated signals, along with per-channel names and directions.
+    The prototypical example for a bundle is a request-response channel pair.
+
+    The direction terminology is a bit confusing. Let us designate the module
+    which is outputting the bundle as the "sender" module and a module which has
+    a bundle as an input as the "receiver". The directions "from" and "to" are
+    from the senders perspective. So, the "to" direction means that channel is
+    transmitting messages from the sender to the receiver. Then, "from" means
+    that the sender is getting messages from the receiver (typically responses).
+
+    When requesting a bundle from a service, the client is always considered the
+    sender. So the "to" direction is for the client to send messages to the
+    service.
+  }];
+
+  let mnemonic = "bundle";
+  let parameters = (ins ArrayRefParameter<"BundledChannel">:$channels,
+                        UnitParameter:$resettable);
+  let assemblyFormat = [{
+    `<` `[` $channels `]` (`reset` $resettable^)? `>`
+  }];
+}
+
+
+def PackBundleOp : ESI_Op<"bundle.pack", []> {
+  let summary = "pack channels into a bundle";
+
+  let arguments = (ins Variadic<ChannelType>:$toChannels);
+  let results =  (outs ChannelBundleImpl:$bundle,
+                       Variadic<ChannelType>:$fromChannels);
+  let assemblyFormat = [{
+    `to` $toChannels attr-dict `:` custom<UnPackBundleType>(
+      type($toChannels), type($fromChannels), type($bundle))
+  }];
+}
+
+def UnpackBundleOp : ESI_Op<"bundle.unpack", []> {
+  let summary = "unpack channels from a bundle";
+
+  let arguments = (ins ChannelBundleImpl:$bundle,
+                       Variadic<ChannelType>:$fromChannels);
+  let results =  (outs Variadic<ChannelType>:$toChannels);
+  let assemblyFormat = [{
+    $bundle `from` $fromChannels attr-dict `:` custom<UnPackBundleType>(
+      type($toChannels), type($fromChannels), type($bundle))
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Data windows
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/ESI/ESIChannels.td
+++ b/include/circt/Dialect/ESI/ESIChannels.td
@@ -252,7 +252,7 @@ def PackBundleOp : ESI_Op<"bundle.pack", []> {
   let results =  (outs ChannelBundleImpl:$bundle,
                        Variadic<ChannelType>:$fromChannels);
   let assemblyFormat = [{
-    `to` $toChannels attr-dict `:` custom<UnPackBundleType>(
+    $toChannels attr-dict `:` custom<UnPackBundleType>(
       type($toChannels), type($fromChannels), type($bundle))
   }];
 }
@@ -264,7 +264,7 @@ def UnpackBundleOp : ESI_Op<"bundle.unpack", []> {
                        Variadic<ChannelType>:$fromChannels);
   let results =  (outs Variadic<ChannelType>:$toChannels);
   let assemblyFormat = [{
-    $bundle `from` $fromChannels attr-dict `:` custom<UnPackBundleType>(
+    $fromChannels `from` $bundle attr-dict `:` custom<UnPackBundleType>(
       type($toChannels), type($fromChannels), type($bundle))
   }];
 }

--- a/include/circt/Dialect/ESI/ESITypes.h
+++ b/include/circt/Dialect/ESI/ESITypes.h
@@ -22,11 +22,32 @@
 
 #include "ESIDialect.h"
 
+namespace circt {
+namespace esi {
+struct BundledChannel;
+} // namespace esi
+} // namespace circt
+
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/ESI/ESITypes.h.inc"
 
 namespace circt {
 namespace esi {
+
+struct BundledChannel {
+  StringAttr name;
+  ChannelDirection direction;
+  ChannelType type;
+
+  int operator==(const BundledChannel &that) const {
+    return name == that.name && direction == that.direction &&
+           type == that.type;
+  }
+};
+
+inline llvm::hash_code hash_value(const BundledChannel channel) {
+  return llvm::hash_combine(channel.name, channel.direction, channel.type);
+}
 
 // If 'type' is an esi:ChannelType, will return the inner type of said channel.
 // Else, returns 'type'.

--- a/include/circt/Dialect/ESI/ESITypes.h
+++ b/include/circt/Dialect/ESI/ESITypes.h
@@ -45,6 +45,7 @@ struct BundledChannel {
   }
 };
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 inline llvm::hash_code hash_value(const BundledChannel channel) {
   return llvm::hash_combine(channel.name, channel.direction, channel.type);
 }

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -493,68 +493,6 @@ static void printUnPackBundleType(OpAsmPrinter &p, Operation *, T3, T4,
   p.printType(bundleType);
 }
 
-// static ParseResult parseUnPackBundleType(
-//     OpAsmParser &parser, OperationState &result,
-//     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &operandChannels,
-//     SmallVectorImpl<Type> &toChannelTypes,
-//     SmallVectorImpl<Type> &fromChannelTypes, ChannelBundleType &bundleType) {
-
-//   if (parser.parseOperandList(operandChannels) ||
-//       parser.parseOptionalAttrDict(result.attributes) ||
-//       parser.parseColonType(bundleType))
-//     return failure();
-
-//   for (BundledChannel ch : bundleType.getChannels())
-//     if (ch.direction == ChannelDirection::to)
-//       toChannelTypes.push_back(ch.type);
-//     else if (ch.direction == ChannelDirection::from)
-//       fromChannelTypes.push_back(ch.type);
-//     else
-//       assert(false && "Channel direction invalid");
-//   return success();
-// }
-
-// ParseResult PackBundleOp::parse(OpAsmParser &parser, OperationState &result)
-// {
-//   SmallVector<OpAsmParser::UnresolvedOperand, 4> toChannels;
-//   ChannelBundleType bundleType;
-//   SmallVector<Type, 4> toChannelTypes, fromChannelTypes;
-
-//   if (parser.parseKeyword("to") ||
-//       parseUnPackBundleType(parser, result, toChannels, toChannelTypes,
-//                             fromChannelTypes, bundleType))
-//     return failure();
-
-//   if (parser.resolveOperands(toChannels, toChannelTypes,
-//                              parser.getCurrentLocation(), result.operands))
-//     return failure();
-//   result.addTypes(bundleType);
-//   result.addTypes(fromChannelTypes);
-//   return success();
-// }
-// void PackBundleOp::print(OpAsmPrinter &p) {}
-
-// ParseResult UnpackBundleOp::parse(OpAsmParser &parser, OperationState
-// &result) {
-//   OpAsmParser::UnresolvedOperand bundle;
-//   SmallVector<OpAsmParser::UnresolvedOperand, 4> fromChannels;
-//   ChannelBundleType bundleType;
-//   SmallVector<Type, 4> toChannelTypes, fromChannelTypes;
-
-//   if (parser.parseOperand(bundle) || parser.parseKeyword("from") ||
-//       parseUnPackBundleType(parser, result, fromChannels, toChannelTypes,
-//                             fromChannelTypes, bundleType))
-//     return failure();
-
-//   result.addTypes(bundleType);
-//   if (parser.resolveOperands(fromChannels, fromChannelTypes,
-//                              parser.getCurrentLocation(), result.operands))
-//     return failure();
-//   result.addTypes(fromChannelTypes);
-//   return success();
-// }
-// void UnpackBundleOp::print(OpAsmPrinter &p) {}
-
 //===----------------------------------------------------------------------===//
 // Structural ops.
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -465,6 +465,97 @@ LogicalResult ServiceHierarchyMetadataOp::verifySymbolUses(
 }
 
 //===----------------------------------------------------------------------===//
+// Bundle ops.
+//===----------------------------------------------------------------------===//
+
+static ParseResult
+parseUnPackBundleType(OpAsmParser &parser,
+                      SmallVectorImpl<Type> &toChannelTypes,
+                      SmallVectorImpl<Type> &fromChannelTypes, Type &type) {
+
+  ChannelBundleType bundleType;
+  if (parser.parseType(bundleType))
+    return failure();
+  type = bundleType;
+
+  for (BundledChannel ch : bundleType.getChannels())
+    if (ch.direction == ChannelDirection::to)
+      toChannelTypes.push_back(ch.type);
+    else if (ch.direction == ChannelDirection::from)
+      fromChannelTypes.push_back(ch.type);
+    else
+      assert(false && "Channel direction invalid");
+  return success();
+}
+template <typename T3, typename T4>
+static void printUnPackBundleType(OpAsmPrinter &p, Operation *, T3, T4,
+                                  Type bundleType) {
+  p.printType(bundleType);
+}
+
+// static ParseResult parseUnPackBundleType(
+//     OpAsmParser &parser, OperationState &result,
+//     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &operandChannels,
+//     SmallVectorImpl<Type> &toChannelTypes,
+//     SmallVectorImpl<Type> &fromChannelTypes, ChannelBundleType &bundleType) {
+
+//   if (parser.parseOperandList(operandChannels) ||
+//       parser.parseOptionalAttrDict(result.attributes) ||
+//       parser.parseColonType(bundleType))
+//     return failure();
+
+//   for (BundledChannel ch : bundleType.getChannels())
+//     if (ch.direction == ChannelDirection::to)
+//       toChannelTypes.push_back(ch.type);
+//     else if (ch.direction == ChannelDirection::from)
+//       fromChannelTypes.push_back(ch.type);
+//     else
+//       assert(false && "Channel direction invalid");
+//   return success();
+// }
+
+// ParseResult PackBundleOp::parse(OpAsmParser &parser, OperationState &result)
+// {
+//   SmallVector<OpAsmParser::UnresolvedOperand, 4> toChannels;
+//   ChannelBundleType bundleType;
+//   SmallVector<Type, 4> toChannelTypes, fromChannelTypes;
+
+//   if (parser.parseKeyword("to") ||
+//       parseUnPackBundleType(parser, result, toChannels, toChannelTypes,
+//                             fromChannelTypes, bundleType))
+//     return failure();
+
+//   if (parser.resolveOperands(toChannels, toChannelTypes,
+//                              parser.getCurrentLocation(), result.operands))
+//     return failure();
+//   result.addTypes(bundleType);
+//   result.addTypes(fromChannelTypes);
+//   return success();
+// }
+// void PackBundleOp::print(OpAsmPrinter &p) {}
+
+// ParseResult UnpackBundleOp::parse(OpAsmParser &parser, OperationState
+// &result) {
+//   OpAsmParser::UnresolvedOperand bundle;
+//   SmallVector<OpAsmParser::UnresolvedOperand, 4> fromChannels;
+//   ChannelBundleType bundleType;
+//   SmallVector<Type, 4> toChannelTypes, fromChannelTypes;
+
+//   if (parser.parseOperand(bundle) || parser.parseKeyword("from") ||
+//       parseUnPackBundleType(parser, result, fromChannels, toChannelTypes,
+//                             fromChannelTypes, bundleType))
+//     return failure();
+
+//   result.addTypes(bundleType);
+//   if (parser.resolveOperands(fromChannels, fromChannelTypes,
+//                              parser.getCurrentLocation(), result.operands))
+//     return failure();
+//   result.addTypes(fromChannelTypes);
+//   return success();
+// }
+// void UnpackBundleOp::print(OpAsmPrinter &p) {}
+
+//===----------------------------------------------------------------------===//
 // Structural ops.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -493,6 +493,22 @@ static void printUnPackBundleType(OpAsmPrinter &p, Operation *, T3, T4,
   p.printType(bundleType);
 }
 
+void PackBundleOp::getAsmResultNames(::mlir::OpAsmSetValueNameFn setNameFn) {
+  setNameFn(getResult(0), "bundle");
+  for (auto [idx, from] : llvm::enumerate(llvm::make_filter_range(
+           getBundle().getType().getChannels(), [](BundledChannel ch) {
+             return ch.direction == ChannelDirection::from;
+           })))
+    setNameFn(getResult(idx + 1), from.name.getValue());
+}
+
+void UnpackBundleOp::getAsmResultNames(::mlir::OpAsmSetValueNameFn setNameFn) {
+  for (auto [idx, to] : llvm::enumerate(llvm::make_filter_range(
+           getBundle().getType().getChannels(), [](BundledChannel ch) {
+             return ch.direction == ChannelDirection::to;
+           })))
+    setNameFn(getResult(idx), to.name.getValue());
+}
 //===----------------------------------------------------------------------===//
 // Structural ops.
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/ESI/bundles.mlir
+++ b/test/Dialect/ESI/bundles.mlir
@@ -1,0 +1,36 @@
+// RUN: circt-opt %s | circt-opt | FileCheck %s
+
+!bundleType = !esi.bundle<[
+  !esi.channel<i8> to "data",
+  !esi.channel<none> from ack]>
+
+// CHECK-LABEL: hw.module @Receiver(%foo: !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>) {
+// CHECK-NEXT:     [[R0:%.+]] = esi.null : !esi.channel<none>
+// CHECK-NEXT:     [[R1:%.+]] = esi.bundle.unpack %foo from [[R0]] : !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>
+hw.module @Receiver(%foo: !bundleType) {
+  %ack = esi.null : !esi.channel<none>
+  %data = esi.bundle.unpack %foo from %ack : !bundleType
+}
+
+// CHECK-LABEL:  hw.module @Sender() -> (foo: !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>) {
+// CHECK-NEXT:     [[R0:%.+]] = esi.null : !esi.channel<i8>
+// CHECK-NEXT:     %bundle, %fromChannels = esi.bundle.pack to [[R0]] : !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>
+// CHECK-NEXT:     hw.output %bundle : !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>
+hw.module @Sender() -> (foo: !bundleType) {
+  %data = esi.null : !esi.channel<i8>
+  %bundle, %ack = esi.bundle.pack to %data : !bundleType
+  hw.output %bundle : !bundleType
+}
+
+// CHECK-LABEL:  hw.module @Top() {
+// CHECK-NEXT:     %sender.foo = hw.instance "sender" @Sender() -> (foo: !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>)
+// CHECK-NEXT:     hw.instance "receiver" @Receiver(foo: %sender.foo: !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>) -> ()
+hw.module @Top() {
+  %b = hw.instance "sender" @Sender() -> (foo: !bundleType)
+  hw.instance "receiver" @Receiver(foo: %b: !bundleType) -> ()
+}
+
+// CHECK-LABEL:  hw.module.extern @ResettableBundleModule(%foo: !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"] reset >)
+hw.module.extern @ResettableBundleModule(%foo: !esi.bundle<[
+  !esi.channel<i8> to "data",
+  !esi.channel<none> from ack] reset>)

--- a/test/Dialect/ESI/bundles.mlir
+++ b/test/Dialect/ESI/bundles.mlir
@@ -6,19 +6,19 @@
 
 // CHECK-LABEL: hw.module @Receiver(%foo: !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>) {
 // CHECK-NEXT:     [[R0:%.+]] = esi.null : !esi.channel<none>
-// CHECK-NEXT:     [[R1:%.+]] = esi.bundle.unpack %foo from [[R0]] : !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>
+// CHECK-NEXT:     [[R1:%.+]] = esi.bundle.unpack [[R0]] from %foo : !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>
 hw.module @Receiver(%foo: !bundleType) {
   %ack = esi.null : !esi.channel<none>
-  %data = esi.bundle.unpack %foo from %ack : !bundleType
+  %data = esi.bundle.unpack %ack from %foo : !bundleType
 }
 
 // CHECK-LABEL:  hw.module @Sender() -> (foo: !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>) {
 // CHECK-NEXT:     [[R0:%.+]] = esi.null : !esi.channel<i8>
-// CHECK-NEXT:     %bundle, %fromChannels = esi.bundle.pack to [[R0]] : !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>
+// CHECK-NEXT:     %bundle, %fromChannels = esi.bundle.pack [[R0]] : !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>
 // CHECK-NEXT:     hw.output %bundle : !esi.bundle<[!esi.channel<i8> to "data", !esi.channel<none> from "ack"]>
 hw.module @Sender() -> (foo: !bundleType) {
   %data = esi.null : !esi.channel<i8>
-  %bundle, %ack = esi.bundle.pack to %data : !bundleType
+  %bundle, %ack = esi.bundle.pack %data : !bundleType
   hw.output %bundle : !bundleType
 }
 

--- a/test/Dialect/ESI/bundles_errors.mlir
+++ b/test/Dialect/ESI/bundles_errors.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt %s --verify-diagnostics --split-input-file
+
+!bundleType = !esi.channel<i8>
+
+hw.module @Receiver(%foo: !bundleType) -> (data: !esi.channel<i8>) {
+  %ack = esi.null : !esi.channel<none>
+  // expected-error @+1 {{custom op 'esi.bundle.unpack' invalid kind of type specified}}
+  %data = esi.bundle.unpack %ack from %foo : !bundleType
+  hw.output %data : !esi.channel<i8>
+}
+
+// -----


### PR DESCRIPTION
A channel bundle (sometimes referred to as just "bundle") is a set of channels of associated signals, along with per-channel names and directions. The prototypical example for a bundle is a request-response channel pair.