### PR TITLE
[ESI] Simplify services by standardizing on `to_client` ports

### DIFF
--- a/include/circt/Dialect/ESI/ESIChannels.td
+++ b/include/circt/Dialect/ESI/ESIChannels.td
@@ -236,9 +236,9 @@ def ChannelBundleType : ESI_Type<"ChannelBundle"> {
     transmitting messages from the sender to the receiver. Then, "from" means
     that the sender is getting messages from the receiver (typically responses).
 
-    When requesting a bundle from a service, the client is always considered the
-    sender. So the "to" direction is for the client to send messages to the
-    service.
+    When requesting a bundle from a service, the service is always considered
+    the sender; so, "to" means the service is sending messages to the client and
+    "from" means the service is receiving messages from the client.
   }];
 
   let mnemonic = "bundle";

--- a/include/circt/Dialect/ESI/ESIManifest.td
+++ b/include/circt/Dialect/ESI/ESIManifest.td
@@ -57,14 +57,6 @@ def AppIDPathAttr : ESI_Attr<"AppIDPath"> {
   }];
 }
 
-def BundleDirection : I32EnumAttr<"BundleDirection",
-  "Direction of original request", [
-    I32EnumAttrCase<"toServer", 1>,
-    I32EnumAttrCase<"toClient", 2>,
-  ]> {
-  let cppNamespace = "::circt::esi";
-}
-
 def ServiceRequestRecordOp : ESI_Op<"manifest.req", [
         DeclareOpInterfaceMethods<IsManifestData>,
         DeclareOpInterfaceMethods<HasAppIDOpInterface>]> {
@@ -78,12 +70,11 @@ def ServiceRequestRecordOp : ESI_Op<"manifest.req", [
   let arguments = (ins AppIDAttr:$requestor,
                        InnerRefAttr:$servicePort,
                        OptionalAttr<StrAttr>:$stdService,
-                       BundleDirection:$direction,
                        TypeAttrOf<ChannelBundleType>:$bundleType);
 
   let assemblyFormat = [{
     qualified($requestor) `,` $servicePort (`std` $stdService^)?
-    `,` $direction `,` $bundleType attr-dict
+    `,` $bundleType attr-dict
   }];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/ESI/ESIOps.h
+++ b/include/circt/Dialect/ESI/ESIOps.h
@@ -29,16 +29,8 @@ namespace esi {
 /// Describes a service port. In the unidirection case, either (but not both)
 /// type fields will be null.
 struct ServicePortInfo {
-  enum class Direction { toClient, toServer };
-
   hw::InnerRefAttr port;
-  Direction direction;
   ChannelBundleType type;
-
-  StringRef directionAsString() {
-    return direction == ServicePortInfo::Direction::toClient ? "toClient"
-                                                             : "toServer";
-  }
 };
 
 } // namespace esi

--- a/include/circt/Dialect/ESI/ESIServices.td
+++ b/include/circt/Dialect/ESI/ESIServices.td
@@ -32,8 +32,8 @@ def CustomServiceDeclOp : ESI_Op<"service.decl",
 
     ```mlir
     esi.service.decl @HostComms {
-      esi.service.to_server send : !esi.channel<!esi.any>
-      esi.service.to_client recieve : !esi.channel<i8>
+      esi.service.port send : !esi.bundle<[!esi.any from "send"]>
+      esi.service.port recieve : !esi.channel<[i8 to "recv"]>
     }
     ```
   }];
@@ -46,18 +46,7 @@ def CustomServiceDeclOp : ESI_Op<"service.decl",
   }];
 }
 
-def ToServerOp : ESI_Op<"service.to_server",
-                        [HasParent<"::circt::esi::CustomServiceDeclOp">]> {
-  let summary = "An ESI service bundle being sent to the service";
-
-  let arguments = (ins SymbolNameAttr:$inner_sym,
-                       TypeAttrOf<ChannelBundleType>:$toServerType);
-  let assemblyFormat = [{
-    $inner_sym attr-dict `:` $toServerType
-  }];
-}
-
-def ToClientOp : ESI_Op<"service.to_client",
+def ServiceDeclPortOp : ESI_Op<"service.port",
                         [HasParent<"::circt::esi::CustomServiceDeclOp">]> {
   let summary = "An ESI service bundle being received by the client";
 
@@ -167,21 +156,7 @@ def ServiceImplementConnReqOp : ESI_Op<"service.impl_req.req", [
   }];
 }
 
