### PR TITLE
[Arc] Allow top-level logic in LowerState; detect clock edges

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -157,7 +157,7 @@ def LowerState : Pass<"arc-lower-state", "mlir::ModuleOp"> {
   let constructor = "circt::arc::createLowerStatePass()";
   let dependentDialects = [
     "arc::ArcDialect", "mlir::scf::SCFDialect", "mlir::func::FuncDialect",
-    "mlir::LLVM::LLVMDialect"
+    "mlir::LLVM::LLVMDialect", "comb::CombDialect"
   ];
 }
 

--- a/test/arcilator/arcilator.mlir
+++ b/test/arcilator/arcilator.mlir
@@ -19,40 +19,47 @@
 
 // CHECK-NOT: hw.module @Top
 // CHECK-LABEL: arc.model "Top" {
-// CHECK-NEXT: ^bb0(%arg0: !arc.storage<6>):
+// CHECK-NEXT: ^bb0(%arg0: !arc.storage<7>):
 hw.module @Top(%clock: !seq.clock, %i0: i4, %i1: i4) -> (out: i4) {
-  // CHECK-DAG: arc.root_input "clock", %arg0 {offset = 0
-  // CHECK-DAG: arc.root_input "i0", %arg0 {offset = 1
-  // CHECK-DAG: arc.root_input "i1", %arg0 {offset = 2
-  // CHECK-DAG: arc.root_output "out", %arg0 {offset = 3
-  // CHECK-DAG: arc.alloc_state %arg0 {name = "foo", offset = 4
-  // CHECK-DAG: arc.alloc_state %arg0 {name = "bar", offset = 5
+  // CHECK-DAG: arc.alloc_state %arg0 {offset = 0 : i32} {{.+}} !arc.state<i1>
+  // CHECK-DAG: arc.alloc_state %arg0 {name = "foo", offset = 1 : i32} {{.+}} !arc.state<i4>
+  // CHECK-DAG: arc.alloc_state %arg0 {name = "bar", offset = 2 : i32} {{.+}} !arc.state<i4>
+  // CHECK-DAG: arc.root_input "clock", %arg0 {offset = 3 : i32} {{.+}} !arc.state<i1>
+  // CHECK-DAG: arc.root_input "i0", %arg0 {offset = 4 : i32} {{.+}} !arc.state<i4>
+  // CHECK-DAG: arc.root_input "i1", %arg0 {offset = 5 : i32} {{.+}} !arc.state<i4>
+  // CHECK-DAG: arc.root_output "out", %arg0 {offset = 6 : i32} {{.+}} !arc.state<i4>
 
-  // CHECK-DAG: arc.passthrough {
-  // CHECK-DAG:   [[FOO:%.+]] = arc.storage.get %arg0[4]
-  // CHECK-DAG:   [[READ_FOO:%.+]] = arc.state_read [[FOO]]
-  // CHECK-DAG:   [[BAR:%.+]] = arc.storage.get %arg0[5]
-  // CHECK-DAG:   [[READ_BAR:%.+]] = arc.state_read [[BAR]]
-  // CHECK-DAG:   [[MUL:%.+]] = arc.state @[[MUL_ARC]]([[READ_FOO]], [[READ_BAR]]) lat 0
-  // CHECK-DAG:   [[PTR_OUT:%.+]] = arc.storage.get %arg0[3]
-  // CHECK-DAG:   arc.state_write [[PTR_OUT]] = [[MUL]]
-  // CHECK-DAG: }
-
-  // CHECK-DAG: [[CLOCK:%.+]] = arc.storage.get %arg0[0]
+  // CHECK-DAG: [[CLOCK:%.+]] = arc.storage.get %arg0[3]
   // CHECK-DAG: [[READ_CLOCK:%.+]] = arc.state_read [[CLOCK]]
-  // CHECK-DAG:  arc.clock_tree [[READ_CLOCK]] {
-  // CHECK-DAG:   [[I0:%.+]] = arc.storage.get %arg0[1]
+  // CHECK-DAG: [[CLOCK_OLD:%.+]] = arc.storage.get %arg0[0]
+  // CHECK-DAG: arc.state_write [[CLOCK_OLD]] = [[READ_CLOCK]]
+  // CHECK-DAG: [[READ_CLOCK_OLD:%.+]] = arc.state_read [[CLOCK_OLD]]
+  // CHECK-NEXT: [[CLOCK_CHANGED:%.+]] = comb.icmp ne [[READ_CLOCK_OLD]], [[READ_CLOCK]] : i1
+  // CHECK-NEXT: [[CLOCK_ROSE:%.+]] = comb.and [[CLOCK_CHANGED]], [[READ_CLOCK]] : i1
+
+  // CHECK-DAG:  arc.clock_tree [[CLOCK_ROSE]] {
+  // CHECK-DAG:   [[I0:%.+]] = arc.storage.get %arg0[4]
   // CHECK-DAG:   [[READ_I0:%.+]] = arc.state_read [[I0]]
-  // CHECK-DAG:   [[I1:%.+]] = arc.storage.get %arg0[2]
+  // CHECK-DAG:   [[I1:%.+]] = arc.storage.get %arg0[5]
   // CHECK-DAG:   [[READ_I1:%.+]] = arc.state_read [[I1]]
   // CHECK-DAG:   [[ADD:%.+]] = arc.state @[[ADD_ARC]]([[READ_I0]], [[READ_I1]]) lat 0
   // CHECK-DAG:   [[XOR1:%.+]] = arc.state @[[XOR_ARC]]([[ADD]], [[READ_I0]]) lat 0
   // CHECK-DAG:   [[XOR2:%.+]] = arc.state @[[XOR_ARC]]([[ADD]], [[READ_I1]]) lat 0
-  // CHECK-DAG:   [[FOO:%.+]] = arc.storage.get %arg0[4]
+  // CHECK-DAG:   [[FOO:%.+]] = arc.storage.get %arg0[1]
   // CHECK-DAG:   arc.state_write [[FOO]] = [[XOR1]]
-  // CHECK-DAG:   [[BAR:%.+]] = arc.storage.get %arg0[5]
+  // CHECK-DAG:   [[BAR:%.+]] = arc.storage.get %arg0[2]
   // CHECK-DAG:   arc.state_write [[BAR]] = [[XOR2]]
   // CHECK-DAG:  }
+
+  // CHECK-DAG: arc.passthrough {
+  // CHECK-DAG:   [[FOO:%.+]] = arc.storage.get %arg0[1]
+  // CHECK-DAG:   [[READ_FOO:%.+]] = arc.state_read [[FOO]]
+  // CHECK-DAG:   [[BAR:%.+]] = arc.storage.get %arg0[2]
+  // CHECK-DAG:   [[READ_BAR:%.+]] = arc.state_read [[BAR]]
+  // CHECK-DAG:   [[MUL:%.+]] = arc.state @[[MUL_ARC]]([[READ_FOO]], [[READ_BAR]]) lat 0
+  // CHECK-DAG:   [[PTR_OUT:%.+]] = arc.storage.get %arg0[6]
+  // CHECK-DAG:   arc.state_write [[PTR_OUT]] = [[MUL]]
+  // CHECK-DAG: }
 
   %0 = comb.add %i0, %i1 : i4
   %1 = comb.xor %0, %i0 : i4
@@ -63,16 +70,16 @@ hw.module @Top(%clock: !seq.clock, %i0: i4, %i1: i4) -> (out: i4) {
   hw.output %3 : i4
 }
 
-// LLVM: define void @Top_passthrough(ptr %0)
-// LLVM:   mul i4
 // LLVM: define void @Top_clock(ptr %0)
 // LLVM:   add i4
 // LLVM:   xor i4
 // LLVM:   xor i4
+// LLVM: define void @Top_passthrough(ptr %0)
+// LLVM:   mul i4
 
-// LLVM-DEBUG: define void @Top_passthrough(ptr %0){{.*}}!dbg
-// LLVM-DEBUG:   mul i4{{.*}}!dbg
 // LLVM-DEBUG: define void @Top_clock(ptr %0){{.*}}!dbg
 // LLVM-DEBUG:   add i4{{.*}}!dbg
 // LLVM-DEBUG:   xor i4{{.*}}!dbg
 // LLVM-DEBUG:   xor i4{{.*}}!dbg
+// LLVM-DEBUG: define void @Top_passthrough(ptr %0){{.*}}!dbg
+// LLVM-DEBUG:   mul i4{{.*}}!dbg


### PR DESCRIPTION
Make the `LowerState` pass allow operations to remain in the top-level `arc.model` op after state lowering. This is necessary for lowering the model op into an `eval` function in the future. Make use of this new flexibility by inserting logic into the model that detects edges on the clocks of the `arc.clock_tree` ops. The clock trees no longer trigger on the clock itself, but are given an "enable" signal that indicates whether a clock edge has been observed.

In the future, we'll want to schedule the ops in the `arc.model` and lower it to a separate `eval` function, instead of throwing it away. In doing so the user will no longer have to manually call clock functions, but can call a singular `eval` function instead. A centralized function that performs model execution will also allow us to properly simulate clock edges occurring at the same time -- something which is impossible today.

Together with the `arc.clock_domain` op, this `eval` function will make the entire clock detection and grouping a performance optimization instead of a required transformation. Theoretically, even if we did not separate state with the same clock into dedicated clock functions, we'll still be able to generate an `eval` function, with all logic inlined. This will ultimately make the Arc dialect more robust and the transforms more composable.

Most of the changes here will become obsolete once we enable the `IsolateClocks` pass, which handles the grouping of operations into a common clock region. At that point `LowerState` should become an almost trivial local lowering.