### PR TITLE
[CombToArith] Fix lowering of concat with single operand

### DIFF
--- a/lib/Conversion/CombToArith/CombToArith.cpp
+++ b/lib/Conversion/CombToArith/CombToArith.cpp
@@ -139,21 +139,30 @@ struct ConcatOpConversion : OpConversionPattern<ConcatOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Type type = op.getResult().getType();
     Location loc = op.getLoc();
-    unsigned nextInsertion = type.getIntOrFloatBitWidth();
 
+    // Handle the trivial case where we have only one operand. The concat is a
+    // no-op in this case.
+    if (op.getNumOperands() == 1) {
+      rewriter.replaceOp(op, adaptor.getOperands().back());
+      return success();
+    }
+
+    // The operand at the least significant bit position (the one all the way on
+    // the right at the highest index) does not need to be shifted and can just
+    // be zero-extended to the final bit width.
     Value aggregate =
-        rewriter.create<arith::ConstantOp>(loc, IntegerAttr::get(type, 0));
+        rewriter.createOrFold<ExtUIOp>(loc, type, adaptor.getOperands().back());
 
-    for (unsigned i = 0, e = op.getNumOperands(); i < e; i++) {
-      nextInsertion -=
-          adaptor.getOperands()[i].getType().getIntOrFloatBitWidth();
-
-      Value nextInsValue = rewriter.create<arith::ConstantOp>(
-          loc, IntegerAttr::get(type, nextInsertion));
-      Value extended =
-          rewriter.create<ExtUIOp>(loc, type, adaptor.getOperands()[i]);
-      Value shifted = rewriter.create<ShLIOp>(loc, extended, nextInsValue);
-      aggregate = rewriter.create<OrIOp>(loc, aggregate, shifted);
+    // Shift and OR all the other operands onto the aggregate. Skip the last
+    // operand because it has already been incorporated into the aggregate.
+    unsigned offset = type.getIntOrFloatBitWidth();
+    for (auto operand : adaptor.getOperands().drop_back()) {
+      offset -= operand.getType().getIntOrFloatBitWidth();
+      auto offsetConst = rewriter.create<arith::ConstantOp>(
+          loc, IntegerAttr::get(type, offset));
+      auto extended = rewriter.createOrFold<ExtUIOp>(loc, type, operand);
+      auto shifted = rewriter.createOrFold<ShLIOp>(loc, extended, offsetConst);
+      aggregate = rewriter.createOrFold<OrIOp>(loc, aggregate, shifted);
     }
 
     rewriter.replaceOp(op, aggregate);

--- a/test/Conversion/CombToArith/comb-to-arith.mlir
+++ b/test/Conversion/CombToArith/comb-to-arith.mlir
@@ -75,30 +75,30 @@ hw.module @test(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32, in %
   // CHECK-NEXT: arith.trunci [[V0]] : i32 to i16
   %28 = comb.extract %arg0 from 5 : (i32) -> i16
 
-  // CHECK-NEXT: %c0_i64 = arith.constant 0 : i64
-  // CHECK-NEXT: %c32_i64 = arith.constant 32 : i64
-  // CHECK-NEXT: [[V1:%.+]] = arith.extui %arg0 : i32 to i64
-  // CHECK-NEXT: [[V2:%.+]] = arith.shli [[V1]], %c32_i64 : i64
-  // CHECK-NEXT: [[V3:%.+]] = arith.ori %c0_i64, [[V2]] : i64
-  // CHECK-NEXT: %c0_i64_0 = arith.constant 0 : i64
-  // CHECK-NEXT: [[V4:%.+]] = arith.extui %arg1 : i32 to i64
-  // CHECK-NEXT: [[V5:%.+]] = arith.shli [[V4]], %c0_i64_0 : i64
-  // CHECK-NEXT: arith.ori [[V3]], [[V5]] : i64
+  // CHECK-NEXT: [[AGG0:%.+]] = arith.extui %arg1 : i32 to i64
+  // CHECK-NEXT: [[C32:%.+]] = arith.constant 32 : i64
+  // CHECK-NEXT: [[V0:%.+]] = arith.extui %arg0 : i32 to i64
+  // CHECK-NEXT: [[V1:%.+]] = arith.shli [[V0]], [[C32]] : i64
+  // CHECK-NEXT: [[AGG1:%.+]] = arith.ori [[AGG0]], [[V1]] : i64
   %29 = comb.concat %arg0, %arg1 : i32, i32
 
   // CHECK-NEXT: arith.extsi %arg4 : i1 to i32
   %30 = comb.replicate %arg4 : (i1) -> i32
 
-  // CHECK-NEXT: [[C0:%.+]] = arith.constant 0 : i64
-  // CHECK-NEXT: [[C1:%.+]] = arith.constant 32 : i64
-  // CHECK-NEXT: [[V1:%.+]] = arith.extui %arg0 : i32 to i64
-  // CHECK-NEXT: [[V2:%.+]] = arith.shli [[V1]], [[C1]] : i64
-  // CHECK-NEXT: [[V3:%.+]] = arith.ori [[C0]], [[V2]] : i64
-  // CHECK-NEXT: [[C2:%.+]] = arith.constant 0 : i64
-  // CHECK-NEXT: [[V4:%.+]] = arith.extui %arg0 : i32 to i64
-  // CHECK-NEXT: [[V5:%.+]] = arith.shli [[V4]], [[C2]] : i64
-  // CHECK-NEXT: arith.ori [[V3]], [[V5]] : i64
+  // CHECK-NEXT: [[AGG0:%.+]] = arith.extui %arg0 : i32 to i64
+  // CHECK-NEXT: [[C32:%.+]] = arith.constant 32 : i64
+  // CHECK-NEXT: [[V0:%.+]] = arith.extui %arg0 : i32 to i64
+  // CHECK-NEXT: [[V1:%.+]] = arith.shli [[V0]], [[C32]] : i64
+  // CHECK-NEXT: [[AGG1:%.+]] = arith.ori [[AGG0]], [[V1]] : i64
   %31 = comb.replicate %arg0 : (i32) -> i64
+
+  // The following used to trigger the arith.extui verifier.
+  // CHECK-NEXT: scf.execute_region
+  // CHECK-NEXT: scf.yield %arg0 : i32
+  scf.execute_region -> i32 {
+    %32 = comb.concat %arg0 : i32
+    scf.yield %32 : i32
+  }
 }
 
 // CHECK-LABEL: @shlTest


### PR DESCRIPTION
A `comb.concat` operation with only a single operand would cause an `arith.extui` to be emitted with the same operand and result type. This trips the verifier of `extui`. Add a special case to that conversion to simply remove the `comb.concat` if it only has one operand.

The canonicalizer would usually delete these degenerate concats, which is why we haven't seen this issue earlier.

Also slightly tweak the lowering to produce a shift and or op for the least significant operand of the concat, which is already in the right spot.