### PR TITLE
[FIRRTL] Remove support for circt.Intrinsic annotation.

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -858,19 +858,6 @@ Example:
 }
 ```
 
-### circt.Intrinsic
-
-| Property   | Type   | Description       |
-| ---------- | ------ | -------------     |
-| class      | string | `circt.Intrinsic` |
-| target     | string | Reference target  |
-| intrinsic  | string | Name of Intrinsic |
-
-Used to indicate an external module is really an intrinsic module.  This exists
-to allow a frontend to generate intrinsics without FIRRTL language support for
-intrinsics.  It is expected this will be deprecated as soon as the FIRRTL language
-supports intrinsics.  This annotation can only be local and applied to a module.
-
 ### SitestBlackBoxAnnotation
 
 | Property   | Type   | Description                                         |

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -129,19 +129,8 @@ LogicalResult IntrinsicLowerings::lower(CircuitOp circuit,
         } else {
           ++numFailures;
         }
-        continue;
       }
-
-      // Otherwise, find extmodules which have an intrinsic annotation.
-      auto anno = AnnotationSet(&*op).getAnnotation("circt.Intrinsic");
-      if (!anno)
-        continue;
-      intname = anno.getMember<StringAttr>("intrinsic");
-      if (!intname) {
-        op.emitError("intrinsic annotation with no intrinsic name");
-        ++numFailures;
-        continue;
-      }
+      continue;
     } else if (auto intMod = dyn_cast<FIntModuleOp>(*op)) {
       intname = intMod.getIntrinsicAttr();
       if (!intname) {

--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -118,7 +118,6 @@ LogicalResult IntrinsicLowerings::lower(CircuitOp circuit,
                                         bool allowUnknownIntrinsics) {
   unsigned numFailures = 0;
   for (auto op : llvm::make_early_inc_range(circuit.getOps<FModuleLike>())) {
-    StringAttr intname;
     if (auto extMod = dyn_cast<FExtModuleOp>(*op)) {
       // Special-case some extmodules, identifying them by name.
       auto it = extmods.find(extMod.getDefnameAttr());
@@ -131,14 +130,16 @@ LogicalResult IntrinsicLowerings::lower(CircuitOp circuit,
         }
       }
       continue;
-    } else if (auto intMod = dyn_cast<FIntModuleOp>(*op)) {
-      intname = intMod.getIntrinsicAttr();
-      if (!intname) {
-        op.emitError("intrinsic module with no intrinsic name");
-        ++numFailures;
-        continue;
-      }
-    } else {
+    }
+
+    auto intMod = dyn_cast<FIntModuleOp>(*op);
+    if (!intMod)
+      continue;
+
+    auto intname = intMod.getIntrinsicAttr();
+    if (!intname) {
+      op.emitError("intrinsic module with no intrinsic name");
+      ++numFailures;
       continue;
     }
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -414,7 +414,6 @@ static llvm::StringMap<AnnoRecord> annotationRecords{{
     {"circt.testLocalOnly", {stdResolve, applyWithoutTarget<>}},
     {"circt.testNT", {noResolve, applyWithoutTarget<>}},
     {"circt.missing", {tryResolve, applyWithoutTarget<true>}},
-    {"circt.Intrinsic", {stdResolve, applyWithoutTarget<false, FExtModuleOp>}},
     // Grand Central Views/Interfaces Annotations
     {extractGrandCentralClass, NoTargetAnnotation},
     {grandCentralHierarchyFileAnnoClass, NoTargetAnnotation},

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -3,46 +3,7 @@
 
 // CHECK-LABEL: "Foo"
 firrtl.circuit "Foo" {
-  // CHECK-NOT: NameDoesNotMatter
-  firrtl.extmodule @NameDoesNotMatter(in i : !firrtl.clock, out size : !firrtl.uint<32>) attributes
-                                     {annotations = [{class = "circt.Intrinsic", intrinsic = "circt.sizeof"}]}
-  // CHECK-NOT: NameDoesNotMatter2
-  firrtl.extmodule @NameDoesNotMatter2(in i : !firrtl.clock, out found : !firrtl.uint<1>) attributes
-                                     {annotations = [{class = "circt.Intrinsic", intrinsic = "circt.isX"}]}
-  // CHECK-NOT: NameDoesNotMatter3
-  firrtl.extmodule @NameDoesNotMatter3<FORMAT: none = "foo">(out found : !firrtl.uint<1>) attributes
-                                     {annotations = [{class = "circt.Intrinsic", intrinsic = "circt.plusargs.test"}]}
-  // CHECK-NOT: NameDoesNotMatter4
-  firrtl.extmodule @NameDoesNotMatter4<FORMAT: none = "foo">(out found : !firrtl.uint<1>, out result: !firrtl.uint<5>) attributes
-                                     {annotations = [{class = "circt.Intrinsic", intrinsic = "circt.plusargs.value"}]}
-
-  // CHECK: Foo
-  firrtl.module @Foo(in %clk : !firrtl.clock, out %s : !firrtl.uint<32>, out %io1 : !firrtl.uint<1>, out %io2 : !firrtl.uint<1>, out %io3 : !firrtl.uint<1>, out %io4 : !firrtl.uint<5>) {
-    %i1, %size = firrtl.instance "" @NameDoesNotMatter(in i : !firrtl.clock, out size : !firrtl.uint<32>)
-    // CHECK-NOT: NameDoesNotMatter
-    // CHECK: firrtl.int.sizeof
-    firrtl.strictconnect %i1, %clk : !firrtl.clock
-    firrtl.strictconnect %s, %size : !firrtl.uint<32>
-
-    %i2, %found2 = firrtl.instance "" @NameDoesNotMatter2(in i : !firrtl.clock, out found : !firrtl.uint<1>)
-    // CHECK-NOT: NameDoesNotMatter2
-    // CHECK: firrtl.int.isX
-    firrtl.strictconnect %i2, %clk : !firrtl.clock
-    firrtl.strictconnect %io1, %found2 : !firrtl.uint<1>
-
-    %found3 = firrtl.instance "" @NameDoesNotMatter3(out found : !firrtl.uint<1>)
-    // CHECK-NOT: NameDoesNotMatter3
-    // CHECK: firrtl.int.plusargs.test "foo"
-    firrtl.strictconnect %io2, %found3 : !firrtl.uint<1>
-
-    %found4, %result1 = firrtl.instance "" @NameDoesNotMatter4(out found : !firrtl.uint<1>, out result: !firrtl.uint<5>)
-    // CHECK-NOT: NameDoesNotMatter4
-    // CHECK: firrtl.int.plusargs.value "foo" : !firrtl.uint<5>
-    firrtl.strictconnect %io3, %found4 : !firrtl.uint<1>
-    firrtl.strictconnect %io4, %result1 : !firrtl.uint<5>
-  }
-
-  // CHECK-NOT: NameDoesNotMatte5
+  // CHECK-NOT: NameDoesNotMatter5
   firrtl.intmodule @NameDoesNotMatter5(in i : !firrtl.clock, out size : !firrtl.uint<32>) attributes
                                      {intrinsic = "circt.sizeof"}
   // CHECK-NOT: NameDoesNotMatter6
@@ -55,8 +16,8 @@ firrtl.circuit "Foo" {
   firrtl.intmodule @NameDoesNotMatter8<FORMAT: none = "foo">(out found : !firrtl.uint<1>, out result: !firrtl.uint<5>) attributes
                                      {intrinsic = "circt.plusargs.value"}
 
-  // CHECK: Bar
-  firrtl.module @Bar(in %clk : !firrtl.clock, out %s : !firrtl.uint<32>, out %io1 : !firrtl.uint<1>, out %io2 : !firrtl.uint<1>, out %io3 : !firrtl.uint<1>, out %io4 : !firrtl.uint<5>) {
+  // CHECK: Foo
+  firrtl.module @Foo(in %clk : !firrtl.clock, out %s : !firrtl.uint<32>, out %io1 : !firrtl.uint<1>, out %io2 : !firrtl.uint<1>, out %io3 : !firrtl.uint<1>, out %io4 : !firrtl.uint<5>) {
     %i1, %size = firrtl.instance "" @NameDoesNotMatter5(in i : !firrtl.clock, out size : !firrtl.uint<32>)
     // CHECK-NOT: NameDoesNotMatter5
     // CHECK: firrtl.int.sizeof
@@ -81,19 +42,11 @@ firrtl.circuit "Foo" {
     firrtl.strictconnect %io4, %result1 : !firrtl.uint<5>
   }
 
-  // CHECK-NOT: ClockGate0
   // CHECK-NOT: ClockGate1
-  firrtl.extmodule @ClockGate0(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {annotations = [{class = "circt.Intrinsic", intrinsic = "circt.clock_gate"}]}
   firrtl.intmodule @ClockGate1(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {intrinsic = "circt.clock_gate"}
 
   // CHECK: ClockGate
   firrtl.module @ClockGate(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>) {
-    // CHECK-NOT: ClockGate0
-    // CHECK: firrtl.int.clock_gate
-    %in1, %en1, %out1 = firrtl.instance "" @ClockGate0(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
-    firrtl.strictconnect %in1, %clk : !firrtl.clock
-    firrtl.strictconnect %en1, %en : !firrtl.uint<1>
-
     // CHECK-NOT: ClockGate1
     // CHECK: firrtl.int.clock_gate
     %in2, %en2, %out2 = firrtl.instance "" @ClockGate1(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
@@ -101,18 +54,11 @@ firrtl.circuit "Foo" {
     firrtl.strictconnect %en2, %en : !firrtl.uint<1>
   }
 
-  // CHECK-NOT: ClockInverter0
   // CHECK-NOT: ClockInverter1
-  firrtl.extmodule @ClockInverter0(in in: !firrtl.clock, out out: !firrtl.clock) attributes {annotations = [{class = "circt.Intrinsic", intrinsic = "circt.clock_inv"}]}
   firrtl.intmodule @ClockInverter1(in in: !firrtl.clock, out out: !firrtl.clock) attributes {intrinsic = "circt.clock_inv"}
 
   // CHECK: ClockInverter
   firrtl.module @ClockInverter(in %clk: !firrtl.clock) {
-    // CHECK-NOT: ClockInverter0
-    // CHECK: firrtl.int.clock_inv
-    %in1, %out1 = firrtl.instance "" @ClockInverter0(in in: !firrtl.clock, out out: !firrtl.clock)
-    firrtl.strictconnect %in1, %clk : !firrtl.clock
-
     // CHECK-NOT: ClockInverter1
     // CHECK: firrtl.int.clock_inv
     %in2, %out2 = firrtl.instance "" @ClockInverter1(in in: !firrtl.clock, out out: !firrtl.clock)
@@ -203,7 +149,7 @@ firrtl.circuit "Foo" {
     %cover.property = firrtl.instance "cover" @VerifCover(in property: !firrtl.uint<1>)
   }
 
-  firrtl.extmodule @Mux2Cell(in sel: !firrtl.uint<1>, in high: !firrtl.uint, in low: !firrtl.uint, out out: !firrtl.uint) attributes {annotations = [{class = "circt.Intrinsic", intrinsic = "circt.mux2cell"}]}
+  firrtl.intmodule @Mux2Cell(in sel: !firrtl.uint<1>, in high: !firrtl.uint, in low: !firrtl.uint, out out: !firrtl.uint) attributes {intrinsic = "circt.mux2cell"}
   firrtl.intmodule @Mux4Cell(in sel: !firrtl.uint<2>, in v3: !firrtl.uint, in v2: !firrtl.uint, in v1: !firrtl.uint, in v0: !firrtl.uint, out out: !firrtl.uint) attributes {intrinsic = "circt.mux4cell"}
 
   // CHECK: firrtl.module @MuxCell()


### PR DESCRIPTION
Documentation indicates this was intended to be removed once FIRRTL language supports intrinsics, and we have intmodule's now.