### PR TITLE
[PyCDE] Adapt to new to_client style services

### DIFF
--- a/frontends/PyCDE/integration_test/esi_test.py
+++ b/frontends/PyCDE/integration_test/esi_test.py
@@ -15,8 +15,8 @@ from pycde.types import (Bits, Bundle, BundledChannel, Channel,
 import sys
 
 TestBundle = Bundle([
-    BundledChannel("resp", ChannelDirection.TO, UInt(16)),
-    BundledChannel("req", ChannelDirection.FROM, UInt(24))
+    BundledChannel("resp", ChannelDirection.FROM, UInt(16)),
+    BundledChannel("req", ChannelDirection.TO, UInt(24))
 ])
 
 
@@ -31,8 +31,8 @@ class LoopbackInOutAdd7(Module):
   @generator
   def construct(ports):
     loopback = Wire(Channel(UInt(16)))
-    call_bundle, [(_, from_host)] = TestBundle.pack(resp=loopback)
-    HostComms.req_resp(call_bundle, AppID("loopback_inout"))
+    call_bundle = HostComms.req_resp(AppID("loopback_inout"))
+    [from_host] = call_bundle.unpack(resp=loopback).values()
 
     ready = Wire(Bits(1))
     data, valid = from_host.unwrap(ready)

--- a/frontends/PyCDE/src/signals.py
+++ b/frontends/PyCDE/src/signals.py
@@ -747,6 +747,17 @@ class BundleSignal(Signal):
         for idx, bc in enumerate(to_channels)
     }
 
+  def connect(self, other: BundleSignal):
+    """Connect two bundles together such that one drives the other."""
+    from .constructs import Wire
+    froms = [(bc.name, Wire(bc.channel))
+             for bc in other.type.channels
+             if bc.direction == ChannelDirection.FROM]
+    unpacked_other = other.unpack(**{name: wire for name, wire in froms})
+    unpacked_self = self.unpack(**unpacked_other)
+    for name, wire in froms:
+      wire.assign(unpacked_self[name])
+
 
 class ListSignal(Signal):
   pass

--- a/frontends/PyCDE/src/types.py
+++ b/frontends/PyCDE/src/types.py
@@ -606,6 +606,15 @@ class Bundle(Type):
         for (name, dir, type) in self._type.channels
     ]
 
+  def inverted(self) -> "Bundle":
+    """Return a new bundle with all the channels direction inverted."""
+    return Bundle([
+        BundledChannel(
+            name, ChannelDirection.TO
+            if dir == ChannelDirection.FROM else ChannelDirection.FROM,
+            _FromCirctType(ty)) for (name, dir, ty) in self._type.channels
+    ])
+
   # Easy accessor for channel types by name.
   def __getattr__(self, attrname: str):
     for channel in self.channels:


### PR DESCRIPTION
Turns out the default style PyCDE selected was the non-canonical one -- to_server -- instead of to_client.