### PR TITLE
[Firtool][CAPI] Refactor options, separate storage and structures

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -22,7 +22,13 @@ extern "C" {
   };                                                                           \
   typedef struct name name
 
-DEFINE_C_API_STRUCT(FirtoolOptions, void);
+DEFINE_C_API_STRUCT(FirtoolGeneralOptions, void);
+DEFINE_C_API_STRUCT(FirtoolPreprocessTransformsOptions, void);
+DEFINE_C_API_STRUCT(FirtoolCHIRRTLToLowFIRRTLOptions, void);
+DEFINE_C_API_STRUCT(FirtoolLowFIRRTLToHWOptions, void);
+DEFINE_C_API_STRUCT(FirtoolHWToSVOptions, void);
+DEFINE_C_API_STRUCT(FirtoolExportVerilogOptions, void);
+DEFINE_C_API_STRUCT(FirtoolFinalizeIROptions, void);
 
 #undef DEFINE_C_API_STRUCT
 
@@ -62,83 +68,125 @@ typedef enum FirtoolRandomKind {
   FIRTOOL_RANDOM_KIND_ALL,
 } FirtoolRandomKind;
 
-MLIR_CAPI_EXPORTED FirtoolOptions firtoolOptionsCreateDefault();
-MLIR_CAPI_EXPORTED void firtoolOptionsDestroy(FirtoolOptions options);
+#define DECLARE_FIRTOOL_OPTIONS_CREATE_DESTROY(opt)                            \
+  MLIR_CAPI_EXPORTED Firtool##opt##Options firtool##opt##OptionsCreateDefault( \
+      FirtoolGeneralOptions general);                                          \
+  MLIR_CAPI_EXPORTED void firtool##opt##OptionsDestroy(                        \
+      Firtool##opt##Options options);                                          \
+  MLIR_CAPI_EXPORTED void firtool##opt##OptionsSetGeneral(                     \
+      Firtool##opt##Options options, FirtoolGeneralOptions general);           \
+  MLIR_CAPI_EXPORTED FirtoolGeneralOptions firtool##opt##OptionsGetGeneral(    \
+      Firtool##opt##Options options);
 
-#define DECLARE_FIRTOOL_OPTION(name, type)                                     \
-  MLIR_CAPI_EXPORTED void firtoolOptionsSet##name(FirtoolOptions options,      \
-                                                  type value);                 \
-  MLIR_CAPI_EXPORTED type firtoolOptionsGet##name(FirtoolOptions options)
+#define DECLARE_FIRTOOL_OPTION(opt, name, type)                                \
+  MLIR_CAPI_EXPORTED void firtool##opt##OptionsSet##name(                      \
+      Firtool##opt##Options options, type value);                              \
+  MLIR_CAPI_EXPORTED type firtool##opt##OptionsGet##name(                      \
+      Firtool##opt##Options options)
 
-DECLARE_FIRTOOL_OPTION(OutputFilename, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(DisableAnnotationsUnknown, bool);
-DECLARE_FIRTOOL_OPTION(DisableAnnotationsClassless, bool);
-DECLARE_FIRTOOL_OPTION(LowerAnnotationsNoRefTypePorts, bool);
-DECLARE_FIRTOOL_OPTION(PreserveAggregate, FirtoolPreserveAggregateMode);
-DECLARE_FIRTOOL_OPTION(PreserveValues, FirtoolPreserveValuesMode);
-DECLARE_FIRTOOL_OPTION(BuildMode, FirtoolBuildMode);
-DECLARE_FIRTOOL_OPTION(DisableOptimization, bool);
-DECLARE_FIRTOOL_OPTION(ExportChiselInterface, bool);
-DECLARE_FIRTOOL_OPTION(ChiselInterfaceOutDirectory, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(VbToBv, bool);
-DECLARE_FIRTOOL_OPTION(Dedup, bool);
-DECLARE_FIRTOOL_OPTION(CompanionMode, FirtoolCompanionMode);
-DECLARE_FIRTOOL_OPTION(DisableAggressiveMergeConnections, bool);
-DECLARE_FIRTOOL_OPTION(EmitOMIR, bool);
-DECLARE_FIRTOOL_OPTION(OMIROutFile, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(LowerMemories, bool);
-DECLARE_FIRTOOL_OPTION(BlackBoxRootPath, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(ReplSeqMem, bool);
-DECLARE_FIRTOOL_OPTION(ReplSeqMemFile, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(ExtractTestCode, bool);
-DECLARE_FIRTOOL_OPTION(IgnoreReadEnableMem, bool);
-DECLARE_FIRTOOL_OPTION(DisableRandom, FirtoolRandomKind);
-DECLARE_FIRTOOL_OPTION(OutputAnnotationFilename, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(EnableAnnotationWarning, bool);
-DECLARE_FIRTOOL_OPTION(AddMuxPragmas, bool);
-DECLARE_FIRTOOL_OPTION(EmitChiselAssertsAsSVA, bool);
-DECLARE_FIRTOOL_OPTION(EmitSeparateAlwaysBlocks, bool);
-DECLARE_FIRTOOL_OPTION(EtcDisableInstanceExtraction, bool);
-DECLARE_FIRTOOL_OPTION(EtcDisableRegisterExtraction, bool);
-DECLARE_FIRTOOL_OPTION(EtcDisableModuleInlining, bool);
-DECLARE_FIRTOOL_OPTION(AddVivadoRAMAddressConflictSynthesisBugWorkaround, bool);
-DECLARE_FIRTOOL_OPTION(CkgModuleName, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(CkgInputName, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(CkgOutputName, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(CkgEnableName, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(CkgTestEnableName, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(ExportModuleHierarchy, bool);
-DECLARE_FIRTOOL_OPTION(StripFirDebugInfo, bool);
-DECLARE_FIRTOOL_OPTION(StripDebugInfo, bool);
+// ========== General ==========
+
+MLIR_CAPI_EXPORTED FirtoolGeneralOptions firtoolGeneralOptionsCreateDefault();
+MLIR_CAPI_EXPORTED void
+firtoolGeneralOptionsDestroy(FirtoolGeneralOptions options);
+DECLARE_FIRTOOL_OPTION(General, DisableOptimization, bool);
+DECLARE_FIRTOOL_OPTION(General, ReplSeqMem, bool);
+DECLARE_FIRTOOL_OPTION(General, ReplSeqMemFile, MlirStringRef);
+DECLARE_FIRTOOL_OPTION(General, IgnoreReadEnableMem, bool);
+DECLARE_FIRTOOL_OPTION(General, DisableRandom, FirtoolRandomKind);
+
+// ========== PreprocessTransforms ==========
+
+DECLARE_FIRTOOL_OPTIONS_CREATE_DESTROY(PreprocessTransforms);
+DECLARE_FIRTOOL_OPTION(PreprocessTransforms, DisableAnnotationsUnknown, bool);
+DECLARE_FIRTOOL_OPTION(PreprocessTransforms, DisableAnnotationsClassless, bool);
+DECLARE_FIRTOOL_OPTION(PreprocessTransforms, LowerAnnotationsNoRefTypePorts,
+                       bool);
+
+// ========== CHIRRTLToLowFIRRTL ==========
+
+DECLARE_FIRTOOL_OPTIONS_CREATE_DESTROY(CHIRRTLToLowFIRRTL);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, PreserveValues,
+                       FirtoolPreserveValuesMode);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, PreserveAggregate,
+                       FirtoolPreserveAggregateMode);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, ExportChiselInterface, bool);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, ChiselInterfaceOutDirectory,
+                       MlirStringRef);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, DisableHoistingHWPassthrough, bool);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, Dedup, bool);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, NoDedup, bool);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, VbToBv, bool);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, LowerMemories, bool);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, CompanionMode, FirtoolCompanionMode);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, BlackBoxRootPath, MlirStringRef);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, EmitOMIR, bool);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, OMIROutFile, MlirStringRef);
+DECLARE_FIRTOOL_OPTION(CHIRRTLToLowFIRRTL, DisableAggressiveMergeConnections,
+                       bool);
+
+// ========== LowFIRRTLToHW ==========
+
+DECLARE_FIRTOOL_OPTIONS_CREATE_DESTROY(LowFIRRTLToHW);
+DECLARE_FIRTOOL_OPTION(LowFIRRTLToHW, OutputAnnotationFilename, MlirStringRef);
+DECLARE_FIRTOOL_OPTION(LowFIRRTLToHW, EnableAnnotationWarning, bool);
+DECLARE_FIRTOOL_OPTION(LowFIRRTLToHW, EmitChiselAssertsAsSVA, bool);
+
+// ========== HWToSV ==========
+
+DECLARE_FIRTOOL_OPTIONS_CREATE_DESTROY(HWToSV);
+DECLARE_FIRTOOL_OPTION(HWToSV, ExtractTestCode, bool);
+DECLARE_FIRTOOL_OPTION(HWToSV, EtcDisableInstanceExtraction, bool);
+DECLARE_FIRTOOL_OPTION(HWToSV, EtcDisableRegisterExtraction, bool);
+DECLARE_FIRTOOL_OPTION(HWToSV, EtcDisableModuleInlining, bool);
+DECLARE_FIRTOOL_OPTION(HWToSV, CkgModuleName, MlirStringRef);
+DECLARE_FIRTOOL_OPTION(HWToSV, CkgInputName, MlirStringRef);
+DECLARE_FIRTOOL_OPTION(HWToSV, CkgOutputName, MlirStringRef);
+DECLARE_FIRTOOL_OPTION(HWToSV, CkgEnableName, MlirStringRef);
+DECLARE_FIRTOOL_OPTION(HWToSV, CkgTestEnableName, MlirStringRef);
+DECLARE_FIRTOOL_OPTION(HWToSV, CkgInstName, MlirStringRef);
+DECLARE_FIRTOOL_OPTION(HWToSV, EmitSeparateAlwaysBlocks, bool);
+DECLARE_FIRTOOL_OPTION(HWToSV, AddMuxPragmas, bool);
+DECLARE_FIRTOOL_OPTION(HWToSV,
+                       AddVivadoRAMAddressConflictSynthesisBugWorkaround, bool);
+
+// ========== ExportVerilog ==========
+
+DECLARE_FIRTOOL_OPTIONS_CREATE_DESTROY(ExportVerilog);
+DECLARE_FIRTOOL_OPTION(ExportVerilog, StripFirDebugInfo, bool);
+DECLARE_FIRTOOL_OPTION(ExportVerilog, StripDebugInfo, bool);
+DECLARE_FIRTOOL_OPTION(ExportVerilog, ExportModuleHierarchy, bool);
+// Filename for ExportVerilog, directory for ExportSplitVerilog
+DECLARE_FIRTOOL_OPTION(ExportVerilog, OutputPath, MlirStringRef);
 
 #undef DECLARE_FIRTOOL_OPTION
