### PR TITLE
[LowerToHW] Emission Option for verification flavors

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -60,6 +60,14 @@ typedef enum CirctFirtoolRandomKind {
   CIRCT_FIRTOOL_RANDOM_KIND_ALL,
 } CirctFirtoolRandomKind;
 
+// NOLINTNEXTLINE(modernize-use-using)
+typedef enum CirctFirtoolVerificationFlavor {
+  CIRCT_FIRTOOL_VERIFICATION_FLAVOR_NONE,
+  CIRCT_FIRTOOL_VERIFICATION_FLAVOR_IF_ELSE_FATAL,
+  CIRCT_FIRTOOL_VERIFICATION_FLAVOR_IMMEDIATE,
+  CIRCT_FIRTOOL_VERIFICATION_FLAVOR_SVA,
+} CirctFirtoolVerificationFlavor;
+
 MLIR_CAPI_EXPORTED CirctFirtoolFirtoolOptions
 circtFirtoolOptionsCreateDefault(void);
 MLIR_CAPI_EXPORTED void
@@ -166,8 +174,8 @@ circtFirtoolOptionsSetAddMuxPragmas(CirctFirtoolFirtoolOptions options,
                                     bool value);
 
 MLIR_CAPI_EXPORTED void
-circtFirtoolOptionsSetverificationFlavor(CirctFirtoolFirtoolOptions options,
-                                         bool value);
+circtFirtoolOptionsSetVerificationFlavor(CirctFirtoolFirtoolOptions options,
+                                         CirctFirtoolVerificationFlavor value);
 
 MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetEmitSeparateAlwaysBlocks(
     CirctFirtoolFirtoolOptions options, bool value);

--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -166,8 +166,8 @@ circtFirtoolOptionsSetAddMuxPragmas(CirctFirtoolFirtoolOptions options,
                                     bool value);
 
 MLIR_CAPI_EXPORTED void
-circtFirtoolOptionsSetEmitChiselAssertsAsSVA(CirctFirtoolFirtoolOptions options,
-                                             bool value);
+circtFirtoolOptionsSetverificationFlavor(CirctFirtoolFirtoolOptions options,
+                                         bool value);
 
 MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetEmitSeparateAlwaysBlocks(
     CirctFirtoolFirtoolOptions options, bool value);

--- a/include/circt/Conversion/FIRRTLToHW.h
+++ b/include/circt/Conversion/FIRRTLToHW.h
@@ -22,10 +22,24 @@ class Pass;
 } // namespace mlir
 
 namespace circt {
+namespace firrtl {
+enum class VerificationFlavor {
+  // Use the flavor specified by the op.
+  // TOOD: Drop this option once the migration finished.
+  None,
+  // Use `if(cond) else $fatal(..)` format.
+  IfElseFatal,
+  // Use immediate form.
+  Immediate,
+  // Use SVA.
+  SVA
+};
+}
 
 std::unique_ptr<mlir::Pass>
 createLowerFIRRTLToHWPass(bool enableAnnotationWarning = false,
-                          bool emitChiselAssertsAsSVA = false);
+                          firrtl::VerificationFlavor assertionFlavor =
+                              firrtl::VerificationFlavor::None);
 
 } // namespace circt
 

--- a/include/circt/Conversion/FIRRTLToHW.h
+++ b/include/circt/Conversion/FIRRTLToHW.h
@@ -34,7 +34,7 @@ enum class VerificationFlavor {
   // Use SVA.
   SVA
 };
-}
+} // namespace firrtl
 
 std::unique_ptr<mlir::Pass>
 createLowerFIRRTLToHWPass(bool enableAnnotationWarning = false,

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -438,8 +438,20 @@ def LowerFIRRTLToHW : Pass<"lower-firrtl-to-hw", "mlir::ModuleOp"> {
     Option<"enableAnnotationWarning", "warn-on-unprocessed-annotations",
            "bool", "false",
     "Emit warnings on unprocessed annotations during lower-to-hw pass">,
-    Option<"emitChiselAssertsAsSVA", "emit-chisel-asserts-as-sva",
-           "bool", "false","Convert all Chisel asserts to SVA">
+    Option<"verificationFlavor", "verification-flavor",
+           "circt::firrtl::VerificationFlavor", 
+           "circt::firrtl::VerificationFlavor::None", 
+           "Specify a verification flavor used in the lowering", 
+           [{::llvm::cl::values(
+            clEnumValN(circt::firrtl::VerificationFlavor::None, 
+              "none", "Use the flavor specified by the op"),
+            clEnumValN(circt::firrtl::VerificationFlavor::IfElseFatal,
+              "if-else-fatal", "Use Use `if(cond) else $fatal(..)` format"),
+            clEnumValN(circt::firrtl::VerificationFlavor::Immediate, 
+              "immediate", "Use immediate verif statements"),
+            clEnumValN(circt::firrtl::VerificationFlavor::SVA, "sva", "Use SVA")
+          )}]
+           >
   ];
 }
 

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_FIRTOOL_FIRTOOL_H
 #define CIRCT_FIRTOOL_FIRTOOL_H
 
