### PR TITLE
[arcilator] Introduce simulation orchestration subdialect

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -573,7 +573,7 @@ def StateWriteOp : ArcOp<"state_write", [
 def SimInstantiate : ArcOp<"sim.instantiate"> {
   let summary = "Instantiates an Arc model for simulation";
   let description = [{
-    TODO
+    Creates an instance of an Arc model in scope, in order to simulate it.
   }];
   let results = (outs SimModelInstance:$instance);
   let assemblyFormat = [{ attr-dict `:` qualified(type($instance)) }];
@@ -582,35 +582,47 @@ def SimInstantiate : ArcOp<"sim.instantiate"> {
 def SimSetInput : ArcOp<"sim.set_input"> {
   let summary = "Sets the value of an input of the model instance";
   let description = [{
-    TODO
+    Sets the value of an input port in a specific instance of a model. The
+    provided input port must be of input type and contain an integer of the
+    right size.
   }];
-  let arguments = (ins SimModelInstance:$instance, StrAttr:$input, AnyInteger:$value);
-  let assemblyFormat = [{ $instance `,` $input `=` $value attr-dict `:` type($value) `,` qualified(type($instance)) }];
+  let arguments = (ins SimModelInstance:$instance,
+                       StrAttr:$input,
+                       AnyInteger:$value);
+  let assemblyFormat =
+    [{ $instance `,` $input `=` $value attr-dict
+       `:` type($value) `,` qualified(type($instance)) }];
 }
 
 def SimGetPort : ArcOp<"sim.get_port"> {
   let summary = "Gets the value of a port of the model instance";
   let description = [{
-    TODO
+    Gets the value of the given port in a specific instance of a model. The
+    provided input port must be of the provided size.
   }];
   let arguments = (ins SimModelInstance:$instance, StrAttr:$port);
   let results = (outs AnyInteger:$value);
-  let assemblyFormat = [{ $instance `,` $port attr-dict `:` type($value) `,` qualified(type($instance)) }];
+  let assemblyFormat =
+    [{ $instance `,` $port attr-dict
+       `:` type($value) `,` qualified(type($instance)) }];
 }
 
 def SimStep : ArcOp<"sim.step"> {
-  let summary = "Evaluates one step of the simulation for the provided model instance";
+  let summary =
+    "Evaluates one step of the simulation for the provided model instance";
   let description = [{
-    TODO
+    Evaluates one step of the simulation for the provided model instance,
   }];
   let arguments = (ins SimModelInstance:$instance);
-  let assemblyFormat = [{ $instance attr-dict `:` qualified(type($instance)) }];
+  let assemblyFormat =
+    [{ $instance attr-dict `:` qualified(type($instance)) }];
 }
 
 def SimEmitValue : ArcOp<"sim.emit"> {
   let summary = "Sends a value to the simulation driver";
   let description = [{
-    TODO
+    Sends a named value to the simulation driver. This is notably useful
+    for printing values during simulation.
   }];
   let arguments = (ins StrAttr:$valueName, AnyInteger:$value);
   let assemblyFormat = [{ $valueName `,` $value attr-dict `:` type($value) }];

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -576,7 +576,7 @@ def SimInstantiate : ArcOp<"sim.instantiate"> {
     TODO
   }];
   let results = (outs SimModelInstance:$instance);
-  let assemblyFormat = [{ attr-dict `:` type($instance) }];
+  let assemblyFormat = [{ attr-dict `:` qualified(type($instance)) }];
 }
 
 def SimSetInput : ArcOp<"sim.set_input"> {
@@ -585,7 +585,7 @@ def SimSetInput : ArcOp<"sim.set_input"> {
     TODO
   }];
   let arguments = (ins SimModelInstance:$instance, StrAttr:$input, AnyInteger:$value);
-  let assemblyFormat = [{ $instance `,` $input `=` $value attr-dict `:` type($value) `,` type($instance) }];
+  let assemblyFormat = [{ $instance `,` $input `=` $value attr-dict `:` type($value) `,` qualified(type($instance)) }];
 }
 
 def SimGetPort : ArcOp<"sim.get_port"> {
@@ -595,7 +595,7 @@ def SimGetPort : ArcOp<"sim.get_port"> {
   }];
   let arguments = (ins SimModelInstance:$instance, StrAttr:$port);
   let results = (outs AnyInteger:$value);
-  let assemblyFormat = [{ $instance `,` $port attr-dict `:` type($value) `,` type($instance) }];
+  let assemblyFormat = [{ $instance `,` $port attr-dict `:` type($value) `,` qualified(type($instance)) }];
 }
 
 def SimStep : ArcOp<"sim.step"> {
@@ -604,7 +604,16 @@ def SimStep : ArcOp<"sim.step"> {
     TODO
   }];
   let arguments = (ins SimModelInstance:$instance);