+#undef DECLARE_FIRTOOL_OPTIONS_CREATE_DESTROY
 
 //===----------------------------------------------------------------------===//
 // Populate API.
 //===----------------------------------------------------------------------===//
 
-MLIR_CAPI_EXPORTED MlirLogicalResult
-firtoolPopulatePreprocessTransforms(MlirPassManager pm, FirtoolOptions options);
+MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulatePreprocessTransforms(
+    MlirPassManager pm, FirtoolPreprocessTransformsOptions options);
 
 MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulateCHIRRTLToLowFIRRTL(
-    MlirPassManager pm, FirtoolOptions options, MlirModule module,
-    MlirStringRef inputFilename);
+    MlirPassManager pm, FirtoolCHIRRTLToLowFIRRTLOptions options);
+
+MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulateLowFIRRTLToHW(
+    MlirPassManager pm, FirtoolLowFIRRTLToHWOptions options);
 
 MLIR_CAPI_EXPORTED MlirLogicalResult
-firtoolPopulateLowFIRRTLToHW(MlirPassManager pm, FirtoolOptions options);
+firtoolPopulateHWToSV(MlirPassManager pm, FirtoolHWToSVOptions options);
 
-MLIR_CAPI_EXPORTED MlirLogicalResult
-firtoolPopulateHWToSV(MlirPassManager pm, FirtoolOptions options);
-
-MLIR_CAPI_EXPORTED MlirLogicalResult
-firtoolPopulateExportVerilog(MlirPassManager pm, FirtoolOptions options,
-                             MlirStringCallback callback, void *userData);
+MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulateExportVerilog(
+    MlirPassManager pm, FirtoolExportVerilogOptions options,
+    MlirStringCallback callback, void *userData);
 
 MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulateExportSplitVerilog(
-    MlirPassManager pm, FirtoolOptions options, MlirStringRef directory);
+    MlirPassManager pm, FirtoolExportVerilogOptions options);
 
 MLIR_CAPI_EXPORTED MlirLogicalResult
