### PR TITLE
[firtool] Add extra insertion point for pass plugin

### DIFF
--- a/test/firtool/pass-plugins.fir
+++ b/test/firtool/pass-plugins.fir
@@ -1,0 +1,19 @@
+; RUN: firtool -mlir-timing -initial-firrtl-pass-plugin='strip-debuginfo' \ 
+; RUN:   -high-firrtl-pass-plugin='strip-debuginfo' \
+; RUN:   -low-firrtl-pass-plugin='strip-debuginfo'  \
+; RUN:   -hw-pass-plugin='strip-debuginfo'  \
+; RUN:   -sv-pass-plugin='strip-debuginfo'  %s 2>&1 | FileCheck %s
+
+; CHECK: FIR Parser
+; CHECK: StripDebugInfo
+; CHECK: LowerFIRRTLAnnotations
+; CHECK: StripDebugInfo
+; CHECK: EmitOMIR
+; CHECK: StripDebugInfo
+; CHECK: LowerFIRRTLToHW
+; CHECK: StripDebugInfo
+; CHECK: LowerSeqToSV
+; CHECK: StripDebugInfo
+; CHECK: ExportVerilog
+circuit Example: 
+  module Example:

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -135,11 +135,17 @@ static cl::list<std::string>
     passPlugins("load-pass-plugin", cl::desc("Load passes from plugin library"),
                 cl::CommaSeparated, cl::cat(mainCategory));
 
-static cl::opt<std::string>
-    highFIRRTLPassPlugin("high-firrtl-pass-plugin",
-                         cl::desc("Insert passes after parsing FIRRTL. Specify "
-                                  "passes with MLIR textual format."),
-                         cl::init(""), cl::cat(mainCategory));
+static cl::opt<std::string> initialFIRRTLPassPlugin(
+    "initial-firrtl-pass-plugin",
+    cl::desc("Insert passes just after parsing FIRRTL. Specify "
+             "passes with MLIR textual format."),
+    cl::init(""), cl::cat(mainCategory));
+
+static cl::opt<std::string> highFIRRTLPassPlugin(
+    "high-firrtl-pass-plugin",
+    cl::desc("Insert passes after annotation lowering. Specify "
+             "passes with MLIR textual format."),
+    cl::init(""), cl::cat(mainCategory));
 
 static cl::opt<std::string>
     lowFIRRTLPassPlugin("low-firrtl-pass-plugin",
@@ -368,6 +374,10 @@ static LogicalResult processBuffer(
             "firtool"));
   if (failed(applyPassManagerCLOptions(pm)))
     return failure();
+
+  if (!initialFIRRTLPassPlugin.empty())
+    if (failed(parsePassPipeline(StringRef(initialFIRRTLPassPlugin), pm)))
+      return failure();
 
   if (failed(firtool::populatePreprocessTransforms(pm, firtoolOptions)))
     return failure();


### PR DESCRIPTION
This adds an `initial-firrtl-pass-plugin` option as a pass plugin insertion point at just after parsing so that downstream tools can insert customized LowerAnnotation pass. Added a test as well.