### PR TITLE
[FIRTOOL] Make firtool options behave like the rest of llvm.

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -12,19 +12,9 @@
 extern "C" {
 #endif
 
-//===----------------------------------------------------------------------===//
-// Option API.
-//===----------------------------------------------------------------------===//
-
-#define DEFINE_C_API_STRUCT(name, storage)                                     \
-  struct name {                                                                \
-    storage *ptr;                                                              \
-  };                                                                           \
-  typedef struct name name
-
+DEFINE_C_API_PTR_METHODS(CirctFirtoolFirtoolOptions,
+                         circt::firtool::FirtoolOptions)
 DEFINE_C_API_STRUCT(FirtoolOptions, void);
-
-#undef DEFINE_C_API_STRUCT
 
 // NOLINTNEXTLINE(modernize-use-using)
 typedef enum FirtoolPreserveAggregateMode {
@@ -62,55 +52,17 @@ typedef enum FirtoolRandomKind {
   FIRTOOL_RANDOM_KIND_ALL,
 } FirtoolRandomKind;
 
-MLIR_CAPI_EXPORTED FirtoolOptions firtoolOptionsCreateDefault();
-MLIR_CAPI_EXPORTED void firtoolOptionsDestroy(FirtoolOptions options);
+MLIR_CAPI_EXPORTED CirctFirtoolFirtoolOptions
+circtFirtoolOptionsCreateDefault();
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsDestroy(CirctFirtoolFirtoolOptions options);
 
-#define DECLARE_FIRTOOL_OPTION(name, type)                                     \
-  MLIR_CAPI_EXPORTED void firtoolOptionsSet##name(FirtoolOptions options,      \
-                                                  type value);                 \
-  MLIR_CAPI_EXPORTED type firtoolOptionsGet##name(FirtoolOptions options)
-
-DECLARE_FIRTOOL_OPTION(OutputFilename, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(DisableAnnotationsUnknown, bool);
-DECLARE_FIRTOOL_OPTION(DisableAnnotationsClassless, bool);
-DECLARE_FIRTOOL_OPTION(LowerAnnotationsNoRefTypePorts, bool);
-DECLARE_FIRTOOL_OPTION(PreserveAggregate, FirtoolPreserveAggregateMode);
-DECLARE_FIRTOOL_OPTION(PreserveValues, FirtoolPreserveValuesMode);
-DECLARE_FIRTOOL_OPTION(BuildMode, FirtoolBuildMode);
-DECLARE_FIRTOOL_OPTION(DisableOptimization, bool);
-DECLARE_FIRTOOL_OPTION(ExportChiselInterface, bool);
-DECLARE_FIRTOOL_OPTION(ChiselInterfaceOutDirectory, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(VbToBv, bool);
-DECLARE_FIRTOOL_OPTION(CompanionMode, FirtoolCompanionMode);
-DECLARE_FIRTOOL_OPTION(DisableAggressiveMergeConnections, bool);
-DECLARE_FIRTOOL_OPTION(EmitOMIR, bool);
-DECLARE_FIRTOOL_OPTION(OMIROutFile, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(LowerMemories, bool);
-DECLARE_FIRTOOL_OPTION(BlackBoxRootPath, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(ReplSeqMem, bool);
-DECLARE_FIRTOOL_OPTION(ReplSeqMemFile, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(ExtractTestCode, bool);
-DECLARE_FIRTOOL_OPTION(IgnoreReadEnableMem, bool);
-DECLARE_FIRTOOL_OPTION(DisableRandom, FirtoolRandomKind);
-DECLARE_FIRTOOL_OPTION(OutputAnnotationFilename, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(EnableAnnotationWarning, bool);
-DECLARE_FIRTOOL_OPTION(AddMuxPragmas, bool);
-DECLARE_FIRTOOL_OPTION(EmitChiselAssertsAsSVA, bool);
-DECLARE_FIRTOOL_OPTION(EmitSeparateAlwaysBlocks, bool);
-DECLARE_FIRTOOL_OPTION(EtcDisableInstanceExtraction, bool);
-DECLARE_FIRTOOL_OPTION(EtcDisableRegisterExtraction, bool);
-DECLARE_FIRTOOL_OPTION(EtcDisableModuleInlining, bool);
-DECLARE_FIRTOOL_OPTION(AddVivadoRAMAddressConflictSynthesisBugWorkaround, bool);
-DECLARE_FIRTOOL_OPTION(CkgModuleName, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(CkgInputName, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(CkgOutputName, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(CkgEnableName, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(CkgTestEnableName, MlirStringRef);
-DECLARE_FIRTOOL_OPTION(ExportModuleHierarchy, bool);
-DECLARE_FIRTOOL_OPTION(StripFirDebugInfo, bool);
-DECLARE_FIRTOOL_OPTION(StripDebugInfo, bool);
-
-#undef DECLARE_FIRTOOL_OPTION
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetOutputFilename(CirctFirtoolOptions options,
+                                     MlirStringRef filename);
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsDisableUnknownAnnotations(CirctFirtoolOptions options,
+                                             bool disable);
 
 //===----------------------------------------------------------------------===//
 // Populate API.

--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -34,8 +34,7 @@ std::unique_ptr<mlir::Pass>
 createSVExtractTestCodePass(bool disableInstanceExtraction = false,
                             bool disableRegisterExtraction = false,
                             bool disableModuleInlining = false);
-std::unique_ptr<mlir::Pass>
-createHWExportModuleHierarchyPass(std::optional<std::string> directory = {});
+std::unique_ptr<mlir::Pass> createHWExportModuleHierarchyPass();
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/SV/SVPasses.h.inc"

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -29,7 +29,6 @@ namespace firtool {
 class FirtoolOptions {
 public:
   FirtoolOptions();
-  FirtoolOptions(std::nullopt_t) : FirtoolOptions() {}
 
   // Helper Types
   enum BuildMode { BuildModeDefault, BuildModeDebug, BuildModeRelease };
@@ -119,6 +118,17 @@ public:
     return addVivadoRAMAddressConflictSynthesisBugWorkaround;
   }
   bool shouldExtractTestCode() const { return extractTestCode; }
+
+  // Setters, used by the CAPI
+  FirtoolOptions &setOutputFilename(StringRef name) {
+    outputFilename = name;
+    return *this;
+  }
+
+  FirtoolOptions &setDisableUnknownAnnotations(bool disable) {
+    disableAnnotationsUnknown = disable;
+    return *this;
+  }
 
 private:
   std::string outputFilename;

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -41,34 +41,67 @@ public:
   }
 
   firrtl::PreserveValues::PreserveMode getPreserveMode() const {
-    if (buildMode == BuildModeDefault)
-      return preserveMode;
     switch (buildMode) {
     case BuildModeDebug:
       return firrtl::PreserveValues::Named;
     case BuildModeRelease:
       return firrtl::PreserveValues::None;
+      case BuildModeDefault:
+      return preserveMode;
     }
     llvm_unreachable("unknown build mode");
   }
 
+    StringRef getOutputFilename() const { return outputFilename; }
+    StringRef getOmirOutputFile() const { return omirOutFile; }
+    StringRef getBlackBoxRootPath() const { return blackBoxRootPath; }
+    StringRef getChiselInterfaceOutputDirectory() const { return chiselInterfaceOutDirectory; }
+    StringRef getReplaceSequentialMemoriesFile() const { return replSeqMemFile; }
+    StringRef getOutputAnnotationFilename() const { return outputAnnotationFilename; }
+    firrtl::PreserveAggregate::PreserveMode getPreserveAggregate() const { return preserveAggregate; }
+    firrtl::CompanionMode getCompanionMode() const { return companionMode; }
+    bool isDefaultOutputFilename() const { return outputFilename == "-"; }
+    bool shouldDisableUnknownAnnotations() const { return disableAnnotationsUnknown; }
+    bool shouldDisableClasslessAnnotations() const { return disableAnnotationsClassless; }
+    bool shouldLowerNoRefTypePortAnnotations() const { return lowerAnnotationsNoRefTypePorts; }
+    bool shouldReplicateSequentialMemories() const { return replSeqMem; }
+    bool shouldDisableOptimization() const { return disableOptimization; }
+    bool shouldLowerMemories() const { return lowerMemories; }
+    bool shouldDedup() const { return !noDedup; }
+    bool shouldEnableDebugInfo() const { return enableDebugInfo; }
+    bool shouldIgnoreReadEnableMemories() const { return ignoreReadEnableMem; }
+    bool shouldEmitOMIR() const { return emitOMIR; }
+    bool shouldExportChiselInterface() const { return exportChiselInterface; }
+    bool shouldDisableHoistingHWPassthrough() const { return disableHoistingHWPassthrough; }
+    bool shouldConvertVecOfBundle() const { return vbToBV; }
+    bool shouldEtcDisableInstanceExtraction() const { return etcDisableInstanceExtraction; }
+    bool shouldEtcDisableRegisterExtraction() const { return etcDisableRegisterExtraction; }
+    bool shouldEtcDisableModuleInlining() const { return etcDisableModuleInlining; }
+    bool shouldStripDebugInfo() const { return stripDebugInfo; }
+    bool shouldStripFirDebugInfo() const { return stripFirDebugInfo; }
+    bool shouldExportModuleHierarchy() const { return exportModuleHierarchy; }
+    bool shouldDisableAggressiveMergeConnections() const { return disableAggressiveMergeConnections; }
+    bool shouldEnableAnnotationWarning() const { return enableAnnotationWarning; }
+    bool shouldEmitChiselAssertsAsSVA() const { return emitChiselAssertsAsSVA; }
+    bool shouldEmitSeparateAlwaysBlocks() const { return emitSeparateAlwaysBlocks; }
+    bool shouldAddMuxPragmas() const { return addMuxPragmas; }
+    bool shouldAddVivadoRAMAddressConflictSynthesisBugWorkaround() const { return addVivadoRAMAddressConflictSynthesisBugWorkaround; }
+    bool shouldExtractTestCode() const { return extractTestCode; }
+    
 
 private:
   std::string outputFilename;
-
   bool disableAnnotationsUnknown;
-
   bool disableAnnotationsClassless;
-
   bool lowerAnnotationsNoRefTypePorts;
-  circt::firrtl::PreserveAggregate::PreserveMode preserveAggregate;
+  firrtl::PreserveAggregate::PreserveMode preserveAggregate;
   firrtl::PreserveValues::PreserveMode preserveMode;
   bool enableDebugInfo;
   BuildMode buildMode;
   bool disableOptimization;
   bool exportChiselInterface;
   std::string chiselInterfaceOutDirectory;
-bool vbToBV;
+  bool vbToBV;
   bool noDedup;
   firrtl::CompanionMode companionMode;
   bool disableAggressiveMergeConnections;

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -21,289 +21,27 @@
 
 namespace circt {
 namespace firtool {
-// Remember to sync changes to C-API
-struct FirtoolOptions {
-  llvm::cl::OptionCategory &category;
+//===----------------------------------------------------------------------===//
+// FirtoolOptions
+//===----------------------------------------------------------------------===//
 
-  llvm::cl::opt<std::string> outputFilename{
-      "o", llvm::cl::desc("Output filename, or directory for split output"),
-      llvm::cl::value_desc("filename"), llvm::cl::init("-"),
-      llvm::cl::cat(category)};
+/// Set of options used to control the behavior of the firtool pipeline.
+class FirtoolOptions {
+public:
+  FirtoolOptions();
+  FirtoolOptions(std::nullopt_t) : FirtoolOptions() {}
 
-  llvm::cl::opt<bool> disableAnnotationsUnknown{
-      "disable-annotation-unknown",
-      llvm::cl::desc("Ignore unknown annotations when parsing"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> disableAnnotationsClassless{
-      "disable-annotation-classless",
-      llvm::cl::desc("Ignore annotations without a class when parsing"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> lowerAnnotationsNoRefTypePorts{
-      "lower-annotations-no-ref-type-ports",
-      llvm::cl::desc(
-          "Create real ports instead of ref type ports when resolving "
-          "wiring problems inside the LowerAnnotations pass"),
-      llvm::cl::init(false), llvm::cl::Hidden, llvm::cl::cat(category)};
-
-  llvm::cl::opt<circt::firrtl::PreserveAggregate::PreserveMode>
-      preserveAggregate{
-          "preserve-aggregate", llvm::cl::desc("Specify input file format:"),
-          llvm::cl::values(
-              clEnumValN(circt::firrtl::PreserveAggregate::None, "none",
-                         "Preserve no aggregate"),
-              clEnumValN(circt::firrtl::PreserveAggregate::OneDimVec, "1d-vec",
-                         "Preserve only 1d vectors of ground type"),
-              clEnumValN(circt::firrtl::PreserveAggregate::Vec, "vec",
-                         "Preserve only vectors"),
-              clEnumValN(circt::firrtl::PreserveAggregate::All, "all",
-                         "Preserve vectors and bundles")),
-          llvm::cl::init(circt::firrtl::PreserveAggregate::None),
-          llvm::cl::cat(category)};
-
-  llvm::cl::opt<firrtl::PreserveValues::PreserveMode> preserveMode{
-      "preserve-values",
-      llvm::cl::desc("Specify the values which can be optimized away"),
-      llvm::cl::values(
-          clEnumValN(firrtl::PreserveValues::Strip, "strip",
-                     "Strip all names. No name is preserved"),
-          clEnumValN(firrtl::PreserveValues::None, "none",
-                     "Names could be preserved by best-effort unlike `strip`"),
-          clEnumValN(firrtl::PreserveValues::Named, "named",
-                     "Preserve values with meaningful names"),
-          clEnumValN(firrtl::PreserveValues::All, "all",
-                     "Preserve all values")),
-      llvm::cl::init(firrtl::PreserveValues::None), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> enableDebugInfo{
-      "g", llvm::cl::desc("Enable the generation of debug information"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  // Build mode options.
-  enum BuildMode { BuildModeDebug, BuildModeRelease };
-  llvm::cl::opt<BuildMode> buildMode{
-      "O", llvm::cl::desc("Controls how much optimization should be performed"),
-      llvm::cl::values(clEnumValN(BuildModeDebug, "debug",
-                                  "Compile with only necessary optimizations"),
-                       clEnumValN(BuildModeRelease, "release",
-                                  "Compile with optimizations")),
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> disableOptimization{
-      "disable-opt", llvm::cl::desc("Disable optimizations"),
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> exportChiselInterface{
-      "export-chisel-interface",
-      llvm::cl::desc("Generate a Scala Chisel interface to the top level "
-                     "module of the firrtl circuit"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string> chiselInterfaceOutDirectory{
-      "chisel-interface-out-dir",
-      llvm::cl::desc(
-          "The output directory for generated Chisel interface files"),
-      llvm::cl::init(""), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> vbToBV{
-      "vb-to-bv",
-      llvm::cl::desc("Transform vectors of bundles to bundles of vectors"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> noDedup{
-      "no-dedup",
-      llvm::cl::desc("Disable deduplication of structurally identical modules"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<firrtl::CompanionMode> companionMode{
-      "grand-central-companion-mode",
-      llvm::cl::desc("Specifies the handling of Grand Central companions"),
-      ::llvm::cl::values(
-          clEnumValN(firrtl::CompanionMode::Bind, "bind",
-                     "Lower companion instances to SystemVerilog binds"),
-          clEnumValN(firrtl::CompanionMode::Instantiate, "instantiate",
-                     "Instantiate companions in the design"),
-          clEnumValN(firrtl::CompanionMode::Drop, "drop",
-                     "Remove companions from the design")),
-      llvm::cl::init(firrtl::CompanionMode::Bind),
-      llvm::cl::Hidden,
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> disableAggressiveMergeConnections{
-      "disable-aggressive-merge-connections",
-      llvm::cl::desc(
-          "Disable aggressive merge connections (i.e. merge all field-level "
-          "connections into bulk connections)"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> disableHoistingHWPassthrough{
-      "disable-hoisting-hw-passthrough",
-      llvm::cl::desc("Disable hoisting HW passthrough signals"),
-      llvm::cl::init(true), llvm::cl::Hidden, llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> emitOMIR{
-      "emit-omir", llvm::cl::desc("Emit OMIR annotations to a JSON file"),
-      llvm::cl::init(true), llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string> omirOutFile{
-      "output-omir", llvm::cl::desc("File name for the output omir"),
-      llvm::cl::init(""), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> lowerMemories{
-      "lower-memories",
-      llvm::cl::desc("Lower memories to have memories with masks as an "
-                     "array with one memory per ground type"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string> blackBoxRootPath{
-      "blackbox-path",
-      llvm::cl::desc(
-          "Optional path to use as the root of black box annotations"),
-      llvm::cl::value_desc("path"), llvm::cl::init(""),
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> replSeqMem{
-      "repl-seq-mem",
-      llvm::cl::desc("Replace the seq mem for macro replacement and emit "
-                     "relevant metadata"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string> replSeqMemFile{
-      "repl-seq-mem-file", llvm::cl::desc("File name for seq mem metadata"),
-      llvm::cl::init(""), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> extractTestCode{
-      "extract-test-code", llvm::cl::desc("Run the extract test code pass"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> ignoreReadEnableMem{
-      "ignore-read-enable-mem",
-      llvm::cl::desc("Ignore the read enable signal, instead of "
-                     "assigning X on read disable"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
+  // Helper Types
+  enum BuildMode { BuildModeDefault, BuildModeDebug, BuildModeRelease };
   enum class RandomKind { None, Mem, Reg, All };
 
-  llvm::cl::opt<RandomKind> disableRandom{
-      llvm::cl::desc(
-          "Disable random initialization code (may break semantics!)"),
-      llvm::cl::values(
-          clEnumValN(RandomKind::Mem, "disable-mem-randomization",
-                     "Disable emission of memory randomization code"),
-          clEnumValN(RandomKind::Reg, "disable-reg-randomization",
-                     "Disable emission of register randomization code"),
-          clEnumValN(RandomKind::All, "disable-all-randomization",
-                     "Disable emission of all randomization code")),
-      llvm::cl::init(RandomKind::None), llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string> outputAnnotationFilename{
-      "output-annotation-file",
-      llvm::cl::desc("Optional output annotation file"),
-      llvm::cl::CommaSeparated, llvm::cl::value_desc("filename"),
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> enableAnnotationWarning{
-      "warn-on-unprocessed-annotations",
-      llvm::cl::desc(
-          "Warn about annotations that were not removed by lower-to-hw"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> addMuxPragmas{
-      "add-mux-pragmas",
-      llvm::cl::desc("Annotate mux pragmas for memory array access"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> emitChiselAssertsAsSVA{
-      "emit-chisel-asserts-as-sva",
-      llvm::cl::desc("Convert all chisel asserts into SVA"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> emitSeparateAlwaysBlocks{
-      "emit-separate-always-blocks",
-      llvm::cl::desc(
-          "Prevent always blocks from being merged and emit constructs into "
-          "separate always blocks whenever possible"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> etcDisableInstanceExtraction{
-      "etc-disable-instance-extraction",
-      llvm::cl::desc("Disable extracting instances only that feed test code"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> etcDisableRegisterExtraction{
-      "etc-disable-register-extraction",
-      llvm::cl::desc("Disable extracting registers that only feed test code"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> etcDisableModuleInlining{
-      "etc-disable-module-inlining",
-      llvm::cl::desc("Disable inlining modules that only feed test code"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> addVivadoRAMAddressConflictSynthesisBugWorkaround{
-      "add-vivado-ram-address-conflict-synthesis-bug-workaround",
-      llvm::cl::desc(
-          "Add a vivado specific SV attribute (* ram_style = "
-          "\"distributed\" *) to unpacked array registers as a workaronud "
-          "for a vivado synthesis bug that incorrectly modifies "
-          "address conflict behavivor of combinational memories"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  //===----------------------------------------------------------------------===
-  // External Clock Gate Options
-  //===----------------------------------------------------------------------===
-
-  seq::ExternalizeClockGateOptions clockGateOpts;
-
-  llvm::cl::opt<std::string, true> ckgModuleName{
-      "ckg-name", llvm::cl::desc("Clock gate module name"),
-      llvm::cl::location(clockGateOpts.moduleName),
-      llvm::cl::init("EICG_wrapper"), llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string, true> ckgInputName{
-      "ckg-input", llvm::cl::desc("Clock gate input port name"),
-      llvm::cl::location(clockGateOpts.inputName), llvm::cl::init("in"),
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string, true> ckgOutputName{
-      "ckg-output", llvm::cl::desc("Clock gate output port name"),
-      llvm::cl::location(clockGateOpts.outputName), llvm::cl::init("out"),
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string, true> ckgEnableName{
-      "ckg-enable", llvm::cl::desc("Clock gate enable port name"),
-      llvm::cl::location(clockGateOpts.enableName), llvm::cl::init("en"),
-      llvm::cl::cat(category)};
-
-  llvm::cl::opt<std::string, true> ckgTestEnableName{
-      "ckg-test-enable",
-      llvm::cl::desc("Clock gate test enable port name (optional)"),
-      llvm::cl::location(clockGateOpts.testEnableName),
-      llvm::cl::init("test_en"), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> exportModuleHierarchy{
-      "export-module-hierarchy",
-      llvm::cl::desc("Export module and instance hierarchy as JSON"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> stripFirDebugInfo{
-      "strip-fir-debug-info",
-      llvm::cl::desc(
-          "Disable source fir locator information in output Verilog"),
-      llvm::cl::init(true), llvm::cl::cat(category)};
-
-  llvm::cl::opt<bool> stripDebugInfo{
-      "strip-debug-info",
-      llvm::cl::desc("Disable source locator information in output Verilog"),
-      llvm::cl::init(false), llvm::cl::cat(category)};
 
   bool isRandomEnabled(RandomKind kind) const {
     return disableRandom != RandomKind::All && disableRandom != kind;
   }
 
   firrtl::PreserveValues::PreserveMode getPreserveMode() const {
-    if (!buildMode.getNumOccurrences())
+    if (buildMode == BuildModeDefault)
       return preserveMode;
     switch (buildMode) {
     case BuildModeDebug:
@@ -314,8 +52,56 @@ struct FirtoolOptions {
     llvm_unreachable("unknown build mode");
   }
 
-  FirtoolOptions(llvm::cl::OptionCategory &category) : category(category) {}
+
+private:
+  std::string outputFilename;
+
+  bool disableAnnotationsUnknown;
+
+  bool disableAnnotationsClassless;
+
+  bool lowerAnnotationsNoRefTypePorts;
+  circt::firrtl::PreserveAggregate::PreserveMode preserveAggregate;
+  firrtl::PreserveValues::PreserveMode preserveMode;
+  bool enableDebugInfo;
+  BuildMode buildMode;
+  bool disableOptimization;
+  bool exportChiselInterface;
+  std::string chiselInterfaceOutDirectory;
+bool vbToBV;
+  bool noDedup;
+  firrtl::CompanionMode companionMode;
+  bool disableAggressiveMergeConnections;
+  bool disableHoistingHWPassthrough;
+  bool emitOMIR;
+  std::string omirOutFile;
+  bool lowerMemories;
+  std::string blackBoxRootPath;
+  bool replSeqMem;
+  std::string replSeqMemFile;
+  bool extractTestCode;
+  bool ignoreReadEnableMem;
+  RandomKind disableRandom;
+  std::string outputAnnotationFilename;
+  bool enableAnnotationWarning;
+  bool addMuxPragmas;
+  bool emitChiselAssertsAsSVA;
+  bool emitSeparateAlwaysBlocks;
+  bool etcDisableInstanceExtraction;
+  bool etcDisableRegisterExtraction;
+  bool etcDisableModuleInlining;
+  bool addVivadoRAMAddressConflictSynthesisBugWorkaround;
+  std::string ckgModuleName;
+  std::string ckgInputName;
+  std::string ckgOutputName;
+  std::string ckgEnableName;
+  std::string ckgTestEnableName;
+  bool exportModuleHierarchy;
+  bool stripFirDebugInfo;
+  bool stripDebugInfo;
 };
+
+void registerFirtoolCLOptions();
 
 LogicalResult populatePreprocessTransforms(mlir::PassManager &pm,
                                            const FirtoolOptions &opt);

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -35,7 +35,6 @@ public:
   enum BuildMode { BuildModeDefault, BuildModeDebug, BuildModeRelease };
   enum class RandomKind { None, Mem, Reg, All };
 
-
   bool isRandomEnabled(RandomKind kind) const {
     return disableRandom != RandomKind::All && disableRandom != kind;
   }
@@ -46,48 +45,80 @@ public:
       return firrtl::PreserveValues::Named;
     case BuildModeRelease:
       return firrtl::PreserveValues::None;
-      case BuildModeDefault:
+    case BuildModeDefault:
       return preserveMode;
     }
     llvm_unreachable("unknown build mode");
   }
 
-    StringRef getOutputFilename() const { return outputFilename; }
-    StringRef getOmirOutputFile() const { return omirOutFile; }
-    StringRef getBlackBoxRootPath() const { return blackBoxRootPath; }
-    StringRef getChiselInterfaceOutputDirectory() const { return chiselInterfaceOutDirectory; }
-    StringRef getReplaceSequentialMemoriesFile() const { return replSeqMemFile; }
-    StringRef getOutputAnnotationFilename() const { return outputAnnotationFilename; }
-    firrtl::PreserveAggregate::PreserveMode getPreserveAggregate() const { return preserveAggregate; }
-    firrtl::CompanionMode getCompanionMode() const { return companionMode; }
-    bool isDefaultOutputFilename() const { return outputFilename == "-"; }
-    bool shouldDisableUnknownAnnotations() const { return disableAnnotationsUnknown; }
-    bool shouldDisableClasslessAnnotations() const { return disableAnnotationsClassless; }
-    bool shouldLowerNoRefTypePortAnnotations() const { return lowerAnnotationsNoRefTypePorts; }
-    bool shouldReplicateSequentialMemories() const { return replSeqMem; }
-    bool shouldDisableOptimization() const { return disableOptimization; }
-    bool shouldLowerMemories() const { return lowerMemories; }
-    bool shouldDedup() const { return !noDedup; }
-    bool shouldEnableDebugInfo() const { return enableDebugInfo; }
-    bool shouldIgnoreReadEnableMemories() const { return ignoreReadEnableMem; }
-    bool shouldEmitOMIR() const { return emitOMIR; }
-    bool shouldExportChiselInterface() const { return exportChiselInterface; }
-    bool shouldDisableHoistingHWPassthrough() const { return disableHoistingHWPassthrough; }
-    bool shouldConvertVecOfBundle() const { return vbToBV; }
-    bool shouldEtcDisableInstanceExtraction() const { return etcDisableInstanceExtraction; }
-    bool shouldEtcDisableRegisterExtraction() const { return etcDisableRegisterExtraction; }
-    bool shouldEtcDisableModuleInlining() const { return etcDisableModuleInlining; }
-    bool shouldStripDebugInfo() const { return stripDebugInfo; }
-    bool shouldStripFirDebugInfo() const { return stripFirDebugInfo; }
-    bool shouldExportModuleHierarchy() const { return exportModuleHierarchy; }
-    bool shouldDisableAggressiveMergeConnections() const { return disableAggressiveMergeConnections; }
-    bool shouldEnableAnnotationWarning() const { return enableAnnotationWarning; }
-    bool shouldEmitChiselAssertsAsSVA() const { return emitChiselAssertsAsSVA; }
-    bool shouldEmitSeparateAlwaysBlocks() const { return emitSeparateAlwaysBlocks; }
-    bool shouldAddMuxPragmas() const { return addMuxPragmas; }
-    bool shouldAddVivadoRAMAddressConflictSynthesisBugWorkaround() const { return addVivadoRAMAddressConflictSynthesisBugWorkaround; }
-    bool shouldExtractTestCode() const { return extractTestCode; }
-    
+  StringRef getOutputFilename() const { return outputFilename; }
+  StringRef getOmirOutputFile() const { return omirOutFile; }
+  StringRef getBlackBoxRootPath() const { return blackBoxRootPath; }
+  StringRef getChiselInterfaceOutputDirectory() const {
+    return chiselInterfaceOutDirectory;
+  }
+  StringRef getReplaceSequentialMemoriesFile() const { return replSeqMemFile; }
+  StringRef getOutputAnnotationFilename() const {
+    return outputAnnotationFilename;
+  }
+
+  firrtl::PreserveAggregate::PreserveMode getPreserveAggregate() const {
+    return preserveAggregate;
+  }
+  firrtl::CompanionMode getCompanionMode() const { return companionMode; }
+
+  seq::ExternalizeClockGateOptions getClockGateOptions() const {
+    return {ckgModuleName, ckgInputName,      ckgOutputName,
+            ckgEnableName, ckgTestEnableName, "ckg"};
+  }
+
+  bool isDefaultOutputFilename() const { return outputFilename == "-"; }
+  bool shouldDisableUnknownAnnotations() const {
+    return disableAnnotationsUnknown;
+  }
+  bool shouldDisableClasslessAnnotations() const {
+    return disableAnnotationsClassless;
+  }
+  bool shouldLowerNoRefTypePortAnnotations() const {
+    return lowerAnnotationsNoRefTypePorts;
+  }
+  bool shouldReplicateSequentialMemories() const { return replSeqMem; }
+  bool shouldDisableOptimization() const { return disableOptimization; }
+  bool shouldLowerMemories() const { return lowerMemories; }
+  bool shouldDedup() const { return !noDedup; }
+  bool shouldEnableDebugInfo() const { return enableDebugInfo; }
+  bool shouldIgnoreReadEnableMemories() const { return ignoreReadEnableMem; }
+  bool shouldEmitOMIR() const { return emitOMIR; }
+  bool shouldExportChiselInterface() const { return exportChiselInterface; }
+  bool shouldDisableHoistingHWPassthrough() const {
+    return disableHoistingHWPassthrough;
+  }
+  bool shouldConvertVecOfBundle() const { return vbToBV; }
+  bool shouldEtcDisableInstanceExtraction() const {
+    return etcDisableInstanceExtraction;
+  }
+  bool shouldEtcDisableRegisterExtraction() const {
+    return etcDisableRegisterExtraction;
+  }
+  bool shouldEtcDisableModuleInlining() const {
+    return etcDisableModuleInlining;
+  }
+  bool shouldStripDebugInfo() const { return stripDebugInfo; }
+  bool shouldStripFirDebugInfo() const { return stripFirDebugInfo; }
+  bool shouldExportModuleHierarchy() const { return exportModuleHierarchy; }
+  bool shouldDisableAggressiveMergeConnections() const {
+    return disableAggressiveMergeConnections;
+  }
+  bool shouldEnableAnnotationWarning() const { return enableAnnotationWarning; }
+  bool shouldEmitChiselAssertsAsSVA() const { return emitChiselAssertsAsSVA; }
+  bool shouldEmitSeparateAlwaysBlocks() const {
+    return emitSeparateAlwaysBlocks;
+  }
+  bool shouldAddMuxPragmas() const { return addMuxPragmas; }
+  bool shouldAddVivadoRAMAddressConflictSynthesisBugWorkaround() const {
+    return addVivadoRAMAddressConflictSynthesisBugWorkaround;
+  }
+  bool shouldExtractTestCode() const { return extractTestCode; }
 
 private:
   std::string outputFilename;

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -20,219 +20,24 @@ using namespace circt;
 // Option API.
 //===----------------------------------------------------------------------===//
 
-DEFINE_C_API_PTR_METHODS(FirtoolOptions, firtool::FirtoolOptions)
-
-FirtoolOptions firtoolOptionsCreateDefault() {
+FirtoolOptions circtFirtoolOptionsCreateDefault() {
   auto *options = new firtool::FirtoolOptions();
   return wrap(options);
 }
 
-void firtoolOptionsDestroy(FirtoolOptions options) { delete unwrap(options); }
+void circtFirtoolOptionsDestroy(CirctFirtoolOptions options) {
+  delete unwrap(options);
+}
 
-#define DEFINE_FIRTOOL_OPTION_STRING(name, field)                              \
-  //  void firtoolOptionsSet##name(FirtoolOptions options, MlirStringRef value) {  \
-//    unwrap(options)->field = unwrap(value).str();                              \
-//  }                                                                            \
-//  MlirStringRef firtoolOptionsGet##name(FirtoolOptions options) {              \
-//    return wrap(unwrap(options)->field.getValue());                            \
-//  }
+void circtFirtoolOptionsSetOutputFilename(CirctFirtoolOptions options,
+                                          MlirStringRef filename) {
+  unwrap(options)->setOutputFilename(name);
+}
 
-#define DEFINE_FIRTOOL_OPTION_BOOL(name, field)                                \
-  //  void firtoolOptionsSet##name(FirtoolOptions options, bool value) {           \
-//    unwrap(options)->field = value;                                            \
-//  }                                                                            \
-//  bool firtoolOptionsGet##name(FirtoolOptions options) {                       \
-//    return unwrap(options)->field;                                             \
-//  }
-
-#define DEFINE_FIRTOOL_OPTION_ENUM(name, field, enum_type, c_to_cpp, cpp_to_c) \
-  //  void firtoolOptionsSet##name(FirtoolOptions options, enum_type value) {      \
-//    unwrap(options)->field = c_to_cpp(value);                                  \
-//  }                                                                            \
-//  enum_type firtoolOptionsGet##name(FirtoolOptions options) {                  \
-//    return cpp_to_c(unwrap(options)->field);                                   \
-//  }
-
-DEFINE_FIRTOOL_OPTION_STRING(OutputFilename, outputFilename)
-DEFINE_FIRTOOL_OPTION_BOOL(DisableAnnotationsUnknown, disableAnnotationsUnknown)
-DEFINE_FIRTOOL_OPTION_BOOL(DisableAnnotationsClassless,
-                           disableAnnotationsClassless)
-DEFINE_FIRTOOL_OPTION_BOOL(LowerAnnotationsNoRefTypePorts,
-                           lowerAnnotationsNoRefTypePorts)
-DEFINE_FIRTOOL_OPTION_ENUM(
-    PreserveAggregate, preserveAggregate, FirtoolPreserveAggregateMode,
-    [](FirtoolPreserveAggregateMode value) {
-      switch (value) {
-      case FIRTOOL_PRESERVE_AGGREGATE_MODE_NONE:
-        return firrtl::PreserveAggregate::None;
-      case FIRTOOL_PRESERVE_AGGREGATE_MODE_ONE_DIM_VEC:
-        return firrtl::PreserveAggregate::OneDimVec;
-      case FIRTOOL_PRESERVE_AGGREGATE_MODE_VEC:
-        return firrtl::PreserveAggregate::Vec;
-      case FIRTOOL_PRESERVE_AGGREGATE_MODE_ALL:
-        return firrtl::PreserveAggregate::All;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown preserve aggregate mode");
-      }
-    },
-    [](firrtl::PreserveAggregate::PreserveMode value) {
-      switch (value) {
-      case firrtl::PreserveAggregate::None:
-        return FIRTOOL_PRESERVE_AGGREGATE_MODE_NONE;
-      case firrtl::PreserveAggregate::OneDimVec:
-        return FIRTOOL_PRESERVE_AGGREGATE_MODE_ONE_DIM_VEC;
-      case firrtl::PreserveAggregate::Vec:
-        return FIRTOOL_PRESERVE_AGGREGATE_MODE_VEC;
-      case firrtl::PreserveAggregate::All:
-        return FIRTOOL_PRESERVE_AGGREGATE_MODE_ALL;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown preserve aggregate mode");
-      }
-    })
-DEFINE_FIRTOOL_OPTION_ENUM(
-    PreserveValues, preserveMode, FirtoolPreserveValuesMode,
-    [](FirtoolPreserveValuesMode value) {
-      switch (value) {
-      case FIRTOOL_PRESERVE_VALUES_MODE_NONE:
-        return firrtl::PreserveValues::None;
-      case FIRTOOL_PRESERVE_VALUES_MODE_NAMED:
-        return firrtl::PreserveValues::Named;
-      case FIRTOOL_PRESERVE_VALUES_MODE_ALL:
-        return firrtl::PreserveValues::All;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown preserve values mode");
-      }
-    },
-    [](firrtl::PreserveValues::PreserveMode value) {
-      switch (value) {
-      case firrtl::PreserveValues::None:
-        return FIRTOOL_PRESERVE_VALUES_MODE_NONE;
-      case firrtl::PreserveValues::Named:
-        return FIRTOOL_PRESERVE_VALUES_MODE_NAMED;
-      case firrtl::PreserveValues::All:
-        return FIRTOOL_PRESERVE_VALUES_MODE_ALL;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown preserve values mode");
-      }
-    })
-DEFINE_FIRTOOL_OPTION_ENUM(
-    BuildMode, buildMode, FirtoolBuildMode,
-    [](FirtoolBuildMode value) {
-      switch (value) {
-      case FIRTOOL_BUILD_MODE_DEBUG:
-        return firtool::FirtoolOptions::BuildModeDebug;
-      case FIRTOOL_BUILD_MODE_RELEASE:
-        return firtool::FirtoolOptions::BuildModeRelease;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown build mode");
-      }
-    },
-    [](firtool::FirtoolOptions::BuildMode value) {
-      switch (value) {
-      case firtool::FirtoolOptions::BuildModeDebug:
-        return FIRTOOL_BUILD_MODE_DEBUG;
-      case firtool::FirtoolOptions::BuildModeRelease:
-        return FIRTOOL_BUILD_MODE_RELEASE;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown build mode");
-      }
-    })
-DEFINE_FIRTOOL_OPTION_BOOL(DisableOptimization, disableOptimization)
-DEFINE_FIRTOOL_OPTION_BOOL(ExportChiselInterface, exportChiselInterface)
-DEFINE_FIRTOOL_OPTION_STRING(ChiselInterfaceOutDirectory,
-                             chiselInterfaceOutDirectory)
-DEFINE_FIRTOOL_OPTION_BOOL(VbToBv, vbToBV)
-DEFINE_FIRTOOL_OPTION_ENUM(
-    CompanionMode, companionMode, FirtoolCompanionMode,
-    [](FirtoolCompanionMode value) {
-      switch (value) {
-      case FIRTOOL_COMPANION_MODE_BIND:
-        return firrtl::CompanionMode::Bind;
-      case FIRTOOL_COMPANION_MODE_INSTANTIATE:
-        return firrtl::CompanionMode::Instantiate;
-      case FIRTOOL_COMPANION_MODE_DROP:
-        return firrtl::CompanionMode::Drop;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown build mode");
-      }
-    },
-    [](firrtl::CompanionMode value) {
-      switch (value) {
-      case firrtl::CompanionMode::Bind:
-        return FIRTOOL_COMPANION_MODE_BIND;
-      case firrtl::CompanionMode::Instantiate:
-        return FIRTOOL_COMPANION_MODE_INSTANTIATE;
-      case firrtl::CompanionMode::Drop:
-        return FIRTOOL_COMPANION_MODE_DROP;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown build mode");
-      }
-    })
-
-DEFINE_FIRTOOL_OPTION_BOOL(DisableAggressiveMergeConnections,
-                           disableAggressiveMergeConnections)
-DEFINE_FIRTOOL_OPTION_BOOL(EmitOMIR, emitOMIR)
-DEFINE_FIRTOOL_OPTION_STRING(OMIROutFile, omirOutFile)
-DEFINE_FIRTOOL_OPTION_BOOL(LowerMemories, lowerMemories)
-DEFINE_FIRTOOL_OPTION_STRING(BlackBoxRootPath, blackBoxRootPath)
-DEFINE_FIRTOOL_OPTION_BOOL(ReplSeqMem, replSeqMem)
-DEFINE_FIRTOOL_OPTION_STRING(ReplSeqMemFile, replSeqMemFile)
-DEFINE_FIRTOOL_OPTION_BOOL(ExtractTestCode, extractTestCode)
-DEFINE_FIRTOOL_OPTION_BOOL(IgnoreReadEnableMem, ignoreReadEnableMem)
-DEFINE_FIRTOOL_OPTION_ENUM(
-    DisableRandom, disableRandom, FirtoolRandomKind,
-    [](FirtoolRandomKind value) {
-      switch (value) {
-      case FIRTOOL_RANDOM_KIND_NONE:
-        return firtool::FirtoolOptions::RandomKind::None;
-      case FIRTOOL_RANDOM_KIND_MEM:
-        return firtool::FirtoolOptions::RandomKind::Mem;
-      case FIRTOOL_RANDOM_KIND_REG:
-        return firtool::FirtoolOptions::RandomKind::Reg;
-      case FIRTOOL_RANDOM_KIND_ALL:
-        return firtool::FirtoolOptions::RandomKind::All;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown random kind");
-      }
-    },
-    [](firtool::FirtoolOptions::RandomKind value) {
-      switch (value) {
-      case firtool::FirtoolOptions::RandomKind::None:
-        return FIRTOOL_RANDOM_KIND_NONE;
-      case firtool::FirtoolOptions::RandomKind::Mem:
-        return FIRTOOL_RANDOM_KIND_MEM;
-      case firtool::FirtoolOptions::RandomKind::Reg:
-        return FIRTOOL_RANDOM_KIND_REG;
-      case firtool::FirtoolOptions::RandomKind::All:
-        return FIRTOOL_RANDOM_KIND_ALL;
-      default: // NOLINT(clang-diagnostic-covered-switch-default)
-        llvm_unreachable("unknown random kind");
-      }
-    })
-DEFINE_FIRTOOL_OPTION_STRING(OutputAnnotationFilename, outputAnnotationFilename)
-DEFINE_FIRTOOL_OPTION_BOOL(EnableAnnotationWarning, enableAnnotationWarning)
-DEFINE_FIRTOOL_OPTION_BOOL(AddMuxPragmas, addMuxPragmas)
-DEFINE_FIRTOOL_OPTION_BOOL(EmitChiselAssertsAsSVA, emitChiselAssertsAsSVA)
-DEFINE_FIRTOOL_OPTION_BOOL(EmitSeparateAlwaysBlocks, emitSeparateAlwaysBlocks)
-DEFINE_FIRTOOL_OPTION_BOOL(EtcDisableInstanceExtraction,
-                           etcDisableInstanceExtraction)
-DEFINE_FIRTOOL_OPTION_BOOL(EtcDisableRegisterExtraction,
-                           etcDisableRegisterExtraction)
-DEFINE_FIRTOOL_OPTION_BOOL(EtcDisableModuleInlining, etcDisableModuleInlining)
-DEFINE_FIRTOOL_OPTION_BOOL(AddVivadoRAMAddressConflictSynthesisBugWorkaround,
-                           addVivadoRAMAddressConflictSynthesisBugWorkaround)
-DEFINE_FIRTOOL_OPTION_STRING(CkgModuleName, ckgModuleName)
-DEFINE_FIRTOOL_OPTION_STRING(CkgInputName, ckgInputName)
-DEFINE_FIRTOOL_OPTION_STRING(CkgOutputName, ckgOutputName)
-DEFINE_FIRTOOL_OPTION_STRING(CkgEnableName, ckgEnableName)
-DEFINE_FIRTOOL_OPTION_STRING(CkgTestEnableName, ckgTestEnableName)
-DEFINE_FIRTOOL_OPTION_BOOL(ExportModuleHierarchy, exportModuleHierarchy)
-DEFINE_FIRTOOL_OPTION_BOOL(StripFirDebugInfo, stripFirDebugInfo)
-DEFINE_FIRTOOL_OPTION_BOOL(StripDebugInfo, stripDebugInfo)
-
-#undef DEFINE_FIRTOOL_OPTION_STRING
-#undef DEFINE_FIRTOOL_OPTION_BOOL
-#undef DEFINE_FIRTOOL_OPTION_ENUM
+void circtFirtoolOptionsDisableUnknownAnnotations(CirctFirtoolOptions options,
+                                                  bool disable) {
+  unwrap(options)->setDisableUnknownAnnotations(disable);
+}
 
 //===----------------------------------------------------------------------===//
 // Populate API.

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -30,28 +30,28 @@ FirtoolOptions firtoolOptionsCreateDefault() {
 void firtoolOptionsDestroy(FirtoolOptions options) { delete unwrap(options); }
 
 #define DEFINE_FIRTOOL_OPTION_STRING(name, field)                              \
-  void firtoolOptionsSet##name(FirtoolOptions options, MlirStringRef value) {  \
-    unwrap(options)->field = unwrap(value).str();                              \
-  }                                                                            \
-  MlirStringRef firtoolOptionsGet##name(FirtoolOptions options) {              \
-    return wrap(unwrap(options)->field.getValue());                            \
-  }
+  //  void firtoolOptionsSet##name(FirtoolOptions options, MlirStringRef value) {  \
+//    unwrap(options)->field = unwrap(value).str();                              \
+//  }                                                                            \
+//  MlirStringRef firtoolOptionsGet##name(FirtoolOptions options) {              \
+//    return wrap(unwrap(options)->field.getValue());                            \
+//  }
 
 #define DEFINE_FIRTOOL_OPTION_BOOL(name, field)                                \
-  void firtoolOptionsSet##name(FirtoolOptions options, bool value) {           \
-    unwrap(options)->field = value;                                            \
-  }                                                                            \
-  bool firtoolOptionsGet##name(FirtoolOptions options) {                       \
-    return unwrap(options)->field;                                             \
-  }
+  //  void firtoolOptionsSet##name(FirtoolOptions options, bool value) {           \
+//    unwrap(options)->field = value;                                            \
+//  }                                                                            \
+//  bool firtoolOptionsGet##name(FirtoolOptions options) {                       \
+//    return unwrap(options)->field;                                             \
+//  }
 
 #define DEFINE_FIRTOOL_OPTION_ENUM(name, field, enum_type, c_to_cpp, cpp_to_c) \
-  void firtoolOptionsSet##name(FirtoolOptions options, enum_type value) {      \
-    unwrap(options)->field = c_to_cpp(value);                                  \
-  }                                                                            \
-  enum_type firtoolOptionsGet##name(FirtoolOptions options) {                  \
-    return cpp_to_c(unwrap(options)->field);                                   \
-  }
+  //  void firtoolOptionsSet##name(FirtoolOptions options, enum_type value) {      \
+//    unwrap(options)->field = c_to_cpp(value);                                  \
+//  }                                                                            \
+//  enum_type firtoolOptionsGet##name(FirtoolOptions options) {                  \
+//    return cpp_to_c(unwrap(options)->field);                                   \
+//  }
 
 DEFINE_FIRTOOL_OPTION_STRING(OutputFilename, outputFilename)
 DEFINE_FIRTOOL_OPTION_BOOL(DisableAnnotationsUnknown, disableAnnotationsUnknown)

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -23,8 +23,7 @@ using namespace circt;
 DEFINE_C_API_PTR_METHODS(FirtoolOptions, firtool::FirtoolOptions)
 
 FirtoolOptions firtoolOptionsCreateDefault() {
-  static auto category = llvm::cl::OptionCategory{"Firtool Options"};
-  auto *options = new firtool::FirtoolOptions{category};
+  auto *options = new firtool::FirtoolOptions();
   return wrap(options);
 }
 

--- a/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
+++ b/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
@@ -137,7 +137,6 @@ void HWExportModuleHierarchyPass::runOnOperation() {
 // Pass Creation
 //===----------------------------------------------------------------------===//
 
-std::unique_ptr<mlir::Pass>
-sv::createHWExportModuleHierarchyPass(std::optional<std::string> directory) {
+std::unique_ptr<mlir::Pass> sv::createHWExportModuleHierarchyPass() {
   return std::make_unique<HWExportModuleHierarchyPass>();
 }

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -687,4 +687,42 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   lowerAnnotationsNoRefTypePorts = clOptions->lowerAnnotationsNoRefTypePorts;
   preserveAggregate = clOptions->preserveAggregate;
   preserveMode = clOptions->preserveMode;
+  enableDebugInfo = clOptions->enableDebugInfo;
+  buildMode = clOptions->buildMode;
+  disableOptimization = clOptions->disableOptimization;
+  exportChiselInterface = clOptions->exportChiselInterface;
+  chiselInterfaceOutDirectory = clOptions->chiselInterfaceOutDirectory;
+  vbToBV = clOptions->vbToBV;
+  noDedup = clOptions->noDedup;
+  companionMode = clOptions->companionMode;
+  disableAggressiveMergeConnections =
+      clOptions->disableAggressiveMergeConnections;
+  disableHoistingHWPassthrough = clOptions->disableHoistingHWPassthrough;
+  emitOMIR = clOptions->emitOMIR;
+  omirOutFile = clOptions->omirOutFile;
+  lowerMemories = clOptions->lowerMemories;
+  blackBoxRootPath = clOptions->blackBoxRootPath;
+  replSeqMem = clOptions->replSeqMem;
+  replSeqMemFile = clOptions->replSeqMemFile;
+  extractTestCode = clOptions->extractTestCode;
+  ignoreReadEnableMem = clOptions->ignoreReadEnableMem;
+  disableRandom = clOptions->disableRandom;
+  outputAnnotationFilename = clOptions->outputAnnotationFilename;
+  enableAnnotationWarning = clOptions->enableAnnotationWarning;
+  addMuxPragmas = clOptions->addMuxPragmas;
+  emitChiselAssertsAsSVA = clOptions->emitChiselAssertsAsSVA;
+  emitSeparateAlwaysBlocks = clOptions->emitSeparateAlwaysBlocks;
+  etcDisableInstanceExtraction = clOptions->etcDisableInstanceExtraction;
+  etcDisableRegisterExtraction = clOptions->etcDisableRegisterExtraction;
+  etcDisableModuleInlining = clOptions->etcDisableModuleInlining;
+  addVivadoRAMAddressConflictSynthesisBugWorkaround =
+      clOptions->addVivadoRAMAddressConflictSynthesisBugWorkaround;
+  ckgModuleName = clOptions->ckgModuleName;
+  ckgInputName = clOptions->ckgInputName;
+  ckgOutputName = clOptions->ckgOutputName;
+  ckgEnableName = clOptions->ckgEnableName;
+  ckgTestEnableName = clOptions->ckgTestEnableName;
+  exportModuleHierarchy = clOptions->exportModuleHierarchy;
+  stripFirDebugInfo = clOptions->stripFirDebugInfo;
+  stripDebugInfo = clOptions->stripDebugInfo;
 }

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -130,8 +130,6 @@ static cl::opt<bool>
                         cl::desc("Scalarize the ports of any external modules"),
                         cl::init(true), cl::cat(mainCategory));
 
-static firtool::FirtoolOptions firtoolOptions(mainCategory);
-
 static cl::list<std::string>
     passPlugins("load-pass-plugin", cl::desc("Load passes from plugin library"),
                 cl::CommaSeparated, cl::cat(mainCategory));
@@ -298,8 +296,10 @@ struct EmitSplitHGLDDPass
 
 /// Process a single buffer of the input.
 static LogicalResult processBuffer(
-    MLIRContext &context, TimingScope &ts, llvm::SourceMgr &sourceMgr,
+    MLIRContext &context, firtool::FirtoolOptions& firtoolOptions, TimingScope &ts, llvm::SourceMgr &sourceMgr,
     std::optional<std::unique_ptr<llvm::ToolOutputFile>> &outputFile) {
+
+
   // Add the annotation file if one was explicitly specified.
   unsigned numAnnotationFiles = 0;
   for (const auto &inputAnnotationFilename : inputAnnotationFilenames) {
@@ -435,7 +435,7 @@ static LogicalResult processBuffer(
       break;
     case OutputSplitVerilog:
       if (failed(firtool::populateExportSplitVerilog(
-              pm, firtoolOptions, firtoolOptions.outputFilename)))
+              pm, firtoolOptions, firtoolOptions.getOutputFilename())))
         return failure();
       if (emitHGLDD)
         pm.addPass(std::make_unique<EmitSplitHGLDDPass>());
@@ -517,7 +517,7 @@ public:
 /// creates a regular or verifying diagnostic handler, depending on whether the
 /// user set the verifyDiagnostics option.
 static LogicalResult processInputSplit(
-    MLIRContext &context, TimingScope &ts,
+    MLIRContext &context, firtool::FirtoolOptions& firtoolOptions, TimingScope &ts,
     std::unique_ptr<llvm::MemoryBuffer> buffer,
     std::optional<std::unique_ptr<llvm::ToolOutputFile>> &outputFile) {
   llvm::SourceMgr sourceMgr;
@@ -527,23 +527,23 @@ static LogicalResult processInputSplit(
     SourceMgrDiagnosticHandler sourceMgrHandler(sourceMgr,
                                                 &context /*, shouldShow */);
     FileLineColLocsAsNotesDiagnosticHandler addLocs(&context);
-    return processBuffer(context, ts, sourceMgr, outputFile);
+    return processBuffer(context, firtoolOptions, ts, sourceMgr, outputFile);
   }
 
   SourceMgrDiagnosticVerifierHandler sourceMgrHandler(sourceMgr, &context);
   context.printOpOnDiagnostic(false);
-  (void)processBuffer(context, ts, sourceMgr, outputFile);
+  (void)processBuffer(context, firtoolOptions, ts, sourceMgr, outputFile);
   return sourceMgrHandler.verify();
 }
 
 /// Process the entire input provided by the user, splitting it up if the
 /// corresponding option was specified.
 static LogicalResult
-processInput(MLIRContext &context, TimingScope &ts,
+processInput(MLIRContext &context, firtool::FirtoolOptions& firtoolOptions, TimingScope &ts,
              std::unique_ptr<llvm::MemoryBuffer> input,
              std::optional<std::unique_ptr<llvm::ToolOutputFile>> &outputFile) {
   if (!splitInputFile)
-    return processInputSplit(context, ts, std::move(input), outputFile);
+    return processInputSplit(context, firtoolOptions, ts, std::move(input), outputFile);
 
   // Emit an error if the user provides a separate annotation file alongside
   // split input. This is technically not a problem, but the user likely
@@ -561,7 +561,7 @@ processInput(MLIRContext &context, TimingScope &ts,
   return splitAndProcessBuffer(
       std::move(input),
       [&](std::unique_ptr<MemoryBuffer> buffer, raw_ostream &) {
-        return processInputSplit(context, ts, std::move(buffer), outputFile);
+        return processInputSplit(context, firtoolOptions, ts, std::move(buffer), outputFile);
       },
       llvm::outs());
 }
@@ -569,7 +569,7 @@ processInput(MLIRContext &context, TimingScope &ts,
 /// This implements the top-level logic for the firtool command, invoked once
 /// command line options are parsed and LLVM/MLIR are all set up and ready to
 /// go.
-static LogicalResult executeFirtool(MLIRContext &context) {
+static LogicalResult executeFirtool(MLIRContext &context, firtool::FirtoolOptions& firtoolOptions) {
   // Create the timing manager we use to sample execution times.
   DefaultTimingManager tm;
   applyDefaultTimingManagerCLOptions(tm);
@@ -603,23 +603,22 @@ static LogicalResult executeFirtool(MLIRContext &context) {
   if (outputFormat != OutputSplitVerilog) {
     // Create an output file.
     outputFile.emplace(
-        openOutputFile(firtoolOptions.outputFilename, &errorMessage));
+        openOutputFile(firtoolOptions.getOutputFilename(), &errorMessage));
     if (!(*outputFile)) {
       llvm::errs() << errorMessage << "\n";
       return failure();
     }
   } else {
     // Create an output directory.
-    if (firtoolOptions.outputFilename.isDefaultOption() ||
-        firtoolOptions.outputFilename == "-") {
+    if (firtoolOptions.isDefaultOutputFilename()) {
       llvm::errs() << "missing output directory: specify with -o=<dir>\n";
       return failure();
     }
     auto error =
-        llvm::sys::fs::create_directories(firtoolOptions.outputFilename);
+        llvm::sys::fs::create_directories(firtoolOptions.getOutputFilename());
     if (error) {
       llvm::errs() << "cannot create output directory '"
-                   << firtoolOptions.outputFilename << "': " << error.message()
+                   << firtoolOptions.getOutputFilename() << "': " << error.message()
                    << "\n";
       return failure();
     }
@@ -632,7 +631,7 @@ static LogicalResult executeFirtool(MLIRContext &context) {
                       ltl::LTLDialect, debug::DebugDialect>();
 
   // Process the input.
-  if (failed(processInput(context, ts, std::move(input), outputFile)))
+  if (failed(processInput(context, firtoolOptions, ts, std::move(input), outputFile)))
     return failure();
 
   // If the result succeeded and we're emitting a file, close it.
@@ -704,15 +703,18 @@ int main(int argc, char **argv) {
   registerPassManagerCLOptions();
   registerDefaultTimingManagerCLOptions();
   registerAsmPrinterCLOptions();
+  firtool::registerFirtoolCLOptions();
   cl::AddExtraVersionPrinter(
       [](raw_ostream &os) { os << getCirctVersion() << '\n'; });
   // Parse pass names in main to ensure static initialization completed.
   cl::ParseCommandLineOptions(argc, argv, "MLIR-based FIRRTL compiler\n");
 
   MLIRContext context;
+  // Get firtool options from cmdline
+  firtool::FirtoolOptions firtoolOptions;
 
   // Do the guts of the firtool process.
-  auto result = executeFirtool(context);
+  auto result = executeFirtool(context, firtoolOptions);
 
   // Use "exit" instead of return'ing to signal completion.  This avoids
   // invoking the MLIRContext destructor, which spends a bunch of time


### PR DESCRIPTION
Move firtool pipeline configuration over to the same mechanism the rest of llvm and mlir use.  Export this via the CAPI.  Add a couple examples of methods to change options to the CAPI.  Interested parties are encouraged to finish out the set of functions.

Since the CAPI has no tests, this breaks nothing.

As an aside, the configuration space of the firrtl pipeline is WAY too big.