### PR TITLE
[ESI] Lower manifest op to a ROM

### DIFF
--- a/include/circt/Dialect/ESI/ESIManifest.td
+++ b/include/circt/Dialect/ESI/ESIManifest.td
@@ -209,7 +209,7 @@ def SymbolMetadataOp : ESI_Op<"manifest.sym", [
 def BlobAttr : ESI_Attr<"Blob"> {
   let summary = "A binary blob";
 
-  let parameters = (ins ArrayRefParameter<"char">:$data);
+  let parameters = (ins ArrayRefParameter<"uint8_t">:$data);
   let mnemonic = "blob";
   let hasCustomAssemblyFormat = 1;
 }

--- a/include/circt/Dialect/ESI/ESIPasses.h
+++ b/include/circt/Dialect/ESI/ESIPasses.h
@@ -26,6 +26,7 @@ namespace esi {
 /// platform-specific lowerings.
 struct Platform {
   static constexpr char cosim[] = "cosim";
+  static constexpr char fpga[] = "fpga";
 };
 
 std::unique_ptr<OperationPass<ModuleOp>> createESIPhysicalLoweringPass();

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -53,6 +53,13 @@ def CompRegOp : SeqOp<"compreg",
   let hasVerifier = 1;
 
   let builders = [
+    /// Create a register with no name nor inner_sym.
+    OpBuilder<(ins "Value":$input, "Value":$clk), [{
+      return build($_builder, $_state, input.getType(), input, clk,
+                   /*name*/ StringAttr(),
+                   /*reset*/ Value(), /*resetValue*/ Value(),
+                   /*powerOnValue*/ Value(), hw::InnerSymAttr());
+    }]>,
     /// Create a register with an inner_sym matching the register's name.
     OpBuilder<(ins "Value":$input, "Value":$clk, "StringAttrOrRef":$name), [{
       auto nameAttr = name.get($_builder.getContext());

--- a/lib/Dialect/ESI/ESIAttributes.cpp
+++ b/lib/Dialect/ESI/ESIAttributes.cpp
@@ -36,7 +36,9 @@ Attribute BlobAttr::parse(AsmParser &odsParser, Type odsType) {
     });
     return {};
   }
-  return BlobAttr::get(odsParser.getBuilder().getContext(), data);
+  ArrayRef<uint8_t> unsigned_data(
+      reinterpret_cast<const uint8_t *>(data.data()), data.size());
+  return BlobAttr::get(odsParser.getBuilder().getContext(), unsigned_data);
 }
 void BlobAttr::print(AsmPrinter &odsPrinter) const {
   odsPrinter << "<\"" << llvm::encodeBase64(getData()) << "\">";

--- a/lib/Dialect/ESI/ESIAttributes.cpp
+++ b/lib/Dialect/ESI/ESIAttributes.cpp
@@ -36,9 +36,9 @@ Attribute BlobAttr::parse(AsmParser &odsParser, Type odsType) {
     });
     return {};
   }
-  ArrayRef<uint8_t> unsigned_data(
-      reinterpret_cast<const uint8_t *>(data.data()), data.size());
-  return BlobAttr::get(odsParser.getBuilder().getContext(), unsigned_data);
+  ArrayRef<uint8_t> unsignedData(reinterpret_cast<const uint8_t *>(data.data()),
+                                 data.size());
+  return BlobAttr::get(odsParser.getBuilder().getContext(), unsignedData);
 }
 void BlobAttr::print(AsmPrinter &odsPrinter) const {
   odsPrinter << "<\"" << llvm::encodeBase64(getData()) << "\">";

--- a/lib/Dialect/ESI/Passes/ESIBuildManifest.cpp
+++ b/lib/Dialect/ESI/Passes/ESIBuildManifest.cpp
@@ -115,11 +115,8 @@ void ESIBuildManifestPass::runOnOperation() {
                     ->getRegion(0)
                     .front()
                     .getTerminator());
-    b.create<CompressedManifestOp>(
-        b.getUnknownLoc(),
-        BlobAttr::get(ctxt, ArrayRef<char>(reinterpret_cast<char *>(
-                                               compressedManifest.data()),
-                                           compressedManifest.size())));
+    b.create<CompressedManifestOp>(b.getUnknownLoc(),
+                                   BlobAttr::get(ctxt, compressedManifest));
   } else {
     mod->emitWarning()
         << "zlib not available but required for manifest support";

--- a/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
@@ -17,6 +17,7 @@
 #include "circt/Dialect/ESI/ESIOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Support/BackedgeBuilder.h"
 #include "circt/Support/LLVM.h"
 #include "circt/Support/SymCache.h"
@@ -451,11 +452,114 @@ LogicalResult CosimFromHostLowering::matchAndRewrite(
 }
 
 namespace {
-/// Lower `CompressedManifestOps` ops to a SystemVerilog extern module.
-struct CosimManifestLowering
-    : public OpConversionPattern<CompressedManifestOp> {
+/// Lower `CompressedManifestOps` ops to a module containing an on-chip ROM.
+/// Said module has registered input and outputs, so it has two cycles latency
+/// between changing the address and the data being reflected on the output.
+struct ManifestRomLowering : public OpConversionPattern<CompressedManifestOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
+  constexpr static StringRef ManifestRomName = "__ESI_Manifest_ROM";
+
+  LogicalResult matchAndRewrite(CompressedManifestOp, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const;
+
+protected:
+  LogicalResult createRomModule(CompressedManifestOp op,
+                                ConversionPatternRewriter &rewriter) const;
+};
+} // anonymous namespace
+
+LogicalResult ManifestRomLowering::createRomModule(
+    CompressedManifestOp op, ConversionPatternRewriter &rewriter) const {
+  Location loc = op.getLoc();
+  auto mlirModBody = op->getParentOfType<mlir::ModuleOp>();
+  rewriter.setInsertionPointToStart(mlirModBody.getBody());
+
+  // Find possible existing module (which may have been created as a dummy
+  // module) and erase it.
+  if (Operation *existingExtern = mlirModBody.lookupSymbol(ManifestRomName)) {
+    if (!isa<hw::HWModuleExternOp>(existingExtern))
+      return rewriter.notifyMatchFailure(
+          op,
+          "Found " + ManifestRomName + " but it wasn't an HWModuleExternOp");
+    rewriter.eraseOp(existingExtern);
+  }
+
+  // Create the real module.
+  PortInfo ports[] = {
+      {{rewriter.getStringAttr("clk"), rewriter.getType<seq::ClockType>(),
+        ModulePort::Direction::Input}},
+      {{rewriter.getStringAttr("address"), rewriter.getIntegerType(30),
+        ModulePort::Direction::Input}},
+      {{rewriter.getStringAttr("data"), rewriter.getI32Type(),
+        ModulePort::Direction::Output}},
+  };
+  auto rom = rewriter.create<HWModuleOp>(
+      loc, rewriter.getStringAttr(ManifestRomName), ports);
+  Block *romBody = rom.getBodyBlock();
+  rewriter.setInsertionPointToStart(romBody);
+  Value clk = romBody->getArgument(0);
+  Value inputAddress = romBody->getArgument(1);
+
+  // Manifest the compressed manifest into 32-bit words.
+  ArrayRef<uint8_t> maniBytes = op.getCompressedManifest().getData();
+  SmallVector<uint32_t> words;
+  words.push_back(maniBytes.size());
+
+  for (size_t i = 0; i < maniBytes.size() - 3; i += 4) {
+    uint32_t word = maniBytes[i] | (maniBytes[i + 1] << 8) |
+                    (maniBytes[i + 2] << 16) | (maniBytes[i + 3] << 24);
+    words.push_back(word);
+  }
+  size_t overHang = maniBytes.size() % 4;
+  if (overHang != 0) {
+    uint32_t word = 0;
+    for (size_t i = 0; i < overHang; ++i)
+      word |= maniBytes[maniBytes.size() - overHang + i] << (i * 8);
+    words.push_back(word);
+  }
+
+  // From the words, create an the register which will hold the manifest (and
+  // hopefully synthized to a ROM).
+  SmallVector<Attribute> wordAttrs;
+  for (uint32_t word : words)
+    wordAttrs.push_back(rewriter.getI32IntegerAttr(word));
+  auto manifestConstant = rewriter.create<hw::AggregateConstantOp>(
+      loc, hw::UnpackedArrayType::get(rewriter.getI32Type(), words.size()),
+      rewriter.getArrayAttr(wordAttrs));
+  auto manifestReg =
+      rewriter.create<sv::RegOp>(loc, manifestConstant.getType());
+  rewriter.create<sv::AssignOp>(loc, manifestReg, manifestConstant);
+
+  // Slim down the address, register it, do the lookup, and register the output.
+  size_t addrBits = llvm::Log2_64_Ceil(words.size());
+  auto slimmedIdx =
+      rewriter.create<comb::ExtractOp>(loc, inputAddress, 0, addrBits);
+  Value inputAddresReg = rewriter.create<seq::CompRegOp>(loc, slimmedIdx, clk);
+  auto readIdx =
+      rewriter.create<sv::ArrayIndexInOutOp>(loc, manifestReg, inputAddresReg);
+  auto readData = rewriter.create<sv::ReadInOutOp>(loc, readIdx);
+  Value readDataReg = rewriter.create<seq::CompRegOp>(loc, readData, clk);
+  if (auto term = romBody->getTerminator())
+    rewriter.eraseOp(term);
+  rewriter.create<hw::OutputOp>(loc, ValueRange{readDataReg});
+  return success();
+}
+
+LogicalResult ManifestRomLowering::matchAndRewrite(
+    CompressedManifestOp op, OpAdaptor adaptor,
+    ConversionPatternRewriter &rewriter) const {
+  LogicalResult ret = createRomModule(op, rewriter);
+  rewriter.eraseOp(op);
+  return ret;
+}
+
+namespace {
+/// Lower `CompressedManifestOps` ops to a SystemVerilog module which sets the
+/// Cosim manifest using a DPI support module.
+struct CosimManifestLowering : public ManifestRomLowering {
+public:
+  using ManifestRomLowering::ManifestRomLowering;
 
   LogicalResult
   matchAndRewrite(CompressedManifestOp, OpAdaptor adaptor,
@@ -468,6 +572,12 @@ LogicalResult CosimManifestLowering::matchAndRewrite(
     ConversionPatternRewriter &rewriter) const {
   MLIRContext *ctxt = rewriter.getContext();
   Location loc = op.getLoc();
+
+  // Cosim can optionally include a manifest simulation, so produce it in case
+  // the Cosim BSP wants it.
+  LogicalResult ret = createRomModule(op, rewriter);
+  if (failed(ret))
+    return ret;
 
   // Declare external module.
   Attribute params[] = {
@@ -494,7 +604,7 @@ LogicalResult CosimManifestLowering::matchAndRewrite(
       [&](OpBuilder &rewriter, const hw::HWModulePortAccessor &) {
         // Assemble the manifest data into a constant.
         SmallVector<Attribute> bytes;
-        for (char b : op.getCompressedManifest().getData())
+        for (uint8_t b : op.getCompressedManifest().getData())
           bytes.push_back(rewriter.getI8IntegerAttr(b));
         auto manifestConstant = rewriter.create<hw::AggregateConstantOp>(
             loc, hw::UnpackedArrayType::get(rewriter.getI8Type(), bytes.size()),
@@ -520,7 +630,6 @@ LogicalResult CosimManifestLowering::matchAndRewrite(
   rewriter.eraseOp(op);
   return success();
 }
-
 void ESItoHWPass::runOnOperation() {
   auto top = getOperation();
   auto *ctxt = &getContext();
@@ -542,6 +651,7 @@ void ESItoHWPass::runOnOperation() {
   pass1Target.addLegalDialect<comb::CombDialect>();
   pass1Target.addLegalDialect<HWDialect>();
   pass1Target.addLegalDialect<SVDialect>();
+  pass1Target.addLegalDialect<seq::SeqDialect>();
   pass1Target.addLegalOp<WrapValidReadyOp, UnwrapValidReadyOp>();
 
   pass1Target.addIllegalOp<WrapSVInterfaceOp, UnwrapSVInterfaceOp>();
@@ -560,6 +670,8 @@ void ESItoHWPass::runOnOperation() {
 
   if (platform == Platform::cosim) {
     pass1Patterns.insert<CosimManifestLowering>(ctxt);
+  } else if (platform == Platform::fpga) {
+    pass1Patterns.insert<ManifestRomLowering>(ctxt);
   }
 
   // Run the conversion.

--- a/test/Dialect/ESI/manifest.mlir
+++ b/test/Dialect/ESI/manifest.mlir
@@ -75,6 +75,17 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // HIER-NEXT:     esi.manifest.req #esi.appid<"func1">, <@funcs::@call> std "esi.service.std.func", toClient, !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>
 // HIER-NEXT:   }
 
+// HW-LABEL:    hw.module @__ESI_Manifest_ROM(in %clk : !seq.clock, in %address : i30, out data : i32) {
+// HW:            [[R0:%.+]] = hw.aggregate_constant
+// HW:            [[R1:%.+]] = sv.reg : !hw.inout<uarray<279xi32>>
+// HW:            sv.assign [[R1]], [[R0]] : !hw.uarray<279xi32>
+// HW:            [[R2:%.+]] = comb.extract %address from 0 : (i30) -> i9
+// HW:            [[R3:%.+]] = seq.compreg  [[R2]], %clk : i9
+// HW:            [[R4:%.+]] = sv.array_index_inout [[R1]][[[R3]]] : !hw.inout<uarray<279xi32>>, i9
+// HW:            [[R5:%.+]] = sv.read_inout [[R4]] : !hw.inout<i32>
+// HW:            [[R6:%.+]] = seq.compreg  [[R5]], %clk : i32
+// HW:            hw.output [[R6]] : i32
+
 // HW-LABEL:    hw.module @top
 // HW:            hw.instance "__manifest" @__ESIManifest() -> ()
 // HW-LABEL:    hw.module.extern @Cosim_Manifest<COMPRESSED_MANIFEST_SIZE: i32>(in %compressed_manifest : !hw.uarray<#hw.param.decl.ref<"COMPRESSED_MANIFEST_SIZE">xi8>) attributes {verilogName = "Cosim_Manifest"}


### PR DESCRIPTION
Since ESI hardware embeds the manifest, lower the zlib-compressed version of it to a module to be instantiated by a BSP.