### PR TITLE
[FIRRTL] Add CreateCompanionAssume pass; Decouple UNROnlyAssume generation from AssertOp lowering

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -201,6 +201,8 @@ std::unique_ptr<mlir::Pass> createLintingPass();
 
 std::unique_ptr<mlir::Pass> createSpecializeOptionPass();
 
+std::unique_ptr<mlir::Pass> createCreateCompanionAssume();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -659,6 +659,16 @@ def RandomizeRegisterInit :
   let constructor = "circt::firrtl::createRandomizeRegisterInitPass()";
 }
 
+def CreateCompanionAssume : Pass<"firrtl-create-companion-assume", "firrtl::FModuleOp"> {
+  let summary = "Create companion assume statements for assertions";
+  let description = [{
+    This pass generates companion assume statements gated by macros to assertions.
+    If the assertion is UNR only one, a special form of assume (AssumeEdgedPredicateIntrinsicOp)
+    is used. Otherwise a concurrent assume is used
+  }];
+  let constructor = "circt::firrtl::createCreateCompanionAssume()";
+}
+
 def LowerXMR : Pass<"firrtl-lower-xmr", "firrtl::CircuitOp"> {
   let summary = "Lower ref ports to XMR";
   let description = [{

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -129,6 +129,7 @@ public:
   }
   bool shouldExtractTestCode() const { return extractTestCode; }
   bool shouldFixupEICGWrapper() const { return fixupEICGWrapper; }
+  bool shouldAddCompanionAssume() const { return addCompanionAssume; }
 
   // Setters, used by the CAPI
   FirtoolOptions &setOutputFilename(StringRef name) {
@@ -349,6 +350,11 @@ public:
     return *this;
   }
 
+  FirtoolOptions &setAddCompanionAssume(bool value) {
+    addCompanionAssume = value;
+    return *this;
+  }
+
 private:
   std::string outputFilename;
   bool disableAnnotationsUnknown;
@@ -394,6 +400,7 @@ private:
   bool stripFirDebugInfo;
   bool stripDebugInfo;
   bool fixupEICGWrapper;
+  bool addCompanionAssume;
 };
 
 void registerFirtoolCLOptions();

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1471,6 +1471,8 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
                      std::function<void(void)>());
   }
 
+  LogicalResult emitGuards(Location loc, ArrayRef<Attribute> guards,
+                           std::function<void(void)> emit);
   void addToIfDefBlock(StringRef cond, std::function<void(void)> thenCtor,
                        std::function<void(void)> elseCtor = {});
   void addToInitialBlock(std::function<void(void)> body);
@@ -1619,6 +1621,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult visitStmt(VerifAssumeIntrinsicOp op);
   LogicalResult visitStmt(VerifCoverIntrinsicOp op);
   LogicalResult visitExpr(HasBeenResetIntrinsicOp op);
+  LogicalResult visitStmt(AssumeEdgedPredicateIntrinsicOp op);
 
   // Other Operations
   LogicalResult visitExpr(BitsPrimOp op);
@@ -2532,6 +2535,27 @@ void FIRRTLLowering::addToAlwaysBlock(sv::EventControl clockEdge, Value clock,
   // defined ahead of the uses, which leads to better generated Verilog.
   alwaysOp->moveBefore(builder.getInsertionBlock(),
                        builder.getInsertionPoint());
+}
+
+LogicalResult FIRRTLLowering::emitGuards(Location loc,
+                                         ArrayRef<Attribute> guards,
+                                         std::function<void(void)> emit) {
+  if (guards.empty()) {
+    emit();
+    return success();
+  }
+  auto guard = guards[0].dyn_cast<StringAttr>();
+  if (!guard)
+    return mlir::emitError(loc,
+                           "elements in `guards` array must be `StringAttr`");
+
+  // Record the guard macro to emit a declaration for it.
+  circuitState.addMacroDecl(builder.getStringAttr(guard.getValue()));
+  LogicalResult result = LogicalResult::failure();
+  addToIfDefBlock(guard.getValue(), [&]() {
+    result = emitGuards(loc, guards.drop_front(), emit);
+  });
+  return result;
 }
 
 void FIRRTLLowering::addToIfDefBlock(StringRef cond,
@@ -4356,18 +4380,7 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
   if (auto guardsAttr = op->template getAttrOfType<ArrayAttr>("guards"))
     guards = guardsAttr.getValue();
 
-  auto isAssert = opName == "assert";
-  auto isCover = opName == "cover";
-
-  // TODO : Need to figure out if there is a cleaner way to get the string which
-  // indicates the assert is UNR only. Or better - not rely on this at all -
-  // ideally there should have been some other attribute which indicated that
-  // this assert for UNR only.
-  auto isUnrOnlyAssert = llvm::any_of(guards, [](Attribute attr) {
-    StringAttr strAttr = dyn_cast<StringAttr>(attr);
-    return strAttr && strAttr.getValue() == "USE_UNR_ONLY_CONSTRAINTS";
-  });
-
+  auto isCover = isa<CoverOp>(op);
   auto clock = getLoweredNonClockValue(opClock);
   auto enable = getLoweredValue(opEnable);
   auto predicate = getLoweredValue(opPredicate);
@@ -4484,61 +4497,12 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
         builder, opName,
         circt::sv::EventControlAttr::get(builder.getContext(), event), clock,
         predicate, prefixedLabel, message, messageOps);
-
-    // Assertions gain a companion `assume` behind a
-    // `USE_PROPERTY_AS_CONSTRAINT` guard.
-    if (isAssert) {
-      StringAttr assumeLabel;
-      if (label)
-        assumeLabel = StringAttr::get(builder.getContext(),
-                                      "assume__" + label.getValue());
-
-      circuitState.addMacroDecl(
-          builder.getStringAttr("USE_PROPERTY_AS_CONSTRAINT"));
-      addToIfDefBlock("USE_PROPERTY_AS_CONSTRAINT", [&]() {
-        if (!isUnrOnlyAssert) {
-          builder.create<sv::AssumeConcurrentOp>(
-              circt::sv::EventControlAttr::get(builder.getContext(), event),
-              clock, predicate, assumeLabel);
-        } else {
-          builder.create<sv::AlwaysOp>(
-              ArrayRef(sv::EventControl::AtEdge), ArrayRef(predicate), [&]() {
-                buildImmediateVerifOp(builder, "assume", predicate,
-                                      circt::sv::DeferAssertAttr::get(
-                                          builder.getContext(),
-                                          circt::sv::DeferAssert::Immediate),
-                                      assumeLabel);
-              });
-        }
-      });
-    }
   };
 
   // Wrap the verification statement up in the optional preprocessor
   // guards. This is a bit awkward since we want to translate an array of
   // guards  into a recursive call to `addToIfDefBlock`.
