### PR TITLE
[FIRRTL] Add AnyRef cast operation, and insert during parsing.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1095,7 +1095,7 @@ def ObjectAnyRefCastOp : FIRRTLOp<"object.anyref_cast", [Pure]> {
 
     Example
     ```
-      %0= firrtl.object.anyref_cast %object : (!firrtl.class<@Foo()>) -> !firrtl.anyref
+      %0= firrtl.object.anyref_cast %object : !firrtl.class<@Foo()>
     ```
     }];
 
@@ -1103,14 +1103,7 @@ def ObjectAnyRefCastOp : FIRRTLOp<"object.anyref_cast", [Pure]> {
   let results = (outs AnyRefType:$result);
 
   let assemblyFormat =
-     "$input attr-dict `:` functional-type($input, $result)";
-
-  let builders = [
-    OpBuilder<(ins "Value":$input), [{
-      auto resultType = AnyRefType::get($_builder.getContext());
-      return build($_builder, $_state, resultType, input);
-    }]>
-  ];
+     "$input attr-dict `:` type($input)";
 }
 
 def StringConstantOp : FIRRTLOp<"string", [Pure, ConstantLike]> {

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1087,6 +1087,32 @@ def ObjectSubfieldOp : FIRRTLOp<"object.subfield",
   }];
 }
 
+def ObjectAnyRefCastOp : FIRRTLOp<"object.anyref_cast", [Pure]> {
+  let summary = "Cast object reference to anyref.";
+  let description = [{
+    Cast any object reference to AnyRef type. This is needed for passing objects
+    of a known class to sinks that accept any reference.
+
+    Example
+    ```
+      %0= firrtl.object.anyref_cast %object : (!firrtl.class<@Foo()>) -> !firrtl.anyref
+    ```
+    }];
+
+  let arguments = (ins ClassType:$input);
+  let results = (outs AnyRefType:$result);
+
+  let assemblyFormat =
+     "$input attr-dict `:` functional-type($input, $result)";
+
+  let builders = [
+    OpBuilder<(ins "Value":$input), [{
+      auto resultType = AnyRefType::get($_builder.getContext());
+      return build($_builder, $_state, resultType, input);
+    }]>
+  ];
+}
+
 def StringConstantOp : FIRRTLOp<"string", [Pure, ConstantLike]> {
   let summary = "Produce a constant string value";
   let description = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -208,7 +208,8 @@ def PropertyType : FIRRTLDialectTypeHelper<
 
 def ClassType : FIRRTLDialectTypeHelper<"ClassType", "class type">;
 
-def AnyRefType : FIRRTLDialectTypeHelper<"AnyRefType", "any reference type">;
+def AnyRefType : FIRRTLDialectTypeHelper<"AnyRefType", "any reference type">,
+  BuildableType<"::circt::firrtl::AnyRefType::get($_builder.getContext())">;
 
 def StringType : FIRRTLDialectTypeHelper<"StringType", "string type">,
   BuildableType<"::circt::firrtl::StringType::get($_builder.getContext())">;

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3450,10 +3450,15 @@ ParseResult FIRStmtParser::parsePropAssign() {
   auto rhsType = type_dyn_cast<PropertyType>(rhs.getType());
   if (!lhsType || !rhsType)
     return emitError(loc, "can only propassign property types");
-  if (lhsType != rhsType)
-    return emitError(loc, "cannot propassign non-equivalent type ")
-           << rhsType << " to " << lhsType;
   locationProcessor.setLoc(loc);
+  if (lhsType != rhsType) {
+    // If the lhs is anyref, and the rhs is a ClassType, insert a cast.
+    if (isa<AnyRefType>(lhsType) && isa<ClassType>(rhsType))
+      rhs = builder.create<ObjectAnyRefCastOp>(rhs);
+    else
+      return emitError(loc, "cannot propassign non-equivalent type ")
+             << rhsType << " to " << lhsType;
+  }
   builder.create<PropAssignOp>(lhs, rhs);
   return success();
 }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1848,6 +1848,16 @@ FIRRTL version 3.2.0
 
 ; CHECK-LABEL: circuit "AnyRef"
 circuit AnyRef:
+  class Foo:
+    skip
   module AnyRef:
     input x : AnyRef
     ; CHECK: !firrtl.anyref
+    output y : AnyRef
+    ; CHECK: !firrtl.anyref
+
+    object foo of Foo
+    propassign y, foo
+    ; CHECK: %[[OBJ:.+]] = firrtl.object
+    ; CHECK: %[[CAST:.+]] = firrtl.object.anyref_cast %[[OBJ]]
+    ; CHECK: firrtl.propassign %y, %[[CAST]]

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -352,7 +352,7 @@ firrtl.module @AnyRefTest(in %in: !firrtl.anyref, out %out: !firrtl.anyref, in %
 
   // CHECK: %[[CAST:.+]] = firrtl.object.anyref_cast %[[REF]]
   // CHECK: firrtl.propassign %[[REF_OUT]], %[[CAST]]
-  %0 = firrtl.object.anyref_cast %ref : (!firrtl.class<@ClassTest()>) -> !firrtl.anyref
+  %0 = firrtl.object.anyref_cast %ref : !firrtl.class<@ClassTest()>
   firrtl.propassign %anyref, %0 : !firrtl.anyref
 }
 

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -345,10 +345,15 @@ firrtl.module @BoolTest(in %in: !firrtl.bool, out %out: !firrtl.bool) {
 }
 
 // CHECK-LABEL: AnyRefTest
-// CHECK-SAME: (in %in: !firrtl.anyref, out %out: !firrtl.anyref)
-firrtl.module @AnyRefTest(in %in: !firrtl.anyref, out %out: !firrtl.anyref) {
+// CHECK-SAME: (in %in: !firrtl.anyref, out %out: !firrtl.anyref, in %[[REF:.+]]: !firrtl.class<@ClassTest()>, out %[[REF_OUT:.+]]: !firrtl.anyref)
+firrtl.module @AnyRefTest(in %in: !firrtl.anyref, out %out: !firrtl.anyref, in %ref: !firrtl.class<@ClassTest()>, out %anyref: !firrtl.anyref) {
   // CHECK: firrtl.propassign %out, %in : !firrtl.anyref
   firrtl.propassign %out, %in : !firrtl.anyref
+
+  // CHECK: %[[CAST:.+]] = firrtl.object.anyref_cast %[[REF]]
+  // CHECK: firrtl.propassign %[[REF_OUT]], %[[CAST]]
+  %0 = firrtl.object.anyref_cast %ref : (!firrtl.class<@ClassTest()>) -> !firrtl.anyref
+  firrtl.propassign %anyref, %0 : !firrtl.anyref
 }
 
 // CHECK-LABEL: TypeAlias


### PR DESCRIPTION
In situations where an object is instantiated and passed to a sink that expects any reference, we need to cast away the object's type to AnyRef type. This adds an operation to accomplish this, and inserts it when necessary in the parser.