### PR TITLE
firtoolPopulateCHIRRTLToLowFIRRTL doesn't need a module

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -121,8 +121,7 @@ MLIR_CAPI_EXPORTED MlirLogicalResult
 firtoolPopulatePreprocessTransforms(MlirPassManager pm, FirtoolOptions options);
 
 MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulateCHIRRTLToLowFIRRTL(
-    MlirPassManager pm, FirtoolOptions options, MlirModule module,
-    MlirStringRef inputFilename);
+    MlirPassManager pm, FirtoolOptions options, MlirStringRef inputFilename);
 
 MLIR_CAPI_EXPORTED MlirLogicalResult
 firtoolPopulateLowFIRRTLToHW(MlirPassManager pm, FirtoolOptions options);

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -322,7 +322,6 @@ LogicalResult populatePreprocessTransforms(mlir::PassManager &pm,
 
 LogicalResult populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
                                          const FirtoolOptions &opt,
-                                         ModuleOp module,
                                          StringRef inputFilename);
 
 LogicalResult populateLowFIRRTLToHW(mlir::PassManager &pm,

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -248,10 +248,9 @@ MlirLogicalResult firtoolPopulatePreprocessTransforms(MlirPassManager pm,
 
 MlirLogicalResult
 firtoolPopulateCHIRRTLToLowFIRRTL(MlirPassManager pm, FirtoolOptions options,
-                                  MlirModule module,
                                   MlirStringRef inputFilename) {
-  return wrap(firtool::populateCHIRRTLToLowFIRRTL(
-      *unwrap(pm), *unwrap(options), unwrap(module), unwrap(inputFilename)));
+  return wrap(firtool::populateCHIRRTLToLowFIRRTL(*unwrap(pm), *unwrap(options),
+                                                  unwrap(inputFilename)));
 }
 
 MlirLogicalResult firtoolPopulateLowFIRRTLToHW(MlirPassManager pm,

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -39,7 +39,6 @@ LogicalResult firtool::populatePreprocessTransforms(mlir::PassManager &pm,
 
 LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
                                                   const FirtoolOptions &opt,
-                                                  ModuleOp module,
                                                   StringRef inputFilename) {
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerIntrinsicsPass());
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -384,7 +384,7 @@ static LogicalResult processBuffer(
     if (failed(parsePassPipeline(StringRef(highFIRRTLPassPlugin), pm)))
       return failure();
 
-  if (failed(firtool::populateCHIRRTLToLowFIRRTL(pm, firtoolOptions, *module,
+  if (failed(firtool::populateCHIRRTLToLowFIRRTL(pm, firtoolOptions,
                                                  inputFilename)))
     return failure();
 


### PR DESCRIPTION
I noticed this while trying to bind Firtool APIs, not sure if there was some historical reason for this.