### PR TITLE
[ExportVerilog] Make ExprEmitter sensitive to assignment-like context

### DIFF
--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -203,9 +203,9 @@ hw.module @TESTSIMPLE(in %a: i4, in %b: i4, in %c: i2, in %cond: i1,
 // CHECK-NEXT:      assign r37 = array2d[a][b] (* svAttr *);
 // CHECK-NEXT:      assign r38 = {3{a}};
 // CHECK-NEXT:      assign r39 = '{a: 1'h0, b: 1'h1};
-// CHECK-NEXT:      assign r40 = {2'h0, 2'h1, 2'h2, 2'h3};
+// CHECK-NEXT:      assign r40 = '{2'h0, 2'h1, 2'h2, 2'h3};
 // CHECK-NEXT:      assign r41 = '{1'h0};
-// CHECK-NEXT:      assign r42 = '{a: {1'h0}};
+// CHECK-NEXT:      assign r42 = '{a: '{1'h0}};
 // CHECK-NEXT:      assign r43 = structA.bar;
 // CHECK-NEXT:      assign r44 = '{foo: structA.foo, bar: a};
 // CHECK-NEXT:      assign r45 = _GEN_0;
@@ -1419,7 +1419,7 @@ hw.module @inline_bitcast_in_concat(in %in1: i7, in %in2: !hw.array<8xi4>, out o
 }
 
 // CHECK-LABEL: module DontInlineAggregateConstantIntoPorts(
-// CHECK:         wire [1:0][3:0] _GEN = {4'h0, 4'h1};
+// CHECK:         wire [1:0][3:0] _GEN = '{4'h0, 4'h1};
 // CHECK-NEXT:    Array i0 (
 // CHECK-NEXT:     .a (_GEN)
 // CHECK-NEXT:    );
@@ -1459,4 +1459,11 @@ hw.module @FooB(in %test: !unionB, out a: i16, out b: i14) {
   %0 = hw.union_extract %test["a"] : !unionB
   %1 = hw.union_extract %test["b"] : !unionB
   hw.output %0, %1 : i16, i14
+}
+
+// CHECK-LABEL: module Issue6275
+hw.module @Issue6275(out z: !hw.struct<a: !hw.array<2xstruct<b: i1>>>) {
+  // CHECK: assign z = '{a: '{'{b: 1'h0}, '{b: 1'h1}}};
+  %0 = hw.aggregate_constant [[[false], [true]]] : !hw.struct<a: !hw.array<2xstruct<b: i1>>>
+  hw.output %0 : !hw.struct<a: !hw.array<2xstruct<b: i1>>>
 }

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -483,7 +483,7 @@ hw.module @ArrayParamsInst() {
     arr: %arr : !hw.array<2 x i8>,
     uarr: %uarr : !hw.uarray<2 x i8>) -> ()
 }
-// CHECK:       wire [1:0][7:0] [[G0:_.*]] = {8'h1, 8'h2};
+// CHECK:       wire [1:0][7:0] [[G0:_.*]] = '{8'h1, 8'h2};
 // CHECK:       wire [7:0]      [[G1:_.*]][0:1] = '{8'h1, 8'h2};
 // CHECK:       ArrayParams #(
 // CHECK:         .param(2)


### PR DESCRIPTION
Make the `ExprEmitter` track whether the current expressions is being emitted into an assignment-like context. Fix the emission of struct and array aggregates to only use `'{...}` assignment patterns when the expression is in such an assignment-like context. These patterns cannot be used otherwise.

For packed arrays and structs, pick `'{...}` assignment patterns or `{...}` concatenation based on whether they are printed in an assignment-like context or not.

For unpacked arrays (and later unpacked structs), properly emit an error if they are being printed outside an assignment-like context. Unpacked values cannot be created inline arbitrarily. Instead, the `PrepareForEmission` pass has to spill them into a separate variable to artificially construct an assignment-like context (the initializer of or assignment to the spill declaration).

We currently seem to do the right thing for unpacked arrays already, such that `PrepareForEmission` does not have to do any additional spilling. Basically, by virtue of spilling arrays and structs to declarations anyway such that they can be accessed into, we are already working around the assignment-like context problem. However, as we build out more support for unpacked data types, we need to update `PrepareForEmission` to make it check if an expression requires an assignment-like context, and if it does, spill the declaration for that reason.

Fixes #6275.