### PR TITLE
[Python] Remove CI options that only applied to MacOS universal.

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -61,8 +61,6 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BUILD_FRONTEND: build
           SETUPTOOLS_SCM_DEBUG: True
-          CIBW_ARCHS_MACOS: universal2
-          CIBW_TEST_SKIP: '*universal2:arm64'
 
       - name: Upload (stage) wheels as artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
We were having problems with the universal MacOS wheels, so we reverted back to just building the x86 wheels. But this still fails, because these options are telling cibuildwheel to build for the universal architecture on MacOS, which is not enabled.

cc @leonardt 