### PR TITLE
[Arc] Support lowering of seq clock type and conversion operations

### DIFF
--- a/lib/Conversion/ArcToLLVM/CMakeLists.txt
+++ b/lib/Conversion/ArcToLLVM/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_conversion_library(CIRCTArcToLLVM
   LINK_LIBS PUBLIC
   CIRCTArc
   CIRCTComb
+  CIRCTSeq
   CIRCTCombToLLVM
   CIRCTHWToLLVM
   MLIRArithToLLVM

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -170,3 +170,15 @@ func.func @funcCallOp(%arg0: i32) -> (i32, i32) {
 func.func @dummyFuncCallee(%arg0: i32) -> (i32, i32) {
   func.return %arg0, %arg0 : i32, i32
 }
+
+func.func @seqClocks(%clk1: !seq.clock, %clk2: !seq.clock) -> !seq.clock {
+  %0 = seq.from_clock %clk1
+  %1 = seq.from_clock %clk2
+  %2 = arith.xori %0, %1 : i1
+  %3 = seq.to_clock %2
+  return %3 : !seq.clock
+}
+// CHECK-LABEL: llvm.func @seqClocks
+//  CHECK-SAME: ([[CLK1:%.+]]: i1, [[CLK2:%.+]]: i1)
+//       CHECK: [[RES:%.+]] = llvm.xor [[CLK1]], [[CLK2]]
+//       CHECK: llvm.return [[RES]] : i1


### PR DESCRIPTION
Recently, arc operations where updated to use the `!seq.clock` type instead of `i1` values. However, if there are clock gates present that aren't explicitly represented using the clock gate operation, or some other arithmetic is performed on clocks, the lowering will fail because `!seq.clock` arguments and conversion operations would fail to legalize.

This commit adds conversion patterns for the `to_clock` and `from_clock` operations and the clock type itself.

Should we introduce a new `SeqToLLVM` conversion pass for this simple conversion or is it fine like that for now?