### PR TITLE
[FIRRTL] Add lowering option to inline memory wrapper modules (#5681)

### DIFF
--- a/docs/ToolsWorkarounds.md
+++ b/docs/ToolsWorkarounds.md
@@ -133,3 +133,122 @@ cause the bug to manifest (since they are version dependent), thus there isn't
 a universal fix that can be applied in the generated verilog.
 
 https://github.com/llvm/circt/commit/e9f443be475e0ef796c0c6af1ce09d6e783fcd5a
+
+# Inline memory module wrappers
+
+By default, firtool wraps each memory in its own module and instantiates it inside the parent module.
+
+Vivado, for example, does not merge memories with shift registers at their outputs when there is a module boundary between them. This can make it harder to achieve good timing.
+
+## Example
+
+Input FIRRTL:
+
+```
+FIRRTL version 3.0.0
+circuit Foo:
+  module Foo:
+    input r: {addr: UInt<3>, en: UInt<1>, clk: Clock, flip data: UInt<32>}
+    input w: {addr: UInt<3>, en: UInt<1>, clk: Clock, data: UInt<32>, mask: UInt<1>}
+
+    mem memory :
+      data-type => UInt<32>
+      depth => 8
+      read-latency => 1
+      write-latency => 1
+      reader => r
+      writer => w
+      read-under-write => undefined
+
+
+    connect memory.r, r
+    connect memory.w, w
+```
+
+Default output Verilog. The memory is inside a newly created module: 
+
+```Verilog
+module memory_8x32(
+  input  [2:0]  R0_addr,
+  input         R0_en,
+                R0_clk,
+  output [31:0] R0_data,
+  input  [2:0]  W0_addr,
+  input         W0_en,
+                W0_clk,
+  input  [31:0] W0_data
+);
+
+  reg [31:0] Memory[0:7];
+  reg        _R0_en_d0;
+  reg [2:0]  _R0_addr_d0;
+  always @(posedge R0_clk) begin
+    _R0_en_d0 <= R0_en;
+    _R0_addr_d0 <= R0_addr;
+  end // always @(posedge)
+  always @(posedge W0_clk) begin
+    if (W0_en & 1'h1)
+      Memory[W0_addr] <= W0_data;
+  end // always @(posedge)
+  assign R0_data = _R0_en_d0 ? Memory[_R0_addr_d0] : 32'bx;
+endmodule
+
+module Foo(
+  input  [2:0]  r_addr,
+  input         r_en,
+                r_clk,
+  output [31:0] r_data,
+  input  [2:0]  w_addr,
+  input         w_en,
+                w_clk,
+  input  [31:0] w_data,
+  input         w_mask
+);
+
+  memory_8x32 memory_ext (
+    .R0_addr (r_addr),
+    .R0_en   (r_en),
+    .R0_clk  (r_clk),
+    .R0_data (r_data),
+    .W0_addr (w_addr),
+    .W0_en   (w_en & w_mask),
+    .W0_clk  (w_clk),
+    .W0_data (w_data)
+  );
+endmodule
+```
+
+## Workaround
+
+Compile with `firtool --lowering-options=inlineMemoryWrapperModules` to inline the content of the memory wrapper module into the parent module.
+
+With the `inlineMemoryWrapperModules` lowering option, the memory is inside the parent module.
+
+```Verilog
+module Foo(
+  input  [2:0]  r_addr,
+  input         r_en,
+                r_clk,
+  output [31:0] r_data,
+  input  [2:0]  w_addr,
+  input         w_en,
+                w_clk,
+  input  [31:0] w_data,
+  input         w_mask
+);
+
+  reg [31:0] memory_ext_Memory[0:7];
+  reg        memory_ext__R0_en_d0;
+  reg [2:0]  memory_ext__R0_addr_d0;
+  always @(posedge r_clk) begin
+    memory_ext__R0_en_d0 <= r_en;
+    memory_ext__R0_addr_d0 <= r_addr;
+  end // always @(posedge)
+  always @(posedge w_clk) begin
+    if (w_en & w_mask & 1'h1)
+      memory_ext_Memory[w_addr] <= w_data;
+  end // always @(posedge)
+  assign r_data =
+    memory_ext__R0_en_d0 ? memory_ext_Memory[memory_ext__R0_addr_d0] : 32'bx;
+endmodule
+```

--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -1,4 +1,4 @@
-# Verilog and SystemVerilog Generation
+#Verilog and SystemVerilog Generation
 
 [Verilog](https://en.wikipedia.org/wiki/Verilog) and
  [SystemVerilog](https://en.wikipedia.org/wiki/SystemVerilog) are critical
@@ -107,6 +107,9 @@ The current set of "style" Lowering Options is:
    declaration when possible.
  * `printDebugInfo` (default=`false`). If true, emit additional debug information
    (e.g. inner symbols) into comments.
+ * `inlineMemoryWrapperModules` (default=`false`). If true, inline memory wrapper modules. Module 
+   bounaries around memories in Vivado prevent it from merging memories and shift registers at
+   memory outputs, resulting in worse timing.
  * `disallowMuxInlining` (default=`false`). If true, every mux expression is spilled to a wire.
    This is used to avoid emitting deeply nested mux expressions to improve readability.
  * `wireSpillingHeuristic` (default=`spillNone`). This controls extra wire spilling performed

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -117,6 +117,9 @@ struct LoweringOptions {
   /// Print debug info.
   bool printDebugInfo = false;
 
+  /// If true, inline memory wrapper modules in to the parent module.
+  bool inlineMemoryWrapperModules = false;
+
   /// If true, every mux expression is spilled to a wire.
   bool disallowMuxInlining = false;
 

--- a/include/circt/Support/LoweringOptionsParser.h
+++ b/include/circt/Support/LoweringOptionsParser.h
@@ -47,7 +47,8 @@ struct LoweringOptionsOption
                 "explicitBitcast, emitReplicatedOpsToHeader, "
                 "locationInfoStyle={plain,wrapInAtSquareBracket,none}, "
                 "disallowPortDeclSharing, printDebugInfo, "
-                "disallowExpressionInliningInPorts, disallowMuxInlining, "
+                "disallowExpressionInliningInPorts, "
+                "inlineMemoryWrapperModules, disallowMuxInlining, "
                 "emitWireInPort, emitBindComments, omitVersionComment, "
                 "caseInsensitiveKeywords"),
             llvm::cl::cat(cat), llvm::cl::value_desc("option")} {}

--- a/lib/Dialect/Seq/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/Seq/Transforms/HWMemSimImpl.cpp
@@ -24,6 +24,9 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Path.h"
 
+#include "circt/Support/LoweringOptions.h"
+#include "mlir/Transforms/InliningUtils.h"
+
 using namespace circt;
 using namespace hw;
 using namespace seq;
@@ -700,6 +703,39 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
   });
 }
 
