### PR TITLE
[Debug] Include Verilog instance names in HGLDD output

### DIFF
--- a/lib/Target/DebugInfo/EmitHGLDD.cpp
+++ b/lib/Target/DebugInfo/EmitHGLDD.cpp
@@ -203,6 +203,13 @@ StringAttr getVerilogModuleName(DIModule &module) {
   return module.name;
 }
 
+StringAttr getVerilogInstanceName(DIInstance &inst) {
+  if (auto *op = inst.op)
+    if (auto attr = op->getAttrOfType<StringAttr>("hw.verilogName"))
+      return attr;
+  return inst.name;
+}
+
 /// Emit the debug info for a `DIModule`.
 void FileEmitter::emitModule(llvm::json::OStream &json, DIModule *module) {
   json.objectBegin();
@@ -232,6 +239,9 @@ void FileEmitter::emitInstance(llvm::json::OStream &json,
                                DIInstance *instance) {
   json.objectBegin();
   json.attribute("name", instance->name.getValue());
+  auto verilogName = getVerilogInstanceName(*instance);
+  if (verilogName != instance->name)
+    json.attribute("hdl_obj_name", verilogName.getValue());
   json.attribute("obj_name", instance->module->name.getValue()); // HGL
   json.attribute("module_name",
                  getVerilogModuleName(*instance->module).getValue()); // HDL

--- a/test/Target/DebugInfo/emit-hgldd.mlir
+++ b/test/Target/DebugInfo/emit-hgldd.mlir
@@ -89,3 +89,14 @@ hw.module private @Bar(in %x: i32 loc(#loc7), out y: i32 loc(#loc8)) {
 // CHECK:       "module_name": "CustomSingleResult123"
 // CHECK:       "isExtModule": 1
 hw.module.extern @SingleResult(out outPort: i1) attributes {verilogName = "CustomSingleResult123"}
+
+// CHECK-LABEL: "module_name": "LegalizedNames"
+// CHECK:       "children"
+// CHECK:         "name": "reg"
+// CHECK:         "hdl_obj_name": "reg_0"
+// CHECK:         "obj_name": "Dummy"
+// CHECK:         "module_name": "CustomDummy"
+hw.module @LegalizedNames() {
+  hw.instance "reg" @Dummy() -> () {hw.verilogName = "reg_0"}
+}
+hw.module.extern @Dummy() attributes {verilogName = "CustomDummy"}


### PR DESCRIPTION
If an instance's Verilog name differs from the debug info instance name, add an additional `hdl_obj_name` field to the HGLDD output. Currently, the only way to trigger this is to have an instance name be a Verilog keyword, such that name legalization appens a `_N` suffix. In the future, with inlining and artificial levels of hierarchy, there are likely going to be more ways of how a DI instance name can differ from the Verilog hierarchy.