### PR TITLE
[Seq] Add optional power-on value to `compreg` ops

### DIFF
--- a/docs/Dialects/Seq/RationaleSeq.md
+++ b/docs/Dialects/Seq/RationaleSeq.md
@@ -56,6 +56,7 @@ addressing, meaning that this operation sets / reads the entire value.
 - **reset**: Signal to set the state to 'resetValue'. Optional.
 - **resetValue**: A value which the state is set to upon reset. Required iff
 'reset' is present.
+- **powerOn**: A value which will be assigned to the register upon system power-on.
 - **name**: A name for the register, defaults to `""`. Inferred from the textual
 SSA value name, or passed explicitly in builder APIs. The name will be passed to
 the `sv.reg` during lowering.
@@ -63,7 +64,7 @@ the `sv.reg` during lowering.
 passed to the `sv.reg` during lowering if present.
 
 ```mlir
-%q = seq.compreg %input, %clk [, %reset, %resetValue ] : $type(input)
+%q = seq.compreg %input, %clk [ reset %reset, %resetValue ] [powerOn %powerOn] : $type(input)
 ```
 
 Upon initialization, the state is defined to be uninitialized.

--- a/frontends/PyCDE/test/test_constructs.py
+++ b/frontends/PyCDE/test/test_constructs.py
@@ -15,7 +15,7 @@ from pycde.testing import unittestmodule
 # CHECK:         sv.assign %in, %In : i8
 # CHECK:         [[r1:%.+]] = seq.compreg %In, %clk : i8
 # CHECK:         %c0_i8{{.*}} = hw.constant 0 : i8
-# CHECK:         [[r5:%.+]] = seq.compreg %In, %clk, %rst, %c0_i8{{.*}}  : i8
+# CHECK:         [[r5:%.+]] = seq.compreg %In, %clk reset %rst, %c0_i8{{.*}}  : i8
 # CHECK:         [[r6:%.+]] = seq.compreg.ce %In, %clk, %InCE : i8
 # CHECK:         hw.output [[r2]], [[r1]], [[r5]], [[r6]] : i8, i8, i8, i8
 

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -25,9 +25,9 @@ class SeqOp<string mnemonic, list<Trait> traits = []> :
 def CompRegOp : SeqOp<"compreg",
     [Pure, Clocked, Resettable,
      AllTypesMatch<["input", "data"/*, "resetValue"*/]>,
-     SameVariadicOperandSize,
      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-     DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>]> {
+     DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>,
+     AttrSizedOperandSegments]> {
        // AllTypesMatch doesn't work with Optional types yet.
 
   let summary = "Register a value, storing it for one cycle";
@@ -39,6 +39,7 @@ def CompRegOp : SeqOp<"compreg",
     StrAttr:$name,
     Optional<I1>:$reset,
     Optional<AnyType>:$resetValue,
+    Optional<AnyType>:$powerOnValue,
     OptionalAttr<InnerSymAttr>:$inner_sym
   );
   let results = (outs AnyType:$data);
@@ -50,25 +51,26 @@ def CompRegOp : SeqOp<"compreg",
     OpBuilder<(ins "Value":$input, "Value":$clk, "StringRef":$name), [{
       auto nameAttr = StringAttr::get($_builder.getContext(), name);
       return build($_builder, $_state, input.getType(), input, clk, nameAttr,
-                   Value(), Value(), hw::InnerSymAttr::get(nameAttr));
+                   /*reset*/ Value(), /*resetValue*/ Value(),
+                   /*powerOnValue*/ Value(), hw::InnerSymAttr::get(nameAttr));
     }]>,
     /// Create a register with a reset, with an inner_sym matching the
-    /// register's name.
+    /// register's name, and optional power-on value.
     OpBuilder<(ins "Value":$input, "Value":$clk, "Value":$reset,
-                   "Value":$rstValue, "StringRef":$name), [{
+                   "Value":$rstValue, "StringRef":$name, CArg<"Value", "{}">:$powerOnValue), [{
       auto nameAttr = StringAttr::get($_builder.getContext(), name);
       return build($_builder, $_state, input.getType(), input, clk, nameAttr,
-                   reset, rstValue, hw::InnerSymAttr::get(nameAttr));
-    }]>,
+                   reset, rstValue, powerOnValue, hw::InnerSymAttr::get(nameAttr));
+    }]>
   ];
 }
 
 def CompRegClockEnabledOp : SeqOp<"compreg.ce",
     [Pure, Clocked, Resettable,
      AllTypesMatch<["input", "data"/*, "resetValue"*/]>,
-     SameVariadicOperandSize,
      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-     DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>]> {
+     DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>,
+     AttrSizedOperandSegments]> {
        // AllTypesMatch doesn't work with Optional types yet.
 
   let summary = "When enabled, register a value";
@@ -81,6 +83,7 @@ def CompRegClockEnabledOp : SeqOp<"compreg.ce",
     StrAttr:$name,
     Optional<I1>:$reset,
     Optional<AnyType>:$resetValue,
+    Optional<AnyType>:$powerOnValue,
     OptionalAttr<InnerSymAttr>:$inner_sym
   );
   let results = (outs AnyType:$data);
@@ -92,14 +95,18 @@ def CompRegClockEnabledOp : SeqOp<"compreg.ce",
                    "StringRef":$name), [{
       auto nameAttr = StringAttr::get($_builder.getContext(), name);
       return build($_builder, $_state, input.getType(), input, clk, ce,
-                   nameAttr, Value(), Value(), hw::InnerSymAttr::get(nameAttr));
+                   nameAttr, /*reset*/ Value(), /*resetValue*/ Value(),
+                   /*powerOnValue*/ Value(),
+                   hw::InnerSymAttr::get(nameAttr));
     }]>,
     OpBuilder<(ins "Value":$input, "Value":$clk, "Value":$ce,
-                   "Value":$reset, "Value":$rstValue, "StringRef":$name),
+                   "Value":$reset, "Value":$rstValue, "StringRef":$name,
+                   CArg<"Value", "{}">:$powerOnValue),
     [{
       auto nameAttr = StringAttr::get($_builder.getContext(), name);
       return build($_builder, $_state, input.getType(), input, clk, ce,
-                   nameAttr, reset, rstValue, hw::InnerSymAttr::get(nameAttr));
+                   nameAttr, reset, rstValue, powerOnValue,
+                   hw::InnerSymAttr::get(nameAttr));
     }]>,
   ];
 }

--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -24,22 +24,25 @@ with Context() as ctx, Location.unknown():
     def top(module):
       # CHECK: %[[RESET_VAL:.+]] = hw.constant 0
       reg_reset = hw.ConstantOp.create(i32, 0).result
+      # CHECK: %[[POWERON_VAL:.+]] = hw.constant 42
+      poweron_value = hw.ConstantOp.create(i32, 42).result
       # CHECK: %[[INPUT_VAL:.+]] = hw.constant 45
       reg_input = hw.ConstantOp.create(i32, 45).result
-      # CHECK: %[[DATA_VAL:.+]] = seq.compreg %[[INPUT_VAL]], %clk, %rst, %[[RESET_VAL]]
+      # CHECK: %[[DATA_VAL:.+]] = seq.compreg %[[INPUT_VAL]], %clk reset %rst, %[[RESET_VAL]] powerOn %[[POWERON_VAL]]
       reg = seq.CompRegOp(i32,
                           reg_input,
                           module.clk,
                           reset=module.rst,
                           reset_value=reg_reset,
+                          power_on_value=poweron_value,
                           name="my_reg")
 
       # CHECK: seq.compreg %[[INPUT_VAL]], %clk
       seq.reg(reg_input, module.clk)
-      # CHECK: seq.compreg %[[INPUT_VAL]], %clk, %rst, %{{.+}}
+      # CHECK: seq.compreg %[[INPUT_VAL]], %clk reset %rst, %{{.+}}
       seq.reg(reg_input, module.clk, reset=module.rst)
       # CHECK: %[[RESET_VALUE:.+]] = hw.constant 123
-      # CHECK: seq.compreg %[[INPUT_VAL]], %clk, %rst, %[[RESET_VALUE]]
+      # CHECK: seq.compreg %[[INPUT_VAL]], %clk reset %rst, %[[RESET_VALUE]]
       custom_reset = hw.ConstantOp.create(i32, 123).result
       seq.reg(reg_input, module.clk, reset=module.rst, reset_value=custom_reset)
       # CHECK: %FuBar = seq.compreg {{.+}}

--- a/lib/Bindings/Python/dialects/_seq_ops_ext.py
+++ b/lib/Bindings/Python/dialects/_seq_ops_ext.py
@@ -26,16 +26,16 @@ class CompRegLike:
                *,
                reset=None,
                reset_value=None,
+               power_on_value=None,
                name=None,
                sym_name=None,
                loc=None,
                ip=None):
-    operands = []
+    operands = [input, clk]
     results = []
     attributes = {}
     results.append(data_type)
-    operands.append(input)
-    operands.append(clk)
+    operand_segment_sizes = [1, 1]
     if isinstance(self, CompRegOp):
       if clockEnable is not None:
         raise Exception("Clock enable not supported on compreg")
@@ -43,18 +43,31 @@ class CompRegLike:
       if clockEnable is None:
         raise Exception("Clock enable required on compreg.ce")
       operands.append(clockEnable)
+      operand_segment_sizes.append(1)
     else:
       assert False, "Class not recognized"
-    if reset is not None:
+    if reset is not None and reset_value is not None:
       operands.append(reset)
-    if reset_value is not None:
       operands.append(reset_value)
+      operand_segment_sizes += [1, 1]
+    else:
+      operand_segment_sizes += [0, 0]
+      operands += [None, None]
+
+    if power_on_value is not None:
+      operands.append(power_on_value)
+      operand_segment_sizes.append(1)
+    else:
+      operands.append(None)
+      operand_segment_sizes.append(0)
     if name is None:
       attributes["name"] = StringAttr.get("")
     else:
       attributes["name"] = StringAttr.get(name)
     if sym_name is not None:
       attributes["inner_sym"] = hw.InnerSymAttr.get(StringAttr.get(sym_name))
