### PR TITLE
[RFC] [Comb][Canonicalize] Best effort dialect attribute propagation

### DIFF
--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -1662,3 +1662,12 @@ hw.module @cantCombineOppositeNonBinCmpIntoConstant(in %tag_0: i4, in %tag_1: i4
             %opposite_xor_or, %opposite_xor_and :
             i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i4, i4
 }
+
+// https://github.com/llvm/circt/issues/6767
+// CHECK-LABEL: @Issue6767
+hw.module @Issue6767(in %arg0 : i64, out out: i32) {
+  // CHECK:  %0 = comb.extract %arg0 from 0 {custom_dialect.attr = "test"} : (i64) -> i32
+  %0 = comb.extract %arg0 from 0 : (i64) -> i42
+  %1 = comb.extract %0 from 0 {custom_dialect.attr = "test"} : (i42) -> i32
+  hw.output %1 : i32
+}


### PR DESCRIPTION
Addresses https://github.com/llvm/circt/issues/6767.
This is a first draft how a less conservative dialect attribute propagation could be implemented.

I checked the uses of `replaceOpWithNewOpAndCopyName` and found one candidate where I would personally not propagate the dialect attributes: https://github.com/llvm/circt/blob/c4038382fbbaea7b7b1abebaf4ba769d51609b11/lib/Dialect/Comb/CombFolds.cpp#L1685-L1689
It should be possible to opt-out of the implicit attribute propagation by explicitly using `Operation*` as second template parameter:
```
replaceOpWithNewOpAndCopyName<MulOp,  Operation*>(rewriter, op, op.getType(),
                                                  ArrayRef<Value>(shlOp), false);
```
Alternatively, the implementation may be changed to add a boolean template parameter to explicitly opt-in/out of the attribute propagation.