### PR TITLE
[FIRRTL] Add GroupMerge pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -185,6 +185,8 @@ std::unique_ptr<mlir::Pass> createLowerClassesPass();
 
 std::unique_ptr<mlir::Pass> createLowerGroupsPass();
 
+std::unique_ptr<mlir::Pass> createGroupMergePass();
+
 std::unique_ptr<mlir::Pass> createGroupSinkPass();
 
 std::unique_ptr<mlir::Pass> createMaterializeDebugInfoPass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -748,6 +748,18 @@ def LowerGroups : Pass<"firrtl-lower-groups", "firrtl::CircuitOp"> {
   let dependentDialects = ["sv::SVDialect"];
 }
 
+def GroupMerge : Pass<"firrtl-group-merge", "firrtl::FModuleOp"> {
+  let summary = "Merge group definitions";
+  let description = [{
+    Combine all group definitions in a module which reference the same group
+    declaration.
+  }];
+  let constructor = "::circt::firrtl::createGroupMergePass()";
+  let statistics = [
+    Statistic<"numMerged", "num-merged", "Number of groups merged">,
+  ];
+}
+
 def GroupSink : Pass<"firrtl-group-sink", "firrtl::FModuleOp"> {
   let summary = "Sink operations into FIRRTL optional groups";
   let description = [{

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -12,6 +12,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   FinalizeIR.cpp
   FlattenMemory.cpp
   GrandCentral.cpp
+  GroupMerge.cpp
   GroupSink.cpp
   HoistPassthrough.cpp
   IMConstProp.cpp

--- a/lib/Dialect/FIRRTL/Transforms/GroupMerge.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GroupMerge.cpp
@@ -1,0 +1,77 @@
+//===- GroupMerge.cpp - Merge optional groups together --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass merges group definitions which reference the same group
+// declaration.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "mlir/IR/PatternMatch.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "firrtl-group-merge"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+/// A pass that merges optional groups referencing the same group declaration.
+struct GroupMerge : public GroupMergeBase<GroupMerge> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void GroupMerge::runOnOperation() {
+  LLVM_DEBUG(
+      llvm::dbgs() << "==----- Running GroupMerge "
+                      "--------------------------------------------------===\n"
+                   << "Module: '" << getOperation().getName() << "'\n";);
+
+  // Track the last group that we saw which referenced a specific group
+  // declaration.  Because this pass operates as a single walk of the IR, it is
+  // only ever possible that there is one prior group that references a given
+  // group declaration.
+  llvm::DenseMap<SymbolRefAttr, GroupOp> priorGroups;
+
+  // Recursively walk GroupOps in the module.  Whenever we see a group, check to
+  // see if there is a prior group that references the same declaration.  If
+  // not, this group becomes the prior group and we continue.  If there is a
+  // prior group, then splice the prior group's body into the beginning of this
+  // group and erase the prior group.  This group then becomes the new prior
+  // group.
+  //
+  // The recursive walk will cause nested groups to also be merged.
+  auto moduleOp = getOperation();
+  mlir::IRRewriter rewriter(moduleOp.getContext());
+  moduleOp.walk([&](GroupOp group) {
+    auto groupName = group.getGroupName();
+    // If we haven't seen this group before, then just insert it into
+    // priorGroups.
+    auto priorGroupIt = priorGroups.find(groupName);
+    if (priorGroupIt == priorGroups.end()) {
+      priorGroups[groupName] = group;
+      return WalkResult::advance();
+    }
+
+    // Merge the prior group's body into this group.  Erase the prior group.
+    // This merged group is now the new prior group (and will be merged into the
+    // next group if one is found).
+    auto &priorGroup = priorGroupIt->getSecond();
+    rewriter.inlineBlockBefore(priorGroup.getBody(), group.getBody(),
+                               group.getBody()->begin());
+    priorGroup->erase();
+    priorGroups[groupName] = group;
+    numMerged++;
+    return WalkResult::advance();
+  });
+}
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createGroupMergePass() {
+  return std::make_unique<GroupMerge>();
+}

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -118,6 +118,7 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
 
   auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
   modulePM.addPass(firrtl::createSFCCompatPass());
+  modulePM.addPass(firrtl::createGroupMergePass());
   modulePM.addPass(firrtl::createGroupSinkPass());
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerGroupsPass());

--- a/test/Dialect/FIRRTL/group-merge.mlir
+++ b/test/Dialect/FIRRTL/group-merge.mlir
@@ -1,0 +1,33 @@
+// RUN: circt-opt -pass-pipeline="builtin.module(firrtl.circuit(firrtl.module(firrtl-group-merge)))" %s | FileCheck %s
+
+// CHECK-LABEL: firrtl.circuit "SimpleMerge"
+firrtl.circuit "SimpleMerge" {
+  firrtl.declgroup @A  bind {
+    firrtl.declgroup @B  bind {
+    }
+  }
+  // CHECK: firrtl.module @SimpleMerge
+  firrtl.module @SimpleMerge(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>) {
+    // CHECK-NEXT: firrtl.group @A {
+    // CHECK-NEXT:   %A_a = firrtl.node %a
+    // CHECK-NEXT:   %A_b = firrtl.node %b
+    // CHECK-NEXT:   firrtl.group @A::@B {
+    // CHECK-NEXT:     %A_B_a = firrtl.node %A_a
+    // CHECK-NEXT:     %A_B_b = firrtl.node %A_b
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
+    // CHECK-NOT:  firrtl.group
+    firrtl.group @A {
+      %A_a = firrtl.node %a : !firrtl.uint<1>
+      firrtl.group @A::@B {
+        %A_B_a = firrtl.node %A_a : !firrtl.uint<1>
+      }
+    }
+    firrtl.group @A {
+      %A_b = firrtl.node %b : !firrtl.uint<1>
+      firrtl.group @A::@B {
+        %A_B_b = firrtl.node %A_b : !firrtl.uint<1>
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a pass that merges optional groups which reference the same
declaration.  This exposes additional optimization opportunities and
produces better Verilog output for groups.

Add this pass to `firtool`.

Fixes #6228.

#### Example

Input:

```
FIRRTL version 3.3.0
circuit Foo: %[[
  {"class":"firrtl.transforms.DontTouchAnnotation", "target":"~Foo|Foo>A_a"},
  {"class":"firrtl.transforms.DontTouchAnnotation", "target":"~Foo|Foo>A_b"},
  {"class":"firrtl.transforms.DontTouchAnnotation", "target":"~Foo|Foo>A_B_a"},
  {"class":"firrtl.transforms.DontTouchAnnotation", "target":"~Foo|Foo>A_B_b"}
]]
  declgroup A, bind:
    declgroup B, bind:

  module Foo:
    input a: UInt<1>
    input b: UInt<1>

    group A:
      node A_a = a
      group B:
        node A_B_a = A_a

    group A:
      node A_b = b
      group B:
        node A_B_b = A_b
```

Old output (without this PR):
``` verilog
// Generated by CIRCT firtool-1.57.1-100-g460016cea
module Foo_A_B(
  input _A_a
);

  wire A_B_a = _A_a;
endmodule

module Foo_A(
  input _a
);

  wire A_a = _a;
  wire A_a_probe = A_a;
endmodule

module Foo_A_B_0(
  input _A_b
);

  wire A_B_b = _A_b;
endmodule

module Foo_A_0(
  input _b
);

  wire A_b = _b;
  wire A_b_probe = A_b;
endmodule

module Foo(
  input a,
        b
);

endmodule


// ----- 8< ----- FILE "groups_Foo_A_B.sv" ----- 8< -----

// Generated by CIRCT firtool-1.57.1-100-g460016cea
`include "groups_Foo_A.sv"
`ifndef groups_Foo_A_B
`define groups_Foo_A_B
bind Foo Foo_A_B foo_A_B (
  ._A_a (Foo.foo_A.A_a_probe)
);
bind Foo Foo_A_B_0 foo_A_B_0 (
  ._A_b (Foo.foo_A_0.A_b_probe)
);
`endif // groups_Foo_A_B

// ----- 8< ----- FILE "groups_Foo_A.sv" ----- 8< -----

// Generated by CIRCT firtool-1.57.1-100-g460016cea
`ifndef groups_Foo_A
`define groups_Foo_A
bind Foo Foo_A foo_A (
  ._a (a)
);
bind Foo Foo_A_0 foo_A_0 (
  ._b (b)
);
`endif // groups_Foo_A
```

New output (with this PR):
``` verilog
// Generated by CIRCT firtool-1.57.1-100-g460016cea
module Foo_A_B(
  input _A_a,
        _A_b
);

  wire A_B_a = _A_a;
  wire A_B_b = _A_b;
endmodule

module Foo_A(
  input _a,
        _b
);

  wire A_a = _a;
  wire A_b = _b;
  wire A_a_probe = A_a;
  wire A_b_probe = A_b;
endmodule

module Foo(
  input a,
        b
);

endmodule


// ----- 8< ----- FILE "groups_Foo_A_B.sv" ----- 8< -----

// Generated by CIRCT firtool-1.57.1-100-g460016cea
`include "groups_Foo_A.sv"
`ifndef groups_Foo_A_B
`define groups_Foo_A_B
bind Foo Foo_A_B foo_A_B (
  ._A_a (Foo.foo_A.A_a_probe),
  ._A_b (Foo.foo_A.A_b_probe)
);
`endif // groups_Foo_A_B

// ----- 8< ----- FILE "groups_Foo_A.sv" ----- 8< -----

// Generated by CIRCT firtool-1.57.1-100-g460016cea
`ifndef groups_Foo_A
`define groups_Foo_A
bind Foo Foo_A foo_A (
  ._a (a),
  ._b (b)
);
`endif // groups_Foo_A
```