### PR TITLE
[WireDFT] Disable the pass by default

### DIFF
--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -95,6 +95,7 @@ public:
   bool shouldDisableOptimization() const { return disableOptimization; }
   bool shouldLowerMemories() const { return lowerMemories; }
   bool shouldDedup() const { return !noDedup; }
+  bool shouldRunWireDFT() const { return runWireDFT; }
   bool shouldEnableDebugInfo() const { return enableDebugInfo; }
   bool shouldIgnoreReadEnableMemories() const { return ignoreReadEnableMem; }
   bool shouldEmitOMIR() const { return emitOMIR; }
@@ -363,6 +364,7 @@ private:
   std::string chiselInterfaceOutDirectory;
   bool vbToBV;
   bool noDedup;
+  bool runWireDFT;
   firrtl::CompanionMode companionMode;
   bool disableAggressiveMergeConnections;
   bool disableHoistingHWPassthrough;

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -98,7 +98,8 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   if (opt.shouldDedup())
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDedupPass());
 
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createWireDFTPass());
+  if (opt.shouldRunWireDFT())
+    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createWireDFTPass());
 
   if (opt.shouldConvertVecOfBundle()) {
     pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass(
@@ -479,6 +480,13 @@ struct FirtoolCmdOptions {
       llvm::cl::desc("Disable deduplication of structurally identical modules"),
       llvm::cl::init(false)};
 
+  llvm::cl::opt<bool> runWireDFT{
+      "run-wire-dft",
+      llvm::cl::desc("Run the now-deprecated WireDFT transform"),
+      llvm::cl::init(false),
+      llvm::cl::Hidden,
+  };
+
   llvm::cl::opt<firrtl::CompanionMode> companionMode{
       "grand-central-companion-mode",
       llvm::cl::desc("Specifies the handling of Grand Central companions"),
@@ -680,7 +688,8 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       preserveMode(firrtl::PreserveValues::None), enableDebugInfo(false),
       buildMode(BuildModeRelease), disableOptimization(false),
       exportChiselInterface(false), chiselInterfaceOutDirectory(""),
-      vbToBV(false), noDedup(false), companionMode(firrtl::CompanionMode::Bind),
+      vbToBV(false), noDedup(false), runWireDFT(false),
+      companionMode(firrtl::CompanionMode::Bind),
       disableAggressiveMergeConnections(false),
       disableHoistingHWPassthrough(true), emitOMIR(true), omirOutFile(""),
       lowerMemories(false), blackBoxRootPath(""), replSeqMem(false),
@@ -710,6 +719,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   chiselInterfaceOutDirectory = clOptions->chiselInterfaceOutDirectory;
   vbToBV = clOptions->vbToBV;
   noDedup = clOptions->noDedup;
+  runWireDFT = clOptions->runWireDFT;
   companionMode = clOptions->companionMode;
   disableAggressiveMergeConnections =
       clOptions->disableAggressiveMergeConnections;


### PR DESCRIPTION
A hidden command-line argument is added to re-enable the pass on possible backports or during the next release.