### PR TITLE
Track instance layers

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -62,6 +62,7 @@ def InstanceOp : HardwareDeclOp<"instance", [
                        APIntAttr:$portDirections, StrArrayAttr:$portNames,
                        AnnotationArrayAttr:$annotations,
                        PortAnnotationsAttr:$portAnnotations,
+                       LayerArrayAttr:$layers,
                        UnitAttr:$lowerToBind,
                        OptionalAttr<InnerSymAttr>:$inner_sym);
 
@@ -78,6 +79,7 @@ def InstanceOp : HardwareDeclOp<"instance", [
                    "::mlir::ArrayRef<Attribute>":$portNames,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
                    CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
+                   CArg<"::mlir::ArrayRef<Attribute>", "{}">:$layers,
                    CArg<"bool","false">:$lowerToBind,
                    CArg<"StringAttr", "StringAttr()">:$innerSym)>,
     OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
@@ -88,6 +90,7 @@ def InstanceOp : HardwareDeclOp<"instance", [
                    "::mlir::ArrayRef<Attribute>":$portNames,
                    "ArrayRef<Attribute>":$annotations,
                    "ArrayRef<Attribute>":$portAnnotations,
+                   "::mlir::ArrayRef<Attribute>":$layers,
                    "bool":$lowerToBind,
                    "hw::InnerSymAttr":$innerSym)>,
 
@@ -106,9 +109,9 @@ def InstanceOp : HardwareDeclOp<"instance", [
                    "mlir::StringRef":$name,
                    CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                    CArg<"ArrayRef<Attribute>", "{}">:$annotations,
+                   CArg<"ArrayRef<Attribute>", "{}">:$layers,
                    CArg<"bool","false">:$lowerToBind,
                    CArg<"hw::InnerSymAttr", "hw::InnerSymAttr()">:$innerSym)>
-
   ];
 
   let extraClassDeclaration = [{
@@ -159,6 +162,8 @@ def InstanceOp : HardwareDeclOp<"instance", [
     //===------------------------------------------------------------------===//
     SmallVector<::circt::hw::PortInfo> getPortList();
   }];
+
+  let hasVerifier = true;
 }
 
 def InstanceChoiceOp : HardwareDeclOp<"instance_choice", [
@@ -186,6 +191,7 @@ def InstanceChoiceOp : HardwareDeclOp<"instance_choice", [
                        APIntAttr:$portDirections, StrArrayAttr:$portNames,
                        AnnotationArrayAttr:$annotations,
                        PortAnnotationsAttr:$portAnnotations,
+                       LayerArrayAttr:$layers,
                        OptionalAttr<InnerSymAttr>:$inner_sym);
 
   let results = (outs Variadic<AnyType>:$results);

--- a/lib/Dialect/FIRRTL/FIRRTLInstanceImplementation.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLInstanceImplementation.cpp
@@ -133,5 +133,13 @@ instance_like_impl::verifyReferencedModule(Operation *instanceOp,
     llvm_unreachable("should have found something wrong");
   }
 
+  // Check that the instance op lists the correct layer requirements.
+  auto instanceLayers = instanceOp->getAttrOfType<ArrayAttr>("layers");
+  auto moduleLayers = referencedModule.getLayersAttr();
+  if (instanceLayers != moduleLayers)
+    return emitNote(instanceOp->emitOpError()
+                    << "layers must be " << moduleLayers << ", but got "
+                    << instanceLayers);
+
   return success();
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -477,7 +477,8 @@ InstanceOp LowerMemoryPass::emitMemoryInstance(MemOp op, FModuleOp module,
       op.getLoc(), portTypes, module.getNameAttr(), summary.getFirMemoryName(),
       op.getNameKind(), portDirections, portNames,
       /*annotations=*/ArrayRef<Attribute>(),
-      /*portAnnotations=*/ArrayRef<Attribute>(), /*lowerToBind=*/false,
+      /*portAnnotations=*/ArrayRef<Attribute>(),
+      /*layers=*/ArrayRef<Attribute>(), /*lowerToBind=*/false,
       op.getInnerSymAttr());
 
   // Update all users of the result of read ports

--- a/lib/Dialect/FIRRTL/Transforms/LowerSignatures.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerSignatures.cpp
@@ -407,7 +407,8 @@ static void lowerModuleBody(FModuleOp mod,
     auto annos = inst.getAnnotations();
     auto newOp = theBuilder.create<InstanceOp>(
         instPorts, inst.getModuleName(), inst.getName(), inst.getNameKind(),
-        annos.getValue(), inst.getLowerToBind(), inst.getInnerSymAttr());
+        annos.getValue(), inst.getLayers(), inst.getLowerToBind(),
+        inst.getInnerSymAttr());
 
     auto oldDict = inst->getDiscardableAttrDictionary();
     auto newDict = newOp->getDiscardableAttrDictionary();

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1466,7 +1466,8 @@ bool TypeLoweringVisitor::visitDecl(InstanceOp op) {
       resultTypes, op.getModuleNameAttr(), op.getNameAttr(),
       op.getNameKindAttr(), direction::packAttribute(context, newDirs),
       builder->getArrayAttr(newNames), op.getAnnotations(),
-      builder->getArrayAttr(newPortAnno), op.getLowerToBindAttr(),
+      builder->getArrayAttr(newPortAnno), op.getLayersAttr(),
+      op.getLowerToBindAttr(),
       sym ? hw::InnerSymAttr::get(sym) : hw::InnerSymAttr());
 
   // Copy over any attributes which have not already been copied over by

--- a/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
@@ -72,7 +72,7 @@ struct SpecializeOptionPass
                 inst.getNameAttr(), inst.getNameKindAttr(),
                 inst.getPortDirectionsAttr(), inst.getPortNamesAttr(),
                 inst.getAnnotationsAttr(), inst.getPortAnnotationsAttr(),
-                UnitAttr{}, inst.getInnerSymAttr());
+                builder.getArrayAttr({}), UnitAttr{}, inst.getInnerSymAttr());
             inst.replaceAllUsesWith(newInst);
             inst.erase();
 

