### PR TITLE
Tree-wide test fixes for FileCheck directive typos

### DIFF
--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1296,7 +1296,7 @@ hw.module.extern @MyExtModule(in %in: i8)
 hw.module.extern @ExtModule(in %in: i8, out out: i8)
 
 // CHECK-LABEL: module InlineBind
-// CHEC:        output wire_0
+// CHECK:       output [7:0] wire_0
 hw.module @InlineBind(in %a_in: i8, out wire: i8){
   // CHECK:      wire [7:0] _ext1_out;
   // CHECK-NEXT: wire [7:0] _GEN;

--- a/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Companion.fir
+++ b/test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Companion.fir
@@ -69,7 +69,7 @@ circuit Foo : %[[
 
     ; DROP-NOT: module Companion
     ; DROP:     module Foo
-    ; DROP NOT: Companion
+    ; DROP-NOT: Companion
     ; DROP: endmodule
     ; DROP:     FILE "gct.yaml"
     ; DROP:     []

--- a/test/Dialect/FIRRTL/SFCTests/directories.fir
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir
@@ -123,7 +123,7 @@ circuit TestHarness:
 ; CHECK:            endmodule
 
 ; SITEST_DUT:       FILE "testbench.sitest.json"
-; SITEST-DUT-NOT:   FILE
+; SITEST_DUT-NOT:   FILE
 ; SITEST_DUT:         "Foo_BlackBox"
 
 ; SITEST_DUT:       FILE "design.sitest.json"
@@ -132,7 +132,7 @@ circuit TestHarness:
 ; SITEST_DUT-DAG:     "Baz_BlackBox"
 
 ; SITEST_NODUT:     FILE "testbench.sitest.json"
-; SITEST-NODUT-NOT: FILE
+; SITEST_NODUT-NOT: FILE
 
 ; MLIR_OUT:  om.class @SitestBlackBoxModulesSchema(%moduleName: !om.sym_ref) {
 ; MLIR_OUT:    om.class.field @moduleName, %moduleName : !om.sym_ref

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2594,12 +2594,12 @@ firrtl.module @DontMergeVector(out %o:!firrtl.vector<uint<1>, 1>, in %i:!firrtl.
   // CHECK-NEXT: firrtl.strictconnect %0, %i
 }
 
-// TODO: Move to an apporpriate place
+// TODO: Move to an appropriate place
 // Issue #2197
 // CHECK-LABEL: @Issue2197
 firrtl.module @Issue2197(in %clock: !firrtl.clock, out %x: !firrtl.uint<2>) {
-//  // _HECK: [[ZERO:%.+]] = firrtl.constant 0 : !firrtl.uint<2>
-//  // _HECK-NEXT: firrtl.strictconnect %x, [[ZERO]] : !firrtl.uint<2>
+//  // COM: CHECK: [[ZERO:%.+]] = firrtl.constant 0 : !firrtl.uint<2>
+//  // COM: CHECK-NEXT: firrtl.strictconnect %x, [[ZERO]] : !firrtl.uint<2>
 //  %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
 //  %_reg = firrtl.reg droppable_name %clock : !firrtl.clock, !firrtl.uint<2>
 //  %0 = firrtl.pad %invalid_ui1, 2 : (!firrtl.uint<1>) -> !firrtl.uint<2>
@@ -2655,8 +2655,8 @@ firrtl.module @Issue2251(out %o: !firrtl.sint<15>) {
 //  %invalid_si1 = firrtl.invalidvalue : !firrtl.sint<1>
 //  %0 = firrtl.pad %invalid_si1, 15 : (!firrtl.sint<1>) -> !firrtl.sint<15>
 //  firrtl.connect %o, %0 : !firrtl.sint<15>, !firrtl.sint<15>
-//  // _HECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<15>
-//  // _HECK-NEXT: firrtl.strictconnect %o, %[[zero]]
+//  // COM: CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<15>
+//  // COM: CHECK-NEXT: firrtl.strictconnect %o, %[[zero]]
 }
 
 // Issue mentioned in #2289

--- a/test/Dialect/FIRRTL/lower-open-aggs.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs.mlir
@@ -304,8 +304,8 @@ firrtl.circuit "WireProbes" {
 firrtl.circuit "WireSymbols" {
   // CHECK-LABEL: module{{.*}} @WireSymbols
   firrtl.module @WireSymbols() {
-    // CHECk-NEXT: %a = firrtl.wire sym [<@sym_a_c, 1, public>] : !firrtl.bundle<c: uint<1>>
-    // CHECk-NEXT: %a_b = firrtl.wire : !firrtl.string
+    // CHECK-NEXT: %a = firrtl.wire sym [<@sym_a_c,1,public>] : !firrtl.bundle<c: uint<1>>
+    // CHECK-NEXT: %a_b = firrtl.wire : !firrtl.string
     %a = firrtl.wire sym [<@sym_a_c, 2, public>] : !firrtl.openbundle<b: string, c: uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/lower-signatures.mlir
+++ b/test/Dialect/FIRRTL/lower-signatures.mlir
@@ -77,7 +77,7 @@ firrtl.circuit "InternalPaths"  {
   // CHECK-SAME: #firrtl.internalpath
   // CHECK-SAME: #firrtl.internalpath
   // CHECK-SAME: #firrtl.internalpath<"some_probe">
-  // CHECK-sAME: ]
+  // CHECK-SAME: ]
   firrtl.extmodule private @BlackBox(
     out bundle : !firrtl.bundle<a: uint<32>, b: uint<23>>,
     out array : !firrtl.vector<uint<1>, 2>,

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -3,8 +3,8 @@
 // Test for same module lowering
 // CHECK-LABEL: firrtl.circuit "xmr"
 firrtl.circuit "xmr" {
-  // CHECK : #hw.innerNameRef<@xmr::@[[wSym]]>
-  // CHECK-LABEL: firrtl.module @xmr(out %o: !firrtl.uint<2>)
+  // CHECK-DAG: @xmr::@[[wSym:[a-zA-Z0-9]+]]
+  // CHECK: firrtl.module @xmr(out %o: !firrtl.uint<2>)
   firrtl.module @xmr(out %o: !firrtl.uint<2>) {
     %w = firrtl.wire : !firrtl.uint<2>
     %1 = firrtl.ref.send %w : !firrtl.uint<2>
@@ -12,7 +12,7 @@ firrtl.circuit "xmr" {
     // CHECK-NOT: firrtl.ref.resolve
     firrtl.strictconnect %o, %x : !firrtl.uint<2>
     // CHECK:      %w = firrtl.wire : !firrtl.uint<2>
-    // CHECK:      %w_probe = firrtl.node sym @[[wSym:[a-zA-Z0-9_]+]] interesting_name %w : !firrtl.uint<2>
+    // CHECK:      %w_probe = firrtl.node sym @[[wSym]] interesting_name %w : !firrtl.uint<2>
     // CHECK-NEXT: %[[#xmr:]] = firrtl.xmr.deref @xmrPath : !firrtl.uint<2>
     // CHECK:      firrtl.strictconnect %o, %[[#xmr]] : !firrtl.uint<2>
   }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1920,7 +1920,7 @@ circuit PublicModules:
 ;// -----
 
 FIRRTL version 4.0.0
-; CHECK-LABLE: firrtl.circuit "LayerEnabledModule"
+; CHECK-LABEL: firrtl.circuit "LayerEnabledModule"
 circuit LayerEnabledModule:
   layer A, bind:
   layer B, bind:

--- a/test/Dialect/FIRRTL/remove-unused-ports.mlir
+++ b/test/Dialect/FIRRTL/remove-unused-ports.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-remove-unused-ports))' %s -split-input-file | FileCheck %s
 firrtl.circuit "Top"   {
   // CHECK-LABEL: firrtl.module @Top(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
-  // CHECK-SAME :                    out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>)
+  // CHECK-SAME:                     out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>)
   firrtl.module @Top(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
                      out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
     %A_a, %A_b, %A_c, %A_d_unused, %A_d_invalid, %A_d_constant = firrtl.instance A  @UseBar(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d_unused: !firrtl.uint<1>, out d_invalid: !firrtl.uint<1>, out d_constant: !firrtl.uint<1>)
@@ -72,7 +72,7 @@ firrtl.circuit "Top"   {
 // Strict connect version.
 firrtl.circuit "Top"   {
   // CHECK-LABEL: firrtl.module @Top(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
-  // CHECK-SAME :                    out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>)
+  // CHECK-SAME:                     out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>)
   firrtl.module @Top(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
                      out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
     %A_a, %A_b, %A_c, %A_d_unused, %A_d_invalid, %A_d_constant = firrtl.instance A  @UseBar(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d_unused: !firrtl.uint<1>, out d_invalid: !firrtl.uint<1>, out d_constant: !firrtl.uint<1>)

--- a/test/Dialect/HW/flatten-io.mlir
+++ b/test/Dialect/HW/flatten-io.mlir
@@ -71,7 +71,7 @@ hw.module @instance_extern2(in %arg0 : i32, in %arg1 : !Struct1, out out : !Stru
 }
 
 // EXTERN-LABEL: hw.module.extern @level1_extern
-// EXERN-SAME: (in %arg0 : i32, in %in_a : i1, in %in_b : i2, in %arg1 : i32, out out0 : i32, out out_a : i1, out out_b : i2, out out1 : i32)
+// EXTERN-SAME: (in %arg0 : i32, in %in_a : i1, in %in_b : i2, in %arg1 : i32, out out0 : i32, out out_a : i1, out out_b : i2, out out1 : i32)
 // BASIC-LABEL: hw.module.extern @level1_extern(in %arg0 : i32, in %in : !hw.struct<a: i1, b: i2>, in %arg1 : i32, out out0 : i32, out out : !hw.struct<a: i1, b: i2>, out out1 : i32)
 hw.module.extern @level1_extern(in %arg0 : i32, in %in : !Struct1, in %arg1: i32, out out0 : i32, out out: !Struct1, out out1: i32)
 

--- a/test/Dialect/LLHD/IR/entity.mlir
+++ b/test/Dialect/LLHD/IR/entity.mlir
@@ -29,5 +29,5 @@
 // CHECK-NEXT: llhd.entity @out_of_names () -> () {
 "llhd.entity"() ({
 ^body:
-// CHECK-NEXT : }
+// CHECK-NEXT: }
 }) {sym_name="out_of_names", ins=0, function_type=()->()} : () -> ()

--- a/test/Dialect/LTL/canonicalization.mlir
+++ b/test/Dialect/LTL/canonicalization.mlir
@@ -8,7 +8,7 @@ func.func private @Prop(%arg0: !ltl.property)
 func.func @DelayFolds(%arg0: !ltl.sequence) {
   // TODO: This can't happen because the fold changes type, need to be able to cast i1 to sequence
   // delay(s, 0, 0) -> s
-  // HECK-NEXT: call @Seq(%arg0)
+  // COM: CHECK-NEXT: call @Seq(%arg0)
   //%0 = ltl.delay %arg0, 0, 0 : !ltl.sequence
   //call @Seq(%0) : (!ltl.sequence) -> ()
 

--- a/test/Dialect/Seq/clock-type.mlir
+++ b/test/Dialect/Seq/clock-type.mlir
@@ -68,7 +68,7 @@ hw.module public @CrossReferences() {
 // CHECK-LABEL: hw.module @ClockAgg(in %c : !hw.struct<clock: i1>, out oc : !hw.struct<clock: i1>)
 // CHECK: [[CLOCK:%.+]] = hw.struct_extract %c["clock"] : !hw.struct<clock: i1>
 // CHECK: [[STRUCT:%.+]] = hw.struct_create ([[CLOCK]]) : !hw.struct<clock: i1>
-// CHECL: hw.output [[STRUCT]] : !hw.struct<clock: i1>
+// CHECK: hw.output [[STRUCT]] : !hw.struct<clock: i1>
 hw.module @ClockAgg(in %c: !hw.struct<clock: !seq.clock>, out oc: !hw.struct<clock: !seq.clock>) {
   %clock = hw.struct_extract %c["clock"] : !hw.struct<clock: !seq.clock>
   %0 = hw.struct_create (%clock) : !hw.struct<clock: !seq.clock>

--- a/test/firtool/firtool.mlir
+++ b/test/firtool/firtool.mlir
@@ -21,13 +21,17 @@ firrtl.circuit "Top" {
 
 // VERILOG-LABEL: module Top(
 // VERILOG-NEXT:    input  [7:0] in,
-// VERILOG-NEXT:    output [7:0] out);
+// VERILOG-NEXT:    output [7:0] out
+// VERILOG-NEXT:    );
+// VERILOG-EMPTY:
 // VERILOG-NEXT:    assign out = in;
 // VERILOG-NEXT:  endmodule
 
 // VERILOG-WITH-MLIR-LABEL: module Top(
 // VERILOG-WITH-MLIR-NEXT:    input  [7:0] in,
-// VERILOG-WITH-MLIR-NEXT:    output [7:0] out);
+// VERILOG-WITH-MLIR-NEXT:    output [7:0] out
+// VERILOG-WITH-MLIR-NEXT:  );
+// VERILOG-WITH-MLIR-EMPTY:
 // VERILOG-WITH-MLIR-NEXT:    assign out = in;
 // VERILOG-WITH-MLIR-NEXT:  endmodule
 

--- a/test/firtool/firtool.mlir
+++ b/test/firtool/firtool.mlir
@@ -20,16 +20,16 @@ firrtl.circuit "Top" {
 // MLIR-NEXT:  }
 
 // VERILOG-LABEL: module Top(
-// VERILOG-NEXT :   input  [7:0] in,
-// VERILOG-NEXT :   output [7:0] out);
-// VERILOG-NEXT :   assign out = in;
-// VERILOG-NEXT : endmodule
+// VERILOG-NEXT:    input  [7:0] in,
+// VERILOG-NEXT:    output [7:0] out);
+// VERILOG-NEXT:    assign out = in;
+// VERILOG-NEXT:  endmodule
 
 // VERILOG-WITH-MLIR-LABEL: module Top(
-// VERILOG-WITH-MLIR-NEXT :   input  [7:0] in,
-// VERILOG-WITH-MLIR-NEXT :   output [7:0] out);
-// VERILOG-WITH-MLIR-NEXT :   assign out = in;
-// VERILOG-WITH-MLIR-NEXT : endmodule
+// VERILOG-WITH-MLIR-NEXT:    input  [7:0] in,
+// VERILOG-WITH-MLIR-NEXT:    output [7:0] out);
+// VERILOG-WITH-MLIR-NEXT:    assign out = in;
+// VERILOG-WITH-MLIR-NEXT:  endmodule
 
 // VERILOG-WITH-MLIR-OUT-NOT: sv.verbatim{{.*}}output_file = {{.*}}meta.omir.json
 


### PR DESCRIPTION
Mostly just fix the typos and lowerXMR, lower-open-aggs.mlir, and sv-dialect.mlir needed the check line tweaked to pass.

Found via the (TIL) LLVM utility `llvm/utils/filecheck_lint/filecheck_lint.py`.

Hopefully coming to a CI near you soon :wink: .