### PR TITLE
[FIRRTL] Add integer addition parser support.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1186,6 +1186,18 @@ class IntegerBinaryPrimOp<string mnemonic, list<Trait> traits = []> :
                 [Pure, SameOperandsAndResultType] # traits> {
   // We use the standard inferReturnTypes from SameOperandsAndResultType.
   let inferReturnTypesDecl = "";
+
+  // We use a static inferType that always returns FIntegerType.
+  let inferType = "getFIntegerType";
+
+  // Define the getFIntegerType inline in ODS.
+  let firrtlExtraClassDeclaration = [{
+    static FIntegerType getFIntegerType(FIRRTLType lhs,
+                                        FIRRTLType rhs,
+                                        std::optional<Location> loc) {
+      return FIntegerType::get(lhs.getContext());
+    }
+  }];
 }
 
 def IntegerAddOp : IntegerBinaryPrimOp<"integer.add", [Commutative]> {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2252,6 +2252,10 @@ ParseResult FIRStmtParser::parsePrimExp(Value &result) {
   case FIRToken::lp_tail:
     attrNames.push_back(getConstants().amountIdentifier);
     break;
+  case FIRToken::lp_integer_add:
+    if (requireFeature({4, 0, 0}, "Integer arithmetic expressions", loc))
+      return failure();
+    break;
   }
 
   if (operands.size() != numOperandsExpected) {

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -215,6 +215,7 @@ TOK_LPKEYWORD_PRIM(sub, SubPrimOp, 2)
 TOK_LPKEYWORD_PRIM(tail, TailPrimOp, 1)
 TOK_LPKEYWORD_PRIM(xor, XorPrimOp, 2)
 TOK_LPKEYWORD_PRIM(xorr, XorRPrimOp, 1)
+TOK_LPKEYWORD_PRIM(integer_add, IntegerAddOp, 2)
 
 #undef TOK_MARKER
 #undef TOK_IDENTIFIER

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1850,6 +1850,20 @@ circuit BasicProps :
     propassign nested, List<List<String>>(List<String>(), List<String>(String("test")), List<String>())
 
 ;// -----
+FIRRTL version 4.0.0
+
+; CHECK-LABEL: firrtl.circuit "IntegerArithmetic"
+circuit IntegerArithmetic :
+  module IntegerArithmetic :
+    input a : Integer
+    input b : Integer
+    output c : Integer
+
+    ; CHECK: [[C:%.+]] = firrtl.integer.add %a, %b
+    ; CHECK: firrtl.propassign %c, [[C]]
+    propassign c, integer_add(a, b)
+
+;// -----
 FIRRTL version 3.1.0
 
 ; CHECK-LABEL: circuit "BundleOfProps"

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -870,6 +870,17 @@ circuit Top:
     propassign out, in
 
 ;// -----
+FIRRTL version 3.1.0
+
+circuit Top:
+  module Top:
+    input a : Integer
+    input b : Integer
+    output c : Integer
+    ; expected-error @below {{Integer arithmetic expressions are a FIRRTL 4.0.0+ feature, but the specified FIRRTL version was 3.1.0}}
+    propassign c, integer_add(a, b)
+
+;// -----
 FIRRTL version 3.3.0
 
 circuit Top:


### PR DESCRIPTION
This adds parser support for IntegerAddOp by defining the primitive expression keyword. This is only supported in FIRRTL version 4.0.0 and up.