### PR TITLE
[firrtl] Add Connection Graph

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLConnectionGraph.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLConnectionGraph.h
@@ -1,0 +1,162 @@
+//===- FIRRTLConnectionGraph.h - Graph of connections in FIRRTL -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides utilities for working with FIRRTL operations using LLVM
+// graph utilties.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_FIRRTLCONNECTIONGRAPH_H
+#define CIRCT_DIALECT_FIRRTL_FIRRTLCONNECTIONGRAPH_H
+
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/GraphTraits.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/ADT/iterator.h"
+#include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
+#include <variant>
+
+namespace circt {
+namespace firrtl {
+namespace detail {
+
+// "Using" is used here to avoid polluting the global namespace with
+// CIRCT-specific graph traits.  This pattern is borrowed from HWModuleGraph.h.
+using FIRRTLOperation = mlir::Operation;
+
+/// An iterator over connections to a module's ports.
+class FModuleOpIterator
+    : public llvm::iterator_facade_base<
+          FModuleOpIterator, std::forward_iterator_tag, FIRRTLOperation> {
+
+  FModuleOp op;
+
+  Block::iterator iterator, iteratorEnd;
+
+public:
+  FModuleOpIterator() = default;
+
+  FModuleOpIterator(FModuleOp op);
+
+  bool operator==(const FModuleOpIterator &other) const;
+
+  FIRRTLOperation &operator*() const {
+    // return *(operations.back());
+    return *iterator;
+  }
+
+  FModuleOpIterator &operator++();
+};
+
+/// An iterator over the connections of an FConnectLikeOp.
+class FConnectLikeIterator
+    : public llvm::iterator_facade_base<
+          FConnectLikeIterator, std::forward_iterator_tag, FIRRTLOperation> {
+
+  FConnectLike op;
+
+  bool visited = true;
+
+public:
+  FConnectLikeIterator() = default;
+
+  FConnectLikeIterator(FConnectLike op) : op(op), visited(false) {}
+
+  bool operator==(const FConnectLikeIterator &other) const;
+
+  FIRRTLOperation &operator*();
+
+  FConnectLikeIterator &operator++();
+};
+
+/// Generic iterator for anything that is not an FConnectLike or an FModuleOp.
+class ResultIterator
+    : public llvm::iterator_facade_base<
+          ResultIterator, std::forward_iterator_tag, FIRRTLOperation> {
+
+  FIRRTLOperation *op;
+
+  Value::use_iterator resultIterator, resultIteratorEnd;
+  int resultIndex = 0, resultIndexEnd = 0;
+
+  /// Iterate through results which have no users or are used as the
+  /// dsetinations of connects.
+  void fastforward();
+
+public:
+  ResultIterator() = default;
+
+  ResultIterator(FIRRTLOperation *op);
+
+  bool operator==(const ResultIterator &other) const;
+
+  FIRRTLOperation &operator*() const;
+
+  ResultIterator &operator++();
+};
+
+class ConnectionIterator {
+
+  using VariantIterator = std::variant<std::monostate, FModuleOpIterator,
+                                       FConnectLikeIterator, ResultIterator>;
+
+  FIRRTLOperation *op = nullptr;
+
+  VariantIterator iterator;
+
+public:
+  ConnectionIterator(FIRRTLOperation *op, bool empty = false);
+
+  bool operator==(const ConnectionIterator &other) const;
+
+  bool operator!=(const ConnectionIterator &other) const;
+
+  FIRRTLOperation *operator*();
+
+  ConnectionIterator &operator++();
+
+  ConnectionIterator operator++(int);
+
+  static ConnectionIterator childBegin(FIRRTLOperation *op) {
+    return ConnectionIterator(op);
+  }
+
+  static ConnectionIterator childEnd(FIRRTLOperation *op) {
+    return ConnectionIterator(op, /*empty=*/true);
+  }
+};
+} // namespace detail
+} // namespace firrtl
+} // namespace circt
+
+namespace llvm {
+
+template <>
+struct GraphTraits<circt::firrtl::detail::FIRRTLOperation *> {
+  using ChildIteratorType = circt::firrtl::detail::ConnectionIterator;
+  using Node = circt::firrtl::detail::FIRRTLOperation;
+  using NodeRef = Node *;
+
+  static NodeRef getEntryNode(NodeRef op) { return op; }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  static ChildIteratorType child_begin(NodeRef op) {
+    return circt::firrtl::detail::ConnectionIterator::childBegin(op);
+  }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  static ChildIteratorType child_end(NodeRef op) {
+    return circt::firrtl::detail::ConnectionIterator::childEnd(op);
+  }
+};
+
+} // namespace llvm
+
+#endif // CIRCT_DIALECT_FIRRTL_FIRRTLCONNECTIONGRAPH_H

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CIRCT_FIRRTL_Sources
   FIRRTLAnnotationHelper.cpp
   FIRRTLAnnotations.cpp
   FIRRTLAttributes.cpp
