### PR TITLE
[ESI] Fix AppID index walk

### DIFF
--- a/integration_test/Bindings/Python/dialects/esi_appid.py
+++ b/integration_test/Bindings/Python/dialects/esi_appid.py
@@ -58,7 +58,7 @@ with ir.Context() as ctx, ir.Location.unknown():
   print(mainmod)
 
   appids = appid_idx.get_child_appids_of(top)
-  # CHECK: [#esi.appid<"ext"[0]>, #esi.appid<"bar"[2]>]
+  # CHECK: [#esi.appid<"bar"[2]>, #esi.appid<"ext"[0]>]
   print(appids)
   path = appid_idx.get_appid_path(top, esi.AppIDAttr.get("bar", 2),
                                   ir.Location.file("msft.py", 12, 0))

--- a/lib/Dialect/ESI/Passes/ESIAppIDHier.cpp
+++ b/lib/Dialect/ESI/Passes/ESIAppIDHier.cpp
@@ -40,7 +40,7 @@ private:
     } else {
       Block *parentBlock = getBlock(path.getParent(), opStack.drop_back());
       Operation *op = opStack.back();
-      if (auto inst = dyn_cast<hw::InstanceOp>(op); inst) {
+      if (auto inst = dyn_cast<hw::InstanceOp>(op)) {
         // Create a normal node underneath the parent AppID.
         auto node = OpBuilder::atBlockEnd(parentBlock)
                         .create<AppIDHierNodeOp>(UnknownLoc::get(&getContext()),

--- a/lib/Dialect/ESI/Passes/ESIAppIDHier.cpp
+++ b/lib/Dialect/ESI/Passes/ESIAppIDHier.cpp
@@ -40,9 +40,8 @@ private:
     } else {
       Block *parentBlock = getBlock(path.getParent(), opStack.drop_back());
       Operation *op = opStack.back();
-      if (auto inst = dyn_cast<hw::InstanceOp>(op)) {
+      if (auto inst = dyn_cast<hw::InstanceOp>(op); inst) {
         // Create a normal node underneath the parent AppID.
-
         auto node = OpBuilder::atBlockEnd(parentBlock)
                         .create<AppIDHierNodeOp>(UnknownLoc::get(&getContext()),
                                                  path.getPath().back(),
@@ -66,6 +65,8 @@ void ESIAppIDHierPass::runOnOperation() {
   // Clone in manifest data, creating the instance hierarchy as we go.
   LogicalResult rc = index.walk(
       top, [&](AppIDPathAttr appidPath, ArrayRef<Operation *> opStack) {
+        assert(appidPath.getPath().size() == opStack.size() &&
+               "path and opStack must be the same size.");
         auto *block = getBlock(appidPath, opStack);
         auto *op = opStack.back();
         if (isa<IsManifestData>(op))

--- a/test/Dialect/ESI/appid_hier.mlir
+++ b/test/Dialect/ESI/appid_hier.mlir
@@ -1,0 +1,28 @@
+// RUN: circt-opt %s --esi-appid-hier=top=main | FileCheck %s
+
+hw.module @main(in %clk : !seq.clock, in %rst : i1) {
+  hw.instance "Top" sym @Top @Top() -> () 
+  esi.manifest.service_impl #esi.appid<"cosim"[0]> by "cosim" with {} {
+    esi.manifest.impl_conn [#esi.appid<"loopback_inout"[0]>] req <@HostComms::@req_resp>(!esi.bundle<[!esi.channel<i16> from "resp", !esi.channel<i24> to "req"]>) with {channel_assignments = {req = "loopback_inout[0].req", resp = "loopback_inout[0].resp"}}
+  }
+}
+
+hw.module @Top() {
+  hw.instance "LoopbackInOutAdd7" sym @LoopbackInOutAdd7 @LoopbackInOutAdd7() -> ()
+  hw.instance "Bar" sym @Bar @Bar() -> () {esi.appid=#esi.appid<"bar"[0]>}
+}
+
+hw.module @LoopbackInOutAdd7() {
+  esi.manifest.req #esi.appid<"loopback_inout"[0]>, <@HostComms::@req_resp>, toServer, !esi.bundle<[!esi.channel<i16> to "resp", !esi.channel<i24> from "req"]>
+}
+
+hw.module @Bar () {}
+
+// CHECK-LABEL: esi.manifest.hier_root @main {
+// CHECK-NEXT:    esi.manifest.req #esi.appid<"loopback_inout"[0]>, <@HostComms::@req_resp>, toServer, !esi.bundle<[!esi.channel<i16> to "resp", !esi.channel<i24> from "req"]>
+// CHECK-NEXT:    esi.manifest.hier_node #esi.appid<"bar"[0]> mod @Bar {
+// CHECK-NEXT:    }
+// CHECK-NEXT:    esi.manifest.service_impl #esi.appid<"cosim"[0]> by "cosim" with {} {
+// CHECK-NEXT:      esi.manifest.impl_conn [#esi.appid<"loopback_inout"[0]>] req <@HostComms::@req_resp>(!esi.bundle<[!esi.channel<i16> from "resp", !esi.channel<i24> to "req"]>) with {channel_assignments = {req = "loopback_inout[0].req", resp = "loopback_inout[0].resp"}}
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }


### PR DESCRIPTION
Don't call the callback on non-appid ops. Also, simplify some code sorting AppIDs merely to be deterministic.