### PR TITLE
[FIRRTL][IMCP] Propagate through nodes with annotations, but keep.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -755,9 +755,10 @@ void IMConstPropPass::visitNode(NodeOp node, FieldRef changedFieldRef) {
 
   // Nodes don't fold if they have interesting names, but they should still
   // propagate values.
-  if (hasDontTouch(node.getResult()) ||
-      (node.getAnnotationsAttr() && !node.getAnnotationsAttr().empty()) ||
-      node.isForceable()) {
+  // This is handled by isDeletableWireOrRegOrNode.
+
+  // Propagate if able, otherwise mark overdefined.
+  if (hasDontTouch(node.getResult()) || node.isForceable()) {
     for (auto result : node.getResults())
       markOverdefined(result);
     return;

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -752,12 +752,6 @@ void IMConstPropPass::visitRefResolve(RefResolveOp resolve,
 }
 
 void IMConstPropPass::visitNode(NodeOp node, FieldRef changedFieldRef) {
-
-  // Nodes don't fold if they have interesting names, but they should still
-  // propagate values.
-  // This is handled by isDeletableWireOrRegOrNode.
-
-  // Propagate if able, otherwise mark overdefined.
   if (hasDontTouch(node.getResult()) || node.isForceable()) {
     for (auto result : node.getResults())
       markOverdefined(result);

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -771,3 +771,29 @@ firrtl.circuit "WireProp" {
     firrtl.propassign %s, %w : !firrtl.string
   }
 }
+
+// -----
+
+// Check ability to const-prop through declarations (wires, nodes)
+// with annotations, but keep them around.
+firrtl.circuit "ConstPropAnno" {
+  firrtl.module @ConstPropAnno(out %val : !firrtl.uint<3>,
+                               out %val2 : !firrtl.uint<3>) {
+    // CHECK: %[[ZERO:.+]] = firrtl.constant 0
+    %zero = firrtl.constant 0 : !firrtl.uint<3>
+    // CHECK: %w = firrtl.wire
+    %w = firrtl.wire {annotations = [{class = "circt.test"}]} : !firrtl.uint<3>
+    // CHECK-NOT: firrtl.wire
+    %w2 = firrtl.wire : !firrtl.uint<3>
+    firrtl.strictconnect %w, %w2 : !firrtl.uint<3>
+    firrtl.strictconnect %w2, %zero : !firrtl.uint<3>
+    firrtl.strictconnect %val, %w : !firrtl.uint<3>
+
+    // CHECK: firrtl.node %[[ZERO]]
+    %n = firrtl.node %w2 {annotations = [{class = "circt.test"}]} : !firrtl.uint<3>
+    // CHECK-NOT: firrtl.wire
+    %w3 = firrtl.wire : !firrtl.uint<3>
+    firrtl.strictconnect %w3, %n : !firrtl.uint<3>
+    firrtl.strictconnect %val2, %w3 : !firrtl.uint<3>
+  }
+}

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -785,8 +785,8 @@ firrtl.circuit "ConstPropAnno" {
     %w = firrtl.wire {annotations = [{class = "circt.test"}]} : !firrtl.uint<3>
     // CHECK-NOT: firrtl.wire
     %w2 = firrtl.wire : !firrtl.uint<3>
-    firrtl.strictconnect %w, %w2 : !firrtl.uint<3>
     firrtl.strictconnect %w2, %zero : !firrtl.uint<3>
+    firrtl.strictconnect %w, %w2 : !firrtl.uint<3>
     firrtl.strictconnect %val, %w : !firrtl.uint<3>
 
     // CHECK: firrtl.node %[[ZERO]]


### PR DESCRIPTION
This is the behavior used for wires, align.

GrandCentral makes use of many of these sorts of nodes.

Fixes #6096.