### PR TITLE
[OM] Extend APSInts as necessary before performing arithmetic.

### DIFF
--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -885,4 +885,38 @@ TEST(EvaluatorTests, IntegerBinaryArithmeticObjectsDelayed) {
                    .getValue());
 }
 
+TEST(EvaluatorTests, IntegerBinaryArithmeticWidthMismatch) {
+  StringRef mod = "om.class @IntegerBinaryArithmeticWidthMismatch() {"
+                  "  %0 = om.constant #om.integer<1 : si3> : !om.integer"
+                  "  %1 = om.constant #om.integer<2 : si4> : !om.integer"
+                  "  %2 = om.integer.add %0, %1 : !om.integer"
+                  "  om.class.field @result, %2 : !om.integer"
+                  "}";
+
+  DialectRegistry registry;
+  registry.insert<OMDialect>();
+
+  MLIRContext context(registry);
+  context.getOrLoadDialect<OMDialect>();
+
+  OwningOpRef<ModuleOp> owning =
+      parseSourceString<ModuleOp>(mod, ParserConfig(&context));
+
+  Evaluator evaluator(owning.release());
+
+  auto result = evaluator.instantiate(
+      StringAttr::get(&context, "IntegerBinaryArithmeticWidthMismatch"), {});
+
+  ASSERT_TRUE(succeeded(result));
+
+  auto fieldValue = llvm::cast<evaluator::ObjectValue>(result.value().get())
+                        ->getField("result")
+                        .value();
+
+  ASSERT_EQ(3, llvm::cast<evaluator::AttributeValue>(fieldValue.get())
+                   ->getAs<circt::om::IntegerAttr>()
+                   .getValue()
+                   .getValue());
+}
+
 } // namespace


### PR DESCRIPTION
Most interesting arithmetic on APSInt asserts that both operands are the same bitwidth, but the IntegerAttrs that we are working with may have used the smallest necessary bitwidth to represent the number they hold, and won't necessarily match.

This extends the smaller operand if necessary. This is safe to do, even for operands like the RHS of a shift right, because it will zero or sign extend without adding "significant bits" in the APSInt representation. So if we had a shift right amount that previously fit in 64 bits, and we had to extend it beyond 64 bits, we are still able to truncate to 64 bits when performing the shift.