### PR TITLE
[FIRRTL] Change LowerXMR to use ifdef ABI

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1226,6 +1226,32 @@ def RefCastOp : FIRRTLOp<"ref.cast",
      "$input attr-dict `:` functional-type($input, $result)";
 }
 
+def RefCastUnsafeOp : FIRRTLOp<"ref.cast.unsafe",
+    [HasCustomSSAName,
+     Pure,
+     CompatibleRefTypes<"result","input">]> {
+  let summary = "Cast between compatible reference types";
+  let description = [{
+    This op allows for casting between ref types without verifying the legality
+    of any layer-associated probe types.
+
+    Losslessly cast between any reference types.
+    Source and destination must be recursively identical or destination
+    has uninferred variants of the corresponding element in source.
+    ```
+      %result = firrtl.ref.cast %ref : (t1) -> t2
+    ```
+    }];
+
+  let arguments = (ins RefType:$input);
+  let results = (outs RefType:$result);
+
+  let hasFolder = 1;
+
+  let assemblyFormat =
+     "$input attr-dict `:` functional-type($input, $result)";
+}
+
 def RefResolveOp: FIRRTLExprOp<"ref.resolve",
                               [RefTypeConstraint<"ref","result">]> {
   let summary = "FIRRTL Resolve a Reference";

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -106,6 +106,35 @@ def RefDefineOp : FIRRTLOp<"ref.define", [SameTypeOperands, FConnectLike]> {
   }];
 }
 
+def RefDefineUnsafeOp : FIRRTLOp<"ref.define.unsafe", [FConnectLike]> {
+  let summary = "FIRRTL Define References";
+  let description = [{
+    Define a target reference to the source reference:
+    ```
+      firrtl.ref.define %dest, %src : ref<t1>
+    ```
+    Used to statically route reference from source to destination
+    through the design, one module at a time.
+
+    Similar to "connect" but cannot have multiple define's to same
+    destination and the define is never conditional even if under
+    a "when".
+
+    Source and destination must resolve statically.
+  }];
+  let arguments = (ins RefType:$dest, RefType:$src);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat =
+    "$dest `,` $src  attr-dict `:` qualified(type($dest)) `,` qualified(type($src))";
+
+  let extraClassDeclaration = [{
+    static ConnectBehaviorKind getConnectBehaviorKind() {
+      return ConnectBehaviorKind::StaticSingleConnect;
+    }
+  }];
+}
 
 def PrintFOp : FIRRTLOp<"printf"> {
   let summary = "Formatted Print Statement";

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -59,7 +59,7 @@ public:
             TailPrimOp, VerbatimExprOp, HWStructCastOp, BitCastOp, RefSendOp,
             RefResolveOp, RefSubOp, RWProbeOp, XMRRefOp, XMRDerefOp,
             // Casts to deal with weird stuff
-            UninferredResetCastOp, ConstCastOp, RefCastOp,
+            UninferredResetCastOp, ConstCastOp, RefCastOp, RefCastUnsafeOp,
             mlir::UnrealizedConversionCastOp,
             // Property expressions.
             StringConstantOp, FIntegerConstantOp, BoolConstantOp,
@@ -205,6 +205,7 @@ public:
   HANDLE(mlir::UnrealizedConversionCastOp, Unhandled);
   HANDLE(BitCastOp, Unhandled);
   HANDLE(RefCastOp, Unhandled);
+  HANDLE(RefCastUnsafeOp, Unhandled);
 
   // Property expressions.
   HANDLE(StringConstantOp, Unhandled);

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -227,14 +227,14 @@ public:
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
         .template Case<AttachOp, ConnectOp, StrictConnectOp, RefDefineOp,
-                       ForceOp, PrintFOp, SkipOp, StopOp, WhenOp, AssertOp,
-                       AssumeOp, CoverOp, PropAssignOp, RefForceOp,
-                       RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp,
-                       VerifAssertIntrinsicOp, VerifAssumeIntrinsicOp,
-                       VerifCoverIntrinsicOp, LayerBlockOp>(
-            [&](auto opNode) -> ResultType {
-              return thisCast->visitStmt(opNode, args...);
-            })
+                       RefDefineUnsafeOp, ForceOp, PrintFOp, SkipOp, StopOp,
+                       WhenOp, AssertOp, AssumeOp, CoverOp, PropAssignOp,
+                       RefForceOp, RefForceInitialOp, RefReleaseOp,
+                       RefReleaseInitialOp, VerifAssertIntrinsicOp,
+                       VerifAssumeIntrinsicOp, VerifCoverIntrinsicOp,
+                       LayerBlockOp>([&](auto opNode) -> ResultType {
+          return thisCast->visitStmt(opNode, args...);
+        })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidStmt(op, args...);
         });
