### PR TITLE
[Emit] Copy fragments into modules created by ExtractTestCode

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -222,6 +222,8 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
       b.getStringAttr(getVerilogModuleNameAttr(op).getValue() + suffix), ports);
   if (path)
     newMod->setAttr("output_file", path);
+  if (auto fragments = op->getAttr("emit.fragments"))
+    newMod->setAttr("emit.fragments", fragments);
   newMod.setCommentAttr(b.getStringAttr("VCS coverage exclude_file"));
   newMod.setPrivate();
 


### PR DESCRIPTION
This ensures that the extracted modules have the same fragments included as the original modules.