### PR TITLE
[FIRRTL] XFAIL'ing the mem-taps tests on Windows

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
@@ -1,3 +1,4 @@
+; XFAIL: windows
 ; RUN: firtool --verilog %s | FileCheck %s
 
 circuit Top : %[[

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps-reg.fir
@@ -1,4 +1,4 @@
-; XFAIL: windows
+; XFAIL: system-windows
 ; RUN: firtool --verilog %s | FileCheck %s
 
 circuit Top : %[[

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -1,4 +1,4 @@
-; XFAIL: windows
+; XFAIL: system-windows
 ; RUN: firtool --verilog %s | FileCheck %s
 ; RUN: firtool --verilog -preserve-aggregate=1d-vec %s | FileCheck %s --check-prefix=AGGGREGATE
 ; RUN: firtool --verilog -lower-annotations-no-ref-type-ports %s | FileCheck %s --check-prefix=NOREFS

--- a/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/mem-taps.fir
@@ -1,3 +1,4 @@
+; XFAIL: windows
 ; RUN: firtool --verilog %s | FileCheck %s
 ; RUN: firtool --verilog -preserve-aggregate=1d-vec %s | FileCheck %s --check-prefix=AGGGREGATE
 ; RUN: firtool --verilog -lower-annotations-no-ref-type-ports %s | FileCheck %s --check-prefix=NOREFS


### PR DESCRIPTION
Unbreaks the Windows build, but #6513 remains.