### PR TITLE
[FIRRTL][CAPI] Expose options to parameter list of `populate-` functions

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -12,83 +12,84 @@
 extern "C" {
 #endif
 
-DEFINE_C_API_PTR_METHODS(CirctFirtoolFirtoolOptions,
-                         circt::firtool::FirtoolOptions)
-DEFINE_C_API_STRUCT(FirtoolOptions, void);
+// NOLINTNEXTLINE(modernize-use-using)
+typedef enum CirctFirtoolPreserveAggregateMode {
+  CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_NONE,
+  CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_ONE_DIM_VEC,
+  CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_VEC,
+  CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_ALL,
+} CirctFirtoolPreserveAggregateMode;
 
 // NOLINTNEXTLINE(modernize-use-using)
-typedef enum FirtoolPreserveAggregateMode {
-  FIRTOOL_PRESERVE_AGGREGATE_MODE_NONE,
-  FIRTOOL_PRESERVE_AGGREGATE_MODE_ONE_DIM_VEC,
-  FIRTOOL_PRESERVE_AGGREGATE_MODE_VEC,
-  FIRTOOL_PRESERVE_AGGREGATE_MODE_ALL,
-} FirtoolPreserveAggregateMode;
+typedef enum CirctFirtoolPreserveValuesMode {
+  CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_SRIP,
+  CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_NONE,
+  CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_NAMED,
+  CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_ALL,
+} CirctFirtoolPreserveValuesMode;
 
 // NOLINTNEXTLINE(modernize-use-using)
-typedef enum FirtoolPreserveValuesMode {
-  FIRTOOL_PRESERVE_VALUES_MODE_NONE,
-  FIRTOOL_PRESERVE_VALUES_MODE_NAMED,
-  FIRTOOL_PRESERVE_VALUES_MODE_ALL,
-} FirtoolPreserveValuesMode;
+typedef enum CirctFirtoolCompanionMode {
+  CIRCT_FIRTOOL_COMPANION_MODE_BIND,
+  CIRCT_FIRTOOL_COMPANION_MODE_INSTANTIATE,
+  CIRCT_FIRTOOL_COMPANION_MODE_DROP,
+} CirctFirtoolCompanionMode;
 
 // NOLINTNEXTLINE(modernize-use-using)
-typedef enum FirtoolCompanionMode {
-  FIRTOOL_COMPANION_MODE_BIND,
-  FIRTOOL_COMPANION_MODE_INSTANTIATE,
-  FIRTOOL_COMPANION_MODE_DROP,
-} FirtoolCompanionMode;
-
-// NOLINTNEXTLINE(modernize-use-using)
-typedef enum FirtoolBuildMode {
-  FIRTOOL_BUILD_MODE_DEBUG,
-  FIRTOOL_BUILD_MODE_RELEASE,
-} FirtoolBuildMode;
-
-// NOLINTNEXTLINE(modernize-use-using)
-typedef enum FirtoolRandomKind {
-  FIRTOOL_RANDOM_KIND_NONE,
-  FIRTOOL_RANDOM_KIND_MEM,
-  FIRTOOL_RANDOM_KIND_REG,
-  FIRTOOL_RANDOM_KIND_ALL,
-} FirtoolRandomKind;
-
-MLIR_CAPI_EXPORTED CirctFirtoolFirtoolOptions
-circtFirtoolOptionsCreateDefault();
-MLIR_CAPI_EXPORTED void
-circtFirtoolOptionsDestroy(CirctFirtoolFirtoolOptions options);
-
-MLIR_CAPI_EXPORTED void
-circtFirtoolOptionsSetOutputFilename(CirctFirtoolOptions options,
-                                     MlirStringRef filename);
-MLIR_CAPI_EXPORTED void
-circtFirtoolOptionsDisableUnknownAnnotations(CirctFirtoolOptions options,
-                                             bool disable);
+typedef enum CirctFirtoolRandomKind {
+  CIRCT_FIRTOOL_RANDOM_KIND_NONE,
+  CIRCT_FIRTOOL_RANDOM_KIND_MEM,
+  CIRCT_FIRTOOL_RANDOM_KIND_REG,
+  CIRCT_FIRTOOL_RANDOM_KIND_ALL,
+} CirctFirtoolRandomKind;
 
 //===----------------------------------------------------------------------===//
 // Populate API.
 //===----------------------------------------------------------------------===//
 
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulatePreprocessTransforms(
+    MlirPassManager pm, bool disableAnnotationsUnknown,
+    bool disableAnnotationsClassless, bool lowerAnnotationsNoRefTypePorts,
+    bool enableDebugInfo);
+
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulateCHIRRTLToLowFIRRTL(
+    MlirPassManager pm, bool disableOptimization,
+    CirctFirtoolPreserveValuesMode preserveValues,
+    CirctFirtoolPreserveAggregateMode preserveAggregate, bool replSeqMem,
+    MlirStringRef replSeqMemFile, bool ignoreReadEnableMem,
+    bool exportChiselInterface, MlirStringRef chiselInterfaceOutDirectory,
+    bool disableHoistingHWPassthrough, bool noDedup, bool vbToBV,
+    bool lowerMemories, CirctFirtoolRandomKind disableRandom,
+    CirctFirtoolCompanionMode companionMode, MlirStringRef blackBoxRoot,
+    bool emitOMIR, MlirStringRef omirOutFile,
+    bool disableAggressiveMergeConnections);
+
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulateLowFIRRTLToHW(
+    MlirPassManager pm, bool disableOptimization,
+    MlirStringRef outputAnnotationFilename, bool enableAnnotationWarning,
+    bool emitChiselAssertsAsSVA);
+
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulateHWToSV(
+    MlirPassManager pm, bool disableOptimization, bool extractTestCode,
+    bool etcDisableInstanceExtraction, bool etcDisableRegisterExtraction,
+    bool etcDisableModuleInlining, MlirStringRef ckgModuleName,
+    MlirStringRef ckgInputName, MlirStringRef ckgOutputName,
+    MlirStringRef ckgEnableName, MlirStringRef ckgTestEnableName,
+    MlirStringRef ckgInstName, CirctFirtoolRandomKind disableRandom,
+    bool emitSeparateAlwaysBlocks, bool replSeqMem, bool ignoreReadEnableMem,
+    bool addMuxPragmas, bool addVivadoRAMAddressConflictSynthesisBugWorkaround);
+
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulateExportVerilog(
+    MlirPassManager pm, bool disableOptimization, bool stripFirDebugInfo,
+    bool stripDebugInfo, bool exportModuleHierarchy,
+    MlirStringCallback callback, void *userData);
+
+MLIR_CAPI_EXPORTED MlirLogicalResult circtFirtoolPopulateExportSplitVerilog(
+    MlirPassManager pm, bool disableOptimization, bool stripFirDebugInfo,
+    bool stripDebugInfo, bool exportModuleHierarchy, MlirStringRef directory);
+
 MLIR_CAPI_EXPORTED MlirLogicalResult
-firtoolPopulatePreprocessTransforms(MlirPassManager pm, FirtoolOptions options);
-
-MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulateCHIRRTLToLowFIRRTL(
-    MlirPassManager pm, FirtoolOptions options, MlirStringRef inputFilename);
-
-MLIR_CAPI_EXPORTED MlirLogicalResult
-firtoolPopulateLowFIRRTLToHW(MlirPassManager pm, FirtoolOptions options);
-
-MLIR_CAPI_EXPORTED MlirLogicalResult
-firtoolPopulateHWToSV(MlirPassManager pm, FirtoolOptions options);
-
-MLIR_CAPI_EXPORTED MlirLogicalResult
-firtoolPopulateExportVerilog(MlirPassManager pm, FirtoolOptions options,
-                             MlirStringCallback callback, void *userData);
-
-MLIR_CAPI_EXPORTED MlirLogicalResult firtoolPopulateExportSplitVerilog(
-    MlirPassManager pm, FirtoolOptions options, MlirStringRef directory);
-
-MLIR_CAPI_EXPORTED MlirLogicalResult
-firtoolPopulateFinalizeIR(MlirPassManager pm, FirtoolOptions options);
+circtFirtoolPopulateFinalizeIR(MlirPassManager pm);
 
 #ifdef __cplusplus
 }

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -17,73 +17,185 @@
 using namespace circt;
 
 //===----------------------------------------------------------------------===//
