### PR TITLE
[firrtl] Improve LayerSink with scc_iterator

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LayerSink.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LayerSink.cpp
@@ -6,47 +6,254 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file sinks operations into layer blocks.
+// A module pass that sinks operations into layer blocks.
+//
+// This works by iterating, in reverse topological order, over the strongly
+// connected components (SCC) for operations in a FIRRTL module.  The operations
+// in each SCC are iterated over to compute the "highest" layer that they can be
+// sunk into.  This is determined by analyzing the users of all operations in
+// each SCC.  Following that, all operations are moved into the highest layer.
+//
+// SCC iteration relies on the graph traits defined in FIRRTLConnectionGraph.
+// Currently this is deficient for partial writes to aggregates, i.e.,
+// FConnectLike operations where the destination is a subaccess, subfield, or
+// subindex.  For situations involviung these operations, this pass will not
+// fail, but will be less effective than it should be.
+//
+// Tests tracking improvements related to aggregates are located here:
+//
+//     test/Dialect/FIRRTL/layer-sink-xfail.mlir
 //
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"
 
+#include "circt/Dialect/FIRRTL/FIRRTLConnectionGraph.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Transforms/ControlFlowSinkUtils.h"
+#include "llvm/ADT/EquivalenceClasses.h"
+#include "llvm/ADT/SCCIterator.h"
+#include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "firrtl-layer-sink"
 
 using namespace circt;
 using namespace firrtl;
 
