### PR TITLE
[FIRRTL] Use untyped propassign source accessor in LowerClasses.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -760,7 +760,7 @@ updateInstanceInClass(InstanceOp firrtlInstance, hw::HierPathOp hierPath,
     // Value as an actual parameter to the Object instance.
     auto propertyAssignment = getPropertyAssignment(propertyResult);
     assert(propertyAssignment && "properties require single assignment");
-    actualParameters.push_back(propertyAssignment.getSrc());
+    actualParameters.push_back(propertyAssignment.getSrcMutable().get());
 
     // Erase the property assignment.
     opsToErase.push_back(propertyAssignment);

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -338,3 +338,19 @@ firrtl.circuit "ModuleWithPropertySubmodule" {
   firrtl.module private @SubmoduleWithProperty(in %prop: !firrtl.integer) {
   }
 }
+
+// CHECK-LABEL: firrtl.circuit "DownwardReferences"
+firrtl.circuit "DownwardReferences" {
+  firrtl.class @MyClass() {
+  }
+  firrtl.module @MyClassUser(in %myClassIn: !firrtl.class<@MyClass()>) {
+  }
+  firrtl.module @DownwardReferences() {
+    // CHECK: [[OBJ:%.+]] = om.object @MyClass
+    %myClass = firrtl.object @MyClass()
+    // CHECK: [[BP:%.+]] = om.basepath_create
+    // CHECK: om.object @MyClassUser_Class([[BP]], [[OBJ]])
+    %myClassUser.myClassIn = firrtl.instance myClassUser @MyClassUser(in myClassIn: !firrtl.class<@MyClass()>)
+    firrtl.propassign %myClassUser.myClassIn, %myClass : !firrtl.class<@MyClass()>
+  }
+}


### PR DESCRIPTION
When lowering object instantiations, we need to get the source from a propassign to pass that Value to the newly created OM dialect object op. However, in some cases, like when passing references to objects down the hierarchy, we have already converted the source Value to an OM dialect object op. This means the typed getSrc accessor will fail, as it expects the source Value to be a FIRRTLType.

The IR is in the desired state at this point, so instead we can simply use the untyped getSrcMutable accessor to get the corresponding OpOperand, and get the Value from there. This avoids errors when the pass has knowingly put the IR into a state that won't pass the verifier.