### PR TITLE
[HW] Lower hw.instance_choice to SV

### DIFF
--- a/include/circt/Conversion/ExportVerilog.h
+++ b/include/circt/Conversion/ExportVerilog.h
@@ -22,6 +22,7 @@ std::unique_ptr<mlir::Pass>
 createTestApplyLoweringOptionPass(llvm::StringRef options);
 std::unique_ptr<mlir::Pass> createTestApplyLoweringOptionPass();
 
+std::unique_ptr<mlir::Pass> createHWLowerInstanceChoicesPass();
 std::unique_ptr<mlir::Pass> createPrepareForEmissionPass();
 std::unique_ptr<mlir::Pass> createLegalizeAnonEnumsPass();
 

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -104,6 +104,20 @@ def LegalizeAnonEnums : Pass<"legalize-anon-enums", "mlir::ModuleOp"> {
   ];
 }
 
+def HWLowerInstanceChoices : Pass<"hw-lower-instance-choices",
+                                  "mlir::ModuleOp"> {
+  let summary = "Prepare the collateral for instance choice emission";
+  let description = [{
+    This pass runs as part of verilog emission.
+    It introduces the macros & file lists to which instance choices lower to.
+  }];
+
+  let constructor = "createHWLowerInstanceChoicesPass()";
+  let dependentDialects = [
+    "circt::sv::SVDialect", "circt::hw::HWDialect"
+  ];
+}
+
 def PrepareForEmission : Pass<"prepare-for-emission",
                               "hw::HWModuleOp"> {
   let summary = "Prepare IR for ExportVerilog";

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -539,6 +539,7 @@ def InstanceOp : HWInstanceOpBase<"instance", [HWInstanceLike]> {
 }
 
 def InstanceChoiceOp : HWInstanceOpBase<"instance_choice", [
+    HWInstanceLike,
     DeclareOpInterfaceMethods<InstanceGraphInstanceOpInterface, [
       "getReferencedModuleNamesAttr"
     ]>

--- a/include/circt/Dialect/HW/HWVisitors.h
+++ b/include/circt/Dialect/HW/HWVisitors.h
@@ -89,10 +89,10 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<OutputOp, InstanceOp, TypeScopeOp, TypedeclOp>(
-            [&](auto expr) -> ResultType {
-              return thisCast->visitStmt(expr, args...);
-            })
+        .template Case<OutputOp, InstanceOp, InstanceChoiceOp, TypeScopeOp,
+                       TypedeclOp>([&](auto expr) -> ResultType {
+          return thisCast->visitStmt(expr, args...);
+        })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidStmt(op, args...);
         });
@@ -129,6 +129,7 @@ public:
   // Basic nodes.
   HANDLE(OutputOp, Unhandled);
   HANDLE(InstanceOp, Unhandled);
+  HANDLE(InstanceChoiceOp, Uhandled);
   HANDLE(TypeScopeOp, Unhandled);
   HANDLE(TypedeclOp, Unhandled);
 #undef HANDLE

--- a/include/circt/Dialect/SV/SVPasses.h
+++ b/include/circt/Dialect/SV/SVPasses.h
@@ -27,6 +27,7 @@ std::unique_ptr<mlir::Pass> createHWCleanupPass(bool mergeAlwaysBlocks = true);
 std::unique_ptr<mlir::Pass> createHWStubExternalModulesPass();
 std::unique_ptr<mlir::Pass> createHWLegalizeModulesPass();
 std::unique_ptr<mlir::Pass> createSVTraceIVerilogPass();
+std::unique_ptr<mlir::Pass> createHWLowerInstanceChoices();
 std::unique_ptr<mlir::Pass> createHWGeneratorCalloutPass();
 std::unique_ptr<mlir::Pass> createHWEliminateInOutPortsPass(
     const HWEliminateInOutPortsOptions &options = {});

