### PR TITLE
[FIRRTL] Replace the unrealized conversion cast in `LowerXMR` with an XMR op

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -348,6 +348,20 @@ def RefReleaseInitialOp : FIRRTLOp<"ref.release_initial"> {
   let hasCanonicalizer = 1;
 }
 
+def XMRRefOp : FIRRTLOp<"xmr.ref"> {
+  let summary = "FIRRTL XMR operation, targetable by ref ops.";
+  let arguments = (ins FlatSymbolRefAttr:$ref, DefaultValuedAttr<StrAttr, "{}">:$verbatimSuffix);
+  let results = (outs RefType:$dest);
+  let assemblyFormat = "$ref (`,` $verbatimSuffix^)? attr-dict `:` qualified(type($dest))";
+}
+
+def XMRDerefOp : FIRRTLOp<"xmr.deref"> {
+  let summary = "FIRRTL XMR operation, reading an XMR target.";
+  let arguments = (ins FlatSymbolRefAttr:$ref, DefaultValuedAttr<StrAttr, "{}">:$verbatimSuffix);
+  let results = (outs PassiveType:$dest);
+  let assemblyFormat = "$ref (`,` $verbatimSuffix^)? attr-dict `:` qualified(type($dest))";
+}
+
 //===----------------------------------------------------------------------===//
 // Verif Dialect Intrinsics
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -57,7 +57,7 @@ public:
             // Miscellaneous.
             BitsPrimOp, HeadPrimOp, MuxPrimOp, PadPrimOp, ShlPrimOp, ShrPrimOp,
             TailPrimOp, VerbatimExprOp, HWStructCastOp, BitCastOp, RefSendOp,
-            RefResolveOp, RefSubOp, RWProbeOp,
+            RefResolveOp, RefSubOp, RWProbeOp, XMRRefOp, XMRDerefOp,
             // Casts to deal with weird stuff
             UninferredResetCastOp, ConstCastOp, RefCastOp,
             mlir::UnrealizedConversionCastOp,
@@ -193,6 +193,8 @@ public:
   HANDLE(RefResolveOp, Unhandled);
   HANDLE(RefSubOp, Unhandled);
   HANDLE(RWProbeOp, Unhandled);
