### PR TITLE
[OM] Overhaul of path operations

### DIFF
--- a/include/circt/Dialect/OM/OMAttributes.h
+++ b/include/circt/Dialect/OM/OMAttributes.h
@@ -13,6 +13,30 @@
 #ifndef CIRCT_DIALECT_OM_OMATTRIBUTES_H
 #define CIRCT_DIALECT_OM_OMATTRIBUTES_H
 
+#include "circt/Dialect/OM/OMDialect.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+namespace circt::om {
+
+/// A module name, and the name of an instance inside that module.
+struct PathElement {
+  PathElement(mlir::StringAttr module, mlir::StringAttr instance)
+      : module(module), instance(instance) {}
+
+  bool operator==(const PathElement &rhs) const {
+    return module == rhs.module && instance == rhs.instance;
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  friend llvm::hash_code hash_value(const PathElement &arg) {
+    return ::llvm::hash_combine(arg.module, arg.instance);
+  }
+
+  mlir::StringAttr module;
+  mlir::StringAttr instance;
+};
+} // namespace circt::om
+
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "mlir/IR/Attributes.h"
 

--- a/include/circt/Dialect/OM/OMAttributes.td
+++ b/include/circt/Dialect/OM/OMAttributes.td
@@ -103,21 +103,20 @@ def MapAttr : AttrDef<OMDialect, "Map", [TypedAttrInterface]> {
   }];
 }
 
-def OMPathAttribute : AttrDef<OMDialect, "Path", [TypedAttrInterface]> {
-  let summary = "An attribute that represents a path";
+def OMPathAttr : AttrDef<OMDialect, "Path"> {
+  let summary = "An attribute that represents an instance path";
 
   let mnemonic = "path";
 
-  let parameters = (ins "::mlir::StringAttr":$path);
+  let parameters = (ins ArrayRefParameter<"::circt::om::PathElement">:$path);
 
-  let builders = [
-    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$path)>
-  ];
+  let genVerifyDecl = 1;
 
-  let assemblyFormat = " `<` $path `>` ";
+  let hasCustomAssemblyFormat = 1;
 
   let extraClassDeclaration = [{
-    mlir::Type getType();
+    auto begin() const { return getPath().begin(); }
+    auto end() const { return getPath().end(); }
   }];
 }
 

--- a/include/circt/Dialect/OM/OMOps.h
+++ b/include/circt/Dialect/OM/OMOps.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_OM_OMOPS_H
 #define CIRCT_DIALECT_OM_OMOPS_H
 
+#include "circt/Dialect/OM/OMAttributes.h"
 #include "circt/Dialect/OM/OMDialect.h"
 #include "circt/Dialect/OM/OMOpInterfaces.h"
 #include "circt/Dialect/OM/OMTypes.h"

--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -297,27 +297,138 @@ def MapCreateOp : OMOp<"map_create", [Pure, SameTypeOperands]> {
   let hasCustomAssemblyFormat = true;
 }
 
