### PR TITLE
[Pipeline] Remove internal clock, reset,stall signals.

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -27,7 +27,11 @@ class PipelineBase<string mnemonic, list<Trait> traits = []> :
   Op<Pipeline_Dialect, mnemonic, !listconcat(traits, [
       Pure,
       RegionKindInterface,
-      AttrSizedOperandSegments])> {
+      AttrSizedOperandSegments,
+      DeclareOpInterfaceMethods<OpAsmOpInterface, [
+        "getAsmResultNames",
+        "getAsmBlockArgumentNames"]>
+      ])> {
   let results = (outs Variadic<AnyType>:$dataOutputs, I1:$done);
   let hasCustomAssemblyFormat = 1;
 
@@ -50,34 +54,9 @@ class PipelineBase<string mnemonic, list<Trait> traits = []> :
       return &region->front();
     }
 
-    // Returns the inner clock signal argument of this pipeline.
-    BlockArgument getInnerClock() {
-      Block* entryStage = getEntryStage();
-      return entryStage->getArgument(entryStage->getNumArguments() - 3);
-    }
-
-    // Returns the inner reset signal argument of this pipeline.
-    BlockArgument getInnerReset() {
-      Block* entryStage = getEntryStage();
-      return getEntryStage()->getArgument(entryStage->getNumArguments() - 2);
-    }
-
-    // Returns the inner go signal argument of this pipeline.
-    BlockArgument getInnerGo() {
-      Block* entryStage = getEntryStage();
-      return getEntryStage()->getArgument(entryStage->getNumArguments() - 1);
-    }
-
     // Returns true if this pipeline has a stall signal.
     bool hasStall() {
       return static_cast<bool>(getStall());
-    }
-
-    // Returns the stall signal argument of this pipeline, if it exists.
-    BlockArgument getInnerStall() {
-      assert(hasStall() && "pipeline has no stall signal");
-      Block* entryStage = getEntryStage();
-      return getEntryStage()->getArgument(entryStage->getNumArguments() - 4);
     }
 
     llvm::ArrayRef<BlockArgument> getInnerInputs() {
@@ -90,6 +69,25 @@ class PipelineBase<string mnemonic, list<Trait> traits = []> :
     // result if it is used multiple times.
     llvm::SmallVector<Value> getExtInputs() {
       return detail::getValuesDefinedOutsideRegion(getRegion());
+    }
+
+    // Gets the n'th stage of this pipeline
+    Block* getStage(unsigned n) {
+      auto& blocks = getRegion().getBlocks();
+      assert(n < blocks.size() && "Stage index out of bounds");
+      return &*std::next(blocks.begin(), n);
+    }
+
+    // Returns the enable signal of the given pipeline stage. This is always
+    // the last block argument of a stage for anything but the entry stage.
+    Value getStageEnableSignal(size_t stageIdx) {
+      return getStageEnableSignal(getStage(stageIdx));
+    }
+
+    // Returns the enable signal for the given stage. The enable signal is always
+    // the last signal in the stage argument list.
+    Value getStageEnableSignal(Block* stage) {
+      return stage->getArguments().back();
     }
   }];
 }
@@ -121,9 +119,7 @@ def UnscheduledPipelineOp : PipelineBase<"unscheduled", [
   let extraModuleClassDeclaration = "";
 }
 
