### PR TITLE
[ESI] Cosim: punt endpoint naming to users

### DIFF
--- a/include/circt/Dialect/ESI/ESIChannels.td
+++ b/include/circt/Dialect/ESI/ESIChannels.td
@@ -475,13 +475,15 @@ def CosimToHostEndpointOp : ESI_Physical_Op<"cosim.to_host", []> {
 
     It is uni-directional, in this case sending data from the simulation to the
     host.
+
+    NOTE: $id MUST be unique across all endpoints at simulation runtime.
   }];
 
   let arguments = (ins ClockType:$clk, I1:$rst,
-                       ChannelType:$toHost, StrAttr:$name);
+                       ChannelType:$toHost, StrAttr:$id);
 
   let assemblyFormat = [{
-    $clk `,` $rst `,` $toHost`,` $name attr-dict `:` qualified(type($toHost))
+    $clk `,` $rst `,` $toHost`,` $id attr-dict `:` qualified(type($toHost))
   }];
 }
 
@@ -494,13 +496,15 @@ def CosimFromHostEndpointOp : ESI_Physical_Op<"cosim.from_host", []> {
 
     It is uni-directional, in this case receiving data from the host for the
     simulation.
+
+    NOTE: $id MUST be unique across all endpoints at simulation runtime.
   }];
 
-  let arguments = (ins ClockType:$clk, I1:$rst, StrAttr:$name);
+  let arguments = (ins ClockType:$clk, I1:$rst, StrAttr:$id);
   let results = (outs ChannelType:$fromHost);
 
   let assemblyFormat = [{
-    $clk `,` $rst `,` $name attr-dict `:` qualified(type($fromHost))
+    $clk `,` $rst `,` $id attr-dict `:` qualified(type($fromHost))
   }];
 }
 

--- a/integration_test/Dialect/ESI/cosim/cosim_only.sv
+++ b/integration_test/Dialect/ESI/cosim/cosim_only.sv
@@ -33,6 +33,7 @@ module top(
     logic [31:0] DataIn;
 
     Cosim_Endpoint_FromHost #(
+        .ENDPOINT_ID("fromHost"),
         .FROM_HOST_TYPE_ID("i24"),
         .FROM_HOST_SIZE_BITS(24)
     ) fromHost (
@@ -40,6 +41,7 @@ module top(
     );
 
     Cosim_Endpoint_ToHost #(
+        .ENDPOINT_ID("toHost"),
         .TO_HOST_TYPE_ID("i32"),
         .TO_HOST_SIZE_BITS(32)
     ) toHost (

--- a/integration_test/Dialect/ESI/cosim/loopback.py
+++ b/integration_test/Dialect/ESI/cosim/loopback.py
@@ -13,8 +13,8 @@ class LoopbackTester(esi_cosim.CosimBase):
     assert len(ifaces) > 0
 
   def test_two_chan_loopback(self, num_msgs):
-    to_hw = self.openEP("top.loopback_inst5B05D_loopback_tohw_recv")
-    from_hw = self.openEP("top.loopback_inst5B05D_loopback_fromhw_send")
+    to_hw = self.openEP("loopback_inst[0].loopback_tohw.recv")
+    from_hw = self.openEP("loopback_inst[0].loopback_fromhw.send")
     for _ in range(num_msgs):
       i = random.randint(0, 2**8 - 1)
       print(f"Sending {i}")
@@ -38,8 +38,8 @@ class LoopbackTester(esi_cosim.CosimBase):
     return i
 
   def test_3bytes(self, num_msgs=50):
-    send_ep = self.openEP("top.fromHost", from_host_type="i24")
-    recv_ep = self.openEP("top.toHost", to_host_type="i32")
+    send_ep = self.openEP("fromHost", from_host_type="i24")
+    recv_ep = self.openEP("toHost", to_host_type="i32")
     print("Testing writes")
     dataSent = list()
     for _ in range(num_msgs):

--- a/lib/Dialect/ESI/ESIPasses.cpp
+++ b/lib/Dialect/ESI/ESIPasses.cpp
@@ -181,6 +181,8 @@ ESIHWBuilder::declareCosimEndpointToHostModule(Operation *symTable) {
 
   SmallVector<Attribute, 8> params;
   params.push_back(
+      ParamDeclAttr::get("ENDPOINT_ID", NoneType::get(getContext())));
+  params.push_back(
       ParamDeclAttr::get("TO_HOST_TYPE_ID", NoneType::get(getContext())));
   params.push_back(ParamDeclAttr::get("TO_HOST_SIZE_BITS", getI32Type()));
 
@@ -206,6 +208,8 @@ ESIHWBuilder::declareCosimEndpointFromHostModule(Operation *symTable) {
     return *declaredCosimEndpointFromHostModule;
 
   SmallVector<Attribute, 8> params;
+  params.push_back(
+      ParamDeclAttr::get("ENDPOINT_ID", NoneType::get(getContext())));
   params.push_back(
       ParamDeclAttr::get("FROM_HOST_TYPE_ID", NoneType::get(getContext())));
   params.push_back(ParamDeclAttr::get("FROM_HOST_SIZE_BITS", getI32Type()));

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -105,7 +105,7 @@ static LogicalResult instantiateCosimEndpointOps(ServiceImplementReqOp implReq,
             toStringAttr(req.getRelativeAppIDPathAttr(), ch.name));
         toServerValues.push_back(cosim.getFromHost());
         channelAssignments.push_back(
-            b.getNamedAttr(ch.name, cosim.getNameAttr()));
+            b.getNamedAttr(ch.name, cosim.getIdAttr()));
       }
     }
 
