### PR TITLE
[ImportVerilog] Add if and loop statements

### DIFF
--- a/lib/Conversion/ImportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ImportVerilog/CMakeLists.txt
@@ -40,7 +40,9 @@ add_circt_translation_library(CIRCTImportVerilog
 
   LINK_LIBS PUBLIC
   CIRCTMoore
+  CIRCTHW
   MLIRTranslateLib
+  MLIRSCFDialect
   PRIVATE
   slang_slang
 )

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -259,7 +259,8 @@ LogicalResult ImportDriver::importVerilog(ModuleOp module) {
   compileTimer.stop();
 
   // Traverse the parsed Verilog AST and map it to the equivalent CIRCT ops.
-  mlirContext->loadDialect<moore::MooreDialect>();
+  mlirContext
+      ->loadDialect<moore::MooreDialect, hw::HWDialect, scf::SCFDialect>();
   auto conversionTimer = ts.nest("Verilog to dialect mapping");
   Context context(module, driver.sourceManager, bufferFilePaths);
   if (failed(context.convertCompilation(*compilation)))

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -11,7 +11,9 @@
 #define CONVERSION_IMPORTVERILOG_IMPORTVERILOGINTERNALS_H
 
 #include "circt/Conversion/ImportVerilog.h"
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/Moore/MooreOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "slang/ast/ASTVisitor.h"
 #include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/Support/Debug.h"

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -8,6 +8,7 @@
 
 #include "ImportVerilogInternals.h"
 
+using namespace mlir;
 using namespace circt;
 using namespace ImportVerilog;
 
@@ -64,6 +65,183 @@ struct StmtVisitor {
 
     builder.create<moore::VariableOp>(loc, type,
                                       builder.getStringAttr(var.name), initial);
+    return success();
+  }
+
+  // Handle if statements.
+  LogicalResult visit(const slang::ast::ConditionalStatement &stmt) {
+    // Generate the condition. There may be multiple conditions linked with the
+    // `&&&` operator.
+    Value allConds;
+    for (const auto &condition : stmt.conditions) {
+      if (condition.pattern)
+        return mlir::emitError(loc,
+                               "match patterns in if conditions not supported");
+      auto cond = context.convertExpression(*condition.expr);
+      if (!cond)
+        return failure();
+      cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
+      if (allConds)
+        allConds = builder.create<moore::AndOp>(loc, allConds, cond);
+      else
+        allConds = cond;
+    }
+    assert(allConds && "slang guarantees at least one condition");
+    allConds =
+        builder.create<moore::ConversionOp>(loc, builder.getI1Type(), allConds);
+
+    // Generate the if operation.
+    auto ifOp =
+        builder.create<scf::IfOp>(loc, allConds, stmt.ifFalse != nullptr);
+    OpBuilder::InsertionGuard guard(builder);
+
+    // Generate the "then" body.
+    builder.setInsertionPoint(ifOp.thenYield());
+    if (failed(context.convertStatement(stmt.ifTrue)))
+      return failure();
+
+    // Generate the "else" body if present.
+    if (stmt.ifFalse) {
+      builder.setInsertionPoint(ifOp.elseYield());
+      if (failed(context.convertStatement(*stmt.ifFalse)))
+        return failure();
+    }
+
+    return success();
+  }
+
+  // Handle `for` loops.
+  LogicalResult visit(const slang::ast::ForLoopStatement &stmt) {
+    if (!stmt.loopVars.empty())
+      return mlir::emitError(loc,
+                             "variables in for loop initializer not supported");
+
+    // Generate the initializers.
+    for (auto *initExpr : stmt.initializers)
+      if (!context.convertExpression(*initExpr))
+        return failure();
+
+    // Create the while op.
+    auto whileOp = builder.create<scf::WhileOp>(loc, TypeRange{}, ValueRange{});
+    OpBuilder::InsertionGuard guard(builder);
+
+    // In the "before" region, check that the condition holds.
+    builder.createBlock(&whileOp.getBefore());
+    auto cond = context.convertExpression(*stmt.stopExpr);
+    if (!cond)
+      return failure();
+    cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
+    cond = builder.create<moore::ConversionOp>(loc, builder.getI1Type(), cond);
+    builder.create<mlir::scf::ConditionOp>(loc, cond, ValueRange{});
+
+    // In the "after" region, generate the loop body and step expressions.
+    builder.createBlock(&whileOp.getAfter());
+    if (failed(context.convertStatement(stmt.body)))
+      return failure();
+    for (auto *stepExpr : stmt.steps)
+      if (!context.convertExpression(*stepExpr))
+        return failure();
+    builder.create<mlir::scf::YieldOp>(loc);
+
+    return success();
+  }
+
+  // Handle `repeat` loops.
+  LogicalResult visit(const slang::ast::RepeatLoopStatement &stmt) {
+    // Create the while op and feed in the repeat count as the initial counter
+    // value.
+    auto count = context.convertExpression(stmt.count);
+    if (!count)
+      return failure();
+    auto type = count.getType();
+    auto whileOp = builder.create<scf::WhileOp>(loc, type, count);
+    OpBuilder::InsertionGuard guard(builder);
+
+    // In the "before" region, check that the counter is non-zero.
+    auto *block = builder.createBlock(&whileOp.getBefore(), {}, type, loc);
+    auto counterArg = block->getArgument(0);
+    auto cond = builder.createOrFold<moore::BoolCastOp>(loc, counterArg);
+    cond = builder.create<moore::ConversionOp>(loc, builder.getI1Type(), cond);
+    builder.create<scf::ConditionOp>(loc, cond, counterArg);
+
+    // In the "after" region, generate the loop body and decrement the counter.
+    block = builder.createBlock(&whileOp.getAfter(), {}, type, loc);
+    if (failed(context.convertStatement(stmt.body)))
+      return failure();
+    counterArg = block->getArgument(0);
+    auto constOne = builder.create<moore::ConstantOp>(loc, type, 1);
+    auto subOp = builder.create<moore::SubOp>(loc, counterArg, constOne);
+    builder.create<scf::YieldOp>(loc, ValueRange{subOp});
+
+    return success();
+  }
+
+  // Handle `while` loops.
+  LogicalResult visit(const slang::ast::WhileLoopStatement &stmt) {
+    // Create the while op.
+    auto whileOp = builder.create<scf::WhileOp>(loc, TypeRange{}, ValueRange{});
+    OpBuilder::InsertionGuard guard(builder);
+
+    // In the "before" region, check that the condition holds.
+    builder.createBlock(&whileOp.getBefore());
+    auto cond = context.convertExpression(stmt.cond);
+    if (!cond)
+      return failure();
+    cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
+    cond = builder.create<moore::ConversionOp>(loc, builder.getI1Type(), cond);
+    builder.create<mlir::scf::ConditionOp>(loc, cond, ValueRange{});
+
+    // In the "after" region, generate the loop body.
+    builder.createBlock(&whileOp.getAfter());
+    if (failed(context.convertStatement(stmt.body)))
+      return failure();
+    builder.create<mlir::scf::YieldOp>(loc);
+
+    return success();
+  }
+
+  // Handle `do ... while` loops.
+  LogicalResult visit(const slang::ast::DoWhileLoopStatement &stmt) {
+    // Create the while op.
+    auto whileOp = builder.create<scf::WhileOp>(loc, TypeRange{}, ValueRange{});
+    OpBuilder::InsertionGuard guard(builder);
+
+    // In the "before" region, generate the loop body and check that the
+    // condition holds.
+    builder.createBlock(&whileOp.getBefore());
+    if (failed(context.convertStatement(stmt.body)))
+      return failure();
+    auto cond = context.convertExpression(stmt.cond);
+    if (!cond)
+      return failure();
+    cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
+    cond = builder.create<moore::ConversionOp>(loc, builder.getI1Type(), cond);
+    builder.create<mlir::scf::ConditionOp>(loc, cond, ValueRange{});
+
+    // Generate an empty "after" region.
+    builder.createBlock(&whileOp.getAfter());
+    builder.create<mlir::scf::YieldOp>(loc);
+
+    return success();
+  }
+
+  // Handle `forever` loops.
+  LogicalResult visit(const slang::ast::ForeverLoopStatement &stmt) {
+    // Create the while op.
+    auto whileOp = builder.create<scf::WhileOp>(loc, TypeRange{}, ValueRange{});
+    OpBuilder::InsertionGuard guard(builder);
+
+    // In the "before" region, return true for the condition.
+    builder.createBlock(&whileOp.getBefore());
+    auto cond = builder.create<hw::ConstantOp>(loc, builder.getI1Type(), 1);
+    builder.create<mlir::scf::ConditionOp>(loc, cond, ValueRange{});
+
+    // In the "after" region, generate the loop body.
+    builder.createBlock(&whileOp.getAfter());
+    if (failed(context.convertStatement(stmt.body)))
+      return failure();
+    builder.create<mlir::scf::YieldOp>(loc);
+
     return success();
   }
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -84,7 +84,108 @@ endmodule
 // CHECK-LABEL: moore.module @Statements
 module Statements;
   bit x, y, z;
+  int i;
   initial begin
+    //===------------------------------------------------------------------===//
+    // Conditional statements
+
+    // CHECK: [[COND:%.+]] = moore.conversion %x : !moore.bit -> i1
+    // CHECK: scf.if [[COND]] {
+    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK: }
+    if (x) x = y;
+
+    // CHECK: [[COND0:%.+]] = moore.and %x, %y
+    // CHECK: [[COND1:%.+]] = moore.conversion [[COND0]] : !moore.bit -> i1
+    // CHECK: scf.if [[COND1]] {
+    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK: }
+    if (x &&& y) x = y;
+
+    // CHECK: [[COND:%.+]] = moore.conversion %x : !moore.bit -> i1
+    // CHECK: scf.if [[COND]] {
+    // CHECK:   moore.blocking_assign %x, %z
+    // CHECK: } else {
+    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK: }
+    if (x) x = z; else x = y;
+
+    // CHECK: [[COND:%.+]] = moore.conversion %x : !moore.bit -> i1
+    // CHECK: scf.if [[COND]] {
+    // CHECK:   moore.blocking_assign %x, %x
+    // CHECK: } else {
+    // CHECK:   [[COND:%.+]] = moore.conversion %y : !moore.bit -> i1
+    // CHECK:   scf.if [[COND]] {
+    // CHECK:     moore.blocking_assign %x, %y
+    // CHECK:   } else {
+    // CHECK:     moore.blocking_assign %x, %z
+    // CHECK:   }
+    // CHECK: }
+    if (x) begin
+      x = x;
+    end else if (y) begin
+      x = y;
+    end else begin
+      x = z;
+    end
+
+    //===------------------------------------------------------------------===//
+    // Loop statements
+
+    // CHECK: moore.blocking_assign %y, %x
+    // CHECK: scf.while : () -> () {
+    // CHECK:   [[COND:%.+]] = moore.conversion %x : !moore.bit -> i1
+    // CHECK:   scf.condition([[COND]])
+    // CHECK: } do {
+    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK:   moore.blocking_assign %x, %z
+    // CHECK:   scf.yield
+    // CHECK: }
+    for (y = x; x; x = z) x = y;
+
+    // CHECK: scf.while (%arg0 = %i) : (!moore.int) -> !moore.int {
+    // CHECK:   [[TMP0:%.+]] = moore.bool_cast %arg0 : !moore.int -> !moore.bit
+    // CHECK:   [[TMP1:%.+]] = moore.conversion [[TMP0]] : !moore.bit -> i1
+    // CHECK:   scf.condition([[TMP1]]) %arg0 : !moore.int
+    // CHECK: } do {
+    // CHECK: ^bb0(%arg0: !moore.int):
+    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK:   [[TMP0:%.+]] = moore.constant 1 : !moore.int
+    // CHECK:   [[TMP1:%.+]] = moore.sub %arg0, [[TMP0]] : !moore.int
+    // CHECK:   scf.yield [[TMP1]] : !moore.int
+    // CHECK: }
+    repeat (i) x = y;
+
+    // CHECK: scf.while : () -> () {
+    // CHECK:   [[COND:%.+]] = moore.conversion %x : !moore.bit -> i1
+    // CHECK:   scf.condition([[COND]])
+    // CHECK: } do {
+    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK:   scf.yield
+    // CHECK: }
+    while (x) x = y;
+
+    // CHECK: scf.while : () -> () {
+    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK:   [[COND:%.+]] = moore.conversion %x : !moore.bit -> i1
+    // CHECK:   scf.condition([[COND]])
+    // CHECK: } do {
+    // CHECK:   scf.yield
+    // CHECK: }
+    do x = y; while (x);
+
+    // CHECK: scf.while : () -> () {
+    // CHECK:   %true = hw.constant true
+    // CHECK:   scf.condition(%true)
+    // CHECK: } do {
+    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK:   scf.yield
+    // CHECK: }
+    forever x = y;
+
+    //===------------------------------------------------------------------===//
+    // Assignments
+
     // CHECK: moore.blocking_assign %x, %y : !moore.bit
     x = y;
 

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -80,6 +80,22 @@ endmodule
 // -----
 
 module Foo;
+  bit x, y;
+  // expected-error @below {{match patterns in if conditions not supported}}
+  initial if (x matches 42) x = y;
+endmodule
+
+// -----
+
+module Foo;
+  bit y;
+  // expected-error @below {{variables in for loop initializer not supported}}
+  initial for (bit x = 0; x;) x = y;
+endmodule
+
+// -----
+
+module Foo;
   logic x;
   // expected-error @below {{literals with X or Z bits not supported}}
   initial x = 'x;


### PR DESCRIPTION
Extend the `ImportVerilog` conversion to support `if` statements and `for`, `repeat`, `while`, `do ... while`, and `forever` loops. Lower them to `scf.if` and `scf.while` ops for now. In the future, since Verilog has `break`, `continue`, and `return` statements, we may have to switch to a different dialect or defined these ops in the Moore dialect.