### PR TITLE
[FIRRTL] Simplify getFieldRefFromValue, add+use FieldRefCache.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -88,6 +88,9 @@ bool walkDrivers(FIRRTLBaseValue value, bool lookThroughWires,
 /// likely will result in source having slightly different type.
 FieldRef getFieldRefFromValue(Value value, bool lookThroughCasts = false);
 
+/// Get the delta indexing from a value, as a FieldRef.
+FieldRef getDeltaRef(Value value, bool lookThroughCasts = false);
+
 /// Get a string identifier representing the FieldRef.  Return this string and a
 /// boolean indicating if a valid "root" for the identifier was found.  If
 /// nameSafe is true, this will generate a string that is better suited for

--- a/include/circt/Dialect/FIRRTL/FieldRefCache.h
+++ b/include/circt/Dialect/FIRRTL/FieldRefCache.h
@@ -1,0 +1,57 @@
+//===- FieldRefCache.h - FieldRef cache -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares FieldRefCache, a caching getFieldRefFromValue that
+// caching FieldRef's for each queried value and all indexing operations
+// visited during the walk.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_FIELDREFCACHE_H
+#define CIRCT_DIALECT_FIRRTL_FIELDREFCACHE_H
+
+#include "circt/Support/FieldRef.h"
+#include "circt/Support/LLVM.h"
+
+namespace circt {
+namespace firrtl {
+
+/// Caching version of getFieldRefFromValue.  Computes the requested FieldRef
+/// and for all operations visited along the way.  Tracks some stats in debug.
+class FieldRefCache {
+  using Key = llvm::PointerIntPair<Value, 1, bool>;
+  DenseMap<Key, FieldRef> refs;
+#ifndef NDEBUG
+  size_t computed = 0;
+  size_t hits = 0;
+  size_t queries = 0;
+#endif
+
+public:
+  FieldRef getFieldRefFromValue(Value value, bool lookThroughCasts = false);
+
+#ifndef NDEBUG
+  void printStats(llvm::raw_ostream &os) const;
+  void addToTotals(size_t &totalHits, size_t &totalComputed,
+                   size_t &totalQueries) const;
+  void verifyImpl() const;
+#endif // NDEBUG
+
+  /// Verify cached fieldRefs against firrtl::getFieldRefFromValue.
+  /// No-op in release builds.
+  void verify() const {
+#ifndef NDEBUG
+    verifyImpl();
+#endif // NDEBUG
+  }
+};
+
+} // namespace firrtl
+} // namespace circt
+
+#endif // CIRCT_DIALECT_FIRRTL_FIELDREFCACHE_H

--- a/include/circt/Dialect/FIRRTL/FieldRefCache.h
+++ b/include/circt/Dialect/FIRRTL/FieldRefCache.h
@@ -33,7 +33,11 @@ class FieldRefCache {
 #endif
 
 public:
+  /// Caching version of getFieldRefFromValue.
   FieldRef getFieldRefFromValue(Value value, bool lookThroughCasts = false);
+
+  /// Drop all cached entries.
+  void clear() { refs.clear(); }
 
 #ifndef NDEBUG
   void printStats(llvm::raw_ostream &os) const;

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(CIRCT_FIRRTL_Sources
   CHIRRTLDialect.cpp
+  FieldRefCache.cpp
   FIRRTLAnnotationHelper.cpp
   FIRRTLAnnotations.cpp
   FIRRTLAttributes.cpp

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -475,59 +475,38 @@ bool circt::firrtl::walkDrivers(FIRRTLBaseValue value, bool lookThroughWires,
 
 FieldRef circt::firrtl::getFieldRefFromValue(Value value,
                                              bool lookThroughCasts) {
-  // This code walks upwards from the subfield and calculates the field ID at
-  // each level. At each stage, it must take the current id, and re-index it as
-  // a nested bundle under the parent field.. This is accomplished by using the
-  // parent field's ID as a base, and adding the field ID of the child.
+  if (LLVM_UNLIKELY(!value))
+    return {value, 0};
+
+  // Walk through indexing operations, and optionally through casts.
   unsigned id = 0;
-  while (value) {
+  while (true) {
     Operation *op = value.getDefiningOp();
 
     // If this is a block argument, we are done.
     if (!op)
-      break;
+      return {value, id};
 
-    auto handled =
-        TypeSwitch<Operation *, bool>(op)
-            .Case<RefCastOp, ConstCastOp, UninferredResetCastOp>([&](auto op) {
-              if (!lookThroughCasts)
-                return false;
-              value = op.getInput();
-              return true;
-            })
-            .Case<SubfieldOp, OpenSubfieldOp>([&](auto subfieldOp) {
-              value = subfieldOp.getInput();
-              typename decltype(subfieldOp)::InputType bundleType =
-                  subfieldOp.getInput().getType();
-              // Rebase the current index on the parent field's
-              // index.
-              id += bundleType.getFieldID(subfieldOp.getFieldIndex());
-              return true;
-            })
-            .Case<SubindexOp, OpenSubindexOp>([&](auto subindexOp) {
-              value = subindexOp.getInput();
-              typename decltype(subindexOp)::InputType vecType =
-                  subindexOp.getInput().getType();
-              // Rebase the current index on the parent field's
-              // index.
-              id += vecType.getFieldID(subindexOp.getIndex());
-              return true;
-            })
-            .Case<RefSubOp>([&](RefSubOp refSubOp) {
-              value = refSubOp.getInput();
-              auto refInputType = refSubOp.getInput().getType();
-              id += FIRRTLTypeSwitch<FIRRTLBaseType, size_t>(
-                        refInputType.getType())
-                        .Case<FVectorType, BundleType>([&](auto type) {
-                          return type.getFieldID(refSubOp.getIndex());
-                        });
-              return true;
-            })
-            .Default(false);
-    if (!handled)
-      break;
+    auto deltaRef =
+        TypeSwitch<Operation *, FieldRef>(op)
+            .Case<RefCastOp, ConstCastOp, UninferredResetCastOp>(
+                [lookThroughCasts](auto op) {
+                  if (!lookThroughCasts)
+                    return FieldRef();
+                  return FieldRef(op.getInput(), 0);
+                })
+            .Case<SubfieldOp, OpenSubfieldOp, SubindexOp, OpenSubindexOp,
+                  RefSubOp>([](auto subOp) { return subOp.getAccessedField(); })
+            .Default(FieldRef());
+    auto next = deltaRef.getValue();
+    if (!next)
+      return {value, id};
+
+    // Update total fieldID.
+    id = deltaRef.getSubField(id).getFieldID();
+    // Chase to next value.
+    value = next;
   }
-  return {value, id};
 }
 
 /// Get the string name of a value which is a direct child of a declaration op.

--- a/lib/Dialect/FIRRTL/FieldRefCache.cpp
+++ b/lib/Dialect/FIRRTL/FieldRefCache.cpp
@@ -129,8 +129,7 @@ void firrtl::FieldRefCache::addToTotals(size_t &totalHits,
 
 void firrtl::FieldRefCache::verifyImpl() const {
   // (Guarding under EXPENSIVE_CHECKS may be appropriate.)
-  for (auto &[key, ref] : refs) {
+  for (auto &[key, ref] : refs)
     assert(ref == firrtl::getFieldRefFromValue(key.getPointer(), key.getInt()));
-  }
 }
 #endif // NDEBUG

--- a/lib/Dialect/FIRRTL/FieldRefCache.cpp
+++ b/lib/Dialect/FIRRTL/FieldRefCache.cpp
@@ -1,0 +1,136 @@
+//===- FieldRefCache.cpp - FieldRef cache ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines FieldRefCache, a caching getFieldRefFromValue that caching
+// FieldRef's for each queried value and all indexing operations visited during
+// the walk.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/FieldRefCache.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/FormatVariadic.h"
+
+using namespace circt;
+using namespace firrtl;
+
+FieldRef firrtl::FieldRefCache::getFieldRefFromValue(Value value,
+                                                     bool lookThroughCasts) {
+  using Info = std::pair<Value, size_t>;
+  // Vector of values and delta to next entry.
+  // Last will be root (delta == 0), so walking backwards constructs
+  // FieldRef's for all visited operations.
+  SmallVector<Info> indexing;
+  // Ignore null value for simplicity.
+  if (!value)
+    return FieldRef();
+
+#ifndef NDEBUG
+  ++queries;
+#endif
+
+  while (value) {
+    // Check cache to see if already visited.
+    auto it = refs.find(Key(value, lookThroughCasts));
+    if (it != refs.end()) {
+      // Found! If entire query is hit, we're done.
+#ifndef NDEBUG
+      ++hits;
+#endif
+      auto ref = it->second;
+      if (indexing.empty())
+        return ref;
+      // Otherwise, add entry for this using cached FieldRef,
+      // and add the FieldRef's value as last (root) entry.
+      indexing.emplace_back(value, ref.getFieldID());
+      indexing.emplace_back(ref.getValue(), 0);
+      break;
+    }
+#ifndef NDEBUG
+    ++computed;
+#endif
+
+    Operation *op = value.getDefiningOp();
+
+    // If this is a block argument, we are done.
+    if (!op) {
+      indexing.emplace_back(value, 0);
+      break;
+    }
+
+    auto [newValue, adj] =
+        TypeSwitch<Operation *, Info>(op)
+            .Case<RefCastOp, ConstCastOp, UninferredResetCastOp>([&](auto op) {
+              if (!lookThroughCasts)
+                return Info{};
+              return Info{op.getInput(), 0};
+            })
+            .Case<SubfieldOp, OpenSubfieldOp>([&](auto subfieldOp) {
+              typename decltype(subfieldOp)::InputType bundleType =
+                  subfieldOp.getInput().getType();
+              return Info{subfieldOp.getInput(),
+                          bundleType.getFieldID(subfieldOp.getFieldIndex())};
+            })
+            .Case<SubindexOp, OpenSubindexOp>([&](auto subindexOp) {
+              typename decltype(subindexOp)::InputType vecType =
+                  subindexOp.getInput().getType();
+              return Info{subindexOp.getInput(),
+                          vecType.getFieldID(subindexOp.getIndex())};
+            })
+            .Case<RefSubOp>([&](RefSubOp refSubOp) {
+              auto refInputType = refSubOp.getInput().getType();
+              size_t delta = FIRRTLTypeSwitch<FIRRTLBaseType, size_t>(
+                                 refInputType.getType())
+                                 .Case<FVectorType, BundleType>([&](auto type) {
+                                   return type.getFieldID(refSubOp.getIndex());
+                                 });
+              return Info{refSubOp.getInput(), delta};
+            })
+            .Default(Info{});
+    indexing.emplace_back(value, adj); // adj is zero in 'unhandled' case.
+    value = newValue;
+  }
+  // Last entry in indexing is the root.
+  assert(!indexing.empty());
+  assert(indexing.back().second == 0);
+
+  auto root = indexing.back().first;
+  size_t id = 0;
+  FieldRef cur(root, 0);
+  for (auto &info : llvm::reverse(indexing)) {
+    id += info.second;
+    cur = FieldRef(root, id);
+    refs.try_emplace({info.first, lookThroughCasts}, cur);
+  }
+  return cur;
+}
+
+#ifndef NDEBUG
+void firrtl::FieldRefCache::printStats(llvm::raw_ostream &os) const {
+  os << llvm::formatv("FieldRefCache stats:\n"
+                      "\thits:     {0}\n"
+                      "\tcomputed: {1}\n"
+                      "\tqueries:  {2}\n",
+                      hits, computed, queries);
+}
+void firrtl::FieldRefCache::addToTotals(size_t &totalHits,
+                                        size_t &totalComputed,
+                                        size_t &totalQueries) const {
+  totalHits += hits;
+  totalComputed += computed;
+  totalQueries += queries;
+}
+
+void firrtl::FieldRefCache::verifyImpl() const {
+  // (Guarding under EXPENSIVE_CHECKS may be appropriate.)
+  for (auto &[key, ref] : refs) {
+    assert(ref == firrtl::getFieldRefFromValue(key.getPointer(), key.getInt()));
+  }
+}
+#endif // NDEBUG

--- a/lib/Dialect/FIRRTL/FieldRefCache.cpp
+++ b/lib/Dialect/FIRRTL/FieldRefCache.cpp
@@ -55,25 +55,7 @@ FieldRef firrtl::FieldRefCache::getFieldRefFromValue(Value value,
     ++computed;
 #endif
 
-    Operation *op = value.getDefiningOp();
-
-    // If this is a block argument, we are done.
-    if (!op) {
-      indexing.emplace_back(value, 0);
-      break;
-    }
-
-    auto deltaRef =
-        TypeSwitch<Operation *, FieldRef>(op)
-            .Case<RefCastOp, ConstCastOp, UninferredResetCastOp>([&](auto op) {
-              if (!lookThroughCasts)
-                return FieldRef();
-              return FieldRef(op.getInput(), 0);
-            })
-            .Case<SubindexOp, OpenSubindexOp, SubfieldOp, OpenSubfieldOp,
-                  RefSubOp>(
-                [&](auto subOp) { return subOp.getAccessedField(); })
-            .Default(FieldRef());
+    auto deltaRef = getDeltaRef(value, lookThroughCasts);
     indexing.emplace_back(value, deltaRef.getFieldID());
     value = deltaRef.getValue();
   }


### PR DESCRIPTION
As suggested in review to avoid worst-case behavior causing
many repeated walks of same indexing chain (in part or whole).

Pull into small helper class for possible re-use in transforms
or a simple analysis wrapper.

Refactor `getFieldFromFromValue` to be bother simpler and to share code with `FieldRefCache`'s version.