### PR TITLE
[FIRRTL] Add debug info materialization pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -187,6 +187,8 @@ std::unique_ptr<mlir::Pass> createLowerGroupsPass();
 
 std::unique_ptr<mlir::Pass> createGroupSinkPass();
 
+std::unique_ptr<mlir::Pass> createMaterializeDebugInfoPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -793,4 +793,17 @@ def ProbeDCE : Pass<"firrtl-probe-dce", "firrtl::CircuitOp"> {
   ];
 }
 
+def MaterializeDebugInfo :
+    Pass<"firrtl-materialize-debug-info", "firrtl::FModuleOp"> {
+  let summary = "Generate debug ops to track FIRRTL values";
+  let description = [{
+    This pass creates debug ops to track FIRRTL-level ports, nodes, wires,
+    registers, and instances throughout the pipeline. The `DebugInfo` analysis
+    can then be used at a later point in the pipeline to obtain a source
+    language view into the lowered IR.
+  }];
+  let constructor = "circt::firrtl::createMaterializeDebugInfoPass()";
+  let dependentDialects = ["debug::DebugDialect"];
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -32,6 +32,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   LowerOpenAggs.cpp
   LowerTypes.cpp
   LowerXMR.cpp
+  MaterializeDebugInfo.cpp
   MemToRegOfVec.cpp
   MergeConnections.cpp
   ModuleInliner.cpp
@@ -58,6 +59,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
 
   LINK_LIBS PUBLIC
   CIRCTFIRRTL
+  CIRCTDebug
   CIRCTHW
   CIRCTOM
   CIRCTSV

--- a/lib/Dialect/FIRRTL/Transforms/MaterializeDebugInfo.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MaterializeDebugInfo.cpp
@@ -1,0 +1,111 @@
+//===- MaterializeDebugInfo.cpp - DI materialization ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Debug/DebugOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Parallel.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+struct MaterializeDebugInfoPass
+    : public MaterializeDebugInfoBase<MaterializeDebugInfoPass> {
+  void runOnOperation() override;
+  void materializeVariable(OpBuilder &builder, StringAttr name, Value value);
+  Value convertToDebugAggregates(OpBuilder &builder, Value value);
+};
+} // namespace
+
+void MaterializeDebugInfoPass::runOnOperation() {
+  auto module = getOperation();
+  auto builder = OpBuilder::atBlockBegin(module.getBodyBlock());
+
+  // Create DI variables for each port.
+  for (const auto &[port, value] :
+       llvm::zip(module.getPorts(), module.getArguments())) {
+    materializeVariable(builder, port.name, value);
+  }
+
+  // Create DI variables for each declaration in the module body.
+  module.walk([&](Operation *op) {
+    TypeSwitch<Operation *>(op).Case<WireOp, NodeOp, RegOp, RegResetOp>(
+        [&](auto op) {
+          builder.setInsertionPointAfter(op);
+          materializeVariable(builder, op.getNameAttr(), op.getResult());
+        });
+  });
+}
+
+/// Materialize debug variable ops for a value.
+void MaterializeDebugInfoPass::materializeVariable(OpBuilder &builder,
+                                                   StringAttr name,
+                                                   Value value) {
+  if (!name || isUselessName(name.getValue()))
+    return;
+  if (name.getValue().starts_with("_"))
+    return;
+  if (auto dbgValue = convertToDebugAggregates(builder, value))
+    builder.create<debug::VariableOp>(value.getLoc(), name, dbgValue);
+}
+
+/// Unpack all aggregates in a FIRRTL value and repack them as debug aggregates.
+/// For example, converts a FIRRTL vector `v` into `dbg.array [v[0],v[1],...]`.
+Value MaterializeDebugInfoPass::convertToDebugAggregates(OpBuilder &builder,
+                                                         Value value) {
+  return FIRRTLTypeSwitch<Type, Value>(value.getType())
+      .Case<BundleType>([&](auto type) {
+        SmallVector<Value> fields;
+        SmallVector<Attribute> names;
+        SmallVector<Operation *> subOps;
+        for (auto [index, element] : llvm::enumerate(type.getElements())) {
+          auto subOp = builder.create<SubfieldOp>(value.getLoc(), value, index);
+          subOps.push_back(subOp);
+          if (auto dbgValue = convertToDebugAggregates(builder, subOp)) {
+            fields.push_back(dbgValue);
+            names.push_back(element.name);
+          }
+        }
+        auto result = builder.create<debug::StructOp>(
+            value.getLoc(), fields, builder.getArrayAttr(names));
+        for (auto *subOp : subOps)
+          if (subOp->use_empty())
+            subOp->erase();
+        return result;
+      })
+      .Case<FVectorType>([&](auto type) -> Value {
+        SmallVector<Value> elements;
+        SmallVector<Operation *> subOps;
+        for (unsigned index = 0; index < type.getNumElements(); ++index) {
+          auto subOp = builder.create<SubindexOp>(value.getLoc(), value, index);
+          subOps.push_back(subOp);
+          if (auto dbgValue = convertToDebugAggregates(builder, subOp))
+            elements.push_back(dbgValue);
+        }
+        Value result;
+        if (!elements.empty() && elements.size() == type.getNumElements())
+          result = builder.create<debug::ArrayOp>(value.getLoc(), elements);
+        for (auto *subOp : subOps)
+          if (subOp->use_empty())
+            subOp->erase();
+        return result;
+      })
+      .Case<FIRRTLBaseType>(
+          [&](auto type) { return type.isGround() ? value : Value{}; })
+      .Default({});
+}
+
+std::unique_ptr<Pass> firrtl::createMaterializeDebugInfoPass() {
+  return std::make_unique<MaterializeDebugInfoPass>();
+}

