### PR TITLE
[Ibis] Added missing ibistool to integration test

### DIFF
--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -86,7 +86,7 @@ tool_dirs = [
 ]
 tools = [
     'circt-opt', 'circt-translate', 'firtool', 'circt-rtl-sim.py',
-    'esi-cosim-runner.py', 'equiv-rtl.sh', 'handshake-runner', 'hlstool'
+    'esi-cosim-runner.py', 'equiv-rtl.sh', 'handshake-runner', 'hlstool', 'ibistool'
 ]
 
 # Enable python if its path was configured

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -86,7 +86,8 @@ tool_dirs = [
 ]
 tools = [
     'circt-opt', 'circt-translate', 'firtool', 'circt-rtl-sim.py',
-    'esi-cosim-runner.py', 'equiv-rtl.sh', 'handshake-runner', 'hlstool', 'ibistool'
+    'esi-cosim-runner.py', 'equiv-rtl.sh', 'handshake-runner', 'hlstool', 
+    'ibistool'
 ]
 
 # Enable python if its path was configured

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -86,7 +86,7 @@ tool_dirs = [
 ]
 tools = [
     'circt-opt', 'circt-translate', 'firtool', 'circt-rtl-sim.py',
-    'esi-cosim-runner.py', 'equiv-rtl.sh', 'handshake-runner', 'hlstool', 
+    'esi-cosim-runner.py', 'equiv-rtl.sh', 'handshake-runner', 'hlstool',
     'ibistool'
 ]
 


### PR DESCRIPTION
`ibistool` was missing in the tool list in the integration test making it crash, so I simply added it in. Now the tests run without a problem.