### PR TITLE
[FSM] Remove Symbol trait from InstanceOp and HWInstanceOp.

### DIFF
--- a/frontends/PyCDE/src/fsm.py
+++ b/frontends/PyCDE/src/fsm.py
@@ -203,7 +203,7 @@ class MachineModuleBuilder(ModuleLikeBuilderBase):
 
     op = raw_fsm.HWInstanceOp(outputs=circt_mod.type.results,
                               inputs=inputs,
-                              sym_name=StringAttr.get(instance_name),
+                              name=StringAttr.get(instance_name),
                               machine=FlatSymbolRefAttr.get(
                                   StringAttr(
                                       circt_mod.attributes["sym_name"]).value),

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -96,17 +96,17 @@ def MachineOp : FSMOp<"machine", [
   let hasVerifier = 1;
 }
 
-def InstanceOp : FSMOp<"instance", [Symbol, HasCustomSSAName]> {
+def InstanceOp : FSMOp<"instance", [HasCustomSSAName]> {
   let summary = "Create an instance of a state machine";
   let description = [{
     `fsm.instance` represents an instance of a state machine, including an
     instance name and a symbol reference of the machine.
   }];
 
-  let arguments = (ins StrAttr:$sym_name, FlatSymbolRefAttr:$machine);
+  let arguments = (ins StrAttr:$name, FlatSymbolRefAttr:$machine);
   let results = (outs InstanceType:$instance);
 
-  let assemblyFormat = [{ $sym_name $machine attr-dict }];
+  let assemblyFormat = [{ $name $machine attr-dict }];
 
   let extraClassDeclaration = [{
     /// Lookup the machine for the symbol. This returns null on invalid IR.
@@ -145,7 +145,6 @@ def TriggerOp : FSMOp<"trigger", []> {
 }
 
 def HWInstanceOp : FSMOp<"hw_instance", [
-    Symbol,
     DeclareOpInterfaceMethods<InstanceGraphInstanceOpInterface>
   ]> {
   let summary = "Create a hardware-style instance of a state machine";
@@ -156,12 +155,12 @@ def HWInstanceOp : FSMOp<"hw_instance", [
     machine.
   }];
 
-  let arguments = (ins StrAttr:$sym_name, FlatSymbolRefAttr:$machine,
+  let arguments = (ins StrAttr:$name, FlatSymbolRefAttr:$machine,
                        Variadic<AnyType>:$inputs, ClockType:$clock, I1:$reset);
   let results = (outs Variadic<AnyType>:$outputs);
 
   let assemblyFormat = [{
-    $sym_name $machine attr-dict `(` $inputs `)`
+    $name $machine attr-dict `(` $inputs `)`
     `,` `clock` $clock `,` `reset` $reset `:` functional-type($inputs, $outputs)
   }];
 

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -234,7 +234,7 @@ LogicalResult InstanceOp::verify() {
 
 void InstanceOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
-  setNameFn(getInstance(), getSymName());
+  setNameFn(getInstance(), getName());
 }
 
 //===----------------------------------------------------------------------===//
@@ -301,11 +301,9 @@ SmallVector<hw::PortInfo> HWInstanceOp::getPortList() {
 StringRef HWInstanceOp::getModuleName() { return getMachine(); }
 FlatSymbolRefAttr HWInstanceOp::getModuleNameAttr() { return getMachineAttr(); }
 
-mlir::StringAttr HWInstanceOp::getInstanceNameAttr() {
-  return getSymNameAttr();
-}
+mlir::StringAttr HWInstanceOp::getInstanceNameAttr() { return getNameAttr(); }
 
-llvm::StringRef HWInstanceOp::getInstanceName() { return getSymName(); }
+llvm::StringRef HWInstanceOp::getInstanceName() { return getName(); }
 
 //===----------------------------------------------------------------------===//
 // StateOp


### PR DESCRIPTION
These are used in contexts that are not SymbolTables, so these cannot be Symbols. It appears that nothing actually needs the Symbol functionality, and all we need here is the string name. This removes the Symbol trait and renames the attribute to just `name`.