### PR TITLE
[OM] Add utility for parsing target strings

### DIFF
--- a/include/circt/Dialect/OM/OMAttributes.h
+++ b/include/circt/Dialect/OM/OMAttributes.h
@@ -13,6 +13,29 @@
 #ifndef CIRCT_DIALECT_OM_OMATTRIBUTES_H
 #define CIRCT_DIALECT_OM_OMATTRIBUTES_H
 
+#include "circt/Dialect/OM/OMDialect.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+namespace circt::om {
+
+struct PathElement {
+  PathElement(mlir::StringAttr module, mlir::StringAttr instance)
+      : module(module), instance(instance) {}
+
+  bool operator==(const PathElement &rhs) const {
+    return module == rhs.module && instance == rhs.instance;
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  friend llvm::hash_code hash_value(const PathElement &arg) {
+    return ::llvm::hash_combine(arg.module, arg.instance);
+  }
+
+  mlir::StringAttr module;
+  mlir::StringAttr instance;
+};
+} // namespace circt::om
+
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "mlir/IR/Attributes.h"
 

--- a/include/circt/Dialect/OM/OMUtils.h
+++ b/include/circt/Dialect/OM/OMUtils.h
@@ -1,0 +1,35 @@
+//===- OMUtils.h - OM Utility Functions -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_OM_OMUTILS_H
+#define CIRCT_DIALECT_OM_OMUTILS_H
+
+#include "circt/Support/LLVM.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace circt::om {
+
+struct PathElement;
+class PathAttr;
+
+/// Parse a target string of the form "Foo/bar:Bar/baz" in to a base path.
+ParseResult parseBasePath(MLIRContext *context, StringRef spelling,
+                          PathAttr &path);
+
+/// Parse a target string in to a path.
+/// "Foo/bar:Bar/baz:Baz>wire.a[1]"
+///  |--------------|              Path
+///                  |--|          Module
+///                      |--|      Ref
+///                          |---| Field
+ParseResult parsePath(MLIRContext *context, StringRef spelling, PathAttr &path,
+                      StringAttr &module, StringAttr &ref, StringAttr &field);
+
+} // namespace circt::om
+
+#endif // CIRCT_DIALECT_OM_OMUTILS_H

