### PR TITLE
[FIRRTL] Add generic intrinsic op.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -25,11 +25,11 @@ def GenericIntrinsicOp : FIRRTLOp<"int.generic",
 
   let arguments = (
     ins StrAttr:$intrinsic,
-    Variadic<AnyType>:$operands,
+    Variadic<PassiveType>:$operands,
     DefaultValuedAttr<ParamDeclArrayAttr, "{}">:$parameters
   );
 
-  let results = (outs Optional<AnyType>:$result);
+  let results = (outs Optional<PassiveType>:$result);
   let assemblyFormat = "$intrinsic custom<ParameterList>($parameters) ($operands^)? attr-dict-with-keyword `:` functional-type($operands, $result)";
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -30,7 +30,7 @@ def GenericIntrinsicOp : FIRRTLOp<"int.generic",
   );
 
   let results = (outs Optional<AnyType>:$result);
-  let assemblyFormat = "$intrinsic ($operands^)? attr-dict-with-keyword `:` functional-type($operands, $result)";
+  let assemblyFormat = "$intrinsic custom<ParameterList>($parameters) ($operands^)? attr-dict-with-keyword `:` functional-type($operands, $result)";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -13,36 +13,24 @@
 #ifndef CIRCT_DIALECT_FIRRTL_FIRRTLINTRINSICS_TD
 #define CIRCT_DIALECT_FIRRTL_FIRRTLINTRINSICS_TD
 
-def IsXIntrinsicOp : FIRRTLOp<"int.isX",
-    [HasCustomSSAName, Pure]> {
-  let summary = "Test for 'x";
-  let description = [{
-    The `int.isX` expression checks that the operand is not a verilog literal
-    'x.  FIRRTL doesn't have a notion of 'x per-se, but x can come in to the
-    system from external modules and from SV constructs.  Verification
-    constructs need to explicitly test for 'x.
-    }];
+include "FIRRTLDialect.td"
 
-  let arguments = (ins FIRRTLBaseType:$arg);
-  let results = (outs NonConstUInt1Type:$result);
-  let hasFolder = 1;
-  let assemblyFormat = "$arg attr-dict `:` type($arg)";
-}
+//===----------------------------------------------------------------------===//
+// Generic intrinsic operation for parsing into before lowering.
+//===----------------------------------------------------------------------===//
 
