### PR TITLE
[OM] Add AnyType and AnyType cast.

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -320,4 +320,22 @@ def PathOp : OMOp<"path", [Pure,
   let assemblyFormat = "$targetKind $target attr-dict";
 }
 
+def AnyCastOp : OMOp<"any_cast", [Pure]> {
+  let summary = "Cast any value to any type.";
+
+  let description = [{
+    Casts any value to AnyType. This is useful for situations where a value of
+    AnyType is needed, but a value of some concrete type is known.
+
+    In the evaluator, this is a noop, and the value of concrete type is used.
+  }];
+
+  let arguments = (ins AnyType:$input);
+
+  let results = (outs OMAnyType:$result);
+
+  let assemblyFormat =
+     "$input attr-dict `:` functional-type($input, $result)";
+}
+
 #endif // CIRCT_DIALECT_OM_OMOPS_TD

--- a/include/circt/Dialect/OM/OMTypes.td
+++ b/include/circt/Dialect/OM/OMTypes.td
@@ -109,4 +109,10 @@ def EnumType : TypeDef<OMDialect, "Enum", []> {
   }];
 }
 
+def OMAnyType : TypeDef<OMDialect, "Any", []> {
+  let summary = "A type that represents any valid OM type.";
+
+  let mnemonic = "any";
+}
+
 #endif // CIRCT_DIALECT_OM_OMTYPES_TD

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -262,3 +262,12 @@ om.class @Path() {
 om.class @Enum(%e : !om.enum<a: !om.string, b: i64>) {
   om.class.field @map_i64, %e : !om.enum<a: !om.string, b: i64>
 }
+
+// CHECK-LABEL: @Any
+// CHECK-SAME: %[[IN:.+]]: !om.class.type
+om.class @Any(%in: !om.class.type<@Empty>) {
+  // CHECK: %[[CAST:.+]] = om.any_cast %[[IN]]
+  %0 = om.any_cast %in : (!om.class.type<@Empty>) -> !om.any
+  // CHECK: om.class.field @field, %[[CAST]]
+  om.class.field @field, %0 : !om.any
+}


### PR DESCRIPTION
The AnyType is used to represent any valid OM type, without needing to declare it. The AnyType cast can cast any value to AnyType. This is useful when dealing with values opaquely in a limited way.