### PR TITLE
[Ibis] Refactor to use inner symbols

### DIFF
--- a/include/circt/Dialect/Ibis/IbisDialect.td
+++ b/include/circt/Dialect/Ibis/IbisDialect.td
@@ -32,7 +32,7 @@ def IbisDialect : Dialect {
   }];
 
   // Needed for ibis.pipeline_header
-  let dependentDialects = ["seq::SeqDialect"];
+  let dependentDialects = ["seq::SeqDialect", "hw::HWDialect"];
 }
 
 #endif // CIRCT_DIALECT_IBIS_DIALECT_TD

--- a/include/circt/Dialect/Ibis/IbisInterfaces.td
+++ b/include/circt/Dialect/Ibis/IbisInterfaces.td
@@ -35,6 +35,8 @@ def PortOpInterface : OpInterface<"PortOpInterface"> {
   ];
 }
 
+// TODO: @mortbopet: should inherit from InnerSymTable once we have a way to
+// support nested symbol tables.
 def ScopeOpInterface : OpInterface<"ScopeOpInterface", [Symbol]> {
   let cppNamespace = "circt::ibis";
   let description = [{
@@ -74,12 +76,29 @@ def ScopeOpInterface : OpInterface<"ScopeOpInterface", [Symbol]> {
       }]
     >,
     InterfaceMethod<
+      "Lookup an inner symbol in the scope",
+      "Operation*", "lookupInnerSym",
+      (ins "llvm::StringRef":$symName),
+      "",
+      [{
+        // TODO: @mortbopet: fix once we have a way to do nested symbol
+        // tables, and by extension, do nested symbol table lookup inside this
+        // scope.
+        // Until then, brute-force scan the inner symbol ops for a match.
+        for (auto op : $_op.getBodyBlock()->template getOps<hw::InnerSymbolOpInterface>()) {
+          if (*op.getInnerName() == symName)
+            return op;
+        }
+        return nullptr;
+      }]
+    >,
+    InterfaceMethod<
       "Lookup a port in the scope",
       "ibis::PortOpInterface", "lookupPort",
-      (ins "llvm::StringRef":$portName), [{
-        // @teqdruid TODO: make this more efficient using
-        // innersymtablecollection when that's available to non-firrtl dialects.
-        return dyn_cast_or_null<ibis::PortOpInterface>(SymbolTable::lookupSymbolIn($_op, portName));
+      (ins "llvm::StringRef":$portName),
+      [{}],
+      [{
+        return dyn_cast_or_null<ibis::PortOpInterface>(this->lookupInnerSym(portName));
       }]
     >
   ];
@@ -97,6 +116,56 @@ def BlockOpInterface : OpInterface<"BlockOpInterface"> {
       "llvm::SmallVector<Type>", "getInternalResultTypes",
       (ins)>
   ];
+}
+
+def MethodLikeOpInterface : OpInterface<"MethodLikeOpInterface"> {
+  let cppNamespace = "circt::ibis";
+  let description = [{
+    An interface for Ibis operations that act like callable methods.
+    This partially implements similar functionality to the FunctionLike interface
+    which cannot be used for Ibis Methods due to Ibis methods defining InnerSym's
+    whereas the FunctionLike interface is built on the assumption of the function
+    defining a Symbol (i.e. inherits from the Symbol interface).
+  }];
+
+  let methods = [
+    InterfaceMethod<[{
+      Returns the type of the method.
+    }],
+    "::mlir::FunctionType", "getFunctionType">,
+    InterfaceMethod<[{
+      Returns the name of the method.
+    }],
+    "::mlir::StringAttr", "getMethodName">
+  ];
+
+  let extraClassDeclaration = [{
+    //===------------------------------------------------------------------===//
+    // FunctionOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// Returns the argument types of this function.
+    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+
+    /// Returns the result types of this function.
+    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+  }];
+
+  let extraSharedClassDeclaration = [{
+    /// Returns the entry block of the function.
+    Block* getBodyBlock() {
+      auto& region = getFunctionBody();
+      assert(!region.empty() && "expected non-empty function body");
+      return &region.front();
+    }
+
+    using BlockArgListType = Region::BlockArgListType;
+    BlockArgListType getArguments() { return getFunctionBody().getArguments(); }
+    Region &getFunctionBody() {
+      assert($_op->getNumRegions() == 1 && "expected one region");
+      return $_op->getRegion(0);
+    }
+  }];
 }
 
 #endif // CIRCT_DIALECT_IBIS_INTERFACES_TD

--- a/include/circt/Dialect/Ibis/IbisOps.h
+++ b/include/circt/Dialect/Ibis/IbisOps.h
@@ -10,6 +10,7 @@
 #define CIRCT_DIALECT_IBIS_IBISOPS_H
 
 #include "circt/Dialect/DC/DCTypes.h"
+#include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/Handshake/HandshakeInterfaces.h"
 #include "circt/Dialect/Ibis/IbisDialect.h"
 #include "circt/Dialect/Ibis/IbisTypes.h"

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -18,13 +18,14 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
 
-include  "circt/Dialect/Handshake/HandshakeInterfaces.td"
+include "circt/Dialect/Handshake/HandshakeInterfaces.td"
 include "circt/Dialect/HW/HWOpInterfaces.td"
 include "circt/Dialect/Ibis/IbisInterfaces.td"
 include "circt/Dialect/Ibis/IbisTypes.td"
 include "circt/Dialect/Handshake/HandshakeInterfaces.td"
 include "circt/Dialect/Seq/SeqTypes.td"
 include "circt/Support/InstanceGraphInterface.td"
+include "circt/Dialect/HW/HWTypes.td"
 
 class IbisOp<string mnemonic, list<Trait> traits = []> :
     Op<IbisDialect, mnemonic, traits>;
@@ -35,7 +36,8 @@ def HasCustomSSAName :
 def ClassOp : IbisOp<"class", [
     Symbol,
     IsolatedFromAbove, RegionKindInterface,
-    SymbolTable, SingleBlock,
+    InnerSymbolTable,
+    SingleBlock,
     NoTerminator, ScopeOpInterface,
     InstanceGraphModuleOpInterface,
     HasParent<"mlir::ModuleOp">]> {
@@ -72,21 +74,21 @@ def ClassOp : IbisOp<"class", [
 }
 
 class InstanceOpBase<string mnemonic> : IbisOp<mnemonic, [
-    Symbol,
+    DeclareOpInterfaceMethods<InnerSymbol,["getTargetResultIndex"]>,
     DeclareOpInterfaceMethods<SymbolUserOpInterface>,
     InstanceGraphInstanceOpInterface,
     HasCustomSSAName
 ]> {
 
-  let arguments = (ins SymbolNameAttr:$sym_name, FlatSymbolRefAttr:$targetName);
+  let arguments = (ins InnerSymAttr:$inner_sym, FlatSymbolRefAttr:$targetName);
   let results = (outs ScopeRefType:$scopeRef);
   let assemblyFormat = [{
-    $sym_name `,` $targetName attr-dict
+    $inner_sym `,` $targetName attr-dict
     custom<ScopeRefFromName>(type($scopeRef), ref($targetName))
   }];
 
   let builders = [
-    OpBuilder<(ins "StringAttr":$instanceName, "StringAttr":$targetName), [{
+    OpBuilder<(ins "hw::InnerSymAttr":$instanceName, "StringAttr":$targetName), [{
       build($_builder, $_state, $_builder.getType<ScopeRefType>(targetName),
         instanceName, targetName);
     }]>
@@ -96,11 +98,11 @@ class InstanceOpBase<string mnemonic> : IbisOp<mnemonic, [
 
   let extraClassDeclaration = extraInstanceClassDeclaration # [{
     llvm::StringRef getInstanceName() {
-      return getSymName();
+      return getInnerSym().getSymName().strref();
     }
 
     mlir::StringAttr getInstanceNameAttr() {
-      return getSymNameAttr();
+      return getInnerSymAttr().getSymName();
     }
 
     llvm::StringRef getModuleName() {
@@ -109,6 +111,14 @@ class InstanceOpBase<string mnemonic> : IbisOp<mnemonic, [
 
     mlir::FlatSymbolRefAttr getModuleNameAttr() {
       return getTargetNameAttr();
+    }
+  }];
+
+  code extraInstanceClassDefinition = ?;
+  let extraClassDefinition = extraInstanceClassDefinition # [{
+    // For hw:InnerSymbol - the symbol targets the operation and not any result.
+    std::optional<size_t> $cppClass::getTargetResultIndex() {
+      return std::nullopt;
     }
   }];
 }
@@ -127,7 +137,7 @@ def InstanceOp : InstanceOpBase<"instance"> {
     Operation* getReferencedModule(SymbolTable&);
   }];
 
-  let extraClassDefinition = [{
+  let extraInstanceClassDefinition = [{
     Operation* InstanceOp::getReferencedModuleSlow() {
       return getClass();
     }
@@ -142,11 +152,15 @@ def InstanceOp : InstanceOpBase<"instance"> {
 class MethodOpBase<string mnemonic, list<Trait> traits = []> :
     IbisOp<mnemonic, !listconcat(traits, [
       IsolatedFromAbove,
-      Symbol, FunctionOpInterface,
-      HasParent<"ClassOp">
+      DeclareOpInterfaceMethods<InnerSymbol,["getTargetResultIndex"]>,
+      // FunctionOpInterface @mortbopet: This is very much a function-like
+      // operation, but FunctionOpInterface inherits from Symbol which is
+      // incompatible with the fact that ibis methods define inner symbols.
+      MethodLikeOpInterface,
+      HasParent<"ClassOp">,
   ])> {
 
-  let arguments = (ins SymbolNameAttr:$sym_name,
+  let arguments = (ins InnerSymAttr:$inner_sym,
                        TypeAttrOf<FunctionType>:$function_type,
                        ArrayAttr:$argNames,
                        OptionalAttr<DictArrayAttr>:$arg_attrs,
@@ -155,25 +169,16 @@ class MethodOpBase<string mnemonic, list<Trait> traits = []> :
 
   code extraMethodClassDeclaration = "";
   let extraClassDeclaration = extraMethodClassDeclaration # [{
-    //===------------------------------------------------------------------===//
-    // FunctionOpInterface Methods
-    //===------------------------------------------------------------------===//
-
-    /// Returns the argument types of this function.
-    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
-
-    /// Returns the result types of this function.
-    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
-
-    /// Returns the region on the current operation that is callable. This may
-    /// return null in the case of an external callable object, e.g. an external
-    /// function.
-    ::mlir::Region *getCallableRegion() {
-      return &getBody();
+    StringAttr getMethodName() {
+      return getInnerSymAttr().getSymName();
     }
+  }];
 
-    /// Returns the entry block of the function.
-    Block* getBodyBlock() { return &getBody().front(); }
+  let extraClassDefinition = [{
+    // For hw:InnerSymbol - the symbol targets the operation and not any result.
+    std::optional<size_t> $cppClass::getTargetResultIndex() {
+      return std::nullopt;
+    }
   }];
 }
 
@@ -386,7 +391,7 @@ def BlockReturnOp : IbisOp<"sblock.return", [
 
 def MemRefTypeAttr : TypeAttrBase<"MemRefType", "any memref type">;
 def VarOp : IbisOp<"var", [
-  Symbol
+  DeclareOpInterfaceMethods<InnerSymbol,["getTargetResultIndex"]>
 ]> {
   let summary = "Ibis variable definition";
   let description = [{
@@ -397,12 +402,19 @@ def VarOp : IbisOp<"var", [
     be dereferenced through a `!ibis.scoperef` value of the parent class.
   }];
 
-  let arguments = (ins SymbolNameAttr:$sym_name, MemRefTypeAttr:$type);
-  let assemblyFormat = "$sym_name `:` $type attr-dict";
+  let arguments = (ins InnerSymAttr:$inner_sym, MemRefTypeAttr:$type);
+  let assemblyFormat = "$inner_sym `:` $type attr-dict";
+
+  let extraClassDefinition = [{
+    // For hw:InnerSymbol - the symbol targets the operation and not any result.
+    std::optional<size_t> $cppClass::getTargetResultIndex() {
+      return std::nullopt;
+    }
+  }];
 }
 
 def GetVarOp : IbisOp<"get_var", [
-  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  DeclareOpInterfaceMethods<InnerRefUserOpInterface>,
   HasCustomSSAName
 ]> {
   let summary = "Dereferences an ibis member variable through a scoperef";
@@ -530,7 +542,7 @@ def PathOp : IbisOp<"path", [
 }
 
 def ThisOp : IbisOp<"this", [
-  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  DeclareOpInterfaceMethods<InnerRefUserOpInterface>,
   HasCustomSSAName
 ]> {
   let summary = "Return a handle to the current scope `!ibis.scoperef`";
@@ -554,7 +566,10 @@ def ThisOp : IbisOp<"this", [
 
 def ContainerOp : IbisOp<"container", [
   Symbol,
-  SymbolTable, SingleBlock,
+  // TODO: @mortbopet: ContainerOp should be an innersymbol table (or equivalent)
+  // whenever we figure out how to support nested symbol tables...
+  // InnerSymbolTable
+  SingleBlock,
   NoTerminator, NoRegionArguments,
   ScopeOpInterface, IsolatedFromAbove,
   InstanceGraphModuleOpInterface,
@@ -611,7 +626,7 @@ def ContainerInstanceOp : InstanceOpBase<"container.instance"> {
     Operation* getReferencedModule(SymbolTable&);
   }];
 
-  let extraClassDefinition = [{
+  let extraInstanceClassDefinition = [{
     Operation* ContainerInstanceOp::getReferencedModuleSlow() {
       return getContainer();
     }
@@ -624,7 +639,7 @@ def ContainerInstanceOp : InstanceOpBase<"container.instance"> {
 
 def GetPortOp : IbisOp<"get_port", [
       Pure,
-      DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+      DeclareOpInterfaceMethods<InnerRefUserOpInterface>,
       HasCustomSSAName
 ]> {
   let summary = "Ibis get port";
@@ -677,12 +692,13 @@ class PortLikeOp<string mnemonic, list<Trait> traits = []> :
       PortOpInterface,
       ParentOneOf<["ClassOp", "ContainerOp"]>,
       InferTypeOpInterface,
-      HasCustomSSAName
+      HasCustomSSAName,
+      DeclareOpInterfaceMethods<InnerSymbol,["getTargetResultIndex"]>
   ])> {
-  let arguments = (ins SymbolNameAttr:$sym_name, TypeAttrOf<AnyType>:$type);
+  let arguments = (ins InnerSymAttr:$inner_sym, TypeAttrOf<AnyType>:$type);
   let results = (outs PortRefType:$port);
   let assemblyFormat = [{
-    $sym_name `:` $type attr-dict
+    $inner_sym `:` $type attr-dict
   }];
 
   let extraClassDeclaration = [{
@@ -691,7 +707,7 @@ class PortLikeOp<string mnemonic, list<Trait> traits = []> :
     }
 
     mlir::StringAttr getPortName() {
-      return getSymNameAttr();
+      return getInnerSymAttr().getSymName();
     }
 
     static ibis::Direction getPortDirection();
@@ -724,6 +740,11 @@ class PortLikeOp<string mnemonic, list<Trait> traits = []> :
     void $cppClass::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
       setNameFn(getResult(), getPortName());
     }
+
+    // For hw:InnerSymbol - the symbol targets the operation and not any result.
+    std::optional<size_t> $cppClass::getTargetResultIndex() {
+      return std::nullopt;
+    }
   }];
 }
 
@@ -751,7 +772,8 @@ class WireLikeOp<string mnemonic, list<Trait> traits = []> :
     IbisOp<mnemonic, !listconcat(traits, [
       PortOpInterface,
       ParentOneOf<["ClassOp", "ContainerOp"]>,
-      HasCustomSSAName
+      HasCustomSSAName,
+      DeclareOpInterfaceMethods<InnerSymbol,["getTargetResultIndex"]>
   ])> {
 
   let extraClassDeclaration = [{
@@ -760,10 +782,18 @@ class WireLikeOp<string mnemonic, list<Trait> traits = []> :
     }
 
     mlir::StringAttr getPortName() {
-      return getSymNameAttr();
+      return getInnerSymAttr().getSymName();
     }
 
     static ibis::Direction getPortDirection();
+  }];
+
+  code extraWireClassDefinition = ?;
+  let extraClassDefinition = extraWireClassDefinition # [{
+    // For hw:InnerSymbol - the symbol targets the operation and not any result.
+    std::optional<size_t> $cppClass::getTargetResultIndex() {
+      return std::nullopt;
+    }
   }];
 }
 
@@ -784,13 +814,13 @@ def InputWireOp : WireLikeOp<"wire.input", [
     of type `T` which represents the value to-be-written to the wire.
   }];
 
-  let arguments = (ins SymbolNameAttr:$sym_name);
+  let arguments = (ins InnerSymAttr:$inner_sym);
   let results = (outs PortRefType:$port, AnyType:$output);
   let assemblyFormat = [{
-    $sym_name `:` qualified(type($output)) attr-dict
+    $inner_sym `:` qualified(type($output)) attr-dict
   }];
 
-  let extraClassDefinition =  [{
+  let extraWireClassDefinition =  [{
     ibis::Direction $cppClass::getPortDirection() {
       return ibis::Direction::Input;
     }
@@ -806,7 +836,7 @@ def InputWireOp : WireLikeOp<"wire.input", [
     OpBuilder<(ins "StringAttr":$name, "Type":$innerPortType), [{
       build($_builder, $_state,
         {$_builder.getType<PortRefType>(
-          innerPortType, ibis::Direction::Input), innerPortType}, name);
+          innerPortType, ibis::Direction::Input), innerPortType}, hw::InnerSymAttr::get(name));
     }]>
   ];
 
@@ -823,12 +853,13 @@ def OutputWireOp : WireLikeOp<"wire.output", [
     on the output portref.
   }];
 
-  let arguments = (ins SymbolNameAttr:$sym_name, AnyType:$input);
+  let arguments = (ins InnerSymAttr:$inner_sym, AnyType:$input);
   let results = (outs PortRefType:$port);
   let assemblyFormat = [{
-    $sym_name `,` $input `:` qualified(type($input)) attr-dict
+    $inner_sym `,` $input `:` qualified(type($input)) attr-dict
   }];
-  let extraClassDefinition = [{
+
+  let extraWireClassDefinition = [{
     ibis::Direction $cppClass::getPortDirection() {
       return ibis::Direction::Output;
     }

--- a/lib/Dialect/Ibis/Transforms/IbisCleanSelfdrivers.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisCleanSelfdrivers.cpp
@@ -141,7 +141,7 @@ struct InputPortOpConversionPattern : public OpConversionPattern<InputPortOp> {
 
     // Create a `hw.wire` to ensure that the input port name is maintained.
     auto wire = rewriter.create<hw::WireOp>(op.getLoc(), writer.getValue(),
-                                            op.getSymName());
+                                            op.getInnerSymAttrName());
 
     // Replace all reads of the input port with the wire.
     for (auto reader : readers)
@@ -165,7 +165,7 @@ struct InputPortOpConversionPattern : public OpConversionPattern<InputPortOp> {
 
       if (anyOutsideReads) {
         auto outputPort = rewriter.create<OutputPortOp>(
-            op.getLoc(), op.getSymName(), op.getType());
+            op.getLoc(), op.getInnerSym(), op.getType());
         rewriter.create<PortWriteOp>(op.getLoc(), outputPort, wire);
       }
     }

--- a/lib/Dialect/Ibis/Transforms/IbisContainerize.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisContainerize.cpp
@@ -39,7 +39,7 @@ struct OutlineContainerPattern : public OpConversionPattern<ContainerOp> {
                           "that is not nested within a class.");
 
     rewriter.setInsertionPoint(parentClass);
-    auto newContainerName = rewriter.getStringAttr(
+    StringAttr newContainerName = rewriter.getStringAttr(
         ns.newName(parentClass.getName() + "_" + op.getName()));
     auto newContainer =
         rewriter.create<ContainerOp>(op.getLoc(), newContainerName);
@@ -56,8 +56,9 @@ struct OutlineContainerPattern : public OpConversionPattern<ContainerOp> {
 
     // Create a container instance op in the parent class.
     rewriter.setInsertionPoint(op);
-    rewriter.create<ContainerInstanceOp>(parentClass.getLoc(), newContainerName,
-                                         newContainer.getNameAttr());
+    rewriter.create<ContainerInstanceOp>(
+        parentClass.getLoc(), hw::InnerSymAttr::get(newContainerName),
+        newContainer.getNameAttr());
     rewriter.eraseOp(op);
     return success();
   }
@@ -89,7 +90,7 @@ struct InstanceToContainerInstancePattern
                   ConversionPatternRewriter &rewriter) const override {
     // Replace the instance by a container instance of the same name.
     rewriter.replaceOpWithNewOp<ContainerInstanceOp>(
-        op, op.getNameAttr(), op.getTargetNameAttr().getAttr());
+        op, op.getInnerSym(), op.getTargetNameAttr().getAttr());
     return success();
   }
 };

--- a/lib/Dialect/Ibis/Transforms/IbisConvertHandshakeToDC.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisConvertHandshakeToDC.cpp
@@ -81,8 +81,9 @@ void ConvertHandshakeToDCPass::runOnOperation() {
   auto targetModifier = [&](mlir::ConversionTarget &target) {
     target.addDynamicallyLegalOp<ibis::DataflowMethodOp>(
         [](ibis::DataflowMethodOp op) {
-          return llvm::all_of(op.getArgumentTypes(), isDCType) &&
-                 llvm::all_of(op.getResultTypes(), isDCType);
+          auto methodLikeOp = cast<MethodLikeOpInterface>(op.getOperation());
+          return llvm::all_of(methodLikeOp.getArgumentTypes(), isDCType) &&
+                 llvm::all_of(methodLikeOp.getResultTypes(), isDCType);
         });
     target.addDynamicallyLegalOp<ibis::ReturnOp>(isDCTypedOp);
     target.addLegalDialect<hw::HWDialect, ibis::IbisDialect>();

--- a/test/Dialect/Ibis/Transforms/argify_blocks.mlir
+++ b/test/Dialect/Ibis/Transforms/argify_blocks.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: ibis.class @Argify {
 // CHECK-NEXT:   %this = ibis.this @Argify 
-// CHECK-NEXT:   ibis.method @foo() {
+// CHECK-NEXT:   ibis.method @foo() -> () {
 // CHECK-NEXT:     %c32_i32 = hw.constant 32 : i32
 // CHECK-NEXT:     %0:2 = ibis.sblock.isolated (%arg0 : i32 = %c32_i32) -> (i32, i32) {
 // CHECK-NEXT:       %c31_i32 = hw.constant 31 : i32

--- a/test/Dialect/Ibis/Transforms/inline_sblocks.mlir
+++ b/test/Dialect/Ibis/Transforms/inline_sblocks.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL:   ibis.class @Inline1 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @Inline1
-// CHECK:           ibis.method @foo(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) {
+// CHECK:           ibis.method @foo(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) -> () {
 // CHECK:             ibis.sblock.inline.begin {maxThreads = 1 : i64}
 // CHECK:             %[[VAL_3:.*]] = "foo.op1"(%[[VAL_1]], %[[VAL_2]]) : (i32, i32) -> i32
 // CHECK:             ibis.sblock.inline.end
@@ -23,7 +23,7 @@ ibis.class @Inline1 {
 
 // CHECK-LABEL:   ibis.class @Inline2 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @Inline2
-// CHECK:           ibis.method @foo(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) {
+// CHECK:           ibis.method @foo(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) -> () {
 // CHECK:             "foo.unused1"() : () -> ()
 // CHECK:             ibis.sblock.inline.begin {maxThreads = 1 : i64}
 // CHECK:             %[[VAL_3:.*]] = "foo.op1"(%[[VAL_1]], %[[VAL_2]]) : (i32, i32) -> i32

--- a/test/Dialect/Ibis/Transforms/structure.mlir
+++ b/test/Dialect/Ibis/Transforms/structure.mlir
@@ -5,14 +5,14 @@
 // CHECK-LABEL: ibis.class @C {
 // CHECK:         ibis.method @getAndSet(%x: ui32) -> ui32 {
 // CHECK:           ibis.return %x : ui32
-// CHECK:         ibis.method @returnNothingWithRet() {
+// CHECK:         ibis.method @returnNothingWithRet() -> () {
 // CHECK:           ibis.return
 
 // PREP-LABEL: ibis.class @C {
 // PREP:         ibis.method @getAndSet(%arg: !hw.struct<x: ui32>) -> ui32 {
 // PREP:           %x = hw.struct_explode %arg : !hw.struct<x: ui32>
 // PREP:           ibis.return %x : ui32
-// PREP:         ibis.method @returnNothingWithRet(%arg: !hw.struct<>) {
+// PREP:         ibis.method @returnNothingWithRet(%arg: !hw.struct<>) -> () {
 // PREP:           hw.struct_explode %arg : !hw.struct<>
 // PREP:           ibis.return
 ibis.class @C {

--- a/test/Dialect/Ibis/errors.mlir
+++ b/test/Dialect/Ibis/errors.mlir
@@ -20,23 +20,6 @@ ibis.class @C {
 
 // -----
 
-ibis.class @MissingPort {
-  %this = ibis.this @MissingPort
-  // expected-error @+1 {{'ibis.get_port' op port '@C_in' does not exist in "MissingPort"}}
-  %c_in = ibis.get_port %this, @C_in : !ibis.scoperef<@MissingPort> -> !ibis.portref<in i1>
-}
-
-// -----
-
-ibis.class @PortTypeMismatch {
-  %this = ibis.this @PortTypeMismatch
-  ibis.port.input @in : i1
-  // expected-error @+1 {{'ibis.get_port' op symbol '@in' refers to a port of type 'i1', but this op has type 'i2'}}
-  %c_in = ibis.get_port %this, @in : !ibis.scoperef<@PortTypeMismatch> -> !ibis.portref<in i2>
-}
-
-// -----
-
 // expected-error @+1 {{'ibis.class' op must contain only one 'ibis.this' operation}}
 ibis.class @MultipleThis {
   %this = ibis.this @MultipleThis
@@ -95,36 +78,6 @@ ibis.class @InvalidVar {
   %this = ibis.this @C
   // expected-error @+1 {{'ibis.var' op attribute 'type' failed to satisfy constraint: any memref type}}
   ibis.var @var : i32
-}
-
-// -----
-
-ibis.class @InvalidGetVar {
-  %this = ibis.this @InvalidGetVar
-  ibis.var @var : memref<i32>
-  ibis.method @foo()  {
-    %parent = ibis.path [
-      #ibis.step<parent : !ibis.scoperef<@InvalidGetVar>>
-    ]
-    // expected-error @+1 {{'ibis.get_var' op result #0 must be memref of any type values, but got 'i32'}}
-    %var = ibis.get_var %parent, @var : !ibis.scoperef<@InvalidGetVar> -> i32
-    ibis.return
-  }
-}
-
-// -----
-
-ibis.class @InvalidGetVar2 {
-  %this = ibis.this @InvalidGetVar2
-  ibis.var @var : memref<i32>
-  ibis.method @foo()  {
-    %parent = ibis.path [
-      #ibis.step<parent : !ibis.scoperef<@InvalidGetVar2>>
-    ]
-    // expected-error @+1 {{'ibis.get_var' op dereferenced type ('memref<i1>') must match variable type ('memref<i32>')}}
-    %var = ibis.get_var %parent, @var : !ibis.scoperef<@InvalidGetVar2> -> memref<i1>
-    ibis.return
-  }
 }
 
 // -----

--- a/test/Dialect/Ibis/inner_ref_errors.mlir
+++ b/test/Dialect/Ibis/inner_ref_errors.mlir
@@ -1,0 +1,54 @@
+// RUN: circt-opt --hw-verify-irn --split-input-file --verify-diagnostics %s
+
+ibis.class @MissingPort {
+  %this = ibis.this @MissingPort
+  // expected-error @+1 {{'ibis.get_port' op port '@C_in' does not exist in @MissingPort}}
+  %c_in = ibis.get_port %this, @C_in : !ibis.scoperef<@MissingPort> -> !ibis.portref<in i1>
+}
+
+// -----
+
+ibis.class @InvalidGetVar2 {
+  %this = ibis.this @InvalidGetVar2
+  ibis.var @var : memref<i32>
+  ibis.method @foo()  {
+    %parent = ibis.path [
+      #ibis.step<parent : !ibis.scoperef<@InvalidGetVar2>>
+    ]
+    // expected-error @+1 {{'ibis.get_var' op dereferenced type ('memref<i1>') must match variable type ('memref<i32>')}}
+    %var = ibis.get_var %parent, @var : !ibis.scoperef<@InvalidGetVar2> -> memref<i1>
+    ibis.return
+  }
+}
+
+// -----
+
+ibis.class @InvalidGetVar {
+  %this = ibis.this @InvalidGetVar
+  ibis.var @var : memref<i32>
+  ibis.method @foo()  {
+    %parent = ibis.path [
+      #ibis.step<parent : !ibis.scoperef<@InvalidGetVar>>
+    ]
+    // expected-error @+1 {{'ibis.get_var' op result #0 must be memref of any type values, but got 'i32'}}
+    %var = ibis.get_var %parent, @var : !ibis.scoperef<@InvalidGetVar> -> i32
+    ibis.return
+  }
+}
+
+// -----
+
+ibis.class @MissingPort {
+  %this = ibis.this @MissingPort
+  // expected-error @+1 {{'ibis.get_port' op port '@C_in' does not exist in @MissingPort}}
+  %c_in = ibis.get_port %this, @C_in : !ibis.scoperef<@MissingPort> -> !ibis.portref<in i1>
+}
+
+// -----
+
+ibis.class @PortTypeMismatch {
+  %this = ibis.this @PortTypeMismatch
+  ibis.port.input @in : i1
+  // expected-error @+1 {{'ibis.get_port' op symbol '@in' refers to a port of type 'i1', but this op has type 'i2'}}
+  %c_in = ibis.get_port %this, @in : !ibis.scoperef<@PortTypeMismatch> -> !ibis.portref<in i2>
+}

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -78,6 +78,7 @@ ibis.class @HighLevel {
 // CHECK-NEXT:      %parent.a.out.ref = ibis.get_port %parent.a, @out : !ibis.scoperef<@A> -> !ibis.portref<out i1>
 // CHECK-NEXT:      ibis.port.write %parent.a.in.ref, %parent.LowLevel_out.ref.val : !ibis.portref<in i1>
 // CHECK-NEXT:      %parent.a.out.ref.val = ibis.port.read %parent.a.out.ref : !ibis.portref<out i1>
+// CHECK-NEXT:      hw.instance "foo" @externModule() -> ()
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
@@ -120,5 +121,10 @@ ibis.class @LowLevel {
     %A.out_p = ibis.get_port %A.in_parent, @out : !ibis.scoperef<@A> -> !ibis.portref<out i1>
     ibis.port.write %A.in_p, %LowLevel_out : !ibis.portref<in i1>
     %A.out = ibis.port.read %A.out_p : !ibis.portref<out i1>
+
+    // Test hw.instance ops inside a container (symbol table usage)
+    hw.instance "foo" @externModule() -> ()
   }
 }
+
+hw.module.extern @externModule()


### PR DESCRIPTION
- Symbol-defining operations nested within `ibis.class` and `ibis.container` ops are now declared as `InnerSymbol`s.
- `ibis.class` is now an `NestedSymbolTable`s.
- `ibis.method` can no longer inherit from `FunctionLike` since that interface is built around an assumption of the function inheriting from `Symbol`.
- Containers are NOT `InnerSymbolTable`s yet - we cannot yet support nested symbol tables; see #6330; given that `ibis.container` needs to be able to still be able to be placed inside an `ibis.class` op.

Given the latter point, this is not a perfect implementation. As such, some parts of the implementation is still underperformant (e.g. `ScopeOpInterface::lookupInnerSym` which essentially does a scan of `InnerSymbol` ops inside the scope to facilitate symbol-lookup-like capability).

However, the implementation solves the immediate goals of:
1. not misusing MLIR by having nested symbol tables and looking across them
2. allowing the use of `hw.instance` operations inside containers nested in classes.