### PR TITLE
[Ibis] Introduce `ibis.block` instead of `ibis.schedule`

### DIFF
--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -215,9 +215,7 @@ def BlockOp : IbisOp<"block", [
   );
   let results = (outs Variadic<AnyType>:$outputs);
   let regions = (region SizedRegion<1>:$body);
-  let assemblyFormat = [{
-   `(` $inputs `)` `:` functional-type($inputs, $outputs) $body attr-dict
-  }];
+  let hasCustomAssemblyFormat = 1;
 
   let extraClassDeclaration = [{
     // Return the body of this block.

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -190,27 +190,53 @@ def ReturnOp : IbisOp<"return", [
   ];
 }
 
-def ScheduleOp : IbisOp<"schedule", [
-  HasParent<"MethodOp">,
+def BlockOp : IbisOp<"block", [
   SingleBlock,
-  NoRegionArguments,
-  NoTerminator
+  SingleBlockImplicitTerminator<"BlockReturnOp">,
+  AutomaticAllocationScope
 ]> {
-  let summary = "Ibis scheduling constraint block";
+  let summary = "Ibis block";
   let description = [{
-    The `ibis.schedule` operation defines a block wherein a group of operations
-    can be placed wherein a limited number of Ibis threads can execute at once.
-    The operation is not isolated from above and has no return types. References
-    to external values should be performed through SSA dominance or memrefs.
+    The `ibis.block` operation defines a block wherein a group of operations
+    are expected to be statically scheduleable.
+    The operation is not isolated from above to facilitate ease of construction.
+    However, once a program has been constructed and lowered to a sufficient
+    level, the user may run `--ibis-argify-blocks` to effectively isolate the
+    block from above, by converting SSA values referenced through dominanes into
+    arguments of the block
+
+    The block may contain additional attributes to specify constraints on
+    the block further down the compilation pipeline.
   }];
 
   let arguments = (ins
-    ConfinedAttr<I32Attr, [IntMinValue<1>]>:$limit
+    Variadic<AnyType>:$inputs,
+    OptionalAttr<ConfinedAttr<I32Attr, [IntMinValue<1>]>>:$maxThreads
   );
+  let results = (outs Variadic<AnyType>:$outputs);
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = [{
-    $limit $body attr-dict
+   `(` $inputs `)` `:` functional-type($inputs, $outputs) $body attr-dict
   }];
+
+  let extraClassDeclaration = [{
+    // Return the body of this block.
+    Block* getBodyBlock() { return &getBody().front(); }
+  }];
+  let hasVerifier = 1;
+}
+
+def BlockReturnOp : IbisOp<"block.return", [
+  Pure, ReturnLike, Terminator, HasParent<"BlockOp">]> {
+  let summary = "Ibis block terminator";
+
+  let arguments = (ins Variadic<AnyType>:$retValues);
+  let assemblyFormat = "($retValues^)? attr-dict (`:` type($retValues)^)?";
+  let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins), "/*no-op*/">
+  ];
 }
 
 def MemRefTypeAttr : TypeAttrBase<"MemRefType", "any memref type">;

--- a/include/circt/Support/ParsingUtils.h
+++ b/include/circt/Support/ParsingUtils.h
@@ -13,9 +13,9 @@
 #ifndef CIRCT_SUPPORT_PARSINGUTILS_H
 #define CIRCT_SUPPORT_PARSINGUTILS_H
 
-#include "mlir/IR/BuiltinAttributes.h"
-
 #include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/OpImplementation.h"
 
 namespace circt {
 namespace parsing_util {
@@ -33,6 +33,23 @@ static StringAttr getNameFromSSA(MLIRContext *context, StringRef name) {
   }
   return StringAttr::get(context, name);
 }
+
+//===----------------------------------------------------------------------===//
+// Initializer lists
+//===----------------------------------------------------------------------===//
+
+/// Parses an initializer.
+/// An initializer list is a list of operands, types and names on the format:
+///  (%arg = %input : type, ...)
+ParseResult parseInitializerList(
+    mlir::OpAsmParser &parser,
+    llvm::SmallVector<mlir::OpAsmParser::Argument> &inputArguments,
+    llvm::SmallVector<mlir::OpAsmParser::UnresolvedOperand> &inputOperands,
+    llvm::SmallVector<Type> &inputTypes, ArrayAttr &inputNames);
+
+// Prints an initializer list.
+void printInitializerList(OpAsmPrinter &p, ValueRange ins,
+                          ArrayRef<BlockArgument> args);
 
 } // namespace parsing_util
 } // namespace circt

