### PR TITLE
[OM] Load post-export dialects in om-linker.

### DIFF
--- a/tools/om-linker/CMakeLists.txt
+++ b/tools/om-linker/CMakeLists.txt
@@ -7,8 +7,11 @@ add_circt_tool(om-linker
 )
 llvm_update_compile_flags(om-linker)
 target_link_libraries(om-linker PRIVATE
+  CIRCTComb
+  CIRCTHW
   CIRCTOM
   CIRCTOMTransforms
+  CIRCTSV
   CIRCTSupport
 
   MLIRBytecodeReader

--- a/tools/om-linker/om-linker.cpp
+++ b/tools/om-linker/om-linker.cpp
@@ -11,8 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/Comb/CombDialect.h"
+#include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/OM/OMDialect.h"
 #include "circt/Dialect/OM/OMPasses.h"
+#include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Support/Version.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Threading.h"
@@ -202,8 +205,11 @@ int main(int argc, char **argv) {
   cl::ParseCommandLineOptions(argc, argv, "OM linker\n");
 
   MLIRContext context;
-  // Register OM dialect.
+  // Register post-export dialects.
+  context.loadDialect<comb::CombDialect>();
+  context.loadDialect<hw::HWDialect>();
   context.loadDialect<om::OMDialect>();
+  context.loadDialect<sv::SVDialect>();
 
   // Do the guts of the om-linker process.
   auto result = executeOMLinker(context);


### PR DESCRIPTION
We expect to run this tool on post-export IR, so load the appropriate dialects in the context.