### PR TITLE
[CAPI][MSFT]: Remove include of C++ header in C-API

### DIFF
--- a/include/circt-c/Dialect/MSFT.h
+++ b/include/circt-c/Dialect/MSFT.h
@@ -11,7 +11,6 @@
 #ifndef CIRCT_C_DIALECT_MSFT_H
 #define CIRCT_C_DIALECT_MSFT_H
 
-#include "circt/Dialect/MSFT/MSFTDialect.h"
 #include "mlir-c/IR.h"
 #include "mlir-c/Pass.h"
 
@@ -89,8 +88,8 @@ typedef struct {
 
 enum CirctMSFTDirection { NONE = 0, ASC = 1, DESC = 2 };
 typedef struct {
-  CirctMSFTDirection columns;
-  CirctMSFTDirection rows;
+  enum CirctMSFTDirection columns;
+  enum CirctMSFTDirection rows;
 } CirctMSFTWalkOrder;
 
 MLIR_CAPI_EXPORTED CirctMSFTPlacementDB

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -9,6 +9,7 @@
 #include "DialectModules.h"
 
 #include "circt-c/Dialect/MSFT.h"
+#include "circt/Dialect/MSFT/MSFTDialect.h"
 
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 #include "mlir/CAPI/IR.h"


### PR DESCRIPTION
 I ran into issues trying to make bindings to the C API and including the MSFT dialect header, and it seems it accidentally includes a C++ header. There's also an issue with an `enum` tag not being used when referring to `CirctMSFTDirection` which I fixed. 