### PR TITLE
[SMT] Add declare_const, assert, solver, and check operations

### DIFF
--- a/include/circt/Dialect/SMT/SMTOps.h
+++ b/include/circt/Dialect/SMT/SMTOps.h
@@ -11,6 +11,7 @@
 
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 

--- a/include/circt/Dialect/SMT/SMTOps.td
+++ b/include/circt/Dialect/SMT/SMTOps.td
@@ -16,8 +16,152 @@ include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
 
 class SMTOp<string mnemonic, list<Trait> traits = []> :
   Op<SMTDialect, mnemonic, traits>;
+
+def DeclareConstOp : SMTOp<"declare_const", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+]> {
+  let summary = "declare a symbolic value of a given sort";
+  let description = [{
+    This operation declares a symbolic value just as the `declare-const`
+    statement in SMT-LIB 2.6. The result type determines the SMT sort of the
+    symbolic value. The returned value can then be used to refer to the symbolic
+    value instead of using the identifier like in SMT-LIB.
+
+    The optionally provided string will be used as a prefix for the newly
+    generated identifier (useful for easier readability when exporting to
+    SMT-LIB). Each `declare_const` will always provide a unique new symbolic
+    value even if the identifier strings are the same.
+
+    Note that this operation cannot be marked as Pure since two operations (even
+    with the same identifier string) could then be CSEd, leading to incorrect
+    behavior.
+  }];
+
+  let arguments = (ins OptionalAttr<StrAttr>:$namePrefix);
+  let results = (outs Res<AnySMTType, "a symbolic value", [MemAlloc]>:$result);
+
+  let assemblyFormat = [{
+    ($namePrefix^)? attr-dict `:` qualified(type($result))
+  }];
+}
+
+def SolverOp : SMTOp<"solver", [
+  IsolatedFromAbove,
+  SingleBlockImplicitTerminator<"smt::YieldOp">,
+]> {
+  let summary = "create a solver instance within a lifespan";
+  let description = [{
+    This operation defines an SMT context with a solver instance. SMT operations
+    are only valid when being executed between the start and end of the region
+    of this operation. Any invocation outside is undefined. However, they do not
+    have to be direct children of this operation. For example, it is allowed to
+    have SMT operations in a `func.func` which is only called from within this
+    region. No SMT value may enter or exit the lifespan of this region (such
+    that no value created from another SMT context can be used in this scope and
+    the solver can deallocate all state required to keep track of SMT values at
+    the end).
+
+    As a result, the region is comparable to an entire SMT-LIB script, but
+    allows for concrete operations and control-flow. Concrete values may be
+    passed in and returned to influence the computations after the `smt.solver`
+    operation.
+
+    Example:
+    ```mlir
+    %0:2 = smt.solver (%in) {smt.some_attr} : (i8) -> (i8, i32) {
+    ^bb0(%arg0: i8):
+      %c = smt.declare_const "c" : !smt.bool
+      smt.assert %c
+      %1 = smt.check sat {
+        %c1_i32 = arith.constant 1 : i32
+        smt.yield %c1_i32 : i32
+      } unknown {
+        %c0_i32 = arith.constant 0 : i32
+        smt.yield %c0_i32 : i32
+      } unsat {
+        %c-1_i32 = arith.constant -1 : i32
+        smt.yield %c-1_i32 : i32
+      } -> i32
+      smt.yield %arg0, %1 : i8, i32
+    }
+    ```
+
+    TODO: solver configuration attributes
+  }];
+
+  let arguments = (ins Variadic<AnyNonSMTType>:$inputs);
+  let regions = (region SizedRegion<1>:$bodyRegion);
+  let results = (outs Variadic<AnyNonSMTType>:$results);
+
+  let assemblyFormat = [{
+    `(` $inputs `)` attr-dict `:` functional-type($inputs, $results) $bodyRegion
+  }];
+
+  let hasRegionVerifier = true;
+}
+
+def AssertOp : SMTOp<"assert", []> {
+  let summary = "assert that a boolean expression holds";
+  let arguments = (ins BoolType:$input);
+  let assemblyFormat = "$input attr-dict";
+}
+
+def CheckOp : SMTOp<"check", [
+  NoRegionArguments,
+  SingleBlockImplicitTerminator<"smt::YieldOp">,
+]> {
+  let summary = "check if the current set of assertions is satisfiable";
+  let description = [{
+    This operation checks if all the assertions in the solver defined by the
+    nearest ancestor operation of type `smt.solver` are consistent. The outcome
+    an be 'satisfiable', 'unknown', or 'unsatisfiable' and the corresponding
+    region will be executed. It is the corresponding construct to the
+    `check-sat` in SMT-LIB.
+
+    Example:
+    ```mlir
+    %0 = smt.check sat {
+      %c1_i32 = arith.constant 1 : i32
+      smt.yield %c1_i32 : i32
+    } unknown {
+      %c0_i32 = arith.constant 0 : i32
+      smt.yield %c0_i32 : i32
+    } unsat {
+      %c-1_i32 = arith.constant -1 : i32
+      smt.yield %c-1_i32 : i32
+    } -> i32
+    ```
+  }];
+
+  let regions = (region SizedRegion<1>:$satRegion,
+                        SizedRegion<1>:$unknownRegion,
+                        SizedRegion<1>:$unsatRegion);
+  let results = (outs Variadic<AnyType>:$results);
+
+  let assemblyFormat = [{
+    attr-dict `sat` $satRegion `unknown` $unknownRegion `unsat` $unsatRegion
+    (`->` qualified(type($results))^ )?
+  }];
+
+  let hasRegionVerifier = true;
+}
+
+def YieldOp : SMTOp<"yield", [
+  Pure,
+  Terminator,
+  ReturnLike,
+  ParentOneOf<["smt::SolverOp", "smt::CheckOp"]>,
+]> {
+  let summary = "terminator operation for various regions of SMT operations";
+  let arguments = (ins Variadic<AnyType>:$values);
+  let assemblyFormat = "($values^ `:` qualified(type($values)))? attr-dict";
+  let builders = [OpBuilder<(ins), [{
+    build($_builder, $_state, std::nullopt);
+  }]>];
+}
 
 #endif // CIRCT_DIALECT_SMT_SMTOPS_TD

