### PR TITLE
[ExtractTestCode] Specify non-empty unqiue port names

### DIFF
--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -802,12 +802,10 @@ TypedeclOp TypeAliasType::getTypeDecl(const HWSymbolCache &cache) {
 
 LogicalResult ModuleType::verify(function_ref<InFlightDiagnostic()> emitError,
                                  ArrayRef<ModulePort> ports) {
-  for (auto port : ports) {
-    if (hasHWInOutType(port.type))
-      return emitError() << "Ports cannot be inout types";
-    if (port.name.empty())
-      return emitError() << "Port names cannot be empty";
-  }
+  if (llvm::any_of(ports, [](const ModulePort &port) {
+        return hasHWInOutType(port.type);
+      }))
+    return emitError() << "Ports cannot be inout types";
   return success();
 }
 

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -802,10 +802,12 @@ TypedeclOp TypeAliasType::getTypeDecl(const HWSymbolCache &cache) {
 
 LogicalResult ModuleType::verify(function_ref<InFlightDiagnostic()> emitError,
                                  ArrayRef<ModulePort> ports) {
-  if (llvm::any_of(ports, [](const ModulePort &port) {
-        return hasHWInOutType(port.type);
-      }))
-    return emitError() << "Ports cannot be inout types";
+  for (auto port : ports) {
+    if (hasHWInOutType(port.type))
+      return emitError() << "Ports cannot be inout types";
+    if (port.name.empty())
+      return emitError() << "Port names cannot be empty";
+  }
   return success();
 }
 

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -204,6 +204,7 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   {
     auto srcPorts = op.getInputNames();
     for (auto port : llvm::enumerate(realInputs)) {
+      // Append the port index to create unique names.
       auto name =
           b.getStringAttr(getNameForPort(port.value(), srcPorts).getValue() +
                           Twine(port.index()));

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -137,8 +137,7 @@ getBackwardSlice(hw::HWModuleOp module,
 }
 
 static StringAttr getNameForPort(Value val,
-                                 SmallVector<mlir::Attribute> modulePorts,
-                                 unsigned index) {
+                                 SmallVector<mlir::Attribute> modulePorts) {
   if (auto bv = val.dyn_cast<BlockArgument>())
     return modulePorts[bv.getArgNumber()].cast<StringAttr>();
 
@@ -168,7 +167,7 @@ static StringAttr getNameForPort(Value val,
     }
   }
 
-  return StringAttr::get(val.getContext(), "arg" + Twine(index));
+  return StringAttr::get(val.getContext(), "arg");
 }
 
 // Given a set of values, construct a module and bind instance of that module
@@ -205,7 +204,10 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   {
     auto srcPorts = op.getInputNames();
     for (auto port : llvm::enumerate(realInputs)) {
-      auto name = getNameForPort(port.value(), srcPorts, port.index());
+      auto name =
+          b.getStringAttr(getNameForPort(port.value(), srcPorts).getValue() +
+                          Twine(port.index()));
+
       ports.push_back(
           {{name, port.value().getType(), hw::ModulePort::Direction::Input},
            port.index()});

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -22,6 +22,7 @@
 #include "circt/Dialect/SV/SVPasses.h"
 #include "circt/Dialect/Seq/SeqDialect.h"
 #include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Support/Namespace.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/IRMapping.h"
 #include "llvm/ADT/SetVector.h"
@@ -203,18 +204,15 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   // Construct the ports, this is just the input Values
   SmallVector<hw::PortInfo> ports;
   {
+    Namespace portNames;
     auto srcPorts = op.getInputNames();
-    llvm::SmallSetVector<StringRef, 8> portNames;
-    portNames.insert("");
     for (auto port : llvm::enumerate(realInputs)) {
-      auto name = getNameForPort(port.value(), srcPorts);
-      if (!portNames.insert(name.getValue())) {
-        // Append the port index to create unique names.
-        name = b.getStringAttr(name.getValue() + "port_" + Twine(port.index()));
-      }
-      ports.push_back(
-          {{name, port.value().getType(), hw::ModulePort::Direction::Input},
-           port.index()});
+      auto name = getNameForPort(port.value(), srcPorts).getValue();
+      name = portNames.newName(name.empty() ? "port_" + Twine(port.index())
+                                            : name);
+      ports.push_back({{b.getStringAttr(name), port.value().getType(),
+                        hw::ModulePort::Direction::Input},
+                       port.index()});
     }
   }
 

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -167,7 +167,7 @@ static StringAttr getNameForPort(Value val,
     }
   }
 
-  return StringAttr::get(val.getContext(), "");
+  return StringAttr::get(val.getContext(), "port");
 }
 
 // Given a set of values, construct a module and bind instance of that module

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -137,7 +137,8 @@ getBackwardSlice(hw::HWModuleOp module,
 }
 
 static StringAttr getNameForPort(Value val,
-                                 SmallVector<mlir::Attribute> modulePorts) {
+                                 SmallVector<mlir::Attribute> modulePorts,
+                                 unsigned index) {
   if (auto bv = val.dyn_cast<BlockArgument>())
     return modulePorts[bv.getArgNumber()].cast<StringAttr>();
 
@@ -167,7 +168,7 @@ static StringAttr getNameForPort(Value val,
     }
   }
 
-  return StringAttr::get(val.getContext(), "port");
+  return StringAttr::get(val.getContext(), "arg" + Twine(index));
 }
 
 // Given a set of values, construct a module and bind instance of that module
@@ -204,7 +205,7 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
   {
     auto srcPorts = op.getInputNames();
     for (auto port : llvm::enumerate(realInputs)) {
-      auto name = getNameForPort(port.value(), srcPorts);
+      auto name = getNameForPort(port.value(), srcPorts, port.index());
       ports.push_back(
           {{name, port.value().getType(), hw::ModulePort::Direction::Input},
            port.index()});

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -6,7 +6,7 @@
 // CHECK-NOT: attributes
 // CHECK-NEXT: hw.module.extern @foo_assert
 // CHECK-NOT: attributes
-// CHECK: hw.module @issue1246_assert(in %clock : i1) attributes {comment = "VCS coverage exclude_file", output_file = #hw.output_file<"dir3{{/|\\\\}}", excludeFromFileList, includeReplicatedOps>}
+// CHECK: hw.module @issue1246_assert(in %{{[^ ]+}} : i1) attributes {comment = "VCS coverage exclude_file", output_file = #hw.output_file<"dir3{{/|\\\\}}", excludeFromFileList, includeReplicatedOps>}
 // CHECK: sv.assert
 // CHECK: sv.error "Assertion failed"
 // CHECK: sv.error "assert:"
@@ -14,11 +14,11 @@
 // CHECK: sv.error "check [verif-library-assert] is included"
 // CHECK: sv.fatal 1
 // CHECK: foo_assert
-// CHECK: hw.module @issue1246_assume(in %clock : i1)
+// CHECK: hw.module @issue1246_assume(in %{{[^ ]+}} : i1)
 // CHECK-SAME: attributes {comment = "VCS coverage exclude_file"}
 // CHECK: sv.assume
 // CHECK: foo_assume
-// CHECK: hw.module @issue1246_cover(in %clock : i1)
+// CHECK: hw.module @issue1246_cover(in %{{[^ ]+}} : i1)
 // CHECK-SAME: attributes {comment = "VCS coverage exclude_file"}
 // CHECK: sv.cover
 // CHECK: foo_cover
@@ -117,7 +117,7 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
 // Check wires are extracted once
 
 // CHECK-LABEL: @MultiRead(
-// CHECK: hw.instance "[[name:.+]]_cover"  sym @{{[^ ]+}} @[[name]]_cover(foo: %0: i1, clock: %clock: i1)
+// CHECK: hw.instance "[[name:.+]]_cover"  sym @{{[^ ]+}} @[[name]]_cover({{[^ ]+}}: %0: i1, {{[^ ]+}}: %clock: i1)
 module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>} {
   hw.module @MultiRead(in %clock: i1, in %cond: i1) {
     %foo = sv.wire : !hw.inout<i1>
@@ -137,7 +137,7 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
 // Check extracted module ports take name of instance result when needed.
 
 // CHECK-LABEL: @InstResult(
-// CHECK: hw.instance "[[name:.+]]_cover"  sym @{{[^ ]+}} @[[name]]_cover(mem.result_name: %{{[^ ]+}}: i1, mem.1: %{{[^ ]+}}: i1, clock: %clock: i1)
+// CHECK: hw.instance "[[name:.+]]_cover"  sym @{{[^ ]+}} @[[name]]_cover({{[^ ]+}}: %{{[^ ]+}}: i1, {{[^ ]+}}: %{{[^ ]+}}: i1, {{[^ ]+}}: %clock: i1)
 module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFromFileList, includeReplicatedOps>} {
   hw.module @Mem(out result_name: i1, out "": i1) {
     %reg = sv.reg : !hw.inout<i1>
@@ -266,7 +266,7 @@ module {
 // CHECK: hw.instance "qux"
 // CHECK-LABEL: @MultiResultExtracted
 // CHECK-SAME: (in %[[clock:.+]] : i1, in %[[in:.+]] : i1)
-// CHECK: hw.instance {{.+}} @MultiResultExtracted_cover([[in]]: %[[in]]: i1, [[clock]]: %[[clock]]: i1)
+// CHECK: hw.instance {{.+}} @MultiResultExtracted_cover({{[^ ]+}}: %[[in]]: i1, {{[^ ]+}}: %{{[^ ]+}}: i1)
 
 // In SymNotExtracted, instance foo should not be extracted because it has a sym.
 // CHECK-LABEL: @SymNotExtracted_cover
@@ -452,9 +452,10 @@ module {
 // Check that constants are cloned freely.
 
 module {
-  // CHECK-LABEL: @ConstantCloned_cover(in %in : i1, in %clock : i1)
+  // CHECK-LABEL: @ConstantCloned_cover
+  // CHECK-SAME:  in %[[vin:.+]] : i1, in %{{[^ ]+}} : i1)
   // CHECK-NEXT:   %true = hw.constant true
-  // CHECK-NEXT:   comb.xor bin %in, %true : i1
+  // CHECK-NEXT:   comb.xor bin %[[vin]], %true : i1
   hw.module @ConstantCloned(in %clock: i1, in %in: i1, out out: i1) {
     %true = hw.constant true
     %not = comb.xor bin %in, %true : i1
@@ -545,7 +546,7 @@ module {
     hw.instance "dut" @Foo(clock: %clock: !seq.clock, in: %in: i1) -> ()
     hw.output
   }
-  // CHECK: hw.module @Foo_cover(in %clock : !seq.clock, in %in : i1)
+  // CHECK: hw.module @Foo_cover(in %{{[^ ]+}} : !seq.clock, in %{{[^ ]+}} : i1)
   hw.module private @Foo(in %clock: !seq.clock, in %in: i1) {
     %0 = seq.from_clock %clock
     sv.cover.concurrent posedge %0, %in label "cover__hello"


### PR DESCRIPTION
Update ETC to add non-empty and unique port names. The name itself is not important, but this exposes a bug in inconsistent port names with the `hw.instance` and the `ModuleType`. 
This is a temporary fix, to unblock downstream tools, while the actual bug is fixed.