### PR TITLE
[FIRRTL] Add `chisel_assert` intrinsic

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
+++ b/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
@@ -95,6 +95,28 @@ The enable input is sampled at the rising edge of the input clock; any changes o
 | en   | input     | UInt<1>  | enable for the output clock |
 | out  | output    | Clock    | gated output clock          |
 
+### circt.chisel_assert
+
+Generate a clocked SV assertion, with optional formatted error message.
+
+| Parameter | Type   | Description                                                                         |
+| --------- | ------ | ----------------------------------------------------------------------------------- |
+| format    | string | Format string per SV 20.10, 21.2.1.  Optional.                                      |
+| label     | string | Label for assert.  Optional.                                                 |
+| guards    | string | Semicolon-delimited list of pre-processor tokens to use as ifdef guards.  Optional. |
+
+| Port      | Direction | Type     | Description                |
+| --------- | --------- | -------- | -------------------------- |
+| clock     | input     | Clock    | input clock                |
+| predicate | input     | UInt<1>  | predicate to assert/assume |
+| enable    | input     | UInt<1>  | enable signal              |
+| ...       | input     | Signals  | arguments to format string |
+
+Example output:
+```systemverilog
+assert__label: assume property (@(posedge clock) ~enable | cond) else $error("message");	
+```
+
 ### circt.chisel_assert_assume
 
 Generate a clocked SV assertion with companion assume statement.

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -4482,7 +4482,7 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
 
     // Assertions gain a companion `assume` behind a
     // `USE_PROPERTY_AS_CONSTRAINT` guard.
