### PR TITLE
[FIRRTL] chisel_{assert_assume,assume,cover,ifelsefatal} intrinsics.

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
+++ b/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
@@ -94,3 +94,108 @@ The enable input is sampled at the rising edge of the input clock; any changes o
 | in   | input     | Clock    | input clock                 |
 | en   | input     | UInt<1>  | enable for the output clock |
 | out  | output    | Clock    | gated output clock          |
+
+### circt.chisel_assert_assume
+
+Generate a clocked SV assertion with companion assume statement.
+
+Has legacy special behavior and should not be used by new code.
+
+| Parameter | Type   | Description                                                                         |
+| --------- | ------ | ----------------------------------------------------------------------------------- |
+| format    | string | Format string per SV 20.10, 21.2.1                                                  |
+| label     | string | Label for assert/assume.  Optional.                                                 |
+| guards    | string | Semicolon-delimited list of pre-processor tokens to use as ifdef guards.  Optional. |
+
+| Port      | Direction | Type     | Description                 |
+| --------- | --------- | -------- | --------------------------- |
+| clock     | input     | Clock    | input clock                 |
+| predicate | input     | UInt<1>  | predicate to assert/assume  |
+| enable    | input     | UInt<1>  | enable signal               |
+| ...       | input     | Signals  | arguments to format string  |
+
+Example output:
+```systemverilog
+wire _GEN = ~enable | cond;
+assert__label: assert property (@(posedge clock) _GEN) else $error("message");
+`ifdef USE_PROPERTY_AS_CONSTRAINT
+  assume__label: assume property (@(posedge clock) _GEN);
+`endif // USE_PROPERTY_AS_CONSTRAINT
+```
+
+### circt.chisel_ifelsefatal
+
+Generate a particular Verilog sequence that's similar to an assertion.
+
+Has legacy special behavior and should not be used by new code.
+
+| Parameter | Type   | Description                        |
+| --------- | ------ | ---------------------------------- |
+| format    | string | Format string per SV 20.10, 21.2.1 |
+
+This intrinsic also accepts the `label` and `guard` parameters which
+are recorded but not used in the normal emission.
+
+| Port      | Direction | Type     | Description                 |
+| --------- | --------- | -------- | --------------------------- |
+| clock     | input     | Clock    | input clock                 |
+| predicate | input     | UInt<1>  | predicate to check          |
+| enable    | input     | UInt<1>  | enable signal               |
+| ...       | input     | Signals  | arguments to format string  |
+
+Example SV output:
+```systemverilog
+`ifndef SYNTHESIS
+  always @(posedge clock) begin
+    if (enable & ~cond) begin
+      if (`ASSERT_VERBOSE_COND_)
+        $error("message");
+      if (`STOP_COND_)
+        $fatal;
+    end
+  end // always @(posedge)
+`endif // not def SYNTHESIS
+```
+
+### circt.chisel_assume
+
+Generate a clocked SV assume statement, with optional error message.
+
+
+| Parameter | Type   | Description                                                                         |
+| --------- | ------ | ----------------------------------------------------------------------------------- |
+| format    | string | Format string per SV 20.10, 21.2.1                                                  |
+| label     | string | Label for statement.  Optional.                                                     |
+| guards    | string | Semicolon-delimited list of pre-processor tokens to use as ifdef guards.  Optional. |
+
+| Port      | Direction | Type     | Description                 |
+| --------- | --------- | -------- | --------------------------- |
+| clock     | input     | Clock    | input clock                 |
+| predicate | input     | UInt<1>  | predicate to assert/assume  |
+| enable    | input     | UInt<1>  | enable signal               |
+| ...       | input     | Signals  | arguments to format string  |
+
+Example SV output:
+```systemverilog
+assume__label: assume property (@(posedge clock) ~enable | cond) else $error("message");	
+```
+
+### circt.chisel_cover
+
+Generate a clocked SV cover statement.
+
+| Parameter | Type   | Description                                                             |
+| --------- | ------ | ----------------------------------------------------------------------- |
+| label     | string | Label for assertion                                                     |
+| guards    | string | Semicolon-delimited list of pre-processor tokens to use as ifdef guards |
+
+| Port      | Direction | Type     | Description                 |
+| --------- | --------- | -------- | --------------------------- |
+| clock     | input     | Clock    | input clock                 |
+| predicate | input     | UInt<1>  | predicate to assert/assume  |
+| enable    | input     | UInt<1>  | enable signal               |
+
+Example SV output:
+```systemverilog
+cover__label: cover property (@(posedge clock) enable & cond);
+```

