### PR TITLE
[OM][Bindings] Make Python Evaluator Object hashable

### DIFF
--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -107,6 +107,13 @@ MLIR_CAPI_EXPORTED MlirType omEvaluatorObjectGetType(OMEvaluatorValue object);
 MLIR_CAPI_EXPORTED OMEvaluatorValue
 omEvaluatorObjectGetField(OMEvaluatorValue object, MlirAttribute name);
 
+/// Get the object hash.
+MLIR_CAPI_EXPORTED unsigned omEvaluatorObjectGetHash(OMEvaluatorValue object);
+
+/// Check equality of two objects.
+MLIR_CAPI_EXPORTED bool omEvaluatorObjectIsEq(OMEvaluatorValue object,
+                                              OMEvaluatorValue other);
+
 /// Get all the field names from an Object, can be empty if object has no
 /// fields.
 MLIR_CAPI_EXPORTED MlirAttribute

--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -45,7 +45,6 @@ struct EvaluatorValue : std::enable_shared_from_this<EvaluatorValue> {
   EvaluatorValue(MLIRContext *ctx, Kind kind) : kind(kind) {}
   Kind getKind() const { return kind; }
   MLIRContext *getContext() const { return ctx; }
-  llvm::hash_code getHash() { return 0; };
 
 private:
   const Kind kind;
@@ -64,7 +63,6 @@ struct AttributeValue : EvaluatorValue {
   static bool classof(const EvaluatorValue *e) {
     return e->getKind() == Kind::Attr;
   }
-  llvm::hash_code getHash() { return mlir::hash_value(attr); }
 
 private:
   Attribute attr;
@@ -84,14 +82,6 @@ struct ListValue : EvaluatorValue {
   /// Implement LLVM RTTI.
   static bool classof(const EvaluatorValue *e) {
     return e->getKind() == Kind::List;
-  }
-
-  llvm::hash_code getHash() {
-    llvm::hash_code res = mlir::hash_value(type);
-    for (const auto &elem : elements) {
-      res = llvm::hash_combine(res, elem->getHash());
-    }
-    return res;
   }
 
 private:
@@ -116,14 +106,6 @@ struct MapValue : EvaluatorValue {
   /// Implement LLVM RTTI.
   static bool classof(const EvaluatorValue *e) {
     return e->getKind() == Kind::Map;
-  }
-
-  llvm::hash_code getHash() {
-    llvm::hash_code res = mlir::hash_value(type);
-    for (const auto &elem : elements) {
-      res = llvm::hash_combine(res, elem.second->getHash());
-    }
-    return res;
   }
 
 private:
@@ -157,14 +139,6 @@ struct ObjectValue : EvaluatorValue {
   /// Get all the field names of the Object.
   ArrayAttr getFieldNames();
 
-  llvm::hash_code getHash() {
-    llvm::hash_code hashResult = mlir::hash_value(cls.getNameAttr());
-    for (auto iter : fields)
-      hashResult = llvm::hash_combine(mlir::hash_value(iter.getFirst()),
-                                      iter.second->getHash(), hashResult);
-    return hashResult;
-  }
-
 private:
   om::ClassOp cls;
   llvm::SmallDenseMap<StringAttr, EvaluatorValuePtr> fields;
@@ -186,13 +160,6 @@ struct TupleValue : EvaluatorValue {
   TupleType getType() const { return type; }
 
   const TupleElements &getElements() const { return elements; }
-
-  llvm::hash_code getHash() {
-    auto hashRes = mlir::hash_value(type);
-    for (const auto &e : elements)
-      hashRes = llvm::hash_combine(hashRes, e->getHash());
-    return hashRes;
-  }
 
 private:
   TupleType type;

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -13,6 +13,28 @@ with Context() as ctx, Location.unknown():
 
   module = Module.parse("""
   module {
+    om.class @node() {
+      %0 = om.constant #om.list<!om.string,["MyThing" : !om.string]> : !om.list<!om.string>
+      %1 = om.constant "Component.inst1.foo" : !om.string
+      om.class.field @field2, %1 : !om.string
+    }
+    
+    om.class @comp(
+        %inst1_propOut_bore: !om.class.type<@node>,
+        %inst2_propOut_bore: !om.class.type<@node>) {
+      om.class.field @field2, %inst1_propOut_bore : !om.class.type<@node>
+      om.class.field @field3, %inst2_propOut_bore : !om.class.type<@node>
+    }
+    
+    om.class  @Client() {
+      %0 = om.object @node() : () -> !om.class.type<@node>
+      %2 = om.object @comp(%0, %0) : (!om.class.type<@node>, !om.class.type<@node>) -> !om.class.type<@comp>
+    
+      om.class.field @client_omnode_0_OMIROut, %2 : !om.class.type<@comp>
+      om.class.field @node0_OMIROut, %0 : !om.class.type<@node>
+      om.class.field @node1_OMIROut, %0 : !om.class.type<@node>
+    }
+
     %sym = om.constant #om.ref<<@Root::@x>> : !om.ref
 
     om.class @Test(%param: !om.integer) {
@@ -150,3 +172,10 @@ for k, v in obj.map_create.items():
   # CHECK-NEXT: X 14
   # CHECK-NEXT: Y 15
   print(k, v)
+
+obj = evaluator.instantiate("Client")
+object_dict: dict[om.Object, str] = {}
+for field_name, data in obj:
+    if isinstance(data, om.Object):
+        object_dict[data] = field_name 
+assert len(object_dict) == 2

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -176,6 +176,6 @@ for k, v in obj.map_create.items():
 obj = evaluator.instantiate("Client")
 object_dict: dict[om.Object, str] = {}
 for field_name, data in obj:
-    if isinstance(data, om.Object):
-        object_dict[data] = field_name 
+  if isinstance(data, om.Object):
+    object_dict[data] = field_name
 assert len(object_dict) == 2

--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -136,6 +136,12 @@ struct Object {
     return pyFieldNames;
   }
 
+  // Get the hash of the object
+  unsigned getHash() { return omEvaluatorObjectGetHash(value); }
+
+  // Check the equality of the underlying values.
+  bool eq(Object &other) { return omEvaluatorObjectIsEq(value, other.value); }
+
   OMEvaluatorValue getValue() const { return value; }
 
 private:
@@ -361,8 +367,9 @@ void circt::python::populateDialectOMSubmodule(py::module &m) {
            py::arg("name"))
       .def_property_readonly("field_names", &Object::getFieldNames,
                              "Get field names from an Object")
-      .def_property_readonly("type", &Object::getType,
-                             "The Type of the Object");
+      .def_property_readonly("type", &Object::getType, "The Type of the Object")
+      .def("__hash__", &Object::getHash, "Get object hash")
+      .def("__eq__", &Object::eq, "Check if two objects are same");
 
   // Add the ReferenceAttr definition
   mlir_attribute_subclass(m, "ReferenceAttr", omAttrIsAReferenceAttr)

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -140,6 +140,17 @@ MlirType omEvaluatorObjectGetType(OMEvaluatorValue object) {
   return wrap(llvm::cast<Object>(unwrap(object).get())->getType());
 }
 
+/// Get the hash for the object.
+unsigned omEvaluatorObjectGetHash(OMEvaluatorValue object) {
+  return llvm::cast<Object>(unwrap(object).get())->getHash();
+}
+
+/// Check if two objects are same.
+bool omEvaluatorObjectIsEq(OMEvaluatorValue object, OMEvaluatorValue other) {
+  return llvm::cast<Object>(unwrap(object).get()) ==
+         llvm::cast<Object>(unwrap(other).get());
+}
+
 /// Get an ArrayAttr with the names of the fields in an Object.
 MlirAttribute omEvaluatorObjectGetFieldNames(OMEvaluatorValue object) {
   return wrap(llvm::cast<Object>(unwrap(object).get())->getFieldNames());

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/OM/OMDialect.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Wrap.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/Support/Casting.h"
 
 using namespace mlir;
@@ -142,7 +143,7 @@ MlirType omEvaluatorObjectGetType(OMEvaluatorValue object) {
 
 /// Get the hash for the object.
 unsigned omEvaluatorObjectGetHash(OMEvaluatorValue object) {
-  return llvm::cast<Object>(unwrap(object).get())->getHash();
+  return llvm::hash_value(llvm::cast<Object>(unwrap(object).get()));
 }
 
 /// Check if two objects are same.


### PR DESCRIPTION
This fixes an issue with the `Object` returned by `Evaluator::instantiate`, that was not "hashable".
In Python, a "hashable" object is an object that has a hash value that remains constant throughout its lifetime and can be compared to other objects. User-defined classes need to implement the `__hash__()` and `__eq__()` methods, to be hashable.
The `__hash__()` method should return an integer that represents the object's hash value, and the `__eq__()` method should define the object's equality with other objects.
This PR ensures the correct equality and hash methods are called on the underlying data-structures and not on the wrapper pointers.

Without this change, the test in `integration_tests` would create 3 entries in the dictionary.