### PR TITLE
Bump LLVM

### DIFF
--- a/integration_test/Target/ExportSystemC/basic.mlir
+++ b/integration_test/Target/ExportSystemC/basic.mlir
@@ -74,12 +74,12 @@ systemc.module @emitcEmission () {
     %1 = emitc.apply "&"(%five) : (!emitc.opaque<"int">) -> !emitc.ptr<!emitc.opaque<"int">>
     %2 = emitc.apply "*"(%1) : (!emitc.ptr<!emitc.opaque<"int">>) -> !emitc.opaque<"int">
     %3 = emitc.cast %2: !emitc.opaque<"int"> to !emitc.opaque<"long">
-    emitc.call "printf" (%3) {args=["result: %ld\n", 0 : index]} : (!emitc.opaque<"long">) -> ()
+    emitc.call_opaque "printf" (%3) {args=["result: %ld\n", 0 : index]} : (!emitc.opaque<"long">) -> ()
 
     %idx = systemc.cpp.variable : index
 
     %4 = hw.constant 4 : i32
-    %5 = emitc.call "malloc" (%4) : (i32) -> !emitc.ptr<!emitc.opaque<"void">>
+    %5 = emitc.call_opaque "malloc" (%4) : (i32) -> !emitc.ptr<!emitc.opaque<"void">>
     %6 = emitc.cast %5 : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<!emitc.opaque<"int">>
     %somePtr = systemc.cpp.variable %6 : !emitc.ptr<!emitc.opaque<"int">>
   }