+using circt::firrtl::detail::FIRRTLOperation;
+using llvm::EquivalenceClasses;
+
 namespace {
 /// A control-flow sink pass.
-struct LayerSink : public LayerSinkBase<LayerSink> {
+class LayerSink : public LayerSinkBase<LayerSink> {
   void runOnOperation() override;
+
+  /// This contains disjoint sets of all operations in a module that either
+  /// already are in a layer block or can be safely moved into a layer block if
+  /// all operations in this set are also moved.  Operations which should not be
+  /// moved are NOT added to an equivalence class!
+  EquivalenceClasses<Operation *> layerSets;
+
+  /// A mapping of a leader from the layerSets to the parent in which this
+  /// exists or can be moved.
+  DenseMap<Operation *, Operation *> leaderToParent;
+
+  /// A mapping of a layer/parent to the leader which contains all the
+  /// operations that are under or can be moved under this layer/parent;
+  DenseMap<Operation *, Operation *> parentToLeader;
+
+  /// Return the parent of two operations.  `Initial` is the current "best"
+  /// operation (and maye be null if no operation is known to be best) and `x`
+  /// is the new operation (and must not be null).  This will never return an
+  /// operation above an `FModuleOp`.
+  Operation *foldParent(Operation *initial, Operation *x);
+
+  /// Return the common parent of all operations in an SCC.  If this returns
+  /// `nullptr` then it indicates that there is no information to indicate a
+  /// better common parent exists.
+  Operation *processScc(llvm::scc_iterator<FIRRTLOperation *> &i);
 };
-} // end anonymous namespace
+} // namespace
+
+Operation *LayerSink::foldParent(Operation *initial, Operation *x) {
+  if (llvm::isa_and_nonnull<FModuleOp>(initial))
+    return initial;
+
+  assert(x && "x must not be null");
+  if (llvm::isa<FModuleOp>(x))
+    return x;
+
+  // Determine the parent of `x`.  This is either the actual parent or, if this
+  // exists in layerSets, then it is the layer that `x` will be moved into.
+  Operation *xParent = x->getParentOp();
+  auto leader = layerSets.findLeader(x);
+  if (leader != layerSets.member_end())
+    xParent = leaderToParent.lookup(*leader);
+
+  if (!initial)
+    return xParent;
+
+  while (initial != xParent)
+    initial = initial->getParentOp();
+
+  return initial;
+}
+
+Operation *LayerSink::processScc(llvm::scc_iterator<FIRRTLOperation *> &i) {
+
+  // Mutable temporary that will be updated with the current "best parent".  The
+  // initial value of `nullptr` indicates that there is no relevant information
+  // indicating a change of parent should occur.
+  Operation *bestParent = nullptr;
+
+  // Cache information about what operations are in the SCC.  This is queried to
+  // know when a user is in the SCC and analysis of that user contains no
+  // bearing on the parent.
+  llvm::DenseSet<Operation *> sccOps(i->begin(), i->end());
+
+  for (auto *op : *i) {
+    // If the parent is already known to be a module, then stop processing this
+    // SCC---continued processing cannot change this result.
+    if (isa_and_nonnull<FModuleOp>(bestParent))
+      break;
+
+    // Process connect destinations only.
+    if (auto connect = dyn_cast<FConnectLike>(op)) {
+      auto dest = connect.getDest();
+      if (auto blockArg = dyn_cast<BlockArgument>(dest)) {
+        bestParent = blockArg.getDefiningOp();
+        continue;
+      }
+      auto *definingOp = dest.getDefiningOp();
+      if (sccOps.contains(definingOp))
+        continue;
+      bestParent = foldParent(bestParent, definingOp);
+      continue;
+    }
+
+    // If this operation is marked don't touch, then treat it as having itself
+    // as a user.  This has the effect of causing it to not be moved.
+    if (hasDontTouch(op)) {
+      bestParent = foldParent(bestParent, op);
+      continue;
+    }
+
+    // Process operation users not in this SCC.  Skip connect destinations.
+    for (auto &use : op->getUses()) {
+      auto *user = use.getOwner();
+      // Skip users in the same SCC.
+      if (sccOps.contains(user))
+        continue;
+      // Skip uses that are connect desintations.
+      if (auto connect = dyn_cast<FConnectLike>(user))
+        if (use.get() == connect.getDest())
+          continue;
+      bestParent = foldParent(bestParent, user);
+    }
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "SCC:\n"
+                 << "  operations:\n";
+    for (auto *op : *i)
+      llvm::dbgs() << "    - op: " << *op << "\n";
+    llvm::dbgs() << "  commonParent: ";
+    if (auto moduleOp = dyn_cast_or_null<FModuleOp>(bestParent))
+      llvm::dbgs() << "module";
+    else if (auto layerBlockOp = dyn_cast_or_null<LayerBlockOp>(bestParent))
+      llvm::dbgs() << layerBlockOp.getLayerName();
+    else {
+      if (bestParent)
+        llvm::dbgs() << *bestParent << "\n";
+      assert(!bestParent && "expected commonParent to be null");
+      llvm::dbgs() << "<null>";
+    }
+    llvm::dbgs() << "\n";
+  });
+
+  assert((!bestParent || isa<FModuleOp>(bestParent) ||
+          isa<LayerBlockOp>(bestParent)) &&
+         "expected parent to be null, a Module, or a LayerBlock");
+  return bestParent;
+}
 
 void LayerSink::runOnOperation() {
   LLVM_DEBUG(
       llvm::dbgs() << "==----- Running LayerSink "
                       "---------------------------------------------------===\n"
                    << "Module: '" << getOperation().getName() << "'\n";);
-  auto &domInfo = getAnalysis<mlir::DominanceInfo>();
-  getOperation()->walk([&](LayerBlockOp layerBlock) {
-    SmallVector<Region *> regionsToSink({&layerBlock.getRegion()});
-    numSunk = controlFlowSink(
-        regionsToSink, domInfo,
-        [](Operation *op, Region *) { return !hasDontTouch(op); },
-        [](Operation *op, Region *region) {
-          // Move the operation to the beginning of the region's entry block.
-          // This guarantees the preservation of SSA dominance of all of the
-          // operation's uses are in the region.
-          op->moveBefore(&region->front(), region->front().begin());
-        });
-  });
+
+  FIRRTLOperation *moduleOp = getOperation();
+
+  // Iterate over the SCCs in this module, populating `layerSets` with
+  // operations which should be moved.
+  for (llvm::scc_iterator<detail::FIRRTLOperation *>
+           i = llvm::scc_begin(moduleOp),
+           e = llvm::scc_end(moduleOp);
+       i != e; ++i) {
+
+    // Determine the best parent for all operations in this SCC.  If this is
+    // null, then it means there is no information indicating that the
+    // operations can be moved.
+    Operation *bestParent = processScc(i);
+
+    // Do not add anything which shouldn't be moved to `layerSets`.
+    if (!bestParent || isa<FModuleOp>(bestParent))
+      continue;
+
+    // Update `layerSets` with the operations in this SCC.  If this is a new
+    // equivalence class, then update `leaderToParent`/`parentToLeader` and
+    // start a new equivalence class.  Otherwise, merge these operations into an
+    // existing equivalence class.
+    auto *first = *(*i).begin();
+    auto leaderIt = parentToLeader.find(bestParent);
+    if (leaderIt == parentToLeader.end()) {
+      leaderToParent.insert({first, bestParent});
+      parentToLeader.insert({bestParent, first});
+      leaderIt = parentToLeader.find(bestParent);
+      layerSets.insert(first);
+    } else
+      layerSets.unionSets(leaderIt->second, first);
+
+    for (auto *op : *i)
+      layerSets.unionSets(leaderIt->second, op);
+  }
+
+  // Iterate over each `layerSet` and move all operations into their new layer.
+  // Do this while preserving the original order in the module.
+  for (auto leaderIt = layerSets.begin(), leaderEnd = layerSets.end();
+       leaderIt != leaderEnd; ++leaderIt) {
+    if (!leaderIt->isLeader())
+      continue;
+
+    SmallVector<Operation *> layerOpsReverseModuleOrdered(
+        layerSets.member_begin(leaderIt), layerSets.member_end());
+    llvm::sort(layerOpsReverseModuleOrdered.begin(),
+               layerOpsReverseModuleOrdered.end(),
+               [](Operation *a, Operation *b) {
+                 auto aBlock = a->getBlock(), bBlock = b->getBlock();
+                 if (aBlock == bBlock)
+                   return !a->isBeforeInBlock(b);
+                 while (isa<FModuleOp>(aBlock->getParentOp())) {
+                   aBlock = a->getParentOp()->getBlock();
+                   if (aBlock == bBlock)
+                     return true;
+                 }
+                 return false;
+               });
+
+    auto commonParent = leaderToParent.find(leaderIt->getData());
+    assert(commonParent != leaderToParent.end() &&
+           "a common parent should already exist in leaderToParent");
+    assert(commonParent->second && "a common parent should not be null");
+
+    for (auto *op : layerOpsReverseModuleOrdered) {
+      auto &region = commonParent->second->getRegion(0);
+      op->moveBefore(&region.front(), region.front().begin());
+    }
+  }
 }
 
 std::unique_ptr<mlir::Pass> circt::firrtl::createLayerSinkPass() {

--- a/test/Dialect/FIRRTL/layer-sink-xfail.mlir
+++ b/test/Dialect/FIRRTL/layer-sink-xfail.mlir
@@ -11,7 +11,7 @@ firrtl.circuit "LayerSinkExpectedFailures" {
 
   // CHECk: firrtl.module @LayerSinkExpectedFailures
   firrtl.module @LayerSinkExpectedFailures(in %a: !firrtl.uint<1>) {
-
+    %wire_subaccess = firrtl.wire : !firrtl.vector<uint<1>, 2>
     %2 = firrtl.subaccess %wire_subaccess[%a] : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
     firrtl.strictconnect %2, %2 : !firrtl.uint<1>
     firrtl.layerblock @Subaccess {

--- a/test/Dialect/FIRRTL/layer-sink-xfail.mlir
+++ b/test/Dialect/FIRRTL/layer-sink-xfail.mlir
@@ -1,0 +1,54 @@
+// RUN: circt-opt -pass-pipeline="builtin.module(firrtl.circuit(firrtl.module(firrtl-layer-sink)))" %s | FileCheck %s
+// XFAIL: *
+
+// Tests of things which do not currently sink, but should.
+//
+// CHECK-LABEL: firrtl.circuit "LayerSinkExpectedFailures"
+firrtl.circuit "LayerSinkExpectedFailures" {
+  firrtl.layer @Subaccess bind {}
+  firrtl.layer @Subfield bind {}
+  firrtl.layer @Subindex bind {}
+
+  // CHECk: firrtl.module @LayerSinkExpectedFailures
+  firrtl.module @LayerSinkExpectedFailures(in %a: !firrtl.uint<1>) {
+
+    %2 = firrtl.subaccess %wire_subaccess[%a] : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
+    firrtl.strictconnect %2, %2 : !firrtl.uint<1>
+    firrtl.layerblock @Subaccess {
+      %layer_wire_subaccess = firrtl.node %wire_subaccess : !firrtl.vector<uint<1>, 2>
+    }
+    // CHECK-NEXT: firrtl.layerblock @Subaccess {
+    // CHECK-NEXT:   %wire_subaccess = firrtl.wire
+    // CHECK-NEXT:   %2 = firrtl.subaccess %wire_subaccess[%a] : !firrtl.vector<uint<1>, 2>, !firrtl.uint<1>
+    // CHECK-NEXT:   firrtl.strictconnect %2, %2 : !firrtl.uint<1>
+    // CHECK-NEXT:   firrtl.strictconnect %3, %2
+    // CHECK-NEXT:   %layer_wire_subaccess = firrtl.node %wire_subaccess
+    // CHECK-NEXT: }
+
+    %wire_subfield = firrtl.wire : !firrtl.bundle<a: uint<1>>
+    %0 = firrtl.subfield %wire_subfield[a] : !firrtl.bundle<a: uint<1>>
+    firrtl.strictconnect %0, %0 : !firrtl.uint<1>
+    firrtl.layerblock @Subfield {
+      %layer_wire_subfield = firrtl.node %wire_subfield : !firrtl.bundle<a: uint<1>>
+    }
+    // CHECK-NEXT: firrtl.layerblock @Subfield {
+    // CHECK-NEXT:   %wire_subfield = firrtl.wire
+    // CHECK-NEXT:   %0 = firrtl.subfield %wire_subfield[a]
+    // CHECK-NEXT:   firrtl.strictconnect %0, %0
+    // CHECK-NEXT:   %layer_wire_subfield = firrtl.node %wire_subfield
+    // CHECK-NEXT: }
+
+    %wire_subindex = firrtl.wire : !firrtl.vector<uint<1>, 1>
+    %1 = firrtl.subindex %wire_subindex[0] : !firrtl.vector<uint<1>, 1>
+    firrtl.strictconnect %1, %1 : !firrtl.uint<1>
+    firrtl.layerblock @Subindex {
+      %layer_wire_subindex = firrtl.node %wire_subindex : !firrtl.vector<uint<1>, 1>
+    }
+    // CHECK-NEXT: firrtl.layerblock @Subindex {
+    // CHECK-NEXT:   %wire_subindex = firrtl.wire
+    // CHECK-NEXT:   %1 = firrtl.subindex %wire_subindex[0]
+    // CHECK-NEXT:   firrtl.strictconnect %1, %1
+    // CHECK-NEXT:   %layer_wire_subindex = firrtl.node %wire_subindex
+    // CHECK-NEXT: }
+  }
+}

--- a/test/Dialect/FIRRTL/layer-sink.mlir
+++ b/test/Dialect/FIRRTL/layer-sink.mlir
@@ -1,27 +1,209 @@
 // RUN: circt-opt -pass-pipeline="builtin.module(firrtl.circuit(firrtl.module(firrtl-layer-sink)))" %s | FileCheck %s
 
-// Test that simple things are sunk:
-//   - nodes
-//   - constants
-//   - primitive operations
+// Test that simple things with uses only in layers are sunk.
 //
 // CHECK-LABEL: firrtl.circuit "SimpleSink"
 firrtl.circuit "SimpleSink" {
- firrtl.layer @A bind {
- }
- // CHECK: firrtl.module @SimpleSink
- firrtl.module @SimpleSink(in %a: !firrtl.uint<1>) {
-   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-   %node = firrtl.node %a : !firrtl.uint<1>
-   %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
-   // CHECK-NEXT: firrtl.layerblock @A
-   firrtl.layerblock @A {
-     // CHECK: %c0_ui1 = firrtl.constant
-     %constant_layer = firrtl.node %c0_ui1 : !firrtl.uint<1>
-     // CHECK: %node = firrtl.node
-     %node_layer = firrtl.node %node : !firrtl.uint<1>
-     // CHECK: %0 = firrtl.not
-     %primop_layer = firrtl.node %0 : !firrtl.uint<1>
-   }
- }
+  firrtl.layer @Constant bind {}
+  firrtl.layer @Node bind {}
+  firrtl.layer @Expression bind {}
+  firrtl.layer @Wire bind {}
+  firrtl.layer @Reg bind {}
+  firrtl.layer @Mem bind {}
+  firrtl.layer @Instance bind {}
+  firrtl.layer @DeepSinking bind {
+    firrtl.layer @A bind {
+      firrtl.layer @B bind {
+        firrtl.layer @C bind {
+        }
+      }
+    }
+  }
+  firrtl.layer @RegCycle bind {}
+  firrtl.layer @InstanceCycle bind {}
+  firrtl.layer @BlockedSinking bind {
+    firrtl.layer @A bind {}
+    firrtl.layer @B bind {}
+  }
+  firrtl.layer @DontTouch bind {}
+  firrtl.layer @Aggregates bind {}
+
+  firrtl.module @Foo(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+    firrtl.strictconnect %b, %a : !firrtl.uint<1>
+  }
+
+  // CHECK: firrtl.module @SimpleSink
+  firrtl.module @SimpleSink(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>) {
+
+    //===------------------------------------------------------------------===//
+    // Check that various kinds of operations are all sunk.
+    //===------------------------------------------------------------------===//
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    firrtl.layerblock @Constant {
+      %layer_constant = firrtl.node %c0_ui1 : !firrtl.uint<1>
+    }
+    // CHECK-NEXT: firrtl.layerblock @Constant {
+    // CHECK-NEXT:   %c0_ui1 = firrtl.constant 0
+    // CHECK-NEXT:   %layer_constant = firrtl.node %c0_ui1
+    // CHECK-NEXT: }
+
+    %node = firrtl.node %a : !firrtl.uint<1>
+    firrtl.layerblock @Node {
+      %layer_node = firrtl.node %node : !firrtl.uint<1>
+    }
+    // CHECK-NEXT: firrtl.layerblock @Node {
+    // CHECK-NEXT:   %node = firrtl.node %a
+    // CHECK-NEXT:   %layer_node = firrtl.node %node
+    // CHECK-NEXT: }
+
+    %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    firrtl.layerblock @Expression {
+      %layer_expression = firrtl.node %0 : !firrtl.uint<1>
+    }
+    // CHECK-NEXT: firrtl.layerblock @Expression {
+    // CHECK-NEXT:   %0 = firrtl.not %a
+    // CHECK-NEXT:   %layer_expression = firrtl.node %0
+    // CHECK-NEXT: }
+
+    %wire = firrtl.wire : !firrtl.uint<1>
+    firrtl.strictconnect %wire, %a : !firrtl.uint<1>
+    firrtl.layerblock @Wire {
+      %layer_wire = firrtl.node %wire : !firrtl.uint<1>
+    }
+    // CHECK-NEXT: firrtl.layerblock @Wire {
+    // CHECK-NEXT:   %wire = firrtl.wire
+    // CHECK-NEXT:   firrtl.strictconnect %wire, %a
+    // CHECK-NEXT:   %layer_wire = firrtl.node %wire
+    // CHECK-NEXT: }
+
+    %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
+    firrtl.strictconnect %reg, %a : !firrtl.uint<1>
+    firrtl.layerblock @Reg {
+      %layeyr_reg = firrtl.node %reg : !firrtl.uint<1>
+    }
+    // CHECK-NEXT: firrtl.layerblock @Reg {
+    // CHECK-NEXT:   %reg = firrtl.reg %clock
+    // CHECK-NEXT:   firrtl.strictconnect %reg, %a
+    // CHECK-NEXT:   %layeyr_reg = firrtl.node %reg
+    // CHECK-NEXT: }
+
+    %mem_r = firrtl.mem Undefined {depth = 2, name = "mem", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<8>>
+    %mem_r_data = firrtl.subfield %mem_r[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<8>>
+    firrtl.layerblock @Mem {
+      %layer_mem = firrtl.node %mem_r_data : !firrtl.uint<8>
+    }
+    // CHECK-NEXT: firrtl.layerblock @Mem {
+    // CHECK-NEXT:   %mem_r = firrtl.mem
+    // CHECK-NEXT:   %[[mem_r_data:[_A-Za-z0-9]+]] = firrtl.subfield %mem_r[data]
+    // CHECK-NEXT:   %layer_mem = firrtl.node %[[mem_r_data]]
+    // CHECK-NEXT: }
+
+    %foo_a, %foo_b = firrtl.instance foo @Foo(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+    firrtl.strictconnect %foo_a, %a : !firrtl.uint<1>
+    firrtl.layerblock @Instance {
+      %layer_instance = firrtl.node %foo_b : !firrtl.uint<1>
+    }
+    // CHECK-NEXT: firrtl.layerblock @Instance {
+    // CHECK-NEXT:   %foo_a, %foo_b = firrtl.instance foo @Foo
+    // CHECK-NEXT:   firrtl.strictconnect %foo_a, %a
+    // CHECK-NEXT:   %layer_instance = firrtl.node %foo_b
+    // CHECK-NEXT: }
+
+    //===------------------------------------------------------------------===//
+    // Check that sinking sinks to the highest layer.
+    //===------------------------------------------------------------------===//
+    %node_deep = firrtl.node %a : !firrtl.uint<1>
+    firrtl.layerblock @DeepSinking {
+      %node_deep_0 = firrtl.node %node_deep : !firrtl.uint<1>
+      firrtl.layerblock @DeepSinking::@A {
+        %node_deep_1 = firrtl.node %node_deep_0 : !firrtl.uint<1>
+        firrtl.layerblock @DeepSinking::@A::@B {
+          %node_deep_2 = firrtl.node %node_deep_1 : !firrtl.uint<1>
+          firrtl.layerblock @DeepSinking::@A::@B::@C {
+            %node_deep_3 = firrtl.node %node_deep_2 : !firrtl.uint<1>
+          }
+        }
+      }
+    }
+    // CHECK-NEXT: firrtl.layerblock @DeepSinking {
+    // CHECK-NEXT:   firrtl.layerblock @DeepSinking::@A {
+    // CHECK-NEXT:     firrtl.layerblock @DeepSinking::@A::@B {
+    // CHECK-NEXT:       firrtl.layerblock @DeepSinking::@A::@B::@C {
+    // CHECK-NEXT:         %node_deep = firrtl.node %a : !firrtl.uint<1>
+    // CHECK-NEXT:         %node_deep_0 = firrtl.node %node_deep : !firrtl.uint<1>
+    // CHECK-NEXT:         %node_deep_1 = firrtl.node %node_deep_0 : !firrtl.uint<1>
+    // CHECK-NEXT:         %node_deep_2 = firrtl.node %node_deep_1 : !firrtl.uint<1>
+    // CHECK-NEXT:         %node_deep_3 = firrtl.node %node_deep_2 : !firrtl.uint<1>
+    // CHECK-NEXT:       }
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
+
+    //===------------------------------------------------------------------===//
+    // Check that operations with cycles are collectively sunk.
+    //===------------------------------------------------------------------===//
+    %reg_cycle_a = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
+    %reg_cycle_b = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
+    firrtl.strictconnect %reg_cycle_a, %reg_cycle_b : !firrtl.uint<1>
+    firrtl.strictconnect %reg_cycle_b, %reg_cycle_a : !firrtl.uint<1>
+    firrtl.layerblock @RegCycle {
+      %layer_reg_cycle = firrtl.node %reg_cycle_b : !firrtl.uint<1>
+    }
+    // CHECK-NEXT: firrtl.layerblock @RegCycle {
+    // CHECK-NEXT:   %reg_cycle_a = firrtl.reg %clock
+    // CHECK-NEXT:   %reg_cycle_b = firrtl.reg %clock
+    // CHECK-NEXT:   firrtl.strictconnect %reg_cycle_a, %reg_cycle_b
+    // CHECK-NEXT:   firrtl.strictconnect %reg_cycle_b, %reg_cycle_a
+    // CHECK-NEXT:   %layer_reg_cycle = firrtl.node %reg_cycle_b
+    // CHECK-NEXT: }
+
+    %bar_a, %bar_b = firrtl.instance bar @Foo(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+    %baz_a, %baz_b = firrtl.instance baz @Foo(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+    firrtl.strictconnect %bar_a, %baz_b : !firrtl.uint<1>
+    firrtl.strictconnect %baz_a, %bar_b : !firrtl.uint<1>
+    firrtl.layerblock @InstanceCycle {
+      %layer_instance_cycle = firrtl.node %baz_b : !firrtl.uint<1>
+    }
+    // CHECK-NEXT: firrtl.layerblock @InstanceCycle {
+    // CHECK-NEXT:   %bar_a, %bar_b = firrtl.instance bar @Foo(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+    // CHECK-NEXT:   %baz_a, %baz_b = firrtl.instance baz @Foo(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
+    // CHECK-NEXT:   firrtl.strictconnect %bar_a, %baz_b : !firrtl.uint<1>
+    // CHECK-NEXT:   firrtl.strictconnect %baz_a, %bar_b : !firrtl.uint<1>
+    // CHECK-NEXT:   %layer_instance_cycle = firrtl.node %baz_b : !firrtl.uint<1>
+    // CHECK-NEXT: }
+
+    //===------------------------------------------------------------------===//
+    // Check that shared usage blocks sinking.
+    //===------------------------------------------------------------------===//
+    firrtl.layerblock @BlockedSinking {
+      %1 = firrtl.node %a : !firrtl.uint<1>
+      firrtl.layerblock @BlockedSinking::@A {
+        %2 = firrtl.node %1 : !firrtl.uint<1>
+      }
+      firrtl.layerblock @BlockedSinking::@B {
+        %2 = firrtl.node %1 : !firrtl.uint<1>
+      }
+    }
+    // CHECK-NEXT: firrtl.layerblock @BlockedSinking {
+    // CHECK-NEXT:   %[[shared:[_A-Za-z0-9]+]] = firrtl.node %a
+    // CHECK-NEXT:   firrtl.layerblock @BlockedSinking::@A {
+    // CHECK-NEXT:     firrtl.node %[[shared]]
+    // CHECK-NEXT:   }
+    // CHECK-NEXT:   firrtl.layerblock @BlockedSinking::@B {
+    // CHECK-NEXT:     firrtl.node %[[shared]]
+    // CHECK-NEXT:   }
+    // CHECK-NEXT: }
+
+    //===------------------------------------------------------------------===//
+    // Check annotation interactions.
+    //===------------------------------------------------------------------===//
+    %node_dontTouch = firrtl.node %a {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
+    firrtl.layerblock @BlockedSinking {
+      %layer_node_dontTouch = firrtl.node %node_dontTouch : !firrtl.uint<1>
+    }
+    // CHECK-NEXT: %node_dontTouch = firrtl.node %a
+    // CHECK-NEXT: firrtl.layerblock @BlockedSinking {
+    // CHECK-NEXT:   %layer_node_dontTouch = firrtl.node %node_dontTouch
+    // CHECK-NEXT: }
+  }
 }


### PR DESCRIPTION
Modify the LayerSink pass to compute and use the strongly connected components (SCCs) of FIRRTL operations to more aggressively sink operations into layerblocks.

Fixes #6391.

This is stacked on: #6491