### PR TITLE
[FIRRTL][NFC] Move xmr.ref and xmr.deref into expressions.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1371,6 +1371,20 @@ def RWProbeOp : FIRRTLOp<"ref.rwprobe",
   let assemblyFormat = "$target attr-dict `:` type($result)";
 }
 
+def XMRRefOp : FIRRTLOp<"xmr.ref"> {
+  let summary = "FIRRTL XMR operation, targetable by ref ops.";
+  let arguments = (ins FlatSymbolRefAttr:$ref, DefaultValuedAttr<StrAttr, "{}">:$verbatimSuffix);
+  let results = (outs RefType:$dest);
+  let assemblyFormat = "$ref (`,` $verbatimSuffix^)? attr-dict `:` qualified(type($dest))";
+}
+
+def XMRDerefOp : FIRRTLOp<"xmr.deref"> {
+  let summary = "FIRRTL XMR operation, reading an XMR target.";
+  let arguments = (ins FlatSymbolRefAttr:$ref, DefaultValuedAttr<StrAttr, "{}">:$verbatimSuffix);
+  let results = (outs PassiveType:$dest);
+  let assemblyFormat = "$ref (`,` $verbatimSuffix^)? attr-dict `:` qualified(type($dest))";
+}
+
 //===----------------------------------------------------------------------===//
 // LTL Dialect Sequence and Property Intrinsics
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -348,20 +348,6 @@ def RefReleaseInitialOp : FIRRTLOp<"ref.release_initial"> {
   let hasCanonicalizer = 1;
 }
 
-def XMRRefOp : FIRRTLOp<"xmr.ref"> {
-  let summary = "FIRRTL XMR operation, targetable by ref ops.";
-  let arguments = (ins FlatSymbolRefAttr:$ref, DefaultValuedAttr<StrAttr, "{}">:$verbatimSuffix);
-  let results = (outs RefType:$dest);
-  let assemblyFormat = "$ref (`,` $verbatimSuffix^)? attr-dict `:` qualified(type($dest))";
-}
-
-def XMRDerefOp : FIRRTLOp<"xmr.deref"> {
-  let summary = "FIRRTL XMR operation, reading an XMR target.";
-  let arguments = (ins FlatSymbolRefAttr:$ref, DefaultValuedAttr<StrAttr, "{}">:$verbatimSuffix);
-  let results = (outs PassiveType:$dest);
-  let assemblyFormat = "$ref (`,` $verbatimSuffix^)? attr-dict `:` qualified(type($dest))";
-}
-
 //===----------------------------------------------------------------------===//
 // Verif Dialect Intrinsics
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
These are expressions not statements, they have return values.