### PR TITLE
[Ibis] Mark all not-illegal ops as legal

### DIFF
--- a/lib/Dialect/Ibis/Transforms/IbisContainersToHW.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisContainersToHW.cpp
@@ -303,7 +303,7 @@ void ContainersToHWPass::runOnOperation() {
 
   ConversionTarget target(*ctx);
   target.addIllegalOp<ContainerOp, ContainerInstanceOp, ThisOp>();
-  target.addLegalDialect<hw::HWDialect>();
+  target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 
   // Parts of the conversion patterns will update operations in place, which in
   // turn requires the updated operations to be legalizeable. These in-place ops


### PR DESCRIPTION
Any operation which the dialect conversion framework so much as touches must be legalized. In general, when you're just trying to lower a few ops, you need to mark all other ops as legal.