+  HANDLE(XMRRefOp, Unhandled);
+  HANDLE(XMRDerefOp, Unhandled);
 
   // Conversions.
   HANDLE(HWStructCastOp, Unhandled);

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1341,18 +1341,14 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-LABEL: hw.module @ForceRelease(
   firrtl.module @ForceRelease(in %c: !firrtl.uint<1>, in %clock: !firrtl.clock, in %x: !firrtl.uint<4>) {
     firrtl.instance r sym @xmr_sym @RefMe()
-    %0 = sv.xmr.ref @xmrPath : !hw.inout<i4>
-    %1 = builtin.unrealized_conversion_cast %0 : !hw.inout<i4> to !firrtl.rwprobe<uint<4>>
-    firrtl.ref.force %clock, %c, %1, %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
-    %2 = sv.xmr.ref @xmrPath : !hw.inout<i4>
-    %3 = builtin.unrealized_conversion_cast %2 : !hw.inout<i4> to !firrtl.rwprobe<uint<4>>
-    firrtl.ref.force_initial %c, %3, %x : !firrtl.uint<1>, !firrtl.uint<4>
-    %4 = sv.xmr.ref @xmrPath : !hw.inout<i4>
-    %5 = builtin.unrealized_conversion_cast %4 : !hw.inout<i4> to !firrtl.rwprobe<uint<4>>
-    firrtl.ref.release %clock, %c, %5 : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
-    %6 = sv.xmr.ref @xmrPath : !hw.inout<i4>
-    %7 = builtin.unrealized_conversion_cast %6 : !hw.inout<i4> to !firrtl.rwprobe<uint<4>>
-    firrtl.ref.release_initial %c, %7 : !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
+    %0 = firrtl.xmr.ref @xmrPath : !firrtl.rwprobe<uint<4>>
+    firrtl.ref.force %clock, %c, %0, %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
+    %1 = firrtl.xmr.ref @xmrPath : !firrtl.rwprobe<uint<4>>
+    firrtl.ref.force_initial %c, %1, %x : !firrtl.uint<1>, !firrtl.uint<4>
+    %2 = firrtl.xmr.ref @xmrPath : !firrtl.rwprobe<uint<4>>
+    firrtl.ref.release %clock, %c, %2 : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
+    %3 = firrtl.xmr.ref @xmrPath : !firrtl.rwprobe<uint<4>>
+    firrtl.ref.release_initial %c, %3 : !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
   }
   // CHECK-NEXT:  [[CLOCK:%.+]] = seq.from_clock %clock
   // CHECK-NEXT:  hw.instance "r" sym @xmr_sym @RefMe() -> ()
@@ -1551,4 +1547,17 @@ firrtl.circuit "ClockMuxLowering" {
     %0 = firrtl.mux(%cond, %clockTrue, %clockFalse) : (!firrtl.uint<1>, !firrtl.clock, !firrtl.clock) -> !firrtl.clock
     firrtl.strictconnect %out, %0 : !firrtl.clock
   }
+}
+
+// -----
+
+firrtl.circuit "RefXMRLowering" {
+  hw.hierpath private @path [@RefXMRLowering::@dummy]
+
+  firrtl.module @RefXMRLowering() {
+    // CHECK: sv.xmr.ref @path "test" : !hw.inout<i3>
+    firrtl.wire sym @dummy : !firrtl.uint<1>
+    firrtl.xmr.ref @path, "test" : !firrtl.rwprobe<uint<3>>
+  }
+
 }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -14,9 +14,8 @@ firrtl.circuit "xmr" {
     firrtl.strictconnect %o, %x : !firrtl.uint<2>
     // CHECK:      %w = firrtl.wire : !firrtl.uint<2>
     // CHECK:      %w_probe = firrtl.node sym @[[wSym:[a-zA-Z0-9_]+]] interesting_name %w : !firrtl.uint<2>
-    // CHECK-NEXT: %[[#xmr:]] = sv.xmr.ref @xmrPath : !hw.inout<i2>
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i2> to !firrtl.uint<2>
-    // CHECK:      firrtl.strictconnect %o, %[[#cast]] : !firrtl.uint<2>
+    // CHECK-NEXT: %[[#xmr:]] = firrtl.xmr.deref @xmrPath : !firrtl.uint<2>
+    // CHECK:      firrtl.strictconnect %o, %[[#xmr]] : !firrtl.uint<2>
   }
 }
 
@@ -45,9 +44,8 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] : !hw.inout<i1>
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i1> to !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]] : !firrtl.uint<1>
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]] : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#xmr]] : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
   }
 }
@@ -94,10 +92,9 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] : !hw.inout<i1>
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i1> to !firrtl.uint<1>
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]] : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#xmr]]
   }
 }
 
@@ -124,22 +121,20 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @fooXMR  @XmrSrcMod()
     firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_0]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path_0]]
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK:      firrtl.strictconnect %a, %[[#cast]]
+    // CHECK:      firrtl.strictconnect %a, %[[#xmr]]
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK:  firrtl.instance bar sym @barXMR  @XmrSrcMod()
     firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_1]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path_1]]
     %a = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK:      firrtl.strictconnect %a, %[[#cast]]
+    // CHECK:      firrtl.strictconnect %a, %[[#xmr]]
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -152,20 +147,17 @@ firrtl.circuit "Top" {
     %b = firrtl.wire : !firrtl.uint<1>
     %c = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_2]]
-    // CHECK-NEXT: %[[#cast_2:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr_2:]] = firrtl.xmr.deref @[[path_2]]
     %1 = firrtl.ref.resolve %foo_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_3]]
-    // CHECK-NEXT: %[[#cast_3:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr_3:]] = firrtl.xmr.deref @[[path_3]]
     %2 = firrtl.ref.resolve %xmr_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_4]]
