### PR TITLE
[FIRRTL] Add integer addition conversion to LowerClasses.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -984,6 +984,19 @@ struct ListCreateOpConversion
   }
 };
 
+struct IntegerAddOpConversion
+    : public OpConversionPattern<firrtl::IntegerAddOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(firrtl::IntegerAddOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<om::IntegerAddOp>(op, adaptor.getLhs(),
+                                                  adaptor.getRhs());
+    return success();
+  }
+};
+
 struct PathOpConversion : public OpConversionPattern<firrtl::PathOp> {
 
   PathOpConversion(TypeConverter &typeConverter, MLIRContext *context,
@@ -1397,6 +1410,7 @@ static void populateRewritePatterns(
   patterns.add<ListCreateOpConversion>(converter, patterns.getContext());
   patterns.add<BoolConstantOpConversion>(converter, patterns.getContext());
   patterns.add<DoubleConstantOpConversion>(converter, patterns.getContext());
+  patterns.add<IntegerAddOpConversion>(converter, patterns.getContext());
 }
 
 // Convert to OM ops and types in Classes or Modules.

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -357,3 +357,14 @@ firrtl.circuit "DownwardReferences" {
     firrtl.propassign %myClassUser.myClassIn, %myClass : !firrtl.class<@MyClass()>
   }
 }
+
+// CHECK-LABEL: firrtl.circuit "IntegerArithmetic"
+firrtl.circuit "IntegerArithmetic" {
+  firrtl.module @IntegerArithmetic() {
+    %0 = firrtl.integer 1
+    %1 = firrtl.integer 2
+
+    // CHECK: om.integer.add %0, %1 : !om.integer
+    %2 = firrtl.integer.add %0, %1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+  }
+}


### PR DESCRIPTION
This is a straightforward 1:1 conversion from FIRRTL IntegerAddOp to OM IntegerAddOp, using the converted operand types from the OpAdaptor.