+  FIRRTLConnectionGraph.cpp
   FIRRTLDialect.cpp
   FIRRTLFieldSource.cpp
   FIRRTLFolds.cpp

--- a/lib/Dialect/FIRRTL/FIRRTLConnectionGraph.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLConnectionGraph.cpp
@@ -1,0 +1,222 @@
+//===- FIRRTLConnectionGraph.h - Graph of connections in FIRRTL -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides utilities for working with FIRRTL operations using LLVM
+// graph utilties.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/FIRRTLConnectionGraph.h"
+
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+
+using namespace circt;
+using namespace firrtl;
+using namespace detail;
+
+//===----------------------------------------------------------------------===//
+//
+// FModuleOpIterator
+//
+//===----------------------------------------------------------------------===//
+
+FModuleOpIterator::FModuleOpIterator(FModuleOp op) : op(op) {
+  auto &operations = op.getBodyBlock()->getOperations();
+  iterator = operations.begin();
+  iteratorEnd = operations.end();
+}
+
+bool FModuleOpIterator::operator==(const FModuleOpIterator &other) const {
+  if (iterator == iteratorEnd)
+    return other.iterator == other.iteratorEnd;
+
+  return iterator == other.iterator && iteratorEnd == other.iteratorEnd;
+}
+
+FModuleOpIterator &FModuleOpIterator::operator++() {
+  assert(iterator != iteratorEnd &&
+         "incrementing past the end of the iterator");
+  ++iterator;
+  return *this;
+}
+
+//===----------------------------------------------------------------------===//
+//
+// FConnectLikeIterator
+//
+//===----------------------------------------------------------------------===//
+
+bool FConnectLikeIterator::operator==(const FConnectLikeIterator &other) const {
+  if (visited)
+    return other.visited;
+  return op == other.op && !other.visited;
+}
+
+FIRRTLOperation &FConnectLikeIterator::operator*() {
+  assert(!visited && "tried to dereference past the end");
+  auto dest = op.getDest();
+  FIRRTLOperation *result;
+  if (auto blockArg = dyn_cast<BlockArgument>(dest)) {
+    result = blockArg.getParentBlock()->getParentOp();
+  } else {
+    result = dest.getDefiningOp();
+  }
+  return *result;
+}
+
+FConnectLikeIterator &FConnectLikeIterator::operator++() {
+  assert(!visited && "incrementing past the end of the iterator");
+  visited = true;
+  return *this;
+}
+
+//===----------------------------------------------------------------------===//
+//
+// ResultIterator
+//
+//===----------------------------------------------------------------------===//
+
+ResultIterator::ResultIterator(FIRRTLOperation *op)
+    : op(op), resultIndexEnd(op->getNumResults()) {
+  if (resultIndex == resultIndexEnd)
+    return;
+  auto result = op->getResult(resultIndex);
+  resultIterator = result.use_begin();
+  resultIteratorEnd = result.use_end();
+  fastforward();
+}
+
+void ResultIterator::fastforward() {
+  while (resultIterator != resultIteratorEnd &&
+         dyn_cast<FConnectLike>(resultIterator.getUser()) &&
+         resultIterator.getOperand()->getOperandNumber() == 0)
+    ++resultIterator;
+  while (resultIterator == resultIteratorEnd && resultIndex != resultIndexEnd) {
+    ++resultIndex;
+    if (resultIndex == resultIndexEnd)
+      break;
+    auto result = op->getResult(resultIndex);
+    resultIterator = result.use_begin();
+    resultIteratorEnd = result.use_end();
+    while (resultIterator != resultIteratorEnd &&
+           dyn_cast<FConnectLike>(resultIterator.getUser()) &&
+           resultIterator.getOperand()->getOperandNumber() == 0)
+      ++resultIterator;
+  }
+}
+
+bool ResultIterator::operator==(const ResultIterator &other) const {
+  if (resultIndex == resultIndexEnd)
+    return other.resultIndex == other.resultIndexEnd;
+
+  return resultIterator == other.resultIterator &&
+         resultIteratorEnd == other.resultIteratorEnd &&
+         resultIndex == other.resultIndex &&
+         resultIndexEnd == other.resultIndexEnd;
+}
+
+FIRRTLOperation &ResultIterator::operator*() const {
+  assert(resultIndex != resultIndexEnd && "tried to dereference past the end");
+  return *resultIterator->getOwner();
+}
+
+ResultIterator &ResultIterator::operator++() {
+  assert(resultIndex != resultIndexEnd &&
+         "incrementing past the end of the iterator");
+  ++resultIterator;
+  fastforward();
+  return *this;
+}
+
+//===----------------------------------------------------------------------===//
+//
+// ConnectionIterator
+//
+//===----------------------------------------------------------------------===//
+
+ConnectionIterator::ConnectionIterator(FIRRTLOperation *op, bool empty) {
+  assert(op && "op should not be null");
+  TypeSwitch<FIRRTLOperation *>(op)
+      .Case<FModuleOp>([&](auto op) {
+        iterator = empty ? FModuleOpIterator() : FModuleOpIterator(op);
+      })
+      .Case<FConnectLike>([&](auto op) {
+        iterator = empty ? FConnectLikeIterator() : FConnectLikeIterator(op);
+      })
+      .Default([&](auto *op) {
+        iterator = empty ? ResultIterator() : ResultIterator(op);
+      });
+  this->op = op;
+}
+
+bool ConnectionIterator::operator==(const ConnectionIterator &other) const {
+  assert(iterator.index() == other.iterator.index() &&
+         "comparing different iterator variants");
+  switch (iterator.index()) {
+  case 0:
+    assert(false && "should be impossible");
+    break;
+  case 1:
+    return std::get<FModuleOpIterator>(iterator) ==
+           std::get<FModuleOpIterator>(other.iterator);
+  case 2:
+    return std::get<FConnectLikeIterator>(iterator) ==
+           std::get<FConnectLikeIterator>(other.iterator);
+  case 3:
+    return std::get<ResultIterator>(iterator) ==
+           std::get<ResultIterator>(other.iterator);
+  }
+  return false;
+}
+
+bool ConnectionIterator::operator!=(const ConnectionIterator &other) const {
+  return !(*this == other);
+}
+
+FIRRTLOperation *ConnectionIterator::operator*() {
+  FIRRTLOperation *result;
+  switch (iterator.index()) {
+  case 0:
+    assert(false && "should be impossible");
+    break;
+  case 1:
+    result = &(*std::get<FModuleOpIterator>(iterator));
+    break;
+  case 2:
+    result = &(*std::get<FConnectLikeIterator>(iterator));
+    break;
+  case 3:
+    result = &(*std::get<ResultIterator>(iterator));
+    break;
+  }
+  return result;
+}
+
+ConnectionIterator &ConnectionIterator::operator++() {
+  switch (iterator.index()) {
+  case 0:
+    assert(false && "should be impossible");
+    break;
+  case 1:
+    ++std::get<FModuleOpIterator>(iterator);
+    break;
+  case 2:
+    ++std::get<FConnectLikeIterator>(iterator);
+    break;
+  case 3:
+    ++std::get<ResultIterator>(iterator);
+    break;
+  }
+  return *this;
+}
+
+ConnectionIterator ConnectionIterator::operator++(int) {
+  ConnectionIterator result(*this);
+  ++(*this);
+  return result;
+}