-def HasBeenResetIntrinsicOp : FIRRTLOp<"int.has_been_reset", [Pure]> {
-  let summary = "Check that a proper reset has been seen.";
-  let description = [{
-    The result of `firrtl.int.has_been_reset` reads as 0 immediately after simulation
-    startup and after each power-cycle in a power-aware simulation. The result
-    remains 0 before and during reset and only switches to 1 after the reset is
-    deasserted again.
+def GenericIntrinsicOp : FIRRTLOp<"int.generic",
+    [HasCustomSSAName]> {
+  let summary = "Generic intrinsic operation for FIRRTL intrinsics.";
 
-    See the corresponding `verif.has_been_reset` operation.
-  }];
-  let arguments = (ins NonConstClockType:$clock, AnyResetType:$reset);
-  let results = (outs NonConstUInt1Type:$result);
-  let hasFolder = 1;
-  let assemblyFormat = "$clock `,` $reset attr-dict `:` type($reset)";
+  let arguments = (
+    ins StrAttr:$intrinsic,
+    Variadic<AnyType>:$operands,
+    DefaultValuedAttr<ParamDeclArrayAttr, "{}">:$parameters
+  );
+
+  let results = (outs Optional<AnyType>:$result);
+  let assemblyFormat = "$intrinsic ($operands^)? attr-dict-with-keyword `:` functional-type($operands, $result)";
 }
 
 //===----------------------------------------------------------------------===//
@@ -134,5 +122,42 @@ def ClockInverterIntrinsicOp : FIRRTLOp<"int.clock_inv", []> {
   let results = (outs NonConstClockType:$output);
   let assemblyFormat = "$input attr-dict";
 }
+
+//===----------------------------------------------------------------------===//
+// Other intrinsics
+//===----------------------------------------------------------------------===//
+
+def IsXIntrinsicOp : FIRRTLOp<"int.isX",
+    [HasCustomSSAName, Pure]> {
+  let summary = "Test for 'x";
+  let description = [{
+    The `int.isX` expression checks that the operand is not a verilog literal
+    'x.  FIRRTL doesn't have a notion of 'x per-se, but x can come in to the
+    system from external modules and from SV constructs.  Verification
+    constructs need to explicitly test for 'x.
+    }];
+
+  let arguments = (ins FIRRTLBaseType:$arg);
+  let results = (outs NonConstUInt1Type:$result);
+  let hasFolder = 1;
+  let assemblyFormat = "$arg attr-dict `:` type($arg)";
+}
+
+def HasBeenResetIntrinsicOp : FIRRTLOp<"int.has_been_reset", [Pure]> {
+  let summary = "Check that a proper reset has been seen.";
+  let description = [{
+    The result of `firrtl.int.has_been_reset` reads as 0 immediately after simulation
+    startup and after each power-cycle in a power-aware simulation. The result
+    remains 0 before and during reset and only switches to 1 after the reset is
+    deasserted again.
+
+    See the corresponding `verif.has_been_reset` operation.
+  }];
+  let arguments = (ins NonConstClockType:$clock, AnyResetType:$reset);
+  let results = (outs NonConstUInt1Type:$result);
+  let hasFolder = 1;
+  let assemblyFormat = "$clock `,` $reset attr-dict `:` type($reset)";
+}
+
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLINTRINSICS_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -53,7 +53,7 @@ public:
             LTLConcatIntrinsicOp, LTLNotIntrinsicOp, LTLImplicationIntrinsicOp,
             LTLEventuallyIntrinsicOp, LTLClockIntrinsicOp,
             LTLDisableIntrinsicOp, Mux2CellIntrinsicOp, Mux4CellIntrinsicOp,
-            HasBeenResetIntrinsicOp, FPGAProbeIntrinsicOp,
+            HasBeenResetIntrinsicOp, FPGAProbeIntrinsicOp, GenericIntrinsicOp,
             // Miscellaneous.
             BitsPrimOp, HeadPrimOp, MuxPrimOp, PadPrimOp, ShlPrimOp, ShrPrimOp,
             TailPrimOp, VerbatimExprOp, HWStructCastOp, BitCastOp, RefSendOp,
@@ -180,6 +180,7 @@ public:
   HANDLE(Mux2CellIntrinsicOp, Unhandled);
   HANDLE(HasBeenResetIntrinsicOp, Unhandled);
   HANDLE(FPGAProbeIntrinsicOp, Unhandled);
+  HANDLE(GenericIntrinsicOp, Unhandled);
 
   // Miscellaneous.
   HANDLE(BitsPrimOp, Unhandled);

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -5764,6 +5764,9 @@ void GEQPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 void GTPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
+void GenericIntrinsicOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  genericAsmResultNames(*this, setNameFn);
+}
 void HeadPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1255,7 +1255,8 @@ parseModulePorts(OpAsmParser &parser, bool hasSSAIdentifiers,
 }
 
 /// Print a paramter list for a module or instance.
-static void printParameterList(ArrayAttr parameters, OpAsmPrinter &p) {
+static void printParameterList(OpAsmPrinter &p, Operation *op,
+                               ArrayAttr parameters) {
   if (!parameters || parameters.empty())
     return;
 
@@ -1283,7 +1284,7 @@ static void printFModuleLikeOp(OpAsmPrinter &p, FModuleLike op) {
   p.printSymbolName(op.getModuleName());
 
   // Print the parameter list (if non-empty).
-  printParameterList(op->getAttrOfType<ArrayAttr>("parameters"), p);
+  printParameterList(p, op, op->getAttrOfType<ArrayAttr>("parameters"));
 
   // Both modules and external modules have a body, but it is always empty for
   // external modules.
@@ -1370,6 +1371,18 @@ parseOptionalParameters(OpAsmParser &parser,
             builder.getContext(), builder.getStringAttr(name), type, value));
         return success();
       });
