### PR TITLE
[HW] Introduce the `hw.instance_choice` op

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -518,6 +518,40 @@ def InstanceOp : HWInstanceOpBase<"instance", [HWInstanceLike]> {
   let hasVerifier = 1;
 }
 
+def InstanceChoiceOp : HWInstanceOpBase<"instance_choice", []> {
+  let summary = "Represents an instance with a target-specific reference";
+  let description = [{
+    This represents an instance to a module which is determined based on the
+    target through the ABI. Besides a default implementation, other targets can
+    be associated with a string, which will later determined which reference
+    is chosen.
+
+    For the purposes of analyses and transformations, it is assumed that any of
+    the targets is a possibility.
+
+    Example:
+    ```mlir
+    %b = hw.instance_choice "inst" sym
+        @TargetDefault or
+        @TargetA if "A" or
+        @TargetB if "B"
+        : (a: %a: i32) -> (b: i32)
+    ```
+  }];
+
+  let arguments = (ins StrAttr:$instanceName,
+                       FlatSymbolRefArrayAttr:$moduleNames,
+                       StrArrayAttr:$targetNames,
+                       Variadic<AnyType>:$inputs,
+                       StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
+                       ParamDeclArrayAttr:$parameters,
+                       OptionalAttr<InnerSymAttr>:$inner_sym);
+  let results = (outs Variadic<AnyType>:$results);
+
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
 def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
                                 Pure, ReturnLike]> {
   let summary = "HW termination operation";

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -493,3 +493,11 @@ builtin.module @Nested {
     hw.instance "inst" @Foo () -> ()
   }
 }
+
+// -----
+
+hw.module @Foo () {
+  // expected-error @+1 {{Cannot find module definition 'DoesNotExist'}}
+  hw.instance_choice "inst" @DoesNotExist () -> ()
+}
+

--- a/test/Dialect/HW/round-trip.mlir
+++ b/test/Dialect/HW/round-trip.mlir
@@ -1,0 +1,21 @@
+// RUN: circt-opt %s | circt-opt | FileCheck %s
+
+hw.module private @TargetA(in %a: i32, out b: i32) {
+  hw.output %a : i32
+}
+
+hw.module private @TargetB(in %a: i32, out b: i32) {
+  hw.output %a : i32
+}
+
+hw.module private @TargetDefault(in %a: i32, out b: i32) {
+  hw.output %a : i32
+}
+
+hw.module public @top(in %a: i32) {
+  // CHECK: hw.instance_choice "inst1" sym @inst1 @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
+  hw.instance_choice "inst1" sym @inst1 @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
+  // CHECK: hw.instance_choice "inst2" @TargetDefault(a: %a: i32) -> (b: i32)
+  hw.instance_choice "inst2" @TargetDefault(a: %a: i32) -> (b: i32)
+}
+


### PR DESCRIPTION
This PR introduces an op to represent instance alternatives in the HW dialect.

It brings in the definition and the syntax of the op. Subsequent changes will implement a FIRRTL source op and adjust the pipeline to handle then.