### PR TITLE
[FIRRTL][NFC] Use underscores in documentation.

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
+++ b/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
@@ -3,8 +3,7 @@
 Intrinsics provide an implementation-specific way to extend the FIRRTL language
 with new operations.
 
-Intrinsics are currently implemented as annotated external modules.  We expect
-that native FIRRTL support for intrinsics will be added to the language.
+Intrinsics are currently implemented as `intmodule`'s.
 
 ## Motivation
 
@@ -15,15 +14,8 @@ and type checking.
 
 ## Supported Intrinsics
 
-Annotations here are written in their JSON format. A "reference target"
-indicates that the annotation could target any object in the hierarchy,
-although there may be further restrictions in the annotation.
 
-We also accept the `intmodule` version of any of these annotation strings used
-as the intrinsic name.  To work with the requirement of the intrinsic name being
-an identifier, replace any period is with an underscore in the intrinsic name.
-
-### circt.sizeof
+### circt_sizeof
 
 Returns the size of a type.  The input port is not read from and may be any 
 type, including uninferred types.
@@ -36,7 +28,7 @@ type, including uninferred types.
 | i          | input     | Any      | value whose type is to be returned  |
 | size       | output    | UInt<32> | Size of type of i                   |
 
-### circt.isX
+### circt_isX
 
 Tests if the value is a literal `x`.  FIRRTL doesn't have a notion of 'x per-se, 
 but x can come in to the system from external modules and from SV constructs.  
@@ -50,7 +42,7 @@ Verification constructs need to explicitly test for 'x.
 | i          | input     | Any      | value test                          |
 | found      | output    | UInt<1>  | i is `x`                            |
 
-### circt.plusargs.value
+### circt_plusargs_value
 
 Tests and extracts a value from simulator command line options with SystemVerilog
 `$value$plusargs`.  This is described in SystemVerilog 2012 section 21.6.
@@ -67,7 +59,7 @@ type of the result.
 | found      | output    | UInt<1>  | found in args                       |
 | result     | output    | AnyType  | found in args                       |
 
-### circt.plusargs.test
+### circt_plusargs_test
 
 Tests simulator command line options with SystemVerilog `$test$plusargs`.  This
 is described in SystemVerilog 2012 section 21.6.
@@ -80,7 +72,7 @@ is described in SystemVerilog 2012 section 21.6.
 | ---------- | --------- | -------- | ----------------------------------- |
 | found      | output    | UInt<1>  | found in args                       |
 
-### circt.clock_gate
+### circt_clock_gate
 
 Enables and disables a clock safely, without glitches, based on a boolean enable value. If the enable input is 1, the output clock produced by the clock gate is identical to the input clock. If the enable input is 0, the output clock is a constant zero.
 
@@ -95,7 +87,7 @@ The enable input is sampled at the rising edge of the input clock; any changes o
 | en   | input     | UInt<1>  | enable for the output clock |
 | out  | output    | Clock    | gated output clock          |
 
-### circt.chisel_assert
+### circt_chisel_assert
 
 Generate a clocked SV assert statement, with optional formatted error message.
 
@@ -118,7 +110,7 @@ wire _GEN = ~enable | cond;
 assert__label: assert property (@(posedge clock) _GEN) else $error("message");
 ```
 
-### circt.chisel_ifelsefatal
+### circt_chisel_ifelsefatal
 
 Generate a particular Verilog sequence that's similar to an assertion.
 
@@ -152,7 +144,7 @@ Example SV output:
 `endif // not def SYNTHESIS
 ```
 
-### circt.chisel_assume
+### circt_chisel_assume
 
 Generate a clocked SV assume statement, with optional formatted error message.
 
@@ -175,7 +167,7 @@ Example SV output:
 assume__label: assume property (@(posedge clock) ~enable | cond) else $error("message");	
 ```
 
-### circt.chisel_cover
+### circt_chisel_cover
 
 Generate a clocked SV cover statement.
 
@@ -195,7 +187,7 @@ Example SV output:
 cover__label: cover property (@(posedge clock) enable & cond);
 ```
 
-### circt.unclocked_assume
+### circt_unclocked_assume
 
 Generate a SV assume statement whose predicate is used in a sensitivity list of the enclosing always block.
 


### PR DESCRIPTION
In the only supported mechanism for using intrinsics, the name must be an identifier so just document that.

Periods are nice, we can adjust the FIRRTL grammar / syntax to allow this in the future if we miss them.

This does not modify the code internally that looks for the dot syntax.