-    if (isAssert) {
+    if (isAssert && op->hasAttrOfType<UnitAttr>("with_companion_assume")) {
       StringAttr assumeLabel;
       if (label)
         assumeLabel = StringAttr::get(builder.getContext(),

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -604,7 +604,8 @@ static ParamDeclAttr getNamedParam(ArrayAttr params, StringRef name) {
 
 namespace {
 
-template <class OpTy, bool ifElseFatal = false>
+template <class OpTy, bool ifElseFatal = false,
+          bool withCompanionAssume = false>
 class CirctAssertAssumeConverter : public IntrinsicConverter {
 public:
   using IntrinsicConverter::IntrinsicConverter;
@@ -649,6 +650,9 @@ public:
 
     if constexpr (ifElseFatal)
       op->setAttr("format", builder.getStringAttr("ifElseFatal"));
+
+    if constexpr (withCompanionAssume)
+      op->setAttr("with_companion_assume", builder.getUnitAttr());
 
     inst.erase();
     return success();
@@ -750,9 +754,14 @@ void LowerIntrinsicsPass::runOnOperation() {
   lowering.add<CirctHasBeenResetConverter>("circt.has_been_reset",
                                            "circt_has_been_reset");
   lowering.add<CirctProbeConverter>("circt.fpga_probe", "circt_fpga_probe");
-  lowering.add<CirctAssertAssumeConverter<AssertOp>>(
+  lowering.add<CirctAssertAssumeConverter<AssertOp, /*ifElseFatal=*/false,
+                                          /*withCompanionAssume=*/true>>(
       "circt.chisel_assert_assume", "circt_chisel_assert_assume");
-  lowering.add<CirctAssertAssumeConverter<AssertOp, /*ifElseFatal=*/true>>(
+  lowering.add<CirctAssertAssumeConverter<AssertOp, /*ifElseFatal=*/false,
+                                          /*withCompanionAssume=*/false>>(
+      "circt.chisel_assert", "circt_chisel_assert");
+  lowering.add<CirctAssertAssumeConverter<AssertOp, /*ifElseFatal=*/true,
+                                          /*withCompanionAssume=*/true>>(
       "circt.chisel_ifelsefatal", "circt_chisel_ifelsefatal");
   lowering.add<CirctAssertAssumeConverter<AssumeOp>>("circt.chisel_assume",
                                                      "circt_chisel_assume");

--- a/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
+++ b/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
@@ -7,7 +7,7 @@ firrtl.circuit "ifElseFatalToSVA" {
     in %cond: !firrtl.uint<1>,
     in %enable: !firrtl.uint<1>
   ) {
-    firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, format = "ifElseFatal"}
+    firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, format = "ifElseFatal", with_companion_assume}
     // CHECK-NEXT: [[CLK:%.+]] = seq.from_clock %clock
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor bin %enable, [[TRUE]]

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -401,9 +401,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     in %aEn: !firrtl.uint<1>, in %bCond: !firrtl.uint<1>, in %bEn: !firrtl.uint<1>,
     in %cCond: !firrtl.uint<1>, in %cEn: !firrtl.uint<1>, in %value: !firrtl.uint<42>) {
 
-    firrtl.assert %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true}
-    firrtl.assert %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, name = "assert_0"}
-    firrtl.assert %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {isConcurrent = true}
+    firrtl.assert %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, with_companion_assume}
+    firrtl.assert %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, name = "assert_0", with_companion_assume}
+    firrtl.assert %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {isConcurrent = true, with_companion_assume}
     // CHECK-NEXT: [[CLOCK:%.+]] = seq.from_clock %clock
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor bin %aEn, [[TRUE]]
@@ -490,7 +490,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     in %cond: !firrtl.uint<1>,
     in %enable: !firrtl.uint<1>
   ) {
-    firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, guards = ["HELLO", "WORLD"]}
+    firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, guards = ["HELLO", "WORLD"], with_companion_assume}
     firrtl.assume %clock, %cond, %enable, "assume0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, guards = ["HELLO", "WORLD"]}
     firrtl.cover %clock, %cond, %enable, "cover0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, guards = ["HELLO", "WORLD"]}
 
@@ -524,7 +524,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     in %value: !firrtl.uint<42>,
     in %i0: !firrtl.uint<0>
   ) {
-    firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, format = "sva"}
+    firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, format = "sva", with_companion_assume}
     // CHECK-NEXT: [[FALSE:%.+]] = hw.constant false
     // CHECK-NEXT: [[CLOCK:%.+]] = seq.from_clock %clock
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -260,6 +260,15 @@ firrtl.circuit "Foo" {
   // CHECK-NOT: VerifAssume
   // CHECK-NOT: VerifCover
 // TODO:
+  firrtl.intmodule private @AssertFormat<format: none = "message: %d",
+                                               label: none = "label for assert with format string",
+                                               guards: none = "MACRO_GUARD;ASDF">(
+                                                 in clock: !firrtl.clock,
+                                                 in predicate: !firrtl.uint<1>,
+                                                 in enable: !firrtl.uint<1>,
+                                                 in val: !firrtl.uint<1>
+                                               ) attributes {intrinsic = "circt.chisel_assert"}
+
   firrtl.intmodule private @AssertAssume<format: none = "testing">(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>) attributes {intrinsic = "circt.chisel_assert_assume"}
   firrtl.intmodule private @AssertAssumeFormat<format: none = "message: %d",
                                                label: none = "label for assert with format string",
@@ -299,6 +308,19 @@ firrtl.circuit "Foo" {
   firrtl.module @ChiselVerif(in %clock: !firrtl.clock,
                              in %cond: !firrtl.uint<1>,
                              in %enable: !firrtl.uint<1>) {
+
+    // CHECK-NOT: firrtl.instance
+    // CHECK: firrtl.assert %{{.+}}, %{{.+}}, %{{.+}}, "message: %d"(
+    // CHECK-SAME: guards = ["MACRO_GUARD", "ASDF"]
+    // CHECK-SAME: isConcurrent = true
+    // CHECK-SAME: name = "label for assert with format string"
+    // CHECK-NOT: with_companion_assume
+    %assertOnlyFormat_clock, %assertOnlyFormat_predicate, %assertOnlyFormat_enable, %assertOnlyFormat_val = firrtl.instance assertOnlyFormat interesting_name @AssertFormat(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
+    firrtl.strictconnect %assertOnlyFormat_clock, %clock : !firrtl.clock
+    firrtl.strictconnect %assertOnlyFormat_predicate, %cond : !firrtl.uint<1>
+    firrtl.strictconnect %assertOnlyFormat_enable, %enable : !firrtl.uint<1>
+    firrtl.strictconnect %assertOnlyFormat_val, %cond : !firrtl.uint<1>
+
     // CHECK-NOT: firrtl.instance
     // CHECK: firrtl.assert %{{.+}}, %{{.+}}, %{{.+}}, "testing" :
     // CHECK-SAME: isConcurrent = true
@@ -311,6 +333,7 @@ firrtl.circuit "Foo" {
     // CHECK-SAME: guards = ["MACRO_GUARD", "ASDF"]
     // CHECK-SAME: isConcurrent = true
     // CHECK-SAME: name = "label for assert with format string"
+    // CHECK-SAME: with_companion_assume
     %assertFormat_clock, %assertFormat_predicate, %assertFormat_enable, %assertFormat_val = firrtl.instance assertFormat interesting_name @AssertAssumeFormat(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
     firrtl.strictconnect %assertFormat_clock, %clock : !firrtl.clock
     firrtl.strictconnect %assertFormat_predicate, %cond : !firrtl.uint<1>
@@ -322,6 +345,8 @@ firrtl.circuit "Foo" {
     // CHECK-SAME: guards = ["MACRO_GUARD", "ASDF"]
     // CHECK-SAME: isConcurrent = true
     // CHECK-SAME: name = "label for ifelsefatal assert"
+    // CHECK-SAME: with_companion_assume
+
     %ief_clock, %ief_predicate, %ief_enable, %ief_val = firrtl.instance ief interesting_name @IfElseFatalFormat(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
     firrtl.strictconnect %ief_clock, %clock : !firrtl.clock
     firrtl.strictconnect %ief_predicate, %cond : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -949,7 +949,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     when cond:
       printf(clock, enable, "assert:foo 0", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true}
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, with_companion_assume}
 
     when cond:
       printf(clock, enable, "assume:foo 1", value)
@@ -963,7 +963,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     when cond:
       printf(clock, enable, "assert:foo_0:", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "foo_0"}
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "foo_0", with_companion_assume}
 
     when cond:
       printf(clock, enable, "assume:foo_1:", value)
@@ -977,7 +977,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     when cond:
       printf(clock, enable, "assert:custom label 0:foo 3", value)
     ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 3" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "custom label 0"}
+    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 3" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "custom label 0", with_companion_assume}
 
     when cond:
       printf(clock, enable, "assume:custom label 1:foo 4", value)
@@ -1042,6 +1042,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-SAME: format = "sva"
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_label_magic"
+    ; CHECK-SAME: with_companion_assume
 
     ; Predicate modifier `trueOrIsX`
     when cond:
@@ -1055,6 +1056,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-SAME: format = "sva"
     ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
     ; CHECK-SAME: name = "verif_library_label_magic"
+    ; CHECK-SAME: with_companion_assume
 
     ; Verification Library Assumptions
 
@@ -1116,7 +1118,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
         printf(clock, not(enable), "assert: bar")
     ; CHECK: [[NOT_ENABLE:%.+]] = firrtl.not %enable
     ; CHECK-NEXT: [[NOT_COND:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[NOT_COND]], [[NOT_ENABLE]], " bar" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true}
+    ; CHECK-NEXT: firrtl.assert %clock, [[NOT_COND]], [[NOT_ENABLE]], " bar" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, with_companion_assume}
 
     ; Verification Library Covers
 


### PR DESCRIPTION
This implements `chisel_assert` intrinsic that is similar to `chisel_assert_assume` except that it doesn't create a companion assume. Internally `with_companion_assume` attribute is attached to assert op for assertions with companion assume (currently all assertions are expected to create companion assertions, unfortunately). 