### PR TITLE
[ESI] Add std service name to manifest

### DIFF
--- a/include/circt/Dialect/ESI/ESIManifest.td
+++ b/include/circt/Dialect/ESI/ESIManifest.td
@@ -77,12 +77,13 @@ def ServiceRequestRecordOp : ESI_Op<"manifest.req", [
 
   let arguments = (ins AppIDAttr:$requestor,
                        InnerRefAttr:$servicePort,
+                       OptionalAttr<StrAttr>:$stdService,
                        BundleDirection:$direction,
                        TypeAttrOf<ChannelBundleType>:$bundleType);
 
   let assemblyFormat = [{
-    qualified($requestor) `,` $servicePort `,` $direction `,` $bundleType
-    attr-dict
+    qualified($requestor) `,` $servicePort (`std` $stdService^)?
+    `,` $direction `,` $bundleType attr-dict
   }];
 
   let extraClassDeclaration = [{
@@ -108,11 +109,13 @@ def ServiceImplRecordOp : ESI_Op<"manifest.service_impl", [
 
   let arguments = (ins AppIDAttr:$appID,
                        OptionalAttr<FlatSymbolRefAttr>:$service,
+                       OptionalAttr<StrAttr>:$stdService,
                        StrAttr:$serviceImplName,
                        DictionaryAttr:$implDetails);
   let regions = (region SizedRegion<1>:$reqDetails);
   let assemblyFormat = [{
-    qualified($appID) (`svc` $service^)? `by` $serviceImplName `with` $implDetails
+    qualified($appID) (`svc` $service^)? (`std` $stdService^)?
+   `by` $serviceImplName `with` $implDetails
     attr-dict-with-keyword custom<ServiceImplRecordReqDetails>($reqDetails)
   }];
 

--- a/include/circt/Dialect/ESI/ESIServices.td
+++ b/include/circt/Dialect/ESI/ESIServices.td
@@ -136,6 +136,7 @@ def ServiceImplementReqOp : ESI_Op<"service.impl_req", [
   let arguments = (ins AppIDAttr:$appID,
                        OptionalAttr<FlatSymbolRefAttr>:$service_symbol,
                        StrAttr:$impl_type,
+                       OptionalAttr<StrAttr>:$stdService,
                        OptionalAttr<DictionaryAttr>:$impl_opts,
                        Variadic<AnyType>:$inputs);
   let results = (outs Variadic<AnyType>:$outputs);
@@ -143,7 +144,7 @@ def ServiceImplementReqOp : ESI_Op<"service.impl_req", [
 
   let assemblyFormat = [{
     qualified($appID) (`svc` $service_symbol^)? `impl` `as` $impl_type
-      (`opts` $impl_opts^)? `(` $inputs `)`
+      (`std` $stdService^)? (`opts` $impl_opts^)? `(` $inputs `)`
       attr-dict `:` functional-type($inputs, results)
       $portReqs
   }];

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -705,6 +705,8 @@ void ServiceRequestRecordOp::getDetails(
       StringAttr::get(ctxt, stringifyBundleDirection(getDirection())));
   results.emplace_back(getBundleTypeAttrName(), getBundleTypeAttr());
   results.emplace_back(getServicePortAttrName(), getServicePortAttr());
+  if (auto stdSvc = getStdServiceAttr())
+    results.emplace_back(getStdServiceAttrName(), getStdServiceAttr());
 }
 
 StringRef SymbolMetadataOp::getManifestClass() { return "sym_info"; }

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -179,26 +179,26 @@ hw.module @MemoryAccess2Read(in %clk: !seq.clock, in %rst: i1, in %write: !esi.c
 // Check that it doesn't crap out on external modules.
 hw.module.extern @extern()
 
-// CHECK-LABEL:  esi.service.std.func @funcs
+// CONN-LABEL:  esi.service.std.func @funcs
 esi.service.std.func @funcs
 
-// CHECK-LABEL:   hw.module @CallableFunc1(in %func1 : !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>) {
-// CHECK-NEXT:      esi.manifest.req #esi.appid<"func1">, <@funcs::@call>, toClient, !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>
-// CHECK-NEXT:      %arg = esi.bundle.unpack %arg from %func1 : !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>
+// CONN-LABEL:   hw.module @CallableFunc1(in %func1 : !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>) {
+// CONN-NEXT:      esi.manifest.req #esi.appid<"func1">, <@funcs::@call> std "esi.service.std.func", toClient, !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>
+// CONN-NEXT:      %arg = esi.bundle.unpack %arg from %func1 : !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>
 !func1Signature = !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>
 hw.module @CallableFunc1() {
   %call = esi.service.req.to_client <@funcs::@call> (#esi.appid<"func1">) : !func1Signature
   %arg = esi.bundle.unpack %arg from %call : !func1Signature
 }
 
-// CHECK-LABEL:   hw.module @CallableAccel1(in %clk : !seq.clock, in %rst : i1) {
-// CHECK-NEXT:      hw.instance "func1" @CallableFunc1(func1: %bundle: !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>) -> ()
-// CHECK-NEXT:      esi.manifest.service_impl #esi.appid<"funcComms"> svc @funcs by "cosim" with {} {
-// CHECK-NEXT:        esi.manifest.impl_conn [#esi.appid<"func1">] req <@funcs::@call>(!esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>) with {channel_assignments = {arg = "func1.arg", result = "func1.result"}}
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %0 = esi.cosim.from_host %clk, %rst, "func1.arg" : !esi.channel<i16>
-// CHECK-NEXT:      %bundle, %result = esi.bundle.pack %0 : !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>
-// CHECK-NEXT:      esi.cosim.to_host %clk, %rst, %result, "func1.result" : !esi.channel<i16>
+// CONN-LABEL:   hw.module @CallableAccel1(in %clk : !seq.clock, in %rst : i1) {
+// CONN-NEXT:      hw.instance "func1" @CallableFunc1(func1: %bundle: !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>) -> ()
+// CONN-NEXT:      esi.manifest.service_impl #esi.appid<"funcComms"> svc @funcs std "esi.service.std.func" by "cosim" with {} {
+// CONN-NEXT:        esi.manifest.impl_conn [#esi.appid<"func1">] req <@funcs::@call>(!esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>) with {channel_assignments = {arg = "func1.arg", result = "func1.result"}}
+// CONN-NEXT:      }
+// CONN-NEXT:      %0 = esi.cosim.from_host %clk, %rst, "func1.arg" : !esi.channel<i16>
+// CONN-NEXT:      %bundle, %result = esi.bundle.pack %0 : !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>
+// CONN-NEXT:      esi.cosim.to_host %clk, %rst, %result, "func1.result" : !esi.channel<i16>
 hw.module @CallableAccel1(in %clk: !seq.clock, in %rst: i1) {
   hw.instance "func1" @CallableFunc1() -> ()
   esi.service.instance #esi.appid<"funcComms"> svc @funcs impl as "cosim" (%clk, %rst) : (!seq.clock, i1) -> ()


### PR DESCRIPTION
Make the std service (if any) show up in the manifest. Allows the runtime to instantiate special support for std services.