### PR TITLE
[ESI] XRT support for MMIO based manifest fetching

### DIFF
--- a/frontends/PyCDE/integration_test/esi_ram.py
+++ b/frontends/PyCDE/integration_test/esi_ram.py
@@ -7,7 +7,7 @@
 import pycde
 from pycde import (AppID, Clock, Input, Module, generator)
 from pycde.esi import DeclareRandomAccessMemory, ServiceDecl
-from pycde.bsp import cosim
+from pycde.bsp import cosim, xrt
 from pycde.types import Bits
 
 import sys
@@ -46,29 +46,40 @@ class MemWriter(Module):
     RamI64x8.write(write_bundle, appid=AppID("int_writer"))
 
 
-class Top(Module):
-  clk = Clock()
-  rst = Input(Bits(1))
+def Top(xrt: bool):
 
-  @generator
-  def construct(ports):
-    MemWriter(clk=ports.clk, rst=ports.rst)
+  class Top(Module):
+    clk = Clock()
+    rst = Input(Bits(1))
 
-    # Pass through reads and writes from the host.
-    ram_write = MemComms.write(AppID("write"))
-    RamI64x8.write(ram_write, AppID("ram_write"))
-    ram_read = MemComms.read(AppID("read"))
-    RamI64x8.read(ram_read, AppID("ram_read"))
+    @generator
+    def construct(ports):
+      MemWriter(clk=ports.clk, rst=ports.rst)
 
-    # Instantiate the RAM.
-    RamI64x8.instantiate_builtin(appid=AppID("mem"),
-                                 builtin="sv_mem",
-                                 result_types=[],
-                                 inputs=[ports.clk, ports.rst])
+      # We don't have support for host--device channel communication on XRT yet.
+      if not xrt:
+        # Pass through reads and writes from the host.
+        ram_write = MemComms.write(AppID("write"))
+        RamI64x8.write(ram_write, AppID("ram_write"))
+        ram_read = MemComms.read(AppID("read"))
+        RamI64x8.read(ram_read, AppID("ram_read"))
+
+      # Instantiate the RAM.
+      RamI64x8.instantiate_builtin(appid=AppID("mem"),
+                                   builtin="sv_mem",
+                                   result_types=[],
+                                   inputs=[ports.clk, ports.rst])
+
+  return Top
 
 
 if __name__ == "__main__":
