### PR TITLE
[FIRRTL] Add Layer Association to Probes

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -391,7 +391,8 @@ def RefImpl : FIRRTLImplType<"Ref",
   }];
   let parameters = (ins TypeParameter<"::circt::firrtl::FIRRTLBaseType",
                                       "Type of reference target">:$type,
-                        "bool":$forceable);
+                        "bool":$forceable,
+                        OptionalParameter<"::mlir::SymbolRefAttr">:$layer);
   let genAccessors = true;
   let genStorageClass = true;
   let genVerifyDecl = true;
@@ -400,7 +401,8 @@ def RefImpl : FIRRTLImplType<"Ref",
   let skipDefaultBuilders = true;
   let builders = [
     TypeBuilderWithInferredContext<(ins "::circt::firrtl::FIRRTLBaseType":$type,
-                                        CArg<"bool", "false">:$forceable)>
+                                        CArg<"bool", "false">:$forceable,
+                                        CArg<"::mlir::SymbolRefAttr", "{}">:$layer)>
   ];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -234,7 +234,8 @@ inline FIRRTLType mapBaseType(FIRRTLType type,
   return TypeSwitch<FIRRTLType, FIRRTLType>(type)
       .Case<FIRRTLBaseType>([&](auto base) { return fn(base); })
       .Case<RefType>([&](auto ref) {
-        return RefType::get(fn(ref.getType()), ref.getForceable());
+        return RefType::get(fn(ref.getType()), ref.getForceable(),
+                            ref.getLayer());
       });
 }
 
@@ -250,7 +251,7 @@ mapBaseTypeNullable(FIRRTLType type,
         auto result = fn(ref.getType());
         if (!result)
           return {};
-        return RefType::get(result, ref.getForceable());
+        return RefType::get(result, ref.getForceable(), ref.getLayer());
       });
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/DropConst.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/DropConst.cpp
@@ -35,7 +35,8 @@ static Type convertType(Type type) {
 
   if (auto refType = type_dyn_cast<RefType>(type)) {
     if (auto converted = convertType(refType.getType()))
-      return RefType::get(converted, refType.getForceable());
+      return RefType::get(converted, refType.getForceable(),
+                          refType.getLayer());
   }
 
   return {};

--- a/lib/Dialect/FIRRTL/Transforms/VBToBV.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/VBToBV.cpp
@@ -174,7 +174,8 @@ RefType Visitor::convertType(RefType type) {
   auto cached = typeMap.lookup(type);
   if (cached)
     return type_cast<RefType>(cached);
-  auto converted = RefType::get(convertType(type.getType()));
+  auto converted = RefType::get(convertType(type.getType()),
+                                type.getForceable(), type.getLayer());
   typeMap.insert({type, converted});
   return converted;
 }

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -44,4 +44,16 @@ firrtl.module @Foo(in %clock: !firrtl.clock) {
   firrtl.strictconnect %inst_clock, %clock : !firrtl.clock
 }
 
+firrtl.layer @LayerA bind {
+  firrtl.layer @LayerB bind {}
+}
+
+// CHECK-LABEL: firrtl.module @Layers
+// CHECK-SAME:    out %a: !firrtl.probe<uint<1>, @LayerA>
+// CHECK-SAME:    out %b: !firrtl.rwprobe<uint<1>, @LayerA::@LayerB>
+firrtl.module @Layers(
+  out %a: !firrtl.probe<uint<1>, @LayerA>,
+  out %b: !firrtl.rwprobe<uint<1>, @LayerA::@LayerB>
+) {}
+
 }


### PR DESCRIPTION
Add support for representing an optional layer in each probe type.  This only handles storage and MLIR printing/parsing.

I'll be breaking this work up into a bunch of small pieces. This is the first.