### PR TITLE
[FIRRTL][IMDCE] Mark all objects as alive

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -96,6 +96,7 @@ struct IMDeadCodeElimPass : public IMDeadCodeElimBase<IMDeadCodeElimPass> {
 
   void markDeclaration(Operation *op);
   void markInstanceOp(InstanceOp instanceOp);
+  void markObjectOp(ObjectOp objectOp);
   void markUnknownSideEffectOp(Operation *op);
   void visitInstanceOp(InstanceOp instance);
   void visitHierPathOp(hw::HierPathOp hierpath);
@@ -202,7 +203,7 @@ void IMDeadCodeElimPass::visitUser(Operation *op) {
   LLVM_DEBUG(llvm::dbgs() << "Visit: " << *op << "\n");
   if (auto connectOp = dyn_cast<FConnectLike>(op))
     return visitConnect(connectOp);
-  if (isa<SubfieldOp, SubindexOp, SubaccessOp>(op))
+  if (isa<SubfieldOp, SubindexOp, SubaccessOp, ObjectSubfieldOp>(op))
     return visitSubelement(op);
 }
 
@@ -232,6 +233,11 @@ void IMDeadCodeElimPass::markInstanceOp(InstanceOp instance) {
   markBlockExecutable(fModule.getBodyBlock());
 }
 
+void IMDeadCodeElimPass::markObjectOp(ObjectOp object) {
+  // unconditionally keep all objects alive.
+  markAlive(object);
+}
+
 void IMDeadCodeElimPass::markBlockExecutable(Block *block) {
   if (!executableBlocks.insert(block).second)
     return; // Already executable.
@@ -252,6 +258,8 @@ void IMDeadCodeElimPass::markBlockExecutable(Block *block) {
       markDeclaration(&op);
     else if (auto instance = dyn_cast<InstanceOp>(op))
       markInstanceOp(instance);
+    else if (auto object = dyn_cast<ObjectOp>(op))
+      markObjectOp(object);
     else if (isa<FConnectLike>(op))
       // Skip connect op.
       continue;


### PR DESCRIPTION
This is a minimal change to keep all objects alive, as well as their ports (object subfield ops), as well as all writes to their ports (propassigns to object subfields). By marking objects as live, liveness should propagate through object subfield ops (which are handled the same as other subfield ops), and then through the propassigns (which are connect-like), back to the value being driven.

Class ops are ignored by this pass, so their bodies should not be cleaned up, and empty classes should be kept around.

The ObjectOp is not Pure, this prevents object ops from being deleted, even if they have no uses.