### PR TITLE
[FIRRTL][Parser] Wires of non-agg non-hw should have droppable names.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3955,8 +3955,13 @@ ParseResult FIRStmtParser::parseWire() {
   StringAttr sym = {};
 
   bool forceable = !!firrtl::detail::getForceableResultType(true, type);
-  auto result = builder.create<WireOp>(type, id, NameKindEnum::InterestingName,
-                                       annotations, sym, forceable);
+  // Names of only-nonHW should be droppable.
+  auto namekind = isa<PropertyType, RefType>(type)
+                      ? NameKindEnum::DroppableName
+                      : NameKindEnum::InterestingName;
+
+  auto result =
+      builder.create<WireOp>(type, id, namekind, annotations, sym, forceable);
   return moduleContext.addSymbolEntry(id, result.getResult(),
                                       startTok.getLoc());
 }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1844,6 +1844,16 @@ circuit VecOfProps:
     ; CHECK-COUNT-2: openvector<string, 2>
 
 ;// -----
+; Test parsing of wires of probes, wires of agg of probes, and namekinds.
+; CHECK-LABEL: circuit "WireOfProbesAndNames"
+circuit WireOfProbesAndNames:
+  module WireOfProbesAndNames:
+    ; CHECK: %mixed = firrtl.wire interesting_name : !firrtl.openbundle
+    wire mixed : { a : UInt<3>, b : Probe<UInt<3>> }
+    ; CHECK: %probe = firrtl.wire : !firrtl.probe
+    wire probe : Probe<UInt<1>>
+
+;// -----
 FIRRTL version 3.2.0
 
 ; CHECK-LABEL: circuit "AnyRef"


### PR DESCRIPTION
cc #6099.