--- a/lib/Dialect/Ibis/IbisOps.cpp
+++ b/lib/Dialect/Ibis/IbisOps.cpp
@@ -589,6 +589,41 @@ LogicalResult OutputWireOp::canonicalize(OutputWireOp op,
 }
 
 //===----------------------------------------------------------------------===//
+// BlockOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult BlockOp::verify() {
+  if (getInputs().size() != getBodyBlock()->getNumArguments())
+    return emitOpError("number of inputs must match number of block arguments");
+
+  for (auto [arg, barg] :
+       llvm::zip(getInputs(), getBodyBlock()->getArguments())) {
+    if (arg.getType() != barg.getType())
+      return emitOpError("block argument type must match input type");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// BlockReturnOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult BlockReturnOp::verify() {
+  BlockOp parent = cast<BlockOp>(getOperation()->getParentOp());
+
+  if (getNumOperands() != parent.getOutputs().size())
+    return emitOpError("number of operands must match number of block outputs");
+
+  for (auto [op, out] : llvm::zip(getOperands(), parent.getOutputs())) {
+    if (op.getType() != out.getType())
+      return emitOpError("operand type must match block output type");
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic
 //===----------------------------------------------------------------------===//
 

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -17,6 +17,7 @@ add_circt_library(CIRCTSupport
   Path.cpp
   PrettyPrinter.cpp
   PrettyPrinterHelpers.cpp
+  ParsingUtils.cpp
   SymCache.cpp
   ValueMapper.cpp
   InstanceGraph.cpp

--- a/lib/Support/ParsingUtils.cpp
+++ b/lib/Support/ParsingUtils.cpp
@@ -1,0 +1,50 @@
+//===- ParsingUtils.cpp - CIRCT parsing common functions ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/ParsingUtils.h"
+
+using namespace circt;
+
+ParseResult circt::parsing_util::parseInitializerList(
+    OpAsmParser &parser,
+    llvm::SmallVector<OpAsmParser::Argument> &inputArguments,
+    llvm::SmallVector<OpAsmParser::UnresolvedOperand> &inputOperands,
+    llvm::SmallVector<Type> &inputTypes, ArrayAttr &inputNames) {
+  llvm::SmallVector<Attribute> names;
+  if (failed(parser.parseCommaSeparatedList(
+          OpAsmParser::Delimiter::Paren, [&]() -> ParseResult {
+            OpAsmParser::UnresolvedOperand inputOperand;
+            Type type;
+            auto &arg = inputArguments.emplace_back();
+            if (parser.parseArgument(arg) || parser.parseColonType(type) ||
+                parser.parseEqual() || parser.parseOperand(inputOperand))
+              return failure();
+
+            inputOperands.push_back(inputOperand);
+            inputTypes.push_back(type);
+            arg.type = type;
+            names.push_back(StringAttr::get(
+                parser.getContext(),
+                /*drop leading %*/ arg.ssaName.name.drop_front()));
+            return success();
+          })))
+    return failure();
+
+  inputNames = ArrayAttr::get(parser.getContext(), names);
+  return success();
+}
+
+void circt::parsing_util::printInitializerList(OpAsmPrinter &p, ValueRange ins,
+                                               ArrayRef<BlockArgument> args) {
+  p << "(";
+  llvm::interleaveComma(llvm::zip(ins, args), p, [&](auto it) {
+    auto [in, arg] = it;
+    p << arg << " : " << in.getType() << " = " << in;
+  });
+  p << ")";
+}

--- a/test/Dialect/Ibis/errors.mlir
+++ b/test/Dialect/Ibis/errors.mlir
@@ -135,3 +135,15 @@ ibis.class @InvalidGetVar2 {
     %var = ibis.get_var %parent, @var : !ibis.scoperef<@InvalidGetVar2> -> memref<i1>
   }
 }
+
+// -----
+
+ibis.class @InvalidReturn {
+  %this = ibis.this @InvalidReturn
+  ibis.method @foo() {
+    %c = hw.constant 1 : i32
+    // expected-error @+1 {{'ibis.block.return' op number of operands must match number of block outputs}}
+    %ret = ibis.block() -> i32 {
+    }
+  }
+}

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -10,12 +10,11 @@
 // CHECK-NEXT:      %array = ibis.get_var %parent, @array : !ibis.scoperef<@HighLevel> -> memref<10xi32>
 // CHECK-NEXT:      %alloca = memref.alloca() : memref<i32>
 // CHECK-NEXT:      %c32_i32 = hw.constant 32 : i32
-// CHECK-NEXT:      %0 = ibis.block(%c32_i32) : (i32) -> i32 {
-// CHECK-NEXT:      ^bb0(%arg0: i32):
+// CHECK-NEXT:      %0:2 = ibis.block (%arg0 : i32 = %c32_i32) -> (i32, i32) attributes {schedule = 1 : i64}{
 // CHECK-NEXT:        %1 = memref.load %alloca[] : memref<i32>
 // CHECK-NEXT:        memref.store %arg0, %alloca[] : memref<i32>
-// CHECK-NEXT:        ibis.block.return %1 : i32
-// CHECK-NEXT:      } {schedule = 1 : i64}
+// CHECK-NEXT:        ibis.block.return %1, %1 : i32, i32
+// CHECK-NEXT:      }
 // CHECK-NEXT:      ibis.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
@@ -33,12 +32,11 @@ ibis.class @HighLevel {
     %array = ibis.get_var %parent, @array : !ibis.scoperef<@HighLevel> -> memref<10xi32>
     %local = memref.alloca() : memref<i32>
     %c32 = hw.constant 32 : i32
-    %res = ibis.block(%c32) : (i32) -> (i32) {
-      ^bb0(%arg : i32):
+    %out1, %out2 = ibis.block(%arg : i32 = %c32) -> (i32, i32) attributes {schedule = 1} {
       %v = memref.load %local[] : memref<i32>
       memref.store %arg, %local[] : memref<i32>
-      ibis.block.return %v : i32
-    } {schedule = 1}
+      ibis.block.return %v, %v : i32, i32
+    } 
   }
 }
 

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -9,10 +9,13 @@
 // CHECK-NEXT:      %single = ibis.get_var %parent, @single : !ibis.scoperef<@HighLevel> -> memref<i32>
 // CHECK-NEXT:      %array = ibis.get_var %parent, @array : !ibis.scoperef<@HighLevel> -> memref<10xi32>
 // CHECK-NEXT:      %alloca = memref.alloca() : memref<i32>
-// CHECK-NEXT:      ibis.schedule 1 {
-// CHECK-NEXT:        %0 = memref.load %alloca[] : memref<i32>
-// CHECK-NEXT:        memref.store %0, %alloca[] : memref<i32>
-// CHECK-NEXT:      }
+// CHECK-NEXT:      %c32_i32 = hw.constant 32 : i32
+// CHECK-NEXT:      %0 = ibis.block(%c32_i32) : (i32) -> i32 {
+// CHECK-NEXT:      ^bb0(%arg0: i32):
+// CHECK-NEXT:        %1 = memref.load %alloca[] : memref<i32>
+// CHECK-NEXT:        memref.store %arg0, %alloca[] : memref<i32>
+// CHECK-NEXT:        ibis.block.return %1 : i32
+// CHECK-NEXT:      } {schedule = 1 : i64}
 // CHECK-NEXT:      ibis.return
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
@@ -29,10 +32,13 @@ ibis.class @HighLevel {
     %single = ibis.get_var %parent, @single : !ibis.scoperef<@HighLevel> -> memref<i32>
     %array = ibis.get_var %parent, @array : !ibis.scoperef<@HighLevel> -> memref<10xi32>
     %local = memref.alloca() : memref<i32>
-    ibis.schedule 1 {
+    %c32 = hw.constant 32 : i32
+    %res = ibis.block(%c32) : (i32) -> (i32) {
+      ^bb0(%arg : i32):
       %v = memref.load %local[] : memref<i32>
-      memref.store %v, %local[] : memref<i32>
-    }
+      memref.store %arg, %local[] : memref<i32>
+      ibis.block.return %v : i32
+    } {schedule = 1}
   }
 }
 


### PR DESCRIPTION
The `ibis.block` operation defines a block wherein a group of operations are expected to be statically scheduleable. The operation is not isolated from above to facilitate ease of construction. However, once a program has been constructed and lowered to a sufficient level, the user may run `--ibis-argify-blocks` to effectively isolate the block from above, by converting SSA values referenced through dominanes into arguments of the block

The block may contain additional attributes to specify constraints on the block further down the compilation pipeline.

This operation subsumes the `ibis.schedule` in that `ibis.schedule` has the same semantics as if we attach some scheduling constraint attribute to the block.