--- a/lib/Dialect/FIRRTL/Transforms/PassDetails.h
+++ b/lib/Dialect/FIRRTL/Transforms/PassDetails.h
@@ -24,11 +24,15 @@ namespace circt {
 
 namespace hw {
 class HWDialect;
-}
+} // namespace hw
 
 namespace sv {
 class SVDialect;
-}
+} // namespace sv
+
+namespace debug {
+class DebugDialect;
+} // namespace debug
 
 namespace firrtl {
 

--- a/test/Dialect/FIRRTL/materialize-debug-info.mlir
+++ b/test/Dialect/FIRRTL/materialize-debug-info.mlir
@@ -1,0 +1,69 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-materialize-debug-info)))' %s | FileCheck %s
+
+firrtl.circuit "Ports" {
+
+// CHECK-LABEL: firrtl.module @Ports
+firrtl.module @Ports(
+  in %inA: !firrtl.uint<42>,
+  in %inB: !firrtl.bundle<a: sint<19>, b: clock>,
+  in %inC: !firrtl.vector<asyncreset, 2>,
+  in %inD: !firrtl.bundle<clocks: vector<clock, 4>>,
+  out %outA: !firrtl.uint<42>
+) {
+  // CHECK-NEXT: dbg.variable "inA", %inA
+
+  // CHECK-NEXT: [[TMP0:%.+]] = firrtl.subfield %inB[a]
+  // CHECK-NEXT: [[TMP1:%.+]] = firrtl.subfield %inB[b]
+  // CHECK-NEXT: [[TMP:%.+]] = dbg.struct {"a": [[TMP0]], "b": [[TMP1]]}
+  // CHECK-NEXT: dbg.variable "inB", [[TMP]]
+
+  // CHECK-NEXT: [[TMP0:%.+]] = firrtl.subindex %inC[0]
+  // CHECK-NEXT: [[TMP1:%.+]] = firrtl.subindex %inC[1]
+  // CHECK-NEXT: [[TMP:%.+]] = dbg.array [[[TMP0]], [[TMP1]]]
+  // CHECK-NEXT: dbg.variable "inC", [[TMP]]
+
+  // CHECK-NEXT: [[TMP1:%.+]] = firrtl.subfield %inD[clocks]
+  // CHECK-NEXT: [[TMP2:%.+]] = firrtl.subindex [[TMP1]][0]
+  // CHECK-NEXT: [[TMP3:%.+]] = firrtl.subindex [[TMP1]][1]
+  // CHECK-NEXT: [[TMP4:%.+]] = firrtl.subindex [[TMP1]][2]
+  // CHECK-NEXT: [[TMP5:%.+]] = firrtl.subindex [[TMP1]][3]
+  // CHECK-NEXT: [[TMP6:%.+]] = dbg.array [[[TMP2]], [[TMP3]], [[TMP4]], [[TMP5]]]
+  // CHECK-NEXT: [[TMP7:%.+]] = dbg.struct {"clocks": [[TMP6]]}
+  // CHECK-NEXT: dbg.variable "inD", [[TMP7]]
+
+  // CHECK-NEXT: dbg.variable "outA", %outA
+
+  // CHECK-NEXT: firrtl.strictconnect
+  firrtl.strictconnect %outA, %inA : !firrtl.uint<42>
+}
+
+// CHECK-LABEL: firrtl.module @Decls
+firrtl.module @Decls() {
+  // CHECK-NEXT: firrtl.constant
+  // CHECK-NEXT: firrtl.constant
+  // CHECK-NEXT: firrtl.specialconstant
+  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+  %c0_ui17 = firrtl.constant 0 : !firrtl.uint<17>
+  %c0_clock = firrtl.specialconstant 0 : !firrtl.clock
+
+  // CHECK-NEXT: firrtl.wire
+  // CHECK-NEXT: dbg.variable "someWire", %someWire
+  %someWire = firrtl.wire : !firrtl.uint<17>
+
+  // CHECK-NEXT: firrtl.node
+  // CHECK-NEXT: dbg.variable "someNode", %someNode
+  %someNode = firrtl.node %c0_ui17 : !firrtl.uint<17>
+
+  // CHECK-NEXT: firrtl.reg
+  // CHECK-NEXT: dbg.variable "someReg1", %someReg1
+  %someReg1 = firrtl.reg %c0_clock : !firrtl.clock, !firrtl.uint<17>
+
+  // CHECK-NEXT: firrtl.regreset
+  // CHECK-NEXT: dbg.variable "someReg2", %someReg2
+  %someReg2 = firrtl.regreset %c0_clock, %c0_ui1, %c0_ui17 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<17>
+
+  // CHECK-NEXT: firrtl.strictconnect
+  firrtl.strictconnect %someWire, %c0_ui17 : !firrtl.uint<17>
+}
+
+}


### PR DESCRIPTION
Add the `MaterializeDebugInfo` pass, which creates debug ops to track FIRRTL-level ports, nodes, wires, registers, and instances throughout the pipeline. This is a fairly simple first attempt at tracking higher-level source language information through the compilation using the debug dialect.

Also add the `-g` option to firtool, which causes this pass to run very early on in the pipeline where all the high-level information is still available. Enabling this option will currently cause `ExportVerilog` to fail because of the additional operations in the IR -- to be rectified by a later PR.