### PR TITLE
[FIRRTL][Parser] Update groups version check to 3.2.0.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2582,7 +2582,7 @@ ParseResult FIRStmtParser::parseSimpleStmtImpl(unsigned stmtIndent) {
   case FIRToken::lp_release_initial:
     return parseRefReleaseInitial();
   case FIRToken::kw_group:
-    if (requireFeature({3, 1, 0}, "optional groups"))
+    if (requireFeature({3, 2, 0}, "optional groups"))
       return failure();
     return parseGroup(stmtIndent);
 
@@ -4749,7 +4749,7 @@ ParseResult FIRCircuitParser::parseToplevelDefinition(CircuitOp circuit,
   case FIRToken::kw_class:
     return parseClass(circuit, indent);
   case FIRToken::kw_declgroup:
-    if (requireFeature({3, 1, 0}, "optional groups"))
+    if (requireFeature({3, 2, 0}, "optional groups"))
       return failure();
     return parseGroupDecl(circuit);
   case FIRToken::kw_extclass:

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1619,7 +1619,7 @@ circuit Top:
 ;// -----
 
 ; CHECK-LABEL: firrtl.circuit "Groups"
-FIRRTL version 3.1.0
+FIRRTL version 3.2.0
 circuit Groups:
   declgroup A, bind:
     declgroup B, bind:

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -787,29 +787,29 @@ circuit KeywordTypeName:
 
 ;// -----
 
-FIRRTL version 3.0.0
+FIRRTL version 3.1.0
 circuit UnsupportedVersionDeclGroups:
-  ; expected-error @below {{optional groups are a FIRRTL 3.1.0+ feature, but the specified FIRRTL version was 3.0.0}}
+  ; expected-error @below {{optional groups are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.1.0}}
   declgroup A, bind:
 
 ;// -----
 
-FIRRTL version 3.0.0
+FIRRTL version 3.1.0
 circuit UnsupportedVersionGroups:
   module UnsupportedVersionGroups:
-    ; expected-error @below {{optional groups are a FIRRTL 3.1.0+ feature, but the specified FIRRTL version was 3.0.0}}
+    ; expected-error @below {{optional groups are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.1.0}}
     group A:
 
 ;// -----
 
-FIRRTL version 3.1.0
+FIRRTL version 3.2.0
 circuit UnsupportedGroupConvention:
   ; expected-error @below {{unknown convention 'foo'}}
   declgroup A, foo :
 
 ;// -----
 
-FIRRTL version 3.1.0
+FIRRTL version 3.2.0
 circuit GroupAndCircuitShareName:
   ; expected-error @below {{cannot have the same name as the circuit}}
   declgroup GroupAndCircuitShareName, bind :

--- a/test/firtool/groups.fir
+++ b/test/firtool/groups.fir
@@ -1,6 +1,6 @@
 ; RUN: firtool %s | FileCheck %s
 
-FIRRTL version 3.1.0
+FIRRTL version 3.2.0
 circuit Foo: %[[
   {
     "class": "firrtl.transforms.DontTouchAnnotation",


### PR DESCRIPTION
They were added in 3.2.0.