### PR TITLE
[FIRRTL] Add AnyRef type, parser, emitter, and printed form.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -37,6 +37,7 @@ struct OpenBundleTypeStorage;
 struct OpenVectorTypeStorage;
 } // namespace detail.
 
+class AnyRefType;
 class ClassType;
 class ClockType;
 class ResetType;
@@ -315,8 +316,8 @@ class PropertyType : public FIRRTLType {
 public:
   /// Support method to enable LLVM-style type casting.
   static bool classof(Type type) {
-    return llvm::isa<ClassType, StringType, FIntegerType, ListType, MapType,
-                     PathType, BoolType>(type);
+    return llvm::isa<AnyRefType, ClassType, StringType, FIntegerType, ListType,
+                     MapType, PathType, BoolType>(type);
   }
 
 protected:

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -208,6 +208,8 @@ def PropertyType : FIRRTLDialectTypeHelper<
 
 def ClassType : FIRRTLDialectTypeHelper<"ClassType", "class type">;
 
+def AnyRefType : FIRRTLDialectTypeHelper<"AnyRefType", "any reference type">;
+
 def StringType : FIRRTLDialectTypeHelper<"StringType", "string type">,
   BuildableType<"::circt::firrtl::StringType::get($_builder.getContext())">;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -480,6 +480,17 @@ def ClassImpl : PropImplType<"Class"> {
   }];
 }
 
+def AnyRefImpl : PropImplType<"AnyRef"> {
+  let summary = "A reference to an instance of any class.";
+  let description = [{
+    A reference of type AnyRef can be used in ports, property assignments, and
+    any other Property "plumbing" ops. But it is opaque, and references to
+    objects of AnyRef type cannot be "dereferenced". There is no information
+    about the referred to object's fields, so subfield access, etc. is illegal.
+  }];
+  let genStorageClass = true;
+}
+
 def StringImpl : PropImplType<"String"> {
   let summary = "An unlimited length string type. Not representable in hardware.";
   let parameters = (ins);

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -1321,6 +1321,7 @@ void Emitter::emitType(Type type, bool includeConst) {
         emitType(type.getType());
         ps << ">";
       })
+      .Case<AnyRefType>([&](AnyRefType type) { ps << "AnyRef"; })
       .Case<StringType>([&](StringType type) { ps << "String"; })
       .Case<FIntegerType>([&](FIntegerType type) { ps << "Integer"; })
       .Case<BoolType>([&](BoolType type) { ps << "Bool"; })

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -138,6 +138,7 @@ static LogicalResult customTypePrinter(Type type, AsmPrinter &os) {
         type.printInterface(os);
         os << ">";
       })
+      .Case<AnyRefType>([&](AnyRefType type) { os << "anyref"; })
       .Default([&](auto) { anyFailed = true; });
   return failure(anyFailed);
 }
@@ -368,6 +369,13 @@ static OptionalParseResult customTypeParser(AsmParser &parser, StringRef name,
         parser.parseGreater())
       return failure();
     result = classType;
+    return success();
+  }
+  if (name.equals("anyref")) {
+    if (isConst)
+      return parser.emitError(parser.getNameLoc(), "any refs cannot be const");
+
+    result = AnyRefType::get(parser.getContext());
     return success();
   }
   if (name.equals("string")) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -896,6 +896,12 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
     break;
   }
 
+  case FIRToken::kw_AnyRef: {
+    consumeToken(FIRToken::kw_AnyRef);
+    result = AnyRefType::get(getContext());
+    break;
+  }
+
   case FIRToken::kw_Reset:
     consumeToken(FIRToken::kw_Reset);
     result = ResetType::get(getContext());

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -897,6 +897,9 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
   }
 
   case FIRToken::kw_AnyRef: {
+    if (requireFeature({3, 2, 0}, "AnyRef types"))
+      return failure();
+
     consumeToken(FIRToken::kw_AnyRef);
     result = AnyRefType::get(getContext());
     break;

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -85,6 +85,7 @@ TOK_PUNCTUATION(equal_greater, "=>")
 // NOTE: Please key these alphabetized to make it easier to find something in
 // this list and to cater to OCD.
 TOK_KEYWORD(Analog)
+TOK_KEYWORD(AnyRef)
 TOK_KEYWORD(AsyncReset)
 TOK_KEYWORD(Bool)
 TOK_KEYWORD(Clock)

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -35,6 +35,7 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT: output b0 : UInt
     // CHECK-NEXT: output b1 : Probe<UInt<1>>
     // CHECK-NEXT: output b2 : RWProbe<UInt<1>>
+    // CHECK-NEXT: input anyref : AnyRef
     // CHECK-NEXT: input string : String
     // CHECK-NEXT: input integer : Integer
     // CHECK-NEXT: input bool : Bool
@@ -54,6 +55,7 @@ firrtl.circuit "Foo" {
     out %b0: !firrtl.uint,
     out %b1: !firrtl.probe<uint<1>>,
     out %b2: !firrtl.rwprobe<uint<1>>,
+    in %anyref: !firrtl.anyref,
     in %string: !firrtl.string,
     in %integer: !firrtl.integer,
     in %bool : !firrtl.bool,

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1842,3 +1842,12 @@ circuit VecOfProps:
     input x : String[2]
     wire y : String[2]
     ; CHECK-COUNT-2: openvector<string, 2>
+
+;// -----
+FIRRTL version 3.1.0
+
+; CHECK-LABEL: circuit "AnyRef"
+circuit AnyRef:
+  module AnyRef:
+    input x : AnyRef
+    ; CHECK: !firrtl.anyref

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1844,7 +1844,7 @@ circuit VecOfProps:
     ; CHECK-COUNT-2: openvector<string, 2>
 
 ;// -----
-FIRRTL version 3.1.0
+FIRRTL version 3.2.0
 
 ; CHECK-LABEL: circuit "AnyRef"
 circuit AnyRef:

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1086,3 +1086,11 @@ circuit ConstMap:
   module ConstMap:
     ; expected-error @below {{only hardware types can be 'const'}}
     output m: const Map<String, String>
+
+;// -----
+; AnyRef not yet supported.
+FIRRTL version 3.1.0
+circuit AnyRef:
+   module AnyRef:
+     ; expected-error @below {{AnyRef types are a FIRRTL 3.2.0+ feature}}
+     output a : AnyRef

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -344,6 +344,13 @@ firrtl.module @BoolTest(in %in: !firrtl.bool, out %out: !firrtl.bool) {
   %1 = firrtl.bool false
 }
 
+// CHECK-LABEL: AnyRefTest
+// CHECK-SAME: (in %in: !firrtl.anyref, out %out: !firrtl.anyref)
+firrtl.module @AnyRefTest(in %in: !firrtl.anyref, out %out: !firrtl.anyref) {
+  // CHECK: firrtl.propassign %out, %in : !firrtl.anyref
+  firrtl.propassign %out, %in : !firrtl.anyref
+}
+
 // CHECK-LABEL: TypeAlias
 // CHECK-SAME: %in: !firrtl.alias<bar, uint<1>>
 // CHECK-SAME: %const: !firrtl.const.alias<baz, const.uint<1>>


### PR DESCRIPTION
This is conceptually similar to Class type, but represents a reference to any class. It is opaque, like a void pointer, so it can be passed around but not "deferenced". For example, accessing a subfield of the referred to object is illegal.