### PR TITLE
[NFC] Cache common lookups in ModuleType

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -31,6 +31,53 @@ struct ModulePort {
   Direction dir;
 };
 
+static bool operator==(const ModulePort &a, const ModulePort &b) {
+  return a.dir == b.dir && a.name == b.name && a.type == b.type;
+}
+static llvm::hash_code hash_value(const ModulePort &port) {
+  return llvm::hash_combine(port.dir, port.name, port.type);
+}
+
+namespace detail {
+struct ModuleTypeStorage : public TypeStorage {
+  ModuleTypeStorage(ArrayRef<ModulePort> inPorts);
+
+  /// The hash key for this storage is a pair of the integer and type params.
+  using KeyTy = ArrayRef<ModulePort>;
+
+  /// Define the comparison function for the key type.
+  bool operator==(const KeyTy &key) const {
+    return std::equal(key.begin(), key.end(), ports.begin(), ports.end());
+  }
+
+  /// Define a hash function for the key type.
+  /// Note: This isn't necessary because std::pair, unsigned, and Type all have
+  /// hash functions already available.
+  static llvm::hash_code hashKey(const KeyTy &key) {
+    return llvm::hash_combine_range(key.begin(), key.end());
+  }
+
+  /// Define a construction method for creating a new instance of this storage.
+  static ModuleTypeStorage *construct(mlir::TypeStorageAllocator &allocator,
+                                      const KeyTy &key) {
+    return new (allocator.allocate<ModuleTypeStorage>()) ModuleTypeStorage(key);
+  }
+
+  /// Construct an instance of the key from this storage class.
+  KeyTy getAsKey() const { return ports; }
+
+  ArrayRef<ModulePort> getPorts() const { return ports; }
+
+  /// The parametric data held by the storage class.
+  SmallVector<ModulePort> ports;
+  // Cache of common lookups
+  SmallVector<size_t> inputToAbs;
+  SmallVector<size_t> outputToAbs;
+  SmallVector<size_t> absToInput;
+  SmallVector<size_t> absToOutput;
+};
+} // namespace detail
+
 class HWSymbolCache;
 class ParamDeclAttr;
 class TypedeclOp;

--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -42,7 +42,6 @@ namespace detail {
 struct ModuleTypeStorage : public TypeStorage {
   ModuleTypeStorage(ArrayRef<ModulePort> inPorts);
 
-  /// The hash key for this storage is a pair of the integer and type params.
   using KeyTy = ArrayRef<ModulePort>;
 
   /// Define the comparison function for the key type.
@@ -51,8 +50,6 @@ struct ModuleTypeStorage : public TypeStorage {
   }
 
   /// Define a hash function for the key type.
-  /// Note: This isn't necessary because std::pair, unsigned, and Type all have
-  /// hash functions already available.
   static llvm::hash_code hashKey(const KeyTy &key) {
     return llvm::hash_combine_range(key.begin(), key.end());
   }

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -243,6 +243,7 @@ def ModuleTypeImpl : HWType<"Module"> {
   let hasCustomAssemblyFormat = 1;
   let genVerifyDecl = 1;
   let mnemonic = "modty";
+  let genStorageClass = 0;
 
   let extraClassDeclaration = [{
     // Many of these are transitional and will be removed when modules and instances

--- a/lib/CAPI/Dialect/FIRRTL.cpp
+++ b/lib/CAPI/Dialect/FIRRTL.cpp
@@ -311,6 +311,7 @@ FIRRTLValueFlow firrtlValueFoldFlow(MlirValue value, FIRRTLValueFlow flow) {
   case Flow::Duplex:
     return FIRRTL_VALUE_FLOW_DUPLEX;
   }
+  llvm_unreachable("invalid flow");
 }
 
 bool firrtlImportAnnotationsFromJSONRaw(

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1075,8 +1075,6 @@ static LogicalResult verifyModuleCommon(HWModuleLike module) {
   assert(isa<HWModuleLike>(module) &&
          "verifier hook should only be called on modules");
 
-  auto moduleType = module.getHWModuleType();
-
   SmallPtrSet<Attribute, 4> paramNames;
 
   // Check parameter default values are sensible.


### PR DESCRIPTION
Use custom storage for ModuleType to cache input/output <-> index mappings.  Speeds up many things in small ways.