### PR TITLE
[ESI] Service requests now track AppIDs rather than instance hierarchy

### DIFF
--- a/include/circt-c/Dialect/ESI.h
+++ b/include/circt-c/Dialect/ESI.h
@@ -81,7 +81,8 @@ MLIR_CAPI_EXPORTED
 MlirAttribute circtESIAppIDAttrGet(MlirContext, MlirStringRef name,
                                    uint64_t index);
 MLIR_CAPI_EXPORTED MlirStringRef circtESIAppIDAttrGetName(MlirAttribute attr);
-MLIR_CAPI_EXPORTED uint64_t circtESIAppIDAttrGetIndex(MlirAttribute attr);
+MLIR_CAPI_EXPORTED bool circtESIAppIDAttrGetIndex(MlirAttribute attr,
+                                                  uint64_t *index);
 
 MLIR_CAPI_EXPORTED bool circtESIAttributeIsAnAppIDPathAttr(MlirAttribute);
 MLIR_CAPI_EXPORTED

--- a/include/circt/Dialect/ESI/ESIAppID.td
+++ b/include/circt/Dialect/ESI/ESIAppID.td
@@ -13,6 +13,8 @@
 #ifndef CIRCT_DIALECT_ESI_APPID_TD
 #define CIRCT_DIALECT_ESI_APPID_TD
 
+include "circt/Dialect/ESI/ESIDialect.td"
+
 include "mlir/IR/AttrTypeBase.td"
 
 def AppIDAttr : ESI_Attr<"AppID"> {

--- a/include/circt/Dialect/ESI/ESIAppID.td
+++ b/include/circt/Dialect/ESI/ESIAppID.td
@@ -22,16 +22,20 @@ def AppIDAttr : ESI_Attr<"AppID"> {
     Indended to make locating an instance easier in the instance hierarchy.
   }];
 
-  let parameters = (ins "StringAttr":$name, "uint64_t":$index);
-  let mnemonic = "appid";
-  let assemblyFormat = [{
-    `<` $name `[` $index `]` `>`
-  }];
+  let parameters = (ins "StringAttr":$name,
+                        OptionalParameter<"std::optional<uint64_t>">:$index);
+   let mnemonic = "appid";
+   let assemblyFormat = [{
+    `<` $name (`[` $index^ `]`)? `>`
+   }];
 
   let extraClassDeclaration = [{
     static constexpr StringRef AppIDAttrName = "esi.appid";
   }];
 }
+
+def AppIDArrayAttr :
+  TypedArrayAttrBase<AppIDAttr, "Array of AppIDs">;
 
 def AppIDPathAttr : ESI_Attr<"AppIDPath"> {
   let summary = "An application-specific hierarchical path through a design";

--- a/include/circt/Dialect/ESI/ESIOps.h
+++ b/include/circt/Dialect/ESI/ESIOps.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_ESI_ESIOPS_H
 #define CIRCT_DIALECT_ESI_ESIOPS_H
 
+#include "circt/Dialect/ESI/ESIAttributes.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
 #include "circt/Dialect/ESI/ESITypes.h"
 

--- a/include/circt/Dialect/ESI/ESIServices.td
+++ b/include/circt/Dialect/ESI/ESIServices.td
@@ -12,6 +12,7 @@
 include "mlir/IR/RegionKindInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
 
+include "circt/Dialect/ESI/ESIAppID.td"
 include "circt/Dialect/ESI/ESIChannels.td"
 include "circt/Dialect/ESI/ESIInterfaces.td"
 include "circt/Dialect/ESI/ESITypes.td"
@@ -147,10 +148,10 @@ def ServiceImplementConnReqOp : ESI_Op<"service.impl_req.req", [
   let summary = "The canonical form of a connection request";
 
   let arguments = (ins InnerRefAttr:$servicePort,
-                       StrArrayAttr:$clientNamePath);
+                       AppIDArrayAttr:$relativeAppIDPath);
   let results = (outs ChannelBundleType:$toClient);
   let assemblyFormat = [{
-    $servicePort `(` $clientNamePath `)`
+    $servicePort `(` $relativeAppIDPath `)`
       attr-dict `:` qualified(type($toClient))
   }];
 
@@ -165,9 +166,9 @@ def RequestToServerConnectionOp : ESI_Op<"service.req.to_server", [
 
   let arguments = (ins InnerRefAttr:$servicePort,
                        ChannelBundleType:$toServer,
-                       StrArrayAttr:$clientNamePath);
+                       AppIDAttr:$appID);
   let assemblyFormat = [{
-    $toServer `->` $servicePort `(` $clientNamePath `)`
+    $toServer `->` $servicePort `(` qualified($appID) `)`
       attr-dict `:` qualified(type($toServer))
   }];
 }
