### PR TITLE
[Firtool] Rerun IMCP after register optimizations

### DIFF
--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -191,6 +191,9 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
         createSimpleCanonicalizerPass());
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         circt::firrtl::createRegisterOptimizerPass());
+    // Re-run IMConstProp to propagate constants produced by register
+    // optimizations.
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMConstPropPass());
     pm.addPass(firrtl::createIMDeadCodeElimPass());
   }
 

--- a/test/firtool/register-optimization.fir
+++ b/test/firtool/register-optimization.fir
@@ -1,4 +1,5 @@
 ; RUN: firtool %s | FileCheck %s
+; Check that `r` is optimized and the constant is propagated to the top-level port. 
 ; CHECK-NOT:   Passthrough
 ; CHECK-NOT:   Child
 ; CHECK-LABEL: module Example

--- a/test/firtool/register-optimization.fir
+++ b/test/firtool/register-optimization.fir
@@ -1,0 +1,34 @@
+; RUN: firtool %s | FileCheck %s
+; CHECK-NOT:   Passthrough
+; CHECK-NOT:   Child
+; CHECK-LABEL: module Example
+; CHECK:       assign out = 1'h0;
+
+circuit Example :
+  module Passthrough:
+    input en: UInt<1>
+    output out: UInt<1>
+    out <= en
+
+  module Child:
+    input clock: Clock
+    input zero: UInt<1>
+    input unknown: UInt<1>
+    output out: UInt<1>
+    
+    reg r : UInt<1>, clock
+    r <= zero
+    node b = and(r, unknown)
+    inst p of Passthrough
+    p.en <= b
+    out <= p.out
+
+  module Example:
+    input clock: Clock
+    input unknown: UInt<1>
+    output out: UInt<1>
+    inst c of Child
+    c.clock <= clock
+    c.zero <= UInt<1>(0)
+    c.unknown <= unknown
+    out <= c.out


### PR DESCRIPTION
This PR adds extra IMCP just after register optimization pass.
We separated register optimization from IMCP to avoid changing
observable behaivor of hardward in IMCP but the separation started
to craete phase-ordering problem regarding IMCP and reg optimization pass.
This commit for now adds one more IMCP after register optimization
to fix one particular regression reported internally