+struct PrefixingInliner : public mlir::InlinerInterface {
+  StringRef prefix;
+  PrefixingInliner(MLIRContext *context, StringRef prefix)
+      : mlir::InlinerInterface(context), prefix(prefix) {}
+
+  bool isLegalToInline(Region *dest, Region *src, bool wouldBeCloned,
+                       IRMapping &valueMapping) const override {
+    return true;
+  }
+  bool isLegalToInline(Operation *op, Region *dest, bool wouldBeCloned,
+                       IRMapping &valueMapping) const override {
+    return true;
+  }
+  void handleTerminator(Operation *op,
+                        ArrayRef<Value> valuesToRepl) const override {
+    assert(isa<hw::OutputOp>(op));
+    for (auto [from, to] : llvm::zip(valuesToRepl, op->getOperands()))
+      from.replaceAllUsesWith(to);
+  }
+
+  void processInlinedBlocks(
+      iterator_range<Region::iterator> inlinedBlocks) override {
+    for (Block &block : inlinedBlocks)
+      block.walk([&](Operation *op) {
+        if (auto name = op->getAttrOfType<StringAttr>("name");
+            name && !name.getValue().empty()) {
+          op->setAttr("name", StringAttr::get(name.getContext(),
+                                              prefix + "_" + name.getValue()));
+        }
+      });
+  }
+};
+
 void HWMemSimImplPass::runOnOperation() {
   auto topModule = getOperation();
 
@@ -713,6 +749,7 @@ void HWMemSimImplPass::runOnOperation() {
 
   SmallVector<HWModuleGeneratedOp> toErase;
   bool anythingChanged = false;
+  DenseSet<HWModuleOp> wrapperModules;
 
   for (auto op :
        llvm::make_early_inc_range(topModule.getOps<HWModuleGeneratedOp>())) {
@@ -737,6 +774,7 @@ void HWMemSimImplPass::runOnOperation() {
       } else {
         auto newModule = builder.create<HWModuleOp>(
             oldModule.getLoc(), nameAttr, oldModule.getPortList());
+        wrapperModules.insert(newModule);
         if (auto outdir = oldModule->getAttr("output_file"))
           newModule->setAttr("output_file", outdir);
         newModule.setCommentAttr(
@@ -752,6 +790,40 @@ void HWMemSimImplPass::runOnOperation() {
 
       oldModule.erase();
       anythingChanged = true;
+    }
+  }
+
+  // inline the memory modules created in the previous stage if
+  // inlineMemoryWrapperModules lowering options is enabled
+  if (!wrapperModules.empty() &&
+      LoweringOptions(topModule).inlineMemoryWrapperModules) {
+    SmallVector<InstanceOp> inlinedInstances;
+    auto &symbolTable = getAnalysis<SymbolTable>();
+    for (auto mod :
+         llvm::make_early_inc_range(topModule.getOps<HWModuleOp>())) {
+      for (auto inst : mod.getOps<InstanceOp>()) {
+        auto mem =
+            dyn_cast<HWModuleOp>(symbolTable.lookup(inst.getModuleName()));
+        if (wrapperModules.find(mem) == wrapperModules.end()) {
+          continue;
+        }
+        PrefixingInliner interface(&getContext(), inst.getInstanceName());
+        if (failed(mlir::inlineRegion(interface, &mem.getBody(), inst,
+                                      inst.getOperands(), inst.getResults(),
+                                      std::nullopt, true))) {
+          inst.emitError("failed to inline '")
+              << mod.getModuleName() << "' into instance '"
+              << inst.getInstanceName() << "'";
+          return signalPassFailure();
+        }
+        inlinedInstances.push_back(inst);
+      }
+    }
+    for (auto inst : inlinedInstances) {
+      inst.erase();
+    }
+    for (auto mod : wrapperModules) {
+      mod.erase();
     }
   }
 

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -95,6 +95,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       printDebugInfo = true;
     } else if (option == "disallowExpressionInliningInPorts") {
       disallowExpressionInliningInPorts = true;
+    } else if (option == "inlineMemoryWrapperModules") {
+      inlineMemoryWrapperModules = true;
     } else if (option == "disallowMuxInlining") {
       disallowMuxInlining = true;
     } else if (option == "mitigateVivadoArrayIndexConstPropBug") {
@@ -160,6 +162,8 @@ std::string LoweringOptions::toString() const {
     options += "wireSpillingHeuristic=spillLargeTermsWithNamehints,";
   if (disallowExpressionInliningInPorts)
     options += "disallowExpressionInliningInPorts,";
+  if (inlineMemoryWrapperModules)
+    options += "inlineMemoryWrapperModules,";
   if (disallowMuxInlining)
     options += "disallowMuxInlining,";
   if (mitigateVivadoArrayIndexConstPropBug)


### PR DESCRIPTION
This PR addresses issue #5681.

When the new `inlineMemoryWrapperModules` is enabled, at the end HWMemSimImpl pass, it inlines the newly created memory wrapper modules and then removes them. 

Input FIRRTL (from the issue):

```
FIRRTL version 3.0.0
circuit Foo:
  module Foo:
    input r: {addr: UInt<3>, en: UInt<1>, clk: Clock, flip data: UInt<32>}
    input w: {addr: UInt<3>, en: UInt<1>, clk: Clock, data: UInt<32>, mask: UInt<1>}

    mem memory :
      data-type => UInt<32>
      depth => 8
      read-latency => 1
      write-latency => 1
      reader => r
      writer => w
      read-under-write => undefined


    connect memory.r, r
    connect memory.w, w
```

Default output Verilog. The memory is inside a newly created `memory_8x32` module: 

```Verilog
module memory_8x32(
  input  [2:0]  R0_addr,
  input         R0_en,
                R0_clk,
  output [31:0] R0_data,
  input  [2:0]  W0_addr,
  input         W0_en,
                W0_clk,
  input  [31:0] W0_data
);

  reg [31:0] Memory[0:7];
  reg        _R0_en_d0;
  reg [2:0]  _R0_addr_d0;
  always @(posedge R0_clk) begin
    _R0_en_d0 <= R0_en;
    _R0_addr_d0 <= R0_addr;
  end // always @(posedge)
  always @(posedge W0_clk) begin
    if (W0_en & 1'h1)
      Memory[W0_addr] <= W0_data;
  end // always @(posedge)
  assign R0_data = _R0_en_d0 ? Memory[_R0_addr_d0] : 32'bx;
endmodule

module Foo(
  input  [2:0]  r_addr,
  input         r_en,
                r_clk,
  output [31:0] r_data,
  input  [2:0]  w_addr,
  input         w_en,
                w_clk,
  input  [31:0] w_data,
  input         w_mask
);

  memory_8x32 memory_ext (
    .R0_addr (r_addr),
    .R0_en   (r_en),
    .R0_clk  (r_clk),
    .R0_data (r_data),
    .W0_addr (w_addr),
    .W0_en   (w_en & w_mask),
    .W0_clk  (w_clk),
    .W0_data (w_data)
  );
endmodule
```

With the `inlineMemoryWrapperModules` lowering option, the memory is inside the parent module.

```Verilog
module Foo(
  input  [2:0]  r_addr,
  input         r_en,
                r_clk,
  output [31:0] r_data,
  input  [2:0]  w_addr,
  input         w_en,
                w_clk,
  input  [31:0] w_data,
  input         w_mask
);

  reg [31:0] memory_ext_Memory[0:7];
  reg        memory_ext__R0_en_d0;
  reg [2:0]  memory_ext__R0_addr_d0;
  always @(posedge r_clk) begin
    memory_ext__R0_en_d0 <= r_en;
    memory_ext__R0_addr_d0 <= r_addr;
  end // always @(posedge)
  always @(posedge w_clk) begin
    if (w_en & w_mask & 1'h1)
      memory_ext_Memory[w_addr] <= w_data;
  end // always @(posedge)
  assign r_data =
    memory_ext__R0_en_d0 ? memory_ext_Memory[memory_ext__R0_addr_d0] : 32'bx;
endmodule
```

Feedback will be highly appreceiate, I'm not very familiar with the LLVM/MLIR/CIRCT conventions.

A few qustions:

* Should this really be a lowering option rather than a firtool option?
* Is the name of the option appropriate? 
