### PR TITLE
[firtool] Run canonicalizer before LowerTypes

### DIFF
--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -68,6 +68,12 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createWireDFTPass());
 
+  // Run canonicalizer before LowerTypes to prevent constant subaccess from
+  // causing IR size explosion.
+  if (!opt.disableOptimization)
+    pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
+        createSimpleCanonicalizerPass());
+
   if (opt.vbToBV) {
     pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass(
         firrtl::PreserveAggregate::All, firrtl::PreserveAggregate::All));


### PR DESCRIPTION
This adds extract canonicalizer to the early pipeline (even before LowerTypes). Chisel sometimes generates many subaccess  with constant indices which designers expect the compiler to optimize away. However since we didn't run canonicalizer before LowerTypes/ExpandWhens, LowerTypes expands subaccess into when-chains. This caused compile time regression internally. 

Depends on #6080 , #6083, #6085 so CI failure is expected. 