### PR TITLE
[Ibis] Add Ibis CF to Handshake conversion

### DIFF
--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -22,6 +22,7 @@ include  "circt/Dialect/Handshake/HandshakeInterfaces.td"
 include "circt/Dialect/HW/HWOpInterfaces.td"
 include "circt/Dialect/Ibis/IbisInterfaces.td"
 include "circt/Dialect/Ibis/IbisTypes.td"
+include "circt/Dialect/Handshake/HandshakeInterfaces.td"
 
 include "circt/Support/InstanceGraphInterface.td"
 
@@ -170,6 +171,9 @@ class MethodOpBase<string mnemonic, list<Trait> traits = []> :
     ::mlir::Region *getCallableRegion() {
       return &getBody();
     }
+
+    /// Returns the entry block of the function.
+    Block* getBodyBlock() { return &getBody().front(); }
   }];
 }
 

--- a/include/circt/Dialect/Ibis/IbisPasses.h
+++ b/include/circt/Dialect/Ibis/IbisPasses.h
@@ -27,6 +27,7 @@ std::unique_ptr<Pass> createContainersToHWPass();
 std::unique_ptr<Pass> createArgifyBlocksPass();
 std::unique_ptr<Pass> createReblockPass();
 std::unique_ptr<Pass> createInlineSBlocksPass();
+std::unique_ptr<Pass> createConvertCFToHandshakePass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Ibis/IbisPasses.td
+++ b/include/circt/Dialect/Ibis/IbisPasses.td
@@ -151,4 +151,16 @@ def IbisInlineSBlocks : Pass<"ibis-inline-sblocks", "ibis::MethodOp"> {
   let dependentDialects = ["mlir::cf::ControlFlowDialect"];
 }
 
+def IbisConvertCFToHandshake : Pass<"ibis-convert-cf-to-handshake", "ibis::ClassOp"> {
+  let summary = "Converts an `ibis.method` to `ibis.method.df`";
+  let description = [{
+    Converts an `ibis.method` from using `cf` operations and MLIR blocks to
+    an `ibis.method.df` operation, using the `handshake` dialect to represent
+    control flow through the `handshake` fine grained dataflow operations.
+  }];
+
+  let constructor = "circt::ibis::createConvertCFToHandshakePass()";
+  let dependentDialects = ["circt::handshake::HandshakeDialect", "mlir::cf::ControlFlowDialect"];
+}
+
 #endif // CIRCT_DIALECT_IBIS_PASSES_TD

