### PR TITLE
[Verif] Add LEC operation

### DIFF
--- a/include/circt/Conversion/Passes.h
+++ b/include/circt/Conversion/Passes.h
@@ -43,6 +43,7 @@
 #include "circt/Conversion/SCFToCalyx.h"
 #include "circt/Conversion/SeqToSV.h"
 #include "circt/Conversion/SimToSV.h"
+#include "circt/Conversion/VerifToSMT.h"
 #include "circt/Conversion/VerifToSV.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/Pass/Pass.h"

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -688,6 +688,15 @@ def ConvertHWToSMT : Pass<"convert-hw-to-smt", "mlir::ModuleOp"> {
 }
 
 //===----------------------------------------------------------------------===//
+// ConvertVerifToSMT
+//===----------------------------------------------------------------------===//
+
+def ConvertVerifToSMT : Pass<"convert-verif-to-smt", "mlir::ModuleOp"> {
+  let summary = "Convert Verif ops to SMT ops";
+  let dependentDialects = ["smt::SMTDialect", "mlir::arith::ArithDialect"];
+}
+
+//===----------------------------------------------------------------------===//
 // ConvertArcToLLVM
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Conversion/VerifToSMT.h
+++ b/include/circt/Conversion/VerifToSMT.h
@@ -1,0 +1,26 @@
+//===- VerifToSMT.h - Verif to SMT dialect conversion -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_CONVERSION_VERIFTOSMT_H
+#define CIRCT_CONVERSION_VERIFTOSMT_H
+
+#include "circt/Support/LLVM.h"
+#include <memory>
+
+namespace circt {
+
+/// Get the Verif to SMT conversion patterns.
+void populateVerifToSMTConversionPatterns(TypeConverter &converter,
+                                          RewritePatternSet &patterns);
+
+#define GEN_PASS_DECL_CONVERTVERIFTOSMT
+#include "circt/Conversion/Passes.h.inc"
+
+} // namespace circt
+
+#endif // CIRCT_CONVERSION_VERIFTOSMT_H

