### PR TITLE
[InstancePath] Add accessors to allow ops to reference multiple targets

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -623,11 +623,11 @@ def ObjectOp :  FIRRTLOp<"object", [
     ParentOneOf<["firrtl::FModuleOp, firrtl::ClassOp"]>,
     DeclareOpInterfaceMethods<SymbolUserOpInterface>,
     DeclareOpInterfaceMethods<FInstanceLike, [
-      "getReferencedOperation"
-    ]>,
-    DeclareOpInterfaceMethods<InstanceGraphInstanceOpInterface, [
+      "getReferencedOperation",
       "getReferencedModuleName",
       "getReferencedModuleNameAttr",
+    ]>,
+    DeclareOpInterfaceMethods<InstanceGraphInstanceOpInterface, [
       "getReferencedModuleSlow"
     ]>,
     DeclareOpInterfaceMethods<OpAsmOpInterface, [

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -363,6 +363,16 @@ def FInstanceLike : OpInterface<"FInstanceLike", [
   let description = "Provide common  instance information.";
 
   let methods = [
+    InterfaceMethod<"Get the name of the instantiated module",
+    "::llvm::StringRef", "getReferencedModuleName", (ins),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{ return $_op.getModuleName(); }]>,
+
+    InterfaceMethod<"Get the name of the instantiated module",
+    "::mlir::StringAttr", "getReferencedModuleNameAttr", (ins),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{ return $_op.getModuleNameAttr().getAttr(); }]>,
+
     InterfaceMethod<"Get the referenced module via a symbol table.",
     "::mlir::Operation *", "getReferencedOperation",
     (ins "const SymbolTable&":$symtbl),

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -174,6 +174,10 @@ def HWInstanceOp : FSMOp<"hw_instance", [
 
     FlatSymbolRefAttr getModuleNameAttr();
 
+    StringAttr getReferencedModuleNameAttr() {
+      return getModuleNameAttr().getAttr();
+    }
+
     //===------------------------------------------------------------------===//
     // PortList Methods
     //===------------------------------------------------------------------===//

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -393,6 +393,16 @@ def HWInstanceLike : OpInterface<"HWInstanceLike", [
   let description = "Provide common  module information.";
 
   let methods = [
+    InterfaceMethod<"Get the name of the instantiated module",
+    "::llvm::StringRef", "getReferencedModuleName", (ins),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{ return $_op.getModuleName(); }]>,
+
+    InterfaceMethod<"Get the name of the instantiated module",
+    "::mlir::StringAttr", "getReferencedModuleNameAttr", (ins),
+    /*methodBody=*/[{}],
+    /*defaultImplementation=*/[{ return $_op.getModuleNameAttr().getAttr(); }]>,
+
     InterfaceMethod<"Get the referenced module via a HW symbol cache.",
     "::mlir::Operation *", "getReferencedModuleCached", (ins
       "const ::circt::hw::HWSymbolCache *":$cache),

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -518,7 +518,11 @@ def InstanceOp : HWInstanceOpBase<"instance", [HWInstanceLike]> {
   let hasVerifier = 1;
 }
 
-def InstanceChoiceOp : HWInstanceOpBase<"instance_choice", []> {
+def InstanceChoiceOp : HWInstanceOpBase<"instance_choice", [
+    DeclareOpInterfaceMethods<InstanceGraphInstanceOpInterface, [
+      "getReferencedModuleNamesAttr"
+    ]>
+]> {
   let summary = "Represents an instance with a target-specific reference";
   let description = [{
     This represents an instance to a module which is determined based on the

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -112,6 +112,10 @@ class InstanceOpBase<string mnemonic> : IbisOp<mnemonic, [
     mlir::FlatSymbolRefAttr getModuleNameAttr() {
       return getTargetNameAttr();
     }
+
+    StringAttr getReferencedModuleNameAttr() {
+      return getModuleNameAttr().getAttr();
+    }
   }];
 
   code extraInstanceClassDefinition = ?;

--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -141,6 +141,14 @@ def InstanceDeclOp : SystemCOp<"instance.decl", [
     bool isOptionalSymbol() { return false; }
 
     //===------------------------------------------------------------------===//
+    // InstanceGraphInstanceOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    StringAttr getReferencedModuleNameAttr() {
+      return getModuleNameAttr().getAttr();
+    }
+
+    //===------------------------------------------------------------------===//
     // PortList Methods
     //===------------------------------------------------------------------===//
     SmallVector<::circt::hw::PortInfo> getPortList();

--- a/include/circt/Support/InstanceGraphInterface.td
+++ b/include/circt/Support/InstanceGraphInterface.td
@@ -30,15 +30,24 @@ def InstanceGraphInstanceOpInterface : OpInterface<"InstanceOpInterface"> {
     InterfaceMethod<"Get the name of the instance",
     "::mlir::StringAttr", "getInstanceNameAttr", (ins)>,
 
-    InterfaceMethod<"Get the name of the instantiated module",
-    "::llvm::StringRef", "getReferencedModuleName", (ins),
+    InterfaceMethod<"Get the name of all the possibly instantiated modules",
+    "::llvm::SmallVector<::llvm::StringRef, 1>", "getReferencedModuleNames", (ins),
     /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{ return $_op.getModuleName(); }]>,
+    /*defaultImplementation=*/[{
+      ::llvm::SmallVector<::llvm::StringRef, 1> targetNames;
+      for (::mlir::Attribute targetNameAttr : $_op.getReferencedModuleNamesAttr())
+        targetNames.push_back(
+            targetNameAttr.cast<::mlir::StringAttr>().getValue());
+      return targetNames;
+    }]>,
 
-    InterfaceMethod<"Get the name of the instantiated module",
-    "::mlir::StringAttr", "getReferencedModuleNameAttr", (ins),
+    InterfaceMethod<"Get the names of the instantiated modules",
+    "::mlir::ArrayAttr", "getReferencedModuleNamesAttr", (ins),
     /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{ return $_op.getModuleNameAttr().getAttr(); }]>,
+    /*defaultImplementation=*/[{
+      auto attr = $_op.getReferencedModuleNameAttr();
+      return ::mlir::ArrayAttr::get(attr.getContext(), {attr});
+    }]>,
   ];
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -338,8 +338,10 @@ CreateSiFiveMetadataPass::emitMemoryMetadata(ObjectModelIR &omir) {
           // the DUT is the top module or when no DUT is specified.
           if (everythingInDUT ||
               llvm::any_of(p, [&](circt::igraph::InstanceOpInterface inst) {
-                return inst.getReferencedModuleNameAttr() ==
-                       dutMod.getNameAttr();
+                return llvm::all_of(inst.getReferencedModuleNamesAttr(),
+                                    [&](Attribute attr) {
+                                      return attr == dutMod.getNameAttr();
+                                    });
               }))
             jsonStream.value(hierName);
         }

--- a/lib/Dialect/MSFT/Transforms/PassCommon.cpp
+++ b/lib/Dialect/MSFT/Transforms/PassCommon.cpp
@@ -74,12 +74,15 @@ void PassCommon::getAndSortModulesVisitor(
   modsSeen.insert(mod);
 
   mod.walk([&](igraph::InstanceOpInterface inst) {
-    Operation *modOp =
-        topLevelSyms.getDefinition(inst.getReferencedModuleNameAttr());
-    assert(modOp);
-    moduleInstantiations[modOp].push_back(inst);
-    if (auto modLike = dyn_cast<hw::HWModuleLike>(modOp))
-      getAndSortModulesVisitor(modLike, mods, modsSeen);
+    auto targetNameAttrs = inst.getReferencedModuleNamesAttr();
+    for (auto targetNameAttr : targetNameAttrs) {
+      Operation *modOp =
+          topLevelSyms.getDefinition(targetNameAttr.cast<StringAttr>());
+      assert(modOp);
+      moduleInstantiations[modOp].push_back(inst);
+      if (auto modLike = dyn_cast<hw::HWModuleLike>(modOp))
+        getAndSortModulesVisitor(modLike, mods, modsSeen);
+    }
   });
 
   mods.push_back(mod);

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -821,7 +821,7 @@ firrtl.circuit "NLATop" {
 // -----
 
 firrtl.circuit "NLATop1" {
-  // expected-error @+1 {{instance path is incorrect. Expected module: "Aardvark" instead found: "Zebra"}}
+  // expected-error @+1 {{instance path is incorrect. Expected "Aardvark". Instead found: "Zebra"}}
   hw.hierpath private @nla [@NLATop1::@test, @Zebra::@test,@Aardvark::@test]
   hw.hierpath private @nla_1 [@NLATop1::@test,@Aardvark::@test_1, @Zebra]
   firrtl.module @NLATop1() {
@@ -882,7 +882,7 @@ firrtl.circuit "Foo"   {
 firrtl.circuit "Top"   {
  // Legal nla would be:
 //hw.hierpath private @nla [@Top::@mid, @Mid::@leaf, @Leaf::@w]
-  // expected-error @+1 {{instance path is incorrect. Expected module: "Middle" instead found: "Leaf"}}
+  // expected-error @+1 {{instance path is incorrect. Expected "Middle". Instead found: "Leaf"}}
   hw.hierpath private @nla [@Top::@mid, @Leaf::@w]
   firrtl.module @Leaf() {
     %w = firrtl.wire sym @w  {annotations = [{circt.nonlocal = @nla, class = "fake1"}]} : !firrtl.uint<3>

--- a/test/Dialect/HW/verify-irn.mlir
+++ b/test/Dialect/HW/verify-irn.mlir
@@ -20,3 +20,24 @@ hw.hierpath private @test [@A::@invalid]
 
 hw.module @A() {
 }
+
+// -----
+
+// expected-error @below {{'hw.hierpath' op instance path is incorrect. Expected one of "XMRRefA", "XMRRefB" or "XMRRefC". Instead found: "XMRRefD"}}
+hw.hierpath private @ref [@XMRRefOp::@foo, @XMRRefD::@a]
+
+hw.module @XMRRefA() {
+  %a = sv.wire sym @a : !hw.inout<i2>
+}
+hw.module @XMRRefB() {
+  %a = sv.wire sym @a : !hw.inout<i2>
+}
+hw.module @XMRRefC() {
+  %a = sv.wire sym @a : !hw.inout<i2>
+}
+hw.module @XMRRefD() {
+  %a = sv.wire sym @a : !hw.inout<i2>
+}
+hw.module @XMRRefOp() {
+  hw.instance_choice "foo" sym @foo @XMRRefA or @XMRRefB if "B" or @XMRRefC if "C"() -> ()
+}


### PR DESCRIPTION
This PR introduces accessors for instance-like ops that allow multiple modules to be referenced and represented in the instance graph. Single-target users were adjusted to refer to one of their attributes instead of relying on the interface accessor.