-  s = pycde.System([cosim.CosimBSP(Top)],
+  is_xrt = len(sys.argv) > 2 and sys.argv[2] == "xrt"
+  if is_xrt:
+    bsp = xrt.XrtBSP
+  else:
+    bsp = cosim.CosimBSP
+  s = pycde.System(bsp(Top(is_xrt)),
                    name="ESIMem",
                    output_directory=sys.argv[1])
   s.compile()

--- a/frontends/PyCDE/src/CMakeLists.txt
+++ b/frontends/PyCDE/src/CMakeLists.txt
@@ -52,8 +52,8 @@ declare_mlir_python_sources(PyCDESources
   bsp/cosim.py
   bsp/xrt.py
   bsp/EsiXrtPython.cpp
-  bsp/Makefile.xrt.j2
-  bsp/xrt_package.tcl.j2
+  bsp/Makefile.xrt.mk
+  bsp/xrt_package.tcl
   bsp/xrt_api.py
   bsp/xrt.ini
   bsp/xsim.tcl

--- a/frontends/PyCDE/src/bsp/xrt.py
+++ b/frontends/PyCDE/src/bsp/xrt.py
@@ -3,69 +3,18 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ..common import Clock, Input, Output
-from ..constructs import ControlReg, Wire
 from ..module import Module, generator
 from ..system import System
-from ..types import bit, types, Bits
+from ..types import Bits
 from .. import esi
 
+from .common import AxiMMIO
+
 import glob
-from io import FileIO
-import math
 import pathlib
 import shutil
 
 __dir__ = pathlib.Path(__file__).parent
-
-# Parameters for AXI4-Lite interface
-axil_addr_width = 32
-axil_data_width = 32
-axil_data_width_bytes = int(axil_data_width / 8)
-
-# Constants for MMIO registers
-MagicNumberLo = 0xE5100E51  # ESI__ESI
-MagicNumberHi = 0x207D98E5  # Random
-VersionNumber = 0  # Version 0: format subject to change
-
-
-# Signals from master
-def axil_in_type(addr_width, data_width):
-  return types.struct({
-      "awvalid": types.i1,
-      "awaddr": types.int(addr_width),
-      "wvalid": types.i1,
-      "wdata": types.int(data_width),
-      "wstrb": types.int(data_width // 8),
-      "arvalid": types.i1,
-      "araddr": types.int(addr_width),
-      "rready": types.i1,
-      "bready": types.i1
-  })
-
-
-# Signals to master
-def axil_out_type(data_width):
-  return types.struct({
-      "awready": types.i1,
-      "wready": types.i1,
-      "arready": types.i1,
-      "rvalid": types.i1,
-      "rdata": types.int(data_width),
-      "rresp": types.i2,
-      "bvalid": types.i1,
-      "bresp": types.i2
-  })
-
-
-def output_tcl(os: FileIO):
-  """Output Vitis tcl describing the registers."""
-
-  from jinja2 import Environment, FileSystemLoader, StrictUndefined
-
-  env = Environment(loader=FileSystemLoader(str(__dir__)),
-                    undefined=StrictUndefined)
-  template = env.get_template("xrt_package.tcl.j2")
-  os.write(template.render(system_name=System.current().name))
 
 
 def XrtBSP(user_module):
@@ -74,7 +23,7 @@ def XrtBSP(user_module):
   How to use this BSP:
   - Wrap your top PyCDE module in `XrtBSP`.
   - Run your script. This BSP will write a 'build package' to the output dir.
-  This package contains a Makefile.xrt which (given a proper Vitis dev
+  This package contains a Makefile.xrt.mk which (given a proper Vitis dev
   environment) will compile a hw image or hw_emu image. It is a free-standing
   build package -- you do not need PyCDE installed on the same machine as you
   want to do the image build.
@@ -85,145 +34,70 @@ def XrtBSP(user_module):
   This target requires a few environment variables to be set (which the Makefile
   will tell you about).
   - To build a hw emulation image, run with TARGET=hw_emu.
-  - The makefile also builds a Python plugin. To specify the python version to
-  build against (if different from the version ran by 'python3' in your
-  environment), set the PYTHON variable (e.g. 'PYTHON=python3.9').
+  - Validated ONLY on Vitis 2023.1. Known to NOT work with Vitis <2022.1.
   """
 
-  class XrtService(Module):
-    clk = Clock(types.i1)
-    rst = Input(types.i1)
-
-    axil_in = Input(axil_in_type(axil_addr_width, axil_data_width))
-    axil_out = Output(axil_out_type(axil_data_width))
-
-    @generator
-    def generate(self):
-      clk = self.clk
-      rst = self.rst
-
-      sys: System = System.current()
-      output_tcl((sys.hw_output_dir / "xrt_package.tcl").open("w"))
-
-      ######
-      # Write side.
-
-      # So that we don't wedge the AXI-lite for writes, just ack all of them.
-      write_happened = Wire(bit)
-      latched_aw = ControlReg(self.clk, self.rst, [self.axil_in.awvalid],
-                              [write_happened])
-      latched_w = ControlReg(self.clk, self.rst, [self.axil_in.wvalid],
-                             [write_happened])
-      write_happened.assign(latched_aw & latched_w)
-
-      ######
-      # Read side.
-
-      # Track the non-zero registers in the read address space.
-      rd_addr_data = {
-          16: Bits(32)(MagicNumberLo),
-          20: Bits(32)(MagicNumberHi),
-          24: Bits(32)(VersionNumber),
-      }
-
-      # Create an array out of the sparse value map 'rd_addr_data' and zero
-      # constants. Then create a potentially giant mux. There's probably a much
-      # better way to do this. I suspect this is a common high-level construct
-      # which should be automatically optimized, but I'm not sure how common
-      # this actually is.
-
-      max_addr_log2 = int(
-          math.ceil(math.log2(max([a for a in rd_addr_data.keys()]) + 1)))
-
-      # Convert the sparse dict into a zero filled array.
-      zero = types.int(axil_data_width)(0)
-      rd_space = [zero] * int(math.pow(2, max_addr_log2))
-      for (addr, val) in rd_addr_data.items():
-        rd_space[addr] = val
-
-      # Create the address index signal and do the muxing.
-      addr_slice = self.axil_in.araddr.slice(
-          types.int(axil_addr_width)(0), max_addr_log2)
-      rd_addr = addr_slice.reg(clk, rst)
-      rvalid = self.axil_in.arvalid.reg(clk, rst, cycles=2)
-      rdata = types.array(types.int(axil_data_width),
-                          len(rd_space))(rd_space)[rd_addr].reg(clk)
-
-      # Assign the module outputs.
-      self.axil_out = axil_out_type(axil_data_width)({
-          "awready": 1,
-          "wready": 1,
-          "arready": 1,
-          "rvalid": rvalid,
-          "rdata": rdata,
-          "rresp": 0,
-          "bvalid": write_happened,
-          "bresp": 0
-      })
-
-  class top(Module):
+  class XrtTop(Module):
     ap_clk = Clock()
-    ap_resetn = Input(types.i1)
+    ap_resetn = Input(Bits(1))
 
     # AXI4-Lite slave interface
-    s_axi_control_AWVALID = Input(types.i1)
-    s_axi_control_AWREADY = Output(types.i1)
-    s_axi_control_AWADDR = Input(types.int(axil_addr_width))
-    s_axi_control_WVALID = Input(types.i1)
-    s_axi_control_WREADY = Output(types.i1)
-    s_axi_control_WDATA = Input(types.int(axil_data_width))
-    s_axi_control_WSTRB = Input(types.int(axil_data_width // 8))
-    s_axi_control_ARVALID = Input(types.i1)
-    s_axi_control_ARREADY = Output(types.i1)
-    s_axi_control_ARADDR = Input(types.int(axil_addr_width))
-    s_axi_control_RVALID = Output(types.i1)
-    s_axi_control_RREADY = Input(types.i1)
-    s_axi_control_RDATA = Output(types.int(axil_data_width))
-    s_axi_control_RRESP = Output(types.i2)
-    s_axi_control_BVALID = Output(types.i1)
-    s_axi_control_BREADY = Input(types.i1)
-    s_axi_control_BRESP = Output(types.i2)
+    s_axi_control_AWVALID = Input(Bits(1))
+    s_axi_control_AWREADY = Output(Bits(1))
+    s_axi_control_AWADDR = Input(Bits(20))
+    s_axi_control_WVALID = Input(Bits(1))
+    s_axi_control_WREADY = Output(Bits(1))
+    s_axi_control_WDATA = Input(Bits(32))
+    s_axi_control_WSTRB = Input(Bits(32 // 8))
+    s_axi_control_ARVALID = Input(Bits(1))
+    s_axi_control_ARREADY = Output(Bits(1))
+    s_axi_control_ARADDR = Input(Bits(20))
+    s_axi_control_RVALID = Output(Bits(1))
+    s_axi_control_RREADY = Input(Bits(1))
+    s_axi_control_RDATA = Output(Bits(32))
+    s_axi_control_RRESP = Output(Bits(2))
+    s_axi_control_BVALID = Output(Bits(1))
+    s_axi_control_BREADY = Input(Bits(1))
+    s_axi_control_BRESP = Output(Bits(2))
 
     @generator
     def construct(ports):
-
-      axil_in_sig = axil_in_type(axil_addr_width, axil_data_width)({
-          "awvalid": ports.s_axi_control_AWVALID,
-          "awaddr": ports.s_axi_control_AWADDR,
-          "wvalid": ports.s_axi_control_WVALID,
-          "wdata": ports.s_axi_control_WDATA,
-          "wstrb": ports.s_axi_control_WSTRB,
-          "arvalid": ports.s_axi_control_ARVALID,
-          "araddr": ports.s_axi_control_ARADDR,
-          "rready": ports.s_axi_control_RREADY,
-          "bready": ports.s_axi_control_BREADY,
-      })
+      System.current().platform = "fpga"
 
       rst = ~ports.ap_resetn
 
-      xrt = XrtService(clk=ports.ap_clk, rst=rst, axil_in=axil_in_sig)
-
-      axil_out = xrt.axil_out
+      xrt = AxiMMIO(
+          esi.MMIO,
+          appid=esi.AppID("xrt_mmio"),
+          clk=ports.ap_clk,
+          rst=rst,
+          awvalid=ports.s_axi_control_AWVALID,
+          awaddr=ports.s_axi_control_AWADDR,
+          wvalid=ports.s_axi_control_WVALID,
+          wdata=ports.s_axi_control_WDATA,
+          wstrb=ports.s_axi_control_WSTRB,
+          arvalid=ports.s_axi_control_ARVALID,
+          araddr=ports.s_axi_control_ARADDR,
+          rready=ports.s_axi_control_RREADY,
+          bready=ports.s_axi_control_BREADY,
+      )
 
       # AXI-Lite control
-      ports.s_axi_control_AWREADY = axil_out['awready']
-      ports.s_axi_control_WREADY = axil_out['wready']
-      ports.s_axi_control_ARREADY = axil_out['arready']
-      ports.s_axi_control_RVALID = axil_out['rvalid']
-      ports.s_axi_control_RDATA = axil_out['rdata']
-      ports.s_axi_control_RRESP = axil_out['rresp']
-      ports.s_axi_control_BVALID = axil_out['bvalid']
-      ports.s_axi_control_BRESP = axil_out['bresp']
+      ports.s_axi_control_AWREADY = xrt.awready
+      ports.s_axi_control_WREADY = xrt.wready
+      ports.s_axi_control_ARREADY = xrt.arready
+      ports.s_axi_control_RVALID = xrt.rvalid
+      ports.s_axi_control_RDATA = xrt.rdata
+      ports.s_axi_control_RRESP = xrt.rresp
+      ports.s_axi_control_BVALID = xrt.bvalid
+      ports.s_axi_control_BRESP = xrt.bresp
 
-      # Splice in the user's code
-      # NOTE: the clock is `ports.ap_clk`
-      #       and reset is `ports.ap_resetn` which is active low
       user_module(clk=ports.ap_clk, rst=rst)
 
       # Copy additional sources
       sys: System = System.current()
       sys.add_packaging_step(esi.package)
-      sys.add_packaging_step(top.package)
+      sys.add_packaging_step(XrtTop.package)
 
     @staticmethod
     def package(sys: System):
@@ -231,21 +105,16 @@ def XrtBSP(user_module):
       collateral (about which we are aware), build/debug scripts, and the
       generated runtime."""
 
-      from jinja2 import Environment, FileSystemLoader, StrictUndefined
-
       sv_sources = glob.glob(str(__dir__ / '*.sv'))
       tcl_sources = glob.glob(str(__dir__ / '*.tcl'))
       for source in sv_sources + tcl_sources:
         shutil.copy(source, sys.hw_output_dir)
 
-      env = Environment(loader=FileSystemLoader(str(__dir__)),
-                        undefined=StrictUndefined)
-      makefile_template = env.get_template("Makefile.xrt.j2")
-      dst_makefile = sys.output_directory / "Makefile.xrt"
-      dst_makefile.open("w").write(
-          makefile_template.render(system_name=sys.name))
-
+      shutil.copy(__dir__ / "Makefile.xrt.mk",
+                  sys.output_directory / "Makefile.xrt.mk")
+      shutil.copy(__dir__ / "xrt_package.tcl",
+                  sys.output_directory / "xrt_package.mk")
       shutil.copy(__dir__ / "xrt.ini", sys.output_directory / "xrt.ini")
       shutil.copy(__dir__ / "xsim.tcl", sys.output_directory / "xsim.tcl")
 
-  return top
+  return XrtTop

--- a/frontends/PyCDE/src/bsp/xrt_package.tcl
+++ b/frontends/PyCDE/src/bsp/xrt_package.tcl
@@ -12,7 +12,7 @@ set target    [lindex $::argv 2]
 set xpfm_path [lindex $::argv 3]
 set device    [lindex $::argv 4]
 
-set krnl_name {{system_name}}
+set krnl_name esi_kernel
 set suffix "${krnl_name}_${target}_${device}"
 
 set project_path "./temp_kernel"
@@ -25,13 +25,13 @@ create_project -force kernel $project_path
 add_files -norecurse [glob $srcs/*.sv]
 
 # Use the correct top level module
-set_property top top [current_fileset]
+set_property top XrtTop [current_fileset]
 
 update_compile_order -fileset sources_1
 update_compile_order -fileset sim_1
 
 # Package the temporary project
-ipx::package_project -root_dir $package_path -vendor circt.llvm.org -library {{system_name}} -taxonomy /KernelIP -import_files -set_current false
+ipx::package_project -root_dir $package_path -taxonomy /KernelIP -import_files -set_current false
 
 # Load a new project to edit the packaged kernel IP
 ipx::unload_core $package_path/component.xml
@@ -39,20 +39,32 @@ ipx::edit_ip_in_project -upgrade true -name tmp_prj -directory $package_path $pa
 
 set core [ipx::current_core]
 
-# Associate AXI-Lite control interfaces
+# Associate AXI data & AXI-Lite control interfaces
 ipx::associate_bus_interfaces -busif s_axi_control -clock ap_clk $core
 
 # Create the address space for CSRs
-set mem_map     [::ipx::add_memory_map -quiet "s_axi_control" $core]
-set addr_block  [::ipx::add_address_block -quiet "reg0" $mem_map]
+set mem_map     [::ipx::add_memory_map "s_axi_control" $core]
+set addr_block  [::ipx::add_address_block "reg0" $mem_map]
 
-set reg      [::ipx::add_register "EsiMagicNumber" $addr_block]
+set_property range 0x100000 $addr_block
+set_property range_resolve_type "immediate" $addr_block
+set_property range_minimum 0x100000 $addr_block
+
+set reg      [::ipx::add_register "EsiMagicNumberLow" $addr_block]
   set_property address_offset 16  $reg
-  set_property size           64 $reg
+  set_property size           32 $reg
+
+set reg      [::ipx::add_register "EsiMagicNumberHigh" $addr_block]
+  set_property address_offset 20  $reg
+  set_property size           32 $reg
 
 set reg      [::ipx::add_register "EsiVersionNumber" $addr_block]
   set_property address_offset 24  $reg
   set_property size           32 $reg
+
+set reg [::ipx::add_register "EsiManifestLoc" $addr_block]
+  set_property address_offset 32 $reg
+  set_property size 32 $reg
 
 set_property slave_memory_map_ref "s_axi_control" [::ipx::get_bus_interfaces -of $core "s_axi_control"]
 

--- a/frontends/PyCDE/src/system.py
+++ b/frontends/PyCDE/src/system.py
@@ -261,7 +261,8 @@ class System:
       "builtin.module(hw.module(lower-seq-hlmem))",
       "builtin.module(lower-esi-to-physical)",
       # TODO: support more than just cosim.
-      "builtin.module(lower-esi-bundles, lower-esi-ports, lower-esi-to-hw{{platform=cosim}})",
+      "builtin.module(lower-esi-bundles, lower-esi-ports)",
+      "builtin.module(lower-esi-to-hw{{platform={platform}}})",
       "builtin.module(convert-fsm-to-sv)",
       "builtin.module(lower-hwarith-to-hw)",
       "builtin.module(lower-seq-to-sv)",
@@ -293,7 +294,8 @@ class System:
         if isinstance(phase, str):
           passes = phase.format(tops=tops,
                                 verilog_file=verilog_file,
-                                tcl_file=tcl_file).strip()
+                                tcl_file=tcl_file,
+                                platform=self.platform).strip()
           if aplog is not None:
             aplog.write(f"// passes ran: {passes}\n")
             aplog.flush()

--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -63,6 +63,10 @@ set(ESIPythonRuntimeSources
   python/esi/types.py
   python/esi/esiCppAccel.pyi
 )
+set(ESIRuntimeIncludeDirs)
+set(ESIRuntimeCxxFlags)
+set(ESIRuntimeLinkFlags)
+set(ESIRuntimeLibDirs)
 
 IF(MSVC)
     set(CMAKE_CXX_FLAGS "/EHa")
@@ -106,12 +110,48 @@ if(CapnProto_FOUND)
   )
 endif()
 
+option(XRT_PATH "Path to XRT lib.")
+if (XRT_PATH)
+  message("-- XRT enabled with path ${XRT_PATH}")
+
+  set(ESIRuntimeSources
+    ${ESIRuntimeSources}
+    cpp/lib/backends/Xrt.cpp
+  )
+  set(ESIRuntimeIncludeDirs
+    ${ESIRuntimeIncludeDirs}
+    ${XRT_PATH}/include
+  )
+  set(ESIRuntimeCxxFlags
+    ${ESIRuntimeCxxFlags}
+    -fmessage-length=0
+    -Wno-nested-anon-types
+    -Wno-c++98-compat-extra-semi
+  )
+  set(ESIRuntimeLinkLibraries
+    ${ESIRuntimeLinkLibraries}
+    xrt_coreutil
+  )
+  set(ESIRuntimeLinkFlags
+    ${ESIRuntimeLinkFlags}
+    -pthread
+  )
+  set(ESIRuntimeLibDirs
+    ${ESIRuntimeLibDirs}
+    ${XRT_PATH}/lib
+  )
+endif()
+
 # The core API. For now, compile the backends into it directly.
 # TODO: make this a plugin architecture.
 add_library(ESIRuntime SHARED
   ${ESIRuntimeSources}
 )
 target_link_libraries(ESIRuntime PRIVATE ${ESIRuntimeLinkLibraries})
+target_include_directories(ESIRuntime PRIVATE ${ESIRuntimeIncludeDirs})
+target_compile_options(ESIRuntime PRIVATE ${ESIRuntimeCxxFlags})
+target_link_directories(ESIRuntime PRIVATE ${ESIRuntimeLibDirs})
+target_link_options(ESIRuntime PRIVATE ${ESIRuntimeLinkFlags})
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_options(ESIRuntime PRIVATE -Wno-covered-switch-default)

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Xrt.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Xrt.h
@@ -1,0 +1,53 @@
+//===- Xrt.h - ESI XRT device backend ---------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This is a specialization of the ESI C++ API (backend) for connection into
+// hardware on an XRT device. Requires XRT C++ library.
+//
+// DO NOT EDIT!
+// This file is distributed as part of an ESI package. The source for this file
+// should always be modified within CIRCT (lib/dialect/ESI/runtime/cpp).
+//
+//===----------------------------------------------------------------------===//
+
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef ESI_BACKENDS_XRT_H
+#define ESI_BACKENDS_XRT_H
+
+#include "esi/Accelerator.h"
+
+#include <memory>
+
+namespace esi {
+namespace backends {
+namespace xrt {
+
+/// Connect to an ESI simulation.
+class XrtAccelerator : public esi::AcceleratorConnection {
+public:
+  struct Impl;
+
+  XrtAccelerator(std::string xclbin, std::string kernelName);
+  static std::unique_ptr<AcceleratorConnection>
+  connect(std::string connectionString);
+
+protected:
+  virtual Service *createService(Service::Type service, AppIDPath path,
+                                 std::string implName,
+                                 const ServiceImplDetails &details,
+                                 const HWClientDetails &clients) override;
+
+private:
+  std::unique_ptr<Impl> impl;
+};
+
+} // namespace xrt
+} // namespace backends
+} // namespace esi
+
+#endif // ESI_BACKENDS_XRT_H

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Xrt.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Xrt.cpp
@@ -1,0 +1,103 @@
+//===- Xrt.cpp - ESI XRT device backend -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// DO NOT EDIT!
+// This file is distributed as part of an ESI package. The source for this file
+// should always be modified within CIRCT
+// (lib/dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp).
+//
+//===----------------------------------------------------------------------===//
+
+#include "esi/backends/Xrt.h"
+#include "esi/Services.h"
+
+// XRT includes
+#include "experimental/xrt_bo.h"
+#include "experimental/xrt_device.h"
+#include "experimental/xrt_ip.h"
+#include "experimental/xrt_xclbin.h"
+
+#include <fstream>
+#include <iostream>
+#include <set>
+
+using namespace std;
+
+using namespace esi;
+using namespace esi::services;
+using namespace esi::backends::xrt;
+
+/// Parse the connection string and instantiate the accelerator. Connection
+/// string format:
+///  <xclbin>[:<device_id>]
+/// wherein <device_id> is in BDF format.
+unique_ptr<AcceleratorConnection>
+XrtAccelerator::connect(string connectionString) {
+  string xclbin;
+  string device_id;
+
+  size_t colon = connectionString.find(':');
+  if (colon == string::npos) {
+    xclbin = connectionString;
+  } else {
+    xclbin = connectionString.substr(0, colon);
+    device_id = connectionString.substr(colon + 1);
+  }
+
+  return make_unique<XrtAccelerator>(xclbin, device_id);
+}
+
+struct esi::backends::xrt::XrtAccelerator::Impl {
+  constexpr static char kernel[] = "esi_kernel";
+
+  Impl(string xclbin, string device_id) {
+    if (device_id.empty())
+      device = ::xrt::device(0);
+    else
+      device = ::xrt::device(device_id);
+
+    auto uuid = device.load_xclbin(xclbin);
+    ip = ::xrt::ip(device, uuid, kernel);
+  }
+
+  ::xrt::device device;
+  ::xrt::ip ip;
+};
+
+/// Construct and connect to a cosim server.
+XrtAccelerator::XrtAccelerator(string xclbin, string device_id) {
+  impl = make_unique<Impl>(xclbin, device_id);
+}
+
+namespace {
+class XrtMMIO : public MMIO {
+public:
+  XrtMMIO(::xrt::ip &ip) : ip(ip) {}
+
+  uint32_t read(uint32_t addr) const override { return ip.read_register(addr); }
+  void write(uint32_t addr, uint32_t data) override {
+    ip.write_register(addr, data);
+  }
+
+private:
+  ::xrt::ip &ip;
+};
+} // namespace
+
+Service *XrtAccelerator::createService(Service::Type svcType, AppIDPath id,
+                                       std::string implName,
+                                       const ServiceImplDetails &details,
+                                       const HWClientDetails &clients) {
+  if (svcType == typeid(MMIO))
+    return new XrtMMIO(impl->ip);
+  else if (svcType == typeid(SysInfo))
+    return new MMIOSysInfo(getService<MMIO>());
+  return nullptr;
+}
+
+REGISTER_ACCELERATOR("xrt", backends::xrt::XrtAccelerator);


### PR DESCRIPTION
Xilinx Runtime Shell (XRT) support for exposing the MMIO header and manifest over MMIO. XRT is the platform used by Azure's NP instances which have access to attached U250 FPGAs. Works in both hw_emu and real hardware.