### PR TITLE
[Arc] Add support for struct and array states

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -527,7 +527,7 @@ def StateReadOp : ArcOp<"state_read", [
 ]> {
   let summary = "Get a state's current value";
   let arguments = (ins StateType:$state);
-  let results = (outs AnyInteger:$value);
+  let results = (outs AnyType:$value);
   let assemblyFormat = [{
     $state attr-dict `:` type($state)
   }];
@@ -551,7 +551,7 @@ def StateWriteOp : ArcOp<"state_write", [
     immediately without affecting correctness. This allows later lowering passes
     to treat `arc.state_write` as an immediate assignment (without defering).
   }];
-  let arguments = (ins StateType:$state, AnyInteger:$value,
+  let arguments = (ins StateType:$state, AnyType:$value,
                        Optional<I1>:$condition);
   let assemblyFormat = [{
     $state `=` $value (`if` $condition^)? attr-dict `:` type($state)

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -16,16 +16,17 @@ class ArcTypeDef<string name> : TypeDef<ArcDialect, name> { }
 
 def StateType : ArcTypeDef<"State"> {
   let mnemonic = "state";
-  let parameters = (ins "::mlir::IntegerType":$type);
+  let parameters = (ins "::mlir::Type":$type);
   let assemblyFormat = "`<` $type `>`";
+  let genVerifyDecl = 1;
   let builders = [
-    AttrBuilderWithInferredContext<(ins "::mlir::IntegerType":$type), [{
+    AttrBuilderWithInferredContext<(ins "::mlir::Type":$type), [{
       return $_get(type.getContext(), type);
     }]>
   ];
 
   let extraClassDeclaration = [{
-    unsigned getBitWidth() { return getType().getWidth(); }
+    unsigned getBitWidth();
     unsigned getByteWidth() { return (getBitWidth() + 7) / 8; }
   }];
 }

--- a/lib/Dialect/Arc/ArcTypes.cpp
+++ b/lib/Dialect/Arc/ArcTypes.cpp
@@ -8,6 +8,7 @@
 
 #include "circt/Dialect/Arc/ArcTypes.h"
 #include "circt/Dialect/Arc/ArcDialect.h"
+#include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/Seq/SeqTypes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -19,6 +20,17 @@ using namespace mlir;
 
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/Arc/ArcTypes.cpp.inc"
+
+unsigned StateType::getBitWidth() { return hw::getBitWidth(getType()); }
+
+LogicalResult
+StateType::verify(llvm::function_ref<InFlightDiagnostic()> emitError,
+                  Type innerType) {
+  if (hw::getBitWidth(innerType) < 0)
+    return emitError() << "state type must have a known bit width; got "
+                       << innerType;
+  return success();
+}
 
 unsigned MemoryType::getStride() {
   unsigned stride = (getWordType().getWidth() + 7) / 8;

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -563,3 +563,8 @@ hw.module @vectorize(in %in0: i4, in %in1: i4, out out0: i4) {
   }
   hw.output %0 : i4
 }
+
+// -----
+
+// expected-error @below {{state type must have a known bit width}}
+func.func @InvalidStateType(%arg0: !arc.state<index>)


### PR DESCRIPTION
Allow `!arc.state` to carry HW structs and arrays. The state only has to be able to compute the bit width of the inner type, but it does not care what exactly this type is.

Rework the Arc-to-LLVM lowering to do the entire lowering in one full conversion, instead of two separate ones. There is no real need for the split, and combining all patterns into one large conversion allows all Arc types to be directly converted to LLVM types. Previously, after the first partial conversion the IR would be in a strange in-between state of mixing Arc types into LLVM operations (for example, loads and stores of HW struct/array types).