### PR TITLE
[FIRRTL] Change Port Direction attribute from an APInt to a DenseArray.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
@@ -49,13 +49,13 @@ static inline StringRef toString(bool direction) {
   return toString(get(direction));
 }
 
-/// Return a \p DenseBoolArrayAttr containing the packed representation of an array
-/// of directions.
+/// Return a \p DenseBoolArrayAttr containing the packed representation of an
+/// array of directions.
 mlir::DenseBoolArrayAttr packAttribute(MLIRContext *context,
                                        ArrayRef<Direction> directions);
 
-/// Return a \p DenseBoolArrayAttr containing the packed representation of an array
-/// of directions.
+/// Return a \p DenseBoolArrayAttr containing the packed representation of an
+/// array of directions.
 mlir::DenseBoolArrayAttr packAttribute(MLIRContext *context,
                                        ArrayRef<bool> directions);
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
@@ -33,22 +33,33 @@ namespace direction {
 
 /// Return an output direction if \p isOutput is true, otherwise return an
 /// input direction.
-inline Direction get(bool isOutput) { return (Direction)isOutput; }
+static inline Direction get(bool isOutput) { return (Direction)isOutput; }
+
+/// Convert from Direction to bool.  The opposite of get;
+static inline bool unGet(Direction dir) { return (bool)dir; }
 
 /// Flip a port direction.
 Direction flip(Direction direction);
 
-inline StringRef toString(Direction direction) {
+static inline StringRef toString(Direction direction) {
   return direction == Direction::In ? "in" : "out";
+}
+
+static inline StringRef toString(bool direction) {
+  return toString(get(direction));
 }
 
 /// Return a \p IntegerAttr containing the packed representation of an array
 /// of directions.
-IntegerAttr packAttribute(MLIRContext *context, ArrayRef<Direction> directions);
+mlir::DenseBoolArrayAttr packAttribute(MLIRContext *context, ArrayRef<Direction> directions);
+
+/// Return a \p IntegerAttr containing the packed representation of an array
+/// of directions.
+mlir::DenseBoolArrayAttr packAttribute(MLIRContext *context, ArrayRef<bool> directions);
 
 /// Turn a packed representation of port attributes into a vector that can
 /// be worked with.
-SmallVector<Direction> unpackAttribute(IntegerAttr directions);
+SmallVector<Direction> unpackAttribute(mlir::DenseBoolArrayAttr directions);
 
 } // namespace direction
 } // namespace firrtl

