### PR TITLE
[FIRRTL] Cause "weak" OMIR Annotations to not block optimizations

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -93,6 +93,10 @@ public:
   void removeMember(StringAttr name);
   void removeMember(StringRef name);
 
+  /// Returns true if this is an annotation which can be safely deleted without
+  /// consequence.
+  bool canBeDeleted();
+
   using iterator = llvm::ArrayRef<NamedAttribute>::iterator;
   iterator begin() const { return getDict().begin(); }
   iterator end() const { return getDict().end(); }
@@ -262,6 +266,10 @@ public:
   static bool setDontTouch(Operation *op, bool dontTouch);
   static bool addDontTouch(Operation *op);
   static bool removeDontTouch(Operation *op);
+
+  /// Check if every annotation can be deleted.
+  bool canBeDeleted() const;
+  static bool canBeDeleted(Operation *op);
 
   bool operator==(const AnnotationSet &other) const {
     return annotations == other.annotations;

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1909,7 +1909,7 @@ struct FoldNodeName : public mlir::RewritePattern {
     auto node = cast<NodeOp>(op);
     auto name = node.getNameAttr();
     if (!node.hasDroppableName() || node.getInnerSym() ||
-        !node.getAnnotations().empty() || node.isForceable())
+        !AnnotationSet(node).canBeDeleted() || node.isForceable())
       return failure();
     auto *newOp = node.getInput().getDefiningOp();
     // Best effort, do not rename InstanceOp
@@ -1927,7 +1927,7 @@ struct NodeBypass : public mlir::RewritePattern {
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
     auto node = cast<NodeOp>(op);
-    if (node.getInnerSym() || !node.getAnnotations().empty() ||
+    if (node.getInnerSym() || !AnnotationSet(node).canBeDeleted() ||
         node.use_empty() || node.isForceable())
       return failure();
     rewriter.startRootUpdate(node);
@@ -1956,7 +1956,8 @@ LogicalResult NodeOp::fold(FoldAdaptor adaptor,
     return failure();
   if (hasDontTouch(getResult())) // handles inner symbols
     return failure();
-  if (getAnnotationsAttr() && !getAnnotationsAttr().empty())
+  if (getAnnotationsAttr() &&
+      !AnnotationSet(getAnnotationsAttr()).canBeDeleted())
     return failure();
   if (isForceable())
     return failure();
@@ -2183,7 +2184,7 @@ struct FoldResetMux : public mlir::RewritePattern {
     auto reset =
         dyn_cast_or_null<ConstantOp>(reg.getResetValue().getDefiningOp());
     if (!reset || hasDontTouch(reg.getOperation()) ||
-        !reg.getAnnotations().empty() || reg.isForceable())
+        !AnnotationSet(reg).canBeDeleted() || reg.isForceable())
       return failure();
     // Find the one true connect, or bail
     auto con = getSingleConnectUserOf(reg.getResult());

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1754,7 +1754,8 @@ static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
   // Only support wire and reg for now.
   if (!isa<WireOp>(connectedDecl) && !isa<RegOp>(connectedDecl))
     return failure();
-  if (hasDontTouch(connectedDecl) || !AnnotationSet(connectedDecl).empty() ||
+  if (hasDontTouch(connectedDecl) ||
+      !AnnotationSet(connectedDecl).canBeDeleted() ||
       !hasDroppableName(connectedDecl) ||
       cast<Forceable>(connectedDecl).isForceable())
     return failure();

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -57,7 +57,7 @@ static bool isDeletableWireOrRegOrNode(Operation *op) {
     return true;
 
   // Otherwise, don't delete if has anything keeping it around or unknown.
-  return AnnotationSet(op).empty() && !hasDontTouch(op) &&
+  return AnnotationSet(op).canBeDeleted() && !hasDontTouch(op) &&
          hasDroppableName(op) && !cast<Forceable>(op).isForceable();
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -46,17 +46,6 @@ static bool isDeletableDeclaration(Operation *op) {
   return !hasDontTouch(op) && AnnotationSet(op).empty();
 }
 
-/// Return true if the annotation is ok to drop when the target is dead.
-static bool isWeakReferencingAnnotation(Annotation anno) {
-  if (!anno.isClass(omirTrackerAnnoClass))
-    return false;
-
-  auto tpe = anno.getMember<StringAttr>("type");
-  return tpe &&
-         (tpe == "OMReferenceTarget" || tpe == "OMMemberReferenceTarget" ||
-          tpe == "OMMemberInstanceTarget");
-}
-
 namespace {
 struct IMDeadCodeElimPass : public IMDeadCodeElimBase<IMDeadCodeElimPass> {
   void runOnOperation() override;
@@ -402,7 +391,7 @@ void IMDeadCodeElimPass::runOnOperation() {
         hierPathOp =
             symbolTable->template lookup<hw::HierPathOp>(hierPathSym.getAttr());
 
-      if (isWeakReferencingAnnotation(anno)) {
+      if (anno.canBeDeleted()) {
         if (hierPathOp && portId >= 0)
           hierPathToElements[hierPathOp].insert(module.getArgument(portId));
         return false;
@@ -554,7 +543,7 @@ void IMDeadCodeElimPass::rewriteModuleBody(FModuleOp module) {
     auto hierPathSym = anno.getMember<FlatSymbolRefAttr>("circt.nonlocal");
     // We only clean up non-local annotations here as local annotations will
     // be deleted afterwards.
-    if (!isWeakReferencingAnnotation(anno) || !hierPathSym)
+    if (!anno.canBeDeleted() || !hierPathSym)
       return false;
     auto hierPathOp =
         symbolTable->template lookup<hw::HierPathOp>(hierPathSym.getAttr());

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -43,7 +43,7 @@ static bool isDeletableDeclaration(Operation *op) {
   if (auto name = dyn_cast<FNamableOp>(op))
     if (!name.hasDroppableName())
       return false;
-  return !hasDontTouch(op) && AnnotationSet(op).empty();
+  return !hasDontTouch(op) && AnnotationSet(op).canBeDeleted();
 }
 
 namespace {

--- a/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
@@ -68,7 +68,8 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
 
     // If the port is don't touch or has unprocessed annotations, we cannot
     // remove the port. Maybe we can allow annotations though.
-    if ((hasDontTouch(arg) || !port.annotations.empty()) && !ignoreDontTouch)
+    if ((hasDontTouch(arg) || !port.annotations.canBeDeleted()) &&
+        !ignoreDontTouch)
       continue;
 
     // TODO: Handle inout ports.

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -880,3 +880,73 @@ firrtl.circuit "RefSubOpPropagate" {
    // CHECK-NEXT: }
   }
 }
+
+// -----
+
+// OMIR annotation should not block removal.
+//   - See: https://github.com/llvm/circt/issues/6199
+//
+// CHECK-LABEL: firrtl.circuit "OMIRRemoval"
+firrtl.circuit "OMIRRemoval" {
+  firrtl.module @OMIRRemoval(
+    out %a: !firrtl.uint<1>,
+    out %b: !firrtl.uint<2>,
+    out %c: !firrtl.uint<3>,
+    out %d: !firrtl.uint<4>
+  ) {
+    %c1_ui1  = firrtl.constant 1  : !firrtl.uint<1>
+    %c3_ui2  = firrtl.constant 3  : !firrtl.uint<2>
+    %c7_ui3  = firrtl.constant 7  : !firrtl.uint<3>
+    %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
+
+    // CHECK-NOT: %tmp_0
+    %tmp_0 = firrtl.node %c1_ui1 {
+      annotations = [
+        {
+           class = "freechips.rocketchip.objectmodel.OMIRTracker",
+           id = 0 : i64,
+           type = "OMReferenceTarget"
+        }
+      ]} : !firrtl.uint<1>
+    firrtl.strictconnect %a, %tmp_0 : !firrtl.uint<1>
+
+    // CHECK-NOT: %tmp_1
+    %tmp_1 = firrtl.node %c3_ui2 {
+      annotations = [
+        {
+           class = "freechips.rocketchip.objectmodel.OMIRTracker",
+           id = 1 : i64,
+           type = "OMMemberReferenceTarget"
+        }
+      ]} : !firrtl.uint<2>
+    firrtl.strictconnect %b, %tmp_1 : !firrtl.uint<2>
+
+    // CHECK-NOT: %tmp_2
+    %tmp_2 = firrtl.node %c7_ui3 {
+      annotations = [
+        {
+           class = "freechips.rocketchip.objectmodel.OMIRTracker",
+           id = 3 : i64,
+           type = "OMMemberInstanceTarget"
+        }
+      ]} : !firrtl.uint<3>
+    firrtl.strictconnect %c, %tmp_2 : !firrtl.uint<3>
+
+    // Adding one additional annotation will block removal.
+    //
+    // CHECK: %tmp_3
+    %tmp_3 = firrtl.node %c15_ui4 {
+      annotations = [
+        {
+           class = "freechips.rocketchip.objectmodel.OMIRTracker",
+           id = 4 : i64,
+           type = "OMReferenceTarget"
+        },
+        {
+           class = "circt.test"
+        }
+      ]} : !firrtl.uint<4>
+    // CHECK-NEXT: firrtl.strictconnect %d, %c15_ui4
+    firrtl.strictconnect %d, %tmp_3 : !firrtl.uint<4>
+  }
+}

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -561,3 +561,57 @@ firrtl.circuit "DeadPublic" {
      firrtl.instance pdc @PublicDeadChild()
   }
 }
+
+// -----
+// OMIR annotation should not block removal.
+//   - See: https://github.com/llvm/circt/issues/6199
+//
+// CHECK-LABEL: firrtl.circuit "OMIRRemoval"
+firrtl.circuit "OMIRRemoval" {
+  firrtl.module @OMIRRemoval() {
+    // CHECK-NOT: %tmp_0
+    %tmp_0 = firrtl.wire {
+      annotations = [
+        {
+           class = "freechips.rocketchip.objectmodel.OMIRTracker",
+           id = 0 : i64,
+           type = "OMReferenceTarget"
+        }
+      ]} : !firrtl.uint<1>
+
+    // CHECK-NOT: %tmp_1
+    %tmp_1 = firrtl.wire {
+      annotations = [
+        {
+           class = "freechips.rocketchip.objectmodel.OMIRTracker",
+           id = 1 : i64,
+           type = "OMMemberReferenceTarget"
+        }
+      ]} : !firrtl.uint<2>
+
+    // CHECK-NOT: %tmp_2
+    %tmp_2 = firrtl.wire {
+      annotations = [
+        {
+           class = "freechips.rocketchip.objectmodel.OMIRTracker",
+           id = 3 : i64,
+           type = "OMMemberInstanceTarget"
+        }
+      ]} : !firrtl.uint<3>
+
+    // Adding one additional annotation will block removal.
+    //
+    // CHECK: %tmp_3
+    %tmp_3 = firrtl.wire {
+      annotations = [
+        {
+           class = "freechips.rocketchip.objectmodel.OMIRTracker",
+           id = 4 : i64,
+           type = "OMMemberInstanceTarget"
+        },
+        {
+           class = "circt.test"
+        }
+      ]} : !firrtl.uint<4>
+  }
+}

--- a/test/Dialect/FIRRTL/remove-unused-ports.mlir
+++ b/test/Dialect/FIRRTL/remove-unused-ports.mlir
@@ -180,3 +180,58 @@ firrtl.circuit "UnusedOutput"  {
     firrtl.strictconnect %b, %singleDriver_b : !firrtl.uint<1>
   }
 }
+
+// -----
+
+// OMIR annotations should not block removal.
+//   - See: https://github.com/llvm/circt/issues/6199
+//
+// CHECK-LABEL: firrtl.circuit "OMIRRemoval"
+firrtl.circuit "OMIRRemoval" {
+  // CHECK-NOT: %a
+  // CHECK-NOT: %b
+  // CHECK-NOT: %c
+  // CHECK:     %d
+  firrtl.module private @Foo(
+    out %a: !firrtl.uint<1> [
+      {
+         class = "freechips.rocketchip.objectmodel.OMIRTracker",
+         id = 0 : i64,
+         type = "OMReferenceTarget"
+      }
+    ],
+    out %b: !firrtl.uint<2> [
+      {
+         class = "freechips.rocketchip.objectmodel.OMIRTracker",
+         id = 1 : i64,
+         type = "OMMemberReferenceTarget"
+      }
+    ],
+    in %c: !firrtl.uint<3> [
+      {
+         class = "freechips.rocketchip.objectmodel.OMIRTracker",
+         id = 3 : i64,
+         type = "OMMemberInstanceTarget"
+      }
+    ],
+    in %d: !firrtl.uint<4> [
+      {
+         class = "freechips.rocketchip.objectmodel.OMIRTracker",
+         id = 4 : i64,
+         type = "OMMemberInstanceTarget"
+      },
+      // Adding one additional annotation will block removal.
+      {
+         class = "circt.test"
+      }
+    ]
+  ) {}
+  firrtl.module @OMIRRemoval() {
+    %foo_a, %foo_b, %foo_c, %foo_d = firrtl.instance foo @Foo(
+      out a: !firrtl.uint<1>,
+      out b: !firrtl.uint<2>,
+      in  c: !firrtl.uint<3>,
+      in  d: !firrtl.uint<4>
+    )
+  }
+}


### PR DESCRIPTION
Add member functions to Annotation and AnnotationSet that can be used to
query if a specific Annotation or if all Annotations can be
removed/deleted.  There are certain "weak" annotations used by Object
Model which can be safely deleted because their downstream consumers will
_NOT_ error if they no longer exist.

As an aside, the whole notion of a removable annotation is somewhat
tenuous as a compiler could legally drop a removable annotation.  The
actual semantics of a removable annotation are best effort.

Switch from a static method to annotation member functions to determine of
a port with annotations can be deleted by IMDCE.

Modify the following passes to allow removal of weakly annotated things:

  - Connect canonicalization (`canonicalizeSingleSetConnect`)
  - IMCP
  - IMDCE
  - RemoveUnusedPorts

Add tests that the above passes remove OMIR "weak" annotations.

Fixes #6199.