### PR TITLE
[Ibis] Add `ibis.sblock` inlining operations and passes

### DIFF
--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -239,6 +239,48 @@ def StaticBlockOp : IbisOp<"sblock", [
   ];
 }
 
+def InlineStaticBlockBeginOp : IbisOp<"sblock.inline.begin", [
+  HasParent<"MethodOp">
+]> {
+  let summary = "Ibis inline static block begin marker";
+  let description = [{
+    The `ibis.sblock.inline.begin` operation is a marker that indicates the
+    begin of an inline static block.
+    The operation is used to maintain `ibis.sblocks` while in the Ibis inline
+    phase (to facilitate e.g. mem2reg).
+
+    The operation:
+    1. denotes the begin of the sblock
+    2. carries whatever attributes that the source `ibis.sblock` carried.
+    3. is considered side-effectfull.
+  }];
+
+  let assemblyFormat = "attr-dict";
+  let extraClassDeclaration = [{
+    /// Return the `InlineStaticBlockEndOp` that this operation is referencing.
+    InlineStaticBlockEndOp getEndOp();
+  }];
+}
+
+def InlineStaticBlockEndOp : IbisOp<"sblock.inline.end", [
+  HasParent<"MethodOp">
+]> {
+  let summary = "Ibis inline static block end marker";
+  let description = [{
+    The `ibis.sblock.inline.end` operation is a marker that indicates the
+    end of an inline static block.
+    The operation is used to maintain `ibis.sblocks` while in the Ibis inline
+    phase (to facilitate e.g. mem2reg).
+  }];
+
+  let assemblyFormat = "attr-dict";
+
+  let extraClassDeclaration = [{
+    /// Return the `InlineStaticBlockBeginOp` that this operation is referencing.
+    InlineStaticBlockBeginOp getBeginOp();
+  }];
+}
+
 def BlockReturnOp : IbisOp<"sblock.return", [
   Pure, ReturnLike, Terminator, HasParent<"StaticBlockOp">]> {
   let summary = "Ibis static block terminator";

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -213,7 +213,7 @@ def StaticBlockOp : IbisOp<"sblock", [
 
   let arguments = (ins
     Variadic<AnyType>:$inputs,
-    OptionalAttr<ConfinedAttr<I32Attr, [IntMinValue<1>]>>:$maxThreads
+    OptionalAttr<ConfinedAttr<I64Attr, [IntMinValue<1>]>>:$maxThreads
   );
   let results = (outs Variadic<AnyType>:$outputs);
   let regions = (region SizedRegion<1>:$body);

--- a/include/circt/Dialect/Ibis/IbisPasses.h
+++ b/include/circt/Dialect/Ibis/IbisPasses.h
@@ -32,9 +32,6 @@ std::unique_ptr<Pass> createInlineSBlocksPass();
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/Ibis/IbisPasses.h.inc"
 
-// Returns an ID of an MLIR block, used during the sblock inline/reblock phase.
-size_t blockID(mlir::Block *block);
-
 } // namespace ibis
 } // namespace circt
 

--- a/include/circt/Dialect/Ibis/IbisPasses.h
+++ b/include/circt/Dialect/Ibis/IbisPasses.h
@@ -9,6 +9,7 @@
 #ifndef CIRCT_DIALECT_IBIS_IBISPASSES_H
 #define CIRCT_DIALECT_IBIS_IBISPASSES_H
 
+#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 #include <memory>
@@ -25,10 +26,14 @@ std::unique_ptr<Pass> createCleanSelfdriversPass();
 std::unique_ptr<Pass> createContainersToHWPass();
 std::unique_ptr<Pass> createArgifyBlocksPass();
 std::unique_ptr<Pass> createReblockPass();
+std::unique_ptr<Pass> createInlineSBlocksPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/Ibis/IbisPasses.h.inc"
+
+// Returns an ID of an MLIR block, used during the sblock inline/reblock phase.
+size_t blockID(mlir::Block *block);
 
 } // namespace ibis
 } // namespace circt

--- a/include/circt/Dialect/Ibis/IbisPasses.td
+++ b/include/circt/Dialect/Ibis/IbisPasses.td
@@ -133,4 +133,22 @@ def IbisReblock : Pass<"ibis-reblock", "ibis::MethodOp"> {
   let constructor = "circt::ibis::createReblockPass()";
 }
 
+def IbisInlineSBlocks : Pass<"ibis-inline-sblocks", "ibis::MethodOp"> {
+  let summary = "Inlines `ibis.sblock` operations as MLIR blocks";
+  let description = [{
+    Inlines `ibis.sblock` operations, by creating MLIR blocks and `cf`
+    operations, while adding attributes to the parent operation about
+    `sblock`-specific attributes.
+
+    The parent attributes are located under the `ibis.blockinfo` identifier as
+    a dictionary attribute.
+    Each entry in the dictionary consists of:
+    - Key: an ID (numerical) string identifying the block.
+    - Value: a dictionary of attributes. As a minimum this will contain a
+      `loc`-keyed attribute specifying the location of the block.
+  }];
+  let constructor = "circt::ibis::createInlineSBlocksPass()";
+  let dependentDialects = ["mlir::cf::ControlFlowDialect"];
+}
+
 #endif // CIRCT_DIALECT_IBIS_PASSES_TD

--- a/lib/Dialect/Ibis/IbisOps.cpp
+++ b/lib/Dialect/Ibis/IbisOps.cpp
@@ -642,8 +642,8 @@ void StaticBlockOp::print(OpAsmPrinter &p) {
   parsing_util::printInitializerList(p, getInputs(),
                                      getBodyBlock()->getArguments());
   p.printOptionalArrowTypeList(getResultTypes());
-  p.printOptionalAttrDictWithKeyword(getOperation()->getAttrs(),
-                                     getAttributeNames());
+  p.printOptionalAttrDictWithKeyword(getOperation()->getAttrs());
+  p << ' ';
   p.printRegion(getBody(), /*printEntryBlockArgs=*/false);
 }
 