-  bool anyFailed = false;
-  std::function<void()> emitWrapped = [&]() {
-    if (guards.empty()) {
-      emit();
-      return;
-    }
-    auto guard = guards[0].dyn_cast<StringAttr>();
-    if (!guard) {
-      op->emitOpError("elements in `guards` array must be `StringAttr`");
-      anyFailed = true;
-      return;
-    }
-
-    // Record the guard macro to emit a declaration for it.
-    circuitState.addMacroDecl(builder.getStringAttr(guard.getValue()));
-    guards = guards.drop_front();
-    addToIfDefBlock(guard.getValue(), emitWrapped);
-  };
-  emitWrapped();
-  if (anyFailed)
-    return failure();
-  return success();
+  return emitGuards(op->getLoc(), guards, emit);
 }
 
 // Lower an assert to SystemVerilog.
@@ -4563,6 +4527,49 @@ LogicalResult FIRRTLLowering::visitStmt(CoverOp op) {
       op, "cover__", op.getClock(), op.getPredicate(), op.getEnable(),
       op.getMessageAttr(), op.getSubstitutions(), op.getNameAttr(),
       op.getIsConcurrent(), op.getEventControl());
+}
+
+// Lower an UNR only assume to a specific style of SV assume.
+LogicalResult FIRRTLLowering::visitStmt(AssumeEdgedPredicateIntrinsicOp op) {
+  // TODO : Need to figure out if there is a cleaner way to get the string which
+  // indicates the assert is UNR only. Or better - not rely on this at all -
+  // ideally there should have been some other attribute which indicated that
+  // this assert for UNR only.
+  auto guardsAttr = op->getAttrOfType<mlir::ArrayAttr>("guards");
+  ArrayRef<Attribute> guards =
+      guardsAttr ? guardsAttr.getValue() : ArrayRef<Attribute>();
+
+  auto label = op.getNameAttr();
+  StringAttr assumeLabel;
+  if (label)
+    assumeLabel =
+        StringAttr::get(builder.getContext(), "assume__" + label.getValue());
+  auto predicate = getLoweredValue(op.getPredicate());
+  auto enable = getLoweredValue(op.getEnable());
+  auto notEnable = comb::createOrFoldNot(enable, builder, /*twoState=*/true);
+  predicate = builder.createOrFold<comb::OrOp>(notEnable, predicate, true);
+
+  SmallVector<Value> messageOps;
+  for (auto operand : op.getSubstitutions()) {
+    auto loweredValue = getLoweredValue(operand);
+    if (!loweredValue) {
+      // If this is a zero bit operand, just pass a one bit zero.
+      if (!isZeroBitFIRRTLType(operand.getType()))
+        return failure();
+      loweredValue = getOrCreateIntConstant(1, 0);
+    }
+    messageOps.push_back(loweredValue);
+  }
+  return emitGuards(op.getLoc(), guards, [&]() {
+    builder.create<sv::AlwaysOp>(
+        ArrayRef(sv::EventControl::AtEdge), ArrayRef(predicate), [&]() {
+          buildImmediateVerifOp(
+              builder, "assume", predicate,
+              circt::sv::DeferAssertAttr::get(
+                  builder.getContext(), circt::sv::DeferAssert::Immediate),
+              assumeLabel, op.getMessageAttr(), messageOps);
+        });
+  });
 }
 
 LogicalResult FIRRTLLowering::visitStmt(AttachOp op) {

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   AddSeqMemPorts.cpp
   BlackBoxReader.cpp
   CheckCombLoops.cpp
+  CreateCompanionAssume.cpp
   CreateSiFiveMetadata.cpp
   Dedup.cpp
   DropConst.cpp

--- a/lib/Dialect/FIRRTL/Transforms/CreateCompanionAssume.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateCompanionAssume.cpp
@@ -38,8 +38,8 @@ struct CreateCompanionAssumePass
         });
       }
 
-      // TODO: Currently messages are dropped to preserve the old behaviour. Copy
-      // messages once we confirmed that it works well with UNR tools.
+      // TODO: Currently messages are dropped to preserve the old behaviour.
+      // Copy messages once we confirmed that it works well with UNR tools.
       if (isUnrOnlyAssert)
         // If UNROnly, use UnclockedAssumeIntrinsicOp.
         assume = builder.create<firrtl::UnclockedAssumeIntrinsicOp>(

--- a/lib/Dialect/FIRRTL/Transforms/CreateCompanionAssume.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateCompanionAssume.cpp
@@ -38,8 +38,8 @@ struct CreateCompanionAssumePass
         });
       }
 
