### PR TITLE
Bump LLVM

### DIFF
--- a/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
+++ b/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
@@ -423,8 +423,7 @@ LogicalResult AffineToLoopSchedule::createLoopSchedulePipeline(
 
   SmallVector<Value> iterArgs;
   iterArgs.push_back(lowerBound);
-  iterArgs.append(innerLoop.getIterOperands().begin(),
-                  innerLoop.getIterOperands().end());
+  iterArgs.append(innerLoop.getInits().begin(), innerLoop.getInits().end());
 
   // If possible, attach a constant trip count attribute. This could be
   // generalized to support non-constant trip counts by supporting an AffineMap.

--- a/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
+++ b/lib/Conversion/LLHDToLLVM/LLHDToLLVM.cpp
@@ -1087,7 +1087,7 @@ struct InstOpConversion : public ConvertToLLVMPattern {
       auto oneC = initBuilder.create<LLVM::ConstantOp>(
           op->getLoc(), i32Ty, rewriter.getI32IntegerAttr(1));
       auto regNull =
-          initBuilder.create<LLVM::NullOp>(op->getLoc(), regStatePtrTy);
+          initBuilder.create<LLVM::ZeroOp>(op->getLoc(), regStatePtrTy);
       auto regGep = initBuilder.create<LLVM::GEPOp>(
           op->getLoc(), regStatePtrTy, regNull, ArrayRef<Value>({oneC}));
       auto regSize =
@@ -1157,7 +1157,7 @@ struct InstOpConversion : public ConvertToLLVMPattern {
             op.getLoc(), i32Ty, rewriter.getI32IntegerAttr(1));
         auto twoC = initBuilder.create<LLVM::ConstantOp>(
             op.getLoc(), i64Ty, rewriter.getI32IntegerAttr(2));
-        auto nullPtr = initBuilder.create<LLVM::NullOp>(
+        auto nullPtr = initBuilder.create<LLVM::ZeroOp>(
             op.getLoc(), LLVM::LLVMPointerType::get(underlyingTy));
         auto sizeGep = initBuilder.create<LLVM::GEPOp>(
             op.getLoc(), LLVM::LLVMPointerType::get(underlyingTy), nullPtr,
@@ -1210,7 +1210,7 @@ struct InstOpConversion : public ConvertToLLVMPattern {
               rewriter.getI32IntegerAttr(arrayTy.getNumElements()));
 
           // Get element size.
-          auto null = initBuilder.create<LLVM::NullOp>(
+          auto null = initBuilder.create<LLVM::ZeroOp>(
               op.getLoc(), LLVM::LLVMPointerType::get(arrayTy));
           auto gepFirst = initBuilder.create<LLVM::GEPOp>(
               op.getLoc(), LLVM::LLVMPointerType::get(arrayTy.getElementType()),
@@ -1227,7 +1227,7 @@ struct InstOpConversion : public ConvertToLLVMPattern {
           auto zeroC = initBuilder.create<LLVM::ConstantOp>(
               op.getLoc(), i32Ty, rewriter.getI32IntegerAttr(0));
 
-          auto null = initBuilder.create<LLVM::NullOp>(
+          auto null = initBuilder.create<LLVM::ZeroOp>(
               op.getLoc(), LLVM::LLVMPointerType::get(structTy));
           for (size_t i = 0, e = structTy.getBody().size(); i < e; ++i) {
             auto oneC = initBuilder.create<LLVM::ConstantOp>(
@@ -1243,7 +1243,7 @@ struct InstOpConversion : public ConvertToLLVMPattern {
                 op.getLoc(), i32Ty, gepElem);
 
             // Get element size.
-            auto elemNull = initBuilder.create<LLVM::NullOp>(
+            auto elemNull = initBuilder.create<LLVM::ZeroOp>(
                 op.getLoc(), LLVM::LLVMPointerType::get(structTy.getBody()[i]));
             auto gepElemSize = initBuilder.create<LLVM::GEPOp>(
                 op.getLoc(), LLVM::LLVMPointerType::get(structTy.getBody()[i]),
@@ -1283,7 +1283,7 @@ struct InstOpConversion : public ConvertToLLVMPattern {
 
       // Malloc space for the process state.
       auto procStateNullPtr =
-          initBuilder.create<LLVM::NullOp>(op->getLoc(), procStatePtrTy);
+          initBuilder.create<LLVM::ZeroOp>(op->getLoc(), procStatePtrTy);
       auto procStateGep = initBuilder.create<LLVM::GEPOp>(
           op->getLoc(), procStatePtrTy, procStateNullPtr,
           ArrayRef<Value>({oneC}));
@@ -1307,7 +1307,7 @@ struct InstOpConversion : public ConvertToLLVMPattern {
 
       // Malloc space for the senses table.
       auto sensesNullPtr =
-          initBuilder.create<LLVM::NullOp>(op->getLoc(), sensesPtrTy);
+          initBuilder.create<LLVM::ZeroOp>(op->getLoc(), sensesPtrTy);
       auto sensesGep = initBuilder.create<LLVM::GEPOp>(
           op->getLoc(), sensesPtrTy, sensesNullPtr, ArrayRef<Value>({oneC}));
       auto sensesSize =
@@ -1512,7 +1512,7 @@ struct DrvOpConversion : public ConvertToLLVMPattern {
           op->getLoc(), i32Ty, rewriter.getI32IntegerAttr(1));
       auto eightC = rewriter.create<LLVM::ConstantOp>(
           op->getLoc(), i64Ty, rewriter.getI64IntegerAttr(8));
-      auto nullPtr = rewriter.create<LLVM::NullOp>(op->getLoc(), llvmPtrTy);
+      auto nullPtr = rewriter.create<LLVM::ZeroOp>(op->getLoc(), llvmPtrTy);
       auto gepOne = rewriter.create<LLVM::GEPOp>(
           op->getLoc(), llvmPtrTy, nullPtr, ArrayRef<Value>(oneC));
       auto toInt =

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -73,11 +73,11 @@ public:
   explicit ScfForOp(scf::ForOp op) : calyx::RepeatOpInterface<scf::ForOp>(op) {}
 
   Block::BlockArgListType getBodyArgs() override {
-    return getOperation().getLoopBody().getArguments();
+    return getOperation().getRegion().getArguments();
   }
 
   Block *getBodyBlock() override {
-    return &getOperation().getLoopBody().getBlocks().front();
+    return &getOperation().getRegion().getBlocks().front();
   }
 
   std::optional<int64_t> getBound() override {

--- a/test/Conversion/LLHDToLLVM/convert_signals.mlir
+++ b/test/Conversion/LLHDToLLVM/convert_signals.mlir
@@ -78,7 +78,7 @@ llhd.entity @convert_prb (%sI1 : !llhd.sig<i1>, %sArr : !llhd.sig<!hw.array<3xi5
 // CHECK:           llvm.call @driveSignal(%[[VAL_0]], %[[VAL_4]], %[[VAL_17]], %[[VAL_14]], %[[VAL_18]], %[[VAL_19]], %[[VAL_20]]) : (!llvm.ptr, !llvm.ptr<struct<(ptr, i64, i64, i64)>>, !llvm.ptr, i64, i64, i64, i64) -> ()
 // CHECK:           %[[VAL_21:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:           %[[VAL_22:.*]] = llvm.mlir.constant(8 : i64) : i64
-// CHECK:           %[[VAL_23:.*]] = llvm.mlir.null : !llvm.ptr<array<3 x i5>>
+// CHECK:           %[[VAL_23:.*]] = llvm.mlir.zero : !llvm.ptr<array<3 x i5>>
 // CHECK:           %[[VAL_24:.*]] = llvm.getelementptr %[[VAL_23]]{{\[}}%[[VAL_21]]] : (!llvm.ptr<array<3 x i5>>, i32) -> !llvm.ptr<array<3 x i5>>
 // CHECK:           %[[VAL_25:.*]] = llvm.ptrtoint %[[VAL_24]] : !llvm.ptr<array<3 x i5>> to i64
 // CHECK:           %[[VAL_26:.*]] = llvm.mul %[[VAL_25]], %[[VAL_22]]  : i64


### PR DESCRIPTION
There were three breaking changes in LLVM:

1: In the LLVM dialect, NullOp was replaced with a more general ZeroOp. See: https://github.com/llvm/llvm-project/pull/67183.

2: AffineForOp's getInitOperands was renamed to getInits. See: https://github.com/llvm/llvm-project/pull/66925.

3: In the SCF dialect, the WhileOp now implements LoopLikeOpInterface, which now supports multiple loop regions. The getLoopBody member-function was removed in favour of LoopLike's getLoopRegions.  The While Op only has a single region, so we can replace calls to getLoopBody with getRegion. See: https://github.com/llvm/llvm-project/pull/66754