### PR TITLE
[NFC][arcilator] Reenable instrumentation for ArcToLLVM passes.

### DIFF
--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -368,6 +368,10 @@ static LogicalResult processBuffer(
   pmLlvm.enableTiming(ts);
   if (failed(applyPassManagerCLOptions(pmLlvm)))
     return failure();
+  if (verbosePassExecutions)
+    pmLlvm.addInstrumentation(
+        std::make_unique<VerbosePassInstrumentation<mlir::ModuleOp>>(
+            "arcilator"));
   populateArcToLLVMPipeline(pmLlvm);
 
   if (printDebugInfo && outputFormat == OutputLLVM)


### PR DESCRIPTION
Yet another tiny PR:
Add `VerbosePassInstrumentation` to the second pass manager of the arcilator tool to include its statistics in the `--verbose-pass-executions` output.