### PR TITLE
[OM] Add evaluator support for paths

### DIFF
--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -187,21 +187,21 @@ MLIR_CAPI_EXPORTED bool omEvaluatorValueIsAMap(OMEvaluatorValue evaluatorValue);
 MLIR_CAPI_EXPORTED MlirType
 omEvaluatorMapGetType(OMEvaluatorValue evaluatorValue);
 
-/// Query if the EvaluatorValue is a FrozenBasePath.
+/// Query if the EvaluatorValue is a BasePath.
 MLIR_CAPI_EXPORTED bool
-omEvaluatorValueIsAFrozenBasePath(OMEvaluatorValue evaluatorValue);
+omEvaluatorValueIsABasePath(OMEvaluatorValue evaluatorValue);
 
-/// Create an empty FrozenBasePath.
+/// Create an empty BasePath.
 MLIR_CAPI_EXPORTED OMEvaluatorValue
-omEvaluatorFrozenBasePathGetEmpty(MlirContext context);
+omEvaluatorBasePathGetEmpty(MlirContext context);
 
-/// Query if the EvaluatorValue is a FrozenPath.
+/// Query if the EvaluatorValue is a Path.
 MLIR_CAPI_EXPORTED bool
-omEvaluatorValueIsAFrozenPath(OMEvaluatorValue evaluatorValue);
+omEvaluatorValueIsAPath(OMEvaluatorValue evaluatorValue);
 
-/// Get a string representation of a FrozenPath.
+/// Get a string representation of a Path.
 MLIR_CAPI_EXPORTED MlirAttribute
-omEvaluatorFrozenPathGetAsString(OMEvaluatorValue evaluatorValue);
+omEvaluatorPathGetAsString(OMEvaluatorValue evaluatorValue);
 
 //===----------------------------------------------------------------------===//
 // ReferenceAttr API
@@ -247,7 +247,6 @@ MLIR_CAPI_EXPORTED MlirIdentifier omMapAttrGetElementKey(MlirAttribute attr,
 
 MLIR_CAPI_EXPORTED MlirAttribute omMapAttrGetElementValue(MlirAttribute attr,
                                                           intptr_t pos);
-
 
 #ifdef __cplusplus
 }

--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -187,6 +187,22 @@ MLIR_CAPI_EXPORTED bool omEvaluatorValueIsAMap(OMEvaluatorValue evaluatorValue);
 MLIR_CAPI_EXPORTED MlirType
 omEvaluatorMapGetType(OMEvaluatorValue evaluatorValue);
 
+/// Query if the EvaluatorValue is a FrozenBasePath.
+MLIR_CAPI_EXPORTED bool
+omEvaluatorValueIsAFrozenBasePath(OMEvaluatorValue evaluatorValue);
+
+/// Create an empty FrozenBasePath.
+MLIR_CAPI_EXPORTED OMEvaluatorValue
+omEvaluatorFrozenBasePathGetEmpty(MlirContext context);
+
+/// Query if the EvaluatorValue is a FrozenPath.
+MLIR_CAPI_EXPORTED bool
+omEvaluatorValueIsAFrozenPath(OMEvaluatorValue evaluatorValue);
+
+/// Get a string representation of a FrozenPath.
+MLIR_CAPI_EXPORTED MlirAttribute
+omEvaluatorFrozenPathGetAsString(OMEvaluatorValue evaluatorValue);
+
 //===----------------------------------------------------------------------===//
 // ReferenceAttr API
 //===----------------------------------------------------------------------===//
@@ -232,13 +248,6 @@ MLIR_CAPI_EXPORTED MlirIdentifier omMapAttrGetElementKey(MlirAttribute attr,
 MLIR_CAPI_EXPORTED MlirAttribute omMapAttrGetElementValue(MlirAttribute attr,
                                                           intptr_t pos);
 
-//===----------------------------------------------------------------------===//
-// PathAttr API
-//===----------------------------------------------------------------------===//
-
-MLIR_CAPI_EXPORTED bool omAttrIsAPathAttr(MlirAttribute attr);
-
-MLIR_CAPI_EXPORTED MlirIdentifier omPathAttrGetPath(MlirAttribute attr);
 
 #ifdef __cplusplus
 }

--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -22,6 +22,7 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallString.h"
 
 #include <queue>
 #include <utility>
