### PR TITLE
[arcilator] Strip Emit dialect operations

### DIFF
--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -29,6 +29,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   CIRCTArc
   CIRCTArcExternalInterfaces
   CIRCTComb
+  CIRCTEmit
   CIRCTHW
   CIRCTOM
   CIRCTSV

--- a/lib/Dialect/Arc/Transforms/StripSV.cpp
+++ b/lib/Dialect/Arc/Transforms/StripSV.cpp
@@ -9,6 +9,7 @@
 #include "circt/Dialect/Arc/ArcOps.h"
 #include "circt/Dialect/Arc/ArcPasses.h"
 #include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/Emit/EmitDialect.h"
 #include "circt/Dialect/OM/OMDialect.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
@@ -75,9 +76,9 @@ void StripSVPass::runOnOperation() {
   LLVM_DEBUG(llvm::dbgs() << "Found " << clockGateModuleNames.size()
                           << " clock gates\n");
 
-  // Remove OM dialect nodes.
+  // Remove OM and Emit dialect nodes.
   for (auto &op : llvm::make_early_inc_range(*mlirModule.getBody()))
-    if (isa<om::OMDialect>(op.getDialect()))
+    if (isa<emit::EmitDialect, om::OMDialect>(op.getDialect()))
       op.erase();
 
   // Remove `sv.*` operation attributes.

--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(arcilator
   CIRCTArcTransforms
   CIRCTCombToArith
   CIRCTConvertToArcs
+  CIRCTEmit
   CIRCTExportArc
   CIRCTOM
   CIRCTSeqToSV

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -19,6 +19,7 @@
 #include "circt/Dialect/Arc/ArcPasses.h"
 #include "circt/Dialect/Arc/ModelInfo.h"
 #include "circt/Dialect/Arc/ModelInfoExport.h"
+#include "circt/Dialect/Emit/EmitDialect.h"
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/InitAllDialects.h"
 #include "circt/InitAllPasses.h"
@@ -468,6 +469,7 @@ static LogicalResult executeArcilator(MLIRContext &context) {
   registry.insert<
     arc::ArcDialect,
     comb::CombDialect,
+    emit::EmitDialect,
     hw::HWDialect,
     mlir::LLVM::LLVMDialect,
     mlir::arith::ArithDialect,


### PR DESCRIPTION
This PR enables the arcilator tool to run on IR containing Emit dialect nodes. However, they are simply discarded. It is mainly intended to allow lowering of designs containing blackboxed stubs, notably the plusargreader in rocket-chip. Obviously, this is just a stopgap solution until we can feed them to ImportVerilog. :wink: 