### PR TITLE
[NFC] Massive Export Verilog Speedup

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -230,8 +230,8 @@ static StringRef getInputPortVerilogName(Operation *module, size_t portArgNum) {
   auto hml = cast<HWModuleLike>(module);
   auto pId = hml.getHWModuleType().getPortIdForInputId(portArgNum);
   if (auto attrs = dyn_cast_or_null<DictionaryAttr>(hml.getPortAttrs(pId)))
-    if (auto updatedName = attrs.get("hw.verilogName"))
-      return updatedName.cast<StringAttr>().getValue();
+    if (auto updatedName = attrs.getAs<StringAttr>("hw.verilogName"))
+      return updatedName.getValue();
   return hml.getHWModuleType().getPortName(pId);
 }
 

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -228,8 +228,11 @@ static StringRef getPortVerilogName(Operation *module, size_t portArgNum) {
 /// Return the verilog name of the port for the module.
 static StringRef getInputPortVerilogName(Operation *module, size_t portArgNum) {
   auto hml = cast<HWModuleLike>(module);
-  return hml.getPort(hml.getHWModuleType().getPortIdForInputId(portArgNum))
-      .getVerilogName();
+  auto pId = hml.getHWModuleType().getPortIdForInputId(portArgNum);
+  if (auto attrs = dyn_cast_or_null<DictionaryAttr>(hml.getPortAttrs(pId)))
+    if (auto updatedName = attrs.get("hw.verilogName"))
+      return updatedName.cast<StringAttr>().getValue();
+  return hml.getHWModuleType().getPortName(pId);
 }
 
 /// This predicate returns true if the specified operation is considered a


### PR DESCRIPTION
Getting all the ports to lookup one attribute is very expensive.  Mainly from GetAllPortLocs requiring several lookups and allocations.  Just avoid doing this by not using the summary functions and looking up individual ports directly (as should generally be done to avoid the overly broad expensive functions).  Granted that getPort goes through the summary functions isn't obvious or ideal.  It should be fixed.