### PR TITLE
[LTL] Add fundamental operators

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1411,10 +1411,28 @@ def LTLDelayIntrinsicOp : LTLIntrinsicOp<"delay"> {
   }];
 }
 def LTLConcatIntrinsicOp : BinaryLTLIntrinsicOp<"concat">;
+def LTLRepeatIntrinsicOp : LTLIntrinsicOp<"repeat"> {
+  let arguments = (ins UInt1Type:$input,
+                       I64Attr:$base,
+                       OptionalAttr<I64Attr>:$more);
+  let assemblyFormat = [{
+    $input `,` $base (`,` $more^)? attr-dict `:`
+    functional-type(operands, results)
+  }];
+}
 
 // Properties
 def LTLNotIntrinsicOp : UnaryLTLIntrinsicOp<"not">;
 def LTLImplicationIntrinsicOp : BinaryLTLIntrinsicOp<"implication">;
+def LTLNextIntrinsicOp : LTLIntrinsicOp<"next"> {
+  let arguments = (ins UInt1Type:$input,
+                       I64Attr:$time);
+  let assemblyFormat = [{
+    $input `,` $time attr-dict `:`
+    functional-type(operands, results)
+  }];
+}
+def LTLUntilIntrinsicOp : BinaryLTLIntrinsicOp<"until">;
 def LTLEventuallyIntrinsicOp : UnaryLTLIntrinsicOp<"eventually">;
 
 // Clocking

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -50,7 +50,8 @@ public:
             IsXIntrinsicOp, PlusArgsValueIntrinsicOp, PlusArgsTestIntrinsicOp,
             SizeOfIntrinsicOp, ClockGateIntrinsicOp, ClockInverterIntrinsicOp,
             LTLAndIntrinsicOp, LTLOrIntrinsicOp, LTLDelayIntrinsicOp,
-            LTLConcatIntrinsicOp, LTLNotIntrinsicOp, LTLImplicationIntrinsicOp,
+            LTLConcatIntrinsicOp, LTLRepeatIntrinsicOp, LTLNotIntrinsicOp,
+            LTLImplicationIntrinsicOp, LTLNextIntrinsicOp, LTLUntilIntrinsicOp,
             LTLEventuallyIntrinsicOp, LTLClockIntrinsicOp,
             LTLDisableIntrinsicOp, Mux2CellIntrinsicOp, Mux4CellIntrinsicOp,
             HasBeenResetIntrinsicOp, FPGAProbeIntrinsicOp,
@@ -171,8 +172,11 @@ public:
   HANDLE(LTLOrIntrinsicOp, Unhandled);
   HANDLE(LTLDelayIntrinsicOp, Unhandled);
   HANDLE(LTLConcatIntrinsicOp, Unhandled);
+  HANDLE(LTLRepeatIntrinsicOp, Unhandled);
   HANDLE(LTLNotIntrinsicOp, Unhandled);
   HANDLE(LTLImplicationIntrinsicOp, Unhandled);
+  HANDLE(LTLNextIntrinsicOp, Unhandled);
+  HANDLE(LTLUntilIntrinsicOp, Unhandled);
   HANDLE(LTLEventuallyIntrinsicOp, Unhandled);
   HANDLE(LTLClockIntrinsicOp, Unhandled);
   HANDLE(LTLDisableIntrinsicOp, Unhandled);

--- a/include/circt/Dialect/LTL/LTLFolds.td
+++ b/include/circt/Dialect/LTL/LTLFolds.td
@@ -62,4 +62,15 @@ def FlattenConcats : Pat<
   (ConcatOp $inputs), (ConcatOp (flattenConcats $inputs)),
   [(AnyDefiningOpIsConcat $inputs)]>;
 
+//===----------------------------------------------------------------------===//
+// NextOp
+//===----------------------------------------------------------------------===//
+
+// next(next(p, N), M) -> next(p, N+M)
+def mergedTimes : NativeCodeCall<
+  "$_builder.getI64IntegerAttr($0.getInt() + $1.getInt())">;
+def NestedNexts : Pat<
+  (NextOp (NextOp $input, $times1), $times2),
+  (NextOp $input, (mergedTimes $times1, $times2))>;
+
 #endif // CIRCT_DIALECT_LTL_LTLFOLDS_TD

