### PR TITLE
[Arc] Add LowerVectorizations pass

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -776,7 +776,16 @@ def VectorizeOp : ArcOp<"vectorize", [
   }];
 
   let extraClassDeclaration = [{
+    /// Returns whether the `arc.vectorize` boundary is already vectorized.
+    /// The boundary is vectorized if each input vector has only one element
+    /// (either of integer or vector type), i.e., the vector itself.
     bool isBoundaryVectorized();
+
+    /// Returns whether the body block of the `arc.vectorize` is already
+    /// vectorized. The body is vectorized if the boundary is vectorized and
+    /// the body's argument and result types match those of the boundary, or
+    /// they are a vectorized version of the boundary types (i.e., a matching
+    /// vector type or integer with summed-up bitwidth).
     bool isBodyVectorized();
   }];
 

--- a/include/circt/Dialect/Arc/ArcPasses.h
+++ b/include/circt/Dialect/Arc/ArcPasses.h
@@ -17,6 +17,8 @@ namespace mlir {
 class Pass;
 } // namespace mlir
 
+#include "circt/Dialect/Arc/ArcPassesEnums.h.inc"
+
 namespace circt {
 namespace arc {
 
@@ -42,6 +44,8 @@ std::unique_ptr<mlir::Pass> createLegalizeStateUpdatePass();
 std::unique_ptr<mlir::Pass> createLowerClocksToFuncsPass();
 std::unique_ptr<mlir::Pass> createLowerLUTPass();
 std::unique_ptr<mlir::Pass> createLowerStatePass();
+std::unique_ptr<mlir::Pass> createLowerVectorizationsPass(
+    LowerVectorizationsModeEnum mode = LowerVectorizationsModeEnum::Full);
 std::unique_ptr<mlir::Pass> createMakeTablesPass();
 std::unique_ptr<mlir::Pass> createMuxToControlFlowPass();
 std::unique_ptr<mlir::Pass>

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -9,6 +9,7 @@
 #ifndef CIRCT_DIALECT_ARC_ARCPASSES_TD
 #define CIRCT_DIALECT_ARC_ARCPASSES_TD
 
+include "mlir/IR/EnumAttr.td"
 include "mlir/Pass/PassBase.td"
 
 def AddTaps : Pass<"arc-add-taps", "mlir::ModuleOp"> {
@@ -158,6 +159,79 @@ def LowerState : Pass<"arc-lower-state", "mlir::ModuleOp"> {
   let dependentDialects = [
     "arc::ArcDialect", "mlir::scf::SCFDialect", "mlir::func::FuncDialect",
     "mlir::LLVM::LLVMDialect"
+  ];
+}
+
+def LowerVectorizationsMode : I32EnumAttr<
+  "LowerVectorizationsModeEnum", "Lowering Mode", [
+    I32EnumAttrCase<"Boundary", 0, "boundary">,
+    I32EnumAttrCase<"Body", 1, "body">,
+    I32EnumAttrCase<"InlineBody", 2, "inline-body">,
+    I32EnumAttrCase<"Full", 3>,
+  ]> {
+  let cppNamespace = "circt::arc";
+}
+
+def LowerVectorizations : Pass<"arc-lower-vectorizations", "mlir::ModuleOp"> {
+  let summary = "lower `arc.vectorize` operations";
+  let description = [{
+    This pass lowers `arc.vectorize` operations. By default, the operation will
+    be fully lowered (i.e., the op disappears in the IR). Alternatively, it can
+    be partially lowered.
+    
+    The "mode" pass option allows to only lower the boundary, only the body, or
+    only inline the body given that both the boundary and the body are already
+    lowered.
+
+    The pass supports vectorization within scalar registers and SIMD
+    vectorization and prioritizes vectorization by packing the vector elements
+    into a scalar value if it can fit into 64 bits.
+
+    Example:
+    ```mlir
+    hw.module @example(%in0: i8, %in1: i8, %in2: i8) -> (out0: i8, out1: i8) {
+      %0:2 = arc.vectorize (%in0, %in1), (%in2, %in2) :
+        (i8, i8, i8, i8) -> (i8, i8) {
+      ^bb0(%arg0: i8, %arg1: i8):
+        %1 = comb.and %arg0, %arg1 : i8
+        arc.vectorize.return %1 : i8
+      }
+      hw.output %0#0, %0#1 : i8, i8
+    }
+    ```
+    This piece of IR is lowered to the following fully vectorized IR:
+    ```mlir
+    hw.module @example(%in0: i8, %in1: i8, %in2: i8) -> (out0: i8, out1: i8) {
+      %0 = comb.concat %in0, %in1 : i8, i8
+      %1 = comb.concat %in2, %in2 : i8, i8
+      %2 = comb.and %0, %1 : i16
+      %3 = comb.extract %2 from 0 : (i16) -> i8
+      %4 = comb.extract %2 from 8 : (i16) -> i8
+      hw.output %3, %4 : i8, i8
+    }
+    ```
+  }];
+  let constructor = "circt::arc::createLowerVectorizationsPass()";
+
+  let options = [
+    Option<"mode", "mode", "circt::arc::LowerVectorizationsModeEnum",
+           /*default=*/"circt::arc::LowerVectorizationsModeEnum::Full",
+           "Select what should be lowered.",
+           [{::llvm::cl::values(
+             clEnumValN(circt::arc::LowerVectorizationsModeEnum::Boundary,
+             "boundary", "Lower boundary only."),
+             clEnumValN(circt::arc::LowerVectorizationsModeEnum::Body,
+             "body", "Lower body only."),
+             clEnumValN(circt::arc::LowerVectorizationsModeEnum::InlineBody,
+             "inline-body", "Inline already vectorized ops only."),
+             clEnumValN(circt::arc::LowerVectorizationsModeEnum::Full,
+             "full", "Perform the complete lowering.")
+           )}]>,
+  ];
+
+  let dependentDialects = [
+    "arc::ArcDialect", "circt::comb::CombDialect", "mlir::arith::ArithDialect",
+    "mlir::vector::VectorDialect",
   ];
 }
 

--- a/include/circt/Dialect/Arc/CMakeLists.txt
+++ b/include/circt/Dialect/Arc/CMakeLists.txt
@@ -3,6 +3,8 @@ add_circt_dialect_doc(Arc arc)
 
 set(LLVM_TARGET_DEFINITIONS ArcPasses.td)
 mlir_tablegen(ArcPasses.h.inc -gen-pass-decls)
+mlir_tablegen(ArcPassesEnums.h.inc -gen-enum-decls)
+mlir_tablegen(ArcPassesEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(CIRCTArcTransformsIncGen)
 add_circt_doc(ArcPasses ArcPasses -gen-pass-doc)
 

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -419,8 +419,12 @@ bool VectorizeOp::isBodyVectorized() {
       returnOp.getValue().getType() == getResultTypes().front())
     return true;
 
-  return succeeded(
-      getVectorWidth(getResultTypes().front(), returnOp.getValue().getType()));
+  if (auto width = getVectorWidth(getResultTypes().front(),
+                                  returnOp.getValue().getType());
+      succeeded(width))
+    return *width > 1;
+
+  return false;
 }
 
 #include "circt/Dialect/Arc/ArcInterfaces.cpp.inc"

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -14,6 +14,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   LowerClocksToFuncs.cpp
   LowerLUT.cpp
   LowerState.cpp
+  LowerVectorizations.cpp
   MakeTables.cpp
   MuxToControlFlow.cpp
   PrintStateInfo.cpp
@@ -36,6 +37,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   MLIRFuncDialect
   MLIRLLVMDialect
   MLIRSCFDialect
+  MLIRVectorDialect
   MLIRIR
   MLIRPass
   MLIRTransformUtils

--- a/lib/Dialect/Arc/Transforms/LowerVectorizations.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerVectorizations.cpp
@@ -1,0 +1,286 @@
+//===- LowerVectorizations.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Pass/Pass.h"
+
+#include "circt/Dialect/Arc/ArcPassesEnums.cpp.inc"
+
+namespace circt {
+namespace arc {
+#define GEN_PASS_DEF_LOWERVECTORIZATIONS
+#include "circt/Dialect/Arc/ArcPasses.h.inc"
+} // namespace arc
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+
+/// Vectorizes the `arc.vectorize` boundary by packing the vector elements into
+/// an integer value. Returns the vectorized version of the op. May invalidate
+/// the passed operation.
+///
+/// Example:
+/// ```mlir
+/// %0:2 = arc.vectorize (%in0, %in1), (%in2, %in3) : (i1, i1, i1, i1) -> (i1,
+/// i1) { ^bb0(%arg0: i1, %arg1: i1):
+///   %1 = comb.and %arg0, %arg1 : i1
+///   arc.vectorize.return %1 : i1
+/// }
+/// ```
+/// becomes
+/// ```mlir
+/// %0 = comb.concat %in0, %in1 : i1, i1
+/// %1 = comb.concat %in2, %in3 : i1, i1
+/// %2 = arc.vectorize (%0), (%1) : (i2, i2) -> i2 {
+/// ^bb0(%arg0: i1, %arg1: i1):
+///   %11 = comb.and %arg0, %arg1 : i1
+///   arc.vectorize.return %11 : i1
+/// }
+/// %3 = comb.extract %2 from 0 : (i2) -> i1
+/// %4 = comb.extract %2 from 1 : (i2) -> i1
+/// ```
+static VectorizeOp lowerBoundaryScalar(VectorizeOp op) {
+  ImplicitLocOpBuilder builder(op.getLoc(), op);
+  SmallVector<ValueRange> vectors;
+
+  for (ValueRange range : op.getInputs()) {
+    unsigned bw = range.front().getType().getIntOrFloatBitWidth();
+    vectors.push_back(builder
+                          .create<comb::ConcatOp>(
+                              builder.getIntegerType(bw * range.size()), range)
+                          ->getResults());
+  }
+
+  unsigned width = op->getResult(0).getType().getIntOrFloatBitWidth();
+  VectorizeOp newOp = builder.create<VectorizeOp>(
+      builder.getIntegerType(width * op->getNumResults()), vectors);
+  newOp.getBody().takeBody(op.getBody());
+
+  for (OpResult res : op.getResults()) {
+    Value newRes = builder.create<comb::ExtractOp>(
+        newOp.getResult(0), width * res.getResultNumber(), width);
+    res.replaceAllUsesWith(newRes);
+  }
+
+  op->erase();
+  return newOp;
+}
+
+/// Vectorizes the `arc.vectorize` boundary by using the `vector` type and
+/// dialect for SIMD-based vectorization. Returns the vectorized version of the
+/// op. May invalidate the passed operation.
+///
+/// Example:
+/// ```mlir
+/// %0:2 = arc.vectorize (%in0, %in1), (%in2, %in2) : (i64, i64, i32, i32) ->
+/// (i64, i64) { ^bb0(%arg0: i64, %arg1: i32):
+///   %c0_i32 = hw.constant 0 : i32
+///   %1 = comb.concat %c0_i32, %arg1 : i32, i32
+///   %2 = comb.and %arg0, %1 : i64
+///   arc.vectorize.return %2 : i64
+/// }
+/// ```
+/// becomes
+/// ```mlir
+/// %cst = arith.constant dense<0> : vector<2xi64>
+/// %0 = vector.insert %in0, %cst [0] : i64 into vector<2xi64>
+/// %1 = vector.insert %in1, %0 [1] : i64 into vector<2xi64>
+/// %2 = vector.broadcast %in2 : i32 to vector<2xi32>
+/// %3 = arc.vectorize (%1), (%2) : (vector<2xi64>, vector<2xi32>) ->
+/// vector<2xi64> { ^bb0(%arg0: i64, %arg1: i32):
+///   %c0_i32 = hw.constant 0 : i32
+///   %4 = comb.concat %c0_i32, %arg1 : i32, i32
+///   %5 = comb.and %arg0, %4 : i64
+///   arc.vectorize.return %5 : i64
+/// }
+/// %4 = vector.extract %3[0] : vector<2xi64>
+/// %5 = vector.extract %3[1] : vector<2xi64>
+/// ```
+static VectorizeOp lowerBoundaryVector(VectorizeOp op) {
+  ImplicitLocOpBuilder builder(op.getLoc(), op);
+  SmallVector<ValueRange> vectors;
+
+  for (ValueRange range : op.getInputs()) {
+    // Insert a broadcast operation if all elements of a vector are the same
+    // because it's a significantly cheaper instruction.
+    VectorType type = VectorType::get(SmallVector<int64_t>(1, range.size()),
+                                      range.front().getType());
+    if (llvm::all_equal(range)) {
+      vectors.push_back(
+          builder.create<vector::BroadcastOp>(type, range.front())
+              ->getResults());
+      continue;
+    }
+
+    // Otherwise do a gather.
+    ValueRange vector =
+        builder
+            .create<arith::ConstantOp>(DenseElementsAttr::get(
+                type, SmallVector<Attribute>(
+                          range.size(),
+                          builder.getIntegerAttr(type.getElementType(), 0))))
+            ->getResults();
+    for (auto [i, element] : llvm::enumerate(range))
+      vector = builder.create<vector::InsertOp>(element, vector.front(), i)
+                   ->getResults();
+
+    vectors.push_back(vector);
+  }
+
+  VectorType resType = VectorType::get(
+      SmallVector<int64_t>(1, op->getNumResults()), op.getResult(0).getType());
+  VectorizeOp newOp = builder.create<VectorizeOp>(resType, vectors);
+  newOp.getBody().takeBody(op.getBody());
+
+  for (OpResult res : op.getResults())
+    res.replaceAllUsesWith(builder.create<vector::ExtractOp>(
+        newOp.getResult(0), res.getResultNumber()));
+
+  op->erase();
+  return newOp;
+}
+
+/// Vectorizes the boundary of the given `arc.vectorize` operation if it is not
+/// already vectorized. If the body of the `arc.vectorize` operation is already
+/// vectorized the same vectorization technique (SIMD or scalar) is chosen.
+/// Otherwise,
+///  * packs the vector in a scalar if it fits in a 64-bit integer or
+///  * uses the `vector` type and dialect for SIMD vectorization
+/// Returns the vectorized version of the op. May invalidate the passed
+/// operation.
+static VectorizeOp lowerBoundary(VectorizeOp op) {
+  // Nothing to do if it is already vectorized.
+  if (op.isBoundaryVectorized())
+    return op;
+
+  // If the body is already vectorized, we must use the same vectorization
+  // technique. Otherwise, we would produce invalid IR.
+  if (op.isBodyVectorized()) {
+    if (isa<VectorType>(op.getBody().front().getArgumentTypes().front()))
+      return lowerBoundaryVector(op);
+    return lowerBoundaryScalar(op);
+  }
+
+  // If the vector can fit in an i64 value, use scalar vectorization, otherwise
+  // use SIMD.
+  unsigned numLanes = op.getInputs().size();
+  unsigned maxLaneWidth = 0;
+  for (OperandRange range : op.getInputs())
+    maxLaneWidth =
+        std::max(maxLaneWidth, range.front().getType().getIntOrFloatBitWidth());
+
+  if ((numLanes * maxLaneWidth <= 64) &&
+      op->getResult(0).getType().getIntOrFloatBitWidth() *
+              op->getNumResults() <=
+          64)
+    return lowerBoundaryScalar(op);
+  return lowerBoundaryVector(op);
+}
+
+/// Vectorizes the body of the given `arc.vectorize` operation if it is not
+/// already vectorized. If the boundary of the `arc.vectorize` operation is
+/// already vectorized the same vectorization technique (SIMD or scalar) is
+/// chosen. Otherwise,
+///  * packs the vector in a scalar if it fits in a 64-bit integer or
+///  * uses the `vector` type and dialect for SIMD vectorization
+/// Returns the vectorized version of the op or failure. May invalidate the
+/// passed operation.
+static FailureOr<VectorizeOp> lowerBody(VectorizeOp op) {
+  if (op.isBodyVectorized())
+    return op;
+
+  return op->emitError("lowering body not yet supported");
+}
+
+/// Inlines the `arc.vectorize` operations body once both the boundary and body
+/// are vectorized.
+///
+/// Example:
+/// ```mlir
+/// %0 = comb.concat %in0, %in1 : i1, i1
+/// %1 = comb.concat %in2, %in2 : i1, i1
+/// %2 = arc.vectorize (%0), (%1) : (i2, i2) -> i2 {
+/// ^bb0(%arg0: i2, %arg1: i2):
+///   %12 = arith.andi %arg0, %arg1 : i2
+///   arc.vectorize.return %12 : i2
+/// }
+/// %3 = comb.extract %2 from 0 : (i2) -> i1
+/// %4 = comb.extract %2 from 1 : (i2) -> i1
+/// ```
+/// becomes
+/// ```mlir
+/// %0 = comb.concat %in0, %in1 : i1, i1
+/// %1 = comb.concat %in2, %in2 : i1, i1
+/// %2 = arith.andi %0, %1 : i2
+/// %3 = comb.extract %2 from 0 : (i2) -> i1
+/// %4 = comb.extract %2 from 1 : (i2) -> i1
+/// ```
+static LogicalResult inlineBody(VectorizeOp op) {
+  if (!(op.isBodyVectorized() && op.isBoundaryVectorized()))
+    return op->emitError(
+        "can only inline body if boundary and body are already vectorized");
+
+  Block &block = op.getBody().front();
+  for (auto [operand, arg] : llvm::zip(op.getInputs(), block.getArguments()))
+    arg.replaceAllUsesWith(operand.front());
+
+  Operation *terminator = block.getTerminator();
+  op->getResult(0).replaceAllUsesWith(terminator->getOperand(0));
+  terminator->erase();
+
+  op->getBlock()->getOperations().splice(op->getIterator(),
+                                         block.getOperations());
+  op->erase();
+
+  return success();
+}
+
+namespace {
+/// A pass to vectorize (parts of) an `arc.vectorize` operation.
+struct LowerVectorizationsPass
+    : public arc::impl::LowerVectorizationsBase<LowerVectorizationsPass> {
+  LowerVectorizationsPass() = default;
+  explicit LowerVectorizationsPass(LowerVectorizationsModeEnum mode)
+      : LowerVectorizationsPass() {
+    this->mode.setValue(mode);
+  }
+
+  void runOnOperation() override {
+    WalkResult result = getOperation().walk([&](VectorizeOp op) -> WalkResult {
+      switch (mode) {
+      case LowerVectorizationsModeEnum::Full:
+        if (auto newOp = lowerBody(lowerBoundary(op));
+            succeeded(newOp) && succeeded(inlineBody(*newOp)))
+          return WalkResult::advance();
+        return WalkResult::interrupt();
+      case LowerVectorizationsModeEnum::Boundary:
+        return lowerBoundary(op), WalkResult::advance();
+      case LowerVectorizationsModeEnum::Body:
+        return static_cast<LogicalResult>(lowerBody(op));
+      case LowerVectorizationsModeEnum::InlineBody:
+        return inlineBody(op);
+      }
+      llvm_unreachable("all enum cases must be handled above");
+    });
+    if (result.wasInterrupted())
+      signalPassFailure();
+  }
+};
+} // namespace
+
+std::unique_ptr<Pass>
+arc::createLowerVectorizationsPass(LowerVectorizationsModeEnum mode) {
+  return std::make_unique<LowerVectorizationsPass>(mode);
+}

--- a/test/Dialect/Arc/lower-vectorizations-boundary.mlir
+++ b/test/Dialect/Arc/lower-vectorizations-boundary.mlir
@@ -1,0 +1,106 @@
+// RUN: circt-opt %s --arc-lower-vectorizations=mode=boundary -split-input-file | FileCheck %s
+
+hw.module @vectorize(%in0: i1, %in1: i1, %in2: i1, %in3: i1, %in4: i64, %in5: i64, %in6: i32, %in7: i32) -> (out0: i1, out1: i1, out2: i64, out3: i64) {
+  %0:2 = arc.vectorize (%in0, %in1), (%in2, %in3) : (i1, i1, i1, i1) -> (i1, i1) {
+  ^bb0(%arg0: i1, %arg1: i1):
+    %1 = comb.and %arg0, %arg1 : i1
+    arc.vectorize.return %1 : i1
+  }
+  %1:2 = arc.vectorize (%in4, %in5), (%in6, %in6) : (i64, i64, i32, i32) -> (i64, i64) {
+  ^bb0(%arg0: i64, %arg1: i32):
+    %c0_i32 = hw.constant 0 : i32
+    %2 = comb.concat %c0_i32, %arg1 : i32, i32
+    %3 = comb.and %arg0, %2 : i64
+    arc.vectorize.return %3 : i64
+  }
+  hw.output %0#0, %0#1, %1#0, %1#1 : i1, i1, i64, i64
+}
+
+// CHECK-LABEL: hw.module @vectorize
+//  CHECK-SAME: ([[IN0:%.+]]: i1, [[IN1:%.+]]: i1, [[IN2:%.+]]: i1, [[IN3:%.+]]: i1, [[IN4:%.+]]: i64, [[IN5:%.+]]: i64, [[IN6:%.+]]: i32, [[IN7:%.+]]: i32) ->
+//       CHECK: [[V0:%.+]] = comb.concat [[IN0]], [[IN1]] :
+//       CHECK: [[V1:%.+]] = comb.concat [[IN2]], [[IN3]] :
+//       CHECK: [[V2:%.+]] = arc.vectorize ([[V0]]), ([[V1]])
+//       CHECK: ^bb0({{.*}}: i1, {{.*}}: i1):
+//       CHECK: arc.vectorize.return {{.*}} : i1
+//       CHECK: [[V3:%.+]] = comb.extract [[V2]] from 0
+//       CHECK: [[V4:%.+]] = comb.extract [[V2]] from 1
+//       CHECK: [[CST:%.+]] = arith.constant dense<0>
+//       CHECK: [[V5:%.+]] = vector.insert [[IN4]], [[CST]] [0]
+//       CHECK: [[V6:%.+]] = vector.insert [[IN5]], [[V5]] [1]
+//       CHECK: [[V7:%.+]] = vector.broadcast [[IN6]]
+//       CHECK: [[V8:%.+]] = arc.vectorize ([[V6]]), ([[V7]])
+//       CHECK: ^bb0({{.*}}: i64, {{.*}}: i32):
+//       CHECK: arc.vectorize.return {{.*}} : i64
+//       CHECK: [[V9:%.+]] = vector.extract [[V8]][0]
+//       CHECK: [[V10:%.+]] = vector.extract [[V8]][1]
+//       CHECK: hw.output [[V3]], [[V4]], [[V9]], [[V10]]
+
+// -----
+
+hw.module @vectorize_body_already_lowered(%in0: i1, %in1: i1, %in2: i1, %in3: i1) -> (out0: i1, out1: i1, out2: i1, out3: i1) {
+  %0:2 = arc.vectorize (%in0, %in1), (%in2, %in2) : (i1, i1, i1, i1) -> (i1, i1) {
+  ^bb0(%arg0: i2, %arg1: i2):
+    %1 = arith.andi %arg0, %arg1 : i2
+    arc.vectorize.return %1 : i2
+  }
+
+  %1:2 = arc.vectorize (%in0, %in1), (%in2, %in3) : (i1, i1, i1, i1) -> (i1, i1) {
+  ^bb0(%arg0: vector<2xi1>, %arg1: vector<2xi1>):
+    %1 = arith.andi %arg0, %arg1 : vector<2xi1>
+    arc.vectorize.return %1 : vector<2xi1>
+  }
+
+  hw.output %0#0, %0#1, %1#0, %1#1 : i1, i1, i1, i1
+}
+
+// CHECK-LABEL: hw.module @vectorize_body_already_lowered
+//  CHECK-SAME: ([[IN0:%.+]]: i1, [[IN1:%.+]]: i1, [[IN2:%.+]]: i1, [[IN3:%.+]]: i1) ->
+//       CHECK: [[V0:%.+]] = comb.concat [[IN0]], [[IN1]] :
+//       CHECK: [[V1:%.+]] = comb.concat [[IN2]], [[IN2]] :
+//       CHECK: [[V2:%.+]] = arc.vectorize ([[V0]]), ([[V1]])
+//       CHECK: ^bb0({{.*}}: i2, {{.*}}: i2):
+//       CHECK: arc.vectorize.return {{.*}} : i2
+//       CHECK: [[V3:%.+]] = comb.extract [[V2]] from 0
+//       CHECK: [[V4:%.+]] = comb.extract [[V2]] from 1
+//       CHECK: [[CST:%.+]] = arith.constant dense<false>
+//       CHECK: [[V5:%.+]] = vector.insert [[IN0]], [[CST]] [0]
+//       CHECK: [[V6:%.+]] = vector.insert [[IN1]], [[V5]] [1]
+//       CHECK: [[CST:%.+]] = arith.constant dense<false>
+//       CHECK: [[V7:%.+]] = vector.insert [[IN2]], [[CST]] [0]
+//       CHECK: [[V8:%.+]] = vector.insert [[IN3]], [[V7]] [1]
+//       CHECK: [[V9:%.+]] = arc.vectorize ([[V6]]), ([[V8]])
+//       CHECK: ^bb0({{.*}}: vector<2xi1>, {{.*}}: vector<2xi1>):
+//       CHECK: arc.vectorize.return {{.*}} : vector<2xi1>
+//       CHECK: [[V10:%.+]] = vector.extract [[V9]][0]
+//       CHECK: [[V11:%.+]] = vector.extract [[V9]][1]
+//       CHECK: hw.output [[V3]], [[V4]], [[V10]], [[V11]]
+
+// -----
+
+hw.module @boundary_already_vectorized(%in0: i1, %in1: i1, %in2: i1) -> (out0: i1, out1: i1) {
+  %cst = arith.constant dense<0> : vector<2xi1>
+  %0 = vector.insert %in0, %cst[0] : i1 into vector<2xi1>
+  %1 = vector.insert %in1, %0[1] : i1 into vector<2xi1>
+  %2 = vector.broadcast %in2 : i1 to vector<2xi1>
+  %3 = arc.vectorize (%1), (%2) :
+    (vector<2xi1>, vector<2xi1>) -> (vector<2xi1>) {
+  ^bb0(%arg0: i1, %arg1: i1):
+    %4 = arith.andi %arg0, %arg1 : i1
+    arc.vectorize.return %4 : i1
+  }
+  %4 = vector.extract %2[0] : vector<2xi1>
+  %5 = vector.extract %2[1] : vector<2xi1>
+  hw.output %4, %5 : i1, i1
+}
+
+// CHECK-LABEL: hw.module @boundary_already_vectorized
+//  CHECK-SAME: ([[IN0:%.+]]: i1, [[IN1:%.+]]: i1, [[IN2:%.+]]: i1) ->
+//       CHECK:  [[CST:%.+]] = arith.constant dense<false>
+//       CHECK:  [[V0:%.+]] = vector.insert [[IN0]], [[CST]] [0]
+//       CHECK:  [[V1:%.+]] = vector.insert [[IN1]], [[V0]] [1]
+//       CHECK:  [[V2:%.+]] = vector.broadcast [[IN2]]
+//       CHECK:  [[V3:%.+]] = arc.vectorize ([[V1]]), ([[V2]]) :
+//       CHECK:  [[V4:%.+]] = vector.extract [[V2]][0]
+//       CHECK:  [[V5:%.+]] = vector.extract [[V2]][1]
+//       CHECK:  hw.output [[V4]], [[V5]]

--- a/test/Dialect/Arc/lower-vectorizations-full.mlir
+++ b/test/Dialect/Arc/lower-vectorizations-full.mlir
@@ -1,0 +1,35 @@
+// RUN: circt-opt %s --arc-lower-vectorizations=mode=full -split-input-file | FileCheck %s
+
+hw.module @vectorize_body_already_lowered(%in0: i1, %in1: i1, %in2: i1, %in3: i1) -> (out0: i1, out1: i1, out2: i1, out3: i1) {
+  %0:2 = arc.vectorize (%in0, %in1), (%in2, %in2) : (i1, i1, i1, i1) -> (i1, i1) {
+  ^bb0(%arg0: i2, %arg1: i2):
+    %1 = arith.andi %arg0, %arg1 : i2
+    arc.vectorize.return %1 : i2
+  }
+
+  %1:2 = arc.vectorize (%in0, %in1), (%in2, %in3) : (i1, i1, i1, i1) -> (i1, i1) {
+  ^bb0(%arg0: vector<2xi1>, %arg1: vector<2xi1>):
+    %1 = arith.andi %arg0, %arg1 : vector<2xi1>
+    arc.vectorize.return %1 : vector<2xi1>
+  }
+
+  hw.output %0#0, %0#1, %1#0, %1#1 : i1, i1, i1, i1
+}
+
+// CHECK-LABEL: hw.module @vectorize_body_already_lowered
+//  CHECK-SAME: ([[IN0:%.+]]: i1, [[IN1:%.+]]: i1, [[IN2:%.+]]: i1, [[IN3:%.+]]: i1) ->
+//       CHECK: [[V0:%.+]] = comb.concat [[IN0]], [[IN1]] :
+//       CHECK: [[V1:%.+]] = comb.concat [[IN2]], [[IN2]] :
+//       CHECK: [[V2:%.+]] = arith.andi [[V0]], [[V1]]
+//       CHECK: [[V3:%.+]] = comb.extract [[V2]] from 0
+//       CHECK: [[V4:%.+]] = comb.extract [[V2]] from 1
+//       CHECK: [[CST:%.+]] = arith.constant dense<false>
+//       CHECK: [[V5:%.+]] = vector.insert [[IN0]], [[CST]] [0]
+//       CHECK: [[V6:%.+]] = vector.insert [[IN1]], [[V5]] [1]
+//       CHECK: [[CST:%.+]] = arith.constant dense<false>
+//       CHECK: [[V7:%.+]] = vector.insert [[IN2]], [[CST]] [0]
+//       CHECK: [[V8:%.+]] = vector.insert [[IN3]], [[V7]] [1]
+//       CHECK: [[V9:%.+]] = arith.andi [[V6]], [[V8]]
+//       CHECK: [[V10:%.+]] = vector.extract [[V9]][0]
+//       CHECK: [[V11:%.+]] = vector.extract [[V9]][1]
+//       CHECK: hw.output [[V3]], [[V4]], [[V10]], [[V11]]

--- a/test/Dialect/Arc/lower-vectorizations-inline-body.mlir
+++ b/test/Dialect/Arc/lower-vectorizations-inline-body.mlir
@@ -1,0 +1,62 @@
+// RUN: circt-opt %s --arc-lower-vectorizations=mode=inline-body --split-input-file --verify-diagnostics | FileCheck %s
+
+hw.module @inline_body(%in0: i1, %in1: i1, %in2: i1, %in3: i1) -> (out0: i1, out1: i1, out2: i1, out3: i1) {
+  %0 = comb.concat %in0, %in1 : i1, i1
+  %1 = comb.concat %in2, %in2 : i1, i1
+
+  %2 = arc.vectorize (%0), (%1) : (i2, i2) -> i2 {
+  ^bb0(%arg0: i2, %arg1: i2):
+    %12 = arith.andi %arg0, %arg1 : i2
+    arc.vectorize.return %12 : i2
+  }
+
+  %3 = comb.extract %2 from 0 : (i2) -> i1
+  %4 = comb.extract %2 from 1 : (i2) -> i1
+
+  %cst = arith.constant dense<false> : vector<2xi1>
+  %5 = vector.insert %in0, %cst [0] : i1 into vector<2xi1>
+  %6 = vector.insert %in1, %5 [1] : i1 into vector<2xi1>
+  %cst_0 = arith.constant dense<false> : vector<2xi1>
+  %7 = vector.insert %in2, %cst_0 [0] : i1 into vector<2xi1>
+  %8 = vector.insert %in3, %7 [1] : i1 into vector<2xi1>
+
+  %9 = arc.vectorize (%6), (%8) : (vector<2xi1>, vector<2xi1>) -> vector<2xi1> {
+  ^bb0(%arg0: vector<2xi1>, %arg1: vector<2xi1>):
+    %12 = arith.andi %arg0, %arg1 : vector<2xi1>
+    arc.vectorize.return %12 : vector<2xi1>
+  }
+
+  %10 = vector.extract %9[0] : vector<2xi1>
+  %11 = vector.extract %9[1] : vector<2xi1>
+  hw.output %3, %4, %10, %11 : i1, i1, i1, i1
+}
+
+// CHECK-LABEL: hw.module @inline_body
+//  CHECK-SAME: ([[IN0:%.+]]: i1, [[IN1:%.+]]: i1, [[IN2:%.+]]: i1, [[IN3:%.+]]: i1) ->
+//       CHECK: [[V0:%.+]] = comb.concat [[IN0]], [[IN1]] :
+//       CHECK: [[V1:%.+]] = comb.concat [[IN2]], [[IN2]] :
+//       CHECK: [[V2:%.+]] = arith.andi [[V0]], [[V1]]
+//       CHECK: [[V3:%.+]] = comb.extract [[V2]] from 0
+//       CHECK: [[V4:%.+]] = comb.extract [[V2]] from 1
+//       CHECK: [[CST:%.+]] = arith.constant dense<false>
+//       CHECK: [[V5:%.+]] = vector.insert [[IN0]], [[CST]] [0]
+//       CHECK: [[V6:%.+]] = vector.insert [[IN1]], [[V5]] [1]
+//       CHECK: [[CST:%.+]] = arith.constant dense<false>
+//       CHECK: [[V7:%.+]] = vector.insert [[IN2]], [[CST]] [0]
+//       CHECK: [[V8:%.+]] = vector.insert [[IN3]], [[V7]] [1]
+//       CHECK: [[V9:%.+]] = arith.andi [[V6]], [[V8]]
+//       CHECK: [[V10:%.+]] = vector.extract [[V9]][0]
+//       CHECK: [[V11:%.+]] = vector.extract [[V9]][1]
+//       CHECK: hw.output [[V3]], [[V4]], [[V10]], [[V11]]
+
+// -----
+
+hw.module @vectorize(%in0: i1, %in1: i1, %in2: i1, %in3: i1) -> (out0: i1, out1: i1) {
+  // expected-error @below {{can only inline body if boundary and body are already vectorized}}
+  %0:2 = arc.vectorize (%in0, %in1), (%in2, %in3) : (i1, i1, i1, i1) -> (i1, i1) {
+  ^bb0(%arg0: i1, %arg1: i1):
+    %1 = comb.and %arg0, %arg1 : i1
+    arc.vectorize.return %1 : i1
+  }
+  hw.output %0#0, %0#1 : i1, i1
+}


### PR DESCRIPTION
Adds a pass to lower  operations. Currently, only lowering the boundary and inlining the op body is supported. Lowering of the body will be added in a separate commit since that is a bit more complex.