--- a/include/circt/Dialect/SMT/SMTOps.td
+++ b/include/circt/Dialect/SMT/SMTOps.td
@@ -47,6 +47,12 @@ def DeclareConstOp : SMTOp<"declare_const", [
   let assemblyFormat = [{
     ($namePrefix^)? attr-dict `:` qualified(type($result))
   }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$type), [{
+      build($_builder, $_state, type, nullptr);
+    }]>
+  ];
 }
 
 def BoolConstantOp : SMTOp<"constant", [

--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -109,4 +109,53 @@ def HasBeenResetOp : VerifOp<"has_been_reset", [Pure]> {
   let hasFolder = true;
 }
 
+//===----------------------------------------------------------------------===//
+// Logical Equivalence Checking and Model Checking
+//===----------------------------------------------------------------------===//
+
+def LogicEquivalenceCheckingOp : VerifOp<"lec", [
+  IsolatedFromAbove,
+  SingleBlockImplicitTerminator<"verif::YieldOp">,
+]> {
+  let summary = "represents a logical equivalence checking problem";
+  let description = [{
+    This operation represents a logic equivalence checking problem explicitly in
+    the IR. There are several possiblities to perform logical equivalence
+    checking. For example, equivalence checking of combinational circuits can be
+    done by constructing a miter circuit and testing whether the result is
+    satisfiable (can be non-zero for some input), or two canonical BDDs could be
+    constructed and compared for identity, etc.
+    
+    The number and types of the inputs and outputs of the two circuits (and thus
+    also the block arguments and yielded values of both regions) have to match.
+    Otherwise, the two should be considered trivially non-equivalent.
+  }];
+
+  let results = (outs I1:$areEquivalent);
+  let regions = (region SizedRegion<1>:$firstCircuit,
+                        SizedRegion<1>:$secondCircuit);
+
+  let assemblyFormat = [{
+    attr-dict `first` $firstCircuit `second` $secondCircuit
+  }];
+
+  let hasRegionVerifier = true;
+}
+
+def YieldOp : VerifOp<"yield", [
+  Terminator,
+  ParentOneOf<["verif::LogicEquivalenceCheckingOp"]>
+]> {
+  let summary = "yields values from a region";
+
+  let arguments = (ins Variadic<AnyType>:$inputs);
+  let assemblyFormat = "($inputs^ `:` type($inputs))? attr-dict";
+
+  let builders = [
+    OpBuilder<(ins), [{
+      build($_builder, $_state, std::nullopt);
+    }]>,
+  ];
+}
+
 #endif // CIRCT_DIALECT_VERIF_VERIFOPS_TD

--- a/lib/CAPI/Conversion/CMakeLists.txt
+++ b/lib/CAPI/Conversion/CMakeLists.txt
@@ -33,5 +33,6 @@ add_mlir_public_c_api_library(CIRCTCAPIConversion
   CIRCTSeqToSV
   CIRCTSimToSV
   CIRCTCFToHandshake
+  CIRCTVerifToSMT
   CIRCTVerifToSV
 )

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -28,6 +28,7 @@ add_subdirectory(SCFToCalyx)
 add_subdirectory(SeqToSV)
 add_subdirectory(SimToSV)
 add_subdirectory(CFToHandshake)
+add_subdirectory(VerifToSMT)
 add_subdirectory(VerifToSV)
 add_subdirectory(CalyxNative)
 

--- a/lib/Conversion/VerifToSMT/CMakeLists.txt
+++ b/lib/Conversion/VerifToSMT/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_circt_conversion_library(CIRCTVerifToSMT
+  VerifToSMT.cpp
+
+  DEPENDS
+  CIRCTConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  CIRCTHW
+  CIRCTHWToSMT
+  CIRCTSMT
+  CIRCTVerif
+  MLIRArithDialect
+  MLIRTransforms
+  MLIRTransformUtils
+  MLIRReconcileUnrealizedCasts
+)

--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -1,0 +1,200 @@
+//===- VerifToSMT.cpp -----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Conversion/VerifToSMT.h"
+#include "circt/Conversion/HWToSMT.h"
+#include "circt/Dialect/SMT/SMTOps.h"
+#include "circt/Dialect/Verif/VerifOps.h"
+#include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace circt {
+#define GEN_PASS_DEF_CONVERTVERIFTOSMT
+#include "circt/Conversion/Passes.h.inc"
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace hw;
+
+//===----------------------------------------------------------------------===//
+// Conversion patterns
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Lower a verif::AssertOp operation with an i1 operand to a smt::AssertOp.
+struct VerifAssertOpConversion : OpConversionPattern<verif::AssertOp> {
+  using OpConversionPattern<verif::AssertOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(verif::AssertOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value cond = typeConverter->materializeTargetConversion(
+        rewriter, op.getLoc(), smt::BoolType::get(getContext()),
+        adaptor.getProperty());
+    rewriter.replaceOpWithNewOp<smt::AssertOp>(op, cond);
+    return success();
+  }
+};
+
+/// Lower a verif::LecOp operation to a miter circuit encoded in SMT.
+/// More information on miter circuits can be found, e.g., in this paper:
+/// Brand, D., 1993, November. Verification of large synthesized designs. In
+/// Proceedings of 1993 International Conference on Computer Aided Design
+/// (ICCAD) (pp. 534-537). IEEE.
+struct LogicEquivalenceCheckingOpConversion
+    : OpConversionPattern<verif::LogicEquivalenceCheckingOp> {
+  using OpConversionPattern<
+      verif::LogicEquivalenceCheckingOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(verif::LogicEquivalenceCheckingOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto *firstOutputs = adaptor.getFirstCircuit().front().getTerminator();
+    auto *secondOutputs = adaptor.getSecondCircuit().front().getTerminator();
+
+    if (firstOutputs->getNumOperands() == 0) {
+      // Trivially equivalent
+      Value trueVal =
+          rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(true));
+      rewriter.replaceOp(op, trueVal);
+      return success();
+    }
+
+    smt::SolverOp solver =
+        rewriter.create<smt::SolverOp>(loc, rewriter.getI1Type(), ValueRange{});
+    rewriter.createBlock(&solver.getBodyRegion());
+
+    // First, convert the block arguments of the miter bodies.
+    if (failed(rewriter.convertRegionTypes(&adaptor.getFirstCircuit(),
+                                           *typeConverter)))
+      return failure();
+    if (failed(rewriter.convertRegionTypes(&adaptor.getSecondCircuit(),
+                                           *typeConverter)))
+      return failure();
+
+    // Second, create the symbolic values we replace the block arguments with
+    SmallVector<Value> inputs;
+    for (auto arg : adaptor.getFirstCircuit().getArguments())
+      inputs.push_back(
+          rewriter.create<smt::DeclareConstOp>(loc, arg.getType()));
+
+    // Third, inline the blocks
+    // Note: the argument value replacement does not happen immediately, but
+    // only after all the operations are already legalized.
+    // Also, it has to be ensured that the original argument type and the type
+    // of the value with which is is to be replaced match. The value is looked
+    // up (transitively) in the replacement map at the time the replacement
+    // pattern is committed.
+    rewriter.mergeBlocks(&adaptor.getFirstCircuit().front(), solver.getBody(),
+                         inputs);
+    rewriter.mergeBlocks(&adaptor.getSecondCircuit().front(), solver.getBody(),
+                         inputs);
+    rewriter.setInsertionPointToEnd(solver.getBody());
+
+    // Fourth, convert the yielded values back to the source type system (since
+    // the operations of the inlined blocks will be converted by other patterns
+    // later on and we should make sure the IR is well-typed after each pattern
+    // application), and build the 'assert'.
+    SmallVector<Value> outputsDifferent;
+    for (auto [out1, out2] :
+         llvm::zip(firstOutputs->getOperands(), secondOutputs->getOperands())) {
+      Value o1 = typeConverter->materializeTargetConversion(
+          rewriter, loc, typeConverter->convertType(out1.getType()), out1);
+      Value o2 = typeConverter->materializeTargetConversion(
+          rewriter, loc, typeConverter->convertType(out1.getType()), out2);
+      outputsDifferent.emplace_back(
+          rewriter.create<smt::DistinctOp>(loc, o1, o2));
+    }
+
+    rewriter.eraseOp(firstOutputs);
+    rewriter.eraseOp(secondOutputs);
+
+    Value toAssert;
+    if (outputsDifferent.size() == 1)
+      toAssert = outputsDifferent[0];
+    else
+      toAssert = rewriter.create<smt::OrOp>(loc, outputsDifferent);
+
+    rewriter.create<smt::AssertOp>(loc, toAssert);
+
+    // Fifth, check for satisfiablility and report the result back.
+    Value falseVal =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(false));
+    Value trueVal =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(true));
+    auto checkOp = rewriter.create<smt::CheckOp>(loc, rewriter.getI1Type());
+    rewriter.createBlock(&checkOp.getSatRegion());
+    rewriter.create<smt::YieldOp>(loc, falseVal);
+    rewriter.createBlock(&checkOp.getUnknownRegion());
+    rewriter.create<smt::YieldOp>(loc, falseVal);
+    rewriter.createBlock(&checkOp.getUnsatRegion());
+    rewriter.create<smt::YieldOp>(loc, trueVal);
+    rewriter.setInsertionPointAfter(checkOp);
+    rewriter.create<smt::YieldOp>(loc, checkOp->getResults());
+
+    rewriter.replaceOp(op, solver->getResults());
+    return success();
+  }
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Convert Verif to SMT pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct ConvertVerifToSMTPass
+    : public circt::impl::ConvertVerifToSMTBase<ConvertVerifToSMTPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void circt::populateVerifToSMTConversionPatterns(TypeConverter &converter,
+                                                 RewritePatternSet &patterns) {
+  patterns.add<VerifAssertOpConversion, LogicEquivalenceCheckingOpConversion>(
+      converter, patterns.getContext());
+}
+
+void ConvertVerifToSMTPass::runOnOperation() {
+  ConversionTarget target(getContext());
+  target.addIllegalDialect<verif::VerifDialect>();
+  target.addLegalDialect<smt::SMTDialect, arith::ArithDialect>();
+  target.addLegalOp<UnrealizedConversionCastOp>();
+
+  RewritePatternSet patterns(&getContext());
+  TypeConverter converter;
+  populateHWToSMTTypeConverter(converter);
+  populateVerifToSMTConversionPatterns(converter, patterns);
+
+  if (failed(mlir::applyPartialConversion(getOperation(), target,
+                                          std::move(patterns))))
+    return signalPassFailure();
+
+  // Cleanup as many unrealized conversion casts as possible. This is applied
+  // separately because we would otherwise need to make them entirely illegal,
+  // but we want to allow them such that we can run a series of conversion
+  // passes to SMT converting different dialects. Also, not marking the
+  // unrealized conversion casts legal above (but adding the simplification
+  // patterns) does not work, because the dialect conversion framework adds
+  // IRRewrite patterns to replace values which are only applied after all
+  // operations are legalized. This means, folding the casts away will not be
+  // possible in many cases (especially the explicitly inserted target
+  // materializations in the lowering of the 'miter' operation).
+  RewritePatternSet cleanupPatterns(&getContext());
+  populateReconcileUnrealizedCastsPatterns(cleanupPatterns);
+
+  if (failed(mlir::applyPatternsAndFoldGreedily(getOperation(),
+                                                std::move(cleanupPatterns))))
+    return signalPassFailure();
+}

