### PR TITLE
[FIRRTL][ExpandWhens] Allow zero-width wires to be uninitialized

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -729,6 +729,12 @@ LogicalResult ModuleVisitor::checkInitialization() {
 
     // Get the op which defines the sink, and emit an error.
     FieldRef dest = std::get<0>(destAndConnect);
+
+    // zero-width wires do not need to be initialized
+    if (auto op = type_dyn_cast<FIRRTLBaseType>(dest.getValue().getType()))
+      if (op.getBitWidthOrSentinel() == 0)
+        continue;
+
     auto loc = dest.getValue().getLoc();
     auto *definingOp = dest.getDefiningOp();
     if (auto mod = dyn_cast<FModuleLike>(definingOp))

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -630,4 +630,12 @@ firrtl.module @ModuleWithObjectWire(in %in: !firrtl.class<@ClassWithInput(in in:
   firrtl.propassign %0, %in : !firrtl.class<@ClassWithInput(in in: !firrtl.string)>
 }
 
+// Check that no error is emitted for zero width wires
+// CHECK: firrtl.module @ZeroWidthWire() {
+// CHECK:   %0 = firrtl.wire : !firrtl.uint<0>
+// CHECK: }
+firrtl.module @ZeroWidthWire() {
+  %0 = firrtl.wire : !firrtl.uint<0>
+}
+
 }


### PR DESCRIPTION
Don't emit uninitialized errors for zero-width wires