### PR TITLE
[FIRRTL][Parser] Improve rwprobe parsing, support inst results.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1552,6 +1552,8 @@ private:
   ParseResult parsePathExp(Value &result);
   ParseResult parseRefExp(Value &result, const Twine &message);
   ParseResult parseStaticRefExp(Value &result, const Twine &message);
+  ParseResult parseRWProbeStaticRefExp(FieldRef &refResult, Type &type,
+                                       const Twine &message);
 
   template <typename subop>
   FailureOr<Value> emitCachedSubAccess(Value base,
@@ -3048,6 +3050,168 @@ ParseResult FIRStmtParser::parseStaticRefExp(Value &result,
   return failure(parseIdOrInstance() ||
                  parseOptionalExpPostscript(result, false));
 }
+/// static_reference ::= id
+///                  ::= static_reference '.' id
+///                  ::= static_reference '[' int ']'
+/// Populate `refResult` with rwprobe "root" and parsed indexing.
+/// Root is base-type target, and will be block argument or forceable.
+/// Also set `Type`, so we can handle const-ness while visiting.
+/// If root is an unbundled entry, replace with bounce wire.
+// NOLINTNEXTLINE(misc-no-recursion)
+ParseResult FIRStmtParser::parseRWProbeStaticRefExp(FieldRef &refResult,
+                                                    Type &type,
+                                                    const Twine &message) {
+  auto loc = getToken().getLoc();
+
+  StringRef id;
+  SymbolValueEntry symtabEntry;
+  if (parseId(id, message) ||
+      moduleContext.lookupSymbolEntry(symtabEntry, id, loc))
+    return failure();
+
+  // Three kinds of rwprobe targets:
+  // 1. Instance result.  Replace with a forceable wire, handle as (2).
+  // 2. Forceable declaration.
+  // 3. BlockArgument.
+
+  // Figure out what we have, and parse indexing.
+  Value result;
+  if (auto unbundledId = symtabEntry.dyn_cast<UnbundledID>()) {
+    // This means we have an instance.
+    auto &ubEntry = moduleContext.getUnbundledEntry(unbundledId - 1);
+
+    StringRef fieldName;
+    auto loc = getToken().getLoc();
+    if (parseToken(FIRToken::period, "expected '.' in field reference") ||
+        parseFieldId(fieldName, "expected field name"))
+      return failure();
+
+    // Find unbundled entry for the specified result/port.
+    auto fieldAttr = StringAttr::get(getContext(), fieldName);
+    for (auto &elt : ubEntry) {
+      if (elt.first == fieldAttr) {
+        auto &instResult = elt.second;
+
+        // If it's already forceable, use that.
+        auto *defining = instResult.getDefiningOp();
+        assert(defining);
+        if (isa<Forceable>(defining)) {
+          assert(cast<Forceable>(defining).isForceable());
+          result = instResult;
+          break;
+        }
+
+        // Otherwise, replace with bounce wire.
+        auto type = instResult.getType();
+
+        // Either entire instance result is forceable + bounce wire, or reject.
+        // (even if rwprobe is of a portion of the port)
+        bool forceable = !!firrtl::detail::getForceableResultType(true, type);
+        if (!forceable)
+          return emitError(loc, "unable to force instance result of type ")
+                 << type;
+
+        // Create bounce wire for the instance result.
+        auto annotations = getConstants().emptyArrayAttr;
+        StringAttr sym = {};
+        SmallString<64> name;
+        (id + "_" + fieldName + "_bounce").toVector(name);
+        locationProcessor.setLoc(loc);
+        OpBuilder::InsertionGuard guard(builder);
+        builder.setInsertionPoint(defining);
+        auto bounce =
+            builder.create<WireOp>(type, name, NameKindEnum::InterestingName,
+                                   annotations, sym, /*forceable=*/true);
+        auto bounceVal = bounce.getData();
+
+        // Replace instance result with reads from bounce wire.
+        instResult.replaceAllUsesWith(bounceVal);
+
+        // Connect to/from the result per flow.
+        builder.setInsertionPointAfter(defining);
+        if (foldFlow(instResult) == Flow::Source)
+          emitConnect(builder, bounceVal, instResult);
+        else
+          emitConnect(builder, instResult, bounceVal);
+        result = instResult = bounce.getDataRaw();
+        break;
+      }
+    }
+
+    if (!result) {
+      emitError(loc, "use of invalid field name '")
+          << fieldName << "' on bundle value";
+      return failure();
+    }
+  } else {
+    // This target can be a port or a regular value.
+    result = symtabEntry.get<Value>();
+  }
+
+  assert(result);
+  assert(isa<BlockArgument>(result) || result.getDefiningOp<Forceable>());
+
+  // We have our root value, we just need to parse the field id.
+  // Build up the FieldRef as processing indexing expressions, and
+  // compute the type so that we know the const-ness of the final expression.
+  refResult = FieldRef(result, 0);
+  type = result.getType();
+  while (true) {
+    if (consumeIf(FIRToken::period)) {
+      SmallVector<StringRef, 3> fields;
+      if (parseFieldIdSeq(fields, "expected field name"))
+        return failure();
+      for (auto fieldName : fields) {
+        if (auto bundle = type_dyn_cast<BundleType>(type)) {
+          if (auto index = bundle.getElementIndex(fieldName)) {
+            refResult = refResult.getSubField(bundle.getFieldID(*index));
+            type = bundle.getElementTypePreservingConst(*index);
+            continue;
+          }
+        } else if (auto bundle = type_dyn_cast<OpenBundleType>(type)) {
+          if (auto index = bundle.getElementIndex(fieldName)) {
+            refResult = refResult.getSubField(bundle.getFieldID(*index));
+            type = bundle.getElementTypePreservingConst(*index);
+            continue;
+          }
+        } else {
+          return emitError(loc, "subfield requires bundle operand")
+                 << "got " << type << "\n";
+        }
+        return emitError(loc,
+                         "unknown field '" + fieldName + "' in bundle type ")
+               << type;
+      }
+      continue;
+    }
+    if (consumeIf(FIRToken::l_square)) {
+      auto loc = getToken().getLoc();
+      int32_t index;
+      if (parseIntLit(index, "expected index") ||
+          parseToken(FIRToken::r_square, "expected ']'"))
+        return failure();
+
+      if (index < 0)
+        return emitError(loc, "invalid index specifier");
+
+      if (auto vector = type_dyn_cast<FVectorType>(type)) {
+        if ((unsigned)index < vector.getNumElements()) {
+          refResult = refResult.getSubField(vector.getFieldID(index));
+          type = vector.getElementTypePreservingConst();
+        }
+      } else if (auto vector = type_dyn_cast<OpenVectorType>(type)) {
+        if ((unsigned)index < vector.getNumElements()) {
+          refResult = refResult.getSubField(vector.getFieldID(index));
+          type = vector.getElementTypePreservingConst();
+        }
+      } else {
+        return emitError(loc, "subindex requires vector operand");
+      }
+      continue;
+    }
+    return success();
+  }
+}
 
 /// path ::= 'path(' StringLit ')'
 // NOLINTNEXTLINE(misc-no-recursion)
@@ -3163,9 +3327,11 @@ ParseResult FIRStmtParser::parseProbe(Value &result) {
 ParseResult FIRStmtParser::parseRWProbe(Value &result) {
   auto startTok = consumeToken(FIRToken::lp_rwprobe);
 
-  Value staticRef;
-  if (parseStaticRefExp(staticRef,
-                        "expected static reference expression in 'rwprobe'") ||
+  FieldRef staticRef;
+  Type parsedTargetType;
+  if (parseRWProbeStaticRefExp(
+          staticRef, parsedTargetType,
+          "expected static reference expression in 'rwprobe'") ||
       parseToken(FIRToken::r_paren, "expected ')' in 'rwprobe'"))
     return failure();
 
@@ -3175,20 +3341,24 @@ ParseResult FIRStmtParser::parseRWProbe(Value &result) {
   // Not public port (verifier)
 
   // Check probe expression is base-type.
-  auto targetType = type_dyn_cast<FIRRTLBaseType>(staticRef.getType());
+  auto targetType = type_dyn_cast<FIRRTLBaseType>(parsedTargetType);
   if (!targetType)
     return emitError(startTok.getLoc(),
                      "expected base-type expression in 'rwprobe', got ")
-           << staticRef.getType();
+           << parsedTargetType;
 
-  auto fieldRef = getFieldRefFromValue(staticRef);
-  auto target = fieldRef.getValue();
-
-  auto *definingOp = target.getDefiningOp();
+  auto root = staticRef.getValue();
+  auto *definingOp = root.getDefiningOp();
 
   if (isa_and_nonnull<MemOp, CombMemOp, SeqMemOp, MemoryPortOp,
                       MemoryDebugPortOp, MemoryPortAccessOp>(definingOp))
     return emitError(startTok.getLoc(), "cannot probe memories or their ports");
+
+  auto forceableType =
+    firrtl::detail::getForceableResultType(true, targetType);
+  if (!forceableType)
+    return emitError(startTok.getLoc(), "cannot force target of type ")
+      << targetType;
 
   // Use Forceable if necessary (reset).
   if (targetType.hasUninferredReset()) {
@@ -3202,22 +3372,15 @@ ParseResult FIRStmtParser::parseRWProbe(Value &result) {
       return emitError(startTok.getLoc(), "rwprobe target not forceable")
           .attachNote(definingOp->getLoc());
 
-    // TODO: do the ref.sub work while parsing the static expression.
     result = getValueByFieldID(builder, forceable.getDataRef(),
-                               fieldRef.getFieldID());
-
+                               staticRef.getFieldID());
+    assert(result.getType() == forceableType);
     return success();
   }
 
-  // RWProbe op!
-  auto forceableType = firrtl::detail::getForceableResultType(true, targetType);
-  if (!forceableType)
-    return emitError(startTok.getLoc(), "cannot force target of type ")
-           << targetType;
-
   // Get InnerRef for target field.
   auto sym = getInnerRefTo(
-      getTargetFor(fieldRef),
+      getTargetFor(staticRef),
       [&](auto _) -> hw::InnerSymbolNamespace & { return modNameSpace; });
   result = builder.create<RWProbeOp>(forceableType, sym);
   return success();

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3206,16 +3206,19 @@ ParseResult FIRStmtParser::parseRWProbeStaticRefExp(FieldRef &refResult,
         if ((unsigned)index < vector.getNumElements()) {
           refResult = refResult.getSubField(vector.getFieldID(index));
           type = vector.getElementTypePreservingConst();
+          continue;
         }
       } else if (auto vector = type_dyn_cast<OpenVectorType>(type)) {
         if ((unsigned)index < vector.getNumElements()) {
           refResult = refResult.getSubField(vector.getFieldID(index));
           type = vector.getElementTypePreservingConst();
+          continue;
         }
       } else {
         return emitError(loc, "subindex requires vector operand");
       }
-      continue;
+      return emitError(loc, "out of range index '")
+             << index << "' for vector type " << type;
     }
     return success();
   }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3361,11 +3361,10 @@ ParseResult FIRStmtParser::parseRWProbe(Value &result) {
                       MemoryDebugPortOp, MemoryPortAccessOp>(definingOp))
     return emitError(startTok.getLoc(), "cannot probe memories or their ports");
 
-  auto forceableType =
-    firrtl::detail::getForceableResultType(true, targetType);
+  auto forceableType = firrtl::detail::getForceableResultType(true, targetType);
   if (!forceableType)
     return emitError(startTok.getLoc(), "cannot force target of type ")
-      << targetType;
+           << targetType;
 
   // Use Forceable if necessary (reset).
   if (targetType.hasUninferredReset()) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3110,7 +3110,8 @@ ParseResult FIRStmtParser::parseRWProbeStaticRefExp(FieldRef &refResult,
 
         // Either entire instance result is forceable + bounce wire, or reject.
         // (even if rwprobe is of a portion of the port)
-        bool forceable = !!firrtl::detail::getForceableResultType(true, type);
+        bool forceable = static_cast<bool>(
+            firrtl::detail::getForceableResultType(true, type));
         if (!forceable)
           return emitError(loc, "unable to force instance result of type ")
                  << type;

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1294,7 +1294,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     wire inst_rw2 : RWProbe<UInt<1>>
     inst rc2 of RefsChild
 
-    ; CHECK: firrtl.strictconnect %rc2_in_bounce,
+    ; CHECK: %[[IN_CAST:[^ ]+]] = firrtl.constCast %in :
+    ; CHECK: firrtl.strictconnect %rc2_in_bounce, %[[IN_CAST]]
     rc2.in <= in
    ; CHECK-NEXT: firrtl.when %rc2_in_bounce :
    ; CHECK-NEXT:   %[[RWPROBE_RC2_IN_BOUNCE_1:[^ ]+]] = firrtl.ref.rwprobe <@Refs::@[[RC2_IN_BOUNCE_SYM]]>

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1195,6 +1195,15 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NEXT: ref.define %rw, %[[NODE_RWREF]]
     define rw = rwprobe(n)
 
+  ; CHECK-LABEL: module private @RefsChildOpenAgg(
+  ; CHECK-SAME: in %in: !firrtl.openbundle<a: uint<1>, rw flip: rwprobe<uint<1>>> sym [<@[[SYM:[^,]+]],1,
+  module RefsChildOpenAgg :
+    input in : { a : UInt<1>, flip rw: RWProbe<UInt<1>> }
+    ; CHECK-NEXT: %[[IN_RW:[^ ]+]] = firrtl.opensubfield %in[rw]
+    ; CHECK-NEXT: %[[RWPROBE_IN_A:[^ ]+]] = firrtl.ref.rwprobe <@RefsChildOpenAgg::@[[SYM]]>
+    ; CHECK-NEXT: firrtl.ref.define %[[IN_RW]], %[[RWPROBE_IN_A]]
+    define in.rw = rwprobe(in.a)
+
   ; CHECK-LABEL: module private @Refs(
   module Refs :
     input in : const UInt<1>
@@ -1275,6 +1284,29 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %[[AGG4_RW_0_b_x:.+]] = firrtl.ref.rwprobe <@Refs::@[[AGG4_0_b_x_SYM]]>
     ; CHECK-NEXT: firrtl.ref.define %field_rw, %[[AGG4_RW_0_b_x]]
     define field_rw = rwprobe(agg4[0].b.x)
+
+   ; CHECK: %inst_rw = firrtl.wire : !firrtl.rwprobe<uint<1>>
+   ; CHECK-NEXT: %inst_rw2 = firrtl.wire : !firrtl.rwprobe<uint<1>>
+   ; CHECK-NEXT: %rc2_in_bounce = firrtl.wire sym @[[RC2_IN_BOUNCE_SYM:[^ ]+]]
+   ; CHECK-NEXT: %rc2_in, %rc2_r, %rc2_rw = firrtl.instance rc2
+   ; CHECK-NEXT: firrtl.strictconnect %rc2_in, %rc2_in_bounce
+    wire inst_rw : RWProbe<UInt<1>>
+    wire inst_rw2 : RWProbe<UInt<1>>
+    inst rc2 of RefsChild
+
+    ; CHECK: firrtl.strictconnect %rc2_in_bounce,
+    rc2.in <= in
+   ; CHECK-NEXT: firrtl.when %rc2_in_bounce :
+   ; CHECK-NEXT:   %[[RWPROBE_RC2_IN_BOUNCE_1:[^ ]+]] = firrtl.ref.rwprobe <@Refs::@[[RC2_IN_BOUNCE_SYM]]>
+   ; CHECK-NEXT:   firrtl.ref.define %inst_rw, %[[RWPROBE_RC2_IN_BOUNCE_1]]
+   ; CHECK-NEXT: }
+    when rc2.in:
+      define inst_rw = rwprobe(rc2.in)
+   ; CHECK-NEXT: firrtl.strictconnect %rc2_in_bounce,
+    rc2.in <= rc.in
+   ; CHECK-NEXT: %[[RWPROBE_RC2_IN_BOUNCE_2:[^ ]+]] = firrtl.ref.rwprobe <@Refs::@[[RC2_IN_BOUNCE_SYM]]>
+   ; CHECK-NEXT: firrtl.ref.define %inst_rw2, %[[RWPROBE_RC2_IN_BOUNCE_2]]
+    define inst_rw2 = rwprobe(rc2.in)
 
   ; CHECK-LABEL: module private @ForceRelease(
   module ForceRelease :

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1141,3 +1141,16 @@ circuit PublicNonModule:
   ; expected-error @below {{only modules may be public}}
   public extmodule Foo:
   module PublicNonModule:
+
+;// -----
+circuit RWProbeExprOOB :
+  module RWProbeExprOOB :
+    output p : RWProbe<UInt<1>>
+    wire x : UInt<1>[2]
+    x is invalid
+
+    ; expected-error @below {{out of range index '100' for vector type '!firrtl.vector<uint<1>, 2>'}}
+    define p = rwprobe(x[100])
+
+   input out_0 : SInt<8>[5]
+   out_0[4] <- out_0[5]


### PR DESCRIPTION
Parse explicitly for rwprobe case for better handling and to avoid creating spurious indexing operations.

Instance results are supported by inserting a forceable bounce wire.  The wire replaces the instance port entirely (including its unbundled entry) locally, and is connected to/from the instance result.

Wires are created for entire result (port) only, and will be re-used by repeated rwprobe's to the result in part or whole. This means the entire port must be forceable and will go through the bounce wire.

Annotations will continue to resolve as they do today, not to the inserted bounce wire.

Indexing parsing based on code from #5809, thanks @youngar!