### PR TITLE
[Ibis] Add ibis.sblock.isolated

### DIFF
--- a/include/circt/Dialect/Ibis/IbisInterfaces.td
+++ b/include/circt/Dialect/Ibis/IbisInterfaces.td
@@ -85,4 +85,18 @@ def ScopeOpInterface : OpInterface<"ScopeOpInterface", [Symbol]> {
   ];
 }
 
+def BlockOpInterface : OpInterface<"BlockOpInterface"> {
+  let cppNamespace = "circt::ibis";
+  let description = [{
+    An interface for Ibis block-like operations.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      "Returns the result types of this block from the point of view of inside the block",
+      "llvm::SmallVector<Type>", "getInternalResultTypes",
+      (ins)>
+  ];
+}
+
 #endif // CIRCT_DIALECT_IBIS_INTERFACES_TD

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -225,10 +225,54 @@ def ReturnOp : IbisOp<"return", [
   ];
 }
 
-def StaticBlockOp : IbisOp<"sblock", [
+class BlockLikeOp<string mnemonic, list<Trait> traits = []> : IbisOp<mnemonic, !listconcat(traits, [
   SingleBlockImplicitTerminator<"BlockReturnOp">,
-  AutomaticAllocationScope
-]> {
+  AutomaticAllocationScope,
+  BlockOpInterface])> {
+  let arguments = (ins
+    Variadic<AnyType>:$inputs,
+    OptionalAttr<ConfinedAttr<I64Attr, [IntMinValue<1>]>>:$maxThreads
+  );
+  let results = (outs Variadic<AnyType>:$outputs);
+  let regions = (region SizedRegion<1>:$body);
+  let hasCustomAssemblyFormat = 1;
+
+  code extraBlockClassDeclaration = ?;
+  let extraClassDeclaration = extraBlockClassDeclaration # [{
+    // Return the body of this block.
+    Block* getBodyBlock() { return &getBody().front(); }
+  }];
+  let hasVerifier = 1;
+  let skipDefaultBuilders = 1;
+}
+
+class HighLevelBlockLikeOp<string mnemonic, list<Trait> traits = []> : BlockLikeOp<mnemonic, traits> {
+  let builders = [
+    OpBuilder<(ins "TypeRange":$outputs, "ValueRange":$inputs,
+        CArg<"IntegerAttr", "{}">:$maxThreads), [{
+      $_state.addOperands(inputs);
+      if (maxThreads)
+        $_state.addAttribute(getMaxThreadsAttrName($_state.name), maxThreads);
+      auto* region = $_state.addRegion();
+      $_state.addTypes(outputs);
+      ensureTerminator(*region, $_builder, $_state.location);
+      llvm::SmallVector<Location> argLocs;
+      for(auto input : inputs)
+        argLocs.push_back(input.getLoc());
+      region->front().addArguments(inputs.getTypes(), argLocs);
+    }]>
+  ];
+
+  let extraBlockClassDeclaration = [{
+    llvm::SmallVector<Type> getInternalResultTypes() {
+      llvm::SmallVector<Type> outTypes;
+      llvm::copy(getResultTypes(), std::back_inserter(outTypes));
+      return outTypes;
+    }
+  }];
+}
+
+def StaticBlockOp : HighLevelBlockLikeOp<"sblock"> {
   let summary = "Ibis block";
   let description = [{
     The `ibis.sblock` operation defines a block wherein a group of operations
@@ -242,33 +286,17 @@ def StaticBlockOp : IbisOp<"sblock", [
     The block may contain additional attributes to specify constraints on
     the block further down the compilation pipeline.
   }];
+}
 
-  let arguments = (ins
-    Variadic<AnyType>:$inputs,
-    OptionalAttr<ConfinedAttr<I64Attr, [IntMinValue<1>]>>:$maxThreads
-  );
-  let results = (outs Variadic<AnyType>:$outputs);
-  let regions = (region SizedRegion<1>:$body);
-  let hasCustomAssemblyFormat = 1;
-
-  let extraClassDeclaration = [{
-    // Return the body of this block.
-    Block* getBodyBlock() { return &getBody().front(); }
+def IsolatedStaticBlockOp : HighLevelBlockLikeOp<"sblock.isolated", [
+  IsolatedFromAbove
+]> {
+  let summary = "Ibis isolated block";
+  let description = [{
+    The `ibis.sblock.isolated` operation is like an `ibis.sblock` operation
+    but with an IsolatedFromAbove condition, meaning that all arguments and
+    results are passed through the block as arguments and results.
   }];
-  let hasVerifier = 1;
-  let skipDefaultBuilders = 1;
-    let builders = [
-    OpBuilder<(ins "TypeRange":$outputs, "ValueRange":$inputs,
-        CArg<"IntegerAttr", "{}">:$maxThreads), [{
-      $_state.addOperands(inputs);
-      if (maxThreads) {
-        $_state.addAttribute(getMaxThreadsAttrName($_state.name), maxThreads);
-      }
-      auto* region = $_state.addRegion();
-      $_state.addTypes(outputs);
-      ensureTerminator(*region, $_builder, $_state.location);
-    }]>
-  ];
 }
 
 def InlineStaticBlockBeginOp : IbisOp<"sblock.inline.begin", [
@@ -314,7 +342,7 @@ def InlineStaticBlockEndOp : IbisOp<"sblock.inline.end", [
 }
 
 def BlockReturnOp : IbisOp<"sblock.return", [
-  Pure, ReturnLike, Terminator, HasParent<"StaticBlockOp">]> {
+  Pure, ReturnLike, Terminator, ParentOneOf<["StaticBlockOp", "IsolatedStaticBlockOp"]>]> {
   let summary = "Ibis static block terminator";
 
   let arguments = (ins Variadic<AnyType>:$retValues);

--- a/include/circt/Dialect/Ibis/IbisPasses.td
+++ b/include/circt/Dialect/Ibis/IbisPasses.td
@@ -106,7 +106,8 @@ def IbisArgifyBlocks : Pass<"ibis-argify-blocks"> {
   let summary = "Add arguments to ibis blocks";
   let description = [{
     Analyses `ibis.sblock` operations and converts any SSA value defined outside
-    the `ibis.sblock` to a block argument.
+    the `ibis.sblock` to a block argument. As a result, `ibis.sblock.isolated`
+    are produced.
   }];
   let constructor = "circt::ibis::createArgifyBlocksPass()";
 }
@@ -179,7 +180,7 @@ def IbisConvertCFToHandshake : Pass<"ibis-convert-cf-to-handshake", "ibis::Class
   let dependentDialects = ["circt::handshake::HandshakeDialect", "mlir::cf::ControlFlowDialect"];
 }
 
-def IbisPrepareScheduling : Pass<"ibis-prepare-scheduling", "ibis::DataflowMethodOp"> {
+def IbisPrepareScheduling : Pass<"ibis-prepare-scheduling", "ibis::IsolatedStaticBlockOp"> {
   let summary = "Prepare `ibis.sblock` operations for scheduling";
   let description = [{
     Prepares `ibis.sblock` operations for scheduling by:

--- a/lib/Dialect/Ibis/Transforms/IbisPassPipelines.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPassPipelines.cpp
@@ -67,6 +67,8 @@ void circt::ibis::loadIbisHighLevelPassPipeline(mlir::PassManager &pm) {
   pm.addPass(createSimpleCanonicalizerPass());
 
   // Now we're ready to schedule our pipelines.
-  pm.nest<ibis::ClassOp>().nest<ibis::DataflowMethodOp>().addPass(
-      ibis::createPrepareSchedulingPass());
+  pm.nest<ibis::ClassOp>()
+      .nest<ibis::DataflowMethodOp>()
+      .nest<ibis::IsolatedStaticBlockOp>()
+      .addPass(ibis::createPrepareSchedulingPass());
 }

--- a/lib/Dialect/Ibis/Transforms/IbisPrepareScheduling.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPrepareScheduling.cpp
@@ -27,18 +27,13 @@ struct PrepareSchedulingPass
     : public IbisPrepareSchedulingBase<PrepareSchedulingPass> {
   void runOnOperation() override;
 
-  void prepareSBlock(StaticBlockOp op);
+  void prepareSBlock(IsolatedStaticBlockOp op);
 };
 } // anonymous namespace
 
-void PrepareSchedulingPass::runOnOperation() {
-  DataflowMethodOp method = getOperation();
+void PrepareSchedulingPass::runOnOperation() { prepareSBlock(getOperation()); }
 
-  for (auto sblock : method.getOps<StaticBlockOp>())
-    prepareSBlock(sblock);
-}
-
-void PrepareSchedulingPass::prepareSBlock(StaticBlockOp sblock) {
+void PrepareSchedulingPass::prepareSBlock(IsolatedStaticBlockOp sblock) {
   Location loc = sblock.getLoc();
   Block *bodyBlock = sblock.getBodyBlock();
   auto b = OpBuilder::atBlockBegin(bodyBlock);

--- a/lib/Dialect/Ibis/Transforms/IbisPrepareScheduling.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPrepareScheduling.cpp
@@ -27,7 +27,7 @@ struct PrepareSchedulingPass
     : public IbisPrepareSchedulingBase<PrepareSchedulingPass> {
   void runOnOperation() override;
 
-  void prepareSBlock(IsolatedStaticBlockOp op);
+  void prepareSBlock(IsolatedStaticBlockOp sblock);
 };
 } // anonymous namespace
 

--- a/test/Dialect/Ibis/Transforms/argify_blocks.mlir
+++ b/test/Dialect/Ibis/Transforms/argify_blocks.mlir
@@ -4,7 +4,7 @@
 // CHECK-NEXT:   %this = ibis.this @Argify 
 // CHECK-NEXT:   ibis.method @foo() {
 // CHECK-NEXT:     %c32_i32 = hw.constant 32 : i32
-// CHECK-NEXT:     %0:2 = ibis.sblock (%arg0 : i32 = %c32_i32) -> (i32, i32) {
+// CHECK-NEXT:     %0:2 = ibis.sblock.isolated (%arg0 : i32 = %c32_i32) -> (i32, i32) {
 // CHECK-NEXT:       %c31_i32 = hw.constant 31 : i32
 // CHECK-NEXT:       %1 = arith.addi %arg0, %c31_i32 : i32
 // CHECK-NEXT:       ibis.sblock.return %1, %arg0 : i32, i32

--- a/test/Dialect/Ibis/Transforms/prepare_scheduling.mlir
+++ b/test/Dialect/Ibis/Transforms/prepare_scheduling.mlir
@@ -1,7 +1,7 @@
-// RUN: circt-opt --pass-pipeline="builtin.module(ibis.class(ibis.method.df(ibis-prepare-scheduling)))" \
+// RUN: circt-opt --pass-pipeline="builtin.module(ibis.class(ibis.method.df(ibis.sblock.isolated(ibis-prepare-scheduling))))" \
 // RUN:      --allow-unregistered-dialect %s | FileCheck %s
 
-// CHECK:   %[[VAL_3:.*]]:2 = ibis.sblock (%[[VAL_4:.*]] : i32 = %[[VAL_1:.*]], %[[VAL_5:.*]] : i32 = %[[VAL_2:.*]]) -> (i32, i32) {
+// CHECK:   %[[VAL_3:.*]]:2 = ibis.sblock.isolated (%[[VAL_4:.*]] : i32 = %[[VAL_1:.*]], %[[VAL_5:.*]] : i32 = %[[VAL_2:.*]]) -> (i32, i32) {
 // CHECK:     %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]] = ibis.pipeline.header
 // CHECK:     %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = pipeline.unscheduled(%[[VAL_13:.*]] : i32 = %[[VAL_4]], %[[VAL_14:.*]] : i32 = %[[VAL_5]]) stall(%[[VAL_9]]) clock(%[[VAL_6]]) reset(%[[VAL_7]]) go(%[[VAL_8]]) entryEn(%[[VAL_15:.*]])  -> (out0 : i32, out1 : i32) {
 // CHECK:       %[[VAL_16:.*]] = "foo.op1"(%[[VAL_13]], %[[VAL_14]]) : (i32, i32) -> i32
@@ -17,7 +17,7 @@ ibis.class @PrepareScheduling {
   // The resulting IR should have all values passing through the newly created
   // pipeline.
   ibis.method.df @foo(%a: i32, %b: i32) -> (i32, i32) {
-    %0, %1 = ibis.sblock (%arg0 : i32 = %a, %arg1 : i32 = %b) -> (i32, i32) {
+    %0, %1 = ibis.sblock.isolated (%arg0 : i32 = %a, %arg1 : i32 = %b) -> (i32, i32) {
       %4 = "foo.op1"(%arg0, %arg1) : (i32, i32) -> i32
       ibis.sblock.return %4, %arg0 : i32, i32
     }

--- a/test/ibistool/high_level.mlir
+++ b/test/ibistool/high_level.mlir
@@ -3,13 +3,13 @@
 // CHECK-LABEL:   ibis.class @ToHandshake {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @ToHandshake
 // CHECK:           ibis.method.df @foo(%[[VAL_1:.*]]: index, %[[VAL_2:.*]]: index, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: none) -> (i32, none) {
-// CHECK:             %[[VAL_5:.*]] = handshake.constant %[[VAL_4]] {value = 0 : i32} : i32
-// CHECK:             %[[VAL_6:.*]] = handshake.constant %[[VAL_4]] {value = 1 : index} : index
-// CHECK:             %[[VAL_7:.*]] = handshake.constant %[[VAL_4]] {value = 2 : i32} : i32
-// CHECK:             %[[VAL_8:.*]]:3 = ibis.sblock () -> (i32, index, i32) {
-// CHECK:               %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = ibis.pipeline.header
-// CHECK:               %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]] = pipeline.unscheduled() stall(%[[VAL_12]]) clock(%[[VAL_9]]) reset(%[[VAL_10]]) go(%[[VAL_11]]) entryEn(%[[VAL_17:.*]])  -> (out0 : i32, out1 : index, out2 : i32) {
-// CHECK:                 pipeline.return %[[VAL_7]], %[[VAL_6]], %[[VAL_5]] : i32, index, i32
+// CHECK:             %[[VAL_5:.*]]:3 = ibis.sblock.isolated () -> (i32, index, i32) {
+// CHECK:               %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]] = ibis.pipeline.header
+// CHECK:               %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]] = pipeline.unscheduled() stall(%[[VAL_9]]) clock(%[[VAL_6]]) reset(%[[VAL_7]]) go(%[[VAL_8]]) entryEn(%[[VAL_14:.*]])  -> (out0 : i32, out1 : index, out2 : i32) {
+// CHECK:                 %[[VAL_15:.*]] = arith.constant 2 : i32
+// CHECK:                 %[[VAL_16:.*]] = arith.constant 1 : index
+// CHECK:                 %[[VAL_17:.*]] = arith.constant 0 : i32
+// CHECK:                 pipeline.return %[[VAL_15]], %[[VAL_16]], %[[VAL_17]] : i32, index, i32
 // CHECK:               }
 // CHECK:               ibis.sblock.return %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] : i32, index, i32
 // CHECK:             }
@@ -21,7 +21,7 @@
 // CHECK:             %[[VAL_32:.*]] = handshake.mux %[[VAL_21]] {{\[}}%[[VAL_28]]#0, %[[VAL_33:.*]]] : i1, i32
 // CHECK:             %[[VAL_34:.*]] = handshake.mux %[[VAL_21]] {{\[}}%[[VAL_28]]#1, %[[VAL_35:.*]]] : i1, index
 // CHECK:             %[[VAL_36:.*]] = handshake.mux %[[VAL_21]] {{\[}}%[[VAL_28]]#2, %[[VAL_37:.*]]] : i1, i32
-// CHECK:             %[[VAL_22]] = ibis.sblock (%[[VAL_38:.*]] : index = %[[VAL_25]], %[[VAL_39:.*]] : index = %[[VAL_30]]) -> i1 {
+// CHECK:             %[[VAL_22]] = ibis.sblock.isolated (%[[VAL_38:.*]] : index = %[[VAL_25]], %[[VAL_39:.*]] : index = %[[VAL_30]]) -> i1 {
 // CHECK:               %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]] = ibis.pipeline.header
 // CHECK:               %[[VAL_44:.*]], %[[VAL_45:.*]] = pipeline.unscheduled(%[[VAL_46:.*]] : index = %[[VAL_38]], %[[VAL_47:.*]] : index = %[[VAL_39]]) stall(%[[VAL_43]]) clock(%[[VAL_40]]) reset(%[[VAL_41]]) go(%[[VAL_42]]) entryEn(%[[VAL_48:.*]])  -> (out0 : i1) {
 // CHECK:                 %[[VAL_49:.*]] = arith.cmpi slt, %[[VAL_46]], %[[VAL_47]] : index
@@ -36,7 +36,7 @@
 // CHECK:             %[[VAL_35]], %[[VAL_57:.*]] = handshake.cond_br %[[VAL_22]], %[[VAL_34]] : index
 // CHECK:             %[[VAL_37]], %[[VAL_58:.*]] = handshake.cond_br %[[VAL_22]], %[[VAL_36]] : i32
 // CHECK:             %[[VAL_59:.*]], %[[VAL_60:.*]] = handshake.cond_br %[[VAL_22]], %[[VAL_23]] : none
-// CHECK:             %[[VAL_61:.*]]:2 = ibis.sblock (%[[VAL_38]] : index = %[[VAL_51]], %[[VAL_62:.*]] : i32 = %[[VAL_53]], %[[VAL_63:.*]] : i32 = %[[VAL_33]], %[[VAL_64:.*]] : i32 = %[[VAL_37]]) -> (i32, i1) {
+// CHECK:             %[[VAL_61:.*]]:2 = ibis.sblock.isolated (%[[VAL_38]] : index = %[[VAL_51]], %[[VAL_62:.*]] : i32 = %[[VAL_53]], %[[VAL_63:.*]] : i32 = %[[VAL_33]], %[[VAL_64:.*]] : i32 = %[[VAL_37]]) -> (i32, i1) {
 // CHECK:               %[[VAL_65:.*]], %[[VAL_66:.*]], %[[VAL_67:.*]], %[[VAL_68:.*]] = ibis.pipeline.header
 // CHECK:               %[[VAL_69:.*]], %[[VAL_70:.*]], %[[VAL_71:.*]] = pipeline.unscheduled(%[[VAL_72:.*]] : index = %[[VAL_38]], %[[VAL_73:.*]] : i32 = %[[VAL_62]], %[[VAL_74:.*]] : i32 = %[[VAL_63]], %[[VAL_75:.*]] : i32 = %[[VAL_64]]) stall(%[[VAL_68]]) clock(%[[VAL_65]]) reset(%[[VAL_66]]) go(%[[VAL_67]]) entryEn(%[[VAL_76:.*]])  -> (out0 : i32, out1 : i1) {
 // CHECK:                 %[[VAL_77:.*]] = arith.index_cast %[[VAL_72]] : index to i32
@@ -49,7 +49,7 @@
 // CHECK:             %[[VAL_82:.*]], %[[VAL_83:.*]] = handshake.cond_br %[[VAL_84:.*]]#1, %[[VAL_53]] : i32
 // CHECK:             %[[VAL_85:.*]], %[[VAL_86:.*]] = handshake.cond_br %[[VAL_84]]#1, %[[VAL_59]] : none
 // CHECK:             %[[VAL_87:.*]], %[[VAL_88:.*]] = handshake.cond_br %[[VAL_84]]#1, %[[VAL_84]]#0 : i32
-// CHECK:             %[[VAL_89:.*]] = ibis.sblock (%[[VAL_38]] : i32 = %[[VAL_82]], %[[VAL_90:.*]] : i32 = %[[VAL_87]]) -> i32 {
+// CHECK:             %[[VAL_89:.*]] = ibis.sblock.isolated (%[[VAL_38]] : i32 = %[[VAL_82]], %[[VAL_90:.*]] : i32 = %[[VAL_87]]) -> i32 {
 // CHECK:               %[[VAL_91:.*]], %[[VAL_92:.*]], %[[VAL_93:.*]], %[[VAL_94:.*]] = ibis.pipeline.header
 // CHECK:               %[[VAL_95:.*]], %[[VAL_96:.*]] = pipeline.unscheduled(%[[VAL_97:.*]] : i32 = %[[VAL_38]], %[[VAL_98:.*]] : i32 = %[[VAL_90]]) stall(%[[VAL_94]]) clock(%[[VAL_91]]) reset(%[[VAL_92]]) go(%[[VAL_93]]) entryEn(%[[VAL_99:.*]])  -> (out0 : i32) {
 // CHECK:                 %[[VAL_100:.*]] = arith.addi %[[VAL_97]], %[[VAL_98]] : i32
@@ -57,7 +57,7 @@
 // CHECK:               }
 // CHECK:               ibis.sblock.return %[[VAL_101:.*]] : i32
 // CHECK:             }
-// CHECK:             %[[VAL_102:.*]] = ibis.sblock (%[[VAL_38]] : i32 = %[[VAL_83]], %[[VAL_103:.*]] : i32 = %[[VAL_88]]) -> i32 {
+// CHECK:             %[[VAL_102:.*]] = ibis.sblock.isolated (%[[VAL_38]] : i32 = %[[VAL_83]], %[[VAL_103:.*]] : i32 = %[[VAL_88]]) -> i32 {
 // CHECK:               %[[VAL_104:.*]], %[[VAL_105:.*]], %[[VAL_106:.*]], %[[VAL_107:.*]] = ibis.pipeline.header
 // CHECK:               %[[VAL_108:.*]], %[[VAL_109:.*]] = pipeline.unscheduled(%[[VAL_110:.*]] : i32 = %[[VAL_38]], %[[VAL_111:.*]] : i32 = %[[VAL_103]]) stall(%[[VAL_107]]) clock(%[[VAL_104]]) reset(%[[VAL_105]]) go(%[[VAL_106]]) entryEn(%[[VAL_112:.*]])  -> (out0 : i32) {
 // CHECK:                 %[[VAL_113:.*]] = arith.subi %[[VAL_110]], %[[VAL_111]] : i32
@@ -67,7 +67,7 @@
 // CHECK:             }
 // CHECK:             %[[VAL_29]] = handshake.mux %[[VAL_115:.*]] {{\[}}%[[VAL_102]], %[[VAL_89]]] : index, i32
 // CHECK:             %[[VAL_24]], %[[VAL_115]] = handshake.control_merge %[[VAL_86]], %[[VAL_85]] : none, index
-// CHECK:             %[[VAL_26]] = ibis.sblock (%[[VAL_38]] : index = %[[VAL_51]], %[[VAL_116:.*]] : index = %[[VAL_35]]) -> index {
+// CHECK:             %[[VAL_26]] = ibis.sblock.isolated (%[[VAL_38]] : index = %[[VAL_51]], %[[VAL_116:.*]] : index = %[[VAL_35]]) -> index {
 // CHECK:               %[[VAL_117:.*]], %[[VAL_118:.*]], %[[VAL_119:.*]], %[[VAL_120:.*]] = ibis.pipeline.header
 // CHECK:               %[[VAL_121:.*]], %[[VAL_122:.*]] = pipeline.unscheduled(%[[VAL_123:.*]] : index = %[[VAL_38]], %[[VAL_124:.*]] : index = %[[VAL_116]]) stall(%[[VAL_120]]) clock(%[[VAL_117]]) reset(%[[VAL_118]]) go(%[[VAL_119]]) entryEn(%[[VAL_125:.*]])  -> (out0 : index) {
 // CHECK:                 %[[VAL_126:.*]] = arith.addi %[[VAL_123]], %[[VAL_124]] : index


### PR DESCRIPTION
Post-argification it makes a lot of sense to have an IsolatedFromAbove block:
1. for pass scheduling purposes (eg. prepare-scheduling pass)
2. To ensure that constants aren't being pulled out of `ibis.sblock`s during canonicalization (which makes things harder post-handshake conversion, when we expect argification to persist)