@@ -46,7 +47,7 @@ using ObjectFields = SmallDenseMap<StringAttr, EvaluatorValuePtr>;
 /// the appropriate reference count.
 struct EvaluatorValue : std::enable_shared_from_this<EvaluatorValue> {
   // Implement LLVM RTTI.
-  enum class Kind { Attr, Object, List, Tuple, Map, Reference };
+  enum class Kind { Attr, Object, List, Tuple, Map, Reference, BasePath, Path };
   EvaluatorValue(MLIRContext *ctx, Kind kind, Location loc)
       : kind(kind), ctx(ctx), loc(loc) {}
   Kind getKind() const { return kind; }
@@ -58,6 +59,9 @@ struct EvaluatorValue : std::enable_shared_from_this<EvaluatorValue> {
     assert(!fullyEvaluated && "should not mark twice");
     fullyEvaluated = true;
   }
+
+  /// Return the associated MLIR context.
+  MLIRContext *getContext() { return ctx; }
 
   // Return a MLIR type which the value represents.
   Type getType() const;
@@ -328,6 +332,140 @@ private:
   TupleElements elements;
 };
 
+/// A Basepath value.
+struct BasePathValue : EvaluatorValue {
+  BasePathValue(MLIRContext *context)
+      : EvaluatorValue(context, Kind::BasePath, UnknownLoc::get(context)),
+        path(PathAttr::get(context, {})) {
+    markFullyEvaluated();
+  }
+
+  /// Create a path value representing a basepath.
+  BasePathValue(om::PathAttr path, Location loc)
+      : EvaluatorValue(path.getContext(), Kind::BasePath, loc), path(path) {}
+
+  om::PathAttr getPath() const {
+    assert(isFullyEvaluated());
+    return path;
+  }
+
+  /// Set the basepath which this path is relative to.
+  void setBasepath(const BasePathValue &basepath) {
+    assert(!isFullyEvaluated());
+    auto newPath = llvm::to_vector(basepath.path.getPath());
+    auto oldPath = path.getPath();
+    newPath.append(oldPath.begin(), oldPath.end());
+    path = PathAttr::get(path.getContext(), newPath);
+    markFullyEvaluated();
+  }
+
+  /// Finalize the evaluator value.
+  LogicalResult finalizeImpl() { return success(); }
+
+  /// Implement LLVM RTTI.
+  static bool classof(const EvaluatorValue *e) {
+    return e->getKind() == Kind::BasePath;
+  }
+
+private:
+  om::PathAttr path;
+};
+
+/// A Path value.
+struct PathValue : EvaluatorValue {
+  /// Create a path value representing a regular path.
+  PathValue(om::TargetKindAttr targetKind, om::PathAttr path, StringAttr module,
+            StringAttr ref, StringAttr field, Location loc)
+      : EvaluatorValue(loc.getContext(), Kind::Path, loc),
+        targetKind(targetKind), path(path), module(module), ref(ref),
+        field(field) {}
+
+  static PathValue getEmptyPath(Location loc) {
+    PathValue path(nullptr, nullptr, nullptr, nullptr, nullptr, loc);
+    path.markFullyEvaluated();
+    return path;
+  }
+
+  om::TargetKindAttr getTargetKind() const { return targetKind; }
+
+  om::PathAttr getPath() const { return path; }
+
+  StringAttr getModule() const { return module; }
+
+  StringAttr getRef() const { return ref; }
+
+  StringAttr getField() const { return field; }
+
+  StringAttr getAsString() const {
+    // If the module is null, then this is a path to a deleted object.
+    if (!targetKind)
+      return StringAttr::get(getContext(), "OMDeleted");
+    SmallString<64> result;
+    switch (targetKind.getValue()) {
+    case om::TargetKind::DontTouch:
+      result += "OMDontTouchedReferenceTarget";
+      break;
+    case om::TargetKind::Instance:
+      result += "OMInstanceTarget";
+      break;
+    case om::TargetKind::MemberInstance:
+      result += "OMMemberInstanceTarget";
+      break;
+    case om::TargetKind::MemberReference:
+      result += "OMMemberReferenceTarget";
+      break;
+    case om::TargetKind::Reference:
+      result += "OMReferenceTarget";
+      break;
+    }
+    result += ":~";
+    if (!path.getPath().empty())
+      result += path.getPath().front().module;
+    else
+      result += module.getValue();
+    result += '|';
+    for (const auto &elt : path) {
+      result += elt.module.getValue();
+      result += '/';
+      result += elt.instance.getValue();
+      result += ':';
+    }
+    if (!module.getValue().empty())
+      result += module.getValue();
+    if (!ref.getValue().empty()) {
+      result += '>';
+      result += ref.getValue();
+    }
+    if (!field.getValue().empty())
+      result += field.getValue();
+    return StringAttr::get(field.getContext(), result);
+  }
+
+  void setBasepath(const BasePathValue &basepath) {
+    assert(!isFullyEvaluated());
+    auto newPath = llvm::to_vector(basepath.getPath().getPath());
+    auto oldPath = path.getPath();
+    newPath.append(oldPath.begin(), oldPath.end());
+    path = PathAttr::get(path.getContext(), newPath);
+    markFullyEvaluated();
+  }
+
+  // Finalize the evaluator value.
+  LogicalResult finalizeImpl() { return success(); }
+
+  /// Implement LLVM RTTI.
+  static bool classof(const EvaluatorValue *e) {
+    return e->getKind() == Kind::Path;
+  }
+
+private:
+  om::TargetKindAttr targetKind;
+  om::PathAttr path;
+  StringAttr module;
+  StringAttr ref;
+  StringAttr field;
+};
+
 } // namespace evaluator
 
 using Object = evaluator::ObjectValue;