--- a/test/Dialect/FIRRTL/layers-errors.mlir
+++ b/test/Dialect/FIRRTL/layers-errors.mlir
@@ -101,3 +101,33 @@ firrtl.circuit "Top" {
     }
   }
 }
+
+// -----
+
+firrtl.circuit "Top" {
+  firrtl.layer @A bind {}
+  firrtl.module @Foo() attributes {layers = [@A]} {}
+  firrtl.module @Top() {
+    // expected-error @below {{'firrtl.instance' op ambient layers are insufficient to instantiate module}}
+    // expected-note  @below {{missing layer requirements: @A}}
+    firrtl.instance foo {layers = [@A]} @Foo()
+  }
+}
+
+// -----
+
+firrtl.circuit "Top" {
+  firrtl.layer @A bind {}
+  firrtl.option @O {
+    firrtl.option_case @C1
+  }
+  firrtl.module @Foo() attributes {layers = [@A]} {}
+  firrtl.module @Bar() attributes {layers = [@A]} {}
+  firrtl.module @Top() {
+    // expected-error @below {{'firrtl.instance_choice' op ambient layers are insufficient to instantiate module}}
+    // expected-note  @below {{missing layer requirements: @A}}
+    firrtl.instance_choice foo {layers = [@A]} @Foo alternatives @O {
+      @C1 -> @Bar
+    } ()
+  }
+}

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1928,3 +1928,9 @@ circuit LayerEnabledModule:
   ; CHECK: firrtl.module @LayerEnabledModule
   ; CHECK-SAME: layers = [@A, @B::@C]
   module LayerEnabledModule enablelayer A enablelayer B.C:
+
+  ; CHECK: firrtl.module private @UserOfLayerEnabledModule
+  ; CHECK-SAME: layers = [@A, @B::@C]
+  module UserOfLayerEnabledModule enablelayer A enablelayer B.C:
+    ; CHECK: firrtl.instance i interesting_name {layers = [@A, @B::@C]} @LayerEnabledModule()
+    inst i of LayerEnabledModule


### PR DESCRIPTION
The enabled layers of a module act as requirements on the instance op--the module may only be instantiated where the enabled layer set is in the ambient layer set.

This PR adds verification for this rule.

Changes:
- Start tracking the required layers on instance ops.
- Verify the ambient layers of instance ops.
- Verify that the layers attribute on instance ops agrees with the referenced module.
- Update places where we create instance ops to pass the layers.