--- a/include/circt/Dialect/SMT/SMTTypes.td
+++ b/include/circt/Dialect/SMT/SMTTypes.td
@@ -52,5 +52,6 @@ def ArrayType : SMTTypeDef<"Array"> {
 
 def AnySMTType : Type<CPred<"smt::isAnySMTValueType($_self)">,
                       "any SMT value type">;
+def AnyNonSMTType : Type<Neg<AnySMTType.predicate>, "any non-smt type">;
 
 #endif // CIRCT_DIALECT_SMT_SMTTYPES_TD

--- a/lib/Dialect/SMT/CMakeLists.txt
+++ b/lib/Dialect/SMT/CMakeLists.txt
@@ -19,6 +19,7 @@ add_circt_dialect_library(CIRCTSMT
   MLIRIR
   MLIRInferTypeOpInterface
   MLIRSideEffectInterfaces
+  MLIRControlFlowInterfaces
 )
 
 add_dependencies(circt-headers

--- a/test/Dialect/SMT/basic.mlir
+++ b/test/Dialect/SMT/basic.mlir
@@ -5,3 +5,51 @@
 func.func @types(%arg0: !smt.bool, %arg1: !smt.bv<32>) {
   return
 }
+
+func.func @core(%in: i8) {
+  // CHECK: %a = smt.declare_const "a" {smt.some_attr} : !smt.bool
+  %a = smt.declare_const "a" {smt.some_attr} : !smt.bool
+  // CHECK: smt.declare_const {smt.some_attr} : !smt.bv<32>
+  %b = smt.declare_const {smt.some_attr} : !smt.bv<32>
+
+  // CHECK: smt.assert %a {smt.some_attr}
+  smt.assert %a {smt.some_attr}
+
+  // CHECK: %{{.*}} = smt.solver(%{{.*}}) {smt.some_attr} : (i8) -> (i8, i32) {
+  // CHECK: ^bb0(%{{.*}}: i8)
+  // CHECK:   %{{.*}} = smt.check {smt.some_attr} sat {
+  // CHECK:     smt.yield %{{.*}} : i32
+  // CHECK:   } unknown {
+  // CHECK:     smt.yield %{{.*}} : i32
+  // CHECK:   } unsat {
+  // CHECK:     smt.yield %{{.*}} : i32
+  // CHECK:   } -> i32
+  // CHECK:   smt.yield %{{.*}}, %{{.*}} : i8, i32
+  // CHECK: }
+  %0:2 = smt.solver(%in) {smt.some_attr} : (i8) -> (i8, i32) {
+  ^bb0(%arg0: i8):
+    %1 = smt.check {smt.some_attr} sat {
+      %c1_i32 = arith.constant 1 : i32
+      smt.yield %c1_i32 : i32
+    } unknown {
+      %c0_i32 = arith.constant 0 : i32
+      smt.yield %c0_i32 : i32
+    } unsat {
+      %c-1_i32 = arith.constant -1 : i32
+      smt.yield %c-1_i32 : i32
+    } -> i32
+    smt.yield %arg0, %1 : i8, i32
+  }
+
+  // CHECK: smt.solver() : () -> () {
+  // CHECK-NEXT: }
+  smt.solver() : () -> () { }
+
+  //      CHECK: smt.check sat {
+  // CHECK-NEXT: } unknown {
+  // CHECK-NEXT: } unsat {
+  // CHECK-NEXT: }
+  smt.check sat { } unknown { } unsat { }
+
+  return
+}

--- a/test/Dialect/SMT/core-errors.mlir
+++ b/test/Dialect/SMT/core-errors.mlir
@@ -1,0 +1,133 @@
+// RUN: circt-opt %s --split-input-file --verify-diagnostics
+
+func.func @solver_isolated_from_above(%arg0: !smt.bool) {
+  // expected-note @below {{required by region isolation constraints}}
+  smt.solver() : () -> () {
+    // expected-error @below {{using value defined outside the region}}
+    smt.assert %arg0
+  }
+  return
+}
+
+// -----
+
+func.func @no_smt_value_enters_solver(%arg0: !smt.bool) {
+  // expected-error @below {{operand #0 must be variadic of any non-smt type, but got '!smt.bool'}}
+  smt.solver(%arg0) : (!smt.bool) -> () {
+  ^bb0(%arg1: !smt.bool):
+    smt.assert %arg1
+  }
+  return
+}
+
+// -----
+
+func.func @no_smt_value_exits_solver() {
+  // expected-error @below {{result #0 must be variadic of any non-smt type, but got '!smt.bool'}}
+  %0 = smt.solver() : () -> !smt.bool {
+    %a = smt.declare_const "a" : !smt.bool
+    smt.yield %a : !smt.bool
+  }
+  return
+}
+
+// -----
+
+func.func @block_args_and_inputs_match() {
+  // expected-error @below {{block argument types must match the types of the 'inputs'}}
+  smt.solver() : () -> () {
+    ^bb0(%arg0: i32):
+  }
+  return
+}
+
+// -----
+
+func.func @solver_yield_operands_and_results_match() {
+  // expected-error @below {{types of yielded values must match return values}}
+  smt.solver() : () -> () {
+    %1 = hw.constant 0 : i32
+    smt.yield %1 : i32
+  }
+  return
+}
+
+// -----
+
+func.func @check_yield_operands_and_results_match() {
+  // expected-error @below {{types of yielded values in 'unsat' region must match return values}}
+  %0 = smt.check sat {
+    %1 = hw.constant 0 : i32
+    smt.yield %1 : i32
+  } unknown {
+    %1 = hw.constant 0 : i32
+    smt.yield %1 : i32
+  } unsat { } -> i32
+  return
+}
+
+// -----
+
+func.func @check_yield_operands_and_results_match() {
+  // expected-error @below {{types of yielded values in 'unknown' region must match return values}}
+  %0 = smt.check sat {
+    %1 = hw.constant 0 : i32
+    smt.yield %1 : i32
+  } unknown {
+  } unsat {
+    %1 = hw.constant 0 : i32
+    smt.yield %1 : i32
+  } -> i32
+  return
+}
+
+// -----
+
+func.func @check_yield_operands_and_results_match() {
+  // expected-error @below {{types of yielded values in 'sat' region must match return values}}
+  %0 = smt.check sat {
+  } unknown {
+    %1 = hw.constant 0 : i32
+    smt.yield %1 : i32
+  } unsat {
+    %1 = hw.constant 0 : i32
+    smt.yield %1 : i32
+  } -> i32
+  return
+}
+
+// -----
+
+func.func @check_no_block_arguments() {
+  // expected-error @below {{region #0 should have no arguments}}
+  smt.check sat {
+  ^bb0(%arg0: i32):
+  } unknown {
+  } unsat {
+  }
+  return
+}
+
+// -----
+
+func.func @check_no_block_arguments() {
+  // expected-error @below {{region #1 should have no arguments}}
+  smt.check sat {
+  } unknown {
+  ^bb0(%arg0: i32):
+  } unsat {
+  }
+  return
+}
+
+// -----
+
+func.func @check_no_block_arguments() {
+  // expected-error @below {{region #2 should have no arguments}}
+  smt.check sat {
+  } unknown {
+  } unsat {
+  ^bb0(%arg0: i32):
+  }
+  return
+}

--- a/test/Dialect/SMT/cse-test.mlir
+++ b/test/Dialect/SMT/cse-test.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt %s --cse | FileCheck %s
+
+func.func @declare_const_cse(%in: i8) -> (!smt.bool, !smt.bool){
+  // CHECK: smt.declare_const "a" : !smt.bool
+  %a = smt.declare_const "a" : !smt.bool
+  // CHECK-NEXT: smt.declare_const "a" : !smt.bool
+  %b = smt.declare_const "a" : !smt.bool
+  // CHECK-NEXT: return
+  %c = smt.declare_const "a" : !smt.bool
+
+  return %a, %b : !smt.bool, !smt.bool
+}


### PR DESCRIPTION
The `declare_const` operation could be pure if `fresh` is not specified. If `fresh` maybe an allocate side-effect could work? I think tablegen does not have the traits to specify this so fine-grained, we'd need to fall back to C++, so I'd leave it to another PR. Also to have it as the sole focus. There might be some corner cases to think about, e.g., what if there are `declare_const` with the same identifier, but different sort/type. The lack of such traits and optimizations makes it behave like SMT-LIB, though.