### PR TITLE
[FIRRTL] Optionally look through casts for fieldref chasing.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -84,8 +84,9 @@ bool walkDrivers(FIRRTLBaseValue value, bool lookThroughWires,
 
 /// Get the FieldRef from a value.  This will travel backwards to through the
 /// IR, following Subfield and Subindex to find the op which declares the
-/// location.
-FieldRef getFieldRefFromValue(Value value);
+/// location.  Optionally look through recognized cast operations, which
+/// likely will result in source having slightly different type.
+FieldRef getFieldRefFromValue(Value value, bool lookThroughCasts = false);
 
 /// Get a string identifier representing the FieldRef.  Return this string and a
 /// boolean indicating if a valid "root" for the identifier was found.  If

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2941,7 +2941,7 @@ static LogicalResult checkConnectFlow(Operation *connect) {
     // A sink that is a port output or instance input used as a source is okay.
     auto kind = getDeclarationKind(src);
     if (kind != DeclKind::Port && kind != DeclKind::Instance) {
-      auto srcRef = getFieldRefFromValue(src);
+      auto srcRef = getFieldRefFromValue(src, /*lookThroughCasts=*/true);
       auto [srcName, rootKnown] = getFieldName(srcRef);
       auto diag = emitError(connect->getLoc());
       diag << "connect has invalid flow: the source expression ";
@@ -2954,7 +2954,7 @@ static LogicalResult checkConnectFlow(Operation *connect) {
 
   auto dstFlow = foldFlow(dst);
   if (!isValidDst(dstFlow)) {
-    auto dstRef = getFieldRefFromValue(dst);
+    auto dstRef = getFieldRefFromValue(dst, /*lookThroughCasts=*/true);
     auto [dstName, rootKnown] = getFieldName(dstRef);
     auto diag = emitError(connect->getLoc());
     diag << "connect has invalid flow: the destination expression ";

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -683,12 +683,19 @@ struct Equivalence {
       if (bValue != data.map.lookup(aValue)) {
         diag.attachNote(a->getLoc())
             << "operations use different operands, first operand is '"
-            << getFieldName(getFieldRefFromValue(aValue)).first << "'";
+            << getFieldName(
+                   getFieldRefFromValue(aValue, /*lookThroughCasts=*/true))
+                   .first
+            << "'";
         diag.attachNote(b->getLoc())
             << "second operand is '"
-            << getFieldName(getFieldRefFromValue(bValue)).first
+            << getFieldName(
+                   getFieldRefFromValue(bValue, /*lookThroughCasts=*/true))
+                   .first
             << "', but should have been '"
-            << getFieldName(getFieldRefFromValue(data.map.lookup(aValue))).first
+            << getFieldName(getFieldRefFromValue(data.map.lookup(aValue),
+                                                 /*lookThroughCasts=*/true))
+                   .first
             << "'";
         return failure();
       }

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -925,7 +925,9 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
         if (name.empty()) {
           if (problem.newNameHint.empty())
             name = state.getNamespace(mod).newName(
-                getFieldName(getFieldRefFromValue(val), /*nameSafe=*/true)
+                getFieldName(
+                    getFieldRefFromValue(val, /*lookThroughCasts=*/true),
+                    /*nameSafe=*/true)
                     .first +
                 "__bore");
           else

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -120,7 +120,8 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
             auto nameKind = NameKindEnum::DroppableName;
 
             if (auto [name, rootKnown] = getFieldName(
-                    getFieldRefFromValue(xmrDef), /*nameSafe=*/true);
+                    getFieldRefFromValue(xmrDef, /*lookThroughCasts=*/true),
+                    /*nameSafe=*/true);
                 rootKnown) {
               opName = name + "_probe";
               nameKind = NameKindEnum::InterestingName;

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1237,12 +1237,14 @@ firrtl.circuit "NoDefineIntoRefSub" {
 // Can't define into a ref.cast.
 
 firrtl.circuit "NoDefineIntoRefCast" {
-  firrtl.module @NoDefineIntoRefCast(out %r: !firrtl.probe<uint<1>>) {
+  firrtl.module @NoDefineIntoRefCast(
     // expected-note @below {{the destination was defined here}}
+      out %r: !firrtl.probe<uint<1>>
+      ) {
     %dest_cast = firrtl.ref.cast %r : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint>
     %x = firrtl.wire : !firrtl.uint
     %xref = firrtl.ref.send %x : !firrtl.uint
-    // expected-error @below {{has invalid flow: the destination expression has source flow, expected sink or duplex flow}}
+    // expected-error @below {{has invalid flow: the destination expression "r" has source flow, expected sink or duplex flow}}
     firrtl.ref.define %dest_cast, %xref : !firrtl.probe<uint>
   }
 }


### PR DESCRIPTION
Don't do this by default, as code reasonably expects the returned FieldRef has expected type if indexed to the specified fieldID, however when this is used for producing names just walk through the cast operations to find the originating declaration.