-    // CHECK-NEXT: %[[#cast_4:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr_4:]] = firrtl.xmr.deref @[[path_4]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast_2]]
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#xmr_2]]
     firrtl.strictconnect %b, %1 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %b, %[[#cast_3]]
+    // CHECK-NEXT: firrtl.strictconnect %b, %[[#xmr_3]]
     firrtl.strictconnect %c, %2 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %c, %[[#cast_4]]
+    // CHECK-NEXT: firrtl.strictconnect %c, %[[#xmr_4]]
   }
 }
 
@@ -193,17 +185,15 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#xmr]]
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.probe<uint<1>>)
     firrtl.ref.define %c_a, %bar_a : !firrtl.probe<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
   }
 
 }
@@ -230,17 +220,15 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#xmr]]
     %c_a = firrtl.instance child @Child(in  _a: !firrtl.probe<uint<1>>)
     firrtl.ref.define %c_a, %bar_a : !firrtl.probe<uint<1>>
   }
   firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
   }
 }
 
@@ -271,11 +259,9 @@ firrtl.circuit "Top" {
   }
   firrtl.module @Child2p(in  %_a: !firrtl.probe<uint<1>>, in  %_b: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_0]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path_0]]
     %1 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path_1]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path_1]]
   }
 }
 
@@ -299,8 +285,7 @@ firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>, in _b: !firrtl.probe<uint<1>> )
     firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
     firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>
@@ -309,19 +294,15 @@ firrtl.circuit "Top" {
   }
   firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>, in  %_b: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
     %1 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
   }
   firrtl.module @Child3(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
     %1 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
   }
 }
 
@@ -345,8 +326,7 @@ firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>, in _b: !firrtl.probe<uint<1>> )
     firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
     firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>
@@ -355,19 +335,15 @@ firrtl.circuit "Top" {
   }
   firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>, in  %_b: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
     %1 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
   }
   firrtl.module @Child3(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
     %1 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
   }
 }
 
@@ -396,8 +372,7 @@ firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Child1() {
   firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
     %c_a, %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>, in _b: !firrtl.probe<uint<1>> )
     firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
     firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>
@@ -406,19 +381,15 @@ firrtl.circuit "Top" {
   }
   firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>, in  %_b: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
     %1 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
   }
   firrtl.module @Child3(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
     %1 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
   }
 }
 
@@ -457,8 +428,7 @@ firrtl.circuit "Top"  {
     // CHECK: firrtl.instance dut sym @[[TOP_XMR_SYM]] @DUTModule
     %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap: !firrtl.probe<vector<uint<8>, 8>>)
     %0 = firrtl.ref.resolve %dut__gen_memTap : !firrtl.probe<vector<uint<8>, 8>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".Memory"
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]], ".Memory"
     firrtl.strictconnect %dut_clock, %clock : !firrtl.clock
     %memTap_0 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
     %memTap_1 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
