### PR TITLE
[ESI] Add `HasAppID` op interface

### DIFF
--- a/include/circt/Dialect/ESI/AppID.h
+++ b/include/circt/Dialect/ESI/AppID.h
@@ -24,6 +24,10 @@
 namespace circt {
 namespace esi {
 
+/// Get the AppID of a particular operation. Returns null if the operation does
+/// not have one.
+AppIDAttr getAppID(Operation *op);
+
 /// An index for resolving AppIDPaths to dynamic instances.
 class AppIDIndex {
 public:

--- a/include/circt/Dialect/ESI/ESIInterfaces.td
+++ b/include/circt/Dialect/ESI/ESIInterfaces.td
@@ -39,6 +39,24 @@ def ChannelOpInterface : OpInterface<"ChannelOpInterface"> {
   ];
 }
 
+def HasAppIDOpInterface : OpInterface<"HasAppID"> {
+  let cppNamespace = "circt::esi";
+  let description = [{
+    Op can be identified by an AppID.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      "Returns the AppID of this operation.",
+      "::circt::esi::AppIDAttr", "getAppID", (ins),
+        /*methodBody=*/"",
+        /*defaultImplementation=*/[{
+          return $_op.getAppID();
+        }]
+    >,
+  ];
+}
+
 //===----------------------------------------------------------------------===//
 //
 // Service-related interfaces.

--- a/include/circt/Dialect/ESI/ESIManifest.td
+++ b/include/circt/Dialect/ESI/ESIManifest.td
@@ -59,7 +59,8 @@ def BundleDirection : I32EnumAttr<"BundleDirection",
   let cppNamespace = "::circt::esi";
 }
 
-def ServiceRequestRecordOp : ESI_Op<"esi.manifest.req", []> {
+def ServiceRequestRecordOp : ESI_Op<"esi.manifest.req", [
+        DeclareOpInterfaceMethods<HasAppIDOpInterface>]> {
   let summary = "Record of a service request";
   let description = [{
     A record of a service request, including the requestor, the service
@@ -75,6 +76,12 @@ def ServiceRequestRecordOp : ESI_Op<"esi.manifest.req", []> {
   let assemblyFormat = [{
     qualified($requestor) `,` $servicePort `,` $direction `,` $bundleType
     attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    AppIDAttr getAppID() {
+      return getRequestor();
+    }
   }];
 }
 

--- a/include/circt/Dialect/ESI/ESIServices.td
+++ b/include/circt/Dialect/ESI/ESIServices.td
@@ -83,7 +83,8 @@ def ESIAnyType : ESI_Type<"Any"> {
   }];
 }
 
-def ServiceInstanceOp : ESI_Op<"service.instance"> {
+def ServiceInstanceOp : ESI_Op<"service.instance", [
+        DeclareOpInterfaceMethods<HasAppIDOpInterface>]> {
   let summary = "Instantiate a server module";
   let description = [{
     Instantiate a service adhering to a service declaration interface.
@@ -165,6 +166,7 @@ def ServiceImplementConnReqOp : ESI_Op<"service.impl_req.req", [
 }
 
 def RequestToServerConnectionOp : ESI_Op<"service.req.to_server", [
+        DeclareOpInterfaceMethods<HasAppIDOpInterface>,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Request a connection to send data";
 
@@ -178,6 +180,7 @@ def RequestToServerConnectionOp : ESI_Op<"service.req.to_server", [
 }
 
 def RequestToClientConnectionOp : ESI_Op<"service.req.to_client", [
+        DeclareOpInterfaceMethods<HasAppIDOpInterface>,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Request a connection to receive data";
 


### PR DESCRIPTION
Some ops have an AppID as an inherent attribute. This (along with the `getAppID` function) covers those cases.