### PR TITLE
[Seq][FIRRTL] Add a representation for clock inverters

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -89,7 +89,7 @@ def FPGAProbeIntrinsicOp : FIRRTLOp<"int.fpga_probe", []> {
 }
 
 //===----------------------------------------------------------------------===//
-// Clock Gate Intrinsic
+// Clock Intrinsics
 //===----------------------------------------------------------------------===//
 
 def ClockGateIntrinsicOp : FIRRTLOp<"int.clock_gate", [Pure]> {
@@ -114,6 +114,23 @@ def ClockGateIntrinsicOp : FIRRTLOp<"int.clock_gate", [Pure]> {
   let assemblyFormat = [{
     $input `,` $enable (`,` $test_enable^)? attr-dict
   }];
+}
+
+def ClockInverterIntrinsicOp : FIRRTLOp<"int.clock_inv", []> {
+  let summary = "Inverts the clock signal";
+
+  let description = [{
+    The `firrtl.int.clock.inv` intrinsic takes a clock signal and inverts it.
+    It can be used to build registers and other operations which are triggered
+    by a negative clock edge relative to a reference signal. The compiler is
+    free to optimize inverters (particularly double inverters).
+
+    See the corresponding `seq.clock_inv` operation.
+  }];
+
+  let arguments = (ins NonConstClockType:$input);
+  let results = (outs NonConstClockType:$output);
+  let assemblyFormat = "$input attr-dict";
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLINTRINSICS_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -48,9 +48,9 @@ public:
             CvtPrimOp, NegPrimOp, NotPrimOp, AndRPrimOp, OrRPrimOp, XorRPrimOp,
             // Intrinsic Expressions.
             IsXIntrinsicOp, PlusArgsValueIntrinsicOp, PlusArgsTestIntrinsicOp,
-            SizeOfIntrinsicOp, ClockGateIntrinsicOp, LTLAndIntrinsicOp,
-            LTLOrIntrinsicOp, LTLDelayIntrinsicOp, LTLConcatIntrinsicOp,
-            LTLNotIntrinsicOp, LTLImplicationIntrinsicOp,
+            SizeOfIntrinsicOp, ClockGateIntrinsicOp, ClockInverterIntrinsicOp,
+            LTLAndIntrinsicOp, LTLOrIntrinsicOp, LTLDelayIntrinsicOp,
+            LTLConcatIntrinsicOp, LTLNotIntrinsicOp, LTLImplicationIntrinsicOp,
             LTLEventuallyIntrinsicOp, LTLClockIntrinsicOp,
             LTLDisableIntrinsicOp, Mux2CellIntrinsicOp, Mux4CellIntrinsicOp,
             HasBeenResetIntrinsicOp, FPGAProbeIntrinsicOp,
@@ -166,6 +166,7 @@ public:
   HANDLE(PlusArgsTestIntrinsicOp, Unhandled);
   HANDLE(SizeOfIntrinsicOp, Unhandled);
   HANDLE(ClockGateIntrinsicOp, Unhandled);
+  HANDLE(ClockInverterIntrinsicOp, Unhandled);
   HANDLE(LTLAndIntrinsicOp, Unhandled);
   HANDLE(LTLOrIntrinsicOp, Unhandled);
   HANDLE(LTLDelayIntrinsicOp, Unhandled);

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -451,6 +451,31 @@ def ClockDividerOp : SeqOp<"clock_div", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// Clock Inverter and Buffer
+//===----------------------------------------------------------------------===//
+
+def ClockInverterOp : SeqOp<"clock_inv", [Pure]> {
+  let summary = "Inverts the clock signal";
+  let description = [{
+    Note that the compiler can optimize inverters away, preventing their
+    use as part of explicit clock buffers.
+
+    ```
+    %inv_clock = seq.clock_inv %clock
+    ```
+  }];
+
+  let arguments = (ins ClockType:$input);
+  let results = (outs ClockType:$output);
+
+  let hasFolder = 1;
+
+  let assemblyFormat = [{
+    $input attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // FIRRTL-flavored memory
 //===----------------------------------------------------------------------===//
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1544,6 +1544,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult visitExpr(PlusArgsTestIntrinsicOp op);
   LogicalResult visitExpr(PlusArgsValueIntrinsicOp op);
   LogicalResult visitExpr(FPGAProbeIntrinsicOp op);
+  LogicalResult visitExpr(ClockInverterIntrinsicOp op);
   LogicalResult visitExpr(SizeOfIntrinsicOp op);
   LogicalResult visitExpr(ClockGateIntrinsicOp op);
   LogicalResult visitExpr(LTLAndIntrinsicOp op);
@@ -3578,6 +3579,11 @@ LogicalResult FIRRTLLowering::visitExpr(ClockGateIntrinsicOp op) {
   return setLoweringTo<seq::ClockGateOp>(
       op, getLoweredValue(op.getInput()), getLoweredValue(op.getEnable()),
       testEnable, /*inner_sym=*/hw::InnerSymAttr{});
+}
+
+LogicalResult FIRRTLLowering::visitExpr(ClockInverterIntrinsicOp op) {
+  auto operand = getLoweredValue(op.getInput());
+  return setLoweringTo<seq::ClockInverterOp>(op, operand);
 }
 
 LogicalResult FIRRTLLowering::visitExpr(LTLAndIntrinsicOp op) {

--- a/lib/Conversion/SeqToSV/SeqToSV.cpp
+++ b/lib/Conversion/SeqToSV/SeqToSV.cpp
@@ -184,6 +184,24 @@ public:
   }
 };
 
+// Lower seq.clock_inv to a regular inverter.
+//
+class ClockInverterLowering : public OpConversionPattern<ClockInverterOp> {
+public:
+  using OpConversionPattern<ClockInverterOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ClockInverterOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    auto loc = op.getLoc();
+    Value clk = adaptor.getInput();
+
+    Value one = rewriter.create<hw::ConstantOp>(loc, APInt(1, 1));
+    rewriter.replaceOpWithNewOp<comb::XorOp>(op, clk, one);
+    return success();
+  }
+};
+
 // Lower seq.clock_mux to a `comb.mux` op
 //
 class ClockMuxLowering : public OpConversionPattern<ClockMuxOp> {
@@ -426,6 +444,7 @@ void SeqToSVPass::runOnOperation() {
   patterns.add<ClockCastLowering<seq::FromClockOp>>(typeConverter, context);
   patterns.add<ClockCastLowering<seq::ToClockOp>>(typeConverter, context);
   patterns.add<ClockGateLowering>(typeConverter, context);
+  patterns.add<ClockInverterLowering>(typeConverter, context);
   patterns.add<ClockMuxLowering>(typeConverter, context);
   patterns.add<ClockDividerLowering>(typeConverter, context);
   patterns.add<ClockConstLowering>(typeConverter, context);

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -902,6 +902,21 @@ OpFoldResult FromClockOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// ClockInverterOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult ClockInverterOp::fold(FoldAdaptor adaptor) {
+  if (auto chainedInv = getInput().getDefiningOp<ClockInverterOp>())
+    return chainedInv.getInput();
+  if (auto clockAttr = dyn_cast_or_null<ClockConstAttr>(adaptor.getInput())) {
+    auto clockIn = clockAttr.getValue() == ClockConst::High;
+    return ClockConstAttr::get(getContext(),
+                               clockIn ? ClockConst::Low : ClockConst::High);
+  }
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
 // FIR memory helper
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -161,4 +161,14 @@ firrtl.circuit "Intrinsics" {
     // CHECK: hw.wire %in
     firrtl.int.fpga_probe %clock, %in : !firrtl.uint<8>
   }
+
+  // CHECK-LABEL: hw.module @ClockInverter
+  firrtl.module @ClockInverter(
+    in %clock_in: !firrtl.clock,
+    out %clock_out: !firrtl.clock
+  ) {
+    // CHECK: seq.clock_inv %clock_in
+    %0 = firrtl.int.clock_inv %clock_in
+    firrtl.strictconnect %clock_out, %0 : !firrtl.clock
+  }
 }

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -101,6 +101,24 @@ firrtl.circuit "Foo" {
     firrtl.strictconnect %en2, %en : !firrtl.uint<1>
   }
 
+  // CHECK-NOT: ClockInverter0
+  // CHECK-NOT: ClockInverter1
+  firrtl.extmodule @ClockInverter0(in in: !firrtl.clock, out out: !firrtl.clock) attributes {annotations = [{class = "circt.Intrinsic", intrinsic = "circt.clock_inv"}]}
+  firrtl.intmodule @ClockInverter1(in in: !firrtl.clock, out out: !firrtl.clock) attributes {intrinsic = "circt.clock_inv"}
+
+  // CHECK: ClockInverter
+  firrtl.module @ClockInverter(in %clk: !firrtl.clock) {
+    // CHECK-NOT: ClockInverter0
+    // CHECK: firrtl.int.clock_inv
+    %in1, %out1 = firrtl.instance "" @ClockInverter0(in in: !firrtl.clock, out out: !firrtl.clock)
+    firrtl.strictconnect %in1, %clk : !firrtl.clock
+
+    // CHECK-NOT: ClockInverter1
+    // CHECK: firrtl.int.clock_inv
+    %in2, %out2 = firrtl.instance "" @ClockInverter1(in in: !firrtl.clock, out out: !firrtl.clock)
+    firrtl.strictconnect %in2, %clk : !firrtl.clock
+  }
+
   // CHECK-NOT: LTLAnd
   // CHECK-NOT: LTLOr
   // CHECK-NOT: LTLDelay1

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -239,3 +239,22 @@ hw.module @const_clock_reg(in %clock : !seq.clock, out r_data : !seq.clock) {
   %1 = seq.firreg %1 clock %0 : !seq.clock
   hw.output %1 : !seq.clock
 }
+
+// CHECK-LABEL: @clock_inv
+hw.module @clock_inv(in %clock : !seq.clock, out clock_true : !seq.clock, out clock_false : !seq.clock, out same_clock: !seq.clock) {
+  %clk_low = seq.const_clock low
+  %clk_high = seq.const_clock high
+
+  %clk_inv_low = seq.clock_inv %clk_low
+  %clk_inv_high = seq.clock_inv %clk_high
+
+  %clk_inv = seq.clock_inv %clock
+  %clk_orig = seq.clock_inv %clk_inv
+
+
+  // CHECK: [[CLK_HIGH:%.+]] = seq.const_clock high
+  // CHECK: [[CLK_LOW:%.+]] = seq.const_clock low
+  // CHECK: hw.output [[CLK_HIGH]], [[CLK_LOW]], %clock
+  hw.output %clk_inv_low, %clk_inv_high, %clk_orig : !seq.clock, !seq.clock, !seq.clock
+
+}

--- a/test/Dialect/Seq/clock-inv.mlir
+++ b/test/Dialect/Seq/clock-inv.mlir
@@ -1,0 +1,10 @@
+// RUN: circt-opt --lower-seq-to-sv %s | FileCheck %s
+
+// CHECK-LABEL: @clock_inv
+hw.module @clock_inv(in %clk_in : !seq.clock, out clk_out : !seq.clock) {
+  // CHECK: [[INV:%.+]] = comb.xor %clk_in, %true : i1
+  // CHECK: hw.output [[INV]] : i1
+  %0 = seq.clock_inv %clk_in
+  hw.output %0 : !seq.clock
+}
+

--- a/test/Dialect/Seq/round-trip.mlir
+++ b/test/Dialect/Seq/round-trip.mlir
@@ -92,3 +92,8 @@ hw.module @clock_const() {
   // CHECK: seq.const_clock low
   %low = seq.const_clock low
 }
+
+hw.module @clock_inv(in %clock: !seq.clock) {
+  // CHECK: seq.clock_inv %clock
+  %inv = seq.clock_inv %clock
+}

--- a/test/firtool/clocking.fir
+++ b/test/firtool/clocking.fir
@@ -1,0 +1,18 @@
+; RUN: firtool %s | FileCheck %s
+
+circuit Foo:
+  intmodule ClockInverter:
+    input in: Clock
+    output out: Clock
+    intrinsic = circt_clock_inv
+
+  module Foo:
+    input clk: Clock
+    output inverted_clk: Clock
+
+    inst inv of ClockInverter
+    inv.in <= clk
+    inverted_clk <= inv.out
+
+  ; CHECK-LABEL: module Foo
+  ; CHECK: assign inverted_clk = ~clk;


### PR DESCRIPTION
The clock inverter ops provides an explicit representation for the negation of the clock signal, without having to rely on clock casts and wire-level operations. 

At the FIRRTL level, it is useful for the represenation of JTAG-related hardware, which often relies on registers triggered on the negative clock edge, represented by wiring an inverted clock to the registers.

The inverter is not suitable for clock buffers, as double inversion can be optimized away by the compiler.