@@ -473,35 +443,35 @@ firrtl.circuit "Top"  {
     firrtl.strictconnect %dut_io_dataIn, %io_dataIn : !firrtl.uint<8>
     firrtl.strictconnect %dut_io_addr, %io_addr : !firrtl.uint<3>
     %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<8>, 8>
-    // CHECK: %[[#cast_0:]] = firrtl.subindex %[[#cast]][0]
+    // CHECK: %[[#cast_0:]] = firrtl.subindex %[[#xmr]][0]
     firrtl.strictconnect %memTap_0, %1 : !firrtl.uint<8>
     // CHECK:  firrtl.strictconnect %memTap_0, %[[#cast_0]] : !firrtl.uint<8>
     %2 = firrtl.subindex %0[1] : !firrtl.vector<uint<8>, 8>
-    // CHECK: %[[#cast_1:]] = firrtl.subindex %[[#cast]][1]
+    // CHECK: %[[#cast_1:]] = firrtl.subindex %[[#xmr]][1]
     firrtl.strictconnect %memTap_1, %2 : !firrtl.uint<8>
     // CHECK:  firrtl.strictconnect %memTap_1, %[[#cast_1]] : !firrtl.uint<8>
     %3 = firrtl.subindex %0[2] : !firrtl.vector<uint<8>, 8>
-    // CHECK: %[[#cast_2:]] = firrtl.subindex %[[#cast]][2]
+    // CHECK: %[[#cast_2:]] = firrtl.subindex %[[#xmr]][2]
     firrtl.strictconnect %memTap_2, %3 : !firrtl.uint<8>
     // CHECK:  firrtl.strictconnect %memTap_2, %[[#cast_2]] : !firrtl.uint<8>
     %4 = firrtl.subindex %0[3] : !firrtl.vector<uint<8>, 8>
-    // CHECK: %[[#cast_3:]] = firrtl.subindex %[[#cast]][3]
+    // CHECK: %[[#cast_3:]] = firrtl.subindex %[[#xmr]][3]
     firrtl.strictconnect %memTap_3, %4 : !firrtl.uint<8>
     // CHECK:  firrtl.strictconnect %memTap_3, %[[#cast_3]] : !firrtl.uint<8>
     %5 = firrtl.subindex %0[4] : !firrtl.vector<uint<8>, 8>
-    // CHECK: %[[#cast_4:]] = firrtl.subindex %[[#cast]][4]
+    // CHECK: %[[#cast_4:]] = firrtl.subindex %[[#xmr]][4]
     firrtl.strictconnect %memTap_4, %5 : !firrtl.uint<8>
     // CHECK:  firrtl.strictconnect %memTap_4, %[[#cast_4]] : !firrtl.uint<8>
     %6 = firrtl.subindex %0[5] : !firrtl.vector<uint<8>, 8>
-    // CHECK: %[[#cast_5:]] = firrtl.subindex %[[#cast]][5]
+    // CHECK: %[[#cast_5:]] = firrtl.subindex %[[#xmr]][5]
     firrtl.strictconnect %memTap_5, %6 : !firrtl.uint<8>
     // CHECK:  firrtl.strictconnect %memTap_5, %[[#cast_5]] : !firrtl.uint<8>
     %7 = firrtl.subindex %0[6] : !firrtl.vector<uint<8>, 8>
-    // CHECK: %[[#cast_6:]] = firrtl.subindex %[[#cast]][6]
+    // CHECK: %[[#cast_6:]] = firrtl.subindex %[[#xmr]][6]
     firrtl.strictconnect %memTap_6, %7 : !firrtl.uint<8>
     // CHECK:  firrtl.strictconnect %memTap_6, %[[#cast_6]] : !firrtl.uint<8>
     %8 = firrtl.subindex %0[7] : !firrtl.vector<uint<8>, 8>
-    // CHECK: %[[#cast_7:]] = firrtl.subindex %[[#cast]][7]
+    // CHECK: %[[#cast_7:]] = firrtl.subindex %[[#xmr]][7]
     firrtl.strictconnect %memTap_7, %8 : !firrtl.uint<8>
     // CHECK:  firrtl.strictconnect %memTap_7, %[[#cast_7]] : !firrtl.uint<8>
     }
@@ -526,18 +496,16 @@ firrtl.circuit "Top"  {
     // CHECK: firrtl.instance dut sym @[[TOP_XMR_SYM]] @DUTModule
     %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap_0, %dut__gen_memTap_1 = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap_0: !firrtl.probe<uint<8>>, out _gen_memTap_1: !firrtl.probe<uint<8>>)
     %0 = firrtl.ref.resolve %dut__gen_memTap_0 : !firrtl.probe<uint<8>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".Memory[0]"
-    // CHECK-NEXT: %[[#cast_0:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr_0:]] = firrtl.xmr.deref @[[path]], ".Memory[0]"
     %1 = firrtl.ref.resolve %dut__gen_memTap_1 : !firrtl.probe<uint<8>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".Memory[1]"
-    // CHECK-NEXT: %[[#cast_1:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr_1:]] = firrtl.xmr.deref @[[path]], ".Memory[1]"
     firrtl.strictconnect %dut_clock, %clock : !firrtl.clock
     %memTap_0 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
     %memTap_1 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
     firrtl.strictconnect %memTap_0, %0 : !firrtl.uint<8>
-    // CHECK:      firrtl.strictconnect %memTap_0, %[[#cast_0]]
+    // CHECK:      firrtl.strictconnect %memTap_0, %[[#xmr_0]]
     firrtl.strictconnect %memTap_1, %1 : !firrtl.uint<8>
-    // CHECK:      firrtl.strictconnect %memTap_1, %[[#cast_1]]
+    // CHECK:      firrtl.strictconnect %memTap_1, %[[#xmr_1]]
   }
 }
 
