### PR TITLE
[ExportVerilog] Format specifiers: hierpath separation character

### DIFF
--- a/docs/Dialects/SV/RationaleSV.md
+++ b/docs/Dialects/SV/RationaleSV.md
@@ -141,6 +141,20 @@ sv.verbatim "MACRO({{0}}, {{1}} reg={{4}}, {{3}})"
             {symRefs = [@reg1, @Module1, @instance1]}
 ```
 
+Substitions also allow format specifier after a ':'. The meaning of said options
+depends on the of the operand or symbol. So far, the follow format specifiers
+are supported:
+
+- Symbol refering to a `hw.hierpath`: the separation character for joining names
+in the path. Defaults to '.'.
+
+Example:
+
+```
+sv.verbatim "hierpath {{0:|}}" {symbols = [@instref_1]}
+// Produces: "hierpath foo|bar|leaf"
+```
+
 ## Cost Model
 
 The SV dialect is primarily designed for human consumption, not machines.  As

--- a/docs/Dialects/SV/RationaleSV.md
+++ b/docs/Dialects/SV/RationaleSV.md
@@ -151,6 +151,7 @@ in the path. Defaults to '.'.
 Example:
 
 ```
+hw.hierpath @instref_1 [@TopModule::@foo, @FooModule::@bar, @BarModule::@leaf]
 sv.verbatim "hierpath {{0:|}}" {symbols = [@instref_1]}
 // Produces: "hierpath foo|bar|leaf"
 ```

--- a/docs/Dialects/SV/RationaleSV.md
+++ b/docs/Dialects/SV/RationaleSV.md
@@ -117,7 +117,7 @@ The verbatim operation produces a typed value expressed by a string of
 SystemVerilog.  This can be used to access macros and other values that are
 only sensible as Verilog text. There are three kinds of verbatim operations:
 
- 1. VerbatimOp(`sv.verbatim`, the statement form
+ 1. VerbatimOp(`sv.verbatim`), the statement form
  2. VerbatimExprOp(`sv.verbatim.expr`), the expression form.
  3. VerbatimExprSEOp(`sv.verbatim.expr.se`), the effectful expression form.
 
@@ -142,11 +142,11 @@ sv.verbatim "MACRO({{0}}, {{1}} reg={{4}}, {{3}})"
 ```
 
 Substitions also allow format specifier after a ':'. The meaning of said options
-depends on the of the operand or symbol. So far, the follow format specifiers
-are supported:
+depends on the operand type or the operation pointed to by the symbol. So far,
+the following format specifiers are supported:
 
-- Symbol refering to a `hw.hierpath`: the separation character for joining names
-in the path. Defaults to '.'.
+- Symbol refering to a `hw.hierpath`: the separation string for joining names
+in the path. Defaults to ".".
 
 Example:
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1270,6 +1270,7 @@ void EmitterBase::emitTextWithSubstitutions(
             if (auto globalRef = dyn_cast<HierPathOp>(symOp)) {
               auto namepath = globalRef.getNamepathAttr().getValue();
               for (auto [index, sym] : llvm::enumerate(namepath)) {
+                // Emit the seperator string.
                 if (index > 0)
                   ps << (fmtOptsStr.empty() ? "." : fmtOptsStr);
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1226,6 +1226,16 @@ void EmitterBase::emitTextWithSubstitutions(
         next--;
         continue;
       }
+      size_t operandNoLength = next - start;
+
+      // Format string options follow a ':'.
+      StringRef fmtOptsStr;
+      if (string[next] == ':') {
+        size_t startFmtOpts = next + 1;
+        while (next < string.size() && string[next] != '}')
+          ++next;
+        fmtOptsStr = string.substr(startFmtOpts, next - startFmtOpts);
+      }
 
       // We must have a }} right after the digits.
       if (!string.substr(next).startswith("}}"))
@@ -1234,7 +1244,7 @@ void EmitterBase::emitTextWithSubstitutions(
       // We must be able to decode the integer into an unsigned.
       unsigned operandNo = 0;
       if (string.drop_front(start)
-              .take_front(next - start)
+              .take_front(operandNoLength)
               .getAsInteger(10, operandNo)) {
         emitError(op, "operand substitution too large");
         continue;
@@ -1261,7 +1271,7 @@ void EmitterBase::emitTextWithSubstitutions(
               auto namepath = globalRef.getNamepathAttr().getValue();
               for (auto [index, sym] : llvm::enumerate(namepath)) {
                 if (index > 0)
-                  ps << ".";
+                  ps << (fmtOptsStr.empty() ? "." : fmtOptsStr);
 
                 auto innerRef = cast<InnerRefAttr>(sym);
                 auto ref = state.symbolCache.getInnerDefinition(

--- a/lib/Dialect/MSFT/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/ExportQuartusTcl.cpp
@@ -131,16 +131,8 @@ void TclOutputState::emitInnerRefPart(hw::InnerRefAttr innerRef) {
 
 void TclOutputState::emitPath(hw::HierPathOp ref,
                               std::optional<StringRef> subpath) {
-  // Traverse each part of the path.
-  auto parts = ref.getNamepathAttr().getAsRange<hw::InnerRefAttr>();
-  auto lastPart = std::prev(parts.end());
-  for (auto part : parts) {
-    emitInnerRefPart(part);
-    if (part != *lastPart)
-      os << '|';
-  }
-
-  // Some placements don't require subpaths.
+  os << "{{" << symbolRefs.size() << ":|}}";
+  symbolRefs.push_back(FlatSymbolRefAttr::get(ref));
   if (subpath)
     os << subpath;
 }

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -577,6 +577,9 @@ hw.module @ReadMemXMRHierPath() {
   }
 }
 
+// CHECK: // VERB: hierpath ReadMemXMR|ReadMem|mem
+sv.verbatim "// VERB: hierpath {{0:|}}" {symbols = [@ReadMem_path]}
+
 // CHECK-LABEL: module UninitReg1(
 hw.module @UninitReg1(%clock: i1, %reset: i1, %cond: i1, %value: i2) {
   %c-1_i2 = hw.constant -1 : i2


### PR DESCRIPTION
Support format specifiers on Verbatim*Op substitutions. The first one only applies to hierpaths: the separation character.