### PR TITLE
[LowerToHW] Fix shr(0-bit, n) lowering

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3749,7 +3749,7 @@ LogicalResult FIRRTLLowering::visitExpr(ShlPrimOp op) {
 
 LogicalResult FIRRTLLowering::visitExpr(ShrPrimOp op) {
   // If this is a 0-bit value shifted by any amount, then return a 1-bit zero.
-  if (!op.getInput().getType().getBitWidthOrSentinel())
+  if (isZeroBitFIRRTLType(op.getInput().getType()))
     return setLowering(op, getOrCreateIntConstant(1, 0));
 
   auto input = getLoweredValue(op.getInput());

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3748,6 +3748,10 @@ LogicalResult FIRRTLLowering::visitExpr(ShlPrimOp op) {
 }
 
 LogicalResult FIRRTLLowering::visitExpr(ShrPrimOp op) {
+  // If this is a 0-bit value shifted by any amount, then return a 1-bit zero.
+  if (!op.getInput().getType().getBitWidthOrSentinel())
+    return setLowering(op, getOrCreateIntConstant(1, 0));
+
   auto input = getLoweredValue(op.getInput());
   if (!input)
     return failure();

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1586,3 +1586,16 @@ firrtl.circuit "PortSym" {
     %0 = firrtl.eq %out, %c1_ui5 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<1>
   }
 }
+
+// -----
+
+// Check that a zero-width value shifted right produces a zero.
+// See: https://github.com/llvm/circt/issues/6652
+firrtl.circuit "ShrZW" {
+  firrtl.module @ShrZW(in %x: !firrtl.uint<0>, out %out: !firrtl.uint<1>) attributes {convention = #firrtl<convention scalarized>} {
+    %0 = firrtl.shr %x, 5 : (!firrtl.uint<0>) -> !firrtl.uint<1>
+    firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK:      %[[false:.+]] = hw.constant false
+    // CHECK-NEXT: hw.output %false
+  }
+}

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1586,16 +1586,3 @@ firrtl.circuit "PortSym" {
     %0 = firrtl.eq %out, %c1_ui5 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<1>
   }
 }
-
-// -----
-
-// Check that a zero-width value shifted right produces a zero.
-// See: https://github.com/llvm/circt/issues/6652
-firrtl.circuit "ShrZW" {
-  firrtl.module @ShrZW(in %x: !firrtl.uint<0>, out %out: !firrtl.uint<1>) attributes {convention = #firrtl<convention scalarized>} {
-    %0 = firrtl.shr %x, 5 : (!firrtl.uint<0>) -> !firrtl.uint<1>
-    firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-    // CHECK:      %[[false:.+]] = hw.constant false
-    // CHECK-NEXT: hw.output %false
-  }
-}

--- a/test/Conversion/FIRRTLToHW/zero-width.mlir
+++ b/test/Conversion/FIRRTLToHW/zero-width.mlir
@@ -79,4 +79,14 @@ firrtl.circuit "Arithmetic" {
     // CHECK-NEXT: hw.output
   }
 
+  // Check that a zero-width value shifted right produces a zero.
+  // See: https://github.com/llvm/circt/issues/6652
+  // CHECK-LABEL: hw.module @ShrZW
+  firrtl.module @ShrZW(in %x: !firrtl.uint<0>, out %out: !firrtl.uint<1>) attributes {convention = #firrtl<convention scalarized>} {
+    %0 = firrtl.shr %x, 5 : (!firrtl.uint<0>) -> !firrtl.uint<1>
+    firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK:      %[[false:.+]] = hw.constant false
+    // CHECK-NEXT: hw.output %false
+  }
+
 }


### PR DESCRIPTION
Fix an error if a 0-bit was shifted right by any amount and this made it all the way to LowerToHW (and wasn't canonicalized away earlier).  FIRRTL semantics interpret this case as a 1-bit zero.  Insert the 1-bit zero if we ever see this.

Fixes #6652.