### PR TITLE
[MSFT][Emit] Replace `output_file` with an `emit::File`

### DIFF
--- a/include/circt/Dialect/MSFT/MSFTPasses.td
+++ b/include/circt/Dialect/MSFT/MSFTPasses.td
@@ -11,7 +11,11 @@ include "mlir/Pass/PassBase.td"
 def ExportTcl: Pass<"msft-export-tcl", "mlir::ModuleOp"> {
   let summary = "Create tcl ops";
   let constructor = "circt::msft::createExportTclPass()";
-  let dependentDialects = ["circt::sv::SVDialect", "circt::hw::HWDialect"];
+  let dependentDialects = [
+    "circt::emit::EmitDialect",
+    "circt::hw::HWDialect",
+    "circt::sv::SVDialect",
+  ];
   let options = [
     ListOption<"tops", "tops", "std::string",
                "List of top modules to export Tcl for",

--- a/lib/Dialect/MSFT/CMakeLists.txt
+++ b/lib/Dialect/MSFT/CMakeLists.txt
@@ -18,11 +18,12 @@ add_circt_dialect_library(CIRCTMSFT
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/MSFT
 
   DEPENDS
+  CIRCTEmit
   CIRCTHW
   CIRCTSV
   MLIRMSFTIncGen
   MLIRMSFTExtraIncGen
-  
+
   LINK_COMPONENTS
   Support
 
@@ -30,6 +31,7 @@ add_circt_dialect_library(CIRCTMSFT
   MLIRIR
   MLIRTransforms
   MLIRInferTypeOpInterface
+  CIRCTEmit
   CIRCTHW
   CIRCTSeq
   CIRCTSV

--- a/lib/Dialect/MSFT/Transforms/CMakeLists.txt
+++ b/lib/Dialect/MSFT/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_circt_dialect_library(CIRCTMSFTTransforms
   CIRCTMSFTTransformsIncGen
 
   LINK_LIBS PUBLIC
+  CIRCTEmit
   CIRCTMSFT
   CIRCTHW
   CIRCTSV

--- a/lib/Dialect/MSFT/Transforms/PassDetails.h
+++ b/lib/Dialect/MSFT/Transforms/PassDetails.h
@@ -16,6 +16,7 @@
 #ifndef DIALECT_MSFT_TRANSFORMS_PASSDETAILS_H
 #define DIALECT_MSFT_TRANSFORMS_PASSDETAILS_H
 
+#include "circt/Dialect/Emit/EmitDialect.h"
 #include "circt/Dialect/MSFT/MSFTOps.h"
 #include "circt/Dialect/MSFT/MSFTPasses.h"
 #include "circt/Dialect/SV/SVOps.h"


### PR DESCRIPTION
`output_file` is to be replaced with explicit files constructed via the emit dialect. This PR replaces its use in the MSFT dialect.
Behaviour is slighly altered: the verbatim is always emitted to a file as we should not mix in TCL with SV and it is omitted from the default file list as it should always point to SV.