@@ -406,6 +544,15 @@ private:
   FailureOr<evaluator::EvaluatorValuePtr>
   evaluateMapCreate(MapCreateOp op, ActualParameters actualParams,
                     Location loc);
+  FailureOr<evaluator::EvaluatorValuePtr>
+  evaluateBasePathCreate(FrozenBasePathCreateOp op,
+                         ActualParameters actualParams, Location loc);
+  FailureOr<evaluator::EvaluatorValuePtr>
+  evaluatePathCreate(FrozenPathCreateOp op, ActualParameters actualParams,
+                     Location loc);
+  FailureOr<evaluator::EvaluatorValuePtr>
+  evaluateEmptyPath(FrozenEmptyPathOp op, ActualParameters actualParams,
+                    Location loc);
 
   FailureOr<ActualParameters>
   createParametersFromOperands(ValueRange range, ActualParameters actualParams,
@@ -441,6 +588,11 @@ operator<<(mlir::Diagnostic &diag,
     diag << "List(" << list->getType() << ")";
   else if (auto *map = llvm::dyn_cast<evaluator::MapValue>(&evaluatorValue))
     diag << "Map(" << map->getType() << ")";
+  else if (auto *basePath =
+               llvm::dyn_cast<evaluator::BasePathValue>(&evaluatorValue))
+    diag << "BasePath()";
+  else if (auto *path = llvm::dyn_cast<evaluator::PathValue>(&evaluatorValue))
+    diag << "Path()";
   else
     assert(false && "unhandled evaluator value");
   return diag;

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -210,7 +210,7 @@ obj = evaluator.instantiate("Test", 41)
 # CHECK: 41
 print(obj.field)
 
-path = om.FrozenBasePath.get_empty(evaluator.module.context)
+path = om.BasePath.get_empty(evaluator.module.context)
 obj = evaluator.instantiate("Paths", path)
 print(obj.path)
 # CHECK: OMReferenceTarget:~Foo|Foo/bar:Bar/baz:Baz>w

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -81,6 +81,15 @@ with Context() as ctx, Location.unknown():
     hw.module @Root(in %clock: i1) {
       %0 = sv.wire sym @x : !hw.inout<i1>
     }
+    
+    om.class @Paths(%basepath: !om.frozenbasepath) {
+      %0 = om.frozenbasepath_create %basepath "Foo/bar"
+      %1 = om.frozenpath_create reference %0 "Bar/baz:Baz>w"
+      om.class.field @path, %1 : !om.frozenpath
+
+      %3 = om.frozenpath_empty
+      om.class.field @deleted, %3 : !om.frozenpath
+    }
   }
   """)
 
@@ -200,3 +209,11 @@ assert len(object_dict) == 2
 obj = evaluator.instantiate("Test", 41)
 # CHECK: 41
 print(obj.field)
+
+path = om.FrozenBasePath.get_empty(evaluator.module.context)
+obj = evaluator.instantiate("Paths", path)
+print(obj.path)
+# CHECK: OMReferenceTarget:~Foo|Foo/bar:Bar/baz:Baz>w
+
+print(obj.deleted)
+# CHECK: OMDeleted

--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -110,7 +110,8 @@ private:
 
 /// Provides a BasePath class by simply wrapping the OMObject CAPI.
 struct BasePath {
-  // Instantiate a Map with a reference to the underlying OMEvaluatorValue.
+  /// Instantiate a BasePath with a reference to the underlying
+  /// OMEvaluatorValue.
   BasePath(OMEvaluatorValue value) : value(value) {}
 
   static BasePath getEmpty(MlirContext context) {
@@ -129,7 +130,7 @@ private:
 
 /// Provides a Path class by simply wrapping the OMObject CAPI.
 struct Path {
-  // Instantiate a Map with a reference to the underlying OMEvaluatorValue.
+  /// Instantiate a Path with a reference to the underlying OMEvaluatorValue.
   Path(OMEvaluatorValue value) : value(value) {}
 
   /// Return a context from an underlying value.
@@ -443,7 +444,7 @@ void circt::python::populateDialectOMSubmodule(py::module &m) {
 
   // Add the Path class definition.
   py::class_<Path>(m, "Path")
-      .def(py::init<Path>(), py::arg("basepath"))
+      .def(py::init<Path>(), py::arg("path"))
       .def("__str__", &Path::dunderStr);
 
   // Add the Object class definition.

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from ._om_ops_gen import *
-from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, Tuple as BaseTuple, Map as BaseMap, ClassType, ReferenceAttr, ListAttr, MapAttr, OMIntegerAttr
+from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, Tuple as BaseTuple, Map as BaseMap, FrozenBasePath as BaseFrozenBasePath, FrozenPath as BaseFrozenPath, ClassType, ReferenceAttr, ListAttr, MapAttr, OMIntegerAttr
 
 from ..ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr, IntegerAttr, IntegerType
 from ..support import attribute_to_var, var_to_attribute
@@ -34,6 +34,12 @@ def wrap_mlir_object(value):
   if isinstance(value, BaseMap):
     return Map(value)
 
+  if isinstance(value, BaseFrozenBasePath):
+    return FrozenBasePath(value)
+
+  if isinstance(value, BaseFrozenPath):
+    return FrozenPath(value)
+
   # For objects, return an Object, wrapping the base implementation.
   assert isinstance(value, BaseObject)
   return Object(value)
@@ -60,6 +66,12 @@ def unwrap_python_object(value):
 
   if isinstance(value, Map):
     return BaseMap(value)
+
+  if isinstance(value, FrozenBasePath):
+    return BaseFrozenBasePath(value)
+
+  if isinstance(value, FrozenPath):
+    return BaseFrozenPath(value)
 
   # Otherwise, it must be an Object. Cast to the mlir object.
   assert isinstance(value, Object)
@@ -120,6 +132,22 @@ class Map(BaseMap):
   def __iter__(self):
     for i in super().keys():
       yield (wrap_mlir_object(i), self.__getitem__(i))
+
+
+class FrozenBasePath(BaseFrozenBasePath):
+
+  def __init__(self, obj: BaseFrozenBasePath) -> None:
+    super().__init__(obj)
+
+  @staticmethod
+  def get_empty(context=None) -> "FrozenBasePath":
+    return FrozenBasePath(BaseFrozenBasePath.get_empty(context))
+
+
+class FrozenPath(BaseFrozenPath):
+
+  def __init__(self, obj: BaseFrozenPath) -> None:
+    super().__init__(obj)
 
 
 # Define the Object class by inheriting from the base implementation in C++.

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from ._om_ops_gen import *
-from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, Tuple as BaseTuple, Map as BaseMap, FrozenBasePath as BaseFrozenBasePath, FrozenPath as BaseFrozenPath, ClassType, ReferenceAttr, ListAttr, MapAttr, OMIntegerAttr
+from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, Tuple as BaseTuple, Map as BaseMap, BasePath as BaseBasePath, Path, ClassType, ReferenceAttr, ListAttr, MapAttr, OMIntegerAttr
 
 from ..ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr, IntegerAttr, IntegerType
 from ..support import attribute_to_var, var_to_attribute
@@ -34,11 +34,11 @@ def wrap_mlir_object(value):
   if isinstance(value, BaseMap):
     return Map(value)
 
-  if isinstance(value, BaseFrozenBasePath):
-    return FrozenBasePath(value)
+  if isinstance(value, BaseBasePath):
+    return BasePath(value)
 
-  if isinstance(value, BaseFrozenPath):
-    return FrozenPath(value)
+  if isinstance(value, Path):
+    return value
 
   # For objects, return an Object, wrapping the base implementation.
   assert isinstance(value, BaseObject)
@@ -67,11 +67,11 @@ def unwrap_python_object(value):
   if isinstance(value, Map):
     return BaseMap(value)
 
-  if isinstance(value, FrozenBasePath):
-    return BaseFrozenBasePath(value)
+  if isinstance(value, BasePath):
+    return BaseBasePath(value)
 
-  if isinstance(value, FrozenPath):
-    return BaseFrozenPath(value)
+  if isinstance(value, Path):
+    return value
 
   # Otherwise, it must be an Object. Cast to the mlir object.
   assert isinstance(value, Object)
@@ -134,20 +134,11 @@ class Map(BaseMap):
       yield (wrap_mlir_object(i), self.__getitem__(i))
 
 
-class FrozenBasePath(BaseFrozenBasePath):
-
-  def __init__(self, obj: BaseFrozenBasePath) -> None:
-    super().__init__(obj)
+class BasePath(BaseBasePath):
 
   @staticmethod
-  def get_empty(context=None) -> "FrozenBasePath":
-    return FrozenBasePath(BaseFrozenBasePath.get_empty(context))
-
-
-class FrozenPath(BaseFrozenPath):
-
-  def __init__(self, obj: BaseFrozenPath) -> None:
-    super().__init__(obj)
+  def get_empty(context=None) -> "BasePath":
+    return BasePath(BaseBasePath.get_empty(context))
 
 
 # Define the Object class by inheriting from the base implementation in C++.

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -292,20 +292,19 @@ bool omEvaluatorValueIsAMap(OMEvaluatorValue evaluatorValue) {
   return isa<evaluator::MapValue>(unwrap(evaluatorValue).get());
 }
 
-bool omEvaluatorValueIsAFrozenBasePath(OMEvaluatorValue evaluatorValue) {
+bool omEvaluatorValueIsABasePath(OMEvaluatorValue evaluatorValue) {
   return isa<evaluator::BasePathValue>(unwrap(evaluatorValue).get());
 }
 
-OMEvaluatorValue omEvaluatorFrozenBasePathGetEmpty(MlirContext context) {
+OMEvaluatorValue omEvaluatorBasePathGetEmpty(MlirContext context) {
   return wrap(std::make_shared<evaluator::BasePathValue>(unwrap(context)));
 }
 
-bool omEvaluatorValueIsAFrozenPath(OMEvaluatorValue evaluatorValue) {
+bool omEvaluatorValueIsAPath(OMEvaluatorValue evaluatorValue) {
   return isa<evaluator::PathValue>(unwrap(evaluatorValue).get());
 }
 
-MlirAttribute
-omEvaluatorFrozenPathGetAsString(OMEvaluatorValue evaluatorValue) {
+MlirAttribute omEvaluatorPathGetAsString(OMEvaluatorValue evaluatorValue) {
   const auto *path = cast<evaluator::PathValue>(unwrap(evaluatorValue).get());
   return wrap((Attribute)path->getAsString());
 }

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -292,6 +292,24 @@ bool omEvaluatorValueIsAMap(OMEvaluatorValue evaluatorValue) {
   return isa<evaluator::MapValue>(unwrap(evaluatorValue).get());
 }
 
+bool omEvaluatorValueIsAFrozenBasePath(OMEvaluatorValue evaluatorValue) {
+  return isa<evaluator::BasePathValue>(unwrap(evaluatorValue).get());
+}
+
+OMEvaluatorValue omEvaluatorFrozenBasePathGetEmpty(MlirContext context) {
+  return wrap(std::make_shared<evaluator::BasePathValue>(unwrap(context)));
+}
+
+bool omEvaluatorValueIsAFrozenPath(OMEvaluatorValue evaluatorValue) {
+  return isa<evaluator::PathValue>(unwrap(evaluatorValue).get());
+}
+
+MlirAttribute
+omEvaluatorFrozenPathGetAsString(OMEvaluatorValue evaluatorValue) {
+  const auto *path = cast<evaluator::PathValue>(unwrap(evaluatorValue).get());
+  return wrap((Attribute)path->getAsString());
+}
+
 //===----------------------------------------------------------------------===//
 // ReferenceAttr API.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This change adds evaluator support for frozen paths.

Two new EvaluatorValues have been added, one for BasePaths, which represent fragments of paths through the instance hiearchy, and one for Paths, which represent a full path to a hardware component.

When the evaluator instantiates an OM class, it is expected that it will usually have to pass in an empty basepath, which signifies that the class is at the top of the hierarchy. To facilitate this, we exposed the ability to create an empty basepath value in the python API.

Path values can be transformed in to strings, where in they are printed as FIRRTL style target paths. In the future, we may want a richer API. Deleted paths are represented as Path values with the targetKind attribute nulled out, which is handled specially in the string serializer.