### PR TITLE
[Seq] Convert `seq.clock_gate` to use the clock type exclusively

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineDialect.td
+++ b/include/circt/Dialect/Pipeline/PipelineDialect.td
@@ -18,6 +18,9 @@ def Pipeline_Dialect : Dialect {
   // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
   let usePropertiesForAttributes = 0;
 
+  let dependentDialects = [
+    "circt::seq::SeqDialect"
+  ];
 }
 
 #endif // CIRCT_DIALECT_PIPELINE_DIALECT_TD

--- a/include/circt/Dialect/Pipeline/PipelineOps.h
+++ b/include/circt/Dialect/Pipeline/PipelineOps.h
@@ -18,6 +18,7 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "circt/Dialect/Pipeline/PipelineDialect.h"
+#include "circt/Dialect/Seq/SeqTypes.h"
 
 namespace circt {
 namespace pipeline {

--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -20,9 +20,10 @@ include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
 
 include "circt/Dialect/Pipeline/PipelineDialect.td"
+include "circt/Dialect/Seq/SeqTypes.td"
 
 
-class PipelineBase<string mnemonic, list<Trait> traits = []> : 
+class PipelineBase<string mnemonic, list<Trait> traits = []> :
   Op<Pipeline_Dialect, mnemonic, !listconcat(traits, [
       Pure,
       RegionKindInterface,
@@ -98,7 +99,7 @@ def UnscheduledPipelineOp : PipelineBase<"unscheduled", [
     HasOnlyGraphRegion,
     SingleBlockImplicitTerminator<"ReturnOp">
   ]> {
-  
+
   let summary = "unscheduled pipeline operation";
   let description = [{
     The "pipeline.unscheduled" operation represents a pipeline that has not yet
@@ -113,7 +114,7 @@ def UnscheduledPipelineOp : PipelineBase<"unscheduled", [
 
   let arguments = (ins
     OptionalAttr<StrAttr>:$name, Variadic<AnyType>:$inputs, Optional<I1>:$stall,
-    I1:$clock, I1:$reset, I1:$go, StrArrayAttr:$inputNames,
+    ClockType:$clock, I1:$reset, I1:$go, StrArrayAttr:$inputNames,
     StrArrayAttr:$outputNames
   );
   let regions = (region SizedRegion<1>: $body);
@@ -169,7 +170,7 @@ def ScheduledPipelineOp : PipelineBase<"scheduled", [
     OptionalAttr<StrAttr>:$name,
     Variadic<AnyType>:$inputs,
     Optional<I1>:$stall,
-    I1:$clock, I1:$reset, I1:$go,
+    ClockType:$clock, I1:$reset, I1:$go,
     StrArrayAttr:$inputNames, StrArrayAttr:$outputNames,
     OptionalAttr<BoolArrayAttr>:$stallability
   );
@@ -307,7 +308,7 @@ def StageOp : Op<Pipeline_Dialect, "stage", [
   let assemblyFormat = [{
     $nextStage
     custom<StageRegisters>($registers, type($registers), $clockGates, $clockGatesPerRegister, $registerNames)
-    custom<Passthroughs>($passthroughs, type($passthroughs), $passthroughNames)  
+    custom<Passthroughs>($passthroughs, type($passthroughs), $passthroughNames)
     attr-dict
   }];
 
@@ -375,7 +376,7 @@ def LatencyOp : Op<Pipeline_Dialect, "latency", [
     HasOnlyGraphRegion,
     ParentOneOf<["UnscheduledPipelineOp", "ScheduledPipelineOp"]>
   ]> {
-  
+
   let summary = "Pipeline dialect latency operation.";
   let description = [{
     The `pipeline.latency` operation represents an operation for wrapping

--- a/include/circt/Dialect/Seq/SeqAttributes.td
+++ b/include/circt/Dialect/Seq/SeqAttributes.td
@@ -15,6 +15,15 @@ include "mlir/IR/BuiltinAttributeInterfaces.td"
 
 let cppNamespace = "circt::seq" in {
 
+// Constant clock values.
+def ClockLow : I32EnumAttrCase<"Low", 0, "low">;
+def ClockHigh : I32EnumAttrCase<"High", 1, "high">;
+def ClockConstAttrImpl: I32EnumAttr<"ClockConst", "clock constant",
+                                [ClockLow, ClockHigh]> {
+  let genSpecializedAttr = 0;
+}
+def ClockConstAttr : EnumAttr<SeqDialect, ClockConstAttrImpl, "clock constant">;
+
 // Read-under-write behavior
 def RUW_Undefined : I32EnumAttrCase<"Undefined", 0, "undefined">;
 def RUW_Old : I32EnumAttrCase<"Old", 1, "old">;

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -320,24 +320,23 @@ def ClockGateOp : SeqOp<"clock_gate", [
     symbol will target the instance to the external module it lowers to.
 
     ```
-    %gatedClock = seq.clock_gate %clock, %enable : i1
-    %gatedClock = seq.clock_gate %clock, %enable, %test_enable : i1, i1
+    %gatedClock = seq.clock_gate %clock, %enable
+    %gatedClock = seq.clock_gate %clock, %enable, %test_enable
     ```
   }];
 
   let arguments = (ins
-    ClockOrI1Type:$input,
+    ClockType:$input,
     I1:$enable,
     Optional<I1>:$test_enable,
     OptionalAttr<InnerSymAttr>:$inner_sym
   );
 
-  let results = (outs ClockOrI1Type:$output);
+  let results = (outs ClockType:$output);
   let hasFolder = 1;
   let hasCanonicalizeMethod = 1;
   let assemblyFormat = [{
-    $input `,` $enable (`,` $test_enable^)? (`sym` $inner_sym^)?
-      attr-dict `:` qualified(type($output))
+    $input `,` $enable (`,` $test_enable^)? (`sym` $inner_sym^)? attr-dict
   }];
 }
 
@@ -547,6 +546,27 @@ def FirMemReadWriteOp : SeqOp<"firmem.read_write_port", [
   }];
   let hasVerifier = 1;
   let hasCanonicalizeMethod = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// Tied-off clock
+//===----------------------------------------------------------------------===//
+
+def ConstClockOp : SeqOp<"const_clock", [Pure, ConstantLike]> {
+  let summary = "Produce constant clock value";
+  let description = [{
+    The constant operation produces a constant clock value.
+    ```
+      %clock = seq.const_clock low
+    ```
+  }];
+
+  let arguments = (ins ClockConstAttr:$value);
+  let results = (outs ClockType:$result);
+
+  let assemblyFormat = "$value attr-dict";
+
+  let hasFolder = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/integration_test/Dialect/Ibis/end_to_end.mlir
+++ b/integration_test/Dialect/Ibis/end_to_end.mlir
@@ -17,7 +17,7 @@ ibis.class @C2 {
   %this = ibis.this @C2
 
   %go_port = ibis.port.input @go : i1
-  %clk_port = ibis.port.input @clk : i1
+  %clk_port = ibis.port.input @clk : !seq.clock
   %rst_port = ibis.port.input @rst : i1
   %done_port = ibis.port.output @done : i1
   %out_port = ibis.port.output @out : i32
@@ -33,8 +33,8 @@ ibis.class @C2 {
     ]
     %go_ref = ibis.get_port %parent, @go : !ibis.scoperef<@C2> -> !ibis.portref<out i1>
     %go = ibis.port.read %go_ref : !ibis.portref<out i1>
-    %clk_ref = ibis.get_port %parent, @clk : !ibis.scoperef<@C2> -> !ibis.portref<out i1>
-    %clk = ibis.port.read %clk_ref : !ibis.portref<out i1>
+    %clk_ref = ibis.get_port %parent, @clk : !ibis.scoperef<@C2> -> !ibis.portref<out !seq.clock>
+    %clk = ibis.port.read %clk_ref : !ibis.portref<out !seq.clock>
     %rst_ref = ibis.get_port %parent, @rst : !ibis.scoperef<@C2> -> !ibis.portref<out i1>
     %rst = ibis.port.read %rst_ref : !ibis.portref<out i1>
 
@@ -74,7 +74,7 @@ ibis.class @Parent {
   %c2 = ibis.instance @c2, @C2
 
   %go = ibis.port.input @go : i1
-  %clk = ibis.port.input @clk : i1
+  %clk = ibis.port.input @clk : !seq.clock
   %rst = ibis.port.input @rst : i1
 
   %done = ibis.port.output @done : i1
@@ -85,9 +85,9 @@ ibis.class @Parent {
   %go_val = ibis.port.read %go : !ibis.portref<in i1>
   ibis.port.write %go_ref, %go_val : !ibis.portref<in i1>
 
-  %clk_ref = ibis.get_port %c2, @clk : !ibis.scoperef<@C2> -> !ibis.portref<in i1>
-  %clk_val = ibis.port.read %clk : !ibis.portref<in i1>
-  ibis.port.write %clk_ref, %clk_val : !ibis.portref<in i1>
+  %clk_ref = ibis.get_port %c2, @clk : !ibis.scoperef<@C2> -> !ibis.portref<in !seq.clock>
+  %clk_val = ibis.port.read %clk : !ibis.portref<in !seq.clock>
+  ibis.port.write %clk_ref, %clk_val : !ibis.portref<in !seq.clock>
 
   %rst_ref = ibis.get_port %c2, @rst : !ibis.scoperef<@C2> -> !ibis.portref<in i1>
   %rst_val = ibis.port.read %rst : !ibis.portref<in i1>

--- a/integration_test/Dialect/Pipeline/nonstallable/test1/nonstallable_test1.mlir
+++ b/integration_test/Dialect/Pipeline/nonstallable/test1/nonstallable_test1.mlir
@@ -10,7 +10,7 @@
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0
 
-hw.module @nonstallable_test1(%arg0: i32, %go: i1, %clock: i1, %reset: i1, %stall: i1) -> (out: i32, done: i1) {
+hw.module @nonstallable_test1(%arg0: i32, %go: i1, %clock: !seq.clock, %reset: i1, %stall: i1) -> (out: i32, done: i1) {
   %out, %done = pipeline.scheduled "nonstallable_test1"(%a0 : i32 = %arg0)
       stall(%s = %stall) clock(%c = %clock) reset(%r = %reset) go(%g = %go)
         {stallability = [true, false, false, true, true]} -> (out : i32) {

--- a/integration_test/Dialect/Pipeline/nonstallable/test2/nonstallable_test2.mlir
+++ b/integration_test/Dialect/Pipeline/nonstallable/test2/nonstallable_test2.mlir
@@ -10,7 +10,7 @@
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0
 
-hw.module @nonstallable_test2(%arg0: i32, %go: i1, %clock: i1, %reset: i1, %stall: i1) -> (out: i32, done : i1) {
+hw.module @nonstallable_test2(%arg0: i32, %go: i1, %clock: !seq.clock, %reset: i1, %stall: i1) -> (out: i32, done : i1) {
   %out, %done = pipeline.scheduled "nonstallable_test2"(%a0 : i32 = %arg0)
       stall(%s = %stall) clock(%c = %clock) reset(%r = %reset) go(%g = %go)
         {stallability = [true, false, true, false, true]} -> (out : i32) {

--- a/integration_test/Dialect/Pipeline/simple/simple.mlir
+++ b/integration_test/Dialect/Pipeline/simple/simple.mlir
@@ -20,7 +20,7 @@
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0
 
-hw.module @simple(%arg0 : i32, %arg1 : i32, %go : i1, %clock : i1, %reset : i1) -> (out: i32, done : i1) {
+hw.module @simple(%arg0 : i32, %arg1 : i32, %go : i1, %clock : !seq.clock, %reset : i1) -> (out: i32, done : i1) {
   %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clock) reset(%r = %reset) go(%g = %go) -> (out: i32) {
       %add0 = comb.add %a0, %a1 : i32
       pipeline.stage ^bb1

--- a/integration_test/Dialect/Pipeline/stall/stallTest.mlir
+++ b/integration_test/Dialect/Pipeline/stall/stallTest.mlir
@@ -20,7 +20,7 @@
 // CHECK: ** TEST
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0
 
-hw.module @stallTest(%arg0 : i32, %arg1 : i32, %go : i1, %stall : i1, %clock : i1, %reset : i1) -> (out: i32, done : i1) {
+hw.module @stallTest(%arg0 : i32, %arg1 : i32, %go : i1, %stall : i1, %clock : !seq.clock, %reset : i1) -> (out: i32, done : i1) {
   %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) stall(%s = %stall) clock(%c = %clock) reset(%r = %reset) go(%g = %go) -> (out: i32) {
       %add0 = comb.add %a0, %a1 : i32
       pipeline.stage ^bb1

--- a/lib/Dialect/Seq/SeqDialect.cpp
+++ b/lib/Dialect/Seq/SeqDialect.cpp
@@ -49,6 +49,10 @@ Operation *SeqDialect::materializeConstant(OpBuilder &builder, Attribute value,
     if (auto attrValue = value.dyn_cast<IntegerAttr>())
       return builder.create<hw::ConstantOp>(loc, type, attrValue);
 
+  if (type.isa<ClockType>())
+    if (auto attrValue = value.dyn_cast<ClockConstAttr>())
+      return builder.create<seq::ConstClockOp>(loc, attrValue);
+
   return nullptr;
 }
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -61,6 +61,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-DAG: hw.constant 2 : i3
     %c2_si3 = firrtl.constant 2 : !firrtl.sint<3>
 
+    // CHECK-DAG: [[CLOCK_LOW:%.+]] = seq.const_clock  low
 
     // CHECK: %out4 = hw.wire [[OUT4_VAL:%.+]] sym @{{.*}} : i4
     %out4 = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<4>
@@ -72,8 +73,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: %dntnode = hw.wire %in1 sym @{{.+}}
     %dntnode = firrtl.node %in1 {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<4>
 
-    // CHECK: [[CLOCK:%.+]] = seq.to_clock %false
-    // CHECK: %clockWire = hw.wire [[CLOCK]] : !seq.clock
+    // CHECK: %clockWire = hw.wire [[CLOCK_LOW]] : !seq.clock
     %c0_clock = firrtl.specialconstant 0 : !firrtl.clock
     %clockWire = firrtl.wire : !firrtl.clock
     firrtl.connect %clockWire, %c0_clock : !firrtl.clock, !firrtl.clock

--- a/test/Conversion/PipelineToHW/test_basic.mlir
+++ b/test/Conversion/PipelineToHW/test_basic.mlir
@@ -1,10 +1,10 @@
 // RUN: circt-opt --lower-pipeline-to-hw %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @testBasic(
-// CHECK-SAME:           %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) -> (out: i1) {
+// CHECK-SAME:           %[[VAL_0:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_2:.*]]: i1) -> (out: i1) {
 // CHECK:           hw.output %[[VAL_0]] : i1
 // CHECK:         }
-hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
+hw.module @testBasic(%arg0: i1, %clk: !seq.clock, %rst: i1) -> (out: i1) {
   %0:2 = pipeline.scheduled(%a0 : i1 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %arg0) -> (out : i1) {
     pipeline.return %a0 : i1
   }
@@ -12,21 +12,21 @@ hw.module @testBasic(%arg0: i1, %clk: i1, %rst: i1) -> (out: i1) {
 }
 
 // CHECK-LABEL:   hw.module @testLatency1(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32, done: i1) {
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out: i32, done: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_6:.*]] = hw.constant false
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_6]]  : i1
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_6]]  : i1
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage2_enable %[[VAL_7]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
-// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_stage2_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage2_enable %[[VAL_7]], %[[CLOCK]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_stage2_reg0 %[[VAL_5]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_11:.*]] = hw.constant false
-// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_stage3_enable %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_11]]  : i1
-// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_stage3_reg0 %[[VAL_10]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_stage3_enable %[[VAL_9]], %[[CLOCK]], %[[VAL_4]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_stage3_reg0 %[[VAL_10]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_14:.*]] = hw.constant false
-// CHECK:           %[[VAL_15:.*]] = seq.compreg sym @p0_stage4_enable %[[VAL_12]], %[[VAL_3]], %[[VAL_4]], %[[VAL_14]]  : i1
+// CHECK:           %[[VAL_15:.*]] = seq.compreg sym @p0_stage4_enable %[[VAL_12]], %[[CLOCK]], %[[VAL_4]], %[[VAL_14]]  : i1
 // CHECK:           hw.output %[[VAL_13]], %[[VAL_15]] : i32, i1
 // CHECK:         }
-hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32, done: i1) {
+hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32, done: i1) {
   %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     %1 = pipeline.latency 2 -> (i32) {
       %6 = comb.add %a0, %a0 : i32
@@ -46,16 +46,16 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 }
 
 // CHECK-LABEL:   hw.module @testSingle(
-// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[CLOCK]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
 // CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
 // CHECK:         }
-hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
+hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
@@ -67,32 +67,32 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (o
 }
 
 // CHECK-LABEL:   hw.module @testMultiple(
-// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[CLOCK]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_10]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_stage1_reg1 %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_10]], %[[CLOCK]] : i32
+// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_stage1_reg1 %[[VAL_6]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_13:.*]] = hw.constant false
-// CHECK:           %[[VAL_14:.*]] = seq.compreg sym @p0_stage2_enable %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
+// CHECK:           %[[VAL_14:.*]] = seq.compreg sym @p0_stage2_enable %[[VAL_9]], %[[CLOCK]], %[[VAL_4]], %[[VAL_13]]  : i1
 // CHECK:           %[[VAL_15:.*]] = comb.mul %[[VAL_11]], %[[VAL_12]] : i32
 // CHECK:           %[[VAL_16:.*]] = comb.sub %[[VAL_15]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_17:.*]] = seq.compreg sym @p1_stage0_reg0 %[[VAL_16]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p1_stage0_reg1 %[[VAL_15]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_17:.*]] = seq.compreg sym @p1_stage0_reg0 %[[VAL_16]], %[[CLOCK]] : i32
+// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p1_stage0_reg1 %[[VAL_15]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_19:.*]] = hw.constant false
-// CHECK:           %[[VAL_20:.*]] = seq.compreg sym @p1_stage1_enable %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_19]]  : i1
+// CHECK:           %[[VAL_20:.*]] = seq.compreg sym @p1_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_19]]  : i1
 // CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_17]], %[[VAL_18]] : i32
-// CHECK:           %[[VAL_22:.*]] = seq.compreg sym @p1_stage1_reg0 %[[VAL_21]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_23:.*]] = seq.compreg sym @p1_stage1_reg1 %[[VAL_17]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_22:.*]] = seq.compreg sym @p1_stage1_reg0 %[[VAL_21]], %[[CLOCK]] : i32
+// CHECK:           %[[VAL_23:.*]] = seq.compreg sym @p1_stage1_reg1 %[[VAL_17]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_24:.*]] = hw.constant false
-// CHECK:           %[[VAL_25:.*]] = seq.compreg sym @p1_stage2_enable %[[VAL_20]], %[[VAL_3]], %[[VAL_4]], %[[VAL_24]]  : i1
+// CHECK:           %[[VAL_25:.*]] = seq.compreg sym @p1_stage2_enable %[[VAL_20]], %[[CLOCK]], %[[VAL_4]], %[[VAL_24]]  : i1
 // CHECK:           %[[VAL_26:.*]] = comb.mul %[[VAL_22]], %[[VAL_23]] : i32
 // CHECK:           hw.output %[[VAL_15]], %[[VAL_14]] : i32, i1
 // CHECK:         }
-hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
+hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
@@ -119,19 +119,19 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 }
 
 // CHECK-LABEL:   hw.module @testSingleWithExt(
-// CHECK-SAME:                                 %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
+// CHECK-SAME:                                 %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_6]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_6]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_10]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_10]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_12:.*]] = hw.constant false
-// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_stage2_enable %[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_12]]  : i1
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_stage2_enable %[[VAL_9]], %[[CLOCK]], %[[VAL_4]], %[[VAL_12]]  : i1
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_1]] : i32, i32
 // CHECK:         }
-hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i32) {
+hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: !seq.clock, %rst: i1) -> (out0: i32, out1: i32) {
   %0:3 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0: i32, out1: i32) {
     %true = hw.constant true
     %1 = comb.sub %a0, %a0 : i32
@@ -141,7 +141,7 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
     // Use the external value inside a stage
     %8 = comb.add %6, %ext1 : i32
     pipeline.stage ^bb2 regs(%8 : i32)
-  
+
   ^bb2(%9 : i32, %s2_enable: i1):
   // Use the external value in the exit stage.
     pipeline.return %9, %ext1 : i32, i32
@@ -150,38 +150,38 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: i1, %rst: i
 }
 
 // CHECK-LABEL:   hw.module @testControlUsage(
-// CHECK-SAME:              %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1) -> (out0: i32) {
+// CHECK-SAME:              %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_3:.*]]: i1) -> (out0: i32) {
 // CHECK:           %[[VAL_4:.*]] = hw.constant 0 : i32
 // CHECK:           %[[VAL_5:.*]] = sv.wire : !hw.inout<i32>
 // CHECK:           %[[VAL_6:.*]] = sv.read_inout %[[VAL_5]] : !hw.inout<i32>
 // CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[CLOCK]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_8]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_8]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_1]], %[[CLOCK]], %[[VAL_3]], %[[VAL_10]]  : i1
 // CHECK:           %[[VAL_12:.*]] = sv.wire : !hw.inout<i32>
 // CHECK:           %[[VAL_13:.*]] = sv.read_inout %[[VAL_12]] : !hw.inout<i32>
 // CHECK:           %[[VAL_14:.*]] = comb.add %[[VAL_13]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_15:.*]] = seq.compreg.ce %[[VAL_14]], %[[VAL_2]], %[[VAL_11]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           %[[VAL_15:.*]] = seq.compreg.ce %[[VAL_14]], %[[CLOCK]], %[[VAL_11]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_12]], %[[VAL_15]] : i32
-// CHECK:           %[[VAL_16:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_15]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_16:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_15]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_17:.*]] = hw.constant false
-// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p0_stage2_enable %[[VAL_11]], %[[VAL_2]], %[[VAL_3]], %[[VAL_17]]  : i1
+// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p0_stage2_enable %[[VAL_11]], %[[CLOCK]], %[[VAL_3]], %[[VAL_17]]  : i1
 // CHECK:           %[[VAL_19:.*]] = sv.wire : !hw.inout<i32>
 // CHECK:           %[[VAL_20:.*]] = sv.read_inout %[[VAL_19]] : !hw.inout<i32>
 // CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_20]], %[[VAL_16]] : i32
-// CHECK:           %[[VAL_22:.*]] = seq.compreg.ce %[[VAL_21]], %[[VAL_2]], %[[VAL_18]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           %[[VAL_22:.*]] = seq.compreg.ce %[[VAL_21]], %[[CLOCK]], %[[VAL_18]], %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_19]], %[[VAL_22]] : i32
 // CHECK:           hw.output %[[VAL_22]] : i32
 // CHECK:         }
-hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: i32) {
+hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: !seq.clock, %rst: i1) -> (out0: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     %zero = hw.constant 0 : i32
     %reg_out_wire = sv.wire : !hw.inout<i32>
     %reg_out = sv.read_inout %reg_out_wire : !hw.inout<i32>
     %add0 = comb.add %reg_out, %a0 : i32
-    %out = seq.compreg.ce %add0, %c, %g, %r, %zero : i32
+    %out = seq.compreg.ce %add0, %c, %g, %r, %zero : i32, !seq.clock
     sv.assign %reg_out_wire, %out : i32
     pipeline.stage ^bb1 regs(%out : i32)
 
@@ -189,16 +189,16 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: 
     %reg1_out_wire = sv.wire : !hw.inout<i32>
     %reg1_out = sv.read_inout %reg1_out_wire : !hw.inout<i32>
     %add1 = comb.add %reg1_out, %6 : i32
-    %out1 = seq.compreg.ce %add1, %c, %s1_enable, %r, %zero : i32
+    %out1 = seq.compreg.ce %add1, %c, %s1_enable, %r, %zero : i32, !seq.clock
     sv.assign %reg1_out_wire, %out1 : i32
 
     pipeline.stage ^bb2 regs(%out1 : i32)
-  
+
   ^bb2(%9 : i32, %s2_enable: i1):
     %reg2_out_wire = sv.wire : !hw.inout<i32>
     %reg2_out = sv.read_inout %reg2_out_wire : !hw.inout<i32>
     %add2 = comb.add %reg2_out, %9 : i32
-    %out2 = seq.compreg.ce %add2, %c, %s2_enable, %r, %zero : i32
+    %out2 = seq.compreg.ce %add2, %c, %s2_enable, %r, %zero : i32, !seq.clock
     sv.assign %reg2_out_wire, %out2 : i32
     pipeline.return %out2  : i32
   }
@@ -208,21 +208,21 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: i1, %rst: i1) -> (out0: 
 // -----
 
 // CHECK-LABEL:   hw.module @testWithStall(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.xor %[[VAL_2]], %[[VAL_5]] : i1
 // CHECK:           %[[VAL_7:.*]] = comb.and %[[VAL_1]], %[[VAL_6]]
-// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @p0_stage0_reg0 %[[VAL_0]], %[[VAL_3]], %[[VAL_7]] : i32, i1
+// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @p0_stage0_reg0 %[[VAL_0]], %[[CLOCK]], %[[VAL_7]] : i32, !seq.clock
 // CHECK:           %[[VAL_9:.*]] = hw.constant false
 // CHECK:           %[[VAL_10:.*]] = hw.constant true
 // CHECK:           %[[VAL_11:.*]] = comb.xor %[[VAL_2]], %[[VAL_10]] : i1
-// CHECK:           %[[VAL_12:.*]] = seq.compreg.ce sym @p0_stage1_enable %[[VAL_7]], %[[VAL_3]], %[[VAL_11]], %[[VAL_4]], %[[VAL_9]]  : i1, i1
+// CHECK:           %[[VAL_12:.*]] = seq.compreg.ce sym @p0_stage1_enable %[[VAL_7]], %[[CLOCK]], %[[VAL_11]], %[[VAL_4]], %[[VAL_9]]  : i1, !seq.clock
 // CHECK:           %[[VAL_13:.*]] = hw.constant true
 // CHECK:           %[[VAL_14:.*]] = comb.xor %[[VAL_2]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_15:.*]] = comb.and %[[VAL_12]], %[[VAL_14]]
 // CHECK:           hw.output %[[VAL_8]], %[[VAL_15]] : i32, i1
 // CHECK:         }
-hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
+hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: !seq.clock, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     pipeline.stage ^bb1 regs(%a0 : i32)
   ^bb1(%1: i32, %s1_enable : i1):  // pred: ^bb1
@@ -234,29 +234,29 @@ hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: i1, %rst: i1) -
 // -----
 
 // CHECK-LABEL:   hw.module @testStallability(
-// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = comb.xor %[[VAL_4]], %[[VAL_5]] : i1
 // CHECK:           %[[VAL_7:.*]] = comb.and %[[VAL_1]], %[[VAL_6]]
-// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @MyPipeline_a0 %[[VAL_0]], %[[VAL_2]], %[[VAL_7]] : i32, i1
+// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @MyPipeline_a0 %[[VAL_0]], %[[CLOCK]], %[[VAL_7]] : i32, !seq.clock
 // CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @MyPipeline_stage1_enable %[[VAL_7]], %[[VAL_2]], %[[VAL_3]], %[[VAL_9]]  : i1, i1
-// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce sym @MyPipeline_a0 %[[VAL_8]], %[[VAL_2]], %[[VAL_10]] {name = "MyPipeline_a0"} : i32, i1
+// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @MyPipeline_stage1_enable %[[VAL_7]], %[[CLOCK]], %[[VAL_3]], %[[VAL_9]]  : i1, !seq.clock
+// CHECK:           %[[VAL_11:.*]] = seq.compreg.ce sym @MyPipeline_a0 %[[VAL_8]], %[[CLOCK]], %[[VAL_10]] {name = "MyPipeline_a0"} : i32, !seq.clock
 // CHECK:           %[[VAL_12:.*]] = hw.constant false
 // CHECK:           %[[VAL_13:.*]] = hw.constant true
 // CHECK:           %[[VAL_14:.*]] = comb.xor %[[VAL_4]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_15:.*]] = comb.or %[[VAL_10]], %[[VAL_14]] : i1
-// CHECK:           %[[VAL_16:.*]] = seq.compreg.ce sym @MyPipeline_stage2_enable %[[VAL_10]], %[[VAL_2]], %[[VAL_15]], %[[VAL_3]], %[[VAL_12]]  : i1, i1
+// CHECK:           %[[VAL_16:.*]] = seq.compreg.ce sym @MyPipeline_stage2_enable %[[VAL_10]], %[[CLOCK]], %[[VAL_15]], %[[VAL_3]], %[[VAL_12]]  : i1, !seq.clock
 // CHECK:           %[[VAL_17:.*]] = hw.constant true
 // CHECK:           %[[VAL_18:.*]] = comb.xor %[[VAL_4]], %[[VAL_17]] : i1
 // CHECK:           %[[VAL_19:.*]] = comb.or %[[VAL_10]], %[[VAL_18]] : i1
 // CHECK:           %[[VAL_20:.*]] = comb.and %[[VAL_16]], %[[VAL_19]]
-// CHECK:           %[[VAL_21:.*]] = seq.compreg.ce sym @MyPipeline_a0 %[[VAL_11]], %[[VAL_2]], %[[VAL_20]] {name = "MyPipeline_a0"} : i32, i1
+// CHECK:           %[[VAL_21:.*]] = seq.compreg.ce sym @MyPipeline_a0 %[[VAL_11]], %[[CLOCK]], %[[VAL_20]] {name = "MyPipeline_a0"} : i32, !seq.clock
 // CHECK:           %[[VAL_22:.*]] = hw.constant false
 // CHECK:           %[[VAL_23:.*]] = hw.constant true
 // CHECK:           %[[VAL_24:.*]] = comb.xor %[[VAL_4]], %[[VAL_23]] : i1
 // CHECK:           %[[VAL_25:.*]] = comb.or %[[VAL_10]], %[[VAL_24]] : i1
-// CHECK:           %[[VAL_26:.*]] = seq.compreg.ce sym @MyPipeline_stage3_enable %[[VAL_20]], %[[VAL_2]], %[[VAL_25]], %[[VAL_3]], %[[VAL_22]]  : i1, i1
+// CHECK:           %[[VAL_26:.*]] = seq.compreg.ce sym @MyPipeline_stage3_enable %[[VAL_20]], %[[CLOCK]], %[[VAL_25]], %[[VAL_3]], %[[VAL_22]]  : i1, !seq.clock
 // CHECK:           %[[VAL_27:.*]] = hw.constant true
 // CHECK:           %[[VAL_28:.*]] = comb.xor %[[VAL_4]], %[[VAL_27]] : i1
 // CHECK:           %[[VAL_29:.*]] = comb.or %[[VAL_10]], %[[VAL_28]] : i1
@@ -264,15 +264,15 @@ hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: i1, %rst: i1) -
 // CHECK:           hw.output %[[VAL_21]] : i32
 // CHECK:         }
 
-hw.module @testStallability(%arg0: i32, %go: i1, %clk: i1, %rst: i1, %stall: i1) -> (out: i32) {
+hw.module @testStallability(%arg0: i32, %go: i1, %clk: !seq.clock, %rst: i1, %stall: i1) -> (out: i32) {
   %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0)
       stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go)
       {stallability = [true, false, true]} -> (out : i32) {
-    pipeline.stage ^bb1 regs("a0" = %a0 : i32) 
+    pipeline.stage ^bb1 regs("a0" = %a0 : i32)
   ^bb1(%a0_0: i32, %s1_enable: i1):  // pred: ^bb0
-    pipeline.stage ^bb2 regs("a0" = %a0_0 : i32) 
+    pipeline.stage ^bb2 regs("a0" = %a0_0 : i32)
   ^bb2(%a0_1: i32, %s2_enable: i1):  // pred: ^bb1
-    pipeline.stage ^bb3 regs("a0" = %a0_1 : i32) 
+    pipeline.stage ^bb3 regs("a0" = %a0_1 : i32)
   ^bb3(%a0_2: i32, %s3_enable: i1):  // pred: ^bb2
     pipeline.return %a0_2 : i32
   }

--- a/test/Conversion/PipelineToHW/test_ce.mlir
+++ b/test/Conversion/PipelineToHW/test_ce.mlir
@@ -2,18 +2,18 @@
 
 
 // CHECK-LABEL:   hw.module @testSingle(
-// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CHECK:           %[[VAL_6:.*]] = seq.clock_gate %[[CLOCK]], %[[VAL_2]]
 // CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_6]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_6]] : i32
 // CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_9]]  : i1
 // CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_10]] : i32, i1
 // CHECK:         }
 
-hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
+hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)

--- a/test/Conversion/PipelineToHW/test_clockgates.mlir
+++ b/test/Conversion/PipelineToHW/test_clockgates.mlir
@@ -3,35 +3,35 @@
 
 
 // CHECK-LABEL:   hw.module @testSingle(
-// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK:           %[[VAL_6:.*]] = hw.constant true
 // CHECK:           %[[VAL_7:.*]] = hw.constant false
-// CHECK:           %[[VAL_8:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[CLOCK]] : i32
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_10]]  : i1
 // CHECK:           %[[VAL_12:.*]] = comb.add %[[VAL_8]], %[[VAL_9]] : i32
 // CHECK:           hw.output %[[VAL_12]], %[[VAL_11]] : i32, i1
 // CHECK:         }
 
 // CGATE-LABEL:   hw.module @testSingle(
-// CGATE-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CGATE-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
 // CGATE:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
 // CGATE:           %[[VAL_6:.*]] = hw.constant true
 // CGATE:           %[[VAL_7:.*]] = hw.constant false
-// CGATE:           %[[VAL_8:.*]] = seq.clock_gate %[[VAL_3]], %[[VAL_2]]
+// CGATE:           %[[VAL_8:.*]] = seq.clock_gate %[[CLOCK]], %[[VAL_2]]
 // CGATE:           %[[VAL_9:.*]] = seq.clock_gate %[[VAL_8]], %[[VAL_6]]
 // CGATE:           %[[VAL_10:.*]] = seq.clock_gate %[[VAL_9]], %[[VAL_7]]
 // CGATE:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_10]] : i32
 // CGATE:           %[[VAL_12:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_8]] : i32
 // CGATE:           %[[VAL_13:.*]] = hw.constant false
-// CGATE:           %[[VAL_14:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[VAL_3]], %[[VAL_4]], %[[VAL_13]]  : i1
+// CGATE:           %[[VAL_14:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_13]]  : i1
 // CGATE:           %[[VAL_15:.*]] = comb.add %[[VAL_11]], %[[VAL_12]] : i32
 // CGATE:           hw.output %[[VAL_15]], %[[VAL_14]] : i32, i1
 // CGATE:         }
 
-hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out0: i32, out1: i1) {
+hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out0: i32, out1: i1) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %1 = comb.sub %a0, %a1 : i32
     %true = hw.constant true

--- a/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
+++ b/test/Dialect/Pipeline/Transforms/explicit-regs.mlir
@@ -1,8 +1,8 @@
 // RUN: circt-opt -pipeline-explicit-regs --allow-unregistered-dialect %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @testRegsOnly(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]], %[[VAL_8:.*]] : i32 = %[[VAL_1]]) clock(%[[VAL_9:.*]] = %[[VAL_3]]) reset(%[[VAL_10:.*]] = %[[VAL_4]]) go(%[[VAL_11:.*]] = %[[VAL_2]]) -> (out : i32) {
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i1) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]], %[[VAL_8:.*]] : i32 = %[[VAL_1]]) clock(%[[VAL_9:.*]] = %[[CLOCK]]) reset(%[[VAL_10:.*]] = %[[VAL_4]]) go(%[[VAL_11:.*]] = %[[VAL_2]]) -> (out : i32) {
 // CHECK:             %[[VAL_12:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
 // CHECK:             pipeline.stage ^bb1 regs(%[[VAL_12]] : i32, "a0" = %[[VAL_7]] : i32)
 // CHECK:           ^bb1(%[[VAL_13:.*]]: i32, %[[VAL_14:.*]]: i32, %[[VAL_15:.*]]: i1):
@@ -14,11 +14,11 @@
 // CHECK:           }
 // CHECK:           hw.output %[[VAL_21:.*]], %[[VAL_22:.*]] : i32, i1
 // CHECK:         }
-hw.module @testRegsOnly(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out0: i32, out1: i1) {
+hw.module @testRegsOnly(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out0: i32, out1: i1) {
   %out:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
       %add0 = comb.add %a0, %a1 : i32
       pipeline.stage ^bb1
-    
+
     ^bb1(%s1_enable : i1):
       %add1 = comb.add %add0, %a0 : i32 // %a0 is a block argument fed through a stage.
       pipeline.stage ^bb2
@@ -31,8 +31,8 @@ hw.module @testRegsOnly(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
 }
 
 // CHECK-LABEL:   hw.module @testLatency1(
-// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]]) clock(%[[VAL_8:.*]] = %[[VAL_3]]) reset(%[[VAL_9:.*]] = %[[VAL_4]]) go(%[[VAL_10:.*]] = %[[VAL_2]]) -> (out : i32) {
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]]) clock(%[[VAL_8:.*]] = %[[CLOCK]]) reset(%[[VAL_9:.*]] = %[[VAL_4]]) go(%[[VAL_10:.*]] = %[[VAL_2]]) -> (out : i32) {
 // CHECK:             %[[VAL_11:.*]] = hw.constant true
 // CHECK:             %[[VAL_12:.*]] = pipeline.latency 2 -> (i32) {
 // CHECK:               %[[VAL_13:.*]] = comb.add %[[VAL_7]], %[[VAL_7]] : i32
@@ -50,7 +50,7 @@ hw.module @testRegsOnly(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
 // CHECK:           }
 // CHECK:           hw.output %[[VAL_23:.*]] : i32
 // CHECK:         }
-hw.module @testLatency1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @testLatency1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %out:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     %true = hw.constant true
     %out = pipeline.latency 2 -> (i32) {
@@ -71,8 +71,8 @@ hw.module @testLatency1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
 }
 
 // CHECK-LABEL:   hw.module @testLatency2(
-// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]]) clock(%[[VAL_8:.*]] = %[[VAL_3]]) reset(%[[VAL_9:.*]] = %[[VAL_4]]) go(%[[VAL_10:.*]] = %[[VAL_2]]) -> (out : i32) {
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]]) clock(%[[VAL_8:.*]] = %[[CLOCK]]) reset(%[[VAL_9:.*]] = %[[VAL_4]]) go(%[[VAL_10:.*]] = %[[VAL_2]]) -> (out : i32) {
 // CHECK:             %[[VAL_11:.*]] = hw.constant true
 // CHECK:             %[[VAL_12:.*]] = pipeline.latency 1 -> (i32) {
 // CHECK:               %[[VAL_13:.*]] = comb.add %[[VAL_7]], %[[VAL_7]] : i32
@@ -95,7 +95,7 @@ hw.module @testLatency1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
 // CHECK:           }
 // CHECK:           hw.output %[[VAL_29:.*]] : i32
 // CHECK:         }
-hw.module @testLatency2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @testLatency2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %out:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     %true = hw.constant true
     %out = pipeline.latency 1 -> (i32) {
@@ -121,8 +121,8 @@ hw.module @testLatency2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
 }
 
 // CHECK-LABEL:   hw.module @testLatencyToLatency(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]]) clock(%[[VAL_8:.*]] = %[[VAL_3]]) reset(%[[VAL_9:.*]] = %[[VAL_4]]) go(%[[VAL_10:.*]] = %[[VAL_2]]) -> (out : i32) {
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]]) clock(%[[VAL_8:.*]] = %[[CLOCK]]) reset(%[[VAL_9:.*]] = %[[VAL_4]]) go(%[[VAL_10:.*]] = %[[VAL_2]]) -> (out : i32) {
 // CHECK:             %[[VAL_11:.*]] = hw.constant true
 // CHECK:             %[[VAL_12:.*]] = pipeline.latency 2 -> (i32) {
 // CHECK:               %[[VAL_13:.*]] = comb.add %[[VAL_7]], %[[VAL_7]] : i32
@@ -145,7 +145,7 @@ hw.module @testLatency2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
 // CHECK:           }
 // CHECK:           hw.output %[[VAL_27:.*]] : i32
 // CHECK:         }
-hw.module @testLatencyToLatency(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+hw.module @testLatencyToLatency(%arg0: i32, %arg1: i32, %go: i1, %clk : !seq.clock, %rst: i1) -> (out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     %true = hw.constant true
     %1 = pipeline.latency 2 -> (i32) {
@@ -174,8 +174,8 @@ hw.module @testLatencyToLatency(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst:
 }
 
 // CHECK-LABEL:   hw.module @test_arbitrary_nesting(
-// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]]) clock(%[[VAL_8:.*]] = %[[VAL_3]]) reset(%[[VAL_9:.*]] = %[[VAL_4]]) go(%[[VAL_10:.*]] = %[[VAL_2]]) -> (out : i32) {
+// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]]) clock(%[[VAL_8:.*]] = %[[CLOCK]]) reset(%[[VAL_9:.*]] = %[[VAL_4]]) go(%[[VAL_10:.*]] = %[[VAL_2]]) -> (out : i32) {
 // CHECK:             %[[VAL_11:.*]] = hw.constant true
 // CHECK:             pipeline.stage ^bb1 regs("a0" = %[[VAL_7]] : i32)
 // CHECK:           ^bb1(%[[VAL_12:.*]]: i32, %[[VAL_13:.*]]: i1):
@@ -194,7 +194,7 @@ hw.module @testLatencyToLatency(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst:
 // CHECK:           }
 // CHECK:           hw.output %[[VAL_19:.*]] : i32
 // CHECK:         }
-hw.module @test_arbitrary_nesting(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @test_arbitrary_nesting(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %out:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     %true = hw.constant true
     pipeline.stage ^bb1
@@ -222,8 +222,8 @@ hw.module @test_arbitrary_nesting(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1,
 }
 
 // CHECK-LABEL:   hw.module @testExtInput(
-// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = pipeline.scheduled(%[[VAL_8:.*]] : i32 = %[[VAL_0]]) clock(%[[VAL_10:.*]] = %[[VAL_3]]) reset(%[[VAL_11:.*]] = %[[VAL_4]]) go(%[[VAL_12:.*]] = %[[VAL_2]]) -> (out0 : i32, out1 : i32) {
+// CHECK-SAME:            %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out0: i32, out1: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]] = pipeline.scheduled(%[[VAL_8:.*]] : i32 = %[[VAL_0]]) clock(%[[VAL_10:.*]] = %[[CLOCK]]) reset(%[[VAL_11:.*]] = %[[VAL_4]]) go(%[[VAL_12:.*]] = %[[VAL_2]]) -> (out0 : i32, out1 : i32) {
 // CHECK:             %[[VAL_13:.*]] = hw.constant true
 // CHECK:             %[[VAL_14:.*]] = comb.add %[[VAL_8]], %[[VAL_1]] : i32
 // CHECK:             pipeline.stage ^bb1 regs(%[[VAL_14]] : i32)
@@ -232,7 +232,7 @@ hw.module @test_arbitrary_nesting(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1,
 // CHECK:           }
 // CHECK:           hw.output %[[VAL_17:.*]], %[[VAL_18:.*]] : i32, i32
 // CHECK:         }
-hw.module @testExtInput(%arg0 : i32, %ext1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out0: i32, out1: i32) {
+hw.module @testExtInput(%arg0 : i32, %ext1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out0: i32, out1: i32) {
   %out:3 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0: i32, out1: i32) {
       %true = hw.constant true
       %add0 = comb.add %a0, %ext1 : i32
@@ -244,7 +244,7 @@ hw.module @testExtInput(%arg0 : i32, %ext1 : i32, %go : i1, %clk : i1, %rst : i1
   hw.output %out#0, %out#1 : i32, i32
 }
 
-// CHECK-LABEL:  hw.module @testNaming(%myArg: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+// CHECK-LABEL:  hw.module @testNaming(%myArg: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
 // CHECK-NEXT:    %out, %done = pipeline.scheduled(%A : i32 = %myArg) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      %0 = pipeline.latency 2 -> (i32) {
 // CHECK-NEXT:        %2 = comb.add %A, %A : i32
@@ -255,13 +255,13 @@ hw.module @testExtInput(%arg0 : i32, %ext1 : i32, %go : i1, %clk : i1, %rst : i1
 // CHECK-NEXT:      pipeline.stage ^bb2 regs("A" = %A_0 : i32) pass("foo" = %foo : i32)
 // CHECK-NEXT:    ^bb2(%A_1: i32, %foo_2: i32, %s2_enable: i1):  // pred: ^bb1
 // CHECK-NEXT:      %1 = comb.add %A_1, %foo_2 {sv.namehint = "bar"} : i32
-// CHECK-NEXT:      pipeline.stage ^bb3 regs("bar" = %1 : i32) 
+// CHECK-NEXT:      pipeline.stage ^bb3 regs("bar" = %1 : i32)
 // CHECK-NEXT:    ^bb3(%bar: i32, %s3_enable: i1):  // pred: ^bb2
 // CHECK-NEXT:      pipeline.return %bar : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
-hw.module @testNaming(%myArg : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @testNaming(%myArg : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %out:2 = pipeline.scheduled(%A : i32 = %myArg) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     %res = pipeline.latency 2 -> (i32) {
       %d = comb.add %A, %A : i32
@@ -280,8 +280,8 @@ hw.module @testNaming(%myArg : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32
 }
 
 // CHECK-LABEL:   hw.module @pipelineLatencyCrashRepro(
-// CHECK-SAME:            %[[VAL_0:.*]]: i1, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) {
-// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = pipeline.scheduled() clock(%[[VAL_5:.*]] = %[[VAL_0]]) reset(%[[VAL_6:.*]] = %[[VAL_1]]) go(%[[VAL_7:.*]] = %[[VAL_2]]) -> (pipeline_done : i128) {
+// CHECK-SAME:            %[[CLOCK:.*]]: !seq.clock, %[[VAL_1:.*]]: i1, %[[VAL_2:.*]]: i1) {
+// CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = pipeline.scheduled() clock(%[[VAL_5:.*]] = %[[CLOCK]]) reset(%[[VAL_6:.*]] = %[[VAL_1]]) go(%[[VAL_7:.*]] = %[[VAL_2]]) -> (pipeline_done : i128) {
 // CHECK:             %[[VAL_8:.*]] = "dummy.op"() : () -> i128
 // CHECK:             pipeline.stage ^bb1 regs(%[[VAL_8]] : i128)
 // CHECK:           ^bb1(%[[VAL_9:.*]]: i128, %[[VAL_10:.*]]: i1):
@@ -305,21 +305,21 @@ hw.module @testNaming(%myArg : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32
 // between the order that block arguments were added to a stage, and the order
 // that said block arguments were used to replace backedges within a block.
 
-hw.module @pipelineLatencyCrashRepro(%clk: i1, %rst: i1, %go: i1) {
+hw.module @pipelineLatencyCrashRepro(%clk : !seq.clock, %rst: i1, %go: i1) {
   %pipeline_done, %done = pipeline.scheduled() clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (pipeline_done : i128) {
     %0 = "dummy.op"() : () -> i128
-    pipeline.stage ^bb1  
+    pipeline.stage ^bb1
   ^bb1(%s1_enable: i1):  // pred: ^bb0
     %1 = pipeline.latency 2 -> (i54) {
       %2 = "dummy.op"() : () -> i54
       pipeline.latency.return %2 : i54
     }
-    pipeline.stage ^bb2  
+    pipeline.stage ^bb2
   ^bb2(%s2_enable: i1):  // pred: ^bb1
-    pipeline.stage ^bb3  
+    pipeline.stage ^bb3
   ^bb3(%s3_enable: i1):  // pred: ^bb2
     "dummy.op"(%1) : (i54) -> ()
-    pipeline.stage ^bb4  
+    pipeline.stage ^bb4
   ^bb4(%s4_enable: i1):  // pred: ^bb3
     pipeline.return %0 : i128
   }

--- a/test/Dialect/Pipeline/Transforms/schedule-linear-pipeline.mlir
+++ b/test/Dialect/Pipeline/Transforms/schedule-linear-pipeline.mlir
@@ -1,8 +1,8 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(any(pipeline-schedule-linear))' %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @pipeline(
-// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]], %[[VAL_8:.*]] : i32 = %[[VAL_1]]) clock(%[[VAL_9:.*]] = %[[VAL_3]]) reset(%[[VAL_10:.*]] = %[[VAL_4]]) go(%[[VAL_11:.*]] = %[[VAL_2]]) -> (out : i32) {
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]], %[[VAL_8:.*]] : i32 = %[[VAL_1]]) clock(%[[VAL_9:.*]] = %[[CLOCK]]) reset(%[[VAL_10:.*]] = %[[VAL_4]]) go(%[[VAL_11:.*]] = %[[VAL_2]]) -> (out : i32) {
 // CHECK:             %[[VAL_12:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] {ssp.operator_type = @add1} : i32
 // CHECK:             %[[VAL_13:.*]] = comb.add %[[VAL_8]], %[[VAL_7]] {ssp.operator_type = @add1} : i32
 // CHECK:             pipeline.stage ^bb1
@@ -32,7 +32,7 @@ module {
     operator_type @mul2 [latency<3>]
   }
 
-  hw.module @pipeline(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+  hw.module @pipeline(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
     %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go)
       {operator_lib = @lib} -> (out: i32) {
       %0 = comb.add %a0, %a1 {ssp.operator_type = @add1} : i32

--- a/test/Dialect/Pipeline/errors.mlir
+++ b/test/Dialect/Pipeline/errors.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt -split-input-file -verify-diagnostics %s
 
 
-hw.module @res_argn(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @res_argn(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     // expected-error @+1 {{'pipeline.return' op expected 1 return values, got 0.}}
     pipeline.return
@@ -11,7 +11,7 @@ hw.module @res_argn(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) ->
 
 // -----
 
-hw.module @res_argtype(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i31) {
+hw.module @res_argtype(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i31) {
   %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i31) {
     // expected-error @+1 {{'pipeline.return' op expected return value of type 'i31', got 'i32'.}}
     pipeline.return %a0 : i32
@@ -21,7 +21,7 @@ hw.module @res_argtype(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1)
 
 // -----
 
-hw.module @unterminated(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @unterminated(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op all blocks must be terminated with a `pipeline.stage` or `pipeline.return` op.}}
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
@@ -37,7 +37,7 @@ hw.module @unterminated(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
 
 // -----
 
-hw.module @mixed_stages(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @mixed_stages(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1
@@ -54,7 +54,7 @@ hw.module @mixed_stages(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
 
 // -----
 
-hw.module @cycle_pipeline1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @cycle_pipeline1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op pipeline contains a cycle.}}
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
@@ -74,7 +74,7 @@ hw.module @cycle_pipeline1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst :
 
 // -----
 
-hw.module @cycle_pipeline2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @cycle_pipeline2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op pipeline contains a cycle.}}
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
@@ -91,7 +91,7 @@ hw.module @cycle_pipeline2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst :
 
 // -----
 
-hw.module @earlyAccess(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+hw.module @earlyAccess(%arg0: i32, %arg1: i32, %go: i1, %clk : !seq.clock, %rst: i1) -> (out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     // expected-error @+1 {{'pipeline.latency' op result 0 is used before it is available.}}
     %1 = pipeline.latency 2 -> (i32) {
@@ -110,7 +110,7 @@ hw.module @earlyAccess(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (
 
 // Test which verifies that the values referenced within the body of a
 // latency operation also adhere to the latency constraints.
-hw.module @earlyAccess2(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+hw.module @earlyAccess2(%arg0: i32, %arg1: i32, %go: i1, %clk : !seq.clock, %rst: i1) -> (out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     // expected-error @+1 {{'pipeline.latency' op result 0 is used before it is available.}}
     %1 = pipeline.latency 2 -> (i32) {
@@ -140,7 +140,7 @@ hw.module @earlyAccess2(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> 
 // -----
 
 
-hw.module @registeredPass(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+hw.module @registeredPass(%arg0: i32, %arg1: i32, %go: i1, %clk : !seq.clock, %rst: i1) -> (out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     // expected-error @+1 {{'pipeline.latency' op result 0 is used before it is available.}}
     %1 = pipeline.latency 2 -> (i32) {
@@ -157,7 +157,7 @@ hw.module @registeredPass(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -
 
 // -----
 
-hw.module @missing_valid_entry3(%arg : i32, %go : i1, %clk : i1, %rst : i1) -> () {
+hw.module @missing_valid_entry3(%arg : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> () {
   // expected-error @+1 {{'pipeline.scheduled' op block 1 must have an i1 argument as the last block argument (stage valid signal).}}
   %done = pipeline.scheduled(%a0 : i32 = %arg) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> () {
      pipeline.stage ^bb1
@@ -169,7 +169,7 @@ hw.module @missing_valid_entry3(%arg : i32, %go : i1, %clk : i1, %rst : i1) -> (
 
 // -----
 
-hw.module @invalid_clock_gate(%arg : i32, %go : i1, %clk : i1, %rst : i1) -> () {
+hw.module @invalid_clock_gate(%arg : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> () {
   %done = pipeline.scheduled(%a0 : i32 = %arg) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> () {
      // expected-note@+1 {{prior use here}}
      %c0_i2 = hw.constant 0 : i2
@@ -183,7 +183,7 @@ hw.module @invalid_clock_gate(%arg : i32, %go : i1, %clk : i1, %rst : i1) -> () 
 
 // -----
 
-hw.module @noStallSignalWithStallability(%arg0 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @noStallSignalWithStallability(%arg0 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op cannot specify stallability without a stall signal.}}
   %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go)
     {stallability = [true, false, true]}
@@ -201,7 +201,7 @@ hw.module @noStallSignalWithStallability(%arg0 : i32, %go : i1, %clk : i1, %rst 
 
 // -----
 
-hw.module @incorrectStallabilitySize(%arg0 : i32, %go : i1, %clk : i1, %rst : i1, %stall : i1) -> (out: i32) {
+hw.module @incorrectStallabilitySize(%arg0 : i32, %go : i1, %clk : !seq.clock, %rst : i1, %stall : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op stallability array must be the same length as the number of stages. Pipeline has 3 stages but array had 2 elements.}}
   %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go)
     {stallability = [true, false]}

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL:  hw.module @unscheduled1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+// CHECK-LABEL:  hw.module @unscheduled1(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
 // CHECK-NEXT:    %dataOutputs, %done = pipeline.unscheduled(%arg0_0 : i32 = %arg0, %arg1_1 : i32 = %arg1) clock(%arg2 = %clk) reset(%arg3 = %rst) go(%arg4 = %go) -> (out : i32) {
 // CHECK-NEXT:      %0 = pipeline.latency 2 -> (i32) {
 // CHECK-NEXT:        %1 = comb.add %arg0_0, %arg1_1 : i32
@@ -10,7 +10,7 @@
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %dataOutputs : i32
 // CHECK-NEXT:  }
-hw.module @unscheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @unscheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %0 = pipeline.latency 2 -> (i32) {
       %1 = comb.add %a0, %a1 : i32
@@ -21,16 +21,16 @@ hw.module @unscheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1
   hw.output %0 : i32
 }
 
-// CHECK-LABEL:  hw.module @scheduled1(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+// CHECK-LABEL:  hw.module @scheduled1(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
 // CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
-// CHECK-NEXT:      pipeline.stage ^bb1 
+// CHECK-NEXT:      pipeline.stage ^bb1
 // CHECK-NEXT:    ^bb1(%s1_enable: i1):  // pred: ^bb0
 // CHECK-NEXT:      pipeline.return %0 : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
-hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1
@@ -42,7 +42,7 @@ hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) 
 }
 
 
-// CHECK-LABEL:  hw.module @scheduled2(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+// CHECK-LABEL:  hw.module @scheduled2(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
 // CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%0 : i32)
@@ -51,7 +51,7 @@ hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) 
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
-hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1 regs(%0 : i32)
@@ -62,7 +62,7 @@ hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) 
   hw.output %0 : i32
 }
 
-// CHECK-LABEL:  hw.module @scheduledWithPassthrough(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+// CHECK-LABEL:  hw.module @scheduledWithPassthrough(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
 // CHECK-NEXT:    %out0, %out1, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0 : i32, out1 : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%0 : i32) pass(%a1 : i32)
@@ -71,7 +71,7 @@ hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) 
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out0 : i32
 // CHECK-NEXT:  }
-hw.module @scheduledWithPassthrough(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @scheduledWithPassthrough(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %0:3 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0: i32, out1: i32) {
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1 regs(%0 : i32) pass(%a1 : i32)
@@ -82,20 +82,20 @@ hw.module @scheduledWithPassthrough(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i
   hw.output %0#0 : i32
 }
 
-// CHECK-LABEL:  hw.module @withStall(%arg0: i32, %stall: i1, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+// CHECK-LABEL:  hw.module @withStall(%arg0: i32, %stall: i1, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
 // CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      pipeline.return %a0 : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
-hw.module @withStall(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @withStall(%arg0 : i32, %stall : i1, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     pipeline.return %a0 : i32
   }
   hw.output %0 : i32
 }
 
-// CHECK-LABEL:  hw.module @withMultipleRegs(%arg0: i32, %stall: i1, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+// CHECK-LABEL:  hw.module @withMultipleRegs(%arg0: i32, %stall: i1, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
 // CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%a0 : i32, %a0 : i32)
 // CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_reg1: i32, %s1_enable: i1):  // pred: ^bb0
@@ -103,7 +103,7 @@ hw.module @withStall(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : i1) -
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
-hw.module @withMultipleRegs(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @withMultipleRegs(%arg0 : i32, %stall : i1, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     pipeline.stage ^bb1 regs(%a0 : i32, %a0 : i32)
 
@@ -113,7 +113,7 @@ hw.module @withMultipleRegs(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst 
   hw.output %0 : i32
 }
 
-// CHECK-LABEL:  hw.module @withClockGates(%arg0: i32, %stall: i1, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+// CHECK-LABEL:  hw.module @withClockGates(%arg0: i32, %stall: i1, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
 // CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      %true = hw.constant true
 // CHECK-NEXT:      %true_0 = hw.constant true
@@ -124,7 +124,7 @@ hw.module @withMultipleRegs(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst 
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
-hw.module @withClockGates(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @withClockGates(%arg0 : i32, %stall : i1, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
     %true1 = hw.constant true
     %true2 = hw.constant true
@@ -137,16 +137,16 @@ hw.module @withClockGates(%arg0 : i32, %stall : i1, %go : i1, %clk : i1, %rst : 
   hw.output %0 : i32
 }
 
-// CHECK-LABEL:  hw.module @withNames(%arg0: i32, %arg1: i32, %go: i1, %clk: i1, %rst: i1) -> (out: i32) {
+// CHECK-LABEL:  hw.module @withNames(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
 // CHECK-NEXT:    %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
-// CHECK-NEXT:      pipeline.stage ^bb1 regs("myAdd" = %0 : i32, %0 : i32, "myOtherAdd" = %0 : i32) 
+// CHECK-NEXT:      pipeline.stage ^bb1 regs("myAdd" = %0 : i32, %0 : i32, "myOtherAdd" = %0 : i32)
 // CHECK-NEXT:    ^bb1(%myAdd: i32, %s1_reg1: i32, %myOtherAdd: i32, %s1_enable: i1):  // pred: ^bb0
 // CHECK-NEXT:      pipeline.return %myAdd : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
-hw.module @withNames(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -> (out: i32) {
+hw.module @withNames(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1 regs("myAdd" = %0 : i32, %0 : i32, "myOtherAdd" = %0 : i32)
@@ -159,7 +159,7 @@ hw.module @withNames(%arg0 : i32, %arg1 : i32, %go : i1, %clk : i1, %rst : i1) -
 
 // CHECK-LABEL:   hw.module @withStallability(
 // CHECK:           %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) {stallability = [true, false, true]} -> (out : i32)
-hw.module @withStallability(%arg0 : i32, %go : i1, %clk : i1, %rst : i1, %stall : i1) -> (out: i32) {
+hw.module @withStallability(%arg0 : i32, %go : i1, %clk : !seq.clock, %rst : i1, %stall : i1) -> (out: i32) {
   %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go)
     {stallability = [true, false, true]}
    -> (out: i32) {

--- a/test/Dialect/Seq/clock-gate.mlir
+++ b/test/Dialect/Seq/clock-gate.mlir
@@ -14,9 +14,9 @@
 // CHECK:           %[[VAL_6:.*]] = comb.and %[[VAL_0]], %[[VAL_5]] : i1
 // CHECK:           hw.output %[[VAL_6]] : i1
 // CHECK:         }
-hw.module @cg1(%clk : i1, %enable : i1) -> (gclk : i1) {
-    %0 = seq.clock_gate %clk, %enable : i1
-    hw.output %0 : i1
+hw.module @cg1(%clk : !seq.clock, %enable : i1) -> (gclk : !seq.clock) {
+    %0 = seq.clock_gate %clk, %enable
+    hw.output %0 : !seq.clock
 }
 
 // CHECK-LABEL:   hw.module @cg2(
@@ -34,7 +34,7 @@ hw.module @cg1(%clk : i1, %enable : i1) -> (gclk : i1) {
 // CHECK:           %[[VAL_8:.*]] = comb.and %[[VAL_0]], %[[VAL_7]] : i1
 // CHECK:           hw.output %[[VAL_8]] : i1
 // CHECK:         }
-hw.module @cg2(%clk : i1, %enable : i1, %test_enable : i1) -> (gclk : i1) {
-    %0 = seq.clock_gate %clk, %enable, %test_enable : i1
-    hw.output %0 : i1
+hw.module @cg2(%clk : !seq.clock, %enable : i1, %test_enable : i1) -> (gclk : !seq.clock) {
+    %0 = seq.clock_gate %clk, %enable, %test_enable
+    hw.output %0 : !seq.clock
 }

--- a/test/Dialect/Seq/clock-type.mlir
+++ b/test/Dialect/Seq/clock-type.mlir
@@ -8,8 +8,18 @@ hw.module.generated @generated, @Some_schema(%clock: !seq.clock, %other: i1) -> 
 // CHECK-LABEL: hw.module.extern @extern(%clock: i1, %other: i1) -> (out: i32)
 hw.module.extern @extern(%clock: !seq.clock, %other: i1) -> (out: i32)
 
+// CHECK-LABEL: @const_clock
+hw.module @const_clock() -> () {
+  // CHECK: hw.constant false
+  seq.const_clock low
+
+  // CHECK: hw.constant true
+  seq.const_clock high
+}
+
 // CHECK-LABEL: hw.module @top(%clock: i1, %other: i1, %wire: i1) -> (out: i1)
 hw.module @top(%clock: !seq.clock, %other: i1, %wire: i1) -> (out: !seq.clock) {
+
 
   // CHECK: %tap_generated = hw.wire %clock  : i1
   %tap_generated = hw.wire %clock : !seq.clock
@@ -23,7 +33,8 @@ hw.module @top(%clock: !seq.clock, %other: i1, %wire: i1) -> (out: !seq.clock) {
   // CHECK: %inner.out = hw.instance "inner" @inner(clock: %clock: i1, other: %other: i1) -> (out: i32)
   %out_inner = hw.instance "inner" @inner(clock: %clock: !seq.clock, other: %other: i1) -> (out: i32)
 
-  // CHECK: [[NEGATED:%.+]] = comb.xor %clock, %true : i1
+  // CHECK: [[TRUE:%.+]] = hw.constant true
+  // CHECK: [[NEGATED:%.+]] = comb.xor %clock, [[TRUE]] : i1
   %clock_wire = seq.from_clock %clock
   %one = hw.constant 1 : i1
   %tmp = comb.xor %clock_wire, %one : i1
@@ -42,8 +53,7 @@ hw.module private @inner(%clock: !seq.clock, %other: i1) -> (out: i32) {
 // CHECK-LABEL: hw.module private @SinkSource(%clock: i1) -> (out: i1)
 hw.module private @SinkSource(%clock: !seq.clock) -> (out: !seq.clock) {
   // CHECK: hw.output %false : i1
-  %false = hw.constant 0 : i1
-  %out = seq.to_clock %false
+  %out = seq.const_clock low
   hw.output %out : !seq.clock
 }
 

--- a/test/Dialect/Seq/externalize-clock-gate.mlir
+++ b/test/Dialect/Seq/externalize-clock-gate.mlir
@@ -7,25 +7,25 @@
 // CHECK-WITHOUT-TESTENABLE: hw.module.extern @VeryGate(%I: i1, %E: i1) -> (O: i1)
 
 // CHECK-LABEL: hw.module @Foo
-hw.module @Foo(%clock: !seq.clock, %clk: i1, %enable: i1, %test_enable: i1) {
+hw.module @Foo(%clock: !seq.clock, %enable: i1, %test_enable: i1) {
   // CHECK-NOT: seq.clock_gate
-  %cg0 = seq.clock_gate %clock, %enable : !seq.clock
-  %cg1 = seq.clock_gate %clock, %enable, %test_enable : !seq.clock
-  %cg2 = seq.clock_gate %clk, %enable sym @symbol : i1
+  %cg0 = seq.clock_gate %clock, %enable
+  %cg1 = seq.clock_gate %clock, %enable, %test_enable
+  %cg2 = seq.clock_gate %clock, %enable sym @symbol
 
   // CHECK-DEFAULT: [[CAST:%.+]] = seq.from_clock %clock
   // CHECK-DEFAULT: hw.instance "ckg" @CKG(I: [[CAST]]: i1, E: %enable: i1, TE: %false: i1) -> (O: i1)
   // CHECK-DEFAULT: hw.instance "ckg" @CKG(I: [[CAST]]: i1, E: %enable: i1, TE: %test_enable: i1) -> (O: i1)
-  // CHECK-DEFAULT: hw.instance "ckg" sym @symbol @CKG(I: %clk: i1, E: %enable: i1, TE: %false: i1) -> (O: i1)
+  // CHECK-DEFAULT: hw.instance "ckg" sym @symbol @CKG(I: [[CAST]]: i1, E: %enable: i1, TE: %false: i1) -> (O: i1)
 
   // CHECK-CUSTOM: [[CAST:%.+]] = seq.from_clock %clock
   // CHECK-CUSTOM: hw.instance "gated" @SuchClock(CI: [[CAST]]: i1, EN: %enable: i1, TEN: %false: i1) -> (CO: i1)
   // CHECK-CUSTOM: hw.instance "gated" @SuchClock(CI: [[CAST]]: i1, EN: %enable: i1, TEN: %test_enable: i1) -> (CO: i1)
-  // CHECK-CUSTOM: hw.instance "gated" sym @symbol @SuchClock(CI: %clk: i1, EN: %enable: i1, TEN: %false: i1) -> (CO: i1)
+  // CHECK-CUSTOM: hw.instance "gated" sym @symbol @SuchClock(CI: [[CAST]]: i1, EN: %enable: i1, TEN: %false: i1) -> (CO: i1)
 
   // CHECK-WITHOUT-TESTENABLE: [[CAST:%.+]] = seq.from_clock %clock
   // CHECK-WITHOUT-TESTENABLE: hw.instance "ckg" @VeryGate(I: [[CAST]]: i1, E: %enable: i1) -> (O: i1)
   // CHECK-WITHOUT-TESTENABLE: [[COMBINED_ENABLE:%.+]] = comb.or bin %enable, %test_enable : i1
   // CHECK-WITHOUT-TESTENABLE: hw.instance "ckg" @VeryGate(I: [[CAST]]: i1, E: [[COMBINED_ENABLE]]: i1) -> (O: i1)
-  // CHECK-WITHOUT-TESTENABLE: hw.instance "ckg" sym @symbol @VeryGate(I: %clk: i1, E: %enable: i1) -> (O: i1)
+  // CHECK-WITHOUT-TESTENABLE: hw.instance "ckg" sym @symbol @VeryGate(I: [[CAST]]: i1, E: %enable: i1) -> (O: i1)
 }

--- a/test/Dialect/Seq/round-trip.mlir
+++ b/test/Dialect/Seq/round-trip.mlir
@@ -48,13 +48,13 @@ hw.module @d0(%clk : i1, %rst : i1) -> () {
 }
 
 // CHECK-LABEL: hw.module @ClockGate
-hw.module @ClockGate(%clock: i1, %enable: i1, %test_enable: i1) {
+hw.module @ClockGate(%clock: !seq.clock, %enable: i1, %test_enable: i1) {
   // CHECK-NEXT: seq.clock_gate %clock, %enable
   // CHECK-NEXT: seq.clock_gate %clock, %enable, %test_enable
   // CHECK-NEXT: seq.clock_gate %clock, %enable, %test_enable sym @gate_sym
-  %cg0 = seq.clock_gate %clock, %enable : i1
-  %cg1 = seq.clock_gate %clock, %enable, %test_enable : i1
-  %cg2 = seq.clock_gate %clock, %enable, %test_enable sym @gate_sym : i1
+  %cg0 = seq.clock_gate %clock, %enable
+  %cg1 = seq.clock_gate %clock, %enable, %test_enable
+  %cg2 = seq.clock_gate %clock, %enable, %test_enable sym @gate_sym
 }
 
 // CHECK-LABEL: hw.module @ClockMux
@@ -82,4 +82,11 @@ hw.module @preset(%clock : !seq.clock, %reset : i1, %next : i32) -> () {
 hw.module @clock_dividers(%clock: !seq.clock) -> () {
   // CHECK: seq.clock_div %clock by 1
   %by_2 = seq.clock_div %clock by 1
+}
+
+hw.module @clock_const() -> () {
+  // CHECK: seq.const_clock high
+  %high = seq.const_clock high
+  // CHECK: seq.const_clock low
+  %low = seq.const_clock low
 }


### PR DESCRIPTION
This PR restricts the clock gate op to solely use the clock type.

Uses in other dialects, especially Pipeline, were adjusted.

To maintain canonicalization behaviour, a clock constant op along with an attribute is also introduced to represent constant clocks and to fold ops to them.