### PR TITLE
[Ibis] Add methods-to-containers pass

### DIFF
--- a/include/circt/Dialect/Ibis/IbisPasses.h
+++ b/include/circt/Dialect/Ibis/IbisPasses.h
@@ -36,6 +36,7 @@ std::unique_ptr<mlir::Pass> createInlineSBlocksPass();
 std::unique_ptr<mlir::Pass> createConvertCFToHandshakePass();
 std::unique_ptr<mlir::Pass> createPrepareSchedulingPass();
 std::unique_ptr<mlir::Pass> createConvertHandshakeToDCPass();
+std::unique_ptr<mlir::Pass> createConvertMethodsToContainersPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Ibis/IbisPasses.td
+++ b/include/circt/Dialect/Ibis/IbisPasses.td
@@ -206,4 +206,9 @@ def IbisPrepareScheduling : Pass<"ibis-prepare-scheduling", "ibis::IsolatedStati
   let dependentDialects = ["circt::pipeline::PipelineDialect"];
 }
 
+def IbisConvertMethodsToContainers : Pass<"ibis-convert-methods-to-containers", "ibis::ClassOp"> {
+  let summary = "Converts `ibis.method.df` to `ibis.container`s";
+  let constructor = "circt::ibis::createConvertMethodsToContainersPass()";
+}
+
 #endif // CIRCT_DIALECT_IBIS_PASSES_TD

