### PR TITLE
[FIRRTL] Passive Wires pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -90,6 +90,8 @@ std::unique_ptr<mlir::Pass> createLowerMatchesPass();
 
 std::unique_ptr<mlir::Pass> createLowerSignaturesPass();
 
+std::unique_ptr<mlir::Pass> createPassiveWiresPass();
+
 std::unique_ptr<mlir::Pass> createExpandWhensPass();
 
 std::unique_ptr<mlir::Pass> createFlattenMemoryPass();

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -102,6 +102,14 @@ def LowerSignatures : Pass<"firrtl-lower-signatures", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createLowerSignaturesPass()";
 }
 
+def PassiveWires : Pass<"firrtl-passive-wires", "firrtl::FModuleOp"> {
+  let summary = "Make FIRRTL wires have passive type";
+  let description = [{
+    Eliminate flips from aggregate types on wires.
+  }];
+  let constructor = "circt::firrtl::createPassiveWiresPass()";
+}
+
 
 def IMConstProp : Pass<"firrtl-imconstprop", "firrtl::CircuitOp"> {
   let summary = "Intermodule constant propagation and dead code elimination";

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -39,6 +39,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   MemToRegOfVec.cpp
   MergeConnections.cpp
   ModuleInliner.cpp
+  PassiveWires.cpp
   PrefixModules.cpp
   PrintFIRRTLFieldSource.cpp
   PrintInstanceGraph.cpp

--- a/lib/Dialect/FIRRTL/Transforms/PassiveWires.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PassiveWires.cpp
@@ -1,0 +1,81 @@
+//===- PassiveWires.cpp - Make Wires Passive --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the PassiveWires pass.  This pass eliminated flips from
+// wires with aggregate types.  Since flips only determine connect direction,
+// they are unnecessary on wires and just get in the way.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "firrtl-passive-wires"
+
+using namespace circt;
+using namespace firrtl;
+
+static bool hasFlip(Type t) {
+  if (auto type = type_dyn_cast<FIRRTLBaseType>(t))
+    return !type.isPassive();
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct PassiveWiresPass : public PassiveWiresBase<PassiveWiresPass> {
+  void runOnOperation() override;
+};
+} // end anonymous namespace
+
+// This is the main entrypoint for the lowering pass.
+void PassiveWiresPass::runOnOperation() {
+  LLVM_DEBUG(
+      llvm::dbgs() << "===- Running Passive Wires Pass "
+                      "------------------------------------------------===\n");
+  auto module = getOperation();
+
+  // First, expand any connects to resolve flips
+  SmallVector<WireOp> wires;
+  module.walk([&](Operation *op) -> WalkResult {
+    if (auto wire = dyn_cast<WireOp>(op)) {
+      if (hasFlip(wire.getType(0)))
+        wires.push_back(wire);
+      return WalkResult::advance();
+    }
+    if (!isa<ConnectOp, StrictConnectOp>(op))
+      return WalkResult::advance();
+    // connect/strictconnect
+    if (!hasFlip(op->getOperand(0).getType()))
+      return WalkResult::advance();
+
+    mlir::ImplicitLocOpBuilder builder(op->getLoc(), op);
+    // This will "blow out" a connect to passive pieces
+    emitConnect(builder, op->getOperand(0), op->getOperand(1));
+    op->erase();
+    return WalkResult::advance();
+  });
+
+  // Second, remove flips from wires.
+  for (auto w : wires) {
+    auto r = w.getResult();
+    // in-place updates is safe as consumers don't care about flip
+    r.setType(type_cast<FIRRTLBaseType>(r.getType()).getPassiveType());
+  }
+}
+
+/// This is the pass constructor.
+std::unique_ptr<mlir::Pass> circt::firrtl::createPassiveWiresPass() {
+  return std::make_unique<PassiveWiresPass>();
+}

--- a/lib/Dialect/FIRRTL/Transforms/PassiveWires.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PassiveWires.cpp
@@ -43,10 +43,10 @@ struct PassiveWiresPass : public PassiveWiresBase<PassiveWiresPass> {
 void PassiveWiresPass::runOnOperation() {
   LLVM_DEBUG(
       llvm::dbgs() << "===- Running Passive Wires Pass "
-                      "------------------------------------------------===\n");
+                      "---------------------------------------------===\n");
   auto module = getOperation();
 
-  // First, expand any connects to resolve flips
+  // First, expand any connects to resolve flips.
   SmallVector<WireOp> wires;
   module.walk([&](Operation *op) -> WalkResult {
     if (auto wire = dyn_cast<WireOp>(op)) {
@@ -70,7 +70,7 @@ void PassiveWiresPass::runOnOperation() {
   // Second, remove flips from wires.
   for (auto w : wires) {
     auto r = w.getResult();
-    // in-place updates is safe as consumers don't care about flip
+    // In-place updates is safe as consumers don't care about flip.
     r.setType(type_cast<FIRRTLBaseType>(r.getType()).getPassiveType());
   }
 }

--- a/test/Dialect/FIRRTL/passive-wire.mlir
+++ b/test/Dialect/FIRRTL/passive-wire.mlir
@@ -1,0 +1,45 @@
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-passive-wires)))' --allow-unregistered-dialect %s | FileCheck --check-prefixes=CHECK %s
+
+firrtl.circuit "TopLevel" {
+
+  // CHECK-LABEL: @TopLevel
+  firrtl.module @TopLevel(in %source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>,
+                             out %sink: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>) {
+    %w = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+    firrtl.connect %w, %source : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+    firrtl.connect %sink, %w : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+
+// CHECK: %w = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>> 
+// CHECK: %0 = firrtl.subfield %w[valid] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+// CHECK: %1 = firrtl.subfield %source[valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK: firrtl.strictconnect %0, %1 : !firrtl.uint<1>
+// CHECK: %2 = firrtl.subfield %w[ready] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+// CHECK: %3 = firrtl.subfield %source[ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK: firrtl.strictconnect %3, %2 : !firrtl.uint<1>
+// CHECK: %4 = firrtl.subfield %w[data] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+// CHECK: %5 = firrtl.subfield %source[data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK: firrtl.strictconnect %4, %5 : !firrtl.uint<64>
+// CHECK: %6 = firrtl.subfield %sink[valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK: %7 = firrtl.subfield %w[valid] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+// CHECK: firrtl.strictconnect %6, %7 : !firrtl.uint<1>
+// CHECK: %8 = firrtl.subfield %sink[ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK: %9 = firrtl.subfield %w[ready] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+// CHECK: firrtl.strictconnect %9, %8 : !firrtl.uint<1>
+// CHECK: %10 = firrtl.subfield %sink[data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
+// CHECK: %11 = firrtl.subfield %w[data] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
+// CHECK: firrtl.strictconnect %10, %11 : !firrtl.uint<64>
+  }
+
+
+  // CHECK-LABEL: firrtl.module private @SendRefTypeVectors1
+  firrtl.module private @SendRefTypeVectors1(out %b: !firrtl.probe<bundle<b : vector<uint<1>, 2>>>) {
+    %a = firrtl.wire : !firrtl.bundle<b flip : vector<uint<1>, 2>>
+    %0 = firrtl.ref.send %a : !firrtl.bundle<b flip : vector<uint<1>, 2>>
+    firrtl.ref.define %b, %0 : !firrtl.probe<bundle<b : vector<uint<1>, 2>>>
+
+    // CHECK:  %a = firrtl.wire : !firrtl.bundle<b: vector<uint<1>, 2>>
+    // CHECK: %0 = firrtl.ref.send %a : !firrtl.bundle<b: vector<uint<1>, 2>>
+    // CHECK: firrtl.ref.define %b, %0 : !firrtl.probe<bundle<b: vector<uint<1>, 2>>>
+  }
+
+}


### PR DESCRIPTION
This pass converts wires with flips in their types to wires with passive types.  This expands connects to resolve flips effects on data flow.  After expansion, flips carry no more information and can be removed from wires (as wires have duplex flow).