@@ -564,10 +532,9 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]] ".internal.path"
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]], ".internal.path"
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#xmr]]
   }
 }
 
@@ -595,10 +562,9 @@ firrtl.circuit "Top" {
     // CHECK:  firrtl.instance bar sym @bar  @Bar()
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    // CHECK:      %[[#xmr:]] = sv.xmr.ref @[[path]]
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]]
+    // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
     firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %a, %[[#cast]]
+    // CHECK-NEXT: firrtl.strictconnect %a, %[[#xmr]]
   }
 }
 
@@ -636,7 +602,7 @@ firrtl.circuit "Issue4559" {
   firrtl.module @Issue4559() {
     // CHECK: %[[PORT:.+]] = firrtl.instance source @Source
     // CHECK-NEXT: %[[NODE:.+]] = firrtl.node sym @[[SYM]] interesting_name %[[PORT]]
-    // CHECK-NEXT: = sv.xmr.ref @xmrPath
+    // CHECK-NEXT: = firrtl.xmr.deref @xmrPath
     %port = firrtl.instance source @Source(out sourceport: !firrtl.uint<1>)
     %port_ref = firrtl.ref.send %port : !firrtl.uint<1>
     %port_val = firrtl.ref.resolve %port_ref : !firrtl.probe<uint<1>>
@@ -656,9 +622,8 @@ firrtl.circuit "ReadForceable" {
     // CHECK-NOT: firrtl.ref.resolve
     firrtl.strictconnect %o, %x : !firrtl.uint<2>
     // CHECK:      %w, %w_ref = firrtl.wire sym @[[wSym]] forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
-    // CHECK-NEXT: %[[#xmr:]] = sv.xmr.ref @xmrPath : !hw.inout<i2>
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i2> to !firrtl.uint<2>
-    // CHECK:      firrtl.strictconnect %o, %[[#cast]] : !firrtl.uint<2>
+    // CHECK-NEXT: %[[#xmr:]] = firrtl.xmr.deref @xmrPath : !firrtl.uint<2>
+    // CHECK:      firrtl.strictconnect %o, %[[#xmr]] : !firrtl.uint<2>
   }
 }
 
@@ -675,9 +640,8 @@ firrtl.circuit "RefCast" {
     %x = firrtl.ref.resolve %w_ro : !firrtl.probe<uint<2>>
     firrtl.strictconnect %o, %x : !firrtl.uint<2>
     // CHECK-NEXT: %w, %w_ref = firrtl.wire sym @[[wSym]] forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
-    // CHECK-NEXT: %[[#xmr:]] = sv.xmr.ref @xmrPath : !hw.inout<i2>
-    // CHECK-NEXT: %[[#cast:]] = builtin.unrealized_conversion_cast %[[#xmr]] : !hw.inout<i2> to !firrtl.uint<2>
-    // CHECK-NEXT: firrtl.strictconnect %o, %[[#cast]] : !firrtl.uint<2>
+    // CHECK-NEXT: %[[#xmr:]] = firrtl.xmr.deref @xmrPath : !firrtl.uint<2>
+    // CHECK-NEXT: firrtl.strictconnect %o, %[[#xmr]] : !firrtl.uint<2>
   }
 }
 
