### PR TITLE
[firtool] Deprecate -dedup option

### DIFF
--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -84,7 +84,12 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
       !opt.disableHoistingHWPassthrough));
 
   if (opt.dedup)
-    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDedupPass());
+    emitWarning(UnknownLoc::get(pm.getContext()),
+                "option -dedup is deprecated since firtool 1.57.0, has no "
+                "effect (deduplication is always enabled), and will be removed "
+                "in firtool 1.58.0");
+
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDedupPass());
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createWireDFTPass());
 

--- a/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
+++ b/test/Dialect/FIRRTL/SFCTests/ExtractSeqMems/Compose.fir
@@ -1,7 +1,7 @@
 ; UNSUPPORTED: system-windows
 ;   See https://github.com/llvm/circt/issues/4128
 ; RUN: rm -rf %t
-; RUN: firtool --repl-seq-mem --repl-seq-mem-file=mems.conf --split-verilog --dedup --emit-omir -o=%t %s
+; RUN: firtool --repl-seq-mem --repl-seq-mem-file=mems.conf --split-verilog --emit-omir -o=%t %s
 ; RUN: FileCheck %s --check-prefix=TESTHARNESS < %t/TestHarness.sv
 ; RUN: FileCheck %s --check-prefix=DUTMODULE < %t/Prefix_DUTModule.sv
 ; RUN: FileCheck %s --check-prefix=SEQMEMSGROUP < %t/Prefix_SeqMemsGroup.sv

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -1,4 +1,4 @@
-; RUN: firtool -dedup -split-input-file -ir-fir --preserve-aggregate=all -disable-opt %s | FileCheck %s
+; RUN: firtool -split-input-file -ir-fir --preserve-aggregate=all -disable-opt %s | FileCheck %s
 ; Tests extracted from:
 ;   - test/scala/firrtlTests/transforms/DedupTests.scala
 ; The following tests are not included:

--- a/test/firtool/blackbox-directories.fir
+++ b/test/firtool/blackbox-directories.fir
@@ -1,4 +1,4 @@
-; RUN: firtool -dedup %s | FileCheck %s
+; RUN: firtool %s | FileCheck %s
 
 ; This test is checking that FIRRTL external modules which have BlackBoxInline
 ; annotations want to write to the same file write to the proper output

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -11,7 +11,7 @@ circuit test:
     input wData: UInt<8>
 
     mem tbMemoryKind1:
-      data-type => UInt<8>
+      data-type => UInt<1>
       depth => 16
       reader => r
       writer => w
@@ -42,7 +42,7 @@ circuit test:
     input wData: UInt<8>
 
     mem dutMemory:
-      data-type => UInt<8>
+      data-type => UInt<2>
       depth => 32
       reader => r
       writer => w
@@ -72,7 +72,7 @@ circuit test:
     input wData: UInt<8>
 
     mem tbMemoryKind1:
-      data-type => UInt<8>
+      data-type => UInt<3>
       depth => 16
       reader => r
       writer => w
@@ -180,7 +180,7 @@ circuit test:
 ; CHECK-NEXT:   {
 ; CHECK-NEXT:     "module_name": "dutMemory_ext",
 ; CHECK-NEXT:     "depth": 32,
-; CHECK-NEXT:     "width": 8,
+; CHECK-NEXT:     "width": 2,
 ; CHECK-NEXT:     "masked": false,
 ; CHECK-NEXT:     "read": 1,
 ; CHECK-NEXT:     "write": 1,
@@ -194,6 +194,6 @@ circuit test:
 
 
 ; CHECK-LABEL: FILE "dutModule.conf"
-; CHECK: name tbMemoryKind1_ext depth 16 width 8 ports write,read
-; CHECK: name dutMemory_ext depth 32 width 8 ports write,read
-; CHECK: name tbMemoryKind1_0_ext depth 16 width 8 ports write,read
+; CHECK: name tbMemoryKind1_ext depth 16 width 1 ports write,read
+; CHECK: name dutMemory_ext depth 32 width 2 ports write,read
+; CHECK: name tbMemoryKind1_0_ext depth 16 width 3 ports write,read

--- a/test/firtool/prefixMemory.fir
+++ b/test/firtool/prefixMemory.fir
@@ -86,7 +86,7 @@ circuit Foo : %[[
     ; SIM-FIR-SAME:   prefix = "prefix2_"
     ; SIM-HW:       hw.instance "mem_ext" @prefix2_mem
     mem mem :
-      data-type => UInt<1>
+      data-type => UInt<2>
       depth => 8
       read-latency => 1
       write-latency => 1


### PR DESCRIPTION
Deprecate the "-dedup" option.  Make this a no-op and always run FIRRTL deduplication.  It would be exceedingly rare for a user to actually not want dedup and it is a bit of a footgun that firtool requires users to specify it.

Treat this option as deprecated in 1.57.0 and remove it in 1.58.0. This makes things simpler as 1.57.0 will not require any atomic updates to projects which use firtool.