+
+    self._ODS_OPERAND_SEGMENTS = operand_segment_sizes
 
     OpView.__init__(
         self,

--- a/lib/Conversion/DCToHW/DCToHW.cpp
+++ b/lib/Conversion/DCToHW/DCToHW.cpp
@@ -254,8 +254,8 @@ struct RTLBuilder {
            "No global reset provided to this RTLBuilder - a reset "
            "signal must be provided to the reg(...) function.");
 
-    return b.create<seq::CompRegOp>(loc, in.getType(), in, resolvedClk, name,
-                                    resolvedRst, rstValue, hw::InnerSymAttr());
+    return b.create<seq::CompRegOp>(loc, in, resolvedClk, resolvedRst, rstValue,
+                                    name);
   }
 
   Value cmp(Value lhs, Value rhs, comb::ICmpPredicate predicate,

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -499,8 +499,8 @@ struct RTLBuilder {
            "No global reset provided to this RTLBuilder - a reset "
            "signal must be provided to the reg(...) function.");
 
-    return b.create<seq::CompRegOp>(loc, in.getType(), in, resolvedClk, name,
-                                    resolvedRst, rstValue, hw::InnerSymAttr());
+    return b.create<seq::CompRegOp>(loc, in, resolvedClk, resolvedRst, rstValue,
+                                    name);
   }
 
   Value cmp(Value lhs, Value rhs, comb::ICmpPredicate predicate,

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -178,7 +178,8 @@ public:
         // be clocked.
         if (isStallablePipeline) {
           dataReg = builder.create<seq::CompRegClockEnabledOp>(
-              stageOp->getLoc(), regIn, args.clock, stageValid, regName);
+              stageOp->getLoc(), regIn, args.clock, stageValid,
+              regName.strref());
         } else {
           dataReg = builder.create<seq::CompRegOp>(stageOp->getLoc(), regIn,
                                                    args.clock, regName);

--- a/lib/Conversion/SeqToSV/SeqToSV.cpp
+++ b/lib/Conversion/SeqToSV/SeqToSV.cpp
@@ -74,7 +74,8 @@ public:
         ConversionPattern::getTypeConverter()->convertType(reg.getType());
 
     auto svReg = rewriter.create<sv::RegOp>(loc, regTy, reg.getNameAttr(),
-                                            reg.getInnerSymAttr());
+                                            reg.getInnerSymAttr(),
+                                            reg.getPowerOnValue());
     svReg->setDialectAttrs(reg->getDialectAttrs());
 
     circt::sv::setSVAttributes(svReg, circt::sv::getSVAttributes(reg));

--- a/lib/Dialect/Arc/Transforms/InferMemories.cpp
+++ b/lib/Dialect/Arc/Transforms/InferMemories.cpp
@@ -125,7 +125,7 @@ void InferMemoriesPass::runOnOperation() {
     auto applyLatency = [&](Value clock, Value data, unsigned latency) {
       for (unsigned i = 0; i < latency; ++i)
         data = builder.create<seq::CompRegOp>(
-            data, clock, builder.getStringAttr(""), Value{}, Value{},
+            data, clock, builder.getStringAttr(""), Value{}, Value{}, Value{},
             hw::InnerSymAttr{});
       return data;
     };

--- a/lib/Dialect/Arc/Transforms/StripSV.cpp
+++ b/lib/Dialect/Arc/Transforms/StripSV.cpp
@@ -152,7 +152,7 @@ void StripSVPass::runOnOperation() {
 
         Value compReg = builder.create<seq::CompRegOp>(
             reg.getLoc(), next.getType(), next, reg.getClk(), reg.getNameAttr(),
-            Value{}, Value{}, reg.getInnerSymAttr());
+            Value{}, Value{}, Value{}, reg.getInnerSymAttr());
         reg.replaceAllUsesWith(compReg);
         opsToDelete.push_back(reg);
         continue;

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -288,59 +288,79 @@ static ParseResult parseCompReg(OpAsmParser &parser, OperationState &result) {
       return failure();
   }
 
-  constexpr size_t ceOperandOffset = (size_t)ClockEnabled;
-  SmallVector<OpAsmParser::UnresolvedOperand, 5> operands;
-  if (parser.parseOperandList(operands))
-    return failure();
-  switch (operands.size()) {
-  case 0:
-    return parser.emitError(loc, "expected operands");
-  case 1:
-    return parser.emitError(loc, "expected clock operand");
-  case 2 + ceOperandOffset:
-    // No reset.
-    break;
-  case 3 + ceOperandOffset:
-    return parser.emitError(loc, "expected resetValue operand");
-  case 4 + ceOperandOffset:
-    // reset and reset value included.
-    break;
-  default:
-    if (ClockEnabled && operands.size() == 2)
-      return parser.emitError(loc, "expected clock enable");
-    return parser.emitError(loc, "too many operands");
+  llvm::SmallVector<OpAsmParser::UnresolvedOperand, 6> operands;
+  OpAsmParser::UnresolvedOperand input, clock, reset, resetValue, ce, powerOn;
+  bool withReset = false;
+  bool withPowerOn = false;
+
+  if (failed(parser.parseOperand(input)) || failed(parser.parseComma()) ||
+      failed(parser.parseOperand(clock)))
+    return parser.emitError(loc, "expected input and clock operands");
+
+  operands.append({input, clock});
+  llvm::SmallVector<int32_t> operandSegmentSizes = {
+      1, // input
+      1, // clock
+  };
+
+  if constexpr (ClockEnabled) {
+    if (failed(parser.parseComma()) || failed(parser.parseOperand(ce)))
+      return parser.emitError(loc, "expected clock enable operand");
+    operands.push_back(ce);
+    operandSegmentSizes.push_back(1);
+  }
+
+  if (succeeded(parser.parseOptionalKeyword("reset"))) {
+    if (failed(parser.parseOperand(reset)) || failed(parser.parseComma()) ||
+        failed(parser.parseOperand(resetValue)))
+      return parser.emitError(loc, "expected reset and resetValue operands");
+    operands.append({reset, resetValue});
+    operandSegmentSizes.append({1, 1});
+    withReset = true;
+  } else {
+    operandSegmentSizes.append({0, 0});
+  }
+
+  if (succeeded(parser.parseOptionalKeyword("powerOn"))) {
+    if (failed(parser.parseOperand(powerOn)))
+      return parser.emitError(loc, "expected powerOn operand");
+    operands.push_back(powerOn);
+    operandSegmentSizes.push_back(1);
+    withPowerOn = true;
+  } else {
+    operandSegmentSizes.push_back(0);
   }
 
   Type i1 = IntegerType::get(result.getContext(), 1);
-
   Type ty;
   if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
       parser.parseType(ty))
     return failure();
 
-  setNameFromResult(parser, result);
-
-  result.addTypes({ty});
-
   SmallVector<Type, 5> operandTypes;
   operandTypes.append({ty, ClockType::get(result.getContext())});
   if constexpr (ClockEnabled)
     operandTypes.push_back(i1);
-  if (operands.size() > 2 + ceOperandOffset)
-    operandTypes.append({i1, ty});
-  return parser.resolveOperands(operands, operandTypes, loc, result.operands);
-}
+  if (withReset)
+    operandTypes.append({i1, ty}); /*reset*/
+  if (withPowerOn)
+    operandTypes.push_back(ty); /*powerOnValue*/
 
-static void printClockEnable(::mlir::OpAsmPrinter &p, CompRegOp op) {}
+  setNameFromResult(parser, result);
+  result.addTypes({ty});
+  if (failed(
+          parser.resolveOperands(operands, operandTypes, loc, result.operands)))
+    return failure();
 