--- a/include/circt/Dialect/LTL/LTLOps.td
+++ b/include/circt/Dialect/LTL/LTLOps.td
@@ -151,6 +151,31 @@ def ConcatOp : LTLOp<"concat", [Pure]> {
   }];
 }
 
+def RepeatOp : LTLOp<"repeat", [Pure]> {
+  let arguments = (ins
+    LTLAnySequenceType:$input,
+    I64Attr:$base,
+    OptionalAttr<I64Attr>:$more);
+  let results = (outs LTLSequenceType:$result);
+  let assemblyFormat = [{
+    $input `,` $base (`,` $more^)? attr-dict `:` type($input)
+  }];
+  let hasFolder = 1;
+
+  let summary = "Repeat a sequence by a number.";
+  let description = [{
+    Repeat the `$input` sequence at least `$base` times, at most `$base` +
+    `$more` times. The number must be greater than or equal to zero. Omitting
+    `$more` indicates an unbounded but finite repeat. For example:
+
+    - `ltl.repeat %seq, 2, 0` repeats `%seq` exactly 2 times.
+    - `ltl.repeat %seq, 2, 2` repeats `%seq` 2, 3, or 4 times.
+    - `ltl.repeat %seq, 2` repeats `%seq` 2 or more times. The number of times
+      is unbounded but finite.
+    - `ltl.repeat %seq, 0, 0` represents an empty sequence.
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Properties
 //===----------------------------------------------------------------------===//
@@ -188,6 +213,41 @@ def ImplicationOp : LTLOp<"implication", [Pure]> {
     `$antecedent` does *not* match at a given point in time, the result property
     trivially holds. This is conceptually identical to the implication operator
     →, but with additional temporal semantics.
+  }];
+}
+
+def NextOp : LTLOp<"next", [Pure]> {
+  let arguments = (ins LTLAnyPropertyType:$input,
+                       I64Attr:$time);
+  let results = (outs LTLPropertyType:$result);
+  let assemblyFormat = [{
+    $input `,` $time attr-dict `:` type($input)
+  }];
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
+
+  let summary = "Property holds after a specific number of cycles.";
+  let description = [{
+    The `$input` property holds after `$time` cycles exactly. The delay must be
+    greater than or equal to zero. This operator is weak: the operator will hold
+    if there is not enough cycles.
+  }];
+}
+
+def UntilOp: LTLOp<"until", [Pure]> {
+  let arguments = (ins LTLAnyPropertyType:$input,
+                       LTLAnyPropertyType:$condition);
+  let results = (outs LTLPropertyType:$result);
+  let assemblyFormat = [{
+    operands attr-dict `:` type(operands)
+  }];
+
+  let summary = "Property always holds until another property holds.";
+  let description = [{
+    Checks that the `$input` property always holds until the `$condition`
+    property holds once. This operator is weak: the property will hold even if
+    `$input` always holds and `$condition` never holds. This operator is
+    nonoverlapping: `$input` does not have to hold when `$condition` holds.
   }];
 }
 

--- a/include/circt/Dialect/LTL/LTLVisitors.h
+++ b/include/circt/Dialect/LTL/LTLVisitors.h
@@ -21,11 +21,11 @@ public:
   ResultType dispatchLTLVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<AndOp, OrOp, DelayOp, ConcatOp, NotOp, ImplicationOp,
-                       EventuallyOp, ClockOp, DisableOp>(
-            [&](auto op) -> ResultType {
-              return thisCast->visitLTL(op, args...);
-            })
+        .template Case<AndOp, OrOp, DelayOp, ConcatOp, RepeatOp, NotOp,
+                       ImplicationOp, NextOp, UntilOp, EventuallyOp, ClockOp,
+                       DisableOp>([&](auto op) -> ResultType {
+          return thisCast->visitLTL(op, args...);
+        })
         .Default([&](auto) -> ResultType {
           return thisCast->visitInvalidLTL(op, args...);
         });
@@ -52,8 +52,11 @@ public:
   HANDLE(OrOp, Unhandled);
   HANDLE(DelayOp, Unhandled);
   HANDLE(ConcatOp, Unhandled);
+  HANDLE(RepeatOp, Unhandled);
   HANDLE(NotOp, Unhandled);
   HANDLE(ImplicationOp, Unhandled);
+  HANDLE(NextOp, Unhandled);
+  HANDLE(UntilOp, Unhandled);
   HANDLE(EventuallyOp, Unhandled);
   HANDLE(ClockOp, Unhandled);
   HANDLE(DisableOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3382,8 +3382,11 @@ private:
   EmittedProperty visitLTL(ltl::OrOp op);
   EmittedProperty visitLTL(ltl::DelayOp op);
   EmittedProperty visitLTL(ltl::ConcatOp op);
+  EmittedProperty visitLTL(ltl::RepeatOp op);
   EmittedProperty visitLTL(ltl::NotOp op);
   EmittedProperty visitLTL(ltl::ImplicationOp op);
+  EmittedProperty visitLTL(ltl::NextOp op);
+  EmittedProperty visitLTL(ltl::UntilOp op);
   EmittedProperty visitLTL(ltl::EventuallyOp op);
   EmittedProperty visitLTL(ltl::ClockOp op);
   EmittedProperty visitLTL(ltl::DisableOp op);
@@ -3529,6 +3532,34 @@ EmittedProperty PropertyEmitter::visitLTL(ltl::ConcatOp op) {
   return {PropertyPrecedence::Concat};
 }
 
+EmittedProperty PropertyEmitter::visitLTL(ltl::RepeatOp op) {
+  emitNestedProperty(op.getInput(), PropertyPrecedence::Unary);
+  if (auto more = op.getMore()) {
+    if (*more == 0) {
+      ps << "[*";
+      ps.addAsString(op.getBase());
+      ps << "]";
+    } else {
+      ps << "[*";
+      ps.addAsString(op.getBase());
+      ps << ":";
+      ps.addAsString(op.getBase() + *more);
+      ps << "]";
+    }
+  } else {
+    if (op.getBase() == 0) {
+      ps << "[*]";
+    } else if (op.getBase() == 1) {
+      ps << "[+]";
+    } else {
+      ps << "[*";
+      ps.addAsString(op.getBase());
+      ps << ":$]";
+    }
+  }
+  return {PropertyPrecedence::Unary};
+}
+
 EmittedProperty PropertyEmitter::visitLTL(ltl::NotOp op) {
   ps << "not" << PP::space;
   emitNestedProperty(op.getInput(), PropertyPrecedence::Unary);
@@ -3562,6 +3593,29 @@ EmittedProperty PropertyEmitter::visitLTL(ltl::ImplicationOp op) {
   }
   emitNestedProperty(op.getConsequent(), PropertyPrecedence::Implication);
   return {PropertyPrecedence::Implication};
+}
+
+EmittedProperty PropertyEmitter::visitLTL(ltl::NextOp op) {
+  if (op.getTime() == 0) {
+    return emitNestedProperty(op.getInput(), PropertyPrecedence::Lowest);
+  }
+
+  if (op.getTime() == 1) {
+    ps << "nexttime" << PP::space;
+  } else {
+    ps << "nexttime[";
+    ps.addAsString(op.getTime());
+    ps << "]" << PP::space;
+  }
+  emitNestedProperty(op.getInput(), PropertyPrecedence::Unary);
+  return {PropertyPrecedence::Unary};
+}
+
+EmittedProperty PropertyEmitter::visitLTL(ltl::UntilOp op) {
+  emitNestedProperty(op.getInput(), PropertyPrecedence::Until);
+  ps << PP::space << "until" << PP::space;
+  emitNestedProperty(op.getCondition(), PropertyPrecedence::Until);
+  return {PropertyPrecedence::Until};
 }
 
 EmittedProperty PropertyEmitter::visitLTL(ltl::EventuallyOp op) {

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1612,8 +1612,11 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult visitExpr(LTLOrIntrinsicOp op);
   LogicalResult visitExpr(LTLDelayIntrinsicOp op);
   LogicalResult visitExpr(LTLConcatIntrinsicOp op);
+  LogicalResult visitExpr(LTLRepeatIntrinsicOp op);
   LogicalResult visitExpr(LTLNotIntrinsicOp op);
   LogicalResult visitExpr(LTLImplicationIntrinsicOp op);
+  LogicalResult visitExpr(LTLNextIntrinsicOp op);
+  LogicalResult visitExpr(LTLUntilIntrinsicOp op);
   LogicalResult visitExpr(LTLEventuallyIntrinsicOp op);
   LogicalResult visitExpr(LTLClockIntrinsicOp op);
   LogicalResult visitExpr(LTLDisableIntrinsicOp op);
@@ -3670,12 +3673,28 @@ LogicalResult FIRRTLLowering::visitExpr(LTLConcatIntrinsicOp op) {
       ValueRange{getLoweredValue(op.getLhs()), getLoweredValue(op.getRhs())});
 }
 
+LogicalResult FIRRTLLowering::visitExpr(LTLRepeatIntrinsicOp op) {
+  return setLoweringToLTL<ltl::RepeatOp>(op, getLoweredValue(op.getInput()),
+                                         op.getBaseAttr(), op.getMoreAttr());
+}
+
 LogicalResult FIRRTLLowering::visitExpr(LTLNotIntrinsicOp op) {
   return setLoweringToLTL<ltl::NotOp>(op, getLoweredValue(op.getInput()));
 }
 
 LogicalResult FIRRTLLowering::visitExpr(LTLImplicationIntrinsicOp op) {
   return setLoweringToLTL<ltl::ImplicationOp>(
+      op,
+      ValueRange{getLoweredValue(op.getLhs()), getLoweredValue(op.getRhs())});
+}
+
+LogicalResult FIRRTLLowering::visitExpr(LTLNextIntrinsicOp op) {
+  return setLoweringToLTL<ltl::NextOp>(op, getLoweredValue(op.getInput()),
+                                       op.getTimeAttr());
+}
+
+LogicalResult FIRRTLLowering::visitExpr(LTLUntilIntrinsicOp op) {
+  return setLoweringToLTL<ltl::UntilOp>(
       op,
       ValueRange{getLoweredValue(op.getLhs()), getLoweredValue(op.getRhs())});
 }

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -378,6 +378,51 @@ public:
   }
 };
 
