### PR TITLE
[Ibis] Add `ibis.method.df` operation

### DIFF
--- a/include/circt/Dialect/Ibis/IbisOps.h
+++ b/include/circt/Dialect/Ibis/IbisOps.h
@@ -9,6 +9,7 @@
 #ifndef CIRCT_DIALECT_IBIS_IBISOPS_H
 #define CIRCT_DIALECT_IBIS_IBISOPS_H
 
+#include "circt/Dialect/Handshake/HandshakeInterfaces.h"
 #include "circt/Dialect/Ibis/IbisDialect.h"
 #include "circt/Dialect/Ibis/IbisTypes.h"
 #include "circt/Support/InstanceGraphInterface.h"

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -18,6 +18,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
 
+include  "circt/Dialect/Handshake/HandshakeInterfaces.td"
 include "circt/Dialect/HW/HWOpInterfaces.td"
 include "circt/Dialect/Ibis/IbisInterfaces.td"
 include "circt/Dialect/Ibis/IbisTypes.td"
@@ -136,30 +137,23 @@ def InstanceOp : InstanceOpBase<"instance"> {
   }];
 }
 
-def MethodOp : IbisOp<"method", [
+
+class MethodOpBase<string mnemonic, list<Trait> traits = []> :
+    IbisOp<mnemonic, !listconcat(traits, [
       IsolatedFromAbove,
       Symbol, FunctionOpInterface,
-      AutomaticAllocationScope,
-      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>,
-      HasParent<"ClassOp">]> {
-
-  let summary = "Ibis method";
-  let description = [{
-    Ibis functions are a lot like software functions: a list of named arguments
-    and unnamed return values.
-
-    Can only live inside of classes.
-  }];
+      HasParent<"ClassOp">
+  ])> {
 
   let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<FunctionType>:$function_type,
                        ArrayAttr:$argNames,
                        OptionalAttr<DictArrayAttr>:$arg_attrs,
                        OptionalAttr<DictArrayAttr>:$res_attrs);
-  let regions = (region AnyRegion:$body);
   let hasCustomAssemblyFormat = 1;
 
-  let extraClassDeclaration = [{
+  code extraMethodClassDeclaration = "";
+  let extraClassDeclaration = extraMethodClassDeclaration # [{
     //===------------------------------------------------------------------===//
     // FunctionOpInterface Methods
     //===------------------------------------------------------------------===//
@@ -179,8 +173,43 @@ def MethodOp : IbisOp<"method", [
   }];
 }
 
+def MethodOp : MethodOpBase<"method", [
+      AutomaticAllocationScope,
+      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>
+  ]> {
+
+  let summary = "Ibis method";
+  let description = [{
+    Ibis methods are a lot like software functions: a list of named arguments
+    and unnamed return values with imperative control flow.
+  }];
+
+  let regions = (region AnyRegion:$body);
+}
+
+def DataflowMethodOp : MethodOpBase<"method.df", [
+      SingleBlockImplicitTerminator<"ibis::ReturnOp">,
+      RegionKindInterface,
+      FineGrainedDataflowRegionOpInterface
+  ]> {
+
+  let summary = "Ibis dataflow method";
+  let description = [{
+    Ibis dataflow methods share the same interface as an `ibis.method` but
+    without imperative CFG-based control flow. Instead, this method implements a
+    graph region, and control flow is expected to be defined by dataflow operations.
+  }];
+  let regions = (region SizedRegion<1>:$body);
+
+  let extraMethodClassDeclaration = [{
+    // Implement RegionKindInterface.
+    static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph; }
+  }];
+}
+
 def ReturnOp : IbisOp<"return", [
-      Pure, ReturnLike, Terminator, HasParent<"MethodOp">]> {
+      Pure, ReturnLike, Terminator,
+      ParentOneOf<["MethodOp", "DataflowMethodOp"]>]> {
   let summary = "Ibis method terminator";
 
   let arguments = (ins Variadic<AnyType>:$retValues);

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -17,6 +17,10 @@
 // CHECK-NEXT:      }
 // CHECK-NEXT:      ibis.return %0#0, %0#1 : i32, i32
 // CHECK-NEXT:    }
+// CHECK-NEXT:    ibis.method.df @bar(%arg0: none) -> none {
+// CHECK-NEXT:      %0 = handshake.join %arg0 : none
+// CHECK-NEXT:      ibis.return %0 : none
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
 ibis.class @HighLevel {
@@ -38,6 +42,11 @@ ibis.class @HighLevel {
       ibis.sblock.return %v, %v : i32, i32
     }
     ibis.return %out1, %out2 : i32, i32
+  }
+
+  ibis.method.df @bar(%arg0 : none) -> (none) {
+    %0 = handshake.join %arg0 : none
+    ibis.return %0 : none
   }
 }
 


### PR DESCRIPTION
Ibis dataflow methods share the same interface as an `ibis.method` but without imperative CFG-based control flow. Instead, this method implements a graph region, and control flow is expected to be defined by dataflow operations.