-static void printClockEnable(::mlir::OpAsmPrinter &p,
-                             CompRegClockEnabledOp op) {
-  p << ", " << op.getClockEnable();
+  result.addAttribute(
+      "operandSegmentSizes",
+      parser.getBuilder().getDenseI32ArrayAttr(operandSegmentSizes));
+  return success();
 }
 
 template <class Op>
 static void printCompReg(::mlir::OpAsmPrinter &p, Op op) {
-  SmallVector<StringRef> elidedAttrs;
+  SmallVector<StringRef> elidedAttrs{"operandSegmentSizes"};
   if (auto sym = op.getInnerSymAttr()) {
     elidedAttrs.push_back("inner_sym");
     p << ' ' << "sym ";
@@ -348,9 +368,15 @@ static void printCompReg(::mlir::OpAsmPrinter &p, Op op) {
   }
 
   p << ' ' << op.getInput() << ", " << op.getClk();
-  printClockEnable(p, op);
+
+  if constexpr (std::is_same<Op, CompRegClockEnabledOp>::value)
+    p << ", " << op.getClockEnable();
+
   if (op.getReset())
-    p << ", " << op.getReset() << ", " << op.getResetValue() << ' ';
+    p << " reset " << op.getReset() << ", " << op.getResetValue() << ' ';
+
+  if (Value pov = op.getPowerOnValue())
+    p << " powerOn " << pov;
 
   // Determine if 'name' can be elided.
   if (canElideName(p, op))

--- a/test/Conversion/CalyxToHW/basic.mlir
+++ b/test/Conversion/CalyxToHW/basic.mlir
@@ -54,7 +54,7 @@
     // CHECK-DAG:  %[[BUF_RESET_VAL:.+]] = sv.read_inout %buf_reset
     // CHECK-DAG:  %[[FALSE:.+]] = hw.constant false
     // CHECK-DAG:  %[[SEQ_CLK:.+]] = seq.to_clock %[[BUF_CLK_VAL]]
-    // CHECK-DAG:  %[[BUF_DONE_REG:.+]] = seq.compreg sym @buf_done_reg %[[BUF_WRITE_EN_VAL]], %[[SEQ_CLK]], %[[BUF_RESET_VAL]], %[[FALSE]]  : i1
+    // CHECK-DAG:  %[[BUF_DONE_REG:.+]] = seq.compreg sym @buf_done_reg %[[BUF_WRITE_EN_VAL]], %[[SEQ_CLK]] reset %[[BUF_RESET_VAL]], %[[FALSE]]  : i1
     // CHECK-DAG:  %buf_done = sv.wire
     // CHECK-DAG:  sv.assign %buf_done, %[[BUF_DONE_REG]]
     // CHECK-DAG:  %[[BUF_DONE_VAL:.+]] = sv.read_inout %buf_done
@@ -62,7 +62,7 @@
     // CHECK-DAG:  %[[BUF_DONE_VAL_NEG:.+]] = comb.xor %[[BUF_DONE_VAL]], %true : i1
     // CHECK-DAG:  %[[BUF_REG_WRITE_EN:.+]] = comb.and %[[BUF_WRITE_EN_VAL]], %[[BUF_DONE_VAL_NEG]] : i1
     // CHECK-DAG:  %[[C0_I32:.+]] = hw.constant 0 : i32
-    // CHECK-DAG:  %[[BUF_REG:.+]] = seq.compreg.ce sym @buf_reg %[[BUF_IN_VAL]], %[[SEQ_CLK]], %[[BUF_REG_WRITE_EN]], %[[BUF_RESET_VAL]], %[[C0_I32]]
+    // CHECK-DAG:  %[[BUF_REG:.+]] = seq.compreg.ce sym @buf_reg %[[BUF_IN_VAL]], %[[SEQ_CLK]], %[[BUF_REG_WRITE_EN]] reset %[[BUF_RESET_VAL]], %[[C0_I32]]
     // CHECK-DAG:  %buf = sv.wire
     // CHECK-DAG:  sv.assign %buf, %[[BUF_REG]]
     // CHECK-DAG:  %[[BUF_VAL:.+]] = sv.read_inout %buf

--- a/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
@@ -191,7 +191,7 @@ hw.module @Trivial(in %clock: !seq.clock, in %i0: i4, in %reset: i1, out out: i4
   // CHECK: [[RES0:%.+]] = arc.state @[[TRIVIAL_ARC]](%i0) clock %clock reset %reset lat 1 {names = ["foo"]
   // CHECK-NEXT: hw.output [[RES0:%.+]]
   %0 = hw.constant 0 : i4
-  %foo = seq.compreg %i0, %clock, %reset, %0 : i4
+  %foo = seq.compreg %i0, %clock reset %reset, %0 : i4
   hw.output %foo : i4
 }
 // CHECK-NEXT: }
@@ -210,8 +210,8 @@ hw.module @NonTrivial(in %clock: !seq.clock, in %i0: i4, in %reset1: i1, in %res
   // CHECK-NEXT: [[RES3:%.+]] = arc.state @[[NONTRIVIAL_ARC_1]](%i0) clock %clock reset %reset2 lat 1 {names = ["bar"]
   // CHECK-NEXT: hw.output [[RES2]], [[RES3]]
   %0 = hw.constant 0 : i4
-  %foo = seq.compreg %i0, %clock, %reset1, %0 : i4
-  %bar = seq.compreg %i0, %clock, %reset2, %0 : i4
+  %foo = seq.compreg %i0, %clock reset %reset1, %0 : i4
+  %bar = seq.compreg %i0, %clock reset %reset2, %0 : i4
   hw.output %foo, %bar : i4, i4
 }
 // CHECK-NEXT: }

--- a/test/Conversion/DCToHW/basic.mlir
+++ b/test/Conversion/DCToHW/basic.mlir
@@ -56,14 +56,14 @@ hw.module @join(in %t1 : !dc.token, in %t2 : !dc.token, out out0: !dc.token) {
 // CHECK:           %[[VAL_15:.*]] = hw.constant true
 // CHECK:           %[[VAL_16:.*]] = comb.xor %[[VAL_5]], %[[VAL_15]] : i1
 // CHECK:           %[[VAL_17:.*]] = comb.and %[[VAL_18:.*]], %[[VAL_16]] : i1
-// CHECK:           %[[VAL_19:.*]] = seq.compreg %[[VAL_17]], %[[VAL_1]], %[[VAL_2]], %[[VAL_14]]  : i1
+// CHECK:           %[[VAL_19:.*]] = seq.compreg sym @emitted_0 %[[VAL_17]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_14]]  : i1
 // CHECK:           %[[VAL_20:.*]] = comb.xor %[[VAL_19]], %[[VAL_15]] : i1
 // CHECK:           %[[VAL_9]] = comb.and %[[VAL_20]], %[[VAL_4]] : i1
 // CHECK:           %[[VAL_21:.*]] = comb.and %[[VAL_8]], %[[VAL_9]] : i1
 // CHECK:           %[[VAL_18]] = comb.or %[[VAL_21]], %[[VAL_19]] {sv.namehint = "done0"} : i1
 // CHECK:           %[[VAL_22:.*]] = comb.xor %[[VAL_5]], %[[VAL_15]] : i1
 // CHECK:           %[[VAL_23:.*]] = comb.and %[[VAL_24:.*]], %[[VAL_22]] : i1
-// CHECK:           %[[VAL_25:.*]] = seq.compreg %[[VAL_23]], %[[VAL_1]], %[[VAL_2]], %[[VAL_14]]  : i1
+// CHECK:           %[[VAL_25:.*]] = seq.compreg sym @emitted_1 %[[VAL_23]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_14]]  : i1
 // CHECK:           %[[VAL_26:.*]] = comb.xor %[[VAL_25]], %[[VAL_15]] : i1
 // CHECK:           %[[VAL_13]] = comb.and %[[VAL_26]], %[[VAL_4]] : i1
 // CHECK:           %[[VAL_27:.*]] = comb.and %[[VAL_12]], %[[VAL_13]] : i1

--- a/test/Conversion/FSMToSV/test_basic.mlir
+++ b/test/Conversion/FSMToSV/test_basic.mlir
@@ -41,7 +41,7 @@ hw.module @top(in %arg0: i1, in %arg1: i1, in %clk : !seq.clock, in %rst : i1, o
 // CHECK-NEXT:    %1 = sv.read_inout %to_B : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
 // CHECK-NEXT:    %state_next = sv.reg  : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
 // CHECK-NEXT:    %2 = sv.read_inout %state_next : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
-// CHECK-NEXT:    %state_reg = seq.compreg %2, %clk, %rst, %0  : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
+// CHECK-NEXT:    %state_reg = seq.compreg sym @state_reg %2, %clk reset %rst, %0  : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:    %c42_i8 = hw.constant 42 : i8
 // CHECK-NEXT:    %c0_i8 = hw.constant 0 : i8
 // CHECK-NEXT:    %c1_i8 = hw.constant 1 : i8

--- a/test/Conversion/HandshakeToHW/test_buffer.mlir
+++ b/test/Conversion/HandshakeToHW/test_buffer.mlir
@@ -1,23 +1,19 @@
 // RUN: circt-opt -lower-handshake-to-hw --split-input-file %s | FileCheck %s
 
-// CHECK-LABEL:   hw.module @handshake_buffer_3slots_seq_1ins_1outs_ctrl(
-// CHECK-SAME:          in %[[VAL_0:.*]] : !esi.channel<i0>, 
-// CHECK-SAME:          in %[[CLOCK:.*]] : !seq.clock, 
-// CHECK-SAME:          in %[[VAL_2:.*]] : i1,
-// CHECK-SAME:          out out0 : !esi.channel<i0>
-// CHECK-SAME:    ) {
+// CHECK-LABEL:   hw.module @handshake_buffer_3slots_seq_1ins_1outs_ctrl(in 
+// CHECK-SAME:            %[[VAL_0:.*]] : !esi.channel<i0>, in %[[VAL_1:.*]] : !seq.clock, in %[[VAL_2:.*]] : i1, out out0 : !esi.channel<i0>) {
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_5:.*]] : i0
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = esi.wrap.vr %[[VAL_8:.*]], %[[VAL_9:.*]] : i0
 // CHECK:           %[[VAL_10:.*]] = hw.constant 0 : i0
 // CHECK:           %[[VAL_11:.*]] = hw.constant false
-// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_13:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @valid0_reg %[[VAL_13:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_11]]  : i1
 // CHECK:           %[[VAL_14:.*]] = hw.constant true
 // CHECK:           %[[VAL_15:.*]] = comb.xor %[[VAL_12]], %[[VAL_14]] : i1
 // CHECK:           %[[VAL_5]] = comb.or %[[VAL_15]], %[[VAL_16:.*]] : i1
 // CHECK:           %[[VAL_13]] = comb.mux %[[VAL_5]], %[[VAL_4]], %[[VAL_12]] : i1
 // CHECK:           %[[VAL_17:.*]] = comb.mux %[[VAL_5]], %[[VAL_3]], %[[VAL_18:.*]] : i0
-// CHECK:           %[[VAL_18]] = seq.compreg %[[VAL_17]], %[[CLOCK]], %[[VAL_2]], %[[VAL_10]]  : i0
-// CHECK:           %[[VAL_19:.*]] = seq.compreg %[[VAL_20:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_18]] = seq.compreg sym @data0_reg %[[VAL_17]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_10]]  : i0
+// CHECK:           %[[VAL_19:.*]] = seq.compreg sym @ready0_reg %[[VAL_20:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_11]]  : i1
 // CHECK:           %[[VAL_21:.*]] = comb.mux %[[VAL_19]], %[[VAL_19]], %[[VAL_12]] : i1
 // CHECK:           %[[VAL_16]] = comb.xor %[[VAL_19]], %[[VAL_14]] : i1
 // CHECK:           %[[VAL_22:.*]] = comb.xor %[[VAL_23:.*]], %[[VAL_14]] : i1
@@ -25,18 +21,18 @@
 // CHECK:           %[[VAL_25:.*]] = comb.mux %[[VAL_24]], %[[VAL_12]], %[[VAL_19]] : i1
 // CHECK:           %[[VAL_26:.*]] = comb.and %[[VAL_23]], %[[VAL_19]] : i1
 // CHECK:           %[[VAL_20]] = comb.mux %[[VAL_26]], %[[VAL_11]], %[[VAL_25]] : i1
-// CHECK:           %[[VAL_27:.*]] = seq.compreg %[[VAL_28:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_10]]  : i0
+// CHECK:           %[[VAL_27:.*]] = seq.compreg sym @ctrl_data0_reg %[[VAL_28:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_10]]  : i0
 // CHECK:           %[[VAL_29:.*]] = comb.mux %[[VAL_19]], %[[VAL_27]], %[[VAL_18]] : i0
 // CHECK:           %[[VAL_30:.*]] = comb.mux %[[VAL_24]], %[[VAL_18]], %[[VAL_27]] : i0
 // CHECK:           %[[VAL_28]] = comb.mux %[[VAL_26]], %[[VAL_10]], %[[VAL_30]] : i0
 // CHECK:           %[[VAL_31:.*]] = hw.constant 0 : i0
-// CHECK:           %[[VAL_32:.*]] = seq.compreg %[[VAL_33:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_32:.*]] = seq.compreg sym @valid1_reg %[[VAL_33:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_11]]  : i1
 // CHECK:           %[[VAL_34:.*]] = comb.xor %[[VAL_32]], %[[VAL_14]] : i1
 // CHECK:           %[[VAL_23]] = comb.or %[[VAL_34]], %[[VAL_35:.*]] : i1
 // CHECK:           %[[VAL_33]] = comb.mux %[[VAL_23]], %[[VAL_21]], %[[VAL_32]] : i1
 // CHECK:           %[[VAL_36:.*]] = comb.mux %[[VAL_23]], %[[VAL_29]], %[[VAL_37:.*]] : i0
-// CHECK:           %[[VAL_37]] = seq.compreg %[[VAL_36]], %[[CLOCK]], %[[VAL_2]], %[[VAL_31]]  : i0
-// CHECK:           %[[VAL_38:.*]] = seq.compreg %[[VAL_39:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_37]] = seq.compreg sym @data1_reg %[[VAL_36]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_31]]  : i0
+// CHECK:           %[[VAL_38:.*]] = seq.compreg sym @ready1_reg %[[VAL_39:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_11]]  : i1
 // CHECK:           %[[VAL_40:.*]] = comb.mux %[[VAL_38]], %[[VAL_38]], %[[VAL_32]] : i1
 // CHECK:           %[[VAL_35]] = comb.xor %[[VAL_38]], %[[VAL_14]] : i1
 // CHECK:           %[[VAL_41:.*]] = comb.xor %[[VAL_42:.*]], %[[VAL_14]] : i1
@@ -44,18 +40,18 @@
 // CHECK:           %[[VAL_44:.*]] = comb.mux %[[VAL_43]], %[[VAL_32]], %[[VAL_38]] : i1
 // CHECK:           %[[VAL_45:.*]] = comb.and %[[VAL_42]], %[[VAL_38]] : i1
 // CHECK:           %[[VAL_39]] = comb.mux %[[VAL_45]], %[[VAL_11]], %[[VAL_44]] : i1
-// CHECK:           %[[VAL_46:.*]] = seq.compreg %[[VAL_47:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_31]]  : i0
+// CHECK:           %[[VAL_46:.*]] = seq.compreg sym @ctrl_data1_reg %[[VAL_47:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_31]]  : i0
 // CHECK:           %[[VAL_48:.*]] = comb.mux %[[VAL_38]], %[[VAL_46]], %[[VAL_37]] : i0
 // CHECK:           %[[VAL_49:.*]] = comb.mux %[[VAL_43]], %[[VAL_37]], %[[VAL_46]] : i0
 // CHECK:           %[[VAL_47]] = comb.mux %[[VAL_45]], %[[VAL_31]], %[[VAL_49]] : i0
 // CHECK:           %[[VAL_50:.*]] = hw.constant 0 : i0
-// CHECK:           %[[VAL_51:.*]] = seq.compreg %[[VAL_52:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_51:.*]] = seq.compreg sym @valid2_reg %[[VAL_52:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_11]]  : i1
 // CHECK:           %[[VAL_53:.*]] = comb.xor %[[VAL_51]], %[[VAL_14]] : i1
 // CHECK:           %[[VAL_42]] = comb.or %[[VAL_53]], %[[VAL_54:.*]] : i1
 // CHECK:           %[[VAL_52]] = comb.mux %[[VAL_42]], %[[VAL_40]], %[[VAL_51]] : i1
 // CHECK:           %[[VAL_55:.*]] = comb.mux %[[VAL_42]], %[[VAL_48]], %[[VAL_56:.*]] : i0
-// CHECK:           %[[VAL_56]] = seq.compreg %[[VAL_55]], %[[CLOCK]], %[[VAL_2]], %[[VAL_50]]  : i0
-// CHECK:           %[[VAL_57:.*]] = seq.compreg %[[VAL_58:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_56]] = seq.compreg sym @data2_reg %[[VAL_55]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_50]]  : i0
+// CHECK:           %[[VAL_57:.*]] = seq.compreg sym @ready2_reg %[[VAL_58:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_11]]  : i1
 // CHECK:           %[[VAL_9]] = comb.mux %[[VAL_57]], %[[VAL_57]], %[[VAL_51]] : i1
 // CHECK:           %[[VAL_54]] = comb.xor %[[VAL_57]], %[[VAL_14]] : i1
 // CHECK:           %[[VAL_59:.*]] = comb.xor %[[VAL_7]], %[[VAL_14]] : i1
@@ -63,7 +59,7 @@
 // CHECK:           %[[VAL_61:.*]] = comb.mux %[[VAL_60]], %[[VAL_51]], %[[VAL_57]] : i1
 // CHECK:           %[[VAL_62:.*]] = comb.and %[[VAL_7]], %[[VAL_57]] : i1
 // CHECK:           %[[VAL_58]] = comb.mux %[[VAL_62]], %[[VAL_11]], %[[VAL_61]] : i1
-// CHECK:           %[[VAL_63:.*]] = seq.compreg %[[VAL_64:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_50]]  : i0
+// CHECK:           %[[VAL_63:.*]] = seq.compreg sym @ctrl_data2_reg %[[VAL_64:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_50]]  : i0
 // CHECK:           %[[VAL_8]] = comb.mux %[[VAL_57]], %[[VAL_63]], %[[VAL_56]] : i0
 // CHECK:           %[[VAL_65:.*]] = comb.mux %[[VAL_60]], %[[VAL_56]], %[[VAL_63]] : i0
 // CHECK:           %[[VAL_64]] = comb.mux %[[VAL_62]], %[[VAL_50]], %[[VAL_65]] : i0
@@ -77,24 +73,20 @@ handshake.func @test_buffer_none(%arg0: none, %arg1: none, ...) -> (none, none) 
 
 // -----
 
-// CHECK-LABEL:   hw.module @handshake_buffer_in_ui64_out_ui64_2slots_seq(
-// CHECK-SAME:           in %[[VAL_0:.*]] : !esi.channel<i64>, 
-// CHECK-SAME:           in %[[CLOCK:.*]] : !seq.clock, 
-// CHECK-SAME:           in %[[VAL_2:.*]] : i1,
-// CHECK-SAME:           out out0 : !esi.channel<i64>
-// CHECK-SAME:    ) {
+// CHECK-LABEL:   hw.module @handshake_buffer_in_ui64_out_ui64_2slots_seq(in 
+// CHECK-SAME:               %[[VAL_0:.*]] : !esi.channel<i64>, in %[[VAL_1:.*]] : !seq.clock, in %[[VAL_2:.*]] : i1, out out0 : !esi.channel<i64>) {
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_5:.*]] : i64
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]] = esi.wrap.vr %[[VAL_8:.*]], %[[VAL_9:.*]] : i64
 // CHECK:           %[[VAL_10:.*]] = hw.constant 0 : i64
 // CHECK:           %[[VAL_11:.*]] = hw.constant false
