### PR TITLE
[CI] Fix release asset upload job permissions, support manual runs.

### DIFF
--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -127,6 +127,8 @@ on:
 jobs:
   build-test-and-install:
     runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: write # Upload assets to release.
     steps:
       - name: Clone llvm/circt
         uses: actions/checkout@v3

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -271,9 +271,10 @@ jobs:
           retention-days: 7
 
       - name: Upload Binaries (Tag)
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@v3.0
         if: inputs.install && github.ref_type == 'tag'
         with:
           # The * will grab the .sha256 as well
           files: ${{ steps.name_archive.outputs.name }}*
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          release-tag: ${{ github.ref_name }} # Upload to release tag when manually run.

--- a/.github/workflows/uploadReleaseArtifacts.yml
+++ b/.github/workflows/uploadReleaseArtifacts.yml
@@ -30,6 +30,8 @@ jobs:
   publish-sources:
     if: github.ref_type == 'tag'
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write # Upload assets to release.
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
@@ -174,6 +176,8 @@ jobs:
     strategy:
       matrix:
         generated: ${{ fromJSON(needs.choose-matrix.outputs.matrix) }}
+    permissions:
+      contents: write # Upload assets to release.
     uses: ./.github/workflows/unifiedBuildTestAndInstall.yml
     with:
       runner: ${{ matrix.generated.runner }}

--- a/.github/workflows/uploadReleaseArtifacts.yml
+++ b/.github/workflows/uploadReleaseArtifacts.yml
@@ -53,11 +53,12 @@ jobs:
           shasum -a 256 circt-full-sources.tar.gz | cut -d ' ' -f1 > circt-full-sources.tar.gz.sha256
 
       - name: Upload Source Archive
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@v3.0
         with:
           # The * will grab the .sha256 as well
           files: circt-full-sources.tar.gz*
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          release-tag: ${{ github.ref_name }} # Upload to release tag when manually run.
 
   # This job sets up the build matrix.
   choose-matrix:


### PR DESCRIPTION
Give write permissions to jobs that upload release assets.
Set the `release-tag` explicitly so the upload action knows where to upload on manual runs (on a tag).  When triggered by a release this isn't needed but doesn't hurt.

Bump the upload-release-assets action v2 -> v3: https://github.com/AButler/upload-release-assets/releases/tag/v3.0
(This is needed for the `release-tag` support, also fixes a warning about node version).