@@ -697,24 +661,17 @@ firrtl.circuit "ForceRelease" {
   firrtl.module @ForceRelease(in %c: !firrtl.uint<1>, in %clock: !firrtl.clock, in %x: !firrtl.uint<4>) {
       // CHECK-NEXT: firrtl.instance r sym @[[INST_SYM]] @RefMe()
       %r_p = firrtl.instance r @RefMe(out p: !firrtl.rwprobe<uint<4>>)
-      // CHECK-NEXT: %[[REF1:.+]] = sv.xmr.ref @[[XMRPATH]] : !hw.inout<i4>
-      // CHECK-NEXT: %[[CAST1:.+]] = builtin.unrealized_conversion_cast %[[REF1]] : !hw.inout<i4> to !firrtl.rwprobe<uint<4>>
-   
-      // CHECK-NEXT: firrtl.ref.force %clock, %c, %[[CAST1]], %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
-
+      // CHECK-NEXT: %[[REF1:.+]] = firrtl.xmr.ref @[[XMRPATH]] : !firrtl.rwprobe<uint<4>>
+      // CHECK-NEXT: firrtl.ref.force %clock, %c, %[[REF1]], %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
       firrtl.ref.force %clock, %c, %r_p, %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
-      // CHECK-NEXT: %[[REF2:.+]] = sv.xmr.ref @[[XMRPATH]] : !hw.inout<i4>
-      // CHECK-NEXT: %[[CAST2:.+]] = builtin.unrealized_conversion_cast %[[REF2]] : !hw.inout<i4> to !firrtl.rwprobe<uint<4>>
-
-      // CHECK-NEXT: firrtl.ref.force_initial %c, %[[CAST2]], %x : !firrtl.uint<1>, !firrtl.uint<4>
+      // CHECK-NEXT: %[[REF2:.+]] = firrtl.xmr.ref @[[XMRPATH]] : !firrtl.rwprobe<uint<4>>
+      // CHECK-NEXT: firrtl.ref.force_initial %c, %[[REF2]], %x : !firrtl.uint<1>, !firrtl.uint<4>
       firrtl.ref.force_initial %c, %r_p, %x : !firrtl.uint<1>, !firrtl.uint<4>
-      // CHECK-NEXT: %[[REF3:.+]] = sv.xmr.ref @[[XMRPATH]] : !hw.inout<i4>
-      // CHECK-NEXT: %[[CAST3:.+]] = builtin.unrealized_conversion_cast %[[REF3]] : !hw.inout<i4> to !firrtl.rwprobe<uint<4>>
-      // CHECK-NEXT: firrtl.ref.release %clock, %c, %[[CAST3]] : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
+      // CHECK-NEXT: %[[REF3:.+]] = firrtl.xmr.ref @[[XMRPATH]] : !firrtl.rwprobe<uint<4>>
+      // CHECK-NEXT: firrtl.ref.release %clock, %c, %[[REF3]] : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
       firrtl.ref.release %clock, %c, %r_p : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
-      // CHECK-NEXT: %[[REF4:.+]] = sv.xmr.ref @[[XMRPATH]] : !hw.inout<i4>
-      // CHECK-NEXT: %[[CAST4:.+]] = builtin.unrealized_conversion_cast %[[REF4]] : !hw.inout<i4> to !firrtl.rwprobe<uint<4>>
-      // CHECK-NEXT: firrtl.ref.release_initial %c, %[[CAST4]] : !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
+      // CHECK-NEXT: %[[REF4:.+]] = firrtl.xmr.ref @[[XMRPATH]] : !firrtl.rwprobe<uint<4>>
+      // CHECK-NEXT: firrtl.ref.release_initial %c, %[[REF4]] : !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
       firrtl.ref.release_initial %c, %r_p : !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
     }
   }
