### PR TITLE
[HW] Move getPortVerilogName helper into HW PortInfo; NFC

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -50,6 +50,12 @@ struct PortInfo : public ModulePort {
   // Inspect or mutate attributes
   InnerSymAttr getSym() const;
   void setSym(InnerSymAttr sym, MLIRContext *ctx);
+
+  // Return the port's Verilog name. This returns either the port's name, or the
+  // `hw.verilogName` attribute if one is present. After `ExportVerilog` has
+  // run, this will reflect the exact name of the port as emitted to the Verilog
+  // output.
+  StringRef getVerilogName() const;
 };
 
 raw_ostream &operator<<(raw_ostream &printer, PortInfo port);

--- a/lib/Dialect/HW/HWOpInterfaces.cpp
+++ b/lib/Dialect/HW/HWOpInterfaces.cpp
@@ -43,6 +43,13 @@ void hw::PortInfo::setSym(InnerSymAttr sym, MLIRContext *ctx) {
   }
 }
 
+StringRef hw::PortInfo::getVerilogName() const {
+  if (attrs)
+    if (auto updatedName = attrs.get("hw.verilogName"))
+      return updatedName.cast<StringAttr>().getValue();
+  return name.getValue();
+}
+
 LogicalResult hw::verifyInnerSymAttr(InnerSymbolOpInterface op) {
   auto innerSym = op.getInnerSymAttr();
   // If does not have any inner sym then ignore.


### PR DESCRIPTION
Pull the `getPortVerilogName` helper out of `ExportVerilog` and move it into the `hw::PortInfo` struct as `getVerilogName`. This allows other passes that run after Verilog emission to query a port's Verilog name without duplicating that piece of code.