@@ -663,6 +663,39 @@ LogicalResult BlockReturnOp::verify() {
   }
 
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// InlineStaticBlockEndOp
+//===----------------------------------------------------------------------===//
+
+InlineStaticBlockBeginOp InlineStaticBlockEndOp::getBeginOp() {
+  auto curr = getOperation()->getReverseIterator();
+  Operation *firstOp = &getOperation()->getBlock()->front();
+  while (true) {
+    if (auto beginOp = dyn_cast<InlineStaticBlockBeginOp>(*curr))
+      return beginOp;
+    if (curr.getNodePtr() == firstOp)
+      break;
+    ++curr;
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// InlineStaticBlockBeginOp
+//===----------------------------------------------------------------------===//
+
+InlineStaticBlockEndOp InlineStaticBlockBeginOp::getEndOp() {
+  auto curr = getOperation()->getIterator();
+  auto end = getOperation()->getBlock()->end();
+  while (curr != end) {
+    if (auto endOp = dyn_cast<InlineStaticBlockEndOp>(*curr))
+      return endOp;
+
+    ++curr;
+  }
+  return nullptr;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Ibis/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Ibis/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_circt_dialect_library(CIRCTIbisTransforms
   IbisContainersToHW.cpp
   IbisArgifyBlocksPass.cpp
   IbisReblockPass.cpp
+  IbisInlineSBlocksPass.cpp
 
   DEPENDS
   CIRCTIbisTransformsIncGen

--- a/lib/Dialect/Ibis/Transforms/IbisInlineSBlocksPass.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisInlineSBlocksPass.cpp
@@ -27,10 +27,6 @@ using namespace ibis;
 
 namespace {
 
-static size_t getNumOps(mlir::Block *block) {
-  return std::distance(block->begin(), block->end());
-}
-
 struct InlineSBlocksPass : public IbisInlineSBlocksBase<InlineSBlocksPass> {
   void runOnOperation() override;
 
@@ -44,10 +40,7 @@ struct InlineSBlocksPass : public IbisInlineSBlocksBase<InlineSBlocksPass> {
 
 class InlineSBlocksPattern : public OpConversionPattern<ibis::StaticBlockOp> {
 public:
-  InlineSBlocksPattern(MLIRContext *context,
-                       DenseMap<Block *, DictionaryAttr> &blockAttrMap)
-      : OpConversionPattern<ibis::StaticBlockOp>(context),
-        blockAttrMap(blockAttrMap) {}
+  using OpConversionPattern<ibis::StaticBlockOp>::OpConversionPattern;
   using OpAdaptor =
       typename OpConversionPattern<ibis::StaticBlockOp>::OpAdaptor;
 
@@ -55,65 +48,29 @@ public:
   matchAndRewrite(ibis::StaticBlockOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
-    Block *predBlock = op->getBlock();
-    Block *succBlock =
-        predBlock->splitBlock(std::next(op.getOperation()->getIterator()));
 
-    // Move the body of the ibis.sblock before the successor block.
+    // Start the inline block...
+    auto inlineStart = rewriter.create<ibis::InlineStaticBlockBeginOp>(loc);
+    inlineStart->setAttrs(op->getAttrs());
+
+    // Inline the sblock.
     Block *sblockBody = op.getBodyBlock();
-    sblockBody->moveBefore(succBlock);
     BlockReturnOp ret = cast<BlockReturnOp>(sblockBody->getTerminator());
+    rewriter.inlineBlockBefore(sblockBody, op->getNextNode());
 
     // Replace the ibis.sblock return values with the values that were defined
     // (returned from) within the sblock body, and erase the return op.
     for (auto [res, val] : llvm::zip(op.getResults(), ret.getRetValues()))
-      res.replaceAllUsesWith(val);
-    ret.erase();
+      rewriter.replaceAllUsesWith(res, val);
 
-    // Create control flow from the predecessor block to the sblock body.
-    if (getNumOps(predBlock) == 1) {
-      // Predecessor block only contained the sblock, so we can merge it
-      // with the sblock body.
-      predBlock->getOperations().splice(predBlock->end(),
-                                        sblockBody->getOperations());
-      sblockBody->erase();
-      sblockBody = predBlock;
+    // Close the inline block
+    rewriter.setInsertionPoint(ret);
+    rewriter.create<ibis::InlineStaticBlockEndOp>(loc);
 
-      // Outgoing control flow should start from the end of the merged block.
-      rewriter.setInsertionPointToEnd(predBlock);
-    } else {
-      rewriter.setInsertionPointToEnd(predBlock);
-      rewriter.create<cf::BranchOp>(loc, sblockBody);
-      // Outgoing control flow should start from the end of the sblock body.
-      rewriter.setInsertionPointToEnd(sblockBody);
-    }
-
-    // Create control flow from the sblock body to the successor block.
-    if (getNumOps(succBlock) == 1) {
-      // Successor block only contains a branch, so we can merge it with the
-      // sblock body.
-      sblockBody->getOperations().splice(sblockBody->end(),
-                                         succBlock->getOperations());
-      rewriter.eraseBlock(succBlock);
-    } else {
-      // Successor block contains more than just a branch, so we need to create
-      // a branch to it.
-      rewriter.create<cf::BranchOp>(loc, succBlock);
-    }
-
-    // Add an attribute for the source block location.
-    llvm::SmallVector<NamedAttribute> blockAttrs;
-    blockAttrs.push_back(
-        rewriter.getNamedAttr("loc", static_cast<LocationAttr>(loc)));
-    if (auto maxThreads = op.getMaxThreadsAttr())
-      blockAttrs.push_back(rewriter.getNamedAttr("maxThreads", maxThreads));
-
-    blockAttrMap[sblockBody] = rewriter.getDictionaryAttr(blockAttrs);
+    rewriter.eraseOp(ret);
     rewriter.eraseOp(op);
     return success();
   }
-
-  DenseMap<Block *, DictionaryAttr> &blockAttrMap;
 };
 
 } // anonymous namespace
@@ -121,24 +78,15 @@ public:
 void InlineSBlocksPass::runOnOperation() {
   MethodOp parent = getOperation();
   ConversionTarget target(getContext());
-  target.addLegalDialect<cf::ControlFlowDialect>();
   target.addIllegalOp<ibis::StaticBlockOp>();
-
-  DenseMap<Block *, DictionaryAttr> blockAttrMap;
+  // Mark everything but `ibis.sblock` as legal - we need a legalization pattern
+  // for any possible op that gets inlined from a block.
+  target.markUnknownOpDynamicallyLegal([](Operation *op) { return true; });
   RewritePatternSet patterns(&getContext());
-  patterns.add<InlineSBlocksPattern>(&getContext(), blockAttrMap);
+  patterns.add<InlineSBlocksPattern>(&getContext());
 
   if (failed(applyPartialConversion(parent, target, std::move(patterns))))
     return signalPassFailure();
-
-  // Add block annotations to the parent method op.
-  llvm::SmallVector<NamedAttribute> blockInfo;
-  for (auto [block, attrs] : blockAttrMap)
-    blockInfo.push_back(NamedAttribute(
-        StringAttr::get(&getContext(), std::to_string(blockID(block))), attrs));
-
-  parent->setAttr("ibis.blockinfo",
-                  DictionaryAttr::get(&getContext(), blockInfo));
 }
 
 std::unique_ptr<Pass> circt::ibis::createInlineSBlocksPass() {

--- a/lib/Dialect/Ibis/Transforms/IbisInlineSBlocksPass.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisInlineSBlocksPass.cpp
@@ -29,13 +29,6 @@ namespace {
 
 struct InlineSBlocksPass : public IbisInlineSBlocksBase<InlineSBlocksPass> {
   void runOnOperation() override;
-
-  // Inlines an ibis.sblock into the CFG of the parent block.
-  // Will attempt to reduce the number of empty blocks (i.e. blocks only
-  // containing branches to other blocks) - this is imperative, since region
-  // simplification is not allowed to run after this pass.
-  void inlineSBlock(OpBuilder &b, ibis::StaticBlockOp op,
-                    DenseMap<Block *, DictionaryAttr> &blockAttrMap);
 };
 
 class InlineSBlocksPattern : public OpConversionPattern<ibis::StaticBlockOp> {

--- a/lib/Dialect/Ibis/Transforms/IbisInlineSBlocksPass.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisInlineSBlocksPass.cpp
@@ -27,6 +27,10 @@ using namespace ibis;
 
 namespace {
 
+static size_t getNumOps(mlir::Block *block) {
+  return std::distance(block->begin(), block->end());
+}
+
 struct InlineSBlocksPass : public IbisInlineSBlocksBase<InlineSBlocksPass> {
   void runOnOperation() override;
 
@@ -37,93 +41,104 @@ struct InlineSBlocksPass : public IbisInlineSBlocksBase<InlineSBlocksPass> {
   void inlineSBlock(OpBuilder &b, ibis::StaticBlockOp op,
                     DenseMap<Block *, DictionaryAttr> &blockAttrMap);
 };
+
+class InlineSBlocksPattern : public OpConversionPattern<ibis::StaticBlockOp> {
+public:
+  InlineSBlocksPattern(MLIRContext *context,
+                       DenseMap<Block *, DictionaryAttr> &blockAttrMap)
+      : OpConversionPattern<ibis::StaticBlockOp>(context),
+        blockAttrMap(blockAttrMap) {}
+  using OpAdaptor =
+      typename OpConversionPattern<ibis::StaticBlockOp>::OpAdaptor;
+
+  LogicalResult
+  matchAndRewrite(ibis::StaticBlockOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Block *predBlock = op->getBlock();
+    Block *succBlock =
+        predBlock->splitBlock(std::next(op.getOperation()->getIterator()));
+
+    // Move the body of the ibis.sblock before the successor block.
+    Block *sblockBody = op.getBodyBlock();
+    sblockBody->moveBefore(succBlock);
+    BlockReturnOp ret = cast<BlockReturnOp>(sblockBody->getTerminator());
+
+    // Replace the ibis.sblock return values with the values that were defined
+    // (returned from) within the sblock body, and erase the return op.
+    for (auto [res, val] : llvm::zip(op.getResults(), ret.getRetValues()))
+      res.replaceAllUsesWith(val);
+    ret.erase();
+
+    // Create control flow from the predecessor block to the sblock body.
+    if (getNumOps(predBlock) == 1) {
+      // Predecessor block only contained the sblock, so we can merge it
+      // with the sblock body.
+      predBlock->getOperations().splice(predBlock->end(),
+                                        sblockBody->getOperations());
+      sblockBody->erase();
+      sblockBody = predBlock;
+
+      // Outgoing control flow should start from the end of the merged block.
+      rewriter.setInsertionPointToEnd(predBlock);
+    } else {
+      rewriter.setInsertionPointToEnd(predBlock);
+      rewriter.create<cf::BranchOp>(loc, sblockBody);
+      // Outgoing control flow should start from the end of the sblock body.
+      rewriter.setInsertionPointToEnd(sblockBody);
+    }
+
+    // Create control flow from the sblock body to the successor block.
+    if (getNumOps(succBlock) == 1) {
+      // Successor block only contains a branch, so we can merge it with the
+      // sblock body.
+      sblockBody->getOperations().splice(sblockBody->end(),
+                                         succBlock->getOperations());
+      rewriter.eraseBlock(succBlock);
+    } else {
+      // Successor block contains more than just a branch, so we need to create
+      // a branch to it.
+      rewriter.create<cf::BranchOp>(loc, succBlock);
+    }
+
+    // Add an attribute for the source block location.
+    llvm::SmallVector<NamedAttribute> blockAttrs;
+    blockAttrs.push_back(
+        rewriter.getNamedAttr("loc", static_cast<LocationAttr>(loc)));
+    if (auto maxThreads = op.getMaxThreadsAttr())
+      blockAttrs.push_back(rewriter.getNamedAttr("maxThreads", maxThreads));
+
+    blockAttrMap[sblockBody] = rewriter.getDictionaryAttr(blockAttrs);
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+  DenseMap<Block *, DictionaryAttr> &blockAttrMap;
+};
+
 } // anonymous namespace
 
 void InlineSBlocksPass::runOnOperation() {
   MethodOp parent = getOperation();
-  // @mortbopet: Would use a PatternRewriter here, if not for the fact that
-  // lowering ibis.sblocks modifies the parent operations' attributes, which
-  // would be illegal.
-  // In the future, if we want speedup here, we could consider introducing
-  // either auxilary information-carrying ops within each block, or look into
-  // adding upstream support for block attributes.
+  ConversionTarget target(getContext());
+  target.addLegalDialect<cf::ControlFlowDialect>();
+  target.addIllegalOp<ibis::StaticBlockOp>();
+
   DenseMap<Block *, DictionaryAttr> blockAttrMap;
-  OpBuilder b(parent);
-  for (auto StaticBlockOp :
-       llvm::make_early_inc_range(parent.getOps<ibis::StaticBlockOp>()))
-    inlineSBlock(b, StaticBlockOp, blockAttrMap);
+  RewritePatternSet patterns(&getContext());
+  patterns.add<InlineSBlocksPattern>(&getContext(), blockAttrMap);
+
+  if (failed(applyPartialConversion(parent, target, std::move(patterns))))
+    return signalPassFailure();
 
   // Add block annotations to the parent method op.
   llvm::SmallVector<NamedAttribute> blockInfo;
   for (auto [block, attrs] : blockAttrMap)
-    blockInfo.push_back(b.getNamedAttr(std::to_string(blockID(block)), attrs));
+    blockInfo.push_back(NamedAttribute(
+        StringAttr::get(&getContext(), std::to_string(blockID(block))), attrs));
 
-  parent->setAttr("ibis.blockinfo", b.getDictionaryAttr(blockInfo));
-}
-
-static size_t getNumOps(mlir::Block *block) {
-  return std::distance(block->begin(), block->end());
-}
-
-void InlineSBlocksPass::inlineSBlock(
-    OpBuilder &b, ibis::StaticBlockOp op,
-    DenseMap<Block *, DictionaryAttr> &blockAttrMap) {
-  b.setInsertionPoint(op);
-  Location loc = op.getLoc();
-  Block *predBlock = op->getBlock();
-  Block *succBlock =
-      predBlock->splitBlock(std::next(op.getOperation()->getIterator()));
-
-  // Move the body of the ibis.sblock before the successor block.
-  Block *sblockBody = op.getBodyBlock();
-  sblockBody->moveBefore(succBlock);
-  BlockReturnOp ret = cast<BlockReturnOp>(sblockBody->getTerminator());
-
-  // Replace the ibis.sblock return values with the values that were defined
-  // (returned from) within the sblock body, and erase the return op.
-  for (auto [res, val] : llvm::zip(op.getResults(), ret.getRetValues()))
-    res.replaceAllUsesWith(val);
-  ret.erase();
-
-  // Create control flow from the predecessor block to the sblock body.
-  if (getNumOps(predBlock) == 1) {
-    // Predecessor block only contained the sblock, so we can merge it
-    // with the sblock body.
-    predBlock->getOperations().splice(predBlock->end(),
-                                      sblockBody->getOperations());
-    sblockBody->erase();
-    sblockBody = predBlock;
-
-    // Outgoing control flow should start from the end of the merged block.
-    b.setInsertionPointToEnd(predBlock);
-  } else {
-    b.setInsertionPointToEnd(predBlock);
-    b.create<cf::BranchOp>(loc, sblockBody);
-    // Outgoing control flow should start from the end of the sblock body.
-    b.setInsertionPointToEnd(sblockBody);
-  }
-
-  // Create control flow from the sblock body to the successor block.
-  if (getNumOps(succBlock) == 1) {
-    // Successor block only contains a branch, so we can merge it with the
-    // sblock body.
-    sblockBody->getOperations().splice(sblockBody->end(),
-                                       succBlock->getOperations());
-    succBlock->erase();
-  } else {
-    // Successor block contains more than just a branch, so we need to create
-    // a branch to it.
-    b.create<cf::BranchOp>(loc, succBlock);
-  }
-
-  // Add an attribute for the source block location.
-  llvm::SmallVector<NamedAttribute> blockAttrs;
-  blockAttrs.push_back(b.getNamedAttr("loc", static_cast<LocationAttr>(loc)));
-  if (auto maxThreads = op.getMaxThreadsAttr())
-    blockAttrs.push_back(b.getNamedAttr("maxThreads", maxThreads));
-
-  blockAttrMap[sblockBody] = b.getDictionaryAttr(blockAttrs);
-  op.erase();
+  parent->setAttr("ibis.blockinfo",
+                  DictionaryAttr::get(&getContext(), blockInfo));
 }
 
 std::unique_ptr<Pass> circt::ibis::createInlineSBlocksPass() {

--- a/lib/Dialect/Ibis/Transforms/IbisInlineSBlocksPass.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisInlineSBlocksPass.cpp
@@ -1,0 +1,131 @@
+//===- IbisInlineSBlocksPass.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+#include "circt/Dialect/Ibis/IbisDialect.h"
+#include "circt/Dialect/Ibis/IbisOps.h"
+#include "circt/Dialect/Ibis/IbisPasses.h"
+#include "circt/Dialect/Ibis/IbisTypes.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+
+#include "circt/Transforms/Passes.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include <iterator>
+
+using namespace mlir;
+using namespace circt;
+using namespace ibis;
+
+namespace {
+
+struct InlineSBlocksPass : public IbisInlineSBlocksBase<InlineSBlocksPass> {
+  void runOnOperation() override;
+
+  // Inlines an ibis.sblock into the CFG of the parent block.
+  // Will attempt to reduce the number of empty blocks (i.e. blocks only
+  // containing branches to other blocks) - this is imperative, since region
+  // simplification is not allowed to run after this pass.
+  void inlineSBlock(OpBuilder &b, ibis::StaticBlockOp op,
+                    DenseMap<Block *, DictionaryAttr> &blockAttrMap);
+};
+} // anonymous namespace
+
+void InlineSBlocksPass::runOnOperation() {
+  MethodOp parent = getOperation();
+  // @mortbopet: Would use a PatternRewriter here, if not for the fact that
+  // lowering ibis.sblocks modifies the parent operations' attributes, which
+  // would be illegal.
+  // In the future, if we want speedup here, we could consider introducing
+  // either auxilary information-carrying ops within each block, or look into
+  // adding upstream support for block attributes.
+  DenseMap<Block *, DictionaryAttr> blockAttrMap;
+  OpBuilder b(parent);
+  for (auto StaticBlockOp :
+       llvm::make_early_inc_range(parent.getOps<ibis::StaticBlockOp>()))
+    inlineSBlock(b, StaticBlockOp, blockAttrMap);
+
+  // Add block annotations to the parent method op.
+  llvm::SmallVector<NamedAttribute> blockInfo;
+  for (auto [block, attrs] : blockAttrMap)
+    blockInfo.push_back(b.getNamedAttr(std::to_string(blockID(block)), attrs));
+
+  parent->setAttr("ibis.blockinfo", b.getDictionaryAttr(blockInfo));
+}
+
+static size_t getNumOps(mlir::Block *block) {
+  return std::distance(block->begin(), block->end());
+}
+
+void InlineSBlocksPass::inlineSBlock(
+    OpBuilder &b, ibis::StaticBlockOp op,
+    DenseMap<Block *, DictionaryAttr> &blockAttrMap) {
+  b.setInsertionPoint(op);
+  Location loc = op.getLoc();
+  Block *predBlock = op->getBlock();
+  Block *succBlock =
+      predBlock->splitBlock(std::next(op.getOperation()->getIterator()));
+
+  // Move the body of the ibis.sblock before the successor block.
+  Block *sblockBody = op.getBodyBlock();
+  sblockBody->moveBefore(succBlock);
+  BlockReturnOp ret = cast<BlockReturnOp>(sblockBody->getTerminator());
+
+  // Replace the ibis.sblock return values with the values that were defined
+  // (returned from) within the sblock body, and erase the return op.
+  for (auto [res, val] : llvm::zip(op.getResults(), ret.getRetValues()))
+    res.replaceAllUsesWith(val);
+  ret.erase();
+
+  // Create control flow from the predecessor block to the sblock body.
+  if (getNumOps(predBlock) == 1) {
+    // Predecessor block only contained the sblock, so we can merge it
+    // with the sblock body.
+    predBlock->getOperations().splice(predBlock->end(),
+                                      sblockBody->getOperations());
+    sblockBody->erase();
+    sblockBody = predBlock;
+
+    // Outgoing control flow should start from the end of the merged block.
+    b.setInsertionPointToEnd(predBlock);
+  } else {
+    b.setInsertionPointToEnd(predBlock);
+    b.create<cf::BranchOp>(loc, sblockBody);
+    // Outgoing control flow should start from the end of the sblock body.
+    b.setInsertionPointToEnd(sblockBody);
+  }
+
+  // Create control flow from the sblock body to the successor block.
+  if (getNumOps(succBlock) == 1) {
+    // Successor block only contains a branch, so we can merge it with the
+    // sblock body.
+    sblockBody->getOperations().splice(sblockBody->end(),
+                                       succBlock->getOperations());
+    succBlock->erase();
+  } else {
+    // Successor block contains more than just a branch, so we need to create
+    // a branch to it.
+    b.create<cf::BranchOp>(loc, succBlock);
+  }
+
+  // Add an attribute for the source block location.
+  llvm::SmallVector<NamedAttribute> blockAttrs;
+  blockAttrs.push_back(b.getNamedAttr("loc", static_cast<LocationAttr>(loc)));
+  if (auto maxThreads = op.getMaxThreadsAttr())
+    blockAttrs.push_back(b.getNamedAttr("maxThreads", maxThreads));
+
+  blockAttrMap[sblockBody] = b.getDictionaryAttr(blockAttrs);
+  op.erase();
+}
+
+std::unique_ptr<Pass> circt::ibis::createInlineSBlocksPass() {
+  return std::make_unique<InlineSBlocksPass>();
+}

--- a/lib/Dialect/Ibis/Transforms/IbisReblockPass.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisReblockPass.cpp
@@ -16,131 +16,98 @@
 #include "circt/Transforms/Passes.h"
 #include "mlir/Transforms/DialectConversion.h"
 
-#include <iterator>
-
 using namespace circt;
 using namespace ibis;
-
-size_t circt::ibis::blockID(mlir::Block *block) {
-  return std::distance(block->getParent()->front().getIterator(),
-                       block->getIterator());
-}
 
 namespace {
 
 struct ReblockPass : public IbisReblockBase<ReblockPass> {
   void runOnOperation() override;
 
-  LogicalResult reblock(Block &block, DictionaryAttr blockInfo);
+  LogicalResult reblock(ibis::InlineStaticBlockBeginOp);
 };
 } // anonymous namespace
 
 void ReblockPass::runOnOperation() {
   MethodOp parent = getOperation();
-  auto &region = parent.getRegion();
-  // Fetch the 'ibis.blockinfo' attribute from the parent operation. This will
-  // contain information tagged to each MLIR block which needs to be propagated
-  // to the corresponding ibis.sblock operations.
-  auto blockInfoAttr = parent->getAttrOfType<DictionaryAttr>("ibis.blockinfo");
-
-  if (!blockInfoAttr) {
-    parent->emitOpError("missing 'ibis.blockinfo' attribute");
-    return signalPassFailure();
-  }
+  Region &region = parent.getRegion();
 
   if (!isRegionSSAMaximized(region)) {
     parent->emitOpError() << "region is not in maximal SSA form";
     return signalPassFailure();
   }
 
-  for (Block &block : region.getBlocks()) {
-    DictionaryAttr blockInfo =
-        blockInfoAttr.getAs<DictionaryAttr>(Twine(blockID(&block)).str());
-
-    if (!blockInfo) {
-      parent->emitOpError("missing 'ibis.blockinfo' attribute for block " +
-                          Twine(blockID(&block)));
-      return signalPassFailure();
-    }
-
-    if (failed(reblock(block, blockInfo)))
+  for (auto blockBeginOp : llvm::make_early_inc_range(
+           parent.getOps<ibis::InlineStaticBlockBeginOp>())) {
+    if (failed(reblock(blockBeginOp)))
       return signalPassFailure();
   }
 }
 
-LogicalResult ReblockPass::reblock(mlir::Block &block,
-                                   DictionaryAttr blockInfo) {
-  // Record whether an ibis.call was found in this block
-  bool hadCall = false;
-  llvm::SmallVector<Operation *> blockOps;
-  Operation *terminator = block.getTerminator();
-  for (Operation &op : block.getOperations()) {
-    if (&op == terminator)
-      continue;
+LogicalResult ReblockPass::reblock(ibis::InlineStaticBlockBeginOp beginOp) {
+  // Determine which values we need to return from within the block scope.
+  // This is done by collecting all values defined within the start/end scope,
+  // and recording uses that exist outside of the scope.
+  ibis::InlineStaticBlockEndOp endOp = beginOp.getEndOp();
+  assert(endOp);
 
-    hadCall |= isa<CallOp>(op);
-    blockOps.push_back(&op);
+  auto startIt = beginOp->getIterator();
+  auto endIt = endOp->getIterator();
+
+  auto usedOutsideBlock = [&](OpOperand &use) {
+    Operation *owner = use.getOwner();
+    bool isBefore = owner->isBeforeInBlock(beginOp);
+    bool isAfter = isBefore ? false : endOp->isBeforeInBlock(owner);
+    return isBefore || isAfter;
+  };
+
+  llvm::MapVector<Value, llvm::SmallVector<OpOperand *>> returnValueUses;
+  for (auto &op : llvm::make_range(startIt, endIt)) {
+    for (Value result : op.getResults()) {
+      for (OpOperand &use : result.getUses())
+        if (usedOutsideBlock(use))
+          returnValueUses[result].push_back(&use);
+    }
   }
 
-  if (hadCall && blockOps.size() > 1)
-    return block.getParentOp()->emitError(
-        "a block has both calls and other ops");
-
-  if (hadCall) {
-    // Nothing to do - call ops are themselves considered control-passing
-    // operations.
-    return success();
-  }
-
-  // Given that we're in maximum SSA form, the only values we need to return
-  // from within the block are values used by the terminator, if they're not
-  // already block arguments.
-
-  // Maintain a mapping between the value used by the terminator and the
-  // OpOperands that holds said value.
-  llvm::MapVector<Value, llvm::SmallVector<OpOperand *>> terminatorOperands;
-  for (auto &operand : terminator->getOpOperands()) {
-    if (operand.get().isa<BlockArgument>())
-      continue;
-    terminatorOperands[operand.get()].push_back(&operand);
-  }
-
-  // The above de-aliased multiple-returns of the same value. We now gather
-  // the set of types that needs to be returned from within the block.
+  // Gather the set of types that needs to be returned from within the block.
   llvm::SmallVector<Type> blockRetTypes;
-  llvm::SmallVector<Value> blockReturnValues;
-  for (auto &[v, _] : terminatorOperands) {
-    blockReturnValues.push_back(v);
+  llvm::SmallVector<Value> blockRetValues;
+  for (auto &[v, _] : returnValueUses) {
     blockRetTypes.push_back(v.getType());
+    blockRetValues.push_back(v);
   }
 
-  auto b = OpBuilder::atBlockBegin(&block);
+  auto b = OpBuilder(beginOp);
 
   // Lookup block location from the block info.
-  auto loc = blockInfo.getAs<LocationAttr>("loc");
-  if (!loc) {
-    block.getParentOp()->emitError("missing 'loc' attribute for block");
-    return failure();
-  }
-  auto ibisBlock = b.create<StaticBlockOp>(loc, blockRetTypes, ValueRange{});
+  auto ibisBlock =
+      b.create<StaticBlockOp>(beginOp.getLoc(), blockRetTypes, ValueRange{});
+
+  // The new `ibis.sblock` should inherit the attributes of the block begin op.
+  ibisBlock->setAttrs(beginOp->getAttrs());
 
   // Move operations into the `ibis.sblock` op.
   BlockReturnOp blockReturn =
       cast<BlockReturnOp>(ibisBlock.getBodyBlock()->getTerminator());
 
-  for (auto *op : blockOps)
-    op->moveBefore(blockReturn);
+  for (auto &op : llvm::make_early_inc_range(llvm::make_range(startIt, endIt)))
+    op.moveBefore(blockReturn);
 
   // Append the terminator operands to the block return.
-  blockReturn->setOperands(blockReturnValues);
+  blockReturn->setOperands(blockRetValues);
 
-  // Replace the basic block terminator operands with the block return values.
-  for (auto [blockRet, termOperands] :
-       llvm::zip(ibisBlock.getResults(), terminatorOperands)) {
-    for (auto *termOperand : termOperands.second)
-      termOperand->set(blockRet);
+  // Replace the uses of the returned values outside of the block with the
+  // block return values.
+  for (auto [blockRet, innerDefAndUses] :
+       llvm::zip(ibisBlock.getResults(), returnValueUses)) {
+    auto &uses = std::get<1>(innerDefAndUses);
+    for (OpOperand *use : uses)
+      use->set(blockRet);
   }
-
+  // Erase the start/end ops.
+  beginOp.erase();
+  endOp.erase();
   return success();
 }
 

--- a/lib/Dialect/Ibis/Transforms/IbisReblockPass.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisReblockPass.cpp
@@ -21,6 +21,11 @@
 using namespace circt;
 using namespace ibis;
 
+size_t circt::ibis::blockID(mlir::Block *block) {
+  return std::distance(block->getParent()->front().getIterator(),
+                       block->getIterator());
+}
+
 namespace {
 
 struct ReblockPass : public IbisReblockBase<ReblockPass> {
@@ -48,17 +53,13 @@ void ReblockPass::runOnOperation() {
     return signalPassFailure();
   }
 
-  auto blockID = [&](Block &block) {
-    return std::distance(region.front().getIterator(), block.getIterator());
-  };
-
   for (Block &block : region.getBlocks()) {
     DictionaryAttr blockInfo =
-        blockInfoAttr.getAs<DictionaryAttr>(Twine(blockID(block)).str());
+        blockInfoAttr.getAs<DictionaryAttr>(Twine(blockID(&block)).str());
 
     if (!blockInfo) {
       parent->emitOpError("missing 'ibis.blockinfo' attribute for block " +
-                          Twine(blockID(block)));
+                          Twine(blockID(&block)));
       return signalPassFailure();
     }
 

--- a/test/Dialect/Ibis/Transforms/argify_blocks.mlir
+++ b/test/Dialect/Ibis/Transforms/argify_blocks.mlir
@@ -4,7 +4,7 @@
 // CHECK-NEXT:   %this = ibis.this @Argify 
 // CHECK-NEXT:   ibis.method @foo() {
 // CHECK-NEXT:     %c32_i32 = hw.constant 32 : i32
-// CHECK-NEXT:     %0:2 = ibis.sblock (%arg0 : i32 = %c32_i32) -> (i32, i32){
+// CHECK-NEXT:     %0:2 = ibis.sblock (%arg0 : i32 = %c32_i32) -> (i32, i32) {
 // CHECK-NEXT:       %c31_i32 = hw.constant 31 : i32
 // CHECK-NEXT:       %1 = arith.addi %arg0, %c31_i32 : i32
 // CHECK-NEXT:       ibis.sblock.return %1, %arg0 : i32, i32

--- a/test/Dialect/Ibis/Transforms/inline_sblocks.mlir
+++ b/test/Dialect/Ibis/Transforms/inline_sblocks.mlir
@@ -1,0 +1,100 @@
+// RUN: circt-opt %s --pass-pipeline='builtin.module(ibis.class(ibis.method(ibis-inline-sblocks)))' --allow-unregistered-dialect | FileCheck %s
+
+// CHECK: #[[$ATTR_0:.+]] = loc("foo")
+// CHECK: #[[$ATTR_1:.+]] = loc("bar")
+
+// CHECK-LABEL:   ibis.class @Inline1 {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @Inline1
+// CHECK:           ibis.method @foo(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) attributes {ibis.blockinfo = {"0" = {loc = #[[$ATTR_0]], maxThreads = 1 : i64}}} {
+// CHECK:             %[[VAL_3:.*]] = "foo.op1"(%[[VAL_1]], %[[VAL_2]]) : (i32, i32) -> i32
+// CHECK:             ibis.return
+// CHECK:           }
+// CHECK:         }
+ibis.class @Inline1 {
+  %this = ibis.this @Inline1
+
+  ibis.method @foo(%a : i32, %b : i32) {
+    %0 = ibis.sblock() -> (i32) attributes {maxThreads = 1} {
+      %res = "foo.op1"(%a, %b) : (i32, i32) -> i32
+      ibis.sblock.return %res : i32
+    } loc("foo")
+    ibis.return
+  }
+}
+
+// CHECK-LABEL:   ibis.class @Inline2 {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @Inline2
+// CHECK:           ibis.method @foo(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) attributes {ibis.blockinfo = {"0" = {loc = #[[$ATTR_0]], maxThreads = 1 : i64}, "1" = {loc = #[[$ATTR_1]]}}} {
+// CHECK:             %[[VAL_3:.*]] = "foo.op1"(%[[VAL_1]], %[[VAL_2]]) : (i32, i32) -> i32
+// CHECK:             cf.br ^bb1
+// CHECK:           ^bb1:
+// CHECK:             %[[VAL_4:.*]] = "foo.op2"(%[[VAL_3]], %[[VAL_1]]) : (i32, i32) -> i32
+// CHECK:             ibis.return
+// CHECK:           }
+// CHECK:         }
+ibis.class @Inline2 {
+  %this = ibis.this @Inline2
+
+  // Given the "simple" blocks (i.e. the ibis.sblock is the entirety of the MLIR
+  // block), we should see that no superflous MLIR blocks are created.
+  ibis.method @foo(%a : i32, %b : i32) {
+    %0 = ibis.sblock() -> (i32) attributes {maxThreads = 1} {
+      %res = "foo.op1"(%a, %b) : (i32, i32) -> i32
+      ibis.sblock.return %res : i32
+    } loc("foo")
+    cf.br ^bb1
+  ^bb1:
+    %1 = ibis.sblock() -> (i32) {
+      %res = "foo.op2"(%0, %a) : (i32, i32) -> i32
+      ibis.sblock.return %res : i32
+    } loc("bar")
+    ibis.return
+  }
+}
+
+
+// CHECK-LABEL:   ibis.class @Inline3 {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @Inline3
+// CHECK:           ibis.method @foo(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) attributes {ibis.blockinfo = {"1" = {loc = #[[$ATTR_0]], maxThreads = 1 : i64}, "4" = {loc = #[[$ATTR_1]]}}} {
+// CHECK:             "foo.unused1"() : () -> ()
+// CHECK:             cf.br ^bb1
+// CHECK:           ^bb1:
+// CHECK:             %[[VAL_3:.*]] = "foo.op1"(%[[VAL_1]], %[[VAL_2]]) : (i32, i32) -> i32
+// CHECK:             cf.br ^bb2
+// CHECK:           ^bb2:
+// CHECK:             "foo.unused2"() : () -> ()
+// CHECK:             cf.br ^bb3
+// CHECK:           ^bb3:
+// CHECK:             "foo.unused3"() : () -> ()
+// CHECK:             cf.br ^bb4
+// CHECK:           ^bb4:
+// CHECK:             %[[VAL_4:.*]] = "foo.op2"(%[[VAL_3]], %[[VAL_1]]) : (i32, i32) -> i32
+// CHECK:             cf.br ^bb5
+// CHECK:           ^bb5:
+// CHECK:             "foo.unused4"() : () -> ()
+// CHECK:             ibis.return
+// CHECK:           }
+// CHECK:         }
+ibis.class @Inline3 {
+  %this = ibis.this @Inline3
+
+  // Opposite to the above, we have extra ops surrounding the ibis.sblock,
+  // which requires the addition of new MLIR blocks and cf ops.
+  ibis.method @foo(%a : i32, %b : i32) {
+    "foo.unused1"() : () -> ()
+    %0 = ibis.sblock() -> (i32) attributes {maxThreads = 1} {
+      %res = "foo.op1"(%a, %b) : (i32, i32) -> i32
+      ibis.sblock.return %res : i32
+    } loc("foo")
+    "foo.unused2"() : () -> ()
+    cf.br ^bb1
+  ^bb1:
+    "foo.unused3"() : () -> ()
+    %1 = ibis.sblock() -> (i32) {
+      %res = "foo.op2"(%0, %a) : (i32, i32) -> i32
+      ibis.sblock.return %res : i32
+    } loc("bar")
+    "foo.unused4"() : () -> ()
+    ibis.return
+  }
+}

--- a/test/Dialect/Ibis/Transforms/reblock.mlir
+++ b/test/Dialect/Ibis/Transforms/reblock.mlir
@@ -1,66 +1,25 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(ibis.class(ibis.method(ibis-reblock)))' %s | FileCheck %s
 
-// CHECK: #[[$ATTR_0:.+]] = loc("dummy":0:0)
-
-// CHECK-LABEL:   ibis.class @Argify {
-// CHECK:           %[[VAL_0:.*]] = ibis.this @Argify
-// CHECK:           ibis.method @bar(%[[VAL_1:.*]]: i32) -> i32 attributes {ibis.blockinfo = {"0" = {loc = #[[$ATTR_0]]}}} {
-// CHECK:             ibis.sblock (){
-// CHECK:               ibis.sblock.return
-// CHECK:             }
-// CHECK:             ibis.return %[[VAL_1]] : i32
-// CHECK:           }
-// CHECK:           ibis.method @foo(%[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32) -> i32 attributes {ibis.blockinfo = {"0" = {loc = #[[$ATTR_0]]}, "1" = {loc = #[[$ATTR_0]]}, "2" = {loc = #[[$ATTR_0]]}}} {
-// CHECK:             %[[VAL_4:.*]] = ibis.sblock () -> i32{
-// CHECK:               %[[VAL_5:.*]] = arith.addi %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-LABEL:   ibis.class @Reblock {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @Reblock
+// CHECK:           ibis.method @foo(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) -> i32 {
+// CHECK:             %[[VAL_3:.*]] = ibis.sblock () -> i32 attributes {maxThreads = 2 : i64} {
+// CHECK:               %[[VAL_4:.*]] = arith.addi %[[VAL_1]], %[[VAL_2]] : i32
+// CHECK:               %[[VAL_5:.*]] = arith.addi %[[VAL_4]], %[[VAL_2]] : i32
 // CHECK:               ibis.sblock.return %[[VAL_5]] : i32
 // CHECK:             }
-// CHECK:             cf.br ^bb1(%[[VAL_2]], %[[VAL_4]] : i32, i32)
-// CHECK:           ^bb1(%[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32):
-// CHECK:             %[[VAL_8:.*]] = ibis.call @bar(%[[VAL_6]]) : (i32) -> i32
-// CHECK:             cf.br ^bb2(%[[VAL_6]], %[[VAL_8]] : i32, i32)
-// CHECK:           ^bb2(%[[VAL_9:.*]]: i32, %[[VAL_10:.*]]: i32):
-// CHECK:             %[[VAL_11:.*]] = ibis.sblock () -> i32{
-// CHECK:               %[[VAL_12:.*]] = arith.addi %[[VAL_10]], %[[VAL_9]] : i32
-// CHECK:               ibis.sblock.return %[[VAL_12]] : i32
-// CHECK:             }
-// CHECK:             ibis.return %[[VAL_11]] : i32
+// CHECK:             ibis.return %[[VAL_3]] : i32
 // CHECK:           }
 // CHECK:         }
 
-ibis.class @Argify {
-  %this = ibis.this @Argify
+ibis.class @Reblock {
+  %this = ibis.this @Reblock
 
-  ibis.method @bar(%arg0 : i32) -> i32 attributes {
-    "ibis.blockinfo" = {
-      "0" = {
-        "loc" = loc("dummy":0:0)
-      }
-    }
-  } {
-    ibis.return %arg0 : i32
-  }
-
-  ibis.method @foo(%arg0 : i32, %arg1 : i32) -> i32 attributes {
-    "ibis.blockinfo" = {
-      "0" = {
-        "loc" = loc("dummy":0:0)
-      },
-      "1" = {
-        "loc" = loc("dummy":0:0)
-      },
-      "2" = {
-        "loc" = loc("dummy":0:0)
-      }
-    }
-  } {
-      %0 = arith.addi %arg0, %arg1 : i32
-      cf.br ^bb1(%arg0, %0 : i32, i32)
-    ^bb1(%aa : i32, %b : i32):
-      %c = ibis.call @bar(%aa) : (i32) -> (i32)
-      cf.br ^bb2(%aa, %c : i32, i32)
-    ^bb2(%aaa : i32, %cc : i32):
-      %d = arith.addi %cc, %aaa : i32
-      ibis.return %d : i32
+  ibis.method @foo(%arg0 : i32, %arg1 : i32) -> i32 {
+      ibis.sblock.inline.begin {maxThreads = 2}
+      %inner = arith.addi %arg0, %arg1 : i32
+      %0 = arith.addi %inner, %arg1 : i32
+      ibis.sblock.inline.end
+      ibis.return %0 : i32
   }
 }

--- a/test/Dialect/Ibis/Transforms/reblock.mlir
+++ b/test/Dialect/Ibis/Transforms/reblock.mlir
@@ -3,12 +3,15 @@
 // CHECK-LABEL:   ibis.class @Reblock {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @Reblock
 // CHECK:           ibis.method @foo(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) -> i32 {
-// CHECK:             %[[VAL_3:.*]] = ibis.sblock () -> i32 attributes {maxThreads = 2 : i64} {
+// CHECK:             %[[VAL_3:.*]]:2 = ibis.sblock () -> (i32, i32) attributes {maxThreads = 2 : i64} {
 // CHECK:               %[[VAL_4:.*]] = arith.addi %[[VAL_1]], %[[VAL_2]] : i32
 // CHECK:               %[[VAL_5:.*]] = arith.addi %[[VAL_4]], %[[VAL_2]] : i32
-// CHECK:               ibis.sblock.return %[[VAL_5]] : i32
+// CHECK:               %[[VAL_6:.*]] = arith.addi %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:               ibis.sblock.return %[[VAL_5]], %[[VAL_6]] : i32, i32
 // CHECK:             }
-// CHECK:             ibis.return %[[VAL_3]] : i32
+// CHECK:             cf.br ^bb1(%[[VAL_7:.*]]#0 : i32)
+// CHECK:           ^bb1(%[[VAL_8:.*]]: i32):
+// CHECK:             ibis.return %[[VAL_7]]#1 : i32
 // CHECK:           }
 // CHECK:         }
 
@@ -19,7 +22,12 @@ ibis.class @Reblock {
       ibis.sblock.inline.begin {maxThreads = 2}
       %inner = arith.addi %arg0, %arg1 : i32
       %0 = arith.addi %inner, %arg1 : i32
+      %1 = arith.addi %0, %arg1 : i32
       ibis.sblock.inline.end
-      ibis.return %0 : i32
+      // %0 is used within the same MLIR block but outside the scope.
+      cf.br ^bb1(%0 : i32)
+    ^bb1(%barg : i32):
+      // %1 is used in a different MLIR block (dominated by the sblock parent block).
+      ibis.return %1 : i32
   }
 }

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -10,7 +10,7 @@
 // CHECK-NEXT:      %array = ibis.get_var %parent, @array : !ibis.scoperef<@HighLevel> -> memref<10xi32>
 // CHECK-NEXT:      %alloca = memref.alloca() : memref<i32>
 // CHECK-NEXT:      %c32_i32 = hw.constant 32 : i32
-// CHECK-NEXT:      %0:2 = ibis.sblock (%arg0 : i32 = %c32_i32) -> (i32, i32) attributes {schedule = 1 : i64}{
+// CHECK-NEXT:      %0:2 = ibis.sblock (%arg0 : i32 = %c32_i32) -> (i32, i32) attributes {schedule = 1 : i64} {
 // CHECK-NEXT:        %1 = memref.load %alloca[] : memref<i32>
 // CHECK-NEXT:        memref.store %arg0, %alloca[] : memref<i32>
 // CHECK-NEXT:        ibis.sblock.return %1, %1 : i32, i32


### PR DESCRIPTION
Inlines `ibis.sblock` operations, by creating begin and end marker operations to denote the block scope. Attributes from the block will be placed upon the begin marker.
Similarly, the reblocking pass has been refactored to accommodate this change.