### PR TITLE
[HW] Reference struct/union fields by index

### DIFF
--- a/include/circt-c/Dialect/HW.h
+++ b/include/circt-c/Dialect/HW.h
@@ -132,8 +132,12 @@ MLIR_CAPI_EXPORTED MlirType hwParamIntTypeGet(MlirAttribute parameter);
 
 MLIR_CAPI_EXPORTED MlirAttribute hwParamIntTypeGetWidthAttr(MlirType);
 
+MLIR_CAPI_EXPORTED MlirAttribute
+hwStructTypeGetFieldIndex(MlirType structType, MlirStringRef fieldName);
+
 MLIR_CAPI_EXPORTED HWStructFieldInfo
 hwStructTypeGetFieldNum(MlirType structType, unsigned idx);
+
 MLIR_CAPI_EXPORTED intptr_t hwStructTypeGetNumFields(MlirType structType);
 
 MLIR_CAPI_EXPORTED MlirType hwTypeAliasTypeGet(MlirStringRef scope,

--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -205,17 +205,31 @@ def StructExtractOp : HWOp<"struct_extract",
     ```
   }];
 
-  let arguments = (ins StructType:$input, StrAttr:$field);
+  let arguments = (ins StructType:$input, I32Attr:$fieldIndex);
   let results = (outs HWNonInOutType:$result);
   let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
 
   let builders = [
     OpBuilder<(ins "Value":$input, "StructType::FieldInfo":$field)>,
-    OpBuilder<(ins "Value":$input, "StringAttr":$field)>,
-    OpBuilder<(ins "Value":$input, "StringRef":$field), [{
-      build(odsBuilder, odsState, input, odsBuilder.getStringAttr(field));
+    OpBuilder<(ins "Value":$input, "StringAttr":$fieldName)>,
+    OpBuilder<(ins "Value":$input, "StringRef":$fieldName), [{
+      build($_builder, $_state, input, $_builder.getStringAttr(fieldName));
     }]>
   ];
+
+  let extraClassDeclaration = [{
+    /// Return the name attribute of the accessed field.
+    StringAttr getFieldNameAttr() {
+      StructType type = getInput().getType();
+      return type.getElements()[getFieldIndex()].name;
+    }
+
+    /// Return the name of the accessed field.
+    StringRef getFieldName() {
+      return getFieldNameAttr().getValue();
+    }
+  }];
 
   let hasFolder = 1;
   let hasCanonicalizeMethod = 1;
@@ -232,10 +246,32 @@ def StructInjectOp : HWOp<"struct_inject", [Pure,
     ```
   }];
 
-  let arguments = (ins StructType:$input, StrAttr:$field,
+  let arguments = (ins StructType:$input, I32Attr:$fieldIndex,
                    HWNonInOutType:$newValue);
   let results = (outs StructType:$result);
   let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins "Value":$input, "StringAttr":$fieldName, "Value":$newValue)>,
+    OpBuilder<(ins "Value":$input, "StringRef":$fieldName, "Value":$newValue), [{
+      build($_builder, $_state, input, $_builder.getStringAttr(fieldName), newValue);
+    }]>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Return the name attribute of the accessed field.
+    StringAttr getFieldNameAttr() {
+      StructType type = getInput().getType();
+      return type.getElements()[getFieldIndex()].name;
+    }
+
+    /// Return the name of the accessed field.
+    StringRef getFieldName() {
+      return getFieldNameAttr().getValue();
+    }
+  }];
+
   let hasFolder = 1;
   let hasCanonicalizeMethod = 1;
 }
@@ -277,9 +313,30 @@ def UnionCreateOp : HWOp<"union_create", [Pure]> {
     ```
   }];
 
-  let arguments = (ins StrAttr:$field, HWNonInOutType:$input);
+  let arguments = (ins I32Attr:$fieldIndex, HWNonInOutType:$input);
   let results = (outs UnionType:$result);
   let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins "Type":$unionType, "StringAttr":$fieldName, "Value":$input)>,
+    OpBuilder<(ins "Type":$unionType, "StringRef":$fieldName, "Value":$input), [{
+      build($_builder, $_state, unionType, $_builder.getStringAttr(fieldName), input);
+    }]>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Return the name attribute of the accessed field.
+    StringAttr getFieldNameAttr() {
+      UnionType type = getType();
+      return type.getElements()[getFieldIndex()].name;
+    }
+
+    /// Return the name of the accessed field.
+    StringRef getFieldName() {
+      return getFieldNameAttr().getValue();
+    }
+  }];
 }
 
 def UnionExtractOp : HWOp<"union_extract", [Pure, 
@@ -298,9 +355,29 @@ def UnionExtractOp : HWOp<"union_extract", [Pure,
     ```
   }];
 
-  let arguments = (ins UnionType:$input, StrAttr:$field);
+  let arguments = (ins UnionType:$input, I32Attr:$fieldIndex);
   let results = (outs HWNonInOutType:$result);
   let hasCustomAssemblyFormat = 1;
