### PR TITLE
[SMT] Add concat, extract, repeat operations

### DIFF
--- a/include/circt/Dialect/SMT/SMTBitVectorOps.td
+++ b/include/circt/Dialect/SMT/SMTBitVectorOps.td
@@ -146,4 +146,96 @@ def BVCmpOp : SMTBVOp<"cmp", [Pure, SameTypeOperands]> {
   }];
 }
 
+def ConcatOp : SMTBVOp<"concat", [
+  Pure,
+  DeclareOpInterfaceMethods<InferTypeOpInterface, ["inferReturnTypes"]>
+]> {
+  let summary = "bit-vector concatenation";
+  let description = [{
+    This operation concatenates bit-vector values with semantics equivalent to
+    the `concat` operator defined in the SMT-LIB 2.6 standard. More precisely in
+    the [theory of FixedSizeBitVectors](https://smtlib.cs.uiowa.edu/Theories/FixedSizeBitVectors.smt2)
+    and the [QF_BV logic](https://smtlib.cs.uiowa.edu/Logics/QF_BV.smt2)
+    describing closed quantifier-free formulas over the theory of fixed-size
+    bit-vectors.
+
+    Note that the following equivalences hold:
+    * `smt.bv.concat %a, %b : !smt.bv<4>, !smt.bv<4>` is equivalent to
+      `(concat a b)` in SMT-LIB
+    * `(= (concat #xf #x0) #xf0)`
+  }];
+
+  let arguments = (ins BitVectorType:$lhs, BitVectorType:$rhs);
+  let results = (outs BitVectorType:$result);
+
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` qualified(type(operands))";
+}
+
+def ExtractOp : SMTBVOp<"extract", [Pure]> {
+  let summary = "bit-vector extraction";
+  let description = [{
+    This operation extracts the range of bits starting at the 'lowBit' index
+    (inclusive) up to the 'lowBit' + result-width index (exclusive). The
+    semantics are equivalent to the `extract` operator defined in the SMT-LIB
+    2.6 standard. More precisely in the
+    [theory of FixedSizeBitVectors](https://smtlib.cs.uiowa.edu/Theories/FixedSizeBitVectors.smt2)
+    and the [QF_BV logic](https://smtlib.cs.uiowa.edu/Logics/QF_BV.smt2)
+    describing closed quantifier-free formulas over the theory of fixed-size
+    bit-vectors.
+
+    Note that `smt.bv.extract %bv from 2 : (!smt.bv<32>) -> !smt.bv<16>` is
+    equivalent to `((_ extract 17 2) bv)`, i.e., the SMT-LIB operator takes the
+    low and high indices where both are inclusive. The following equivalence
+    holds: `(= ((_ extract 3 0) #x0f) #xf)`
+  }];
+
+  let arguments = (ins I32Attr:$lowBit, BitVectorType:$input);
+  let results = (outs BitVectorType:$result);
+
+  let assemblyFormat = [{
+    $input `from` $lowBit attr-dict `:` functional-type($input, $result)
+  }];
+
+  let hasVerifier = true;
+}
+
+def RepeatOp : SMTBVOp<"repeat", [Pure]> {
+  let summary = "repeated bit-vector concatenation of one value";
+  let description = [{
+    This operation is a shorthand for repeated concatenation of the same
+    bit-vector value, i.e.,
+    ```mlir
+    smt.bv.repeat 5 times %a : !smt.bv<4>
+    // is the same as
+    %0 = smt.bv.repeat 4 times %a : !smt.bv<4>
+    smt.bv.concat %a, %0 : !smt.bv<4>, !smt.bv<16>
+    // or also 
+    %0 = smt.bv.repeat 4 times %a : !smt.bv<4>
+    smt.bv.concat %0, %a : !smt.bv<16>, !smt.bv<4>
+    ```
+    
+    The semantics are equivalent to the `repeat` operator defined in the SMT-LIB
+    2.6 standard. More precisely in the
+    [theory of FixedSizeBitVectors](https://smtlib.cs.uiowa.edu/Theories/FixedSizeBitVectors.smt2)
+    and the [QF_BV logic](https://smtlib.cs.uiowa.edu/Logics/QF_BV.smt2)
+    describing closed quantifier-free formulas over the theory of fixed-size
+    bit-vectors.
+  }];
+
+  let arguments = (ins BitVectorType:$input);
+  let results = (outs BitVectorType:$result);
+
+  let hasCustomAssemblyFormat = true;
+  let hasVerifier = true;
+
+  let builders = [
+    OpBuilder<(ins "unsigned":$count, "mlir::Value":$input)>,
+  ];
+
+  let extraClassDeclaration = [{
+    /// Get the number of times the input operand is repeated.
+    unsigned getCount();
+  }];
+}
+
 #endif // CIRCT_DIALECT_SMT_SMTBITVECTOROPS_TD

--- a/include/circt/Dialect/SMT/SMTTypes.td
+++ b/include/circt/Dialect/SMT/SMTTypes.td
@@ -29,7 +29,7 @@ def BitVectorType : SMTTypeDef<"BitVector"> {
     The bit-width must be strictly greater than zero.
   }];
 
-  let parameters = (ins "unsigned":$width);
+  let parameters = (ins "uint64_t":$width);
   let assemblyFormat = "`<` $width `>`";
 
   let genVerifyDecl = true;

--- a/lib/Dialect/SMT/SMTTypes.cpp
+++ b/lib/Dialect/SMT/SMTTypes.cpp
@@ -36,8 +36,8 @@ bool smt::isAnySMTValueType(Type type) {
 
 LogicalResult
 BitVectorType::verify(function_ref<InFlightDiagnostic()> emitError,
-                      unsigned width) {
-  if (width <= 0)
+                      uint64_t width) {
+  if (width <= 0U)
     return emitError() << "bit-vector must have at least a width of one";
   return success();
 }

--- a/test/Dialect/SMT/bitvector-errors.mlir
+++ b/test/Dialect/SMT/bitvector-errors.mlir
@@ -34,3 +34,63 @@ func.func @invalid_bitvector_attr() {
   // expected-error @below {{integer value out of range for given bit-vector type}}
   smt.bv.constant #smt.bv<-4> : !smt.bv<2>
 }
+
+// -----
+
+func.func @extraction(%arg0: !smt.bv<32>) {
+  // expected-error @below {{range to be extracted is too big, expected range starting at index 20 of length 16 requires input width of at least 36, but the input width is only 32}}
+  smt.bv.extract %arg0 from 20 : (!smt.bv<32>) -> !smt.bv<16>
+  return
+}
+
+// -----
+
+func.func @concat(%arg0: !smt.bv<32>) {
+  // expected-error @below {{inferred type(s) '!smt.bv<64>' are incompatible with return type(s) of operation '!smt.bv<33>'}}
+  // expected-error @below {{failed to infer returned types}}
+  "smt.bv.concat"(%arg0, %arg0) {} : (!smt.bv<32>, !smt.bv<32>) -> !smt.bv<33>
+  return
+}
+
+// -----
+
+func.func @repeat_result_type_no_multiple_of_input_type(%arg0: !smt.bv<32>) {
+  // expected-error @below {{result bit-vector width must be a multiple of the input bit-vector width}}
+  "smt.bv.repeat"(%arg0) : (!smt.bv<32>) -> !smt.bv<65>
+  return
+}
+
+// -----
+
+func.func @repeat_negative_count(%arg0: !smt.bv<32>) {
+  // expected-error @below {{integer must be positive}}
+  smt.bv.repeat -2 times %arg0 : !smt.bv<32>
+  return
+}
+
+// -----
+
+// The parser has to extract the bit-width of the input and thus we need to
+// test that this is handled correctly in the parser, we cannot just rely on the
+// verifier.
+func.func @repeat_wrong_input_type(%arg0: !smt.bool) {
+  // expected-error @below {{input must have bit-vector type}}
+  smt.bv.repeat 2 times %arg0 : !smt.bool
+  return
+}
+
+// -----
+
+func.func @repeat_count_too_large(%arg0: !smt.bv<32>) {
+  // expected-error @below {{integer must fit into 64 bits}}
+  smt.bv.repeat 18446744073709551617 times %arg0 : !smt.bv<32>
+  return
+}
+
+// -----
+
+func.func @repeat_result_type_bitwidth_too_large(%arg0: !smt.bv<18446744073709551612>) {
+  // expected-error @below {{result bit-width (provided integer times bit-width of the input type) must fit into 64 bits}}
+  smt.bv.repeat 2 times %arg0 : !smt.bv<18446744073709551612>
+  return
+}

--- a/test/Dialect/SMT/bitvectors.mlir
+++ b/test/Dialect/SMT/bitvectors.mlir
@@ -61,5 +61,12 @@ func.func @bitvectors() {
   // CHECK: %{{.*}} = smt.bv.cmp uge [[C0]], [[C0]] {smt.some_attr} : !smt.bv<32>
   %24 = smt.bv.cmp uge %c, %c {smt.some_attr} : !smt.bv<32>
 
+  // CHECK: %{{.*}} = smt.bv.concat [[C0]], [[C0]] {smt.some_attr} : !smt.bv<32>, !smt.bv<32>
+  %25 = smt.bv.concat %c, %c {smt.some_attr} : !smt.bv<32>, !smt.bv<32>
+  // CHECK: %{{.*}} = smt.bv.extract [[C0]] from 8 {smt.some_attr} : (!smt.bv<32>) -> !smt.bv<16>
+  %26 = smt.bv.extract %c from 8 {smt.some_attr} : (!smt.bv<32>) -> !smt.bv<16>
+  // CHECK: %{{.*}} = smt.bv.repeat 2 times [[C0]] {smt.some_attr} : !smt.bv<32>
+  %27 = smt.bv.repeat 2 times %c {smt.some_attr} : !smt.bv<32>
+
   return
 }


### PR DESCRIPTION
The last few operations to be able to fully lower comb (except `comb.mux` for which we need more boolean operators to use `ite`, and `comb.parity`).