### PR TITLE
[firtool] Add option to treat EICG_wrapper as intrinsic

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -60,7 +60,8 @@ std::unique_ptr<mlir::Pass> createLowerBundleVectorTypesPass();
 
 std::unique_ptr<mlir::Pass> createLowerCHIRRTLPass();
 
-std::unique_ptr<mlir::Pass> createLowerIntrinsicsPass();
+std::unique_ptr<mlir::Pass>
+createLowerIntrinsicsPass(bool fixupEICGWrapper = false);
 
 std::unique_ptr<mlir::Pass> createIMConstPropPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -666,6 +666,10 @@ def LowerIntrinsics : Pass<"firrtl-lower-intrinsics", "firrtl::CircuitOp"> {
     intmodule to their implementation or op.
   }];
   let constructor = "circt::firrtl::createLowerIntrinsicsPass()";
+  let options = [
+    Option<"fixupEICGWrapper", "fixup-eicg-wrapper", "bool", "false",
+      "Lower `EICG_wrapper` modules into clock gate intrinsics">,
+  ];
 }
 
 def LowerOpenAggs : Pass<"firrtl-lower-open-aggs", "firrtl::CircuitOp"> {

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -128,6 +128,7 @@ public:
     return addVivadoRAMAddressConflictSynthesisBugWorkaround;
   }
   bool shouldExtractTestCode() const { return extractTestCode; }
+  bool shouldFixupEICGWrapper() const { return fixupEICGWrapper; }
 
   // Setters, used by the CAPI
   FirtoolOptions &setOutputFilename(StringRef name) {
@@ -343,6 +344,11 @@ public:
     return *this;
   }
 
+  FirtoolOptions &setFixupEICGWrapper(bool value) {
+    fixupEICGWrapper = value;
+    return *this;
+  }
+
 private:
   std::string outputFilename;
   bool disableAnnotationsUnknown;
@@ -387,6 +393,7 @@ private:
   bool exportModuleHierarchy;
   bool stripFirDebugInfo;
   bool stripDebugInfo;
+  bool fixupEICGWrapper;
 };
 
 void registerFirtoolCLOptions();

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -35,6 +35,7 @@ using namespace firrtl;
 namespace {
 struct LowerIntrinsicsPass : public LowerIntrinsicsBase<LowerIntrinsicsPass> {
   void runOnOperation() override;
+  using LowerIntrinsicsBase::fixupEICGWrapper;
 };
 } // end anonymous namespace
 