-// Option API.
-//===----------------------------------------------------------------------===//
-
-FirtoolOptions circtFirtoolOptionsCreateDefault() {
-  auto *options = new firtool::FirtoolOptions();
-  return wrap(options);
-}
-
-void circtFirtoolOptionsDestroy(CirctFirtoolOptions options) {
-  delete unwrap(options);
-}
-
-void circtFirtoolOptionsSetOutputFilename(CirctFirtoolOptions options,
-                                          MlirStringRef filename) {
-  unwrap(options)->setOutputFilename(name);
-}
-
-void circtFirtoolOptionsDisableUnknownAnnotations(CirctFirtoolOptions options,
-                                                  bool disable) {
-  unwrap(options)->setDisableUnknownAnnotations(disable);
-}
-
-//===----------------------------------------------------------------------===//
 // Populate API.
 //===----------------------------------------------------------------------===//
 
-MlirLogicalResult firtoolPopulatePreprocessTransforms(MlirPassManager pm,
-                                                      FirtoolOptions options) {
-  return wrap(
-      firtool::populatePreprocessTransforms(*unwrap(pm), *unwrap(options)));
+MlirLogicalResult circtFirtoolPopulatePreprocessTransforms(
+    MlirPassManager pm, bool disableAnnotationsUnknown,
+    bool disableAnnotationsClassless, bool lowerAnnotationsNoRefTypePorts,
+    bool enableDebugInfo) {
+  return wrap(firtool::populatePreprocessTransforms(
+      *unwrap(pm), disableAnnotationsUnknown, disableAnnotationsClassless,
+      lowerAnnotationsNoRefTypePorts, enableDebugInfo));
+}
+
+MlirLogicalResult circtFirtoolPopulateCHIRRTLToLowFIRRTL(
+    MlirPassManager pm, bool disableOptimization,
+    CirctFirtoolPreserveValuesMode preserveValues,
+    CirctFirtoolPreserveAggregateMode preserveAggregate, bool replSeqMem,
+    MlirStringRef replSeqMemFile, bool ignoreReadEnableMem,
+    bool exportChiselInterface, MlirStringRef chiselInterfaceOutDirectory,
+    bool disableHoistingHWPassthrough, bool noDedup, bool vbToBV,
+    bool lowerMemories, CirctFirtoolRandomKind disableRandom,
+    CirctFirtoolCompanionMode companionMode, MlirStringRef blackBoxRoot,
+    bool emitOMIR, MlirStringRef omirOutFile,
+    bool disableAggressiveMergeConnections) {
+
+  firrtl::PreserveValues::PreserveMode preserveValuesMode;
+
+  switch (preserveValues) {
+  case CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_SRIP:
+    preserveValuesMode = firrtl::PreserveValues::PreserveMode::Strip;
+    break;
+  case CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_NONE:
+    preserveValuesMode = firrtl::PreserveValues::PreserveMode::Strip;
+    break;
+  case CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_NAMED:
+    preserveValuesMode = firrtl::PreserveValues::PreserveMode::Named;
+    break;
+  case CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_ALL:
+    preserveValuesMode = firrtl::PreserveValues::PreserveMode::All;
+    break;
+  default:
+    llvm_unreachable("unknown preserve values mode");
+  }
+
+  firrtl::PreserveAggregate::PreserveMode preserveAggregateMode;
+
+  switch (preserveAggregate) {
+  case CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_NONE:
+    preserveAggregateMode = firrtl::PreserveAggregate::PreserveMode::None;
+    break;
+  case CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_ONE_DIM_VEC:
+    preserveAggregateMode = firrtl::PreserveAggregate::PreserveMode::OneDimVec;
+    break;
+  case CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_VEC:
+    preserveAggregateMode = firrtl::PreserveAggregate::PreserveMode::Vec;
+    break;
+  case CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_ALL:
+    preserveAggregateMode = firrtl::PreserveAggregate::PreserveMode::All;
+    break;
+  default:
+    llvm_unreachable("unknown preserve aggregate mode");
+  }
+
+  firtool::FirtoolOptions::RandomKind disableRandomKind;
+
+  switch (disableRandom) {
+  case CIRCT_FIRTOOL_RANDOM_KIND_NONE:
+    disableRandomKind = firtool::FirtoolOptions::RandomKind::None;
+    break;
+  case CIRCT_FIRTOOL_RANDOM_KIND_MEM:
+    disableRandomKind = firtool::FirtoolOptions::RandomKind::Mem;
+    break;
+  case CIRCT_FIRTOOL_RANDOM_KIND_REG:
+    disableRandomKind = firtool::FirtoolOptions::RandomKind::Reg;
+    break;
+  case CIRCT_FIRTOOL_RANDOM_KIND_ALL:
+    disableRandomKind = firtool::FirtoolOptions::RandomKind::All;
+    break;
+  default:
+    llvm_unreachable("unknown random kind");
+  }
+
+  firrtl::CompanionMode companionModeValue;
+
+  switch (companionMode) {
+  case CIRCT_FIRTOOL_COMPANION_MODE_BIND:
+    companionModeValue = firrtl::CompanionMode::Bind;
+    break;
+  case CIRCT_FIRTOOL_COMPANION_MODE_INSTANTIATE:
+    companionModeValue = firrtl::CompanionMode::Instantiate;
+    break;
+  case CIRCT_FIRTOOL_COMPANION_MODE_DROP:
+    companionModeValue = firrtl::CompanionMode::Drop;
+    break;
+  default:
+    llvm_unreachable("unknown companion mode");
+  }
+
+  return wrap(firtool::populateCHIRRTLToLowFIRRTL(
+      *unwrap(pm), disableOptimization, preserveValuesMode,
+      preserveAggregateMode, replSeqMem, unwrap(replSeqMemFile),
+      ignoreReadEnableMem, exportChiselInterface,
+      unwrap(chiselInterfaceOutDirectory), disableHoistingHWPassthrough,
+      noDedup, vbToBV, lowerMemories, disableRandomKind, companionModeValue,
+      unwrap(blackBoxRoot), emitOMIR, unwrap(omirOutFile),
+      disableAggressiveMergeConnections));
 }
 
 MlirLogicalResult
-firtoolPopulateCHIRRTLToLowFIRRTL(MlirPassManager pm, FirtoolOptions options,
-                                  MlirStringRef inputFilename) {
-  return wrap(firtool::populateCHIRRTLToLowFIRRTL(*unwrap(pm), *unwrap(options),
-                                                  unwrap(inputFilename)));
+circtFirtoolPopulateLowFIRRTLToHW(MlirPassManager pm, bool disableOptimization,
+                                  MlirStringRef outputAnnotationFilename,
+                                  bool enableAnnotationWarning,
+                                  bool emitChiselAssertsAsSVA) {
+  return wrap(firtool::populateLowFIRRTLToHW(
+      *unwrap(pm), disableOptimization, unwrap(outputAnnotationFilename),
+      enableAnnotationWarning, emitChiselAssertsAsSVA));
 }
 
-MlirLogicalResult firtoolPopulateLowFIRRTLToHW(MlirPassManager pm,
-                                               FirtoolOptions options) {
-  return wrap(firtool::populateLowFIRRTLToHW(*unwrap(pm), *unwrap(options)));
+MlirLogicalResult circtFirtoolPopulateHWToSV(
+    MlirPassManager pm, bool disableOptimization, bool extractTestCode,
+    bool etcDisableInstanceExtraction, bool etcDisableRegisterExtraction,
+    bool etcDisableModuleInlining, MlirStringRef ckgModuleName,
+    MlirStringRef ckgInputName, MlirStringRef ckgOutputName,
+    MlirStringRef ckgEnableName, MlirStringRef ckgTestEnableName,
+    MlirStringRef ckgInstName, CirctFirtoolRandomKind disableRandom,
+    bool emitSeparateAlwaysBlocks, bool replSeqMem, bool ignoreReadEnableMem,
+    bool addMuxPragmas,
+    bool addVivadoRAMAddressConflictSynthesisBugWorkaround) {
+
+  firtool::FirtoolOptions::RandomKind disableRandomKind;
+
+  switch (disableRandom) {
+  case CIRCT_FIRTOOL_RANDOM_KIND_NONE:
+    disableRandomKind = firtool::FirtoolOptions::RandomKind::None;
+    break;
+  case CIRCT_FIRTOOL_RANDOM_KIND_MEM:
+    disableRandomKind = firtool::FirtoolOptions::RandomKind::Mem;
+    break;
+  case CIRCT_FIRTOOL_RANDOM_KIND_REG:
+    disableRandomKind = firtool::FirtoolOptions::RandomKind::Reg;
+    break;
+  case CIRCT_FIRTOOL_RANDOM_KIND_ALL:
+    disableRandomKind = firtool::FirtoolOptions::RandomKind::All;
+    break;
+  default:
+    llvm_unreachable("unknown random kind");
+  }
+
+  return wrap(firtool::populateHWToSV(
+      *unwrap(pm), disableOptimization, extractTestCode,
+      etcDisableInstanceExtraction, etcDisableRegisterExtraction,
+      etcDisableModuleInlining,
+      {unwrap(ckgModuleName).str(), unwrap(ckgInputName).str(),
+       unwrap(ckgOutputName).str(), unwrap(ckgEnableName).str(),
+       unwrap(ckgTestEnableName).str(), unwrap(ckgInstName).str()},
+      disableRandomKind, emitSeparateAlwaysBlocks, replSeqMem,
+      ignoreReadEnableMem, addMuxPragmas,
+      addVivadoRAMAddressConflictSynthesisBugWorkaround));
 }
 
-MlirLogicalResult firtoolPopulateHWToSV(MlirPassManager pm,
-                                        FirtoolOptions options) {
-  return wrap(firtool::populateHWToSV(*unwrap(pm), *unwrap(options)));
-}
-
-MlirLogicalResult firtoolPopulateExportVerilog(MlirPassManager pm,
-                                               FirtoolOptions options,
-                                               MlirStringCallback callback,
-                                               void *userData) {
+MlirLogicalResult
+circtFirtoolPopulateExportVerilog(MlirPassManager pm, bool disableOptimization,
+                                  bool stripFirDebugInfo, bool stripDebugInfo,
+                                  bool exportModuleHierarchy,
+                                  MlirStringCallback callback, void *userData) {
   auto stream =
       std::make_unique<mlir::detail::CallbackOstream>(callback, userData);
-  return wrap(firtool::populateExportVerilog(*unwrap(pm), *unwrap(options),
-                                             std::move(stream)));
+  return wrap(firtool::populateExportVerilog(
+      *unwrap(pm), disableOptimization, stripFirDebugInfo, stripDebugInfo,
+      exportModuleHierarchy, std::move(stream)));
 }
 
-MlirLogicalResult firtoolPopulateExportSplitVerilog(MlirPassManager pm,
-                                                    FirtoolOptions options,
-                                                    MlirStringRef directory) {
-  return wrap(firtool::populateExportSplitVerilog(*unwrap(pm), *unwrap(options),
-                                                  unwrap(directory)));
+MlirLogicalResult circtFirtoolPopulateExportSplitVerilog(
+    MlirPassManager pm, bool disableOptimization, bool stripFirDebugInfo,
+    bool stripDebugInfo, bool exportModuleHierarchy, MlirStringRef directory) {
+  return wrap(firtool::populateExportSplitVerilog(
+      *unwrap(pm), disableOptimization, stripFirDebugInfo, stripDebugInfo,
+      exportModuleHierarchy, unwrap(directory)));
 }
 
-MlirLogicalResult firtoolPopulateFinalizeIR(MlirPassManager pm,
-                                            FirtoolOptions options) {
-  return wrap(firtool::populateFinalizeIR(*unwrap(pm), *unwrap(options)));
+MlirLogicalResult circtFirtoolPopulateFinalizeIR(MlirPassManager pm) {
+  return wrap(firtool::populateFinalizeIR(*unwrap(pm)));
 }

--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -42,3 +42,17 @@ target_link_libraries(circt-capi-firrtl-test
   CIRCTCAPIFIRRTL
   CIRCTCAPIExportFIRRTL
 )
+
+add_llvm_executable(circt-capi-firtool-test
+  PARTIAL_SOURCES_INTENDED
+  firtool.c
+)
+llvm_update_compile_flags(circt-capi-firtool-test)
+
+target_link_libraries(circt-capi-firtool-test
+  PRIVATE
+
+  MLIRCAPIIR
+  CIRCTCAPIFIRRTL
+  CIRCTCAPIFirtool
+)

--- a/test/CAPI/firtool.c
+++ b/test/CAPI/firtool.c
@@ -1,0 +1,133 @@
+/*===- firtool.c - Simple test of FIRRTL C APIs ---------------------------===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+/* RUN: circt-capi-firtool-test 2>&1 | FileCheck %s
+ */
+
+#include "circt-c/Firtool/Firtool.h"
+#include "circt-c/Dialect/FIRRTL.h"
+#include "mlir-c/BuiltinAttributes.h"
+#include "mlir-c/BuiltinTypes.h"
+#include "mlir-c/IR.h"
+#include "mlir-c/Pass.h"
+#include "mlir-c/Support.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void exportCallback(MlirStringRef message, void *userData) {
+  printf("%.*s", (int)message.length, message.data);
+}
+
+void exportVerilog(MlirContext ctx, bool disableOptimization) {
+  // clang-format off
+  const char *testFIR =
+    "firrtl.circuit \"ExportTestSimpleModule\" {\n"
+    "  firrtl.module @ExportTestSimpleModule(in %in_1: !firrtl.uint<32>,\n"
+    "                                        in %in_2: !firrtl.uint<32>,\n"
+    "                                        out %out: !firrtl.uint<32>) {\n"
+    "    %0 = firrtl.and %in_1, %in_2 : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>\n"
+    "    %1 = firrtl.and %0, %in_2 : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>\n"
+    "    firrtl.connect %out, %1 : !firrtl.uint<32>, !firrtl.uint<32>\n"
+    "  }\n"
+    "}\n";
+  // clang-format on
+  MlirModule module =
+      mlirModuleCreateParse(ctx, mlirStringRefCreateFromCString(testFIR));
+
+  MlirPassManager pm = mlirPassManagerCreate(ctx);
+
+  assert(mlirLogicalResultIsSuccess(circtFirtoolPopulatePreprocessTransforms(
+      pm,
+      /* disableAnnotationsUnknown */ false,
+      /* disableAnnotationsClassless */ false,
+      /* lowerAnnotationsNoRefTypePorts */ false,
+      /* enableDebugInfo */ false)));
+  assert(mlirLogicalResultIsSuccess(circtFirtoolPopulateCHIRRTLToLowFIRRTL(
+      pm, disableOptimization,
+      /* preserveValues */ CIRCT_FIRTOOL_PRESERVE_VALUES_MODE_NONE,
+      /* preserveAggregate */ CIRCT_FIRTOOL_PRESERVE_AGGREGATE_MODE_NONE,
+      /* replSeqMem */ false,
+      /* replSeqMemFile */ mlirStringRefCreateFromCString(""),
+      /* ignoreReadEnableMem */ false,
+      /* exportChiselInterface */ false,
+      /* chiselInterfaceOutDirectory */ mlirStringRefCreateFromCString(""),
+      /* disableHoistingHWPassthrough */ true,
+      /* noDedup */ false,
+      /* vbToBV */ false,
+      /* lowerMemories */ false,
+      /* disableRandom */ CIRCT_FIRTOOL_RANDOM_KIND_NONE,
+      /* companionMode */ CIRCT_FIRTOOL_COMPANION_MODE_BIND,
+      /* blackBoxRoot */ mlirStringRefCreateFromCString("-"),
+      /* emitOMIR */ true,
+      /* omirOutFile */ mlirStringRefCreateFromCString("-"),
+      /* disableAggressiveMergeConnections */ false)));
+  assert(mlirLogicalResultIsSuccess(circtFirtoolPopulateLowFIRRTLToHW(
+      pm, disableOptimization,
+      /* outputAnnotationFilename */ mlirStringRefCreateFromCString(""),
+      /* enableAnnotationWarning */ false,
+      /* emitChiselAssertsAsSVA */ false)));
+  assert(mlirLogicalResultIsSuccess(circtFirtoolPopulateHWToSV(
+      pm, disableOptimization,
+      /* extractTestCode */ false,
+      /* etcDisableInstanceExtraction */ false,
+      /* etcDisableRegisterExtraction */ false,
+      /* etcDisableModuleInlining */ false,
+      /* ckgModuleName */ mlirStringRefCreateFromCString("EICG_wrapper"),
+      /* ckgInputName */ mlirStringRefCreateFromCString("in"),
+      /* ckgOutputName */ mlirStringRefCreateFromCString("out"),
+      /* ckgEnableName */ mlirStringRefCreateFromCString("en"),
+      /* ckgTestEnableName */ mlirStringRefCreateFromCString("test_en"),
+      /* ckgInstName */ mlirStringRefCreateFromCString("ckg"),
+      /* disableRandom */ CIRCT_FIRTOOL_RANDOM_KIND_NONE,
+      /* emitSeparateAlwaysBlocks */ false,
+      /* replSeqMem */ false,
+      /* ignoreReadEnableMem */ false,
+      /* addMuxPragmas */ false,
+      /* addVivadoRAMAddressConflictSynthesisBugWorkaround */ false)));
+  assert(mlirLogicalResultIsSuccess(circtFirtoolPopulateExportVerilog(
+      pm, disableOptimization,
+      /* stripFirDebugInfo */ true,
+      /* stripDebugInfo */ false,
+      /* exportModuleHierarchy */ false, exportCallback, NULL)));
+  assert(mlirLogicalResultIsSuccess(circtFirtoolPopulateFinalizeIR(pm)));
+  assert(mlirLogicalResultIsSuccess(
+      mlirPassManagerRunOnOp(pm, mlirModuleGetOperation(module))));
+}
+
+void testExportVerilog(MlirContext ctx) {
+  exportVerilog(ctx, false);
+
+  // CHECK:      module ExportTestSimpleModule(  // -:2:3
+  // CHECK-NEXT:   input  [31:0] in_1,   // -:2:44
+  // CHECK-NEXT:                 in_2,   // -:3:44
+  // CHECK-NEXT:   output [31:0] out     // -:4:45
+  // CHECK-NEXT: );
+  // CHECK-EMPTY:
+  // CHECK-NEXT:   assign out = in_1 & in_2;     // -:2:3, :6:10
+  // CHECK-NEXT: endmodule
+
+  exportVerilog(ctx, true);
+
+  // CHECK:      module ExportTestSimpleModule(  // -:2:3
+  // CHECK-NEXT:   input  [31:0] in_1,   // -:2:44
+  // CHECK-NEXT:                 in_2,   // -:3:44
+  // CHECK-NEXT:   output [31:0] out     // -:4:45
+  // CHECK-NEXT: );
+  // CHECK-EMPTY:
+  // CHECK-NEXT:   assign out = in_1 & in_2 & in_2;      // -:2:3, :5:10, :6:10
+  // CHECK-NEXT: endmodule
+}
+
+int main(void) {
+  MlirContext ctx = mlirContextCreate();
+  mlirDialectHandleLoadDialect(mlirGetDialectHandle__firrtl__(), ctx);
+  testExportVerilog(ctx);
+  return 0;
+}

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -57,8 +57,9 @@ tool_dirs = [
 ]
 tools = [
     'arcilator', 'circt-as', 'circt-capi-ir-test', 'circt-capi-om-test',
-    'circt-capi-firrtl-test', 'circt-dis', 'circt-opt', 'circt-reduce',
-    'circt-translate', 'firtool', 'hlstool', 'om-linker', 'ibistool'
+    'circt-capi-firrtl-test', 'circt-capi-firtool-test', 'circt-dis',
+    'circt-opt', 'circt-reduce', 'circt-translate', 'firtool', 'hlstool',
+    'om-linker', 'ibistool'
 ]
 
 # Enable Verilator if it has been detected.


### PR DESCRIPTION
This PR is based on PR #6435. Appreciate @darthscsi's work on rewriting the part of options for Firtool-bin.

Based on the description in that PR

> Interested parties are encouraged to finish out the set of functions.

So I'm trying to finish the rest work.

I proposed two solutions, but @darthscsi was probably too busy to comment any further on this. So I implemented them both as 2 PRs to further preview how they look and then we can compare and discuss which one is better.

---

This is the second solution. It exposes the options needed by `populate-` functions to their parameter list, which eliminates the need for C-API to touch any options structs and setter functions. The first solution is #6438.

This PR also added a simple test for Firtool-lib C-API.

---

@darthscsi Would you mind making some constructive comments on this? And I'd love to hear if @mikeurbach and @seldridge have any opinions on this as well. Thanks!