### PR TITLE
[Ibis] Add handshake to DC conversion

### DIFF
--- a/include/circt/Dialect/Ibis/IbisOps.h
+++ b/include/circt/Dialect/Ibis/IbisOps.h
@@ -9,6 +9,7 @@
 #ifndef CIRCT_DIALECT_IBIS_IBISOPS_H
 #define CIRCT_DIALECT_IBIS_IBISOPS_H
 
+#include "circt/Dialect/DC/DCTypes.h"
 #include "circt/Dialect/Handshake/HandshakeInterfaces.h"
 #include "circt/Dialect/Ibis/IbisDialect.h"
 #include "circt/Dialect/Ibis/IbisTypes.h"
@@ -25,7 +26,6 @@
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
-
 namespace circt {
 namespace ibis {
 class ContainerOp;

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -299,6 +299,35 @@ def IsolatedStaticBlockOp : HighLevelBlockLikeOp<"sblock.isolated", [
   }];
 }
 
+def DCBlockOp : BlockLikeOp<"sblock.dc", [
+  IsolatedFromAbove
+]> {
+  let summary = "DC-interfaced Ibis block";
+  let description = [{
+    The `ibis.sblock.dc` operation is like an `ibis.sblock` operation with
+    a few differences, being:
+    1. The operation is DC-interfaced, meaning that all arguments and results
+       are dc-value typed.
+    2. The operation is IsolatedFromAbove.
+  }];
+
+  let builders = [
+    OpBuilder<(ins "TypeRange":$outputs, "ValueRange":$inputs,
+        CArg<"IntegerAttr", "{}">:$maxThreads)>
+  ];
+
+  let extraBlockClassDeclaration = [{
+    // The internal result types of a DC block op is the DC-type stripped
+    // outer result values.
+    llvm::SmallVector<Type> getInternalResultTypes() {
+      llvm::SmallVector<Type> innerRes;
+      for(Type outerRes : getResultTypes())
+        innerRes.push_back(outerRes.cast<dc::ValueType>().getInnerType());
+      return innerRes;
+    }
+  }];
+}
+
 def InlineStaticBlockBeginOp : IbisOp<"sblock.inline.begin", [
   HasParent<"MethodOp">
 ]> {
@@ -342,7 +371,8 @@ def InlineStaticBlockEndOp : IbisOp<"sblock.inline.end", [
 }
 
 def BlockReturnOp : IbisOp<"sblock.return", [
-  Pure, ReturnLike, Terminator, ParentOneOf<["StaticBlockOp", "IsolatedStaticBlockOp"]>]> {
+    Pure, ReturnLike, Terminator,
+    ParentOneOf<["StaticBlockOp", "IsolatedStaticBlockOp", "DCBlockOp"]>]> {
   let summary = "Ibis static block terminator";
 
   let arguments = (ins Variadic<AnyType>:$retValues);

--- a/include/circt/Dialect/Ibis/IbisPasses.h
+++ b/include/circt/Dialect/Ibis/IbisPasses.h
@@ -10,6 +10,7 @@
 #define CIRCT_DIALECT_IBIS_IBISPASSES_H
 
 #include "circt/Dialect/Pipeline/PipelineDialect.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
@@ -34,6 +35,7 @@ std::unique_ptr<mlir::Pass> createReblockPass();
 std::unique_ptr<mlir::Pass> createInlineSBlocksPass();
 std::unique_ptr<mlir::Pass> createConvertCFToHandshakePass();
 std::unique_ptr<mlir::Pass> createPrepareSchedulingPass();
+std::unique_ptr<mlir::Pass> createConvertHandshakeToDCPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Ibis/IbisPasses.td
+++ b/include/circt/Dialect/Ibis/IbisPasses.td
@@ -180,6 +180,20 @@ def IbisConvertCFToHandshake : Pass<"ibis-convert-cf-to-handshake", "ibis::Class
   let dependentDialects = ["circt::handshake::HandshakeDialect", "mlir::cf::ControlFlowDialect"];
 }
 
+def IbisConvertHandshakeToDC : Pass<"ibis-convert-handshake-to-dc", "ibis::ClassOp"> {
+  let summary = "Converts an `ibis.method.df` to use DC";
+  let description = [{
+    Converts an `ibis.method.df` from using `handshake` operations to
+    `dc` operations.
+  }];
+  let constructor = "circt::ibis::createConvertHandshakeToDCPass()";
+  let dependentDialects = [
+    "circt::dc::DCDialect",
+    "circt::handshake::HandshakeDialect",
+    "mlir::arith::ArithDialect"
+  ];
+}
+
 def IbisPrepareScheduling : Pass<"ibis-prepare-scheduling", "ibis::IsolatedStaticBlockOp"> {
   let summary = "Prepare `ibis.sblock` operations for scheduling";
   let description = [{

--- a/lib/Dialect/Ibis/CMakeLists.txt
+++ b/lib/Dialect/Ibis/CMakeLists.txt
@@ -9,7 +9,8 @@ add_circt_dialect_library(CIRCTIbis
   LINK_LIBS PUBLIC
   MLIRIR
   CIRCTHW
+  CIRCTDC
   CIRCTSeq
-  )
+)
 
 add_subdirectory(Transforms)

--- a/lib/Dialect/Ibis/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Ibis/Transforms/CMakeLists.txt
@@ -11,6 +11,7 @@ add_circt_dialect_library(CIRCTIbisTransforms
   IbisConvertCFToHandshake.cpp
   IbisPassPipelines.cpp
   IbisPrepareScheduling.cpp
+  IbisConvertHandshakeToDC.cpp
 
   DEPENDS
   CIRCTIbisTransformsIncGen
@@ -20,6 +21,7 @@ add_circt_dialect_library(CIRCTIbisTransforms
   CIRCTHandshake
   CIRCTPipelineOps
   CIRCTCFToHandshake
+  CIRCTHandshakeToDC
   CIRCTIbis
   CIRCTHW
   CIRCTSupport

--- a/lib/Dialect/Ibis/Transforms/IbisConvertHandshakeToDC.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisConvertHandshakeToDC.cpp
@@ -1,0 +1,115 @@
+//===- IbisConvertHandshakeToDCPass.cpp -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+#include "circt/Conversion/HandshakeToDC.h"
+#include "circt/Dialect/DC/DCTypes.h"
+#include "circt/Dialect/HW/ConversionPatterns.h"
+#include "circt/Dialect/Ibis/IbisDialect.h"
+#include "circt/Dialect/Ibis/IbisOps.h"
+#include "circt/Dialect/Ibis/IbisPasses.h"
+#include "circt/Dialect/Ibis/IbisTypes.h"
+
+#include "circt/Transforms/Passes.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "circt/Conversion/HandshakeToDC.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace ibis;
+
+namespace {
+
+struct ConvertHandshakeToDCPass
+    : public IbisConvertHandshakeToDCBase<ConvertHandshakeToDCPass> {
+  void runOnOperation() override;
+};
+
+class ReturnOpConversion : public OpConversionPattern<ReturnOp> {
+  using OpConversionPattern<ReturnOp>::OpConversionPattern;
+  using OpAdaptor = typename ReturnOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(ReturnOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<ibis::ReturnOp>(op, adaptor.getOperands());
+    return success();
+  }
+};
+
+struct StaticBlockOpConversion
+    : public OpConversionPattern<IsolatedStaticBlockOp> {
+  using OpConversionPattern<IsolatedStaticBlockOp>::OpConversionPattern;
+  using OpAdaptor = typename IsolatedStaticBlockOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(IsolatedStaticBlockOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    llvm::SmallVector<Type> resultTypes;
+    if (failed(
+            getTypeConverter()->convertTypes(op.getResultTypes(), resultTypes)))
+      return failure();
+    auto dcBlock = rewriter.create<DCBlockOp>(op.getLoc(), resultTypes,
+                                              adaptor.getOperands());
+    rewriter.eraseOp(dcBlock.getBodyBlock()->getTerminator());
+    rewriter.mergeBlocks(op.getBodyBlock(), dcBlock.getBodyBlock(),
+                         dcBlock.getBodyBlock()->getArguments());
+
+    rewriter.replaceOp(op, dcBlock.getResults());
+    return success();
+  }
+};
+
+} // anonymous namespace
+
+static bool isDCType(Type t) { return t.isa<dc::ValueType, dc::TokenType>(); }
+
+static bool isDCTypedOp(Operation *op) {
+  return llvm::all_of(op->getOperandTypes(), isDCType) &&
+         llvm::all_of(op->getResultTypes(), isDCType);
+}
+
+void ConvertHandshakeToDCPass::runOnOperation() {
+  ibis::ClassOp classOp = getOperation();
+  auto targetModifier = [&](mlir::ConversionTarget &target) {
+    target.addDynamicallyLegalOp<ibis::DataflowMethodOp>(
+        [](ibis::DataflowMethodOp op) {
+          return llvm::all_of(op.getArgumentTypes(), isDCType) &&
+                 llvm::all_of(op.getResultTypes(), isDCType);
+        });
+    target.addDynamicallyLegalOp<ibis::ReturnOp>(isDCTypedOp);
+    target.addLegalDialect<hw::HWDialect, ibis::IbisDialect>();
+    target.addIllegalOp<ibis::IsolatedStaticBlockOp>();
+
+    // ibis.sblock.dc ops are recursively legal - we're only considering the
+    // DataflowMethodOp's region for conversion.
+    target.addLegalOp<ibis::DCBlockOp>();
+    target.markOpRecursivelyLegal<ibis::DCBlockOp>();
+  };
+
+  auto patternBuilder = [&](TypeConverter &typeConverter,
+                            handshaketodc::ConvertedOps &convertedOps,
+                            RewritePatternSet &patterns) {
+    patterns
+        .add<TypeOpConversionPattern<DataflowMethodOp>,
+             TypeOpConversionPattern<ReturnOp>,
+             TypeOpConversionPattern<StaticBlockOp>, StaticBlockOpConversion>(
+            typeConverter, classOp.getContext());
+  };
+
+  LogicalResult res =
+      handshaketodc::runHandshakeToDC(classOp, patternBuilder, targetModifier);
+  if (failed(res))
+    signalPassFailure();
+}
+
+std::unique_ptr<Pass> circt::ibis::createConvertHandshakeToDCPass() {
+  return std::make_unique<ConvertHandshakeToDCPass>();
+}

--- a/lib/Dialect/Ibis/Transforms/IbisPassPipelines.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPassPipelines.cpp
@@ -57,15 +57,6 @@ void circt::ibis::loadIbisHighLevelPassPipeline(mlir::PassManager &pm) {
   pm.addPass(ibis::createArgifyBlocksPass());
   pm.addPass(createSimpleCanonicalizerPass());
 
-  // Make the CFG a binary tree by inserting merge blocks.
-  pm.addPass(circt::createInsertMergeBlocksPass());
-
-  // Perform dataflow conversion
-  pm.nest<ibis::ClassOp>().addPass(ibis::createConvertCFToHandshakePass());
-  // Canonicalize - necessary after handshake conversion to clean up a lot of
-  // stuff e.g. simple branches.
-  pm.addPass(createSimpleCanonicalizerPass());
-
   // Now we're ready to schedule our pipelines.
   pm.nest<ibis::ClassOp>()
       .nest<ibis::DataflowMethodOp>()

--- a/test/Dialect/Ibis/Transforms/cf_to_handshake.mlir
+++ b/test/Dialect/Ibis/Transforms/cf_to_handshake.mlir
@@ -9,7 +9,7 @@
 // CHECK:             %[[VAL_8:.*]] = handshake.buffer [2] fifo %[[VAL_7]] : i1
 // CHECK:             %[[VAL_9:.*]] = handshake.merge %[[VAL_4]] : none
 // CHECK:             %[[VAL_10:.*]] = ibis.sblock (%[[VAL_11:.*]] : i32 = %[[VAL_5]], %[[VAL_12:.*]] : i32 = %[[VAL_6]]) -> i32 attributes {maxThreads = 1 : i64} {
-// CHECK:               %[[VAL_13:.*]] = "foo.op1"(%[[VAL_11]], %[[VAL_12]]) : (i32, i32) -> i32
+// CHECK:               %[[VAL_13:.*]] = arith.addi %[[VAL_11]], %[[VAL_12]] : i32
 // CHECK:               ibis.sblock.return %[[VAL_13]] : i32
 // CHECK:             }
 // CHECK:             %[[VAL_14:.*]], %[[VAL_15:.*]] = handshake.cond_br %[[VAL_7]], %[[VAL_5]] : i32
@@ -19,7 +19,7 @@
 // CHECK:             %[[VAL_21:.*]] = handshake.merge %[[VAL_18]] : i32
 // CHECK:             %[[VAL_22:.*]], %[[VAL_23:.*]] = handshake.control_merge %[[VAL_16]] : none, index
 // CHECK:             %[[VAL_24:.*]] = ibis.sblock (%[[VAL_25:.*]] : i32 = %[[VAL_21]], %[[VAL_26:.*]] : i32 = %[[VAL_20]]) -> i32 {
-// CHECK:               %[[VAL_27:.*]] = "foo.op2"(%[[VAL_25]], %[[VAL_26]]) : (i32, i32) -> i32
+// CHECK:               %[[VAL_27:.*]] = arith.subi %[[VAL_25]], %[[VAL_26]] : i32
 // CHECK:               ibis.sblock.return %[[VAL_27]] : i32
 // CHECK:             }
 // CHECK:             %[[VAL_28:.*]] = handshake.br %[[VAL_22]] : none
@@ -46,13 +46,13 @@ ibis.class @ToHandshake {
   // in the handshake dialect tests.
   ibis.method @foo(%a: i32, %b: i32, %cond : i1) -> i32 {
     %0 = ibis.sblock (%arg0 : i32 = %a, %arg1 : i32 = %b) -> i32 attributes {maxThreads = 1 : i64} {
-      %4 = "foo.op1"(%arg0, %arg1) : (i32, i32) -> i32
+      %4 = arith.addi %arg0, %arg1 : i32
       ibis.sblock.return %4 : i32
     }
     cf.cond_br %cond, ^bb1(%a, %0 : i32, i32), ^bb2(%a, %0 : i32, i32)
   ^bb1(%11: i32, %21: i32):  // pred: ^bb0
     %31 = ibis.sblock (%arg0 : i32 = %21, %arg1 : i32 = %11) -> i32 {
-      %4 = "foo.op2"(%arg0, %arg1) : (i32, i32) -> i32
+      %4 = arith.subi %arg0, %arg1 : i32
       ibis.sblock.return %4 : i32
     }
     cf.br ^bb4(%31 : i32)

--- a/test/Dialect/Ibis/Transforms/handshake_to_dc.mlir
+++ b/test/Dialect/Ibis/Transforms/handshake_to_dc.mlir
@@ -1,0 +1,31 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(ibis.class(ibis-convert-handshake-to-dc))' %s | FileCheck %s
+
+// Actual handshake-to-dc conversion is tested in the respective pass tests.
+// This file just tests the ibis-specific hooks.
+
+// CHECK-LABEL:   ibis.class @ToDC {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @ToDC
+// CHECK:           ibis.method.df @foo(%[[VAL_1:.*]]: !dc.value<i32>) -> !dc.value<i32> {
+// CHECK:             %[[VAL_2:.*]], %[[VAL_3:.*]] = dc.unpack %[[VAL_1]] : !dc.value<i32>
+// CHECK:             %[[VAL_4:.*]]:2 = dc.fork [2] %[[VAL_2]]
+// CHECK:             %[[VAL_5:.*]] = dc.pack %[[VAL_4]]#0, %[[VAL_3]] : i32
+// CHECK:             %[[VAL_6:.*]] = dc.pack %[[VAL_4]]#1, %[[VAL_3]] : i32
+// CHECK:             %[[VAL_7:.*]] = ibis.sblock.dc (%[[VAL_8:.*]] : !dc.value<i32> = %[[VAL_5]], %[[VAL_9:.*]] : !dc.value<i32> = %[[VAL_6]]) -> !dc.value<i32> {
+// CHECK:               %[[VAL_10:.*]] = arith.addi %[[VAL_8]], %[[VAL_9]] : i32
+// CHECK:               ibis.sblock.return %[[VAL_10]] : i32
+// CHECK:             }
+// CHECK:             ibis.return %[[VAL_7]] : !dc.value<i32>
+// CHECK:           }
+// CHECK:         }
+
+ibis.class @ToDC {
+  %this = ibis.this @ToDC 
+  ibis.method.df @foo(%arg0: i32) -> (i32) {
+    %o0, %o1 = handshake.fork [2] %arg0 : i32
+    %1 = ibis.sblock.isolated(%a0 : i32 = %o0, %a1 : i32 = %o1) -> i32 {
+      %res = arith.addi %a0, %a1 : i32
+      ibis.sblock.return %res : i32
+    }
+    ibis.return %1 : i32
+  }
+}

--- a/test/ibistool/high_level.mlir
+++ b/test/ibistool/high_level.mlir
@@ -2,80 +2,48 @@
 
 // CHECK-LABEL:   ibis.class @ToHandshake {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @ToHandshake
-// CHECK:           ibis.method.df @foo(%[[VAL_1:.*]]: index, %[[VAL_2:.*]]: index, %[[VAL_3:.*]]: i1, %[[VAL_4:.*]]: none) -> (i32, none) {
-// CHECK:             %[[VAL_5:.*]]:3 = ibis.sblock.isolated () -> (i32, index, i32) {
-// CHECK:               %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]] = ibis.pipeline.header
-// CHECK:               %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]] = pipeline.unscheduled() stall(%[[VAL_9]]) clock(%[[VAL_6]]) reset(%[[VAL_7]]) go(%[[VAL_8]]) entryEn(%[[VAL_14:.*]])  -> (out0 : i32, out1 : index, out2 : i32) {
-// CHECK:                 %[[VAL_15:.*]] = arith.constant 2 : i32
-// CHECK:                 %[[VAL_16:.*]] = arith.constant 1 : index
-// CHECK:                 %[[VAL_17:.*]] = arith.constant 0 : i32
-// CHECK:                 pipeline.return %[[VAL_15]], %[[VAL_16]], %[[VAL_17]] : i32, index, i32
-// CHECK:               }
-// CHECK:               ibis.sblock.return %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] : i32, index, i32
+// CHECK:           ibis.method @foo(%[[VAL_1:.*]]: index, %[[VAL_2:.*]]: index, %[[VAL_3:.*]]: i1) -> i32 {
+// CHECK:             %[[VAL_4:.*]]:3 = ibis.sblock.isolated () -> (i32, index, i32) {
+// CHECK:               %[[VAL_5:.*]] = arith.constant 2 : i32
+// CHECK:               %[[VAL_6:.*]] = arith.constant 1 : index
+// CHECK:               %[[VAL_7:.*]] = arith.constant 0 : i32
+// CHECK:               ibis.sblock.return %[[VAL_5]], %[[VAL_6]], %[[VAL_7]] : i32, index, i32
 // CHECK:             }
-// CHECK:             %[[VAL_21:.*]] = handshake.buffer [1] seq %[[VAL_22:.*]] {initValues = [0]} : i1
-// CHECK:             %[[VAL_23:.*]] = handshake.mux %[[VAL_21]] {{\[}}%[[VAL_4]], %[[VAL_24:.*]]] : i1, none
-// CHECK:             %[[VAL_25:.*]] = handshake.mux %[[VAL_21]] {{\[}}%[[VAL_1]], %[[VAL_26:.*]]] : i1, index
-// CHECK:             %[[VAL_27:.*]] = handshake.mux %[[VAL_21]] {{\[}}%[[VAL_28:.*]]#2, %[[VAL_29:.*]]] : i1, i32
-// CHECK:             %[[VAL_30:.*]] = handshake.mux %[[VAL_21]] {{\[}}%[[VAL_2]], %[[VAL_31:.*]]] : i1, index
-// CHECK:             %[[VAL_32:.*]] = handshake.mux %[[VAL_21]] {{\[}}%[[VAL_28]]#0, %[[VAL_33:.*]]] : i1, i32
-// CHECK:             %[[VAL_34:.*]] = handshake.mux %[[VAL_21]] {{\[}}%[[VAL_28]]#1, %[[VAL_35:.*]]] : i1, index
-// CHECK:             %[[VAL_36:.*]] = handshake.mux %[[VAL_21]] {{\[}}%[[VAL_28]]#2, %[[VAL_37:.*]]] : i1, i32
-// CHECK:             %[[VAL_22]] = ibis.sblock.isolated (%[[VAL_38:.*]] : index = %[[VAL_25]], %[[VAL_39:.*]] : index = %[[VAL_30]]) -> i1 {
-// CHECK:               %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]] = ibis.pipeline.header
-// CHECK:               %[[VAL_44:.*]], %[[VAL_45:.*]] = pipeline.unscheduled(%[[VAL_46:.*]] : index = %[[VAL_38]], %[[VAL_47:.*]] : index = %[[VAL_39]]) stall(%[[VAL_43]]) clock(%[[VAL_40]]) reset(%[[VAL_41]]) go(%[[VAL_42]]) entryEn(%[[VAL_48:.*]])  -> (out0 : i1) {
-// CHECK:                 %[[VAL_49:.*]] = arith.cmpi slt, %[[VAL_46]], %[[VAL_47]] : index
-// CHECK:                 pipeline.return %[[VAL_49]] : i1
-// CHECK:               }
-// CHECK:               ibis.sblock.return %[[VAL_50:.*]] : i1
+// CHECK:             cf.br ^bb1(%[[VAL_1]], %[[VAL_8:.*]]#2, %[[VAL_2]], %[[VAL_8]]#0, %[[VAL_8]]#1, %[[VAL_8]]#2 : index, i32, index, i32, index, i32)
+// CHECK:           ^bb1(%[[VAL_9:.*]]: index, %[[VAL_10:.*]]: i32, %[[VAL_11:.*]]: index, %[[VAL_12:.*]]: i32, %[[VAL_13:.*]]: index, %[[VAL_14:.*]]: i32):
+// CHECK:             %[[VAL_15:.*]] = ibis.sblock.isolated (%[[VAL_16:.*]] : index = %[[VAL_9]], %[[VAL_17:.*]] : index = %[[VAL_11]]) -> i1 {
+// CHECK:               %[[VAL_18:.*]] = arith.cmpi slt, %[[VAL_16]], %[[VAL_17]] : index
+// CHECK:               ibis.sblock.return %[[VAL_18]] : i1
 // CHECK:             }
-// CHECK:             %[[VAL_51:.*]], %[[VAL_52:.*]] = handshake.cond_br %[[VAL_22]], %[[VAL_25]] : index
-// CHECK:             %[[VAL_53:.*]], %[[VAL_54:.*]] = handshake.cond_br %[[VAL_22]], %[[VAL_27]] : i32
-// CHECK:             %[[VAL_31]], %[[VAL_55:.*]] = handshake.cond_br %[[VAL_22]], %[[VAL_30]] : index
-// CHECK:             %[[VAL_33]], %[[VAL_56:.*]] = handshake.cond_br %[[VAL_22]], %[[VAL_32]] : i32
-// CHECK:             %[[VAL_35]], %[[VAL_57:.*]] = handshake.cond_br %[[VAL_22]], %[[VAL_34]] : index
-// CHECK:             %[[VAL_37]], %[[VAL_58:.*]] = handshake.cond_br %[[VAL_22]], %[[VAL_36]] : i32
-// CHECK:             %[[VAL_59:.*]], %[[VAL_60:.*]] = handshake.cond_br %[[VAL_22]], %[[VAL_23]] : none
-// CHECK:             %[[VAL_61:.*]]:2 = ibis.sblock.isolated (%[[VAL_38]] : index = %[[VAL_51]], %[[VAL_62:.*]] : i32 = %[[VAL_53]], %[[VAL_63:.*]] : i32 = %[[VAL_33]], %[[VAL_64:.*]] : i32 = %[[VAL_37]]) -> (i32, i1) {
-// CHECK:               %[[VAL_65:.*]], %[[VAL_66:.*]], %[[VAL_67:.*]], %[[VAL_68:.*]] = ibis.pipeline.header
-// CHECK:               %[[VAL_69:.*]], %[[VAL_70:.*]], %[[VAL_71:.*]] = pipeline.unscheduled(%[[VAL_72:.*]] : index = %[[VAL_38]], %[[VAL_73:.*]] : i32 = %[[VAL_62]], %[[VAL_74:.*]] : i32 = %[[VAL_63]], %[[VAL_75:.*]] : i32 = %[[VAL_64]]) stall(%[[VAL_68]]) clock(%[[VAL_65]]) reset(%[[VAL_66]]) go(%[[VAL_67]]) entryEn(%[[VAL_76:.*]])  -> (out0 : i32, out1 : i1) {
-// CHECK:                 %[[VAL_77:.*]] = arith.index_cast %[[VAL_72]] : index to i32
-// CHECK:                 %[[VAL_78:.*]] = arith.remsi %[[VAL_73]], %[[VAL_74]] : i32
-// CHECK:                 %[[VAL_79:.*]] = arith.cmpi eq, %[[VAL_78]], %[[VAL_75]] : i32
-// CHECK:                 pipeline.return %[[VAL_77]], %[[VAL_79]] : i32, i1
-// CHECK:               }
-// CHECK:               ibis.sblock.return %[[VAL_80:.*]], %[[VAL_81:.*]] : i32, i1
+// CHECK:             cf.cond_br %[[VAL_15]], ^bb2(%[[VAL_11]], %[[VAL_12]], %[[VAL_13]], %[[VAL_14]], %[[VAL_9]], %[[VAL_10]] : index, i32, index, i32, index, i32), ^bb6(%[[VAL_10]] : i32)
+// CHECK:           ^bb2(%[[VAL_19:.*]]: index, %[[VAL_20:.*]]: i32, %[[VAL_21:.*]]: index, %[[VAL_22:.*]]: i32, %[[VAL_23:.*]]: index, %[[VAL_24:.*]]: i32):
+// CHECK:             %[[VAL_25:.*]]:2 = ibis.sblock.isolated (%[[VAL_26:.*]] : index = %[[VAL_23]], %[[VAL_27:.*]] : i32 = %[[VAL_24]], %[[VAL_28:.*]] : i32 = %[[VAL_20]], %[[VAL_29:.*]] : i32 = %[[VAL_22]]) -> (i32, i1) {
+// CHECK:               %[[VAL_30:.*]] = arith.index_cast %[[VAL_26]] : index to i32
+// CHECK:               %[[VAL_31:.*]] = arith.remsi %[[VAL_27]], %[[VAL_28]] : i32
+// CHECK:               %[[VAL_32:.*]] = arith.cmpi eq, %[[VAL_31]], %[[VAL_29]] : i32
+// CHECK:               ibis.sblock.return %[[VAL_30]], %[[VAL_32]] : i32, i1
 // CHECK:             }
-// CHECK:             %[[VAL_82:.*]], %[[VAL_83:.*]] = handshake.cond_br %[[VAL_84:.*]]#1, %[[VAL_53]] : i32
-// CHECK:             %[[VAL_85:.*]], %[[VAL_86:.*]] = handshake.cond_br %[[VAL_84]]#1, %[[VAL_59]] : none
-// CHECK:             %[[VAL_87:.*]], %[[VAL_88:.*]] = handshake.cond_br %[[VAL_84]]#1, %[[VAL_84]]#0 : i32
-// CHECK:             %[[VAL_89:.*]] = ibis.sblock.isolated (%[[VAL_38]] : i32 = %[[VAL_82]], %[[VAL_90:.*]] : i32 = %[[VAL_87]]) -> i32 {
-// CHECK:               %[[VAL_91:.*]], %[[VAL_92:.*]], %[[VAL_93:.*]], %[[VAL_94:.*]] = ibis.pipeline.header
-// CHECK:               %[[VAL_95:.*]], %[[VAL_96:.*]] = pipeline.unscheduled(%[[VAL_97:.*]] : i32 = %[[VAL_38]], %[[VAL_98:.*]] : i32 = %[[VAL_90]]) stall(%[[VAL_94]]) clock(%[[VAL_91]]) reset(%[[VAL_92]]) go(%[[VAL_93]]) entryEn(%[[VAL_99:.*]])  -> (out0 : i32) {
-// CHECK:                 %[[VAL_100:.*]] = arith.addi %[[VAL_97]], %[[VAL_98]] : i32
-// CHECK:                 pipeline.return %[[VAL_100]] : i32
-// CHECK:               }
-// CHECK:               ibis.sblock.return %[[VAL_101:.*]] : i32
+// CHECK:             cf.cond_br %[[VAL_33:.*]]#1, ^bb3(%[[VAL_19]], %[[VAL_20]], %[[VAL_21]], %[[VAL_22]], %[[VAL_23]], %[[VAL_24]], %[[VAL_33]]#0 : index, i32, index, i32, index, i32, i32), ^bb4(%[[VAL_19]], %[[VAL_20]], %[[VAL_21]], %[[VAL_22]], %[[VAL_23]], %[[VAL_24]], %[[VAL_33]]#0 : index, i32, index, i32, index, i32, i32)
+// CHECK:           ^bb3(%[[VAL_34:.*]]: index, %[[VAL_35:.*]]: i32, %[[VAL_36:.*]]: index, %[[VAL_37:.*]]: i32, %[[VAL_38:.*]]: index, %[[VAL_39:.*]]: i32, %[[VAL_40:.*]]: i32):
+// CHECK:             %[[VAL_41:.*]] = ibis.sblock.isolated (%[[VAL_42:.*]] : i32 = %[[VAL_39]], %[[VAL_43:.*]] : i32 = %[[VAL_40]]) -> i32 {
+// CHECK:               %[[VAL_44:.*]] = arith.addi %[[VAL_42]], %[[VAL_43]] : i32
+// CHECK:               ibis.sblock.return %[[VAL_44]] : i32
 // CHECK:             }
-// CHECK:             %[[VAL_102:.*]] = ibis.sblock.isolated (%[[VAL_38]] : i32 = %[[VAL_83]], %[[VAL_103:.*]] : i32 = %[[VAL_88]]) -> i32 {
-// CHECK:               %[[VAL_104:.*]], %[[VAL_105:.*]], %[[VAL_106:.*]], %[[VAL_107:.*]] = ibis.pipeline.header
-// CHECK:               %[[VAL_108:.*]], %[[VAL_109:.*]] = pipeline.unscheduled(%[[VAL_110:.*]] : i32 = %[[VAL_38]], %[[VAL_111:.*]] : i32 = %[[VAL_103]]) stall(%[[VAL_107]]) clock(%[[VAL_104]]) reset(%[[VAL_105]]) go(%[[VAL_106]]) entryEn(%[[VAL_112:.*]])  -> (out0 : i32) {
-// CHECK:                 %[[VAL_113:.*]] = arith.subi %[[VAL_110]], %[[VAL_111]] : i32
-// CHECK:                 pipeline.return %[[VAL_113]] : i32
-// CHECK:               }
-// CHECK:               ibis.sblock.return %[[VAL_114:.*]] : i32
+// CHECK:             cf.br ^bb5(%[[VAL_41]], %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]] : i32, index, i32, index, i32, index)
+// CHECK:           ^bb4(%[[VAL_45:.*]]: index, %[[VAL_46:.*]]: i32, %[[VAL_47:.*]]: index, %[[VAL_48:.*]]: i32, %[[VAL_49:.*]]: index, %[[VAL_50:.*]]: i32, %[[VAL_51:.*]]: i32):
+// CHECK:             %[[VAL_52:.*]] = ibis.sblock.isolated (%[[VAL_53:.*]] : i32 = %[[VAL_50]], %[[VAL_54:.*]] : i32 = %[[VAL_51]]) -> i32 {
+// CHECK:               %[[VAL_55:.*]] = arith.subi %[[VAL_53]], %[[VAL_54]] : i32
+// CHECK:               ibis.sblock.return %[[VAL_55]] : i32
 // CHECK:             }
-// CHECK:             %[[VAL_29]] = handshake.mux %[[VAL_115:.*]] {{\[}}%[[VAL_102]], %[[VAL_89]]] : index, i32
-// CHECK:             %[[VAL_24]], %[[VAL_115]] = handshake.control_merge %[[VAL_86]], %[[VAL_85]] : none, index
-// CHECK:             %[[VAL_26]] = ibis.sblock.isolated (%[[VAL_38]] : index = %[[VAL_51]], %[[VAL_116:.*]] : index = %[[VAL_35]]) -> index {
-// CHECK:               %[[VAL_117:.*]], %[[VAL_118:.*]], %[[VAL_119:.*]], %[[VAL_120:.*]] = ibis.pipeline.header
-// CHECK:               %[[VAL_121:.*]], %[[VAL_122:.*]] = pipeline.unscheduled(%[[VAL_123:.*]] : index = %[[VAL_38]], %[[VAL_124:.*]] : index = %[[VAL_116]]) stall(%[[VAL_120]]) clock(%[[VAL_117]]) reset(%[[VAL_118]]) go(%[[VAL_119]]) entryEn(%[[VAL_125:.*]])  -> (out0 : index) {
-// CHECK:                 %[[VAL_126:.*]] = arith.addi %[[VAL_123]], %[[VAL_124]] : index
-// CHECK:                 pipeline.return %[[VAL_126]] : index
-// CHECK:               }
-// CHECK:               ibis.sblock.return %[[VAL_127:.*]] : index
+// CHECK:             cf.br ^bb5(%[[VAL_52]], %[[VAL_45]], %[[VAL_46]], %[[VAL_47]], %[[VAL_48]], %[[VAL_49]] : i32, index, i32, index, i32, index)
+// CHECK:           ^bb5(%[[VAL_56:.*]]: i32, %[[VAL_57:.*]]: index, %[[VAL_58:.*]]: i32, %[[VAL_59:.*]]: index, %[[VAL_60:.*]]: i32, %[[VAL_61:.*]]: index):
+// CHECK:             %[[VAL_62:.*]] = ibis.sblock.isolated (%[[VAL_63:.*]] : index = %[[VAL_61]], %[[VAL_64:.*]] : index = %[[VAL_59]]) -> index {
+// CHECK:               %[[VAL_65:.*]] = arith.addi %[[VAL_63]], %[[VAL_64]] : index
+// CHECK:               ibis.sblock.return %[[VAL_65]] : index
 // CHECK:             }
-// CHECK:             ibis.return %[[VAL_54]], %[[VAL_60]] : i32, none
+// CHECK:             cf.br ^bb1(%[[VAL_62]], %[[VAL_56]], %[[VAL_57]], %[[VAL_58]], %[[VAL_59]], %[[VAL_60]] : index, i32, index, i32, index, i32)
+// CHECK:           ^bb6(%[[VAL_66:.*]]: i32):
+// CHECK:             ibis.return %[[VAL_66]] : i32
 // CHECK:           }
 // CHECK:         }
 


### PR DESCRIPTION
Adds an Ibis-based handshake-to-DC conversion, using the handshake-to-DC conversion library. To facilitate this, a new block is introduced, which has a DC interface (`ibis.sblock.dc`).