### PR TITLE
[FIRRTL] Framework for intrinsic lowering

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.h
@@ -1,0 +1,148 @@
+//===- FIRRTLDialect.h - FIRRTL dialect declaration ------------*- C++ --*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines helpers for the lowering of intrinsics.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_FIRRTLINTRINSICS_H
+#define CIRCT_DIALECT_FIRRTL_FIRRTLINTRINSICS_H
+
+#include "circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+
+namespace circt {
+namespace firrtl {
+class InstanceGraph;
+
+/// Base class for Intrinsic Converters.
+///
+/// Intrinsic converters contain validation logic, along with a converter
+/// method to transform instances to extmodules/intmodules into ops.
+class IntrinsicConverter {
+protected:
+  StringRef name;
+  FModuleLike mod;
+
+public:
+  IntrinsicConverter(StringRef name, FModuleLike mod) : name(name), mod(mod) {}
+
+  virtual ~IntrinsicConverter();
+
+  /// Checks whether the intrinsic module is well-formed.
+  ///
+  /// This or's multiple ParseResults together, returning true on failure.
+  virtual bool check() { return false; }
+
+  /// Transform an instance of the intrinsic.
+  virtual void convert(InstanceOp op) = 0;
+
+protected:
+  ParseResult hasNPorts(unsigned n);
+
+  ParseResult namedPort(unsigned n, StringRef portName);
+
+  ParseResult resetPort(unsigned n);
+
+  ParseResult hasNParam(unsigned n, unsigned c = 0);
+
+  ParseResult namedParam(StringRef paramName, bool optional = false);
+
+  ParseResult namedIntParam(StringRef paramName, bool optional = false);
+
+  template <typename T>
+  ParseResult typedPort(unsigned n) {
+    auto ports = mod.getPorts();
+    if (n >= ports.size()) {
+      mod.emitError(name) << " missing port " << n;
+      return failure();
+    }
+    if (!isa<T>(ports[n].type)) {
+      mod.emitError(name) << " port " << n << " not of correct type";
+      return failure();
+    }
+    return success();
+  }
+
+  template <typename T>
+  ParseResult sizedPort(unsigned n, int32_t size) {
+    auto ports = mod.getPorts();
+    if (failed(typedPort<T>(n)))
+      return failure();
+    if (cast<T>(ports[n].type).getWidth() != size) {
+      mod.emitError(name) << " port " << n << " not size " << size;
+      return failure();
+    }
+    return success();
+  }
+};
+
+/// Lowering helper which collects all intrinsic converters.
+class IntrinsicLowerings {
+private:
+  using ConverterFn = std::function<LogicalResult(FModuleLike)>;
+
+  /// Reference to the MLIR context.
+  MLIRContext *context;
+
+  /// Reference to the instance graph to find module instances.
+  InstanceGraph &graph;
+
+  /// Mapping from intrinsic names to converters.
+  DenseMap<StringAttr, ConverterFn> intmods;
+  /// Mapping from extmodule names to converters.
+  DenseMap<StringAttr, ConverterFn> extmods;
+
+public:
+  IntrinsicLowerings(MLIRContext *context, InstanceGraph &graph)
+      : context(context), graph(graph) {}
+
+  /// Registers a converter to an intrinsic name.
+  template <typename T>
+  void add(StringRef name) {
+    addConverter<T>(intmods, name);
+  }
+
+  /// Registers a converter to an extmodule name.
+  template <typename T>
+  void addExtmod(StringRef name) {
+    addConverter<T>(extmods, name);
+  }
+
+  /// Registers a converter to multiple intrinsic names.
+  template <typename T, typename... Args>
+  void add(StringRef name, Args... args) {
+    add<T>(name);
+    add<T>(args...);
+  }
+
+  /// Lowers a module to an intrinsic, given an intrinsic name.
+  LogicalResult lower(CircuitOp circuit);
+
+  /// Return the number of intrinsics converted.
+  unsigned getNumConverted() const { return numConverted; }
+
+private:
+  template <typename T>
+  void addConverter(DenseMap<StringAttr, ConverterFn> &map, StringRef name) {
+    auto nameAttr = StringAttr::get(context, name);
+    map.try_emplace(nameAttr, [&](FModuleLike mod) -> LogicalResult {
+      T conv(name, mod);
+      return doLowering(mod, conv);
+    });
+  }
+
+  LogicalResult doLowering(FModuleLike mod, IntrinsicConverter &conv);
+
+  unsigned numConverted = 0;
+};
+
+} // namespace firrtl
+} // namespace circt
+
+#endif // CIRCT_DIALECT_FIRRTL_FIRRTLINTRINSICS_H

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CIRCT_FIRRTL_Sources
   FIRRTLFolds.cpp
   FIRRTLInstanceGraph.cpp
   FIRRTLInstanceImplementation.cpp
