### PR TITLE
[FIRRTL][LowerType] Handle unrealized_conversion_cast of other dialects

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1334,9 +1334,9 @@ bool TypeLoweringVisitor::visitExpr(mlir::UnrealizedConversionCastOp op) {
     return builder->create<mlir::UnrealizedConversionCastOp>(field.type, input)
         .getResult(0);
   };
-  // If the input to the cast is an unknown type, getSubWhatever cannot handle
+  // If the input to the cast is not a FIRRTL type, getSubWhatever cannot handle
   // it, donot lower the op.
-  if (!isa<FVectorType, BundleType, RefType>(op->getOperand(0).getType()))
+  if (!type_isa<FIRRTLType>(op->getOperand(0).getType()))
     return false;
   return lowerProducer(op, clone);
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1334,6 +1334,10 @@ bool TypeLoweringVisitor::visitExpr(mlir::UnrealizedConversionCastOp op) {
     return builder->create<mlir::UnrealizedConversionCastOp>(field.type, input)
         .getResult(0);
   };
+  // If the input to the cast is an unknown type, getSubWhatever cannot handle
+  // it, donot lower the op.
+  if (!isa<FVectorType, BundleType, RefType>(op->getOperand(0).getType()))
+    return false;
   return lowerProducer(op, clone);
 }
 


### PR DESCRIPTION
LowerTypes was crashing when lowering `unrealized_conversion_cast` from other dialects.
This PR fixes the crash and ignores the cast op from other dialects instead of lowering them.