### PR TITLE
[FSM] Add CAPI dependency on conversion pass header generation.

### DIFF
--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -126,6 +126,9 @@ add_mlir_public_c_api_library(CIRCTCAPISV
 add_mlir_public_c_api_library(CIRCTCAPIFSM
   FSM.cpp
 
+  DEPENDS
+  CIRCTConversionPassIncGen
+
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTFSM


### PR DESCRIPTION
When the conversion from FSM to SV was added to the CAPI, an include of the circt/Conversion/Passes.h header was included for the pass registration function. But nothing guarantees the generated header that is included by Passes.h actually exists.

We have seen intermittent failures from it not existing, for example: https://github.com/llvm/circt/actions/runs/7474242994/job/20339994666

This adds a DEPENDS on the target that generates the missing header, so it will be available.