### PR TITLE
[FIRRTL] Cache a symbol table instead of doing linear lookups every instance.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1541,12 +1541,14 @@ struct FIRStmtParser : public FIRParser {
   explicit FIRStmtParser(Block &blockToInsertInto,
                          FIRModuleContext &moduleContext,
                          hw::InnerSymbolNamespace &modNameSpace,
-                         FIRVersion version, SymbolRefAttr layerSym = {})
+                         SymbolTable &circuitSymTbl, FIRVersion version,
+                         SymbolRefAttr layerSym = {})
       : FIRParser(moduleContext.getConstants(), moduleContext.getLexer(),
                   version),
         builder(UnknownLoc::get(getContext()), getContext()),
         locationProcessor(this->builder), moduleContext(moduleContext),
-        modNameSpace(modNameSpace), layerSym(layerSym) {
+        modNameSpace(modNameSpace), layerSym(layerSym),
+        circuitSymTbl(circuitSymTbl) {
     builder.setInsertionPointToEnd(&blockToInsertInto);
   }
 
@@ -1662,6 +1664,8 @@ private:
   // An optional symbol that contains the current layer block that we are in.
   // This is used to construct a nested symbol for a layer block operation.
   SymbolRefAttr layerSym;
+
+  SymbolTable &circuitSymTbl;
 };
 
 } // end anonymous namespace
@@ -2632,7 +2636,8 @@ ParseResult FIRStmtParser::parseSubBlock(Block &blockToInsertInto,
   // We parse the substatements into their own parser, so they get inserted
   // into the specified 'when' region.
   auto subParser = std::make_unique<FIRStmtParser>(
-      blockToInsertInto, moduleContext, modNameSpace, version, layerSym);
+      blockToInsertInto, moduleContext, modNameSpace, circuitSymTbl, version,
+      layerSym);
 
   // Figure out whether the body is a single statement or a nested one.
   auto stmtIndent = getIndentation();
