### PR TITLE
[Sim] Introduce wrappers on top of `sv.finish`/`sv.fatal`

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -15,6 +15,7 @@
 
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "circt/Dialect/Sim/SimDialect.td"
+include "circt/Dialect/Seq/SeqTypes.td"
 
 class SimOp<string mnemonic, list<Trait> traits = []> :
     Op<SimDialect, mnemonic, traits>;
@@ -33,6 +34,24 @@ def PlusArgsValueOp : SimOp<"plusargs.value", [Pure]> {
   let arguments = (ins StrAttr:$formatString);
   let results = (outs I1:$found, AnyType:$result);
   let assemblyFormat = "$formatString attr-dict `:` type($result)";
+}
+
+def FinishOp : SimOp<"finish"> {
+  let summary = "Simulation finish condition";
+
+  let arguments = (ins ClockType:$clk, I1:$cond);
+  let results = (outs);
+
+  let assemblyFormat = "$clk `,` $cond attr-dict";
+}
+
+def FatalOp : SimOp<"fatal"> {
+  let summary = "Simulation failure condition";
+
+  let arguments = (ins ClockType:$clk, I1:$cond);
+  let results = (outs);
+
+  let assemblyFormat = "$clk `,` $cond attr-dict";
 }
 
 #endif // CIRCT_DIALECT_SIM_SIMOPS_TD

--- a/lib/Conversion/SimToSV/CMakeLists.txt
+++ b/lib/Conversion/SimToSV/CMakeLists.txt
@@ -9,4 +9,5 @@ add_circt_conversion_library(CIRCTSimToSV
 
   LINK_LIBS PUBLIC
   CIRCTSim
+  CIRCTSeq
 )

--- a/lib/Dialect/Sim/CMakeLists.txt
+++ b/lib/Dialect/Sim/CMakeLists.txt
@@ -26,9 +26,9 @@ add_circt_dialect_library(CIRCTSim
 
   LINK_LIBS PUBLIC
   CIRCTHW
+  CIRCTSeq
   CIRCTSV
   MLIRIR
   MLIRPass
   MLIRTransforms
 )
-

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -266,6 +266,7 @@ LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
         opt.shouldEtcDisableModuleInlining()));
 
   pm.addPass(seq::createExternalizeClockGatePass(opt.getClockGateOptions()));
+  pm.addNestedPass<hw::HWModuleOp>(circt::createLowerSimToSVPass());
   pm.addPass(circt::createLowerSeqToSVPass(
       {/*disableRegRandomization=*/!opt.isRandomEnabled(
            FirtoolOptions::RandomKind::Reg),
@@ -273,7 +274,6 @@ LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
        !opt.isRandomEnabled(FirtoolOptions::RandomKind::Mem),
        /*emitSeparateAlwaysBlocks=*/
        opt.shouldEmitSeparateAlwaysBlocks()}));
