### PR TITLE
[HW] Allow for quoted struct field names

### DIFF
--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -242,9 +242,10 @@ static ParseResult parseFields(AsmParser &p,
                                SmallVectorImpl<FieldInfo> &parameters) {
   return p.parseCommaSeparatedList(
       mlir::AsmParser::Delimiter::LessGreater, [&]() -> ParseResult {
-        StringRef name;
+        std::string name;
         Type type;
-        if (p.parseKeyword(&name) || p.parseColon() || p.parseType(type))
+        if (p.parseKeywordOrString(&name) || p.parseColon() ||
+            p.parseType(type))
           return failure();
         parameters.push_back(
             FieldInfo{StringAttr::get(p.getContext(), name), type});
@@ -256,7 +257,8 @@ static ParseResult parseFields(AsmParser &p,
 static void printFields(AsmPrinter &p, ArrayRef<FieldInfo> fields) {
   p << '<';
   llvm::interleaveComma(fields, p, [&](const FieldInfo &field) {
-    p << field.name.getValue() << ": " << field.type;
+    p.printKeywordOrString(field.name.getValue());
+    p << ": " << field.type;
   });
   p << ">";
 }

--- a/test/Dialect/HW/types.mlir
+++ b/test/Dialect/HW/types.mlir
@@ -17,8 +17,8 @@ module {
     return
   }
 
-  // CHECK-LABEL: func @structType(%arg0: !hw.struct<>, %arg1: !hw.struct<foo: i32, bar: i4, baz: !hw.struct<foo: i7>>) {
-  func.func @structType(%SE: !hw.struct<>, %SF: !hw.struct<foo: i32, bar: i4, baz: !hw.struct<foo: i7>>) {
+  // CHECK-LABEL: func @structType(%arg0: !hw.struct<>, %arg1: !hw.struct<foo: i32, bar: i4, baz: !hw.struct<foo: i7>, "123": i42>) {
+  func.func @structType(%SE: !hw.struct<>, %SF: !hw.struct<foo: i32, bar: i4, baz: !hw.struct<foo: i7>, "123": i42>) {
     return
   }
 


### PR DESCRIPTION
Change `parseKeyword` to `parseKeywordOrString` in `StructType`, such that struct field names that aren't valid keywords in MLIR can still be used. They now print as quoted strings instead of crashing any MLIR tool trying to read the type back in.