### PR TITLE
[Arc] Lower models into eval functions

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -150,7 +150,7 @@ def LowerArcsToFuncs : Pass<"arc-lower-arcs-to-funcs", "mlir::ModuleOp"> {
 def LowerClocksToFuncs : Pass<"arc-lower-clocks-to-funcs", "mlir::ModuleOp"> {
   let summary = "Lower clock trees into functions";
   let constructor = "circt::arc::createLowerClocksToFuncsPass()";
-  let dependentDialects = ["mlir::func::FuncDialect"];
+  let dependentDialects = ["mlir::func::FuncDialect", "mlir::scf::SCFDialect"];
 }
 
 def LowerLUT : Pass<"arc-lower-lut", "arc::DefineOp"> {

--- a/test/Dialect/Arc/lower-clocks-to-funcs.mlir
+++ b/test/Dialect/Arc/lower-clocks-to-funcs.mlir
@@ -16,8 +16,11 @@
 
 // CHECK-LABEL: arc.model "Trivial" {
 // CHECK-NEXT:  ^bb0(%arg0: !arc.storage<42>):
+// CHECK-NEXT:    %true = hw.constant true
 // CHECK-NEXT:    %false = hw.constant false
-// CHECK-NEXT:    func.call @Trivial_clock(%arg0) : (!arc.storage<42>) -> ()
+// CHECK-NEXT:    scf.if %true {
+// CHECK-NEXT:      func.call @Trivial_clock(%arg0) : (!arc.storage<42>) -> ()
+// CHECK-NEXT:    }
 // CHECK-NEXT:    func.call @Trivial_passthrough(%arg0) : (!arc.storage<42>) -> ()
 // CHECK-NEXT:  }
 

--- a/test/arcilator/arcilator.mlir
+++ b/test/arcilator/arcilator.mlir
@@ -1,57 +1,33 @@
-// RUN: arcilator %s --inline=0 --until-before=state-alloc | FileCheck %s
+// RUN: arcilator %s --inline=0 --until-before=llvm-lowering | FileCheck %s
 // RUN: arcilator %s | FileCheck %s --check-prefix=LLVM
 // RUN: arcilator --print-debug-info %s | FileCheck %s --check-prefix=LLVM-DEBUG
 
-// CHECK:      arc.define @[[XOR_ARC:.+]](
+// CHECK:      func.func @[[XOR_ARC:.+]](
 // CHECK-NEXT:   comb.xor
-// CHECK-NEXT:   arc.output
+// CHECK-NEXT:   return
 // CHECK-NEXT: }
 
-// CHECK:      arc.define @[[ADD_ARC:.+]](
+// CHECK:      func.func @[[ADD_ARC:.+]](
 // CHECK-NEXT:   comb.add
-// CHECK-NEXT:   arc.output
+// CHECK-NEXT:   return
 // CHECK-NEXT: }
 
-// CHECK:      arc.define @[[MUL_ARC:.+]](
+// CHECK:      func.func @[[MUL_ARC:.+]](
 // CHECK-NEXT:   comb.mul
-// CHECK-NEXT:   arc.output
+// CHECK-NEXT:   return
 // CHECK-NEXT: }
+
+// CHECK: func.func @Top_passthrough
+// CHECK: func.func @Top_clock
 
 // CHECK-NOT: hw.module @Top
 // CHECK-LABEL: arc.model "Top" {
-// CHECK-NEXT: ^bb0(%arg0: !arc.storage):
+// CHECK-NEXT: ^bb0(%arg0: !arc.storage<8>):
 hw.module @Top(in %clock : !seq.clock, in %i0 : i4, in %i1 : i4, out out : i4) {
-  // CHECK-DAG: [[CLOCK:%.+]] = arc.root_input "clock", %arg0 {{.+}} !arc.state<i1>
-  // CHECK-DAG: [[I0:%.+]] = arc.root_input "i0", %arg0 {{.+}} !arc.state<i4>
-  // CHECK-DAG: [[I1:%.+]] = arc.root_input "i1", %arg0 {{.+}} !arc.state<i4>
-  // CHECK-DAG: [[PTR_OUT:%.+]] = arc.root_output "out", %arg0 {{.+}} !arc.state<i4>
-  // CHECK-DAG: [[CLOCK_OLD:%.+]] = arc.alloc_state %arg0 {{.+}} !arc.state<i1>
-  // CHECK-DAG: [[FOO:%.+]] = arc.alloc_state %arg0 {name = "foo"} {{.+}} !arc.state<i4>
-  // CHECK-DAG: [[BAR:%.+]] = arc.alloc_state %arg0 {name = "bar"} {{.+}} !arc.state<i4>
-
-  // CHECK-DAG: [[READ_CLOCK:%.+]] = arc.state_read [[CLOCK]]
-  // CHECK-DAG: arc.state_write [[CLOCK_OLD]] = [[READ_CLOCK]]
-  // CHECK-DAG: [[READ_CLOCK_OLD:%.+]] = arc.state_read [[CLOCK_OLD]]
-  // CHECK-DAG: [[CLOCK_CHANGED:%.+]] = comb.icmp ne [[READ_CLOCK_OLD]], [[READ_CLOCK]] : i1
-  // CHECK-DAG: [[CLOCK_ROSE:%.+]] = comb.and [[CLOCK_CHANGED]], [[READ_CLOCK]] : i1
-
-  // CHECK-DAG: arc.clock_tree [[CLOCK_ROSE]] {
-  // CHECK-DAG:   [[READ_I0:%.+]] = arc.state_read [[I0]]
-  // CHECK-DAG:   [[READ_I1:%.+]] = arc.state_read [[I1]]
-  // CHECK-DAG:   [[ADD:%.+]] = arc.state @[[ADD_ARC]]([[READ_I0]], [[READ_I1]]) lat 0
-  // CHECK-DAG:   [[XOR1:%.+]] = arc.state @[[XOR_ARC]]([[ADD]], [[READ_I0]]) lat 0
-  // CHECK-DAG:   [[XOR2:%.+]] = arc.state @[[XOR_ARC]]([[ADD]], [[READ_I1]]) lat 0
-  // CHECK-DAG:   arc.state_write [[FOO]] = [[XOR1]]
-  // CHECK-DAG:   arc.state_write [[BAR]] = [[XOR2]]
-  // CHECK-DAG: }
-
-  // CHECK-DAG: arc.passthrough {
-  // CHECK-DAG:   [[READ_FOO:%.+]] = arc.state_read [[FOO]]
-  // CHECK-DAG:   [[READ_BAR:%.+]] = arc.state_read [[BAR]]
-  // CHECK-DAG:   [[MUL:%.+]] = arc.state @[[MUL_ARC]]([[READ_FOO]], [[READ_BAR]]) lat 0
-  // CHECK-DAG:   arc.state_write [[PTR_OUT]] = [[MUL]]
-  // CHECK-DAG: }
-
+  // CHECK: func.call @Top_passthrough(%arg0)
+  // CHECK: scf.if {{%.+}} {
+  // CHECK:   func.call @Top_clock(%arg0)
+  // CHECK: }
   %0 = comb.add %i0, %i1 : i4
   %1 = comb.xor %0, %i0 : i4
   %2 = comb.xor %0, %i1 : i4
@@ -67,6 +43,9 @@ hw.module @Top(in %clock : !seq.clock, in %i0 : i4, in %i1 : i4, out out : i4) {
 // LLVM:   add i4
 // LLVM:   xor i4
 // LLVM:   xor i4
+// LLVM: define void @Top_eval(ptr %0)
+// LLVM:   call void @Top_passthrough(ptr %0)
+// LLVM:   call void @Top_clock(ptr %0)
 
 // LLVM-DEBUG: define void @Top_passthrough(ptr %0){{.*}}!dbg
 // LLVM-DEBUG:   mul i4{{.*}}!dbg
@@ -74,3 +53,6 @@ hw.module @Top(in %clock : !seq.clock, in %i0 : i4, in %i1 : i4, out out : i4) {
 // LLVM-DEBUG:   add i4{{.*}}!dbg
 // LLVM-DEBUG:   xor i4{{.*}}!dbg
 // LLVM-DEBUG:   xor i4{{.*}}!dbg
+// LLVM-DEBUG: define void @Top_eval(ptr %0){{.*}}!dbg
+// LLVM-DEBUG:   call void @Top_passthrough(ptr %0){{.*}}!dbg
+// LLVM-DEBUG:   call void @Top_clock(ptr %0){{.*}}!dbg

--- a/tools/arcilator/arcilator-header-cpp.py
+++ b/tools/arcilator/arcilator-header-cpp.py
@@ -240,8 +240,7 @@ for model in models:
       io.name = io.name + "_"
 
   print('extern "C" {')
-  print(f"void {model.name}_clock(void* state);")
-  print(f"void {model.name}_passthrough(void* state);")
+  print(f"void {model.name}_eval(void* state);")
   print('}')
 
   # Generate the model layout.
@@ -300,8 +299,7 @@ for model in models:
   print(
       f"  {model.name}() : storage({model.name}Layout::numStateBytes, 0), view(&storage[0]) {{}}"
   )
-  print(f"  void clock() {{ {model.name}_clock(&storage[0]); }}")
-  print(f"  void passthrough() {{ {model.name}_passthrough(&storage[0]); }}")
+  print(f"  void eval() {{ {model.name}_eval(&storage[0]); }}")
   print(
       f"  ValueChangeDump<{model.name}Layout> vcd(std::basic_ostream<char> &os) {{"
   )


### PR DESCRIPTION
Lower `arc.model` operations to an eval function similar to what Verilator creates. Instead of requiring the user to explicitly call the clock and passthrough functions, the eval function will check which clock inputs toggled and then call the appropriate clock function. Since all clocks are now called from one central point, `LegalizeStateUpdate` can ensure that clock edges happening at the same time will both see the state values before the edge. This was impossible up until now, since the user had to call one clock function before the other, which would cause the state changes of the first clock to fully propagate before the second was called.

This is an important step forward to make Arc useful for simulating complex, multi-clock designs. There are still a few remaining issues around passthrough signals, and how reads/writes have to be legalized around them. These issues can be resolved at a later point though.

The Rocket and BOOM cores in github.com/circt/arc-tests work well with this new eval function approach. In fact, the testbench becomes slightly easier to write, and the Verilator and Arcilator models feel almost identical in their use.