### PR TITLE
[ESI] Introduce MMIO std service

### DIFF
--- a/include/circt/Dialect/ESI/ESIStdServices.td
+++ b/include/circt/Dialect/ESI/ESIStdServices.td
@@ -62,3 +62,19 @@ def FuncServiceDeclOp : ESI_Op<"service.std.func",
     $sym_name attr-dict
   }];
 }
+
+def MMIOServiceDeclOp: ESI_Op<"service.std.mmio",
+          [HasParent<"::mlir::ModuleOp">, Symbol,
+           DeclareOpInterfaceMethods<ServiceDeclOpInterface>]> {
+  let summary = "MMIO service";
+  let description = [{
+    Declares a service to be backed by a MMIO interface, which is platform
+    dependent. Must be implemented by a BSP.
+  }];
+
+  let arguments = (ins SymbolNameAttr:$sym_name);
+
+  let assemblyFormat = [{
+    $sym_name attr-dict
+  }];
+}

--- a/lib/Dialect/ESI/ESIStdServices.cpp
+++ b/lib/Dialect/ESI/ESIStdServices.cpp
@@ -80,3 +80,31 @@ void FuncServiceDeclOp::getPortList(SmallVectorImpl<ServicePortInfo> &ports) {
                           ChannelType::get(ctxt, AnyType::get(ctxt))}},
           /*resettable=*/UnitAttr())});
 }
+
+void MMIOServiceDeclOp::getPortList(SmallVectorImpl<ServicePortInfo> &ports) {
+  auto *ctxt = getContext();
+  // Read only port.
+  ports.push_back(ServicePortInfo{
+      hw::InnerRefAttr::get(getSymNameAttr(), StringAttr::get(ctxt, "read")),
+      ServicePortInfo::Direction::toClient,
+      ChannelBundleType::get(
+          ctxt,
+          {BundledChannel{StringAttr::get(ctxt, "offset"),
+                          ChannelDirection::from,
+                          ChannelType::get(ctxt, IntegerType::get(ctxt, 32))},
+           BundledChannel{StringAttr::get(ctxt, "data"), ChannelDirection::to,
+                          ChannelType::get(ctxt, IntegerType::get(ctxt, 32))}},
+          /*resettable=*/UnitAttr())});
+  // Write only port.
+  ports.push_back(ServicePortInfo{
+      hw::InnerRefAttr::get(getSymNameAttr(), StringAttr::get(ctxt, "write")),
+      ServicePortInfo::Direction::toClient,
+      ChannelBundleType::get(
+          ctxt,
+          {BundledChannel{StringAttr::get(ctxt, "offset"),
+                          ChannelDirection::from,
+                          ChannelType::get(ctxt, IntegerType::get(ctxt, 32))},
+           BundledChannel{StringAttr::get(ctxt, "data"), ChannelDirection::from,
+                          ChannelType::get(ctxt, IntegerType::get(ctxt, 32))}},
+          /*resettable=*/UnitAttr())});
+}

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -203,3 +203,14 @@ hw.module @CallableAccel1(in %clk: !seq.clock, in %rst: i1) {
   hw.instance "func1" @CallableFunc1() -> ()
   esi.service.instance #esi.appid<"funcComms"> svc @funcs impl as "cosim" (%clk, %rst) : (!seq.clock, i1) -> ()
 }
+
+esi.service.std.mmio @mmio
+!mmioReq = !esi.bundle<[!esi.channel<i32> from "offset", !esi.channel<i32> to "data"]>
+
+// CONN-LABEL:  hw.module @MMIOManifest(in %clk : !seq.clock, in %rst : i1, in %manifest : !esi.bundle<[!esi.channel<i32> from "offset", !esi.channel<i32> to "data"]>) {
+// CONN-NEXT:     esi.manifest.req #esi.appid<"manifest">, <@mmio::@read> std "esi.service.std.mmio", toClient, !esi.bundle<[!esi.channel<i32> from "offset", !esi.channel<i32> to "data"]>
+// CONN-NEXT:     %data = esi.bundle.unpack %data from %manifest : !esi.bundle<[!esi.channel<i32> from "offset", !esi.channel<i32> to "data"]>
+hw.module @MMIOManifest(in %clk: !seq.clock, in %rst: i1) {
+  %req = esi.service.req.to_client <@mmio::@read> (#esi.appid<"manifest">) : !mmioReq
+  %loopback = esi.bundle.unpack %loopback from %req : !mmioReq
+}


### PR DESCRIPTION
Currently, can only request a single 32-bit register. In the future, we'll add the ability to request structs of config/status registers.