### PR TITLE
[FIRRTL][GrandCentral] Add a mode to drop companion modules

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -117,8 +117,18 @@ std::unique_ptr<mlir::Pass> createPrintNLATablePass();
 std::unique_ptr<mlir::Pass>
 createBlackBoxReaderPass(std::optional<mlir::StringRef> inputPrefix = {});
 
+enum class CompanionMode {
+  // Lower companions to SystemVerilog binds.
+  Bind,
+  // Lower companions to explicit instances. Used when assertions or other
+  // debugging constructs from the companion are to be included in the design.
+  Instantiate,
+  // Drop companion modules, eliminating them from the design.
+  Drop,
+};
+
 std::unique_ptr<mlir::Pass>
-createGrandCentralPass(bool instantiateCompanionOnly = false);
+createGrandCentralPass(CompanionMode companionMode = CompanionMode::Bind);
 
 std::unique_ptr<mlir::Pass> createCheckCombLoopsPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -463,8 +463,17 @@ def GrandCentral : Pass<"firrtl-grand-central", "CircuitOp"> {
   let constructor = "circt::firrtl::createGrandCentralPass()";
   let dependentDialects = ["circt::sv::SVDialect", "circt::hw::HWDialect"];
   let options = [
-    Option<"instantiateCompanionOnly", "instantiate-companion-only", "bool", "false",
-      "Instantiate the companion without a bind and drop the interface">
+    Option<"companionMode", "companion-mode", "CompanionMode",
+           "CompanionMode::Bind",
+           "specify the handling of companion modules", [{
+            ::llvm::cl::values(
+              clEnumValN(CompanionMode::Bind, "bind",
+                "Lower companion instances to SystemVerilog binds"),
+              clEnumValN(CompanionMode::Instantiate, "instantiate",
+                "Instantiate companions in the design"),
+              clEnumValN(CompanionMode::Drop, "drop",
+                "Remove companions from the design"))
+           }]>
   ];
   let statistics = [
     Statistic<"numViews", "num-views-created",

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -113,14 +113,19 @@ struct FirtoolOptions {
       llvm::cl::desc("Disable deduplication of structurally identical modules"),
       llvm::cl::init(false), llvm::cl::cat(category)};
 
-  llvm::cl::opt<bool> grandCentralInstantiateCompanionOnly{
-      "grand-central-instantiate-companion",
-      llvm::cl::desc("Run Grand Central in a mode where the companion module "
-                     "is instantiated and not bound in and the interface is "
-                     "dropped.  This is intended for situations where there is "
-                     "useful assertion logic inside the companion, but you "
-                     "don't care about the actual interface."),
-      llvm::cl::init(false), llvm::cl::Hidden, llvm::cl::cat(category)};
+  llvm::cl::opt<firrtl::CompanionMode> companionMode{
+      "grand-central-companion-mode",
+      llvm::cl::desc("Specifies the handling of Grand Central companions"),
+      ::llvm::cl::values(
+          clEnumValN(firrtl::CompanionMode::Bind, "bind",
+                     "Lower companion instances to SystemVerilog binds"),
+          clEnumValN(firrtl::CompanionMode::Instantiate, "instantiate",
+                     "Instantiate companions in the design"),
+          clEnumValN(firrtl::CompanionMode::Drop, "drop",
+                     "Remove companions from the design")),
+      llvm::cl::init(firrtl::CompanionMode::Bind),
+      llvm::cl::Hidden,
+      llvm::cl::cat(category)};
 
   llvm::cl::opt<bool> disableAggressiveMergeConnections{
       "disable-aggressive-merge-connections",

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -169,7 +169,7 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   // certain black boxes should be placed.  Note: all Grand Central Taps related
   // collateral is resolved entirely by LowerAnnotations.
   pm.addNestedPass<firrtl::CircuitOp>(
-      firrtl::createGrandCentralPass(opt.grandCentralInstantiateCompanionOnly));
+      firrtl::createGrandCentralPass(opt.companionMode));
 
   // Read black box source files into the IR.
   StringRef blackBoxRoot = opt.blackBoxRootPath.empty()

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Companion.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Companion.fir
@@ -1,4 +1,6 @@
-; RUN: firtool %s --grand-central-instantiate-companion | FileCheck %s --check-prefix CHECK
+; RUN: firtool %s --grand-central-companion-mode=instantiate | FileCheck %s --check-prefixes=INST
+; RUN: firtool %s --grand-central-companion-mode=drop | FileCheck %s --check-prefixes=DROP
+; RUN: firtool %s --grand-central-companion-mode=bind | FileCheck %s --check-prefixes=BIND
 
 circuit Foo : %[[
   {
@@ -56,12 +58,23 @@ circuit Foo : %[[
     companion.clock <= clock
     companion.a <= a
 
-    ; CHECK:     module Foo
-    ; CHECK-NOT: endmodule
-    ; CHECK-NOT:   emitted as a bind statement
-    ; CHECK:       Companion companion
-    ; CHECK:     endmodule
+    ; INST:     module Foo
+    ; INST-NOT: endmodule
+    ; INST-NOT:   emitted as a bind statement
+    ; INST:       Companion companion
+    ; INST:     endmodule
+    ; INST:     FILE "gct.yaml"
+    ; INST:     []
 
-; Verify that an empty yaml file is created.
-; CHECK: FILE "gct.yaml"
-; CHECK: []  
+    ; DROP-NOT: module Companion
+    ; DROP:     module Foo
+    ; DROP NOT: Companion
+    ; DROP: endmodule
+    ; DROP:     FILE "gct.yaml"
+    ; DROP:     []
+
+    ; BIND: module Foo
+    ; BIND:     FILE "gct.yaml"
+    ; BIND:     []
+    ; BIND: module Companion
+    ; BIND: bind Foo Companion companion

--- a/test/Dialect/FIRRTL/grand-central-errors.mlir
+++ b/test/Dialect/FIRRTL/grand-central-errors.mlir
@@ -346,3 +346,32 @@ firrtl.circuit "NotInstantiated" attributes {
     firrtl.instance dut @DUT()
   }
 }
+
+// -----
+
+firrtl.circuit "CompanionWithOutputs"
+  attributes {annotations = [
+    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+     defName = "Foo",
+     elements = [
+       {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+        defName = "Bar",
+        elements = [],
+        name = "bar"}],
+     id = 0 : i64,
+     name = "MyView"}]}  {
+  // expected-error @below {{'firrtl.module' op companion instance cannot have output ports}}
+  firrtl.module private @MyView_companion(
+    out %out : !firrtl.uint<32>
+  )
+    attributes {annotations = [{
+      class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+      id = 0 : i64,
+      name = "MyView"}]} {}
+  firrtl.module private @DUT() {
+    firrtl.instance MyView_companion  @MyView_companion(out out: !firrtl.uint<32>)
+  }
+  firrtl.module @CompanionWithOutputs() {
+    firrtl.instance dut @DUT()
+  }
+}


### PR DESCRIPTION
Instead of the `--instantiate-companion-only` flag, Grand Central now takes a `--grand-central-companion-mode` flag which specifies the handling of companion objects. The modes are:

* `bind`, the original behaviour
* `instantiate`, which creates explicit instances
* `drop` which removes companions and companion-only sub-hierarchies from the design