### PR TITLE
[Ibis] Fix issues in Tunneling and PortRef lowering

### DIFF
--- a/include/circt/Dialect/Ibis/IbisPasses.h
+++ b/include/circt/Dialect/Ibis/IbisPasses.h
@@ -18,9 +18,12 @@
 namespace circt {
 namespace ibis {
 
+#define GEN_PASS_DECL_IBISTUNNELING
+#include "circt/Dialect/Ibis/IbisPasses.h.inc"
+
 std::unique_ptr<Pass> createCallPrepPass();
 std::unique_ptr<Pass> createContainerizePass();
-std::unique_ptr<Pass> createTunnelingPass();
+std::unique_ptr<Pass> createTunnelingPass(const IbisTunnelingOptions & = {});
 std::unique_ptr<Pass> createPortrefLoweringPass();
 std::unique_ptr<Pass> createCleanSelfdriversPass();
 std::unique_ptr<Pass> createContainersToHWPass();

--- a/include/circt/Dialect/Ibis/IbisPasses.td
+++ b/include/circt/Dialect/Ibis/IbisPasses.td
@@ -35,8 +35,21 @@ def IbisTunneling : Pass<"ibis-tunneling", "mlir::ModuleOp"> {
     ports of `!ibis.portref<...>` type are created.
     After this pass, `get_port` ops should only exist at the same scope of
     container instantiations.
+
+    The user may provide options for `readSuffix` and `writeSuffix`, respectively,
+    which is to be used to generate the name of the ports that are tunneled
+    through the hierarchy, with respect to how the port was requested to be accessed.
+    Suffixes must be provided in cases where a port is tunneled for both read and
+    write accesses, and the suffixes must be different (in this case, the suffixes
+    will be appended to the target port name, and thus de-alias the resulting ports).
   }];
   let constructor = "circt::ibis::createTunnelingPass()";
+  let options = [
+    Option<"readSuffix", "read-suffix", "std::string", "\".rd\"",
+           "Suffix to be used for the port when a port is tunneled for read access">,
+    Option<"writeSuffix", "write-suffix", "std::string", "\".wr\"",
+            "Suffix to be used for the port when a port is tunneled for write access">
+  ];
 }
 
 def IbisPortrefLowering : Pass<"ibis-lower-portrefs", "mlir::ModuleOp"> {

--- a/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
@@ -16,12 +16,23 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "ibis-lower-portrefs"
 
 using namespace mlir;
 using namespace circt;
 using namespace ibis;
 
 namespace {
+
+// Prints an operation in generic form, for debugging purposes. Generic form is
+// chosen to avoid triggering op verification.
+static void debugPrintOp(Twine msg, Operation *op) {
+  llvm::dbgs() << msg << ": ";
+  op->print(llvm::dbgs(), OpPrintingFlags().printGenericOpForm());
+  llvm::dbgs() << "\n";
+}
 
 class InputPortConversionPattern : public OpConversionPattern<InputPortOp> {
 public:
@@ -198,7 +209,7 @@ class GetPortConversionPattern : public OpConversionPattern<GetPortOp> {
         return rewriter.notifyMatchFailure(
             op, "expected an ibis.port.write to wrap the get_port result");
       wrapper = getPortWrapper;
-
+      LLVM_DEBUG(debugPrintOp("Found wrapper: ", wrapper));
       if (innerDirection == Direction::Input) {
         // The portref<in portref<in T>> is now an output port.
         auto newGetPort =
@@ -233,41 +244,81 @@ class GetPortConversionPattern : public OpConversionPattern<GetPortOp> {
             op, "expected an ibis.port.read to unwrap the get_port result");
       wrapper = getPortUnwrapper;
 
+      LLVM_DEBUG(debugPrintOp("Found unwrapper: ", wrapper));
       if (innerDirection == Direction::Input) {
         // In this situation, we're retrieving an input port that is sent as an
         // output of the container: %rr = ibis.get_port %c %c_in :
         // !ibis.scoperef<...> -> !ibis.portref<out !ibis.portref<in T>>
         //
-        // Thus we expect two ops to be present:
-        // 1. a read op which unwraps the portref<out portref<in T>> into a
-        // portref<in T>
+        // Thus we expect one of these cases:
+        // (always). a read op which unwraps the portref<out portref<in T>> into
+        // a portref<in T>
         //    %r = ibis.port.read %rr : !ibis.portref<out !ibis.portref<in T>>
-        // 2. A write to %r which drives the input port
+        // either:
+        // 1. A write to %r which drives the target input port
         //    ibis.port.write %r, %someValue : !ibis.portref<in T>
+        // 2. A write using %r which forwards the input port reference
+        //    ibis.port.write %r_fw, %r : !ibis.portref<out !ibis.portref<in
+        //    T>>
         //
-        // We then replace the whole structure above with simply writing the
-        // driving value to the actual input port of the container.
         PortWriteOp portDriver;
+        PortWriteOp portForwardingDriver;
         for (auto *user : getPortUnwrapper.getResult().getUsers()) {
           auto writeOp = dyn_cast<PortWriteOp>(user);
-          if (!writeOp || writeOp.getPort() != getPortUnwrapper.getResult())
+          if (!writeOp)
             continue;
 
-          portDriver = writeOp;
-          break;
+          bool isForwarding = writeOp.getPort() != getPortUnwrapper.getResult();
+          if (isForwarding) {
+            if (portForwardingDriver)
+              return rewriter.notifyMatchFailure(
+                  op, "expected a single ibis.port.write to use the unwrapped "
+                      "get_port result, but found multiple");
+            portForwardingDriver = writeOp;
+            LLVM_DEBUG(debugPrintOp("Found forwarding driver: ",
+                                    portForwardingDriver));
+          } else {
+            if (portDriver)
+              return rewriter.notifyMatchFailure(
+                  op, "expected a single ibis.port.write to use the unwrapped "
+                      "get_port result, but found multiple");
+            portDriver = writeOp;
+            LLVM_DEBUG(debugPrintOp("Found driver: ", portDriver));
+          }
         }
 
-        if (!portDriver)
+        if (!portDriver && !portForwardingDriver)
           return rewriter.notifyMatchFailure(
               op, "expected an ibis.port.write to drive the unwrapped get_port "
                   "result");
 
+        Value portDriverValue;
+        if (portForwardingDriver) {
+          // In the case of forwarding, it is simplest to just create a new
+          // input port, and write the forwarded value to it. This will allow
+          // this pattern to recurse and eventually reach the case where the
+          // forwarding is resolved through reading/writing the intermediate
+          // inputs.
+          auto forwardedInputPort = rewriter.create<InputPortOp>(
+              op.getLoc(), rewriter.getStringAttr(portName.strref() + "_fw"),
+              innerType);
+
+          rewriter.replaceAllUsesWith(getPortUnwrapper, forwardedInputPort);
+          portDriverValue = rewriter.create<PortReadOp>(
+              op.getLoc(), forwardedInputPort.getPort());
+        } else {
+          // Direct assignmenet - the driver value will be the value of
+          // the driver.
+          portDriverValue = portDriver.getValue();
+          rewriter.eraseOp(portDriver);
+        }
+
+        // Perform assignment to the input port of the target instance using
+        // the driver value.
         auto rawPort =
             rewriter.create<GetPortOp>(op.getLoc(), op.getInstance(), portName,
                                        innerType, Direction::Input);
-        rewriter.create<PortWriteOp>(op.getLoc(), rawPort,
-                                     portDriver.getValue());
-        rewriter.eraseOp(portDriver);
+        rewriter.create<PortWriteOp>(op.getLoc(), rawPort, portDriverValue);
       } else {
         // In this situation, we're retrieving an output port that is sent as an
         // output of the container: %rr = ibis.get_port %c %c_in :

--- a/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
@@ -26,14 +26,6 @@ using namespace ibis;
 
 namespace {
 
-// Prints an operation in generic form, for debugging purposes. Generic form is
-// chosen to avoid triggering op verification.
-static void debugPrintOp(Twine msg, Operation *op) {
-  llvm::dbgs() << msg << ": ";
-  op->print(llvm::dbgs(), OpPrintingFlags().printGenericOpForm());
-  llvm::dbgs() << "\n";
-}
-
 class InputPortConversionPattern : public OpConversionPattern<InputPortOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
@@ -209,7 +201,7 @@ class GetPortConversionPattern : public OpConversionPattern<GetPortOp> {
         return rewriter.notifyMatchFailure(
             op, "expected an ibis.port.write to wrap the get_port result");
       wrapper = getPortWrapper;
-      LLVM_DEBUG(debugPrintOp("Found wrapper: ", wrapper));
+      LLVM_DEBUG(llvm::dbgs() << "Found wrapper: " << *wrapper);
       if (innerDirection == Direction::Input) {
         // The portref<in portref<in T>> is now an output port.
         auto newGetPort =
@@ -244,7 +236,7 @@ class GetPortConversionPattern : public OpConversionPattern<GetPortOp> {
             op, "expected an ibis.port.read to unwrap the get_port result");
       wrapper = getPortUnwrapper;
 
-      LLVM_DEBUG(debugPrintOp("Found unwrapper: ", wrapper));
+      LLVM_DEBUG(llvm::dbgs() << "Found unwrapper: " << *wrapper);
       if (innerDirection == Direction::Input) {
         // In this situation, we're retrieving an input port that is sent as an
         // output of the container: %rr = ibis.get_port %c %c_in :
@@ -275,15 +267,15 @@ class GetPortConversionPattern : public OpConversionPattern<GetPortOp> {
                   op, "expected a single ibis.port.write to use the unwrapped "
                       "get_port result, but found multiple");
             portForwardingDriver = writeOp;
-            LLVM_DEBUG(debugPrintOp("Found forwarding driver: ",
-                                    portForwardingDriver));
+            LLVM_DEBUG(llvm::dbgs()
+                       << "Found forwarding driver: " << *portForwardingDriver);
           } else {
             if (portDriver)
               return rewriter.notifyMatchFailure(
                   op, "expected a single ibis.port.write to use the unwrapped "
                       "get_port result, but found multiple");
             portDriver = writeOp;
-            LLVM_DEBUG(debugPrintOp("Found driver: ", portDriver));
+            LLVM_DEBUG(llvm::dbgs() << "Found driver: " << *portDriver);
           }
         }
 

--- a/lib/Dialect/Ibis/Transforms/IbisTunneling.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisTunneling.cpp
@@ -45,7 +45,7 @@ struct PortInfo {
 
 struct Tunneler {
 public:
-  Tunneler(IbisTunnelingOptions options, PathOp op,
+  Tunneler(const IbisTunnelingOptions &options, PathOp op,
            ConversionPatternRewriter &rewriter, InstanceGraph &ig);
 
   // A mapping between requested port names from a ScopeRef and the actual
@@ -91,7 +91,7 @@ private:
   PathOp op;
   ConversionPatternRewriter &rewriter;
   InstanceGraph &ig;
-  IbisTunnelingOptions options;
+  const IbisTunnelingOptions &options;
   mlir::StringAttr pathName;
   llvm::SmallVector<PathStepAttr> path;
 
@@ -104,7 +104,7 @@ private:
   FlatSymbolRefAttr targetName;
 };
 
-Tunneler::Tunneler(IbisTunnelingOptions options, PathOp op,
+Tunneler::Tunneler(const IbisTunnelingOptions &options, PathOp op,
                    ConversionPatternRewriter &rewriter, InstanceGraph &ig)
     : op(op), rewriter(rewriter), ig(ig), options(options) {
   llvm::copy(op.getPathAsRange(), std::back_inserter(path));
@@ -387,7 +387,8 @@ class TunnelingConversionPattern : public OpConversionPattern<PathOp> {
 public:
   TunnelingConversionPattern(MLIRContext *context, InstanceGraph &ig,
                              IbisTunnelingOptions options)
-      : OpConversionPattern<PathOp>(context), ig(ig), options(options) {}
+      : OpConversionPattern<PathOp>(context), ig(ig),
+        options(std::move(options)) {}
 
   LogicalResult
   matchAndRewrite(PathOp op, OpAdaptor adaptor,

--- a/lib/Dialect/Ibis/Transforms/IbisTunneling.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisTunneling.cpp
@@ -36,7 +36,7 @@ struct PortInfo {
     return getPortOp.getPort().getType().cast<PortRefType>();
   }
   Type getInnerType() { return getType().getPortType(); }
-  Direction requestedDirection() { return getType().getDirection(); }
+  Direction getRequestedDirection() { return getType().getDirection(); }
 };
 
 struct Tunneler {
@@ -46,7 +46,7 @@ public:
   // A mapping between requested port names from a ScopeRef and the actual
   // portref SSA values that are used to replace the get_port ops.
   // MapVector to ensure determinism.
-  using PortRefMapping = llvm::MapVector<StringAttr, Value>;
+  using PortRefMapping = llvm::MapVector<PortInfo *, Value>;
 
   // Launch the tunneling process.
   LogicalResult go();
@@ -81,7 +81,7 @@ private:
                            PortRefMapping &portMapping);
 
   // Generates names for the port refs to be created.
-  void genPortNames(llvm::MapVector<StringAttr, PortInfo> &portInfos);
+  void genPortNames(llvm::SmallVectorImpl<PortInfo> &portInfos);
 
   PathOp op;
   ConversionPatternRewriter &rewriter;
@@ -90,7 +90,7 @@ private:
   llvm::SmallVector<PathStepAttr> path;
 
   // MapVector to ensure determinism.
-  llvm::MapVector<StringAttr, PortInfo> portInfos;
+  llvm::SmallVector<PortInfo> portInfos;
 
   // "Target" refers to the last step in the path which is the scoperef that
   // all port requests are tunneling towards.
@@ -108,7 +108,7 @@ Tunneler::Tunneler(PathOp op, ConversionPatternRewriter &rewriter,
   targetName = target.getChild();
 }
 
-void Tunneler::genPortNames(llvm::MapVector<StringAttr, PortInfo> &pis) {
+void Tunneler::genPortNames(llvm::SmallVectorImpl<PortInfo> &portInfos) {
   std::string pathName;
   llvm::raw_string_ostream ss(pathName);
   llvm::interleave(
@@ -121,8 +121,14 @@ void Tunneler::genPortNames(llvm::MapVector<StringAttr, PortInfo> &pis) {
       },
       "_");
 
-  for (auto &[sym, portInfo] : pis)
-    portInfo.portName = rewriter.getStringAttr(pathName + "_" + sym.getValue());
+  for (PortInfo &pi : portInfos) {
+    // Suffix the ports by the intended usage (read/write). This also de-aliases
+    // cases where one both reads and writes from the same input port.
+    std::string suffix =
+        pi.getRequestedDirection() == Direction::Input ? ".wr" : ".rd";
+    pi.portName = rewriter.getStringAttr(pathName + "_" +
+                                         pi.portName.getValue() + suffix);
+  }
 }
 
 LogicalResult Tunneler::go() {
@@ -132,7 +138,8 @@ LogicalResult Tunneler::go() {
     if (!getPortOp)
       return user->emitOpError() << "unknown user of a PathOp result - "
                                     "tunneling only supports ibis.get_port";
-    portInfos[getPortOp.getPortSymbolAttr().getAttr()].getPortOp = getPortOp;
+    portInfos.push_back(
+        PortInfo{getPortOp.getPortSymbolAttr().getAttr(), getPortOp});
   }
   genPortNames(portInfos);
 
@@ -144,11 +151,11 @@ LogicalResult Tunneler::go() {
     return failure();
 
   // Replace the get_port ops with the target value.
-  for (auto [sym, portInfo] : portInfos) {
-    auto *it = mapping.find(sym);
+  for (PortInfo &pi : portInfos) {
+    auto *it = mapping.find(&pi);
     assert(it != mapping.end() &&
            "expected to find a portref mapping for all get_port ops");
-    rewriter.replaceOp(portInfo.getPortOp, it->second);
+    rewriter.replaceOp(pi.getPortOp, it->second);
   }
 
   // And finally erase the path.
@@ -181,7 +188,7 @@ Value Tunneler::portForwardIfNeeded(PortOpInterface actualPort,
                                     PortInfo &portInfo) {
   Direction actualDir =
       actualPort.getPort().getType().cast<PortRefType>().getDirection();
-  Direction requestedDir = portInfo.requestedDirection();
+  Direction requestedDir = portInfo.getRequestedDirection();
 
   // Match - just return the port itself.
   if (actualDir == requestedDir)
@@ -260,10 +267,11 @@ LogicalResult Tunneler::tunnelDown(InstanceGraphNode *currentContainer,
     // Tunneling ended with a 'child' step - create get_ports of all of the
     // requested ports.
     rewriter.setInsertionPointAfter(tunnelInstance);
-    for (auto [sym, portInfo] : portInfos) {
-      auto targetGetPortOp = rewriter.create<GetPortOp>(
-          op.getLoc(), portInfo.getType(), tunnelInstance, sym);
-      portMapping[sym] = targetGetPortOp.getResult();
+    for (PortInfo &pi : portInfos) {
+      auto targetGetPortOp =
+          rewriter.create<GetPortOp>(op.getLoc(), pi.getType(), tunnelInstance,
+                                     pi.getPortOp.getPortSymbol());
+      portMapping[&pi] = targetGetPortOp.getResult();
     }
     return success();
   }
@@ -276,9 +284,9 @@ LogicalResult Tunneler::tunnelDown(InstanceGraphNode *currentContainer,
 
   rewriter.setInsertionPointToEnd(tunnelScope.getBodyBlock());
   llvm::DenseMap<StringAttr, OutputPortOp> outputPortOps;
-  for (auto [sym, portInfo] : portInfos) {
-    outputPortOps[sym] = rewriter.create<OutputPortOp>(
-        op.getLoc(), portInfo.portName, portInfo.getType());
+  for (PortInfo &pi : portInfos) {
+    outputPortOps[pi.portName] =
+        rewriter.create<OutputPortOp>(op.getLoc(), pi.portName, pi.getType());
   }
 
   // Recurse into the tunnel instance container.
@@ -286,12 +294,13 @@ LogicalResult Tunneler::tunnelDown(InstanceGraphNode *currentContainer,
   if (failed(tunnelDispatch(tunnelScopeNode, path, childMapping)))
     return failure();
 
-  for (auto [sym, res] : childMapping) {
-    auto &portInfo = portInfos[sym];
+  for (auto [pi, res] : childMapping) {
+    PortInfo &portInfo = *pi;
 
     // Write the target value to the output port.
     rewriter.setInsertionPointToEnd(tunnelScope.getBodyBlock());
-    rewriter.create<PortWriteOp>(op.getLoc(), outputPortOps[sym], res);
+    rewriter.create<PortWriteOp>(op.getLoc(), outputPortOps[portInfo.portName],
+                                 res);
 
     // Back in the current container, read the new output port of the child
     // instance and assign it to the port mapping.
@@ -299,7 +308,7 @@ LogicalResult Tunneler::tunnelDown(InstanceGraphNode *currentContainer,
     auto getPortOp = rewriter.create<GetPortOp>(
         op.getLoc(), tunnelInstance, portInfo.portName, portInfo.getType(),
         Direction::Output);
-    portMapping[sym] =
+    portMapping[pi] =
         rewriter.create<PortReadOp>(op.getLoc(), getPortOp).getResult();
   }
 
@@ -324,15 +333,16 @@ LogicalResult Tunneler::tunnelUp(InstanceGraphNode *currentContainer,
     if (path.empty()) {
       // Tunneling ended with a 'parent' step - all of the requested ports
       // should be available right here in the parent scope.
-      for (auto [sym, portInfo] : portInfos) {
-        PortOpInterface portLikeOp = parentScope.lookupPort(sym.strref());
+      for (PortInfo &pi : portInfos) {
+        StringRef targetPortName = pi.getPortOp.getPortSymbol();
+        PortOpInterface portLikeOp = parentScope.lookupPort(targetPortName);
         if (!portLikeOp)
           return op->emitOpError()
-                 << "expected a port named " << sym << " in "
+                 << "expected a port named " << targetPortName << " in "
                  << parentScope.getScopeName() << " but found none";
 
         // "Port forwarding" check - see comment in portForwardIfNeeded.
-        targetPortMapping[sym] = portForwardIfNeeded(portLikeOp, portInfo);
+        targetPortMapping[&pi] = portForwardIfNeeded(portLikeOp, pi);
       }
     } else {
       // recurse into the parents, which will define the target value that
@@ -343,24 +353,22 @@ LogicalResult Tunneler::tunnelUp(InstanceGraphNode *currentContainer,
 
     auto instance = use->getInstance<ContainerInstanceOp>();
     rewriter.setInsertionPointAfter(instance);
-    for (auto [sym, portInfo] : portInfos) {
-
-      auto getPortOp =
-          rewriter.create<GetPortOp>(op.getLoc(), instance, portInfo.portName,
-                                     portInfo.getType(), Direction::Input);
+    for (PortInfo &pi : portInfos) {
+      auto getPortOp = rewriter.create<GetPortOp>(
+          op.getLoc(), instance, pi.portName, pi.getType(), Direction::Input);
       rewriter.create<PortWriteOp>(op.getLoc(), getPortOp,
-                                   targetPortMapping[sym]);
+                                   targetPortMapping[&pi]);
     }
   }
 
   // Create input ports for the requested portrefs.
   rewriter.setInsertionPointToEnd(scopeOp.getBodyBlock());
-  for (auto [sym, portInfo] : portInfos) {
-    auto inputPort = rewriter.create<InputPortOp>(
-        op.getLoc(), portInfo.portName, portInfo.getType());
+  for (PortInfo &pi : portInfos) {
+    auto inputPort =
+        rewriter.create<InputPortOp>(op.getLoc(), pi.portName, pi.getType());
     // Read the input port of the current container to forward the portref.
 
-    portMapping[sym] =
+    portMapping[&pi] =
         rewriter.create<PortReadOp>(op.getLoc(), inputPort.getResult())
             .getResult();
   }

--- a/test/Dialect/Ibis/Transforms/path_end_to_end.mlir
+++ b/test/Dialect/Ibis/Transforms/path_end_to_end.mlir
@@ -1,0 +1,71 @@
+// The ultimate tunneling test - by having 3 intermediate levels for both up-
+// and downwards tunneling, we are sure test all the possible combinations of
+// tunneling. This is more of a sanity check that everything works as expected.
+
+// RUN: circt-opt --split-input-file --ibis-tunneling \
+// RUN:    --ibis-lower-portrefs --ibis-clean-selfdrivers \
+// RUN:    --ibis-convert-containers-to-hw
+
+ibis.container @D_up {
+  %this = ibis.this @D_up
+  %d = ibis.path [
+    #ibis.step<parent : !ibis.scoperef>,
+    #ibis.step<parent : !ibis.scoperef>,
+    #ibis.step<parent : !ibis.scoperef>,
+    #ibis.step<parent : !ibis.scoperef>,
+    #ibis.step<child, @a_down : !ibis.scoperef> : !ibis.scoperef,
+    #ibis.step<child, @b : !ibis.scoperef> : !ibis.scoperef,
+    #ibis.step<child, @c : !ibis.scoperef> : !ibis.scoperef,
+    #ibis.step<child, @d : !ibis.scoperef<@D_down>> : !ibis.scoperef<@D_down>]
+  // Write an input port
+  %clk_ref = ibis.get_port %d, @clk_in : !ibis.scoperef<@D_down> -> !ibis.portref<in i1>
+  %clk = hw.constant 1 : i1
+  ibis.port.write %clk_ref, %clk : !ibis.portref<in i1>
+
+  // Read an input port
+  %clk_ref_2 = ibis.get_port %d, @clk_in : !ibis.scoperef<@D_down> -> !ibis.portref<out i1>
+  %clk_in_val = ibis.port.read %clk_ref_2 : !ibis.portref<out i1>
+
+  // Read an output port
+  %clk_out_ref = ibis.get_port %d, @clk_out : !ibis.scoperef<@D_down> -> !ibis.portref<out i1>
+  %clk_out_val = ibis.port.read %clk_out_ref : !ibis.portref<out i1>
+}
+ibis.container @C_up {
+  %this = ibis.this @C_up
+  %d = ibis.container.instance @d, @D_up
+}
+ibis.container @B_up {
+  %this = ibis.this @B_up
+  %c = ibis.container.instance @c, @C_up
+  
+}
+
+ibis.container @A_up {
+  %this = ibis.this @A_up
+  %b = ibis.container.instance @b, @B_up
+}
+
+ibis.container @Top {
+  %this = ibis.this @Top
+  %a_down = ibis.container.instance @a_down, @A_down
+  %a_up = ibis.container.instance @a_up, @A_up
+}
+ibis.container @A_down {
+  %this = ibis.this @A_down
+  %b = ibis.container.instance @b, @B_down
+}
+ibis.container @B_down {
+  %this = ibis.this @B_down
+  %c = ibis.container.instance @c, @C_down
+}
+ibis.container @C_down {
+  %this = ibis.this @C_down
+  %d = ibis.container.instance @d, @D_down
+}
+ibis.container @D_down {
+  %this = ibis.this @D_down
+  %clk = ibis.port.input @clk_in : i1
+  %clk_out = ibis.port.output @clk_out : i1
+  %clk.val = ibis.port.read %clk : !ibis.portref<in i1>
+  ibis.port.write %clk_out, %clk.val : !ibis.portref<out i1>
+}

--- a/test/Dialect/Ibis/Transforms/portref_lowering.mlir
+++ b/test/Dialect/Ibis/Transforms/portref_lowering.mlir
@@ -169,13 +169,16 @@ ibis.container @P1 {
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @p1, @P1
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @parent_parent_c2_c3_in : !ibis.scoperef<@P1> -> !ibis.portref<out i1>
 // CHECK:           %[[VAL_3:.*]] = ibis.port.read %[[VAL_2]] : !ibis.portref<out i1>
-// CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @parent_parent_c2_c3_out : !ibis.scoperef<@P1> -> !ibis.portref<in i1>
-// CHECK:           %[[VAL_5:.*]] = ibis.port.read %[[VAL_6:.*]] : !ibis.portref<out i1>
-// CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_5]] : !ibis.portref<in i1>
-// CHECK:           %[[VAL_7:.*]] = ibis.container.instance @c2, @C2
-// CHECK:           %[[VAL_6]] = ibis.get_port %[[VAL_7]], @parent_parent_c2_c3_out : !ibis.scoperef<@C2> -> !ibis.portref<out i1>
-// CHECK:           %[[VAL_8:.*]] = ibis.get_port %[[VAL_7]], @parent_parent_c2_c3_in : !ibis.scoperef<@C2> -> !ibis.portref<in i1>
-// CHECK:           ibis.port.write %[[VAL_8]], %[[VAL_3]] : !ibis.portref<in i1>
+// CHECK:           ibis.port.write %[[VAL_4:.*]], %[[VAL_3]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_5:.*]] = ibis.get_port %[[VAL_1]], @parent_parent_c2_c3_out : !ibis.scoperef<@P1> -> !ibis.portref<in i1>
+// CHECK:           %[[VAL_6:.*]] = ibis.port.read %[[VAL_7:.*]] : !ibis.portref<out i1>
+// CHECK:           ibis.port.write %[[VAL_5]], %[[VAL_6]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_8:.*]] = ibis.container.instance @c2, @C2
+// CHECK:           %[[VAL_7]] = ibis.get_port %[[VAL_8]], @parent_parent_c2_c3_out : !ibis.scoperef<@C2> -> !ibis.portref<out i1>
+// CHECK:           %[[VAL_4]] = ibis.port.input @parent_parent_c2_c3_in_fw : i1
+// CHECK:           %[[VAL_9:.*]] = ibis.port.read %[[VAL_4]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_10:.*]] = ibis.get_port %[[VAL_8]], @parent_parent_c2_c3_in : !ibis.scoperef<@C2> -> !ibis.portref<in i1>
+// CHECK:           ibis.port.write %[[VAL_10]], %[[VAL_9]] : !ibis.portref<in i1>
 // CHECK:         }
 ibis.container @P2 {
   %this = ibis.this @P2 

--- a/test/Dialect/Ibis/Transforms/scoperef_tunneling.mlir
+++ b/test/Dialect/Ibis/Transforms/scoperef_tunneling.mlir
@@ -33,9 +33,9 @@ ibis.container @C {
 
 // CHECK-LABEL:   ibis.container @AccessSibling {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @AccessSibling
-// CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_b_out : !ibis.portref<out i1>
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input @[[VAL_1]] : !ibis.portref<out i1>
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in !ibis.portref<out i1>>
-// CHECK:           %[[VAL_3:.*]] = ibis.port.input @p_b_in : !ibis.portref<in i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.input @[[VAL_3]] : !ibis.portref<in i1>
 // CHECK:           %[[VAL_4:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:         }
 ibis.container @AccessSibling {
@@ -51,9 +51,9 @@ ibis.container @AccessSibling {
 // CHECK-LABEL:   ibis.container @Parent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @Parent
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @a, @AccessSibling
-// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_b_out : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_b_out.rd : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_3:.*]] : !ibis.portref<in !ibis.portref<out i1>>
-// CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @p_b_in : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @p_b_in.wr : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_5:.*]] : !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:           %[[VAL_6:.*]] = ibis.container.instance @b, @C
 // CHECK:           %[[VAL_3]] = ibis.get_port %[[VAL_6]], @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
@@ -72,9 +72,9 @@ ibis.container @Parent {
 
 // CHECK-LABEL:   ibis.container @C1 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @C1
-// CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_p_c2_c3_out : !ibis.portref<out i1>
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_p_c2_c3_out.rd : !ibis.portref<out i1>
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in !ibis.portref<out i1>>
-// CHECK:           %[[VAL_3:.*]] = ibis.port.input @p_p_c2_c3_in : !ibis.portref<in i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.input @p_p_c2_c3_in.wr : !ibis.portref<in i1>
 // CHECK:           %[[VAL_4:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:         }
 ibis.container @C1 {
@@ -94,8 +94,8 @@ ibis.container @C1 {
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c3, @C
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
 // CHECK:           %[[VAL_3:.*]] = ibis.get_port %[[VAL_1]], @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
-// CHECK:           %[[VAL_4:.*]] = ibis.port.output @p_p_c2_c3_out : !ibis.portref<out i1>
-// CHECK:           %[[VAL_5:.*]] = ibis.port.output @p_p_c2_c3_in : !ibis.portref<in i1>
+// CHECK:           %[[VAL_4:.*]] = ibis.port.output @p_p_c2_c3_out.rd : !ibis.portref<out i1>
+// CHECK:           %[[VAL_5:.*]] = ibis.port.output @p_p_c2_c3_in.wr : !ibis.portref<in i1>
 // CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_2]] : !ibis.portref<out !ibis.portref<out i1>>
 // CHECK:           ibis.port.write %[[VAL_5]], %[[VAL_3]] : !ibis.portref<out !ibis.portref<in i1>>
 // CHECK:         }
@@ -113,13 +113,13 @@ ibis.container @C {
 // CHECK-LABEL:   ibis.container @P1 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @P1
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c1, @C1
-// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_out : !ibis.scoperef<@C1> -> !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_out.rd : !ibis.scoperef<@C1> -> !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_3:.*]] : !ibis.portref<in !ibis.portref<out i1>>
-// CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_in : !ibis.scoperef<@C1> -> !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_in.wr : !ibis.scoperef<@C1> -> !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_5:.*]] : !ibis.portref<in !ibis.portref<in i1>>
-// CHECK:           %[[VAL_6:.*]] = ibis.port.input @p_p_c2_c3_out : !ibis.portref<out i1>
+// CHECK:           %[[VAL_6:.*]] = ibis.port.input @p_p_c2_c3_out.rd : !ibis.portref<out i1>
 // CHECK:           %[[VAL_3]] = ibis.port.read %[[VAL_6]] : !ibis.portref<in !ibis.portref<out i1>>
-// CHECK:           %[[VAL_7:.*]] = ibis.port.input @p_p_c2_c3_in : !ibis.portref<in i1>
+// CHECK:           %[[VAL_7:.*]] = ibis.port.input @p_p_c2_c3_in.wr : !ibis.portref<in i1>
 // CHECK:           %[[VAL_5]] = ibis.port.read %[[VAL_7]] : !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:         }
 ibis.container @P1 {
@@ -130,14 +130,14 @@ ibis.container @P1 {
 // CHECK-LABEL:   ibis.container @P2 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @P2
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @p1, @P1
-// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_out : !ibis.scoperef<@P1> -> !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_out.rd : !ibis.scoperef<@P1> -> !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_3:.*]] : !ibis.portref<in !ibis.portref<out i1>>
-// CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_in : !ibis.scoperef<@P1> -> !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_in.wr : !ibis.scoperef<@P1> -> !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_5:.*]] : !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:           %[[VAL_6:.*]] = ibis.container.instance @c2, @C2
-// CHECK:           %[[VAL_7:.*]] = ibis.get_port %[[VAL_6]], @p_p_c2_c3_in : !ibis.scoperef<@C2> -> !ibis.portref<out !ibis.portref<in i1>>
+// CHECK:           %[[VAL_7:.*]] = ibis.get_port %[[VAL_6]], @p_p_c2_c3_in.wr : !ibis.scoperef<@C2> -> !ibis.portref<out !ibis.portref<in i1>>
 // CHECK:           %[[VAL_5]] = ibis.port.read %[[VAL_7]] : !ibis.portref<out !ibis.portref<in i1>>
-// CHECK:           %[[VAL_8:.*]] = ibis.get_port %[[VAL_6]], @p_p_c2_c3_out : !ibis.scoperef<@C2> -> !ibis.portref<out !ibis.portref<out i1>>
+// CHECK:           %[[VAL_8:.*]] = ibis.get_port %[[VAL_6]], @p_p_c2_c3_out.rd : !ibis.scoperef<@C2> -> !ibis.portref<out !ibis.portref<out i1>>
 // CHECK:           %[[VAL_3]] = ibis.port.read %[[VAL_8]] : !ibis.portref<out !ibis.portref<out i1>>
 // CHECK:         }
 ibis.container @P2 {
@@ -150,9 +150,9 @@ ibis.container @P2 {
 
 // CHECK-LABEL:   ibis.container @AccessParent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @AccessParent
-// CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_out : !ibis.portref<in i1>
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_out.wr : !ibis.portref<in i1>
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in !ibis.portref<in i1>>
-// CHECK:           %[[VAL_3:.*]] = ibis.port.input @p_in : !ibis.portref<out i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.input @p_in.rd : !ibis.portref<out i1>
 // CHECK:           %[[VAL_4:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:         }
 ibis.container @AccessParent {
@@ -178,9 +178,9 @@ ibis.container @AccessParent {
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = ibis.wire.input @out.wr : i1
 // CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_6]] : !ibis.portref<out i1>
 // CHECK:           %[[VAL_7:.*]] = ibis.container.instance @c, @AccessParent
-// CHECK:           %[[VAL_8:.*]] = ibis.get_port %[[VAL_7]], @p_out : !ibis.scoperef<@AccessParent> -> !ibis.portref<in !ibis.portref<in i1>>
+// CHECK:           %[[VAL_8:.*]] = ibis.get_port %[[VAL_7]], @p_out.wr : !ibis.scoperef<@AccessParent> -> !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:           ibis.port.write %[[VAL_8]], %[[VAL_5]] : !ibis.portref<in !ibis.portref<in i1>>
-// CHECK:           %[[VAL_9:.*]] = ibis.get_port %[[VAL_7]], @p_in : !ibis.scoperef<@AccessParent> -> !ibis.portref<in !ibis.portref<out i1>>
+// CHECK:           %[[VAL_9:.*]] = ibis.get_port %[[VAL_7]], @p_in.rd : !ibis.scoperef<@AccessParent> -> !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:           ibis.port.write %[[VAL_9]], %[[VAL_3]] : !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:         }
 ibis.container @Parent {
@@ -212,4 +212,74 @@ hw.module @AccessChildFromHW() -> () {
   ]
   %c_in = ibis.get_port %c_ref, @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
   %c_out = ibis.get_port %c_ref, @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
+}
+
+// -----
+
+// The ultimate tunneling test - by having 3 intermediate levels for both up-
+// and downwards tunneling, we are sure test all the possible combinations of
+// tunneling.
+
+ibis.container @D_up {
+  %this = ibis.this @D_up
+  %d = ibis.path [
+    #ibis.step<parent : !ibis.scoperef>,
+    #ibis.step<parent : !ibis.scoperef>,
+    #ibis.step<parent : !ibis.scoperef>,
+    #ibis.step<parent : !ibis.scoperef>,
+    #ibis.step<child, @a_down : !ibis.scoperef> : !ibis.scoperef,
+    #ibis.step<child, @b : !ibis.scoperef> : !ibis.scoperef,
+    #ibis.step<child, @c : !ibis.scoperef> : !ibis.scoperef,
+    #ibis.step<child, @d : !ibis.scoperef<@D_down>> : !ibis.scoperef<@D_down>]
+  // Write an input port
+  %clk_ref = ibis.get_port %d, @clk_in : !ibis.scoperef<@D_down> -> !ibis.portref<in i1>
+  %clk = hw.constant 1 : i1
+  ibis.port.write %clk_ref, %clk : !ibis.portref<in i1>
+
+  // Read an input port
+  %clk_ref_2 = ibis.get_port %d, @clk_in : !ibis.scoperef<@D_down> -> !ibis.portref<out i1>
+  %clk_in_val = ibis.port.read %clk_ref_2 : !ibis.portref<out i1>
+
+  // Read an output port
+  %clk_out_ref = ibis.get_port %d, @clk_out : !ibis.scoperef<@D_down> -> !ibis.portref<out i1>
+  %clk_out_val = ibis.port.read %clk_out_ref : !ibis.portref<out i1>
+}
+ibis.container @C_up {
+  %this = ibis.this @C_up
+  %d = ibis.container.instance @d, @D_up
+}
+ibis.container @B_up {
+  %this = ibis.this @B_up
+  %c = ibis.container.instance @c, @C_up
+  
+}
+
+ibis.container @A_up {
+  %this = ibis.this @A_up
+  %b = ibis.container.instance @b, @B_up
+}
+
+ibis.container @Top {
+  %this = ibis.this @Top
+  %a_down = ibis.container.instance @a_down, @A_down
+  %a_up = ibis.container.instance @a_up, @A_up
+}
+ibis.container @A_down {
+  %this = ibis.this @A_down
+  %b = ibis.container.instance @b, @B_down
+}
+ibis.container @B_down {
+  %this = ibis.this @B_down
+  %c = ibis.container.instance @c, @C_down
+}
+ibis.container @C_down {
+  %this = ibis.this @C_down
+  %d = ibis.container.instance @d, @D_down
+}
+ibis.container @D_down {
+  %this = ibis.this @D_down
+  %clk = ibis.port.input @clk_in : i1
+  %clk_out = ibis.port.output @clk_out : i1
+  %clk.val = ibis.port.read %clk : !ibis.portref<in i1>
+  ibis.port.write %clk_out, %clk.val : !ibis.portref<out i1>
 }


### PR DESCRIPTION
Tunneling did not work in case the same port was requested for multiple tunneling purposes (e.g. both reading and writing to an input port of an instance). Will this happen often/ever? probably not. But now it's supported - and i count it as an error, since the logic previously made multiple distinct accesses alias.

PortRef lowering did not work in case input ports were "forwarded" through modules. To support this, these forwarded ports will now create intermediate input ports within a module. By doing so, we allow the lowering patterns to recurse, since the intermediate port now looks like any other input port that is provided as a port reference. These input ports are then trivially removed by running `ibis-clean-selfdrivers` (which anyways is a prerequisite before running `ibis-convert-containers-to-hw`).