@@ -2932,9 +2937,9 @@ ParseResult FIRStmtParser::parseWhen(unsigned whenIndent) {
   // the outer 'when'.
   if (getToken().is(FIRToken::kw_when)) {
     // We create a sub parser for the else block.
-    auto subParser =
-        std::make_unique<FIRStmtParser>(whenStmt.getElseBlock(), moduleContext,
-                                        modNameSpace, version, layerSym);
+    auto subParser = std::make_unique<FIRStmtParser>(
+        whenStmt.getElseBlock(), moduleContext, modNameSpace, circuitSymTbl,
+        version, layerSym);
 
     return subParser->parseSimpleStmt(whenIndent);
   }
@@ -3072,8 +3077,9 @@ ParseResult FIRStmtParser::parseMatch(unsigned matchIndent) {
       return failure();
 
     // Parse a block of statements that are indented more than the case.
-    auto subParser = std::make_unique<FIRStmtParser>(
-        *caseBlock, moduleContext, modNameSpace, version, layerSym);
+    auto subParser =
+        std::make_unique<FIRStmtParser>(*caseBlock, moduleContext, modNameSpace,
+                                        circuitSymTbl, version, layerSym);
     if (subParser->parseSimpleStmtBlock(*caseIndent))
       return failure();
   }
@@ -3942,10 +3948,7 @@ ParseResult FIRStmtParser::parseInstanceChoice() {
 
 FModuleLike FIRStmtParser::getReferencedModule(SMLoc loc,
                                                StringRef moduleName) {
-  auto circuit =
-      builder.getBlock()->getParentOp()->getParentOfType<CircuitOp>();
-  auto referencedModule =
-      dyn_cast_or_null<FModuleLike>(circuit.lookupSymbol(moduleName));
+  auto referencedModule = circuitSymTbl.lookup<FModuleLike>(moduleName);
   if (!referencedModule) {
     emitError(loc,
               "use of undefined module name '" + moduleName + "' in instance");
@@ -4486,7 +4489,8 @@ private:
     unsigned indent;
   };
 
-  ParseResult parseModuleBody(DeferredModuleToParse &deferredModule);
+  ParseResult parseModuleBody(SymbolTable &circuitSymTbl,
+                              DeferredModuleToParse &deferredModule);
 
   SmallVector<DeferredModuleToParse, 0> deferredModules;
   ModuleOp mlirModule;
@@ -5261,7 +5265,8 @@ ParseResult FIRCircuitParser::parseLayer(CircuitOp circuit) {
 
 // Parse the body of this module.
 ParseResult
-FIRCircuitParser::parseModuleBody(DeferredModuleToParse &deferredModule) {
+FIRCircuitParser::parseModuleBody(SymbolTable &circuitSymTbl,
+                                  DeferredModuleToParse &deferredModule) {
   FModuleLike moduleOp = deferredModule.moduleOp;
   auto &body = moduleOp->getRegion(0).front();
   auto &portLocs = deferredModule.portLocs;
@@ -5289,7 +5294,8 @@ FIRCircuitParser::parseModuleBody(DeferredModuleToParse &deferredModule) {
   }
 
   hw::InnerSymbolNamespace modNameSpace(moduleOp);
-  FIRStmtParser stmtParser(body, moduleContext, modNameSpace, version);
+  FIRStmtParser stmtParser(body, moduleContext, modNameSpace, circuitSymTbl,
+                           version);
 
   // Parse the moduleBlock.
   auto result = stmtParser.parseSimpleStmtBlock(deferredModule.indent);
@@ -5453,10 +5459,17 @@ DoneParsing:
   // proactively touch it to make sure that it is always already created.
   (void)getLexer().translateLocation(info.getFIRLoc());
 
+  // Pre-verify symbol table, so we can construct it next.  Ideally, we would do
+  // this verification through the trait.
+  if (failed(mlir::detail::verifySymbolTable(circuit)))
+    return failure();
+
+  SymbolTable circuitSymTbl(circuit);
+
   // Next, parse all the module bodies.
   auto anyFailed = mlir::failableParallelForEachN(
       getContext(), 0, deferredModules.size(), [&](size_t index) {
-        if (parseModuleBody(deferredModules[index]))
+        if (parseModuleBody(circuitSymTbl, deferredModules[index]))
           return failure();
         return success();
       });

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -1541,7 +1541,7 @@ struct FIRStmtParser : public FIRParser {
   explicit FIRStmtParser(Block &blockToInsertInto,
                          FIRModuleContext &moduleContext,
                          hw::InnerSymbolNamespace &modNameSpace,
-                         SymbolTable &circuitSymTbl, FIRVersion version,
+                         const SymbolTable &circuitSymTbl, FIRVersion version,
                          SymbolRefAttr layerSym = {})
       : FIRParser(moduleContext.getConstants(), moduleContext.getLexer(),
                   version),
@@ -1665,7 +1665,7 @@ private:
   // This is used to construct a nested symbol for a layer block operation.
   SymbolRefAttr layerSym;
 
-  SymbolTable &circuitSymTbl;
+  const SymbolTable &circuitSymTbl;
 };
 
 } // end anonymous namespace
@@ -4489,7 +4489,7 @@ private:
     unsigned indent;
   };
 
-  ParseResult parseModuleBody(SymbolTable &circuitSymTbl,
+  ParseResult parseModuleBody(const SymbolTable &circuitSymTbl,
                               DeferredModuleToParse &deferredModule);
 
   SmallVector<DeferredModuleToParse, 0> deferredModules;
@@ -5265,7 +5265,7 @@ ParseResult FIRCircuitParser::parseLayer(CircuitOp circuit) {
 
 // Parse the body of this module.
 ParseResult
-FIRCircuitParser::parseModuleBody(SymbolTable &circuitSymTbl,
+FIRCircuitParser::parseModuleBody(const SymbolTable &circuitSymTbl,
                                   DeferredModuleToParse &deferredModule) {
   FModuleLike moduleOp = deferredModule.moduleOp;
   auto &body = moduleOp->getRegion(0).front();


### PR DESCRIPTION
roughly triples modules parsing performance on large designs.  This is about a 2x speedup for overall parsing stage.