### PR TITLE
[FIRRTL] Add strip option to DropName

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -136,6 +136,8 @@ std::unique_ptr<mlir::Pass> createDropConstPass();
 /// Configure which values will be explicitly preserved by the DropNames pass.
 namespace PreserveValues {
 enum PreserveMode {
+  /// Strip all names. No name on declaration is preserved.
+  Strip,
   /// Don't explicitly preserve any named values. Every named operation could
   /// be optimized away by the compiler.
   None,

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -139,7 +139,8 @@ enum PreserveMode {
   /// Strip all names. No name on declaration is preserved.
   Strip,
   /// Don't explicitly preserve any named values. Every named operation could
-  /// be optimized away by the compiler.
+  /// be optimized away by the compiler. Unlike `Strip` names could be preserved
+  /// until the end.
   None,
   // Explicitly preserved values with meaningful names.  If a name begins with
   // an "_" it is not considered meaningful.

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -591,9 +591,9 @@ def DropName : Pass<"firrtl-drop-names", "firrtl::FModuleOp"> {
            "specify the values which can be optimized away", [{
             ::llvm::cl::values(
               clEnumValN(PreserveValues::Strip, "strip",
-                "Strip all names"),
+                "Strip all names. No name is preserved"),
               clEnumValN(PreserveValues::None, "none",
-                "Preserve no values"),
+                "Preserve no named values. Names could be preserved by best-effort unlike `strip`"),
               clEnumValN(PreserveValues::Named, "named",
                 "Preserve values with meaningful names"),
               clEnumValN(PreserveValues::All, "all",

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -590,6 +590,8 @@ def DropName : Pass<"firrtl-drop-names", "firrtl::FModuleOp"> {
            "PreserveValues::None",
            "specify the values which can be optimized away", [{
             ::llvm::cl::values(
+              clEnumValN(PreserveValues::Strip, "strip",
+                "Strip all names"),
               clEnumValN(PreserveValues::None, "none",
                 "Preserve no values"),
               clEnumValN(PreserveValues::Named, "named",

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -65,12 +65,14 @@ struct FirtoolOptions {
   llvm::cl::opt<firrtl::PreserveValues::PreserveMode> preserveMode{
       "preserve-values",
       llvm::cl::desc("Specify the values which can be optimized away"),
-      llvm::cl::values(clEnumValN(firrtl::PreserveValues::None, "none",
-                                  "Preserve no values"),
-                       clEnumValN(firrtl::PreserveValues::Named, "named",
-                                  "Preserve values with meaningful names"),
-                       clEnumValN(firrtl::PreserveValues::All, "all",
-                                  "Preserve all values")),
+      llvm::cl::values(
+          clEnumValN(firrtl::PreserveValues::Strip, "strip", "Strip all names"),
+          clEnumValN(firrtl::PreserveValues::None, "none",
+                     "Preserve no values"),
+          clEnumValN(firrtl::PreserveValues::Named, "named",
+                     "Preserve values with meaningful names"),
+          clEnumValN(firrtl::PreserveValues::All, "all",
+                     "Preserve all values")),
       llvm::cl::init(firrtl::PreserveValues::None), llvm::cl::cat(category)};
 
   // Build mode options.

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -66,9 +66,10 @@ struct FirtoolOptions {
       "preserve-values",
       llvm::cl::desc("Specify the values which can be optimized away"),
       llvm::cl::values(
-          clEnumValN(firrtl::PreserveValues::Strip, "strip", "Strip all names"),
+          clEnumValN(firrtl::PreserveValues::Strip, "strip",
+                     "Strip all names. No name is preserved"),
           clEnumValN(firrtl::PreserveValues::None, "none",
-                     "Preserve no values"),
+                     "Names could be preserved by best-effort unlike `strip`"),
           clEnumValN(firrtl::PreserveValues::Named, "named",
                      "Preserve values with meaningful names"),
           clEnumValN(firrtl::PreserveValues::All, "all",

--- a/lib/Dialect/FIRRTL/Transforms/DropName.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/DropName.cpp
@@ -36,6 +36,10 @@ struct DropNamesPass : public DropNameBase<DropNamesPass> {
           return ModAction::Drop;
         return ModAction::Demote;
       });
+    } else if (preserveMode == PreserveValues::Strip) {
+      // Strip all names.
+      dropNamesIf(namesChanged, namesDropped,
+                  [](FNamableOp op) { return ModAction::Drop; });
     } else if (preserveMode == PreserveValues::Named) {
       // Drop the name if it isn't considered meaningful.
       dropNamesIf(namesChanged, namesDropped, [](FNamableOp op) {

--- a/test/Dialect/FIRRTL/drop-name.mlir
+++ b/test/Dialect/FIRRTL/drop-name.mlir
@@ -1,22 +1,26 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=all})))' %s   | FileCheck %s --check-prefix=ALL
 // RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=named})))' %s | FileCheck %s --check-prefix=NAMED
 // RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=none})))' %s  | FileCheck %s --check-prefix=NONE
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-drop-names{preserve-values=strip})))' %s  | FileCheck %s --check-prefix=STRIP
 
 firrtl.circuit "Foo" {
   firrtl.module @Foo() {
     // ALL:   %a = firrtl.wire  interesting_name : !firrtl.uint<1>
     // NAMED: %a = firrtl.wire  interesting_name : !firrtl.uint<1>
     // NONE:  %a = firrtl.wire  : !firrtl.uint<1>
+    // STRIP: %0 = firrtl.wire  : !firrtl.uint<1>
     %a = firrtl.wire interesting_name : !firrtl.uint<1>
 
     // ALL:   %_a = firrtl.wire  interesting_name : !firrtl.uint<1>
     // NAMED: %_a = firrtl.wire  : !firrtl.uint<1>
     // NONE:  %_a = firrtl.wire  : !firrtl.uint<1>
+    // STRIP: %1 = firrtl.wire  : !firrtl.uint<1>
     %_a = firrtl.wire interesting_name : !firrtl.uint<1>
 
     // ALL:   %_T = firrtl.wire : !firrtl.uint<1>
     // NAMED: %0 = firrtl.wire  : !firrtl.uint<1>
     // NONE:  %0 = firrtl.wire  : !firrtl.uint<1>
+    // STRIP: %2 = firrtl.wire  : !firrtl.uint<1>
     %_T = firrtl.wire interesting_name : !firrtl.uint<1>
 
   }


### PR DESCRIPTION
This commit adds `strip` option to drop name pass. Even though there is `none` option but `none` option does keep existing names. `strip` explicitly strips all names to remove variable names form Chisel.