### PR TITLE
[Sim] Introduce an op to represent prints

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -52,6 +52,29 @@ def FatalOp : SimOp<"fatal"> {
   let results = (outs);
 
   let assemblyFormat = "$clk `,` $cond attr-dict";
+
+}
+
+def PrintOp : SimOp<"print"> {
+  let summary = "Prints a formatted string to `stderr`";
+
+  let description = [{
+    Prints a formatted string, using standard SystemVerilog placeholders,
+    to `stderr` on the rising edge of `clk` when `cond` is high.
+  }];
+
+  let arguments = (ins
+    ClockType:$clk,
+    I1:$cond,
+    StrAttr:$format_string,
+    Variadic<AnyType>:$substitutions
+  );
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $clk `,` $cond `,` $format_string attr-dict (`(` $substitutions^ `)`
+      `:` qualified(type($substitutions)))?
+  }];
 }
 
 #endif // CIRCT_DIALECT_SIM_SIMOPS_TD

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -50,7 +50,6 @@ firrtl.circuit "Simple" {
   firrtl.module private @TestInstance(in %u2: !firrtl.uint<2>, in %s8: !firrtl.sint<8>,
                               in %clock: !firrtl.clock,
                               in %reset: !firrtl.uint<1>) {
-    // CHECK-NEXT: [[CLK:%.+]] = seq.from_clock %clock
     // CHECK-NEXT: %c0_i2 = hw.constant
     // CHECK-NEXT: %xyz.out4 = hw.instance "xyz" @Simple(in1: [[ARG1:%.+]]: i4, in2: %u2: i2, in3: %s8: i8) -> (out4: i4)
     %xyz:4 = firrtl.instance xyz @Simple(in in1: !firrtl.uint<4>, in in2: !firrtl.uint<2>, in in3: !firrtl.sint<8>, out out4: !firrtl.uint<4>)
@@ -63,6 +62,9 @@ firrtl.circuit "Simple" {
 
     firrtl.connect %xyz#2, %s8 : !firrtl.sint<8>, !firrtl.sint<8>
 
+    // CHECK: [[PRINTF_COND_0:%.+]] = sv.macro.ref @PRINTF_COND_() : () -> i1
+    // CHECK: [[COND_0:%.+]] = comb.and bin [[PRINTF_COND_0]], %reset : i1
+    // CHECK: sim.print %clock, [[COND_0]], "%x"(%xyz.out4) : i4
     firrtl.printf %clock, %reset, "%x"(%xyz#3) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
 
     // Parameterized module reference.
@@ -71,10 +73,9 @@ firrtl.circuit "Simple" {
     // CHECK: %myext.out = hw.instance "myext" @MyParameterizedExtModule<DEFAULT: i64 = 0, DEPTH: f64 = 3.242000e+01, FORMAT: none = "xyz_timeout=%d\0A", WIDTH: i8 = 32>(in: %reset: i1) -> (out: i8)
     %myext:2 = firrtl.instance myext @MyParameterizedExtModule(in in: !firrtl.uint<1>, out out: !firrtl.uint<8>)
 
-    // CHECK: [[FD:%.*]] = hw.constant -2147483646 : i32
-    // CHECK: sv.fwrite [[FD]], "%x"(%xyz.out4) : i4
-    // CHECK: sv.fwrite [[FD]], "Something interesting! %x"(%myext.out) : i8
-
+    // CHECK: [[PRINTF_COND_1:%.+]] = sv.macro.ref @PRINTF_COND_() : () -> i1
+    // CHECK: [[COND_1:%.+]] = comb.and bin [[PRINTF_COND_1]], %reset : i1
+    // CHECK: sim.print %clock, [[COND_1]], "Something interesting! %x"(%myext.out) : i8
     firrtl.connect %myext#0, %reset : !firrtl.uint<1>, !firrtl.uint<1>
 
     firrtl.printf %clock, %reset, "Something interesting! %x"(%myext#1) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -326,30 +326,18 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-SAME: attributes {emit.fragments = [@PRINTF_COND_FRAGMENT]}
   firrtl.module private @Print(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
                        in %a: !firrtl.uint<4>, in %b: !firrtl.uint<4>) {
-    // CHECK: [[CLOCK:%.+]] = seq.from_clock %clock
-    // CHECK: [[ADD:%.+]] = comb.add
 
-    // CHECK:      sv.ifdef @SYNTHESIS {
-    // CHECK-NEXT: } else  {
-    // CHECK-NEXT:   sv.always posedge [[CLOCK]] {
-    // CHECK-NEXT:     %PRINTF_COND_ = sv.macro.ref @PRINTF_COND_() : () -> i1
-    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND_, %reset
-    // CHECK-NEXT:     sv.if [[AND]] {
-    // CHECK-NEXT:       [[FD:%.+]] = hw.constant -2147483646 : i32
-    // CHECK-NEXT:       sv.fwrite [[FD]], "No operands!\0A"
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:     %PRINTF_COND__0 = sv.macro.ref @PRINTF_COND_() : () -> i1
-    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND__0, %reset : i1
-    // CHECK-NEXT:     sv.if [[AND]] {
-    // CHECK-NEXT:       [[FD:%.+]] = hw.constant -2147483646 : i32
-    // CHECK-NEXT:       sv.fwrite [[FD]], "Hi %x %x\0A"([[ADD]], %b) : i5, i4
-    // CHECK-NEXT:     }
-    // CHECK-NEXT:   }
-    // CHECK-NEXT: }
-   firrtl.printf %clock, %reset, "No operands!\0A" : !firrtl.clock, !firrtl.uint<1>
+    // CHECK: [[PRINTF_COND_0:%.+]] = sv.macro.ref @PRINTF_COND_() : () -> i1
+    // CHECK: [[COND_0:%.+]] = comb.and bin [[PRINTF_COND_0]], %reset : i1
+    // CHECK: sim.print %clock, [[COND_0]], "No operands!\0A"
+    firrtl.printf %clock, %reset, "No operands!\0A" : !firrtl.clock, !firrtl.uint<1>
 
+    // CHECK: [[ADD:%.+]] = comb.add bin %1, %2 : i5
     %0 = firrtl.add %a, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
 
+    // CHECK: [[PRINTF_COND_1:%.+]] = sv.macro.ref @PRINTF_COND_() : () -> i1
+    // CHECK: [[COND_1:%.+]] = comb.and bin [[PRINTF_COND_1]], %reset : i1
+    // CHECK: sim.print %clock, [[COND_1]], "Hi %x %x\0A"([[ADD]], %b) : i5, i4
     firrtl.printf %clock, %reset, "Hi %x %x\0A"(%0, %b) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<4>
 
     firrtl.skip

--- a/test/Conversion/SimToSV/print.mlir
+++ b/test/Conversion/SimToSV/print.mlir
@@ -1,0 +1,16 @@
+// RUN: circt-opt --lower-sim-to-sv %s | FileCheck %s
+
+// CHECK-LABEL: hw.module @print
+hw.module @print(in %clock : !seq.clock, in %cond : i1, in %val : i32) {
+  // CHECK:      [[HW_CLK:%.+]] = seq.from_clock %clock
+  // CHECK-NEXT: sv.ifdef  @SYNTHESIS {
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.always posedge [[HW_CLK]] {
+  // CHECK-NEXT:     sv.if %cond {
+  // CHECK-NEXT:       %c-2147483646_i32 = hw.constant -2147483646 : i32
+  // CHECK-NEXT:       sv.fwrite %c-2147483646_i32, "print %d\0A"(%val) : i32
+  // CHECK-NEXT:     }
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  sim.print %clock, %cond, "print %d\n" (%val) : i32
+}

--- a/test/Dialect/Sim/round-trip.mlir
+++ b/test/Dialect/Sim/round-trip.mlir
@@ -16,3 +16,9 @@ hw.module @stop_finish(in %clock : !seq.clock, in %cond : i1) {
   // CHECK: sim.fatal %clock, %cond
   sim.fatal %clock, %cond
 }
+
+// CHECK-LABEL: hw.module @print
+hw.module @print(in %clock : !seq.clock, in %cond : i1, in %val : i32) {
+  // CHECK: sim.print %clock, %cond, "print %d"(%val) : i32
+  sim.print %clock, %cond, "print %d"(%val) : i32
+}

--- a/test/firtool/print.fir
+++ b/test/firtool/print.fir
@@ -8,11 +8,11 @@ circuit PrintTest:
     input var : UInt<32>
     printf(clock, cond, "test %d\n", var)
 
+    ; CHECK:      [[PRINTF_COND:%.+]] = sv.macro.ref @PRINTF_COND_() : () -> i1
+    ; CHECK:      [[COND:%.+]] = comb.and bin [[PRINTF_COND]], %cond : i1
     ; CHECK:      sv.ifdef  @SYNTHESIS {
     ; CHECK-NEXT: } else {
     ; CHECK-NEXT:   sv.always posedge %clock {
-    ; CHECK-NEXT:     [[PRINTF_COND:%.+]] = sv.macro.ref @PRINTF_COND_() : () -> i1
-    ; CHECK-NEXT:     [[COND:%.+]] = comb.and bin [[PRINTF_COND]], %cond : i1
     ; CHECK-NEXT:     sv.if [[COND]] {
     ; CHECK-NEXT:       sv.fwrite %c-2147483646_i32, "test %d\0A"(%var) : i32
     ; CHECK-NEXT:     }


### PR DESCRIPTION
This PR introduces a `sim.print` op that mainly acts as an intermediary between FIRRTL and SV to carry print statements.
Its output is hard-wired to `stderr`, similarly to the FIRRTL version. This could be relaxed in the future if the need arises.
Presenly, the goal of this op is to provide a compact representation that makes prints easier to analyze, without having to trace the parent op to find their clocking. Additionally, since FIRRTL stop lowers to a print + stop operation combination, this op makes it easier for some flows to perform fusion.