### PR TITLE
[FIRRTL][CAPI] Add the rest of setters for options

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -23,40 +23,42 @@ DEFINE_C_API_STRUCT(CirctFirtoolFirtoolOptions, void);
 #undef DEFINE_C_API_STRUCT
 
 // NOLINTNEXTLINE(modernize-use-using)
-typedef enum FirtoolPreserveAggregateMode {
-  FIRTOOL_PRESERVE_AGGREGATE_MODE_NONE,
-  FIRTOOL_PRESERVE_AGGREGATE_MODE_ONE_DIM_VEC,
-  FIRTOOL_PRESERVE_AGGREGATE_MODE_VEC,
-  FIRTOOL_PRESERVE_AGGREGATE_MODE_ALL,
-} FirtoolPreserveAggregateMode;
+typedef enum CirctFirtoolPreserveAggregateMode {
+  CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_NONE,
+  CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_ONE_DIM_VEC,
+  CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_VEC,
+  CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_ALL,
+} CirctFirtoolPreserveAggregateMode;
 
 // NOLINTNEXTLINE(modernize-use-using)
-typedef enum FirtoolPreserveValuesMode {
-  FIRTOOL_PRESERVE_VALUES_MODE_NONE,
-  FIRTOOL_PRESERVE_VALUES_MODE_NAMED,
-  FIRTOOL_PRESERVE_VALUES_MODE_ALL,
-} FirtoolPreserveValuesMode;
+typedef enum CirctFirtoolPreserveValuesMode {
+  CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_STRIP,
+  CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_NONE,
+  CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_NAMED,
+  CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_ALL,
+} CirctFirtoolPreserveValuesMode;
 
 // NOLINTNEXTLINE(modernize-use-using)
-typedef enum FirtoolCompanionMode {
-  FIRTOOL_COMPANION_MODE_BIND,
-  FIRTOOL_COMPANION_MODE_INSTANTIATE,
-  FIRTOOL_COMPANION_MODE_DROP,
-} FirtoolCompanionMode;
+typedef enum CirctFirtoolCompanionMode {
+  CIRCT_FIRTOOL_COMPANION_MODE_BIND,
+  CIRCT_FIRTOOL_COMPANION_MODE_INSTANTIATE,
+  CIRCT_FIRTOOL_COMPANION_MODE_DROP,
+} CirctFirtoolCompanionMode;
 
 // NOLINTNEXTLINE(modernize-use-using)
-typedef enum FirtoolBuildMode {
-  FIRTOOL_BUILD_MODE_DEBUG,
-  FIRTOOL_BUILD_MODE_RELEASE,
-} FirtoolBuildMode;
+typedef enum CirctFirtoolBuildMode {
+  CIRCT_FIRTOOL_BUILD_MODE_DEFAULT,
+  CIRCT_FIRTOOL_BUILD_MODE_DEBUG,
+  CIRCT_FIRTOOL_BUILD_MODE_RELEASE,
+} CirctFirtoolBuildMode;
 
 // NOLINTNEXTLINE(modernize-use-using)
-typedef enum FirtoolRandomKind {
-  FIRTOOL_RANDOM_KIND_NONE,
-  FIRTOOL_RANDOM_KIND_MEM,
-  FIRTOOL_RANDOM_KIND_REG,
-  FIRTOOL_RANDOM_KIND_ALL,
-} FirtoolRandomKind;
+typedef enum CirctFirtoolRandomKind {
+  CIRCT_FIRTOOL_RANDOM_KIND_NONE,
+  CIRCT_FIRTOOL_RANDOM_KIND_MEM,
+  CIRCT_FIRTOOL_RANDOM_KIND_REG,
+  CIRCT_FIRTOOL_RANDOM_KIND_ALL,
+} CirctFirtoolRandomKind;
 
 MLIR_CAPI_EXPORTED CirctFirtoolFirtoolOptions
 circtFirtoolOptionsCreateDefault();
