### PR TITLE
[arcilator] Disable JIT on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,7 +597,8 @@ endif()
 # Arcilator JIT
 #-------------------------------------------------------------------------------
 
-if(MLIR_ENABLE_EXECUTION_ENGINE)
+# TODO: find why MSVC cannot build the JIT
+if(MLIR_ENABLE_EXECUTION_ENGINE AND NOT WIN32)
   set(ARCILATOR_JIT_ENABLED 1)
 else()
   set(ARCILATOR_JIT_ENABLED 0)

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -35,8 +35,6 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/ExecutionEngine/ExecutionEngine.h"
-#include "mlir/ExecutionEngine/OptUtils.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OperationSupport.h"
@@ -60,6 +58,11 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/ToolOutputFile.h"
+
+#ifdef ARCILATOR_ENABLE_JIT
+#include "mlir/ExecutionEngine/ExecutionEngine.h"
+#include "mlir/ExecutionEngine/OptUtils.h"
+#endif // ARCILATOR_ENABLE_JIT
 
 #include <iostream>
 #include <optional>


### PR DESCRIPTION
Unfortunately it seems like MSVC cannot build the Arcilator JIT. This PR thus disables the JIT infrastructure on Windows for the time being.