### PR TITLE
[CI] Update Python wheel action for MacOS.

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -24,13 +24,13 @@ jobs:
             cibw_build: cp310-manylinux_x86_64
           - os: ubuntu-20.04
             cibw_build: cp311-manylinux_x86_64
-          - os: macos-latest
+          - os: macos-12
             cibw_build: cp38-macosx_x86_64
-          - os: macos-latest
+          - os: macos-12
             cibw_build: cp39-macosx_x86_64
-          - os: macos-latest
+          - os: macos-12
             cibw_build: cp310-macosx_x86_64
-          - os: macos-latest
+          - os: macos-12
             cibw_build: cp311-macosx_x86_64
 
     steps:
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-python@v3
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.12.0
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse ./lib/Bindings/Python


### PR DESCRIPTION
The macos-latest tag has been migrated to macos-12, and the version of cibuildwheel we use doesn't run with the version of Python included in macos-12 (Python 3.12). Note that this has no bearing on the versions of Python we build the wheels for; this is the cibuildwheel Python code that is running on the runner's default Python to set up the build for the version of Python the wheel is targeting.

To amend this, I am locking to MacOS tag to a specific version, and updating the cibuildhweel version.

Fixes https://github.com/llvm/circt/issues/6385.