@@ -261,6 +261,7 @@ public:
   HANDLE(ConnectOp);
   HANDLE(StrictConnectOp);
   HANDLE(RefDefineOp);
+  HANDLE(RefDefineUnsafeOp);
   HANDLE(ForceOp);
   HANDLE(PrintFOp);
   HANDLE(SkipOp);

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -3238,6 +3238,13 @@ OpFoldResult RefCastOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+OpFoldResult RefCastUnsafeOp::fold(FoldAdaptor adaptor) {
+  // RefCast is unnecessary if types match.
+  if (getInput().getType() == getType())
+    return getInput();
+  return {};
+}
+
 static bool isConstantZero(Value operand) {
   auto constOp = operand.getDefiningOp<ConstantOp>();
   return constOp && constOp.getValue().isZero();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -5751,6 +5751,10 @@ void RefCastOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
 
+void RefCastUnsafeOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+
 void RefResolveOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -640,6 +640,57 @@ class LowerXMRPass : public LowerXMRBase<LowerXMRPass> {
           getRefABIMacroForPort(module, portIndex, circuitRefPrefix);
       builder.create<sv::MacroDeclOp>(macroName, ArrayAttr(), StringAttr());
 
+      OpBuilder::InsertionGuard guard(builder);
+      if (auto layer = refType.getLayer()) {
+        SmallVector<FlatSymbolRefAttr> refStack;
+        auto layerIt = layer;
+        while (layerIt && ifDefMap.find(layerIt) == ifDefMap.end()) {
+          if (layerIt.getNestedReferences().empty()) {
+            refStack.push_back(
+                FlatSymbolRefAttr::get(layerIt.getRootReference()));
+            layerIt = {};
+            continue;
+          }
+          refStack.push_back(layerIt.getNestedReferences().back());
+          layerIt =
+              SymbolRefAttr::get(layerIt.getRootReference(),
+                                 layerIt.getNestedReferences().drop_back());
+        }
+
+        SmallVector<FlatSymbolRefAttr> nestedRefs;
+        StringAttr root;
+        SmallString<128> ifdefName;
+        if (layerIt) {
+          auto closestIfdefOp = ifDefMap[layerIt];
+          builder.setInsertionPointToEnd(closestIfdefOp.getThenBlock());
+          root = layerIt.getRootReference();
+          nestedRefs.append(layerIt.getNestedReferences().begin(),
+                            layerIt.getNestedReferences().end());
+          ifdefName.append(closestIfdefOp.getCondAttr().getName());
+        } else {
+          ifdefName.append("groups_");
+          ifdefName.append(module.getName());
+        }
+        while (!refStack.empty()) {
+          ifdefName.append("_");
+          if (!root) {
+            root = refStack.pop_back_val().getAttr();
+            ifdefName.append(root);
+          } else {
+            auto nextRef = refStack.pop_back_val();
+            nestedRefs.push_back(nextRef);
+            ifdefName.append(nextRef.getAttr());
+          }
+          layerIt = SymbolRefAttr::get(root, nestedRefs);
+          auto ifDefOp = builder.create<sv::IfDefOp>(ifdefName);
+          ifDefOp->setAttr("output_file",
+                           hw::OutputFileAttr::getFromFilename(
+                               &getContext(), circuitRefPrefix + ".sv"));
+          ifDefMap[layerIt] = ifDefOp;
+          builder.setInsertionPointToStart(ifDefOp.getThenBlock());
+        }
+      }
+
       auto macroDefOp = builder.create<sv::MacroDefOp>(
           FlatSymbolRefAttr::get(macroName),
           builder.getStringAttr(formatString),
@@ -863,6 +914,9 @@ private:
 
   /// The insertion point where the pass inserts HierPathOps.
   OpBuilder::InsertPoint pathInsertPoint = {};
+
+  /// A map of layer name to an `ifdef associated with this layer.
+  DenseMap<SymbolRefAttr, sv::IfDefOp> ifDefMap;
 };
 
 std::unique_ptr<mlir::Pass> circt::firrtl::createLowerXMRPass() {

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -95,6 +95,36 @@ firrtl.circuit "Simple" {
 
 // -----
 
+firrtl.circuit "ProbeColors" {
+  firrtl.layer @A bind {}
+  firrtl.module @ProbeColors(
+    out %a : !firrtl.probe<uint<1>, @A>
+  ) {
+    %b = firrtl.wire : !firrtl.uint<1>
+    firrtl.layerblock @A {
+      %0 = firrtl.ref.send %b : !firrtl.uint<1>
+      %1 = firrtl.ref.cast %0 : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>, @A>
+      firrtl.ref.define %a, %1 : !firrtl.probe<uint<1>, @A>
+    }
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "ProbeColors"
+//
+// CHECK:       firrtl.module private @ProbeColors_A(
+// CHECK-SAME:    in %[[b_port:[_a-zA-Z0-9]+]]: !firrtl.uint<1>
+// CHECK-SAME:    out %[[a_port:[_a-zA-Z0-9]+]]: !firrtl.probe<uint<1>, @A>
+//
+// CHECK-NEXT:    %[[b_send:[_a-zA-Z0-9]+]] = firrtl.ref.send %[[b_port]]
+// CHECK-NEXT:    firrtl.ref.define.unsafe %[[a_port]], %[[b_send]]
+//
+// CHECK:       firrtl.module @ProbeColors
+// CHECK:         %[[b_port:[_a-zA-Z0-9]+]], %[[a_port:[_a-zA-Z0-9]+]] = firrtl.instance probeColors_A
+// CHECK-NEXT:    firrtl.ref.define.unsafe %a, %[[a_port]]
+// CHECK-NEXT:    firrtl.strictconnect %[[b_port]], %b
+
+// -----
+
 firrtl.circuit "ModuleNameConflict" {
   firrtl.layer @A bind {}
   firrtl.module private @ModuleNameConflict_A() {}

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -1010,7 +1010,7 @@ firrtl.circuit "WireProbe" {
 }
 
 // -----
-// Test that all layer-colored probes produce Verilog macros after LowerXMR.
+// Test that ifdefs are correctly generated for layer-colored probes.
 
 firrtl.circuit "ProbeColors" {
   firrtl.layer @A bind {
@@ -1036,8 +1036,12 @@ firrtl.circuit "ProbeColors" {
 // CHECK:         sv.macro.decl @ref_ProbeColors_ProbeColors_a
 // CHECK-NEXT:    sv.macro.def @ref_ProbeColors_ProbeColors_a
 // CHECK-NEXT:    sv.macro.decl @ref_ProbeColors_ProbeColors_b
-// CHECK-NEXT:    sv.macro.def @ref_ProbeColors_ProbeColors_b
+// CHECK-NEXT:    sv.ifdef "groups_ProbeColors_A" {
+// CHECK-NEXT:      sv.ifdef "groups_ProbeColors_A_B" {
+// CHECK-NEXT:        sv.macro.def @ref_ProbeColors_ProbeColors_b
+// CHECK-NEXT:        sv.macro.def @ref_ProbeColors_ProbeColors_d{{.*}}
+// CHECK-NEXT:      }
+// CHECK-NEXT:      sv.macro.def @ref_ProbeColors_ProbeColors_c{{.*}}
+// CHECK-NEXT:    }
 // CHECK-NEXT:    sv.macro.decl @ref_ProbeColors_ProbeColors_c
-// CHECK-NEXT:    sv.macro.def @ref_ProbeColors_ProbeColors_c
 // CHECK-NEXT:    sv.macro.decl @ref_ProbeColors_ProbeColors_d
-// CHECK-NEXT:    sv.macro.def @ref_ProbeColors_ProbeColors_d

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -1008,3 +1008,36 @@ firrtl.circuit "WireProbe" {
     firrtl.ref.define %p, %w : !firrtl.probe<uint<5>>
   }
 }
+
+// -----
+// Test that all layer-colored probes produce Verilog macros after LowerXMR.
+
+firrtl.circuit "ProbeColors" {
+  firrtl.layer @A bind {
+    firrtl.layer @B bind {}
+  }
+  firrtl.module @ProbeColors(
+    out %a : !firrtl.probe<uint<1>>,
+    out %b : !firrtl.probe<uint<1>, @A::@B>,
+    out %c : !firrtl.probe<uint<1>, @A>,
+    out %d : !firrtl.probe<uint<1>, @A::@B>
+  ) {
+    %x = firrtl.wire : !firrtl.uint<1>
+    %0 = firrtl.ref.send %x : !firrtl.uint<1>
+    firrtl.ref.define.unsafe %a, %0 : !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
+    firrtl.ref.define.unsafe %b, %0 : !firrtl.probe<uint<1>, @A::@B>, !firrtl.probe<uint<1>>
+    firrtl.ref.define.unsafe %c, %0 : !firrtl.probe<uint<1>, @A>, !firrtl.probe<uint<1>>
+    firrtl.ref.define.unsafe %d, %0 : !firrtl.probe<uint<1>, @A::@B>, !firrtl.probe<uint<1>>
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "ProbeColors"
+//
+// CHECK:         sv.macro.decl @ref_ProbeColors_ProbeColors_a
+// CHECK-NEXT:    sv.macro.def @ref_ProbeColors_ProbeColors_a
+// CHECK-NEXT:    sv.macro.decl @ref_ProbeColors_ProbeColors_b
+// CHECK-NEXT:    sv.macro.def @ref_ProbeColors_ProbeColors_b
+// CHECK-NEXT:    sv.macro.decl @ref_ProbeColors_ProbeColors_c
+// CHECK-NEXT:    sv.macro.def @ref_ProbeColors_ProbeColors_c
+// CHECK-NEXT:    sv.macro.decl @ref_ProbeColors_ProbeColors_d
+// CHECK-NEXT:    sv.macro.def @ref_ProbeColors_ProbeColors_d

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -70,6 +70,9 @@ firrtl.module @Layers(
   // CHECK: %1 = firrtl.ref.cast.unsafe %0 : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>, @LayerA>
   %1 = firrtl.ref.cast.unsafe %0 : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>, @LayerA>
 
+  // CHECK: firrtl.ref.define.unsafe %a, %0 : !firrtl.probe<uint<1>, @LayerA>, !firrtl.probe<uint<1>>
+  firrtl.ref.define.unsafe %a, %0 : !firrtl.probe<uint<1>, @LayerA>, !firrtl.probe<uint<1>>
+
 }
 
 // CHECK-LABEL: firrtl.module @LayersEnabled

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -64,7 +64,13 @@ firrtl.layer @LayerA bind {
 firrtl.module @Layers(
   out %a: !firrtl.probe<uint<1>, @LayerA>,
   out %b: !firrtl.rwprobe<uint<1>, @LayerA::@LayerB>
-) {}
+) {
+
+  %0 = firrtl.wire : !firrtl.probe<uint<1>>
+  // CHECK: %1 = firrtl.ref.cast.unsafe %0 : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>, @LayerA>
+  %1 = firrtl.ref.cast.unsafe %0 : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>, @LayerA>
+
+}
 
 // CHECK-LABEL: firrtl.module @LayersEnabled
 // CHECK-SAME:    layers = [@LayerA]

--- a/test/firtool/layers.fir
+++ b/test/firtool/layers.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s | FileCheck %s
+; RUN: firtool %s -split-input-file | FileCheck %s
 
 FIRRTL version 4.0.0
 circuit Foo: %[[
@@ -50,4 +50,61 @@ circuit Foo: %[[
 ; CHECK-NEXT:   bind Foo Foo_A foo_A (
 ; CHECK-NEXT:     ._in (in)
 ; CHECK-NEXT:   );
+; CHECK-NEXT:  `endif // groups_Foo_A
+
+; // -----
+
+FIRRTL version 4.0.0
+circuit Foo: %[[
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Foo|Bar>b"
+  },
+  {
+    "class": "firrtl.transforms.DontTouchAnnotation",
+    "target": "~Foo|Foo>c"
+  }
+]]
+  layer A, bind:
+
+  module Bar:
+    output a: Probe<UInt<1>>
+    input x: UInt<1>
+
+    node b = UInt<1>(0)
+
+    layerblock A:
+      define a = probe(b)
+
+  module Foo:
+    input x: UInt<1>
+
+    inst bar of Bar
+    connect bar.x, x
+
+    layerblock A:
+
+      node c = read(bar.a)
+
+; CHECK-LABEL: module Bar_A(
+; CHECK-NEXT:    input _b
+; CHECK-NEXT:  );
+; CHECK:         wire _b_probe = _b;
+; CHECK-NEXT:  endmodule
+
+; CHECK-LABEL: module Foo_A(
+; CHECK-NEXT:    input _bar_a
+; CHECK-NEXT:  );
+; CHECK:         wire c = _bar_a;
+; CHECK-NEXT:  endmodule
+
+; CHECK-LABEL: FILE "groups_Foo_A.sv"
+; CHECK:       `ifndef groups_Foo_A
+; CHECK-NEXT:  `define groups_Foo_A
+; CHECK-NEXT:  bind Bar Bar_A bar_A (
+; CHECK-NEXT:    ._b (b)
+; CHECK-NEXT:  );
+; CHECK-NEXT:  bind Foo Foo_A foo_A (
+; CHECK-NEXT:    ._bar_a (Foo.bar.bar_A._b_probe)
+; CHECK-NEXT:  );
 ; CHECK-NEXT:  `endif // groups_Foo_A


### PR DESCRIPTION
Use an alternative FIRRTL ABI that places ifdef guards around layer-colored probes.

This is factored out of a previous PR. I'm not sure that we want to use this ABI. However, the actual code uses a bunch of somewhat tedious logic in order to get the emission correct. This draft PR is a record of this so we don't lose it.