### PR TITLE
[SV] Use a symbol in macro identifiers

### DIFF
--- a/include/circt/Dialect/SV/SVAttributes.td
+++ b/include/circt/Dialect/SV/SVAttributes.td
@@ -15,16 +15,20 @@ def MacroIdentAttr : AttrDef<SVDialect, "MacroIdent"> {
   let description = [{
     Represents a reference to a macro identifier.
   }];
-  let parameters = (ins "::mlir::StringAttr":$ident);
+  let parameters = (ins "::mlir::FlatSymbolRefAttr":$ident);
   let mnemonic = "macro.ident";
 
   let assemblyFormat = "$ident";
 
   let builders = [
     AttrBuilder<(ins "::llvm::StringRef":$ident), [{
-      return $_get($_ctxt, ::mlir::StringAttr::get($_ctxt, ident));
+      return get(::mlir::StringAttr::get($_ctxt, ident));
+    }]>,
+    AttrBuilderWithInferredContext<(ins "::mlir::StringAttr":$ident), [{
+      return $_get(ident.getContext(), ::mlir::FlatSymbolRefAttr::get(ident));
     }]>,
   ];
+
   let extraClassDeclaration = [{
     ::llvm::StringRef getName() { return getIdent().getValue(); }
   }];

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -39,8 +39,13 @@ def OrderedOutputOp : SVOp<"ordered", [SingleBlock, NoTerminator, NoRegionArgume
   ];
 }
 