-// CHECK:           %[[VAL_12:.*]] = seq.compreg %[[VAL_13:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @valid0_reg %[[VAL_13:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_11]]  : i1
 // CHECK:           %[[VAL_14:.*]] = hw.constant true
 // CHECK:           %[[VAL_15:.*]] = comb.xor %[[VAL_12]], %[[VAL_14]] : i1
 // CHECK:           %[[VAL_5]] = comb.or %[[VAL_15]], %[[VAL_16:.*]] : i1
 // CHECK:           %[[VAL_13]] = comb.mux %[[VAL_5]], %[[VAL_4]], %[[VAL_12]] : i1
 // CHECK:           %[[VAL_17:.*]] = comb.mux %[[VAL_5]], %[[VAL_3]], %[[VAL_18:.*]] : i64
-// CHECK:           %[[VAL_18]] = seq.compreg %[[VAL_17]], %[[CLOCK]], %[[VAL_2]], %[[VAL_10]]  : i64
-// CHECK:           %[[VAL_19:.*]] = seq.compreg %[[VAL_20:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_18]] = seq.compreg sym @data0_reg %[[VAL_17]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_10]]  : i64
+// CHECK:           %[[VAL_19:.*]] = seq.compreg sym @ready0_reg %[[VAL_20:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_11]]  : i1
 // CHECK:           %[[VAL_21:.*]] = comb.mux %[[VAL_19]], %[[VAL_19]], %[[VAL_12]] : i1
 // CHECK:           %[[VAL_16]] = comb.xor %[[VAL_19]], %[[VAL_14]] : i1
 // CHECK:           %[[VAL_22:.*]] = comb.xor %[[VAL_23:.*]], %[[VAL_14]] : i1
@@ -102,17 +94,17 @@ handshake.func @test_buffer_none(%arg0: none, %arg1: none, ...) -> (none, none) 
 // CHECK:           %[[VAL_25:.*]] = comb.mux %[[VAL_24]], %[[VAL_12]], %[[VAL_19]] : i1
 // CHECK:           %[[VAL_26:.*]] = comb.and %[[VAL_23]], %[[VAL_19]] : i1
 // CHECK:           %[[VAL_20]] = comb.mux %[[VAL_26]], %[[VAL_11]], %[[VAL_25]] : i1
-// CHECK:           %[[VAL_27:.*]] = seq.compreg %[[VAL_28:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_10]]  : i64
+// CHECK:           %[[VAL_27:.*]] = seq.compreg sym @ctrl_data0_reg %[[VAL_28:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_10]]  : i64
 // CHECK:           %[[VAL_29:.*]] = comb.mux %[[VAL_19]], %[[VAL_27]], %[[VAL_18]] : i64
 // CHECK:           %[[VAL_30:.*]] = comb.mux %[[VAL_24]], %[[VAL_18]], %[[VAL_27]] : i64
 // CHECK:           %[[VAL_28]] = comb.mux %[[VAL_26]], %[[VAL_10]], %[[VAL_30]] : i64
-// CHECK:           %[[VAL_31:.*]] = seq.compreg %[[VAL_32:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_31:.*]] = seq.compreg sym @valid1_reg %[[VAL_32:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_11]]  : i1
 // CHECK:           %[[VAL_33:.*]] = comb.xor %[[VAL_31]], %[[VAL_14]] : i1
 // CHECK:           %[[VAL_23]] = comb.or %[[VAL_33]], %[[VAL_34:.*]] : i1
 // CHECK:           %[[VAL_32]] = comb.mux %[[VAL_23]], %[[VAL_21]], %[[VAL_31]] : i1
 // CHECK:           %[[VAL_35:.*]] = comb.mux %[[VAL_23]], %[[VAL_29]], %[[VAL_36:.*]] : i64
-// CHECK:           %[[VAL_36]] = seq.compreg %[[VAL_35]], %[[CLOCK]], %[[VAL_2]], %[[VAL_10]]  : i64
-// CHECK:           %[[VAL_37:.*]] = seq.compreg %[[VAL_38:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_36]] = seq.compreg sym @data1_reg %[[VAL_35]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_10]]  : i64
+// CHECK:           %[[VAL_37:.*]] = seq.compreg sym @ready1_reg %[[VAL_38:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_11]]  : i1
 // CHECK:           %[[VAL_9]] = comb.mux %[[VAL_37]], %[[VAL_37]], %[[VAL_31]] : i1
 // CHECK:           %[[VAL_34]] = comb.xor %[[VAL_37]], %[[VAL_14]] : i1
 // CHECK:           %[[VAL_39:.*]] = comb.xor %[[VAL_7]], %[[VAL_14]] : i1
@@ -120,7 +112,7 @@ handshake.func @test_buffer_none(%arg0: none, %arg1: none, ...) -> (none, none) 
 // CHECK:           %[[VAL_41:.*]] = comb.mux %[[VAL_40]], %[[VAL_31]], %[[VAL_37]] : i1
 // CHECK:           %[[VAL_42:.*]] = comb.and %[[VAL_7]], %[[VAL_37]] : i1
 // CHECK:           %[[VAL_38]] = comb.mux %[[VAL_42]], %[[VAL_11]], %[[VAL_41]] : i1
-// CHECK:           %[[VAL_43:.*]] = seq.compreg %[[VAL_44:.*]], %[[CLOCK]], %[[VAL_2]], %[[VAL_10]]  : i64
+// CHECK:           %[[VAL_43:.*]] = seq.compreg sym @ctrl_data1_reg %[[VAL_44:.*]], %[[VAL_1]] reset %[[VAL_2]], %[[VAL_10]]  : i64
 // CHECK:           %[[VAL_8]] = comb.mux %[[VAL_37]], %[[VAL_43]], %[[VAL_36]] : i64
 // CHECK:           %[[VAL_45:.*]] = comb.mux %[[VAL_40]], %[[VAL_36]], %[[VAL_43]] : i64
 // CHECK:           %[[VAL_44]] = comb.mux %[[VAL_42]], %[[VAL_10]], %[[VAL_45]] : i64
