### PR TITLE
[ESI][Runtime] Add type serialization support to Python bindings

### DIFF
--- a/integration_test/Dialect/ESI/runtime/loopback.mlir
+++ b/integration_test/Dialect/ESI/runtime/loopback.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: esi-cosim, esi-runtime, rtl-sim
 // RUN: rm -rf %t6 && mkdir %t6 && cd %t6
 // RUN: circt-opt %s --esi-connect-services --esi-appid-hier=top=top --esi-build-manifest=top=top --esi-clean-metadata > %t4.mlir
-// RUN: circt-opt %t4.mlir --lower-esi-to-physical --lower-esi-bundles --lower-esi-ports --lower-esi-to-hw=platform=cosim --lower-seq-to-sv --export-split-verilog -o %t3.mlir
+// RUN: circt-opt %t4.mlir --lower-esi-to-physical --lower-esi-bundles --lower-esi-ports --lower-esi-to-hw=platform=cosim --lower-seq-to-sv --lower-hwarith-to-hw --canonicalize --export-split-verilog -o %t3.mlir
 // RUN: cd ..
 // RUN: esiquery trace w:%t6/esi_system_manifest.json hier | FileCheck %s --check-prefix=QUERY-HIER
 // RUN: %python %s.py trace w:%t6/esi_system_manifest.json
@@ -41,17 +41,38 @@ hw.module @Loopback (in %clk: !seq.clock) {
 esi.service.std.func @funcs
 
 !structFunc = !esi.bundle<[
-  !esi.channel<!hw.struct<a: ui4, b: si8>> to "arg",
-  !esi.channel<!hw.array<1xsi8>> from "result"]>
+  !esi.channel<!hw.struct<a: ui16, b: si8>> to "arg",
+  !esi.channel<!hw.struct<x: si8, y: si8>> from "result"]>
 
 hw.module @LoopbackStruct() {
   %callBundle = esi.service.req.to_client <@funcs::@call> (#esi.appid<"structFunc">) : !structFunc
   %arg = esi.bundle.unpack %resultChan from %callBundle : !structFunc
 
-  %argData, %valid = esi.unwrap.vr %arg, %ready : !hw.struct<a: ui4, b: si8>
-  %resultElem = hw.struct_extract %argData["b"] : !hw.struct<a: ui4, b: si8>
-  %resultArray = hw.array_create %resultElem : si8
-  %resultChan, %ready = esi.wrap.vr %resultArray, %valid : !hw.array<1xsi8>
+  %argData, %valid = esi.unwrap.vr %arg, %ready : !hw.struct<a: ui16, b: si8>
+  %resultElem = hw.struct_extract %argData["b"] : !hw.struct<a: ui16, b: si8>
+  %c1 = hwarith.constant 1 : si2
+  %resultPlusOne = hwarith.add %resultElem, %c1 : (si8, si2) -> si9
+  %resultPlusOneSliced = hwarith.cast %resultPlusOne : (si9) -> si8
+  %result = hw.struct_create (%resultPlusOneSliced, %resultElem) : !hw.struct<x: si8, y: si8>
+  %resultChan, %ready = esi.wrap.vr %result, %valid : !hw.struct<x: si8, y: si8>
+}
+
+!arrFunc = !esi.bundle<[
+  !esi.channel<!hw.array<1xsi8>> to "arg",
+  !esi.channel<!hw.array<2xsi8>> from "result"]>
+
+hw.module @LoopbackArray() {
+  %callBundle = esi.service.req.to_client <@funcs::@call> (#esi.appid<"arrayFunc">) : !arrFunc
+  %arg = esi.bundle.unpack %resultChan from %callBundle : !arrFunc
+
+  %argData, %valid = esi.unwrap.vr %arg, %ready : !hw.array<1xsi8>
+  %idx = hw.constant 0 : i0
+  %resultElem = hw.array_get %argData[%idx] : !hw.array<1xsi8>, i0
+  %c1 = hwarith.constant 1 : si2
+  %resultPlusOne = hwarith.add %resultElem, %c1 : (si8, si2) -> si9
+  %resultPlusOneSliced = hwarith.cast %resultPlusOne : (si9) -> si8
+  %result = hw.array_create %resultPlusOneSliced, %resultElem : si8
+  %resultChan, %ready = esi.wrap.vr %result, %valid : !hw.array<2xsi8>
 }
 
 esi.mem.ram @MemA i64 x 20
@@ -83,6 +104,7 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
   hw.instance "int_mem" @MemoryAccess1 (clk: %clk: !seq.clock, rst: %rst: i1) -> ()
   hw.instance "func1" @CallableFunc1() -> ()
   hw.instance "loopback_struct" @LoopbackStruct() -> ()
+  hw.instance "loopback_array" @LoopbackArray() -> ()
 }
 
 // QUERY-HIER: ********************************
@@ -97,8 +119,11 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // QUERY-HIER:       arg: !esi.channel<i16>
 // QUERY-HIER:       result: !esi.channel<i16>
 // QUERY-HIER:     structFunc:
-// QUERY-HIER:       arg: !esi.channel<!hw.struct<a: ui4, b: si8>>
-// QUERY-HIER:       result: !esi.channel<!hw.array<1xsi8>>
+// QUERY-HIER:       arg: !esi.channel<!hw.struct<a: ui16, b: si8>>
+// QUERY-HIER:       result: !esi.channel<!hw.struct<x: si8, y: si8>>
+// QUERY-HIER:     arrayFunc:
+// QUERY-HIER:       arg: !esi.channel<!hw.array<1xsi8>>
+// QUERY-HIER:       result: !esi.channel<!hw.array<2xsi8>>
 // QUERY-HIER: * Children:
 // QUERY-HIER:   * Instance:loopback_inst[0]
 // QUERY-HIER:   * Ports:

--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -59,6 +59,7 @@ set(ESIRuntimeLinkLibraries
 set(ESIPythonRuntimeSources
   python/esi/__init__.py
   python/esi/accelerator.py
+  python/esi/types.py
   python/esi/esiCppAccel.pyi
 )
 

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Types.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Types.h
@@ -66,6 +66,12 @@ private:
   const Type &inner;
 };
 
+/// The "void" type is a special type which can be used to represent no type.
+class VoidType : public Type {
+public:
+  VoidType(const ID &id) : Type(id) {}
+};
+
 /// The "any" type is a special type which can be used to represent any type, as
 /// identified by the type id. Said type id is guaranteed to be present in the
 /// manifest. Importantly, the "any" type id over the wire may not be a string

--- a/lib/Dialect/ESI/runtime/cpp/lib/Manifest.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Manifest.cpp
@@ -417,8 +417,8 @@ ChannelType *parseChannelType(const nlohmann::json &typeJson,
                          parseType(typeJson.at("inner"), cache));
 }
 
