### PR TITLE
[Arc] Add LowerArcsToFuncs pass

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.h
+++ b/include/circt/Dialect/Arc/ArcPasses.h
@@ -41,6 +41,7 @@ std::unique_ptr<mlir::Pass> createInlineModulesPass();
 std::unique_ptr<mlir::Pass> createIsolateClocksPass();
 std::unique_ptr<mlir::Pass> createLatencyRetimingPass();
 std::unique_ptr<mlir::Pass> createLegalizeStateUpdatePass();
+std::unique_ptr<mlir::Pass> createLowerArcsToFuncsPass();
 std::unique_ptr<mlir::Pass> createLowerClocksToFuncsPass();
 std::unique_ptr<mlir::Pass> createLowerLUTPass();
 std::unique_ptr<mlir::Pass> createLowerStatePass();

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -141,6 +141,12 @@ def LegalizeStateUpdate : Pass<"arc-legalize-state-update", "mlir::ModuleOp"> {
   let dependentDialects = ["arc::ArcDialect"];
 }
 
+def LowerArcsToFuncs : Pass<"arc-lower-arcs-to-funcs", "mlir::ModuleOp"> {
+  let summary = "Lower arc definitions into functions";
+  let constructor = "circt::arc::createLowerArcsToFuncsPass()";
+  let dependentDialects = ["mlir::func::FuncDialect"];
+}
+
 def LowerClocksToFuncs : Pass<"arc-lower-clocks-to-funcs", "mlir::ModuleOp"> {
   let summary = "Lower clock trees into functions";
   let constructor = "circt::arc::createLowerClocksToFuncsPass()";

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -144,7 +144,7 @@ def LegalizeStateUpdate : Pass<"arc-legalize-state-update", "mlir::ModuleOp"> {
 def LowerArcsToFuncs : Pass<"arc-lower-arcs-to-funcs", "mlir::ModuleOp"> {
   let summary = "Lower arc definitions into functions";
   let constructor = "circt::arc::createLowerArcsToFuncsPass()";
-  let dependentDialects = ["mlir::func::FuncDialect"];
+  let dependentDialects = ["mlir::func::FuncDialect", "mlir::LLVM::LLVMDialect"];
 }
 
 def LowerClocksToFuncs : Pass<"arc-lower-clocks-to-funcs", "mlir::ModuleOp"> {

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   IsolateClocks.cpp
   LatencyRetiming.cpp
   LegalizeStateUpdate.cpp
+  LowerArcsToFuncs.cpp
   LowerClocksToFuncs.cpp
   LowerLUT.cpp
   LowerState.cpp

--- a/lib/Dialect/Arc/Transforms/LowerArcsToFuncs.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerArcsToFuncs.cpp
@@ -111,9 +111,6 @@ static void populateOpConversion(RewritePatternSet &patterns,
   patterns
       .add<CallOpLowering, DefineOpLowering, OutputOpLowering, StateOpLowering>(
           typeConverter, context);
-
-  mlir::populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
-      patterns, typeConverter);
 }
 
 static void populateTypeConversion(TypeConverter &typeConverter) {

--- a/lib/Dialect/Arc/Transforms/LowerArcsToFuncs.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerArcsToFuncs.cpp
@@ -108,12 +108,9 @@ static void populateLegality(ConversionTarget &target) {
 static void populateOpConversion(RewritePatternSet &patterns,
                                  TypeConverter &typeConverter) {
   auto *context = patterns.getContext();
-  patterns.add<
-    CallOpLowering,
-    DefineOpLowering,
-    OutputOpLowering,
-    StateOpLowering
-  >(typeConverter, context);
+  patterns
+      .add<CallOpLowering, DefineOpLowering, OutputOpLowering, StateOpLowering>(
+          typeConverter, context);
 
   mlir::populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
       patterns, typeConverter);

--- a/lib/Dialect/Arc/Transforms/LowerArcsToFuncs.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerArcsToFuncs.cpp
@@ -1,0 +1,232 @@
+//===- LowerArcsToFuncs.cpp ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Support/Namespace.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-lower-arcs-to-funcs"
+
+namespace circt {
+namespace arc {
+#define GEN_PASS_DEF_LOWERARCSTOFUNCS
+#include "circt/Dialect/Arc/ArcPasses.h.inc"
+} // namespace arc
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+using namespace hw;
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LowerArcsToFuncsPass
+    : public arc::impl::LowerArcsToFuncsBase<LowerArcsToFuncsPass> {
+  LowerArcsToFuncsPass() = default;
+  LowerArcsToFuncsPass(const LowerArcsToFuncsPass &pass)
+      : LowerArcsToFuncsPass() {}
+
+  LogicalResult lowerToFuncs();
+  void runOnOperation() override;
+};
+
+struct DefineOpLowering : public OpConversionPattern<arc::DefineOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(arc::DefineOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto func = rewriter.create<mlir::func::FuncOp>(op.getLoc(), op.getName(),
+                                                    op.getFunctionType());
+    func->setAttr(
+        "llvm.linkage",
+        LLVM::LinkageAttr::get(getContext(), LLVM::linkage::Linkage::Internal));
+    rewriter.inlineRegionBefore(op.getRegion(), func.getBody(), func.end());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct OutputOpLowering : public OpConversionPattern<arc::OutputOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(arc::OutputOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    rewriter.replaceOpWithNewOp<func::ReturnOp>(op, adaptor.getOutputs());
+    return success();
+  }
+};
+
+struct CallOpLowering : public OpConversionPattern<arc::CallOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(arc::CallOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    SmallVector<Type> newResultTypes;
+    if (failed(
+            typeConverter->convertTypes(op.getResultTypes(), newResultTypes)))
+      return failure();
+    rewriter.replaceOpWithNewOp<func::CallOp>(
+        op, newResultTypes, op.getArcAttr(), adaptor.getInputs());
+    return success();
+  }
+};
+
+struct StateOpLowering : public OpConversionPattern<arc::StateOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(arc::StateOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    SmallVector<Type> newResultTypes;
+    if (failed(
+            typeConverter->convertTypes(op.getResultTypes(), newResultTypes)))
+      return failure();
+    rewriter.replaceOpWithNewOp<func::CallOp>(
+        op, newResultTypes, op.getArcAttr(), adaptor.getInputs());
+    return success();
+  }
+};
+
+struct ReturnOpLowering : public OpConversionPattern<func::ReturnOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(func::ReturnOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<func::ReturnOp>(op, adaptor.getOperands());
+    return success();
+  }
+};
+
+struct FuncCallOpLowering : public OpConversionPattern<func::CallOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(func::CallOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> newResultTypes;
+    if (failed(
+            typeConverter->convertTypes(op->getResultTypes(), newResultTypes)))
+      return failure();
+    rewriter.replaceOpWithNewOp<func::CallOp>(
+        op, op.getCalleeAttr(), newResultTypes, adaptor.getOperands());
+    return success();
+  }
+};
+
+} // namespace
+
+static bool isArcType(Type type) {
+  return type.isa<StorageType>() || type.isa<MemoryType>() ||
+         type.isa<StateType>();
+}
+
+static bool hasArcType(TypeRange types) {
+  return llvm::any_of(types, isArcType);
+}
+
+static bool hasArcType(ValueRange values) {
+  return hasArcType(values.getTypes());
+}
+
+template <typename Op>
+static void addGenericLegality(ConversionTarget &target) {
+  target.addDynamicallyLegalOp<Op>([](Op op) {
+    return !hasArcType(op->getOperands()) && !hasArcType(op->getResults());
+  });
+}
+
+static void populateLegality(ConversionTarget &target) {
+  target.addLegalDialect<mlir::BuiltinDialect>();
+  target.addLegalDialect<hw::HWDialect>();
+  target.addLegalDialect<comb::CombDialect>();
+  target.addLegalDialect<func::FuncDialect>();
+  target.addLegalDialect<scf::SCFDialect>();
+  target.addLegalDialect<LLVM::LLVMDialect>();
+
+  target.addIllegalOp<arc::DefineOp>();
+  target.addIllegalOp<arc::OutputOp>();
+  target.addIllegalOp<arc::StateOp>();
+
+  target.addDynamicallyLegalOp<func::FuncOp>([](func::FuncOp op) {
+    auto argsConverted = llvm::none_of(op.getBlocks(), [](auto &block) {
+      return hasArcType(block.getArguments());
+    });
+    auto resultsConverted = !hasArcType(op.getResultTypes());
+    return argsConverted && resultsConverted;
+  });
+  addGenericLegality<func::ReturnOp>(target);
+  addGenericLegality<func::CallOp>(target);
+}
+
+static void populateOpConversion(RewritePatternSet &patterns,
+                                 TypeConverter &typeConverter) {
+  auto *context = patterns.getContext();
+  // clang-format off
+  patterns.add<
+    CallOpLowering,
+    DefineOpLowering,
+    OutputOpLowering,
+    FuncCallOpLowering,
+    ReturnOpLowering,
+    StateOpLowering
+  >(typeConverter, context);
+  // clang-format on
+
+  mlir::populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(
+      patterns, typeConverter);
+}
+
+static void populateTypeConversion(TypeConverter &typeConverter) {
+  typeConverter.addConversion([&](StorageType type) {
+    return LLVM::LLVMPointerType::get(IntegerType::get(type.getContext(), 8));
+  });
+  typeConverter.addConversion([&](MemoryType type) {
+    return LLVM::LLVMPointerType::get(
+        IntegerType::get(type.getContext(), type.getStride() * 8));
+  });
+  typeConverter.addConversion([&](StateType type) {
+    return LLVM::LLVMPointerType::get(
+        typeConverter.convertType(type.getType()));
+  });
+  typeConverter.addConversion([](hw::ArrayType type) { return type; });
+  typeConverter.addConversion([](mlir::IntegerType type) { return type; });
+}
+
+
+/// Perform the lowering to Func and SCF.
+LogicalResult LowerArcsToFuncsPass::lowerToFuncs() {
+  LLVM_DEBUG(llvm::dbgs() << "Lowering arcs to Func/SCF dialects\n");
+  ConversionTarget target(getContext());
+  TypeConverter converter;
+  RewritePatternSet patterns(&getContext());
+  populateLegality(target);
+  populateTypeConversion(converter);
+  populateOpConversion(patterns, converter);
+  return applyPartialConversion(getOperation(), target, std::move(patterns));
+}
+
+void LowerArcsToFuncsPass::runOnOperation() {
+  if (failed(lowerToFuncs()))
+    return signalPassFailure();
+}
+
+std::unique_ptr<Pass> arc::createLowerArcsToFuncsPass() {
+  return std::make_unique<LowerArcsToFuncsPass>();
+}

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -1,12 +1,5 @@
 // RUN: circt-opt %s --lower-arc-to-llvm | FileCheck %s
 
