### PR TITLE
[FIRRTL] Update ExtractInstances to use the new instance symbol.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -701,9 +701,8 @@ void ExtractInstancesPass::extractInstances() {
           LLVM_DEBUG(llvm::dbgs() << "    - Re-rooting " << nlaPath[0] << "\n");
           assert(isa<InnerRefAttr>(nlaPath[0]) &&
                  "head of hierpath must be an InnerRefAttr");
-          nlaPath[0] =
-              InnerRefAttr::get(newParent.getModuleNameAttr(),
-                                cast<InnerRefAttr>(nlaPath[0]).getName());
+          nlaPath[0] = InnerRefAttr::get(newParent.getModuleNameAttr(),
+                                         getInnerSymName(newInst));
 
           if (instParentNode->hasOneUse()) {
             // Simply update the existing NLA since our parent is only


### PR DESCRIPTION
In the case we need need to make a new NLA for an instance that has moved past the module at which the old NLA was rooted, use the new instance's inner symbol name. This code path used the original inner symbol in the old NLA, but this would get out of sync if the new instance needed to get a new symbol in the namespace. Similar logic exists later in this method, but seems to have been missed here.