### PR TITLE
[FlattenIO] Fix module input and output port name order.

### DIFF
--- a/include/circt/Dialect/HW/HWPasses.h
+++ b/include/circt/Dialect/HW/HWPasses.h
@@ -25,7 +25,8 @@ std::unique_ptr<mlir::Pass> createPrintInstanceGraphPass();
 std::unique_ptr<mlir::Pass> createHWSpecializePass();
 std::unique_ptr<mlir::Pass> createPrintHWModuleGraphPass();
 std::unique_ptr<mlir::Pass> createFlattenIOPass(bool recursiveFlag = true,
-                                                bool flattenExternFlag = false);
+                                                bool flattenExternFlag = false,
+                                                char joinChar = '.');
 std::unique_ptr<mlir::Pass> createVerifyInnerRefNamespacePass();
 
 /// Generate the code for registering passes.

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -39,6 +39,8 @@ def FlattenIO : Pass<"hw-flatten-io", "mlir::ModuleOp"> {
       "Recursively flatten nested structs.">,
     Option<"flattenExtern", "flatten-extern", "bool", "false",
       "Flatten the extern modules also.">,
+    Option<"joinChar", "join-char", "char", "'.'",
+      "Use a custom character to construct the flattened names.">,
   ];
 }
 

--- a/lib/Dialect/HW/Transforms/FlattenIO.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenIO.cpp
@@ -255,7 +255,8 @@ static DenseMap<Operation *, IOTypes> populateIOMap(mlir::ModuleOp module) {
 template <typename ModTy, typename T>
 static llvm::SmallVector<Attribute>
 updateNameAttribute(ModTy op, StringRef attrName,
-                    DenseMap<unsigned, hw::StructType> &structMap, T oldNames) {
+                    DenseMap<unsigned, hw::StructType> &structMap, T oldNames,
+                    char joinChar) {
   llvm::SmallVector<Attribute> newNames;
   for (auto [i, oldName] : llvm::enumerate(oldNames)) {
     // Was this arg/res index a struct?
@@ -270,14 +271,15 @@ updateNameAttribute(ModTy op, StringRef attrName,
     // index.
     auto structType = it->second;
     for (auto field : structType.getElements())
-      newNames.push_back(
-          StringAttr::get(op->getContext(), oldName + "." + field.name.str()));
+      newNames.push_back(StringAttr::get(
+          op->getContext(), oldName + Twine(joinChar) + field.name.str()));
   }
   return newNames;
 }
 
 template <typename ModTy>
-static void updateModulePortNames(ModTy op, hw::ModuleType oldModType) {
+static void updateModulePortNames(ModTy op, hw::ModuleType oldModType,
+                                  char joinChar) {
   // Module arg and result port names may not be ordered. So we cannot reuse
   // updateNameAttribute. The arg and result order must be preserved.
   SmallVector<Attribute> newNames;
@@ -288,7 +290,8 @@ static void updateModulePortNames(ModTy op, hw::ModuleType oldModType) {
     if (auto structType = getStructType(oldPort.type)) {
       for (auto field : structType.getElements()) {
         newNames.push_back(StringAttr::get(
-            op->getContext(), oldName.getValue() + "." + field.name.str()));
+            op->getContext(),
+            oldName.getValue() + Twine(joinChar) + field.name.str()));
       }
     } else
       newNames.push_back(oldName);
@@ -357,7 +360,8 @@ static DenseMap<Operation *, IOInfo> populateIOInfoMap(mlir::ModuleOp module) {
 
 template <typename T>
 static LogicalResult flattenOpsOfType(ModuleOp module, bool recursive,
-                                      StringSet<> &externModules) {
+                                      StringSet<> &externModules,
+                                      char joinChar) {
   auto *ctx = module.getContext();
   FlattenIOTypeConverter typeConverter;
 
@@ -418,7 +422,7 @@ static LogicalResult flattenOpsOfType(ModuleOp module, bool recursive,
     // Update the arg/res names of the module.
     for (auto op : module.getOps<T>()) {
       auto ioInfo = ioInfoMap[op];
-      updateModulePortNames(op, oldModTypes[op]);
+      updateModulePortNames(op, oldModTypes[op], joinChar);
       auto newArgLocs = updateLocAttribute(ioInfo.argStructs, oldArgLocs[op]);
       auto newResLocs = updateLocAttribute(ioInfo.resStructs, oldResLocs[op]);
       newArgLocs.append(newResLocs.begin(), newResLocs.end());
@@ -448,14 +452,16 @@ static LogicalResult flattenOpsOfType(ModuleOp module, bool recursive,
 
       instanceOp.setInputNames(ArrayAttr::get(
           instanceOp.getContext(),
-          updateNameAttribute(instanceOp, "argNames", ioInfo.argStructs,
-                              oldArgNames[targetModule]
-                                  .template getAsValueRange<StringAttr>())));
+          updateNameAttribute(
+              instanceOp, "argNames", ioInfo.argStructs,
+              oldArgNames[targetModule].template getAsValueRange<StringAttr>(),
+              joinChar)));
       instanceOp.setOutputNames(ArrayAttr::get(
           instanceOp.getContext(),
-          updateNameAttribute(instanceOp, "resultNames", ioInfo.resStructs,
-                              oldResNames[targetModule]
-                                  .template getAsValueRange<StringAttr>())));
+          updateNameAttribute(
+              instanceOp, "resultNames", ioInfo.resStructs,
+              oldResNames[targetModule].template getAsValueRange<StringAttr>(),
+              joinChar)));
     }
 
     // Break if we've only lowering a single level of structs.
@@ -471,8 +477,9 @@ static LogicalResult flattenOpsOfType(ModuleOp module, bool recursive,
 
 template <typename... TOps>
 static bool flattenIO(ModuleOp module, bool recursive,
-                      StringSet<> &externModules) {
-  return (failed(flattenOpsOfType<TOps>(module, recursive, externModules)) ||
+                      StringSet<> &externModules, char joinChar) {
+  return (failed(flattenOpsOfType<TOps>(module, recursive, externModules,
+                                        joinChar)) ||
           ...);
 }
 
@@ -480,9 +487,10 @@ namespace {
 
 class FlattenIOPass : public circt::hw::FlattenIOBase<FlattenIOPass> {
 public:
-  FlattenIOPass(bool recursiveFlag, bool flattenExternFlag) {
+  FlattenIOPass(bool recursiveFlag, bool flattenExternFlag, char join) {
     recursive = recursiveFlag;
     flattenExtern = flattenExternFlag;
+    joinChar = join;
   }
 
   void runOnOperation() override {
@@ -491,14 +499,15 @@ public:
       // Record the extern modules, donot flatten them.
       for (auto m : module.getOps<hw::HWModuleExternOp>())
         externModules.insert(m.getModuleName());
-      if (flattenIO<hw::HWModuleOp, hw::HWModuleGeneratedOp>(module, recursive,
-                                                             externModules))
+      if (flattenIO<hw::HWModuleOp, hw::HWModuleGeneratedOp>(
+              module, recursive, externModules, joinChar))
         signalPassFailure();
       return;
     }
 
     if (flattenIO<hw::HWModuleOp, hw::HWModuleExternOp,
-                  hw::HWModuleGeneratedOp>(module, recursive, externModules))
+                  hw::HWModuleGeneratedOp>(module, recursive, externModules,
+                                           joinChar))
       signalPassFailure();
   };
 
@@ -512,6 +521,8 @@ private:
 //===----------------------------------------------------------------------===//
 
 std::unique_ptr<Pass> circt::hw::createFlattenIOPass(bool recursiveFlag,
-                                                     bool flattenExternFlag) {
-  return std::make_unique<FlattenIOPass>(recursiveFlag, flattenExternFlag);
+                                                     bool flattenExternFlag,
+                                                     char joinChar) {
+  return std::make_unique<FlattenIOPass>(recursiveFlag, flattenExternFlag,
+                                         joinChar);
 }

--- a/test/Dialect/HW/flatten-io.mlir
+++ b/test/Dialect/HW/flatten-io.mlir
@@ -1,5 +1,5 @@
 // RUN: circt-opt --hw-flatten-io %s | FileCheck %s -check-prefix BASIC
-// RUN: circt-opt --hw-flatten-io="flatten-extern=true" %s | FileCheck %s -check-prefix EXTERN
+// RUN: circt-opt --hw-flatten-io="flatten-extern=true join-char=_" %s | FileCheck %s -check-prefix EXTERN
 
 // Ensure that non-struct-using modules pass cleanly through the pass.
 
@@ -61,29 +61,30 @@ hw.module @instance(in %arg0 : i32, in %arg1 : !Struct1, out out : !Struct1) {
   hw.output %0#1 : !Struct1
 }
 
-// EXTERN-LABEL: hw.module.extern @level1_extern(in %arg0 : i32, in %in.a : i1, in %in.b : i2, in %arg1 : i32, out out0 : i32, out out.a : i1, out out.b : i2, out out1 : i32)
-// BASIC-LABEL: hw.module.extern @level1_extern(in %arg0 : i32, in %in : !hw.struct<a: i1, b: i2>, in %arg1 : i32, out out0 : i32, out out : !hw.struct<a: i1, b: i2>, out out1 : i32)
-hw.module.extern @level1_extern(in %arg0 : i32, in %in : !Struct1, in %arg1: i32, out out0 : i32, out out: !Struct1, out out1: i32)
+hw.module.extern @level1_extern2(out out1: i32, in %arg0 : i32, out out: !Struct1, in %in : !Struct1, in %arg1: i32, out out0 : i32 )
+// EXTERN-LABEL:  hw.module.extern @level1_extern2
+// EXTERN-SAME: out out1 : i32, in %arg0 : i32, out out_a : i1, out out_b : i2, in %in_a : i1, in %in_b : i2, in %arg1 : i32, out out0 : i32
 
-
-// EXTERN-LABEL: hw.module @instance_extern(in %arg0 : i32, in %arg1.a : i1, in %arg1.b : i2, out out.a : i1, out out.b : i2) {
-// EXTERN-NEXT:   %0 = hw.struct_create (%arg1.a, %arg1.b) : !hw.struct<a: i1, b: i2>
-// EXTERN-NEXT:   %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
-// EXTERN-NEXT:   %l1.out0, %l1.out.a, %l1.out.b, %l1.out1 = hw.instance "l1" @level1_extern(arg0: %arg0: i32, in.a: %a: i1, in.b: %b: i2, arg1: %arg0: i32) -> (out0: i32, out.a: i1, out.b: i2, out1: i32)
-// EXTERN-NEXT:   %1 = hw.struct_create (%l1.out.a, %l1.out.b) : !hw.struct<a: i1, b: i2>
-// EXTERN-NEXT:   %a_0, %b_1 = hw.struct_explode %1 : !hw.struct<a: i1, b: i2>
-// EXTERN-NEXT:   hw.output %a_0, %b_1 : i1, i2
-
-hw.module @instance_extern(in %arg0 : i32, in %arg1 : !Struct1, out out : !Struct1) {
+hw.module @instance_extern2(in %arg0 : i32, in %arg1 : !Struct1, out out : !Struct1) {
   %0:3 = hw.instance "l1" @level1_extern(arg0: %arg0 : i32, in: %arg1 : !Struct1, arg1: %arg0 : i32) -> (out0: i32, out: !Struct1, out1: i32)
   hw.output %0#1 : !Struct1
 }
 
-hw.module.extern @level1_extern2(out out1: i32, in %arg0 : i32, out out: !Struct1, in %in : !Struct1, in %arg1: i32, out out0 : i32 )
-// EXTERN-LABEL:  hw.module.extern @level1_extern2
-// EXTERN-SAME: out out1 : i32, in %arg0 : i32, out out.a : i1, out out.b : i2, in %in.a : i1, in %in.b : i2, in %arg1 : i32, out out0 : i32
+// EXTERN-LABEL: hw.module.extern @level1_extern
+// EXERN-SAME: (in %arg0 : i32, in %in_a : i1, in %in_b : i2, in %arg1 : i32, out out0 : i32, out out_a : i1, out out_b : i2, out out1 : i32)
+// BASIC-LABEL: hw.module.extern @level1_extern(in %arg0 : i32, in %in : !hw.struct<a: i1, b: i2>, in %arg1 : i32, out out0 : i32, out out : !hw.struct<a: i1, b: i2>, out out1 : i32)
+hw.module.extern @level1_extern(in %arg0 : i32, in %in : !Struct1, in %arg1: i32, out out0 : i32, out out: !Struct1, out out1: i32)
 
-hw.module @instance_extern2(in %arg0 : i32, in %arg1 : !Struct1, out out : !Struct1) {
+
+// EXTERN-LABEL: hw.module @instance_extern(in %arg0 : i32, in %arg1_a : i1, in %arg1_b : i2, out out_a : i1, out out_b : i2) {
+// EXTERN-NEXT:   %0 = hw.struct_create (%arg1_a, %arg1_b) : !hw.struct<a: i1, b: i2>
+// EXTERN-NEXT:   %a, %b = hw.struct_explode %0 : !hw.struct<a: i1, b: i2>
+// EXTERN-NEXT:   %l1.out0, %l1.out_a, %l1.out_b, %l1.out1 = hw.instance "l1" @level1_extern(arg0: %arg0: i32, in_a: %a: i1, in_b: %b: i2, arg1: %arg0: i32) -> (out0: i32, out_a: i1, out_b: i2, out1: i32)
+// EXTERN-NEXT:   %1 = hw.struct_create (%l1.out_a, %l1.out_b) : !hw.struct<a: i1, b: i2>
+// EXTERN-NEXT:   %a_0, %b_1 = hw.struct_explode %1 : !hw.struct<a: i1, b: i2>
+// EXTERN-NEXT:   hw.output %a_0, %b_1 : i1, i2
+
+hw.module @instance_extern(in %arg0 : i32, in %arg1 : !Struct1, out out : !Struct1) {
   %0:3 = hw.instance "l1" @level1_extern(arg0: %arg0 : i32, in: %arg1 : !Struct1, arg1: %arg0 : i32) -> (out0: i32, out: !Struct1, out1: i32)
   hw.output %0#1 : !Struct1
 }

--- a/test/Dialect/HW/flatten-io.mlir
+++ b/test/Dialect/HW/flatten-io.mlir
@@ -78,3 +78,12 @@ hw.module @instance_extern(in %arg0 : i32, in %arg1 : !Struct1, out out : !Struc
   %0:3 = hw.instance "l1" @level1_extern(arg0: %arg0 : i32, in: %arg1 : !Struct1, arg1: %arg0 : i32) -> (out0: i32, out: !Struct1, out1: i32)
   hw.output %0#1 : !Struct1
 }
+
+hw.module.extern @level1_extern2(out out1: i32, in %arg0 : i32, out out: !Struct1, in %in : !Struct1, in %arg1: i32, out out0 : i32 )
+// EXTERN-LABEL:  hw.module.extern @level1_extern2
+// EXTERN-SAME: out out1 : i32, in %arg0 : i32, out out.a : i1, out out.b : i2, in %in.a : i1, in %in.b : i2, in %arg1 : i32, out out0 : i32
+
+hw.module @instance_extern2(in %arg0 : i32, in %arg1 : !Struct1, out out : !Struct1) {
+  %0:3 = hw.instance "l1" @level1_extern(arg0: %arg0 : i32, in: %arg1 : !Struct1, arg1: %arg0 : i32) -> (out0: i32, out: !Struct1, out1: i32)
+  hw.output %0#1 : !Struct1
+}


### PR DESCRIPTION
Fix a bug in `FlattenIO`, it was incorrectly reordering the input and output port name attributes of a module.