### PR TITLE
[OM] Add OpInterface for IntegerBinaryArithmeticOp.

### DIFF
--- a/include/circt/Dialect/OM/OMOpInterfaces.h
+++ b/include/circt/Dialect/OM/OMOpInterfaces.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_OM_OMOPINTERFACES_H
 
 #include "mlir/IR/OpDefinition.h"
+#include "llvm/ADT/APSInt.h"
 
 #include "circt/Dialect/OM/OMOpInterfaces.h.inc"
 

--- a/include/circt/Dialect/OM/OMOpInterfaces.td
+++ b/include/circt/Dialect/OM/OMOpInterfaces.td
@@ -56,4 +56,20 @@ def ClassFieldLike : OpInterface<"ClassFieldLike"> {
   ];
 }
 
+def IntegerBinaryArithmeticInterface : OpInterface<"IntegerBinaryArithmeticOp"> {
+  let cppNamespace = "circt::om";
+  let description = "Common interface for integer binary arithmetic ops.";
+  let methods = [
+    InterfaceMethod<"Get the lhs Value",
+      "mlir::Value", "getLhs", (ins)>,
+    InterfaceMethod<"Get the rhs Value",
+      "mlir::Value", "getRhs", (ins)>,
+    InterfaceMethod<"Get the result Value",
+      "mlir::Value", "getResult", (ins)>,
+    InterfaceMethod<"Evaluate the integer binary arithmetic operation",
+      "mlir::FailureOr<llvm::APSInt>", "evaluateIntegerOperation",
+      (ins "llvm::APSInt":$lhs, "llvm::APSInt":$rhs)>
+  ];
+}
+
 #endif // CIRCT_DIALECT_OM_OMOPINTERFACES_TD


### PR DESCRIPTION
As we start adding integer binary arithmetic expressions, this will
allow us to abstract over these ops in the evaluator. The interfaces
defines accessors for each operand and the result, which can be
trivially implemented by a shared helper in ODS. The interface also
defines one method to be used in the evaluator, which is to actually
evaluate the integer arithmetic operation. APSInts for each operand
are passed to the interface method, and an APSInt representing the
result or a failure must be returned.