### PR TITLE
Support `scf.if` Op Lowering to Calyx

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1420,13 +1420,13 @@ class BuildIfGroups : public calyx::FuncOpPartialLoweringPattern {
         getState<ComponentLoweringState>().setElseGroup(scfIfOp, elseGroupOp);
       }
 
-      for (auto res : scfIfOp.getResults()) {
+      for (auto ifOpRes : scfIfOp.getResults()) {
         auto reg = createRegister(
             scfIfOp.getLoc(), rewriter, getComponent(),
-            res.getType().getIntOrFloatBitWidth(),
+            ifOpRes.getType().getIntOrFloatBitWidth(),
             getState<ComponentLoweringState>().getUniqueName("if_res"));
-        getState<ComponentLoweringState>().setResultRegs(scfIfOp, reg,
-                                                         res.getResultNumber());
+        getState<ComponentLoweringState>().setResultRegs(
+            scfIfOp, reg, ifOpRes.getResultNumber());
       }
 
       return WalkResult::advance();

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -95,6 +95,10 @@ public:
 // Lowering state classes
 //===----------------------------------------------------------------------===//
 
+struct IfScheduleable {
+  scf::IfOp ifOp;
+};
+
 struct WhileScheduleable {
   /// While operation to schedule.
   ScfWhileOp whileOp;
@@ -115,8 +119,63 @@ struct CallScheduleable {
 };
 
 /// A variant of types representing scheduleable operations.
-using Scheduleable = std::variant<calyx::GroupOp, WhileScheduleable,
-                                  ForScheduleable, CallScheduleable>;
+using Scheduleable =
+    std::variant<calyx::GroupOp, WhileScheduleable, ForScheduleable,
+                 IfScheduleable, CallScheduleable>;
+
+class IfLoweringStateInterface {
+public:
+  void setThenGroup(scf::IfOp op, calyx::GroupOp group) {
+    Operation *operation = op.getOperation();
+    assert(thenGroup.count(operation) == 0 &&
+           "A then group was already set for this scf::IfOp!\n");
+    thenGroup[operation] = group;
+  }
+
+  calyx::GroupOp getThenGroup(scf::IfOp op) {
+    auto it = thenGroup.find(op.getOperation());
+    assert(it != thenGroup.end() &&
+           "No then group was set for this scf::IfOp!\n");
+    return it->second;
+  }
+
+  void setElseGroup(scf::IfOp op, calyx::GroupOp group) {
+    Operation *operation = op.getOperation();
+    assert(elseGroup.count(operation) == 0 &&
+           "An else group was already set for this scf::IfOp!\n");
+    elseGroup[operation] = group;
+  }
+
+  calyx::GroupOp getElseGroup(scf::IfOp op) {
+    auto it = elseGroup.find(op.getOperation());
+    assert(it != elseGroup.end() &&
+           "No else group was set for this scf::IfOp!\n");
+    return it->second;
+  }
+
+  void setResultRegs(scf::IfOp op, calyx::RegisterOp reg, unsigned idx) {
+    assert(resultRegs[op.getOperation()].count(idx) == 0 &&
+           "A register was already registered for the given yield result.\n");
+    assert(idx < op->getNumOperands());
+    resultRegs[op.getOperation()][idx] = reg;
+  }
+
+  const DenseMap<unsigned, calyx::RegisterOp> &getResultRegs(scf::IfOp op) {
+    return resultRegs[op.getOperation()];
+  }
+
+  calyx::RegisterOp getResultRegs(scf::IfOp op, unsigned idx) {
+    auto regs = getResultRegs(op);
+    auto it = regs.find(idx);
+    assert(it != regs.end() && "resultReg not found");
+    return it->second;
+  }
+
+private:
+  DenseMap<Operation *, calyx::GroupOp> thenGroup;
+  DenseMap<Operation *, calyx::GroupOp> elseGroup;
+  DenseMap<Operation *, DenseMap<unsigned, calyx::RegisterOp>> resultRegs;
+};
 
 class WhileLoopLoweringStateInterface
     : calyx::LoopLoweringStateInterface<ScfWhileOp> {
@@ -187,6 +246,7 @@ public:
 class ComponentLoweringState : public calyx::ComponentLoweringStateInterface,
                                public WhileLoopLoweringStateInterface,
                                public ForLoopLoweringStateInterface,
+                               public IfLoweringStateInterface,
                                public calyx::SchedulerInterface<Scheduleable> {
 public:
   ComponentLoweringState(calyx::ComponentOp component)
@@ -213,7 +273,7 @@ class BuildOpGroups : public calyx::FuncOpPartialLoweringPattern {
           TypeSwitch<mlir::Operation *, bool>(_op)
               .template Case<arith::ConstantOp, ReturnOp, BranchOpInterface,
                              /// SCF
-                             scf::YieldOp, scf::WhileOp, scf::ForOp,
+                             scf::YieldOp, scf::WhileOp, scf::ForOp, scf::IfOp,
                              /// memref
                              memref::AllocOp, memref::AllocaOp, memref::LoadOp,
                              memref::StoreOp,
@@ -272,6 +332,7 @@ private:
   LogicalResult buildOp(PatternRewriter &rewriter, memref::StoreOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, scf::WhileOp whileOp) const;
   LogicalResult buildOp(PatternRewriter &rewriter, scf::ForOp forOp) const;
+  LogicalResult buildOp(PatternRewriter &rewriter, scf::IfOp ifOp) const;
   LogicalResult buildOp(PatternRewriter &rewriter, CallOp callOp) const;
 
   /// buildLibraryOp will build a TCalyxLibOp inside a TGroupOp based on the
@@ -720,22 +781,53 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
               "loops. Run --scf-for-to-while before running --scf-to-calyx.";
   }
 
-  auto whileOp = dyn_cast<scf::WhileOp>(yieldOp->getParentOp());
-  if (!whileOp) {
-    return yieldOp.getOperation()->emitError()
-           << "Currently only support yield operations inside for and while "
-              "loops.";
-  }
-  ScfWhileOp whileOpInterface(whileOp);
+  if (auto whileOp = dyn_cast<scf::WhileOp>(yieldOp->getParentOp())) {
+    ScfWhileOp whileOpInterface(whileOp);
 
-  auto assignGroup =
-      getState<ComponentLoweringState>().buildWhileLoopIterArgAssignments(
-          rewriter, whileOpInterface,
-          getState<ComponentLoweringState>().getComponentOp(),
-          getState<ComponentLoweringState>().getUniqueName(whileOp) + "_latch",
-          yieldOp->getOpOperands());
-  getState<ComponentLoweringState>().setWhileLoopLatchGroup(whileOpInterface,
-                                                            assignGroup);
+    auto assignGroup =
+        getState<ComponentLoweringState>().buildWhileLoopIterArgAssignments(
+            rewriter, whileOpInterface,
+            getState<ComponentLoweringState>().getComponentOp(),
+            getState<ComponentLoweringState>().getUniqueName(whileOp) +
+                "_latch",
+            yieldOp->getOpOperands());
+    getState<ComponentLoweringState>().setWhileLoopLatchGroup(whileOpInterface,
+                                                              assignGroup);
+    return success();
+  }
+
+  if (auto ifOp = dyn_cast<scf::IfOp>(yieldOp->getParentOp())) {
+    auto resultRegs = getState<ComponentLoweringState>().getResultRegs(ifOp);
+
+    if (yieldOp->getParentRegion() == &ifOp.getThenRegion()) {
+      auto thenGroup = getState<ComponentLoweringState>().getThenGroup(ifOp);
+      for (auto op : enumerate(yieldOp.getOperands())) {
+        auto resultReg =
+            getState<ComponentLoweringState>().getResultRegs(ifOp, op.index());
+        buildAssignmentsForRegisterWrite(
+            rewriter, thenGroup,
+            getState<ComponentLoweringState>().getComponentOp(), resultReg,
+            op.value());
+        getState<ComponentLoweringState>().registerEvaluatingGroup(
+            ifOp.getResult(op.index()), thenGroup);
+      }
+    }
+
+    if (!ifOp.getElseRegion().empty() &&
+        (yieldOp->getParentRegion() == &ifOp.getElseRegion())) {
+      auto elseGroup = getState<ComponentLoweringState>().getElseGroup(ifOp);
+      for (auto op : enumerate(yieldOp.getOperands())) {
+        auto resultReg =
+            getState<ComponentLoweringState>().getResultRegs(ifOp, op.index());
+        buildAssignmentsForRegisterWrite(
+            rewriter, elseGroup,
+            getState<ComponentLoweringState>().getComponentOp(), resultReg,
+            op.value());
+        getState<ComponentLoweringState>().registerEvaluatingGroup(
+            ifOp.getResult(op.index()), elseGroup);
+      }
+    }
+  }
   return success();
 }
 
@@ -942,6 +1034,13 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                             scfForOp,
                                             bound.value(),
                                         });
+  return success();
+}
+
+LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
+                                     scf::IfOp ifOp) const {
+  getState<ComponentLoweringState>().addBlockScheduleable(
+      ifOp.getOperation()->getBlock(), IfScheduleable{ifOp});
   return success();
 }
 
