### PR TITLE
[Arc] StateOp: latency instead of lat in assembly format

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -147,7 +147,7 @@ def StateOp : ArcOp<"state", [
 
   let assemblyFormat = [{
     $arc `(` $inputs `)` (`clock` $clock^)? (`enable` $enable^)?
-    (`reset` $reset^)? `lat` $latency attr-dict
+    (`reset` $reset^)? `latency` $latency attr-dict
     `:` functional-type($inputs, results)
   }];
 
@@ -326,7 +326,7 @@ def MemoryWritePortOp : ArcOp<"memory_write_port", [
 
   let assemblyFormat = [{
     $memory `,` $arc  `(` $inputs `)` (`clock` $clock^)?  (`enable` $enable^)?
-    (`mask` $mask^)? `lat` $latency attr-dict `:`
+    (`mask` $mask^)? `latency` $latency attr-dict `:`
     type($memory) `,` type($inputs)
   }];
 

--- a/test/Conversion/ConvertToArcs/convert-to-arcs-names.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs-names.mlir
@@ -3,7 +3,7 @@
 
 // CHECK-LABEL: hw.module @Trivial(
 hw.module @Trivial(in %clock: !seq.clock, in %i0: i4, in %reset: i1, out o0: i4) {
-  // CHECK: arc.state {{@.+}}(%i0) clock %clock lat 1
+  // CHECK: arc.state {{@.+}}(%i0) clock %clock latency 1
   // CHECK-TAP-OFF-NOT: names = ["foo"]
   // CHECK-TAP-ON: names = ["foo"]
   %foo = seq.compreg %i0, %clock : i4

--- a/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
@@ -71,8 +71,8 @@ hw.module @SplitAtConstants(out z: i4) {
 
 // CHECK-LABEL: hw.module @Pipeline
 hw.module @Pipeline(in %clock: !seq.clock, in %i0: i4, in %i1: i4, out z: i4) {
-  // CHECK-NEXT: [[S0:%.+]] = arc.state @Pipeline_arc(%i0, %i1) clock %clock lat 1
-  // CHECK-NEXT: [[S1:%.+]] = arc.state @Pipeline_arc_0([[S0]], %i0) clock %clock lat 1
+  // CHECK-NEXT: [[S0:%.+]] = arc.state @Pipeline_arc(%i0, %i1) clock %clock latency 1
+  // CHECK-NEXT: [[S1:%.+]] = arc.state @Pipeline_arc_0([[S0]], %i0) clock %clock latency 1
   // CHECK-NEXT: [[S2:%.+]] = arc.call @Pipeline_arc_1([[S1]], %i1)
   // CHECK-NEXT: hw.output [[S2]]
   %0 = comb.add %i0, %i1 : i4
@@ -96,8 +96,8 @@ hw.module @Pipeline(in %clock: !seq.clock, in %i0: i4, in %i1: i4, out z: i4) {
 // CHECK-LABEL: hw.module @Reshuffling
 hw.module @Reshuffling(in %clockA: !seq.clock, in %clockB: !seq.clock, out z0: i4, out z1: i4, out z2: i4, out z3: i4) {
   // CHECK-NEXT: hw.instance "x" @Reshuffling2()
-  // CHECK-NEXT: arc.state @Reshuffling_arc(%x.z0, %x.z1) clock %clockA lat 1
-  // CHECK-NEXT: arc.state @Reshuffling_arc_0(%x.z2, %x.z3) clock %clockB lat 1
+  // CHECK-NEXT: arc.state @Reshuffling_arc(%x.z0, %x.z1) clock %clockA latency 1
+  // CHECK-NEXT: arc.state @Reshuffling_arc_0(%x.z2, %x.z3) clock %clockB latency 1
   // CHECK-NEXT: hw.output
   %x.z0, %x.z1, %x.z2, %x.z3 = hw.instance "x" @Reshuffling2() -> (z0: i4, z1: i4, z2: i4, z3: i4)
   %4 = seq.compreg %x.z0, %clockA : i4
@@ -130,8 +130,8 @@ hw.module.extern private @Reshuffling2(out z0: i4, out z1: i4, out z2: i4, out z
 hw.module @FactorOutCommonOps(in %clock: !seq.clock, in %i0: i4, in %i1: i4, out o0: i4, out o1: i4) {
   // CHECK-DAG: [[T0:%.+]] = arc.call @FactorOutCommonOps_arc_1(%i0, %i1)
   %0 = comb.add %i0, %i1 : i4
-  // CHECK-DAG: [[T1:%.+]] = arc.state @FactorOutCommonOps_arc([[T0]], %i0) clock %clock lat 1
-  // CHECK-DAG: [[T2:%.+]] = arc.state @FactorOutCommonOps_arc_0([[T0]], %i1) clock %clock lat 1
+  // CHECK-DAG: [[T1:%.+]] = arc.state @FactorOutCommonOps_arc([[T0]], %i0) clock %clock latency 1
+  // CHECK-DAG: [[T2:%.+]] = arc.state @FactorOutCommonOps_arc_0([[T0]], %i1) clock %clock latency 1
   %1 = comb.xor %0, %i0 : i4
   %2 = comb.mul %0, %i1 : i4
   %3 = seq.compreg %1, %clock : i4
@@ -171,7 +171,7 @@ hw.module.extern private @SplitAtInstance2(in %a: i4, out z: i4)
 // CHECK-LABEL: hw.module @AbsorbNames
 hw.module @AbsorbNames(in %clock: !seq.clock) {
   // CHECK-NEXT: %x.z0, %x.z1 = hw.instance "x" @AbsorbNames2()
-  // CHECK-NEXT: arc.state @AbsorbNames_arc(%x.z0, %x.z1) clock %clock lat 1
+  // CHECK-NEXT: arc.state @AbsorbNames_arc(%x.z0, %x.z1) clock %clock latency 1
   // CHECK-SAME:   {names = ["myRegA", "myRegB"]}
   // CHECK-NEXT: hw.output
   %x.z0, %x.z1 = hw.instance "x" @AbsorbNames2() -> (z0: i4, z1: i4)
@@ -188,7 +188,7 @@ hw.module.extern @AbsorbNames2(out z0: i4, out z1: i4)
 
 // CHECK-LABEL: hw.module @Trivial(
 hw.module @Trivial(in %clock: !seq.clock, in %i0: i4, in %reset: i1, out out: i4) {
-  // CHECK: [[RES0:%.+]] = arc.state @[[TRIVIAL_ARC]](%i0) clock %clock reset %reset lat 1 {names = ["foo"]
+  // CHECK: [[RES0:%.+]] = arc.state @[[TRIVIAL_ARC]](%i0) clock %clock reset %reset latency 1 {names = ["foo"]
   // CHECK-NEXT: hw.output [[RES0:%.+]]
   %0 = hw.constant 0 : i4
   %foo = seq.compreg %i0, %clock reset %reset, %0 : i4
@@ -206,8 +206,8 @@ hw.module @Trivial(in %clock: !seq.clock, in %i0: i4, in %reset: i1, out out: i4
 
 // CHECK-LABEL: hw.module @NonTrivial(
 hw.module @NonTrivial(in %clock: !seq.clock, in %i0: i4, in %reset1: i1, in %reset2: i1, out out1: i4, out out2: i4) {
-  // CHECK: [[RES2:%.+]] = arc.state @[[NONTRIVIAL_ARC_0]](%i0) clock %clock reset %reset1 lat 1 {names = ["foo"]
-  // CHECK-NEXT: [[RES3:%.+]] = arc.state @[[NONTRIVIAL_ARC_1]](%i0) clock %clock reset %reset2 lat 1 {names = ["bar"]
+  // CHECK: [[RES2:%.+]] = arc.state @[[NONTRIVIAL_ARC_0]](%i0) clock %clock reset %reset1 latency 1 {names = ["foo"]
+  // CHECK-NEXT: [[RES3:%.+]] = arc.state @[[NONTRIVIAL_ARC_1]](%i0) clock %clock reset %reset2 latency 1 {names = ["bar"]
   // CHECK-NEXT: hw.output [[RES2]], [[RES3]]
   %0 = hw.constant 0 : i4
   %foo = seq.compreg %i0, %clock reset %reset1, %0 : i4

--- a/test/Dialect/Arc/Reduction/state-elimination.mlir
+++ b/test/Dialect/Arc/Reduction/state-elimination.mlir
@@ -5,7 +5,7 @@
 // CHECK-LABEL: hw.module @Foo
 hw.module @Foo(in %clk: !seq.clock, in %en: i1, in %rst: i1, in %arg0: i32, out out: i32) {
   // CHECK-NEXT: [[V0:%.+]] = arc.call @DummyArc(%arg0) : (i32) -> i32
-  %0 = arc.state @DummyArc(%arg0) clock %clk enable %en reset %rst lat 1 {name="reg1"} : (i32) -> (i32)
+  %0 = arc.state @DummyArc(%arg0) clock %clk enable %en reset %rst latency 1 {name="reg1"} : (i32) -> (i32)
   // CHECK-NEXT: hw.output [[V0]]
   hw.output %0 : i32
 }

--- a/test/Dialect/Arc/arc-canonicalizer.mlir
+++ b/test/Dialect/Arc/arc-canonicalizer.mlir
@@ -8,10 +8,10 @@
 hw.module @passthoughChecks(in %clock: !seq.clock, in %in0: i1, in %in1: i1, out out0: i1, out out1: i1, out out2: i1, out out3: i1, out out4: i1, out out5: i1) {
   %0:2 = arc.call @passthrough(%in0, %in1) : (i1, i1) -> (i1, i1)
   %1:2 = arc.call @noPassthrough(%in0, %in1) : (i1, i1) -> (i1, i1)
-  %2:2 = arc.state @passthrough(%in0, %in1) clock %clock lat 1 : (i1, i1) -> (i1, i1)
+  %2:2 = arc.state @passthrough(%in0, %in1) clock %clock latency 1 : (i1, i1) -> (i1, i1)
   hw.output %0#0, %0#1, %1#0, %1#1, %2#0, %2#1 : i1, i1, i1, i1, i1, i1
   // CHECK-NEXT: [[V0:%.+]]:2 = arc.call @noPassthrough(%in0, %in1) :
-  // CHECK-NEXT: [[V2:%.+]]:2 = arc.state @passthrough(%in0, %in1) clock %clock lat 1 :
+  // CHECK-NEXT: [[V2:%.+]]:2 = arc.state @passthrough(%in0, %in1) clock %clock latency 1 :
   // CHECK-NEXT: hw.output %in0, %in1, [[V0]]#0, [[V0]]#1, [[V2]]#0, [[V2]]#1 :
 }
 arc.define @passthrough(%arg0: i1, %arg1: i1) -> (i1, i1) {
@@ -38,11 +38,11 @@ arc.define @memArcTrue(%arg0: i1, %arg1: i32) -> (i1, i32, i1) {
 hw.module @memoryWritePortCanonicalizations(in %clk: !seq.clock, in %addr: i1, in %data: i32) {
   // CHECK-NEXT: [[MEM:%.+]] = arc.memory <2 x i32, i1>
   %mem = arc.memory <2 x i32, i1>
-  arc.memory_write_port %mem, @memArcFalse(%addr, %data) clock %clk enable lat 1 : <2 x i32, i1>, i1, i32
-  // CHECK-NEXT: arc.memory_write_port [[MEM]], @memArcTrue_0(%addr, %data) clock %clk lat 1 :
-  arc.memory_write_port %mem, @memArcTrue(%addr, %data) clock %clk enable lat 1 : <2 x i32, i1>, i1, i32
-  // CHECK-NEXT: arc.memory_write_port [[MEM]], @memArcTrue_0(%addr, %data) clock %clk lat 1 :
-  arc.memory_write_port %mem, @memArcTrue(%addr, %data) clock %clk enable lat 1 : <2 x i32, i1>, i1, i32
+  arc.memory_write_port %mem, @memArcFalse(%addr, %data) clock %clk enable latency 1 : <2 x i32, i1>, i1, i32
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @memArcTrue_0(%addr, %data) clock %clk latency 1 :
+  arc.memory_write_port %mem, @memArcTrue(%addr, %data) clock %clk enable latency 1 : <2 x i32, i1>, i1, i32
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @memArcTrue_0(%addr, %data) clock %clk latency 1 :
+  arc.memory_write_port %mem, @memArcTrue(%addr, %data) clock %clk enable latency 1 : <2 x i32, i1>, i1, i32
   // COM: trivially dead operation, requires listener callback to keep symbol cache up-to-date
   %0:3 = arc.call @memArcTrue(%addr, %data) : (i1, i32) -> (i1, i32, i1)
   // CHECK-NEXT: hw.output
@@ -149,10 +149,10 @@ arc.define @OneOfThreeUsed(%arg0: i1, %arg1: i1, %arg2: i1) -> i1 {
 
 // CHECK: @test1
 hw.module @test1 (in %arg0: i1, in %arg1: i1, in %arg2: i1, in %clock: !seq.clock, out out0: i1, out out1: i1) {
-  // CHECK-NEXT: arc.state @OneOfThreeUsed(%arg1) clock %clock lat 1 : (i1) -> i1
-  %0 = arc.state @OneOfThreeUsed(%arg0, %arg1, %arg2) clock %clock lat 1 : (i1, i1, i1) -> i1
+  // CHECK-NEXT: arc.state @OneOfThreeUsed(%arg1) clock %clock latency 1 : (i1) -> i1
+  %0 = arc.state @OneOfThreeUsed(%arg0, %arg1, %arg2) clock %clock latency 1 : (i1, i1, i1) -> i1
   // CHECK-NEXT: arc.state @NestedCall(%arg1)
-  %1 = arc.state @NestedCall(%arg0, %arg1, %arg2) clock %clock lat 1 : (i1, i1, i1) -> i1
+  %1 = arc.state @NestedCall(%arg0, %arg1, %arg2) clock %clock latency 1 : (i1, i1, i1) -> i1
   hw.output %0, %1 : i1, i1
 }
 

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -3,7 +3,7 @@
 // expected-error @+1 {{body contains non-pure operation}}
 arc.define @Foo(%arg0: !seq.clock) {
   // expected-note @+1 {{first non-pure operation here:}}
-  arc.state @Bar() clock %arg0 lat 1 : () -> ()
+  arc.state @Bar() clock %arg0 latency 1 : () -> ()
   arc.output
 }
 arc.define @Bar() {
@@ -14,7 +14,7 @@ arc.define @Bar() {
 
 hw.module @Foo(in %clock: !seq.clock) {
   // expected-error @+1 {{'arc.state' op outside a clock domain requires a clock}}
-  arc.state @Bar() lat 1 : () -> ()
+  arc.state @Bar() latency 1 : () -> ()
 }
 arc.define @Bar() {
   arc.output
@@ -24,7 +24,7 @@ arc.define @Bar() {
 
 hw.module @Foo(in %clock: !seq.clock) {
   // expected-error @+1 {{'arc.state' op latency must be a positive integer}}
-  arc.state @Bar() clock %clock lat 0 : () -> ()
+  arc.state @Bar() clock %clock latency 0 : () -> ()
 }
 arc.define @Bar() {
   arc.output
@@ -36,7 +36,7 @@ arc.define @Bar() {
 arc.define @SupportRecursiveMemoryEffects(%arg0: i1, %arg1: !seq.clock) {
   // expected-note @+1 {{first non-pure operation here:}}
   scf.if %arg0 {
-    arc.state @Bar() clock %arg1 lat 1 : () -> ()
+    arc.state @Bar() clock %arg1 latency 1 : () -> ()
   }
   arc.output
 }
@@ -252,7 +252,7 @@ hw.module @stateOpInsideClockDomain(in %clk: !seq.clock) {
   arc.clock_domain (%clk) clock %clk : (!seq.clock) -> () {
   ^bb0(%arg0: !seq.clock):
     // expected-error @+1 {{inside a clock domain cannot have a clock}}
-    arc.state @dummyArc() clock %arg0 lat 1 : () -> ()
+    arc.state @dummyArc() clock %arg0 latency 1 : () -> ()
     arc.output
   }
   hw.output
@@ -269,7 +269,7 @@ hw.module @memoryWritePortOpInsideClockDomain(in %clk: !seq.clock) {
     %mem = arc.memory <4 x i32, i32>
     %c0_i32 = hw.constant 0 : i32
     // expected-error @+1 {{inside a clock domain cannot have a clock}}
-    arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32, %arg0) clock %arg0 enable lat 1: !arc.memory<4 x i32, i32>, i32, i32, !seq.clock
+    arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32, %arg0) clock %arg0 enable latency 1: !arc.memory<4 x i32, i32>, i32, i32, !seq.clock
     arc.output
   }
 }
@@ -283,7 +283,7 @@ hw.module @memoryWritePortOpOutsideClockDomain(in %clock: !seq.clock, in %en: i1
   %mem = arc.memory <4 x i32, i32>
   %c0_i32 = hw.constant 0 : i32
   // expected-error @+1 {{outside a clock domain requires a clock}}
-  arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32, %en) lat 1 : !arc.memory<4 x i32, i32>, i32, i32, i1
+  arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32, %en) latency 1 : !arc.memory<4 x i32, i32>, i32, i32, i1
 }
 arc.define @identity(%addr: i32, %data: i32, %enable: i1) -> (i32, i32, i1) {
   arc.output %addr, %data, %enable : i32, i32, i1
@@ -295,7 +295,7 @@ hw.module @memoryWritePortOpLatZero(in %clock: !seq.clock, in %en: i1) {
   %mem = arc.memory <4 x i32, i32>
   %c0_i32 = hw.constant 0 : i32
   // expected-error @+1 {{latency must be at least 1}}
-  arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32, %en) lat 0 : !arc.memory<4 x i32, i32>, i32, i32, i1
+  arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32, %en) latency 0 : !arc.memory<4 x i32, i32>, i32, i32, i1
 }
 arc.define @identity(%addr: i32, %data: i32, %enable: i1) -> (i32, i32, i1) {
   arc.output %addr, %data, %enable : i32, i32, i1

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -14,11 +14,11 @@ arc.define @Bar(%arg0: i42) -> i42 {
 
 // CHECK-LABEL: hw.module @Module
 hw.module @Module(in %clock: !seq.clock, in %enable: i1, in %a: i42, in %b: i9) {
-  // CHECK: arc.state @Foo(%a, %b) clock %clock lat 1 : (i42, i9) -> (i42, i9)
-  arc.state @Foo(%a, %b) clock %clock lat 1 : (i42, i9) -> (i42, i9)
+  // CHECK: arc.state @Foo(%a, %b) clock %clock latency 1 : (i42, i9) -> (i42, i9)
+  arc.state @Foo(%a, %b) clock %clock latency 1 : (i42, i9) -> (i42, i9)
 
-  // CHECK: arc.state @Foo(%a, %b) clock %clock enable %enable lat 1 : (i42, i9) -> (i42, i9)
-  arc.state @Foo(%a, %b) clock %clock enable %enable lat 1 : (i42, i9) -> (i42, i9)
+  // CHECK: arc.state @Foo(%a, %b) clock %clock enable %enable latency 1 : (i42, i9) -> (i42, i9)
+  arc.state @Foo(%a, %b) clock %clock enable %enable latency 1 : (i42, i9) -> (i42, i9)
 }
 
 // CHECK-LABEL: arc.define @SupportRecurisveMemoryEffects
@@ -115,14 +115,14 @@ hw.module @memoryOps(in %clk: !seq.clock, in %en: i1, in %mask: i32, in %arg: i1
 
   // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM]][%c0_i32] : <4 x i32, i32>
   %0 = arc.memory_read_port %mem[%c0_i32] : <4 x i32, i32>
-  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity1(%c0_i32, %c0_i32, %en) clock %clk enable lat 1 : <4 x i32, i32>, i32, i32, i1
-  arc.memory_write_port %mem, @identity1(%c0_i32, %c0_i32, %en) clock %clk enable lat 1 : <4 x i32, i32>, i32, i32, i1
-  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity2(%c0_i32, %c0_i32, %en, %mask) clock %clk enable mask lat 2 : <4 x i32, i32>, i32, i32, i1, i32
-  arc.memory_write_port %mem, @identity2(%c0_i32, %c0_i32, %en, %mask) clock %clk enable mask lat 2 : <4 x i32, i32>, i32, i32, i1, i32
-  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity3(%c0_i32, %c0_i32, %mask) clock %clk mask lat 3 : <4 x i32, i32>, i32, i32, i32
-  arc.memory_write_port %mem, @identity3(%c0_i32, %c0_i32, %mask) clock %clk mask lat 3 : <4 x i32, i32>, i32, i32, i32
-  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity(%c0_i32, %c0_i32) clock %clk lat 4 : <4 x i32, i32>, i32, i32
-  arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32) clock %clk lat 4 : <4 x i32, i32>, i32, i32
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity1(%c0_i32, %c0_i32, %en) clock %clk enable latency 1 : <4 x i32, i32>, i32, i32, i1
+  arc.memory_write_port %mem, @identity1(%c0_i32, %c0_i32, %en) clock %clk enable latency 1 : <4 x i32, i32>, i32, i32, i1
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity2(%c0_i32, %c0_i32, %en, %mask) clock %clk enable mask latency 2 : <4 x i32, i32>, i32, i32, i1, i32
+  arc.memory_write_port %mem, @identity2(%c0_i32, %c0_i32, %en, %mask) clock %clk enable mask latency 2 : <4 x i32, i32>, i32, i32, i1, i32
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity3(%c0_i32, %c0_i32, %mask) clock %clk mask latency 3 : <4 x i32, i32>, i32, i32, i32
+  arc.memory_write_port %mem, @identity3(%c0_i32, %c0_i32, %mask) clock %clk mask latency 3 : <4 x i32, i32>, i32, i32, i32
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @identity(%c0_i32, %c0_i32) clock %clk latency 4 : <4 x i32, i32>, i32, i32
+  arc.memory_write_port %mem, @identity(%c0_i32, %c0_i32) clock %clk latency 4 : <4 x i32, i32>, i32, i32
 
   // CHECK-NEXT: arc.clock_domain
   arc.clock_domain (%arg) clock %clk : (i1) -> () {
@@ -132,10 +132,10 @@ hw.module @memoryOps(in %clk: !seq.clock, in %en: i1, in %mask: i32, in %arg: i1
     %mem2 = arc.memory <4 x i32, i32>
     // CHECK-NEXT: %{{.+}} = arc.memory_read_port [[MEM2]][%c1_i32] : <4 x i32, i32>
     %2 = arc.memory_read_port %mem2[%c1_i32] : <4 x i32, i32>
-    // CHECK-NEXT: arc.memory_write_port [[MEM2]], @identity1(%c1_i32, %c1_i32, %arg0) enable lat 1 : <4 x i32, i32>, i32, i32, i1
-    arc.memory_write_port %mem2, @identity1(%c1_i32, %c1_i32, %arg0) enable lat 1 : <4 x i32, i32>, i32, i32, i1
-    // CHECK-NEXT: arc.memory_write_port [[MEM2]], @identity(%c1_i32, %c1_i32) lat 1 : <4 x i32, i32>, i32, i32
-    arc.memory_write_port %mem2, @identity(%c1_i32, %c1_i32) lat 1 : <4 x i32, i32>, i32, i32
+    // CHECK-NEXT: arc.memory_write_port [[MEM2]], @identity1(%c1_i32, %c1_i32, %arg0) enable latency 1 : <4 x i32, i32>, i32, i32, i1
+    arc.memory_write_port %mem2, @identity1(%c1_i32, %c1_i32, %arg0) enable latency 1 : <4 x i32, i32>, i32, i32, i1
+    // CHECK-NEXT: arc.memory_write_port [[MEM2]], @identity(%c1_i32, %c1_i32) latency 1 : <4 x i32, i32>, i32, i32
+    arc.memory_write_port %mem2, @identity(%c1_i32, %c1_i32) latency 1 : <4 x i32, i32>, i32, i32
   }
 
   // CHECK: %{{.+}} = arc.memory_read [[MEM]][%c0_i32] : <4 x i32, i32>
@@ -166,7 +166,7 @@ hw.module @vectorize_in_clock_domain(in %in0: i2, in %in1: i2, in %in2: i1, in %
     ^bb0(%arg0: i2, %arg1: i2, %arg2: i1, %arg3: i1):
     %1:2 = arc.vectorize (%arg0, %arg1), (%arg2, %arg3) : (i2, i2, i1, i1) -> (i1, i1) {
     ^bb0(%arg4: i2, %arg5: i1):
-      %2 = arc.state @vectorizable(%arg4, %arg5) lat 1 : (i2, i1) -> i1
+      %2 = arc.state @vectorizable(%arg4, %arg5) latency 1 : (i2, i1) -> i1
       arc.vectorize.return %2 : i1
     }
     arc.output %1#0, %1#1 : i1, i1
@@ -183,7 +183,7 @@ arc.define @vectorizable(%arg0: i2, %arg1: i1) -> i1 {
 //       CHECK: arc.clock_domain
 //       CHECK: %{{.+}}:2 = arc.vectorize ({{.*}}, {{.*}}), ({{.*}}, {{.*}}) : (i2, i2, i1, i1) -> (i1, i1) {
 //       CHECK: ^bb0([[A:%.+]]: i2, [[B:%.+]]: i1):
-//       CHECK:   [[V1:%.+]] = arc.state @vectorizable([[A]], [[B]]) lat 1 : (i2, i1) -> i1
+//       CHECK:   [[V1:%.+]] = arc.state @vectorizable([[A]], [[B]]) latency 1 : (i2, i1) -> i1
 //       CHECK:   arc.vectorize.return [[V1]] : i1
 //       CHECK: }
 

--- a/test/Dialect/Arc/canonicalizers.mlir
+++ b/test/Dialect/Arc/canonicalizers.mlir
@@ -8,36 +8,36 @@ hw.module @stateOpCanonicalizer(in %clk: !seq.clock, in %in: i32, in %en: i1, in
   %true = hw.constant true
   %false = hw.constant false
 
-  arc.state @Foo(%in) clock %clk lat 1 : (i32) -> ()
-  // CHECK-NEXT: {{%.+}} = arc.state @Bar(%in) clock %clk lat 1 {name = "stateName"} : (i32) -> i32
-  %1 = arc.state @Bar(%in) clock %clk lat 1 {name = "stateName"} : (i32) -> i32
-  // CHECK-NEXT: {{%.+}} = arc.state @Bar(%in) clock %clk lat 1 {names = ["stateName"]} : (i32) -> i32
-  %2 = arc.state @Bar(%in) clock %clk lat 1 {names = ["stateName"]} : (i32) -> i32
+  arc.state @Foo(%in) clock %clk latency 1 : (i32) -> ()
+  // CHECK-NEXT: {{%.+}} = arc.state @Bar(%in) clock %clk latency 1 {name = "stateName"} : (i32) -> i32
+  %1 = arc.state @Bar(%in) clock %clk latency 1 {name = "stateName"} : (i32) -> i32
+  // CHECK-NEXT: {{%.+}} = arc.state @Bar(%in) clock %clk latency 1 {names = ["stateName"]} : (i32) -> i32
+  %2 = arc.state @Bar(%in) clock %clk latency 1 {names = ["stateName"]} : (i32) -> i32
 
-  %3 = arc.state @Passthrough(%in) clock %clk enable %false reset %false lat 1 : (i32) -> i32
-  // CHECK-NEXT: [[V4:%.+]] = arc.state @Passthrough(%in) clock %clk lat 1 : (i32) -> i32
-  %4 = arc.state @Passthrough(%in) clock %clk enable %true reset %false lat 1 : (i32) -> i32
-  %5 = arc.state @Passthrough(%in) clock %clk enable %false reset %true lat 1 : (i32) -> i32
-  %6 = arc.state @Passthrough(%in) clock %clk enable %true reset %true lat 1 : (i32) -> i32
+  %3 = arc.state @Passthrough(%in) clock %clk enable %false reset %false latency 1 : (i32) -> i32
+  // CHECK-NEXT: [[V4:%.+]] = arc.state @Passthrough(%in) clock %clk latency 1 : (i32) -> i32
+  %4 = arc.state @Passthrough(%in) clock %clk enable %true reset %false latency 1 : (i32) -> i32
+  %5 = arc.state @Passthrough(%in) clock %clk enable %false reset %true latency 1 : (i32) -> i32
+  %6 = arc.state @Passthrough(%in) clock %clk enable %true reset %true latency 1 : (i32) -> i32
 
-  %7 = arc.state @Passthrough(%in) clock %clk enable %false reset %rst lat 1 : (i32) -> i32
-  // CHECK-NEXT: [[V8:%.+]] = arc.state @Passthrough(%in) clock %clk reset %rst lat 1 : (i32) -> i32
-  %8 = arc.state @Passthrough(%in) clock %clk enable %true reset %rst lat 1 : (i32) -> i32
-  // CHECK-NEXT: [[V9:%.+]] = arc.state @Passthrough(%in) clock %clk enable %en lat 1 : (i32) -> i32
-  %9 = arc.state @Passthrough(%in) clock %clk enable %en reset %false lat 1 : (i32) -> i32
-  %10 = arc.state @Passthrough(%in) clock %clk enable %en reset %true lat 1 : (i32) -> i32
+  %7 = arc.state @Passthrough(%in) clock %clk enable %false reset %rst latency 1 : (i32) -> i32
+  // CHECK-NEXT: [[V8:%.+]] = arc.state @Passthrough(%in) clock %clk reset %rst latency 1 : (i32) -> i32
+  %8 = arc.state @Passthrough(%in) clock %clk enable %true reset %rst latency 1 : (i32) -> i32
+  // CHECK-NEXT: [[V9:%.+]] = arc.state @Passthrough(%in) clock %clk enable %en latency 1 : (i32) -> i32
+  %9 = arc.state @Passthrough(%in) clock %clk enable %en reset %false latency 1 : (i32) -> i32
+  %10 = arc.state @Passthrough(%in) clock %clk enable %en reset %true latency 1 : (i32) -> i32
 
-  %11:2 = arc.state @Passthrough2(%in, %in) clock %clk enable %false lat 1 : (i32, i32) -> (i32, i32)
-  // CHECK-NEXT: [[V12:%.+]]:2 = arc.state @Passthrough2(%in, %in) clock %clk lat 1 : (i32, i32) -> (i32, i32)
-  %12:2 = arc.state @Passthrough2(%in, %in) clock %clk enable %true lat 1 : (i32, i32) -> (i32, i32)
-  // CHECK-NEXT: [[V13:%.+]]:2 = arc.state @Passthrough2(%in, %in) clock %clk lat 1 : (i32, i32) -> (i32, i32)
-  %13:2 = arc.state @Passthrough2(%in, %in) clock %clk reset %false lat 1 : (i32, i32) -> (i32, i32)
-  %14:2 = arc.state @Passthrough2(%in, %in) clock %clk reset %true lat 1 : (i32, i32) -> (i32, i32)
+  %11:2 = arc.state @Passthrough2(%in, %in) clock %clk enable %false latency 1 : (i32, i32) -> (i32, i32)
+  // CHECK-NEXT: [[V12:%.+]]:2 = arc.state @Passthrough2(%in, %in) clock %clk latency 1 : (i32, i32) -> (i32, i32)
+  %12:2 = arc.state @Passthrough2(%in, %in) clock %clk enable %true latency 1 : (i32, i32) -> (i32, i32)
+  // CHECK-NEXT: [[V13:%.+]]:2 = arc.state @Passthrough2(%in, %in) clock %clk latency 1 : (i32, i32) -> (i32, i32)
+  %13:2 = arc.state @Passthrough2(%in, %in) clock %clk reset %false latency 1 : (i32, i32) -> (i32, i32)
+  %14:2 = arc.state @Passthrough2(%in, %in) clock %clk reset %true latency 1 : (i32, i32) -> (i32, i32)
 
-  // CHECK-NEXT: %{{.+}} = arc.state @Passthrough(%in) clock %clk enable %false reset %true lat 1 {name = "stateName"} : (i32) -> i32
-  %15 = arc.state @Passthrough(%in) clock %clk enable %false reset %true lat 1 {name = "stateName"} : (i32) -> i32
-  // CHECK-NEXT: %{{.+}} = arc.state @Passthrough(%in) clock %clk enable %false reset %true lat 1 {names = ["stateName"]} : (i32) -> i32
-  %16 = arc.state @Passthrough(%in) clock %clk enable %false reset %true lat 1 {names = ["stateName"]} : (i32) -> i32
+  // CHECK-NEXT: %{{.+}} = arc.state @Passthrough(%in) clock %clk enable %false reset %true latency 1 {name = "stateName"} : (i32) -> i32
+  %15 = arc.state @Passthrough(%in) clock %clk enable %false reset %true latency 1 {name = "stateName"} : (i32) -> i32
+  // CHECK-NEXT: %{{.+}} = arc.state @Passthrough(%in) clock %clk enable %false reset %true latency 1 {names = ["stateName"]} : (i32) -> i32
+  %16 = arc.state @Passthrough(%in) clock %clk enable %false reset %true latency 1 {names = ["stateName"]} : (i32) -> i32
 
   // CHECK-NEXT: hw.output %c0_i32, [[V4]], %c0_i32, %c0_i32, %c0_i32, [[V8]], [[V9]], %c0_i32, %c0_i32, %c0_i32, [[V12]]#0, [[V12]]#1, [[V13]]#0, [[V13]]#1, %c0_i32, %c0_i32 : i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
   hw.output %3, %4, %5, %6, %7, %8, %9, %10, %11#0, %11#1, %12#0, %12#1, %13#0, %13#1, %14#0, %14#1 : i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
@@ -86,10 +86,10 @@ hw.module @clockDomainCanonicalizer(in %clk: !seq.clock, in %data: i32, out out0
   // CHECK-NEXT: [[T:%.+]] = hw.constant true
   // CHECK-NEXT: [[C0:%.+]] = hw.constant 0
   // CHECK-NEXT: [[MEM:%.+]] = arc.memory
-  // CHECK-NEXT: arc.memory_write_port [[MEM]], @memWrite([[C0]], [[C0]], [[T]]) enable lat 1 :
+  // CHECK-NEXT: arc.memory_write_port [[MEM]], @memWrite([[C0]], [[C0]], [[T]]) enable latency 1 :
   %0 = arc.clock_domain (%c0_i32, %mem, %true) clock %clk : (i32, !arc.memory<4 x i32, i32>, i1) -> i32 {
   ^bb0(%arg0: i32, %arg1: !arc.memory<4 x i32, i32>, %arg2: i1):
-    arc.memory_write_port %arg1, @memWrite(%arg0, %arg0, %arg2) enable lat 1 : !arc.memory<4 x i32, i32>, i32, i32, i1
+    arc.memory_write_port %arg1, @memWrite(%arg0, %arg0, %arg2) enable latency 1 : !arc.memory<4 x i32, i32>, i32, i32, i1
     arc.output %arg0 : i32
   }
   // COM: check that unused inputs are removed, and constants are cloned into it
@@ -98,7 +98,7 @@ hw.module @clockDomainCanonicalizer(in %clk: !seq.clock, in %data: i32, out out0
   // CHECK-NEXT: arc.state
   %1 = arc.clock_domain (%true, %data) clock %clk : (i1, i32) -> i1 {
   ^bb0(%arg0: i1, %arg1: i32):
-    %1 = arc.state @identityi1(%arg0) lat 1 : (i1) -> i1
+    %1 = arc.state @identityi1(%arg0) latency 1 : (i1) -> i1
     arc.output %1 : i1
   }
   // COM: check that duplicate inputs are merged
@@ -106,7 +106,7 @@ hw.module @clockDomainCanonicalizer(in %clk: !seq.clock, in %data: i32, out out0
   %2 = arc.clock_domain (%data, %data, %data) clock %clk : (i32, i32, i32) -> i32 {
   ^bb0(%arg0: i32, %arg1: i32, %arg2: i32):
     %3 = comb.add %arg0, %arg1, %arg2 : i32
-    %4 = arc.state @Passthrough(%3) lat 1 : (i32) -> i32
+    %4 = arc.state @Passthrough(%3) latency 1 : (i32) -> i32
     arc.output %4 : i32
   }
   // COM: check that unused outputs are removed
@@ -120,8 +120,8 @@ hw.module @clockDomainCanonicalizer(in %clk: !seq.clock, in %data: i32, out out0
   ^bb0(%arg0: i32, %arg1: i32):
   // TODO: add op such that it is not folded away because it's just passthrough
     %3 = hw.constant 0 : i32
-    %4 = arc.state @Passthrough(%arg1) lat 1 : (i32) -> i32
-    %5 = arc.state @Passthrough(%arg0) lat 1 : (i32) -> i32
+    %4 = arc.state @Passthrough(%arg1) latency 1 : (i32) -> i32
+    %5 = arc.state @Passthrough(%arg0) latency 1 : (i32) -> i32
     arc.output %arg0, %3, %4, %5 : i32, i32, i32, i32
   }
 

--- a/test/Dialect/Arc/infer-memories.mlir
+++ b/test/Dialect/Arc/infer-memories.mlir
@@ -7,7 +7,7 @@ hw.generator.schema @FIRRTLMem, "FIRRTL_Memory", ["depth", "numReadPorts", "numW
 hw.module @TestWOMemory(in %clock: !seq.clock, in %addr: i10, in %enable: i1, in %data: i8) {
   // CHECK-NOT: hw.instance
   // CHECK-NEXT: [[FOO:%.+]] = arc.memory <1024 x i8, i10> {name = "foo"}
-  // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %data, %enable) clock %clock enable lat 1 : <1024 x i8, i10>, i10, i8, i1
+  // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %data, %enable) clock %clock enable latency 1 : <1024 x i8, i10>, i10, i8, i1
   // CHECK-NEXT: hw.output
   hw.instance "foo" @WOMemory(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: !seq.clock, W0_data: %data: i8) -> ()
 }
@@ -25,7 +25,7 @@ hw.module @TestWOMemoryWithMask(in %clock: !seq.clock, in %addr: i10, in %enable
   // CHECK-NEXT: [[MASK_BIT1:%.+]] = comb.extract %mask from 1 : (i2) -> i1
   // CHECK-NEXT: [[MASK_BYTE1:%.+]] = comb.replicate [[MASK_BIT1]] : (i1) -> i8
   // CHECK-NEXT: [[MASK:%.+]] = comb.concat [[MASK_BYTE1]], [[MASK_BYTE0]]
-  // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %data, %enable, [[MASK]]) clock %clock enable mask lat 1 : <1024 x i16, i10>, i10, i16, i1, i16
+  // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %data, %enable, [[MASK]]) clock %clock enable mask latency 1 : <1024 x i16, i10>, i10, i16, i1, i16
   // CHECK-NEXT: hw.output
   hw.instance "foo" @WOMemoryWithMask(W0_addr: %addr: i10, W0_en: %enable: i1, W0_clk: %clock: !seq.clock, W0_data: %data: i16, W0_mask: %mask: i2) -> ()
 }
@@ -83,7 +83,7 @@ hw.module @TestRWMemory(in %clock: !seq.clock, in %addr: i10, in %enable: i1, in
   // CHECK-NEXT: [[ZERO:%.+]] = hw.constant 0 : i8
   // CHECK-NEXT: [[MUX:%.+]] = comb.mux [[RENABLE]], [[RDATA]], [[ZERO]] : i8
   // CHECK-NEXT: [[WENABLE:%.+]] = comb.and %enable, %wmode
-  // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %wdata, [[WENABLE]]) clock %clock enable lat 1 : <1024 x i8, i10>, i10, i8, i1
+  // CHECK-NEXT: arc.memory_write_port [[FOO]], @mem_write{{.*}}(%addr, %wdata, [[WENABLE]]) clock %clock enable latency 1 : <1024 x i8, i10>, i10, i8, i1
   // CHECK-NEXT: hw.output [[MUX]]
   %0 = hw.instance "foo" @RWMemory(RW0_addr: %addr: i10, RW0_en: %enable: i1, RW0_clk: %clock: !seq.clock, RW0_wmode: %wmode: i1, RW0_wdata: %wdata: i8) -> (RW0_rdata: i8)
   hw.output %0 : i8

--- a/test/Dialect/Arc/infer-state-properties.mlir
+++ b/test/Dialect/Arc/infer-state-properties.mlir
@@ -173,76 +173,76 @@ arc.define @onlyOneReset(%arg0: i1, %arg1: i1, %arg2: i1) -> (i1, i1) {
 // CHECK-LABEL: hw.module @testModule
 hw.module @testModule (in %arg0: i1, in %arg1: i1, in %arg2: i1, in %arg3: i1, in %clock: !seq.clock) {
   // COM: Test: AND based reset pattern detected
-  // CHECK: arc.state @ANDBasedReset(%arg0, %arg1, %arg2) clock %clock reset %arg0 lat 1 : (i1, i1, i1) -> i1
-  %0 = arc.state @ANDBasedReset(%arg0, %arg1, %arg2) clock %clock lat 1 : (i1, i1, i1) -> i1
+  // CHECK: arc.state @ANDBasedReset(%arg0, %arg1, %arg2) clock %clock reset %arg0 latency 1 : (i1, i1, i1) -> i1
+  %0 = arc.state @ANDBasedReset(%arg0, %arg1, %arg2) clock %clock latency 1 : (i1, i1, i1) -> i1
 
   // COM: Test: MUX based reset pattern detected
-  // CHECK: arc.state @MUXBasedReset(%arg0, %arg1, %arg2) clock %clock reset %arg0 lat 1 : (i1, i1, i1) -> i1
-  %1 = arc.state @MUXBasedReset(%arg0, %arg1, %arg2) clock %clock lat 1 : (i1, i1, i1) -> i1
+  // CHECK: arc.state @MUXBasedReset(%arg0, %arg1, %arg2) clock %clock reset %arg0 latency 1 : (i1, i1, i1) -> i1
+  %1 = arc.state @MUXBasedReset(%arg0, %arg1, %arg2) clock %clock latency 1 : (i1, i1, i1) -> i1
 
   // COM: Test: MUX based enable pattern detected
-  // CHECK: arc.state @enable(%true{{(_[0-9]+)?}}, %arg1, %arg2, %false{{(_[0-9]+)?}}) clock %clock enable %arg0 lat 1 : (i1, i1, i1, i1) -> i1
-  %2 = arc.state @enable(%arg0, %arg1, %arg2, %2) clock %clock lat 1 : (i1, i1, i1, i1) -> i1
+  // CHECK: arc.state @enable(%true{{(_[0-9]+)?}}, %arg1, %arg2, %false{{(_[0-9]+)?}}) clock %clock enable %arg0 latency 1 : (i1, i1, i1, i1) -> i1
+  %2 = arc.state @enable(%arg0, %arg1, %arg2, %2) clock %clock latency 1 : (i1, i1, i1, i1) -> i1
 
   // COM: Test: MUX based disable pattern detected
   // CHECK: [[DISABLE:%.+]] = comb.xor %arg0, %true{{(_[0-9]+)?}}
-  // CHECK: arc.state @disable(%false{{(_[0-9]+)?}}, %arg1, %arg2, %false{{(_[0-9]+)?}}) clock %clock enable [[DISABLE]] lat 1 : (i1, i1, i1, i1) -> i1
-  %3 = arc.state @disable(%arg0, %arg1, %arg2, %3) clock %clock lat 1 : (i1, i1, i1, i1) -> i1
+  // CHECK: arc.state @disable(%false{{(_[0-9]+)?}}, %arg1, %arg2, %false{{(_[0-9]+)?}}) clock %clock enable [[DISABLE]] latency 1 : (i1, i1, i1, i1) -> i1
+  %3 = arc.state @disable(%arg0, %arg1, %arg2, %3) clock %clock latency 1 : (i1, i1, i1, i1) -> i1
 
   // COM: Test: both reset and enable are detected in one go
-  // CHECK: arc.state @resetAndEnable(%true{{(_[0-9]+)?}}, %arg1, %arg2, %false{{(_[0-9]+)?}}, %arg3) clock %clock enable %arg0 reset %arg3 lat 1 : (i1, i1, i1, i1, i1) -> i1
-  %4 = arc.state @resetAndEnable(%arg0, %arg1, %arg2, %4, %arg3) clock %clock lat 1 : (i1, i1, i1, i1, i1) -> i1
+  // CHECK: arc.state @resetAndEnable(%true{{(_[0-9]+)?}}, %arg1, %arg2, %false{{(_[0-9]+)?}}, %arg3) clock %clock enable %arg0 reset %arg3 latency 1 : (i1, i1, i1, i1, i1) -> i1
+  %4 = arc.state @resetAndEnable(%arg0, %arg1, %arg2, %4, %arg3) clock %clock latency 1 : (i1, i1, i1, i1, i1) -> i1
 
   // COM: Test: mixed enables and disables do not work
-  // CHECK-NEXT: [[EN_DIS:%.+]]:2 = arc.state @mixedEnableAndDisable(%arg0, %arg1, %arg2, [[EN_DIS]]#0, [[EN_DIS]]#1) clock %clock lat 1 : (i1, i1, i1, i1, i1) -> (i1, i1)
-  %5, %6 = arc.state @mixedEnableAndDisable(%arg0, %arg1, %arg2, %5, %6) clock %clock lat 1 : (i1, i1, i1, i1, i1) -> (i1, i1)
+  // CHECK-NEXT: [[EN_DIS:%.+]]:2 = arc.state @mixedEnableAndDisable(%arg0, %arg1, %arg2, [[EN_DIS]]#0, [[EN_DIS]]#1) clock %clock latency 1 : (i1, i1, i1, i1, i1) -> (i1, i1)
+  %5, %6 = arc.state @mixedEnableAndDisable(%arg0, %arg1, %arg2, %5, %6) clock %clock latency 1 : (i1, i1, i1, i1, i1) -> (i1, i1)
 
   // COM: Test: mixed MUX and AND resets for different output work
-  // CHECK-NEXT: arc.state @mixedAndMuxReset(%arg0, %arg1, %arg2) clock %clock reset %arg0 lat 1 : (i1, i1, i1) -> (i1, i1)
-  %7, %8 = arc.state @mixedAndMuxReset(%arg0, %arg1, %arg2) clock %clock lat 1 : (i1, i1, i1) -> (i1, i1)
+  // CHECK-NEXT: arc.state @mixedAndMuxReset(%arg0, %arg1, %arg2) clock %clock reset %arg0 latency 1 : (i1, i1, i1) -> (i1, i1)
+  %7, %8 = arc.state @mixedAndMuxReset(%arg0, %arg1, %arg2) clock %clock latency 1 : (i1, i1, i1) -> (i1, i1)
 
   // COM: Test: mixed MUX and AND resets do not work when the reset conditions are different
-  // CHECK-NEXT: arc.state @mixedAndMuxResetDifferentConditions(%arg0, %arg1, %arg2, %arg3) clock %clock lat 1 : (i1, i1, i1, i1) -> (i1, i1)
-  %9, %10 = arc.state @mixedAndMuxResetDifferentConditions(%arg0, %arg1, %arg2, %arg3) clock %clock lat 1 : (i1, i1, i1, i1) -> (i1, i1)
+  // CHECK-NEXT: arc.state @mixedAndMuxResetDifferentConditions(%arg0, %arg1, %arg2, %arg3) clock %clock latency 1 : (i1, i1, i1, i1) -> (i1, i1)
+  %9, %10 = arc.state @mixedAndMuxResetDifferentConditions(%arg0, %arg1, %arg2, %arg3) clock %clock latency 1 : (i1, i1, i1, i1) -> (i1, i1)
 
   // COM: Test: Reset can be pulled out even if there is already a reset operand
   // CHECK-NEXT: [[NEW_RST:%.+]] = comb.or %arg1, %arg0 : i1
-  // CHECK-NEXT: arc.state @MUXBasedReset(%arg0, %arg1, %arg2) clock %clock reset [[NEW_RST]] lat 1 : (i1, i1, i1) -> i1
-  %11 = arc.state @MUXBasedReset(%arg0, %arg1, %arg2) clock %clock reset %arg1 lat 1 : (i1, i1, i1) -> i1
+  // CHECK-NEXT: arc.state @MUXBasedReset(%arg0, %arg1, %arg2) clock %clock reset [[NEW_RST]] latency 1 : (i1, i1, i1) -> i1
+  %11 = arc.state @MUXBasedReset(%arg0, %arg1, %arg2) clock %clock reset %arg1 latency 1 : (i1, i1, i1) -> i1
 
   // COM: Test: Enable can be pulled out even if there is already an enable operand
   // CHECK: [[NEW_EN:%.+]] = comb.and %arg1, %arg0 : i1
-  // CHECK: arc.state @enable(%true{{(_[0-9]+)?}}, %arg1, %arg2, %false{{(_[0-9]+)?}}) clock %clock enable [[NEW_EN]] lat 1 : (i1, i1, i1, i1) -> i1
-  %12 = arc.state @enable(%arg0, %arg1, %arg2, %12) clock %clock enable %arg1 lat 1 : (i1, i1, i1, i1) -> i1
+  // CHECK: arc.state @enable(%true{{(_[0-9]+)?}}, %arg1, %arg2, %false{{(_[0-9]+)?}}) clock %clock enable [[NEW_EN]] latency 1 : (i1, i1, i1, i1) -> i1
+  %12 = arc.state @enable(%arg0, %arg1, %arg2, %12) clock %clock enable %arg1 latency 1 : (i1, i1, i1, i1) -> i1
 
   // COM: Test: Reset can be pulled out even if there is already an enable operand
   // CHECK: [[RST_COND:%.+]] = comb.and %arg1, %arg0 : i1
-  // CHECK: arc.state @MUXBasedReset(%arg0, %arg1, %arg2) clock %clock enable %arg1 reset [[RST_COND]] lat 1 : (i1, i1, i1) -> i1
-  %13 = arc.state @MUXBasedReset(%arg0, %arg1, %arg2) clock %clock enable %arg1 lat 1 : (i1, i1, i1) -> i1
+  // CHECK: arc.state @MUXBasedReset(%arg0, %arg1, %arg2) clock %clock enable %arg1 reset [[RST_COND]] latency 1 : (i1, i1, i1) -> i1
+  %13 = arc.state @MUXBasedReset(%arg0, %arg1, %arg2) clock %clock enable %arg1 latency 1 : (i1, i1, i1) -> i1
 
   // COM: Test: mixed high and low resets cannot be pulled out
-  // CHECK-NEXT: arc.state @mixedAndMuxResetLowAndHigh(%arg0, %arg1, %arg2) clock %clock lat 1 : (i1, i1, i1) -> (i1, i1)
-  %14, %15 = arc.state @mixedAndMuxResetLowAndHigh(%arg0, %arg1, %arg2) clock %clock lat 1 : (i1, i1, i1) -> (i1, i1)
+  // CHECK-NEXT: arc.state @mixedAndMuxResetLowAndHigh(%arg0, %arg1, %arg2) clock %clock latency 1 : (i1, i1, i1) -> (i1, i1)
+  %14, %15 = arc.state @mixedAndMuxResetLowAndHigh(%arg0, %arg1, %arg2) clock %clock latency 1 : (i1, i1, i1) -> (i1, i1)
 
   // COM: Test: outputs with different enable conditions cannot be combined
-  // CHECK-NEXT: [[EN0:%.+]]:2 = arc.state @differentEnables(%arg0, %arg1, %arg2, [[EN0]]#0, [[EN0]]#1) clock %clock lat 1 : (i1, i1, i1, i1, i1) -> (i1, i1)
-  %16, %17 = arc.state @differentEnables(%arg0, %arg1, %arg2, %16, %17) clock %clock lat 1 : (i1, i1, i1, i1, i1) -> (i1, i1)
+  // CHECK-NEXT: [[EN0:%.+]]:2 = arc.state @differentEnables(%arg0, %arg1, %arg2, [[EN0]]#0, [[EN0]]#1) clock %clock latency 1 : (i1, i1, i1, i1, i1) -> (i1, i1)
+  %16, %17 = arc.state @differentEnables(%arg0, %arg1, %arg2, %16, %17) clock %clock latency 1 : (i1, i1, i1, i1, i1) -> (i1, i1)
 
   // COM: Test: enable where not all outputs have them (some have none rather than mismatching) cannot be combined
-  // CHECK-NEXT: [[EN1:%.+]]:2 = arc.state @onlyOneEnable(%arg0, %arg1, %arg2, [[EN1]]#0) clock %clock lat 1 : (i1, i1, i1, i1) -> (i1, i1)
-  %18, %19 = arc.state @onlyOneEnable(%arg0, %arg1, %arg2, %18) clock %clock lat 1 : (i1, i1, i1, i1) -> (i1, i1)
+  // CHECK-NEXT: [[EN1:%.+]]:2 = arc.state @onlyOneEnable(%arg0, %arg1, %arg2, [[EN1]]#0) clock %clock latency 1 : (i1, i1, i1, i1) -> (i1, i1)
+  %18, %19 = arc.state @onlyOneEnable(%arg0, %arg1, %arg2, %18) clock %clock latency 1 : (i1, i1, i1, i1) -> (i1, i1)
 
   // COM: Test: reset where not all outputs have them (some have none rather than mismatching) cannot be combined
-  // CHECK-NEXT: arc.state @onlyOneReset(%arg0, %arg1, %arg2) clock %clock lat 1 : (i1, i1, i1) -> (i1, i1)
-  %20, %21 = arc.state @onlyOneReset(%arg0, %arg1, %arg2) clock %clock lat 1 : (i1, i1, i1) -> (i1, i1)
+  // CHECK-NEXT: arc.state @onlyOneReset(%arg0, %arg1, %arg2) clock %clock latency 1 : (i1, i1, i1) -> (i1, i1)
+  %20, %21 = arc.state @onlyOneReset(%arg0, %arg1, %arg2) clock %clock latency 1 : (i1, i1, i1) -> (i1, i1)
 
   // COM: the next case can in theory be supported, but requires quite a bit more complexity in the pass
-  // CHECK-NEXT: [[EN2:%.+]] = arc.state @enableConditionHasOtherUse(%arg0, %arg1, [[EN2]]) clock %clock lat 1 : (i1, i1, i1) -> i1
-  %22 = arc.state @enableConditionHasOtherUse(%arg0, %arg1, %22) clock %clock lat 1 : (i1, i1, i1) -> i1
+  // CHECK-NEXT: [[EN2:%.+]] = arc.state @enableConditionHasOtherUse(%arg0, %arg1, [[EN2]]) clock %clock latency 1 : (i1, i1, i1) -> i1
+  %22 = arc.state @enableConditionHasOtherUse(%arg0, %arg1, %22) clock %clock latency 1 : (i1, i1, i1) -> i1
 
   // COM: Test: When the feedback loop has another use inside the arc, we can not simply replace it with constant 0
-  // CHECK: [[EN3:%.+]] = arc.state @enableFeedbackHasOtherUse(%true{{(_[0-9]+)?}}, %arg1, [[EN3]]) clock %clock enable %arg0 lat 1 : (i1, i1, i1) -> i1
-  %23 = arc.state @enableFeedbackHasOtherUse(%arg0, %arg1, %23) clock %clock lat 1 : (i1, i1, i1) -> i1
+  // CHECK: [[EN3:%.+]] = arc.state @enableFeedbackHasOtherUse(%true{{(_[0-9]+)?}}, %arg1, [[EN3]]) clock %clock enable %arg0 latency 1 : (i1, i1, i1) -> i1
+  %23 = arc.state @enableFeedbackHasOtherUse(%arg0, %arg1, %23) clock %clock latency 1 : (i1, i1, i1) -> i1
 }
 
 // TODO: test that patterns handle the case where the output is used for another thing as well properly

--- a/test/Dialect/Arc/inline-arcs.mlir
+++ b/test/Dialect/Arc/inline-arcs.mlir
@@ -6,10 +6,10 @@
 // CHECK-LABEL: func.func @Simple
 func.func @Simple(%arg0: i4, %arg1: !seq.clock) -> (i4, i4) {
   // CHECK-NEXT: %0 = comb.and %arg0, %arg0
-  // CHECK-NEXT: %1 = arc.state @SimpleB(%arg0) clock %arg1 lat 1
+  // CHECK-NEXT: %1 = arc.state @SimpleB(%arg0) clock %arg1 latency 1
   // CHECK-NEXT: return %0, %1
   %0 = arc.call @SimpleA(%arg0) : (i4) -> i4
-  %1 = arc.state @SimpleB(%arg0) clock %arg1 lat 1 : (i4) -> i4
+  %1 = arc.state @SimpleB(%arg0) clock %arg1 latency 1 : (i4) -> i4
   return %0, %1 : i4, i4
 }
 // CHECK-NEXT:  }
@@ -102,8 +102,8 @@ arc.define @sub5(%arg0: index, %arg1: i4) -> i4 {
 
 // CHECK-LABEL: hw.module @TopLevel
 hw.module @TopLevel(in %clk: !seq.clock, in %arg0: i32, in %arg1: i32, out out0: i32, out out1: i32, out out2: i32, out out3: i32) {
-  %0:2 = arc.state @inlineIntoArc(%arg0, %arg1) clock %clk lat 1 : (i32, i32) -> (i32, i32)
-  %1:2 = arc.state @inlineIntoArc2(%arg0, %arg1) clock %clk lat 1 : (i32, i32) -> (i32, i32)
+  %0:2 = arc.state @inlineIntoArc(%arg0, %arg1) clock %clk latency 1 : (i32, i32) -> (i32, i32)
+  %1:2 = arc.state @inlineIntoArc2(%arg0, %arg1) clock %clk latency 1 : (i32, i32) -> (i32, i32)
   hw.output %0#0, %0#1, %1#0, %1#1 : i32, i32, i32, i32
 }
 

--- a/test/Dialect/Arc/isolate-clocks.mlir
+++ b/test/Dialect/Arc/isolate-clocks.mlir
@@ -5,14 +5,14 @@ hw.module @basics(in %clk0: !seq.clock, in %clk1: !seq.clock, in %clk2: !seq.clo
   // COM: check the basic things: clocked ops are grouped properly
   // COM: are not considered clocked, clock domain materialization
   %0 = comb.and %c0, %c1 : i1
-  %1 = arc.state @DummyArc(%in) clock %clk0 enable %0 reset %c1 lat 1 : (i32) -> i32
+  %1 = arc.state @DummyArc(%in) clock %clk0 enable %0 reset %c1 latency 1 : (i32) -> i32
   %mem = arc.memory <2 x i32, i1>
-  arc.memory_write_port %mem, @identity(%c0, %2) clock %clk0 lat 1 : <2 x i32, i1>, i1, i32
+  arc.memory_write_port %mem, @identity(%c0, %2) clock %clk0 latency 1 : <2 x i32, i1>, i1, i32
   %2 = arc.memory_read_port %mem[%c0] : <2 x i32, i1>
-  arc.memory_write_port %mem, @identity(%c1, %1) clock %clk0 lat 1 : <2 x i32, i1>, i1, i32
-  %3 = arc.state @DummyArc(%4) clock %clk1 enable %0 reset %c1  lat 1 : (i32) -> i32
+  arc.memory_write_port %mem, @identity(%c1, %1) clock %clk0 latency 1 : <2 x i32, i1>, i1, i32
+  %3 = arc.state @DummyArc(%4) clock %clk1 enable %0 reset %c1  latency 1 : (i32) -> i32
   %4 = arc.call @DummyArc(%2) : (i32) -> i32
-  %5 = arc.state @DummyArc(%4) clock %clk2 lat 1 : (i32) -> i32
+  %5 = arc.state @DummyArc(%4) clock %clk2 latency 1 : (i32) -> i32
   hw.output %3, %5 : i32, i32
 
   // CHECK-NEXT: [[V0:%.+]] = comb.and %c0, %c1 : i1
@@ -21,18 +21,18 @@ hw.module @basics(in %clk0: !seq.clock, in %clk1: !seq.clock, in %clk2: !seq.clo
   // CHECK-NEXT: [[V1:%.+]] = arc.call @DummyArc([[V6]]) : (i32) -> i32
   // CHECK-NEXT: arc.clock_domain ([[MEM]], %c1, %c0, [[V6]], [[V0]], %in) clock %clk0 : (!arc.memory<2 x i32, i1>, i1, i1, i32, i1, i32) -> () {
   // CHECK-NEXT: ^bb0(%arg0: !arc.memory<2 x i32, i1>, %arg1: i1, %arg2: i1, %arg3: i32, %arg4: i1, %arg5: i32):
-  // CHECK-NEXT:   arc.memory_write_port %arg0, @identity(%arg1, [[V7:%.+]]) lat 1 :
-  // CHECK-NEXT:   arc.memory_write_port %arg0, @identity(%arg2, %arg3) lat 1 :
-  // CHECK-NEXT:   [[V7]] = arc.state @DummyArc(%arg5) enable %arg4 reset %arg1 lat 1 : (i32) -> i32
+  // CHECK-NEXT:   arc.memory_write_port %arg0, @identity(%arg1, [[V7:%.+]]) latency 1 :
+  // CHECK-NEXT:   arc.memory_write_port %arg0, @identity(%arg2, %arg3) latency 1 :
+  // CHECK-NEXT:   [[V7]] = arc.state @DummyArc(%arg5) enable %arg4 reset %arg1 latency 1 : (i32) -> i32
   // CHECK-NEXT: }
   // CHECK-NEXT: [[V3:%.+]] = arc.clock_domain ([[V0]], %c1, [[V1]]) clock %clk1 : (i1, i1, i32) -> i32 {
   // CHECK-NEXT: ^bb0(%arg0: i1, %arg1: i1, %arg2: i32):
-  // CHECK-NEXT:   [[V5:%.+]] = arc.state @DummyArc(%arg2) enable %arg0 reset %arg1 lat 1 : (i32) -> i32
+  // CHECK-NEXT:   [[V5:%.+]] = arc.state @DummyArc(%arg2) enable %arg0 reset %arg1 latency 1 : (i32) -> i32
   // CHECK-NEXT:   arc.output [[V5]] : i32
   // CHECK-NEXT: }
   // CHECK-NEXT: [[V4:%.+]] = arc.clock_domain ([[V1]]) clock %clk2 : (i32) -> i32 {
   // CHECK-NEXT: ^bb0(%arg0: i32):
-  // CHECK-NEXT:   [[V5:%.+]] = arc.state @DummyArc(%arg0) lat 1 : (i32) -> i32
+  // CHECK-NEXT:   [[V5:%.+]] = arc.state @DummyArc(%arg0) latency 1 : (i32) -> i32
   // CHECK-NEXT:   arc.output [[V5]] : i32
   // CHECK-NEXT: }
   // CHECK-NEXT: hw.output [[V3]], [[V4]] : i32, i32
@@ -49,40 +49,40 @@ hw.module @preexistingClockDomain(in %clk0: !seq.clock, in %clk1: !seq.clock, in
   // COM: the pass also works when there are already clock domains present, but
   // COM: it creates new clock domain ops for all clocks of clocked operations
   // COM: outside of the existing domains instead of merging them.
-  %0 = arc.state @DummyArc(%in) clock %clk0 lat 1 : (i32) -> i32
+  %0 = arc.state @DummyArc(%in) clock %clk0 latency 1 : (i32) -> i32
   %1 = arc.clock_domain (%0) clock %clk0 : (i32) -> i32 {
   ^bb0(%arg0: i32):
-    %2 = arc.state @DummyArc(%arg0) lat 1 : (i32) -> i32
+    %2 = arc.state @DummyArc(%arg0) latency 1 : (i32) -> i32
     arc.output %2 : i32
   }
-  %2 = arc.state @DummyArc(%in) clock %clk0 lat 1 : (i32) -> i32
+  %2 = arc.state @DummyArc(%in) clock %clk0 latency 1 : (i32) -> i32
   %3 = arc.clock_domain (%2) clock %clk1 : (i32) -> i32 {
   ^bb0(%arg2: i32):
-    %4 = arc.state @DummyArc(%arg2) lat 1 : (i32) -> i32
+    %4 = arc.state @DummyArc(%arg2) latency 1 : (i32) -> i32
     arc.output %4 : i32
   }
-  %4 = arc.state @DummyArc(%1) clock %clk0 lat 1 : (i32) -> i32
-  %5 = arc.state @DummyArc(%3) clock %clk0 lat 1 : (i32) -> i32
-  %6 = arc.state @DummyArc2(%1, %3) clock %clk0 lat 1 : (i32, i32) -> i32
+  %4 = arc.state @DummyArc(%1) clock %clk0 latency 1 : (i32) -> i32
+  %5 = arc.state @DummyArc(%3) clock %clk0 latency 1 : (i32) -> i32
+  %6 = arc.state @DummyArc2(%1, %3) clock %clk0 latency 1 : (i32, i32) -> i32
   hw.output %4, %6 : i32, i32
 
   // CHECK-NEXT: [[V0:%.+]] = arc.clock_domain ([[V2:%.+]]#3) clock %clk0 : (i32) -> i32 {
   // CHECK-NEXT: ^bb0(%arg0: i32):
-  // CHECK-NEXT:   [[V3:%.+]] = arc.state @DummyArc(%arg0) lat 1 : (i32) -> i32
+  // CHECK-NEXT:   [[V3:%.+]] = arc.state @DummyArc(%arg0) latency 1 : (i32) -> i32
   // CHECK-NEXT:   arc.output [[V3]] : i32
   // CHECK-NEXT: }
   // CHECK-NEXT: [[V1:%.+]] = arc.clock_domain ([[V2]]#2) clock %clk1 : (i32) -> i32 {
   // CHECK-NEXT: ^bb0(%arg0: i32):
-  // CHECK-NEXT:   [[V3:%.+]] = arc.state @DummyArc(%arg0) lat 1 : (i32) -> i32
+  // CHECK-NEXT:   [[V3:%.+]] = arc.state @DummyArc(%arg0) latency 1 : (i32) -> i32
   // CHECK-NEXT:   arc.output [[V3]] : i32
   // CHECK-NEXT: }
   // CHECK-NEXT: [[V2]]:4 = arc.clock_domain ([[V0]], [[V1]], %in) clock %clk0 : (i32, i32, i32) -> (i32, i32, i32, i32) {
   // CHECK-NEXT: ^bb0(%arg0: i32, %arg1: i32, %arg2: i32):
-  // CHECK-NEXT:   [[V3:%.+]] = arc.state @DummyArc2(%arg0, %arg1) lat 1 : (i32, i32) -> i32
-  // CHECK-NEXT:   [[V4:%.+]] = arc.state @DummyArc(%arg1) lat 1 : (i32) -> i32
-  // CHECK-NEXT:   [[V5:%.+]] = arc.state @DummyArc(%arg0) lat 1 : (i32) -> i32
-  // CHECK-NEXT:   [[V6:%.+]] = arc.state @DummyArc(%arg2) lat 1 : (i32) -> i32
-  // CHECK-NEXT:   [[V7:%.+]] = arc.state @DummyArc(%arg2) lat 1 : (i32) -> i32
+  // CHECK-NEXT:   [[V3:%.+]] = arc.state @DummyArc2(%arg0, %arg1) latency 1 : (i32, i32) -> i32
+  // CHECK-NEXT:   [[V4:%.+]] = arc.state @DummyArc(%arg1) latency 1 : (i32) -> i32
+  // CHECK-NEXT:   [[V5:%.+]] = arc.state @DummyArc(%arg0) latency 1 : (i32) -> i32
+  // CHECK-NEXT:   [[V6:%.+]] = arc.state @DummyArc(%arg2) latency 1 : (i32) -> i32
+  // CHECK-NEXT:   [[V7:%.+]] = arc.state @DummyArc(%arg2) latency 1 : (i32) -> i32
   // CHECK-NEXT:   arc.output [[V3]], [[V5]], [[V6]], [[V7]] : i32, i32, i32, i32
   // CHECK-NEXT: }
   // CHECK-NEXT: hw.output [[V2]]#1, [[V2]]#0 : i32, i32

--- a/test/Dialect/Arc/latency-retiming.mlir
+++ b/test/Dialect/Arc/latency-retiming.mlir
@@ -3,10 +3,10 @@
 // CHECK-LABEL: hw.module @Foo
 hw.module @Foo(in %clk: !seq.clock, in %clk2: !seq.clock, in %en: i1, in %rst: i1, in %arg0: i32, in %arg1: i32, out out0 : i32, out out1 : i32, out out2: i32, out out3: i32, out out4: i32, out out5: i32, out out6: i32, out out7: i32, out out8: i32, out out9: i32, out out10: i32, out out11: i32) {
   // COM: simple shift-register of depth 3 is merged to one arc.state
-  %0 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
-  %1 = arc.state @Bar(%0) clock %clk lat 1 : (i32) -> i32
-  %2 = arc.state @Bar(%1) clock %clk lat 1 : (i32) -> i32
-  // CHECK-NEXT: [[V0:%.+]] = arc.state @Bar(%arg0) clock %clk lat 3 :
+  %0 = arc.state @Bar(%arg0) clock %clk latency 1 : (i32) -> i32
+  %1 = arc.state @Bar(%0) clock %clk latency 1 : (i32) -> i32
+  %2 = arc.state @Bar(%1) clock %clk latency 1 : (i32) -> i32
+  // CHECK-NEXT: [[V0:%.+]] = arc.state @Bar(%arg0) clock %clk latency 3 :
 
   // COM: looks like a shift register from the outside (and actually is), but
   // COM: the arcs are not exactly passthroughs, so don't erase them
@@ -14,76 +14,76 @@ hw.module @Foo(in %clk: !seq.clock, in %clk2: !seq.clock, in %en: i1, in %rst: i
   // COM:       this also folds to just one state, but inlining will get rid of
   // COM:       them anyways.
   // CHECK-NEXT: [[V1:%.+]]:2 = arc.call @Baz(%arg0, %arg1) :
-  %3:2 = arc.state @Baz(%arg0, %arg1) clock %clk lat 1 : (i32, i32) -> (i32, i32)
+  %3:2 = arc.state @Baz(%arg0, %arg1) clock %clk latency 1 : (i32, i32) -> (i32, i32)
   // CHECK-NEXT: [[V2:%.+]]:2 = arc.call @Baz([[V1]]#0, [[V1]]#1) :
-  %4:2 = arc.state @Baz(%3#0, %3#1) clock %clk lat 2 : (i32, i32) -> (i32, i32)
-  // CHECK-NEXT: [[V3:%.+]]:2 = arc.state @Baz([[V2]]#0, [[V2]]#1) clock %clk lat 6 :
-  %5:2 = arc.state @Baz(%4#0, %4#1) clock %clk lat 3 : (i32, i32) -> (i32, i32)
+  %4:2 = arc.state @Baz(%3#0, %3#1) clock %clk latency 2 : (i32, i32) -> (i32, i32)
+  // CHECK-NEXT: [[V3:%.+]]:2 = arc.state @Baz([[V2]]#0, [[V2]]#1) clock %clk latency 6 :
+  %5:2 = arc.state @Baz(%4#0, %4#1) clock %clk latency 3 : (i32, i32) -> (i32, i32)
 
   // COM: a fan-in tree, op that gets the latencies is initially a call and
   // becomes a state op
-  %6 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
-  %7 = arc.state @Bar(%arg1) clock %clk lat 1 : (i32) -> i32
+  %6 = arc.state @Bar(%arg0) clock %clk latency 1 : (i32) -> i32
+  %7 = arc.state @Bar(%arg1) clock %clk latency 1 : (i32) -> i32
   // CHECK-NEXT: [[V4:%.+]]:2 = arc.call @Baz(%arg0, %arg1) :
-  %8:2 = arc.state @Baz(%6, %7) clock %clk lat 1 : (i32, i32) -> (i32, i32)
-  %9 = arc.state @Bar(%arg1) clock %clk lat 2 : (i32) -> i32
-  // CHECK-NEXT: [[V5:%.+]]:2 = arc.state @Baz([[V4]]#0, %arg1) clock %clk lat 2 :
+  %8:2 = arc.state @Baz(%6, %7) clock %clk latency 1 : (i32, i32) -> (i32, i32)
+  %9 = arc.state @Bar(%arg1) clock %clk latency 2 : (i32) -> i32
+  // CHECK-NEXT: [[V5:%.+]]:2 = arc.state @Baz([[V4]]#0, %arg1) clock %clk latency 2 :
   %10:2 = arc.call @Baz(%8#0, %9) : (i32, i32) -> (i32, i32)
 
   // COM: fan-out tree
-  // CHECK-NEXT: [[V6:%.+]] = arc.state @Bar(%arg0) clock %clk lat 1 :
-  %11 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
-  // CHECK-NEXT: arc.state @Bar([[V6]]) clock %clk lat 1 :
-  %12 = arc.state @Bar(%11) clock %clk lat 1 : (i32) -> i32
-  // CHECK-NEXT: arc.state @Bar([[V6]]) clock %clk lat 1 :
-  %13 = arc.state @Bar(%11) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: [[V6:%.+]] = arc.state @Bar(%arg0) clock %clk latency 1 :
+  %11 = arc.state @Bar(%arg0) clock %clk latency 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar([[V6]]) clock %clk latency 1 :
+  %12 = arc.state @Bar(%11) clock %clk latency 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar([[V6]]) clock %clk latency 1 :
+  %13 = arc.state @Bar(%11) clock %clk latency 1 : (i32) -> i32
 
   // COM: states with names attached are not touched
-  %14 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
-  // CHECK-NEXT: [[V7:%.+]] = arc.state @Bar(%arg0) clock %clk lat 2 {name = "reg"} :
-  %15 = arc.state @Bar(%14) clock %clk lat 1 {name = "reg"} : (i32) -> i32
-  // CHECK-NEXT: arc.state @Bar([[V7]]) clock %clk lat 1 :
-  %16 = arc.state @Bar(%15) clock %clk lat 1 : (i32) -> i32
+  %14 = arc.state @Bar(%arg0) clock %clk latency 1 : (i32) -> i32
+  // CHECK-NEXT: [[V7:%.+]] = arc.state @Bar(%arg0) clock %clk latency 2 {name = "reg"} :
+  %15 = arc.state @Bar(%14) clock %clk latency 1 {name = "reg"} : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar([[V7]]) clock %clk latency 1 :
+  %16 = arc.state @Bar(%15) clock %clk latency 1 : (i32) -> i32
 
   // COM: states with names attached are not touched
-  %17 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
-  // CHECK-NEXT: [[V8:%.+]] = arc.state @Bar(%arg0) clock %clk lat 2 {names = ["reg"]} :
-  %18 = arc.state @Bar(%17) clock %clk lat 1 {names = ["reg"]} : (i32) -> i32
-  // CHECK-NEXT: arc.state @Bar([[V8]]) clock %clk lat 1 :
-  %19 = arc.state @Bar(%18) clock %clk lat 1 : (i32) -> i32
+  %17 = arc.state @Bar(%arg0) clock %clk latency 1 : (i32) -> i32
+  // CHECK-NEXT: [[V8:%.+]] = arc.state @Bar(%arg0) clock %clk latency 2 {names = ["reg"]} :
+  %18 = arc.state @Bar(%17) clock %clk latency 1 {names = ["reg"]} : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar([[V8]]) clock %clk latency 1 :
+  %19 = arc.state @Bar(%18) clock %clk latency 1 : (i32) -> i32
 
   // COM: states with enables are not touched
-  // CHECK-NEXT: [[V9:%.+]] = arc.state @Bar(%arg0) clock %clk lat 1 :
-  %20 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
-  // CHECK-NEXT: [[V10:%.+]] = arc.state @Bar([[V9]]) clock %clk enable %en lat 1 :
-  %21 = arc.state @Bar(%20) clock %clk enable %en lat 1 : (i32) -> i32
-  // CHECK-NEXT: arc.state @Bar([[V10]]) clock %clk lat 1 :
-  %22 = arc.state @Bar(%21) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: [[V9:%.+]] = arc.state @Bar(%arg0) clock %clk latency 1 :
+  %20 = arc.state @Bar(%arg0) clock %clk latency 1 : (i32) -> i32
+  // CHECK-NEXT: [[V10:%.+]] = arc.state @Bar([[V9]]) clock %clk enable %en latency 1 :
+  %21 = arc.state @Bar(%20) clock %clk enable %en latency 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar([[V10]]) clock %clk latency 1 :
+  %22 = arc.state @Bar(%21) clock %clk latency 1 : (i32) -> i32
 
   // COM: states with resets are not touched
-  // CHECK-NEXT: [[V11:%.+]] = arc.state @Bar(%arg0) clock %clk lat 1 :
-  %23 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
-  // CHECK-NEXT: [[V12:%.+]] = arc.state @Bar([[V11]]) clock %clk reset %rst lat 1 :
-  %24 = arc.state @Bar(%23) clock %clk reset %rst lat 1 : (i32) -> i32
-  // CHECK-NEXT: arc.state @Bar([[V12]]) clock %clk lat 1 :
-  %25 = arc.state @Bar(%24) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: [[V11:%.+]] = arc.state @Bar(%arg0) clock %clk latency 1 :
+  %23 = arc.state @Bar(%arg0) clock %clk latency 1 : (i32) -> i32
+  // CHECK-NEXT: [[V12:%.+]] = arc.state @Bar([[V11]]) clock %clk reset %rst latency 1 :
+  %24 = arc.state @Bar(%23) clock %clk reset %rst latency 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar([[V12]]) clock %clk latency 1 :
+  %25 = arc.state @Bar(%24) clock %clk latency 1 : (i32) -> i32
 
   // COM: using own result value
-  // CHECK-NEXT: [[V13:%.+]] = arc.state @Bar([[V13]]) clock %clk lat 1 :
-  %26 = arc.state @Bar(%26) clock %clk lat 1 : (i32) -> i32
+  // CHECK-NEXT: [[V13:%.+]] = arc.state @Bar([[V13]]) clock %clk latency 1 :
+  %26 = arc.state @Bar(%26) clock %clk latency 1 : (i32) -> i32
 
   // COM: different clocks
-  // CHECK-NEXT: arc.state @Bar(%arg0) clock %clk lat 1 :
-  %27 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
-  // CHECK-NEXT: arc.state @Bar({{.*}}) clock %clk2 lat 1 :
-  %28 = arc.state @Bar(%27) clock %clk2 lat 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar(%arg0) clock %clk latency 1 :
+  %27 = arc.state @Bar(%arg0) clock %clk latency 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar({{.*}}) clock %clk2 latency 1 :
+  %28 = arc.state @Bar(%27) clock %clk2 latency 1 : (i32) -> i32
 
   // COM: can only partially take over latencies
-  %29 = arc.state @Bar(%arg0) clock %clk lat 1 : (i32) -> i32
-  // CHECK-NEXT: arc.state @Bar(%arg1) clock %clk lat 1 :
-  %30 = arc.state @Bar(%arg1) clock %clk lat 2 : (i32) -> i32
-  // CHECK-NEXT: arc.state @Baz(%arg0, {{.+}}) clock %clk lat 2 :
-  %31:2 = arc.state @Baz(%29, %30) clock %clk lat 1 : (i32, i32) -> (i32, i32)
+  %29 = arc.state @Bar(%arg0) clock %clk latency 1 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Bar(%arg1) clock %clk latency 1 :
+  %30 = arc.state @Bar(%arg1) clock %clk latency 2 : (i32) -> i32
+  // CHECK-NEXT: arc.state @Baz(%arg0, {{.+}}) clock %clk latency 2 :
+  %31:2 = arc.state @Baz(%29, %30) clock %clk latency 1 : (i32, i32) -> (i32, i32)
 
   // CHECK-NEXT: hw.output [[V0]], [[V3]]#0, [[V3]]#1, [[V5]]#0
   hw.output %2, %5#0, %5#1, %10#0, %12, %13, %16, %19, %22, %25, %28, %31 : i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -30,8 +30,8 @@ hw.module @InputsAndOutputs(in %a: i42, in %b: i17, out c: i42, out d: i17) {
 // CHECK-LABEL: arc.model "State" {
 hw.module @State(in %clk: !seq.clock, in %en: i1, in %en2: i1) {
   %gclk = seq.clock_gate %clk, %en, %en2
-  %3 = arc.state @DummyArc(%6) clock %clk lat 1 : (i42) -> i42
-  %4 = arc.state @DummyArc(%5) clock %gclk lat 1 : (i42) -> i42
+  %3 = arc.state @DummyArc(%6) clock %clk latency 1 : (i42) -> i42
+  %4 = arc.state @DummyArc(%5) clock %gclk latency 1 : (i42) -> i42
   %5 = comb.add %3, %3 : i42
   %6 = comb.add %4, %4 : i42
   // CHECK-NEXT: (%arg0: !arc.storage):
@@ -65,8 +65,8 @@ hw.module @State(in %clk: !seq.clock, in %en: i1, in %en2: i1) {
 
 // CHECK-LABEL: arc.model "State2" {
 hw.module @State2(in %clk: !seq.clock) {
-  %3 = arc.state @DummyArc(%3) clock %clk lat 1 : (i42) -> i42
-  %4 = arc.state @DummyArc(%4) clock %clk lat 1 : (i42) -> i42
+  %3 = arc.state @DummyArc(%3) clock %clk latency 1 : (i42) -> i42
+  %4 = arc.state @DummyArc(%4) clock %clk latency 1 : (i42) -> i42
   // CHECK-NEXT: (%arg0: !arc.storage):
   // CHECK-NEXT: [[INCLK:%.+]] = arc.root_input "clk", %arg0 : (!arc.storage) -> !arc.state<i1>
   // CHECK-NEXT: [[CLK_OLD:%.+]] = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
@@ -98,7 +98,7 @@ hw.module @NonMaskedMemoryWrite(in %clk0: !seq.clock) {
   %c0_i2 = hw.constant 0 : i2
   %c9001_i42 = hw.constant 9001 : i42
   %mem = arc.memory <4 x i42, i2>
-  arc.memory_write_port %mem, @identity(%c0_i2, %c9001_i42) clock %clk0 lat 1 : <4 x i42, i2>, i2, i42
+  arc.memory_write_port %mem, @identity(%c0_i2, %c9001_i42) clock %clk0 latency 1 : <4 x i42, i2>, i2, i42
 
   // CHECK-NEXT: (%arg0: !arc.storage):
   // CHECK-NEXT: [[INCLK:%.+]] = arc.root_input "clk0", %arg0 : (!arc.storage) -> !arc.state<i1>
@@ -147,7 +147,7 @@ hw.module @maskedMemoryWrite(in %clk: !seq.clock) {
   %c9001_i42 = hw.constant 9001 : i42
   %c1010_i42 = hw.constant 1010 : i42
   %mem = arc.memory <4 x i42, i2>
-  arc.memory_write_port %mem, @identity2(%c0_i2, %c9001_i42, %true, %c1010_i42) clock %clk enable mask lat 1 : <4 x i42, i2>, i2, i42, i1, i42
+  arc.memory_write_port %mem, @identity2(%c0_i2, %c9001_i42, %true, %c1010_i42) clock %clk enable mask latency 1 : <4 x i42, i2>, i2, i42, i1, i42
 }
 arc.define @identity2(%arg0: i2, %arg1: i42, %arg2: i1, %arg3: i42) -> (i2, i42, i1, i42) {
   arc.output %arg0, %arg1, %arg2, %arg3 : i2, i42, i1, i42
@@ -226,8 +226,8 @@ hw.module @MaterializeOpsWithRegions(in %clk0: !seq.clock, in %clk1: !seq.clock,
   // CHECK-NEXT:   arc.state_write
   // CHECK-NEXT: }
 
-  %1 = arc.state @DummyArc(%0) clock %clk0 lat 1 : (i42) -> i42
-  %2 = arc.state @DummyArc(%0) clock %clk1 lat 1 : (i42) -> i42
+  %1 = arc.state @DummyArc(%0) clock %clk0 latency 1 : (i42) -> i42
+  %2 = arc.state @DummyArc(%0) clock %clk1 latency 1 : (i42) -> i42
   hw.output %0 : i42
 }
 
@@ -242,7 +242,7 @@ arc.define @DummyArc2(%arg0: i42) -> (i42, i42) {
 hw.module @stateReset(in %clk: !seq.clock, in %arg0: i42, in %rst: i1, out out0: i42, out out1: i42) {
   %0 = arc.call @i1Identity(%rst) : (i1) -> (i1)
   %1 = arc.call @i1Identity(%rst) : (i1) -> (i1)
-  %2, %3 = arc.state @DummyArc2(%arg0) clock %clk enable %0 reset %1 lat 1 : (i42) -> (i42, i42)
+  %2, %3 = arc.state @DummyArc2(%arg0) clock %clk enable %0 reset %1 latency 1 : (i42) -> (i42, i42)
   hw.output %2, %3 : i42, i42
 }
 // CHECK-LABEL: arc.model "stateReset"
@@ -264,8 +264,8 @@ hw.module @stateReset(in %clk: !seq.clock, in %arg0: i42, in %rst: i1, out out0:
 // CHECK: }
 
 hw.module @SeparateResets(in %clock: !seq.clock, in %i0: i42, in %rst1: i1, in %rst2: i1, out out1: i42, out out2: i42) {
-  %0 = arc.state @DummyArc(%i0) clock %clock reset %rst1 lat 1 {names = ["foo"]} : (i42) -> i42
-  %1 = arc.state @DummyArc(%i0) clock %clock reset %rst2 lat 1 {names = ["bar"]} : (i42) -> i42
+  %0 = arc.state @DummyArc(%i0) clock %clock reset %rst1 latency 1 {names = ["foo"]} : (i42) -> i42
+  %1 = arc.state @DummyArc(%i0) clock %clock reset %rst2 latency 1 {names = ["bar"]} : (i42) -> i42
   hw.output %0, %1 : i42, i42
 }
 
@@ -295,7 +295,7 @@ hw.module @SeparateResets(in %clock: !seq.clock, in %i0: i42, in %rst1: i1, in %
 // Regression check on worklist producing false positive comb loop errors.
 // CHECK-LABEL: @CombLoopRegression
 hw.module @CombLoopRegression(in %clk: !seq.clock) {
-  %0 = arc.state @CombLoopRegressionArc1(%3, %3) clock %clk lat 1 : (i1, i1) -> i1
+  %0 = arc.state @CombLoopRegressionArc1(%3, %3) clock %clk latency 1 : (i1, i1) -> i1
   %1, %2 = arc.call @CombLoopRegressionArc2(%0) : (i1) -> (i1, i1)
   %3 = arc.call @CombLoopRegressionArc1(%1, %2) : (i1, i1) -> i1
 }
@@ -311,8 +311,8 @@ arc.define @CombLoopRegressionArc2(%arg0: i1) -> (i1, i1) {
 hw.module private @MemoryPortRegression(in %clock: !seq.clock, in %reset: i1, in %in: i3, out x: i3) {
   %0 = arc.memory <2 x i3, i1> {name = "ram_ext"}
   %1 = arc.memory_read_port %0[%3] : <2 x i3, i1>
-  arc.memory_write_port %0, @identity3(%3, %in) clock %clock lat 1 : <2 x i3, i1>, i1, i3
-  %3 = arc.state @Queue_arc_0(%reset) clock %clock lat 1 : (i1) -> i1
+  arc.memory_write_port %0, @identity3(%3, %in) clock %clock latency 1 : <2 x i3, i1>, i1, i3
+  %3 = arc.state @Queue_arc_0(%reset) clock %clock latency 1 : (i1) -> i1
   %4 = arc.call @Queue_arc_1(%1) : (i3) -> i3
   hw.output %4 : i3
 }
@@ -328,7 +328,7 @@ arc.define @Queue_arc_1(%arg0: i3) -> i3 {
 
 // CHECK-LABEL: arc.model "BlackBox"
 hw.module @BlackBox(in %clk: !seq.clock) {
-  %0 = arc.state @DummyArc(%2) clock %clk lat 1 : (i42) -> i42
+  %0 = arc.state @DummyArc(%2) clock %clk latency 1 : (i42) -> i42
   %1 = comb.and %0, %0 : i42
   %ext.c, %ext.d = hw.instance "ext" @BlackBoxExt(a: %0: i42, b: %1: i42) -> (c: i42, d: i42)
   %2 = comb.or %ext.c, %ext.d : i42


### PR DESCRIPTION
I was asked a few times what the `lat` means in the assembly format. I think spelling out latency should make it easier to understand what this attribute means.
Maybe we want to rename `arc.state` to something more meaningful at some point as well.

**Stacked PR: Only review top commit**