### PR TITLE
[FIRRTL] Dedup memory wrapper modules in LowerMemory

### DIFF
--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -68,15 +68,12 @@ firrtl.module @Dedup() {
   %mem0_write = firrtl.mem Undefined {depth = 12 : i64, name = "mem0", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
   %mem1_write = firrtl.mem Undefined {depth = 12 : i64, name = "mem1", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
   // CHECK: firrtl.instance mem0  @mem0(
-  // CHECK: firrtl.instance mem1  @mem1(
+  // CHECK: firrtl.instance mem1  @mem0(
 }
 // CHECK: firrtl.module private @mem0
 // CHECK-NEXT: firrtl.instance mem0_ext  @mem0_ext
 
 // CHECK: firrtl.memmodule private @mem0_ext
-
-// CHECK: firrtl.module private @mem1
-// CHECK-NEXT: firrtl.instance mem0_ext @mem0_ext
 }
 
 // Test that memories in the testharness are not deduped with other memories in
@@ -240,9 +237,9 @@ firrtl.module @Annotations() attributes {annotations = [{class = "sifive.enterpr
 // CHECK-LABEL: firrtl.circuit "NonLocalAnnotation"
 firrtl.circuit "NonLocalAnnotation" {
 
-// CHECK:  hw.hierpath private @[[nla_0:.+]] [@NonLocalAnnotation::@dut, @DUT::@[[MEM0:.+]], @mem0]
+// CHECK:  hw.hierpath private @[[nla0_0:.+]] [@NonLocalAnnotation::@dut, @DUT::@[[MEM0:.+]], @mem0]
 hw.hierpath private @nla0 [@NonLocalAnnotation::@dut, @DUT::@mem0]
-// CHECK:  hw.hierpath private @[[nla_1:.+]] [@NonLocalAnnotation::@dut, @DUT::@[[MEM1:.+]], @mem1]
+// CHECK:  hw.hierpath private @[[nla1_0:.+]] [@NonLocalAnnotation::@dut, @DUT::@[[MEM1:.+]], @mem0]
 hw.hierpath private @nla1 [@NonLocalAnnotation::@dut, @DUT]
 
 // CHECK: firrtl.module @NonLocalAnnotation()
@@ -256,7 +253,7 @@ firrtl.module @DUT() {
   %mem0_write = firrtl.mem sym @mem0 Undefined {annotations = [{circt.nonlocal = @nla0, class = "test0"}], depth = 12 : i64, name = "mem0", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 
   // This memory does not have a symbol already attached.
-  // CHECK: firrtl.instance mem1 sym @[[MEM1]] @mem1
+  // CHECK: firrtl.instance mem1 sym @[[MEM1]] @mem0
   %mem1_write = firrtl.mem Undefined {annotations = [{circt.nonlocal = @nla1, class = "test1"}], depth = 12 : i64, name = "mem1", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 
 // LowerMemory should ignore MemOps that are not seqmems. The following memory is a combmem with readLatency=0.
@@ -266,12 +263,7 @@ firrtl.module @DUT() {
 
 // CHECK: firrtl.module private @mem0
 // CHECK:   firrtl.instance mem0_ext sym @mem0_ext
-// CHECK-SAME: {annotations = [{circt.nonlocal = @[[nla_0]], class = "test0"}]}
+// CHECK-SAME: {annotations = [{circt.nonlocal = @[[nla0_0]], class = "test0"}, {circt.nonlocal = @[[nla1_0]], class = "test1"}]}
 // CHECK-SAME:  @mem0_ext(
 // CHECK: }
-
-// CHECK: firrtl.module private @mem1
-// CHECK:   firrtl.instance mem0_ext sym @mem0_ext
-// CHECK-SAME:  {annotations = [{circt.nonlocal = @[[nla_1]], class = "test1"}]}
-// CHECK-SAME:  @mem0_ext(
 }


### PR DESCRIPTION
Instead of just dedup-ing the external memory module, we include the memory wrapper module in the dedup calculation.

Resolves #6445.

Diff in `circt-opt -firrtl-lower-memory test/Dialect/FIRRTL/lower-memory.mlir` after this change:

```diff
--- main
+++ dedup-lower-memory-modules
@@ -75,7 +75,7 @@
   firrtl.circuit "Dedup" {
     firrtl.module @Dedup() {
       %mem0_W0_addr, %mem0_W0_en, %mem0_W0_clk, %mem0_W0_data = firrtl.instance mem0 @mem0(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
-      %mem1_W0_addr, %mem1_W0_en, %mem1_W0_clk, %mem1_W0_data = firrtl.instance mem1 @mem1(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+      %mem1_W0_addr, %mem1_W0_en, %mem1_W0_clk, %mem1_W0_data = firrtl.instance mem1 @mem0(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
     }
     firrtl.module private @mem0(in %W0_addr: !firrtl.uint<4>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.uint<42>) {
       %mem0_ext_W0_addr, %mem0_ext_W0_en, %mem0_ext_W0_clk, %mem0_ext_W0_data = firrtl.instance mem0_ext @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
@@ -85,13 +85,6 @@
       firrtl.strictconnect %mem0_ext_W0_data, %W0_data : !firrtl.uint<42>
     }
     firrtl.memmodule private @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-    firrtl.module private @mem1(in %W0_addr: !firrtl.uint<4>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.uint<42>) {
-      %mem0_ext_W0_addr, %mem0_ext_W0_en, %mem0_ext_W0_clk, %mem0_ext_W0_data = firrtl.instance mem0_ext @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
-      firrtl.strictconnect %mem0_ext_W0_addr, %W0_addr : !firrtl.uint<4>
-      firrtl.strictconnect %mem0_ext_W0_en, %W0_en : !firrtl.uint<1>
-      firrtl.strictconnect %mem0_ext_W0_clk, %W0_clk : !firrtl.clock
-      firrtl.strictconnect %mem0_ext_W0_data, %W0_data : !firrtl.uint<42>
-    }
   }
   firrtl.circuit "NoTestharnessDedup0" {
     firrtl.module @NoTestharnessDedup0() {
@@ -257,30 +250,23 @@
     hw.hierpath private @nla0 [@NonLocalAnnotation::@dut, @DUT::@mem0]
     hw.hierpath private @nla0_0 [@NonLocalAnnotation::@dut, @DUT::@mem0, @mem0]
     hw.hierpath private @nla1 [@NonLocalAnnotation::@dut, @DUT]
-    hw.hierpath private @nla1_0 [@NonLocalAnnotation::@dut, @DUT::@sym, @mem1]
+    hw.hierpath private @nla1_0 [@NonLocalAnnotation::@dut, @DUT::@sym, @mem0]
     firrtl.module @NonLocalAnnotation() {
       firrtl.instance dut sym @dut @DUT()
     }
     firrtl.module @DUT() {
       %mem0_W0_addr, %mem0_W0_en, %mem0_W0_clk, %mem0_W0_data = firrtl.instance mem0 sym @mem0 @mem0(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
-      %mem1_W0_addr, %mem1_W0_en, %mem1_W0_clk, %mem1_W0_data = firrtl.instance mem1 sym @sym @mem1(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+      %mem1_W0_addr, %mem1_W0_en, %mem1_W0_clk, %mem1_W0_data = firrtl.instance mem1 sym @sym @mem0(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
       %MRead_read = firrtl.mem Undefined {depth = 12 : i64, name = "MRead", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     }
     firrtl.module private @mem0(in %W0_addr: !firrtl.uint<4>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.uint<42>) {
-      %mem0_ext_W0_addr, %mem0_ext_W0_en, %mem0_ext_W0_clk, %mem0_ext_W0_data = firrtl.instance mem0_ext sym @mem0_ext {annotations = [{circt.nonlocal = @nla0_0, class = "test0"}]} @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
+      %mem0_ext_W0_addr, %mem0_ext_W0_en, %mem0_ext_W0_clk, %mem0_ext_W0_data = firrtl.instance mem0_ext sym @mem0_ext {annotations = [{circt.nonlocal = @nla0_0, class = "test0"}, {circt.nonlocal = @nla1_0, class = "test1"}]} @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
       firrtl.strictconnect %mem0_ext_W0_addr, %W0_addr : !firrtl.uint<4>
       firrtl.strictconnect %mem0_ext_W0_en, %W0_en : !firrtl.uint<1>
       firrtl.strictconnect %mem0_ext_W0_clk, %W0_clk : !firrtl.clock
       firrtl.strictconnect %mem0_ext_W0_data, %W0_data : !firrtl.uint<42>
     }
     firrtl.memmodule private @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-    firrtl.module private @mem1(in %W0_addr: !firrtl.uint<4>, in %W0_en: !firrtl.uint<1>, in %W0_clk: !firrtl.clock, in %W0_data: !firrtl.uint<42>) {
-      %mem0_ext_W0_addr, %mem0_ext_W0_en, %mem0_ext_W0_clk, %mem0_ext_W0_data = firrtl.instance mem0_ext sym @mem0_ext {annotations = [{circt.nonlocal = @nla1_0, class = "test1"}]} @mem0_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
-      firrtl.strictconnect %mem0_ext_W0_addr, %W0_addr : !firrtl.uint<4>
-      firrtl.strictconnect %mem0_ext_W0_en, %W0_en : !firrtl.uint<1>
-      firrtl.strictconnect %mem0_ext_W0_clk, %W0_clk : !firrtl.clock
-      firrtl.strictconnect %mem0_ext_W0_data, %W0_data : !firrtl.uint<42>
-    }
   }
 }
```