### PR TITLE
[FIRRTL][ExtractInstances] Clear entire state on pass invocation

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -147,6 +147,8 @@ void ExtractInstancesPass::runOnOperation() {
   annotatedModules.clear();
   dutRootModules.clear();
   dutModules.clear();
+  dutModuleNames.clear();
+  dutPrefix = "";
   extractionWorklist.clear();
   extractionPaths.clear();
   originalInstanceParents.clear();


### PR DESCRIPTION
Clear 'dutModuleNames' and 'dutPrefix' along with the other members before running the pass.

Not doing so most likely caused the spurious CI failure in https://github.com/llvm/circt/actions/runs/7615901959/job/20741468888 where the "Plop" prefix got carried inadvertently. But I have no idea how this pass works, so take it with a grain of salt.