### PR TITLE
[LowerToHW] Wrap signed operands of `PrintFOp` in sv `$signed()`

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1416,6 +1416,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   Value getLoweredNonClockValue(Value value);
   Value getLoweredAndExtendedValue(Value value, Type destType);
   Value getLoweredAndExtOrTruncValue(Value value, Type destType);
+  Value getLoweredFmtOperand(Value operand);
   LogicalResult setLowering(Value orig, Value result);
   LogicalResult setPossiblyFoldedLowering(Value orig, Value result);
   template <typename ResultOpType, typename... CtorArgTypes>
@@ -2294,6 +2295,28 @@ Value FIRRTLLowering::getLoweredAndExtOrTruncValue(Value value, Type destType) {
 
   auto zero = getOrCreateIntConstant(destWidth - srcWidth, 0);
   return builder.createOrFold<comb::ConcatOp>(zero, result);
+}
+
+/// Return a lowered version of 'operand' suitable for use with substitution /
+/// format strings. Zero bit operands are rewritten as one bit zeros and signed
+/// integers are wrapped in $signed().
+Value FIRRTLLowering::getLoweredFmtOperand(Value operand) {
+  auto loweredValue = getLoweredValue(operand);
+  if (!loweredValue) {
+    // If this is a zero bit operand, just pass a one bit zero.
+    if (!isZeroBitFIRRTLType(operand.getType()))
+      return nullptr;
+    loweredValue = getOrCreateIntConstant(1, 0);
+  }
+
+  // If the operand was an SInt, we want to give the user the option to print
+  // it as signed decimal and have to wrap it in $signed().
+  if (auto intTy = firrtl::type_cast<IntType>(operand.getType()))
+    if (intTy.isSigned())
+      loweredValue = builder.create<sv::SystemFunctionOp>(
+          loweredValue.getType(), "signed", loweredValue);
+
+  return loweredValue;
 }
 
 /// Set the lowered value of 'orig' to 'result', remembering this in a map.
@@ -4266,20 +4289,10 @@ LogicalResult FIRRTLLowering::visitStmt(PrintFOp op) {
   SmallVector<Value, 4> operands;
   operands.reserve(op.getSubstitutions().size());
   for (auto operand : op.getSubstitutions()) {
-    operands.push_back(getLoweredValue(operand));
-    if (!operands.back()) {
-      // If this is a zero bit operand, just pass a one bit zero.
-      if (!isZeroBitFIRRTLType(operand.getType()))
-        return failure();
-      operands.back() = getOrCreateIntConstant(1, 0);
-    }
-
-    // If the operand was an SInt, we want to give the user the option to print
-    // it as signed decimal and have to wrap it in $signed().
-    if (auto intTy = firrtl::type_cast<IntType>(operand.getType()))
-      if (intTy.isSigned())
-        operands.back() = builder.create<sv::SystemFunctionOp>(
-            operands.back().getType(), "signed", operands.back());
+    Value loweredValue = getLoweredFmtOperand(operand);
+    if (!loweredValue)
+      return failure();
+    operands.push_back(loweredValue);
   }
 
   // Emit an "#ifndef SYNTHESIS" guard into the always block.
@@ -4430,13 +4443,10 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
   if (!isCover && opMessageAttr && !opMessageAttr.getValue().empty()) {
     message = opMessageAttr;
     for (auto operand : opOperands) {
-      auto loweredValue = getLoweredValue(operand);
-      if (!loweredValue) {
-        // If this is a zero bit operand, just pass a one bit zero.
-        if (!isZeroBitFIRRTLType(operand.getType()))
-          return failure();
-        loweredValue = getOrCreateIntConstant(1, 0);
-      }
+      auto loweredValue = getLoweredFmtOperand(operand);
+      if (!loweredValue)
+        return failure();
+
       // For SVA assert/assume statements, wrap any message ops in $sampled() to
       // guarantee that these will print with the same value as when the
       // assertion triggers.  (See SystemVerilog 2017 spec section 16.9.3 for

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -4273,6 +4273,13 @@ LogicalResult FIRRTLLowering::visitStmt(PrintFOp op) {
         return failure();
       operands.back() = getOrCreateIntConstant(1, 0);
     }
+
+    // If the operand was an SInt, we want to give the user the option to print
+    // it as signed decimal and have to wrap it in $signed().
+    if (auto intTy = firrtl::type_cast<IntType>(operand.getType()))
+      if (intTy.isSigned())
+        operands.back() = builder.create<sv::SystemFunctionOp>(
+            operands.back().getType(), "signed", operands.back());
   }
 
   // Emit an "#ifndef SYNTHESIS" guard into the always block.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -610,8 +610,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:     }
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
-
-    
   }
 
   firrtl.module private @bar(in %io_cpu_flush: !firrtl.uint<1>) { }


### PR DESCRIPTION
When we have a firrtl printf operation with `SInt` operands, it gets lowered something like this:

```verilog
//FIRRTL version 3.3.0
//circuit Test :
// module Test :
//    input clock : Clock
//    input reset : UInt<1>
//    input a : SInt<8>
//    node int = SInt<8>(-0h10)
//
//    printf(clock, UInt<1>(0h1), "int : %d %d\n", int, add(a, int)) : printf_1

[...]
  input [7:0] a
[...]
$fwrite(32'h80000002, "int : %d %d\n", 8'hF0, {a[7], a} - 9'h10);
[...]
```

As far as verilog is concerned, the operands to `$fwrite` are unsigned, which means that we get inconvenient printing for negative decimals. This patch wraps signed operands of `firrtl.printf` in `$signed()` during lowering. This is realized as `sv.system "signed" ...` for now. In the next step, we could introduce a separate `sv.signed()` Op and insert this in places where we need this conversion.

With this patch, the above firrtl gets lowered like this:
```verilog
$fwrite(32'h80000002, "int : %d %d\n", $signed(8'hF0),
                $signed({a[7], a} - 9'h10));
```