--- a/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
+++ b/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
@@ -103,16 +103,16 @@ Has legacy special behavior and should not be used by new code.
 
 | Parameter | Type   | Description                                                                         |
 | --------- | ------ | ----------------------------------------------------------------------------------- |
-| format    | string | Format string per SV 20.10, 21.2.1                                                  |
+| format    | string | Format string per SV 20.10, 21.2.1.  Optional.                                      |
 | label     | string | Label for assert/assume.  Optional.                                                 |
 | guards    | string | Semicolon-delimited list of pre-processor tokens to use as ifdef guards.  Optional. |
 
-| Port      | Direction | Type     | Description                 |
-| --------- | --------- | -------- | --------------------------- |
-| clock     | input     | Clock    | input clock                 |
-| predicate | input     | UInt<1>  | predicate to assert/assume  |
-| enable    | input     | UInt<1>  | enable signal               |
-| ...       | input     | Signals  | arguments to format string  |
+| Port      | Direction | Type     | Description                |
+| --------- | --------- | -------- | -------------------------- |
+| clock     | input     | Clock    | input clock                |
+| predicate | input     | UInt<1>  | predicate to assert/assume |
+| enable    | input     | UInt<1>  | enable signal              |
+| ...       | input     | Signals  | arguments to format string |
 
 Example output:
 ```systemverilog
@@ -165,15 +165,15 @@ Generate a clocked SV assume statement, with optional formatted error message.
 | Parameter | Type   | Description                                                                         |
 | --------- | ------ | ----------------------------------------------------------------------------------- |
 | format    | string | Format string per SV 20.10, 21.2.1.  Optional.                                      |
-| label     | string | Label for statement.  Optional.                                                     |
+| label     | string | Label for assume statement.  Optional.                                              |
 | guards    | string | Semicolon-delimited list of pre-processor tokens to use as ifdef guards.  Optional. |
 
-| Port      | Direction | Type     | Description                 |
-| --------- | --------- | -------- | --------------------------- |
-| clock     | input     | Clock    | input clock                 |
-| predicate | input     | UInt<1>  | predicate to assert/assume  |
-| enable    | input     | UInt<1>  | enable signal               |
-| ...       | input     | Signals  | arguments to format string  |
+| Port      | Direction | Type     | Description                |
+| --------- | --------- | -------- | -------------------------- |
+| clock     | input     | Clock    | input clock                |
+| predicate | input     | UInt<1>  | predicate to assume        |
+| enable    | input     | UInt<1>  | enable signal              |
+| ...       | input     | Signals  | arguments to format string |
 
 Example SV output:
 ```systemverilog
