### PR TITLE
[FIRRTL] Reject ref statements in 4.0.0+.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4666,6 +4666,11 @@ ParseResult FIRCircuitParser::parseRefList(ArrayRef<PortInfo> portList,
   SmallPtrSet<StringAttr, 8> seenNames;
   SmallPtrSet<StringAttr, 8> seenRefs;
 
+  // Ref statements were removed in 4.0.0, check.
+  if (getToken().is(FIRToken::kw_ref) &&
+      removedFeature({4, 0, 0}, "ref statements"))
+    return failure();
+
   // Parse the ref statements.
   while (consumeIf(FIRToken::kw_ref)) {
     auto loc = getToken().getLoc();

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -497,6 +497,14 @@ circuit ConnectWrongType:
     b <= a ; expected-error {{cannot connect non-equivalent type}}
 
 ;// -----
+FIRRTL version 4.0.0
+
+circuit RefStatementDeprecated:
+  extmodule RefStatementDeprecated:
+    output p : Probe<UInt<1>>
+    ref p is "x.y" ; expected-error {{ref statements were removed in FIRRTL 4.0.0, but the specified FIRRTL version was 4.0.0}}
+
+;// -----
 
 FIRRTL version 3.0.0
 circuit ConnectAlternateWrongType:


### PR DESCRIPTION
cc #6715 .

Continue to support for versions it's part of the FIRRTL spec.

It may make sense to simplify parser (and IR/passes a smidge) and not support at some point?
The test mentioned in that issue (and corresponding `parse-errors.fir`) as well as the spec-conformance ref test (`ext.fir`) will can be adjusted if this is dropped entirely.

Cannot drop "internalPaths" and pass support until this is removed which also requires annotations that rely on it to be deprecated / removed.