### PR TITLE
[MSFT] Add multicycle path op

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTOpInterfaces.h
+++ b/include/circt/Dialect/MSFT/MSFTOpInterfaces.h
@@ -14,7 +14,13 @@
 
 namespace circt {
 namespace msft {
-LogicalResult verifyDynInstData(Operation *);
+LogicalResult verifyUnaryDynInstDataOp(Operation *);
+
+/// Returns the top-level module which the given HierPathOp that defines
+/// pathSym, refers to.
+Operation *getHierPathTopModule(Location loc,
+                                circt::hw::HWSymbolCache &symCache,
+                                FlatSymbolRefAttr pathSym);
 class InstanceHierarchyOp;
 } // namespace msft
 } // namespace circt

--- a/include/circt/Dialect/MSFT/MSFTOpInterfaces.td
+++ b/include/circt/Dialect/MSFT/MSFTOpInterfaces.td
@@ -10,11 +10,30 @@ include "mlir/IR/OpBase.td"
 
 def DynInstDataOpInterface : OpInterface<"DynInstDataOpInterface"> {
   let description = [{
+    Interface for ops that define dynamic instance data.
+  }];
+  let cppNamespace = "::circt::msft";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Get the top module op to which this op is providing data for.
+      }],
+      /*retTy=*/"Operation *",
+      /*methodName=*/"getTopModule",
+      /*args=*/(ins "circt::hw::HWSymbolCache &":$symCache)
+    >
+  ];
+}
+
+  def UnaryDynInstDataOpInterface : OpInterface<"UnaryDynInstDataOpInterface",
+    [DynInstDataOpInterface]> {  
+  let description = [{
     Interface for anything which needs to refer to a HierPathOp.
   }];
   let cppNamespace = "::circt::msft";
   let verify = [{
-    return ::circt::msft::verifyDynInstData($_op);
+    return ::circt::msft::verifyUnaryDynInstDataOp($_op);
   }];
 
   let methods = [
@@ -41,33 +60,14 @@ def DynInstDataOpInterface : OpInterface<"DynInstDataOpInterface"> {
       /*defaultImplementation=*/[{
         return $_op.getRefAttr();
       }]
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
-        Get the top module op to which the HierPathOp which this op is referring.
-      }],
-      /*retTy=*/"Operation *",
-      /*methodName=*/"getTopModule",
-      /*args=*/(ins "circt::hw::HWSymbolCache &":$symCache),
-      /*methodBody=*/[{}],
-      /*defaultImplementation=*/[{
-        FlatSymbolRefAttr refSym = $_op.getPathSym();
-        if (!refSym) {
-          $_op->emitOpError("must run dynamic instance lowering first");
-          return nullptr;
-        }
-        auto ref = dyn_cast_or_null<hw::HierPathOp>(
-            symCache.getDefinition(refSym));
-        if (!ref) {
-          $_op->emitOpError("could not find hw.hierpath ") << refSym;
-          return nullptr;
-        }
-        if (ref.getNamepath().empty())
-          return nullptr;
-        auto modSym = FlatSymbolRefAttr::get(
-            ref.getNamepath()[0].cast<hw::InnerRefAttr>().getModule());
-        return symCache.getDefinition(modSym);
-      }]
     >
   ];
+
+  let extraClassDeclaration = [{
+    // We cannot directly implement getTopModule of DynInstDataOpInterface
+    // since the generated .cpp will cast to the implementing class and not
+    // consider interface hierarchies. But we still provide an implementation which
+    // ops can reference.
+    Operation* getTopModuleImpl(circt::hw::HWSymbolCache &symCache);
+  }];
 }

--- a/include/circt/Dialect/MSFT/MSFTOpInterfaces.td
+++ b/include/circt/Dialect/MSFT/MSFTOpInterfaces.td
@@ -62,12 +62,4 @@ def DynInstDataOpInterface : OpInterface<"DynInstDataOpInterface"> {
       }]
     >
   ];
-
-  let extraClassDeclaration = [{
-    // We cannot directly implement getTopModule of DynInstDataOpInterface
-    // since the generated .cpp will cast to the implementing class and not
-    // consider interface hierarchies. But we still provide an implementation which
-    // ops can reference.
-    Operation* getTopModuleImpl(circt::hw::HWSymbolCache &symCache);
-  }];
 }

--- a/include/circt/Dialect/MSFT/MSFTPDOps.td
+++ b/include/circt/Dialect/MSFT/MSFTPDOps.td
@@ -22,7 +22,7 @@ def DeclPhysicalRegionOp : MSFTOp<"physical_region",
 }
 
 def PDPhysLocationOp : MSFTOp<"pd.location",
