### PR TITLE
[Arc] Dedup: Fix use after free

### DIFF
--- a/lib/Dialect/Arc/Transforms/Dedup.cpp
+++ b/lib/Dialect/Arc/Transforms/Dedup.cpp
@@ -727,6 +727,11 @@ void DedupPass::replaceArcWith(DefineOp oldArc, DefineOp newArc) {
     callOp.setCalleeFromCallable(newArcName);
     newUses.insert(callOp);
   }
+
+  oldArc.walk([&](mlir::CallOpInterface callOp) {
+    if (auto defOp = dyn_cast_or_null<DefineOp>(callOp.resolveCallable()))
+      callSites[defOp].remove(callOp);
+  });
   callSites.erase(oldArc);
   arcByName.erase(oldArc.getSymNameAttr());
   oldArc->erase();


### PR DESCRIPTION
Using [rr](https://rr-project.org/), I reproduced the crash described in https://github.com/llvm/circt/issues/5307.

I tried my hand at a fix, but bear in mind I have no idea what I'm doing, and I'm not sure if my analysis is correct, even less so the "fix". Any feedback is greatly appreciated.

#### Input file
```
arc.define @Queue_arc_5_split_0(%arg0: i4, %arg1: i1) -> i4 {
  %c0_i4 = hw.constant 0 : i4
  arc.output %c0_i4 : i4
}
arc.define @Queue_arc_5_split_4_0(%arg0: i4, %arg1: i1) -> i4 {
  %0 = arc.call @Queue_arc_5_split_0(%arg0, %arg1) : (i4, i1) -> i4
  arc.output %0 : i4
}
arc.define @TLMonitor_arc_2_12(%arg0: i1, %arg1: i4, %arg2: i4, %arg3: i1) -> i4 {
  %0 = arc.call @Queue_arc_5_split_4_0(%arg2, %arg3) : (i4, i1) -> i4
  arc.output %0 : i4
}
arc.define @TLMonitor_arc_2_13(%arg0: i1, %arg1: i4, %arg2: i4, %arg3: i1) -> i4 {
  %0 = arc.call @Queue_arc_5_split_4_0(%arg2, %arg3) : (i4, i1) -> i4
  arc.output %0 : i4
}
arc.define @Queue_arc_5_split_4_1(%arg0: i4, %arg1: i1) -> i4 {
  %0 = arc.call @Queue_arc_5_split_0(%arg0, %arg1) : (i4, i1) -> i4
  arc.output %0 : i4
}
```
#### What goes wrong?
1. `%0 = arc.call @Queue_arc_5_split_4_0(%arg2, %arg3) : (i4, i1) -> i4` is `push_back`-ed into `callSites`

That is, the one that belongs to
```
arc.define @TLMonitor_arc_2_13(%arg0: i1, %arg1: i4, %arg2: i4, %arg3: i1) -> i4 {
  %0 = arc.call @Queue_arc_5_split_4_0(%arg2, %arg3) : (i4, i1) -> i4
  arc.output %0 : i4
}
```
2. `TLMonitor_arc_2_13` is merged into `TLMonitor_arc_2_12`
```
Check for exact merges (5 arcs)
Check for constant-agnostic merges (5 arcs)
- Outlining 2 operands from "TLMonitor_arc_2_12"
  - Operand #1 of %0 = arc.call @Queue_arc_5_split_4_0(%arg2, %arg3) : (i4, i1) -> i4
  - Operand #0 of %0 = arc.call @Queue_arc_5_split_4_0(%arg2, %arg3) : (i4, i1) -> i4
  - Candidate "TLMonitor_arc_2_13"
  - Merged "TLMonitor_arc_2_12" <- "TLMonitor_arc_2_13"
```
3. This invalidates the `%0 = arc.call @Queue_arc_5_split_4_0(%arg2, %arg3) : (i4, i1) -> i4` that was previously `push_back`-ed into `callSites`.
```
#0  llvm::detail::PunnedPointer<llvm::ilist_node_base<true>*>::operator= (this=0x562aeeab9ac0, V=0)
    at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/PointerIntPair.h:49
#1  0x0000562ae7797eb2 in llvm::PointerIntPair<llvm::ilist_node_base<true>*, 1u, unsigned int, llvm::PointerLikeTypeTraits<llvm::ilist_node_base<true>*>, llvm::PointerIntPairInfo<llvm::ilist_node_base<true>*, 1u, llvm::PointerLikeTypeTraits<llvm::ilist_node_base<true>*> > >::setPointer(llvm::ilist_node_base<true>*) & (this=0x562aeeab9ac0, PtrVal=0x0)
    at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/PointerIntPair.h:99
#2  0x0000562ae77971e1 in llvm::ilist_node_base<true>::setPrev (this=0x562aeeab9ac0, Prev=0x0)
    at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist_node_base.h:40
#3  0x0000562ae779decf in llvm::ilist_base<true>::removeImpl (N=...)
    at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist_base.h:37
#4  0x0000562ae91697bd in llvm::ilist_base<true>::remove<llvm::ilist_node_impl<llvm::ilist_detail::node_options<mlir::Operation, true, false, void, false> > > (N=...)
    at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist_base.h:80
#5  0x0000562ae9165cfa in llvm::simple_ilist<mlir::Operation>::remove (this=0x562aeeab8c70, N=...)
    at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/simple_ilist.h:189
#6  0x0000562ae916102a in llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation> >::remove (this=0x562aeeab8c70, IT=...) at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist.h:191
#7  0x0000562ae915b7ab in llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation> >::erase (this=0x562aeeab8c70, where=...) at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist.h:205
#8  0x0000562ae91553fe in llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation> >::pop_back (this=0x562aeeab8c70) at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist.h:257
#9  0x0000562ae9154410 in mlir::Block::clear (this=0x562aeeab8c50)
    at /home/oystein/build/circt/llvm/mlir/include/mlir/IR/Block.h:42
#10 0x0000562ae951d23a in mlir::Block::~Block (this=0x562aeeab8c50, __in_chrg=<optimized out>)
    at /home/oystein/build/circt/llvm/mlir/lib/IR/Block.cpp:21
#11 0x0000562ae79f5276 in llvm::ilist_alloc_traits<mlir::Block>::deleteNode (V=0x562aeeab8c50)
    at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist.h:42
#12 0x0000562ae79f4e87 in llvm::iplist_impl<llvm::simple_ilist<mlir::Block>, llvm::ilist_traits<mlir::Block> >::erase
    (this=0x562aeeab9480, where=...) at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist.h:205
#13 0x0000562ae79f4a57 in llvm::iplist_impl<llvm::simple_ilist<mlir::Block>, llvm::ilist_traits<mlir::Block> >::erase
    (this=0x562aeeab9480, first=..., last=...) at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist.h:242
#14 0x0000562ae79f40cd in llvm::iplist_impl<llvm::simple_ilist<mlir::Block>, llvm::ilist_traits<mlir::Block> >::clear
    (this=0x562aeeab9480) at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist.h:246
#15 0x0000562ae96e40fc in llvm::iplist_impl<llvm::simple_ilist<mlir::Block>, llvm::ilist_traits<mlir::Block> >::~iplist_impl (this=0x562aeeab9480, __in_chrg=<optimized out>)
    at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist.h:147
#16 0x0000562ae96e3ece in llvm::iplist<mlir::Block>::~iplist (this=0x562aeeab9480, __in_chrg=<optimized out>)
    at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist.h:327
#17 0x0000562ae96e2912 in mlir::Region::~Region (this=0x562aeeab9480, __in_chrg=<optimized out>)
    at /home/oystein/build/circt/llvm/mlir/lib/IR/Region.cpp:20
#18 0x0000562ae96bbea9 in mlir::Operation::~Operation (this=0x562aeeab9440, __in_chrg=<optimized out>)
    at /home/oystein/build/circt/llvm/mlir/lib/IR/Operation.cpp:201
#19 0x0000562ae96bbf56 in mlir::Operation::destroy (this=0x562aeeab9440)
    at /home/oystein/build/circt/llvm/mlir/lib/IR/Operation.cpp:212
#20 0x0000562ae96bd1c6 in llvm::ilist_traits<mlir::Operation>::deleteNode (op=0x562aeeab9440)
    at /home/oystein/build/circt/llvm/mlir/lib/IR/Operation.cpp:491
#21 0x0000562ae915b7b3 in llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation> >::erase (this=0x562aeeaa6180, where=...) at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist.h:205
#22 0x0000562ae96c78d1 in llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation> >::erase (this=0x562aeeaa6180, IT=0x562aeeab9440) at /home/oystein/build/circt/llvm/llvm/include/llvm/ADT/ilist.h:209
#23 0x0000562ae96bd3a3 in mlir::Operation::erase (this=0x562aeeab9440)
    at /home/oystein/build/circt/llvm/mlir/lib/IR/Operation.cpp:540
#24 0x0000562ae7976be9 in (anonymous namespace)::DedupPass::replaceArcWith (this=0x562aeeaadf30, oldArc=..., 
    newArc=...) at /home/oystein/build/circt/lib/Dialect/Arc/Transforms/Dedup.cpp:735
#25 0x0000562ae7976757 in (anonymous namespace)::DedupPass::runOnOperation (this=0x562aeeaadf30)
    at /home/oystein/build/circt/lib/Dialect/Arc/Transforms/Dedup.cpp:716
```

4. Subsequent calls to `addCallSiteOperands` see an invalid `mlir::CallOpInterface` in `callSites`.
```
Program received signal SIGSEGV, Segmentation fault.
0x0000562ae7826d12 in mlir::detail::IROperandBase::insertInto<mlir::IRObjectWithUseList<mlir::OpOperand> > (
    this=0x562aeeab9b10, useList=0x0) at /home/oystein/build/circt/llvm/mlir/include/mlir/IR/UseDefLists.h:99
99	   nextUse = useList->firstUse;

(rr) bt 4

#0  0x0000562ae7826d12 in mlir::detail::IROperandBase::insertInto<mlir::IRObjectWithUseList<mlir::OpOperand> > (
    this=0x562aeeab9b10, useList=0x0) at /home/oystein/build/circt/llvm/mlir/include/mlir/IR/UseDefLists.h:99
#1  0x0000562ae781e934 in mlir::IROperand<mlir::OpOperand, mlir::Value>::insertIntoCurrent (this=0x562aeeab9b10)
    at /home/oystein/build/circt/llvm/mlir/include/mlir/IR/UseDefLists.h:186
#2  0x0000562ae78178b2 in mlir::IROperand<mlir::OpOperand, mlir::Value>::set (this=0x562aeeab9b10, 
    newValue=mlir::Value) at /home/oystein/build/circt/llvm/mlir/include/mlir/IR/UseDefLists.h:168
#3  0x0000562ae96cd000 in mlir::detail::OperandStorage::setOperands (this=0x562aeeab9b00, owner=0x562aeeab9ac0, 
    start=0, length=2, operands=...) at /home/oystein/build/circt/llvm/mlir/lib/IR/OperationSupport.cpp:275
```