### PR TITLE
[InstanceGraph] Add a wrapper for instance paths and fix HW enumeration

### DIFF
--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -281,21 +281,53 @@ protected:
   llvm::SmallVector<InstanceGraphNode *> inferredTopLevelNodes;
 };
 
-/// An absolute instance path.
-using InstancePath = ArrayRef<InstanceOpInterface>;
+struct InstancePathCache;
 
-template <typename T>
-inline static T &formatInstancePath(T &into, const InstancePath &path) {
-  into << "$root";
-  for (auto inst : path)
-    into << "/" << inst.getInstanceName() << ":"
-         << inst.getReferencedModuleName();
-  return into;
-}
+/**
+ * An instance path composed of a series of instances.
+ */
+class InstancePath final {
+public:
+  InstancePath() = default;
+
+  InstanceOpInterface top() const {
+    assert(!empty() && "instance path is empty");
+    return path[0];
+  }
+
+  InstanceOpInterface leaf() const {
+    assert(!empty() && "instance path is empty");
+    return path.back();
+  }
+
+  InstancePath dropFront() const { return InstancePath(path.drop_front()); }
+
+  InstanceOpInterface operator[](size_t idx) const { return path[idx]; }
+  ArrayRef<InstanceOpInterface>::iterator begin() const { return path.begin(); }
+  ArrayRef<InstanceOpInterface>::iterator end() const { return path.end(); }
+  size_t size() const { return path.size(); }
+  bool empty() const { return path.empty(); }
+
+  /// Print the path to any stream-like object.
+  template <typename T>
+  void print(T &into) const {
+    into << "$root";
+    for (auto inst : path)
+      into << "/" << inst.getInstanceName() << ":"
+           << inst.getReferencedModuleName();
+  }
+
+private:
+  // Only the path cache is allowed to create paths.
+  friend class InstancePathCache;
+  InstancePath(ArrayRef<InstanceOpInterface> path) : path(path) {}
+
+  ArrayRef<InstanceOpInterface> path;
+};
 
 template <typename T>
 static T &operator<<(T &os, const InstancePath &path) {
-  return formatInstancePath(os, path);
+  return path.print(os);
 }
 
 /// A data structure that caches and provides absolute paths to module instances
