### PR TITLE
[FIRRTL] Add a pass to specialize instance choices

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -198,6 +198,8 @@ std::unique_ptr<mlir::Pass> createMaterializeDebugInfoPass();
 
 std::unique_ptr<mlir::Pass> createLintingPass();
 
+std::unique_ptr<mlir::Pass> createSpecializeOptionPass();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -96,7 +96,7 @@ def LowerFIRRTLTypes : Pass<"firrtl-lower-types", "firrtl::CircuitOp"> {
 def LowerSignatures : Pass<"firrtl-lower-signatures", "firrtl::CircuitOp"> {
   let summary = "Lower FIRRTL module signatures";
   let description = [{
-    Lower aggregate FIRRTL types in Modules as indicated by the calling 
+    Lower aggregate FIRRTL types in Modules as indicated by the calling
     convention.
   }];
   let constructor = "circt::firrtl::createLowerSignaturesPass()";
@@ -848,6 +848,26 @@ def Lint :
     inferred to be false. The pass emits error on such failing ops.
   }];
   let constructor = "circt::firrtl::createLintingPass()";
+}
+
+def SpecializeOption :
+    Pass<"firrtl-specialize-option", "firrtl::CircuitOp"> {
+  let summary = "Specialize a configurable design for a given option.";
+  let description = [{
+    If the design has option groups, instead of preserving the information
+    up to the emitted SystemVerilog, this pass specializes it early on for a
+    given choice.
+  }];
+  let constructor = "circt::firrtl::createSpecializeOptionPass()";
+
+  let options = [
+    ListOption<"select", "select", "std::string", 
+               "Options to specialize, in option=case format">,
+  ];
+  let statistics = [
+    Statistic<"numInstances", "num-instances",
+      "Number of instances specialized">
+  ];
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -51,6 +51,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   ResolvePaths.cpp
   ResolveTraces.cpp
   SFCCompat.cpp
+  SpecializeOption.cpp
   VBToBV.cpp
   Vectorization.cpp
   WireDFT.cpp

--- a/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
@@ -1,0 +1,91 @@
+//===- SpecializeOption.cpp -------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Threading.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+struct SpecializeOptionPass
+    : public SpecializeOptionBase<SpecializeOptionPass> {
+  using SpecializeOptionBase::numInstances;
+  using SpecializeOptionBase::select;
+
+  void runOnOperation() override {
+    auto circuit = getOperation();
+    if (select.empty()) {
+      markAllAnalysesPreserved();
+      return;
+    }
+
+    DenseMap<StringAttr, OptionCaseOp> selected;
+    for (const auto &optionAndCase : select) {
+      size_t eq = optionAndCase.find("=");
+      if (eq == std::string::npos) {
+        mlir::emitError(circuit.getLoc(),
+                        "invalid option format: \"" + optionAndCase + '"');
+        return signalPassFailure();
+      }
+
+      std::string optionName = optionAndCase.substr(0, eq);
+      auto optionOp = circuit.lookupSymbol<OptionOp>(optionName);
+      if (!optionOp) {
+        mlir::emitWarning(circuit.getLoc(), "unknown option \"")
+            << optionName << '"';
+        continue;
+      }
+
+      std::string caseName = optionAndCase.substr(eq + 1);
+      auto caseOp = optionOp.lookupSymbol<OptionCaseOp>(caseName);
+      if (!caseOp) {
+        mlir::emitWarning(circuit.getLoc(), "invalid option case \"")
+            << caseName << '"';
+        continue;
+      }
+      selected[StringAttr::get(&getContext(), optionName)] = caseOp;
+    }
+
+    bool failed = false;
+    mlir::parallelForEach(
+        &getContext(), circuit.getOps<FModuleOp>(), [&](auto module) {
+          module.walk([&](firrtl::InstanceChoiceOp inst) {
+            auto it = selected.find(inst.getOptionNameAttr());
+            if (it == selected.end()) {
+              inst.emitError("missing specialization for option ")
+                  << inst.getOptionNameAttr();
+              failed = true;
+              return;
+            }
+
+            ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+            auto newInst = builder.create<InstanceOp>(
+                inst->getResultTypes(), inst.getTargetOrDefaultAttr(it->second),
+                inst.getNameAttr(), inst.getNameKindAttr(),
+                inst.getPortDirectionsAttr(), inst.getPortNamesAttr(),
+                inst.getAnnotationsAttr(), inst.getPortAnnotationsAttr(),
+                UnitAttr{}, inst.getInnerSymAttr());
+            inst.replaceAllUsesWith(newInst);
+            inst.erase();
+
+            ++numInstances;
+          });
+        });
+
+    if (failed)
+      signalPassFailure();
+  }
+};
+} // namespace
+
+std::unique_ptr<Pass> firrtl::createSpecializeOptionPass() {
+  return std::make_unique<SpecializeOptionPass>();
+}

