### PR TITLE
[FIRRTL][LowerTypes] Keep the order of bundle fields in lowered `cat`

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1360,8 +1360,13 @@ bool TypeLoweringVisitor::visitExpr(BitCastOp op) {
       // Take the first field, or else Cat the previous fields with this field.
       if (uptoBits == 0)
         srcLoweredVal = src;
-      else
-        srcLoweredVal = builder->create<CatPrimOp>(src, srcLoweredVal);
+      else {
+        if (isa<BundleType>(op.getInput().getType())) {
+          srcLoweredVal = builder->create<CatPrimOp>(srcLoweredVal, src);
+        } else {
+          srcLoweredVal = builder->create<CatPrimOp>(src, srcLoweredVal);
+        }
+      }
       // Record the total bits already accumulated.
       uptoBits += fieldBitwidth;
     }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -992,8 +992,8 @@ firrtl.module private @is1436_FOO() {
     // CHECK-NEXT:  firrtl.strictconnect %d_ready, %[[v4]] : !firrtl.uint<1>
     // CHECK-NEXT:  firrtl.strictconnect %d_data, %[[v5]] : !firrtl.uint<2>
     %e = firrtl.bitcast %d : (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<2>>) -> (!firrtl.bundle<addr: uint<2>, data : vector<uint<1>, 2>>)
-    // CHECK-NEXT:  %[[v6:.+]] = firrtl.cat %d_ready, %d_valid : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-    // CHECK-NEXT:  %[[v7:.+]] = firrtl.cat %d_data, %[[v6]] : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
+    // CHECK-NEXT:  %[[v6:.+]] = firrtl.cat %d_valid, %d_ready : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+    // CHECK-NEXT:  %[[v7:.+]] = firrtl.cat %[[v6]], %d_data : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
     // CHECK-NEXT:  %[[v8:.+]] = firrtl.bits %[[v7]] 1 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
     // CHECK-NEXT:  %[[v9:.+]] = firrtl.bits %[[v7]] 3 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<2>
   %o1 = firrtl.subfield %e[data] : !firrtl.bundle<addr: uint<2>, data : vector<uint<1>, 2>>


### PR DESCRIPTION
Fixes #6124.

The lowering for `bitcast` is initially introduced in PR #1949, for aggregate type

```scala
class MyTest extends Bundle {
  val a0 = UInt(8.W)
  val a1 = UInt(8.W)
  val a2 = UInt(8.W)
  val a3 = UInt(8.W)
  val a4 = UInt(8.W)
}
```

it will be lowered to

fir
```mlir
%8 = firrtl.subfield %ram_MPORT_0[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a0: uint<8>, a1: uint<8>, a2: uint<8>, a3: uint<8>, a4: uint<8>>, mask: bundle<a0: uint<1>, a1: uint<1>, a2: uint<1>, a3: uint<1>, a4: uint<1>>>
%9 = firrtl.subfield %ram_MPORT[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<40>, mask: uint<5>>
%10 = firrtl.subfield %8[a0] : !firrtl.bundle<a0: uint<8>, a1: uint<8>, a2: uint<8>, a3: uint<8>, a4: uint<8>>
%11 = firrtl.subfield %8[a1] : !firrtl.bundle<a0: uint<8>, a1: uint<8>, a2: uint<8>, a3: uint<8>, a4: uint<8>>
%12 = firrtl.cat %11, %10 : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<16>
%13 = firrtl.subfield %8[a2] : !firrtl.bundle<a0: uint<8>, a1: uint<8>, a2: uint<8>, a3: uint<8>, a4: uint<8>>
%14 = firrtl.cat %13, %12 : (!firrtl.uint<8>, !firrtl.uint<16>) -> !firrtl.uint<24>
%15 = firrtl.subfield %8[a3] : !firrtl.bundle<a0: uint<8>, a1: uint<8>, a2: uint<8>, a3: uint<8>, a4: uint<8>>
%16 = firrtl.cat %15, %14 : (!firrtl.uint<8>, !firrtl.uint<24>) -> !firrtl.uint<32>
%17 = firrtl.subfield %8[a4] : !firrtl.bundle<a0: uint<8>, a1: uint<8>, a2: uint<8>, a3: uint<8>, a4: uint<8>>
%18 = firrtl.cat %17, %16 : (!firrtl.uint<8>, !firrtl.uint<32>) -> !firrtl.uint<40>
firrtl.strictconnect %9, %18 : !firrtl.uint<40>
```

hw
```mlir
%ram = seq.firmem 0, 1, undefined, port_order {prefix = ""} : <2 x 40, mask 5>
seq.firmem.write_port %ram[%wrap] = %3, clock %clock enable %27 mask %4 : <2 x 40, mask 5>, i5
%2 = seq.firmem.read_port %ram[%wrap_1], clock %clock : <2 x 40, mask 5>
%3 = comb.concat %19, %18, %17, %16, %15 : i8, i8, i8, i8, i8
%4 = comb.concat %14, %13, %12, %11, %10 : i1, i1, i1, i1, i1
// ...
%a0_5 = hw.struct_extract %io_enq_bits["a0"] : !hw.struct<a0: i8, a1: i8, a2: i8, a3: i8, a4: i8>
%15 = comb.mux bin %9, %a0, %a0_5 : i8
%a1_6 = hw.struct_extract %io_enq_bits["a1"] : !hw.struct<a0: i8, a1: i8, a2: i8, a3: i8, a4: i8>
%16 = comb.mux bin %9, %a1, %a1_6 : i8
%a2_7 = hw.struct_extract %io_enq_bits["a2"] : !hw.struct<a0: i8, a1: i8, a2: i8, a3: i8, a4: i8>
%17 = comb.mux bin %9, %a2, %a2_7 : i8
%a3_8 = hw.struct_extract %io_enq_bits["a3"] : !hw.struct<a0: i8, a1: i8, a2: i8, a3: i8, a4: i8>
%18 = comb.mux bin %9, %a3, %a3_8 : i8
%a4_9 = hw.struct_extract %io_enq_bits["a4"] : !hw.struct<a0: i8, a1: i8, a2: i8, a3: i8, a4: i8>
%19 = comb.mux bin %9, %a4, %a4_9 : i8
```

the order of aggregate fields is reversed, and caused the problem reported in #6124.

---

@poemonsense Could you check if this solves the problem in Verilator?

With this PR, the code you provided will be compiled as

```verilog
module Queue2_MyTest(
  input                                                                                                   clock,
                                                                                                          reset,
  output                                                                                                  io_enq_ready, // src/main/scala/chisel3/util/Decoupled.scala:257:14
  input  struct packed {logic [7:0] a0; logic [7:0] a1; logic [7:0] a2; logic [7:0] a3; logic [7:0] a4; } io_enq_bits,  // src/main/scala/chisel3/util/Decoupled.scala:257:14
  output                                                                                                  io_deq_valid, // src/main/scala/chisel3/util/Decoupled.scala:257:14
  output struct packed {logic [7:0] a0; logic [7:0] a1; logic [7:0] a2; logic [7:0] a3; logic [7:0] a4; } io_deq_bits   // src/main/scala/chisel3/util/Decoupled.scala:257:14
);

  wire [7:0]  _GEN;     // src/main/scala/chisel3/util/Decoupled.scala:258:91, :271:16, :272:24
  wire [7:0]  _GEN_0;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :271:16, :272:24
  wire [7:0]  _GEN_1;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :271:16, :272:24
  wire [7:0]  _GEN_2;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :271:16, :272:24
  wire [7:0]  _GEN_3;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :271:16, :272:24
  wire        _GEN_4;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :271:16, :272:24
  wire        _GEN_5;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :271:16, :272:24
  wire        _GEN_6;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :271:16, :272:24
  wire        _GEN_7;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :271:16, :272:24
  wire        _GEN_8;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :271:16, :272:24
  wire        full;     // src/main/scala/chisel3/util/Decoupled.scala:264:24
  wire [39:0] _ram_ext_R0_data; // src/main/scala/chisel3/util/Decoupled.scala:258:91
  wire struct packed {logic a0; logic a1; logic a2; logic a3; logic a4; } _GEN_9 =
    /*cast(bit)*/5'h0;
  wire
    struct packed {logic [7:0] a0; logic [7:0] a1; logic [7:0] a2; logic [7:0] a3; logic [7:0] a4; }
    _GEN_10 = /*cast(bit)*/40'h0;
  reg         wrap;     // src/main/scala/chisel3/util/Counter.scala:61:40
  reg         wrap_1;   // src/main/scala/chisel3/util/Counter.scala:61:40
  reg         maybe_full;       // src/main/scala/chisel3/util/Decoupled.scala:261:27
  wire        ptr_match = wrap == wrap_1;       // src/main/scala/chisel3/util/Counter.scala:61:40, src/main/scala/chisel3/util/Decoupled.scala:262:33
  wire        empty = ptr_match & ~maybe_full;  // src/main/scala/chisel3/util/Decoupled.scala:261:27, :262:33, :263:{25,28}
  assign full = ptr_match & maybe_full; // src/main/scala/chisel3/util/Decoupled.scala:261:27, :262:33, :264:24
  assign _GEN_8 = ~full | _GEN_9.a0;    // src/main/scala/chisel3/util/Decoupled.scala:258:91, :264:24, :271:16, :272:24, :288:19
  assign _GEN_7 = ~full | _GEN_9.a1;    // src/main/scala/chisel3/util/Decoupled.scala:258:91, :264:24, :271:16, :272:24, :288:19
  assign _GEN_6 = ~full | _GEN_9.a2;    // src/main/scala/chisel3/util/Decoupled.scala:258:91, :264:24, :271:16, :272:24, :288:19
  assign _GEN_5 = ~full | _GEN_9.a3;    // src/main/scala/chisel3/util/Decoupled.scala:258:91, :264:24, :271:16, :272:24, :288:19
  assign _GEN_4 = ~full | _GEN_9.a4;    // src/main/scala/chisel3/util/Decoupled.scala:258:91, :264:24, :271:16, :272:24, :288:19
  assign _GEN_3 = full ? _GEN_10.a0 : io_enq_bits.a0;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :264:24, :271:16, :272:24
  assign _GEN_2 = full ? _GEN_10.a1 : io_enq_bits.a1;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :264:24, :271:16, :272:24
  assign _GEN_1 = full ? _GEN_10.a2 : io_enq_bits.a2;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :264:24, :271:16, :272:24
  assign _GEN_0 = full ? _GEN_10.a3 : io_enq_bits.a3;   // src/main/scala/chisel3/util/Decoupled.scala:258:91, :264:24, :271:16, :272:24
  assign _GEN = full ? _GEN_10.a4 : io_enq_bits.a4;     // src/main/scala/chisel3/util/Decoupled.scala:258:91, :264:24, :271:16, :272:24

  // ...

  ram_2x40 ram_ext (    // src/main/scala/chisel3/util/Decoupled.scala:258:91
    .R0_addr (wrap_1),  // src/main/scala/chisel3/util/Counter.scala:61:40
    .R0_en   (1'h1),
    .R0_clk  (clock),
    .R0_data (_ram_ext_R0_data),
    .W0_addr (wrap),    // src/main/scala/chisel3/util/Counter.scala:61:40
    .W0_en   (~full),   // src/main/scala/chisel3/util/Decoupled.scala:264:24, :288:19
    .W0_clk  (clock),
    .W0_data ({_GEN_3, _GEN_2, _GEN_1, _GEN_0, _GEN}),  // src/main/scala/chisel3/util/Decoupled.scala:258:91, :271:16, :272:24
    .W0_mask ({_GEN_8, _GEN_7, _GEN_6, _GEN_5, _GEN_4}) // src/main/scala/chisel3/util/Decoupled.scala:258:91, :271:16, :272:24
  );
  assign io_enq_ready = ~full;  // src/main/scala/chisel3/util/Decoupled.scala:264:24, :288:19
  assign io_deq_valid = ~empty; // src/main/scala/chisel3/util/Decoupled.scala:263:25, :287:19
  assign io_deq_bits = /*cast(bit)*/_ram_ext_R0_data;   // src/main/scala/chisel3/util/Decoupled.scala:258:91
endmodule
```