### PR TITLE
[ExportVerilog] Skip debug dialect ops

### DIFF
--- a/lib/Conversion/ExportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ExportVerilog/CMakeLists.txt
@@ -17,6 +17,7 @@ add_circt_translation_library(CIRCTExportVerilog
 
   LINK_LIBS PUBLIC
   CIRCTComb
+  CIRCTDebug
   CIRCTHW
   CIRCTLTL
   CIRCTOM

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -20,6 +20,7 @@
 #include "ExportVerilogInternals.h"
 #include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/Comb/CombVisitors.h"
+#include "circt/Dialect/Debug/DebugDialect.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWTypes.h"
@@ -3626,7 +3627,7 @@ void NameCollector::collectNames(Block &block) {
     // anyway.
     if (isa<InstanceOp, InterfaceInstanceOp>(op))
       continue;
-    if (isa<ltl::LTLDialect>(op.getDialect()))
+    if (isa<ltl::LTLDialect, debug::DebugDialect>(op.getDialect()))
       continue;
 
     if (!isVerilogExpression(&op)) {
@@ -5212,8 +5213,8 @@ void StmtEmitter::emitStatement(Operation *op) {
     return;
 
   // Ignore LTL expressions as they are emitted as part of verification
-  // statements.
-  if (isa<ltl::LTLDialect>(op->getDialect()))
+  // statements. Ignore debug ops as they are emitted as part of debug info.
+  if (isa<ltl::LTLDialect, debug::DebugDialect>(op->getDialect()))
     return;
 
   // Handle HW statements, SV statements.


### PR DESCRIPTION
Skip debug dialect ops in `ExportVerilog` and `PrepareForEmission` since those operations and values are only used for debug info emission and cannot be materialized directly in the Verilog output. This allows for the IR to retain debug operations purely for the purpose of documenting how Verilog values map back to the source language.

This fixes an issue where enabling debug info in firtool via the `-g` option causes Verilog emission to fail due to the presence of `dbg.*` operations.

Ideally we'll use the `DebugAnalysis` in the future to skip entire expression trees, operations, values, and block arguments if they are only consumed by debug operations. Doing so isn't as trivial as skipping ops marked as debug-only by the analysis though, since that also skips def-before-use legalization and other restructuring that `ExportVerilog` relies on. Until that is sorted out, skipping ops based on dialect is a conservative stopgap solution.