### PR TITLE
[InstanceGraph] Remove the module lookup helper

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -130,6 +130,21 @@ def InstanceOp : HardwareDeclOp<"instance", [
     InstanceOp cloneAndInsertPorts(ArrayRef<std::pair<unsigned, PortInfo>> ports);
 
     //===------------------------------------------------------------------===//
+    // Instance graph methods
+    //===------------------------------------------------------------------===//
+
+    // Quick lookup of the referenced module using the instance graph.
+    template <typename T = ::circt::igraph::ModuleOpInterface>
+    T getReferencedModule(::circt::igraph::InstanceGraph &instanceGraph) {
+      auto moduleNameAttr = getModuleNameAttr().getAttr();
+      auto *node =  instanceGraph.lookup(moduleNameAttr);
+      if (!node)
+        return nullptr;
+      Operation *moduleOp = node->getModule();
+      return dyn_cast_or_null<T>(moduleOp);
+    }
+
+    //===------------------------------------------------------------------===//
     // PortList Methods
     //===------------------------------------------------------------------===//
     SmallVector<::circt::hw::PortInfo> getPortList();
@@ -598,7 +613,7 @@ def ObjectOp :  FIRRTLOp<"object", [
     ParentOneOf<["firrtl::FModuleOp, firrtl::ClassOp"]>,
     DeclareOpInterfaceMethods<SymbolUserOpInterface>,
     DeclareOpInterfaceMethods<FInstanceLike, [
-      "getReferencedModule"
+      "getReferencedOperation"
     ]>,
     DeclareOpInterfaceMethods<InstanceGraphInstanceOpInterface, [
       "getReferencedModuleName",

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -364,7 +364,7 @@ def FInstanceLike : OpInterface<"FInstanceLike", [
 
   let methods = [
     InterfaceMethod<"Get the referenced module via a symbol table.",
-    "::mlir::Operation *", "getReferencedModule",
+    "::mlir::Operation *", "getReferencedOperation",
     (ins "const SymbolTable&":$symtbl),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -20,6 +20,7 @@
 #include "circt/Dialect/HW/InnerSymbolTable.h"
 #include "circt/Dialect/Seq/SeqAttributes.h"
 #include "circt/Support/FieldRef.h"
+#include "circt/Support/InstanceGraph.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/RegionKindInterface.h"

--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -209,14 +209,6 @@ public:
   /// Lookup an InstanceGraphNode for a module.
   InstanceGraphNode *operator[](ModuleOpInterface op) { return lookup(op); }
 
-  /// Look up the referenced module from an InstanceOp. This will use a
-  /// hashtable lookup to find the module, where
-  /// InstanceOp.getReferencedModule() will be a linear search through the IR.
-  template <typename TTarget = ModuleOpInterface>
-  auto getReferencedModule(InstanceOpInterface op) {
-    return cast<TTarget>(getReferencedModuleImpl(op).getOperation());
-  }
-
   /// Check if child is instantiated by a parent.
   bool isAncestor(ModuleOpInterface child, ModuleOpInterface parent);
 
@@ -330,8 +322,8 @@ static T &operator<<(T &os, const InstancePath &path) {
   return path.print(os);
 }
 
-/// A data structure that caches and provides absolute paths to module instances
-/// in the IR.
+/// A data structure that caches and provides absolute paths to module
+/// instances in the IR.
 struct InstancePathCache {
   /// The instance graph of the IR.
   InstanceGraph &instanceGraph;

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -244,7 +244,7 @@ firrtl::resolveEntities(TokenAnnoTarget path, CircuitOp circuit,
   ArrayRef<TargetToken> component(path.component);
   if (auto instance = dyn_cast<InstanceOp>(ref.getOp())) {
     instances.push_back(instance);
-    auto target = cast<FModuleLike>(instance.getReferencedModule(symTbl));
+    auto target = cast<FModuleLike>(instance.getReferencedOperation(symTbl));
     if (component.empty()) {
       ref = OpAnnoTarget(target);
     } else if (component.front().isIndex) {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2919,7 +2919,7 @@ ClassLike ObjectOp::getReferencedClass(const SymbolTable &symbolTable) {
   return symbolTable.lookup<ClassLike>(symRef.getLeafReference());
 }
 
-Operation *ObjectOp::getReferencedModule(const SymbolTable &symtbl) {
+Operation *ObjectOp::getReferencedOperation(const SymbolTable &symtbl) {
   return getReferencedClass(symtbl);
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -194,7 +194,7 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp module, bool isDUT) {
 
   for (auto &op : llvm::make_early_inc_range(*module.getBodyBlock())) {
     if (auto inst = dyn_cast<InstanceOp>(op)) {
-      auto submodule = instanceGraph->getReferencedModule(inst);
+      auto submodule = inst.getReferencedModule(*instanceGraph);
 
       auto subMemInfoIt = memInfoMap.find(submodule);
       // If there are no extra ports, we don't have to do anything.

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -376,8 +376,7 @@ public:
     if (auto inst = dyn_cast_or_null<InstanceOp>(ref.getDefiningOp())) {
       auto res = cast<OpResult>(ref.getValue());
       auto portNum = res.getResultNumber();
-      auto refMod =
-          dyn_cast_or_null<FModuleOp>(*instanceGraph.getReferencedModule(inst));
+      auto refMod = inst.getReferencedModule<FModuleOp>(instanceGraph);
       if (!refMod)
         return;
       FieldRef modArg(refMod.getArgument(portNum), ref.getFieldID());

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -620,20 +620,20 @@ struct Equivalence {
   LogicalResult check(InFlightDiagnostic &diag, InstanceOp a, InstanceOp b) {
     auto aName = a.getModuleNameAttr().getAttr();
     auto bName = b.getModuleNameAttr().getAttr();
+    if (aName == bName)
+      return success();
+
     // If the modules instantiate are different we will want to know why the
     // sub module did not dedupliate. This code recursively checks the child
     // module.
-    if (aName != bName) {
-      auto aModule = instanceGraph.getReferencedModule(a);
-      auto bModule = instanceGraph.getReferencedModule(b);
-      // Create a new error for the submodule.
-      diag.attachNote(std::nullopt)
-          << "in instance " << a.getNameAttr() << " of " << aName
-          << ", and instance " << b.getNameAttr() << " of " << bName;
-      check(diag, aModule, bModule);
-      return failure();
-    }
-    return success();
+    auto aModule = a.getReferencedModule(instanceGraph);
+    auto bModule = b.getReferencedModule(instanceGraph);
+    // Create a new error for the submodule.
+    diag.attachNote(std::nullopt)
+        << "in instance " << a.getNameAttr() << " of " << aName
+        << ", and instance " << b.getNameAttr() << " of " << bName;
+    check(diag, aModule, bModule);
+    return failure();
   }
 
   // NOLINTNEXTLINE(misc-no-recursion)

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -278,7 +278,7 @@ void ExtractInstancesPass::collectAnnos() {
   // Gather the annotations on instances to be extracted.
   circuit.walk([&](InstanceOp inst) {
     SmallVector<Annotation, 1> instAnnos;
-    Operation *module = instanceGraph->getReferencedModule(inst);
+    Operation *module = inst.getReferencedModule(*instanceGraph);
 
     // Module-level annotations.
     auto it = annotatedModules.find(module);

--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -565,7 +565,7 @@ void IMConstPropPass::markInvalidValueOp(InvalidValueOp invalid) {
 /// enclosing block is marked live.  This sets up the def-use edges for ports.
 void IMConstPropPass::markInstanceOp(InstanceOp instance) {
   // Get the module being reference or a null pointer if this is an extmodule.
-  Operation *op = instanceGraph->getReferencedModule(instance);
+  Operation *op = instance.getReferencedModule(*instanceGraph);
 
   // If this is an extmodule, just remember that any results and inouts are
   // overdefined.
@@ -721,12 +721,11 @@ void IMConstPropPass::visitConnectLike(FConnectLike connect,
     if (auto instance = dest.getDefiningOp<InstanceOp>()) {
       // Update the dest, when its an instance op.
       mergeLatticeValue(fieldRefDestConnected, srcValue);
-      auto module =
-          dyn_cast<FModuleOp>(*instanceGraph->getReferencedModule(instance));
-      if (!module)
+      auto mod = instance.getReferencedModule<FModuleOp>(*instanceGraph);
+      if (!mod)
         return;
 
-      BlockArgument modulePortVal = module.getArgument(dest.getResultNumber());
+      BlockArgument modulePortVal = mod.getArgument(dest.getResultNumber());
 
       return mergeLatticeValue(
           FieldRef(modulePortVal, fieldRefDestConnected.getFieldID()),

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -128,8 +128,7 @@ private:
 void IMDeadCodeElimPass::visitInstanceOp(InstanceOp instance) {
   markBlockUndeletable(instance);
 
-  auto module =
-      dyn_cast<FModuleOp>(*instanceGraph->getReferencedModule(instance));
+  auto module = instance.getReferencedModule<FModuleOp>(*instanceGraph);
 
   if (!module)
     return;
@@ -198,7 +197,7 @@ void IMDeadCodeElimPass::visitUser(Operation *op) {
 
 void IMDeadCodeElimPass::markInstanceOp(InstanceOp instance) {
   // Get the module being referenced.
-  Operation *op = instanceGraph->getReferencedModule(instance);
+  Operation *op = instance.getReferencedModule(*instanceGraph);
 
   // If this is an extmodule, just remember that any inputs and inouts are
   // alive.
@@ -487,8 +486,7 @@ void IMDeadCodeElimPass::visitValue(Value value) {
   if (auto instance = value.getDefiningOp<InstanceOp>()) {
     auto instanceResult = value.cast<mlir::OpResult>();
     // Update the src, when it's an instance op.
-    auto module =
-        dyn_cast<FModuleOp>(*instanceGraph->getReferencedModule(instance));
+    auto module = instance.getReferencedModule<FModuleOp>(*instanceGraph);
 
     // Propagate liveness only when a port is output.
     if (!module || module.getPortDirection(instanceResult.getResultNumber()) ==

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1635,7 +1635,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
 
       // Handle instances of other modules.
       .Case<InstanceOp>([&](auto op) {
-        auto refdModule = op.getReferencedModule(symtbl);
+        auto refdModule = op.getReferencedOperation(symtbl);
         auto module = dyn_cast<FModuleOp>(&*refdModule);
         if (!module) {
           auto diag = mlir::emitError(op.getLoc());

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -808,8 +808,8 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     while (!sources.empty() && !sinks.empty()) {
       if (sources.top() != sinks.top())
         break;
-      auto newLCA = sources.top();
-      lca = cast<FModuleOp>(instanceGraph.getReferencedModule(newLCA));
+      auto newLCA = cast<InstanceOp>(*sources.top());
+      lca = cast<FModuleOp>(newLCA.getReferencedModule(instanceGraph));
       sources = sources.dropFront();
       sinks = sinks.dropFront();
     }
@@ -885,8 +885,9 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     auto addPorts = [&](igraph::InstancePath insts, Value val, Type tpe,
                         Direction dir) {
       StringRef name, instName;
-      for (auto inst : llvm::reverse(insts)) {
-        auto mod = instanceGraph.getReferencedModule<FModuleOp>(inst);
+      for (auto instNode : llvm::reverse(insts)) {
+        auto inst = cast<InstanceOp>(*instNode);
+        auto mod = inst.getReferencedModule<FModuleOp>(instanceGraph);
         if (name.empty()) {
           if (problem.newNameHint.empty())
             name = state.getNamespace(mod).newName(

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1444,7 +1444,7 @@ bool TypeLoweringVisitor::visitDecl(InstanceOp op) {
   SmallVector<Attribute> newNames;
   SmallVector<Attribute> newPortAnno;
   PreserveAggregate::PreserveMode mode = getPreservationModeForModule(
-      cast<FModuleLike>(op.getReferencedModule(symTbl)));
+      cast<FModuleLike>(op.getReferencedOperation(symTbl)));
 
   endFields.push_back(0);
   for (size_t i = 0, e = op.getNumResults(); i != e; ++i) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -517,7 +517,7 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
   // Propagate the reachable RefSendOp across modules.
   LogicalResult handleInstanceOp(InstanceOp inst,
                                  InstanceGraph &instanceGraph) {
-    Operation *mod = instanceGraph.getReferencedModule(inst);
+    Operation *mod = inst.getReferencedModule(instanceGraph);
     if (auto extRefMod = dyn_cast<FExtModuleOp>(mod)) {
       // Extern modules can generate RefType ports, they have an attached
       // attribute which specifies the internal path into the extern module.

--- a/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PrefixModules.cpp
@@ -205,8 +205,7 @@ void PrefixModulesPass::renameModuleBody(std::string prefix, StringRef oldName,
         newPrefix = StringAttr::get(context, prefix);
       memOp->setAttr("prefix", newPrefix);
     } else if (auto instanceOp = dyn_cast<InstanceOp>(op)) {
-      auto target = dyn_cast<FModuleLike>(
-          *instanceGraph->getReferencedModule(instanceOp));
+      auto target = instanceOp.getReferencedModule(*instanceGraph);
 
       // Skip all external modules, unless one of the following conditions
       // is true:

--- a/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
@@ -64,7 +64,7 @@ struct PathResolver {
     // through the list of instances looking for the first module which is
     // multiply instantiated.  We will start our HierPathOp at this instance.
     auto *it = llvm::find_if(target.instances, [&](InstanceOp instance) {
-      auto *node = instanceGraph[instanceGraph.getReferencedModule(instance)];
+      auto *node = instanceGraph.lookup(instance.getReferencedModuleNameAttr());
       return !node->hasOneUse();
     });
 

--- a/lib/Dialect/HW/HWReductions.cpp
+++ b/lib/Dialect/HW/HWReductions.cpp
@@ -34,10 +34,12 @@ struct ModuleSizeCache {
     uint64_t size = 1;
     module->walk([&](Operation *op) {
       size += 1;
-      if (auto instOp = dyn_cast<HWInstanceLike>(op))
+      if (auto instOp = dyn_cast<HWInstanceLike>(op)) {
+        auto *node = instanceGraph.lookup(instOp.getReferencedModuleNameAttr());
         if (auto instModule =
-                instanceGraph.getReferencedModule<hw::HWModuleLike>(instOp))
+                dyn_cast_or_null<hw::HWModuleLike>(*node->getModule()))
           size += getModuleSize(instModule, instanceGraph);
+      }
     });
     moduleSizes.insert({module, size});
     return size;

--- a/lib/Dialect/Ibis/Transforms/IbisTunneling.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisTunneling.cpp
@@ -287,8 +287,8 @@ LogicalResult Tunneler::tunnelDown(InstanceGraphNode *currentContainer,
 
   // We're not in the target, but tunneling into a child instance.
   // Create output ports in the child instance for the requested ports.
-  auto *tunnelScopeNode = ig.lookup(ig.getReferencedModule(
-      cast<InstanceOpInterface>(tunnelInstance.getOperation())));
+  auto *tunnelScopeNode =
+      ig.lookup(tunnelInstance.getReferencedModuleNameAttr());
   auto tunnelScope = tunnelScopeNode->getModule<ScopeOpInterface>();
 
   rewriter.setInsertionPointToEnd(tunnelScope.getBodyBlock());

--- a/lib/LogicalEquivalence/LogicExporter.cpp
+++ b/lib/LogicalEquivalence/LogicExporter.cpp
@@ -74,8 +74,8 @@ struct Visitor : public hw::StmtVisitor<Visitor, LogicalResult>,
   //===--------------------------------------------------------------------===//
 
   LogicalResult visitStmt(hw::InstanceOp op) {
-    if (auto hwModule =
-            llvm::dyn_cast<hw::HWModuleOp>(op.getReferencedModuleSlow())) {
+    if (auto hwModule = llvm::dyn_cast<hw::HWModuleOp>(
+            op.getReferencedModuleCached(/*cache=*/nullptr))) {
       circuit->addInstance(op.getInstanceName(), hwModule, op->getOperands(),
                            op->getResults());
       return success();


### PR DESCRIPTION
The instance graph is transitioning towards supporting multiple possible targets for instance operations. As a consequence, it can no longer assume that there are instance operations with a single target and it will expose a generic interface returning a list of targets.

This PR removes the lookup helper from the graph and instead provides the users (`firrtl::InstanceOp` in particular) with helpers to fetch the unique referenced instance.