@@ -141,7 +133,7 @@ handshake.func @test_buffer_data(%arg0: index, %arg1: none, ...) -> (index, none
 // CHECK-SAME: out out0 : !esi.channel<!hw.struct<field0: i32, field1: i32>>
 // CHECK-SAME: ) {
 // CHECK:         %[[CZERO:.*]] = hw.struct_create (%c0_i32, %c0_i32) : !hw.struct<field0: i32, field1: i32>
-// CHECK:         %data0_reg = seq.compreg %4, %clock, %reset, %[[CZERO]]  : !hw.struct<field0: i32, field1: i32>
+// CHECK:         %data0_reg = seq.compreg sym @data0_reg %4, %clock reset %reset, %[[CZERO]]  : !hw.struct<field0: i32, field1: i32>
 
 handshake.func @test_buffer_tuple_seq(%t: tuple<i32, i32>, %arg0: none, ...) -> (tuple<i32, i32>, none) {
   %0 = buffer [2] seq %t : tuple<i32, i32>

--- a/test/Conversion/HandshakeToHW/test_cmerge.mlir
+++ b/test/Conversion/HandshakeToHW/test_cmerge.mlir
@@ -2,16 +2,17 @@
 
 // Test a control merge that is control only.
 
-// CHECK:   hw.module @handshake_control_merge_out_ui64_2ins_2outs_ctrl(in %[[VAL_0:.*]] : !esi.channel<i0>, in %[[VAL_1:.*]] : !esi.channel<i0>, in %[[CLOCK:.*]] : !seq.clock, in %[[VAL_3:.*]] : i1, out dataOut : !esi.channel<i0>, out index : !esi.channel<i64>) {
+// CHECK-LABEL:   hw.module @handshake_control_merge_out_ui64_2ins_2outs_ctrl(in 
+// CHECK-SAME:             %[[VAL_0:.*]] : !esi.channel<i0>, in %[[VAL_1:.*]] : !esi.channel<i0>, in %[[VAL_2:.*]] : !seq.clock, in %[[VAL_3:.*]] : i1, out dataOut : !esi.channel<i0>, out index : !esi.channel<i64>) {
 // CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_6:.*]] : i0
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_9:.*]] : i0
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = esi.wrap.vr %[[VAL_12:.*]], %[[VAL_13:.*]] : i0
 // CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = esi.wrap.vr %[[VAL_16:.*]], %[[VAL_17:.*]] : i64
 // CHECK:           %[[VAL_18:.*]] = hw.constant 0 : i2
 // CHECK:           %[[VAL_19:.*]] = hw.constant false
-// CHECK:           %[[VAL_20:.*]] = seq.compreg %[[VAL_21:.*]], %[[CLOCK]], %[[VAL_3]], %[[VAL_18]]  : i2
-// CHECK:           %[[VAL_22:.*]] = seq.compreg %[[VAL_23:.*]], %[[CLOCK]], %[[VAL_3]], %[[VAL_19]]  : i1
-// CHECK:           %[[VAL_24:.*]] = seq.compreg %[[VAL_25:.*]], %[[CLOCK]], %[[VAL_3]], %[[VAL_19]]  : i1
+// CHECK:           %[[VAL_20:.*]] = seq.compreg sym @won_reg %[[VAL_21:.*]], %[[VAL_2]] reset %[[VAL_3]], %[[VAL_18]]  : i2
+// CHECK:           %[[VAL_22:.*]] = seq.compreg sym @result_emitted_reg %[[VAL_23:.*]], %[[VAL_2]] reset %[[VAL_3]], %[[VAL_19]]  : i1
+// CHECK:           %[[VAL_24:.*]] = seq.compreg sym @index_emitted_reg %[[VAL_25:.*]], %[[VAL_2]] reset %[[VAL_3]], %[[VAL_19]]  : i1
 // CHECK:           %[[VAL_26:.*]] = comb.extract %[[VAL_27:.*]] from 0 : (i2) -> i1
 // CHECK:           %[[VAL_28:.*]] = comb.extract %[[VAL_27]] from 1 : (i2) -> i1
 // CHECK:           %[[VAL_29:.*]] = comb.or %[[VAL_26]], %[[VAL_28]] : i1
@@ -47,7 +48,7 @@
 // CHECK:           %[[VAL_6]] = comb.icmp eq %[[VAL_50]], %[[VAL_35]] : i2
 // CHECK:           %[[VAL_9]] = comb.icmp eq %[[VAL_50]], %[[VAL_33]] : i2
 // CHECK:           hw.output %[[VAL_10]], %[[VAL_14]] : !esi.channel<i0>, !esi.channel<i64>
