### PR TITLE
[OM] Tweak PathAttr syntax to be more amenable to bytecode.

### DIFF
--- a/lib/Dialect/OM/OMAttributes.cpp
+++ b/lib/Dialect/OM/OMAttributes.cpp
@@ -95,7 +95,7 @@ void PathAttr::print(AsmPrinter &odsPrinter) const {
   odsPrinter << '[';
   llvm::interleaveComma(getPath(), odsPrinter, [&](PathElement element) {
     odsPrinter.printKeywordOrString(element.module);
-    odsPrinter << '>';
+    odsPrinter << ':';
     odsPrinter.printKeywordOrString(element.instance);
   });
   odsPrinter << ']';
@@ -109,7 +109,7 @@ Attribute PathAttr::parse(AsmParser &odsParser, Type odsType) {
             std::string module;
             std::string instance;
             if (odsParser.parseKeywordOrString(&module) ||
-                odsParser.parseGreater() ||
+                odsParser.parseColon() ||
                 odsParser.parseKeywordOrString(&instance))
               return failure();
             path.emplace_back(StringAttr::get(context, module),

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -257,6 +257,8 @@ om.class @Path(%basepath: !om.basepath) {
   %0 = om.basepath_create %basepath @HierPath
   // CHECK: %[[v1:.+]] = om.path_create reference %basepath @HierPath
   %1 = om.path_create reference %basepath @HierPath
+  // CHECK: #om<path[Foo:foo, Bar:bar]>
+  %2 = om.constant 1 : i1 { foo = #om<path[Foo:foo, Bar:bar]>}
 }
 
 om.class @FrozenPath(%basepath: !om.frozenbasepath) {


### PR DESCRIPTION
While testing some OM IR using the bytecode format, I noticed the bytecode parser barfed on the #om.path attribute:

```
loc("#om<path[mod1>inst1, mod2>inst2]>":1:4):
error: unbalanced '[' character in pretty dialect name
error reading inputs
```

I think the way we are using `>` here doesn't play nicely with the fact that attributes are serialized in bytecode in their printed form by default. We can define our own encoding, but for now, using a different separator fixes the issue. I also added a round-trip test for the PathAttr's printed form.