### PR TITLE
[OM] Add integer addition op.

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -447,4 +447,30 @@ def AnyCastOp : OMOp<"any_cast", [Pure]> {
   let assemblyFormat =
      "$input attr-dict `:` functional-type($input, $result)";
 }
+
+class IntegerBinaryArithmeticOp<string mnemonic, list<Trait> traits = []> :
+    OMOp<mnemonic, [
+      Pure,
+      DeclareOpInterfaceMethods<IntegerBinaryArithmeticInterface>
+    ] # traits> {
+  let arguments = (ins OMIntegerType:$lhs, OMIntegerType:$rhs);
+
+  let results = (outs OMIntegerType:$result);
+
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($result)";
+}
+
+def IntegerAddOp : IntegerBinaryArithmeticOp<"integer.add", [Commutative]> {
+  let summary = "Add two OMIntegerType values";
+  let description = [{
+    Perform arbitrary precision signed integer addition of two OMIntegerType
+    values.
+
+    Example:
+    ```mlir
+    %2 = om.integer.add %0, %1 : !om.integer
+    ```
+  }];
+}
+
 #endif // CIRCT_DIALECT_OM_OMOPS_TD

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -536,6 +536,16 @@ PathCreateOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
+// IntegerAddOp
+//===----------------------------------------------------------------------===//
+
+FailureOr<llvm::APSInt>
+IntegerAddOp::evaluateIntegerOperation(const llvm::APSInt &lhs,
+                                       const llvm::APSInt &rhs) {
+  return success(lhs + rhs);
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -280,3 +280,12 @@ om.class @Any(%in: !om.class.type<@Empty>) {
   // CHECK: om.class.field @field, %[[CAST]]
   om.class.field @field, %0 : !om.any
 }
+
+// CHECK-LABEL: @IntegerArithmetic
+om.class @IntegerArithmetic() {
+  %0 = om.constant #om.integer<1 : si3> : !om.integer
+  %1 = om.constant #om.integer<2 : si3> : !om.integer
+
+  // CHECK: om.integer.add %0, %1 : !om.integer
+  %2 = om.integer.add %0, %1 : !om.integer
+}


### PR DESCRIPTION
This op adds two OMIntegerType operands to produce an OMIntegerType result. This defines the evaluateIntegerOperation interface method in terms of APSInt +.