### PR TITLE
[FIRRTL] InferResets: verify that FART annotation is on async resets

### DIFF
--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -164,6 +164,27 @@ firrtl.circuit "top" {
 }
 
 // -----
+// Reset annotation cannot target synchronous reset signals
+firrtl.circuit "top" {
+  firrtl.module @top() {
+    // expected-error @below {{'IgnoreFullAsyncResetAnnotation' must target async reset, but targets '!firrtl.uint<1>'}}
+    %innerReset = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.uint<1>
+  }
+}
+
+// -----
+// Reset annotation cannot target reset signals which are inferred to be synchronous
+firrtl.circuit "top" {
+  firrtl.module @top() {
+   // expected-error @below {{'IgnoreFullAsyncResetAnnotation' must target async reset, but targets '!firrtl.uint<1>'}}
+    %innerReset = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.reset
+    %invalid = firrtl.invalidvalue : !firrtl.reset
+    firrtl.strictconnect %innerReset, %invalid : !firrtl.reset
+  }
+}
+
+
+// -----
 // Ignore reset annotation cannot target port
 firrtl.circuit "top" {
   // expected-error @+1 {{IgnoreFullAsyncResetAnnotation' cannot target port; must target module instead}}


### PR DESCRIPTION
The FullAsynchronousResetAnnotation is used to mark an asynchronous signal in a module to be used as the reset for all registers that do not already have an async reset in this module and below in the hierarchy. There was no error checking that this annotation was attached to an asynchronous reset typed signal, and the pass would accidentally try to wire whatever signal was annotated.  In some cases, this could lead to a connecting the signal to an async typed port, which would become a type checking error in the verifier. This changes InferResets to verify that the FART annotated signal is in fact asynchronous.

Fixes https://github.com/llvm/circt/issues/6635