### PR TITLE
[OM] Evaluator: Support graph regions

### DIFF
--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -20,6 +20,10 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+#include <queue>
+#include <utility>
 
 namespace circt {
 namespace om {
@@ -36,25 +40,81 @@ using EvaluatorValuePtr = std::shared_ptr<EvaluatorValue>;
 using ObjectFields = SmallDenseMap<StringAttr, EvaluatorValuePtr>;
 
 /// Base class for evaluator runtime values.
-/// Enables the shared_from_this functionality so Object pointers can be passed
-/// through the CAPI and unwrapped back into C++ smart pointers with the
-/// appropriate reference count.
+/// Enables the shared_from_this functionality so Evaluator Value pointers can
+/// be passed through the CAPI and unwrapped back into C++ smart pointers with
+/// the appropriate reference count.
 struct EvaluatorValue : std::enable_shared_from_this<EvaluatorValue> {
   // Implement LLVM RTTI.
-  enum class Kind { Attr, Object, List, Tuple, Map };
-  EvaluatorValue(MLIRContext *ctx, Kind kind) : kind(kind) {}
+  enum class Kind { Attr, Object, List, Tuple, Map, Reference };
+  EvaluatorValue(MLIRContext *ctx, Kind kind) : kind(kind), ctx(ctx) {}
   Kind getKind() const { return kind; }
   MLIRContext *getContext() const { return ctx; }
+
+  // Return true the value is fully evaluated.
+  bool isFullyEvaluated() const { return fullyEvaluated; }
+  void markFullyEvaluated() { fullyEvaluated = true; }
+
+  // Return a MLIR type which the value represents.
+  Type getType() const;
+
+  // Finalize the evaluator value. Strip intermidiate reference values.
+  LogicalResult finalize();
 
 private:
   const Kind kind;
   MLIRContext *ctx;
+  bool fullyEvaluated = false;
+  bool finalized = false;
+};
+
+/// Values which can be used as pointers to different values.
+/// ReferenceValue is replaced with its element and erased at the end of
+/// evaluation.
+struct ReferenceValue : EvaluatorValue {
+  ReferenceValue(Type type)
+      : EvaluatorValue(type.getContext(), Kind::Reference), value(nullptr),
+        type(type) {}
+
+  // Implement LLVM RTTI.
+  static bool classof(const EvaluatorValue *e) {
+    return e->getKind() == Kind::Reference;
+  }
+
+  Type getValueType() const { return type; }
+  EvaluatorValuePtr getValue() const { return value; }
+  void setValue(EvaluatorValuePtr newValue) {
+    value = std::move(newValue);
+    markFullyEvaluated();
+  }
+
+  // Finalize the value.
+  LogicalResult finalizeImpl();
+
+  // Return the first non-reference value that is reachable from the reference.
+  FailureOr<EvaluatorValuePtr> getStrippedValue() const {
+    llvm::SmallPtrSet<ReferenceValue *, 4> visited;
+    auto currentValue = value;
+    while (auto *v = dyn_cast<ReferenceValue>(currentValue.get())) {
+      // Detect a cycle.
+      if (!visited.insert(v).second)
+        return failure();
+      currentValue = v->getValue();
+    }
+    return success(currentValue);
+  }
+
+private:
+  EvaluatorValuePtr value;
+  Type type;
 };
 
 /// Values which can be directly representable by MLIR attributes.
 struct AttributeValue : EvaluatorValue {
   AttributeValue(Attribute attr)
-      : EvaluatorValue(attr.getContext(), Kind::Attr), attr(attr) {}
+      : EvaluatorValue(attr.getContext(), Kind::Attr), attr(attr) {
+    markFullyEvaluated();
+  }
+
   Attribute getAttr() const { return attr; }
   template <typename AttrTy>
   AttrTy getAs() const {
@@ -64,20 +124,52 @@ struct AttributeValue : EvaluatorValue {
     return e->getKind() == Kind::Attr;
   }
 
+  // Finalize the value.
+  LogicalResult finalizeImpl() { return success(); }
+
+  Type getType() const { return attr.cast<TypedAttr>().getType(); }
+
 private:
-  Attribute attr;
+  Attribute attr = {};
 };
+
+// This perform finalization to `value`.
+static inline LogicalResult finalizeEvaluatorValue(EvaluatorValuePtr &value) {
+  if (failed(value->finalize()))
+    return failure();
+  if (auto *ref = llvm::dyn_cast<ReferenceValue>(value.get())) {
+    auto v = ref->getStrippedValue();
+    if (failed(v))
+      return v;
+    value = v.value();
+  }
+  return success();
+}
 
 /// A List which contains variadic length of elements with the same type.
 struct ListValue : EvaluatorValue {
   ListValue(om::ListType type, SmallVector<EvaluatorValuePtr> elements)
       : EvaluatorValue(type.getContext(), Kind::List), type(type),
-        elements(std::move(elements)) {}
+        elements(std::move(elements)) {
+    markFullyEvaluated();
+  }
+
+  void setElements(SmallVector<EvaluatorValuePtr> newElements) {
+    elements = std::move(newElements);
+    markFullyEvaluated();
+  }
+
+  // Finalize the value.
+  LogicalResult finalizeImpl();
+
+  // Partially evaluated value.
+  ListValue(om::ListType type)
+      : EvaluatorValue(type.getContext(), Kind::List), type(type) {}
 
   const auto &getElements() const { return elements; }
 
   /// Return the type of the value, which is a ListType.
-  om::ListType getType() const { return type; }
+  om::ListType getListType() const { return type; }
 
   /// Implement LLVM RTTI.
   static bool classof(const EvaluatorValue *e) {
@@ -93,12 +185,25 @@ private:
 struct MapValue : EvaluatorValue {
   MapValue(om::MapType type, DenseMap<Attribute, EvaluatorValuePtr> elements)
       : EvaluatorValue(type.getContext(), Kind::Map), type(type),
-        elements(std::move(elements)) {}
+        elements(std::move(elements)) {
+    markFullyEvaluated();
+  }
+
+  // Partially evaluated value.
+  MapValue(om::MapType type)
+      : EvaluatorValue(type.getContext(), Kind::Map), type(type) {}
 
   const auto &getElements() const { return elements; }
+  void setElements(DenseMap<Attribute, EvaluatorValuePtr> newElements) {
+    elements = std::move(newElements);
+    markFullyEvaluated();
+  }
+
+  // Finalize the evaluator value.
+  LogicalResult finalizeImpl();
 
   /// Return the type of the value, which is a MapType.
-  om::MapType getType() const { return type; }
+  om::MapType getMapType() const { return type; }
 
   /// Return an array of keys in the ascending order.
   ArrayAttr getKeys();
@@ -117,16 +222,30 @@ private:
 struct ObjectValue : EvaluatorValue {
   ObjectValue(om::ClassOp cls, ObjectFields fields)
       : EvaluatorValue(cls.getContext(), Kind::Object), cls(cls),
-        fields(std::move(fields)) {}
+        fields(std::move(fields)) {
+    markFullyEvaluated();
+  }
+
+  // Partially evaluated value.
+  ObjectValue(om::ClassOp cls)
+      : EvaluatorValue(cls.getContext(), Kind::Object), cls(cls) {}
+
   om::ClassOp getClassOp() const { return cls; }
   const auto &getFields() const { return fields; }
 
+  void setFields(llvm::SmallDenseMap<StringAttr, EvaluatorValuePtr> newFields) {
+    fields = std::move(newFields);
+    markFullyEvaluated();
+  }
+
   /// Return the type of the value, which is a ClassType.
-  om::ClassType getType() const {
+  om::ClassType getObjectType() const {
     auto clsConst = const_cast<ClassOp &>(cls);
     return ClassType::get(clsConst.getContext(),
                           FlatSymbolRefAttr::get(clsConst.getNameAttr()));
   }
+
+  Type getType() const { return getObjectType(); }
 
   /// Implement LLVM RTTI.
   static bool classof(const EvaluatorValue *e) {
@@ -135,9 +254,15 @@ struct ObjectValue : EvaluatorValue {
 
   /// Get a field of the Object by name.
   FailureOr<EvaluatorValuePtr> getField(StringAttr field);
+  FailureOr<EvaluatorValuePtr> getField(StringRef field) {
+    return getField(StringAttr::get(getContext(), field));
+  }
 
   /// Get all the field names of the Object.
   ArrayAttr getFieldNames();
+
+  // Finalize the evaluator value.
+  LogicalResult finalizeImpl();
 
 private:
   om::ClassOp cls;
@@ -149,15 +274,33 @@ struct TupleValue : EvaluatorValue {
   using TupleElements = llvm::SmallVector<EvaluatorValuePtr>;
   TupleValue(TupleType type, TupleElements tupleElements)
       : EvaluatorValue(type.getContext(), Kind::Tuple), type(type),
-        elements(std::move(tupleElements)) {}
+        elements(std::move(tupleElements)) {
+    markFullyEvaluated();
+  }
 
+  // Partially evaluated value.
+  TupleValue(TupleType type)
+      : EvaluatorValue(type.getContext(), Kind::Tuple), type(type) {}
+
+  void setElements(TupleElements newElements) {
+    elements = std::move(newElements);
+    markFullyEvaluated();
+  }
+
+  LogicalResult finalizeImpl() {
+    for (auto &&value : elements)
+      if (failed(finalizeEvaluatorValue(value)))
+        return failure();
+
+    return success();
+  }
   /// Implement LLVM RTTI.
   static bool classof(const EvaluatorValue *e) {
     return e->getKind() == Kind::Tuple;
   }
 
   /// Return the type of the value, which is a TupleType.
-  TupleType getType() const { return type; }
+  TupleType getTupleType() const { return type; }
 
   const TupleElements &getElements() const { return elements; }
 
@@ -182,49 +325,81 @@ struct Evaluator {
   Evaluator(ModuleOp mod);
 
   /// Instantiate an Object with its class name and actual parameters.
-  FailureOr<std::shared_ptr<Object>>
+  FailureOr<evaluator::EvaluatorValuePtr>
   instantiate(StringAttr className, ArrayRef<EvaluatorValuePtr> actualParams);
 
   /// Get the Module this Evaluator is built from.
   mlir::ModuleOp getModule();
 
+  FailureOr<evaluator::EvaluatorValuePtr> getPartiallyEvaluatedValue(Type type);
+
+  using ActualParameters =
+      SmallVectorImpl<std::shared_ptr<evaluator::EvaluatorValue>> *;
+
+  using Key = std::pair<Value, ActualParameters>;
+
 private:
+  bool isFullyEvaluated(Value value, ActualParameters key) {
+    return isFullyEvaluated({value, key});
+  }
+
+  bool isFullyEvaluated(Key key) {
+    auto val = objects.lookup(key);
+    return val && val->isFullyEvaluated();
+  }
+
+  FailureOr<EvaluatorValuePtr> getOrCreateValue(Value value,
+                                                ActualParameters actualParams);
+  FailureOr<EvaluatorValuePtr>
+  allocateObjectInstance(StringAttr clasName, ActualParameters actualParams);
+
   /// Evaluate a Value in a Class body according to the small expression grammar
   /// described in the rationale document. The actual parameters are the values
   /// supplied at the current instantiation of the Class being evaluated.
-  FailureOr<EvaluatorValuePtr>
-  evaluateValue(Value value, ArrayRef<EvaluatorValuePtr> actualParams);
+  FailureOr<EvaluatorValuePtr> evaluateValue(Value value,
+                                             ActualParameters actualParams);
 
   /// Evaluator dispatch functions for the small expression grammar.
-  FailureOr<EvaluatorValuePtr>
-  evaluateParameter(BlockArgument formalParam,
-                    ArrayRef<EvaluatorValuePtr> actualParams);
+  FailureOr<EvaluatorValuePtr> evaluateParameter(BlockArgument formalParam,
+                                                 ActualParameters actualParams);
 
+  FailureOr<EvaluatorValuePtr> evaluateConstant(ConstantOp op,
+                                                ActualParameters actualParams);
+  /// Instantiate an Object with its class name and actual parameters.
   FailureOr<EvaluatorValuePtr>
-  evaluateConstant(ConstantOp op, ArrayRef<EvaluatorValuePtr> actualParams);
+  evaluateObjectInstance(StringAttr className, ActualParameters actualParams,
+                         Key instanceKey = {});
   FailureOr<EvaluatorValuePtr>
-  evaluateObjectInstance(ObjectOp op, ArrayRef<EvaluatorValuePtr> actualParams);
+  evaluateObjectInstance(ObjectOp op, ActualParameters actualParams);
   FailureOr<EvaluatorValuePtr>
-  evaluateObjectField(ObjectFieldOp op,
-                      ArrayRef<EvaluatorValuePtr> actualParams);
+  evaluateObjectField(ObjectFieldOp op, ActualParameters actualParams);
   FailureOr<EvaluatorValuePtr>
-  evaluateListCreate(ListCreateOp op, ArrayRef<EvaluatorValuePtr> actualParams);
+  evaluateListCreate(ListCreateOp op, ActualParameters actualParams);
   FailureOr<EvaluatorValuePtr>
-  evaluateTupleCreate(TupleCreateOp op,
-                      ArrayRef<EvaluatorValuePtr> actualParams);
-  FailureOr<EvaluatorValuePtr>
-  evaluateTupleGet(TupleGetOp op, ArrayRef<EvaluatorValuePtr> actualParams);
+  evaluateTupleCreate(TupleCreateOp op, ActualParameters actualParams);
+  FailureOr<EvaluatorValuePtr> evaluateTupleGet(TupleGetOp op,
+                                                ActualParameters actualParams);
   FailureOr<evaluator::EvaluatorValuePtr>
-  evaluateMapCreate(MapCreateOp op,
-                    ArrayRef<evaluator::EvaluatorValuePtr> actualParams);
+  evaluateMapCreate(MapCreateOp op, ActualParameters actualParams);
+
+  FailureOr<ActualParameters>
+  createParametersFromOperands(ValueRange range, ActualParameters actualParams);
 
   /// The symbol table for the IR module the Evaluator was constructed with.
   /// Used to look up class definitions.
   SymbolTable symbolTable;
 
-  /// Object storage. Currently used for memoizing calls to
-  /// evaluateObjectInstance. Further refinement is expected.
-  DenseMap<Value, std::shared_ptr<evaluator::EvaluatorValue>> objects;
+  /// This stores a
+  SmallVector<
+      std::unique_ptr<SmallVector<std::shared_ptr<evaluator::EvaluatorValue>>>>
+      actualParametersBuffers;
+
+  /// A worklist that tracks values which needs to be fully evaluated.
+  std::queue<Key> worklist;
+
+  /// Evaluator value storage. Return an evaluator value for the given
+  /// instantiation context (a pair of Value and parameters).
+  DenseMap<Key, std::shared_ptr<evaluator::EvaluatorValue>> objects;
 };
 
 /// Helper to enable printing objects in Diagnostics.

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -185,3 +185,7 @@ for field_name, data in obj:
   if isinstance(data, om.Object):
     object_dict[data] = field_name
 assert len(object_dict) == 2
+
+obj = evaluator.instantiate("Test", 41)
+# CHECK: 41
+print(obj.field)

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -108,8 +108,7 @@ OMEvaluatorValue omEvaluatorInstantiate(OMEvaluator evaluator,
     cppActualParams.push_back(unwrap(actualParams[i]));
 
   // Invoke the Evaluator to instantiate the Object.
-  FailureOr<std::shared_ptr<evaluator::ObjectValue>> result =
-      cppEvaluator->instantiate(cppClassName, cppActualParams);
+  auto result = cppEvaluator->instantiate(cppClassName, cppActualParams);
 
   // If instantiation failed, return a null Object. A Diagnostic will be emitted
   // in this case.

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -14,6 +14,9 @@
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/SymbolTable.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "om-evaluator"
 
 using namespace mlir;
 using namespace circt::om;
@@ -36,10 +39,126 @@ circt::om::getEvaluatorValuesFromAttributes(MLIRContext *context,
   return values;
 }
 
-/// Instantiate an Object with its class name and actual parameters.
-FailureOr<std::shared_ptr<evaluator::ObjectValue>>
-circt::om::Evaluator::instantiate(
-    StringAttr className, ArrayRef<evaluator::EvaluatorValuePtr> actualParams) {
+LogicalResult circt::om::evaluator::EvaluatorValue::finalize() {
+  using namespace evaluator;
+  // Early return if already finalized.
+  if (finalized)
+    return success();
+  // Enable the flag to avoid infinite recursions.
+  finalized = true;
+  assert(isFullyEvaluated());
+  return llvm::TypeSwitch<EvaluatorValue *, LogicalResult>(this)
+      .Case<AttributeValue, ObjectValue, ListValue, MapValue, ReferenceValue,
+            TupleValue>([](auto v) { return v->finalizeImpl(); });
+}
+
+Type circt::om::evaluator::EvaluatorValue::getType() const {
+  Type actualParamType;
+  if (auto *attr = dyn_cast<evaluator::AttributeValue>(this)) {
+    if (auto typedActualParam = attr->getAttr().dyn_cast_or_null<TypedAttr>())
+      actualParamType = typedActualParam.getType();
+  } else if (auto *object = dyn_cast<evaluator::ObjectValue>(this))
+    actualParamType = object->getObjectType();
+  else if (auto *list = dyn_cast<evaluator::ListValue>(this))
+    actualParamType = list->getListType();
+  else if (auto *tuple = dyn_cast<evaluator::TupleValue>(this))
+    actualParamType = tuple->getTupleType();
+  else if (auto *map = dyn_cast<evaluator::MapValue>(this))
+    actualParamType = map->getMapType();
+  else if (auto *ref = dyn_cast<evaluator::ReferenceValue>(this))
+    actualParamType = ref->getValueType();
+
+  return actualParamType;
+}
+
+FailureOr<evaluator::EvaluatorValuePtr>
+circt::om::Evaluator::getPartiallyEvaluatedValue(Type type) {
+  using namespace circt::om::evaluator;
+
+  return TypeSwitch<mlir::Type, FailureOr<evaluator::EvaluatorValuePtr>>(type)
+      .Case([&](circt::om::MapType type) {
+        evaluator::EvaluatorValuePtr result =
+            std::make_shared<evaluator::MapValue>(type);
+        return success(result);
+      })
+      .Case([&](circt::om::ListType type) {
+        evaluator::EvaluatorValuePtr result =
+            std::make_shared<evaluator::ListValue>(type);
+        return success(result);
+      })
+      .Case([&](mlir::TupleType type) {
+        evaluator::EvaluatorValuePtr result =
+            std::make_shared<evaluator::TupleValue>(type);
+        return success(result);
+      })
+
+      .Case([&](circt::om::ClassType type)
+                -> FailureOr<evaluator::EvaluatorValuePtr> {
+        ClassOp cls =
+            symbolTable.lookup<ClassOp>(type.getClassName().getValue());
+        if (!cls)
+          return symbolTable.getOp()->emitError("unknown class name ")
+                 << type.getClassName();
+
+        evaluator::EvaluatorValuePtr result =
+            std::make_shared<evaluator::ObjectValue>(cls);
+
+        return success(result);
+      })
+      .Default([&](auto type) { return failure(); });
+}
+
+FailureOr<evaluator::EvaluatorValuePtr>
+circt::om::Evaluator::getOrCreateValue(Value value,
+                                       ActualParameters actualParams) {
+  auto it = objects.find({value, actualParams});
+  if (it != objects.end())
+    return it->second;
+
+  FailureOr<evaluator::EvaluatorValuePtr> result =
+      TypeSwitch<Value, FailureOr<evaluator::EvaluatorValuePtr>>(value)
+          .Case([&](BlockArgument arg) {
+            return (*actualParams)[arg.getArgNumber()];
+          })
+          .Case([&](OpResult result) {
+            return TypeSwitch<Operation *,
+                              FailureOr<evaluator::EvaluatorValuePtr>>(
+                       result.getDefiningOp())
+                .Case([&](ConstantOp op) {
+                  return evaluateConstant(op, actualParams);
+                })
+                .Case<ObjectFieldOp>([&](auto op) {
+                  // Create a reference value since the value pointed by object
+                  // field op is not created yet.
+                  evaluator::EvaluatorValuePtr result =
+                      std::make_shared<evaluator::ReferenceValue>(
+                          value.getType());
+                  return success(result);
+                })
+                .Case<AnyCastOp>([&](AnyCastOp op) {
+                  return getOrCreateValue(op.getInput(), actualParams);
+                })
+                .Case<ListCreateOp, TupleCreateOp, MapCreateOp, ObjectFieldOp,
+                      ObjectOp>([&](auto op) {
+                  return getPartiallyEvaluatedValue(op.getType());
+                })
+                .Default([&](Operation *op) {
+                  auto error = op->emitError("unable to evaluate value");
+                  error.attachNote() << "value: " << value;
+                  return error;
+                });
+          });
+  if (failed(result))
+    return result;
+
+  objects[{value, actualParams}] = result.value();
+  return result;
+}
+
+FailureOr<evaluator::EvaluatorValuePtr>
+circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
+                                             ActualParameters actualParams,
+                                             Key instanceKey) {
   ClassOp cls = symbolTable.lookup<ClassOp>(className);
   if (!cls)
     return symbolTable.getOp()->emitError("unknown class name ") << className;
@@ -48,14 +167,14 @@ circt::om::Evaluator::instantiate(
   auto formalParamTypes = cls.getBodyBlock()->getArgumentTypes();
 
   // Verify the actual parameters are the right size and types for this class.
-  if (actualParams.size() != formalParamTypes.size()) {
+  if (actualParams->size() != formalParamTypes.size()) {
     auto error = cls.emitError("actual parameter list length (")
-                 << actualParams.size() << ") does not match formal "
+                 << actualParams->size() << ") does not match formal "
                  << "parameter list length (" << formalParamTypes.size() << ")";
     auto &diag = error.attachNote() << "actual parameters: ";
     // FIXME: `diag << actualParams` doesn't work for some reason.
     bool isFirst = true;
-    for (const auto &param : actualParams) {
+    for (const auto &param : *actualParams) {
       if (isFirst)
         isFirst = false;
       else
@@ -68,7 +187,7 @@ circt::om::Evaluator::instantiate(
 
   // Verify the actual parameter types match.
   for (auto [actualParam, formalParamName, formalParamType] :
-       llvm::zip(actualParams, formalParamNames, formalParamTypes)) {
+       llvm::zip(*actualParams, formalParamNames, formalParamTypes)) {
     if (!actualParam || !actualParam.get())
       return cls.emitError("actual parameter for ")
              << formalParamName << " is null";
@@ -77,17 +196,7 @@ circt::om::Evaluator::instantiate(
     if (isa<AnyType>(formalParamType))
       continue;
 
-    Type actualParamType;
-    if (auto *attr = dyn_cast<evaluator::AttributeValue>(actualParam.get())) {
-      if (auto typedActualParam = attr->getAttr().dyn_cast_or_null<TypedAttr>())
-        actualParamType = typedActualParam.getType();
-    } else if (auto *object =
-                   dyn_cast<evaluator::ObjectValue>(actualParam.get()))
-      actualParamType = object->getType();
-    else if (auto *list = dyn_cast<evaluator::ListValue>(actualParam.get()))
-      actualParamType = list->getType();
-    else if (auto *tuple = dyn_cast<evaluator::TupleValue>(actualParam.get()))
-      actualParamType = tuple->getType();
+    Type actualParamType = actualParam->getType();
 
     assert(actualParamType && "actualParamType must be non-null!");
 
@@ -102,30 +211,97 @@ circt::om::Evaluator::instantiate(
 
   // Instantiate the fields.
   evaluator::ObjectFields fields;
+
+  for (auto &op : cls.getOps())
+    for (auto result : op.getResults()) {
+      // Allocate the value.
+      if (failed(getOrCreateValue(result, actualParams)))
+        return failure();
+      // Add to the worklist.
+      worklist.push({result, actualParams});
+    }
+
   for (auto field : cls.getOps<ClassFieldOp>()) {
     StringAttr name = field.getSymNameAttr();
     Value value = field.getValue();
-
     FailureOr<evaluator::EvaluatorValuePtr> result =
         evaluateValue(value, actualParams);
     if (failed(result))
-      return failure();
+      return result;
 
     fields[name] = result.value();
   }
 
-  // Allocate the Object. Further refinement is expected.
-  auto *object = new evaluator::ObjectValue(cls, fields);
+  // If the there is an instance, we must update the object value.
+  if (instanceKey.first) {
+    auto result =
+        getOrCreateValue(instanceKey.first, instanceKey.second).value();
+    auto *object = llvm::cast<evaluator::ObjectValue>(result.get());
+    object->setFields(std::move(fields));
+    return result;
+  }
 
-  return success(std::shared_ptr<evaluator::ObjectValue>(object));
+  // If it's external call, just allocate new ObjectValue.
+  evaluator::EvaluatorValuePtr result =
+      std::make_shared<evaluator::ObjectValue>(cls, fields);
+  return result;
 }
 
-/// Evaluate a Value in a Class body according to the semantics of the IR. The
-/// actual parameters are the values supplied at the current instantiation of
-/// the Class being evaluated.
-FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateValue(
-    Value value, ArrayRef<evaluator::EvaluatorValuePtr> actualParams) {
-  return TypeSwitch<Value, FailureOr<evaluator::EvaluatorValuePtr>>(value)
+/// Instantiate an Object with its class name and actual parameters.
+FailureOr<std::shared_ptr<evaluator::EvaluatorValue>>
+circt::om::Evaluator::instantiate(
+    StringAttr className, ArrayRef<evaluator::EvaluatorValuePtr> actualParams) {
+  ClassOp cls = symbolTable.lookup<ClassOp>(className);
+  if (!cls)
+    return symbolTable.getOp()->emitError("unknown class name ") << className;
+
+  auto parameters =
+      std::make_unique<SmallVector<std::shared_ptr<evaluator::EvaluatorValue>>>(
+          actualParams);
+
+  actualParametersBuffers.push_back(std::move(parameters));
+
+  auto result =
+      evaluateObjectInstance(className, actualParametersBuffers.back().get());
+
+  if (failed(result))
+    return failure();
+
+  //  evaluateObjectInstance` has populated the worklist. Continue evaluations
+  //  unless there is a partially evaluated value.
+  while (!worklist.empty()) {
+    auto [value, args] = worklist.front();
+    worklist.pop();
+
+    auto result = evaluateValue(value, args);
+
+    if (failed(result))
+      return failure();
+
+    // It's possible that the value is not fully evaluated.
+    if (!result.value()->isFullyEvaluated())
+      worklist.push({value, args});
+  }
+
+  auto &object = result.value();
+  // Finalize the value. This will eliminate intermidiate ReferenceValue used as
+  // a placeholder in the initialization.
+  if (failed(object->finalize()))
+    return cls.emitError() << "failed to finalize evaluation. Probably the "
+                              "class contains a dataflow cycle";
+  return object;
+}
+
+FailureOr<evaluator::EvaluatorValuePtr>
+circt::om::Evaluator::evaluateValue(Value value,
+                                    ActualParameters actualParams) {
+  auto evaluatorValue = getOrCreateValue(value, actualParams).value();
+
+  // Return if the value is already evaluated.
+  if (evaluatorValue->isFullyEvaluated())
+    return evaluatorValue;
+
+  return llvm::TypeSwitch<Value, FailureOr<evaluator::EvaluatorValuePtr>>(value)
       .Case([&](BlockArgument arg) {
         return evaluateParameter(arg, actualParams);
       })
@@ -150,11 +326,11 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateValue(
             .Case([&](TupleGetOp op) {
               return evaluateTupleGet(op, actualParams);
             })
-            .Case([&](MapCreateOp op) {
-              return evaluateMapCreate(op, actualParams);
-            })
             .Case([&](AnyCastOp op) {
               return evaluateValue(op.getInput(), actualParams);
+            })
+            .Case([&](MapCreateOp op) {
+              return evaluateMapCreate(op, actualParams);
             })
             .Default([&](Operation *op) {
               auto error = op->emitError("unable to evaluate value");
@@ -165,53 +341,58 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateValue(
 }
 
 /// Evaluator dispatch function for parameters.
-FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateParameter(
-    BlockArgument formalParam,
-    ArrayRef<evaluator::EvaluatorValuePtr> actualParams) {
-  return success(actualParams[formalParam.getArgNumber()]);
+FailureOr<evaluator::EvaluatorValuePtr>
+circt::om::Evaluator::evaluateParameter(BlockArgument formalParam,
+                                        ActualParameters actualParams) {
+  return success((*actualParams)[formalParam.getArgNumber()]);
 }
 
 /// Evaluator dispatch function for constants.
 FailureOr<circt::om::evaluator::EvaluatorValuePtr>
-circt::om::Evaluator::evaluateConstant(
-    ConstantOp op,
-    ArrayRef<circt::om::evaluator::EvaluatorValuePtr> actualParams) {
+circt::om::Evaluator::evaluateConstant(ConstantOp op,
+                                       ActualParameters actualParams) {
   return success(
       std::make_shared<circt::om::evaluator::AttributeValue>(op.getValue()));
 }
 
 /// Evaluator dispatch function for Object instances.
-FailureOr<evaluator::EvaluatorValuePtr>
-circt::om::Evaluator::evaluateObjectInstance(
-    ObjectOp op, ArrayRef<evaluator::EvaluatorValuePtr> actualParams) {
-  // First, check if we have already evaluated this object, and return it if so.
-  auto existingInstance = objects.find(op);
-  if (existingInstance != objects.end())
-    return success(existingInstance->second);
+FailureOr<circt::om::Evaluator::ActualParameters>
+circt::om::Evaluator::createParametersFromOperands(
+    ValueRange range, ActualParameters actualParams) {
+  // Create an unique storage to store parameters.
+  auto parameters = std::make_unique<
+      SmallVector<std::shared_ptr<evaluator::EvaluatorValue>>>();
 
-  // If we need to instantiate a new object, evaluate values for all of its
-  // actual parameters. Note that this is eager evaluation, which precludes
-  // creating cycles in the object model. Further refinement is expected.
-  SmallVector<evaluator::EvaluatorValuePtr> objectParams;
-  for (auto param : op.getActualParams()) {
-    FailureOr<evaluator::EvaluatorValuePtr> result =
-        evaluateValue(param, actualParams);
-    if (failed(result))
-      return result;
-    objectParams.push_back(result.value());
+  // Collect operands' evaluator values in the current instantiation context.
+  for (auto input : range) {
+    auto inputResult = getOrCreateValue(input, actualParams);
+    if (failed(inputResult))
+      return failure();
+    parameters->push_back(inputResult.value());
   }
 
-  // Instantiate and return the new Object, saving the instance for later.
-  auto newInstance = instantiate(op.getClassNameAttr(), objectParams);
-  if (succeeded(newInstance))
-    objects[op.getResult()] = newInstance.value();
-  return newInstance;
+  actualParametersBuffers.push_back(std::move(parameters));
+  return actualParametersBuffers.back().get();
+}
+
+/// Evaluator dispatch function for Object instances.
+FailureOr<evaluator::EvaluatorValuePtr>
+circt::om::Evaluator::evaluateObjectInstance(ObjectOp op,
+                                             ActualParameters actualParams) {
+  if (isFullyEvaluated({op, actualParams}))
+    return getOrCreateValue(op, actualParams);
+
+  auto params = createParametersFromOperands(op.getOperands(), actualParams);
+  if (failed(params))
+    return failure();
+  return evaluateObjectInstance(op.getClassNameAttr(), params.value(),
+                                {op, actualParams});
 }
 
 /// Evaluator dispatch function for Object fields.
 FailureOr<evaluator::EvaluatorValuePtr>
-circt::om::Evaluator::evaluateObjectField(
-    ObjectFieldOp op, ArrayRef<evaluator::EvaluatorValuePtr> actualParams) {
+circt::om::Evaluator::evaluateObjectField(ObjectFieldOp op,
+                                          ActualParameters actualParams) {
   // Evaluate the Object itself, in case it hasn't been evaluated yet.
   FailureOr<evaluator::EvaluatorValuePtr> currentObjectResult =
       evaluateValue(op.getObject(), actualParams);
@@ -221,10 +402,16 @@ circt::om::Evaluator::evaluateObjectField(
   auto *currentObject =
       llvm::cast<evaluator::ObjectValue>(currentObjectResult.value().get());
 
+  auto objectFieldValue = getOrCreateValue(op, actualParams).value();
+
   // Iteratively access nested fields through the path until we reach the final
   // field in the path.
   evaluator::EvaluatorValuePtr finalField;
   for (auto field : op.getFieldPath().getAsRange<FlatSymbolRefAttr>()) {
+    // `currentObject` might no be fully evaluated.
+    if (!currentObject->getFields().contains(field.getAttr()))
+      return objectFieldValue;
+
     auto currentField = currentObject->getField(field.getAttr());
     finalField = currentField.value();
     if (auto *nextObject =
@@ -232,33 +419,40 @@ circt::om::Evaluator::evaluateObjectField(
       currentObject = nextObject;
   }
 
+  // Update the reference.
+  llvm::cast<evaluator::ReferenceValue>(objectFieldValue.get())
+      ->setValue(finalField);
+
   // Return the field being accessed.
-  return finalField;
+  return objectFieldValue;
 }
 
 /// Evaluator dispatch function for List creation.
 FailureOr<evaluator::EvaluatorValuePtr>
-circt::om::Evaluator::evaluateListCreate(
-    ListCreateOp op, ArrayRef<evaluator::EvaluatorValuePtr> actualParams) {
+circt::om::Evaluator::evaluateListCreate(ListCreateOp op,
+                                         ActualParameters actualParams) {
   // Evaluate the Object itself, in case it hasn't been evaluated yet.
   SmallVector<evaluator::EvaluatorValuePtr> values;
+  auto list = getOrCreateValue(op, actualParams);
   for (auto operand : op.getOperands()) {
     auto result = evaluateValue(operand, actualParams);
     if (failed(result))
       return result;
+    if (!result.value()->isFullyEvaluated())
+      return list;
     values.push_back(result.value());
   }
 
   // Return the list.
-  evaluator::EvaluatorValuePtr result =
-      std::make_shared<evaluator::ListValue>(op.getType(), std::move(values));
-  return result;
+  llvm::cast<evaluator::ListValue>(list.value().get())
+      ->setElements(std::move(values));
+  return list;
 }
 
 /// Evaluator dispatch function for Tuple creation.
 FailureOr<evaluator::EvaluatorValuePtr>
-circt::om::Evaluator::evaluateTupleCreate(
-    TupleCreateOp op, ArrayRef<evaluator::EvaluatorValuePtr> actualParams) {
+circt::om::Evaluator::evaluateTupleCreate(TupleCreateOp op,
+                                          ActualParameters actualParams) {
   SmallVector<evaluator::EvaluatorValuePtr> values;
   for (auto operand : op.getOperands()) {
     auto result = evaluateValue(operand, actualParams);
@@ -268,15 +462,16 @@ circt::om::Evaluator::evaluateTupleCreate(
   }
 
   // Return the tuple.
-  evaluator::EvaluatorValuePtr result = std::make_shared<evaluator::TupleValue>(
-      op.getType().cast<mlir::TupleType>(), std::move(values));
-
-  return result;
+  auto val = getOrCreateValue(op, actualParams);
+  llvm::cast<evaluator::TupleValue>(val.value().get())
+      ->setElements(std::move(values));
+  return val;
 }
 
 /// Evaluator dispatch function for List creation.
-FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateTupleGet(
-    TupleGetOp op, ArrayRef<evaluator::EvaluatorValuePtr> actualParams) {
+FailureOr<evaluator::EvaluatorValuePtr>
+circt::om::Evaluator::evaluateTupleGet(TupleGetOp op,
+                                       ActualParameters actualParams) {
   auto tuple = evaluateValue(op.getInput(), actualParams);
   if (failed(tuple))
     return tuple;
@@ -287,16 +482,20 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateTupleGet(
 }
 
 /// Evaluator dispatch function for Map creation.
-FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateMapCreate(
-    MapCreateOp op, ArrayRef<evaluator::EvaluatorValuePtr> actualParams) {
+FailureOr<evaluator::EvaluatorValuePtr>
+circt::om::Evaluator::evaluateMapCreate(MapCreateOp op,
+                                        ActualParameters actualParams) {
   // Evaluate the Object itself, in case it hasn't been evaluated yet.
   DenseMap<Attribute, evaluator::EvaluatorValuePtr> elements;
+  auto valueResult = getOrCreateValue(op, actualParams).value();
   for (auto operand : op.getOperands()) {
     auto result = evaluateValue(operand, actualParams);
     if (failed(result))
       return result;
     // The result is a tuple.
     auto &value = result.value();
+    if (!value->isFullyEvaluated())
+      return valueResult;
     const auto &element =
         llvm::cast<evaluator::TupleValue>(value.get())->getElements();
     assert(element.size() == 2);
@@ -307,10 +506,14 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::evaluateMapCreate(
   }
 
   // Return the Map.
-  evaluator::EvaluatorValuePtr result =
-      std::make_shared<evaluator::MapValue>(op.getType(), std::move(elements));
-  return result;
+  llvm::cast<evaluator::MapValue>(valueResult.get())
+      ->setElements(std::move(elements));
+  return valueResult;
 }
+
+//===----------------------------------------------------------------------===//
+// ObjectValue
+//===----------------------------------------------------------------------===//
 
 /// Get a field of the Object by name.
 FailureOr<EvaluatorValuePtr>
@@ -335,6 +538,18 @@ ArrayAttr circt::om::Object::getFieldNames() {
   return ArrayAttr::get(cls.getContext(), fieldNames);
 }
 
+LogicalResult circt::om::evaluator::ObjectValue::finalizeImpl() {
+  for (auto &&[e, value] : fields)
+    if (failed(finalizeEvaluatorValue(value)))
+      return failure();
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// MapValue
+//===----------------------------------------------------------------------===//
+
 /// Return an array of keys in the ascending order.
 ArrayAttr circt::om::evaluator::MapValue::getKeys() {
   SmallVector<Attribute> attrs;
@@ -352,4 +567,35 @@ ArrayAttr circt::om::evaluator::MapValue::getKeys() {
   });
 
   return ArrayAttr::get(type.getContext(), attrs);
+}
+
+LogicalResult circt::om::evaluator::MapValue::finalizeImpl() {
+  for (auto &&[e, value] : elements)
+    if (failed(finalizeEvaluatorValue(value)))
+      return failure();
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ReferenceValue
+//===----------------------------------------------------------------------===//
+
+LogicalResult circt::om::evaluator::ReferenceValue::finalizeImpl() {
+  auto result = getStrippedValue();
+  if (failed(result))
+    return result;
+  value = std::move(result.value());
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ListValue
+//===----------------------------------------------------------------------===//
+
+LogicalResult circt::om::evaluator::ListValue::finalizeImpl() {
+  for (auto &value : elements) {
+    if (failed(finalizeEvaluatorValue(value)))
+      return failure();
+  }
+  return success();
 }

--- a/unittests/Dialect/OM/Evaluator/CMakeLists.txt
+++ b/unittests/Dialect/OM/Evaluator/CMakeLists.txt
@@ -7,4 +7,5 @@ target_link_libraries(CIRCTOMEvaluatorTests
   CIRCTOMEvaluator
   CIRCTOM
   MLIRIR
+  MLIRParser
 )

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -356,6 +356,16 @@ TEST(EvaluatorTests, InstantiateObjectWithFieldAccess) {
           &context, builder.getI32IntegerAttr(42)))});
 
   ASSERT_TRUE(succeeded(result));
+
+  auto fieldValue = llvm::cast<evaluator::AttributeValue>(
+                        llvm::cast<evaluator::ObjectValue>(result.value().get())
+                            ->getField(builder.getStringAttr("field"))
+                            .value()
+                            .get())
+                        ->getAs<circt::om::IntegerAttr>();
+
+  ASSERT_TRUE(fieldValue);
+  ASSERT_EQ(fieldValue.getValue().getValue(), 42);
 }
 
 TEST(EvaluatorTests, InstantiateObjectWithChildObjectMemoized) {

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -15,6 +15,7 @@
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/Location.h"
+#include "mlir/Parser/Parser.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
@@ -177,7 +178,8 @@ TEST(EvaluatorTests, GetFieldInvalidName) {
 
   ASSERT_TRUE(succeeded(result));
 
-  auto fieldValue = result.value()->getField(builder.getStringAttr("foo"));
+  auto fieldValue = llvm::cast<evaluator::ObjectValue>(result.value().get())
+                        ->getField(builder.getStringAttr("foo"));
 
   ASSERT_FALSE(succeeded(fieldValue));
 }
@@ -214,7 +216,7 @@ TEST(EvaluatorTests, InstantiateObjectWithParamField) {
   ASSERT_TRUE(succeeded(result));
 
   auto fieldValue = llvm::cast<evaluator::AttributeValue>(
-                        result.value()
+                        llvm::cast<evaluator::ObjectValue>(result.value().get())
                             ->getField(builder.getStringAttr("field"))
                             .value()
                             .get())
@@ -252,7 +254,7 @@ TEST(EvaluatorTests, InstantiateObjectWithConstantField) {
   ASSERT_TRUE(succeeded(result));
 
   auto fieldValue = cast<evaluator::AttributeValue>(
-                        result.value()
+                        llvm::cast<evaluator::ObjectValue>(result.value().get())
                             ->getField(builder.getStringAttr("field"))
                             .value()
                             .get())
@@ -299,7 +301,10 @@ TEST(EvaluatorTests, InstantiateObjectWithChildObject) {
   ASSERT_TRUE(succeeded(result));
 
   auto *fieldValue = llvm::cast<evaluator::ObjectValue>(
-      result.value()->getField(builder.getStringAttr("field")).value().get());
+      llvm::cast<evaluator::ObjectValue>(result.value().get())
+          ->getField(builder.getStringAttr("field"))
+          .value()
+          .get());
 
   ASSERT_TRUE(fieldValue);
 
@@ -351,16 +356,6 @@ TEST(EvaluatorTests, InstantiateObjectWithFieldAccess) {
           &context, builder.getI32IntegerAttr(42)))});
 
   ASSERT_TRUE(succeeded(result));
-
-  auto fieldValue = llvm::cast<evaluator::AttributeValue>(
-                        result.value()
-                            ->getField(builder.getStringAttr("field"))
-                            .value()
-                            .get())
-                        ->getAs<circt::om::IntegerAttr>();
-
-  ASSERT_TRUE(fieldValue);
-  ASSERT_EQ(fieldValue.getValue().getValue(), 42);
 }
 
 TEST(EvaluatorTests, InstantiateObjectWithChildObjectMemoized) {
@@ -395,12 +390,19 @@ TEST(EvaluatorTests, InstantiateObjectWithChildObjectMemoized) {
   ASSERT_TRUE(succeeded(result));
 
   auto *field1Value = llvm::cast<evaluator::ObjectValue>(
-      result.value()->getField(builder.getStringAttr("field1")).value().get());
+      llvm::cast<evaluator::ObjectValue>(result.value().get())
+          ->getField(builder.getStringAttr("field1"))
+          .value()
+          .get());
 
   auto *field2Value = llvm::cast<evaluator::ObjectValue>(
-      result.value()->getField(builder.getStringAttr("field2")).value().get());
+      llvm::cast<evaluator::ObjectValue>(result.value().get())
+          ->getField(builder.getStringAttr("field2"))
+          .value()
+          .get());
 
-  auto fieldNames = result.value()->getFieldNames();
+  auto fieldNames =
+      llvm::cast<evaluator::ObjectValue>(result.value().get())->getFieldNames();
 
   ASSERT_TRUE(fieldNames.size() == 2);
   StringRef fieldNamesTruth[] = {"field1", "field2"};
@@ -448,7 +450,10 @@ TEST(EvaluatorTests, AnyCastObject) {
   ASSERT_TRUE(succeeded(result));
 
   auto *fieldValue = llvm::cast<evaluator::ObjectValue>(
-      result.value()->getField(builder.getStringAttr("field")).value().get());
+      llvm::cast<evaluator::ObjectValue>(result.value().get())
+          ->getField(builder.getStringAttr("field"))
+          .value()
+          .get());
 
   ASSERT_TRUE(fieldValue);
 
@@ -495,7 +500,10 @@ TEST(EvaluatorTests, AnyCastParam) {
   ASSERT_TRUE(succeeded(result));
 
   auto *fieldValue = llvm::cast<evaluator::ObjectValue>(
-      result.value()->getField(builder.getStringAttr("field")).value().get());
+      llvm::cast<evaluator::ObjectValue>(result.value().get())
+          ->getField(builder.getStringAttr("field"))
+          .value()
+          .get());
 
   ASSERT_TRUE(fieldValue);
 
@@ -503,6 +511,96 @@ TEST(EvaluatorTests, AnyCastParam) {
       fieldValue->getField(builder.getStringAttr("field")).value().get());
 
   ASSERT_EQ(innerFieldValue->getAs<mlir::IntegerAttr>().getValue(), 42);
+}
+
+TEST(EvaluatorTests, InstantiateGraphRegion) {
+  StringRef module =
+      "!ty = !om.class.type<@LinkedList>"
+      "om.class @LinkedList(%n: !ty, %val: !om.string) {"
+      "  om.class.field @n, %n : !ty"
+      "  om.class.field @val, %val : !om.string"
+      "}"
+      "om.class @ReferenceEachOther() {"
+      "  %str = om.constant \"foo\" : !om.string"
+      "  %val = om.object.field %1, [@n, @n, @val] : (!ty) -> !om.string"
+      "  %0 = om.object @LinkedList(%1, %val) : (!ty, !om.string) -> !ty"
+      "  %1 = om.object @LinkedList(%0, %str) : (!ty, !om.string) -> !ty"
+      "  om.class.field @field1, %0 : !ty"
+      "  om.class.field @field2, %1 : !ty"
+      "}";
+
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  OwningOpRef<ModuleOp> owning =
+      parseSourceString<ModuleOp>(module, ParserConfig(&context));
+
+  Evaluator evaluator(owning.release());
+
+  auto result = evaluator.instantiate(
+      StringAttr::get(&context, "ReferenceEachOther"), {});
+
+  ASSERT_TRUE(succeeded(result));
+
+  auto *field1 = llvm::cast<evaluator::ObjectValue>(result.value().get())
+                     ->getField("field1")
+                     .value()
+                     .get();
+  auto *field2 = llvm::cast<evaluator::ObjectValue>(result.value().get())
+                     ->getField("field2")
+                     .value()
+                     .get();
+
+  ASSERT_EQ(
+      field1,
+      llvm::cast<evaluator::ObjectValue>(field2)->getField("n").value().get());
+  ASSERT_EQ(
+      field2,
+      llvm::cast<evaluator::ObjectValue>(field1)->getField("n").value().get());
+
+  ASSERT_EQ("foo", llvm::cast<evaluator::AttributeValue>(
+                       llvm::cast<evaluator::ObjectValue>(field1)
+                           ->getField("val")
+                           .value()
+                           .get())
+                       ->getAs<StringAttr>()
+                       .getValue());
+}
+
+TEST(EvaluatorTests, InstantiateCycle) {
+  StringRef module = "!ty = !om.class.type<@LinkedList>"
+                     "om.class @LinkedList(%n: !ty) {"
+                     "  om.class.field @n, %n : !ty"
+                     "}"
+                     "om.class @ReferenceEachOther() {"
+                     "  %val = om.object.field %0, [@n] : (!ty) -> !ty"
+                     "  %0 = om.object @LinkedList(%val) : (!ty) -> !ty"
+                     "  om.class.field @field, %0 : !ty"
+                     "}";
+
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  context.getDiagEngine().registerHandler([&](Diagnostic &diag) {
+    ASSERT_EQ(diag.str(), "failed to finalize evaluation. Probably the class "
+                          "contains a dataflow cycle");
+  });
+
+  OwningOpRef<ModuleOp> owning =
+      parseSourceString<ModuleOp>(module, ParserConfig(&context));
+
+  Evaluator evaluator(owning.release());
+
+  auto result = evaluator.instantiate(
+      StringAttr::get(&context, "ReferenceEachOther"), {});
+
+  ASSERT_TRUE(failed(result));
 }
 
 } // namespace


### PR DESCRIPTION
This commit adds support for graph regions for evaluator.

`ReferenceValue`, a new subclass of `EvaluatorValue`, is added to behave as pointers. `ReferenceValue` can be used as alias to different values and is created for `class.object.field` operation because `class.object.field` can access fields across class hierarchies and the fields might not be initilized yet. `RefenceValue` is not exposed to outside of evaluator implemenation. `EvaluatorValue::finalize` shrinks intermidiate `RefenceValue` in the evaluator value.

Evaluation algorithm is changed to worklist-based iteration. `instantiae` method first traverses the whole IR including sub-class, and create partially evaluaed values for all values and add these values to the worklist. After that we evaluate values until there is no partially evaluaed value.

Fix https://github.com/llvm/circt/issues/5834