### PR TITLE
[FIRRTL] Add parser/emitter support for layer-associated probes

### DIFF
--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -1378,6 +1378,14 @@ void Emitter::emitType(Type type, bool includeConst) {
           ps << "RW";
         ps << "Probe<";
         emitType(type.getType());
+        if (auto layer = type.getLayer()) {
+          ps << "," << PP::nbsp;
+          ps.addAsString(layer.getRootReference().getValue());
+          for (auto nested : layer.getNestedReferences()) {
+            ps << ".";
+            ps.addAsString(nested.getValue());
+          }
+        }
         ps << ">";
       })
       .Case<AnyRefType>([&](AnyRefType type) { ps << "AnyRef"; })

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -942,14 +942,16 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
       return failure();
     while (getToken().getKind() == FIRToken::identifier) {
       StringRef layer;
-      if (parseId(layer, "expected layer name"))
-        return failure();
+      loc = getToken().getLoc();
+      (void)parseId(layer, "expected layer name");
       layers.push_back(layer);
       if (getToken().getKind() == FIRToken::period)
         consumeToken();
     }
-    if (parseToken(FIRToken::greater, "expected '>' in reference type"))
+    if (!consumeIf(FIRToken::greater)) {
+      emitError(loc, "expected '>' to end reference type");
       return failure();
+    }
 
     bool forceable = kind == FIRToken::kw_RWProbe;
 

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -730,6 +730,33 @@ firrtl.circuit "Foo" {
     }
   }
 
+  // Test line-breaks for very large layer associations.
+  firrtl.layer @Group1234567890 bind {
+    firrtl.layer @Group1234567890 bind {
+      firrtl.layer @Group1234567890 bind {
+        firrtl.layer @Group1234567890 bind {
+          firrtl.layer @Group1234567890 bind {
+            firrtl.layer @Group1234567890 bind {
+              firrtl.layer @Group1234567890 bind {
+               firrtl.layer @Group1234567890 bind {}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // CHECK: module ModuleWithLongProbeColor
+  // CHECK-NEXT:  output o : Probe<
+  // CHECK-NEXT:    UInt<1>,
+  // CHECK-NEXT:    Group1234567890.Group1234567890.Group1234567890.Group1234567890
+  // CHECK-NEXT:      .Group1234567890.Group1234567890.Group1234567890.Group1234567890
+  // CHECK-NEXT:  >
+  firrtl.module @ModuleWithLongProbeColor(
+    out %o: !firrtl.probe<uint<1>, @Group1234567890::@Group1234567890::@Group1234567890::@Group1234567890::@Group1234567890::@Group1234567890::@Group1234567890::@Group1234567890>
+  ) {}
+
   // CHECK: module RWProbe :
   // CHECK-NEXT: input in : { a : UInt<1> }[2]
   // CHECK-NEXT: output p : RWProbe<UInt<1>>

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -704,13 +704,18 @@ firrtl.circuit "Foo" {
     }
   }
   // CHECK:      module ModuleWithGroups :
-  // CHECK-NEXT:   layerblock GroupA :
+  // CHECK-NEXT:   output a : Probe<UInt<1>, GroupA>
+  // CHECK-NEXT:   output b : RWProbe<UInt<1>, GroupA.GroupB>
+  // CHECK:        layerblock GroupA :
   // CHECK-NEXT:     layerblock GroupB :
   // CHECK-NEXT:       layerblock GroupC :
   // CHECK-NEXT:       layerblock GroupD :
   // CHECK-NEXT:         layerblock GroupE :
   // CHECK-NEXT:     layerblock GroupF :
-  firrtl.module @ModuleWithGroups() {
+  firrtl.module @ModuleWithGroups(
+    out %a: !firrtl.probe<uint<1>, @GroupA>,
+    out %b: !firrtl.rwprobe<uint<1>, @GroupA::@GroupB>
+  ) {
     firrtl.layerblock @GroupA {
       firrtl.layerblock @GroupA::@GroupB {
         firrtl.layerblock @GroupA::@GroupB::@GroupC {

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1671,9 +1671,13 @@ circuit Layers:
     ; CHECK-NEXT:   }
     ; CHECK-NEXT: }
 
-  ; CHECK: firrtl.module @Layers
+  ; CHECK:      firrtl.module @Layers
+  ; CHECK-SAME:   out %b: !firrtl.probe<uint<1>, @A>
+  ; CHECK-SAME:   out %c: !firrtl.rwprobe<uint<1>, @A::@B>
   module Layers:
     input a: UInt<1>
+    output b: Probe<UInt<1>, A>
+    output c: RWProbe<UInt<1>, A.B>
 
     layerblock A:
       node A_a = a

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1255,9 +1255,62 @@ circuit Foo:
     FPGA
 
 ;// -----
+FIRRTL version 3.1.0
+circuit Foo:
+
+  module Foo:
+    ; expected-error @below {{colored probes are a FIRRTL 3.2.0+ feature, but the specified FIRRTL version was 3.1.0}}
+    output a: Probe<UInt<1>, A>
+
+;// -----
+FIRRTL version 4.0.0
+circuit Foo:
+  layer A bind:
+  module Foo:
+    output a: Probe<
+    ; expected-error @below {{expected probe data type}}
+;// -----
+FIRRTL version 4.0.0
+circuit Foo:
+  layer A bind:
+  module Foo:
+    ; expected-error @below {{expected '<' in reference type}}
+    output a: Probe X
+
+;// -----
+FIRRTL version 4.0.0
+circuit Foo:
+  layer A bind:
+  module Foo:
+    output a: Probe
+    ; expected-error @below {{expected '<' in reference type}}
+;// -----
+FIRRTL version 4.0.0
+circuit Foo:
+  layer A bind:
+  module Foo:
+    ; expected-error @below {{expected probe data type}}
+    output a: Probe<>
+
+;// -----
 FIRRTL version 4.0.0
 circuit Foo:
   layer A bind:
   module Foo:
     ; expected-error @below {{expected '>' to end reference type}}
     output a: Probe<UInt<1>
+;// -----
+FIRRTL version 4.0.0
+circuit Foo:
+  layer A bind:
+  module Foo:
+    ; expected-error @below {{expected '>' to end reference type}}
+    output a: Probe<UInt<1> A
+
+;// -----
+FIRRTL version 4.0.0
+circuit Foo:
+  layer A bind:
+  module Foo:
+    ; expected-error @below {{expected layer name}}
+    output a: Probe<UInt<1> A.>

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1253,3 +1253,11 @@ circuit Foo:
   option Platform:
     FPGA
     FPGA
+
+;// -----
+FIRRTL version 4.0.0
+circuit Foo:
+  layer A bind:
+  module Foo:
+    ; expected-error @below {{expected '>' to end reference type}}
+    output a: Probe<UInt<1>


### PR DESCRIPTION
This adds support to parse and emit layer-associated probes to bring CIRCT more into compliance with the FIRRTL spec around probes.

This is currently stacked on #6551.