@@ -66,36 +68,181 @@ circtFirtoolOptionsDestroy(CirctFirtoolFirtoolOptions options);
 MLIR_CAPI_EXPORTED void
 circtFirtoolOptionsSetOutputFilename(CirctFirtoolFirtoolOptions options,
                                      MlirStringRef filename);
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetDisableUnknownAnnotations(
+    CirctFirtoolFirtoolOptions options, bool disable);
+
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetDisableAnnotationsClassless(
+    CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetLowerAnnotationsNoRefTypePorts(
+    CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetPreserveAggregate(
+    CirctFirtoolFirtoolOptions options,
+    CirctFirtoolPreserveAggregateMode value);
+
 MLIR_CAPI_EXPORTED void
-circtFirtoolOptionsDisableUnknownAnnotations(CirctFirtoolFirtoolOptions options,
-                                             bool disable);
+circtFirtoolOptionsSetPreserveValues(CirctFirtoolFirtoolOptions options,
+                                     CirctFirtoolPreserveValuesMode value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetEnableDebugInfo(CirctFirtoolFirtoolOptions options,
+                                      bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetBuildMode(CirctFirtoolFirtoolOptions options,
+                                CirctFirtoolBuildMode value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetDisableOptimization(CirctFirtoolFirtoolOptions options,
+                                          bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetExportChiselInterface(CirctFirtoolFirtoolOptions options,
+                                            bool value);
+
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetChiselInterfaceOutDirectory(
+    CirctFirtoolFirtoolOptions options, MlirStringRef value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetVbToBv(CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetNoDedup(CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetCompanionMode(CirctFirtoolFirtoolOptions options,
+                                    CirctFirtoolCompanionMode value);
+
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetDisableAggressiveMergeConnections(
+    CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetDisableHoistingHWPassthrough(
+    CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetEmitOmir(CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetOmirOutFile(CirctFirtoolFirtoolOptions options,
+                                  MlirStringRef value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetLowerMemories(CirctFirtoolFirtoolOptions options,
+                                    bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetBlackBoxRootPath(CirctFirtoolFirtoolOptions options,
+                                       MlirStringRef value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetReplSeqMem(CirctFirtoolFirtoolOptions options,
+                                 bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetReplSeqMemFile(CirctFirtoolFirtoolOptions options,
+                                     MlirStringRef value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetExtractTestCode(CirctFirtoolFirtoolOptions options,
+                                      bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetIgnoreReadEnableMem(CirctFirtoolFirtoolOptions options,
+                                          bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetDisableRandom(CirctFirtoolFirtoolOptions options,
+                                    CirctFirtoolRandomKind value);
+
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetOutputAnnotationFilename(
+    CirctFirtoolFirtoolOptions options, MlirStringRef value);
+
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetEnableAnnotationWarning(
+    CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetAddMuxPragmas(CirctFirtoolFirtoolOptions options,
+                                    bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetEmitChiselAssertsAsSVA(CirctFirtoolFirtoolOptions options,
+                                             bool value);
+
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetEmitSeparateAlwaysBlocks(
+    CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetEtcDisableInstanceExtraction(
+    CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetEtcDisableRegisterExtraction(
+    CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetEtcDisableModuleInlining(
+    CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetAddVivadoRAMAddressConflictSynthesisBugWorkaround(
+    CirctFirtoolFirtoolOptions options, bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetCkgModuleName(CirctFirtoolFirtoolOptions options,
+                                    MlirStringRef value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetCkgInputName(CirctFirtoolFirtoolOptions options,
+                                   MlirStringRef value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetCkgOutputName(CirctFirtoolFirtoolOptions options,
+                                    MlirStringRef value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetCkgEnableName(CirctFirtoolFirtoolOptions options,
+                                    MlirStringRef value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetCkgTestEnableName(CirctFirtoolFirtoolOptions options,
+                                        MlirStringRef value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetExportModuleHierarchy(CirctFirtoolFirtoolOptions options,
+                                            bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetStripFirDebugInfo(CirctFirtoolFirtoolOptions options,
+                                        bool value);
+
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetStripDebugInfo(CirctFirtoolFirtoolOptions options,
+                                     bool value);
 
 //===----------------------------------------------------------------------===//
 // Populate API.
 //===----------------------------------------------------------------------===//
 
-MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulatePreprocessTransforms(
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulatePreprocessTransforms(
     MlirPassManager pm, CirctFirtoolFirtoolOptions options);
 
-MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulateCHIRRTLToLowFIRRTL(
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulateCHIRRTLToLowFIRRTL(
     MlirPassManager pm, CirctFirtoolFirtoolOptions options,
     MlirStringRef inputFilename);
 
-MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulateLowFIRRTLToHW(
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulateLowFIRRTLToHW(
     MlirPassManager pm, CirctFirtoolFirtoolOptions options);
 
-MLIR_CAPI_EXPORTED MlirLogicalResult
-firtoolPopulateHWToSV(MlirPassManager pm, CirctFirtoolFirtoolOptions options);
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulateHWToSV(
+    MlirPassManager pm, CirctFirtoolFirtoolOptions options);
 
-MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulateExportVerilog(
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulateExportVerilog(
     MlirPassManager pm, CirctFirtoolFirtoolOptions options,
     MlirStringCallback callback, void *userData);
 
-MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulateExportSplitVerilog(
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulateExportSplitVerilog(
     MlirPassManager pm, CirctFirtoolFirtoolOptions options,
     MlirStringRef directory);
 
-MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulateFinalizeIR(
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulateFinalizeIR(
     MlirPassManager pm, CirctFirtoolFirtoolOptions options);
 
 #ifdef __cplusplus

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -130,6 +130,209 @@ public:
     return *this;
   }
 
+  FirtoolOptions &setDisableAnnotationsClassless(bool value) {
+    disableAnnotationsClassless = value;
+    return *this;
+  }
+
+  FirtoolOptions &setLowerAnnotationsNoRefTypePorts(bool value) {
+    lowerAnnotationsNoRefTypePorts = value;
+    return *this;
+  }
+
+  FirtoolOptions &
+  setPreserveAggregate(firrtl::PreserveAggregate::PreserveMode value) {
+    preserveAggregate = value;
+    return *this;
+  }
+
+  FirtoolOptions &
+  setPreserveValues(firrtl::PreserveValues::PreserveMode value) {
+    preserveMode = value;
+    return *this;
+  }
+
+  FirtoolOptions &setEnableDebugInfo(bool value) {
+    enableDebugInfo = value;
+    return *this;
+  }
+
+  FirtoolOptions &setBuildMode(BuildMode value) {
+    buildMode = value;
+    return *this;
+  }
+
+  FirtoolOptions &setDisableOptimization(bool value) {
+    disableOptimization = value;
+    return *this;
+  }
+
+  FirtoolOptions &setExportChiselInterface(bool value) {
+    exportChiselInterface = value;
+    return *this;
+  }
+
+  FirtoolOptions &setChiselInterfaceOutDirectory(StringRef value) {
+    chiselInterfaceOutDirectory = value;
+    return *this;
+  }
+
+  FirtoolOptions &setVbToBV(bool value) {
+    vbToBV = value;
+    return *this;
+  }
+
+  FirtoolOptions &setNoDedup(bool value) {
+    noDedup = value;
+    return *this;
+  }
+
+  FirtoolOptions &setCompanionMode(firrtl::CompanionMode value) {
+    companionMode = value;
+    return *this;
+  }
+
+  FirtoolOptions &setDisableAggressiveMergeConnections(bool value) {
+    disableAggressiveMergeConnections = value;
+    return *this;
+  }
+
+  FirtoolOptions &setDisableHoistingHWPassthrough(bool value) {
+    disableHoistingHWPassthrough = value;
+    return *this;
+  }
+
+  FirtoolOptions &setEmitOMIR(bool value) {
+    emitOMIR = value;
+    return *this;
+  }
+
+  FirtoolOptions &setOmirOutFile(StringRef value) {
+    omirOutFile = value;
+    return *this;
+  }
+
+  FirtoolOptions &setLowerMemories(bool value) {
+    lowerMemories = value;
+    return *this;
+  }
+
+  FirtoolOptions &setBlackBoxRootPath(StringRef value) {
+    blackBoxRootPath = value;
+    return *this;
+  }
+
+  FirtoolOptions &setReplSeqMem(bool value) {
+    replSeqMem = value;
+    return *this;
+  }
+
+  FirtoolOptions &setReplSeqMemFile(StringRef value) {
+    replSeqMemFile = value;
+    return *this;
+  }
+
+  FirtoolOptions &setExtractTestCode(bool value) {
+    extractTestCode = value;
+    return *this;
+  }
+
+  FirtoolOptions &setIgnoreReadEnableMem(bool value) {
+    ignoreReadEnableMem = value;
+    return *this;
+  }
+
+  FirtoolOptions &setDisableRandom(RandomKind value) {
+    disableRandom = value;
+    return *this;
+  }
+
+  FirtoolOptions &setOutputAnnotationFilename(StringRef value) {
+    outputAnnotationFilename = value;
+    return *this;
+  }
+
+  FirtoolOptions &setEnableAnnotationWarning(bool value) {
+    enableAnnotationWarning = value;
+    return *this;
+  }
+
+  FirtoolOptions &setAddMuxPragmas(bool value) {
+    addMuxPragmas = value;
+    return *this;
+  }
+
+  FirtoolOptions &setEmitChiselAssertsAsSVA(bool value) {
+    emitChiselAssertsAsSVA = value;
+    return *this;
+  }
+
+  FirtoolOptions &setEmitSeparateAlwaysBlocks(bool value) {
+    emitSeparateAlwaysBlocks = value;
+    return *this;
+  }
+
+  FirtoolOptions &setEtcDisableInstanceExtraction(bool value) {
+    etcDisableInstanceExtraction = value;
+    return *this;
+  }
+
+  FirtoolOptions &setEtcDisableRegisterExtraction(bool value) {
+    etcDisableRegisterExtraction = value;
+    return *this;
+  }
+
+  FirtoolOptions &setEtcDisableModuleInlining(bool value) {
+    etcDisableModuleInlining = value;
+    return *this;
+  }
+
+  FirtoolOptions &
+  setAddVivadoRAMAddressConflictSynthesisBugWorkaround(bool value) {
+    addVivadoRAMAddressConflictSynthesisBugWorkaround = value;
+    return *this;
+  }
+
+  FirtoolOptions &setCkgModuleName(StringRef value) {
+    ckgModuleName = value;
+    return *this;
+  }
+
+  FirtoolOptions &setCkgInputName(StringRef value) {
+    ckgInputName = value;
+    return *this;
+  }
+
+  FirtoolOptions &setCkgOutputName(StringRef value) {
+    ckgOutputName = value;
+    return *this;
+  }
+
+  FirtoolOptions &setCkgEnableName(StringRef value) {
+    ckgEnableName = value;
+    return *this;
+  }
+
+  FirtoolOptions &setCkgTestEnableName(StringRef value) {
+    ckgTestEnableName = value;
+    return *this;
+  }
+
+  FirtoolOptions &setExportModuleHierarchy(bool value) {
+    exportModuleHierarchy = value;
+    return *this;
+  }
+
+  FirtoolOptions &setStripFirDebugInfo(bool value) {
+    stripFirDebugInfo = value;
+    return *this;
+  }
+
+  FirtoolOptions &setStripDebugInfo(bool value) {
+    stripDebugInfo = value;
+    return *this;
+  }
+
 private:
   std::string outputFilename;
   bool disableAnnotationsUnknown;

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -7,6 +7,7 @@
 #include "circt-c/Firtool/Firtool.h"
 #include "circt/Firtool/Firtool.h"
 
+#include "circt/Firtool/Firtool.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Pass.h"
 #include "mlir/CAPI/Support.h"
@@ -37,9 +38,299 @@ void circtFirtoolOptionsSetOutputFilename(CirctFirtoolFirtoolOptions options,
   unwrap(options)->setOutputFilename(unwrap(filename));
 }
 
-void circtFirtoolOptionsDisableUnknownAnnotations(
+void circtFirtoolOptionsSetDisableUnknownAnnotations(
     CirctFirtoolFirtoolOptions options, bool disable) {
   unwrap(options)->setDisableUnknownAnnotations(disable);
+}
+
+void circtFirtoolOptionsSetDisableAnnotationsClassless(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setDisableAnnotationsClassless(value);
+}
+
+void circtFirtoolOptionsSetLowerAnnotationsNoRefTypePorts(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setLowerAnnotationsNoRefTypePorts(value);
+}
+
+void circtFirtoolOptionsSetPreserveAggregate(
+    CirctFirtoolFirtoolOptions options,
+    CirctFirtoolPreserveAggregateMode value) {
+  firrtl::PreserveAggregate::PreserveMode converted;
+
+  switch (value) {
+  case CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_NONE:
+    converted = firrtl::PreserveAggregate::PreserveMode::None;
+    break;
+  case CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_ONE_DIM_VEC:
+    converted = firrtl::PreserveAggregate::PreserveMode::OneDimVec;
+    break;
+  case CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_VEC:
+    converted = firrtl::PreserveAggregate::PreserveMode::Vec;
+    break;
+  case CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_ALL:
+    converted = firrtl::PreserveAggregate::PreserveMode::All;
+    break;
+  default:
+    llvm_unreachable("unknown preserve aggregate mode");
+  }
+
+  unwrap(options)->setPreserveAggregate(converted);
+}
+
+void circtFirtoolOptionsSetPreserveValues(
+    CirctFirtoolFirtoolOptions options, CirctFirtoolPreserveValuesMode value) {
+  firrtl::PreserveValues::PreserveMode converted;
+
+  switch (value) {
+  case CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_STRIP:
+    converted = firrtl::PreserveValues::PreserveMode::Strip;
+    break;
+  case CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_NONE:
+    converted = firrtl::PreserveValues::PreserveMode::None;
+    break;
+  case CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_NAMED:
+    converted = firrtl::PreserveValues::PreserveMode::Named;
+    break;
+  case CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_ALL:
+    converted = firrtl::PreserveValues::PreserveMode::All;
+    break;
+  default:
+    llvm_unreachable("unknown preserve values mode");
+  }
+
+  unwrap(options)->setPreserveValues(converted);
+}
+
+void circtFirtoolOptionsSetEnableDebugInfo(CirctFirtoolFirtoolOptions options,
+                                           bool value) {
+  unwrap(options)->setEnableDebugInfo(value);
+}
+
+void circtFirtoolOptionsSetBuildMode(CirctFirtoolFirtoolOptions options,
+                                     CirctFirtoolBuildMode value) {
+  firtool::FirtoolOptions::BuildMode converted;
+
+  switch (value) {
+  case CIRCT_FIRTOOL_BUILD_MODE_DEFAULT:
+    converted = firtool::FirtoolOptions::BuildMode::BuildModeDefault;
+    break;
+  case CIRCT_FIRTOOL_BUILD_MODE_DEBUG:
+    converted = firtool::FirtoolOptions::BuildMode::BuildModeDebug;
+    break;
+  case CIRCT_FIRTOOL_BUILD_MODE_RELEASE:
+    converted = firtool::FirtoolOptions::BuildMode::BuildModeRelease;
+    break;
+  default:
+    llvm_unreachable("unknown build mode");
+  }
+
+  unwrap(options)->setBuildMode(converted);
+}
+
+void circtFirtoolOptionsSetDisableOptimization(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setDisableOptimization(value);
+}
+
+void circtFirtoolOptionsSetExportChiselInterface(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setExportChiselInterface(value);
+}
+
+void circtFirtoolOptionsSetChiselInterfaceOutDirectory(
+    CirctFirtoolFirtoolOptions options, MlirStringRef value) {
+  unwrap(options)->setChiselInterfaceOutDirectory(unwrap(value));
+}
+
+void circtFirtoolOptionsSetVbToBv(CirctFirtoolFirtoolOptions options,
+                                  bool value) {
+  unwrap(options)->setVbToBV(value);
+}
+
+void circtFirtoolOptionsSetNoDedup(CirctFirtoolFirtoolOptions options,
+                                   bool value) {
+  unwrap(options)->setNoDedup(value);
+}
+
+void circtFirtoolOptionsSetCompanionMode(CirctFirtoolFirtoolOptions options,
+                                         CirctFirtoolCompanionMode value) {
+  firrtl::CompanionMode converted;
+
+  switch (value) {
+  case CIRCT_FIRTOOL_COMPANION_MODE_BIND:
+    converted = firrtl::CompanionMode::Bind;
+    break;
+  case CIRCT_FIRTOOL_COMPANION_MODE_INSTANTIATE:
+    converted = firrtl::CompanionMode::Instantiate;
+    break;
+  case CIRCT_FIRTOOL_COMPANION_MODE_DROP:
+    converted = firrtl::CompanionMode::Drop;
+    break;
+  default:
+    llvm_unreachable("unknown companion mode");
+  }
+
+  unwrap(options)->setCompanionMode(converted);
+}
+
+void circtFirtoolOptionsSetDisableAggressiveMergeConnections(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setDisableAggressiveMergeConnections(value);
+}
+
+void circtFirtoolOptionsSetDisableHoistingHWPassthrough(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setDisableHoistingHWPassthrough(value);
+}
+
+void circtFirtoolOptionsSetEmitOmir(CirctFirtoolFirtoolOptions options,
+                                    bool value) {
+  unwrap(options)->setEmitOMIR(value);
+}
+
+void circtFirtoolOptionsSetOmirOutFile(CirctFirtoolFirtoolOptions options,
+                                       MlirStringRef value) {
+  unwrap(options)->setOmirOutFile(unwrap(value));
+}
+
+void circtFirtoolOptionsSetLowerMemories(CirctFirtoolFirtoolOptions options,
+                                         bool value) {
+  unwrap(options)->setLowerMemories(value);
+}
+
+void circtFirtoolOptionsSetBlackBoxRootPath(CirctFirtoolFirtoolOptions options,
+                                            MlirStringRef value) {
+  unwrap(options)->setBlackBoxRootPath(unwrap(value));
+}
+
+void circtFirtoolOptionsSetReplSeqMem(CirctFirtoolFirtoolOptions options,
+                                      bool value) {
+  unwrap(options)->setReplSeqMem(value);
+}
+
+void circtFirtoolOptionsSetReplSeqMemFile(CirctFirtoolFirtoolOptions options,
+                                          MlirStringRef value) {
+  unwrap(options)->setReplSeqMemFile(unwrap(value));
+}
+
+void circtFirtoolOptionsSetExtractTestCode(CirctFirtoolFirtoolOptions options,
+                                           bool value) {
+  unwrap(options)->setExtractTestCode(value);
+}
+
+void circtFirtoolOptionsSetIgnoreReadEnableMem(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setIgnoreReadEnableMem(value);
+}
+
+void circtFirtoolOptionsSetDisableRandom(CirctFirtoolFirtoolOptions options,
+                                         CirctFirtoolRandomKind value) {
+  firtool::FirtoolOptions::RandomKind converted;
+
+  switch (value) {
+  case CIRCT_FIRTOOL_RANDOM_KIND_NONE:
+    converted = firtool::FirtoolOptions::RandomKind::None;
+    break;
+  case CIRCT_FIRTOOL_RANDOM_KIND_MEM:
+    converted = firtool::FirtoolOptions::RandomKind::Mem;
+    break;
+  case CIRCT_FIRTOOL_RANDOM_KIND_REG:
+    converted = firtool::FirtoolOptions::RandomKind::Reg;
+    break;
+  case CIRCT_FIRTOOL_RANDOM_KIND_ALL:
+    converted = firtool::FirtoolOptions::RandomKind::All;
+    break;
+  default:
+    llvm_unreachable("unknown random kind");
+  }
+
+  unwrap(options)->setDisableRandom(converted);
+}
+
+void circtFirtoolOptionsSetOutputAnnotationFilename(
+    CirctFirtoolFirtoolOptions options, MlirStringRef value) {
+  unwrap(options)->setOutputAnnotationFilename(unwrap(value));
+}
+
+void circtFirtoolOptionsSetEnableAnnotationWarning(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setEnableAnnotationWarning(value);
+}
+
+void circtFirtoolOptionsSetAddMuxPragmas(CirctFirtoolFirtoolOptions options,
+                                         bool value) {
+  unwrap(options)->setAddMuxPragmas(value);
+}
+
+void circtFirtoolOptionsSetEmitChiselAssertsAsSVA(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setEmitChiselAssertsAsSVA(value);
+}
+
+void circtFirtoolOptionsSetEmitSeparateAlwaysBlocks(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setEmitSeparateAlwaysBlocks(value);
+}
+
+void circtFirtoolOptionsSetEtcDisableInstanceExtraction(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setEtcDisableInstanceExtraction(value);
+}
+
+void circtFirtoolOptionsSetEtcDisableRegisterExtraction(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setEtcDisableRegisterExtraction(value);
+}
+
+void circtFirtoolOptionsSetEtcDisableModuleInlining(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setEtcDisableModuleInlining(value);
+}
+
+void circtFirtoolOptionsSetAddVivadoRAMAddressConflictSynthesisBugWorkaround(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setAddVivadoRAMAddressConflictSynthesisBugWorkaround(value);
+}
+
+void circtFirtoolOptionsSetCkgModuleName(CirctFirtoolFirtoolOptions options,
+                                         MlirStringRef value) {
+  unwrap(options)->setCkgModuleName(unwrap(value));
+}
+
+void circtFirtoolOptionsSetCkgInputName(CirctFirtoolFirtoolOptions options,
+                                        MlirStringRef value) {
+  unwrap(options)->setCkgInputName(unwrap(value));
+}
+
+void circtFirtoolOptionsSetCkgOutputName(CirctFirtoolFirtoolOptions options,
+                                         MlirStringRef value) {
+  unwrap(options)->setCkgOutputName(unwrap(value));
+}
+
+void circtFirtoolOptionsSetCkgEnableName(CirctFirtoolFirtoolOptions options,
+                                         MlirStringRef value) {
+  unwrap(options)->setCkgEnableName(unwrap(value));
+}
+
+void circtFirtoolOptionsSetCkgTestEnableName(CirctFirtoolFirtoolOptions options,
+                                             MlirStringRef value) {
+  unwrap(options)->setCkgTestEnableName(unwrap(value));
+}
+
+void circtFirtoolOptionsSetExportModuleHierarchy(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setExportModuleHierarchy(value);
+}
+
+void circtFirtoolOptionsSetStripFirDebugInfo(CirctFirtoolFirtoolOptions options,
+                                             bool value) {
+  unwrap(options)->setStripFirDebugInfo(value);
+}
+
+void circtFirtoolOptionsSetStripDebugInfo(CirctFirtoolFirtoolOptions options,
+                                          bool value) {
+  unwrap(options)->setStripDebugInfo(value);
 }
 
 //===----------------------------------------------------------------------===//
@@ -47,35 +338,36 @@ void circtFirtoolOptionsDisableUnknownAnnotations(
 //===----------------------------------------------------------------------===//
 
 MlirLogicalResult
-firtoolPopulatePreprocessTransforms(MlirPassManager pm,
-                                    CirctFirtoolFirtoolOptions options) {
+circtFirtoolPopulatePreprocessTransforms(MlirPassManager pm,
+                                         CirctFirtoolFirtoolOptions options) {
   return wrap(
       firtool::populatePreprocessTransforms(*unwrap(pm), *unwrap(options)));
 }
 
 MlirLogicalResult
-firtoolPopulateCHIRRTLToLowFIRRTL(MlirPassManager pm,
-                                  CirctFirtoolFirtoolOptions options,
-                                  MlirStringRef inputFilename) {
+circtFirtoolPopulateCHIRRTLToLowFIRRTL(MlirPassManager pm,
+                                       CirctFirtoolFirtoolOptions options,
+                                       MlirStringRef inputFilename) {
   return wrap(firtool::populateCHIRRTLToLowFIRRTL(*unwrap(pm), *unwrap(options),
                                                   unwrap(inputFilename)));
 }
 
 MlirLogicalResult
-firtoolPopulateLowFIRRTLToHW(MlirPassManager pm,
-                             CirctFirtoolFirtoolOptions options) {
+circtFirtoolPopulateLowFIRRTLToHW(MlirPassManager pm,
+                                  CirctFirtoolFirtoolOptions options) {
   return wrap(firtool::populateLowFIRRTLToHW(*unwrap(pm), *unwrap(options)));
 }
 
-MlirLogicalResult firtoolPopulateHWToSV(MlirPassManager pm,
-                                        CirctFirtoolFirtoolOptions options) {
+MlirLogicalResult
+circtFirtoolPopulateHWToSV(MlirPassManager pm,
+                           CirctFirtoolFirtoolOptions options) {
   return wrap(firtool::populateHWToSV(*unwrap(pm), *unwrap(options)));
 }
 
 MlirLogicalResult
-firtoolPopulateExportVerilog(MlirPassManager pm,
-                             CirctFirtoolFirtoolOptions options,
-                             MlirStringCallback callback, void *userData) {
+circtFirtoolPopulateExportVerilog(MlirPassManager pm,
+                                  CirctFirtoolFirtoolOptions options,
+                                  MlirStringCallback callback, void *userData) {
   auto stream =
       std::make_unique<mlir::detail::CallbackOstream>(callback, userData);
   return wrap(firtool::populateExportVerilog(*unwrap(pm), *unwrap(options),
@@ -83,15 +375,15 @@ firtoolPopulateExportVerilog(MlirPassManager pm,
 }
 
 MlirLogicalResult
-firtoolPopulateExportSplitVerilog(MlirPassManager pm,
-                                  CirctFirtoolFirtoolOptions options,
-                                  MlirStringRef directory) {
+circtFirtoolPopulateExportSplitVerilog(MlirPassManager pm,
+                                       CirctFirtoolFirtoolOptions options,
+                                       MlirStringRef directory) {
   return wrap(firtool::populateExportSplitVerilog(*unwrap(pm), *unwrap(options),
                                                   unwrap(directory)));
 }
 
 MlirLogicalResult
-firtoolPopulateFinalizeIR(MlirPassManager pm,
-                          CirctFirtoolFirtoolOptions options) {
+circtFirtoolPopulateFinalizeIR(MlirPassManager pm,
+                               CirctFirtoolFirtoolOptions options) {
   return wrap(firtool::populateFinalizeIR(*unwrap(pm), *unwrap(options)));
 }

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -333,8 +333,10 @@ populatePrepareForExportVerilog(mlir::PassManager &pm,
 LogicalResult
 firtool::populateExportVerilog(mlir::PassManager &pm, const FirtoolOptions &opt,
                                std::unique_ptr<llvm::raw_ostream> os) {
-  pm.addPass(createExportVerilogPass(std::move(os)));
+  if (failed(::detail::populatePrepareForExportVerilog(pm, opt)))
+    return failure();
 
+  pm.addPass(createExportVerilogPass(std::move(os)));
   return success();
 }
 

--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -42,3 +42,17 @@ target_link_libraries(circt-capi-firrtl-test
   CIRCTCAPIFIRRTL
   CIRCTCAPIExportFIRRTL
 )
+
+add_llvm_executable(circt-capi-firtool-test
+  PARTIAL_SOURCES_INTENDED
+  firtool.c
+)
+llvm_update_compile_flags(circt-capi-firtool-test)
+
+target_link_libraries(circt-capi-firtool-test
+  PRIVATE
+
+  MLIRCAPIIR
+  CIRCTCAPIFIRRTL
+  CIRCTCAPIFirtool
+)

--- a/test/CAPI/firtool.c
+++ b/test/CAPI/firtool.c
@@ -1,0 +1,93 @@
+/*===- firtool.c - Simple test of FIRRTL C APIs ---------------------------===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+/* RUN: circt-capi-firtool-test 2>&1 | FileCheck %s
+ */
+
+#include "circt-c/Firtool/Firtool.h"
+#include "circt-c/Dialect/FIRRTL.h"
+#include "mlir-c/BuiltinAttributes.h"
+#include "mlir-c/BuiltinTypes.h"
+#include "mlir-c/IR.h"
+#include "mlir-c/Pass.h"
+#include "mlir-c/Support.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void exportCallback(MlirStringRef message, void *userData) {
+  printf("%.*s", (int)message.length, message.data);
+}
+
+void exportVerilog(MlirContext ctx, bool disableOptimization) {
+  // clang-format off
+  const char *testFIR =
+    "firrtl.circuit \"ExportTestSimpleModule\" {\n"
+    "  firrtl.module @ExportTestSimpleModule(in %in_1: !firrtl.uint<32>,\n"
+    "                                        in %in_2: !firrtl.uint<32>,\n"
+    "                                        out %out: !firrtl.uint<32>) {\n"
+    "    %0 = firrtl.and %in_1, %in_2 : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>\n"
+    "    %1 = firrtl.and %0, %in_2 : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>\n"
+    "    firrtl.connect %out, %1 : !firrtl.uint<32>, !firrtl.uint<32>\n"
+    "  }\n"
+    "}\n";
+  // clang-format on
+  MlirModule module =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(testFIR));
+
+  MlirPassManager pm = mlirPassManagerCreate(ctx);
+
+  CirctFirtoolFirtoolOptions options = circtFirtoolOptionsCreateDefault();
+  circtFirtoolOptionsSetDisableOptimization(options, disableOptimization);
+
+  assert(mlirLogicalResultIsSuccess(
+      circtFirtoolPopulatePreprocessTransforms(pm, options)));
+  assert(mlirLogicalResultIsSuccess(circtFirtoolPopulateCHIRRTLToLowFIRRTL(
+      pm, options, mlirStringRefCreateFromCString("-"))));
+  assert(mlirLogicalResultIsSuccess(
+      circtFirtoolPopulateLowFIRRTLToHW(pm, options)));
+  assert(mlirLogicalResultIsSuccess(circtFirtoolPopulateHWToSV(pm, options)));
+  assert(mlirLogicalResultIsSuccess(
+      circtFirtoolPopulateExportVerilog(pm, options, exportCallback, NULL)));
+  assert(
+      mlirLogicalResultIsSuccess(circtFirtoolPopulateFinalizeIR(pm, options)));
+  assert(mlirLogicalResultIsSuccess(
+      mlirPassManagerRunOnOp(pm, mlirModuleGetOperation(module))));
+}
+
+void testExportVerilog(MlirContext ctx) {
+  exportVerilog(ctx, false);
+
+  // CHECK:      module ExportTestSimpleModule(  // -:2:3
+  // CHECK-NEXT:   input  [31:0] in_1,   // -:2:44
+  // CHECK-NEXT:                 in_2,   // -:3:44
+  // CHECK-NEXT:   output [31:0] out     // -:4:45
+  // CHECK-NEXT: );
+  // CHECK-EMPTY:
+  // CHECK-NEXT:   assign out = in_1 & in_2;     // -:2:3, :6:10
+  // CHECK-NEXT: endmodule
+
+  exportVerilog(ctx, true);
+
+  // CHECK:      module ExportTestSimpleModule(  // -:2:3
+  // CHECK-NEXT:   input  [31:0] in_1,   // -:2:44
+  // CHECK-NEXT:                 in_2,   // -:3:44
+  // CHECK-NEXT:   output [31:0] out     // -:4:45
+  // CHECK-NEXT: );
+  // CHECK-EMPTY:
+  // CHECK-NEXT:   assign out = in_1 & in_2 & in_2;      // -:2:3, :5:10, :6:10
+  // CHECK-NEXT: endmodule
+}
+
+int main(void) {
+  MlirContext ctx = mlirContextCreate();
+  mlirDialectHandleLoadDialect(mlirGetDialectHandle__firrtl__(), ctx);
+  testExportVerilog(ctx);
+  return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ set(CIRCT_TEST_DEPENDS
   circt-capi-ir-test
   circt-capi-om-test
   circt-capi-firrtl-test
+  circt-capi-firtool-test
   circt-as
   circt-dis
   circt-opt

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -57,8 +57,9 @@ tool_dirs = [
 ]
 tools = [
     'arcilator', 'circt-as', 'circt-capi-ir-test', 'circt-capi-om-test',
-    'circt-capi-firrtl-test', 'circt-dis', 'circt-opt', 'circt-reduce',
-    'circt-translate', 'firtool', 'hlstool', 'om-linker', 'ibistool'
+    'circt-capi-firrtl-test', 'circt-capi-firtool-test', 'circt-dis',
+    'circt-opt', 'circt-reduce', 'circt-translate', 'firtool', 'hlstool',
+    'om-linker', 'ibistool'
 ]
 
 # Enable Verilator if it has been detected.


### PR DESCRIPTION
This PR is based on ~PR #6435~ the `main` branch. Appreciate @darthscsi's work on rewriting the part of options for Firtool-bin.

Based on the description in that PR

> Interested parties are encouraged to finish out the set of functions.

So I'm trying to finish the rest work.

I proposed two solutions, but @darthscsi was probably too busy to comment any further on this. So I implemented them both as 2 PRs to further preview how they look and then we can compare and discuss which one is better.

---

This is the first solution, which manually implements the setter functions for all options without using macros. The second solution is #6439.

This PR also added a simple test for Firtool-lib C-API.

---

@darthscsi Would you mind making some constructive comments on this? And I'd love to hear if @mikeurbach and @seldridge have any opinions on this as well. Thanks!