-      [DeclareOpInterfaceMethods<DynInstDataOpInterface>]> {
+      [DeclareOpInterfaceMethods<UnaryDynInstDataOpInterface>]> {
   let summary = "Specify a location for an instance";
   let description = [{
     Used to specify a specific location on an FPGA to place a dynamic instance.
@@ -38,10 +38,16 @@ def PDPhysLocationOp : MSFTOp<"pd.location",
   let assemblyFormat = [{
     ($ref^)? custom<PhysLoc>($loc) (`path` `:` $subPath^)? attr-dict
   }];
+
+  let extraClassDeclaration = [{
+    Operation* getTopModule(circt::hw::HWSymbolCache &symCache) {
+      return getHierPathTopModule(getOperation()->getLoc(), symCache, getPathSym());
+    }
+  }];
 }
 
 def PDRegPhysLocationOp : MSFTOp<"pd.reg_location",
-      [DeclareOpInterfaceMethods<DynInstDataOpInterface>]> {
+      [DeclareOpInterfaceMethods<UnaryDynInstDataOpInterface>]> {
   let summary = "Specify register locations";
   let description = [{
     A version of "PDPhysLocationOp" specialized for registers, which have one
@@ -52,10 +58,34 @@ def PDRegPhysLocationOp : MSFTOp<"pd.reg_location",
   let assemblyFormat = [{
     (`ref` $ref^)? custom<ListOptionalRegLocList>($locs) attr-dict
   }];
+
+  let extraClassDeclaration = [{
+    Operation* getTopModule(circt::hw::HWSymbolCache &symCache) {
+      return getHierPathTopModule(getOperation()->getLoc(), symCache, getPathSym());
+    }
+  }];
+}
+
+def PDMulticycleOp : MSFTOp<"pd.multicycle",
+    [DeclareOpInterfaceMethods<DynInstDataOpInterface>]> {
+  let summary = "Specify a multicycle constraint";
+  let description = [{
+    Specifies a multicycle constraint in between two registers.
+    `source` and `dest` symbols reference `HierPathOp` symbols denoting the
+    exact registers in the instance hierarchy to which the constraint applies.
+  }];
+  let arguments = (ins
+    FlatSymbolRefAttr:$source,
+    FlatSymbolRefAttr:$dest,
+    ConfinedAttr<I32Attr, [IntMinValue<1>]>:$cycles
+  );
+  let assemblyFormat = [{
+    $cycles $source `->` $dest attr-dict
+  }];
 }
 
 def PDPhysRegionOp : MSFTOp<"pd.physregion",
-      [DeclareOpInterfaceMethods<DynInstDataOpInterface>]> {
+      [DeclareOpInterfaceMethods<UnaryDynInstDataOpInterface>]> {
   let summary = "Specify a physical region for an instance";
   let description = [{
     Annotate a particular entity within an op with the region of the devices
@@ -67,6 +97,12 @@ def PDPhysRegionOp : MSFTOp<"pd.physregion",
                        OptionalAttr<FlatSymbolRefAttr>:$ref);
   let assemblyFormat = [{
     ($ref^)? $physRegionRef (`path` `:` $subPath^)? attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    Operation* getTopModule(circt::hw::HWSymbolCache &symCache) {
+      return getHierPathTopModule(getOperation()->getLoc(), symCache, getPathSym());
+    }
   }];
 }
 
@@ -123,7 +159,8 @@ def DynamicInstanceOp : MSFTOp<"instance.dynamic",
 }
 
 def DynamicInstanceVerbatimAttrOp : MSFTOp<
-    "instance.verb_attr", [DeclareOpInterfaceMethods<DynInstDataOpInterface>]> {
+    "instance.verb_attr", [
+      DeclareOpInterfaceMethods<UnaryDynInstDataOpInterface>]> {
   let summary = "Specify an arbitrary attribute attached to a dynamic instance";
   let description = [{
     Allows a user to specify a custom attribute name and value which is attached
@@ -138,5 +175,11 @@ def DynamicInstanceVerbatimAttrOp : MSFTOp<
                        OptionalAttr<FlatSymbolRefAttr>:$ref);
   let assemblyFormat = [{
     ($ref^)? `name` `:` $name `value` `:` $value (`path` `:` $subPath^)? attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    Operation* getTopModule(circt::hw::HWSymbolCache &symCache) {
+      return getHierPathTopModule(getOperation()->getLoc(), symCache, getPathSym());
+    }
   }];
 }

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -248,5 +248,22 @@ LogicalResult LinearOp::verify() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// PDMulticycleOp
+//===----------------------------------------------------------------------===//
+
+Operation *PDMulticycleOp::getTopModule(hw::HWSymbolCache &cache) {
+  // Both symbols should reference the same top-level module in their respective
+  // HierPath ops.
+  Operation *srcTop = getHierPathTopModule(getLoc(), cache, getSourceAttr());
+  Operation *dstTop = getHierPathTopModule(getLoc(), cache, getDestAttr());
+  if (srcTop != dstTop) {
+    emitOpError("source and destination paths must refer to the same top-level "
+                "module.");
+    return nullptr;
+  }
+  return srcTop;
+}
+
 #define GET_OP_CLASSES
 #include "circt/Dialect/MSFT/MSFT.cpp.inc"

--- a/lib/Dialect/MSFT/Transforms/MSFTLowerInstances.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTLowerInstances.cpp
@@ -80,7 +80,7 @@ LogicalResult LowerInstancesPass::lower(DynamicInstanceOp inst,
     hierBlock.insert(&op);
 
     // Assign a ref for ops which need it.
-    if (auto specOp = dyn_cast<DynInstDataOpInterface>(op)) {
+    if (auto specOp = dyn_cast<UnaryDynInstDataOpInterface>(op)) {
       assert(ref);
       specOp.setPathOp(ref);
     }

--- a/test/Dialect/MSFT/dynamic_instance.mlir
+++ b/test/Dialect/MSFT/dynamic_instance.mlir
@@ -40,7 +40,11 @@ msft.instance.hierarchy @reg "bar" {
 // CHECK: hw.hierpath @instref_3 [@reg::@reg]
 // CHECK-DAG: msft.pd.reg_location ref @instref_3 i4 [<3, 4, 5>, *, *, *]
 
-
+hw.hierpath @reg.reg [@reg::@reg]
+hw.hierpath @reg.reg2 [@reg::@reg2]
+msft.instance.hierarchy @reg "multicycle" {
+  msft.pd.multicycle 2 @reg.reg -> @reg.reg2
+}
 
 hw.module.extern @Foo()
 
@@ -76,6 +80,7 @@ hw.module @deeper () {
 
 hw.module @reg (in %input : i4, in %clk : !seq.clock) {
   %reg = seq.compreg sym @reg %input, %clk  : i4
+  %reg2 = seq.compreg sym @reg2 %input, %clk  : i4
 }
 // TCL-LABEL: proc reg_0_foo_config
 // TCL: set_location_assignment FF_X1_Y2_N3 -to $parent|reg_0[1]
@@ -84,3 +89,6 @@ hw.module @reg (in %input : i4, in %clk : !seq.clock) {
 
 // TCL-LABEL: proc reg_0_bar_config
 // TCL: set_location_assignment FF_X3_Y4_N5 -to $parent|reg_0[0]
+
+// TCL-LABEL: proc reg_0_multicycle_config { parent } {
+// TCL: set_multicycle_path -hold 1 -setup 2 -from [get_registers {$parent|reg_0}] -to [get_registers {$parent|reg2}]


### PR DESCRIPTION
Adds a new operation to the MSFT dialect which specifies a multicycle path constraint in between two symbols.

This implementation does not opt in to the whole dynamic instance hierarchy specification of MSFT; do we want to do that? Would have to require some thinking about what it means that a PD constraint refrences two dynamic instances, wherein `msft.instance.dynamic` currently expects all nested pd constraints to reference the parent instance exclusively. To this, i don't think it will be needed in our immediate usecase, anyways (assuming we're going to use `hw.path.to_this` which itself will generate the `hw.hierpath` and _not_ use the dynamic instance hierarchy support in MSFT).

Also splits `DynInstDataOpInterface` into a two interfaces; one base interface (anything that pertains to dynamic instance data) and the `UnaryDynInstDataOpInterface` which refers to all data ops which access a single location - some additional boilerplate is introduced since the current implementation of OpInterface's doesn't seem to support inheriting interfaces implementing parent interfaces (everything is expected to be defined by the implementing op).

Exported TCL example:
```tcl
proc reg_0_multicycle_config { parent } {
  set_multicycle_path -hold 1 -setup 2 -from [get_registers {$parent|reg_0}] -to [get_registers {$parent|reg2}]
}
```