### PR TITLE
[Debug] Honor dbg dialect ops in DebugInfo analysis

### DIFF
--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -38,6 +38,7 @@ add_circt_library(CIRCTDebugInfoAnalysis
   DebugInfo.cpp
 
   LINK_LIBS PUBLIC
+  CIRCTDebug
   CIRCTHW
   MLIRIR
 )

--- a/lib/Target/DebugInfo/CMakeLists.txt
+++ b/lib/Target/DebugInfo/CMakeLists.txt
@@ -8,6 +8,7 @@ add_circt_translation_library(CIRCTTargetDebugInfo
 
   LINK_LIBS PUBLIC
   CIRCTComb
+  CIRCTDebug
   CIRCTDebugInfoAnalysis
   CIRCTHW
   CIRCTSeq

--- a/lib/Target/DebugInfo/TranslateRegistration.cpp
+++ b/lib/Target/DebugInfo/TranslateRegistration.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/Comb/CombDialect.h"
+#include "circt/Dialect/Debug/DebugDialect.h"
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/Seq/SeqDialect.h"
@@ -21,6 +22,7 @@ namespace debug {
 
 static void registerDialects(DialectRegistry &registry) {
   registry.insert<comb::CombDialect>();
+  registry.insert<debug::DebugDialect>();
   registry.insert<hw::HWDialect>();
   registry.insert<seq::SeqDialect>();
   registry.insert<sv::SVDialect>();

--- a/test/Analysis/debug-info.mlir
+++ b/test/Analysis/debug-info.mlir
@@ -25,3 +25,26 @@ hw.module @Bar(in %x: i32, out y: i32) {
   %z = hw.wire %0 : i32
   hw.output %z : i32
 }
+
+// CHECK-LABEL: Module "Vars" for hw.module
+// CHECK-NEXT: Variable "inA"
+// CHECK-NEXT:   Arg 0 of hw.module of type i32
+// CHECK-NEXT: Variable "outB"
+// CHECK-NEXT:   Result 0 of comb.add of type i32
+// CHECK-NOT: Variable "a"
+// CHECK-NOT: Variable "b"
+hw.module @Vars(in %a: i32, out b: i32) {
+  dbg.variable "inA", %a : i32
+  dbg.variable "outB", %0 : i32
+  %0 = comb.add %a, %a : i32
+  hw.output %0 : i32
+}
+
+// CHECK-LABEL: Module "Aggregates" for hw.module
+// CHECK-NEXT: Variable "data"
+// CHECK-NEXT:   Result 0 of dbg.struct of type !dbg.struct
+hw.module @Aggregates(in %data_a: i32, in %data_b: index, in %data_c_0: i17, in %data_c_1: i17) {
+  %0 = dbg.array [%data_c_0, %data_c_1] : i17
+  %1 = dbg.struct {"a": %data_a, "b": %data_b, "c": %0} : i32, index, !dbg.array<i17>
+  dbg.variable "data", %1 : !dbg.struct<i32, index, !dbg.array<i17>>
+}

--- a/test/Target/DebugInfo/emit-hgldd.mlir
+++ b/test/Target/DebugInfo/emit-hgldd.mlir
@@ -54,8 +54,8 @@
 // CHECK:     "begin_line": 42
 // CHECK:     "begin_column": 10
 // CHECK:   "port_vars"
-// CHECK:     "var_name": "a"
-// CHECK:     "var_name": "b"
+// CHECK:     "var_name": "inA"
+// CHECK:     "var_name": "outB"
 // CHECK:   "children"
 // CHECK:     "name": "b0"
 // CHECK:     "obj_name": "Bar"
@@ -68,6 +68,8 @@
 // CHECK:     "hgl_loc"
 // CHECK:       "file": 3,
 hw.module @Foo(in %a: i32 loc(#loc2), out b: i32 loc(#loc3)) {
+  dbg.variable "inA", %a : i32 loc(#loc2)
+  dbg.variable "outB", %b1.y : i32 loc(#loc3)
   %b0.y = hw.instance "b0" @Bar(x: %a: i32) -> (y: i32) loc(#loc4)
   %b1.y = hw.instance "b1" @Bar(x: %b0.y: i32) -> (y: i32) loc(#loc5)
   hw.output %b1.y : i32 loc(#loc1)
@@ -76,14 +78,25 @@ hw.module @Foo(in %a: i32 loc(#loc2), out b: i32 loc(#loc3)) {
 // CHECK-LABEL: FILE "Bar.dd"
 // CHECK: "module_name": "Bar"
 // CHECK:   "port_vars"
-// CHECK:     "var_name": "x"
-// CHECK:     "var_name": "y"
-// CHECK:     "var_name": "z"
+// CHECK:     "var_name": "inX"
+// CHECK:     "var_name": "outY"
+// CHECK:     "var_name": "varZ"
 hw.module private @Bar(in %x: i32 loc(#loc7), out y: i32 loc(#loc8)) {
   %0 = comb.mul %x, %x : i32 loc(#loc9)
-  %z = hw.wire %0 : i32 loc(#loc9)
-  hw.output %z : i32 loc(#loc6)
+  dbg.variable "inX", %x : i32 loc(#loc7)
+  dbg.variable "outY", %0 : i32 loc(#loc8)
+  dbg.variable "varZ", %0 : i32 loc(#loc9)
+  hw.output %0 : i32 loc(#loc6)
 } loc(fused[#loc6, "emitted"(#loc11)])
+
+// CHECK-LABEL: FILE "global.dd"
+// CHECK: "module_name": "Aggregates"
+// CHECK:     "var_name": "data"
+hw.module @Aggregates(in %data_a: i32, in %data_b: i42, in %data_c_0: i17, in %data_c_1: i17) {
+  %0 = dbg.array [%data_c_0, %data_c_1] : i17
+  %1 = dbg.struct {"a": %data_a, "b": %data_b, "c": %0} : i32, i42, !dbg.array
+  dbg.variable "data", %1 : !dbg.struct
+}
 
 // CHECK-LABEL: "obj_name": "SingleResult"
 // CHECK:       "module_name": "CustomSingleResult123"


### PR DESCRIPTION
When traversing the IR in the `DebugInfo` analysis, consider `dbg.variable` operations when populating the scope of local names for a module. The current implementation is fairly straightforward, but as the debug dialect evolves and we begin to track module inlining and outlining, this analysis will become more involved and do more of the heavy lifting necessary to extract a clean debug hierarchy from the IR.