### PR TITLE
[FIRRTL] Use isX intrinsic for trueOrIsX verif statements.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -406,7 +406,7 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
         printOp.emitError("printf-encoded assertNotX requires one operand");
         return failure();
       }
-      // Construct a `!whenCond | (value !== 1'bx)` predicate.
+      // Construct a `!whenCond | (^value !== 1'bx)` predicate.
       Value notCond = predicate;
       predicate = builder.create<XorRPrimOp>(printOp.getSubstitutions()[0]);
       predicate = builder.create<IsXIntrinsicOp>(predicate);
@@ -523,10 +523,9 @@ ParseResult circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
       break;
     case PredicateModifier::TrueOrIsX:
       // Construct a `predicate | (^predicate === 1'bx)`.
-      Value orX = builder.create<XorRPrimOp>(predicate);
-      orX = builder.create<VerbatimExprOp>(UIntType::get(context, 1),
-                                           "{{0}} === 1'bx", orX);
-      predicate = builder.create<OrPrimOp>(predicate, orX);
+      Value isX =
+          builder.create<IsXIntrinsicOp>(builder.create<XorRPrimOp>(predicate));
+      predicate = builder.create<OrPrimOp>(predicate, isX);
       break;
     }
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1045,7 +1045,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       stop(clock, enable, 1)
     ; CHECK: [[CONDINV:%.+]] = firrtl.not %cond
     ; CHECK: [[TMP1:%.+]] = firrtl.xorr [[CONDINV]]
-    ; CHECK-NEXT: [[TMP2:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}} === 1'bx"([[TMP1]])
+    ; CHECK-NEXT: [[TMP2:%.+]] = firrtl.int.isX [[TMP1]]
     ; CHECK-NEXT: [[TMP:%.+]] = firrtl.or [[CONDINV]], [[TMP2]]
     ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
     ; CHECK-SAME: format = "sva"
@@ -1069,7 +1069,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       stop(clock, enable, 1)
     ; CHECK: [[CONDINV:%.+]] = firrtl.not %cond
     ; CHECK: [[TMP1:%.+]] = firrtl.xorr [[CONDINV]]
-    ; CHECK-NEXT: [[TMP2:%.+]] = firrtl.verbatim.expr "{{[{][{]0[}][}]}} === 1'bx"([[TMP1]])
+    ; CHECK-NEXT: [[TMP2:%.+]] = firrtl.int.isX [[TMP1]]
     ; CHECK-NEXT: [[TMP:%.+]] = firrtl.or [[CONDINV]], [[TMP2]]
     ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]


### PR DESCRIPTION
Prefer intrinsic over verbatim verilog.