### PR TITLE
[FIRRTLFolds] Ignore reset signals for constant registers in foldHidd…

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -3053,8 +3053,9 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
   if (!constOp)
     return failure();
 
-  // reset should be a module port (heuristic to limit to intended reset lines).
-  if (!isa<BlockArgument>(mux.getSel()))
+  // For a non-constant register, reset should be a module port (heuristic to
+  // limit to intended reset lines). Replace the register anyway if constant.
+  if (!isa<BlockArgument>(mux.getSel()) && !constReg)
     return failure();
 
   // Check all types should be typed by now

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2462,6 +2462,20 @@ firrtl.module @constReg8(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, o
   firrtl.connect %out2, %r2 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
+// CHeck that a register that is only driven by constant and itself
+// is canonicalized into a constant regardless of its reset signal.
+// CHECK-LABEL: @constReg9
+firrtl.module @constReg9(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %en_0: !firrtl.uint<1>, in %en_1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
+  // CHECK-NOT: firrtl.reg
+  // CHECK: firrtl.strictconnect %out, %c0_ui1
+  %r = firrtl.reg %clock {firrtl.random_init_start = 0 : ui64} : !firrtl.clock, !firrtl.uint<1>
+  %0 = firrtl.and %en_0, %en_1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %1 = firrtl.mux(%0, %c0_ui1, %r) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %r, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+  firrtl.strictconnect %out, %r : !firrtl.uint<1>
+}
+
 firrtl.module @BitCast(out %o:!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>> ) {
   %a = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>
   %b = firrtl.bitcast %a : (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>) -> (!firrtl.uint<3>)


### PR DESCRIPTION
…enReset

foldHiddenReset is a canonicalization that replaces registers driven by only constants and registers themselves. Previously there was a condition that the reset signal must be a port for dominace reason, but it's only reasonable for non-constant registers. 

Example:
```scala
circuit Example :
  module Example :
    input clock : Clock
    input reset : UInt<1>
    input en: UInt<1>[2]
    output out : UInt<1>
    reg r : UInt<1>, clock
    when and(en[0], en[1]) :
      r <= UInt<1>(0)
    out <= r
```
After:
```verilog
module Example(
  input  clock,
         reset,
         en_0,
         en_1,
  output out
);

  assign out = 1'h0;
endmodule
```

Before:
```verilog
module Example(
  input  clock,
         reset,
         en_0,
         en_1,
  output out
);

  reg r;
  always @(posedge clock)
    r <= ~(en_0 & en_1) & r;
```
