### PR TITLE
[FIRRTL][LOA][NFCI] Use FieldRefCache.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
@@ -21,6 +21,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/FieldRefCache.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -213,6 +214,10 @@ private:
   /// List of operations to erase at the end.
   SmallVector<Operation *> opsToErase;
 
+  /// FieldRef cache.  Be careful to only use this for operations
+  /// in the original IR / not mutated.
+  FieldRefCache refs;
+
   /// Whether IR was changed.
   bool changesMade = false;
 };
@@ -376,6 +381,8 @@ LogicalResult Visitor::visit(FModuleLike mod) {
   mod.erasePorts(portsToErase);
   recordChanges(portsToErase.any());
 
+  LLVM_DEBUG(refs.printStats(llvm::dbgs()));
+
   return success();
 }
 
@@ -410,7 +417,7 @@ LogicalResult Visitor::visitExpr(OpenSubfieldOp op) {
   // Chase this to its original root.
   // If the FieldRef for this selection has a new home,
   // RAUW to that value and this op is dead.
-  auto resultRef = getFieldRefFromValue(op.getResult());
+  auto resultRef = refs.getFieldRefFromValue(op.getResult());
   auto nonHWForResult = nonHWValues.find(resultRef);
   if (nonHWForResult != nonHWValues.end()) {
     // If has nonHW portion, RAUW to it.
@@ -457,7 +464,7 @@ LogicalResult Visitor::visitExpr(OpenSubindexOp op) {
   // Chase this to its original root.
   // If the FieldRef for this selection has a new home,
   // RAUW to that value and this op is dead.
-  auto resultRef = getFieldRefFromValue(op.getResult());
+  auto resultRef = refs.getFieldRefFromValue(op.getResult());
   auto nonHWForResult = nonHWValues.find(resultRef);
   if (nonHWForResult != nonHWValues.end()) {
     // If has nonHW portion, RAUW to it.


### PR DESCRIPTION
Don't walk indexing operations multiple times, re-use FieldRef calculations.