### PR TITLE
[PipelineToHW] Add optional power-on values to control registers

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -218,7 +218,9 @@ def PipelineToHW : Pass<"lower-pipeline-to-hw", "mlir::ModuleOp"> {
   ];
   let options = [
     Option<"clockGateRegs", "clock-gate-regs", "bool", "false",
-      "Clock gate each register instead of (default) input muxing  (ASIC optimization).">
+      "Clock gate each register instead of (default) input muxing  (ASIC optimization).">,
+    Option<"enablePowerOnValues", "enable-poweron-values", "bool", "false",
+      "Add power-on values to the pipeline control registers">
   ];
 }
 

--- a/include/circt/Conversion/PipelineToHW.h
+++ b/include/circt/Conversion/PipelineToHW.h
@@ -17,10 +17,14 @@
 #include "circt/Support/LLVM.h"
 #include <memory>
 
+#define GEN_PASS_DECL_PIPELINETOHW
+#include "circt/Conversion/Passes.h.inc"
+
 namespace circt {
 
 /// Create an SCF to Calyx conversion pass.
-std::unique_ptr<mlir::Pass> createPipelineToHWPass();
+std::unique_ptr<mlir::Pass>
+createPipelineToHWPass(const PipelineToHWOptions &options = {});
 
 } // namespace circt
 

--- a/test/Conversion/PipelineToHW/test_poweron.mlir
+++ b/test/Conversion/PipelineToHW/test_poweron.mlir
@@ -1,0 +1,24 @@
+// RUN: circt-opt --lower-pipeline-to-hw="enable-poweron-values" %s | FileCheck %s
+
+// CHECK-LABEL:   hw.module @testPowerOn(in 
+// CHECK-SAME:            %[[VAL_0:.*]] : i32, in %[[VAL_1:.*]] : i32, in %[[VAL_2:.*]] : i1, in %[[VAL_3:.*]] : !seq.clock, in %[[VAL_4:.*]] : i1, out out0 : i32, out out1 : i1) {
+// CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant false
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[VAL_3]] reset %[[VAL_4]], %[[VAL_8]]  powerOn %[[VAL_8]] : i1
+// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
+// CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
+// CHECK:         }
+
+hw.module @testPowerOn(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk: !seq.clock, in %rst: i1, out out0: i32, out out1: i1) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
+    %1 = comb.sub %a0,%a1 : i32
+    pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
+  ^bb1(%6: i32, %7: i32, %s1_enable : i1):  // pred: ^bb1
+    %8 = comb.add %6, %7 : i32
+    pipeline.return %8 : i32
+  }
+  hw.output %0#0, %0#1 : i32, i1
+}
+`

--- a/test/Conversion/PipelineToHW/test_poweron.mlir
+++ b/test/Conversion/PipelineToHW/test_poweron.mlir
@@ -21,4 +21,3 @@ hw.module @testPowerOn(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk: !seq.c
   }
   hw.output %0#0, %0#1 : i32, i1
 }
-`


### PR DESCRIPTION
```mlir
hw.module @testPowerOn(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk: !seq.clock, in %rst: i1, out out0: i32, out out1: i1) {
  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
    %1 = comb.sub %a0,%a1 : i32
    pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
  ^bb1(%6: i32, %7: i32, %s1_enable : i1):  // pred: ^bb1
    %8 = comb.add %6, %7 : i32
    pipeline.return %8 : i32
  }
  hw.output %0#0, %0#1 : i32, i1
}
```
generates the following SystemVerilog, provided the `poweron` option is enabled (`0` assigned to the stage enable register).
```sv
module testPowerOn(
  input  [31:0] arg0,
                arg1,
  input         go,
                clk,
                rst,
  output [31:0] out0,
  output        out1
);

  reg [31:0] p0_stage0_reg0;
  reg [31:0] p0_stage0_reg1;
  always_ff @(posedge clk) begin
    p0_stage0_reg0 <= arg0 - arg1;
    p0_stage0_reg1 <= arg0;
  end
  reg        p0_stage1_enable = 1'h0;
  always_ff @(posedge clk) begin
    if (rst)
      p0_stage1_enable <= 1'h0;
    else
      p0_stage1_enable <= go;
  end
  assign out0 = p0_stage0_reg0 + p0_stage0_reg1;
  assign out1 = p0_stage1_enable;
endmodule
```