-firtoolPopulateFinalizeIR(MlirPassManager pm, FirtoolOptions options);
+firtoolPopulateFinalizeIR(MlirPassManager pm, FirtoolFinalizeIROptions options);
 
 #ifdef __cplusplus
 }

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -21,60 +21,99 @@
 
 namespace circt {
 namespace firtool {
+
+enum class RandomKind { None, Mem, Reg, All };
+
+struct FirtoolGeneralOptions {
+  bool disableOptimization{false};
+  bool replSeqMem{false};
+  std::string replSeqMemFile{""};
+  bool ignoreReadEnableMem{false};
+  RandomKind disableRandom{RandomKind::None};
+
+  bool isRandomEnabled(RandomKind kind) const {
+    return disableRandom != RandomKind::All && disableRandom != kind;
+  }
+};
+
+struct FirtoolPreprocessTransformsOptions {
+  FirtoolGeneralOptions *general;
+
+  bool disableAnnotationsUnknown{false};
+  bool disableAnnotationsClassless{false};
+  bool lowerAnnotationsNoRefTypePorts{false};
+
+  FirtoolPreprocessTransformsOptions(FirtoolGeneralOptions *g) : general{g} {}
+};
+
+struct FirtoolCHIRRTLToLowFIRRTLOptions {
+  FirtoolGeneralOptions *general;
+
+  firrtl::PreserveValues::PreserveMode preserveValues{
+      firrtl::PreserveValues::None};
+  circt::firrtl::PreserveAggregate::PreserveMode preserveAggregate{
+      circt::firrtl::PreserveAggregate::None};
+  bool exportChiselInterface{false};
+  std::string chiselInterfaceOutDirectory{""};
+  bool disableHoistingHWPassthrough{true};
+  bool dedup{false};
+  bool noDedup{false};
+  bool vbToBV{false};
+  bool lowerMemories{false};
+  firrtl::CompanionMode companionMode{firrtl::CompanionMode::Bind};
+  std::string blackBoxRootPath{""};
+  bool emitOMIR{true};
+  std::string omirOutFile{""};
+  bool disableAggressiveMergeConnections{false};
+
+  FirtoolCHIRRTLToLowFIRRTLOptions(FirtoolGeneralOptions *g) : general{g} {}
+};
+
+struct FirtoolLowFIRRTLToHWOptions {
+  FirtoolGeneralOptions *general;
+
+  std::string outputAnnotationFilename{""};
+  bool enableAnnotationWarning{false};
+  bool emitChiselAssertsAsSVA{false};
+
+  FirtoolLowFIRRTLToHWOptions(FirtoolGeneralOptions *g) : general{g} {}
+};
+
+struct FirtoolHWToSVOptions {
+  FirtoolGeneralOptions *general;
+
+  bool extractTestCode{false};
+  bool etcDisableInstanceExtraction{false};
+  bool etcDisableRegisterExtraction{false};
+  bool etcDisableModuleInlining{false};
+  seq::ExternalizeClockGateOptions ckg;
+  bool emitSeparateAlwaysBlocks{false};
+  bool addMuxPragmas{false};
+  bool addVivadoRAMAddressConflictSynthesisBugWorkaround{false};
+
+  FirtoolHWToSVOptions(FirtoolGeneralOptions *g) : general{g} {}
+};
+
+struct FirtoolExportVerilogOptions {
+  FirtoolGeneralOptions *general;
+
+  bool stripFirDebugInfo{true};
+  bool stripDebugInfo{false};
+  bool exportModuleHierarchy{false};
+  std::string outputPath{"-"};
+
+  FirtoolExportVerilogOptions(FirtoolGeneralOptions *g) : general{g} {}
+};
+
+struct FirtoolFinalizeIROptions {
+  FirtoolGeneralOptions *general;
+
+  FirtoolFinalizeIROptions(FirtoolGeneralOptions *g) : general{g} {}
+};
+
 // Remember to sync changes to C-API
 struct FirtoolOptions {
   llvm::cl::OptionCategory &category;
-
-  llvm::cl::opt<std::string> outputFilename{
-      "o", llvm::cl::desc("Output filename, or directory for split output"),
-      llvm::cl::value_desc("filename"), llvm::cl::init("-"),
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> disableAnnotationsUnknown{
-      "disable-annotation-unknown",
-      llvm::cl::desc("Ignore unknown annotations when parsing"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> disableAnnotationsClassless{
-      "disable-annotation-classless",
-      llvm::cl::desc("Ignore annotations without a class when parsing"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> lowerAnnotationsNoRefTypePorts{
-      "lower-annotations-no-ref-type-ports",
-      llvm::cl::desc(
-          "Create real ports instead of ref type ports when resolving "
-          "wiring problems inside the LowerAnnotations pass"),
-      llvm::cl::init(false), llvm::cl::Hidden, llvm::cl::cat(category)};
-
-  llvm::cl::opt<circt::firrtl::PreserveAggregate::PreserveMode>
-      preserveAggregate{
-          "preserve-aggregate", llvm::cl::desc("Specify input file format:"),
-          llvm::cl::values(
-              clEnumValN(circt::firrtl::PreserveAggregate::None, "none",
-                         "Preserve no aggregate"),
-              clEnumValN(circt::firrtl::PreserveAggregate::OneDimVec, "1d-vec",
-                         "Preserve only 1d vectors of ground type"),
-              clEnumValN(circt::firrtl::PreserveAggregate::Vec, "vec",
-                         "Preserve only vectors"),
-              clEnumValN(circt::firrtl::PreserveAggregate::All, "all",
-                         "Preserve vectors and bundles")),
-          llvm::cl::init(circt::firrtl::PreserveAggregate::None),
-          llvm::cl::cat(category)};
-
-  llvm::cl::opt<firrtl::PreserveValues::PreserveMode> preserveMode{
-      "preserve-values",
-      llvm::cl::desc("Specify the values which can be optimized away"),
-      llvm::cl::values(
-          clEnumValN(firrtl::PreserveValues::Strip, "strip",
-                     "Strip all names. No name is preserved"),
-          clEnumValN(firrtl::PreserveValues::None, "none",
-                     "Names could be preserved by best-effort unlike `strip`"),
-          clEnumValN(firrtl::PreserveValues::Named, "named",
-                     "Preserve values with meaningful names"),
-          clEnumValN(firrtl::PreserveValues::All, "all",
-                     "Preserve all values")),
-      llvm::cl::init(firrtl::PreserveValues::None), llvm::cl::cat(category)};
 
   // Build mode options.
   enum BuildMode { BuildModeDebug, BuildModeRelease };
@@ -86,106 +125,40 @@ struct FirtoolOptions {
                                   "Compile with optimizations")),
       llvm::cl::cat(category)};
 
-  llvm::cl::opt<bool> disableOptimization{
+  llvm::cl::opt<std::string> outputFilename{
+      "o", llvm::cl::desc("Output filename, or directory for split output"),
+      llvm::cl::value_desc("filename"), llvm::cl::init("-"),
+      llvm::cl::cat(category)};
+
+  // ========== General ==========
+
+  FirtoolGeneralOptions generalOpts;
+
+  llvm::cl::opt<bool, true> disableOptimization{
       "disable-opt", llvm::cl::desc("Disable optimizations"),
+      llvm::cl::location(generalOpts.disableOptimization),
       llvm::cl::cat(category)};
 
-  llvm::cl::opt<bool> exportChiselInterface{
-      "export-chisel-interface",
-      llvm::cl::desc("Generate a Scala Chisel interface to the top level "
-                     "module of the firrtl circuit"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string> chiselInterfaceOutDirectory{
-      "chisel-interface-out-dir",
-      llvm::cl::desc(
-          "The output directory for generated Chisel interface files"),
-      llvm::cl::init(""), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> vbToBV{
-      "vb-to-bv",
-      llvm::cl::desc("Transform vectors of bundles to bundles of vectors"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> dedup{
-      "dedup", llvm::cl::desc("Deduplicate structurally identical modules"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> noDedup{
-      "no-dedup",
-      llvm::cl::desc("Disable deduplication of structurally identical modules"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<firrtl::CompanionMode> companionMode{
-      "grand-central-companion-mode",
-      llvm::cl::desc("Specifies the handling of Grand Central companions"),
-      ::llvm::cl::values(
-          clEnumValN(firrtl::CompanionMode::Bind, "bind",
-                     "Lower companion instances to SystemVerilog binds"),
-          clEnumValN(firrtl::CompanionMode::Instantiate, "instantiate",
-                     "Instantiate companions in the design"),
-          clEnumValN(firrtl::CompanionMode::Drop, "drop",
-                     "Remove companions from the design")),
-      llvm::cl::init(firrtl::CompanionMode::Bind),
-      llvm::cl::Hidden,
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> disableAggressiveMergeConnections{
-      "disable-aggressive-merge-connections",
-      llvm::cl::desc(
-          "Disable aggressive merge connections (i.e. merge all field-level "
-          "connections into bulk connections)"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> disableHoistingHWPassthrough{
-      "disable-hoisting-hw-passthrough",
-      llvm::cl::desc("Disable hoisting HW passthrough signals"),
-      llvm::cl::init(true), llvm::cl::Hidden, llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> emitOMIR{
-      "emit-omir", llvm::cl::desc("Emit OMIR annotations to a JSON file"),
-      llvm::cl::init(true), llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string> omirOutFile{
-      "output-omir", llvm::cl::desc("File name for the output omir"),
-      llvm::cl::init(""), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> lowerMemories{
-      "lower-memories",
-      llvm::cl::desc("Lower memories to have memories with masks as an "
-                     "array with one memory per ground type"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string> blackBoxRootPath{
-      "blackbox-path",
-      llvm::cl::desc(
-          "Optional path to use as the root of black box annotations"),
-      llvm::cl::value_desc("path"), llvm::cl::init(""),
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> replSeqMem{
+  llvm::cl::opt<bool, true> replSeqMem{
       "repl-seq-mem",
       llvm::cl::desc("Replace the seq mem for macro replacement and emit "
                      "relevant metadata"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
+      llvm::cl::location(generalOpts.replSeqMem), llvm::cl::init(false),
+      llvm::cl::cat(category)};
 
-  llvm::cl::opt<std::string> replSeqMemFile{
+  llvm::cl::opt<std::string, true> replSeqMemFile{
       "repl-seq-mem-file", llvm::cl::desc("File name for seq mem metadata"),
-      llvm::cl::init(""), llvm::cl::cat(category)};
+      llvm::cl::location(generalOpts.replSeqMemFile), llvm::cl::init(""),
+      llvm::cl::cat(category)};
 
-  llvm::cl::opt<bool> extractTestCode{
-      "extract-test-code", llvm::cl::desc("Run the extract test code pass"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> ignoreReadEnableMem{
+  llvm::cl::opt<bool, true> ignoreReadEnableMem{
       "ignore-read-enable-mem",
       llvm::cl::desc("Ignore the read enable signal, instead of "
                      "assigning X on read disable"),
+      llvm::cl::location(generalOpts.ignoreReadEnableMem),
       llvm::cl::init(false), llvm::cl::cat(category)};
 
-  enum class RandomKind { None, Mem, Reg, All };
-
-  llvm::cl::opt<RandomKind> disableRandom{
+  llvm::cl::opt<RandomKind, true> disableRandom{
       llvm::cl::desc(
           "Disable random initialization code (may break semantics!)"),
       llvm::cl::values(
@@ -195,155 +168,361 @@ struct FirtoolOptions {
                      "Disable emission of register randomization code"),
           clEnumValN(RandomKind::All, "disable-all-randomization",
                      "Disable emission of all randomization code")),
+      llvm::cl::location(generalOpts.disableRandom),
       llvm::cl::init(RandomKind::None), llvm::cl::cat(category)};
 
-  llvm::cl::opt<std::string> outputAnnotationFilename{
-      "output-annotation-file",
-      llvm::cl::desc("Optional output annotation file"),
-      llvm::cl::CommaSeparated, llvm::cl::value_desc("filename"),
+  // ========== PreprocessTransforms ==========
+
+  FirtoolPreprocessTransformsOptions preprocessTransformsOpts{&generalOpts};
+
+  llvm::cl::opt<bool, true> disableAnnotationsUnknown{
+      "disable-annotation-unknown",
+      llvm::cl::desc("Ignore unknown annotations when parsing"),
+      llvm::cl::location(preprocessTransformsOpts.disableAnnotationsUnknown),
+      llvm::cl::init(false), llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> disableAnnotationsClassless{
+      "disable-annotation-classless",
+      llvm::cl::desc("Ignore annotations without a class when parsing"),
+      llvm::cl::location(preprocessTransformsOpts.disableAnnotationsClassless),
+      llvm::cl::init(false), llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> lowerAnnotationsNoRefTypePorts{
+      "lower-annotations-no-ref-type-ports",
+      llvm::cl::desc(
+          "Create real ports instead of ref type ports when resolving "
+          "wiring problems inside the LowerAnnotations pass"),
+      llvm::cl::location(
+          preprocessTransformsOpts.lowerAnnotationsNoRefTypePorts),
+      llvm::cl::init(false),
+      llvm::cl::Hidden,
       llvm::cl::cat(category)};
 
-  llvm::cl::opt<bool> enableAnnotationWarning{
+  // ========== CHIRRTLToLowFIRRTL ==========
+
+  mutable FirtoolCHIRRTLToLowFIRRTLOptions chirrtlToLowFIRRTLOpts{&generalOpts};
+
+  llvm::cl::opt<firrtl::PreserveValues::PreserveMode, true> preserveValues{
+      "preserve-values",
+      llvm::cl::desc("Specify the values which can be optimized away"),
+      llvm::cl::values(
+          clEnumValN(firrtl::PreserveValues::Strip, "strip",
+                     "Strip all names. No name is preserved"),
+          clEnumValN(firrtl::PreserveValues::None, "none",
+                     "Names could be preserved by best-effort unlike `strip`"),
+          clEnumValN(firrtl::PreserveValues::Named, "named",
+                     "Preserve values with meaningful names"),
+          clEnumValN(firrtl::PreserveValues::All, "all",
+                     "Preserve all values")),
+      llvm::cl::location(chirrtlToLowFIRRTLOpts.preserveValues),
+      llvm::cl::init(firrtl::PreserveValues::None),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<circt::firrtl::PreserveAggregate::PreserveMode, true>
+      preserveAggregate{
+          "preserve-aggregate",
+          llvm::cl::desc("Specify input file format:"),
+          llvm::cl::values(
+              clEnumValN(circt::firrtl::PreserveAggregate::None, "none",
+                         "Preserve no aggregate"),
+              clEnumValN(circt::firrtl::PreserveAggregate::OneDimVec, "1d-vec",
+                         "Preserve only 1d vectors of ground type"),
+              clEnumValN(circt::firrtl::PreserveAggregate::Vec, "vec",
+                         "Preserve only vectors"),
+              clEnumValN(circt::firrtl::PreserveAggregate::All, "all",
+                         "Preserve vectors and bundles")),
+          llvm::cl::location(chirrtlToLowFIRRTLOpts.preserveAggregate),
+          llvm::cl::init(circt::firrtl::PreserveAggregate::None),
+          llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> exportChiselInterface{
+      "export-chisel-interface",
+      llvm::cl::desc("Generate a Scala Chisel interface to the top level "
+                     "module of the firrtl circuit"),
+      llvm::cl::location(chirrtlToLowFIRRTLOpts.exportChiselInterface),
+      llvm::cl::init(false), llvm::cl::cat(category)};
+
+  llvm::cl::opt<std::string, true> chiselInterfaceOutDirectory{
+      "chisel-interface-out-dir",
+      llvm::cl::desc(
+          "The output directory for generated Chisel interface files"),
+      llvm::cl::location(chirrtlToLowFIRRTLOpts.chiselInterfaceOutDirectory),
+      llvm::cl::init(""), llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> disableHoistingHWPassthrough{
+      "disable-hoisting-hw-passthrough",
+      llvm::cl::desc("Disable hoisting HW passthrough signals"),
+      llvm::cl::location(chirrtlToLowFIRRTLOpts.disableHoistingHWPassthrough),
+      llvm::cl::init(true),
+      llvm::cl::Hidden,
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> dedup{
+      "dedup", llvm::cl::desc("Deduplicate structurally identical modules"),
+      llvm::cl::location(chirrtlToLowFIRRTLOpts.dedup), llvm::cl::init(false),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> noDedup{
+      "no-dedup",
+      llvm::cl::desc("Disable deduplication of structurally identical modules"),
+      llvm::cl::location(chirrtlToLowFIRRTLOpts.noDedup), llvm::cl::init(false),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> vbToBV{
+      "vb-to-bv",
+      llvm::cl::desc("Transform vectors of bundles to bundles of vectors"),
+      llvm::cl::location(chirrtlToLowFIRRTLOpts.vbToBV), llvm::cl::init(false),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> lowerMemories{
+      "lower-memories",
+      llvm::cl::desc("Lower memories to have memories with masks as an "
+                     "array with one memory per ground type"),
+      llvm::cl::location(chirrtlToLowFIRRTLOpts.lowerMemories),
+      llvm::cl::init(false), llvm::cl::cat(category)};
+
+  llvm::cl::opt<firrtl::CompanionMode, true> companionMode{
+      "grand-central-companion-mode",
+      llvm::cl::desc("Specifies the handling of Grand Central companions"),
+      ::llvm::cl::values(
+          clEnumValN(firrtl::CompanionMode::Bind, "bind",
+                     "Lower companion instances to SystemVerilog binds"),
+          clEnumValN(firrtl::CompanionMode::Instantiate, "instantiate",
+                     "Instantiate companions in the design"),
+          clEnumValN(firrtl::CompanionMode::Drop, "drop",
+                     "Remove companions from the design")),
+      llvm::cl::location(chirrtlToLowFIRRTLOpts.companionMode),
+      llvm::cl::init(firrtl::CompanionMode::Bind),
+      llvm::cl::Hidden,
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<std::string, true> blackBoxRootPath{
+      "blackbox-path",
+      llvm::cl::desc(
+          "Optional path to use as the root of black box annotations"),
+      llvm::cl::value_desc("path"),
+      llvm::cl::location(chirrtlToLowFIRRTLOpts.blackBoxRootPath),
+      llvm::cl::init(""),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> emitOMIR{
+      "emit-omir", llvm::cl::desc("Emit OMIR annotations to a JSON file"),
+      llvm::cl::location(chirrtlToLowFIRRTLOpts.emitOMIR), llvm::cl::init(true),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<std::string, true> omirOutFile{
+      "output-omir", llvm::cl::desc("File name for the output omir"),
+      llvm::cl::location(chirrtlToLowFIRRTLOpts.omirOutFile),
+      llvm::cl::init(""), llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> disableAggressiveMergeConnections{
+      "disable-aggressive-merge-connections",
+      llvm::cl::desc(
+          "Disable aggressive merge connections (i.e. merge all field-level "
+          "connections into bulk connections)"),
+      llvm::cl::location(
+          chirrtlToLowFIRRTLOpts.disableAggressiveMergeConnections),
+      llvm::cl::init(false), llvm::cl::cat(category)};
+
+  // ========== LowFIRRTLToHW ==========
+
+  FirtoolLowFIRRTLToHWOptions lowFIRRTLToHWOpts{&generalOpts};
+
+  llvm::cl::opt<std::string, true> outputAnnotationFilename{
+      "output-annotation-file",
+      llvm::cl::desc("Optional output annotation file"),
+      llvm::cl::CommaSeparated,
+      llvm::cl::value_desc("filename"),
+      llvm::cl::location(lowFIRRTLToHWOpts.outputAnnotationFilename),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> enableAnnotationWarning{
       "warn-on-unprocessed-annotations",
       llvm::cl::desc(
           "Warn about annotations that were not removed by lower-to-hw"),
+      llvm::cl::location(lowFIRRTLToHWOpts.enableAnnotationWarning),
       llvm::cl::init(false), llvm::cl::cat(category)};
 
-  llvm::cl::opt<bool> addMuxPragmas{
-      "add-mux-pragmas",
-      llvm::cl::desc("Annotate mux pragmas for memory array access"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> emitChiselAssertsAsSVA{
+  llvm::cl::opt<bool, true> emitChiselAssertsAsSVA{
       "emit-chisel-asserts-as-sva",
       llvm::cl::desc("Convert all chisel asserts into SVA"),
+      llvm::cl::location(lowFIRRTLToHWOpts.emitChiselAssertsAsSVA),
       llvm::cl::init(false), llvm::cl::cat(category)};
 
-  llvm::cl::opt<bool> emitSeparateAlwaysBlocks{
+  // ========== HWToSV ==========
+
+  FirtoolHWToSVOptions hwToSVOpts{&generalOpts};
+
+  llvm::cl::opt<bool, true> extractTestCode{
+      "extract-test-code", llvm::cl::desc("Run the extract test code pass"),
+      llvm::cl::location(hwToSVOpts.extractTestCode), llvm::cl::init(false),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> etcDisableInstanceExtraction{
+      "etc-disable-instance-extraction",
+      llvm::cl::desc("Disable extracting instances only that feed test code"),
+      llvm::cl::location(hwToSVOpts.etcDisableInstanceExtraction),
+      llvm::cl::init(false), llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> etcDisableRegisterExtraction{
+      "etc-disable-register-extraction",
+      llvm::cl::desc("Disable extracting registers that only feed test code"),
+      llvm::cl::location(hwToSVOpts.etcDisableRegisterExtraction),
+      llvm::cl::init(false), llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> etcDisableModuleInlining{
+      "etc-disable-module-inlining",
+      llvm::cl::desc("Disable inlining modules that only feed test code"),
+      llvm::cl::location(hwToSVOpts.etcDisableModuleInlining),
+      llvm::cl::init(false), llvm::cl::cat(category)};
+
+  llvm::cl::opt<std::string, true> ckgModuleName{
+      "ckg-name", llvm::cl::desc("Clock gate module name"),
+      llvm::cl::location(hwToSVOpts.ckg.moduleName),
+      llvm::cl::init("EICG_wrapper"), llvm::cl::cat(category)};
+
+  llvm::cl::opt<std::string, true> ckgInputName{
+      "ckg-input", llvm::cl::desc("Clock gate input port name"),
+      llvm::cl::location(hwToSVOpts.ckg.inputName), llvm::cl::init("in"),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<std::string, true> ckgOutputName{
+      "ckg-output", llvm::cl::desc("Clock gate output port name"),
+      llvm::cl::location(hwToSVOpts.ckg.outputName), llvm::cl::init("out"),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<std::string, true> ckgEnableName{
+      "ckg-enable", llvm::cl::desc("Clock gate enable port name"),
+      llvm::cl::location(hwToSVOpts.ckg.enableName), llvm::cl::init("en"),
+      llvm::cl::cat(category)};
+
+  llvm::cl::opt<std::string, true> ckgTestEnableName{
+      "ckg-test-enable",
+      llvm::cl::desc("Clock gate test enable port name (optional)"),
+      llvm::cl::location(hwToSVOpts.ckg.testEnableName),
+      llvm::cl::init("test_en"), llvm::cl::cat(category)};
+
+  llvm::cl::opt<bool, true> emitSeparateAlwaysBlocks{
       "emit-separate-always-blocks",
       llvm::cl::desc(
           "Prevent always blocks from being merged and emit constructs into "
           "separate always blocks whenever possible"),
+      llvm::cl::location(hwToSVOpts.emitSeparateAlwaysBlocks),
       llvm::cl::init(false), llvm::cl::cat(category)};
 
-  llvm::cl::opt<bool> etcDisableInstanceExtraction{
-      "etc-disable-instance-extraction",
-      llvm::cl::desc("Disable extracting instances only that feed test code"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
+  llvm::cl::opt<bool, true> addMuxPragmas{
+      "add-mux-pragmas",
+      llvm::cl::desc("Annotate mux pragmas for memory array access"),
+      llvm::cl::location(hwToSVOpts.addMuxPragmas), llvm::cl::init(false),
+      llvm::cl::cat(category)};
 
-  llvm::cl::opt<bool> etcDisableRegisterExtraction{
-      "etc-disable-register-extraction",
-      llvm::cl::desc("Disable extracting registers that only feed test code"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> etcDisableModuleInlining{
-      "etc-disable-module-inlining",
-      llvm::cl::desc("Disable inlining modules that only feed test code"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> addVivadoRAMAddressConflictSynthesisBugWorkaround{
+  llvm::cl::opt<bool, true> addVivadoRAMAddressConflictSynthesisBugWorkaround{
       "add-vivado-ram-address-conflict-synthesis-bug-workaround",
       llvm::cl::desc(
           "Add a vivado specific SV attribute (* ram_style = "
           "\"distributed\" *) to unpacked array registers as a workaronud "
           "for a vivado synthesis bug that incorrectly modifies "
           "address conflict behavivor of combinational memories"),
+      llvm::cl::location(
+          hwToSVOpts.addVivadoRAMAddressConflictSynthesisBugWorkaround),
       llvm::cl::init(false), llvm::cl::cat(category)};
 
-  //===----------------------------------------------------------------------===
-  // External Clock Gate Options
-  //===----------------------------------------------------------------------===
+  // ========== ExportVerilog ==========
 
-  seq::ExternalizeClockGateOptions clockGateOpts;
+  mutable FirtoolExportVerilogOptions exportVerilogOpts{&generalOpts};
 
-  llvm::cl::opt<std::string, true> ckgModuleName{
-      "ckg-name", llvm::cl::desc("Clock gate module name"),
-      llvm::cl::location(clockGateOpts.moduleName),
-      llvm::cl::init("EICG_wrapper"), llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string, true> ckgInputName{
-      "ckg-input", llvm::cl::desc("Clock gate input port name"),
-      llvm::cl::location(clockGateOpts.inputName), llvm::cl::init("in"),
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string, true> ckgOutputName{
-      "ckg-output", llvm::cl::desc("Clock gate output port name"),
-      llvm::cl::location(clockGateOpts.outputName), llvm::cl::init("out"),
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string, true> ckgEnableName{
-      "ckg-enable", llvm::cl::desc("Clock gate enable port name"),
-      llvm::cl::location(clockGateOpts.enableName), llvm::cl::init("en"),
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string, true> ckgTestEnableName{
-      "ckg-test-enable",
-      llvm::cl::desc("Clock gate test enable port name (optional)"),
-      llvm::cl::location(clockGateOpts.testEnableName),
-      llvm::cl::init("test_en"), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> exportModuleHierarchy{
-      "export-module-hierarchy",
-      llvm::cl::desc("Export module and instance hierarchy as JSON"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> stripFirDebugInfo{
+  llvm::cl::opt<bool, true> stripFirDebugInfo{
       "strip-fir-debug-info",
       llvm::cl::desc(
           "Disable source fir locator information in output Verilog"),
+      llvm::cl::location(exportVerilogOpts.stripFirDebugInfo),
       llvm::cl::init(true), llvm::cl::cat(category)};
 
-  llvm::cl::opt<bool> stripDebugInfo{
+  llvm::cl::opt<bool, true> stripDebugInfo{
       "strip-debug-info",
       llvm::cl::desc("Disable source locator information in output Verilog"),
+      llvm::cl::location(exportVerilogOpts.stripDebugInfo),
       llvm::cl::init(false), llvm::cl::cat(category)};
 
-  bool isRandomEnabled(RandomKind kind) const {
-    return disableRandom != RandomKind::All && disableRandom != kind;
+  llvm::cl::opt<bool, true> exportModuleHierarchy{
+      "export-module-hierarchy",
+      llvm::cl::desc("Export module and instance hierarchy as JSON"),
+      llvm::cl::location(exportVerilogOpts.exportModuleHierarchy),
+      llvm::cl::init(false), llvm::cl::cat(category)};
+
+  // ========== ExportVerilog ==========
+
+  FirtoolFinalizeIROptions finalizeIROpts{&generalOpts};
+
+  //
+
+  const FirtoolPreprocessTransformsOptions &
+  getPreprocessTransformsOptions() const {
+    return preprocessTransformsOpts;
   }
 
-  firrtl::PreserveValues::PreserveMode getPreserveMode() const {
-    if (!buildMode.getNumOccurrences())
-      return preserveMode;
-    switch (buildMode) {
-    case BuildModeDebug:
-      return firrtl::PreserveValues::Named;
-    case BuildModeRelease:
-      return firrtl::PreserveValues::None;
+  const FirtoolCHIRRTLToLowFIRRTLOptions &getCHIRRTLToLowFIRRTLOptions() const {
+    if (buildMode.getNumOccurrences()) {
+      switch (buildMode) {
+      case BuildModeDebug:
+        chirrtlToLowFIRRTLOpts.preserveValues = firrtl::PreserveValues::Named;
+        break;
+      case BuildModeRelease:
+        chirrtlToLowFIRRTLOpts.preserveValues = firrtl::PreserveValues::None;
+        break;
+      default:
+        llvm_unreachable("unknown build mode");
+      }
     }
-    llvm_unreachable("unknown build mode");
+    return chirrtlToLowFIRRTLOpts;
+  }
+
+  const FirtoolLowFIRRTLToHWOptions &getLowFIRRTLToHWOptions() const {
+    return lowFIRRTLToHWOpts;
+  }
+
+  const FirtoolHWToSVOptions &getHWToSVOptions() const { return hwToSVOpts; }
+
+  const FirtoolExportVerilogOptions &getExportVerilogOptions() const {
+    exportVerilogOpts.outputPath = outputFilename;
+    return exportVerilogOpts;
+  }
+
+  const FirtoolFinalizeIROptions &getFinalizeIROptions() const {
+    return finalizeIROpts;
   }
 
   FirtoolOptions(llvm::cl::OptionCategory &category) : category(category) {}
 };
 
-LogicalResult populatePreprocessTransforms(mlir::PassManager &pm,
-                                           const FirtoolOptions &opt);
+LogicalResult
+populatePreprocessTransforms(mlir::PassManager &pm,
+                             const FirtoolPreprocessTransformsOptions &opt);
 
-LogicalResult populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
-                                         const FirtoolOptions &opt,
-                                         ModuleOp module,
-                                         StringRef inputFilename);
+LogicalResult
+populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
+                           const FirtoolCHIRRTLToLowFIRRTLOptions &opt);
 
 LogicalResult populateLowFIRRTLToHW(mlir::PassManager &pm,
-                                    const FirtoolOptions &opt);
+                                    const FirtoolLowFIRRTLToHWOptions &opt);
 
-LogicalResult populateHWToSV(mlir::PassManager &pm, const FirtoolOptions &opt);
+LogicalResult populateHWToSV(mlir::PassManager &pm,
+                             const FirtoolHWToSVOptions &opt);
 
 LogicalResult populateExportVerilog(mlir::PassManager &pm,
-                                    const FirtoolOptions &opt,
+                                    const FirtoolExportVerilogOptions &opt,
                                     std::unique_ptr<llvm::raw_ostream> os);
 
 LogicalResult populateExportVerilog(mlir::PassManager &pm,
-                                    const FirtoolOptions &opt,
+                                    const FirtoolExportVerilogOptions &opt,
                                     llvm::raw_ostream &os);
 
-LogicalResult populateExportSplitVerilog(mlir::PassManager &pm,
-                                         const FirtoolOptions &opt,
-                                         llvm::StringRef directory);
+LogicalResult
+populateExportSplitVerilog(mlir::PassManager &pm,
+                           const FirtoolExportVerilogOptions &opt);
 
 LogicalResult populateFinalizeIR(mlir::PassManager &pm,
-                                 const FirtoolOptions &opt);
+                                 const FirtoolFinalizeIROptions &opt);
 
 } // namespace firtool
 } // namespace circt

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -20,48 +20,155 @@ using namespace circt;
 // Option API.
 //===----------------------------------------------------------------------===//
 
-DEFINE_C_API_PTR_METHODS(FirtoolOptions, firtool::FirtoolOptions)
+DEFINE_C_API_PTR_METHODS(FirtoolGeneralOptions, firtool::FirtoolGeneralOptions)
+DEFINE_C_API_PTR_METHODS(FirtoolPreprocessTransformsOptions,
+                         firtool::FirtoolPreprocessTransformsOptions)
+DEFINE_C_API_PTR_METHODS(FirtoolCHIRRTLToLowFIRRTLOptions,
+                         firtool::FirtoolCHIRRTLToLowFIRRTLOptions)
+DEFINE_C_API_PTR_METHODS(FirtoolLowFIRRTLToHWOptions,
+                         firtool::FirtoolLowFIRRTLToHWOptions)
+DEFINE_C_API_PTR_METHODS(FirtoolHWToSVOptions, firtool::FirtoolHWToSVOptions)
+DEFINE_C_API_PTR_METHODS(FirtoolExportVerilogOptions,
+                         firtool::FirtoolExportVerilogOptions)
+DEFINE_C_API_PTR_METHODS(FirtoolFinalizeIROptions,
+                         firtool::FirtoolFinalizeIROptions)
 
-FirtoolOptions firtoolOptionsCreateDefault() {
-  static auto category = llvm::cl::OptionCategory{"Firtool Options"};
-  auto *options = new firtool::FirtoolOptions{category};
-  return wrap(options);
-}
-
-void firtoolOptionsDestroy(FirtoolOptions options) { delete unwrap(options); }
-
-#define DEFINE_FIRTOOL_OPTION_STRING(name, field)                              \
-  void firtoolOptionsSet##name(FirtoolOptions options, MlirStringRef value) {  \
-    unwrap(options)->field = unwrap(value).str();                              \
+#define DEFINE_FIRTOOL_OPTIONS_CREATE_DESTROY(opt)                             \
+  Firtool##opt##Options firtool##opt##OptionsCreateDefault(                    \
+      FirtoolGeneralOptions general) {                                         \
+    auto *options = new firtool::Firtool##opt##Options{unwrap(general)};       \
+    return wrap(options);                                                      \
   }                                                                            \
-  MlirStringRef firtoolOptionsGet##name(FirtoolOptions options) {              \
-    return wrap(unwrap(options)->field.getValue());                            \
+  void firtool##opt##OptionsDestroy(Firtool##opt##Options options) {           \
+    delete unwrap(options);                                                    \
+  }                                                                            \
+  void firtool##opt##OptionsSetGeneral(Firtool##opt##Options options,          \
+                                       FirtoolGeneralOptions general) {        \
+    unwrap(options)->general = unwrap(general);                                \
+  }                                                                            \
+  FirtoolGeneralOptions firtool##opt##OptionsGetGeneral(                       \
+      Firtool##opt##Options options) {                                         \
+    return wrap(unwrap(options)->general);                                     \
   }
 
-#define DEFINE_FIRTOOL_OPTION_BOOL(name, field)                                \
-  void firtoolOptionsSet##name(FirtoolOptions options, bool value) {           \
+#define DEFINE_FIRTOOL_OPTION_STRING(opt, name, field)                         \
+  void firtool##opt##OptionsSet##name(Firtool##opt##Options options,           \
+                                      MlirStringRef value) {                   \
+    unwrap(options)->field = unwrap(value).str();                              \
+  }                                                                            \
+  MlirStringRef firtool##opt##OptionsGet##name(                                \
+      Firtool##opt##Options options) {                                         \
+    return wrap(unwrap(options)->field);                                       \
+  }
+
+#define DEFINE_FIRTOOL_OPTION_BOOL(opt, name, field)                           \
+  void firtool##opt##OptionsSet##name(Firtool##opt##Options options,           \
+                                      bool value) {                            \
     unwrap(options)->field = value;                                            \
   }                                                                            \
-  bool firtoolOptionsGet##name(FirtoolOptions options) {                       \
+  bool firtool##opt##OptionsGet##name(Firtool##opt##Options options) {         \
     return unwrap(options)->field;                                             \
   }
 
-#define DEFINE_FIRTOOL_OPTION_ENUM(name, field, enum_type, c_to_cpp, cpp_to_c) \
-  void firtoolOptionsSet##name(FirtoolOptions options, enum_type value) {      \
+#define DEFINE_FIRTOOL_OPTION_ENUM(opt, name, field, enum_type, c_to_cpp,      \
+                                   cpp_to_c)                                   \
+  void firtool##opt##OptionsSet##name(Firtool##opt##Options options,           \
+                                      enum_type value) {                       \
     unwrap(options)->field = c_to_cpp(value);                                  \
   }                                                                            \
-  enum_type firtoolOptionsGet##name(FirtoolOptions options) {                  \
+  enum_type firtool##opt##OptionsGet##name(Firtool##opt##Options options) {    \
     return cpp_to_c(unwrap(options)->field);                                   \
   }
 
-DEFINE_FIRTOOL_OPTION_STRING(OutputFilename, outputFilename)
-DEFINE_FIRTOOL_OPTION_BOOL(DisableAnnotationsUnknown, disableAnnotationsUnknown)
-DEFINE_FIRTOOL_OPTION_BOOL(DisableAnnotationsClassless,
-                           disableAnnotationsClassless)
-DEFINE_FIRTOOL_OPTION_BOOL(LowerAnnotationsNoRefTypePorts,
-                           lowerAnnotationsNoRefTypePorts)
+// ========== General ==========
+
+FirtoolGeneralOptions firtoolGeneralOptionsCreateDefault() {
+  auto *options = new firtool::FirtoolGeneralOptions;
+  return wrap(options);
+}
+
+void firtoolGeneralOptionsDestroy(FirtoolGeneralOptions options) {
+  delete unwrap(options);
+}
+
+DEFINE_FIRTOOL_OPTION_BOOL(General, DisableOptimization, disableOptimization)
+DEFINE_FIRTOOL_OPTION_BOOL(General, ReplSeqMem, replSeqMem)
+DEFINE_FIRTOOL_OPTION_STRING(General, ReplSeqMemFile, replSeqMemFile)
+DEFINE_FIRTOOL_OPTION_BOOL(General, IgnoreReadEnableMem, ignoreReadEnableMem)
 DEFINE_FIRTOOL_OPTION_ENUM(
-    PreserveAggregate, preserveAggregate, FirtoolPreserveAggregateMode,
+    General, DisableRandom, disableRandom, FirtoolRandomKind,
+    [](FirtoolRandomKind value) {
+      switch (value) {
+      case FIRTOOL_RANDOM_KIND_NONE:
+        return firtool::RandomKind::None;
+      case FIRTOOL_RANDOM_KIND_MEM:
+        return firtool::RandomKind::Mem;
+      case FIRTOOL_RANDOM_KIND_REG:
+        return firtool::RandomKind::Reg;
+      case FIRTOOL_RANDOM_KIND_ALL:
+        return firtool::RandomKind::All;
+      default: // NOLINT(clang-diagnostic-covered-switch-default)
+        llvm_unreachable("unknown random kind");
+      }
+    },
+    [](firtool::RandomKind value) {
+      switch (value) {
+      case firtool::RandomKind::None:
+        return FIRTOOL_RANDOM_KIND_NONE;
+      case firtool::RandomKind::Mem:
+        return FIRTOOL_RANDOM_KIND_MEM;
+      case firtool::RandomKind::Reg:
+        return FIRTOOL_RANDOM_KIND_REG;
+      case firtool::RandomKind::All:
+        return FIRTOOL_RANDOM_KIND_ALL;
+      default: // NOLINT(clang-diagnostic-covered-switch-default)
+        llvm_unreachable("unknown random kind");
+      }
+    })
+
+// ========== PreprocessTransforms ==========
+
+DEFINE_FIRTOOL_OPTIONS_CREATE_DESTROY(PreprocessTransforms)
+DEFINE_FIRTOOL_OPTION_BOOL(PreprocessTransforms, DisableAnnotationsUnknown,
+                           disableAnnotationsUnknown)
+DEFINE_FIRTOOL_OPTION_BOOL(PreprocessTransforms, DisableAnnotationsClassless,
+                           disableAnnotationsClassless)
+DEFINE_FIRTOOL_OPTION_BOOL(PreprocessTransforms, LowerAnnotationsNoRefTypePorts,
+                           lowerAnnotationsNoRefTypePorts)
+
+// ========== CHIRRTLToLowFIRRTL ==========
+
+DEFINE_FIRTOOL_OPTIONS_CREATE_DESTROY(CHIRRTLToLowFIRRTL)
+DEFINE_FIRTOOL_OPTION_ENUM(
+    CHIRRTLToLowFIRRTL, PreserveValues, preserveValues,
+    FirtoolPreserveValuesMode,
+    [](FirtoolPreserveValuesMode value) {
+      switch (value) {
+      case FIRTOOL_PRESERVE_VALUES_MODE_NONE:
+        return firrtl::PreserveValues::None;
+      case FIRTOOL_PRESERVE_VALUES_MODE_NAMED:
+        return firrtl::PreserveValues::Named;
+      case FIRTOOL_PRESERVE_VALUES_MODE_ALL:
+        return firrtl::PreserveValues::All;
+      default: // NOLINT(clang-diagnostic-covered-switch-default)
+        llvm_unreachable("unknown preserve values mode");
+      }
+    },
+    [](firrtl::PreserveValues::PreserveMode value) {
+      switch (value) {
+      case firrtl::PreserveValues::None:
+        return FIRTOOL_PRESERVE_VALUES_MODE_NONE;
+      case firrtl::PreserveValues::Named:
+        return FIRTOOL_PRESERVE_VALUES_MODE_NAMED;
+      case firrtl::PreserveValues::All:
+        return FIRTOOL_PRESERVE_VALUES_MODE_ALL;
+      default: // NOLINT(clang-diagnostic-covered-switch-default)
+        llvm_unreachable("unknown preserve values mode");
+      }
+    })
+DEFINE_FIRTOOL_OPTION_ENUM(
+    CHIRRTLToLowFIRRTL, PreserveAggregate, preserveAggregate,
+    FirtoolPreserveAggregateMode,
     [](FirtoolPreserveAggregateMode value) {
       switch (value) {
       case FIRTOOL_PRESERVE_AGGREGATE_MODE_NONE:
@@ -90,62 +197,18 @@ DEFINE_FIRTOOL_OPTION_ENUM(
         llvm_unreachable("unknown preserve aggregate mode");
       }
     })
-DEFINE_FIRTOOL_OPTION_ENUM(
-    PreserveValues, preserveMode, FirtoolPreserveValuesMode,
-    [](FirtoolPreserveValuesMode value) {
-      switch (value) {
-      case FIRTOOL_PRESERVE_VALUES_MODE_NONE:
-        return firrtl::PreserveValues::None;
-      case FIRTOOL_PRESERVE_VALUES_MODE_NAMED:
-        return firrtl::PreserveValues::Named;
-      case FIRTOOL_PRESERVE_VALUES_MODE_ALL:
-        return firrtl::PreserveValues::All;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown preserve values mode");
-      }
-    },
-    [](firrtl::PreserveValues::PreserveMode value) {
-      switch (value) {
-      case firrtl::PreserveValues::None:
-        return FIRTOOL_PRESERVE_VALUES_MODE_NONE;
-      case firrtl::PreserveValues::Named:
-        return FIRTOOL_PRESERVE_VALUES_MODE_NAMED;
-      case firrtl::PreserveValues::All:
-        return FIRTOOL_PRESERVE_VALUES_MODE_ALL;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown preserve values mode");
-      }
-    })
-DEFINE_FIRTOOL_OPTION_ENUM(
-    BuildMode, buildMode, FirtoolBuildMode,
-    [](FirtoolBuildMode value) {
-      switch (value) {
-      case FIRTOOL_BUILD_MODE_DEBUG:
-        return firtool::FirtoolOptions::BuildModeDebug;
-      case FIRTOOL_BUILD_MODE_RELEASE:
-        return firtool::FirtoolOptions::BuildModeRelease;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown build mode");
-      }
-    },
-    [](firtool::FirtoolOptions::BuildMode value) {
-      switch (value) {
-      case firtool::FirtoolOptions::BuildModeDebug:
-        return FIRTOOL_BUILD_MODE_DEBUG;
-      case firtool::FirtoolOptions::BuildModeRelease:
-        return FIRTOOL_BUILD_MODE_RELEASE;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown build mode");
-      }
-    })
-DEFINE_FIRTOOL_OPTION_BOOL(DisableOptimization, disableOptimization)
-DEFINE_FIRTOOL_OPTION_BOOL(ExportChiselInterface, exportChiselInterface)
-DEFINE_FIRTOOL_OPTION_STRING(ChiselInterfaceOutDirectory,
+DEFINE_FIRTOOL_OPTION_BOOL(CHIRRTLToLowFIRRTL, ExportChiselInterface,
+                           exportChiselInterface)
+DEFINE_FIRTOOL_OPTION_STRING(CHIRRTLToLowFIRRTL, ChiselInterfaceOutDirectory,
                              chiselInterfaceOutDirectory)
-DEFINE_FIRTOOL_OPTION_BOOL(VbToBv, vbToBV)
-DEFINE_FIRTOOL_OPTION_BOOL(Dedup, dedup)
+DEFINE_FIRTOOL_OPTION_BOOL(CHIRRTLToLowFIRRTL, DisableHoistingHWPassthrough,
+                           disableHoistingHWPassthrough)
+DEFINE_FIRTOOL_OPTION_BOOL(CHIRRTLToLowFIRRTL, Dedup, dedup)
+DEFINE_FIRTOOL_OPTION_BOOL(CHIRRTLToLowFIRRTL, NoDedup, noDedup)
+DEFINE_FIRTOOL_OPTION_BOOL(CHIRRTLToLowFIRRTL, VbToBv, vbToBV)
+DEFINE_FIRTOOL_OPTION_BOOL(CHIRRTLToLowFIRRTL, LowerMemories, lowerMemories)
 DEFINE_FIRTOOL_OPTION_ENUM(
-    CompanionMode, companionMode, FirtoolCompanionMode,
+    CHIRRTLToLowFIRRTL, CompanionMode, companionMode, FirtoolCompanionMode,
     [](FirtoolCompanionMode value) {
       switch (value) {
       case FIRTOOL_COMPANION_MODE_BIND:
@@ -170,68 +233,61 @@ DEFINE_FIRTOOL_OPTION_ENUM(
         llvm_unreachable("unknown build mode");
       }
     })
-
-DEFINE_FIRTOOL_OPTION_BOOL(DisableAggressiveMergeConnections,
+DEFINE_FIRTOOL_OPTION_STRING(CHIRRTLToLowFIRRTL, BlackBoxRootPath,
+                             blackBoxRootPath)
+DEFINE_FIRTOOL_OPTION_BOOL(CHIRRTLToLowFIRRTL, EmitOMIR, emitOMIR)
+DEFINE_FIRTOOL_OPTION_STRING(CHIRRTLToLowFIRRTL, OMIROutFile, omirOutFile)
+DEFINE_FIRTOOL_OPTION_BOOL(CHIRRTLToLowFIRRTL,
+                           DisableAggressiveMergeConnections,
                            disableAggressiveMergeConnections)
-DEFINE_FIRTOOL_OPTION_BOOL(EmitOMIR, emitOMIR)
-DEFINE_FIRTOOL_OPTION_STRING(OMIROutFile, omirOutFile)
-DEFINE_FIRTOOL_OPTION_BOOL(LowerMemories, lowerMemories)
-DEFINE_FIRTOOL_OPTION_STRING(BlackBoxRootPath, blackBoxRootPath)
-DEFINE_FIRTOOL_OPTION_BOOL(ReplSeqMem, replSeqMem)
-DEFINE_FIRTOOL_OPTION_STRING(ReplSeqMemFile, replSeqMemFile)
-DEFINE_FIRTOOL_OPTION_BOOL(ExtractTestCode, extractTestCode)
-DEFINE_FIRTOOL_OPTION_BOOL(IgnoreReadEnableMem, ignoreReadEnableMem)
-DEFINE_FIRTOOL_OPTION_ENUM(
-    DisableRandom, disableRandom, FirtoolRandomKind,
-    [](FirtoolRandomKind value) {
-      switch (value) {
-      case FIRTOOL_RANDOM_KIND_NONE:
-        return firtool::FirtoolOptions::RandomKind::None;
-      case FIRTOOL_RANDOM_KIND_MEM:
-        return firtool::FirtoolOptions::RandomKind::Mem;
-      case FIRTOOL_RANDOM_KIND_REG:
-        return firtool::FirtoolOptions::RandomKind::Reg;
-      case FIRTOOL_RANDOM_KIND_ALL:
-        return firtool::FirtoolOptions::RandomKind::All;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown random kind");
-      }
-    },
-    [](firtool::FirtoolOptions::RandomKind value) {
-      switch (value) {
-      case firtool::FirtoolOptions::RandomKind::None:
-        return FIRTOOL_RANDOM_KIND_NONE;
-      case firtool::FirtoolOptions::RandomKind::Mem:
-        return FIRTOOL_RANDOM_KIND_MEM;
-      case firtool::FirtoolOptions::RandomKind::Reg:
-        return FIRTOOL_RANDOM_KIND_REG;
-      case firtool::FirtoolOptions::RandomKind::All:
-        return FIRTOOL_RANDOM_KIND_ALL;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown random kind");
-      }
-    })
-DEFINE_FIRTOOL_OPTION_STRING(OutputAnnotationFilename, outputAnnotationFilename)
-DEFINE_FIRTOOL_OPTION_BOOL(EnableAnnotationWarning, enableAnnotationWarning)
-DEFINE_FIRTOOL_OPTION_BOOL(AddMuxPragmas, addMuxPragmas)
-DEFINE_FIRTOOL_OPTION_BOOL(EmitChiselAssertsAsSVA, emitChiselAssertsAsSVA)
-DEFINE_FIRTOOL_OPTION_BOOL(EmitSeparateAlwaysBlocks, emitSeparateAlwaysBlocks)
-DEFINE_FIRTOOL_OPTION_BOOL(EtcDisableInstanceExtraction,
-                           etcDisableInstanceExtraction)
-DEFINE_FIRTOOL_OPTION_BOOL(EtcDisableRegisterExtraction,
-                           etcDisableRegisterExtraction)
-DEFINE_FIRTOOL_OPTION_BOOL(EtcDisableModuleInlining, etcDisableModuleInlining)
-DEFINE_FIRTOOL_OPTION_BOOL(AddVivadoRAMAddressConflictSynthesisBugWorkaround,
-                           addVivadoRAMAddressConflictSynthesisBugWorkaround)
-DEFINE_FIRTOOL_OPTION_STRING(CkgModuleName, ckgModuleName)
-DEFINE_FIRTOOL_OPTION_STRING(CkgInputName, ckgInputName)
-DEFINE_FIRTOOL_OPTION_STRING(CkgOutputName, ckgOutputName)
-DEFINE_FIRTOOL_OPTION_STRING(CkgEnableName, ckgEnableName)
-DEFINE_FIRTOOL_OPTION_STRING(CkgTestEnableName, ckgTestEnableName)
-DEFINE_FIRTOOL_OPTION_BOOL(ExportModuleHierarchy, exportModuleHierarchy)
-DEFINE_FIRTOOL_OPTION_BOOL(StripFirDebugInfo, stripFirDebugInfo)
-DEFINE_FIRTOOL_OPTION_BOOL(StripDebugInfo, stripDebugInfo)
 
+// ========== LowFIRRTLToHW ==========
+
+DEFINE_FIRTOOL_OPTIONS_CREATE_DESTROY(LowFIRRTLToHW)
+DEFINE_FIRTOOL_OPTION_STRING(LowFIRRTLToHW, OutputAnnotationFilename,
+                             outputAnnotationFilename)
+DEFINE_FIRTOOL_OPTION_BOOL(LowFIRRTLToHW, EnableAnnotationWarning,
+                           enableAnnotationWarning)
+DEFINE_FIRTOOL_OPTION_BOOL(LowFIRRTLToHW, EmitChiselAssertsAsSVA,
+                           emitChiselAssertsAsSVA)
+
+// ========== HWToSV ==========
+
+DEFINE_FIRTOOL_OPTIONS_CREATE_DESTROY(HWToSV)
+DEFINE_FIRTOOL_OPTION_BOOL(HWToSV, ExtractTestCode, extractTestCode)
+DEFINE_FIRTOOL_OPTION_BOOL(HWToSV, EtcDisableInstanceExtraction,
+                           etcDisableInstanceExtraction)
+DEFINE_FIRTOOL_OPTION_BOOL(HWToSV, EtcDisableRegisterExtraction,
+                           etcDisableRegisterExtraction)
+DEFINE_FIRTOOL_OPTION_BOOL(HWToSV, EtcDisableModuleInlining,
+                           etcDisableModuleInlining)
+DEFINE_FIRTOOL_OPTION_STRING(HWToSV, CkgModuleName, ckg.moduleName)
+DEFINE_FIRTOOL_OPTION_STRING(HWToSV, CkgInputName, ckg.inputName)
+DEFINE_FIRTOOL_OPTION_STRING(HWToSV, CkgOutputName, ckg.outputName)
+DEFINE_FIRTOOL_OPTION_STRING(HWToSV, CkgEnableName, ckg.enableName)
+DEFINE_FIRTOOL_OPTION_STRING(HWToSV, CkgTestEnableName, ckg.testEnableName)
+DEFINE_FIRTOOL_OPTION_STRING(HWToSV, CkgInstName, ckg.instName)
+DEFINE_FIRTOOL_OPTION_BOOL(HWToSV, EmitSeparateAlwaysBlocks,
+                           emitSeparateAlwaysBlocks)
+DEFINE_FIRTOOL_OPTION_BOOL(HWToSV, AddMuxPragmas, addMuxPragmas)
+DEFINE_FIRTOOL_OPTION_BOOL(HWToSV,
+                           AddVivadoRAMAddressConflictSynthesisBugWorkaround,
+                           addVivadoRAMAddressConflictSynthesisBugWorkaround)
+
+// ========== ExportVerilog ==========
+
+DEFINE_FIRTOOL_OPTIONS_CREATE_DESTROY(ExportVerilog)
+DEFINE_FIRTOOL_OPTION_BOOL(ExportVerilog, StripFirDebugInfo, stripFirDebugInfo)
+DEFINE_FIRTOOL_OPTION_BOOL(ExportVerilog, StripDebugInfo, stripDebugInfo)
+DEFINE_FIRTOOL_OPTION_BOOL(ExportVerilog, ExportModuleHierarchy,
+                           exportModuleHierarchy)
+DEFINE_FIRTOOL_OPTION_STRING(ExportVerilog, OutputPath, outputPath)
+
+// ========== FinalizeIR ==========
+
+DEFINE_FIRTOOL_OPTIONS_CREATE_DESTROY(FinalizeIR)
+
+#undef DEFINE_FIRTOOL_OPTIONS_CREATE_DESTROY
 #undef DEFINE_FIRTOOL_OPTION_STRING
 #undef DEFINE_FIRTOOL_OPTION_BOOL
 #undef DEFINE_FIRTOOL_OPTION_ENUM
@@ -240,48 +296,48 @@ DEFINE_FIRTOOL_OPTION_BOOL(StripDebugInfo, stripDebugInfo)
 // Populate API.
 //===----------------------------------------------------------------------===//
 
-MlirLogicalResult firtoolPopulatePreprocessTransforms(MlirPassManager pm,
-                                                      FirtoolOptions options) {
+MlirLogicalResult firtoolPopulatePreprocessTransforms(
+    MlirPassManager pm, FirtoolPreprocessTransformsOptions options) {
   return wrap(
       firtool::populatePreprocessTransforms(*unwrap(pm), *unwrap(options)));
 }
 
 MlirLogicalResult
-firtoolPopulateCHIRRTLToLowFIRRTL(MlirPassManager pm, FirtoolOptions options,
-                                  MlirModule module,
-                                  MlirStringRef inputFilename) {
-  return wrap(firtool::populateCHIRRTLToLowFIRRTL(
-      *unwrap(pm), *unwrap(options), unwrap(module), unwrap(inputFilename)));
+firtoolPopulateCHIRRTLToLowFIRRTL(MlirPassManager pm,
+                                  FirtoolCHIRRTLToLowFIRRTLOptions options) {
+  return wrap(
+      firtool::populateCHIRRTLToLowFIRRTL(*unwrap(pm), *unwrap(options)));
 }
 
-MlirLogicalResult firtoolPopulateLowFIRRTLToHW(MlirPassManager pm,
-                                               FirtoolOptions options) {
+MlirLogicalResult
+firtoolPopulateLowFIRRTLToHW(MlirPassManager pm,
+                             FirtoolLowFIRRTLToHWOptions options) {
   return wrap(firtool::populateLowFIRRTLToHW(*unwrap(pm), *unwrap(options)));
 }
 
 MlirLogicalResult firtoolPopulateHWToSV(MlirPassManager pm,
-                                        FirtoolOptions options) {
+                                        FirtoolHWToSVOptions options) {
   return wrap(firtool::populateHWToSV(*unwrap(pm), *unwrap(options)));
 }
 
-MlirLogicalResult firtoolPopulateExportVerilog(MlirPassManager pm,
-                                               FirtoolOptions options,
-                                               MlirStringCallback callback,
-                                               void *userData) {
+MlirLogicalResult
+firtoolPopulateExportVerilog(MlirPassManager pm,
+                             FirtoolExportVerilogOptions options,
+                             MlirStringCallback callback, void *userData) {
   auto stream =
       std::make_unique<mlir::detail::CallbackOstream>(callback, userData);
   return wrap(firtool::populateExportVerilog(*unwrap(pm), *unwrap(options),
                                              std::move(stream)));
 }
 
-MlirLogicalResult firtoolPopulateExportSplitVerilog(MlirPassManager pm,
-                                                    FirtoolOptions options,
-                                                    MlirStringRef directory) {
-  return wrap(firtool::populateExportSplitVerilog(*unwrap(pm), *unwrap(options),
-                                                  unwrap(directory)));
+MlirLogicalResult
+firtoolPopulateExportSplitVerilog(MlirPassManager pm,
+                                  FirtoolExportVerilogOptions options) {
+  return wrap(
+      firtool::populateExportSplitVerilog(*unwrap(pm), *unwrap(options)));
 }
 
 MlirLogicalResult firtoolPopulateFinalizeIR(MlirPassManager pm,
-                                            FirtoolOptions options) {
+                                            FirtoolFinalizeIROptions options) {
   return wrap(firtool::populateFinalizeIR(*unwrap(pm), *unwrap(options)));
 }


### PR DESCRIPTION
Fixes #6291

This is another approach to fixing that issue besides PR #6292. This approach doesn't use template, but separated `llvm:cl::opt<T>` and `T`, as `opt` is supposed to be used only for command-line and C-API is not command-line related.

This PR changes all `llvm::cl::opt<T>` to 2 variables `llvm::cl::opt<T, true>` and `T`, the `true` meaning that the `opt` has an external storage, so the former references the latter, there is only one storage. Also the PR separates `FirtoolOptions` into more fine-grained structures (`FirtoolGeneralOptions`, `FirtoolPreprocessTransformsOptions`, `FirtoolCHIRRTLToLowFIRRTLOptions`, etc.) as suggested by @sequencer in https://github.com/llvm/circt/issues/6291#issuecomment-1765097617.

Personally, I prefer this approach to #6292, because #6292 is just... too dirty..