### PR TITLE
[Emit] Group file header ops into `emit.fragment`

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -418,10 +418,17 @@ def LowerFIRRTLToHW : Pass<"lower-firrtl-to-hw", "mlir::ModuleOp"> {
     Lower a module of FIRRTL dialect to the HW dialect family.
   }];
   let constructor = "circt::createLowerFIRRTLToHWPass()";
-  let dependentDialects = ["comb::CombDialect", "hw::HWDialect",
-                           "seq::SeqDialect", "sv::SVDialect",
-                           "ltl::LTLDialect", "verif::VerifDialect",
-                           "sim::SimDialect"];
+
+  let dependentDialects = [
+    "comb::CombDialect",
+    "emit::EmitDialect",
+    "hw::HWDialect",
+    "ltl::LTLDialect",
+    "seq::SeqDialect",
+    "sim::SimDialect",
+    "sv::SVDialect",
+    "verif::VerifDialect",
+  ];
   let options = [
     Option<"enableAnnotationWarning", "warn-on-unprocessed-annotations",
            "bool", "false",

--- a/include/circt/Dialect/Emit/EmitOps.td
+++ b/include/circt/Dialect/Emit/EmitOps.td
@@ -64,6 +64,43 @@ def FileOp : EmitOp<"file", [
   }];
 }
 