@@ -1291,6 +1390,51 @@ class BuildForGroups : public calyx::FuncOpPartialLoweringPattern {
   }
 };
 
+class BuildIfGroups : public calyx::FuncOpPartialLoweringPattern {
+  using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
+
+  LogicalResult
+  partiallyLowerFuncToComp(FuncOp funcOp,
+                           PatternRewriter &rewriter) const override {
+    LogicalResult res = success();
+    funcOp.walk([&](Operation *op) {
+      if (!isa<scf::IfOp>(op))
+        return WalkResult::advance();
+
+      auto scfIfOp = cast<scf::IfOp>(op);
+
+      calyx::ComponentOp componentOp =
+          getState<ComponentLoweringState>().getComponentOp();
+
+      std::string thenGroupName =
+          getState<ComponentLoweringState>().getUniqueName("then_br");
+      auto thenGroupOp = calyx::createGroup<calyx::GroupOp>(
+          rewriter, componentOp, scfIfOp.getLoc(), thenGroupName);
+      getState<ComponentLoweringState>().setThenGroup(scfIfOp, thenGroupOp);
+
+      if (!scfIfOp.getElseRegion().empty()) {
+        std::string elseGroupName =
+            getState<ComponentLoweringState>().getUniqueName("else_br");
+        auto elseGroupOp = calyx::createGroup<calyx::GroupOp>(
+            rewriter, componentOp, scfIfOp.getLoc(), elseGroupName);
+        getState<ComponentLoweringState>().setElseGroup(scfIfOp, elseGroupOp);
+      }
+
+      for (auto res : scfIfOp.getResults()) {
+        auto reg = createRegister(
+            scfIfOp.getLoc(), rewriter, getComponent(),
+            res.getType().getIntOrFloatBitWidth(),
+            getState<ComponentLoweringState>().getUniqueName("if_res"));
+        getState<ComponentLoweringState>().setResultRegs(scfIfOp, reg,
+                                                         res.getResultNumber());
+      }
+
+      return WalkResult::advance();
+    });
+    return res;
+  }
+};
+
 /// Builds a control schedule by traversing the CFG of the function and
 /// associating this with the previously created groups.
 /// For simplicity, the generated control flow is expanded for all possible
