### PR TITLE
[FSM][Emit] Convert the FSMToSV pass to use `emit` ops

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -404,8 +404,13 @@ def CalyxRemoveGroupsFromFSM : Pass<"calyx-remove-groups-fsm", "calyx::Component
 def ConvertFSMToSV : Pass<"convert-fsm-to-sv", "mlir::ModuleOp"> {
   let summary = "Convert FSM to SV and HW";
   let constructor = "circt::createConvertFSMToSVPass()";
-  let dependentDialects = ["circt::hw::HWDialect", "circt::comb::CombDialect",
-                           "circt::seq::SeqDialect", "circt::sv::SVDialect"];
+  let dependentDialects = [
+      "circt::comb::CombDialect",
+      "circt::emit::EmitDialect",
+      "circt::hw::HWDialect",
+      "circt::seq::SeqDialect",
+      "circt::sv::SVDialect",
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/HW/HWTypeDecls.td
+++ b/include/circt/Dialect/HW/HWTypeDecls.td
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_HW_HWTYPEDECLS_TD
 #define CIRCT_DIALECT_HW_HWTYPEDECLS_TD
 
+include "circt/Dialect/Emit/EmitOpInterfaces.td"
 include "circt/Dialect/HW/HWDialect.td"
 include "mlir/IR/SymbolInterfaces.td"
 
@@ -20,8 +21,14 @@ include "mlir/IR/SymbolInterfaces.td"
 // Declaration operations
 //===----------------------------------------------------------------------===//
 
-def TypeScopeOp : HWOp<"type_scope",
-      [Symbol, SymbolTable, SingleBlock, NoTerminator, NoRegionArguments]> {
+def TypeScopeOp : HWOp<"type_scope", [
+    Emittable,
+    Symbol,
+    SymbolTable,
+    SingleBlock,
+    NoTerminator,
+    NoRegionArguments
+]> {
   let summary = "Type declaration wrapper.";
   let description = [{
     An operation whose one body block contains type declarations. This op

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -6060,6 +6060,9 @@ void FileEmitter::emit(Block *block) {
         .Case<VerbatimOp, IfDefOp, MacroDefOp>(
             [&](auto op) { ModuleEmitter(state).emitStatement(op); })
         .Case<BindOp>([&](auto op) { ModuleEmitter(state).emitBind(op); })
+        .Case<TypeScopeOp>([&](auto typedecls) {
+          ModuleEmitter(state).emitStatement(typedecls);
+        })
         .Default(
             [&](auto op) { emitOpError(op, "cannot be emitted to a file"); });
   }
@@ -6091,6 +6094,9 @@ void FileEmitter::emitOp(emit::RefOp op) {
   TypeSwitch<Operation *>(targetOp)
       .Case<hw::HWModuleOp>(
           [&](auto module) { ModuleEmitter(state).emitHWModule(module); })
+      .Case<TypeScopeOp>([&](auto typedecls) {
+        ModuleEmitter(state).emitStatement(typedecls);
+      })
       .Default(
           [&](auto op) { emitOpError(op, "cannot be emitted to a file"); });
 }

--- a/lib/Conversion/FSMToSV/CMakeLists.txt
+++ b/lib/Conversion/FSMToSV/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_conversion_library(CIRCTFSMToSV
     LINK_LIBS PUBLIC
     CIRCTComb
     CIRCTHW
+    CIRCTEmit
     CIRCTFSM
     CIRCTSeq
     CIRCTSV

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -9,6 +9,7 @@
 #include "circt/Conversion/FSMToSV.h"
 #include "../PassDetail.h"
 #include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/Emit/EmitOps.h"
 #include "circt/Dialect/FSM/FSMOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVOps.h"
@@ -212,8 +213,9 @@ void StateEncoding::setEncoding(StateOp state, Value v, bool wire) {
 class MachineOpConverter {
 public:
   MachineOpConverter(OpBuilder &builder, hw::TypeScopeOp typeScope,
-                     MachineOp machineOp)
-      : machineOp(machineOp), typeScope(typeScope), b(builder) {}
+                     MachineOp machineOp, FlatSymbolRefAttr headerName)
+      : machineOp(machineOp), typeScope(typeScope), b(builder),
+        headerName(headerName) {}
 
   // Converts the machine op to a hardware module.
   // 1. Creates a HWModuleOp for the machine op, with the same I/O as the FSM +
@@ -310,7 +312,6 @@ private:
 
   // A handle to the MachineOp being converted.
   MachineOp machineOp;
-
   // A handle to the HW ModuleOp being created.
   hw::HWModuleOp hwModuleOp;
 
@@ -321,6 +322,9 @@ private:
   hw::TypeScopeOp typeScope;
 
   OpBuilder &b;
+
+  // The name of the header which contains the type scope for the machine.
+  FlatSymbolRefAttr headerName;
 };
 
 FailureOr<Operation *>
@@ -412,6 +416,7 @@ LogicalResult MachineOpConverter::dispatch() {
   SmallVector<hw::PortInfo, 16> ports;
   auto clkRstIdxs = getMachinePortInfo(ports, machineOp, b);
   hwModuleOp = b.create<hw::HWModuleOp>(loc, machineOp.getSymNameAttr(), ports);
+  hwModuleOp->setAttr("emit.fragments", b.getArrayAttr({headerName}));
   b.setInsertionPointToStart(hwModuleOp.getBodyBlock());
 
   // Replace all uses of the machine arguments with the arguments of the
@@ -671,26 +676,37 @@ struct FSMToSVPass : public ConvertFSMToSVBase<FSMToSVPass> {
 
 void FSMToSVPass::runOnOperation() {
   auto module = getOperation();
+  auto loc = module.getLoc();
   auto b = OpBuilder(module);
-  SmallVector<Operation *, 16> opToErase;
+
+  // Identify the machines to lower, bail out if none exist.
+  auto machineOps = llvm::to_vector(module.getOps<MachineOp>());
+  if (machineOps.empty()) {
+    markAllAnalysesPreserved();
+    return;
+  }
 
   // Create a typescope shared by all of the FSMs. This typescope will be
   // emitted in a single separate file to avoid polluting each output file with
   // typedefs.
-  StringAttr typeScopeFilename = b.getStringAttr("fsm_enum_typedefs.sv");
   b.setInsertionPointToStart(module.getBody());
-  auto typeScope = b.create<hw::TypeScopeOp>(
-      module.getLoc(), b.getStringAttr("fsm_enum_typedecls"));
+  hw::TypeScopeOp typeScope =
+      b.create<hw::TypeScopeOp>(loc, b.getStringAttr("fsm_enum_typedecls"));
   typeScope.getBodyRegion().push_back(new Block());
-  typeScope->setAttr(
-      "output_file",
-      hw::OutputFileAttr::get(typeScopeFilename,
-                              /*excludeFromFileList*/ b.getBoolAttr(false),
-                              /*includeReplicatedOps*/ b.getBoolAttr(false)));
+
+  auto file = b.create<emit::FileOp>(loc, "fsm_enum_typedefs.sv", [&] {
+    b.create<emit::RefOp>(loc,
+                          FlatSymbolRefAttr::get(typeScope.getSymNameAttr()));
+  });
+  auto fragment = b.create<emit::FragmentOp>(loc, "FSM_ENUM_TYPEDEFS", [&] {
+    b.create<sv::VerbatimOp>(loc, "`include \"" + file.getFileName() + "\"");
+  });
+
+  auto headerName = FlatSymbolRefAttr::get(fragment.getSymNameAttr());
 
   // Traverse all machines and convert.
-  for (auto machine : llvm::make_early_inc_range(module.getOps<MachineOp>())) {
-    MachineOpConverter converter(b, typeScope, machine);
+  for (auto machineOp : machineOps) {
+    MachineOpConverter converter(b, typeScope, machineOp, headerName);
 
     if (failed(converter.dispatch())) {
       signalPassFailure();
@@ -718,16 +734,7 @@ void FSMToSVPass::runOnOperation() {
     instance.erase();
   }
 
-  if (typeScope.getBodyBlock()->empty()) {
-    // If the typescope is empty (no FSMs were converted), erase it.
-    typeScope.erase();
-  } else {
-    // Else, add an include file to the top-level (will include typescope
-    // in all files).
-    b.setInsertionPointToStart(module.getBody());
-    b.create<sv::VerbatimOp>(
-        module.getLoc(), "`include \"" + typeScopeFilename.getValue() + "\"");
-  }
+  assert(!typeScope.getBodyBlock()->empty() && "missing type decls");
 }
 
 } // end anonymous namespace

--- a/test/Conversion/FSMToSV/test_basic.mlir
+++ b/test/Conversion/FSMToSV/test_basic.mlir
@@ -30,7 +30,7 @@ hw.module @top(in %arg0: i1, in %arg1: i1, in %clk : !seq.clock, in %rst : i1, o
 // CHECK-NEXT:     hw.typedecl @top_state_t : !hw.enum<A, B>
 // CHECK-NEXT:   }
 
-// CHECK-LABEL:  hw.module @top(in %a0 : i1, in %a1 : i1, out r0 : i8, out r1 : i8, in %clk : !seq.clock, in %rst : i1) {
+// CHECK-LABEL:  hw.module @top(in %a0 : i1, in %a1 : i1, out r0 : i8, out r1 : i8, in %clk : !seq.clock, in %rst : i1)
 // CHECK-NEXT:    %A = hw.enum.constant A : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:    %to_A = sv.reg sym @A  : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
 // CHECK-NEXT:    sv.assign %to_A, %A : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
@@ -92,6 +92,7 @@ fsm.machine @top(%a0: i1, %arg1: i1) -> (i8, i8) attributes {initialState = "A",
 
 // -----
 
+// CHECK-LABEL:   hw.module @FSM(in %in0 : i1, in %in1 : i1, out out0 : i16, in %clk : !seq.clock, in %rst : i1)
 // CHECK:       %[[CNT_ADD_1:.*]] = comb.add %cnt_reg, %c1_i16 : i16
 // CHECK:       sv.alwayscomb {
 // CHECK-NEXT:    sv.bpassign %cnt_next, %cnt_reg : i16
@@ -140,17 +141,24 @@ fsm.machine @FSM(%arg0: i1, %arg1: i1) -> (i16) attributes {initialState = "A"} 
 
 // -----
 
-// CHECK:      hw.type_scope @fsm_enum_typedecls {
-// CHECK-NEXT:   hw.typedecl @M2_state_t : !hw.enum<A, B>
-// CHECK-NEXT:   hw.typedecl @M1_state_t : !hw.enum<A, B>
-// CHECK-NEXT: } {output_file = #hw.output_file<"fsm_enum_typedefs.sv">}
+// CHECK-LABEL: hw.type_scope @fsm_enum_typedecls {
+// CHECK-NEXT:    hw.typedecl @M2_state_t : !hw.enum<A, B>
+// CHECK-NEXT:    hw.typedecl @M1_state_t : !hw.enum<A, B>
+// CHECK-NEXT:  }
+// CHECK-LABEL: emit.file "fsm_enum_typedefs.sv" {
+// CHECK-NEXT:    emit.ref @fsm_enum_typedecls
+// CHECK-NEXT:  }
+// CHECK-LABEL: emit.fragment @FSM_ENUM_TYPEDEFS {
+// CHECK-NEXT:    sv.verbatim "`include \22fsm_enum_typedefs.sv\22"
+// CHECK-NEXT:  }
 
 module {
+  // CHECK-LABEL: hw.module @M1(out out0 : i16, in %clk : !seq.clock, in %rst : i1) attributes {emit.fragments = [@FSM_ENUM_TYPEDEFS]}
   fsm.machine @M1() attributes {initialState = "A"} {
     fsm.state @A
     fsm.state @B
   }
-
+  // CHECK-LABEL: hw.module @M2(out out0 : i16, in %clk : !seq.clock, in %rst : i1) attributes {emit.fragments = [@FSM_ENUM_TYPEDEFS]}
   fsm.machine @M2() attributes {initialState = "A"} {
     fsm.state @A
     fsm.state @B


### PR DESCRIPTION
Instead of relying on replicated ops, the pass now directly sets up its file structure using `emit` ops. As a side effect, the type scope file is no longer included in the default file list as that one is only going to include SV files generated from `hw.module`.