### PR TITLE
[firtool] Remove -dedup option

### DIFF
--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -111,10 +111,6 @@ struct FirtoolOptions {
       llvm::cl::desc("Transform vectors of bundles to bundles of vectors"),
       llvm::cl::init(false), llvm::cl::cat(category)};
 
-  llvm::cl::opt<bool> dedup{
-      "dedup", llvm::cl::desc("Deduplicate structurally identical modules"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
   llvm::cl::opt<bool> noDedup{
       "no-dedup",
       llvm::cl::desc("Disable deduplication of structurally identical modules"),

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -87,12 +87,6 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
       !opt.disableHoistingHWPassthrough));
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createProbeDCEPass());
 
-  if (opt.dedup)
-    emitWarning(UnknownLoc::get(pm.getContext()),
-                "option -dedup is deprecated since firtool 1.57.0, has no "
-                "effect (deduplication is always enabled), and will be removed "
-                "in firtool 1.58.0");
-
   if (!opt.noDedup)
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDedupPass());
 


### PR DESCRIPTION
Fuilly remove deprecated -dedup option.

Land this after `firtool 1.57.0` is cut.