### PR TITLE
Disable MLIR install of CIRCT projects

### DIFF
--- a/cmake/modules/AddCIRCT.cmake
+++ b/cmake/modules/AddCIRCT.cmake
@@ -33,7 +33,7 @@ function(add_circt_dialect_doc dialect dialect_namespace)
 endfunction()
 
 function(add_circt_library name)
-  add_mlir_library(${ARGV})
+  add_mlir_library(${ARGV} DISABLE_INSTALL)
   add_circt_library_install(${name})
 endfunction()
 


### PR DESCRIPTION
When depending on CIRCT libraries in a downstream project, CMake complains that  CIRCT libraries (like CIRCTFIRRTL) are in multiple export sets. This is because currently `add_circt_library` calls `add_mlir_library` without the `DISABLE_INSTALL` argument, resulting in those libraries being added to the MLIRTargets export set. CIRCT libraries should not be a part of MLIR's export sets, so I'm adding this argument. Note the following line adds the library to CIRCT's export set.