### PR TITLE
[HW] Remove the cache-based lookup method from HWInstanceLike

### DIFF
--- a/include/circt/Dialect/HW/HWInstanceImplementation.h
+++ b/include/circt/Dialect/HW/HWInstanceImplementation.h
@@ -31,11 +31,6 @@ namespace instance_like_impl {
 using EmitErrorFn =
     std::function<void(std::function<bool(InFlightDiagnostic &)>)>;
 
-/// Return a pointer to the referenced module operation.
-Operation *getReferencedModule(const HWSymbolCache *cache,
-                               Operation *instanceOp,
-                               mlir::FlatSymbolRefAttr moduleName);
-
 /// Verify that the instance refers to a valid HW module.
 LogicalResult verifyReferencedModule(Operation *instanceOp,
                                      SymbolTableCollection &symbolTable,

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -412,15 +412,6 @@ def HWInstanceLike : OpInterface<"HWInstanceLike", [
     "::mlir::StringAttr", "getReferencedModuleNameAttr", (ins),
     /*methodBody=*/[{}],
     /*defaultImplementation=*/[{ return $_op.getModuleNameAttr().getAttr(); }]>,
-
-    InterfaceMethod<"Get the referenced module via a HW symbol cache.",
-    "::mlir::Operation *", "getReferencedModuleCached", (ins
-      "const ::circt::hw::HWSymbolCache *":$cache),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{
-      return hw::instance_like_impl::getReferencedModule(
-          cache, $_op, $_op.getModuleNameAttr());
-    }]>,
   ];
 }
 

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -237,11 +237,10 @@ def InteropVerilatedOp : SystemCOp<"interop.verilated", [
 
     /// Lookup the module or extmodule for the symbol.  This returns null on
     /// invalid IR.
-    Operation *getReferencedModule(const hw::HWSymbolCache *cache) {
-      return hw::instance_like_impl::getReferencedModule(cache, *this,
-                                                        getModuleNameAttr());
+    Operation *getReferencedModule() {
+      return SymbolTable::lookupNearestSymbolFrom(getOperation(),
+                                                  getModuleNameAttr());
     }
-    Operation *getReferencedModule() { return getReferencedModule(nullptr); }
 
     /// Get the instances's name.
     StringAttr getName() { return getInstanceNameAttr(); }

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4943,7 +4943,8 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
   ops.insert(op);
 
   // Use the specified name or the symbol name as appropriate.
-  auto *moduleOp = op.getReferencedModuleCached(&state.symbolCache);
+  auto *moduleOp =
+      state.symbolCache.getDefinition(op.getReferencedModuleNameAttr());
   assert(moduleOp && "Invalid IR");
   ps << PPExtString(getVerilogModuleName(moduleOp));
 
@@ -5584,7 +5585,8 @@ void ModuleEmitter::emitBind(BindOp op) {
   ModulePortInfo parentPortList(parentMod.getPortList());
   auto parentVerilogName = getVerilogModuleNameAttr(parentMod);
 
-  Operation *childMod = inst.getReferencedModuleCached(&state.symbolCache);
+  Operation *childMod =
+      state.symbolCache.getDefinition(inst.getReferencedModuleNameAttr());
   auto childVerilogName = getVerilogModuleNameAttr(childMod);
 
   startStatement();

--- a/lib/Dialect/HW/HWInstanceImplementation.cpp
+++ b/lib/Dialect/HW/HWInstanceImplementation.cpp
@@ -13,17 +13,6 @@
 using namespace circt;
 using namespace circt::hw;
 
-Operation *
-instance_like_impl::getReferencedModule(const HWSymbolCache *cache,
-                                        Operation *instanceOp,
-                                        mlir::FlatSymbolRefAttr moduleName) {
-  if (cache)
-    if (auto *result = cache->getDefinition(moduleName))
-      return result;
-
-  return SymbolTable::lookupNearestSymbolFrom(instanceOp, moduleName);
-}
-
 LogicalResult instance_like_impl::verifyReferencedModule(
     Operation *instanceOp, SymbolTableCollection &symbolTable,
     mlir::FlatSymbolRefAttr moduleName, Operation *&module) {

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -531,7 +531,8 @@ InstanceDeclOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 SmallVector<hw::PortInfo> InstanceDeclOp::getPortList() {
-  return cast<hw::PortList>(getReferencedModuleCached(/*cache=*/nullptr))
+  return cast<hw::PortList>(SymbolTable::lookupNearestSymbolFrom(
+                                getOperation(), getReferencedModuleNameAttr()))
       .getPortList();
 }
 

--- a/lib/LogicalEquivalence/LogicExporter.cpp
+++ b/lib/LogicalEquivalence/LogicExporter.cpp
@@ -74,8 +74,10 @@ struct Visitor : public hw::StmtVisitor<Visitor, LogicalResult>,
   //===--------------------------------------------------------------------===//
 
   LogicalResult visitStmt(hw::InstanceOp op) {
-    if (auto hwModule = llvm::dyn_cast<hw::HWModuleOp>(
-            op.getReferencedModuleCached(/*cache=*/nullptr))) {
+    Operation *moduleOp =
+        SymbolTable::lookupNearestSymbolFrom(op, op.getModuleNameAttr());
+
+    if (auto hwModule = llvm::dyn_cast<hw::HWModuleOp>(moduleOp)) {
       circuit->addInstance(op.getInstanceName(), hwModule, op->getOperands(),
                            op->getResults());
       return success();

--- a/lib/Target/DebugInfo/EmitHGLDD.cpp
+++ b/lib/Target/DebugInfo/EmitHGLDD.cpp
@@ -664,7 +664,8 @@ EmittedExpr FileEmitter::emitExpression(Value value) {
       instName = instOp.getInstanceNameAttr();
     if (!instName)
       return {};
-    auto *moduleOp = instOp.getReferencedModuleCached(symbolCache);
+    auto *moduleOp =
+        symbolCache->getDefinition(instOp.getReferencedModuleNameAttr());
     auto portName =
         cast<hw::HWModuleLike>(moduleOp)
             .getPort(instOp.getPortIdForOutputId(result.getResultNumber()))


### PR DESCRIPTION
Since it is only used in ExportVerilog, there is no need to expose it to all dialects.