+#include "circt/Conversion/Passes.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/Support/LLVM.h"
@@ -119,7 +120,7 @@ public:
     return disableAggressiveMergeConnections;
   }
   bool shouldEnableAnnotationWarning() const { return enableAnnotationWarning; }
-  bool shouldEmitChiselAssertsAsSVA() const { return emitChiselAssertsAsSVA; }
+  auto getVerificationFlavor() const { return verificationFlavor; }
   bool shouldEmitSeparateAlwaysBlocks() const {
     return emitSeparateAlwaysBlocks;
   }
@@ -274,8 +275,8 @@ public:
     return *this;
   }
 
-  FirtoolOptions &setEmitChiselAssertsAsSVA(bool value) {
-    emitChiselAssertsAsSVA = value;
+  FirtoolOptions &setVerificationFlavor(firrtl::VerificationFlavor value) {
+    verificationFlavor = value;
     return *this;
   }
 
@@ -384,7 +385,7 @@ private:
   std::string outputAnnotationFilename;
   bool enableAnnotationWarning;
   bool addMuxPragmas;
-  bool emitChiselAssertsAsSVA;
+  firrtl::VerificationFlavor verificationFlavor;
   bool emitSeparateAlwaysBlocks;
   bool etcDisableInstanceExtraction;
   bool etcDisableRegisterExtraction;

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -253,7 +253,7 @@ void circtFirtoolOptionsSetAddMuxPragmas(CirctFirtoolFirtoolOptions options,
   unwrap(options)->setAddMuxPragmas(value);
 }
 
-void circtFirtoolOptionsSetverificationFlavor(
+void circtFirtoolOptionsSetVerificationFlavor(
     CirctFirtoolFirtoolOptions options, firrtl::VerificationFlavor value) {
   unwrap(options)->setVerificationFlavor(value);
 }

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -253,9 +253,9 @@ void circtFirtoolOptionsSetAddMuxPragmas(CirctFirtoolFirtoolOptions options,
   unwrap(options)->setAddMuxPragmas(value);
 }
 
-void circtFirtoolOptionsSetEmitChiselAssertsAsSVA(
-    CirctFirtoolFirtoolOptions options, bool value) {
-  unwrap(options)->setEmitChiselAssertsAsSVA(value);
+void circtFirtoolOptionsSetverificationFlavor(
+    CirctFirtoolFirtoolOptions options, firrtl::VerificationFlavor value) {
+  unwrap(options)->setVerificationFlavor(value);
 }
 
 void circtFirtoolOptionsSetEmitSeparateAlwaysBlocks(

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -10,6 +10,7 @@
 #ifndef CONVERSION_PASSDETAIL_H
 #define CONVERSION_PASSDETAIL_H
 
+#include "circt/Conversion/FIRRTLToHW.h"
 #include "circt/Support/LoweringOptions.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/DialectRegistry.h"

--- a/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
+++ b/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
@@ -1,4 +1,7 @@
-// RUN: circt-opt -lower-firrtl-to-hw=emit-chisel-asserts-as-sva %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(lower-firrtl-to-hw{verification-flavor=sva})' %s | FileCheck %s --check-prefixes=CHECK,SVA
+// RUN: circt-opt --pass-pipeline='builtin.module(lower-firrtl-to-hw{verification-flavor=if-else-fatal})' %s | FileCheck %s --check-prefixes=CHECK,IF_ELSE_FATAL
+// RUN: circt-opt --pass-pipeline='builtin.module(lower-firrtl-to-hw{verification-flavor=immediate})' %s | FileCheck %s --check-prefixes=CHECK,IMMEDIATE
+
 
 firrtl.circuit "ifElseFatalToSVA" {
   // CHECK-LABEL: hw.module @ifElseFatalToSVA
@@ -10,20 +13,26 @@ firrtl.circuit "ifElseFatalToSVA" {
     firrtl.assert %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, format = "ifElseFatal"}
     firrtl.assume %clock, %cond, %enable, "assert0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, guards = ["USE_PROPERTY_AS_CONSTRAINT"]}
     // CHECK-NEXT: [[CLK:%.+]] = seq.from_clock %clock
-    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
-    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor bin %enable, [[TRUE]]
-    // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
-    // CHECK-NEXT: sv.assert.concurrent posedge [[CLK]], [[TMP2]] message "assert0"
-    // CHECK-NEXT: sv.ifdef @USE_PROPERTY_AS_CONSTRAINT {
-    // CHECK-NEXT: [[TRUE:%.+]] = hw.constant true
-    // CHECK-NEXT: [[TMP1:%.+]] = comb.xor bin %enable, [[TRUE]]
-    // CHECK-NEXT: [[TMP2:%.+]] = comb.or bin [[TMP1]], %cond
-    // CHECK-NEXT:   sv.assume.concurrent posedge [[CLK]], [[TMP2]]
-    // CHECK-NEXT: }
+    // SVA: sv.assert.concurrent posedge [[CLK]], {{%.+}} message "assert0"
+
+    // IF_ELSE_FATAL:       sv.always posedge [[CLK]] {
+    // IF_ELSE_FATAL-NEXT:    sv.if {{%.+}} {
+    // IF_ELSE_FATAL-NEXT:      %ASSERT_VERBOSE_COND_ = sv.macro.ref @ASSERT_VERBOSE_COND_()
+    // IF_ELSE_FATAL-NEXT:      sv.if %ASSERT_VERBOSE_COND_ {
+    // IF_ELSE_FATAL-NEXT:        sv.error "assert0"
+    // IF_ELSE_FATAL-NEXT:      }
+
+    // IMMEDIATE:      sv.always posedge [[CLK]] {
+    // IMMEDIATE-NEXT:   sv.if %enable {
+    // IMMEDIATE-NEXT:    sv.assert %cond, immediate message "assert0"
+
+    // CHECK: sv.ifdef @USE_PROPERTY_AS_CONSTRAINT {
+    // SVA:           sv.assume.concurrent posedge [[CLK]], {{%.+}}
+    // IF_ELSE_FATAL: sv.assume.concurrent posedge [[CLK]], {{%.+}}
+    // IMMEDIATE:     sv.assume {{%.+}}
   }
 
-  // Test that an immediate assertion is always converted to a concurrent
-  // assertion if the "emit-chisel-asserts-as-sva" option is enabled.
+  // Test that an immediate assertion is converted to an assertion with a specified flavor.
   //
   // CHECK-LABEL: hw.module @immediateToConcurrent
   firrtl.module @immediateToConcurrent(
@@ -32,6 +41,8 @@ firrtl.circuit "ifElseFatalToSVA" {
     in %enable: !firrtl.uint<1>
   ) {
     firrtl.assert %clock, %cond, %enable, "assert1" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
-    // CHECK: sv.assert.concurrent
+    // SVA: sv.assert.concurrent
+    // IF_ELSE_FATAL: sv.if
+    // IMMEDIATE: sv.assert
   }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -218,3 +218,13 @@ firrtl.circuit "InputSelfDriver" {
     firrtl.connect %ip2_in, %ip2_in : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
+
+// -----
+
+firrtl.circuit "IfElseFatalOnAssume" {
+  firrtl.module @IfElseFatalOnAssume (in %clock: !firrtl.clock, in %pred: !firrtl.uint<1>, in %en: !firrtl.uint<1>) {
+    // expected-error @+2 {{ifElseFatal format cannot be used for non-assertions}}
+    // expected-error @below {{'firrtl.assume' op LowerToHW couldn't handle this operation}}
+    firrtl.assume %clock, %en, %pred, "foo" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {isConcurrent = true, format = "ifElseFatal"}
+  }
+}

--- a/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
@@ -1,5 +1,5 @@
 ; RUN: firtool --verify-diagnostics --verilog %s --lowering-options=emittedLineLength=200 --add-companion-assume | FileCheck %s
-; RUN: firtool --verify-diagnostics --verilog --emit-chisel-asserts-as-sva %s --lowering-options=emittedLineLength=200 --add-companion-assume | FileCheck %s --check-prefix=SVA
+; RUN: firtool --verify-diagnostics --verilog --verification-flavor=sva %s --lowering-options=emittedLineLength=200 --add-companion-assume | FileCheck %s --check-prefix=SVA
 ; Tests extracted from:
 ; - test/scala/firrtl/extractverif/ExtractAssertsSpec.scala
 


### PR DESCRIPTION
This commits replaces `--emit-chisel-asserts-as-sva` with an option with more fine grained control.
Specifically an option `--verification-flavor={none, if-else-fatal, immediate, sva}` is added. `none` is the option for the current behaviour that uses per-op configuration (which must be deprecated once after `has_been_reset` is properly used for assertions that are expected to be disabled while pre-resets). 

Close https://github.com/llvm/circt/issues/6543