### PR TITLE
[OM] Use type replacer to handle block arguments.

### DIFF
--- a/test/Dialect/OM/freeze-paths.mlir
+++ b/test/Dialect/OM/freeze-paths.mlir
@@ -96,3 +96,19 @@ om.class @ListCreateTest(%notpath: i1, %basepath : !om.basepath, %path : !om.pat
   // CHECK: om.class.field @nestedpath, [[NESTED_PATH_LIST]] : !om.list<!om.list<!om.frozenpath>>
   om.class.field @nestedpath, %3 : !om.list<!om.list<!om.path>>
 }
+
+// CHECK-LABEL om.class @PathListClass(%pathList: !om.list<!om.frozenpath>)
+om.class @PathListClass(%pathList : !om.list<!om.path>) {
+  om.class.field @pathList, %pathList : !om.list<!om.path>
+}
+
+// CHECK-LABEL om.class @PathListTest(%arg: !om.list<!om.frozenpath>)
+om.class @PathListTest(%arg : !om.list<!om.path>) {
+  // CHECK: om.object @PathListClass(%arg) : (!om.list<!om.frozenpath>)
+  om.object @PathListClass(%arg) : (!om.list<!om.path>) -> !om.class.type<@PathListClass>
+
+  // CHECK: [[RES:%.+]] = om.list_create
+  %0 = om.list_create : !om.path
+  // CHECK: om.object @PathListClass([[RES]]) : (!om.list<!om.frozenpath>)
+  om.object @PathListClass(%0) : (!om.list<!om.path>) -> !om.class.type<@PathListClass>
+}


### PR DESCRIPTION
We added a type replacer and used it to update the type of list create ops previously, but a similar issue shows up if there are lists of paths in block arguments. This factors out some helpers added previously for list create ops, so the same logic and conversion can be used in block arguments.