### PR TITLE
[Ibis] Split ContainerOp in two

### DIFF
--- a/include/circt/Dialect/Ibis/IbisInterfaces.td
+++ b/include/circt/Dialect/Ibis/IbisInterfaces.td
@@ -168,4 +168,42 @@ def MethodLikeOpInterface : OpInterface<"MethodLikeOpInterface"> {
   }];
 }
 
+def ContainerOpInterface : OpInterface<"ContainerOpInterface"> {
+  let cppNamespace = "circt::ibis";
+  let description = [{
+    An interface for Ibis operations that contain other operations.
+  }];
+
+  let methods = [
+    InterfaceMethod<
+      "Returns the body of the container",
+      "mlir::Block*", "getBodyBlock",
+      (ins), [{}], /*defaultImplementation=*/ [{
+        return &$_op.getBody().front();
+      }]
+    >,
+    InterfaceMethod<
+      "Returns the symbol name",
+      "StringAttr", "getSymNameAttr",
+      (ins), [{
+        return $_op.getSymNameAttr();
+      }]
+    >,
+    InterfaceMethod<
+      "Returns the module name as a string attribute",
+      "StringAttr", "getModuleNameAttr",
+      (ins), [{
+        return $_op.getModuleNameAttr();
+      }]
+    >,
+    InterfaceMethod<
+      "Returns the module name",
+      "StringRef", "getModuleName",
+      (ins), [{
+        return $_op.getModuleNameAttr().getValue();
+      }]
+    >
+  ];
+}
+
 #endif // CIRCT_DIALECT_IBIS_INTERFACES_TD

