### PR TITLE
[CI] Bump runner for windows release artifacts 2019 -> 2022.

### DIFF
--- a/.github/workflows/uploadReleaseArtifacts.yml
+++ b/.github/workflows/uploadReleaseArtifacts.yml
@@ -106,7 +106,7 @@ jobs:
         if: github.event_name == 'release' || ( github.event_name == 'workflow_dispatch' && inputs.os == 'windows' )
         env:
           os: windows
-          runner: windows-2019
+          runner: windows-2022
           arch: x64
           tar: tar czf
           archive: zip


### PR DESCRIPTION
Match what we use in CI.