### PR TITLE
[FIRRTL][ExpandWhens] Support flow checking for local and remote objects

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1084,6 +1084,15 @@ def ObjectSubfieldOp : FIRRTLOp<"object.subfield",
     static Type inferReturnType(ValueRange operands,
                                 ArrayRef<NamedAttribute> attrs,
                                 std::optional<Location> loc);
+
+    /// Return a `FieldRef` to the accessed field.
+    FieldRef getAccessedField() {
+      auto input = getInput();
+      auto index = getIndex();
+      auto inputType = input.getType();
+      auto fieldID = inputType.getFieldID(index);
+      return FieldRef(input, fieldID);
+    }
   }];
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -35,6 +35,7 @@ struct RefTypeStorage;
 struct BaseTypeAliasStorage;
 struct OpenBundleTypeStorage;
 struct OpenVectorTypeStorage;
+struct ClassTypeStorage;
 } // namespace detail.
 
 class AnyRefType;

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -436,7 +436,8 @@ class PropImplType<string name,
                    string baseCppClass = "::circt::firrtl::FIRRTLType">
   : FIRRTLImplType<name, traits, baseCppClass>;
 
-def ClassImpl : PropImplType<"Class"> {
+def ClassImpl : PropImplType<"Class", [
+  DeclareTypeInterfaceMethods<FieldIDTypeInterface>]> {
   let summary = [{
     An instance of a class.
 
@@ -449,7 +450,7 @@ def ClassImpl : PropImplType<"Class"> {
     "FlatSymbolRefAttr":$name,
     ArrayRefParameter<"ClassElement">:$elements
   );
-  let genStorageClass = true;
+  let genStorageClass = false;
   let genAccessors = false;
   let builders = [
     TypeBuilderWithInferredContext<(ins

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -275,7 +275,7 @@ def LowerMatches : Pass<"firrtl-lower-matches", "firrtl::FModuleOp"> {
   let constructor = "circt::firrtl::createLowerMatchesPass()";
 }
 
-def ExpandWhens : Pass<"firrtl-expand-whens", "firrtl::FModuleOp"> {
+def ExpandWhens : InterfacePass<"firrtl-expand-whens", "firrtl::FModuleLike"> {
   let summary = "Remove all when conditional blocks.";
   let description = [{
     This pass will:

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -2506,8 +2506,48 @@ AsyncResetType AsyncResetType::getConstType(bool isConst) {
 }
 
 //===----------------------------------------------------------------------===//
-// InstanceType
+// ClassType
 //===----------------------------------------------------------------------===//
+
+struct circt::firrtl::detail::ClassTypeStorage : mlir::TypeStorage {
+  using KeyTy = std::pair<FlatSymbolRefAttr, ArrayRef<ClassElement>>;
+
+  static ClassTypeStorage *construct(TypeStorageAllocator &allocator,
+                                     KeyTy key) {
+    auto name = key.first;
+    auto elements = allocator.copyInto(key.second);
+
+    // build the field ID table
+    SmallVector<uint64_t, 4> ids;
+    uint64_t id = 0;
+    ids.reserve(elements.size());
+    for (auto &element : elements) {
+      id += 1;
+      ids.push_back(id);
+      id += hw::FieldIdImpl::getMaxFieldID(element.type);
+    }
+
+    auto fieldIDs = allocator.copyInto(ArrayRef(ids));
+    auto maxFieldID = id;
+
+    return new (allocator.allocate<ClassTypeStorage>())
+        ClassTypeStorage(name, elements, fieldIDs, maxFieldID);
+  }
+
+  ClassTypeStorage(FlatSymbolRefAttr name, ArrayRef<ClassElement> elements,
+                   ArrayRef<uint64_t> fieldIDs, uint64_t maxFieldID)
+      : name(name), elements(elements), fieldIDs(fieldIDs),
+        maxFieldID(maxFieldID) {}
+
+  bool operator==(const KeyTy &key) const {
+    return name == key.first && elements == key.second;
+  }
+
+  FlatSymbolRefAttr name;
+  ArrayRef<ClassElement> elements;
+  ArrayRef<uint64_t> fieldIDs;
+  uint64_t maxFieldID;
+};
 
 ClassType ClassType::get(FlatSymbolRefAttr name,
                          ArrayRef<ClassElement> elements) {
@@ -2552,6 +2592,45 @@ void ClassType::printInterface(AsmPrinter &p) const {
     first = false;
   }
   p << ")";
+}
+
+uint64_t ClassType::getFieldID(uint64_t index) const {
+  return getImpl()->fieldIDs[index];
+}
+
+uint64_t ClassType::getIndexForFieldID(uint64_t fieldID) const {
+  assert(!getElements().empty() && "Class must have >0 fields");
+  auto fieldIDs = getImpl()->fieldIDs;
+  auto *it = std::prev(llvm::upper_bound(fieldIDs, fieldID));
+  return std::distance(fieldIDs.begin(), it);
+}
+
+std::pair<uint64_t, uint64_t>
+ClassType::getIndexAndSubfieldID(uint64_t fieldID) const {
+  auto index = getIndexForFieldID(fieldID);
+  auto elementFieldID = getFieldID(index);
+  return {index, fieldID - elementFieldID};
+}
+
+std::pair<Type, uint64_t>
+ClassType::getSubTypeByFieldID(uint64_t fieldID) const {
+  if (fieldID == 0)
+    return {*this, 0};
+  auto subfieldIndex = getIndexForFieldID(fieldID);
+  auto subfieldType = getElement(subfieldIndex).type;
+  auto subfieldID = fieldID - getFieldID(subfieldIndex);
+  return {subfieldType, subfieldID};
+}
+
+uint64_t ClassType::getMaxFieldID() const { return getImpl()->maxFieldID; }
+
+std::pair<uint64_t, bool>
+ClassType::projectToChildFieldID(uint64_t fieldID, uint64_t index) const {
+  auto childRoot = getFieldID(index);
+  auto rangeEnd = index + 1 >= getNumElements() ? getMaxFieldID()
+                                                : (getFieldID(index + 1) - 1);
+  return std::make_pair(fieldID - childRoot,
+                        fieldID >= childRoot && fieldID <= rangeEnd);
 }
 
 ParseResult ClassType::parseInterface(AsmParser &parser, ClassType &result) {

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -1555,7 +1555,6 @@ std::pair<Type, uint64_t>
 BundleType::getSubTypeByFieldID(uint64_t fieldID) const {
   if (fieldID == 0)
     return {*this, 0};
-  auto fieldIDs = getImpl()->fieldIDs;
   auto subfieldIndex = getIndexForFieldID(fieldID);
   auto subfieldType = getElementType(subfieldIndex);
   auto subfieldID = fieldID - getFieldID(subfieldIndex);
@@ -1779,7 +1778,6 @@ std::pair<Type, uint64_t>
 OpenBundleType::getSubTypeByFieldID(uint64_t fieldID) const {
   if (fieldID == 0)
     return {*this, 0};
-  auto fieldIDs = getImpl()->fieldIDs;
   auto subfieldIndex = getIndexForFieldID(fieldID);
   auto subfieldType = getElementType(subfieldIndex);
   auto subfieldID = fieldID - getFieldID(subfieldIndex);
@@ -2265,7 +2263,6 @@ std::pair<Type, uint64_t>
 FEnumType::getSubTypeByFieldID(uint64_t fieldID) const {
   if (fieldID == 0)
     return {*this, 0};
-  auto fieldIDs = getImpl()->fieldIDs;
   auto subfieldIndex = getIndexForFieldID(fieldID);
   auto subfieldType = getElementType(subfieldIndex);
   auto subfieldID = fieldID - getFieldID(subfieldIndex);

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -108,9 +108,11 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   // things up.
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass(
       opt.preserveAggregate, firrtl::PreserveAggregate::None));
-  // Only enable expand whens if lower types is also enabled.
+
+  pm.nest<firrtl::CircuitOp>().nestAny().addPass(
+      firrtl::createExpandWhensPass());
+
   auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
-  modulePM.addPass(firrtl::createExpandWhensPass());
   modulePM.addPass(firrtl::createSFCCompatPass());
   modulePM.addPass(firrtl::createGroupSinkPass());
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -2167,10 +2167,10 @@ firrtl.circuit "InternalPathForNonRefType" {
 firrtl.circuit "Top" {
   firrtl.class @MyClass(in %input: !firrtl.string) {}
 
+  // expected-note @below {{the source was defined here}}
   firrtl.module @Top(out %object: !firrtl.class<@MyClass(in input : !firrtl.string)>,  out %str: !firrtl.string) {
-    // expected-note @below {{the source was defined here}}
     %0 = firrtl.object.subfield %object[input] : !firrtl.class<@MyClass(in input: !firrtl.string)>
-    // expected-error @below {{connect has invalid flow: the source expression has no flow, expected source or duplex flow}}
+    // expected-error @below {{connect has invalid flow: the source expression "object.input" has no flow, expected source or duplex flow}}
     firrtl.propassign %str, %0 : !firrtl.string
   }
 }
@@ -2183,11 +2183,11 @@ firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   firrtl.class @MyClass(in %input: !firrtl.string) {}
 
+  // expected-note @below {{the destination was defined here}}
   firrtl.module @Top(out %port: !firrtl.class<@MyClass(in input : !firrtl.string)>) {
     %0 = firrtl.string "foo"
-    // expected-note @below {{the destination was defined here}}
     %1 = firrtl.object.subfield %port[input] : !firrtl.class<@MyClass(in input: !firrtl.string)>
-    // expected-error @below {{connect has invalid flow: the destination expression has no flow, expected sink or duplex flow}}
+    // expected-error @below {{connect has invalid flow: the destination expression "port.input" has no flow, expected sink or duplex flow}}
     firrtl.propassign %1, %0 : !firrtl.string
   }
 }
@@ -2198,11 +2198,11 @@ firrtl.circuit "Top" {
 firrtl.circuit "Top" {
   firrtl.class @MyClass(in %input: !firrtl.string) {}
 
+  // expected-note @below {{the destination was defined here}}
   firrtl.module @Top(out %port: !firrtl.class<@MyClass(in input : !firrtl.string)>) {
     %0 = firrtl.string "foo"
-    // expected-note @below {{the destination was defined here}}
     %1 = firrtl.object.subfield %port[input] : !firrtl.class<@MyClass(in input: !firrtl.string)>
-    // expected-error @below {{connect has invalid flow: the destination expression has no flow, expected sink or duplex flow}}
+    // expected-error @below {{connect has invalid flow: the destination expression "port.input" has no flow, expected sink or duplex flow}}
     firrtl.propassign %1, %0 : !firrtl.string
   }
 }
@@ -2218,12 +2218,12 @@ firrtl.circuit "Top" {
   firrtl.class @A(out %b: !firrtl.class<@B(in input: !firrtl.string)>) {}
 
   firrtl.module @Top(out %port: !firrtl.class<@MyClass(in input : !firrtl.string)>) {
+    // expected-note @below {{the destination was defined here}}
     %a = firrtl.object @A(out b: !firrtl.class<@B(in input: !firrtl.string)>)
     %b = firrtl.object.subfield %a[b] : !firrtl.class<@A(out b: !firrtl.class<@B(in input: !firrtl.string)>)>
-    // expected-note @below {{the destination was defined here}}
     %input = firrtl.object.subfield %b[input] : !firrtl.class<@B(in input: !firrtl.string)>
     %value = firrtl.string "foo"
-    // expected-error @below {{connect has invalid flow: the destination expression has no flow, expected sink or duplex flow}}
+    // expected-error @below {{connect has invalid flow: the destination expression "a.b.input" has no flow, expected sink or duplex flow}}
     firrtl.propassign %input, %value : !firrtl.string
   }
 }

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -1,12 +1,12 @@
-// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-expand-whens)))' -verify-diagnostics --split-input-file %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(any(firrtl-expand-whens)))' -verify-diagnostics --split-input-file %s
 
 // This test is checking each kind of declaration to ensure that it is caught
 // by the initialization coverage check. This is also testing that we can emit
 // all errors in a module at once.
 firrtl.circuit "CheckInitialization" {
 firrtl.module @CheckInitialization(in %clock : !firrtl.clock, in %en : !firrtl.uint<1>, in %p : !firrtl.uint<1>, in %in0 : !firrtl.bundle<a  flip: uint<1>>, out %out0 : !firrtl.uint<2>, out %out1 : !firrtl.bundle<a flip: uint<1>>) {
-  // expected-error @above {{port "in0.a" not fully initialized in module "CheckInitialization"}}
-  // expected-error @above {{port "out0" not fully initialized in module "CheckInitialization"}}
+  // expected-error @above {{port "in0.a" not fully initialized in "CheckInitialization"}}
+  // expected-error @above {{port "out0" not fully initialized in "CheckInitialization"}}
 }
 }
 
@@ -14,8 +14,8 @@ firrtl.module @CheckInitialization(in %clock : !firrtl.clock, in %en : !firrtl.u
 
 firrtl.circuit "CheckInitialization" {
 firrtl.module @CheckInitialization() {
-  // expected-error @below {{sink "w.a" not fully initialized in module "CheckInitialization"}}
-  // expected-error @below {{sink "w.b" not fully initialized in module "CheckInitialization"}}
+  // expected-error @below {{sink "w.a" not fully initialized in "CheckInitialization"}}
+  // expected-error @below {{sink "w.b" not fully initialized in "CheckInitialization"}}
   %w = firrtl.wire : !firrtl.bundle<a : uint<1>, b  flip: uint<1>>
 }
 }
@@ -95,7 +95,7 @@ firrtl.module @complex(in %p : !firrtl.uint<1>, in %q : !firrtl.uint<1>) {
 
 firrtl.circuit "CheckInitialization" {
 firrtl.module @CheckInitialization(out %out : !firrtl.vector<uint<1>, 1>) {
-  // expected-error @above {{port "out[0]" not fully initialized in module "CheckInitialization"}}
+  // expected-error @above {{port "out[0]" not fully initialized in "CheckInitialization"}}
 }
 }
 
@@ -113,7 +113,7 @@ firrtl.module @CheckInitialization() {
 
 firrtl.circuit "CheckInitialization" {
 firrtl.module @CheckInitialization(in %in : !firrtl.uint<1>, out %out : !firrtl.vector<uint<1>, 2>) {
-  // expected-error @above {{port "out[1]" not fully initialized in module "CheckInitialization"}}
+  // expected-error @above {{port "out[1]" not fully initialized in "CheckInitialization"}}
   %0 = firrtl.subindex %out[0] : !firrtl.vector<uint<1>, 2>
   firrtl.connect %0, %in : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -123,7 +123,7 @@ firrtl.module @CheckInitialization(in %in : !firrtl.uint<1>, out %out : !firrtl.
 
 firrtl.circuit "CheckInitialization" {
 firrtl.module @CheckInitialization(in %in : !firrtl.uint<1>, out %out : !firrtl.vector<vector<uint<1>, 1>, 1>) {
-  // expected-error @above {{port "out[0][0]" not fully initialized in module "CheckInitialization"}}
+  // expected-error @above {{port "out[0][0]" not fully initialized in "CheckInitialization"}}
 }
 }
 
@@ -131,8 +131,8 @@ firrtl.module @CheckInitialization(in %in : !firrtl.uint<1>, out %out : !firrtl.
 
 firrtl.circuit "CheckInitialization" {
 firrtl.module @CheckInitialization(in %p : !firrtl.uint<1>, out %out: !firrtl.vector<bundle<a:uint<1>, b:uint<1>>, 1>) {
-  // expected-error @above {{port "out[0].a" not fully initialized in module "CheckInitialization"}}
-  // expected-error @above {{port "out[0].b" not fully initialized in module "CheckInitialization"}}
+  // expected-error @above {{port "out[0].a" not fully initialized in "CheckInitialization"}}
+  // expected-error @above {{port "out[0].b" not fully initialized in "CheckInitialization"}}
 }
 }
 
@@ -141,7 +141,7 @@ firrtl.module @CheckInitialization(in %p : !firrtl.uint<1>, out %out: !firrtl.ve
 // Check initialization error is produced for out-references
 firrtl.circuit "RefInitOut" {
 firrtl.module @RefInitOut(out %out : !firrtl.probe<uint<1>>) {
-  // expected-error @above {{port "out" not fully initialized in module "RefInitOut"}}
+  // expected-error @above {{port "out" not fully initialized in "RefInitOut"}}
 }
 }
 
@@ -152,26 +152,112 @@ firrtl.circuit "RefInitIn" {
 firrtl.module @Child(in %in: !firrtl.probe<uint<1>>) { }
 firrtl.module @RefInitIn() {
   %child_in = firrtl.instance child @Child(in in : !firrtl.probe<uint<1>>)
-  // expected-error @above {{sink "child.in" not fully initialized in module "RefInitIn"}}
+  // expected-error @above {{sink "child.in" not fully initialized in "RefInitIn"}}
 }
 }
 
 // -----
 
-// Check initialization error is produced for out-properties.
+// Check initialization error is produced for output property ports on modules.
 firrtl.circuit "PropInitOut" {
 firrtl.module @PropInitOut(out %out : !firrtl.string) {
-  // expected-error @above {{port "out" not fully initialized in module "PropInitOut"}}
+  // expected-error @above {{port "out" not fully initialized in "PropInitOut"}}
 }
 }
 
 // -----
 
-// Check initialization error is produced for in-properties.
+// Check initialization error is produced for output property ports on classes.
+firrtl.circuit "PropInitOut" {
+  // expected-error @below {{port "out" not fully initialized in "Class"}}
+  firrtl.class @Class(out %out: !firrtl.string) {}
+  firrtl.module @PropInitOut() {}
+}
+
+// -----
+
+// Check initialization error is produced for input property ports on instances.
 firrtl.circuit "PropInitIn" {
-firrtl.module @Child(in %in: !firrtl.string) { }
+firrtl.module @Child(in %in: !firrtl.string) {}
 firrtl.module @PropInitIn() {
   %child_in = firrtl.instance child @Child(in in : !firrtl.string)
-  // expected-error @above {{sink "child.in" not fully initialized in module "PropInitIn"}}
+  // expected-error @above {{sink "child.in" not fully initialized in "PropInitIn"}}
+}
+}
+
+// -----
+
+// Check initialization error is produced for input property ports on local objects.
+firrtl.circuit "PropInitIn" {
+firrtl.class @Class(in %in: !firrtl.string) {}
+firrtl.module @PropInitIn() {
+  // expected-error @below {{sink "obj.in" not fully initialized in "PropInitIn"}}
+  %obj = firrtl.object @Class(in in : !firrtl.string)
+}
+}
+
+// -----
+
+// Check initialization error is produced for output object ports on modules.
+firrtl.circuit "Test" {
+firrtl.class @Class() {}
+// expected-error @below {{port "out" not fully initialized in "Test"}}
+firrtl.module @Test(out %out: !firrtl.class<@Class()>) {}
+}
+
+// -----
+
+// Check initialization error is produced for output object ports on classes.
+firrtl.circuit "Test" {
+firrtl.class @Class1() {}
+// expected-error @below {{port "out" not fully initialized in "Class2"}}
+firrtl.class @Class2(out %out: !firrtl.class<@Class1()>) {}
+firrtl.module @Test() {}
+}
+
+// -----
+
+// Check initialization error is produced for input object ports on instances.
+firrtl.circuit "Test" {
+firrtl.class @Class() {}
+firrtl.module @Module(in %in: !firrtl.class<@Class()>) {}
+firrtl.module @Test() {
+  // expected-error @below {{sink "mod.in" not fully initialized in "Test"}}
+  %mod_in = firrtl.instance mod @Module(in in : !firrtl.class<@Class()>)
+}
+}
+
+// -----
+
+// Check initialization error is produced for input object ports on local objects.
+firrtl.circuit "Test" {
+firrtl.class @Class1() { }
+firrtl.class @Class2(in %in: !firrtl.class<@Class1()>) {}
+firrtl.module @Test() {
+  // expected-error @below {{sink "obj.in" not fully initialized in "Test"}}
+  %obj = firrtl.object @Class2(in in : !firrtl.class<@Class1()>)
+}
+}
+
+// -----
+
+// Check initialization errors for local objects are produced under firrtl classes.
+firrtl.circuit "Test" {
+firrtl.class @Class1(in %in: !firrtl.string) {}
+firrtl.class @Class2() {
+  // expected-error @below {{sink "obj.in" not fully initialized in "Class2"}}
+  %obj = firrtl.object @Class1(in in: !firrtl.string)
+}
+firrtl.module @Test() {}
+}
+
+// -----
+
+// Check initialization errors for objects in wires are produced.
+firrtl.circuit "Test" {
+firrtl.class @Class(in %in: !firrtl.string) {}
+firrtl.module @Test() {
+  // expected-error @below {{sink "w" not fully initialized in "Test"}}
+  %w = firrtl.wire : !firrtl.class<@Class()>
 }
 }


### PR DESCRIPTION
Objects can be classified as either local or remote. A local object is an actual firrtl.object declaration in the current scope. A remote object would be a class-typed port (of either the current module/class, or an instance/object).

For local objects, we are obligated to initialize their input ports. Sink-flow remote objects must be initialized by assigning to the entire thing, at the root.

This PR does a few things:
1) implement Field IDs for ClassType
2) implement FieldRef and field name utilities for objects
3) make expand-whens an interface pass that runs on FModuleLike operations, so that we can run it on class bodies in addition to modules.
4) In expand-whens, add support for flow checking of objects 
