### PR TITLE
[Emit] Use FileOp to emit metadata

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -193,7 +193,11 @@ def AddSeqMemPorts : Pass<"firrtl-add-seqmem-ports", "firrtl::CircuitOp"> {
     the extra ports.
   }];
   let constructor = "circt::firrtl::createAddSeqMemPortsPass()";
-  let dependentDialects = ["sv::SVDialect", "hw::HWDialect"];
+  let dependentDialects = [
+    "emit::EmitDialect",
+    "sv::SVDialect",
+    "hw::HWDialect"
+  ];
   let statistics = [
     Statistic<"numAddedPorts", "num-added-ports", "Number of extra ports added">,
   ];
@@ -210,7 +214,12 @@ def CreateSiFiveMetadata : Pass<"firrtl-emit-metadata", "mlir::ModuleOp"> {
     Option<"replSeqMemFile", "repl-seq-mem-file", "std::string", "",
       "File to which emit seq meme metadata">
   ];
-  let dependentDialects = ["hw::HWDialect", "om::OMDialect"];
+  let dependentDialects = [
+      "emit::EmitDialect",
+      "hw::HWDialect",
+      "om::OMDialect",
+      "sv::SVDialect",
+  ];
 }
 
 def FlattenMemory : Pass<"firrtl-flatten-memory", "firrtl::FModuleOp"> {
@@ -282,7 +291,11 @@ def EmitOMIR : Pass<"firrtl-emit-omir", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createEmitOMIRPass()";
   let options = [Option<"outputFilename", "file", "std::string", "",
       "Output file for the JSON-serialized OMIR data">];
-  let dependentDialects = ["sv::SVDialect", "hw::HWDialect"];
+  let dependentDialects = [
+      "emit::EmitDialect",
+      "sv::SVDialect",
+      "hw::HWDialect"
+  ];
 }
 
 def LowerMatches : Pass<"firrtl-lower-matches", "firrtl::FModuleOp"> {
@@ -661,7 +674,10 @@ def LowerXMR : Pass<"firrtl-lower-xmr", "firrtl::CircuitOp"> {
     This pass lowers RefType ops and ports to verbatim encoded XMRs.
   }];
   let constructor = "circt::firrtl::createLowerXMRPass()";
-  let dependentDialects = ["sv::SVDialect"];
+  let dependentDialects = [
+    "emit::EmitDialect",
+    "sv::SVDialect"
+  ];
 }
 
 def LowerIntrinsics : Pass<"firrtl-lower-intrinsics", "firrtl::CircuitOp"> {
@@ -701,7 +717,7 @@ def ResolveTraces : Pass<"firrtl-resolve-traces", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createResolveTracesPass()";
   let options = [Option<"outputAnnotationFilename", "file", "std::string", "",
       "Output file for the JSON-serialized Trace Annotations">];
-  let dependentDialects = ["sv::SVDialect"];
+  let dependentDialects = ["emit::EmitDialect", "sv::SVDialect"];
 }
 
 def InnerSymbolDCE : Pass<"firrtl-inner-symbol-dce", "mlir::ModuleOp"> {

--- a/include/circt/Dialect/SV/SVPasses.td
+++ b/include/circt/Dialect/SV/SVPasses.td
@@ -141,7 +141,7 @@ def HWExportModuleHierarchy : Pass<"hw-export-module-hierarchy",
   }];
 
   let constructor = "circt::sv::createHWExportModuleHierarchyPass()";
-  let dependentDialects = ["circt::sv::SVDialect"];
+  let dependentDialects = ["circt::emit::EmitDialect", "circt::sv::SVDialect"];
 }
 
 def HWEliminateInOutPorts : Pass<"hw-eliminate-inout-ports",

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"
+#include "circt/Dialect/Emit/EmitOps.h"
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
@@ -30,6 +31,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/Support/Path.h"
 
 using namespace circt;
 using namespace firrtl;
@@ -169,7 +171,6 @@ class CreateSiFiveMetadataPass
   LogicalResult emitRetimeModulesMetadata(ObjectModelIR &omir);
   LogicalResult emitSitestBlackboxMetadata(ObjectModelIR &omir);
   LogicalResult emitMemoryMetadata(ObjectModelIR &omir);
-  void getDependentDialects(mlir::DialectRegistry &registry) const override;
   void runOnOperation() override;
 
   /// Get the cached namespace for a module.
@@ -375,25 +376,29 @@ CreateSiFiveMetadataPass::emitMemoryMetadata(ObjectModelIR &omir) {
       metadataDir = dir.getValue();
 
   // Use unknown loc to avoid printing the location in the metadata files.
-  auto dutVerbatimOp = builder.create<sv::VerbatimOp>(
-      dutJsonBuffer, ValueRange(), builder.getArrayAttr(jsonSymbols));
-  auto fileAttr = hw::OutputFileAttr::getFromDirectoryAndFilename(
-      context, metadataDir, "seq_mems.json", /*excludeFromFilelist=*/true);
-  dutVerbatimOp->setAttr("output_file", fileAttr);
-
-  auto confVerbatimOp = builder.create<sv::VerbatimOp>(
-      seqMemConfStr, ValueRange(), builder.getArrayAttr(seqMemSymbols));
-  if (replSeqMemFile.empty()) {
-    emitError(circuitOp->getLoc())
-        << "metadata emission failed, the option "
-           "`-repl-seq-mem-file=<filename>` is mandatory for specifying a "
-           "valid seq mem metadata file";
-    return failure();
+  {
+    SmallString<128> seqMemsJsonPath(metadataDir);
+    llvm::sys::path::append(seqMemsJsonPath, "seq_mems.json");
+    builder.create<emit::FileOp>(seqMemsJsonPath, [&] {
+      builder.create<sv::VerbatimOp>(dutJsonBuffer, ValueRange{},
+                                     builder.getArrayAttr(jsonSymbols));
+    });
   }
 
-  fileAttr = hw::OutputFileAttr::getFromFilename(context, replSeqMemFile,
-                                                 /*excludeFromFilelist=*/true);
-  confVerbatimOp->setAttr("output_file", fileAttr);
+  {
+    if (replSeqMemFile.empty()) {
+      emitError(circuitOp->getLoc())
+          << "metadata emission failed, the option "
+             "`-repl-seq-mem-file=<filename>` is mandatory for specifying a "
+             "valid seq mem metadata file";
+      return failure();
+    }
+
+    builder.create<emit::FileOp>(replSeqMemFile, [&] {
+      builder.create<sv::VerbatimOp>(seqMemConfStr, ValueRange{},
+                                     builder.getArrayAttr(seqMemSymbols));
+    });
+  }
 
   return success();
 }
@@ -483,13 +488,12 @@ CreateSiFiveMetadataPass::emitRetimeModulesMetadata(ObjectModelIR &omir) {
   });
 
   // Put the retime information in a verbatim operation.
