### PR TITLE
[ESI] Fix operation deletion in services connecting

### DIFF
--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -295,10 +295,8 @@ struct ESIConnectServicesPass
   /// Convert both to_server and to_client requests into the canonical
   /// implementation connection request. This simplifies the rest of the pass
   /// and the service implementation code.
-  void convertReq(RequestToClientConnectionOp,
-                  SmallVectorImpl<Operation *> &opsToErase);
-  void convertReq(RequestToServerConnectionOp,
-                  SmallVectorImpl<Operation *> &opsToErase);
+  void convertReq(RequestToClientConnectionOp);
+  void convertReq(RequestToServerConnectionOp);
 
   /// "Bubble up" the specified requests to all of the instantiations of the
   /// module specified. Create and connect up ports to tunnel the ESI channels
@@ -324,14 +322,12 @@ void ESIConnectServicesPass::runOnOperation() {
   ModuleOp outerMod = getOperation();
   topLevelSyms.addDefinitions(outerMod);
 
-  SmallVector<Operation *> opsToErase;
   outerMod.walk([&](Operation *op) {
     if (auto req = dyn_cast<RequestToClientConnectionOp>(op))
-      convertReq(req, opsToErase);
-    if (auto req = dyn_cast<RequestToServerConnectionOp>(op))
-      convertReq(req, opsToErase);
+      convertReq(req);
+    else if (auto req = dyn_cast<RequestToServerConnectionOp>(op))
+      convertReq(req);
   });
-  llvm::for_each(opsToErase, [](auto *op) { op->erase(); });
 
   // Get a partially-ordered list of modules based on the instantiation DAG.
   // It's _very_ important that we process modules before their instantiations
@@ -351,8 +347,7 @@ void ESIConnectServicesPass::runOnOperation() {
 }
 
 void ESIConnectServicesPass::convertReq(
-    RequestToClientConnectionOp toClientReq,
-    SmallVectorImpl<Operation *> &opsToErase) {
+    RequestToClientConnectionOp toClientReq) {
   OpBuilder b(toClientReq);
   // to_client requests are already in the canonical form, just the wrong op.
   auto newReq = b.create<ServiceImplementConnReqOp>(
@@ -360,12 +355,12 @@ void ESIConnectServicesPass::convertReq(
       toClientReq.getServicePortAttr(), toClientReq.getClientNamePath());
   newReq->setDialectAttrs(toClientReq->getDialectAttrs());
   toClientReq.getToClient().replaceAllUsesWith(newReq.getToClient());
-  opsToErase.push_back(toClientReq);
+
+  toClientReq.erase();
 }
 
 void ESIConnectServicesPass::convertReq(
-    RequestToServerConnectionOp toServerReq,
-    SmallVectorImpl<Operation *> &opsToErase) {
+    RequestToServerConnectionOp toServerReq) {
   OpBuilder b(toServerReq);
   BackedgeBuilder beb(b, toServerReq.getLoc());
 
@@ -403,7 +398,7 @@ void ESIConnectServicesPass::convertReq(
                                       unpackToClientFromChannelsBackedges))
     be.setValue(v);
 
-  opsToErase.push_back(toServerReq);
+  toServerReq.erase();
 }
 
 LogicalResult ESIConnectServicesPass::process(hw::HWModuleLike mod) {


### PR DESCRIPTION
I read the documentation on `walk` and it indicates that it is safe to delete the op in the function. So I think the of the bug fixed in https://github.com/llvm/circt/commit/3a2151c0f064125c7777e1b06fba869d887bda1a was just a missing `else`.

Confirmed with LLVM memory sanitizers.