### PR TITLE
[Debug] Add option to only mention existing files in HGLDD

### DIFF
--- a/include/circt/Target/DebugInfo.h
+++ b/include/circt/Target/DebugInfo.h
@@ -37,6 +37,11 @@ struct EmitHGLDDOptions {
   StringRef outputFilePrefix = "";
   /// The directory in which to place HGLDD output files.
   StringRef outputDirectory = "";
+  /// Only consider location information for files that actually exist on disk.
+  /// This can help strip out placeholder names such as `<stdin>` or
+  /// `<unknown>`, and force the HGLDD file to only refer to files that actually
+  /// exist.
+  bool onlyExistingFileLocs = false;
 };
 
 /// Serialize the debug information in the given `module` into the HGLDD format

--- a/lib/Target/DebugInfo/TranslateRegistration.cpp
+++ b/lib/Target/DebugInfo/TranslateRegistration.cpp
@@ -49,12 +49,17 @@ void registerHGLDDTranslation() {
   static llvm::cl::opt<std::string> outputPrefix(
       "hgldd-output-prefix", llvm::cl::desc("Prefix for output file locations"),
       llvm::cl::init(""));
+  static llvm::cl::opt<bool> onlyExistingFileLocs(
+      "hgldd-only-existing-file-locs",
+      llvm::cl::desc("Only consider locations in files that exist on disk"),
+      llvm::cl::init(false));
 
   auto getOptions = [] {
     EmitHGLDDOptions opts;
     opts.sourceFilePrefix = sourcePrefix;
     opts.outputFilePrefix = outputPrefix;
     opts.outputDirectory = directory;
+    opts.onlyExistingFileLocs = onlyExistingFileLocs;
     return opts;
   };
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -226,6 +226,11 @@ static cl::opt<std::string> hglddOutputDirectory(
     "hgldd-output-dir", cl::desc("Directory into which to emit HGLDD files"),
     cl::init(""), cl::value_desc("path"), cl::cat(mainCategory));
 
+static cl::opt<bool> hglddOnlyExistingFileLocs(
+    "hgldd-only-existing-file-locs",
+    cl::desc("Only consider locations in files that exist on disk"),
+    cl::init(false), cl::cat(mainCategory));
+
 static cl::opt<bool>
     emitBytecode("emit-bytecode",
                  cl::desc("Emit bytecode when generating MLIR output"),
@@ -269,6 +274,7 @@ static debug::EmitHGLDDOptions getHGLDDOptions() {
   opts.sourceFilePrefix = hglddSourcePrefix;
   opts.outputFilePrefix = hglddOutputPrefix;
   opts.outputDirectory = hglddOutputDirectory;
+  opts.onlyExistingFileLocs = hglddOnlyExistingFileLocs;
   return opts;
 }
 


### PR DESCRIPTION
Add an option to HGLDD file emission to only consider location information in the IR if the corresponding file exists on disk. This can help filter out placeholder filenames such as `<stdin>` or `<unknown>`. Also add a corresponding `--hgldd-only-existing-file-locs` option to firtool.