### PR TITLE
[firtool] Move -g option into firtool library

### DIFF
--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -76,6 +76,10 @@ struct FirtoolOptions {
                      "Preserve all values")),
       llvm::cl::init(firrtl::PreserveValues::None), llvm::cl::cat(category)};
 
+  llvm::cl::opt<bool> enableDebugInfo{
+      "g", llvm::cl::desc("Enable the generation of debug information"),
+      llvm::cl::init(false), llvm::cl::cat(category)};
+
   // Build mode options.
   enum BuildMode { BuildModeDebug, BuildModeRelease };
   llvm::cl::opt<BuildMode> buildMode{

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -34,6 +34,10 @@ LogicalResult firtool::populatePreprocessTransforms(mlir::PassManager &pm,
       opt.disableAnnotationsUnknown, opt.disableAnnotationsClassless,
       opt.lowerAnnotationsNoRefTypePorts));
 
+  if (opt.enableDebugInfo)
+    pm.nest<firrtl::CircuitOp>().addNestedPass<firrtl::FModuleOp>(
+        firrtl::createMaterializeDebugInfoPass());
+
   return success();
 }
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -209,10 +209,6 @@ static cl::opt<std::string>
                 cl::init(""), cl::value_desc("filename"),
                 cl::cat(mainCategory));
 
-static cl::opt<bool>
-    enableDebugInfo("g", cl::desc("Enable the generation of debug information"),
-                    cl::init(false), cl::cat(mainCategory));
-
 static cl::opt<bool> emitHGLDD("emit-hgldd", cl::desc("Emit HGLDD debug info"),
                                cl::init(false), cl::cat(mainCategory));
 
@@ -376,10 +372,6 @@ static LogicalResult processBuffer(
 
   if (failed(firtool::populatePreprocessTransforms(pm, firtoolOptions)))
     return failure();
-
-  if (enableDebugInfo)
-    pm.nest<firrtl::CircuitOp>().addNestedPass<firrtl::FModuleOp>(
-        firrtl::createMaterializeDebugInfoPass());
 
   // If the user asked for --parse-only, stop after running LowerAnnotations.
   if (outputFormat == OutputParseOnly) {


### PR DESCRIPTION
Move the `-g` option from `firtool` the tool to `Firtool` the library. See discussion in #6309.