### PR TITLE
[FIRRTL] Prerequisites for Layer-Associated Probes

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -572,7 +572,10 @@ def RegResetOp : HardwareDeclOp<"regreset", [Forceable]> {
   let hasVerifier = 1;
 }
 
-def WireOp : HardwareDeclOp<"wire", [Forceable]> {
+def WireOp : HardwareDeclOp<"wire", [
+    Forceable,
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
   let summary = "Define a new wire";
   let description = [{
     Declare a new wire:

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1220,6 +1220,7 @@ def RefCastOp : FIRRTLOp<"ref.cast",
   let results = (outs RefType:$result);
 
   let hasFolder = 1;
+  let hasVerifier = 1;
 
   let assemblyFormat =
      "$input attr-dict `:` functional-type($input, $result)";
@@ -1238,6 +1239,7 @@ def RefResolveOp: FIRRTLExprOp<"ref.resolve",
   let results = (outs FIRRTLBaseType:$result);
 
   let hasCanonicalizer = true;
+  let hasVerifier = 1;
 
   let assemblyFormat = "$ref attr-dict `:` qualified(type($ref))";
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1432,7 +1432,10 @@ bool TypeLoweringVisitor::visitExpr(RefCastOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
                    ArrayAttr attrs) -> Value {
     auto input = getSubWhatever(op.getInput(), field.index);
-    return builder->create<RefCastOp>(RefType::get(field.type), input);
+    return builder->create<RefCastOp>(RefType::get(field.type,
+                                                   op.getType().getForceable(),
+                                                   op.getType().getLayer()),
+                                      input);
   };
   return lowerProducer(op, clone);
 }


### PR DESCRIPTION
Miscellaneous fixes to get layer-associated probes working.

This primarily makes it so that you can use a probe in a layerblock to define something outside it.  Checks are added along the lines of what is suggested in https://github.com/llvm/circt/pull/6551#issuecomment-1881401430 to do verification of layers. There are only two types of checks that are needed to verify symbols:

1. Module ports are verified that any layer-associated probe points at a defined layer.
2. Ref Cast ops are verified that they cast to a legal destination.
3. Wires are verified that they cast to a defined layer.

There are a lot of other checks that could be added, but are unnecessary. E.g., refsend and refsub don't need to be checked because the only way to get a probe referring to an undefined destination is through a module, refcast, or wire. Hence, these unnecessary checks are skipped.