@@ -177,10 +178,10 @@ def RequestToClientConnectionOp : ESI_Op<"service.req.to_client", [
   let summary = "Request a connection to receive data";
 
   let arguments = (ins InnerRefAttr:$servicePort,
-                       StrArrayAttr:$clientNamePath);
+                       AppIDAttr:$appID);
   let results = (outs ChannelBundleType:$toClient);
   let assemblyFormat = [{
-    $servicePort `(` $clientNamePath `)`
+    $servicePort `(` qualified($appID) `)`
       attr-dict `:` qualified(type($toClient))
   }];
 }

--- a/integration_test/Bindings/Python/dialects/esi.py
+++ b/integration_test/Bindings/Python/dialects/esi.py
@@ -45,7 +45,7 @@ with Context() as ctx:
 
 # CHECK-LABEL: === testGen called with op:
 # CHECK:       %0:2 = esi.service.impl_req svc @HostComms impl as "test"(%clk) : (i1) -> (i8, !esi.bundle<[!esi.channel<i8> to "recv"]>) {
-# CHECK:         %2 = esi.service.impl_req.req <@HostComms::@Recv>(["m1", "loopback_tohw"]) : !esi.bundle<[!esi.channel<i8> to "recv"]>
+# CHECK:         %2 = esi.service.impl_req.req <@HostComms::@Recv>([#esi.appid<"loopback_tohw">]) : !esi.bundle<[!esi.channel<i8> to "recv"]>
 def testGen(reqOp: esi.ServiceImplementReqOp) -> bool:
   print("=== testGen called with op:")
   reqOp.print()