@@ -747,7 +704,7 @@ firrtl.circuit "Top" {
   // CHECK-SAME:          ([@[[XMR5]]]) {output_file = #hw.output_file<"ref_Top_Foo.sv">}
 
   // CHECK-NEXT:  sv.macro.decl @ref_Top_Foo_y
-  // CHECK-NEXT:          sv.macro.def @ref_Top_Foo_y "internal.path" 
+  // CHECK-NEXT:          sv.macro.def @ref_Top_Foo_y "internal.path"
   // CHECK-NOT:           ([
   // CHECK-SAME:          {output_file = #hw.output_file<"ref_Top_Foo.sv">}
 
@@ -755,22 +712,22 @@ firrtl.circuit "Top" {
   // CHECK:        hw.hierpath private @[[XMR2]] [@Top::@foo, @Foo::@[[FOO_X_SYM]]]
   // CHECK:        hw.hierpath private @[[XMR3]] [@Top::@foo]
   // CHECK:        hw.hierpath private @[[XMR4]] [@Top::@{{.+}}]
-  
+
   // CHECK-LABEL: firrtl.module @Top()
-  firrtl.module @Top(out %a: !firrtl.probe<uint<1>>, 
-                     out %b: !firrtl.probe<uint<1>>, 
-                     out %c: !firrtl.probe<uint<1>>, 
+  firrtl.module @Top(out %a: !firrtl.probe<uint<1>>,
+                     out %b: !firrtl.probe<uint<1>>,
+                     out %c: !firrtl.probe<uint<1>>,
                      out %d: !firrtl.probe<uint<1>>,
                      in %e: !firrtl.probe<uint<1>>) {
     %w = firrtl.wire sym @w : !firrtl.uint<1>
     // CHECK: firrtl.node sym @[[TOP_W_SYM]] interesting_name %w
     %0 = firrtl.ref.send %w : !firrtl.uint<1>
     firrtl.ref.define %a, %0 : !firrtl.probe<uint<1>>
-    
+
     %x, %y = firrtl.instance foo sym @foo @Foo(out x: !firrtl.probe<uint<1>>, out y: !firrtl.probe<uint<1>>)
     firrtl.ref.define %b, %x : !firrtl.probe<uint<1>>
     firrtl.ref.define %c, %y : !firrtl.probe<uint<1>>
-    
+
     %constant = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.ref.send %constant : !firrtl.uint<1>
     firrtl.ref.define %d, %1 : !firrtl.probe<uint<1>>
@@ -798,7 +755,7 @@ firrtl.circuit "InternalPaths" {
                                        out r: !firrtl.probe<uint<1>>,
                                        out data: !firrtl.uint<3>,
                                        out r2: !firrtl.probe<vector<bundle<a: uint<3>>, 3>>) attributes {convention = #firrtl<convention scalarized>, internalPaths = [#firrtl.internalpath, #firrtl.internalpath<"path.to.internal.signal">, #firrtl.internalpath, #firrtl.internalpath<"in">]}
-  // CHECK: hw.hierpath private @xmrPath [@InternalPaths::@[[EXT_SYM:.+]]] 
+  // CHECK: hw.hierpath private @xmrPath [@InternalPaths::@[[EXT_SYM:.+]]]
   // CHECK: module public @InternalPaths(
   firrtl.module public @InternalPaths(in %in: !firrtl.uint<1>) {
     // CHECK: firrtl.instance ext sym @[[EXT_SYM]] @RefExtMore
@@ -809,14 +766,12 @@ firrtl.circuit "InternalPaths" {
                                       out r2: !firrtl.probe<vector<bundle<a: uint<3>>, 3>>)
    firrtl.strictconnect %ext_in, %in : !firrtl.uint<1>
 
-   // CHECK: %[[XMR_R:.+]] = sv.xmr.ref @xmrPath ".path.to.internal.signal" : !hw.inout<i1>
-   // CHECK: %[[XMR_R_CAST:.+]] = builtin.unrealized_conversion_cast %[[XMR_R]] : !hw.inout<i1> to !firrtl.uint<1>
-   // CHECK: %node_r = firrtl.node %[[XMR_R_CAST]]
+   // CHECK: %[[XMR_R:.+]] = firrtl.xmr.deref @xmrPath, ".path.to.internal.signal" : !firrtl.uint<1>
+   // CHECK: %node_r = firrtl.node %[[XMR_R]]
    %read_r  = firrtl.ref.resolve %ext_r : !firrtl.probe<uint<1>>
    %node_r = firrtl.node %read_r : !firrtl.uint<1>
-   // CHECK: %[[XMR_R2:.+]] = sv.xmr.ref @xmrPath ".in" : !hw.inout<array<3xstruct<a: i3>>>
-   // CHECK: %[[XMR_R2_CAST:.+]] = builtin.unrealized_conversion_cast %[[XMR_R2]] : !hw.inout<array<3xstruct<a: i3>>> to !firrtl.vector<bundle<a: uint<3>>, 3>
-   // CHECK: %node_r2 = firrtl.node %[[XMR_R2_CAST]]
+   // CHECK: %[[XMR_R2:.+]] = firrtl.xmr.deref @xmrPath, ".in" : !firrtl.vector<bundle<a: uint<3>>, 3>
+   // CHECK: %node_r2 = firrtl.node %[[XMR_R2]]
    %read_r2  = firrtl.ref.resolve %ext_r2 : !firrtl.probe<vector<bundle<a: uint<3>>, 3>>
    %node_r2 = firrtl.node %read_r2 : !firrtl.vector<bundle<a: uint<3>>, 3>
   }
@@ -831,7 +786,7 @@ firrtl.circuit "RefABI" {
                                        out r: !firrtl.probe<uint<1>>,
                                        out data: !firrtl.uint<3>,
                                        out r2: !firrtl.probe<vector<bundle<a: uint<3>>, 3>>) attributes {convention = #firrtl<convention scalarized>}
-  // CHECK:  hw.hierpath private @xmrPath [@RefABI::@[[XMR_SYM:.+]]] 
+  // CHECK:  hw.hierpath private @xmrPath [@RefABI::@[[XMR_SYM:.+]]]
   // CHECK: module public @RefABI(
   firrtl.module public @RefABI(in %in: !firrtl.uint<1>) {
     %ext_in, %ext_r, %ext_data, %ext_r2 =
@@ -842,14 +797,12 @@ firrtl.circuit "RefABI" {
                                       out r2: !firrtl.probe<vector<bundle<a: uint<3>>, 3>>)
    firrtl.strictconnect %ext_in, %in : !firrtl.uint<1>
 
-   // CHECK: %[[XMR_R:.+]] = sv.xmr.ref @xmrPath ".`ref_RefExtMore_RefExtMore_r" : !hw.inout<i1>
-   // CHECK: %[[XMR_R_CAST:.+]] = builtin.unrealized_conversion_cast %[[XMR_R]] : !hw.inout<i1> to !firrtl.uint<1>
-   // CHECK: %node_r = firrtl.node %[[XMR_R_CAST]]
+   // CHECK: %[[XMR_R:.+]] = firrtl.xmr.deref @xmrPath, ".`ref_RefExtMore_RefExtMore_r" : !firrtl.uint<1>
+   // CHECK: %node_r = firrtl.node %[[XMR_R]]
    %read_r  = firrtl.ref.resolve %ext_r : !firrtl.probe<uint<1>>
    %node_r = firrtl.node %read_r : !firrtl.uint<1>
-   // CHECK: %[[XMR_R2:.+]] = sv.xmr.ref @xmrPath ".`ref_RefExtMore_RefExtMore_r2" : !hw.inout<array<3xstruct<a: i3>>>
-   // CHECK: %[[XMR_R2_CAST:.+]] = builtin.unrealized_conversion_cast %[[XMR_R2]] : !hw.inout<array<3xstruct<a: i3>>> to !firrtl.vector<bundle<a: uint<3>>, 3>
-   // CHECK: %node_r2 = firrtl.node %[[XMR_R2_CAST]]
+   // CHECK: %[[XMR_R2:.+]] = firrtl.xmr.deref @xmrPath, ".`ref_RefExtMore_RefExtMore_r2" : !firrtl.vector<bundle<a: uint<3>>, 3>
+   // CHECK: %node_r2 = firrtl.node %[[XMR_R2]]
    %read_r2  = firrtl.ref.resolve %ext_r2 : !firrtl.probe<vector<bundle<a: uint<3>>, 3>>
    %node_r2 = firrtl.node %read_r2 : !firrtl.vector<bundle<a: uint<3>>, 3>
   }
@@ -874,7 +827,7 @@ firrtl.circuit "BasicRefSub" {
     // CHECK: firrtl.instance c sym @[[C_SYM]]
     %c_in, %c_out = firrtl.instance c @Child(in in : !firrtl.bundle<a: uint<1>, b: uint<2>>, out out : !firrtl.probe<uint<2>>)
     firrtl.strictconnect %c_in, %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
-    // CHECK: sv.xmr.ref @[[XMRPATH]] ".b"
+    // CHECK: firrtl.xmr.deref @[[XMRPATH]], ".b"
     %res = firrtl.ref.resolve %c_out : !firrtl.probe<uint<2>>
     firrtl.strictconnect %out, %res : !firrtl.uint<2>
   }


### PR DESCRIPTION
Added basic placeholders for `sv.xmr.ref`, `firrtl.xmr.ref` and `firrtl.xmr.deref`, to the FIRRTL stages of the pipeline. This avoids the use of an unrealized conversion cast and leaves the lowering and type reconciliation to the later `LowerToHW` pass.