@@ -184,16 +184,16 @@ assume__label: assume property (@(posedge clock) ~enable | cond) else $error("me
 
 Generate a clocked SV cover statement.
 
-| Parameter | Type   | Description                                                             |
-| --------- | ------ | ----------------------------------------------------------------------- |
-| label     | string | Label for assertion                                                     |
-| guards    | string | Semicolon-delimited list of pre-processor tokens to use as ifdef guards |
+| Parameter | Type   | Description                                                                         |
+| --------- | ------ | ----------------------------------------------------------------------------------- |
+| label     | string | Label for cover statement.  Optional.                                               |
+| guards    | string | Semicolon-delimited list of pre-processor tokens to use as ifdef guards.  Optional. |
 
-| Port      | Direction | Type     | Description                 |
-| --------- | --------- | -------- | --------------------------- |
-| clock     | input     | Clock    | input clock                 |
-| predicate | input     | UInt<1>  | predicate to assert/assume  |
-| enable    | input     | UInt<1>  | enable signal               |
+| Port      | Direction | Type     | Description        |
+| --------- | --------- | -------- | ------------------ |
+| clock     | input     | Clock    | input clock        |
+| predicate | input     | UInt<1>  | predicate to cover |
+| enable    | input     | UInt<1>  | enable signal      |
 
 Example SV output:
 ```systemverilog

--- a/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
+++ b/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
@@ -129,9 +129,9 @@ Generate a particular Verilog sequence that's similar to an assertion.
 
 Has legacy special behavior and should not be used by new code.
 
-| Parameter | Type   | Description                        |
-| --------- | ------ | ---------------------------------- |
-| format    | string | Format string per SV 20.10, 21.2.1 |
+| Parameter | Type   | Description                                    |
+| --------- | ------ | ---------------------------------------------- |
+| format    | string | Format string per SV 20.10, 21.2.1.  Optional. |
 
 This intrinsic also accepts the `label` and `guard` parameters which
 are recorded but not used in the normal emission.
@@ -159,12 +159,12 @@ Example SV output:
 
 ### circt.chisel_assume
 
-Generate a clocked SV assume statement, with optional error message.
+Generate a clocked SV assume statement, with optional formatted error message.
 
 
 | Parameter | Type   | Description                                                                         |
 | --------- | ------ | ----------------------------------------------------------------------------------- |
-| format    | string | Format string per SV 20.10, 21.2.1                                                  |
+| format    | string | Format string per SV 20.10, 21.2.1.  Optional.                                      |
 | label     | string | Label for statement.  Optional.                                                     |
 | guards    | string | Semicolon-delimited list of pre-processor tokens to use as ifdef guards.  Optional. |
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -539,11 +539,9 @@ static ParseResult allInputs(ArrayRef<PortInfo> ports) {
 
 // Get parameter by the given name.  Null if not found.
 static ParamDeclAttr getNamedParam(ArrayAttr params, StringRef name) {
-  for (auto a : params) {
-    auto param = cast<ParamDeclAttr>(a);
+  for (auto param : params.getAsRange<ParamDeclAttr>())
     if (param.getName().getValue().equals(name))
       return param;
-  }
   return {};
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -518,6 +518,132 @@ public:
 
 } // namespace
 
+// Replace range of values with new wires and return them.
+template <typename R>
+static SmallVector<Value> replaceResults(OpBuilder &b, R &&range) {
+  return llvm::map_to_vector(range, [&b](auto v) {
+    auto w = b.create<WireOp>(v.getLoc(), v.getType()).getResult();
+    v.replaceAllUsesWith(w);
+    return w;
+  });
+}
+
+// Check ports are all inputs, emit diagnostic if not.
+static ParseResult allInputs(ArrayRef<PortInfo> ports) {
+  for (auto &p : ports) {
+    if (p.direction != Direction::In)
+      return mlir::emitError(p.loc, "expected input port");
+  }
+  return success();
+}
+
+// Get parameter by the given name.  Null if not found.
+static ParamDeclAttr getNamedParam(ArrayAttr params, StringRef name) {
+  for (auto a : params) {
+    auto param = cast<ParamDeclAttr>(a);
+    if (param.getName().getValue().equals(name))
+      return param;
+  }
+  return {};
+}
+
+namespace {
+
+template <class OpTy, bool ifElseFatal = false>
+class CirctAssertAssumeConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+
+  bool check() override {
+    return namedPort(0, "clock") || typedPort<ClockType>(0) ||
+           namedPort(1, "predicate") || sizedPort<UIntType>(1, 1) ||
+           namedPort(2, "enable") || sizedPort<UIntType>(2, 1) ||
+           namedParam("format") || namedParam("label", /*optional=*/true) ||
+           namedParam("guards", /*optional=*/true) || allInputs(mod.getPorts());
+    // TODO: Check all parameters accounted for.
+  }
+
+  void convert(InstanceOp inst) override {
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto params = mod.getParameters();
+    auto format = getNamedParam(params, "format");
+    assert(format && "format parameter not found");
+    auto label = getNamedParam(params, "label");
+    auto guards = getNamedParam(params, "guards");
+
+    auto wires = replaceResults(builder, inst.getResults());
+
+    auto clock = wires[0];
+    auto predicate = wires[1];
+    auto enable = wires[2];
+
+    auto substitutions = ArrayRef(wires).drop_front(3);
+    auto name = label ? cast<StringAttr>(label.getValue()).strref() : "";
+
+    auto op = builder.template create<OpTy>(
+        clock, predicate, enable, cast<StringAttr>(format.getValue()),
+        substitutions, name, /*isConcurrent=*/true);
+    if (guards) {
+      SmallVector<StringRef> guardStrings;
+      cast<StringAttr>(guards.getValue()).strref().split(guardStrings, ';');
+      // TODO: Legalize / sanity-check?
+      op->setAttr("guards", builder.getStrArrayAttr(guardStrings));
+    }
+
+    if constexpr (ifElseFatal)
+      op->setAttr("format", builder.getStringAttr("ifElseFatal"));
+
+    inst.erase();
+  }
+
+private:
+};
+
+class CirctCoverConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+
+  bool check() override {
+    return namedPort(0, "clock") || typedPort<ClockType>(0) ||
+           namedPort(1, "predicate") || sizedPort<UIntType>(1, 1) ||
+           namedPort(2, "enable") || sizedPort<UIntType>(2, 1) ||
+           hasNPorts(3) || allInputs(mod.getPorts()) ||
+           namedParam("label", /*optional=*/true) ||
+           namedParam("guards", /*optional=*/true);
+    // TODO: Check all parameters accounted for.
+  }
+
+  void convert(InstanceOp inst) override {
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto params = mod.getParameters();
+    auto label = getNamedParam(params, "label");
+    auto guards = getNamedParam(params, "guards");
+
+    auto wires = replaceResults(builder, inst.getResults());
+
+    auto clock = wires[0];
+    auto predicate = wires[1];
+    auto enable = wires[2];
+
+    auto name = label ? cast<StringAttr>(label.getValue()).strref() : "";
+
+    // Empty message string for cover, only 'name' / label.
+    auto op = builder.create<CoverOp>(clock, predicate, enable,
+                                      builder.getStringAttr(""), ValueRange{},
+                                      name, /*isConcurrent=*/true);
+    if (guards) {
+      SmallVector<StringRef> guardStrings;
+      cast<StringAttr>(guards.getValue()).strref().split(guardStrings, ';');
+      // TODO: Legalize / sanity-check?
+      op->setAttr("guards", builder.getStrArrayAttr(guardStrings));
+    }
+
+    inst.erase();
+  }
+};
+
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // Pass Infrastructure
 //===----------------------------------------------------------------------===//
@@ -565,6 +691,13 @@ void LowerIntrinsicsPass::runOnOperation() {
   lowering.add<CirctHasBeenResetConverter>("circt.has_been_reset",
                                            "circt_has_been_reset");
   lowering.add<CirctProbeConverter>("circt.fpga_probe", "circt_fpga_probe");
+  lowering.add<CirctAssertAssumeConverter<AssertOp>>(
+      "circt.chisel_assert_assume", "circt_chisel_assert_assume");
+  lowering.add<CirctAssertAssumeConverter<AssertOp, /*ifElseFatal=*/true>>(
+      "circt.chisel_ifelsefatal", "circt_chisel_ifelsefatal");
+  lowering.add<CirctAssertAssumeConverter<AssumeOp>>("circt.chisel_assume",
+                                                     "circt_chisel_assume");
+  lowering.add<CirctCoverConverter>("circt.chisel_cover", "circt_chisel_cover");
 
   // Remove this once `EICG_wrapper` is no longer special-cased by firtool.
   if (fixupEICGWrapper)

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -260,24 +260,89 @@ firrtl.circuit "Foo" {
   // CHECK-NOT: VerifAssume
   // CHECK-NOT: VerifCover
 // TODO: 
-  // firrtl.intmodule @CirctAssert1() attributes {intrinsic = "circt.assert"}
-//  firrtl.intmodule @VerifAssert2<label: none = "hello">(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.assert"}
-//  firrtl.intmodule @VerifAssume(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.assume"}
-//  firrtl.intmodule @VerifCover(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.cover"}
+  firrtl.intmodule private @AssertAssume<format: none = "testing">(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>) attributes {intrinsic = "circt.chisel_assert_assume"}
+  firrtl.intmodule private @AssertAssumeFormat<format: none = "message: %d",
+                                               label: none = "label for assert with format string",
+                                               guards: none = "MACRO_GUARD;ASDF">(
+                                                 in clock: !firrtl.clock,
+                                                 in predicate: !firrtl.uint<1>,
+                                                 in enable: !firrtl.uint<1>,
+                                                 in val: !firrtl.uint<1>
+                                               ) attributes {intrinsic = "circt.chisel_assert_assume"}
+  firrtl.intmodule private @IfElseFatalFormat<format: none = "ief: %d",
+                                              label: none = "label for ifelsefatal assert",
+                                              guards: none = "MACRO_GUARD;ASDF">(
+                                                in clock: !firrtl.clock,
+                                                in predicate: !firrtl.uint<1>,
+                                                in enable: !firrtl.uint<1>,
+                                                in val: !firrtl.uint<1>
+                                              ) attributes {intrinsic = "circt.chisel_ifelsefatal"}
+  firrtl.intmodule private @Assume<format: none = "text: %d",
+                                   label: none = "label for assume">(
+                                     in clock: !firrtl.clock,
+                                     in predicate: !firrtl.uint<1>,
+                                     in enable: !firrtl.uint<1>,
+                                     in val: !firrtl.uint<1>
+                                   ) attributes {intrinsic = "circt.chisel_assume"}
+  firrtl.intmodule private @CoverLabel<label: none = "label for cover">(
+                                         in clock: !firrtl.clock,
+                                         in predicate: !firrtl.uint<1>,
+                                         in enable: !firrtl.uint<1>
+                                       ) attributes {intrinsic = "circt.chisel_cover"}
+  // CHECK-NOT: @AssertAssume
+  // CHECK-NOT: @AssertAssumeFormat
+  // CHECK-NOT: @IfElseFatalFormat
+  // CHECK-NOT: @Assume
+  // CHECK-NOT: @CoverLabel
 
-  // CHECK: firrtl.module @ChiselVerif()
-  firrtl.module @ChiselVerif() {
-    // COM: // CHECK-NOT: VerifAssert1
-    // COM: // CHECK-NOT: VerifAssert2
-    // COM: // CHECK-NOT: VerifAssume
-    // COM: // CHECK-NOT: VerifCover
-    // COM: // CHECK: firrtl.int.verif.assert {{%.+}} :
-    // COM: // CHECK: firrtl.int.verif.assert {{%.+}} {label = "hello"} :
-    // COM: // CHECK: firrtl.int.verif.assume {{%.+}} :
-    // COM: // CHECK: firrtl.int.verif.cover {{%.+}} :
-    %assert1.property = firrtl.instance "assert1" @VerifAssert1(in property: !firrtl.uint<1>)
-    %assert2.property = firrtl.instance "assert2" @VerifAssert2(in property: !firrtl.uint<1>)
-    %assume.property = firrtl.instance "assume" @VerifAssume(in property: !firrtl.uint<1>)
-    %cover.property = firrtl.instance "cover" @VerifCover(in property: !firrtl.uint<1>)
+  // CHECK: firrtl.module @ChiselVerif(
+  firrtl.module @ChiselVerif(in %clock: !firrtl.clock,
+                             in %cond: !firrtl.uint<1>,
+                             in %enable: !firrtl.uint<1>) {
+    // CHECK-NOT: firrtl.instance
+    // CHECK: firrtl.assert %{{.+}}, %{{.+}}, %{{.+}}, "testing" :
+    // CHECK-SAME: isConcurrent = true
+    %assert_clock, %assert_predicate, %assert_enable = firrtl.instance assert interesting_name @AssertAssume(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>)
+    firrtl.strictconnect %assert_clock, %clock : !firrtl.clock
+    firrtl.strictconnect %assert_predicate, %cond : !firrtl.uint<1>
+    firrtl.strictconnect %assert_enable, %enable : !firrtl.uint<1>
+    // CHECK-NOT: firrtl.instance
+    // CHECK: firrtl.assert %{{.+}}, %{{.+}}, %{{.+}}, "message: %d"(
+    // CHECK-SAME: guards = ["MACRO_GUARD", "ASDF"]
+    // CHECK-SAME: isConcurrent = true
+    // CHECK-SAME: name = "label for assert with format string"
+    %assertFormat_clock, %assertFormat_predicate, %assertFormat_enable, %assertFormat_val = firrtl.instance assertFormat interesting_name @AssertAssumeFormat(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
+    firrtl.strictconnect %assertFormat_clock, %clock : !firrtl.clock
+    firrtl.strictconnect %assertFormat_predicate, %cond : !firrtl.uint<1>
+    firrtl.strictconnect %assertFormat_enable, %enable : !firrtl.uint<1>
+    firrtl.strictconnect %assertFormat_val, %cond : !firrtl.uint<1>
+    // CHECK-NOT: firrtl.instance
+    // CHECK: firrtl.assert %{{.+}}, %{{.+}}, %{{.+}}, "ief: %d"(
+    // CHECK-SAME: format = "ifElseFatal"
+    // CHECK-SAME: guards = ["MACRO_GUARD", "ASDF"]
+    // CHECK-SAME: isConcurrent = true
+    // CHECK-SAME: name = "label for ifelsefatal assert"
+    %ief_clock, %ief_predicate, %ief_enable, %ief_val = firrtl.instance ief interesting_name @IfElseFatalFormat(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
+    firrtl.strictconnect %ief_clock, %clock : !firrtl.clock
+    firrtl.strictconnect %ief_predicate, %cond : !firrtl.uint<1>
+    firrtl.strictconnect %ief_enable, %enable : !firrtl.uint<1>
+    firrtl.strictconnect %ief_val, %enable : !firrtl.uint<1>
+    // CHECK-NOT: firrtl.instance
+    // CHECK: firrtl.assume %{{.+}}, %{{.+}}, %{{.+}}, "text: %d"(
+    // CHECK-SAME: isConcurrent = true
+    // CHECK-SAME: name = "label for assume"
+    %assume_clock, %assume_predicate, %assume_enable, %assume_val = firrtl.instance assume interesting_name @Assume(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
+    firrtl.strictconnect %assume_clock, %clock : !firrtl.clock
+    firrtl.strictconnect %assume_predicate, %cond : !firrtl.uint<1>
+    firrtl.strictconnect %assume_enable, %enable : !firrtl.uint<1>
+    firrtl.strictconnect %assume_val, %enable : !firrtl.uint<1>
+    // CHECK-NOT: firrtl.instance
+    // CHECK: firrtl.cover %{{.+}}, %{{.+}}, %{{.+}}, "" :
+    // CHECK-SAME: isConcurrent = true
+    // CHECK-SAME: name = "label for cover"
+    %cover_clock, %cover_predicate, %cover_enable = firrtl.instance cover interesting_name @CoverLabel(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>)
+    firrtl.strictconnect %cover_clock, %clock : !firrtl.clock
+    firrtl.strictconnect %cover_predicate, %cond : !firrtl.uint<1>
+    firrtl.strictconnect %cover_enable, %enable : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -254,4 +254,30 @@ firrtl.circuit "Foo" {
     firrtl.strictconnect %ckg_test_en, %en : !firrtl.uint<1>
     firrtl.strictconnect %ckg_en, %en : !firrtl.uint<1>
   }
+
+  // CHECK-NOT: CirctAssert1
+  // CHECK-NOT: CirctAssert2
+  // CHECK-NOT: VerifAssume
+  // CHECK-NOT: VerifCover
+// TODO: 
+  // firrtl.intmodule @CirctAssert1() attributes {intrinsic = "circt.assert"}
+//  firrtl.intmodule @VerifAssert2<label: none = "hello">(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.assert"}
+//  firrtl.intmodule @VerifAssume(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.assume"}
+//  firrtl.intmodule @VerifCover(in property: !firrtl.uint<1>) attributes {intrinsic = "circt.verif.cover"}
+
+  // CHECK: firrtl.module @ChiselVerif()
+  firrtl.module @ChiselVerif() {
+    // COM: // CHECK-NOT: VerifAssert1
+    // COM: // CHECK-NOT: VerifAssert2
+    // COM: // CHECK-NOT: VerifAssume
+    // COM: // CHECK-NOT: VerifCover
+    // COM: // CHECK: firrtl.int.verif.assert {{%.+}} :
+    // COM: // CHECK: firrtl.int.verif.assert {{%.+}} {label = "hello"} :
+    // COM: // CHECK: firrtl.int.verif.assume {{%.+}} :
+    // COM: // CHECK: firrtl.int.verif.cover {{%.+}} :
+    %assert1.property = firrtl.instance "assert1" @VerifAssert1(in property: !firrtl.uint<1>)
+    %assert2.property = firrtl.instance "assert2" @VerifAssert2(in property: !firrtl.uint<1>)
+    %assume.property = firrtl.instance "assume" @VerifAssume(in property: !firrtl.uint<1>)
+    %cover.property = firrtl.instance "cover" @VerifCover(in property: !firrtl.uint<1>)
+  }
 }

--- a/test/firtool/chisel_assert.fir
+++ b/test/firtool/chisel_assert.fir
@@ -8,7 +8,6 @@ circuit ChiselVerif:
     input predicate: UInt<1>
     input enable: UInt<1>
     intrinsic = circt_chisel_assert_assume
-    parameter format = "testing"
 
   intmodule AssertAssumeFormat:
     input clock: Clock
@@ -54,7 +53,7 @@ circuit ChiselVerif:
     input enable: UInt<1>
 
     ; CHECK: assert property
-    ; CHECK-SAME: "testing"
+    ; CHECK-NOT: $error
     ; CHECK: PROPERTY_AS_CONSTRAINT
     ; CHECK: assume
     inst assert of AssertAssume

--- a/test/firtool/chisel_assert.fir
+++ b/test/firtool/chisel_assert.fir
@@ -1,0 +1,104 @@
+; RUN: firtool %s | FileCheck %s
+
+FIRRTL version 4.0.0
+
+circuit ChiselVerif:
+  intmodule AssertAssume:
+    input clock: Clock
+    input predicate: UInt<1>
+    input enable: UInt<1>
+    intrinsic = circt_chisel_assert_assume
+    parameter format = "testing"
+
+  intmodule AssertAssumeFormat:
+    input clock: Clock
+    input predicate: UInt<1>
+    input enable: UInt<1>
+    input val: UInt<1>
+    intrinsic = circt_chisel_assert_assume
+    parameter format = "message: %d"
+    parameter label = "label for assert with format string"
+    parameter guards = "MACRO_GUARD;ASDF"
+
+  intmodule IfElseFatalFormat:
+    input clock: Clock
+    input predicate: UInt<1>
+    input enable: UInt<1>
+    input val: UInt<1>
+    intrinsic = circt_chisel_ifelsefatal
+    parameter format = "ief: %d"
+    ; In normal emission these are unused, but allow them to be set for now.
+    parameter label = "label for ifelsefatal assert"
+    parameter guards = "MACRO_GUARD;ASDF"
+
+  intmodule Assume:
+    input clock: Clock
+    input predicate: UInt<1>
+    input enable: UInt<1>
+    input val: UInt<1>
+    intrinsic = circt_chisel_assume
+    parameter format = "text: %d"
+    parameter label = "label for assume"
+
+  intmodule CoverLabel:
+    input clock: Clock
+    input predicate: UInt<1>
+    input enable: UInt<1>
+    intrinsic = circt_chisel_cover
+    parameter label = "label for cover"
+
+  ; CHECK: module ChiselVerif
+  module ChiselVerif:
+    input clock: Clock
+    input cond: UInt<1>
+    input enable: UInt<1>
+
+    ; CHECK: assert property
+    ; CHECK-SAME: "testing"
+    ; CHECK: PROPERTY_AS_CONSTRAINT
+    ; CHECK: assume
+    inst assert of AssertAssume
+    connect assert.clock, clock
+    connect assert.predicate, cond
+    connect assert.enable, enable
+
+    ; CHECK: `ifdef MACRO_GUARD
+    ; CHECK-NEXT: `ifdef ASDF
+    ; CHECK: label_for_assert_with_format_string
+    ; CHECK: assert property
+    ; CHECK: "message: %d"
+    ; CHECK: $sampled(cond)
+    ; CHECK: PROPERTY_AS_CONSTRAINT
+    ; CHECK: assume
+    inst assertFormat of AssertAssumeFormat
+    connect assertFormat.clock, clock
+    connect assertFormat.predicate, cond
+    connect assertFormat.enable, enable
+    connect assertFormat.val, cond
+
+    ; Special if-else-fatal pattern, assert-like.
+    ; No guards or labels for normal emission flow.
+    ; CHECK: $error("ief: %d"
+    ; CHECK: $fatal
+    inst ief of IfElseFatalFormat
+    connect ief.clock, clock
+    connect ief.predicate, cond
+    connect ief.enable, enable
+    connect ief.val, enable
+
+    ; CHECK: label_for_assume
+    ; CHECK: assume property
+    ; CHECK: "text: %d"
+    ; CHECK: $sampled(enable)
+    inst assume of Assume
+    connect assume.clock, clock
+    connect assume.predicate, cond
+    connect assume.enable, enable
+    connect assume.val, enable
+
+    ; CHECK: label_for_cover
+    ; CHECK: cover property
+    inst cover of CoverLabel
+    connect cover.clock, clock
+    connect cover.predicate, cond
+    connect cover.enable, enable


### PR DESCRIPTION
Provide intrinsics to capture what today is encoded via printf + when/stop/verif-op pattern matching and XML + JSON parameters.

Compared to assert/assume/cover FIRRTL (textual/in-the-spec) ops, these allow specifying labels that are more than identifiers and have optional compilation guards.

These map to current FIRRTL ops directly, including the various special behaviors that means in practice today (as encoded in LowerToHW):

* Assert implies companion assume emission.  Hence `chisel_assert_assume`.
* If the guard `USE_UNR_ONLY_CONSTRAINTS` is present, this companion assume is different, see: https://github.com/llvm/circt/pull/5561 .

There is no "assert" because `firrtl.assert` "concurrent" (SVA) forms always "imply" a "companion assume" and presently there is no FIRRTL dialect encoding for just a concurrent assert without this implied assume.

These are all SVA/concurrent "type".

IfElseFatal:
chisel_ifelsefatal becomes a very specific pattern of verilog that is not concurrent but is modeled that way in the IR (special "assert").
Allow guards and label on the intrinsic but they don't do anything on normal emission flow (`-emit-chisel-asserts-as-sva` will see them however so expose them).