### PR TITLE
[LowerIntrinsics] Accept EICG_wrapper without test_en, reject annos

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.h
@@ -40,7 +40,7 @@ public:
   virtual bool check() { return false; }
 
   /// Transform an instance of the intrinsic.
-  virtual void convert(InstanceOp op) = 0;
+  virtual LogicalResult convert(InstanceOp op) = 0;
 
 protected:
   ParseResult hasNPorts(unsigned n);

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -109,7 +109,8 @@ LogicalResult IntrinsicLowerings::doLowering(FModuleLike mod,
   if (conv.check())
     return failure();
   for (auto *use : graph.lookup(mod)->uses())
-    conv.convert(use->getInstance<InstanceOp>());
+    if (failed(conv.convert(use->getInstance<InstanceOp>())))
+      return failure();
   return success();
 }
 

--- a/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
@@ -1,0 +1,20 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-intrinsics{fixup-eicg-wrapper}))' --split-input-file --verify-diagnostics %s
+
+firrtl.circuit "EICGWithInstAnno" {
+  firrtl.extmodule @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
+  hw.hierpath private @nla [@EICGWithInstAnno::@ckg, @EICG_wrapper]
+  firrtl.module @EICGWithInstAnno(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>) {
+    // expected-error @below {{EICG_wrapper instance cannot have annotations since it is an intrinsic}}
+    firrtl.instance ckg sym @ckg {annotations = [{circt.nonlocal = @nla, class = "DummyA"}]} @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+  }
+}
+
+// -----
+
+firrtl.circuit "EICGWithModuleAnno" {
+  // expected-error @below {{EICG_wrapper cannot have annotations since it is an intrinsic}}
+  firrtl.extmodule @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper", annotations = [{class = "DummyA"}]}
+  firrtl.module @EICGWithModuleAnno(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>) {
+    firrtl.instance ckg @EICG_wrapper(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+  }
+}

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -346,3 +346,20 @@ firrtl.circuit "Foo" {
     firrtl.strictconnect %cover_enable, %enable : !firrtl.uint<1>
   }
 }
+
+// CHECK-LABEL: "FixupEICGWrapper2"
+firrtl.circuit "FixupEICGWrapper2" {
+  // CHECK-NOEICG: LegacyClockGateNoTestEn
+  // CHECK-EICG-NOT: LegacyClockGateNoTestEn
+  firrtl.extmodule @LegacyClockGateNoTestEn(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
+
+  // CHECK: FixupEICGWrapper2
+  firrtl.module @FixupEICGWrapper2(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>) {
+    // CHECK-NOEICG: firrtl.instance
+    // CHECK-EICG-NOT: firrtl.instance
+    // CHECK-EICG: firrtl.int.clock_gate
+    %ckg_in, %ckg_en, %ckg_out = firrtl.instance ckg @LegacyClockGateNoTestEn(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
+    firrtl.strictconnect %ckg_in, %clock : !firrtl.clock
+    firrtl.strictconnect %ckg_en, %en : !firrtl.uint<1>
+  }
+}


### PR DESCRIPTION
Accept `EICG_wrapper` extmodules without `test_en` port in `LowerIntrinsics`, and simply leave the `test_en` unconnected in that case. Also reject `EICG_wrapper` modules and instances if they have annotations attached, as we currently have no mechanism to carry them over onto the intrinsic. (Only if `--fixup-eicg-wrapper` is passed to firtool.)