--- a/include/circt/Dialect/Ibis/IbisOps.h
+++ b/include/circt/Dialect/Ibis/IbisOps.h
@@ -29,7 +29,8 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 namespace circt {
 namespace ibis {
-class ContainerOp;
+class OuterContainerOp;
+class InnerContainerOp;
 class ThisOp;
 
 // Symbol name for the ibis operator library to be used during scheduling.

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -568,14 +568,12 @@ def ThisOp : IbisOp<"this", [
 // Low-level Ibis operations
 // ===---------------------------------------------------------------------===//
 
-def ContainerOp : IbisOp<"container", [
-  Symbol,
-  // TODO: @mortbopet: ContainerOp should be an innersymbol table (or equivalent)
-  // whenever we figure out how to support nested symbol tables...
-  // InnerSymbolTable
+class ContainerOp<string mnemonic, list<Trait> traits> : IbisOp<mnemonic,
+  traits # [
+  ContainerOpInterface,
   SingleBlock,
   NoTerminator, NoRegionArguments,
-  ScopeOpInterface, IsolatedFromAbove,
+  IsolatedFromAbove,
   InstanceGraphModuleOpInterface,
   RegionKindInterface
 ]> {
@@ -584,36 +582,57 @@ def ContainerOp : IbisOp<"container", [
     An ibis container describes a collection of logic nested within an Ibis class.
   }];
 
-  let arguments = (ins SymbolNameAttr:$sym_name);
   let regions = (region SizedRegion<1>:$body);
 
+  code extraContainerClassDeclaration = [{}];
+  let extraClassDeclaration = extraContainerClassDeclaration # [{
+    // Implement RegionKindInterface.
+    static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph; }
+  }];
+
+  let skipDefaultBuilders = 1;
+}
+
+def OuterContainerOp : ContainerOp<"container.outer", [
+  Symbol, InnerSymbolTable, ScopeOpInterface]> {
+  let arguments = (ins SymbolNameAttr:$sym_name);
   let assemblyFormat = [{
     $sym_name attr-dict-with-keyword $body
   }];
 
-  let extraClassDeclaration = [{
-    // Implement RegionKindInterface.
-    static RegionKind getRegionKind(unsigned index) { return RegionKind::Graph; }
+  let builders = [
+    OpBuilder<(ins "StringAttr":$symbol), [{
+      auto region = $_state.addRegion();
+      region->push_back(new Block());
+      $_state.addAttribute(getSymNameAttrName($_state.name), symbol);
+    }]>
+  ];
+}
 
-    Block* getBodyBlock() { return &getBody().front(); }
 
+def InnerContainerOp : ContainerOp<"container.inner", [
+  DeclareOpInterfaceMethods<InnerSymbol>]> {
+  let arguments = (ins InnerSymAttr:$inner_sym);
+  let assemblyFormat = [{
+    $inner_sym attr-dict-with-keyword $body
+  }];
+
+  let builders = [
+    OpBuilder<(ins "::circt::hw::InnerSymAttr":$symbol), [{
+      auto region = $_state.addRegion();
+      region->push_back(new Block());
+      $_state.addAttribute(getInnerSymAttrName($_state.name), symbol);
+    }]>
+  ];
+
+  let extraContainerClassDeclaration = [{
+    StringAttr getSymNameAttr() {
+      return getInnerSymAttr().getSymName();
+    }
     StringAttr getModuleNameAttr() {
       return getSymNameAttr();
     }
-
-    llvm::StringRef getModuleName() {
-      return getSymName();
-    }
   }];
-
-  let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilder<(ins "StringAttr":$name), [{
-      auto region = $_state.addRegion();
-      region->push_back(new Block());
-      $_state.addAttribute(getSymNameAttrName($_state.name), name);
-    }]>
-  ];
 }
 
 def ContainerInstanceOp : InstanceOpBase<"container.instance"> {
@@ -624,7 +643,7 @@ def ContainerInstanceOp : InstanceOpBase<"container.instance"> {
 
   let extraInstanceClassDeclaration = [{
     // Return the container this instance is instantiating.
-    ContainerOp getContainer(const SymbolTable* symbolTable = nullptr);
+    ContainerOpInterface getContainer(const SymbolTable* symbolTable = nullptr);
 
     Operation* getReferencedModuleSlow();
     Operation* getReferencedModule(const SymbolTable&);
@@ -694,7 +713,7 @@ def GetPortOp : IbisOp<"get_port", [
 class PortLikeOp<string mnemonic, list<Trait> traits = []> :
     IbisOp<mnemonic, !listconcat(traits, [
       PortOpInterface,
-      ParentOneOf<["ClassOp", "ContainerOp"]>,
+      ParentOneOf<["ClassOp", "OuterContainerOp", "InnerContainerOp"]>,
       InferTypeOpInterface,
       HasCustomSSAName,
       DeclareOpInterfaceMethods<InnerSymbol,["getTargetResultIndex"]>
@@ -775,7 +794,7 @@ def OutputPortOp : PortLikeOp<"port.output"> {
 class WireLikeOp<string mnemonic, list<Trait> traits = []> :
     IbisOp<mnemonic, !listconcat(traits, [
       PortOpInterface,
-      ParentOneOf<["ClassOp", "ContainerOp"]>,
+      ParentOneOf<["ClassOp", "OuterContainerOp", "InnerContainerOp"]>,
       HasCustomSSAName,
       DeclareOpInterfaceMethods<InnerSymbol,["getTargetResultIndex"]>
   ])> {

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -579,7 +579,12 @@ class ContainerOp<string mnemonic, list<Trait> traits> : IbisOp<mnemonic,
 ]> {
   let summary = "Ibis container";
   let description = [{
-    An ibis container describes a collection of logic nested within an Ibis class.
+    An ibis container describes a collection of logic nested within an Ibis
+    class. We have two container types (ops): one for the outermost containers
+    and one for the nested containers (inner). The outer container is a symbol
+    and sits in the symbol table at the top level. So as to not violate the
+    symbol table rules, the inner container is an InnerSymbol and is contained
+    in the InnerSymbolTable that the outer container defines.
   }];
 
   let regions = (region SizedRegion<1>:$body);

--- a/lib/Dialect/Ibis/IbisOps.cpp
+++ b/lib/Dialect/Ibis/IbisOps.cpp
@@ -405,13 +405,14 @@ void PortReadOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 // ContainerInstanceOp
 //===----------------------------------------------------------------------===//
 
-ContainerOp ContainerInstanceOp::getContainer(const SymbolTable *symbolTable) {
+ContainerOpInterface
+ContainerInstanceOp::getContainer(const SymbolTable *symbolTable) {
   auto mod = getOperation()->getParentOfType<mlir::ModuleOp>();
   if (symbolTable)
-    return dyn_cast_or_null<ContainerOp>(
+    return dyn_cast_or_null<ContainerOpInterface>(
         symbolTable->lookupSymbolIn(mod, getTargetNameAttr()));
 
-  return mod.lookupSymbol<ContainerOp>(getTargetNameAttr());
+  return mod.lookupSymbol<ContainerOpInterface>(getTargetNameAttr());
 }
 
 LogicalResult
@@ -426,6 +427,10 @@ ContainerInstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
 void ContainerInstanceOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   setNameFn(getResult(), genValueNameAttr(getResult()));
+}
+
+std::optional<size_t> InnerContainerOp::getTargetResultIndex() {
+  return std::nullopt;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Ibis/Transforms/IbisContainerize.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisContainerize.cpp
@@ -22,14 +22,14 @@ using namespace ibis;
 
 namespace {
 
-struct OutlineContainerPattern : public OpConversionPattern<ContainerOp> {
+struct OutlineContainerPattern : public OpConversionPattern<InnerContainerOp> {
   OutlineContainerPattern(MLIRContext *context, Namespace &ns)
-      : OpConversionPattern<ContainerOp>(context), ns(ns) {}
+      : OpConversionPattern<InnerContainerOp>(context), ns(ns) {}
 
-  using OpAdaptor = typename OpConversionPattern<ContainerOp>::OpAdaptor;
+  using OpAdaptor = typename OpConversionPattern<InnerContainerOp>::OpAdaptor;
 
   LogicalResult
-  matchAndRewrite(ContainerOp op, OpAdaptor adaptor,
+  matchAndRewrite(InnerContainerOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Outline the container into the module scope, by prefixing it with the
     // parent class name.
@@ -40,9 +40,9 @@ struct OutlineContainerPattern : public OpConversionPattern<ContainerOp> {
 
     rewriter.setInsertionPoint(parentClass);
     StringAttr newContainerName = rewriter.getStringAttr(
-        ns.newName(parentClass.getName() + "_" + op.getName()));
+        ns.newName(parentClass.getName() + "_" + op.getModuleName()));
     auto newContainer =
-        rewriter.create<ContainerOp>(op.getLoc(), newContainerName);
+        rewriter.create<OuterContainerOp>(op.getLoc(), newContainerName);
 
     rewriter.mergeBlocks(op.getBodyBlock(), newContainer.getBodyBlock(), {});
 
@@ -74,7 +74,7 @@ struct ClassToContainerPattern : public OpConversionPattern<ClassOp> {
                   ConversionPatternRewriter &rewriter) const override {
     // Replace the class by a container of the same name.
     auto newContainer =
-        rewriter.create<ContainerOp>(op.getLoc(), op.getNameAttr());
+        rewriter.create<OuterContainerOp>(op.getLoc(), op.getNameAttr());
     rewriter.mergeBlocks(op.getBodyBlock(), newContainer.getBodyBlock(), {});
     rewriter.eraseOp(op);
     return success();
@@ -112,7 +112,7 @@ LogicalResult ContainerizePass::outlineContainers() {
   auto *context = &getContext();
   ConversionTarget target(*context);
   target.addLegalDialect<IbisDialect>();
-  target.addDynamicallyLegalOp<ContainerOp>(
+  target.addDynamicallyLegalOp<InnerContainerOp>(
       [&](auto *op) { return !isa<ibis::ClassOp>(op->getParentOp()); });
   RewritePatternSet patterns(context);
 

--- a/lib/Dialect/Ibis/Transforms/IbisMethodsToContainers.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisMethodsToContainers.cpp
@@ -31,8 +31,8 @@ struct DataflowMethodOpConversion
   matchAndRewrite(DataflowMethodOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     // Replace the class by a container of the same name.
-    auto newContainer = rewriter.create<ContainerOp>(
-        op.getLoc(), op.getInnerSym().getSymName());
+    auto newContainer = rewriter.create<InnerContainerOp>(
+        op.getLoc(), hw::InnerSymAttr::get(op.getInnerSym().getSymName()));
     rewriter.setInsertionPointToStart(newContainer.getBodyBlock());
 
     // Create mandatory %this

--- a/test/Dialect/Ibis/Transforms/clean_selfdrivers.mlir
+++ b/test/Dialect/Ibis/Transforms/clean_selfdrivers.mlir
@@ -1,13 +1,13 @@
 // RUN: circt-opt --allow-unregistered-dialect --split-input-file --ibis-clean-selfdrivers %s | FileCheck %s
 
-// CHECK-LABEL:   ibis.container @C {
+// CHECK-LABEL:   ibis.container.outer @C {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @C
 // CHECK:           %[[VAL_1:.*]] = hw.wire %[[VAL_2:.*]]  : i1
 // CHECK:           %[[VAL_3:.*]] = ibis.port.output @out : i1
 // CHECK:           %[[VAL_2]] = hw.constant true
 // CHECK:           ibis.port.write %[[VAL_3]], %[[VAL_1]] : !ibis.portref<out i1>
 // CHECK:         }
-ibis.container @C {
+ibis.container.outer @C {
     %this = ibis.this @C
     %in = ibis.port.input @in : i1
     %out = ibis.port.output @out : i1
@@ -19,7 +19,7 @@ ibis.container @C {
 
 // -----
 
-// CHECK-LABEL:   ibis.container @Selfdriver {
+// CHECK-LABEL:   ibis.container.outer @Selfdriver {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @Selfdriver
 // CHECK:           %[[VAL_1:.*]] = hw.wire %[[VAL_2:.*]]  : i1
 // CHECK:           %[[VAL_3:.*]] = ibis.port.output @in : i1
@@ -27,21 +27,21 @@ ibis.container @C {
 // CHECK:           %[[VAL_2]] = hw.constant true
 // CHECK:         }
 
-// CHECK-LABEL:   ibis.container @ParentReader {
+// CHECK-LABEL:   ibis.container.outer @ParentReader {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @ParentReader
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @selfdriver, @Selfdriver
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @in : !ibis.scoperef<@Selfdriver> -> !ibis.portref<out i1>
 // CHECK:           %[[VAL_3:.*]] = ibis.port.read %[[VAL_2]] : !ibis.portref<out i1>
 // CHECK:         }
 
-ibis.container @Selfdriver {
+ibis.container.outer @Selfdriver {
   %this = ibis.this @Selfdriver
   %in = ibis.port.input @in : i1
   %true = hw.constant 1 : i1
   ibis.port.write %in, %true : !ibis.portref<in i1>
 }
 
-ibis.container @ParentReader {
+ibis.container.outer @ParentReader {
   %this = ibis.this @ParentReader
   %selfdriver = ibis.container.instance @selfdriver, @Selfdriver
   %in_ref = ibis.get_port %selfdriver, @in : !ibis.scoperef<@Selfdriver> -> !ibis.portref<out i1>
@@ -50,12 +50,12 @@ ibis.container @ParentReader {
 
 // -----
 
-ibis.container @Foo {
+ibis.container.outer @Foo {
   %this = ibis.this @Foo
   %in = ibis.port.input @in : i1
 }
 
-// CHECK-LABEL:   ibis.container @ParentReaderWriter {
+// CHECK-LABEL:   ibis.container.outer @ParentReaderWriter {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @ParentReaderWriter
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @f, @Foo
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @in : !ibis.scoperef<@Foo> -> !ibis.portref<in i1>
@@ -63,7 +63,7 @@ ibis.container @Foo {
 // CHECK:           %[[VAL_3]] = hw.constant true
 // CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_3]] : !ibis.portref<in i1>
 // CHECK:         }
-ibis.container @ParentReaderWriter {
+ibis.container.outer @ParentReaderWriter {
   %this = ibis.this @ParentReaderWriter
   %f = ibis.container.instance @f, @Foo
   %in_wr_ref = ibis.get_port %f, @in : !ibis.scoperef<@Foo> -> !ibis.portref<in i1>
@@ -73,4 +73,3 @@ ibis.container @ParentReaderWriter {
   %true = hw.constant 1 : i1
   ibis.port.write %in_wr_ref, %true : !ibis.portref<in i1>
 }
-

--- a/test/Dialect/Ibis/Transforms/containerize.mlir
+++ b/test/Dialect/Ibis/Transforms/containerize.mlir
@@ -1,12 +1,10 @@
-// XFAIL: *
-// See https://github.com/llvm/circt/issues/6658
 // RUN: circt-opt --ibis-containerize %s | FileCheck %s
 
-// CHECK-LABEL:   ibis.container @A_B
-// CHECK-LABEL:   ibis.container @MyClass
-// CHECK-LABEL:   ibis.container @A_B_0
-// CHECK-LABEL:   ibis.container @A_C
-// CHECK-LABEL:   ibis.container @A {
+// CHECK-LABEL:   ibis.container.outer @A_B
+// CHECK-LABEL:   ibis.container.outer @MyClass
+// CHECK-LABEL:   ibis.container.outer @A_B_0
+// CHECK-LABEL:   ibis.container.outer @A_C
+// CHECK-LABEL:   ibis.container.outer @A {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @A
 // CHECK:           ibis.port.input @A_in : i1
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @myClass, @MyClass
@@ -15,7 +13,7 @@
 
 // This container will alias with the @B inside @A, and thus checks the
 // name uniquing logic.
-ibis.container @A_B {
+ibis.container.outer @A_B {
   %this = ibis.this @A_B
 }
 
@@ -27,10 +25,10 @@ ibis.class @A {
   %this = ibis.this @A
   ibis.port.input @A_in : i1
   %myClass = ibis.instance @myClass, @MyClass
-  ibis.container @B {
+  ibis.container.inner @B {
     %B_this = ibis.this @B
   }
-  ibis.container @C {
+  ibis.container.inner @C {
     %C_this = ibis.this @C
   }
 }

--- a/test/Dialect/Ibis/Transforms/containers_to_hw.mlir
+++ b/test/Dialect/Ibis/Transforms/containers_to_hw.mlir
@@ -13,7 +13,7 @@
 // CHECK:    hw.output
 // CHECK:  }
 
-ibis.container @B {
+ibis.container.outer @B {
   %this = ibis.this @B 
   %in = ibis.port.input @in : i1 {"inputAttr"}
   %out = ibis.port.output @out : i1 {"outputAttr"}
@@ -23,14 +23,14 @@ ibis.container @B {
   ibis.port.write %out, %v : !ibis.portref<out i1>
 }
 
-ibis.container @AccessSibling {
+ibis.container.outer @AccessSibling {
   %this = ibis.this @AccessSibling 
   %p_b_out = ibis.port.input @p_b_out : i1
   %p_b_in = ibis.port.output @p_b_in : i1
   ibis.port.write %p_b_in, %p_b_out.val : !ibis.portref<out i1>
   %p_b_out.val = ibis.port.read %p_b_out : !ibis.portref<in i1>
 }
-ibis.container @Parent {
+ibis.container.outer @Parent {
   %this = ibis.this @Parent 
   %a = ibis.container.instance @a, @AccessSibling 
   %a.p_b_out.ref = ibis.get_port %a, @p_b_out : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in i1>
@@ -56,7 +56,7 @@ ibis.container @Parent {
 // CHECK:    hw.output
 // CHECK:  }
 
-ibis.container @C {
+ibis.container.outer @C {
   %this = ibis.this @C
   %in = ibis.port.input @in : i1
   %out = ibis.port.output @out : i1
@@ -88,13 +88,13 @@ hw.module @Top() {
 // CHECK:           hw.output
 // CHECK:         }
 
-ibis.container @Inst {
+ibis.container.outer @Inst {
   %this = ibis.this @Inst
   %out = ibis.port.output @out : i1
   %true = hw.constant 1 : i1
   ibis.port.write %out, %true : !ibis.portref<out i1>
 }
-ibis.container @Top {
+ibis.container.outer @Top {
   %this = ibis.this @Top
   %myInst = ibis.container.instance @myInst, @Inst
   %true = hw.constant 1 : i1

--- a/test/Dialect/Ibis/Transforms/methods_to_containers.mlir
+++ b/test/Dialect/Ibis/Transforms/methods_to_containers.mlir
@@ -1,10 +1,8 @@
-// XFAIL: *
-// See https://github.com/llvm/circt/issues/6658
 // RUN: circt-opt --pass-pipeline='builtin.module(ibis.class(ibis-convert-methods-to-containers))' %s | FileCheck %s
 
 // CHECK-LABEL:   ibis.class @ToContainers {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @ToContainers
-// CHECK:           ibis.container @foo {
+// CHECK:           ibis.container.inner @foo {
 // CHECK:             %[[VAL_1:.*]] = ibis.this @foo
 // CHECK:             %[[VAL_2:.*]] = ibis.port.input @arg0 : !dc.value<i32>
 // CHECK:             %[[VAL_3:.*]] = ibis.port.read %[[VAL_2]] : !ibis.portref<in !dc.value<i32>>

--- a/test/Dialect/Ibis/Transforms/path_end_to_end.mlir
+++ b/test/Dialect/Ibis/Transforms/path_end_to_end.mlir
@@ -2,11 +2,11 @@
 // and downwards tunneling, we are sure test all the possible combinations of
 // tunneling. This is more of a sanity check that everything works as expected.
 
-// RUN: circt-opt --split-input-file --ibis-tunneling \
+// RUN: circt-opt %s --split-input-file --ibis-tunneling \
 // RUN:    --ibis-lower-portrefs --ibis-clean-selfdrivers \
 // RUN:    --ibis-convert-containers-to-hw
 
-ibis.container @D_up {
+ibis.container.outer @D_up {
   %this = ibis.this @D_up
   %d = ibis.path [
     #ibis.step<parent : !ibis.scoperef>,
@@ -30,39 +30,39 @@ ibis.container @D_up {
   %clk_out_ref = ibis.get_port %d, @clk_out : !ibis.scoperef<@D_down> -> !ibis.portref<out i1>
   %clk_out_val = ibis.port.read %clk_out_ref : !ibis.portref<out i1>
 }
-ibis.container @C_up {
+ibis.container.outer @C_up {
   %this = ibis.this @C_up
   %d = ibis.container.instance @d, @D_up
 }
-ibis.container @B_up {
+ibis.container.outer @B_up {
   %this = ibis.this @B_up
   %c = ibis.container.instance @c, @C_up
   
 }
 
-ibis.container @A_up {
+ibis.container.outer @A_up {
   %this = ibis.this @A_up
   %b = ibis.container.instance @b, @B_up
 }
 
-ibis.container @Top {
+ibis.container.outer @Top {
   %this = ibis.this @Top
   %a_down = ibis.container.instance @a_down, @A_down
   %a_up = ibis.container.instance @a_up, @A_up
 }
-ibis.container @A_down {
+ibis.container.outer @A_down {
   %this = ibis.this @A_down
   %b = ibis.container.instance @b, @B_down
 }
-ibis.container @B_down {
+ibis.container.outer @B_down {
   %this = ibis.this @B_down
   %c = ibis.container.instance @c, @C_down
 }
-ibis.container @C_down {
+ibis.container.outer @C_down {
   %this = ibis.this @C_down
   %d = ibis.container.instance @d, @D_down
 }
-ibis.container @D_down {
+ibis.container.outer @D_down {
   %this = ibis.this @D_down
   %clk = ibis.port.input @clk_in : i1
   %clk_out = ibis.port.output @clk_out : i1

--- a/test/Dialect/Ibis/Transforms/portref_lowering.mlir
+++ b/test/Dialect/Ibis/Transforms/portref_lowering.mlir
@@ -1,19 +1,19 @@
 // RUN: circt-opt --split-input-file --ibis-lower-portrefs %s | FileCheck %s
 
-ibis.container @C {
+ibis.container.outer @C {
   %this = ibis.this @C 
   %in = ibis.port.input @in : i1
   %out = ibis.port.output @out : i1
 }
 
-// CHECK-LABEL:   ibis.container @AccessSibling {
+// CHECK-LABEL:   ibis.container.outer @AccessSibling {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @AccessSibling
 // CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_b_out : i1
 // CHECK:           %[[VAL_2:.*]] = ibis.port.output @p_b_in : i1
 // CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_3:.*]] : !ibis.portref<out i1>
 // CHECK:           %[[VAL_3]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in i1>
 // CHECK:         }
-ibis.container @AccessSibling {
+ibis.container.outer @AccessSibling {
   %this = ibis.this @AccessSibling 
   %p_b_out = ibis.port.input @p_b_out : !ibis.portref<out i1>
   %p_b_out_val = ibis.port.read %p_b_out : !ibis.portref<in !ibis.portref<out i1>>
@@ -25,7 +25,7 @@ ibis.container @AccessSibling {
   ibis.port.write %p_b_in_val, %v : !ibis.portref<in i1>
 }
 
-// CHECK-LABEL:   ibis.container @Parent {
+// CHECK-LABEL:   ibis.container.outer @Parent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @Parent
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @a, @AccessSibling
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_b_out : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in i1>
@@ -38,7 +38,7 @@ ibis.container @AccessSibling {
 // CHECK:           %[[VAL_4]] = ibis.get_port %[[VAL_8]], @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
 // CHECK:           %[[VAL_7]] = ibis.get_port %[[VAL_8]], @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
 // CHECK:         }
-ibis.container @Parent {
+ibis.container.outer @Parent {
   %this = ibis.this @Parent 
   %a = ibis.container.instance @a, @AccessSibling 
   %a.p_b_out = ibis.get_port %a, @p_b_out : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in !ibis.portref<out i1>>
@@ -52,12 +52,12 @@ ibis.container @Parent {
 
 // -----
 
-// CHECK-LABEL:   ibis.container @ParentPortAccess {
+// CHECK-LABEL:   ibis.container.outer @ParentPortAccess {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @ParentPortAccess
 // CHECK:           %[[VAL_1:.*]] = ibis.port.output @p_in : i1
 // CHECK:           %[[VAL_2:.*]] = ibis.port.input @p_out : i1
 // CHECK:         }
-ibis.container @ParentPortAccess {
+ibis.container.outer @ParentPortAccess {
   %this = ibis.this @ParentPortAccess 
   %p_in = ibis.port.input @p_in : !ibis.portref<in i1>
   %p_in_val = ibis.port.read %p_in : !ibis.portref<in !ibis.portref<in i1>>
@@ -65,7 +65,7 @@ ibis.container @ParentPortAccess {
   %p_out_val = ibis.port.read %p_out : !ibis.portref<in !ibis.portref<out i1>>
 }
 
-// CHECK-LABEL:   ibis.container @Parent {
+// CHECK-LABEL:   ibis.container.outer @Parent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @Parent
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c, @ParentPortAccess
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_in : !ibis.scoperef<@ParentPortAccess> -> !ibis.portref<out i1>
@@ -77,7 +77,7 @@ ibis.container @ParentPortAccess {
 // CHECK:           %[[VAL_4]] = ibis.port.input @in : i1
 // CHECK:           %[[VAL_7]] = ibis.port.output @out : i1
 // CHECK:         }
-ibis.container @Parent {
+ibis.container.outer @Parent {
   %this = ibis.this @Parent 
   %c = ibis.container.instance @c, @ParentPortAccess 
   %c.p_in = ibis.get_port %c, @p_in : !ibis.scoperef<@ParentPortAccess> -> !ibis.portref<in !ibis.portref<in i1>>
@@ -92,14 +92,14 @@ ibis.container @Parent {
 
 // C1 child -> P1 parent -> P2 parent -> C2 child -> C3 child
 
-// CHECK-LABEL:   ibis.container @C1 {
+// CHECK-LABEL:   ibis.container.outer @C1 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @C1
 // CHECK:           %[[VAL_1:.*]] = ibis.port.output @parent_parent_c2_c3_in : i1
 // CHECK:           ibis.port.write %[[VAL_1]], %[[VAL_2:.*]] : !ibis.portref<out i1>
 // CHECK:           %[[VAL_3:.*]] = ibis.port.input @parent_parent_c2_c3_out : i1
 // CHECK:           %[[VAL_2]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in i1>
 // CHECK:         }
-ibis.container @C1 {
+ibis.container.outer @C1 {
   %this = ibis.this @C1 
   %parent_parent_c2_c3_in = ibis.port.input @parent_parent_c2_c3_in : !ibis.portref<in i1>
   %parent_parent_c2_c3_out = ibis.port.input @parent_parent_c2_c3_out : !ibis.portref<out i1>
@@ -111,7 +111,7 @@ ibis.container @C1 {
   ibis.port.write %parent_b_in_unwrapped, %parent_b_out_value : !ibis.portref<in i1>
 }
 
-// CHECK-LABEL:   ibis.container @C2 {
+// CHECK-LABEL:   ibis.container.outer @C2 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @C2
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c3, @C
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
@@ -123,7 +123,7 @@ ibis.container @C1 {
 // CHECK:           %[[VAL_7:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<out i1>
 // CHECK:           ibis.port.write %[[VAL_6]], %[[VAL_7]] : !ibis.portref<out i1>
 // CHECK:         }
-ibis.container @C2 {
+ibis.container.outer @C2 {
   %this = ibis.this @C2 
   %c3 = ibis.container.instance @c3, @C 
   %c3.in = ibis.get_port %c3, @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
@@ -133,13 +133,13 @@ ibis.container @C2 {
   ibis.port.write %parent_parent_c2_c3_in, %c3.in : !ibis.portref<out !ibis.portref<in i1>>
   ibis.port.write %parent_parent_c2_c3_out, %c3.out : !ibis.portref<out !ibis.portref<out i1>>
 }
-ibis.container @C {
+ibis.container.outer @C {
   %this = ibis.this @C 
   %in = ibis.port.input @in : i1
   %out = ibis.port.output @out : i1
 }
 
-// CHECK-LABEL:   ibis.container @P1 {
+// CHECK-LABEL:   ibis.container.outer @P1 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @P1
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c1, @C1
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @parent_parent_c2_c3_in : !ibis.scoperef<@C1> -> !ibis.portref<out i1>
@@ -151,7 +151,7 @@ ibis.container @C {
 // CHECK:           ibis.port.write %[[VAL_7]], %[[VAL_3]] : !ibis.portref<out i1>
 // CHECK:           %[[VAL_6]] = ibis.port.input @parent_parent_c2_c3_out : i1
 // CHECK:         }
-ibis.container @P1 {
+ibis.container.outer @P1 {
   %this = ibis.this @P1 
   %c1 = ibis.container.instance @c1, @C1 
   %c1.parent_parent_c2_c3_in = ibis.get_port %c1, @parent_parent_c2_c3_in : !ibis.scoperef<@C1> -> !ibis.portref<in !ibis.portref<in i1>>
@@ -164,7 +164,7 @@ ibis.container @P1 {
   %1 = ibis.port.read %parent_parent_c2_c3_out : !ibis.portref<in !ibis.portref<out i1>>
 }
 
-// CHECK-LABEL:   ibis.container @P2 {
+// CHECK-LABEL:   ibis.container.outer @P2 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @P2
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @p1, @P1
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @parent_parent_c2_c3_in : !ibis.scoperef<@P1> -> !ibis.portref<out i1>
@@ -180,7 +180,7 @@ ibis.container @P1 {
 // CHECK:           %[[VAL_10:.*]] = ibis.get_port %[[VAL_8]], @parent_parent_c2_c3_in : !ibis.scoperef<@C2> -> !ibis.portref<in i1>
 // CHECK:           ibis.port.write %[[VAL_10]], %[[VAL_9]] : !ibis.portref<in i1>
 // CHECK:         }
-ibis.container @P2 {
+ibis.container.outer @P2 {
   %this = ibis.this @P2 
   %p1 = ibis.container.instance @p1, @P1 
   %p1.parent_parent_c2_c3_in = ibis.get_port %p1, @parent_parent_c2_c3_in : !ibis.scoperef<@P1> -> !ibis.portref<in !ibis.portref<in i1>>
@@ -196,12 +196,12 @@ ibis.container @P2 {
 
 // -----
 
-// CHECK-LABEL:   ibis.container @AccessParent {
+// CHECK-LABEL:   ibis.container.outer @AccessParent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @AccessParent
 // CHECK:           %[[VAL_1:.*]] = ibis.port.output @p_out : i1
 // CHECK:           %[[VAL_2:.*]] = ibis.port.input @p_in : i1
 // CHECK:         }
-ibis.container @AccessParent {
+ibis.container.outer @AccessParent {
   %this = ibis.this @AccessParent 
   %p_out = ibis.port.input @p_out : !ibis.portref<in i1>
   %p_out.val = ibis.port.read %p_out : !ibis.portref<in !ibis.portref<in i1>>
@@ -209,7 +209,7 @@ ibis.container @AccessParent {
   %p_in.val = ibis.port.read %p_in : !ibis.portref<in !ibis.portref<out i1>>
 }
 
-// CHECK-LABEL:   ibis.container @Parent {
+// CHECK-LABEL:   ibis.container.outer @Parent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @Parent
 // CHECK:           %[[VAL_1:.*]] = ibis.port.input @in : i1
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in i1>
@@ -225,7 +225,7 @@ ibis.container @AccessParent {
 // CHECK:           %[[VAL_11:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<out i1>
 // CHECK:           ibis.port.write %[[VAL_10]], %[[VAL_11]] : !ibis.portref<in i1>
 // CHECK:         }
-ibis.container @Parent {
+ibis.container.outer @Parent {
   %this = ibis.this @Parent 
   %in = ibis.port.input @in : i1
   %in.val = ibis.port.read %in : !ibis.portref<in i1>

--- a/test/Dialect/Ibis/Transforms/scoperef_tunneling.mlir
+++ b/test/Dialect/Ibis/Transforms/scoperef_tunneling.mlir
@@ -1,19 +1,19 @@
 // RUN: circt-opt --split-input-file --ibis-tunneling %s | FileCheck %s
 
-ibis.container @C {
+ibis.container.outer @C {
   %this = ibis.this @C
   %in = ibis.port.input @in : i1
-%out = ibis.port.output @out : i1
+  %out = ibis.port.output @out : i1
 }
 
-// CHECK-LABEL:   ibis.container @AccessChild {
+// CHECK-LABEL:   ibis.container.outer @AccessChild {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @AccessChild
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c, @C
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
 // CHECK:           %[[VAL_3:.*]] = ibis.get_port %[[VAL_1]], @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
 // CHECK-NEXT:         }
 
-ibis.container @AccessChild {
+ibis.container.outer @AccessChild {
   %this = ibis.this @AccessChild
   %c = ibis.container.instance @c, @C
   %c_ref = ibis.path [
@@ -25,20 +25,20 @@ ibis.container @AccessChild {
 
 // -----
 
-ibis.container @C {
+ibis.container.outer @C {
   %this = ibis.this @C
   %in = ibis.port.input @in : i1
   %out = ibis.port.output @out : i1
 }
 
-// CHECK-LABEL:   ibis.container @AccessSibling {
+// CHECK-LABEL:   ibis.container.outer @AccessSibling {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @AccessSibling
 // CHECK:           %[[VAL_1:.*]] = ibis.port.input @[[VAL_1]] : !ibis.portref<out i1>
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:           %[[VAL_3:.*]] = ibis.port.input @[[VAL_3]] : !ibis.portref<in i1>
 // CHECK:           %[[VAL_4:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:         }
-ibis.container @AccessSibling {
+ibis.container.outer @AccessSibling {
   %this = ibis.this @AccessSibling
   %sibling = ibis.path [
     #ibis.step<parent : !ibis.scoperef>,
@@ -48,7 +48,7 @@ ibis.container @AccessSibling {
   %c_out = ibis.get_port %sibling, @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
 }
 
-// CHECK-LABEL:   ibis.container @Parent {
+// CHECK-LABEL:   ibis.container.outer @Parent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @Parent
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @a, @AccessSibling
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_b_out.rd : !ibis.scoperef<@AccessSibling> -> !ibis.portref<in !ibis.portref<out i1>>
@@ -59,7 +59,7 @@ ibis.container @AccessSibling {
 // CHECK:           %[[VAL_3]] = ibis.get_port %[[VAL_6]], @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
 // CHECK:           %[[VAL_5]] = ibis.get_port %[[VAL_6]], @in : !ibis.scoperef<@C> -> !ibis.portref<in i1>
 // CHECK:         }
-ibis.container @Parent {
+ibis.container.outer @Parent {
   %this = ibis.this @Parent
   %a = ibis.container.instance @a, @AccessSibling
   %b = ibis.container.instance @b, @C
@@ -70,14 +70,14 @@ ibis.container @Parent {
 // "Full"/recursive case.
 // C1 child -> P1 parent -> P2 parent -> C2 child -> C3 child
 
-// CHECK-LABEL:   ibis.container @C1 {
+// CHECK-LABEL:   ibis.container.outer @C1 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @C1
 // CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_p_c2_c3_out.rd : !ibis.portref<out i1>
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:           %[[VAL_3:.*]] = ibis.port.input @p_p_c2_c3_in.wr : !ibis.portref<in i1>
 // CHECK:           %[[VAL_4:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:         }
-ibis.container @C1 {
+ibis.container.outer @C1 {
   %this = ibis.this @C1
   %c3 = ibis.path [
     #ibis.step<parent : !ibis.scoperef>,
@@ -89,7 +89,7 @@ ibis.container @C1 {
   %c_out = ibis.get_port %c3, @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
 }
 
-// CHECK-LABEL:   ibis.container @C2 {
+// CHECK-LABEL:   ibis.container.outer @C2 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @C2
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c3, @C
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @out : !ibis.scoperef<@C> -> !ibis.portref<out i1>
@@ -99,18 +99,18 @@ ibis.container @C1 {
 // CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_2]] : !ibis.portref<out !ibis.portref<out i1>>
 // CHECK:           ibis.port.write %[[VAL_5]], %[[VAL_3]] : !ibis.portref<out !ibis.portref<in i1>>
 // CHECK:         }
-ibis.container @C2 {
+ibis.container.outer @C2 {
   %this = ibis.this @C2
   %c3 = ibis.container.instance @c3, @C
 }
 
-ibis.container @C {
+ibis.container.outer @C {
   %this = ibis.this @C
   %in = ibis.port.input @in : i1
   %out = ibis.port.output @out : i1
 }
 
-// CHECK-LABEL:   ibis.container @P1 {
+// CHECK-LABEL:   ibis.container.outer @P1 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @P1
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c1, @C1
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_out.rd : !ibis.scoperef<@C1> -> !ibis.portref<in !ibis.portref<out i1>>
@@ -122,12 +122,12 @@ ibis.container @C {
 // CHECK:           %[[VAL_7:.*]] = ibis.port.input @p_p_c2_c3_in.wr : !ibis.portref<in i1>
 // CHECK:           %[[VAL_5]] = ibis.port.read %[[VAL_7]] : !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:         }
-ibis.container @P1 {
+ibis.container.outer @P1 {
   %this = ibis.this @P1
   %c1 = ibis.container.instance @c1, @C1
 }
 
-// CHECK-LABEL:   ibis.container @P2 {
+// CHECK-LABEL:   ibis.container.outer @P2 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @P2
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @p1, @P1
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_out.rd : !ibis.scoperef<@P1> -> !ibis.portref<in !ibis.portref<out i1>>
@@ -140,7 +140,7 @@ ibis.container @P1 {
 // CHECK:           %[[VAL_8:.*]] = ibis.get_port %[[VAL_6]], @p_p_c2_c3_out.rd : !ibis.scoperef<@C2> -> !ibis.portref<out !ibis.portref<out i1>>
 // CHECK:           %[[VAL_3]] = ibis.port.read %[[VAL_8]] : !ibis.portref<out !ibis.portref<out i1>>
 // CHECK:         }
-ibis.container @P2 {
+ibis.container.outer @P2 {
   %this = ibis.this @P2
   %p1 = ibis.container.instance @p1, @P1
   %c2 = ibis.container.instance @c2, @C2
@@ -148,14 +148,14 @@ ibis.container @P2 {
 
 // -----
 
-// CHECK-LABEL:   ibis.container @AccessParent {
+// CHECK-LABEL:   ibis.container.outer @AccessParent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @AccessParent
 // CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_out.wr : !ibis.portref<in i1>
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:           %[[VAL_3:.*]] = ibis.port.input @p_in.rd : !ibis.portref<out i1>
 // CHECK:           %[[VAL_4:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:         }
-ibis.container @AccessParent {
+ibis.container.outer @AccessParent {
   %this = ibis.this @AccessParent
   %p = ibis.path [
     #ibis.step<parent : !ibis.scoperef<@Parent>>
@@ -169,7 +169,7 @@ ibis.container @AccessParent {
   %p_out_ref = ibis.get_port %p, @out : !ibis.scoperef<@Parent> -> !ibis.portref<in i1>
 }
 
-// CHECK-LABEL:   ibis.container @Parent {
+// CHECK-LABEL:   ibis.container.outer @Parent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @Parent
 // CHECK:           %[[VAL_1:.*]] = ibis.port.input @in : i1
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in i1>
@@ -183,7 +183,7 @@ ibis.container @AccessParent {
 // CHECK:           %[[VAL_9:.*]] = ibis.get_port %[[VAL_7]], @p_in.rd : !ibis.scoperef<@AccessParent> -> !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:           ibis.port.write %[[VAL_9]], %[[VAL_3]] : !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:         }
-ibis.container @Parent {
+ibis.container.outer @Parent {
   %this = ibis.this @Parent
   %in = ibis.port.input @in : i1
   %out = ibis.port.output @out : i1
@@ -192,7 +192,7 @@ ibis.container @Parent {
 
 // -----
 
-ibis.container @C {
+ibis.container.outer @C {
   %this = ibis.this @C
   %in = ibis.port.input @in : i1
   %out = ibis.port.output @out : i1
@@ -220,7 +220,7 @@ hw.module @AccessChildFromHW() {
 // and downwards tunneling, we are sure test all the possible combinations of
 // tunneling.
 
-ibis.container @D_up {
+ibis.container.outer @D_up {
   %this = ibis.this @D_up
   %d = ibis.path [
     #ibis.step<parent : !ibis.scoperef>,
@@ -244,39 +244,39 @@ ibis.container @D_up {
   %clk_out_ref = ibis.get_port %d, @clk_out : !ibis.scoperef<@D_down> -> !ibis.portref<out i1>
   %clk_out_val = ibis.port.read %clk_out_ref : !ibis.portref<out i1>
 }
-ibis.container @C_up {
+ibis.container.outer @C_up {
   %this = ibis.this @C_up
   %d = ibis.container.instance @d, @D_up
 }
-ibis.container @B_up {
+ibis.container.outer @B_up {
   %this = ibis.this @B_up
   %c = ibis.container.instance @c, @C_up
   
 }
 
-ibis.container @A_up {
+ibis.container.outer @A_up {
   %this = ibis.this @A_up
   %b = ibis.container.instance @b, @B_up
 }
 
-ibis.container @Top {
+ibis.container.outer @Top {
   %this = ibis.this @Top
   %a_down = ibis.container.instance @a_down, @A_down
   %a_up = ibis.container.instance @a_up, @A_up
 }
-ibis.container @A_down {
+ibis.container.outer @A_down {
   %this = ibis.this @A_down
   %b = ibis.container.instance @b, @B_down
 }
-ibis.container @B_down {
+ibis.container.outer @B_down {
   %this = ibis.this @B_down
   %c = ibis.container.instance @c, @C_down
 }
-ibis.container @C_down {
+ibis.container.outer @C_down {
   %this = ibis.this @C_down
   %d = ibis.container.instance @d, @D_down
 }
-ibis.container @D_down {
+ibis.container.outer @D_down {
   %this = ibis.this @D_down
   %clk = ibis.port.input @clk_in : i1
   %clk_out = ibis.port.output @clk_out : i1

--- a/test/Dialect/Ibis/Transforms/tunneling_errors.mlir
+++ b/test/Dialect/Ibis/Transforms/tunneling_errors.mlir
@@ -1,11 +1,11 @@
 // RUN: circt-opt --split-input-file --allow-unregistered-dialect --ibis-tunneling --verify-diagnostics %s
 
-ibis.container @Parent {
+ibis.container.outer @Parent {
   %this = ibis.this @Parent
   %in = ibis.port.input @in : i1
 }
 
-ibis.container @Orphan {
+ibis.container.outer @Orphan {
   %this = ibis.this @Orphan
   // expected-error @+2 {{'ibis.path' op cannot tunnel up from "Orphan" because it has no uses}}
   // expected-error @+1 {{failed to legalize operation 'ibis.path' that was explicitly marked illegal}}
@@ -18,17 +18,17 @@ ibis.container @Orphan {
 
 // -----
 
-ibis.container @Parent {
+ibis.container.outer @Parent {
   %this = ibis.this @Parent
   %mc = ibis.container.instance @mc, @MissingChild
 }
 
-ibis.container @Child {
+ibis.container.outer @Child {
   %this = ibis.this @Child
   %in = ibis.port.input @in : i1
 }
 
-ibis.container @MissingChild {
+ibis.container.outer @MissingChild {
   %this = ibis.this @MissingChild
   // expected-error @+2 {{'ibis.path' op expected an instance named @c in "Parent" but found none}}
   // expected-error @+1 {{failed to legalize operation 'ibis.path' that was explicitly marked illegal}}

--- a/test/Dialect/Ibis/canonicalization.mlir
+++ b/test/Dialect/Ibis/canonicalization.mlir
@@ -1,11 +1,11 @@
 // RUN: circt-opt --allow-unregistered-dialect --split-input-file --canonicalize --cse %s | FileCheck %s
 
-// CHECK-LABEL:   ibis.container @GetPortOnThis {
+// CHECK-LABEL:   ibis.container.outer @GetPortOnThis {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @GetPortOnThis
 // CHECK:           %[[VAL_1:.*]] = ibis.port.input @in : i1
 // CHECK:           "foo.user"(%[[VAL_1]]) : (!ibis.portref<in i1>) -> ()
 // CHECK:         }
-ibis.container @GetPortOnThis {
+ibis.container.outer @GetPortOnThis {
   %this = ibis.this @GetPortOnThis
   %p = ibis.port.input @in : i1
   %p2 = ibis.get_port %this, @in : !ibis.scoperef<@GetPortOnThis> -> !ibis.portref<in i1>
@@ -15,16 +15,16 @@ ibis.container @GetPortOnThis {
 
 // -----
 
-ibis.container @C {
+ibis.container.outer @C {
   %this = ibis.this @C
 }
 
-// CHECK-LABEL:   ibis.container @AccessChild {
+// CHECK-LABEL:   ibis.container.outer @AccessChild {
 // CHECK:           %[[VAL_0:.*]] = ibis.this @AccessChild
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c, @C
 // CHECK:           "foo.user"(%[[VAL_1]]) : (!ibis.scoperef<@C>) -> ()
 // CHECK:         }
-ibis.container @AccessChild {
+ibis.container.outer @AccessChild {
   %this = ibis.this @AccessChild
   %c = ibis.container.instance @c, @C
   %c_ref = ibis.path [

--- a/test/Dialect/Ibis/errors.mlir
+++ b/test/Dialect/Ibis/errors.mlir
@@ -28,8 +28,8 @@ ibis.class @MultipleThis {
 
 // -----
 
-// expected-error @+1 {{'ibis.container' op must contain a 'ibis.this' operation}}
-ibis.container @NoThis {
+// expected-error @+1 {{'ibis.container.outer' op must contain a 'ibis.this' operation}}
+ibis.container.outer @NoThis {
 }
 
 // -----

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -1,5 +1,3 @@
-// XFAIL: *
-// See https://github.com/llvm/circt/issues/6658
 // RUN: circt-opt %s | circt-opt | FileCheck %s
 
 // CHECK-LABEL:  ibis.class @HighLevel {
@@ -67,7 +65,7 @@ ibis.class @HighLevel {
 // CHECK-NEXT:    %true = hw.constant true
 // CHECK-NEXT:    %out_wire = ibis.wire.output @out_wire, %true : i1
 // CHECK-NEXT:    %a = ibis.instance @a, @A 
-// CHECK-NEXT:    ibis.container @D {
+// CHECK-NEXT:    ibis.container.inner @D {
 // CHECK-NEXT:      %this_0 = ibis.this @D 
 // CHECK-NEXT:      %parent = ibis.path [#ibis.step<parent : !ibis.scoperef<@LowLevel>> : !ibis.scoperef<@LowLevel>]
 // CHECK-NEXT:      %parent.LowLevel_in.ref = ibis.get_port %parent, @LowLevel_in : !ibis.scoperef<@LowLevel> -> !ibis.portref<in i1>
@@ -102,7 +100,7 @@ ibis.class @LowLevel {
   // Instantiation
   %a = ibis.instance @a, @A
 
-  ibis.container @D {
+  ibis.container.inner @D {
     %this_d = ibis.this @D
     %parent_C = ibis.path [
       #ibis.step<parent : !ibis.scoperef<@LowLevel>>
@@ -126,6 +124,20 @@ ibis.class @LowLevel {
 
     // Test hw.instance ops inside a container (symbol table usage)
     hw.instance "foo" @externModule() -> ()
+  }
+}
+
+// CHECK-LABEL:  ibis.container.outer @O {
+// CHECK-NEXT:     %this = ibis.this @O
+// CHECK-NEXT:     ibis.container.inner @I {
+// CHECK-NEXT:       %this_0 = ibis.this @I
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+
+ibis.container.outer @O {
+  %thisO = ibis.this @O
+  ibis.container.inner @I {
+    %thisI = ibis.this @I
   }
 }
 


### PR DESCRIPTION
In order to not abuse symbol tables, create an OuterContainerOp for top-level containers, and InnerContainerOp for nested containers. The former has a symbol and is an InnerSymbolTable. The latter has an InnerSymbol.

Fixes #6658.