### PR TITLE
[HGLDD] Uniquify object names during emission

### DIFF
--- a/lib/Target/DebugInfo/EmitHGLDD.cpp
+++ b/lib/Target/DebugInfo/EmitHGLDD.cpp
@@ -160,11 +160,50 @@ static bool makePathRelative(StringRef path, StringRef relativeTo,
   return outputIt == outputEnd;
 }
 
+/// Legalize the given `name` such that it only consists of valid identifier
+/// characters in Verilog and does not collide with any Verilog keyword, and
+/// uniquify the resulting name such that it does not collide with any of the
+/// names stored in the `nextGeneratedNameIDs` map.
+///
+/// The HGLDD output is likely to be ingested by tools that have been developed
+/// to debug Verilog code. These have the limitation of only supporting valid
+/// Verilog identifiers for signals and other names. HGLDD therefore requires
+/// these names to be valid Verilog identifiers.
+static StringRef legalizeName(StringRef name,
+                              llvm::StringMap<size_t> &nextGeneratedNameIDs) {
+  return sv::legalizeName(name, nextGeneratedNameIDs, true);
+}
+
 //===----------------------------------------------------------------------===//
 // HGLDD File Emission
 //===----------------------------------------------------------------------===//
 
 namespace {
+
+/// Contextual information for HGLDD emission shared across multiple HGLDD
+/// files. This struct keeps the DI analysis, symbol caches, and namespaces for
+/// name uniquification.
+struct GlobalState {
+  /// The root operation.
+  Operation *op;
+  /// The emission options.
+  const EmitHGLDDOptions &options;
+  /// The debug info analysis constructed for the root operation.
+  DebugInfo di;
+  /// A symbol cache with all top-level symbols in the root operation.
+  hw::HWSymbolCache symbolCache;
+  /// A uniquified name for each emitted DI module.
+  SmallDenseMap<DIModule *, StringRef> moduleNames;
+  /// A namespace used to deduplicate the names of HGLDD "objects" during
+  /// emission. This includes modules and struct type declarations.
+  llvm::StringMap<size_t> objectNamespace;
+
+  GlobalState(Operation *op, const EmitHGLDDOptions &options)
+      : op(op), options(options), di(op) {
+    symbolCache.addDefinitions(op);
+    symbolCache.freeze();
+  }
+};
 
 /// An emitted type.
 struct EmittedType {
@@ -234,13 +273,18 @@ static llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 
 /// Contextual information for a single HGLDD file to be emitted.
 struct FileEmitter {
-  const EmitHGLDDOptions *options = nullptr;
-  const hw::HWSymbolCache *symbolCache = nullptr;
-  SmallVector<DIModule *> modules;
-  SmallString<64> outputFileName;
+  GlobalState &state;
   StringAttr hdlFile;
+  FileEmitter(GlobalState &state, StringAttr hdlFile)
+      : state(state), hdlFile(hdlFile) {}
+
+  /// The DI modules to be emitted into this HGLDD file.
+  SmallVector<DIModule *> modules;
+  /// The name of the output HGLDD file.
+  SmallString<64> outputFileName;
+
+  llvm::StringMap<size_t> moduleNamespace;
   SmallMapVector<StringAttr, std::pair<StringAttr, unsigned>, 8> sourceFiles;
-  Namespace objectNamespace;
   SmallMapVector<JValue, StringRef, 8> structDefs;
   SmallString<128> structNameHint;
 
@@ -256,7 +300,7 @@ struct FileEmitter {
   unsigned getSourceFile(StringAttr sourceFile, bool emitted);
 
   FileLineColLoc findBestLocation(Location loc, bool emitted) {
-    return ::findBestLocation(loc, emitted, options->onlyExistingFileLocs);
+    return ::findBestLocation(loc, emitted, state.options.onlyExistingFileLocs);
   }
 
   /// Find the best location and, if one is found, emit it under the given
@@ -333,6 +377,19 @@ struct FileEmitter {
     if (auto fileLoc = findBestLocation(loc, true))
       into["hdl_loc"] = emitLoc(fileLoc, {}, true);
   }
+
+  /// Return the legalized and uniquified name of a DI module. Asserts that the
+  /// module has such a name.
+  StringRef getModuleName(DIModule *module) {
+    auto name = state.moduleNames.lookup(module);
+    assert(!name.empty() &&
+           "moduleNames should contain a name for every module");
+    return name;
+  }
+
+  StringRef legalizeInModuleNamespace(StringRef name) {
+    return legalizeName(name, moduleNamespace);
+  }
 };
 
 } // namespace
@@ -360,7 +417,7 @@ unsigned FileEmitter::getSourceFile(StringAttr sourceFile, bool emitted) {
   // (`emitted` is true), or the source file prefix if this is a source file
   // (`emitted` is false).
   StringRef filePrefix =
-      emitted ? options->outputFilePrefix : options->sourceFilePrefix;
+      emitted ? state.options.outputFilePrefix : state.options.sourceFilePrefix;
   if (!filePrefix.empty()) {
     SmallString<64> buffer = filePrefix;
     path::append(buffer, sourceFile.getValue());
@@ -420,9 +477,6 @@ void FileEmitter::emit(llvm::raw_ostream &os) {
 }
 
 void FileEmitter::emit(JOStream &json) {
-  for (auto *module : modules)
-    objectNamespace.newName(module->name.getValue());
-
   // The "HGLDD" header field needs to be the first in the JSON file (which
   // violates the JSON spec, but what can you do). But we only know after module
   // emission what the contents of the header will be.
@@ -514,10 +568,11 @@ StringAttr getVerilogInstanceName(DIInstance &inst) {
 
 /// Emit the debug info for a `DIModule`.
 void FileEmitter::emitModule(JOStream &json, DIModule *module) {
+  moduleNamespace = state.objectNamespace;
   structNameHint = module->name.getValue();
   json.objectBegin();
   json.attribute("kind", "module");
-  json.attribute("obj_name", module->name.getValue()); // HGL
+  json.attribute("obj_name", getModuleName(module)); // HGL
   json.attribute("module_name",
                  getVerilogModuleName(*module).getValue()); // HDL
   if (module->isExtern)
@@ -547,13 +602,15 @@ void FileEmitter::emitInstance(JOStream &json, DIInstance *instance) {
   json.objectBegin();
 
   // Emit the instance and module name.
-  json.attribute("name", instance->name.getValue());
+  auto instanceName = legalizeInModuleNamespace(instance->name.getValue());
+  json.attribute("name", instanceName);
   if (!instance->module->isInline) {
     auto verilogName = getVerilogInstanceName(*instance);
-    if (verilogName != instance->name)
+    if (verilogName != instanceName)
       json.attribute("hdl_obj_name", verilogName.getValue());
 
-    json.attribute("obj_name", instance->module->name.getValue()); // HGL
+    json.attribute("obj_name",
+                   getModuleName(instance->module)); // HGL
     json.attribute("module_name",
                    getVerilogModuleName(*instance->module).getValue()); // HDL
   }
@@ -571,7 +628,7 @@ void FileEmitter::emitInstance(JOStream &json, DIInstance *instance) {
       structNameHint += instance->module->name.getValue();
     } else if (!instance->name.empty()) {
       structNameHint += '_';
-      structNameHint += instance->name.getValue();
+      structNameHint += instanceName;
     }
     emitModuleBody(json, instance->module);
     structNameHint.resize(structNameHintLen);
@@ -583,7 +640,8 @@ void FileEmitter::emitInstance(JOStream &json, DIInstance *instance) {
 /// Emit the debug info for a `DIVariable`.
 void FileEmitter::emitVariable(JOStream &json, DIVariable *variable) {
   json.objectBegin();
-  json.attribute("var_name", variable->name.getValue());
+  auto variableName = legalizeInModuleNamespace(variable->name.getValue());
+  json.attribute("var_name", variableName);
   findAndEmitLoc(json, "hgl_loc", variable->loc, false);
   findAndEmitLoc(json, "hdl_loc", variable->loc, true);
 
@@ -591,7 +649,7 @@ void FileEmitter::emitVariable(JOStream &json, DIVariable *variable) {
   if (auto value = variable->value) {
     auto structNameHintLen = structNameHint.size();
     structNameHint += '_';
-    structNameHint += variable->name.getValue();
+    structNameHint += variableName;
     emitted = emitExpression(value);
     structNameHint.resize(structNameHintLen);
   }
@@ -705,9 +763,11 @@ EmittedExpr FileEmitter::emitExpression(Value value) {
 
     // Assemble the struct type definition.
     JArray fieldDefs;
+    llvm::StringMap<size_t> structNamespace;
     for (auto [type, name, loc] : types) {
       JObject fieldDef;
-      fieldDef["var_name"] = name.getValue();
+      fieldDef["var_name"] =
+          std::string(legalizeName(name.getValue(), structNamespace));
       fieldDef["type_name"] = type.name;
       if (auto dims = type.emitPackedDims(); !dims.empty())
         fieldDef["packed_range"] = std::move(dims);
@@ -716,7 +776,7 @@ EmittedExpr FileEmitter::emitExpression(Value value) {
       findAndSetLocs(fieldDef, loc);
       fieldDefs.push_back(std::move(fieldDef));
     }
-    auto structName = objectNamespace.newName(structNameHint);
+    auto structName = legalizeName(structNameHint, state.objectNamespace);
     JObject structDef;
     structDef["kind"] = "struct";
     structDef["obj_name"] = structName;
@@ -912,40 +972,36 @@ namespace {
 /// files. This struct is used to determine an initial split of debug info files
 /// and to distribute work.
 struct Emitter {
-  DebugInfo di;
+  GlobalState state;
   SmallVector<FileEmitter, 0> files;
-  hw::HWSymbolCache symbolCache;
-
   Emitter(Operation *module, const EmitHGLDDOptions &options);
 };
 
 } // namespace
 
 Emitter::Emitter(Operation *module, const EmitHGLDDOptions &options)
-    : di(module) {
-  symbolCache.addDefinitions(module);
-  symbolCache.freeze();
-
+    : state(module, options) {
   // Group the DI modules according to their emitted file path. Modules that
   // don't have an emitted file path annotated are collected in a separate
   // group. That group, with a null `StringAttr` key, is emitted into a separate
   // "global.dd" file.
   MapVector<StringAttr, FileEmitter> groups;
-  for (auto [moduleName, module] : di.moduleNodes) {
+  for (auto [moduleName, module] : state.di.moduleNodes) {
     StringAttr hdlFile;
     if (module->op)
       if (auto fileLoc = findBestLocation(module->op->getLoc(), true, false))
         hdlFile = fileLoc.getFilename();
-    groups[hdlFile].modules.push_back(module);
+    auto &fileEmitter =
+        groups.try_emplace(hdlFile, state, hdlFile).first->second;
+    fileEmitter.modules.push_back(module);
+    state.moduleNames[module] =
+        legalizeName(module->name.getValue(), state.objectNamespace);
   }
 
   // Determine the output file names and move the emitters into the `files`
   // member.
   files.reserve(groups.size());
   for (auto &[hdlFile, emitter] : groups) {
-    emitter.symbolCache = &symbolCache;
-    emitter.options = &options;
-    emitter.hdlFile = hdlFile;
     emitter.outputFileName = options.outputDirectory;
     StringRef fileName = hdlFile ? hdlFile.getValue() : "global";
     if (llvm::sys::path::is_absolute(fileName))

--- a/test/Target/DebugInfo/emit-hgldd.mlir
+++ b/test/Target/DebugInfo/emit-hgldd.mlir
@@ -245,11 +245,11 @@ hw.module @Expressions(in %a: i1, in %b: i1) {
   %5 = sv.read_inout %svLogic : !hw.inout<i1>
   dbg.variable "readLogic", %5 : i1
 
-  // CHECK-LABEL: "var_name": "wire"
+  // CHECK-LABEL: "var_name": "myWire"
   // CHECK: "value": {"sig_name":"hwWire"}
   // CHECK: "type_name": "logic"
   %hwWire = hw.wire %a : i1
-  dbg.variable "wire", %hwWire : i1
+  dbg.variable "myWire", %hwWire : i1
 
   // CHECK-LABEL: "var_name": "unaryParity"
   // CHECK: "value": {"opcode":"^","operands":[{"sig_name":"a"}]}
@@ -384,23 +384,23 @@ hw.module @Expressions(in %a: i1, in %b: i1) {
   dbg.variable "cmpUge", %29 : i1
   dbg.variable "cmpSge", %30 : i1
 
-  // CHECK-LABEL: "var_name": "and"
+  // CHECK-LABEL: "var_name": "opAnd"
   // CHECK: "value": {"opcode":"&","operands":[{"sig_name":"a"},{"sig_name":"b"}]}
   // CHECK: "type_name": "logic"
   %31 = comb.and %a, %b : i1
-  dbg.variable "and", %31 : i1
+  dbg.variable "opAnd", %31 : i1
 
-  // CHECK-LABEL: "var_name": "or"
+  // CHECK-LABEL: "var_name": "opOr"
   // CHECK: "value": {"opcode":"|","operands":[{"sig_name":"a"},{"sig_name":"b"}]}
   // CHECK: "type_name": "logic"
   %32 = comb.or %a, %b : i1
-  dbg.variable "or", %32 : i1
+  dbg.variable "opOr", %32 : i1
 
-  // CHECK-LABEL: "var_name": "xor"
+  // CHECK-LABEL: "var_name": "opXor"
   // CHECK: "value": {"opcode":"^","operands":[{"sig_name":"a"},{"sig_name":"b"}]}
   // CHECK: "type_name": "logic"
   %33 = comb.xor %a, %b : i1
-  dbg.variable "xor", %33 : i1
+  dbg.variable "opXor", %33 : i1
 
   // CHECK-LABEL: "var_name": "concat"
   // CHECK: "value": {"opcode":"{}","operands":[{"sig_name":"a"},{"sig_name":"b"},{"sig_name":"explicitName"}]}
@@ -447,17 +447,17 @@ hw.module.extern @SingleResult(out outPort: i1) attributes {verilogName = "Custo
 
 // CHECK-LABEL: "module_name": "LegalizedNames"
 // CHECK:       "port_vars"
-// CHECK:          "var_name": "wire"
+// CHECK:          "var_name": "myWire"
 // CHECK:          "value": {"sig_name":"wire_1"}
 // CHECK:       "children"
-// CHECK:         "name": "reg"
+// CHECK:         "name": "myInst"
 // CHECK:         "hdl_obj_name": "reg_0"
 // CHECK:         "obj_name": "Dummy"
 // CHECK:         "module_name": "CustomDummy"
 hw.module @LegalizedNames() {
-  hw.instance "reg" @Dummy() -> () {hw.verilogName = "reg_0"}
+  hw.instance "myInst" @Dummy() -> () {hw.verilogName = "reg_0"}
   %false = hw.constant false
-  %wire = hw.wire %false {hw.verilogName = "wire_1"} : i1
+  %myWire = hw.wire %false {hw.verilogName = "wire_1"} : i1
 }
 hw.module.extern @Dummy() attributes {verilogName = "CustomDummy"}
 
@@ -549,3 +549,27 @@ hw.module @Issue6735_Case2(out x : i36, out y : i36 {hw.verilogName = "verilogY"
   hw.output %a, %b : i36, i36
 }
 hw.module.extern @MultipleResults(out a : i36, out b : i36)
+
+// CHECK-LABEL: "obj_name": "Issue6749"
+hw.module @Issue6749(in %a: i42) {
+  // Variables with empty names must have a non-empty name in the output.
+  // CHECK-NOT: "var_name": ""
+  dbg.variable "", %a : i42
+
+  // Uniquify duplicate variable names.
+  // CHECK: "var_name": "myVar"
+  // CHECK-NOT: "var_name": "myVar"
+  // CHECK: "var_name": "myVar_0"
+  dbg.variable "myVar", %a : i42
+  dbg.variable "myVar", %a : i42
+
+  // Uniquify Verilog keyword collisions.
+  // CHECK-NOT: "var_name": "signed"
+  // CHECK: "var_name": "signed_0"
+  dbg.variable "signed", %a : i42
+
+  // Scopes with empty names must have a non-empty name in the output.
+  // CHECK: "children": [
+  // CHECK-NOT: "name": ""
+  %scope = dbg.scope "", "SomeScope"
+}


### PR DESCRIPTION
Ensure the object and variable names emitted by the `EmitHGLDD` translation are unique and don't collide with any known Verilog keywords.

Refactor the emission code by pulling most of the shared emission state into a `GlobalState` struct that is created by the `Emitter` and is shared by each `FileEmitter`.

Move the `objectNamespace` that is used to uniquify object names into the new global emitter state, and use `sv::legalizeName` to uniquify module names instead of `Namespace`. This avoids keyword collisions. Also add a per-module `moduleNamespace` that is prepopulated with the global `objectNamespace`, and use it to uniquify variable and instance names.

Fixes #6749.