### PR TITLE
[FIRRTLFolds] Remove InvalidValue canonicalization

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1780,10 +1780,10 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
   // Ok, we know we are doing the transformation.
 
   auto replacement = op.getSrc();
-    // This will be replaced with the constant source.  First, make sure the
-    // constant dominates all users.
-    if (srcValueOp && srcValueOp != &declBlock->front())
-      srcValueOp->moveBefore(&declBlock->front());
+  // This will be replaced with the constant source.  First, make sure the
+  // constant dominates all users.
+  if (srcValueOp && srcValueOp != &declBlock->front())
+    srcValueOp->moveBefore(&declBlock->front());
 
   // Replace all things *using* the decl with the constant/port, and
   // remove the declaration.

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1771,7 +1771,7 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
   } else {
     // Constants/invalids in the same block are ok to forward, even through
     // reg's since the clocking doesn't matter for constants.
-    if (!isa<ConstantOp>(srcValueOp) && !isa<InvalidValueOp>(srcValueOp))
+    if (!isa<ConstantOp>(srcValueOp))
       return failure();
     if (srcValueOp->getBlock() != declBlock)
       return failure();
@@ -1780,26 +1780,10 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
   // Ok, we know we are doing the transformation.
 
   auto replacement = op.getSrc();
-  if (srcValueOp) {
-    // Replace with constant zero.
-    if (isa<InvalidValueOp>(srcValueOp)) {
-      if (isa<BundleType, FVectorType>(op.getDest().getType()))
-        return failure();
-      if (isa<ClockType, AsyncResetType, ResetType>(op.getDest().getType()))
-        replacement = rewriter.create<SpecialConstantOp>(
-            op.getSrc().getLoc(), op.getDest().getType(),
-            rewriter.getBoolAttr(false));
-      else
-        replacement = rewriter.create<ConstantOp>(
-            op.getSrc().getLoc(), op.getDest().getType(),
-            getIntZerosAttr(op.getDest().getType()));
-    }
     // This will be replaced with the constant source.  First, make sure the
     // constant dominates all users.
-    else if (srcValueOp != &declBlock->front()) {
+    if (srcValueOp && srcValueOp != &declBlock->front())
       srcValueOp->moveBefore(&declBlock->front());
-    }
-  }
 
   // Replace all things *using* the decl with the constant/port, and
   // remove the declaration.

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2601,31 +2601,6 @@ firrtl.module @Issue2291(out %out: !firrtl.uint<1>) {
   firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
-// Check that canonicalizing connects to zero works for clock, reset, and async
-// reset.  All these types require special constants as opposed to constants.
-//
-// CHECK-LABEL: @Issue2314
-firrtl.module @Issue2314(out %clock: !firrtl.clock, out %reset: !firrtl.reset, out %asyncReset: !firrtl.asyncreset) {
-  // CHECK-DAG: %[[zero_clock:.+]] = firrtl.specialconstant 0 : !firrtl.clock
-  // CHECK-DAG: %[[zero_reset:.+]] = firrtl.specialconstant 0 : !firrtl.reset
-  // CHECK-DAG: %[[zero_asyncReset:.+]] = firrtl.specialconstant 0 : !firrtl.asyncreset
-  %inv_clock = firrtl.wire  : !firrtl.clock
-  %invalid_clock = firrtl.invalidvalue : !firrtl.clock
-  firrtl.connect %inv_clock, %invalid_clock : !firrtl.clock, !firrtl.clock
-  firrtl.connect %clock, %inv_clock : !firrtl.clock, !firrtl.clock
-  // CHECK: firrtl.strictconnect %clock, %[[zero_clock]]
-  %inv_reset = firrtl.wire  : !firrtl.reset
-  %invalid_reset = firrtl.invalidvalue : !firrtl.reset
-  firrtl.connect %inv_reset, %invalid_reset : !firrtl.reset, !firrtl.reset
-  firrtl.connect %reset, %inv_reset : !firrtl.reset, !firrtl.reset
-  // CHECK: firrtl.strictconnect %reset, %[[zero_reset]]
-  %inv_asyncReset = firrtl.wire  : !firrtl.asyncreset
-  %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
-  firrtl.connect %inv_asyncReset, %invalid_asyncreset : !firrtl.asyncreset, !firrtl.asyncreset
-  firrtl.connect %asyncReset, %inv_asyncReset : !firrtl.asyncreset, !firrtl.asyncreset
-  // CHECK: firrtl.strictconnect %asyncReset, %[[zero_asyncReset]]
-}
-
 // Crasher from issue #3043
 // CHECK-LABEL: @Issue3043
 firrtl.module @Issue3043(out %a: !firrtl.vector<uint<5>, 3>) {


### PR DESCRIPTION
Remove canonicalizations related invalid values in RegOp since interpretation is context-dependent and it's unsafe to optimize before SFCCompat.