### PR TITLE
[ExportVerilog] Disallow disable iff cond to be inlined based on option.

### DIFF
--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -147,6 +147,26 @@ module attributes {circt.loweringOptions = "disallowExpressionInliningInPorts"} 
 }
 
 // -----
+
+module attributes {circt.loweringOptions = "disallowExpressionInliningInPorts"} {
+  // CHECK-LABEL: @DisableIff
+  hw.module @DisableIff(in %clk: i1, in %a: i1, in %b: i1) {
+    %b_xor_b = comb.xor %b, %b : i1
+  
+    // CHECK: %[[XOR:.+]] = comb.xor
+    // CHECK: %[[WIRE:.+]] = sv.wire
+    // CHECK: sv.assign %[[WIRE]], %[[XOR]]
+    // CHECK: %[[READ:.+]] = sv.read_inout %[[WIRE]]
+    // CHECK: ltl.disable %{{.+}} if %[[READ]]
+    %i0 = ltl.implication %a, %b : i1, i1
+    %k0 = ltl.clock %i0, posedge %clk : !ltl.property
+    %k5 = ltl.disable %k0 if %b_xor_b : !ltl.property
+  
+    verif.assert %k5: !ltl.property
+  }
+}
+
+// -----
 module attributes {circt.loweringOptions =
                   "wireSpillingHeuristic=spillLargeTermsWithNamehints,wireSpillingNamehintTermLimit=3"} {
   // CHECK-LABEL: namehints


### PR DESCRIPTION
When disallowing expressions in "event control", also disallow the disable iff condition to be inlined.