### PR TITLE
[FIRRTL] Remove RecursiveMemoryEffects and RecursivelySpeculatable from When op, add canonicalizers

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -181,8 +181,7 @@ def CoverOp : VerifOp<"cover"> {
   let summary = "Cover Verification Statement";
 }
 
-def WhenOp : FIRRTLOp<"when", [SingleBlock, NoTerminator, NoRegionArguments,
-                               RecursiveMemoryEffects, RecursivelySpeculatable]> {
+def WhenOp : FIRRTLOp<"when", [SingleBlock, NoTerminator, NoRegionArguments]> {
   let summary = "When Statement";
   let description = [{
     The "firrtl.when" operation represents a conditional.  Connections within
@@ -195,6 +194,7 @@ def WhenOp : FIRRTLOp<"when", [SingleBlock, NoTerminator, NoRegionArguments,
   let regions = (region SizedRegion<1>:$thenRegion, AnyRegion:$elseRegion);
 
   let skipDefaultBuilders = 1;
+  let hasCanonicalizeMethod = 1;
   let builders = [
     OpBuilder<(ins "Value":$condition, "bool":$withElseRegion,
                       CArg<"std::function<void()>", "{}">:$thenCtor,

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1883,6 +1883,49 @@ LogicalResult AttachOp::canonicalize(AttachOp op, PatternRewriter &rewriter) {
   return failure();
 }
 
+/// Replaces the given op with the contents of the given single-block region.
+static void replaceOpWithRegion(PatternRewriter &rewriter, Operation *op,
+                                Region &region) {
+  assert(llvm::hasSingleElement(region) && "expected single-region block");
+  Block *fromBlock = &region.front();
+  // Merge it in above the specified operation.
+  op->getBlock()->getOperations().splice(Block::iterator(op),
+                                         fromBlock->getOperations());
+}
+
+LogicalResult WhenOp::canonicalize(WhenOp op, PatternRewriter &rewriter) {
+  if (auto constant = op.getCondition().getDefiningOp<firrtl::ConstantOp>()) {
+    if (constant.getValue().isAllOnes())
+      replaceOpWithRegion(rewriter, op, op.getThenRegion());
+    else if (!op.getElseRegion().empty())
+      replaceOpWithRegion(rewriter, op, op.getElseRegion());
+
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+
+  // Erase empty if-else block.
+  if (!op.getThenBlock().empty() && op.hasElseRegion() &&
+      op.getElseBlock().empty()) {
+    rewriter.eraseBlock(&op.getElseBlock());
+    return success();
+  }
+
+  // Erase empty whens.
+
+  // If there is stuff in the then block, leave this operation alone.
+  if (!op.getThenBlock().empty())
+    return failure();
+
+  // If not and there is no else, then this operation is just useless.
+  if (!op.hasElseRegion() || op.getElseBlock().empty()) {
+    rewriter.eraseOp(op);
+    return success();
+  }
+  return failure();
+}
+
 namespace {
 // Remove private nodes.  If they have an interesting names, move the name to
 // the source expression.

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3277,6 +3277,9 @@ firrtl.module @OMIRRemoval(in %source : !firrtl.uint<1>) {
 
 // CHECK-LABEL: firrtl.module @Whens
 firrtl.module @Whens(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
+  %true = firrtl.constant 1: !firrtl.uint<1>
+  %false = firrtl.constant 0: !firrtl.uint<1>
+
   // Erase empty whens.
   // CHECK-NOT: when %a
   firrtl.when %a : !firrtl.uint<1> {
@@ -3285,12 +3288,24 @@ firrtl.module @Whens(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, in %reset
   } else {
   }
   // Erase an empty else block.
-  // CHECK-NEXT: firrtl.when %reset : !firrtl.uint<1> {
+  // CHECK:      firrtl.when %reset : !firrtl.uint<1> {
   // CHECK-NEXT:   firrtl.printf %clock, %reset, "foo!"  : !firrtl.clock, !firrtl.uint<1>
   // CHECK-NEXT: }
   firrtl.when %reset : !firrtl.uint<1> {
     firrtl.printf %clock, %reset, "foo!"  : !firrtl.clock, !firrtl.uint<1>
   } else {
+  }
+
+  // CHECK-NEXT:  firrtl.printf %clock, %reset, "bar!"  : !firrtl.clock, !firrtl.uint<1>
+  firrtl.when %false : !firrtl.uint<1> {
+  } else {
+    firrtl.printf %clock, %reset, "bar!"  : !firrtl.clock, !firrtl.uint<1>
+  }
+
+  // CHECK-NOT:  firrtl.when
+  firrtl.when %true : !firrtl.uint<1> {
+  } else {
+    firrtl.printf %clock, %reset, "baz!"  : !firrtl.clock, !firrtl.uint<1>
   }
 }
 

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3275,4 +3275,23 @@ firrtl.module @OMIRRemoval(in %source : !firrtl.uint<1>) {
   firrtl.strictconnect %d, %tmp_3 : !firrtl.uint<1>
 }
 
+// CHECK-LABEL: firrtl.module @Whens
+firrtl.module @Whens(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
+  // Erase empty whens.
+  // CHECK-NOT: when %a
+  firrtl.when %a : !firrtl.uint<1> {
+  }
+  firrtl.when %a : !firrtl.uint<1> {
+  } else {
+  }
+  // Erase an empty else block.
+  // CHECK-NEXT: firrtl.when %reset : !firrtl.uint<1> {
+  // CHECK-NEXT:   firrtl.printf %clock, %reset, "foo!"  : !firrtl.clock, !firrtl.uint<1>
+  // CHECK-NEXT: }
+  firrtl.when %reset : !firrtl.uint<1> {
+    firrtl.printf %clock, %reset, "foo!"  : !firrtl.clock, !firrtl.uint<1>
+  } else {
+  }
+}
+
 }


### PR DESCRIPTION
RecursiveMemoryEffects and RecursivelySpeculatable traits provides automatically derivation of side-effects of operations but these effects are computed by recursive IR walk. This is problematic for firrtl.when since when operations are often deeply nested, which prevents us from running canonicalizers before ExpandWhens. This PR just removes these traits and add caonincalizers for whens manually.