### PR TITLE
[OM] Add Python bindings for path types.

### DIFF
--- a/include/circt-c/Dialect/OM.h
+++ b/include/circt-c/Dialect/OM.h
@@ -42,6 +42,18 @@ MLIR_CAPI_EXPORTED MlirTypeID omClassTypeGetTypeID(void);
 /// Get the name for a ClassType.
 MLIR_CAPI_EXPORTED MlirIdentifier omClassTypeGetName(MlirType type);
 
+/// Is the Type a FrozenBasePathType.
+MLIR_CAPI_EXPORTED bool omTypeIsAFrozenBasePathType(MlirType type);
+
+/// Get the TypeID for a FrozenBasePathType.
+MLIR_CAPI_EXPORTED MlirTypeID omFrozenBasePathTypeGetTypeID(void);
+
+/// Is the Type a FrozenPathType.
+MLIR_CAPI_EXPORTED bool omTypeIsAFrozenPathType(MlirType type);
+
+/// Get the TypeID for a FrozenPathType.
+MLIR_CAPI_EXPORTED MlirTypeID omFrozenPathTypeGetTypeID(void);
+
 /// Is the Type a MapType.
 MLIR_CAPI_EXPORTED bool omTypeIsAMapType(MlirType type);
 

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -218,10 +218,16 @@ print(obj.path)
 print(obj.deleted)
 # CHECK: OMDeleted
 
-paths_class = [cls for cls in module.body if hasattr(cls, "sym_name") and cls.sym_name.value == "Paths"][0]
+paths_class = [
+    cls for cls in module.body
+    if hasattr(cls, "sym_name") and cls.sym_name.value == "Paths"
+][0]
 base_path_type = paths_class.regions[0].blocks[0].arguments[0].type
 assert isinstance(base_path_type, om.BasePathType)
 
-paths_fields = [op for op in paths_class.regions[0].blocks[0] if isinstance(op, om.ClassFieldOp)]
+paths_fields = [
+    op for op in paths_class.regions[0].blocks[0]
+    if isinstance(op, om.ClassFieldOp)
+]
 for paths_field in paths_fields:
   assert isinstance(paths_field.value.type, om.PathType)

--- a/integration_test/Bindings/Python/dialects/om.py
+++ b/integration_test/Bindings/Python/dialects/om.py
@@ -217,3 +217,11 @@ print(obj.path)
 
 print(obj.deleted)
 # CHECK: OMDeleted
+
+paths_class = [cls for cls in module.body if hasattr(cls, "sym_name") and cls.sym_name.value == "Paths"][0]
+base_path_type = paths_class.regions[0].blocks[0].arguments[0].type
+assert isinstance(base_path_type, om.BasePathType)
+
+paths_fields = [op for op in paths_class.regions[0].blocks[0] if isinstance(op, om.ClassFieldOp)]
+for paths_field in paths_fields:
+  assert isinstance(paths_field.value.type, om.PathType)

--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -496,4 +496,12 @@ void circt::python::populateDialectOMSubmodule(py::module &m) {
         MlirStringRef name = mlirIdentifierStr(omClassTypeGetName(type));
         return std::string(name.data, name.length);
       });
+
+  // Add the BasePathType class definition.
+  mlir_type_subclass(m, "BasePathType", omTypeIsAFrozenBasePathType,
+                     omFrozenBasePathTypeGetTypeID);
+
+  // Add the PathType class definition.
+  mlir_type_subclass(m, "PathType", omTypeIsAFrozenPathType,
+                     omFrozenPathTypeGetTypeID);
 }

--- a/lib/Bindings/Python/dialects/om.py
+++ b/lib/Bindings/Python/dialects/om.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from ._om_ops_gen import *
-from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, Tuple as BaseTuple, Map as BaseMap, BasePath as BaseBasePath, Path, ClassType, ReferenceAttr, ListAttr, MapAttr, OMIntegerAttr
+from .._mlir_libs._circt._om import Evaluator as BaseEvaluator, Object as BaseObject, List as BaseList, Tuple as BaseTuple, Map as BaseMap, BasePath as BaseBasePath, BasePathType, Path, PathType, ClassType, ReferenceAttr, ListAttr, MapAttr, OMIntegerAttr
 
 from ..ir import Attribute, Diagnostic, DiagnosticSeverity, Module, StringAttr, IntegerAttr, IntegerType
 from ..support import attribute_to_var, var_to_attribute

--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -44,6 +44,26 @@ MlirIdentifier omClassTypeGetName(MlirType type) {
   return wrap(cast<ClassType>(unwrap(type)).getClassName().getAttr());
 }
 
+/// Is the Type a FrozenBasePathType.
+bool omTypeIsAFrozenBasePathType(MlirType type) {
+  return isa<FrozenBasePathType>(unwrap(type));
+}
+
+/// Get the TypeID for a FrozenBasePathType.
+MlirTypeID omFrozenBasePathTypeGetTypeID(void) {
+  return wrap(FrozenBasePathType::getTypeID());
+}
+
+/// Is the Type a FrozenPathType.
+bool omTypeIsAFrozenPathType(MlirType type) {
+  return isa<FrozenPathType>(unwrap(type));
+}
+
+/// Get the TypeID for a FrozenPathType.
+MlirTypeID omFrozenPathTypeGetTypeID(void) {
+  return wrap(FrozenPathType::getTypeID());
+}
+
 /// Is the Type a StringType.
 bool omTypeIsAStringType(MlirType type) {
   return unwrap(type).isa<StringType>();


### PR DESCRIPTION
In order to use the types in Python with isinstance, etc., we need to provide the mlir_type_subclass bindings. This adds the C API boilerplate and binds the types.