+
+  let builders = [
+    OpBuilder<(ins "Value":$input, "StringAttr":$fieldName)>,
+    OpBuilder<(ins "Value":$input, "StringRef":$fieldName), [{
+      build($_builder, $_state, input, $_builder.getStringAttr(fieldName));
+    }]>
+  ];
+
+  let extraClassDeclaration = [{
+    /// Return the name attribute of the accessed field.
+    StringAttr getFieldNameAttr() {
+      UnionType type = getInput().getType();
+      return type.getElements()[getFieldIndex()].name;
+    }
+
+    /// Return the name of the accessed field.
+    StringRef getFieldName() {
+      return getFieldNameAttr().getValue();
+    }
+  }];
 }
 
 #endif // CIRCT_DIALECT_HW_HWAGGREGATES_TD

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -142,8 +142,8 @@ def StructTypeImpl : HWType<"Struct", [DeclareTypeInterfaceMethods<FieldIDTypeIn
     using FieldInfo = ::circt::hw::detail::FieldInfo;
     mlir::Type getFieldType(mlir::StringRef fieldName);
     void getInnerTypes(mlir::SmallVectorImpl<mlir::Type>&);
-    std::optional<unsigned> getFieldIndex(mlir::StringRef fieldName);
-    std::optional<unsigned> getFieldIndex(mlir::StringAttr fieldName);
+    std::optional<uint32_t> getFieldIndex(mlir::StringRef fieldName);
+    std::optional<uint32_t> getFieldIndex(mlir::StringAttr fieldName);
   }];
 }
 
@@ -193,8 +193,8 @@ def UnionTypeImpl : HWType<"Union"> {
     FieldInfo getFieldInfo(::mlir::StringRef fieldName);
 
     ::mlir::Type getFieldType(::mlir::StringRef fieldName);
-    std::optional<unsigned> getFieldIndex(mlir::StringRef fieldName);
-    std::optional<unsigned> getFieldIndex(mlir::StringAttr fieldName);
+    std::optional<uint32_t> getFieldIndex(mlir::StringRef fieldName);
+    std::optional<uint32_t> getFieldIndex(mlir::StringAttr fieldName);
   }];
 }
 

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -193,6 +193,8 @@ def UnionTypeImpl : HWType<"Union"> {
     FieldInfo getFieldInfo(::mlir::StringRef fieldName);
 
     ::mlir::Type getFieldType(::mlir::StringRef fieldName);
+    std::optional<unsigned> getFieldIndex(mlir::StringRef fieldName);
+    std::optional<unsigned> getFieldIndex(mlir::StringAttr fieldName);
   }];
 }
 

--- a/lib/Bindings/Python/HWModule.cpp
+++ b/lib/Bindings/Python/HWModule.cpp
@@ -149,6 +149,11 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
              return hwStructTypeGetField(
                  self, mlirStringRefCreateFromCString(fieldName.c_str()));
            })