+def FragmentOp : EmitOp<"fragment", [
+    Symbol,
+    SingleBlock,
+    NoTerminator,
+    NoRegionArguments,
+    IsolatedFromAbove,
+    HasParent<"mlir::ModuleOp">
+]> {
+  let summary = "Emittable fragment which can be replicated before modules";
+  let description = [{
+    The fragment operation is a container for other operations that can
+    be emitted before other operations. It carries a symbol that can be
+    referenced by an `emit.fragments` attribute placed on operations before
+    which the fragments should be inserted.
+
+    In single-file mode, each fragment is emitted once. In split file emission
+    mode, fragments precede all operations that reference them, but are still
+    emitted at most once per file.
+  }];
+
+  let regions = (region SizedRegion<1>:$bodyRegion);
+  let arguments = (ins SymbolNameAttr:$sym_name);
+
+  let assemblyFormat = "$sym_name $bodyRegion attr-dict";
+
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "StringRef":$symName,
+                    CArg<"llvm::function_ref<void()>", "{}">:$bodyCtor), [{
+      return build(
+          $_builder, $_state, $_builder.getStringAttr(symName), bodyCtor);
+    }]>,
+    OpBuilder<(ins "StringAttr":$symName,
+                    CArg<"llvm::function_ref<void()>", "{}">:$bodyCtor)>,
+  ];
+}
+
 def VerbatimOp : EmitOp<"verbatim", [HasParent<"circt::emit::FileOp">]> {
   let summary = "Verbatim opaque text emitted inline.";
   let description = [{

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -10,6 +10,7 @@
 #define CONVERSION_EXPORTVERILOG_EXPORTVERILOGINTERNAL_H
 
 #include "circt/Dialect/Comb/CombVisitors.h"
+#include "circt/Dialect/Emit/EmitOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWSymCache.h"
 #include "circt/Dialect/HW/HWVisitors.h"
@@ -328,6 +329,9 @@ private:
 /// Mapping from symbols to file operations.
 using FileMapping = DenseMap<StringAttr, Operation *>;
 
+/// Mapping from symbols to file operations.
+using FragmentMapping = DenseMap<StringAttr, emit::FragmentOp>;
+
 /// This class tracks the top-level state for the emitters, which is built and
 /// then shared across all per-file emissions that happen in parallel.
 struct SharedEmitterState {
@@ -368,6 +372,9 @@ struct SharedEmitterState {
 
   /// Tracks the referenceable files through their symbol.
   FileMapping fileMapping;
+
+  /// Tracks referenceable files through their symbol.
+  FragmentMapping fragmentMapping;
 
   explicit SharedEmitterState(ModuleOp designOp, const LoweringOptions &options,
                               GlobalNameTable globalNames)

--- a/lib/Conversion/FIRRTLToHW/CMakeLists.txt
+++ b/lib/Conversion/FIRRTLToHW/CMakeLists.txt
@@ -9,6 +9,7 @@ add_circt_conversion_library(CIRCTFIRRTLToHW
 
   LINK_LIBS PUBLIC
   CIRCTComb
+  CIRCTEmit
   CIRCTFIRRTL
   CIRCTHW
   CIRCTLTL

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -100,6 +100,10 @@ namespace comb {
 class CombDialect;
 } // namespace comb
 
+namespace emit {
+class EmitDialect;
+} // namespace emit
+
 namespace hw {
 class HWDialect;
 class HWModuleOp;

--- a/lib/Dialect/Emit/EmitOps.cpp
+++ b/lib/Dialect/Emit/EmitOps.cpp
@@ -49,6 +49,23 @@ void FileOp::build(OpBuilder &builder, OperationState &result,
 }
 
 //===----------------------------------------------------------------------===//
+// FragmentOp
+//===----------------------------------------------------------------------===//
+
+void FragmentOp::build(OpBuilder &builder, OperationState &result,
+                       StringAttr symName,
+                       llvm::function_ref<void()> bodyCtor) {
+  OpBuilder::InsertionGuard guard(builder);
+
+  auto &props = result.getOrAddProperties<Properties>();
+  props.sym_name = symName;
+
+  builder.createBlock(result.addRegion());
+  if (bodyCtor)
+    bodyCtor();
+}
+
+//===----------------------------------------------------------------------===//
 // RefOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/ExportVerilog/emit-fragment-errors.mlir
+++ b/test/Conversion/ExportVerilog/emit-fragment-errors.mlir
@@ -1,0 +1,6 @@
+// RUN: circt-opt %s -export-verilog -verify-diagnostics
+
+// expected-error @below {{cannot find referenced fragment @DoesNotExis}}
+hw.module @SomeModule(in %in : i32, out out : i32) attributes { "emit.fragments" = [@DoesNotExist] } {
+  hw.output %in : i32
+}

--- a/test/Conversion/ExportVerilog/emit-fragment.mlir
+++ b/test/Conversion/ExportVerilog/emit-fragment.mlir
@@ -1,0 +1,66 @@
+// RUN: circt-opt -o=- --export-verilog %s | FileCheck %s
+// RUN: circt-opt -o=- --export-split-verilog='dir-name=%t' %s
+// RUN: cat %t%{fs-sep}FirstModule.sv | FileCheck %s --check-prefix=FIRST
+// RUN: cat %t%{fs-sep}SecondModule.sv | FileCheck %s --check-prefix=SECOND
+
+// CHECK:      `ifndef MacroA
+// CHECK-NEXT:   `define MacroA A
+// CHECK-NEXT: `endif
+// CHECK-NEXT: `ifndef MacroB
+// CHECK-NEXT:   `define MacroB B
+// CHECK-NEXT: `endif
+// CHECK-LABEL: FirstModule
+// CHECK-NOT: MacroB
+// CHECK:      `ifndef MacroC
+// CHECK-NEXT:   `define MacroC C
+// CHECK-NEXT: `endif
+// CHECK-LABEL: SecondModule
+
+// FIRST:      `ifndef MacroA
+// FIRST-NEXT:   `define MacroA A
+// FIRST-NEXT: `endif
+// FIRST-NEXT: `ifndef MacroB
+// FIRST-NEXT:   `define MacroB B
+// FIRST-NEXT: `endif
+// FIRST-NEXT: module FirstModule
+
+// SECOND:      `ifndef MacroB
+// SECOND-NEXT:   `define MacroB B
+// SECOND-NEXT: `endif
+// SECOND-NEXT: `ifndef MacroC
+// SECOND-NEXT:   `define MacroC C
+// SECOND-NEXT: `endif
+// SECOND-NEXT: module SecondModule
+
+sv.macro.decl @MacroA
+sv.macro.decl @MacroB
+sv.macro.decl @MacroC
+
+emit.fragment @FragmentA {
+  sv.ifdef @MacroA {
+  } else {
+    sv.macro.def @MacroA "A"
+  }
+}
+
+emit.fragment @FragmentB {
+  sv.ifdef @MacroB {
+  } else {
+    sv.macro.def @MacroB "B"
+  }
+}
+
+emit.fragment @FragmentC {
+  sv.ifdef @MacroC {
+  } else {
+    sv.macro.def @MacroC "C"
+  }
+}
+
+hw.module @FirstModule(in %in : i32, out out : i32) attributes { "emit.fragments" = [@FragmentA, @FragmentB] } {
+  hw.output %in : i32
+}
+
+hw.module @SecondModule(in %in : i32, out out : i32) attributes { "emit.fragments" = [@FragmentB, @FragmentC] } {
+  hw.output %in : i32
+}

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -6,28 +6,34 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 "sifive.enterprise.firrtl.ExtractAssertionsAnnotation", directory = "dir3",  filename = "./dir3/filename3" }]}
 {
   // Headers
-  // CHECK:      sv.ifdef @PRINTF_COND_ {
-  // CHECK-NEXT: } else {
-  // CHECK-NEXT:   sv.ifdef @PRINTF_COND {
-  // CHECK-NEXT:     sv.macro.def @PRINTF_COND_ "(`PRINTF_COND)"
+  // CHECK:      emit.fragment @PRINTF_COND_FRAGMENT {
+  // CHECK:        sv.ifdef @PRINTF_COND_ {
   // CHECK-NEXT:   } else {
-  // CHECK-NEXT:     sv.macro.def @PRINTF_COND_ "1"
+  // CHECK-NEXT:     sv.ifdef @PRINTF_COND {
+  // CHECK-NEXT:       sv.macro.def @PRINTF_COND_ "(`PRINTF_COND)"
+  // CHECK-NEXT:     } else {
+  // CHECK-NEXT:       sv.macro.def @PRINTF_COND_ "1"
+  // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
-  // CHECK:      sv.ifdef @ASSERT_VERBOSE_COND_ {
-  // CHECK-NEXT: } else {
-  // CHECK-NEXT:   sv.ifdef @ASSERT_VERBOSE_COND {
-  // CHECK-NEXT:     sv.macro.def @ASSERT_VERBOSE_COND_ "(`ASSERT_VERBOSE_COND)"
+  // CHECK:      emit.fragment @ASSERT_VERBOSE_COND_FRAGMENT {
+  // CHECK:        sv.ifdef @ASSERT_VERBOSE_COND_ {
   // CHECK-NEXT:   } else {
-  // CHECK-NEXT:     sv.macro.def @ASSERT_VERBOSE_COND_ "1"
+  // CHECK-NEXT:     sv.ifdef @ASSERT_VERBOSE_COND {
+  // CHECK-NEXT:       sv.macro.def @ASSERT_VERBOSE_COND_ "(`ASSERT_VERBOSE_COND)"
+  // CHECK-NEXT:     } else {
+  // CHECK-NEXT:       sv.macro.def @ASSERT_VERBOSE_COND_ "1"
+  // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
-  // CHECK:      sv.ifdef @STOP_COND_ {
-  // CHECK-NEXT: } else {
-  // CHECK-NEXT:   sv.ifdef @STOP_COND {
-  // CHECK-NEXT:     sv.macro.def @STOP_COND_ "(`STOP_COND)"
+  // CHECK:      emit.fragment @STOP_COND_FRAGMENT {
+  // CHECK:        sv.ifdef @STOP_COND_ {
   // CHECK-NEXT:   } else {
-  // CHECK-NEXT:     sv.macro.def @STOP_COND_ "1"
+  // CHECK-NEXT:     sv.ifdef @STOP_COND {
+  // CHECK-NEXT:       sv.macro.def @STOP_COND_ "(`STOP_COND)"
+  // CHECK-NEXT:     } else {
+  // CHECK-NEXT:       sv.macro.def @STOP_COND_ "1"
+  // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
 
@@ -317,6 +323,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 //    printf(clock, reset, "Hi %x %x\n", add(a, a), b)
 
   // CHECK-LABEL: hw.module private @Print
+  // CHECK-SAME: attributes {emit.fragments = [@PRINTF_COND_FRAGMENT]}
   firrtl.module private @Print(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
                        in %a: !firrtl.uint<4>, in %b: !firrtl.uint<4>) {
     // CHECK: [[CLOCK:%.+]] = seq.from_clock %clock
@@ -360,6 +367,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 //    stop(clock2, reset, 0)
 
   // CHECK-LABEL: hw.module private @Stop
+  // CHECK-SAME: attributes {emit.fragments = [@STOP_COND_FRAGMENT]}
   firrtl.module private @Stop(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock, in %reset: !firrtl.uint<1>) {
     // CHECK-NEXT: [[STOP_COND_1:%.+]] = sv.macro.ref @STOP_COND_
     // CHECK-NEXT: [[COND:%.+]] = comb.and bin [[STOP_COND_1]], %reset : i1
@@ -508,6 +516,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
 
   // CHECK-LABEL: hw.module private @VerificationAssertFormat
+  // CHECK-SAME: attributes {emit.fragments = [@STOP_COND_FRAGMENT, @ASSERT_VERBOSE_COND_FRAGMENT]}
   firrtl.module private @VerificationAssertFormat(
     in %clock: !firrtl.clock,
     in %cond: !firrtl.uint<1>,


### PR DESCRIPTION
Instead of using the replicated op mechanism, fragments of SV code which must precede certain modules are grouped into fragment ops. Modules which rely on them reference them through a `emit.fragment` attribute. The fragments are printed through ExportVerilog.

Subsequent PRs will fully replace replicated ops using fragments.