### PR TITLE
[Arc] Partially enable reset/enable detection

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.h
+++ b/include/circt/Dialect/Arc/ArcPasses.h
@@ -33,7 +33,6 @@ std::unique_ptr<mlir::Pass> createDedupPass();
 std::unique_ptr<mlir::Pass> createGroupResetsAndEnablesPass();
 std::unique_ptr<mlir::Pass>
 createInferMemoriesPass(const InferMemoriesOptions &options = {});
-std::unique_ptr<mlir::Pass> createInferStatePropertiesPass();
 std::unique_ptr<mlir::Pass> createInlineArcsPass();
 std::unique_ptr<mlir::Pass> createInlineModulesPass();
 std::unique_ptr<mlir::Pass> createIsolateClocksPass();

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -114,8 +114,21 @@ def InlineModules : Pass<"arc-inline-modules", "mlir::ModuleOp"> {
 def InferStateProperties : Pass<"arc-infer-state-properties",
                                 "mlir::ModuleOp"> {
   let summary = "Add resets and enables explicitly to the state operations";
-  let constructor = "circt::arc::createInferStatePropertiesPass()";
   let dependentDialects = ["circt::hw::HWDialect", "circt::comb::CombDialect"];
+  let options = [
+    Option<"detectEnables", "enables", "bool", "true", "Infer enable signals">,
+    Option<"detectResets", "resets", "bool", "true", "Infer reset signals">,
+  ];
+  let statistics = [
+    Statistic<"addedEnables", "added-enables",
+      "Enables added explicitly to a StateOp">,
+    Statistic<"addedResets", "added-resets",
+      "Resets added explicitly to a StateOp">,
+    Statistic<"missedEnables", "missed-enables",
+      "Detected enables that could not be added explicitly to a StateOp">,
+    Statistic<"missedResets", "missed-resets",
+      "Detected resets that could not be added explicitly to a StateOp">,
+  ];
 }
 
 def IsolateClocks : Pass<"arc-isolate-clocks", "mlir::ModuleOp"> {

--- a/lib/Dialect/Arc/Transforms/InferStateProperties.cpp
+++ b/lib/Dialect/Arc/Transforms/InferStateProperties.cpp
@@ -380,25 +380,12 @@ EnableInfo computeEnableInfoFromPattern(OpOperand &output, StateOp stateOp) {
 
 namespace {
 struct InferStatePropertiesPass
-    : public arc::impl::InferStatePropertiesBase<InferStatePropertiesPass> {
-  InferStatePropertiesPass() = default;
-  InferStatePropertiesPass(const InferStatePropertiesPass &pass)
-      : InferStatePropertiesPass() {}
+    : public impl::InferStatePropertiesBase<InferStatePropertiesPass> {
+  using InferStatePropertiesBase::InferStatePropertiesBase;
 
   void runOnOperation() override;
   void runOnStateOp(arc::StateOp stateOp, arc::DefineOp arc,
                     DenseMap<arc::DefineOp, unsigned> &resetConditionMap);
-
-  Statistic addedEnables{this, "added-enables",
-                         "Enables added explicitly to a StateOp"};
-  Statistic addedResets{this, "added-resets",
-                        "Resets added explicitly to a StateOp"};
-  Statistic missedEnables{
-      this, "missed-enables",
-      "Detected enables that could not be added explicitly to a StateOp"};
-  Statistic missedResets{
-      this, "missed-resets",
-      "Detected resets that could not be added explicitly to a StateOp"};
 };
 } // namespace
 
@@ -422,56 +409,56 @@ void InferStatePropertiesPass::runOnStateOp(
     return;
 
   auto outputOp = cast<arc::OutputOp>(arc.getBodyBlock().getTerminator());
-  const unsigned visitedNoChange = -1;
+  static constexpr unsigned visitedNoChange = -1;
 
-  // Check for reset patterns, we only have to do this once per arc::DefineOp
-  // and store the result for later arc::StateOps referring to the same arc.
-  if (!resetConditionMap.count(arc)) {
-    SmallVector<ResetInfo> resetInfos;
-    int numResets = 0;
-    ;
-    for (auto &output : outputOp->getOpOperands()) {
-      auto resetInfo = computeResetInfoFromPattern(output);
-      resetInfos.push_back(resetInfo);
-      if (resetInfo)
-        ++numResets;
+  if (detectResets) {
+    // Check for reset patterns, we only have to do this once per arc::DefineOp
+    // and store the result for later arc::StateOps referring to the same arc.
+    if (!resetConditionMap.count(arc)) {
+      SmallVector<ResetInfo> resetInfos;
+      int numResets = 0;
+      ;
+      for (auto &output : outputOp->getOpOperands()) {
+        auto resetInfo = computeResetInfoFromPattern(output);
+        resetInfos.push_back(resetInfo);
+        if (resetInfo)
+          ++numResets;
+      }
+
+      // Rewrite the arc::DefineOp if valid
+      auto result = applyResetTransformation(arc, resetInfos);
+      if ((succeeded(result) && resetInfos[0]))
+        resetConditionMap[arc] = resetInfos[0].condition.getArgNumber();
+      else
+        resetConditionMap[arc] = visitedNoChange;
+
+      if (failed(result))
+        missedResets += numResets;
     }
 
-    // Rewrite the arc::DefineOp if valid
-    auto result = applyResetTransformation(arc, resetInfos);
-    if ((succeeded(result) && resetInfos[0]))
-      resetConditionMap[arc] = resetInfos[0].condition.getArgNumber();
+    // Apply resets to the state operation.
+    if (resetConditionMap.count(arc) &&
+        resetConditionMap[arc] != visitedNoChange) {
+      setResetOperandOfStateOp(stateOp, resetConditionMap[arc]);
+      ++addedResets;
+    }
+  }
+
+  if (detectEnables) {
+    // Check for enable patterns.
+    SmallVector<EnableInfo> enableInfos;
+    int numEnables = 0;
+    for (OpOperand &output : outputOp->getOpOperands()) {
+      auto enableInfo = computeEnableInfoFromPattern(output, stateOp);
+      enableInfos.push_back(enableInfo);
+      if (enableInfo)
+        ++numEnables;
+    }
+
+    // Apply enable patterns.
+    if (!failed(applyEnableTransformation(arc, stateOp, enableInfos)))
+      ++addedEnables;
     else
-      resetConditionMap[arc] = visitedNoChange;
-
-    if (failed(result))
-      missedResets += numResets;
+      missedEnables += numEnables;
   }
-
-  // Apply resets to the state operation.
-  if (resetConditionMap.count(arc) &&
-      resetConditionMap[arc] != visitedNoChange) {
-    setResetOperandOfStateOp(stateOp, resetConditionMap[arc]);
-    ++addedResets;
-  }
-
-  // Check for enable patterns.
-  SmallVector<EnableInfo> enableInfos;
-  int numEnables = 0;
-  for (OpOperand &output : outputOp->getOpOperands()) {
-    auto enableInfo = computeEnableInfoFromPattern(output, stateOp);
-    enableInfos.push_back(enableInfo);
-    if (enableInfo)
-      ++numEnables;
-  }
-
-  // Apply enable patterns.
-  if (!failed(applyEnableTransformation(arc, stateOp, enableInfos)))
-    ++addedEnables;
-  else
-    missedEnables += numEnables;
-}
-
-std::unique_ptr<Pass> arc::createInferStatePropertiesPass() {
-  return std::make_unique<InferStatePropertiesPass>();
 }

--- a/lib/Dialect/Arc/Transforms/InferStateProperties.cpp
+++ b/lib/Dialect/Arc/Transforms/InferStateProperties.cpp
@@ -417,7 +417,6 @@ void InferStatePropertiesPass::runOnStateOp(
     if (!resetConditionMap.count(arc)) {
       SmallVector<ResetInfo> resetInfos;
       int numResets = 0;
-      ;
       for (auto &output : outputOp->getOpOperands()) {
         auto resetInfo = computeResetInfoFromPattern(output);
         resetInfos.push_back(resetInfo);


### PR DESCRIPTION
Enable the `InferStateProperties` pass in the arcilator pipeline and make its enable and reset signal detection individually controllable. The enable portion is already supported by the rest of the arcilator pipeline and can produce 20%-35% speedup on the cores in arc-tests.Turn on enable detection by default.

The reset portion is not fully supported yet and causes the simulation to misbehave. It is disabled by default.

As a minor refactoring this removes the `constructor` field from the pass definition, such that the constructor and plumbing for options gets generated automatically. As a side effect, the constructor is now called `arc::createInferStateProperties` instead of the previous `arc::createInferStatePropertiesPass`. (Thanks @uenoku for the pointer.)

Shoutout to @maerhart and @TaoBi22 for this fantastic pass!