### PR TITLE
[Emit] Introduce `emit.ref` to pull ops into file bodies

### DIFF
--- a/include/circt/Dialect/Emit/CMakeLists.txt
+++ b/include/circt/Dialect/Emit/CMakeLists.txt
@@ -12,3 +12,9 @@
 add_circt_dialect(Emit emit)
 add_circt_dialect_doc(Emit emit)
 add_dependencies(circt-headers MLIREmitIncGen)
+
+set(LLVM_TARGET_DEFINITIONS EmitOpInterfaces.td)
+mlir_tablegen(EmitOpInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(EmitOpInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(CIRCTEmitOpInterfacesIncGen)
+add_dependencies(circt-headers CIRCTEmitOpInterfacesIncGen)

--- a/include/circt/Dialect/Emit/EmitOpInterfaces.h
+++ b/include/circt/Dialect/Emit/EmitOpInterfaces.h
@@ -1,0 +1,30 @@
+//===- EmitOpInterfaces.h - Declare Emit op interfaces ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the operation interfaces for the Emit dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_EMIT_EMITOPINTERFACES_H
+#define CIRCT_DIALECT_EMIT_EMITOPINTERFACES_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/OpDefinition.h"
+
+namespace circt {
+namespace emit {
+
+template <typename ConcreteType>
+class Emittable : public OpTrait::TraitBase<ConcreteType, Emittable> {};
+
+} // namespace emit
+} // namespace circt
+
+#include "circt/Dialect/Emit/EmitOpInterfaces.h.inc"
+
+#endif // CIRCT_DIALECT_EMIT_EMITOPINTERFACES_H

--- a/include/circt/Dialect/Emit/EmitOpInterfaces.td
+++ b/include/circt/Dialect/Emit/EmitOpInterfaces.td
@@ -1,0 +1,22 @@
+//===- EmitOpInterfaces.td - Operation Interfaces ----------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This describes the Emit operation interfaces and traits.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_EMIT_EMITOPINTERFACES
+#define CIRCT_DIALECT_EMIT_EMITOPINTERFACES
+
+include "mlir/IR/OpBase.td"
+
+def Emittable : NativeOpTrait<"Emittable"> {
+  let cppNamespace = "::circt::emit";
+}
+
+#endif // CIRCT_DIALECT_EMIT_EMITOPINTERFACES

--- a/include/circt/Dialect/Emit/EmitOps.td
+++ b/include/circt/Dialect/Emit/EmitOps.td
@@ -84,6 +84,23 @@ def VerbatimOp : EmitOp<"verbatim", [HasParent<"circt::emit::FileOp">]> {
   }];
 }
 
