### PR TITLE
[SV] Mark sv.xmr.ref op as pure

### DIFF
--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -110,7 +110,10 @@ def XMROp : SVOp<"xmr", []> {
   let assemblyFormat = "(`isRooted` $isRooted^)? custom<XMRPath>($path, $terminal) attr-dict `:` qualified(type($result))";
 }
 
-def XMRRefOp : SVOp<"xmr.ref", [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+def XMRRefOp : SVOp<"xmr.ref", [
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  Pure
+]> {
   let summary = "Encode a reference to something with a hw.hierpath.";
   let description = [{
     This represents a hierarchical path, but using something which the compiler

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -283,13 +283,10 @@ hw.module @Issue5605(in %a: i1, in %b: i1, in %clock: i1, in %reset: i1) {
 module attributes {circt.loweringOptions = "disallowLocalVariables"} {
   hw.module @Foo(in %a: i1) {
     hw.wire %a sym @a : i1
-    %b = sv.reg : !hw.inout<i1>
     // CHECK: sv.alwayscomb
     sv.alwayscomb {
       // CHECK-NEXT: sv.xmr.ref
       %0 = sv.xmr.ref @xmr : !hw.inout<i1>
-      %1 = sv.read_inout %0 : !hw.inout<i1>
-      sv.bpassign %b, %1 : i1
     }
   }
   hw.hierpath @xmr [@Foo::@a]

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -287,7 +287,7 @@ module attributes {circt.loweringOptions = "disallowLocalVariables"} {
     sv.alwayscomb {
       // CHECK-NEXT: sv.xmr.ref
       %0 = sv.xmr.ref @xmr : !hw.inout<i1>
-      %1 = sv.read_inout %0 : !hw.inout<i1>
+      sv.verbatim "{{0}}" (%0) : !hw.inout<i1>
     }
   }
   hw.hierpath @xmr [@Foo::@a]

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -287,6 +287,7 @@ module attributes {circt.loweringOptions = "disallowLocalVariables"} {
     sv.alwayscomb {
       // CHECK-NEXT: sv.xmr.ref
       %0 = sv.xmr.ref @xmr : !hw.inout<i1>
+      %1 = sv.read_inout %0 : !hw.inout<i1>
     }
   }
   hw.hierpath @xmr [@Foo::@a]


### PR DESCRIPTION
Having an `sv.xmr.ref` op inside a procedural block such as `sv.alwayscomb` triggers an assertion in `PrepareForEmission`. The pass would identify the ref op as having side-effects and then go ahead and try to pull it outside the procedural block. Doing so would create a `sv.reg` op with multiple nested inout types, which breaks.

Fix the issue by marking the `sv.xmr.ref` op as pure. Taking a reference to something does not have a side-effect. It's accessing what's behind the reference that has side-effects.