### PR TITLE
[FIRRTL] Put layer collateral in testbench dir

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1073,9 +1073,11 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
     newModule->setAttr("firrtl.extract.cover.extra", builder.getUnitAttr());
 
   // If this is in the test harness, make sure it goes to the test directory.
+  // Do not update output file information if it is already present.
   if (auto testBenchDir = loweringState.getTestBenchDirectory())
     if (loweringState.isInTestHarness(oldModule)) {
-      newModule->setAttr("output_file", testBenchDir);
+      if (!newModule->hasAttr("output_file"))
+        newModule->setAttr("output_file", testBenchDir);
       newModule->setAttr("firrtl.extract.do_not_extract",
                          builder.getUnitAttr());
       newModule.setCommentAttr(

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1572,3 +1572,34 @@ firrtl.circuit "PortSym" {
     %0 = firrtl.eq %out, %c1_ui5 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<1>
   }
 }
+
+// -----
+
+// Test various aspects of output file behavior.
+
+firrtl.circuit "Directories" attributes {
+  annotations = [
+    {
+      class = "sifive.enterprise.firrtl.TestBenchDirAnnotation",
+      dirname = "testbench"
+    }
+  ]
+} {
+  // CHECK-LABEL: hw.module private @Directories_A
+  // CHECK-SAME:    output_file = #hw.output_file<"hello/"
+  firrtl.module private @Directories_A() attributes {
+    output_file = #hw.output_file<"hello/", excludeFromFileList>
+  } {}
+  firrtl.module private @DUT() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {
+  }
+  firrtl.module @Directories() {
+    firrtl.instance dut @DUT()
+    firrtl.instance dut_A @Directories_A()
+  }
+}

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1590,6 +1590,9 @@ firrtl.circuit "Directories" attributes {
   firrtl.module private @Directories_A() attributes {
     output_file = #hw.output_file<"hello/", excludeFromFileList>
   } {}
+  // CHECK:       hw.module private @BoundUnderDUT
+  // CHECK-SAME:    output_file = #hw.output_file<"testbench/"
+  firrtl.module private @BoundUnderDUT() {}
   firrtl.module private @DUT() attributes {
     annotations = [
       {
@@ -1597,6 +1600,7 @@ firrtl.circuit "Directories" attributes {
       }
     ]
   } {
+    firrtl.instance boundUnderDUT {lowerToBind} @BoundUnderDUT()
   }
   firrtl.module @Directories() {
     firrtl.instance dut @DUT()

--- a/test/Dialect/FIRRTL/grand-central-errors.mlir
+++ b/test/Dialect/FIRRTL/grand-central-errors.mlir
@@ -375,3 +375,36 @@ firrtl.circuit "CompanionWithOutputs"
     firrtl.instance dut @DUT()
   }
 }
+
+// -----
+
+firrtl.circuit "UnexpectedLayer"
+  attributes {annotations = [
+    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+     defName = "Foo",
+     elements = [
+       {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+        defName = "Bar",
+        elements = [],
+        name = "bar"}],
+     id = 0 : i64,
+     name = "MyView"}]}  {
+  firrtl.layer @A bind {}
+  firrtl.module private @MyView_companion()
+    attributes {annotations = [{
+      class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+      id = 0 : i64,
+      name = "MyView"}]} {}
+  firrtl.module private @Foo() {}
+  firrtl.module private @DUT() {
+    firrtl.instance MyView_companion  @MyView_companion()
+    // expected-note @below {{the 'firrtl.layerblock' op is here}}
+    firrtl.layerblock @A {
+      // expected-error @below {{'firrtl.instance' op is instantiated under a 'firrtl.layerblock' op}}
+      firrtl.instance foo @Foo()
+    }
+  }
+  firrtl.module @UnexpectedLayer() {
+    firrtl.instance dut @DUT()
+  }
+}

--- a/test/Dialect/FIRRTL/lower-layers-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-layers-errors.mlir
@@ -1,0 +1,22 @@
+// RUN: circt-opt -firrtl-lower-layers -verify-diagnostics %s
+
+firrtl.circuit "DuplicateMarkDUTAnnotation" {
+  // expected-note @below {{the first DUT was found here}}
+  firrtl.module @Foo() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {}
+  // expected-error @below {{is marked with a 'sifive.enterprise.firrtl.MarkDUTAnnotation', but 'Foo' also had such an annotation}}
+  firrtl.module @DuplicateMarkDUTAnnotation() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {
+    firrtl.instance foo @Foo()
+  }
+}

--- a/test/firtool/lower-layers-directories.fir
+++ b/test/firtool/lower-layers-directories.fir
@@ -1,0 +1,132 @@
+; RUN: firtool %s | FileCheck %s --implicit-check-not FILE
+
+; This test checks output directory behavior of circuits with layers with other
+; features.  Generally, layer code is treated as "verification" code and should
+; be kept out of the design area when `firtool` is run with options where the
+; design area is explicitly specified.
+;
+; This test is expected to eventually be removed once the FIRRTL ABI switches to
+; using filelists or manifests and a flat output directory structure.
+
+FIRRTL version 4.0.0
+circuit Testbench: %[[
+  {
+    "class": "sifive.enterprise.grandcentral.ViewAnnotation",
+    "name": "MyView",
+    "companion": "~Testbench|GrandCentral",
+    "parent": "~Testbench|Testbench",
+    "view": {
+      "class": "sifive.enterprise.grandcentral.AugmentedBundleType",
+      "defName": "Interface",
+      "elements": [
+        {
+          "name": "uint",
+          "description": "a wire called 'uint'",
+          "tpe": {
+            "class": "sifive.enterprise.grandcentral.AugmentedGroundType",
+            "ref": {
+              "circuit": "Testbench",
+              "module": "DUT",
+              "path": [],
+              "ref": "a",
+              "component": []
+            },
+            "tpe": {
+              "class": "sifive.enterprise.grandcentral.GrandCentralView$UnknownGroundType$"
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "class": "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
+    "directory": "gct",
+    "filename": "gct/bindings.sv"
+  },
+  {
+    "class":"firrtl.transforms.DontTouchAnnotation",
+    "target":"~Testbench|DUT>a"
+  },
+  {
+    "class":"firrtl.transforms.DontTouchAnnotation",
+    "target":"~Testbench|Foo>a"
+  },
+  {
+    "class":"firrtl.transforms.DontTouchAnnotation",
+    "target":"~Testbench|Bar>a"
+  },
+  {
+    "class":"firrtl.transforms.DontTouchAnnotation",
+    "target":"~Testbench|Baz>a"
+  },
+  {
+    "class":"firrtl.transforms.DontTouchAnnotation",
+    "target":"~Testbench|Qux>a"
+  },
+  {
+    "class":"firrtl.transforms.DontTouchAnnotation",
+    "target":"~Testbench|Quz>a"
+  },
+  {
+    "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
+    "target": "~Testbench|DUT"
+  },
+  {
+    "class": "sifive.enterprise.firrtl.TestBenchDirAnnotation",
+    "dirname": "testbench"
+  }
+]]
+  layer A, bind:
+
+  module Foo:
+    node a = UInt<1>(0)
+  module Bar:
+    node a = UInt<1>(1)
+  module Baz:
+    node a = UInt<2>(2)
+
+  module Qux:
+    node a = UInt<2>(3)
+  module Quz:
+    node a = UInt<3>(4)
+
+  module GrandCentral:
+    inst qux of Qux
+    inst quz of Quz
+
+  module DUT:
+    inst foo of Foo
+    inst baz of Baz
+    inst grandCentral of GrandCentral
+
+    node a = UInt<3>(4)
+
+    layerblock A:
+      inst bar of Bar
+      inst bazz of Baz
+      inst quz of Quz
+
+  public module Testbench:
+    inst dut of DUT
+
+; The only modules NOT in a file are Foo, Baz, and DUT.
+;
+; CHECK: module Foo();
+; CHECK: module Baz();
+; CHECK: module DUT();
+
+; The following modules are all in the Testbench directory.
+;
+; CHECK-DAG: FILE "testbench{{[/\]}}Bar.sv"
+; CHECK-DAG: FILE "testbench{{[/\]}}DUT_A.sv"
+; CHECK-DAG: FILE "testbench{{[/\]}}Testbench.sv"
+; CHECK-DAG: FILE "testbench{{[/\]}}layers_Testbench_A.sv"
+
+; The following modules are all in the Grand Central directory.
+;
+; CHECK-DAG: FILE "gct{{[/\]}}GrandCentral.sv"
+; CHECK-DAG: FILE "gct{{[/\]}}Interface.sv"
+; CHECK-DAG: FILE "gct{{[/\]}}Qux.sv"
+; CHECK-DAG: FILE "gct{{[/\]}}Quz.sv"
+; CHECK-DAG: FILE "gct{{[/\]}}bindings.sv"


### PR DESCRIPTION
Change the LowerLayers pass to put generated modules inside the testbench directory if one is specified and a DUT is present.  This is a stopgap measure that keeps layers aligned with existing CIRCT compilation of FIRRTL.  This is intended to be replaced with a better FIRRTL ABI based on filelists in the future.

This is currently missing handling of instances instantiated by the layer. Those need to also get moved to the testbench area. I'll mark this non-draft once it's fully working.