--- a/integration_test/EmitVerilog/instance-choice.mlir
+++ b/integration_test/EmitVerilog/instance-choice.mlir
@@ -1,0 +1,54 @@
+// REQUIRES: verilator
+// RUN: circt-opt %s -export-split-verilog='dir-name=%t.dir'
+// RUN: verilator %driver --cc --sv --exe --build -I%t.dir -F %t.dir%{fs-sep}filelist.f -o %t.exe --top-module top
+// RUN: %t.exe --cycles 10 2>&1 | FileCheck %s --check-prefix=DEFAULT
+
+hw.module private @TargetA(in %a: i32, out b: i32) {
+  %cst = hw.constant 5 : i32
+  %out = comb.add %cst, %out : i32
+  hw.output %out : i32
+}
+
+hw.module private @TargetB(in %a: i32, out b: i32) {
+  %cst = hw.constant 15 : i32
+  %out = comb.add %cst, %out : i32
+  hw.output %out : i32
+}
+
+hw.module private @TargetDefault(in %a: i32, out b: i32) {
+  hw.output %a : i32
+}
+
+hw.module public @top(in %clk : i1, in %rst : i1) {
+  %reg = sv.reg : !hw.inout<i32>
+
+  %a = sv.read_inout %reg : !hw.inout<i32>
+  %b = hw.instance_choice "inst1" sym @inst1 @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
+
+  sv.alwaysff(posedge %clk) {
+    sv.if %rst {
+      %zero = hw.constant 0 : i32
+      sv.passign %reg, %zero : i32
+    } else {
+      %one = hw.constant 1 : i32
+
+      %a_read = sv.read_inout %reg : !hw.inout<i32>
+      %next = comb.add %a_read, %one : i32
+      sv.passign %reg, %next : i32
+
+      %fd = hw.constant 0x80000002 : i32
+      sv.fwrite %fd, "b: %d\n" (%b) : i32
+    }
+  }
+}
+
+// DEFAULT: b:          0
+// DEFAULT: b:          1
+// DEFAULT: b:          2
+// DEFAULT: b:          3
+// DEFAULT: b:          4
+// DEFAULT: b:          5
+// DEFAULT: b:          6
+// DEFAULT: b:          7
+// DEFAULT: b:          8
+// DEFAULT: b:          9

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -206,6 +206,7 @@ if config.lec_enabled != "":
   config.available_features.add('circt-lec')
   tools.append('circt-lec')
 
+config.substitutions.append(('%driver', f'{config.driver}'))
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
 # cocotb availability

--- a/integration_test/lit.site.cfg.py.in
+++ b/integration_test/lit.site.cfg.py.in
@@ -55,6 +55,7 @@ config.esi_collateral_path = "@ESI_COLLATERAL_PATH@"
 config.bindings_python_enabled = @CIRCT_BINDINGS_PYTHON_ENABLED@
 config.bindings_tcl_enabled = @CIRCT_BINDINGS_TCL_ENABLED@
 config.lec_enabled = "@CIRCT_LEC_ENABLED@"
+config.driver = "@CIRCT_SOURCE_DIR@/tools/circt-rtl-sim/driver.cpp"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/lib/Conversion/ExportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ExportVerilog/CMakeLists.txt
@@ -4,6 +4,7 @@ add_circt_translation_library(CIRCTExportVerilog
   ExportVerilog.cpp
   LegalizeAnonEnums.cpp
   LegalizeNames.cpp
+  HWLowerInstanceChoices.cpp
   PrepareForEmission.cpp
   PruneZeroValuedLogic.cpp
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -856,8 +856,8 @@ static BlockStatementCount countStatements(Block &block) {
               // Skip single-use instance outputs, they don't get statements.
               // Keep this synchronized with visitStmt(InstanceOp,OutputOp).
               return llvm::count_if(oop->getOperands(), [&](auto operand) {
-                return !operand.hasOneUse() ||
-                       !dyn_cast_or_null<InstanceOp>(operand.getDefiningOp());
+                Operation *op = operand.getDefiningOp();
+                return !operand.hasOneUse() || !op || !isa<HWInstanceLike>(op);
               });
             })
             .Default([](auto) { return 1; });