--- a/lib/Dialect/Verif/VerifOps.cpp
+++ b/lib/Dialect/Verif/VerifOps.cpp
@@ -41,6 +41,22 @@ OpFoldResult HasBeenResetOp::fold(FoldAdaptor adaptor) {
 }
 
 //===----------------------------------------------------------------------===//
+// LogicalEquivalenceCheckingOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult LogicEquivalenceCheckingOp::verifyRegions() {
+  if (getFirstCircuit().getArgumentTypes() !=
+      getSecondCircuit().getArgumentTypes())
+    return emitOpError() << "block argument types of both regions must match";
+  if (getFirstCircuit().front().getTerminator()->getOperandTypes() !=
+      getSecondCircuit().front().getTerminator()->getOperandTypes())
+    return emitOpError()
+           << "types of the yielded values of both regions must match";
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Generated code
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
@@ -1,0 +1,17 @@
+// RUN: circt-opt %s --convert-verif-to-smt --split-input-file --verify-diagnostics
+
+func.func @assert_with_unsupported_property_type(%arg0: !smt.bv<1>) {
+  %0 = builtin.unrealized_conversion_cast %arg0 : !smt.bv<1> to !ltl.sequence
+  // expected-error @below {{failed to legalize operation 'verif.assert' that was explicitly marked illegal}}
+  verif.assert %0 : !ltl.sequence
+  return
+}
+
+// -----
+
+func.func @assert_with_unsupported_property_type(%arg0: !smt.bv<1>) {
+  %0 = builtin.unrealized_conversion_cast %arg0 : !smt.bv<1> to !ltl.property
+  // expected-error @below {{failed to legalize operation 'verif.assert' that was explicitly marked illegal}}
+  verif.assert %0 : !ltl.property
+  return
+}

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -1,0 +1,62 @@
+// RUN: circt-opt %s --convert-verif-to-smt -allow-unregistered-dialect | FileCheck %s
+
+// CHECK-LABEL: func @test
+// CHECK-SAME:  ([[ARG0:%.+]]: !smt.bv<1>)
+func.func @test(%arg0: !smt.bv<1>) -> (i1, i1, i1) {
+  %0 = builtin.unrealized_conversion_cast %arg0 : !smt.bv<1> to i1
+  // CHECK: [[C0:%.+]] = smt.bv.constant #smt.bv<-1> : !smt.bv<1>
+  // CHECK: [[V0:%.+]] = smt.eq %arg0, [[C0]] : !smt.bv<1>
+  // CHECK: smt.assert [[V0]]
+  verif.assert %0 : i1
+
+  // CHECK: [[EQ:%.+]] = smt.solver() : () -> i1
+  // CHECK: [[TRUE:%.+]] = arith.constant true
+  // CHECK: [[FALSE:%.+]] = arith.constant false
+  // CHECK: [[IN0:%.+]] = smt.declare_const : !smt.bv<32>
+  // CHECK: [[V0:%.+]] = builtin.unrealized_conversion_cast [[IN0]] : !smt.bv<32> to i32
+  // CHECK: [[IN1:%.+]] = smt.declare_const : !smt.bv<32>
+  // CHECK: [[V1:%.+]] = builtin.unrealized_conversion_cast [[IN1]] : !smt.bv<32> to i32
+  // CHECK: [[V2:%.+]]:2 = "some_op"([[V0]], [[V1]]) : (i32, i32) -> (i32, i32)
+  // CHECK: [[V3:%.+]] = builtin.unrealized_conversion_cast [[V2]]#0 : i32 to !smt.bv<32>
+  // CHECK: [[V4:%.+]] = smt.distinct [[IN0]], [[V3]] : !smt.bv<32>
+  // CHECK: [[V5:%.+]] = builtin.unrealized_conversion_cast [[V2]]#1 : i32 to !smt.bv<32>
+  // CHECK: [[V6:%.+]] = smt.distinct [[IN1]], [[V5]] : !smt.bv<32>
+  // CHECK: [[V7:%.+]] = smt.or [[V4]], [[V6]]
+  // CHECK: smt.assert [[V7]]
+  // CHECK: [[V8:%.+]] = smt.check
+  // CHECK: smt.yield [[FALSE]]
+  // CHECK: smt.yield [[FALSE]]
+  // CHECK: smt.yield [[TRUE]]
+  // CHECK: smt.yield [[V8]] :
+  %1 = verif.lec first {
+  ^bb0(%arg1: i32, %arg2: i32):
+    verif.yield %arg1, %arg2 : i32, i32
+  } second {
+  ^bb0(%arg1: i32, %arg2: i32):
+    %2, %3 = "some_op"(%arg1, %arg2) : (i32, i32) -> (i32, i32)
+    verif.yield %2, %3 : i32, i32
+  }
+
+  // CHECK: [[EQ2:%.+]] = smt.solver() : () -> i1
+  // CHECK: [[V9:%.+]] = smt.declare_const : !smt.bv<32>
+  // CHECK: [[V10:%.+]] = smt.distinct [[V9]], [[V9]] : !smt.bv<32>
+  // CHECK: smt.assert [[V10]]
+  %2 = verif.lec first {
+  ^bb0(%arg1: i32):
+    verif.yield %arg1 : i32
+  } second {
+  ^bb0(%arg1: i32):
+    verif.yield %arg1 : i32
+  }
+
+  %3 = verif.lec first {
+  ^bb0(%arg1: i32):
+    verif.yield
+  } second {
+  ^bb0(%arg1: i32):
+    verif.yield
+  }
+
+  // CHECK: return [[EQ]], [[EQ2]], %true
+  return %1, %2, %3 : i1, i1, i1
+}