@@ -262,6 +263,36 @@ static bool lowerCirctClockGate(InstanceGraph &ig, FModuleLike mod) {
     inst.getResult(1).replaceAllUsesWith(en);
     auto out = builder.create<ClockGateIntrinsicOp>(in, en, Value{});
     inst.getResult(2).replaceAllUsesWith(out);
+    inst.erase();
+  }
+  return true;
+}
+
+static bool lowerEICGWrapperToClockGate(InstanceGraph &ig, FModuleLike mod) {
+  if (hasNPorts("EICG_wrapper", mod, 4) ||
+      namedPort("EICG_wrapper", mod, 0, "in") ||
+      namedPort("EICG_wrapper", mod, 1, "test_en") ||
+      namedPort("EICG_wrapper", mod, 2, "en") ||
+      namedPort("EICG_wrapper", mod, 3, "out") ||
+      typedPort<ClockType>("EICG_wrapper", mod, 0) ||
+      sizedPort<UIntType>("EICG_wrapper", mod, 1, 1) ||
+      sizedPort<UIntType>("EICG_wrapper", mod, 2, 1) ||
+      typedPort<ClockType>("EICG_wrapper", mod, 3) ||
+      hasNParam("EICG_wrapper", mod, 0))
+    return false;
+
+  for (auto *use : ig.lookup(mod)->uses()) {
+    auto inst = cast<InstanceOp>(use->getInstance().getOperation());
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto in = builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    auto testEn =
+        builder.create<WireOp>(inst.getResult(1).getType()).getResult();
+    auto en = builder.create<WireOp>(inst.getResult(2).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(in);
+    inst.getResult(1).replaceAllUsesWith(testEn);
+    inst.getResult(2).replaceAllUsesWith(en);
+    auto out = builder.create<ClockGateIntrinsicOp>(in, en, testEn);
+    inst.getResult(3).replaceAllUsesWith(out);
     inst.erase();
   }
   return true;
@@ -632,6 +663,7 @@ std::pair<const char *, std::function<bool(InstanceGraph &, FModuleLike)>>
         {"circt_plusargs_value", lowerCirctPlusArgValue},
         {"circt.clock_gate", lowerCirctClockGate},
         {"circt_clock_gate", lowerCirctClockGate},
+        {"EICG_wrapper", lowerEICGWrapperToClockGate}, // remove once EICG gone
         {"circt.ltl.and", lowerCirctLTLAnd},
         {"circt_ltl_and", lowerCirctLTLAnd},
         {"circt.ltl.or", lowerCirctLTLOr},
@@ -674,15 +706,21 @@ void LowerIntrinsicsPass::runOnOperation() {
     if (!isa<FExtModuleOp, FIntModuleOp>(op))
       continue;
     StringAttr intname;
-    if (isa<FExtModuleOp>(op)) {
-      auto anno = AnnotationSet(&op).getAnnotation("circt.Intrinsic");
-      if (!anno)
-        continue;
-      intname = anno.getMember<StringAttr>("intrinsic");
-      if (!intname) {
-        op.emitError("intrinsic annotation with no intrinsic name");
-        ++numFailures;
-        continue;
+    if (auto extMod = dyn_cast<FExtModuleOp>(op)) {
+      if (fixupEICGWrapper && extMod.getDefname() == "EICG_wrapper") {
+        // Remove this once `EICG_wrapper` is no longer special-cased by
+        // firtool.
+        intname = extMod.getDefnameAttr();
+      } else {
+        auto anno = AnnotationSet(&op).getAnnotation("circt.Intrinsic");
+        if (!anno)
+          continue;
+        intname = anno.getMember<StringAttr>("intrinsic");
+        if (!intname) {
+          op.emitError("intrinsic annotation with no intrinsic name");
+          ++numFailures;
+          continue;
+        }
       }
     } else {
       intname = cast<FIntModuleOp>(op).getIntrinsicAttr();
@@ -718,6 +756,9 @@ void LowerIntrinsicsPass::runOnOperation() {
 }
 
 /// This is the pass constructor.
-std::unique_ptr<mlir::Pass> circt::firrtl::createLowerIntrinsicsPass() {
-  return std::make_unique<LowerIntrinsicsPass>();
+std::unique_ptr<mlir::Pass>
+circt::firrtl::createLowerIntrinsicsPass(bool fixupEICGWrapper) {
+  auto pass = std::make_unique<LowerIntrinsicsPass>();
+  pass->fixupEICGWrapper = fixupEICGWrapper;
+  return pass;
 }

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -45,7 +45,8 @@ LogicalResult firtool::populatePreprocessTransforms(mlir::PassManager &pm,
 LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
                                                   const FirtoolOptions &opt,
                                                   StringRef inputFilename) {
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerIntrinsicsPass());
+  pm.nest<firrtl::CircuitOp>().addPass(
+      firrtl::createLowerIntrinsicsPass(opt.shouldFixupEICGWrapper()));
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInjectDUTHierarchyPass());
 
@@ -647,6 +648,11 @@ struct FirtoolCmdOptions {
       "strip-debug-info",
       llvm::cl::desc("Disable source locator information in output Verilog"),
       llvm::cl::init(false)};
+
+  llvm::cl::opt<bool> fixupEICGWrapper{
+      "fixup-eicg-wrapper",
+      llvm::cl::desc("Lower `EICG_wrapper` modules into clock gate intrinsics"),
+      llvm::cl::init(false)};
 };
 } // namespace
 
@@ -682,7 +688,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       ckgModuleName("EICG_wrapper"), ckgInputName("in"), ckgOutputName("out"),
       ckgEnableName("en"), ckgTestEnableName("test_en"), ckgInstName("ckg"),
       exportModuleHierarchy(false), stripFirDebugInfo(true),
-      stripDebugInfo(false) {
+      stripDebugInfo(false), fixupEICGWrapper(false) {
   if (!clOptions.isConstructed())
     return;
   outputFilename = clOptions->outputFilename;
@@ -729,4 +735,5 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   exportModuleHierarchy = clOptions->exportModuleHierarchy;
   stripFirDebugInfo = clOptions->stripFirDebugInfo;
   stripDebugInfo = clOptions->stripDebugInfo;
+  fixupEICGWrapper = clOptions->fixupEICGWrapper;
 }


### PR DESCRIPTION
Add the `--fixup-eicg-wrapper` option to firtool and the LowerIntrinsics pass. Setting the option will treat `EICG_wrapper` modules like an intrinsic and replace them with the `firrtl.int.clock_gate` operation.

In the long run, Chisel/FIRRTL designs will directly emit the clock gate intrinsic, and `EICG_wrapper` extmodules will be gone. However until we get there, this option provides an incremental path towards deprecating the `EICG_wrapper` pattern. It allows us to switch the CIRCT side of the flow over to the intrinsic without having to make changes to Chisel in lockstep. Once all relevant existing designs work with this switch enabled, Chisel projects can opt into emitting clock gates directly, and can gradually upgrade. At that point we can make firtool emit deprecation warnings for uses of `EICG_wrapper` extmodules, and at some point we can entirely drop special handling of these modules altogether.

This switch is disabled by default and does not affect existing flows.