### PR TITLE
[CombToArith] Explicitly handle wide shifts to avoid UB

### DIFF
--- a/test/Conversion/CombToArith/comb-to-arith.mlir
+++ b/test/Conversion/CombToArith/comb-to-arith.mlir
@@ -13,12 +13,7 @@ hw.module @test(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32, in %
   %2 = comb.mods %arg0, %arg1 : i32
   // CHECK-NEXT: arith.remui %arg0, %arg1 : i32
   %3 = comb.modu %arg0, %arg1 : i32
-  // CHECK-NEXT: arith.shli %arg0, %arg1 : i32
-  %4 = comb.shl %arg0, %arg1 : i32
-  // CHECK-NEXT: arith.shrsi %arg0, %arg1 : i32
-  %5 = comb.shrs %arg0, %arg1 : i32
-  // CHECK-NEXT: arith.shrui %arg0, %arg1 : i32
-  %6 = comb.shru %arg0, %arg1 : i32
+
   // CHECK-NEXT: arith.subi %arg0, %arg1 : i32
   %7 = comb.sub %arg0, %arg1 : i32
 
@@ -106,3 +101,30 @@ hw.module @test(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32, in %
   %31 = comb.replicate %arg0 : (i32) -> i64
 }
 
+// CHECK-LABEL: @shlTest
+hw.module @shlTest(in %arg0: i32, in %arg1: i32) {
+  // CHECK-NEXT: [[CST0:%.+]] = arith.constant 0 : i32
+  // CHECK-NEXT: [[CST32:%.+]] = arith.constant 32 : i32
+  // CHECK-NEXT: [[V0:%.+]] = arith.shli %arg0, %arg1 : i32
+  // CHECK-NEXT: [[V1:%.+]] = arith.cmpi uge, %arg1, [[CST32]] : i32
+  // CHECK-NEXT: [[V2:%.+]] = arith.select [[V1]], [[CST0]], [[V0]] : i32
+  %shl = comb.shl %arg0, %arg1 : i32
+}
+
+// CHECK-LABEL: @shruTest
+hw.module @shruTest(in %arg0: i32, in %arg1: i32) {
+  // CHECK-NEXT: [[CST0:%.+]] = arith.constant 0 : i32
+  // CHECK-NEXT: [[CST32:%.+]] = arith.constant 32 : i32
+  // CHECK-NEXT: [[V0:%.+]] = arith.shrui %arg0, %arg1 : i32
+  // CHECK-NEXT: [[V1:%.+]] = arith.cmpi uge, %arg1, [[CST32]] : i32
+  // CHECK-NEXT: [[V2:%.+]] = arith.select [[V1]], [[CST0]], [[V0]] : i32
+  %shru = comb.shru %arg0, %arg1 : i32
+}
+
+// CHECK-LABEL: @shrsTest
+hw.module @shrsTest(in %arg0: i32, in %arg1: i32) {
+  // CHECK-NEXT: [[CST31:%.+]] = arith.constant 31 : i32
+  // CHECK-NEXT: [[V0:%.+]] = arith.minui %arg1, [[CST31]] : i32
+  // CHECK-NEXT: [[V1:%.+]] = arith.shrsi %arg0, [[V0]] : i32
+  %shrs = comb.shrs %arg0, %arg1 : i32
+}


### PR DESCRIPTION
As discussed during the last ODM, we expect shift operations in comb to produce defined values (matching the SV and VHDL behavior) even if the shift amount matches or exceeds the width of the LHS operand. In contrast, the shift operations in LLVM IR produce undefined values (poison) in this case. When converting from CIRCT MLIR to LLVM IR we lower to the MLIR arith dialect as an intermediate step. Currently, the semantics of the arith shift operations are not fully specified (see [[1]](https://discourse.llvm.org/t/rfc-define-precise-arith-semantics/65507),[[2]](https://discourse.llvm.org/t/rfc-arithmetic-vs-llvm-dialect/72477/7)). As a result we cannot safely convert comb shifts to arith shifts directly. This PR changes the conversion patterns for shift operations, which should result in defined behavior for all possible inputs. 

I have attached an end to end test for the arcilator pipeline, that produces a mismatch with the current implementation running on a x86_64 machine. I guess it would be useful to have this as a regression test, but I do not see an obvious way of integrating it in the testing infrastructure.

```
> ../circt/build/bin/arcilator --state-file=shifty.json shifty.mlir > shifty.ll
> ../circt/build/bin/arcilator-header-cpp.py shifty.json > shifty.h
> ../circt/llvm/build/bin/llc shifty.ll -O3 --filetype=obj -o shifty.o
> clang++ -I../circt/build/bin shifty.cpp shifty.o -O3 -o shifty.elf
> ./shifty.elf
FAIL b11111111111111111111111111111111 SHL 32 = b11111111111111111111111111111111 
FAIL b11111111111111111111111111111111 SHRU 32 = b11111111111111111111111111111111
FAIL b11111111111111111111111111111111 SHL 33 = b11111111111111111111111111111110 
FAIL b11111111111111111111111111111111 SHRU 33 = b01111111111111111111111111111111
FAIL b11111111111111111111111111111111 SHL 34 = b11111111111111111111111111111100
...
```

[shifty.cpp.txt](https://github.com/llvm/circt/files/13190704/shifty.cpp.txt)
[shifty.mlir.txt](https://github.com/llvm/circt/files/13190715/shifty.mlir.txt)