### PR TITLE
Add OMInstanceTarget path kind

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
@@ -101,11 +101,12 @@ def EventControlAttr : I32EnumAttr<"EventControl", "edge control trigger",
 //===----------------------------------------------------------------------===//
 
 def DontTouch : I32EnumAttrCase<"DontTouch", 0, "dont_touch">;
-def MemberInstance: I32EnumAttrCase<"MemberInstance", 1, "member_instance">;
-def MemberReference: I32EnumAttrCase<"MemberReference", 2, "member_reference">;
-def Reference: I32EnumAttrCase<"Reference", 3, "reference">;
+def Instance : I32EnumAttrCase<"Instance", 1, "instance">;
+def MemberInstance: I32EnumAttrCase<"MemberInstance", 2, "member_instance">;
+def MemberReference: I32EnumAttrCase<"MemberReference", 3, "member_reference">;
+def Reference: I32EnumAttrCase<"Reference", 4, "reference">;
 def TargetKind : I32EnumAttr<"TargetKind", "object model target kind",
-  [DontTouch, MemberInstance, MemberReference, Reference]>  {}
+  [DontTouch, Instance, MemberInstance, MemberReference, Reference]>  {}
 
 }
 

--- a/include/circt/Dialect/OM/OMEnums.td
+++ b/include/circt/Dialect/OM/OMEnums.td
@@ -23,11 +23,12 @@ let cppNamespace = "::circt::om" in {
 //===----------------------------------------------------------------------===//
 
 def DontTouch : I32EnumAttrCase<"DontTouch", 0, "dont_touch">;
-def MemberInstance: I32EnumAttrCase<"MemberInstance", 1, "member_instance">;
-def MemberReference: I32EnumAttrCase<"MemberReference", 2, "member_reference">;
-def Reference: I32EnumAttrCase<"Reference", 3, "reference">;
+def Instance : I32EnumAttrCase<"Instance", 1, "instance">;
+def MemberInstance: I32EnumAttrCase<"MemberInstance", 2, "member_instance">;
+def MemberReference: I32EnumAttrCase<"MemberReference", 3, "member_reference">;
+def Reference: I32EnumAttrCase<"Reference", 4, "reference">;
 def TargetKind : I32EnumAttr<"TargetKind", "object model target kind",
-  [DontTouch, MemberInstance, MemberReference, Reference]>  {}
+  [DontTouch, Instance, MemberInstance, MemberReference, Reference]>  {}
 
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
@@ -109,6 +109,8 @@ struct PathResolver {
     TargetKind targetKind;
     if (target.consume_front("OMDontTouchedReferenceTarget")) {
       targetKind = TargetKind::DontTouch;
+    } else if (target.consume_front("OMInstanceTarget")) {
+      targetKind = TargetKind::Instance;
     } else if (target.consume_front("OMMemberInstanceTarget")) {
       targetKind = TargetKind::MemberInstance;
     } else if (target.consume_front("OMMemberReferenceTarget")) {

--- a/lib/Dialect/OM/Transforms/FreezePaths.cpp
+++ b/lib/Dialect/OM/Transforms/FreezePaths.cpp
@@ -68,6 +68,9 @@ LogicalResult PathVisitor::processPath(PathOp path) {
   case TargetKind::DontTouch:
     targetKind = "OMDontTouchedReferenceTarget";
     break;
+  case TargetKind::Instance:
+    targetKind = "OMInstanceTarget";
+    break;
   case TargetKind::Reference:
     targetKind = "OMReferenceTarget";
     break;

--- a/test/Dialect/FIRRTL/resolve-paths.mlir
+++ b/test/Dialect/FIRRTL/resolve-paths.mlir
@@ -113,11 +113,19 @@ firrtl.circuit "TargetInstance" {
 // CHECK: firrtl.module @TargetInstance() {
 firrtl.module @TargetInstance() {
     // CHECK: %0 = firrtl.path reference distinct[0]<>
+    // CHECK: %1 = firrtl.path instance distinct[1]<>
+    // CHECK: %2 = firrtl.path member_instance distinct[2]<>
     // CHECK: firrtl.instance child @Child()
     %0 = firrtl.unresolved_path "OMReferenceTarget:~TargetInstance|TargetInstance/child:Child"
+    %1 = firrtl.unresolved_path "OMInstanceTarget:~TargetInstance|TargetInstance/child:Child"
+    %2 = firrtl.unresolved_path "OMMemberInstanceTarget:~TargetInstance|TargetInstance/child:Child"
     firrtl.instance child @Child()
 }
-// CHECK: firrtl.module @Child() attributes {annotations = [{class = "circt.tracker", id = distinct[0]<>}]}
+// CHECK: firrtl.module @Child() attributes {annotations = [
+// CHECK-SAME: {class = "circt.tracker", id = distinct[0]<>},
+// CHECK-SAME: {class = "circt.tracker", id = distinct[1]<>},
+// CHECK-SAME: {class = "circt.tracker", id = distinct[2]<>}
+// CHECK-SAME: ]}
 firrtl.module @Child() { }
 }
 

--- a/test/Dialect/OM/freeze-paths.mlir
+++ b/test/Dialect/OM/freeze-paths.mlir
@@ -42,9 +42,12 @@ om.class @PathTest() {
   // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule/child:Child>non_local"> : !om.path
   %7 = om.path reference @nla_5
 
+  // CHECK: om.constant #om.path<"OMInstanceTarget:PathModule/child:Child"> : !om.path
+  %8 = om.path instance @nla_3
+
   // CHECK: om.constant #om.path<"OMMemberInstanceTarget:PathModule/child:Child"> : !om.path
-  %8 = om.path member_instance @nla_3
+  %9 = om.path member_instance @nla_3
 
   // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule/child:Child"> : !om.path
-  %9 = om.path reference @nla_4
+  %10 = om.path reference @nla_4
 }


### PR DESCRIPTION
This path kind was mistakenly left out.  Upstream code for this path kind can be found [here]( https://github.com/chipsalliance/chisel/blob/e80de64571d47c90050893f066cf288b6acda505/core/src/main/scala/chisel3/properties/Path.scala#L19).