### PR TITLE
[FIRRTL] Add GroupSink pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -170,6 +170,8 @@ std::unique_ptr<mlir::Pass> createLowerClassesPass();
 
 std::unique_ptr<mlir::Pass> createLowerGroupsPass();
 
+std::unique_ptr<mlir::Pass> createGroupSinkPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -737,6 +737,17 @@ def LowerGroups : Pass<"firrtl-lower-groups", "firrtl::CircuitOp"> {
   let dependentDialects = ["sv::SVDialect"];
 }
 
+def GroupSink : Pass<"firrtl-group-sink", "firrtl::FModuleOp"> {
+  let summary = "Sink operations into FIRRTL optional groups";
+  let description = [{
+
+  }];
+  let constructor = "::circt::firrtl::createGroupSinkPass()";
+  let statistics = [
+    Statistic<"numSunk", "num-sunk", "Number of operations sunk">,
+  ];
+}
+
 def HoistPassthrough : Pass<"firrtl-hoist-passthrough", "firrtl::CircuitOp"> {
   let summary = "Hoist passthrough logic";
   let description = [{

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -12,6 +12,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   FinalizeIR.cpp
   FlattenMemory.cpp
   GrandCentral.cpp
+  GroupSink.cpp
   HoistPassthrough.cpp
   IMConstProp.cpp
   IMDeadCodeElim.cpp

--- a/lib/Dialect/FIRRTL/Transforms/GroupSink.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GroupSink.cpp
@@ -1,0 +1,54 @@
+//===- GroupSink.cpp - Sink ops into FIRRTL optional groups ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file sinks operations in FIRRTL optional groups.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+#include "mlir/IR/Dominance.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Transforms/ControlFlowSinkUtils.h"
+
+#define DEBUG_TYPE "firrtl-group-sink"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+/// A control-flow sink pass.
+struct GroupSink : public GroupSinkBase<GroupSink> {
+  void runOnOperation() override;
+};
+} // end anonymous namespace
+
+void GroupSink::runOnOperation() {
+  LLVM_DEBUG(
+      llvm::dbgs() << "==----- Running GroupSink "
+                      "---------------------------------------------------===\n"
+                   << "Module: '" << getOperation().getName() << "'\n";);
+  auto &domInfo = getAnalysis<mlir::DominanceInfo>();
+  getOperation()->walk([&](GroupOp group) {
+    SmallVector<Region *> regionsToSink({&group.getRegion()});
+    numSunk = controlFlowSink(
+        regionsToSink, domInfo,
+        [](Operation *op, Region *) { return !hasDontTouch(op); },
+        [](Operation *op, Region *region) {
+          // Move the operation to the beginning of the region's entry block.
+          // This guarantees the preservation of SSA dominance of all of the
+          // operation's uses are in the region.
+          op->moveBefore(&region->front(), region->front().begin());
+        });
+  });
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createGroupSinkPass() {
+  return std::make_unique<GroupSink>();
+}

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -112,6 +112,7 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
   modulePM.addPass(firrtl::createExpandWhensPass());
   modulePM.addPass(firrtl::createSFCCompatPass());
+  modulePM.addPass(firrtl::createGroupSinkPass());
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerGroupsPass());
 

--- a/test/Dialect/FIRRTL/group-sink.mlir
+++ b/test/Dialect/FIRRTL/group-sink.mlir
@@ -1,0 +1,27 @@
+// RUN: circt-opt -pass-pipeline="builtin.module(firrtl.circuit(firrtl.module(firrtl-group-sink)))" %s | FileCheck %s
+
+// Test that simple things are sunk:
+//   - nodes
+//   - constants
+//   - primitive operations
+//
+// CHECK-LABEL: firrtl.circuit "SimpleSink"
+firrtl.circuit "SimpleSink" {
+ firrtl.declgroup @A bind {
+ }
+ // CHECK: firrtl.module @SimpleSink
+ firrtl.module @SimpleSink(in %a: !firrtl.uint<1>) {
+   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+   %node = firrtl.node %a : !firrtl.uint<1>
+   %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
+   // CHECK-NEXT: firrtl.group @A
+   firrtl.group @A {
+     // CHECK: %c0_ui1 = firrtl.constant
+     %constant_group = firrtl.node %c0_ui1 : !firrtl.uint<1>
+     // CHECK: %node = firrtl.node
+     %node_group = firrtl.node %node : !firrtl.uint<1>
+     // CHECK: %0 = firrtl.not
+     %primop_group = firrtl.node %0 : !firrtl.uint<1>
+   }
+ }
+}


### PR DESCRIPTION
Add a new pass, GroupSink/firrtl-group-sink, which will sink operations that are only used by optional groups into optional groups.