--- a/lib/Dialect/Arc/ArcDialect.cpp
+++ b/lib/Dialect/Arc/ArcDialect.cpp
@@ -39,7 +39,7 @@ struct ArcInlinerInterface : public mlir::DialectInlinerInterface {
     return false;
   }
   void handleTerminator(Operation *op,
-                        ArrayRef<Value> valuesToRepl) const override {
+                        mlir::ValueRange valuesToRepl) const override {
     assert(isa<arc::OutputOp>(op)); // arc does not have another terminator op
     for (auto [from, to] : llvm::zip(valuesToRepl, op->getOperands()))
       from.replaceAllUsesWith(to);

--- a/lib/Dialect/Arc/Transforms/InlineModules.cpp
+++ b/lib/Dialect/Arc/Transforms/InlineModules.cpp
@@ -55,7 +55,7 @@ struct PrefixingInliner : public InlinerInterface {
     return true;
   }
   void handleTerminator(Operation *op,
-                        ArrayRef<Value> valuesToRepl) const override {
+                        mlir::ValueRange valuesToRepl) const override {
     assert(isa<hw::OutputOp>(op));
     for (auto [from, to] : llvm::zip(valuesToRepl, op->getOperands()))
       from.replaceAllUsesWith(to);

--- a/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
+++ b/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
@@ -301,8 +301,8 @@ static Value truncateToMemoryWidth(Location loc, OpBuilder &b, Value v,
 }
 
 static Value plumbLoadPort(Location loc, OpBuilder &b,
-                           const handshake::MemLoadInterface &ldif,
-                           Value loadData, MemRefType memrefType) {
+                           handshake::MemLoadInterface &ldif, Value loadData,
+                           MemRefType memrefType) {
   // We need to feed both the load data and the load done outputs.
   // Fork the extracted load data into two, and 'join' the second one to
   // generate a none-typed output to drive the load done.
@@ -321,8 +321,8 @@ static Value plumbLoadPort(Location loc, OpBuilder &b,
 }
 
 static Value plumbStorePort(Location loc, OpBuilder &b,
-                            const handshake::MemStoreInterface &stif,
-                            Value done, Type outType, MemRefType memrefType) {
+                            handshake::MemStoreInterface &stif, Value done,
+                            Type outType, MemRefType memrefType) {
   stif.doneOut.replaceAllUsesWith(done);
   // Return the store address and data to be fed to the top-level output.
   // Address is truncated to the width of the memory that is accessed.

--- a/test/Target/ExportSystemC/basic.mlir
+++ b/test/Target/ExportSystemC/basic.mlir
@@ -166,28 +166,28 @@ systemc.module @emitcEmission () {
 
     // Test: emit.call without a result is emitted as a statement, having operands and attribute arguments
     // CHECK-NEXT: printf("result: %d, %d\0A", five, 6);
-    emitc.call "printf" (%five) {args=["result: %d, %d\n", 0 : index, 6 : i32]} : (!emitc.opaque<"int">) -> ()
+    emitc.call_opaque "printf" (%five) {args=["result: %d, %d\n", 0 : index, 6 : i32]} : (!emitc.opaque<"int">) -> ()
 
     // Test: emit.call without a result is emitted as a statement and having attribute arguments only
     // CHECK-NEXT: printf("result: %d\0A", 6);
-    emitc.call "printf" () {args=["result: %d\n", 6 : i32]} : () -> ()
+    emitc.call_opaque "printf" () {args=["result: %d\n", 6 : i32]} : () -> ()
 
     // Test: emit.call without a result is emitted as a statement, no operands, no attribute arguments
     // CHECK-NEXT: printf();
-    emitc.call "printf" () : () -> ()
+    emitc.call_opaque "printf" () : () -> ()
 
-    // Test: emitc.call with a result is inlined properly, having operands only
+    // Test: emitc.call_opaque with a result is inlined properly, having operands only
     // CHECK-NEXT: void* v0 = malloc(4);
     %3 = hw.constant 4 : i32
-    %4 = emitc.call "malloc" (%3) : (i32) -> !emitc.ptr<!emitc.opaque<"void">>
+    %4 = emitc.call_opaque "malloc" (%3) : (i32) -> !emitc.ptr<!emitc.opaque<"void">>
     %v0 = systemc.cpp.variable %4 : !emitc.ptr<!emitc.opaque<"void">>
 
-    // Test: emitc.call with a result is inlined properly, attribute arguments only
+    // Test: emitc.call_opaque with a result is inlined properly, attribute arguments only
     // CHECK-NEXT: void* v1 = malloc(4);
-    %5 = emitc.call "malloc" () {args=[4 : i32]}: () -> !emitc.ptr<!emitc.opaque<"void">>
+    %5 = emitc.call_opaque "malloc" () {args=[4 : i32]}: () -> !emitc.ptr<!emitc.opaque<"void">>
     %v1 = systemc.cpp.variable %5 : !emitc.ptr<!emitc.opaque<"void">>
 
-    // Test: emitc.call properly inserts parentheses when an argument has COMMA precedence
+    // Test: emitc.call_opaque properly inserts parentheses when an argument has COMMA precedence
     // TODO: no operation having COMMA precedence supported yet
 
     // Test: emit.cast adds parentheses around the operand when it has higher precedence than the operand
@@ -195,7 +195,7 @@ systemc.module @emitcEmission () {
 
     // Test: emit.cast does not add parentheses around the operand when it has lower precedence than the operand
     // CHECK-NEXT: int* v2 = (int*) malloc(4);
-    %6 = emitc.call "malloc" () {args=[4 : i32]} : () -> !emitc.ptr<!emitc.opaque<"void">>
+    %6 = emitc.call_opaque "malloc" () {args=[4 : i32]} : () -> !emitc.ptr<!emitc.opaque<"void">>
     %7 = emitc.cast %6 : !emitc.ptr<!emitc.opaque<"void">> to !emitc.ptr<!emitc.opaque<"int">>
     %v2 = systemc.cpp.variable %7 : !emitc.ptr<!emitc.opaque<"int">>
 


### PR DESCRIPTION
Includes some updates.

* Similarly to https://github.com/llvm/circt/pull/6489, MLIR removed some uses of `const`: https://github.com/llvm/llvm-project/pull/72765, especially `.replaceAllUsesWith`
* In MLIR emitc, `call` was renamed to `call_opaque`: https://github.com/llvm/llvm-project/pull/72494