### PR TITLE
[HW] HWModule: store input port locations only on block args

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -122,7 +122,7 @@ def HWModuleOp : HWModuleOpBase<"module",
   let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<ModuleType>:$module_type,
                        OptionalAttr<DictArrayAttr>:$per_port_attrs,
-                       OptionalAttr<LocationArrayAttr>:$port_locs,
+                       OptionalAttr<LocationArrayAttr>:$result_locs,
                        ParamDeclArrayAttr:$parameters,
                        OptionalAttr<StrAttr>:$comment);
   let results = (outs);

--- a/include/circt/Dialect/HW/ModuleImplementation.h
+++ b/include/circt/Dialect/HW/ModuleImplementation.h
@@ -22,6 +22,8 @@
 namespace circt {
 namespace hw {
 
+class HWModuleLike;
+
 namespace module_like_impl {
 
 struct PortParse : OpAsmParser::Argument {
@@ -48,7 +50,7 @@ void printModuleSignature(OpAsmPrinter &p, Operation *op,
 ParseResult parseModuleSignature(OpAsmParser &parser,
                                  SmallVectorImpl<PortParse> &args,
                                  TypeAttr &modType);
-void printModuleSignatureNew(OpAsmPrinter &p, Operation *op);
+void printModuleSignatureNew(OpAsmPrinter &p, HWModuleLike op);
 
 } // namespace module_like_impl
 } // namespace hw

--- a/lib/Bindings/Python/dialects/hw.py
+++ b/lib/Bindings/Python/dialects/hw.py
@@ -148,7 +148,6 @@ class ModuleLike:
 
     module_ports = []
     input_names = []
-    port_locs = []
     unknownLoc = Location.unknown().attr
     for (i, (port_name, port_type)) in enumerate(input_ports):
       input_name = StringAttr.get(str(port_name))
@@ -156,7 +155,6 @@ class ModuleLike:
       input_port = hw.ModulePort(input_name, port_type, input_dir)
       module_ports.append(input_port)
       input_names.append(input_name)
-      port_locs.append(unknownLoc)
 
     output_types = []
     output_names = []
@@ -166,8 +164,6 @@ class ModuleLike:
       output_port = hw.ModulePort(output_name, port_type, output_dir)
       module_ports.append(output_port)
       output_names.append(output_name)
-      port_locs.append(unknownLoc)
-    attributes["port_locs"] = ArrayAttr.get(port_locs)
     attributes["per_port_attrs"] = ArrayAttr.get([])
 
     if len(parameters) > 0 or "parameters" not in attributes:

--- a/lib/Transforms/StripDebugInfoWithPred.cpp
+++ b/lib/Transforms/StripDebugInfoWithPred.cpp
@@ -87,8 +87,8 @@ void StripDebugInfoWithPred::runOnOperation() {
       &getContext(), getOperation().getOps(), [&](Operation &toplevelOp) {
         toplevelOp.walk([&](Operation *op) {
           updateLocIfChanged(op, getStrippedLoc(op->getLoc()));
-          updateLocArray(op, "argLocs");
-          updateLocArray(op, "resultLocs");
+          updateLocArray(op, "arg_locs");
+          updateLocArray(op, "result_locs");
           updateLocArray(op, "port_locs");
           // Strip block arguments debug info.
           for (Region &region : op->getRegions())


### PR DESCRIPTION
On modules we keep an array attribute `port_locs` for port location information.  On regular HWModules specifically, which have a body block, we copy the input port location to the entry block arguments, for error messages and such. This is violating the "single source of truth" principle for input port location info, so we added a verifier that ensured the block argument locations were always kept in sync with the port location attributes. This lead to another problem: if you print our IR in the generalized format and try to read it back in, by default with `-mlir-print-debug-info` printing turned off, it will end up throwing away the location on the blocks. When the IR is read back in, the block arguments will have new location information corresponding to the intermediate file, while the location array maintains the old locations. This trips the verifier since the port attribute location will be out of sync with the block argument location.

To fix this problem, this changes the HWModule op to record input port locations only on the blocks, and to store the output port locations in a new `result_locs` array.  The other module types remain the same.  Now, when printing in the generic format, input ports will lose their original location information, but the result locations will remain the same.  If printing with debug information, then both will retain their original locations.

As an example:
```mlir
// locs.mlir
hw.module @B(in %a: i1, out nameOfPortInSV: i1) {
  hw.output %a: i1
}
```
Printing without the debug information with`circt-opt -mlir-print-op-generic locs.mlir | ./bin/circt-opt --mlir-print-debuginfo` gives:
```mlir
#loc2 = loc("<stdin>":4:8)
#loc3 = loc("locs.mlir":1:29)
module {
  hw.module @B(in %a : i1 loc(#loc2), out nameOfPortInSV : i1 loc(#loc3)) {
    hw.output %a : i1 loc(#loc4)
  } loc(#loc1)
} loc(#loc)
#loc = loc("<stdin>":2:1)
#loc1 = loc("<stdin>":3:3)
#loc4 = loc("<stdin>":5:5)
```
Printing with the debug information with `circt-opt -mlir-print-op-generic --mlir-print-debuginfo locs.mlir | ./bin/circt-opt --mlir-print-debuginfo` gives:
```mlir
#loc2 = loc("locs.mlir":1:17)
#loc3 = loc("locs.mlir":1:29)
module {
  hw.module @B(in %a : i1 loc(#loc2), out nameOfPortInSV : i1 loc(#loc3)) {
    hw.output %a : i1 loc(#loc4)
  } loc(#loc1)
} loc(#loc)
#loc = loc("locs.mlir":0:0)
#loc1 = loc("locs.mlir":1:1)
#loc4 = loc("locs.mlir":2:3)
```

Closes #5484.