### PR TITLE
[FIRRTL][Dedup] An extmodule without defname is unique.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1512,6 +1512,11 @@ class DedupPass : public DedupBase<DedupPass> {
               }))
             return success();
 
+          // Only dedup extmodule's with defname.
+          if (auto ext = dyn_cast<FExtModuleOp>(*module);
+              ext && !ext.getDefname().has_value())
+            return success();
+
           llvm::SmallSetVector<StringAttr, 1> groups;
           for (auto annotation : annotations) {
             if (annotation.getClass() == dedupGroupClass)


### PR DESCRIPTION
Don't dedup extmodule's that happen to have same signature -- if defname isn't present the module's expected verilog name is its module name and may have a different implementation.

Fixes:
```firrtl
circuit Dedup:
  extmodule E1:
    output x : UInt<1>
  extmodule E2:
    output x : UInt<1>
  
  module Dedup:
    inst e1 of E1
    inst e2 of E2
```
becoming two instances of `E1` (or `E2`?).