### PR TITLE
[FIRRTL] LowerAnnotations: Allow annotationRecords to be extended externally 

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -449,7 +449,7 @@ struct AnnoRecord {
 /// Register external annotation records.
 LogicalResult registerAnnotationRecord(
     StringRef annoClass, AnnoRecord annoRecord,
-    const std::function<void(llvm::Twine)> errorHandler = {});
+    const std::function<void(llvm::Twine)> &errorHandler = {});
 
 ///===----------------------------------------------------------------------===//
 /// Standard Utility Resolvers

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -449,7 +449,7 @@ struct AnnoRecord {
 /// Register external annotation records.
 LogicalResult registerAnnotationRecord(
     StringRef annoClass, AnnoRecord annoRecord,
-    llvm::function_ref<void(llvm::Twine)> errorHandler = {});
+    const std::function<void(llvm::Twine)> errorHandler = {});
 
 ///===----------------------------------------------------------------------===//
 /// Standard Utility Resolvers

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -446,54 +446,9 @@ struct AnnoRecord {
       applier;
 };
 
-/// A helper struct to lower annotations.
-struct LowerAnnotationsDriver {
-  LowerAnnotationsDriver(CircuitOp circuit, InstanceGraph *instanceGraph,
-                         const llvm::StringMap<AnnoRecord> &annotationRecords,
-                         bool ignoreAnnotationClassless,
-                         bool ignoreAnnotationUnknown, bool noRefTypePorts)
-      : circuit(circuit), instanceGraph(instanceGraph),
-        annotationRecords(annotationRecords),
-        ignoreAnnotationClassless(ignoreAnnotationClassless),
-        ignoreAnnotationUnknown(ignoreAnnotationUnknown),
-        noRefTypePorts(noRefTypePorts) {}
-
-  /// Run the main procedure.
-  bool run();
-
-  LogicalResult applyAnnotation(DictionaryAttr anno, ApplyState &state);
-  LogicalResult legacyToWiringProblems(ApplyState &state);
-  LogicalResult solveWiringProblems(ApplyState &state);
-
-  int64_t getNumFailures() const { return numFailures; }
-  int64_t getNumRawAnnotations() const { return numRawAnnotations; }
-  int64_t getNumAddedAnnos() const { return numAddedAnnos; }
-  int64_t getNumReusedHierPathOps() const { return numReusedHierPathOps; }
-  int64_t getNumUnhandled() const { return numUnhandled; }
-  int64_t getNumAnnos() const { return numAnnos; }
-
-private:
-  CircuitOp circuit;
-  InstanceGraph *instanceGraph;
-
-  // A map from annotation classes to annotation records.
-  const llvm::StringMap<AnnoRecord> &annotationRecords;
-
-  // Stats.
-  int64_t numRawAnnotations = 0;
-  int64_t numAddedAnnos = 0;
-  int64_t numAnnos = 0;
-  int64_t numReusedHierPathOps = 0;
-  int64_t numUnhandled = 0;
-  int64_t numFailures = 0;
-
-  // Options.
-  bool ignoreAnnotationClassless;
-  bool ignoreAnnotationUnknown;
-  bool noRefTypePorts;
-
-  SmallVector<DictionaryAttr> worklistAttrs;
-};
+/// Register external annotation records.
+LogicalResult registerAnnotationRecord(StringRef annoClass,
+                                       AnnoRecord annoRecord);
 
 ///===----------------------------------------------------------------------===//
 /// Standard Utility Resolvers

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -447,8 +447,9 @@ struct AnnoRecord {
 };
 
 /// Register external annotation records.
-LogicalResult registerAnnotationRecord(StringRef annoClass,
-                                       AnnoRecord annoRecord);
+LogicalResult registerAnnotationRecord(
+    StringRef annoClass, AnnoRecord annoRecord,
+    llvm::function_ref<void(llvm::Twine)> errorHandler = {});
 
 ///===----------------------------------------------------------------------===//
 /// Standard Utility Resolvers

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -513,7 +513,7 @@ static llvm::StringMap<AnnoRecord> annotationRecords{{
 
 LogicalResult
 registerAnnotationRecord(StringRef annoClass, AnnoRecord annoRecord,
-                         const std::function<void(llvm::Twine)>& errorHandler) {
+                         const std::function<void(llvm::Twine)> &errorHandler) {
 
   if (annotationRecords.insert({annoClass, annoRecord}).second)
     return LogicalResult::success();

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -513,7 +513,7 @@ static llvm::StringMap<AnnoRecord> annotationRecords{{
 
 LogicalResult
 registerAnnotationRecord(StringRef annoClass, AnnoRecord annoRecord,
-                         std::function<void(llvm::Twine)> errorHandler) {
+                         const std::function<void(llvm::Twine)>& errorHandler) {
 
   if (annotationRecords.insert({annoClass, annoRecord}).second)
     return LogicalResult::success();

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -511,11 +511,17 @@ static llvm::StringMap<AnnoRecord> annotationRecords{{
     {wiringSourceAnnoClass, {stdResolve, applyWiring}},
     {attributeAnnoClass, {stdResolve, applyAttributeAnnotation}}}};
 
-LogicalResult registerAnnotationRecord(StringRef annoClass,
-                                       AnnoRecord annoRecord) {
-  return LogicalResult::success(
-      annotationRecords.insert({annoClass, annoRecord}).second);
+LogicalResult
+registerAnnotationRecord(StringRef annoClass, AnnoRecord annoRecord,
+                         std::function<void(llvm::Twine)> errorHandler) {
+
+  if (annotationRecords.insert({annoClass, annoRecord}).second)
+    return LogicalResult::success();
+  if (errorHandler)
+    errorHandler("annotation record '" + annoClass + "' is registered twice\n");
+  return LogicalResult::failure();
 }
+
 } // namespace circt::firrtl
 
 /// Lookup a record for a given annotation class.  Optionally, returns the


### PR DESCRIPTION
This PR factors out some of LowerAnnotation helpers to a header and introduces registerAnnotationRecord method so that downstream user can extend the table. 

Fixes #4933.