### PR TITLE
[FIRRTL] Verify public FModuleLike's don't have input probes.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -22,6 +22,35 @@ using namespace mlir;
 using namespace llvm;
 using namespace circt::firrtl;
 
+static LogicalResult verifyNoInputProbes(FModuleLike module) {
+  // Helper to check for input-oriented refs.
+  std::function<bool(Type, bool)> hasInputRef = [&](Type type,
+                                                    bool output) -> bool {
+    auto ftype = type_dyn_cast<FIRRTLType>(type);
+    if (!ftype || !ftype.containsReference())
+      return false;
+    return FIRRTLTypeSwitch<FIRRTLType, bool>(ftype)
+        .Case<RefType>([&](auto reftype) { return !output; })
+        .Case<OpenVectorType>([&](OpenVectorType ovt) {
+          return hasInputRef(ovt.getElementType(), output);
+        })
+        .Case<OpenBundleType>([&](OpenBundleType obt) {
+          for (auto field : obt.getElements())
+            if (hasInputRef(field.type, field.isFlip ^ output))
+              return true;
+          return false;
+        });
+  };
+
+  if (module.isPublic()) {
+    for (auto &pi : module.getPorts()) {
+      if (hasInputRef(pi.type, pi.isOutput()))
+        return emitError(pi.loc, "input probe not allowed on public module");
+    }
+  }
+  return success();
+}
+
 LogicalResult circt::firrtl::verifyModuleLikeOpInterface(FModuleLike module) {
   // Verify port types first.  This is used as the basis for the number of
   // ports required everywhere else.
@@ -98,30 +127,8 @@ LogicalResult circt::firrtl::verifyModuleLikeOpInterface(FModuleLike module) {
   if (module->getNumRegions() != 1)
     return module.emitOpError("requires one region");
 
-  if (module.isPublic()) {
-    for (auto &pi : module.getPorts()) {
-      // Helper to check for input-oriented refs.
-      std::function<bool(Type, bool)> hasInputRef = [&](Type type,
-                                                        bool output) -> bool {
-        auto ftype = type_dyn_cast<FIRRTLType>(type);
-        if (!ftype || !ftype.containsReference())
-          return false;
-        return FIRRTLTypeSwitch<FIRRTLType, bool>(ftype)
-            .Case<RefType>([&](auto reftype) { return !output; })
-            .Case<OpenVectorType>([&](OpenVectorType ovt) {
-              return hasInputRef(ovt.getElementType(), output);
-            })
-            .Case<OpenBundleType>([&](OpenBundleType obt) {
-              for (auto field : obt.getElements())
-                if (hasInputRef(field.type, field.isFlip ^ output))
-                  return true;
-              return false;
-            });
-      };
-      if (hasInputRef(pi.type, pi.isOutput()))
-        return emitError(pi.loc, "input probe not allowed on public module");
-    }
-  }
+  if (failed(verifyNoInputProbes(module)))
+    return failure();
 
   return success();
 }

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4971,14 +4971,6 @@ DoneParsing:
       if (mod != main)
         SymbolTable::setSymbolVisibility(mod, SymbolTable::Visibility::Private);
     }
-    // Reject if main module has input ref-type ports.
-    // This should be checked in verifier for all public FModuleLike's but
-    // they're used internally so check this here.
-    for (auto &pi : mainMod.getPorts()) {
-      if (!pi.isOutput() && type_isa<RefType>(pi.type))
-        return mlir::emitError(pi.loc)
-               << "main module may not contain input references";
-    }
   }
   return success();
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3102,7 +3102,7 @@ firrtl.module @DonotUpdateInstanceName(in %in: !firrtl.uint<1>, out %a: !firrtl.
 }
 
 // CHECK-LABEL: @RefCastSame
