### PR TITLE
[CI] Hotfix macosx python wheel

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -27,15 +27,15 @@ jobs:
           - os: ubuntu-20.04
             cibw_build: cp311-manylinux_x86_64
           - os: macos-latest
-            cibw_build: cp37-macosx_universal2
+            cibw_build: cp37-macosx_x86_64
           - os: macos-latest
-            cibw_build: cp38-macosx_universal2
+            cibw_build: cp38-macosx_x86_64
           - os: macos-latest
-            cibw_build: cp39-macosx_universal2
+            cibw_build: cp39-macosx_x86_64
           - os: macos-latest
-            cibw_build: cp310-macosx_universal2
+            cibw_build: cp310-macosx_x86_64
           - os: macos-latest
-            cibw_build: cp311-macosx_universal2
+            cibw_build: cp311-macosx_x86_64
 
     steps:
       - name: Get CIRCT


### PR DESCRIPTION
See https://github.com/llvm/circt/issues/6153

The universal macos wheels are failing, I will follow up in that issue to look for a resolution, but for now we should revert to building the standard wheel.