@@ -1384,6 +1528,50 @@ private:
                                          forLatchGroup.getName());
         if (res.failed())
           return res;
+      } else if (auto *ifSchedPtr = std::get_if<IfScheduleable>(&group);
+                 ifSchedPtr) {
+        auto ifOp = ifSchedPtr->ifOp;
+
+        Location loc = ifOp->getLoc();
+
+        auto cond = ifOp.getCondition();
+        auto condGroup = getState<ComponentLoweringState>()
+                             .getEvaluatingGroup<calyx::CombGroupOp>(cond);
+
+        auto symbolAttr = FlatSymbolRefAttr::get(
+            StringAttr::get(getContext(), condGroup.getSymName()));
+
+        bool initElse = !ifOp.getElseRegion().empty();
+        auto ifCtrlOp = rewriter.create<calyx::IfOp>(
+            loc, cond, symbolAttr, /*initializeElseBody=*/initElse);
+
+        rewriter.setInsertionPointToEnd(ifCtrlOp.getBodyBlock());
+
+        auto thenSeqOp =
+            rewriter.create<calyx::SeqOp>(ifOp.getThenRegion().getLoc());
+        auto *thenSeqOpBlock = thenSeqOp.getBodyBlock();
+
+        rewriter.setInsertionPointToEnd(thenSeqOpBlock);
+
+        calyx::GroupOp thenGroup =
+            getState<ComponentLoweringState>().getThenGroup(ifOp);
+        rewriter.create<calyx::EnableOp>(thenGroup.getLoc(),
+                                         thenGroup.getName());
+
+        if (!ifOp.getElseRegion().empty()) {
+          rewriter.setInsertionPointToEnd(ifCtrlOp.getElseBody());
+
+          auto elseSeqOp =
+              rewriter.create<calyx::SeqOp>(ifOp.getElseRegion().getLoc());
+          auto *elseSeqOpBlock = elseSeqOp.getBodyBlock();
+
+          rewriter.setInsertionPointToEnd(elseSeqOpBlock);
+
+          calyx::GroupOp elseGroup =
+              getState<ComponentLoweringState>().getElseGroup(ifOp);
+          rewriter.create<calyx::EnableOp>(elseGroup.getLoc(),
+                                           elseGroup.getName());
+        }
       } else if (auto *callSchedPtr = std::get_if<CallScheduleable>(&group)) {
         auto instanceOp = callSchedPtr->instanceOp;
         OpBuilder::InsertionGuard g(rewriter);
@@ -1540,6 +1728,12 @@ class LateSSAReplacement : public calyx::FuncOpPartialLoweringPattern {
 
   LogicalResult partiallyLowerFuncToComp(FuncOp funcOp,
                                          PatternRewriter &) const override {
+    funcOp.walk([&](scf::IfOp op) {
+      for (auto res : getState<ComponentLoweringState>().getResultRegs(op))
+        op.getOperation()->getResults()[res.first].replaceAllUsesWith(
+            res.second.getOut());
+    });
+
     funcOp.walk([&](scf::WhileOp op) {
       /// The yielded values returned from the while op will be present in the
       /// iterargs registers post execution of the loop.
@@ -1790,6 +1984,8 @@ void SCFToCalyxPass::runOnOperation() {
   addOncePattern<BuildForGroups>(loweringPatterns, patternState, funcMap,
                                  *loweringState);
 
+  addOncePattern<BuildIfGroups>(loweringPatterns, patternState, funcMap,
+                                *loweringState);
   /// This pattern converts operations within basic blocks to Calyx library
   /// operators. Combinational operations are assigned inside a
   /// calyx::CombGroupOp, and sequential inside calyx::GroupOps.

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -572,3 +572,72 @@ module {
     return
   }
 }
+
+// -----
+
+// Test if op with else branch.
+
+module {
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
+// CHECK-SAME:                          %[[VAL_1:in1]]: i32,
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_5:out0]]: i32,
+// CHECK-SAME:                          %[[VAL_6:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_7:.*]] = hw.constant true
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.std_slt @std_slt_0 : i32, i32, i1
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.register @if_res_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.assign %[[VAL_5]] = %[[VAL_24]] : i32
+// CHECK:             calyx.group @then_br_0 {
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_10]] : i32
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_7]] : i1
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_1]] : i32
+// CHECK:               calyx.group_done %[[VAL_19]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @else_br_0 {
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_1]] : i32
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_7]] : i1
+// CHECK:               calyx.group_done %[[VAL_19]] : i1
+// CHECK:             }
+// CHECK:             calyx.comb_group @bb0_0 {
+// CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_1]] : i32
+// CHECK:             }
+// CHECK:             calyx.group @ret_assign_0 {
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_18]] : i32
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_7]] : i1
+// CHECK:               calyx.group_done %[[VAL_25]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.if %[[VAL_13]] with @bb0_0 {
+// CHECK:                 calyx.seq {
+// CHECK:                   calyx.enable @then_br_0
+// CHECK:                 }
+// CHECK:               } else {
+// CHECK:                 calyx.seq {
+// CHECK:                   calyx.enable @else_br_0
+// CHECK:                 }
+// CHECK:               }
+// CHECK:               calyx.enable @ret_assign_0
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
+  func.func @main(%arg0 : i32, %arg1 : i32) -> i32 {
+    %0 = arith.cmpi slt, %arg0, %arg1 : i32
+    %1 = scf.if %0 -> i32 {
+      %3 = arith.addi %arg0, %arg1 : i32
+      scf.yield %3 : i32
+    } else {
+      scf.yield %arg1 : i32
+    }
+    return %1 : i32
+  }
+}


### PR DESCRIPTION
This  PR tries to add support for `scf.if` during lowering to Calyx, as mentioned in [this issue](https://github.com/llvm/circt/issues/4843) #4843 

Currently this PR is still in early stages and contains some issues, but I believe that some guidance would help ensure I'm on the right track!

### My Thoughts and Progress
To add support for `scf.if`, I think we need:
- The structure for `if` op lowering;
- Basic block analysis fir Then/Else region;
- Proper handling block arguments and yield values

### Challenges/Issues
- I'm not sure if my overall approach is on the right track in general, I'd appreciate any insights or suggestions!
- I'm trying to debug/step in the code I'm writing but somehow this newly created `goupOp` is empty and only has `void` in the body, as [in this line](https://github.com/jiahanxie353/circt/blob/c8ff29c4305e2b62ef61b927a10be718179aed57/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp#L769), so I couldn't move on to debug other issues (but ofc this approach could be wrong in the first place).

I understand that this is still a work-in-progress, and there are several rough edges. I'm hoping to get some guidance on the general direction and any potential pitfalls I might encounter. Any feedback, suggestions, or advice would be greatly appreciated!