### PR TITLE
[Python] Downgrade setuptools_scm, drop python 3.7 as EOL

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -17,8 +17,6 @@ jobs:
       matrix:
         config:
           - os: ubuntu-20.04
-            cibw_build: cp37-manylinux_x86_64
-          - os: ubuntu-20.04
             cibw_build: cp38-manylinux_x86_64
           - os: ubuntu-20.04
             cibw_build: cp39-manylinux_x86_64
@@ -26,8 +24,6 @@ jobs:
             cibw_build: cp310-manylinux_x86_64
           - os: ubuntu-20.04
             cibw_build: cp311-manylinux_x86_64
-          - os: macos-latest
-            cibw_build: cp37-macosx_x86_64
           - os: macos-latest
             cibw_build: cp38-macosx_x86_64
           - os: macos-latest

--- a/lib/Bindings/Python/pyproject.toml
+++ b/lib/Bindings/Python/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "setuptools_scm>=6.2",
+    "setuptools_scm==7.1.0",
     "wheel",
     "cmake>=3.12",
     # MLIR build depends.


### PR DESCRIPTION
The wheel version string has been broken for python>=3.8. It seems
recent version of setuptools_scm has changed something, so
downgrade the version for now.

Also this commit removes python 3.7 supports since it caused some version conflicts.

Testing here: https://github.com/llvm/circt/actions/runs/6272413564