### PR TITLE
Allow propassign under layerblocks

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -278,8 +278,8 @@ def MatchOp : FIRRTLOp<"match", [SingleBlock, NoTerminator,
   }];
 }
 
-def PropAssignOp : FIRRTLOp<"propassign",
-  [FConnectLike, SameTypeOperands, ParentOneOf<["FModuleOp", "ClassOp"]>]> {
+def PropAssignOp : FIRRTLOp<"propassign", [FConnectLike, SameTypeOperands,
+    ParentOneOf<["FModuleOp", "ClassOp", "LayerBlockOp"]>]> {
   let summary = "Assign to a sink property value.";
   let description = [{
     Assign an output property value. The types must match exactly.

--- a/test/Dialect/FIRRTL/layers.mlir
+++ b/test/Dialect/FIRRTL/layers.mlir
@@ -187,4 +187,18 @@ firrtl.circuit "Test" {
       firrtl.ref.define %0, %2 : !firrtl.probe<uint<1>, @A>
     }
   }
+
+  //===--------------------------------------------------------------------===//
+  // Properties Under Layers
+  //===--------------------------------------------------------------------===//
+
+  firrtl.extmodule @WithInputProp(in i : !firrtl.string)
+
+  firrtl.module @InstWithInputPropUnderLayerBlock() {
+    firrtl.layerblock @A {
+      %foo_in = firrtl.instance foo @WithInputProp(in i : !firrtl.string)
+      %str = firrtl.string "whatever"
+      firrtl.propassign %foo_in, %str : !firrtl.string
+    }
+  }
 }


### PR DESCRIPTION
Allow propassign ops to appear under layerblocks, but explicitly do not allow properties to be captured under, or escape out of, a layerblock.