@@ -71,7 +71,7 @@ hw.module @MsTop (in %clk : i1, out chksum : i8) {
 }
 
 hw.module @MsLoopback (in %clk : i1) {
-  %dataIn = esi.service.req.to_client <@HostComms::@Recv> (["loopback_tohw"]) : !recvI8
+  %dataIn = esi.service.req.to_client <@HostComms::@Recv> (#esi.appid<"loopback_tohw">) : !recvI8
 }
 """)
   pm = passmanager.PassManager.parse("builtin.module(esi-connect-services)")

--- a/lib/Bindings/Python/ESIModule.cpp
+++ b/lib/Bindings/Python/ESIModule.cpp
@@ -170,8 +170,11 @@ void circt::python::populateDialectESISubmodule(py::module &m) {
                                    unwrap(circtESIAppIDAttrGetName(self));
                                return std::string(name.data(), name.size());
                              })
-      .def_property_readonly("index", [](MlirAttribute self) {
-        return circtESIAppIDAttrGetIndex(self);
+      .def_property_readonly("index", [](MlirAttribute self) -> py::object {
+        uint64_t index;
+        if (circtESIAppIDAttrGetIndex(self, &index))
+          return py::cast(index);
+        return py::none();
       });
 
   mlir_attribute_subclass(m, "AppIDPathAttr",

--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -145,8 +145,12 @@ MlirAttribute circtESIAppIDAttrGet(MlirContext ctxt, MlirStringRef name,
 MlirStringRef circtESIAppIDAttrGetName(MlirAttribute attr) {
   return wrap(unwrap(attr).cast<AppIDAttr>().getName().getValue());
 }
-uint64_t circtESIAppIDAttrGetIndex(MlirAttribute attr) {
-  return unwrap(attr).cast<AppIDAttr>().getIndex();
+bool circtESIAppIDAttrGetIndex(MlirAttribute attr, uint64_t *indexOut) {
+  std::optional<uint64_t> index = unwrap(attr).cast<AppIDAttr>().getIndex();
+  if (!index)
+    return false;
+  *indexOut = index.value();
+  return true;
 }
 
 bool circtESIAttributeIsAnAppIDPathAttr(MlirAttribute attr) {

--- a/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
+++ b/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
@@ -211,7 +211,8 @@ LogicalResult HandshakeLowerExtmemToHWPass::wrapESI(
       auto reqPack = b.create<esi::PackBundleOp>(loc, readPortInfo.type,
                                                  (Value)backedges[resIdx]);
       b.create<esi::RequestToServerConnectionOp>(
-          loc, readPortInfo.port, reqPack.getBundle(), b.getArrayAttr({}));
+          loc, readPortInfo.port, reqPack.getBundle(),
+          esi::AppIDAttr::get(ctx, b.getStringAttr("load"), {}));
       instanceArgsFromThisMem.push_back(
           reqPack.getFromChannels()
               [esi::RandomAccessMemoryDeclOp::RespDirChannelIdx]);
@@ -223,7 +224,8 @@ LogicalResult HandshakeLowerExtmemToHWPass::wrapESI(
       auto reqPack = b.create<esi::PackBundleOp>(loc, writePortInfo.type,
                                                  (Value)backedges[resIdx]);
       b.create<esi::RequestToServerConnectionOp>(
-          loc, writePortInfo.port, reqPack.getBundle(), b.getArrayAttr({}));
+          loc, writePortInfo.port, reqPack.getBundle(),
+          esi::AppIDAttr::get(ctx, b.getStringAttr("store"), {}));
       instanceArgsFromThisMem.push_back(
           reqPack.getFromChannels()
               [esi::RandomAccessMemoryDeclOp::RespDirChannelIdx]);

--- a/test/Dialect/ESI/errors.mlir
+++ b/test/Dialect/ESI/errors.mlir
@@ -52,7 +52,7 @@ esi.service.decl @HostComms {
 
 hw.module @Loopback (in %clk: i1, in %dataIn: !esi.bundle<[!esi.channel<i8> to "send"]>) {
   // expected-error @+1 {{Service port is not a to-server port}}
-  esi.service.req.to_server %dataIn -> <@HostComms::@Send> (["loopback_fromhw"]) : !esi.bundle<[!esi.channel<i8> to "send"]>
+  esi.service.req.to_server %dataIn -> <@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !esi.bundle<[!esi.channel<i8> to "send"]>
 }
 
 // -----
@@ -63,7 +63,7 @@ esi.service.decl @HostComms {
 
 hw.module @Loopback (in %clk: i1) {
   // expected-error @+1 {{Service port is not a to-client port}}
-  esi.service.req.to_client <@HostComms::@Send> (["loopback_fromhw"]) : !esi.bundle<[!esi.channel<i8> to "send"]>
+  esi.service.req.to_client <@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !esi.bundle<[!esi.channel<i8> to "send"]>
 }
 
 // -----
@@ -74,7 +74,7 @@ esi.service.decl @HostComms {
 
 hw.module @Loopback (in %clk: i1, in %dataIn: !esi.bundle<[!esi.channel<i8> to "send"]>) {
   // expected-error @+1 {{Request channel type does not match service port bundle channel type}}
-  esi.service.req.to_server %dataIn -> <@HostComms::@Send> (["loopback_fromhw"]) : !esi.bundle<[!esi.channel<i8> to "send"]>
+  esi.service.req.to_server %dataIn -> <@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !esi.bundle<[!esi.channel<i8> to "send"]>
 }
 
 // -----
@@ -85,7 +85,7 @@ esi.service.decl @HostComms {
 
 hw.module @Loopback (in %clk: i1, in %dataIn: !esi.bundle<[!esi.channel<i8> to "send", !esi.channel<i3> to "foo"]>) {
   // expected-error @+1 {{Request port bundle channel count does not match service port bundle channel count}}
-  esi.service.req.to_server %dataIn -> <@HostComms::@Send> (["loopback_fromhw"]) : !esi.bundle<[!esi.channel<i8> to "send", !esi.channel<i3> to "foo"]>
+  esi.service.req.to_server %dataIn -> <@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !esi.bundle<[!esi.channel<i8> to "send", !esi.channel<i3> to "foo"]>
 }
 
 // -----
@@ -95,14 +95,14 @@ esi.service.decl @HostComms {
 
 hw.module @Loopback (in %clk: i1) {
   // expected-error @+1 {{'esi.service.req.to_client' op Could not locate port "Recv"}}
-  %dataIn = esi.service.req.to_client <@HostComms::@Recv> (["loopback_tohw"]) : !esi.bundle<[!esi.channel<i1> from "foo"]>
+  %dataIn = esi.service.req.to_client <@HostComms::@Recv> (#esi.appid<"loopback_tohw">) : !esi.bundle<[!esi.channel<i1> from "foo"]>
 }
 
 // -----
 
 hw.module @Loopback (in %clk: i1) {
   // expected-error @+1 {{'esi.service.req.to_client' op Could not find service declaration @HostComms}}
-  %dataIn = esi.service.req.to_client <@HostComms::@Recv> (["loopback_tohw"]) : !esi.bundle<[!esi.channel<i1> from "foo"]>
+  %dataIn = esi.service.req.to_client <@HostComms::@Recv> (#esi.appid<"loopback_tohw">) : !esi.bundle<[!esi.channel<i1> from "foo"]>
 }
 
 // -----

--- a/test/Dialect/Handshake/lower-extmem-esi.mlir
+++ b/test/Dialect/Handshake/lower-extmem-esi.mlir
@@ -28,9 +28,9 @@
 // CHECK-SAME: out out0 : !esi.channel<i0>
 // CHECK-SAME: ) {
 //CHECK-NEXT:   %bundle, %data = esi.bundle.pack %main.mem_ld0.addr : !esi.bundle<[!esi.channel<i4> to "address", !esi.channel<i32> from "data"]>
-//CHECK-NEXT:   esi.service.req.to_server %bundle -> <@mem::@read>([]) : !esi.bundle<[!esi.channel<i4> to "address", !esi.channel<i32> from "data"]>
+//CHECK-NEXT:   esi.service.req.to_server %bundle -> <@mem::@read>(#esi.appid<"load">) : !esi.bundle<[!esi.channel<i4> to "address", !esi.channel<i32> from "data"]>
 //CHECK-NEXT:   %bundle_0, %ack = esi.bundle.pack %main.mem_st0 : !esi.bundle<[!esi.channel<!hw.struct<address: i4, data: i32>> to "req", !esi.channel<i0> from "ack"]>
-//CHECK-NEXT:   esi.service.req.to_server %bundle_0 -> <@mem::@write>([]) : !esi.bundle<[!esi.channel<!hw.struct<address: i4, data: i32>> to "req", !esi.channel<i0> from "ack"]>
+//CHECK-NEXT:   esi.service.req.to_server %bundle_0 -> <@mem::@write>(#esi.appid<"store">) : !esi.bundle<[!esi.channel<!hw.struct<address: i4, data: i32>> to "req", !esi.channel<i0> from "ack"]>
 //CHECK-NEXT:   %main.out0, %main.mem_ld0.addr, %main.mem_st0 = hw.instance "main" @__main_hw(arg0: %arg0: !esi.channel<i64>, arg1: %arg1: !esi.channel<i64>, v: %v: !esi.channel<i32>, mem_ld0.data: %data: !esi.channel<i32>, mem_st0.done: %ack: !esi.channel<i0>, argCtrl: %argCtrl: !esi.channel<i0>, clock: %clock: !seq.clock, reset: %reset: i1) -> (out0: !esi.channel<i0>, mem_ld0.addr: !esi.channel<i4>, mem_st0: !esi.channel<!hw.struct<address: i4, data: i32>>)
 //CHECK-NEXT:   hw.output %main.out0 : !esi.channel<i0>
 //CHECK-NEXT: }


### PR DESCRIPTION
This makes for far more sensible hierarchies. Also makes the index field of AppIDs optional.