### PR TITLE
[FIRRTL][FIRParser] Enforce 4.0.0 main module must be public.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -5037,7 +5037,8 @@ ParseResult FIRCircuitParser::parseModule(CircuitOp circuit, bool isPublic,
   SmallVector<PortInfo, 8> portList;
   SmallVector<SMLoc> portLocs;
   ArrayAttr layers;
-  LocWithInfo info(getToken().getLoc(), this);
+  auto modLoc = getToken().getLoc();
+  LocWithInfo info(modLoc, this);
   consumeToken(FIRToken::kw_module);
   if (parseId(name, "expected module name") ||
       parseOptionalEnabledLayers(layers) ||
@@ -5046,7 +5047,11 @@ ParseResult FIRCircuitParser::parseModule(CircuitOp circuit, bool isPublic,
     return failure();
 
   // The main module is implicitly public.
-  isPublic |= name == circuit.getName();
+  if (name == circuit.getName()) {
+    if (!isPublic && removedFeature({4, 0, 0}, "private main modules", modLoc))
+      return failure();
+    isPublic = true;
+  }
 
   if (isPublic && version >= FIRVersion{4, 0, 0}) {
     for (auto [pi, loc] : llvm::zip_equal(portList, portLocs)) {

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1682,7 +1682,7 @@ circuit Layers:
   ; CHECK:      firrtl.module @Layers
   ; CHECK-SAME:   out %b: !firrtl.probe<uint<1>, @A>
   ; CHECK-SAME:   out %c: !firrtl.rwprobe<uint<1>, @A::@B>
-  module Layers:
+  public module Layers:
     input a: UInt<1>
     output b: Probe<UInt<1>, A>
     output c: RWProbe<UInt<1>, A.B>
@@ -1858,7 +1858,7 @@ FIRRTL version 4.0.0
 
 ; CHECK-LABEL: firrtl.circuit "IntegerArithmetic"
 circuit IntegerArithmetic :
-  module IntegerArithmetic :
+  public module IntegerArithmetic :
     input a : Integer
     input b : Integer
     output c : Integer
@@ -1955,7 +1955,7 @@ circuit LayerEnabledModule:
     layer C, bind:
   ; CHECK: firrtl.module @LayerEnabledModule
   ; CHECK-SAME: layers = [@A, @B::@C]
-  module LayerEnabledModule enablelayer A enablelayer B.C:
+  public module LayerEnabledModule enablelayer A enablelayer B.C:
 
   ; CHECK: firrtl.module private @UserOfLayerEnabledModule
   ; CHECK-SAME: layers = [@A, @B::@C]
@@ -2031,7 +2031,7 @@ FIRRTL version 4.0.0
 ; CHECK-LABEL: circuit "StaticShiftRight"
 circuit StaticShiftRight:
   ; CHECK: firrtl.module @StaticShiftRight
-  module StaticShiftRight:
+  public module StaticShiftRight:
     input a : UInt<8>
     input b : UInt<0>
     input c : SInt<8>

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1368,3 +1368,9 @@ circuit AbstractResetPublic:
   module AbstractResetPublic:
     ; expected-error @below {{public module port must have concrete reset type}}
     input r: Reset
+
+;// -----
+FIRRTL version 4.0.0
+circuit PrivateMainModule:
+  ; expected-error @below {{private main modules were removed in FIRRTL 4.0.0}}
+  module PrivateMainModule:

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -790,7 +790,7 @@ circuit UnsupportedVersionGroups:
 
 FIRRTL version 4.1.0
 circuit RemovedGroups:
-  module RemovedGroups:
+  public module RemovedGroups:
     ; expected-error @below {{optional groups were removed in FIRRTL 4.0.0, but the specified FIRRTL version was 4.1.0}}
     group A:
 
@@ -817,7 +817,7 @@ circuit LayerAndCircuitShareName:
   layer LayerAndCircuitShareName, bind :
 
   ; expected-error @below {{redefinition of symbol named 'LayerAndCircuitShareName'}}
-  module LayerAndCircuitShareName:
+  public module LayerAndCircuitShareName:
 
 ;// -----
 
@@ -1180,7 +1180,7 @@ FIRRTL version 4.0.0
 circuit PublicNonModule:
   ; expected-error @below {{only modules may be public}}
   public extmodule Foo:
-  module PublicNonModule:
+  public module PublicNonModule:
 
 ;// -----
 circuit RWProbeExprOOB :
@@ -1228,7 +1228,7 @@ circuit Foo:
   module FPGATarget:
     input clock: UInt<1>
 
-  module Foo:
+  public module Foo:
     ; expected-error @below {{instance case port 'clock' type does not match the default module port}}
     instchoice inst of DefaultTarget, Platform :
       FPGA => FPGATarget
@@ -1246,7 +1246,7 @@ circuit Foo:
   module FPGATarget:
     input x: UInt<1>
 
-  module Foo:
+  public module Foo:
     ; expected-error @below {{instance case module port 'x' does not match the default module port 'clock'}}
     instchoice inst of DefaultTarget, Platform :
       FPGA => FPGATarget
@@ -1261,7 +1261,7 @@ circuit Foo:
   module DefaultTarget:
   module FPGATarget:
 
-  module Foo:
+  public module Foo:
     ; expected-error @below {{use of undefined option case 'ASIC'}}
     instchoice inst of DefaultTarget, Platform :
       ASIC => FPGATarget
@@ -1273,7 +1273,7 @@ circuit Foo:
   module DefaultTarget:
   module FPGATarget:
 
-  module Foo:
+  public module Foo:
     ; expected-error @below {{use of undefined option group 'Platform'}}
     instchoice inst of DefaultTarget, Platform :
       ASIC => FPGATarget
@@ -1299,14 +1299,14 @@ circuit Foo:
 FIRRTL version 4.0.0
 circuit Foo:
   layer A bind:
-  module Foo:
+  public module Foo:
     output a: Probe<
     ; expected-error @below {{expected probe data type}}
 ;// -----
 FIRRTL version 4.0.0
 circuit Foo:
   layer A bind:
-  module Foo:
+  public module Foo:
     ; expected-error @below {{expected '<' in reference type}}
     output a: Probe X
 
@@ -1314,14 +1314,14 @@ circuit Foo:
 FIRRTL version 4.0.0
 circuit Foo:
   layer A bind:
-  module Foo:
+  public module Foo:
     output a: Probe
     ; expected-error @below {{expected '<' in reference type}}
 ;// -----
 FIRRTL version 4.0.0
 circuit Foo:
   layer A bind:
-  module Foo:
+  public module Foo:
     ; expected-error @below {{expected probe data type}}
     output a: Probe<>
 
@@ -1329,14 +1329,14 @@ circuit Foo:
 FIRRTL version 4.0.0
 circuit Foo:
   layer A bind:
-  module Foo:
+  public module Foo:
     ; expected-error @below {{expected '>' to end reference type}}
     output a: Probe<UInt<1>
 ;// -----
 FIRRTL version 4.0.0
 circuit Foo:
   layer A bind:
-  module Foo:
+  public module Foo:
     ; expected-error @below {{expected '>' to end reference type}}
     output a: Probe<UInt<1> A
 
@@ -1344,7 +1344,7 @@ circuit Foo:
 FIRRTL version 4.0.0
 circuit Foo:
   layer A bind:
-  module Foo:
+  public module Foo:
     ; expected-error @below {{expected layer name}}
     output a: Probe<UInt<1> A.>
 
@@ -1365,7 +1365,7 @@ circuit UnknownWidthExt:
 ;// -----
 FIRRTL version 4.0.0
 circuit AbstractResetPublic:
-  module AbstractResetPublic:
+  public module AbstractResetPublic:
     ; expected-error @below {{public module port must have concrete reset type}}
     input r: Reset
 

--- a/test/firtool/chisel_assert.fir
+++ b/test/firtool/chisel_assert.fir
@@ -47,7 +47,7 @@ circuit ChiselVerif:
     parameter label = "label for cover"
 
   ; CHECK: module ChiselVerif
-  module ChiselVerif:
+  public module ChiselVerif:
     input clock: Clock
     input cond: UInt<1>
     input enable: UInt<1>

--- a/test/firtool/instchoice.fir
+++ b/test/firtool/instchoice.fir
@@ -18,7 +18,7 @@ circuit Foo:
   module ASICTarget:
     input clock: Clock
 
-  module Foo:
+  public module Foo:
     input clock: Clock
 
     ; CHECK: %inst_clock = firrtl.instance_choice inst interesting_name @DefaultTarget

--- a/test/firtool/layers.fir
+++ b/test/firtool/layers.fir
@@ -14,7 +14,7 @@ circuit Foo: %[[
   layer A, bind:
     layer B, bind:
 
-  module Foo:
+  public module Foo:
     input in: UInt<1>
 
     layerblock A:

--- a/test/firtool/lower-layers2.fir
+++ b/test/firtool/lower-layers2.fir
@@ -76,7 +76,7 @@ circuit TestHarness:
   ; CHECK:     .b     (b)
   ; CHECK:   );
   ; CHECK: endmodule
-  module TestHarness:
+  public module TestHarness:
     input clock: Clock
     input reset: UInt<1>
     input a: UInt<32>


### PR DESCRIPTION
The "public" nature of the main module is not optional, require it to be explicitly specified.

cc https://github.com/chipsalliance/firrtl-spec/pull/185 .