-def RequestToServerConnectionOp : ESI_Op<"service.req.to_server", [
-        DeclareOpInterfaceMethods<HasAppIDOpInterface>,
-        DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
-  let summary = "Request a connection to send data";
-
-  let arguments = (ins InnerRefAttr:$servicePort,
-                       ChannelBundleType:$toServer,
-                       AppIDAttr:$appID);
-  let assemblyFormat = [{
-    $toServer `->` $servicePort `(` qualified($appID) `)`
-      attr-dict `:` qualified(type($toServer))
-  }];
-}
-
-def RequestToClientConnectionOp : ESI_Op<"service.req.to_client", [
+def RequestConnectionOp : ESI_Op<"service.req", [
         DeclareOpInterfaceMethods<HasAppIDOpInterface>,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Request a connection to receive data";

--- a/integration_test/Bindings/Python/dialects/esi.py
+++ b/integration_test/Bindings/Python/dialects/esi.py
@@ -60,7 +60,7 @@ with Context() as ctx:
 !recvI8 = !esi.bundle<[!esi.channel<i8> to "recv"]>
 
 esi.service.decl @HostComms {
-  esi.service.to_client @Recv : !recvI8
+  esi.service.port @Recv : !recvI8
 }
 
 hw.module @MsTop (in %clk : i1, out chksum : i8) {
@@ -70,7 +70,7 @@ hw.module @MsTop (in %clk : i1, out chksum : i8) {
 }
 
 hw.module @MsLoopback (in %clk : i1) {
-  %dataIn = esi.service.req.to_client <@HostComms::@Recv> (#esi.appid<"loopback_tohw">) : !recvI8
+  %dataIn = esi.service.req <@HostComms::@Recv> (#esi.appid<"loopback_tohw">) : !recvI8
 }
 """)
   pm = passmanager.PassManager.parse("builtin.module(esi-connect-services)")

--- a/integration_test/Dialect/ESI/runtime/loopback.mlir
+++ b/integration_test/Dialect/ESI/runtime/loopback.mlir
@@ -7,9 +7,9 @@
 // RUN: %python %s.py trace w:%t6/esi_system_manifest.json
 // RUN: %python esi-cosim-runner.py --exec %s.py %t6/*.sv
 
-!sendI8 = !esi.bundle<[!esi.channel<i8> to "send"]>
+!sendI8 = !esi.bundle<[!esi.channel<i8> from "send"]>
 !recvI8 = !esi.bundle<[!esi.channel<i8> to "recv"]>
-!sendI0 = !esi.bundle<[!esi.channel<i0> to "send"]>
+!sendI0 = !esi.bundle<[!esi.channel<i0> from "send"]>
 !recvI0 = !esi.bundle<[!esi.channel<i0> to "recv"]>
 
 !anyFrom = !esi.bundle<[
@@ -17,25 +17,25 @@
   !esi.channel<!esi.any> to "send"]>
 
 esi.service.decl @HostComms {
-  esi.service.to_server @Send : !sendI8
-  esi.service.to_client @Recv : !recvI8
+  esi.service.port @Send : !sendI8
+  esi.service.port @Recv : !recvI8
 }
 
 esi.service.decl @MyService {
-  esi.service.to_server @Send : !sendI0
-  esi.service.to_client @Recv : !recvI0
+  esi.service.port @Send : !sendI0
+  esi.service.port @Recv : !recvI0
 }
 
 hw.module @Loopback (in %clk: !seq.clock) {
-  %dataInBundle = esi.service.req.to_client <@HostComms::@Recv> (#esi.appid<"loopback_tohw">) {esi.appid=#esi.appid<"loopback_tohw">} : !recvI8
+  %dataInBundle = esi.service.req <@HostComms::@Recv> (#esi.appid<"loopback_tohw">) {esi.appid=#esi.appid<"loopback_tohw">} : !recvI8
   %dataOut = esi.bundle.unpack from %dataInBundle : !recvI8
-  %dataOutBundle = esi.bundle.pack %dataOut : !sendI8
-  esi.service.req.to_server %dataOutBundle -> <@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !sendI8
+  %dataOutBundle = esi.service.req <@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !sendI8
+  esi.bundle.unpack %dataOut from %dataOutBundle: !sendI8
 
-  %send = esi.service.req.to_client <@MyService::@Recv> (#esi.appid<"mysvc_recv">) : !recvI0
+  %send = esi.service.req <@MyService::@Recv> (#esi.appid<"mysvc_recv">) : !recvI0
   %send_ch = esi.bundle.unpack from %send : !recvI0
-  %sendi0_bundle = esi.bundle.pack %send_ch : !sendI0
-  esi.service.req.to_server %sendi0_bundle -> <@MyService::@Send> (#esi.appid<"mysvc_send">) : !sendI0
+  %sendi0_bundle = esi.service.req <@MyService::@Send> (#esi.appid<"mysvc_send">) : !sendI0
+  esi.bundle.unpack %send_ch from %sendi0_bundle : !sendI0
 }
 
 esi.service.std.func @funcs
@@ -45,7 +45,7 @@ esi.service.std.func @funcs
   !esi.channel<!hw.struct<x: si8, y: si8>> from "result"]>
 
 hw.module @LoopbackStruct() {
-  %callBundle = esi.service.req.to_client <@funcs::@call> (#esi.appid<"structFunc">) : !structFunc
+  %callBundle = esi.service.req <@funcs::@call> (#esi.appid<"structFunc">) : !structFunc
   %arg = esi.bundle.unpack %resultChan from %callBundle : !structFunc
 
   %argData, %valid = esi.unwrap.vr %arg, %ready : !hw.struct<a: ui16, b: si8>
@@ -62,7 +62,7 @@ hw.module @LoopbackStruct() {
   !esi.channel<!hw.array<2xsi8>> from "result"]>
 
 hw.module @LoopbackArray() {
-  %callBundle = esi.service.req.to_client <@funcs::@call> (#esi.appid<"arrayFunc">) : !arrFunc
+  %callBundle = esi.service.req <@funcs::@call> (#esi.appid<"arrayFunc">) : !arrFunc
   %arg = esi.bundle.unpack %resultChan from %callBundle : !arrFunc
 
   %argData, %valid = esi.unwrap.vr %arg, %ready : !hw.array<1xsi8>
@@ -77,20 +77,20 @@ hw.module @LoopbackArray() {
 
 esi.mem.ram @MemA i64 x 20
 !write = !hw.struct<address: i5, data: i64>
-!writeBundle = !esi.bundle<[!esi.channel<!write> to "req", !esi.channel<i0> from "ack"]>
+!writeBundle = !esi.bundle<[!esi.channel<!write> from "req", !esi.channel<i0> to "ack"]>
 
 hw.module @MemoryAccess1(in %clk : !seq.clock, in %rst : i1) {
   esi.service.instance #esi.appid<"mem"> svc @MemA impl as "sv_mem" (%clk, %rst) : (!seq.clock, i1) -> ()
   %write_struct = hw.aggregate_constant [0 : i5, 0 : i64] : !write
   %valid = hw.constant 0 : i1
   %write_ch, %ready = esi.wrap.vr %write_struct, %valid : !write
-  %writeBundle, %done = esi.bundle.pack %write_ch : !writeBundle
-  esi.service.req.to_server %writeBundle -> <@MemA::@write> (#esi.appid<"internal_write">) : !writeBundle
+  %writeBundle = esi.service.req <@MemA::@write> (#esi.appid<"internal_write">) : !writeBundle
+  %done = esi.bundle.unpack %write_ch from %writeBundle : !writeBundle
 }
 
 !func1Signature = !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>
 hw.module @CallableFunc1() {
-  %call = esi.service.req.to_client <@funcs::@call> (#esi.appid<"func1">) : !func1Signature
+  %call = esi.service.req <@funcs::@call> (#esi.appid<"func1">) : !func1Signature
   %arg = esi.bundle.unpack %arg from %call : !func1Signature
 }
 

--- a/lib/Bindings/Python/dialects/esi.py
+++ b/lib/Bindings/Python/dialects/esi.py
@@ -20,18 +20,7 @@ class ChannelSignaling:
 
 
 @_ods_cext.register_operation(_Dialect, replace=True)
-class RequestToServerConnectionOp(RequestToServerConnectionOp):
-
-  @property
-  def clientNamePath(self) -> List[str]:
-    return [
-        ir.StringAttr(x).value
-        for x in ir.ArrayAttr(self.attributes["clientNamePath"])
-    ]
-
-
-@_ods_cext.register_operation(_Dialect, replace=True)
-class RequestToClientConnectionOp(RequestToClientConnectionOp):
+class RequestConnectionOp(RequestConnectionOp):
 
   @property
   def clientNamePath(self) -> List[str]:

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -402,24 +402,12 @@ static LogicalResult checkTypeMatch(Operation *req,
   return success();
 }
 
-LogicalResult RequestToClientConnectionOp::verifySymbolUses(
-    SymbolTableCollection &symbolTable) {
+LogicalResult
+RequestConnectionOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto svcPort = getServicePortInfo(*this, symbolTable, getServicePortAttr());
   if (failed(svcPort))
     return failure();
-  if (svcPort->direction != ServicePortInfo::Direction::toClient)
-    return emitOpError("Service port is not a to-client port");
   return checkTypeMatch(*this, svcPort->type, getToClient().getType(), false);
-}
-
-LogicalResult RequestToServerConnectionOp::verifySymbolUses(
-    SymbolTableCollection &symbolTable) {
-  auto svcPort = getServicePortInfo(*this, symbolTable, getServicePortAttr());
-  if (failed(svcPort))
-    return failure();
-  if (svcPort->direction != ServicePortInfo::Direction::toServer)
-    return emitOpError("Service port is not a to-server port");
-  return checkTypeMatch(*this, svcPort->type, getToServer().getType(), false);
 }
 
 LogicalResult ServiceImplementConnReqOp::verifySymbolUses(
@@ -431,14 +419,10 @@ LogicalResult ServiceImplementConnReqOp::verifySymbolUses(
 }
 
 void CustomServiceDeclOp::getPortList(SmallVectorImpl<ServicePortInfo> &ports) {
-  for (auto toServer : getOps<ToServerOp>())
-    ports.push_back(ServicePortInfo{
-        hw::InnerRefAttr::get(getSymNameAttr(), toServer.getInnerSymAttr()),
-        ServicePortInfo::Direction::toServer, toServer.getToServerType()});
-  for (auto toClient : getOps<ToClientOp>())
+  for (auto toClient : getOps<ServiceDeclPortOp>())
     ports.push_back(ServicePortInfo{
         hw::InnerRefAttr::get(getSymNameAttr(), toClient.getInnerSymAttr()),
-        ServicePortInfo::Direction::toClient, toClient.getToClientType()});
+        toClient.getToClientType()});
 }
 
 //===----------------------------------------------------------------------===//
@@ -697,9 +681,6 @@ void ServiceRequestRecordOp::getDetails(
     SmallVectorImpl<NamedAttribute> &results) {
   auto *ctxt = getContext();
   results.emplace_back(StringAttr::get(ctxt, "appID"), getRequestorAttr());
-  results.emplace_back(
-      getDirectionAttrName(),
-      StringAttr::get(ctxt, stringifyBundleDirection(getDirection())));
   results.emplace_back(getBundleTypeAttrName(), getBundleTypeAttr());
   results.emplace_back(getServicePortAttrName(), getServicePortAttr());
   if (auto stdSvc = getStdServiceAttr())

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -326,8 +326,7 @@ struct ESIConnectServicesPass
   /// Convert both to_server and to_client requests into the canonical
   /// implementation connection request. This simplifies the rest of the pass
   /// and the service implementation code.
-  void convertReq(RequestToClientConnectionOp);
-  void convertReq(RequestToServerConnectionOp);
+  void convertReq(RequestConnectionOp);
 
   /// "Bubble up" the specified requests to all of the instantiations of the
   /// module specified. Create and connect up ports to tunnel the ESI channels
@@ -356,12 +355,7 @@ void ESIConnectServicesPass::runOnOperation() {
   ModuleOp outerMod = getOperation();
   topLevelSyms.addDefinitions(outerMod);
 
-  outerMod.walk([&](Operation *op) {
-    if (auto req = dyn_cast<RequestToClientConnectionOp>(op))
-      convertReq(req);
-    else if (auto req = dyn_cast<RequestToServerConnectionOp>(op))
-      convertReq(req);
-  });
+  outerMod.walk([&](RequestConnectionOp req) { convertReq(req); });
 
   // Get a partially-ordered list of modules based on the instantiation DAG.
   // It's _very_ important that we process modules before their instantiations
@@ -390,72 +384,21 @@ StringAttr ESIConnectServicesPass::getStdService(FlatSymbolRefAttr svcSym) {
   return {};
 }
 
-void ESIConnectServicesPass::convertReq(
-    RequestToClientConnectionOp toClientReq) {
-  OpBuilder b(toClientReq);
+void ESIConnectServicesPass::convertReq(RequestConnectionOp req) {
+  OpBuilder b(req);
   // to_client requests are already in the canonical form, just the wrong op.
   auto newReq = b.create<ServiceImplementConnReqOp>(
-      toClientReq.getLoc(), toClientReq.getToClient().getType(),
-      toClientReq.getServicePortAttr(),
-      ArrayAttr::get(&getContext(), {toClientReq.getAppIDAttr()}));
-  newReq->setDialectAttrs(toClientReq->getDialectAttrs());
-  toClientReq.getToClient().replaceAllUsesWith(newReq.getToClient());
+      req.getLoc(), req.getToClient().getType(), req.getServicePortAttr(),
+      ArrayAttr::get(&getContext(), {req.getAppIDAttr()}));
+  newReq->setDialectAttrs(req->getDialectAttrs());
+  req.getToClient().replaceAllUsesWith(newReq.getToClient());
 
   // Emit a record of the original request.
   b.create<ServiceRequestRecordOp>(
-      toClientReq.getLoc(), toClientReq.getAppID(),
-      toClientReq.getServicePortAttr(),
-      getStdService(toClientReq.getServicePortAttr().getModuleRef()),
-      BundleDirection::toClient, toClientReq.getToClient().getType());
-  toClientReq.erase();
-}
-
-void ESIConnectServicesPass::convertReq(
-    RequestToServerConnectionOp toServerReq) {
-  OpBuilder b(toServerReq);
-  BackedgeBuilder beb(b, toServerReq.getLoc());
-
-  // to_server requests need to be converted to bundles with the opposite
-  // directions.
-  ChannelBundleType toClientType =
-      toServerReq.getToServer().getType().getReversed();
-
-  // Create the new canonical request. It's modeled in the to_client form.
-  auto toClientReq = b.create<ServiceImplementConnReqOp>(
-      toServerReq.getLoc(), toClientType, toServerReq.getServicePortAttr(),
-      ArrayAttr::get(&getContext(), {toServerReq.getAppIDAttr()}));
-  toClientReq->setDialectAttrs(toServerReq->getDialectAttrs());
-
-  // Unpack the bundle coming from the new request.
-  SmallVector<Value, 8> unpackToClientFromChannels;
-  SmallVector<Backedge, 8> unpackToClientFromChannelsBackedges;
-  for (BundledChannel ch : toClientType.getChannels()) {
-    if (ch.direction == ChannelDirection::to)
-      continue;
-    unpackToClientFromChannelsBackedges.push_back(beb.get(ch.type));
-    unpackToClientFromChannels.push_back(
-        unpackToClientFromChannelsBackedges.back());
-  }
-  auto unpackToClient =
-      b.create<UnpackBundleOp>(toServerReq.getLoc(), toClientReq.getToClient(),
-                               unpackToClientFromChannels);
-
-  // Convert the unpacked channels to the original request's bundle type with
-  // another unpack.
-  auto unpackToServer =
-      b.create<UnpackBundleOp>(toServerReq.getLoc(), toServerReq.getToServer(),
-                               unpackToClient.getToChannels());
-  for (auto [v, be] : llvm::zip_equal(unpackToServer.getToChannels(),
-                                      unpackToClientFromChannelsBackedges))
-    be.setValue(v);
-
-  // Emit a record of the original request.
-  b.create<ServiceRequestRecordOp>(
-      toServerReq.getLoc(), toServerReq.getAppID(),
-      toServerReq.getServicePortAttr(),
-      getStdService(toServerReq.getServicePortAttr().getModuleRef()),
-      BundleDirection::toServer, toServerReq.getToServer().getType());
-  toServerReq.erase();
+      req.getLoc(), req.getAppID(), req.getServicePortAttr(),
+      getStdService(req.getServicePortAttr().getModuleRef()),
+      req.getToClient().getType());
+  req.erase();
 }
 
 LogicalResult ESIConnectServicesPass::process(hw::HWModuleLike mod) {

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -321,11 +321,9 @@ struct ESIConnectServicesPass
 
   void runOnOperation() override;
 
-  /// Bundles allow us to convert to_server requests to to_client requests,
-  /// which is how the canonical implementation connection request is defined.
-  /// Convert both to_server and to_client requests into the canonical
-  /// implementation connection request. This simplifies the rest of the pass
-  /// and the service implementation code.
+  /// Convert connection requests to service implement connection requests,
+  /// which have a relative appid path instead of just an appid. Leave being a
+  /// record for the manifest of the original request.
   void convertReq(RequestConnectionOp);
 
   /// "Bubble up" the specified requests to all of the instantiations of the
@@ -386,7 +384,6 @@ StringAttr ESIConnectServicesPass::getStdService(FlatSymbolRefAttr svcSym) {
 
 void ESIConnectServicesPass::convertReq(RequestConnectionOp req) {
   OpBuilder b(req);
-  // to_client requests are already in the canonical form, just the wrong op.
   auto newReq = b.create<ServiceImplementConnReqOp>(
       req.getLoc(), req.getToClient().getType(), req.getServicePortAttr(),
       ArrayAttr::get(&getContext(), {req.getAppIDAttr()}));

--- a/lib/Dialect/ESI/ESIStdServices.cpp
+++ b/lib/Dialect/ESI/ESIStdServices.cpp
@@ -29,13 +29,12 @@ static ServicePortInfo createReqResp(StringAttr sym, Twine name,
   auto *ctxt = reqType ? reqType.getContext() : respType.getContext();
   auto bundle = ChannelBundleType::get(
       ctxt,
-      {BundledChannel{StringAttr::get(ctxt, reqName), ChannelDirection::to,
+      {BundledChannel{StringAttr::get(ctxt, reqName), ChannelDirection::from,
                       ChannelType::get(ctxt, reqType)},
-       BundledChannel{StringAttr::get(ctxt, respName), ChannelDirection::from,
+       BundledChannel{StringAttr::get(ctxt, respName), ChannelDirection::to,
                       ChannelType::get(ctxt, respType)}},
       /*resettable=false*/ UnitAttr());
-  return {hw::InnerRefAttr::get(sym, StringAttr::get(ctxt, name)),
-          ServicePortInfo::Direction::toServer, bundle};
+  return {hw::InnerRefAttr::get(sym, StringAttr::get(ctxt, name)), bundle};
 }
 
 ServicePortInfo RandomAccessMemoryDeclOp::writePortInfo() {
@@ -70,7 +69,6 @@ void FuncServiceDeclOp::getPortList(SmallVectorImpl<ServicePortInfo> &ports) {
   auto *ctxt = getContext();
   ports.push_back(ServicePortInfo{
       hw::InnerRefAttr::get(getSymNameAttr(), StringAttr::get(ctxt, "call")),
-      ServicePortInfo::Direction::toClient,
       ChannelBundleType::get(
           ctxt,
           {BundledChannel{StringAttr::get(ctxt, "arg"), ChannelDirection::to,
@@ -86,7 +84,6 @@ void MMIOServiceDeclOp::getPortList(SmallVectorImpl<ServicePortInfo> &ports) {
   // Read only port.
   ports.push_back(ServicePortInfo{
       hw::InnerRefAttr::get(getSymNameAttr(), StringAttr::get(ctxt, "read")),
-      ServicePortInfo::Direction::toClient,
       ChannelBundleType::get(
           ctxt,
           {BundledChannel{StringAttr::get(ctxt, "offset"), ChannelDirection::to,
@@ -97,7 +94,6 @@ void MMIOServiceDeclOp::getPortList(SmallVectorImpl<ServicePortInfo> &ports) {
   // Write only port.
   ports.push_back(ServicePortInfo{
       hw::InnerRefAttr::get(getSymNameAttr(), StringAttr::get(ctxt, "write")),
-      ServicePortInfo::Direction::toClient,
       ChannelBundleType::get(
           ctxt,
           {BundledChannel{StringAttr::get(ctxt, "offset"), ChannelDirection::to,

--- a/lib/Dialect/ESI/Passes/ESIBuildManifest.cpp
+++ b/lib/Dialect/ESI/Passes/ESIBuildManifest.cpp
@@ -196,7 +196,6 @@ std::string ESIBuildManifestPass::json() {
           for (auto port : ports) {
             j.object([&] {
               j.attribute("name", port.port.getName().getValue());
-              j.attribute("direction", port.directionAsString());
               j.attribute("type", json(svcDecl, TypeAttr::get(port.type)));
             });
           }

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -65,17 +65,10 @@ public:
 /// ChannelPorts.
 class BundlePort {
 public:
-  /// Direction of a bundle. This -- combined with the channel direction in the
-  /// bundle -- can be used to determine if a channel should be writing to or
-  /// reading from the accelerator.
-  enum Direction { ToServer, ToClient };
-
   /// Compute the direction of a channel given the bundle direction and the
   /// bundle port's direction.
-  static bool isWrite(BundleType::Direction bundleDir, Direction svcDir) {
-    if (svcDir == Direction::ToClient)
-      return bundleDir == BundleType::Direction::To;
-    return bundleDir == BundleType::Direction::From;
+  static bool isWrite(BundleType::Direction bundleDir) {
+    return bundleDir == BundleType::Direction::To;
   }
 
   /// Construct a port.

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
@@ -55,8 +55,7 @@ public:
   /// by the AppID path). For convenience, provide the bundle type and direction
   /// of the bundle port.
   virtual std::map<std::string, ChannelPort &>
-  requestChannelsFor(AppIDPath, const BundleType &,
-                     BundlePort::Direction portDir) = 0;
+  requestChannelsFor(AppIDPath, const BundleType &) = 0;
 
 protected:
   std::string serviceSymbol;

--- a/lib/Dialect/ESI/runtime/cpp/lib/Manifest.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Manifest.cpp
@@ -362,21 +362,11 @@ Manifest::Impl::getBundlePorts(AppIDPath idPath,
     const BundleType &bundleType =
         dynamic_cast<const BundleType &>(type->get());
 
-    BundlePort::Direction portDir;
-    string dirStr = content.at("direction");
-    if (dirStr == "toClient")
-      portDir = BundlePort::Direction::ToClient;
-    else if (dirStr == "toServer")
-      portDir = BundlePort::Direction::ToServer;
-    else
-      throw runtime_error("Malformed manifest: unknown direction '" + dirStr +
-                          "'");
-
     idPath.push_back(parseID(content.at("appID")));
     map<string, ChannelPort &> portChannels;
     // If we need to have custom ports (because of a custom service), add them.
     if (auto *customSvc = dynamic_cast<services::CustomService *>(svc->second))
-      portChannels = customSvc->requestChannelsFor(idPath, bundleType, portDir);
+      portChannels = customSvc->requestChannelsFor(idPath, bundleType);
     ret.emplace_back(idPath.back(), portChannels);
     // Since we share idPath between iterations, pop the last element before the
     // next iteration.

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -307,8 +307,8 @@ public:
   }
 
   virtual map<string, ChannelPort &>
-  requestChannelsFor(AppIDPath fullPath, const BundleType &bundleType,
-                     BundlePort::Direction svcDir) override {
+  requestChannelsFor(AppIDPath fullPath,
+                     const BundleType &bundleType) override {
     // Find the client details for the port at 'fullPath'.
     auto f = clientChannelAssignments.find(fullPath);
     if (f == clientChannelAssignments.end())
@@ -326,7 +326,7 @@ public:
       string channelName = f->second;
 
       ChannelPort *port;
-      if (BundlePort::isWrite(dir, svcDir))
+      if (BundlePort::isWrite(dir))
         port = new WriteCosimChannelPort(impl, type, channelName);
       else
         port = new ReadCosimChannelPort(impl, type, channelName);

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
@@ -199,12 +199,11 @@ public:
       : CustomService(idPath, details, clients), impl(impl) {}
 
   virtual map<string, ChannelPort &>
-  requestChannelsFor(AppIDPath idPath, const BundleType &bundleType,
-                     BundlePort::Direction svcDir) override {
+  requestChannelsFor(AppIDPath idPath, const BundleType &bundleType) override {
     map<string, ChannelPort &> channels;
     for (auto [name, dir, type] : bundleType.getChannels()) {
       ChannelPort *port;
-      if (BundlePort::isWrite(dir, svcDir))
+      if (BundlePort::isWrite(dir))
         port = new WriteTraceChannelPort(impl, type, idPath, name);
       else
         port = new ReadTraceChannelPort(impl, type);

--- a/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
+++ b/lib/Dialect/Handshake/Transforms/LowerExtmemToHW.cpp
@@ -208,26 +208,26 @@ LogicalResult HandshakeLowerExtmemToHWPass::wrapESI(
 
     // Load ports:
     for (unsigned i = 0; i < memType.loadPorts; ++i) {
-      auto reqPack = b.create<esi::PackBundleOp>(loc, readPortInfo.type,
-                                                 (Value)backedges[resIdx]);
-      b.create<esi::RequestToServerConnectionOp>(
-          loc, readPortInfo.port, reqPack.getBundle(),
+      auto req = b.create<esi::RequestConnectionOp>(
+          loc, readPortInfo.type, readPortInfo.port,
           esi::AppIDAttr::get(ctx, b.getStringAttr("load"), {}));
+      auto reqUnpack = b.create<esi::UnpackBundleOp>(
+          loc, req.getToClient(), ValueRange{backedges[resIdx]});
       instanceArgsFromThisMem.push_back(
-          reqPack.getFromChannels()
+          reqUnpack.getToChannels()
               [esi::RandomAccessMemoryDeclOp::RespDirChannelIdx]);
       ++resIdx;
     }
 
     // Store ports:
     for (unsigned i = 0; i < memType.storePorts; ++i) {
-      auto reqPack = b.create<esi::PackBundleOp>(loc, writePortInfo.type,
-                                                 (Value)backedges[resIdx]);
-      b.create<esi::RequestToServerConnectionOp>(
-          loc, writePortInfo.port, reqPack.getBundle(),
+      auto req = b.create<esi::RequestConnectionOp>(
+          loc, writePortInfo.type, writePortInfo.port,
           esi::AppIDAttr::get(ctx, b.getStringAttr("store"), {}));
+      auto reqUnpack = b.create<esi::UnpackBundleOp>(
+          loc, req.getToClient(), ValueRange{backedges[resIdx]});
       instanceArgsFromThisMem.push_back(
-          reqPack.getFromChannels()
+          reqUnpack.getToChannels()
               [esi::RandomAccessMemoryDeclOp::RespDirChannelIdx]);
       ++resIdx;
     }

--- a/test/Dialect/ESI/appid_hier.mlir
+++ b/test/Dialect/ESI/appid_hier.mlir
@@ -13,13 +13,13 @@ hw.module @Top() {
 }
 
 hw.module @LoopbackInOutAdd7() {
-  esi.manifest.req #esi.appid<"loopback_inout"[0]>, <@HostComms::@req_resp>, toServer, !esi.bundle<[!esi.channel<i16> to "resp", !esi.channel<i24> from "req"]>
+  esi.manifest.req #esi.appid<"loopback_inout"[0]>, <@HostComms::@req_resp>, !esi.bundle<[!esi.channel<i16> to "resp", !esi.channel<i24> from "req"]>
 }
 
 hw.module @Bar () {}
 
 // CHECK-LABEL: esi.manifest.hier_root @main {
-// CHECK-NEXT:    esi.manifest.req #esi.appid<"loopback_inout"[0]>, <@HostComms::@req_resp>, toServer, !esi.bundle<[!esi.channel<i16> to "resp", !esi.channel<i24> from "req"]>
+// CHECK-NEXT:    esi.manifest.req #esi.appid<"loopback_inout"[0]>, <@HostComms::@req_resp>, !esi.bundle<[!esi.channel<i16> to "resp", !esi.channel<i24> from "req"]>
 // CHECK-NEXT:    esi.manifest.hier_node #esi.appid<"bar"[0]> mod @Bar {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    esi.manifest.service_impl #esi.appid<"cosim"[0]> by "cosim" with {} {

--- a/test/Dialect/ESI/errors.mlir
+++ b/test/Dialect/ESI/errors.mlir
@@ -47,45 +47,23 @@ hw.module @test(in %m : !sv.modport<@IData::@Noexist>) {
 // -----
 
 esi.service.decl @HostComms {
-  esi.service.to_client @Send : !esi.bundle<[!esi.channel<i8> to "send"]>
-}
-
-hw.module @Loopback (in %clk: i1, in %dataIn: !esi.bundle<[!esi.channel<i8> to "send"]>) {
-  // expected-error @+1 {{Service port is not a to-server port}}
-  esi.service.req.to_server %dataIn -> <@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !esi.bundle<[!esi.channel<i8> to "send"]>
-}
-
-// -----
-
-esi.service.decl @HostComms {
-  esi.service.to_server @Send : !esi.bundle<[!esi.channel<i8> to "send"]>
+  esi.service.port @Send : !esi.bundle<[!esi.channel<i16> from "send"]>
 }
 
 hw.module @Loopback (in %clk: i1) {
-  // expected-error @+1 {{Service port is not a to-client port}}
-  esi.service.req.to_client <@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !esi.bundle<[!esi.channel<i8> to "send"]>
-}
-
-// -----
-
-esi.service.decl @HostComms {
-  esi.service.to_server @Send : !esi.bundle<[!esi.channel<i16> to "send"]>
-}
-
-hw.module @Loopback (in %clk: i1, in %dataIn: !esi.bundle<[!esi.channel<i8> to "send"]>) {
   // expected-error @+1 {{Request channel type does not match service port bundle channel type}}
-  esi.service.req.to_server %dataIn -> <@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !esi.bundle<[!esi.channel<i8> to "send"]>
+  %dataIn = esi.service.req <@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !esi.bundle<[!esi.channel<i8> from "send"]>
 }
 
 // -----
 
 esi.service.decl @HostComms {
-  esi.service.to_server @Send : !esi.bundle<[!esi.channel<i16> to "send"]>
+  esi.service.port @Send : !esi.bundle<[!esi.channel<i16> from "send"]>
 }
 
-hw.module @Loopback (in %clk: i1, in %dataIn: !esi.bundle<[!esi.channel<i8> to "send", !esi.channel<i3> to "foo"]>) {
+hw.module @Loopback (in %clk: i1) {
   // expected-error @+1 {{Request port bundle channel count does not match service port bundle channel count}}
-  esi.service.req.to_server %dataIn -> <@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !esi.bundle<[!esi.channel<i8> to "send", !esi.channel<i3> to "foo"]>
+  %dataIn = esi.service.req<@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !esi.bundle<[!esi.channel<i8> to "send", !esi.channel<i3> to "foo"]>
 }
 
 // -----
@@ -94,22 +72,22 @@ esi.service.decl @HostComms {
 }
 
 hw.module @Loopback (in %clk: i1) {
-  // expected-error @+1 {{'esi.service.req.to_client' op Could not locate port "Recv"}}
-  %dataIn = esi.service.req.to_client <@HostComms::@Recv> (#esi.appid<"loopback_tohw">) : !esi.bundle<[!esi.channel<i1> from "foo"]>
+  // expected-error @+1 {{'esi.service.req' op Could not locate port "Recv"}}
+  %dataIn = esi.service.req <@HostComms::@Recv> (#esi.appid<"loopback_tohw">) : !esi.bundle<[!esi.channel<i1> from "foo"]>
 }
 
 // -----
 
 hw.module @Loopback (in %clk: i1) {
-  // expected-error @+1 {{'esi.service.req.to_client' op Could not find service declaration @HostComms}}
-  %dataIn = esi.service.req.to_client <@HostComms::@Recv> (#esi.appid<"loopback_tohw">) : !esi.bundle<[!esi.channel<i1> from "foo"]>
+  // expected-error @+1 {{'esi.service.req' op Could not find service declaration @HostComms}}
+  %dataIn = esi.service.req <@HostComms::@Recv> (#esi.appid<"loopback_tohw">) : !esi.bundle<[!esi.channel<i1> from "foo"]>
 }
 
 // -----
 
-!reqResp = !esi.bundle<[!esi.channel<i16> to "req", !esi.channel<i8> from "resp"]>
+!reqResp = !esi.bundle<[!esi.channel<i16> from "req", !esi.channel<i8> to "resp"]>
 esi.service.decl @HostComms {
-  esi.service.to_server @ReqResp : !reqResp
+  esi.service.port @ReqResp : !reqResp
 }
 
 hw.module @Top(in %clk: i1, in %rst: i1) {

--- a/test/Dialect/Handshake/lower-extmem-esi.mlir
+++ b/test/Dialect/Handshake/lower-extmem-esi.mlir
@@ -27,10 +27,10 @@
 // CHECK-SAME: in %reset : i1,
 // CHECK-SAME: out out0 : !esi.channel<i0>
 // CHECK-SAME: ) {
-//CHECK-NEXT:   %bundle, %data = esi.bundle.pack %main.mem_ld0.addr : !esi.bundle<[!esi.channel<i4> to "address", !esi.channel<i32> from "data"]>
-//CHECK-NEXT:   esi.service.req.to_server %bundle -> <@mem::@read>(#esi.appid<"load">) : !esi.bundle<[!esi.channel<i4> to "address", !esi.channel<i32> from "data"]>
-//CHECK-NEXT:   %bundle_0, %ack = esi.bundle.pack %main.mem_st0 : !esi.bundle<[!esi.channel<!hw.struct<address: i4, data: i32>> to "req", !esi.channel<i0> from "ack"]>
-//CHECK-NEXT:   esi.service.req.to_server %bundle_0 -> <@mem::@write>(#esi.appid<"store">) : !esi.bundle<[!esi.channel<!hw.struct<address: i4, data: i32>> to "req", !esi.channel<i0> from "ack"]>
+//CHECK-NEXT:   [[B0:%.+]] = esi.service.req <@mem::@read>(#esi.appid<"load">) : !esi.bundle<[!esi.channel<i4> from "address", !esi.channel<i32> to "data"]>
+//CHECK-NEXT:   %data = esi.bundle.unpack %main.mem_ld0.addr from [[B0]] : !esi.bundle<[!esi.channel<i4> from "address", !esi.channel<i32> to "data"]>
+//CHECK-NEXT:   [[B1:%.+]] = esi.service.req <@mem::@write>(#esi.appid<"store">) : !esi.bundle<[!esi.channel<!hw.struct<address: i4, data: i32>> from "req", !esi.channel<i0> to "ack"]>
+//CHECK-NEXT:   %ack = esi.bundle.unpack %main.mem_st0 from [[B1]] : !esi.bundle<[!esi.channel<!hw.struct<address: i4, data: i32>> from "req", !esi.channel<i0> to "ack"]>
 //CHECK-NEXT:   %main.out0, %main.mem_ld0.addr, %main.mem_st0 = hw.instance "main" @__main_hw(arg0: %arg0: !esi.channel<i64>, arg1: %arg1: !esi.channel<i64>, v: %v: !esi.channel<i32>, mem_ld0.data: %data: !esi.channel<i32>, mem_st0.done: %ack: !esi.channel<i0>, argCtrl: %argCtrl: !esi.channel<i0>, clock: %clock: !seq.clock, reset: %reset: i1) -> (out0: !esi.channel<i0>, mem_ld0.addr: !esi.channel<i4>, mem_st0: !esi.channel<!hw.struct<address: i4, data: i32>>)
 //CHECK-NEXT:   hw.output %main.out0 : !esi.channel<i0>
 //CHECK-NEXT: }


### PR DESCRIPTION
Having a direction on the service ports which just reversed the bundle directions was far too complicated. Standardize on the service always packing the bundle and sending it to the client. Standardizing that way has the additional benefit that this was already the canonical form which all the service generators saw. Remove all to_client verbiage from the IR.