### PR TITLE
[ExportVerilog] Support CallSiteLoc and NameLoc emission

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -512,6 +512,12 @@ printFileLineColSetInfo(llvm::raw_string_ostream &sstr,
   }
 }
 
+//===----------------------------------------------------------------------===//
+// Location comparison
+//===----------------------------------------------------------------------===//
+
+// NOLINTBEGIN(misc-no-recursion)
+
 static int compareLocs(Location lhs, Location rhs);
 
 // NameLoc comparator - compare names, then child locations.
@@ -549,10 +555,12 @@ FailureOr<int> dispatchCompareLocations(Location lhs, Location rhs) {
   if (lhsT && rhsT) {
     // Both are of the target location type, compare them directly.
     return compareLocsImpl(lhsT, rhsT);
-  } else if (lhsT) {
+  }
+  if (lhsT) {
     // lhs is TTargetLoc => it comes before rhs.
     return -1;
-  } else if (rhsT) {
+  }
+  if (rhsT) {
     // rhs is TTargetLoc => it comes before lhs.
     return 1;
   }
@@ -587,6 +595,8 @@ static int compareLocs(Location lhs, Location rhs) {
   // Anything else...
   return 0;
 }
+
+// NOLINTEND(misc-no-recursion)
 
 // Sorts a vector of locations in-place.
 template <typename TVector>

--- a/test/Conversion/ExportVerilog/complex-locations.mlir
+++ b/test/Conversion/ExportVerilog/complex-locations.mlir
@@ -1,0 +1,47 @@
+// RUN: circt-opt %s -export-verilog | FileCheck %s
+
+module attributes {circt.loweringOptions = "locationInfoStyle=wrapInAtSquareBracket"} {
+
+// CHECK-LABEL: module Callstack(
+// CHECK-SAME:    // @[{'foo'(fooSource.x:10:8) <- {'bar'(barSource.x:20:8) <- 'baz'(bazSource.x:30:8)}}]
+
+// Emulate a callstack-like location info.
+hw.module @Callstack(%a: i1 loc("")) -> () {
+  hw.output
+} loc(callsite(
+    "foo"("fooSource.x":10:8)
+    at callsite("bar"("barSource.x":20:8) 
+    at "baz"("bazSource.x":30:8))))
+
+
+// Check location merging logic.
+
+// CHECK-LABEL: module MergedLocations(
+hw.module @MergedLocations(%clock: i1, %flag1 : i1, %flag2: i1, %flag3: i1) {
+  %true = hw.constant 1 : i1 loc("")
+  %false = hw.constant 0 : i1
+  %r1 = sv.reg : !hw.inout<i1>
+  %r2 = sv.reg : !hw.inout<i1>
+  sv.always posedge %clock {
+    
+    // Induce FileLineColLoc merging.
+// CHECK:     r1 <= flag1 + flag2 + 1'h1 + flag3; // @[myFile.x:9:3, :10:6, myOtherFile.x:9:4, :10:5]    
+    %0 = comb.add %flag1, %flag2 : i1 loc("myFile.x":10:6)
+    %1 = comb.add %true, %flag3 : i1 loc("myOtherFile.x":10:5)
+    %mergedFLCLoc = comb.add %0, %1 : i1 loc("myOtherFile.x":9:4)
+    sv.passign %r1, %mergedFLCLoc : i1 loc("myFile.x":9:3)
+
+    // Now add in a callstack and named location.
+    // Note: We duplicate the operations here to avoid wire spilling.
+// CHECK:     r2 <= flag1 + flag2 + 1'h1 + flag3 - 1'h1;  // @['MyNamedLocation'(), {'foo'(myFile.x:10:8) <- {'bar'(myFile.x:20:8) <- 'baz'(myFile.x:30:8)}}, myFile.x:9:4, :10:{5,6}]
+    %callstack_0 = comb.add %flag1, %flag2 : i1 loc("myFile.x":10:6)
+    %callstack_1 = comb.add %true, %flag3 : i1 loc("myFile.x":10:5)
+    %callstack_mergedFLCLoc = comb.add %callstack_0, %callstack_1 : i1 loc("myFile.x":9:4)
+    %callstackLoc = comb.add %callstack_mergedFLCLoc, %true : i1 loc(callsite(
+    "foo"("myFile.x":10:8)
+    at callsite("bar"("myFile.x":20:8) 
+    at "baz"("myFile.x":30:8))))
+    sv.passign %r2, %callstackLoc : i1 loc("MyNamedLocation")
+  }
+}
+}


### PR DESCRIPTION
Adds suppport for CallSiteLoc and NameLoc locations in export verilog. I tried to do this without refactoring the whole location printing infra too much, although some refactoring was due. Location printing has been modified such that:
1. There is a top-level dispatch function which dispatches `Location` printing to location type-specific print functions
2. No more passing around of `std::string`s. Instead, location emitter functions take a `llvm::raw_string_ostream`.
3. `FileLineColLoc` locations are still uniqued and printed in a sorted manner, as before. However, any other non `FileLineColLoc`-typed location will be printed without any custom uniquing (apart from set uniquing).

Location printing is still inline, i.e. without newlines. I can easily imagine that this can become a bit unwieldy for complex stack traces. However, deciding how to split locations to multiple lines seems like a separate issue.


Stack traces like:
```mlir
hw.module @Callstack(%a: i1 loc("")) -> () {
  hw.output
} loc(callsite(
    "foo"("fooSource.x":10:8)
    at callsite("bar"("barSource.x":20:8) 
    at "baz"("bazSource.x":30:8))))
```
will be printed as:
```sv
module Callstack(       // {'foo'(fooSource.x:10:8) <- {'bar'(barSource.x:20:8) <- 'baz'(bazSource.x:30:8)}}
  input a
);
```