### PR TITLE
[FIRRTL] Split intrinsic op into expr vs stmt.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -20,7 +20,7 @@ include "FIRRTLDialect.td"
 //===----------------------------------------------------------------------===//
 
 def GenericIntrinsicExprOp : FIRRTLOp<"int.generic.expr",
-    [HasCustomSSAName]> {
+    [HasCustomSSAName, Pure]> {
   let summary = "Generic intrinsic operation for FIRRTL intrinsic expressions";
 
   let arguments = (

--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -16,12 +16,12 @@
 include "FIRRTLDialect.td"
 
 //===----------------------------------------------------------------------===//
-// Generic intrinsic operation for parsing into before lowering.
+// Generic intrinsic operations for parsing into before lowering.
 //===----------------------------------------------------------------------===//
 
-def GenericIntrinsicOp : FIRRTLOp<"int.generic",
+def GenericIntrinsicExprOp : FIRRTLOp<"int.generic.expr",
     [HasCustomSSAName]> {
-  let summary = "Generic intrinsic operation for FIRRTL intrinsics.";
+  let summary = "Generic intrinsic operation for FIRRTL intrinsic expressions";
 
   let arguments = (
     ins StrAttr:$intrinsic,
@@ -29,8 +29,20 @@ def GenericIntrinsicOp : FIRRTLOp<"int.generic",
     DefaultValuedAttr<ParamDeclArrayAttr, "{}">:$parameters
   );
 
-  let results = (outs Optional<PassiveType>:$result);
+  let results = (outs PassiveType:$result);
   let assemblyFormat = "$intrinsic custom<ParameterList>($parameters) ($operands^)? attr-dict-with-keyword `:` functional-type($operands, $result)";
+}
+
+def GenericIntrinsicStmtOp : FIRRTLOp<"int.generic.stmt"> {
+  let summary = "Generic intrinsic operation for FIRRTL intrinsic statements";
+
+  let arguments = (
+    ins StrAttr:$intrinsic,
+    Variadic<PassiveType>:$operands,
+    DefaultValuedAttr<ParamDeclArrayAttr, "{}">:$parameters
+  );
+
+  let assemblyFormat = "$intrinsic custom<ParameterList>($parameters) ($operands^)? attr-dict-with-keyword (`:` type($operands)^)?";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -53,7 +53,8 @@ public:
             LTLConcatIntrinsicOp, LTLNotIntrinsicOp, LTLImplicationIntrinsicOp,
             LTLEventuallyIntrinsicOp, LTLClockIntrinsicOp,
             LTLDisableIntrinsicOp, Mux2CellIntrinsicOp, Mux4CellIntrinsicOp,
-            HasBeenResetIntrinsicOp, FPGAProbeIntrinsicOp, GenericIntrinsicOp,
+            HasBeenResetIntrinsicOp, FPGAProbeIntrinsicOp,
+            GenericIntrinsicExprOp,
             // Miscellaneous.
             BitsPrimOp, HeadPrimOp, MuxPrimOp, PadPrimOp, ShlPrimOp, ShrPrimOp,
             TailPrimOp, VerbatimExprOp, HWStructCastOp, BitCastOp, RefSendOp,
@@ -180,7 +181,7 @@ public:
   HANDLE(Mux2CellIntrinsicOp, Unhandled);
   HANDLE(HasBeenResetIntrinsicOp, Unhandled);
   HANDLE(FPGAProbeIntrinsicOp, Unhandled);
-  HANDLE(GenericIntrinsicOp, Unhandled);
+  HANDLE(GenericIntrinsicExprOp, Unhandled);
 
   // Miscellaneous.
   HANDLE(BitsPrimOp, Unhandled);
@@ -226,12 +227,13 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<
-            AttachOp, ConnectOp, StrictConnectOp, RefDefineOp, ForceOp,
-            PrintFOp, SkipOp, StopOp, WhenOp, AssertOp, AssumeOp, CoverOp,
-            PropAssignOp, RefForceOp, RefForceInitialOp, RefReleaseOp,
-            RefReleaseInitialOp, VerifAssertIntrinsicOp, VerifAssumeIntrinsicOp,
-            UnclockedAssumeIntrinsicOp, VerifCoverIntrinsicOp, LayerBlockOp>(
+        .template Case<AttachOp, ConnectOp, StrictConnectOp, RefDefineOp,
+                       ForceOp, PrintFOp, SkipOp, StopOp, WhenOp, AssertOp,
+                       AssumeOp, CoverOp, PropAssignOp, RefForceOp,
+                       RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp,
+                       VerifAssertIntrinsicOp, VerifAssumeIntrinsicOp,
+                       UnclockedAssumeIntrinsicOp, VerifCoverIntrinsicOp,
+                       LayerBlockOp, GenericIntrinsicStmtOp>(
             [&](auto opNode) -> ResultType {
               return thisCast->visitStmt(opNode, args...);
             })
@@ -279,6 +281,7 @@ public:
   HANDLE(VerifCoverIntrinsicOp);
   HANDLE(UnclockedAssumeIntrinsicOp);
   HANDLE(LayerBlockOp);
+  HANDLE(GenericIntrinsicStmtOp);
 
 #undef HANDLE
 };

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -5765,7 +5765,7 @@ void GEQPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 void GTPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
-void GenericIntrinsicOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+void GenericIntrinsicExprOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   genericAsmResultNames(*this, setNameFn);
 }
 void HeadPrimOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
@@ -100,15 +100,14 @@ void LowerIntmodulesPass::runOnOperation() {
 
       // Create the replacement operation.
       if (outputs.empty()) {
-        // If no outputs, just create the operation.
-        builder.create<GenericIntrinsicOp>(/*result=*/Type(),
-                                           op.getIntrinsicAttr(), inputs,
-                                           op.getParameters());
+        // If no outputs, convert to generic intrinsic statement.
+        builder.create<GenericIntrinsicStmtOp>(op.getIntrinsicAttr(), inputs,
+                                               op.getParameters());
 
       } else if (outputs.size() == 1) {
         // For single output, the result is the output.
         auto resultType = outputs.front().element.type;
-        auto intop = builder.create<GenericIntrinsicOp>(
+        auto intop = builder.create<GenericIntrinsicExprOp>(
             resultType, op.getIntrinsicAttr(), inputs, op.getParameters());
         outputs.front().result.replaceAllUsesWith(intop.getResult());
       } else {
@@ -116,7 +115,7 @@ void LowerIntmodulesPass::runOnOperation() {
         // and replace users with subfields.
         auto resultType = builder.getType<BundleType>(llvm::map_to_vector(
             outputs, [](const auto &info) { return info.element; }));
-        auto intop = builder.create<GenericIntrinsicOp>(
+        auto intop = builder.create<GenericIntrinsicExprOp>(
             resultType, op.getIntrinsicAttr(), inputs, op.getParameters());
         for (auto &output : outputs)
           output.result.replaceAllUsesWith(builder.create<SubfieldOp>(
@@ -157,7 +156,7 @@ void LowerIntmodulesPass::runOnOperation() {
         };
 
         auto inputs = replaceResults(builder, inst.getResults().drop_back());
-        auto intop = builder.create<GenericIntrinsicOp>(
+        auto intop = builder.create<GenericIntrinsicExprOp>(
             builder.getType<ClockType>(), "circt_clock_gate", inputs,
             op.getParameters());
         inst.getResults().back().replaceAllUsesWith(intop.getResult());

--- a/test/Dialect/FIRRTL/lower-intmodules-eicg.mlir
+++ b/test/Dialect/FIRRTL/lower-intmodules-eicg.mlir
@@ -11,7 +11,7 @@ firrtl.circuit "FixupEICGWrapper" {
   firrtl.module @FixupEICGWrapper(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>) {
     // CHECK-NOEICG: firrtl.instance
     // CHECK-EICG-NOT: firrtl.instance
-    // CHECK-EICG: firrtl.int.generic "circt_clock_gate"
+    // CHECK-EICG: firrtl.int.generic.expr "circt_clock_gate"
     %ckg_in, %ckg_test_en, %ckg_en, %ckg_out = firrtl.instance ckg @LegacyClockGate(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
     firrtl.strictconnect %ckg_in, %clock : !firrtl.clock
     firrtl.strictconnect %ckg_test_en, %en : !firrtl.uint<1>
@@ -31,7 +31,7 @@ firrtl.circuit "FixupEICGWrapper2" {
   firrtl.module @FixupEICGWrapper2(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>) {
     // CHECK-NOEICG: firrtl.instance
     // CHECK-EICG-NOT: firrtl.instance
-    // CHECK-EICG: firrtl.int.generic "circt_clock_gate"
+    // CHECK-EICG: firrtl.int.generic.expr "circt_clock_gate"
     %ckg_in, %ckg_en, %ckg_out = firrtl.instance ckg @LegacyClockGateNoTestEn(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
     firrtl.strictconnect %ckg_in, %clock : !firrtl.clock
     firrtl.strictconnect %ckg_en, %en : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/lower-intmodules.mlir
+++ b/test/Dialect/FIRRTL/lower-intmodules.mlir
@@ -19,24 +19,24 @@ firrtl.circuit "BasicIntmoduleInstances" {
   firrtl.module @BasicIntmoduleInstances(in %clk : !firrtl.clock, out %s : !firrtl.uint<32>, out %io1 : !firrtl.uint<1>, out %io2 : !firrtl.uint<1>, out %io3 : !firrtl.uint<1>, out %io4 : !firrtl.uint<5>) {
     %i1, %size = firrtl.instance "" @NameDoesNotMatter5(in i : !firrtl.clock, out size : !firrtl.uint<32>)
     // CHECK-NOT: NameDoesNotMatter5
-    // CHECK: firrtl.int.generic "circt.sizeof"
+    // CHECK: firrtl.int.generic.expr "circt.sizeof"
     firrtl.strictconnect %i1, %clk : !firrtl.clock
     firrtl.strictconnect %s, %size : !firrtl.uint<32>
 
     %i2, %found2 = firrtl.instance "" @NameDoesNotMatter6(in i : !firrtl.clock, out found : !firrtl.uint<1>)
     // CHECK-NOT: NameDoesNotMatter6
-    // CHECK: firrtl.int.generic "circt.isX"
+    // CHECK: firrtl.int.generic.expr "circt.isX"
     firrtl.strictconnect %i2, %clk : !firrtl.clock
     firrtl.strictconnect %io1, %found2 : !firrtl.uint<1>
 
     %found3 = firrtl.instance "" @NameDoesNotMatter7(out found : !firrtl.uint<1>)
     // CHECK-NOT: NameDoesNotMatter7
-    // CHECK: firrtl.int.generic "circt.plusargs.test"
+    // CHECK: firrtl.int.generic.expr "circt.plusargs.test"
     firrtl.strictconnect %io2, %found3 : !firrtl.uint<1>
 
     %found4, %result1 = firrtl.instance "" @NameDoesNotMatter8(out found : !firrtl.uint<1>, out result: !firrtl.uint<5>)
     // CHECK-NOT: NameDoesNotMatter8
-    // CHECK: firrtl.int.generic "circt.plusargs.value" <FORMAT: none = "foo"> : () -> !firrtl.bundle<found: uint<1>, result: uint<5>>
+    // CHECK: firrtl.int.generic.expr "circt.plusargs.value" <FORMAT: none = "foo"> : () -> !firrtl.bundle<found: uint<1>, result: uint<5>>
     firrtl.strictconnect %io3, %found4 : !firrtl.uint<1>
     firrtl.strictconnect %io4, %result1 : !firrtl.uint<5>
   }
@@ -53,7 +53,7 @@ firrtl.circuit "ProbeIntrinsicTest" {
   firrtl.module private @ProbeIntrinsicTest(in %clock : !firrtl.clock, in %data : !firrtl.uint<32>) {
     // CHECK:      [[DATA:%.+]] = firrtl.wire : !firrtl.uint
     // CHECK-NEXT: [[CLOCK:%.+]] = firrtl.wire : !firrtl.clock
-    // CHECK-NEXT: firrtl.int.generic "circt_fpga_probe" [[DATA]], [[CLOCK]] : (!firrtl.uint, !firrtl.clock) -> ()
+    // CHECK-NEXT: firrtl.int.generic.stmt "circt_fpga_probe" [[DATA]], [[CLOCK]] : !firrtl.uint, !firrtl.clock
     // CHECK-NEXT: firrtl.strictconnect [[CLOCK]], %clock : !firrtl.clock
     // CHECK-NEXT: firrtl.connect [[DATA]], %data : !firrtl.uint, !firrtl.uint<32>
     %mod_data, %mod_clock = firrtl.instance mod @FPGAProbeIntrinsic(in data: !firrtl.uint, in clock: !firrtl.clock)

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -22,16 +22,18 @@ firrtl.module @Intrinsics(in %ui : !firrtl.uint, in %clock: !firrtl.clock, in %u
   %cg0 = firrtl.int.clock_gate %clock, %ui1
   %cg1 = firrtl.int.clock_gate %clock, %ui1, %ui1
 
-  // CHECK-NEXT: firrtl.int.generic "clock_gate" %clock, %ui1 : (!firrtl.clock, !firrtl.uint<1>)
-  // CHECK-NEXT: firrtl.int.generic "noargs" : () -> !firrtl.uint<32>
-  // CHECK-NEXT: firrtl.int.generic "params" <FORMAT: none = "foobar"> : () -> !firrtl.bundle<x: uint<1>>
-  // CHECK-NEXT: firrtl.int.generic "params_and_operand" <X: i64 = 123> %ui1 : (!firrtl.uint<1>) -> !firrtl.clock
-  // CHECK-NEXT: firrtl.int.generic "inputs" %clock, %ui1, %clock : (!firrtl.clock, !firrtl.uint<1>, !firrtl.clock) -> ()
-  %cg2 = firrtl.int.generic "clock_gate" %clock, %ui1 : (!firrtl.clock, !firrtl.uint<1>) -> !firrtl.clock
-  %noargs = firrtl.int.generic "noargs" : () -> !firrtl.uint<32>
-  %p = firrtl.int.generic "params" <FORMAT: none = "foobar"> : () -> !firrtl.bundle<x: uint<1>>
-  %po = firrtl.int.generic "params_and_operand" <X: i64 = 123> %ui1 : (!firrtl.uint<1>) -> !firrtl.clock
-  firrtl.int.generic "inputs" %clock, %ui1, %clock : (!firrtl.clock, !firrtl.uint<1>, !firrtl.clock) -> ()
+  // CHECK-NEXT: firrtl.int.generic.expr "clock_gate" %clock, %ui1 : (!firrtl.clock, !firrtl.uint<1>)
+  // CHECK-NEXT: firrtl.int.generic.expr "noargs" : () -> !firrtl.uint<32>
+  // CHECK-NEXT: firrtl.int.generic.expr "params" <FORMAT: none = "foobar"> : () -> !firrtl.bundle<x: uint<1>>
+  // CHECK-NEXT: firrtl.int.generic.expr "params_and_operand" <X: i64 = 123> %ui1 : (!firrtl.uint<1>) -> !firrtl.clock
+  // CHECK-NEXT: firrtl.int.generic.stmt "inputs" %clock, %ui1, %clock : !firrtl.clock, !firrtl.uint<1>, !firrtl.clock
+  // CHECK-NEXT: firrtl.int.generic.stmt "noinputs"
+  %cg2 = firrtl.int.generic.expr "clock_gate" %clock, %ui1 : (!firrtl.clock, !firrtl.uint<1>) -> !firrtl.clock
+  %noargs = firrtl.int.generic.expr "noargs" : () -> !firrtl.uint<32>
+  %p = firrtl.int.generic.expr "params" <FORMAT: none = "foobar"> : () -> !firrtl.bundle<x: uint<1>>
+  %po = firrtl.int.generic.expr "params_and_operand" <X: i64 = 123> %ui1 : (!firrtl.uint<1>) -> !firrtl.clock
+  firrtl.int.generic.stmt "inputs" %clock, %ui1, %clock : !firrtl.clock, !firrtl.uint<1>, !firrtl.clock
+  firrtl.int.generic.stmt "noinputs"
 }
 
 // CHECK-LABEL: firrtl.module @FPGAProbe


### PR DESCRIPTION
Expression form is Pure and must have a result.
Optionally carries a name (like other expressions).

FIRRTL operations are expected to be one of expression or statement (see Visitor, firrtl::isExpression, so on) so split the combined operation into these two kinds.

Statement form is not pure and does not have a result.