--- a/lib/Dialect/Ibis/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Ibis/Transforms/CMakeLists.txt
@@ -8,12 +8,15 @@ add_circt_dialect_library(CIRCTIbisTransforms
   IbisArgifyBlocksPass.cpp
   IbisReblockPass.cpp
   IbisInlineSBlocksPass.cpp
+  IbisConvertCFToHandshake.cpp
 
   DEPENDS
   CIRCTIbisTransformsIncGen
 
   LINK_LIBS PUBLIC
   CIRCTDC
+  CIRCTHandshake
+  CIRCTCFToHandshake
   CIRCTIbis
   CIRCTHW
   CIRCTSupport

--- a/lib/Dialect/Ibis/Transforms/IbisConvertCFToHandshake.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisConvertCFToHandshake.cpp
@@ -1,0 +1,74 @@
+//===- IbisConvertCFToHandshakePass.cpp -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+#include "circt/Dialect/Ibis/IbisDialect.h"
+#include "circt/Dialect/Ibis/IbisOps.h"
+#include "circt/Dialect/Ibis/IbisPasses.h"
+#include "circt/Dialect/Ibis/IbisTypes.h"
+
+#include "circt/Transforms/Passes.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "circt/Conversion/CFToHandshake.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace ibis;
+
+namespace {
+
+struct ConvertCFToHandshakePass
+    : public IbisConvertCFToHandshakeBase<ConvertCFToHandshakePass> {
+  void runOnOperation() override;
+
+  LogicalResult convertMethod(MethodOp method);
+};
+} // anonymous namespace
+
+LogicalResult ConvertCFToHandshakePass::convertMethod(MethodOp method) {
+  // Add a control input/output to the method.
+  OpBuilder b(method);
+  llvm::SmallVector<Type> newArgTypes, newResTypes;
+  llvm::copy(method.getArgumentTypes(), std::back_inserter(newArgTypes));
+  llvm::copy(method.getResultTypes(), std::back_inserter(newResTypes));
+  newArgTypes.push_back(b.getNoneType());
+  newResTypes.push_back(b.getNoneType());
+  auto newFuncType = b.getFunctionType(newArgTypes, newResTypes);
+  auto dataflowMethodOp = b.create<DataflowMethodOp>(
+      method.getLoc(), method.getSymNameAttr(), TypeAttr::get(newFuncType),
+      method.getArgNamesAttr(), method.getArgAttrsAttr(),
+      method.getAllResultAttrs());
+  dataflowMethodOp.getBody().takeBody(method.getBody());
+  dataflowMethodOp.getBodyBlock()->addArgument(b.getNoneType(),
+                                               method.getLoc());
+  Value entryCtrl = dataflowMethodOp.getBodyBlock()->getArguments().back();
+  method.erase();
+
+  handshake::HandshakeLowering fol(dataflowMethodOp.getBody());
+  if (failed(handshake::lowerRegion<ibis::ReturnOp, ibis::ReturnOp>(
+          fol,
+          /*sourceConstants*/ false, /*disableTaskPipelining*/ false,
+          entryCtrl)))
+    return failure();
+
+  return success();
+}
+
+void ConvertCFToHandshakePass::runOnOperation() {
+  ClassOp classOp = getOperation();
+  for (auto method : llvm::make_early_inc_range(classOp.getOps<MethodOp>())) {
+    if (failed(convertMethod(method)))
+      return signalPassFailure();
+  }
+}
+
+std::unique_ptr<Pass> circt::ibis::createConvertCFToHandshakePass() {
+  return std::make_unique<ConvertCFToHandshakePass>();
+}

--- a/lib/Dialect/Ibis/Transforms/PassDetails.h
+++ b/lib/Dialect/Ibis/Transforms/PassDetails.h
@@ -20,12 +20,12 @@
 #include "mlir/Pass/Pass.h"
 
 namespace circt {
-namespace sandpiper {
+namespace ibis {
 
 #define GEN_PASS_CLASSES
 #include "circt/Dialect/Ibis/Ibis.h.inc"
 
-} // namespace sandpiper
+} // namespace ibis
 } // namespace circt
 
 #endif // DIALECT_IBIS_TRANSFORMS_PASSDETAILS_H

--- a/test/Dialect/Ibis/Transforms/cf_to_handshake.mlir
+++ b/test/Dialect/Ibis/Transforms/cf_to_handshake.mlir
@@ -1,0 +1,68 @@
+
+// RUN: circt-opt --pass-pipeline="builtin.module(ibis.class(ibis-convert-cf-to-handshake))" \
+// RUN:      --allow-unregistered-dialect %s | FileCheck %s
+
+// CHECK:           ibis.method.df @foo(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: none) -> (i32, none) {
+// CHECK:             %[[VAL_5:.*]] = handshake.merge %[[VAL_1]] : i32
+// CHECK:             %[[VAL_6:.*]] = handshake.merge %[[VAL_2]] : i32
+// CHECK:             %[[VAL_7:.*]] = handshake.merge %[[VAL_3]] : i1
+// CHECK:             %[[VAL_8:.*]] = handshake.buffer [2] fifo %[[VAL_7]] : i1
+// CHECK:             %[[VAL_9:.*]] = handshake.merge %[[VAL_4]] : none
+// CHECK:             %[[VAL_10:.*]] = ibis.sblock (%[[VAL_11:.*]] : i32 = %[[VAL_5]], %[[VAL_12:.*]] : i32 = %[[VAL_6]]) -> i32 attributes {maxThreads = 1 : i64} {
+// CHECK:               %[[VAL_13:.*]] = "foo.op1"(%[[VAL_11]], %[[VAL_12]]) : (i32, i32) -> i32
+// CHECK:               ibis.sblock.return %[[VAL_13]] : i32
+// CHECK:             }
+// CHECK:             %[[VAL_14:.*]], %[[VAL_15:.*]] = handshake.cond_br %[[VAL_7]], %[[VAL_5]] : i32
+// CHECK:             %[[VAL_16:.*]], %[[VAL_17:.*]] = handshake.cond_br %[[VAL_7]], %[[VAL_9]] : none
+// CHECK:             %[[VAL_18:.*]], %[[VAL_19:.*]] = handshake.cond_br %[[VAL_7]], %[[VAL_10]] : i32
+// CHECK:             %[[VAL_20:.*]] = handshake.merge %[[VAL_14]] : i32
+// CHECK:             %[[VAL_21:.*]] = handshake.merge %[[VAL_18]] : i32
+// CHECK:             %[[VAL_22:.*]], %[[VAL_23:.*]] = handshake.control_merge %[[VAL_16]] : none, index
+// CHECK:             %[[VAL_24:.*]] = ibis.sblock (%[[VAL_25:.*]] : i32 = %[[VAL_21]], %[[VAL_26:.*]] : i32 = %[[VAL_20]]) -> i32 {
+// CHECK:               %[[VAL_27:.*]] = "foo.op2"(%[[VAL_25]], %[[VAL_26]]) : (i32, i32) -> i32
+// CHECK:               ibis.sblock.return %[[VAL_27]] : i32
+// CHECK:             }
+// CHECK:             %[[VAL_28:.*]] = handshake.br %[[VAL_22]] : none
+// CHECK:             %[[VAL_29:.*]] = handshake.br %[[VAL_24]] : i32
+// CHECK:             %[[VAL_30:.*]] = handshake.merge %[[VAL_15]] : i32
+// CHECK:             %[[VAL_31:.*]] = handshake.merge %[[VAL_19]] : i32
+// CHECK:             %[[VAL_32:.*]], %[[VAL_33:.*]] = handshake.control_merge %[[VAL_17]] : none, index
+// CHECK:             %[[VAL_34:.*]] = ibis.sblock (%[[VAL_35:.*]] : i32 = %[[VAL_31]], %[[VAL_36:.*]] : i32 = %[[VAL_30]]) -> i32 {
+// CHECK:               %[[VAL_37:.*]] = "foo.op2"(%[[VAL_35]], %[[VAL_36]]) : (i32, i32) -> i32
+// CHECK:               ibis.sblock.return %[[VAL_37]] : i32
+// CHECK:             }
+// CHECK:             %[[VAL_38:.*]] = handshake.br %[[VAL_32]] : none
+// CHECK:             %[[VAL_39:.*]] = handshake.br %[[VAL_34]] : i32
+// CHECK:             %[[VAL_40:.*]] = handshake.mux %[[VAL_41:.*]] {{\[}}%[[VAL_39]], %[[VAL_29]]] : index, i32
+// CHECK:             %[[VAL_42:.*]] = handshake.mux %[[VAL_8]] {{\[}}%[[VAL_38]], %[[VAL_28]]] : i1, none
+// CHECK:             %[[VAL_41]] = arith.index_cast %[[VAL_8]] : i1 to index
+// CHECK:             ibis.return %[[VAL_40]], %[[VAL_42]] : i32, none
+// CHECK:           }
+
+ibis.class @ToHandshake {
+  %this = ibis.this @ToHandshake
+  // Just a simple test demonstrating the intended mixing of `ibis.sblock`s and
+  // control flow operations. The meat of cf-to-handshake conversion is tested
+  // in the handshake dialect tests.
+  ibis.method @foo(%a: i32, %b: i32, %cond : i1) -> i32 {
+    %0 = ibis.sblock (%arg0 : i32 = %a, %arg1 : i32 = %b) -> i32 attributes {maxThreads = 1 : i64} {
+      %4 = "foo.op1"(%arg0, %arg1) : (i32, i32) -> i32
+      ibis.sblock.return %4 : i32
+    }
+    cf.cond_br %cond, ^bb1(%a, %0 : i32, i32), ^bb2(%a, %0 : i32, i32)
+  ^bb1(%11: i32, %21: i32):  // pred: ^bb0
+    %31 = ibis.sblock (%arg0 : i32 = %21, %arg1 : i32 = %11) -> i32 {
+      %4 = "foo.op2"(%arg0, %arg1) : (i32, i32) -> i32
+      ibis.sblock.return %4 : i32
+    }
+    cf.br ^bb4(%31 : i32)
+  ^bb2(%12 : i32, %22 : i32):
+    %32 = ibis.sblock (%arg0 : i32 = %22, %arg1 : i32 = %12) -> i32 {
+      %4 = "foo.op2"(%arg0, %arg1) : (i32, i32) -> i32
+      ibis.sblock.return %4 : i32
+    }
+    cf.br ^bb4(%32 : i32)
+  ^bb4(%res : i32):
+    ibis.return %res : i32
+  }
+}


### PR DESCRIPTION
Converts an `ibis.method` into an `ibis.method.df` by converting controlflow using `cf` to `handshake` dialect conversion applied to the `ibis.method` body region.