-def IfDefOp : SVOp<"ifdef", [SingleBlock, NoTerminator, NoRegionArguments,
-                             NonProceduralOp]> {
+def IfDefOp : SVOp<"ifdef", [
+    SingleBlock,
+    NoTerminator,
+    NoRegionArguments,
+    NonProceduralOp,
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
   let summary = "'ifdef MACRO' block";
 
   let description = [{
@@ -65,6 +70,9 @@ def IfDefOp : SVOp<"ifdef", [SingleBlock, NoTerminator, NoRegionArguments,
     OpBuilder<(ins "StringAttr":$cond,
                       CArg<"std::function<void()>", "{}">:$thenCtor,
                       CArg<"std::function<void()>", "{}">:$elseCtor)>,
+    OpBuilder<(ins "FlatSymbolRefAttr":$cond,
+                      CArg<"std::function<void()>", "{}">:$thenCtor,
+                      CArg<"std::function<void()>", "{}">:$elseCtor)>,
     OpBuilder<(ins "MacroIdentAttr":$cond,
                       CArg<"std::function<void()>", "{}">:$thenCtor,
                       CArg<"std::function<void()>", "{}">:$elseCtor)>
@@ -86,9 +94,14 @@ def IfDefOp : SVOp<"ifdef", [SingleBlock, NoTerminator, NoRegionArguments,
   }];
 }
 
-def IfDefProceduralOp
-  : SVOp<"ifdef.procedural", [SingleBlock, NoTerminator, NoRegionArguments,
-                              ProceduralRegion, ProceduralOp]> {
+def IfDefProceduralOp : SVOp<"ifdef.procedural", [
+      SingleBlock,
+      NoTerminator,
+      NoRegionArguments,
+      ProceduralRegion,
+      ProceduralOp,
+      DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
   let summary = "'ifdef MACRO' block for procedural regions";
 
   let description = [{
@@ -111,6 +124,9 @@ def IfDefProceduralOp
                       CArg<"std::function<void()>", "{}">:$thenCtor,
                       CArg<"std::function<void()>", "{}">:$elseCtor)>,
     OpBuilder<(ins "StringAttr":$cond,
+                      CArg<"std::function<void()>", "{}">:$thenCtor,
+                      CArg<"std::function<void()>", "{}">:$elseCtor)>,
+    OpBuilder<(ins "FlatSymbolRefAttr":$cond,
                       CArg<"std::function<void()>", "{}">:$thenCtor,
                       CArg<"std::function<void()>", "{}">:$elseCtor)>,
     OpBuilder<(ins "MacroIdentAttr":$cond,
@@ -811,6 +827,14 @@ def MacroDeclOp : SVOp<"macro.decl", [Symbol]> {
                        OptionalAttr<StrArrayAttr>:$args,
                        OptionalAttr<StrAttr>:$verilogName);
   let results = (outs);
+
+  let builders = [
+    OpBuilder<(ins "StringRef":$name), [{
+      return build($_builder, $_state,
+                   ::mlir::StringAttr::get($_builder.getContext(), name),
+                   ::mlir::ArrayAttr{}, ::mlir::StringAttr{});
+    }]>
+  ];
 
   let assemblyFormat = [{
     $sym_name (`[` $verilogName^ `]`)? (`(` $args^ `)`)?  attr-dict

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -91,6 +91,18 @@ static Operation *lookupSymbolInNested(Operation *symbolTableOp,
   return nullptr;
 }
 
+/// Verifies symbols referenced by macro identifiers.
+static LogicalResult
+verifyMacroIdentSymbolUses(Operation *op, FlatSymbolRefAttr attr,
+                           SymbolTableCollection &symbolTable) {
+  auto *refOp = symbolTable.lookupNearestSymbolFrom(op, attr);
+  if (!refOp)
+    return op->emitError("references an undefined symbol: ") << attr;
+  if (!isa<MacroDeclOp>(refOp))
+    return op->emitError("must reference a macro declaration");
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // VerbatimExprOp
 //===----------------------------------------------------------------------===//
@@ -162,31 +174,21 @@ MacroDeclOp MacroDefOp::getReferencedMacro(const hw::HWSymbolCache *cache) {
   return ::getReferencedMacro(cache, *this, getMacroNameAttr());
 }
 
-/// Ensure that the symbol being instantiated exists and is a MacroDeclOp.
-static LogicalResult verifyMacroSymbolUse(Operation *op, StringAttr name,
-                                          SymbolTableCollection &symbolTable) {
-  auto macro = symbolTable.lookupNearestSymbolFrom<MacroDeclOp>(op, name);
-  if (!macro)
-    return op->emitError("Referenced macro doesn't exist ") << name;
-
-  return success();
-}
-
 /// Ensure that the symbol being instantiated exists and is a MacroDefOp.
 LogicalResult
 MacroRefExprOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyMacroSymbolUse(*this, getMacroNameAttr().getAttr(), symbolTable);
+  return verifyMacroIdentSymbolUses(*this, getMacroNameAttr(), symbolTable);
 }
 
 /// Ensure that the symbol being instantiated exists and is a MacroDefOp.
 LogicalResult
 MacroRefExprSEOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyMacroSymbolUse(*this, getMacroNameAttr().getAttr(), symbolTable);
+  return verifyMacroIdentSymbolUses(*this, getMacroNameAttr(), symbolTable);
 }
 
 /// Ensure that the symbol being instantiated exists and is a MacroDefOp.
 LogicalResult MacroDefOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyMacroSymbolUse(*this, getMacroNameAttr().getAttr(), symbolTable);
+  return verifyMacroIdentSymbolUses(*this, getMacroNameAttr(), symbolTable);
 }
 
 //===----------------------------------------------------------------------===//
@@ -357,6 +359,13 @@ void IfDefOp::build(OpBuilder &builder, OperationState &result, StringRef cond,
 void IfDefOp::build(OpBuilder &builder, OperationState &result, StringAttr cond,
                     std::function<void()> thenCtor,
                     std::function<void()> elseCtor) {
+  build(builder, result, FlatSymbolRefAttr::get(builder.getContext(), cond),
+        std::move(thenCtor), std::move(elseCtor));
+}
+
+void IfDefOp::build(OpBuilder &builder, OperationState &result,
+                    FlatSymbolRefAttr cond, std::function<void()> thenCtor,
+                    std::function<void()> elseCtor) {
   build(builder, result, MacroIdentAttr::get(builder.getContext(), cond),
         std::move(thenCtor), std::move(elseCtor));
 }
@@ -378,6 +387,11 @@ void IfDefOp::build(OpBuilder &builder, OperationState &result,
     builder.createBlock(elseRegion);
     elseCtor();
   }
+}
+
+LogicalResult IfDefOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  // TODO(nandor): Pending fixes to the pipeline, verify references.
+  return success();
 }
 
 // If both thenRegion and elseRegion are empty, erase op.
@@ -411,6 +425,14 @@ void IfDefProceduralOp::build(OpBuilder &builder, OperationState &result,
 void IfDefProceduralOp::build(OpBuilder &builder, OperationState &result,
                               StringAttr cond, std::function<void()> thenCtor,
                               std::function<void()> elseCtor) {
+  build(builder, result, FlatSymbolRefAttr::get(builder.getContext(), cond),
+        std::move(thenCtor), std::move(elseCtor));
+}
+
+void IfDefProceduralOp::build(OpBuilder &builder, OperationState &result,
+                              FlatSymbolRefAttr cond,
+                              std::function<void()> thenCtor,
+                              std::function<void()> elseCtor) {
   build(builder, result, MacroIdentAttr::get(builder.getContext(), cond),
         std::move(thenCtor), std::move(elseCtor));
 }
@@ -438,6 +460,12 @@ void IfDefProceduralOp::build(OpBuilder &builder, OperationState &result,
 LogicalResult IfDefProceduralOp::canonicalize(IfDefProceduralOp op,
                                               PatternRewriter &rewriter) {
   return canonicalizeIfDefLike(op, rewriter);
+}
+
+LogicalResult
+IfDefProceduralOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  // TODO(nandor): Pending fixes to the pipeline, verify references.
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ExportVerilog/decl-align.mlir
+++ b/test/Conversion/ExportVerilog/decl-align.mlir
@@ -6,7 +6,7 @@ hw.module @Decl() {
   %x = sv.wire : !hw.inout<i4>
   // CHECK: wire       y;
   %y = sv.wire : !hw.inout<i1>
-  sv.ifdef "foo" {
+  sv.ifdef @foo {
     // CHECK: wire [11:0][9:0][3:0] w;
     %w = sv.wire : !hw.inout<array<12 x array<10xi4>>>
   }

--- a/test/Conversion/ExportVerilog/disallow-local-vars.mlir
+++ b/test/Conversion/ExportVerilog/disallow-local-vars.mlir
@@ -10,7 +10,7 @@ hw.module @side_effect_expr(in %clock: i1, out a: i1, out a2: i1) {
 
   // CHECK: `ifdef FOO_MACRO
   // DISALLOW: `ifdef FOO_MACRO
-  sv.ifdef "FOO_MACRO" {
+  sv.ifdef @FOO_MACRO {
     // DISALLOW: logic logicOp;
     // DISALLOW: {{^    }}reg   [[SE_REG:[_A-Za-z0-9]+]];
 
@@ -180,7 +180,7 @@ hw.module @ReadInoutAggregate(in %clock: i1) {
 // DISALLOW-NEXT:     $error("error")
 
 hw.module @DefinedInDifferentBlock(in %a: i1, in %b: i1) {
-  sv.ifdef "DEF" {
+  sv.ifdef @DEF {
     %0 = comb.icmp eq %a, %b : i1
     sv.initial {
       sv.if %0 {

--- a/test/Conversion/ExportVerilog/emit.mlir
+++ b/test/Conversion/ExportVerilog/emit.mlir
@@ -30,7 +30,7 @@ emit.file "some-file.sv" sym @SomeFile.sv {
   emit.verbatim "WithNewlines\nA\nB\n"
   emit.verbatim "WithEmptyNewlines\n\n\nX"
 
-  sv.ifdef "Macro" {
+  sv.ifdef @Macro {
     sv.macro.def @Macro "1"
   } else {
     sv.macro.def @Macro "2"

--- a/test/Conversion/ExportVerilog/hw-lower-instance-choices.mlir
+++ b/test/Conversion/ExportVerilog/hw-lower-instance-choices.mlir
@@ -16,7 +16,7 @@ hw.module private @TargetDefault(in %a: i32, out b: i32) {
 }
 
 hw.module public @top(in %a: i32, out b: i32, out d: i32) {
-  // CHECK:               sv.ifdef  "__circt_choice_top_inst1" {
+  // CHECK:               sv.ifdef @__circt_choice_top_inst1 {
   // CHECK-NEXT:          } else {
   // CHECK-NEXT{LITERAL}:   sv.macro.def @__circt_choice_top_inst1 "{{0}}"([@TargetDefault])
   // CHECK-NEXT:          }
@@ -24,7 +24,7 @@ hw.module public @top(in %a: i32, out b: i32, out d: i32) {
   // CHECK-SAME:          {hw.choiceTarget = @__circt_choice_top_inst1}
   %b = hw.instance_choice "inst1" sym @inst1 option "Perf" @TargetDefault or @TargetA if "A" or @TargetB if "B"(a: %a: i32) -> (b: i32)
 
-  // CHECK:               sv.ifdef  "__circt_choice_top_inst2" {
+  // CHECK:               sv.ifdef @__circt_choice_top_inst2 {
   // CHECK-NEXT:          } else {
   // CHECK-NEXT{LITERAL}:   sv.macro.def @__circt_choice_top_inst2 "{{0}}"([@TargetB])
   // CHECK-NEXT:          }

--- a/test/Conversion/ExportVerilog/max-terms.mlir
+++ b/test/Conversion/ExportVerilog/max-terms.mlir
@@ -6,7 +6,7 @@ hw.module @large_use_in_procedural(in %clock: i1, in %a: i1) {
 
   // CHECK: always
   sv.always {
-    sv.ifdef.procedural "FOO" {
+    sv.ifdef.procedural @FOO {
       // This expression should be hoisted and spilled.
       // If there is a namehint, we should use the name.
       %1 = comb.add %a, %a, %a, %a, %a {sv.namehint = "long_concat"}: i1
@@ -67,7 +67,7 @@ hw.module @dont_spill_to_procedural_regions(in %z: i10) {
   // CHECK-NEXT: end // initial
   sv.initial {
     %x = sv.read_inout %r2: !hw.inout<i10>
-    sv.ifdef.procedural "BAR" {
+    sv.ifdef.procedural @BAR {
       %2 = comb.add %x, %x, %x, %x, %x : i10
       %3 = comb.icmp eq %2, %z: i10
       sv.passign %r1, %3: i1

--- a/test/Conversion/ExportVerilog/name-legalize.mlir
+++ b/test/Conversion/ExportVerilog/name-legalize.mlir
@@ -20,7 +20,7 @@ hw.module @parametersNameConflict<p2: i42 = 17, wire: i1>(in %p1: i8) {
   %myWire = sv.wire : !hw.inout<i1>
 
   // CHECK: `ifdef SOMEMACRO
-  sv.ifdef "SOMEMACRO" {
+  sv.ifdef @SOMEMACRO {
     // CHECK: localparam local_0 = wire_0;
     %local = sv.localparam { value = #hw.param.decl.ref<"wire">: i1 } : i1
 
@@ -53,7 +53,7 @@ hw.module @useParametersNameConflict(in %xxx: i8) {
   hw.instance "inst" @parametersNameConflict<p2: i42 = 27, wire: i1 = 0>(p1: %xxx: i8) -> ()
 
   // CHECK: `ifdef SOMEMACRO
-  sv.ifdef "SOMEMACRO" {
+  sv.ifdef @SOMEMACRO {
     // CHECK: reg [3:0] xxx_0;
     %0 = sv.reg name "xxx" : !hw.inout<i4>
   }

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -274,7 +274,7 @@ sv.macro.decl @TEST_COND
 // CHECK-NEXT:    `define TEST_COND 1
 // CHECK-NEXT:  `endif // TEST_COND_
 hw.module @TestCond() {
-  sv.ifdef "TEST_COND_" {
+  sv.ifdef @TEST_COND_ {
    sv.macro.def @TEST_COND "TEST_COND_"
   } else {
    sv.macro.def @TEST_COND "1"

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -35,7 +35,7 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
 
     sv.bpassign %logic_op_procedural, %val: i8
   // CHECK-NEXT:   `ifndef SYNTHESIS
-    sv.ifdef.procedural "SYNTHESIS" {
+    sv.ifdef.procedural @SYNTHESIS {
     } else {
   // CHECK-NEXT:     if ((`PRINTF_COND_) & 1'bx & 1'bz & 1'bz & cond & forceWire)
       %tmp = sv.macro.ref @PRINTF_COND_() : () -> i1
@@ -294,7 +294,7 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
     // CHECK-NEXT: wire42 = `THING;
     sv.bpassign %wire42, %thing : i42
 
-    sv.ifdef.procedural "FOO" {
+    sv.ifdef.procedural @FOO {
       // CHECK-NEXT: `ifdef FOO
       %c1 = sv.verbatim.expr "\"THING\"" : () -> i1
       sv.fwrite %fd, "%d" (%c1) : i1
@@ -428,7 +428,7 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
     } // CHECK-NEXT: endcase
   }// CHECK-NEXT:   {{end // initial$}}
 
-  sv.ifdef "VERILATOR"  {          // CHECK-NEXT: `ifdef VERILATOR
+  sv.ifdef @VERILATOR  {           // CHECK-NEXT: `ifdef VERILATOR
     sv.verbatim "`define Thing2"   // CHECK-NEXT:   `define Thing2
   } else  {                        // CHECK-NEXT: `else
     sv.verbatim "`define Thing1"   // CHECK-NEXT:   `define Thing1
@@ -440,7 +440,7 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
   sv.verbatim "`define STUFF \"{{0}} ({{1}})\"" (%wire42, %add) : !hw.inout<i42>, i8
 
   // CHECK-NEXT: `ifdef FOO
-  sv.ifdef "FOO" {
+  sv.ifdef @FOO {
     %c1 = sv.verbatim.expr "\"THING\"" : () -> i1
 
     // CHECK-NEXT: initial begin
@@ -536,12 +536,12 @@ hw.module @reg_1(in %in4: i4, in %in8: i8, out a : i3, out b : i5) {
 }
 
 // CHECK-LABEL: module regWithInit(
-// CHECK:     reg        reg1 = 1'h0; 
+// CHECK:     reg        reg1 = 1'h0;
 // CHECK:     reg [31:0] reg2 = 32'(arg + arg);
 hw.module @regWithInit(in %arg : i32) {
   %c0_i1 = hw.constant 0 : i1
   %reg1 = sv.reg init %c0_i1 : !hw.inout<i1>
-  
+
   %init = comb.add %arg, %arg : i32
   %reg2 = sv.reg init %init : !hw.inout<i32>
 }
@@ -816,7 +816,7 @@ hw.module @issue720ifdef(in %clock: i1, in %arg1: i1, in %arg2: i1, in %arg3: i1
     }
 
     // CHECK:    `ifdef FUN_AND_GAMES
-     sv.ifdef.procedural "FUN_AND_GAMES" {
+     sv.ifdef.procedural @FUN_AND_GAMES {
       // This forces a common subexpression to be output out-of-line
       // CHECK:      _GEN = arg1 & arg2;
       // CHECK:      if (_GEN)
@@ -874,7 +874,7 @@ hw.module @issue728ifdef(in %clock: i1, in %asdfasdfasdfasdfafa: i1, in %gasfdas
   // CHECK-NEXT: end // always @(posedge)
   sv.always posedge %clock  {
      sv.fwrite %fd, "force output"
-     sv.ifdef.procedural "FUN_AND_GAMES" {
+     sv.ifdef.procedural @FUN_AND_GAMES {
        %cond = comb.and %asdfasdfasdfasdfafa, %gasfdasafwjhijjafija, %asdfasdfasdfasdfafa, %gasfdasafwjhijjafija, %asdfasdfasdfasdfafa, %gasfdasafwjhijjafija : i1
        sv.if %cond  {
          sv.fwrite %fd, "this cond is split"
@@ -938,7 +938,7 @@ hw.module @ifdef_beginend(in %clock: i1, in %cond: i1, in %val: i8) {
   // CHECK: always @(posedge clock) begin
   sv.always posedge %clock  {
     // CHECK-NEXT: `ifndef SYNTHESIS
-    sv.ifdef.procedural "SYNTHESIS"  {
+    sv.ifdef.procedural @SYNTHESIS  {
     } // CHECK-NEXT: `endif
   } // CHECK-NEXT: end
 } // CHECK-NEXT: endmodule
@@ -1160,7 +1160,7 @@ hw.module @InlineAutomaticLogicInit(in %a : i42, in %b: i42, in %really_really_l
     // CHECK: regValue = 42'([[GEN_1]] + b);
 
     // CHECK: `ifdef FOO
-    sv.ifdef.procedural "FOO" {
+    sv.ifdef.procedural @FOO {
       // CHECK: [[GEN_2]] = 42'(a + a);
       // tmp is multi-use so it needs a temporary, but cannot be emitted inline
       // because it is in an ifdef.
@@ -1215,8 +1215,8 @@ hw.module @InlineAutomaticLogicInit(in %a : i42, in %b: i42, in %really_really_l
     sv.bpassign %regValue, %manyThing : i42
 
     // CHECK: `ifdef FOO
-    sv.ifdef.procedural "FOO" {
-      sv.ifdef.procedural "BAR" {
+    sv.ifdef.procedural @FOO {
+      sv.ifdef.procedural @BAR {
         // Check that the temporary is inserted at the right level, not at the
         // level of the #ifdef.
         %manyMixed = comb.xor %thing, %thing, %thing, %thing, %thing, %thing,
@@ -1551,7 +1551,7 @@ hw.module @ProhibitReuseOfExistingInOut(in %a: i1, out out1: i1) {
   // CHECK-NEXT: assign out1 = [[GEN]];
   %0 = comb.or %a, %a : i1
   %mywire = sv.wire  : !hw.inout<i1>
-  sv.ifdef "FOO" {
+  sv.ifdef @FOO {
     sv.assign %mywire, %0 : i1
   }
   hw.output %0 : i1
@@ -1659,13 +1659,13 @@ hw.module @IndexPartSelect(out a : i3) {
 
 // CHECK-LABEL: module ConditionalComments(
 hw.module @ConditionalComments() {
-  sv.ifdef "FOO"  {             // CHECK-NEXT: `ifdef FOO
+  sv.ifdef @FOO  {             // CHECK-NEXT: `ifdef FOO
     sv.verbatim "`define FOO_A" // CHECK-NEXT:   `define FOO_A
   } else  {                     // CHECK-NEXT: `else  // FOO
     sv.verbatim "`define FOO_B" // CHECK-NEXT:   `define FOO_B
   }                             // CHECK-NEXT: `endif // FOO
 
-  sv.ifdef "BAR"  {             // CHECK-NEXT: `ifndef BAR
+  sv.ifdef @BAR  {             // CHECK-NEXT: `ifndef BAR
   } else  {
     sv.verbatim "`define X"     // CHECK-NEXT:   `define X
   }                             // CHECK-NEXT: `endif // not def BAR

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -31,10 +31,10 @@ hw.module @no_ports() {
 // CHECK-NEXT:    output [1:0]  orvout
 // CHECK-NEXT:  );
 
-hw.module @Expressions(in %in4: i4, in %clock: i1, 
-  out out1a: i1, out out1b: i1, out out1c: i1, 
+hw.module @Expressions(in %in4: i4, in %clock: i1,
+  out out1a: i1, out out1b: i1, out out1c: i1,
   out out1d: i1, out out1e: i1, out out1f: i1, out out1g: i1,
-   out out4: i4, out out4s: i4, out out16: i16, out out16s: i16, 
+   out out4: i4, out out4s: i4, out out16: i16, out out16s: i16,
    out sext17: i17, out orvout: i2) {
   %c1_i4 = hw.constant 1 : i4
   %c2_i4 = hw.constant 2 : i4
@@ -250,9 +250,9 @@ hw.module @Precedence(in %a: i4, in %b: i4, in %c: i4, out out1: i1, out out: i1
 
 // CHECK-LABEL: module CmpSign(
 hw.module @CmpSign(in %a: i4, in %b: i4, in %c: i4, in %d: i4,
-  out o0: i1, out o1: i1, out o2: i1, out o3: i1, 
+  out o0: i1, out o1: i1, out o2: i1, out o3: i1,
   out o4: i1, out o5: i1, out o6: i1, out o7: i1,
-  out o8: i1, out o9: i1, out o10: i1, out o11: i1, 
+  out o8: i1, out o9: i1, out o10: i1, out o11: i1,
   out o12: i1, out o13: i1, out o14: i1, out o15: i1) {
   // CHECK: assign o0 = a < b;
   %0 = comb.icmp ult %a, %b : i4
@@ -407,14 +407,14 @@ hw.module @InlineDeclAssignment(in %a: i1) {
 hw.module @ordered_region(in %a: i1) {
   sv.ordered {
     // CHECK-NEXT: `ifdef foo
-    sv.ifdef "foo" {
+    sv.ifdef @foo {
       // CHECK-NEXT: wire_0 = a;
       %wire = sv.wire : !hw.inout<i1>
       sv.assign %wire, %a : i1
     }
     // CHECK-NEXT: `endif
     // CHECK-NEXT: `ifdef bar
-    sv.ifdef "bar" {
+    sv.ifdef @bar {
       // CHECK-NEXT: wire_1 = a;
       %wire = sv.wire : !hw.inout<i1>
       sv.assign %wire, %a : i1
@@ -525,7 +525,7 @@ hw.module @Stop(in %clock: i1, in %reset: i1) {
   // CHECK:   `endif
   // CHECK: end // always @(posedge)
   sv.always posedge %clock  {
-    sv.ifdef.procedural "SYNTHESIS"  {
+    sv.ifdef.procedural @SYNTHESIS {
     } else  {
       %0 = sv.verbatim.expr "`STOP_COND_" : () -> i1
       %1 = comb.and %0, %reset : i1

--- a/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
+++ b/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
@@ -13,7 +13,7 @@ firrtl.circuit "ifElseFatalToSVA" {
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor bin %enable, [[TRUE]]
     // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
     // CHECK-NEXT: sv.assert.concurrent posedge [[CLK]], [[TMP2]] message "assert0"
-    // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
+    // CHECK-NEXT: sv.ifdef @USE_PROPERTY_AS_CONSTRAINT {
     // CHECK-NEXT:   sv.assume.concurrent posedge [[CLK]], [[TMP2]]
     // CHECK-NEXT: }
   }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -4,7 +4,7 @@
 // CHECK-NOT: firrtl.circuit
 
 // We should get a large header boilerplate.
-// CHECK:   sv.ifdef "PRINTF_COND" {
+// CHECK:   sv.ifdef @PRINTF_COND {
 // CHECK-NEXT:   sv.macro.def @PRINTF_COND_ "(`PRINTF_COND)"
 // CHECK-NEXT:  } else  {
 firrtl.circuit "Simple" {
@@ -90,7 +90,7 @@ firrtl.circuit "Simple" {
   }
 
   // CHECK-LABEL: hw.module private @PortMadness(
-  // CHECK: in %inA : i4, in %inB : i4, in %inC : i4, 
+  // CHECK: in %inA : i4, in %inB : i4, in %inC : i4,
   // CHECK: out outA : i4, out outB : i4, out outC : i4, out outD : i4, in %inE : i3, out outE : i4) {
   firrtl.module private @PortMadness(in %inA: !firrtl.uint<4>,
                              in %inB: !firrtl.uint<4>,

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -6,25 +6,25 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 "sifive.enterprise.firrtl.ExtractAssertionsAnnotation", directory = "dir3",  filename = "./dir3/filename3" }]}
 {
   // Headers
-  // CHECK:      sv.ifdef  "PRINTF_COND_" {
+  // CHECK:      sv.ifdef @PRINTF_COND_ {
   // CHECK-NEXT: } else {
-  // CHECK-NEXT:   sv.ifdef  "PRINTF_COND" {
+  // CHECK-NEXT:   sv.ifdef @PRINTF_COND {
   // CHECK-NEXT:     sv.macro.def @PRINTF_COND_ "(`PRINTF_COND)"
   // CHECK-NEXT:   } else {
   // CHECK-NEXT:     sv.macro.def @PRINTF_COND_ "1"
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
-  // CHECK:      sv.ifdef  "ASSERT_VERBOSE_COND_" {
+  // CHECK:      sv.ifdef @ASSERT_VERBOSE_COND_ {
   // CHECK-NEXT: } else {
-  // CHECK-NEXT:   sv.ifdef  "ASSERT_VERBOSE_COND" {
+  // CHECK-NEXT:   sv.ifdef @ASSERT_VERBOSE_COND {
   // CHECK-NEXT:     sv.macro.def @ASSERT_VERBOSE_COND_ "(`ASSERT_VERBOSE_COND)"
   // CHECK-NEXT:   } else {
   // CHECK-NEXT:     sv.macro.def @ASSERT_VERBOSE_COND_ "1"
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
-  // CHECK:      sv.ifdef  "STOP_COND_" {
+  // CHECK:      sv.ifdef @STOP_COND_ {
   // CHECK-NEXT: } else {
-  // CHECK-NEXT:   sv.ifdef  "STOP_COND" {
+  // CHECK-NEXT:   sv.ifdef @STOP_COND {
   // CHECK-NEXT:     sv.macro.def @STOP_COND_ "(`STOP_COND)"
   // CHECK-NEXT:   } else {
   // CHECK-NEXT:     sv.macro.def @STOP_COND_ "1"
@@ -322,7 +322,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: [[CLOCK:%.+]] = seq.from_clock %clock
     // CHECK: [[ADD:%.+]] = comb.add
 
-    // CHECK:      sv.ifdef "SYNTHESIS" {
+    // CHECK:      sv.ifdef @SYNTHESIS {
     // CHECK-NEXT: } else  {
     // CHECK-NEXT:   sv.always posedge [[CLOCK]] {
     // CHECK-NEXT:     %PRINTF_COND_ = sv.macro.ref @PRINTF_COND_() : () -> i1
@@ -410,7 +410,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: [[TMP5:%.+]] = comb.xor bin %aEn, [[TRUE]]
     // CHECK-NEXT: [[TMP6:%.+]] = comb.or bin [[TMP5]], %aCond
     // CHECK-NEXT: sv.assert.concurrent posedge [[CLOCK]], [[TMP6]] message "assert0"([[SAMPLED]]) : i42
-    // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
+    // CHECK-NEXT: sv.ifdef @USE_PROPERTY_AS_CONSTRAINT {
     // CHECK-NEXT:   sv.assume.concurrent posedge [[CLOCK]], [[TMP2]]
     // CHECK-NEXT:   sv.assume.concurrent posedge [[CLOCK]], [[TMP4]] label "assume__assert_0"
     // CHECK-NEXT:   sv.assume.concurrent posedge [[CLOCK]], [[TMP6]]
@@ -487,13 +487,13 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.cover %clock, %cond, %enable, "cover0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, guards = ["HELLO", "WORLD"]}
 
     // CHECK-NEXT: [[CLOCK:%.+]] = seq.from_clock
-    // CHECK-NEXT: sv.ifdef "HELLO" {
-    // CHECK-NEXT:   sv.ifdef "WORLD" {
+    // CHECK-NEXT: sv.ifdef @HELLO {
+    // CHECK-NEXT:   sv.ifdef @WORLD {
     // CHECK-NEXT:     [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT:     [[TMP1:%.+]] = comb.xor bin %enable, [[TRUE]]
     // CHECK-NEXT:     [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
     // CHECK-NEXT:     sv.assert.concurrent posedge [[CLOCK]], [[TMP2]] message "assert0"
-    // CHECK-NEXT:     sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
+    // CHECK-NEXT:     sv.ifdef @USE_PROPERTY_AS_CONSTRAINT {
     // CHECK-NEXT:       sv.assume.concurrent posedge [[CLOCK]], [[TMP2]]
     // CHECK-NEXT:     }
     // CHECK-NEXT:     [[TRUE:%.+]] = hw.constant true
@@ -522,14 +522,14 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor bin %enable, [[TRUE]]
     // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
     // CHECK-NEXT: sv.assert.concurrent posedge [[CLOCK]], [[TMP2]] message "assert0"
-    // CHECK-NEXT: sv.ifdef "USE_PROPERTY_AS_CONSTRAINT" {
+    // CHECK-NEXT: sv.ifdef @USE_PROPERTY_AS_CONSTRAINT {
     // CHECK-NEXT:   sv.assume.concurrent posedge [[CLOCK]], [[TMP2]]
     // CHECK-NEXT: }
     firrtl.assert %clock, %cond, %enable, "assert1 %d, %d"(%value, %i0) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<0> {isConcurrent = true, format = "ifElseFatal"}
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor bin %cond, [[TRUE]]
     // CHECK-NEXT: [[TMP2:%.+]] = comb.and bin %enable, [[TMP1]]
-    // CHECK-NEXT: sv.ifdef "SYNTHESIS" {
+    // CHECK-NEXT: sv.ifdef @SYNTHESIS {
     // CHECK-NEXT: } else {
     // CHECK-NEXT:   sv.always posedge [[CLOCK]] {
     // CHECK-NEXT:     sv.if [[TMP2]] {
@@ -619,7 +619,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:   %0 = sv.read_inout %c1 : !hw.inout<i1>
   // CHECK-NEXT:   %1 = sv.read_inout %b1 : !hw.inout<i1>
   // CHECK-NEXT:   %2 = sv.read_inout %a1 : !hw.inout<i1>
-  // CHECK-NEXT:   sv.ifdef "SYNTHESIS"  {
+  // CHECK-NEXT:   sv.ifdef @SYNTHESIS {
   // CHECK-NEXT:     sv.assign %a1, %1 : i1
   // CHECK-NEXT:     sv.assign %a1, %0 : i1
   // CHECK-NEXT:     sv.assign %b1, %2 : i1
@@ -627,7 +627,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:     sv.assign %c1, %2 : i1
   // CHECK-NEXT:     sv.assign %c1, %1 : i1
   // CHECK-NEXT:    } else {
-  // CHECK-NEXT:     sv.ifdef "verilator" {
+  // CHECK-NEXT:     sv.ifdef @verilator {
   // CHECK-NEXT:       sv.verbatim "`error \22Verilator does not support alias and thus cannot arbitrarily connect bidirectional wires and ports\22"
   // CHECK-NEXT:     } else {
   // CHECK-NEXT:       sv.alias %a1, %b1, %c1 : !hw.inout<i1>
@@ -726,11 +726,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: %1 = sv.read_inout %.invalid_analog : !hw.inout<i1>
     %0 = firrtl.invalidvalue : !firrtl.analog<1>
 
-    // CHECK-NEXT: sv.ifdef "SYNTHESIS"  {
+    // CHECK-NEXT: sv.ifdef @SYNTHESIS {
     // CHECK-NEXT:   sv.assign %a, %1 : i1
     // CHECK-NEXT:   sv.assign %.invalid_analog, %0 : i1
     // CHECK-NEXT: } else {
-    // CHECK-NEXT:   sv.ifdef "verilator" {
+    // CHECK-NEXT:   sv.ifdef @verilator {
     // CHECK-NEXT:     sv.verbatim "`error \22Verilator does not support alias and thus cannot arbitrarily connect bidirectional wires and ports\22"
     // CHECK-NEXT:   } else {
     // CHECK-NEXT:     sv.alias %a, %.invalid_analog : !hw.inout<i1>, !hw.inout<i1>
@@ -1331,7 +1331,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:  %[[XMR2:.+]] = sv.xmr.ref @xmrPath : !hw.inout<i4>
   // CHECK-NEXT:  %[[XMR3:.+]] = sv.xmr.ref @xmrPath : !hw.inout<i4>
   // CHECK-NEXT:  %[[XMR4:.+]] = sv.xmr.ref @xmrPath : !hw.inout<i4>
-  // CHECK-NEXT:  sv.ifdef  "SYNTHESIS" {
+  // CHECK-NEXT:  sv.ifdef @SYNTHESIS {
   // CHECK-NEXT:  } else {
   // CHECK-NEXT:    sv.always posedge [[CLOCK]] {
   // CHECK-NEXT:      sv.if %c {

--- a/test/Conversion/SimToSV/plusargs.mlir
+++ b/test/Conversion/SimToSV/plusargs.mlir
@@ -18,7 +18,7 @@ hw.module @plusargs_test(out test: i1) {
 hw.module @plusargs_value(out test: i1, out value: i5) {
   // CHECK-NEXT: [[BAR_VALUE_DECL:%.*]] = sv.reg : !hw.inout<i5>
   // CHECK-NEXT: [[BAR_FOUND_DECL:%.*]] = sv.reg : !hw.inout<i1>
-  // CHECK-NEXT: sv.ifdef "SYNTHESIS" {
+  // CHECK-NEXT: sv.ifdef @SYNTHESIS {
   // CHECK-NEXT:   %false = hw.constant false
   // CHECK-NEXT:   %z_i5 = sv.constantZ : i5
   // CHECK-NEXT:   sv.assign [[BAR_VALUE_DECL]], %z_i5

--- a/test/Conversion/SimToSV/stop.mlir
+++ b/test/Conversion/SimToSV/stop.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: hw.module @finish
 hw.module @finish(in %clock : !seq.clock, in %cond : i1) {
   // CHECK:      [[CLK_SV:%.+]] = seq.from_clock %clock
-  // CHECK-NEXT: sv.ifdef  "SYNTHESIS" {
+  // CHECK-NEXT: sv.ifdef @SYNTHESIS {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.always posedge [[CLK_SV]] {
   // CHECK-NEXT:     sv.if %cond {
@@ -17,7 +17,7 @@ hw.module @finish(in %clock : !seq.clock, in %cond : i1) {
 // CHECK-LABEL: hw.module @fatal
 hw.module @fatal(in %clock : !seq.clock, in %cond : i1) {
   // CHECK:      [[CLK_SV:%.+]] = seq.from_clock %clock
-  // CHECK-NEXT: sv.ifdef  "SYNTHESIS" {
+  // CHECK-NEXT: sv.ifdef @SYNTHESIS {
   // CHECK-NEXT: } else {
   // CHECK-NEXT:   sv.always posedge [[CLK_SV]] {
   // CHECK-NEXT:     sv.if %cond {

--- a/test/Dialect/Arc/inline-modules.mlir
+++ b/test/Dialect/Arc/inline-modules.mlir
@@ -33,21 +33,23 @@ hw.module @DontInlinePublicB(in %x: i4, out y: i4) {
   hw.output %0 : i4
 }
 
+sv.macro.decl @FOO
+sv.macro.decl @BAR
 
 // CHECK-LABEL: hw.module @NestedRegionsA
 hw.module @NestedRegionsA(in %x: i42) {
-  // CHECK-NEXT: sv.ifdef "FOO" {
-  // CHECK-NEXT:   sv.ifdef "BAR" {
+  // CHECK-NEXT: sv.ifdef @FOO {
+  // CHECK-NEXT:   sv.ifdef @BAR {
   // CHECK-NEXT:     comb.mul %x, %x : i42
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
-  sv.ifdef "FOO" {
+  sv.ifdef @FOO {
     hw.instance "b" @NestedRegionsB(y: %x: i42) -> ()
   }
 }
 // CHECK-NOT: hw.module private @NestedRegionsB
 hw.module private @NestedRegionsB(in %y: i42) {
-  sv.ifdef "BAR" {
+  sv.ifdef @BAR {
     %0 = comb.mul %y, %y : i42
   }
 }

--- a/test/Dialect/Arc/strip-sv.mlir
+++ b/test/Dialect/Arc/strip-sv.mlir
@@ -1,9 +1,11 @@
 // RUN: circt-opt %s --arc-strip-sv --verify-diagnostics | FileCheck %s
 
 // CHECK-NOT: sv.verbatim
+// CHECK-NOT: sv.macro.decl
 // CHECK-NOT: sv.ifdef
 sv.verbatim "// Standard header to adapt well known macros to our needs." {symbols = []}
-sv.ifdef  "RANDOMIZE_REG_INIT" {
+sv.macro.decl @RANDOMIZE_REG_INIT
+sv.ifdef  @RANDOMIZE_REG_INIT {
   sv.verbatim "`define RANDOMIZE" {symbols = []}
 }
 

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -3,6 +3,7 @@
 
 sv.macro.decl @RANDOM
 sv.macro.decl @PRINTF_COND_
+sv.macro.decl @SYNTHESIS
 
 // CHECK-LABEL: hw.module @test1(in %arg0 : i1, in %arg1 : i1, in %arg8 : i8) {
 hw.module @test1(in %arg0: i1, in %arg1: i1, in %arg8: i8) {
@@ -21,7 +22,7 @@ hw.module @test1(in %arg0: i1, in %arg1: i1, in %arg8: i8) {
   //    end // always @(posedge)
 
   sv.always posedge  %arg0 {
-    sv.ifdef.procedural "SYNTHESIS" {
+    sv.ifdef.procedural @SYNTHESIS {
     } else {
       %tmp = sv.macro.ref @PRINTF_COND_() : () -> i1
       %tmpx = sv.constantX : i1
@@ -40,7 +41,7 @@ hw.module @test1(in %arg0: i1, in %arg1: i1, in %arg8: i8) {
   }
 
   // CHECK-NEXT: sv.always posedge %arg0 {
-  // CHECK-NEXT:   sv.ifdef.procedural "SYNTHESIS" {
+  // CHECK-NEXT:   sv.ifdef.procedural @SYNTHESIS {
   // CHECK-NEXT:   } else {
   // CHECK-NEXT:     %PRINTF_COND_ = sv.macro.ref @PRINTF_COND
   // CHECK-NEXT:     %x_i1 = sv.constantX : i1
@@ -336,10 +337,15 @@ hw.module @XMR_src(in %a : i23) {
     hw.output %c, %d : i3, i5
 }
 
+// CHECK-LABEL: sv.macro.decl @foo
+sv.macro.decl @foo
+// CHECK-LABEL: sv.macro.decl @bar
+sv.macro.decl @bar
+
 // CHECK-LABEL: hw.module @nested_wire
 hw.module @nested_wire(in %a: i1) {
-  // CHECK: sv.ifdef "foo"
-  sv.ifdef "foo" {
+  // CHECK: sv.ifdef @foo
+  sv.ifdef @foo {
     // CHECK: sv.wire
     %wire = sv.wire : !hw.inout<i1>
     // CHECK: sv.assign
@@ -352,14 +358,14 @@ hw.module @nested_wire(in %a: i1) {
 hw.module @ordered_region(in %a: i1) {
   // CHECK: sv.ordered
   sv.ordered {
-    // CHECK: sv.ifdef "foo"
-    sv.ifdef "foo" {
+    // CHECK: sv.ifdef @foo
+    sv.ifdef @foo {
       // CHECK: sv.wire
       %wire = sv.wire : !hw.inout<i1>
       // CHECK: sv.assign
       sv.assign %wire, %a : i1
     }
-    sv.ifdef "bar" {
+    sv.ifdef @bar {
       // CHECK: sv.wire
       %wire = sv.wire : !hw.inout<i1>
       // CHECK: sv.assign

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -68,11 +68,11 @@ func.func @empy_op(%arg0: i1) {
   sv.initial {
     sv.if %arg0 {}
     sv.if %arg0 {} else {}
-    sv.ifdef.procedural "SYNTHESIS" {}
-    sv.ifdef.procedural "SYNTHESIS" {} else {}
+    sv.ifdef.procedural @SYNTHESIS {}
+    sv.ifdef.procedural @SYNTHESIS {} else {}
   }
-  sv.ifdef "SYNTHESIS" {}
-  sv.ifdef "SYNTHESIS" {} else {}
+  sv.ifdef @SYNTHESIS {}
+  sv.ifdef @SYNTHESIS {} else {}
   sv.always posedge %arg0 {}
   sv.initial {}
   return
@@ -106,7 +106,7 @@ func.func @invert_if(%arg0: i1, %arg1 : i1) {
 // CHECK-NEXT:    [[FD:%.*]] = hw.constant -2147483646 : i32
 // CHECK-NEXT:    sv.initial  {
 // CHECK-NEXT:      sv.if %arg0  {
-// CHECK-NEXT:      } else {  
+// CHECK-NEXT:      } else {
 // CHECK-NEXT:        sv.fwrite [[FD]], "Foo"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -113,7 +113,7 @@ hw.module @Initial() {
 hw.module @IfDef() {
   sv.initial {
     // expected-error @+1 {{sv.ifdef should be in a non-procedural region}}
-    sv.ifdef "SYNTHESIS" {}
+    sv.ifdef @SYNTHESIS {}
   }
 }
 

--- a/test/Dialect/SV/hw-cleanup.mlir
+++ b/test/Dialect/SV/hw-cleanup.mlir
@@ -135,7 +135,7 @@ hw.module @alwaysff_different_reset(in %arg0: i1, in %arg1: i1) {
 
 //CHECK-LABEL: hw.module @alwaysff_ifdef(in %arg0 : i1) {
 //CHECK-NEXT:  [[FD:%.*]] = hw.constant -2147483646 : i32
-//CHECK-NEXT:  sv.ifdef "FOO" {
+//CHECK-NEXT:  sv.ifdef @FOO {
 //CHECK-NEXT:     sv.alwaysff(posedge %arg0)  {
 //CHECK-NEXT:       sv.fwrite [[FD]], "A1"
 //CHECK-NEXT:       sv.fwrite [[FD]], "B1"
@@ -147,7 +147,7 @@ hw.module @alwaysff_different_reset(in %arg0: i1, in %arg1: i1) {
 hw.module @alwaysff_ifdef(in %arg0: i1) {
   %fd = hw.constant 0x80000002 : i32
 
-  sv.ifdef "FOO" {
+  sv.ifdef @FOO {
     sv.alwaysff(posedge %arg0) {
       sv.fwrite %fd, "A1"
     }
@@ -160,7 +160,7 @@ hw.module @alwaysff_ifdef(in %arg0: i1) {
 
 // CHECK-LABEL: hw.module @ifdef_merge(in %arg0 : i1) {
 // CHECK-NEXT:    [[FD:%.*]] = hw.constant -2147483646 : i32
-// CHECK-NEXT:    sv.ifdef "FOO"  {
+// CHECK-NEXT:    sv.ifdef @FOO {
 // CHECK-NEXT:      sv.alwaysff(posedge %arg0)  {
 // CHECK-NEXT:        sv.fwrite [[FD]], "A1"
 // CHECK-NEXT:        sv.fwrite [[FD]], "B1"
@@ -169,12 +169,12 @@ hw.module @alwaysff_ifdef(in %arg0: i1) {
 hw.module @ifdef_merge(in %arg0: i1) {
   %fd = hw.constant 0x80000002 : i32
 
-  sv.ifdef "FOO" {
+  sv.ifdef @FOO {
     sv.alwaysff(posedge %arg0) {
       sv.fwrite %fd, "A1"
     }
   }
-  sv.ifdef "FOO" {
+  sv.ifdef @FOO {
     sv.alwaysff(posedge %arg0) {
       sv.fwrite %fd, "B1"
     }
@@ -187,11 +187,11 @@ hw.module @ifdef_merge(in %arg0: i1) {
 // CHECK-NEXT:    sv.alwaysff(posedge %arg0)  {
 // CHECK-NEXT:      %true = hw.constant true
 // CHECK-NEXT:      [[XOR:%.*]] = comb.xor %arg0, %true : i1
-// CHECK-NEXT:      sv.ifdef.procedural "FOO"  {
+// CHECK-NEXT:      sv.ifdef.procedural @FOO  {
 // CHECK-NEXT:        sv.fwrite [[FD]], "A1"
 // CHECK-NEXT:        sv.fwrite [[FD]], "%x"([[XOR]]) : i1
 // CHECK-NEXT:      }
-// CHECK-NEXT:      sv.ifdef.procedural "BAR"  {
+// CHECK-NEXT:      sv.ifdef.procedural @BAR {
 // CHECK-NEXT:        sv.fwrite [[FD]], "B1"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
@@ -199,15 +199,15 @@ hw.module @ifdef_proc_merge(in %arg0: i1) {
   %fd = hw.constant 0x80000002 : i32
 
   sv.alwaysff(posedge %arg0) {
-    sv.ifdef.procedural "FOO" {
+    sv.ifdef.procedural @FOO {
       sv.fwrite %fd, "A1"
     }
     %true = hw.constant true
     %0 = comb.xor %arg0, %true : i1
-    sv.ifdef.procedural "FOO" {
+    sv.ifdef.procedural @FOO {
        sv.fwrite %fd, "%x"(%0) : i1
     }
-     sv.ifdef.procedural "BAR" {
+    sv.ifdef.procedural @BAR {
        sv.fwrite %fd, "B1"
     }
   }
@@ -322,13 +322,19 @@ hw.module @always_basic(in %arg0: i1, in %arg1: i1) {
   hw.output
 }
 
+// CHECK-LABEL: sv.macro.decl @L1
+sv.macro.decl @L1
+// CHECK-LABEL: sv.macro.decl @L2
+sv.macro.decl @L2
+// CHECK-LABEL: sv.macro.decl @L3
+sv.macro.decl @L3
 
 // CHECK-LABEL: hw.module @nested_regions(
 // CHECK-NEXT:  [[FD:%.*]] = hw.constant -2147483646 : i32
 // CHECK-NEXT:  sv.initial  {
-// CHECK-NEXT:    sv.ifdef.procedural "L1"  {
-// CHECK-NEXT:      sv.ifdef.procedural "L2"  {
-// CHECK-NEXT:        sv.ifdef.procedural "L3"  {
+// CHECK-NEXT:    sv.ifdef.procedural @L1 {
+// CHECK-NEXT:      sv.ifdef.procedural @L2 {
+// CHECK-NEXT:        sv.ifdef.procedural @L3 {
 // CHECK-NEXT:          sv.fwrite [[FD]], "A"
 // CHECK-NEXT:          sv.fwrite [[FD]], "B"
 // CHECK-NEXT:        }
@@ -339,18 +345,18 @@ hw.module @nested_regions() {
   %fd = hw.constant 0x80000002 : i32
 
   sv.initial {
-    sv.ifdef.procedural "L1" {
-      sv.ifdef.procedural "L2" {
-        sv.ifdef.procedural "L3" {
+    sv.ifdef.procedural @L1 {
+      sv.ifdef.procedural @L2 {
+        sv.ifdef.procedural @L3 {
           sv.fwrite %fd, "A"
         }
       }
     }
   }
   sv.initial {
-    sv.ifdef.procedural "L1" {
-      sv.ifdef.procedural "L2" {
-        sv.ifdef.procedural "L3" {
+    sv.ifdef.procedural @L1 {
+      sv.ifdef.procedural @L2 {
+        sv.ifdef.procedural @L3 {
           sv.fwrite %fd, "B"
         }
       }

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -38,7 +38,7 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
   hw.module.extern @foo_assert(in %a : i1) attributes {"firrtl.extract.assert.extra"}
   hw.module @issue1246(in %clock: i1) {
     sv.always posedge %clock  {
-      sv.ifdef.procedural "SYNTHESIS"  {
+      sv.ifdef.procedural @SYNTHESIS {
       } else  {
         sv.if %2937  {
           sv.assert %clock, immediate
@@ -351,7 +351,7 @@ module {
 
   hw.module private @ShouldBeInlined2(in %clock: i1, in %in: i1) {
     %bozo.b = hw.instance "bozo" @Bozo(a: %in: i1) -> (b: i1)
-    sv.ifdef "SYNTHESIS" {
+    sv.ifdef @SYNTHESIS {
     } else {
       sv.always posedge %clock {
         sv.if %bozo.b {

--- a/test/Dialect/SV/prettify-verilog.mlir
+++ b/test/Dialect/SV/prettify-verilog.mlir
@@ -55,7 +55,7 @@ hw.module @sink_constants(in %clock :i1, out out : i1){
   %true = hw.constant true
 
   /// Simple constant sinking.
-  sv.ifdef "FOO" {
+  sv.ifdef @FOO {
     sv.initial {
       // CHECK: [[FALSE:%.*]] = hw.constant false
       // CHECK: [[FD:%.*]] = hw.constant -2147483646 : i32
@@ -68,7 +68,7 @@ hw.module @sink_constants(in %clock :i1, out out : i1){
   }
 
   /// Multiple uses in the same block should use the same constant.
-  sv.ifdef "FOO" {
+  sv.ifdef @FOO {
     sv.initial {
       // CHECK: [[FD:%.*]] = hw.constant -2147483646 : i32
       // CHECK: [[TRUE:%.*]] = hw.constant true
@@ -131,7 +131,7 @@ hw.module @sink_expression(in %clock: i1, in %a: i1, in %a2: i1, in %a3: i1, in 
     // CHECK: [[XOR:%.*]] = comb.xor [[AND]], %a4 : i1
 
     // CHECK: sv.ifdef.procedural
-    sv.ifdef.procedural "SOMETHING"  {
+    sv.ifdef.procedural @SOMETHING {
       // CHECK: [[OR:%.*]] = comb.or %a2, %a3 : i1
       // CHECK: sv.if [[OR]]
       sv.if %0  {

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -103,16 +103,16 @@ hw.module @lowering(in %clk : !seq.clock, in %rst : i1, in %in : i32, out a : i3
   // SEPARATE-NEXT:   sv.passign %rNoSym, %in : i32
   // SEPARATE-NEXT: }
 
-  // CHECK:      sv.ifdef  "ENABLE_INITIAL_REG_" {
+  // CHECK:      sv.ifdef @ENABLE_INITIAL_REG_ {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:     sv.ifdef @FIRRTL_BEFORE_INITIAL {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
-  // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
+  // CHECK-NEXT:       sv.ifdef.procedural @INIT_RANDOM_PROLOG_ {
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
-  // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK-NEXT:         %_RANDOM = sv.logic : !hw.inout<uarray<8xi32>>
   // CHECK-NEXT:         sv.for %i = %c0_i4 to %c-8_i4 step %c1_i4 : i4 {
   // CHECK-NEXT:           %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
@@ -150,7 +150,7 @@ hw.module @lowering(in %clk : !seq.clock, in %rst : i1, in %in : i32, out a : i3
   // CHECK-NEXT:         sv.bpassign %rF, %c0_i32 : i32
   // CHECK-NEXT:       }
   // CHECK-NEXT:     }
-  // CHECK-NEXT:     sv.ifdef  "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:     sv.ifdef @FIRRTL_AFTER_INITIAL {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
@@ -183,16 +183,16 @@ hw.module private @UninitReg1(in %clock : !seq.clock, in %reset : i1, in %cond :
   %1 = comb.mux bin %cond, %value, %count : i2
   %2 = comb.mux bin %reset, %c0_i2, %1 : i2
 
-  // CHECK-NEXT: sv.ifdef "ENABLE_INITIAL_REG_"  {
+  // CHECK-NEXT: sv.ifdef @ENABLE_INITIAL_REG_ {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:     sv.ifdef @FIRRTL_BEFORE_INITIAL {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
-  // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
+  // CHECK-NEXT:       sv.ifdef.procedural @INIT_RANDOM_PROLOG_ {
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
-  // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+  // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK-NEXT:         %_RANDOM = sv.logic : !hw.inout<uarray<1xi32>>
   // CHECK:              sv.for %i = %{{false.*}} to %{{true.*}} step %{{true.*}} : i1 {
   // CHECK-NEXT:           %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
@@ -206,7 +206,7 @@ hw.module private @UninitReg1(in %clock : !seq.clock, in %reset : i1, in %cond :
   // CHECK-NEXT:         sv.bpassign %count, %5 : i2
   // CHECK-NEXT:       }
   // CHECK-NEXT:     }
-  // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:     sv.ifdef @FIRRTL_AFTER_INITIAL {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
@@ -292,16 +292,16 @@ hw.module private @InitReg1(in %clock: !seq.clock, in %reset: i1, in %io_d: i32,
   // COMMON-NEXT:    } else  {
   // COMMON-NEXT:    }
   // COMMON-NEXT:  }
-  // COMMON-NEXT:  sv.ifdef "ENABLE_INITIAL_REG_"  {
+  // COMMON-NEXT:  sv.ifdef @ENABLE_INITIAL_REG_ {
   // COMMON-NEXT:    sv.ordered {
-  // COMMON-NEXT:      sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // COMMON-NEXT:      sv.ifdef @FIRRTL_BEFORE_INITIAL {
   // COMMON-NEXT:        sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // COMMON-NEXT:      }
   // COMMON-NEXT:      sv.initial {
-  // CHECK:            sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
+  // CHECK:            sv.ifdef.procedural @INIT_RANDOM_PROLOG_ {
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
-  // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+  // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK-NEXT:          %_RANDOM = sv.logic : !hw.inout<uarray<3xi32>>
   // CHECK-NEXT:          sv.for %i = %c0_i2 to %c-1_i2 step %c1_i2 : i2 {
   // CHECK-NEXT:            %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
@@ -323,7 +323,7 @@ hw.module private @InitReg1(in %clock: !seq.clock, in %reset: i1, in %io_d: i32,
   // COMMON-NEXT:        sv.bpassign %reg3, %c1_i32 : i32
   // COMMON-NEXT:      }
   // COMMON-NEXT:    }
-  // COMMON-NEXT:    sv.ifdef  "FIRRTL_AFTER_INITIAL" {
+  // COMMON-NEXT:    sv.ifdef @FIRRTL_AFTER_INITIAL {
   // COMMON-NEXT:      sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // COMMON-NEXT:    }
   // COMMON-NEXT:  }
@@ -340,16 +340,16 @@ hw.module private @UninitReg42(in %clock: !seq.clock, in %reset: i1, in %cond: i
   %1 = comb.mux %reset, %c0_i42, %0 : i42
 
   // CHECK:      %count = sv.reg sym @count : !hw.inout<i42>
-  // CHECK:      sv.ifdef "ENABLE_INITIAL_REG_"  {
+  // CHECK:      sv.ifdef @ENABLE_INITIAL_REG_ {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:     sv.ifdef @FIRRTL_BEFORE_INITIAL {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
-  // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
+  // CHECK-NEXT:       sv.ifdef.procedural @INIT_RANDOM_PROLOG_ {
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
-  // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK-NEXT:         %_RANDOM = sv.logic : !hw.inout<uarray<2xi32>>
   // CHECK-NEXT:         sv.for %i = %c0_i2 to %c-2_i2 step %c1_i2 : i2 {
   // CHECK-NEXT:           %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
@@ -366,7 +366,7 @@ hw.module private @UninitReg42(in %clock: !seq.clock, in %reset: i1, in %cond: i
   // CHECK-NEXT:         sv.bpassign %count, %8 : i42
   // CHECK-NEXT:       }
   // CHECK-NEXT:     }
-  // CHECK-NEXT:     sv.ifdef  "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:     sv.ifdef @FIRRTL_AFTER_INITIAL {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
@@ -385,16 +385,16 @@ hw.module private @init1DVector(in %clock: !seq.clock, in %a: !hw.array<2xi1>, o
   // CHECK-NEXT:   sv.passign %r, %a : !hw.array<2xi1>
   // CHECK-NEXT: }
 
-  // CHECK:      sv.ifdef "ENABLE_INITIAL_REG_" {
+  // CHECK:      sv.ifdef @ENABLE_INITIAL_REG_ {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:     sv.ifdef @FIRRTL_BEFORE_INITIAL {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
-  // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
+  // CHECK-NEXT:       sv.ifdef.procedural @INIT_RANDOM_PROLOG_ {
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
-  // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+  // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK-NEXT:       %_RANDOM = sv.logic : !hw.inout<uarray<1xi32>>
   // CHECK-NEXT:       sv.for %i = %false to %true step %true : i1 {
   // CHECK-NEXT:         %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
@@ -414,7 +414,7 @@ hw.module private @init1DVector(in %clock: !seq.clock, in %a: !hw.array<2xi1>, o
 
   // CHECK:            }
   // CHECK-NEXT:     }
-  // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:     sv.ifdef @FIRRTL_AFTER_INITIAL {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
@@ -431,16 +431,16 @@ hw.module private @init2DVector(in %clock: !seq.clock, in %a: !hw.array<1xarray<
   // CHECK:      sv.always posedge %clock  {
   // CHECK-NEXT:   sv.passign %r, %a : !hw.array<1xarray<1xi1>>
   // CHECK-NEXT: }
-  // CHECK-NEXT: sv.ifdef  "ENABLE_INITIAL_REG_" {
+  // CHECK-NEXT: sv.ifdef @ENABLE_INITIAL_REG_ {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:     sv.ifdef @FIRRTL_BEFORE_INITIAL {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
-  // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
+  // CHECK-NEXT:       sv.ifdef.procedural @INIT_RANDOM_PROLOG_ {
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
-  // CHECK-NEXT:       sv.ifdef.procedural  "RANDOMIZE_REG_INIT" {
+  // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK-NEXT:         %_RANDOM = sv.logic : !hw.inout<uarray<1xi32>>
   // CHECK-NEXT:         sv.for %i = %false to %true step %true : i1 {
   // CHECK-NEXT:           %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
@@ -456,7 +456,7 @@ hw.module private @init2DVector(in %clock: !seq.clock, in %a: !hw.array<1xarray<
   // CHECK-NEXT:         sv.bpassign %5, %3 : i1
   // CHECK:            }
   // CHECK-NEXT:     }
-  // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:     sv.ifdef @FIRRTL_AFTER_INITIAL {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }
@@ -471,22 +471,22 @@ hw.module private @initStruct(in %clock: !seq.clock) {
   %r = seq.firreg %r clock %clock sym @__r__ : !hw.struct<a: i1>
 
   // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
-  // CHECK:      sv.ifdef "ENABLE_INITIAL_REG_" {
+  // CHECK:      sv.ifdef @ENABLE_INITIAL_REG_ {
   // CHECK-NEXT:   sv.ordered {
-  // CHECK-NEXT:     sv.ifdef  "FIRRTL_BEFORE_INITIAL" {
+  // CHECK-NEXT:     sv.ifdef @FIRRTL_BEFORE_INITIAL {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_BEFORE_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:     sv.initial {
-  // CHECK-NEXT:       sv.ifdef.procedural "INIT_RANDOM_PROLOG_" {
+  // CHECK-NEXT:       sv.ifdef.procedural @INIT_RANDOM_PROLOG_ {
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
-  // CHECK-NEXT:       sv.ifdef.procedural "RANDOMIZE_REG_INIT"  {
+  // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK:              %[[EXTRACT:.*]] = comb.extract %{{.*}} from 0 : (i32) -> i1
   // CHECK-NEXT:         %[[INOUT:.*]] = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: i1>>
   // CHECK-NEXT:         sv.bpassign %[[INOUT]], %[[EXTRACT]] : i1
   // CHECK:            }
   // CHECK-NEXT:     }
-  // CHECK-NEXT:     sv.ifdef "FIRRTL_AFTER_INITIAL" {
+  // CHECK-NEXT:     sv.ifdef @FIRRTL_AFTER_INITIAL {
   // CHECK-NEXT:       sv.verbatim "`FIRRTL_AFTER_INITIAL"
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }

--- a/test/Dialect/Seq/hw-memsim.mlir
+++ b/test/Dialect/Seq/hw-memsim.mlir
@@ -115,13 +115,13 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(in %ro_addr_0: i4
 //CHECK-NEXT:      sv.passign %[[wslot]], %wo_data_0
 //CHECK-NEXT:    }
 //CHECK-NEXT:  }
-//CHECK-NEXT:  sv.ifdef "ENABLE_INITIAL_MEM_" {
-//CHECK-NEXT:    sv.ifdef "RANDOMIZE_REG_INIT" {
+//CHECK-NEXT:  sv.ifdef @ENABLE_INITIAL_MEM_ {
+//CHECK-NEXT:    sv.ifdef @RANDOMIZE_REG_INIT {
 //CHECK-NEXT:    }
 //CHECK-NEXT:    %_RANDOM_MEM = sv.reg : !hw.inout<i32>
 //CHECK-NEXT:    sv.initial {
 //CHECK-NEXT:      sv.verbatim "`INIT_RANDOM_PROLOG_"
-//CHECK-NEXT:      sv.ifdef.procedural "RANDOMIZE_MEM_INIT" {
+//CHECK-NEXT:      sv.ifdef.procedural @RANDOMIZE_MEM_INIT {
 //CHECK:             sv.for %i = %c0_i4 to %c-6_i4 step %c1_i4 : i4 {
 //CHECK:               sv.for %j = %c0_i6 to %c-32_i6 step %c-32_i6_2 : i6 {
 //CHECK:                 %RANDOM = sv.macro.ref.se @RANDOM
@@ -134,7 +134,7 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(in %ro_addr_0: i4
 //CHECK:               sv.bpassign %[[MEM_INDEX]], %[[EXTRACT]] : i16
 //CHECK:             }
 //CHECK-NEXT:      }
-//CHECK-NEXT:      sv.ifdef.procedural "RANDOMIZE_REG_INIT" {
+//CHECK-NEXT:      sv.ifdef.procedural @RANDOMIZE_REG_INIT {
 //CHECK-NEXT:      }
 //CHECK-NEXT:    }
 //CHECK-NEXT:  }
@@ -329,7 +329,7 @@ numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32,maskGran = 8 :ui32, numWri
 hw.module.generated @PR2769, @FIRRTLMem(in %ro_addr_0: i4, in %ro_en_0: i1, in %ro_clock_0: i1, in %rw_addr_0: i4, in %rw_en_0: i1,  in %rw_clock_0: i1, in %rw_wmode_0: i1, in %rw_wdata_0: i16,  in %wo_addr_0: i4, in %wo_en_0: i1, in %wo_clock_0: i1, in %wo_data_0: i16, out ro_data_0: i16, out rw_rdata_0: i16) attributes {depth = 10 : i64, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 16 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 0 : i32, initFilename = "", initIsBinary = false, initIsInline = false}
 
 // COMMON-LABEL: hw.module private @RandomizeWeirdWidths
-// CHECK: sv.ifdef.procedural "RANDOMIZE_MEM_INIT"
+// CHECK: sv.ifdef.procedural @RANDOMIZE_MEM_INIT
 // CHECK: %[[INOUT:.+]] = sv.array_index_inout %Memory[%i]
 // CHECK: %[[EXTRACT:.+]] = comb.extract %{{.+}} from 0 : (i160) -> i145
 // CHECK-NEXT: sv.bpassign %[[INOUT]], %[[EXTRACT]] : i145

--- a/test/firtool/plusargs.fir
+++ b/test/firtool/plusargs.fir
@@ -38,7 +38,7 @@ circuit PlusArgTest:
 
     ; CHECK:      [[RESULT_BAR_REG:%.+]] = sv.reg : !hw.inout<i32>
     ; CHECK-NEXT: [[FOUND_BAR_REG:%.+]] = sv.reg : !hw.inout<i1>
-    ; CHECK-NEXT: sv.ifdef  "SYNTHESIS" {
+    ; CHECK-NEXT: sv.ifdef @SYNTHESIS {
     ; CHECK-NEXT:   %z_i32 = sv.constantZ : i32
     ; CHECK-NEXT:   sv.assign [[RESULT_BAR_REG]], %z_i32 {sv.attributes = [#sv.attribute<"This dummy assignment exists to avoid undriven lint warnings (e.g., Verilator UNDRIVEN).", emitAsComment>]} : i32
     ; CHECK-NEXT:   sv.assign [[FOUND_BAR_REG]], %false : i1

--- a/test/firtool/split-verilog.mlir
+++ b/test/firtool/split-verilog.mlir
@@ -10,7 +10,8 @@
 // RUN: FileCheck %s --check-prefix=LIST < %t/filelist.f
 
 sv.verbatim "// I'm everywhere"
-sv.ifdef "VERILATOR" {
+sv.macro.decl @VERILATOR
+sv.ifdef @VERILATOR {
   sv.verbatim "// Hello"
 } else {
   sv.verbatim "// World"

--- a/test/firtool/stop.fir
+++ b/test/firtool/stop.fir
@@ -1,8 +1,8 @@
 ; RUN: firtool %s --format=fir --ir-sv | FileCheck %s
 
-; CHECK: sv.ifdef  "STOP_COND_" {
+; CHECK: sv.ifdef @STOP_COND_ {
 ; CHECK: } else {
-; CHECK:   sv.ifdef  "STOP_COND" {
+; CHECK:   sv.ifdef @STOP_COND {
 ; CHECK:     sv.macro.def @STOP_COND_ "(`STOP_COND)"
 ; CHECK:   } else {
 ; CHECK:     sv.macro.def @STOP_COND_ "1"
@@ -16,7 +16,7 @@ circuit StopAndFinishTest:
 
     ; CHECK: [[STOP_COND:%.+]] = sv.macro.ref @STOP_COND_() : () -> i1
     ; CHECK: [[COND:%.+]] = comb.and bin [[STOP_COND:%.+]], %cond : i1
-    ; CHECK: sv.ifdef  "SYNTHESIS" {
+    ; CHECK: sv.ifdef @SYNTHESIS {
     ; CHECK: } else {
     ; CHECK:   sv.always posedge %clock {
     ; CHECK:     sv.if [[COND]] {


### PR DESCRIPTION
Macro identifiers now use a proper symbol to handle references. The verifiers are not yet enabled as more intrusive pipeline changes are required, to be done in follow-ups.