### PR TITLE
[FIRRTL] Add integer addition property op.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1192,7 +1192,7 @@ def IntegerAddOp : IntegerBinaryPrimOp<"integer.add", [Commutative]> {
   let summary = "Add two FIntegerType values";
   let description = [{
     The add operation result is the arbitrary precision signed integer
-    arithmetic sum of the two
+    arithmetic sum of the two operands.
 
     Example:
     ```mlir

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1181,6 +1181,26 @@ def DoubleConstantOp : FIRRTLOp<"double", [Pure, ConstantLike]> {
   let assemblyFormat = "$value attr-dict";
 }
 
+class IntegerBinaryPrimOp<string mnemonic, list<Trait> traits = []> :
+   BinaryPrimOp<mnemonic, FIntegerType, FIntegerType, FIntegerType,
+                [Pure] # traits> {
+  let inferType = "impl::inferIntegerBinaryPrimResult";
+}
+
+def IntegerAddOp : IntegerBinaryPrimOp<"integer.add", [Commutative]> {
+  let summary = "Add two FIntegerType values";
+  let description = [{
+    The add operation result is the arbitrary precision signed integer
+    arithmetic sum of `lhs` and `rhs`.
+
+    Example:
+    ```mlir
+    %2 = firrtl.integer.add %0, %1 : (!firrtl.integer, !firrtl.integer) ->
+                                         !firrtl.integer
+    ```
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // RefOperations: Operations on the RefType.
 //

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1183,15 +1183,16 @@ def DoubleConstantOp : FIRRTLOp<"double", [Pure, ConstantLike]> {
 
 class IntegerBinaryPrimOp<string mnemonic, list<Trait> traits = []> :
    BinaryPrimOp<mnemonic, FIntegerType, FIntegerType, FIntegerType,
-                [Pure] # traits> {
-  let inferType = "impl::inferIntegerBinaryPrimResult";
+                [Pure, SameOperandsAndResultType] # traits> {
+  // We use the standard inferReturnTypes from SameOperandsAndResultType.
+  let inferReturnTypesDecl = "";
 }
 
 def IntegerAddOp : IntegerBinaryPrimOp<"integer.add", [Commutative]> {
   let summary = "Add two FIntegerType values";
   let description = [{
     The add operation result is the arbitrary precision signed integer
-    arithmetic sum of `lhs` and `rhs`.
+    arithmetic sum of the two
 
     Example:
     ```mlir

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -156,6 +156,8 @@ FIRRTLType inferElementwiseResult(FIRRTLType lhs, FIRRTLType rhs,
                                   std::optional<Location> loc);
 FIRRTLType inferComparisonResult(FIRRTLType lhs, FIRRTLType rhs,
                                  std::optional<Location> loc);
+FIRRTLType inferIntegerBinaryPrimResult(FIRRTLType lhs, FIRRTLType rhs,
+                                        std::optional<Location> loc);
 FIRRTLType inferReductionResult(FIRRTLType arg, std::optional<Location> loc);
 
 // Common parsed argument validation functions.

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -156,8 +156,6 @@ FIRRTLType inferElementwiseResult(FIRRTLType lhs, FIRRTLType rhs,
                                   std::optional<Location> loc);
 FIRRTLType inferComparisonResult(FIRRTLType lhs, FIRRTLType rhs,
                                  std::optional<Location> loc);
-FIRRTLType inferIntegerBinaryPrimResult(FIRRTLType lhs, FIRRTLType rhs,
-                                        std::optional<Location> loc);
 FIRRTLType inferReductionResult(FIRRTLType arg, std::optional<Location> loc);
 
 // Common parsed argument validation functions.

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -935,6 +935,11 @@ LogicalResult NEQPrimOp::canonicalize(NEQPrimOp op, PatternRewriter &rewriter) {
       });
 }
 
+OpFoldResult IntegerAddOp::fold(FoldAdaptor adaptor) {
+  // TODO: implement constant folding, etc.
+  return {};
+}
+
 //===----------------------------------------------------------------------===//
 // Unary Operators
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -937,6 +937,7 @@ LogicalResult NEQPrimOp::canonicalize(NEQPrimOp op, PatternRewriter &rewriter) {
 
 OpFoldResult IntegerAddOp::fold(FoldAdaptor adaptor) {
   // TODO: implement constant folding, etc.
+  // Tracked in https://github.com/llvm/circt/issues/6696.
   return {};
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4987,11 +4987,6 @@ FIRRTLType DShrPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
   return lhsi.getConstType(lhsi.isConst() && rhsu.isConst());
 }
 
-FIRRTLType impl::inferIntegerBinaryPrimResult(FIRRTLType lhs, FIRRTLType rhs,
-                                              std::optional<Location> loc) {
-  return FIntegerType::get(lhs.getContext());
-}
-
 //===----------------------------------------------------------------------===//
 // Unary Primitives
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4987,6 +4987,11 @@ FIRRTLType DShrPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
   return lhsi.getConstType(lhsi.isConst() && rhsu.isConst());
 }
 
+FIRRTLType impl::inferIntegerBinaryPrimResult(FIRRTLType lhs, FIRRTLType rhs,
+                                              std::optional<Location> loc) {
+  return FIntegerType::get(lhs.getContext());
+}
+
 //===----------------------------------------------------------------------===//
 // Unary Primitives
 //===----------------------------------------------------------------------===//
@@ -5748,6 +5753,9 @@ void GTPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
 void HeadPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
+void IntegerAddOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
 void IsTagOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -71,4 +71,13 @@ firrtl.module @Layers(
 firrtl.module @LayersEnabled() attributes {layers = [@LayerA]} {
 }
 
+// CHECK-LABEL: firrtl.module @PropertyArithmetic
+firrtl.module @PropertyArithmetic() {
+  %0 = firrtl.integer 1
+  %1 = firrtl.integer 2
+
+  // CHECK: firrtl.integer.add %0, %1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+  %2 = firrtl.integer.add %0, %1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+}
+
 }


### PR DESCRIPTION
This op adds two FIntegerType operands to produce an FIntegerType result. This defines the usual fold and result type inference hooks required on BinaryPrimOp, but doesn't add any folders yet.