### PR TITLE
[FIRRTL][LowerAnnotations] Fix non-probe type compat check.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -858,7 +858,7 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
       // Otherwise they must be identical or FIRRTL type-equivalent
       // (connectable).
       if (sourceFType != sinkFType &&
-          !areTypesEquivalent(sourceFType, sinkFType)) {
+          !areTypesEquivalent(sinkFType, sourceFType)) {
         auto diag = mlir::emitError(source.getLoc())
                     << "Wiring Problem source type " << sourceType
                     << " does not match sink type " << sinkType;

--- a/test/Dialect/FIRRTL/legacy-wiring.mlir
+++ b/test/Dialect/FIRRTL/legacy-wiring.mlir
@@ -206,3 +206,34 @@ firrtl.circuit "IntWidths" attributes {
     firrtl.connect %x, %invalid_ui1 : !firrtl.uint, !firrtl.uint
   }
 }
+
+// -----
+
+// Check direction of compatibility using const/non-const issue encountered (#6819).
+firrtl.circuit "Issue6819" attributes {
+ rawAnnotations = [
+  {
+    class = "firrtl.passes.wiring.SourceAnnotation",
+    target = "~Issue6819|Bar>y",
+    pin = "xyz"
+  },
+  {
+    class = "firrtl.passes.wiring.SinkAnnotation",
+    target = "~Issue6819|Issue6819>x",
+    pin = "xyz"
+  }
+  ]} {
+  firrtl.module private @Bar() {
+    %y = firrtl.wire interesting_name : !firrtl.const.uint<4>
+    %invalid = firrtl.invalidvalue : !firrtl.const.uint<4>
+    firrtl.strictconnect %y, %invalid : !firrtl.const.uint<4>
+  }
+  // CHECK-LABEL: module @Issue6819
+  firrtl.module @Issue6819() {
+    // CHECK: firrtl.connect %x, %{{[^ ]*}} : !firrtl.uint, !firrtl.const.uint<4>
+    firrtl.instance bar interesting_name @Bar()
+    %x = firrtl.wire interesting_name : !firrtl.uint
+    %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint
+    firrtl.connect %x, %invalid_ui1 : !firrtl.uint, !firrtl.uint
+  }
+}


### PR DESCRIPTION
Add test as "legacy wiring" as non-ref-type-port path is a hidden option.

Compatibility dest/source operands were backwards, introduced in #4656 .

Fixes #6819.