### PR TITLE
[circt-opt] Export symbols for MLIR plugins

### DIFF
--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -4,6 +4,9 @@ set(LLVM_LINK_COMPONENTS
 
 add_circt_tool(circt-opt
   circt-opt.cpp
+
+  DEPENDS
+  SUPPORT_PLUGINS
 )
 llvm_update_compile_flags(circt-opt)
 target_link_libraries(circt-opt
@@ -95,3 +98,5 @@ target_link_libraries(circt-opt
   MLIRFuncInlinerExtension
   MLIRVectorDialect
 )
+
+export_executable_symbols_for_plugins(circt-opt)


### PR DESCRIPTION
This commit adds support for MLIR plugins to circt-opt.