### PR TITLE
[Comb] Disallow canonicalization across MLIR blocks

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -37,7 +37,7 @@ static bool hasOperandsOutsideOfBlock(Operation *op) {
 }
 
 #define bailCanonIfOutsideBlockOperands(op)                                    \
-  if (hasOperandsOutsideOfBlock(&*op))                                         \
+  if (hasOperandsOutsideOfBlock(&*(op)))                                       \
     return failure();
 
 /// Create a new instance of a generic operation that only has value operands,
@@ -90,7 +90,7 @@ static void replaceOpAndCopyName(PatternRewriter &rewriter, Operation *op,
 /// this function propagates the name to the new value.
 template <typename OpTy, typename... Args>
 static OpTy replaceOpWithNewOpAndCopyName(PatternRewriter &rewriter,
-                                          Operation *op, Args &&...args) {
+                                          Operation *op, Args &&... args) {
   auto name = op->getAttrOfType<StringAttr>("sv.namehint");
   auto newOp =
       rewriter.replaceOpWithNewOp<OpTy>(op, std::forward<Args>(args)...);

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -86,7 +86,7 @@ static void replaceOpAndCopyName(PatternRewriter &rewriter, Operation *op,
 /// this function propagates the name to the new value.
 template <typename OpTy, typename... Args>
 static OpTy replaceOpWithNewOpAndCopyName(PatternRewriter &rewriter,
-                                          Operation *op, Args &&... args) {
+                                          Operation *op, Args &&...args) {
   auto name = op->getAttrOfType<StringAttr>("sv.namehint");
   auto newOp =
       rewriter.replaceOpWithNewOp<OpTy>(op, std::forward<Args>(args)...);

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -257,6 +257,9 @@ static bool narrowOperationWidth(OpTy op, bool narrowTrailingBits,
 //===----------------------------------------------------------------------===//
 
 OpFoldResult ReplicateOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   // Replicate one time -> noop.
   if (getType().cast<IntegerType>().getWidth() ==
       getInput().getType().getIntOrFloatBitWidth())
@@ -284,6 +287,9 @@ OpFoldResult ReplicateOp::fold(FoldAdaptor adaptor) {
 }
 
 OpFoldResult ParityOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   // Constant fold.
   if (auto input = adaptor.getInput().dyn_cast_or_null<IntegerAttr>())
     return getIntAttr(APInt(1, input.getValue().popcount() & 1), getContext());
@@ -310,6 +316,9 @@ static Attribute constFoldBinaryOp(ArrayRef<Attribute> operands,
 }
 
 OpFoldResult ShlOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   if (auto rhs = adaptor.getRhs().dyn_cast_or_null<IntegerAttr>()) {
     unsigned shift = rhs.getValue().getZExtValue();
     unsigned width = getType().getIntOrFloatBitWidth();
@@ -350,6 +359,9 @@ LogicalResult ShlOp::canonicalize(ShlOp op, PatternRewriter &rewriter) {
 }
 
 OpFoldResult ShrUOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   if (auto rhs = adaptor.getRhs().dyn_cast_or_null<IntegerAttr>()) {
     unsigned shift = rhs.getValue().getZExtValue();
     if (shift == 0)
@@ -390,6 +402,9 @@ LogicalResult ShrUOp::canonicalize(ShrUOp op, PatternRewriter &rewriter) {
 }
 
 OpFoldResult ShrSOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   if (auto rhs = adaptor.getRhs().dyn_cast_or_null<IntegerAttr>()) {
     if (rhs.getValue().getZExtValue() == 0)
       return getOperand(0);
@@ -430,6 +445,9 @@ LogicalResult ShrSOp::canonicalize(ShrSOp op, PatternRewriter &rewriter) {
 //===----------------------------------------------------------------------===//
 
 OpFoldResult ExtractOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   // If we are extracting the entire input, then return it.
   if (getInput().getType() == getType())
     return getInput();
@@ -771,6 +789,9 @@ static bool canonicalizeLogicalCstWithConcat(Operation *logicalOp,
 }
 
 OpFoldResult AndOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   APInt value = APInt::getAllOnes(getType().cast<IntegerType>().getWidth());
 
   auto inputs = adaptor.getInputs();
@@ -1004,6 +1025,9 @@ LogicalResult AndOp::canonicalize(AndOp op, PatternRewriter &rewriter) {
 }
 
 OpFoldResult OrOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   auto value = APInt::getZero(getType().cast<IntegerType>().getWidth());
   auto inputs = adaptor.getInputs();
   // or(x, 10, 01) -> 11
@@ -1245,6 +1269,9 @@ LogicalResult OrOp::canonicalize(OrOp op, PatternRewriter &rewriter) {
 }
 
 OpFoldResult XorOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   auto size = getInputs().size();
   auto inputs = adaptor.getInputs();
 
@@ -1375,6 +1402,9 @@ LogicalResult XorOp::canonicalize(XorOp op, PatternRewriter &rewriter) {
 }
 
 OpFoldResult SubOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   // sub(x - x) -> 0
   if (getRhs() == getLhs())
     return getIntAttr(
@@ -1425,6 +1455,9 @@ LogicalResult SubOp::canonicalize(SubOp op, PatternRewriter &rewriter) {
 }
 
 OpFoldResult AddOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   auto size = getInputs().size();
 
   // add(x) -> x -- noop
@@ -1539,6 +1572,9 @@ LogicalResult AddOp::canonicalize(AddOp op, PatternRewriter &rewriter) {
 }
 
 OpFoldResult MulOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   auto size = getInputs().size();
   auto inputs = adaptor.getInputs();
 
@@ -1630,10 +1666,16 @@ static OpFoldResult foldDiv(Op op, ArrayRef<Attribute> constants) {
 }
 
 OpFoldResult DivUOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   return foldDiv<DivUOp, /*isSigned=*/false>(*this, adaptor.getOperands());
 }
 
 OpFoldResult DivSOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   return foldDiv<DivSOp, /*isSigned=*/true>(*this, adaptor.getOperands());
 }
 
@@ -1661,10 +1703,16 @@ static OpFoldResult foldMod(Op op, ArrayRef<Attribute> constants) {
 }
 
 OpFoldResult ModUOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   return foldMod<ModUOp, /*isSigned=*/false>(*this, adaptor.getOperands());
 }
 
 OpFoldResult ModSOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   return foldMod<ModSOp, /*isSigned=*/true>(*this, adaptor.getOperands());
 }
 //===----------------------------------------------------------------------===//
@@ -1673,6 +1721,9 @@ OpFoldResult ModSOp::fold(FoldAdaptor adaptor) {
 
 // Constant folding
 OpFoldResult ConcatOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   if (getNumOperands() == 1)
     return getOperand(0);
 
@@ -1863,6 +1914,9 @@ LogicalResult ConcatOp::canonicalize(ConcatOp op, PatternRewriter &rewriter) {
 //===----------------------------------------------------------------------===//
 
 OpFoldResult MuxOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   // mux (c, b, b) -> b
   if (getTrueValue() == getFalseValue())
     return getTrueValue();
@@ -2687,6 +2741,9 @@ static bool applyCmpPredicateToEqualOperands(ICmpPredicate predicate) {
 }
 
 OpFoldResult ICmpOp::fold(FoldAdaptor adaptor) {
+  if (hasOperandsOutsideOfBlock(getOperation()))
+    return {};
+
   // gt a, a -> false
   // gte a, a -> true
   if (getLhs() == getRhs()) {

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -90,7 +90,7 @@ static void replaceOpAndCopyName(PatternRewriter &rewriter, Operation *op,
 /// this function propagates the name to the new value.
 template <typename OpTy, typename... Args>
 static OpTy replaceOpWithNewOpAndCopyName(PatternRewriter &rewriter,
-                                          Operation *op, Args &&... args) {
+                                          Operation *op, Args &&...args) {
   auto name = op->getAttrOfType<StringAttr>("sv.namehint");
   auto newOp =
       rewriter.replaceOpWithNewOp<OpTy>(op, std::forward<Args>(args)...);

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -2305,6 +2305,8 @@ struct MuxRewriter : public mlir::OpRewritePattern<MuxOp> {
 
 LogicalResult MuxRewriter::matchAndRewrite(MuxOp op,
                                            PatternRewriter &rewriter) const {
+  bailCanonIfOutsideBlockOperands(op);
+
   // If the op has a SV attribute, don't optimize it.
   if (hasSVAttributes(op))
     return failure();
@@ -2595,6 +2597,8 @@ struct ArrayRewriter : public mlir::OpRewritePattern<hw::ArrayCreateOp> {
 
   LogicalResult matchAndRewrite(hw::ArrayCreateOp op,
                                 PatternRewriter &rewriter) const override {
+    bailCanonIfOutsideBlockOperands(op);
+
     if (foldArrayOfMuxes(op, rewriter))
       return success();
     return failure();

--- a/test/Dialect/Calyx/remove-comb-groups.mlir
+++ b/test/Dialect/Calyx/remove-comb-groups.mlir
@@ -12,7 +12,8 @@ calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%don
 // CHECK:   calyx.assign %eq_reg.write_en = %true : i1
 // CHECK:   calyx.assign %eq.left = %true : i1
 // CHECK:   calyx.assign %eq.right = %true : i1
-// CHECK:   calyx.group_done %eq_reg.done ? %true : i1
+// CHECK:    %0 = comb.and %eq_reg.done : i1
+// CHECK:   calyx.group_done %0 ? %true : i1
     calyx.comb_group @Cond {
       calyx.assign %eq.left =  %c1_1 : i1
       calyx.assign %eq.right = %c1_1 : i1
@@ -59,7 +60,8 @@ calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%don
 // CHECK:   calyx.assign %eq_reg.write_en = %true : i1
 // CHECK:   calyx.assign %eq.left = %true : i1
 // CHECK:   calyx.assign %eq.right = %true : i1
-// CHECK:   calyx.group_done %eq_reg.done ? %true : i1
+// CHECK:   %0 = comb.and %eq_reg.done : i1
+// CHECK:   calyx.group_done %0 ? %true : i1
 // CHECK: }
     calyx.comb_group @Cond1 {
       calyx.assign %eq.left =  %c1_1 : i1
@@ -72,7 +74,8 @@ calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%don
 // CHECK:   calyx.assign %eq_reg.write_en = %true : i1
 // CHECK:   calyx.assign %eq.left = %true : i1
 // CHECK:   calyx.assign %eq.right = %true : i1
-// CHECK:   calyx.group_done %eq_reg.done ? %true : i1
+// CHECK:   %0 = comb.and %eq_reg.done : i1
+// CHECK:   calyx.group_done %0 ? %true : i1
 // CHECK: }
     calyx.comb_group @Cond2 {
       calyx.assign %eq.left =  %c1_1 : i1

--- a/test/Dialect/Seq/hw-memsim.mlir
+++ b/test/Dialect/Seq/hw-memsim.mlir
@@ -107,7 +107,8 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(in %ro_addr_0: i4
 //CHECK-NEXT:    }
 //CHECK-NEXT:  %true_1 = hw.constant true
 //CHECK-NEXT:  sv.always posedge %wo_clock_0 {
-//CHECK-NEXT:    sv.if %wo_en_0 {
+//CHECK-NEXT:    %[[WO_EN:.+]] = comb.and %wo_en_0, %true_1 : i1
+//CHECK-NEXT:    sv.if %[[WO_EN]] {
 //CHECK-NEXT:      %[[wslot:.+]] = sv.array_index_inout %Memory[%wo_addr_0]
 //CHECK-NEXT:      %[[c0_i32:.+]] = hw.constant 0 : i32
 //CHECK-NEXT:      sv.passign %[[wslot]], %wo_data_0


### PR DESCRIPTION
This is probably the most conservative implementation of this, but should suffice for the current requirements to this change. For any comb operation that has a canonicalizer, guard canonicalization on whether any operands are define outside of the current block. This still allows for (constant) folding, which (to me) still should be a safe thing to do across blocks - if that was not the case, then that would be a strange abstraction (i'd expect an op to be `IsolatedFromAbove` if it wants to prevent constant folding).