### PR TITLE
[OM] Add location info to EvaluatorValue

### DIFF
--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -127,6 +127,10 @@ omEvaluatorObjectGetFieldNames(OMEvaluatorValue object);
 MLIR_CAPI_EXPORTED MlirContext
 omEvaluatorValueGetContext(OMEvaluatorValue evaluatorValue);
 
+// Get Location from an EvaluatorValue.
+MLIR_CAPI_EXPORTED MlirLocation
+omEvaluatorValueGetLoc(OMEvaluatorValue evaluatorValue);
+
 // Query if the EvaluatorValue is null.
 MLIR_CAPI_EXPORTED bool omEvaluatorValueIsNull(OMEvaluatorValue evaluatorValue);
 

--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -17,6 +17,7 @@
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/Location.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Support/LogicalResult.h"
@@ -46,7 +47,8 @@ using ObjectFields = SmallDenseMap<StringAttr, EvaluatorValuePtr>;
 struct EvaluatorValue : std::enable_shared_from_this<EvaluatorValue> {
   // Implement LLVM RTTI.
   enum class Kind { Attr, Object, List, Tuple, Map, Reference };
-  EvaluatorValue(MLIRContext *ctx, Kind kind) : kind(kind), ctx(ctx) {}
+  EvaluatorValue(MLIRContext *ctx, Kind kind, Location loc)
+      : kind(kind), ctx(ctx), loc(loc) {}
   Kind getKind() const { return kind; }
   MLIRContext *getContext() const { return ctx; }
 
@@ -63,9 +65,15 @@ struct EvaluatorValue : std::enable_shared_from_this<EvaluatorValue> {
   // Finalize the evaluator value. Strip intermidiate reference values.
   LogicalResult finalize();
 
+  // Return the Location associated with the Value.
+  Location getLoc() const { return loc; }
+  // Set the Location associated with the Value.
+  void setLoc(Location l) { loc = l; }
+
 private:
   const Kind kind;
   MLIRContext *ctx;
+  Location loc;
   bool fullyEvaluated = false;
   bool finalized = false;
 };
@@ -74,8 +82,8 @@ private:
 /// ReferenceValue is replaced with its element and erased at the end of
 /// evaluation.
 struct ReferenceValue : EvaluatorValue {
-  ReferenceValue(Type type)
-      : EvaluatorValue(type.getContext(), Kind::Reference), value(nullptr),
+  ReferenceValue(Type type, Location loc)
+      : EvaluatorValue(type.getContext(), Kind::Reference, loc), value(nullptr),
         type(type) {}
 
   // Implement LLVM RTTI.
@@ -114,10 +122,15 @@ private:
 /// Values which can be directly representable by MLIR attributes.
 struct AttributeValue : EvaluatorValue {
   AttributeValue(Attribute attr)
-      : EvaluatorValue(attr.getContext(), Kind::Attr), attr(attr) {
+      : EvaluatorValue(attr.getContext(), Kind::Attr,
+                       mlir::UnknownLoc::get(attr.getContext())),
+        attr(attr) {
     markFullyEvaluated();
   }
-
+  AttributeValue(Attribute attr, Location loc)
+      : EvaluatorValue(attr.getContext(), Kind::Attr, loc), attr(attr) {
+    markFullyEvaluated();
+  }
   Attribute getAttr() const { return attr; }
   template <typename AttrTy>
   AttrTy getAs() const {
@@ -151,8 +164,9 @@ static inline LogicalResult finalizeEvaluatorValue(EvaluatorValuePtr &value) {
 
 /// A List which contains variadic length of elements with the same type.
 struct ListValue : EvaluatorValue {
-  ListValue(om::ListType type, SmallVector<EvaluatorValuePtr> elements)
-      : EvaluatorValue(type.getContext(), Kind::List), type(type),
+  ListValue(om::ListType type, SmallVector<EvaluatorValuePtr> elements,
+            Location loc)
+      : EvaluatorValue(type.getContext(), Kind::List, loc), type(type),
         elements(std::move(elements)) {
     markFullyEvaluated();
   }
@@ -166,8 +180,8 @@ struct ListValue : EvaluatorValue {
   LogicalResult finalizeImpl();
 
   // Partially evaluated value.
-  ListValue(om::ListType type)
-      : EvaluatorValue(type.getContext(), Kind::List), type(type) {}
+  ListValue(om::ListType type, Location loc)
+      : EvaluatorValue(type.getContext(), Kind::List, loc), type(type) {}
 
   const auto &getElements() const { return elements; }
 
@@ -186,15 +200,16 @@ private:
 
 /// A Map value.
 struct MapValue : EvaluatorValue {
-  MapValue(om::MapType type, DenseMap<Attribute, EvaluatorValuePtr> elements)
-      : EvaluatorValue(type.getContext(), Kind::Map), type(type),
+  MapValue(om::MapType type, DenseMap<Attribute, EvaluatorValuePtr> elements,
+           Location loc)
+      : EvaluatorValue(type.getContext(), Kind::Map, loc), type(type),
         elements(std::move(elements)) {
     markFullyEvaluated();
   }
 
   // Partially evaluated value.
-  MapValue(om::MapType type)
-      : EvaluatorValue(type.getContext(), Kind::Map), type(type) {}
+  MapValue(om::MapType type, Location loc)
+      : EvaluatorValue(type.getContext(), Kind::Map, loc), type(type) {}
 
   const auto &getElements() const { return elements; }
   void setElements(DenseMap<Attribute, EvaluatorValuePtr> newElements) {
@@ -223,15 +238,15 @@ private:
 
 /// A composite Object, which has a type and fields.
 struct ObjectValue : EvaluatorValue {
-  ObjectValue(om::ClassOp cls, ObjectFields fields)
-      : EvaluatorValue(cls.getContext(), Kind::Object), cls(cls),
+  ObjectValue(om::ClassOp cls, ObjectFields fields, Location loc)
+      : EvaluatorValue(cls.getContext(), Kind::Object, loc), cls(cls),
         fields(std::move(fields)) {
     markFullyEvaluated();
   }
 
   // Partially evaluated value.
-  ObjectValue(om::ClassOp cls)
-      : EvaluatorValue(cls.getContext(), Kind::Object), cls(cls) {}
+  ObjectValue(om::ClassOp cls, Location loc)
+      : EvaluatorValue(cls.getContext(), Kind::Object, loc), cls(cls) {}
 
   om::ClassOp getClassOp() const { return cls; }
   const auto &getFields() const { return fields; }
@@ -275,15 +290,15 @@ private:
 /// Tuple values.
 struct TupleValue : EvaluatorValue {
   using TupleElements = llvm::SmallVector<EvaluatorValuePtr>;
-  TupleValue(TupleType type, TupleElements tupleElements)
-      : EvaluatorValue(type.getContext(), Kind::Tuple), type(type),
+  TupleValue(TupleType type, TupleElements tupleElements, Location loc)
+      : EvaluatorValue(type.getContext(), Kind::Tuple, loc), type(type),
         elements(std::move(tupleElements)) {
     markFullyEvaluated();
   }
 
   // Partially evaluated value.
-  TupleValue(TupleType type)
-      : EvaluatorValue(type.getContext(), Kind::Tuple), type(type) {}
+  TupleValue(TupleType type, Location loc)
+      : EvaluatorValue(type.getContext(), Kind::Tuple, loc), type(type) {}
 
   void setElements(TupleElements newElements) {
     elements = std::move(newElements);
@@ -334,7 +349,8 @@ struct Evaluator {
   /// Get the Module this Evaluator is built from.
   mlir::ModuleOp getModule();
 
-  FailureOr<evaluator::EvaluatorValuePtr> getPartiallyEvaluatedValue(Type type);
+  FailureOr<evaluator::EvaluatorValuePtr>
+  getPartiallyEvaluatedValue(Type type, Location loc);
 
   using ActualParameters =
       SmallVectorImpl<std::shared_ptr<evaluator::EvaluatorValue>> *;
@@ -351,42 +367,48 @@ private:
     return val && val->isFullyEvaluated();
   }
 
-  FailureOr<EvaluatorValuePtr> getOrCreateValue(Value value,
-                                                ActualParameters actualParams);
+  FailureOr<EvaluatorValuePtr>
+  getOrCreateValue(Value value, ActualParameters actualParams, Location loc);
   FailureOr<EvaluatorValuePtr>
   allocateObjectInstance(StringAttr clasName, ActualParameters actualParams);
 
   /// Evaluate a Value in a Class body according to the small expression grammar
   /// described in the rationale document. The actual parameters are the values
   /// supplied at the current instantiation of the Class being evaluated.
-  FailureOr<EvaluatorValuePtr> evaluateValue(Value value,
-                                             ActualParameters actualParams);
+  FailureOr<EvaluatorValuePtr>
+  evaluateValue(Value value, ActualParameters actualParams, Location loc);
 
   /// Evaluator dispatch functions for the small expression grammar.
   FailureOr<EvaluatorValuePtr> evaluateParameter(BlockArgument formalParam,
-                                                 ActualParameters actualParams);
+                                                 ActualParameters actualParams,
+                                                 Location loc);
 
-  FailureOr<EvaluatorValuePtr> evaluateConstant(ConstantOp op,
-                                                ActualParameters actualParams);
+  FailureOr<EvaluatorValuePtr>
+  evaluateConstant(ConstantOp op, ActualParameters actualParams, Location loc);
   /// Instantiate an Object with its class name and actual parameters.
   FailureOr<EvaluatorValuePtr>
   evaluateObjectInstance(StringAttr className, ActualParameters actualParams,
-                         ObjectKey instanceObjectKey = {});
+                         Location loc, ObjectKey instanceKey = {});
   FailureOr<EvaluatorValuePtr>
   evaluateObjectInstance(ObjectOp op, ActualParameters actualParams);
   FailureOr<EvaluatorValuePtr>
-  evaluateObjectField(ObjectFieldOp op, ActualParameters actualParams);
+  evaluateObjectField(ObjectFieldOp op, ActualParameters actualParams,
+                      Location loc);
+  FailureOr<EvaluatorValuePtr> evaluateListCreate(ListCreateOp op,
+                                                  ActualParameters actualParams,
+                                                  Location loc);
   FailureOr<EvaluatorValuePtr>
-  evaluateListCreate(ListCreateOp op, ActualParameters actualParams);
+  evaluateTupleCreate(TupleCreateOp op, ActualParameters actualParams,
+                      Location loc);
   FailureOr<EvaluatorValuePtr>
-  evaluateTupleCreate(TupleCreateOp op, ActualParameters actualParams);
-  FailureOr<EvaluatorValuePtr> evaluateTupleGet(TupleGetOp op,
-                                                ActualParameters actualParams);
+  evaluateTupleGet(TupleGetOp op, ActualParameters actualParams, Location loc);
   FailureOr<evaluator::EvaluatorValuePtr>
-  evaluateMapCreate(MapCreateOp op, ActualParameters actualParams);
+  evaluateMapCreate(MapCreateOp op, ActualParameters actualParams,
+                    Location loc);
 
   FailureOr<ActualParameters>
-  createParametersFromOperands(ValueRange range, ActualParameters actualParams);
+  createParametersFromOperands(ValueRange range, ActualParameters actualParams,
+                               Location loc);
 
   /// The symbol table for the IR module the Evaluator was constructed with.
   /// Used to look up class definitions.

--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -69,6 +69,11 @@ struct EvaluatorValue : std::enable_shared_from_this<EvaluatorValue> {
   Location getLoc() const { return loc; }
   // Set the Location associated with the Value.
   void setLoc(Location l) { loc = l; }
+  // Set the Location, if it is unknown.
+  void setLocIfUnknown(Location l) {
+    if (isa<UnknownLoc>(loc))
+      loc = l;
+  }
 
 private:
   const Kind kind;

--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -127,11 +127,7 @@ private:
 /// Values which can be directly representable by MLIR attributes.
 struct AttributeValue : EvaluatorValue {
   AttributeValue(Attribute attr)
-      : EvaluatorValue(attr.getContext(), Kind::Attr,
-                       mlir::UnknownLoc::get(attr.getContext())),
-        attr(attr) {
-    markFullyEvaluated();
-  }
+      : AttributeValue(attr, mlir::UnknownLoc::get(attr.getContext())) {}
   AttributeValue(Attribute attr, Location loc)
       : EvaluatorValue(attr.getContext(), Kind::Attr, loc), attr(attr) {
     markFullyEvaluated();

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -162,7 +162,6 @@ for (name, field) in obj:
   # CHECK: name: reference, field: ('Root', 'x'), loc: loc("-":37:7)
   loc = obj.get_field_loc(name)
   print(f"name: {name}, field: {field}, loc: {loc}")
-  
 
 # CHECK: ['X', 'Y']
 print(obj.list)

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -120,18 +120,30 @@ assert isinstance(obj.type, om.ClassType)
 # CHECK: Test
 print(obj.type.name)
 
+# This is the location of the `om.class @Test`
+# CHECK: loc("-":27:5)
+print(obj.get_loc())
+
 # CHECK: 42
 print(obj.field)
+
+# location of the om.class.field @field
+# CHECK: loc("-":28:7)
+print(obj.get_field_loc("field"))
+
 # CHECK: 14
 print(obj.child.foo)
 # CHECK: ('Root', 'x')
 print(obj.reference)
-# CHECK: 14
 (fst, snd) = obj.tuple
+# CHECK: 14
 print(snd)
 
 # CHECK: path
 print(obj.path)
+# location of om.class.field @path, %path : !om.path
+# CHECK: loc("-":35:7)
+print(obj.get_field_loc("path"))
 
 try:
   print(obj.tuple[3])

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -120,10 +120,6 @@ assert isinstance(obj.type, om.ClassType)
 # CHECK: Test
 print(obj.type.name)
 
-# This is the location of the `om.class @Test`
-# CHECK: loc("-":27:5)
-print(obj.get_loc())
-
 # CHECK: 42
 print(obj.field)
 
@@ -133,11 +129,16 @@ print(obj.get_field_loc("field"))
 
 # CHECK: 14
 print(obj.child.foo)
+# CHECK: loc("-":64:7)
+print(obj.child.get_field_loc("foo"))
 # CHECK: ('Root', 'x')
 print(obj.reference)
 (fst, snd) = obj.tuple
 # CHECK: 14
 print(snd)
+
+# CHECK: loc("-":43:7)
+print(obj.get_field_loc("tuple"))
 
 # CHECK: path
 print(obj.path)
@@ -152,10 +153,16 @@ except IndexError as e:
   print(e)
 
 for (name, field) in obj:
+  # location from om.class.field @child, %0 : !om.class.type<@Child>
   # CHECK: name: child, field: <circt.dialects.om.Object object
-  # CHECK: name: field, field: 42
-  # CHECK: name: reference, field: ('Root', 'x')
-  print(f"name: {name}, field: {field}")
+  # CHECK-SAME: loc: loc("-":32:7)
+  #location from om.class.field @field, %param : !om.integer
+  # CHECK: name: field, field: 42, loc: loc("-":28:7)
+  # location from om.class.field @reference, %sym : !om.ref
+  # CHECK: name: reference, field: ('Root', 'x'), loc: loc("-":37:7)
+  loc = obj.get_field_loc(name)
+  print(f"name: {name}, field: {field}, loc: {loc}")
+  
 
 # CHECK: ['X', 'Y']
 print(obj.list)

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -156,10 +156,12 @@ for (name, field) in obj:
   # location from om.class.field @child, %0 : !om.class.type<@Child>
   # CHECK: name: child, field: <circt.dialects.om.Object object
   # CHECK-SAME: loc: loc("-":32:7)
-  #location from om.class.field @field, %param : !om.integer
-  # CHECK: name: field, field: 42, loc: loc("-":28:7)
+  # location from om.class.field @field, %param : !om.integer
+  # CHECK: name: field, field: 42
+  # CHECK-SAME: loc: loc("-":28:7)
   # location from om.class.field @reference, %sym : !om.ref
-  # CHECK: name: reference, field: ('Root', 'x'), loc: loc("-":37:7)
+  # CHECK: name: reference, field: ('Root', 'x')
+  # CHECK-SAME: loc: loc("-":37:7)
   loc = obj.get_field_loc(name)
   print(f"name: {name}, field: {field}, loc: {loc}")
 

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -133,6 +133,11 @@ class Object(BaseObject):
     field = super().__getattr__(name)
     return wrap_mlir_object(field)
 
+  def get_field_loc(self, name: str):
+    # Call the base method to get the loc.
+    loc = super().get_field_loc(name)
+    return loc
+
   # Support iterating over an Object by yielding its fields.
   def __iter__(self):
     for name in self.field_names:

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/OM/OMDialect.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Wrap.h"
+#include "mlir/IR/Location.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/Support/Casting.h"
 
@@ -189,6 +190,11 @@ OMEvaluatorValue omEvaluatorObjectGetField(OMEvaluatorValue object,
 // Get a context from an EvaluatorValue.
 MlirContext omEvaluatorValueGetContext(OMEvaluatorValue evaluatorValue) {
   return wrap(unwrap(evaluatorValue)->getContext());
+}
+
+// Get location from an EvaluatorValue.
+MlirLocation omEvaluatorValueGetLoc(OMEvaluatorValue evaluatorValue) {
+  return wrap(unwrap(evaluatorValue)->getLoc());
 }
 
 // Query if the EvaluatorValue is null.

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/OM/Evaluator/Evaluator.h"
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
+#include "mlir/IR/Location.h"
 #include "mlir/IR/SymbolTable.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
@@ -65,23 +66,23 @@ Type circt::om::evaluator::EvaluatorValue::getType() const {
 }
 
 FailureOr<evaluator::EvaluatorValuePtr>
-circt::om::Evaluator::getPartiallyEvaluatedValue(Type type) {
+circt::om::Evaluator::getPartiallyEvaluatedValue(Type type, Location loc) {
   using namespace circt::om::evaluator;
 
   return TypeSwitch<mlir::Type, FailureOr<evaluator::EvaluatorValuePtr>>(type)
       .Case([&](circt::om::MapType type) {
         evaluator::EvaluatorValuePtr result =
-            std::make_shared<evaluator::MapValue>(type);
+            std::make_shared<evaluator::MapValue>(type, loc);
         return success(result);
       })
       .Case([&](circt::om::ListType type) {
         evaluator::EvaluatorValuePtr result =
-            std::make_shared<evaluator::ListValue>(type);
+            std::make_shared<evaluator::ListValue>(type, loc);
         return success(result);
       })
       .Case([&](mlir::TupleType type) {
         evaluator::EvaluatorValuePtr result =
-            std::make_shared<evaluator::TupleValue>(type);
+            std::make_shared<evaluator::TupleValue>(type, loc);
         return success(result);
       })
 
@@ -94,16 +95,15 @@ circt::om::Evaluator::getPartiallyEvaluatedValue(Type type) {
                  << type.getClassName();
 
         evaluator::EvaluatorValuePtr result =
-            std::make_shared<evaluator::ObjectValue>(cls);
+            std::make_shared<evaluator::ObjectValue>(cls, loc);
 
         return success(result);
       })
       .Default([&](auto type) { return failure(); });
 }
 
-FailureOr<evaluator::EvaluatorValuePtr>
-circt::om::Evaluator::getOrCreateValue(Value value,
-                                       ActualParameters actualParams) {
+FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::getOrCreateValue(
+    Value value, ActualParameters actualParams, Location loc) {
   auto it = objects.find({value, actualParams});
   if (it != objects.end())
     return it->second;
@@ -118,22 +118,22 @@ circt::om::Evaluator::getOrCreateValue(Value value,
                               FailureOr<evaluator::EvaluatorValuePtr>>(
                        result.getDefiningOp())
                 .Case([&](ConstantOp op) {
-                  return evaluateConstant(op, actualParams);
+                  return evaluateConstant(op, actualParams, loc);
                 })
                 .Case<ObjectFieldOp>([&](auto op) {
                   // Create a reference value since the value pointed by object
                   // field op is not created yet.
                   evaluator::EvaluatorValuePtr result =
                       std::make_shared<evaluator::ReferenceValue>(
-                          value.getType());
+                          value.getType(), loc);
                   return success(result);
                 })
                 .Case<AnyCastOp>([&](AnyCastOp op) {
-                  return getOrCreateValue(op.getInput(), actualParams);
+                  return getOrCreateValue(op.getInput(), actualParams, loc);
                 })
                 .Case<ListCreateOp, TupleCreateOp, MapCreateOp, ObjectFieldOp,
                       ObjectOp>([&](auto op) {
-                  return getPartiallyEvaluatedValue(op.getType());
+                  return getPartiallyEvaluatedValue(op.getType(), loc);
                 })
                 .Default([&](Operation *op) {
                   auto error = op->emitError("unable to evaluate value");
@@ -151,6 +151,7 @@ circt::om::Evaluator::getOrCreateValue(Value value,
 FailureOr<evaluator::EvaluatorValuePtr>
 circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
                                              ActualParameters actualParams,
+                                             Location loc,
                                              ObjectKey instanceKey) {
   ClassOp cls = symbolTable.lookup<ClassOp>(className);
   if (!cls)
@@ -208,7 +209,7 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
   for (auto &op : cls.getOps())
     for (auto result : op.getResults()) {
       // Allocate the value.
-      if (failed(getOrCreateValue(result, actualParams)))
+      if (failed(getOrCreateValue(result, actualParams, loc)))
         return failure();
       // Add to the worklist.
       worklist.push({result, actualParams});
@@ -218,7 +219,7 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
     StringAttr name = field.getSymNameAttr();
     Value value = field.getValue();
     FailureOr<evaluator::EvaluatorValuePtr> result =
-        evaluateValue(value, actualParams);
+        evaluateValue(value, actualParams, field.getLoc());
     if (failed(result))
       return result;
 
@@ -228,7 +229,7 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
   // If the there is an instance, we must update the object value.
   if (instanceKey.first) {
     auto result =
-        getOrCreateValue(instanceKey.first, instanceKey.second).value();
+        getOrCreateValue(instanceKey.first, instanceKey.second, loc).value();
     auto *object = llvm::cast<evaluator::ObjectValue>(result.get());
     object->setFields(std::move(fields));
     return result;
@@ -236,7 +237,7 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
 
   // If it's external call, just allocate new ObjectValue.
   evaluator::EvaluatorValuePtr result =
-      std::make_shared<evaluator::ObjectValue>(cls, fields);
+      std::make_shared<evaluator::ObjectValue>(cls, fields, loc);
   return result;
 }
 
@@ -254,8 +255,9 @@ circt::om::Evaluator::instantiate(
 
   actualParametersBuffers.push_back(std::move(parameters));
 
-  auto result =
-      evaluateObjectInstance(className, actualParametersBuffers.back().get());
+  auto loc = cls.getLoc();
+  auto result = evaluateObjectInstance(
+      className, actualParametersBuffers.back().get(), loc);
 
   if (failed(result))
     return failure();
@@ -266,7 +268,7 @@ circt::om::Evaluator::instantiate(
     auto [value, args] = worklist.front();
     worklist.pop();
 
-    auto result = evaluateValue(value, args);
+    auto result = evaluateValue(value, args, loc);
 
     if (failed(result))
       return failure();
@@ -286,9 +288,9 @@ circt::om::Evaluator::instantiate(
 }
 
 FailureOr<evaluator::EvaluatorValuePtr>
-circt::om::Evaluator::evaluateValue(Value value,
-                                    ActualParameters actualParams) {
-  auto evaluatorValue = getOrCreateValue(value, actualParams).value();
+circt::om::Evaluator::evaluateValue(Value value, ActualParameters actualParams,
+                                    Location loc) {
+  auto evaluatorValue = getOrCreateValue(value, actualParams, loc).value();
 
   // Return if the value is already evaluated.
   if (evaluatorValue->isFullyEvaluated())
@@ -296,34 +298,34 @@ circt::om::Evaluator::evaluateValue(Value value,
 
   return llvm::TypeSwitch<Value, FailureOr<evaluator::EvaluatorValuePtr>>(value)
       .Case([&](BlockArgument arg) {
-        return evaluateParameter(arg, actualParams);
+        return evaluateParameter(arg, actualParams, loc);
       })
       .Case([&](OpResult result) {
         return TypeSwitch<Operation *, FailureOr<evaluator::EvaluatorValuePtr>>(
                    result.getDefiningOp())
             .Case([&](ConstantOp op) {
-              return evaluateConstant(op, actualParams);
+              return evaluateConstant(op, actualParams, loc);
             })
             .Case([&](ObjectOp op) {
               return evaluateObjectInstance(op, actualParams);
             })
             .Case([&](ObjectFieldOp op) {
-              return evaluateObjectField(op, actualParams);
+              return evaluateObjectField(op, actualParams, loc);
             })
             .Case([&](ListCreateOp op) {
-              return evaluateListCreate(op, actualParams);
+              return evaluateListCreate(op, actualParams, loc);
             })
             .Case([&](TupleCreateOp op) {
-              return evaluateTupleCreate(op, actualParams);
+              return evaluateTupleCreate(op, actualParams, loc);
             })
             .Case([&](TupleGetOp op) {
-              return evaluateTupleGet(op, actualParams);
+              return evaluateTupleGet(op, actualParams, loc);
             })
             .Case([&](AnyCastOp op) {
-              return evaluateValue(op.getInput(), actualParams);
+              return evaluateValue(op.getInput(), actualParams, loc);
             })
             .Case([&](MapCreateOp op) {
-              return evaluateMapCreate(op, actualParams);
+              return evaluateMapCreate(op, actualParams, loc);
             })
             .Default([&](Operation *op) {
               auto error = op->emitError("unable to evaluate value");
@@ -334,31 +336,33 @@ circt::om::Evaluator::evaluateValue(Value value,
 }
 
 /// Evaluator dispatch function for parameters.
-FailureOr<evaluator::EvaluatorValuePtr>
-circt::om::Evaluator::evaluateParameter(BlockArgument formalParam,
-                                        ActualParameters actualParams) {
-  return success((*actualParams)[formalParam.getArgNumber()]);
+FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateParameter(
+    BlockArgument formalParam, ActualParameters actualParams, Location loc) {
+  auto val = (*actualParams)[formalParam.getArgNumber()];
+  val->setLoc(loc);
+  return success(val);
 }
 
 /// Evaluator dispatch function for constants.
 FailureOr<circt::om::evaluator::EvaluatorValuePtr>
 circt::om::Evaluator::evaluateConstant(ConstantOp op,
-                                       ActualParameters actualParams) {
-  return success(
-      std::make_shared<circt::om::evaluator::AttributeValue>(op.getValue()));
+                                       ActualParameters actualParams,
+                                       Location loc) {
+  return success(std::make_shared<circt::om::evaluator::AttributeValue>(
+      op.getValue(), loc));
 }
 
 /// Evaluator dispatch function for Object instances.
 FailureOr<circt::om::Evaluator::ActualParameters>
 circt::om::Evaluator::createParametersFromOperands(
-    ValueRange range, ActualParameters actualParams) {
+    ValueRange range, ActualParameters actualParams, Location loc) {
   // Create an unique storage to store parameters.
   auto parameters = std::make_unique<
       SmallVector<std::shared_ptr<evaluator::EvaluatorValue>>>();
 
   // Collect operands' evaluator values in the current instantiation context.
   for (auto input : range) {
-    auto inputResult = getOrCreateValue(input, actualParams);
+    auto inputResult = getOrCreateValue(input, actualParams, loc);
     if (failed(inputResult))
       return failure();
     parameters->push_back(inputResult.value());
@@ -372,30 +376,33 @@ circt::om::Evaluator::createParametersFromOperands(
 FailureOr<evaluator::EvaluatorValuePtr>
 circt::om::Evaluator::evaluateObjectInstance(ObjectOp op,
                                              ActualParameters actualParams) {
+  auto loc = op.getLoc();
   if (isFullyEvaluated({op, actualParams}))
-    return getOrCreateValue(op, actualParams);
+    return getOrCreateValue(op, actualParams, loc);
 
-  auto params = createParametersFromOperands(op.getOperands(), actualParams);
+  auto params =
+      createParametersFromOperands(op.getOperands(), actualParams, loc);
   if (failed(params))
     return failure();
-  return evaluateObjectInstance(op.getClassNameAttr(), params.value(),
+  return evaluateObjectInstance(op.getClassNameAttr(), params.value(), loc,
                                 {op, actualParams});
 }
 
 /// Evaluator dispatch function for Object fields.
 FailureOr<evaluator::EvaluatorValuePtr>
 circt::om::Evaluator::evaluateObjectField(ObjectFieldOp op,
-                                          ActualParameters actualParams) {
+                                          ActualParameters actualParams,
+                                          Location loc) {
   // Evaluate the Object itself, in case it hasn't been evaluated yet.
   FailureOr<evaluator::EvaluatorValuePtr> currentObjectResult =
-      evaluateValue(op.getObject(), actualParams);
+      evaluateValue(op.getObject(), actualParams, loc);
   if (failed(currentObjectResult))
     return currentObjectResult;
 
   auto *currentObject =
       llvm::cast<evaluator::ObjectValue>(currentObjectResult.value().get());
 
-  auto objectFieldValue = getOrCreateValue(op, actualParams).value();
+  auto objectFieldValue = getOrCreateValue(op, actualParams, loc).value();
 
   // Iteratively access nested fields through the path until we reach the final
   // field in the path.
@@ -423,12 +430,13 @@ circt::om::Evaluator::evaluateObjectField(ObjectFieldOp op,
 /// Evaluator dispatch function for List creation.
 FailureOr<evaluator::EvaluatorValuePtr>
 circt::om::Evaluator::evaluateListCreate(ListCreateOp op,
-                                         ActualParameters actualParams) {
+                                         ActualParameters actualParams,
+                                         Location loc) {
   // Evaluate the Object itself, in case it hasn't been evaluated yet.
   SmallVector<evaluator::EvaluatorValuePtr> values;
-  auto list = getOrCreateValue(op, actualParams);
+  auto list = getOrCreateValue(op, actualParams, loc);
   for (auto operand : op.getOperands()) {
-    auto result = evaluateValue(operand, actualParams);
+    auto result = evaluateValue(operand, actualParams, loc);
     if (failed(result))
       return result;
     if (!result.value()->isFullyEvaluated())
@@ -445,27 +453,27 @@ circt::om::Evaluator::evaluateListCreate(ListCreateOp op,
 /// Evaluator dispatch function for Tuple creation.
 FailureOr<evaluator::EvaluatorValuePtr>
 circt::om::Evaluator::evaluateTupleCreate(TupleCreateOp op,
-                                          ActualParameters actualParams) {
+                                          ActualParameters actualParams,
+                                          Location loc) {
   SmallVector<evaluator::EvaluatorValuePtr> values;
   for (auto operand : op.getOperands()) {
-    auto result = evaluateValue(operand, actualParams);
+    auto result = evaluateValue(operand, actualParams, loc);
     if (failed(result))
       return result;
     values.push_back(result.value());
   }
 
   // Return the tuple.
-  auto val = getOrCreateValue(op, actualParams);
+  auto val = getOrCreateValue(op, actualParams, loc);
   llvm::cast<evaluator::TupleValue>(val.value().get())
       ->setElements(std::move(values));
   return val;
 }
 
 /// Evaluator dispatch function for List creation.
-FailureOr<evaluator::EvaluatorValuePtr>
-circt::om::Evaluator::evaluateTupleGet(TupleGetOp op,
-                                       ActualParameters actualParams) {
-  auto tuple = evaluateValue(op.getInput(), actualParams);
+FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateTupleGet(
+    TupleGetOp op, ActualParameters actualParams, Location loc) {
+  auto tuple = evaluateValue(op.getInput(), actualParams, loc);
   if (failed(tuple))
     return tuple;
   evaluator::EvaluatorValuePtr result =
@@ -475,14 +483,13 @@ circt::om::Evaluator::evaluateTupleGet(TupleGetOp op,
 }
 
 /// Evaluator dispatch function for Map creation.
-FailureOr<evaluator::EvaluatorValuePtr>
-circt::om::Evaluator::evaluateMapCreate(MapCreateOp op,
-                                        ActualParameters actualParams) {
+FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateMapCreate(
+    MapCreateOp op, ActualParameters actualParams, Location loc) {
   // Evaluate the Object itself, in case it hasn't been evaluated yet.
   DenseMap<Attribute, evaluator::EvaluatorValuePtr> elements;
-  auto valueResult = getOrCreateValue(op, actualParams).value();
+  auto valueResult = getOrCreateValue(op, actualParams, loc).value();
   for (auto operand : op.getOperands()) {
-    auto result = evaluateValue(operand, actualParams);
+    auto result = evaluateValue(operand, actualParams, loc);
     if (failed(result))
       return result;
     // The result is a tuple.


### PR DESCRIPTION
Add the debug locations to the evaluator value, which will be used to generate `info` fields of the object model output json.