### PR TITLE
[LowerClasses] Lower classes that instantiate properties.

### DIFF
--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -327,3 +327,14 @@ firrtl.circuit "AnyCast" {
     firrtl.propassign %foo, %0 : !firrtl.anyref
   }
 }
+
+// CHECK-LABEL: firrtl.circuit "ModuleWithPropertySubmodule"
+firrtl.circuit "ModuleWithPropertySubmodule" {
+  firrtl.module private @ModuleWithPropertySubmodule() {
+    %c0 = firrtl.integer 0
+    %inst.prop = firrtl.instance inst @SubmoduleWithProperty(in prop: !firrtl.integer)
+    firrtl.propassign %inst.prop, %c0 : !firrtl.integer
+  }
+  firrtl.module private @SubmoduleWithProperty(in %prop: !firrtl.integer) {
+  }
+}


### PR DESCRIPTION
The previous logic would create classes for any FIRRTL modules that had property ports. However, if some intermediate modules had property ports, but their parents did not, we would not convert their parents, which would break pass invariants and lead to failed assertions.

This adds logic to also convert any FIRRTL modules that instantiate FIRRTL modules that will be converted. This upholds the pass invariants, and makes it robust in case property ports are used in part of the hierarchy but not exported from the top-level module of the circuit.