-BitVectorType *parseInt(const nlohmann::json &typeJson,
-                        Manifest::Impl::TypeCache &cache) {
+Type *parseInt(const nlohmann::json &typeJson,
+               Manifest::Impl::TypeCache &cache) {
   assert(typeJson.at("mnemonic") == "int");
   std::string sign = typeJson.at("signedness");
   uint64_t width = typeJson.at("hw_bitwidth");
@@ -428,7 +428,10 @@ BitVectorType *parseInt(const nlohmann::json &typeJson,
     return new SIntType(id, width);
   else if (sign == "unsigned")
     return new UIntType(id, width);
-  else if (sign == "signless")
+  else if (sign == "signless" && width == 0)
+    // By convention, a zero-width signless integer is a void type.
+    return new VoidType(id);
+  else if (sign == "signless" && width > 0)
     return new BitsType(id, width);
   else
     throw runtime_error("Malformed manifest: unknown sign '" + sign + "'");

--- a/lib/Dialect/ESI/runtime/python/esi/accelerator.py
+++ b/lib/Dialect/ESI/runtime/python/esi/accelerator.py
@@ -1,3 +1,4 @@
+# ===-----------------------------------------------------------------------===#
 #  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/lib/Dialect/ESI/runtime/python/esi/accelerator.py
+++ b/lib/Dialect/ESI/runtime/python/esi/accelerator.py
@@ -1,13 +1,78 @@
 #  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# ===-----------------------------------------------------------------------===#
+#
+# The structure of the Python classes and hierarchy roughly mirrors the C++
+# side, but wraps the C++ objects. The wrapper classes sometimes add convenience
+# functionality and serve to return wrapped versions of the returned objects.
+#
+# ===-----------------------------------------------------------------------===#
 
+from typing import Dict, Optional
+
+from .types import BundlePort
 from . import esiCppAccel as cpp
 
 
-class AcceleratorConnection(cpp.AcceleratorConnection):
-  """An ESI accelerator."""
+class AcceleratorConnection:
+  """A connection to an ESI accelerator."""
+
+  def __init__(self, platform: str, connection_str: str):
+    self.cpp_accel = cpp.AcceleratorConnection(platform, connection_str)
 
   def manifest(self) -> cpp.Manifest:
-    """Returns the accelerator's manifest."""
-    return cpp.Manifest(self.sysinfo().json_manifest())
+    """Get and parse the accelerator manifest."""
+    return cpp.Manifest(self.cpp_accel.sysinfo().json_manifest())
+
+  def sysinfo(self) -> cpp.SysInfo:
+    return self.cpp_accel.sysinfo()
+
+  def build_accelerator(self) -> "Accelerator":
+    return Accelerator(self.manifest().build_accelerator(self.cpp_accel))
+
+  def get_service_mmio(self) -> cpp.MMIO:
+    return self.cpp_accel.get_service_mmio()
+
+
+class HWModule:
+  """Represents either the top level or an instance of a hardware module."""
+
+  def __init__(self, parent: Optional["HWModule"], cpp_hwmodule: cpp.HWModule):
+    self.parent = parent
+    self.cpp_hwmodule = cpp_hwmodule
+
+  @property
+  def children(self) -> Dict[cpp.AppID, "Instance"]:
+    return {
+        name: Instance(self, inst)
+        for name, inst in self.cpp_hwmodule.children.items()
+    }
+
+  @property
+  def ports(self) -> Dict[cpp.AppID, BundlePort]:
+    return {
+        name: BundlePort(self, port)
+        for name, port in self.cpp_hwmodule.ports.items()
+    }
+
+
+class Instance(HWModule):
+  """Subclass of `HWModule` which represents a submodule instance. Adds an
+  AppID, which the top level doesn't have or need."""
+
+  def __init__(self, parent: Optional["HWModule"], cpp_instance: cpp.Instance):
+    super().__init__(parent, cpp_instance)
+    self.cpp_hwmodule: cpp.Instance = cpp_instance
+
+  @property
+  def id(self) -> cpp.AppID:
+    return self.cpp_hwmodule.id
+
+
+class Accelerator(HWModule):
+  """Root of the accelerator design hierarchy."""
+
+  def __init__(self, cpp_accelerator: cpp.Accelerator):
+    super().__init__(None, cpp_accelerator)
+    self.cpp_hwmodule = cpp_accelerator

--- a/lib/Dialect/ESI/runtime/python/esi/esiCppAccel.cpp
+++ b/lib/Dialect/ESI/runtime/python/esi/esiCppAccel.cpp
@@ -49,14 +49,15 @@ PYBIND11_MODULE(esiCppAccel, m) {
       .def("__repr__", [](Type &t) { return "<" + t.getID() + ">"; });
   py::class_<ChannelType, Type>(m, "ChannelType")
       .def_property_readonly("inner", &ChannelType::getInner,
-                             py::return_value_policy::reference_internal);
+                             py::return_value_policy::reference);
   py::enum_<BundleType::Direction>(m, "Direction")
       .value("To", BundleType::Direction::To)
       .value("From", BundleType::Direction::From)
       .export_values();
   py::class_<BundleType, Type>(m, "BundleType")
       .def_property_readonly("channels", &BundleType::getChannels,
-                             py::return_value_policy::reference_internal);
+                             py::return_value_policy::reference);
+  py::class_<VoidType, Type>(m, "VoidType");
   py::class_<AnyType, Type>(m, "AnyType");
   py::class_<BitVectorType, Type>(m, "BitVectorType")
       .def_property_readonly("width", &BitVectorType::getWidth);
@@ -66,10 +67,10 @@ PYBIND11_MODULE(esiCppAccel, m) {
   py::class_<UIntType, IntegerType>(m, "UIntType");
   py::class_<StructType, Type>(m, "StructType")
       .def_property_readonly("fields", &StructType::getFields,
-                             py::return_value_policy::reference_internal);
+                             py::return_value_policy::reference);
   py::class_<ArrayType, Type>(m, "ArrayType")
       .def_property_readonly("element", &ArrayType::getElementType,
-                             py::return_value_policy::reference_internal)
+                             py::return_value_policy::reference)
       .def_property_readonly("size", &ArrayType::getSize);
 
   py::class_<ModuleInfo>(m, "ModuleInfo")
@@ -125,20 +126,21 @@ PYBIND11_MODULE(esiCppAccel, m) {
   py::class_<ChannelPort>(m, "ChannelPort")
       .def("connect", &ChannelPort::connect)
       .def_property_readonly("type", &ChannelPort::getType,
-                             py::return_value_policy::reference_internal);
+                             py::return_value_policy::reference);
 
   py::class_<WriteChannelPort, ChannelPort>(m, "WriteChannelPort")
-      .def("write", [](WriteChannelPort &p, std::vector<uint8_t> data) {
-        p.write(data.data(), data.size());
+      .def("write", [](WriteChannelPort &p, py::bytearray &data) {
+        py::buffer_info info(py::buffer(data).request());
+        p.write(info.ptr, info.size);
       });
   py::class_<ReadChannelPort, ChannelPort>(m, "ReadChannelPort")
-      .def("read", [](ReadChannelPort &p, size_t maxSize) {
+      .def("read", [](ReadChannelPort &p, size_t maxSize) -> py::bytearray {
         std::vector<uint8_t> data(maxSize);
         std::ptrdiff_t size = p.read(data.data(), data.size());
         if (size < 0)
           throw std::runtime_error("read failed");
         data.resize(size);
-        return data;
+        return py::bytearray((char *)data.data(), data.size());
       });
 
   py::class_<BundlePort>(m, "BundlePort")
@@ -156,9 +158,9 @@ PYBIND11_MODULE(esiCppAccel, m) {
       py::class_<HWModule>(m, "HWModule")
           .def_property_readonly("info", &HWModule::getInfo)
           .def_property_readonly("ports", &HWModule::getPorts,
-                                 py::return_value_policy::reference_internal);
+                                 py::return_value_policy::reference);
 
-  // In order to inherit methods from "Design", it needs to be defined first.
+  // In order to inherit methods from "HWModule", it needs to be defined first.
   py::class_<Instance, HWModule>(m, "Instance")
       .def_property_readonly("id", &Instance::getID);
 
@@ -167,7 +169,7 @@ PYBIND11_MODULE(esiCppAccel, m) {
   // Since this returns a vector of Instance*, we need to define Instance first
   // or else pybind11-stubgen complains.
   hwmodule.def_property_readonly("children", &HWModule::getChildren,
-                                 py::return_value_policy::reference_internal);
+                                 py::return_value_policy::reference);
 
   py::class_<AcceleratorConnection>(m, "AcceleratorConnection")
       .def(py::init(&registry::connect))
@@ -176,17 +178,18 @@ PYBIND11_MODULE(esiCppAccel, m) {
           [](AcceleratorConnection &acc) {
             return acc.getService<services::SysInfo>({});
           },
-          py::return_value_policy::reference_internal)
+          py::return_value_policy::reference)
       .def(
           "get_service_mmio",
           [](AcceleratorConnection &acc) {
             return acc.getService<services::MMIO>({});
           },
-          py::return_value_policy::reference_internal);
+          py::return_value_policy::reference);
 
   py::class_<Manifest>(m, "Manifest")
       .def(py::init<std::string>())
       .def_property_readonly("api_version", &Manifest::getApiVersion)
-      .def("build_accelerator", &Manifest::buildAccelerator)
+      .def("build_accelerator", &Manifest::buildAccelerator,
+           py::return_value_policy::take_ownership)
       .def_property_readonly("type_table", &Manifest::getTypeTable);
 }

--- a/lib/Dialect/ESI/runtime/python/esi/esiCppAccel.pyi
+++ b/lib/Dialect/ESI/runtime/python/esi/esiCppAccel.pyi
@@ -11,7 +11,8 @@ __all__ = [
     'BitVectorType', 'BitsType', 'BundlePort', 'BundleType', 'ChannelPort',
     'ChannelType', 'Direction', 'From', 'HWModule', 'Instance', 'IntegerType',
     'MMIO', 'Manifest', 'ModuleInfo', 'ReadChannelPort', 'SIntType',
-    'StructType', 'SysInfo', 'To', 'Type', 'UIntType', 'WriteChannelPort'
+    'StructType', 'SysInfo', 'To', 'Type', 'UIntType', 'VoidType',
+    'WriteChannelPort'
 ]
 
 
@@ -254,7 +255,7 @@ class ModuleInfo:
 
 class ReadChannelPort(ChannelPort):
 
-  def read(self, arg0: int) -> list[int]:
+  def read(self, arg0: int) -> bytearray:
     ...
 
 
@@ -292,9 +293,13 @@ class UIntType(IntegerType):
   pass
 
 
+class VoidType(Type):
+  pass
+
+
 class WriteChannelPort(ChannelPort):
 
-  def write(self, arg0: list[int]) -> None:
+  def write(self, arg0: bytearray) -> None:
     ...
 
 

--- a/lib/Dialect/ESI/runtime/python/esi/types.py
+++ b/lib/Dialect/ESI/runtime/python/esi/types.py
@@ -1,3 +1,4 @@
+# ===-----------------------------------------------------------------------===#
 #  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/lib/Dialect/ESI/runtime/python/esi/types.py
+++ b/lib/Dialect/ESI/runtime/python/esi/types.py
@@ -1,0 +1,358 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# ===-----------------------------------------------------------------------===#
+#
+# The structure of the Python classes and hierarchy roughly mirrors the C++
+# side, but wraps the C++ objects. The wrapper classes sometimes add convenience
+# functionality and serve to return wrapped versions of the returned objects.
+#
+# ===-----------------------------------------------------------------------===#
+
+from __future__ import annotations
+
+from . import esiCppAccel as cpp
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+  from .accelerator import HWModule
+
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+
+
+def _get_esi_type(cpp_type: cpp.Type):
+  """Get the wrapper class for a C++ type."""
+  for cpp_type_cls, fn in __esi_mapping.items():
+    if isinstance(cpp_type, cpp_type_cls):
+      return fn(cpp_type)
+  return ESIType(cpp_type)
+
+
+# Mapping from C++ types to functions constructing the Python object
+# corresponding to that type.
+__esi_mapping: Dict[Type, Callable] = {
+    cpp.ChannelType: lambda cpp_type: _get_esi_type(cpp_type.inner)
+}
+
+
+class ESIType:
+
+  def __init__(self, cpp_type: cpp.Type):
+    self.cpp_type = cpp_type
+
+  @property
+  def supports_host(self) -> Tuple[bool, Optional[str]]:
+    """Does this type support host communication via Python? Returns either
+    '(True, None)' if it is, or '(False, reason)' if it is not."""
+
+    if self.bit_width % 8 != 0:
+      return (False, "runtime only supports types with multiple of 8 bits")
+    return (True, None)
+
+  def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
+    """Is a Python object compatible with HW type?  Returns either '(True,
+    None)' if it is, or '(False, reason)' if it is not."""
+    assert False, "unimplemented"
+
+  @property
+  def bit_width(self) -> int:
+    """Size of this type, in bits. Negative for unbounded types."""
+    assert False, "unimplemented"
+
+  @property
+  def max_size(self) -> int:
+    """Maximum size of a value of this type, in bytes."""
+    bitwidth = int((self.bit_width + 7) / 8)
+    if bitwidth < 0:
+      return bitwidth
+    return bitwidth
+
+  def serialize(self, obj) -> bytearray:
+    """Convert a Python object to a bytearray."""
+    assert False, "unimplemented"
+
+  def deserialize(self, data: bytearray) -> Tuple[object, bytearray]:
+    """Convert a bytearray to a Python object. Return the object and the
+    leftover bytes."""
+    assert False, "unimplemented"
+
+  def __str__(self) -> str:
+    return str(self.cpp_type)
+
+
+class VoidType(ESIType):
+
+  def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
+    if obj is not None:
+      return (False, f"void type cannot must represented by None, not {obj}")
+    return (True, None)
+
+  @property
+  def bit_width(self) -> int:
+    return 8
+
+  def serialize(self, obj) -> bytearray:
+    # By convention, void is represented by a single byte of value 0.
+    return bytearray([0])
+
+  def deserialize(self, data: bytearray) -> Tuple[object, bytearray]:
+    if len(data) == 0:
+      raise ValueError(f"void type cannot be represented by {data}")
+    return (None, data[1:])
+
+
+__esi_mapping[cpp.VoidType] = VoidType
+
+
+class BitsType(ESIType):
+
+  def __init__(self, cpp_type: cpp.BitsType):
+    self.cpp_type: cpp.BitsType = cpp_type
+
+  def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
+    if not isinstance(obj, (bytearray, bytes, list)):
+      return (False, f"invalid type: {type(obj)}")
+    if isinstance(obj, list) and not all(
+        [isinstance(b, int) and b.bit_length() <= 8 for b in obj]):
+      return (False, f"list item too large: {obj}")
+    if len(obj) != self.max_size:
+      return (False, f"wrong size: {len(obj)}")
+    return (True, None)
+
+  @property
+  def bit_width(self) -> int:
+    return self.cpp_type.width
+
+  def serialize(self, obj: Union[bytearray, bytes, List[int]]) -> bytearray:
+    if isinstance(obj, bytearray):
+      return obj
+    if isinstance(obj, bytes) or isinstance(obj, list):
+      return bytearray(obj)
+    raise ValueError(f"cannot convert {obj} to bytearray")
+
+  def deserialize(self, data: bytearray) -> Tuple[bytearray, bytearray]:
+    return (data[0:self.max_size], data[self.max_size:])
+
+
+__esi_mapping[cpp.BitsType] = BitsType
+
+
+class IntType(ESIType):
+
+  def __init__(self, cpp_type: cpp.IntegerType):
+    self.cpp_type: cpp.IntegerType = cpp_type
+
+  @property
+  def bit_width(self) -> int:
+    return self.cpp_type.width
+
+
+class UIntType(IntType):
+
+  def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
+    if not isinstance(obj, int):
+      return (False, f"must be an int, not {type(obj)}")
+    if obj < 0 or obj.bit_length() > self.bit_width:
+      return (False, f"out of range: {obj}")
+    return (True, None)
+
+  def __str__(self) -> str:
+    return f"uint{self.bit_width}"
+
+  def serialize(self, obj: int) -> bytearray:
+    return bytearray(int.to_bytes(obj, self.max_size, "little"))
+
+  def deserialize(self, data: bytearray) -> Tuple[int, bytearray]:
+    return (int.from_bytes(data[0:self.max_size],
+                           "little"), data[self.max_size:])
+
+
+__esi_mapping[cpp.UIntType] = UIntType
+
+
+class SIntType(IntType):
+
+  def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
+    if not isinstance(obj, int):
+      return (False, f"must be an int, not {type(obj)}")
+    if obj < 0:
+      if (-1 * obj) > 2**(self.bit_width - 1):
+        return (False, f"out of range: {obj}")
+    elif obj < 0:
+      if obj >= 2**(self.bit_width - 1) - 1:
+        return (False, f"out of range: {obj}")
+    return (True, None)
+
+  def __str__(self) -> str:
+    return f"sint{self.bit_width}"
+
+  def serialize(self, obj: int) -> bytearray:
+    return bytearray(int.to_bytes(obj, self.max_size, "little", signed=True))
+
+  def deserialize(self, data: bytearray) -> Tuple[int, bytearray]:
+    return (int.from_bytes(data[0:self.max_size], "little",
+                           signed=True), data[self.max_size:])
+
+
+__esi_mapping[cpp.SIntType] = SIntType
+
+
+class StructType(ESIType):
+
+  def __init__(self, cpp_type: cpp.StructType):
+    self.cpp_type = cpp_type
+    self.fields: List[Tuple[str, ESIType]] = [
+        (name, _get_esi_type(ty)) for (name, ty) in cpp_type.fields
+    ]
+
+  @property
+  def bit_width(self) -> int:
+    widths = [ty.bit_width for (_, ty) in self.fields]
+    if any([w < 0 for w in widths]):
+      return -1
+    return sum(widths)
+
+  def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
+    fields_count = 0
+    if not isinstance(obj, dict):
+      obj = obj.__dict__
+
+    for (fname, ftype) in self.fields:
+      if fname not in obj:
+        return (False, f"missing field '{fname}'")
+      fvalid, reason = ftype.is_valid(obj[fname])
+      if not fvalid:
+        return (False, f"invalid field '{fname}': {reason}")
+      fields_count += 1
+    if fields_count != len(obj):
+      return (False, "missing fields")
+    return (True, None)
+
+  def serialize(self, obj) -> bytearray:
+    ret = bytearray()
+    for (fname, ftype) in reversed(self.fields):
+      fval = obj[fname]
+      ret.extend(ftype.serialize(fval))
+    return ret
+
+  def deserialize(self, data: bytearray) -> Tuple[Dict[str, Any], bytearray]:
+    ret = {}
+    for (fname, ftype) in reversed(self.fields):
+      (fval, data) = ftype.deserialize(data)
+      ret[fname] = fval
+    return (ret, data)
+
+
+__esi_mapping[cpp.StructType] = StructType
+
+
+class ArrayType(ESIType):
+
+  def __init__(self, cpp_type: cpp.ArrayType):
+    self.cpp_type = cpp_type
+    self.element_type = _get_esi_type(cpp_type.element)
+    self.size = cpp_type.size
+
+  @property
+  def bit_width(self) -> int:
+    return self.element_type.bit_width * self.size
+
+  def is_valid(self, obj) -> Tuple[bool, Optional[str]]:
+    if not isinstance(obj, list):
+      return (False, f"must be a list, not {type(obj)}")
+    if len(obj) != self.size:
+      return (False, f"wrong size: expected {self.size} not {len(obj)}")
+    for (idx, e) in enumerate(obj):
+      evalid, reason = self.element_type.is_valid(e)
+      if not evalid:
+        return (False, f"invalid element {idx}: {reason}")
+    return (True, None)
+
+  def serialize(self, lst: list) -> bytearray:
+    ret = bytearray()
+    for e in reversed(lst):
+      ret.extend(self.element_type.serialize(e))
+    return ret
+
+  def deserialize(self, data: bytearray) -> Tuple[List[Any], bytearray]:
+    ret = []
+    for _ in range(self.size):
+      (obj, data) = self.element_type.deserialize(data)
+      ret.append(obj)
+    ret.reverse()
+    return (ret, data)
+
+
+__esi_mapping[cpp.ArrayType] = ArrayType
+
+
+class Port:
+  """A unidirectional communication channel. This is the basic communication
+  method with an accelerator."""
+
+  def __init__(self, owner: BundlePort, cpp_port: cpp.ChannelPort):
+    self.owner = owner
+    self.cpp_port = cpp_port
+    self.type = _get_esi_type(cpp_port.type)
+    (supports_host, reason) = self.type.supports_host
+    if not supports_host:
+      raise TypeError(f"unsupported type: {reason}")
+
+  def connect(self):
+    self.cpp_port.connect()
+    return self
+
+
+class WritePort(Port):
+  """A unidirectional communication channel from the host to the accelerator."""
+
+  def __init__(self, owner: BundlePort, cpp_port: cpp.WriteChannelPort):
+    super().__init__(owner, cpp_port)
+    self.cpp_port: cpp.WriteChannelPort = cpp_port
+
+  def write(self, msg=None) -> bool:
+    """Write a typed message to the channel. Attempts to serialize 'msg' to what
+    the accelerator expects, but will fail if the object is not convertible to
+    the port type."""
+
+    valid, reason = self.type.is_valid(msg)
+    if not valid:
+      raise ValueError(
+          f"'{msg}' cannot be converted to '{self.type}': {reason}")
+    msg_bytes: bytearray = self.type.serialize(msg)
+    self.cpp_port.write(msg_bytes)
+    return True
+
+
+class ReadPort(Port):
+  """A unidirectional communication channel from the accelerator to the host."""
+
+  def __init__(self, owner: BundlePort, cpp_port: cpp.ReadChannelPort):
+    super().__init__(owner, cpp_port)
+    self.cpp_port: cpp.ReadChannelPort = cpp_port
+
+  def read(self) -> Tuple[bool, Optional[object]]:
+    """Read a typed message from the channel. Returns a deserialized object of a
+    type defined by the port type."""
+
+    msg_bytes = self.cpp_port.read(self.type.max_size)
+    if len(msg_bytes) == 0:
+      return (False, None)
+    (msg, leftover) = self.type.deserialize(msg_bytes)
+    if len(leftover) != 0:
+      raise ValueError(f"leftover bytes: {leftover}")
+    return (True, msg)
+
+
+class BundlePort:
+  """A collections of named, unidirectional communication channels."""
+
+  def __init__(self, owner: HWModule, cpp_port: cpp.BundlePort):
+    self.owner = owner
+    self.cpp_port = cpp_port
+
+  def write_port(self, channel_name: str) -> WritePort:
+    return WritePort(self, self.cpp_port.getWrite(channel_name))
+
+  def read_port(self, channel_name: str) -> ReadPort:
+    return ReadPort(self, self.cpp_port.getRead(channel_name))


### PR DESCRIPTION
- Mirror the C++ design and type hierarchy.
- Add [de-]serialization support to/from Python objects.
- Add support for `void` type.