### PR DESCRIPTION
Add iterators for walking connections in FIRRTL.  This adds two levels of iterators:

1. A ConnectionIterator which wraps an inner iterator (2)

2. One of several types of iterators specialized to handle FIRRTL operations:

   a. A FModuleOpIterator for walking all operations inside a module. (This acts like a "root node" that is the parent of everything.)

   b. A FConnectLikeIterator for walking connection destinations.

   c. A ResultIterator for generically walking results. (This is the default walker for everything that isn't a connect, e.g., instances and memories fall into this category.)

GraphTraits for FIRRTLOperations (just an mlir::Operation) are then added that iterate using the ConnectionIterator.

This is heavily inspired by the old @hanchenye approach for `CheckCombCycles` patch: https://github.com/llvm/circt/pull/1388

For how this is intended to be used, see: https://github.com/llvm/circt/pull/6492 Because graph traits are provided, `scc_iterator` can then be used to compute SCCs of FIRRTL operations in a module. This has been tested to be "fast" on internal designs (it runs with the same speed as other passes that traverse the complete IR of every module in parallel).

This is currently deficient for aggregate connections. Specifically, this will not properly compute SCCs for connections involving destinations that are subaccess/subfield/subindex operations of aggregates. I have some ideas on how to fix this... I'd like to land this version (which works for anything where all internal flips and types are lowered).