### PR TITLE
[ImportVerilog] Update to Slang 4

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -148,11 +148,13 @@ jobs:
             mode: debug
             assert: ON
             shared: ON
-          - cc: gcc
-            cxx: g++
+            slang: OFF
+          - cc: gcc-11
+            cxx: g++-11
             mode: release
             assert: OFF
             shared: OFF
+            slang: ON
 
     steps:
       - name: Configure Environment
@@ -221,7 +223,7 @@ jobs:
             -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DLLVM_LIT_ARGS="-v" \
-            -DCIRCT_SLANG_FRONTEND_ENABLED=ON
+            -DCIRCT_SLANG_FRONTEND_ENABLED=${{ matrix.compiler.slang }}
           ninja check-circt check-circt-unit -j$(nproc)
           ninja circt-doc
 

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -177,7 +177,33 @@ jobs:
           ${{ steps.setup-windows.outputs.setup }}
           mkdir build
           cd build
-          cmake -G Ninja -S "$(pwd)/../llvm/llvm" $EXTRA_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} -DLLVM_BUILD_TOOLS=ON -DLLVM_BUILD_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} -DLLVM_ENABLE_PROJECTS=mlir -DLLVM_EXTERNAL_PROJECTS=circt -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." -DLLVM_STATIC_LINK_CXX_STDLIB=ON -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_TARGETS_TO_BUILD="host" -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} -DLLVM_ENABLE_ZSTD=OFF -DVERILATOR_DISABLE=ON -DLLVM_PARALLEL_LINK_JOBS=1 -DCIRCT_RELEASE_TAG_ENABLED=ON -DCIRCT_RELEASE_TAG=firtool -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} ${{ steps.configure-sccache.outputs.enable_sccache }} -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" -DLLVM_INSTALL_UTILS=ON
+          cmake -G Ninja -S "$(pwd)/../llvm/llvm" \
+            $EXTRA_CMAKE_ARGS \
+            -DCMAKE_BUILD_TYPE=${{ inputs.cmake_build_type }} \
+            -DBUILD_SHARED_LIBS=${{ inputs.build_shared_libs }} \
+            -DLLVM_BUILD_TOOLS=ON \
+            -DLLVM_BUILD_EXAMPLES=OFF \
+            -DLLVM_ENABLE_ASSERTIONS=${{ inputs.llvm_enable_assertions }} \
+            -DLLVM_ENABLE_PROJECTS=mlir \
+            -DLLVM_EXTERNAL_PROJECTS=circt \
+            -DLLVM_EXTERNAL_CIRCT_SOURCE_DIR=".." \
+            -DLLVM_STATIC_LINK_CXX_STDLIB=ON \
+            -DLLVM_ENABLE_TERMINFO=OFF \
+            -DLLVM_PARALLEL_LINK_JOBS=1 \
+            -DLLVM_TARGETS_TO_BUILD="host" \
+            -DLLVM_FORCE_ENABLE_STATS=${{ inputs.llvm_force_enable_stats }} \
+            -DLLVM_ENABLE_ZSTD=OFF \
+            -DVERILATOR_DISABLE=ON \
+            -DLLVM_PARALLEL_LINK_JOBS=1 \
+            -DCIRCT_RELEASE_TAG_ENABLED=ON \
+            -DCIRCT_RELEASE_TAG=firtool \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF \
+            -DCMAKE_C_COMPILER=${{ inputs.cmake_c_compiler }} \
+            -DCMAKE_CXX_COMPILER=${{ inputs.cmake_cxx_compiler }} \
+            ${{ steps.configure-sccache.outputs.enable_sccache }} \
+            -DCMAKE_INSTALL_PREFIX="$(pwd)/../install" \
+            -DLLVM_INSTALL_UTILS=ON \
+            -DCIRCT_SLANG_FRONTEND_ENABLED=ON
 # Optionally test
       - name: Test CIRCT
         if: inputs.runTests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,7 +547,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     FetchContent_Declare(
       slang
       GIT_REPOSITORY https://github.com/MikePopoloski/slang.git
-      GIT_TAG v3.0
+      GIT_TAG v4.0
       GIT_SHALLOW ON)
     set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE "NEVER")
 
