### PR TITLE
chisel_{assert,assume,cover} intrinsics.

### DIFF
--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -254,4 +254,30 @@ firrtl.circuit "Foo" {
     firrtl.strictconnect %ckg_test_en, %en : !firrtl.uint<1>
     firrtl.strictconnect %ckg_en, %en : !firrtl.uint<1>
   }
+
+  // CHECK-NOT: CirctAssert1
+  // CHECK-NOT: CirctAssert2
+  // CHECK-NOT: VerifAssume
+  // CHECK-NOT: VerifCover
+// TODO: 
+  // firrtl.intmodule @CirctAssert1() attributes {intrinsic = "circt.assert"}
+//  firrtl.intmodule @VerifAssert2<label: none = "hello">(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.assert"}
+//  firrtl.intmodule @VerifAssume(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.assume"}
+//  firrtl.intmodule @VerifCover(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.cover"}
+
+  // CHECK: firrtl.module @ChiselVerif()
+  firrtl.module @ChiselVerif() {
+    // COM: // CHECK-NOT: VerifAssert1
+    // COM: // CHECK-NOT: VerifAssert2
+    // COM: // CHECK-NOT: VerifAssume
+    // COM: // CHECK-NOT: VerifCover
+    // COM: // CHECK: firrtl.int.verif.assert {{%.+}} :
+    // COM: // CHECK: firrtl.int.verif.assert {{%.+}} {label = "hello"} :
+    // COM: // CHECK: firrtl.int.verif.assume {{%.+}} :
+    // COM: // CHECK: firrtl.int.verif.cover {{%.+}} :
+    %assert1.property = firrtl.instance "assert1" @VerifAssert1(in property: !firrtl.uint<1>)
+    %assert2.property = firrtl.instance "assert2" @VerifAssert2(in property: !firrtl.uint<1>)
+    %assume.property = firrtl.instance "assume" @VerifAssume(in property: !firrtl.uint<1>)
+    %cover.property = firrtl.instance "cover" @VerifCover(in property: !firrtl.uint<1>)
+  }
 }

--- a/test/firtool/chisel_assert.fir
+++ b/test/firtool/chisel_assert.fir
@@ -1,0 +1,79 @@
+; RUN: firtool %s | FileCheck %s
+
+FIRRTL version 4.0.0
+
+circuit ChiselVerif:
+  intmodule Assert:
+    input clock: Clock
+    input predicate: UInt<1>
+    input enable: UInt<1>
+    intrinsic = circt_chisel_assert
+    parameter format = "testing"
+
+  intmodule AssertFormat:
+    input clock: Clock
+    input predicate: UInt<1>
+    input enable: UInt<1>
+    input val: UInt<1>
+    intrinsic = circt_chisel_assert
+    parameter format = "message: %d"
+    parameter label = "label for assert with format string"
+    parameter guards = "MACRO_GUARD;ASDF"
+
+  intmodule Assume:
+    input clock: Clock
+    input predicate: UInt<1>
+    input enable: UInt<1>
+    input val: UInt<1>
+    intrinsic = circt_chisel_assume
+    parameter format = "text: %d"
+    parameter label = "label for assume"
+
+  intmodule CoverLabel:
+    input clock: Clock
+    input predicate: UInt<1>
+    input enable: UInt<1>
+    intrinsic = circt_chisel_cover
+    parameter label = "label for cover"
+
+  ; CHECK: module ChiselVerif
+  module ChiselVerif:
+    input clock: Clock
+    input cond: UInt<1>
+    input enable: UInt<1>
+
+    ; CHECK: assert property
+    ; CHECk-SAME: "testing"
+    inst assert of Assert
+    connect assert.clock, clock
+    connect assert.predicate, cond
+    connect assert.enable, enable
+
+    ; CHECK: `ifdef MACRO_GUARD
+    ; CHECK-NEXT: `ifdef ASDF
+    ; CHECK: label_for_assert_with_format_string
+    ; CHECK: assert property
+    ; CHECK: "message: %d"
+    ; CHECK: $sampled(cond)
+    inst assertFormat of AssertFormat
+    connect assertFormat.clock, clock
+    connect assertFormat.predicate, cond
+    connect assertFormat.enable, enable
+    connect assertFormat.val, cond
+
+    ; CHECK: label_for_assume
+    ; CHECK: assume property
+    ; CHECK: "text: %d"
+    ; CHECK: $sampled(enable)
+    inst assume of Assume
+    connect assume.clock, clock
+    connect assume.predicate, cond
+    connect assume.enable, enable
+    connect assume.val, enable
+
+    ; CHECK: label_for_cover
+    ; CHECK: cover property
+    inst cover of CoverLabel
+    connect cover.clock, clock
+    connect cover.predicate, cond
+    connect cover.enable, enable


### PR DESCRIPTION
Compare to assert/assume/cover ops,
these allow specifying labels that are more than identifiers and optional compilation guards (for now).