-  auto builder = OpBuilder::atBlockEnd(circuitOp.getBodyBlock());
-  auto verbatimOp = builder.create<sv::VerbatimOp>(
-      builder.getUnknownLoc(), buffer, ValueRange(),
-      builder.getArrayAttr(symbols));
-  auto fileAttr = hw::OutputFileAttr::getFromFilename(
-      context, filename, /*excludeFromFilelist=*/true);
-  verbatimOp->setAttr("output_file", fileAttr);
+  auto builder = ImplicitLocOpBuilder::atBlockEnd(UnknownLoc::get(context),
+                                                  circuitOp.getBodyBlock());
+  builder.create<emit::FileOp>(filename, [&] {
+    builder.create<sv::VerbatimOp>(builder.getStringAttr(buffer), ValueRange{},
+                                   builder.getArrayAttr(symbols));
+  });
   return success();
 }
 
@@ -576,14 +580,13 @@ CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
         j.value(name);
     });
 
-    auto *body = circuitOp.getBodyBlock();
     // Put the information in a verbatim operation.
-    auto builder = OpBuilder::atBlockEnd(body);
-    auto verbatimOp =
-        builder.create<sv::VerbatimOp>(builder.getUnknownLoc(), buffer);
-    auto fileAttr = hw::OutputFileAttr::getFromFilename(
-        context, filename, /*excludeFromFilelist=*/true);
-    verbatimOp->setAttr("output_file", fileAttr);
+    auto builder = ImplicitLocOpBuilder::atBlockEnd(UnknownLoc::get(context),
+                                                    circuitOp.getBodyBlock());
+
+    builder.create<emit::FileOp>(filename, [&] {
+      builder.create<emit::VerbatimOp>(StringAttr::get(context, buffer));
+    });
   };
 
   createOutput(testModules, testFilename);
@@ -594,12 +597,6 @@ CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
     AnnotationSet::removeAnnotations(op, scalaClassAnnoClass);
 
   return success();
-}
-
-void CreateSiFiveMetadataPass::getDependentDialects(
-    mlir::DialectRegistry &registry) const {
-  // We need this for SV verbatim and HW attributes.
-  registry.insert<hw::HWDialect, sv::SVDialect, om::OMDialect>();
 }
 
 void CreateSiFiveMetadataPass::runOnOperation() {

--- a/lib/Dialect/SV/Transforms/CMakeLists.txt
+++ b/lib/Dialect/SV/Transforms/CMakeLists.txt
@@ -14,6 +14,7 @@ add_circt_dialect_library(CIRCTSVTransforms
 
   LINK_LIBS PUBLIC
   CIRCTComb
+  CIRCTEmit
   CIRCTHW
   CIRCTSeq
   CIRCTSupport

--- a/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
+++ b/lib/Dialect/SV/Transforms/HWExportModuleHierarchy.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetail.h"
+#include "circt/Dialect/Emit/EmitOps.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/InnerSymbolNamespace.h"
@@ -124,9 +125,10 @@ void HWExportModuleHierarchyPass::runOnOperation() {
 
       auto builder = ImplicitLocOpBuilder::atBlockEnd(
           UnknownLoc::get(mlirModule.getContext()), mlirModule.getBody());
-      auto verbatim = builder.create<sv::VerbatimOp>(
-          jsonBuffer, ValueRange{}, builder.getArrayAttr(symbols));
-      verbatim->setAttr("output_file", file);
+      builder.create<emit::FileOp>(file.getFilename(), [&] {
+        builder.create<sv::VerbatimOp>(jsonBuffer, ValueRange{},
+                                       builder.getArrayAttr(symbols));
+      });
     }
   }
 

--- a/lib/Dialect/SV/Transforms/PassDetail.h
+++ b/lib/Dialect/SV/Transforms/PassDetail.h
@@ -17,6 +17,10 @@
 
 namespace circt {
 
+namespace emit {
+class EmitDialect;
+} // namespace emit
+
 namespace comb {
 class CombDialect;
 }

--- a/test/Dialect/FIRRTL/add-seqmem-ports.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports.mlir
@@ -9,7 +9,9 @@ firrtl.circuit "NoMems" attributes {annotations = [
     filename = "sram.txt"
   }]} {
   firrtl.module @NoMems() {}
-  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"metadata{{/|\\\\}}sram.txt", excludeFromFileList>}
+  // CHECK:      emit.file "metadata{{/|\\\\}}sram.txt" {
+  // CHECK-NEXT:   sv.verbatim ""
+  // CHECK-NEXT: }
 }
 
 // Test for when there is a memory but no ports are added. The output file
@@ -25,7 +27,9 @@ firrtl.circuit "NoAddedPorts" attributes {annotations = [
   firrtl.module @NoAddedPorts() {
     %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
   }
-  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"metadata{{/|\\\\}}sram.txt", excludeFromFileList>}
+  // CHECK:      emit.file "metadata{{/|\\\\}}sram.txt" {
+  // CHECK-NEXT:   sv.verbatim ""
+  // CHECK-NEXT: }
 }
 
 // Test for when there is no memory and we try to add ports. The output file
