### PR TITLE
[FIRRTL] Fixup visit ops miscategorized.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -53,15 +53,13 @@ public:
             LTLDelayIntrinsicOp, LTLConcatIntrinsicOp, LTLNotIntrinsicOp,
             LTLImplicationIntrinsicOp, LTLEventuallyIntrinsicOp,
             LTLClockIntrinsicOp, LTLDisableIntrinsicOp, Mux2CellIntrinsicOp,
-            Mux4CellIntrinsicOp, HasBeenResetIntrinsicOp, FPGAProbeIntrinsicOp,
-            GenericIntrinsicOp,
+            Mux4CellIntrinsicOp, HasBeenResetIntrinsicOp,
             // Miscellaneous.
             BitsPrimOp, HeadPrimOp, MuxPrimOp, PadPrimOp, ShlPrimOp, ShrPrimOp,
             TailPrimOp, VerbatimExprOp, HWStructCastOp, BitCastOp, RefSendOp,
             RefResolveOp, RefSubOp, RWProbeOp, XMRRefOp, XMRDerefOp,
             // Casts to deal with weird stuff
             UninferredResetCastOp, ConstCastOp, RefCastOp,
-            mlir::UnrealizedConversionCastOp,
             // Property expressions.
             StringConstantOp, FIntegerConstantOp, BoolConstantOp,
             DoubleConstantOp, ListCreateOp, UnresolvedPathOp, PathOp>(
@@ -181,8 +179,6 @@ public:
   HANDLE(Mux4CellIntrinsicOp, Unhandled);
   HANDLE(Mux2CellIntrinsicOp, Unhandled);
   HANDLE(HasBeenResetIntrinsicOp, Unhandled);
-  HANDLE(FPGAProbeIntrinsicOp, Unhandled);
-  HANDLE(GenericIntrinsicOp, Unhandled);
 
   // Miscellaneous.
   HANDLE(BitsPrimOp, Unhandled);
@@ -205,7 +201,6 @@ public:
   HANDLE(HWStructCastOp, Unhandled);
   HANDLE(UninferredResetCastOp, Unhandled);
   HANDLE(ConstCastOp, Unhandled);
-  HANDLE(mlir::UnrealizedConversionCastOp, Unhandled);
   HANDLE(BitCastOp, Unhandled);
   HANDLE(RefCastOp, Unhandled);
 
@@ -228,12 +223,13 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<
-            AttachOp, ConnectOp, StrictConnectOp, RefDefineOp, ForceOp,
-            PrintFOp, SkipOp, StopOp, WhenOp, AssertOp, AssumeOp, CoverOp,
-            PropAssignOp, RefForceOp, RefForceInitialOp, RefReleaseOp,
-            RefReleaseInitialOp, VerifAssertIntrinsicOp, VerifAssumeIntrinsicOp,
-            UnclockedAssumeIntrinsicOp, VerifCoverIntrinsicOp, LayerBlockOp>(
+        .template Case<AttachOp, ConnectOp, StrictConnectOp, RefDefineOp,
+                       ForceOp, PrintFOp, SkipOp, StopOp, WhenOp, AssertOp,
+                       AssumeOp, CoverOp, PropAssignOp, RefForceOp,
+                       RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp,
+                       FPGAProbeIntrinsicOp, VerifAssertIntrinsicOp,
+                       VerifAssumeIntrinsicOp, UnclockedAssumeIntrinsicOp,
+                       VerifCoverIntrinsicOp, LayerBlockOp>(
             [&](auto opNode) -> ResultType {
               return thisCast->visitStmt(opNode, args...);
             })
@@ -276,6 +272,7 @@ public:
   HANDLE(RefForceInitialOp);
   HANDLE(RefReleaseOp);
   HANDLE(RefReleaseInitialOp);
+  HANDLE(FPGAProbeIntrinsicOp);
   HANDLE(VerifAssertIntrinsicOp);
   HANDLE(VerifAssumeIntrinsicOp);
   HANDLE(VerifCoverIntrinsicOp);
@@ -347,6 +344,13 @@ public:
   /// This is the main entrypoint for the FIRRTLVisitor.
   ResultType dispatchVisitor(Operation *op, ExtraArgs... args) {
     return this->dispatchExprVisitor(op, args...);
+  }
+
+  /// Special handling for generic intrinsic op which aren't quite expressions
+  /// nor statements in the usual FIRRTL sense.
+  /// Refactor into specific visitor instead of adding more here.
+  ResultType visitIntrinsicOp(GenericIntrinsicOp *op, ExtraArgs... args) {
+    return static_cast<ConcreteType *>(this)->visitUnhandledOp(op, args...);
   }
 
   // Chain from each visitor onto the next one.

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -372,7 +372,6 @@ struct TypeLoweringVisitor : public FIRRTLVisitor<TypeLoweringVisitor, bool> {
   bool visitExpr(MuxPrimOp op);
   bool visitExpr(Mux2CellIntrinsicOp op);
   bool visitExpr(Mux4CellIntrinsicOp op);
-  bool visitExpr(mlir::UnrealizedConversionCastOp op);
   bool visitExpr(BitCastOp op);
   bool visitExpr(RefSendOp op);
   bool visitExpr(RefResolveOp op);
@@ -382,8 +381,15 @@ struct TypeLoweringVisitor : public FIRRTLVisitor<TypeLoweringVisitor, bool> {
   bool visitStmt(RefDefineOp op);
   bool visitStmt(WhenOp op);
   bool visitStmt(LayerBlockOp op);
+  bool visitUnrealizedConversionCast(mlir::UnrealizedConversionCastOp op);
 
   bool isFailed() const { return encounteredError; }
+
+  bool visitInvalidOp(Operation *op) {
+    if (auto castOp = dyn_cast<mlir::UnrealizedConversionCastOp>(op))
+      return visitUnrealizedConversionCast(castOp);
+    return false;
+  }
 
 private:
   void processUsers(Value val, ArrayRef<Value> mapping);
@@ -1304,7 +1310,8 @@ bool TypeLoweringVisitor::visitExpr(Mux4CellIntrinsicOp op) {
 }
 
 // Expand UnrealizedConversionCastOp of aggregates
-bool TypeLoweringVisitor::visitExpr(mlir::UnrealizedConversionCastOp op) {
+bool TypeLoweringVisitor::visitUnrealizedConversionCast(
+    mlir::UnrealizedConversionCastOp op) {
   auto clone = [&](const FlatBundleFieldEntry &field,
                    ArrayAttr attrs) -> Value {
     auto input = getSubWhatever(op.getOperand(0), field.index);


### PR DESCRIPTION
FPGAProbeIntrinsicOp is not an expression (not pure and no results!), mlir::UnrealizedConversionCast is only sometimes expression-like (and FIRRTLVisitor is for visiting FIRRTL-dialect operations only), and GenericIntrinsicOp is neither expression nor statement so just add a special visitor for it.

Update passes using visitors to reflect these changes.