### PR TITLE
[SeqToSV] Prepend RANDOMIZE-defining snippets

### DIFF
--- a/lib/Conversion/SeqToSV/SeqToSV.cpp
+++ b/lib/Conversion/SeqToSV/SeqToSV.cpp
@@ -413,9 +413,9 @@ void SeqToSVPass::runOnOperation() {
       FlatSymbolRefAttr::get(context, "RANDOM_INIT_MEM_FRAGMENT");
 
   auto regFragments = ArrayAttr::get(
-      context, {randomInitFragmentName, randomInitRegFragmentName});
+      context, {randomInitRegFragmentName, randomInitFragmentName});
   auto memFragments = ArrayAttr::get(
-      context, {randomInitFragmentName, randomInitMemFragmentName});
+      context, {randomInitMemFragmentName, randomInitFragmentName});
 
   auto addFragments = [&](HWModuleOp module, ArrayAttr fragments) {
     ArrayAttr newFragments;

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -55,7 +55,7 @@ emit.fragment @SomeFragment {}
 
 // RANDOM-LABEL: hw.module @fragment_ref
 
-// RANDOM-SAME:   emit.fragments = [@SomeFragment, @RANDOM_INIT_FRAGMENT, @RANDOM_INIT_REG_FRAGMENT]
+// RANDOM-SAME:   emit.fragments = [@SomeFragment, @RANDOM_INIT_REG_FRAGMENT, @RANDOM_INIT_FRAGMENT]
 hw.module @fragment_ref(in %clk : !seq.clock) attributes {emit.fragments = [@SomeFragment]} {
   %cst0_i32 = hw.constant 0 : i32
   %rA = seq.firreg %cst0_i32 clock %clk sym @regA : i32


### PR DESCRIPTION
Fix an issue where the RANDOMIZE Verilog macro was used before it was
defined.