### PR TITLE
broken image src's fixed

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -99,7 +99,7 @@ circuit Foo:
 
 | Folded Module   | Unfolded Modules  |
 | --------------- | ----------------- |
-| <img title="Folded Modules" src="includes/img/firrtl-folded-module.png"/> | <img title="Unfolded Modules" src="includes/img/firrtl-unfolded-module.png"/> |
+| <img title="Folded Modules" src="../../includes/img/firrtl-folded-module.png"/> | <img title="Unfolded Modules" src="../../includes/img/firrtl-unfolded-module.png"/> |
 
 Using targets (or multiple targets), any specific module, instance, or
 combination of instances can be expressed. Some examples include:


### PR DESCRIPTION
There is broken image src's paths in FIRRTLAnnotations.md. I saw them while reading the docs and corrected them.