### PR TITLE
[FIRRTL][LowerAnnotation] Allow `registerAnnotationRecord` to override existing handlers

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -449,7 +449,8 @@ struct AnnoRecord {
 /// Register external annotation records.
 LogicalResult registerAnnotationRecord(
     StringRef annoClass, AnnoRecord annoRecord,
-    const std::function<void(llvm::Twine)> &errorHandler = {});
+    const std::function<void(llvm::Twine)> &errorHandler = {},
+    bool allowOverride = false);
 
 ///===----------------------------------------------------------------------===//
 /// Standard Utility Resolvers

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -515,8 +515,10 @@ static llvm::StringMap<AnnoRecord> annotationRecords{{
 
 LogicalResult
 registerAnnotationRecord(StringRef annoClass, AnnoRecord annoRecord,
-                         const std::function<void(llvm::Twine)> &errorHandler) {
-
+                         const std::function<void(llvm::Twine)> &errorHandler,
+                         bool allowOverride) {
+  if (allowOverride)
+    annotationRecords.erase(annoClass);
   if (annotationRecords.insert({annoClass, annoRecord}).second)
     return LogicalResult::success();
   if (errorHandler)


### PR DESCRIPTION
This adds `allowOverride` argument to registerAnnotationRecord. This is useful for ignoring proprietary annotations in upstream firtool that are handled by plugins.