### PR TITLE
[FIRRTL][HoistPassthrough] Add pass to hoist must-driven output ports.

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -99,6 +99,9 @@ std::unique_ptr<mlir::Pass> createInferResetsPass();
 std::unique_ptr<mlir::Pass> createLowerMemoryPass();
 
 std::unique_ptr<mlir::Pass>
+createHoistPassthroughPass(bool hoistHWDrivers = true);
+
+std::unique_ptr<mlir::Pass>
 createMemToRegOfVecPass(bool replSeqMem = false, bool ignoreReadEnable = false);
 
 std::unique_ptr<mlir::Pass> createPrefixModulesPass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -737,4 +737,24 @@ def LowerGroups : Pass<"firrtl-lower-groups", "firrtl::CircuitOp"> {
   let dependentDialects = ["sv::SVDialect"];
 }
 
+def HoistPassthrough : Pass<"firrtl-hoist-passthrough", "firrtl::CircuitOp"> {
+  let summary = "Hoist passthrough logic";
+  let description = [{
+    This pass hoists simple passthrough connections up.
+  }];
+  let constructor = "circt::firrtl::createHoistPassthroughPass()";
+  let options = [
+    Option<"hoistHWDrivers", "hoist-hw", "bool", "true",
+      "Hoist HW drivers.">
+  ];
+  let statistics = [
+    Statistic<"numUTurnsHoisted", "num-u-turns",
+      "Number of u-turns hoisted">,
+    Statistic<"numRefDrivers", "num-ref-drivers",
+      "Number of ref-type drivers processed">,
+    Statistic<"numHWDrivers", "num-hw-drivers",
+      "Number of hw-type drivers processed">
+  ];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -126,7 +126,7 @@ struct FirtoolOptions {
   llvm::cl::opt<bool> disableHoistingHWPassthrough{
       "disable-hoisting-hw-passthrough",
       llvm::cl::desc("Disable hoisting HW passthrough signals"),
-      llvm::cl::init(false), llvm::cl::Hidden, llvm::cl::cat(category)};
+      llvm::cl::init(true), llvm::cl::Hidden, llvm::cl::cat(category)};
 
   llvm::cl::opt<bool> emitOMIR{
       "emit-omir", llvm::cl::desc("Emit OMIR annotations to a JSON file"),

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -123,6 +123,11 @@ struct FirtoolOptions {
           "connections into bulk connections)"),
       llvm::cl::init(false), llvm::cl::cat(category)};
 
+  llvm::cl::opt<bool> disableHoistingHWPassthrough{
+      "disable-hoisting-hw-passthrough",
+      llvm::cl::desc("Disable hoisting HW passthrough signals"),
+      llvm::cl::init(false), llvm::cl::Hidden, llvm::cl::cat(category)};
+
   llvm::cl::opt<bool> emitOMIR{
       "emit-omir", llvm::cl::desc("Emit OMIR annotations to a JSON file"),
       llvm::cl::init(true), llvm::cl::cat(category)};

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -12,6 +12,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   FinalizeIR.cpp
   FlattenMemory.cpp
   GrandCentral.cpp
+  HoistPassthrough.cpp
   IMConstProp.cpp
   IMDeadCodeElim.cpp
   InferReadWrite.cpp

--- a/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
@@ -1,0 +1,561 @@
+//===- HoistPassthrough.cpp - Hoist basic passthrough ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the HoistPassthrough pass.  This pass identifies basic
+// drivers of output ports that can be pulled out of modules.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "circt/Dialect/HW/HWTypeInterfaces.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "firrtl-hoist-passthrough"
+
+using namespace circt;
+using namespace firrtl;
+
+using RefValue = mlir::TypedValue<RefType>;
+
+namespace {
+// Sanity-check that simple structs are simple.
+// Based on MLIR's IsZeroCostAbstraction, without std::is_standard_layout_v.
+// ABI isn't a concern for these as they're local.
+template <typename T>
+static constexpr bool isTrivially =
+    std::is_trivially_copyable_v<T> && std::is_trivially_destructible_v<T> &&
+    std::is_trivially_move_constructible<T>::value;
+} // end anonymous namespace
+
+namespace {
+
+struct RefDriver;
+struct HWDriver;
+
+//===----------------------------------------------------------------------===//
+// (Rematerializable)Driver declaration.
+//===----------------------------------------------------------------------===//
+/// Statically known driver for a Value.
+///
+/// Driver source expected to be rematerialized provided a mapping.
+/// Generally takes form:
+/// [source]----(static indexing?)---->DRIVE_OP---->[dest]
+///
+/// However, only requirement is that the "driver" can be rematerialized
+/// across a module/instance boundary in terms of mapping args<-->results.
+///
+/// Driver can be reconstructed given a mapping in new location.
+///
+/// "Update":
+/// Map:
+///   source -> A
+///   dest -> B
+///
+/// [source]---(indexing)--> SSA_DRIVE_OP ---> [dest]
+///   + ([s']---> SSA_DRIVE_OP ---> [A])
+///  =>
+///  RAUW(B, [A]--(clone indexing))
+///  (or RAUW(B, [s']--(clone indexing)))
+///
+/// Update is safe if driver classification is ""equivalent"" for each context
+/// on the other side.  For hoisting U-Turns, this is safe in all cases,
+/// for sinking n-turns the driver must be map-equivalent at all instantiation
+/// sites.
+/// Only UTurns are supported presently.
+///
+/// The goal is to drop the destination port, so after replacing all users
+/// on other side of the instantiation, drop the port driver and move
+/// all its users to the driver (immediate) source.
+/// This may not be safe if the driver source does not dominate all users of the
+/// port, in which case either reject (unsafe) or insert a temporary wire to
+/// drive instead.
+///
+/// RAUW'ing may require insertion of conversion ops if types don't match.
+//===----------------------------------------------------------------------===//
+struct Driver {
+  //-- Data -----------------------------------------------------------------//
+
+  /// Connect entirely and definitively driving the destination.
+  FConnectLike drivingConnect;
+  /// Source of LHS.
+  FieldRef source;
+
+  //-- Constructors ---------------------------------------------------------//
+  Driver(Value dest = nullptr) {}
+  Driver(FConnectLike connect, FieldRef source)
+      : drivingConnect(connect), source(source) {
+    assert((isa<RefDriver, HWDriver>(*this)));
+  }
+
+  //-- Driver methods -------------------------------------------------------//
+
+  // "Virtual" methods, either commonly defined or dispatched appropriately.
+
+  /// Determine direct driver for the given value, empty Driver otherwise.
+  static Driver get(Value v);
+
+  /// Whether this can be rematerialized up through an instantiation.
+  bool canHoist() const { return isa<BlockArgument>(source.getValue()); }
+
+  /// Simple mapping across instantiation by index.
+  using PortMappingFn = llvm::function_ref<Value(size_t)>;
+
+  /// Rematerialize this driven value, using provided mapping function and
+  /// builder. New value is returned.
+  Value remat(PortMappingFn mapPortFn, ImplicitLocOpBuilder &builder);
+
+  /// Drop uses of the destination, inserting temporary as necessary.
+  /// Erases the driving connection, invalidating this Driver.
+  void finalize(ImplicitLocOpBuilder &builder);
+
+  //--- Helper methods -------------------------------------------------------//
+
+  /// Return whether this driver is valid/non-null.
+  operator bool() const { return source; }
+
+  /// Get driven destination value.
+  Value getDest() const {
+    // (const cast to workaround getDest() not being const, even if mutates the
+    // Operation* that's fine)
+    return const_cast<Driver *>(this)->drivingConnect.getDest();
+  }
+
+  /// Whether this driver destination is a module port.
+  bool drivesModuleArg() const {
+    auto arg = dyn_cast<BlockArgument>(getDest());
+    assert(!arg || isa<firrtl::FModuleLike>(arg.getOwner()->getParentOp()));
+    return !!arg;
+  }
+
+  /// Whether this driver destination is an instance result.
+  bool drivesInstanceResult() const {
+    return getDest().getDefiningOp<hw::HWInstanceLike>();
+  }
+
+  /// Get destination as block argument.
+  BlockArgument getDestBlockArg() const {
+    assert(drivesModuleArg());
+    return dyn_cast<BlockArgument>(getDest());
+  }
+
+  /// Get destination as operation result, must be instance result.
+  OpResult getDestOpResult() const {
+    assert(drivesInstanceResult());
+    return dyn_cast<OpResult>(getDest());
+  }
+
+  /// Helper to obtain argument/result number of destination.
+  /// Must be block arg or op result.
+  static size_t getIndex(Value v) {
+    if (auto arg = dyn_cast<BlockArgument>(v))
+      return arg.getArgNumber();
+    auto result = dyn_cast<OpResult>(v);
+    assert(result);
+    return result.getResultNumber();
+  }
+};
+static_assert(isTrivially<Driver>);
+
+/// Driver implementation for probes.
+struct RefDriver : public Driver {
+  using Driver::Driver;
+
+  static bool classof(const Driver *t) { return isa<RefValue>(t->getDest()); }
+
+  static RefDriver get(Value v);
+
+  Value remat(PortMappingFn mapPortFn, ImplicitLocOpBuilder &builder);
+};
+static_assert(isTrivially<Driver>);
+static_assert(sizeof(RefDriver) == sizeof(Driver),
+              "passed by value, no slicing");
+
+// Driver implementation for HW signals.
+// Split out because has more complexity re:safety + updating.
+// And can't walk through temporaries in same way.
+struct HWDriver : public Driver {
+  using Driver::Driver;
+
+  static bool classof(const Driver *t) { return !isa<RefValue>(t->getDest()); }
+
+  static HWDriver get(Value v);
+
+  Value remat(PortMappingFn mapPortFn, ImplicitLocOpBuilder &builder);
+};
+static_assert(isTrivially<Driver>);
+static_assert(sizeof(HWDriver) == sizeof(Driver),
+              "passed by value, no slicing");
+
+/// Print driver information.
+template <typename T>
+static inline T &operator<<(T &os, Driver &d) {
+  if (!d)
+    return os << "(null)";
+  return os << d.getDest() << " <-- " << d.drivingConnect << " <-- "
+            << d.source.getValue() << "@" << d.source.getFieldID();
+}
+
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+// Driver implementation.
+//===----------------------------------------------------------------------===//
+
+Driver Driver::get(Value v) {
+  if (auto refDriver = RefDriver::get(v))
+    return refDriver;
+  if (auto hwDriver = HWDriver::get(v))
+    return hwDriver;
+  return {};
+}
+
+Value Driver::remat(PortMappingFn mapPortFn, ImplicitLocOpBuilder &builder) {
+  return TypeSwitch<Driver *, Value>(this)
+      .Case<RefDriver, HWDriver>(
+          [&](auto *d) { return d->remat(mapPortFn, builder); })
+      .Default({});
+}
+
+void Driver::finalize(ImplicitLocOpBuilder &builder) {
+  auto immSource = drivingConnect.getSrc();
+  auto dest = getDest();
+  assert(immSource.getType() == dest.getType() &&
+         "final connect must be strict");
+  if (isa<BlockArgument>(immSource) || dest.hasOneUse()) {
+    drivingConnect.erase();
+    dest.replaceAllUsesWith(immSource);
+  } else {
+    // Insert wire temporary.
+    // For hoisting use-case could also remat using cached indexing inside the
+    // module, but wires keep this simple.
+    auto temp = builder.create<WireOp>(immSource.getType());
+    dest.replaceAllUsesWith(temp.getDataRaw());
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// RefDriver implementation.
+//===----------------------------------------------------------------------===//
+
+static RefDefineOp getRefDefine(Value result) {
+  for (auto *user : result.getUsers()) {
+    if (auto rd = dyn_cast<RefDefineOp>(user); rd && rd.getDest() == result)
+      return rd;
+  }
+  return {};
+}
+
+RefDriver RefDriver::get(Value v) {
+  auto refVal = dyn_cast<RefValue>(v);
+  if (!refVal)
+    return {};
+
+  auto rd = getRefDefine(v);
+  if (!rd)
+    return {};
+
+  auto ref = getFieldRefFromValue(rd.getSrc(), true);
+  if (!ref)
+    return {};
+
+  return RefDriver(rd, ref);
+}
+
+Value RefDriver::remat(PortMappingFn mapPortFn, ImplicitLocOpBuilder &builder) {
+  auto mappedSource = mapPortFn(getIndex(source.getValue()));
+  auto newVal = getValueByFieldID(builder, mappedSource, source.getFieldID());
+  auto destType = getDest().getType();
+  if (newVal.getType() != destType)
+    newVal = builder.create<RefCastOp>(destType, newVal);
+  return newVal;
+}
+
+//===----------------------------------------------------------------------===//
+// HWDriver implementation.
+//===----------------------------------------------------------------------===//
+
+HWDriver HWDriver::get(Value v) {
+  auto baseValue = dyn_cast<FIRRTLBaseValue>(v);
+  if (!baseValue)
+    return {};
+
+  // Output must be passive, for flow reasons.
+  // Reject aggregates for now, to be conservative re:aliasing writes/etc.
+  // before ExpandWhens.
+  if (!baseValue.getType().isPassive() || !baseValue.getType().isGround())
+    return {};
+
+  auto connect = getSingleConnectUserOf(v);
+  if (!connect)
+    return {};
+  auto ref = getFieldRefFromValue(connect.getSrc());
+  if (!ref)
+    return {};
+
+  // Reject if not all same block.
+  if (v.getParentBlock() != ref.getValue().getParentBlock() ||
+      v.getParentBlock() != connect->getBlock())
+    return {};
+
+  // Reject if cannot reason through this.
+  if (hasDontTouch(v) || hasDontTouch(ref.getValue()))
+    return {};
+  if (auto fop = ref.getValue().getDefiningOp<Forceable>();
+      fop && fop.isForceable())
+    return {};
+
+  // Limit to passive sources for now.
+  auto sourceType = type_dyn_cast<FIRRTLBaseType>(ref.getValue().getType());
+  if (!sourceType)
+    return {};
+  if (!sourceType.isPassive())
+    return {};
+
+  assert(hw::FieldIdImpl::getFinalTypeByFieldID(sourceType, ref.getFieldID()) ==
+             baseValue.getType() &&
+         "unexpected type mismatch, cast or extension?");
+
+  return HWDriver(connect, ref);
+}
+
+Value HWDriver::remat(PortMappingFn mapPortFn, ImplicitLocOpBuilder &builder) {
+  auto mappedSource = mapPortFn(getIndex(source.getValue()));
+  // TODO: Cast if needed.  For now only support matching.
+  // (No cast needed for current HWDriver's, getFieldRefFromValue and
+  // assert)
+  return getValueByFieldID(builder, mappedSource, source.getFieldID());
+}
+
+//===----------------------------------------------------------------------===//
+// MustDrivenBy analysis.
+//===----------------------------------------------------------------------===//
+namespace {
+/// Driver analysis, tracking values that "must be driven" by the specified
+/// source (+fieldID), along with final complete driving connect.
+class MustDrivenBy {
+public:
+  MustDrivenBy() = default;
+  MustDrivenBy(FModuleOp mod) { run(mod); }
+
+  /// Get direct driver, if computed, for the specified value.
+  Driver getDriverFor(Value v) const { return driverMap.lookup(v); }
+
+  /// Get combined driver for the specified value.
+  /// Walks the driver "graph" from the value to its ultimate source.
+  Driver getCombinedDriverFor(Value v) const {
+    Driver driver = driverMap.lookup(v);
+    if (!driver)
+      return driver;
+
+    // Chase and collapse.
+    Driver cur = driver;
+    size_t len = 1;
+    SmallPtrSet<Value, 8> seen;
+    while ((cur = driverMap.lookup(cur.source.getValue()))) {
+      // If re-encounter same value, bail.
+      if (!seen.insert(cur.source.getValue()).second)
+        return {};
+      driver.source = cur.source.getSubField(driver.source.getFieldID());
+      ++len;
+    }
+    (void)len;
+    LLVM_DEBUG(llvm::dbgs() << "Found driver for " << v << " (chain length = "
+                            << len << "): " << driver << "\n");
+    return driver;
+  }
+
+  /// Analyze the given module's ports and chase simple storage.
+  void run(FModuleOp mod) {
+    SmallVector<Value, 64> worklist(mod.getArguments());
+
+    DenseSet<Value> processed;
+    processed.insert(worklist.begin(), worklist.end());
+    while (!worklist.empty()) {
+      auto val = worklist.pop_back_val();
+      auto driver = ignoreHWDrivers ? RefDriver::get(val) : Driver::get(val);
+      driverMap.insert({val, driver});
+      if (!driver)
+        continue;
+
+      auto sourceVal = driver.source.getValue();
+
+      // If already enqueued, ignore.
+      if (!processed.insert(sourceVal).second)
+        continue;
+
+      // Only chase through atomic values for now.
+      // Here, atomic implies must be driven entirely.
+      // This is true for HW types, and is true for RefType's because
+      // while they can be indexed into, only RHS can have indexing.
+      if (hw::FieldIdImpl::getMaxFieldID(sourceVal.getType()) != 0)
+        continue;
+
+      // Only through Wires, block arguments, instance results.
+      if (!isa<BlockArgument>(sourceVal) &&
+          !isa_and_nonnull<WireOp, InstanceOp>(sourceVal.getDefiningOp()))
+        continue;
+
+      worklist.push_back(sourceVal);
+    }
+  }
+
+  /// Clear out analysis results and storage.
+  void clear() { driverMap.clear(); }
+
+  /// Configure whether HW signals are analyzed.
+  void setIgnoreHWDrivers(bool ignore) { ignoreHWDrivers = ignore; }
+
+private:
+  /// Map of values to their computed direct must-drive source.
+  DenseMap<Value, Driver> driverMap;
+  bool ignoreHWDrivers = false;
+};
+
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct HoistPassthroughPass
+    : public HoistPassthroughBase<HoistPassthroughPass> {
+  using HoistPassthroughBase::HoistPassthroughBase;
+  void runOnOperation() override;
+
+  using HoistPassthroughBase::hoistHWDrivers;
+};
+} // end anonymous namespace
+
+void HoistPassthroughPass::runOnOperation() {
+  LLVM_DEBUG(llvm::dbgs() << "===- Running HoistPassthrough Pass "
+                             "------------------------------------------===\n");
+  auto &instanceGraph = getAnalysis<InstanceGraph>();
+
+  SmallVector<FModuleOp, 0> modules(llvm::make_filter_range(
+      llvm::map_range(
+          llvm::post_order(&instanceGraph),
+          [](auto *node) { return dyn_cast<FModuleOp>(*node->getModule()); }),
+      [](auto module) { return module; }));
+
+  MustDrivenBy driverAnalysis;
+  driverAnalysis.setIgnoreHWDrivers(!hoistHWDrivers);
+
+  // For each module (PO)...
+  for (auto module : modules) {
+    // TODO: Public means can't reason down into, or remove ports.
+    // Does not mean cannot clone out wires or optimize w.r.t its contents.
+    if (module.isPublic())
+      continue;
+
+    // 1. Analyze.
+
+    // What ports to delete.
+    // Hoisted drivers of output ports will be deleted.
+    BitVector deadPorts(module.getNumPorts());
+
+    // Analyze all ports using current IR.
+    driverAnalysis.clear();
+    driverAnalysis.run(module);
+    auto notNullAndCanHoist = [](const Driver &d) -> bool {
+      return d && d.canHoist();
+    };
+    SmallVector<Driver, 16> drivers(llvm::make_filter_range(
+        llvm::map_range(module.getArguments(),
+                        [&driverAnalysis](auto val) {
+                          return driverAnalysis.getCombinedDriverFor(val);
+                        }),
+        notNullAndCanHoist));
+
+    // 2. Rematerialize must-driven ports at instantiation sites.
+
+    // Do this first, keep alive Driver state pointing to module.
+    for (auto &driver : drivers) {
+      std::optional<size_t> deadPort;
+      {
+        auto destArg = driver.getDestBlockArg();
+        auto mod = cast<firrtl::FModuleLike>(destArg.getOwner()->getParentOp());
+        auto index = destArg.getArgNumber();
+        auto *igNode = instanceGraph.lookup(mod);
+
+        // Replace dest in all instantiations.
+        for (auto *record : igNode->uses()) {
+          auto inst = cast<InstanceOp>(record->getInstance());
+          ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+          builder.setInsertionPointAfter(inst);
+
+          auto mappedDest = inst.getResult(index);
+          mappedDest.replaceAllUsesWith(driver.remat(
+              [&inst](size_t index) { return inst.getResult(index); },
+              builder));
+        }
+        // The driven port has no external users, will soon be dead.
+        deadPort = index;
+      }
+      assert(deadPort.has_value());
+
+      assert(!deadPorts.test(*deadPort));
+      deadPorts.set(*deadPort);
+
+      // Update statistics.
+      TypeSwitch<Driver *, void>(&driver)
+          .Case<RefDriver>([&](auto *) { ++numRefDrivers; })
+          .Case<HWDriver>([&](auto *) { ++numHWDrivers; });
+    }
+
+    // 3. Finalize stage.  Ensure remat'd dest is unused on original side.
+
+    ImplicitLocOpBuilder builder(module.getLoc(), module.getBody());
+    for (auto &driver : drivers) {
+      // Finalize.  Invalidates the driver.
+      builder.setLoc(driver.getDest().getLoc());
+      driver.finalize(builder);
+    }
+
+    // If no ports were dropped, nothing to update.  Onwards!
+    if (deadPorts.none())
+      continue;
+
+    // 4. Delete newly dead ports.
+
+    // Drop dead ports at instantiation sites.
+    auto *igNode = instanceGraph.lookup(module);
+    for (auto *record : llvm::make_early_inc_range(igNode->uses())) {
+      auto inst = cast<InstanceOp>(record->getInstance());
+      ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+
+      assert(inst.getNumResults() == deadPorts.size());
+      auto newInst = inst.erasePorts(builder, deadPorts);
+      instanceGraph.replaceInstance(inst, newInst);
+      inst.erase();
+    }
+
+    // Drop dead ports from module.
+    module.erasePorts(deadPorts);
+
+    numUTurnsHoisted += deadPorts.count();
+  }
+  markAnalysesPreserved<InstanceGraph>();
+}
+
+/// This is the pass constructor.
+std::unique_ptr<mlir::Pass>
+circt::firrtl::createHoistPassthroughPass(bool hoistHWDrivers) {
+  auto pass = std::make_unique<HoistPassthroughPass>();
+  pass->hoistHWDrivers = hoistHWDrivers;
+  return pass;
+}

--- a/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
@@ -31,16 +31,6 @@ using namespace firrtl;
 using RefValue = mlir::TypedValue<RefType>;
 
 namespace {
-// Sanity-check that simple structs are simple.
-// Based on MLIR's IsZeroCostAbstraction, without std::is_standard_layout_v.
-// ABI isn't a concern for these as they're local.
-template <typename T>
-static constexpr bool isTrivially =
-    std::is_trivially_copyable_v<T> && std::is_trivially_destructible_v<T> &&
-    std::is_trivially_move_constructible<T>::value;
-} // end anonymous namespace
-
-namespace {
 
 struct RefDriver;
 struct HWDriver;
@@ -167,7 +157,6 @@ struct Driver {
     return result.getResultNumber();
   }
 };
-static_assert(isTrivially<Driver>);
 
 /// Driver implementation for probes.
 struct RefDriver : public Driver {
@@ -179,7 +168,6 @@ struct RefDriver : public Driver {
 
   Value remat(PortMappingFn mapPortFn, ImplicitLocOpBuilder &builder);
 };
-static_assert(isTrivially<Driver>);
 static_assert(sizeof(RefDriver) == sizeof(Driver),
               "passed by value, no slicing");
 
@@ -195,7 +183,6 @@ struct HWDriver : public Driver {
 
   Value remat(PortMappingFn mapPortFn, ImplicitLocOpBuilder &builder);
 };
-static_assert(isTrivially<Driver>);
 static_assert(sizeof(HWDriver) == sizeof(Driver),
               "passed by value, no slicing");
 

--- a/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
@@ -498,9 +498,8 @@ void HoistPassthroughPass::runOnOperation() {
       std::optional<size_t> deadPort;
       {
         auto destArg = driver.getDestBlockArg();
-        auto mod = cast<firrtl::FModuleLike>(destArg.getOwner()->getParentOp());
         auto index = destArg.getArgNumber();
-        auto *igNode = instanceGraph.lookup(mod);
+        auto *igNode = instanceGraph.lookup(module);
 
         // Replace dest in all instantiations.
         for (auto *record : igNode->uses()) {

--- a/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
@@ -84,7 +84,7 @@ struct Driver {
   FieldRef source;
 
   //-- Constructors ---------------------------------------------------------//
-  Driver(Value dest = nullptr) {}
+  Driver() = default;
   Driver(FConnectLike connect, FieldRef source)
       : drivingConnect(connect), source(source) {
     assert((isa<RefDriver, HWDriver>(*this)));

--- a/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
@@ -387,8 +387,8 @@ public:
   void run(FModuleOp mod) {
     SmallVector<Value, 64> worklist(mod.getArguments());
 
-    DenseSet<Value> processed;
-    processed.insert(worklist.begin(), worklist.end());
+    DenseSet<Value> enqueued;
+    enqueued.insert(worklist.begin(), worklist.end());
     while (!worklist.empty()) {
       auto val = worklist.pop_back_val();
       auto driver = ignoreHWDrivers ? RefDriver::get(val) : Driver::get(val);
@@ -399,7 +399,7 @@ public:
       auto sourceVal = driver.source.getValue();
 
       // If already enqueued, ignore.
-      if (!processed.insert(sourceVal).second)
+      if (!enqueued.insert(sourceVal).second)
         continue;
 
       // Only chase through atomic values for now.

--- a/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
@@ -478,6 +478,9 @@ void HoistPassthroughPass::runOnOperation() {
     // Hoisted drivers of output ports will be deleted.
     BitVector deadPorts(module.getNumPorts());
 
+    // Instance graph node, for walking instances of this module.
+    auto *igNode = instanceGraph.lookup(module);
+
     // Analyze all ports using current IR.
     driverAnalysis.clear();
     driverAnalysis.run(module);
@@ -499,7 +502,6 @@ void HoistPassthroughPass::runOnOperation() {
       {
         auto destArg = driver.getDestBlockArg();
         auto index = destArg.getArgNumber();
-        auto *igNode = instanceGraph.lookup(module);
 
         // Replace dest in all instantiations.
         for (auto *record : igNode->uses()) {
@@ -542,7 +544,6 @@ void HoistPassthroughPass::runOnOperation() {
     // 4. Delete newly dead ports.
 
     // Drop dead ports at instantiation sites.
-    auto *igNode = instanceGraph.lookup(module);
     for (auto *record : llvm::make_early_inc_range(igNode->uses())) {
       auto inst = cast<InstanceOp>(record->getInstance());
       ImplicitLocOpBuilder builder(inst.getLoc(), inst);

--- a/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/HoistPassthrough.cpp
@@ -221,7 +221,11 @@ void Driver::finalize(ImplicitLocOpBuilder &builder) {
   auto dest = getDest();
   assert(immSource.getType() == dest.getType() &&
          "final connect must be strict");
-  if (isa<BlockArgument>(immSource) || dest.hasOneUse()) {
+  if (dest.hasOneUse()) {
+    // Only use is the connect, just drop it.
+    drivingConnect.erase();
+  } else if (isa<BlockArgument>(immSource)) {
+    // Block argument dominates all, so drop connect and RAUW to it.
     drivingConnect.erase();
     dest.replaceAllUsesWith(immSource);
   } else {

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -79,6 +79,9 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDropConstPass());
 
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createHoistPassthroughPass(
+      /*hoistHWDrivers=*/!opt.disableOptimization));
+
   if (opt.dedup)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDedupPass());
 
@@ -133,6 +136,12 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
 
   if (!opt.disableOptimization)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMConstPropPass());
+
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createHoistPassthroughPass(
+      /*hoistHWDrivers=*/!opt.disableOptimization));
+  // Cleanup, for separation-of-concerns.
+  if (!opt.disableOptimization)
+    pm.addPass(firrtl::createIMDeadCodeElimPass());
 
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createAddSeqMemPortsPass());
 

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -135,15 +135,15 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createPrefixModulesPass());
 
-  if (!opt.disableOptimization)
+  if (!opt.disableOptimization) {
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMConstPropPass());
 
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createHoistPassthroughPass(
-      /*hoistHWDrivers=*/!opt.disableOptimization &&
-      !opt.disableHoistingHWPassthrough));
-  // Cleanup, for separation-of-concerns.
-  if (!opt.disableOptimization)
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createHoistPassthroughPass(
+        /*hoistHWDrivers=*/!opt.disableOptimization &&
+        !opt.disableHoistingHWPassthrough));
+    // Cleanup after hoisting passthroughs, for separation-of-concerns.
     pm.addPass(firrtl::createIMDeadCodeElimPass());
+  }
 
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createAddSeqMemPortsPass());
 

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -80,7 +80,8 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDropConstPass());
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createHoistPassthroughPass(
-      /*hoistHWDrivers=*/!opt.disableOptimization));
+      /*hoistHWDrivers=*/!opt.disableOptimization &&
+      !opt.disableHoistingHWPassthrough));
 
   if (opt.dedup)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDedupPass());
@@ -138,7 +139,8 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMConstPropPass());
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createHoistPassthroughPass(
-      /*hoistHWDrivers=*/!opt.disableOptimization));
+      /*hoistHWDrivers=*/!opt.disableOptimization &&
+      !opt.disableHoistingHWPassthrough));
   // Cleanup, for separation-of-concerns.
   if (!opt.disableOptimization)
     pm.addPass(firrtl::createIMDeadCodeElimPass());

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/HWRename.fir
@@ -35,12 +35,9 @@ circuit Top:
 
     ; CHECK:      module DUT
     ; CHECK:        input a
-    ; CHECK:        output b
     ; CHECK:          Companion companion (
     ; CHECK-NEXT:       .[[port]] (a)
     ; CHECK-NEXT:     );
-    ; Wire got optimized away!!
-    ; CHECK:          assign b = a;
     ; CHECK:      endmodule
 
     ; CHECK:      module Top

--- a/test/Dialect/FIRRTL/hoist-passthrough.mlir
+++ b/test/Dialect/FIRRTL/hoist-passthrough.mlir
@@ -397,6 +397,50 @@ firrtl.circuit "SymIntermediate" {
 
 // -----
 
+// Symbol on instance means keep symbol, not dontTouch its ports.
+
+// CHECK-LABEL: SymInstance
+firrtl.circuit "SymInstance" {
+  firrtl.module private @Sink(in %in: !firrtl.uint<1>) {}
+  // CHECK: @UWire(in %in: !firrtl.uint<1>)
+  firrtl.module private @UWire(in %in: !firrtl.uint<1>,
+                               out %out : !firrtl.uint<1>) {
+    %sink_in = firrtl.instance sink sym @blocker @Sink(in in: !firrtl.uint<1>)
+    firrtl.strictconnect %sink_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %sink_in : !firrtl.uint<1>
+  }
+  firrtl.module @SymInstance(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    %u_in, %u_out = firrtl.instance u @UWire(in in : !firrtl.uint<1>,
+                                             out out : !firrtl.uint<1>)
+    firrtl.strictconnect %u_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Through instance input port.
+
+// CHECK-LABEL: "Instance"
+firrtl.circuit "Instance" {
+  firrtl.module private @Sink(in %in: !firrtl.uint<1>) {}
+  // CHECK: @UWire(in %in: !firrtl.uint<1>) {
+  firrtl.module private @UWire(in %in: !firrtl.uint<1>,
+                               out %out : !firrtl.uint<1>) {
+    %sink_in = firrtl.instance sink @Sink(in in: !firrtl.uint<1>)
+    firrtl.strictconnect %sink_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %sink_in : !firrtl.uint<1>
+  }
+  firrtl.module @Instance(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    %u_in, %u_out = firrtl.instance u @UWire(in in : !firrtl.uint<1>,
+                                             out out : !firrtl.uint<1>)
+    firrtl.strictconnect %u_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<1>
+  }
+}
+
+// -----
+
 // Reject non-passive source.
 
 // CHECK-LABEL: "NonPassiveSource"

--- a/test/Dialect/FIRRTL/hoist-passthrough.mlir
+++ b/test/Dialect/FIRRTL/hoist-passthrough.mlir
@@ -1,0 +1,535 @@
+// Check transform output.
+// RUN: circt-opt %s -split-input-file --firrtl-hoist-passthrough | FileCheck %s
+
+// Simple example: HW passthrough.
+
+// CHECK-LABEL: "SimpleHW"
+firrtl.circuit "SimpleHW" {
+  // CHECK:      module private @UTurn(in %in: !firrtl.uint<1>) {
+  // CHECK-NEXT: }
+  firrtl.module private @UTurn(in %in: !firrtl.uint<1>,
+                               out %out : !firrtl.uint<1>) {
+    firrtl.strictconnect %out, %in : !firrtl.uint<1>
+  }
+  firrtl.module @SimpleHW(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    // CHECK: %[[HW_IN:.+]] = firrtl.instance
+    %u_in, %u_out = firrtl.instance u @UTurn(in in : !firrtl.uint<1>,
+                                             out out : !firrtl.uint<1>)
+    // CHECK: strictconnect %out, %[[HW_IN]]
+    firrtl.strictconnect %u_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Combined example.  Hoist passthrough. Ref and HW.
+// CHECK-LABEL: "UTurnTH"
+firrtl.circuit "UTurnTH" {
+  // CHECK:      module private @UTurn(in %in: !firrtl.probe<uint<5>>, in %hw_in: !firrtl.uint<5>) {
+  // CHECK-NEXT: }
+  firrtl.module private @UTurn(in %in : !firrtl.probe<uint<5>>,
+                               out %out : !firrtl.probe<uint<5>>,
+                               in %hw_in : !firrtl.uint<5>,
+                               out %hw_out : !firrtl.uint<5>) {
+    firrtl.ref.define %out, %in : !firrtl.probe<uint<5>>
+    firrtl.strictconnect %hw_out, %hw_in : !firrtl.uint<5>
+  }
+  firrtl.module @UTurnTH(in %in : !firrtl.uint<5>, out %out : !firrtl.uint<5>) {
+    // CHECK: %[[U_IN:.+]], %[[U_HW_IN:.+]] = firrtl.instance
+    %u_in, %u_out, %u_hw_in, %u_hw_out = firrtl.instance u @UTurn(in in : !firrtl.probe<uint<5>>,
+                                                                  out out : !firrtl.probe<uint<5>>,
+                                                                  in hw_in : !firrtl.uint<5>,
+                                                                  out hw_out : !firrtl.uint<5>)
+    %ref = firrtl.ref.send %in : !firrtl.uint<5>
+    firrtl.ref.define %u_in, %ref : !firrtl.probe<uint<5>>
+    // CHECK: firrtl.ref.resolve %[[U_IN]]
+    %data = firrtl.ref.resolve %u_out : !firrtl.probe<uint<5>>
+    firrtl.strictconnect %u_hw_in, %in : !firrtl.uint<5>
+    // CHECK: firrtl.strictconnect %out, %[[U_HW_IN]]
+    firrtl.strictconnect %out, %u_hw_out : !firrtl.uint<5>
+  }
+}
+
+// -----
+
+// Multiple outputs derived from same input.
+
+// CHECK-LABEL: "Split"
+firrtl.circuit "Split" {
+  // CHECK: @SPassthrough(in %in: !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>) {
+  firrtl.module private @SPassthrough(in %in: !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>, out %y: !firrtl.probe<uint<5>>, out %z: !firrtl.probe<uint<5>>) {
+    %w = firrtl.wire : !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>
+    firrtl.ref.define %w, %in : !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>
+
+    %0 = firrtl.ref.sub %w[1] : !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>
+    %1 = firrtl.ref.sub %w[0] : !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>
+    firrtl.ref.define %y, %1 : !firrtl.probe<uint<5>>
+    firrtl.ref.define %z, %0 : !firrtl.probe<uint<5>>
+  }
+  firrtl.module @Split(in %x: !firrtl.bundle<a: uint<5>, b: uint<5>>, out %y: !firrtl.probe<uint<5>>, out %z: !firrtl.probe<uint<5>>) attributes {convention = #firrtl<convention scalarized>} {
+    %sp_in, %sp_y, %sp_z = firrtl.instance sp interesting_name @SPassthrough(in in: !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>, out y: !firrtl.probe<uint<5>>, out z: !firrtl.probe<uint<5>>)
+    %0 = firrtl.ref.send %x : !firrtl.bundle<a: uint<5>, b: uint<5>>
+    firrtl.ref.define %sp_in, %0 : !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>
+    firrtl.ref.define %y, %sp_y : !firrtl.probe<uint<5>>
+    firrtl.ref.define %z, %sp_z : !firrtl.probe<uint<5>>
+  }
+}
+
+// -----
+
+// Multiple-instantiation hoisting
+
+// CHECK-LABEL: "MultUTurnTH"
+firrtl.circuit "MultUTurnTH" {
+  // CHECK:      module private @UTurn(in %in: !firrtl.probe<uint<5>>) {
+  // CHECK-NEXT: }
+  firrtl.module private @UTurn(in %in : !firrtl.probe<uint<5>>, out %out : !firrtl.probe<uint<5>>) {
+    firrtl.ref.define %out, %in : !firrtl.probe<uint<5>>
+  }
+  // CHECK: @MultUTurnTH
+  firrtl.module @MultUTurnTH(in %in : !firrtl.uint<5>, in %in2 : !firrtl.uint<5>) {
+    // CHECK: %[[U_IN:.+]] = firrtl.instance
+    %u_in, %u_out = firrtl.instance u @UTurn(in in : !firrtl.probe<uint<5>>, out out : !firrtl.probe<uint<5>>)
+    %ref = firrtl.ref.send %in : !firrtl.uint<5>
+    firrtl.ref.define %u_in, %ref : !firrtl.probe<uint<5>>
+    // CHECK: firrtl.ref.resolve %[[U_IN]]
+    %data = firrtl.ref.resolve %u_out : !firrtl.probe<uint<5>>
+
+    // CHECK: %[[U2_IN:.+]] = firrtl.instance
+    %u2_in, %u2_out = firrtl.instance u2 @UTurn(in in : !firrtl.probe<uint<5>>, out out : !firrtl.probe<uint<5>>)
+    %ref2 = firrtl.ref.send %in2 : !firrtl.uint<5>
+    firrtl.ref.define %u2_in, %ref2 : !firrtl.probe<uint<5>>
+    // CHECK: firrtl.ref.resolve %[[U2_IN]]
+    %data2 = firrtl.ref.resolve %u2_out : !firrtl.probe<uint<5>>
+  }
+}
+
+// -----
+
+// Multiple-level hoist
+
+// CHECK-LABEL: HWMultiLevel
+firrtl.circuit "HWMultiLevel" {
+  // CHECK:      @Child(in %x: !firrtl.uint<5>) {
+  // CHECK-NEXT: }
+  firrtl.module private @Child(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<5>) {
+    firrtl.strictconnect %y, %x : !firrtl.uint<5>
+  }
+  // CHECK:      @Mid(in %x: !firrtl.uint<5>) {
+  // CHECK-NEXT:   %[[C_IN:.+]] = firrtl.instance c
+  // CHECK-NEXT:   firrtl.strictconnect %[[C_IN]], %x
+  // CHECK-NEXT: }
+  firrtl.module private @Mid(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<5>) {
+    %c_x, %c_y = firrtl.instance c interesting_name @Child(in x: !firrtl.uint<5>, out y: !firrtl.uint<5>)
+    firrtl.strictconnect %c_x, %x : !firrtl.uint<5>
+    firrtl.strictconnect %y, %c_y : !firrtl.uint<5>
+  }
+  // CHECK: @HWMultiLevel
+  firrtl.module @HWMultiLevel(in %x: !firrtl.uint<5>, in %x2: !firrtl.uint<5>, out %y: !firrtl.uint<5>) {
+    // CHECK: %[[M_X:.+]] = firrtl.instance m
+    // CHECK: %[[M2_X:.+]] = firrtl.instance m2
+    %m_x, %m_y = firrtl.instance m interesting_name @Mid(in x: !firrtl.uint<5>, out y: !firrtl.uint<5>)
+    %m2_x, %m2_y = firrtl.instance m2 interesting_name @Mid(in x: !firrtl.uint<5>, out y: !firrtl.uint<5>)
+    firrtl.strictconnect %m_x, %x : !firrtl.uint<5>
+    firrtl.strictconnect %m2_x, %x2 : !firrtl.uint<5>
+
+    // CHECK: firrtl.and %[[M_X]], %[[M2_X]]
+    %0 = firrtl.and %m_y, %m2_y : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+    firrtl.strictconnect %y, %0 : !firrtl.uint<5>
+  }
+}
+
+// -----
+
+// Don't hoist through public modules
+
+// CHECK-LABEL: "Public"
+firrtl.circuit "Public" {
+  // CHECK: @Public(in %in
+  // CHECK-SAME: , out %out
+  firrtl.module @Public(in %in : !firrtl.uint<5>, out %out : !firrtl.uint<5>) {
+    firrtl.strictconnect %out, %in : !firrtl.uint<5>
+  }
+}
+
+// -----
+
+// Check insertion of temporary, and hoisting out of when regions.
+// CHECK-LABEL: "NeedsWire"
+firrtl.circuit "NeedsWire" {
+  firrtl.module @NeedsWire(in %in_cond : !firrtl.uint<1>) {
+    %cond, %in_pass, %out_pass, %out_ref = firrtl.instance c @Child(in cond : !firrtl.uint<1>,
+                                                                    in in : !firrtl.probe<vector<uint<1>,2>>,
+                                                                    out out : !firrtl.probe<uint<1>>,
+                                                                    out out_vec : !firrtl.probe<vector<uint<1>, 2>>)
+    firrtl.ref.define %in_pass, %out_ref: !firrtl.probe<vector<uint<1>, 2>>
+    firrtl.strictconnect %cond, %in_cond : !firrtl.uint<1>
+  }
+  firrtl.extmodule @ExtVec(out vec : !firrtl.vector<uint<1>, 2>)
+  // CHECK: module private @Child(
+  // CHECK-NOT: out %out:
+  // CHECK-SAME: out %out_vec
+  firrtl.module private @Child(in %cond : !firrtl.uint<1>,
+                               in %in : !firrtl.probe<vector<uint<1>,2>>,
+                               out %out : !firrtl.probe<uint<1>>,
+                               out %out_vec : !firrtl.probe<vector<uint<1>, 2>>) {
+    // CHECK-NEXT: firrtl.wire : !firrtl.probe<uint<1>>
+    firrtl.when %cond : !firrtl.uint<1> {
+      %index = firrtl.ref.sub %in[1] : !firrtl.probe<vector<uint<1>,2>>
+      firrtl.ref.define %out, %index : !firrtl.probe<uint<1>>
+    } else {
+      %data = firrtl.ref.resolve %out : !firrtl.probe<uint<1>>
+    }
+
+    %vec = firrtl.instance ev @ExtVec(out vec : !firrtl.vector<uint<1>, 2>)
+    %vec_ref = firrtl.ref.send %vec : !firrtl.vector<uint<1>, 2>
+    firrtl.ref.define %out_vec, %vec_ref : !firrtl.probe<vector<uint<1>, 2>>
+  }
+}
+
+// -----
+
+// Hoisting through cast: refs
+
+// CHECK-LABEL: "RefCast"
+firrtl.circuit "RefCast" {
+  // CHECK:      module private @UTurnCast(in %in: !firrtl.rwprobe<uint<5>>) {
+  // CHECK-NEXT:   firrtl.ref.cast %in : (!firrtl.rwprobe<uint<5>>) -> !firrtl.probe<uint<5>>
+  // CHECK-NEXT: }
+  firrtl.module private @UTurnCast(in %in : !firrtl.rwprobe<uint<5>>, out %out : !firrtl.probe<uint<5>>) {
+    %cast = firrtl.ref.cast %in : (!firrtl.rwprobe<uint<5>>) -> !firrtl.probe<uint<5>>
+    firrtl.ref.define %out, %cast : !firrtl.probe<uint<5>>
+  }
+  firrtl.module @RefCast(in %in : !firrtl.uint<5>) {
+    // CHECK: %[[U_IN:.+]] = firrtl.instance
+    %u_in, %u_out = firrtl.instance u @UTurnCast(in in : !firrtl.rwprobe<uint<5>>, out out : !firrtl.probe<uint<5>>)
+    %n, %ref = firrtl.node %in forceable : !firrtl.uint<5>
+    firrtl.ref.define %u_in, %ref : !firrtl.rwprobe<uint<5>>
+    // CHECK: %[[CAST:.+]] = firrtl.ref.cast %[[U_IN]]
+    // CHECK: firrtl.ref.resolve %[[CAST]]
+    %data = firrtl.ref.resolve %u_out : !firrtl.probe<uint<5>>
+  }
+}
+
+// -----
+
+// Reject through cast: hw
+
+// Some casts are reasonable to handle, future work.
+
+// CHECK-LABEL: "HWCast"
+firrtl.circuit "HWCast" {
+  // CHECK:      module private @UTurnHWCast(in %in: !firrtl.const.uint<5>, out %out: !firrtl.uint<5>) {
+  firrtl.module private @UTurnHWCast(in %in : !firrtl.const.uint<5>, out %out : !firrtl.uint<5>) {
+    %cast = firrtl.constCast %in : (!firrtl.const.uint<5>) -> !firrtl.uint<5>
+    firrtl.strictconnect %out, %cast : !firrtl.uint<5>
+  }
+  firrtl.module @HWCast(in %in : !firrtl.const.uint<5>, out %out : !firrtl.uint<5>) {
+    // CHECK: %{{.+}}, %[[U_OUT:.+]] = firrtl.instance
+    %u_in, %u_out = firrtl.instance u @UTurnHWCast(in in : !firrtl.const.uint<5>, out out : !firrtl.uint<5>)
+    firrtl.strictconnect %u_in, %in : !firrtl.const.uint<5>
+    // CHECK: firrtl.strictconnect %out, %[[U_OUT]] : !firrtl.uint<5>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<5>
+  }
+}
+
+// -----
+
+// Hoisting through wires (+cast): refs
+
+// CHECK-LABEL: "RefWire"
+firrtl.circuit "RefWire" {
+  // CHECK:      module private @UWire(in %in: !firrtl.rwprobe<uint<5>>) {
+  // CHECK-NEXT:   %[[W:.+]] = firrtl.wire : !firrtl.rwprobe
+  // CHECK-NEXT:   firrtl.ref.define %[[W]], %in
+  // CHECK-NEXT:   firrtl.ref.cast %[[W]] : (!firrtl.rwprobe<uint<5>>) -> !firrtl.probe<uint<5>>
+  // CHECK-NEXT: }
+  firrtl.module private @UWire(in %in : !firrtl.rwprobe<uint<5>>, out %out : !firrtl.probe<uint<5>>) {
+    %w = firrtl.wire : !firrtl.rwprobe<uint<5>>
+    firrtl.ref.define %w, %in : !firrtl.rwprobe<uint<5>>
+    %cast = firrtl.ref.cast %w : (!firrtl.rwprobe<uint<5>>) -> !firrtl.probe<uint<5>>
+    firrtl.ref.define %out, %cast : !firrtl.probe<uint<5>>
+  }
+  firrtl.module @RefWire(in %in : !firrtl.uint<5>) {
+    // CHECK: %[[U_IN:.+]] = firrtl.instance
+    %u_in, %u_out = firrtl.instance u @UWire(in in : !firrtl.rwprobe<uint<5>>, out out : !firrtl.probe<uint<5>>)
+    %n, %ref = firrtl.node %in forceable : !firrtl.uint<5>
+    firrtl.ref.define %u_in, %ref : !firrtl.rwprobe<uint<5>>
+    // CHECK: %[[CAST:.+]] = firrtl.ref.cast %[[U_IN]]
+    // CHECK: firrtl.ref.resolve %[[CAST]]
+    %data = firrtl.ref.resolve %u_out : !firrtl.probe<uint<5>>
+  }
+}
+
+// -----
+
+// Hoisting through wires: hw
+
+// CHECK-LABEL: HWWire
+firrtl.circuit "HWWire" {
+  // CHECK:      module private @UWire(in %in: !firrtl.uint<1>) {
+  // CHECK-NEXT:   %[[W:.+]] = firrtl.wire
+  // CHECK-NEXT:   firrtl.strictconnect %[[W]], %in
+  // CHECK-NEXT: }
+  firrtl.module private @UWire(in %in: !firrtl.uint<1>,
+                               out %out : !firrtl.uint<1>) {
+    %w = firrtl.wire : !firrtl.uint<1>
+    firrtl.strictconnect %w, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %w : !firrtl.uint<1>
+  }
+  firrtl.module @HWWire(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    // CHECK: %[[HW_IN:.+]] = firrtl.instance
+    %u_in, %u_out = firrtl.instance u @UWire(in in : !firrtl.uint<1>,
+                                             out out : !firrtl.uint<1>)
+    // CHECK: strictconnect %out, %[[HW_IN]]
+    firrtl.strictconnect %u_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Hoisting reset signal: HW
+
+// CHECK-LABEL: HWReset
+firrtl.circuit "HWReset" {
+  // CHECK:      module private @UTurn(in %in: !firrtl.reset) {
+  // CHECK-NEXT: }
+  firrtl.module private @UTurn(in %in: !firrtl.reset,
+                               out %out : !firrtl.reset) {
+    firrtl.strictconnect %out, %in : !firrtl.reset
+  }
+  firrtl.module @HWReset(in %in : !firrtl.asyncreset, out %out : !firrtl.reset) {
+    // CHECK: %[[HW_IN:.+]] = firrtl.instance
+    %u_in, %u_out = firrtl.instance u @UTurn(in in : !firrtl.reset,
+                                             out out : !firrtl.reset)
+    // CHECK: strictconnect %out, %[[HW_IN]]
+    firrtl.connect %u_in, %in : !firrtl.reset, !firrtl.asyncreset
+    firrtl.strictconnect %out, %u_out : !firrtl.reset
+  }
+}
+
+// -----
+
+// Don't infinite loop on cycles
+
+// CHECK-LABEL: "SimpleCycle"
+firrtl.circuit "SimpleCycle" {
+  firrtl.module private @UTurn(in %in: !firrtl.uint<1>,
+                               out %out : !firrtl.uint<1>) {
+    // Connectivity cycle.
+    %w = firrtl.wire : !firrtl.uint<1>
+    firrtl.strictconnect %out, %w : !firrtl.uint<1>
+    firrtl.strictconnect %w, %out : !firrtl.uint<1>
+  }
+  firrtl.module @SimpleCycle(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    %u_in, %u_out = firrtl.instance u @UTurn(in in : !firrtl.uint<1>,
+                                             out out : !firrtl.uint<1>)
+    firrtl.strictconnect %u_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Reject if symbol on source.
+
+// CHECK-LABEL: "SymSource"
+firrtl.circuit "SymSource" {
+  // CHECK:      module private @UTurn(in %in: !firrtl.uint<1> sym @sym, out %out
+  // CHECK-NEXT:   firrtl.strictconnect
+  // CHECK-NEXT: }
+  firrtl.module private @UTurn(in %in: !firrtl.uint<1> sym @sym,
+                               out %out : !firrtl.uint<1>) {
+    firrtl.strictconnect %out, %in : !firrtl.uint<1>
+  }
+  firrtl.module @SymSource(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    %u_in, %u_out = firrtl.instance u @UTurn(in in : !firrtl.uint<1>,
+                                             out out : !firrtl.uint<1>)
+    firrtl.strictconnect %u_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Reject if symbol on dest.
+
+// CHECK-LABEL: "SymDest"
+firrtl.circuit "SymDest" {
+  // CHECK:      module private @UTurn(in %in: !firrtl.uint<1>, out %out
+  // CHECK-NEXT:   firrtl.strictconnect
+  // CHECK-NEXT: }
+  firrtl.module private @UTurn(in %in: !firrtl.uint<1>,
+                               out %out : !firrtl.uint<1> sym @sym) {
+    firrtl.strictconnect %out, %in : !firrtl.uint<1>
+  }
+  firrtl.module @SymDest(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    %u_in, %u_out = firrtl.instance u @UTurn(in in : !firrtl.uint<1>,
+                                             out out : !firrtl.uint<1>)
+    firrtl.strictconnect %u_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Reject if symbol on intermediate.
+
+// CHECK-LABEL: SymIntermediate
+firrtl.circuit "SymIntermediate" {
+  // CHECK:      module private @UWire(in %in: !firrtl.uint<1>, out
+  // CHECK-NEXT:   %[[W:.+]] = firrtl.wire sym @sym
+  firrtl.module private @UWire(in %in: !firrtl.uint<1>,
+                               out %out : !firrtl.uint<1>) {
+    %w = firrtl.wire sym @sym : !firrtl.uint<1>
+    firrtl.strictconnect %w, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %w : !firrtl.uint<1>
+  }
+  firrtl.module @SymIntermediate(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    %u_in, %u_out = firrtl.instance u @UWire(in in : !firrtl.uint<1>,
+                                             out out : !firrtl.uint<1>)
+    firrtl.strictconnect %u_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Reject non-passive source.
+
+// CHECK-LABEL: "NonPassiveSource"
+firrtl.circuit "NonPassiveSource" {
+  // CHECK: @Child
+  // CHECK-SAME: flip
+  // CHECK-SAME: out %y
+  firrtl.module private @Child(in %x: !firrtl.bundle<a: uint<1>, b flip: uint<2>>, out %y: !firrtl.uint<1>) {
+    %0 = firrtl.subfield %x[b] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
+    %1 = firrtl.subfield %x[a] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
+    firrtl.strictconnect %y, %1 : !firrtl.uint<1>
+    %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
+    firrtl.strictconnect %0, %c1_ui2 : !firrtl.uint<2>
+  }
+  firrtl.module @NonPassiveSource(in %x: !firrtl.bundle<a: uint<1>, b flip: uint<2>>, out %y: !firrtl.uint<1>) attributes {convention = #firrtl<convention scalarized>} {
+    %c_x, %c_y = firrtl.instance c @Child(in x: !firrtl.bundle<a: uint<1>, b flip: uint<2>>, out y: !firrtl.uint<1>)
+    %0 = firrtl.subfield %c_x[a] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
+    %1 = firrtl.subfield %x[a] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
+    firrtl.strictconnect %0, %1 : !firrtl.uint<1>
+    %2 = firrtl.subfield %c_x[b] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
+    %3 = firrtl.subfield %x[b] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
+    firrtl.strictconnect %3, %2 : !firrtl.uint<2>
+    firrtl.strictconnect %y, %c_y : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Reject non-ground dest (for now).
+
+// CHECK-LABEL: "AggHW"
+firrtl.circuit "AggHW" {
+  // CHECK:      module private @UTurn(in %in: !firrtl.vector<uint<1>, 5>, out %out
+  // CHECK-NEXT:   firrtl.strictconnect
+  // CHECK-NEXT: }
+  firrtl.module private @UTurn(in %in: !firrtl.vector<uint<1>, 5>,
+                               out %out : !firrtl.vector<uint<1>, 5>) {
+    firrtl.strictconnect %out, %in : !firrtl.vector<uint<1>, 5>
+  }
+  firrtl.module @AggHW(in %in : !firrtl.vector<uint<1>, 5>, out %out : !firrtl.vector<uint<1>, 5>) {
+    %u_in, %u_out = firrtl.instance u @UTurn(in in : !firrtl.vector<uint<1>, 5>,
+                                             out out : !firrtl.vector<uint<1>, 5>)
+    firrtl.strictconnect %u_in, %in : !firrtl.vector<uint<1>, 5>
+    firrtl.strictconnect %out, %u_out : !firrtl.vector<uint<1>, 5>
+  }
+}
+
+// -----
+
+// Reject multiple drivers: HW
+
+// CHECK-LABEL: "MultiConnect"
+firrtl.circuit "MultiConnect" {
+  // CHECK:      module private @UTurn(in %in: !firrtl.uint<1>, out %out
+  // CHECK-COUNT-2: strictconnect
+  // CHECK-NEXT: }
+  firrtl.module private @UTurn(in %in: !firrtl.uint<1>,
+                               out %out : !firrtl.uint<1>) {
+    firrtl.strictconnect %out, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %in : !firrtl.uint<1>
+  }
+  firrtl.module @MultiConnect(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    %u_in, %u_out = firrtl.instance u @UTurn(in in : !firrtl.uint<1>,
+                                             out out : !firrtl.uint<1>)
+    firrtl.strictconnect %u_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Annotations: DontTouch blocks
+
+// CHECK-LABEL: "DontTouch"
+firrtl.circuit "DontTouch" {
+  // CHECK:      DontTouchAnnotation
+  // CHECK-SAME: out %out
+  // CHECK-NEXT:   firrtl.strictconnect
+  firrtl.module private @UTurn(in %in: !firrtl.uint<1> [{class = "firrtl.transforms.DontTouchAnnotation"}],
+                               out %out : !firrtl.uint<1>) {
+    firrtl.strictconnect %out, %in : !firrtl.uint<1>
+  }
+  firrtl.module @DontTouch(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    %u_in, %u_out = firrtl.instance u @UTurn(in in : !firrtl.uint<1>,
+                                             out out : !firrtl.uint<1>)
+    firrtl.strictconnect %u_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Annotations: hoist through, but leave on original.
+
+// CHECK-LABEL: HWAnno
+firrtl.circuit "HWAnno" {
+  // CHECK:      module private @UAnno(in %in: !firrtl.uint<1>) {
+  // CHECK-NEXT:   %[[W:.+]] = firrtl.wire {annotations
+  // CHECK-NEXT:   firrtl.strictconnect %[[W]], %in
+  // CHECK-NEXT: }
+  firrtl.module private @UAnno(in %in: !firrtl.uint<1>,
+                               out %out : !firrtl.uint<1>) {
+    %w = firrtl.wire {annotations = [{class = "circt.test"}]} : !firrtl.uint<1>
+    firrtl.strictconnect %w, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %w : !firrtl.uint<1>
+  }
+  firrtl.module @HWAnno(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    // CHECK: %[[HW_IN:.+]] = firrtl.instance
+    %u_in, %u_out = firrtl.instance u @UAnno(in in : !firrtl.uint<1>,
+                                             out out : !firrtl.uint<1>)
+    // CHECK: strictconnect %out, %[[HW_IN]]
+    firrtl.strictconnect %u_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// "Forceable" declarations.
+
+// CHECK-LABEL: HWForceable
+firrtl.circuit "HWForceable" {
+  // CHECK:      module private @UForceable(in %in: !firrtl.uint<1>, out %out
+  firrtl.module private @UForceable(in %in: !firrtl.uint<1>,
+                               out %out : !firrtl.uint<1>) {
+    %w, %w_ref = firrtl.wire forceable : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
+    firrtl.strictconnect %w, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %w : !firrtl.uint<1>
+  }
+  firrtl.module @HWForceable(in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
+    %u_in, %u_out = firrtl.instance u @UForceable(in in : !firrtl.uint<1>,
+                                             out out : !firrtl.uint<1>)
+    firrtl.strictconnect %u_in, %in : !firrtl.uint<1>
+    firrtl.strictconnect %out, %u_out : !firrtl.uint<1>
+  }
+}

--- a/test/firtool/extract-test-code.fir
+++ b/test/firtool/extract-test-code.fir
@@ -2,7 +2,9 @@
 ; RUN: firtool %s -extract-test-code -etc-disable-instance-extraction | FileCheck %s --check-prefix=DISABLEINSTANCE
 ; RUN: firtool %s -extract-test-code -etc-disable-module-inlining | FileCheck %s --check-prefix=DISABLEMODULE
 
-circuit Top:
+circuit Top: %[[
+{"class": "firrtl.transforms.DontTouchAnnotation", "target": "~Top|Foo>b"}
+]]
   module Foo:
     input a : UInt<1>
     output b : UInt<1>
@@ -13,7 +15,7 @@ circuit Top:
   ; CHECK: Foo foo
 
   ; Ensure foo is not extracted when disabled.
-  ; DISABLEINSTANCE-LABEL: module InstanceExtracted(
+  ; DISABLEINSTANCE-LABEL: module Top(
   ; DISABLEINSTANCE: Foo foo
 
   module InstanceExtracted:

--- a/test/firtool/extract-test-code.fir
+++ b/test/firtool/extract-test-code.fir
@@ -2,9 +2,7 @@
 ; RUN: firtool %s -extract-test-code -etc-disable-instance-extraction | FileCheck %s --check-prefix=DISABLEINSTANCE
 ; RUN: firtool %s -extract-test-code -etc-disable-module-inlining | FileCheck %s --check-prefix=DISABLEMODULE
 
-circuit Top: %[[
-{"class": "firrtl.transforms.DontTouchAnnotation", "target": "~Top|Foo>b"}
-]]
+circuit Top:
   module Foo:
     input a : UInt<1>
     output b : UInt<1>
@@ -15,7 +13,7 @@ circuit Top: %[[
   ; CHECK: Foo foo
 
   ; Ensure foo is not extracted when disabled.
-  ; DISABLEINSTANCE-LABEL: module Top(
+  ; DISABLEINSTANCE-LABEL: module InstanceExtracted(
   ; DISABLEINSTANCE: Foo foo
 
   module InstanceExtracted:

--- a/test/firtool/passthrough-flips.fir
+++ b/test/firtool/passthrough-flips.fir
@@ -1,0 +1,20 @@
+; Check firtool pipeline hoisting passthroughs with flips (run hoist pass after LowerTypes, presently).
+; RUN: firtool -disable-hoisting-hw-passthrough=false %s | FileCheck %s --implicit-check-not module
+; CHECK: module PassthroughFlips
+; CHECK: endmodule
+circuit PassthroughFlips:
+  module Child:
+    input x : {a: UInt<5>, flip b: UInt<3>}
+    output y : {a: UInt<5>, flip b: UInt<3>}
+    y <= x
+  module PassthroughFlips:
+    input x : {a: UInt<5>, flip b: UInt<3>}
+    output y : {a: UInt<5>, flip b: UInt<3>}
+
+    inst c1 of Child
+    inst c2 of Child
+
+    c1.x <= x
+    c2.x <= c1.y
+    y <= c2.y
+

--- a/test/firtool/passthrough.fir
+++ b/test/firtool/passthrough.fir
@@ -1,6 +1,8 @@
-; RUN: firtool %s | FileCheck %s --implicit-check-not module
+; For now, default to not enabling HW signal hoisting.
+; RUN: firtool %s | FileCheck %s --check-prefix=DISABLE
+; RUN: firtool -disable-hoisting-hw-passthrough=false %s | FileCheck %s --implicit-check-not module
 ; RUN: firtool -disable-opt %s | FileCheck %s --check-prefix=DISABLE
-; RUN: firtool -disable-hoisting-hw-passthrough %s | FileCheck %s --check-prefix=DISABLE
+; RUN: firtool -disable-hoisting-hw-passthrough=true %s | FileCheck %s --check-prefix=DISABLE
 
 ; Check passthrough modules are elided.
 ; CHECK:       module HWMultiLevel

--- a/test/firtool/passthrough.fir
+++ b/test/firtool/passthrough.fir
@@ -1,0 +1,41 @@
+; RUN: firtool %s | FileCheck %s --implicit-check-not module
+; RUN: firtool -disable-opt %s | FileCheck %s --check-prefix=DISABLE
+
+; Check passthrough modules are elided.
+; CHECK:       module HWMultiLevel
+; CHECK:       );
+; CHECK-EMPTY:
+; CHECK-NEXT:    assign y = x & x2;
+; CHECK-NEXT:  endmodule
+
+; Check -disable-opt prevents this.
+; DISABLE: module Child
+; DISABLE: module Mid
+; DISABLE: module HWMultiLevel
+circuit HWMultiLevel:
+  module Child:
+    input x : UInt<5>
+    output y : UInt<5>
+
+    y <= x
+  module Mid:
+    input x : UInt<5>
+    output y : UInt<5>
+
+    inst c of Child
+    c.x <= x
+    y <= c.y
+
+  module HWMultiLevel:
+    input x : UInt<5>
+    input x2 : UInt<5>
+    output y : UInt<5>
+
+    inst m of Mid
+    inst m2 of Mid
+
+    m.x <= x
+    m2.x <= x2
+
+    y <= and(m.y, m2.y)
+

--- a/test/firtool/passthrough.fir
+++ b/test/firtool/passthrough.fir
@@ -1,5 +1,6 @@
 ; RUN: firtool %s | FileCheck %s --implicit-check-not module
 ; RUN: firtool -disable-opt %s | FileCheck %s --check-prefix=DISABLE
+; RUN: firtool -disable-hoisting-hw-passthrough %s | FileCheck %s --check-prefix=DISABLE
 
 ; Check passthrough modules are elided.
 ; CHECK:       module HWMultiLevel


### PR DESCRIPTION
Basic driver analysis to detect must-driven values and hoist/rematerialize them using equivalent driver at instantiation site.

End-to-end example included for testing `-disable-opt` demonstrates why this is desirable -- here's a before/after diff:

```patch
--- /proc/self/fd/11	2023-09-12 15:22:35.254920380 -0500
+++ /proc/self/fd/12	2023-09-12 15:22:35.254920380 -0500
@@ -1,39 +1,10 @@
-// Generated by CIRCT firtool-1.54.0-30-g7bb1650e3
-module Child(
-  input  [4:0] x,
-  output [4:0] y
-);
-
-  assign y = x;
-endmodule
-
-module Mid(
-  input  [4:0] x,
-  output [4:0] y
-);
-
-  Child c (
-    .x (x),
-    .y (y)
-  );
-endmodule
-
+// Generated by CIRCT firtool-1.54.0-29-gc3332a678
 module HWMultiLevel(
   input  [4:0] x,
                x2,
   output [4:0] y
 );
 
-  wire [4:0] _m2_y;
-  wire [4:0] _m_y;
-  Mid m (
-    .x (x),
-    .y (_m_y)
-  );
-  Mid m2 (
-    .x (x2),
-    .y (_m2_y)
-  );
-  assign y = _m_y & _m2_y;
+  assign y = x & x2;
 endmodule
```

This is originally motivated by need to do bottom-up half of "de-squiggling" to handle input probe u-turns, context-sensitively, in an efficient way but leaves cleanup and probe-specific diagnostics to other passes (does not sink equivalently-driven "n-turns" that remain).

Current analysis is intended to be simple (selectively chase output ports through must-drive chains) as that is sufficient for probes ("static single connect"+strict semantics, can't drive partially re:indexing) while lending itself to HW signals naturally.  Support for more sophisticated scenarios and more powerful framing is left for future work if we like this direction and there's need (e.g., more effective when enabling aggregate preservation, ability to hoist logic as well, so on), lots of adventures to be had here! :grin:

Safety is paramount, especially regarding the interpretation of some darker corners of the semantics of FIRRTL re:what it means to annotate, dontTouch, so on, a signal.  Care was taken to align with rest of pipeline and existing use-cases/flows but critical eye appreciated.

This is fairly efficient in practice on large internal designs (at least as fast as passes that are ~linear in size of design, not significant re:total execution time) yet effective for current pipeline, allowing modules to be deleted and exposing optimization opportunities for local and context-insensitive optimizations.

To demonstrate, here's a Chipyard core with and without the pass enabled (same pipeline otherwise): https://github.com/dtzSiFive/chipyard-hoist-comparison/commit/7fc7216003270e4ec85ab2273ac84be341877bfc .