### PR TITLE
 [Ibis] Add ibis reblock pass 

### DIFF
--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -137,11 +137,10 @@ def InstanceOp : InstanceOpBase<"instance"> {
 }
 
 def MethodOp : IbisOp<"method", [
-      IsolatedFromAbove, RegionKindInterface,
+      IsolatedFromAbove,
       Symbol, FunctionOpInterface,
       AutomaticAllocationScope,
       DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>,
-      SingleBlockImplicitTerminator<"ReturnOp">,
       HasParent<"ClassOp">]> {
 
   let summary = "Ibis method";
@@ -157,14 +156,11 @@ def MethodOp : IbisOp<"method", [
                        ArrayAttr:$argNames,
                        OptionalAttr<DictArrayAttr>:$arg_attrs,
                        OptionalAttr<DictArrayAttr>:$res_attrs);
-  let regions = (region SizedRegion<1>:$body);
+  let regions = (region AnyRegion:$body);
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    // Implement RegionKindInterface.
-    static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph;}
-
     //===------------------------------------------------------------------===//
     // FunctionOpInterface Methods
     //===------------------------------------------------------------------===//
@@ -228,6 +224,19 @@ def BlockOp : IbisOp<"block", [
     Block* getBodyBlock() { return &getBody().front(); }
   }];
   let hasVerifier = 1;
