### PR TITLE
[FIRTOOL] Fallback to outDir for empty chiselInterfaceOutDir

### DIFF
--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -54,6 +54,8 @@ public:
   StringRef getOmirOutputFile() const { return omirOutFile; }
   StringRef getBlackBoxRootPath() const { return blackBoxRootPath; }
   StringRef getChiselInterfaceOutputDirectory() const {
+    if (chiselInterfaceOutDirectory.empty() && !isDefaultOutputFilename())
+      return getOutputFilename();
     return chiselInterfaceOutDirectory;
   }
   StringRef getReplaceSequentialMemoriesFile() const { return replSeqMemFile; }


### PR DESCRIPTION
When the user does not explicitly specify the output directory for the generated chisel interface via `--chisel-interface-out-dir`, firtool will use the output directory as the fallback.

This provides the default option for generated files to all be put in the directory specified by `-o`.