### PR TITLE
[HW] Verify dimensions for hw.aggregate_constant ops

### DIFF
--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -438,6 +438,12 @@ static LogicalResult checkAttributes(Operation *op, Attribute attr, Type type) {
       return op->emitOpError("expected array attribute for constant of type ")
              << type;
     auto elementType = arrayType.getElementType();
+    if (arrayType.getNumElements() != arrayAttr.size()) {
+      return op->emitOpError("array attribute (")
+             << arrayAttr.size()
+             << ") has wrong size for unpacked array constant ("
+             << arrayType.getNumElements() << ")";
+    }
     for (auto attr : arrayAttr.getValue()) {
       if (failed(checkAttributes(op, attr, elementType)))
         return failure();

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -407,6 +407,11 @@ static LogicalResult checkAttributes(Operation *op, Attribute attr, Type type) {
     if (!arrayAttr)
       return op->emitOpError("expected array attribute for constant of type ")
              << type;
+    if (structType.getElements().size() != arrayAttr.size()) {
+      return op->emitOpError("array attribute (")
+             << arrayAttr.size() << ") has wrong size for struct constant ("
+             << structType.getElements().size() << ")";
+    }
     for (auto [attr, fieldInfo] :
          llvm::zip(arrayAttr.getValue(), structType.getElements())) {
       if (failed(checkAttributes(op, attr, fieldInfo.type)))
@@ -417,6 +422,11 @@ static LogicalResult checkAttributes(Operation *op, Attribute attr, Type type) {
     if (!arrayAttr)
       return op->emitOpError("expected array attribute for constant of type ")
              << type;
+    if (arrayType.getNumElements() != arrayAttr.size()) {
+      return op->emitOpError("array attribute (")
+             << arrayAttr.size() << ") has wrong size for array constant ("
+             << arrayType.getNumElements() << ")";
+    }
     auto elementType = arrayType.getElementType();
     for (auto attr : arrayAttr.getValue()) {
       if (failed(checkAttributes(op, attr, elementType)))

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -407,11 +407,11 @@ static LogicalResult checkAttributes(Operation *op, Attribute attr, Type type) {
     if (!arrayAttr)
       return op->emitOpError("expected array attribute for constant of type ")
              << type;
-    if (structType.getElements().size() != arrayAttr.size()) {
+    if (structType.getElements().size() != arrayAttr.size())
       return op->emitOpError("array attribute (")
              << arrayAttr.size() << ") has wrong size for struct constant ("
              << structType.getElements().size() << ")";
-    }
+
     for (auto [attr, fieldInfo] :
          llvm::zip(arrayAttr.getValue(), structType.getElements())) {
       if (failed(checkAttributes(op, attr, fieldInfo.type)))
@@ -422,11 +422,11 @@ static LogicalResult checkAttributes(Operation *op, Attribute attr, Type type) {
     if (!arrayAttr)
       return op->emitOpError("expected array attribute for constant of type ")
              << type;
-    if (arrayType.getNumElements() != arrayAttr.size()) {
+    if (arrayType.getNumElements() != arrayAttr.size())
       return op->emitOpError("array attribute (")
              << arrayAttr.size() << ") has wrong size for array constant ("
              << arrayType.getNumElements() << ")";
-    }
+
     auto elementType = arrayType.getElementType();
     for (auto attr : arrayAttr.getValue()) {
       if (failed(checkAttributes(op, attr, elementType)))
@@ -438,12 +438,12 @@ static LogicalResult checkAttributes(Operation *op, Attribute attr, Type type) {
       return op->emitOpError("expected array attribute for constant of type ")
              << type;
     auto elementType = arrayType.getElementType();
-    if (arrayType.getNumElements() != arrayAttr.size()) {
+    if (arrayType.getNumElements() != arrayAttr.size())
       return op->emitOpError("array attribute (")
              << arrayAttr.size()
              << ") has wrong size for unpacked array constant ("
              << arrayType.getNumElements() << ")";
-    }
+
     for (auto attr : arrayAttr.getValue()) {
       if (failed(checkAttributes(op, attr, elementType)))
         return failure();

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -427,6 +427,13 @@ hw.module @aggConstDimArray() {
 
 // -----
 
+hw.module @aggConstDimUArray() {
+  // expected-error @+1 {{'hw.aggregate_constant' op array attribute (1) has wrong size for unpacked array constant (2)}}
+  %0 = hw.aggregate_constant [42 : i8] : !hw.uarray<2xi8>
+}
+
+// -----
+
 hw.module @aggConstDimStruct() {
   // expected-error @+1 {{'hw.aggregate_constant' op array attribute (1) has wrong size for struct constant (2)}}
   %0 = hw.aggregate_constant [42 : i8] : !hw.struct<foo: i8, bar: i8>

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -420,6 +420,20 @@ hw.module @bab<param: i32, N: i32> (in %array2d: !hw.array<i3 x i4>) {}
 
 // -----
 
+hw.module @aggConstDimArray() {
+  // expected-error @+1 {{'hw.aggregate_constant' op array attribute (1) has wrong size for array constant (2)}}
+  %0 = hw.aggregate_constant [42 : i8] : !hw.array<2xi8>
+}
+
+// -----
+
+hw.module @aggConstDimStruct() {
+  // expected-error @+1 {{'hw.aggregate_constant' op array attribute (1) has wrong size for struct constant (2)}}
+  %0 = hw.aggregate_constant [42 : i8] : !hw.struct<foo: i8, bar: i8>
+}
+
+// -----
+
 hw.module @foo() {
   // expected-error @+1 {{enum value 'D' is not a member of enum type '!hw.enum<A, B, C>'}}
   %0 = hw.enum.constant D : !hw.enum<A, B, C>


### PR DESCRIPTION
Make sure the provided constant attribute's dimensions match the return type. Essentially a copy of the FIRRTL AggregateConstantOp verifier.