### PR TITLE
[FIRRTL] Update LowerClasses to handle AnyRef and AnyRef cast.

### DIFF
--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -331,7 +331,7 @@ firrtl.circuit "AnyCast" {
     // CHECK: %[[OBJ:.+]] = om.object @Foo
     %fooObject = firrtl.object @Foo()
     // CHECK: %[[CAST:.+]] = om.any_cast %[[OBJ]]
-    %0 = firrtl.object.anyref_cast %fooObject : (!firrtl.class<@Foo()>) -> !firrtl.anyref
+    %0 = firrtl.object.anyref_cast %fooObject : !firrtl.class<@Foo()>
     // CHECK: om.class.field @foo, %[[CAST]]
     firrtl.propassign %foo, %0 : !firrtl.anyref
   }

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -322,3 +322,17 @@ firrtl.circuit "ModuleInstances" {
   // CHECK:   %[[F1:.+]] = om.object.field %[[O1]], [@outputProp]
   // CHECK:   om.class.field @outputProp, %[[F1]]
 }
+
+// CHECK-LABEL: firrtl.circuit "AnyCast"
+firrtl.circuit "AnyCast" {
+  firrtl.class private @Foo() {}
+
+  firrtl.module @AnyCast(out %foo: !firrtl.anyref) {
+    // CHECK: %[[OBJ:.+]] = om.object @Foo
+    %fooObject = firrtl.object @Foo()
+    // CHECK: %[[CAST:.+]] = om.any_cast %[[OBJ]]
+    %0 = firrtl.object.anyref_cast %fooObject : (!firrtl.class<@Foo()>) -> !firrtl.anyref
+    // CHECK: om.class.field @foo, %[[CAST]]
+    firrtl.propassign %foo, %0 : !firrtl.anyref
+  }
+}


### PR DESCRIPTION
The FIRRTL AnyRef type is converted to an OM Any type, and FIRRTL AnyRef casts are converted to OM Any casts. This is a straightforward conversion of the same concepts into the OM dialect.