### PR TITLE
[Seq] Remove Symbol trait from HLMemOp.

### DIFF
--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -296,14 +296,13 @@ def FIFOOp : SeqOp<"fifo", [
 }
 
 def HLMemOp : SeqOp<"hlmem", [
-     Symbol,
      Clocked,
      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]> ]> {
 
   let summary = "Instantiate a high-level memory.";
   let description = "See the Seq dialect rationale for a longer description";
 
-  let arguments = (ins ClockType:$clk, I1:$rst, SymbolNameAttr:$sym_name);
+  let arguments = (ins ClockType:$clk, I1:$rst, SymbolNameAttr:$name);
   let results = (outs HLMemType:$handle);
 
   let extraClassDeclaration = [{
@@ -311,11 +310,11 @@ def HLMemOp : SeqOp<"hlmem", [
   }];
 
   let builders = [
-    OpBuilder<(ins "Value":$clk, "Value":$rst, "StringRef":$symName,
+    OpBuilder<(ins "Value":$clk, "Value":$rst, "StringRef":$name,
                    "llvm::ArrayRef<int64_t>":$shape, "Type":$elementType)>
   ];
 
-  let assemblyFormat = "$sym_name $clk `,` $rst attr-dict `:` type($handle)";
+  let assemblyFormat = "$name $clk `,` $rst attr-dict `:` type($handle)";
 }
 
 class HLMemTypeValueConstraint<string hlmemvalue, string value>

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -206,10 +206,10 @@ void HLMemOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 }
 
 void HLMemOp::build(OpBuilder &builder, OperationState &result, Value clk,
-                    Value rst, StringRef symName, llvm::ArrayRef<int64_t> shape,
+                    Value rst, StringRef name, llvm::ArrayRef<int64_t> shape,
                     Type elementType) {
   HLMemType t = HLMemType::get(builder.getContext(), shape, elementType);
-  HLMemOp::build(builder, result, t, clk, rst, symName);
+  HLMemOp::build(builder, result, t, clk, rst, name);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
These are used in contexts that are not SymbolTables, so these cannot be Symbols. It appears that nothing actually needs the Symbol functionality, and all we need here is the string name. This removes the Symbol trait and renames the attribute to just name.

If anything needs to reference HLMemOps symbolically, these can become InnerSymbols, but again, I didn't see anything about that in the codebase.

Fixes https://github.com/llvm/circt/issues/6661.