### PR TITLE
[HW] Fix getPortList to avoid n^2 location gathering.

### DIFF
--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1385,8 +1385,9 @@ static SmallVector<PortInfo> getPortList(ModuleTy &mod) {
   auto modTy = mod.getHWModuleType();
   auto emptyDict = DictionaryAttr::get(mod.getContext());
   SmallVector<PortInfo> retval;
+  auto locs = mod.getAllPortLocs();
   for (unsigned i = 0, e = modTy.getNumPorts(); i < e; ++i) {
-    LocationAttr loc = mod.getPortLoc(i);
+    LocationAttr loc = locs[i];
     DictionaryAttr attrs =
         dyn_cast_or_null<DictionaryAttr>(mod.getPortAttrs(i));
     if (!attrs)


### PR DESCRIPTION
Instead of using `getPortLoc(i)` which is implemented in terms of `getAllPortLocs()[i]`, just gather the locations once for populating the returned information.

On this test case, Debug build:
```
circuit Test: %[[
 { "class": "firrtl.transforms.DontTouchAnnotation", "target": "~Test|Test>x" }
]]
  module Test:
    input x : { y : UInt<1>[65536] }
```

LowerToHW: 12.1s -> 5.3s
VerifyInnerRefNamespace (x3): 11s -> 2.6s
ExportVerilog: 57.8s -> 16.8s
Overall: 127s -> 51.8s
