### PR TITLE
[FIRRTL][LowerLayers] Clean up names of artifacts generated by layers

### DIFF
--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -225,8 +225,8 @@ firrtl.circuit "Test" {
 
   // Src Outside Layerblock.
   //
-  // CHECK: firrtl.module private @[[A:.+]](in %_: !firrtl.uint<1>) {
-  // CHECK:   %0 = firrtl.ref.send %_ : !firrtl.uint<1>
+  // CHECK: firrtl.module private @[[A:.+]](in %[[p:.+]]: !firrtl.uint<1>) {
+  // CHECK:   %0 = firrtl.ref.send %[[p]] : !firrtl.uint<1>
   // CHECK:   %1 = firrtl.wire : !firrtl.probe<uint<1>>
   // CHECK:   firrtl.ref.define %1, %0 : !firrtl.probe<uint<1>>
   // CHECK: }
@@ -422,19 +422,19 @@ firrtl.circuit "Simple" {
 // CHECK:      firrtl.module @Simple() {
 // CHECK-NOT:  firrtl.module
 // CHECK-NOT:    firrtl.layerblock
-// CHECK:        %[[A_B_C_cc:[_a-zA-Z0-9]+]] = firrtl.instance simple_A_B_C {
+// CHECK:        %[[A_B_C_cc:[_a-zA-Z0-9]+]] = firrtl.instance a_b_c {
 // CHECK-SAME:     lowerToBind
 // CHECK-SAME:     output_file = #hw.output_file<"layers_Simple_A_B_C.sv"
 // CHECK-SAME:     excludeFromFileList
 // CHECK-SAME:     @Simple_A_B_C(
-// CHECK-NEXT:   %[[A_B_b:[_a-zA-Z0-9]+]], %[[A_B_c:[_a-zA-Z0-9]+]], %[[A_B_cc:[_a-zA-Z0-9]+]] = firrtl.instance simple_A_B {
+// CHECK-NEXT:   %[[A_B_b:[_a-zA-Z0-9]+]], %[[A_B_c:[_a-zA-Z0-9]+]], %[[A_B_cc:[_a-zA-Z0-9]+]] = firrtl.instance a_b {
 // CHECK-SAME:     lowerToBind
 // CHECK-SAME:     output_file = #hw.output_file<"layers_Simple_A_B.sv", excludeFromFileList>
 // CHECK-SAME:     @Simple_A_B(
 // CHECK-NEXT:   %[[A_B_cc_resolve:[_a-zA-Z0-9]+]] = firrtl.ref.resolve %[[A_B_cc]]
 // CHECK-NEXT:   firrtl.strictconnect %[[A_B_C_cc]], %[[A_B_cc_resolve]]
 // CHECK-NEXT:   firrtl.strictconnect %[[A_B_b]], %b
-// CHECK-NEXT:   %[[A_a:[_a-zA-Z0-9]+]], %[[A_c:[_a-zA-Z0-9]+]] = firrtl.instance simple_A {
+// CHECK-NEXT:   %[[A_a:[_a-zA-Z0-9]+]], %[[A_c:[_a-zA-Z0-9]+]] = firrtl.instance a {
 // CHECK-SAME:     lowerToBind
 // CHECK-SAME:     output_file = #hw.output_file<"layers_Simple_A.sv", excludeFromFileList>
 // CHECK-SAME:     @Simple_A(

--- a/test/firtool/layers.fir
+++ b/test/firtool/layers.fir
@@ -24,14 +24,14 @@ circuit Foo: %[[
         node y = x
 
 ; CHECK-LABEL: module Foo_A_B(
-; CHECK-NEXT:    input _x
+; CHECK-NEXT:    input x
 ; CHECK-NEXT:  );
-; CHECK:         wire y = _x;
+; CHECK:         wire y = x;
 ; CHECK-NEXT:  endmodule
 
 ; CHECK-LABEL: module Foo_A(
-; CHECK-NEXT:    input _in
-; CHECK:         wire x = _in;
+; CHECK-NEXT:    input in
+; CHECK:         wire x = in;
 ; CHECK-NEXT:    wire x_probe = x;
 ; CHECK-NEXT:  endmodule
 
@@ -39,15 +39,15 @@ circuit Foo: %[[
 ; CHECK:       `include "layers_Foo_A.sv"
 ; CHECK-NEXT:  `ifndef layers_Foo_A_B
 ; CHECK-NEXT:  `define layers_Foo_A_B
-; CHECK-NEXT:  bind Foo Foo_A_B foo_A_B (
-; CHECK-NEXT:    _x (Foo.foo_A.x_probe)
+; CHECK-NEXT:  bind Foo Foo_A_B a_b (
+; CHECK-NEXT:    x (Foo.a.x_probe)
 ; CHECK-NEXT:  );
 ; CHECK-NEXT:  `endif // layers_Foo_A_B
 
 ; CHECK-LABEL: FILE "layers_Foo_A.sv"
 ; CHECK:       `ifndef layers_Foo_A
 ; CHECK-NEXT:  `define layers_Foo_A
-; CHECK-NEXT:   bind Foo Foo_A foo_A (
-; CHECK-NEXT:     ._in (in)
+; CHECK-NEXT:   bind Foo Foo_A a (
+; CHECK-NEXT:     .in (in)
 ; CHECK-NEXT:   );
 ; CHECK-NEXT:  `endif // layers_Foo_A

--- a/test/firtool/lower-layers.fir
+++ b/test/firtool/lower-layers.fir
@@ -28,7 +28,7 @@ circuit Foo: %[[
       define b = probe(c)
 
   ; CHECK: module Foo();
-  ; CHECK:   wire d = Foo.bar.bar_Verification.c_probe;
+  ; CHECK:   wire d = Foo.bar.verification.c_probe;
   ; CHECK:   Bar bar ();
   ; CHECK: endmodule
   public module Foo enablelayer Verification:
@@ -37,4 +37,3 @@ circuit Foo: %[[
 
     node d = read(bar.b)
     connect bar.a, d
-

--- a/test/firtool/lower-layers2.fir
+++ b/test/firtool/lower-layers2.fir
@@ -11,13 +11,13 @@ circuit TestHarness:
   layer Verification bind:
 
   ; CHECK: module DUT_Verification(
-  ; CHECK:   input        _clock,
-  ; CHECK:   input [31:0] _a
+  ; CHECK:   input        clock,
+  ; CHECK:   input [31:0] a
   ; CHECK: );
   ; CHECK:   reg  [31:0] pc_d;
   ; CHECK:   wire [31:0] pc_d_probe = pc_d;
-  ; CHECK:   always @(posedge _clock)
-  ; CHECK:     pc_d <= _a;
+  ; CHECK:   always @(posedge clock)
+  ; CHECK:     pc_d <= a;
   ; CHECK: endmodule
 
   ; CHECK: module DUT(
@@ -52,14 +52,14 @@ circuit TestHarness:
       define trace = x
 
   ; CHECK: module TestHarness_Verification(
-  ; CHECK:   input [31:0] _dut_trace,
-  ; CHECK:   input        _clock,
-  ; CHECK:                _reset
+  ; CHECK:   input [31:0] dut_trace,
+  ; CHECK:   input        clock,
+  ; CHECK:                reset
   ; CHECK: );
   ; CHECK:   `ifndef SYNTHESIS
-  ; CHECK:     always @(posedge _clock) begin
-  ; CHECK:       if ((`PRINTF_COND_) & _reset)
-  ; CHECK:         $fwrite(32'h80000002, "The last PC was: %x", _dut_trace);
+  ; CHECK:     always @(posedge clock) begin
+  ; CHECK:       if ((`PRINTF_COND_) & reset)
+  ; CHECK:         $fwrite(32'h80000002, "The last PC was: %x", dut_trace);
   ; CHECK:     end // always @(posedge)
   ; CHECK:   `endif // not def SYNTHESIS
   ; CHECK: endmodule
@@ -94,13 +94,13 @@ circuit TestHarness:
 ; CHECK: // ----- 8< ----- FILE "layers_TestHarness_Verification.sv" ----- 8< -----
 ; CHECK: `ifndef layers_TestHarness_Verification
 ; CHECK: `define layers_TestHarness_Verification
-; CHECK: bind DUT DUT_Verification dUT_Verification (
-; CHECK:   ._clock (clock),
-; CHECK:   ._a     (a)
+; CHECK: bind DUT DUT_Verification verification (
+; CHECK:   .clock (clock),
+; CHECK:   .a     (a)
 ; CHECK: );
-; CHECK: bind TestHarness TestHarness_Verification testHarness_Verification (
-; CHECK:   ._dut_trace (TestHarness.dut.dUT_Verification.pc_d_probe),
-; CHECK:   ._clock     (clock),
-; CHECK:   ._reset     (reset)
+; CHECK: bind TestHarness TestHarness_Verification verification (
+; CHECK:   .dut_trace (TestHarness.dut.verification.pc_d_probe),
+; CHECK:   .clock     (clock),
+; CHECK:   .reset     (reset)
 ; CHECK: );
 ; CHECK: `endif // layers_TestHarness_Verification


### PR DESCRIPTION
- Layer module name: move into helper.
- Layer instance name:
  - don't put the parent module name in the instance name,
  - lowercase each part of the instance name, not just the first word.
- Layer file name: move into helper.
- Captured port names: don't prefix the port name with an underscore.