### PR TITLE
[ExportVerilog] Fix line count in debug verilog locations

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -6171,9 +6171,10 @@ void SharedEmitterState::emitOps(EmissionList &thingsToEmit,
         // the verilog location. This also clears the map, so that the map only
         // contains the current iteration's ops.
         state.addVerilogLocToOps(lineOffset, fileName);
-      } else
+      } else {
         os << entry.getStringData();
-      ++lineOffset;
+        ++lineOffset;
+      }
     }
 
     if (state.encounteredError)


### PR DESCRIPTION
Line offset count was incremented outside else block, fix the issue. This resulted in incorrect line number when threading was disabled.
Fix for https://github.com/llvm/circt/issues/6159