### PR TITLE
[OM] Add more path types

### DIFF
--- a/include/circt/Dialect/OM/OMTypes.td
+++ b/include/circt/Dialect/OM/OMTypes.td
@@ -88,10 +88,24 @@ def StringType : TypeDef<OMDialect, "String", []> {
   let mnemonic = "string";
 }
 
+def BasePathType : TypeDef<OMDialect, "BasePath", []> {
+  let summary = "A fragment of a path to a hardware component";
+  let mnemonic = "basepath";
+}
+
 def PathType : TypeDef<OMDialect, "Path", []> {
   let summary = "A path to a hardware component";
-
   let mnemonic = "path";
+}
+
+def FrozenBasePathType : TypeDef<OMDialect, "FrozenBasePath", []> {
+  let summary = "A fragment of a path to a hardware component";
+  let mnemonic = "frozenbasepath";
+}
+
+def FrozenPathType : TypeDef<OMDialect, "FrozenPath", []> {
+  let summary = "A path to a hardware component";
+  let mnemonic = "frozenpath";
 }
 
 def EnumType : TypeDef<OMDialect, "Enum", []> {

--- a/include/circt/Dialect/OM/OMTypes.td
+++ b/include/circt/Dialect/OM/OMTypes.td
@@ -99,12 +99,12 @@ def PathType : TypeDef<OMDialect, "Path", []> {
 }
 
 def FrozenBasePathType : TypeDef<OMDialect, "FrozenBasePath", []> {
-  let summary = "A fragment of a path to a hardware component";
+  let summary = "A frozen fragment of a path to a hardware component";
   let mnemonic = "frozenbasepath";
 }
 
 def FrozenPathType : TypeDef<OMDialect, "FrozenPath", []> {
-  let summary = "A path to a hardware component";
+  let summary = "A frozen path to a hardware component";
   let mnemonic = "frozenpath";
 }
 


### PR DESCRIPTION
This adds more path types which will be used for greater safety in OMIR. This change splits regular paths in to BasePathType and PathType, where the BasePathType is only capable of representing paths through the instance hierarchy, without being able to target hardware components such as wires and registers. In the future, all paths can only be created relative to some base path. This also adds a FrozenBasePathType and FrozenPathType, which will be used to represent lowered paths which no longer depend on the hardware hiearchy being present in the IR.