--- a/lib/Dialect/Ibis/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Ibis/Transforms/CMakeLists.txt
@@ -12,6 +12,7 @@ add_circt_dialect_library(CIRCTIbisTransforms
   IbisPassPipelines.cpp
   IbisPrepareScheduling.cpp
   IbisConvertHandshakeToDC.cpp
+  IbisMethodsToContainers.cpp
 
   DEPENDS
   CIRCTIbisTransformsIncGen

--- a/lib/Dialect/Ibis/Transforms/IbisMethodsToContainers.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisMethodsToContainers.cpp
@@ -1,0 +1,91 @@
+//===- IbisMethodsToContainers.cpp - Implementation of containerizing -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+#include "circt/Dialect/Ibis/IbisDialect.h"
+#include "circt/Dialect/Ibis/IbisOps.h"
+#include "circt/Dialect/Ibis/IbisPasses.h"
+#include "circt/Dialect/Ibis/IbisTypes.h"
+
+#include "circt/Support/Namespace.h"
+#include "circt/Support/SymCache.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace circt;
+using namespace ibis;
+
+namespace {
+
+struct DataflowMethodOpConversion
+    : public OpConversionPattern<DataflowMethodOp> {
+  using OpConversionPattern<DataflowMethodOp>::OpConversionPattern;
+  using OpAdaptor = typename DataflowMethodOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(DataflowMethodOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Replace the class by a container of the same name.
+    auto newContainer =
+        rewriter.create<ContainerOp>(op.getLoc(), op.getNameAttr());
+    rewriter.setInsertionPointToStart(newContainer.getBodyBlock());
+
+    // Create mandatory %this
+    // TODO @mortbopet: this will most likely already be present at the
+    // method.df level soon...
+    rewriter.create<ThisOp>(op.getLoc(), newContainer.getSymNameAttr());
+
+    // Create in- and output ports.
+    llvm::SmallVector<Value> argValues;
+    for (auto [arg, name] : llvm::zip_equal(
+             op.getArguments(), op.getArgNames().getAsRange<StringAttr>())) {
+      auto port =
+          rewriter.create<InputPortOp>(arg.getLoc(), name, arg.getType());
+      argValues.push_back(rewriter.create<PortReadOp>(arg.getLoc(), port));
+    }
+
+    ReturnOp returnOp = cast<ReturnOp>(op.getBodyBlock()->getTerminator());
+    for (auto [idx, resType] : llvm::enumerate(op.getResultTypes())) {
+      auto port = rewriter.create<OutputPortOp>(
+          op.getLoc(), rewriter.getStringAttr("out" + std::to_string(idx)),
+          resType);
+      rewriter.create<PortWriteOp>(op.getLoc(), port, returnOp.getOperand(idx));
+    }
+
+    rewriter.mergeBlocks(op.getBodyBlock(), newContainer.getBodyBlock(),
+                         argValues);
+    rewriter.eraseOp(op);
+    rewriter.eraseOp(returnOp);
+    return success();
+  }
+};
+
+struct MethodsToContainersPass
+    : public IbisConvertMethodsToContainersBase<MethodsToContainersPass> {
+  void runOnOperation() override;
+};
+} // anonymous namespace
+
+void MethodsToContainersPass::runOnOperation() {
+  auto *context = &getContext();
+  ConversionTarget target(*context);
+  target.addLegalDialect<IbisDialect>();
+  target.addIllegalOp<DataflowMethodOp>();
+  target.addIllegalOp<ReturnOp>();
+  RewritePatternSet patterns(context);
+
+  // Setup a namespace to ensure that the new container names are unique.
+  patterns.insert<DataflowMethodOpConversion>(context);
+  if (failed(
+          applyPartialConversion(getOperation(), target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<Pass> circt::ibis::createConvertMethodsToContainersPass() {
+  return std::make_unique<MethodsToContainersPass>();
+}

--- a/lib/Dialect/Ibis/Transforms/IbisMethodsToContainers.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisMethodsToContainers.cpp
@@ -79,7 +79,6 @@ void MethodsToContainersPass::runOnOperation() {
   target.addIllegalOp<ReturnOp>();
   RewritePatternSet patterns(context);
 
-  // Setup a namespace to ensure that the new container names are unique.
   patterns.insert<DataflowMethodOpConversion>(context);
   if (failed(
           applyPartialConversion(getOperation(), target, std::move(patterns))))

--- a/test/Dialect/Ibis/Transforms/methods_to_containers.mlir
+++ b/test/Dialect/Ibis/Transforms/methods_to_containers.mlir
@@ -1,0 +1,35 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(ibis.class(ibis-convert-methods-to-containers))' %s | FileCheck %s
+
+// CHECK-LABEL:   ibis.class @ToContainers {
+// CHECK:           %[[VAL_0:.*]] = ibis.this @ToContainers
+// CHECK:           ibis.container @foo {
+// CHECK:             %[[VAL_1:.*]] = ibis.this @foo
+// CHECK:             %[[VAL_2:.*]] = ibis.port.input @arg0 : !dc.value<i32>
+// CHECK:             %[[VAL_3:.*]] = ibis.port.read %[[VAL_2]] : !ibis.portref<in !dc.value<i32>>
+// CHECK:             %[[VAL_4:.*]] = ibis.port.output @out0 : !dc.value<i32>
+// CHECK:             ibis.port.write %[[VAL_4]], %[[VAL_5:.*]] : !ibis.portref<out !dc.value<i32>>
+// CHECK:             %[[VAL_6:.*]], %[[VAL_7:.*]] = dc.unpack %[[VAL_3]] : !dc.value<i32>
+// CHECK:             %[[VAL_8:.*]]:2 = dc.fork [2] %[[VAL_6]]
+// CHECK:             %[[VAL_9:.*]] = dc.pack %[[VAL_8]]#0, %[[VAL_7]] : i32
+// CHECK:             %[[VAL_10:.*]] = dc.pack %[[VAL_8]]#1, %[[VAL_7]] : i32
+// CHECK:             %[[VAL_5]] = ibis.sblock.dc (%[[VAL_11:.*]] : !dc.value<i32> = %[[VAL_9]], %[[VAL_12:.*]] : !dc.value<i32> = %[[VAL_10]]) -> !dc.value<i32> {
+// CHECK:               %[[VAL_13:.*]] = arith.addi %[[VAL_11]], %[[VAL_12]] : i32
+// CHECK:               ibis.sblock.return %[[VAL_13]] : i32
+// CHECK:             }
+// CHECK:           }
+// CHECK:         }
+
+ibis.class @ToContainers {
+  %this = ibis.this @ToContainers 
+  ibis.method.df @foo(%arg0: !dc.value<i32>) -> !dc.value<i32> {
+    %token, %output = dc.unpack %arg0 : !dc.value<i32>
+    %0:2 = dc.fork [2] %token 
+    %1 = dc.pack %0#0, %output : i32
+    %2 = dc.pack %0#1, %output : i32
+    %3 = ibis.sblock.dc (%arg1 : !dc.value<i32> = %1, %arg2 : !dc.value<i32> = %2) -> !dc.value<i32> {
+      %4 = arith.addi %arg1, %arg2 : i32
+      ibis.sblock.return %4 : i32
+    }
+    ibis.return %3 : !dc.value<i32>
+  }
+}


### PR DESCRIPTION
Dataflow methods can be converted to containers - which allows us to leverage all of the existing infrastructure for e.g. tunneling and outlining.
