### PR TITLE
[FIRRTL] Deprecate AssertAssume intrinsic and rename it to Assert

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
+++ b/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
@@ -95,11 +95,9 @@ The enable input is sampled at the rising edge of the input clock; any changes o
 | en   | input     | UInt<1>  | enable for the output clock |
 | out  | output    | Clock    | gated output clock          |
 
-### circt.chisel_assert_assume
+### circt.chisel_assert
 
-Generate a clocked SV assertion with companion assume statement.
-
-Has legacy special behavior and should not be used by new code.
+Generate a clocked SV assert statement, with optional formatted error message.
 
 | Parameter | Type   | Description                                                                         |
 | --------- | ------ | ----------------------------------------------------------------------------------- |
@@ -118,9 +116,6 @@ Example output:
 ```systemverilog
 wire _GEN = ~enable | cond;
 assert__label: assert property (@(posedge clock) _GEN) else $error("message");
-`ifdef USE_PROPERTY_AS_CONSTRAINT
-  assume__label: assume property (@(posedge clock) _GEN);
-`endif // USE_PROPERTY_AS_CONSTRAINT
 ```
 
 ### circt.chisel_ifelsefatal

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntrinsics.cpp
@@ -605,7 +605,7 @@ static ParamDeclAttr getNamedParam(ArrayAttr params, StringRef name) {
 namespace {
 
 template <class OpTy, bool ifElseFatal = false>
-class CirctAssertAssumeConverter : public IntrinsicConverter {
+class CirctAssertConverter : public IntrinsicConverter {
 public:
   using IntrinsicConverter::IntrinsicConverter;
 
@@ -798,12 +798,12 @@ void LowerIntrinsicsPass::runOnOperation() {
   lowering.add<CirctHasBeenResetConverter>("circt.has_been_reset",
                                            "circt_has_been_reset");
   lowering.add<CirctProbeConverter>("circt.fpga_probe", "circt_fpga_probe");
-  lowering.add<CirctAssertAssumeConverter<AssertOp>>(
-      "circt.chisel_assert_assume", "circt_chisel_assert_assume");
-  lowering.add<CirctAssertAssumeConverter<AssertOp, /*ifElseFatal=*/true>>(
+  lowering.add<CirctAssertConverter<AssertOp>>("circt.chisel_assert",
+                                               "circt_chisel_assert");
+  lowering.add<CirctAssertConverter<AssertOp, /*ifElseFatal=*/true>>(
       "circt.chisel_ifelsefatal", "circt_chisel_ifelsefatal");
-  lowering.add<CirctAssertAssumeConverter<AssumeOp>>("circt.chisel_assume",
-                                                     "circt_chisel_assume");
+  lowering.add<CirctAssertConverter<AssumeOp>>("circt.chisel_assume",
+                                               "circt_chisel_assume");
   lowering.add<CirctCoverConverter>("circt.chisel_cover", "circt_chisel_cover");
   lowering.add<CirctUnclockedAssumeConverter>("circt.unclocked_assume",
                                               "circt_unclocked_assume");

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -206,15 +206,15 @@ firrtl.circuit "Foo" {
   // CHECK-NOT: VerifAssume
   // CHECK-NOT: VerifCover
 // TODO:
-  firrtl.intmodule private @AssertAssume<format: none = "testing">(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>) attributes {intrinsic = "circt.chisel_assert_assume"}
-  firrtl.intmodule private @AssertAssumeFormat<format: none = "message: %d",
+  firrtl.intmodule private @Assert<format: none = "testing">(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>) attributes {intrinsic = "circt.chisel_assert"}
+  firrtl.intmodule private @AssertFormat<format: none = "message: %d",
                                                label: none = "label for assert with format string",
                                                guards: none = "MACRO_GUARD;ASDF">(
                                                  in clock: !firrtl.clock,
                                                  in predicate: !firrtl.uint<1>,
                                                  in enable: !firrtl.uint<1>,
                                                  in val: !firrtl.uint<1>
-                                               ) attributes {intrinsic = "circt.chisel_assert_assume"}
+                                               ) attributes {intrinsic = "circt.chisel_assert"}
   firrtl.intmodule private @IfElseFatalFormat<format: none = "ief: %d",
                                               label: none = "label for ifelsefatal assert",
                                               guards: none = "MACRO_GUARD;ASDF">(
@@ -242,8 +242,8 @@ firrtl.circuit "Foo" {
                                          in enable: !firrtl.uint<1>,
                                          in val: !firrtl.uint<1>
                                        ) attributes {intrinsic = "circt.unclocked_assume"}
-  // CHECK-NOT: @AssertAssume
-  // CHECK-NOT: @AssertAssumeFormat
+  // CHECK-NOT: @Assert
+  // CHECK-NOT: @AssertFormat
   // CHECK-NOT: @IfElseFatalFormat
   // CHECK-NOT: @Assume
   // CHECK-NOT: @CoverLabel
@@ -256,7 +256,7 @@ firrtl.circuit "Foo" {
     // CHECK-NOT: firrtl.instance
     // CHECK: firrtl.assert %{{.+}}, %{{.+}}, %{{.+}}, "testing" :
     // CHECK-SAME: isConcurrent = true
-    %assert_clock, %assert_predicate, %assert_enable = firrtl.instance assert interesting_name @AssertAssume(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>)
+    %assert_clock, %assert_predicate, %assert_enable = firrtl.instance assert interesting_name @Assert(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>)
     firrtl.strictconnect %assert_clock, %clock : !firrtl.clock
     firrtl.strictconnect %assert_predicate, %cond : !firrtl.uint<1>
     firrtl.strictconnect %assert_enable, %enable : !firrtl.uint<1>
@@ -265,7 +265,7 @@ firrtl.circuit "Foo" {
     // CHECK-SAME: guards = ["MACRO_GUARD", "ASDF"]
     // CHECK-SAME: isConcurrent = true
     // CHECK-SAME: name = "label for assert with format string"
-    %assertFormat_clock, %assertFormat_predicate, %assertFormat_enable, %assertFormat_val = firrtl.instance assertFormat interesting_name @AssertAssumeFormat(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
+    %assertFormat_clock, %assertFormat_predicate, %assertFormat_enable, %assertFormat_val = firrtl.instance assertFormat interesting_name @AssertFormat(in clock: !firrtl.clock, in predicate: !firrtl.uint<1>, in enable: !firrtl.uint<1>, in val: !firrtl.uint<1>)
     firrtl.strictconnect %assertFormat_clock, %clock : !firrtl.clock
     firrtl.strictconnect %assertFormat_predicate, %cond : !firrtl.uint<1>
     firrtl.strictconnect %assertFormat_enable, %enable : !firrtl.uint<1>

--- a/test/firtool/chisel_assert.fir
+++ b/test/firtool/chisel_assert.fir
@@ -3,18 +3,18 @@
 FIRRTL version 4.0.0
 
 circuit ChiselVerif:
-  intmodule AssertAssume:
+  intmodule Assert:
     input clock: Clock
     input predicate: UInt<1>
     input enable: UInt<1>
-    intrinsic = circt_chisel_assert_assume
+    intrinsic = circt_chisel_assert
 
-  intmodule AssertAssumeFormat:
+  intmodule AssertFormat:
     input clock: Clock
     input predicate: UInt<1>
     input enable: UInt<1>
     input val: UInt<1>
-    intrinsic = circt_chisel_assert_assume
+    intrinsic = circt_chisel_assert
     parameter format = "message: %d"
     parameter label = "label for assert with format string"
     parameter guards = "MACRO_GUARD;ASDF"
@@ -54,7 +54,7 @@ circuit ChiselVerif:
     ; CHECK:  wire [[GEN:.+]] = ~enable | cond;
     ; CHECK: assert property
     ; CHECK-NOT: $error
-    inst assert of AssertAssume
+    inst assert of Assert
     connect assert.clock, clock
     connect assert.predicate, cond
     connect assert.enable, enable
@@ -65,7 +65,7 @@ circuit ChiselVerif:
     ; CHECK: assert property
     ; CHECK: "message: %d"
     ; CHECK: $sampled(cond)
-    inst assertFormat of AssertAssumeFormat
+    inst assertFormat of AssertFormat
     connect assertFormat.clock, clock
     connect assertFormat.predicate, cond
     connect assertFormat.enable, enable


### PR DESCRIPTION
As we moved companion assume generation to a pass, having `AssertAssume` would not be necessary anymore. We still need assert instrinsic so this PR just renames the intrinsic to `assert`