### PR TITLE
[FIRRTL][LowerXMR] Ignore circuit, always module.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -349,17 +349,16 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
   }
 
   /// Generate the ABI ref_<circuit>_<module> prefix string into `prefix`.
+  /// As an extension, emit ref_<module>_<module> for all modules,
+  /// which is same for only spec-defined "public" module (main module).
+  /// However, this allows use of intermediate modules, as on the extmodule
+  /// side there's no notion of what circuit it belongs to.
   void getRefABIPrefix(FModuleLike mod, SmallVectorImpl<char> &prefix) {
-    auto modName = mod.getModuleName();
-    auto circuitName = getOperation().getName();
-    if (auto ext = dyn_cast<FExtModuleOp>(*mod)) {
-      // Use defName for module portion, if set.
+    auto name = mod.getModuleName();
+    if (auto ext = dyn_cast<FExtModuleOp>(*mod))
       if (auto defname = ext.getDefname(); defname && !defname->empty())
-        modName = *defname;
-      // Assume(/require) all extmodule's are within their own circuit.
-      circuitName = modName;
-    }
-    (Twine("ref_") + circuitName + "_" + modName).toVector(prefix);
+        name = *defname;
+    (Twine("ref_") + name + "_" + name).toVector(prefix);
   }
 
   /// Get full macro name as StringAttr for the specified ref port.

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -699,14 +699,14 @@ firrtl.circuit "Top" {
 
   // CHECK-NOT:   sv.macro.decl @ref_Top_Top_e
   // CHECK:  hw.hierpath private @[[XMR5:.+]] [@Foo::@[[FOO_X_SYM:.+]]]
-  // CHECK:  sv.macro.decl @ref_Top_Foo_x
-  // CHECK-NEXT{LITERAL}: sv.macro.def @ref_Top_Foo_x "{{0}}"
-  // CHECK-SAME:          ([@[[XMR5]]]) {output_file = #hw.output_file<"ref_Top_Foo.sv">}
+  // CHECK:  sv.macro.decl @ref_Foo_Foo_x
+  // CHECK-NEXT{LITERAL}: sv.macro.def @ref_Foo_Foo_x "{{0}}"
+  // CHECK-SAME:          ([@[[XMR5]]]) {output_file = #hw.output_file<"ref_Foo_Foo.sv">}
 
-  // CHECK-NEXT:  sv.macro.decl @ref_Top_Foo_y
-  // CHECK-NEXT:          sv.macro.def @ref_Top_Foo_y "internal.path"
+  // CHECK-NEXT:  sv.macro.decl @ref_Foo_Foo_y
+  // CHECK-NEXT:          sv.macro.def @ref_Foo_Foo_y "internal.path"
   // CHECK-NOT:           ([
-  // CHECK-SAME:          {output_file = #hw.output_file<"ref_Top_Foo.sv">}
+  // CHECK-SAME:          {output_file = #hw.output_file<"ref_Foo_Foo.sv">}
 
   // CHECK:        hw.hierpath private @[[XMR1]] [@Top::@[[TOP_W_SYM:.+]]]
   // CHECK:        hw.hierpath private @[[XMR2]] [@Top::@foo, @Foo::@[[FOO_X_SYM]]]


### PR DESCRIPTION
Allow use from an extmodule that isn't the main module of the circuit it's defined within.