### PR TITLE
[FIRRTL] Expose clock dividers as a FIRRTL intrinsic

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -123,6 +123,22 @@ def ClockInverterIntrinsicOp : FIRRTLOp<"int.clock_inv", [Pure]> {
   let assemblyFormat = "$input attr-dict";
 }
 
+def ClockDividerIntrinsicOp : FIRRTLOp<"int.clock_div", [Pure]> {
+  let summary = "Produces a clock divided by a power of two";
+  let description = [{
+    The `firrtl.int.clock_div` takes a clock signal and divides it by a
+    power-of-two ratio. The output clock is phase-aligned to the input clock.
+
+    ```
+    %div_clock = seq.clock_div %clock by 1
+    ```
+  }];
+
+  let arguments = (ins NonConstClockType:$input, I8Attr:$pow2);
+  let results = (outs NonConstClockType:$output);
+  let assemblyFormat = "$input `by` $pow2 attr-dict";
+}
+
 //===----------------------------------------------------------------------===//
 // Verification Intrinsics
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -49,11 +49,12 @@ public:
             // Intrinsic Expressions.
             IsXIntrinsicOp, PlusArgsValueIntrinsicOp, PlusArgsTestIntrinsicOp,
             SizeOfIntrinsicOp, ClockGateIntrinsicOp, ClockInverterIntrinsicOp,
-            LTLAndIntrinsicOp, LTLOrIntrinsicOp, LTLDelayIntrinsicOp,
-            LTLConcatIntrinsicOp, LTLNotIntrinsicOp, LTLImplicationIntrinsicOp,
-            LTLEventuallyIntrinsicOp, LTLClockIntrinsicOp,
-            LTLDisableIntrinsicOp, Mux2CellIntrinsicOp, Mux4CellIntrinsicOp,
-            HasBeenResetIntrinsicOp, FPGAProbeIntrinsicOp, GenericIntrinsicOp,
+            ClockDividerIntrinsicOp, LTLAndIntrinsicOp, LTLOrIntrinsicOp,
+            LTLDelayIntrinsicOp, LTLConcatIntrinsicOp, LTLNotIntrinsicOp,
+            LTLImplicationIntrinsicOp, LTLEventuallyIntrinsicOp,
+            LTLClockIntrinsicOp, LTLDisableIntrinsicOp, Mux2CellIntrinsicOp,
+            Mux4CellIntrinsicOp, HasBeenResetIntrinsicOp, FPGAProbeIntrinsicOp,
+            GenericIntrinsicOp,
             // Miscellaneous.
             BitsPrimOp, HeadPrimOp, MuxPrimOp, PadPrimOp, ShlPrimOp, ShrPrimOp,
             TailPrimOp, VerbatimExprOp, HWStructCastOp, BitCastOp, RefSendOp,
@@ -167,6 +168,7 @@ public:
   HANDLE(SizeOfIntrinsicOp, Unhandled);
   HANDLE(ClockGateIntrinsicOp, Unhandled);
   HANDLE(ClockInverterIntrinsicOp, Unhandled);
+  HANDLE(ClockDividerIntrinsicOp, Unhandled);
   HANDLE(LTLAndIntrinsicOp, Unhandled);
   HANDLE(LTLOrIntrinsicOp, Unhandled);
   HANDLE(LTLDelayIntrinsicOp, Unhandled);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1606,6 +1606,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   LogicalResult visitExpr(PlusArgsValueIntrinsicOp op);
   LogicalResult visitExpr(FPGAProbeIntrinsicOp op);
   LogicalResult visitExpr(ClockInverterIntrinsicOp op);
+  LogicalResult visitExpr(ClockDividerIntrinsicOp op);
   LogicalResult visitExpr(SizeOfIntrinsicOp op);
   LogicalResult visitExpr(ClockGateIntrinsicOp op);
   LogicalResult visitExpr(LTLAndIntrinsicOp op);
@@ -3667,6 +3668,11 @@ LogicalResult FIRRTLLowering::visitExpr(ClockGateIntrinsicOp op) {
 LogicalResult FIRRTLLowering::visitExpr(ClockInverterIntrinsicOp op) {
   auto operand = getLoweredValue(op.getInput());
   return setLoweringTo<seq::ClockInverterOp>(op, operand);
+}
+
+LogicalResult FIRRTLLowering::visitExpr(ClockDividerIntrinsicOp op) {
+  auto operand = getLoweredValue(op.getInput());
+  return setLoweringTo<seq::ClockDividerOp>(op, operand, op.getPow2());
 }
 
 LogicalResult FIRRTLLowering::visitExpr(LTLAndIntrinsicOp op) {

--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -162,13 +162,18 @@ firrtl.circuit "Intrinsics" {
     firrtl.int.fpga_probe %clock, %in : !firrtl.uint<8>
   }
 
-  // CHECK-LABEL: hw.module @ClockInverter
-  firrtl.module @ClockInverter(
+  // CHECK-LABEL: hw.module @ClockOps
+  firrtl.module @ClockOps(
     in %clock_in: !firrtl.clock,
-    out %clock_out: !firrtl.clock
+    out %clock_inv: !firrtl.clock,
+    out %clock_div: !firrtl.clock
   ) {
     // CHECK: seq.clock_inv %clock_in
-    %0 = firrtl.int.clock_inv %clock_in
-    firrtl.strictconnect %clock_out, %0 : !firrtl.clock
+    %clock_inv_out = firrtl.int.clock_inv %clock_in
+    firrtl.strictconnect %clock_inv, %clock_inv_out : !firrtl.clock
+
+    // CHECK: seq.clock_div %clock_in
+    %clock_div_out = firrtl.int.clock_div %clock_in by 4
+    firrtl.strictconnect %clock_div, %clock_div_out : !firrtl.clock
   }
 }

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -65,6 +65,17 @@ firrtl.circuit "Foo" {
     firrtl.strictconnect %in2, %clk : !firrtl.clock
   }
 
+  // CHECK-NOT: ClockDivider1
+  firrtl.intmodule @ClockDivider1<POW_2: i8 = 8>(in in: !firrtl.clock, out out: !firrtl.clock) attributes {intrinsic = "circt.clock_div"}
+
+  // CHECK: ClockDivider
+  firrtl.module @ClockDivider(in %clk: !firrtl.clock) {
+    // CHECK-NOT: ClockDivider1
+    // CHECK: firrtl.int.clock_div
+    %in2, %out2 = firrtl.instance "" @ClockDivider1(in in: !firrtl.clock, out out: !firrtl.clock)
+    firrtl.strictconnect %in2, %clk : !firrtl.clock
+  }
+
   // CHECK-NOT: LTLAnd
   // CHECK-NOT: LTLOr
   // CHECK-NOT: LTLDelay1


### PR DESCRIPTION
This PR adds an intrinsic to expose `seq.clock_div` to FIRRTL.