### PR TITLE
[Arc] Remove hw.wire once it is tapped

### DIFF
--- a/lib/Dialect/Arc/Transforms/AddTaps.cpp
+++ b/lib/Dialect/Arc/Transforms/AddTaps.cpp
@@ -70,12 +70,12 @@ struct AddTapsPass : public arc::impl::AddTapsBase<AddTapsPass> {
 
   // Add taps for HW wires.
   void tap(hw::WireOp wireOp) {
-    if (!tapWires)
-      return;
-    if (auto name = wireOp.getName()) {
+    if (auto name = wireOp.getName(); name && tapWires) {
       OpBuilder builder(wireOp);
       buildTap(builder, wireOp.getLoc(), wireOp, *name);
     }
+    wireOp.getResult().replaceAllUsesWith(wireOp.getInput());
+    wireOp->erase();
   }
 
   // Add taps for named values.

--- a/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
@@ -215,3 +215,19 @@ hw.module @NonTrivial(in %clock: !seq.clock, in %i0: i4, in %reset1: i1, in %res
   hw.output %foo, %bar : i4, i4
 }
 // CHECK-NEXT: }
+
+hw.module @ObserveWires(in %in1: i32, in %in2: i32, out out: i32) {
+  %c-1_i32 = hw.constant -1 : i32
+  %0 = comb.and %in1, %in2 : i32
+  arc.tap %0 {name = "z"} : i32
+  %1 = comb.xor %0, %c-1_i32 : i32
+  hw.output %1 : i32
+}
+//       CHECK: arc.define @[[ARC_NAME:[a-zA-Z0-9_]+]]
+//       CHECK:   [[V0:%.+]] = comb.and
+//       CHECK:   [[V1:%.+]] = comb.xor [[V0]], {{.*}} :
+//       CHECK:   arc.output [[V0]], [[V1]] :
+//       CHECK: hw.module @ObserveWires
+//   CHECK-DAG:   [[RES:%.+]]:2 = arc.state @[[ARC_NAME]]({{.*}}) lat 0 :
+//   CHECK-DAG:   arc.tap [[RES]]#0 {name = "z"} : i32
+//       CHECK:   hw.output %0#1 : i32

--- a/test/Dialect/Arc/add-taps.mlir
+++ b/test/Dialect/Arc/add-taps.mlir
@@ -30,8 +30,8 @@ hw.module @ObserveWires() {
   %y = sv.wire : !hw.inout<i4>
 
   // CHECK-NEXT: hw.constant
-  // CHECK-NEXT: arc.tap %z {name = "z"} : i4
-  // CHECK-NEXT: %z = hw.wire
+  // CHECK-NEXT: arc.tap %c0_i4 {name = "z"} : i4
+  // CHECK-NOT: hw.wire
   %c0_i4 = hw.constant 0 : i4
   %z = hw.wire %c0_i4 : i4
 


### PR DESCRIPTION
`hw.wire` is not pure, but would end up in arcs that don't allow side-effecting ops. I assume there is no use of `hw.wire` operations anymore once they are tapped, right?