### PR TITLE
[HW][FlattenIO] Fix extern module instances

### DIFF
--- a/include/circt/Dialect/HW/HWPasses.h
+++ b/include/circt/Dialect/HW/HWPasses.h
@@ -24,7 +24,8 @@ namespace hw {
 std::unique_ptr<mlir::Pass> createPrintInstanceGraphPass();
 std::unique_ptr<mlir::Pass> createHWSpecializePass();
 std::unique_ptr<mlir::Pass> createPrintHWModuleGraphPass();
-std::unique_ptr<mlir::Pass> createFlattenIOPass();
+std::unique_ptr<mlir::Pass> createFlattenIOPass(bool recursiveFlag = true,
+                                                bool flattenExternFlag = false);
 std::unique_ptr<mlir::Pass> createVerifyInnerRefNamespacePass();
 
 /// Generate the code for registering passes.

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -35,8 +35,10 @@ def FlattenIO : Pass<"hw-flatten-io", "mlir::ModuleOp"> {
   let constructor =  "circt::hw::createFlattenIOPass()";
   
   let options = [
-    Option<"recursive", "recursive", "bool", "false",
+    Option<"recursive", "recursive", "bool", "true",
       "Recursively flatten nested structs.">,
+    Option<"flattenExtern", "flatten-extern", "bool", "false",
+      "Flatten the extern modules also.">,
   ];
 }
 

--- a/test/Dialect/HW/flatten-io.mlir
+++ b/test/Dialect/HW/flatten-io.mlir
@@ -1,77 +1,79 @@
-// RUN: circt-opt --hw-flatten-io="recursive=true" %s | FileCheck %s
+// RUN: circt-opt --hw-flatten-io %s | FileCheck %s -check-prefix BASIC
+// RUN: circt-opt --hw-flatten-io="flatten-extern=true" %s | FileCheck %s -check-prefix EXTERN
 
 // Ensure that non-struct-using modules pass cleanly through the pass.
 
-// CHECK-LABEL: hw.module @level0(in %arg0 : i32, out out0 : i32) {
-// CHECK-NEXT:    hw.output %arg0 : i32
-// CHECK-NEXT:  }
+// BASIC-LABEL: hw.module @level0(in %arg0 : i32, out out0 : i32) {
+// BASIC-NEXT:    hw.output %arg0 : i32
+// BASIC-NEXT:  }
 hw.module @level0(in %arg0 : i32, out out0 : i32) {
     hw.output %arg0: i32
 }
 
-// CHECK-LABEL: hw.module @level1(in %arg0 : i32, in %in.a : i1, in %in.b : i2, in %arg1 : i32, out out0 : i32, out out.a : i1, out out.b : i2, out out1 : i32) {
-// CHECK-NEXT:    %0 = hw.struct_create (%in.a, %in.b) : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:    %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:    hw.output %arg0, %a, %b, %arg1 : i32, i1, i2, i32
-// CHECK-NEXT:  }
+// BASIC-LABEL: hw.module @level1(in %arg0 : i32, in %in.a : i1, in %in.b : i2, in %arg1 : i32, out out0 : i32, out out.a : i1, out out.b : i2, out out1 : i32) {
+// BASIC-NEXT:    %0 = hw.struct_create (%in.a, %in.b) : !hw.struct<a: i1, b: i2>
+// BASIC-NEXT:    %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
+// BASIC-NEXT:    hw.output %arg0, %a, %b, %arg1 : i32, i1, i2, i32
+// BASIC-NEXT:  }
 !Struct1 = !hw.struct<a: i1, b: i2>
 hw.module @level1(in %arg0 : i32, in %in : !Struct1, in %arg1: i32, out out0 : i32, out out: !Struct1, out out1: i32) {
     hw.output %arg0, %in, %arg1 : i32, !Struct1, i32
 }
 
-// CHECK-LABEL: hw.module @level2(in %in.aa.a : i1, in %in.aa.b : i2, in %in.bb.a : i1, in %in.bb.b : i2, out out.aa.a : i1, out out.aa.b : i2, out out.bb.a : i1, out out.bb.b : i2) {
-// CHECK-NEXT:    %0 = hw.struct_create (%in.aa.a, %in.aa.b) : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:    %1 = hw.struct_create (%in.bb.a, %in.bb.b) : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:    %2 = hw.struct_create (%0, %1) : !hw.struct<aa: !hw.struct<a: i1, b: i2>, bb: !hw.struct<a: i1, b: i2>>
-// CHECK-NEXT:    %aa, %bb = hw.struct_explode %2 : !hw.struct<aa: !hw.struct<a: i1, b: i2>, bb: !hw.struct<a: i1, b: i2>>
-// CHECK-NEXT:    %a, %b = hw.struct_explode %aa : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:    %a_0, %b_1 = hw.struct_explode %bb : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:    hw.output %a, %b, %a_0, %b_1 : i1, i2, i1, i2
-// CHECK-NEXT:  }
+// BASIC-LABEL: hw.module @level2(in %in.aa.a : i1, in %in.aa.b : i2, in %in.bb.a : i1, in %in.bb.b : i2, out out.aa.a : i1, out out.aa.b : i2, out out.bb.a : i1, out out.bb.b : i2) {
+// BASIC-NEXT:    %0 = hw.struct_create (%in.aa.a, %in.aa.b) : !hw.struct<a: i1, b: i2>
+// BASIC-NEXT:    %1 = hw.struct_create (%in.bb.a, %in.bb.b) : !hw.struct<a: i1, b: i2>
+// BASIC-NEXT:    %2 = hw.struct_create (%0, %1) : !hw.struct<aa: !hw.struct<a: i1, b: i2>, bb: !hw.struct<a: i1, b: i2>>
+// BASIC-NEXT:    %aa, %bb = hw.struct_explode %2 : !hw.struct<aa: !hw.struct<a: i1, b: i2>, bb: !hw.struct<a: i1, b: i2>>
+// BASIC-NEXT:    %a, %b = hw.struct_explode %aa : !hw.struct<a: i1, b: i2>
+// BASIC-NEXT:    %a_0, %b_1 = hw.struct_explode %bb : !hw.struct<a: i1, b: i2>
+// BASIC-NEXT:    hw.output %a, %b, %a_0, %b_1 : i1, i2, i1, i2
+// BASIC-NEXT:  }
 !Struct2 = !hw.struct<aa: !Struct1, bb: !Struct1>
 hw.module @level2(in %in : !Struct2, out out: !Struct2) {
     hw.output %in : !Struct2
 }
-
-// CHECK-LABEL: hw.module.extern @level1_extern(in %arg0 : i32, in %in.a : i1, in %in.b : i2, in %arg1 : i32, out out0 : i32, out out.a : i1, out out.b : i2, out out1 : i32)
-hw.module.extern @level1_extern(in %arg0 : i32, in %in : !Struct1, in %arg1: i32, out out0 : i32, out out: !Struct1, out out1: i32)
-
 
 hw.type_scope @foo {
   hw.typedecl @bar : !Struct1
 }
 !ScopedStruct = !hw.typealias<@foo::@bar,!Struct1>
 
-// CHECK-LABEL: hw.module @scoped(in %arg0 : i32, in %in.a : i1, in %in.b : i2, in %arg1 : i32, out out0 : i32, out out.a : i1, out out.b : i2, out out1 : i32) {
-// CHECK-NEXT:    %0 = hw.struct_create (%in.a, %in.b) : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:    %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:    hw.output %arg0, %a, %b, %arg1 : i32, i1, i2, i32
-// CHECK-NEXT:  }
+// BASIC-LABEL: hw.module @scoped(in %arg0 : i32, in %in.a : i1, in %in.b : i2, in %arg1 : i32, out out0 : i32, out out.a : i1, out out.b : i2, out out1 : i32) {
+// BASIC-NEXT:    %0 = hw.struct_create (%in.a, %in.b) : !hw.struct<a: i1, b: i2>
+// BASIC-NEXT:    %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
+// BASIC-NEXT:    hw.output %arg0, %a, %b, %arg1 : i32, i1, i2, i32
+// BASIC-NEXT:  }
 hw.module @scoped(in %arg0 : i32, in %in : !ScopedStruct, in %arg1: i32, out out0 : i32, out out: !ScopedStruct, out out1: i32) {
   hw.output %arg0, %in, %arg1 : i32, !ScopedStruct, i32
 }
 
-// CHECK-LABEL: hw.module @instance(in %arg0 : i32, in %arg1.a : i1, in %arg1.b : i2, out out.a : i1, out out.b : i2) {
-// CHECK-NEXT:   %0 = hw.struct_create (%arg1.a, %arg1.b) : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:   %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:   %l1.out0, %l1.out.a, %l1.out.b, %l1.out1 = hw.instance "l1" @level1(arg0: %arg0: i32, in.a: %a: i1, in.b: %b: i2, arg1: %arg0: i32) -> (out0: i32, out.a: i1, out.b: i2, out1: i32)
-// CHECK-NEXT:   %1 = hw.struct_create (%l1.out.a, %l1.out.b) : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:   %a_0, %b_1 = hw.struct_explode %1 : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:   hw.output %a_0, %b_1 : i1, i2
-// CHECK-NEXT: }
+// BASIC-LABEL: hw.module @instance(in %arg0 : i32, in %arg1.a : i1, in %arg1.b : i2, out out.a : i1, out out.b : i2) {
+// BASIC-NEXT:   %0 = hw.struct_create (%arg1.a, %arg1.b) : !hw.struct<a: i1, b: i2>
+// BASIC-NEXT:   %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
+// BASIC-NEXT:   %l1.out0, %l1.out.a, %l1.out.b, %l1.out1 = hw.instance "l1" @level1(arg0: %arg0: i32, in.a: %a: i1, in.b: %b: i2, arg1: %arg0: i32) -> (out0: i32, out.a: i1, out.b: i2, out1: i32)
+// BASIC-NEXT:   %1 = hw.struct_create (%l1.out.a, %l1.out.b) : !hw.struct<a: i1, b: i2>
+// BASIC-NEXT:   %a_0, %b_1 = hw.struct_explode %1 : !hw.struct<a: i1, b: i2>
+// BASIC-NEXT:   hw.output %a_0, %b_1 : i1, i2
+// BASIC-NEXT: }
 hw.module @instance(in %arg0 : i32, in %arg1 : !Struct1, out out : !Struct1) {
   %0:3 = hw.instance "l1" @level1(arg0: %arg0 : i32, in: %arg1 : !Struct1, arg1: %arg0 : i32) -> (out0: i32, out: !Struct1, out1: i32)
   hw.output %0#1 : !Struct1
 }
 
-// CHECK-LABEL: hw.module @instance_extern(in %arg0 : i32, in %arg1.a : i1, in %arg1.b : i2, out out.a : i1, out out.b : i2) {
-// CHECK-NEXT:   %0 = hw.struct_create (%arg1.a, %arg1.b) : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:   %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:   %l1.out0, %l1.out.a, %l1.out.b, %l1.out1 = hw.instance "l1" @level1_extern(arg0: %arg0: i32, in.a: %a: i1, in.b: %b: i2, arg1: %arg0: i32) -> (out0: i32, out.a: i1, out.b: i2, out1: i32)
-// CHECK-NEXT:   %1 = hw.struct_create (%l1.out.a, %l1.out.b) : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:   %a_0, %b_1 = hw.struct_explode %1 : !hw.struct<a: i1, b: i2>
-// CHECK-NEXT:   hw.output %a_0, %b_1 : i1, i2
-// CHECK-NEXT: }
+// EXTERN-LABEL: hw.module.extern @level1_extern(in %arg0 : i32, in %in.a : i1, in %in.b : i2, in %arg1 : i32, out out0 : i32, out out.a : i1, out out.b : i2, out out1 : i32)
+// BASIC-LABEL: hw.module.extern @level1_extern(in %arg0 : i32, in %in : !hw.struct<a: i1, b: i2>, in %arg1 : i32, out out0 : i32, out out : !hw.struct<a: i1, b: i2>, out out1 : i32)
+hw.module.extern @level1_extern(in %arg0 : i32, in %in : !Struct1, in %arg1: i32, out out0 : i32, out out: !Struct1, out out1: i32)
+
+
+// EXTERN-LABEL: hw.module @instance_extern(in %arg0 : i32, in %arg1.a : i1, in %arg1.b : i2, out out.a : i1, out out.b : i2) {
+// EXTERN-NEXT:   %0 = hw.struct_create (%arg1.a, %arg1.b) : !hw.struct<a: i1, b: i2>
+// EXTERN-NEXT:   %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
+// EXTERN-NEXT:   %l1.out0, %l1.out.a, %l1.out.b, %l1.out1 = hw.instance "l1" @level1_extern(arg0: %arg0: i32, in.a: %a: i1, in.b: %b: i2, arg1: %arg0: i32) -> (out0: i32, out.a: i1, out.b: i2, out1: i32)
+// EXTERN-NEXT:   %1 = hw.struct_create (%l1.out.a, %l1.out.b) : !hw.struct<a: i1, b: i2>
+// EXTERN-NEXT:   %a_0, %b_1 = hw.struct_explode %1 : !hw.struct<a: i1, b: i2>
+// EXTERN-NEXT:   hw.output %a_0, %b_1 : i1, i2
+
 hw.module @instance_extern(in %arg0 : i32, in %arg1 : !Struct1, out out : !Struct1) {
   %0:3 = hw.instance "l1" @level1_extern(arg0: %arg0 : i32, in: %arg1 : !Struct1, arg1: %arg0 : i32) -> (out0: i32, out: !Struct1, out1: i32)
   hw.output %0#1 : !Struct1

--- a/test/Dialect/HW/flatten-io.mlir
+++ b/test/Dialect/HW/flatten-io.mlir
@@ -64,3 +64,15 @@ hw.module @instance(in %arg0 : i32, in %arg1 : !Struct1, out out : !Struct1) {
   hw.output %0#1 : !Struct1
 }
 
+// CHECK-LABEL: hw.module @instance_extern(in %arg0 : i32, in %arg1.a : i1, in %arg1.b : i2, out out.a : i1, out out.b : i2) {
+// CHECK-NEXT:   %0 = hw.struct_create (%arg1.a, %arg1.b) : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:   %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:   %l1.out0, %l1.out.a, %l1.out.b, %l1.out1 = hw.instance "l1" @level1_extern(arg0: %arg0: i32, in.a: %a: i1, in.b: %b: i2, arg1: %arg0: i32) -> (out0: i32, out.a: i1, out.b: i2, out1: i32)
+// CHECK-NEXT:   %1 = hw.struct_create (%l1.out.a, %l1.out.b) : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:   %a_0, %b_1 = hw.struct_explode %1 : !hw.struct<a: i1, b: i2>
+// CHECK-NEXT:   hw.output %a_0, %b_1 : i1, i2
+// CHECK-NEXT: }
+hw.module @instance_extern(in %arg0 : i32, in %arg1 : !Struct1, out out : !Struct1) {
+  %0:3 = hw.instance "l1" @level1_extern(arg0: %arg0 : i32, in: %arg1 : !Struct1, arg1: %arg0 : i32) -> (out0: i32, out: !Struct1, out1: i32)
+  hw.output %0#1 : !Struct1
+}


### PR DESCRIPTION
There was a bug in `FlattenIO`, it was crashing for instances of `hwModuleExternOp`.
If an instance op is flattened before the corresponding module op, then it results in an inconsistent IR.
Fix this issue, by using an explicit `InstanceOp` builder that doesn't rely on the module op.