+def RefOp : EmitOp<"ref", [
+  HasParent<"circt::emit::FileOp">,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "Print a referenced SV operation inline into the file";
+  let description = [{
+    The `emit.ref` operation targets an op via a symbol, emitting its
+    contents into the file it is part of. The set of targetable
+    operations and the emission rules are defined in ExportVerilog.
+  }];
+
+  let arguments = (ins FlatSymbolRefAttr:$target);
+
+  let assemblyFormat = [{
+    $target attr-dict
+  }];
+}
 
 def FileListOp : EmitOp<"file_list", [
     Symbol,

--- a/include/circt/Dialect/HW/HWOps.h
+++ b/include/circt/Dialect/HW/HWOps.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_HW_OPS_H
 #define CIRCT_DIALECT_HW_OPS_H
 
+#include "circt/Dialect/Emit/EmitOpInterfaces.h"
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWEnums.h"
 #include "circt/Dialect/HW/HWOpInterfaces.h"

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -17,6 +17,7 @@ include "circt/Dialect/HW/HWAttributes.td"
 include "circt/Dialect/HW/HWDialect.td"
 include "circt/Dialect/HW/HWOpInterfaces.td"
 include "circt/Dialect/HW/HWTypes.td"
+include "circt/Dialect/Emit/EmitOpInterfaces.td"
 include "mlir/Interfaces/FunctionInterfaces.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/OpBase.td"
@@ -112,7 +113,8 @@ class HWModuleOpBase<string mnemonic, list<Trait> traits = []> :
 
 def HWModuleOp : HWModuleOpBase<"module",
       [IsolatedFromAbove, RegionKindInterface,
-       SingleBlockImplicitTerminator<"OutputOp">]>{
+       SingleBlockImplicitTerminator<"OutputOp">,
+       Emittable]>{
   let summary = "HW Module";
   let description = [{
     The "hw.module" operation represents a Verilog module, including a given

--- a/include/circt/Dialect/Seq/SeqPasses.td
+++ b/include/circt/Dialect/Seq/SeqPasses.td
@@ -59,7 +59,11 @@ def HWMemSimImpl : Pass<"hw-memory-sim", "ModuleOp"> {
   }];
 
   let constructor = "circt::seq::createHWMemSimImplPass()";
-  let dependentDialects = ["circt::hw::HWDialect", "circt::sv::SVDialect"];
+  let dependentDialects = [
+    "circt::emit::EmitDialect",
+    "circt::hw::HWDialect",
+    "circt::sv::SVDialect",
+  ];
 
   let options = [
     Option<"disableMemRandomization", "disable-mem-randomization", "bool", "false",

--- a/lib/Dialect/Emit/CMakeLists.txt
+++ b/lib/Dialect/Emit/CMakeLists.txt
@@ -11,6 +11,7 @@
 
 add_circt_dialect_library(CIRCTEmit
   EmitDialect.cpp
+  EmitOpInterfaces.cpp
   EmitOps.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/Emit/EmitOpInterfaces.cpp
+++ b/lib/Dialect/Emit/EmitOpInterfaces.cpp
@@ -1,0 +1,22 @@
+//===- EmitOpInterfaces.cpp - Implement the Emit op interfaces ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implement the Emit operation interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Emit/EmitOpInterfaces.h"
+#include "circt/Dialect/Emit/EmitOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+using namespace mlir;
+using namespace llvm;
+using namespace circt::seq;
+
+#include "circt/Dialect/Emit/EmitOpInterfaces.cpp.inc"

--- a/lib/Dialect/Emit/EmitOps.cpp
+++ b/lib/Dialect/Emit/EmitOps.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/Emit/EmitOps.h"
+#include "circt/Dialect/Emit/EmitOpInterfaces.h"
 
 using namespace mlir;
 using namespace circt;
@@ -45,6 +46,20 @@ void FileOp::build(OpBuilder &builder, OperationState &result,
   builder.createBlock(result.addRegion());
   if (bodyCtor)
     bodyCtor();
+}
+
+//===----------------------------------------------------------------------===//
+// RefOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult RefOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto target = getTargetAttr();
+  auto *op = symbolTable.lookupNearestSymbolFrom(getOperation(), target);
+  if (!op)
+    return emitError("invalid symbol reference: ") << target;
+  if (!op->hasTrait<emit::Emittable>())
+    return emitError("does not target an emittable op: ") << target;
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Seq/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Seq/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_dialect_library(CIRCTSeqTransforms
 
   LINK_LIBS PUBLIC
   CIRCTComb
+  CIRCTEmit
   CIRCTHW
   CIRCTSeq
   CIRCTSupport

--- a/test/Conversion/ExportVerilog/emit.mlir
+++ b/test/Conversion/ExportVerilog/emit.mlir
@@ -4,17 +4,25 @@
 
 sv.macro.decl @Macro
 
+hw.module private @SomeModule() {
+}
+
 // FILE: SimpleVerbatim
 // FILE-NEXT: WithNewlines
 // FILE-NEXT: A
 // FILE-NEXT: B
 // FILE-NEXT: WithEmptyNewlines
-// FILE: X
+// FILE-EMPTY:
+// FILE-EMPTY:
+// FILE-NEXT: X
 // FILE-NEXT: `ifdef Macro
 // FILE-NEXT:   `define Macro 1
 // FILE-NEXT: `else
 // FILE-NEXT:   `define Macro 2
 // FILE-NEXT: `endif
+// FILE-NEXT: module SomeModule();
+// FILE-NEXT: endmodule
+// FILE-EMPTY:
 // FILE-NEXT: Some Reference: Macro
 
 emit.file "some-file.sv" sym @SomeFile.sv {
@@ -27,6 +35,8 @@ emit.file "some-file.sv" sym @SomeFile.sv {
   } else {
     sv.macro.def @Macro "2"
   }
+
+  emit.ref @SomeModule
 
   sv.verbatim "Some Reference: {{0}}" {symbols = [@Macro]}
 }


### PR DESCRIPTION
This PR introduces a minimal implementation of file-to-operation references. Presently, only modules can be referenced and each module can be referenced by a single file once. As an example, the `HWMemSimImpl` pass is ported over.

Subsequent PRs will rely on this mechanism to phase out the `output_file` attribute.