+}
+
+/// Shim to use with assemblyFormat, custom<ParameterList>.
+static ParseResult parseParameterList(OpAsmParser &parser,
+                                      ArrayAttr &parameters) {
+  SmallVector<Attribute> parseParameters;
+  if (failed(parseOptionalParameters(parser, parseParameters)))
+    return failure();
+
+  parameters = ArrayAttr::get(parser.getContext(), parseParameters);
+
+  return success();
 }
 
 static ParseResult parseFModuleLikeOp(OpAsmParser &parser,

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -24,11 +24,13 @@ firrtl.module @Intrinsics(in %ui : !firrtl.uint, in %clock: !firrtl.clock, in %u
 
   // CHECK-NEXT: firrtl.int.generic "clock_gate" %clock, %ui1 : (!firrtl.clock, !firrtl.uint<1>)
   // CHECK-NEXT: firrtl.int.generic "noargs" : () -> i32
-  // CHECK-NEXT: firrtl.int.generic "params" attributes {parameters = [#firrtl.param.decl<"FORMAT": none = "foobar">]} : () -> i32
+  // CHECK-NEXT: firrtl.int.generic "params" <FORMAT: none = "foobar"> : () -> i32
+  // CHECK-NEXT: firrtl.int.generic "params_and_operand" <X: i64 = 123> %ui1 : (!firrtl.uint<1>) -> i64
   // CHECK-NEXT: firrtl.int.generic "inputs" %clock, %ui1, %clock : (!firrtl.clock, !firrtl.uint<1>, !firrtl.clock) -> ()
   %cg2 = firrtl.int.generic "clock_gate" %clock, %ui1 : (!firrtl.clock, !firrtl.uint<1>) -> !firrtl.clock
-  %cg3 = firrtl.int.generic "noargs" : () -> i32
-  %p = firrtl.int.generic "params" attributes {parameters = [#firrtl.param.decl<"FORMAT": none = "foobar">]} : () -> i32
+  %noargs = firrtl.int.generic "noargs" : () -> i32
+  %p = firrtl.int.generic "params" <FORMAT: none = "foobar"> : () -> i32
+  %po = firrtl.int.generic "params_and_operand" <X: i64 = 123> %ui1 : (!firrtl.uint<1>) -> i64
   firrtl.int.generic "inputs" %clock, %ui1, %clock : (!firrtl.clock, !firrtl.uint<1>, !firrtl.clock) -> ()
 }
 

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -21,6 +21,15 @@ firrtl.module @Intrinsics(in %ui : !firrtl.uint, in %clock: !firrtl.clock, in %u
   // CHECK-NEXT: firrtl.int.clock_gate %clock, %ui1, %ui1
   %cg0 = firrtl.int.clock_gate %clock, %ui1
   %cg1 = firrtl.int.clock_gate %clock, %ui1, %ui1
+
+  // CHECK-NEXT: firrtl.int.generic "clock_gate" %clock, %ui1 : (!firrtl.clock, !firrtl.uint<1>)
+  // CHECK-NEXT: firrtl.int.generic "noargs" : () -> i32
+  // CHECK-NEXT: firrtl.int.generic "params" attributes {parameters = [#firrtl.param.decl<"FORMAT": none = "foobar">]} : () -> i32
+  // CHECK-NEXT: firrtl.int.generic "inputs" %clock, %ui1, %clock : (!firrtl.clock, !firrtl.uint<1>, !firrtl.clock) -> ()
+  %cg2 = firrtl.int.generic "clock_gate" %clock, %ui1 : (!firrtl.clock, !firrtl.uint<1>) -> !firrtl.clock
+  %cg3 = firrtl.int.generic "noargs" : () -> i32
+  %p = firrtl.int.generic "params" attributes {parameters = [#firrtl.param.decl<"FORMAT": none = "foobar">]} : () -> i32
+  firrtl.int.generic "inputs" %clock, %ui1, %clock : (!firrtl.clock, !firrtl.uint<1>, !firrtl.clock) -> ()
 }
 
 // CHECK-LABEL: firrtl.module @FPGAProbe

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -23,14 +23,14 @@ firrtl.module @Intrinsics(in %ui : !firrtl.uint, in %clock: !firrtl.clock, in %u
   %cg1 = firrtl.int.clock_gate %clock, %ui1, %ui1
 
   // CHECK-NEXT: firrtl.int.generic "clock_gate" %clock, %ui1 : (!firrtl.clock, !firrtl.uint<1>)
-  // CHECK-NEXT: firrtl.int.generic "noargs" : () -> i32
-  // CHECK-NEXT: firrtl.int.generic "params" <FORMAT: none = "foobar"> : () -> i32
-  // CHECK-NEXT: firrtl.int.generic "params_and_operand" <X: i64 = 123> %ui1 : (!firrtl.uint<1>) -> i64
+  // CHECK-NEXT: firrtl.int.generic "noargs" : () -> !firrtl.uint<32>
+  // CHECK-NEXT: firrtl.int.generic "params" <FORMAT: none = "foobar"> : () -> !firrtl.bundle<x: uint<1>>
+  // CHECK-NEXT: firrtl.int.generic "params_and_operand" <X: i64 = 123> %ui1 : (!firrtl.uint<1>) -> !firrtl.clock
   // CHECK-NEXT: firrtl.int.generic "inputs" %clock, %ui1, %clock : (!firrtl.clock, !firrtl.uint<1>, !firrtl.clock) -> ()
   %cg2 = firrtl.int.generic "clock_gate" %clock, %ui1 : (!firrtl.clock, !firrtl.uint<1>) -> !firrtl.clock
-  %noargs = firrtl.int.generic "noargs" : () -> i32
-  %p = firrtl.int.generic "params" <FORMAT: none = "foobar"> : () -> i32
-  %po = firrtl.int.generic "params_and_operand" <X: i64 = 123> %ui1 : (!firrtl.uint<1>) -> i64
+  %noargs = firrtl.int.generic "noargs" : () -> !firrtl.uint<32>
+  %p = firrtl.int.generic "params" <FORMAT: none = "foobar"> : () -> !firrtl.bundle<x: uint<1>>
+  %po = firrtl.int.generic "params_and_operand" <X: i64 = 123> %ui1 : (!firrtl.uint<1>) -> !firrtl.clock
   firrtl.int.generic "inputs" %clock, %ui1, %clock : (!firrtl.clock, !firrtl.uint<1>, !firrtl.clock) -> ()
 }
 


### PR DESCRIPTION
Add generic intrinsic operation to FIRRTL.  Not used anywhere, just adding to the IR to build on.
Re-use module parameter printing/parsing for use as custom printer on the op.

Bit of context:

This is intended to have a FIRRTL textual equivalent that allows intrinsics to be used as expressions or statements, as a replacement for instances of intmodule's in the future, for ergonomic but primarily practical reasons that limit intrinsic use today.

The op is generic so that intrinsics may be parsed without the parser knowing details of supported intrinsics while still having sufficient type information to produce IR and good diagnostics during parsing (return value in particular).

Operands and results are required to be passive (and base) as that's all that is supported today (crashes at various points in the pipeline if not), and because passive specifically fits best with the model of intrinsics as having inputs it reads from and outputs distinctly.  This can be loosened in the future should this be needed (and supported).
There is a single (optional) return value, for use as a FIRRTL expression in a single simple format.  Multiple outputs become a single result bundle.

cc #6869 which shows some of what's planned next and demonstrates this in practice (internal to CIRCT anyway):
a pass converting instances+intmodules to these operations, and reworking LowerIntrinsics to expect these ops as the canonical form, making it possible to be a module pass and implement lowering as patterns for safety and simpler lowering code.

For now, start by adding the generic intrinsic operation.