### PR TITLE
[CMake] Add install-circt-libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,6 +601,28 @@ if (NOT LLVM_ENABLE_IDE)
                            COMPONENT circt-headers)
 endif()
 
+# Custom target to install all mlir libraries
+add_custom_target(circt-libraries)
+set_target_properties(circt-libraries PROPERTIES FOLDER "Misc")
+
+if (NOT LLVM_ENABLE_IDE)
+  add_llvm_install_targets(install-circt-libraries
+                           DEPENDS circt-libraries
+                           COMPONENT circt-libraries)
+endif()
+
+get_property(CIRCT_LIBS GLOBAL PROPERTY CIRCT_ALL_LIBS)
+if(CIRCT_LIBS)
+  list(REMOVE_DUPLICATES CIRCT_LIBS)
+  foreach(lib ${CIRCT_LIBS})
+    add_dependencies(circt-libraries ${lib})
+    if(NOT LLVM_ENABLE_IDE)
+      add_dependencies(install-circt-libraries install-${lib})
+      add_dependencies(install-circt-libraries-stripped install-${lib}-stripped)
+    endif()
+  endforeach()
+endif()
+
 add_subdirectory(cmake/modules)
 
 # Set RPATH to $ORIGIN on all targets.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,7 +601,7 @@ if (NOT LLVM_ENABLE_IDE)
                            COMPONENT circt-headers)
 endif()
 
-# Custom target to install all mlir libraries
+# Custom target to install all circt libraries
 add_custom_target(circt-libraries)
 set_target_properties(circt-libraries PROPERTIES FOLDER "Misc")
 


### PR DESCRIPTION
Following [llvm/mlir/CMakeLists.txt](https://github.com/llvm/llvm-project/blob/b2ffc867ada60fde361c198dfc31d9c90f70e1aa/mlir/CMakeLists.txt#L247-L266), this commit adds `install-circt-libraries` cmake target to allow library installation.

