### PR TITLE
[LowerToHW] Pass through attributes on FModuleOp

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1021,19 +1021,33 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
   auto nameAttr = builder.getStringAttr(oldModule.getName());
   auto newModule =
       builder.create<hw::HWModuleOp>(oldModule.getLoc(), nameAttr, ports);
-  if (auto outputFile = oldModule->getAttr("output_file"))
-    newModule->setAttr("output_file", outputFile);
+
   if (auto comment = oldModule->getAttrOfType<StringAttr>("comment"))
     newModule.setCommentAttr(comment);
 
-  // Move SV attributes.
-  if (auto svAttrs = sv::getSVAttributes(oldModule))
-    sv::setSVAttributes(newModule, svAttrs);
+  // Copy over any attributes which are not required for FModuleOp.
+  SmallVector<StringRef, 12> attrNames = {"annotations",
+                                          "convention",
+                                          "portNames",
+                                          "sym_name",
+                                          "portDirections",
+                                          "portTypes",
+                                          "portAnnotations",
+                                          "portSyms",
+                                          "portLocations",
+                                          "parameters",
+                                          SymbolTable::getVisibilityAttrName()};
 
-  // Pass along FIRRTL dialect attributes.
-  for (auto attr : oldModule->getDiscardableAttrs())
-    if (isa_and_nonnull<FIRRTLDialect>(attr.getNameDialect()))
-      newModule->setAttr(attr.getName(), attr.getValue());
+  DenseSet<StringRef> attrSet(attrNames.begin(), attrNames.end());
+  SmallVector<NamedAttribute> newAttrs(newModule->getAttrs());
+  for (auto i :
+       llvm::make_filter_range(oldModule->getAttrs(), [&](auto namedAttr) {
+         return !attrSet.count(namedAttr.getName()) &&
+                !newModule->getAttrDictionary().contains(namedAttr.getName());
+       }))
+    newAttrs.push_back(i);
+
+  newModule->setAttrs(newAttrs);
 
   // If the circuit has an entry point, set all other modules private.
   // Otherwise, mark all modules as public.

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1030,9 +1030,10 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
   if (auto svAttrs = sv::getSVAttributes(oldModule))
     sv::setSVAttributes(newModule, svAttrs);
 
-  // Pass along the number of random initialization bits needed for this module.
-  if (auto randomWidth = oldModule->getAttr("firrtl.random_init_width"))
-    newModule->setAttr("firrtl.random_init_width", randomWidth);
+  // Pass along FIRRTL dialect attributes.
+  for (auto attr : oldModule->getDiscardableAttrs())
+    if (isa_and_nonnull<FIRRTLDialect>(attr.getNameDialect()))
+      newModule->setAttr(attr.getName(), attr.getValue());
 
   // If the circuit has an entry point, set all other modules private.
   // Otherwise, mark all modules as public.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -595,10 +595,13 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
 
-  // CHECK-LABEL: hw.module private @output_fileTest
+  // CHECK-LABEL: hw.module private @attributes_preservation
+  // CHECK-SAME: firrtl.foo = "bar"
   // CHECK-SAME: output_file = #hw.output_file<"output_fileTest.sv", excludeFromFileList>
-  firrtl.module private @output_fileTest() attributes {
-      output_file = #hw.output_file<"output_fileTest.sv", excludeFromFileList >} {
+  firrtl.module private @attributes_preservation() attributes {
+      firrtl.foo = "bar",
+      output_file = #hw.output_file<"output_fileTest.sv", excludeFromFileList >
+      } {
   }
 
   // https://github.com/llvm/circt/issues/314


### PR DESCRIPTION
This commit allows users to propagate attributes on modules to HW dialects. External passes hooked by pass plugin might want to control the passes based on annotation values but currently unhandled annotations or unknown attributes are not attached to lowered hw modules. 