+  let skipDefaultBuilders = 1;
+    let builders = [
+    OpBuilder<(ins "TypeRange":$outputs, "ValueRange":$inputs,
+        CArg<"IntegerAttr", "{}">:$maxThreads), [{
+      $_state.addOperands(inputs);
+      if (maxThreads) {
+        $_state.addAttribute(getMaxThreadsAttrName($_state.name), maxThreads);
+      }
+      auto* region = $_state.addRegion();
+      $_state.addTypes(outputs);
+      ensureTerminator(*region, $_builder, $_state.location);
+    }]>
+  ];
 }
 
 def BlockReturnOp : IbisOp<"block.return", [

--- a/include/circt/Dialect/Ibis/IbisPasses.h
+++ b/include/circt/Dialect/Ibis/IbisPasses.h
@@ -24,6 +24,7 @@ std::unique_ptr<Pass> createPortrefLoweringPass();
 std::unique_ptr<Pass> createCleanSelfdriversPass();
 std::unique_ptr<Pass> createContainersToHWPass();
 std::unique_ptr<Pass> createArgifyBlocksPass();
+std::unique_ptr<Pass> createReblockPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Ibis/IbisPasses.td
+++ b/include/circt/Dialect/Ibis/IbisPasses.td
@@ -95,4 +95,42 @@ def IbisArgifyBlocks : Pass<"ibis-argify-blocks"> {
   let constructor = "circt::ibis::createArgifyBlocksPass()";
 }
 
+def IbisReblock : Pass<"ibis-reblock", "ibis::MethodOp"> {
+  let summary = "Recreates `ibis.block` operations from a CFG";
+  let description = [{
+    Recreates `ibis.block` operations from a CFG. Any `ibis.block.attributes`
+    operations at the parent operation will be added to the resulting blocks.
+
+    The IR is expected to be in maximal SSA form prior to this pass, given that
+    the pass will only inspect the terminator operation of a block for any
+    values that are generated within the block. Maximum SSA form thus ensures
+    that any value defined within the block is never used outside of the block.
+
+    It is expected that `ibis.call` operations have been isolated into
+    their own basic blocks before this pass is run. This implies that all
+    operations within a block (except for the terminator operation) can be
+    statically scheduled with each other.
+
+    e.g.
+    ```mlir
+    ^bb_foo(%arg0 : i32, %arg1 : i32):
+      %res = arith.addi %arg0, %arg1 : i32
+      %v = ...
+      cf.br ^bb_bar(%v : i32)
+    ```
+
+    becomes
+    ```mlir
+    ^bb_foo(%arg0 : i32, %arg1 : i32):
+      %v_outer = ibis.block(%a0 : i32 = %arg0, %a1 : i32 = %arg1) -> (i32) {
+        %res = arith.addi %arg0, %arg1 : i32
+        %v = ...
+        ibis.block.return %v : i32
+      }
+      cf.br ^bb_bar(%v_outer : i32)
+    ```
+  }];
+  let constructor = "circt::ibis::createReblockPass()";
+}
+
 #endif // CIRCT_DIALECT_IBIS_PASSES_TD

--- a/lib/Dialect/Ibis/IbisOps.cpp
+++ b/lib/Dialect/Ibis/IbisOps.cpp
@@ -15,7 +15,6 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/FunctionImplementation.h"
 #include "llvm/ADT/TypeSwitch.h"
-
 using namespace mlir;
 using namespace circt;
 using namespace ibis;
@@ -176,7 +175,6 @@ ParseResult MethodOp::parse(OpAsmParser &parser, OperationState &result) {
   if (parser.parseRegion(*body, args))
     return failure();
 
-  ensureTerminator(*body, parser.getBuilder(), result.location);
   return success();
 }
 

--- a/lib/Dialect/Ibis/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Ibis/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_circt_dialect_library(CIRCTIbisTransforms
   IbisCleanSelfdrivers.cpp
   IbisContainersToHW.cpp
   IbisArgifyBlocksPass.cpp
+  IbisReblockPass.cpp
 
   DEPENDS
   CIRCTIbisTransformsIncGen
@@ -18,4 +19,7 @@ add_circt_dialect_library(CIRCTIbisTransforms
   MLIRIR
   MLIRPass
   MLIRTransformUtils
+
+  # TODO: change me
+  CIRCTCFToHandshake
 )

--- a/lib/Dialect/Ibis/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Ibis/Transforms/CMakeLists.txt
@@ -16,10 +16,8 @@ add_circt_dialect_library(CIRCTIbisTransforms
   CIRCTIbis
   CIRCTHW
   CIRCTSupport
+  CIRCTTransforms
   MLIRIR
   MLIRPass
   MLIRTransformUtils
-
-  # TODO: change me
-  CIRCTCFToHandshake
 )

--- a/lib/Dialect/Ibis/Transforms/IbisCallPrep.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisCallPrep.cpp
@@ -208,8 +208,8 @@ void MergeMethodArgs::rewrite(MethodOp func, OpAdaptor adaptor,
   if (func->getNumRegions() > 0) {
     // Create a body block with a struct explode to the arg struct into the
     // original arguments.
-    Block *b = rewriter.createBlock(&newMethod.getBodyRegion(), {}, {argStruct},
-                                    {argLoc});
+    Block *b =
+        rewriter.createBlock(&newMethod.getRegion(), {}, {argStruct}, {argLoc});
     rewriter.setInsertionPointToStart(b);
     auto replacementArgs =
         rewriter.create<hw::StructExplodeOp>(loc, b->getArgument(0));

--- a/lib/Dialect/Ibis/Transforms/IbisReblockPass.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisReblockPass.cpp
@@ -13,10 +13,9 @@
 #include "circt/Dialect/Ibis/IbisPasses.h"
 #include "circt/Dialect/Ibis/IbisTypes.h"
 
+#include "circt/Transforms/Passes.h"
 #include "mlir/Transforms/DialectConversion.h"
 
-// TODO: change once maximize ssa is moved to transforms
-#include "circt/Conversion/CFToHandshake.h"
 #include <iterator>
 
 using namespace circt;

--- a/lib/Dialect/Ibis/Transforms/IbisReblockPass.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisReblockPass.cpp
@@ -1,0 +1,149 @@
+//===- IbisReblockPass.cpp ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+#include "circt/Dialect/Ibis/IbisDialect.h"
+#include "circt/Dialect/Ibis/IbisOps.h"
+#include "circt/Dialect/Ibis/IbisPasses.h"
+#include "circt/Dialect/Ibis/IbisTypes.h"
+
+#include "mlir/Transforms/DialectConversion.h"
+
+// TODO: change once maximize ssa is moved to transforms
+#include "circt/Conversion/CFToHandshake.h"
+#include <iterator>
+
+using namespace circt;
+using namespace ibis;
+
+namespace {
+
+struct ReblockPass : public IbisReblockBase<ReblockPass> {
+  void runOnOperation() override;
+
+  LogicalResult reblock(Block &block, DictionaryAttr blockInfo);
+};
+} // anonymous namespace
+
+void ReblockPass::runOnOperation() {
+  MethodOp parent = getOperation();
+  auto &region = parent.getRegion();
+  // Fetch the 'ibis.blockinfo' attribute from the parent operation. This will
+  // contain information tagged to each MLIR block which needs to be propagated
+  // to the corresponding ibis.block operations.
+  auto blockInfoAttr = parent->getAttrOfType<DictionaryAttr>("ibis.blockinfo");
+
+  if (!blockInfoAttr) {
+    parent->emitOpError("missing 'ibis.blockinfo' attribute");
+    return signalPassFailure();
+  }
+
+  if (!isRegionSSAMaximized(region)) {
+    parent->emitOpError() << "region is not in maximal SSA form";
+    return signalPassFailure();
+  }
+
+  auto blockID = [&](Block &block) {
+    return std::distance(region.front().getIterator(), block.getIterator());
+  };
+
+  for (Block &block : region.getBlocks()) {
+    DictionaryAttr blockInfo =
+        blockInfoAttr.getAs<DictionaryAttr>(Twine(blockID(block)).str());
+
+    if (!blockInfo) {
+      parent->emitOpError("missing 'ibis.blockinfo' attribute for block " +
+                          Twine(blockID(block)));
+      return signalPassFailure();
+    }
+
+    if (failed(reblock(block, blockInfo)))
+      return signalPassFailure();
+  }
+}
+
+LogicalResult ReblockPass::reblock(mlir::Block &block,
+                                   DictionaryAttr blockInfo) {
+  // Record whether an ibis.call was found in this block
+  bool hadCall = false;
+  llvm::SmallVector<Operation *> blockOps;
+  Operation *terminator = block.getTerminator();
+  for (Operation &op : block.getOperations()) {
+    if (&op == terminator)
+      continue;
+
+    hadCall |= isa<CallOp>(op);
+    blockOps.push_back(&op);
+  }
+
+  if (hadCall && blockOps.size() > 1)
+    return block.getParentOp()->emitError(
+        "a block has both calls and other ops");
+
+  if (hadCall) {
+    // Nothing to do - call ops are themselves considered control-passing
+    // operations.
+    return success();
+  }
+
+  // Given that we're in maximum SSA form, the only values we need to return
+  // from within the block are values used by the terminator, if they're not
+  // already block arguments.
+
+  // Maintain a mapping between the value used by the terminator and the
+  // OpOperands that holds said value.
+  llvm::MapVector<Value, llvm::SmallVector<OpOperand *>> terminatorOperands;
+  for (auto &operand : terminator->getOpOperands()) {
+    if (operand.get().isa<BlockArgument>())
+      continue;
+    terminatorOperands[operand.get()].push_back(&operand);
+  }
+
+  // The above de-aliased multiple-returns of the same value. We now gather
+  // the set of types that needs to be returned from within the block.
+  llvm::SmallVector<Type> blockRetTypes;
+  llvm::SmallVector<Value> blockReturnValues;
+  for (auto &[v, _] : terminatorOperands) {
+    blockReturnValues.push_back(v);
+    blockRetTypes.push_back(v.getType());
+  }
+
+  auto b = OpBuilder::atBlockBegin(&block);
+
+  // Lookup block location from the block info.
+  auto loc = blockInfo.getAs<LocationAttr>("loc");
+  if (!loc) {
+    block.getParentOp()->emitError("missing 'loc' attribute for block");
+    return failure();
+  }
+  auto ibisBlock = b.create<BlockOp>(loc, blockRetTypes, ValueRange{});
+
+  // Move operations into the `ibis.block` op.
+  BlockReturnOp blockReturn =
+      cast<BlockReturnOp>(ibisBlock.getBodyBlock()->getTerminator());
+
+  for (auto *op : blockOps)
+    op->moveBefore(blockReturn);
+
+  // Append the terminator operands to the block return.
+  blockReturn->setOperands(blockReturnValues);
+
+  // Replace the basic block terminator operands with the block return values.
+  for (auto [blockRet, termOperands] :
+       llvm::zip(ibisBlock.getResults(), terminatorOperands)) {
+    for (auto *termOperand : termOperands.second)
+      termOperand->set(blockRet);
+  }
+
+  return success();
+}
+
+std::unique_ptr<Pass> circt::ibis::createReblockPass() {
+  return std::make_unique<ReblockPass>();
+}

--- a/test/Dialect/Ibis/Transforms/argify_blocks.mlir
+++ b/test/Dialect/Ibis/Transforms/argify_blocks.mlir
@@ -22,6 +22,7 @@ ibis.class @Argify {
       %c31 = hw.constant 31 : i32
       %res = arith.addi %c31, %c32 : i32
       ibis.block.return %res, %c32 : i32, i32
-    } 
+    }
+    ibis.return
   }
 }

--- a/test/Dialect/Ibis/Transforms/reblock.mlir
+++ b/test/Dialect/Ibis/Transforms/reblock.mlir
@@ -1,0 +1,66 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(ibis.class(ibis.method(ibis-reblock)))' %s | FileCheck %s
+
+// CHECK: #[[$ATTR_0:.+]] = loc("dummy":0:0)
+
+// CHECK-LABEL:   ibis.class @Argify {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @Argify
+// CHECK:           ibis.method @bar(%[[VAL_1:.*]]: i32) -> i32 attributes {ibis.blockinfo = {"0" = {loc = #[[$ATTR_0]]}}} {
+// CHECK:             ibis.block (){
+// CHECK:               ibis.block.return
+// CHECK:             }
+// CHECK:             ibis.return %[[VAL_1]] : i32
+// CHECK:           }
+// CHECK:           ibis.method @foo(%[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32) -> i32 attributes {ibis.blockinfo = {"0" = {loc = #[[$ATTR_0]]}, "1" = {loc = #[[$ATTR_0]]}, "2" = {loc = #[[$ATTR_0]]}}} {
+// CHECK:             %[[VAL_4:.*]] = ibis.block () -> i32{
+// CHECK:               %[[VAL_5:.*]] = arith.addi %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:               ibis.block.return %[[VAL_5]] : i32
+// CHECK:             }
+// CHECK:             cf.br ^bb1(%[[VAL_2]], %[[VAL_4]] : i32, i32)
+// CHECK:           ^bb1(%[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32):
+// CHECK:             %[[VAL_8:.*]] = ibis.call @bar(%[[VAL_6]]) : (i32) -> i32
+// CHECK:             cf.br ^bb2(%[[VAL_6]], %[[VAL_8]] : i32, i32)
+// CHECK:           ^bb2(%[[VAL_9:.*]]: i32, %[[VAL_10:.*]]: i32):
+// CHECK:             %[[VAL_11:.*]] = ibis.block () -> i32{
+// CHECK:               %[[VAL_12:.*]] = arith.addi %[[VAL_10]], %[[VAL_9]] : i32
+// CHECK:               ibis.block.return %[[VAL_12]] : i32
+// CHECK:             }
+// CHECK:             ibis.return %[[VAL_11]] : i32
+// CHECK:           }
+// CHECK:         }
+
+ibis.class @Argify {
+  %this = ibis.this @Argify
+
+  ibis.method @bar(%arg0 : i32) -> i32 attributes {
+    "ibis.blockinfo" = {
+      "0" = {
+        "loc" = loc("dummy":0:0)
+      }
+    }
+  } {
+    ibis.return %arg0 : i32
+  }
+
+  ibis.method @foo(%arg0 : i32, %arg1 : i32) -> i32 attributes {
+    "ibis.blockinfo" = {
+      "0" = {
+        "loc" = loc("dummy":0:0)
+      },
+      "1" = {
+        "loc" = loc("dummy":0:0)
+      },
+      "2" = {
+        "loc" = loc("dummy":0:0)
+      }
+    }
+  } {
+      %0 = arith.addi %arg0, %arg1 : i32
+      cf.br ^bb1(%arg0, %0 : i32, i32)
+    ^bb1(%aa : i32, %b : i32):
+      %c = ibis.call @bar(%aa) : (i32) -> (i32)
+      cf.br ^bb2(%aa, %c : i32, i32)
+    ^bb2(%aaa : i32, %cc : i32):
+      %d = arith.addi %cc, %aaa : i32
+      ibis.return %d : i32
+  }
+}

--- a/test/Dialect/Ibis/Transforms/structure.mlir
+++ b/test/Dialect/Ibis/Transforms/structure.mlir
@@ -5,8 +5,6 @@
 // CHECK-LABEL: ibis.class @C {
 // CHECK:         ibis.method @getAndSet(%x: ui32) -> ui32 {
 // CHECK:           ibis.return %x : ui32
-// CHECK:         ibis.method @returnNothing() {
-// CHECK:           ibis.return
 // CHECK:         ibis.method @returnNothingWithRet() {
 // CHECK:           ibis.return
 
@@ -14,9 +12,6 @@
 // PREP:         ibis.method @getAndSet(%arg: !hw.struct<x: ui32>) -> ui32 {
 // PREP:           %x = hw.struct_explode %arg : !hw.struct<x: ui32>
 // PREP:           ibis.return %x : ui32
-// PREP:         ibis.method @returnNothing(%arg: !hw.struct<>) {
-// PREP:           hw.struct_explode %arg : !hw.struct<>
-// PREP:           ibis.return
 // PREP:         ibis.method @returnNothingWithRet(%arg: !hw.struct<>) {
 // PREP:           hw.struct_explode %arg : !hw.struct<>
 // PREP:           ibis.return
@@ -25,7 +20,6 @@ ibis.class @C {
   ibis.method @getAndSet(%x: ui32) -> ui32 {
     ibis.return %x : ui32
   }
-  ibis.method @returnNothing() {}
   ibis.method @returnNothingWithRet() {
     ibis.return
   }

--- a/test/Dialect/Ibis/errors.mlir
+++ b/test/Dialect/Ibis/errors.mlir
@@ -119,6 +119,7 @@ ibis.class @InvalidGetVar {
     ]
     // expected-error @+1 {{'ibis.get_var' op result #0 must be memref of any type values, but got 'i32'}}
     %var = ibis.get_var %parent, @var : !ibis.scoperef<@InvalidGetVar> -> i32
+    ibis.return
   }
 }
 