-      // TODO: Currently messages are dropped to preserve the old behaivor. Copy
-      // messages once it works well with UNR tools.
+      // TODO: Currently messages are dropped to preserve the old behaviour. Copy
+      // messages once we confirmed that it works well with UNR tools.
       if (isUnrOnlyAssert)
         // If UNROnly, use UnclockedAssumeIntrinsicOp.
         assume = builder.create<firrtl::UnclockedAssumeIntrinsicOp>(

--- a/lib/Dialect/FIRRTL/Transforms/CreateCompanionAssume.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateCompanionAssume.cpp
@@ -1,0 +1,66 @@
+//===- CreateCompanionAssume.cpp - Create companion assume ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the CreateCompanionAssume pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+struct CreateCompanionAssumePass
+    : public CreateCompanionAssumeBase<CreateCompanionAssumePass> {
+  void runOnOperation() override {
+    getOperation().walk([](firrtl::AssertOp assertOp) {
+      OpBuilder builder(assertOp);
+      builder.setInsertionPointAfter(assertOp);
+      auto guards = assertOp->getAttrOfType<ArrayAttr>("guards");
+      Operation *assume;
+      bool isUnrOnlyAssert = false;
+      // Regard the assertion as UNR only if "USE_UNR_ONLY_CONSTRAINTS" is
+      // included in the guards.
+      if (guards) {
+        isUnrOnlyAssert = llvm::any_of(guards, [](Attribute attr) {
+          StringAttr strAttr = dyn_cast<StringAttr>(attr);
+          return strAttr && strAttr.getValue() == "USE_UNR_ONLY_CONSTRAINTS";
+        });
+      }
+
+      // If so, use AssumeEdgedPredicateIntrinsicOp.
+      if (isUnrOnlyAssert)
+        assume = builder.create<firrtl::AssumeEdgedPredicateIntrinsicOp>(
+            assertOp.getLoc(), assertOp.getPredicate(), assertOp.getEnable(),
+            assertOp.getMessage(), assertOp.getSubstitutions(),
+            assertOp.getName());
+      else
+        // Otherwise use concurrent assume.
+        assume = builder.create<firrtl::AssumeOp>(
+            assertOp.getLoc(), assertOp.getClock(), assertOp.getPredicate(),
+            assertOp.getEnable(), assertOp.getMessage(),
+            assertOp.getSubstitutions(), assertOp.getName(),
+            /*isConcurrent=*/true);
+      SmallVector<Attribute> newGuards{
+          builder.getStringAttr("USE_PROPERTY_AS_CONSTRAINT")};
+      if (guards)
+        newGuards.append(guards.begin(), guards.end());
+      assume->setAttr("guards", builder.getArrayAttr(newGuards));
+    });
+  }
+};
+
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createCreateCompanionAssume() {
+  return std::make_unique<CreateCompanionAssumePass>();
+}

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -155,6 +155,10 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createPrefixModulesPass());
 
+  if (opt.shouldAddCompanionAssume())
+    pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
+        circt::firrtl::createCreateCompanionAssume());
+
   if (!opt.shouldDisableOptimization()) {
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMConstPropPass());
 
@@ -660,6 +664,11 @@ struct FirtoolCmdOptions {
       "fixup-eicg-wrapper",
       llvm::cl::desc("Lower `EICG_wrapper` modules into clock gate intrinsics"),
       llvm::cl::init(false)};
+
+  llvm::cl::opt<bool> addCompanionAssume{
+      "add-companion-assume",
+      llvm::cl::desc("Add companion assumes to assertions"),
+      llvm::cl::init(false)};
 };
 } // namespace
 
@@ -695,7 +704,8 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       ckgModuleName("EICG_wrapper"), ckgInputName("in"), ckgOutputName("out"),
       ckgEnableName("en"), ckgTestEnableName("test_en"), ckgInstName("ckg"),
       exportModuleHierarchy(false), stripFirDebugInfo(true),
-      stripDebugInfo(false), fixupEICGWrapper(false) {
+      stripDebugInfo(false), fixupEICGWrapper(false),
+      addCompanionAssume(false) {
   if (!clOptions.isConstructed())
     return;
   outputFilename = clOptions->outputFilename;
@@ -743,4 +753,5 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   stripFirDebugInfo = clOptions->stripFirDebugInfo;
   stripDebugInfo = clOptions->stripDebugInfo;
   fixupEICGWrapper = clOptions->fixupEICGWrapper;
+  addCompanionAssume = clOptions->addCompanionAssume;
 }

--- a/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
+++ b/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
@@ -8,12 +8,16 @@ firrtl.circuit "ifElseFatalToSVA" {
     in %enable: !firrtl.uint<1>
   ) {
     firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, format = "ifElseFatal"}
+    firrtl.assume %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, guards = ["USE_PROPERTY_AS_CONSTRAINT"]}
     // CHECK-NEXT: [[CLK:%.+]] = seq.from_clock %clock
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor bin %enable, [[TRUE]]
     // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
     // CHECK-NEXT: sv.assert.concurrent posedge [[CLK]], [[TMP2]] message "assert0"
     // CHECK-NEXT: sv.ifdef @USE_PROPERTY_AS_CONSTRAINT {
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor bin %enable, [[TRUE]]
+    // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
     // CHECK-NEXT:   sv.assume.concurrent posedge [[CLK]], [[TMP2]]
     // CHECK-NEXT: }
   }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -407,7 +407,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.assume %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {guards = ["USE_PROPERTY_AS_CONSTRAINT"], isConcurrent = true}
     firrtl.assume %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {name = "assert_0", guards = ["USE_PROPERTY_AS_CONSTRAINT"], isConcurrent = true}
     firrtl.assume %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {guards = ["USE_PROPERTY_AS_CONSTRAINT"], isConcurrent = true}
-    firrtl.int.assume.edged_predicate %bCond, %bEn, "assume0"(%value) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {name = "assume_unr", guards = ["USE_PROPERTY_AS_CONSTRAINT", "USE_UNR_ONLY_CONSTRAINTS"]}
+    firrtl.int.unclocked_assume %bCond, %bEn, "assume0"(%value) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {name = "assume_unr", guards = ["USE_PROPERTY_AS_CONSTRAINT", "USE_UNR_ONLY_CONSTRAINTS"]}
     // CHECK-NEXT: [[CLOCK:%.+]] = seq.from_clock %clock
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor bin %aEn, [[TRUE]]

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -404,6 +404,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.assert %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true}
     firrtl.assert %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, name = "assert_0"}
     firrtl.assert %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {isConcurrent = true}
+    firrtl.assume %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {guards = ["USE_PROPERTY_AS_CONSTRAINT"], isConcurrent = true}
+    firrtl.assume %clock, %aCond, %aEn, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {name = "assert_0", guards = ["USE_PROPERTY_AS_CONSTRAINT"], isConcurrent = true}
+    firrtl.assume %clock, %aCond, %aEn, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {guards = ["USE_PROPERTY_AS_CONSTRAINT"], isConcurrent = true}
+    firrtl.int.assume.edged_predicate %bCond, %bEn, "assume0"(%value) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {name = "assume_unr", guards = ["USE_PROPERTY_AS_CONSTRAINT", "USE_UNR_ONLY_CONSTRAINTS"]}
     // CHECK-NEXT: [[CLOCK:%.+]] = seq.from_clock %clock
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT: [[TMP1:%.+]] = comb.xor bin %aEn, [[TRUE]]
@@ -418,10 +422,28 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: [[TMP5:%.+]] = comb.xor bin %aEn, [[TRUE]]
     // CHECK-NEXT: [[TMP6:%.+]] = comb.or bin [[TMP5]], %aCond
     // CHECK-NEXT: sv.assert.concurrent posedge [[CLOCK]], [[TMP6]] message "assert0"([[SAMPLED]]) : i42
