### PR TITLE
[MSFT] Add module-level PD capability

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTPDOps.td
+++ b/include/circt/Dialect/MSFT/MSFTPDOps.td
@@ -106,8 +106,9 @@ def PDPhysRegionOp : MSFTOp<"pd.physregion",
   }];
 }
 
-def InstanceHierarchyOp : MSFTOp<"instance.hierarchy",
-                                 [HasParent<"mlir::ModuleOp">, NoTerminator]> {
+def InstanceHierarchyOp : MSFTOp<"instance.hierarchy",[
+    HasParent<"mlir::ModuleOp">, SingleBlock, NoTerminator, Symbol
+  ]> {
   let summary = "The root of an instance hierarchy";
   let description = [{
     Models the "root" / "top" of an instance hierarchy. `DynamicInstanceOp`s
@@ -117,12 +118,14 @@ def InstanceHierarchyOp : MSFTOp<"instance.hierarchy",
     producing the design's "top" module but a subdesign.)
   }];
 
-  let arguments = (ins FlatSymbolRefAttr:$topModuleRef,
-                       OptionalAttr<StrAttr>:$instName);
-  let regions = (region SizedRegion<1>:$body);
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    FlatSymbolRefAttr:$topModuleRef,
+    OptionalAttr<StrAttr>:$instName);
+  let regions = (region SizedRegion<1>:$region);
 
   let assemblyFormat = [{
-    $topModuleRef ($instName^)? $body attr-dict
+    $sym_name `(` $topModuleRef ($instName^)? `)` $region attr-dict
   }];
 }
 
@@ -181,5 +184,19 @@ def DynamicInstanceVerbatimAttrOp : MSFTOp<
     Operation* getTopModule(circt::hw::HWSymbolCache &symCache) {
       return getHierPathTopModule(getOperation()->getLoc(), symCache, getPathSym());
     }
+  }];
+}
+
+def PDInstanceHierarchyCallOp : MSFTOp<"instance.hierarchy.call", [
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  DeclareOpInterfaceMethods<DynInstDataOpInterface>
+]> {
+  let summary = "Call an instance hierarchy config procedure on an instance";
+  let arguments = (ins
+    FlatSymbolRefAttr:$proc,
+    OptionalAttr<FlatSymbolRefAttr>:$ref
+  );
+  let assemblyFormat = [{
+    $proc (`ref` $ref^)? attr-dict
   }];
 }

