### PR TITLE
[HW] Make HWInstanceLike agnostic of the number of targets

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -401,18 +401,6 @@ def HWInstanceLike : OpInterface<"HWInstanceLike", [
     PortList, InstanceGraphInstanceOpInterface]> {
   let cppNamespace = "circt::hw";
   let description = "Provide common  module information.";
-
-  let methods = [
-    InterfaceMethod<"Get the name of the instantiated module",
-    "::llvm::StringRef", "getReferencedModuleName", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{ return $_op.getModuleName(); }]>,
-
-    InterfaceMethod<"Get the name of the instantiated module",
-    "::mlir::StringAttr", "getReferencedModuleNameAttr", (ins),
-    /*methodBody=*/[{}],
-    /*defaultImplementation=*/[{ return $_op.getModuleNameAttr().getAttr(); }]>,
-  ];
 }
 
 def InnerRefNamespace : NativeOpTrait<"InnerRefNamespace">;

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -395,7 +395,9 @@ class HWInstanceOpBase<string mnemonic, list<Trait> traits = []> :
       DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>
     ]>
 {
-  let extraClassDeclaration = [{
+  code extraInstanceClassDeclaration = [{}];
+
+  let extraClassDeclaration = extraInstanceClassDeclaration # [{
     /// Return the name of the specified input port or null if it cannot be
     /// determined.
     StringAttr getArgumentName(size_t idx) {
@@ -434,7 +436,9 @@ class HWInstanceOpBase<string mnemonic, list<Trait> traits = []> :
     void getValues(SmallVectorImpl<Value> &values, const ModulePortInfo &mpi);
   }];
 
-  let extraClassDefinition = [{
+  code extraInstanceClassDefinition = [{}];
+
+  let extraClassDefinition = extraInstanceClassDefinition # [{
     ::llvm::SmallVector<::circt::hw::PortInfo> $cppClass::getPortList() {
       return instance_like_impl::getPortList(getOperation());
     }
@@ -516,6 +520,22 @@ def InstanceOp : HWInstanceOpBase<"instance", [HWInstanceLike]> {
 
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
+
+  let extraInstanceClassDeclaration = [{
+    /**
+     * Return the name of the default target.
+     */
+    ::llvm::StringRef getReferencedModuleName() {
+      return getReferencedModuleNameAttr().getValue();
+    }
+
+    /**
+     * Return the name of the default target.
+     */
+    ::mlir::StringAttr getReferencedModuleNameAttr() {
+      return getModuleNameAttr().getAttr();
+    }
+  }];
 }
 
 def InstanceChoiceOp : HWInstanceOpBase<"instance_choice", [
@@ -554,6 +574,15 @@ def InstanceChoiceOp : HWInstanceOpBase<"instance_choice", [
 
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
+
+  let extraInstanceClassDeclaration = [{
+    /**
+     * Return the name of the default target.
+     */
+    StringAttr getDefaultModuleNameAttr() {
+      return getModuleNamesAttr()[0].cast<FlatSymbolRefAttr>().getAttr();
+    }
+  }];
 }
 
 def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,

--- a/lib/Dialect/HW/HWReductions.cpp
+++ b/lib/Dialect/HW/HWReductions.cpp
@@ -35,10 +35,12 @@ struct ModuleSizeCache {
     module->walk([&](Operation *op) {
       size += 1;
       if (auto instOp = dyn_cast<HWInstanceLike>(op)) {
-        auto *node = instanceGraph.lookup(instOp.getReferencedModuleNameAttr());
-        if (auto instModule =
-                dyn_cast_or_null<hw::HWModuleLike>(*node->getModule()))
-          size += getModuleSize(instModule, instanceGraph);
+        for (auto moduleName : instOp.getReferencedModuleNamesAttr()) {
+          auto *node = instanceGraph.lookup(moduleName.cast<StringAttr>());
+          if (auto instModule =
+                  dyn_cast_or_null<hw::HWModuleLike>(*node->getModule()))
+            size += getModuleSize(instModule, instanceGraph);
+        }
       }
     });
     moduleSizes.insert({module, size});

--- a/lib/Dialect/OM/Transforms/FreezePaths.cpp
+++ b/lib/Dialect/OM/Transforms/FreezePaths.cpp
@@ -148,7 +148,11 @@ LogicalResult PathVisitor::processPath(Location loc, hw::HierPathOp hierPathOp,
       // If this is our inner ref pair: [Foo::bar]
       // if "bar" is an instance, modules = [Foo::bar], bottomModule = Bar.
       // if "bar" is a wire, modules = [], bottomModule = Foo, component = bar.
-      if (auto inst = dyn_cast<hw::HWInstanceLike>(op)) {
+      if (isa<hw::HWInstanceLike>(op)) {
+        // TODO: add support for instance choices.
+        auto inst = dyn_cast<hw::InstanceOp>(op);
+        if (!inst)
+          return op->emitError("unsupported instance operation");
         // We are targeting an instance.
         modules.emplace_back(currentModule, verilogName);
         bottomModule = inst.getReferencedModuleNameAttr();


### PR DESCRIPTION
This PR removes the assumption that instance-like ops have a single reference target in order for https://github.com/llvm/circt/pull/6624 to also make instance choices instance-like ops.

Some shortcuts are taken, instances where passes do not trivially support multiple targets are stubbed out to be implemented later, once the choice op is actually materialized and present in the pipeline.