### PR TITLE
[FIRRTL] Improve IMCP for non-hw; support mat'izing refs of constants.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -48,18 +48,6 @@ void FIRRTLDialect::initialize() {
 Operation *FIRRTLDialect::materializeConstant(OpBuilder &builder,
                                               Attribute value, Type type,
                                               Location loc) {
-  // Materialize reftype "constants" by materializing the constant
-  // and probing it.
-  if (auto refType = type_dyn_cast<RefType>(type)) {
-    assert(!type_cast<RefType>(type).getForceable() &&
-           "Attempting to materialize rwprobe of constant, shouldn't happen");
-    auto *constantValue =
-        materializeConstant(builder, value, refType.getType(), loc);
-    if (!constantValue)
-      return nullptr;
-    assert(constantValue->getNumResults() == 1);
-    return builder.create<RefSendOp>(loc, constantValue->getResult(0));
-  }
 
   // Boolean constants. Boolean attributes are always a special constant type
   // like ClockType and ResetType.  Since BoolAttrs are also IntegerAttrs, its

--- a/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLDialect.cpp
@@ -48,6 +48,18 @@ void FIRRTLDialect::initialize() {
 Operation *FIRRTLDialect::materializeConstant(OpBuilder &builder,
                                               Attribute value, Type type,
                                               Location loc) {
+  // Materialize reftype "constants" by materializing the constant
+  // and probing it.
+  if (auto refType = type_dyn_cast<RefType>(type)) {
+    assert(!type_cast<RefType>(type).getForceable() &&
+           "Attempting to materialize rwprobe of constant, shouldn't happen");
+    auto *constantValue =
+        materializeConstant(builder, value, refType.getType(), loc);
+    if (!constantValue)
+      return nullptr;
+    assert(constantValue->getNumResults() == 1);
+    return builder.create<RefSendOp>(loc, constantValue->getResult(0));
+  }
 
   // Boolean constants. Boolean attributes are always a special constant type
   // like ClockType and ResetType.  Since BoolAttrs are also IntegerAttrs, its

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -952,7 +952,7 @@ void IMConstPropPass::rewriteModuleBody(FModuleOp module) {
     // Cannot materialize constants for certain types.
     // TODO: Let materializeConstant tell us what it supports instead of this.
     // Presently it asserts on unsupported combinations, so check this here.
-    if (!type_isa<FIRRTLBaseType, FIntegerType, StringType, BoolType>(
+    if (!type_isa<FIRRTLBaseType, RefType, FIntegerType, StringType, BoolType>(
             value.getType()))
       return false;
 
@@ -1011,8 +1011,8 @@ void IMConstPropPass::rewriteModuleBody(FModuleOp module) {
         auto type = type_dyn_cast<FIRRTLType>(connect.getDest().getType());
         if (!type)
           continue;
-        auto baseType = getBaseType(type);
-        if (!baseType || !baseType.isGround())
+        auto baseType = type_dyn_cast<FIRRTLBaseType>(type);
+        if (baseType && !baseType.isGround())
           continue;
         if (isDeletableWireOrRegOrNode(destOp) && !isOverdefined(fieldRef)) {
           connect.erase();

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -732,3 +732,42 @@ firrtl.circuit "KeepForceable" {
     firrtl.ref.define %a, %b_c : !firrtl.rwprobe<uint<1>>
   }
 }
+
+// -----
+
+// Fix partly deleting non-hw dataflow.
+// Issue #6076.
+
+// CHECK-LABEL: "WireProbe"
+firrtl.circuit "WireProbe" {
+  // CHECK: module @WireProbe
+  firrtl.module @WireProbe(out %p : !firrtl.probe<uint<5>>) {
+    // CHECK-NEXT: %[[ZERO:.+]] = firrtl.constant 0
+    // CHECK-NEXT: %[[REF:.+]] = firrtl.ref.send %[[ZERO]]
+    // CHECK-NEXT: firrtl.ref.define %p, %[[REF]]
+    // CHECK-NEXT: }
+    %x = firrtl.constant 0: !firrtl.uint<5>
+    %0 = firrtl.ref.send %x : !firrtl.uint<5>
+    %w = firrtl.wire : !firrtl.probe<uint<5>>
+    firrtl.ref.define %w, %0: !firrtl.probe<uint<5>>
+    firrtl.ref.define %p, %w : !firrtl.probe<uint<5>>
+  }
+}
+
+// -----
+
+// Also for properties that we const-prop.
+// Drop connections to, and wires, that are not overdefined.
+
+// CHECK-LABEL: firrtl.circuit "WireProp"
+firrtl.circuit "WireProp" {
+  // CHECK-NOT: firrtl.wire
+  firrtl.module @WireProp(out %s : !firrtl.string) {
+    %x = firrtl.string "hello"
+    %w = firrtl.wire : !firrtl.string
+    %w2 = firrtl.wire : !firrtl.string
+    firrtl.propassign %w, %x: !firrtl.string
+    firrtl.propassign %w2, %w: !firrtl.string
+    firrtl.propassign %s, %w : !firrtl.string
+  }
+}

--- a/test/firtool/export-ref.fir
+++ b/test/firtool/export-ref.fir
@@ -1,15 +1,19 @@
 ; RUN: firtool %s -split-verilog -o %t
 ; RUN: cat %t/ref_Top_Top.sv | FileCheck %s
 
-; CHECK:      `define ref_Top_Top_direct_probe direct_probe
-; CHECK-NEXT: `define ref_Top_Top_inner_probe inner.x_probe
-; CHECK-NEXT: `define ref_Top_Top_keyword_probe always_probe
+; CHECK:      `define ref_Top_Top_direct_probe _GEN{{(_[[0-9]+])?}}
+; CHECK-NEXT: `define ref_Top_Top_inner_x_probe inner.x_probe
+; CHECK-NEXT: `define ref_Top_Top_inner_y_probe _GEN{{(_[0-9]+])?}}
+; CHECK-NEXT: `define ref_Top_Top_keyword_probe _GEN{{(_[[0-9]+])?}}
 
 FIRRTL version 3.0.0
-circuit Top:
+circuit Top: %[[
+{"class": "firrtl.transforms.DontTouchAnnotation", "target": "~Top|Inner>x"}
+]]
   module Top:
     output direct_probe: Probe<UInt<1>>
-    output inner_probe: Probe<UInt<2>>
+    output inner_x_probe: Probe<UInt<2>>
+    output inner_y_probe: Probe<UInt<2>>
     output keyword_probe: Probe<UInt<3>>
 
     wire direct: UInt<1>
@@ -17,7 +21,8 @@ circuit Top:
     define direct_probe = probe(direct)
 
     inst inner of Inner
-    define inner_probe = inner.x_probe
+    define inner_x_probe = inner.x_probe
+    define inner_y_probe = inner.y_probe
 
     wire always: UInt<3>
     invalidate always
@@ -25,6 +30,12 @@ circuit Top:
 
   module Inner:
     output x_probe: Probe<UInt<2>>
+    output y_probe: Probe<UInt<2>>
+
     wire x: UInt<2>
     invalidate x
+    wire y : UInt<2>
+    invalidate y
+
     define x_probe = probe(x)
+    define y_probe = probe(y)


### PR DESCRIPTION
Fixes #6076.

Fixes leaving dead property wires around if they're constant-prop'd through.

Tweak export-ref test to demonstrate somewhat that this now enables a probe of a constant in a module to be hoisted to a probe of the constant at the boundary, allow for more cleanup -- in particular prevents modules with probed constants being preserved just for that reason. (The test adds a dontTouch to avoid this to check the exported macro)