### PR TITLE
[firtool] Add option to disable black box resource

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -217,6 +217,9 @@ MLIR_CAPI_EXPORTED void
 circtFirtoolOptionsSetStripDebugInfo(CirctFirtoolFirtoolOptions options,
                                      bool value);
 
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetDisableBlackBoxReourceFile(
+    CirctFirtoolFirtoolOptions options, bool value);
+
 //===----------------------------------------------------------------------===//
 // Populate API.
 //===----------------------------------------------------------------------===//

--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -217,7 +217,7 @@ MLIR_CAPI_EXPORTED void
 circtFirtoolOptionsSetStripDebugInfo(CirctFirtoolFirtoolOptions options,
                                      bool value);
 
-MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetDisableBlackBoxReourceFile(
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetDisableBlackBoxResourceFile(
     CirctFirtoolFirtoolOptions options, bool value);
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -120,7 +120,8 @@ std::unique_ptr<mlir::Pass> createPrintInstanceGraphPass();
 std::unique_ptr<mlir::Pass> createPrintNLATablePass();
 
 std::unique_ptr<mlir::Pass>
-createBlackBoxReaderPass(std::optional<mlir::StringRef> inputPrefix = {});
+createBlackBoxReaderPass(std::optional<mlir::StringRef> inputPrefix = {},
+                         bool disableBlackBoxResourceFile = false);
 
 enum class CompanionMode {
   // Lower companions to SystemVerilog binds.

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -427,7 +427,9 @@ def BlackBoxReader : Pass<"firrtl-blackbox-reader", "CircuitOp"> {
     Option<"inputPrefix", "input-prefix", "std::string", "",
       "Prefix for input paths in black box annotations. This should be the "
       "directory where the input file was located, to allow for annotations "
-      "relative to the input file.">
+      "relative to the input file.">,
+    Option<"disableBlackBoxResourceFile", "disable-blackbox-resource-file",
+      "bool", "false", "Disable the output of the black box resource file">
   ];
   let dependentDialects = ["sv::SVDialect", "hw::HWDialect"];
 }

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -129,6 +129,9 @@ public:
   }
   bool shouldExtractTestCode() const { return extractTestCode; }
   bool shouldFixupEICGWrapper() const { return fixupEICGWrapper; }
+  bool shouldDisableBlackBoxResourceFile() const {
+    return disableBlackBoxResourceFile;
+  }
 
   // Setters, used by the CAPI
   FirtoolOptions &setOutputFilename(StringRef name) {
@@ -349,6 +352,11 @@ public:
     return *this;
   }
 
+  FirtoolOptions &setDisableBlackBoxResourceFile(bool value) {
+    disableBlackBoxResourceFile = value;
+    return *this;
+  }
+
 private:
   std::string outputFilename;
   bool disableAnnotationsUnknown;
@@ -394,6 +402,7 @@ private:
   bool stripFirDebugInfo;
   bool stripDebugInfo;
   bool fixupEICGWrapper;
+  bool disableBlackBoxResourceFile;
 };
 
 void registerFirtoolCLOptions();

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -323,7 +323,7 @@ void circtFirtoolOptionsSetStripDebugInfo(CirctFirtoolFirtoolOptions options,
   unwrap(options)->setStripDebugInfo(value);
 }
 
-void circtFirtoolOptionsSetDisableBlackBoxReourceFile(
+void circtFirtoolOptionsSetDisableBlackBoxResourceFile(
     CirctFirtoolFirtoolOptions options, bool value) {
   unwrap(options)->setDisableBlackBoxResourceFile(value);
 }

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -323,6 +323,11 @@ void circtFirtoolOptionsSetStripDebugInfo(CirctFirtoolFirtoolOptions options,
   unwrap(options)->setStripDebugInfo(value);
 }
 
+void circtFirtoolOptionsSetDisableBlackBoxReourceFile(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setDisableBlackBoxResourceFile(value);
+}
+
 //===----------------------------------------------------------------------===//
 // Populate API.
 //===----------------------------------------------------------------------===//

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -183,8 +183,8 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   StringRef blackBoxRoot = opt.getBlackBoxRootPath().empty()
                                ? llvm::sys::path::parent_path(inputFilename)
                                : opt.getBlackBoxRootPath();
-  pm.nest<firrtl::CircuitOp>().addPass(
-      firrtl::createBlackBoxReaderPass(blackBoxRoot));
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createBlackBoxReaderPass(
+      blackBoxRoot, opt.shouldDisableBlackBoxResourceFile()));
 
   // Run SymbolDCE as late as possible, but before InnerSymbolDCE. This is for
   // hierpathop's and just for general cleanup.