-    // CHECK-NEXT: sv.ifdef @USE_PROPERTY_AS_CONSTRAINT {
-    // CHECK-NEXT:   sv.assume.concurrent posedge [[CLOCK]], [[TMP2]]
-    // CHECK-NEXT:   sv.assume.concurrent posedge [[CLOCK]], [[TMP4]] label "assume__assert_0"
-    // CHECK-NEXT:   sv.assume.concurrent posedge [[CLOCK]], [[TMP6]]
+    // CHECK-NEXT: [[SAMPLED:%.+]] = sv.system.sampled %value : i42
+    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT: [[TMP7:%.+]] = comb.xor bin %bEn, [[TRUE]] : i1
+    // CHECK-NEXT: [[TMP8:%.+]] = comb.or bin [[TMP7]], %bCond : i1
+    // CHECK:      sv.ifdef @USE_PROPERTY_AS_CONSTRAINT {
+    // CHECK-NEXT:   [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT:   [[TMP1:%.+]] = comb.xor bin %aEn, [[TRUE]]
+    // CHECK-NEXT:   [[TMP2:%.+]] = comb.or bin [[TMP1]], %aCond
+    // CHECK-NEXT:   sv.assume.concurrent posedge [[CLOCK]], [[TMP2]] message "assert0"
+    // CHECK-NEXT:   [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT:   [[TMP3:%.+]] = comb.xor bin %aEn, [[TRUE]]
+    // CHECK-NEXT:   [[TMP4:%.+]] = comb.or bin [[TMP3]], %aCond
+    // CHECK-NEXT:   sv.assume.concurrent posedge [[CLOCK]], [[TMP4]] label "assume__assert_0" message "assert0"
+    // CHECK-NEXT:   [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT:   [[TMP5:%.+]] = comb.xor bin %aEn, [[TRUE]]
+    // CHECK-NEXT:   [[TMP6:%.+]] = comb.or bin [[TMP5]], %aCond
+    // CHECK-NEXT:   sv.assume.concurrent posedge [[CLOCK]], [[TMP6]] message "assert0"([[SAMPLED]])
+    // CHECK-NEXT:   sv.ifdef  @USE_UNR_ONLY_CONSTRAINTS {
+    // CHECK-NEXT:     sv.always edge [[TMP8]] {
+    // CHECK-NEXT:       sv.assume [[TMP8]], immediate label "assume__assume_unr" message "assume0"(%value) : i42
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:   }
     // CHECK-NEXT: }
     firrtl.assume %clock, %bCond, %bEn, "assume0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true}
     firrtl.assume %clock, %bCond, %bEn, "assume0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, name = "assume_0"}
@@ -501,9 +523,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:     [[TMP1:%.+]] = comb.xor bin %enable, [[TRUE]]
     // CHECK-NEXT:     [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
     // CHECK-NEXT:     sv.assert.concurrent posedge [[CLOCK]], [[TMP2]] message "assert0"
-    // CHECK-NEXT:     sv.ifdef @USE_PROPERTY_AS_CONSTRAINT {
-    // CHECK-NEXT:       sv.assume.concurrent posedge [[CLOCK]], [[TMP2]]
-    // CHECK-NEXT:     }
     // CHECK-NEXT:     [[TRUE:%.+]] = hw.constant true
     // CHECK-NEXT:     [[TMP1:%.+]] = comb.xor bin %enable, [[TRUE]]
     // CHECK-NEXT:     [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
@@ -525,6 +544,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     in %i0: !firrtl.uint<0>
   ) {
     firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, format = "sva"}
+    firrtl.assume %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, guards = ["USE_PROPERTY_AS_CONSTRAINT"]}
     // CHECK-NEXT: [[FALSE:%.+]] = hw.constant false
     // CHECK-NEXT: [[CLOCK:%.+]] = seq.from_clock %clock
     // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
@@ -532,6 +552,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
     // CHECK-NEXT: sv.assert.concurrent posedge [[CLOCK]], [[TMP2]] message "assert0"
     // CHECK-NEXT: sv.ifdef @USE_PROPERTY_AS_CONSTRAINT {
+    // CHECK-NEXT:   [[TRUE:%.+]] = hw.constant true
+    // CHECK-NEXT:   [[TMP1:%.+]] = comb.xor bin %enable, [[TRUE]]
+    // CHECK-NEXT:   [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
     // CHECK-NEXT:   sv.assume.concurrent posedge [[CLOCK]], [[TMP2]]
     // CHECK-NEXT: }
     firrtl.assert %clock, %cond, %enable, "assert1 %d, %d"(%value, %i0) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>, !firrtl.uint<0> {isConcurrent = true, format = "ifElseFatal"}

--- a/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
@@ -1,5 +1,5 @@
-; RUN: firtool --verify-diagnostics --verilog %s --lowering-options=emittedLineLength=200 | FileCheck %s
-; RUN: firtool --verify-diagnostics --verilog --emit-chisel-asserts-as-sva %s --lowering-options=emittedLineLength=200 | FileCheck %s --check-prefix=SVA
+; RUN: firtool --verify-diagnostics --verilog %s --lowering-options=emittedLineLength=200 --add-companion-assume | FileCheck %s
+; RUN: firtool --verify-diagnostics --verilog --emit-chisel-asserts-as-sva %s --lowering-options=emittedLineLength=200 --add-companion-assume | FileCheck %s --check-prefix=SVA
 ; Tests extracted from:
 ; - test/scala/firrtl/extractverif/ExtractAssertsSpec.scala
 
@@ -21,11 +21,16 @@ circuit Foo:
     input other : UInt<1>
     input sum : UInt<42>
 
