### PR TITLE
[Calyx] Make ControlOp a SymbolTable.

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -15,7 +15,7 @@ def ControlLike : NativeOpTrait<"ControlLike"> {
 }
 
 def ControlOp : CalyxContainer<"control", [
-    HasParent<"ComponentOp">
+    HasParent<"ComponentOp">, SymbolTable
   ]> {
   let summary = "Calyx Control";
   let description = [{

--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -14,6 +14,9 @@ def ControlLike : NativeOpTrait<"ControlLike"> {
   let cppNamespace = "::circt::calyx";
 }
 
+// ControlOp is a SymbolTable even though ControlLike ops are not Symbols
+// because in the lowering pipeline, we add FSM MachineOps under ControlOp, and
+// MachineOps are Symbols. See https://github.com/llvm/circt/issues/6667.
 def ControlOp : CalyxContainer<"control", [
     HasParent<"ComponentOp">, SymbolTable
   ]> {


### PR DESCRIPTION
During the Calyx control lowering, in an intermediate state, we have fsm.machine ops embedded within the calyx.control op. fsm.machine defines a Symbol, so this is illegal unless calyx.control is a SymbolTable.

We consistently hit issues when we try to nest SymbolTables, but I don't think those will actually bite us in the Calyx lowering pipeline. Since no one is actively maintaining this, I'm proposing to add SymbolTable to ControlOp until we have a reason to change this, so the IR is legal during the Calyx lowering.

Fixes https://github.com/llvm/circt/issues/6667.