### PR TITLE
[HW] Add `hw.path.to_here` op

### DIFF
--- a/include/circt/Dialect/HW/HWPasses.h
+++ b/include/circt/Dialect/HW/HWPasses.h
@@ -26,6 +26,8 @@ std::unique_ptr<mlir::Pass> createHWSpecializePass();
 std::unique_ptr<mlir::Pass> createPrintHWModuleGraphPass();
 std::unique_ptr<mlir::Pass> createFlattenIOPass();
 std::unique_ptr<mlir::Pass> createVerifyInnerRefNamespacePass();
+std::unique_ptr<mlir::Pass> createHWLegalizeNamesPass();
+std::unique_ptr<mlir::Pass> createLowerPathToHereOpsPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/HW/HWPasses.h
+++ b/include/circt/Dialect/HW/HWPasses.h
@@ -27,7 +27,7 @@ std::unique_ptr<mlir::Pass> createPrintHWModuleGraphPass();
 std::unique_ptr<mlir::Pass> createFlattenIOPass();
 std::unique_ptr<mlir::Pass> createVerifyInnerRefNamespacePass();
 std::unique_ptr<mlir::Pass> createHWLegalizeNamesPass();
-std::unique_ptr<mlir::Pass> createLowerPathToHereOpsPass();
+std::unique_ptr<mlir::Pass> createLowerHierPathToOpsPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -485,6 +485,28 @@ def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
   let hasVerifier = 1;
 }
 
+def PathToHereOp : HWOp<"path.to_here", [Symbol, Pure]> {
+  let summary = "Path to current location operation";
+  let description = [{
+    The `hw.path.to_here` operation represents a path through the instance
+    hierarchy which starts from the top-level module and ends at the current
+    instance wherein the `hw.path.to_here` is located. The operation can be
+    lowered to `hw.hierpath` and is useful in cases where we want to track the
+    absolute path of an instance in the design, but not yet want to use
+    `hw.hierpath` operations due to the extra overhead involved in maintaining
+    said op if the instance hierarchy is modified.
+
+    The operation (and pass) should only be used in cases where modules are
+    expected to be unique within the design, i.e. only a single instance exists
+    for any given module in between the module instance and the top level module
+    (note: this does not imply that the entire module hierarchy must be
+    elaborated); thus the user must either ensure this by design, or elaborate
+    parts of the design accordingly.
+  }];
+  let arguments = (ins SymbolNameAttr:$sym_name);
+  let assemblyFormat = "$sym_name attr-dict";
+}
+
 def HierPathOp : HWOp<"hierpath",
       [IsolatedFromAbove, Symbol,
        DeclareOpInterfaceMethods<InnerRefUserOpInterface>]> {

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -485,16 +485,16 @@ def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
   let hasVerifier = 1;
 }
 
