### PR TITLE
[FIRRTL] Fix sign bit truncation in constant parser

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3933,8 +3933,10 @@ ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
     } else if (width < value.getBitWidth()) {
       // The parser can return an unnecessarily wide result with leading
       // zeros. This isn't a problem, but truncating off bits is bad.
-      if (value.getNumSignBits() < value.getBitWidth() - width)
-        return parser.emitError(loc, "constant too large for result type ")
+      unsigned neededBits = value.isNegative() ? value.getSignificantBits()
+                                               : value.getActiveBits();
+      if (width < neededBits)
+        return parser.emitError(loc, "constant out of range for result type ")
                << resultType;
       value = value.trunc(width);
     }

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -139,7 +139,7 @@ firrtl.module @Foo() {
 
 firrtl.circuit "Foo" {
 firrtl.module @Foo() {
-  // expected-error @+1 {{constant too large for result type}}
+  // expected-error @+1 {{constant out of range for result type}}
   firrtl.constant 100 : !firrtl.uint<4>
 }
 }
@@ -148,8 +148,17 @@ firrtl.module @Foo() {
 
 firrtl.circuit "Foo" {
 firrtl.module @Foo() {
-  // expected-error @+1 {{constant too large for result type}}
+  // expected-error @+1 {{constant out of range for result type}}
   firrtl.constant -100 : !firrtl.sint<4>
+}
+}
+
+// -----
+
+firrtl.circuit "Foo" {
+firrtl.module @Foo() {
+  // expected-error @+1 {{constant out of range for result type}}
+  firrtl.constant -2 : !firrtl.sint<1>
 }
 }
 


### PR DESCRIPTION
Fix an issue in the parser of the `firrtl.constant` op, which would truncate the sign bit of negative constants without reporting an error. This would for example accept -2 as a valid 1-bit constant, truncating the `...11111110` bit pattern to `0`.