+    ; CHECK:      wire [[GEN:.+]] = predicate1 | reset;
+    ; CHECK-NEXT: wire [[GEN_0:.+]] = predicate2 | reset;
+    ; CHECK-NEXT: wire [[GEN_1:.+]] = predicate3 | reset;
+    ; CHECK-NEXT: wire [[GEN_2:.+]] = other & enable;
+    ; CHECK-NEXT: wire [[GEN_3:.+]] = predicate4 | reset;
+
     ; CHECK: `ifndef SYNTHESIS
     ; CHECK-NEXT: always @(posedge clock) begin
-
     ; assert with predicate only
-    ; CHECK-NEXT: if (enable & ~(predicate1 | reset)) begin
+    ; CHECK-NEXT: if (enable & ~[[GEN]]) begin
     ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
     ; CHECK-NEXT:     $error("Assertion failed (verification library): ");
     ; CHECK-NEXT:   if (`STOP_COND_)
@@ -40,7 +45,7 @@ circuit Foo:
       stop(clock, enable, 1)
 
     ; assert with message
-    ; CHECK-NEXT: if (enable & ~(predicate2 | reset)) begin
+    ; CHECK-NEXT: if (enable & ~[[GEN_0]]) begin
     ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
     ; CHECK-NEXT:     $error("Assertion failed (verification library): sum =/= 1.U");
     ; CHECK-NEXT:   if (`STOP_COND_)
@@ -51,7 +56,7 @@ circuit Foo:
       stop(clock, enable, 1)
 
     ; assert with when
-    ; CHECK-NEXT: if (other & enable & ~(predicate3 | reset)) begin
+    ; CHECK-NEXT: if ([[GEN_2]] & ~[[GEN_1]]) begin
     ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
     ; CHECK-NEXT:     $error("Assertion failed (verification library): Assert with when");
     ; CHECK-NEXT:   if (`STOP_COND_)
@@ -63,7 +68,7 @@ circuit Foo:
         stop(clock, enable, 1)
 
     ; assert with message with arguments
