### PR TITLE
[Namespace] Return an empty string for empty string.

### DIFF
--- a/include/circt/Support/Namespace.h
+++ b/include/circt/Support/Namespace.h
@@ -28,7 +28,11 @@ namespace circt {
 /// namespaces implementations.
 class Namespace {
 public:
-  Namespace() {}
+  Namespace() {
+    // This fills an entry for an empty string beforehand so that `newName`
+    // doesn't return an empty string.
+    nextIndex.insert({"", 0});
+  }
   Namespace(const Namespace &other) = default;
   Namespace(Namespace &&other) : nextIndex(std::move(other.nextIndex)) {}
 

--- a/test/Dialect/SV/hw-export-module-hierarchy.mlir
+++ b/test/Dialect/SV/hw-export-module-hierarchy.mlir
@@ -3,6 +3,7 @@
 hw.module @InnerModule() {}
 
 hw.module @MainDesign() {
+  hw.instance "" @InnerModule() -> ()
   hw.instance "inner" @InnerModule() -> ()
 }
 
@@ -11,6 +12,8 @@ hw.module @TestHarness() attributes {firrtl.moduleHierarchyFile = [#hw.output_fi
 }
 
 // CHECK:      hw.module @MainDesign()
+// CHECK-NEXT:   hw.instance ""
+// CHECK-SAME:     sym @{{[_a-zA-Z0-9]+}}
 // CHECK-NEXT:   hw.instance "inner"
 // CHECK-SAME:     sym @[[MainDesign_inner_sym:[_a-zA-Z0-9]+]]
 


### PR DESCRIPTION
Previously Namespace::newName could return empty string for empty string. This is a problematic behaivor since primary use cases of Namespace is symbol generation but empty string cannot be used a symbol.

For example HWExportModuleHierarchy crashed with an instance with an empty name.

This commit fixes the issue by pre-registering empty string in a constructor of Namespace.