-// CHECK-LABEL: llvm.func internal @EmptyArc() {
-arc.define @EmptyArc() {
-  arc.output
-  // CHECK-NEXT: llvm.return
-}
-// CHECK-NEXT: }
-
 // CHECK-LABEL: llvm.func @Types(
 // CHECK-SAME:    %arg0: !llvm.ptr<i8>
 // CHECK-SAME:    %arg1: !llvm.ptr<i1>
@@ -155,12 +148,12 @@ func.func @zeroCount(%arg0 : i32) {
 // CHECK-LABEL: llvm.func @callOp
 func.func @callOp(%arg0: i32) -> i32 {
   // CHECK-NEXT: [[V0:%.+]] = llvm.call @dummyCallee(%arg0) : (i32) -> i32
-  %0 = arc.call @dummyCallee(%arg0) : (i32) -> i32
+  %0 = func.call @dummyCallee(%arg0) : (i32) -> i32
   // CHECK-NEXT: return [[V0]] : i32
   return %0 : i32
 }
-arc.define @dummyCallee(%arg0: i32) -> i32 {
-  arc.output %arg0 : i32
+func.func @dummyCallee(%arg0: i32) -> i32 {
+  return %arg0 : i32
 }
 
 // FIXME: this does not really belong here, but there is no better place either.

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -145,17 +145,6 @@ func.func @zeroCount(%arg0 : i32) {
   return
 }
 
-// CHECK-LABEL: llvm.func @callOp
-func.func @callOp(%arg0: i32) -> i32 {
-  // CHECK-NEXT: [[V0:%.+]] = llvm.call @dummyCallee(%arg0) : (i32) -> i32
-  %0 = func.call @dummyCallee(%arg0) : (i32) -> i32
-  // CHECK-NEXT: return [[V0]] : i32
-  return %0 : i32
-}
-func.func @dummyCallee(%arg0: i32) -> i32 {
-  return %arg0 : i32
-}
-
 // FIXME: this does not really belong here, but there is no better place either.
 // CHECK-LABEL: llvm.func @lowerCombParity
 func.func @lowerCombParity(%arg0: i32) -> i1 {

--- a/test/Dialect/Arc/lower-arcs-to-funcs.mlir
+++ b/test/Dialect/Arc/lower-arcs-to-funcs.mlir
@@ -7,16 +7,16 @@ arc.define @EmptyArc() {
 }
 // CHECK-NEXT: }
 
-// CHECK-LABEL: func.func @test1(%arg0: i32)
-arc.define @test1(%arg0: i32) -> (i32) {
+// CHECK-LABEL: func.func @callTest(%arg0: i32)
+arc.define @callTest(%arg0: i32) -> (i32) {
     %0 = arc.call @sub1(%arg0) : (i32) -> i32
     // CHECK-NEXT: %0 = call @sub1(%arg0) : (i32) -> i32
     arc.output %0 : i32
     // CHECK-NEXT: return %0 : i32
 }
 
-// CHECK-LABEL: hw.module @test2
-hw.module @test2(%arg0: i32) -> (out0: i32) {
+// CHECK-LABEL: hw.module @stateTest
+hw.module @stateTest(%arg0: i32) -> (out0: i32) {
   %0 = arc.state @sub1(%arg0) lat 0 : (i32) -> i32
   // CHECK-NEXT: %0 = func.call @sub1(%arg0) : (i32) -> i32
   hw.output %0 : i32

--- a/test/Dialect/Arc/lower-arcs-to-funcs.mlir
+++ b/test/Dialect/Arc/lower-arcs-to-funcs.mlir
@@ -1,0 +1,30 @@
+// RUN: circt-opt %s --arc-lower-arcs-to-funcs --verify-diagnostics | FileCheck %s
+
+// CHECK-LABEL: func.func @EmptyArc() attributes {llvm.linkage = #llvm.linkage<internal>} {
+arc.define @EmptyArc() {
+  arc.output
+  // CHECK-NEXT: return
+}
+// CHECK-NEXT: }
+
+// CHECK-LABEL: func.func @test1(%arg0: i32)
+arc.define @test1(%arg0: i32) -> (i32) {
+    %0 = arc.call @sub1(%arg0) : (i32) -> i32
+    // CHECK-NEXT: %0 = call @sub1(%arg0) : (i32) -> i32
+    arc.output %0 : i32
+    // CHECK-NEXT: return %0 : i32
+}
+
+// CHECK-LABEL: hw.module @test2
+hw.module @test2(%arg0: i32) -> (out0: i32) {
+  %0 = arc.state @sub1(%arg0) lat 0 : (i32) -> i32
+  // CHECK-NEXT: %0 = func.call @sub1(%arg0) : (i32) -> i32
+  hw.output %0 : i32
+  // CHECK-NEXT: hw.output %0 : i32
+}
+
+// CHECK-LABEL: func.func @sub1
+arc.define @sub1(%arg0: i32) -> i32 {
+  arc.output %arg0 : i32
+  // CHECK-NEXT: return %arg0 : i32
+}

--- a/test/Dialect/Arc/lower-arcs-to-funcs.mlir
+++ b/test/Dialect/Arc/lower-arcs-to-funcs.mlir
@@ -16,7 +16,7 @@ arc.define @callTest(%arg0: i32) -> (i32) {
 }
 
 // CHECK-LABEL: hw.module @stateTest
-hw.module @stateTest(%arg0: i32) -> (out0: i32) {
+hw.module @stateTest(in %arg0: i32) -> (out0: i32) {
   %0 = arc.state @sub1(%arg0) lat 0 : (i32) -> i32
   // CHECK-NEXT: %0 = func.call @sub1(%arg0) : (i32) -> i32
   hw.output %0 : i32

--- a/test/Dialect/Arc/lower-arcs-to-funcs.mlir
+++ b/test/Dialect/Arc/lower-arcs-to-funcs.mlir
@@ -16,7 +16,7 @@ arc.define @callTest(%arg0: i32) -> (i32) {
 }
 
 // CHECK-LABEL: hw.module @stateTest
-hw.module @stateTest(in %arg0: i32) -> (out0: i32) {
+hw.module @stateTest(in %arg0: i32, out out0: i32) {
   %0 = arc.state @sub1(%arg0) lat 0 : (i32) -> i32
   // CHECK-NEXT: %0 = func.call @sub1(%arg0) : (i32) -> i32
   hw.output %0 : i32

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -262,6 +262,7 @@ static void populatePipeline(PassManager &pm) {
   pm.addPass(arc::createLegalizeStateUpdatePass());
   pm.addPass(createCSEPass());
   pm.addPass(arc::createArcCanonicalizerPass());
+  pm.addPass(arc::createLowerArcsToFuncsPass());
 
   // Allocate states.
   if (untilReached(UntilStateAlloc))

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -262,11 +262,11 @@ static void populatePipeline(PassManager &pm) {
   pm.addPass(arc::createLegalizeStateUpdatePass());
   pm.addPass(createCSEPass());
   pm.addPass(arc::createArcCanonicalizerPass());
-  pm.addPass(arc::createLowerArcsToFuncsPass());
 
   // Allocate states.
   if (untilReached(UntilStateAlloc))
     return;
+  pm.addPass(arc::createLowerArcsToFuncsPass());
   pm.nest<arc::ModelOp>().addPass(arc::createAllocateStatePass());
   if (!stateFile.empty())
     pm.addPass(arc::createPrintStateInfoPass(stateFile));


### PR DESCRIPTION
This splits out the parts of the LowerArcToLLVM pass that lower arc definitions to functions into a separate pass. This allows general function calls to be added by other passes in the pipeline before fully lowering to LLVM. Thanks!