@@ -45,7 +49,9 @@ firrtl.circuit "NoMemory" attributes {annotations = [
   }]} {
   firrtl.module @NoMemory() {
   }
-  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"metadata{{/|\\\\}}sram.txt", excludeFromFileList>}
+  // CHECK:      emit.file "metadata{{/|\\\\}}sram.txt" {
+  // CHECK-NEXT:   sv.verbatim ""
+  // CHECK-NEXT: }
 }
 
 // Test for a single added port.
@@ -167,10 +173,11 @@ firrtl.circuit "Complex" attributes {annotations = [
   firrtl.module @Complex() {
     firrtl.instance dut @DUT()
   }
-  // CHECK: sv.verbatim
-  // CHECK-SAME{LITERAL}: 0 -> {{0}}.{{1}}
-  // CHECK-SAME{LITERAL}: 1 -> {{0}}.{{2}}.{{3}}
-  // CHECK-SAME{LITERAL}: 2 -> {{0}}.{{4}}
-  // CHECK-SAME: {output_file = #hw.output_file<"metadata{{/|\\\\}}sram.txt", excludeFromFileList>,
-  // CHECK-SAME: symbols = [@DUT, #hw.innerNameRef<@DUT::@[[MWRITE_EXT]]>, #hw.innerNameRef<@DUT::@[[CHILD]]>, #hw.innerNameRef<@Child::@[[CHILD_MWRITE_EXT]]>, #hw.innerNameRef<@DUT::@[[MWRITE_EXT_0]]>]
+  // CHECK:               emit.file "metadata{{/|\\\\}}sram.txt" {
+  // CHECK-NEXT:            sv.verbatim
+  // CHECK-SAME{LITERAL}:     0 -> {{0}}.{{1}}
+  // CHECK-SAME{LITERAL}:     1 -> {{0}}.{{2}}.{{3}}
+  // CHECK-SAME{LITERAL}:     2 -> {{0}}.{{4}}
+  // CHECK-SAME:              {symbols = [@DUT, #hw.innerNameRef<@DUT::@[[MWRITE_EXT]]>, #hw.innerNameRef<@DUT::@[[CHILD]]>, #hw.innerNameRef<@Child::@[[CHILD_MWRITE_EXT]]>, #hw.innerNameRef<@DUT::@[[MWRITE_EXT_0]]>]}
+  // CHECK-NEXT:          }
 }

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --firrtl-emit-metadata="repl-seq-mem=true repl-seq-mem-file='dut.conf'" -split-input-file %s | FileCheck %s
+// RUN: circt-opt --firrtl-emit-metadata="repl-seq-mem=true repl-seq-mem-file=dut.conf" -split-input-file %s | FileCheck %s
 
 firrtl.circuit "empty" {
   firrtl.module @empty() {
@@ -6,6 +6,12 @@ firrtl.circuit "empty" {
 }
 // CHECK-LABEL: firrtl.circuit "empty"   {
 // CHECK-NEXT:    firrtl.module @empty() {
+// CHECK-NEXT:    }
+// CHECK-NEXT:    emit.file "metadata/seq_mems.json" {
+// CHECK-NEXT:      sv.verbatim "[]"
+// CHECK-NEXT:    }
+// CHECK-NEXT:    emit.file "dut.conf" {
+// CHECK-NEXT:      sv.verbatim ""
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 // Memory metadata om class should not be created.
@@ -36,9 +42,9 @@ firrtl.circuit "retime0" attributes { annotations = [{
 // CHECK:         firrtl.module @retime0() {
 // CHECK:         firrtl.module @retime1() {
 // CHECK:         firrtl.module @retime2() {
-// CHECK{LITERAL}:  sv.verbatim "[\0A \22{{0}}\22,\0A \22{{1}}\22\0A]"
-// CHECK-SAME:        output_file = #hw.output_file<"retime_modules.json", excludeFromFileList>
-// CHECK-SAME:        symbols = [@retime0, @retime2]
+// CHECK:               emit.file "retime_modules.json" {
+// CHECK-NEXT{LITERAL}:   sv.verbatim "[\0A \22{{0}}\22,\0A \22{{1}}\22\0A]" {symbols = [@retime0, @retime2]}
+// CHECK-NEXT:          }
 
 // CHECK:   om.class @RetimeModulesSchema(%moduleName: !om.sym_ref) {
 // CHECK-NEXT:     om.class.field @moduleName, %moduleName : !om.sym_ref
@@ -67,9 +73,11 @@ firrtl.circuit "DUTBlackboxes" attributes { annotations = [{
   firrtl.module @DUTBlackboxes() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
   }
-// CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>}
-// CHECK:     sv.verbatim "[]" {output_file = #hw.output_file<"dut_blackboxes.json", excludeFromFileList>}
-// CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>}
+// CHECK-NOT:  emit.file ""
+// CHECK:      emit.file "dut_blackboxes.json" {
+// CHECK-NEXT:   emit.verbatim "[]"
+// CHECK-NEXT: }
+// CHECK-NOT:  emit.file ""
 }
 
 // -----
@@ -82,9 +90,11 @@ firrtl.circuit "TestBlackboxes" attributes { annotations = [{
   firrtl.module @TestBlackboxes() attributes {annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
   }
-// CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>}
-// CHECK:     sv.verbatim "[]" {output_file = #hw.output_file<"test_blackboxes.json", excludeFromFileList>}
-// CHECK-NOT: sv.verbatim "[]" {output_file = #hw.output_file<"", excludeFromFileList>}
+// CHECK-NOT:  emit.file ""
+// CHECK:      emit.file "test_blackboxes.json" {
+// CHECK-NEXT:   emit.verbatim "[]"
+// CHECK-NEXT: }
+// CHECK-NOT:  emit.file ""
 }
 
 // -----
@@ -121,13 +131,18 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
   firrtl.extmodule @NoDefName()
 
   firrtl.extmodule @TestBlackbox() attributes {defname = "TestBlackbox"}
-  // CHECK: sv.verbatim "[\0A \22TestBlackbox\22\0A]" {output_file = #hw.output_file<"test_blackboxes.json", excludeFromFileList>}
+
+  // CHECK:               emit.file "test_blackboxes.json" {
+  // CHECK-NEXT{LITERAL}:   emit.verbatim "[\0A \22TestBlackbox\22\0A]"
+  // CHECK-NEXT:          }
 
   // Should be de-duplicated and sorted.
   firrtl.extmodule @DUTBlackbox_0() attributes {defname = "DUTBlackbox2"}
   firrtl.extmodule @DUTBlackbox_1() attributes {defname = "DUTBlackbox1"}
   firrtl.extmodule @DUTBlackbox_2() attributes {defname = "DUTBlackbox1"}
-  // CHECK: sv.verbatim "[\0A \22DUTBlackbox1\22,\0A \22DUTBlackbox2\22\0A]" {output_file = #hw.output_file<"dut_blackboxes.json", excludeFromFileList>}
+  // CHECK:               emit.file "dut_blackboxes.json" {
+  // CHECK-NEXT{LITERAL}:   emit.verbatim "[\0A \22DUTBlackbox1\22,\0A \22DUTBlackbox2\22\0A]"
+  // CHECK-NEXT:          }
 }
 // CHECK:  om.class @SitestBlackBoxModulesSchema(%moduleName: !om.sym_ref) {
 // CHECK-NEXT:    om.class.field @moduleName, %moduleName : !om.sym_ref
@@ -159,8 +174,14 @@ firrtl.circuit "top"
 {
   firrtl.module @top() { }
   // When there are no memories, we still need to emit the memory metadata.
-  // CHECK: sv.verbatim "[]" {output_file = #hw.output_file<"metadata{{/|\\\\}}seq_mems.json", excludeFromFileList>}
-  // CHECK: sv.verbatim "" {output_file = #hw.output_file<"'dut.conf'", excludeFromFileList>}
+
+  // CHECK:      emit.file "metadata{{/|\\\\}}seq_mems.json" {
+  // CHECK-NEXT:   sv.verbatim "[]"
+  // CHECK-NEXT: }
+
+  // CHECK:      emit.file "dut.conf" {
+  // CHECK-NEXT:   sv.verbatim ""
+  // CHECK-NEXT: }
 }
 
 // -----
@@ -171,10 +192,16 @@ firrtl.circuit "OneMemory" {
     %0:5= firrtl.instance MWrite_ext sym @MWrite_ext_0  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>, in user_input: !firrtl.uint<5>)
   }
   firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>, in user_input: !firrtl.uint<5>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [{direction = "input", name = "user_input", width = 5 : ui32}], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-  // CHECK{LITERAL}: "[\0A {\0A \22module_name\22: \22{{0}}\22,\0A \22depth\22: 12,\0A \22width\22: 42,\0A \22masked\22: false,\0A \22read\22: 0,\0A \22write\22: 1,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [\0A {\0A \22name\22: \22user_input\22,\0A \22direction\22: \22input\22,\0A \22width\22: 5\0A }\0A ],\0A \22hierarchy\22: [\0A \22{{1}}.MWrite_ext\22\0A ]\0A }\0A]"
-  // CHECK-SAME: symbols = [@MWrite_ext, @OneMemory]
-  // CHECK{LITERAL}: sv.verbatim "name {{0}} depth 12 width 42 ports write\0A" {output_file = #hw.output_file<"'dut.conf'"
-  // CHECK-SAME: symbols = [@MWrite_ext]
+
+  // CHECK:               emit.file "metadata{{/|\\\\}}seq_mems.json" {
+  // CHECK-NEXT{LITERAL}:   sv.verbatim  "[\0A {\0A \22module_name\22: \22{{0}}\22,\0A \22depth\22: 12,\0A \22width\22: 42,\0A \22masked\22: false,\0A \22read\22: 0,\0A \22write\22: 1,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [\0A {\0A \22name\22: \22user_input\22,\0A \22direction\22: \22input\22,\0A \22width\22: 5\0A }\0A ],\0A \22hierarchy\22: [\0A \22{{1}}.MWrite_ext\22\0A ]\0A }\0A]"
+  // CHECK-SAME:              {symbols = [@MWrite_ext, @OneMemory]}
+  // CHECK-NEXT:          }
+
+  // CHECK:               emit.file "dut.conf" {
+  // CHECK-NEXT{LITERAL}:   sv.verbatim "name {{0}} depth 12 width 42 ports write\0A"
+  // CHECK-SAME:              {symbols = [@MWrite_ext]}
+  // CHECK-NEXT:          }
 }
 
 // -----
@@ -186,8 +213,8 @@ firrtl.circuit "DualReadsSMem" {
   }
   firrtl.memmodule @DualReads_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, in R0_data: !firrtl.uint<42>, in R1_addr: !firrtl.uint<4>, in R1_en: !firrtl.uint<1>, in R1_clk: !firrtl.clock, in R1_data: !firrtl.uint<42>, in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 2 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
   // CHECK{LITERAL}: sv.verbatim "[\0A {\0A \22module_name\22: \22{{0}}\22,\0A \22depth\22: 12,\0A \22width\22: 42,\0A \22masked\22: false,\0A \22read\22: 2,\0A \22write\22: 1,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22{{1}}.DualReads_ext\22\0A ]\0A }\0A]"
-  // CHECK: symbols = [@DualReads_ext, @DualReadsSMem]}
-  // CHECK{LITERAL}: sv.verbatim "name {{0}} depth 12 width 42 ports write,read,read\0A" {output_file = #hw.output_file<"'dut.conf'", excludeFromFileList>, symbols = [@DualReads_ext]}
+  // CHECK: {symbols = [@DualReads_ext, @DualReadsSMem]}
+  // CHECK{LITERAL}: sv.verbatim "name {{0}} depth 12 width 42 ports write,read,read\0A" {symbols = [@DualReads_ext]}
 
 }
 
@@ -201,43 +228,48 @@ firrtl.circuit "ReadOnlyMemory" {
   firrtl.memmodule @rom_ext(in R0_addr: !firrtl.uint<9>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<32>) attributes {dataWidth = 32 : ui32, depth = 512 : ui64, extraPorts = [], maskBits = 0 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 0 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
   // CHECK{LITERAL}: sv.verbatim "[\0A  {\0A \22module_name\22: \22{{0}}\22,\0A \22depth\22: 512,\0A \22width\22: 32,\0A \22masked\22: false,\0A \22read\22: 1,\0A \22write\22: 0,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22{{1}}.rom_ext\22\0A ]\0A }\0A]"
   // CHECK: symbols = [@rom_ext, @ReadOnlyMemory]}
-  // CHECK{LITERAL}: sv.verbatim "name {{0}} depth 512 width 32 ports read\0A" {output_file = #hw.output_file<"'dut.conf'", excludeFromFileList>, symbols = [@rom_ext]}
+  // CHECK{LITERAL}: sv.verbatim "name {{0}} depth 512 width 32 ports read\0A" {symbols = [@rom_ext]}
 }
 
 // -----
 
 // CHECK-LABEL: firrtl.circuit "top"
 firrtl.circuit "top" {
-    firrtl.module @top()  {
-      // CHECK: firrtl.instance dut sym @[[DUT_SYM:.+]] @DUT
-      firrtl.instance dut @DUT()
-      firrtl.instance mem1 @Mem1()
-      firrtl.instance mem2 @Mem2()
-    }
-    firrtl.module private @Mem1() {
-      %0:4 = firrtl.instance head_ext  @head_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
-    }
-    firrtl.module private @Mem2() {
-      %0:4 =  firrtl.instance head_0_ext  @head_0_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
-    }
-    firrtl.module private @DUT() attributes {annotations = [
-      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-      // CHECK: firrtl.instance mem1 sym @[[MEM1_SYM:.+]] @Mem(
-      firrtl.instance mem1 @Mem()
-    }
-    firrtl.module private @Mem() {
-      %0:10 = firrtl.instance memory_ext {annotations = [{class = "sifive.enterprise.firrtl.SeqMemInstanceMetadataAnnotation", data = {baseAddress = 2147483648 : i64, dataBits = 8 : i64, eccBits = 0 : i64, eccIndices = [], eccScheme = "none"}}]} @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>)
-      %1:8 = firrtl.instance dumm_ext @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
-    }
-    firrtl.memmodule private @head_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-    firrtl.memmodule private @head_0_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-    firrtl.memmodule private @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>) attributes {dataWidth = 8 : ui32, depth = 16 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-    firrtl.memmodule private @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
-    // CHECK{LITERAL}: sv.verbatim "[\0A {\0A \22module_name\22: \22{{0}}\22,\0A \22depth\22: 16,\0A \22width\22: 8,\0A \22masked\22: false,\0A \22read\22: 1,\0A \22write\22: 0,\0A \22readwrite\22: 1,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22{{3}}.{{4}}.memory_ext\22\0A ]\0A },\0A {\0A \22module_name\22: \22{{5}}\22,\0A \22depth\22: 20,\0A \22width\22: 5,\0A \22masked\22: false,\0A \22read\22: 1,\0A \22write\22: 1,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22{{3}}.{{4}}.dumm_ext\22\0A ]\0A }\0A]"
-    // CHECK-SAME: symbols = [@memory_ext, @top, #hw.innerNameRef<@top::@[[DUT_SYM]]>, @DUT, #hw.innerNameRef<@DUT::@[[MEM1_SYM]]>, @dumm_ext]
-    // CHECK{LITERAL}: sv.verbatim "name {{0}} depth 20 width 5 ports write\0Aname {{1}} depth 20 width 5 ports write\0Aname {{2}} depth 16 width 8 ports read,rw\0Aname {{3}} depth 20 width 5 ports write,read\0A"
-    // CHECK-SAME: {output_file = #hw.output_file<"'dut.conf'", excludeFromFileList
-    // CHECK-SAME: symbols = [@head_ext, @head_0_ext, @memory_ext, @dumm_ext]
+  firrtl.module @top()  {
+    // CHECK: firrtl.instance dut sym @[[DUT_SYM:.+]] @DUT
+    firrtl.instance dut @DUT()
+    firrtl.instance mem1 @Mem1()
+    firrtl.instance mem2 @Mem2()
+  }
+  firrtl.module private @Mem1() {
+    %0:4 = firrtl.instance head_ext  @head_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
+  }
+  firrtl.module private @Mem2() {
+    %0:4 =  firrtl.instance head_0_ext  @head_0_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
+  }
+  firrtl.module private @DUT() attributes {annotations = [
+    {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    // CHECK: firrtl.instance mem1 sym @[[MEM1_SYM:.+]] @Mem(
+    firrtl.instance mem1 @Mem()
+  }
+  firrtl.module private @Mem() {
+    %0:10 = firrtl.instance memory_ext {annotations = [{class = "sifive.enterprise.firrtl.SeqMemInstanceMetadataAnnotation", data = {baseAddress = 2147483648 : i64, dataBits = 8 : i64, eccBits = 0 : i64, eccIndices = [], eccScheme = "none"}}]} @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>)
+    %1:8 = firrtl.instance dumm_ext @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>)
+  }
+  firrtl.memmodule private @head_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+  firrtl.memmodule private @head_0_ext(in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+  firrtl.memmodule private @memory_ext(in R0_addr: !firrtl.uint<4>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<8>, in RW0_addr: !firrtl.uint<4>, in RW0_en: !firrtl.uint<1>, in RW0_clk: !firrtl.clock, in RW0_wmode: !firrtl.uint<1>, in RW0_wdata: !firrtl.uint<8>, out RW0_rdata: !firrtl.uint<8>) attributes {dataWidth = 8 : ui32, depth = 16 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+  firrtl.memmodule private @dumm_ext(in R0_addr: !firrtl.uint<5>, in R0_en: !firrtl.uint<1>, in R0_clk: !firrtl.clock, out R0_data: !firrtl.uint<5>, in W0_addr: !firrtl.uint<5>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<5>) attributes {dataWidth = 5 : ui32, depth = 20 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
+
+  // CHECK:               emit.file "metadata{{/|\\\\}}seq_mems.json" {
+  // CHECK-NEXT{LITERAL}:   sv.verbatim "[\0A {\0A \22module_name\22: \22{{0}}\22,\0A \22depth\22: 16,\0A \22width\22: 8,\0A \22masked\22: false,\0A \22read\22: 1,\0A \22write\22: 0,\0A \22readwrite\22: 1,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22{{3}}.{{4}}.memory_ext\22\0A ]\0A },\0A {\0A \22module_name\22: \22{{5}}\22,\0A \22depth\22: 20,\0A \22width\22: 5,\0A \22masked\22: false,\0A \22read\22: 1,\0A \22write\22: 1,\0A \22readwrite\22: 0,\0A \22extra_ports\22: [],\0A \22hierarchy\22: [\0A \22{{3}}.{{4}}.dumm_ext\22\0A ]\0A }\0A]"
+  // CHECK-SAME:              {symbols = [@memory_ext, @top, #hw.innerNameRef<@top::@[[DUT_SYM]]>, @DUT, #hw.innerNameRef<@DUT::@[[MEM1_SYM]]>, @dumm_ext]}
+  // CHECK-NEXT:          }
+
+  // CHECK:               emit.file "dut.conf" {
+  // CHECK-NEXT{LITERAL}:   sv.verbatim "name {{0}} depth 20 width 5 ports write\0Aname {{1}} depth 20 width 5 ports write\0Aname {{2}} depth 16 width 8 ports read,rw\0Aname {{3}} depth 20 width 5 ports write,read\0A"
+  // CHECK-SAME:              {symbols = [@head_ext, @head_0_ext, @memory_ext, @dumm_ext]}
+  // CHECK-NEXT:          }
 }
 
 // CHECK:  om.class @MemorySchema(%name: !om.sym_ref, %depth: ui64, %width: ui32, %maskBits: ui32, %readPorts: ui32, %writePorts: ui32, %readwritePorts: ui32, %writeLatency: ui32, %readLatency: ui32) {

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -11,8 +11,9 @@ firrtl.circuit "NoOMIR" {
 // CHECK-LABEL: firrtl.circuit "NoOMIR" {
 // CHECK-NEXT:    firrtl.module @NoOMIR() {
 // CHECK-NEXT:    }
-// CHECK-NEXT:    sv.verbatim "[]"
-// CHECK-SAME:    #hw.output_file<"omir.json", excludeFromFileList>}
+// CHECK-NEXT:    emit.file "omir.json" {
+// CHECK-NEXT:      sv.verbatim "[]"
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
 //===----------------------------------------------------------------------===//
@@ -26,8 +27,9 @@ firrtl.circuit "NoNodes" attributes {annotations = [{class = "freechips.rocketch
 // CHECK-LABEL: firrtl.circuit "NoNodes" {
 // CHECK-NEXT:    firrtl.module @NoNodes() {
 // CHECK-NEXT:    }
-// CHECK-NEXT:    sv.verbatim "[]"
-// CHECK-SAME:    excludeFromFileList>}
+// CHECK-NEXT:    emit.file "omir.json" {
+// CHECK-NEXT:      sv.verbatim "[]"
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
 //===----------------------------------------------------------------------===//
@@ -42,11 +44,14 @@ firrtl.circuit "EmptyNode" attributes {annotations = [{class = "freechips.rocket
 // CHECK-LABEL: firrtl.circuit "EmptyNode" {
 // CHECK-NEXT:    firrtl.module @EmptyNode() {
 // CHECK-NEXT:    }
-// CHECK-NEXT:    sv.verbatim
-// CHECK-SAME:    \22info\22: \22UnlocatableSourceInfo\22
-// CHECK-SAME:    \22id\22: \22OMID:0\22
-// CHECK-SAME:    \22fields\22: []
-// CHECK-SAME:    excludeFromFileList>}
+// CHECK-NEXT:    emit.file "omir.json" {
+// CHECK-NEXT:      sv.verbatim
+// CHECK-SAME:      {
+// CHECK-SAME:        \22info\22: \22UnlocatableSourceInfo\22
+// CHECK-SAME:        \22id\22: \22OMID:0\22
+// CHECK-SAME:        \22fields\22: []
+// CHECK-SAME:      }
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
 //===----------------------------------------------------------------------===//
@@ -63,22 +68,25 @@ firrtl.circuit "SourceLocators" attributes {annotations = [{class = "freechips.r
 // CHECK-LABEL: firrtl.circuit "SourceLocators" {
 // CHECK-NEXT:    firrtl.module @SourceLocators() {
 // CHECK-NEXT:    }
-// CHECK-NEXT:    sv.verbatim
-// CHECK-SAME:    \22info\22: \22@[A 0:1]\22
-// CHECK-SAME:    \22id\22: \22OMID:0\22
-// CHECK-SAME:    \22fields\22: [
+// CHECK-NEXT:    emit.file "omir.json" {
+// CHECK-NEXT:      sv.verbatim
 // CHECK-SAME:      {
-// CHECK-SAME:        \22info\22: \22@[C 4:5 D 6:7]\22
-// CHECK-SAME:        \22name\22: \22y\22
-// CHECK-SAME:        \22value\22: \22OMReference:0\22
+// CHECK-SAME:        \22info\22: \22@[A 0:1]\22
+// CHECK-SAME:        \22id\22: \22OMID:0\22
+// CHECK-SAME:        \22fields\22: [
+// CHECK-SAME:          {
+// CHECK-SAME:            \22info\22: \22@[C 4:5 D 6:7]\22
+// CHECK-SAME:            \22name\22: \22y\22
+// CHECK-SAME:            \22value\22: \22OMReference:0\22
+// CHECK-SAME:          }
+// CHECK-SAME:          {
+// CHECK-SAME:            \22info\22: \22@[B 2:3]\22
+// CHECK-SAME:            \22name\22: \22x\22
+// CHECK-SAME:            \22value\22: \22OMReference:0\22
+// CHECK-SAME:          }
+// CHECK-SAME:        ]
 // CHECK-SAME:      }
-// CHECK-SAME:      {
-// CHECK-SAME:        \22info\22: \22@[B 2:3]\22
-// CHECK-SAME:        \22name\22: \22x\22
-// CHECK-SAME:        \22value\22: \22OMReference:0\22
-// CHECK-SAME:      }
-// CHECK-SAME:    ]
-// CHECK-SAME:    excludeFromFileList>}
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
 //===----------------------------------------------------------------------===//
@@ -109,41 +117,48 @@ firrtl.circuit "AllTypesSupported" attributes {annotations = [{
 // CHECK-LABEL: firrtl.circuit "AllTypesSupported" {
 // CHECK-NEXT:    firrtl.module @AllTypesSupported() {
 // CHECK-NEXT:    }
-// CHECK-NEXT:    sv.verbatim
-// CHECK-SAME:    \22name\22: \22OMBoolean\22
-// CHECK-SAME:    \22value\22: true
-// CHECK-SAME:    \22name\22: \22OMInt1\22
-// CHECK-SAME:    \22value\22: 9001
-// CHECK-SAME:    \22name\22: \22OMInt2\22
-// CHECK-SAME:    \22value\22: -42
-// CHECK-SAME:    \22name\22: \22OMDouble\22
-// CHECK-SAME:    \22value\22: 3.14
-// CHECK-SAME:    \22name\22: \22OMID\22
-// CHECK-SAME:    \22value\22: \22OMID:1337\22
-// CHECK-SAME:    \22name\22: \22OMReference\22
-// CHECK-SAME:    \22value\22: \22OMReference:0\22
-// CHECK-SAME:    \22name\22: \22OMBigInt\22
-// CHECK-SAME:    \22value\22: \22OMBigInt:42\22
-// CHECK-SAME:    \22name\22: \22OMLong\22
-// CHECK-SAME:    \22value\22: \22OMLong:ff\22
-// CHECK-SAME:    \22name\22: \22OMString\22
-// CHECK-SAME:    \22value\22: \22OMString:hello\22
-// CHECK-SAME:    \22name\22: \22OMBigDecimal\22
-// CHECK-SAME:    \22value\22: \22OMBigDecimal:10.5\22
-// CHECK-SAME:    \22name\22: \22OMDeleted\22
-// CHECK-SAME:    \22value\22: \22OMDeleted\22
-// CHECK-SAME:    \22name\22: \22OMArray\22
-// CHECK-SAME:    \22value\22: [
-// CHECK-SAME:      true
-// CHECK-SAME:      9001
-// CHECK-SAME:      \22OMString:bar\22
-// CHECK-SAME:    ]
-// CHECK-SAME:    \22name\22: \22OMMap\22
-// CHECK-SAME:    \22value\22: {
-// CHECK-SAME:      \22bar\22: 9001
-// CHECK-SAME:      \22foo\22: true
-// CHECK-SAME:    }
-// CHECK-SAME:    excludeFromFileList>}
+// CHECK-NEXT:    emit.file "omir.json" {
+// CHECK-NEXT:      sv.verbatim
+// CHECK-SAME:      {
+// CHECK-SAME:        [
+// CHECK-SAME:          {
+// CHECK-SAME:            \22name\22: \22OMBoolean\22
+// CHECK-SAME:            \22value\22: true
+// CHECK-SAME:            \22name\22: \22OMInt1\22
+// CHECK-SAME:            \22value\22: 9001
+// CHECK-SAME:            \22name\22: \22OMInt2\22
+// CHECK-SAME:            \22value\22: -42
+// CHECK-SAME:            \22name\22: \22OMDouble\22
+// CHECK-SAME:            \22value\22: 3.14
+// CHECK-SAME:            \22name\22: \22OMID\22
+// CHECK-SAME:            \22value\22: \22OMID:1337\22
+// CHECK-SAME:            \22name\22: \22OMReference\22
+// CHECK-SAME:            \22value\22: \22OMReference:0\22
+// CHECK-SAME:            \22name\22: \22OMBigInt\22
+// CHECK-SAME:            \22value\22: \22OMBigInt:42\22
+// CHECK-SAME:            \22name\22: \22OMLong\22
+// CHECK-SAME:            \22value\22: \22OMLong:ff\22
+// CHECK-SAME:            \22name\22: \22OMString\22
+// CHECK-SAME:            \22value\22: \22OMString:hello\22
+// CHECK-SAME:            \22name\22: \22OMBigDecimal\22
+// CHECK-SAME:            \22value\22: \22OMBigDecimal:10.5\22
+// CHECK-SAME:            \22name\22: \22OMDeleted\22
+// CHECK-SAME:            \22value\22: \22OMDeleted\22
+// CHECK-SAME:            \22name\22: \22OMArray\22
+// CHECK-SAME:            \22value\22: [
+// CHECK-SAME:              true
+// CHECK-SAME:              9001
+// CHECK-SAME:              \22OMString:bar\22
+// CHECK-SAME:            ]
+// CHECK-SAME:            \22name\22: \22OMMap\22
+// CHECK-SAME:            \22value\22: {
+// CHECK-SAME:              \22bar\22: 9001
+// CHECK-SAME:              \22foo\22: true
+// CHECK-SAME:            }
+// CHECK-SAME:          }
+// CHECK-SAME:        ]
+// CHECK-SAME:      }
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
 //===----------------------------------------------------------------------===//
@@ -175,6 +190,7 @@ firrtl.circuit "LocalTrackers" attributes {annotations = [{
 // CHECK-NEXT:      firrtl.instance a sym [[SYMA:@[a-zA-Z0-9_]+]] @A()
 // CHECK-NEXT:      %b = firrtl.wire sym [[SYMB:@[a-zA-Z0-9_]+]] : !firrtl.uint<42>
 // CHECK-NEXT:    }
+// CHECK-NEXT:    emit.file "omir.json" {
 // CHECK-NEXT:    sv.verbatim
 // CHECK-SAME:           \22name\22: \22OMReferenceTarget1\22
 // CHECK-SAME{LITERAL}:  \22value\22: \22OMReferenceTarget:~LocalTrackers|{{0}}\22
@@ -222,7 +238,8 @@ firrtl.circuit "NonLocalTrackers" attributes {annotations = [{
 }
 // CHECK:       firrtl.instance a sym [[SYMA:@[a-zA-Z0-9_]+]]
 // CHECK:       firrtl.instance b sym [[SYMB:@[a-zA-Z0-9_]+]]
-// CHECK:       sv.verbatim
+// CHECK:       emit.file "omir.json" {
+// CHECK-NEXT:    sv.verbatim
 // CHECK-SAME:           \22name\22: \22OMReferenceTarget1\22
 // CHECK-SAME{LITERAL}:  \22value\22: \22OMReferenceTarget:~NonLocalTrackers|{{0}}/{{1}}:{{2}}/{{3}}:{{4}}\22
 // CHECK-SAME:           \22name\22: \22OMReferenceTarget2\22
@@ -510,7 +527,8 @@ firrtl.circuit "SRAMPaths" attributes {annotations = [{
 // CHECK-NOT:         circt.nonlocal
 // CHECK-SAME:        @Submodule()
 // CHECK-NEXT:    }
-// CHECK-NEXT:    sv.verbatim
+// CHECK-NEXT:    emit.file "omir.json" {
+// CHECK-NEXT:      sv.verbatim
 
 // CHECK-SAME:           \22id\22: \22OMID:0\22
 // CHECK-SAME:             \22name\22: \22omType\22
@@ -532,14 +550,15 @@ firrtl.circuit "SRAMPaths" attributes {annotations = [{
 // CHECK-NOT:                {{.+}}
 // CHECK-SAME:               {{[^\\]+}}\22
 
-// CHECK-SAME:    symbols = [
-// CHECK-SAME:      @SRAMPaths,
-// CHECK-SAME:      #hw.innerNameRef<@SRAMPaths::[[SYMSUB]]>,
-// CHECK-SAME:      @Submodule,
-// CHECK-SAME:      #hw.innerNameRef<@Submodule::[[SYMMEM1]]>,
-// CHECK-SAME:      @MySRAM,
-// CHECK-SAME:      #hw.innerNameRef<@Submodule::[[SYMMEM2]]>
-// CHECK-SAME:    ]}
+// CHECK-SAME:      symbols = [
+// CHECK-SAME:        @SRAMPaths,
+// CHECK-SAME:        #hw.innerNameRef<@SRAMPaths::[[SYMSUB]]>,
+// CHECK-SAME:        @Submodule,
+// CHECK-SAME:        #hw.innerNameRef<@Submodule::[[SYMMEM1]]>,
+// CHECK-SAME:        @MySRAM,
+// CHECK-SAME:        #hw.innerNameRef<@Submodule::[[SYMMEM2]]>
+// CHECK-SAME:      ]}
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
 //===----------------------------------------------------------------------===//
@@ -1001,7 +1020,8 @@ firrtl.circuit "FixPath"  attributes {annotations = [
   // CHECK-LABEL: firrtl.circuit "FixPath"
   // CHECK:         firrtl.module @FixPath
   // CHECK:           firrtl.instance d  @D()
-  // CHECK:         sv.verbatim
+  // CHECK:         emit.file "omir.json" {
+  // CHECK-NEXT:      sv.verbatim
   // CHECK-SAME:               name\22: \22dutInstance\22,\0A
   // CHECK-SAME{LITERAL}:      OMMemberInstanceTarget:~FixPath|{{0}}/{{1}}:{{2}}
   // CHECK-SAME:               name\22: \22pwm\22,\0A
@@ -1010,5 +1030,5 @@ firrtl.circuit "FixPath"  attributes {annotations = [
   // CHECK-SAME{LITERAL}:      value\22: \22OMMemberInstanceTarget:~C|{{2}}/{{4}}:{{5}}
   // CHECK-SAME:               name\22: \22d\22,\0A
   // CHECK-SAME{LITERAL}:      value\22: \22OMMemberInstanceTarget:~FixPath|{{5}}\22\0A
-  // CHECK-SAME:      {output_file = #hw.output_file<"omir.json", excludeFromFileList>, symbols = [@FixPath, #hw.innerNameRef<@FixPath::@c>, @C, #hw.innerNameRef<@C::@in>, #hw.innerNameRef<@C::@cd>, @D]}
+  // CHECK-SAME:      {symbols = [@FixPath, #hw.innerNameRef<@FixPath::@c>, @C, #hw.innerNameRef<@C::@in>, #hw.innerNameRef<@C::@cd>, @D]}
 }

--- a/test/Dialect/FIRRTL/resolve-traces.mlir
+++ b/test/Dialect/FIRRTL/resolve-traces.mlir
@@ -11,13 +11,10 @@ firrtl.circuit "Foo" {
 
 // Test that a local module annotation is resolved.
 //
+// CHECK:               emit.file "{{.*}}Foo.anno.json" {
 // CHECK:               class{{.*}}:{{.*}}chisel3.experimental.Trace$TraceAnnotation
 // CHECK-SAME{LITERAL}:   \22target\22: \22~Foo|{{0}}\22
 // CHECK-SAME:            \22chiselTarget\22:  \22~Foo|Original\22
-
-// Test that the output file is set to include the circuit name.
-//
-// CHECK-SAME: #hw.output_file<{{.*}}Foo.anno.json
 
 // Test that the symbols are correct.
 // CHECK-SAME: symbols = [@Foo]


### PR DESCRIPTION
Port over FIRRTL passes to emit metadata using `emit::FileOp`.

This PR re-uses the `sv::Verbatim` to format in the presence of SV symbols.