-    ; CHECK-NEXT: if (enable & ~(predicate4 | reset)) begin
+    ; CHECK-NEXT: if (enable & ~[[GEN_3]]) begin
     ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
     ; CHECK-NEXT:     $error("Assertion failed (verification library): expected sum === 2.U but got %d", sum);
     ; CHECK-NEXT:   if (`STOP_COND_)
@@ -78,46 +83,35 @@ circuit Foo:
 
 
     ; assert emitted as SVA
-    ; CHECK-NEXT: wire [[TMP1:.+]] = ~enable | predicate5 | reset;
-    ; CHECK-NEXT: assert__verif_library: assert property (@(posedge clock) [[TMP1]])
+    ; CHECK: wire [[GEN_4:.+]] = ~enable | predicate5 | reset;
+    ; CHECK-NEXT: assert__verif_library: assert property (@(posedge clock) [[GEN_4]])
     ; CHECK-SAME:   else $error("Assertion failed (verification library): SVA assert example, sum was %d", $sampled(sum));
     when not(or(predicate5, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): SVA assert example, sum was %d\"}</extraction-summary> bar", sum)
       stop(clock, enable, 1)
 
     ; assert with custom label
-    ; CHECK-NEXT: wire [[TMP2:.+]] = ~enable | predicate6 | reset;
-    ; CHECK-NEXT: assert__verif_library_hello_world: assert property (@(posedge clock) [[TMP2]])
+    ; CHECK: wire [[GEN_5:.+]] = ~enable | predicate6 | reset;
+    ; CHECK-NEXT: assert__verif_library_hello_world: assert property (@(posedge clock) [[GEN_5]])
     ; CHECK-SAME:   else $error("Assertion failed (verification library): Custom label example");
     when not(or(predicate6, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"sva\"},\"labelExts\":[\"hello\",\"world\"],\"baseMsg\":\"Assertion failed (verification library): Custom label example\"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
     ; assert with predicate option for X-passing
-    ; CHECK-NEXT: wire [[TMP3:.+]] = ~enable | predicate7 | predicate7 === 1'bx;
-    ; CHECK-NEXT: assert__verif_library_0: assert property (@(posedge clock) [[TMP3]])
+    ; CHECK-NEXT: wire [[GEN_6:.+]] = ~enable | predicate7 | predicate7 === 1'bx;
+    ; CHECK-NEXT: assert__verif_library_0: assert property (@(posedge clock) [[GEN_6]])
     ; CHECK-SAME:   else $error("Assertion failed (verification library): X-passing assert example");
     when not(predicate7) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): X-passing assert example\"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
-    ; The companion assumes get bunched up in an ifdef block.
-    ; CHECK-NEXT: `ifdef USE_PROPERTY_AS_CONSTRAINT
-    ; CHECK-NEXT:   assume__verif_library: assume property (@(posedge clock) [[TMP1]]);
-    ; CHECK-NEXT:   assume__verif_library_hello_world: assume property (@(posedge clock) [[TMP2]]);
-    ; CHECK-NEXT:   assume__verif_library_0: assume property (@(posedge clock) [[TMP3]]);
-    ; CHECK-NEXT: `endif
-
-
+    ; CHECK-NEXT: wire [[GEN_7:.+]] = ~enable | predicate8 | reset;
+    ; CHECK-NEXT: wire [[GEN_8:.+]] = predicate9 | reset;
     ; assert with toggle option e.g. UNROnly
     ; CHECK-NEXT: `ifdef USE_UNR_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:   wire [[TMP4:.+]] = ~enable | predicate8 | reset;
-    ; CHECK-NEXT:   assert__verif_library_1: assert property (@(posedge clock) [[TMP4]])
+    ; CHECK-NEXT:   assert__verif_library_1: assert property (@(posedge clock) [[GEN_7]])
     ; CHECK-SAME:     else $error("Assertion failed (verification library): Conditional compilation example for UNR-only assert");
-    ; CHECK-NEXT:   `ifdef USE_PROPERTY_AS_CONSTRAINT
-    ; CHECK-NEXT:     always @(edge [[TMP4]])
-    ; CHECK-NEXT:       assume__verif_library_1: assume([[TMP4]]);
-    ; CHECK-NEXT:   `endif
     when not(or(predicate8, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"}],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): Conditional compilation example for UNR-only assert\"}</extraction-summary> bar")
       stop(clock, enable, 1)
@@ -125,7 +119,7 @@ circuit Foo:
     ; if-else-fatal style assert with conditional compilation toggles
     ; CHECK-NEXT:  `ifndef SYNTHESIS
     ; CHECK-NEXT:    always @(posedge clock) begin
-    ; CHECK-NEXT:     if (enable & ~(predicate9 | reset)) begin
+    ; CHECK-NEXT:     if (enable & ~[[GEN_8]]) begin
     ; CHECK-NEXT:       if (`ASSERT_VERBOSE_COND_)
     ; CHECK-NEXT:         $error("Assertion failed (verification library): Conditional compilation example with if-else-fatal style assert");
     ; CHECK-NEXT:       if (`STOP_COND_)
@@ -139,17 +133,39 @@ circuit Foo:
       stop(clock, enable, 1)
 
     ; assert with multiple toggle options
+    ; CHECK-NEXT:  wire [[GEN_9:.+]] = predicate10 | reset;
     ; CHECK-NEXT: `ifdef USE_FORMAL_ONLY_CONSTRAINTS
     ; CHECK-NEXT:   `ifdef USE_UNR_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:     wire [[TMP5:.+]] = ~enable | predicate10 | reset;
-    ; CHECK-NEXT:     assert__verif_library_2: assert property (@(posedge clock) [[TMP5]])
+    ; CHECK-NEXT:     assert__verif_library_2: 
+    ; CHECK-NEXT:       assert property (@(posedge clock) ~enable | [[GEN_9]])
     ; CHECK-SAME:       else $error("Assertion failed (verification library): Conditional compilation example for UNR-only and formal-only assert");
-    ; CHECK-NEXT:     `ifdef USE_PROPERTY_AS_CONSTRAINT
-    ; CHECK-NEXT:       always @(edge [[TMP5]])
-    ; CHECK-NEXT:         assume__verif_library_2: assume([[TMP5]]);
-    ; CHECK-NEXT:     `endif
     ; CHECK-NEXT:   `endif
     ; CHECK-NEXT: `endif
     when not(or(predicate10, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"formalOnly\"},{\"type\":\"unrOnly\"}],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): Conditional compilation example for UNR-only and formal-only assert\"}</extraction-summary> bar")
       stop(clock, enable, 1)
+
+    ; The companion assumes get bunched up in an ifdef block.
+    ; CHECK-NEXT: `ifdef USE_PROPERTY_AS_CONSTRAINT
+    ; CHECK-NEXT:   assume__verif_library: assume property (@(posedge clock) ~enable | [[GEN]]) else $error("Assertion failed (verification library): ");
+    ; CHECK-NEXT:   assume__verif_library_0: assume property (@(posedge clock) ~enable | [[GEN_0]]) else $error("Assertion failed (verification library): sum =/= 1.U");
+    ; CHECK-NEXT:   assume__verif_library_1: assume property (@(posedge clock) ~[[GEN_2]] | [[GEN_1]]) else $error("Assertion failed (verification library): Assert with when");
+    ; CHECK-NEXT:   assume__verif_library_2: assume property (@(posedge clock) ~enable | [[GEN_3]]) else $error("Assertion failed (verification library): expected sum === 2.U but got %d", $sampled(sum));
+    ; CHECK-NEXT:   assume__verif_library_3: assume property (@(posedge clock) [[GEN_4]]) else $error("Assertion failed (verification library): SVA assert example, sum was %d", $sampled(sum));
+    ; CHECK-NEXT:   assume__verif_library_hello_world: assume property (@(posedge clock) [[GEN_5]]) else $error("Assertion failed (verification library): Custom label example");
+    ; CHECK-NEXT:   assume__verif_library_4: assume property (@(posedge clock) [[GEN_6]]) else $error("Assertion failed (verification library): X-passing assert example");
+    ; CHECK-NEXT:   `ifdef USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:   wire [[GEN_10:.+]] = ~enable | [[GEN_8]];
+    ; CHECK-NEXT:   always @(edge [[GEN_7]])
+    ; CHECK-NEXT:     assume__verif_library_5: assume([[GEN_7]]) else $error("Assertion failed (verification library): Conditional compilation example for UNR-only assert");
+    ; CHECK-NEXT:   always @(edge [[GEN_10]])
+    ; CHECK-NEXT:     assume__verif_library_6: assume([[GEN_10]]) else $error("Assertion failed (verification library): Conditional compilation example with if-else-fatal style assert");
+    ; CHECK-NEXT:   `endif // USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:   `ifdef USE_FORMAL_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:     `ifdef USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:       wire [[GEN_11:.+]] = ~enable | [[GEN_9]];
+    ; CHECK-NEXT:       always @(edge [[GEN_11]])
+    ; CHECK-NEXT:         assume__verif_library_7: assume([[GEN_11]]) else $error("Assertion failed (verification library): Conditional compilation example for UNR-only and formal-only assert");
+    ; CHECK-NEXT:     `endif // USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:   `endif // USE_FORMAL_ONLY_CONSTRAINTS
+    ; CHECK-NEXT: `endif

--- a/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
@@ -147,25 +147,25 @@ circuit Foo:
 
     ; The companion assumes get bunched up in an ifdef block.
     ; CHECK-NEXT: `ifdef USE_PROPERTY_AS_CONSTRAINT
-    ; CHECK-NEXT:   assume__verif_library: assume property (@(posedge clock) ~enable | [[GEN]]) else $error("Assertion failed (verification library): ");
-    ; CHECK-NEXT:   assume__verif_library_0: assume property (@(posedge clock) ~enable | [[GEN_0]]) else $error("Assertion failed (verification library): sum =/= 1.U");
-    ; CHECK-NEXT:   assume__verif_library_1: assume property (@(posedge clock) ~[[GEN_2]] | [[GEN_1]]) else $error("Assertion failed (verification library): Assert with when");
-    ; CHECK-NEXT:   assume__verif_library_2: assume property (@(posedge clock) ~enable | [[GEN_3]]) else $error("Assertion failed (verification library): expected sum === 2.U but got %d", $sampled(sum));
-    ; CHECK-NEXT:   assume__verif_library_3: assume property (@(posedge clock) [[GEN_4]]) else $error("Assertion failed (verification library): SVA assert example, sum was %d", $sampled(sum));
-    ; CHECK-NEXT:   assume__verif_library_hello_world: assume property (@(posedge clock) [[GEN_5]]) else $error("Assertion failed (verification library): Custom label example");
-    ; CHECK-NEXT:   assume__verif_library_4: assume property (@(posedge clock) [[GEN_6]]) else $error("Assertion failed (verification library): X-passing assert example");
+    ; CHECK-NEXT:   assume__verif_library: assume property (@(posedge clock) ~enable | [[GEN]]);
+    ; CHECK-NEXT:   assume__verif_library_0: assume property (@(posedge clock) ~enable | [[GEN_0]]);
+    ; CHECK-NEXT:   assume__verif_library_1: assume property (@(posedge clock) ~[[GEN_2]] | [[GEN_1]]);
+    ; CHECK-NEXT:   assume__verif_library_2: assume property (@(posedge clock) ~enable | [[GEN_3]]);
+    ; CHECK-NEXT:   assume__verif_library_3: assume property (@(posedge clock) [[GEN_4]]);
+    ; CHECK-NEXT:   assume__verif_library_hello_world: assume property (@(posedge clock) [[GEN_5]]);
+    ; CHECK-NEXT:   assume__verif_library_4: assume property (@(posedge clock) [[GEN_6]]);
     ; CHECK-NEXT:   `ifdef USE_UNR_ONLY_CONSTRAINTS
     ; CHECK-NEXT:   wire [[GEN_10:.+]] = ~enable | [[GEN_8]];
     ; CHECK-NEXT:   always @(edge [[GEN_7]])
-    ; CHECK-NEXT:     assume__verif_library_5: assume([[GEN_7]]) else $error("Assertion failed (verification library): Conditional compilation example for UNR-only assert");
+    ; CHECK-NEXT:     assume__verif_library_5: assume([[GEN_7]]);
     ; CHECK-NEXT:   always @(edge [[GEN_10]])
-    ; CHECK-NEXT:     assume__verif_library_6: assume([[GEN_10]]) else $error("Assertion failed (verification library): Conditional compilation example with if-else-fatal style assert");
+    ; CHECK-NEXT:     assume__verif_library_6: assume([[GEN_10]]);
     ; CHECK-NEXT:   `endif // USE_UNR_ONLY_CONSTRAINTS
     ; CHECK-NEXT:   `ifdef USE_FORMAL_ONLY_CONSTRAINTS
     ; CHECK-NEXT:     `ifdef USE_UNR_ONLY_CONSTRAINTS
     ; CHECK-NEXT:       wire [[GEN_11:.+]] = ~enable | [[GEN_9]];
     ; CHECK-NEXT:       always @(edge [[GEN_11]])
-    ; CHECK-NEXT:         assume__verif_library_7: assume([[GEN_11]]) else $error("Assertion failed (verification library): Conditional compilation example for UNR-only and formal-only assert");
+    ; CHECK-NEXT:         assume__verif_library_7: assume([[GEN_11]]);
     ; CHECK-NEXT:     `endif // USE_UNR_ONLY_CONSTRAINTS
     ; CHECK-NEXT:   `endif // USE_FORMAL_ONLY_CONSTRAINTS
     ; CHECK-NEXT: `endif

--- a/test/Dialect/FIRRTL/create-companion-assume.mlir
+++ b/test/Dialect/FIRRTL/create-companion-assume.mlir
@@ -7,12 +7,12 @@ firrtl.module @Assert(in %clock: !firrtl.clock, in %pred: !firrtl.uint<1>,  in %
                       in %value: !firrtl.uint<42>) {
     firrtl.assert %clock, %pred, %en, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {guards=["Foo"]}
     // CHECK: firrtl.assert
-    // CHECK-NEXT: firrtl.assume %clock, %pred, %en, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
+    // CHECK-NEXT: firrtl.assume %clock, %pred, %en, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-SAME: {eventControl = 0 : i32, guards = ["USE_PROPERTY_AS_CONSTRAINT", "Foo"], isConcurrent = true}
 
     firrtl.assert %clock, %pred, %en, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {guards=["USE_UNR_ONLY_CONSTRAINTS"]}
     // CHECK: firrtl.assert
-    // CHECK-NEXT: firrtl.int.assume.edged_predicate %pred, %en, "assert0"(%value) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
+    // CHECK-NEXT: firrtl.int.unclocked_assume %pred, %en, "" : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-SAME: {guards = ["USE_PROPERTY_AS_CONSTRAINT", "USE_UNR_ONLY_CONSTRAINTS"]}
 }
 

--- a/test/Dialect/FIRRTL/create-companion-assume.mlir
+++ b/test/Dialect/FIRRTL/create-companion-assume.mlir
@@ -1,0 +1,19 @@
+    
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-create-companion-assume)))' %s | FileCheck %s
+firrtl.circuit "Assert" {
+
+// CHECK-LABEL: firrtl.module @Assert
+firrtl.module @Assert(in %clock: !firrtl.clock, in %pred: !firrtl.uint<1>,  in %en: !firrtl.uint<1>,
+                      in %value: !firrtl.uint<42>) {
+    firrtl.assert %clock, %pred, %en, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {guards=["Foo"]}
+    // CHECK: firrtl.assert
+    // CHECK-NEXT: firrtl.assume %clock, %pred, %en, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
+    // CHECK-SAME: {eventControl = 0 : i32, guards = ["USE_PROPERTY_AS_CONSTRAINT", "Foo"], isConcurrent = true}
+
+    firrtl.assert %clock, %pred, %en, "assert0"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42> {guards=["USE_UNR_ONLY_CONSTRAINTS"]}
+    // CHECK: firrtl.assert
+    // CHECK-NEXT: firrtl.int.assume.edged_predicate %pred, %en, "assert0"(%value) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
+    // CHECK-SAME: {guards = ["USE_PROPERTY_AS_CONSTRAINT", "USE_UNR_ONLY_CONSTRAINTS"]}
+}
+
+}

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -303,7 +303,7 @@ firrtl.circuit "Foo" {
     // CHECK: firrtl.int.unclocked_assume %{{.+}}, %{{.+}}, "text: %d"(
     // CHECK-SAME: guards = ["MACRO_GUARD", "ASDF"]
     // CHECK-SAME: name = "label for unr" 
-    %unr_predicate, %unr_enable, %unr_val = firrtl.instance unr interesting_name @AssumeEdgedPredicate(in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
+    %unr_predicate, %unr_enable, %unr_val = firrtl.instance unr interesting_name @UnclockedAssume(in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
     firrtl.strictconnect %unr_predicate, %cond : !firrtl.uint<1>
     firrtl.strictconnect %unr_enable, %enable : !firrtl.uint<1>
     firrtl.strictconnect %unr_val, %enable : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -302,8 +302,8 @@ firrtl.circuit "Foo" {
     // CHECK-NOT: firrtl.instance
     // CHECK: firrtl.int.unclocked_assume %{{.+}}, %{{.+}}, "text: %d"(
     // CHECK-SAME: guards = ["MACRO_GUARD", "ASDF"]
-    // CHECK-SAME: name = "label for unr"
-    %unr_predicate, %unr_enable, %unr_val = firrtl.instance unr interesting_name @UnclockedAssume(in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
+    // CHECK-SAME: name = "label for unr" 
+    %unr_predicate, %unr_enable, %unr_val = firrtl.instance unr interesting_name @AssumeEdgedPredicate(in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
     firrtl.strictconnect %unr_predicate, %cond : !firrtl.uint<1>
     firrtl.strictconnect %unr_enable, %enable : !firrtl.uint<1>
     firrtl.strictconnect %unr_val, %enable : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -302,7 +302,7 @@ firrtl.circuit "Foo" {
     // CHECK-NOT: firrtl.instance
     // CHECK: firrtl.int.unclocked_assume %{{.+}}, %{{.+}}, "text: %d"(
     // CHECK-SAME: guards = ["MACRO_GUARD", "ASDF"]
-    // CHECK-SAME: name = "label for unr" 
+    // CHECK-SAME: name = "label for unr"
     %unr_predicate, %unr_enable, %unr_val = firrtl.instance unr interesting_name @UnclockedAssume(in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
     firrtl.strictconnect %unr_predicate, %cond : !firrtl.uint<1>
     firrtl.strictconnect %unr_enable, %enable : !firrtl.uint<1>

--- a/test/firtool/chisel_assert.fir
+++ b/test/firtool/chisel_assert.fir
@@ -85,11 +85,9 @@ circuit ChiselVerif:
     ; CHECK-NEXT:  `ifdef MACRO_GUARD
     ; CHECK-NEXT:    `ifdef ASDF
     ; CHECK-NEXT:      assume__label_for_assert_with_format_string:
-    ; CHECK-NEXT:        assume property (@(posedge clock) [[GEN]])
-    ; CHECK-NEXT:        else $error("message: %d", $sampled(cond));
+    ; CHECK-NEXT:        assume property (@(posedge clock) [[GEN]]);
     ; CHECK-NEXT:      assume__label_for_ifelsefatal_assert:
-    ; CHECK-NEXT:        assume property (@(posedge clock) [[GEN]])
-    ; CHECK-NEXT:        else $error("ief: %d", $sampled(enable));
+    ; CHECK-SAME:        assume property (@(posedge clock) [[GEN]]);
     ; CHECK-NEXT:    `endif
     ; CHECK-NEXT:  `endif
     ; CHECK-NEXT:`endif

--- a/test/firtool/chisel_assert.fir
+++ b/test/firtool/chisel_assert.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s | FileCheck %s
+; RUN: firtool %s --add-companion-assume | FileCheck %s
 
 FIRRTL version 4.0.0
 
@@ -51,11 +51,9 @@ circuit ChiselVerif:
     input clock: Clock
     input cond: UInt<1>
     input enable: UInt<1>
-
+    ; CHECK:  wire [[GEN:.+]] = ~enable | cond;
     ; CHECK: assert property
     ; CHECK-NOT: $error
-    ; CHECK: PROPERTY_AS_CONSTRAINT
-    ; CHECK: assume
     inst assert of AssertAssume
     connect assert.clock, clock
     connect assert.predicate, cond
@@ -67,8 +65,6 @@ circuit ChiselVerif:
     ; CHECK: assert property
     ; CHECK: "message: %d"
     ; CHECK: $sampled(cond)
-    ; CHECK: PROPERTY_AS_CONSTRAINT
-    ; CHECK: assume
     inst assertFormat of AssertAssumeFormat
     connect assertFormat.clock, clock
     connect assertFormat.predicate, cond
@@ -84,6 +80,19 @@ circuit ChiselVerif:
     connect ief.predicate, cond
     connect ief.enable, enable
     connect ief.val, enable
+    ; CHECK: `ifdef USE_PROPERTY_AS_CONSTRAINT
+    ; CHECK-NEXT:  assume property (@(posedge clock) [[GEN]]);
+    ; CHECK-NEXT:  `ifdef MACRO_GUARD
+    ; CHECK-NEXT:    `ifdef ASDF
+    ; CHECK-NEXT:      assume__label_for_assert_with_format_string:
+    ; CHECK-NEXT:        assume property (@(posedge clock) [[GEN]])
+    ; CHECK-NEXT:        else $error("message: %d", $sampled(cond));
+    ; CHECK-NEXT:      assume__label_for_ifelsefatal_assert:
+    ; CHECK-NEXT:        assume property (@(posedge clock) [[GEN]])
+    ; CHECK-NEXT:        else $error("ief: %d", $sampled(enable));
+    ; CHECK-NEXT:    `endif
+    ; CHECK-NEXT:  `endif
+    ; CHECK-NEXT:`endif
 
     ; CHECK: label_for_assume
     ; CHECK: assume property


### PR DESCRIPTION
This PR separates UNROnlyAssume generation from AssertOp lowering into a dedicate op.

This commit adds:
* LowerToHW support for `UnclockedPredicateIntrinsicOp` (added in https://github.com/llvm/circt/pull/6867).
* CreateCompanionAssume pass which explicitly introduces companion assumes to the IR. Normal assume and UnclockedPredicateIntrinsicOp are used based on the guard's content.

The commit is intended not to change semantics of generated verilog. This commit should only introduces cosmetic changes regarding guards(because now they are reused).