### PR TITLE
[Arc] Introduce vectorize operation

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -646,4 +646,150 @@ def ZeroCountOp : ArcOp<"zero_count", [Pure, SameOperandsAndResultType]> {
   let assemblyFormat = "$predicate $input attr-dict `:` type($input)";
 }
 
+def IntOr1DVectorOfInt : AnyTypeOf<[
+  AnySignlessInteger,
+  VectorOfRankAndType<[1], [AnySignlessInteger]>
+]>;
+
+def VectorizeOp : ArcOp<"vectorize", [
+    IsolatedFromAbove, RecursiveMemoryEffects
+  ]> {
+  let summary = "isolated subgraph of operations to be vectorized";
+  let description = [{
+    This operation represents a vectorized computation DAG. It places a
+    convenient boundary between the subgraph to be vectorized and the
+    surrounding non-vectorizable parts of the original graph.
+
+    This allows us to split the vectorization transformations into multiple
+    parts/passes:
+      * Finding an initial set of operations to be vectorized
+      * Optimizing this set by pulling in more operations into the nested block,
+        splitting it such that the vector width does not exceed a given limit,
+        applying a cost model and potentially reverting the decision to
+        vectorize this subgraph (e.g., because not enough ops could be pulled
+        in)
+      * Performing the actual vectorization by lowering this operation. This
+        operation allows to perform the lowering of the boundary and the body
+        separately and either via 1D `vector` types for SIMD vectorization or
+        plain integers for manual vectorization within a scalar register.
+
+    For each block argument of the nested block, there is a list of operands
+    that represent the elements of the vector. If the boundary is already
+    vectorized each list will only contain a single SSA value of either vector
+    type or an integer representing the concatenation of all original operands
+    of that vector.
+    Only integer types can be vectorized, no arrays or structs are allowed.
+
+    Example:
+
+    Given the following two AND operations in the IR
+    ```mlir
+    %0 = arith.and %in0, %in1 : i1
+    %1 = arith.and %in2, %in2 : i1
+    ```
+    they could be vectorized by putting one such AND operation in the body block
+    of the `arc.vectorize` operation and forwarding the operands accordingly.
+    ```mlir
+    %0:2 = arc.vectorize (%in0, %in1), (%in2, %in2) :
+      (i1, i1, i1, i1) -> (i1, i1) {
+    ^bb0(%arg0: i1, %arg1: i1):
+      %1 = arith.and %arg0, %arg1 : i1
+      arc.output %1 : i1
+    }
+    ```
+    In a next step, the boundary could be lowered/vectorized. This can happen
+    in terms of integers for vectorization within scalar registers:
+    ```mlir
+    %0 = comb.concat %in0, %in1 : i1, i1
+    %1 = comb.replicate %in2 : (i1) -> i2
+    %2 = arc.vectorize (%0), (%1) : (i2, i2) -> (i2) {
+    ^bb0(%arg0: i1, %arg1: i1):
+      %1 = arith.and %arg0, %arg1 : i1
+      arc.output %1 : i1
+    }
+    %3 = comb.extract %2 from 1 : (i2) -> i1
+    %4 = comb.extract %2 from 0 : (i2) -> i1
+    ```
+    Or via `vector` types for SIMD vectorization:
+    ```mlir
+    %cst = arith.constant dense<0> : vector<2xi1>
+    %0 = vector.insert %in0, %cst[0] : i1 into vector<2xi1>
+    %1 = vector.insert %in1, %0[1] : i1 into vector<2xi1>
+    %2 = vector.broadcast %in2 : i1 to vector<2xi1>
+    %3 = arc.vectorize (%1), (%2) :
+      (vector<2xi1>, vector<2xi1>) -> (vector<2xi1>) {
+    ^bb0(%arg0: i1, %arg1: i1):
+      %1 = arith.and %arg0, %arg1 : i1
+      arc.output %1 : i1
+    }
+    %4 = vector.extract %2[0] : vector<2xi1>
+    %5 = vector.extract %2[1] : vector<2xi1>
+    ```
+    Alternatively, the body could be vectorized first. Again, as integers
+    ```mlir
+    %0:2 = arc.vectorize (%in0, %in1), (%in2, %in2) :
+      (i1, i1, i1, i1) -> (i1, i1) {
+    ^bb0(%arg0: i2, %arg1: i2):
+      %1 = arith.and %arg0, %arg1 : i2
+      arc.output %1 : i2
+    }
+    ```
+    or SIMD vectors.
+    ```mlir
+    %0:2 = arc.vectorize (%in0, %in1), (%in2, %in3) : 
+      (i1, i1, i1, i1) -> (i1, i1) {
+    ^bb0(%arg0: vector<2xi1>, %arg1: vector<2xi1>):
+      %1 = arith.and %arg0, %arg1 : vector<2xi1>
+      arc.output %1 : vector<2xi1>
+    }
+    ```
+    Once both sides are lowered, the `arc.vectorize` op simply becomes a
+    passthrough for the operands and can be removed by inlining the nested
+    block. The integer based vectorization would then look like the following:
+    ```mlir
+    %0 = comb.concat %in0, %in1 : i1, i1
+    %1 = comb.replicate %in2 : (i1) -> i2
+    %2 = arith.and %0, %1 : i2
+    %3 = comb.extract %2 from 1 : (i2) -> i1
+    %4 = comb.extract %2 from 0 : (i2) -> i1
+    ```
+    The SIMD vector based lowering would result in the following IR:
+    ```mlir
+    %cst = arith.constant dense<0> : vector<2xi1>
+    %0 = vector.insert %in0, %cst[0] : i1 into vector<2xi1>
+    %1 = vector.insert %in1, %0[1] : i1 into vector<2xi1>
+    %2 = vector.broadcast %in2 : i1 to vector<2xi1>
+    %3 = arith.and %1, %2 : vector<2xi1>
+    %4 = vector.extract %3[0] : vector<2xi1>
+    %5 = vector.extract %3[1] : vector<2xi1>
+    ```
+  }];
+
+  let arguments = (ins
+    VariadicOfVariadic<IntOr1DVectorOfInt, "inputOperandSegments">:$inputs,
+    DenseI32ArrayAttr:$inputOperandSegments);
+  let results = (outs Variadic<IntOr1DVectorOfInt>:$results);
+  let regions = (region SizedRegion<1>:$body);
+
+  let assemblyFormat = [{
+    $inputs attr-dict `:` functional-type($inputs, $results) $body
+  }];
+
+  let extraClassDeclaration = [{
+    bool isBoundaryVectorized();
+    bool isBodyVectorized();
+  }];
+
+  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
+}
+
+def VectorizeReturnOp : ArcOp<"vectorize.return", [
+  HasParent<"VectorizeOp">, Pure, ReturnLike, Terminator
+]> {
+  let summary = "arc.vectorized terminator";
+  let arguments = (ins IntOr1DVectorOfInt:$value);
+  let assemblyFormat = "operands attr-dict `:` qualified(type(operands))";
+}
+
 #endif // CIRCT_DIALECT_ARC_ARCOPS_TD

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -285,6 +285,144 @@ LogicalResult LutOp::verify() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// VectorizeOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult VectorizeOp::verify() {
+  if (getInputs().empty())
+    return emitOpError("there has to be at least one input vector");
+
+  if (!llvm::all_equal(llvm::map_range(
+          getInputs(), [](OperandRange range) { return range.size(); })))
+    return emitOpError("all input vectors must have the same size");
+
+  for (OperandRange range : getInputs()) {
+    if (!llvm::all_equal(range.getTypes()))
+      return emitOpError("all input vector lane types must match");
+
+    if (range.empty())
+      return emitOpError("input vector must have at least one element");
+  }
+
+  if (getInputs().front().size() > 1 &&
+      !isa<IntegerType>(getInputs().front().front().getType()))
+    return emitOpError("input vector element type must be a signless integer");
+
+  if (getResults().empty())
+    return emitOpError("must have at least one result");
+
+  if (!llvm::all_equal(getResults().getTypes()))
+    return emitOpError("all result types must match");
+
+  if (getResults().size() != getInputs().front().size())
+    return emitOpError("number results must match input vector size");
+
+  if (getResults().size() > 1 &&
+      !isa<IntegerType>(getResults().front().getType()))
+    return emitError(
+        "may only return a vector type if boundary is already vectorized");
+
+  return success();
+}
+
+static FailureOr<unsigned> getVectorWidth(Type base, Type vectorized) {
+  if (isa<VectorType>(base))
+    return failure();
+
+  if (auto vectorTy = dyn_cast<VectorType>(vectorized)) {
+    if (vectorTy.getElementType() != base)
+      return failure();
+
+    return vectorTy.getDimSize(0);
+  }
+
+  if (vectorized.getIntOrFloatBitWidth() < base.getIntOrFloatBitWidth())
+    return failure();
+
+  if (vectorized.getIntOrFloatBitWidth() % base.getIntOrFloatBitWidth() == 0)
+    return vectorized.getIntOrFloatBitWidth() / base.getIntOrFloatBitWidth();
+
+  return failure();
+}
+
+LogicalResult VectorizeOp::verifyRegions() {
+  auto returnOp = cast<VectorizeReturnOp>(getBody().front().getTerminator());
+  TypeRange bodyArgTypes = getBody().front().getArgumentTypes();
+
+  if (bodyArgTypes.size() != getInputs().size())
+    return emitOpError(
+        "number of block arguments must match number of input vectors");
+
+  // Boundary and body are vectorized, or both are not vectorized
+  if (returnOp.getValue().getType() == getResultTypes().front()) {
+    for (auto [i, argTy] : llvm::enumerate(bodyArgTypes))
+      if (argTy != getInputs()[i].getTypes().front())
+        return emitOpError("if terminator type matches result type the "
+                           "argument types must match the input types");
+
+    return success();
+  }
+
+  // Boundary is vectorized, body is not
+  if (auto width = getVectorWidth(returnOp.getValue().getType(),
+                                  getResultTypes().front());
+      succeeded(width)) {
+    for (auto [i, argTy] : llvm::enumerate(bodyArgTypes)) {
+      Type inputTy = getInputs()[i].getTypes().front();
+      FailureOr<unsigned> argWidth = getVectorWidth(argTy, inputTy);
+      if (failed(argWidth))
+        return emitOpError("block argument must be a scalar variant of the "
+                           "vectorized operand");
+
+      if (*argWidth != width)
+        return emitOpError("input and output vector width must match");
+    }
+
+    return success();
+  }
+
+  // Body is vectorized, boundary is not
+  if (auto width = getVectorWidth(getResultTypes().front(),
+                                  returnOp.getValue().getType());
+      succeeded(width)) {
+    for (auto [i, argTy] : llvm::enumerate(bodyArgTypes)) {
+      Type inputTy = getInputs()[i].getTypes().front();
+      FailureOr<unsigned> argWidth = getVectorWidth(inputTy, argTy);
+      if (failed(argWidth))
+        return emitOpError(
+            "block argument must be a vectorized variant of the operand");
+
+      if (*argWidth != width)
+        return emitOpError("input and output vector width must match");
+
+      if (getInputs()[i].size() > 1 && argWidth != getInputs()[i].size())
+        return emitOpError(
+            "when boundary not vectorized the number of vector element "
+            "operands must match the width of the vectorized body");
+    }
+
+    return success();
+  }
+
+  return returnOp.emitOpError(
+      "operand type must match parent op's result value or be a vectorized or "
+      "non-vectorized variant of it");
+}
+
+bool VectorizeOp::isBoundaryVectorized() {
+  return getInputs().front().size() == 1;
+}
+bool VectorizeOp::isBodyVectorized() {
+  auto returnOp = cast<VectorizeReturnOp>(getBody().front().getTerminator());
+  if (isBoundaryVectorized() &&
+      returnOp.getValue().getType() == getResultTypes().front())
+    return true;
+
+  return succeeded(
+      getVectorWidth(getResultTypes().front(), returnOp.getValue().getType()));
+}
+
 #include "circt/Dialect/Arc/ArcInterfaces.cpp.inc"
 
 #define GET_OP_CLASSES

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -93,4 +93,5 @@ target_link_libraries(circt-opt
   MLIRSCFDialect
   MLIREmitCDialect
   MLIRFuncInlinerExtension
+  MLIRVectorDialect
 )

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "mlir/Transforms/Passes.h"
@@ -52,6 +53,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::cf::ControlFlowDialect>();
   registry.insert<mlir::scf::SCFDialect>();
   registry.insert<mlir::emitc::EmitCDialect>();
+  registry.insert<mlir::vector::VectorDialect>();
 
   circt::registerAllDialects(registry);
   circt::registerAllPasses();


### PR DESCRIPTION
Hardware designs commonly have a considerable amount of duplicated logic for parallel execution (e.g., multiple cores). This logic can be collected and vectorized. This operation allows us to separate the concerns of finding logic to vectorize, applying a cost model on whether it is actually worth vectorizing the found set of operations (since gather, scatter, shuffling might be more expensive than what we save from vectorizing), and performing the actual vectorization to SIMD registers or pack them within a scalar register.