+class CirctLTLRepeatConverter : public IntrinsicConverter {
+public:
+  CirctLTLRepeatConverter(StringRef name, FModuleLike mod)
+      : IntrinsicConverter(name, mod) {
+    auto getI64Attr = [&](int64_t value) {
+      return IntegerAttr::get(IntegerType::get(mod.getContext(), 64), value);
+    };
+
+    auto params = mod.getParameters();
+    base = getI64Attr(params[0]
+                          .cast<ParamDeclAttr>()
+                          .getValue()
+                          .cast<IntegerAttr>()
+                          .getValue()
+                          .getZExtValue());
+
+    if (params.size() >= 2)
+      if (auto moreDecl = cast<ParamDeclAttr>(params[1]))
+        more = getI64Attr(
+            cast<IntegerAttr>(moreDecl.getValue()).getValue().getZExtValue());
+  }
+
+  bool check() override {
+    return hasNPorts(2) || namedPort(0, "in") || namedPort(1, "out") ||
+           sizedPort<UIntType>(0, 1) || sizedPort<UIntType>(1, 1) ||
+           hasNParam(1, 2) || namedIntParam("base") ||
+           namedIntParam("more", true);
+  }
+
+  LogicalResult convert(InstanceOp inst) override {
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto in = builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(in);
+    auto out =
+        builder.create<LTLRepeatIntrinsicOp>(in.getType(), in, base, more);
+    inst.getResult(1).replaceAllUsesWith(out);
+    inst.erase();
+    return success();
+  }
+
+private:
+  IntegerAttr base;
+  IntegerAttr more;
+};
+
 class CirctLTLNotConverter : public IntrinsicConverter {
 public:
   using IntrinsicConverter::IntrinsicConverter;
@@ -419,6 +464,67 @@ public:
     inst.getResult(1).replaceAllUsesWith(rhs);
     auto out =
         builder.create<LTLImplicationIntrinsicOp>(lhs.getType(), lhs, rhs);
+    inst.getResult(2).replaceAllUsesWith(out);
+    inst.erase();
+    return success();
+  }
+};
+
+class CirctLTLNextConverter : public IntrinsicConverter {
+public:
+  CirctLTLNextConverter(StringRef name, FModuleLike mod)
+      : IntrinsicConverter(name, mod) {
+    auto getI64Attr = [&](int64_t value) {
+      return IntegerAttr::get(IntegerType::get(mod.getContext(), 64), value);
+    };
+
+    auto params = mod.getParameters();
+    time = getI64Attr(params[0]
+                          .cast<ParamDeclAttr>()
+                          .getValue()
+                          .cast<IntegerAttr>()
+                          .getValue()
+                          .getZExtValue());
+  }
+
+  bool check() override {
+    return hasNPorts(2) || namedPort(0, "in") || namedPort(1, "out") ||
+           sizedPort<UIntType>(0, 1) || sizedPort<UIntType>(1, 1) ||
+           hasNParam(1) || namedIntParam("time");
+  }
+
+  LogicalResult convert(InstanceOp inst) override {
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto in = builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(in);
+    auto out = builder.create<LTLNextIntrinsicOp>(in.getType(), in, time);
+    inst.getResult(1).replaceAllUsesWith(out);
+    inst.erase();
+    return success();
+  }
+
+private:
+  IntegerAttr time;
+};
+
+class CirctLTLUntilConverter : public IntrinsicConverter {
+public:
+  using IntrinsicConverter::IntrinsicConverter;
+
+  bool check() override {
+    return hasNPorts(3) || namedPort(0, "lhs") || namedPort(1, "rhs") ||
+           namedPort(2, "out") || sizedPort<UIntType>(0, 1) ||
+           sizedPort<UIntType>(1, 1) || sizedPort<UIntType>(2, 1) ||
+           hasNParam(0);
+  }
+
+  LogicalResult convert(InstanceOp inst) override {
+    ImplicitLocOpBuilder builder(inst.getLoc(), inst);
+    auto lhs = builder.create<WireOp>(inst.getResult(0).getType()).getResult();
+    auto rhs = builder.create<WireOp>(inst.getResult(1).getType()).getResult();
+    inst.getResult(0).replaceAllUsesWith(lhs);
+    inst.getResult(1).replaceAllUsesWith(rhs);
+    auto out = builder.create<LTLUntilIntrinsicOp>(lhs.getType(), lhs, rhs);
     inst.getResult(2).replaceAllUsesWith(out);
     inst.erase();
     return success();
@@ -730,9 +836,12 @@ void LowerIntrinsicsPass::runOnOperation() {
   lowering.add<CirctLTLOrConverter>("circt.ltl.or", "circt_ltl_or");
   lowering.add<CirctLTLDelayConverter>("circt.ltl.delay", "circt_ltl_delay");
   lowering.add<CirctLTLConcatConverter>("circt.ltl.concat", "circt_ltl_concat");
+  lowering.add<CirctLTLRepeatConverter>("circt.ltl.repeat", "circt_ltl_repeat");
   lowering.add<CirctLTLNotConverter>("circt.ltl.not", "circt_ltl_not");
   lowering.add<CirctLTLImplicationConverter>("circt.ltl.implication",
                                              "circt_ltl_implication");
+  lowering.add<CirctLTLNextConverter>("circt.ltl.next", "circt_ltl_next");
+  lowering.add<CirctLTLUntilConverter>("circt.ltl.until", "circt_ltl_until");
   lowering.add<CirctLTLEventuallyConverter>("circt.ltl.eventually",
                                             "circt_ltl_eventually");
   lowering.add<CirctLTLClockConverter>("circt.ltl.clock", "circt_ltl_clock");

--- a/lib/Dialect/LTL/LTLFolds.cpp
+++ b/lib/Dialect/LTL/LTLFolds.cpp
@@ -62,7 +62,7 @@ namespace patterns {
 OpFoldResult DelayOp::fold(FoldAdaptor adaptor) {
   // delay(s, 0, 0) -> s
   if (adaptor.getDelay() == 0 && adaptor.getLength() == 0 &&
-      !isa<SequenceType>(getResult().getType()))
+      isa<SequenceType>(getInput().getType()))
     return getInput();
 
   return {};
@@ -89,6 +89,36 @@ OpFoldResult ConcatOp::fold(FoldAdaptor adaptor) {
 void ConcatOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                            MLIRContext *context) {
   results.add<patterns::FlattenConcats>(results.getContext());
+}
+
+//===----------------------------------------------------------------------===//
+// RepeatOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult RepeatOp::fold(FoldAdaptor adaptor) {
+  // repeat(s, 1, 0) -> s
+  if (adaptor.getBase() == 1 && adaptor.getMore() == 0 &&
+      isa<SequenceType>(getInput().getType()))
+    return getInput();
+
+  return {};
+}
+
+//===----------------------------------------------------------------------===//
+// NextOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult NextOp::fold(FoldAdaptor adaptor) {
+  // next(p, 0) -> p
+  if (adaptor.getTime() == 0 && isa<PropertyType>(getInput().getType()))
+    return getInput();
+
+  return {};
+}
+
+void NextOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                         MLIRContext *context) {
+  results.add<patterns::NestedNexts>(results.getContext());
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ExportVerilog/verif.mlir
+++ b/test/Conversion/ExportVerilog/verif.mlir
@@ -107,6 +107,25 @@ hw.module @Sequences(in %clk: i1, in %a: i1, in %b: i1) {
   verif.assert %g2 : !ltl.sequence
   verif.assert %g3 : !ltl.sequence
 
+  // CHECK: assert property (a[*0]);
+  // CHECK: assert property (a[*4]);
+  // CHECK: assert property (a[*5:6]);
+  // CHECK: assert property (a[*7:$]);
+  // CHECK: assert property (a[*]);
+  // CHECK: assert property (a[+]);
+  %r0 = ltl.repeat %a, 0, 0 : i1
+  %r1 = ltl.repeat %a, 4, 0 : i1
+  %r2 = ltl.repeat %a, 5, 1 : i1
+  %r3 = ltl.repeat %a, 7 : i1
+  %r4 = ltl.repeat %a, 0 : i1
+  %r5 = ltl.repeat %a, 1 : i1
+  verif.assert %r0 : !ltl.sequence
+  verif.assert %r1 : !ltl.sequence
+  verif.assert %r2 : !ltl.sequence
+  verif.assert %r3 : !ltl.sequence
+  verif.assert %r4 : !ltl.sequence
+  verif.assert %r5 : !ltl.sequence
+
   // CHECK: assert property (@(posedge clk) a);
   // CHECK: assert property (@(negedge clk) a);
   // CHECK: assert property (@(edge clk) a);
@@ -145,6 +164,20 @@ hw.module @Properties(in %clk: i1, in %a: i1, in %b: i1) {
   %i5 = ltl.concat %a, %i1, %i4 : i1, !ltl.sequence, !ltl.sequence
   %i6 = ltl.implication %i5, %n0 : !ltl.sequence, !ltl.property
   verif.assert %i6 : !ltl.property
+
+  // CHECK: assert property (a)
+  // CHECK: assert property (nexttime a)
+  // CHECK: assert property (nexttime[2] a)
+  %x0 = ltl.next %a, 0 : i1
+  %x1 = ltl.next %a, 1 : i1
+  %x2 = ltl.next %a, 2 : i1
+  verif.assert %x0 : !ltl.property
+  verif.assert %x1 : !ltl.property
+  verif.assert %x2 : !ltl.property
+
+  // CHECK: assert property (a until b);
+  %u0 = ltl.until %a, %b : i1, i1
+  verif.assert %u0 : !ltl.property
 
   // CHECK: assert property (s_eventually a);
   %e0 = ltl.eventually %a : i1
@@ -196,6 +229,11 @@ hw.module @Precedence(in %a: i1, in %b: i1) {
   %e2 = ltl.and %b, %e0 : i1, !ltl.property
   verif.assert %e1 : !ltl.property
   verif.assert %e2 : !ltl.property
+
+  // CHECK: assert property ((a until b) and a);
+  %u0 = ltl.until %a, %b : i1, i1
+  %u1 = ltl.and %u0, %a : !ltl.property, i1
+  verif.assert %u1 : !ltl.property
 }
 
 // CHECK-LABEL: module SystemVerilogSpecExamples

--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -59,11 +59,22 @@ firrtl.circuit "Intrinsics" {
     // CHECK-NEXT: [[C0:%.+]] = ltl.concat [[D0]], [[L1]] : !ltl.sequence, !ltl.sequence
     %c0 = firrtl.int.ltl.concat %d0, %l1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 
+    // CHECK-NEXT: [[R0:%.+]] = ltl.repeat %a, 42 : i1
+    // CHECK-NEXT: [[R1:%.+]] = ltl.repeat %b, 42, 1337 : i1
+    %r0 = firrtl.int.ltl.repeat %a, 42 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %r1 = firrtl.int.ltl.repeat %b, 42, 1337 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+
     // CHECK-NEXT: [[N0:%.+]] = ltl.not [[C0]] : !ltl.sequence
     %n0 = firrtl.int.ltl.not %c0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
 
     // CHECK-NEXT: [[I0:%.+]] = ltl.implication [[C0]], [[N0]] : !ltl.sequence, !ltl.property
     %i0 = firrtl.int.ltl.implication %c0, %n0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+
+    // CHECK-NEXT: [[X0:%.+]] = ltl.next [[N0]], 1 : !ltl.property
+    %x0 = firrtl.int.ltl.next %n0, 1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+
+    // CHECK-NEXT: [[U0:%.+]] = ltl.until [[N0]], [[N0]] : !ltl.property, !ltl.property
+    %u0 = firrtl.int.ltl.until %n0, %n0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 
     // CHECK-NEXT: [[E0:%.+]] = ltl.eventually [[I0]] : !ltl.property
     %e0 = firrtl.int.ltl.eventually %i0 : (!firrtl.uint<1>) -> !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -124,8 +124,12 @@ firrtl.circuit "Foo" {
   // CHECK-NOT: LTLDelay1
   // CHECK-NOT: LTLDelay2
   // CHECK-NOT: LTLConcat
+  // CHECK-NOT: LTLRepeat1
+  // CHECK-NOT: LTLRepeat2
   // CHECK-NOT: LTLNot
   // CHECK-NOT: LTLImplication
+  // CHECK-NOT: LTLNext
+  // CHECK-NOT: LTLUntil
   // CHECK-NOT: LTLEventually
   // CHECK-NOT: LTLClock
   // CHECK-NOT: LTLDisable
@@ -134,8 +138,12 @@ firrtl.circuit "Foo" {
   firrtl.intmodule @LTLDelay1<delay: i64 = 42>(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.delay"}
   firrtl.intmodule @LTLDelay2<delay: i64 = 42, length: i64 = 1337>(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.delay"}
   firrtl.intmodule @LTLConcat(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.concat"}
+  firrtl.intmodule @LTLRepeat1<base: i64 = 42>(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.repeat"}
+  firrtl.intmodule @LTLRepeat2<base: i64 = 42, more: i64 = 1337>(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.repeat"}
   firrtl.intmodule @LTLNot(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.not"}
   firrtl.intmodule @LTLImplication(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.implication"}
+  firrtl.intmodule @LTLNext<time: i64 = 42>(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.next"}
+  firrtl.intmodule @LTLUntil(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.until"}
   firrtl.intmodule @LTLEventually(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.eventually"}
   firrtl.intmodule @LTLClock(in in: !firrtl.uint<1>, in clock: !firrtl.clock, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.clock"}
   firrtl.intmodule @LTLDisable(in in: !firrtl.uint<1>, in condition: !firrtl.uint<1>, out out: !firrtl.uint<1>) attributes {intrinsic = "circt.ltl.disable"}
@@ -157,16 +165,30 @@ firrtl.circuit "Foo" {
     %delay2.in, %delay2.out = firrtl.instance "delay2" @LTLDelay2(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
 
     // CHECK-NOT: LTLConcat
+    // CHECK: firrtl.int.ltl.concat {{%.+}}, {{%.+}} :
+    %concat.lhs, %concat.rhs, %concat.out = firrtl.instance "concat" @LTLConcat(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+
+    // CHECH-NOT: LTLRepeat1
+    // CHECH-NOT: LTLRepeat2
+    // CHECK: firrtl.int.ltl.repeat {{%.+}}, 42 :
+    // CHECK: firrtl.int.ltl.repeat {{%.+}}, 42, 1337 :
+    %repeat1.in, %repeat1.out = firrtl.instance "repeat1" @LTLRepeat1(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+    %repeat2.in, %repeat2.out = firrtl.instance "repeat2" @LTLRepeat2(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+
     // CHECK-NOT: LTLNot
     // CHECK-NOT: LTLImplication
+    // CHECK-NOT: LTLNext
+    // CHECK-NOT: LTLUntil
     // CHECK-NOT: LTLEventually
-    // CHECK: firrtl.int.ltl.concat {{%.+}}, {{%.+}} :
     // CHECK: firrtl.int.ltl.not {{%.+}} :
     // CHECK: firrtl.int.ltl.implication {{%.+}}, {{%.+}} :
+    // CHECK: firrtl.int.ltl.next {{%.+}}, 42 :
+    // CHECK: firrtl.int.ltl.until {{%.+}}, {{%.+}} :
     // CHECK: firrtl.int.ltl.eventually {{%.+}} :
-    %concat.lhs, %concat.rhs, %concat.out = firrtl.instance "concat" @LTLConcat(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     %not.in, %not.out = firrtl.instance "not" @LTLNot(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     %implication.lhs, %implication.rhs, %implication.out = firrtl.instance "implication" @LTLImplication(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+    %next.in, %next.out = firrtl.instance "next" @LTLNext(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
+    %until.lhs, %until.rhs, %until.out = firrtl.instance "until" @LTLUntil(in lhs: !firrtl.uint<1>, in rhs: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     %eventually.in, %eventually.out = firrtl.instance "eventually" @LTLEventually(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
 
     // CHECK-NOT: LTLClock

--- a/test/Dialect/LTL/basic.mlir
+++ b/test/Dialect/LTL/basic.mlir
@@ -62,6 +62,13 @@ ltl.concat %s : !ltl.sequence
 ltl.concat %s, %s : !ltl.sequence, !ltl.sequence
 ltl.concat %s, %s, %s : !ltl.sequence, !ltl.sequence, !ltl.sequence
 
+// CHECK: ltl.repeat {{%.+}}, 0 : !ltl.sequence
+// CHECK: ltl.repeat {{%.+}}, 42 : !ltl.sequence
+// CHECK: ltl.repeat {{%.+}}, 42, 1337 : !ltl.sequence
+ltl.repeat %s, 0 : !ltl.sequence
+ltl.repeat %s, 42 : !ltl.sequence
+ltl.repeat %s, 42, 1337 : !ltl.sequence
+
 //===----------------------------------------------------------------------===//
 // Properties
 //===----------------------------------------------------------------------===//
@@ -75,6 +82,12 @@ ltl.not %p : !ltl.property
 
 // CHECK: ltl.implication {{%.+}}, {{%.+}} : !ltl.sequence, !ltl.property
 ltl.implication %s, %p : !ltl.sequence, !ltl.property
+
+// CHECK: ltl.next {{%.+}}, 10 : !ltl.property
+ltl.next %p, 10 : !ltl.property
+
+// CHECK: ltl.until {{%.+}}, {{%.+}} : !ltl.property, !ltl.property
+ltl.until %p, %p : !ltl.property, !ltl.property
 
 // CHECK: ltl.eventually {{%.+}} : i1
 // CHECK: ltl.eventually {{%.+}} : !ltl.sequence


### PR DESCRIPTION
This PR aims to add fundamental operators into LTL dialect, namely `until`, `next` and `repeat`, to complete expressive power according to #6618 .

The current plan is:
- Add `ltl.until` for properties.
- Reuse `ltl.delay` as `next` operator on property. Inspired by `ltl.or` can be applied to both sequences and properties.
- Add `ltl.repeat` for sequences.

The document for the LTL dialect has been updated. I will add code implementation later.

Please let me know if you have any advice.