--- a/test/Dialect/Verif/basic.mlir
+++ b/test/Dialect/Verif/basic.mlir
@@ -57,3 +57,29 @@ hw.module @HasBeenReset(in %clock: i1, in %reset: i1) {
   %hbr0 = verif.has_been_reset %clock, async %reset
   %hbr1 = verif.has_been_reset %clock, sync %reset
 }
+
+//===----------------------------------------------------------------------===//
+// Logical Equivalence Checking related operations
+//===----------------------------------------------------------------------===//
+
+// CHECK: verif.lec first {
+// CHECK: } second {
+// CHECK: }
+verif.lec first {
+} second {
+}
+
+// CHECK: verif.lec {verif.some_attr} first {
+// CHECK: ^bb0(%{{.*}}: i32, %{{.*}}: i32):
+// CHECK:   verif.yield %{{.*}}, %{{.*}} : i32, i32 {verif.some_attr}
+// CHECK: } second {
+// CHECK: ^bb0(%{{.*}}: i32, %{{.*}}: i32):
+// CHECK:   verif.yield %{{.*}}, %{{.*}} : i32, i32 {verif.some_attr}
+// CHECK: }
+verif.lec {verif.some_attr} first {
+^bb0(%arg0: i32, %arg1: i32):
+  verif.yield %arg0, %arg1 : i32, i32 {verif.some_attr}
+} second {
+^bb0(%arg0: i32, %arg1: i32):
+  verif.yield %arg0, %arg1 : i32, i32 {verif.some_attr}
+}

