### PR TITLE
[ImportVerilog] Fix single unit preprocessor option

### DIFF
--- a/test/circt-verilog/preprocess-multiple-files.sv
+++ b/test/circt-verilog/preprocess-multiple-files.sv
@@ -1,0 +1,19 @@
+// RUN: split-file %s %t
+// RUN: circt-verilog %t/a.sv %t/b.sv -E | FileCheck %s --check-prefixes=CHECK-MULTI-UNIT
+// RUN: circt-verilog %t/a.sv %t/b.sv -E --single-unit | FileCheck %s --check-prefixes=CHECK-SINGLE-UNIT
+// REQUIRES: slang
+
+// CHECK-MULTI-UNIT: import hello::undefined;
+// CHECK-SINGLE-UNIT: import hello::defined;
+
+//--- a.sv
+
+`define HELLO
+
+//--- b.sv
+
+`ifdef HELLO
+import hello::defined;
+`else
+import hello::undefined;
+`endif


### PR DESCRIPTION
Make `ImportVerilog` honor the `singleUnit` option by either adding all source files to a single preprocessor (single unit), or creating a fresh preprocessor for every single file (multiple units).

Fixes #6680.