### PR TITLE
[HW][IST] Verify simple inner-ref-user ops sequentially, perf fix.

### DIFF
--- a/lib/Dialect/HW/InnerSymbolTable.cpp
+++ b/lib/Dialect/HW/InnerSymbolTable.cpp
@@ -235,9 +235,21 @@ LogicalResult verifyInnerRefNamespace(Operation *op) {
       return WalkResult(user.verifyInnerRefs(ns));
     return WalkResult::advance();
   };
+
+  SmallVector<Operation *> topLevelOps;
+  for (auto &op : op->getRegion(0).front()) {
+    // Gather operations with regions for parallel processing.
+    if (op.getNumRegions() != 0) {
+      topLevelOps.push_back(&op);
+      continue;
+    }
+    // Otherwise, handle right now -- not worth the cost.
+    if (verifySymbolUserFn(&op).wasInterrupted())
+      return failure();
+  }
   return mlir::failableParallelForEach(
-      op->getContext(), op->getRegion(0).front(), [&](auto &op) {
-        return success(!op.walk(verifySymbolUserFn).wasInterrupted());
+      op->getContext(), topLevelOps, [&](Operation *op) {
+        return success(!op->walk(verifySymbolUserFn).wasInterrupted());
       });
 }
 


### PR DESCRIPTION
When an IRN has a huge number of top-level operations that need inner ref verification, the current code scaled poorly as the amount of per-op verification work is tiny (handful of hashtable lookups) compared to the overhead and atomic access of failableParallelForEach.

Scan through the operations sequentially as a pre-pass and directly verify operations with no regions, only using parallelization for verifying recursive walks of modules.