@@ -558,11 +558,12 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     set(ORIGINAL_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 
     if (MSVC)
-      set(CMAKE_CXX_FLAGS "/EHsc")
+      # MSVC seems to build without exception support by default anyway.
     else ()
-      set(CMAKE_CXX_FLAGS "")
+      set(CMAKE_CXX_FLAGS "-fno-exceptions -fno-rtti")
     endif ()
     set(BUILD_SHARED_LIBS OFF)
+    set(SLANG_USE_MIMALLOC OFF)
     FetchContent_MakeAvailable(slang)
 
     set(CMAKE_CXX_FLAGS ${ORIGINAL_CMAKE_CXX_FLAGS})
@@ -571,7 +572,7 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     if(BUILD_SHARED_LIBS)
       set_target_properties(slang_slang PROPERTIES POSITION_INDEPENDENT_CODE ON)
       set_target_properties(fmt PROPERTIES POSITION_INDEPENDENT_CODE ON)
-      set_target_properties(unordered_dense PROPERTIES POSITION_INDEPENDENT_CODE ON)
+      set_target_properties(boost_unordered PROPERTIES POSITION_INDEPENDENT_CODE ON)
     endif()
 
     # The following feels *very* hacky, but CMake complains about the
@@ -579,11 +580,18 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     # linking) without the latter being in an export set. I think we'd want to
     # statically link slang into the CIRCTImportVerilog library, but seems to be
     # harder than it ought to be.
-    set_property(
-      GLOBAL APPEND PROPERTY CIRCT_EXPORTS slang_slang unordered_dense fmt)
-    install(TARGETS slang_slang unordered_dense fmt EXPORT CIRCTTargets)
+    if(TARGET fmt)
+      set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS fmt)
+      install(TARGETS fmt EXPORT CIRCTTargets)
+    endif()
+    if(TARGET boost_unordered)
+      set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS boost_unordered)
+      install(TARGETS boost_unordered EXPORT CIRCTTargets)
+    endif()
+    set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS slang_slang)
+    install(TARGETS slang_slang EXPORT CIRCTTargets)
   else()
-    find_package(slang 3.0 REQUIRED)
+    find_package(slang 4.0 REQUIRED)
   endif()
 endif()
 

--- a/lib/Conversion/ImportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ImportVerilog/CMakeLists.txt
@@ -1,6 +1,4 @@
-# slang uses exceptions
-set(LLVM_REQUIRES_EH ON)
-set(LLVM_REQUIRES_RTTI ON)
+set(CMAKE_CXX_STANDARD 20)
 
 # For ABI compatibility, define the DEBUG macro in debug builds. Slang sets this
 # internally. If we don't set this here as well, header-defined things like the
@@ -9,15 +7,17 @@ set(LLVM_REQUIRES_RTTI ON)
 # or modified by code compiled in the Slang compilation unit.
 add_compile_definitions($<$<CONFIG:Debug>:DEBUG>)
 
+# If Slang is using its vendored version of `boost_unordered`, the `SLANG_BOOST_SINGLE_HEADER` define must be set.
+if(TARGET boost_unordered)
+  add_compile_definitions(SLANG_BOOST_SINGLE_HEADER)
+endif()
+
 # Disable some compiler warnings caused by slang headers such that the
 # `ImportVerilog` build doesn't spew out a ton of warnings that are not related
 # to CIRCT.
 if (MSVC)
   # No idea what to put here
 else ()
-  # slang uses exceptions; we intercept these in ImportVerilog
-  add_compile_options(-fexceptions)
-  add_compile_options(-frtti)
   # slang has some classes with virtual funcs but non-virtual destructor.
   add_compile_options(-Wno-non-virtual-dtor)
   # some other warnings we've seen

--- a/test/circt-verilog/commandline.sv
+++ b/test/circt-verilog/commandline.sv
@@ -3,4 +3,4 @@
 // REQUIRES: slang
 
 // CHECK-HELP: OVERVIEW: Verilog and SystemVerilog frontend
-// CHECK-VERSION: slang version 3.
+// CHECK-VERSION: slang version 4.


### PR DESCRIPTION
Bump the Slang dependency to version 4. This version supports builds with exceptions and RTTI fully disabled, which allows us to get rid of the ugly glue code that tried to bridge the gap between the RTTI/EH world of Slang and the non-RTTI/non-EH world of LLVM.