### PR TITLE
[CMake] Make ImportVerilog compile-time depend on slang

### DIFF
--- a/lib/Conversion/ImportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ImportVerilog/CMakeLists.txt
@@ -31,6 +31,9 @@ endif ()
 add_circt_translation_library(CIRCTImportVerilog
   ImportVerilog.cpp
 
+  DEPENDS
+  slang_slang
+
   LINK_LIBS PUBLIC
   MLIRTranslateLib
   PRIVATE


### PR DESCRIPTION
ImportVerilog.cpp depends on header files which are generated during the build of the `slang_slang` target. Not having this dependeny in CMake [can cause clean builds to fail](https://github.com/llvm/circt/actions/runs/7846969281/job/21414887555):

```
FAILED: lib/Conversion/ImportVerilog/CMakeFiles/obj.CIRCTImportVerilog.dir/ImportVerilog.cpp.o 
/usr/bin/g++ -D_DEBUG -D_GLIBCXX_ASSERTIONS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/__w/circt/circt/llvm/install/include -I/__w/circt/circt/include -I/__w/circt/circt/build/include -I/__w/circt/circt/build/_deps/slang-src/source/../include -I/__w/circt/circt/build/_deps/slang-build/source -I/__w/circt/circt/build/_deps/slang-src/source/../external -I/__w/circt/circt/build/_deps/unordered_dense-src/include -fno-exceptions -fno-rtti -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -fno-lifetime-dse -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -Wimplicit-fallthrough -Wno-nonnull -Wno-class-memaccess -Wno-redundant-move -Wno-pessimizing-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-comment -Wno-misleading-indentation -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -UNDEBUG -fexceptions -frtti -Wno-non-virtual-dtor -Wno-c++98-compat-extra-semi -Wno-ctad-maybe-unsupported -Wno-cast-qual -Wno-covered-switch-default -std=gnu++17 -MD -MT lib/Conversion/ImportVerilog/CMakeFiles/obj.CIRCTImportVerilog.dir/ImportVerilog.cpp.o -MF lib/Conversion/ImportVerilog/CMakeFiles/obj.CIRCTImportVerilog.dir/ImportVerilog.cpp.o.d -o lib/Conversion/ImportVerilog/CMakeFiles/obj.CIRCTImportVerilog.dir/ImportVerilog.cpp.o -c /__w/circt/circt/lib/Conversion/ImportVerilog/ImportVerilog.cpp
In file included from /__w/circt/circt/build/_deps/slang-src/source/../include/slang/diagnostics/DiagnosticEngine.h:16,
                 from /__w/circt/circt/build/_deps/slang-src/source/../include/slang/diagnostics/DiagnosticClient.h:10,
                 from /__w/circt/circt/lib/Conversion/ImportVerilog/ImportVerilog.cpp:23:
/__w/circt/circt/build/_deps/slang-src/source/../include/slang/diagnostics/Diagnostics.h:226:10: fatal error: slang/diagnostics/GeneralDiags.h: No such file or directory
  226 | #include "slang/diagnostics/GeneralDiags.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

Of course it would be better to specifically depend on the headers. But I don't see a way of doing this without changing the slang CMake files.