### PR TITLE
[firtool] Remove -dedup option

### DIFF
--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -103,10 +103,6 @@ struct FirtoolOptions {
       llvm::cl::desc("Transform vectors of bundles to bundles of vectors"),
       llvm::cl::init(false), llvm::cl::cat(category)};
 
-  llvm::cl::opt<bool> dedup{
-      "dedup", llvm::cl::desc("Deduplicate structurally identical modules"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
   llvm::cl::opt<bool> grandCentralInstantiateCompanionOnly{
       "grand-central-instantiate-companion",
       llvm::cl::desc("Run Grand Central in a mode where the companion module "

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -83,12 +83,6 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
       /*hoistHWDrivers=*/!opt.disableOptimization &&
       !opt.disableHoistingHWPassthrough));
 
-  if (opt.dedup)
-    emitWarning(UnknownLoc::get(pm.getContext()),
-                "option -dedup is deprecated since firtool 1.57.0, has no "
-                "effect (deduplication is always enabled), and will be removed "
-                "in firtool 1.58.0");
-
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDedupPass());
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createWireDFTPass());


### PR DESCRIPTION
Fuilly remove deprecated -dedup option.

This should land after the firtool 1.57.0. release is tagged.