+      .def("get_field_index",
+           [](MlirType self, const std::string &fieldName) {
+             return hwStructTypeGetFieldIndex(
+                 self, mlirStringRefCreateFromCString(fieldName.c_str()));
+           })
       .def("get_fields", [](MlirType self) {
         intptr_t num_fields = hwStructTypeGetNumFields(self);
         py::list fields;

--- a/lib/Bindings/Python/dialects/hw.py
+++ b/lib/Bindings/Python/dialects/hw.py
@@ -521,8 +521,11 @@ class StructExtractOp(StructExtractOp):
     struct_value = support.get_value(struct_value)
     struct_type = support.get_self_or_inner(struct_value.type)
     field_type = struct_type.get_field(field_name)
-    return hw.StructExtractOp(field_type, struct_value,
-                              StringAttr.get(field_name))
+    field_index = struct_type.get_field_index(field_name)
+    if field_index == UnitAttr.get():
+      raise TypeError(
+          f"field '{field_name}' not element of struct type {struct_type}")
+    return hw.StructExtractOp(field_type, struct_value, field_index)
 
 
 @_ods_cext.register_operation(_Dialect, replace=True)

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -146,6 +146,14 @@ MlirType hwStructTypeGetField(MlirType structType, MlirStringRef fieldName) {
   return wrap(st.getFieldType(unwrap(fieldName)));
 }
 
+MlirAttribute hwStructTypeGetFieldIndex(MlirType structType,
+                                        MlirStringRef fieldName) {
+  StructType st = unwrap(structType).cast<StructType>();
+  if (auto idx = st.getFieldIndex(unwrap(fieldName)))
+    return wrap(IntegerAttr::get(IntegerType::get(st.getContext(), 32), *idx));
+  return wrap(UnitAttr::get(st.getContext()));
+}
+
 intptr_t hwStructTypeGetNumFields(MlirType structType) {
   StructType st = unwrap(structType).cast<StructType>();
   return st.getElements().size();

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3078,7 +3078,7 @@ SubExprInfo ExprEmitter::visitTypeOp(StructExtractOp op) {
 
   emitSubExpr(op.getInput(), Selection);
   ps << "."
-     << PPExtString(emitter.getVerilogStructFieldName(op.getFieldAttr()));
+     << PPExtString(emitter.getVerilogStructFieldName(op.getFieldNameAttr()));
   return {Selection, IsUnsigned};
 }
 
@@ -3098,7 +3098,7 @@ SubExprInfo ExprEmitter::visitTypeOp(StructInjectOp op) {
         ps.scopedBox(PP::ibox2, [&]() {
           ps << PPExtString(emitter.getVerilogStructFieldName(field.name))
              << ":" << PP::space;
-          if (field.name == op.getField()) {
+          if (field.name == op.getFieldNameAttr()) {
             emitSubExpr(op.getNewValue(), Selection);
           } else {
             emitSubExpr(op.getInput(), Selection);
@@ -3131,10 +3131,9 @@ SubExprInfo ExprEmitter::visitTypeOp(UnionCreateOp op) {
     emitError(op, "SV attributes emission is unimplemented for the op");
 
   // Check if this union type has been padded.
-  auto fieldName = op.getFieldAttr();
   auto unionType = cast<UnionType>(getCanonicalType(op.getType()));
   auto unionWidth = hw::getBitWidth(unionType);
-  auto element = unionType.getFieldInfo(fieldName.getValue());
+  auto &element = unionType.getElements()[op.getFieldIndex()];
   auto elementWidth = hw::getBitWidth(element.type);
 
   // If the element is 0 width, just fill the union with 0s.
@@ -3175,13 +3174,12 @@ SubExprInfo ExprEmitter::visitTypeOp(UnionExtractOp op) {
   emitSubExpr(op.getInput(), Selection);
 
   // Check if this union type has been padded.
-  auto fieldName = op.getFieldAttr();
   auto unionType = cast<UnionType>(getCanonicalType(op.getInput().getType()));
   auto unionWidth = hw::getBitWidth(unionType);
-  auto element = unionType.getFieldInfo(fieldName.getValue());
+  auto &element = unionType.getElements()[op.getFieldIndex()];
   auto elementWidth = hw::getBitWidth(element.type);
   bool needsPadding = elementWidth < unionWidth || element.offset > 0;
-  auto verilogFieldName = emitter.getVerilogStructFieldName(fieldName);
+  auto verilogFieldName = emitter.getVerilogStructFieldName(element.name);
 
   // If the element needs padding then we need to get the actual element out
   // of an anonymous structure.

--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -123,8 +123,8 @@ struct StructExtractOpConversion
   matchAndRewrite(hw::StructExtractOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    uint32_t fieldIndex = HWToLLVMEndianessConverter::llvmIndexOfStructField(
-        op.getInput().getType().cast<hw::StructType>(), op.getField());
+    uint32_t fieldIndex = HWToLLVMEndianessConverter::convertToLLVMEndianess(
+        op.getInput().getType(), op.getFieldIndex());
     rewriter.replaceOpWithNewOp<LLVM::ExtractValueOp>(op, adaptor.getInput(),
                                                       fieldIndex);
     return success();
@@ -250,9 +250,8 @@ struct StructInjectOpConversion
   matchAndRewrite(hw::StructInjectOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    uint32_t fieldIndex = HWToLLVMEndianessConverter::llvmIndexOfStructField(
-        op.getInput().getType().cast<hw::StructType>(),
-        op.getFieldAttr().getValue());
+    uint32_t fieldIndex = HWToLLVMEndianessConverter::convertToLLVMEndianess(
+        op.getInput().getType(), op.getFieldIndex());
 
     rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(
         op, adaptor.getInput(), op.getNewValue(), fieldIndex);

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -65,17 +65,15 @@ bool hw::isCombinational(Operation *op) {
          IsCombClassifier().dispatchTypeOpVisitor(op);
 }
 
-static Value foldStructExtract(Operation *inputOp, StringRef field) {
+static Value foldStructExtract(Operation *inputOp, uint32_t fieldIndex) {
   // A struct extract of a struct create -> corresponding struct create operand.
   if (auto structCreate = dyn_cast_or_null<StructCreateOp>(inputOp)) {
-    auto ty = type_cast<StructType>(structCreate.getResult().getType());
-    if (auto idx = ty.getFieldIndex(field))
-      return structCreate.getOperand(*idx);
-    return {};
+    return structCreate.getOperand(fieldIndex);
   }
+
   // Extracting injected field -> corresponding field
   if (auto structInject = dyn_cast_or_null<StructInjectOp>(inputOp)) {
-    if (structInject.getField() != field)
+    if (structInject.getFieldIndex() != fieldIndex)
       return {};
     return structInject.getNewValue();
   }
@@ -2313,9 +2311,10 @@ LogicalResult StructExplodeOp::canonicalize(StructExplodeOp op,
   auto *inputOp = op.getInput().getDefiningOp();
   auto elements = type_cast<StructType>(op.getInput().getType()).getElements();
   auto result = failure();
-  for (auto [element, res] : llvm::zip(elements, op.getResults())) {
-    if (auto foldResult = foldStructExtract(inputOp, element.name.str())) {
-      rewriter.replaceAllUsesWith(res, foldResult);
+  auto opResults = op.getResults();
+  for (unsigned index = 0; index < elements.size(); index++) {
+    if (auto foldResult = foldStructExtract(inputOp, index)) {
+      rewriter.replaceAllUsesWith(opResults[index], foldResult);
       result = success();
     }
   }
@@ -2343,6 +2342,30 @@ void StructExplodeOp::build(OpBuilder &odsBuilder, OperationState &odsState,
 // StructExtractOp
 //===----------------------------------------------------------------------===//
 
+/// Ensure an aggregate op's field index is within the bounds of
+/// the aggregate type and the accessed field is of 'elementType'.
+template <typename AggregateOp, typename AggregateType>
+static LogicalResult verifyAggregateFieldIndexAndType(AggregateOp &op,
+                                                      AggregateType aggType,
+                                                      Type elementType) {
+  auto index = op.getFieldIndex();
+  if (index >= aggType.getElements().size())
+    return op.emitOpError("field index " + Twine(index) +
+                          " exceeds element count of aggregate type");
+
+  if (getCanonicalType(elementType) !=
+      getCanonicalType(aggType.getElements()[index].type))
+    return op.emitOpError("type of accessed field in aggregate at index " +
+                          Twine(index) + " does not match expected type");
+
+  return success();
+}
+
+LogicalResult StructExtractOp::verify() {
+  return verifyAggregateFieldIndexAndType<StructExtractOp, StructType>(
+      *this, getInput().getType(), getType());
+}
+
 /// Use the same parser for both struct_extract and union_extract since the
 /// syntax is identical.
 template <typename AggregateType>
@@ -2352,8 +2375,7 @@ static ParseResult parseExtractOp(OpAsmParser &parser, OperationState &result) {
   Type declType;
 
   if (parser.parseOperand(operand) || parser.parseLSquare() ||
-      parser.parseAttribute(fieldName, "field", result.attributes) ||
-      parser.parseRSquare() ||
+      parser.parseAttribute(fieldName) || parser.parseRSquare() ||
       parser.parseOptionalAttrDict(result.attributes) ||
       parser.parseColonType(declType))
     return failure();
@@ -2362,11 +2384,16 @@ static ParseResult parseExtractOp(OpAsmParser &parser, OperationState &result) {
     return parser.emitError(parser.getNameLoc(),
                             "invalid kind of type specified");
 
-  Type resultType = aggType.getFieldType(fieldName.getValue());
-  if (!resultType) {
+  auto fieldIndex = aggType.getFieldIndex(fieldName);
+  if (!fieldIndex) {
     parser.emitError(parser.getNameLoc(), "invalid field name specified");
     return failure();
   }
+
+  auto indexAttr =
+      IntegerAttr::get(IntegerType::get(parser.getContext(), 32), *fieldIndex);
+  result.addAttribute("fieldIndex", indexAttr);
+  Type resultType = aggType.getElements()[*fieldIndex].type;
   result.addTypes(resultType);
 
   if (parser.resolveOperand(operand, declType, result.operands))
@@ -2380,8 +2407,8 @@ template <typename AggType>
 static void printExtractOp(OpAsmPrinter &printer, AggType op) {
   printer << " ";
   printer.printOperand(op.getInput());
-  printer << "[\"" << op.getField() << "\"]";
-  printer.printOptionalAttrDict(op->getAttrs(), {"field"});
+  printer << "[\"" << op.getFieldName() << "\"]";
+  printer.printOptionalAttrDict(op->getAttrs(), {"fieldIndex"});
   printer << " : " << op.getInput().getType();
 }
 
@@ -2396,27 +2423,30 @@ void StructExtractOp::print(OpAsmPrinter &printer) {
 
 void StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
                             Value input, StructType::FieldInfo field) {
-  build(builder, odsState, field.type, input, field.name);
+  auto fieldIndex =
+      type_cast<StructType>(input.getType()).getFieldIndex(field.name);
+  assert(fieldIndex.has_value() && "field name not found in aggregate type");
+  build(builder, odsState, field.type, input, *fieldIndex);
 }
 
 void StructExtractOp::build(OpBuilder &builder, OperationState &odsState,
-                            Value input, StringAttr fieldAttr) {
+                            Value input, StringAttr fieldName) {
   auto structType = type_cast<StructType>(input.getType());
-  auto resultType = structType.getFieldType(fieldAttr);
-  build(builder, odsState, resultType, input, fieldAttr);
+  auto fieldIndex = structType.getFieldIndex(fieldName);
+  assert(fieldIndex.has_value() && "field name not found in aggregate type");
+  auto resultType = structType.getElements()[*fieldIndex].type;
+  build(builder, odsState, resultType, input, *fieldIndex);
 }
 
 OpFoldResult StructExtractOp::fold(FoldAdaptor adaptor) {
   if (auto constOperand = adaptor.getInput()) {
     // Fold extract from aggregate constant
-    auto operandType = type_cast<StructType>(getOperand().getType());
-    auto fieldIdx = operandType.getFieldIndex(getField());
     auto operandAttr = llvm::cast<ArrayAttr>(constOperand);
-    return operandAttr.getValue()[*fieldIdx];
+    return operandAttr.getValue()[getFieldIndex()];
   }
 
   if (auto foldResult =
-          foldStructExtract(getInput().getDefiningOp(), getField()))
+          foldStructExtract(getInput().getDefiningOp(), getFieldIndex()))
     return foldResult;
   return {};
 }
@@ -2427,9 +2457,9 @@ LogicalResult StructExtractOp::canonicalize(StructExtractOp op,
 
   // b = extract(inject(x["a"], v0)["b"]) => extract(x, "b")
   if (auto structInject = dyn_cast_or_null<StructInjectOp>(inputOp)) {
-    if (structInject.getField() != op.getField()) {
+    if (structInject.getFieldIndex() != op.getFieldIndex()) {
       rewriter.replaceOpWithNewOp<StructExtractOp>(
-          op, op.getType(), structInject.getInput(), op.getField());
+          op, op.getType(), structInject.getInput(), op.getFieldIndexAttr());
       return success();
     }
   }
@@ -2439,18 +2469,25 @@ LogicalResult StructExtractOp::canonicalize(StructExtractOp op,
 
 void StructExtractOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
-  auto structType = type_cast<StructType>(getInput().getType());
-  for (auto field : structType.getElements()) {
-    if (field.name == getField()) {
-      setNameFn(getResult(), field.name.str());
-      return;
-    }
-  }
+  setNameFn(getResult(), getFieldName());
 }
 
 //===----------------------------------------------------------------------===//
 // StructInjectOp
 //===----------------------------------------------------------------------===//
+
+void StructInjectOp::build(OpBuilder &builder, OperationState &odsState,
+                           Value input, StringAttr fieldName, Value newValue) {
+  auto structType = type_cast<StructType>(input.getType());
+  auto fieldIndex = structType.getFieldIndex(fieldName);
+  assert(fieldIndex.has_value() && "field name not found in aggregate type");
+  build(builder, odsState, input, *fieldIndex, newValue);
+}
+
+LogicalResult StructInjectOp::verify() {
+  return verifyAggregateFieldIndexAndType<StructInjectOp, StructType>(
+      *this, getInput().getType(), getNewValue().getType());
+}
 
 ParseResult StructInjectOp::parse(OpAsmParser &parser, OperationState &result) {
   llvm::SMLoc inputOperandsLoc = parser.getCurrentLocation();
@@ -2459,9 +2496,8 @@ ParseResult StructInjectOp::parse(OpAsmParser &parser, OperationState &result) {
   Type declType;
 
   if (parser.parseOperand(operand) || parser.parseLSquare() ||
-      parser.parseAttribute(fieldName, "field", result.attributes) ||
-      parser.parseRSquare() || parser.parseComma() ||
-      parser.parseOperand(val) ||
+      parser.parseAttribute(fieldName) || parser.parseRSquare() ||
+      parser.parseComma() || parser.parseOperand(val) ||
       parser.parseOptionalAttrDict(result.attributes) ||
       parser.parseColonType(declType))
     return failure();
@@ -2469,13 +2505,18 @@ ParseResult StructInjectOp::parse(OpAsmParser &parser, OperationState &result) {
   if (!structType)
     return parser.emitError(inputOperandsLoc, "invalid kind of type specified");
 
-  Type resultType = structType.getFieldType(fieldName.getValue());
-  if (!resultType) {
-    parser.emitError(inputOperandsLoc, "invalid field name specified");
+  auto fieldIndex = structType.getFieldIndex(fieldName);
+  if (!fieldIndex) {
+    parser.emitError(parser.getNameLoc(), "invalid field name specified");
     return failure();
   }
+
+  auto indexAttr =
+      IntegerAttr::get(IntegerType::get(parser.getContext(), 32), *fieldIndex);
+  result.addAttribute("fieldIndex", indexAttr);
   result.addTypes(declType);
 
+  Type resultType = structType.getElements()[*fieldIndex].type;
   if (parser.resolveOperands({operand, val}, {declType, resultType},
                              inputOperandsLoc, result.operands))
     return failure();
@@ -2485,9 +2526,9 @@ ParseResult StructInjectOp::parse(OpAsmParser &parser, OperationState &result) {
 void StructInjectOp::print(OpAsmPrinter &printer) {
   printer << " ";
   printer.printOperand(getInput());
-  printer << "[\"" << getField() << "\"], ";
+  printer << "[\"" << getFieldName() << "\"], ";
   printer.printOperand(getNewValue());
-  printer.printOptionalAttrDict((*this)->getAttrs(), {"field"});
+  printer.printOptionalAttrDict((*this)->getAttrs(), {"fieldIndex"});
   printer << " : " << getInput().getType();
 }
 
@@ -2498,9 +2539,7 @@ OpFoldResult StructInjectOp::fold(FoldAdaptor adaptor) {
     return {};
   SmallVector<Attribute> array;
   llvm::copy(input.cast<ArrayAttr>(), std::back_inserter(array));
-  StructType structType = getInput().getType();
-  auto index = *structType.getFieldIndex(getField());
-  array[index] = newValue;
+  array[getFieldIndex()] = newValue;
   return ArrayAttr::get(getContext(), array);
 }
 
@@ -2517,7 +2556,7 @@ LogicalResult StructInjectOp::canonicalize(StructInjectOp op,
     if (!injects.insert(inject).second)
       return failure();
 
-    fields.try_emplace(inject.getFieldAttr(), inject.getNewValue());
+    fields.try_emplace(inject.getFieldNameAttr(), inject.getNewValue());
     input = inject.getInput();
     inject = dyn_cast_or_null<StructInjectOp>(input.getDefiningOp());
   } while (inject);
@@ -2543,11 +2582,11 @@ LogicalResult StructInjectOp::canonicalize(StructInjectOp op,
     return failure();
 
   // Eliminate overwrites. The hash map contains the last write to each field.
-  for (const auto &field : elements) {
-    auto it = fields.find(field.name);
+  for (uint32_t fieldIndex = 0; fieldIndex < elements.size(); fieldIndex++) {
+    auto it = fields.find(elements[fieldIndex].name);
     if (it == fields.end())
       continue;
-    input = rewriter.create<StructInjectOp>(op.getLoc(), ty, input, field.name,
+    input = rewriter.create<StructInjectOp>(op.getLoc(), ty, input, fieldIndex,
                                             it->second);
   }
 
@@ -2559,14 +2598,26 @@ LogicalResult StructInjectOp::canonicalize(StructInjectOp op,
 // UnionCreateOp
 //===----------------------------------------------------------------------===//
 
+LogicalResult UnionCreateOp::verify() {
+  return verifyAggregateFieldIndexAndType<UnionCreateOp, UnionType>(
+      *this, getType(), getInput().getType());
+}
+
+void UnionCreateOp::build(OpBuilder &builder, OperationState &odsState,
+                          Type unionType, StringAttr fieldName, Value input) {
+  auto fieldIndex = type_cast<UnionType>(unionType).getFieldIndex(fieldName);
+  assert(fieldIndex.has_value() && "field name not found in aggregate type");
+  build(builder, odsState, unionType, *fieldIndex, input);
+}
+
 ParseResult UnionCreateOp::parse(OpAsmParser &parser, OperationState &result) {
   Type declOrAliasType;
-  StringAttr field;
+  StringAttr fieldName;
   OpAsmParser::UnresolvedOperand input;
   llvm::SMLoc fieldLoc = parser.getCurrentLocation();
 
-  if (parser.parseAttribute(field, "field", result.attributes) ||
-      parser.parseComma() || parser.parseOperand(input) ||
+  if (parser.parseAttribute(fieldName) || parser.parseComma() ||
+      parser.parseOperand(input) ||
       parser.parseOptionalAttrDict(result.attributes) ||
       parser.parseColonType(declOrAliasType))
     return failure();
@@ -2576,12 +2627,17 @@ ParseResult UnionCreateOp::parse(OpAsmParser &parser, OperationState &result) {
     return parser.emitError(parser.getNameLoc(),
                             "expected !hw.union type or alias");
 
-  Type inputType = declType.getFieldType(field.getValue());
-  if (!inputType) {
+  auto fieldIndex = declType.getFieldIndex(fieldName);
+  if (!fieldIndex) {
     parser.emitError(fieldLoc, "cannot find union field '")
-        << field.getValue() << '\'';
+        << fieldName.getValue() << '\'';
     return failure();
   }
+
+  auto indexAttr =
+      IntegerAttr::get(IntegerType::get(parser.getContext(), 32), *fieldIndex);
+  result.addAttribute("fieldIndex", indexAttr);
+  Type inputType = declType.getElements()[*fieldIndex].type;
 
   if (parser.resolveOperand(input, inputType, result.operands))
     return failure();
@@ -2590,9 +2646,9 @@ ParseResult UnionCreateOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 void UnionCreateOp::print(OpAsmPrinter &printer) {
-  printer << " \"" << getField() << "\", ";
+  printer << " \"" << getFieldName() << "\", ";
   printer.printOperand(getInput());
-  printer.printOptionalAttrDict((*this)->getAttrs(), {"field"});
+  printer.printOptionalAttrDict((*this)->getAttrs(), {"fieldIndex"});
   printer << " : " << getType();
 }
 
@@ -2612,9 +2668,27 @@ LogicalResult UnionExtractOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::OpaqueProperties properties,
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
-  results.push_back(cast<UnionType>(getCanonicalType(operands[0].getType()))
-                        .getFieldType(attrs.getAs<StringAttr>("field")));
+  auto unionElements =
+      hw::type_cast<UnionType>((operands[0].getType())).getElements();
+  unsigned fieldIndex =
+      attrs.getAs<IntegerAttr>("fieldIndex").getValue().getZExtValue();
+  if (fieldIndex >= unionElements.size()) {
+    if (loc)
+      mlir::emitError(*loc, "field index " + Twine(fieldIndex) +
+                                " exceeds element count of aggregate type");
+    return failure();
+  }
+  results.push_back(unionElements[fieldIndex].type);
   return success();
+}
+
+void UnionExtractOp::build(OpBuilder &odsBuilder, OperationState &odsState,
+                           Value input, StringAttr fieldName) {
+  auto unionType = type_cast<UnionType>(input.getType());
+  auto fieldIndex = unionType.getFieldIndex(fieldName);
+  assert(fieldIndex.has_value() && "field name not found in aggregate type");
+  auto resultType = unionType.getElements()[*fieldIndex].type;
+  build(odsBuilder, odsState, resultType, input, *fieldIndex);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2350,13 +2350,15 @@ static LogicalResult verifyAggregateFieldIndexAndType(AggregateOp &op,
                                                       Type elementType) {
   auto index = op.getFieldIndex();
   if (index >= aggType.getElements().size())
-    return op.emitOpError("field index " + Twine(index) +
-                          " exceeds element count of aggregate type");
+    return op.emitOpError() << "field index " << index
+                            << " exceeds element count of aggregate type";
 
   if (getCanonicalType(elementType) !=
       getCanonicalType(aggType.getElements()[index].type))
-    return op.emitOpError("type of accessed field in aggregate at index " +
-                          Twine(index) + " does not match expected type");
+    return op.emitOpError()
+           << "type " << aggType.getElements()[index].type
+           << " of accessed field in aggregate at index " << index
+           << " does not match expected type " << elementType;
 
   return success();
 }

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2312,7 +2312,7 @@ LogicalResult StructExplodeOp::canonicalize(StructExplodeOp op,
   auto elements = type_cast<StructType>(op.getInput().getType()).getElements();
   auto result = failure();
   auto opResults = op.getResults();
-  for (unsigned index = 0; index < elements.size(); index++) {
+  for (uint32_t index = 0; index < elements.size(); index++) {
     if (auto foldResult = foldStructExtract(inputOp, index)) {
       rewriter.replaceAllUsesWith(opResults[index], foldResult);
       result = success();

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2388,7 +2388,9 @@ static ParseResult parseExtractOp(OpAsmParser &parser, OperationState &result) {
 
   auto fieldIndex = aggType.getFieldIndex(fieldName);
   if (!fieldIndex) {
-    parser.emitError(parser.getNameLoc(), "invalid field name specified");
+    parser.emitError(parser.getNameLoc(), "field name '" +
+                                              fieldName.getValue() +
+                                              "' not found in aggregate type");
     return failure();
   }
 
@@ -2509,7 +2511,9 @@ ParseResult StructInjectOp::parse(OpAsmParser &parser, OperationState &result) {
 
   auto fieldIndex = structType.getFieldIndex(fieldName);
   if (!fieldIndex) {
-    parser.emitError(parser.getNameLoc(), "invalid field name specified");
+    parser.emitError(parser.getNameLoc(), "field name '" +
+                                              fieldName.getValue() +
+                                              "' not found in aggregate type");
     return failure();
   }
 

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -476,10 +476,21 @@ LogicalResult UnionType::verify(function_ref<InFlightDiagnostic()> emitError,
   return result;
 }
 
+std::optional<unsigned> UnionType::getFieldIndex(mlir::StringAttr fieldName) {
+  ArrayRef<hw::UnionType::FieldInfo> elems = getElements();
+  for (size_t idx = 0, numElems = elems.size(); idx < numElems; ++idx)
+    if (elems[idx].name == fieldName)
+      return idx;
+  return {};
+}
+
+std::optional<unsigned> UnionType::getFieldIndex(mlir::StringRef fieldName) {
+  return getFieldIndex(StringAttr::get(getContext(), fieldName));
+}
+
 UnionType::FieldInfo UnionType::getFieldInfo(::mlir::StringRef fieldName) {
-  for (const auto &field : getElements())
-    if (field.name == fieldName)
-      return field;
+  if (auto fieldIndex = getFieldIndex(fieldName))
+    return getElements()[*fieldIndex];
   return FieldInfo();
 }
 

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -311,7 +311,7 @@ Type StructType::getFieldType(mlir::StringRef fieldName) {
   return Type();
 }
 
-std::optional<unsigned> StructType::getFieldIndex(mlir::StringRef fieldName) {
+std::optional<uint32_t> StructType::getFieldIndex(mlir::StringRef fieldName) {
   ArrayRef<hw::StructType::FieldInfo> elems = getElements();
   for (size_t idx = 0, numElems = elems.size(); idx < numElems; ++idx)
     if (elems[idx].name == fieldName)
@@ -319,7 +319,7 @@ std::optional<unsigned> StructType::getFieldIndex(mlir::StringRef fieldName) {
   return {};
 }
 
-std::optional<unsigned> StructType::getFieldIndex(mlir::StringAttr fieldName) {
+std::optional<uint32_t> StructType::getFieldIndex(mlir::StringAttr fieldName) {
   ArrayRef<hw::StructType::FieldInfo> elems = getElements();
   for (size_t idx = 0, numElems = elems.size(); idx < numElems; ++idx)
     if (elems[idx].name == fieldName)
@@ -476,7 +476,7 @@ LogicalResult UnionType::verify(function_ref<InFlightDiagnostic()> emitError,
   return result;
 }
 
-std::optional<unsigned> UnionType::getFieldIndex(mlir::StringAttr fieldName) {
+std::optional<uint32_t> UnionType::getFieldIndex(mlir::StringAttr fieldName) {
   ArrayRef<hw::UnionType::FieldInfo> elems = getElements();
   for (size_t idx = 0, numElems = elems.size(); idx < numElems; ++idx)
     if (elems[idx].name == fieldName)
@@ -484,7 +484,7 @@ std::optional<unsigned> UnionType::getFieldIndex(mlir::StringAttr fieldName) {
   return {};
 }
 
-std::optional<unsigned> UnionType::getFieldIndex(mlir::StringRef fieldName) {
+std::optional<uint32_t> UnionType::getFieldIndex(mlir::StringRef fieldName) {
   return getFieldIndex(StringAttr::get(getContext(), fieldName));
 }
 

--- a/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
+++ b/lib/Dialect/SV/Transforms/PrettifyVerilog.cpp
@@ -97,7 +97,7 @@ static bool isSelfWrite(Value dst, Value src) {
         auto toField = dyn_cast<sv::StructFieldInOutOp>(dstOp);
         if (!toField)
           return false;
-        if (toField.getField() != extract.getField())
+        if (toField.getFieldAttr() != extract.getFieldNameAttr())
           return false;
         return isSelfWrite(toField.getInput(), extract.getInput());
       })
@@ -126,7 +126,7 @@ bool PrettifyVerilogPass::splitStructAssignment(OpBuilder &builder,
     // Inner injects are overwritten by outer injects.
     // Insert does not overwrite the store to be lowered.
     auto field = std::make_pair(inj.getLoc(), inj.getNewValue());
-    fields.try_emplace(inj.getFieldAttr(), field);
+    fields.try_emplace(inj.getFieldNameAttr(), field);
     src = inj.getInput();
   }
 

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -110,7 +110,7 @@ hw.module @struct(in %a: !hw.struct<foo: i42>) {
 // -----
 
 hw.module @struct(in %a: !hw.struct<foo: i42>) {
-  // expected-error @+1 {{custom op 'hw.struct_extract' invalid field name specified}}
+  // expected-error @+1 {{custom op 'hw.struct_extract' field name 'bar' not found in aggregate type}}
   %aget = hw.struct_extract %a["bar"] : !hw.struct<foo: i42>
 }
 
@@ -138,7 +138,7 @@ hw.module @struct(in %a: !hw.struct<foo: i42>, in %b: i42) {
 // -----
 
 hw.module @struct(in %a: !hw.struct<foo: i42>, in %b: i42) {
-  // expected-error @+1 {{custom op 'hw.struct_inject' invalid field name specified}}
+  // expected-error @+1 {{custom op 'hw.struct_inject' field name 'bar' not found in aggregate type}}
   %aget = hw.struct_inject %a["bar"], %b : !hw.struct<foo: i42>
 }
 
@@ -179,7 +179,7 @@ hw.module @union(in %a: i12) {
 // -----
 
 hw.module @union(in %a: !hw.union<foo: i42>) {
-  // expected-error @+1 {{custom op 'hw.union_extract' invalid field name specified}}
+  // expected-error @+1 {{custom op 'hw.union_extract' field name 'bar' not found in aggregate type}}
   %aget = hw.union_extract %a["bar"] : !hw.union<foo: i42>
 }
 // -----

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -116,6 +116,20 @@ hw.module @struct(in %a: !hw.struct<foo: i42>) {
 
 // -----
 
+hw.module @struct(in %a: !hw.struct<foo: i32, bar: i18>) {
+  // expected-error @+1 {{'hw.struct_extract' op field index 2 exceeds element count of aggregate type}}
+  %0 = "hw.struct_extract"(%a) {fieldIndex = 2 : i32} : (!hw.struct<foo: i32, bar: i18>) -> i18
+}
+
+// -----
+
+hw.module @struct(in %a: !hw.struct<foo: i32, bar: i18>) {
+  // expected-error @+1 {{'hw.struct_extract' op type 'i18' of accessed field in aggregate at index 1 does not match expected type 'i19'}}
+  %0 = "hw.struct_extract"(%a) {fieldIndex = 1 : i32} : (!hw.struct<foo: i32, bar: i18>) -> i19
+}
+
+// -----
+
 hw.module @struct(in %a: !hw.struct<foo: i42>, in %b: i42) {
   // expected-error @+1 {{custom op 'hw.struct_inject' invalid kind of type specified}}
   %aget = hw.struct_inject %a["foo"], %b : i42
@@ -130,9 +144,36 @@ hw.module @struct(in %a: !hw.struct<foo: i42>, in %b: i42) {
 
 // -----
 
-hw.module @union(in %b: i42) {
+hw.module @struct(in %a: !hw.struct<foo: i32, bar: i18>, in %b: i18) {
+  // expected-error @+1 {{'hw.struct_inject' op field index 2 exceeds element count of aggregate type}}
+  %0 = "hw.struct_inject"(%a, %b) {fieldIndex = 2 : i32} : (!hw.struct<foo: i32, bar: i18>, i18) -> !hw.struct<foo: i32, bar: i18>
+}
+
+// -----
+
+hw.module @struct(in %a: !hw.struct<foo: i32, bar: i18>, in %b: i42) {
+  // expected-error @+1 {{'hw.struct_inject' op type 'i18' of accessed field in aggregate at index 1 does not match expected type 'i42'}}
+  %0 = "hw.struct_inject"(%a, %b) {fieldIndex = 1 : i32} : (!hw.struct<foo: i32, bar: i18>, i42) -> !hw.struct<foo: i32, bar: i18>
+}
+// -----
+
+hw.module @union(in %a: i42) {
   // expected-error @+1 {{custom op 'hw.union_create' cannot find union field 'bar'}}
   %u = hw.union_create "bar", %a : !hw.union<foo: i42>
+}
+
+// -----
+
+hw.module @union(in %a: i42) {
+  // expected-error @+1 {{'hw.union_create' op field index 1 exceeds element count of aggregate type}}
+  %0 = "hw.union_create"(%a) {fieldIndex = 1 : i32} : (i42) -> !hw.union<foo: i42>
+}
+
+// -----
+
+hw.module @union(in %a: i12) {
+  // expected-error @+1 {{'hw.union_create' op type 'i42' of accessed field in aggregate at index 0 does not match expected type 'i12'}}
+  %0 = "hw.union_create"(%a) {fieldIndex = 0 : i32} : (i12) -> !hw.union<foo: i42, bar: i12>
 }
 
 // -----
@@ -140,6 +181,20 @@ hw.module @union(in %b: i42) {
 hw.module @union(in %a: !hw.union<foo: i42>) {
   // expected-error @+1 {{custom op 'hw.union_extract' invalid field name specified}}
   %aget = hw.union_extract %a["bar"] : !hw.union<foo: i42>
+}
+// -----
+
+hw.module @union(in %a: !hw.union<foo: i42>) {
+  // expected-error @+2 {{'hw.union_extract' op failed to infer returned types}}
+  // expected-error @+1 {{field index 1 exceeds element count of aggregate type}}
+  %aget = "hw.union_extract"(%a) {fieldIndex = 1 : i32} : (!hw.union<foo: i42>) -> i42
+}
+// -----
+
+hw.module @union(in %a: !hw.union<foo: i42, bar: i12>) {
+  // expected-error @+2 {{'hw.union_extract' op failed to infer returned types}}
+  // expected-error @+1 {{'hw.union_extract' op inferred type(s) 'i12' are incompatible with return type(s) of operation 'i42'}}
+  %aget = "hw.union_extract"(%a) {fieldIndex = 1 : i32} : (!hw.union<foo: i42, bar: i12>) -> i42
 }
 
 // -----

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -137,6 +137,13 @@ hw.module @union(in %b: i42) {
 
 // -----
 
+hw.module @union(in %a: !hw.union<foo: i42>) {
+  // expected-error @+1 {{custom op 'hw.union_extract' invalid field name specified}}
+  %aget = hw.union_extract %a["bar"] : !hw.union<foo: i42>
+}
+
+// -----
+
 // expected-note @+1 {{module declared here}}
 hw.module @empty() {
   hw.output


### PR DESCRIPTION
This PR changes the HW StructExtract, StructInject, UnionCreate and UnionExtract ops to reference their accessed field by the respective aggregate type's field index instead of the field name. This allows us to access the field's FieldInfo struct directly instead of having to traverse the array to find the matching name.

This change should mostly stay under the hood. The op printers and parsers still use the field name, and builder interfaces are added for backward compatibility.