### PR TITLE
[Seq] Enforce non-negative preset values in FirRegOp printer/parser

### DIFF
--- a/test/Dialect/Seq/firreg-errors.mlir
+++ b/test/Dialect/Seq/firreg-errors.mlir
@@ -12,3 +12,11 @@ hw.module @preset_too_large(in %clock: !seq.clock, in %reset: i1, in %next4: i4)
   // expected-error@below {{custom op 'seq.firreg' preset value too large}}
   seq.firreg %next4 clock %clock preset 1024 : i4
 }
+
+// -----
+
+// CHECK-LABEL: @preset_negative
+hw.module @preset_negative(in %clock: !seq.clock, in %reset: i1, in %next: i1) {
+  // expected-error@below {{custom op 'seq.firreg' preset value must not be negative}}
+  seq.firreg %next clock %clock preset -1 : i1
+}


### PR DESCRIPTION
Parsing a negative preset value for the `FirRegOp` will currently produce the slightly inappropriate message "preset value too large". On the other hand, the printer does output negative integers if the value's MSB is set.

This PR adds a more specific error message to the parser and ensures the printed value is always non-negative.