### PR TITLE
[FIRRTL] Add bool isFlip argument to walkGroundTypes callback

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -110,9 +110,11 @@ Value getValueByFieldID(ImplicitLocOpBuilder builder, Value value,
 
 /// Walk leaf ground types in the `firrtlType` and apply the function `fn`.
 /// The first argument of `fn` is field ID, and the second argument is a
-/// leaf ground type.
-void walkGroundTypes(FIRRTLType firrtlType,
-                     llvm::function_ref<void(uint64_t, FIRRTLBaseType)> fn);
+/// leaf ground type, and the third argument indicates if the element was
+/// flipped in a bundle.
+void walkGroundTypes(
+    FIRRTLType firrtlType,
+    llvm::function_ref<void(uint64_t, FIRRTLBaseType, bool)> fn);
 
 //===----------------------------------------------------------------------===//
 // Inner symbol and InnerRef helpers.

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -689,10 +689,10 @@ Value circt::firrtl::getValueByFieldID(ImplicitLocOpBuilder builder,
 
 /// Walk leaf ground types in the `firrtlType` and apply the function `fn`.
 /// The first argument of `fn` is field ID, and the second argument is a
-/// leaf ground type.
+/// leaf ground type and the third argument is a bool to indicate flip.
 void circt::firrtl::walkGroundTypes(
     FIRRTLType firrtlType,
-    llvm::function_ref<void(uint64_t, FIRRTLBaseType)> fn) {
+    llvm::function_ref<void(uint64_t, FIRRTLBaseType, bool)> fn) {
   auto type = getBaseType(firrtlType);
 
   // If this is not a base type, return.
@@ -701,36 +701,37 @@ void circt::firrtl::walkGroundTypes(
 
   // If this is a ground type, don't call recursive functions.
   if (type.isGround())
-    return fn(0, type);
+    return fn(0, type, false);
 
   uint64_t fieldID = 0;
-  auto recurse = [&](auto &&f, FIRRTLBaseType type) -> void {
+  auto recurse = [&](auto &&f, FIRRTLBaseType type, bool isFlip) -> void {
     FIRRTLTypeSwitch<FIRRTLBaseType>(type)
         .Case<BundleType>([&](BundleType bundle) {
           for (size_t i = 0, e = bundle.getNumElements(); i < e; ++i) {
             fieldID++;
-            f(f, bundle.getElementType(i));
+            f(f, bundle.getElementType(i),
+              isFlip ^ bundle.getElement(i).isFlip);
           }
         })
         .template Case<FVectorType>([&](FVectorType vector) {
           for (size_t i = 0, e = vector.getNumElements(); i < e; ++i) {
             fieldID++;
-            f(f, vector.getElementType());
+            f(f, vector.getElementType(), isFlip);
           }
         })
         .template Case<FEnumType>([&](FEnumType fenum) {
           for (size_t i = 0, e = fenum.getNumElements(); i < e; ++i) {
             fieldID++;
-            f(f, fenum.getElementType(i));
+            f(f, fenum.getElementType(i), isFlip);
           }
         })
         .Default([&](FIRRTLBaseType groundType) {
           assert(groundType.isGround() &&
                  "only ground types are expected here");
-          fn(fieldID, groundType);
+          fn(fieldID, groundType, isFlip);
         });
   };
-  recurse(recurse, type);
+  recurse(recurse, type, false);
 }
 
 /// Return the inner sym target for the specified value and fieldID.

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -199,7 +199,7 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
       return;
     }
 
-    walkGroundTypes(firrtlType, [&](uint64_t fieldID, auto) {
+    walkGroundTypes(firrtlType, [&](uint64_t fieldID, auto, auto) {
       markOverdefined(fieldRef.getSubField(fieldID));
     });
   }
@@ -257,7 +257,7 @@ struct IMConstPropPass : public IMConstPropBase<IMConstPropPass> {
     if (type_isa<PropertyType>(result.getType()))
       return mergeLatticeValue(fieldRefResult, fieldRefFrom);
     walkGroundTypes(type_cast<FIRRTLType>(result.getType()),
-                    [&](uint64_t fieldID, auto) {
+                    [&](uint64_t fieldID, auto, auto) {
                       mergeLatticeValue(fieldRefResult.getSubField(fieldID),
                                         fieldRefFrom.getSubField(fieldID));
                     });
@@ -518,7 +518,7 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
           fieldRefToUsers[fieldRef].push_back(&op);
           continue;
         }
-        walkGroundTypes(firrtlType, [&](uint64_t fieldID, auto type) {
+        walkGroundTypes(firrtlType, [&](uint64_t fieldID, auto type, auto) {
           fieldRefToUsers[fieldRef.getSubField(fieldID)].push_back(&op);
         });
       }
@@ -550,7 +550,7 @@ void IMConstPropPass::markConstantValueOp(OpTy op) {
 }
 
 void IMConstPropPass::markAggregateConstantOp(AggregateConstantOp constant) {
-  walkGroundTypes(constant.getType(), [&](uint64_t fieldID, auto) {
+  walkGroundTypes(constant.getType(), [&](uint64_t fieldID, auto, auto) {
     mergeLatticeValue(FieldRef(constant, fieldID),
                       LatticeValue(cast<IntegerAttr>(
                           constant.getAttributeFromFieldID(fieldID))));


### PR DESCRIPTION
Add an argument to the callback of `walkGroundTypes` to indicate if the ground type is flipped.
This is required for dataflow analysis of connections of flipped aggregate fields, demonstrated in https://github.com/llvm/circt/pull/5647