-  pm.addNestedPass<hw::HWModuleOp>(circt::createLowerSimToSVPass());
   pm.addNestedPass<hw::HWModuleOp>(createLowerVerifToSVPass());
   pm.addPass(seq::createHWMemSimImplPass(
       {/*disableMemRandomization=*/!opt.isRandomEnabled(

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -361,28 +361,14 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: hw.module private @Stop
   firrtl.module private @Stop(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock, in %reset: !firrtl.uint<1>) {
-    // CHECK: [[CLOCK2:%.+]] = seq.from_clock %clock2
-    // CHECK: [[CLOCK1:%.+]] = seq.from_clock %clock1
-
-    // CHECK-NEXT: sv.ifdef "SYNTHESIS" {
-    // CHECK-NEXT: } else {
-    // CHECK-NEXT:   sv.always posedge [[CLOCK1]] {
-    // CHECK-NEXT:     %STOP_COND_ = sv.macro.ref @STOP_COND_
-    // CHECK-NEXT:     [[COND:%.+]] = comb.and bin %STOP_COND_, %reset : i1
-    // CHECK-NEXT:     sv.if [[COND]] {
-    // CHECK-NEXT:       sv.fatal
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:   }
+    // CHECK-NEXT: [[STOP_COND_1:%.+]] = sv.macro.ref @STOP_COND_
+    // CHECK-NEXT: [[COND:%.+]] = comb.and bin [[STOP_COND_1]], %reset : i1
+    // CHECK-NEXT: sim.fatal %clock1, [[COND]]
     firrtl.stop %clock1, %reset, 42 : !firrtl.clock, !firrtl.uint<1>
 
-    // CHECK-NEXT:   sv.always posedge [[CLOCK2]] {
-    // CHECK-NEXT:     %STOP_COND_ = sv.macro.ref @STOP_COND_
-    // CHECK-NEXT:     [[COND:%.+]] = comb.and bin %STOP_COND_, %reset : i1
-    // CHECK-NEXT:     sv.if [[COND]] {
-    // CHECK-NEXT:       sv.finish
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:   }
-    // CHECK-NEXT: }
+    // CHECK-NEXT: [[STOP_COND_2:%.+]] = sv.macro.ref @STOP_COND_
+    // CHECK-NEXT: [[COND:%.+]] = comb.and bin [[STOP_COND_2:%.+]], %reset : i1
+    // CHECK-NEXT: sim.finish %clock2, [[COND]]
     firrtl.stop %clock2, %reset, 0 : !firrtl.clock, !firrtl.uint<1>
   }
 

--- a/test/Conversion/SimToSV/stop.mlir
+++ b/test/Conversion/SimToSV/stop.mlir
@@ -1,0 +1,29 @@
+// RUN: circt-opt --lower-sim-to-sv %s | FileCheck %s
+
+// CHECK-LABEL: hw.module @finish
+hw.module @finish(in %clock : !seq.clock, in %cond : i1) {
+  // CHECK:      [[CLK_SV:%.+]] = seq.from_clock %clock
+  // CHECK-NEXT: sv.ifdef  "SYNTHESIS" {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.always posedge [[CLK_SV]] {
+  // CHECK-NEXT:     sv.if %cond {
+  // CHECK-NEXT:       sv.finish 1
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  sim.finish %clock, %cond
+}
+
+// CHECK-LABEL: hw.module @fatal
+hw.module @fatal(in %clock : !seq.clock, in %cond : i1) {
+  // CHECK:      [[CLK_SV:%.+]] = seq.from_clock %clock
+  // CHECK-NEXT: sv.ifdef  "SYNTHESIS" {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.always posedge [[CLK_SV]] {
+  // CHECK-NEXT:     sv.if %cond {
+  // CHECK-NEXT:       sv.fatal 1
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  sim.fatal %clock, %cond
+}

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -9,3 +9,10 @@ hw.module @plusargs_value() {
   %1, %2 = sim.plusargs.value "bar" : i5
 }
 
+// CHECK-LABEL: hw.module @stop_finish
+hw.module @stop_finish(in %clock : !seq.clock, in %cond : i1) {
+  // sim.finish %clock, %cond
+  sim.finish %clock, %cond
+  // sim.fatal %clock, %cond
+  sim.fatal %clock, %cond
+}

--- a/test/firtool/stop.fir
+++ b/test/firtool/stop.fir
@@ -1,0 +1,30 @@
+; RUN: firtool %s --format=fir --ir-sv | FileCheck %s
+
+; CHECK: sv.ifdef  "STOP_COND_" {
+; CHECK: } else {
+; CHECK:   sv.ifdef  "STOP_COND" {
+; CHECK:     sv.macro.def @STOP_COND_ "(`STOP_COND)"
+; CHECK:   } else {
+; CHECK:     sv.macro.def @STOP_COND_ "1"
+; CHECK:   }
+; CHECK: }
+
+circuit StopAndFinishTest:
+  module StopAndFinishTest :
+    input clock : Clock
+    input cond : UInt<1>
+
+    ; CHECK: [[STOP_COND:%.+]] = sv.macro.ref @STOP_COND_() : () -> i1
+    ; CHECK: [[COND:%.+]] = comb.and bin [[STOP_COND:%.+]], %cond : i1
+    ; CHECK: sv.ifdef  "SYNTHESIS" {
+    ; CHECK: } else {
+    ; CHECK:   sv.always posedge %clock {
+    ; CHECK:     sv.if [[COND]] {
+    ; CHECK:       sv.finish 1
+    ; CHECK:       sv.fatal 1
+    ; CHECK:     }
+    ; CHECK:   }
+    ; CHECK: }
+
+    stop(clock, cond, 0)
+    stop(clock, cond, 1)


### PR DESCRIPTION
This PR introduces wrapper operations to act as intermediaries in the lowering of FIRRTL to SV. The `sim.finish` and the `sim.fatal` ops capture the clocks and conditions, lowering to an always block and an if statement gated behind the `SYNTHESIS` flag. The `STOP_COND_` condition, which is tied to the FIRRTL ABI, is resolved in `LowerToHW`.

This change is beneficial for Arc and an internal SiFive tool by providing an trivially analyzable representation for stop conditions.