### PR TITLE
[SMT] Add comparison operations

### DIFF
--- a/include/circt/Dialect/SMT/SMTBitVectorOps.td
+++ b/include/circt/Dialect/SMT/SMTBitVectorOps.td
@@ -107,4 +107,43 @@ def BVShlOp  : BinaryBVOp<"shl", "shift left">;
 def BVLShrOp : BinaryBVOp<"lshr", "logical shift right">;
 def BVAShrOp : BinaryBVOp<"ashr", "arithmetic shift right">;
 
+def PredicateSLT : I64EnumAttrCase<"slt", 0>;
+def PredicateSLE : I64EnumAttrCase<"sle", 1>;
+def PredicateSGT : I64EnumAttrCase<"sgt", 2>;
+def PredicateSGE : I64EnumAttrCase<"sge", 3>;
+def PredicateULT : I64EnumAttrCase<"ult", 4>;
+def PredicateULE : I64EnumAttrCase<"ule", 5>;
+def PredicateUGT : I64EnumAttrCase<"ugt", 6>;
+def PredicateUGE : I64EnumAttrCase<"uge", 7>;
+let cppNamespace = "circt::smt" in
+def BVCmpPredicate : I64EnumAttr<
+    "BVCmpPredicate",
+    "smt bit-vector comparison predicate",
+    [PredicateSLT, PredicateSLE, PredicateSGT, PredicateSGE,
+     PredicateULT, PredicateULE, PredicateUGT, PredicateUGE]>;
+
+def BVCmpOp : SMTBVOp<"cmp", [Pure, SameTypeOperands]> {
+  let summary = "compare bit-vectors interpreted as signed or unsigned";
+  let description = [{
+    This operation compares bit-vector values, interpreting them as signed or
+    unsigned values depending on the predicate. The semantics are equivalent to
+    the `bvslt`, `bvsle`, `bvsgt`, `bvsge`, `bvult`, `bvule`, `bvugt`, or
+    `bvuge` operator defined in the SMT-LIB 2.6 standard depending on the
+    specified predicate. More precisely in the
+    [theory of FixedSizeBitVectors](https://smtlib.cs.uiowa.edu/Theories/FixedSizeBitVectors.smt2)
+    and the [QF_BV logic](https://smtlib.cs.uiowa.edu/Logics/QF_BV.smt2)
+    describing closed quantifier-free formulas over the theory of fixed-size
+    bit-vectors.
+  }];
+
+  let arguments = (ins BVCmpPredicate:$pred,
+                       BitVectorType:$lhs,
+                       BitVectorType:$rhs);
+  let results = (outs BoolType:$result);
+
+  let assemblyFormat = [{
+    $pred $lhs `,` $rhs attr-dict `:` qualified(type($lhs))
+  }];
+}
+
 #endif // CIRCT_DIALECT_SMT_SMTBITVECTOROPS_TD

--- a/include/circt/Dialect/SMT/SMTOps.td
+++ b/include/circt/Dialect/SMT/SMTOps.td
@@ -164,4 +164,62 @@ def YieldOp : SMTOp<"yield", [
   }]>];
 }
 
