### PR TITLE
[HW] Encode the option group name in instance choice ops

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -566,7 +566,8 @@ def InstanceChoiceOp : HWInstanceOpBase<"instance_choice", [
 
   let arguments = (ins StrAttr:$instanceName,
                        FlatSymbolRefArrayAttr:$moduleNames,
-                       StrArrayAttr:$targetNames,
+                       StrAttr:$optionName,
+                       StrArrayAttr:$caseNames,
                        Variadic<AnyType>:$inputs,
                        StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,

--- a/integration_test/EmitVerilog/instance-choice.mlir
+++ b/integration_test/EmitVerilog/instance-choice.mlir
@@ -23,7 +23,7 @@ hw.module public @top(in %clk : i1, in %rst : i1) {
   %reg = sv.reg : !hw.inout<i32>
 
   %a = sv.read_inout %reg : !hw.inout<i32>
-  %b = hw.instance_choice "inst1" sym @inst1 @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
+  %b = hw.instance_choice "inst1" sym @inst1 option "Perf" @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
 
   sv.alwaysff(posedge %clk) {
     sv.if %rst {

--- a/test/Conversion/ExportVerilog/hw-lower-instance-choices.mlir
+++ b/test/Conversion/ExportVerilog/hw-lower-instance-choices.mlir
@@ -22,7 +22,7 @@ hw.module public @top(in %a: i32, out b: i32, out d: i32) {
   // CHECK-NEXT:          }
   // CHECK-NEXT:          hw.instance_choice "inst1"
   // CHECK-SAME:          {hw.choiceTarget = @__circt_choice_top_inst1}
-  %b = hw.instance_choice "inst1" sym @inst1 @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
+  %b = hw.instance_choice "inst1" sym @inst1 option "Perf" @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
 
   // CHECK:               sv.ifdef  "__circt_choice_top_inst2" {
   // CHECK-NEXT:          } else {
@@ -30,7 +30,7 @@ hw.module public @top(in %a: i32, out b: i32, out d: i32) {
   // CHECK-NEXT:          }
   // CHECK-NEXT:          hw.instance_choice "inst2"
   // CHECK-SAME:          {hw.choiceTarget = @__circt_choice_top_inst2}
-  %c = hw.instance_choice "inst2" sym @inst2 @TargetB or @TargetA if "A" or @TargetDefault if "B"(a: %a: i32) -> (b: i32)
+  %c = hw.instance_choice "inst2" sym @inst2 option "Perf" @TargetB or @TargetA if "A" or @TargetDefault if "B"(a: %a: i32) -> (b: i32)
 
   %d = comb.add %c, %a : i32
 

--- a/test/Conversion/ExportVerilog/instance-choice.mlir
+++ b/test/Conversion/ExportVerilog/instance-choice.mlir
@@ -22,7 +22,7 @@ hw.module public @top(in %a: i32, out b: i32, out d: i32) {
   // CHECK-NEXT:    .a (a),
   // CHECK-NEXT:    .b (b)
   // CHECK-NEXT: );
-  %b = hw.instance_choice "inst1" sym @inst1 @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
+  %b = hw.instance_choice "inst1" sym @inst1 option "Perf" @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
 
   // CHECK:      `ifndef __circt_choice_top_inst2
   // CHECK-NEXT: `define __circt_choice_top_inst2 TargetDefault
@@ -32,7 +32,7 @@ hw.module public @top(in %a: i32, out b: i32, out d: i32) {
   // CHECK-NEXT:   .b (_inst2_b)
   // CHECK-NEXT: );
 
-  %c = hw.instance_choice "inst2" sym @inst2 @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
+  %c = hw.instance_choice "inst2" sym @inst2 option "Perf" @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
 
   %d = comb.add %c, %a : i32
 

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -498,6 +498,6 @@ builtin.module @Nested {
 
 hw.module @Foo () {
   // expected-error @+1 {{Cannot find module definition 'DoesNotExist'}}
-  hw.instance_choice "inst" @DoesNotExist () -> ()
+  hw.instance_choice "inst" option "foo" @DoesNotExist () -> ()
 }
 

--- a/test/Dialect/HW/round-trip.mlir
+++ b/test/Dialect/HW/round-trip.mlir
@@ -13,9 +13,9 @@ hw.module private @TargetDefault(in %a: i32, out b: i32) {
 }
 
 hw.module public @top(in %a: i32) {
-  // CHECK: hw.instance_choice "inst1" sym @inst1 @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
-  hw.instance_choice "inst1" sym @inst1 @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
-  // CHECK: hw.instance_choice "inst2" @TargetDefault(a: %a: i32) -> (b: i32)
-  hw.instance_choice "inst2" @TargetDefault(a: %a: i32) -> (b: i32)
+  // CHECK: hw.instance_choice "inst1" sym @inst1 option "bar" @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
+  hw.instance_choice "inst1" sym @inst1 option "bar" @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
+  // CHECK: hw.instance_choice "inst2" option "baz" @TargetDefault(a: %a: i32) -> (b: i32)
+  hw.instance_choice "inst2" option "baz" @TargetDefault(a: %a: i32) -> (b: i32)
 }
 

--- a/test/Dialect/HW/verify-irn.mlir
+++ b/test/Dialect/HW/verify-irn.mlir
@@ -39,5 +39,5 @@ hw.module @XMRRefD() {
   %a = sv.wire sym @a : !hw.inout<i2>
 }
 hw.module @XMRRefOp() {
-  hw.instance_choice "foo" sym @foo @XMRRefA or @XMRRefB if "B" or @XMRRefC if "C"() -> ()
+  hw.instance_choice "foo" sym @foo option "bar" @XMRRefA or @XMRRefB if "B" or @XMRRefC if "C"() -> ()
 }


### PR DESCRIPTION
Also renamed `targetNames` to `caseNames` to better match the FIRRTL-level terminology