### PR TITLE
[HW] Disallow duplicate field names in HW aggregate types

### DIFF
--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -131,6 +131,7 @@ def StructTypeImpl : HWType<"Struct", [DeclareTypeInterfaceMethods<FieldIDTypeIn
   let mnemonic = "struct";
 
   let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
 
   let parameters = (
     ins ArrayRefParameter<
@@ -184,6 +185,7 @@ def UnionTypeImpl : HWType<"Union"> {
   let mnemonic = "union";
 
   let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
 
   let extraClassDeclaration = [{
     using FieldInfo = ::circt::hw::detail::OffsetFieldInfo;

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -248,13 +248,14 @@ static ParseResult parseFields(AsmParser &p,
       mlir::AsmParser::Delimiter::LessGreater, [&]() -> ParseResult {
         std::string name;
         Type type;
+
+        auto fieldLoc = p.getCurrentLocation();
         if (p.parseKeywordOrString(&name) || p.parseColon() ||
             p.parseType(type))
           return failure();
 
         if (!nameSet.insert(name).second) {
-          p.emitError(p.getCurrentLocation(),
-                      "duplicate field name \'" + name + "\'");
+          p.emitError(fieldLoc, "duplicate field name \'" + name + "\'");
           // Continue parsing to print all duplicates, but make sure to error
           // eventually
           hasDuplicateName = true;

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -422,13 +422,14 @@ Type UnionType::parse(AsmParser &p) {
           mlir::AsmParser::Delimiter::LessGreater, [&]() -> ParseResult {
             StringRef name;
             Type type;
+
+            auto fieldLoc = p.getCurrentLocation();
             if (p.parseKeyword(&name) || p.parseColon() || p.parseType(type))
               return failure();
 
             if (!nameSet.insert(name).second) {
-              p.emitError(p.getCurrentLocation(), "duplicate field name \'" +
-                                                      name +
-                                                      "\' in hw.union type");
+              p.emitError(fieldLoc, "duplicate field name \'" + name +
+                                        "\' in hw.union type");
               // Continue parsing to print all duplicates, but make sure to
               // error eventually
               hasDuplicateName = true;

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -384,14 +384,12 @@ hw.module @foo() {
 
 // -----
 
-// expected-error @+1 {{duplicate field name 'foo'}}
-hw.module @struct(in %a: !hw.struct<foo: i8, bar: i8, foo: i8, baz: i8>) {
-    hw.output
-}
+// expected-error @+2 {{duplicate field name 'foo'}}
+// expected-error @+1 {{duplicate field name 'bar'}}
+hw.module @struct(in %a: !hw.struct<foo: i8, bar: i8, foo: i8, baz: i8, bar: i8>) {}
 
 // -----
 
-// expected-error @+1 {{duplicate field name 'foo' in hw.union type}}
-hw.module @union(in %a: !hw.union<foo: i8, bar: i8, foo: i8, baz: i8>) {
-    hw.output
-}
+// expected-error @+2 {{duplicate field name 'foo' in hw.union type}}
+// expected-error @+1 {{duplicate field name 'bar' in hw.union type}}
+hw.module @union(in %a: !hw.union<foo: i8, bar: i8, foo: i8, baz: i8, bar: i8>) {}

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -381,3 +381,17 @@ hw.module @foo() {
   %2 = hw.enum.cmp %0, %1 : !hw.enum<A>, !hw.enum<B>
   hw.output
 }
+
+// -----
+
+// expected-error @+1 {{duplicate field name 'foo'}}
+hw.module @struct(in %a: !hw.struct<foo: i8, bar: i8, foo: i8, baz: i8>) {
+    hw.output
+}
+
+// -----
+
+// expected-error @+1 {{duplicate field name 'foo' in hw.union type}}
+hw.module @union(in %a: !hw.union<foo: i8, bar: i8, foo: i8, baz: i8>) {
+    hw.output
+}


### PR DESCRIPTION
`hw.struct_extract`, `hw.struct_inject` and `hw.union_extract` refer to their respective field by name. However, field names of structs and union types are currently not enforced to be unique. This can cause ambiguities, e.g.:

```
hw.module @extract(in %a: i8, in %b: i8, out o: i8) {
    %0 = hw.struct_create (%a, %b) : !hw.struct<foo: i8, foo: i8>
    %1 = hw.struct_extract %0["foo"] :  !hw.struct<foo: i8, foo: i8>
    hw.output %1 : i8
}

> circt-opt ... --canonicalize

hw.module @extract(in %a : i8, in %b : i8, out o : i8) {
    hw.output %a : i8
}
``` 

This PR prevents the creation of HW aggregate types with duplicate field names.

As @seldridge pointed out to me, the FIRRTL dialect refers to subfields by index rather than by name. I've prepared a follow-up commit adopting this for StructExtract and StructInject ops. Allowing ambiguous names in structs is probably not a good idea either way. But it should be marginally more efficient, as it avoids iterating over the field names to find the matching one.  