### PR TITLE
[ESI][Runtime] When a service cannot be created, ignore it

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
@@ -115,14 +115,16 @@ public:
   /// ownership of the returned pointer -- the Accelerator object owns it.
   /// Pointer lifetime ends with the Accelerator lifetime.
   template <typename ServiceClass>
-  ServiceClass *getService(AppIDPath id = {}, ServiceImplDetails details = {},
+  ServiceClass *getService(AppIDPath id = {}, std::string implName = {},
+                           ServiceImplDetails details = {},
                            HWClientDetails clients = {}) {
     return dynamic_cast<ServiceClass *>(
-        getService(typeid(ServiceClass), id, details, clients));
+        getService(typeid(ServiceClass), id, implName, details, clients));
   }
   /// Calls `createService` and caches the result. Subclasses can override if
   /// they want to use their own caching mechanism.
   virtual Service *getService(Service::Type service, AppIDPath id = {},
+                              std::string implName = {},
                               ServiceImplDetails details = {},
                               HWClientDetails clients = {});
 
@@ -131,6 +133,7 @@ protected:
   /// this in a unique_ptr and caches it. Separate this from the
   /// wrapping/caching since wrapping/caching is an implementation detail.
   virtual Service *createService(Service::Type service, AppIDPath idPath,
+                                 std::string implName,
                                  const ServiceImplDetails &details,
                                  const HWClientDetails &clients) = 0;
 

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Cosim.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Cosim.h
@@ -38,6 +38,7 @@ public:
 
 protected:
   virtual Service *createService(Service::Type service, AppIDPath path,
+                                 std::string implName,
                                  const ServiceImplDetails &details,
                                  const HWClientDetails &clients) override;
 

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Trace.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Trace.h
@@ -62,6 +62,7 @@ public:
 
 protected:
   virtual Service *createService(Service::Type service, AppIDPath idPath,
+                                 std::string implName,
                                  const ServiceImplDetails &details,
                                  const HWClientDetails &clients) override;
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
@@ -35,12 +35,16 @@ CustomService::CustomService(AppIDPath idPath,
 
 namespace esi {
 services::Service *Accelerator::getService(Service::Type svcType, AppIDPath id,
+                                           std::string implName,
                                            ServiceImplDetails details,
                                            HWClientDetails clients) {
   unique_ptr<Service> &cacheEntry = serviceCache[make_tuple(&svcType, id)];
-  if (cacheEntry == nullptr)
-    cacheEntry =
-        unique_ptr<Service>(createService(svcType, id, details, clients));
+  if (cacheEntry == nullptr) {
+    Service *svc = createService(svcType, id, implName, details, clients);
+    if (!svc)
+      return nullptr;
+    cacheEntry = unique_ptr<Service>(svc);
+  }
   return cacheEntry.get();
 }
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -327,6 +327,7 @@ private:
 } // namespace
 
 Service *CosimAccelerator::createService(Service::Type svcType, AppIDPath id,
+                                         std::string implName,
                                          const ServiceImplDetails &details,
                                          const HWClientDetails &clients) {
   if (svcType == typeid(MMIO))
@@ -334,7 +335,7 @@ Service *CosimAccelerator::createService(Service::Type svcType, AppIDPath id,
   else if (svcType == typeid(SysInfo))
     // return new MMIOSysInfo(getService<MMIO>());
     return new CosimSysInfo(impl->cosim, impl->waitScope);
-  else if (svcType == typeid(CustomService))
+  else if (svcType == typeid(CustomService) && implName == "cosim")
     return new CosimCustomService(*impl, id, details, clients);
   return nullptr;
 }

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
@@ -119,7 +119,7 @@ TraceAccelerator::TraceAccelerator(Mode mode, filesystem::path manifestJson,
 }
 
 Service *TraceAccelerator::createService(Service::Type svcType,
-                                         AppIDPath idPath,
+                                         AppIDPath idPath, std::string implName,
                                          const ServiceImplDetails &details,
                                          const HWClientDetails &clients) {
   return impl->createService(svcType, idPath, details, clients);


### PR DESCRIPTION
If createService returns null, it means either that service hasn't been
connected up externally or we do not have an implementation for it.
Either way, just ignore it and let it error when/if the user tries to
access it.

Also, pass the implementation name to createService to make it easier to
check compat.