### PR TITLE
[Calyx] Fix memory import locations

### DIFF
--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -119,9 +119,9 @@ private:
               static constexpr std::string_view sCompile = "compile";
               return {sCompile};
             })
-        .Case<NotLibOp, AndLibOp, OrLibOp, XorLibOp, SubLibOp,
-              GtLibOp, LtLibOp, EqLibOp, NeqLibOp, GeLibOp, LeLibOp, LshLibOp,
-              RshLibOp, SliceLibOp, PadLibOp, MuxLibOp>(
+        .Case<NotLibOp, AndLibOp, OrLibOp, XorLibOp, SubLibOp, GtLibOp, LtLibOp,
+              EqLibOp, NeqLibOp, GeLibOp, LeLibOp, LshLibOp, RshLibOp,
+              SliceLibOp, PadLibOp, MuxLibOp>(
             [&](auto op) -> FailureOr<StringRef> {
               static constexpr std::string_view sCore = "core";
               return {sCore};

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -119,7 +119,7 @@ private:
               static constexpr std::string_view sCompile = "compile";
               return {sCompile};
             })
-        .Case<MemoryOp, NotLibOp, AndLibOp, OrLibOp, XorLibOp, SubLibOp,
+        .Case<NotLibOp, AndLibOp, OrLibOp, XorLibOp, SubLibOp,
               GtLibOp, LtLibOp, EqLibOp, NeqLibOp, GeLibOp, LeLibOp, LshLibOp,
               RshLibOp, SliceLibOp, PadLibOp, MuxLibOp>(
             [&](auto op) -> FailureOr<StringRef> {
@@ -134,8 +134,12 @@ private:
                   "binary_operators";
               return {sBinaryOperators};
             })
+        .Case<MemoryOp>([&](auto op) -> FailureOr<StringRef> {
+          static constexpr std::string_view sMemories = "memories/comb";
+          return {sMemories};
+        })
         .Case<SeqMemoryOp>([&](auto op) -> FailureOr<StringRef> {
-          static constexpr std::string_view sMemories = "memories";
+          static constexpr std::string_view sMemories = "memories/seq";
           return {sMemories};
         })
         .Default([&](auto op) {

--- a/test/Dialect/Calyx/emit-seq-memory.mlir
+++ b/test/Dialect/Calyx/emit-seq-memory.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-translate --export-calyx --split-input-file --verify-diagnostics %s | FileCheck %s --strict-whitespace
 
 module attributes {calyx.entrypoint = "main"} {
-  // CHECK: import "primitives/memories.futil";
+  // CHECK: import "primitives/memories/seq.futil";
   // CHECK-LABEL: component main<"static"=1,>(in: 32, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 32, @done done: 1) {
   calyx.component @main(%in: i32, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out: i32, %done: i1 {done}) {
     %c1_1 = hw.constant 1 : i1

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -2,6 +2,7 @@
 
 module attributes {calyx.metadata = ["location1", "location2"], calyx.entrypoint = "main"} {
 
+  // CHECK: import "primitives/memories/comb.futil";
   // CHECK: import "primitives/core.futil";
   // CHECK-LABEL: component A<"static"=1,>(in: 32, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 32, @done done: 1) {
   calyx.component @A(%in: i32, %go: i1 {go = 1}, %clk: i1 {clk = 1}, %reset: i1 {reset = 1}) -> (%out: i32, %done: i1 {done = 1}) {


### PR DESCRIPTION
Updates memory import locations to be correct for the current calyx native compiler `main`.