-def ScheduledPipelineOp : PipelineBase<"scheduled", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
-  ]> {
+def ScheduledPipelineOp : PipelineBase<"scheduled"> {
   let summary = "Scheduled pipeline operation";
   let description = [{
     The `pipeline.scheduled` operation represents a scheduled pipeline.
@@ -204,9 +200,6 @@ def ScheduledPipelineOp : PipelineBase<"scheduled", [
       return getStages().size();
     }
 
-    void getAsmBlockArgumentNames(mlir::Region &region,
-                        mlir::OpAsmSetValueNameFn setNameFn);
-
     // Returns all of the stages in this pipeline. The stages are ordered
     // with respect to their position in the pipeline as determined by the
     // control flow of `pipeline.stage` operations.
@@ -216,13 +209,6 @@ def ScheduledPipelineOp : PipelineBase<"scheduled", [
     // Returns a map of stages to their index in the pipeline - this is
     // with respect to 'getOrderedStages'.
     llvm::DenseMap<Block*, unsigned> getStageMap();
-
-    // Gets the n'th stage of this pipeline
-    Block* getStage(unsigned n) {
-      auto& blocks = getRegion().getBlocks();
-      assert(n < blocks.size() && "Stage index out of bounds");
-      return &*std::next(blocks.begin(), n);
-    }
 
     // Returns the last stage in the pipeline.
     Block* getLastStage();
@@ -245,20 +231,6 @@ def ScheduledPipelineOp : PipelineBase<"scheduled", [
       // Data arguments for all non-entry stages are all block arguments
       // except for the last block arguments (which is the stage enable signal).
       return stage->getArguments().drop_back();
-    }
-
-    // Returns the enable signal of the given pipeline stage. This is always
-    // the last block argument of a stage for anything but the entry stage.
-    Value getStageEnableSignal(size_t stageIdx) {
-      return getStageEnableSignal(getStage(stageIdx));
-    }
-
-    // Returns the enable signal for the given stage. The enable signal is always
-    // the last signal in the stage argument list.
-    Value getStageEnableSignal(Block* stage) {
-      if(stage != getEntryStage())
-        return stage->getArguments().back();
-      return getInnerGo();
     }
 
     // Returns the stage kind of the given stage index.

--- a/integration_test/Dialect/Ibis/end_to_end.mlir
+++ b/integration_test/Dialect/Ibis/end_to_end.mlir
@@ -47,7 +47,7 @@ ibis.class @C2 {
     %sibling_out_ref = ibis.get_port %sibling, @out : !ibis.scoperef<@C1> -> !ibis.portref<out i32>
     %sibling_out = ibis.port.read %sibling_out_ref : !ibis.portref<out i32>
 
-    %res, %done = pipeline.scheduled(%a0 : i32 = %sibling_out) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
+    %res, %done = pipeline.scheduled(%a0 : i32 = %sibling_out) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
         %0 = comb.mul %a0, %a0 : i32
         pipeline.stage ^bb1
       ^bb1(%s1_enable : i1):

--- a/integration_test/Dialect/Pipeline/nonstallable/test1/nonstallable_test1.mlir
+++ b/integration_test/Dialect/Pipeline/nonstallable/test1/nonstallable_test1.mlir
@@ -12,7 +12,7 @@
 
 hw.module @nonstallable_test1(%arg0: i32, %go: i1, %clock: !seq.clock, %reset: i1, %stall: i1) -> (out: i32, done: i1) {
   %out, %done = pipeline.scheduled "nonstallable_test1"(%a0 : i32 = %arg0)
-      stall(%s = %stall) clock(%c = %clock) reset(%r = %reset) go(%g = %go)
+      stall(%stall) clock(%clock) reset(%reset) go(%go) entryEn(%s0_enable)
         {stallability = [true, false, false, true, true]} -> (out : i32) {
     pipeline.stage ^bb1
   ^bb1(%s1_enable: i1):

--- a/integration_test/Dialect/Pipeline/nonstallable/test2/nonstallable_test2.mlir
+++ b/integration_test/Dialect/Pipeline/nonstallable/test2/nonstallable_test2.mlir
@@ -12,7 +12,7 @@
 
 hw.module @nonstallable_test2(%arg0: i32, %go: i1, %clock: !seq.clock, %reset: i1, %stall: i1) -> (out: i32, done : i1) {
   %out, %done = pipeline.scheduled "nonstallable_test2"(%a0 : i32 = %arg0)
-      stall(%s = %stall) clock(%c = %clock) reset(%r = %reset) go(%g = %go)
+      stall(%stall) clock(%clock) reset(%reset) go(%go) entryEn(%s0_enable)
         {stallability = [true, false, true, false, true]} -> (out : i32) {
     pipeline.stage ^bb1
   ^bb1(%s1_enable: i1):

--- a/integration_test/Dialect/Pipeline/simple/simple.mlir
+++ b/integration_test/Dialect/Pipeline/simple/simple.mlir
@@ -21,7 +21,7 @@
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0
 
 hw.module @simple(%arg0 : i32, %arg1 : i32, %go : i1, %clock : !seq.clock, %reset : i1) -> (out: i32, done : i1) {
-  %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clock) reset(%r = %reset) go(%g = %go) -> (out: i32) {
+  %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clock) reset(%reset) go(%go) entryEn(%s0_enable) -> (out: i32) {
       %add0 = comb.add %a0, %a1 : i32
       pipeline.stage ^bb1
 

--- a/integration_test/Dialect/Pipeline/stall/stallTest.mlir
+++ b/integration_test/Dialect/Pipeline/stall/stallTest.mlir
@@ -21,7 +21,7 @@
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0
 
 hw.module @stallTest(%arg0 : i32, %arg1 : i32, %go : i1, %stall : i1, %clock : !seq.clock, %reset : i1) -> (out: i32, done : i1) {
-  %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) stall(%s = %stall) clock(%c = %clock) reset(%r = %reset) go(%g = %go) -> (out: i32) {
+  %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) stall(%stall) clock(%clock) reset(%reset) go(%go) entryEn(%s0_enable) -> (out: i32) {
       %add0 = comb.add %a0, %a1 : i32
       pipeline.stage ^bb1
 

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -330,12 +330,6 @@ public:
     if (failed(lowerStage(pipeline.getEntryStage(), args, 0)))
       return failure();
 
-    // Replace uses of clock, reset, and stall.
-    pipeline.getInnerClock().replaceAllUsesWith(pipeline.getClock());
-    pipeline.getInnerReset().replaceAllUsesWith(pipeline.getReset());
-    if (auto stall = pipeline.getStall())
-      pipeline.getInnerStall().replaceAllUsesWith(stall);
-
     pipeline.erase();
     return success();
   }

--- a/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
@@ -166,10 +166,10 @@ void ExplicitRegsPass::runOnPipeline(ScheduledPipelineOp pipeline) {
   llvm::DenseSet<Value> extLikeInputs;
   for (auto extInput : pipeline.getExtInputs())
     extLikeInputs.insert(extInput);
-  extLikeInputs.insert(pipeline.getInnerClock());
-  extLikeInputs.insert(pipeline.getInnerReset());
+  extLikeInputs.insert(pipeline.getClock());
+  extLikeInputs.insert(pipeline.getReset());
   if (pipeline.hasStall())
-    extLikeInputs.insert(pipeline.getInnerStall());
+    extLikeInputs.insert(pipeline.getStall());
 
   // Iterate over the pipeline body in-order (!).
   stageMap = pipeline.getStageMap();

--- a/test/Conversion/PipelineToHW/test_basic.mlir
+++ b/test/Conversion/PipelineToHW/test_basic.mlir
@@ -5,7 +5,7 @@
 // CHECK:           hw.output %[[VAL_0]] : i1
 // CHECK:         }
 hw.module @testBasic(%arg0: i1, %clk: !seq.clock, %rst: i1) -> (out: i1) {
-  %0:2 = pipeline.scheduled(%a0 : i1 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %arg0) -> (out : i1) {
+  %0:2 = pipeline.scheduled(%a0 : i1 = %arg0) clock(%clk) reset(%rst) go(%arg0) entryEn(%s0_enable) -> (out : i1) {
     pipeline.return %a0 : i1
   }
   hw.output %0#0 : i1
@@ -27,7 +27,7 @@ hw.module @testBasic(%arg0: i1, %clk: !seq.clock, %rst: i1) -> (out: i1) {
 // CHECK:           hw.output %[[VAL_13]], %[[VAL_15]] : i32, i1
 // CHECK:         }
 hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32, done: i1) {
-  %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
+  %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     %1 = pipeline.latency 2 -> (i32) {
       %6 = comb.add %a0, %a0 : i32
       pipeline.latency.return %6 : i32
@@ -56,7 +56,7 @@ hw.module @testLatency1(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst:
 // CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
 // CHECK:         }
 hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out0: i32, out1: i1) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
   ^bb1(%6: i32, %7: i32, %s1_enable : i1):  // pred: ^bb1
@@ -93,7 +93,7 @@ hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i
 // CHECK:           hw.output %[[VAL_15]], %[[VAL_14]] : i32, i1
 // CHECK:         }
 hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out0: i32, out1: i1) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
   ^bb1(%2: i32, %3: i32, %s1_enable: i1):  // pred: ^bb0
@@ -104,7 +104,7 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst:
     pipeline.return %8 : i32
   }
 
-  %1:2 = pipeline.scheduled(%a0 : i32 = %0#0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %1:2 = pipeline.scheduled(%a0 : i32 = %0#0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
   ^bb1(%2: i32, %3: i32, %s1_enable: i1):  // pred: ^bb0
@@ -132,7 +132,7 @@ hw.module @testMultiple(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst:
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_1]] : i32, i32
 // CHECK:         }
 hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: !seq.clock, %rst: i1) -> (out0: i32, out1: i32) {
-  %0:3 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0: i32, out1: i32) {
+  %0:3 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg0) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out0: i32, out1: i32) {
     %true = hw.constant true
     %1 = comb.sub %a0, %a0 : i32
     pipeline.stage ^bb1 regs(%1 : i32)
@@ -176,12 +176,12 @@ hw.module @testSingleWithExt(%arg0: i32, %ext1: i32, %go : i1, %clk: !seq.clock,
 // CHECK:           hw.output %[[VAL_22]] : i32
 // CHECK:         }
 hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: !seq.clock, %rst: i1) -> (out0: i32) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     %zero = hw.constant 0 : i32
     %reg_out_wire = sv.wire : !hw.inout<i32>
     %reg_out = sv.read_inout %reg_out_wire : !hw.inout<i32>
     %add0 = comb.add %reg_out, %a0 : i32
-    %out = seq.compreg.ce %add0, %c, %g, %r, %zero : i32
+    %out = seq.compreg.ce %add0, %clk, %go, %rst, %zero : i32
     sv.assign %reg_out_wire, %out : i32
     pipeline.stage ^bb1 regs(%out : i32)
 
@@ -189,7 +189,7 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: !seq.clock, %rst: i1) ->
     %reg1_out_wire = sv.wire : !hw.inout<i32>
     %reg1_out = sv.read_inout %reg1_out_wire : !hw.inout<i32>
     %add1 = comb.add %reg1_out, %6 : i32
-    %out1 = seq.compreg.ce %add1, %c, %s1_enable, %r, %zero : i32
+    %out1 = seq.compreg.ce %add1, %clk, %s1_enable, %rst, %zero : i32
     sv.assign %reg1_out_wire, %out1 : i32
 
     pipeline.stage ^bb2 regs(%out1 : i32)
@@ -198,7 +198,7 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: !seq.clock, %rst: i1) ->
     %reg2_out_wire = sv.wire : !hw.inout<i32>
     %reg2_out = sv.read_inout %reg2_out_wire : !hw.inout<i32>
     %add2 = comb.add %reg2_out, %9 : i32
-    %out2 = seq.compreg.ce %add2, %c, %s2_enable, %r, %zero : i32
+    %out2 = seq.compreg.ce %add2, %clk, %s2_enable, %rst, %zero : i32
     sv.assign %reg2_out_wire, %out2 : i32
     pipeline.return %out2  : i32
   }
@@ -223,7 +223,7 @@ hw.module @testControlUsage(%arg0: i32, %go : i1, %clk: !seq.clock, %rst: i1) ->
 // CHECK:           hw.output %[[VAL_8]], %[[VAL_15]] : i32, i1
 // CHECK:         }
 hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: !seq.clock, %rst: i1) -> (out0: i32, out1: i1) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     pipeline.stage ^bb1 regs(%a0 : i32)
   ^bb1(%1: i32, %s1_enable : i1):  // pred: ^bb1
     pipeline.return %1 : i32
@@ -266,7 +266,7 @@ hw.module @testWithStall(%arg0: i32, %go: i1, %stall : i1, %clk: !seq.clock, %rs
 
 hw.module @testStallability(%arg0: i32, %go: i1, %clk: !seq.clock, %rst: i1, %stall: i1) -> (out: i32) {
   %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0)
-      stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go)
+      stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable)
       {stallability = [true, false, true]} -> (out : i32) {
     pipeline.stage ^bb1 regs("a0" = %a0 : i32)
   ^bb1(%a0_0: i32, %s1_enable: i1):  // pred: ^bb0

--- a/test/Conversion/PipelineToHW/test_ce.mlir
+++ b/test/Conversion/PipelineToHW/test_ce.mlir
@@ -14,7 +14,7 @@
 // CHECK:         }
 
 hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out0: i32, out1: i1) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
   ^bb1(%6: i32, %7: i32, %s1_enable : i1):  // pred: ^bb1

--- a/test/Conversion/PipelineToHW/test_clockgates.mlir
+++ b/test/Conversion/PipelineToHW/test_clockgates.mlir
@@ -32,7 +32,7 @@
 // CGATE:         }
 
 hw.module @testSingle(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out0: i32, out1: i1) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %1 = comb.sub %a0, %a1 : i32
     %true = hw.constant true
     %false = hw.constant false

--- a/test/Dialect/Pipeline/Transforms/schedule-linear-pipeline.mlir
+++ b/test/Dialect/Pipeline/Transforms/schedule-linear-pipeline.mlir
@@ -1,29 +1,29 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(any(pipeline-schedule-linear))' %s | FileCheck %s
 
 // CHECK-LABEL:   hw.module @pipeline(
-// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[VAL_4:.*]]: i1) -> (out: i32) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]], %[[VAL_8:.*]] : i32 = %[[VAL_1]]) clock(%[[VAL_9:.*]] = %[[CLOCK]]) reset(%[[VAL_10:.*]] = %[[VAL_4]]) go(%[[VAL_11:.*]] = %[[VAL_2]]) -> (out : i32) {
-// CHECK:             %[[VAL_12:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] {ssp.operator_type = @add1} : i32
-// CHECK:             %[[VAL_13:.*]] = comb.add %[[VAL_8]], %[[VAL_7]] {ssp.operator_type = @add1} : i32
+// CHECK-SAME:          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[GO:.*]]: i1, %[[CLOCK:.*]]: !seq.clock, %[[RESET:.*]]: i1) -> (out: i32) {
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]], %[[VAL_8:.*]] : i32 = %[[VAL_1]]) clock(%[[CLOCK]]) reset(%[[RESET]]) go(%[[GO]]) entryEn(%[[VAL_9:.*]]) -> (out : i32) {
+// CHECK:             %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] {ssp.operator_type = @add1} : i32
+// CHECK:             %[[VAL_11:.*]] = comb.add %[[VAL_8]], %[[VAL_7]] {ssp.operator_type = @add1} : i32
 // CHECK:             pipeline.stage ^bb1
-// CHECK:           ^bb1(%[[VAL_14:.*]]: i1):
+// CHECK:           ^bb1(%[[VAL_12:.*]]: i1):
 // CHECK:             pipeline.stage ^bb2
-// CHECK:           ^bb2(%[[VAL_15:.*]]: i1):
-// CHECK:             %[[VAL_16:.*]] = comb.mul %[[VAL_7]], %[[VAL_12]] {ssp.operator_type = @mul2} : i32
+// CHECK:           ^bb2(%[[VAL_13:.*]]: i1):
+// CHECK:             %[[VAL_14:.*]] = comb.mul %[[VAL_7]], %[[VAL_10]] {ssp.operator_type = @mul2} : i32
 // CHECK:             pipeline.stage ^bb3
-// CHECK:           ^bb3(%[[VAL_17:.*]]: i1):
+// CHECK:           ^bb3(%[[VAL_15:.*]]: i1):
 // CHECK:             pipeline.stage ^bb4
-// CHECK:           ^bb4(%[[VAL_18:.*]]: i1):
+// CHECK:           ^bb4(%[[VAL_16:.*]]: i1):
 // CHECK:             pipeline.stage ^bb5
-// CHECK:           ^bb5(%[[VAL_19:.*]]: i1):
-// CHECK:             %[[VAL_20:.*]] = comb.add %[[VAL_16]], %[[VAL_13]] {ssp.operator_type = @add1} : i32
+// CHECK:           ^bb5(%[[VAL_17:.*]]: i1):
+// CHECK:             %[[VAL_18:.*]] = comb.add %[[VAL_14]], %[[VAL_11]] {ssp.operator_type = @add1} : i32
 // CHECK:             pipeline.stage ^bb6
-// CHECK:           ^bb6(%[[VAL_21:.*]]: i1):
+// CHECK:           ^bb6(%[[VAL_19:.*]]: i1):
 // CHECK:             pipeline.stage ^bb7
-// CHECK:           ^bb7(%[[VAL_22:.*]]: i1):
-// CHECK:             pipeline.return %[[VAL_20]] : i32
+// CHECK:           ^bb7(%[[VAL_20:.*]]: i1):
+// CHECK:             pipeline.return %[[VAL_18]] : i32
 // CHECK:           }
-// CHECK:           hw.output %[[VAL_23:.*]] : i32
+// CHECK:           hw.output %[[VAL_21:.*]] : i32
 // CHECK:         }
 
 module {
@@ -33,7 +33,7 @@ module {
   }
 
   hw.module @pipeline(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
-    %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go)
+    %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable)
       {operator_lib = @lib} -> (out: i32) {
       %0 = comb.add %a0, %a1 {ssp.operator_type = @add1} : i32
       %1 = comb.mul %a0, %0 {ssp.operator_type = @mul2} : i32

--- a/test/Dialect/Pipeline/errors.mlir
+++ b/test/Dialect/Pipeline/errors.mlir
@@ -2,7 +2,7 @@
 
 
 hw.module @res_argn(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
-  %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     // expected-error @+1 {{'pipeline.return' op expected 1 return values, got 0.}}
     pipeline.return
   }
@@ -12,7 +12,7 @@ hw.module @res_argn(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst 
 // -----
 
 hw.module @res_argtype(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i31) {
-  %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i31) {
+  %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i31) {
     // expected-error @+1 {{'pipeline.return' op expected return value of type 'i31', got 'i32'.}}
     pipeline.return %a0 : i32
   }
@@ -23,7 +23,7 @@ hw.module @res_argtype(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %r
 
 hw.module @unterminated(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op all blocks must be terminated with a `pipeline.stage` or `pipeline.return` op.}}
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
 
   ^bb1(%s1_enable : i1):
@@ -38,7 +38,7 @@ hw.module @unterminated(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %
 // -----
 
 hw.module @mixed_stages(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1
 
@@ -56,7 +56,7 @@ hw.module @mixed_stages(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %
 
 hw.module @cycle_pipeline1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op pipeline contains a cycle.}}
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1
 
@@ -76,7 +76,7 @@ hw.module @cycle_pipeline1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock
 
 hw.module @cycle_pipeline2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op pipeline contains a cycle.}}
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1
 
@@ -92,7 +92,7 @@ hw.module @cycle_pipeline2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock
 // -----
 
 hw.module @earlyAccess(%arg0: i32, %arg1: i32, %go: i1, %clk : !seq.clock, %rst: i1) -> (out: i32) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     // expected-error @+1 {{'pipeline.latency' op result 0 is used before it is available.}}
     %1 = pipeline.latency 2 -> (i32) {
       %6 = comb.add %a0, %a0 : i32
@@ -111,7 +111,7 @@ hw.module @earlyAccess(%arg0: i32, %arg1: i32, %go: i1, %clk : !seq.clock, %rst:
 // Test which verifies that the values referenced within the body of a
 // latency operation also adhere to the latency constraints.
 hw.module @earlyAccess2(%arg0: i32, %arg1: i32, %go: i1, %clk : !seq.clock, %rst: i1) -> (out: i32) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     // expected-error @+1 {{'pipeline.latency' op result 0 is used before it is available.}}
     %1 = pipeline.latency 2 -> (i32) {
       %res = comb.add %a0, %a0 : i32
@@ -141,7 +141,7 @@ hw.module @earlyAccess2(%arg0: i32, %arg1: i32, %go: i1, %clk : !seq.clock, %rst
 
 
 hw.module @registeredPass(%arg0: i32, %arg1: i32, %go: i1, %clk : !seq.clock, %rst: i1) -> (out: i32) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     // expected-error @+1 {{'pipeline.latency' op result 0 is used before it is available.}}
     %1 = pipeline.latency 2 -> (i32) {
       %6 = comb.add %a0, %a0 : i32
@@ -159,7 +159,7 @@ hw.module @registeredPass(%arg0: i32, %arg1: i32, %go: i1, %clk : !seq.clock, %r
 
 hw.module @missing_valid_entry3(%arg : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> () {
   // expected-error @+1 {{'pipeline.scheduled' op block 1 must have an i1 argument as the last block argument (stage valid signal).}}
-  %done = pipeline.scheduled(%a0 : i32 = %arg) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> () {
+  %done = pipeline.scheduled(%a0 : i32 = %arg) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> () {
      pipeline.stage ^bb1
    ^bb1:
       pipeline.return
@@ -170,7 +170,7 @@ hw.module @missing_valid_entry3(%arg : i32, %go : i1, %clk : !seq.clock, %rst : 
 // -----
 
 hw.module @invalid_clock_gate(%arg : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> () {
-  %done = pipeline.scheduled(%a0 : i32 = %arg) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> () {
+  %done = pipeline.scheduled(%a0 : i32 = %arg) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> () {
      // expected-note@+1 {{prior use here}}
      %c0_i2 = hw.constant 0 : i2
      // expected-error @+1 {{use of value '%c0_i2' expects different type than prior uses: 'i1' vs 'i2'}}
@@ -185,7 +185,7 @@ hw.module @invalid_clock_gate(%arg : i32, %go : i1, %clk : !seq.clock, %rst : i1
 
 hw.module @noStallSignalWithStallability(%arg0 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op cannot specify stallability without a stall signal.}}
-  %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) clock(%c = %clk) reset(%r = %rst) go(%g = %go)
+  %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable)
     {stallability = [true, false, true]}
    -> (out: i32) {
     pipeline.stage ^bb1
@@ -203,7 +203,7 @@ hw.module @noStallSignalWithStallability(%arg0 : i32, %go : i1, %clk : !seq.cloc
 
 hw.module @incorrectStallabilitySize(%arg0 : i32, %go : i1, %clk : !seq.clock, %rst : i1, %stall : i1) -> (out: i32) {
   // expected-error @+1 {{'pipeline.scheduled' op stallability array must be the same length as the number of stages. Pipeline has 3 stages but array had 2 elements.}}
-  %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go)
+  %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable)
     {stallability = [true, false]}
    -> (out: i32) {
     pipeline.stage ^bb1

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -1,17 +1,17 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL:  hw.module @unscheduled1(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
-// CHECK-NEXT:    %dataOutputs, %done = pipeline.unscheduled(%arg0_0 : i32 = %arg0, %arg1_1 : i32 = %arg1) clock(%arg2 = %clk) reset(%arg3 = %rst) go(%arg4 = %go) -> (out : i32) {
+// CHECK-NEXT:    %out, %done = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable)  -> (out : i32) {
 // CHECK-NEXT:      %0 = pipeline.latency 2 -> (i32) {
-// CHECK-NEXT:        %1 = comb.add %arg0_0, %arg1_1 : i32
+// CHECK-NEXT:        %1 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:        pipeline.latency.return %1 : i32
 // CHECK-NEXT:      }
 // CHECK-NEXT:      pipeline.return %0 : i32
 // CHECK-NEXT:    }
-// CHECK-NEXT:    hw.output %dataOutputs : i32
+// CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
 hw.module @unscheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
-  %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %0 = pipeline.latency 2 -> (i32) {
       %1 = comb.add %a0, %a1 : i32
       pipeline.latency.return %1 : i32
@@ -22,7 +22,7 @@ hw.module @unscheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %
 }
 
 // CHECK-LABEL:  hw.module @scheduled1(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
-// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
+// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:      pipeline.stage ^bb1
 // CHECK-NEXT:    ^bb1(%s1_enable: i1):  // pred: ^bb0
@@ -31,7 +31,7 @@ hw.module @unscheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
 hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1
 
@@ -43,7 +43,7 @@ hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rs
 
 
 // CHECK-LABEL:  hw.module @scheduled2(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
-// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
+// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%0 : i32)
 // CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_enable: i1):  // pred: ^bb0
@@ -52,7 +52,7 @@ hw.module @scheduled1(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rs
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
 hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1 regs(%0 : i32)
 
@@ -63,7 +63,7 @@ hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rs
 }
 
 // CHECK-LABEL:  hw.module @scheduledWithPassthrough(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
-// CHECK-NEXT:    %out0, %out1, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0 : i32, out1 : i32) {
+// CHECK-NEXT:    %out0, %out1, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out0 : i32, out1 : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%0 : i32) pass(%a1 : i32)
 // CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_pass0: i32, %s1_enable: i1):  // pred: ^bb0
@@ -72,7 +72,7 @@ hw.module @scheduled2(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rs
 // CHECK-NEXT:    hw.output %out0 : i32
 // CHECK-NEXT:  }
 hw.module @scheduledWithPassthrough(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
-  %0:3 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out0: i32, out1: i32) {
+  %0:3 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out0: i32, out1: i32) {
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1 regs(%0 : i32) pass(%a1 : i32)
 
@@ -83,20 +83,20 @@ hw.module @scheduledWithPassthrough(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !
 }
 
 // CHECK-LABEL:  hw.module @withStall(%arg0: i32, %stall: i1, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
-// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
+// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
 // CHECK-NEXT:      pipeline.return %a0 : i32
 // CHECK-NEXT:    }
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
 hw.module @withStall(%arg0 : i32, %stall : i1, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     pipeline.return %a0 : i32
   }
   hw.output %0 : i32
 }
 
 // CHECK-LABEL:  hw.module @withMultipleRegs(%arg0: i32, %stall: i1, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
-// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
+// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
 // CHECK-NEXT:      pipeline.stage ^bb1 regs(%a0 : i32, %a0 : i32)
 // CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_reg1: i32, %s1_enable: i1):  // pred: ^bb0
 // CHECK-NEXT:      pipeline.return %s1_reg0 : i32
@@ -104,7 +104,7 @@ hw.module @withStall(%arg0 : i32, %stall : i1, %go : i1, %clk : !seq.clock, %rst
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
 hw.module @withMultipleRegs(%arg0 : i32, %stall : i1, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     pipeline.stage ^bb1 regs(%a0 : i32, %a0 : i32)
 
    ^bb1(%0 : i32, %1 : i32, %s1_enable : i1):
@@ -114,7 +114,7 @@ hw.module @withMultipleRegs(%arg0 : i32, %stall : i1, %go : i1, %clk : !seq.cloc
 }
 
 // CHECK-LABEL:  hw.module @withClockGates(%arg0: i32, %stall: i1, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
-// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
+// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
 // CHECK-NEXT:      %true = hw.constant true
 // CHECK-NEXT:      %true_0 = hw.constant true
 // CHECK-NEXT:      %true_1 = hw.constant true
@@ -125,7 +125,7 @@ hw.module @withMultipleRegs(%arg0 : i32, %stall : i1, %go : i1, %clk : !seq.cloc
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
 hw.module @withClockGates(%arg0 : i32, %stall : i1, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     %true1 = hw.constant true
     %true2 = hw.constant true
     %true3 = hw.constant true
@@ -138,7 +138,7 @@ hw.module @withClockGates(%arg0 : i32, %stall : i1, %go : i1, %clk : !seq.clock,
 }
 
 // CHECK-LABEL:  hw.module @withNames(%arg0: i32, %arg1: i32, %go: i1, %clk: !seq.clock, %rst: i1) -> (out: i32) {
-// CHECK-NEXT:    %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out : i32) {
+// CHECK-NEXT:    %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
 // CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
 // CHECK-NEXT:      pipeline.stage ^bb1 regs("myAdd" = %0 : i32, %0 : i32, "myOtherAdd" = %0 : i32)
 // CHECK-NEXT:    ^bb1(%myAdd: i32, %s1_reg1: i32, %myOtherAdd: i32, %s1_enable: i1):  // pred: ^bb0
@@ -147,7 +147,7 @@ hw.module @withClockGates(%arg0 : i32, %stall : i1, %go : i1, %clk : !seq.clock,
 // CHECK-NEXT:    hw.output %out : i32
 // CHECK-NEXT:  }
 hw.module @withNames(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst : i1) -> (out: i32) {
-  %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%c = %clk) reset(%r = %rst) go(%g = %go) -> (out: i32){
+  %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1 regs("myAdd" = %0 : i32, %0 : i32, "myOtherAdd" = %0 : i32)
 
@@ -158,9 +158,9 @@ hw.module @withNames(%arg0 : i32, %arg1 : i32, %go : i1, %clk : !seq.clock, %rst
 }
 
 // CHECK-LABEL:   hw.module @withStallability(
-// CHECK:           %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go) {stallability = [true, false, true]} -> (out : i32)
+// CHECK:           %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) {stallability = [true, false, true]} -> (out : i32)
 hw.module @withStallability(%arg0 : i32, %go : i1, %clk : !seq.clock, %rst : i1, %stall : i1) -> (out: i32) {
-  %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) stall(%s = %stall) clock(%c = %clk) reset(%r = %rst) go(%g = %go)
+  %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable)
     {stallability = [true, false, true]}
    -> (out: i32) {
     pipeline.stage ^bb1


### PR DESCRIPTION
This also simplifies the stage enable signals, seeing as the entry enable signal will now always be the last argument of any mlir block inside the pipeline.