@@ -3625,7 +3625,7 @@ void NameCollector::collectNames(Block &block) {
     // Instances have an instance name to recognize but we don't need to look
     // at the result values since wires used by instances should be traversed
     // anyway.
-    if (isa<InstanceOp, InterfaceInstanceOp>(op))
+    if (isa<InstanceOp, InstanceChoiceOp, InterfaceInstanceOp>(op))
       continue;
     if (isa<ltl::LTLDialect, debug::DebugDialect>(op.getDialect()))
       continue;
@@ -3728,7 +3728,12 @@ private:
   LogicalResult visitSV(AliasOp op);
   LogicalResult visitSV(InterfaceInstanceOp op);
   LogicalResult visitStmt(OutputOp op);
+
   LogicalResult visitStmt(InstanceOp op);
+  LogicalResult visitStmt(InstanceChoiceOp op);
+  void emitInstancePortList(Operation *op, ModulePortInfo &modPortInfo,
+                            ArrayRef<Value> instPortValues);
+
   LogicalResult visitStmt(TypeScopeOp op);
   LogicalResult visitStmt(TypedeclOp op);
 
@@ -3884,7 +3889,7 @@ StmtEmitter::emitAssignLike(Op op, PPExtString syntax,
 LogicalResult StmtEmitter::visitSV(AssignOp op) {
   // prepare assigns wires to instance outputs, but these are logically handled
   // in the port binding list when outputing an instance.
-  if (dyn_cast_or_null<InstanceOp>(op.getSrc().getDefiningOp()))
+  if (dyn_cast_or_null<HWInstanceLike>(op.getSrc().getDefiningOp()))
     return success();
 
   if (emitter.assignsInlined.count(op))
@@ -4011,8 +4016,8 @@ LogicalResult StmtEmitter::visitStmt(OutputOp op) {
     // Outputs that are set by the output port of an instance are handled
     // directly when the instance is emitted.
     // Keep synced with countStatements() and visitStmt(InstanceOp).
-    if (operand.hasOneUse() &&
-        dyn_cast_or_null<InstanceOp>(operand.getDefiningOp())) {
+    if (operand.hasOneUse() && operand.getDefiningOp() &&
+        isa<InstanceOp, InstanceChoiceOp>(operand.getDefiningOp())) {
       ++operandIndex;
       continue;
     }
@@ -4986,9 +4991,60 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
     }
   }
 
-  ps << PP::nbsp << PPExtString(getSymOpName(op)) << " (";
+  ps << PP::nbsp << PPExtString(getSymOpName(op));
 
   ModulePortInfo modPortInfo(cast<PortList>(moduleOp).getPortList());
+  SmallVector<Value> instPortValues(modPortInfo.size());
+  op.getValues(instPortValues, modPortInfo);
+  emitInstancePortList(op, modPortInfo, instPortValues);
+
+  ps.addCallback({op, false});
+  emitLocationInfoAndNewLine(ops);
+  if (doNotPrint) {
+    ps << PP::end;
+    startStatement();
+    ps << "*/";
+    setPendingNewline();
+  }
+  return success();
+}
+
+LogicalResult StmtEmitter::visitStmt(InstanceChoiceOp op) {
+  HWModuleOp parentMod = op->getParentOfType<hw::HWModuleOp>();
+
+  startStatement();
+  Operation *choiceMacroDeclOp = state.symbolCache.getDefinition(
+      op->getAttrOfType<FlatSymbolRefAttr>("hw.choiceTarget"));
+
+  ps << "`" << PPExtString(getSymOpName(choiceMacroDeclOp)) << PP::nbsp
+     << PPExtString(getSymOpName(op));
+
+  Operation *defaultModuleOp =
+      state.symbolCache.getDefinition(op.getDefaultModuleNameAttr());
+  ModulePortInfo modPortInfo(cast<PortList>(defaultModuleOp).getPortList());
+  SmallVector<Value> instPortValues(modPortInfo.size());
+  op.getValues(instPortValues, modPortInfo);
+  emitInstancePortList(op, modPortInfo, instPortValues);
+
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+  ps.addCallback({op, false});
+  emitLocationInfoAndNewLine(ops);
+
+  return success();
+}
+
+void StmtEmitter::emitInstancePortList(Operation *op,
+                                       ModulePortInfo &modPortInfo,
+                                       ArrayRef<Value> instPortValues) {
+  SmallPtrSet<Operation *, 8> ops;
+  ops.insert(op);
+
+  auto containingModule = cast<HWModuleOp>(emitter.currentModuleOp);
+  ModulePortInfo containingPortList(containingModule.getPortList());
+
+  ps << " (";
+
   // Get the max port name length so we can align the '('.
   size_t maxNameLength = 0;
   for (auto &elt : modPortInfo) {
@@ -5003,10 +5059,6 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
   bool isFirst = true; // True until we print a port.
   bool isZeroWidth = false;
 
-  auto containingModule = cast<HWModuleOp>(emitter.currentModuleOp);
-  ModulePortInfo containingPortList(containingModule.getPortList());
-  SmallVector<Value> instPortValues(modPortInfo.size());
-  op.getValues(instPortValues, modPortInfo);
   for (size_t portNum = 0, portEnd = modPortInfo.size(); portNum < portEnd;
        ++portNum) {
     auto &modPort = modPortInfo.at(portNum);
@@ -5088,15 +5140,6 @@ LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
     startStatement();
   }
   ps << ");";
-  ps.addCallback({op, false});
-  emitLocationInfoAndNewLine(ops);
-  if (doNotPrint) {
-    ps << PP::end;
-    startStatement();
-    ps << "*/";
-    setPendingNewline();
-  }
-  return success();
 }
 
 // This may be called in the top-level, not just in an hw.module.  Thus we can't
@@ -6375,6 +6418,7 @@ static LogicalResult exportVerilogImpl(ModuleOp module, llvm::raw_ostream &os) {
 
 LogicalResult circt::exportVerilog(ModuleOp module, llvm::raw_ostream &os) {
   LoweringOptions options(module);
+  lowerHWInstanceChoices(module);
   SmallVector<HWModuleOp> modulesToPrepare;
   module.walk([&](HWModuleOp op) { modulesToPrepare.push_back(op); });
   if (failed(failableParallelForEach(
@@ -6392,6 +6436,7 @@ struct ExportVerilogPass : public ExportVerilogBase<ExportVerilogPass> {
     // Prepare the ops in the module for emission.
     mlir::OpPassManager preparePM("builtin.module");
     preparePM.addPass(createLegalizeAnonEnumsPass());
+    preparePM.addPass(createHWLowerInstanceChoicesPass());
     auto &modulePM = preparePM.nest<hw::HWModuleOp>();
     modulePM.addPass(createPrepareForEmissionPass());
     if (failed(runPipeline(preparePM, getOperation())))
@@ -6549,6 +6594,7 @@ static LogicalResult exportSplitVerilogImpl(ModuleOp module,
 
 LogicalResult circt::exportSplitVerilog(ModuleOp module, StringRef dirname) {
   LoweringOptions options(module);
+  lowerHWInstanceChoices(module);
   SmallVector<HWModuleOp> modulesToPrepare;
   module.walk([&](HWModuleOp op) { modulesToPrepare.push_back(op); });
   if (failed(failableParallelForEach(
@@ -6569,6 +6615,8 @@ struct ExportSplitVerilogPass
   void runOnOperation() override {
     // Prepare the ops in the module for emission.
     mlir::OpPassManager preparePM("builtin.module");
+    preparePM.addPass(createHWLowerInstanceChoicesPass());
+
     auto &modulePM = preparePM.nest<hw::HWModuleOp>();
     modulePM.addPass(createPrepareForEmissionPass());
     if (failed(runPipeline(preparePM, getOperation())))

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -426,6 +426,9 @@ bool isZeroBitType(Type type);
 /// that uses it.
 bool isExpressionEmittedInline(Operation *op, const LoweringOptions &options);
 
+/// Generates the macros used by instance choices.
+LogicalResult lowerHWInstanceChoices(mlir::ModuleOp module);
+
 /// For each module we emit, do a prepass over the structure, pre-lowering and
 /// otherwise rewriting operations we don't want to emit.
 LogicalResult prepareHWModule(Block &block, const LoweringOptions &options);

--- a/lib/Conversion/ExportVerilog/HWLowerInstanceChoices.cpp
+++ b/lib/Conversion/ExportVerilog/HWLowerInstanceChoices.cpp
@@ -1,0 +1,113 @@
+//===- HWLowerInstanceChoices.cpp - IR Prepass for Emitter ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the "prepare" pass that walks the IR before the emitter
+// gets involved.  This allows us to do some transformations that would be
+// awkward to implement inline in the emitter.
+//
+// NOTE: This file covers the preparation phase of `ExportVerilog` which mainly
+// legalizes the IR and makes adjustments necessary for emission. This is the
+// place to mutate the IR if emission needs it. The IR cannot be modified during
+// emission itself, which happens in parallel.
+//
+//===----------------------------------------------------------------------===//
+
+#include "../PassDetail.h"
+#include "ExportVerilogInternals.h"
+#include "circt/Conversion/ExportVerilog.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Support/LLVM.h"
+#include "circt/Support/Namespace.h"
+#include "circt/Support/SymCache.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/SymbolTable.h"
+
+#define DEBUG_TYPE "lower-hw-instance-choices"
+
+using namespace mlir;
+using namespace circt;
+using namespace hw;
+using namespace sv;
+using namespace ExportVerilog;
+
+namespace {
+
+struct HWLowerInstanceChoicesPass
+    : public HWLowerInstanceChoicesBase<HWLowerInstanceChoicesPass> {
+  void runOnOperation() override;
+};
+
+} // end anonymous namespace
+
+LogicalResult ExportVerilog::lowerHWInstanceChoices(mlir::ModuleOp module) {
+  // Collect all instance choices & symbols.
+  SmallVector<InstanceChoiceOp> instances;
+  SymbolCache symCache;
+  for (Operation &op : *module.getBody()) {
+    if (auto sym = dyn_cast<SymbolOpInterface>(&op))
+      symCache.addSymbol(sym);
+
+    if (auto module = dyn_cast<HWModuleOp>(&op))
+      module.walk([&](InstanceChoiceOp inst) { instances.push_back(inst); });
+  }
+
+  // Build a namespace to generate unique macro names.
+  Namespace ns;
+  ns.add(symCache);
+
+  auto declBuilder = OpBuilder::atBlockBegin(module.getBody());
+  for (InstanceChoiceOp inst : instances) {
+    auto parent = inst->getParentOfType<HWModuleOp>();
+
+    auto defaultModuleOp = cast<HWModuleLike>(
+        symCache.getDefinition(inst.getDefaultModuleNameAttr()));
+
+    // Generate a macro name to describe the target of this instance.
+    SmallString<128> name;
+    {
+      llvm::raw_svector_ostream os(name);
+      os << "__circt_choice_" << parent.getName() << "_"
+         << inst.getInstanceName();
+    }
+
+    auto symName = ns.newName(name);
+    auto symNameAttr = declBuilder.getStringAttr(symName);
+    auto symRef = FlatSymbolRefAttr::get(symNameAttr);
+    declBuilder.create<MacroDeclOp>(inst.getLoc(), symNameAttr,
+                                    /*args=*/ArrayAttr{},
+                                    /*verilogName=*/StringAttr{});
+
+    // This pass now generates the macros and attaches them to the instance
+    // choice as an attribute. As a better solution, this pass should be moved
+    // out of the umbrella of ExportVerilog and it should lower the `hw`
+    // instance choices to a better SV-level representation of the operation.
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    builder.create<sv::IfDefOp>(
+        symName, [&] {},
+        [&] {
+          builder.create<sv::MacroDefOp>(
+              symRef, builder.getStringAttr("{{0}}"),
+              builder.getArrayAttr(
+                  {FlatSymbolRefAttr::get(defaultModuleOp.getNameAttr())}));
+        });
+    inst->setAttr("hw.choiceTarget", symRef);
+  }
+
+  return success();
+}
+
+void HWLowerInstanceChoicesPass::runOnOperation() {
+  ModuleOp module = getOperation();
+  if (failed(lowerHWInstanceChoices(module)))
+    signalPassFailure();
+}
+
+std::unique_ptr<mlir::Pass> circt::createHWLowerInstanceChoicesPass() {
+  return std::make_unique<HWLowerInstanceChoicesPass>();
+}

--- a/lib/LogicalEquivalence/LogicExporter.cpp
+++ b/lib/LogicalEquivalence/LogicExporter.cpp
@@ -87,6 +87,10 @@ struct Visitor : public hw::StmtVisitor<Visitor, LogicalResult>,
     return failure();
   }
 
+  LogicalResult visitStmt(hw::InstanceChoiceOp op) {
+    return op.emitError("instance choices are not supported");
+  }
+
   LogicalResult visitStmt(hw::OutputOp op) {
     for (auto operand : op.getOperands())
       circuit->addOutput(operand);

--- a/test/Conversion/ExportVerilog/hw-lower-instance-choices.mlir
+++ b/test/Conversion/ExportVerilog/hw-lower-instance-choices.mlir
@@ -1,0 +1,38 @@
+// RUN: circt-opt %s -hw-lower-instance-choices --split-input-file -verify-diagnostics | FileCheck %s
+
+// CHECK: sv.macro.decl @__circt_choice_top_inst1
+// CHECK: sv.macro.decl @__circt_choice_top_inst2
+
+hw.module private @TargetA(in %a: i32, out b: i32) {
+  hw.output %a : i32
+}
+
+hw.module private @TargetB(in %a: i32, out b: i32) {
+  hw.output %a : i32
+}
+
+hw.module private @TargetDefault(in %a: i32, out b: i32) {
+  hw.output %a : i32
+}
+
+hw.module public @top(in %a: i32, out b: i32, out d: i32) {
+  // CHECK:               sv.ifdef  "__circt_choice_top_inst1" {
+  // CHECK-NEXT:          } else {
+  // CHECK-NEXT{LITERAL}:   sv.macro.def @__circt_choice_top_inst1 "{{0}}"([@TargetDefault])
+  // CHECK-NEXT:          }
+  // CHECK-NEXT:          hw.instance_choice "inst1"
+  // CHECK-SAME:          {hw.choiceTarget = @__circt_choice_top_inst1}
+  %b = hw.instance_choice "inst1" sym @inst1 @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
+
+  // CHECK:               sv.ifdef  "__circt_choice_top_inst2" {
+  // CHECK-NEXT:          } else {
+  // CHECK-NEXT{LITERAL}:   sv.macro.def @__circt_choice_top_inst2 "{{0}}"([@TargetB])
+  // CHECK-NEXT:          }
+  // CHECK-NEXT:          hw.instance_choice "inst2"
+  // CHECK-SAME:          {hw.choiceTarget = @__circt_choice_top_inst2}
+  %c = hw.instance_choice "inst2" sym @inst2 @TargetB or @TargetA if "A" or @TargetDefault if "B"(a: %a: i32) -> (b: i32)
+
+  %d = comb.add %c, %a : i32
+
+  hw.output %b, %d : i32, i32
+}

--- a/test/Conversion/ExportVerilog/instance-choice.mlir
+++ b/test/Conversion/ExportVerilog/instance-choice.mlir
@@ -1,0 +1,40 @@
+// RUN: circt-opt %s -export-split-verilog='dir-name=%t.dir'
+// RUN: cat %t.dir%{fs-sep}top.sv | FileCheck %s
+
+hw.module private @TargetA(in %a: i32, out b: i32) {
+  hw.output %a : i32
+}
+
+hw.module private @TargetB(in %a: i32, out b: i32) {
+  hw.output %a : i32
+}
+
+hw.module private @TargetDefault(in %a: i32, out b: i32) {
+  hw.output %a : i32
+}
+
+// CHECK-LABEL: module top
+hw.module public @top(in %a: i32, out b: i32, out d: i32) {
+  // CHECK:      `ifndef __circt_choice_top_inst1
+  // CHECK-NEXT: `define __circt_choice_top_inst1 TargetDefault
+  // CHECK-NEXT: `endif
+  // CHECK-NEXT: `__circt_choice_top_inst1 inst1 (
+  // CHECK-NEXT:    .a (a),
+  // CHECK-NEXT:    .b (b)
+  // CHECK-NEXT: );
+  %b = hw.instance_choice "inst1" sym @inst1 @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
+
+  // CHECK:      `ifndef __circt_choice_top_inst2
+  // CHECK-NEXT: `define __circt_choice_top_inst2 TargetDefault
+  // CHECK-NEXT: `endif
+  // CHECK-NEXT: `__circt_choice_top_inst2 inst2 (
+  // CHECK-NEXT:   .a (a),
+  // CHECK-NEXT:   .b (_inst2_b)
+  // CHECK-NEXT: );
+
+  %c = hw.instance_choice "inst2" sym @inst2 @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
+
+  %d = comb.add %c, %a : i32
+
+  hw.output %b, %d : i32, i32
+}

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -703,6 +703,7 @@ int main(int argc, char **argv) {
 
     // Conversion passes:
     registerPrepareForEmissionPass();
+    registerHWLowerInstanceChoicesPass();
     registerLowerFIRRTLToHWPass();
     registerLegalizeAnonEnumsPass();
     registerLowerSeqToSVPass();


### PR DESCRIPTION
This PR sketches the lowering of instance choices to SystemVerilog, emitting the placeholder macros and producing the output for the default branches.

The emission of the alternatives will be done in a follow-up PR. 

An integration test is also built out to verify the correctness of the behaviour of the ops and to verify the correctness of the file list and macro definition groups involved.

SV code is emitted directly instead of building IR for it at the moment as regular instance operations cannot use a symbolic (macro) reference to name the target module.

Upon further thought, the details of the lowerings will not be included in the FIRRTL ABI: the ABI will pin down the ordering in which files emitted by the compiler will be consumed, however their contents which implement instance choices will be left up to the implementation, i.e. CIRCT. 