### PR TITLE
[FIRRTL][LOA] Created Non-HW wires should always have droppable names.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
@@ -637,12 +637,13 @@ LogicalResult Visitor::visitDecl(WireOp op) {
             .getResult();
 
   // Create the non-HW wires.
+  // Non-HW wire names are always droppable.
   for (auto &[type, fieldID, _, suffix] : mappings.fields)
     nonHWValues[FieldRef(op.getResult(), fieldID)] =
         builder
             .create<WireOp>(type,
                             builder.getStringAttr(Twine(op.getName()) + suffix),
-                            op.getNameKind())
+                            NameKindEnum::DroppableName)
             .getResult();
 
   for (auto fieldID : mappings.mapToNullInteriors)

--- a/test/Dialect/FIRRTL/lower-open-aggs.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs.mlir
@@ -309,3 +309,27 @@ firrtl.circuit "WireSymbols" {
     %a = firrtl.wire sym [<@sym_a_c, 2, public>] : !firrtl.openbundle<b: string, c: uint<1>>
   }
 }
+
+// -----
+
+// CHECK-LABEL: circuit "WireMixedProbes"
+firrtl.circuit "WireMixedProbes" {
+  // CHECK-LABEL: module @WireMixedProbes
+  firrtl.module @WireMixedProbes() {
+    // CHECK:      %w = firrtl.wire interesting_name : !firrtl.bundle<a: uint<1>>
+    // CHECK-NEXT: %w_b = firrtl.wire : !firrtl.probe<uint<1>>
+    %w = firrtl.wire interesting_name : !firrtl.openbundle<a: uint<1>, b: probe<uint<1>>>
+    // CHECK:      %[[W_A:.+]] = firrtl.subfield %w[a]
+    %w_a = firrtl.opensubfield %w[a] : !firrtl.openbundle<a: uint<1>, b: probe<uint<1>>>
+    %w_b = firrtl.opensubfield %w[b] : !firrtl.openbundle<a: uint<1>, b: probe<uint<1>>>
+
+    // CHECK-NEXT: %[[ZERO:.+]] = firrtl.constant 0
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.strictconnect %[[W_A]], %[[ZERO]] : !firrtl.uint<1>
+    firrtl.strictconnect %w_a, %zero : !firrtl.uint<1>
+    // CHECK-NEXT: %[[REF:.+]] = firrtl.ref.send %[[ZERO]]
+    %ref = firrtl.ref.send %zero : !firrtl.uint<1>
+    // CHECK:      firrtl.ref.define %w_b, %[[REF]] : !firrtl.probe<uint<1>>
+    firrtl.ref.define %w_b, %ref : !firrtl.probe<uint<1>>
+  }
+}


### PR DESCRIPTION
These will never appear in the output verilog, and may cause the wires to be unnecessarily preserved.

cc #6099, addresses this for aggregates with non-hw in them.