--- a/lib/Dialect/OM/CMakeLists.txt
+++ b/lib/Dialect/OM/CMakeLists.txt
@@ -14,6 +14,7 @@ add_circt_dialect_library(
   OMOpInterfaces.cpp
   OMOps.cpp
   OMTypes.cpp
+  OMUtils.cpp
 
   DEPENDS
   MLIROMIncGen

--- a/lib/Dialect/OM/OMUtils.cpp
+++ b/lib/Dialect/OM/OMUtils.cpp
@@ -1,0 +1,190 @@
+//===- OMUtils.cpp - OM Utility Functions ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/OM/OMUtils.h"
+#include "circt/Dialect/OM/OMAttributes.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+using namespace circt;
+using namespace om;
+
+namespace {
+struct PathParser {
+  enum class TokenKind {
+    Tilde,
+    Bar,
+    Colon,
+    Greater,
+    Slash,
+    LBrace,
+    RBrace,
+    Period,
+    Id,
+    Error,
+    Eof
+  };
+
+  struct Token {
+    TokenKind kind;
+    StringRef spelling;
+  };
+
+  Token formToken(TokenKind kind, size_t n) {
+    auto s = spelling.take_front(n);
+    spelling = spelling.drop_front(n);
+    return {kind, s};
+  }
+
+  bool isIDChar(char c) {
+    return c != '~' && c != '|' && c != ':' && c != '>' && c != '/' &&
+           c != '[' && c != ']' && c != '.';
+  }
+
+  Token parseToken() {
+    size_t pos = 0;
+    auto size = spelling.size();
+    if (0 == size)
+      return formToken(TokenKind::Eof, pos);
+    auto current = spelling[pos];
+    switch (current) {
+    case '~':
+      return formToken(TokenKind::Tilde, pos + 1);
+    case '|':
+      return formToken(TokenKind::Bar, pos + 1);
+    case ':':
+      return formToken(TokenKind::Colon, pos + 1);
+    case '>':
+      return formToken(TokenKind::Greater, pos + 1);
+    case '/':
+      return formToken(TokenKind::Slash, pos + 1);
+    case '[':
+      return formToken(TokenKind::LBrace, pos + 1);
+    case ']':
+      return formToken(TokenKind::RBrace, pos + 1);
+    case '.':
+      return formToken(TokenKind::Period, pos + 1);
+    default:
+      break;
+    }
+
+    // Parsing a token.
+    while (pos != size && isIDChar(spelling[pos]))
+      ++pos;
+    return formToken(TokenKind::Id, pos);
+  }
+
+  ParseResult parseToken(TokenKind kind, StringRef &result) {
+    auto save = spelling;
+    auto token = parseToken();
+    if (token.kind != kind)
+      return spelling = save, failure();
+    result = token.spelling;
+    return success();
+  }
+
+  ParseResult parseToken(TokenKind kind) {
+    StringRef ignore;
+    return parseToken(kind, ignore);
+  }
+
+  /// basepath ::= eof | id '/' id (':' id '/' id)* eof
+  ParseResult parseBasePath(PathAttr &pathAttr) {
+    llvm::errs() << "!!! parsing a base path\n";
+    llvm::errs() << "!!! spelling " << spelling << "\n";
+    if (succeeded(parseToken(TokenKind::Eof)))
+      return success();
+    SmallVector<PathElement> path;
+    while (true) {
+      StringRef module;
+      StringRef instance;
+      llvm::errs() << "@@@ spelling " << spelling << "\n";
+      if (parseToken(TokenKind::Id, module) || parseToken(TokenKind::Slash) ||
+          parseToken(TokenKind::Id, instance))
+        return failure();
+      llvm::errs() << "@@@ spelling " << spelling << "\n";
+      path.emplace_back(StringAttr::get(context, module),
+                        StringAttr::get(context, instance));
+      if (parseToken(TokenKind::Colon))
+        break;
+    }
+    pathAttr = PathAttr::get(context, path);
+    if (parseToken(TokenKind::Eof))
+      return failure();
+    return success();
+  }
+
+  /// path ::= id ('/' id ':' path | ('>' id ('[' id ']' | '.' id)* )?) eof
+  ParseResult parsePath(PathAttr &pathAttr, StringAttr &moduleAttr,
+                        StringAttr &refAttr, StringAttr &fieldAttr) {
+    SmallVector<PathElement> path;
+    StringRef module;
+    while (true) {
+      if (parseToken(TokenKind::Id, module))
+        return failure();
+      if (parseToken(TokenKind::Slash))
+        break;
+      StringRef instance;
+      if (parseToken(TokenKind::Id, instance) || parseToken(TokenKind::Colon))
+        return failure();
+      path.emplace_back(StringAttr::get(context, module),
+                        StringAttr::get(context, instance));
+    }
+    pathAttr = PathAttr::get(context, path);
+    moduleAttr = StringAttr::get(context, module);
+    if (succeeded(parseToken(TokenKind::Greater))) {
+      StringRef ref;
+      if (parseToken(TokenKind::Id, ref))
+        return failure();
+      refAttr = StringAttr::get(context, ref);
+
+      SmallString<64> field;
+      while (true) {
+        if (succeeded(parseToken(TokenKind::LBrace))) {
+          StringRef id;
+          if (parseToken(TokenKind::Id, id) || parseToken(TokenKind::RBrace))
+            return failure();
+          field += '[';
+          field += id;
+          field += ']';
+        } else if (succeeded(parseToken(TokenKind::Period))) {
+          StringRef id;
+          if (parseToken(TokenKind::Id, id))
+            return failure();
+          field += '.';
+          field += id;
+        } else {
+          break;
+        }
+      }
+      fieldAttr = StringAttr::get(context, field);
+    } else {
+      refAttr = StringAttr::get(context, "");
+      fieldAttr = StringAttr::get(context, "");
+    }
+    if (parseToken(TokenKind::Eof))
+      return failure();
+    return success();
+  }
+
+  MLIRContext *context;
+  StringRef spelling;
+};
+} // namespace
+
+ParseResult circt::om::parseBasePath(MLIRContext *context, StringRef spelling,
+                                     PathAttr &path) {
+  return PathParser{context, spelling}.parseBasePath(path);
+}
+
+ParseResult circt::om::parsePath(MLIRContext *context, StringRef spelling,
+                                 PathAttr &path, StringAttr &module,
+                                 StringAttr &ref, StringAttr &field) {
+  return PathParser{context, spelling}.parsePath(path, module, ref, field);
+}


### PR DESCRIPTION
This adds an OM utility for parsing FIRRTL style target strings, with the intention of using them in the frozen path MLIR assembly format.  The existing APIs contained in FIRRTL were not suitable since these new strings do not include the circuit name, and we need some restrictions for parsing base paths, which can not target components. The new parser is a bit more resilient to badly formed path strings. In the future it may be possible to reunite these two bodies of code.