### PR TITLE
[FIRRTL] Bump FIRRTL version to 3.3.0 for parsing

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -107,7 +107,8 @@ struct FIRVersion {
 };
 
 constexpr FIRVersion minimumFIRVersion(0, 2, 0);
-constexpr FIRVersion latestFIRVersion(3, 2, 0);
+constexpr FIRVersion latestFIRVersion(3, 3, 0);
+constexpr FIRVersion nextFIRVersion(3, 3, 0);
 constexpr FIRVersion defaultFIRVersion(1, 0, 0);
 
 template <typename T>

--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -107,8 +107,8 @@ struct FIRVersion {
 };
 
 constexpr FIRVersion minimumFIRVersion(0, 2, 0);
-constexpr FIRVersion latestFIRVersion(3, 3, 0);
 constexpr FIRVersion nextFIRVersion(3, 3, 0);
+constexpr FIRVersion exportFIRVersion = nextFIRVersion;
 constexpr FIRVersion defaultFIRVersion(1, 0, 0);
 
 template <typename T>

--- a/lib/CAPI/ExportFIRRTL/ExportFIRRTL.cpp
+++ b/lib/CAPI/ExportFIRRTL/ExportFIRRTL.cpp
@@ -20,5 +20,5 @@ MlirLogicalResult mlirExportFIRRTL(MlirModule module,
                                    MlirStringCallback callback,
                                    void *userData) {
   mlir::detail::CallbackOstream stream(callback, userData);
-  return wrap(exportFIRFile(unwrap(module), stream, {}, latestFIRVersion));
+  return wrap(exportFIRFile(unwrap(module), stream, {}, exportFIRVersion));
 }

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -1398,7 +1398,7 @@ void circt::firrtl::registerToFIRFileTranslation() {
   static mlir::TranslateFromMLIRRegistration toFIR(
       "export-firrtl", "emit FIRRTL dialect operations to .fir output",
       [](ModuleOp module, llvm::raw_ostream &os) {
-        return exportFIRFile(module, os, targetLineLength, latestFIRVersion);
+        return exportFIRFile(module, os, targetLineLength, exportFIRVersion);
       },
       [](mlir::DialectRegistry &registry) {
         registry.insert<chirrtl::CHIRRTLDialect>();

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -869,7 +869,7 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
     break;
 
   case FIRToken::kw_Inst: {
-    if (requireFeature({3, 2, 0}, "Inst types"))
+    if (requireFeature(nextFIRVersion, "Inst types"))
       return failure();
 
     consumeToken(FIRToken::kw_Inst);
@@ -897,7 +897,7 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
   }
 
   case FIRToken::kw_AnyRef: {
-    if (requireFeature({3, 2, 0}, "AnyRef types"))
+    if (requireFeature(nextFIRVersion, "AnyRef types"))
       return failure();
 
     consumeToken(FIRToken::kw_AnyRef);
@@ -1054,29 +1054,29 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
     result = FIntegerType::get(getContext());
     break;
   case FIRToken::kw_Bool:
-    if (requireFeature({3, 2, 0}, "Bools"))
+    if (requireFeature(nextFIRVersion, "Bools"))
       return failure();
     consumeToken(FIRToken::kw_Bool);
     result = BoolType::get(getContext());
     break;
   case FIRToken::kw_Double:
-    if (requireFeature({3, 2, 0}, "Doubles"))
+    if (requireFeature(nextFIRVersion, "Doubles"))
       return failure();
     consumeToken(FIRToken::kw_Double);
     result = DoubleType::get(getContext());
     break;
   case FIRToken::kw_Path:
-    if (requireFeature({3, 1, 0}, "Paths"))
+    if (requireFeature(nextFIRVersion, "Paths"))
       return failure();
     consumeToken(FIRToken::kw_Path);
     result = PathType::get(getContext());
     break;
   case FIRToken::kw_List:
-    if (requireFeature({3, 2, 0}, "Lists") || parseListType(result))
+    if (requireFeature(nextFIRVersion, "Lists") || parseListType(result))
       return failure();
     break;
   case FIRToken::kw_Map:
-    if (requireFeature({3, 2, 0}, "Maps") || parseMapType(result))
+    if (requireFeature(nextFIRVersion, "Maps") || parseMapType(result))
       return failure();
     break;
   }
@@ -1854,7 +1854,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
     break;
   }
   case FIRToken::kw_Bool: {
-    if (requireFeature({3, 2, 0}, "Bools"))
+    if (requireFeature(nextFIRVersion, "Bools"))
       return failure();
     locationProcessor.setLoc(getToken().getLoc());
     consumeToken(FIRToken::kw_Bool);
@@ -1873,7 +1873,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
     break;
   }
   case FIRToken::kw_Double: {
-    if (requireFeature({3, 2, 0}, "Doubles"))
+    if (requireFeature(nextFIRVersion, "Doubles"))
       return failure();
     locationProcessor.setLoc(getToken().getLoc());
     consumeToken(FIRToken::kw_Double);
@@ -1893,7 +1893,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
     break;
   }
   case FIRToken::kw_List: {
-    if (requireFeature({3, 2, 0}, "Lists"))
+    if (requireFeature(nextFIRVersion, "Lists"))
       return failure();
     if (isLeadingStmt)
       return emitError("unexpected List<>() as start of statement");
@@ -1902,7 +1902,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
     break;
   }
   case FIRToken::kw_Map: {
-    if (requireFeature({3, 2, 0}, "Maps"))
+    if (requireFeature(nextFIRVersion, "Maps"))
       return failure();
     if (isLeadingStmt)
       return emitError("unexpected Map<>() as start of statement");
@@ -1913,7 +1913,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
   case FIRToken::lp_path:
     if (isLeadingStmt)
       return emitError("unexpected path() as start of statement");
-    if (requireFeature({3, 2, 0}, "paths") || parsePathExp(result))
+    if (requireFeature(nextFIRVersion, "paths") || parsePathExp(result))
       return failure();
     break;
 
@@ -3691,7 +3691,7 @@ ParseResult FIRStmtParser::parseObject() {
   if (auto isExpr = parseExpWithLeadingKeyword(startTok))
     return *isExpr;
 
-  if (requireFeature({3, 2, 0}, "object statements"))
+  if (requireFeature(nextFIRVersion, "object statements"))
     return failure();
 
   StringRef id;
@@ -4569,7 +4569,7 @@ ParseResult FIRCircuitParser::parseClass(CircuitOp circuit, unsigned indent) {
   SmallVector<SMLoc> portLocs;
   LocWithInfo info(getToken().getLoc(), this);
 
-  if (requireFeature({3, 2, 0}, "classes"))
+  if (requireFeature(nextFIRVersion, "classes"))
     return failure();
 
   consumeToken(FIRToken::kw_class);
@@ -4606,7 +4606,7 @@ ParseResult FIRCircuitParser::parseExtClass(CircuitOp circuit,
   SmallVector<SMLoc> portLocs;
   LocWithInfo info(getToken().getLoc(), this);
 
-  if (requireFeature({3, 2, 0}, "classes"))
+  if (requireFeature(nextFIRVersion, "classes"))
     return failure();
 
   consumeToken(FIRToken::kw_extclass);

--- a/test/CAPI/firrtl.c
+++ b/test/CAPI/firrtl.c
@@ -42,7 +42,7 @@ void testExport(MlirContext ctx) {
   MlirLogicalResult result = mlirExportFIRRTL(module, exportCallback, NULL);
   assert(mlirLogicalResultIsSuccess(result));
 
-  // CHECK: FIRRTL version 3.2.0
+  // CHECK: FIRRTL version 3.3.0
   // CHECK-NEXT: circuit ExportTestSimpleModule :
   // CHECK-NEXT:   module ExportTestSimpleModule : @[- 2:3]
   // CHECK-NEXT:     input in_1 : UInt<32> @[- 2:44]

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -12,7 +12,7 @@
 // Check if printing with very short line length, removing info locators (@[...]), no line is longer than 5x line length.
 // RUN: circt-translate --export-firrtl %s --target-line-length=10 | sed -e 's/ @\[.*\]//' | FileCheck %s --implicit-check-not "{{^(.{50})}}" --check-prefix PRETTY
 
-// CHECK-LABEL: FIRRTL version 3.2.0
+// CHECK-LABEL: FIRRTL version 3.3.0
 // CHECK-LABEL: circuit Foo :
 // PRETTY-LABEL: circuit Foo :
 firrtl.circuit "Foo" {
@@ -646,7 +646,7 @@ firrtl.circuit "Foo" {
     firrtl.ref.define %_12, %18 : !firrtl.probe<uint<1>>
     firrtl.ref.define %_13, %_15_ref : !firrtl.rwprobe<uint<1>>
   }
-  
+
   // CHECK-LABEL: module Properties :
   firrtl.module @Properties(out %string : !firrtl.string,
                             out %integer : !firrtl.integer,

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1679,7 +1679,7 @@ circuit Groups:
 
 ;// -----
 ; CHECK-LABEL: firrtl.circuit "BasicProps"
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit BasicProps :
   module BasicProps :
   ; CHECK-LABEL: module private @Integer
@@ -1879,7 +1879,7 @@ circuit WireOfProbesAndNames:
     wire probe : Probe<UInt<1>>
 
 ;// -----
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 
 ; CHECK-LABEL: circuit "AnyRef"
 circuit AnyRef:

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -166,7 +166,7 @@ circuit invalid_inst :
 
 ;// -----
 
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit class_inst :
   class some_class :
   module class_inst :
@@ -819,21 +819,21 @@ circuit GroupAndCircuitShareName:
 
 ;// -----
 
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit Top:
   ; expected-error @below {{class cannot be the top of a circuit}}
   class Top:
 
 ;// -----
 
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit Top:
   ; expected-error @below {{extclass cannot be the top of a circuit}}
   extclass Top:
 
 ;// -----
 
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit Top:
   module Top:
   class Foo:
@@ -842,7 +842,7 @@ circuit Top:
 
 ;// -----
 
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit Top:
   module Top:
   extclass Foo:
@@ -868,7 +868,7 @@ circuit Top:
     propassign out, in
 
 ;// -----
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 
 circuit Top:
   module Top:
@@ -876,7 +876,7 @@ circuit Top:
     input in : Inst<Missing>
 
 ;// -----
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 
 circuit Top:
   module Top:
@@ -884,7 +884,7 @@ circuit Top:
     object x of Missing
 
 ;// -----
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 
 circuit Top:
   class MyClass:
@@ -900,7 +900,7 @@ circuit Top:
 FIRRTL version 3.0.0
 
 circuit Top:
-  ; expected-error @below {{classes are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.0.0}}
+  ; expected-error @below {{classes are a FIRRTL 3.3.0+ feature, but the specified FIRRTL version was 3.0.0}}
   class MyClass:
     skip
 
@@ -912,15 +912,15 @@ FIRRTL version 3.0.0
 
 circuit Top:
   module Top:
-    ; expected-error @below {{object statements are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.0.0}}
+    ; expected-error @below {{object statements are a FIRRTL 3.3.0+ feature, but the specified FIRRTL version was 3.0.0}}
     object x of MyClass
-  
+
 ;// -----
 FIRRTL version 3.0.0
 
 circuit Top:
   module Top:
-    ; expected-error @below {{Inst types are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.0.0}}
+    ; expected-error @below {{Inst types are a FIRRTL 3.3.0+ feature, but the specified FIRRTL version was 3.0.0}}
     output o: Inst<MyClass>
 
 ;// -----
@@ -928,11 +928,11 @@ circuit Top:
 FIRRTL version 3.1.0
 circuit ListOfInt:
    module ListOfInt:
-     ; expected-error @below {{Lists are a FIRRTL 3.2.0+ feature}}
+     ; expected-error @below {{Lists are a FIRRTL 3.3.0+ feature}}
      output a : List<Integer>
 
 ;// -----
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit ListOfUInt:
    module ListOfUInt:
      ; expected-error @below {{expected property type}}
@@ -940,7 +940,7 @@ circuit ListOfUInt:
 
 ;// -----
 ; Wrong type of elements in List expression.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit ListOfUInt:
    module ListOfUInt:
      output a : List<String>
@@ -949,7 +949,7 @@ circuit ListOfUInt:
 
 ;// -----
 ; List should not be leading a statement.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit LeadingList:
   module LeadingList:
     ; expected-error @below {{unexpected List<>() as start of statement}}
@@ -957,7 +957,7 @@ circuit LeadingList:
 
 ;// -----
 ; Path should not be leading a statement.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit LeadingPath:
   module LeadingPath:
     ; expected-error @below {{unexpected path() as start of statement}}
@@ -967,13 +967,13 @@ circuit LeadingPath:
 FIRRTL version 3.1.0
 circuit PathVersion:
   module PathVersion:
+    ; expected-error @below {{Paths are a FIRRTL 3.3.0+ feature, but the specified FIRRTL version was 3.1.0}}
     output path : Path
-    ; expected-error @below {{paths are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.1.0}}
     propassign path, path("")
 
 ;// -----
 ; Path operation should have a single string argument.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit BadPathExpr:
   module BadPathExp:
     output path : Path
@@ -982,7 +982,7 @@ circuit BadPathExpr:
 
 ;// -----
 ; Path operation should have a single string argument.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit BadPathExpr:
   module BadPathExp:
     output path : Path
@@ -991,7 +991,7 @@ circuit BadPathExpr:
 
 ;// -----
 ; Path operation should have a single string argument.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit BadPathExpr:
   module BadPathExp:
     output path : Path
@@ -1004,14 +1004,14 @@ FIRRTL version 3.0.0
 
 circuit Top:
   module Top:
-    ; expected-error @below {{Bools are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.0.0}}
+    ; expected-error @below {{Bools are a FIRRTL 3.3.0+ feature, but the specified FIRRTL version was 3.0.0}}
     input in : Bool
     output out : Bool
     propassign out, in
 
 ;// -----
 ; Bool literal must be true or false.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 
 circuit Top:
   module Top:
@@ -1021,7 +1021,7 @@ circuit Top:
 
 ;// -----
 ; Properties can't be const.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 
 circuit Top:
   module Top:
@@ -1033,12 +1033,12 @@ circuit Top:
 FIRRTL version 3.1.0
 circuit MapStrToInt:
    module MapStrToInt:
-     ; expected-error @below {{Maps are a FIRRTL 3.2.0+ feature}}
+     ; expected-error @below {{Maps are a FIRRTL 3.3.0+ feature}}
      output a : Map<String, Integer>
 
 ;// -----
 ; Map with non-property key type.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit MapUIntTo:
    module MapUIntTo:
      ; expected-error @below {{expected property type}}
@@ -1046,7 +1046,7 @@ circuit MapUIntTo:
 
 ;// -----
 ; Map with non-property value type.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit MapToUInt:
    module MapToUInt:
      ; expected-error @below {{expected property type}}
@@ -1054,7 +1054,7 @@ circuit MapToUInt:
 
 ;// -----
 ; Wrong type of keys in Map expression.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit MapToString:
    module MapToString:
      output a : Map<Integer, String>
@@ -1063,7 +1063,7 @@ circuit MapToString:
 
 ;// -----
 ; Wrong type of values in Map expression.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit MapBoolTo:
    module MapBoolTo:
      output a : Map<Bool, Integer>
@@ -1073,7 +1073,7 @@ circuit MapBoolTo:
 
 ;// -----
 ; Map should not be leading a statement.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit LeadingMap:
   module LeadingMap:
     ; expected-error @below {{unexpected Map<>() as start of statement}}
@@ -1081,7 +1081,7 @@ circuit LeadingMap:
 
 ;// -----
 ; Map should not be const.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit ConstMap:
   module ConstMap:
     ; expected-error @below {{only hardware types can be 'const'}}
@@ -1092,12 +1092,12 @@ circuit ConstMap:
 FIRRTL version 3.1.0
 circuit AnyRef:
    module AnyRef:
-     ; expected-error @below {{AnyRef types are a FIRRTL 3.2.0+ feature}}
+     ; expected-error @below {{AnyRef types are a FIRRTL 3.3.0+ feature}}
      output a : AnyRef
 
 ;// -----
 ; Only objects are valid as AnyRef
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit AnyRef:
   module AnyRef:
     output out : AnyRef
@@ -1106,7 +1106,7 @@ circuit AnyRef:
 
 ;// -----
 ; Only objects are valid as AnyRef in Lists
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit AnyRefList:
   module AnyRefList:
     output list : List<AnyRef>
@@ -1115,7 +1115,7 @@ circuit AnyRefList:
 
 ;// -----
 ; Only objects are valid as AnyRef in Maps (keys)
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit MapFromAnyRef:
   module MapFromAnyRef:
     output mapFrom : Map<AnyRef, Integer>
@@ -1124,7 +1124,7 @@ circuit MapFromAnyRef:
 
 ;// -----
 ; Only objects are valid as AnyRef in Maps (values)
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit MapToAnyRef:
   module MapToAnyRef:
     output mapTo: Map<Integer, AnyRef>
@@ -1133,7 +1133,7 @@ circuit MapToAnyRef:
 
 ;// -----
 ; Not Covariant.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit NotCovariant:
   class Class:
 
@@ -1146,7 +1146,7 @@ circuit NotCovariant:
 
 ;// -----
 ; Not Contravariant.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit NotContravariant:
   class Class:
 
@@ -1159,7 +1159,7 @@ circuit NotContravariant:
 
 ;// -----
 ; Double: must have digit before point.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit DoubleNegPeriod:
   module DoubleNegPeriod:
     output d : Double
@@ -1168,7 +1168,7 @@ circuit DoubleNegPeriod:
 
 ;// -----
 ; Double: must have digit after point.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit DoublePeriodEnd:
   module DoublePeriodEnd:
     output d : Double
@@ -1177,7 +1177,7 @@ circuit DoublePeriodEnd:
 
 ;// -----
 ; Double: Not an integer.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit DoubleInteger:
   module DoubleInteger:
     output d : Double
@@ -1186,7 +1186,7 @@ circuit DoubleInteger:
 
 ;// -----
 ; Double: don't support NaN or inf.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit DoubleNaN:
   module DoubleNaN:
     output d : Double
@@ -1195,7 +1195,7 @@ circuit DoubleNaN:
 
 ;// -----
 ; Double: Don't support hex.
-FIRRTL version 3.2.0
+FIRRTL version 3.3.0
 circuit DoubleHex:
   module DoubleHex:
     output d : Double
@@ -1203,8 +1203,8 @@ circuit DoubleHex:
     propassign d, Double(0x0)
 
 ;// -----
-; Double: Don't support FIRRTL-y radix.
-FIRRTL version 3.2.0
+; Double: Don't suuport FIRRTL-y radix.
+FIRRTL version 3.3.0
 circuit DoubleRadix:
   module DoubleRadix:
     output d : Double


### PR DESCRIPTION
Change the gating of new FIRRTL features from 3.2.0 to 3.3.0.  Simplify
this through the use of a new `nextFIRVersion`.

Change the name of the constexpr `latestFIRVersion` to `exportFIRVersion`
as this is not the "latest" version, but the version that is used when
exporting FIRRTL.  This will avoid confusion about what this is.