### PR TITLE
[FIRRTL] Support PropertyType in emitConnect.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -43,8 +43,14 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
       if (dstFType != srcFType)
         src = builder.create<RefCastOp>(dstFType, src);
       builder.create<RefDefineOp>(dst, src);
-    } else // Other types, give up and leave a connect
+    } else if (type_isa<PropertyType>(dstFType) &&
+               type_isa<PropertyType>(srcFType)) {
+      // Properties use propassign.
+      builder.create<PropAssignOp>(dst, src);
+    } else {
+      // Other types, give up and leave a connect
       builder.create<ConnectOp>(dst, src);
+    }
     return;
   }
 

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
@@ -157,3 +157,27 @@ firrtl.circuit "Refs" attributes {
     %dut_in, %dut_tap = firrtl.instance dut sym @dut @DUT(in in: !firrtl.uint<1>, out out: !firrtl.ref<uint<1>>)
   }
 }
+
+// -----
+
+// CHECK-LABEL: firrtl.circuit "Properties"
+firrtl.circuit "Properties" attributes {
+    annotations = [{class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Foo"}]
+  } {
+
+  firrtl.module private @DUT(
+    in %in: !firrtl.integer, out %out: !firrtl.integer
+  ) attributes {
+    annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
+    ]}
+  {
+    // CHECK: [[IN:%.+]], [[OUT:%.+]] = firrtl.instance Foo
+    // CHECK: firrtl.propassign [[IN]], %in
+    // CHECK: firrtl.propassign %out, [[OUT]]
+    firrtl.propassign %out, %in : !firrtl.integer
+  }
+  firrtl.module @Properties() {
+    %dut_in, %dut_out = firrtl.instance dut sym @dut @DUT(in in: !firrtl.integer, out out: !firrtl.integer)
+  }
+}


### PR DESCRIPTION
We have a centralized emitConnect helper that knows how to create the right kind of connections for various special, non-base types, like RefType and AnalogType. This adds another special case for PropertyType, which emits a PropAssignOp.

This is used in various places, but the pass where I noticed this was missing is InjectDUTHierarchy, so I've added a test there similar to the test for RefType.