@@ -311,15 +343,18 @@ struct InstancePathCache {
   /// Replace an InstanceOp. This is required to keep the cache updated.
   void replaceInstance(InstanceOpInterface oldOp, InstanceOpInterface newOp);
 
+  /// Append an instance to a path.
+  InstancePath appendInstance(InstancePath path, InstanceOpInterface inst);
+
+  /// Prepend an instance to a path.
+  InstancePath prependInstance(InstanceOpInterface inst, InstancePath path);
+
 private:
   /// An allocator for individual instance paths and entire path lists.
   llvm::BumpPtrAllocator allocator;
 
   /// Cached absolute instance paths.
   DenseMap<Operation *, ArrayRef<InstancePath>> absolutePathsCache;
-
-  /// Append an instance to a path.
-  InstancePath appendInstance(InstancePath path, InstanceOpInterface inst);
 };
 
 } // namespace igraph

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -315,12 +315,12 @@ CreateSiFiveMetadataPass::emitMemoryMetadata(ObjectModelIR &omir) {
         for (auto p : paths) {
           if (p.empty())
             continue;
-          auto top = p.front();
+          auto top = p.top();
           std::string hierName =
               addSymbolToVerbatimOp(top->getParentOfType<FModuleOp>(),
                                     jsonSymbols)
                   .c_str();
-          auto finalInst = p.back();
+          auto finalInst = p.leaf();
           for (auto inst : llvm::drop_end(p)) {
             auto parentModule = inst->getParentOfType<FModuleOp>();
             if (dutMod == parentModule)

--- a/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EmitOMIR.cpp
@@ -739,7 +739,7 @@ void EmitOMIRPass::makeTrackerAbsolute(Tracker &tracker) {
     diag.attachNote(tracker.op->getLoc())
         << "may refer to the following paths:";
     for (auto path : paths)
-      formatInstancePath(diag.attachNote(tracker.op->getLoc()) << "- ", path);
+      path.print(diag.attachNote(tracker.op->getLoc()) << "- ");
     anyFailures = true;
     return;
   }

--- a/lib/Dialect/FIRRTL/Transforms/LegacyWiring.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LegacyWiring.cpp
@@ -51,7 +51,7 @@ LogicalResult circt::firrtl::applyWiring(const AnnoPathValue &target,
               << target.ref;
           return failure();
         }
-        inst = cast<InstanceOp>(paths[0].back());
+        inst = cast<InstanceOp>(paths[0].leaf());
       } else {
         inst = cast<InstanceOp>(target.instances.back());
       }

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -841,12 +841,12 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     auto sources = sourcePaths[0];
     auto sinks = sinkPaths[0];
     while (!sources.empty() && !sinks.empty()) {
-      if (sources[0] != sinks[0])
+      if (sources.top() != sinks.top())
         break;
-      auto newLCA = sources[0];
+      auto newLCA = sources.top();
       lca = cast<FModuleOp>(instanceGraph.getReferencedModule(newLCA));
-      sources = sources.drop_front();
-      sinks = sinks.drop_front();
+      sources = sources.dropFront();
+      sinks = sinks.dropFront();
     }
 
     LLVM_DEBUG({
@@ -917,8 +917,8 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
              << "\" must be passive (no flips) when using references";
 
     // Record module modifications related to adding ports to modules.
-    auto addPorts = [&](ArrayRef<igraph::InstanceOpInterface> insts, Value val,
-                        Type tpe, Direction dir) {
+    auto addPorts = [&](igraph::InstancePath insts, Value val, Type tpe,
+                        Direction dir) {
       StringRef name, instName;
       for (auto inst : llvm::reverse(insts)) {
         auto mod = instanceGraph.getReferencedModule<FModuleOp>(inst);

--- a/unittests/Dialect/HW/CMakeLists.txt
+++ b/unittests/Dialect/HW/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_circt_unittest(CIRCTHWTests
+  GraphFixture.cpp
   HWModuleTest.cpp
   InstanceGraphTest.cpp
+  InstancePathTest.cpp
 )
 
 target_link_libraries(CIRCTHWTests

--- a/unittests/Dialect/HW/GraphFixture.cpp
+++ b/unittests/Dialect/HW/GraphFixture.cpp
@@ -1,0 +1,61 @@
+//===- GraphFixutre.cpp - A fixture for instance graph unit tests ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "GraphFixture.h"
+#include "circt/Dialect/HW/HWDialect.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace hw;
+
+mlir::ModuleOp fixtures::createModule(MLIRContext *context) {
+  context->loadDialect<HWDialect>();
+
+  // Build the following graph:
+  // hw.module @Top() {
+  //   hw.instance "alligator" @Alligator() -> ()
+  //   hw.instance "cat" @Cat() -> ()
+  // }
+  // hw.module private @Alligator() {
+  //   hw.instance "bear" @Bear() -> ()
+  // }
+  // hw.module private @Bear() {
+  //   hw.instance "cat" @Cat() -> ()
+  // }
+  // hw.module private @Cat() { }
+
+  LocationAttr loc = UnknownLoc::get(context);
+  auto circuit = ModuleOp::create(loc);
+  auto builder = ImplicitLocOpBuilder::atBlockEnd(loc, circuit.getBody());
+
+  auto top = builder.create<HWModuleOp>(StringAttr::get(context, "Top"),
+                                        ArrayRef<PortInfo>{});
+  auto alligator = builder.create<HWModuleOp>(
+      StringAttr::get(context, "Alligator"), ArrayRef<PortInfo>{});
+  auto bear = builder.create<HWModuleOp>(StringAttr::get(context, "Bear"),
+                                         ArrayRef<PortInfo>{});
+  auto cat = builder.create<HWModuleOp>(StringAttr::get(context, "Cat"),
+                                        ArrayRef<PortInfo>{});
+
+  alligator.setVisibility(SymbolTable::Visibility::Private);
+  bear.setVisibility(SymbolTable::Visibility::Private);
+  cat.setVisibility(SymbolTable::Visibility::Private);
+
+  builder.setInsertionPointToStart(top.getBodyBlock());
+  builder.create<InstanceOp>(alligator, "alligator", ArrayRef<Value>{});
+  builder.create<InstanceOp>(cat, "cat", ArrayRef<Value>{});
+
+  builder.setInsertionPointToStart(alligator.getBodyBlock());
+  builder.create<InstanceOp>(bear, "bear", ArrayRef<Value>{});
+
+  builder.setInsertionPointToStart(bear.getBodyBlock());
+  builder.create<InstanceOp>(cat, "cat", ArrayRef<Value>{});
+
+  return circuit;
+}

--- a/unittests/Dialect/HW/GraphFixture.h
+++ b/unittests/Dialect/HW/GraphFixture.h
@@ -1,0 +1,21 @@
+//===- GraphFixutre.h - A fixture for instance graph unit tests -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef UNITTEST_DIALECT_FIRRTL_HW_GRAPHFIXTURE_H
+#define UNITTEST_DIALECT_FIRRTL_HW_GRAPHFIXTURE_H
+
+#include "circt/Dialect/HW/HWOps.h"
+
+namespace fixtures {
+
+mlir::ModuleOp createModule(mlir::MLIRContext *context);
+
+} // end namespace fixtures
+
+#endif // UNITTEST_DIALECT_FIRRTL_HW_GRAPHFIXTURE_H

--- a/unittests/Dialect/HW/InstanceGraphTest.cpp
+++ b/unittests/Dialect/HW/InstanceGraphTest.cpp
@@ -1,4 +1,4 @@
-//===- InstanceGraphTest.cpp - FIRRTL type unit tests ---------------------===//
+//===- InstanceGraphTest.cpp - HW instance graph tests --------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,10 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "circt/Dialect/HW/HWDialect.h"
+#include "GraphFixture.h"
 #include "circt/Dialect/HW/HWInstanceGraph.h"
-#include "circt/Dialect/HW/HWOps.h"
-#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "gtest/gtest.h"
 
@@ -21,45 +19,7 @@ namespace {
 
 TEST(InstanceGraphTest, PostOrderTraversal) {
   MLIRContext context;
-  context.loadDialect<HWDialect>();
-
-  // Build the following graph:
-  // hw.module @Top() {
-  //   hw.instance "alligator" @Alligator() -> ()
-  //   hw.instance "cat" @Cat() -> ()
-  // }
-  // hw.module private @Alligator() {
-  //   hw.instance "bear" @Bear() -> ()
-  // }
-  // hw.module private @Bear() {
-  //   hw.instance "cat" @Cat() -> ()
-  // }
-  // hw.module private @Cat() { }
-
-  LocationAttr loc = UnknownLoc::get(&context);
-  auto module = ModuleOp::create(loc);
-  auto builder = ImplicitLocOpBuilder::atBlockEnd(loc, module.getBody());
-
-  auto top = builder.create<HWModuleOp>(StringAttr::get(&context, "Top"),
-                                        ArrayRef<PortInfo>{});
-  auto alligator = builder.create<HWModuleOp>(
-      StringAttr::get(&context, "Alligator"), ArrayRef<PortInfo>{});
-  auto bear = builder.create<HWModuleOp>(StringAttr::get(&context, "Bear"),
-                                         ArrayRef<PortInfo>{});
-  auto cat = builder.create<HWModuleOp>(StringAttr::get(&context, "Cat"),
-                                        ArrayRef<PortInfo>{});
-
-  builder.setInsertionPointToStart(top.getBodyBlock());
-  builder.create<InstanceOp>(alligator, "alligator", ArrayRef<Value>{});
-  builder.create<InstanceOp>(cat, "cat", ArrayRef<Value>{});
-
-  builder.setInsertionPointToStart(alligator.getBodyBlock());
-  builder.create<InstanceOp>(bear, "bear", ArrayRef<Value>{});
-
-  builder.setInsertionPointToStart(bear.getBodyBlock());
-  builder.create<InstanceOp>(cat, "cat", ArrayRef<Value>{});
-
-  InstanceGraph graph(module);
+  InstanceGraph graph(fixtures::createModule(&context));
 
   auto range = llvm::post_order(&graph);
 

--- a/unittests/Dialect/HW/InstancePathTest.cpp
+++ b/unittests/Dialect/HW/InstancePathTest.cpp
@@ -1,0 +1,79 @@
+//===- InstancePathTest.cpp - HW instance path tests ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "GraphFixture.h"
+#include "circt/Dialect/HW/HWInstanceGraph.h"
+#include "circt/Support/InstanceGraph.h"
+#include "gtest/gtest.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace hw;
+
+namespace {
+
+TEST(InstancePathTest, Enumerate) {
+  MLIRContext context;
+  ModuleOp circuit = fixtures::createModule(&context);
+  hw::InstanceGraph graph(circuit);
+  igraph::InstancePathCache pathCache(graph);
+
+  auto cat = cast<HWModuleOp>(*circuit.getBody()->rbegin());
+  auto catPaths = pathCache.getAbsolutePaths(cat);
+  ASSERT_EQ(2ull, catPaths.size());
+
+  ASSERT_EQ(3ull, catPaths[0].size());
+  EXPECT_EQ("alligator", catPaths[0][0].getInstanceName());
+  EXPECT_EQ("bear", catPaths[0][1].getInstanceName());
+  EXPECT_EQ("cat", catPaths[0][2].getInstanceName());
+
+  ASSERT_EQ(1ull, catPaths[1].size());
+  EXPECT_EQ("cat", catPaths[1][0].getInstanceName());
+
+  auto top = cast<HWModuleOp>(*circuit.getBody()->begin());
+  auto topPaths = pathCache.getAbsolutePaths(top);
+  ASSERT_EQ(1ull, topPaths.size());
+}
+
+TEST(InstancePathTest, AppendPrependInstance) {
+  MLIRContext context;
+  ModuleOp circuit = fixtures::createModule(&context);
+  hw::InstanceGraph graph(circuit);
+  igraph::InstancePathCache pathCache(graph);
+
+  igraph::InstancePath empty;
+
+  auto top = cast<HWModuleOp>(*circuit.getBody()->begin());
+  auto cat = cast<HWModuleOp>(*circuit.getBody()->rbegin());
+
+  auto builder =
+      ImplicitLocOpBuilder::atBlockEnd(circuit.getLoc(), circuit.getBody());
+  auto dragon = builder.create<HWModuleOp>(StringAttr::get(&context, "Dragon"),
+                                           ArrayRef<PortInfo>{});
+
+  builder.setInsertionPointToStart(dragon.getBodyBlock());
+  auto breakfast =
+      builder.create<InstanceOp>(cat, "breakfast", ArrayRef<Value>{});
+
+  builder.setInsertionPointToStart(top.getBodyBlock());
+  auto kitty = builder.create<InstanceOp>(cat, "kitty", ArrayRef<Value>{});
+
+  auto prepended = pathCache.prependInstance(
+      breakfast, pathCache.prependInstance(kitty, empty));
+  ASSERT_EQ(2ull, prepended.size());
+  EXPECT_EQ(breakfast, prepended[0]);
+  EXPECT_EQ(kitty, prepended[1]);
+
+  auto appended = pathCache.appendInstance(
+      pathCache.appendInstance(empty, breakfast), kitty);
+  ASSERT_EQ(2ull, appended.size());
+  EXPECT_EQ(breakfast, appended[0]);
+  EXPECT_EQ(kitty, appended[1]);
+}
+
+} // namespace


### PR DESCRIPTION
This PR adds a light wrapper on top of instance path. With this wrapper, a subsequent PR should be able to de-duplicate instance paths to save on memory usage and provide quick comparison operators.

HW enumeration was also fixed and a new unit test codifies behaviour.