### PR TITLE
[FIRRTL] Use set-based logic to test for layer compatibility

### DIFF
--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1906,57 +1906,13 @@ firrtl.circuit "LayerBlockDrivesSinksOutside" {
 
 // -----
 
-firrtl.circuit "IllegalRefDefine" {
-  firrtl.layer @A bind {}
-  firrtl.module @Bar(out %a: !firrtl.probe<uint<1>, @A>) {}
-  // expected-note @below {{the enclosing 'firrtl.module' is defined here}}
-  firrtl.module @IllegalRefDefine(out %a: !firrtl.probe<uint<1>, @A>) {
-    %bar_a = firrtl.instance bar interesting_name @Bar(out a: !firrtl.probe<uint<1>, @A>)
-    // expected-error @below {{'firrtl.ref.define' op cannot interact with layer '@A' because it is not inside a 'firrtl.module' or 'firrtl.layerblock' which enables layer '@A' or a child layer}}
-    firrtl.ref.define %a, %bar_a : !firrtl.probe<uint<1>, @A>
-  }
-}
-
-// -----
-
-firrtl.circuit "IllegalRefCastDestModule" {
-  // expected-note @below {{the enclosing 'firrtl.module' is defined here}}
-  firrtl.module @IllegalRefCastDestModule() {
-    %a = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.ref.send %a : !firrtl.uint<1>
-    // expected-error @below {{'firrtl.ref.cast' op cannot interact with layer '@A' because it is not inside a 'firrtl.module' or 'firrtl.layerblock' which enables layer '@A' or a child layer}}
-    %1 = firrtl.ref.cast %0 : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>, @A>
-  }
-}
-
-// -----
-
-firrtl.circuit "IllegalRefCastDestLayerBlock" {
-  firrtl.layer @A bind {
-  }
-  firrtl.layer @B bind {
-  }
-  // expected-note @below {{the enclosing 'firrtl.module' is defined here}}
-  firrtl.module @IllegalRefCastDestLayerBlock() {
-    // expected-note @below {{the enclosing 'firrtl.layerblock' is defined here}}
-    firrtl.layerblock @A {
-      %a = firrtl.wire : !firrtl.uint<1>
-      %0 = firrtl.ref.send %a : !firrtl.uint<1>
-      // expected-error @below {{'firrtl.ref.cast' op cannot interact with layer '@B' because it is not inside a 'firrtl.module' or 'firrtl.layerblock' which enables layer '@B' or a child layer}}
-      %1 = firrtl.ref.cast %0 : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>, @B>
-    }
-  }
-}
-
-// -----
-
 firrtl.circuit "IllegalRefResolve_NotInLayerBlock" {
   firrtl.layer @A bind {
   }
-  // expected-note @below {{the enclosing 'firrtl.module' is defined here}}
   firrtl.module @IllegalRefResolve_NotInLayerBlock() {
     %0 = firrtl.wire : !firrtl.probe<uint<1>, @A>
-    // expected-error @below {{'firrtl.ref.resolve' op cannot interact with layer '@A' because it is not inside a 'firrtl.module' or 'firrtl.layerblock' which enables layer '@A' or a child layer}}
+    // expected-error @below {{'firrtl.ref.resolve' op ambient layers are insufficient to resolve reference}}
+    // expected-note  @below {{missing layer requirements: @A}}
     %1 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>, @A>
   }
 }
@@ -1964,16 +1920,13 @@ firrtl.circuit "IllegalRefResolve_NotInLayerBlock" {
 // -----
 
 firrtl.circuit "IllegalRefResolve_IllegalLayer" {
-  firrtl.layer @A bind {
-  }
-  firrtl.layer @B bind {
-  }
-  // expected-note @below {{the enclosing 'firrtl.module' is defined here}}
+  firrtl.layer @A bind {}
+  firrtl.layer @B bind {}
   firrtl.module @IllegalRefResolve_IllegalLayer() {
     %0 = firrtl.wire : !firrtl.probe<uint<1>, @A>
-    // expected-note @below {{the enclosing 'firrtl.layerblock' is defined here}}
     firrtl.layerblock @B {
-      // expected-error @below {{'firrtl.ref.resolve' op cannot interact with layer '@A' because it is not inside a 'firrtl.module' or 'firrtl.layerblock' which enables layer '@A' or a child layer}}
+      // expected-error @below {{'firrtl.ref.resolve' op ambient layers are insufficient to resolve reference}}
+      // expected-note  @below {{missing layer requirements: @A}}
       %1 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>, @A>
     }
   }

--- a/test/Dialect/FIRRTL/layers-errors.mlir
+++ b/test/Dialect/FIRRTL/layers-errors.mlir
@@ -1,0 +1,103 @@
+// RUN: circt-opt %s -split-input-file -verify-diagnostics
+
+// Cannot cast away a probe color.
+firrtl.circuit "Top" {
+  firrtl.layer @A bind {}
+  firrtl.module @Top() {
+    %w = firrtl.wire : !firrtl.probe<uint<1>, @A>
+    // expected-error @below {{cannot discard layer requirements of input ref}}
+    // expected-note  @below {{discarding layer requirements: @A}}
+    %s = firrtl.ref.cast %w : (!firrtl.probe<uint<1>, @A>) -> !firrtl.probe<uint<1>>
+  }
+}
+
+// -----
+
+firrtl.circuit "Top" {
+  firrtl.layer @A bind {}
+  firrtl.module @Top(out %o : !firrtl.probe<uint<1>>) {
+    %c = firrtl.constant 0 : !firrtl.uint<1>
+    %r = firrtl.ref.send %c : !firrtl.uint<1>
+    firrtl.layerblock @A {
+      // expected-error @below {{'firrtl.ref.define' op has more layer requirements than destination}}
+      // expected-note  @below {{additional layers required: @A}}
+      firrtl.ref.define %o, %r : !firrtl.probe<uint<1>>
+    }
+  }
+}
+
+// -----
+
+firrtl.circuit "Top" {
+  firrtl.layer @A bind {}
+  firrtl.module @Top(out %o : !firrtl.probe<uint<1>>) {
+    firrtl.layerblock @A {
+      %c = firrtl.constant 0  : !firrtl.uint<1>
+      %r = firrtl.ref.send %c : !firrtl.uint<1>
+      // expected-error @below {{'firrtl.ref.define' op has more layer requirements than destination}}
+      // expected-note  @below {{additional layers required: @A}}
+      firrtl.ref.define %o, %r : !firrtl.probe<uint<1>>
+    }
+  }
+}
+
+// -----
+
+firrtl.circuit "Top" {
+  firrtl.layer @A bind {}
+  firrtl.layer @B bind {}
+  firrtl.extmodule @Foo(out o : !firrtl.probe<uint<1>, @B>)
+  firrtl.module @Top(out %o : !firrtl.probe<uint<1>, @B>) {
+    firrtl.layerblock @A {
+      %foo_o = firrtl.instance foo @Foo(out o : !firrtl.probe<uint<1>, @B>)
+      // expected-error @below {{'firrtl.ref.define' op has more layer requirements than destination}}
+      // expected-note  @below {{additional layers required: @A}}
+      firrtl.ref.define %o, %foo_o : !firrtl.probe<uint<1>, @B>
+    }
+  }
+}
+
+// -----
+
+firrtl.circuit "Top" {
+  firrtl.layer @A bind {}
+  firrtl.module @Top(out %o : !firrtl.probe<uint<1>>) {
+    %w = firrtl.wire : !firrtl.openbundle<f: probe<uint<1>>>
+    firrtl.layerblock @A {
+      %f = firrtl.opensubfield %w[f] : !firrtl.openbundle<f: probe<uint<1>>>
+      %c = firrtl.constant 0 : !firrtl.uint<1>
+      %r = firrtl.ref.send %c : !firrtl.uint<1>
+      // expected-error @below {{'firrtl.ref.define' op has more layer requirements than destination}}
+      // expected-note  @below {{additional layers required: @A}}
+      firrtl.ref.define %f, %r : !firrtl.probe<uint<1>>
+    }
+  }
+}
+
+// -----
+
+// ref.resolve under insufficient layers.
+firrtl.circuit "Top" {
+  firrtl.layer @A bind {}
+  firrtl.module @Top() {
+    %w = firrtl.wire : !firrtl.probe<uint<1>, @A>
+    // expected-error @below {{'firrtl.ref.resolve' op ambient layers are insufficient to resolve reference}}
+    // expected-note  @below {{missing layer requirements: @A}}
+    %0 = firrtl.ref.resolve %w : !firrtl.probe<uint<1>, @A>
+  }
+}
+
+// -----
+
+// ref.resolve under insufficient layers (with nested layers).
+firrtl.circuit "Top" {
+  firrtl.layer @A bind {}
+  firrtl.module @Top() {
+    %w = firrtl.wire : !firrtl.probe<uint<1>, @A::@B>
+    firrtl.layerblock @A {
+      // expected-error @below {{'firrtl.ref.resolve' op ambient layers are insufficient to resolve reference}}
+      // expected-note  @below {{missing layer requirements: @A}}
+      %0 = firrtl.ref.resolve %w : !firrtl.probe<uint<1>, @A::@B>
+    }
+  }
+}

--- a/test/Dialect/FIRRTL/layers.mlir
+++ b/test/Dialect/FIRRTL/layers.mlir
@@ -1,9 +1,163 @@
 // RUN: circt-opt %s
 
 firrtl.circuit "Test" {
+
   firrtl.module @Test() {}
 
-  firrtl.layer @A bind {}
+  firrtl.layer @A bind {
+    firrtl.layer @B bind {
+    }
+  }
+
+  firrtl.layer @B bind {}
+
+  firrtl.module @Foo(out %o : !firrtl.probe<uint<1>, @A>) {
+    %c = firrtl.constant 0 : !firrtl.uint<1>
+    %r = firrtl.ref.send %c : !firrtl.uint<1>
+    %s = firrtl.ref.cast %r : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>, @A>
+    firrtl.ref.define %o, %s : !firrtl.probe<uint<1>, @A>
+  }
+
+  firrtl.module @Bar(out %o : !firrtl.probe<uint<1>, @B>) {
+    %c = firrtl.constant 0 : !firrtl.uint<1>
+    %r = firrtl.ref.send %c : !firrtl.uint<1>
+    %s = firrtl.ref.cast %r : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>, @B>
+    firrtl.ref.define %o, %s : !firrtl.probe<uint<1>, @B>
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Basic Casting Tests
+  //===--------------------------------------------------------------------===//
+
+  firrtl.module @CastToAnyLayer() {
+    // Safe to take an uncolored probe and colorize it.
+    %c = firrtl.constant 0 : !firrtl.uint<1>
+    %r = firrtl.ref.send %c : !firrtl.uint<1>
+    %s = firrtl.ref.cast %r : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>, @A>
+  }
+
+  firrtl.module @CastToSublayer() {
+    // Safe to take a colored probe and cast it to a nested/child/sub-layer.
+    %c = firrtl.constant 0 : !firrtl.uint<1>
+    %r = firrtl.ref.send %c : !firrtl.uint<1>
+    %s = firrtl.ref.cast %r : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>, @A>
+    %t = firrtl.ref.cast %s : (!firrtl.probe<uint<1>, @A>) -> !firrtl.probe<uint<1>, @A::@B>
+  }
+
+  firrtl.module @CastToAmbientLayer(out %o : !firrtl.probe<uint<1>, @A::@B>) {
+    // safe to take a value under layerblock @A and cast it to @A::B
+    firrtl.layerblock @A {
+      %c = firrtl.constant 0 : !firrtl.uint<1>
+      %r = firrtl.ref.send %c : !firrtl.uint<1>
+      %s = firrtl.ref.cast %r : (!firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>, @A::@B>
+      firrtl.ref.define %o, %s : !firrtl.probe<uint<1>, @A::@B>
+    }
+  }
+
+  firrtl.module @CastAwayColorUnderLayerBlock(out %o : !firrtl.probe<uint<1>>) {
+    %w = firrtl.wire : !firrtl.probe<uint<1>, @A>
+
+    // define %w, a wire colored by @A
+    firrtl.layerblock @A {
+      %c = firrtl.constant 0 : !firrtl.uint<1>
+      %r = firrtl.ref.send %c : !firrtl.uint<1>
+    }
+
+    // erase color from %w, safe under layerblock @A
+    firrtl.layerblock @A {
+      %r = firrtl.ref.cast %w : (!firrtl.probe<uint<1>, @A>) -> !firrtl.probe<uint<1>>
+      %d = firrtl.ref.resolve %r : !firrtl.probe<uint<1>>
+    }
+  }
+
+  firrtl.module @CastAwayPortColorUnderLayerBlock() {
+    firrtl.layerblock @A {
+      %o = firrtl.instance foo @Foo(out o : !firrtl.probe<uint<1>, @A>)
+      // safe to cast away @A from %o under layerblock @A
+      %r = firrtl.ref.cast %o : (!firrtl.probe<uint<1>, @A>) -> !firrtl.probe<uint<1>>
+    }
+  }
+
+  firrtl.module @CastAwayColorUnderEnabledLayer(out %o : !firrtl.probe<uint<1>>) attributes {layers = [@A]} {
+    %w = firrtl.wire : !firrtl.probe<uint<1>, @A>
+    firrtl.layerblock @A {
+      %c = firrtl.constant 0 : !firrtl.uint<1>
+      %r = firrtl.ref.send %c : !firrtl.uint<1>
+      %s = firrtl.ref.cast %w : (!firrtl.probe<uint<1>, @A>) -> !firrtl.probe<uint<1>>
+      %d = firrtl.ref.resolve %s : !firrtl.probe<uint<1>>
+    }
+    // cast away the @A from %w, safe under enabled layers.
+    %r = firrtl.ref.cast %w : (!firrtl.probe<uint<1>, @A>) -> !firrtl.probe<uint<1>>
+    firrtl.ref.define %o, %r : !firrtl.probe<uint<1>>
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Enabled Layers Tests
+  //===--------------------------------------------------------------------===//
+
+  firrtl.module @CastAwayPortColorUnderEnabledLayer(out %o : !firrtl.probe<uint<1>>) attributes {layers = [@A]} {
+    %foo_o = firrtl.instance foo @Foo(out o : !firrtl.probe<uint<1>, @A>)
+    // safe to cast away @A from %foo_o under enabled layers
+    %r = firrtl.ref.cast %foo_o : (!firrtl.probe<uint<1>, @A>) -> !firrtl.probe<uint<1>>
+    firrtl.ref.define %o, %r : !firrtl.probe<uint<1>>
+  }
+
+  firrtl.module @DefineUncoloredProbeUnderEnabledLayerWithReferentUnderLayerBlock(out %o : !firrtl.probe<uint<1>>)
+  attributes {layers = [@A]} {
+    firrtl.layerblock @A {
+      %c = firrtl.constant 0 : !firrtl.uint<1>
+      %r = firrtl.ref.send %c : !firrtl.uint<1>
+      firrtl.ref.define %o, %r : !firrtl.probe<uint<1>>
+    }
+  }
+
+  firrtl.module @CastAwayMultipleColorsUnderEnabledLayers(out %o : !firrtl.probe<uint<1>>)
+  attributes {layers = [@A, @B]} {
+    firrtl.layerblock @A {
+      %bar_o = firrtl.instance bar @Bar(out o : !firrtl.probe<uint<1>, @B>)
+      %r = firrtl.ref.cast %bar_o : (!firrtl.probe<uint<1>, @B>) -> !firrtl.probe<uint<1>>
+      firrtl.ref.define %o, %r : !firrtl.probe<uint<1>>
+    }
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Ref Resolve Tests
+  //===--------------------------------------------------------------------===//
+
+  firrtl.module @ResolveColoredRefUnderLayerBlock() {
+    %w = firrtl.wire : !firrtl.probe<uint<1>, @A>
+    firrtl.layerblock @A {
+      %0 = firrtl.ref.resolve %w : !firrtl.probe<uint<1>, @A>
+    }
+  }
+
+  firrtl.module @ResolveColoredRefUnderEnabledLayer() attributes {layers=[@A]} {
+    %w = firrtl.wire : !firrtl.probe<uint<1>, @A>
+    %0 = firrtl.ref.resolve %w : !firrtl.probe<uint<1>, @A>
+  }
+
+  firrtl.module @ResolveColoredRefPortUnderLayerBlock1() {
+    %foo_o = firrtl.instance foo @Foo(out o : !firrtl.probe<uint<1>, @A>)
+    firrtl.layerblock @A {
+      %x = firrtl.ref.resolve %foo_o : !firrtl.probe<uint<1>, @A>
+    }
+  }
+
+  firrtl.module @ResolveColoredRefPortUnderLayerBlock2() {
+    firrtl.layerblock @A {
+      %foo_o = firrtl.instance foo @Foo(out o : !firrtl.probe<uint<1>, @A>)
+      %x = firrtl.ref.resolve %foo_o : !firrtl.probe<uint<1>, @A>
+    }
+  }
+
+  firrtl.module @ResolveColoredRefPortUnderEnabledLayer() attributes {layers=[@A]} {
+    %foo_o = firrtl.instance foo @Foo(out o : !firrtl.probe<uint<1>, @A>)
+    %x = firrtl.ref.resolve %foo_o : !firrtl.probe<uint<1>, @A>
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Regression Tests
+  //===--------------------------------------------------------------------===//
 
   firrtl.module @WhenUnderLayer(in %test: !firrtl.uint<1>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>


### PR DESCRIPTION
This PR updates the logic which checks for layer compatibility when casting, resolving, or defining refs.

## Layer Requirements for Hardware Objects

We consider the layers which must be enabled for the hardware object to exist. This is the set of layers which are either enabled by the parent module, or required by any parent layerblocks. We call these the ambient layers of a definition. 

For example:
```firrtl
module Foo enablelayer A:
  layerblock B:
    layerblock C:
      wire w : UInt<1>
```

At the definition site of `w`, the ambient layers are  `A`, `B`, and `B.C`. We also call these the required layers of `w`, because `w` will not exist unless all these layers are enabled.

## Layer Requirements for Probe Wires

Probe wires, or wires containing probes, have not only ambient layer requirements, but also explicit layer requirements, which are written in the wire's type.

For example:
```firrtl
module Foo enablelayer A:
  layerblock B:
    wire p : Probe<UInt<1>, C>
```

The wire `p` has ambient layers `A` and `B`, as well as an explicit layer requirement on `C`.  In order for this probe to be resolved, all three layers must be active. Together, the ambient layers and explicit layers requirements of a probe are called the required layers of a probe.

 ## Layer requirements for probe expressions
 
When probing a hardware object, the resulting probe requires any ambient layers at the site of the `probe`, or `firrtl.ref.send`, expression. Dominance rules tells us this is always an improper superset (⊇) of the required layers of the probed hardware.
 
For example:
```firrtl
module Foo enablelayer A:
  wire w : UInt<1>
  layerblock B:
    layerblock C:
      node n = probe(w)
```

The probed wire `w` requires layer `A`, but the  result of  `probe(w)` requires the layers `A`, `B`, and `B.C` to be enabled, in order to be resolved.

## Layer requirements for probe definitions

When we `define` a probe, we must ensure that the effective layer requirements of the source probe are met by the destination. Put another way, we cannot throw away layer requirements.

For example, If a probe escapes a layerblock via a define, then the "ambient requirements" of that source probe must be represented in the "explicit requirements" of the destination:
```firrtl
module Foo enablelayer A:
  output o : Probe<UInt<1>, B.C>
  layerblock B:
    layerblock C:
      wire w : UInt<1>
      define o = probe(w)
```

The requirements of `probe(w)` are respected, because `o` has an ambient requirement on layer `A`, and an explicit requirement on layer `B.C`, which in turn implies a requirement on layer `B` due to layer nesting.

A `define` op is only active when its ambient layers are enabled, so we must also check that the `define` op will be active any time the destination's layer requirements are met. Effectively, the define op cannot have more layer requirements than its destination. This check prevents us from writing code such as:

```firrtl
module Foo:
  output o : Probe<UInt<1>>
  node n = UInt<1>(0)
  wire w = probe(n)
  layerblock A:
    define o = w // bad
```

## Layer requirements for reading a probe

To read a probe, the ambient layers of the read expression, or `firrtl.ref.resolve`, must meet the effective layer requirements of the input probe. 

For example, the following is valid:
```firrtl
extmodule Foo enablelayer B:
  output p : Probe<UInt<1>, A>

module Bar enablelayer A:
  inst foo of Foo
  layerblock B:
    node n = resolve(foo.p)
```
  
## Probe color conversion rules

In the FIRRTL language, probes are implicitly converted.  This is achieved in the FIRRTL IR through an explicit cast operation.

When casting a ref, the effective layer requirements of the output must at least meet the effective layer requirements of the input probe.  The cast is allowed to do the following conversions:

1. It may drop any explicit layer requirement on the input probe that is present in the ambient layers of the cast operation.  This is because the effective layer requirements remain unchanged. For example:
  ```firrtl
  module Foo enablelayer A:
    input in : Probe<UInt<1>, A>
    output out : Probe<UInt<1>>
    define out = in
  ```

2. It may add any explicit layer requirement, with no constraint.  This is because when a probe is valid, it will still be valid under additional layer requirements. For example:
  ```firrtl
  module Foo:
    input in : Probe<UInt<1>>
    output out : Probe<UInt<1>, A>
    define out = in
  ```
 
---

Note: although it is certainly possible for a probe to effectively require multiple unrelated layers, it's not actually possible to write this as an explicit probe color. E.g., the following is not possible:
```
extmodule Foo:
  output p : Probe<UInt<1>, A>
 
module Foo:
  output p : Probe<UInt<1>, {A, B}> ;; impossible.
  layerblock B:
     inst foo of Foo
     define p = foo.p
 ```
 
 ---
 
 Note, this PR attempts to verify the validity of probes without modifying the IR or requiring that the layer requirements of probes are canonicalized / expressed explicitly in the IR, which would actually break the fir emitter. As it is, an input firrtl program should round trip "just fine" through the emitter.
 

    
  
