### PR TITLE
[FIRRTL][MergeConnections] Reject non-passive aggregates.

### DIFF
--- a/test/Dialect/FIRRTL/merge-connections.mlir
+++ b/test/Dialect/FIRRTL/merge-connections.mlir
@@ -88,15 +88,15 @@ firrtl.circuit "Test"   {
 
 
   // Check that we don't use strictconnect when merging connections into non-passive type.
-  // COMMON-LABEL:   firrtl.module private @DUT
-  // COMMON-NEXT:     %p = firrtl.wire
-  // COMMON-NEXT:     %0 = firrtl.subfield
-  // COMMON-NEXT:      firrtl.strictconnect %0, %x_a
-  // COMMON-NEXT:     %1 = firrtl.subfield
-  // COMMON-NEXT:     firrtl.strictconnect %x_b, %1
-  // COMMON-NEXT:     firrtl.strictconnect %y_a, %0
-  // COMMON-NEXT:      firrtl.strictconnect %1, %y_b
-  // COMMON-NEXT:   }
+  // COMMON-LABEL: firrtl.module private @DUT
+  // COMMON-NEXT:    %p = firrtl.wire
+  // COMMON-NEXT:    %0 = firrtl.subfield
+  // COMMON-NEXT:    firrtl.strictconnect %0, %x_a
+  // COMMON-NEXT:    %1 = firrtl.subfield
+  // COMMON-NEXT:    firrtl.strictconnect %x_b, %1
+  // COMMON-NEXT:    firrtl.strictconnect %y_a, %0
+  // COMMON-NEXT:    firrtl.strictconnect %1, %y_b
+  // COMMON-NEXT:  }
   firrtl.module private @DUT(in %x_a: !firrtl.uint<2>,
                              out %x_b: !firrtl.uint<2>,
                              out %y_a: !firrtl.uint<2>,

--- a/test/Dialect/FIRRTL/merge-connections.mlir
+++ b/test/Dialect/FIRRTL/merge-connections.mlir
@@ -91,13 +91,11 @@ firrtl.circuit "Test"   {
   // COMMON-LABEL:   firrtl.module private @DUT
   // COMMON-NEXT:     %p = firrtl.wire
   // COMMON-NEXT:     %0 = firrtl.subfield
-  // CHECK-NEXT:      firrtl.strictconnect %0, %x_a
+  // COMMON-NEXT:      firrtl.strictconnect %0, %x_a
   // COMMON-NEXT:     %1 = firrtl.subfield
   // COMMON-NEXT:     firrtl.strictconnect %x_b, %1
   // COMMON-NEXT:     firrtl.strictconnect %y_a, %0
-  // CHECK-NEXT:      firrtl.strictconnect %1, %y_b
-  // AGGRESSIVE-NEXT: %[[AGG:.+]] = firrtl.bundlecreate
-  // AGGRESSIVE-NEXT: firrtl.connect %p, %[[AGG]]
+  // COMMON-NEXT:      firrtl.strictconnect %1, %y_b
   // COMMON-NEXT:   }
   firrtl.module private @DUT(in %x_a: !firrtl.uint<2>,
                              out %x_b: !firrtl.uint<2>,
@@ -110,6 +108,21 @@ firrtl.circuit "Test"   {
     firrtl.strictconnect %x_b, %1 : !firrtl.uint<2>
     firrtl.strictconnect %y_a, %0 : !firrtl.uint<2>
     firrtl.strictconnect %1, %y_b : !firrtl.uint<2>
+  }
+
+  // Don't create aggregateconstant of non-passive. #6259.
+  // COMMON-LABEL: @Issue6259
+  // COMMON-NOT: aggregateconstant
+  // COMMON: }
+  firrtl.module private @Issue6259(out %a: !firrtl.rwprobe<bundle<a: uint<1>, b: uint<2>>>) {
+    %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    %w, %w_ref = firrtl.wire forceable {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.bundle<a: uint<1>, b flip: uint<2>>, !firrtl.rwprobe<bundle<a: uint<1>, b: uint<2>>>
+    %0 = firrtl.subfield %w[b] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
+    %1 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
+    firrtl.strictconnect %1, %c0_ui1 : !firrtl.uint<1>
+    firrtl.strictconnect %0, %c0_ui2 : !firrtl.uint<2>
+    firrtl.ref.define %a, %w_ref : !firrtl.rwprobe<bundle<a: uint<1>, b: uint<2>>>
   }
 }
 


### PR DESCRIPTION
Previously: #5780.

Fixes #6259.

(along with #5835 for the specific FIRRTL input)