@@ -133,6 +134,7 @@ ibis.class @InvalidGetVar2 {
     ]
     // expected-error @+1 {{'ibis.get_var' op dereferenced type ('memref<i1>') must match variable type ('memref<i32>')}}
     %var = ibis.get_var %parent, @var : !ibis.scoperef<@InvalidGetVar2> -> memref<i1>
+    ibis.return
   }
 }
 
@@ -145,5 +147,6 @@ ibis.class @InvalidReturn {
     // expected-error @+1 {{'ibis.block.return' op number of operands must match number of block outputs}}
     %ret = ibis.block() -> i32 {
     }
+    ibis.return
   }
 }

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -36,7 +36,8 @@ ibis.class @HighLevel {
       %v = memref.load %local[] : memref<i32>
       memref.store %arg, %local[] : memref<i32>
       ibis.block.return %v, %v : i32, i32
-    } 
+    }
+    ibis.return
   }
 }
 


### PR DESCRIPTION
Recreates `ibis.block` operations from a CFG. Any `ibis.block.attributes` operations at the parent operation will be added to the resulting blocks.

The IR is expected to be in maximal SSA form prior to this pass, given that the pass will only inspect the terminator operation of a block for any values that are generated within the block. Maximum SSA form thus ensures that any value defined within the block is never used outside of the block.

It is expected that `ibis.call` operations have been isolated into their own basic blocks before this pass is run. This implies that all operations within a block (except for the terminator operation) can be statically scheduled with each other.

Also adds changes to the Ibis method op to make it more "imperative". This is under the assumption that we want to use the method op as the container of choice while going through "impeartive" lowering steps (i.e. all steps wherein we expect to keep around `cf` and MLIR blocks).
