### PR TITLE
 [ModuleInliner] Donot retop a HierPathOp if flattening the root

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -1150,7 +1150,7 @@ void Inliner::inlineInstances(FModuleOp module) {
     // participate in any HierPathOp. But the reTop might add a symbol to it, if
     // a HierPathOp is added to this Op.
     DenseMap<Attribute, Attribute> symbolRenames;
-    if (!rootMap[target.getNameAttr()].empty()) {
+    if (!rootMap[target.getNameAttr()].empty() && !toBeFlattened) {
       for (auto sym : rootMap[target.getNameAttr()]) {
         auto &mnla = nlaMap[sym];
         sym = mnla.reTop(module);


### PR DESCRIPTION
If a `HierPathOp` has a root module that is flattened and inlined, then donot
 retop the root module, this results in incorrect `HierPathOp` that as stale
 symbols. 
This commit fixes the issue.