### PR TITLE
[FIRRTL] Input probe support.

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -101,6 +101,8 @@ std::unique_ptr<mlir::Pass> createLowerMemoryPass();
 std::unique_ptr<mlir::Pass>
 createHoistPassthroughPass(bool hoistHWDrivers = true);
 
+std::unique_ptr<mlir::Pass> createProbeDCEPass();
+
 std::unique_ptr<mlir::Pass>
 createMemToRegOfVecPass(bool replSeqMem = false, bool ignoreReadEnable = false);
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -772,7 +772,8 @@ def ProbeDCE : Pass<"firrtl-probe-dce", "firrtl::CircuitOp"> {
   let summary = "Delete dead probe ports and operations.";
   let description = [{
     Simple pass to delete dead probe ports and operations.
-    Needed until IMDCE can run earlier in pipeline.
+    Diagnoses illegal or unsupported input probe uses.
+    Post-condition: no input probe ports.
   }];
   let constructor = "circt::firrtl::createProbeDCEPass()";
   let statistics = [

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -768,4 +768,17 @@ def HoistPassthrough : Pass<"firrtl-hoist-passthrough", "firrtl::CircuitOp"> {
   ];
 }
 
+def ProbeDCE : Pass<"firrtl-probe-dce", "firrtl::CircuitOp"> {
+  let summary = "Delete dead probe ports and operations.";
+  let description = [{
+    Simple pass to delete dead probe ports and operations.
+    Needed until IMDCE can run earlier in pipeline.
+  }];
+  let constructor = "circt::firrtl::createProbeDCEPass()";
+  let statistics = [
+    Statistic<"numErasedPorts", "num-erased-ports", "Number of ports erased">,
+    Statistic<"numErasedOps", "num-erased-ops", "Number of operations erased">
+  ];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -39,6 +39,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   PrintFIRRTLFieldSource.cpp
   PrintInstanceGraph.cpp
   PrintNLATable.cpp
+  ProbeDCE.cpp
   RandomizeRegisterInit.cpp
   RegisterOptimizer.cpp
   RemoveUnusedPorts.cpp

--- a/lib/Dialect/FIRRTL/Transforms/ProbeDCE.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ProbeDCE.cpp
@@ -1,0 +1,221 @@
+//===- ProbeDCE.cpp - Delete input probes and dead dead probe ops ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the ProbeDCE pass.  This pass ensures all input probes
+// are removed and diagnoses where that is not possible.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Iterators.h"
+#include "mlir/IR/Threading.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "firrtl-probe-dce"
+
+using namespace circt;
+using namespace firrtl;
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct ProbeDCEPass : public ProbeDCEBase<ProbeDCEPass> {
+  using ProbeDCEBase::ProbeDCEBase;
+  void runOnOperation() override;
+
+  LogicalResult process(FModuleLike mod);
+};
+} // end anonymous namespace
+
+void ProbeDCEPass::runOnOperation() {
+  LLVM_DEBUG(llvm::dbgs()
+             << "===- Running ProbeDCE Pass "
+                "--------------------------------------------------===\n");
+
+  SmallVector<Operation *, 0> ops(getOperation().getOps<FModuleLike>());
+
+  auto result = failableParallelForEach(&getContext(), ops, [&](Operation *op) {
+    return process(cast<FModuleLike>(op));
+  });
+
+  if (result.failed())
+    signalPassFailure();
+}
+
+/// This is the pass constructor.
+std::unique_ptr<mlir::Pass> circt::firrtl::createProbeDCEPass() {
+  return std::make_unique<ProbeDCEPass>();
+}
+
+//===----------------------------------------------------------------------===//
+// Per-module input probe removal.
+//===----------------------------------------------------------------------===//
+
+LogicalResult ProbeDCEPass::process(FModuleLike mod) {
+  SmallVector<size_t> probePortIndices;
+
+  // Find input probes.
+  for (auto idx : llvm::seq(mod.getNumPorts())) {
+    if (mod.getPortDirection(idx) == Direction::In &&
+        type_isa<RefType>(mod.getPortType(idx)))
+      probePortIndices.push_back(idx);
+  }
+
+  // Reject input probes across boundaries.
+  if (!probePortIndices.empty() && mod.isPublic()) {
+    auto idx = probePortIndices.front();
+    return mlir::emitError(mod.getPortLocation(idx),
+                           "input probe not allowed on public module");
+  }
+  auto modOp = dyn_cast<FModuleOp>(mod.getOperation());
+  if (!modOp) {
+    if (!probePortIndices.empty()) {
+      auto idx = probePortIndices.front();
+      return mlir::emitError(mod.getPortLocation(idx),
+                             "input probe not allowed on this module kind");
+    }
+    return success();
+  }
+
+  SmallVector<BlockArgument> args;
+  BitVector portsToErase(mod.getNumPorts());
+
+  // Forward slice over users of each.
+  // Build cumulatively, for diagnostic specificity.
+  DenseSet<Operation *> toRemoveIfNotInst;
+  SmallVector<Operation *> worklist;
+  for (auto idx : probePortIndices) {
+    worklist.clear();
+
+    auto arg = modOp.getArgument(idx);
+    portsToErase.set(idx);
+
+    // Operation is in forward slice, add.
+    auto chase = [&](Operation *op) {
+      if (!toRemoveIfNotInst.insert(op).second)
+        return;
+      worklist.push_back(op);
+    };
+    // Forward slice through value -> users.
+    auto chaseUsers = [&](Value v) {
+      for (auto *user : v.getUsers())
+        chase(user);
+    };
+    // Upwards chase for connect, and chase all users.
+    auto chaseVal = [&](Value v) -> LogicalResult {
+      if (auto depArg = dyn_cast<BlockArgument>(v)) {
+        // Input probe flows to different argument?
+        // With current (valid) IR this should not be possible.
+        if (depArg != arg)
+          return emitError(depArg.getLoc(), "argument depends on input probe")
+                     .attachNote(arg.getLoc())
+                 << "input probe";
+        // Shouldn't happen either, but safe to ignore.
+        return success();
+      }
+      auto *op = v.getDefiningOp();
+      assert(op);
+      chase(op);
+      chaseUsers(v);
+      return success();
+    };
+
+    // Start with all users of the input probe.
+    chaseUsers(arg);
+
+    while (!worklist.empty()) {
+      auto *op = worklist.pop_back_val();
+
+      // Generally just walk users.  Only "backwards" chasing is for connect,
+      // which only flows to the destination which must not be a refsub or cast.
+      auto result =
+          TypeSwitch<Operation *, LogicalResult>(op)
+              .Case([&](InstanceOp inst) {
+                // Ignore, only reachable via connect which also chases users
+                // for us.  Don't chase results not in slice.
+                return success();
+              })
+              .Case([&](FConnectLike connect) {
+                return chaseVal(connect.getDest());
+              })
+              .Case([&](RefSubOp op) {
+                chaseUsers(op.getResult());
+                return success();
+              })
+              .Case([&](RefCastOp op) {
+                chaseUsers(op.getResult());
+                return success();
+              })
+              .Case([&](WireOp op) {
+                // Ignore, only reachable via connect which also chases users
+                // for us.
+                return success();
+              })
+              .Default([&](auto *op) -> LogicalResult {
+                return emitError(op->getLoc(), "input probes cannot be used")
+                           .attachNote(arg.getLoc())
+                       << "input probe here";
+              });
+      if (failed(result))
+        return result;
+    }
+  }
+
+  // Walk the module, removing all operations in forward slice from input probes
+  // and updating all instances to reflect no more input probes anywhere.
+  // Walk post-order, reverse, so can erase as we encounter operations.
+  modOp.walk<mlir::WalkOrder::PostOrder, mlir::ReverseIterator>(
+      [&](Operation *op) {
+        auto inst = dyn_cast<InstanceOp>(op);
+        // For everything that's not an instance, remove if in slice.
+        if (!inst) {
+          if (toRemoveIfNotInst.contains(op)) {
+            ++numErasedOps;
+            op->erase();
+          }
+          return;
+        }
+        // Handle all instances, regardless of presence in slice.
+
+        // All input probes will be removed.
+        // The processing of the instantiated module ensures these are dead.
+        ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+        builder.setInsertionPointAfter(op);
+        BitVector instPortsToErase(inst.getNumResults());
+        for (auto [idx, result] : llvm::enumerate(inst.getResults())) {
+          if (inst.getPortDirection(idx) == Direction::Out)
+            continue;
+          if (!type_isa<RefType>(result.getType()))
+            continue;
+          instPortsToErase.set(idx);
+
+          // Convert to wire if not (newly) dead -- there's some local flow
+          // that uses them, perhaps what was previously a u-turn/passthrough.
+          if (result.use_empty())
+            continue;
+
+          auto wire = builder.create<WireOp>(result.getType());
+          result.replaceAllUsesWith(wire.getDataRaw());
+        }
+        if (instPortsToErase.none())
+          return;
+        inst.erasePorts(builder, instPortsToErase);
+        inst.erase();
+      });
+
+  numErasedPorts += portsToErase.count();
+  mod.erasePorts(portsToErase);
+
+  return success();
+}

--- a/lib/Dialect/FIRRTL/Transforms/ProbeDCE.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ProbeDCE.cpp
@@ -133,7 +133,9 @@ public:
   /// Forward slice through the given input probe argument, diagnosing
   /// illegal/unsupported uses if encountered.
   LogicalResult add(BlockArgument arg) {
+    // Set current slice source for use by helpers, clear when done.
     llvm::SaveAndRestore<BlockArgument> x(this->currentSliceSource, arg);
+    // Slice worklist.
     SmallVector<Operation *> worklist;
 
     // Start with all users of the input probe.

--- a/lib/Dialect/FIRRTL/Transforms/ProbeDCE.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ProbeDCE.cpp
@@ -115,7 +115,7 @@ ProbeDCEPass::process(FModuleLike mod,
   BitVector portsToErase(mod.getNumPorts());
 
   // Forward slice over users of each.
-  // Build cumulatively, for diagnostic specificity.
+  // Build cumulatively, slice individually for diagnostic specificity.
   DenseSet<Operation *> toRemoveIfNotInst;
   SmallVector<Operation *> worklist;
   for (auto idx : probePortIndices) {

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -82,6 +82,7 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createHoistPassthroughPass(
       /*hoistHWDrivers=*/!opt.disableOptimization &&
       !opt.disableHoistingHWPassthrough));
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createProbeDCEPass());
 
   if (opt.dedup)
     emitWarning(UnknownLoc::get(pm.getContext()),

--- a/test/Dialect/FIRRTL/input-probe-n-turn.mlir
+++ b/test/Dialect/FIRRTL/input-probe-n-turn.mlir
@@ -1,0 +1,31 @@
+// RUN: firtool %s --verify-diagnostics
+// For now, input probes must be passthrough (or unused).
+
+// Per 3.0.0 spec however, they should be supported as long
+// as the input probe is equivalently driven in all contexts
+// and resolves to a signal below its use.
+
+// Arguably this should be XFAIL, but instead let's test the expected
+// behavior where this is rejected with diagnostic.
+
+firrtl.circuit "NTurn" {
+  firrtl.extmodule @Ext(in sink: !firrtl.uint<1>,
+                        out ref: !firrtl.probe<uint<1>>)
+  firrtl.module private @UseAndExport(in %in: !firrtl.probe<uint<1>>,
+                                      // expected-note @above {{input probe here}}
+                                      out %out: !firrtl.probe<uint<1>>) {
+    %sink, %ref = firrtl.instance e @Ext(in sink: !firrtl.uint<1>,
+                                         out ref: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %out, %ref : !firrtl.probe<uint<1>>
+    // expected-error @below {{input probes cannot be used}}
+    %read = firrtl.ref.resolve %in : !firrtl.probe<uint<1>>
+    firrtl.strictconnect %sink, %read : !firrtl.uint<1>
+  }
+  firrtl.module @NTurn() {
+    %in, %out = firrtl.instance uae @UseAndExport(in in: !firrtl.probe<uint<1>>,
+                                                  out out: !firrtl.probe<uint<1>>)
+
+    // Send probe back in for use.
+    firrtl.ref.define %in, %out : !firrtl.probe<uint<1>>
+  }
+}

--- a/test/Dialect/FIRRTL/input-probe-u-turn-dedup.mlir
+++ b/test/Dialect/FIRRTL/input-probe-u-turn-dedup.mlir
@@ -1,0 +1,28 @@
+// Ensure composition of hoist-passthrough + probe-dce allows dedup of modules
+// w/input probes.
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-hoist-passthrough,firrtl-probe-dce,firrtl-dedup))' %s
+
+firrtl.circuit "UTurnDedup" attributes {annotations = [{
+    class = "firrtl.transforms.MustDeduplicateAnnotation",
+    modules = ["~UTurnDedup|UTurn1", "~MustDedup|UTurn2"]}]
+   } {
+  firrtl.module private @UTurn1(in %in : !firrtl.probe<uint<5>>,
+                               out %out : !firrtl.probe<uint<5>>) {
+    firrtl.ref.define %out, %in : !firrtl.probe<uint<5>>
+  }
+  firrtl.module private @UTurn2(in %in : !firrtl.probe<uint<5>>,
+                               out %out : !firrtl.probe<uint<5>>) {
+    firrtl.ref.define %out, %in : !firrtl.probe<uint<5>>
+  }
+  firrtl.module @UTurnDedup(in %in : !firrtl.uint<5>, out %out : !firrtl.uint<5>) {
+    %u1_in, %u1_out = firrtl.instance u @UTurn1(in in : !firrtl.probe<uint<5>>,
+                                               out out : !firrtl.probe<uint<5>>)
+    %u2_in, %u2_out = firrtl.instance u @UTurn2(in in : !firrtl.probe<uint<5>>,
+                                                out out : !firrtl.probe<uint<5>>)
+    %ref = firrtl.ref.send %in : !firrtl.uint<5>
+    firrtl.ref.define %u1_in, %ref : !firrtl.probe<uint<5>>
+    firrtl.ref.define %u2_in, %ref : !firrtl.probe<uint<5>>
+    %data1 = firrtl.ref.resolve %u1_out : !firrtl.probe<uint<5>>
+    %data2 = firrtl.ref.resolve %u2_out : !firrtl.probe<uint<5>>
+  }
+}

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -445,38 +445,16 @@ circuit DefineIntoProbe:
 
 circuit InProbeTop:
   module InProbeTop:
-    input p : Probe<UInt<1>> ; expected-error {{input probes not yet supported}}
+    input p : Probe<UInt<1>> ; expected-error {{main module may not contain input references}}
 
 ;// -----
 
 circuit InProbeExt:
   extmodule BadExtMod:
-    input p : Probe<UInt<1>> ; expected-error {{input probes not yet supported}}
+    input p : Probe<UInt<1>> ; expected-error {{references in ports must be output on extmodule and intmodule}}
 
   module InProbeExt:
     inst e of BadExtMod
-
-;// -----
-; Input probes not allowed anywhere for now.
-
-circuit InProbe:
-  module Child:
-    input p : Probe<UInt<1>> ; expected-error {{input probes not yet supported}}
-  module InProbe:
-    input x : UInt<1>
-    inst c of Child
-    define c.p = probe(x)
-
-;// -----
-; Input probes not allowed anywhere for now.
-
-circuit InProbeBundle:
-  module Child:
-    output out : { flip p: Probe<UInt<1>>} ; expected-error {{input probes not yet supported}}
-  module InProbeBundle:
-    input x : UInt<1>
-    inst c of Child
-    define c.out.p = probe(x)
 
 ;// -----
 

--- a/test/Dialect/FIRRTL/probe-dce-errors.mlir
+++ b/test/Dialect/FIRRTL/probe-dce-errors.mlir
@@ -1,0 +1,66 @@
+// RUN: circt-opt --firrtl-probe-dce --split-input-file --verify-diagnostics %s
+
+// Diagnose input probes on external modules.
+firrtl.circuit "ExtPort" {
+  // expected-error @below {{input probe not allowed on this module kind}}
+  firrtl.extmodule private @Ext(in in : !firrtl.probe<uint<1>>)
+  firrtl.module @ExtPort() {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %ref = firrtl.ref.send %zero : !firrtl.uint<1>
+    %in = firrtl.instance ext @Ext(in in : !firrtl.probe<uint<1>>)
+    firrtl.ref.define %in, %ref : !firrtl.probe<uint<1>>
+  }
+}
+
+// -----
+// Diagnose input probe on public modules.
+
+firrtl.circuit "PublicMod" {
+  // expected-error @below {{input probe not allowed on public module}}
+  firrtl.module @Pub(in %in : !firrtl.probe<uint<1>>) { }
+  firrtl.module @PublicMod() {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %ref = firrtl.ref.send %zero : !firrtl.uint<1>
+    %in = firrtl.instance p @Pub(in in : !firrtl.probe<uint<1>>)
+    firrtl.ref.define %in, %ref : !firrtl.probe<uint<1>>
+  }
+}
+
+// -----
+// Diagnose use of input probe (upwards or n-turn).
+
+firrtl.circuit "Upwards" {
+  firrtl.module private @Read(
+      // expected-note @below {{input probe}}
+      in %in : !firrtl.probe<uint<1>>) {
+    // expected-error @below {{input probes cannot be used}}
+    %data = firrtl.ref.resolve %in : !firrtl.probe<uint<1>>
+  }
+  firrtl.module @Upwards() {
+    %zero = firrtl.constant 0 : !firrtl.uint<1>
+    %ref = firrtl.ref.send %zero : !firrtl.uint<1>
+    %in = firrtl.instance r @Read(in in : !firrtl.probe<uint<1>>)
+    firrtl.ref.define %in, %ref : !firrtl.probe<uint<1>>
+  }
+}
+
+// -----
+
+// U-turn: Can't use input probes.  Hoist-passthroughs is expected to handle this.
+firrtl.circuit "UTurnTH" {
+  firrtl.module private @UTurn(
+                               // expected-note @below {{input probe}}
+                               in %in : !firrtl.probe<uint<5>>,
+                               // expected-error @below {{argument depends on input probe}}
+                               out %out : !firrtl.probe<uint<5>>) {
+    firrtl.ref.define %out, %in : !firrtl.probe<uint<5>>
+  }
+  firrtl.module @UTurnTH(in %in : !firrtl.uint<5>, out %out : !firrtl.uint<5>) {
+    %u_in, %u_out  = firrtl.instance u @UTurn(in in : !firrtl.probe<uint<5>>,
+                                              out out : !firrtl.probe<uint<5>>)
+    %ref = firrtl.ref.send %in : !firrtl.uint<5>
+    firrtl.ref.define %u_in, %ref : !firrtl.probe<uint<5>>
+    %data = firrtl.ref.resolve %u_out : !firrtl.probe<uint<5>>
+  }
+}
+

--- a/test/Dialect/FIRRTL/probe-dce.mlir
+++ b/test/Dialect/FIRRTL/probe-dce.mlir
@@ -1,0 +1,147 @@
+// RUN: circt-opt --firrtl-probe-dce --split-input-file %s | FileCheck %s
+
+
+// Input probe used locally, but not within module it is port for.
+// CHECK-LABEL: "UTurnTH"
+firrtl.circuit "UTurnTH" {
+  // CHECK-NOT: probe
+  firrtl.module private @UTurn(in %in: !firrtl.probe<uint<5>>) { }
+  // CHECK: @UTurnTH
+  firrtl.module @UTurnTH(in %in: !firrtl.uint<5>) {
+    // CHECK: firrtl.wire : !firrtl.probe
+    %u_in = firrtl.instance u @UTurn(in in: !firrtl.probe<uint<5>>)
+    %0 = firrtl.ref.send %in : !firrtl.uint<5>
+    firrtl.ref.define %u_in, %0 : !firrtl.probe<uint<5>>
+    %1 = firrtl.ref.resolve %u_in : !firrtl.probe<uint<5>>
+  }
+}
+
+// -----
+
+// Wire, connect, ref.sub's
+// CHECK-LABEL: "Split"
+firrtl.circuit "Split" {
+  // CHECK-NOT: probe
+  firrtl.module private @SPassthrough(in %in: !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>) {
+    %w = firrtl.wire : !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>
+    firrtl.ref.define %w, %in : !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>
+    %0 = firrtl.ref.sub %w[1] : !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>
+    %1 = firrtl.ref.sub %w[0] : !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>
+  }
+  // CHECK: module @Split
+  firrtl.module @Split(in %x: !firrtl.bundle<a: uint<5>, b: uint<5>>, out %y: !firrtl.probe<uint<5>>, out %z: !firrtl.probe<uint<5>>) {
+    // CHECK: %[[WIRE:.+]] = firrtl.wire : !firrtl.probe
+    // CHECK: firrtl.instance sp interesting_name @SPassthrough()
+    %sp_in = firrtl.instance sp interesting_name @SPassthrough(in in: !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>)
+    // CHECK: ref.sub %[[WIRE]][1]
+    %0 = firrtl.ref.sub %sp_in[1] : !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>
+    %1 = firrtl.ref.sub %sp_in[0] : !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>
+    %2 = firrtl.ref.send %x : !firrtl.bundle<a: uint<5>, b: uint<5>>
+    firrtl.ref.define %sp_in, %2 : !firrtl.probe<bundle<a: uint<5>, b: uint<5>>>
+    firrtl.ref.define %y, %1 : !firrtl.probe<uint<5>>
+    firrtl.ref.define %z, %0 : !firrtl.probe<uint<5>>
+  }
+}
+
+// -----
+
+// Multi-level.
+// CHECK-LABEL: "ProbeMultiLevel"
+firrtl.circuit "ProbeMultiLevel" {
+  // CHECK: @Child()
+  firrtl.module private @Child(in %x: !firrtl.probe<uint<5>>) { }
+  // CHECK: @Mid() {
+  firrtl.module private @Mid(in %x: !firrtl.probe<uint<5>>) {
+    // CHECK-NEXT: firrtl.instance c interesting_name @Child()
+    // CHECK-NEXT: }
+    %c_x = firrtl.instance c interesting_name @Child(in x: !firrtl.probe<uint<5>>)
+    firrtl.ref.define %c_x, %x : !firrtl.probe<uint<5>>
+  }
+  // CHECK: @ProbeMultiLevel
+  firrtl.module @ProbeMultiLevel(in %x: !firrtl.uint<5>, in %x2: !firrtl.uint<5>) {
+    // CHECK: %[[W1:.+]] = firrtl.wire : !firrtl.probe
+    %m_x = firrtl.instance m interesting_name @Mid(in x: !firrtl.probe<uint<5>>)
+    // CHECK: %[[W2:.+]] = firrtl.wire : !firrtl.probe
+    %m2_x = firrtl.instance m2 interesting_name @Mid(in x: !firrtl.probe<uint<5>>)
+    // CHECK: %[[REF:.+]] = firrtl.ref.send
+    %ref = firrtl.ref.send %x : !firrtl.uint<5>
+    // CHECK: ref.define %[[W1]], %[[REF]]
+    // CHECK: ref.define %[[W2]], %[[REF]]
+    firrtl.ref.define %m_x, %ref : !firrtl.probe<uint<5>>
+    firrtl.ref.define %m2_x, %ref : !firrtl.probe<uint<5>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: "RefCast"
+firrtl.circuit "RefCast" {
+  // CHECK: @UTurnCast() {
+  // CHECK-NEXT: }
+  firrtl.module private @UTurnCast(in %in: !firrtl.rwprobe<uint<5>>) {
+    %0 = firrtl.ref.cast %in : (!firrtl.rwprobe<uint<5>>) -> !firrtl.probe<uint<5>>
+  }
+  // CHECK: @RefCast(
+  firrtl.module @RefCast(in %in: !firrtl.uint<5>) {
+    // CHECK: @UTurnCast()
+    %u_in = firrtl.instance u @UTurnCast(in in: !firrtl.rwprobe<uint<5>>)
+    %0 = firrtl.ref.cast %u_in : (!firrtl.rwprobe<uint<5>>) -> !firrtl.probe<uint<5>>
+    %n, %n_ref = firrtl.node %in forceable : !firrtl.uint<5>
+    firrtl.ref.define %u_in, %n_ref : !firrtl.rwprobe<uint<5>>
+    %1 = firrtl.ref.resolve %0 : !firrtl.probe<uint<5>>
+  }
+}
+
+// -----
+// Wire + cast.
+
+// CHECK-LABEL: "RefWire"
+firrtl.circuit "RefWire" {
+  // CHECK: @UWire() {
+  // CHECK-NEXT: }
+  firrtl.module private @UWire(in %in: !firrtl.rwprobe<uint<5>>) {
+    %w = firrtl.wire : !firrtl.rwprobe<uint<5>>
+    firrtl.ref.define %w, %in : !firrtl.rwprobe<uint<5>>
+    %0 = firrtl.ref.cast %w : (!firrtl.rwprobe<uint<5>>) -> !firrtl.probe<uint<5>>
+  }
+  // CHECK: @RefWire(
+  firrtl.module @RefWire(in %in: !firrtl.uint<5>) {
+   // CHECK: UWire()
+    %u_in = firrtl.instance u @UWire(in in: !firrtl.rwprobe<uint<5>>)
+    %0 = firrtl.ref.cast %u_in : (!firrtl.rwprobe<uint<5>>) -> !firrtl.probe<uint<5>>
+    %n, %n_ref = firrtl.node %in forceable : !firrtl.uint<5>
+    firrtl.ref.define %u_in, %n_ref : !firrtl.rwprobe<uint<5>>
+    %1 = firrtl.ref.resolve %0 : !firrtl.probe<uint<5>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: "WireWhen"
+firrtl.circuit "WireWhen" {
+  // CHECK: @WireWhen(
+  firrtl.module @WireWhen(in %in_cond: !firrtl.uint<1>, in %data: !firrtl.vector<uint<1>, 2>) {
+    // CHECK: @Child(in cond: !firrtl.uint<1>)
+    %c_cond, %c_in = firrtl.instance c @Child(in cond: !firrtl.uint<1>, in in: !firrtl.probe<vector<uint<1>, 2>>)
+    firrtl.strictconnect %c_cond, %in_cond : !firrtl.uint<1>
+    %0 = firrtl.ref.sub %c_in[1] : !firrtl.probe<vector<uint<1>, 2>>
+    %ref = firrtl.ref.send %data : !firrtl.vector<uint<1>, 2>
+    firrtl.ref.define %c_in, %ref : !firrtl.probe<vector<uint<1>, 2>>
+  }
+  // CHECK: @Child(in %cond: !firrtl.uint<1>) {
+  // CHECK-NEXT: firrtl.when
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT: }
+  // CHECK-NEXT: }
+  firrtl.module private @Child(in %cond: !firrtl.uint<1>, in %in: !firrtl.probe<vector<uint<1>, 2>>) {
+    %0 = firrtl.wire : !firrtl.probe<uint<1>>
+    firrtl.when %cond : !firrtl.uint<1> {
+      %2 = firrtl.ref.sub %in[1] : !firrtl.probe<vector<uint<1>, 2>>
+      firrtl.ref.define %0, %2 : !firrtl.probe<uint<1>>
+    } else {
+      %w = firrtl.wire : !firrtl.probe<uint<1>>
+      firrtl.ref.define %w, %0 : !firrtl.probe<uint<1>>
+    }
+  }
+}
+

--- a/test/firtool/spec/refs/endpoints.fir
+++ b/test/firtool/spec/refs/endpoints.fir
@@ -1,8 +1,10 @@
-; RUN: firtool %s --verify-diagnostics
-; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false --verify-diagnostics
+; RUN: firtool %s
+; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false
 FIRRTL version 3.0.0
-circuit Top :
-  ; expected-error @+3 {{input probes not yet supported}}
+circuit Top : %[[
+{ "class": "firrtl.transforms.DontTouchAnnotation", "target": "~Top|Top>producer_debug"},
+{ "class": "firrtl.transforms.DontTouchAnnotation", "target": "~Top|Top>consumer_debug"}
+]]
   ; SPEC EXAMPLE BEGIN
   module Consumer:
     input in : {a: UInt, pref: Probe<UInt>, flip cref: Probe<UInt>}
@@ -16,6 +18,7 @@ circuit Top :
     define out.pref = probe(x)
     ; ...
     connect out.a, x
+    x <= UInt<3>(5) ; XXX: Modification: initialize x.
 
   module Connect:
     output out : {pref: Probe<UInt>, cref: Probe<UInt>}

--- a/test/firtool/spec/refs/in_ref_context.fir
+++ b/test/firtool/spec/refs/in_ref_context.fir
@@ -1,6 +1,8 @@
 ; RUN: firtool %s -verify-diagnostics
 ; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false -verify-diagnostics
 FIRRTL version 3.0.0
+; expected-error @+27 {{input probes cannot be used}}
+; expected-note @+19 {{input probe here}}
 ; SPEC EXAMPLE BEGIN
 circuit Top:
   module Top:
@@ -19,7 +21,6 @@ circuit Top:
 
   module UpDown:
     input in : UInt<4>
-    ; expected-error @below {{input probes cannot be used}}
     input in_ref : Probe<UInt<4>>
     output r1 : Probe<UInt<4>>
     output r2 : Probe<UInt<4>>

--- a/test/firtool/spec/refs/in_ref_context.fir
+++ b/test/firtool/spec/refs/in_ref_context.fir
@@ -19,7 +19,7 @@ circuit Top:
 
   module UpDown:
     input in : UInt<4>
-    ; expected-error @below {{input probes not yet supported}}
+    ; expected-error @below {{input probes cannot be used}}
     input in_ref : Probe<UInt<4>>
     output r1 : Probe<UInt<4>>
     output r2 : Probe<UInt<4>>

--- a/test/firtool/spec/refs/invalid_in.fir
+++ b/test/firtool/spec/refs/invalid_in.fir
@@ -3,7 +3,8 @@
 FIRRTL version 3.0.0
 circuit FooUser:
   ; Invalid, per spec
-  ; expected-error @+3 {{input probes cannot be used}}
+  ; expected-error @+7 {{input probes cannot be used}}
+  ; expected-note @+3 {{input probe here}}
   ; SPEC EXAMPLE BEGIN
   module Foo:
      input in : Probe<UInt>

--- a/test/firtool/spec/refs/invalid_in.fir
+++ b/test/firtool/spec/refs/invalid_in.fir
@@ -3,7 +3,7 @@
 FIRRTL version 3.0.0
 circuit FooUser:
   ; Invalid, per spec
-  ; expected-error @+3 {{input probes not yet supported}}
+  ; expected-error @+3 {{input probes cannot be used}}
   ; SPEC EXAMPLE BEGIN
   module Foo:
      input in : Probe<UInt>
@@ -12,9 +12,9 @@ circuit FooUser:
      connect out, read(in)
   ; SPEC EXAMPLE END
   module FooUser:
+    input in : UInt<2>
     output out : UInt
 
-    node n = UInt<2>(1)
     inst f of Foo
-    connect f.in, probe(n)
+    define f.in = probe(in)
     connect out, f.out

--- a/test/firtool/spec/refs/unused_in.fir
+++ b/test/firtool/spec/refs/unused_in.fir
@@ -1,7 +1,15 @@
 ; RUN: firtool %s -verify-diagnostics
 ; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false -verify-diagnostics
-circuit UnusedInputRef :
-  ; expected-error @+3 {{input probes not yet supported}}
+FIRRTL version 3.0.0
+circuit ForwardDownwardsTH :
+  module ForwardDownwardsTH :
+    input in : UInt<1>
+    output out : UInt<1>
+    connect out, in ; Do something to quiet warnings about empty.
+
+    inst fd of ForwardDownwards
+    connect fd.in, in
+
   ; SPEC EXAMPLE BEGIN
   module UnusedInputRef :
     input r : Probe<UInt<1>>

--- a/test/firtool/spec/refs/uturn.fir
+++ b/test/firtool/spec/refs/uturn.fir
@@ -1,8 +1,15 @@
 ; RUN: firtool %s -verify-diagnostics
 ; RUN: firtool %s -preserve-aggregate=all -scalarize-top-module=false -verify-diagnostics
 FIRRTL version 3.0.0
-circuit UTurn:
-  ; expected-error @+3 {{input probes not yet supported}}
+circuit UTurnTH:
+  module UTurnTH:
+    input in : UInt<5>
+    output out : UInt<5>
+
+    inst rb of RefBouncing
+    connect rb.x, in
+    connect out, rb.y
+
   ; SPEC EXAMPLE BEGIN
   module UTurn:
     input in : Probe<UInt>


### PR DESCRIPTION
Add and enable support for input probes.

Per spec, all uses (XMR read/force/release) of a probe must resolve to below the point of use in the hierarchy.
With this PR this is now supported in majority of cases.

The main exception to full support, with test demonstrating, is "n-turns" where a module uses an input probe (that resolves below that point) by sending it out and it comes back in equivalently driven in all instantiation contexts.

In this PR:
* Input probes enabled in parser
* Pass added to run after "de-squiggling" to drop all input probes, diagnosing when this is not possible (illegal input).
* Test cases involving input probes from spec now work.