### PR TITLE
[FirRegLowering] Add a limit to nested-if depth

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -662,7 +662,9 @@ def LowerSeqToSV: Pass<"lower-seq-to-sv",  "mlir::ModuleOp"> {
     Option<"emitSeparateAlwaysBlocks", "emit-separate-always-blocks", "bool", "false",
            "Emit assigments to registers in separate always blocks">,
     Option<"lowerToAlwaysFF", "lower-to-always-ff", "bool", "true",
-           "Place assignments to registers into `always_ff` blocks">
+           "Place assignments to registers into `always_ff` blocks">,
+    Option<"nestdIfDepthLimit", "nested-if-depth-limit", "int64_t", "4096",
+           "Set a limit for nested if depth. Use -1 for unlimited depth">
   ];
   let statistics = [
     Statistic<"numSubaccessRestored", "num-subaccess-restored",

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -71,6 +71,8 @@ public:
             ckgEnableName, ckgTestEnableName, ckgInstName};
   }
 
+  int64_t getNestedIfDepthLimit() const { return nestedIfDepthLimit; }
+
   FirtoolOptions &setClockGateOptions(seq::ExternalizeClockGateOptions &opts) {
     ckgModuleName = opts.moduleName;
     ckgInputName = opts.inputName;
@@ -349,6 +351,11 @@ public:
     return *this;
   }
 
+  FirtoolOptions &setNestedIfDepthLimit(int64_t value) {
+    nestedIfDepthLimit = value;
+    return *this;
+  }
+
 private:
   std::string outputFilename;
   bool disableAnnotationsUnknown;
@@ -394,6 +401,7 @@ private:
   bool stripFirDebugInfo;
   bool stripDebugInfo;
   bool fixupEICGWrapper;
+  int64_t nestedIfDepthLimit;
 };
 
 void registerFirtoolCLOptions();

--- a/lib/Conversion/SeqToSV/FirRegLowering.h
+++ b/lib/Conversion/SeqToSV/FirRegLowering.h
@@ -23,10 +23,12 @@ class FirRegLowering {
 public:
   FirRegLowering(TypeConverter &typeConverter, hw::HWModuleOp module,
                  bool disableRegRandomization = false,
-                 bool emitSeparateAlwaysBlocks = false)
+                 bool emitSeparateAlwaysBlocks = false,
+                 int64_t nestedIfDepthLimit = 2048)
       : typeConverter(typeConverter), module(module),
         disableRegRandomization(disableRegRandomization),
-        emitSeparateAlwaysBlocks(emitSeparateAlwaysBlocks){};
+        emitSeparateAlwaysBlocks(emitSeparateAlwaysBlocks),
+        nestedIfDepthLimit(nestedIfDepthLimit){};
 
   void lower();
 
@@ -95,6 +97,7 @@ private:
   bool emitSeparateAlwaysBlocks;
 
   bool needsRandom = false;
+  int64_t nestedIfDepthLimit;
 };
 } // namespace circt
 

--- a/lib/Conversion/SeqToSV/SeqToSV.cpp
+++ b/lib/Conversion/SeqToSV/SeqToSV.cpp
@@ -395,7 +395,7 @@ void SeqToSVPass::runOnOperation() {
   mlir::parallelForEach(&getContext(), modules, [&](HWModuleOp module) {
     SeqToSVTypeConverter typeConverter;
     FirRegLowering regLowering(typeConverter, module, disableRegRandomization,
-                               emitSeparateAlwaysBlocks);
+                               emitSeparateAlwaysBlocks, nestdIfDepthLimit);
     regLowering.lower();
     if (regLowering.needsRegRandomization())
       needsRegRandomization = true;

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -658,6 +658,11 @@ struct FirtoolCmdOptions {
       "fixup-eicg-wrapper",
       llvm::cl::desc("Lower `EICG_wrapper` modules into clock gate intrinsics"),
       llvm::cl::init(false)};
+  llvm::cl::opt<int64_t> nestedIfDepthLimit{
+      "nested-if-depth-limit",
+      llvm::cl::desc("Set a limit for nested if depth created in firreg "
+                     "lowering. Use -1 for unlimited depth"),
+      llvm::cl::init(4096)};
 };
 } // namespace
 
@@ -693,7 +698,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       ckgModuleName("EICG_wrapper"), ckgInputName("in"), ckgOutputName("out"),
       ckgEnableName("en"), ckgTestEnableName("test_en"), ckgInstName("ckg"),
       exportModuleHierarchy(false), stripFirDebugInfo(true),
-      stripDebugInfo(false), fixupEICGWrapper(false) {
+      stripDebugInfo(false), fixupEICGWrapper(false), nestedIfDepthLimit(4096) {
   if (!clOptions.isConstructed())
     return;
   outputFilename = clOptions->outputFilename;
@@ -741,4 +746,5 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   stripFirDebugInfo = clOptions->stripFirDebugInfo;
   stripDebugInfo = clOptions->stripDebugInfo;
   fixupEICGWrapper = clOptions->fixupEICGWrapper;
+  nestedIfDepthLimit = clOptions->nestedIfDepthLimit;
 }


### PR DESCRIPTION
Mux2if lowering in fitted lowering could create deeply nested regions whose depth is up to 65536. Since mlir is not capable of handling deeply nested regions(there are still recursions for regions in the mlir codebase e.g walk, CSE and etc.), this PR adds a limit to the depth. 