+  FIRRTLIntrinsics.cpp
   FIRRTLOpInterfaces.cpp
   FIRRTLOps.cpp
   FIRRTLTypes.cpp

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -1,0 +1,165 @@
+//===- FIRRTLIntrinsics.cpp - Lower Intrinsics ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/FIRRTLIntrinsics.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+
+using namespace circt;
+using namespace firrtl;
+
+IntrinsicConverter::~IntrinsicConverter() = default;
+
+ParseResult IntrinsicConverter::hasNPorts(unsigned n) {
+  if (mod.getPorts().size() != n) {
+    mod.emitError(name) << " has " << mod.getPorts().size()
+                        << " ports instead of " << n;
+    return failure();
+  }
+  return success();
+}
+
+ParseResult IntrinsicConverter::namedPort(unsigned n, StringRef portName) {
+  auto ports = mod.getPorts();
+  if (n >= ports.size()) {
+    mod.emitError(name) << " missing port " << n;
+    return failure();
+  }
+  if (!ports[n].getName().equals(portName)) {
+    mod.emitError(name) << " port " << n << " named '" << ports[n].getName()
+                        << "' instead of '" << portName << "'";
+    return failure();
+  }
+  return success();
+}
+
+ParseResult IntrinsicConverter::resetPort(unsigned n) {
+  auto ports = mod.getPorts();
+  if (n >= ports.size()) {
+    mod.emitError(name) << " missing port " << n;
+    return failure();
+  }
+  if (isa<ResetType, AsyncResetType>(ports[n].type))
+    return success();
+  if (auto uintType = dyn_cast<UIntType>(ports[n].type))
+    if (uintType.getWidth() == 1)
+      return success();
+  mod.emitError(name) << " port " << n << " not of correct type";
+  return failure();
+}
+
+ParseResult IntrinsicConverter::hasNParam(unsigned n, unsigned c) {
+  unsigned num = 0;
+  if (mod.getParameters())
+    num = mod.getParameters().size();
+  if (num < n || num > n + c) {
+    auto d = mod.emitError(name) << " has " << num << " parameters instead of ";
+    if (c == 0)
+      d << n;
+    else
+      d << " between " << n << " and " << (n + c);
+    return failure();
+  }
+  return success();
+}
+
+ParseResult IntrinsicConverter::namedParam(StringRef paramName, bool optional) {
+  for (auto a : mod.getParameters()) {
+    auto param = cast<ParamDeclAttr>(a);
+    if (param.getName().getValue().equals(paramName)) {
+      if (isa<StringAttr>(param.getValue()))
+        return success();
+
+      mod.emitError(name) << " has parameter '" << param.getName()
+                          << "' which should be a string but is not";
+      return failure();
+    }
+  }
+  if (optional)
+    return success();
+  mod.emitError(name) << " is missing parameter " << paramName;
+  return failure();
+}
+
+ParseResult IntrinsicConverter::namedIntParam(StringRef paramName,
+                                              bool optional) {
+  for (auto a : mod.getParameters()) {
+    auto param = cast<ParamDeclAttr>(a);
+    if (param.getName().getValue().equals(paramName)) {
+      if (isa<IntegerAttr>(param.getValue()))
+        return success();
+
+      mod.emitError(name) << " has parameter '" << param.getName()
+                          << "' which should be an integer but is not";
+      return failure();
+    }
+  }
+  if (optional)
+    return success();
+  mod.emitError(name) << " is missing parameter " << paramName;
+  return failure();
+}
+
+LogicalResult IntrinsicLowerings::doLowering(FModuleLike mod,
+                                             IntrinsicConverter &conv) {
+  if (conv.check())
+    return failure();
+  for (auto *use : graph.lookup(mod)->uses())
+    conv.convert(use->getInstance<InstanceOp>());
+  return success();
+}
+
+LogicalResult IntrinsicLowerings::lower(CircuitOp circuit) {
+  unsigned numFailures = 0;
+  for (auto op : llvm::make_early_inc_range(circuit.getOps<FModuleLike>())) {
+    StringAttr intname;
+    if (auto extMod = dyn_cast<FExtModuleOp>(*op)) {
+      // Special-case some extmodules, identifying them by name.
+      auto it = extmods.find(extMod.getDefnameAttr());
+      if (it != extmods.end()) {
+        if (succeeded(it->second(op))) {
+          op.erase();
+        } else {
+          ++numFailures;
+        }
+        continue;
+      }
+
+      // Otherwise, find extmodules which have an intrinsic annotation.
+      auto anno = AnnotationSet(&*op).getAnnotation("circt.Intrinsic");
+      if (!anno)
+        continue;
+      intname = anno.getMember<StringAttr>("intrinsic");
+      if (!intname) {
+        op.emitError("intrinsic annotation with no intrinsic name");
+        ++numFailures;
+        continue;
+      }
+    } else if (auto intMod = dyn_cast<FIntModuleOp>(*op)) {
+      intname = intMod.getIntrinsicAttr();
+      if (!intname) {
+        op.emitError("intrinsic module with no intrinsic name");
+        ++numFailures;
+        continue;
+      }
+    } else {
+      continue;
+    }
+
+    // Find the converter and apply it.
+    auto it = intmods.find(intname);
+    if (it == intmods.end())
+      return op.emitError() << "intrinsic not recognized";
+    if (failed(it->second(op))) {
+      ++numFailures;
+      continue;
+    }
+    op.erase();
+  }
+
+  return success(numFailures == 0);
+}


### PR DESCRIPTION
This PR wraps most of the functionality of `LowerIntrinsics` into a re-usable utility class and converts the lowering functions into classes more similar to conversion patterns.

This is done in order to allow other tools tools to re-use the `IntrinsicLowerings` to handle their own intrinsics.