### PR TITLE
[capi][python] Add Emit Dialect

### DIFF
--- a/include/circt-c/Dialect/Emit.h
+++ b/include/circt-c/Dialect/Emit.h
@@ -1,0 +1,24 @@
+//===- Emit.h - C interface for the Emit dialect ------------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_C_DIALECT_EMIT_H
+#define CIRCT_C_DIALECT_EMIT_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Emit, emit);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CIRCT_C_DIALECT_EMIT_H

--- a/integration_test/Bindings/Python/dialects/emit.py
+++ b/integration_test/Bindings/Python/dialects/emit.py
@@ -1,0 +1,16 @@
+# REQUIRES: bindings_python
+# RUN: %PYTHON% %s | FileCheck %s
+
+import circt
+
+from circt.dialects import emit
+from circt.ir import Context, Location, Module, InsertionPoint, IntegerAttr, IntegerType
+
+with Context() as ctx, Location.unknown():
+  circt.register_dialects(ctx)
+  m = Module.create()
+  with InsertionPoint(m.body):
+    fileOp = emit.file("foo.sv")
+    # CHECK:      emit.file
+    # CHECK-SAME:   file_name = "foo.sv"
+    print(fileOp)

--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -12,6 +12,7 @@
 #include "circt-c/Dialect/Comb.h"
 #include "circt-c/Dialect/Debug.h"
 #include "circt-c/Dialect/ESI.h"
+#include "circt-c/Dialect/Emit.h"
 #include "circt-c/Dialect/FSM.h"
 #include "circt-c/Dialect/HW.h"
 #include "circt-c/Dialect/HWArith.h"
@@ -67,6 +68,10 @@ PYBIND11_MODULE(_circt, m) {
         MlirDialectHandle debug = mlirGetDialectHandle__debug__();
         mlirDialectHandleRegisterDialect(debug, context);
         mlirDialectHandleLoadDialect(debug, context);
+
+        MlirDialectHandle emit = mlirGetDialectHandle__emit__();
+        mlirDialectHandleRegisterDialect(emit, context);
+        mlirDialectHandleLoadDialect(emit, context);
 
         MlirDialectHandle esi = mlirGetDialectHandle__esi__();
         mlirDialectHandleRegisterDialect(esi, context);

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -24,6 +24,7 @@ declare_mlir_python_extension(CIRCTBindingsPythonExtension
   EMBED_CAPI_LINK_LIBS
     CIRCTCAPIComb
     CIRCTCAPIDebug
+    CIRCTCAPIEmit
     CIRCTCAPIESI
     CIRCTCAPIExportVerilog
     CIRCTCAPIFSM
@@ -161,6 +162,14 @@ declare_mlir_dialect_python_bindings(
   SOURCES
     dialects/verif.py
   DIALECT_NAME verif)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT CIRCTBindingsPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+  TD_FILE dialects/EmitOps.td
+  SOURCES
+    dialects/emit.py
+  DIALECT_NAME emit)
 
 ################################################################################
 # Build composite binaries

--- a/lib/Bindings/Python/dialects/EmitOps.td
+++ b/lib/Bindings/Python/dialects/EmitOps.td
@@ -1,0 +1,14 @@
+//===- EmitOps.td - Entry point for Emit bindings ----------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BINDINGS_PYTHON_EMIT_OPS
+#define BINDINGS_PYTHON_EMIT_OPS
+
+include "circt/Dialect/Emit/Emit.td"
+
+#endif

--- a/lib/Bindings/Python/dialects/emit.py
+++ b/lib/Bindings/Python/dialects/emit.py
@@ -1,0 +1,5 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._emit_ops_gen import *

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_OPTIONAL_SOURCES
   CHIRRTL.cpp
   Comb.cpp
   Debug.cpp
+  Emit.cpp
   ESI.cpp
   FIRRTL.cpp
   FSM.cpp
@@ -173,4 +174,12 @@ add_mlir_public_c_api_library(CIRCTCAPILTL
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTLTL
+)
+
+add_mlir_public_c_api_library(CIRCTCAPIEmit
+  Emit.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  CIRCTEmit
 )

--- a/lib/CAPI/Dialect/Emit.cpp
+++ b/lib/CAPI/Dialect/Emit.cpp
@@ -1,0 +1,14 @@
+//===- Emit.cpp - C interface for the Emit dialect ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt-c/Dialect/Emit.h"
+#include "circt/Dialect/Emit/EmitDialect.h"
+
+#include "mlir/CAPI/Registration.h"
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Emit, emit, circt::emit::EmitDialect)


### PR DESCRIPTION
Add the emit dialect to the C-API and to Python.  This is both missing and is necessary for downstream Python tooling to not break.