### PR TITLE
[HW][Python] Add name getters for ModuleType

### DIFF
--- a/include/circt-c/Dialect/HW.h
+++ b/include/circt-c/Dialect/HW.h
@@ -106,6 +106,10 @@ MLIR_CAPI_EXPORTED intptr_t hwModuleTypeGetNumInputs(MlirType type);
 MLIR_CAPI_EXPORTED MlirType hwModuleTypeGetInputType(MlirType type,
                                                      intptr_t index);
 
+/// Get an HW module type's input name at a specific index.
+MLIR_CAPI_EXPORTED MlirStringRef hwModuleTypeGetInputName(MlirType type,
+                                                          intptr_t index);
+
 /// Get an HW module type's number of outputs.
 MLIR_CAPI_EXPORTED intptr_t hwModuleTypeGetNumOutputs(MlirType type);
 
@@ -113,6 +117,9 @@ MLIR_CAPI_EXPORTED intptr_t hwModuleTypeGetNumOutputs(MlirType type);
 MLIR_CAPI_EXPORTED MlirType hwModuleTypeGetOutputType(MlirType type,
                                                       intptr_t index);
 
+/// Get an HW module type's output name at a specific index.
+MLIR_CAPI_EXPORTED MlirStringRef hwModuleTypeGetOutputName(MlirType type,
+                                                           intptr_t index);
 /// Creates an HW struct type in the context associated with the elements.
 MLIR_CAPI_EXPORTED MlirType hwStructTypeGet(MlirContext ctx,
                                             intptr_t numElements,

--- a/integration_test/Bindings/Python/dialects/hw.py
+++ b/integration_test/Bindings/Python/dialects/hw.py
@@ -120,3 +120,20 @@ with Context() as ctx, Location.unknown():
   global_ref = hw.GlobalRefAttr.get(StringAttr.get("foo"))
   # CHECK: #hw.globalNameRef<@foo>
   print(global_ref)
+
+  ports = [
+      hw.ModulePort(StringAttr.get("out"), i1, hw.ModulePortDirection.OUTPUT),
+      hw.ModulePort(StringAttr.get("in1"), i2, hw.ModulePortDirection.INPUT),
+      hw.ModulePort(StringAttr.get("in2"), i32, hw.ModulePortDirection.INPUT)
+  ]
+  module_type = hw.ModuleType.get(ports)
+  # CHECK: !hw.modty<output out : i1, input in1 : i2, input in2 : i32>
+  print(module_type)
+  # CHECK-NEXT:  [IntegerType(i2), IntegerType(i32)]
+  print(module_type.input_types)
+  # CHECK-NEXT:  [IntegerType(i1)]
+  print(module_type.output_types)
+  # CHECK-NEXT:  ['in1', 'in2']
+  print(module_type.input_names)
+  # CHECK-NEXT:  ['out']
+  print(module_type.output_names)

--- a/lib/Bindings/Python/HWModule.cpp
+++ b/lib/Bindings/Python/HWModule.cpp
@@ -81,12 +81,34 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
               inputTypes.append(hwModuleTypeGetInputType(self, i));
             return inputTypes;
           })
-      .def_property_readonly("output_types", [](MlirType self) {
-        py::list outputTypes;
+      .def_property_readonly(
+          "input_names",
+          [](MlirType self) {
+            std::vector<std::string> inputNames;
+            intptr_t numInputs = hwModuleTypeGetNumInputs(self);
+            for (intptr_t i = 0; i < numInputs; ++i) {
+              auto name = hwModuleTypeGetInputName(self, i);
+              inputNames.emplace_back(name.data, name.length);
+            }
+            return inputNames;
+          })
+      .def_property_readonly(
+          "output_types",
+          [](MlirType self) {
+            py::list outputTypes;
+            intptr_t numOutputs = hwModuleTypeGetNumOutputs(self);
+            for (intptr_t i = 0; i < numOutputs; ++i)
+              outputTypes.append(hwModuleTypeGetOutputType(self, i));
+            return outputTypes;
+          })
+      .def_property_readonly("output_names", [](MlirType self) {
+        std::vector<std::string> outputNames;
         intptr_t numOutputs = hwModuleTypeGetNumOutputs(self);
-        for (intptr_t i = 0; i < numOutputs; ++i)
-          outputTypes.append(hwModuleTypeGetOutputType(self, i));
-        return outputTypes;
+        for (intptr_t i = 0; i < numOutputs; ++i) {
+          auto name = hwModuleTypeGetOutputName(self, i);
+          outputNames.emplace_back(name.data, name.length);
+        }
+        return outputNames;
       });
 
   mlir_type_subclass(m, "ParamIntType", hwTypeIsAIntType)

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -110,12 +110,20 @@ MlirType hwModuleTypeGetInputType(MlirType type, intptr_t index) {
   return wrap(cast<ModuleType>(unwrap(type)).getInputType(index));
 }
 
+MlirStringRef hwModuleTypeGetInputName(MlirType type, intptr_t index) {
+  return wrap(cast<ModuleType>(unwrap(type)).getInputName(index));
+}
+
 intptr_t hwModuleTypeGetNumOutputs(MlirType type) {
   return cast<ModuleType>(unwrap(type)).getNumOutputs();
 }
 
 MlirType hwModuleTypeGetOutputType(MlirType type, intptr_t index) {
   return wrap(cast<ModuleType>(unwrap(type)).getOutputType(index));
+}
+
+MlirStringRef hwModuleTypeGetOutputName(MlirType type, intptr_t index) {
+  return wrap(cast<ModuleType>(unwrap(type)).getOutputName(index));
 }
 
 bool hwTypeIsAStructType(MlirType type) {


### PR DESCRIPTION
 `argNames` and `resultNames` attributes were removed from HWModule (https://github.com/llvm/circt/pull/6095) in the presence of ModuleType but downstream python tools are relying these attributes for name look up. However currently there is no CAPI/Python API for ModuleType to query names of ports so this PR adds CAPI and bindings respectively in the same way to port types. 