### PR TITLE
[Firtool][CAPI] Remove dedup option from C API

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -81,7 +81,6 @@ DECLARE_FIRTOOL_OPTION(DisableOptimization, bool);
 DECLARE_FIRTOOL_OPTION(ExportChiselInterface, bool);
 DECLARE_FIRTOOL_OPTION(ChiselInterfaceOutDirectory, MlirStringRef);
 DECLARE_FIRTOOL_OPTION(VbToBv, bool);
-DECLARE_FIRTOOL_OPTION(Dedup, bool);
 DECLARE_FIRTOOL_OPTION(CompanionMode, FirtoolCompanionMode);
 DECLARE_FIRTOOL_OPTION(DisableAggressiveMergeConnections, bool);
 DECLARE_FIRTOOL_OPTION(EmitOMIR, bool);

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -143,7 +143,6 @@ DEFINE_FIRTOOL_OPTION_BOOL(ExportChiselInterface, exportChiselInterface)
 DEFINE_FIRTOOL_OPTION_STRING(ChiselInterfaceOutDirectory,
                              chiselInterfaceOutDirectory)
 DEFINE_FIRTOOL_OPTION_BOOL(VbToBv, vbToBV)
-DEFINE_FIRTOOL_OPTION_BOOL(Dedup, dedup)
 DEFINE_FIRTOOL_OPTION_ENUM(
     CompanionMode, companionMode, FirtoolCompanionMode,
     [](FirtoolCompanionMode value) {


### PR DESCRIPTION
Option was removed in cac97104a042e7ebfa06ed24b82c0137d0e5d7e3