### PR TITLE
[ImportVerilog] Add import options and Verilog preprocessing

### DIFF
--- a/include/circt/Conversion/ImportVerilog.h
+++ b/include/circt/Conversion/ImportVerilog.h
@@ -34,11 +34,16 @@ namespace circt {
 /// `Driver::addStandardArgs()` for some inspiration on how to expose these on
 /// the command line.
 struct ImportVerilogOptions {
-  /// Only lint the input, without elaboration and lowering to CIRCT IR.
-  bool onlyLint = false;
-
-  /// Only parse and elaborate the input, without mapping to CIRCT IR.
-  bool onlyParse = false;
+  /// Limit importing to linting or parsing only.
+  enum class Mode {
+    /// Only lint the input, without elaboration and lowering to CIRCT IR.
+    OnlyLint,
+    /// Only parse and elaborate the input, without mapping to CIRCT IR.
+    OnlyParse,
+    /// Perform a full import and mapping to CIRCT IR.
+    Full
+  };
+  Mode mode = Mode::Full;
 
   //===--------------------------------------------------------------------===//
   // Include paths

--- a/include/circt/Conversion/ImportVerilog.h
+++ b/include/circt/Conversion/ImportVerilog.h
@@ -13,9 +13,133 @@
 #ifndef CIRCT_CONVERSION_IMPORTVERILOG_H
 #define CIRCT_CONVERSION_IMPORTVERILOG_H
 
+#include "circt/Support/LLVM.h"
+#include <optional>
 #include <string>
 
+namespace llvm {
+class SourceMgr;
+} // namespace llvm
+
+namespace mlir {
+class LocationAttr;
+class TimingScope;
+} // namespace mlir
+
 namespace circt {
+
+/// Options that control how Verilog input files are parsed and processed.
+///
+/// See `slang::driver::Driver::Options` for inspiration. Also check out
+/// `Driver::addStandardArgs()` for some inspiration on how to expose these on
+/// the command line.
+struct ImportVerilogOptions {
+  /// Only lint the input, without elaboration and lowering to CIRCT IR.
+  bool onlyLint = false;
+
+  /// Only parse and elaborate the input, without mapping to CIRCT IR.
+  bool onlyParse = false;
+
+  //===--------------------------------------------------------------------===//
+  // Include paths
+  //===--------------------------------------------------------------------===//
+
+  /// A list of include directories in which to search for files.
+  std::vector<std::string> includeDirs;
+
+  /// A list of system include directories in which to search for files.
+  std::vector<std::string> includeSystemDirs;
+
+  /// A list of library directories in which to search for missing modules.
+  std::vector<std::string> libDirs;
+
+  /// A list of extensions that will be used to search for library files.
+  std::vector<std::string> libExts;
+
+  /// A list of extensions that will be used to exclude files.
+  std::vector<std::string> excludeExts;
+
+  /// A list of preprocessor directives to be ignored.
+  std::vector<std::string> ignoreDirectives;
+
+  //===--------------------------------------------------------------------===//
+  // Preprocessing
+  //===--------------------------------------------------------------------===//
+
+  /// The maximum depth of included files before an error is issued.
+  std::optional<uint32_t> maxIncludeDepth;
+
+  /// A list of macros that should be defined in each compilation unit.
+  std::vector<std::string> defines;
+
+  /// A list of macros that should be undefined in each compilation unit.
+  std::vector<std::string> undefines;
+
+  /// If true, library files will inherit macro definitions from primary source
+  /// files.
+  std::optional<bool> librariesInheritMacros;
+
+  //===--------------------------------------------------------------------===//
+  // Compilation
+  //===--------------------------------------------------------------------===//
+
+  /// A string that indicates the default time scale to use for any design
+  /// elements that don't specify one explicitly.
+  std::optional<std::string> timeScale;
+
+  /// If true, allow various to be referenced before they are declared.
+  std::optional<bool> allowUseBeforeDeclare;
+
+  /// If true, ignore errors about unknown modules.
+  std::optional<bool> ignoreUnknownModules;
+
+  /// If non-empty, specifies the list of modules that should serve as the top
+  /// modules in the design. If empty, this will be automatically determined
+  /// based on which modules are unreferenced elsewhere.
+  std::vector<std::string> topModules;
+
+  /// A list of top-level module parameters to override, of the form
+  /// `<name>=<value>`.
+  std::vector<std::string> paramOverrides;
+
+  //===--------------------------------------------------------------------===//
+  // Diagnostics Control
+  //===--------------------------------------------------------------------===//
+
+  /// The maximum number of errors to print before giving up.
+  std::optional<uint32_t> errorLimit;
+
+  /// A list of warning options that will be passed to the DiagnosticEngine.
+  std::vector<std::string> warningOptions;
+
+  /// A list of paths in which to suppress warnings.
+  std::vector<std::string> suppressWarningsPaths;
+
+  //===--------------------------------------------------------------------===//
+  // File lists
+  //===--------------------------------------------------------------------===//
+
+  /// If set to true, all source files will be treated as part of a single
+  /// compilation unit, meaning all of their text will be merged together.
+  std::optional<bool> singleUnit;
+
+  /// A list of library files to include in the compilation.
+  std::vector<std::string> libraryFiles;
+};
+
+/// Parse files in a source manager as Verilog source code and populate the
+/// given MLIR `module` with corresponding ops.
+mlir::LogicalResult
+importVerilog(llvm::SourceMgr &sourceMgr, mlir::MLIRContext *context,
+              mlir::TimingScope &ts, mlir::ModuleOp module,
+              const ImportVerilogOptions *options = nullptr);
+
+/// Run the files in a source manager through Slang's Verilog preprocessor and
+/// emit the result to the given output stream.
+mlir::LogicalResult
+preprocessVerilog(llvm::SourceMgr &sourceMgr, mlir::MLIRContext *context,
+                  mlir::TimingScope &ts, llvm::raw_ostream &os,
+                  const ImportVerilogOptions *options = nullptr);
 
 /// Return a human-readable string describing the slang frontend version linked
 /// into CIRCT.

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -11,9 +11,25 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Conversion/ImportVerilog.h"
-#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Support/Timing.h"
+#include "mlir/Tools/mlir-translate/Translation.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/Support/SourceMgr.h"
 
+#include "slang/diagnostics/DiagnosticClient.h"
+#include "slang/driver/Driver.h"
+#include "slang/parsing/Preprocessor.h"
+#include "slang/syntax/SyntaxPrinter.h"
 #include "slang/util/Version.h"
+
+using namespace mlir;
+using namespace circt;
+
+using llvm::SourceMgr;
 
 std::string circt::getSlangVersion() {
   std::string buffer;
@@ -24,4 +40,274 @@ std::string circt::getSlangVersion() {
   os << slang::VersionInfo::getPatch() << "+";
   os << slang::VersionInfo::getHash();
   return buffer;
+}
+
+//===----------------------------------------------------------------------===//
+// Diagnostics
+//===----------------------------------------------------------------------===//
+
+/// Convert a slang `SourceLocation` to an MLIR `Location`.
+static Location
+convertLocation(MLIRContext *context, const slang::SourceManager &sourceManager,
+                SmallDenseMap<slang::BufferID, StringRef> &bufferFilePaths,
+                slang::SourceLocation loc) {
+  if (loc && loc.buffer() != slang::SourceLocation::NoLocation.buffer()) {
+    auto fileName = bufferFilePaths.lookup(loc.buffer());
+    auto line = sourceManager.getLineNumber(loc);
+    auto column = sourceManager.getColumnNumber(loc);
+    return FileLineColLoc::get(context, fileName, line, column);
+  }
+  return UnknownLoc::get(context);
+}
+
+namespace {
+/// A converter that can be plugged into a slang `DiagnosticEngine` as a client
+/// that will map slang diagnostics to their MLIR counterpart and emit them.
+class MlirDiagnosticClient : public slang::DiagnosticClient {
+public:
+  MlirDiagnosticClient(
+      MLIRContext *context,
+      SmallDenseMap<slang::BufferID, StringRef> &bufferFilePaths)
+      : context(context), bufferFilePaths(bufferFilePaths) {}
+
+  void report(const slang::ReportedDiagnostic &diag) override {
+    // Generate the primary MLIR diagnostic.
+    auto &diagEngine = context->getDiagEngine();
+    auto mlirDiag = diagEngine.emit(convertLocation(diag.location),
+                                    getSeverity(diag.severity));
+    mlirDiag << diag.formattedMessage;
+
+    // Append the name of the option that can be used to control this
+    // diagnostic.
+    auto optionName = engine->getOptionName(diag.originalDiagnostic.code);
+    if (!optionName.empty())
+      mlirDiag << " [-W" << optionName << "]";
+
+    // Write out macro expansions, if we have any, in reverse order.
+    for (auto it = diag.expansionLocs.rbegin(); it != diag.expansionLocs.rend();
+         it++) {
+      auto &note = mlirDiag.attachNote(
+          convertLocation(sourceManager->getFullyOriginalLoc(*it)));
+      auto macroName = sourceManager->getMacroName(*it);
+      if (macroName.empty())
+        note << "expanded from here";
+      else
+        note << "expanded from macro '" << macroName << "'";
+    }
+  }
+
+  /// Convert a slang `SourceLocation` to an MLIR `Location`.
+  Location convertLocation(slang::SourceLocation loc) const {
+    return ::convertLocation(context, *sourceManager, bufferFilePaths, loc);
+  }
+
+  static DiagnosticSeverity getSeverity(slang::DiagnosticSeverity severity) {
+    switch (severity) {
+    case slang::DiagnosticSeverity::Fatal:
+    case slang::DiagnosticSeverity::Error:
+      return DiagnosticSeverity::Error;
+    case slang::DiagnosticSeverity::Warning:
+      return DiagnosticSeverity::Warning;
+    case slang::DiagnosticSeverity::Ignored:
+    case slang::DiagnosticSeverity::Note:
+      return DiagnosticSeverity::Remark;
+    }
+    llvm_unreachable("all slang diagnostic severities should be handled");
+    return DiagnosticSeverity::Error;
+  }
+
+private:
+  MLIRContext *context;
+  SmallDenseMap<slang::BufferID, StringRef> &bufferFilePaths;
+};
+} // namespace
+
+// Allow for `slang::BufferID` to be used as hash map keys.
+namespace llvm {
+template <>
+struct DenseMapInfo<slang::BufferID> {
+  static slang::BufferID getEmptyKey() { return slang::BufferID(); }
+  static slang::BufferID getTombstoneKey() {
+    return slang::BufferID(UINT32_MAX - 1, ""sv);
+    // UINT32_MAX is already used by `BufferID::getPlaceholder`.
+  }
+  static unsigned getHashValue(slang::BufferID id) {
+    return llvm::hash_value(id.getId());
+  }
+  static bool isEqual(slang::BufferID a, slang::BufferID b) { return a == b; }
+};
+} // namespace llvm
+
+//===----------------------------------------------------------------------===//
+// Driver
+//===----------------------------------------------------------------------===//
+
+namespace {
+const static ImportVerilogOptions defaultOptions;
+
+struct ImportContext {
+  ImportContext(MLIRContext *mlirContext, TimingScope &ts,
+                const ImportVerilogOptions *options)
+      : mlirContext(mlirContext), ts(ts),
+        options(options ? *options : defaultOptions) {}
+
+  LogicalResult prepareDriver(SourceMgr &sourceMgr);
+  LogicalResult importVerilog(ModuleOp module);
+  LogicalResult preprocessVerilog(llvm::raw_ostream &os);
+
+  MLIRContext *mlirContext;
+  TimingScope &ts;
+  const ImportVerilogOptions &options;
+
+  // Use slang's driver which conveniently packages a lot of the things we
+  // need for compilation.
+  slang::driver::Driver driver;
+
+  // A separate mapping from slang's buffers to the original MLIR file name
+  // since slang's `SourceLocation::getFileName` returns a modified version that
+  // is nice for human consumption (proximate paths, just file names, etc.), but
+  // breaks MLIR's assumption that the diagnostics report the exact file paths
+  // that appear in the `SourceMgr`. We use this separate map to lookup the
+  // exact paths and use those for reporting.
+  //
+  // See: https://github.com/MikePopoloski/slang/discussions/658
+  SmallDenseMap<slang::BufferID, StringRef> bufferFilePaths;
+};
+} // namespace
+
+/// Populate the Slang driver with source files from the given `sourceMgr`, and
+/// configure driver options based on the `ImportVerilogOptions` passed to the
+/// `ImportContext` constructor.
+LogicalResult ImportContext::prepareDriver(SourceMgr &sourceMgr) {
+  // Use slang's driver which conveniently packages a lot of the things we
+  // need for compilation.
+  auto diagClient =
+      std::make_shared<MlirDiagnosticClient>(mlirContext, bufferFilePaths);
+  driver.diagEngine.addClient(diagClient);
+
+  // Populate the source manager with the source files.
+  // NOTE: This is a bit ugly since we're essentially copying the Verilog
+  // source text in memory. At a later stage we'll want to extend slang's
+  // SourceManager such that it can contain non-owned buffers. This will do
+  // for now.
+  for (unsigned i = 0, e = sourceMgr.getNumBuffers(); i < e; ++i) {
+    const llvm::MemoryBuffer *mlirBuffer = sourceMgr.getMemoryBuffer(i + 1);
+    auto slangBuffer = driver.sourceManager.assignText(
+        mlirBuffer->getBufferIdentifier(), mlirBuffer->getBuffer());
+    driver.buffers.push_back(slangBuffer);
+    bufferFilePaths.insert({slangBuffer.id, mlirBuffer->getBufferIdentifier()});
+  }
+
+  // Populate the driver options.
+  driver.options.includeDirs = options.includeDirs;
+  driver.options.includeSystemDirs = options.includeSystemDirs;
+  driver.options.libDirs = options.libDirs;
+  driver.options.libExts = options.libExts;
+  driver.options.excludeExts.insert(options.excludeExts.begin(),
+                                    options.excludeExts.end());
+  driver.options.ignoreDirectives = options.ignoreDirectives;
+
+  driver.options.maxIncludeDepth = options.maxIncludeDepth;
+  driver.options.defines = options.defines;
+  driver.options.undefines = options.undefines;
+  driver.options.librariesInheritMacros = options.librariesInheritMacros;
+
+  driver.options.timeScale = options.timeScale;
+  driver.options.allowUseBeforeDeclare = options.allowUseBeforeDeclare;
+  driver.options.ignoreUnknownModules = options.ignoreUnknownModules;
+  driver.options.onlyLint = options.onlyLint;
+  driver.options.topModules = options.topModules;
+  driver.options.paramOverrides = options.paramOverrides;
+
+  driver.options.errorLimit = options.errorLimit;
+  driver.options.warningOptions = options.warningOptions;
+  driver.options.suppressWarningsPaths = options.suppressWarningsPaths;
+
+  driver.options.singleUnit = options.singleUnit;
+  driver.options.libraryFiles = options.libraryFiles;
+
+  for (auto &dir : sourceMgr.getIncludeDirs())
+    driver.options.includeDirs.push_back(dir);
+
+  return success(driver.processOptions());
+}
+
+/// Parse and elaborate the prepared source files, and populate the given MLIR
+/// `module` with corresponding operations.
+LogicalResult ImportContext::importVerilog(ModuleOp module) {
+  // This is where the Slang AST to CIRCT op conversion will go.
+  return success();
+}
+
+/// Preprocess the prepared source files and print them to the given output
+/// stream.
+LogicalResult ImportContext::preprocessVerilog(llvm::raw_ostream &os) {
+  auto parseTimer = ts.nest("Verilog preprocessing");
+  for (auto &buffer : driver.buffers) {
+    slang::BumpAllocator alloc;
+    slang::Diagnostics diagnostics;
+    slang::parsing::Preprocessor preprocessor(
+        driver.sourceManager, alloc, diagnostics, driver.createOptionBag());
+    preprocessor.pushSource(buffer);
+
+    slang::syntax::SyntaxPrinter output;
+    output.setIncludeComments(false);
+    while (true) {
+      slang::parsing::Token token = preprocessor.next();
+      output.print(token);
+      if (token.kind == slang::parsing::TokenKind::EndOfFile)
+        break;
+    }
+
+    for (auto &diag : diagnostics) {
+      if (diag.isError()) {
+        driver.diagEngine.issue(diag);
+        return failure();
+      }
+    }
+    os << output.str();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Entry Points
+//===----------------------------------------------------------------------===//
+
+/// Execute a callback and report any thrown exceptions as "internal slang
+/// error" MLIR diagnostics.
+static LogicalResult
+catchExceptions(llvm::function_ref<LogicalResult()> callback) {
+  try {
+    return callback();
+  } catch (const std::exception &e) {
+    return emitError(UnknownLoc(), "internal slang error: ") << e.what();
+  }
+}
+
+/// Parse the specified Verilog inputs into the specified MLIR context.
+LogicalResult circt::importVerilog(SourceMgr &sourceMgr,
+                                   MLIRContext *mlirContext, TimingScope &ts,
+                                   ModuleOp module,
+                                   const ImportVerilogOptions *options) {
+  return catchExceptions([&] {
+    ImportContext context(mlirContext, ts, options);
+    if (failed(context.prepareDriver(sourceMgr)))
+      return failure();
+    return context.importVerilog(module);
+  });
+}
+
+/// Run the files in a source manager through Slang's Verilog preprocessor and
+/// emit the result to the given output stream.
+LogicalResult circt::preprocessVerilog(SourceMgr &sourceMgr,
+                                       MLIRContext *mlirContext,
+                                       TimingScope &ts, llvm::raw_ostream &os,
+                                       const ImportVerilogOptions *options) {
+  return catchExceptions([&] {
+    ImportContext context(mlirContext, ts, options);
+    if (failed(context.prepareDriver(sourceMgr)))
+      return failure();
+    return context.preprocessVerilog(os);
+  });
 }

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -215,7 +215,8 @@ LogicalResult ImportContext::prepareDriver(SourceMgr &sourceMgr) {
   driver.options.timeScale = options.timeScale;
   driver.options.allowUseBeforeDeclare = options.allowUseBeforeDeclare;
   driver.options.ignoreUnknownModules = options.ignoreUnknownModules;
-  driver.options.onlyLint = options.onlyLint;
+  driver.options.onlyLint =
+      options.mode == ImportVerilogOptions::Mode::OnlyLint;
   driver.options.topModules = options.topModules;
   driver.options.paramOverrides = options.paramOverrides;
 

--- a/test/circt-verilog/include/other.sv
+++ b/test/circt-verilog/include/other.sv
@@ -1,0 +1,5 @@
+// This file is included from `preprocess.sv`. Empty `RUN` line such that it
+// does not get picked up by lit.
+// RUN:
+
+localparam Z = 9001;

--- a/test/circt-verilog/preprocess-errors.sv
+++ b/test/circt-verilog/preprocess-errors.sv
@@ -1,0 +1,4 @@
+// RUN: circt-verilog %s -E --verify-diagnostics
+
+// expected-error @below {{could not find or open include file}}
+`include "unknown.sv"

--- a/test/circt-verilog/preprocess.sv
+++ b/test/circt-verilog/preprocess.sv
@@ -1,0 +1,17 @@
+// RUN: circt-verilog %s -E -DBAR=1337 -DHELLO -I%S/include | FileCheck %s
+
+// CHECK-NOT: define FOO
+// CHECK: localparam X = 42
+`define FOO 42
+localparam X = `FOO;
+
+// CHECK: localparam Y = 1337
+localparam Y = `BAR;
+
+// CHECK: localparam FOUND_HELLO;
+`ifdef HELLO
+localparam FOUND_HELLO;
+`endif
+
+// CHECK: localparam Z = 9001
+`include "other.sv"

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -16,20 +16,291 @@
 #include "circt/Support/Version.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Support/FileUtilities.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ToolOutputFile.h"
 
 using namespace llvm;
 using namespace mlir;
 using namespace circt;
 
 //===----------------------------------------------------------------------===//
+// Command Line Options
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct CLOptions {
+  cl::OptionCategory cat{"Verilog Frontend Options"};
+
+  cl::list<std::string> inputFilenames{cl::Positional,
+                                       cl::desc("<input files>"), cl::cat(cat)};
+
+  cl::opt<std::string> outputFilename{
+      "o", cl::desc("Output filename (`-` for stdout)"),
+      cl::value_desc("filename"), cl::init("-"), cl::cat(cat)};
+
+  cl::opt<bool> verifyDiagnostics{
+      "verify-diagnostics",
+      cl::desc("Check that emitted diagnostics match expected-* lines on the "
+               "corresponding line"),
+      cl::init(false), cl::Hidden, cl::cat(cat)};
+
+  cl::opt<bool> onlyPreprocess{
+      "E", cl::desc("Only run the preprocessor (and print preprocessed files)"),
+      cl::init(false), cl::cat(cat)};
+  cl::alias onlyPreprocessLong{"preprocess-only", cl::desc("Alias for -E"),
+                               cl::aliasopt(onlyPreprocess), cl::NotHidden,
+                               cl::cat(cat)};
+
+  cl::opt<bool> onlyLint{
+      "lint-only",
+      cl::desc(
+          "Only lint the input, without elaboration and mapping to CIRCT IR"),
+      cl::init(false), cl::cat(cat)};
+
+  cl::opt<bool> onlyParse{
+      "parse-only",
+      cl::desc(
+          "Only parse and elaborate the input, without mapping to CIRCT IR"),
+      cl::init(false), cl::cat(cat)};
+
+  //===--------------------------------------------------------------------===//
+  // Include paths
+  //===--------------------------------------------------------------------===//
+
+  cl::list<std::string> includeDirs{
+      "I", cl::desc("Additional include search paths"), cl::value_desc("dir"),
+      cl::Prefix, cl::cat(cat)};
+  cl::alias includeDirsLong{"include-dir", cl::desc("Alias for -I"),
+                            cl::aliasopt(includeDirs), cl::NotHidden,
+                            cl::cat(cat)};
+
+  cl::list<std::string> includeSystemDirs{
+      "isystem", cl::desc("Additional system include search paths"),
+      cl::value_desc("dir"), cl::cat(cat)};
+
+  cl::list<std::string> libDirs{
+      "y",
+      cl::desc(
+          "Library search paths, which will be searched for missing modules"),
+      cl::value_desc("dir"), cl::Prefix, cl::cat(cat)};
+  cl::alias libDirsLong{"libdir", cl::desc("Alias for -y"),
+                        cl::aliasopt(libDirs), cl::NotHidden, cl::cat(cat)};
+
+  cl::list<std::string> libExts{
+      "Y", cl::desc("Additional library file extensions to search"),
+      cl::value_desc("ext"), cl::Prefix, cl::cat(cat)};
+  cl::alias libExtsLong{"libext", cl::desc("Alias for -Y"),
+                        cl::aliasopt(libExts), cl::NotHidden, cl::cat(cat)};
+
+  cl::list<std::string> excludeExts{
+      "exclude-ext",
+      cl::desc("Exclude provided source files with these extensions"),
+      cl::value_desc("ext"), cl::cat(cat)};
+
+  //===--------------------------------------------------------------------===//
+  // Preprocessor
+  //===--------------------------------------------------------------------===//
+
+  cl::list<std::string> defines{
+      "D",
+      cl::desc("Define <macro> to <value> (or 1 if <value> ommitted) in all "
+               "source files"),
+      cl::value_desc("<macro>=<value>"), cl::Prefix, cl::cat(cat)};
+  cl::alias definesLong{"define-macro", cl::desc("Alias for -D"),
+                        cl::aliasopt(defines), cl::NotHidden, cl::cat(cat)};
+
+  cl::list<std::string> undefines{
+      "U", cl::desc("Undefine macro name at the start of all source files"),
+      cl::value_desc("macro"), cl::Prefix, cl::cat(cat)};
+  cl::alias undefinesLong{"undefine-macro", cl::desc("Alias for -U"),
+                          cl::aliasopt(undefines), cl::NotHidden, cl::cat(cat)};
+
+  cl::opt<uint32_t> maxIncludeDepth{
+      "max-include-depth",
+      cl::desc("Maximum depth of nested include files allowed"),
+      cl::value_desc("depth"), cl::cat(cat)};
+
+  cl::opt<bool> librariesInheritMacros{
+      "libraries-inherit-macros",
+      cl::desc(
+          "If true, library files will inherit macro definitions from the "
+          "primary "
+          "source "
+          "files. --single-unit must also be passed when this option is used."),
+      cl::init(false), cl::cat(cat)};
+
+  //===--------------------------------------------------------------------===//
+  // Compilation
+  //===--------------------------------------------------------------------===//
+
+  cl::opt<std::string> timeScale{
+      "timescale",
+      cl::desc("Default time scale to use for design elements that don't "
+               "specify one explicitly"),
+      cl::value_desc("<base>/<precision>"), cl::cat(cat)};
+
+  cl::opt<bool> allowUseBeforeDeclare{
+      "allow-use-before-declare",
+      cl::desc(
+          "Don't issue an error for use of names before their declarations."),
+      cl::init(false), cl::cat(cat)};
+
+  cl::opt<bool> ignoreUnknownModules{
+      "ignore-unknown-modules",
+      cl::desc("Don't issue an error for instantiations of unknown modules, "
+               "interface, and programs."),
+      cl::init(false), cl::cat(cat)};
+
+  cl::list<std::string> topModules{
+      "top",
+      cl::desc("One or more top-level modules to instantiate (instead of "
+               "figuring it out automatically)"),
+      cl::value_desc("name"), cl::cat(cat)};
+
+  cl::list<std::string> paramOverrides{
+      "G",
+      cl::desc("One or more parameter overrides to apply when instantiating "
+               "top-level modules"),
+      cl::value_desc("<name>=<value>"), cl::Prefix, cl::cat(cat)};
+
+  //===--------------------------------------------------------------------===//
+  // Diagnostics control
+  //===--------------------------------------------------------------------===//
+
+  cl::list<std::string> warningOptions{
+      "W", cl::desc("Control the specified warning"), cl::value_desc("warning"),
+      cl::Prefix, cl::cat(cat)};
+
+  cl::opt<uint32_t> errorLimit{
+      "error-limit",
+      cl::desc("Limit on the number of errors that will be printed. Setting "
+               "this to zero will disable the limit."),
+      cl::value_desc("limit"), cl::cat(cat)};
+
+  cl::list<std::string> suppressWarningsPaths{
+      "suppress-warnings",
+      cl::desc("One or more paths in which to suppress warnings"),
+      cl::value_desc("filename"), cl::cat(cat)};
+
+  //===--------------------------------------------------------------------===//
+  // File lists
+  //===--------------------------------------------------------------------===//
+
+  cl::opt<bool> singleUnit{
+      "single-unit",
+      cl::desc("Treat all input files as a single compilation unit"),
+      cl::init(false), cl::cat(cat)};
+
+  cl::list<std::string> libraryFiles{
+      "l",
+      cl::desc(
+          "One or more library files, which are separate compilation units "
+          "where modules are not automatically instantiated."),
+      cl::value_desc("filename"), cl::Prefix, cl::cat(cat)};
+};
+} // namespace
+
+static CLOptions opts;
+
+//===----------------------------------------------------------------------===//
 // Implementation
 //===----------------------------------------------------------------------===//
 
-static LogicalResult execute(MLIRContext *context) {
-  // This is where we would call out to ImportVerilog to parse the input.
+static LogicalResult executeWithSources(MLIRContext *context,
+                                        llvm::SourceMgr &sourceMgr) {
+  // Create the timing manager we use to sample execution times.
+  DefaultTimingManager tm;
+  applyDefaultTimingManagerCLOptions(tm);
+  auto ts = tm.getRootScope();
+
+  // Map the command line options to `ImportVerilog`'s conversion options.
+  ImportVerilogOptions options;
+  options.onlyLint = opts.onlyLint;
+  options.onlyParse = opts.onlyParse;
+
+  options.includeDirs = opts.includeDirs;
+  options.includeSystemDirs = opts.includeSystemDirs;
+  options.libDirs = opts.libDirs;
+  options.libExts = opts.libExts;
+  options.excludeExts = opts.excludeExts;
+
+  options.defines = opts.defines;
+  options.undefines = opts.undefines;
+  if (opts.maxIncludeDepth.getNumOccurrences() > 0)
+    options.maxIncludeDepth = opts.maxIncludeDepth;
+  options.librariesInheritMacros = opts.librariesInheritMacros;
+
+  if (opts.timeScale.getNumOccurrences() > 0)
+    options.timeScale = opts.timeScale;
+  options.allowUseBeforeDeclare = opts.allowUseBeforeDeclare;
+  options.ignoreUnknownModules = opts.ignoreUnknownModules;
+  if (!opts.onlyLint)
+    options.topModules = opts.topModules;
+  options.paramOverrides = opts.paramOverrides;
+
+  options.warningOptions = opts.warningOptions;
+  if (opts.errorLimit.getNumOccurrences() > 0)
+    options.errorLimit = opts.errorLimit;
+  options.suppressWarningsPaths = opts.suppressWarningsPaths;
+
+  options.singleUnit = opts.singleUnit;
+  options.libraryFiles = opts.libraryFiles;
+
+  // Open the output file.
+  std::string errorMessage;
+  auto outputFile = openOutputFile(opts.outputFilename, &errorMessage);
+  if (!outputFile) {
+    llvm::errs() << errorMessage << "\n";
+    return failure();
+  }
+
+  // If the user requested for the files to be only preprocessed, do so and
+  // print the results to the configured output file.
+  if (opts.onlyPreprocess) {
+    auto result =
+        preprocessVerilog(sourceMgr, context, ts, outputFile->os(), &options);
+    if (succeeded(result))
+      outputFile->keep();
+    return result;
+  }
+
+  // Parse the Verilog input into an MLIR module.
+  OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(context)));
+  if (failed(importVerilog(sourceMgr, context, ts, module.get(), &options)))
+    return failure();
+
+  // Print the final MLIR.
+  module->print(outputFile->os());
+  outputFile->keep();
   return success();
+}
+
+static LogicalResult execute(MLIRContext *context) {
+  // Open the input files.
+  llvm::SourceMgr sourceMgr;
+  for (const auto &inputFilename : opts.inputFilenames) {
+    std::string errorMessage;
+    auto buffer = openInputFile(inputFilename, &errorMessage);
+    if (!buffer) {
+      llvm::errs() << errorMessage << "\n";
+      return failure();
+    }
+    sourceMgr.AddNewSourceBuffer(std::move(buffer), llvm::SMLoc());
+  }
+
+  // Call `executeWithSources` with either the regular diagnostic handler, or,
+  // if `--verify-diagnostics` is set, with the verifying handler.
+  if (opts.verifyDiagnostics) {
+    SourceMgrDiagnosticVerifierHandler handler(sourceMgr, context);
+    context->printOpOnDiagnostic(false);
+    (void)executeWithSources(context, sourceMgr);
+    return handler.verify();
+  }
+  SourceMgrDiagnosticHandler handler(sourceMgr, context);
+  return executeWithSources(context, sourceMgr);
 }
 
 int main(int argc, char **argv) {

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -106,7 +106,7 @@ struct CLOptions {
 
   cl::list<std::string> defines{
       "D",
-      cl::desc("Define <macro> to <value> (or 1 if <value> ommitted) in all "
+      cl::desc("Define <macro> to <value> (or 1 if <value> omitted) in all "
                "source files"),
       cl::value_desc("<macro>=<value>"), cl::Prefix, cl::cat(cat)};
   cl::alias definesLong{"define-macro", cl::desc("Alias for -D"),


### PR DESCRIPTION
Add the `ImportVerilogOptions` struct to capture various options that can be passed to the Slang Verilog frontend. This covers things like include search directories, macro definitions, top modules, time scales, and other settings commonly found in Verilog tools. The struct is inspired by `slang::driver::Driver::Options`, but we intentionally create our own struct such that no Slang headers leak through into CIRCT space.

Add corresponding command line options to `circt-verilog`, and use them to populate an `ImportVerilogOptions` struct that can be passed to `ImportVerilog`.

Add `importVerilog` and `preprocessVerilog` functions to `ImportVerilog` and add corresponding options to `circt-verilog` that call the respective import function. This commit only implements preprocessing.

This commit also adds a mechanism to bridge between the diagnostic world of Slang and MLIR (`MlirDiagnosticClient`). This allows us to emit any Slang-generated diagnostics as regular MLIR diagnostics, alongside any other errors or warnings the Verilog import might generate.

Add tests for the preprocessor (with include paths and macros) and the diagnostic bridge.