### PR TITLE
[Docs] Fix documentation typos, NFC

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -212,7 +212,7 @@ although there may be further restrictions in the annotation.
 This annotation attaches SV attributes to a specified target. A reference
 target must be a wire, node, reg, or module. This annotation doesn't prevent
 optimizations so it's necessary to add dontTouch annotation if users want to
-preseve the target.
+preserve the target.
 
 Example:
 ```json
@@ -287,10 +287,10 @@ Example:
 
 ### [BlackBoxResourceFileNameAnno](https://javadoc.io/doc/edu.berkeley.cs/firrtl_2.13/latest/firrtl/transforms/BlackBoxResourceFileNameAnno.html)
 
-| Property         | Type   | Description                              |
-| ----------       | ------ | -------------                            |
-| class            | string | `firrtl.transforms.BlackBoxFileNameAnno` |
-| resourceFileName | string | Output filename                          |
+| Property         | Type   | Description                                      |
+| ----------       | ------ | -------------                                    |
+| class            | string | `firrtl.transforms.BlackBoxResourceFileNameAnno` |
+| resourceFileName | string | Output filename                                  |
 
 Specifies the output file name for the list of black box source files that
 is generated as a collateral of the pass.
@@ -424,7 +424,7 @@ Example:
 This annotation attaches a comment to a specified target. A reference
 target must be a wire, node, reg, or module. This annotation doesn't prevent
 optimizations so it's necessary to add dontTouch annotation if users want to
-preseve the target.
+preserve the target.
 
 Example:
 ```json
@@ -807,7 +807,7 @@ containing the names of all modules annotated with the
 Example:
 ```json
 {
-  "class": "sifive.enterprise.firrtl.RetimeModuleAnnotation",
+  "class": "sifive.enterprise.firrtl.RetimeModulesAnnotation",
   "filename": "retime_modules.json"
 }
 ```
@@ -893,10 +893,10 @@ Example:
 
 ### SitestTestHarnessBlackBoxAnnotation
 
-| Property   | Type   | Description                                                     |
-| ---------- | ------ | -------------                                                   |
-| class      | string | `sifive.enterprise.firrtl.SittestTestHarnessBlackBoxAnnotation` |
-| filename   | string | The file to write to                                            |
+| Property   | Type   | Description                                                    |
+| ---------- | ------ | -------------                                                  |
+| class      | string | `sifive.enterprise.firrtl.SitestTestHarnessBlackBoxAnnotation` |
+| filename   | string | The file to write to                                           |
 
 This annotation triggers the creation of a file containing a JSON array of the
 names of all external modules in the test harness which are not imported or

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -400,7 +400,7 @@ def GroupDeclOp : FIRRTLOp<
   let summary = "A declaration of an optional group";
   let description = [{
     The `firrtl.declgroup` operation declares an optional group and a lowering
-    convetion for that group.  Optional groups are a feature of FIRRTL that add
+    convention for that group.  Optional groups are a feature of FIRRTL that add
     verification or debugging code to an existing module at runtime.
 
     A `firrtl.declgroup` operation only declares the group and any groups nested

--- a/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/BlackBoxReader.cpp
@@ -304,7 +304,7 @@ void BlackBoxReaderPass::runOnOperation() {
                                    /*excludeFromFileList=*/true));
   }
 
-  // If nothing has changed we can preseve the analysis.
+  // If nothing has changed we can preserve the analysis.
   if (!anythingChanged)
     markAllAnalysesPreserved();
   markAnalysesPreserved<InstanceGraph>();

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -178,7 +178,7 @@ void ExtractInstancesPass::runOnOperation() {
   if (anyFailures)
     return signalPassFailure();
 
-  // If nothing has changed we can preseve the analysis.
+  // If nothing has changed we can preserve the analysis.
   LLVM_DEBUG(llvm::dbgs() << "\n");
   if (!anythingChanged)
     markAllAnalysesPreserved();


### PR DESCRIPTION
Fixes a few comment typos, plus some mis-named FIRRTL annotations in the annotation documentation.