### PR TITLE
[OM] Remove Symbol trait from ClassFieldLikes.

### DIFF
--- a/include/circt/Dialect/OM/OMOpInterfaces.td
+++ b/include/circt/Dialect/OM/OMOpInterfaces.td
@@ -50,7 +50,9 @@ def ClassFieldLike : OpInterface<"ClassFieldLike"> {
 
   let methods = [
     InterfaceMethod<"Get the class-like field's type",
-      "mlir::Type", "getType", (ins)>
+      "mlir::Type", "getType", (ins)>,
+    InterfaceMethod<"Get the class-like field's name attribute",
+      "mlir::StringAttr", "getNameAttr", (ins)>
   ];
 }
 

--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -59,7 +59,6 @@ class OMClassLike<string mnemonic, list<Trait> traits = []> :
 
 class OMClassFieldLike<string mnemonic, list<Trait> traits = []> :
   OMOp<mnemonic, traits # [
-    Symbol,
     DeclareOpInterfaceMethods<ClassFieldLike>]> {
 }
 
@@ -89,12 +88,12 @@ def ClassOp : OMClassLike<"class"> {
 def ClassFieldOp : OMClassFieldLike<"class.field",
     [HasParent<"ClassOp">]> {
   let arguments = (ins
-    SymbolNameAttr:$sym_name,
+    SymbolNameAttr:$name,
     AnyType:$value
   );
 
   let assemblyFormat = [{
-    $sym_name `,` $value  attr-dict `:` type($value)
+    $name `,` $value  attr-dict `:` type($value)
   }];
 }
 
@@ -116,12 +115,12 @@ def ClassExternOp : OMClassLike<"class.extern"> {
 def ClassExternFieldOp : OMClassFieldLike<"class.extern.field",
     [HasParent<"ClassExternOp">]> {
   let arguments = (ins
-    SymbolNameAttr:$sym_name,
+    SymbolNameAttr:$name,
     TypeAttr:$type
   );
 
   let assemblyFormat = [{
-    $sym_name attr-dict `:` $type
+    $name attr-dict `:` $type
   }];
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -1127,7 +1127,7 @@ struct ClassFieldOpConversion : public OpConversionPattern<ClassFieldOp> {
   LogicalResult
   matchAndRewrite(ClassFieldOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<ClassFieldOp>(op, adaptor.getSymNameAttr(),
+    rewriter.replaceOpWithNewOp<ClassFieldOp>(op, adaptor.getNameAttr(),
                                               adaptor.getValue());
     return success();
   }
@@ -1143,8 +1143,8 @@ struct ClassExternFieldOpConversion
     auto type = typeConverter->convertType(adaptor.getType());
     if (!type)
       return failure();
-    rewriter.replaceOpWithNewOp<ClassExternFieldOp>(
-        op, adaptor.getSymNameAttr(), type);
+    rewriter.replaceOpWithNewOp<ClassExternFieldOp>(op, adaptor.getNameAttr(),
+                                                    type);
     return success();
   }
 };

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -249,7 +249,7 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
     }
 
   for (auto field : cls.getOps<ClassFieldOp>()) {
-    StringAttr name = field.getSymNameAttr();
+    StringAttr name = field.getNameAttr();
     Value value = field.getValue();
     FailureOr<evaluator::EvaluatorValuePtr> result =
         evaluateValue(value, actualParams, field.getLoc());

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -349,12 +349,10 @@ circt::om::ObjectFieldOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
     // Verify the field exists on the ClassOp.
     auto field = fields[i];
     ClassFieldLike fieldDef;
-    classDef.walk([&](SymbolOpInterface symbol) {
-      if (auto fieldLike = dyn_cast<ClassFieldLike>(symbol.getOperation())) {
-        if (symbol.getNameAttr() == field.getAttr()) {
-          fieldDef = fieldLike;
-          return WalkResult::interrupt();
-        }
+    classDef.walk([&](ClassFieldLike fieldLike) {
+      if (fieldLike.getNameAttr() == field.getAttr()) {
+        fieldDef = fieldLike;
+        return WalkResult::interrupt();
       }
       return WalkResult::advance();
     });


### PR DESCRIPTION
Since 5fb4cf5fd3a3dcaa05b43e340120ce9c3a75f597, ClassLikes are not SymbolTables, due to the usual reasons that led to us inventing InnerSymbolTables. However, that change left the Symbol trait on ClassFieldLikes, which is not legal. We need to fix this, and stop using Symbols in illegal locations.

This change removes the Symbol trait, and includes some minor juggling so the current implementation can continue working with minimal changes.

This renames the attribute name from sym_name to name and adds an interface method to ClassFieldLike called getNameAttr. Together, these changes align the accessor for this field to match the previous getNameAttr accessor on Symbols.

This also updates a couple call sites that directly called getSymNameAttr to use getNameAttr like the other call sites.

This updates the ObjectFieldOp verifier, which already has to linearly walk a ClassLike's fields, to stop walking SymbolOpInterface and instead directly walk ClassFieldLikes.

The last thing is a non-change, where we keep the name attributes as SymbolNameAttr in ODS, so the printed form still looks like a symbol. This also aligns with the ObjectFieldOp printed form. This is so this change can be backwards compatible in the printed IR; if we think it is better to call a spade a spade, this can be updated to print these field names as quoted strings, to better reflect that they're actually just StringAttrs.

Fixes https://github.com/llvm/circt/issues/6659.