--- a/test/Dialect/Verif/errors.mlir
+++ b/test/Dialect/Verif/errors.mlir
@@ -1,0 +1,21 @@
+// RUN: circt-opt %s --split-input-file --verify-diagnostics
+
+// expected-error @below {{types of the yielded values of both regions must match}}
+verif.lec first {
+^bb0(%arg0: i32):
+  verif.yield %arg0 : i32
+} second {
+^bb0(%arg0: i32):
+  verif.yield
+}
+
+// -----
+
+// expected-error @below {{block argument types of both regions must match}}
+verif.lec first {
+^bb0(%arg0: i32, %arg1: i32):
+  verif.yield %arg0 : i32
+} second {
+^bb0(%arg0: i32):
+  verif.yield %arg0 : i32
+}

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -90,6 +90,7 @@ target_link_libraries(circt-opt
   CIRCTSystemCTransforms
   CIRCTTransforms
   CIRCTVerif
+  CIRCTVerifToSMT
   CIRCTVerifToSV
 
   MLIRIR


### PR DESCRIPTION
Add a first implementation of a LEC operation. This has to be refined as we go forward, e.g., to support reporting of counter-examples. An operation to express a LEC statement explicitly in the IR at the CIRCT Core level allows us to state the general intent to perform LEC without committing to one specific approach/backend yet.

This PR also already adds one such lowering (constructing a simple miter circuit encoded in SMT). A followup PR will introduce a separate pass that takes two `hw.module`s and transforms them into one `verif.lec` operation.