### PR TITLE
[HW] Ignore empty port names

### DIFF
--- a/lib/Dialect/HW/InstanceImplementation.cpp
+++ b/lib/Dialect/HW/InstanceImplementation.cpp
@@ -97,7 +97,8 @@ LogicalResult instance_like_impl::verifyInputs(ArrayAttr argNames,
       return failure();
     }
 
-    if (argNames[i] != moduleArgNames[i]) {
+    if (argNames[i] != moduleArgNames[i] &&
+        !argNames[i].cast<StringAttr>().empty()) {
       emitError([&](auto &diag) {
         diag << "input label #" << i << " must be " << moduleArgNames[i]
              << ", but got " << argNames[i];

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -192,3 +192,12 @@ hw.module @fileListTest(in %arg1: i32) attributes {output_filelist = #hw.output_
 // CHECK-SAME: attributes {comment = "hello world"}
 hw.module @commentModule() attributes {comment = "hello world"} {}
 
+
+// CHECK-LABEL: hw.module @Foo(in %arg0 : i1) {
+hw.module @Foo(in %0 "" : i1) {
+}
+// CHECK-LABEL: hw.module @Bar(in %foo : i1) {
+hw.module @Bar(in %foo : i1) {
+  // CHECK-NEXT:  hw.instance "foo" @Foo("": %foo: i1) -> ()
+  hw.instance "foo" @Foo("": %foo: i1)  -> ()
+}


### PR DESCRIPTION
This PR attempts to bypass an issue with module port names. 
If a `hw.module` port is not named, for example `%0`, then mlir renames it to `arg0` during serialization, https://github.com/llvm/llvm-project/blob/main/mlir/lib/IR/AsmPrinter.cpp#L1498.
This lit snippet shows the output of `circt-opt`, that demonstrates the block argument renaming.
```
// CHECK-LABEL: hw.module @Foo(in %arg0 : i1) {
hw.module @Foo(in %0 "" : i1) {
```
The `hw::ModuleType` gets the module port name from the SSA name, https://github.com/llvm/circt/blob/main/lib/Dialect/HW/ModuleImplementation.cpp#L358, during parsing. If the SSA has no name, then the port name is `""` which is fine.

The problem is that after serialization the `ModuleType` port names will be inconsistent with the SSA name because of the above shown block argument renaming. `ModuleType` will still have `""` as port name but the SSA name will be printed as `arg0`. As a result after serialization any `hw.instance` to the module will have incorrect argument names and will fail to parse and round trip.
```
hw.instance "foo" @Foo("": %foo: i1) -> ()
```
As a temporary fix, this PR just skips the verifier check if the name is empty.