--- a/test/Dialect/FIRRTL/specialize-option-errors.mlir
+++ b/test/Dialect/FIRRTL/specialize-option-errors.mlir
@@ -1,0 +1,18 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-specialize-option{select=Platform=SuperDuperSystem,Bad=Dummy,worst}))' --verify-diagnostics %s
+
+// expected-warning @below {{invalid option case "SuperDuperSystem"}}
+// expected-warning @below {{unknown option "Bad"}}
+// expected-error @below {{invalid option format: "worst"}}
+firrtl.circuit "Foo" {
+
+firrtl.option @Platform {
+  firrtl.option_case @FPGA
+  firrtl.option_case @ASIC
+}
+
+firrtl.option @Performance {
+  firrtl.option_case @Fast
+  firrtl.option_case @Small
+}
+
+}

--- a/test/Dialect/FIRRTL/specialize-option-omit.mlir
+++ b/test/Dialect/FIRRTL/specialize-option-omit.mlir
@@ -1,0 +1,30 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-specialize-option{select=Platform=FPGA}))' --verify-diagnostics %s
+
+firrtl.circuit "Foo" {
+firrtl.option @Platform {
+  firrtl.option_case @FPGA
+  firrtl.option_case @ASIC
+}
+firrtl.option @Performance {
+  firrtl.option_case @Fast
+  firrtl.option_case @Small
+}
+
+firrtl.module private @DefaultTarget() {}
+firrtl.module private @FPGATarget() {}
+firrtl.module private @ASICTarget() {}
+firrtl.module private @FastTarget() {}
+
+firrtl.module @Foo() {
+  firrtl.instance_choice inst_fpga @DefaultTarget alternatives @Platform
+    { @FPGA -> @FPGATarget, @ASIC -> @ASICTarget } ()
+
+  firrtl.instance_choice inst_default @DefaultTarget alternatives @Platform
+    { @ASIC -> @ASICTarget } ()
+
+  // expected-error @below {{missing specialization for option "Performance"}}
+  firrtl.instance_choice inst_perf @DefaultTarget alternatives @Performance
+    { @Fast -> @FastTarget } ()
+}
+
+}

--- a/test/Dialect/FIRRTL/specialize-option.mlir
+++ b/test/Dialect/FIRRTL/specialize-option.mlir
@@ -1,0 +1,34 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-specialize-option{select=Platform=FPGA,Performance=Fast}))' %s | FileCheck %s
+
+
+firrtl.circuit "Foo" {
+firrtl.option @Platform {
+  firrtl.option_case @FPGA
+  firrtl.option_case @ASIC
+}
+firrtl.option @Performance {
+  firrtl.option_case @Fast
+  firrtl.option_case @Small
+}
+
+firrtl.module private @DefaultTarget() {}
+firrtl.module private @FPGATarget() {}
+firrtl.module private @ASICTarget() {}
+firrtl.module private @FastTarget() {}
+
+// CHECK-LABEL: firrtl.module @Foo
+firrtl.module @Foo() {
+  // CHECK: firrtl.instance inst_fpga @FPGATarget()
+  firrtl.instance_choice inst_fpga @DefaultTarget alternatives @Platform
+    { @FPGA -> @FPGATarget, @ASIC -> @ASICTarget } ()
+
+  // CHECK: firrtl.instance inst_default @DefaultTarget()
+  firrtl.instance_choice inst_default @DefaultTarget alternatives @Platform
+    { @ASIC -> @ASICTarget } ()
+
+  // CHECK: firrtl.instance inst_perf @FastTarget()
+  firrtl.instance_choice inst_perf @DefaultTarget alternatives @Performance
+    { @Fast -> @FastTarget } ()
+}
+
+}


### PR DESCRIPTION
The `SpecializeOptions` pass eliminates instance choices and replaces them with instances targeting the modules associated with a case provided through the options.