@@ -121,7 +121,7 @@ static LogicalResult instantiateCosimEndpointOps(ServiceImplementReqOp implReq,
             loc, clk, rst, pack.getFromChannels()[chanIdx++],
             toStringAttr(req.getRelativeAppIDPathAttr(), ch.name));
         channelAssignments.push_back(
-            b.getNamedAttr(ch.name, cosim.getNameAttr()));
+            b.getNamedAttr(ch.name, cosim.getIdAttr()));
       }
     }
 

--- a/lib/Dialect/ESI/runtime/cosim/Cosim_Endpoint.sv
+++ b/lib/Dialect/ESI/runtime/cosim/Cosim_Endpoint.sv
@@ -16,7 +16,7 @@ import Cosim_DpiPkg::*;
 
 module Cosim_Endpoint_ToHost
 #(
-  parameter string ENDPOINT_ID_EXT = "",
+  parameter string ENDPOINT_ID = "",
   parameter string TO_HOST_TYPE_ID = "",
   parameter int TO_HOST_SIZE_BITS = -1
 )
@@ -28,13 +28,6 @@ module Cosim_Endpoint_ToHost
   output logic DataInReady,
   input  logic [TO_HOST_SIZE_BITS-1:0] DataIn
 );
-
-  string ENDPOINT_ID_BASE = $sformatf("%m");
-  string ENDPOINT_ID;
-  if (ENDPOINT_ID_EXT != "")
-    assign ENDPOINT_ID = $sformatf("%s.%s", ENDPOINT_ID_BASE, ENDPOINT_ID_EXT);
-  else
-    assign ENDPOINT_ID = ENDPOINT_ID_BASE;
 
   initial begin
     int rc;
@@ -100,7 +93,7 @@ endmodule
 
 module Cosim_Endpoint_FromHost
 #(
-  parameter string ENDPOINT_ID_EXT = "",
+  parameter string ENDPOINT_ID = "",
   parameter string FROM_HOST_TYPE_ID = "",
   parameter int FROM_HOST_SIZE_BITS = -1
 )
@@ -112,13 +105,6 @@ module Cosim_Endpoint_FromHost
   input  logic DataOutReady,
   output logic [FROM_HOST_SIZE_BITS-1:0] DataOut
 );
-
-  string ENDPOINT_ID_BASE = $sformatf("%m");
-  string ENDPOINT_ID;
-  if (ENDPOINT_ID_EXT != "")
-    assign ENDPOINT_ID = $sformatf("%s.%s", ENDPOINT_ID_BASE, ENDPOINT_ID_EXT);
-  else
-    assign ENDPOINT_ID = ENDPOINT_ID_BASE;
 
   // Handle initialization logic.
   initial begin

--- a/tools/esi/esi_cosim.py.in
+++ b/tools/esi/esi_cosim.py.in
@@ -10,8 +10,6 @@ class CosimBase:
     self.schema = capnp.load(schemaPath)
     self.rpc_client = capnp.TwoPartyClient(hostPort)
     self.cosim = self.rpc_client.bootstrap().cast_as(self.schema.CosimDpiServer)
-    ifaces = self.list()
-    self.prefix = "" if len(ifaces) == 0 else ifaces[0].endpointID.split(".")[0]
 
   def list(self):
     """List the available interfaces"""
@@ -20,7 +18,6 @@ class CosimBase:
   def openEP(self, epid: str, from_host_type=None, to_host_type=None):
     """Open the endpoint, optionally checking the send and recieve types"""
     ifaces = self.cosim.list().wait().ifaces
-    epid = self.prefix + "." + epid
     for iface in ifaces:
       if iface.endpointID == epid:
         # Optionally check that the type IDs match.
@@ -32,7 +29,7 @@ class CosimBase:
         openResp = self.cosim.open(iface).wait()
         assert openResp.iface is not None
         return openResp.iface
-    assert False, "Could not find specified EndpointID"
+    assert False, f"Could not find specified EndpointID '{epid}'"
 
   def readMsg(self, ep):
     """Cosim doesn't currently support blocking reads. Implement a blocking


### PR DESCRIPTION
Rather than identifying cosim endpoints by "%m", have them specified entirely upstream. The easiest way to ensure uniqueness then is to only allow cosim endpoints at the top level. This solves a number of issues, and also makes cosim look a lot more like other ESI services.