+def EqOp : SMTOp<"eq", [Pure, SameTypeOperands]> {
+  let summary = "returns true iff all operands are identical";
+  let description = [{
+    This operation compares the operands and returns true iff all operands are
+    identical. The semantics are equivalent to the `=` operator defined in the
+    SMT-LIB Standard 2.6 in the
+    [Core theory](https://smtlib.cs.uiowa.edu/Theories/Core.smt2).
+
+    Any SMT sort/type is allowed for the operands and it supports a variadic
+    number of operands, but requires at least two. This is because the `=`
+    operator is annotated with `:chainable` which means that `= a b c d` is
+    equivalent to `and (= a b) (= b c) (= c d)` where `and` is annotated
+    `:left-assoc`, i.e., it can be further rewritten to
+    `and (and (= a b) (= b c)) (= c d)`.
+  }];
+
+  let arguments = (ins Variadic<AnySMTType>:$inputs);
+  let results = (outs BoolType:$result);
+
+  let hasCustomAssemblyFormat = true;
+  let hasVerifier = true;
+}
+
+def DistinctOp : SMTOp<"distinct", [Pure, SameTypeOperands]> {
+  let summary = "returns true iff all operands are not identical to any other";
+  let description = [{
+    This operation compares the operands and returns true iff all operands are
+    not identical to any of the other operands. The semantics are equivalent to
+    the `distinct` operator defined in the SMT-LIB Standard 2.6 in the
+    [Core theory](https://smtlib.cs.uiowa.edu/Theories/Core.smt2).
+
+    Any SMT sort/type is allowed for the operands and it supports a variadic
+    number of operands, but requires at least two. This is because the
+    `distinct` operator is annotated with `:pairwise` which means that
+    `distinct a b c d` is equivalent to
+    ```
+    and (distinct a b) (distinct a c) (distinct a d)
+        (distinct b c) (distinct b d)
+        (distinct c d)
+    ```
+    where `and` is annotated `:left-assoc`, i.e., it can be further rewritten to
+    ```
+    (and (and (and (and (and (distinct a b)
+                             (distinct a c))
+                        (distinct a d))
+                   (distinct b c))
+              (distinct b d))
+         (distinct c d)
+    ```
+  }];
+
+  let arguments = (ins Variadic<AnySMTType>:$inputs);
+  let results = (outs BoolType:$result);
+
+  let hasCustomAssemblyFormat = true;
+  let hasVerifier = true;
+}
+
 #endif // CIRCT_DIALECT_SMT_SMTOPS_TD

--- a/lib/Dialect/SMT/SMTOps.cpp
+++ b/lib/Dialect/SMT/SMTOps.cpp
@@ -85,5 +85,69 @@ LogicalResult CheckOp::verifyRegions() {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// EqOp
+//===----------------------------------------------------------------------===//
+
+static LogicalResult
+parseSameOperandTypeVariadicToBoolOp(OpAsmParser &parser,
+                                     OperationState &result) {
+  SmallVector<OpAsmParser::UnresolvedOperand, 4> inputs;
+  SMLoc loc = parser.getCurrentLocation();
+  Type type;
+
+  if (parser.parseOperandList(inputs) ||
+      parser.parseOptionalAttrDict(result.attributes) || parser.parseColon() ||
+      parser.parseType(type))
+    return failure();
+
+  result.addTypes(BoolType::get(parser.getContext()));
+  if (parser.resolveOperands(inputs, SmallVector<Type>(inputs.size(), type),
+                             loc, result.operands))
+    return failure();
+
+  return success();
+}
+
+ParseResult EqOp::parse(OpAsmParser &parser, OperationState &result) {
+  return parseSameOperandTypeVariadicToBoolOp(parser, result);
+}
+
+void EqOp::print(OpAsmPrinter &printer) {
+  printer << ' ' << getInputs();
+  printer.printOptionalAttrDict(getOperation()->getAttrs());
+  printer << " : " << getInputs().front().getType();
+}
+
+LogicalResult EqOp::verify() {
+  if (getInputs().size() < 2)
+    return emitOpError() << "'inputs' must have at least size 2, but got "
+                         << getInputs().size();
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// DistinctOp
+//===----------------------------------------------------------------------===//
+
+ParseResult DistinctOp::parse(OpAsmParser &parser, OperationState &result) {
+  return parseSameOperandTypeVariadicToBoolOp(parser, result);
+}
+
+void DistinctOp::print(OpAsmPrinter &printer) {
+  printer << ' ' << getInputs();
+  printer.printOptionalAttrDict(getOperation()->getAttrs());
+  printer << " : " << getInputs().front().getType();
+}
+
+LogicalResult DistinctOp::verify() {
+  if (getInputs().size() < 2)
+    return emitOpError() << "'inputs' must have at least size 2, but got "
+                         << getInputs().size();
+
+  return success();
+}
+
 #define GET_OP_CLASSES
 #include "circt/Dialect/SMT/SMT.cpp.inc"

--- a/test/Dialect/SMT/basic.mlir
+++ b/test/Dialect/SMT/basic.mlir
@@ -51,5 +51,15 @@ func.func @core(%in: i8) {
   // CHECK-NEXT: }
   smt.check sat { } unknown { } unsat { }
 
+  // CHECK: %{{.*}} = smt.eq %{{.*}}, %{{.*}} {smt.some_attr} : !smt.bv<32>
+  %1 = smt.eq %b, %b {smt.some_attr} : !smt.bv<32>
+  // CHECK: %{{.*}} = smt.distinct %{{.*}}, %{{.*}} {smt.some_attr} : !smt.bv<32>
+  %2 = smt.distinct %b, %b {smt.some_attr} : !smt.bv<32>
+
+  // CHECK: %{{.*}} = smt.eq %{{.*}}, %{{.*}}, %{{.*}} : !smt.bool
+  %3 = smt.eq %a, %a, %a : !smt.bool
+  // CHECK: %{{.*}} = smt.distinct %{{.*}}, %{{.*}}, %{{.*}} : !smt.bool
+  %4 = smt.distinct %a, %a, %a : !smt.bool
+
   return
 }

--- a/test/Dialect/SMT/bitvectors.mlir
+++ b/test/Dialect/SMT/bitvectors.mlir
@@ -44,5 +44,22 @@ func.func @bitvectors() {
   // CHECK: %{{.*}} = smt.bv.xor [[C0]], [[C0]] {smt.some_attr} : !smt.bv<32>
   %16 = smt.bv.xor %c, %c {smt.some_attr} : !smt.bv<32>
 
+  // CHECK: %{{.*}} = smt.bv.cmp slt [[C0]], [[C0]] {smt.some_attr} : !smt.bv<32>
+  %17 = smt.bv.cmp slt %c, %c {smt.some_attr} : !smt.bv<32>
+  // CHECK: %{{.*}} = smt.bv.cmp sle [[C0]], [[C0]] {smt.some_attr} : !smt.bv<32>
+  %18 = smt.bv.cmp sle %c, %c {smt.some_attr} : !smt.bv<32>
+  // CHECK: %{{.*}} = smt.bv.cmp sgt [[C0]], [[C0]] {smt.some_attr} : !smt.bv<32>
+  %19 = smt.bv.cmp sgt %c, %c {smt.some_attr} : !smt.bv<32>
+  // CHECK: %{{.*}} = smt.bv.cmp sge [[C0]], [[C0]] {smt.some_attr} : !smt.bv<32>
+  %20 = smt.bv.cmp sge %c, %c {smt.some_attr} : !smt.bv<32>
+  // CHECK: %{{.*}} = smt.bv.cmp ult [[C0]], [[C0]] {smt.some_attr} : !smt.bv<32>
+  %21 = smt.bv.cmp ult %c, %c {smt.some_attr} : !smt.bv<32>
+  // CHECK: %{{.*}} = smt.bv.cmp ule [[C0]], [[C0]] {smt.some_attr} : !smt.bv<32>
+  %22 = smt.bv.cmp ule %c, %c {smt.some_attr} : !smt.bv<32>
+  // CHECK: %{{.*}} = smt.bv.cmp ugt [[C0]], [[C0]] {smt.some_attr} : !smt.bv<32>
+  %23 = smt.bv.cmp ugt %c, %c {smt.some_attr} : !smt.bv<32>
+  // CHECK: %{{.*}} = smt.bv.cmp uge [[C0]], [[C0]] {smt.some_attr} : !smt.bv<32>
+  %24 = smt.bv.cmp uge %c, %c {smt.some_attr} : !smt.bv<32>
+
   return
 }

--- a/test/Dialect/SMT/core-errors.mlir
+++ b/test/Dialect/SMT/core-errors.mlir
@@ -131,3 +131,19 @@ func.func @check_no_block_arguments() {
   }
   return
 }
+
+// -----
+
+func.func @too_few_operands() {
+  // expected-error @below {{'inputs' must have at least size 2, but got 0}}
+  smt.eq : !smt.bool
+  return
+}
+
+// -----
+
+func.func @too_few_operands(%a: !smt.bool) {
+  // expected-error @below {{'inputs' must have at least size 2, but got 1}}
+  smt.distinct %a : !smt.bool
+  return
+}


### PR DESCRIPTION
Unfortunately, I had to write a custom parser for the `eq` and `distinct` operations to only specify one of the operands types (`eq %a, %b : !smt.bool` vs. `eq %a, %b : !smt.bool, !smt.bool`). Let me know if there's a feature for that in tablegen in case I missed something.