### PR TITLE
[ExportVerilog] Bound type size considered for decl alignment

### DIFF
--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -546,8 +546,7 @@ hw.module @TestZeroStruct(in %structZero: !hw.struct<>, in %structZeroNest: !hw.
 hw.module @zeroElements(in %in0: i0, in %in1: i32, out out0: !hw.struct<z1: i0, a: i32, z2: i0, b: i32, c: !hw.struct<z: i0>, d: !hw.struct<d1:i32, z:i0>>) {
   // CHECK:      // Zero width: wire /*Zero Width*/
   // CHECK-SAME: _GEN = '{};
-  // CHECK-NEXT: wire struct packed {logic [31:0] d1; /*z: Zero Width;*/ }
-  // CHECK-NEXT:   _GEN_0 = '{d1: in1};
+  // CHECK-NEXT: wire struct packed {logic [31:0] d1; /*z: Zero Width;*/ } _GEN_0 = '{d1: in1};
   //      CHECK: wire
   // CHECK-NEXT:   struct packed {/*z1: Zero Width;*/ logic [31:0] a; /*z2: Zero Width;*/ logic [31:0] b; /*c: Zero Width;*/ struct packed {logic [31:0] d1; /*z: Zero Width;*/ } d; } 
   // CHECK-NEXT:   _GEN_1 = '{a: in1, b: in1, d: _GEN_0};

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -281,3 +281,23 @@ hw.module @TestCond() {
   }
   hw.output
 }
+
+// -----
+
+// Declaration keyword, type, and name alignment should not produce excessively
+// long lines when large aggregate types are involved. Lack of a declaration
+// keyword, i.e. when the declaration directly starts with a type, should not
+// indent the declaration.
+//
+// See https://github.com/llvm/circt/pull/6171
+
+// CHECK-LABEL:module Top{{.*}}
+// CHECK-NEXT:  reg        foo;{{.*}}
+// CHECK-NEXT:  reg [63:0] bar;{{.*}}
+// CHECK-NEXT:  struct packed {logic dw; logic [3:0] fn; logic [63:0] in; } agg;{{.*}}
+// CHECK-NEXT:endmodule
+hw.module @Top() {
+  %foo = sv.reg : !hw.inout<i1>
+  %bar = sv.reg : !hw.inout<i64>
+  %agg = sv.reg : !hw.inout<struct<dw: i1, fn: i4, in: i64>>
+}


### PR DESCRIPTION
We currently blindly align the types and names of declarations, which causes excessively large types like structs to ruin the alignment of declarations. Instead, introduce an upper bound above which a type does not contribute towards the `maxTypeWidth` count. This means that excessively large types are just emitted without alignment, without other declarations being forced to follow the same alignment. This change is purely cosmetic.

Also tweak the code that emits the spacing around declarations to work by specifying a target column up to which spaces should be filled, and then filling in those spaces, or a minimum of 1. This makes it harder to get the alignment off by 1 just because some type or decl word was empty and didn't need a trailing space.