-// CHECK:         }
+// CHECK:         } 
 
 handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none, index, none) {
   %0:2 = control_merge %arg0, %arg1 : none, index
@@ -58,7 +59,8 @@ handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none
 
 // Test a control merge that also outputs the selected input's data.
 
-// CHECK:   hw.module @handshake_control_merge_in_ui64_ui64_ui64_out_ui64_ui64(in %[[VAL_0:.*]] : !esi.channel<i64>, in %[[VAL_1:.*]] : !esi.channel<i64>, in %[[VAL_2:.*]] : !esi.channel<i64>, in %[[CLOCK:.*]] : !seq.clock, in %[[VAL_4:.*]] : i1, out dataOut : !esi.channel<i64>, out index : !esi.channel<i64>) {
+// CHECK-LABEL:   hw.module @handshake_control_merge_in_ui64_ui64_ui64_out_ui64_ui64(in 
+// CHECK-SAME:         %[[VAL_0:.*]] : !esi.channel<i64>, in %[[VAL_1:.*]] : !esi.channel<i64>, in %[[VAL_2:.*]] : !esi.channel<i64>, in %[[VAL_3:.*]] : !seq.clock, in %[[VAL_4:.*]] : i1, out dataOut : !esi.channel<i64>, out index : !esi.channel<i64>) {
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = esi.unwrap.vr %[[VAL_0]], %[[VAL_7:.*]] : i64
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = esi.unwrap.vr %[[VAL_1]], %[[VAL_10:.*]] : i64
 // CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]] = esi.unwrap.vr %[[VAL_2]], %[[VAL_13:.*]] : i64
@@ -66,9 +68,9 @@ handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none
 // CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]] = esi.wrap.vr %[[VAL_20:.*]], %[[VAL_21:.*]] : i64
 // CHECK:           %[[VAL_22:.*]] = hw.constant 0 : i3
 // CHECK:           %[[VAL_23:.*]] = hw.constant false
-// CHECK:           %[[VAL_24:.*]] = seq.compreg %[[VAL_25:.*]], %[[CLOCK]], %[[VAL_4]], %[[VAL_22]]  : i3
-// CHECK:           %[[VAL_26:.*]] = seq.compreg %[[VAL_27:.*]], %[[CLOCK]], %[[VAL_4]], %[[VAL_23]]  : i1
-// CHECK:           %[[VAL_28:.*]] = seq.compreg %[[VAL_29:.*]], %[[CLOCK]], %[[VAL_4]], %[[VAL_23]]  : i1
+// CHECK:           %[[VAL_24:.*]] = seq.compreg sym @won_reg %[[VAL_25:.*]], %[[VAL_3]] reset %[[VAL_4]], %[[VAL_22]]  : i3
+// CHECK:           %[[VAL_26:.*]] = seq.compreg sym @result_emitted_reg %[[VAL_27:.*]], %[[VAL_3]] reset %[[VAL_4]], %[[VAL_23]]  : i1
+// CHECK:           %[[VAL_28:.*]] = seq.compreg sym @index_emitted_reg %[[VAL_29:.*]], %[[VAL_3]] reset %[[VAL_4]], %[[VAL_23]]  : i1
 // CHECK:           %[[VAL_30:.*]] = comb.extract %[[VAL_31:.*]] from 0 : (i3) -> i1
 // CHECK:           %[[VAL_32:.*]] = comb.extract %[[VAL_31]] from 1 : (i3) -> i1
 // CHECK:           %[[VAL_33:.*]] = comb.extract %[[VAL_31]] from 2 : (i3) -> i1
@@ -114,7 +116,6 @@ handshake.func @test_cmerge(%arg0: none, %arg1: none, %arg2: none, ...) -> (none
 // CHECK:           %[[VAL_13]] = comb.icmp eq %[[VAL_62]], %[[VAL_39]] : i3
 // CHECK:           hw.output %[[VAL_14]], %[[VAL_18]] : !esi.channel<i64>, !esi.channel<i64>
 // CHECK:         }
-
 handshake.func @test_cmerge_data(%arg0: index, %arg1: index, %arg2: index) -> (index, index) {
   %0:2 = control_merge %arg0, %arg1, %arg2 : index, index
   return %0#0, %0#1 : index, index

--- a/test/Conversion/HandshakeToHW/test_fork.mlir
+++ b/test/Conversion/HandshakeToHW/test_fork.mlir
@@ -8,14 +8,14 @@
 // CHECK:           %[[VAL_13:.*]] = hw.constant true
 // CHECK:           %[[VAL_14:.*]] = comb.xor %[[VAL_5]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_15:.*]] = comb.and %[[VAL_16:.*]], %[[VAL_14]] : i1
-// CHECK:           %[[VAL_17:.*]] = seq.compreg %[[VAL_15]], %[[CLOCK]], %[[VAL_2]], %[[VAL_12]]  : i1
+// CHECK:           %[[VAL_17:.*]] = seq.compreg sym @emitted_0 %[[VAL_15]], %[[CLOCK]] reset %[[VAL_2]], %[[VAL_12]]  : i1
 // CHECK:           %[[VAL_18:.*]] = comb.xor %[[VAL_17]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_8]] = comb.and %[[VAL_18]], %[[VAL_4]] : i1
 // CHECK:           %[[VAL_19:.*]] = comb.and %[[VAL_7]], %[[VAL_8]] : i1
 // CHECK:           %[[VAL_16]] = comb.or %[[VAL_19]], %[[VAL_17]] {sv.namehint = "done0"} : i1
 // CHECK:           %[[VAL_20:.*]] = comb.xor %[[VAL_5]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_21:.*]] = comb.and %[[VAL_22:.*]], %[[VAL_20]] : i1
-// CHECK:           %[[VAL_23:.*]] = seq.compreg %[[VAL_21]], %[[CLOCK]], %[[VAL_2]], %[[VAL_12]]  : i1
+// CHECK:           %[[VAL_23:.*]] = seq.compreg sym @emitted_1 %[[VAL_21]], %[[CLOCK]] reset %[[VAL_2]], %[[VAL_12]]  : i1
 // CHECK:           %[[VAL_24:.*]] = comb.xor %[[VAL_23]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_11]] = comb.and %[[VAL_24]], %[[VAL_4]] : i1
 // CHECK:           %[[VAL_25:.*]] = comb.and %[[VAL_10]], %[[VAL_11]] : i1
@@ -39,14 +39,14 @@ handshake.func @test_fork(%arg0: none, %arg1: none, ...) -> (none, none, none) {
 // CHECK:           %[[VAL_13:.*]] = hw.constant true
 // CHECK:           %[[VAL_14:.*]] = comb.xor %[[VAL_5]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_15:.*]] = comb.and %[[VAL_16:.*]], %[[VAL_14]] : i1
-// CHECK:           %[[VAL_17:.*]] = seq.compreg %[[VAL_15]], %[[CLOCK]], %[[VAL_2]], %[[VAL_12]]  : i1
+// CHECK:           %[[VAL_17:.*]] = seq.compreg sym @emitted_0 %[[VAL_15]], %[[CLOCK]] reset %[[VAL_2]], %[[VAL_12]]  : i1
 // CHECK:           %[[VAL_18:.*]] = comb.xor %[[VAL_17]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_8]] = comb.and %[[VAL_18]], %[[VAL_4]] : i1
 // CHECK:           %[[VAL_19:.*]] = comb.and %[[VAL_7]], %[[VAL_8]] : i1
 // CHECK:           %[[VAL_16]] = comb.or %[[VAL_19]], %[[VAL_17]] {sv.namehint = "done0"} : i1
 // CHECK:           %[[VAL_20:.*]] = comb.xor %[[VAL_5]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_21:.*]] = comb.and %[[VAL_22:.*]], %[[VAL_20]] : i1
-// CHECK:           %[[VAL_23:.*]] = seq.compreg %[[VAL_21]], %[[CLOCK]], %[[VAL_2]], %[[VAL_12]]  : i1
+// CHECK:           %[[VAL_23:.*]] = seq.compreg sym @emitted_1 %[[VAL_21]], %[[CLOCK]] reset %[[VAL_2]], %[[VAL_12]]  : i1
 // CHECK:           %[[VAL_24:.*]] = comb.xor %[[VAL_23]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_11]] = comb.and %[[VAL_24]], %[[VAL_4]] : i1
 // CHECK:           %[[VAL_25:.*]] = comb.and %[[VAL_10]], %[[VAL_11]] : i1

--- a/test/Conversion/HandshakeToHW/test_pack_unpack.mlir
+++ b/test/Conversion/HandshakeToHW/test_pack_unpack.mlir
@@ -33,14 +33,14 @@ handshake.func @test_pack(%arg0: i64, %arg1: i32, %ctrl: none, ...) -> (tuple<i6
 // CHECK:           %[[VAL_15:.*]] = hw.constant true
 // CHECK:           %[[VAL_16:.*]] = comb.xor %[[VAL_5]], %[[VAL_15]] : i1
 // CHECK:           %[[VAL_17:.*]] = comb.and %[[VAL_18:.*]], %[[VAL_16]] : i1
-// CHECK:           %[[VAL_19:.*]] = seq.compreg %[[VAL_17]], %[[CLOCK]], %[[VAL_2]], %[[VAL_14]]  : i1
+// CHECK:           %[[VAL_19:.*]] = seq.compreg sym @emitted_0 %[[VAL_17]], %[[CLOCK]] reset %[[VAL_2]], %[[VAL_14]]  : i1
 // CHECK:           %[[VAL_20:.*]] = comb.xor %[[VAL_19]], %[[VAL_15]] : i1
 // CHECK:           %[[VAL_9]] = comb.and %[[VAL_20]], %[[VAL_4]] : i1
 // CHECK:           %[[VAL_21:.*]] = comb.and %[[VAL_7]], %[[VAL_9]] : i1
 // CHECK:           %[[VAL_18]] = comb.or %[[VAL_21]], %[[VAL_19]] {sv.namehint = "done0"} : i1
 // CHECK:           %[[VAL_22:.*]] = comb.xor %[[VAL_5]], %[[VAL_15]] : i1
 // CHECK:           %[[VAL_23:.*]] = comb.and %[[VAL_24:.*]], %[[VAL_22]] : i1
-// CHECK:           %[[VAL_25:.*]] = seq.compreg %[[VAL_23]], %[[CLOCK]], %[[VAL_2]], %[[VAL_14]]  : i1
+// CHECK:           %[[VAL_25:.*]] = seq.compreg sym @emitted_1 %[[VAL_23]], %[[CLOCK]] reset %[[VAL_2]], %[[VAL_14]]  : i1
 // CHECK:           %[[VAL_26:.*]] = comb.xor %[[VAL_25]], %[[VAL_15]] : i1
 // CHECK:           %[[VAL_13]] = comb.and %[[VAL_26]], %[[VAL_4]] : i1
 // CHECK:           %[[VAL_27:.*]] = comb.and %[[VAL_11]], %[[VAL_13]] : i1

--- a/test/Conversion/HandshakeToHW/test_sync.mlir
+++ b/test/Conversion/HandshakeToHW/test_sync.mlir
@@ -11,14 +11,14 @@
 // CHECK:           %[[VAL_18:.*]] = hw.constant true
 // CHECK:           %[[VAL_19:.*]] = comb.xor %[[VAL_16]], %[[VAL_18]] : i1
 // CHECK:           %[[VAL_20:.*]] = comb.and %[[VAL_21:.*]], %[[VAL_19]] : i1
-// CHECK:           %[[VAL_22:.*]] = seq.compreg %[[VAL_20]], %[[CLOCK]], %[[VAL_3]], %[[VAL_17]]  : i1
+// CHECK:           %[[VAL_22:.*]] = seq.compreg sym @emitted_0 %[[VAL_20]], %[[CLOCK]] reset %[[VAL_3]], %[[VAL_17]]  : i1
 // CHECK:           %[[VAL_23:.*]] = comb.xor %[[VAL_22]], %[[VAL_18]] : i1
 // CHECK:           %[[VAL_11]] = comb.and %[[VAL_23]], %[[VAL_15]] : i1
 // CHECK:           %[[VAL_24:.*]] = comb.and %[[VAL_10]], %[[VAL_11]] : i1
 // CHECK:           %[[VAL_21]] = comb.or %[[VAL_24]], %[[VAL_22]] {sv.namehint = "done0"} : i1
 // CHECK:           %[[VAL_25:.*]] = comb.xor %[[VAL_16]], %[[VAL_18]] : i1
 // CHECK:           %[[VAL_26:.*]] = comb.and %[[VAL_27:.*]], %[[VAL_25]] : i1
-// CHECK:           %[[VAL_28:.*]] = seq.compreg %[[VAL_26]], %[[CLOCK]], %[[VAL_3]], %[[VAL_17]]  : i1
+// CHECK:           %[[VAL_28:.*]] = seq.compreg sym @emitted_1 %[[VAL_26]], %[[CLOCK]] reset %[[VAL_3]], %[[VAL_17]]  : i1
 // CHECK:           %[[VAL_29:.*]] = comb.xor %[[VAL_28]], %[[VAL_18]] : i1
 // CHECK:           %[[VAL_14]] = comb.and %[[VAL_29]], %[[VAL_15]] : i1
 // CHECK:           %[[VAL_30:.*]] = comb.and %[[VAL_13]], %[[VAL_14]] : i1

--- a/test/Conversion/PipelineToHW/test_basic.mlir
+++ b/test/Conversion/PipelineToHW/test_basic.mlir
@@ -13,15 +13,15 @@ hw.module @testBasic(in %arg0: i1, in %clk: !seq.clock, in %rst: i1, out out : i
 // CHECK:   hw.module @testLatency1(in %[[VAL_0:.*]] : i32, in %[[VAL_1:.*]] : i32, in %[[VAL_2:.*]] : i1, in %[[CLOCK:.*]] : !seq.clock, in %[[VAL_4:.*]] : i1, out out : i32, out done : i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.add %[[VAL_0]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_6:.*]] = hw.constant false
-// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_6]]  : i1
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage1_enable  %[[VAL_2]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_6]]  : i1
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage2_enable %[[VAL_7]], %[[CLOCK]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage2_enable  %[[VAL_7]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_stage2_reg0 %[[VAL_5]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_11:.*]] = hw.constant false
-// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_stage3_enable %[[VAL_9]], %[[CLOCK]], %[[VAL_4]], %[[VAL_11]]  : i1
+// CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_stage3_enable  %[[VAL_9]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_11]]  : i1
 // CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_stage3_reg0 %[[VAL_10]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_14:.*]] = hw.constant false
-// CHECK:           %[[VAL_15:.*]] = seq.compreg sym @p0_stage4_enable %[[VAL_12]], %[[CLOCK]], %[[VAL_4]], %[[VAL_14]]  : i1
+// CHECK:           %[[VAL_15:.*]] = seq.compreg sym @p0_stage4_enable  %[[VAL_12]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_14]]  : i1
 // CHECK:           hw.output %[[VAL_13]], %[[VAL_15]] : i32, i1
 // CHECK:         }
 hw.module @testLatency1(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk: !seq.clock, in %rst: i1, out out: i32, out done: i1) {
@@ -48,7 +48,7 @@ hw.module @testLatency1(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk: !seq.
 // CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable  %[[VAL_2]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
 // CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
 // CHECK:         }
@@ -68,23 +68,23 @@ hw.module @testSingle(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk: !seq.cl
 // CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable  %[[VAL_2]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
 // CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_10]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_12:.*]] = seq.compreg sym @p0_stage1_reg1 %[[VAL_6]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_13:.*]] = hw.constant false
-// CHECK:           %[[VAL_14:.*]] = seq.compreg sym @p0_stage2_enable %[[VAL_9]], %[[CLOCK]], %[[VAL_4]], %[[VAL_13]]  : i1
+// CHECK:           %[[VAL_14:.*]] = seq.compreg sym @p0_stage2_enable  %[[VAL_9]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_13]]  : i1
 // CHECK:           %[[VAL_15:.*]] = comb.mul %[[VAL_11]], %[[VAL_12]] : i32
 // CHECK:           %[[VAL_16:.*]] = comb.sub %[[VAL_15]], %[[VAL_1]] : i32
 // CHECK:           %[[VAL_17:.*]] = seq.compreg sym @p1_stage0_reg0 %[[VAL_16]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p1_stage0_reg1 %[[VAL_15]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_19:.*]] = hw.constant false
-// CHECK:           %[[VAL_20:.*]] = seq.compreg sym @p1_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_19]]  : i1
+// CHECK:           %[[VAL_20:.*]] = seq.compreg sym @p1_stage1_enable  %[[VAL_2]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_19]]  : i1
 // CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_17]], %[[VAL_18]] : i32
 // CHECK:           %[[VAL_22:.*]] = seq.compreg sym @p1_stage1_reg0 %[[VAL_21]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_23:.*]] = seq.compreg sym @p1_stage1_reg1 %[[VAL_17]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_24:.*]] = hw.constant false
-// CHECK:           %[[VAL_25:.*]] = seq.compreg sym @p1_stage2_enable %[[VAL_20]], %[[CLOCK]], %[[VAL_4]], %[[VAL_24]]  : i1
+// CHECK:           %[[VAL_25:.*]] = seq.compreg sym @p1_stage2_enable  %[[VAL_20]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_24]]  : i1
 // CHECK:           %[[VAL_26:.*]] = comb.mul %[[VAL_22]], %[[VAL_23]] : i32
 // CHECK:           hw.output %[[VAL_15]], %[[VAL_14]] : i32, i1
 // CHECK:         }
@@ -119,11 +119,11 @@ hw.module @testMultiple(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk: !seq.
 // CHECK:           %[[VAL_6:.*]] = comb.sub %[[VAL_0]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_6]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_8]]  : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable  %[[VAL_2]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_8]]  : i1
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_1]] : i32
 // CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_10]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_12:.*]] = hw.constant false
-// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_stage2_enable %[[VAL_9]], %[[CLOCK]], %[[VAL_4]], %[[VAL_12]]  : i1
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @p0_stage2_enable  %[[VAL_9]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_12]]  : i1
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_1]] : i32, i32
 // CHECK:         }
 hw.module @testSingleWithExt(in %arg0: i32, in %ext1: i32, in %go : i1, in %clk: !seq.clock, in %rst: i1, out out0: i32, out out1: i32) {
@@ -149,23 +149,23 @@ hw.module @testSingleWithExt(in %arg0: i32, in %ext1: i32, in %go : i1, in %clk:
 // CHECK:           %[[VAL_5:.*]] = sv.wire : !hw.inout<i32>
 // CHECK:           %[[VAL_6:.*]] = sv.read_inout %[[VAL_5]] : !hw.inout<i32>
 // CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
-// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[CLOCK]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[CLOCK]], %[[VAL_1]] reset %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_8]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_1]], %[[CLOCK]], %[[VAL_3]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_enable  %[[VAL_1]], %[[CLOCK]] reset %[[VAL_3]], %[[VAL_10]]  : i1
 // CHECK:           %[[VAL_12:.*]] = sv.wire : !hw.inout<i32>
 // CHECK:           %[[VAL_13:.*]] = sv.read_inout %[[VAL_12]] : !hw.inout<i32>
 // CHECK:           %[[VAL_14:.*]] = comb.add %[[VAL_13]], %[[VAL_9]] : i32
-// CHECK:           %[[VAL_15:.*]] = seq.compreg.ce %[[VAL_14]], %[[CLOCK]], %[[VAL_11]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           %[[VAL_15:.*]] = seq.compreg.ce %[[VAL_14]], %[[CLOCK]], %[[VAL_11]] reset %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_12]], %[[VAL_15]] : i32
 // CHECK:           %[[VAL_16:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_15]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_17:.*]] = hw.constant false
-// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p0_stage2_enable %[[VAL_11]], %[[CLOCK]], %[[VAL_3]], %[[VAL_17]]  : i1
+// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p0_stage2_enable  %[[VAL_11]], %[[CLOCK]] reset %[[VAL_3]], %[[VAL_17]]  : i1
 // CHECK:           %[[VAL_19:.*]] = sv.wire : !hw.inout<i32>
 // CHECK:           %[[VAL_20:.*]] = sv.read_inout %[[VAL_19]] : !hw.inout<i32>
 // CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_20]], %[[VAL_16]] : i32
-// CHECK:           %[[VAL_22:.*]] = seq.compreg.ce %[[VAL_21]], %[[CLOCK]], %[[VAL_18]], %[[VAL_3]], %[[VAL_4]]  : i32
+// CHECK:           %[[VAL_22:.*]] = seq.compreg.ce %[[VAL_21]], %[[CLOCK]], %[[VAL_18]] reset %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_19]], %[[VAL_22]] : i32
 // CHECK:           hw.output %[[VAL_22]] : i32
 // CHECK:         }
@@ -175,7 +175,7 @@ hw.module @testControlUsage(in %arg0: i32, in %go : i1, in %clk: !seq.clock, in 
     %reg_out_wire = sv.wire : !hw.inout<i32>
     %reg_out = sv.read_inout %reg_out_wire : !hw.inout<i32>
     %add0 = comb.add %reg_out, %a0 : i32
-    %out = seq.compreg.ce %add0, %clk, %go, %rst, %zero : i32
+    %out = seq.compreg.ce %add0, %clk, %go reset %rst, %zero : i32
     sv.assign %reg_out_wire, %out : i32
     pipeline.stage ^bb1 regs(%out : i32)
 
@@ -183,7 +183,7 @@ hw.module @testControlUsage(in %arg0: i32, in %go : i1, in %clk: !seq.clock, in 
     %reg1_out_wire = sv.wire : !hw.inout<i32>
     %reg1_out = sv.read_inout %reg1_out_wire : !hw.inout<i32>
     %add1 = comb.add %reg1_out, %6 : i32
-    %out1 = seq.compreg.ce %add1, %clk, %s1_enable, %rst, %zero : i32
+    %out1 = seq.compreg.ce %add1, %clk, %s1_enable reset %rst, %zero : i32
     sv.assign %reg1_out_wire, %out1 : i32
 
     pipeline.stage ^bb2 regs(%out1 : i32)
@@ -192,7 +192,7 @@ hw.module @testControlUsage(in %arg0: i32, in %go : i1, in %clk: !seq.clock, in 
     %reg2_out_wire = sv.wire : !hw.inout<i32>
     %reg2_out = sv.read_inout %reg2_out_wire : !hw.inout<i32>
     %add2 = comb.add %reg2_out, %9 : i32
-    %out2 = seq.compreg.ce %add2, %clk, %s2_enable, %rst, %zero : i32
+    %out2 = seq.compreg.ce %add2, %clk, %s2_enable reset %rst, %zero : i32
     sv.assign %reg2_out_wire, %out2 : i32
     pipeline.return %out2  : i32
   }
@@ -209,7 +209,7 @@ hw.module @testControlUsage(in %arg0: i32, in %go : i1, in %clk: !seq.clock, in 
 // CHECK:           %[[VAL_9:.*]] = hw.constant false
 // CHECK:           %[[VAL_10:.*]] = hw.constant true
 // CHECK:           %[[VAL_11:.*]] = comb.xor %[[VAL_2]], %[[VAL_10]] : i1
-// CHECK:           %[[VAL_12:.*]] = seq.compreg.ce sym @p0_stage1_enable %[[VAL_7]], %[[CLOCK]], %[[VAL_11]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_12:.*]] = seq.compreg.ce sym @p0_stage1_enable %[[VAL_7]], %[[CLOCK]], %[[VAL_11]] reset %[[VAL_4]], %[[VAL_9]]  : i1
 // CHECK:           %[[VAL_13:.*]] = hw.constant true
 // CHECK:           %[[VAL_14:.*]] = comb.xor %[[VAL_2]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_15:.*]] = comb.and %[[VAL_12]], %[[VAL_14]]
@@ -232,13 +232,13 @@ hw.module @testWithStall(in %arg0: i32, in %go: i1, in %stall : i1, in %clk: !se
 // CHECK:           %[[VAL_7:.*]] = comb.and %[[VAL_1]], %[[VAL_6]]
 // CHECK:           %[[VAL_8:.*]] = seq.compreg.ce sym @MyPipeline_a0 %[[VAL_0]], %[[CLOCK]], %[[VAL_7]] : i32
 // CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @MyPipeline_stage1_enable %[[VAL_7]], %[[CLOCK]], %[[VAL_3]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @MyPipeline_stage1_enable  %[[VAL_7]], %[[CLOCK]] reset %[[VAL_3]], %[[VAL_9]]  : i1
 // CHECK:           %[[VAL_11:.*]] = seq.compreg.ce sym @MyPipeline_a0 %[[VAL_8]], %[[CLOCK]], %[[VAL_10]] {name = "MyPipeline_a0"} : i32
 // CHECK:           %[[VAL_12:.*]] = hw.constant false
 // CHECK:           %[[VAL_13:.*]] = hw.constant true
 // CHECK:           %[[VAL_14:.*]] = comb.xor %[[VAL_4]], %[[VAL_13]] : i1
 // CHECK:           %[[VAL_15:.*]] = comb.or %[[VAL_10]], %[[VAL_14]] : i1
-// CHECK:           %[[VAL_16:.*]] = seq.compreg.ce sym @MyPipeline_stage2_enable %[[VAL_10]], %[[CLOCK]], %[[VAL_15]], %[[VAL_3]], %[[VAL_12]]  : i1
+// CHECK:           %[[VAL_16:.*]] = seq.compreg.ce sym @MyPipeline_stage2_enable %[[VAL_10]], %[[CLOCK]], %[[VAL_15]] reset %[[VAL_3]], %[[VAL_12]]  : i1
 // CHECK:           %[[VAL_17:.*]] = hw.constant true
 // CHECK:           %[[VAL_18:.*]] = comb.xor %[[VAL_4]], %[[VAL_17]] : i1
 // CHECK:           %[[VAL_19:.*]] = comb.or %[[VAL_10]], %[[VAL_18]] : i1
@@ -248,7 +248,7 @@ hw.module @testWithStall(in %arg0: i32, in %go: i1, in %stall : i1, in %clk: !se
 // CHECK:           %[[VAL_23:.*]] = hw.constant true
 // CHECK:           %[[VAL_24:.*]] = comb.xor %[[VAL_4]], %[[VAL_23]] : i1
 // CHECK:           %[[VAL_25:.*]] = comb.or %[[VAL_10]], %[[VAL_24]] : i1
-// CHECK:           %[[VAL_26:.*]] = seq.compreg.ce sym @MyPipeline_stage3_enable %[[VAL_20]], %[[CLOCK]], %[[VAL_25]], %[[VAL_3]], %[[VAL_22]]  : i1
+// CHECK:           %[[VAL_26:.*]] = seq.compreg.ce sym @MyPipeline_stage3_enable %[[VAL_20]], %[[CLOCK]], %[[VAL_25]] reset %[[VAL_3]], %[[VAL_22]]  : i1
 // CHECK:           %[[VAL_27:.*]] = hw.constant true
 // CHECK:           %[[VAL_28:.*]] = comb.xor %[[VAL_4]], %[[VAL_27]] : i1
 // CHECK:           %[[VAL_29:.*]] = comb.or %[[VAL_10]], %[[VAL_28]] : i1
@@ -276,7 +276,7 @@ hw.module @testStallability(in %arg0: i32, in %go: i1, in %clk: !seq.clock, in %
 // CHECK-LABEL:  hw.module @testAnonymous(in %arg0 : i1, in %clk : !seq.clock, in %rst : i1, out out : i1) {
 // CHECK-NEXT:    %stage0_reg0 = seq.compreg sym @stage0_reg0 %arg0, %clk : i1
 // CHECK-NEXT:    %false = hw.constant false
-// CHECK-NEXT:    %stage1_enable = seq.compreg sym @stage1_enable %arg0, %clk, %rst, %false  : i1
+// CHECK-NEXT:    %stage1_enable = seq.compreg sym @stage1_enable  %arg0, %clk reset %rst, %false  : i1
 // CHECK-NEXT:    hw.output %stage0_reg0 : i1
 // CHECK-NEXT:  }
 

--- a/test/Conversion/PipelineToHW/test_ce.mlir
+++ b/test/Conversion/PipelineToHW/test_ce.mlir
@@ -7,7 +7,7 @@
 // CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_6]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_6]] : i32
 // CHECK:           %[[VAL_9:.*]] = hw.constant false
-// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_9]]  : i1
+// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @p0_stage1_enable  %[[VAL_2]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_9]]  : i1
 // CHECK:           %[[VAL_11:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] : i32
 // CHECK:           hw.output %[[VAL_11]], %[[VAL_10]] : i32, i1
 // CHECK:         }

--- a/test/Conversion/PipelineToHW/test_clockgates.mlir
+++ b/test/Conversion/PipelineToHW/test_clockgates.mlir
@@ -10,7 +10,7 @@
 // CHECK:           %[[VAL_8:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
-// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_10]]  : i1
+// CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_enable  %[[VAL_2]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_10]]  : i1
 // CHECK:           %[[VAL_12:.*]] = comb.add %[[VAL_8]], %[[VAL_9]] : i32
 // CHECK:           hw.output %[[VAL_12]], %[[VAL_11]] : i32, i1
 // CHECK:         }
@@ -26,7 +26,7 @@
 // CGATE:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_10]] : i32
 // CGATE:           %[[VAL_12:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_8]] : i32
 // CGATE:           %[[VAL_13:.*]] = hw.constant false
-// CGATE:           %[[VAL_14:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[CLOCK]], %[[VAL_4]], %[[VAL_13]]  : i1
+// CGATE:           %[[VAL_14:.*]] = seq.compreg sym @p0_stage1_enable  %[[VAL_2]], %[[CLOCK]] reset %[[VAL_4]], %[[VAL_13]]  : i1
 // CGATE:           %[[VAL_15:.*]] = comb.add %[[VAL_11]], %[[VAL_12]] : i32
 // CGATE:           hw.output %[[VAL_15]], %[[VAL_14]] : i32, i1
 // CGATE:         }

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -128,7 +128,7 @@ esi.pure_module @LoopbackCosimPure {
 // CONN:         %address = hw.struct_extract %rawOutput["address"] : !hw.struct<address: i5, data: i64>
 // CONN:         %data = hw.struct_extract %rawOutput["data"] : !hw.struct<address: i5, data: i64>
 // CONN:         %[[ANDVR:.*]] = comb.and %valid, %ready {sv.namehint = "write_go"} : i1
-// CONN:         %write_done = seq.compreg sym @write_done %[[ANDVR]], %clk, %rst, %false  : i1
+// CONN:         %write_done = seq.compreg sym @write_done  %[[ANDVR]], %clk reset %rst, %false  : i1
 // CONN:         %chanOutput_0, %ready_1 = esi.wrap.vr %[[MEMREAD:.*]], %valid_3 : i64
 // CONN:         %rawOutput_2, %valid_3 = esi.unwrap.vr %readAddress, %ready_1 : i5
 // CONN:         %[[MEMREADIO:.*]] = sv.array_index_inout %MemA[%rawOutput_2] : !hw.inout<uarray<20xi64>>, i5

--- a/test/Dialect/Seq/compreg-errors.mlir
+++ b/test/Dialect/Seq/compreg-errors.mlir
@@ -1,50 +1,56 @@
 // RUN: circt-opt %s -verify-diagnostics --split-input-file
 
-hw.module @top(in %clk: i1, in %rst: i1, in %i: i32) {
-  // expected-error@+1 {{'seq.compreg' expected resetValue operand}}
-  seq.compreg %i, %clk, %rst : i32
+hw.module @top(in %clk : !seq.clock, in %rst: i1, in %i: i32) {
+  // expected-error@+2 {{expected ','}}
+  // expected-error@+1 {{'seq.compreg' expected reset and resetValue operands}}
+  seq.compreg %i, %clk reset %rst : i32
 }
 
 // -----
 
-hw.module @top(in %clk: i1, in %rst: i1, in %i: i32) {
-  // expected-error@+1 {{'seq.compreg' expected clock operand}}
+hw.module @top(in %clk : !seq.clock, in %rst: i1, in %i: i32) {
+  // expected-error@+2 {{expected ','}}
+  // expected-error@+1 {{'seq.compreg' expected input and clock operands}}
   seq.compreg %i : i32
 }
 
 // -----
 
 
-hw.module @top(in %clk: i1, in %rst: i1, in %i: i32) {
-  // expected-error@+1 {{'seq.compreg' expected operands}}
+hw.module @top(in %clk : !seq.clock, in %rst: i1, in %i: i32) {
+  // expected-error@+2 {{expected SSA operand}}
+  // expected-error@+1 {{'seq.compreg' expected input and clock operands}}
   seq.compreg : i32
 }
 
 // -----
 
-hw.module @top(in %clk: i1, in %rst: i1, in %i: i32) {
+hw.module @top(in %clk : !seq.clock, in %rst: i1, in %i: i32) {
   %rv = hw.constant 0 : i32
-  // expected-error@+1 {{'seq.compreg' too many operands}}
-  seq.compreg %i, %clk, %rst, %rv, %rv : i32
+  // expected-error@+1 {{expected ':'}}
+  seq.compreg %i, %clk reset %rst, %rv, %rv : i32
 }
 
 // -----
-hw.module @top_ce(in %clk: i1, in %rst: i1, in %ce: i1, in %i: i32) {
-  // expected-error@+1 {{'seq.compreg.ce' expected resetValue operand}}
-  %r0 = seq.compreg.ce %i, %clk, %ce, %rst : i32
+hw.module @top_ce(in %clk : !seq.clock, in %rst: i1, in %ce: i1, in %i: i32) {
+  // expected-error@+2 {{expected ','}}
+  // expected-error@+1 {{'seq.compreg.ce' expected reset and resetValue operands}}
+  %r0 = seq.compreg.ce %i, %clk, %ce reset %rst : i32
 }
 
 // -----
 
-hw.module @top_ce(in %clk: i1, in %rst: i1, in %ce: i1, in %i: i32) {
-  // expected-error@+1 {{'seq.compreg.ce' expected clock enable}}
+hw.module @top_ce(in %clk : !seq.clock, in %rst: i1, in %ce: i1, in %i: i32) {
+  // expected-error@+2 {{expected ','}}
+  // expected-error@+1 {{'seq.compreg.ce' expected clock enable operand}}
   %r0 = seq.compreg.ce %i, %clk : i32
 }
 
 // -----
 
-hw.module @top_ce(in %clk: i1, in %rst: i1, in %ce: i1, in %i: i32) {
+hw.module @top_powerOn(in %clk : !seq.clock, in %rst : i1, in %powerOn : i32, in %i : i32) {
   %rv = hw.constant 0 : i32
-  // expected-error@+1 {{'seq.compreg.ce' too many operands}}
-  %r0 = seq.compreg.ce %i, %clk, %ce, %rst, %rv, %rv : i32
+  // expected-error@+2 {{expected SSA operand}}
+  // expected-error@+1 {{'seq.compreg' expected powerOn operand}}
+  %r0 = seq.compreg %i, %clk reset %rst, %rv powerOn : i32
 }

--- a/test/Dialect/Seq/lower-fifo.mlir
+++ b/test/Dialect/Seq/lower-fifo.mlir
@@ -10,10 +10,10 @@
 // CHECK:           %[[VAL_7:.*]] = hw.constant -2 : i2
 // CHECK:           %[[VAL_8:.*]] = hw.constant 1 : i2
 // CHECK:           %[[VAL_9:.*]] = hw.constant 0 : i2
-// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @fifo_count %[[VAL_11:.*]], %[[CLOCK]], %[[VAL_1]], %[[VAL_9]]  : i2
+// CHECK:           %[[VAL_10:.*]] = seq.compreg sym @fifo_count  %[[VAL_11:.*]], %[[CLOCK]] reset %[[VAL_1]], %[[VAL_9]]  : i2
 // CHECK:           %[[VAL_12:.*]] = seq.hlmem @fifo_mem %[[CLOCK]], %[[VAL_1]] : <3xi32>
-// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @fifo_rd_addr %[[VAL_14:.*]], %[[CLOCK]], %[[VAL_1]], %[[VAL_9]]  : i2
-// CHECK:           %[[VAL_15:.*]] = seq.compreg sym @fifo_wr_addr %[[VAL_16:.*]], %[[CLOCK]], %[[VAL_1]], %[[VAL_9]]  : i2
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @fifo_rd_addr  %[[VAL_14:.*]], %[[CLOCK]] reset %[[VAL_1]], %[[VAL_9]]  : i2
+// CHECK:           %[[VAL_15:.*]] = seq.compreg sym @fifo_wr_addr  %[[VAL_16:.*]], %[[CLOCK]] reset %[[VAL_1]], %[[VAL_9]]  : i2
 // CHECK:           %[[VAL_17:.*]] = seq.read %[[VAL_12]]{{\[}}%[[VAL_13]]] rden %[[VAL_3]] {latency = 0 : i64} : !seq.hlmem<3xi32>
 // CHECK:           seq.write %[[VAL_12]]{{\[}}%[[VAL_15]]] %[[VAL_2]] wren %[[VAL_4]] {latency = 1 : i64} : !seq.hlmem<3xi32>
 // CHECK:           %[[VAL_18:.*]] = comb.xor %[[VAL_3]], %[[VAL_5]] : i1
@@ -56,10 +56,10 @@ hw.module @fifo1(in %clk : !seq.clock, in %rst : i1, in %in : i32, in %rdEn : i1
 // CHECK:           %[[VAL_10:.*]] = hw.constant 1 : i3
 // CHECK:           %[[VAL_11:.*]] = hw.constant 0 : i3
 // CHECK:           %[[VAL_12:.*]] = hw.constant 1 : i2
-// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @fifo_count %[[VAL_14:.*]], %[[CLOCK]], %[[VAL_1]], %[[VAL_11]]  : i3
+// CHECK:           %[[VAL_13:.*]] = seq.compreg sym @fifo_count  %[[VAL_14:.*]], %[[CLOCK]] reset %[[VAL_1]], %[[VAL_11]]  : i3
 // CHECK:           %[[VAL_15:.*]] = seq.hlmem @fifo_mem %[[CLOCK]], %[[VAL_1]] : <4xi32>
-// CHECK:           %[[VAL_16:.*]] = seq.compreg sym @fifo_rd_addr %[[VAL_17:.*]], %[[CLOCK]], %[[VAL_1]], %[[VAL_6]]  : i2
-// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @fifo_wr_addr %[[VAL_19:.*]], %[[CLOCK]], %[[VAL_1]], %[[VAL_6]]  : i2
+// CHECK:           %[[VAL_16:.*]] = seq.compreg sym @fifo_rd_addr  %[[VAL_17:.*]], %[[CLOCK]] reset %[[VAL_1]], %[[VAL_6]]  : i2
+// CHECK:           %[[VAL_18:.*]] = seq.compreg sym @fifo_wr_addr  %[[VAL_19:.*]], %[[CLOCK]] reset %[[VAL_1]], %[[VAL_6]]  : i2
 // CHECK:           %[[VAL_20:.*]] = seq.read %[[VAL_15]]{{\[}}%[[VAL_16]]] rden %[[VAL_3]] {latency = 0 : i64} : !seq.hlmem<4xi32>
 // CHECK:           seq.write %[[VAL_15]]{{\[}}%[[VAL_18]]] %[[VAL_2]] wren %[[VAL_4]] {latency = 1 : i64} : !seq.hlmem<4xi32>
 // CHECK:           %[[VAL_21:.*]] = comb.icmp eq %[[VAL_13]], %[[VAL_9]] {sv.namehint = "fifo_full"} : i3


### PR DESCRIPTION
In doing so, also opt to move to a keyword style assembly format, rather than a flat list of operands. This is needed to resolve the now two distinct, optional, operands that can occur in the assembly format (reset operands and the power-on operand). To avoid making things too complicated, a keyword is required for either group, e.g.
> `seq.compreg %in %clk reset %rst, %rstValue powerOn %po`

+some related cleanups in places where the default generated builder was being used (without good reason).