### PR TITLE
[FIRRTL] Intrinsics: Fix mistakenly preserved analyses.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -123,6 +123,7 @@ LogicalResult IntrinsicLowerings::lower(CircuitOp circuit) {
       if (it != extmods.end()) {
         if (succeeded(it->second(op))) {
           op.erase();
+          ++numConverted;
         } else {
           ++numFailures;
         }
@@ -158,6 +159,7 @@ LogicalResult IntrinsicLowerings::lower(CircuitOp circuit) {
       ++numFailures;
       continue;
     }
+    ++numConverted;
     op.erase();
   }
 


### PR DESCRIPTION
Conversions weren't actually counted, fix.