### PR TITLE
[Pipeline] Remove `Pure` trait from Pipeline operations

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -25,7 +25,6 @@ include "circt/Dialect/Seq/SeqTypes.td"
 
 class PipelineBase<string mnemonic, list<Trait> traits = []> :
   Op<Pipeline_Dialect, mnemonic, !listconcat(traits, [
-      Pure,
       RegionKindInterface,
       AttrSizedOperandSegments,
       DeclareOpInterfaceMethods<OpAsmOpInterface, [

--- a/test/Dialect/Pipeline/canonicalization.mlir
+++ b/test/Dialect/Pipeline/canonicalization.mlir
@@ -1,0 +1,11 @@
+// RUN: circt-opt --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: hw.module @testNoDCE
+// CHECK:   %[[DONE:.*]] = pipeline.scheduled
+// CHECK:   hw.output
+// CHECK: }
+hw.module @testNoDCE(in %arg0: i1, in %clk: !seq.clock, in %rst: i1) {
+  %done = pipeline.scheduled(%a0 : i1 = %arg0) clock(%clk) reset(%rst) go(%arg0) entryEn(%s0_enable) -> () {
+    pipeline.return
+  }
+}


### PR DESCRIPTION
Pipelines may be side-effectful - remove `Pure` trait to prevent such pipelines from being DCE'd during canonicalization.