### PR TITLE
[NFC] Move 'using namespace' out of headers.

### DIFF
--- a/include/circt/Analysis/SchedulingAnalysis.h
+++ b/include/circt/Analysis/SchedulingAnalysis.h
@@ -25,10 +25,6 @@ namespace func {
 class FuncOp;
 } // namespace func
 } // namespace mlir
-
-using namespace mlir;
-using namespace circt::scheduling;
-
 namespace circt {
 namespace analysis {
 
@@ -37,15 +33,15 @@ namespace analysis {
 /// problem. The client should retrieve the partially complete problem to add
 /// and associate operator types.
 struct CyclicSchedulingAnalysis {
-  CyclicSchedulingAnalysis(Operation *funcOp, AnalysisManager &am);
+  CyclicSchedulingAnalysis(Operation *funcOp, mlir::AnalysisManager &am);
 
-  CyclicProblem &getProblem(affine::AffineForOp forOp);
+  scheduling::CyclicProblem &getProblem(mlir::affine::AffineForOp forOp);
 
 private:
-  void analyzeForOp(affine::AffineForOp forOp,
+  void analyzeForOp(mlir::affine::AffineForOp forOp,
                     MemoryDependenceAnalysis memoryAnalysis);
 
-  DenseMap<Operation *, CyclicProblem> problems;
+  DenseMap<Operation *, scheduling::CyclicProblem> problems;
 };
 
 } // namespace analysis

--- a/include/circt/Conversion/HWToBTOR2.h
+++ b/include/circt/Conversion/HWToBTOR2.h
@@ -21,8 +21,6 @@ namespace mlir {
 class Pass;
 } // namespace mlir
 
-using namespace mlir;
-
 namespace circt {
 std::unique_ptr<mlir::Pass> createConvertHWToBTOR2Pass(llvm::raw_ostream &os);
 std::unique_ptr<mlir::Pass> createConvertHWToBTOR2Pass();

--- a/lib/Analysis/SchedulingAnalysis.cpp
+++ b/lib/Analysis/SchedulingAnalysis.cpp
@@ -24,6 +24,7 @@
 
 using namespace mlir;
 using namespace mlir::affine;
+using namespace circt::scheduling;
 
 /// CyclicSchedulingAnalysis constructs a CyclicProblem for each AffineForOp by
 /// performing a memory dependence analysis and inserting dependences into the

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -27,6 +27,7 @@ using namespace mlir;
 using namespace mlir::affine;
 using namespace circt;
 using namespace circt::analysis;
+using namespace circt::scheduling;
 
 //===----------------------------------------------------------------------===//
 // DebugAnalysis

--- a/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
@@ -24,6 +24,7 @@
 
 using namespace mlir;
 using namespace circt;
+using namespace circt::scheduling;
 using namespace pipeline;
 
 namespace {


### PR DESCRIPTION
`using namespace` generally should not be in headers as it can lead to _interesting_ aliasing problems, especially w.r.t. `namespace mlir` and `namespace llvm`.