### PR TITLE
[FIRRTL][NFC] Move FieldRef -> InnerSymTarget to utility.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -118,6 +118,10 @@ void walkGroundTypes(FIRRTLType firrtlType,
 // Inner symbol and InnerRef helpers.
 //===----------------------------------------------------------------------===//
 
+/// Return the inner sym target for the specified value and fieldID.
+/// If root is a blockargument, this must be FModuleLike.
+hw::InnerSymTarget getTargetFor(FieldRef ref);
+
 /// Ensure that the the InnerSymAttr has a symbol on the field specified.
 /// Returns the updated InnerSymAttr as well as the name of the symbol attached
 /// to the specified field.

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -733,6 +733,17 @@ void circt::firrtl::walkGroundTypes(
   recurse(recurse, type);
 }
 
+/// Return the inner sym target for the specified value and fieldID.
+/// If root is a blockargument, this must be FModuleLike.
+hw::InnerSymTarget circt::firrtl::getTargetFor(FieldRef ref) {
+  auto root = ref.getValue();
+  if (auto arg = dyn_cast<BlockArgument>(root)) {
+    auto mod = cast<FModuleLike>(arg.getOwner()->getParentOp());
+    return hw::InnerSymTarget(arg.getArgNumber(), mod, ref.getFieldID());
+  }
+  return hw::InnerSymTarget(root.getDefiningOp(), ref.getFieldID());
+}
+
 // Return InnerSymAttr with sym on specified fieldID.
 std::pair<hw::InnerSymAttr, StringAttr> circt::firrtl::getOrAddInnerSym(
     MLIRContext *context, hw::InnerSymAttr attr, uint64_t fieldID,

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3282,20 +3282,10 @@ ParseResult FIRStmtParser::parseRWProbe(Value &result) {
     return emitError(startTok.getLoc(), "cannot force target of type ")
            << targetType;
 
-  hw::InnerSymTarget innerSymTarget;
-  if (auto arg = dyn_cast<BlockArgument>(target)) {
-    auto mod = cast<FModuleOp>(arg.getOwner()->getParentOp());
-    innerSymTarget =
-        hw::InnerSymTarget(arg.getArgNumber(), mod, fieldRef.getFieldID());
-  } else {
-    innerSymTarget = hw::InnerSymTarget(definingOp, fieldRef.getFieldID());
-  }
-
   // Get InnerRef for target field.
-  auto sym =
-      getInnerRefTo(innerSymTarget, [&](auto _) -> hw::InnerSymbolNamespace & {
-        return modNameSpace;
-      });
+  auto sym = getInnerRefTo(
+      getTargetFor(fieldRef),
+      [&](auto _) -> hw::InnerSymbolNamespace & { return modNameSpace; });
   result = builder.create<RWProbeOp>(forceableType, sym);
   return success();
 }


### PR DESCRIPTION
Keep FIRRTL-only for now due to dependence on dialect-specific mechanism to get port number from block argument.
(HW has this but don't want FModuleLike dep in HW)