### PR TITLE
[ESI][Manifest] Make service records required

### DIFF
--- a/include/circt/Dialect/ESI/ESIManifest.td
+++ b/include/circt/Dialect/ESI/ESIManifest.td
@@ -113,7 +113,7 @@ def ServiceImplRecordOp : ESI_Op<"manifest.service_impl", [
   let regions = (region SizedRegion<1>:$reqDetails);
   let assemblyFormat = [{
     qualified($appID) (`svc` $service^)? `by` $serviceImplName `with` $implDetails
-    attr-dict-with-keyword $reqDetails
+    attr-dict-with-keyword custom<ServiceImplRecordReqDetails>($reqDetails)
   }];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/ESI/ESIServices.h
+++ b/include/circt/Dialect/ESI/ESIServices.h
@@ -25,7 +25,7 @@ class ServiceGeneratorDispatcher {
 public:
   // All generators must support this function pointer signature.
   using ServiceGeneratorFunc = std::function<LogicalResult(
-      ServiceImplementReqOp, ServiceDeclOpInterface)>;
+      ServiceImplementReqOp, ServiceDeclOpInterface, ServiceImplRecordOp)>;
 
   // Since passes don't have access to a context at creation time (and
   // Attributes are tied to the context), we need to delay lookup table creation

--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -82,8 +82,9 @@ void circtESIRegisterGlobalServiceGenerator(
     MlirStringRef impl_type, CirctESIServiceGeneratorFunc genFunc,
     void *userData) {
   ServiceGeneratorDispatcher::globalDispatcher().registerGenerator(
-      unwrap(impl_type), [genFunc, userData](ServiceImplementReqOp req,
-                                             ServiceDeclOpInterface decl) {
+      unwrap(impl_type),
+      [genFunc, userData](ServiceImplementReqOp req,
+                          ServiceDeclOpInterface decl, ServiceImplRecordOp) {
         return unwrap(genFunc(wrap(req), wrap(decl.getOperation()), userData));
       });
 }

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -664,6 +664,21 @@ void ServiceImplRecordOp::getDetails(SmallVectorImpl<NamedAttribute> &results) {
                        ArrayAttr::get(ctxt, reqDetails));
 }
 
+bool parseServiceImplRecordReqDetails(OpAsmParser &parser,
+                                      Region &reqDetailsRegion) {
+  parser.parseOptionalRegion(reqDetailsRegion);
+  if (reqDetailsRegion.empty())
+    reqDetailsRegion.emplaceBlock();
+  return false;
+}
+
+void printServiceImplRecordReqDetails(OpAsmPrinter &p, ServiceImplRecordOp,
+                                      Region &reqDetailsRegion) {
+  if (!reqDetailsRegion.empty() && !reqDetailsRegion.front().empty())
+    p.printRegion(reqDetailsRegion, /*printEntryBlockArgs=*/false,
+                  /*printBlockTerminators=*/false);
+}
+
 StringRef ServiceImplClientRecordOp::getManifestClass() {
   return "service_client";
 }


### PR DESCRIPTION
Build them before calling the generator then let the generator modify it. Ensures that it is always present even if the generator ignores it. Also, fix a bug in the printer/parser.