### PR TITLE
[Ibis] Print offending port name and use count on containers-to-hw error

### DIFF
--- a/lib/Dialect/Ibis/Transforms/IbisContainersToHW.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisContainersToHW.cpp
@@ -112,7 +112,8 @@ struct ContainerOpConversionPattern : public OpConversionPattern<ContainerOp> {
       if (nUsers != 1)
         return outputPort->emitOpError()
                << "expected exactly one ibis.port.write op of the output "
-                  "port: " << output.name.str() << " found: " << nUsers;
+                  "port: "
+               << output.name.str() << " found: " << nUsers;
       auto writer = cast<PortWriteOp>(*users.begin());
       outputValues.push_back(writer.getValue());
       rewriter.eraseOp(outputPort);

--- a/lib/Dialect/Ibis/Transforms/IbisContainersToHW.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisContainersToHW.cpp
@@ -112,7 +112,7 @@ struct ContainerOpConversionPattern : public OpConversionPattern<ContainerOp> {
       if (nUsers != 1)
         return outputPort->emitOpError()
                << "expected exactly one ibis.port.write op of the output "
-                  "port";
+                  "port: " << output.name.str() << " found: " << nUsers;
       auto writer = cast<PortWriteOp>(*users.begin());
       outputValues.push_back(writer.getValue());
       rewriter.eraseOp(outputPort);


### PR DESCRIPTION
The containers-to-hw passes requires each output port to be written exactly once.  Extend the error message to contain the port name and the actual number of writes.