### PR TITLE
[HW] Resolve parametric types in the InstanceOp builder

### DIFF
--- a/include/circt/Dialect/HW/HWAttributes.h
+++ b/include/circt/Dialect/HW/HWAttributes.h
@@ -23,13 +23,14 @@ enum class PEO : uint32_t;
 /// has been evaluated based on the set of provided 'parameters'.
 mlir::FailureOr<mlir::Type> evaluateParametricType(mlir::Location loc,
                                                    mlir::ArrayAttr parameters,
-                                                   mlir::Type type);
+                                                   mlir::Type type,
+                                                   bool emitErrors = true);
 
 /// Evaluates a parametric attribute (param.decl.ref/param.expr) based on a set
 /// of provided parameter values.
 mlir::FailureOr<mlir::TypedAttr>
 evaluateParametricAttr(mlir::Location loc, mlir::ArrayAttr parameters,
-                       mlir::Attribute paramAttr);
+                       mlir::Attribute paramAttr, bool emitErrors = true);
 
 /// Returns true if any part of t is parametric.
 bool isParametricType(mlir::Type t);

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -274,7 +274,7 @@ def ModuleTypeImpl : HWType<"Module"> {
     size_t getPortIdForInputId(size_t);
     size_t getPortIdForOutputId(size_t);
     FailureOr<ModuleType> resolveParametricTypes(
-      ArrayAttr parameters, LocationAttr loc);
+      ArrayAttr parameters, LocationAttr loc, bool emitErrors);
   }];
 }
 

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -273,6 +273,8 @@ def ModuleTypeImpl : HWType<"Module"> {
     size_t getOutputIdForPortId(size_t);
     size_t getPortIdForInputId(size_t);
     size_t getPortIdForOutputId(size_t);
+    FailureOr<ModuleType> resolveParametricTypes(
+      ArrayAttr parameters, LocationAttr loc);
   }];
 }
 

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1413,6 +1413,10 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
   auto mod = cast<hw::HWModuleLike>(module);
   auto argNames = builder.getArrayAttr(mod.getInputNames());
   auto resultNames = builder.getArrayAttr(mod.getOutputNames());
+
+  // Try to resolve the parameterized module type. If failed, use the module's
+  // parmeterized type. If the client doesn't fix this error, the verifier will
+  // fail.
   ModuleType modType = mod.getHWModuleType();
   FailureOr<ModuleType> resolvedModType = modType.resolveParametricTypes(
       parameters, result.location, /*emitErrors=*/false);

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1413,12 +1413,13 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
   auto mod = cast<hw::HWModuleLike>(module);
   auto argNames = builder.getArrayAttr(mod.getInputNames());
   auto resultNames = builder.getArrayAttr(mod.getOutputNames());
-  FailureOr<ModuleType> resolvedModType =
-      mod.getHWModuleType().resolveParametricTypes(parameters, result.location);
-  if (failed(resolvedModType))
-    return;
-  FunctionType modType = resolvedModType->getFuncType();
-  build(builder, result, modType.getResults(), name,
+  ModuleType modType = mod.getHWModuleType();
+  FailureOr<ModuleType> resolvedModType = modType.resolveParametricTypes(
+      parameters, result.location, /*emitErrors=*/false);
+  if (succeeded(resolvedModType))
+    modType = *resolvedModType;
+  FunctionType funcType = resolvedModType->getFuncType();
+  build(builder, result, funcType.getResults(), name,
         FlatSymbolRefAttr::get(SymbolTable::getSymbolName(module)), inputs,
         argNames, resultNames, parameters, innerSym);
 }

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1413,7 +1413,11 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
   auto mod = cast<hw::HWModuleLike>(module);
   auto argNames = builder.getArrayAttr(mod.getInputNames());
   auto resultNames = builder.getArrayAttr(mod.getOutputNames());
-  FunctionType modType = mod.getHWModuleType().getFuncType();
+  FailureOr<ModuleType> resolvedModType =
+      mod.getHWModuleType().resolveParametricTypes(parameters, result.location);
+  if (failed(resolvedModType))
+    return;
+  FunctionType modType = resolvedModType->getFuncType();
   build(builder, result, modType.getResults(), name,
         FlatSymbolRefAttr::get(SymbolTable::getSymbolName(module)), inputs,
         argNames, resultNames, parameters, innerSym);

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -987,6 +987,21 @@ FunctionType ModuleType::getFuncType() {
   return FunctionType::get(getContext(), inputs, outputs);
 }
 
+FailureOr<ModuleType> ModuleType::resolveParametricTypes(ArrayAttr parameters,
+                                                         LocationAttr loc) {
+  SmallVector<ModulePort, 8> resolvedPorts;
+  for (ModulePort port : getPorts()) {
+    FailureOr<Type> resolvedType =
+        evaluateParametricType(loc, parameters, port.type);
+    if (failed(resolvedType))
+      // What should I do here?
+      return failure();
+    port.type = *resolvedType;
+    resolvedPorts.push_back(port);
+  }
+  return ModuleType::get(getContext(), resolvedPorts);
+}
+
 static StringRef dirToStr(ModulePort::Direction dir) {
   switch (dir) {
   case ModulePort::Direction::Input:

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -988,11 +988,12 @@ FunctionType ModuleType::getFuncType() {
 }
 
 FailureOr<ModuleType> ModuleType::resolveParametricTypes(ArrayAttr parameters,
-                                                         LocationAttr loc) {
+                                                         LocationAttr loc,
+                                                         bool emitErrors) {
   SmallVector<ModulePort, 8> resolvedPorts;
   for (ModulePort port : getPorts()) {
     FailureOr<Type> resolvedType =
-        evaluateParametricType(loc, parameters, port.type);
+        evaluateParametricType(loc, parameters, port.type, emitErrors);
     if (failed(resolvedType))
       // What should I do here?
       return failure();

--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -995,7 +995,6 @@ FailureOr<ModuleType> ModuleType::resolveParametricTypes(ArrayAttr parameters,
     FailureOr<Type> resolvedType =
         evaluateParametricType(loc, parameters, port.type, emitErrors);
     if (failed(resolvedType))
-      // What should I do here?
       return failure();
     port.type = *resolvedType;
     resolvedPorts.push_back(port);


### PR DESCRIPTION
Have the instance op builder try to resolve any parametric types in the module. If it fails, fallback to the parameterized module types and don't print an error message.