### PR TITLE
[Emit][Seq] Emit random init headers using fragments

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -724,7 +724,11 @@ def LowerArcToLLVM : Pass<"lower-arc-to-llvm", "mlir::ModuleOp"> {
 def LowerSeqToSV: Pass<"lower-seq-to-sv",  "mlir::ModuleOp"> {
   let summary = "Lower sequential firrtl ops to SV.";
   let constructor = "circt::createLowerSeqToSVPass()";
-  let dependentDialects = ["circt::sv::SVDialect", "circt::hw::HWDialect"];
+  let dependentDialects = [
+    "circt::emit::EmitDialect",
+    "circt::hw::HWDialect",
+    "circt::sv::SVDialect",
+  ];
   let options = [
     Option<"disableRegRandomization", "disable-reg-randomization", "bool", "false",
            "Disable emission of register randomization code">,

--- a/lib/Conversion/SeqToSV/CMakeLists.txt
+++ b/lib/Conversion/SeqToSV/CMakeLists.txt
@@ -11,5 +11,6 @@ add_circt_conversion_library(CIRCTSeqToSV
   Core
 
   LINK_LIBS PUBLIC
+  CIRCTEmit
   CIRCTSeq
 )

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -1,6 +1,65 @@
-// RUN: circt-opt %s -verify-diagnostics --lower-seq-to-sv | FileCheck %s --check-prefixes=CHECK,COMMON
+// RUN: circt-opt %s -verify-diagnostics --lower-seq-to-sv | FileCheck %s --check-prefixes=CHECK,COMMON,RANDOM
 // RUN: circt-opt %s -verify-diagnostics --pass-pipeline="builtin.module(lower-seq-to-sv{disable-reg-randomization})" | FileCheck %s --check-prefixes=COMMON,DISABLED
 // RUN: circt-opt %s -verify-diagnostics --pass-pipeline="builtin.module(lower-seq-to-sv{emit-separate-always-blocks})" | FileCheck %s --check-prefixes=SEPARATE
+
+// RANDOM-LABEL: emit.fragment @RANDOM_INIT_FRAGMENT {
+// RANDOM-NEXT:    sv.verbatim "// Standard header to adapt well known macros for register randomization."
+// RANDOM-NEXT:    sv.verbatim "\0A// RANDOM may be set to an expression that produces a 32-bit random unsigned value."
+// RANDOM-NEXT:    sv.ifdef  @RANDOM {
+// RANDOM-NEXT:    } else {
+// RANDOM-NEXT:      sv.macro.def @RANDOM "$random"
+// RANDOM-NEXT:    }
+// RANDOM-NEXT:    sv.verbatim "\0A// Users can define INIT_RANDOM as general code that gets injected into the\0A// initializer block for modules with registers."
+// RANDOM-NEXT:    sv.ifdef  @INIT_RANDOM {
+// RANDOM-NEXT:    } else {
+// RANDOM-NEXT:      sv.macro.def @INIT_RANDOM ""
+// RANDOM-NEXT:    }
+// RANDOM-NEXT:    sv.verbatim "\0A// If using random initialization, you can also define RANDOMIZE_DELAY to\0A// customize the delay used, otherwise 0.002 is used."
+// RANDOM-NEXT:    sv.ifdef  @RANDOMIZE_DELAY {
+// RANDOM-NEXT:    } else {
+// RANDOM-NEXT:      sv.macro.def @RANDOMIZE_DELAY "0.002"
+// RANDOM-NEXT:    }
+// RANDOM-NEXT:    sv.verbatim "\0A// Define INIT_RANDOM_PROLOG_ for use in our modules below."
+// RANDOM-NEXT:    sv.ifdef  @INIT_RANDOM_PROLOG_ {
+// RANDOM-NEXT:    } else {
+// RANDOM-NEXT:      sv.ifdef  @RANDOMIZE {
+// RANDOM-NEXT:        sv.ifdef  @VERILATOR {
+// RANDOM-NEXT:          sv.macro.def @INIT_RANDOM_PROLOG_ "`INIT_RANDOM"
+// RANDOM-NEXT:        } else {
+// RANDOM-NEXT:          sv.macro.def @INIT_RANDOM_PROLOG_ "`INIT_RANDOM #`RANDOMIZE_DELAY begin end"
+// RANDOM-NEXT:        }
+// RANDOM-NEXT:      } else {
+// RANDOM-NEXT:        sv.macro.def @INIT_RANDOM_PROLOG_ ""
+// RANDOM-NEXT:      }
+// RANDOM-NEXT:    }
+// RANDOM-NEXT:  }
+// RANDOM-LABEL: emit.fragment @RANDOM_INIT_REG_FRAGMENT {
+// RANDOM-NEXT:    sv.verbatim "\0A// Include register initializers in init blocks unless synthesis is set"
+// RANDOM-NEXT:    sv.ifdef  @RANDOMIZE {
+// RANDOM-NEXT:    } else {
+// RANDOM-NEXT:      sv.ifdef  @RANDOMIZE_REG_INIT {
+// RANDOM-NEXT:        sv.macro.def @RANDOMIZE ""
+// RANDOM-NEXT:      }
+// RANDOM-NEXT:    }
+// RANDOM-NEXT:    sv.ifdef  @SYNTHESIS {
+// RANDOM-NEXT:    } else {
+// RANDOM-NEXT:      sv.ifdef  @ENABLE_INITIAL_REG_ {
+// RANDOM-NEXT:      } else {
+// RANDOM-NEXT:        sv.macro.def @ENABLE_INITIAL_REG_ ""
+// RANDOM-NEXT:      }
+// RANDOM-NEXT:    }
+// RANDOM-NEXT:    sv.verbatim ""
+// RANDOM-NEXT:  }
+
+emit.fragment @SomeFragment {}
+
+// RANDOM-LABEL: hw.module @fragment_ref
+
+// RANDOM-SAME:   emit.fragments = [@SomeFragment, @RANDOM_INIT_FRAGMENT, @RANDOM_INIT_REG_FRAGMENT]
+hw.module @fragment_ref(in %clk : !seq.clock) attributes {emit.fragments = [@SomeFragment]} {
+  %cst0_i32 = hw.constant 0 : i32
+  %rA = seq.firreg %cst0_i32 clock %clk sym @regA : i32
+}
 
 // COMMON-LABEL: hw.module @lowering
 // SEPARATE-LABEL: hw.module @lowering
@@ -161,7 +220,7 @@ hw.module @lowering(in %clk : !seq.clock, in %rst : i1, in %in : i32, out a : i3
   hw.output %rA, %rB, %rC, %rD, %rE, %rF : i32, i32, i32, i32, i32, i32
 }
 
-// COMMON-LABEL: hw.module private @UninitReg1(in %clock : i1, in %reset : i1, in %cond : i1, in %value : i2) {
+// COMMON-LABEL: hw.module private @UninitReg1(in %clock : i1, in %reset : i1, in %cond : i1, in %value : i2)
 hw.module private @UninitReg1(in %clock : !seq.clock, in %reset : i1, in %cond : i1, in %value : i2) {
   // CHECK: %c0_i2 = hw.constant 0 : i2
   %c0_i2 = hw.constant 0 : i2
@@ -217,7 +276,8 @@ hw.module private @UninitReg1(in %clock : !seq.clock, in %reset : i1, in %cond :
   // CHECK: hw.output
   hw.output
 }
-// COMMON-LABEL: hw.module private @UninitReg1_nonbin(in %clock : i1, in %reset : i1, in %cond : i1, in %value : i2) {
+
+// COMMON-LABEL: hw.module private @UninitReg1_nonbin(in %clock : i1, in %reset : i1, in %cond : i1, in %value : i2)
 hw.module private @UninitReg1_nonbin(in %clock : !seq.clock, in %reset : i1, in %cond : i1, in %value : i2) {
   // CHECK: %c0_i2 = hw.constant 0 : i2
   %c0_i2 = hw.constant 0 : i2
@@ -335,7 +395,7 @@ hw.module private @InitReg1(in %clock: !seq.clock, in %reset: i1, in %io_d: i32,
   hw.output %reg : i32
 }
 
-// COMMON-LABEL: hw.module private @UninitReg42(in %clock : i1, in %reset : i1, in %cond : i1, in %value : i42) {
+// COMMON-LABEL: hw.module private @UninitReg42(in %clock : i1, in %reset : i1, in %cond : i1, in %value : i42)
 hw.module private @UninitReg42(in %clock: !seq.clock, in %reset: i1, in %cond: i1, in %value: i42) {
   %c0_i42 = hw.constant 0 : i42
   %count = seq.firreg %1 clock %clock sym @count : i42


### PR DESCRIPTION
The verbatims and SV macros are grouped into fragments now. As a beneficial side effect, a module is prefixed with fragments in its file only when it is actually using the fragments, reducing output size.