### PR TITLE
[OM] Handle AnyType casts in Evaluator.

### DIFF
--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -148,6 +148,9 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateValue(
             .Case([&](MapCreateOp op) {
               return evaluateMapCreate(op, actualParams);
             })
+            .Case([&](AnyCastOp op) {
+              return evaluateValue(op.getInput(), actualParams);
+            })
             .Default([&](Operation *op) {
               auto error = op->emitError("unable to evaluate value");
               error.attachNote() << "value: " << value;

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -72,6 +72,11 @@ circt::om::Evaluator::instantiate(
     if (!actualParam || !actualParam.get())
       return cls.emitError("actual parameter for ")
              << formalParamName << " is null";
+
+    // Subtyping: if formal param is any type, any actual param may be passed.
+    if (isa<AnyType>(formalParamType))
+      continue;
+
     Type actualParamType;
     if (auto *attr = dyn_cast<evaluator::AttributeValue>(actualParam.get())) {
       if (auto typedActualParam = attr->getAttr().dyn_cast_or_null<TypedAttr>())

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -412,4 +412,43 @@ TEST(EvaluatorTests, InstantiateObjectWithChildObjectMemoized) {
   ASSERT_EQ(field1Value, field2Value);
 }
 
+TEST(EvaluatorTests, AnyCastObject) {
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  Location loc(UnknownLoc::get(&context));
+
+  ImplicitLocOpBuilder builder(loc, &context);
+
+  auto mod = builder.create<ModuleOp>(loc);
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  auto innerCls = builder.create<ClassOp>("MyInnerClass");
+  innerCls.getBody().emplaceBlock();
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  auto cls = builder.create<ClassOp>("MyClass");
+  auto &body = cls.getBody().emplaceBlock();
+  builder.setInsertionPointToStart(&body);
+  auto object = builder.create<ObjectOp>(innerCls, body.getArguments());
+  auto cast = builder.create<AnyCastOp>(object);
+  builder.create<ClassFieldOp>("field", cast);
+
+  Evaluator evaluator(mod);
+
+  auto result = evaluator.instantiate(builder.getStringAttr("MyClass"), {});
+
+  ASSERT_TRUE(succeeded(result));
+
+  auto *fieldValue = llvm::cast<evaluator::ObjectValue>(
+      result.value()->getField(builder.getStringAttr("field")).value().get());
+
+  ASSERT_TRUE(fieldValue);
+
+  ASSERT_EQ(fieldValue->getClassOp(), innerCls);
+}
+
 } // namespace

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -451,4 +451,54 @@ TEST(EvaluatorTests, AnyCastObject) {
   ASSERT_EQ(fieldValue->getClassOp(), innerCls);
 }
 
+TEST(EvaluatorTests, AnyCastParam) {
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  Location loc(UnknownLoc::get(&context));
+
+  ImplicitLocOpBuilder builder(loc, &context);
+
+  auto mod = builder.create<ModuleOp>(loc);
+
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  auto innerCls = ClassOp::buildSimpleClassOp(
+      builder, builder.getLoc(), "MyInnerClass", {"param"}, {"field"},
+      {AnyType::get(&context)});
+
+  auto i64 = builder.getIntegerType(64);
+  builder.setInsertionPointToStart(&mod.getBodyRegion().front());
+  StringRef params[] = {"param"};
+  auto cls = builder.create<ClassOp>("MyClass", params);
+  auto &body = cls.getBody().emplaceBlock();
+  body.addArguments({i64}, {builder.getLoc()});
+  builder.setInsertionPointToStart(&body);
+  auto cast = builder.create<AnyCastOp>(body.getArgument(0));
+  SmallVector<Value> objectParams = {cast};
+  auto object = builder.create<ObjectOp>(innerCls, objectParams);
+  builder.create<ClassFieldOp>("field", object);
+
+  Evaluator evaluator(mod);
+
+  auto result =
+      evaluator.instantiate(builder.getStringAttr("MyClass"),
+                            getEvaluatorValuesFromAttributes(
+                                &context, {builder.getIntegerAttr(i64, 42)}));
+
+  ASSERT_TRUE(succeeded(result));
+
+  auto *fieldValue = llvm::cast<evaluator::ObjectValue>(
+      result.value()->getField(builder.getStringAttr("field")).value().get());
+
+  ASSERT_TRUE(fieldValue);
+
+  auto *innerFieldValue = llvm::cast<evaluator::AttributeValue>(
+      fieldValue->getField(builder.getStringAttr("field")).value().get());
+
+  ASSERT_EQ(innerFieldValue->getAs<IntegerAttr>().getValue(), 42);
+}
+
 } // namespace


### PR DESCRIPTION
These casts are introduced in situations where the type of a value needs to be opaque. In the Evaluator, we just need to see through the cast to the actual value, and evaluate that.