### PR TITLE
[ImportVerilog] Add translation, run Slang compilation

### DIFF
--- a/include/circt/Conversion/ImportVerilog.h
+++ b/include/circt/Conversion/ImportVerilog.h
@@ -146,6 +146,9 @@ preprocessVerilog(llvm::SourceMgr &sourceMgr, mlir::MLIRContext *context,
                   mlir::TimingScope &ts, llvm::raw_ostream &os,
                   const ImportVerilogOptions *options = nullptr);
 
+/// Register the `import-verilog` MLIR translation.
+void registerFromVerilogTranslation();
+
 /// Return a human-readable string describing the slang frontend version linked
 /// into CIRCT.
 std::string getSlangVersion();

--- a/include/circt/InitAllTranslations.h
+++ b/include/circt/InitAllTranslations.h
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Conversion/ImportVerilog.h"
 #include "circt/Dialect/Arc/ModelInfoExport.h"
 #include "circt/Dialect/Calyx/CalyxEmitter.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
@@ -36,6 +37,7 @@ inline void registerAllTranslations() {
     firrtl::registerToFIRFileTranslation();
     ExportSystemC::registerExportSystemCTranslation();
     debug::registerTranslations();
+    registerFromVerilogTranslation();
     return true;
   }();
   (void)initOnce;

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1,0 +1,7 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// REQUIRES: slang
+
+// CHECK: module {
+// CHECK: }
+module Foo;
+endmodule

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -1,0 +1,25 @@
+// RUN: circt-translate --import-verilog --verify-diagnostics --split-input-file %s
+// REQUIRES: slang
+
+// expected-error @below {{expected ';'}}
+module Foo 4;
+endmodule
+
+// -----
+
+// expected-note @below {{expanded from macro 'FOO'}}
+`define FOO input
+// expected-note @below {{expanded from macro 'BAR'}}
+`define BAR `FOO
+// expected-error @below {{expected identifier}}
+module Bar(`BAR);
+endmodule
+
+// -----
+
+module Baz;
+  mailbox a;
+  string b;
+  // expected-error @below {{value of type 'string' cannot be assigned to type 'mailbox'}}
+  initial a = b;
+endmodule


### PR DESCRIPTION
Add an `--import-verilog` translation target for `circt-translate`. This facilitates writing single-file test cases that don't require configuration of the Slang language frontend.

Actually run the Slang elaboration and compilation from within `ImportContext::importVerilog`. This will essentially do the full frontend work to ingest Verilog, but the part that translates from the Slang AST to CIRCT IR ops is still left to be filled in. The import will always produce an empty MLIR module for now. However, reporting of syntax or other errors on the Verilog side is already covered and can be tested for.