--- a/include/circt/Dialect/MSFT/MSFTPasses.h
+++ b/include/circt/Dialect/MSFT/MSFTPasses.h
@@ -25,6 +25,7 @@ namespace msft {
 std::unique_ptr<mlir::Pass> createLowerInstancesPass();
 std::unique_ptr<mlir::Pass> createLowerConstructsPass();
 std::unique_ptr<mlir::Pass> createExportTclPass();
+std::unique_ptr<mlir::Pass> createCreateGenericPDHierarchyPass();
 
 /// A set of methods which are broadly useful in a number of dialects.
 struct PassCommon {

--- a/include/circt/Dialect/MSFT/MSFTPasses.td
+++ b/include/circt/Dialect/MSFT/MSFTPasses.td
@@ -13,8 +13,8 @@ def ExportTcl: Pass<"msft-export-tcl", "mlir::ModuleOp"> {
   let constructor = "circt::msft::createExportTclPass()";
   let dependentDialects = ["circt::sv::SVDialect", "circt::hw::HWDialect"];
   let options = [
-    ListOption<"tops", "tops", "std::string",
-               "List of top modules to export Tcl for",
+    ListOption<"topsOpt", "tops", "std::string",
+               "List of top modules to export Tcl for. If empty, exports all tops.",
                "llvm::cl::ZeroOrMore,">,
     Option<"tclFile", "tcl-file", "std::string",
            "", "File to output Tcl into">
@@ -31,4 +31,9 @@ def LowerConstructs: Pass<"msft-lower-constructs", "mlir::ModuleOp"> {
   let summary = "Lower high-level constructs";
   let constructor = "circt::msft::createLowerConstructsPass()";
   let dependentDialects = ["circt::hw::HWDialect"];
+}
+
+def CreateGenericPDHierarchy : Pass<"msft-create-generic-pd-hierarchy", "mlir::ModuleOp"> {
+  let summary = "Create generic PD hierarchy from module-local PD constraints and the instance graph";
+  let constructor = "circt::msft::createCreateGenericPDHierarchyPass()";
 }

--- a/lib/Dialect/MSFT/MSFTOps.cpp
+++ b/lib/Dialect/MSFT/MSFTOps.cpp
@@ -265,5 +265,24 @@ Operation *PDMulticycleOp::getTopModule(hw::HWSymbolCache &cache) {
   return srcTop;
 }
 
+//===----------------------------------------------------------------------===//
+// PDInstanceHierarchyCallOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult PDInstanceHierarchyCallOp::verifySymbolUses(
+    mlir::SymbolTableCollection &symbolTable) {
+  auto parentModule = getOperation()->getParentOfType<mlir::ModuleOp>();
+  auto ih = symbolTable.lookupSymbolIn<msft::InstanceHierarchyOp>(
+      parentModule, getProcAttr());
+  if (!ih)
+    return emitOpError("could not find instance hierarchy op named ")
+           << getProc();
+  return success();
+}
+
+Operation *PDInstanceHierarchyCallOp::getTopModule(hw::HWSymbolCache &cache) {
+  return getHierPathTopModule(getLoc(), cache, getRefAttr());
+}
+
 #define GET_OP_CLASSES
 #include "circt/Dialect/MSFT/MSFT.cpp.inc"

--- a/lib/Dialect/MSFT/Transforms/CMakeLists.txt
+++ b/lib/Dialect/MSFT/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_dialect_library(CIRCTMSFTTransforms
   MSFTLowerInstances.cpp
   MSFTLowerConstructs.cpp
   PassCommon.cpp
+  MSFTCreateGenericPDHierarchy.cpp
 
   DEPENDS
   CIRCTMSFTTransformsIncGen

--- a/lib/Dialect/MSFT/Transforms/MSFTCreateGenericPDHierarchy.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTCreateGenericPDHierarchy.cpp
@@ -1,0 +1,174 @@
+//===- MSFTCreateGenericPDHierarchy.cpp - PD hierarchy ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/HW/HWAttributes.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/MSFT/MSFTDialect.h"
+#include "circt/Dialect/MSFT/MSFTOpInterfaces.h"
+#include "circt/Dialect/MSFT/MSFTOps.h"
+#include "circt/Dialect/MSFT/MSFTPasses.h"
+#include "circt/Support/InstanceGraph.h"
+#include "circt/Support/Namespace.h"
+#include "circt/Support/SymCache.h"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "llvm/ADT/PostOrderIterator.h"
+
+using namespace circt;
+using namespace msft;
+using namespace mlir;
+
+namespace {
+struct CreateGenericPDHierarchyPass
+    : public CreateGenericPDHierarchyBase<CreateGenericPDHierarchyPass> {
+  void runOnOperation() override;
+
+  FailureOr<msft::InstanceHierarchyOp>
+  lower(OpBuilder &b, SymbolTable symbolTable, hw::HWModuleLike mod);
+
+  Namespace ns;
+  DenseMap<Operation *, msft::InstanceHierarchyOp> hierarchyOpForModule;
+};
+} // anonymous namespace
+
+FailureOr<msft::InstanceHierarchyOp>
+CreateGenericPDHierarchyPass::lower(OpBuilder &b, SymbolTable symbolTable,
+                                    hw::HWModuleLike mod) {
+  OpBuilder::InsertionGuard g(b);
+  msft::InstanceHierarchyOp hierarchyOpForMod;
+  auto getOrCreateHierOp = [&]() -> msft::InstanceHierarchyOp {
+    if (hierarchyOpForMod)
+      return hierarchyOpForMod;
+
+    OpBuilder::InsertionGuard guard(b);
+    b.setInsertionPoint(mod);
+    hierarchyOpForMod = b.create<msft::InstanceHierarchyOp>(
+        mod.getLoc(),
+        b.getStringAttr(ns.newName(mod.getName() + "_generic_pd_config")),
+        FlatSymbolRefAttr::get(mod.getNameAttr()),
+        /*inst_name*/ StringAttr{});
+    hierarchyOpForMod.getBodyRegion().push_back(new Block);
+    return hierarchyOpForMod;
+  };
+
+  auto addToConfig = [&](llvm::function_ref<void(OpBuilder & b)> f) {
+    b.setInsertionPointToEnd(getOrCreateHierOp().getBody());
+    f(b);
+  };
+
+  // Look for module-local annotations
+  for (auto &op : llvm::make_early_inc_range(*mod.getBodyBlock())) {
+    llvm::TypeSwitch<Operation *, void>(&op)
+        .Case<msft::PDMulticycleOp>([&](auto mcOp) {
+          addToConfig([&](OpBuilder &b) {
+            mcOp->moveBefore(b.getInsertionBlock(), b.getInsertionPoint());
+
+            // Also create hierpaths... needed for TCL emission but obviously
+            // redundant and should be rethought.
+            b.setInsertionPoint(hierarchyOpForMod);
+            auto srcHierPath = b.create<hw::HierPathOp>(
+                mcOp.getLoc(),
+                b.getStringAttr(mod.getName() + "." + mcOp.getSource()),
+                b.getArrayAttr(
+                    llvm::SmallVector<Attribute>{hw::InnerRefAttr::get(
+                        mod.getNameAttr(), mcOp.getSourceAttr().getAttr())}));
+            auto dstHierPath = b.create<hw::HierPathOp>(
+                mcOp.getLoc(),
+                b.getStringAttr(mod.getName() + "." + mcOp.getDest()),
+                b.getArrayAttr(
+                    llvm::SmallVector<Attribute>{hw::InnerRefAttr::get(
+                        mod.getNameAttr(), mcOp.getDestAttr().getAttr())}));
+            mcOp.setSource(srcHierPath.getName());
+            mcOp.setDest(dstHierPath.getName());
+          });
+        })
+        .Default([&](auto) {});
+  }
+
+  // Look for instantiations of modules with local annotations
+  for (auto instanceLike : mod.getBodyBlock()->getOps<hw::HWInstanceLike>()) {
+    hw::HWModuleLike refMod =
+        cast<hw::HWModuleLike>(instanceLike.getReferencedModule(symbolTable));
+    if (auto hierarchyOp = hierarchyOpForModule.lookup(refMod)) {
+      addToConfig([&](OpBuilder &b) {
+        hw::HierPathOp instanceHierPathOp;
+        {
+          OpBuilder::InsertionGuard g(b);
+          b.setInsertionPoint(mod);
+          instanceHierPathOp = b.create<hw::HierPathOp>(
+              instanceLike.getLoc(),
+              b.getStringAttr(mod.getName() + "." +
+                              instanceLike.getInstanceName()),
+              b.getArrayAttr(llvm::SmallVector<Attribute>{hw::InnerRefAttr::get(
+                  mod.getNameAttr(), instanceLike.getInstanceNameAttr())}));
+        }
+
+        b.create<msft::PDInstanceHierarchyCallOp>(
+            instanceLike.getLoc(),
+            FlatSymbolRefAttr::get(hierarchyOp.getSymNameAttr()),
+            FlatSymbolRefAttr::get(instanceHierPathOp.getNameAttr()));
+      });
+    }
+  }
+
+  return hierarchyOpForMod;
+}
+
+void CreateGenericPDHierarchyPass::runOnOperation() {
+  auto top = getOperation();
+  auto *ctxt = &getContext();
+  SymbolTable symbolTable(top);
+  OpBuilder b(ctxt);
+
+  // Populate the top level symbol cache.
+  SymbolCache topSyms;
+  topSyms.addDefinitions(top);
+  ns.add(topSyms);
+
+  // Generate an instance graph
+  auto &instanceGraph = getAnalysis<igraph::InstanceGraph>();
+
+  // 1. Iterate the instance graph in post order
+  // 2. determine if there's any module-local annotations OR
+  //    if there's instantiations of any modules with local annotations
+  //    (recursively)
+  // 3. If so, create a hierarchy op for the module and populate it with
+  //    the annotations
+  DenseSet<Operation *> visited;
+  for (auto *startNode : instanceGraph) {
+    if (visited.contains(startNode->getModule()))
+      continue;
+
+    for (igraph::InstanceGraphNode *node : llvm::post_order(startNode)) {
+      if (!visited.insert(node->getModule().getOperation()).second)
+        continue;
+
+      auto res = lower(b, symbolTable, node->getModule<hw::HWModuleLike>());
+      if (failed(res)) {
+        signalPassFailure();
+        return;
+      }
+      hierarchyOpForModule[node->getModule().getOperation()] = *res;
+    }
+  }
+
+  hierarchyOpForModule.clear();
+}
+
+namespace circt {
+namespace msft {
+std::unique_ptr<Pass> createCreateGenericPDHierarchyPass() {
+  return std::make_unique<CreateGenericPDHierarchyPass>();
+}
+} // namespace msft
+} // namespace circt

--- a/lib/Dialect/MSFT/Transforms/MSFTExportTcl.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTExportTcl.cpp
@@ -57,6 +57,19 @@ void ExportTclPass::runOnOperation() {
   auto *ctxt = &getContext();
   TclEmitter emitter(top);
 
+  llvm::SmallVector<std::string, 4> tops;
+  if (topsOpt.empty()) {
+    DenseSet<StringAttr> uniqueTops;
+    for (msft::InstanceHierarchyOp ihop :
+         top.getOps<msft::InstanceHierarchyOp>())
+      uniqueTops.insert(ihop.getTopModuleRefAttr().getAttr());
+
+    for (auto top : uniqueTops)
+      tops.push_back(top.getValue().str());
+  } else {
+    llvm::copy(topsOpt, std::back_inserter(tops));
+  }
+
   // Traverse MSFT location attributes and export the required Tcl into
   // templated `sv::VerbatimOp`s with symbolic references to the instance paths.
   for (const std::string &moduleName : tops) {

--- a/lib/Dialect/MSFT/Transforms/MSFTLowerInstances.cpp
+++ b/lib/Dialect/MSFT/Transforms/MSFTLowerInstances.cpp
@@ -72,7 +72,7 @@ LogicalResult LowerInstancesPass::lower(DynamicInstanceOp inst,
   }
 
   // Relocate all my children.
-  OpBuilder hierBlock(&hier.getBody().front().front());
+  OpBuilder hierBlock(hier.getBodyRegion());
   for (Operation &op : llvm::make_early_inc_range(inst.getOps())) {
     // Child instances should have been lowered already.
     assert(!isa<DynamicInstanceOp>(op));

--- a/test/Dialect/MSFT/dynamic_instance.mlir
+++ b/test/Dialect/MSFT/dynamic_instance.mlir
@@ -2,7 +2,7 @@
 // RUN: circt-opt %s --msft-lower-instances --verify-each | FileCheck %s
 // RUN: circt-opt %s --msft-lower-instances --lower-seq-to-sv --msft-export-tcl=tops=shallow,deeper,reg --export-verilog -o %t.mlir | FileCheck %s --check-prefix=TCL
 
-msft.instance.hierarchy @deeper {
+msft.instance.hierarchy @d(@deeper) {
   msft.instance.dynamic @deeper::@branch {
     msft.instance.dynamic @shallow::@leaf {
       msft.instance.dynamic @leaf::@module {
@@ -15,7 +15,7 @@ msft.instance.hierarchy @deeper {
 // CHECK: hw.hierpath @instref [@deeper::@branch, @shallow::@leaf, @leaf::@module]
 // CHECK: msft.pd.location @instref M20K x: 15 y: 9 n: 3 path : "|memBank2"
 
-msft.instance.hierarchy @shallow {
+msft.instance.hierarchy @a1(@shallow) {
   msft.instance.dynamic @shallow::@leaf {
     msft.instance.dynamic @leaf::@module {
       msft.pd.location M20K x: 8 y: 19 n: 1 path: "|memBank2"
@@ -25,12 +25,12 @@ msft.instance.hierarchy @shallow {
 // CHECK: hw.hierpath @instref_1 [@shallow::@leaf, @leaf::@module]
 // CHECK: msft.pd.location @instref_1 M20K x: 8 y: 19 n: 1 path : "|memBank2"
 
-msft.instance.hierarchy @reg "foo" {
+msft.instance.hierarchy @a2(@reg "foo") {
   msft.instance.dynamic @reg::@reg {
     msft.pd.reg_location i4 [*, <1,2,3>, <1,2,4>, <1,2,5>]
   }
 }
-msft.instance.hierarchy @reg "bar" {
+msft.instance.hierarchy @a3(@reg "bar") {
   msft.instance.dynamic @reg::@reg {
     msft.pd.reg_location i4 [<3,4,5>, *, *, *]
   }
@@ -42,7 +42,7 @@ msft.instance.hierarchy @reg "bar" {
 
 hw.hierpath @reg.reg [@reg::@reg]
 hw.hierpath @reg.reg2 [@reg::@reg2]
-msft.instance.hierarchy @reg "multicycle" {
+msft.instance.hierarchy @ms(@reg "multicycle") {
   msft.pd.multicycle 2 @reg.reg -> @reg.reg2
 }
 

--- a/test/Dialect/MSFT/module_pd_constraint.mlir
+++ b/test/Dialect/MSFT/module_pd_constraint.mlir
@@ -1,0 +1,62 @@
+// RUN: circt-opt --msft-create-generic-pd-hierarchy %s | FileCheck %s
+// RUN: circt-opt --msft-create-generic-pd-hierarchy --msft-lower-instances --lower-seq-to-sv --msft-export-tcl --export-verilog %s -o %t.mlir | FileCheck %s --check-prefix=TCL
+
+// CHECK-LABEL:   msft.instance.hierarchy @top_generic_pd_config(@top) {
+// CHECK:           msft.instance.hierarchy.call @middle_generic_pd_config ref @top.myMiddle
+// CHECK:         }
+
+// CHECK:         hw.hierpath @top.myMiddle [@top::@myMiddle]
+
+// CHECK-LABEL:   msft.instance.hierarchy @middle_generic_pd_config(@middle) {
+// CHECK:           msft.instance.hierarchy.call @reg_generic_pd_config ref @middle.regA
+// CHECK:           msft.instance.hierarchy.call @reg_generic_pd_config ref @middle.regB
+// CHECK:         }
+
+// CHECK:         hw.hierpath @middle.regA [@middle::@regA]
+// CHECK:         hw.hierpath @middle.regB [@middle::@regB]
+// CHECK:         hw.hierpath @reg.reg1 [@reg::@reg1]
+// CHECK:         hw.hierpath @reg.reg2 [@reg::@reg2]
+
+// CHECK-LABEL:   msft.instance.hierarchy @reg_generic_pd_config(@reg) {
+// CHECK:           msft.pd.multicycle 2 @reg.reg1 -> @reg.reg2
+// CHECK:         }
+
+msft.instance.hierarchy @top_pd(@top) {
+  msft.instance.dynamic @top::@myMiddle {
+    msft.instance.dynamic @middle::@regA {
+      msft.instance.dynamic @reg::@reg1 {
+        msft.pd.reg_location i4 [*, <1,2,3>, <1,2,4>, <1,2,5>]
+      }
+    }
+  }
+}
+
+hw.module @top(in %input : i4, in %clk : !seq.clock) {
+  hw.instance "myMiddle" sym @myMiddle @middle(input : %input : i4, clk : %clk : !seq.clock) -> ()
+}
+
+hw.module @middle(in %input : i4, in %clk : !seq.clock) {
+  hw.instance "regA" sym @regA @reg(input : %input : i4, clk : %clk : !seq.clock) -> ()
+  hw.instance "regB" sym @regB @reg(input : %input : i4, clk : %clk : !seq.clock) -> ()
+}
+
+hw.module @reg (in %input : i4, in %clk : !seq.clock) {
+  %reg1 = seq.compreg sym @reg1 %input, %clk  : i4
+  %reg2 = seq.compreg sym @reg2 %reg1, %clk  : i4
+  msft.pd.multicycle 2 @reg1 -> @reg2
+}
+
+
+// TCL: proc reg_0_config { parent } {
+// TCL:   set_multicycle_path -hold 1 -setup 2 -from [get_registers {$parent|reg1}] -to [get_registers {$parent|reg2}]
+// TCL: }
+// TCL: proc top_config { parent } {
+// TCL:   set_location_assignment FF_X1_Y2_N3 -to $parent|myMiddle|regA|reg1[1]
+// TCL:   set_location_assignment FF_X1_Y2_N4 -to $parent|myMiddle|regA|reg1[2]
+// TCL:   set_location_assignment FF_X1_Y2_N5 -to $parent|myMiddle|regA|reg1[3]
+// TCL:   middle_config $parent|myMiddle
+// TCL: }
+// TCL: proc middle_config { parent } {
+// TCL:   reg_0_config $parent|regA
+// TCL:   reg_0_config $parent|regB
+// TCL: }

--- a/test/Dialect/MSFT/opt-errors.mlir
+++ b/test/Dialect/MSFT/opt-errors.mlir
@@ -16,7 +16,7 @@ module {
 
 // -----
 
-msft.instance.hierarchy @reg {
+msft.instance.hierarchy @reg_pd(@reg) {
   msft.instance.dynamic @reg::@reg {
     // expected-error @+1 {{'msft.pd.location' op cannot both have a global ref symbol and be a child of a dynamic instance op}}
     msft.pd.location @ref FF x: 0 y: 0 n: 0


### PR DESCRIPTION
Some prototype-y work to investigate how to do module-level PD. That is, we want to be able to place PD constraints at a module-granularity, s.t. every instantiation of that module has the given PD constraint applied to it when compiling the design.

To do so:
1. Allow placing PD constraint ops inside modules (e.g. `msft.pd.multicycle`)
2. Introduce the `--msft-create-generic-pd-hierarchy` pass which will create `${module name}_generic_pd_config` `msft.instance.hierarchy` ops (sidenote: that name seems like a misnomer wrt. what it's used for) that denote _generic_ configuration of said module; that is, a TCL proc which should be called on _all_ instantiations of that module. Given these, a traversal of the instance hierarchy then calls these config routines on all instances of the respective modules. Config routines are only emitted for modules that actually require configuration (this is a transitive property wrt. if any leaf node requires configuration, such as in the `module_pd_constraints.mlir` example). The benefit of this (as opposed to a single, flat TCL proc) should be obvious; less LOC, way more readable, ...
3. To facilitate this, `msft.instance.hierarchy` now defines a symbol that can be referred to by an `msft.instance.hierarchy.call` operation (again, misnomer).
4. `msft-export-tcl` now also by default will emit ALL instance hierarchies (misnomer) if no `tops` argument is provided. This is obviously needed since the user should not have to manually specify every single module in the design (which will be required for this new capability). If anything, this options should probably be changed into an option for _excluding_ tops from the emission.

This seems like a very useful capability, that will compose well with the existing instance hierarchy PD constraints (e.g. non-generic PD constraints that apply to specific instances).

For the  `module_pd_constraints.mlir` test, the following TCL is produced:
```tcl
proc middle_config { parent } {
  reg_0_config $parent|regA
  reg_0_config $parent|regB
}
proc reg_0_config { parent } {
  set_multicycle_path -hold 1 -setup 2 -from [get_registers {$parent|reg1}] -to [get_registers {$parent|reg2}]
}
proc top_config { parent } {
  set_location_assignment FF_X1_Y2_N3 -to $parent|myMiddle|regA|reg1[1]
  set_location_assignment FF_X1_Y2_N4 -to $parent|myMiddle|regA|reg1[2]
  set_location_assignment FF_X1_Y2_N5 -to $parent|myMiddle|regA|reg1[3]
  middle_config $parent|myMiddle
}
```