### PR TITLE
[ESI][Runtime] Wire up services and ports into the design tree

### DIFF
--- a/integration_test/Dialect/ESI/runtime/loopback.mlir.py
+++ b/integration_test/Dialect/ESI/runtime/loopback.mlir.py
@@ -1,7 +1,8 @@
 import esi
 import sys
 
-acc = esi.Accelerator(sys.argv[1], sys.argv[2])
+platform = sys.argv[1]
+acc = esi.Accelerator(platform, sys.argv[2])
 
 assert acc.sysinfo().esi_version() == 1
 m = acc.manifest()
@@ -14,3 +15,11 @@ appid = d.children[0].id
 print(appid)
 assert appid.name == "loopback_inst"
 assert appid.idx == 0
+
+# Services are only hooked up for the trace backend currently.
+if platform == "trace":
+  d.children[0].ports[0].getWrite("recv").write([45] * 128)
+  d.children[0].ports[0].getWrite("recv").write([24])
+  d.children[0].ports[0].getWrite("recv").write([24, 45, 138])
+
+  d.children[0].ports[1].getRead("send").read(8)

--- a/integration_test/Dialect/ESI/runtime/loopback.mlir.py
+++ b/integration_test/Dialect/ESI/runtime/loopback.mlir.py
@@ -5,7 +5,6 @@ acc = esi.Accelerator(sys.argv[1], sys.argv[2])
 
 assert acc.sysinfo().esi_version() == 1
 assert acc.manifest.api_version == 1
-
 d = acc.manifest.build_design(acc)
 
 appid = d.children[0].id

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -689,6 +689,7 @@ void ServiceRequestRecordOp::getDetails(
       getDirectionAttrName(),
       StringAttr::get(ctxt, stringifyBundleDirection(getDirection())));
   results.emplace_back(getBundleTypeAttrName(), getBundleTypeAttr());
+  results.emplace_back(getServicePortAttrName(), getServicePortAttr());
 }
 
 StringRef SymbolMetadataOp::getManifestClass() { return "sym_info"; }

