### PR TITLE
[PyCDE] Fix service generator warning

### DIFF
--- a/frontends/PyCDE/src/common.py
+++ b/frontends/PyCDE/src/common.py
@@ -117,6 +117,10 @@ class _PyProxy:
   def __init__(self, name: str):
     self.name = name
 
+  def clear_op_refs(self):
+    """Clear all references to IR ops."""
+    pass
+
 
 class PortError(Exception):
   pass

--- a/frontends/PyCDE/src/esi.py
+++ b/frontends/PyCDE/src/esi.py
@@ -13,7 +13,7 @@ from .circt import ir
 from .circt.dialects import esi as raw_esi, hw, msft
 
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 __dir__ = Path(__file__).parent
 
@@ -300,8 +300,9 @@ class _ServiceGeneratorRegistry:
   _registered = False
   _impl_type_name = ir.StringAttr.get("pycde")
 
-  def __init__(self):
-    self._registry: Dict[str, ServiceImplementation] = {}
+  def __init__(self) -> None:
+    self._registry: Dict[ir.StringAttr, Tuple[ServiceImplementation,
+                                              System]] = {}
 
     # Register myself with ESI so I can dispatch to my internal registry.
     assert _ServiceGeneratorRegistry._registered is False, \
@@ -324,6 +325,7 @@ class _ServiceGeneratorRegistry:
       ctr += 1
       name = basename + "_" + str(ctr)
     name_attr = ir.StringAttr.get(name)
+
     self._registry[name_attr] = (service_implementation, System.current())
     return ir.DictAttr.get({"name": name_attr})
 

--- a/frontends/PyCDE/src/module.py
+++ b/frontends/PyCDE/src/module.py
@@ -499,7 +499,7 @@ class ModuleBuilder(ModuleLikeBuilderBase):
       hw.OutputOp([o.value for o in ports._output_values])
 
 
-class Module(metaclass=ModuleLikeType):
+class Module(_PyProxy, metaclass=ModuleLikeType):
   """Subclass this class to define a regular PyCDE or external module. To define
   a module in PyCDE, supply a `@generator` method. To create an external module,
   don't. In either case, a list of ports is required.
@@ -520,6 +520,7 @@ class Module(metaclass=ModuleLikeType):
     """Create an instance of this module. Instance namd and appid are optional.
     All inputs must be specified. If a signal has not been produced yet, use the
     `Wire` construct and assign the signal to that wire later on."""
+    from .system import System
 
     kwargs = dict()
 
@@ -540,9 +541,13 @@ class Module(metaclass=ModuleLikeType):
         kwargs["appid"] = appid
 
     self.inst = self._builder.instantiate(self, inputs, **kwargs)
-
     if appid is not None:
       self.inst.operation.attributes[AppID.AttributeName] = appid._appid
+
+    System.current()._op_cache.register_pyproxy(self)
+
+  def clear_op_refs(self):
+    self.inst = None
 
   @classmethod
   def print(cls, out=sys.stdout):


### PR DESCRIPTION
Fix warning about holding on to MLIR ops. Service generator instances get held through a C++/Python interaction barrier, unlike regular instances. So the member variable `inst` (which points to the MLIR instance operation) has to be cleared before attempting to clear the live operations.