### PR TITLE
[Ibis] Allow multiple return values for `ibis.method`

### DIFF
--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -146,7 +146,7 @@ def MethodOp : IbisOp<"method", [
   let summary = "Ibis method";
   let description = [{
     Ibis functions are a lot like software functions: a list of named arguments
-    and one unnamed return value.
+    and unnamed return values.
 
     Can only live inside of classes.
   }];
@@ -158,7 +158,6 @@ def MethodOp : IbisOp<"method", [
                        OptionalAttr<DictArrayAttr>:$res_attrs);
   let regions = (region AnyRegion:$body);
   let hasCustomAssemblyFormat = 1;
-  let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     //===------------------------------------------------------------------===//
@@ -182,10 +181,10 @@ def MethodOp : IbisOp<"method", [
 
 def ReturnOp : IbisOp<"return", [
       Pure, ReturnLike, Terminator, HasParent<"MethodOp">]> {
-  let summary = "Ibis function terminator";
+  let summary = "Ibis method terminator";
 
-  let arguments = (ins Optional<AnyType>:$retValue);
-  let assemblyFormat = "($retValue^)? attr-dict (`:` type($retValue)^)?";
+  let arguments = (ins Variadic<AnyType>:$retValues);
+  let assemblyFormat = "($retValues^)? attr-dict (`:` type($retValues)^)?";
   let hasVerifier = 1;
 
   let builders = [

--- a/test/Dialect/Ibis/errors.mlir
+++ b/test/Dialect/Ibis/errors.mlir
@@ -2,20 +2,9 @@
 
 ibis.class @C {
   %this = ibis.this @C
-  ibis.method @typeMismatch1() -> ui32 {
-    // expected-error @+1 {{must return a value}}
+  ibis.method @typeMismatch1() -> (ui32, i32) {
+    // expected-error @+1 {{'ibis.return' op must have the same number of operands as the method has results}}
     ibis.return
-  }
-}
-
-// -----
-
-ibis.class @C {
-  %this = ibis.this @C
-  ibis.method @typeMismatch2() {
-    %c = hw.constant 1 : i8
-    // expected-error @+1 {{cannot return a value from a function with no result type}}
-    ibis.return %c : i8
   }
 }
 
@@ -24,7 +13,7 @@ ibis.class @C {
   %this = ibis.this @C
   ibis.method @typeMismatch3() -> ui32 {
     %c = hw.constant 1 : i8
-    // expected-error @+1 {{return type ('i8') must match function return type ('ui32')}}
+    // expected-error @+1 {{'ibis.return' op operand type ('i8') must match function return type ('ui32')}}
     ibis.return %c : i8
   }
 }

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -4,7 +4,7 @@
 // CHECK-NEXT:    %this = ibis.this @HighLevel 
 // CHECK-NEXT:    ibis.var @single : memref<i32>
 // CHECK-NEXT:    ibis.var @array : memref<10xi32>
-// CHECK-NEXT:    ibis.method @foo() {
+// CHECK-NEXT:    ibis.method @foo() -> (i32, i32) {
 // CHECK-NEXT:      %parent = ibis.path [#ibis.step<parent : !ibis.scoperef<@HighLevel>> : !ibis.scoperef<@HighLevel>]
 // CHECK-NEXT:      %single = ibis.get_var %parent, @single : !ibis.scoperef<@HighLevel> -> memref<i32>
 // CHECK-NEXT:      %array = ibis.get_var %parent, @array : !ibis.scoperef<@HighLevel> -> memref<10xi32>
@@ -15,7 +15,7 @@
 // CHECK-NEXT:        memref.store %arg0, %alloca[] : memref<i32>
 // CHECK-NEXT:        ibis.sblock.return %1, %1 : i32, i32
 // CHECK-NEXT:      }
-// CHECK-NEXT:      ibis.return
+// CHECK-NEXT:      ibis.return %0#0, %0#1 : i32, i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
@@ -24,7 +24,7 @@ ibis.class @HighLevel {
   ibis.var @single : memref<i32>
   ibis.var @array : memref<10xi32>
 
-  ibis.method @foo()  {
+  ibis.method @foo() -> (i32, i32)  {
     %parent = ibis.path [
       #ibis.step<parent : !ibis.scoperef<@HighLevel>>
     ]
@@ -37,7 +37,7 @@ ibis.class @HighLevel {
       memref.store %arg, %local[] : memref<i32>
       ibis.sblock.return %v, %v : i32, i32
     }
-    ibis.return
+    ibis.return %out1, %out2 : i32, i32
   }
 }
 


### PR DESCRIPTION
The prior motivation for a single return value was to enforce... well, exactly that. However, this is nothing but a pain, requiring the user to tupel/struct-ify return values at a high level. This is a trivial transformation that can be done down the line. Allowing multiple return values, however, allows this op to play much more nicely with other passes and code that expects function-like operations (and terminators of said ops) to -generally speaking - accept multiple return values.