### PR TITLE
[FIRRTL] Use the class map in ObjectOp parser.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3981,12 +3981,12 @@ ParseResult FIRStmtParser::parseObject() {
   locationProcessor.setLoc(startTok.getLoc());
 
   // Look up the class that is being referenced.
-  auto circuit =
-      builder.getBlock()->getParentOp()->getParentOfType<CircuitOp>();
-  auto referencedClass = circuit.lookupSymbol<ClassLike>(className);
-  if (!referencedClass)
+  const auto &classMap = getConstants().classMap;
+  auto lookup = classMap.find(className);
+  if (lookup == classMap.end())
     return emitError(startTok.getLoc(), "use of undefined class name '" +
                                             className + "' in object");
+  auto referencedClass = lookup->getSecond();
   auto result = builder.create<ObjectOp>(referencedClass, id);
   return moduleContext.addSymbolEntry(id, result, startTok.getLoc());
 }


### PR DESCRIPTION
We already store a mapping from class name to ClassOp when we parse the ClassOp signatures, in case the class name is referenced in any ClassOp port types. This re-uses the same data structure when parsing an ObjectOp to a) ensure the class exists, and b) construct the ObjectOp using the ClassOp.

The previous implementation would look up the ClassOp symbol in the circuit, but this would simply scan the circuit body again and again. This change makes a significant difference for performance, on the order of 90% overall parsing time reduction for large designs with many objects.