-def PathOp : OMOp<"path", [Pure, 
+def BasePathCreateOp : OMOp<"basepath_create", [Pure, 
+      DeclareOpInterfaceMethods<SymbolUserOpInterface>
+    ]> {
+  let summary = "Produce a base path value";
+  let description = [{
+    Produces a value which represents a fragment of a hierarchical path to a
+    target. Given a base path, extend it with the name of a module instance, to
+    produce a new base path. The instance is identified via an NLA. Once the
+    final verilog name of the instance is known, this op can be converted into
+    a FrozenBasePathOp.
+
+    Example:
+    ```mlir
+    hw.module @Foo() -> () {
+      hw.inst "bar" sym @bar @Bar() -> ()
+    }
+    hw.hierpath @Path [@Foo::@bar]
+    om.class @OM(%basepath: !om.basepath) {
+      %0 = om.basepath_create %base @Path
+    }
+    ```
+  }];
+  let arguments = (ins BasePathType:$basePath, FlatSymbolRefAttr:$target);
+  let results = (outs BasePathType:$result);
+  let assemblyFormat = "$basePath $target attr-dict";
+}
+
+def PathCreateOp : OMOp<"path_create", [Pure,
       DeclareOpInterfaceMethods<SymbolUserOpInterface>
     ]> {
   let summary = "Produce a path value";
   let description = [{
     Produces a value which represents a hierarchical path to a hardware
-    component.
+    target.
+     from a base path to a target.
 
     Example:
     ```mlir
-    hw.module @Foo {
+    hw.module @Foo() -> () {
       %wire = hw.wire sym @w: !i1
     }
     hw.hierpath @Path [@Foo::@w]
-    %0 = om.path member @Path
+    om.class @OM(%basepath: !om.basepath)
+      %0 = om.path_create reference %basepath @Path
+    }
     ```
   }];
-  let arguments = (ins TargetKind:$targetKind,
-                       FlatSymbolRefAttr:$target);
+  let arguments = (ins
+    TargetKind:$targetKind,
+    BasePathType:$basePath,
+    FlatSymbolRefAttr:$target
+  );
   let results = (outs PathType:$result);
-  let assemblyFormat = "$targetKind $target attr-dict";
+  let assemblyFormat = "$targetKind $basePath $target attr-dict";
+}
+
+def EmptyPathOp : OMOp<"path_empty", [Pure]> {
+  let summary = "Produce a path value to nothing";
+  let description = [{
+    Produces a value which represents a hierarchical path to nothing.
+
+    Example:
+    ```mlir
+    om.class @OM()
+      %0 = om.path_empty
+    }
+    ```
+  }];
+  let results = (outs FrozenPathType:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+def FrozenBasePathCreateOp : OMOp<"frozenbasepath_create", [Pure]> {
+  let summary = "Produce a frozen base path value";
+  let description = [{
+    Produces a value which represents a fragment of a hierarchical path to a
+    target.
+
+    Example:
+    ```mlir
+    om.class @OM(%basepath: !om.basepath)
+      %0 = om.frozenbasepath_create %basepath "Foo/bar:Bar/baz"
+    }
+    ```
+  }];
+  let arguments = (ins FrozenBasePathType:$basePath, OMPathAttr:$path);
+  let results = (outs FrozenBasePathType:$result);
+  let assemblyFormat = "$basePath custom<BasePathString>($path) attr-dict";
+}
+
+def FrozenPathCreateOp : OMOp<"frozenpath_create", [Pure]> {
+  let summary = "Produce a frozen path value";
+  let description = [{
+    Produces a value which represents a hierarchical path to a hardware
+    component from a base path to a target.
+
+    Example:
+    ```mlir
+    om.class @OM(%basepath: !om.basepath)
+      %0 = om.frozenpath_create reference %base "Foo/bar:Bar>w.a"
+    }
+    ```
+  }];
+  let arguments = (ins
+    TargetKind:$targetKind,
+    FrozenBasePathType:$basePath,
+    OMPathAttr:$path,
+    StrAttr:$module,
+    StrAttr:$ref,
+    StrAttr:$field
+  );
+  let results = (outs FrozenPathType:$result);
+  let assemblyFormat = [{
+    $targetKind $basePath custom<PathString>($path, $module, $ref, $field)
+      attr-dict
+  }];
+}
+
+def FrozenEmptyPathOp : OMOp<"frozenpath_empty", [Pure]> {
+  let summary = "Produce a frozen path value to nothing";
+  let description = [{
+    Produces a value which represents a hierarchical path to nothing.
+
+    Example:
+    ```mlir
+    om.class @OM()
+      %0 = om.frozenpath_empty
+    }
+    ```
+  }];
+  let results = (outs FrozenPathType:$result);
+  let assemblyFormat = "attr-dict";
 }
 
 def AnyCastOp : OMOp<"any_cast", [Pure]> {
@@ -336,23 +447,5 @@ def AnyCastOp : OMOp<"any_cast", [Pure]> {
 
   let assemblyFormat =
      "$input attr-dict `:` functional-type($input, $result)";
-}
-
-def PathAppendOp : OMOp<"path_append", [Pure]> {
-  let summary = "Append two path value";
-  let description = [{
-    Appends the path to the root path. The root path must not have a component.
-    The appended path must begin where the root path ends.
-
-    Example:
-    ```mlir
-    %root = om.constant #om.path<"Foo/bar:Bar">
-    %path = om.constant #om.path<"Bar/baz:Baz>output">
-    %0 = om.path_append %root, %path
-    ```
-  }];
-  let arguments = (ins PathType:$root, PathType:$path);
-  let results = (outs PathType:$result);
-  let assemblyFormat = "$root `,` $path attr-dict";
 }
 #endif // CIRCT_DIALECT_OM_OMOPS_TD

--- a/include/circt/Dialect/OM/OMUtils.h
+++ b/include/circt/Dialect/OM/OMUtils.h
@@ -1,0 +1,35 @@
+//===- OMUtils.h - OM Utility Functions -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_OM_OMUTILS_H
+#define CIRCT_DIALECT_OM_OMUTILS_H
+
+#include "circt/Support/LLVM.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace circt::om {
+
+struct PathElement;
+class PathAttr;
+
+/// Parse a target string of the form "Foo/bar:Bar/baz" in to a base path.
+ParseResult parseBasePath(MLIRContext *context, StringRef spelling,
+                          PathAttr &path);
+
+/// Parse a target string in to a path.
+/// "Foo/bar:Bar/baz:Baz>wire.a[1]"
+///  |--------------|              Path
+///                  |--|          Module
+///                      |--|      Ref
+///                          |---| Field
+ParseResult parsePath(MLIRContext *context, StringRef spelling, PathAttr &path,
+                      StringAttr &module, StringAttr &ref, StringAttr &field);
+
+} // namespace circt::om
+
+#endif // CIRCT_DIALECT_OM_OMUTILS_H

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -44,9 +44,6 @@ with Context() as ctx, Location.unknown():
       %0 = om.object @Child(%c_14) : (!om.integer) -> !om.class.type<@Child>
       om.class.field @child, %0 : !om.class.type<@Child>
 
-      %path = om.constant #om.path<"path"> : !om.path
-      om.class.field @path, %path : !om.path
-
       om.class.field @reference, %sym : !om.ref
 
       %list = om.constant #om.list<!om.string, ["X" : !om.string, "Y" : !om.string]> : !om.list<!om.string>
@@ -129,7 +126,7 @@ print(obj.get_field_loc("field"))
 
 # CHECK: 14
 print(obj.child.foo)
-# CHECK: loc("-":64:7)
+# CHECK: loc("-":61:7)
 print(obj.child.get_field_loc("foo"))
 # CHECK: ('Root', 'x')
 print(obj.reference)
@@ -137,14 +134,8 @@ print(obj.reference)
 # CHECK: 14
 print(snd)
 
-# CHECK: loc("-":43:7)
+# CHECK: loc("-":40:7)
 print(obj.get_field_loc("tuple"))
-
-# CHECK: path
-print(obj.path)
-# location of om.class.field @path, %path : !om.path
-# CHECK: loc("-":35:7)
-print(obj.get_field_loc("path"))
 
 try:
   print(obj.tuple[3])
@@ -161,7 +152,7 @@ for (name, field) in obj:
   # CHECK-SAME: loc: loc("-":28:7)
   # location from om.class.field @reference, %sym : !om.ref
   # CHECK: name: reference, field: ('Root', 'x')
-  # CHECK-SAME: loc: loc("-":37:7)
+  # CHECK-SAME: loc: loc("-":34:7)
   loc = obj.get_field_loc(name)
   print(f"name: {name}, field: {field}, loc: {loc}")
 

--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -416,14 +416,6 @@ void circt::python::populateDialectOMSubmodule(py::module &m) {
       .def("__len__", &omMapAttrGetNumElements);
   PyMapAttrIterator::bind(m);
 
-  // Add the PathAttr definition
-  mlir_attribute_subclass(m, "PathAttr", omAttrIsAPathAttr)
-      .def_property_readonly("value", [](MlirAttribute arr) {
-        auto path = mlirIdentifierStr(omPathAttrGetPath(arr));
-        std::string pathStr(path.data, path.length);
-        return pathStr;
-      });
-
   // Add the ClassType class definition.
   mlir_type_subclass(m, "ClassType", omTypeIsAClassType, omClassTypeGetTypeID)
       .def_property_readonly("name", [](MlirType type) {

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from ._om_ops_gen import *
-from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, Tuple as BaseTuple, Map as BaseMap, ClassType, ReferenceAttr, ListAttr, MapAttr, PathAttr, OMIntegerAttr
+from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, Tuple as BaseTuple, Map as BaseMap, ClassType, ReferenceAttr, ListAttr, MapAttr, OMIntegerAttr
 
 from ..ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr, IntegerAttr, IntegerType
 from ..support import attribute_to_var, var_to_attribute

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -363,15 +363,3 @@ MlirAttribute omMapAttrGetElementValue(MlirAttribute attr, intptr_t pos) {
   auto mapAttr = llvm::cast<MapAttr>(unwrap(attr));
   return wrap(mapAttr.getElements().getValue()[pos].getValue());
 }
-
-//===----------------------------------------------------------------------===//
-// PathAttr API.
-//===----------------------------------------------------------------------===//
-
-bool omAttrIsAPathAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<PathAttr>();
-}
-
-MlirIdentifier omPathAttrGetPath(MlirAttribute attr) {
-  return wrap(unwrap(attr).cast<PathAttr>().getPath());
-}

--- a/lib/Dialect/OM/CMakeLists.txt
+++ b/lib/Dialect/OM/CMakeLists.txt
@@ -14,6 +14,7 @@ add_circt_dialect_library(
   OMOpInterfaces.cpp
   OMOps.cpp
   OMTypes.cpp
+  OMUtils.cpp
 
   DEPENDS
   MLIROMIncGen

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -565,8 +565,8 @@ ArrayAttr circt::om::evaluator::MapValue::getKeys() {
     attrs.push_back(key);
 
   std::sort(attrs.begin(), attrs.end(), [](Attribute l, Attribute r) {
-    if (auto lInt = dyn_cast<IntegerAttr>(l))
-      if (auto rInt = dyn_cast<IntegerAttr>(r))
+    if (auto lInt = dyn_cast<mlir::IntegerAttr>(l))
+      if (auto rInt = dyn_cast<mlir::IntegerAttr>(r))
         return lInt.getValue().ult(rInt.getValue());
 
     assert(isa<StringAttr>(l) && isa<StringAttr>(r) &&

--- a/lib/Dialect/OM/OMUtils.cpp
+++ b/lib/Dialect/OM/OMUtils.cpp
@@ -1,0 +1,186 @@
+//===- OMUtils.cpp - OM Utility Functions ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/OM/OMUtils.h"
+#include "circt/Dialect/OM/OMAttributes.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+using namespace circt;
+using namespace om;
+
+namespace {
+struct PathParser {
+  enum class TokenKind {
+    Space,
+    Tilde,
+    Bar,
+    Colon,
+    Greater,
+    Slash,
+    LBrace,
+    RBrace,
+    Period,
+    Id,
+    Eof
+  };
+
+  struct Token {
+    TokenKind kind;
+    StringRef spelling;
+  };
+
+  Token formToken(TokenKind kind, size_t n) {
+    auto s = spelling.take_front(n);
+    spelling = spelling.drop_front(n);
+    return {kind, s};
+  }
+
+  bool isIDChar(char c) {
+    return c != ' ' && c != '~' && c != '|' && c != ':' && c != '>' &&
+           c != '/' && c != '[' && c != ']' && c != '.';
+  }
+
+  Token parseToken() {
+    size_t pos = 0;
+    auto size = spelling.size();
+    if (0 == size)
+      return formToken(TokenKind::Eof, pos);
+    auto current = spelling[pos];
+    switch (current) {
+    case '~':
+      return formToken(TokenKind::Tilde, pos + 1);
+    case '|':
+      return formToken(TokenKind::Bar, pos + 1);
+    case ':':
+      return formToken(TokenKind::Colon, pos + 1);
+    case '>':
+      return formToken(TokenKind::Greater, pos + 1);
+    case '/':
+      return formToken(TokenKind::Slash, pos + 1);
+    case '[':
+      return formToken(TokenKind::LBrace, pos + 1);
+    case ']':
+      return formToken(TokenKind::RBrace, pos + 1);
+    case '.':
+      return formToken(TokenKind::Period, pos + 1);
+    default:
+      break;
+    }
+
+    // Parsing a token.
+    while (pos != size && isIDChar(spelling[pos]))
+      ++pos;
+    return formToken(TokenKind::Id, pos);
+  }
+
+  ParseResult parseToken(TokenKind kind, StringRef &result) {
+    auto save = spelling;
+    auto token = parseToken();
+    if (token.kind != kind)
+      return spelling = save, failure();
+    result = token.spelling;
+    return success();
+  }
+
+  ParseResult parseToken(TokenKind kind) {
+    StringRef ignore;
+    return parseToken(kind, ignore);
+  }
+
+  /// basepath ::= eof | id '/' id (':' id '/' id)* eof
+  ParseResult parseBasePath(PathAttr &pathAttr) {
+    if (succeeded(parseToken(TokenKind::Eof)))
+      return success();
+    SmallVector<PathElement> path;
+    while (true) {
+      StringRef module;
+      StringRef instance;
+      if (parseToken(TokenKind::Id, module) || parseToken(TokenKind::Slash) ||
+          parseToken(TokenKind::Id, instance))
+        return failure();
+      path.emplace_back(StringAttr::get(context, module),
+                        StringAttr::get(context, instance));
+      if (parseToken(TokenKind::Colon))
+        break;
+    }
+    pathAttr = PathAttr::get(context, path);
+    if (parseToken(TokenKind::Eof))
+      return failure();
+    return success();
+  }
+
+  /// path ::= id ('/' id ':' path | ('>' id ('[' id ']' | '.' id)* )?) eof
+  ParseResult parsePath(PathAttr &pathAttr, StringAttr &moduleAttr,
+                        StringAttr &refAttr, StringAttr &fieldAttr) {
+    SmallVector<PathElement> path;
+    StringRef module;
+    while (true) {
+      if (parseToken(TokenKind::Id, module))
+        return failure();
+      if (parseToken(TokenKind::Slash))
+        break;
+      StringRef instance;
+      if (parseToken(TokenKind::Id, instance) || parseToken(TokenKind::Colon))
+        return failure();
+      path.emplace_back(StringAttr::get(context, module),
+                        StringAttr::get(context, instance));
+    }
+    pathAttr = PathAttr::get(context, path);
+    moduleAttr = StringAttr::get(context, module);
+    if (succeeded(parseToken(TokenKind::Greater))) {
+      StringRef ref;
+      if (parseToken(TokenKind::Id, ref))
+        return failure();
+      refAttr = StringAttr::get(context, ref);
+
+      SmallString<64> field;
+      while (true) {
+        if (succeeded(parseToken(TokenKind::LBrace))) {
+          StringRef id;
+          if (parseToken(TokenKind::Id, id) || parseToken(TokenKind::RBrace))
+            return failure();
+          field += '[';
+          field += id;
+          field += ']';
+        } else if (succeeded(parseToken(TokenKind::Period))) {
+          StringRef id;
+          if (parseToken(TokenKind::Id, id))
+            return failure();
+          field += '.';
+          field += id;
+        } else {
+          break;
+        }
+      }
+      fieldAttr = StringAttr::get(context, field);
+    } else {
+      refAttr = StringAttr::get(context, "");
+      fieldAttr = StringAttr::get(context, "");
+    }
+    if (parseToken(TokenKind::Eof))
+      return failure();
+    return success();
+  }
+
+  MLIRContext *context;
+  StringRef spelling;
+};
+} // namespace
+
+ParseResult circt::om::parseBasePath(MLIRContext *context, StringRef spelling,
+                                     PathAttr &path) {
+  return PathParser{context, spelling}.parseBasePath(path);
+}
+
+ParseResult circt::om::parsePath(MLIRContext *context, StringRef spelling,
+                                 PathAttr &path, StringAttr &module,
+                                 StringAttr &ref, StringAttr &field) {
+  return PathParser{context, spelling}.parsePath(path, module, ref, field);
+}

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -2,7 +2,7 @@
 
 firrtl.circuit "Component" {
   // CHECK-LABEL: om.class @Class_0
-  // CHECK-SAME: %[[REF1:.+]]: !om.class.type<@Class_1>
+  // CHECK-SAME: %[[REF1:[^ ]+]]: !om.class.type<@Class_1>
   firrtl.class private @Class_0(in %someReference_in: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>, out %someReference: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>) {
     // CHECK: om.class.field @someReference, %[[REF1]]
     firrtl.propassign %someReference, %someReference_in : !firrtl.class<@Class_1(out someInt: !firrtl.integer)>
@@ -24,17 +24,17 @@ firrtl.circuit "Component" {
     firrtl.propassign %someString, %0 : !firrtl.string
   }
 
-  // CHECK-LABEL: om.class.extern @ExtClass(%input: !om.string) {
+  // CHECK-LABEL: om.class.extern @ExtClass(%basepath: !om.basepath, %input: !om.string) {
   // CHECK-NEXT:    om.class.extern.field @field : !om.string
   // CHECK-NEXT:  }
   firrtl.extclass private @ExtClass(in input: !firrtl.string, out field: !firrtl.string)
 
   // CHECK-LABEL: om.class @ClassEntrypoint
   firrtl.class private @ClassEntrypoint(out %obj_0_out: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>) {
-    // CHECK: %[[OBJ1:.+]] = om.object @Class_1() : () -> !om.class.type<@Class_1>
+    // CHECK: %[[OBJ1:.+]] = om.object @Class_1(%basepath) : (!om.basepath) -> !om.class.type<@Class_1>
     %obj1 = firrtl.object @Class_1(out someInt: !firrtl.integer)
 
-    // CHECK: %[[OBJ0:.+]] = om.object @Class_0(%[[OBJ1]]) : (!om.class.type<@Class_1>) -> !om.class.type<@Class_0>
+    // CHECK: %[[OBJ0:.+]] = om.object @Class_0(%basepath, %[[OBJ1]]) : (!om.basepath, !om.class.type<@Class_1>) -> !om.class.type<@Class_0>
     %obj0 = firrtl.object @Class_0(in someReference_in: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>, out someReference: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>)
     %obj0_someReference_in = firrtl.object.subfield %obj0[someReference_in] : !firrtl.class<@Class_0(in someReference_in: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>, out someReference: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>)>
     firrtl.propassign %obj0_someReference_in, %obj1 : !firrtl.class<@Class_1(out someInt: !firrtl.integer)>
@@ -45,9 +45,9 @@ firrtl.circuit "Component" {
     firrtl.propassign %obj_0_out, %obj0_someReference: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>
   }
 
-  // CHECK-LABEL: om.class @ReadOutputPort()
+  // CHECK-LABEL: om.class @ReadOutputPort(%basepath: !om.basepath)
   firrtl.class @ReadOutputPort(out %output : !firrtl.integer) {
-    // CHECK: %[[OBJ:.+]] = om.object @Class_1() : () -> !om.class.type<@Class_1>
+    // CHECK: %[[OBJ:.+]] = om.object @Class_1(%basepath) : (!om.basepath) -> !om.class.type<@Class_1>
     // CHECK: %[[FIELD:.+]] = om.object.field %[[OBJ]], [@someInt] : (!om.class.type<@Class_1>) -> !om.integer
     // CHECK: om.class.field @output, %[[FIELD]] : !om.integer
     %obj = firrtl.object @Class_1(out someInt: !firrtl.integer)
@@ -60,7 +60,7 @@ firrtl.circuit "Component" {
   firrtl.class @AssignInputsInOrder() {
     // CHECK: %0 = om.constant #om.integer<123 : si12> : !om.integer
     // CHECK: %1 = om.constant #om.integer<456 : si12> : !om.integer
-    // CHECK: %2 = om.object @TwoInputs(%0, %1) : (!om.integer, !om.integer) -> !om.class.type<@TwoInputs>
+    // CHECK: %2 = om.object @TwoInputs(%basepath, %0, %1) : (!om.basepath, !om.integer, !om.integer) -> !om.class.type<@TwoInputs>
     %x = firrtl.integer 123
     %y = firrtl.integer 456
     %obj = firrtl.object @TwoInputs(in a: !firrtl.integer, in b: !firrtl.integer)
@@ -75,7 +75,7 @@ firrtl.circuit "Component" {
   firrtl.class @AssignInputsOutOfOrder() {
     // CHECK: %0 = om.constant #om.integer<123 : si12> : !om.integer
     // CHECK: %1 = om.constant #om.integer<456 : si12> : !om.integer
-    // CHECK: %2 = om.object @TwoInputs(%0, %1) : (!om.integer, !om.integer) -> !om.class.type<@TwoInputs>
+    // CHECK: %2 = om.object @TwoInputs(%basepath, %0, %1) : (!om.basepath, !om.integer, !om.integer) -> !om.class.type<@TwoInputs>
     %x = firrtl.integer 123
     %y = firrtl.integer 456
     %obj = firrtl.object @TwoInputs(in a: !firrtl.integer, in b: !firrtl.integer)
@@ -135,7 +135,7 @@ firrtl.circuit "Component" {
     // CHECK-NEXT: om.class.field @out_objs, %[[OBJS]] : !om.list<!om.class.type<@ClassTest>
   }
 
-  // CHECK-LABEL: om.class @BoolTest()
+  // CHECK-LABEL: om.class @BoolTest
   firrtl.class @BoolTest(out %b : !firrtl.bool) {
     // CHECK-NEXT: %[[TRUE:.+]] = om.constant true
     // CHECK-NEXT: om.class.field @b, %[[TRUE]] : i1
@@ -143,7 +143,7 @@ firrtl.circuit "Component" {
     firrtl.propassign %b, %true : !firrtl.bool
   }
 
-  // CHECK-LABEL: om.class @DoubleTest()
+  // CHECK-LABEL: om.class @DoubleTest
   firrtl.class @DoubleTest(out %d : !firrtl.double) {
     // CHECK-NEXT: %[[DBL:.+]] = om.constant 4.0{{0*[eE]}}-01 : f64
     // CHECK-NEXT: om.class.field @d, %[[DBL]] : f64
@@ -217,38 +217,38 @@ firrtl.circuit "PathModule" {
     // CHECK: %non_local = firrtl.wire sym [[NONLOCAL_SYM]] : !firrtl.uint<8>
     %non_local = firrtl.wire {annotations = [{circt.nonlocal = @NonLocal, class = "circt.tracker", id = distinct[3]<>}]} : !firrtl.uint<8>
   }
-  // CHECK: om.class @PathTest
+  // CHECK: om.class @PathTest(%basepath: !om.basepath)
   firrtl.class @PathTest() {
     
-    // CHECK: om.path reference [[PORT_PATH]]
+    // CHECK: om.path_create reference %basepath [[PORT_PATH]]
     %port_path = firrtl.path reference distinct[0]<>
 
-    // CHECK: om.constant #om.path<"OMDeleted"> : !om.path
+    // CHECK: om.path_empty
     %deleted_path = firrtl.path reference distinct[99]<>
 
-    // CHECK: om.path reference [[WIRE_PATH]]
-    // CHECK: om.path member_reference [[WIRE_PATH]]
-    // CHECK: om.path member_reference [[WIRE_PATH]]
-    // CHECK: om.path dont_touch [[WIRE_PATH]]
+    // CHECK: om.path_create reference %basepath [[WIRE_PATH]]
+    // CHECK: om.path_create member_reference %basepath [[WIRE_PATH]]
+    // CHECK: om.path_create member_reference %basepath [[WIRE_PATH]]
+    // CHECK: om.path_create dont_touch %basepath [[WIRE_PATH]]
     %wire_reference = firrtl.path reference distinct[1]<>
     %wire_member_instance = firrtl.path member_instance distinct[1]<>
     %wire_member_reference = firrtl.path member_reference distinct[1]<>
     %wire_dont_touch = firrtl.path dont_touch distinct[1]<>
 
-    // CHECK: om.path reference [[VECTOR_PATH]]
+    // CHECK: om.path_create reference %basepath [[VECTOR_PATH]]
     %vector_reference = firrtl.path reference distinct[2]<>
 
-    // CHECK: om.path reference [[NONLOCAL_PATH]]
+    // CHECK: om.path_create reference %basepath [[NONLOCAL_PATH]]
     %non_local_path = firrtl.path reference distinct[3]<>
 
-    // CHECK: om.path member_instance [[INST_PATH]]
-    // CHECK: om.path member_instance [[INST_PATH]]
-    // CHECK: om.path instance [[INST_PATH]]
+    // CHECK: om.path_create member_instance %basepath [[INST_PATH]]
+    // CHECK: om.path_create member_instance %basepath [[INST_PATH]]
+    // CHECK: om.path_create instance %basepath [[INST_PATH]]
     %instance_member_instance = firrtl.path member_instance distinct[4]<>
     %instance_member_reference = firrtl.path member_reference distinct[4]<>
     %instance = firrtl.path instance distinct[4]<>
 
-    // CHECK: om.path reference [[MODULE_PATH]]
+    // CHECK: om.path_create reference %basepath [[MODULE_PATH]]
     %module_path = firrtl.path reference distinct[5]<>
   }
   firrtl.module @ListCreate(in %propIn: !firrtl.integer, out %propOut: !firrtl.list<integer>) attributes {convention = #firrtl<convention scalarized>} {
@@ -264,7 +264,7 @@ firrtl.circuit "PathModule" {
 // CHECK-LABEL: firrtl.circuit "WireProp"
 firrtl.circuit "WireProp" {
   // CHECK: om.class @WireProp
-  // CHECK-SAME: %[[IN:.+]]: !om.string
+  // CHECK-SAME: %[[IN:[^ ]+]]: !om.string
   firrtl.module @WireProp(in %in: !firrtl.string, out %out: !firrtl.string) attributes {convention = #firrtl<convention scalarized>} {
     // CHECK-NOT: firrtl.wire
     // CHECK-NOT: firrtl.propassign
@@ -329,20 +329,20 @@ firrtl.circuit "ModuleInstances" {
     firrtl.propassign %outputProp, %mod.outputProp : !firrtl.string
   }
 
-  // CHECK: om.class.extern @ExtModule_Class(%inputProp: !om.string)
+  // CHECK: om.class.extern @ExtModule_Class(%basepath: !om.basepath, %inputProp: !om.string)
   // CHECK:   om.class.extern.field @outputProp : !om.string
 
-  // CHECK: om.class.extern @TheRealName_Class(%inputProp: !om.string)
+  // CHECK: om.class.extern @TheRealName_Class(%basepath: !om.basepath, %inputProp: !om.string)
   // CHECK:   om.class.extern.field @outputProp : !om.string
 
-  // CHECK: om.class @Module_Class(%[[IN_PROP0:.+]]: !om.string)
+  // CHECK: om.class @Module_Class(%basepath: !om.basepath, %[[IN_PROP0:.+]]: !om.string)
   // CHECK:   om.class.field @outputProp, %[[IN_PROP0]] : !om.string
 
-  // CHECK: om.class @ModuleInstances_Class(%[[IN_PROP1:.+]]: !om.string)
-  // CHECK:   %[[O0:.+]] = om.object @ExtModule_Class(%[[IN_PROP1]])
+  // CHECK: om.class @ModuleInstances_Class(%basepath: !om.basepath, %[[IN_PROP1:.+]]: !om.string)
+  // CHECK:   %[[O0:.+]] = om.object @ExtModule_Class(%basepath, %[[IN_PROP1]])
   // CHECK:   %[[F0:.+]] = om.object.field %[[O0]], [@outputProp]
   // CHECK:   om.object @TheRealName_Class
-  // CHECK:   %[[O1:.+]] = om.object @Module_Class(%[[F0]])
+  // CHECK:   %[[O1:.+]] = om.object @Module_Class(%basepath, %[[F0]])
   // CHECK:   %[[F1:.+]] = om.object.field %[[O1]], [@outputProp]
   // CHECK:   om.class.field @outputProp, %[[F1]]
 }

--- a/test/Dialect/OM/errors.mlir
+++ b/test/Dialect/OM/errors.mlir
@@ -120,7 +120,7 @@ om.class @MapConstant() {
 // -----
 
 om.class @Thing() { }
-om.class @BadPath() {
+om.class @BadPath(%basepath: !om.basepath) {
   // expected-error @below {{invalid symbol reference}}
-  %0 = om.path reference @Thing
+  %0 = om.path_create reference %basepath @Thing
 }

--- a/test/Dialect/OM/freeze-paths-errors.mlir
+++ b/test/Dialect/OM/freeze-paths-errors.mlir
@@ -4,9 +4,11 @@ hw.hierpath private @nla [@Top::@sym]
 hw.module @Top() {
   // expected-note @below {{component here}}
   %wire = hw.wire %wire sym @sym : i8
-  // expected-error @below {{component does not have verilog name}}
-  %path = om.path reference @nla
   hw.output
+}
+om.class @OM(%basepath: !om.basepath) {
+  // expected-error @below {{component does not have verilog name}}
+  %path = om.path_create reference %basepath @nla
 }
 
 // -----
@@ -14,11 +16,25 @@ hw.module @Top() {
 hw.hierpath private @nla [@Child]
 hw.module private @Child() {}
 hw.module @Top() {
-  // expected-error @below {{unable to uniquely resolve target due to multiple instantiation}}
-  %path = om.path reference @nla
   // expected-note @below {{instance here}}
   hw.instance "child0" @Child() -> ()
   // expected-note @below {{instance here}}
   hw.instance "child1" @Child() -> ()
   hw.output
+}
+om.class @OM(%basepath: !om.basepath) {
+  // expected-error @below {{unable to uniquely resolve target due to multiple instantiation}}
+  %path = om.path_create reference %basepath @nla
+}
+
+// -----
+
+hw.hierpath private @nla [@Top::@sym]
+hw.module @Top() {
+  %wire = hw.wire %wire sym @sym {hw.verilogName = "wire"} : i8
+  hw.output
+}
+om.class @OM(%basepath: !om.basepath) {
+  // expected-error @below {{basepath must target an instance}}
+  %path = om.basepath_create %basepath @nla
 }

--- a/test/Dialect/OM/freeze-paths.mlir
+++ b/test/Dialect/OM/freeze-paths.mlir
@@ -29,37 +29,43 @@ hw.module @PublicMiddle() {
 hw.module private @PublicLeaf() {}
 
 // CHECK-LABEL om.class @PathTest()
-om.class @PathTest() {
-  // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule>in"> : !om.path
-  %0 = om.path reference @nla
+om.class @PathTest(%basepath : !om.basepath, %path : !om.path) {
+  // CHECK: om.frozenpath_create reference %basepath "PathModule>in"
+  %0 = om.path_create reference %basepath @nla
 
-  // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule>wire"> : !om.path
-  %1 = om.path reference @nla_0
+  // CHECK: om.frozenpath_create reference %basepath "PathModule>wire"
+  %1 = om.path_create reference %basepath @nla_0
 
-  // CHECK: om.constant #om.path<"OMMemberReferenceTarget:PathModule>wire"> : !om.path
-  %2 = om.path member_reference @nla_0
+  // CHECK: om.frozenpath_create member_reference %basepath "PathModule>wire"
+  %2 = om.path_create member_reference %basepath @nla_0
 
-  // CHECK: om.constant #om.path<"OMDontTouchedReferenceTarget:PathModule>wire"> : !om.path
-  %4 = om.path dont_touch @nla_0
+  // CHECK: om.frozenpath_create dont_touch %basepath "PathModule>wire"
+  %4 = om.path_create dont_touch %basepath @nla_0
 
-  // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule>array[0]"> : !om.path
-  %5 = om.path reference @nla_1
+  // CHECK: om.frozenpath_create reference %basepath "PathModule>array[0]" 
+  %5 = om.path_create reference %basepath @nla_1
 
-  // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule>struct.a"> : !om.path
-  %6 = om.path reference @nla_2
+  // CHECK: om.frozenpath_create reference %basepath "PathModule>struct.a"
+  %6 = om.path_create reference %basepath @nla_2
 
-  // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule/child:Child>non_local"> : !om.path
-  %7 = om.path reference @nla_5
+  // CHECK: om.frozenpath_create reference %basepath "PathModule/child:Child>non_local"
+  %7 = om.path_create reference %basepath @nla_5
 
-  // CHECK: om.constant #om.path<"OMInstanceTarget:PathModule/child:Child"> : !om.path
-  %8 = om.path instance @nla_3
+  // CHECK: om.frozenpath_create instance %basepath "PathModule/child:Child"
+  %8 = om.path_create instance %basepath @nla_3
 
-  // CHECK: om.constant #om.path<"OMMemberInstanceTarget:PathModule/child:Child"> : !om.path
-  %9 = om.path member_instance @nla_3
+  // CHECK: om.frozenpath_create member_instance %basepath "PathModule/child:Child"
+  %9 = om.path_create member_instance %basepath @nla_3
 
-  // CHECK: om.constant #om.path<"OMReferenceTarget:PathModule/child:Child"> : !om.path
-  %10 = om.path reference @nla_4
+  // CHECK: om.frozenpath_create reference %basepath "PathModule/child:Child"
+  %10 = om.path_create reference %basepath @nla_4
 
-  // CHECK: om.constant #om.path<"OMReferenceTarget:PublicMiddle/leaf:PublicLeaf"> : !om.path
-  %11 = om.path reference @nla_6
+  // CHECK: om.frozenpath_create reference %basepath "PublicMiddle/leaf:PublicLeaf"
+  %11 = om.path_create reference %basepath @nla_6
+
+  // CHECK: om.frozenpath_empty
+  %12 = om.path_empty
+
+  // CHECK: om.frozenbasepath_create %basepath "PathModule/child"
+  %13 = om.basepath_create %basepath @nla_3
 }

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -252,13 +252,18 @@ hw.module @PathModule() {
   %wire = hw.wire %wire sym @wire : i1
 }
 // CHECK-LABEL: @Path
-om.class @Path(%p: !om.path) {
-  // CHECK: %[[v0:.+]] = om.path reference @HierPath
-  %0 = om.path reference @HierPath
-  // CHECK: %[[v1:.+]] = om.path_append %p, %[[v0]]
-  %1 = om.path_append %p, %0
-  // CHECK: om.class.field @path1, %[[v1]] : !om.path
-  om.class.field @path1, %1 : !om.path
+om.class @Path(%basepath: !om.basepath) {
+  // CHECK: %[[v0:.+]] = om.basepath_create %basepath @HierPath
+  %0 = om.basepath_create %basepath @HierPath
+  // CHECK: %[[v1:.+]] = om.path_create reference %basepath @HierPath
+  %1 = om.path_create reference %basepath @HierPath
+}
+
+om.class @FrozenPath(%basepath: !om.frozenbasepath) {
+  // CHECK: %[[v0:.+]] = om.frozenbasepath_create %basepath "Foo/bar"
+  %0 = om.frozenbasepath_create %basepath "Foo/bar"
+  // CHECK: %[[v1:.+]] = om.frozenpath_create reference %basepath "Foo/bar:Bar>w.a"
+  %1 = om.frozenpath_create reference %basepath "Foo/bar:Bar>w.a"
 }
 
 // CHECK-LABEL: @Enum


### PR DESCRIPTION
This PR does an overhaul of how path related operations work in the OM dialect.

When OM classes are created from FIRRTL, a base path is now fed through the class hieararchy.  All paths to hardware objects are now created relative to the base path.  The `path` op has been renamed to `path_create`, and now takes a basepath SSA parameter, which means that it is impossible to create a path which is not relative to some base.

A second set of operations to create "frozen paths" have been added.  In FreezePaths, we lower all path operations to hard-coded strings, which allows us to remove the hardware from the OM IR and still be valid.  These operations have been changed to return `FrozenPathType`, which is to make sure that people don't try to inter-mix the two kinds of path types.  The intention is that the evaluator will only understand frozen paths.

The PathAttr in OM no longer represents the entire target path, but just the list of instances which lead up to it.

This also adds an OM utility for parsing FIRRTL style target strings, which is used in the `frozenpath_create` MLIR assembly format.  The existing APIs contained in FIRRTL were not suitable since these new strings do not include the circuit name, and we need some restrictions for parsing base paths, which can not target components. The new parser is a bit more resilient to badly formed path strings. In the future it may be possible to reunite these two bodies of code.