### PR TITLE
[HW] Fix ModuleType::getInputType to return InOutType for InOut port

### DIFF
--- a/integration_test/Bindings/Python/dialects/hw.py
+++ b/integration_test/Bindings/Python/dialects/hw.py
@@ -124,16 +124,17 @@ with Context() as ctx, Location.unknown():
   ports = [
       hw.ModulePort(StringAttr.get("out"), i1, hw.ModulePortDirection.OUTPUT),
       hw.ModulePort(StringAttr.get("in1"), i2, hw.ModulePortDirection.INPUT),
-      hw.ModulePort(StringAttr.get("in2"), i32, hw.ModulePortDirection.INPUT)
+      hw.ModulePort(StringAttr.get("in2"), i32, hw.ModulePortDirection.INPUT),
+      hw.ModulePort(StringAttr.get("in3"), i32, hw.ModulePortDirection.INOUT)
   ]
   module_type = hw.ModuleType.get(ports)
-  # CHECK: !hw.modty<output out : i1, input in1 : i2, input in2 : i32>
+  # CHECK: !hw.modty<output out : i1, input in1 : i2, input in2 : i32, inout in3 : i32>
   print(module_type)
-  # CHECK-NEXT:  [IntegerType(i2), IntegerType(i32)]
+  # CHECK-NEXT:  [IntegerType(i2), IntegerType(i32), Type(!hw.inout<i32>)]
   print(module_type.input_types)
   # CHECK-NEXT:  [IntegerType(i1)]
   print(module_type.output_types)
-  # CHECK-NEXT:  ['in1', 'in2']
+  # CHECK-NEXT:  ['in1', 'in2', 'in3']
   print(module_type.input_names)
   # CHECK-NEXT:  ['out']
   print(module_type.output_names)

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -830,7 +830,10 @@ SmallVector<Type> ModuleType::getPortTypes() {
 }
 
 Type ModuleType::getInputType(size_t idx) {
-  return getPorts()[getPortIdForInputId(idx)].type;
+  const auto &portInfo = getPorts()[getPortIdForInputId(idx)];
+  if (portInfo.dir != ModulePort::InOut)
+    return portInfo.type;
+  return InOutType::get(portInfo.type);
 }
 
 Type ModuleType::getOutputType(size_t idx) {


### PR DESCRIPTION
`ModuleType::getInputTypes` returns inout types for inout ports but `getInputType` doesn't wrap with inout. This is inconsistent and python API `module_type.input_types` returns a wrong type for this. 