--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
@@ -54,7 +54,7 @@ static inline StringRef toString(bool direction) {
 mlir::DenseBoolArrayAttr packAttribute(MLIRContext *context,
                                        ArrayRef<Direction> directions);
 
-/// Return a \p IntegerAttr containing the packed representation of an array
+/// Return a \p DenseBoolArrayAttr containing the packed representation of an array
 /// of directions.
 mlir::DenseBoolArrayAttr packAttribute(MLIRContext *context,
                                        ArrayRef<bool> directions);

--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.h
@@ -51,11 +51,13 @@ static inline StringRef toString(bool direction) {
 
 /// Return a \p IntegerAttr containing the packed representation of an array
 /// of directions.
-mlir::DenseBoolArrayAttr packAttribute(MLIRContext *context, ArrayRef<Direction> directions);
+mlir::DenseBoolArrayAttr packAttribute(MLIRContext *context,
+                                       ArrayRef<Direction> directions);
 
 /// Return a \p IntegerAttr containing the packed representation of an array
 /// of directions.
-mlir::DenseBoolArrayAttr packAttribute(MLIRContext *context, ArrayRef<bool> directions);
+mlir::DenseBoolArrayAttr packAttribute(MLIRContext *context,
+                                       ArrayRef<bool> directions);
 
 /// Turn a packed representation of port attributes into a vector that can
 /// be worked with.

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -59,7 +59,7 @@ def InstanceOp : HardwareDeclOp<"instance", [
   }];
 
   let arguments = (ins FlatSymbolRefAttr:$moduleName, StrAttr:$name, NameKindAttr:$nameKind,
-                       APIntAttr:$portDirections, StrArrayAttr:$portNames,
+                       DenseBoolArrayAttr:$portDirections, StrArrayAttr:$portNames,
                        AnnotationArrayAttr:$annotations,
                        PortAnnotationsAttr:$portAnnotations,
                        LayerArrayAttr:$layers,
@@ -188,7 +188,7 @@ def InstanceChoiceOp : HardwareDeclOp<"instance_choice", [
   let arguments = (ins FlatSymbolRefArrayAttr:$moduleNames,
                        SymbolRefArrayAttr:$caseNames,
                        StrAttr:$name, NameKindAttr:$nameKind,
-                       APIntAttr:$portDirections, StrArrayAttr:$portNames,
+                       DenseBoolArrayAttr:$portDirections, StrArrayAttr:$portNames,
                        AnnotationArrayAttr:$annotations,
                        PortAnnotationsAttr:$portAnnotations,
                        LayerArrayAttr:$layers,

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -54,14 +54,14 @@ def FModuleLike : OpInterface<"FModuleLike", [Symbol, PortList, InstanceGraphMod
     //===------------------------------------------------------------------===//
 
     InterfaceMethod<"Get the port directions attribute",
-    "IntegerAttr", "getPortDirectionsAttr", (ins), [{}],
+    "mlir::DenseBoolArrayAttr", "getPortDirectionsAttr", (ins), [{}],
     /*defaultImplementation=*/[{
       return $_op->template
-        getAttrOfType<IntegerAttr>(FModuleLike::getPortDirectionsAttrName());
+        getAttrOfType<mlir::DenseBoolArrayAttr>(FModuleLike::getPortDirectionsAttrName());
     }]>,
 
     InterfaceMethod<"Get the port directions",
-    "APInt", "getPortDirections", (ins), [{}],
+    "ArrayRef<bool>", "getPortDirections", (ins), [{}],
     /*defaultImplementation=*/[{
       return $_op.getPortDirectionsAttr().getValue();
     }]>,

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -130,6 +130,7 @@ def FModuleOp : FIRRTLModuleLike<"module", [SingleBlock, NoTerminator]> {
   }];
   let arguments =
       (ins ConventionAttr:$convention,
+           DenseBoolArrayAttr:$portDirections,
            ArrayRefAttr:$portLocations,
            ArrayRefAttr:$portAnnotations,
            ArrayRefAttr:$portSyms,
@@ -194,6 +195,7 @@ def FExtModuleOp : FIRRTLModuleLike<"extmodule"> {
       (ins OptionalAttr<StrAttr>:$defname,
            ParamDeclArrayAttr:$parameters,
            ConventionAttr:$convention,
+           DenseBoolArrayAttr:$portDirections,
            ArrayRefAttr:$portLocations,
            ArrayRefAttr:$portAnnotations,
            ArrayRefAttr:$portSyms,
@@ -235,6 +237,7 @@ def FIntModuleOp : FIRRTLModuleLike<"intmodule"> {
   let arguments = 
       (ins StrAttr:$intrinsic,
            ParamDeclArrayAttr:$parameters,
+           DenseBoolArrayAttr:$portDirections,
            ArrayRefAttr:$portLocations,
            ArrayRefAttr:$portAnnotations,
            ArrayRefAttr:$portSyms,
@@ -282,6 +285,7 @@ def FMemModuleOp : FIRRTLModuleLike<"memmodule"> {
            UI32Attr:$numReadWritePorts, UI32Attr:$dataWidth, UI32Attr:$maskBits,
            UI32Attr:$readLatency, UI32Attr:$writeLatency, UI64Attr:$depth,
            ArrayAttr:$extraPorts,
+           DenseBoolArrayAttr:$portDirections,
            ArrayRefAttr:$portLocations,
            ArrayRefAttr:$portAnnotations,
            ArrayRefAttr:$portSyms,
@@ -334,7 +338,8 @@ def ClassOp : FIRRTLModuleLike<"class", [
     A class may only have property ports, and its body may only be ops that act
     on properties, such as propassign ops.
   }];
-  let arguments = (ins SymbolNameAttr:$sym_name, APIntAttr:$portDirections,
+  let arguments = (ins SymbolNameAttr:$sym_name,
+                       DenseBoolArrayAttr:$portDirections,
                        ArrayRefAttr:$portNames, ArrayRefAttr:$portTypes,
                        ArrayRefAttr:$portSyms, ArrayRefAttr:$portLocations);
   let results = (outs);
@@ -394,7 +399,8 @@ def ExtClassOp : FIRRTLModuleLike<"extclass", [
     firrtl.extclass @MyImportedClass(in in_str: !firrtl.string, out out_str: !firrtl.string)
     ```
   }];
-  let arguments = (ins SymbolNameAttr:$sym_name, APIntAttr:$portDirections,
+  let arguments = (ins SymbolNameAttr:$sym_name, 
+                       DenseBoolArrayAttr:$portDirections,
                        ArrayRefAttr:$portNames, ArrayRefAttr:$portTypes,
                        ArrayRefAttr:$portSyms, ArrayRefAttr:$portLocations);
   let results = (outs);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -221,7 +221,8 @@ static void emitZeroWidthIndexingValue(PPS &os) {
 
 /// Return the verilog name of the port for the module.
 static StringRef getPortVerilogName(Operation *module, size_t portArgNum) {
-  return cast<HWModuleLike>(module).getPort(portArgNum).getVerilogName();
+  auto hml = cast<HWModuleLike>(module);
+  return hml.getPort(portArgNum).getVerilogName();
 }
 
 /// Return the verilog name of the port for the module.

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1277,7 +1277,6 @@ LogicalResult FIRRTLModuleLowering::lowerModulePortsAndMoveBody(
 
   // Insert argument casts, and re-vector users in the old body to use them.
   SmallVector<PortInfo> firrtlPorts = oldModule.getPorts();
-  SmallVector<hw::PortInfo> hwPorts = newModule.getPortList();
   assert(oldModule.getBody().getNumArguments() == firrtlPorts.size() &&
          "port count mismatch");
 
@@ -1348,7 +1347,7 @@ LogicalResult FIRRTLModuleLowering::lowerModulePortsAndMoveBody(
       outputs.push_back(output);
 
       // If output port has symbol, move it to this wire.
-      if (auto sym = hwPorts[hwPortIndex].getSym()) {
+      if (auto sym = newModule.getPort(hwPortIndex).getSym()) {
         newArg.setInnerSymAttr(sym);
         newModule.setPortSymbolAttr(hwPortIndex, {});
       }

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -290,7 +290,6 @@ portToFieldInfo(llvm::ArrayRef<hw::PortInfo> portInfo) {
 // Convert any handshake.extmemory operations and the top-level I/O
 // associated with these.
 static LogicalResult convertExtMemoryOps(HWModuleOp mod) {
-  //  auto ports = mod.getPortList();
   auto *ctx = mod.getContext();
 
   // Gather memref ports to be converted.

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -290,7 +290,7 @@ portToFieldInfo(llvm::ArrayRef<hw::PortInfo> portInfo) {
 // Convert any handshake.extmemory operations and the top-level I/O
 // associated with these.
 static LogicalResult convertExtMemoryOps(HWModuleOp mod) {
-  auto ports = mod.getPortList();
+  //  auto ports = mod.getPortList();
   auto *ctx = mod.getContext();
 
   // Gather memref ports to be converted.

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -34,26 +34,27 @@ Direction direction::flip(Direction direction) {
   llvm_unreachable("unknown direction");
 }
 
-IntegerAttr direction::packAttribute(MLIRContext *context,
-                                     ArrayRef<Direction> directions) {
+mlir::DenseBoolArrayAttr
+direction::packAttribute(MLIRContext *context, ArrayRef<Direction> directions) {
   // Pack the array of directions into an APInt.  Input is zero, output is one.
-  auto size = directions.size();
-  APInt portDirections(size, 0);
-  for (size_t i = 0; i != size; ++i)
-    if (directions[i] == Direction::Out)
-      portDirections.setBit(i);
-  return IntegerAttr::get(IntegerType::get(context, size), portDirections);
+  SmallVector<bool> dirs;
+  for (auto d : directions)
+    dirs.push_back(d == Direction::Out);
+  return mlir::DenseBoolArrayAttr::get(context, dirs);
 }
 
-SmallVector<Direction> direction::unpackAttribute(IntegerAttr directions) {
-  assert(directions.getType().isSignlessInteger() &&
-         "Direction attributes must be signless integers");
-  auto value = directions.getValue();
-  auto size = value.getBitWidth();
+mlir::DenseBoolArrayAttr direction::packAttribute(MLIRContext *context,
+                                                  ArrayRef<bool> directions) {
+  // Pack the array of directions into an APInt.  Input is zero, output is one.
+  return mlir::DenseBoolArrayAttr::get(context, directions);
+}
+
+SmallVector<Direction>
+direction::unpackAttribute(mlir::DenseBoolArrayAttr directions) {
   SmallVector<Direction> result;
-  result.reserve(size);
-  for (size_t i = 0; i != size; ++i)
-    result.push_back(direction::get(value[i]));
+  result.reserve(directions.size());
+  for (size_t i = 0ULL, e = directions.size(); i != e; ++i)
+    result.push_back(direction::get(directions[i]));
   return result;
 }
 

--- a/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAttributes.cpp
@@ -38,6 +38,7 @@ mlir::DenseBoolArrayAttr
 direction::packAttribute(MLIRContext *context, ArrayRef<Direction> directions) {
   // Pack the array of directions into an APInt.  Input is zero, output is one.
   SmallVector<bool> dirs;
+  dirs.reserve(directions.size());
   for (auto d : directions)
     dirs.push_back(d == Direction::Out);
   return mlir::DenseBoolArrayAttr::get(context, dirs);

--- a/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOpInterfaces.cpp
@@ -68,7 +68,7 @@ LogicalResult circt::firrtl::verifyModuleLikeOpInterface(FModuleLike module) {
     return module.emitOpError("requires valid port direction");
   // TODO: bitwidth is 1 when there are no ports, since APInt previously did not
   // support 0 bit widths.
-  auto bitWidth = portDirections.getValue().getBitWidth();
+  auto bitWidth = portDirections.size();
   if (bitWidth != numPorts)
     return module.emitOpError("requires ") << numPorts << " port directions";
 

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -527,16 +527,15 @@ struct Equivalence {
     return success();
   }
 
-  LogicalResult check(InFlightDiagnostic &diag, Operation *a, IntegerAttr aAttr,
-                      Operation *b, IntegerAttr bAttr) {
+  LogicalResult check(InFlightDiagnostic &diag, Operation *a,
+                      mlir::DenseBoolArrayAttr aAttr, Operation *b,
+                      mlir::DenseBoolArrayAttr bAttr) {
     if (aAttr == bAttr)
       return success();
-    auto aDirections = direction::unpackAttribute(aAttr);
-    auto bDirections = direction::unpackAttribute(bAttr);
     auto portNames = a->getAttrOfType<ArrayAttr>("portNames");
-    for (unsigned i = 0, e = aDirections.size(); i < e; ++i) {
-      auto aDirection = aDirections[i];
-      auto bDirection = bDirections[i];
+    for (unsigned i = 0, e = aAttr.size(); i < e; ++i) {
+      auto aDirection = aAttr[i];
+      auto bDirection = bAttr[i];
       if (aDirection != bDirection) {
         auto &note = diag.attachNote(a->getLoc()) << "module port ";
         if (portNames)
@@ -606,8 +605,8 @@ struct Equivalence {
       } else if (attrName == portDirectionsAttr) {
         // Special handling for the port directions attribute for better
         // error messages.
-        if (failed(check(diag, a, cast<IntegerAttr>(aAttr), b,
-                         cast<IntegerAttr>(bAttr))))
+        if (failed(check(diag, a, cast<mlir::DenseBoolArrayAttr>(aAttr), b,
+                         cast<mlir::DenseBoolArrayAttr>(bAttr))))
           return failure();
       } else if (isa<DistinctAttr>(aAttr) && isa<DistinctAttr>(bAttr)) {
         // TODO: properly handle DistinctAttr, including its use in paths.

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -857,7 +857,6 @@ void InferResetsPass::traceResets(InstanceOp inst) {
   LLVM_DEBUG(llvm::dbgs() << "Visiting instance " << inst.getName() << "\n");
 
   // Establish a connection between the instance ports and module ports.
-  auto dirs = module.getPortDirections();
   for (const auto &it : llvm::enumerate(inst.getResults())) {
     auto dir = module.getPortDirection(it.index());
     Value dstPort = module.getArgument(it.index());

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -35,7 +35,7 @@ firrtl.circuit "" {
 
 firrtl.circuit "foo" {
 // expected-error @+1 {{requires 1 port directions}}
-firrtl.module @foo(in %a : !firrtl.uint<1>) attributes {portDirections = 3 : i2} {}
+firrtl.module @foo(in %a : !firrtl.uint<1>) attributes {portDirections = array<i1: true, true>} {}
 }
 
 // -----
@@ -72,7 +72,7 @@ firrtl.circuit "foo" {
 // expected-error @+1 {{requires one region}}
 "firrtl.module"() ( { }, { })
    {sym_name = "foo", convention = #firrtl<convention internal>,
-    portTypes = [!firrtl.uint], portDirections = 1 : i1,
+    portTypes = [!firrtl.uint], portDirections = array<i1: true>,
     portNames = ["in0"], portAnnotations = [], portSyms = []} : () -> ()
 }
 
@@ -83,7 +83,7 @@ firrtl.circuit "foo" {
 "firrtl.module"() ( {
   ^entry:
 }) { sym_name = "foo", convention = #firrtl<convention internal>,
-    portTypes = [!firrtl.uint], portDirections = 1 : i1,
+    portTypes = [!firrtl.uint], portDirections = array<i1: true>,
     portNames = ["in0"], portAnnotations = [], portSyms = []} : () -> ()
 }
 
@@ -94,7 +94,7 @@ firrtl.circuit "foo" {
 "firrtl.module"() ( {
   ^entry:
 }) {sym_name = "foo", convention = #firrtl<convention internal>,
-    portTypes = [!firrtl.uint], portDirections = 1 : i1,
+    portTypes = [!firrtl.uint], portDirections = array<i1: true>,
     portNames = ["in0"], portAnnotations = [], portSyms = [],
     portLocations = []} : () -> ()
 }
@@ -109,7 +109,7 @@ firrtl.circuit "foo" {
 "firrtl.module"() ( {
   ^entry:
 }) {sym_name = "foo", convention = #firrtl<convention internal>,
-    portTypes = [!firrtl.uint], portDirections = 1 : i1,
+    portTypes = [!firrtl.uint], portDirections = array<i1: true>,
     portNames = ["in0"], portAnnotations = [], portSyms = [],
     portLocations = [loc("loc")]} : () -> ()
 }
@@ -121,7 +121,7 @@ firrtl.circuit "foo" {
 "firrtl.module"() ( {
   ^entry(%a: i1):
 }) {sym_name = "foo", convention = #firrtl<convention internal>,
-    portTypes = [!firrtl.uint], portDirections = 1 : i1,
+    portTypes = [!firrtl.uint], portDirections = array<i1: true>,
     portNames = ["in0"], portAnnotations = [], portSyms = [],
     portLocations = [loc("foo")]} : () -> ()
 }
@@ -2381,7 +2381,7 @@ firrtl.circuit "NoCases" {
       caseNames = [],
       name = "inst",
       nameKind = #firrtl<name_kind interesting_name>,
-      portDirections = 0 : i0,
+      portDirections = array<i1>,
       portNames = [],
       annotations = [],
       portAnnotations = [],
@@ -2412,7 +2412,7 @@ firrtl.circuit "MismatchedCases" {
       caseNames = [@Platform::@ASIC, @Perf::@Fast],
       name = "inst",
       nameKind = #firrtl<name_kind interesting_name>,
-      portDirections = 0 : i0,
+      portDirections = array<i1>,
       portNames = [],
       annotations = [],
       portAnnotations = [],


### PR DESCRIPTION
APInt requires an allocation to start large values.  Using apint for port directions requires copying the apint when inspecting port directions, thus introducing huge amount of copies throughout the code.  On large designs just this allocation overhead amounted to over 25% of the time spent (plus copy times).  DenseArrays are less space efficient (by 8x as used), but can be accessed by reference, removing these allocations.

Overall improvement is about 35% - 40%.