### PR TITLE
[HW] Align instance_like_impl verification with `getReferencedModule`

### DIFF
--- a/lib/Dialect/HW/InstanceImplementation.cpp
+++ b/lib/Dialect/HW/InstanceImplementation.cpp
@@ -28,7 +28,7 @@ instance_like_impl::getReferencedModule(const HWSymbolCache *cache,
 LogicalResult instance_like_impl::verifyReferencedModule(
     Operation *instanceOp, SymbolTableCollection &symbolTable,
     mlir::FlatSymbolRefAttr moduleName, Operation *&module) {
-  module = symbolTable.lookupNearestSymbolFrom(instanceOp, moduleName);
+  module = getReferencedModule(nullptr, instanceOp, moduleName);
   if (module == nullptr)
     return instanceOp->emitError("Cannot find module definition '")
            << moduleName.getValue() << "'";


### PR DESCRIPTION
Previously, `instance_like_impl::verifyReferencedModule` and `instance_like_impl::getReferencedModule` had different semantics for where the referenced module is located;

`getReferencedModule` uses the nearest parent `ModuleOp` as the target symbol table, whereas `verifyReferencedModule` uses the nearest (i.e. any) parent symbol table. As a result, `verifyReferencedModule` fails if the `hw.instance` op is nested within another symbol table operation.

e.g. the following would fail:
```mlir
module {
  hw.module.extern @Foo()
  ibis.container @C {
    %this = ibis.this @C
    hw.instance "foo" @Foo() -> ()
  }
}
```