-firrtl.module @RefCastSame(in %in: !firrtl.probe<uint<1>>, out %out: !firrtl.probe<uint<1>>) {
+firrtl.module private @RefCastSame(in %in: !firrtl.probe<uint<1>>, out %out: !firrtl.probe<uint<1>>) {
   // Drop no-op ref.cast's.
   // CHECK-NEXT:  firrtl.ref.define %out, %in
   // CHECK-NEXT:  }

--- a/test/Dialect/FIRRTL/expand-whens-errors.mlir
+++ b/test/Dialect/FIRRTL/expand-whens-errors.mlir
@@ -149,7 +149,7 @@ firrtl.module @RefInitOut(out %out : !firrtl.probe<uint<1>>) {
 
 // Check initialization error is produced for in-references
 firrtl.circuit "RefInitIn" {
-firrtl.module @Child(in %in: !firrtl.probe<uint<1>>) { }
+firrtl.module private @Child(in %in: !firrtl.probe<uint<1>>) { }
 firrtl.module @RefInitIn() {
   %child_in = firrtl.instance child @Child(in in : !firrtl.probe<uint<1>>)
   // expected-error @above {{sink "child.in" not fully initialized in "RefInitIn"}}

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -978,7 +978,7 @@ firrtl.circuit "Top" attributes {
     }
   ]
 } {
-  firrtl.module @Companion_w1(in %_gen_uint: !firrtl.probe<uint<1>>) attributes {
+  firrtl.module private @Companion_w1(in %_gen_uint: !firrtl.probe<uint<1>>) attributes {
     annotations = [
       {
         class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
@@ -997,7 +997,7 @@ firrtl.circuit "Top" attributes {
       ]
     } : !firrtl.uint<1>
   }
-  firrtl.module @Companion_w2(in %_gen_uint: !firrtl.probe<uint<2>>) attributes {
+  firrtl.module private @Companion_w2(in %_gen_uint: !firrtl.probe<uint<2>>) attributes {
     annotations = [
       {
         class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",

--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -240,7 +240,8 @@ firrtl.circuit "UninferredReset" {
 // -----
 
 firrtl.circuit "UninferredRefReset" {
+  firrtl.module @UninferredRefReset() {}
   // expected-error @+2 {{a port "reset" with abstract reset type was unable to be inferred by InferResets}}
   // expected-note @+1 {{the module with this uninferred reset port was defined here}}
-  firrtl.module @UninferredRefReset(in %reset: !firrtl.probe<reset>) {}
+  firrtl.module private @UninferredRefResetPriv(in %reset: !firrtl.probe<reset>) {}
 }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -991,13 +991,13 @@ firrtl.circuit "InlineInputProbe" {
     // CHECK-NEXT: firrtl.ref.define %child_child__a, %child__a : !firrtl.probe<uint<1>>
     // CHECK-NEXT: firrtl.ref.define %child__a, %xmr__a : !firrtl.probe<uint<1>>
   }
-  // CHECK: module @Child
-  firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+  // CHECK: module private @Child
+  firrtl.module private @Child(in  %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
     firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>) {
+  firrtl.module private @Child2(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
   }
 }
@@ -1027,13 +1027,13 @@ firrtl.circuit "InlineInputProbe2" {
     // CHECK-NEXT: firrtl.ref.define %child_child__a, %child__a : !firrtl.probe<uint<1>>
     // CHECK-NEXT: firrtl.ref.define %child__a, %xmr__a : !firrtl.probe<uint<1>>
   }
-  // CHECK: module @Child
-  firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+  // CHECK-NOT: module private @Child
+  firrtl.module private @Child(in  %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
     firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+  firrtl.module private @Child2(in  %_a: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
   }
 }
@@ -1056,6 +1056,9 @@ firrtl.circuit "RecursiveInlineInputProbe" {
     %c_a1, %c_a2  = firrtl.instance child @Child(in  _a1: !firrtl.probe<uint<1>>, in  _a2: !firrtl.probe<uint<1>>)
     firrtl.ref.define %c_a1, %xmr : !firrtl.probe<uint<1>>
     firrtl.ref.define %c_a2, %xmr2 : !firrtl.probe<uint<1>>
+    %cn_a1, %cn_a2  = firrtl.instance child @ChildNoInline(in  _a1: !firrtl.probe<uint<1>>, in  _a2: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %cn_a1, %xmr : !firrtl.probe<uint<1>>
+    firrtl.ref.define %cn_a2, %xmr2 : !firrtl.probe<uint<1>>
     // CHECK:      %child__a1 = firrtl.wire : !firrtl.probe<uint<1>>
     // CHECK-NEXT: %child__a2 = firrtl.wire : !firrtl.probe<uint<1>>
     // CHECK-NEXT: %child_child__a = firrtl.wire : !firrtl.probe<uint<1>>
@@ -1070,8 +1073,24 @@ firrtl.circuit "RecursiveInlineInputProbe" {
     // CHECK-NEXT: firrtl.ref.define %child__a1, %xmr__a : !firrtl.probe<uint<1>>
     // CHECK-NEXT: firrtl.ref.define %child__a2, %0 : !firrtl.probe<uint<1>>
   }
-  // CHECK: module @Child
-  firrtl.module @Child(in  %_a1: !firrtl.probe<uint<1>>, in  %_a2: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+  // CHECK-NOT: module private @Child
+  firrtl.module private @Child(in  %_a1: !firrtl.probe<uint<1>>, in  %_a2: !firrtl.probe<uint<1>>)  attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %_a1 : !firrtl.probe<uint<1>>
+    %0 = firrtl.ref.resolve %_a2 : !firrtl.probe<uint<1>>
+    %cw = firrtl.wire : !firrtl.uint<1>
+    firrtl.strictconnect %cw, %0 : !firrtl.uint<1>
+  }
+  firrtl.module private @Child2(in  %_a: !firrtl.probe<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
+    %c_a = firrtl.instance child @Child3(in  _b: !firrtl.probe<uint<1>>)
+    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
+  }
+  firrtl.module private @Child3(in  %_b: !firrtl.probe<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+    %0 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
+  }
+  // CHECK: module private @ChildNoInline
+  firrtl.module private @ChildNoInline(in  %_a1: !firrtl.probe<uint<1>>, in  %_a2: !firrtl.probe<uint<1>>) {
     %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
     // CHECK-NEXT: %child__a = firrtl.wire : !firrtl.probe<uint<1>>
     // CHECK-NEXT: %0 = firrtl.ref.resolve %child__a : !firrtl.probe<uint<1>>
@@ -1087,14 +1106,6 @@ firrtl.circuit "RecursiveInlineInputProbe" {
     %0 = firrtl.ref.resolve %_a2 : !firrtl.probe<uint<1>>
     %cw = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %cw, %0 : !firrtl.uint<1>
-  }
-  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
-    %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
-    %c_a = firrtl.instance child @Child3(in  _b: !firrtl.probe<uint<1>>)
-    firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
-  }
-  firrtl.module @Child3(in  %_b: !firrtl.probe<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
-    %0 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
   }
 }
 
@@ -1137,20 +1148,20 @@ firrtl.circuit "FlattenProbe" {
     firrtl.ref.define %c_a1, %xmr : !firrtl.probe<uint<1>>
     firrtl.ref.define %c_a2, %xmr2 : !firrtl.probe<uint<1>>
   }
-  // CHECK: module @Child
-  firrtl.module @Child(in  %_a1: !firrtl.probe<uint<1>>, in  %_a2: !firrtl.probe<uint<1>>)  {
+  // CHECK-NOT: module private @Child
+  firrtl.module private @Child(in  %_a1: !firrtl.probe<uint<1>>, in  %_a2: !firrtl.probe<uint<1>>)  {
     %c_a = firrtl.instance child @Child2(in  _a: !firrtl.probe<uint<1>>)
     firrtl.ref.define %c_a, %_a1 : !firrtl.probe<uint<1>>
     %0 = firrtl.ref.resolve %_a2 : !firrtl.probe<uint<1>>
     %cw = firrtl.wire : !firrtl.uint<1>
     firrtl.strictconnect %cw, %0 : !firrtl.uint<1>
   }
-  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>){
+  firrtl.module private @Child2(in  %_a: !firrtl.probe<uint<1>>){
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     %c_a = firrtl.instance child @Child3(in  _b: !firrtl.probe<uint<1>>)
     firrtl.ref.define %c_a, %_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child3(in  %_b: !firrtl.probe<uint<1>>){
+  firrtl.module private @Child3(in  %_b: !firrtl.probe<uint<1>>){
     %0 = firrtl.ref.resolve %_b : !firrtl.probe<uint<1>>
   }
 }
@@ -1171,7 +1182,7 @@ firrtl.circuit "UTurn" {
     // CHECK-NEXT: firrtl.ref.define %child_o_a, %child_bar__a : !firrtl.probe<uint<1>>
     // CHECK-NEXT: firrtl.ref.define %child__a, %child_o_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child(in  %_a: !firrtl.probe<uint<1>>, out  %o_a: !firrtl.probe<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
+  firrtl.module private @Child(in  %_a: !firrtl.probe<uint<1>>, out  %o_a: !firrtl.probe<uint<1>>)   attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]}{
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     firrtl.ref.define %o_a, %bar_a : !firrtl.probe<uint<1>>

--- a/test/Dialect/FIRRTL/lower-open-aggs.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs.mlir
@@ -195,8 +195,8 @@ firrtl.circuit "ManySymbols" {
   // CHECK-SAME: <@b,7,public>
   firrtl.extmodule @ManySymbols2(
     out mixed: !firrtl.openbundle<a: uint<1>,
-                                   x flip: openvector<openbundle<refsonly : openbundle<p: probe<bundle<a: uint<1>,
-                                                                                                       b: vector<uint<1>, 2>>>>,
+                                   x flip: openvector<openbundle<refsonly : openbundle<p flip: probe<bundle<a: uint<1>,
+                                                                                                            b: vector<uint<1>, 2>>>>,
                                                                  data flip: uint<1>
                                                       >, 2>,
                                    b: vector<uint<1>, 2>>

--- a/test/Dialect/FIRRTL/lower-types-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-types-errors.mlir
@@ -15,6 +15,6 @@ firrtl.circuit "InnerSym" {
 firrtl.circuit "InternalPath" {
   firrtl.extmodule @InternalPath(
   // expected-error @below {{cannot lower port with internal path}}
-      in x: !firrtl.probe<bundle<a: uint<5>, b: uint<3>>>
+      out x: !firrtl.probe<bundle<a: uint<5>, b: uint<3>>>
     ) attributes { internalPaths = [#firrtl.internalpath<"a.b.c">] }
 }

--- a/test/Dialect/FIRRTL/lowerXMR-errors.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR-errors.mlir
@@ -3,8 +3,13 @@
 // Test for same module lowering
 // CHECK-LABEL: firrtl.circuit "xmr"
 firrtl.circuit "xmr" {
+  firrtl.module @xmr() {
+    %a = builtin.unrealized_conversion_cast to !firrtl.probe<uint<2>>
+    %x_a = firrtl.instance x @xmrPriv(in a: !firrtl.probe<uint<2>>)
+    firrtl.ref.define %x_a, %a : !firrtl.probe<uint<2>>
+  }
   // expected-error @+1 {{reference dataflow cannot be traced back to the remote read op for module port 'a'}}
-  firrtl.module @xmr(in %a: !firrtl.probe<uint<2>>) {
+  firrtl.module private @xmrPriv(in %a: !firrtl.probe<uint<2>>) {
     %x = firrtl.ref.resolve %a : !firrtl.probe<uint<2>>
   }
 }
@@ -24,13 +29,13 @@ firrtl.circuit "Top" {
     firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>
     firrtl.ref.define %c_b, %xmr_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
+  firrtl.module private @Child1(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
     %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>)
     firrtl.ref.define %c_b, %_a : !firrtl.probe<uint<1>>
   }
   // expected-error @+1 {{op multiply instantiated module with input RefType port '_a'}}
-  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>) {
+  firrtl.module private @Child2(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
   }
 }
@@ -49,11 +54,11 @@ firrtl.circuit "Top" {
     %c_b = firrtl.instance child @Child2(in _a: !firrtl.probe<uint<1>>)
     firrtl.ref.define %c_a, %xmr_a : !firrtl.probe<uint<1>>
   }
-  firrtl.module @Child1(in  %_a: !firrtl.probe<uint<1>>) {
+  firrtl.module private @Child1(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
   }
   // expected-error @+1 {{reference dataflow cannot be traced back to the remote read op for module port '_a'}}
-  firrtl.module @Child2(in  %_a: !firrtl.probe<uint<1>>) {
+  firrtl.module private @Child2(in  %_a: !firrtl.probe<uint<1>>) {
     %0 = firrtl.ref.resolve %_a : !firrtl.probe<uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -445,7 +445,7 @@ circuit DefineIntoProbe:
 
 circuit InProbeTop:
   module InProbeTop:
-    input p : Probe<UInt<1>> ; expected-error {{main module may not contain input references}}
+    input p : Probe<UInt<1>> ; expected-error {{input probe not allowed on public module}}
 
 ;// -----
 

--- a/test/Dialect/FIRRTL/probe-dce-errors.mlir
+++ b/test/Dialect/FIRRTL/probe-dce-errors.mlir
@@ -13,20 +13,6 @@ firrtl.circuit "ExtPort" {
 }
 
 // -----
-// Diagnose input probe on public modules.
-
-firrtl.circuit "PublicMod" {
-  // expected-error @below {{input probe not allowed on public module}}
-  firrtl.module @Pub(in %in : !firrtl.probe<uint<1>>) { }
-  firrtl.module @PublicMod() {
-    %zero = firrtl.constant 0 : !firrtl.uint<1>
-    %ref = firrtl.ref.send %zero : !firrtl.uint<1>
-    %in = firrtl.instance p @Pub(in in : !firrtl.probe<uint<1>>)
-    firrtl.ref.define %in, %ref : !firrtl.probe<uint<1>>
-  }
-}
-
-// -----
 // Diagnose use of input probe (upwards or n-turn).
 
 firrtl.circuit "Upwards" {

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -227,14 +227,14 @@ firrtl.module @EnumTest(in %in : !firrtl.enum<a: uint<1>, b: uint<2>>,
 }
 
 // CHECK-LABEL: OpenAggTest
-// CHECK-SAME: !firrtl.openbundle<a: bundle<data: uint<1>>, b: openvector<openbundle<x: uint<2>, y: probe<uint<2>>>, 2>>
-firrtl.module @OpenAggTest(in %in: !firrtl.openbundle<a: bundle<data: uint<1>>, b: openvector<openbundle<x: uint<2>, y: probe<uint<2>>>, 2>>) {
-  %a = firrtl.opensubfield %in[a] : !firrtl.openbundle<a: bundle<data: uint<1>>, b: openvector<openbundle<x: uint<2>, y: probe<uint<2>>>, 2>>
+// CHECK-SAME: !firrtl.openbundle<a: bundle<data: uint<1>>, b: openvector<openbundle<x: uint<2>, y flip: probe<uint<2>>>, 2>>
+firrtl.module @OpenAggTest(in %in: !firrtl.openbundle<a: bundle<data: uint<1>>, b: openvector<openbundle<x: uint<2>, y flip: probe<uint<2>>>, 2>>) {
+  %a = firrtl.opensubfield %in[a] : !firrtl.openbundle<a: bundle<data: uint<1>>, b: openvector<openbundle<x: uint<2>, y flip: probe<uint<2>>>, 2>>
   %data = firrtl.subfield %a[data] : !firrtl.bundle<data: uint<1>>
-  %b = firrtl.opensubfield %in[b] : !firrtl.openbundle<a: bundle<data: uint<1>>, b: openvector<openbundle<x: uint<2>, y: probe<uint<2>>>, 2>>
-  %b_0 = firrtl.opensubindex %b[0] : !firrtl.openvector<openbundle<x: uint<2>, y: probe<uint<2>>>, 2>
-  %b_1 = firrtl.opensubindex %b[1] : !firrtl.openvector<openbundle<x: uint<2>, y: probe<uint<2>>>, 2>
-  %b_0_y = firrtl.opensubfield %b_0[y] : !firrtl.openbundle<x : uint<2>, y: probe<uint<2>>>
+  %b = firrtl.opensubfield %in[b] : !firrtl.openbundle<a: bundle<data: uint<1>>, b: openvector<openbundle<x: uint<2>, y flip: probe<uint<2>>>, 2>>
+  %b_0 = firrtl.opensubindex %b[0] : !firrtl.openvector<openbundle<x: uint<2>, y flip: probe<uint<2>>>, 2>
+  %b_1 = firrtl.opensubindex %b[1] : !firrtl.openvector<openbundle<x: uint<2>, y flip: probe<uint<2>>>, 2>
+  %b_0_y = firrtl.opensubfield %b_0[y] : !firrtl.openbundle<x : uint<2>, y flip: probe<uint<2>>>
 }
 
 // CHECK-LABEL: StringTest


### PR DESCRIPTION
Add verifier for public modules not having input-oriented probes.

Fixes #6432.

Previously: https://github.com/llvm/circt/pull/6121/files#r1334831540 .