### PR TITLE
[Seq] Add the `Clocked` trait to FIR mem read/write ops

### DIFF
--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -465,6 +465,7 @@ class DataMatchesFirMem<string memoryValue, string dataValue> :
     }]>;
 
 def FirMemReadOp : SeqOp<"firmem.read_port", [
+  Clocked,
   MemoryEffects<[MemRead]>,
   AddressMatchesFirMem<"memory", "address">,
   DataMatchesFirMem<"memory", "data">
@@ -481,12 +482,12 @@ def FirMemReadOp : SeqOp<"firmem.read_port", [
   let arguments = (ins
     FirMemType:$memory,
     AnySignlessInteger:$address,
-    ClockType:$clock,
+    ClockType:$clk,
     Optional<I1>:$enable
   );
   let results = (outs AnySignlessInteger:$data);
   let assemblyFormat = [{
-    $memory `[` $address `]` `,` `clock` $clock
+    $memory `[` $address `]` `,` `clock` $clk
     (`enable` $enable^)?
     attr-dict `:` type($memory)
   }];
@@ -494,6 +495,7 @@ def FirMemReadOp : SeqOp<"firmem.read_port", [
 }
 
 def FirMemWriteOp : SeqOp<"firmem.write_port", [
+  Clocked,
   MemoryEffects<[MemWrite]>,
   AddressMatchesFirMem<"memory", "address">,
   DataMatchesFirMem<"memory", "data">,
@@ -514,13 +516,13 @@ def FirMemWriteOp : SeqOp<"firmem.write_port", [
   let arguments = (ins
     FirMemType:$memory,
     AnySignlessInteger:$address,
-    ClockType:$clock,
+    ClockType:$clk,
     Optional<I1>:$enable,
     AnySignlessInteger:$data,
     Optional<AnySignlessInteger>:$mask
   );
   let assemblyFormat = [{
-    $memory `[` $address `]` `=` $data `,` `clock` $clock
+    $memory `[` $address `]` `=` $data `,` `clock` $clk
     (`enable` $enable^)? (`mask` $mask^)?
     attr-dict `:` type($memory) (`,` type($mask)^)?
   }];
@@ -529,6 +531,7 @@ def FirMemWriteOp : SeqOp<"firmem.write_port", [
 }
 
 def FirMemReadWriteOp : SeqOp<"firmem.read_write_port", [
+  Clocked,
   MemoryEffects<[MemRead, MemWrite]>,
   AddressMatchesFirMem<"memory", "address">,
   DataMatchesFirMem<"memory", "writeData">,
@@ -551,7 +554,7 @@ def FirMemReadWriteOp : SeqOp<"firmem.read_write_port", [
   let arguments = (ins
     FirMemType:$memory,
     AnySignlessInteger:$address,
-    ClockType:$clock,
+    ClockType:$clk,
     Optional<I1>:$enable,
     AnySignlessInteger:$writeData,
     I1:$mode,
@@ -559,7 +562,7 @@ def FirMemReadWriteOp : SeqOp<"firmem.read_write_port", [
   );
   let results = (outs AnySignlessInteger:$readData);
   let assemblyFormat = [{
-    $memory `[` $address `]` `=` $writeData `if` $mode `,` `clock` $clock
+    $memory `[` $address `]` `=` $writeData `if` $mode `,` `clock` $clk
     (`enable` $enable^)? (`mask` $mask^)?
     attr-dict `:` type($memory) (`,` type($mask)^)?
   }];

--- a/lib/Conversion/SeqToSV/FirMemLowering.cpp
+++ b/lib/Conversion/SeqToSV/FirMemLowering.cpp
@@ -335,7 +335,7 @@ void FirMemLowering::lowerMemoriesInModule(
         continue;
       addInput(port.getAddress());
       addInput(valueOrOne(port.getEnable()));
-      addInput(port.getClock());
+      addInput(port.getClk());
       addOutput(port.getData());
     }
 
@@ -346,7 +346,7 @@ void FirMemLowering::lowerMemoriesInModule(
         continue;
       addInput(port.getAddress());
       addInput(valueOrOne(port.getEnable()));
-      addInput(port.getClock());
+      addInput(port.getClk());
       addInput(port.getMode());
       addInput(port.getWriteData());
       addOutput(port.getReadData());
@@ -361,7 +361,7 @@ void FirMemLowering::lowerMemoriesInModule(
         continue;
       addInput(port.getAddress());
       addInput(valueOrOne(port.getEnable()));
-      addInput(port.getClock());
+      addInput(port.getClk());
       addInput(port.getData());
       if (config->maskBits > 1)
         addInput(valueOrOne(port.getMask(), config->maskBits));

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -764,7 +764,7 @@ LogicalResult FirMemWriteOp::canonicalize(FirMemWriteOp op,
                                           PatternRewriter &rewriter) {
   // Remove the write port if it is trivially dead.
   if (isConstZero(op.getEnable()) || isConstZero(op.getMask()) ||
-      isConstClock(op.getClock())) {
+      isConstClock(op.getClk())) {
     rewriter.eraseOp(op);
     return success();
   }
@@ -790,11 +790,11 @@ LogicalResult FirMemReadWriteOp::canonicalize(FirMemReadWriteOp op,
   // Replace the read-write port with a read port if the write behavior is
   // trivially disabled.
   if (isConstZero(op.getEnable()) || isConstZero(op.getMask()) ||
-      isConstClock(op.getClock()) || isConstZero(op.getMode())) {
+      isConstClock(op.getClk()) || isConstZero(op.getMode())) {
     auto opAttrs = op->getAttrs();
     auto opAttrNames = op.getAttributeNames();
     auto newOp = rewriter.replaceOpWithNewOp<FirMemReadOp>(
-        op, op.getMemory(), op.getAddress(), op.getClock(), op.getEnable());
+        op, op.getMemory(), op.getAddress(), op.getClk(), op.getEnable());
     for (auto namedAttr : opAttrs)
       if (!llvm::is_contained(opAttrNames, namedAttr.getName()))
         newOp->setAttr(namedAttr.getName(), namedAttr.getValue());


### PR DESCRIPTION
The ops are consumers of clock signals, so the trait is added. Additionally, the `clock` operand is renamed into `clk` to keep it consistent with other `seq` ops.