### PR TITLE
[OM] Remove enum type.

### DIFF
--- a/include/circt/Dialect/OM/OMTypes.h
+++ b/include/circt/Dialect/OM/OMTypes.h
@@ -21,14 +21,6 @@ namespace circt::om {
 // integer.
 bool isMapKeyValuePairType(mlir::Type);
 
-namespace detail {
-struct EnumElement {
-  mlir::StringAttr name;
-  mlir::Type type;
-};
-
-} // namespace detail
-
 } // namespace circt::om
 
 #define GET_TYPEDEF_CLASSES

--- a/include/circt/Dialect/OM/OMTypes.td
+++ b/include/circt/Dialect/OM/OMTypes.td
@@ -108,21 +108,6 @@ def FrozenPathType : TypeDef<OMDialect, "FrozenPath", []> {
   let mnemonic = "frozenpath";
 }
 
-def EnumType : TypeDef<OMDialect, "Enum", []> {
-  let summary = "An enum type";
-
-  let mnemonic = "enum";
-  let parameters = (
-    ins ArrayRefParameter<
-      "::circt::om::EnumType::EnumElement", 
-      "enum fields">: $elements
-  );
-  let hasCustomAssemblyFormat = 1;
-  let extraClassDeclaration = [{
-    using EnumElement = ::circt::om::detail::EnumElement;
-  }];
-}
-
 def OMAnyType : TypeDef<OMDialect, "Any", []> {
   let summary = "A type that represents any valid OM type.";
 

--- a/lib/Dialect/OM/OMTypes.cpp
+++ b/lib/Dialect/OM/OMTypes.cpp
@@ -20,7 +20,6 @@
 using namespace circt;
 using namespace mlir;
 using namespace circt::om;
-using namespace circt::om::detail;
 
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/OM/OMTypes.cpp.inc"
@@ -45,57 +44,4 @@ bool circt::om::isMapKeyValuePairType(mlir::Type type) {
   auto tuple = llvm::dyn_cast<mlir::TupleType>(type);
   return tuple && tuple.getTypes().size() == 2 &&
          llvm::isa<om::StringType, mlir::IntegerType>(tuple.getTypes().front());
-}
-
-namespace circt {
-namespace om {
-namespace detail {
-bool operator==(const EnumElement &a, const EnumElement &b) {
-  return a.name == b.name && a.type == b.type;
-}
-
-llvm::hash_code
-hash_value(const EnumElement &fi) { // NOLINT(readability-identifier-naming)
-  return llvm::hash_combine(fi.name, fi.type);
-}
-} // namespace detail
-} // namespace om
-} // namespace circt
-
-/// Parse a list of field names and types within <>. E.g.:
-/// <foo: i7, bar: i8>
-static mlir::ParseResult
-parseEnumFields(AsmParser &p,
-                SmallVectorImpl<EnumType::EnumElement> &parameters) {
-  return p.parseCommaSeparatedList(
-      mlir::AsmParser::Delimiter::LessGreater, [&]() -> ParseResult {
-        StringRef name;
-        Type type;
-        if (p.parseKeyword(&name) || p.parseColon() || p.parseType(type))
-          return failure();
-        parameters.push_back(
-            EnumType::EnumElement{StringAttr::get(p.getContext(), name), type});
-        return success();
-      });
-}
-
-/// Print out a list of named fields surrounded by <>.
-static void printEnumFields(AsmPrinter &p,
-                            ArrayRef<EnumType::EnumElement> fields) {
-  p << '<';
-  llvm::interleaveComma(fields, p, [&](const EnumType::EnumElement &field) {
-    p << field.name.getValue() << ": " << field.type;
-  });
-  p << '>';
-}
-
-mlir::Type circt::om::EnumType::parse(AsmParser &p) {
-  llvm::SmallVector<EnumType::EnumElement, 4> parameters;
-  if (parseEnumFields(p, parameters))
-    return Type();
-  return get(p.getContext(), parameters);
-}
-
-void circt::om::EnumType::print(AsmPrinter &p) const {
-  printEnumFields(p, getElements());
 }

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -266,12 +266,6 @@ om.class @FrozenPath(%basepath: !om.frozenbasepath) {
   %1 = om.frozenpath_create reference %basepath "Foo/bar:Bar>w.a"
 }
 
-// CHECK-LABEL: @Enum
-// CHECK-SAME: !om.enum<a: !om.string, b: i64>
-om.class @Enum(%e : !om.enum<a: !om.string, b: i64>) {
-  om.class.field @map_i64, %e : !om.enum<a: !om.string, b: i64>
-}
-
 // CHECK-LABEL: @Any
 // CHECK-SAME: %[[IN:.+]]: !om.class.type
 om.class @Any(%in: !om.class.type<@Empty>) {


### PR DESCRIPTION
This type wasn't needed after all. We may eventually want some form of this, but there is no immediate need. Removing this for now reduces maintainence burden until we are sure what we want.