### PR TITLE
[Builds] Revert back to small runners

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -132,7 +132,10 @@ jobs:
     # much.
     # If individual jobs fail due to timeouts or disconnects, please report to
     # John and re-run the job.
-    runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
+    # runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
+    # Disabled temporarily since self-hosted runners were disabled in our repo.
+
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/circt/images/circt-ci-build:20230126201226
       volumes:

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -27,7 +27,10 @@ jobs:
     # much.
     # If individual jobs fail due to timeouts or disconnects, please report to
     # John and re-run the job.
-    runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
+    # runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
+    # Disabled temporarily since self-hosted runners were disabled in our repo.
+
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/circt/images/circt-integration-test:v12.2
       volumes:


### PR DESCRIPTION
Self-hosted runners were disabled in our repo, so none of our builds are being picked up. Going back to the slow ones (with less disk space) while we figure out the situation.