--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -44,6 +44,7 @@ include_directories(cpp/include)
 
 set(ESIRuntimeSources
   cpp/lib/Accelerator.cpp
+  cpp/lib/Design.cpp
   cpp/lib/Manifest.cpp
   cpp/lib/StdServices.cpp
 

--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -47,6 +47,7 @@ set(ESIRuntimeSources
   cpp/lib/Design.cpp
   cpp/lib/Manifest.cpp
   cpp/lib/StdServices.cpp
+  cpp/lib/Utils.cpp
 
   cpp/lib/backends/Trace.cpp
 )

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
@@ -67,7 +67,6 @@ public:
 };
 
 namespace services {
-
 /// Parent class of all APIs modeled as 'services'. May or may not map to a
 /// hardware side 'service'.
 class Service {
@@ -78,7 +77,9 @@ public:
   virtual std::string getServiceSymbol() const = 0;
 };
 
-/// A service for which there are no standard services registered.
+/// A service for which there are no standard services registered. Requires
+/// ports be added to the design hierarchy instead of high level interfaces like
+/// the ones in StdServices.h.
 class CustomService : public Service {
 public:
   CustomService(AppIDPath idPath, const ServiceImplDetails &details,

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Design.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Design.h
@@ -36,11 +36,28 @@ namespace esi {
 // Forward declarations.
 class Instance;
 
+class ChannelPort {};
+
+class BundlePort {
+  friend class services::Service;
+
+public:
+  BundlePort(AppID id, std::map<std::string, ChannelPort *> channels);
+  bool isConnected() const;
+
+private:
+  AppID _id;
+  std::map<std::string, ChannelPort *> _channels;
+};
+
 class Design {
 public:
   Design(std::optional<ModuleInfo> info,
-         std::vector<std::unique_ptr<Instance>> children)
-      : _info(info), _children(std::move(children)) {}
+         std::vector<std::unique_ptr<Instance>> children,
+         std::vector<services::Service *> services,
+         std::vector<BundlePort> ports)
+      : _info(info), _children(std::move(children)), _services(services),
+        _ports(ports) {}
 
   std::optional<ModuleInfo> info() const { return _info; }
   const std::vector<std::unique_ptr<Instance>> &children() const {
@@ -50,6 +67,8 @@ public:
 protected:
   const std::optional<ModuleInfo> _info;
   const std::vector<std::unique_ptr<Instance>> _children;
+  const std::vector<services::Service *> _services;
+  const std::vector<BundlePort> _ports;
 };
 
 class Instance : public Design {
@@ -58,8 +77,10 @@ public:
   Instance(const Instance &) = delete;
   ~Instance() = default;
   Instance(AppID id, std::optional<ModuleInfo> info,
-           std::vector<std::unique_ptr<Instance>> children)
-      : Design(info, std::move(children)), _id(id) {}
+           std::vector<std::unique_ptr<Instance>> children,
+           std::vector<services::Service *> services,
+           std::vector<BundlePort> ports)
+      : Design(info, std::move(children), services, ports), _id(id) {}
 
   const AppID id() const { return _id; }
 

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Design.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Design.h
@@ -45,8 +45,6 @@ class Service;
 /// unidirectional communication channels. This class provides access to those
 /// ChannelPorts.
 class BundlePort {
-  friend class services::Service;
-
 public:
   /// Direction of a bundle. This -- combined with the channel direction in the
   /// bundle -- can be used to determine if a channel should be writing to or
@@ -64,7 +62,7 @@ public:
   /// Construct a port.
   BundlePort(AppID id, std::map<std::string, ChannelPort &> channels);
 
-  /// Get access to the raw byte streams of a channel. Not intended for internal
+  /// Get access to the raw byte streams of a channel. Intended for internal
   /// usage and binding to other languages (e.g. Python) which have their own
   /// message serialization code.
   WriteChannelPort &getRawWrite(const std::string &name) const;
@@ -88,7 +86,6 @@ public:
   const std::vector<std::unique_ptr<Instance>> &children() const {
     return _children;
   }
-
   const std::vector<BundlePort> &getPorts() const { return _ports; }
 
 protected:

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Design.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Design.h
@@ -25,7 +25,6 @@
 #ifndef ESI_DESIGN_H
 #define ESI_DESIGN_H
 
-#include "esi/Accelerator.h"
 #include "esi/Manifest.h"
 
 #include <any>
@@ -35,19 +34,45 @@
 namespace esi {
 // Forward declarations.
 class Instance;
+class ChannelPort;
+class WriteChannelPort;
+class ReadChannelPort;
+namespace services {
+class Service;
+}
 
-class ChannelPort {};
-
+/// Services provide connections to 'bundles' -- collections of named,
+/// unidirectional communication channels. This class provides access to those
+/// ChannelPorts.
 class BundlePort {
   friend class services::Service;
 
 public:
-  BundlePort(AppID id, std::map<std::string, ChannelPort *> channels);
-  bool isConnected() const;
+  /// Direction of a bundle. This -- combined with the channel direction in the
+  /// bundle -- can be used to determine if a channel should be writing to or
+  /// reading from the accelerator.
+  enum Direction { ToServer, ToClient };
+
+  /// Compute the direction of a channel given the bundle direction and the
+  /// bundle port's direction.
+  static bool isWrite(BundleType::Direction bundleDir, Direction svcDir) {
+    if (svcDir == Direction::ToClient)
+      return bundleDir == BundleType::Direction::To;
+    return bundleDir == BundleType::Direction::From;
+  }
+
+  /// Construct a port.
+  BundlePort(AppID id, std::map<std::string, ChannelPort &> channels);
+
+  /// Get access to the raw byte streams of a channel. Not intended for internal
+  /// usage and binding to other languages (e.g. Python) which have their own
+  /// message serialization code.
+  WriteChannelPort &getRawWrite(const std::string &name) const;
+  ReadChannelPort &getRawRead(const std::string &name) const;
 
 private:
   AppID _id;
-  std::map<std::string, ChannelPort *> _channels;
+  std::map<std::string, ChannelPort &> _channels;
 };
 
 class Design {
@@ -63,6 +88,8 @@ public:
   const std::vector<std::unique_ptr<Instance>> &children() const {
     return _children;
   }
+
+  const std::vector<BundlePort> &getPorts() const { return _ports; }
 
 protected:
   const std::optional<ModuleInfo> _info;

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Manifest.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Manifest.h
@@ -21,7 +21,6 @@
 #include "esi/Types.h"
 
 #include <any>
-#include <cassert>
 #include <cstdint>
 #include <map>
 #include <memory>

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Manifest.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Manifest.h
@@ -21,7 +21,7 @@
 #include "esi/Types.h"
 
 #include <any>
-#include <assert.h>
+#include <cassert>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -47,6 +47,7 @@ struct AppID {
 };
 using AppIDPath = std::vector<AppID>;
 bool operator<(const AppIDPath &a, const AppIDPath &b);
+std::ostream &operator<<(std::ostream &, const AppIDPath &);
 
 struct ModuleInfo {
   const std::optional<std::string> name;
@@ -57,10 +58,22 @@ struct ModuleInfo {
   const std::map<std::string, std::any> extra;
 };
 
-struct ServicePort {
+/// A description of a service port. Used pretty exclusively in setting up the
+/// design.
+struct ServicePortDesc {
   std::string name;
   std::string portName;
 };
+
+/// A description of a hardware client. Used pretty exclusively in setting up
+/// the design.
+struct HWClientDetail {
+  AppIDPath path;
+  ServicePortDesc port;
+  std::map<std::string, std::any> implOptions;
+};
+using HWClientDetails = std::vector<HWClientDetail>;
+using ServiceImplDetails = std::map<std::string, std::any>;
 
 //===----------------------------------------------------------------------===//
 // Manifest parsing and API creation.

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Manifest.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Manifest.h
@@ -19,10 +19,12 @@
 #define ESI_MANIFEST_H
 
 #include <any>
+#include <assert.h>
 #include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -35,8 +37,14 @@ namespace esi {
 struct AppID {
   const std::string name;
   const std::optional<uint32_t> idx;
+
+  bool operator==(const AppID &other) const {
+    return name == other.name && idx == other.idx;
+  }
+  bool operator!=(const AppID &other) const { return !(*this == other); }
 };
 using AppIDPath = std::vector<AppID>;
+bool operator<(const AppIDPath &a, const AppIDPath &b);
 
 struct ModuleInfo {
   const std::optional<std::string> name;

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/StdServices.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/StdServices.h
@@ -32,6 +32,8 @@ class SysInfo : public Service {
 public:
   virtual ~SysInfo() = default;
 
+  virtual std::string getServiceSymbol() const;
+
   /// Get the ESI version number to check version compatibility.
   virtual uint32_t esiVersion() const = 0;
 
@@ -47,6 +49,7 @@ public:
   virtual ~MMIO() = default;
   virtual uint64_t read(uint32_t addr) const = 0;
   virtual void write(uint32_t addr, uint64_t data) = 0;
+  virtual std::string getServiceSymbol() const;
 };
 
 /// Implement the SysInfo API for a standard MMIO protocol.

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Types.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Types.h
@@ -33,6 +33,7 @@ class Type {
 public:
   using ID = std::string;
   Type(const ID &id) : id(id) {}
+  virtual ~Type() = default;
 
   ID getID() { return id; }
 
@@ -54,7 +55,7 @@ public:
   BundleType(const ID &id, const ChannelVector &channels)
       : Type(id), channels(channels) {}
 
-  const ChannelVector &getChannels() { return channels; }
+  const ChannelVector &getChannels() const { return channels; }
 
 protected:
   ChannelVector channels;

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Utils.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Utils.h
@@ -1,0 +1,29 @@
+//===- Utils.h - ESI runtime utility code -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// DO NOT EDIT!
+// This file is distributed as part of an ESI package. The source for this file
+// should always be modified within CIRCT.
+//
+//===----------------------------------------------------------------------===//
+
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef ESI_UTILS_H
+#define ESI_UTILS_H
+
+#include <cstdint>
+#include <string>
+
+namespace esi {
+namespace utils {
+// Very basic base64 encoding.
+void encodeBase64(const void *data, size_t size, std::string &out);
+} // namespace utils
+} // namespace esi
+
+#endif // ESI_UTILS_H

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Cosim.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Cosim.h
@@ -35,10 +35,9 @@ public:
   static std::unique_ptr<Accelerator> connect(std::string connectionString);
 
 protected:
-  virtual Service *
-  createService(Service::Type service, AppIDPath path,
-                const services::ServiceImplDetails &details,
-                const services::HWClientDetails &clients) override;
+  virtual Service *createService(Service::Type service, AppIDPath path,
+                                 const ServiceImplDetails &details,
+                                 const HWClientDetails &clients) override;
 
 private:
   struct Impl;

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Cosim.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Cosim.h
@@ -12,7 +12,7 @@
 //
 // DO NOT EDIT!
 // This file is distributed as part of an ESI package. The source for this file
-// should always be modified within CIRCT (lib/dialect/ESI/runtime/cpp/esi.h).
+// should always be modified within CIRCT (lib/dialect/ESI/runtime/cpp).
 //
 //===----------------------------------------------------------------------===//
 
@@ -35,7 +35,10 @@ public:
   static std::unique_ptr<Accelerator> connect(std::string connectionString);
 
 protected:
-  virtual Service *createService(Service::Type service) override;
+  virtual Service *
+  createService(Service::Type service, AppIDPath path,
+                const services::ServiceImplDetails &details,
+                const services::HWClientDetails &clients) override;
 
 private:
   struct Impl;

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Trace.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Trace.h
@@ -58,7 +58,10 @@ public:
   static std::unique_ptr<Accelerator> connect(std::string connectionString);
 
 protected:
-  virtual Service *createService(Service::Type service) override;
+  virtual Service *
+  createService(Service::Type service, AppIDPath idPath,
+                const services::ServiceImplDetails &details,
+                const services::HWClientDetails &clients) override;
 
 private:
   struct Impl;

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Trace.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Trace.h
@@ -57,14 +57,15 @@ public:
   /// "<mode>:<manifest path>[:<traceFile>]".
   static std::unique_ptr<Accelerator> connect(std::string connectionString);
 
+  /// Internal implementation.
+  struct Impl;
+
 protected:
-  virtual Service *
-  createService(Service::Type service, AppIDPath idPath,
-                const services::ServiceImplDetails &details,
-                const services::HWClientDetails &clients) override;
+  virtual Service *createService(Service::Type service, AppIDPath idPath,
+                                 const ServiceImplDetails &details,
+                                 const HWClientDetails &clients) override;
 
 private:
-  struct Impl;
   std::unique_ptr<Impl> impl;
 };
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
@@ -21,8 +21,8 @@ using namespace esi;
 using namespace esi::services;
 
 CustomService::CustomService(AppIDPath idPath,
-                             const services::ServiceImplDetails &details,
-                             const services::HWClientDetails &clients) {
+                             const ServiceImplDetails &details,
+                             const HWClientDetails &clients) {
   _serviceSymbol = std::any_cast<std::string>(details.at("service"));
   // Strip off initial '@'.
   _serviceSymbol = _serviceSymbol.substr(1);
@@ -30,8 +30,8 @@ CustomService::CustomService(AppIDPath idPath,
 
 namespace esi {
 services::Service *Accelerator::getService(Service::Type svcType, AppIDPath id,
-                                           services::ServiceImplDetails details,
-                                           services::HWClientDetails clients) {
+                                           ServiceImplDetails details,
+                                           HWClientDetails clients) {
   std::unique_ptr<Service> &cacheEntry =
       serviceCache[std::make_tuple(&svcType, id)];
   if (cacheEntry == nullptr)

--- a/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
@@ -8,8 +8,7 @@
 //
 // DO NOT EDIT!
 // This file is distributed as part of an ESI package. The source for this file
-// should always be modified within CIRCT
-// (lib/dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp).
+// should always be modified within CIRCT (lib/dialect/ESI/runtime/cpp/).
 //
 //===----------------------------------------------------------------------===//
 
@@ -18,13 +17,29 @@
 #include <map>
 #include <stdexcept>
 
+using namespace esi;
+using namespace esi::services;
+
+CustomService::CustomService(AppIDPath idPath,
+                             const services::ServiceImplDetails &details,
+                             const services::HWClientDetails &clients) {
+  _serviceSymbol = std::any_cast<std::string>(details.at("service"));
+  // Strip off initial '@'.
+  _serviceSymbol = _serviceSymbol.substr(1);
+}
+
 namespace esi {
-services::Service *Accelerator::getServiceImpl(Service::Type svcType) {
-  std::unique_ptr<Service> &cacheEntry = serviceCache[&svcType];
+services::Service *Accelerator::getService(Service::Type svcType, AppIDPath id,
+                                           services::ServiceImplDetails details,
+                                           services::HWClientDetails clients) {
+  std::unique_ptr<Service> &cacheEntry =
+      serviceCache[std::make_tuple(&svcType, id)];
   if (cacheEntry == nullptr)
-    cacheEntry = std::unique_ptr<Service>(createService(svcType));
+    cacheEntry =
+        std::unique_ptr<Service>(createService(svcType, id, details, clients));
   return cacheEntry.get();
 }
+
 namespace registry {
 namespace internal {
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/Design.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Design.cpp
@@ -13,8 +13,29 @@
 //===----------------------------------------------------------------------===//
 
 #include "esi/Design.h"
+#include "esi/Accelerator.h"
 
 using namespace esi;
 
-BundlePort::BundlePort(AppID id, std::map<std::string, ChannelPort *> channels)
+BundlePort::BundlePort(AppID id, std::map<std::string, ChannelPort &> channels)
     : _id(id), _channels(channels) {}
+
+WriteChannelPort &BundlePort::getRawWrite(const std::string &name) const {
+  auto f = _channels.find(name);
+  if (f == _channels.end())
+    throw std::runtime_error("Channel '" + name + "' not found");
+  auto *write = dynamic_cast<WriteChannelPort *>(&f->second);
+  if (!write)
+    throw std::runtime_error("Channel '" + name + "' is not a write channel");
+  return *write;
+}
+
+ReadChannelPort &BundlePort::getRawRead(const std::string &name) const {
+  auto f = _channels.find(name);
+  if (f == _channels.end())
+    throw std::runtime_error("Channel '" + name + "' not found");
+  auto *read = dynamic_cast<ReadChannelPort *>(&f->second);
+  if (!read)
+    throw std::runtime_error("Channel '" + name + "' is not a read channel");
+  return *read;
+}

--- a/lib/Dialect/ESI/runtime/cpp/lib/Design.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Design.cpp
@@ -1,0 +1,20 @@
+//===- Design.cpp - Implementation of dynamic API -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// DO NOT EDIT!
+// This file is distributed as part of an ESI package. The source for this file
+// should always be modified within CIRCT (lib/dialect/ESI/runtime/cpp/).
+//
+//===----------------------------------------------------------------------===//
+
+#include "esi/Design.h"
+
+using namespace esi;
+
+BundlePort::BundlePort(AppID id, std::map<std::string, ChannelPort *> channels)
+    : _id(id), _channels(channels) {}

--- a/lib/Dialect/ESI/runtime/cpp/lib/Manifest.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Manifest.cpp
@@ -8,8 +8,7 @@
 //
 // DO NOT EDIT!
 // This file is distributed as part of an ESI package. The source for this file
-// should always be modified within CIRCT
-// (lib/dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp).
+// should always be modified within CIRCT (lib/dialect/ESI/runtime/cpp/).
 //
 //===----------------------------------------------------------------------===//
 
@@ -25,6 +24,10 @@ using namespace esi;
 namespace esi {
 namespace internal {
 
+// While building the design, keep around a map of active services indexed by
+// the service name.
+using ServiceTable = std::map<std::string, services::Service *>;
+
 // This is a proxy class to the manifest JSON. It is used to avoid having to
 // include the JSON parser in the header. Forward references don't work since
 // nlohmann::json is a rather complex template.
@@ -38,17 +41,30 @@ public:
   auto at(const std::string &key) const { return manifestJson.at(key); }
 
   // Get the module info (if any) for the module instance in 'json'.
-  std::optional<ModuleInfo> getModInfo(const nlohmann::json &json) const;
+  std::optional<ModuleInfo> getModInfo(const nlohmann::json &) const;
 
-  // Build the 'Instance' recursively for the instance in 'json'.
-  Instance getInstance(const nlohmann::json &json) const;
+  services::Service *getService(AppIDPath idPath, Accelerator &,
+                                const nlohmann::json &,
+                                ServiceTable &activeServices) const;
+  void getServices(AppIDPath idPath, Accelerator &, const nlohmann::json &,
+                   std::vector<services::Service *> &outServices,
+                   ServiceTable &activeServices) const;
 
-  /// Build the set of child instances for the module instance in 'json'.
+  std::vector<BundlePort> getBundlePorts(AppIDPath idPath,
+                                         const ServiceTable &activeServices,
+                                         const nlohmann::json &json) const;
+
+  /// Build the set of child instances (recursively) for the module instance in
+  /// 'json'.
   std::vector<std::unique_ptr<Instance>>
-  getChildInstances(const nlohmann::json &json) const;
-
-  /// Build a dynamic API for the Accelerator connection 'acc' based on the
-  /// manifest stored herein.
+  getChildInstances(AppIDPath idPath, Accelerator &acc,
+                    ServiceTable activeServices,
+                    const nlohmann::json &json) const;
+  std::unique_ptr<Instance> getChildInstance(AppIDPath idPath, Accelerator &acc,
+                                             ServiceTable activeServices,
+                                             const nlohmann::json &json) const;
+  /// Build a dynamic API for the Accelerator connection 'acc'
+  /// based on the manifest stored herein.
   std::unique_ptr<Design> buildDesign(Accelerator &acc) const;
 
 private:
@@ -71,23 +87,56 @@ static AppID parseID(const nlohmann::json &jsonID) {
   return AppID{jsonID.at("name").get<std::string>(), idx};
 }
 
-static ModuleInfo parseModuleInfo(const nlohmann::json &mod) {
-  auto getAny = [](const nlohmann::json &value) -> std::any {
-    if (value.is_string())
-      return value.get<std::string>();
-    else if (value.is_number_integer())
-      return value.get<int64_t>();
-    else if (value.is_number_unsigned())
-      return value.get<uint64_t>();
-    else if (value.is_number_float())
-      return value.get<double>();
-    else if (value.is_boolean())
-      return value.get<bool>();
-    else if (value.is_null())
-      return value.get<std::nullptr_t>();
-    else
-      throw std::runtime_error("Unknown type in manifest: " + value.dump(2));
+static AppIDPath parseIDPath(const nlohmann::json &jsonIDPath) {
+  AppIDPath ret;
+  for (auto &id : jsonIDPath)
+    ret.push_back(parseID(id));
+  return ret;
+}
+
+static services::ServicePortDesc
+parseServicePort(const nlohmann::json &jsonPort) {
+  return services::ServicePortDesc{jsonPort.at("outer_sym").get<std::string>(),
+                                   jsonPort.at("inner").get<std::string>()};
+}
+
+static std::any getAny(const nlohmann::json &value) {
+  auto getObject = [](const nlohmann::json &json) {
+    std::map<std::string, std::any> ret;
+    for (auto &e : json.items())
+      ret[e.key()] = getAny(e.value());
+    return ret;
   };
+
+  auto getArray = [](const nlohmann::json &json) {
+    std::vector<std::any> ret;
+    for (auto &e : json)
+      ret.push_back(getAny(e));
+    return ret;
+  };
+
+  if (value.is_string())
+    return value.get<std::string>();
+  else if (value.is_number_integer())
+    return value.get<int64_t>();
+  else if (value.is_number_unsigned())
+    return value.get<uint64_t>();
+  else if (value.is_number_float())
+    return value.get<double>();
+  else if (value.is_boolean())
+    return value.get<bool>();
+  else if (value.is_null())
+    return value.get<std::nullptr_t>();
+  else if (value.is_object())
+    return getObject(value);
+  else if (value.is_array())
+    return getArray(value);
+  else
+    throw std::runtime_error("Unknown type in manifest: " + value.dump(2));
+}
+
+static ModuleInfo parseModuleInfo(const nlohmann::json &mod) {
+
   std::map<std::string, std::any> extras;
   for (auto &extra : mod.items())
     if (extra.key() != "name" && extra.key() != "summary" &&
@@ -121,9 +170,15 @@ internal::ManifestProxy::ManifestProxy(const std::string &manifestStr,
 std::unique_ptr<Design>
 internal::ManifestProxy::buildDesign(Accelerator &acc) const {
   auto designJson = manifestJson.at("design");
-  std::vector<std::unique_ptr<Instance>> children =
-      getChildInstances(designJson);
-  return std::make_unique<Design>(getModInfo(designJson), std::move(children));
+
+  ServiceTable activeSvcs;
+  std::vector<services::Service *> services;
+  getServices({}, acc, designJson, services, activeSvcs);
+
+  return std::make_unique<Design>(
+      getModInfo(designJson),
+      getChildInstances({}, acc, activeSvcs, designJson), services,
+      getBundlePorts({}, activeSvcs, designJson));
 }
 
 std::optional<ModuleInfo>
@@ -138,15 +193,105 @@ internal::ManifestProxy::getModInfo(const nlohmann::json &json) const {
 }
 
 std::vector<std::unique_ptr<Instance>>
-internal::ManifestProxy::getChildInstances(const nlohmann::json &json) const {
+internal::ManifestProxy::getChildInstances(
+    AppIDPath idPath, Accelerator &acc, ServiceTable activeServices,
+    const nlohmann::json &instJson) const {
   std::vector<std::unique_ptr<Instance>> ret;
-  auto childrenIter = json.find("children");
-  if (childrenIter == json.end())
+  auto childrenIter = instJson.find("children");
+  if (childrenIter == instJson.end())
     return ret;
-  for (auto &child : childrenIter.value()) {
-    auto children = getChildInstances(child);
-    ret.emplace_back(std::make_unique<Instance>(
-        parseID(child.at("app_id")), getModInfo(child), std::move(children)));
+  for (auto &child : childrenIter.value())
+    ret.emplace_back(getChildInstance(idPath, acc, activeServices, child));
+  return ret;
+}
+std::unique_ptr<Instance>
+internal::ManifestProxy::getChildInstance(AppIDPath idPath, Accelerator &acc,
+                                          ServiceTable activeServices,
+                                          const nlohmann::json &child) const {
+  AppID childID = parseID(child.at("app_id"));
+  idPath.push_back(childID);
+
+  std::vector<services::Service *> services;
+  getServices(idPath, acc, child, services, activeServices);
+
+  auto children = getChildInstances(idPath, acc, activeServices, child);
+  return std::make_unique<Instance>(
+      parseID(child.at("app_id")), getModInfo(child), std::move(children),
+      services, getBundlePorts(idPath, activeServices, child));
+}
+
+services::Service *
+internal::ManifestProxy::getService(AppIDPath idPath, Accelerator &acc,
+                                    const nlohmann::json &svcJson,
+                                    ServiceTable &activeServices) const {
+
+  AppID id = parseID(svcJson.at("appID"));
+  idPath.push_back(id);
+
+  services::HWClientDetails clientDetails;
+  for (auto &client : svcJson.at("client_details")) {
+    services::HWClientDetail clientDetail;
+    for (auto &detail : client.items()) {
+      if (detail.key() == "relAppIDPath")
+        clientDetail.path = parseIDPath(detail.value());
+      else if (detail.key() == "port")
+        clientDetail.port = parseServicePort(detail.value());
+      else
+        clientDetail.implOptions[detail.key()] = getAny(detail.value());
+    }
+  }
+
+  services::ServiceImplDetails svcDetails;
+  for (auto &detail : svcJson.items())
+    if (detail.key() != "appID" && detail.key() != "client_details")
+      svcDetails[detail.key()] = getAny(detail.value());
+
+  auto svc = acc.getService<services::CustomService>(idPath, svcDetails,
+                                                     clientDetails);
+  if (!svc) {
+    throw std::runtime_error("Could not create service for ");
+  }
+  activeServices[svc->getServiceSymbol()] = svc;
+  return svc;
+}
+
+void internal::ManifestProxy::getServices(AppIDPath idPath, Accelerator &acc,
+                                          const nlohmann::json &svcsJson,
+                                          std::vector<services::Service *> &ret,
+                                          ServiceTable &activeServices) const {
+
+  auto contentsIter = svcsJson.find("contents");
+  if (contentsIter == svcsJson.end())
+    return;
+
+  for (auto &content : contentsIter.value())
+    if (content.at("class") == "service")
+      ret.emplace_back(getService(idPath, acc, content, activeServices));
+}
+
+std::vector<BundlePort>
+internal::ManifestProxy::getBundlePorts(AppIDPath idPath,
+                                        const ServiceTable &activeServices,
+                                        const nlohmann::json &instJson) const {
+
+  std::vector<BundlePort> ret;
+  auto contentsIter = instJson.find("contents");
+  if (contentsIter == instJson.end())
+    return ret;
+
+  for (auto &content : contentsIter.value()) {
+    if (content.at("class") != "client_port")
+      continue;
+
+    services::ServicePortDesc port =
+        parseServicePort(content.at("servicePort"));
+    auto f = activeServices.find(port.name);
+    if (f == activeServices.end())
+      throw std::runtime_error("Could not find service '" + port.name + "'");
+
+    idPath.push_back(parseID(content.at("appID")));
+    ret.emplace_back(idPath.back(), f->second->requestChannelsFor(idPath));
+    idPath.pop_back();
   }
   return ret;
 }
@@ -223,3 +368,19 @@ std::ostream &operator<<(std::ostream &os, const ModuleInfo &m) {
   }
   return os;
 }
+
+namespace esi {
+bool operator<(const AppID &a, const AppID &b) {
+  if (a.name != b.name)
+    return a.name < b.name;
+  return a.idx < b.idx;
+}
+bool operator<(const AppIDPath &a, const AppIDPath &b) {
+  if (a.size() != b.size())
+    return a.size() < b.size();
+  for (size_t i = 0, e = a.size(); i < e; ++i)
+    if (a[i] != b[i])
+      return a[i] < b[i];
+  return false;
+}
+} // namespace esi

--- a/lib/Dialect/ESI/runtime/cpp/lib/StdServices.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/StdServices.cpp
@@ -23,6 +23,8 @@
 using namespace esi;
 using namespace esi::services;
 
+std::string SysInfo::getServiceSymbol() const { return "__builtin_SysInfo"; }
+
 // Allocate 10MB for the uncompressed manifest. This should be plenty.
 constexpr uint32_t MAX_MANIFEST_SIZE = 10 << 20;
 /// Get the compressed manifest, uncompress, and return it.
@@ -37,6 +39,8 @@ std::string SysInfo::jsonManifest() const {
                              std::to_string(rc));
   return std::string(reinterpret_cast<char *>(dst.data()), dstSize);
 }
+
+std::string MMIO::getServiceSymbol() const { return "__builtin_MMIO"; }
 
 MMIOSysInfo::MMIOSysInfo(const MMIO *mmio) : mmio(mmio) {}
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/Utils.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Utils.cpp
@@ -1,0 +1,51 @@
+//===- Utils.cpp - implementations ESI utility code -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// DO NOT EDIT!
+// This file is distributed as part of an ESI package. The source for this file
+// should always be modified within CIRCT
+// (lib/dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp).
+//
+//===----------------------------------------------------------------------===//
+
+#include "esi/Utils.h"
+
+static constexpr char Table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                "abcdefghijklmnopqrstuvwxyz"
+                                "0123456789+/";
+
+// Copied then modified slightly from llvm/lib/Support/Base64.cpp.
+void esi::utils::encodeBase64(const void *dataIn, size_t size,
+                              std::string &buffer) {
+  const char *data = static_cast<const char *>(dataIn);
+  buffer.resize(((size + 2) / 3) * 4);
+
+  size_t i = 0, j = 0;
+  for (size_t n = size / 3 * 3; i < n; i += 3, j += 4) {
+    uint32_t x = ((unsigned char)data[i] << 16) |
+                 ((unsigned char)data[i + 1] << 8) | (unsigned char)data[i + 2];
+    buffer[j + 0] = Table[(x >> 18) & 63];
+    buffer[j + 1] = Table[(x >> 12) & 63];
+    buffer[j + 2] = Table[(x >> 6) & 63];
+    buffer[j + 3] = Table[x & 63];
+  }
+  if (i + 1 == size) {
+    uint32_t x = ((unsigned char)data[i] << 16);
+    buffer[j + 0] = Table[(x >> 18) & 63];
+    buffer[j + 1] = Table[(x >> 12) & 63];
+    buffer[j + 2] = '=';
+    buffer[j + 3] = '=';
+  } else if (i + 2 == size) {
+    uint32_t x =
+        ((unsigned char)data[i] << 16) | ((unsigned char)data[i + 1] << 8);
+    buffer[j + 0] = Table[(x >> 18) & 63];
+    buffer[j + 1] = Table[(x >> 12) & 63];
+    buffer[j + 2] = Table[(x >> 6) & 63];
+    buffer[j + 3] = '=';
+  }
+}

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -130,17 +130,29 @@ private:
 };
 } // namespace
 
-Service *
-CosimAccelerator::createService(Service::Type svcType, AppIDPath id,
-                                const services::ServiceImplDetails &details,
-                                const services::HWClientDetails &clients) {
+namespace {
+class CosimCustomService : public services::CustomService {
+public:
+  using CustomService::CustomService;
+
+  virtual std::map<std::string, ChannelPort &>
+  requestChannelsFor(AppIDPath, const BundleType &,
+                     BundlePort::Direction portDir) override {
+    return {};
+  }
+};
+} // namespace
+
+Service *CosimAccelerator::createService(Service::Type svcType, AppIDPath id,
+                                         const ServiceImplDetails &details,
+                                         const HWClientDetails &clients) {
   if (svcType == typeid(MMIO))
     return new CosimMMIO(impl->lowLevel, impl->waitScope);
   else if (svcType == typeid(SysInfo))
     // return new MMIOSysInfo(getService<MMIO>());
     return new CosimSysInfo(impl->cosim, impl->waitScope);
   else if (svcType == typeid(CustomService))
-    return new CustomService(id, details, clients);
+    return new CosimCustomService(id, details, clients);
   return nullptr;
 }
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -130,12 +130,17 @@ private:
 };
 } // namespace
 
-Service *CosimAccelerator::createService(Service::Type svcType) {
+Service *
+CosimAccelerator::createService(Service::Type svcType, AppIDPath id,
+                                const services::ServiceImplDetails &details,
+                                const services::HWClientDetails &clients) {
   if (svcType == typeid(MMIO))
     return new CosimMMIO(impl->lowLevel, impl->waitScope);
   else if (svcType == typeid(SysInfo))
     // return new MMIOSysInfo(getService<MMIO>());
     return new CosimSysInfo(impl->cosim, impl->waitScope);
+  else if (svcType == typeid(CustomService))
+    return new CustomService(id, details, clients);
   return nullptr;
 }
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
@@ -13,7 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "esi/backends/Trace.h"
+#include "esi/Design.h"
 #include "esi/StdServices.h"
+#include "esi/Utils.h"
 
 #include <fstream>
 #include <iostream>
@@ -27,6 +29,62 @@ using namespace esi::backends::trace;
 
 // We only support v1.
 constexpr uint32_t ESIVersion = 1;
+
+namespace {
+class TraceChannelPort;
+}
+
+struct esi::backends::trace::TraceAccelerator::Impl {
+  Impl(Mode mode, std::filesystem::path manifestJson,
+       std::filesystem::path traceFile)
+      : manifestJson(manifestJson), traceFile(traceFile) {
+    if (!filesystem::exists(manifestJson))
+      throw runtime_error("manifest file '" + manifestJson.string() +
+                          "' does not exist");
+
+    if (mode == Write) {
+      // Open the trace file for writing.
+      traceWrite = new ofstream(traceFile);
+      if (!traceWrite->is_open())
+        throw runtime_error("failed to open trace file '" + traceFile.string() +
+                            "'");
+    } else {
+      assert(false && "not implemented");
+    }
+  }
+
+  ~Impl() {
+    if (traceWrite) {
+      traceWrite->close();
+      delete traceWrite;
+    }
+  }
+
+  Service *createService(Service::Type svcType, AppIDPath idPath,
+                         const ServiceImplDetails &details,
+                         const HWClientDetails &clients);
+
+  void adoptChannelPort(ChannelPort *port) { channels.emplace_back(port); }
+
+  void write(const AppIDPath &id, const std::string &portName, const void *data,
+             size_t size);
+
+private:
+  ofstream *traceWrite;
+  std::filesystem::path manifestJson;
+  std::filesystem::path traceFile;
+  vector<unique_ptr<ChannelPort>> channels;
+};
+
+void TraceAccelerator::Impl::write(const AppIDPath &id,
+                                   const std::string &portName,
+                                   const void *data, size_t size) {
+  std::string b64data;
+  utils::encodeBase64(data, size, b64data);
+
+  *traceWrite << "write " << id << '.' << portName << ": " << b64data
+              << std::endl;
+}
 
 unique_ptr<Accelerator> TraceAccelerator::connect(string connectionString) {
   string modeStr;
@@ -58,6 +116,18 @@ unique_ptr<Accelerator> TraceAccelerator::connect(string connectionString) {
       mode, filesystem::path(manifestPath), filesystem::path(traceFile));
 }
 
+TraceAccelerator::TraceAccelerator(Mode mode,
+                                   std::filesystem::path manifestJson,
+                                   std::filesystem::path traceFile) {
+  impl = std::make_unique<Impl>(mode, manifestJson, traceFile);
+}
+
+Service *TraceAccelerator::createService(Service::Type svcType,
+                                         AppIDPath idPath,
+                                         const ServiceImplDetails &details,
+                                         const HWClientDetails &clients) {
+  return impl->createService(svcType, idPath, details, clients);
+}
 namespace {
 class TraceSysInfo : public SysInfo {
 public:
@@ -88,56 +158,77 @@ private:
 } // namespace
 
 namespace {
-class TraceCustomService : public CustomService {
+class WriteTraceChannelPort : public WriteChannelPort {
 public:
-  using CustomService::CustomService;
+  WriteTraceChannelPort(TraceAccelerator::Impl &impl, const AppIDPath &id,
+                        const std::string &portName)
+      : impl(impl), id(id), portName(portName) {}
 
-  virtual std::map<std::string, ChannelPort *> requestChannelsFor(AppIDPath) {
-    return {};
+  virtual void write(const void *data, size_t size) override {
+    impl.write(id, portName, data, size);
   }
+
+protected:
+  TraceAccelerator::Impl &impl;
+  AppIDPath id;
+  std::string portName;
 };
 } // namespace
 
-struct esi::backends::trace::TraceAccelerator::Impl {
-  Impl(Mode mode, std::filesystem::path manifestJson,
-       std::filesystem::path traceFile)
-      : mode(mode), manifestJson(manifestJson), traceFile(traceFile) {
-    if (!filesystem::exists(manifestJson))
-      throw runtime_error("manifest file '" + manifestJson.string() +
-                          "' does not exist");
+namespace {
+class ReadTraceChannelPort : public ReadChannelPort {
+public:
+  ReadTraceChannelPort(TraceAccelerator::Impl &impl) {}
+
+  virtual ssize_t read(void *data, size_t maxSize) override;
+};
+} // namespace
+
+ssize_t ReadTraceChannelPort::read(void *data, size_t maxSize) {
+  uint8_t *dataPtr = reinterpret_cast<uint8_t *>(data);
+  for (size_t i = 0; i < maxSize; ++i)
+    dataPtr[i] = rand() % 256;
+  return maxSize;
+}
+
+namespace {
+class TraceCustomService : public CustomService {
+public:
+  TraceCustomService(TraceAccelerator::Impl &impl, AppIDPath idPath,
+                     const ServiceImplDetails &details,
+                     const HWClientDetails &clients)
+      : CustomService(idPath, details, clients), impl(impl) {}
+
+  virtual std::map<std::string, ChannelPort &>
+  requestChannelsFor(AppIDPath idPath, const BundleType &bundleType,
+                     BundlePort::Direction svcDir) override {
+    std::map<std::string, ChannelPort &> channels;
+    for (auto [name, dir, type] : bundleType.getChannels()) {
+      ChannelPort *port;
+      if (BundlePort::isWrite(dir, svcDir))
+        port = new WriteTraceChannelPort(impl, idPath, name);
+      else
+        port = new ReadTraceChannelPort(impl);
+      channels.emplace(name, *port);
+      impl.adoptChannelPort(port);
+    }
+    return channels;
   }
 
-  Service *createService(Service::Type svcType, AppIDPath idPath,
-                         const services::ServiceImplDetails &details,
-                         const services::HWClientDetails &clients);
-
 private:
-  Mode mode;
-  std::filesystem::path manifestJson;
-  std::filesystem::path traceFile;
+  TraceAccelerator::Impl &impl;
 };
+} // namespace
 
-Service *TraceAccelerator::Impl::createService(
-    Service::Type svcType, AppIDPath idPath,
-    const services::ServiceImplDetails &details,
-    const services::HWClientDetails &clients) {
+Service *
+TraceAccelerator::Impl::createService(Service::Type svcType, AppIDPath idPath,
+                                      const ServiceImplDetails &details,
+                                      const HWClientDetails &clients) {
   if (svcType == typeid(SysInfo))
     return new TraceSysInfo(manifestJson);
   if (svcType == typeid(CustomService))
-    return new TraceCustomService(idPath, details, clients);
+    return new TraceCustomService(*this, idPath, details, clients);
   return nullptr;
-}
-
-TraceAccelerator::TraceAccelerator(Mode mode,
-                                   std::filesystem::path manifestJson,
-                                   std::filesystem::path traceFile) {
-  impl = std::make_unique<Impl>(mode, manifestJson, traceFile);
-}
-Service *
-TraceAccelerator::createService(Service::Type svcType, AppIDPath idPath,
-                                const services::ServiceImplDetails &details,
-                                const services::HWClientDetails &clients) {
-  return impl->createService(svcType, idPath, details, clients);
 }
 
 REGISTER_ACCELERATOR("trace", TraceAccelerator);

--- a/lib/Dialect/ESI/runtime/python/esi/esiCppAccel.cpp
+++ b/lib/Dialect/ESI/runtime/python/esi/esiCppAccel.cpp
@@ -91,10 +91,16 @@ PYBIND11_MODULE(esiCppAccel, m) {
 
   py::class_<Accelerator>(m, "Accelerator")
       .def(py::init(&registry::connect))
-      .def("sysinfo", &Accelerator::getService<SysInfo>,
-           py::return_value_policy::reference_internal)
-      .def("get_service_mmio", &Accelerator::getService<services::MMIO>,
-           py::return_value_policy::reference_internal);
+      .def(
+          "sysinfo",
+          [](Accelerator &acc) {
+            return acc.getService<services::SysInfo>({});
+          },
+          py::return_value_policy::reference_internal)
+      .def(
+          "get_service_mmio",
+          [](Accelerator &acc) { return acc.getService<services::MMIO>({}); },
+          py::return_value_policy::reference_internal);
 
   py::class_<Manifest>(m, "Manifest")
       .def(py::init<std::string>())

--- a/lib/Dialect/ESI/runtime/python/esi/esiCppAccel.cpp
+++ b/lib/Dialect/ESI/runtime/python/esi/esiCppAccel.cpp
@@ -68,10 +68,34 @@ PYBIND11_MODULE(esiCppAccel, m) {
         return ret;
       });
 
+  py::class_<ChannelPort>(m, "ChannelPort");
+  py::class_<WriteChannelPort, ChannelPort>(m, "WriteChannelPort")
+      .def("write", [](WriteChannelPort &p, std::vector<uint8_t> data) {
+        p.write(data.data(), data.size());
+      });
+  py::class_<ReadChannelPort, ChannelPort>(m, "ReadChannelPort")
+      .def("read", [](ReadChannelPort &p, size_t maxSize) {
+        std::vector<uint8_t> data(maxSize);
+        ssize_t size = p.read(data.data(), data.size());
+        if (size < 0)
+          throw std::runtime_error("read failed");
+        data.resize(size);
+        return data;
+      });
+
+  py::class_<BundlePort>(m, "BundlePort")
+      .def("getWrite", &BundlePort::getRawWrite,
+           py::return_value_policy::reference)
+      .def("getRead", &BundlePort::getRawRead,
+           py::return_value_policy::reference);
+
   // Store this variable (not commonly done) as the "children" method needs for
   // "Instance" to be defined first.
-  auto design = py::class_<Design>(m, "Design")
-                    .def_property_readonly("info", &Design::info);
+  auto design =
+      py::class_<Design>(m, "Design")
+          .def_property_readonly("info", &Design::info)
+          .def_property_readonly("ports", &Design::getPorts,
+                                 py::return_value_policy::reference_internal);
 
   // In order to inherit methods from "Design", it needs to be defined first.
   py::class_<Instance, Design>(m, "Instance")

--- a/lib/Dialect/ESI/runtime/python/esi/esiCppAccel.pyi
+++ b/lib/Dialect/ESI/runtime/python/esi/esiCppAccel.pyi
@@ -7,8 +7,9 @@ from __future__ import annotations
 import typing
 
 __all__ = [
-    'Accelerator', 'AppID', 'Design', 'Instance', 'MMIO', 'Manifest',
-    'ModuleInfo', 'SysInfo', 'Type'
+    'Accelerator', 'AppID', 'BundlePort', 'ChannelPort', 'Design', 'Instance',
+    'MMIO', 'Manifest', 'ModuleInfo', 'ReadChannelPort', 'SysInfo', 'Type',
+    'WriteChannelPort'
 ]
 
 
@@ -38,6 +39,19 @@ class AppID:
     ...
 
 
+class BundlePort:
+
+  def getRead(self, arg0: str) -> ReadChannelPort:
+    ...
+
+  def getWrite(self, arg0: str) -> WriteChannelPort:
+    ...
+
+
+class ChannelPort:
+  pass
+
+
 class Design:
 
   @property
@@ -46,6 +60,10 @@ class Design:
 
   @property
   def info(self) -> ModuleInfo | None:
+    ...
+
+  @property
+  def ports(self) -> list[BundlePort]:
     ...
 
 
@@ -108,6 +126,12 @@ class ModuleInfo:
     ...
 
 
+class ReadChannelPort(ChannelPort):
+
+  def read(self, arg0: int) -> list[int]:
+    ...
+
+
 class SysInfo:
 
   def esi_version(self) -> int:
@@ -124,4 +148,10 @@ class Type:
 
   @property
   def id(self) -> str:
+    ...
+
+
+class WriteChannelPort(ChannelPort):
+
+  def write(self, arg0: list[int]) -> None:
     ...

--- a/test/Dialect/ESI/manifest.mlir
+++ b/test/Dialect/ESI/manifest.mlir
@@ -51,7 +51,7 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // HIER:        }
 
 // HW-LABEL:    hw.module @top
-// HW:            hw.instance "__manifest" @Cosim_Manifest<COMPRESSED_MANIFEST_SIZE: i32 = 780>(compressed_manifest: %{{.+}}: !hw.uarray<780xi8>) -> ()
+// HW:            hw.instance "__manifest" @Cosim_Manifest<COMPRESSED_MANIFEST_SIZE: i32 = {{.+}}>(compressed_manifest: %{{.+}}: !hw.uarray<{{.+}}xi8>) -> ()
 // HW-LABEL:    hw.module.extern @Cosim_Manifest<COMPRESSED_MANIFEST_SIZE: i32>(in %compressed_manifest : !hw.uarray<#hw.param.decl.ref<"COMPRESSED_MANIFEST_SIZE">xi8>) attributes {verilogName = "Cosim_Manifest"}
 
 // CHECK:       {
@@ -169,6 +169,10 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // CHECK-NEXT:              "direction": "toClient",
 // CHECK-NEXT:              "bundleType": {
 // CHECK-NEXT:                "circt_name": "!esi.bundle<[!esi.channel<i8> to \"recv\"]>"
+// CHECK-NEXT:              },
+// CHECK-NEXT:              "servicePort": {
+// CHECK-NEXT:                "inner": "Recv",
+// CHECK-NEXT:                "outer_sym": "HostComms"
 // CHECK-NEXT:              }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            {
@@ -179,6 +183,10 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // CHECK-NEXT:              "direction": "toServer",
 // CHECK-NEXT:              "bundleType": {
 // CHECK-NEXT:                "circt_name": "!esi.bundle<[!esi.channel<i8> to \"send\"]>"
+// CHECK-NEXT:              },
+// CHECK-NEXT:              "servicePort": {
+// CHECK-NEXT:                "inner": "Send",
+// CHECK-NEXT:                "outer_sym": "HostComms"
 // CHECK-NEXT:              }
 // CHECK-NEXT:            }
 // CHECK-NEXT:          ],
@@ -199,6 +207,10 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // CHECK-NEXT:              "direction": "toClient",
 // CHECK-NEXT:              "bundleType": {
 // CHECK-NEXT:                "circt_name": "!esi.bundle<[!esi.channel<i8> to \"recv\"]>"
+// CHECK-NEXT:              },
+// CHECK-NEXT:              "servicePort": {
+// CHECK-NEXT:                "inner": "Recv",
+// CHECK-NEXT:                "outer_sym": "HostComms"
 // CHECK-NEXT:              }
 // CHECK-NEXT:            },
 // CHECK-NEXT:            {
@@ -209,6 +221,10 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // CHECK-NEXT:              "direction": "toServer",
 // CHECK-NEXT:              "bundleType": {
 // CHECK-NEXT:                "circt_name": "!esi.bundle<[!esi.channel<i8> to \"send\"]>"
+// CHECK-NEXT:              },
+// CHECK-NEXT:              "servicePort": {
+// CHECK-NEXT:                "inner": "Send",
+// CHECK-NEXT:                "outer_sym": "HostComms"
 // CHECK-NEXT:              }
 // CHECK-NEXT:            }
 // CHECK-NEXT:          ],


### PR DESCRIPTION
Create ports in the design hierarchy and wire them up to the correct service. Patch is a bit larger than it probably should be since it includes some not-unrelated NFC refactoring and `TraceAccelerator` support for writing to trace files.