### PR TITLE
[NFC] Disable -misc-include-cleaner

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ Checks: >
         -misc-unused-parameters,
         -misc-non-private-member-variables-in-classes,
         -misc-use-anonymous-namespace,
+        -misc-include-cleaner,
         readability-identifier-naming,
         bugprone-argument-comment,
         bugprone-assert-side-effect,


### PR DESCRIPTION
The warning is too verbose and the header setup of CIRCT does not line up with it.