### PR TITLE
[FIRRTL] Update LowerClasses to handle property wires.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -611,6 +611,15 @@ struct WireOpConversion : public OpConversionPattern<WireOp> {
     if (!wireValue)
       return failure();
 
+    // If the wire isn't inside a graph region, we can't trivially remove it. In
+    // practice, this pattern does run for wires in graph regions, so this check
+    // should pass and we can proceed with the trivial rewrite.
+    auto regionKindInterface = wireOp->getParentOfType<RegionKindInterface>();
+    if (!regionKindInterface)
+      return failure();
+    if (regionKindInterface.getRegionKind(0) != RegionKind::Graph)
+      return failure();
+
     // Find the assignment to the wire.
     PropAssignOp propAssign = getPropertyAssignment(wireValue);
 

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -198,3 +198,17 @@ firrtl.circuit "PathModule" {
     // CHECK:  om.class.field @propOut, %[[c1]] : !om.list<!om.integer>
   }
 }
+
+// CHECK-LABEL: firrtl.circuit "WireProp"
+firrtl.circuit "WireProp" {
+  // CHECK: om.class @WireProp
+  // CHECK-SAME: %[[IN:.+]]: !om.string
+  firrtl.module @WireProp(in %in: !firrtl.string, out %out: !firrtl.string) attributes {convention = #firrtl<convention scalarized>} {
+    // CHECK-NOT: firrtl.wire
+    // CHECK-NOT: firrtl.propassign
+    // CHECK: om.class.field @out, %[[IN]] : !om.string
+    %s = firrtl.wire : !firrtl.string
+    firrtl.propassign %s, %in : !firrtl.string
+    firrtl.propassign %out, %s : !firrtl.string
+  }
+}


### PR DESCRIPTION
Property wires are added in some scenarios for convenience. This would be a good canonicalization pattern to have, but canonicalization shouldn't be needed for correctness. So, this pass explicitly handles wires of properties, by simply finding the single assignment to the wire, using that value instead of the wire, and removing the assignment.

Closes https://github.com/llvm/circt/issues/6051.