-def PathToHereOp : HWOp<"path.to_here", [Symbol, Pure]> {
+def HierPathToOp : HWOp<"hierpath.to", [Symbol, Pure]> {
   let summary = "Path to current location operation";
   let description = [{
-    The `hw.path.to_here` operation represents a path through the instance
-    hierarchy which starts from the top-level module and ends at the current
-    instance wherein the `hw.path.to_here` is located. The operation can be
-    lowered to `hw.hierpath` and is useful in cases where we want to track the
-    absolute path of an instance in the design, but not yet want to use
-    `hw.hierpath` operations due to the extra overhead involved in maintaining
-    said op if the instance hierarchy is modified.
+    The `hierpath.to` operation represents a path through the instance
+    hierarchy which starts from the top-level module and ends at the provided
+    symbol in the current instance wherein the `hierpath.to` is located.
+    The operation can be lowered to `hw.hierpath` and is useful in cases where
+    we want to track the absolute path of an instance in the design, but not yet
+    want to use `hw.hierpath` operations due to the extra overhead involved in
+    maintaining said op if the instance hierarchy is modified.
 
     The operation (and pass) should only be used in cases where modules are
     expected to be unique within the design, i.e. only a single instance exists
@@ -503,8 +503,8 @@ def PathToHereOp : HWOp<"path.to_here", [Symbol, Pure]> {
     elaborated); thus the user must either ensure this by design, or elaborate
     parts of the design accordingly.
   }];
-  let arguments = (ins SymbolNameAttr:$sym_name);
-  let assemblyFormat = "$sym_name attr-dict";
+  let arguments = (ins SymbolNameAttr:$sym_name, FlatSymbolRefAttr:$target);
+  let assemblyFormat = "$sym_name `(` $target `)` attr-dict";
 }
 
 def HierPathOp : HWOp<"hierpath",

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -58,9 +58,9 @@ def VerifyInnerRefNamespace : Pass<"hw-verify-irn"> {
   let constructor =  "circt::hw::createVerifyInnerRefNamespacePass()";
 }
 
-def LowerPathToHereOps : Pass<"hw-lower-path-to-here"> {
-  let summary = "Lower hw.path.here operations to hw.hierpath operations.";
-  let constructor =  "circt::hw::createLowerPathToHereOpsPass()";
+def LowerHierPathToOps : Pass<"hw-lower-hierpathto-ops"> {
+  let summary = "Lower hw.hierpath.to operations to hw.hierpath operations.";
+  let constructor =  "circt::hw::createLowerHierPathToOpsPass()";
 }
 
 #endif // CIRCT_DIALECT_HW_PASSES_TD

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -58,4 +58,9 @@ def VerifyInnerRefNamespace : Pass<"hw-verify-irn"> {
   let constructor =  "circt::hw::createVerifyInnerRefNamespacePass()";
 }
 
+def LowerPathToHereOps : Pass<"hw-lower-path-to-here"> {
+  let summary = "Lower hw.path.here operations to hw.hierpath operations.";
+  let constructor =  "circt::hw::createLowerPathToHereOpsPass()";
+}
+
 #endif // CIRCT_DIALECT_HW_PASSES_TD

--- a/lib/Dialect/HW/Transforms/CMakeLists.txt
+++ b/lib/Dialect/HW/Transforms/CMakeLists.txt
@@ -4,7 +4,7 @@ add_circt_dialect_library(CIRCTHWTransforms
   PrintHWModuleGraph.cpp
   FlattenIO.cpp
   VerifyInnerRefNamespace.cpp
-  LowerPathToHereOps.cpp
+  LowerHierPathToOps.cpp
 
   DEPENDS
   CIRCTHWTransformsIncGen

--- a/lib/Dialect/HW/Transforms/CMakeLists.txt
+++ b/lib/Dialect/HW/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_circt_dialect_library(CIRCTHWTransforms
   PrintHWModuleGraph.cpp
   FlattenIO.cpp
   VerifyInnerRefNamespace.cpp
+  LowerPathToHereOps.cpp
 
   DEPENDS
   CIRCTHWTransformsIncGen

--- a/lib/Dialect/HW/Transforms/LowerPathToHereOps.cpp
+++ b/lib/Dialect/HW/Transforms/LowerPathToHereOps.cpp
@@ -1,0 +1,108 @@
+//===- LowerPathToHereOps.cpp - Lower hw.path.to_here ops -------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// Lowers `hw.path.to_here` operations to `hw.hierpath` ops.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/HWPasses.h"
+#include "circt/Support/InstanceGraph.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace circt;
+using namespace hw;
+
+namespace {
+
+struct PathToHereOpConversionPattern
+    : public OpConversionPattern<hw::PathToHereOp> {
+  PathToHereOpConversionPattern(MLIRContext *ctx,
+                                igraph::InstanceGraph &instanceGraph)
+      : OpConversionPattern(ctx), instanceGraph(instanceGraph) {}
+
+  LogicalResult
+  matchAndRewrite(hw::PathToHereOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto parentOp = dyn_cast<igraph::ModuleOpInterface>(op->getParentOp());
+    if (!parentOp)
+      return op.emitError("hw.path.to_here must be in an op implementing "
+                          "igraph::ModuleOpInterface.");
+    igraph::InstanceGraphNode *parentNode = instanceGraph.lookup(parentOp);
+    llvm::SmallVector<Attribute> path;
+    while (parentNode) {
+      // Verify that exactly one instance of the parent exists.
+      size_t nUses = parentNode->getNumUses();
+      if (nUses > 1) {
+        auto err = op.emitError(
+            "cannot lower path.to_here ops in module hierarchies with "
+            "multiple instantiations.");
+        for (igraph::InstanceRecord *use : parentNode->uses())
+          err.attachNote(use->getInstance().getLoc())
+              << "instantiated here: " << use->getInstance();
+        return err;
+      }
+      if (nUses == 0) {
+        if (path.empty())
+          return op.emitError(
+              "cannot lower path.to_here ops in modules with no "
+              "instantiations.");
+        // End of hierarchy.
+        break;
+      }
+
+      igraph::InstanceRecord *instanceNode = *parentNode->uses().begin();
+      igraph::InstanceGraphNode *instantiatedIn = instanceNode->getParent();
+      if (!instantiatedIn) {
+        // We've recursed up to the top of the instance graph.
+        break;
+      }
+
+      igraph::InstanceOpInterface instance = instanceNode->getInstance();
+      path.insert(
+          path.begin(),
+          hw::InnerRefAttr::get(instantiatedIn->getModule().getModuleNameAttr(),
+                                instance.getInstanceNameAttr()));
+
+      // Recurse up to parent of parent, if any.
+      parentNode = instantiatedIn;
+    }
+
+    // Create a new path op.
+    rewriter.replaceOpWithNewOp<hw::HierPathOp>(op, op.getName(),
+                                                rewriter.getArrayAttr(path));
+    return success();
+  }
+
+  igraph::InstanceGraph &instanceGraph;
+};
+
+struct LowerPathToHereOpsPass
+    : public LowerPathToHereOpsBase<LowerPathToHereOpsPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void LowerPathToHereOpsPass::runOnOperation() {
+  Operation *parent = getOperation();
+  igraph::InstanceGraph &instanceGraph = getAnalysis<igraph::InstanceGraph>();
+
+  ConversionTarget target(getContext());
+  target.addLegalDialect<hw::HWDialect>();
+  target.addIllegalOp<hw::PathToHereOp>();
+
+  RewritePatternSet patterns(&getContext());
+  patterns.add<PathToHereOpConversionPattern>(&getContext(), instanceGraph);
+
+  if (failed(applyPartialConversion(parent, target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<mlir::Pass> circt::hw::createLowerPathToHereOpsPass() {
+  return std::make_unique<LowerPathToHereOpsPass>();
+}

--- a/test/Dialect/HW/path_to_here.mlir
+++ b/test/Dialect/HW/path_to_here.mlir
@@ -1,0 +1,88 @@
+// RUN: circt-opt --hw-lower-path-to-here --split-input-file --verify-diagnostics %s | FileCheck %s
+
+hw.module @Root() {
+  // CHECK: hw.hierpath @sym [@ParentOne::@root]
+  hw.path.to_here @sym
+}
+
+hw.module @ParentOne() {
+  hw.instance "root" @Root() -> ()
+}
+
+// -----
+
+hw.module @Root() {
+  // CHECK: hw.hierpath @sym [@ParentTwo::@parentOne, @ParentOne::@root]
+  hw.path.to_here @sym
+}
+
+hw.module @ParentOne() {
+  hw.instance "root" @Root() -> ()
+}
+
+hw.module @ParentTwo() {
+  hw.instance "parentOne" @ParentOne() -> ()
+}
+
+// -----
+
+hw.module @NoParent() {
+  // expected-error @below {{cannot lower path.to_here ops in modules with no instantiations.}}
+  // expected-error @below {{failed to legalize operation 'hw.path.to_here' that was explicitly marked illegal}}
+  hw.path.to_here @sym
+}
+
+// -----
+
+// Test non-unique instance hierarchy at the first level
+
+hw.module @Root() {
+  // expected-error @below {{cannot lower path.to_here ops in module hierarchies with multiple instantiations.}}
+  // expected-error @below {{failed to legalize operation 'hw.path.to_here' that was explicitly marked illegal}}
+  hw.path.to_here @sym
+}
+
+hw.module @FirstUser() {
+  // expected-note@below {{instantiated here: hw.instance "root" @Root() -> ()}}
+  hw.instance "root" @Root() -> ()
+}
+
+hw.module @SecondUser() {
+  // expected-note@below {{instantiated here: hw.instance "root" @Root() -> ()}}
+  hw.instance "root" @Root() -> ()
+}
+
+hw.module @Top() {
+  hw.instance "firstUser" @FirstUser() -> ()
+  hw.instance "secondUser" @SecondUser() -> ()
+}
+
+// -----
+
+// Test non-unique instance hierarchy at the second level.
+
+hw.module @Root() {
+  // expected-error @below {{cannot lower path.to_here ops in module hierarchies with multiple instantiations.}}
+  // expected-error @below {{failed to legalize operation 'hw.path.to_here' that was explicitly marked illegal}}
+  hw.path.to_here @sym
+}
+
+hw.module @RootParent() {
+  hw.instance "root" @Root() -> ()
+}
+
+
+hw.module @FirstUser() {
+  // expected-note@below {{instantiated here: hw.instance "rp" @RootParent() -> ()}}
+  hw.instance "rp" @RootParent() -> ()
+}
+
+hw.module @SecondUser() {
+  // expected-note@below {{instantiated here: hw.instance "rp" @RootParent() -> ()}}
+  hw.instance "rp" @RootParent() -> ()
+}
+
+hw.module @Top() {
+  hw.instance "firstUser" @FirstUser() -> ()
+  hw.instance "secondUser" @SecondUser() -> ()
+}

--- a/test/Dialect/HW/path_to_here.mlir
+++ b/test/Dialect/HW/path_to_here.mlir
@@ -30,6 +30,8 @@ hw.module @ParentTwo() {
 
 // -----
 
+// CHECK-LABEL:   hw.module @NoParent() {
+// CHECK:           hw.hierpath @sym [@NoParent::@w]
 hw.module @NoParent() {
   hw.hierpath.to @sym(@w)
   %c0 = hw.constant false

--- a/test/Dialect/HW/path_to_here.mlir
+++ b/test/Dialect/HW/path_to_here.mlir
@@ -1,8 +1,10 @@
-// RUN: circt-opt --hw-lower-path-to-here --split-input-file --verify-diagnostics %s | FileCheck %s
+// RUN: circt-opt --hw-lower-hierpathto-ops --split-input-file --verify-diagnostics %s | FileCheck %s
 
 hw.module @Root() {
-  // CHECK: hw.hierpath @sym [@ParentOne::@root]
-  hw.path.to_here @sym
+  // CHECK: hw.hierpath @sym [@ParentOne::@root, @Root::@w]
+  hw.hierpath.to @sym(@w)
+  %c0 = hw.constant false
+  hw.wire %c0 sym @w : i1
 }
 
 hw.module @ParentOne() {
@@ -12,8 +14,10 @@ hw.module @ParentOne() {
 // -----
 
 hw.module @Root() {
-  // CHECK: hw.hierpath @sym [@ParentTwo::@parentOne, @ParentOne::@root]
-  hw.path.to_here @sym
+  // CHECK: hw.hierpath @sym [@ParentTwo::@parentOne, @ParentOne::@root, @Root::@w]
+  hw.hierpath.to @sym(@w)
+  %c0 = hw.constant false
+  hw.wire %c0 sym @w : i1
 }
 
 hw.module @ParentOne() {
@@ -27,9 +31,9 @@ hw.module @ParentTwo() {
 // -----
 
 hw.module @NoParent() {
-  // expected-error @below {{cannot lower path.to_here ops in modules with no instantiations.}}
-  // expected-error @below {{failed to legalize operation 'hw.path.to_here' that was explicitly marked illegal}}
-  hw.path.to_here @sym
+  hw.hierpath.to @sym(@w)
+  %c0 = hw.constant false
+  hw.wire %c0 sym @w : i1
 }
 
 // -----
@@ -37,9 +41,11 @@ hw.module @NoParent() {
 // Test non-unique instance hierarchy at the first level
 
 hw.module @Root() {
-  // expected-error @below {{cannot lower path.to_here ops in module hierarchies with multiple instantiations.}}
-  // expected-error @below {{failed to legalize operation 'hw.path.to_here' that was explicitly marked illegal}}
-  hw.path.to_here @sym
+  // expected-error @below {{cannot lower hierpath.to ops in module hierarchies with multiple instantiations.}}
+  // expected-error @below {{failed to legalize operation 'hw.hierpath.to' that was explicitly marked illegal}}
+  hw.hierpath.to @sym(@w)
+  %c0 = hw.constant false
+  hw.wire %c0 sym @w : i1
 }
 
 hw.module @FirstUser() {
@@ -62,9 +68,11 @@ hw.module @Top() {
 // Test non-unique instance hierarchy at the second level.
 
 hw.module @Root() {
-  // expected-error @below {{cannot lower path.to_here ops in module hierarchies with multiple instantiations.}}
-  // expected-error @below {{failed to legalize operation 'hw.path.to_here' that was explicitly marked illegal}}
-  hw.path.to_here @sym
+  // expected-error @below {{cannot lower hierpath.to ops in module hierarchies with multiple instantiations.}}
+  // expected-error @below {{failed to legalize operation 'hw.hierpath.to' that was explicitly marked illegal}}
+  hw.hierpath.to @sym(@w)
+  %c0 = hw.constant false
+  hw.wire %c0 sym @w : i1
 }
 
 hw.module @RootParent() {


### PR DESCRIPTION
The `hw.path.to_here` operation represents a path through the instance hierarchy which starts from the top-level module and ends at the current instance wherein the `hw.path.to_here` is located. The operation can be lowered to `hw.hierpath` and is useful in cases where we want to track the absolute path of an instance in the design, but not yet want to use `hw.hierpath` operations due to the extra overhead involved in maintaining said op if the instance hierarchy is modified.

The operation (and pass) should only be used in cases where modules are expected to be unique within the design, i.e. only a single instance exists for any given module in between the module instance and the top level module (note: this does not imply that the entire module hierarchy must be elaborated); thus the user must either ensure this by design, or elaborate parts of the design accordingly.