@@ -614,6 +614,11 @@ struct FirtoolCmdOptions {
           "address conflict behavivor of combinational memories"),
       llvm::cl::init(false)};
 
+  llvm::cl::opt<bool> disableBlackBoxResourceFile{
+      "disable-blackbox-resource-file",
+      llvm::cl::desc("Disable the output of the black box resource file"),
+      llvm::cl::init(false)};
+
   //===----------------------------------------------------------------------===
   // External Clock Gate Options
   //===----------------------------------------------------------------------===
@@ -694,7 +699,8 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       ckgModuleName("EICG_wrapper"), ckgInputName("in"), ckgOutputName("out"),
       ckgEnableName("en"), ckgTestEnableName("test_en"), ckgInstName("ckg"),
       exportModuleHierarchy(false), stripFirDebugInfo(true),
-      stripDebugInfo(false), fixupEICGWrapper(false) {
+      stripDebugInfo(false), fixupEICGWrapper(false),
+      disableBlackBoxResourceFile(false) {
   if (!clOptions.isConstructed())
     return;
   outputFilename = clOptions->outputFilename;
@@ -742,4 +748,5 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   stripFirDebugInfo = clOptions->stripFirDebugInfo;
   stripDebugInfo = clOptions->stripDebugInfo;
   fixupEICGWrapper = clOptions->fixupEICGWrapper;
+  disableBlackBoxResourceFile = clOptions->disableBlackBoxResourceFile;
 }

--- a/test/firtool/disable-blackbox-resource.fir
+++ b/test/firtool/disable-blackbox-resource.fir
@@ -1,0 +1,42 @@
+; RUN: firtool %s | FileCheck --check-prefix=RESOURCE_FILE %s
+; RUN: firtool --disable-blackbox-resource-file %s | FileCheck --check-prefix=NO_RESOURCE_FILE %s
+FIRRTL version 3.3.0
+circuit BlackBar :%[[
+  {
+    "class":"firrtl.transforms.DedupGroupAnnotation",
+    "target":"~BlackBar|BlackFoo",
+    "group":"BlackFoo"
+  },
+  {
+    "class":"firrtl.transforms.DedupGroupAnnotation",
+    "target":"~BlackBar|BlackBar",
+    "group":"BlackBar"
+  },
+  {
+    "class":"firrtl.transforms.BlackBoxInlineAnno",
+    "target":"BlackBar.BlackFoo",
+    "name":"BlackFoo.v",
+    "text":"module BlackFoo (\n    input a,\n    output b\n  );\n\n  assign b = ~a;\n\nendmodule\n"
+  }
+]]
+  extmodule BlackFoo :
+    input a : UInt<1>
+    output b : UInt<1>
+    defname = BlackFoo
+
+  module BlackBar :
+    input clock : Clock
+    input reset : UInt<1>
+    output io : { flip a : UInt<1>, b : UInt<1>}
+
+    inst foo of BlackFoo
+    connect foo.a, io.a
+    connect io.b, foo.b
+
+; RESOURCE_FILE: BlackFoo.v
+; RESOURCE_FILE: firrtl_black_box_resource_files.f
+; RESOURCE_FILE-EMPTY:
+; RESOURCE_FILE-NEXT: BlackFoo.v
+
+; NO_RESOURCE_FILE: BlackFoo.v
+; NO_RESOURCE_FILE-NOT: firrtl_black_box_resource_files.f


### PR DESCRIPTION
Add the `--disable-blackbox-resource-file` option to firtool and the BlackBoxReaderPass.

Fix #4249, #2266 and #6600. Another way to resolve it is adding an optional output filename for this file, but this would break the uniformity of the behavior when split-verilog is turn on or off.

Note that this option also works for targets other than verilog/systemverilog.

This switch does not affect the workflows that exists.