### PR TITLE
[OM][firtool] Add FreezePaths pass 

### DIFF
--- a/include/circt/Dialect/OM/OMPasses.h
+++ b/include/circt/Dialect/OM/OMPasses.h
@@ -20,6 +20,7 @@ namespace circt {
 namespace om {
 
 std::unique_ptr<mlir::Pass> createOMLinkModulesPass();
+std::unique_ptr<mlir::Pass> createFreezePathsPass();
 
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/OM/OMPasses.h.inc"

--- a/include/circt/Dialect/OM/OMPasses.td
+++ b/include/circt/Dialect/OM/OMPasses.td
@@ -8,6 +8,16 @@
 
 include "mlir/Pass/PassBase.td"
 
+def FreezePaths: Pass<"om-freeze-paths", "mlir::ModuleOp"> {
+  let summary = "Hard code all path information";
+  let description = [{
+    Replaces paths to hardware with hard-coded string paths.  This pass should
+    only run once the hierarchy will no longer change, and the final names for
+    objects have been decided.
+  }];
+  let constructor = "circt::om::createFreezePathsPass()";
+}
+
 def LinkModules: Pass<"om-link-modules", "mlir::ModuleOp"> {
   let summary = "Link separated OM modules into a single module";
   let description = [{

--- a/lib/Dialect/OM/Transforms/CMakeLists.txt
+++ b/lib/Dialect/OM/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_dialect_library(CIRCTOMTransforms
+  FreezePaths.cpp
   LinkModules.cpp
 
   DEPENDS
@@ -6,6 +7,7 @@ add_circt_dialect_library(CIRCTOMTransforms
 
   LINK_LIBS PUBLIC
   CIRCTOM
+  CIRCTHW
   CIRCTSupport
   MLIRIR
   MLIRPass

--- a/lib/Dialect/OM/Transforms/FreezePaths.cpp
+++ b/lib/Dialect/OM/Transforms/FreezePaths.cpp
@@ -1,0 +1,239 @@
+//===- FreezePaths.cpp - Freeze Paths pass ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the definitions of the OM freeze paths pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/HW/HWInstanceGraph.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/InnerSymbolTable.h"
+#include "circt/Dialect/OM/OMAttributes.h"
+#include "circt/Dialect/OM/OMOps.h"
+#include "circt/Dialect/OM/OMPasses.h"
+
+using namespace circt;
+using namespace om;
+
+namespace {
+struct PathVisitor {
+  PathVisitor(hw::InstanceGraph &instanceGraph, hw::InnerRefNamespace &irn)
+      : instanceGraph(instanceGraph), irn(irn) {}
+  LogicalResult processPath(PathOp path);
+  LogicalResult run(Operation *op);
+  hw::InstanceGraph &instanceGraph;
+  hw::InnerRefNamespace &irn;
+};
+} // namespace
+
+static LogicalResult getAccessPath(Location loc, Type type, size_t fieldId,
+                                   SmallVectorImpl<char> &result) {
+  while (fieldId) {
+    if (auto aliasType = dyn_cast<hw::TypeAliasType>(type))
+      type = aliasType.getCanonicalType();
+    if (auto structType = dyn_cast<hw::StructType>(type)) {
+      auto index = structType.getIndexForFieldID(fieldId);
+      auto &element = structType.getElements()[index];
+      result.push_back('.');
+      llvm::append_range(result, element.name.getValue());
+      type = element.type;
+      fieldId -= structType.getFieldID(index);
+    } else if (auto arrayType = dyn_cast<hw::ArrayType>(type)) {
+      auto index = arrayType.getIndexForFieldID(fieldId);
+      result.push_back('[');
+      Twine(index).toVector(result);
+      result.push_back(']');
+      type = arrayType.getElementType();
+      fieldId -= arrayType.getFieldID(index);
+    } else {
+      return emitError(loc) << "can't create access path with fieldID "
+                            << fieldId << " in type " << type;
+    }
+  }
+  return success();
+}
+
+LogicalResult PathVisitor::processPath(PathOp path) {
+  auto *context = path->getContext();
+  auto &symbolTable = irn.symTable;
+
+  StringRef targetKind;
+  switch (path.getTargetKind()) {
+  case TargetKind::DontTouch:
+    targetKind = "OMDontTouchedReferenceTarget";
+    break;
+  case TargetKind::Reference:
+    targetKind = "OMReferenceTarget";
+    break;
+  case TargetKind::MemberReference:
+    targetKind = "OMMemberReferenceTarget";
+    break;
+  case TargetKind::MemberInstance:
+    targetKind = "OMMemberInstanceTarget";
+    break;
+  }
+
+  // Look up the associated HierPathOp.
+  auto hierPathOp =
+      symbolTable.lookup<hw::HierPathOp>(path.getTargetAttr().getAttr());
+  auto namepath = hierPathOp.getNamepathAttr().getValue();
+
+  // The name of the module which starts off the path.
+  StringAttr topModule;
+  // The path from the top module to the target. Represents a pair of instance
+  // and its target module's name.
+  SmallVector<std::pair<StringAttr, StringAttr>> modules;
+  // If we're targeting a component or port of the target module, this will hold
+  // its name.
+  StringAttr component;
+  // If we're indexing in to the component, this will be the access path.
+  SmallString<64> field;
+
+  // Process the final target first.
+  auto &end = namepath.back();
+  if (auto innerRef = dyn_cast<hw::InnerRefAttr>(end)) {
+    auto target = irn.lookup(innerRef);
+    if (target.isPort()) {
+      // We are targeting the port of a module.
+      auto module = cast<hw::HWModuleLike>(target.getOp());
+      auto index = target.getPort();
+      component = StringAttr::get(context, module.getPortName(index));
+      auto loc = module.getPortLoc(index);
+      auto type = module.getPortTypes()[index];
+      if (failed(getAccessPath(loc, type, target.getField(), field)))
+        return failure();
+      topModule = module.getModuleNameAttr();
+    } else {
+      auto *op = target.getOp();
+      assert(op && "innerRef should be targeting something");
+      // Get the current module.
+      topModule = innerRef.getModule();
+      // Get the verilog name of the target.
+      auto verilogName = op->getAttrOfType<StringAttr>("hw.verilogName");
+      if (!verilogName) {
+        auto diag = path->emitError("component does not have verilog name");
+        diag.attachNote(op->getLoc()) << "component here";
+        return diag;
+      }
+      if (auto inst = dyn_cast<hw::HWInstanceLike>(op)) {
+        // We are targeting an instance.
+        modules.emplace_back(verilogName, inst.getReferencedModuleNameAttr());
+      } else {
+        // We are targeting a regular component.
+        component = verilogName;
+        auto innerSym = cast<hw::InnerSymbolOpInterface>(op);
+        auto value = innerSym.getTargetResult();
+        if (failed(getAccessPath(value.getLoc(), value.getType(),
+                                 target.getField(), field)))
+          return failure();
+      }
+    }
+  } else {
+    // We are targeting a module.
+    auto symbolRef = cast<FlatSymbolRefAttr>(end);
+    topModule = symbolRef.getAttr();
+  }
+
+  // Process the rest of the hierarchical path.
+  for (auto attr : llvm::reverse(namepath.drop_back())) {
+    auto innerRef = cast<hw::InnerRefAttr>(attr);
+    modules.emplace_back(innerRef.getName(), topModule);
+    topModule = innerRef.getModule();
+  }
+
+  // Handle the modules not present in the path.
+  assert(topModule && "must have something?");
+  auto *node = instanceGraph.lookup(topModule);
+  while (!node->noUses()) {
+    auto module = node->getModule();
+    if (!node->hasOneUse()) {
+      auto diag = path->emitError() << "unable to uniquely resolve target "
+                                       "due to multiple instantiation";
+      for (auto *use : node->uses()) {
+        if (auto *op = use->getInstance<Operation *>())
+          diag.attachNote(op->getLoc()) << "instance here";
+        else
+          diag.attachNote(module->getLoc()) << "module marked public";
+      }
+      return diag;
+    }
+    auto *record = *node->usesBegin();
+
+    // Get the verilog name of the instance.
+    auto *inst = record->getInstance<Operation *>();
+    // If the instance is external, just break here.
+    if (!inst)
+      break;
+    auto verilogName = inst->getAttrOfType<StringAttr>("hw.verilogName");
+    if (!verilogName)
+      return inst->emitError("component does not have verilog name");
+    modules.emplace_back(verilogName, module.getModuleNameAttr());
+    node = record->getParent();
+  }
+
+  // We are finally at the top of the instance graph.
+  topModule = node->getModule().getModuleNameAttr();
+
+  // Create the target string.
+  SmallString<128> targetString;
+  targetString.append(targetKind);
+  targetString.append(":");
+  targetString.append(topModule);
+  if (!modules.empty())
+    targetString.append("/");
+  for (auto [instance, module] : llvm::reverse(modules)) {
+    targetString.append(instance);
+    targetString.append(":");
+    targetString.append(module);
+  }
+  if (component) {
+    targetString.append(">");
+    targetString.append(component);
+  }
+  targetString.append(field);
+  auto targetPath = PathAttr::get(StringAttr::get(context, targetString));
+
+  // Replace the old path operation.
+  OpBuilder builder(path);
+  auto constantOp = builder.create<ConstantOp>(path.getLoc(), targetPath);
+  path.replaceAllUsesWith(constantOp.getResult());
+  path->erase();
+  return success();
+}
+
+LogicalResult PathVisitor::run(Operation *op) {
+  auto result = op->walk([&](PathOp path) -> WalkResult {
+    if (failed(processPath(path)))
+      return WalkResult::interrupt();
+    return WalkResult::advance();
+  });
+  if (result.wasInterrupted())
+    return failure();
+  return success();
+}
+
+namespace {
+struct FreezePathsPass : public FreezePathsBase<FreezePathsPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void FreezePathsPass::runOnOperation() {
+  auto module = getOperation();
+  auto &instanceGraph = getAnalysis<hw::InstanceGraph>();
+  auto &symbolTable = getAnalysis<SymbolTable>();
+  hw::InnerSymbolTableCollection collection(module);
+  hw::InnerRefNamespace irn{symbolTable, collection};
+  if (failed(PathVisitor(instanceGraph, irn).run(module)))
+    signalPassFailure();
+}
+
+std::unique_ptr<mlir::Pass> circt::om::createFreezePathsPass() {
+  return std::make_unique<FreezePathsPass>();
+}

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -143,6 +143,7 @@ firrtl.circuit "PathModule" {
   // CHECK: hw.hierpath private [[WIRE_PATH:@.+]] [@PathModule::[[WIRE_SYM:@.+]]]
   // CHECK: hw.hierpath private [[VECTOR_PATH:@.+]] [@PathModule::[[VECTOR_SYM:@.+]]]
   // CHECK: hw.hierpath private [[INST_PATH:@.+]] [@PathModule::@child]
+  // CHECK: hw.hierpath private [[MODULE_PATH:@.+]] [@Child]
   // CHECK: hw.hierpath private [[NONLOCAL_PATH:@.+]] [@PathModule::@child, @Child::[[NONLOCAL_SYM:@.+]]]
 
   // CHECK: firrtl.module @PathModule(in %in: !firrtl.uint<1> sym [[PORT_SYM]]) {
@@ -156,7 +157,7 @@ firrtl.circuit "PathModule" {
   }
   hw.hierpath @NonLocal [@PathModule::@child, @Child]
   // CHECK: firrtl.module @Child() {
-  firrtl.module @Child() {
+  firrtl.module @Child() attributes {annotations = [{class = "circt.tracker", id = distinct[5]<>}]} {
     // CHECK: %non_local = firrtl.wire sym [[NONLOCAL_SYM]] : !firrtl.uint<8>
     %non_local = firrtl.wire {annotations = [{circt.nonlocal = @NonLocal, class = "circt.tracker", id = distinct[3]<>}]} : !firrtl.uint<8>
   }
@@ -188,6 +189,9 @@ firrtl.circuit "PathModule" {
     // CHECK: om.path member_instance [[INST_PATH]]
     %instance_member_instance = firrtl.path member_instance distinct[4]<>
     %instance_member_reference = firrtl.path member_reference distinct[4]<>
+
+    // CHECK: om.path reference [[MODULE_PATH]]
+    %module_path = firrtl.path reference distinct[5]<>
   }
   firrtl.module @ListCreate(in %propIn: !firrtl.integer, out %propOut: !firrtl.list<integer>) attributes {convention = #firrtl<convention scalarized>} {
     %0 = firrtl.integer 123

--- a/test/Dialect/OM/freeze-paths-errors.mlir
+++ b/test/Dialect/OM/freeze-paths-errors.mlir
@@ -1,0 +1,25 @@
+// RUN: circt-opt -om-freeze-paths --split-input-file --verify-diagnostics %s
+
+hw.hierpath private @nla [@Top::@sym]
+hw.module @Top() {
+  // expected-note @below {{component here}}
+  %wire = hw.wire %wire sym @sym : i8
+  // expected-error @below {{component does not have verilog name}}
+  %path = om.path reference @nla
+  hw.output
+}
+
+// -----
+
+hw.hierpath private @nla [@Child]
+// expected-note @below {{module marked public}}
+hw.module @Child() {}
+hw.module @Top() {
+  // expected-error @below {{unable to uniquely resolve target due to multiple instantiation}}
+  %path = om.path reference @nla
+  // expected-note @below {{instance here}}
+  hw.instance "child0" @Child() -> ()
+  // expected-note @below {{instance here}}
+  hw.instance "child1" @Child() -> ()
+  hw.output
+}

--- a/test/Dialect/OM/freeze-paths.mlir
+++ b/test/Dialect/OM/freeze-paths.mlir
@@ -1,0 +1,50 @@
+// RUN: circt-opt -om-freeze-paths %s | FileCheck %s
+hw.hierpath private @nla [@PathModule::@sym]
+hw.hierpath private @nla_0 [@PathModule::@sym_0]
+hw.hierpath private @nla_1 [@PathModule::@sym_1]
+hw.hierpath private @nla_2 [@PathModule::@sym_2]
+hw.hierpath private @nla_3 [@PathModule::@child]
+hw.hierpath private @nla_4 [@Child]
+hw.hierpath private @nla_5 [@PathModule::@child, @Child::@sym]
+hw.module @PathModule(%in: i1 {hw.exportPort = #hw<innerSym@sym>}) {
+  %wire = hw.wire %wire sym @sym_0 {hw.verilogName = "wire"} : i8
+  %array = hw.wire %array sym [<@sym_1,1,public>] {hw.verilogName = "array"}: !hw.array<1xi8>
+  %struct = hw.wire %struct sym [<@sym_2,1,public>] {hw.verilogName = "struct"}: !hw.struct<a: i8>
+  hw.instance "child" sym @child @Child() -> () {hw.verilogName = "child"}
+  hw.output
+}
+hw.hierpath private @NonLocal [@PathModule::@child, @Child]
+hw.module private @Child() {
+  %z_i8 = sv.constantZ : i8
+  %non_local = hw.wire %z_i8 sym @sym {hw.verilogName = "non_local"}  : i8
+  hw.output
+}
+// CHECK-LABEL om.class @PathTest()
+om.class @PathTest() {
+  // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule>in"> : !om.path
+  %0 = om.path reference @nla
+
+  // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule>wire"> : !om.path
+  %1 = om.path reference @nla_0
+
+  // CHECK: om.constant #om.path<"OMMemberReferenceTarget:PathModule>wire"> : !om.path
+  %2 = om.path member_reference @nla_0
+
+  // CHECK: om.constant #om.path<"OMDontTouchedReferenceTarget:PathModule>wire"> : !om.path
+  %4 = om.path dont_touch @nla_0
+
+  // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule>array[0]"> : !om.path
+  %5 = om.path reference @nla_1
+
+  // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule>struct.a"> : !om.path
+  %6 = om.path reference @nla_2
+
+  // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule/child:Child>non_local"> : !om.path
+  %7 = om.path reference @nla_5
+
+  // CHECK: om.constant #om.path<"OMMemberInstanceTarget:PathModule/child:Child"> : !om.path
+  %8 = om.path member_instance @nla_3
+
+  // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule/child:Child"> : !om.path
+  %9 = om.path reference @nla_4
+}

--- a/tools/firtool/CMakeLists.txt
+++ b/tools/firtool/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(firtool PRIVATE
   CIRCTImportFIRFile
   CIRCTFIRRTLTransforms
   CIRCTHWTransforms
+  CIRCTOMTransforms
   CIRCTSeq
   CIRCTSVTransforms
   CIRCTTransforms

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -619,6 +619,7 @@ int main(int argc, char **argv) {
 
     // Dialect passes:
     firrtl::registerPasses();
+    om::registerPasses();
     sv::registerPasses();
 
     // Export passes:

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -26,6 +26,7 @@
 #include "circt/Dialect/LTL/LTLDialect.h"
 #include "circt/Dialect/OM/OMDialect.h"
 #include "circt/Dialect/OM/OMOps.h"
+#include "circt/Dialect/OM/OMPasses.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Dialect/Seq/SeqDialect.h"
@@ -405,8 +406,10 @@ static LogicalResult processBuffer(
 
     // Run final IR mutations to clean it up after ExportVerilog and before
     // emitting the final MLIR.
-    if (!mlirOutFile.empty())
+    if (!mlirOutFile.empty()) {
       pm.addPass(firrtl::createFinalizeIRPass());
+      pm.addPass(om::createFreezePathsPass());
+    }
   }
 
   if (failed(pm.run(module.get())))


### PR DESCRIPTION
This adds the FreezePaths pass which performs the final lowering of path
operations after ExportVerilog.  This prepares the OMIR be split from the
hardware by transforming the dynamic hardware references in to frozen
attributes.