### PR TITLE
[OM] Update FreezePaths to root paths at the nearest public module.

### DIFF
--- a/lib/Dialect/OM/Transforms/FreezePaths.cpp
+++ b/lib/Dialect/OM/Transforms/FreezePaths.cpp
@@ -154,7 +154,12 @@ LogicalResult PathVisitor::processPath(PathOp path) {
   assert(topModule && "must have something?");
   auto *node = instanceGraph.lookup(topModule);
   while (!node->noUses()) {
-    auto module = node->getModule();
+    auto module = node->getModule<hw::HWModuleLike>();
+
+    // If the module is public, stop here.
+    if (module.getVisibility() == SymbolTable::Visibility::Public)
+      break;
+
     if (!node->hasOneUse()) {
       auto diag = path->emitError() << "unable to uniquely resolve target "
                                        "due to multiple instantiation";

--- a/lib/Dialect/OM/Transforms/FreezePaths.cpp
+++ b/lib/Dialect/OM/Transforms/FreezePaths.cpp
@@ -157,7 +157,7 @@ LogicalResult PathVisitor::processPath(PathOp path) {
     auto module = node->getModule<hw::HWModuleLike>();
 
     // If the module is public, stop here.
-    if (module.getVisibility() == SymbolTable::Visibility::Public)
+    if (module.isPublic())
       break;
 
     if (!node->hasOneUse()) {

--- a/test/Dialect/OM/freeze-paths-errors.mlir
+++ b/test/Dialect/OM/freeze-paths-errors.mlir
@@ -12,8 +12,7 @@ hw.module @Top() {
 // -----
 
 hw.hierpath private @nla [@Child]
-// expected-note @below {{module marked public}}
-hw.module @Child() {}
+hw.module private @Child() {}
 hw.module @Top() {
   // expected-error @below {{unable to uniquely resolve target due to multiple instantiation}}
   %path = om.path reference @nla

--- a/test/Dialect/OM/freeze-paths.mlir
+++ b/test/Dialect/OM/freeze-paths.mlir
@@ -6,11 +6,13 @@ hw.hierpath private @nla_2 [@PathModule::@sym_2]
 hw.hierpath private @nla_3 [@PathModule::@child]
 hw.hierpath private @nla_4 [@Child]
 hw.hierpath private @nla_5 [@PathModule::@child, @Child::@sym]
+hw.hierpath private @nla_6 [@PublicLeaf]
 hw.module @PathModule(in %in: i1 {hw.exportPort = #hw<innerSym@sym>}) {
   %wire = hw.wire %wire sym @sym_0 {hw.verilogName = "wire"} : i8
   %array = hw.wire %array sym [<@sym_1,1,public>] {hw.verilogName = "array"}: !hw.array<1xi8>
   %struct = hw.wire %struct sym [<@sym_2,1,public>] {hw.verilogName = "struct"}: !hw.struct<a: i8>
   hw.instance "child" sym @child @Child() -> () {hw.verilogName = "child"}
+  hw.instance "public_middle" @PublicMiddle() -> () {hw.verilogName = "public_middle"}
   hw.output
 }
 hw.hierpath private @NonLocal [@PathModule::@child, @Child]
@@ -19,6 +21,13 @@ hw.module private @Child() {
   %non_local = hw.wire %z_i8 sym @sym {hw.verilogName = "non_local"}  : i8
   hw.output
 }
+
+hw.module @PublicMiddle() {
+  hw.instance "leaf" @PublicLeaf() -> () {hw.verilogName = "leaf"}
+}
+
+hw.module private @PublicLeaf() {}
+
 // CHECK-LABEL om.class @PathTest()
 om.class @PathTest() {
   // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule>in"> : !om.path
@@ -50,4 +59,7 @@ om.class @PathTest() {
 
   // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule/child:Child"> : !om.path
   %10 = om.path reference @nla_4
+
+  // CHECK: om.constant #om.path<"OMReferenceTarget:PublicMiddle/leaf:PublicLeaf"> : !om.path
+  %11 = om.path reference @nla_6
 }


### PR DESCRIPTION
The current logic doesn't support freezing paths with multiple public modules. In the current setup, multiple public modules are allowed, so this updates the instance graph traversal to allow rooting paths at the nearest public module.