-  let assemblyFormat = [{ $instance attr-dict `:` type($instance) }];
+  let assemblyFormat = [{ $instance attr-dict `:` qualified(type($instance)) }];
+}
+
+def SimEmitValue : ArcOp<"sim.emit"> {
+  let summary = "Sends a value to the simulation driver";
+  let description = [{
+    TODO
+  }];
+  let arguments = (ins StrAttr:$valueName, AnyInteger:$value);
+  let assemblyFormat = [{ $valueName `,` $value attr-dict `:` type($value) }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -10,9 +10,10 @@
 #define CIRCT_DIALECT_ARC_ARCOPS_TD
 
 include "circt/Dialect/Arc/ArcDialect.td"
-include "circt/Dialect/Arc/ArcTypes.td"
-include "circt/Dialect/Seq/SeqTypes.td"
 include "circt/Dialect/Arc/ArcInterfaces.td"
+include "circt/Dialect/Arc/ArcTypes.td"
+include "circt/Dialect/HW/HWTypes.td"
+include "circt/Dialect/Seq/SeqTypes.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/Interfaces/FunctionInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
@@ -570,8 +571,9 @@ def StateWriteOp : ArcOp<"state_write", [
 // Simulation Orchestration
 //===----------------------------------------------------------------------===//
 
-def SimInstantiateOp : ArcOp<"sim.instantiate", [MemoryEffects<[MemAlloc]>,
-                                                 NoTerminator]> {
+def SimInstantiateOp : ArcOp<"sim.instantiate",
+  [MemoryEffects<[MemAlloc]>, NoTerminator,
+   DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Instantiates an Arc model for simulation";
   let description = [{
     Creates an instance of an Arc model in scope, in order to simulate it.
@@ -584,7 +586,9 @@ def SimInstantiateOp : ArcOp<"sim.instantiate", [MemoryEffects<[MemAlloc]>,
   let hasCustomAssemblyFormat = 1;
 }
 
-def SimSetInputOp : ArcOp<"sim.set_input", [MemoryEffects<[MemWrite]>]> {
+def SimSetInputOp : ArcOp<"sim.set_input",
+  [MemoryEffects<[MemWrite]>,
+   DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Sets the value of an input of the model instance";
   let description = [{
     Sets the value of an input port in a specific instance of a model. The
@@ -593,26 +597,29 @@ def SimSetInputOp : ArcOp<"sim.set_input", [MemoryEffects<[MemWrite]>]> {
   }];
   let arguments = (ins SimModelInstance:$instance,
                        StrAttr:$input,
-                       AnyInteger:$value);
+                       AnyType:$value);
   let assemblyFormat =
     [{ $instance `,` $input `=` $value attr-dict
        `:` type($value) `,` qualified(type($instance)) }];
 }
 
-def SimGetPortOp : ArcOp<"sim.get_port", [MemoryEffects<[MemRead]>]> {
+def SimGetPortOp : ArcOp<"sim.get_port",
+  [MemoryEffects<[MemRead]>, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Gets the value of a port of the model instance";
   let description = [{
     Gets the value of the given port in a specific instance of a model. The
     provided input port must be of the provided size.
   }];
   let arguments = (ins SimModelInstance:$instance, StrAttr:$port);
-  let results = (outs AnyInteger:$value);
+  let results = (outs AnyType:$value);
   let assemblyFormat =
     [{ $instance `,` $port attr-dict
        `:` type($value) `,` qualified(type($instance)) }];
 }
 
-def SimStepOp : ArcOp<"sim.step", [MemoryEffects<[MemRead, MemWrite]>]> {
+def SimStepOp : ArcOp<"sim.step",
+  [MemoryEffects<[MemRead, MemWrite]>,
+   DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary =
     "Evaluates one step of the simulation for the provided model instance";
   let description = [{
@@ -630,7 +637,7 @@ def SimEmitValueOp : ArcOp<"sim.emit"> {
     Sends a named value to the simulation driver. This is notably useful
     for printing values during simulation.
   }];
-  let arguments = (ins StrAttr:$valueName, AnyInteger:$value);
+  let arguments = (ins StrAttr:$valueName, AnyType:$value);
   let assemblyFormat = [{ $valueName `,` $value attr-dict `:` type($value) }];
 }
 
@@ -645,13 +652,18 @@ def TapOp : ArcOp<"tap"> {
 }
 
 def ModelOp : ArcOp<"model", [RegionKindInterface, IsolatedFromAbove,
-                              NoTerminator]> {
+                              NoTerminator, Symbol]> {
   let summary = "A model with stratified clocks";
-  let arguments = (ins StrAttr:$name);
+  let description = [{
+    A model with stratified clocks. The `io` optional attribute
+    specifies the I/O of the module associated to this model.
+  }];
+  let arguments = (ins StrAttr:$sym_name,
+                       TypeAttrOf<ModuleType>:$io);
   let regions = (region SizedRegion<1>:$body);
 
   let assemblyFormat = [{
-    $name attr-dict-with-keyword $body
+    $sym_name `io` $io attr-dict-with-keyword $body
   }];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -570,16 +570,21 @@ def StateWriteOp : ArcOp<"state_write", [
 // Simulation Orchestration
 //===----------------------------------------------------------------------===//
 
-def SimInstantiate : ArcOp<"sim.instantiate"> {
+def SimInstantiateOp : ArcOp<"sim.instantiate", [MemoryEffects<[MemAlloc]>,
+                                                 NoTerminator]> {
   let summary = "Instantiates an Arc model for simulation";
   let description = [{
     Creates an instance of an Arc model in scope, in order to simulate it.
+    The model can be used from within the associated region, modelling its
+    lifetime.
   }];
-  let results = (outs SimModelInstance:$instance);
-  let assemblyFormat = [{ attr-dict `:` qualified(type($instance)) }];
+  let regions = (region SizedRegion<1>:$body);
+
+  let hasRegionVerifier = 1;
+  let hasCustomAssemblyFormat = 1;
 }
 
-def SimSetInput : ArcOp<"sim.set_input"> {
+def SimSetInputOp : ArcOp<"sim.set_input", [MemoryEffects<[MemWrite]>]> {
   let summary = "Sets the value of an input of the model instance";
   let description = [{
     Sets the value of an input port in a specific instance of a model. The
@@ -594,7 +599,7 @@ def SimSetInput : ArcOp<"sim.set_input"> {
        `:` type($value) `,` qualified(type($instance)) }];
 }
 
-def SimGetPort : ArcOp<"sim.get_port"> {
+def SimGetPortOp : ArcOp<"sim.get_port", [MemoryEffects<[MemRead]>]> {
   let summary = "Gets the value of a port of the model instance";
   let description = [{
     Gets the value of the given port in a specific instance of a model. The
@@ -607,18 +612,19 @@ def SimGetPort : ArcOp<"sim.get_port"> {
        `:` type($value) `,` qualified(type($instance)) }];
 }
 
-def SimStep : ArcOp<"sim.step"> {
+def SimStepOp : ArcOp<"sim.step", [MemoryEffects<[MemRead, MemWrite]>]> {
   let summary =
     "Evaluates one step of the simulation for the provided model instance";
   let description = [{
     Evaluates one step of the simulation for the provided model instance,
+    updating ports accordingly.
   }];
   let arguments = (ins SimModelInstance:$instance);
   let assemblyFormat =
     [{ $instance attr-dict `:` qualified(type($instance)) }];
 }
 
-def SimEmitValue : ArcOp<"sim.emit"> {
+def SimEmitValueOp : ArcOp<"sim.emit"> {
   let summary = "Sends a value to the simulation driver";
   let description = [{
     Sends a named value to the simulation driver. This is notably useful

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -592,8 +592,8 @@ def SimSetInputOp : ArcOp<"sim.set_input",
   let summary = "Sets the value of an input of the model instance";
   let description = [{
     Sets the value of an input port in a specific instance of a model. The
-    provided input port must be of input type and contain an integer of the
-    right size.
+    provided input port must be of input type on the model and its type must
+    match the type of the value operand.
   }];
   let arguments = (ins SimModelInstance:$instance,
                        StrAttr:$input,
@@ -608,7 +608,7 @@ def SimGetPortOp : ArcOp<"sim.get_port",
   let summary = "Gets the value of a port of the model instance";
   let description = [{
     Gets the value of the given port in a specific instance of a model. The
-    provided input port must be of the provided size.
+    provided port must be of the type of the expected value.
   }];
   let arguments = (ins SimModelInstance:$instance, StrAttr:$port);
   let results = (outs AnyType:$value);
@@ -658,7 +658,7 @@ def ModelOp : ArcOp<"model", [RegionKindInterface, IsolatedFromAbove,
     A model with stratified clocks. The `io` optional attribute
     specifies the I/O of the module associated to this model.
   }];
-  let arguments = (ins StrAttr:$sym_name,
+  let arguments = (ins SymbolNameAttr:$sym_name,
                        TypeAttrOf<ModuleType>:$io);
   let regions = (region SizedRegion<1>:$body);
 

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -567,6 +567,47 @@ def StateWriteOp : ArcOp<"state_write", [
 }
 
 //===----------------------------------------------------------------------===//
+// Simulation Orchestration
+//===----------------------------------------------------------------------===//
+
+def SimInstantiate : ArcOp<"sim.instantiate"> {
+  let summary = "Instantiates an Arc model for simulation";
+  let description = [{
+    TODO
+  }];
+  let results = (outs SimModelInstance:$instance);
+  let assemblyFormat = [{ attr-dict `:` type($instance) }];
+}
+
+def SimSetInput : ArcOp<"sim.set_input"> {
+  let summary = "Sets the value of an input of the model instance";
+  let description = [{
+    TODO
+  }];
+  let arguments = (ins SimModelInstance:$instance, StrAttr:$input, AnyInteger:$value);
+  let assemblyFormat = [{ $instance `,` $input `=` $value attr-dict `:` type($value) `,` type($instance) }];
+}
+
+def SimGetPort : ArcOp<"sim.get_port"> {
+  let summary = "Gets the value of a port of the model instance";
+  let description = [{
+    TODO
+  }];
+  let arguments = (ins SimModelInstance:$instance, StrAttr:$port);
+  let results = (outs AnyInteger:$value);
+  let assemblyFormat = [{ $instance `,` $port attr-dict `:` type($value) `,` type($instance) }];
+}
+
+def SimStep : ArcOp<"sim.step"> {
+  let summary = "Evaluates one step of the simulation for the provided model instance";
+  let description = [{
+    TODO
+  }];
+  let arguments = (ins SimModelInstance:$instance);
+  let assemblyFormat = [{ $instance attr-dict `:` type($instance) }];
+}
+
+//===----------------------------------------------------------------------===//
 // Miscellaneous
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/Arc/ArcTypes.h
+++ b/include/circt/Dialect/Arc/ArcTypes.h
@@ -9,6 +9,7 @@
 #ifndef CIRCT_DIALECT_ARC_ARCTYPES_H
 #define CIRCT_DIALECT_ARC_ARCTYPES_H
 
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Types.h"
 

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -49,4 +49,10 @@ def StorageType : ArcTypeDef<"Storage"> {
   let assemblyFormat = "(`<` $size^ `>`)?";
 }
 
+def SimModelInstance : ArcTypeDef<"SimModelInstance"> {
+  let mnemonic = "sim.model";
+  let parameters = (ins "mlir::StringAttr":$model);
+  let assemblyFormat = "$model";
+}
+
 #endif // CIRCT_DIALECT_ARC_ARCTYPES_TD

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -51,7 +51,7 @@ def StorageType : ArcTypeDef<"Storage"> {
 
 def SimModelInstance : ArcTypeDef<"SimModelInstance"> {
   let mnemonic = "sim.instance";
-  let parameters = (ins "mlir::StringAttr":$model);
+  let parameters = (ins "mlir::FlatSymbolRefAttr":$model);
   let assemblyFormat = "`<` $model `>`";
 }
 

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -50,9 +50,9 @@ def StorageType : ArcTypeDef<"Storage"> {
 }
 
 def SimModelInstance : ArcTypeDef<"SimModelInstance"> {
-  let mnemonic = "sim.model";
+  let mnemonic = "sim.instance";
   let parameters = (ins "mlir::StringAttr":$model);
-  let assemblyFormat = "$model";
+  let assemblyFormat = "`<` $model `>`";
 }
 
 #endif // CIRCT_DIALECT_ARC_ARCTYPES_TD

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -608,18 +608,16 @@ void LowerArcToLLVMPass::runOnOperation() {
     llvm::DenseMap<StringRef, StateInfo> states(modelInfo.states.size());
     for (StateInfo &stateInfo : modelInfo.states)
       states.insert({stateInfo.name, stateInfo});
-    modelMap.insert({modelInfo.name, ModelInfoMap {
-      .numStateBytes = modelInfo.numStateBytes,
-      .states = std::move(states),
-    }});
+    modelMap.insert(
+        {modelInfo.name, ModelInfoMap{
+                             .numStateBytes = modelInfo.numStateBytes,
+                             .states = std::move(states),
+                         }});
   }
 
-  patterns.add<
-    SimInstantiateOpLowering,
-    SimSetInputOpLowering,
-    SimGetPortOpLowering,
-    SimStepOpLowering
-  >(converter, &getContext(), modelMap);
+  patterns.add<SimInstantiateOpLowering, SimSetInputOpLowering,
+               SimGetPortOpLowering, SimStepOpLowering>(
+      converter, &getContext(), modelMap);
 
   // Apply the conversion.
   if (failed(applyFullConversion(getOperation(), target, std::move(patterns))))

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -345,7 +345,8 @@ struct SimInstantiateOpLowering
                   ConversionPatternRewriter &rewriter) const final {
     auto modelIt = modelInfo.find(
         cast<SimModelInstanceType>(op.getBody().getArgument(0).getType())
-            .getModel().getValue());
+            .getModel()
+            .getValue());
     ModelInfoMap &model = modelIt->second;
 
     ModuleOp moduleOp = op->getParentOfType<ModuleOp>();
@@ -385,8 +386,10 @@ struct SimSetInputOpLowering : public ModelAwarePattern<arc::SimSetInputOp> {
   LogicalResult
   matchAndRewrite(arc::SimSetInputOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    auto modelIt = modelInfo.find(
-        cast<SimModelInstanceType>(op.getInstance().getType()).getModel().getValue());
+    auto modelIt =
+        modelInfo.find(cast<SimModelInstanceType>(op.getInstance().getType())
+                           .getModel()
+                           .getValue());
     ModelInfoMap &model = modelIt->second;
 
     auto portIt = model.states.find(op.getInput());
@@ -413,8 +416,10 @@ struct SimGetPortOpLowering : public ModelAwarePattern<arc::SimGetPortOp> {
   LogicalResult
   matchAndRewrite(arc::SimGetPortOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    auto modelIt = modelInfo.find(
-        cast<SimModelInstanceType>(op.getInstance().getType()).getModel().getValue());
+    auto modelIt =
+        modelInfo.find(cast<SimModelInstanceType>(op.getInstance().getType())
+                           .getModel()
+                           .getValue());
     ModelInfoMap &model = modelIt->second;
 
     auto portIt = model.states.find(op.getPort());
@@ -442,8 +447,9 @@ struct SimStepOpLowering : public ModelAwarePattern<arc::SimStepOp> {
   LogicalResult
   matchAndRewrite(arc::SimStepOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    StringRef modelName =
-        cast<SimModelInstanceType>(op.getInstance().getType()).getModel().getValue();
+    StringRef modelName = cast<SimModelInstanceType>(op.getInstance().getType())
+                              .getModel()
+                              .getValue();
 
     StringAttr evalFunc =
         rewriter.getStringAttr(evalSymbolFromModelName(modelName));

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -345,7 +345,7 @@ struct SimInstantiateOpLowering
                   ConversionPatternRewriter &rewriter) const final {
     auto modelIt = modelInfo.find(
         cast<SimModelInstanceType>(op.getBody().getArgument(0).getType())
-            .getModel());
+            .getModel().getValue());
     ModelInfoMap &model = modelIt->second;
 
     ModuleOp moduleOp = op->getParentOfType<ModuleOp>();
@@ -386,7 +386,7 @@ struct SimSetInputOpLowering : public ModelAwarePattern<arc::SimSetInputOp> {
   matchAndRewrite(arc::SimSetInputOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     auto modelIt = modelInfo.find(
-        cast<SimModelInstanceType>(op.getInstance().getType()).getModel());
+        cast<SimModelInstanceType>(op.getInstance().getType()).getModel().getValue());
     ModelInfoMap &model = modelIt->second;
 
     auto portIt = model.states.find(op.getInput());
@@ -414,7 +414,7 @@ struct SimGetPortOpLowering : public ModelAwarePattern<arc::SimGetPortOp> {
   matchAndRewrite(arc::SimGetPortOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     auto modelIt = modelInfo.find(
-        cast<SimModelInstanceType>(op.getInstance().getType()).getModel());
+        cast<SimModelInstanceType>(op.getInstance().getType()).getModel().getValue());
     ModelInfoMap &model = modelIt->second;
 
     auto portIt = model.states.find(op.getPort());
@@ -443,7 +443,7 @@ struct SimStepOpLowering : public ModelAwarePattern<arc::SimStepOp> {
   matchAndRewrite(arc::SimStepOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     StringRef modelName =
-        cast<SimModelInstanceType>(op.getInstance().getType()).getModel();
+        cast<SimModelInstanceType>(op.getInstance().getType()).getModel().getValue();
 
     StringAttr evalFunc =
         rewriter.getStringAttr(evalSymbolFromModelName(modelName));

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -595,7 +595,7 @@ void LowerArcToLLVMPass::runOnOperation() {
     StorageGetOpLowering,
     ZeroCountOpLowering
   >(converter, &getContext());
-  // clang-format
+  // clang-format on
 
   SmallVector<ModelInfo> models;
   if (failed(collectModels(getOperation(), models))) {

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -485,9 +485,7 @@ void SimInstantiateOp::print(OpAsmPrinter &p) {
   BlockArgument modelArg = getBody().getArgument(0);
   auto modelType = cast<SimModelInstanceType>(modelArg.getType());
 
-  p << " ";
-  p.printSymbolName(modelType.getModel());
-  p << " as ";
+  p << " " << modelType.getModel() << " as ";
   p.printRegionArgument(modelArg, {}, true);
 
   p.printOptionalAttrDictWithKeyword(getOperation()->getAttrs());
@@ -513,7 +511,9 @@ ParseResult SimInstantiateOp::parse(OpAsmParser &parser,
   if (failed(parser.parseOptionalAttrDictWithKeyword(result.attributes)))
     return failure();
 
-  modelArg.type = SimModelInstanceType::get(result.getContext(), modelName);
+  auto ctxt = result.getContext();
+  modelArg.type =
+      SimModelInstanceType::get(ctxt, FlatSymbolRefAttr::get(ctxt, modelName));
 
   std::unique_ptr<Region> body = std::make_unique<Region>();
   if (failed(parser.parseRegion(*body, {modelArg})))
@@ -538,7 +538,8 @@ SimInstantiateOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   Operation *moduleOp = getSupportedModuleOp(
       symbolTable, getOperation(),
       llvm::cast<SimModelInstanceType>(getBody().getArgument(0).getType())
-          .getModel());
+          .getModel()
+          .getAttr());
   if (!moduleOp)
     return failure();
 
@@ -553,7 +554,9 @@ LogicalResult
 SimSetInputOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   Operation *moduleOp = getSupportedModuleOp(
       symbolTable, getOperation(),
-      llvm::cast<SimModelInstanceType>(getInstance().getType()).getModel());
+      llvm::cast<SimModelInstanceType>(getInstance().getType())
+          .getModel()
+          .getAttr());
   if (!moduleOp)
     return failure();
 
@@ -581,7 +584,9 @@ LogicalResult
 SimGetPortOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   Operation *moduleOp = getSupportedModuleOp(
       symbolTable, getOperation(),
-      llvm::cast<SimModelInstanceType>(getInstance().getType()).getModel());
+      llvm::cast<SimModelInstanceType>(getInstance().getType())
+          .getModel()
+          .getAttr());
   if (!moduleOp)
     return failure();
 
@@ -604,7 +609,9 @@ SimGetPortOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 LogicalResult SimStepOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   Operation *moduleOp = getSupportedModuleOp(
       symbolTable, getOperation(),
-      llvm::cast<SimModelInstanceType>(getInstance().getType()).getModel());
+      llvm::cast<SimModelInstanceType>(getInstance().getType())
+          .getModel()
+          .getAttr());
   if (!moduleOp)
     return failure();
 

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -7,12 +7,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/FunctionImplementation.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using namespace circt;
 using namespace arc;
@@ -68,6 +71,32 @@ static LogicalResult verifyArcSymbolUse(Operation *op, TypeRange inputs,
     return failure();
 
   return success();
+}
+
+static bool isSupportedModuleOp(Operation *moduleOp) {
+  return llvm::isa<arc::ModelOp, hw::HWModuleLike>(moduleOp);
+}
+
+static std::optional<hw::ModulePort> getModulePort(Operation *moduleOp,
+                                                   StringRef portName) {
+  auto findRightPort = [&](auto ports) -> std::optional<hw::ModulePort> {
+    const hw::ModulePort *port = llvm::find_if(
+        ports, [&](hw::ModulePort port) { return port.name == portName; });
+    if (port == ports.end())
+      return std::nullopt;
+    return *port;
+  };
+
+  return TypeSwitch<Operation *, std::optional<hw::ModulePort>>(moduleOp)
+      .Case<arc::ModelOp>(
+          [&](arc::ModelOp modelOp) -> std::optional<hw::ModulePort> {
+            return findRightPort(modelOp.getIo().getPorts());
+          })
+      .Case<hw::HWModuleLike>(
+          [&](hw::HWModuleLike moduleLike) -> std::optional<hw::ModulePort> {
+            return findRightPort(moduleLike.getPortList());
+          })
+      .Default([](Operation *) { return std::nullopt; });
 }
 
 //===----------------------------------------------------------------------===//
@@ -252,6 +281,9 @@ LogicalResult ModelOp::verify() {
   if (auto type = getBodyBlock().getArgument(0).getType();
       !isa<StorageType>(type))
     return emitOpError("argument must be of storage type");
+  for (const hw::ModulePort &port : getIo().getPorts())
+    if (port.dir == hw::ModulePort::Direction::InOut)
+      return emitOpError("inout ports are not supported");
   return success();
 }
 
@@ -472,6 +504,100 @@ LogicalResult SimInstantiateOp::verifyRegions() {
                      "as a single argument");
   if (!llvm::isa<SimModelInstanceType>(body.getArgument(0).getType()))
     return emitError("entry block argument type is not a model instance");
+  return success();
+}
+
+LogicalResult
+SimInstantiateOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  Operation *moduleOp = symbolTable.lookupNearestSymbolFrom(
+      getOperation(),
+      llvm::cast<SimModelInstanceType>(getBody().getArgument(0).getType())
+          .getModel());
+  if (!moduleOp)
+    return emitOpError("model not found");
+
+  if (!isSupportedModuleOp(moduleOp))
+    return emitOpError(
+        "model symbol does not point to a supported model operation");
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// SimSetInputOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+SimSetInputOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  Operation *moduleOp = symbolTable.lookupNearestSymbolFrom(
+      getOperation(),
+      llvm::cast<SimModelInstanceType>(getInstance().getType()).getModel());
+  if (!moduleOp)
+    return emitOpError("model not found");
+
+  if (!isSupportedModuleOp(moduleOp))
+    return emitOpError(
+        "model symbol does not point to a supported model operation");
+
+  std::optional<hw::ModulePort> port = getModulePort(moduleOp, getInput());
+  if (!port)
+    return emitOpError("port not found on model");
+
+  if (port->dir != hw::ModulePort::Direction::Input &&
+      port->dir != hw::ModulePort::Direction::InOut)
+    return emitOpError("port is not an input port");
+
+  if (port->type != getValue().getType())
+    return emitOpError(
+               "mismatched types between value and model port, port expects ")
+           << port->type;
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// SimGetPortOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+SimGetPortOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  Operation *moduleOp = symbolTable.lookupNearestSymbolFrom(
+      getOperation(),
+      llvm::cast<SimModelInstanceType>(getInstance().getType()).getModel());
+  if (!moduleOp)
+    return emitOpError("model not found");
+
+  if (!isSupportedModuleOp(moduleOp))
+    return emitOpError(
+        "model symbol does not point to a supported model operation");
+
+  std::optional<hw::ModulePort> port = getModulePort(moduleOp, getPort());
+  if (!port)
+    return emitOpError("port not found on model");
+
+  if (port->type != getValue().getType())
+    return emitOpError(
+               "mismatched types between value and model port, port expects ")
+           << port->type;
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// SimStepOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult SimStepOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  Operation *moduleOp = symbolTable.lookupNearestSymbolFrom(
+      getOperation(),
+      llvm::cast<SimModelInstanceType>(getInstance().getType()).getModel());
+  if (!moduleOp)
+    return emitOpError("model not found");
+
+  if (!isSupportedModuleOp(moduleOp))
+    return emitOpError(
+        "model symbol does not point to a supported model operation");
+
   return success();
 }
 

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -511,7 +511,7 @@ ParseResult SimInstantiateOp::parse(OpAsmParser &parser,
   if (failed(parser.parseOptionalAttrDictWithKeyword(result.attributes)))
     return failure();
 
-  auto ctxt = result.getContext();
+  MLIRContext *ctxt = result.getContext();
   modelArg.type =
       SimModelInstanceType::get(ctxt, FlatSymbolRefAttr::get(ctxt, modelName));
 

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -830,7 +830,8 @@ LogicalResult LowerStatePass::runOnModule(HWModuleOp moduleOp,
       [&](auto arg) { return arg != lowering.storageArg; });
   ImplicitLocOpBuilder builder(moduleOp.getLoc(), moduleOp);
   auto modelOp =
-      builder.create<ModelOp>(moduleOp.getLoc(), moduleOp.getModuleNameAttr());
+      builder.create<ModelOp>(moduleOp.getLoc(), moduleOp.getModuleNameAttr(),
+                              TypeAttr::get(moduleOp.getModuleType()));
   modelOp.getBody().takeBody(moduleOp.getBody());
   moduleOp->erase();
   sortTopologically(&modelOp.getBodyBlock());

--- a/test/Dialect/Arc/Export/info-gathering-errors.mlir
+++ b/test/Dialect/Arc/Export/info-gathering-errors.mlir
@@ -1,13 +1,13 @@
 // RUN: circt-translate %s --export-arc-model-info --split-input-file --verify-diagnostics
 
-arc.model "Foo" {
+arc.model "Foo" io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   // expected-error @below {{'arc.alloc_storage' op without allocated offset}}
   arc.alloc_storage %arg0 : (!arc.storage<42>) -> !arc.storage<42>
 }
 
 // -----
-arc.model "Foo" {
+arc.model "Foo" io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   // ignore unnamed
   arc.alloc_state %arg0 : (!arc.storage<42>) -> !arc.state<i1>
@@ -16,7 +16,7 @@ arc.model "Foo" {
 }
 
 // -----
-arc.model "Foo" {
+arc.model "Foo" io !hw.modty<input foo : i1> {
 ^bb0(%arg0: !arc.storage<42>):
   // ignore unnamed
   arc.root_input "", %arg0 : (!arc.storage<42>) -> !arc.state<i1>
@@ -25,7 +25,7 @@ arc.model "Foo" {
 }
 
 // -----
-arc.model "Foo" {
+arc.model "Foo" io !hw.modty<output foo : i1> {
 ^bb0(%arg0: !arc.storage<42>):
   // ignore unnamed
   arc.root_output "", %arg0 : (!arc.storage<42>) -> !arc.state<i1>
@@ -34,7 +34,7 @@ arc.model "Foo" {
 }
 
 // -----
-arc.model "Foo" {
+arc.model "Foo" io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   // ignore unnamed
   arc.alloc_memory %arg0 : (!arc.storage<42>) -> !arc.memory<4 x i1, i2>
@@ -43,7 +43,7 @@ arc.model "Foo" {
 }
 
 // -----
-arc.model "Foo" {
+arc.model "Foo" io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   // expected-error @below {{'arc.alloc_memory' op without allocated stride}}
   arc.alloc_memory %arg0 {name = "foo", offset = 8} : (!arc.storage<42>) -> !arc.memory<4 x i1, i2>

--- a/test/Dialect/Arc/Export/info-gathering-errors.mlir
+++ b/test/Dialect/Arc/Export/info-gathering-errors.mlir
@@ -1,13 +1,13 @@
 // RUN: circt-translate %s --export-arc-model-info --split-input-file --verify-diagnostics
 
-arc.model "Foo" io !hw.modty<> {
+arc.model @Foo io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   // expected-error @below {{'arc.alloc_storage' op without allocated offset}}
   arc.alloc_storage %arg0 : (!arc.storage<42>) -> !arc.storage<42>
 }
 
 // -----
-arc.model "Foo" io !hw.modty<> {
+arc.model @Foo io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   // ignore unnamed
   arc.alloc_state %arg0 : (!arc.storage<42>) -> !arc.state<i1>
@@ -16,7 +16,7 @@ arc.model "Foo" io !hw.modty<> {
 }
 
 // -----
-arc.model "Foo" io !hw.modty<input foo : i1> {
+arc.model @Foo io !hw.modty<input foo : i1> {
 ^bb0(%arg0: !arc.storage<42>):
   // ignore unnamed
   arc.root_input "", %arg0 : (!arc.storage<42>) -> !arc.state<i1>
@@ -25,7 +25,7 @@ arc.model "Foo" io !hw.modty<input foo : i1> {
 }
 
 // -----
-arc.model "Foo" io !hw.modty<output foo : i1> {
+arc.model @Foo io !hw.modty<output foo : i1> {
 ^bb0(%arg0: !arc.storage<42>):
   // ignore unnamed
   arc.root_output "", %arg0 : (!arc.storage<42>) -> !arc.state<i1>
@@ -34,7 +34,7 @@ arc.model "Foo" io !hw.modty<output foo : i1> {
 }
 
 // -----
-arc.model "Foo" io !hw.modty<> {
+arc.model @Foo io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   // ignore unnamed
   arc.alloc_memory %arg0 : (!arc.storage<42>) -> !arc.memory<4 x i1, i2>
@@ -43,7 +43,7 @@ arc.model "Foo" io !hw.modty<> {
 }
 
 // -----
-arc.model "Foo" io !hw.modty<> {
+arc.model @Foo io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   // expected-error @below {{'arc.alloc_memory' op without allocated stride}}
   arc.alloc_memory %arg0 {name = "foo", offset = 8} : (!arc.storage<42>) -> !arc.memory<4 x i1, i2>

--- a/test/Dialect/Arc/Export/serialize-state-info.mlir
+++ b/test/Dialect/Arc/Export/serialize-state-info.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: "name": "Foo"
 // CHECK-DAG: "numStateBytes": 5724
-arc.model "Foo" io !hw.modty<input a : i19, output b : i42> {
+arc.model @Foo io !hw.modty<input a : i19, output b : i42> {
 ^bb0(%arg0: !arc.storage<5724>):
   // CHECK:      "name": "a"
   // CHECK-NEXT: "offset": 0
@@ -19,7 +19,7 @@ arc.model "Foo" io !hw.modty<input a : i19, output b : i42> {
 
 // CHECK-LABEL: "name": "Bar"
 // CHECK-DAG: "numStateBytes": 9001
-arc.model "Bar" io !hw.modty<> {
+arc.model @Bar io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<9001>):
   // CHECK-NOT: "offset": "420"
   arc.alloc_state %arg0 {offset = 420} : (!arc.storage<9001>) -> !arc.state<i11>

--- a/test/Dialect/Arc/Export/serialize-state-info.mlir
+++ b/test/Dialect/Arc/Export/serialize-state-info.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: "name": "Foo"
 // CHECK-DAG: "numStateBytes": 5724
-arc.model "Foo" {
+arc.model "Foo" io !hw.modty<input a : i19, output b : i42> {
 ^bb0(%arg0: !arc.storage<5724>):
   // CHECK:      "name": "a"
   // CHECK-NEXT: "offset": 0
@@ -19,7 +19,7 @@ arc.model "Foo" {
 
 // CHECK-LABEL: "name": "Bar"
 // CHECK-DAG: "numStateBytes": 9001
-arc.model "Bar" {
+arc.model "Bar" io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<9001>):
   // CHECK-NOT: "offset": "420"
   arc.alloc_state %arg0 {offset = 420} : (!arc.storage<9001>) -> !arc.state<i11>

--- a/test/Dialect/Arc/allocate-state.mlir
+++ b/test/Dialect/Arc/allocate-state.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s --arc-allocate-state | FileCheck %s
 
 // CHECK-LABEL: arc.model "test"
-arc.model "test" {
+arc.model "test" io !hw.modty<input x : i1, output y : i1> {
 ^bb0(%arg0: !arc.storage):
   // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage<5780>):
 

--- a/test/Dialect/Arc/allocate-state.mlir
+++ b/test/Dialect/Arc/allocate-state.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s --arc-allocate-state | FileCheck %s
 
-// CHECK-LABEL: arc.model "test"
-arc.model "test" io !hw.modty<input x : i1, output y : i1> {
+// CHECK-LABEL: arc.model @test
+arc.model @test io !hw.modty<input x : i1, output y : i1> {
 ^bb0(%arg0: !arc.storage):
   // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage<5780>):
 

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -47,21 +47,21 @@ arc.define @Bar() {
 // -----
 
 // expected-error @below {{op must have exactly one argument}}
-arc.model "MissingArg" io !hw.modty<> {
+arc.model @MissingArg io !hw.modty<> {
 ^bb0:
 }
 
 // -----
 
 // expected-error @below {{op must have exactly one argument}}
-arc.model "TooManyArgs" io !hw.modty<> {
+arc.model @TooManyArgs io !hw.modty<> {
 ^bb0(%arg0: !arc.storage, %arg1: !arc.storage):
 }
 
 // -----
 
 // expected-error @below {{op argument must be of storage type}}
-arc.model "WrongArgType" io !hw.modty<> {
+arc.model @WrongArgType io !hw.modty<> {
 ^bb0(%arg0: i32):
 }
 

--- a/test/Dialect/Arc/basic-errors.mlir
+++ b/test/Dialect/Arc/basic-errors.mlir
@@ -47,21 +47,21 @@ arc.define @Bar() {
 // -----
 
 // expected-error @below {{op must have exactly one argument}}
-arc.model "MissingArg" {
+arc.model "MissingArg" io !hw.modty<> {
 ^bb0:
 }
 
 // -----
 
 // expected-error @below {{op must have exactly one argument}}
-arc.model "TooManyArgs" {
+arc.model "TooManyArgs" io !hw.modty<> {
 ^bb0(%arg0: !arc.storage, %arg1: !arc.storage):
 }
 
 // -----
 
 // expected-error @below {{op argument must be of storage type}}
-arc.model "WrongArgType" {
+arc.model "WrongArgType" io !hw.modty<> {
 ^bb0(%arg0: i32):
 }
 

--- a/test/Dialect/Arc/basic.mlir
+++ b/test/Dialect/Arc/basic.mlir
@@ -347,3 +347,24 @@ hw.module @vectorize_both_sides_lowered(in %in0: i1, in %in1: i1, in %in2: i1, i
 //       CHECK: [[V8:%.+]] = vector.extract [[V7]][0]
 //       CHECK: [[V9:%.+]] = vector.extract [[V7]][1]
 //       CHECK: hw.output [[V3]], [[V4]], [[V8]], [[V9]] :
+
+// -----
+
+// CHECK-LABEL: hw.module @sim_test
+hw.module @sim_test(in %a : i8, out b : i8) {
+  hw.output %a : i8
+}
+
+// CHECK-LABEL: func.func @no_attr
+func.func @no_attr() {
+  // CHECK: arc.sim.instantiate @sim_test as %{{.*}} {
+  arc.sim.instantiate @sim_test as %model {}
+  return
+}
+
+// CHECK-LABEL: func.func @with_attr
+func.func @with_attr() {
+  // CHECK: arc.sim.instantiate @sim_test as %{{.*}} attributes {foo = "foo"} {
+  arc.sim.instantiate @sim_test as %model attributes {foo = "foo"} {}
+  return
+}

--- a/test/Dialect/Arc/canonicalizers.mlir
+++ b/test/Dialect/Arc/canonicalizers.mlir
@@ -135,8 +135,8 @@ arc.define @memWrite(%arg0: i32, %arg1: i32, %arg2: i1) -> (i32, i32, i1) {
   arc.output %arg0, %arg1, %arg2 : i32, i32, i1
 }
 
-// CHECK-LABEL: arc.model "StorageGetCanonicalizers"
-arc.model "StorageGetCanonicalizers" io !hw.modty<> {
+// CHECK-LABEL: arc.model @StorageGetCanonicalizers
+arc.model @StorageGetCanonicalizers io !hw.modty<> {
 // CHECK-NEXT: ^bb
 ^bb0(%arg0: !arc.storage<512>):
   %0 = arc.storage.get %arg0[16] : !arc.storage<512> -> !arc.storage<16>

--- a/test/Dialect/Arc/canonicalizers.mlir
+++ b/test/Dialect/Arc/canonicalizers.mlir
@@ -136,7 +136,7 @@ arc.define @memWrite(%arg0: i32, %arg1: i32, %arg2: i1) -> (i32, i32, i1) {
 }
 
 // CHECK-LABEL: arc.model "StorageGetCanonicalizers"
-arc.model "StorageGetCanonicalizers" {
+arc.model "StorageGetCanonicalizers" io !hw.modty<> {
 // CHECK-NEXT: ^bb
 ^bb0(%arg0: !arc.storage<512>):
   %0 = arc.storage.get %arg0[16] : !arc.storage<512> -> !arc.storage<16>

--- a/test/Dialect/Arc/group-resets-and-enables.mlir
+++ b/test/Dialect/Arc/group-resets-and-enables.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s --arc-group-resets-and-enables | FileCheck %s
 
 // CHECK-LABEL: arc.model "BasicResetGrouping"
-arc.model "BasicResetGrouping" {
+arc.model "BasicResetGrouping" io !hw.modty<input clock : i1, input i0 : i4, input i1 : i4, input reset0 : i1, input reset1 : i1> {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
@@ -154,7 +154,7 @@ arc.model "BasicResetGrouping" {
 }
 
 // CHECK-LABEL: arc.model "BasicEnableGrouping"
-arc.model "BasicEnableGrouping" {
+arc.model "BasicEnableGrouping" io !hw.modty<input clock : i1, input i0 : i4, input i1 : i4, input en0 : i1, input en1 : i1> {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
@@ -211,7 +211,7 @@ arc.model "BasicEnableGrouping" {
 }
 
 // CHECK-LABEL: arc.model "GroupAssignmentsInIfTesting"
-arc.model "GroupAssignmentsInIfTesting" {
+arc.model "GroupAssignmentsInIfTesting" io !hw.modty<input clock : i1, input i1 : i4, input i2 : i4, input cond0 : i1, input cond1 : i1> {
 ^bb0(%arg0: !arc.storage):
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
@@ -288,7 +288,7 @@ arc.model "GroupAssignmentsInIfTesting" {
 }
 
 // CHECK-LABEL: arc.model "ResetAndEnableGrouping"
-arc.model "ResetAndEnableGrouping" {
+arc.model "ResetAndEnableGrouping" io !hw.modty<input clock : i1, input i0 : i4, input i1 : i4, input reset : i1, input en0 : i1, input en1 : i1> {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>

--- a/test/Dialect/Arc/group-resets-and-enables.mlir
+++ b/test/Dialect/Arc/group-resets-and-enables.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s --arc-group-resets-and-enables | FileCheck %s
 
-// CHECK-LABEL: arc.model "BasicResetGrouping"
-arc.model "BasicResetGrouping" io !hw.modty<input clock : i1, input i0 : i4, input i1 : i4, input reset0 : i1, input reset1 : i1> {
+// CHECK-LABEL: arc.model @BasicResetGrouping
+arc.model @BasicResetGrouping io !hw.modty<input clock : i1, input i0 : i4, input i1 : i4, input reset0 : i1, input reset1 : i1> {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
@@ -153,8 +153,8 @@ arc.model "BasicResetGrouping" io !hw.modty<input clock : i1, input i0 : i4, inp
   %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
 }
 
-// CHECK-LABEL: arc.model "BasicEnableGrouping"
-arc.model "BasicEnableGrouping" io !hw.modty<input clock : i1, input i0 : i4, input i1 : i4, input en0 : i1, input en1 : i1> {
+// CHECK-LABEL: arc.model @BasicEnableGrouping
+arc.model @BasicEnableGrouping io !hw.modty<input clock : i1, input i0 : i4, input i1 : i4, input en0 : i1, input en1 : i1> {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
@@ -210,8 +210,8 @@ arc.model "BasicEnableGrouping" io !hw.modty<input clock : i1, input i0 : i4, in
   %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
 }
 
-// CHECK-LABEL: arc.model "GroupAssignmentsInIfTesting"
-arc.model "GroupAssignmentsInIfTesting" io !hw.modty<input clock : i1, input i1 : i4, input i2 : i4, input cond0 : i1, input cond1 : i1> {
+// CHECK-LABEL: arc.model @GroupAssignmentsInIfTesting
+arc.model @GroupAssignmentsInIfTesting io !hw.modty<input clock : i1, input i1 : i4, input i2 : i4, input cond0 : i1, input cond1 : i1> {
 ^bb0(%arg0: !arc.storage):
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>
   %in_i1 = arc.root_input "i1", %arg0 : (!arc.storage) -> !arc.state<i4>
@@ -287,8 +287,8 @@ arc.model "GroupAssignmentsInIfTesting" io !hw.modty<input clock : i1, input i1 
   %2 = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i4>
 }
 
-// CHECK-LABEL: arc.model "ResetAndEnableGrouping"
-arc.model "ResetAndEnableGrouping" io !hw.modty<input clock : i1, input i0 : i4, input i1 : i4, input reset : i1, input en0 : i1, input en1 : i1> {
+// CHECK-LABEL: arc.model @ResetAndEnableGrouping
+arc.model @ResetAndEnableGrouping io !hw.modty<input clock : i1, input i0 : i4, input i1 : i4, input reset : i1, input en0 : i1, input en1 : i1> {
 ^bb0(%arg0: !arc.storage):
   %c0_i4 = hw.constant 0 : i4
   %in_clock = arc.root_input "clock", %arg0 : (!arc.storage) -> !arc.state<i1>

--- a/test/Dialect/Arc/legalize-state-update-error.mlir
+++ b/test/Dialect/Arc/legalize-state-update-error.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s --arc-legalize-state-update --split-input-file --verify-diagnostics
 
-arc.model "Memory" io !hw.modty<> {
+arc.model @Memory io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   %false = hw.constant false
   arc.clock_tree %false attributes {ct4} {

--- a/test/Dialect/Arc/legalize-state-update-error.mlir
+++ b/test/Dialect/Arc/legalize-state-update-error.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s --arc-legalize-state-update --split-input-file --verify-diagnostics
 
-arc.model "Memory" {
+arc.model "Memory" io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   %false = hw.constant false
   arc.clock_tree %false attributes {ct4} {

--- a/test/Dialect/Arc/legalize-state-update.mlir
+++ b/test/Dialect/Arc/legalize-state-update.mlir
@@ -165,7 +165,7 @@ func.func @InnerWriteFunc(%arg0: !arc.state<i4>, %arg1: i4) {
 
 // State legalization should not happen across clock trees and passthrough ops.
 // CHECK-LABEL: arc.model "DontLeakThroughClockTreeOrPassthrough"
-arc.model "DontLeakThroughClockTreeOrPassthrough" {
+arc.model "DontLeakThroughClockTreeOrPassthrough" io !hw.modty<input a : i1, output b : i1> {
 ^bb0(%arg0: !arc.storage):
   %false = hw.constant false
   %in_a = arc.root_input "a", %arg0 : (!arc.storage) -> !arc.state<i1>
@@ -188,7 +188,7 @@ arc.model "DontLeakThroughClockTreeOrPassthrough" {
 }
 
 // CHECK-LABEL: arc.model "Memory"
-arc.model "Memory" {
+arc.model "Memory" io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   %false = hw.constant false
   // CHECK: arc.clock_tree %false attributes {ct1}

--- a/test/Dialect/Arc/legalize-state-update.mlir
+++ b/test/Dialect/Arc/legalize-state-update.mlir
@@ -164,8 +164,8 @@ func.func @InnerWriteFunc(%arg0: !arc.state<i4>, %arg1: i4) {
 }
 
 // State legalization should not happen across clock trees and passthrough ops.
-// CHECK-LABEL: arc.model "DontLeakThroughClockTreeOrPassthrough"
-arc.model "DontLeakThroughClockTreeOrPassthrough" io !hw.modty<input a : i1, output b : i1> {
+// CHECK-LABEL: arc.model @DontLeakThroughClockTreeOrPassthrough
+arc.model @DontLeakThroughClockTreeOrPassthrough io !hw.modty<input a : i1, output b : i1> {
 ^bb0(%arg0: !arc.storage):
   %false = hw.constant false
   %in_a = arc.root_input "a", %arg0 : (!arc.storage) -> !arc.state<i1>
@@ -187,8 +187,8 @@ arc.model "DontLeakThroughClockTreeOrPassthrough" io !hw.modty<input a : i1, out
   }
 }
 
-// CHECK-LABEL: arc.model "Memory"
-arc.model "Memory" io !hw.modty<> {
+// CHECK-LABEL: arc.model @Memory
+arc.model @Memory io !hw.modty<> {
 ^bb0(%arg0: !arc.storage):
   %false = hw.constant false
   // CHECK: arc.clock_tree %false attributes {ct1}

--- a/test/Dialect/Arc/lower-clocks-to-funcs-errors.mlir
+++ b/test/Dialect/Arc/lower-clocks-to-funcs-errors.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s --arc-lower-clocks-to-funcs --verify-diagnostics
 
-arc.model "NonConstExternalValue" {
+arc.model "NonConstExternalValue" io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   %c0_i9001 = hw.constant 0 : i9001
   // expected-note @+1 {{external value defined here:}}

--- a/test/Dialect/Arc/lower-clocks-to-funcs-errors.mlir
+++ b/test/Dialect/Arc/lower-clocks-to-funcs-errors.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s --arc-lower-clocks-to-funcs --verify-diagnostics
 
-arc.model "NonConstExternalValue" io !hw.modty<> {
+arc.model @NonConstExternalValue io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   %c0_i9001 = hw.constant 0 : i9001
   // expected-note @+1 {{external value defined here:}}

--- a/test/Dialect/Arc/lower-clocks-to-funcs.mlir
+++ b/test/Dialect/Arc/lower-clocks-to-funcs.mlir
@@ -14,7 +14,7 @@
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: arc.model "Trivial" io !hw.modty<> {
+// CHECK-LABEL: arc.model @Trivial io !hw.modty<> {
 // CHECK-NEXT:  ^bb0(%arg0: !arc.storage<42>):
 // CHECK-NEXT:    %true = hw.constant true
 // CHECK-NEXT:    %false = hw.constant false
@@ -24,7 +24,7 @@
 // CHECK-NEXT:    func.call @Trivial_passthrough(%arg0) : (!arc.storage<42>) -> ()
 // CHECK-NEXT:  }
 
-arc.model "Trivial" io !hw.modty<> {
+arc.model @Trivial io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   %true = hw.constant true
   %false = hw.constant false
@@ -48,12 +48,12 @@ arc.model "Trivial" io !hw.modty<> {
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: arc.model "NestedRegions" io !hw.modty<> {
+// CHECK-LABEL: arc.model @NestedRegions io !hw.modty<> {
 // CHECK-NEXT:  ^bb0(%arg0: !arc.storage<42>):
 // CHECK-NEXT:    func.call @NestedRegions_passthrough(%arg0) : (!arc.storage<42>) -> ()
 // CHECK-NEXT:  }
 
-arc.model "NestedRegions" io !hw.modty<> {
+arc.model @NestedRegions io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   arc.passthrough {
     %true = hw.constant true
@@ -78,8 +78,8 @@ arc.model "NestedRegions" io !hw.modty<> {
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: arc.model "InsertionOrderProblem"
-arc.model "InsertionOrderProblem" io !hw.modty<> {
+// CHECK-LABEL: arc.model @InsertionOrderProblem
+arc.model @InsertionOrderProblem io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   %true = hw.constant true
   %false = hw.constant false

--- a/test/Dialect/Arc/lower-clocks-to-funcs.mlir
+++ b/test/Dialect/Arc/lower-clocks-to-funcs.mlir
@@ -14,7 +14,7 @@
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: arc.model "Trivial" {
+// CHECK-LABEL: arc.model "Trivial" io !hw.modty<> {
 // CHECK-NEXT:  ^bb0(%arg0: !arc.storage<42>):
 // CHECK-NEXT:    %true = hw.constant true
 // CHECK-NEXT:    %false = hw.constant false
@@ -24,7 +24,7 @@
 // CHECK-NEXT:    func.call @Trivial_passthrough(%arg0) : (!arc.storage<42>) -> ()
 // CHECK-NEXT:  }
 
-arc.model "Trivial" {
+arc.model "Trivial" io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   %true = hw.constant true
   %false = hw.constant false
@@ -48,12 +48,12 @@ arc.model "Trivial" {
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: arc.model "NestedRegions" {
+// CHECK-LABEL: arc.model "NestedRegions" io !hw.modty<> {
 // CHECK-NEXT:  ^bb0(%arg0: !arc.storage<42>):
 // CHECK-NEXT:    func.call @NestedRegions_passthrough(%arg0) : (!arc.storage<42>) -> ()
 // CHECK-NEXT:  }
 
-arc.model "NestedRegions" {
+arc.model "NestedRegions" io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   arc.passthrough {
     %true = hw.constant true
@@ -78,8 +78,8 @@ arc.model "NestedRegions" {
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: arc.model "InsertionOrderProblem" {
-arc.model "InsertionOrderProblem" {
+// CHECK-LABEL: arc.model "InsertionOrderProblem"
+arc.model "InsertionOrderProblem" io !hw.modty<> {
 ^bb0(%arg0: !arc.storage<42>):
   %true = hw.constant true
   %false = hw.constant false

--- a/test/Dialect/Arc/lower-sim-err.mlir
+++ b/test/Dialect/Arc/lower-sim-err.mlir
@@ -1,0 +1,88 @@
+// RUN: arcilator %s --disable-output --verify-diagnostics --split-input-file
+
+hw.module @id(in %i: i8, in %j: i8, out o: i8) {
+    hw.output %i : i8
+}
+
+func.func @model_not_found() {
+    // expected-error @+2 {{failed to legalize}}
+    // expected-error @+1 {{model not found}}
+    %model = arc.sim.instantiate : !arc.sim.instance<"unknown">
+    return
+}
+
+// -----
+
+hw.module @id(in %i: i8, in %j: i8, out o: i8) {
+    hw.output %i : i8
+}
+
+func.func @port_not_found() {
+    %model = arc.sim.instantiate : !arc.sim.instance<"id">
+    // expected-error @+2 {{failed to legalize}}
+    // expected-error @+1 {{port not found}}
+    arc.sim.get_port %model, "unknown" : i8, !arc.sim.instance<"id">
+    return
+}
+
+// -----
+
+hw.module @id(in %i: i8, in %j: i8, out o: i8) {
+    hw.output %i : i8
+}
+
+func.func @port_wrong_size() {
+    %model = arc.sim.instantiate : !arc.sim.instance<"id">
+    // expected-error @+2 {{failed to legalize}}
+    // expected-error @+1 {{expected port of width 8, got 16}}
+    arc.sim.get_port %model, "i" : i16, !arc.sim.instance<"id">
+    return
+}
+
+// -----
+
+hw.module @id(in %i: i8, in %j: i8, out o: i8) {
+    hw.output %i : i8
+}
+
+func.func @input_not_found() {
+    %model = arc.sim.instantiate : !arc.sim.instance<"id">
+    %v = arith.constant 24 : i8
+
+    // expected-error @+2 {{failed to legalize}}
+    // expected-error @+1 {{input not found}}
+    arc.sim.set_input %model, "unknown" = %v : i8, !arc.sim.instance<"id">
+    return
+}
+
+// -----
+
+hw.module @id(in %i: i8, in %j: i8, out o: i8) {
+    hw.output %i : i8
+}
+
+func.func @set_port_wrong_size() {
+    %model = arc.sim.instantiate : !arc.sim.instance<"id">
+    %v = arith.constant 24 : i16
+
+    // expected-error @+2 {{failed to legalize}}
+    // expected-error @+1 {{expected input of width 8, got 16}}
+    arc.sim.set_input %model, "i" = %v : i16, !arc.sim.instance<"id">
+    return
+}
+
+// -----
+
+hw.module @id(in %i: i8, in %j: i8, out o: i8) {
+    hw.output %i : i8
+}
+
+func.func @set_port_not_input() {
+    %model = arc.sim.instantiate : !arc.sim.instance<"id">
+    %v = arith.constant 24 : i8
+
+    // expected-error @+2 {{failed to legalize}}
+    // expected-error @+1 {{provided port is not an input port}}
+    arc.sim.set_input %model, "o" = %v : i8, !arc.sim.instance<"id">
+    return
+}

--- a/test/Dialect/Arc/lower-sim-err.mlir
+++ b/test/Dialect/Arc/lower-sim-err.mlir
@@ -1,5 +1,29 @@
 // RUN: arcilator %s --disable-output --verify-diagnostics --split-input-file
 
+func.func @model_not_found() {
+    // This test uses the generic operation format to test the verifier, as this case cannot happen
+    // when using the custom format.
+    // expected-error @+1 {{entry block of body region must have the model instance as a single argument}}
+    "arc.sim.instantiate"() ({
+        ^entry:
+    }) : () -> ()
+    return
+}
+
+// -----
+
+func.func @invalid_arg() {
+    // This test uses the generic operation format to test the verifier, as this case cannot happen
+    // when using the custom format.
+    // expected-error @+1 {{entry block argument type is not a model instance}}
+    "arc.sim.instantiate"() ({
+        ^entry(%model: i32):
+    }) : () -> ()
+    return
+}
+
+// -----
+
 hw.module @id(in %i: i8, in %j: i8, out o: i8) {
     hw.output %i : i8
 }
@@ -7,7 +31,7 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 func.func @model_not_found() {
     // expected-error @+2 {{failed to legalize}}
     // expected-error @+1 {{model not found}}
-    %model = arc.sim.instantiate : !arc.sim.instance<"unknown">
+    arc.sim.instantiate @unknown as %model {}
     return
 }
 
@@ -18,10 +42,12 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 }
 
 func.func @port_not_found() {
-    %model = arc.sim.instantiate : !arc.sim.instance<"id">
-    // expected-error @+2 {{failed to legalize}}
-    // expected-error @+1 {{port not found}}
-    arc.sim.get_port %model, "unknown" : i8, !arc.sim.instance<"id">
+    arc.sim.instantiate @id as %model {
+        // expected-error @+2 {{failed to legalize}}
+        // expected-error @+1 {{port not found}}
+        %res = arc.sim.get_port %model, "unknown" : i8, !arc.sim.instance<"id">
+        arc.sim.emit "use", %res : i8
+    }
     return
 }
 
@@ -32,10 +58,12 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 }
 
 func.func @port_wrong_size() {
-    %model = arc.sim.instantiate : !arc.sim.instance<"id">
-    // expected-error @+2 {{failed to legalize}}
-    // expected-error @+1 {{expected port of width 8, got 16}}
-    arc.sim.get_port %model, "i" : i16, !arc.sim.instance<"id">
+    arc.sim.instantiate @id as %model {
+        // expected-error @+2 {{failed to legalize}}
+        // expected-error @+1 {{expected port of width 8, got 16}}
+        %res = arc.sim.get_port %model, "i" : i16, !arc.sim.instance<"id">
+        arc.sim.emit "use", %res : i16
+    }
     return
 }
 
@@ -46,12 +74,12 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 }
 
 func.func @input_not_found() {
-    %model = arc.sim.instantiate : !arc.sim.instance<"id">
     %v = arith.constant 24 : i8
-
-    // expected-error @+2 {{failed to legalize}}
-    // expected-error @+1 {{input not found}}
-    arc.sim.set_input %model, "unknown" = %v : i8, !arc.sim.instance<"id">
+    arc.sim.instantiate @id as %model {
+        // expected-error @+2 {{failed to legalize}}
+        // expected-error @+1 {{input not found}}
+        arc.sim.set_input %model, "unknown" = %v : i8, !arc.sim.instance<"id">
+    }
     return
 }
 
@@ -62,12 +90,12 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 }
 
 func.func @set_port_wrong_size() {
-    %model = arc.sim.instantiate : !arc.sim.instance<"id">
     %v = arith.constant 24 : i16
-
-    // expected-error @+2 {{failed to legalize}}
-    // expected-error @+1 {{expected input of width 8, got 16}}
-    arc.sim.set_input %model, "i" = %v : i16, !arc.sim.instance<"id">
+    arc.sim.instantiate @id as %model {
+        // expected-error @+2 {{failed to legalize}}
+        // expected-error @+1 {{expected input of width 8, got 16}}
+        arc.sim.set_input %model, "i" = %v : i16, !arc.sim.instance<"id">
+    }
     return
 }
 
@@ -78,11 +106,11 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 }
 
 func.func @set_port_not_input() {
-    %model = arc.sim.instantiate : !arc.sim.instance<"id">
     %v = arith.constant 24 : i8
-
-    // expected-error @+2 {{failed to legalize}}
-    // expected-error @+1 {{provided port is not an input port}}
-    arc.sim.set_input %model, "o" = %v : i8, !arc.sim.instance<"id">
+    arc.sim.instantiate @id as %model {
+        // expected-error @+2 {{failed to legalize}}
+        // expected-error @+1 {{provided port is not an input port}}
+        arc.sim.set_input %model, "o" = %v : i8, !arc.sim.instance<"id">
+    }
     return
 }

--- a/test/Dialect/Arc/lower-sim.mlir
+++ b/test/Dialect/Arc/lower-sim.mlir
@@ -7,41 +7,42 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 // CHECK-DAG: llvm.mlir.global internal constant @[[format_str:.*]]("result = %0.8p\0A\00")
 // CHECK-DAG: llvm.mlir.global internal constant @[[format_str2:.*]]("result2 = %0.8p\0A\00")
 // CHECK-LABEL: llvm.func @full
-func.func @full() -> i8 {
+func.func @full() {
     %c = arith.constant 24 : i8
+
     // CHECK-DAG: %[[c:.*]] = llvm.mlir.constant(24 : i8)
     // CHECK-DAG: %[[zero:.*]] = llvm.mlir.constant(0 : i8)
     // CHECK-DAG: %[[size:.*]] = llvm.mlir.constant(3 : i64)
-    // CHECK-DAG: %[[state:.*]] = llvm.alloca %[[size]] x i8
+    // CHECK-DAG: %[[state:.*]] = llvm.call @malloc(%[[size:.*]]) :
     // CHECK: "llvm.intr.memset"(%[[state]], %[[zero]], %[[size]]) <{isVolatile = false}>
-    %model = arc.sim.instantiate : !arc.sim.instance<"id">
+    arc.sim.instantiate @id as %model {
+        // CHECK-NEXT: llvm.store %[[c]], %[[state]] : i8
+        arc.sim.set_input %model, "i" = %c : i8, !arc.sim.instance<"id">
 
-    // CHECK-NEXT: llvm.store %[[c]], %[[state]] : i8
-    arc.sim.set_input %model, "i" = %c : i8, !arc.sim.instance<"id">
+        // CHECK-NEXT: %[[j_ptr:.*]] = llvm.getelementptr %[[state]][1] : (!llvm.ptr) -> !llvm.ptr, i8
+        // CHECK-NEXT: llvm.store %[[c]], %[[j_ptr]] : i8
+        arc.sim.set_input %model, "j" = %c : i8, !arc.sim.instance<"id">
 
-    // CHECK-NEXT: %[[j_ptr:.*]] = llvm.getelementptr %[[state]][1] : (!llvm.ptr) -> !llvm.ptr, i8
-    // CHECK-NEXT: llvm.store %[[c]], %[[j_ptr]] : i8
-    arc.sim.set_input %model, "j" = %c : i8, !arc.sim.instance<"id">
+        // CHECK-NEXT: llvm.call @id_eval(%[[state]])
+        arc.sim.step %model : !arc.sim.instance<"id">
 
-    // CHECK-NEXT: llvm.call @id_eval(%[[state]])
-    arc.sim.step %model : !arc.sim.instance<"id">
+        // CHECK-NEXT: %[[o_ptr:.*]] = llvm.getelementptr %[[state]][2] : (!llvm.ptr) -> !llvm.ptr, i8
+        // CHECK-NEXT: %[[result:.*]] = llvm.load %[[o_ptr]] : !llvm.ptr -> i8
+        %result = arc.sim.get_port %model, "o" : i8, !arc.sim.instance<"id">
 
-    // CHECK-NEXT: %[[o_ptr:.*]] = llvm.getelementptr %[[state]][2] : (!llvm.ptr) -> !llvm.ptr, i8
-    // CHECK-NEXT: %[[result:.*]] = llvm.load %[[o_ptr]] : !llvm.ptr -> i8
-    %result = arc.sim.get_port %model, "o" : i8, !arc.sim.instance<"id">
+        // CHECK-DAG: %[[to_print:.*]] = llvm.inttoptr %[[result]] : i8 to !llvm.ptr
+        // CHECK-DAG: %[[format_str_ptr:.*]] = llvm.mlir.addressof @[[format_str]] : !llvm.ptr
+        // CHECK: llvm.call @printf(%[[format_str_ptr]], %[[to_print]])
+        arc.sim.emit "result", %result : i8
 
-    // CHECK-DAG: %[[to_print:.*]] = llvm.inttoptr %[[result]] : i8 to !llvm.ptr
-    // CHECK-DAG: %[[format_str_ptr:.*]] = llvm.mlir.addressof @[[format_str]] : !llvm.ptr
-    // CHECK: llvm.call @printf(%[[format_str_ptr]], %[[to_print]])
-    arc.sim.emit "result", %result : i8
+        // CHECK-DAG: %[[format_str2_ptr:.*]] = llvm.mlir.addressof @[[format_str2]] : !llvm.ptr
+        // CHECK: llvm.call @printf(%[[format_str2_ptr]], %[[to_print]])
+        arc.sim.emit "result2", %result : i8
 
-    // CHECK-DAG: %[[format_str2_ptr:.*]] = llvm.mlir.addressof @[[format_str2]] : !llvm.ptr
-    // CHECK: llvm.call @printf(%[[format_str2_ptr]], %[[to_print]])
-    arc.sim.emit "result2", %result : i8
+        // CHECK: llvm.call @printf(%[[format_str_ptr]], %[[to_print]])
+        arc.sim.emit "result", %result : i8
+    }
+    // CHECK: llvm.call @free(%[[state]])
 
-    // CHECK: llvm.call @printf(%[[format_str_ptr]], %[[to_print]])
-    arc.sim.emit "result", %result : i8
-
-    // CHECK-NEXT: llvm.return %[[result]]
-    return %result : i8
+    return
 }

--- a/test/Dialect/Arc/lower-sim.mlir
+++ b/test/Dialect/Arc/lower-sim.mlir
@@ -4,14 +4,15 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
     hw.output %i : i8
 }
 
-// CHECK-LABEL: llvm.func @basic
-func.func @basic() -> i8 {
+// CHECK: llvm.mlir.global internal constant @[[format_str:.*]]("result = %0.8p\0A\00")
+// CHECK-LABEL: llvm.func @full
+func.func @full() -> i8 {
     %c = arith.constant 24 : i8
     // CHECK-DAG: %[[c:.*]] = llvm.mlir.constant(24 : i8)
     // CHECK-DAG: %[[zero:.*]] = llvm.mlir.constant(0 : i8)
     // CHECK-DAG: %[[size:.*]] = llvm.mlir.constant(3 : i64)
     // CHECK-DAG: %[[state:.*]] = llvm.alloca %[[size]] x i8
-    // CHECK-NEXT: "llvm.intr.memset"(%[[state]], %[[zero]], %[[size]]) <{isVolatile = false}>
+    // CHECK: "llvm.intr.memset"(%[[state]], %[[zero]], %[[size]]) <{isVolatile = false}>
     %model = arc.sim.instantiate : !arc.sim.instance<"id">
 
     // CHECK-NEXT: llvm.store %[[c]], %[[state]] : i8
@@ -27,6 +28,11 @@ func.func @basic() -> i8 {
     // CHECK-NEXT: %[[o_ptr:.*]] = llvm.getelementptr %[[state]][2] : (!llvm.ptr) -> !llvm.ptr, i8
     // CHECK-NEXT: %[[result:.*]] = llvm.load %[[o_ptr]] : !llvm.ptr -> i8
     %result = arc.sim.get_port %model, "o" : i8, !arc.sim.instance<"id">
+
+    // CHECK-DAG: %[[to_print:.*]] = llvm.inttoptr %[[result]] : i8 to !llvm.ptr
+    // CHECK-DAG: %[[format_str_ptr:.*]] = llvm.mlir.addressof @[[format_str]] : !llvm.ptr
+    // CHECK: llvm.call @printf(%[[format_str_ptr]], %[[to_print]])
+    arc.sim.emit "result", %result : i8
 
     // CHECK-NEXT: llvm.return %[[result]]
     return %result : i8

--- a/test/Dialect/Arc/lower-sim.mlir
+++ b/test/Dialect/Arc/lower-sim.mlir
@@ -1,0 +1,33 @@
+// RUN: arcilator %s --emit-mlir | FileCheck %s
+
+hw.module @id(in %i: i8, in %j: i8, out o: i8) {
+    hw.output %i : i8
+}
+
+// CHECK-LABEL: llvm.func @basic
+func.func @basic() -> i8 {
+    %c = arith.constant 24 : i8
+    // CHECK-DAG: %[[c:.*]] = llvm.mlir.constant(24 : i8)
+    // CHECK-DAG: %[[zero:.*]] = llvm.mlir.constant(0 : i8)
+    // CHECK-DAG: %[[size:.*]] = llvm.mlir.constant(3 : i64)
+    // CHECK-DAG: %[[state:.*]] = llvm.alloca %[[size]] x i8
+    // CHECK-NEXT: "llvm.intr.memset"(%[[state]], %[[zero]], %[[size]]) <{isVolatile = false}>
+    %model = arc.sim.instantiate : !arc.sim.instance<"id">
+
+    // CHECK-NEXT: llvm.store %[[c]], %[[state]] : i8
+    arc.sim.set_input %model, "i" = %c : i8, !arc.sim.instance<"id">
+
+    // CHECK-NEXT: %[[j_ptr:.*]] = llvm.getelementptr %[[state]][1] : (!llvm.ptr) -> !llvm.ptr, i8
+    // CHECK-NEXT: llvm.store %[[c]], %[[j_ptr]] : i8
+    arc.sim.set_input %model, "j" = %c : i8, !arc.sim.instance<"id">
+
+    // CHECK-NEXT: llvm.call @id_eval(%[[state]])
+    arc.sim.step %model : !arc.sim.instance<"id">
+
+    // CHECK-NEXT: %[[o_ptr:.*]] = llvm.getelementptr %[[state]][2] : (!llvm.ptr) -> !llvm.ptr, i8
+    // CHECK-NEXT: %[[result:.*]] = llvm.load %[[o_ptr]] : !llvm.ptr -> i8
+    %result = arc.sim.get_port %model, "o" : i8, !arc.sim.instance<"id">
+
+    // CHECK-NEXT: llvm.return %[[result]]
+    return %result : i8
+}

--- a/test/Dialect/Arc/lower-sim.mlir
+++ b/test/Dialect/Arc/lower-sim.mlir
@@ -4,7 +4,8 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
     hw.output %i : i8
 }
 
-// CHECK: llvm.mlir.global internal constant @[[format_str:.*]]("result = %0.8p\0A\00")
+// CHECK-DAG: llvm.mlir.global internal constant @[[format_str:.*]]("result = %0.8p\0A\00")
+// CHECK-DAG: llvm.mlir.global internal constant @[[format_str2:.*]]("result2 = %0.8p\0A\00")
 // CHECK-LABEL: llvm.func @full
 func.func @full() -> i8 {
     %c = arith.constant 24 : i8
@@ -31,6 +32,13 @@ func.func @full() -> i8 {
 
     // CHECK-DAG: %[[to_print:.*]] = llvm.inttoptr %[[result]] : i8 to !llvm.ptr
     // CHECK-DAG: %[[format_str_ptr:.*]] = llvm.mlir.addressof @[[format_str]] : !llvm.ptr
+    // CHECK: llvm.call @printf(%[[format_str_ptr]], %[[to_print]])
+    arc.sim.emit "result", %result : i8
+
+    // CHECK-DAG: %[[format_str2_ptr:.*]] = llvm.mlir.addressof @[[format_str2]] : !llvm.ptr
+    // CHECK: llvm.call @printf(%[[format_str2_ptr]], %[[to_print]])
+    arc.sim.emit "result2", %result : i8
+
     // CHECK: llvm.call @printf(%[[format_str_ptr]], %[[to_print]])
     arc.sim.emit "result", %result : i8
 

--- a/test/Dialect/Arc/lower-sim.mlir
+++ b/test/Dialect/Arc/lower-sim.mlir
@@ -17,18 +17,18 @@ func.func @full() {
     // CHECK: "llvm.intr.memset"(%[[state]], %[[zero]], %[[size]]) <{isVolatile = false}>
     arc.sim.instantiate @id as %model {
         // CHECK-NEXT: llvm.store %[[c]], %[[state]] : i8
-        arc.sim.set_input %model, "i" = %c : i8, !arc.sim.instance<"id">
+        arc.sim.set_input %model, "i" = %c : i8, !arc.sim.instance<@id>
 
         // CHECK-NEXT: %[[j_ptr:.*]] = llvm.getelementptr %[[state]][1] : (!llvm.ptr) -> !llvm.ptr, i8
         // CHECK-NEXT: llvm.store %[[c]], %[[j_ptr]] : i8
-        arc.sim.set_input %model, "j" = %c : i8, !arc.sim.instance<"id">
+        arc.sim.set_input %model, "j" = %c : i8, !arc.sim.instance<@id>
 
         // CHECK-NEXT: llvm.call @id_eval(%[[state]])
-        arc.sim.step %model : !arc.sim.instance<"id">
+        arc.sim.step %model : !arc.sim.instance<@id>
 
         // CHECK-NEXT: %[[o_ptr:.*]] = llvm.getelementptr %[[state]][2] : (!llvm.ptr) -> !llvm.ptr, i8
         // CHECK-NEXT: %[[result:.*]] = llvm.load %[[o_ptr]] : !llvm.ptr -> i8
-        %result = arc.sim.get_port %model, "o" : i8, !arc.sim.instance<"id">
+        %result = arc.sim.get_port %model, "o" : i8, !arc.sim.instance<@id>
 
         // CHECK-DAG: %[[to_print:.*]] = llvm.inttoptr %[[result]] : i8 to !llvm.ptr
         // CHECK-DAG: %[[format_str_ptr:.*]] = llvm.mlir.addressof @[[format_str]] : !llvm.ptr

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -1,12 +1,12 @@
 // RUN: circt-opt %s --arc-lower-state | FileCheck %s
 
-// CHECK-LABEL: arc.model "Empty"
+// CHECK-LABEL: arc.model @Empty
 // CHECK-NEXT:  ^bb0(%arg0: !arc.storage):
 // CHECK-NEXT:  }
 hw.module @Empty() {
 }
 
-// CHECK-LABEL: arc.model "InputsAndOutputs"
+// CHECK-LABEL: arc.model @InputsAndOutputs
 hw.module @InputsAndOutputs(in %a: i42, in %b: i17, out c: i42, out d: i17) {
   %0 = comb.add %a, %a : i42
   %1 = comb.add %b, %b : i17
@@ -27,7 +27,7 @@ hw.module @InputsAndOutputs(in %a: i42, in %b: i17, out c: i42, out d: i17) {
   // CHECK-NEXT: }
 }
 
-// CHECK-LABEL: arc.model "State"
+// CHECK-LABEL: arc.model @State
 hw.module @State(in %clk: !seq.clock, in %en: i1, in %en2: i1) {
   %gclk = seq.clock_gate %clk, %en, %en2
   %3 = arc.state @DummyArc(%6) clock %clk latency 1 : (i42) -> i42
@@ -63,7 +63,7 @@ hw.module @State(in %clk: !seq.clock, in %en: i1, in %en2: i1) {
   // CHECK-NEXT: }
 }
 
-// CHECK-LABEL: arc.model "State2"
+// CHECK-LABEL: arc.model @State2
 hw.module @State2(in %clk: !seq.clock) {
   %3 = arc.state @DummyArc(%3) clock %clk latency 1 : (i42) -> i42
   %4 = arc.state @DummyArc(%4) clock %clk latency 1 : (i42) -> i42
@@ -93,7 +93,7 @@ arc.define @DummyArc(%arg0: i42) -> i42 {
   arc.output %arg0 : i42
 }
 
-// CHECK-LABEL: arc.model "NonMaskedMemoryWrite"
+// CHECK-LABEL: arc.model @NonMaskedMemoryWrite
 hw.module @NonMaskedMemoryWrite(in %clk0: !seq.clock) {
   %c0_i2 = hw.constant 0 : i2
   %c9001_i42 = hw.constant 9001 : i42
@@ -120,7 +120,7 @@ arc.define @identity(%arg0: i2, %arg1: i42) -> (i2, i42) {
   arc.output %arg0, %arg1 : i2, i42
 }
 
-// CHECK-LABEL: arc.model "lowerMemoryReadPorts"
+// CHECK-LABEL: arc.model @lowerMemoryReadPorts
 hw.module @lowerMemoryReadPorts(out out0: i42, out out1: i42) {
   %c0_i2 = hw.constant 0 : i2
   %mem = arc.memory <4 x i42, i2>
@@ -140,7 +140,7 @@ arc.define @arcWithMemoryReadsIsLowered(%mem: !arc.memory<4 x i42, i2>) -> i42 {
   arc.output %0 : i42
 }
 
-// CHECK-LABEL:  arc.model "maskedMemoryWrite"
+// CHECK-LABEL:  arc.model @maskedMemoryWrite
 hw.module @maskedMemoryWrite(in %clk: !seq.clock) {
   %true = hw.constant true
   %c0_i2 = hw.constant 0 : i2
@@ -163,7 +163,7 @@ arc.define @identity2(%arg0: i2, %arg1: i42, %arg2: i1, %arg3: i42) -> (i2, i42,
 // CHECK:      [[DATA:%.+]] = comb.or bin [[OLD_MASKED]], [[NEW_MASKED]] : i42
 // CHECK:      arc.memory_write [[MEM]][[[RES]]#0], [[DATA]] if [[RES]]#2 : <4 x i42, i2>
 
-// CHECK-LABEL: arc.model "Taps"
+// CHECK-LABEL: arc.model @Taps
 hw.module @Taps() {
   // CHECK-NOT: arc.tap
   // CHECK-DAG: [[VALUE:%.+]] = hw.constant 0 : i42
@@ -173,7 +173,7 @@ hw.module @Taps() {
   arc.tap %c0_i42 {name = "myTap"} : i42
 }
 
-// CHECK-LABEL: arc.model "MaterializeOpsWithRegions"
+// CHECK-LABEL: arc.model @MaterializeOpsWithRegions
 hw.module @MaterializeOpsWithRegions(in %clk0: !seq.clock, in %clk1: !seq.clock, out z: i42) {
   %true = hw.constant true
   %c19_i42 = hw.constant 19 : i42
@@ -245,7 +245,7 @@ hw.module @stateReset(in %clk: !seq.clock, in %arg0: i42, in %rst: i1, out out0:
   %2, %3 = arc.state @DummyArc2(%arg0) clock %clk enable %0 reset %1 latency 1 : (i42) -> (i42, i42)
   hw.output %2, %3 : i42, i42
 }
-// CHECK-LABEL: arc.model "stateReset"
+// CHECK-LABEL: arc.model @stateReset
 // CHECK: [[ALLOC1:%.+]] = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i42>
 // CHECK: [[ALLOC2:%.+]] = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i42>
 // CHECK: arc.clock_tree %{{.*}} {
@@ -269,7 +269,7 @@ hw.module @SeparateResets(in %clock: !seq.clock, in %i0: i42, in %rst1: i1, in %
   hw.output %0, %1 : i42, i42
 }
 
-// CHECK-LABEL: arc.model "SeparateResets"
+// CHECK-LABEL: arc.model @SeparateResets
 // CHECK: [[FOO_ALLOC:%.+]] = arc.alloc_state %arg0 {name = "foo"} : (!arc.storage) -> !arc.state<i42>
 // CHECK: [[BAR_ALLOC:%.+]] = arc.alloc_state %arg0 {name = "bar"} : (!arc.storage) -> !arc.state<i42>
 // CHECK: arc.clock_tree %{{.*}} {
@@ -307,7 +307,7 @@ arc.define @CombLoopRegressionArc2(%arg0: i1) -> (i1, i1) {
 }
 
 // Regression check for invalid memory port lowering errors.
-// CHECK-LABEL: arc.model "MemoryPortRegression"
+// CHECK-LABEL: arc.model @MemoryPortRegression
 hw.module private @MemoryPortRegression(in %clock: !seq.clock, in %reset: i1, in %in: i3, out x: i3) {
   %0 = arc.memory <2 x i3, i1> {name = "ram_ext"}
   %1 = arc.memory_read_port %0[%3] : <2 x i3, i1>
@@ -326,7 +326,7 @@ arc.define @Queue_arc_1(%arg0: i3) -> i3 {
   arc.output %arg0 : i3
 }
 
-// CHECK-LABEL: arc.model "BlackBox"
+// CHECK-LABEL: arc.model @BlackBox
 hw.module @BlackBox(in %clk: !seq.clock) {
   %0 = arc.state @DummyArc(%2) clock %clk latency 1 : (i42) -> i42
   %1 = comb.and %0, %0 : i42

--- a/test/Dialect/Arc/lower-state.mlir
+++ b/test/Dialect/Arc/lower-state.mlir
@@ -1,12 +1,12 @@
 // RUN: circt-opt %s --arc-lower-state | FileCheck %s
 
-// CHECK-LABEL: arc.model "Empty" {
+// CHECK-LABEL: arc.model "Empty"
 // CHECK-NEXT:  ^bb0(%arg0: !arc.storage):
 // CHECK-NEXT:  }
 hw.module @Empty() {
 }
 
-// CHECK-LABEL: arc.model "InputsAndOutputs" {
+// CHECK-LABEL: arc.model "InputsAndOutputs"
 hw.module @InputsAndOutputs(in %a: i42, in %b: i17, out c: i42, out d: i17) {
   %0 = comb.add %a, %a : i42
   %1 = comb.add %b, %b : i17
@@ -27,7 +27,7 @@ hw.module @InputsAndOutputs(in %a: i42, in %b: i17, out c: i42, out d: i17) {
   // CHECK-NEXT: }
 }
 
-// CHECK-LABEL: arc.model "State" {
+// CHECK-LABEL: arc.model "State"
 hw.module @State(in %clk: !seq.clock, in %en: i1, in %en2: i1) {
   %gclk = seq.clock_gate %clk, %en, %en2
   %3 = arc.state @DummyArc(%6) clock %clk latency 1 : (i42) -> i42
@@ -63,7 +63,7 @@ hw.module @State(in %clk: !seq.clock, in %en: i1, in %en2: i1) {
   // CHECK-NEXT: }
 }
 
-// CHECK-LABEL: arc.model "State2" {
+// CHECK-LABEL: arc.model "State2"
 hw.module @State2(in %clk: !seq.clock) {
   %3 = arc.state @DummyArc(%3) clock %clk latency 1 : (i42) -> i42
   %4 = arc.state @DummyArc(%4) clock %clk latency 1 : (i42) -> i42

--- a/test/Dialect/Arc/sim-errors.mlir
+++ b/test/Dialect/Arc/sim-errors.mlir
@@ -39,7 +39,7 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 func.func @port_not_found() {
     arc.sim.instantiate @id as %model {
         // expected-error @+1 {{port not found}}
-        %res = arc.sim.get_port %model, "unknown" : i8, !arc.sim.instance<"id">
+        %res = arc.sim.get_port %model, "unknown" : i8, !arc.sim.instance<@id>
         arc.sim.emit "use", %res : i8
     }
     return
@@ -54,7 +54,7 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 func.func @port_wrong_size() {
     arc.sim.instantiate @id as %model {
         // expected-error @+1 {{'arc.sim.get_port' op mismatched types between value and model port, port expects 'i8'}}
-        %res = arc.sim.get_port %model, "i" : i16, !arc.sim.instance<"id">
+        %res = arc.sim.get_port %model, "i" : i16, !arc.sim.instance<@id>
         arc.sim.emit "use", %res : i16
     }
     return
@@ -70,7 +70,7 @@ func.func @input_not_found() {
     %v = arith.constant 24 : i8
     arc.sim.instantiate @id as %model {
         // expected-error @+1 {{'arc.sim.set_input' op port not found on model}}
-        arc.sim.set_input %model, "unknown" = %v : i8, !arc.sim.instance<"id">
+        arc.sim.set_input %model, "unknown" = %v : i8, !arc.sim.instance<@id>
     }
     return
 }
@@ -85,7 +85,7 @@ func.func @set_port_wrong_size() {
     %v = arith.constant 24 : i16
     arc.sim.instantiate @id as %model {
         // expected-error @+1 {{'arc.sim.set_input' op mismatched types between value and model port, port expects 'i8'}}
-        arc.sim.set_input %model, "i" = %v : i16, !arc.sim.instance<"id">
+        arc.sim.set_input %model, "i" = %v : i16, !arc.sim.instance<@id>
     }
     return
 }
@@ -100,7 +100,7 @@ func.func @set_port_not_input() {
     %v = arith.constant 24 : i8
     arc.sim.instantiate @id as %model {
         // expected-error @+1 {{'arc.sim.set_input' op port is not an input port}}
-        arc.sim.set_input %model, "o" = %v : i8, !arc.sim.instance<"id">
+        arc.sim.set_input %model, "o" = %v : i8, !arc.sim.instance<@id>
     }
     return
 }

--- a/test/Dialect/Arc/sim-errors.mlir
+++ b/test/Dialect/Arc/sim-errors.mlir
@@ -29,7 +29,6 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 }
 
 func.func @model_not_found() {
-    // expected-error @+2 {{failed to legalize}}
     // expected-error @+1 {{model not found}}
     arc.sim.instantiate @unknown as %model {}
     return
@@ -43,7 +42,6 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 
 func.func @port_not_found() {
     arc.sim.instantiate @id as %model {
-        // expected-error @+2 {{failed to legalize}}
         // expected-error @+1 {{port not found}}
         %res = arc.sim.get_port %model, "unknown" : i8, !arc.sim.instance<"id">
         arc.sim.emit "use", %res : i8
@@ -59,8 +57,7 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 
 func.func @port_wrong_size() {
     arc.sim.instantiate @id as %model {
-        // expected-error @+2 {{failed to legalize}}
-        // expected-error @+1 {{expected port of width 8, got 16}}
+        // expected-error @+1 {{'arc.sim.get_port' op mismatched types between value and model port, port expects 'i8'}}
         %res = arc.sim.get_port %model, "i" : i16, !arc.sim.instance<"id">
         arc.sim.emit "use", %res : i16
     }
@@ -76,8 +73,7 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 func.func @input_not_found() {
     %v = arith.constant 24 : i8
     arc.sim.instantiate @id as %model {
-        // expected-error @+2 {{failed to legalize}}
-        // expected-error @+1 {{input not found}}
+        // expected-error @+1 {{'arc.sim.set_input' op port not found on model}}
         arc.sim.set_input %model, "unknown" = %v : i8, !arc.sim.instance<"id">
     }
     return
@@ -92,8 +88,7 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 func.func @set_port_wrong_size() {
     %v = arith.constant 24 : i16
     arc.sim.instantiate @id as %model {
-        // expected-error @+2 {{failed to legalize}}
-        // expected-error @+1 {{expected input of width 8, got 16}}
+        // expected-error @+1 {{'arc.sim.set_input' op mismatched types between value and model port, port expects 'i8'}}
         arc.sim.set_input %model, "i" = %v : i16, !arc.sim.instance<"id">
     }
     return
@@ -108,8 +103,7 @@ hw.module @id(in %i: i8, in %j: i8, out o: i8) {
 func.func @set_port_not_input() {
     %v = arith.constant 24 : i8
     arc.sim.instantiate @id as %model {
-        // expected-error @+2 {{failed to legalize}}
-        // expected-error @+1 {{provided port is not an input port}}
+        // expected-error @+1 {{'arc.sim.set_input' op port is not an input port}}
         arc.sim.set_input %model, "o" = %v : i8, !arc.sim.instance<"id">
     }
     return

--- a/test/Dialect/Arc/sim-errors.mlir
+++ b/test/Dialect/Arc/sim-errors.mlir
@@ -24,10 +24,6 @@ func.func @invalid_arg() {
 
 // -----
 
-hw.module @id(in %i: i8, in %j: i8, out o: i8) {
-    hw.output %i : i8
-}
-
 func.func @model_not_found() {
     // expected-error @+1 {{model not found}}
     arc.sim.instantiate @unknown as %model {}

--- a/test/arcilator/arcilator.mlir
+++ b/test/arcilator/arcilator.mlir
@@ -21,7 +21,7 @@
 // CHECK: func.func @Top_clock
 
 // CHECK-NOT: hw.module @Top
-// CHECK-LABEL: arc.model "Top" io !hw.modty<input clock : !seq.clock, input i0 : i4, input i1 : i4, output out : i4>
+// CHECK-LABEL: arc.model @Top io !hw.modty<input clock : !seq.clock, input i0 : i4, input i1 : i4, output out : i4>
 // CHECK-NEXT: ^bb0(%arg0: !arc.storage<8>):
 hw.module @Top(in %clock : !seq.clock, in %i0 : i4, in %i1 : i4, out out : i4) {
   // CHECK: func.call @Top_passthrough(%arg0)

--- a/test/arcilator/arcilator.mlir
+++ b/test/arcilator/arcilator.mlir
@@ -21,7 +21,7 @@
 // CHECK: func.func @Top_clock
 
 // CHECK-NOT: hw.module @Top
-// CHECK-LABEL: arc.model "Top" {
+// CHECK-LABEL: arc.model "Top" io !hw.modty<input clock : !seq.clock, input i0 : i4, input i1 : i4, output out : i4>
 // CHECK-NEXT: ^bb0(%arg0: !arc.storage<8>):
 hw.module @Top(in %clock : !seq.clock, in %i0 : i4, in %i1 : i4, out out : i4) {
   // CHECK: func.call @Top_passthrough(%arg0)


### PR DESCRIPTION
This introduces a couple new operations to drive simulation from within an MLIR program, next to the models themselves. This can be lowered by Arcilator to create LLVM functions that run the simulation. `arc.sim.emit` can be used to print values during the simulation. The semantics of this operation are to send a value to the simulation driver, but for now in practice this amounts to being lowered into a libc print to stdout.