### PR TITLE
[LowerToHW] Avoid uninit plusargs.value reg

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3633,6 +3633,7 @@ LogicalResult FIRRTLLowering::visitExpr(PlusArgsValueIntrinsicOp op) {
       "SYNTHESIS",
       [&]() {
         auto cst0 = getOrCreateIntConstant(1, 0);
+        builder.create<sv::AssignOp>(regv, getOrCreateZConstant(type));
         builder.create<sv::AssignOp>(regf, cst0);
       },
       [&]() {

--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -4,6 +4,7 @@ firrtl.circuit "Intrinsics" {
   // CHECK-LABEL: hw.module @Intrinsics
   firrtl.module @Intrinsics(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>) {
     // CHECK-NEXT: %c0_i32 = hw.constant 0 : i32
+    // CHECK-NEXT: %z_i5 = sv.constantZ : i5
     // CHECK-NEXT: %false = hw.constant false
     // CHECK-NEXT: [[CLK:%.+]] = seq.from_clock %clk
     // CHECK-NEXT: %x_i1 = sv.constantX : i1
@@ -26,6 +27,7 @@ firrtl.circuit "Intrinsics" {
     // CHECK-NEXT: [[BAR_VALUE_DECL:%.*]] = sv.reg : !hw.inout<i5>
     // CHECK-NEXT: [[BAR_FOUND_DECL:%.*]] = sv.reg : !hw.inout<i1>
     // CHECK-NEXT: sv.ifdef "SYNTHESIS" {
+    // CHECK-NEXT:   sv.assign [[BAR_VALUE_DECL]], %z_i5
     // CHECK-NEXT:   sv.assign [[BAR_FOUND_DECL]], %false
     // CHECK-NEXT: } else {
     // CHECK-NEXT:   sv.initial {


### PR DESCRIPTION
Change LowerToHW to not emit an uninitialized register in the SYNTHESIS-defined path when lowering a "firrtl.int.plusargs.value".  This is done to avoid a lint warning related to uninitialized registers.

Fixes #6307.