### PR TITLE
Make circt-verilog available to integration tests.

### DIFF
--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -206,6 +206,11 @@ if config.lec_enabled != "":
   config.available_features.add('circt-lec')
   tools.append('circt-lec')
 
+# Add circt-verilog if the Slang frontend is enabled.
+if config.slang_frontend_enabled:
+  config.available_features.add('slang')
+  tools.append('circt-verilog')
+
 config.substitutions.append(('%driver', f'{config.driver}'))
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 

--- a/integration_test/lit.site.cfg.py.in
+++ b/integration_test/lit.site.cfg.py.in
@@ -55,6 +55,7 @@ config.esi_collateral_path = "@ESI_COLLATERAL_PATH@"
 config.bindings_python_enabled = @CIRCT_BINDINGS_PYTHON_ENABLED@
 config.bindings_tcl_enabled = @CIRCT_BINDINGS_TCL_ENABLED@
 config.lec_enabled = "@CIRCT_LEC_ENABLED@"
+config.slang_frontend_enabled = "@CIRCT_SLANG_FRONTEND_ENABLED@"
 config.driver = "@CIRCT_SOURCE_DIR@/tools/circt-rtl-sim/driver.cpp"
 
 # Support substitution of the tools_dir with user parameters. This is


### PR DESCRIPTION
Not used yet, but make this available for future use.