### PR TITLE
[ExportVerilog] Fix crash on `sv.reg` with initial value

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -498,7 +498,7 @@ static bool isMovableDeclaration(Operation *op) {
 
   // If all operands (e.g. init value) are constant, it is safe to move
   return llvm::all_of(op->getOperands(), [](Value operand) -> bool {
-    auto defOp = operand.getDefiningOp();
+    auto *defOp = operand.getDefiningOp();
     return !!defOp && isConstantExpression(defOp);
   });
 }

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -163,25 +163,50 @@ static void lowerUsersToTemporaryWire(Operation &op,
 
   auto createWireForResult = [&](Value result, StringAttr name) {
     Value newWire;
-    // If the op is in a procedural region, use logic op.
-    if (isProceduralRegion)
-      newWire = builder.create<LogicOp>(result.getType(), name);
-    else
-      newWire = builder.create<sv::WireOp>(result.getType(), name);
+    Type wireElementType = result.getType();
+    bool isResultInOut = false;
 
-    while (!result.use_empty()) {
-      auto newWireRead = builder.create<ReadInOutOp>(newWire);
-      OpOperand &use = *result.getUses().begin();
-      use.set(newWireRead);
-      newWireRead->moveBefore(use.getOwner());
+    // If the result already is an InOut, make sure to not wrap it again
+    if (auto inoutType = hw::type_dyn_cast<hw::InOutType>(result.getType())) {
+      wireElementType = inoutType.getElementType();
+      isResultInOut = true;
     }
 
-    Operation *connect;
+    // If the op is in a procedural region, use logic op.
     if (isProceduralRegion)
-      connect = builder.create<BPAssignOp>(newWire, result);
+      newWire = builder.create<LogicOp>(wireElementType, name);
     else
-      connect = builder.create<AssignOp>(newWire, result);
+      newWire = builder.create<sv::WireOp>(wireElementType, name);
+
+    // Replace all uses with newWire. Wrap in ReadInOutOp if required.
+    while (!result.use_empty()) {
+      OpOperand &use = *result.getUses().begin();
+      if (isResultInOut) {
+        use.set(newWire);
+      } else {
+        auto newWireRead = builder.create<ReadInOutOp>(newWire);
+        use.set(newWireRead);
+        newWireRead->moveBefore(use.getOwner());
+      }
+    }
+
+    // Assign the original result to the temporary wire.
+    Operation *connect;
+    ReadInOutOp resultRead;
+
+    if (isResultInOut)
+      resultRead = builder.create<ReadInOutOp>(result);
+
+    if (isProceduralRegion)
+      connect = builder.create<BPAssignOp>(
+          newWire, isResultInOut ? resultRead.getResult() : result);
+    else
+      connect = builder.create<AssignOp>(
+          newWire, isResultInOut ? resultRead.getResult() : result);
+
     connect->moveAfter(&op);
+    if (resultRead)
+      resultRead->moveBefore(connect);
 
     // Move the temporary to the appropriate place.
     if (!emitWireAtBlockBegin) {

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -292,3 +292,18 @@ module attributes {circt.loweringOptions = "disallowLocalVariables"} {
   }
   hw.hierpath @xmr [@Foo::@a]
 }
+
+
+// -----
+
+// CHECK-LABEL: @constantInitRegWithBackEdge
+hw.module @constantInitRegWithBackEdge() {
+  // CHECK: %reg = sv.reg init %false : !hw.inout<i1>
+  // CHECK-NEXT: %false = hw.constant false
+  // CHECK-NEXT: %[[VAL_0:.*]] = sv.read_inout %reg : !hw.inout<i1>
+  // CHECK-NEXT: %[[VAL_1:.*]] = comb.or %false, %[[VAL_0]] : i1
+  %false = hw.constant false
+  %0 = comb.or %false, %1 : i1
+  %reg = sv.reg init %false : !hw.inout<i1>
+  %1 = sv.read_inout %reg : !hw.inout<i1>
+}

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -307,3 +307,20 @@ hw.module @constantInitRegWithBackEdge() {
   %reg = sv.reg init %false : !hw.inout<i1>
   %1 = sv.read_inout %reg : !hw.inout<i1>
 }
+
+// -----
+
+// CHECK-LABEL: @temporaryWireForReg
+hw.module @temporaryWireForReg() {
+  // CHECK: %[[WIRE:.*]] = sv.wire : !hw.inout<i1>
+  // CHECK-NEXT: %[[VAL_0:.*]] = sv.read_inout %[[WIRE]]  : !hw.inout<i1>
+  // CHECK-NEXT: %b = sv.reg init %[[VAL_0]] : !hw.inout<i1>
+  // CHECK-NEXT: %[[VAL_1:.*]] = sv.read_inout %b : !hw.inout<i1>
+  // CHECK-NEXT: %a = sv.reg init %[[VAL_1]] : !hw.inout<i1>
+  // CHECK-NEXT: %[[VAL_2:.*]] = sv.read_inout %a : !hw.inout<i1>
+  // CHECK-NEXT: sv.assign %[[WIRE]], %[[VAL_2]] : i1
+  %0 = sv.read_inout %a : !hw.inout<i1>
+  %1 = sv.read_inout %b : !hw.inout<i1>
+  %b = sv.reg init %0 : !hw.inout<i1>
+  %a = sv.reg init %1 : !hw.inout<i1>
+}


### PR DESCRIPTION
When I tried lowering the output of test example in #6649 to SV it crashed in PrepareForEmission. The issue can be reduced to:

```
%false = hw.constant false
%0 = comb.or %false, %1 : i1
%reg = sv.reg init %false : !hw.inout<i1>
%1 = sv.read_inout %reg : !hw.inout<i1>
```

The presence of an initial value prevents the register and `ReadInOutOp` from being moved to the top of the module. The pass then attempts to create a temporary wire to remove the backedge on `%1`. This fails because the value is already an InOut type.

This PR changes `isMovableDeclaration` to allow operations to be lifted if all their operands are constant expressions, which in most cases should avoid the backedge for the `ReadInOutOp`. While this may technically break dominance, it should not cause a problem during emission as the constant expressions are emitted inline. (If it turns out to be a problem after all, we could also move the constants.)

Additionally, `lowerUsersToTemporaryWire` is adapted to handle InOut values in case a backedge remains.