### PR TITLE
Fix performance regression in verifiers 

### DIFF
--- a/lib/Dialect/HW/InstanceImplementation.cpp
+++ b/lib/Dialect/HW/InstanceImplementation.cpp
@@ -28,7 +28,7 @@ instance_like_impl::getReferencedModule(const HWSymbolCache *cache,
 LogicalResult instance_like_impl::verifyReferencedModule(
     Operation *instanceOp, SymbolTableCollection &symbolTable,
     mlir::FlatSymbolRefAttr moduleName, Operation *&module) {
-  module = getReferencedModule(nullptr, instanceOp, moduleName);
+  module = symbolTable.lookupNearestSymbolFrom(instanceOp, moduleName);
   if (module == nullptr)
     return instanceOp->emitError("Cannot find module definition '")
            << moduleName.getValue() << "'";


### PR DESCRIPTION
by using the required symbol table collection to resolve the module name.  The symbol table collection is required for this function explicitly for this lookup, it just wasn't being used