### PR TITLE
[ExportVerilog] Remove useless assert from NameCollector

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3280,13 +3280,7 @@ void NameCollector::collectNames(Block &block) {
     if (isa<ltl::LTLDialect>(op.getDialect()))
       continue;
 
-    bool isExpr = isVerilogExpression(&op);
-    assert((!isExpr ||
-            isExpressionEmittedInline(&op, moduleEmitter.state.options)) &&
-           "If 'op' is a verilog expression, the expression must be inlinable. "
-           "Otherwise, it is a bug of PrepareForEmission");
-
-    if (!isExpr) {
+    if (!isVerilogExpression(&op)) {
       for (auto result : op.getResults()) {
         StringRef declName =
             getVerilogDeclWord(&op, moduleEmitter.state.options);
@@ -3311,14 +3305,6 @@ void NameCollector::collectNames(Block &block) {
         if (!region.empty())
           collectNames(region.front());
       }
-      continue;
-    }
-
-    // Recursively process any expressions in else blocks that can be emitted
-    // as `else if`.
-    if (auto ifOp = dyn_cast<IfOp>(op)) {
-      if (ifOp.hasElse() && findNestedElseIf(ifOp.getElseBlock()))
-        collectNames(*ifOp.getElseBlock());
       continue;
     }
   }
@@ -4971,8 +4957,11 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
     if (!isZeroBit) {
       if (!word.empty())
         ps << PPExtString(word);
+      unsigned spaces = 0;
+      if (word.size() < maxDeclNameWidth)
+        spaces += maxDeclNameWidth - word.size();
       auto extraIndent = word.empty() ? 0 : 1;
-      ps.spaces(maxDeclNameWidth - word.size() + extraIndent);
+      ps.spaces(spaces + extraIndent);
     } else {
       ps << "// Zero width: " << PPExtString(word) << PP::space;
     }


### PR DESCRIPTION
The `NameCollector` is only used to compute declaration word and type string length such that we can format declarations nicely. Currently it also asserts a weird invariant that `PrepareForEmission` must uphold, but then it never actually relies on that invariant. And for some reason the `NameCollector` also collects names in else branches of `IfOp`s, but not in then branches.

Push `NameCollector` more into the best-effort cosmetics direction it's already going by removing that assert and not visiting else branches. Either we visit both branches of an if, or none at all. And since if blocks introduce a separate scope with a separate place for decls, the visition is not necessary. (It would just potentially add whitespace to the if's surrounding scope's decl stack, to account for decls that are actually emitted within the if scope.)

This also uncovered one instance of `maxDeclNameWidth - x` that was left unguarded by `if (x < maxDeclNameWidth)`. Fix this.

This change doesn't affect the output, but makes ExportVerilog less brittle by not enforcing invariants that it actually doesn't care about.