### PR TITLE
 [CreateSiFiveMetadata] Generate firrtl.class instead of om.class 

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -182,6 +182,9 @@ struct ObjectModelIR {
   void addBlackBoxModule(FExtModuleOp module) {
     if (!blackBoxModulesSchemaClass)
       addBlackBoxModulesSchema();
+    StringRef defName = *module.getDefname();
+    if (!blackboxModules.insert(defName).second)
+      return;
     auto builderOM = mlir::ImplicitLocOpBuilder::atBlockEnd(
         module.getLoc(), blackBoxMetadataClass.getBodyBlock());
     auto modEntry = builderOM.create<StringConstantOp>(module.getDefnameAttr());
@@ -318,6 +321,7 @@ struct ObjectModelIR {
       "readLatency", "hierarchy"};
   StringRef retimeModulesParamNames[1] = {"moduleName"};
   StringRef blackBoxModulesParamNames[1] = {"moduleName"};
+  llvm::SmallDenseSet<StringRef> blackboxModules;
 };
 
 class CreateSiFiveMetadataPass

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -849,9 +849,8 @@ void CreateSiFiveMetadataPass::runOnOperation() {
       failed(emitSitestBlackboxMetadata(omir)) ||
       failed(emitMemoryMetadata(omir)))
     return signalPassFailure();
-
-  if (FModuleOp topMod =
-          dyn_cast<FModuleOp>(instanceGraph.getTopLevelNode()->getModule()))
+  auto *node = instanceGraph.getTopLevelNode();
+  if (FModuleOp topMod = dyn_cast<FModuleOp>(*node->getModule()))
     if (auto objectOp = omir.instantiateSifiveMetadata(topMod)) {
       SmallVector<std::pair<unsigned, PortInfo>> ports = {
           {topMod.getNumPorts(),

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -232,7 +232,6 @@ struct ObjectModelIR {
         return builderOM.create<FIntegerConstantOp>(intConstant);
       if (auto strConstant = dyn_cast_or_null<mlir::StringAttr>(constVal))
         return builderOM.create<StringConstantOp>(strConstant);
-      // static_assert(false, "Attribute not handled");
       return {};
     };
     auto nlaBuilder = OpBuilder::atBlockBegin(circtOp.getBodyBlock());
@@ -314,6 +313,11 @@ struct ObjectModelIR {
           propVal = extraPorts;
       }
 
+      // The memory schema is a simple class, with input tied to output. The
+      // arguments are ordered such that, port index i is the input that is tied
+      // to i+1 which is the output.
+      // The following `2*index` translates the index to the memory schema input
+      // port number.
       auto inPort =
           builderOM.create<ObjectSubfieldOp>(object, 2 * field.index());
       builderOM.create<PropAssignOp>(inPort, propVal);
@@ -869,8 +873,7 @@ void CreateSiFiveMetadataPass::runOnOperation() {
       topMod.insertPorts(ports);
     }
 
-  // This pass does not modify the hierarchy.
-  markAnalysesPreserved<InstanceGraph>();
+  // This pass modifies the hierarchy, InstanceGraph is not preserved.
 
   // Clear pass-global state as required by MLIR pass infrastructure.
   dutMod = {};

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -146,7 +146,7 @@ struct ObjectModelIR {
     auto unknownLoc = mlir::UnknownLoc::get(context);
     auto builderOM = mlir::ImplicitLocOpBuilder::atBlockEnd(
         unknownLoc, circtOp.getBodyBlock());
-    Type classFieldTypes[] = {PathType::get(context)};
+    Type classFieldTypes[] = {StringType::get(context)};
     retimeModulesSchemaClass =
         buildSimpleClassOp(builderOM, unknownLoc, "RetimeModulesSchema",
                            retimeModulesParamNames, classFieldTypes);
@@ -163,7 +163,8 @@ struct ObjectModelIR {
         module->getLoc(), retimeModulesMetadataClass.getBodyBlock());
 
     // Create the path operation.
-    auto modEntry = createPathRef(module, nullptr, builderOM);
+    auto modEntry =
+        builderOM.create<StringConstantOp>(module.getModuleNameAttr());
     auto object = builderOM.create<ObjectOp>(retimeModulesSchemaClass,
                                              module.getModuleNameAttr());
 

--- a/test/Dialect/FIRRTL/SFCTests/directories.fir
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir
@@ -134,20 +134,20 @@ circuit TestHarness:
 ; SITEST_NODUT:     FILE "testbench.sitest.json"
 ; SITEST_NODUT-NOT: FILE
 
-; MLIR_OUT:  om.class @SitestBlackBoxModulesSchema(%moduleName: !om.sym_ref) {
-; MLIR_OUT:    om.class.field @moduleName, %moduleName : !om.sym_ref
+; MLIR_OUT:  om.class @SitestBlackBoxModulesSchema(%basepath: !om.basepath, %moduleName_in: !om.string) {
+; MLIR_OUT:    om.class.field @moduleName, %moduleName_in : !om.string
 ; MLIR_OUT:  }
 
-; MLIR_OUT:  om.class @SitestBlackBoxMetadata() {
-; MLIR_OUT:    %0 = om.constant #om.sym_ref<@Foo_BlackBox> : !om.sym_ref
-; MLIR_OUT:    %1 = om.object @SitestBlackBoxModulesSchema(%0) : (!om.sym_ref) -> !om.class.type<@SitestBlackBoxModulesSchema>
-; MLIR_OUT:    om.class.field @exterMod_Foo_BlackBox, %1 : !om.class.type<@SitestBlackBoxModulesSchema>
-; MLIR_OUT:    %2 = om.constant #om.sym_ref<@Bar_BlackBox> : !om.sym_ref
-; MLIR_OUT:    %3 = om.object @SitestBlackBoxModulesSchema(%2) : (!om.sym_ref) -> !om.class.type<@SitestBlackBoxModulesSchema>
-; MLIR_OUT:    om.class.field @exterMod_Bar_BlackBox, %3 : !om.class.type<@SitestBlackBoxModulesSchema>
-; MLIR_OUT:    %4 = om.constant #om.sym_ref<@Baz_BlackBox> : !om.sym_ref
-; MLIR_OUT:    %5 = om.object @SitestBlackBoxModulesSchema(%4) : (!om.sym_ref) -> !om.class.type<@SitestBlackBoxModulesSchema>
-; MLIR_OUT:    om.class.field @exterMod_Baz_BlackBox, %5 : !om.class.type<@SitestBlackBoxModulesSchema>
+; MLIR_OUT:  om.class @SitestBlackBoxMetadata(%basepath: !om.basepath)
+; MLIR_OUT:    %0 = om.constant "Foo_BlackBox" : !om.string
+; MLIR_OUT:    %1 = om.object @SitestBlackBoxModulesSchema(%basepath, %0) : (!om.basepath, !om.string) -> !om.class.type<@SitestBlackBoxModulesSchema>
+; MLIR_OUT:    %2 = om.constant "Bar_BlackBox" : !om.string
+; MLIR_OUT:    %3 = om.object @SitestBlackBoxModulesSchema(%basepath, %2) : (!om.basepath, !om.string) -> !om.class.type<@SitestBlackBoxModulesSchema>
+; MLIR_OUT:    %4 = om.constant "Baz_BlackBox" : !om.string
+; MLIR_OUT:    %5 = om.object @SitestBlackBoxModulesSchema(%basepath, %4) : (!om.basepath, !om.string) -> !om.class.type<@SitestBlackBoxModulesSchema>
+; MLIR_OUT:    om.class.field @[[V1:.+]], %1 : !om.class.type<@SitestBlackBoxModulesSchema>
+; MLIR_OUT:    om.class.field @[[V2:.+]], %3 : !om.class.type<@SitestBlackBoxModulesSchema>
+; MLIR_OUT:    om.class.field @[[V3:.+]], %5 : !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT:  }
 
 ; MLIR_OUT:  om.class @MemorySchema(%name: !om.sym_ref, %depth: ui64, %width: ui32, %maskBits: ui32, %readPorts: ui32, %writePorts: ui32, %readwritePorts: ui32, %writeLatency: ui32, %readLatency: ui32) {

--- a/test/Dialect/FIRRTL/SFCTests/directories.fir
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir
@@ -150,7 +150,7 @@ circuit TestHarness:
 ; MLIR_OUT:    om.class.field @[[V3:.+]], %5 : !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT:  }
 
-; MLIR_OUT:  om.class @MemorySchema(%basepath: !om.basepath, %name_in: !om.string, %depth_in: !om.integer, %width_in: !om.integer, %maskBits_in: !om.integer, %readPorts_in: !om.integer, %writePorts_in: !om.integer, %readwritePorts_in: !om.integer, %writeLatency_in: !om.integer, %readLatency_in: !om.integer, %hierarchy_in: !om.list<!om.path>) {
+; MLIR_OUT:  om.class @MemorySchema(%basepath: !om.basepath, %name_in: !om.string, %depth_in: !om.integer, %width_in: !om.integer, %maskBits_in: !om.integer, %readPorts_in: !om.integer, %writePorts_in: !om.integer, %readwritePorts_in: !om.integer, %writeLatency_in: !om.integer, %readLatency_in: !om.integer, %hierarchy_in: !om.list<!om.path>, %inDut_in: i1, %extraPorts_in: !om.list<!om.class.type<@ExtraPortsMemorySchema>>)
 ; MLIR_OUT:    om.class.field @name, %name_in : !om.string
 ; MLIR_OUT:    om.class.field @depth, %depth_in : !om.integer
 ; MLIR_OUT:    om.class.field @width, %width_in : !om.integer
@@ -161,6 +161,7 @@ circuit TestHarness:
 ; MLIR_OUT:    om.class.field @writeLatency, %writeLatency_in : !om.integer
 ; MLIR_OUT:    om.class.field @readLatency, %readLatency_in : !om.integer
 ; MLIR_OUT:    om.class.field @hierarchy, %hierarchy_in : !om.list<!om.path>
+; MLIR_OUT:    om.class.field @extraPorts, %extraPorts_in : !om.list<!om.class.type<@ExtraPortsMemorySchema>>
 ; MLIR_OUT:  }
 ; MLIR_OUT:  om.class @MemoryMetadata(%basepath: !om.basepath)
 ; MLIR_OUT:     om.path_create reference %basepath @memNLA

--- a/test/Dialect/FIRRTL/SFCTests/directories.fir
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir
@@ -150,25 +150,59 @@ circuit TestHarness:
 ; MLIR_OUT:    om.class.field @[[V3:.+]], %5 : !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT:  }
 
-; MLIR_OUT:  om.class @MemorySchema(%name: !om.sym_ref, %depth: ui64, %width: ui32, %maskBits: ui32, %readPorts: ui32, %writePorts: ui32, %readwritePorts: ui32, %writeLatency: ui32, %readLatency: ui32) {
-; MLIR_OUT:    om.class.field @name, %name : !om.sym_ref
-; MLIR_OUT:    om.class.field @depth, %depth : ui64
-; MLIR_OUT:    om.class.field @width, %width : ui32
-; MLIR_OUT:    om.class.field @maskBits, %maskBits : ui32
-; MLIR_OUT:    om.class.field @readPorts, %readPorts : ui32
-; MLIR_OUT:    om.class.field @writePorts, %writePorts : ui32
-; MLIR_OUT:    om.class.field @readwritePorts, %readwritePorts : ui32
-; MLIR_OUT:    om.class.field @writeLatency, %writeLatency : ui32
-; MLIR_OUT:    om.class.field @readLatency, %readLatency : ui32
+; MLIR_OUT:  om.class @MemorySchema(%basepath: !om.basepath, %name_in: !om.string, %depth_in: !om.integer, %width_in: !om.integer, %maskBits_in: !om.integer, %readPorts_in: !om.integer, %writePorts_in: !om.integer, %readwritePorts_in: !om.integer, %writeLatency_in: !om.integer, %readLatency_in: !om.integer, %hierarchy_in: !om.list<!om.path>) {
+; MLIR_OUT:    om.class.field @name, %name_in : !om.string
+; MLIR_OUT:    om.class.field @depth, %depth_in : !om.integer
+; MLIR_OUT:    om.class.field @width, %width_in : !om.integer
+; MLIR_OUT:    om.class.field @maskBits, %maskBits_in : !om.integer
+; MLIR_OUT:    om.class.field @readPorts, %readPorts_in : !om.integer
+; MLIR_OUT:    om.class.field @writePorts, %writePorts_in : !om.integer
+; MLIR_OUT:    om.class.field @readwritePorts, %readwritePorts_in : !om.integer
+; MLIR_OUT:    om.class.field @writeLatency, %writeLatency_in : !om.integer
+; MLIR_OUT:    om.class.field @readLatency, %readLatency_in : !om.integer
+; MLIR_OUT:    om.class.field @hierarchy, %hierarchy_in : !om.list<!om.path>
 ; MLIR_OUT:  }
-; MLIR_OUT:  om.class @MemoryMetadata() {
-; MLIR_OUT:    om.constant #om.sym_ref<@foo_m_ext> : !om.sym_ref
-; MLIR_OUT:    om.object @MemorySchema
-; MLIR_OUT:    om.constant #om.sym_ref<@bar_m_ext> : !om.sym_ref
-; MLIR_OUT:    om.object @MemorySchema
-; MLIR_OUT:    om.constant #om.sym_ref<@baz_m_ext> : !om.sym_ref
-; MLIR_OUT:    om.object @MemorySchema
-; MLIR_OUT:  }
+; MLIR_OUT:  om.class @MemoryMetadata(%basepath: !om.basepath)
+; MLIR_OUT:     om.path_create reference %basepath @memNLA
+; MLIR_OUT:     om.list_create
+; MLIR_OUT:     om.object @MemorySchema
+; MLIR_OUT:     om.constant "foo_m_ext" : !om.string
+; MLIR_OUT:     om.constant #om.integer<1 : ui64> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<8 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<0 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.path_create reference %basepath @memNLA_0
+; MLIR_OUT:     om.list_create
+; MLIR_OUT:     om.object @MemorySchema
+; MLIR_OUT:     om.constant "bar_m_ext" : !om.string
+; MLIR_OUT:     om.constant #om.integer<2 : ui64> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<8 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<0 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.path_create reference %basepath @memNLA_1
+; MLIR_OUT:     om.path_create reference %basepath @memNLA_2
+; MLIR_OUT:     om.list_create
+; MLIR_OUT:     om.object @MemorySchema
+; MLIR_OUT:     om.constant "baz_m_ext" : !om.string
+; MLIR_OUT:     om.constant #om.integer<3 : ui64> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<8 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<0 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
+; MLIR_OUT:    om.class.field @foo_m_ext_field
+; MLIR_OUT:    om.class.field @bar_m_ext_field
+; MLIR_OUT:    om.class.field @baz_m_ext_field
 
 ; SITEST_NODUT:     FILE "design.sitest.json"
 ; SITEST_NODUT-NOT: FILE

--- a/test/Dialect/FIRRTL/SFCTests/directories.fir
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir
@@ -164,7 +164,7 @@ circuit TestHarness:
 ; MLIR_OUT:    om.class.field @extraPorts, %extraPorts_in : !om.list<!om.class.type<@ExtraPortsMemorySchema>>
 ; MLIR_OUT:  }
 ; MLIR_OUT:  om.class @MemoryMetadata(%basepath: !om.basepath)
-; MLIR_OUT:     om.path_create reference %basepath @memNLA
+; MLIR_OUT:     om.path_create instance %basepath @memNLA
 ; MLIR_OUT:     om.list_create
 ; MLIR_OUT:     om.object @MemorySchema
 ; MLIR_OUT:     om.constant "foo_m_ext" : !om.string
@@ -176,7 +176,7 @@ circuit TestHarness:
 ; MLIR_OUT:     om.constant #om.integer<0 : ui32> : !om.integer
 ; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
 ; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
-; MLIR_OUT:     om.path_create reference %basepath @memNLA_0
+; MLIR_OUT:     om.path_create instance %basepath @memNLA_0
 ; MLIR_OUT:     om.list_create
 ; MLIR_OUT:     om.object @MemorySchema
 ; MLIR_OUT:     om.constant "bar_m_ext" : !om.string
@@ -188,8 +188,8 @@ circuit TestHarness:
 ; MLIR_OUT:     om.constant #om.integer<0 : ui32> : !om.integer
 ; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
 ; MLIR_OUT:     om.constant #om.integer<1 : ui32> : !om.integer
-; MLIR_OUT:     om.path_create reference %basepath @memNLA_1
-; MLIR_OUT:     om.path_create reference %basepath @memNLA_2
+; MLIR_OUT:     om.path_create instance %basepath @memNLA_1
+; MLIR_OUT:     om.path_create instance %basepath @memNLA_2
 ; MLIR_OUT:     om.list_create
 ; MLIR_OUT:     om.object @MemorySchema
 ; MLIR_OUT:     om.constant "baz_m_ext" : !om.string

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -39,14 +39,11 @@ firrtl.circuit "retime0" attributes { annotations = [{
   }]} { }
 }
 // CHECK-LABEL: firrtl.circuit "retime0"   {
-// CHECK:         firrtl.module @retime0() 
+// CHECK:         firrtl.module @retime0(out %metadataObj: !firrtl.class<@SiFive_Metadata()>)
 // CHECK-SAME:               [{class = "circt.tracker", id = distinct[0]<>}]
 // CHECK:           %sifive_metadata = firrtl.object @SiFive_Metadata()
 // CHECK:         firrtl.module @retime1() {
-// CHECK:         firrtl.module @retime2() {
-// CHECK:               emit.file "retime_modules.json" {
-// CHECK-NEXT{LITERAL}:   sv.verbatim "[\0A \22{{0}}\22,\0A \22{{1}}\22\0A]" {symbols = [@retime0, @retime2]}
-// CHECK-NEXT:          }
+// CHECK:         firrtl.module @retime2() attributes {annotations = [{class = "circt.tracker", id = distinct[1]<>}]}
 
 // CHECK:  firrtl.class @RetimeModulesSchema(in %[[moduleName_in:.+]]: !firrtl.path, out %moduleName: !firrtl.path) {
 // CHECK:    firrtl.propassign %moduleName, %[[moduleName_in]] : !firrtl.path
@@ -60,7 +57,10 @@ firrtl.circuit "retime0" attributes { annotations = [{
 // CHECK:    %retime2 = firrtl.object @RetimeModulesSchema
 // CHECK:    firrtl.object.subfield %retime2
 // CHECK:    firrtl.propassign %[[retime2field]], %retime2
-    
+
+// CHECK:               emit.file "retime_modules.json" {
+// CHECK-NEXT{LITERAL}:   sv.verbatim "[\0A \22{{0}}\22,\0A \22{{1}}\22\0A]" {symbols = [@retime0, @retime2]}
+// CHECK-NEXT:          }
 
 // -----
 
@@ -193,15 +193,6 @@ firrtl.circuit "OneMemory" {
   }
   firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>, in user_input: !firrtl.uint<5>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [{direction = "input", name = "user_input", width = 5 : ui32}], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
 
-  // CHECK:               emit.file "metadata{{/|\\\\}}seq_mems.json" {
-  // CHECK-NEXT{LITERAL}:   sv.verbatim  "[\0A {\0A \22module_name\22: \22{{0}}\22,\0A \22depth\22: 12,\0A \22width\22: 42,\0A \22masked\22: false,\0A \22read\22: 0,\0A \22write\22: 1,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [\0A {\0A \22name\22: \22user_input\22,\0A \22direction\22: \22input\22,\0A \22width\22: 5\0A }\0A ],\0A \22hierarchy\22: [\0A \22{{1}}.MWrite_ext\22\0A ]\0A }\0A]"
-  // CHECK-SAME:              {symbols = [@MWrite_ext, @OneMemory]}
-  // CHECK-NEXT:          }
-
-  // CHECK:               emit.file "dut.conf" {
-  // CHECK-NEXT{LITERAL}:   sv.verbatim "name {{0}} depth 12 width 42 ports write\0A"
-  // CHECK-SAME:              {symbols = [@MWrite_ext]}
-  // CHECK-NEXT:          }
 
   // CHECK:  firrtl.class @MemorySchema
   // CHECK:    firrtl.propassign %name, %name_in : !firrtl.string
@@ -239,6 +230,16 @@ firrtl.circuit "OneMemory" {
   // CHECK:   firrtl.object.subfield %MWrite_ext[hierarchy_in]
   // CHECK:   firrtl.propassign %MWrite_ext_field, %MWrite_ext
   // CHECK: }
+
+  // CHECK:               emit.file "metadata{{/|\\\\}}seq_mems.json" {
+  // CHECK-NEXT{LITERAL}:   sv.verbatim  "[\0A {\0A \22module_name\22: \22{{0}}\22,\0A \22depth\22: 12,\0A \22width\22: 42,\0A \22masked\22: false,\0A \22read\22: 0,\0A \22write\22: 1,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [\0A {\0A \22name\22: \22user_input\22,\0A \22direction\22: \22input\22,\0A \22width\22: 5\0A }\0A ],\0A \22hierarchy\22: [\0A \22{{1}}.MWrite_ext\22\0A ]\0A }\0A]"
+  // CHECK-SAME:              {symbols = [@MWrite_ext, @OneMemory]}
+  // CHECK-NEXT:          }
+
+  // CHECK:               emit.file "dut.conf" {
+  // CHECK-NEXT{LITERAL}:   sv.verbatim "name {{0}} depth 12 width 42 ports write\0A"
+  // CHECK-SAME:              {symbols = [@MWrite_ext]}
+  // CHECK-NEXT:          }
 }
 
 // -----

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -39,25 +39,29 @@ firrtl.circuit "retime0" attributes { annotations = [{
   }]} { }
 }
 // CHECK-LABEL: firrtl.circuit "retime0"   {
-// CHECK:         firrtl.module @retime0() {
+// CHECK:         firrtl.module @retime0() 
+// CHECK-SAME:               [{class = "circt.tracker", id = distinct[0]<>}]
+// CHECK:           %sifive_metadata = firrtl.object @SiFive_Metadata()
 // CHECK:         firrtl.module @retime1() {
 // CHECK:         firrtl.module @retime2() {
 // CHECK:               emit.file "retime_modules.json" {
 // CHECK-NEXT{LITERAL}:   sv.verbatim "[\0A \22{{0}}\22,\0A \22{{1}}\22\0A]" {symbols = [@retime0, @retime2]}
 // CHECK-NEXT:          }
 
-// CHECK:   om.class @RetimeModulesSchema(%moduleName: !om.sym_ref) {
-// CHECK-NEXT:     om.class.field @moduleName, %moduleName : !om.sym_ref
-// CHECK-NEXT:   }
-
-// CHECK:   om.class @RetimeModulesMetadata() {
-// CHECK-NEXT:     %0 = om.constant #om.sym_ref<@retime0> : !om.sym_ref
-// CHECK-NEXT:     %1 = om.object @RetimeModulesSchema(%0) : (!om.sym_ref) -> !om.class.type<@RetimeModulesSchema>
-// CHECK-NEXT:     om.class.field @[[m1:.+]], %1 : !om.class.type<@RetimeModulesSchema>
-// CHECK-NEXT:     %2 = om.constant #om.sym_ref<@retime2> : !om.sym_ref
-// CHECK-NEXT:     %3 = om.object @RetimeModulesSchema(%2) : (!om.sym_ref) -> !om.class.type<@RetimeModulesSchema>
-// CHECK-NEXT:     om.class.field @[[m2:.+]], %3 : !om.class.type<@RetimeModulesSchema>
-// CHECK-NEXT:   }
+// CHECK:  firrtl.class @RetimeModulesSchema(in %[[moduleName_in:.+]]: !firrtl.path, out %moduleName: !firrtl.path) {
+// CHECK:    firrtl.propassign %moduleName, %[[moduleName_in]] : !firrtl.path
+// CHECK:  }
+// CHECK:  firrtl.class @RetimeModulesMetadata@RetimeModulesMetadata(out %retime0_field: !firrtl.class<@RetimeModulesSchema(in moduleName_in: !firrtl.path, out moduleName: !firrtl.path)>, out %retime2_field: !firrtl.class<@RetimeModulesSchema(in moduleName_in: !firrtl.path, out moduleName: !firrtl.path)>)
+// CHECK:    %0 = firrtl.path reference distinct[0]<>
+// CHECK:    %retime0 = firrtl.object @RetimeModulesSchema
+// CHECK:    %1 = firrtl.object.subfield %retime0
+// CHECK:    firrtl.propassign %[[retime0_field]], %retime0 : !firrtl.class\<@RetimeModulesSchema
+// CHECK:    %2 = firrtl.path reference distinct[1]<>
+// CHECK:    %retime2 = firrtl.object @RetimeModulesSchema
+// CHECK:    %3 = firrtl.object.subfield %retime2
+// CHECK:    firrtl.propassign %3, %2 : !firrtl.path
+// CHECK:    firrtl.propassign %[[retime2field]], %retime2 : !firrtl.class<@RetimeModulesSchema
+    
 
 // -----
 

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -51,16 +51,15 @@ firrtl.circuit "retime0" attributes { annotations = [{
 // CHECK:  firrtl.class @RetimeModulesSchema(in %[[moduleName_in:.+]]: !firrtl.path, out %moduleName: !firrtl.path) {
 // CHECK:    firrtl.propassign %moduleName, %[[moduleName_in]] : !firrtl.path
 // CHECK:  }
-// CHECK:  firrtl.class @RetimeModulesMetadata@RetimeModulesMetadata(out %retime0_field: !firrtl.class<@RetimeModulesSchema(in moduleName_in: !firrtl.path, out moduleName: !firrtl.path)>, out %retime2_field: !firrtl.class<@RetimeModulesSchema(in moduleName_in: !firrtl.path, out moduleName: !firrtl.path)>)
-// CHECK:    %0 = firrtl.path reference distinct[0]<>
+// CHECK:  firrtl.class @RetimeModulesMetadata(out %[[retime0_field:.+]]: !firrtl.class<@RetimeModulesSchema(in moduleName_in: !firrtl.path, out moduleName: !firrtl.path)>, out %[[retime2field:.+]]: !firrtl.class<@RetimeModulesSchema(in moduleName_in: !firrtl.path, out moduleName: !firrtl.path)>)
+// CHECK:    firrtl.path reference distinct[0]<>
 // CHECK:    %retime0 = firrtl.object @RetimeModulesSchema
-// CHECK:    %1 = firrtl.object.subfield %retime0
-// CHECK:    firrtl.propassign %[[retime0_field]], %retime0 : !firrtl.class\<@RetimeModulesSchema
-// CHECK:    %2 = firrtl.path reference distinct[1]<>
+// CHECK:    firrtl.object.subfield %retime0
+// CHECK:    firrtl.propassign %[[retime0_field]], %retime0 : !firrtl.class<@RetimeModulesSchema
+// CHECK:    firrtl.path reference distinct[1]<>
 // CHECK:    %retime2 = firrtl.object @RetimeModulesSchema
-// CHECK:    %3 = firrtl.object.subfield %retime2
-// CHECK:    firrtl.propassign %3, %2 : !firrtl.path
-// CHECK:    firrtl.propassign %[[retime2field]], %retime2 : !firrtl.class<@RetimeModulesSchema
+// CHECK:    firrtl.object.subfield %retime2
+// CHECK:    firrtl.propassign %[[retime2field]], %retime2
     
 
 // -----
@@ -131,6 +130,21 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
   // CHECK: firrtl.extmodule @ignored2()
   // CHECK-NOT: sifive.enterprise.firrtl.ScalaClassAnnotation
 
+// CHECK:    firrtl.class @SitestBlackBoxModulesSchema(in %[[moduleName_in:.+]]: !firrtl.string, out %moduleName: !firrtl.string) {
+// CHECK:      firrtl.propassign %moduleName, %[[moduleName_in]]
+// CHECK:    }
+
+// CHECK:    firrtl.class @SitestBlackBoxMetadata(out %TestBlackbox_field: !firrtl.class<@SitestBlackBoxModulesSchema(in moduleName_in: !firrtl.string, out moduleName: !firrtl.string)>, out %DUTBlackbox_0_field: !firrtl.class<@SitestBlackBoxModulesSchema(in moduleName_in: !firrtl.string, out moduleName: !firrtl.string)>, out %DUTBlackbox_1_field: !firrtl.class<@SitestBlackBoxModulesSchema(in moduleName_in: !firrtl.string, out moduleName: !firrtl.string)>) attributes {portAnnotations = []} {
+// CHECK:      firrtl.string "TestBlackbox"
+// CHECK:      %TestBlackbox = firrtl.object @SitestBlackBoxModulesSchema
+// CHECK:      firrtl.propassign %TestBlackbox_field, %TestBlackbox
+// CHECK:      firrtl.string "DUTBlackbox2"
+// CHECK:      %DUTBlackbox_0 = firrtl.object @SitestBlackBoxModulesSchema
+// CHECK:      firrtl.propassign %DUTBlackbox_0_field, %DUTBlackbox_0
+// CHECK:      firrtl.string "DUTBlackbox1"
+// CHECK:      %DUTBlackbox_1 = firrtl.object @SitestBlackBoxModulesSchema
+// CHECK:      firrtl.propassign %DUTBlackbox_1_field, %DUTBlackbox_1
+// CHECK:    }
   // Gracefully handle missing defnames.
   firrtl.extmodule @NoDefName()
 
@@ -148,24 +162,6 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
   // CHECK-NEXT{LITERAL}:   emit.verbatim "[\0A \22DUTBlackbox1\22,\0A \22DUTBlackbox2\22\0A]"
   // CHECK-NEXT:          }
 }
-// CHECK:  om.class @SitestBlackBoxModulesSchema(%moduleName: !om.sym_ref) {
-// CHECK-NEXT:    om.class.field @moduleName, %moduleName : !om.sym_ref
-// CHECK-NEXT:  }
-
-// CHECK:   om.class @SitestBlackBoxMetadata() {
-// CHECK:     %0 = om.constant #om.sym_ref<@TestBlackbox> : !om.sym_ref
-// CHECK:     %1 = om.object @SitestBlackBoxModulesSchema(%0)
-// CHECK:     om.class.field @exterMod_TestBlackbox, %1
-// CHECK:     %2 = om.constant #om.sym_ref<@DUTBlackbox_0> : !om.sym_ref
-// CHECK:     %3 = om.object @SitestBlackBoxModulesSchema(%2)
-// CHECK:     om.class.field @exterMod_DUTBlackbox_0, %3
-// CHECK:     %4 = om.constant #om.sym_ref<@DUTBlackbox_1> : !om.sym_ref
-// CHECK:     %5 = om.object @SitestBlackBoxModulesSchema(%4)
-// CHECK:     om.class.field @exterMod_DUTBlackbox_1, %5
-// CHECK:     %6 = om.constant #om.sym_ref<@DUTBlackbox_2> : !om.sym_ref
-// CHECK:     %7 = om.object @SitestBlackBoxModulesSchema(%6)
-// CHECK:     om.class.field @exterMod_DUTBlackbox_2, %7
-// CHECK:   }
 
 // -----
 
@@ -206,6 +202,43 @@ firrtl.circuit "OneMemory" {
   // CHECK-NEXT{LITERAL}:   sv.verbatim "name {{0}} depth 12 width 42 ports write\0A"
   // CHECK-SAME:              {symbols = [@MWrite_ext]}
   // CHECK-NEXT:          }
+
+  // CHECK:  firrtl.class @MemorySchema
+  // CHECK:    firrtl.propassign %name, %name_in : !firrtl.string
+  // CHECK:    firrtl.propassign %depth, %depth_in : !firrtl.integer
+  // CHECK:    firrtl.propassign %width, %width_in : !firrtl.integer
+  // CHECK:    firrtl.propassign %maskBits, %maskBits_in : !firrtl.integer
+  // CHECK:    firrtl.propassign %readPorts, %readPorts_in : !firrtl.integer
+  // CHECK:    firrtl.propassign %writePorts, %writePorts_in : !firrtl.integer
+  // CHECK:    firrtl.propassign %readwritePorts, %readwritePorts_in : !firrtl.integer
+  // CHECK:    firrtl.propassign %writeLatency, %writeLatency_in : !firrtl.integer
+  // CHECK:    firrtl.propassign %readLatency, %readLatency_in : !firrtl.integer
+  // CHECK:    firrtl.propassign %hierarchy, %hierarchy_in : !firrtl.list<path>
+  
+  // CHECK: firrtl.class @MemoryMetadata
+  // CHECK:   firrtl.path reference distinct[0]<>
+  // CHECK:   %MWrite_ext = firrtl.object @MemorySchema
+  // CHECK:   firrtl.string "MWrite_ext"
+  // CHECK:   firrtl.object.subfield %MWrite_ext[name_in]
+  // CHECK:   firrtl.integer 12
+  // CHECK:   firrtl.object.subfield %MWrite_ext[depth_in]
+  // CHECK:   firrtl.integer 42
+  // CHECK:   firrtl.object.subfield %MWrite_ext[width_in]
+  // CHECK:   firrtl.integer 1
+  // CHECK:   firrtl.object.subfield %MWrite_ext[maskBits_in]
+  // CHECK:   firrtl.integer 0
+  // CHECK:   firrtl.object.subfield %MWrite_ext[readPorts_in]
+  // CHECK:   firrtl.integer 1
+  // CHECK:   firrtl.object.subfield %MWrite_ext[writePorts_in]
+  // CHECK:   firrtl.integer 0
+  // CHECK:   firrtl.object.subfield %MWrite_ext[readwritePorts_in]
+  // CHECK:   firrtl.integer 1
+  // CHECK:   firrtl.object.subfield %MWrite_ext[writeLatency_in]
+  // CHECK:   firrtl.integer 1
+  // CHECK:   firrtl.object.subfield %MWrite_ext[readLatency_in]
+  // CHECK:   firrtl.object.subfield %MWrite_ext[hierarchy_in]
+  // CHECK:   firrtl.propassign %MWrite_ext_field, %MWrite_ext
+  // CHECK: }
 }
 
 // -----
@@ -239,31 +272,31 @@ firrtl.circuit "ReadOnlyMemory" {
 
 // CHECK-LABEL: firrtl.circuit "top"
 firrtl.circuit "top" {
-  firrtl.module @top()  {
-    // CHECK: firrtl.instance dut sym @[[DUT_SYM:.+]] @DUT
-    firrtl.instance dut @DUT()
-    firrtl.instance mem1 @Mem1()
-    firrtl.instance mem2 @Mem2()
-  }
-  firrtl.module private @Mem1() {
-    %0:4 = firrtl.instance head_ext  @head_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
-  }
-  firrtl.module private @Mem2() {
-    %0:4 =  firrtl.instance head_0_ext  @head_0_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
-  }
-  firrtl.module private @DUT() attributes {annotations = [
-    {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    // CHECK: firrtl.instance mem1 sym @[[MEM1_SYM:.+]] @Mem(
-    firrtl.instance mem1 @Mem()
-  }
-  firrtl.module private @Mem() {
-    %0:10 = firrtl.instance memory_ext {annotations = [{class = "sifive.enterprise.firrtl.SeqMemInstanceMetadataAnnotation", data = {baseAddress = 2147483648 : i64, dataBits = 8 : i64, eccBits = 0 : i64, eccIndices = [], eccScheme = "none"}}]} @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>)
-    %1:8 = firrtl.instance dumm_ext @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
-  }
-  firrtl.memmodule private @head_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-  firrtl.memmodule private @head_0_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-  firrtl.memmodule private @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>) attributes {dataWidth = 8 : ui32, depth = 16 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-  firrtl.memmodule private @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+    firrtl.module @top()  {
+      // CHECK: firrtl.instance dut sym @[[DUT_SYM:.+]] @DUT
+      firrtl.instance dut @DUT()
+      firrtl.instance mem1 @Mem1()
+      firrtl.instance mem2 @Mem2()
+    }
+    firrtl.module private @Mem1() {
+      %0:4 = firrtl.instance head_ext  @head_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
+    }
+    firrtl.module private @Mem2() {
+      %0:4 =  firrtl.instance head_0_ext  @head_0_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
+    }
+    firrtl.module private @DUT() attributes {annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+      // CHECK: firrtl.instance mem1 sym @[[MEM1_SYM:.+]] @Mem(
+      firrtl.instance mem1 @Mem()
+    }
+    firrtl.module private @Mem() {
+      %0:10 = firrtl.instance memory_ext {annotations = [{class = "sifive.enterprise.firrtl.SeqMemInstanceMetadataAnnotation", data = {baseAddress = 2147483648 : i64, dataBits = 8 : i64, eccBits = 0 : i64, eccIndices = [], eccScheme = "none"}}]} @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>)
+      %1:8 = firrtl.instance dumm_ext @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
+    }
+    firrtl.memmodule private @head_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+    firrtl.memmodule private @head_0_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+    firrtl.memmodule private @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>) attributes {dataWidth = 8 : ui32, depth = 16 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+    firrtl.memmodule private @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
 
   // CHECK:               emit.file "metadata{{/|\\\\}}seq_mems.json" {
   // CHECK-NEXT{LITERAL}:   sv.verbatim "[\0A {\0A \22module_name\22: \22{{0}}\22,\0A \22depth\22: 16,\0A \22width\22: 8,\0A \22masked\22: false,\0A \22read\22: 1,\0A \22write\22: 0,\0A \22readwrite\22: 1,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22{{3}}.{{4}}.memory_ext\22\0A ]\0A },\0A {\0A \22module_name\22: \22{{5}}\22,\0A \22depth\22: 20,\0A \22width\22: 5,\0A \22masked\22: false,\0A \22read\22: 1,\0A \22write\22: 1,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22{{3}}.{{4}}.dumm_ext\22\0A ]\0A }\0A]"
@@ -275,62 +308,3 @@ firrtl.circuit "top" {
   // CHECK-SAME:              {symbols = [@head_ext, @head_0_ext, @memory_ext, @dumm_ext]}
   // CHECK-NEXT:          }
 }
-
-// CHECK:  om.class @MemorySchema(%name: !om.sym_ref, %depth: ui64, %width: ui32, %maskBits: ui32, %readPorts: ui32, %writePorts: ui32, %readwritePorts: ui32, %writeLatency: ui32, %readLatency: ui32) {
-// CHECK-NEXT:    om.class.field @name, %name : !om.sym_ref
-// CHECK-NEXT:    om.class.field @depth, %depth : ui64
-// CHECK-NEXT:    om.class.field @width, %width : ui32
-// CHECK-NEXT:    om.class.field @maskBits, %maskBits : ui32
-// CHECK-NEXT:    om.class.field @readPorts, %readPorts : ui32
-// CHECK-NEXT:    om.class.field @writePorts, %writePorts : ui32
-// CHECK-NEXT:    om.class.field @readwritePorts, %readwritePorts : ui32
-// CHECK-NEXT:    om.class.field @writeLatency, %writeLatency : ui32
-// CHECK-NEXT:    om.class.field @readLatency, %readLatency : ui32
-// CHECK-NEXT:  }
-
-// CHECK:  om.class @MemoryMetadata() {
-// CHECK-NEXT:    %[[v0:.+]] = om.constant #om.sym_ref<@head_ext> : !om.sym_ref
-// CHECK-NEXT:    %[[v1:.+]] = om.constant 20 : ui64
-// CHECK-NEXT:    %[[v2:.+]] = om.constant 5 : ui32
-// CHECK-NEXT:    %[[v3:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v4:.+]] = om.constant 0 : ui32
-// CHECK-NEXT:    %[[v5:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v6:.+]] = om.constant 0 : ui32
-// CHECK-NEXT:    %[[v7:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v8:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v9:.+]] = om.object @MemorySchema(%[[v0]], %[[v1]], %[[v2]], %[[v3]], %[[v4]], %[[v5]], %[[v6]], %[[v7]], %[[v8]])
-// CHECK-NEXT:    om.class.field @[[m0:.+]], %[[v9]] : !om.class.type<@MemorySchema>
-// CHECK-NEXT:    %[[v10:.+]] = om.constant #om.sym_ref<@head_0_ext> : !om.sym_ref
-// CHECK-NEXT:    %[[v11:.+]] = om.constant 20 : ui64
-// CHECK-NEXT:    %[[v12:.+]] = om.constant 5 : ui32
-// CHECK-NEXT:    %[[v13:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v14:.+]] = om.constant 0 : ui32
-// CHECK-NEXT:    %[[v15:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v16:.+]] = om.constant 0 : ui32
-// CHECK-NEXT:    %[[v17:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v18:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v19:.+]] = om.object @MemorySchema(%[[v10]], %[[v11]], %[[v12]], %[[v13]], %[[v14]], %[[v15]], %[[v16]], %[[v17]], %[[v18]])
-// CHECK-NEXT:    om.class.field @[[m1:.+]], %[[v19]] : !om.class.type<@MemorySchema>
-// CHECK-NEXT:    %[[v20:.+]] = om.constant #om.sym_ref<@memory_ext> : !om.sym_ref
-// CHECK-NEXT:    %[[v21:.+]] = om.constant 16 : ui64
-// CHECK-NEXT:    %[[v22:.+]] = om.constant 8 : ui32
-// CHECK-NEXT:    %[[v23:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v24:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v25:.+]] = om.constant 0 : ui32
-// CHECK-NEXT:    %[[v26:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v27:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v28:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v29:.+]] = om.object @MemorySchema(%[[v20]], %[[v21]], %[[v22]], %[[v23]], %[[v24]], %[[v25]], %[[v26]], %[[v27]], %[[v28]])
-// CHECK-NEXT:    om.class.field @[[m2:.+]], %[[v29]] : !om.class.type<@MemorySchema>
-// CHECK-NEXT:    %[[v30:.+]] = om.constant #om.sym_ref<@dumm_ext> : !om.sym_ref
-// CHECK-NEXT:    %[[v31:.+]] = om.constant 20 : ui64
-// CHECK-NEXT:    %[[v32:.+]] = om.constant 5 : ui32
-// CHECK-NEXT:    %[[v33:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v34:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v35:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v36:.+]] = om.constant 0 : ui32
-// CHECK-NEXT:    %[[v37:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v38:.+]] = om.constant 1 : ui32
-// CHECK-NEXT:    %[[v39:.+]] = om.object @MemorySchema(%[[v30]], %[[v31]], %[[v32]], %[[v33]], %[[v34]], %[[v35]], %[[v36]], %[[v37]], %[[v38]]) : (!om.sym_ref, ui64, ui32, ui32, ui32, ui32, ui32, ui32, ui32) -> !om.class.type<@MemorySchema>
-// CHECK-NEXT:    om.class.field @[[m3:.+]], %[[v39]] : !om.class.type<@MemorySchema>
-// CHECK-NEXT:  }

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -39,9 +39,9 @@ firrtl.circuit "retime0" attributes { annotations = [{
   }]} { }
 }
 // CHECK-LABEL: firrtl.circuit "retime0"   {
-// CHECK:         firrtl.module @retime0(out %metadataObj: !firrtl.class<@SiFive_Metadata()>)
+// CHECK:         firrtl.module @retime0(out %metadataObj: !firrtl.class<@SiFive_Metadata
 // CHECK-SAME:               [{class = "circt.tracker", id = distinct[0]<>}]
-// CHECK:           %sifive_metadata = firrtl.object @SiFive_Metadata()
+// CHECK:           %sifive_metadata = firrtl.object @SiFive_Metadata
 // CHECK:         firrtl.module @retime1() {
 // CHECK:         firrtl.module @retime2() attributes {annotations = [{class = "circt.tracker", id = distinct[1]<>}]}
 
@@ -49,11 +49,11 @@ firrtl.circuit "retime0" attributes { annotations = [{
 // CHECK:    firrtl.propassign %moduleName, %[[moduleName_in]] : !firrtl.path
 // CHECK:  }
 // CHECK:  firrtl.class @RetimeModulesMetadata(out %[[retime0_field:.+]]: !firrtl.class<@RetimeModulesSchema(in moduleName_in: !firrtl.path, out moduleName: !firrtl.path)>, out %[[retime2field:.+]]: !firrtl.class<@RetimeModulesSchema(in moduleName_in: !firrtl.path, out moduleName: !firrtl.path)>)
-// CHECK:    firrtl.path reference distinct[0]<>
+// CHECK:    firrtl.path instance distinct[0]<>
 // CHECK:    %retime0 = firrtl.object @RetimeModulesSchema
 // CHECK:    firrtl.object.subfield %retime0
 // CHECK:    firrtl.propassign %[[retime0_field]], %retime0 : !firrtl.class<@RetimeModulesSchema
-// CHECK:    firrtl.path reference distinct[1]<>
+// CHECK:    firrtl.path instance distinct[1]<>
 // CHECK:    %retime2 = firrtl.object @RetimeModulesSchema
 // CHECK:    firrtl.object.subfield %retime2
 // CHECK:    firrtl.propassign %[[retime2field]], %retime2
@@ -207,7 +207,7 @@ firrtl.circuit "OneMemory" {
   // CHECK:    firrtl.propassign %hierarchy, %hierarchy_in : !firrtl.list<path>
   
   // CHECK: firrtl.class @MemoryMetadata
-  // CHECK:   firrtl.path reference distinct[0]<>
+  // CHECK:   firrtl.path instance distinct[0]<>
   // CHECK:   %MWrite_ext = firrtl.object @MemorySchema
   // CHECK:   firrtl.string "MWrite_ext"
   // CHECK:   firrtl.object.subfield %MWrite_ext[name_in]

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -40,23 +40,24 @@ firrtl.circuit "retime0" attributes { annotations = [{
 }
 // CHECK-LABEL: firrtl.circuit "retime0"   {
 // CHECK:         firrtl.module @retime0(out %metadataObj: !firrtl.class<@SiFive_Metadata
-// CHECK-SAME:               [{class = "circt.tracker", id = distinct[0]<>}]
 // CHECK:           %sifive_metadata = firrtl.object @SiFive_Metadata
 // CHECK:         firrtl.module @retime1() {
-// CHECK:         firrtl.module @retime2() attributes {annotations = [{class = "circt.tracker", id = distinct[1]<>}]}
+// CHECK:         firrtl.module @retime2()
 
-// CHECK:  firrtl.class @RetimeModulesSchema(in %[[moduleName_in:.+]]: !firrtl.path, out %moduleName: !firrtl.path) {
-// CHECK:    firrtl.propassign %moduleName, %[[moduleName_in]] : !firrtl.path
-// CHECK:  }
-// CHECK:  firrtl.class @RetimeModulesMetadata(out %[[retime0_field:.+]]: !firrtl.class<@RetimeModulesSchema(in moduleName_in: !firrtl.path, out moduleName: !firrtl.path)>, out %[[retime2field:.+]]: !firrtl.class<@RetimeModulesSchema(in moduleName_in: !firrtl.path, out moduleName: !firrtl.path)>)
-// CHECK:    firrtl.path instance distinct[0]<>
+// CHECK:    firrtl.class @RetimeModulesSchema(in %[[moduleName_in:.+]]: !firrtl.string, out %moduleName: !firrtl.string) {
+// CHECK:    firrtl.propassign %moduleName, %[[moduleName_in]]
+
+// CHECK:  firrtl.class @RetimeModulesMetadata
+// CHECK-SAME: (out %[[retime0_field:[a-zA-Z][a-zA-Z0-9_]*]]: !firrtl.class<@RetimeModulesSchema
+// CHECK:    %[[v0:.+]] = firrtl.string "retime0"
 // CHECK:    %retime0 = firrtl.object @RetimeModulesSchema
-// CHECK:    firrtl.object.subfield %retime0
-// CHECK:    firrtl.propassign %[[retime0_field]], %retime0 : !firrtl.class<@RetimeModulesSchema
-// CHECK:    firrtl.path instance distinct[1]<>
+// CHECK-NEXT:    %[[v1:.+]] = firrtl.object.subfield %retime0
+// CHECK-NEXT:    firrtl.propassign %[[v1]], %[[v0]] : !firrtl.string
+// CHECK-NEXT:    firrtl.propassign %[[retime0_field]], %retime0
+// CHECK:    %2 = firrtl.string "retime2"
 // CHECK:    %retime2 = firrtl.object @RetimeModulesSchema
 // CHECK:    firrtl.object.subfield %retime2
-// CHECK:    firrtl.propassign %[[retime2field]], %retime2
+// CHECK:    firrtl.propassign %[[retime2field:.+]], %retime2
 
 // CHECK:               emit.file "retime_modules.json" {
 // CHECK-NEXT{LITERAL}:   sv.verbatim "[\0A \22{{0}}\22,\0A \22{{1}}\22\0A]" {symbols = [@retime0, @retime2]}


### PR DESCRIPTION
Update the object model generated by the CreateSiFiveMetadata pass to generate `firrtl` dialect, instead of `om` dialect.
Ensure all `firrtl.class` associated with the metadata are instantiated inside a top level `firrtl.class` `SiFive_Metadata` , which is instantiated inside the top level `firrtl.module`.  This is required for ensuring that subsequent passes can lower it correctly.
Generate all the hierarchical paths to the memory and associate them with the path operation for the memory metadata.