### PR TITLE
[Arc] Align >=128-bit integers to 16 bytes

### DIFF
--- a/lib/Dialect/Arc/ArcTypes.cpp
+++ b/lib/Dialect/Arc/ArcTypes.cpp
@@ -22,7 +22,7 @@ using namespace mlir;
 
 unsigned MemoryType::getStride() {
   unsigned stride = (getWordType().getWidth() + 7) / 8;
-  return llvm::alignToPowerOf2(stride, llvm::bit_ceil(std::min(stride, 8U)));
+  return llvm::alignToPowerOf2(stride, llvm::bit_ceil(std::min(stride, 16U)));
 }
 
 void ArcDialect::registerTypes() {

--- a/lib/Dialect/Arc/Transforms/AllocateState.cpp
+++ b/lib/Dialect/Arc/Transforms/AllocateState.cpp
@@ -76,8 +76,8 @@ void AllocateStatePass::allocateOps(Value storage, Block *block,
   // most.
   unsigned currentByte = 0;
   auto allocBytes = [&](unsigned numBytes) {
-    currentByte = llvm::alignToPowerOf2(currentByte,
-                                        llvm::bit_ceil(std::min(numBytes, 8U)));
+    currentByte = llvm::alignToPowerOf2(
+        currentByte, llvm::bit_ceil(std::min(numBytes, 16U)));
     unsigned offset = currentByte;
     currentByte += numBytes;
     return offset;

--- a/test/Dialect/Arc/allocate-state.mlir
+++ b/test/Dialect/Arc/allocate-state.mlir
@@ -3,17 +3,18 @@
 // CHECK-LABEL: arc.model "test"
 arc.model "test" {
 ^bb0(%arg0: !arc.storage):
-  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage<5724>):
+  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage<5780>):
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][0] : (!arc.storage<5724>) -> !arc.storage<1143>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][0] : (!arc.storage<5780>) -> !arc.storage<1159>
   // CHECK-NEXT: arc.passthrough {
   arc.passthrough {
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][0] : !arc.storage<5724> -> !arc.storage<1143>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][0] : !arc.storage<5780> -> !arc.storage<1159>
     %0 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i8>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i16>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i32>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i64>
+    arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1> // make sure the current offset is not already 16-byte aligned
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i9001>
     %1 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
     // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 0 : i32}
@@ -22,15 +23,16 @@ arc.model "test" {
     // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 4 : i32}
     // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 8 : i32}
     // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 16 : i32}
-    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 1142 : i32}
+    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 32 : i32}
+    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 1158 : i32}
     // CHECK-NEXT: scf.execute_region {
     scf.execute_region {
       arc.state_read %0 : <i1>
-      // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][0] : !arc.storage<5724> -> !arc.storage<1143>
-      // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][0] : !arc.storage<1143> -> !arc.state<i1>
+      // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][0] : !arc.storage<5780> -> !arc.storage<1159>
+      // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][0] : !arc.storage<1159> -> !arc.state<i1>
       // CHECK-NEXT: arc.state_read [[STATE]] : <i1>
       arc.state_read %1 : <i1>
-      // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][1142] : !arc.storage<1143> -> !arc.state<i1>
+      // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][1158] : !arc.storage<1159> -> !arc.state<i1>
       // CHECK-NEXT: arc.state_read [[STATE]] : <i1>
       scf.yield
       // CHECK-NEXT: scf.yield
@@ -39,10 +41,10 @@ arc.model "test" {
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][1144] : (!arc.storage<5724>) -> !arc.storage<4577>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][1168] : (!arc.storage<5780>) -> !arc.storage<4609>
   // CHECK-NEXT: arc.passthrough {
   arc.passthrough {
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][1144] : !arc.storage<5724> -> !arc.storage<4577>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][1168] : !arc.storage<5780> -> !arc.storage<4609>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i1, i1>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i8, i1>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i16, i1>
@@ -60,18 +62,18 @@ arc.model "test" {
     // CHECK-SAME: -> !arc.memory<4 x i32, i1>
     // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 32 : i32, stride = 8 : i32}
     // CHECK-SAME: -> !arc.memory<4 x i64, i1>
-    // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 64 : i32, stride = 1128 : i32}
+    // CHECK-NEXT: arc.alloc_memory [[SUBPTR]] {offset = 64 : i32, stride = 1136 : i32}
     // CHECK-SAME: -> !arc.memory<4 x i9001, i1>
-    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 4576 : i32}
+    // CHECK-NEXT: arc.alloc_state [[SUBPTR]] {offset = 4608 : i32}
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][5722] : (!arc.storage<5724>) -> !arc.storage<2>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][5778] : (!arc.storage<5780>) -> !arc.storage<2>
   // CHECK-NEXT: arc.passthrough {
   arc.passthrough {
     arc.root_input "x", %arg0 : (!arc.storage) -> !arc.state<i1>
     arc.root_output "y", %arg0 : (!arc.storage) -> !arc.state<i1>
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][5722] : !arc.storage<5724> -> !arc.storage<2>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][5778] : !arc.storage<5780> -> !arc.storage<2>
     // CHECK-NEXT: arc.root_input "x", [[SUBPTR]] {offset = 0 : i32}
     // CHECK-NEXT: arc.root_output "y", [[SUBPTR]] {offset = 1 : i32}
   }


### PR DESCRIPTION
This is a fix for an issue introduced by llvm/llvm-project@a21abc782a8e1cb718a10c471a3b634f3102fc1c via b895069. The alignment in LLVM was changed from 8 to 16 bytes but in Arc we still allocated memory according to the old alignment, thus leading to overlapping memory accesses (a store to a HW memory could modify the state of a register stored after it in memory).