### PR TITLE
[FIRRTL] Generic intrinsic parsing/emitter support

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -282,6 +282,9 @@ struct FIRParser {
 
   ParseResult parseOptionalRUW(RUWAttr &result);
 
+  ParseResult parseParameter(StringAttr &resultName, TypedAttr &resultValue,
+                             SMLoc &resultLoc);
+
   /// The version of FIRRTL to use for this parser.
   FIRVersion version;
 
@@ -1150,6 +1153,72 @@ ParseResult FIRParser::parseOptionalRUW(RUWAttr &result) {
   return success();
 }
 
+/// param ::= id '=' intLit
+///       ::= id '=' StringLit
+///       ::= id '=' floatingpoint
+///       ::= id '=' VerbatimStringLit
+ParseResult FIRParser::parseParameter(StringAttr &resultName,
+                                      TypedAttr &resultValue,
+                                      SMLoc &resultLoc) {
+  mlir::Builder builder(getContext());
+
+  auto loc = getToken().getLoc();
+
+  StringRef name;
+  if (parseId(name, "expected parameter name") ||
+      parseToken(FIRToken::equal, "expected '=' in parameter"))
+    return failure();
+
+  TypedAttr value;
+  switch (getToken().getKind()) {
+  default:
+    return emitError("expected parameter value"), failure();
+  case FIRToken::integer:
+  case FIRToken::signed_integer: {
+    APInt result;
+    if (parseIntLit(result, "invalid integer parameter"))
+      return failure();
+
+    // If the integer parameter is less than 32-bits, sign extend this to a
+    // 32-bit value.  This needs to eventually emit as a 32-bit value in
+    // Verilog and we want to get the size correct immediately.
+    if (result.getBitWidth() < 32)
+      result = result.sext(32);
+
+    value = builder.getIntegerAttr(
+        builder.getIntegerType(result.getBitWidth(), result.isSignBitSet()),
+        result);
+    break;
+  }
+  case FIRToken::string: {
+    // Drop the double quotes and unescape.
+    value = builder.getStringAttr(getToken().getStringValue());
+    consumeToken(FIRToken::string);
+    break;
+  }
+  case FIRToken::verbatim_string: {
+    // Drop the single quotes and unescape the ones inside.
+    auto text = builder.getStringAttr(getToken().getVerbatimStringValue());
+    value = hw::ParamVerbatimAttr::get(text);
+    consumeToken(FIRToken::verbatim_string);
+    break;
+  }
+  case FIRToken::floatingpoint:
+    double v;
+    if (!llvm::to_float(getTokenSpelling(), v))
+      return emitError("invalid float parameter syntax"), failure();
+
+    value = builder.getF64FloatAttr(v);
+    consumeToken(FIRToken::floatingpoint);
+    break;
+  }
+
+  resultName = builder.getStringAttr(name);
+  resultValue = value;
+  resultLoc = loc;
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // FIRModuleContext
 //===----------------------------------------------------------------------===//
@@ -1595,6 +1664,17 @@ private:
   ParseResult parseRWProbeStaticRefExp(FieldRef &refResult, Type &type,
                                        const Twine &message);
 
+  // Generic intrinsic parsing.
+  ParseResult parseIntrinsic(Value &result, bool isStatement);
+  ParseResult parseIntrinsicStmt() {
+    Value unused;
+    return parseIntrinsic(unused, /*isStatement=*/true);
+  }
+  ParseResult parseIntrinsicExp(Value &result) {
+    return parseIntrinsic(result, /*isStatement=*/false);
+  }
+  ParseResult parseOptionalParams(ArrayAttr &resultParameters);
+
   template <typename subop>
   FailureOr<Value> emitCachedSubAccess(Value base,
                                        ArrayRef<NamedAttribute> attrs,
@@ -1940,6 +2020,12 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
     if (isLeadingStmt)
       return emitError("unexpected path() as start of statement");
     if (requireFeature(nextFIRVersion, "paths") || parsePathExp(result))
+      return failure();
+    break;
+
+  case FIRToken::kw_intrinsic:
+    if (requireFeature({4, 0, 0}, "generic intrinsics") ||
+        parseIntrinsicExp(result))
       return failure();
     break;
 
@@ -2583,7 +2669,10 @@ ParseResult FIRStmtParser::parseSimpleStmtImpl(unsigned stmtIndent) {
     if (requireFeature({4, 0, 0}, "layers"))
       return failure();
     return parseLayerBlockOrGroup(stmtIndent);
-
+  case FIRToken::kw_intrinsic:
+    if (requireFeature({4, 0, 0}, "generic intrinsics"))
+      return failure();
+    return parseIntrinsicStmt();
   default: {
     // Statement productions that start with an expression.
     Value lhs;
@@ -3305,6 +3394,75 @@ ParseResult FIRStmtParser::parseRWProbeStaticRefExp(FieldRef &refResult,
     }
     return success();
   }
+}
+
+/// intrinsic_expr ::=  'intrinsic(' Id (params)?  ':' type    exp* ')'
+/// intrinsic_stmt ::=  'intrinsic(' Id (params)? (':' type )? exp* ')'
+ParseResult FIRStmtParser::parseIntrinsic(Value &result, bool isStatement) {
+  auto startTok = consumeToken(FIRToken::kw_intrinsic);
+  StringRef intrinsic;
+  ArrayAttr parameters;
+  FIRRTLType type;
+
+  if (parseToken(FIRToken::l_paren, "expected '(' in intrinsic expression") ||
+      parseId(intrinsic, "expected intrinsic identifier") ||
+      parseOptionalParams(parameters))
+    return failure();
+
+  if (consumeIf(FIRToken::colon)) {
+    if (parseType(type, "expected intrinsic return type"))
+      return failure();
+  } else if (!isStatement)
+    return emitError("expected ':' in intrinsic expression");
+
+  SmallVector<Value> operands;
+  auto loc = startTok.getLoc();
+  if (parseListUntil(FIRToken::r_paren, [&]() -> ParseResult {
+        Value operand;
+        if (parseExp(operand, "expected operand in intrinsic"))
+          return failure();
+        operands.push_back(operand);
+        locationProcessor.setLoc(loc);
+        return success();
+      }))
+    return failure();
+
+  if (isStatement)
+    if (parseOptionalInfo())
+      return failure();
+
+  locationProcessor.setLoc(loc);
+
+  auto op = builder.create<GenericIntrinsicOp>(
+      type, builder.getStringAttr(intrinsic), operands, parameters);
+  if (type)
+    result = op.getResult();
+  return success();
+}
+
+/// params ::= '<' param param* '>'
+ParseResult FIRStmtParser::parseOptionalParams(ArrayAttr &resultParameters) {
+  if (!consumeIf(FIRToken::less))
+    return success();
+
+  SmallVector<Attribute, 8> parameters;
+  SmallPtrSet<StringAttr, 8> seen;
+  if (parseListUntil(FIRToken::greater, [&]() -> ParseResult {
+        StringAttr name;
+        TypedAttr value;
+        SMLoc loc;
+        if (parseParameter(name, value, loc))
+          return failure();
+        if (!seen.insert(name).second)
+          return emitError(loc, "redefinition of parameter '" +
+                                    name.getValue() + "'");
+        parameters.push_back(ParamDeclAttr::get(name, value));
+        return success();
+      }))
+    return failure();
+
+  resultParameters = ArrayAttr::get(getContext(), parameters);
+  return success();
 }
 
 /// path ::= 'path(' StringLit ')'
@@ -4466,8 +4624,6 @@ private:
                             SmallVectorImpl<SMLoc> &resultPortLocs,
                             unsigned indent);
   ParseResult parseParameterList(ArrayAttr &resultParameters);
-  ParseResult parseParameter(StringAttr &resultName, TypedAttr &resultValue,
-                             SMLoc &resultLoc);
   ParseResult parseRefList(ArrayRef<PortInfo> portList,
                            ArrayAttr &internalPathsResult);
 
@@ -4784,78 +4940,12 @@ ParseResult FIRCircuitParser::skipToModuleEnd(unsigned indent) {
   }
 }
 
-/// parameter ::= 'parameter' id '=' intLit NEWLINE
-/// parameter ::= 'parameter' id '=' StringLit NEWLINE
-/// parameter ::= 'parameter' id '=' floatingpoint NEWLINE
-/// parameter ::= 'parameter' id '=' VerbatimStringLit NEWLINE
-ParseResult FIRCircuitParser::parseParameter(StringAttr &resultName,
-                                             TypedAttr &resultValue,
-                                             SMLoc &resultLoc) {
-  mlir::Builder builder(getContext());
-
-  consumeToken(FIRToken::kw_parameter);
-  auto loc = getToken().getLoc();
-
-  StringRef name;
-  if (parseId(name, "expected parameter name") ||
-      parseToken(FIRToken::equal, "expected '=' in parameter"))
-    return failure();
-
-  TypedAttr value;
-  switch (getToken().getKind()) {
-  default:
-    return emitError("expected parameter value"), failure();
-  case FIRToken::integer:
-  case FIRToken::signed_integer: {
-    APInt result;
-    if (parseIntLit(result, "invalid integer parameter"))
-      return failure();
-
-    // If the integer parameter is less than 32-bits, sign extend this to a
-    // 32-bit value.  This needs to eventually emit as a 32-bit value in
-    // Verilog and we want to get the size correct immediately.
-    if (result.getBitWidth() < 32)
-      result = result.sext(32);
-
-    value = builder.getIntegerAttr(
-        builder.getIntegerType(result.getBitWidth(), result.isSignBitSet()),
-        result);
-    break;
-  }
-  case FIRToken::string: {
-    // Drop the double quotes and unescape.
-    value = builder.getStringAttr(getToken().getStringValue());
-    consumeToken(FIRToken::string);
-    break;
-  }
-  case FIRToken::verbatim_string: {
-    // Drop the single quotes and unescape the ones inside.
-    auto text = builder.getStringAttr(getToken().getVerbatimStringValue());
-    value = hw::ParamVerbatimAttr::get(text);
-    consumeToken(FIRToken::verbatim_string);
-    break;
-  }
-  case FIRToken::floatingpoint:
-    double v;
-    if (!llvm::to_float(getTokenSpelling(), v))
-      return emitError("invalid float parameter syntax"), failure();
-
-    value = builder.getF64FloatAttr(v);
-    consumeToken(FIRToken::floatingpoint);
-    break;
-  }
-
-  resultName = builder.getStringAttr(name);
-  resultValue = value;
-  resultLoc = loc;
-  return success();
-}
-
 /// parameter-list ::= parameter*
+/// parameter ::= 'parameter' param NEWLINE
 ParseResult FIRCircuitParser::parseParameterList(ArrayAttr &resultParameters) {
   SmallVector<Attribute, 8> parameters;
   SmallPtrSet<StringAttr, 8> seen;
-  while (getToken().is(FIRToken::kw_parameter)) {
+  while (consumeIf(FIRToken::kw_parameter)) {
     StringAttr name;
     TypedAttr value;
     SMLoc loc;

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2023,7 +2023,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
       return failure();
     break;
 
-  case FIRToken::kw_intrinsic:
+  case FIRToken::lp_intrinsic:
     if (requireFeature({4, 0, 0}, "generic intrinsics") ||
         parseIntrinsicExp(result))
       return failure();
@@ -2669,7 +2669,7 @@ ParseResult FIRStmtParser::parseSimpleStmtImpl(unsigned stmtIndent) {
     if (requireFeature({4, 0, 0}, "layers"))
       return failure();
     return parseLayerBlockOrGroup(stmtIndent);
-  case FIRToken::kw_intrinsic:
+  case FIRToken::lp_intrinsic:
     if (requireFeature({4, 0, 0}, "generic intrinsics"))
       return failure();
     return parseIntrinsicStmt();
@@ -3399,13 +3399,12 @@ ParseResult FIRStmtParser::parseRWProbeStaticRefExp(FieldRef &refResult,
 /// intrinsic_expr ::=  'intrinsic(' Id (params)?  ':' type    exp* ')'
 /// intrinsic_stmt ::=  'intrinsic(' Id (params)? (':' type )? exp* ')'
 ParseResult FIRStmtParser::parseIntrinsic(Value &result, bool isStatement) {
-  auto startTok = consumeToken(FIRToken::kw_intrinsic);
+  auto startTok = consumeToken(FIRToken::lp_intrinsic);
   StringRef intrinsic;
   ArrayAttr parameters;
   FIRRTLType type;
 
-  if (parseToken(FIRToken::l_paren, "expected '(' in intrinsic expression") ||
-      parseId(intrinsic, "expected intrinsic identifier") ||
+  if (parseId(intrinsic, "expected intrinsic identifier") ||
       parseOptionalParams(parameters))
     return failure();
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3439,7 +3439,7 @@ ParseResult FIRStmtParser::parseIntrinsic(Value &result, bool isStatement) {
   return success();
 }
 
-/// params ::= '<' param param* '>'
+/// params ::= '<' param* '>'
 ParseResult FIRStmtParser::parseOptionalParams(ArrayAttr &resultParameters) {
   if (!consumeIf(FIRToken::less))
     return success();

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -179,6 +179,8 @@ TOK_LPKEYWORD(read)
 TOK_LPKEYWORD(probe)
 TOK_LPKEYWORD(rwprobe)
 
+TOK_LPKEYWORD(intrinsic)
+
 // These are for LPKEYWORD cases that correspond to a primitive operation.
 TOK_LPKEYWORD_PRIM(add, AddPrimOp, 2)
 TOK_LPKEYWORD_PRIM(and, AndPrimOp, 2)

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2080,3 +2080,36 @@ circuit StaticShiftRight:
     ; CHECK: %11 = firrtl.shr %x, 10
     ; CHECK: %x_1 = firrtl.node {{.*}} %11 : !firrtl.sint
     node x_1 = shr(x, 10)
+
+;// -----
+FIRRTL version 4.0.0
+; CHECK-LABEL: circuit "GenericIntrinsics"
+circuit GenericIntrinsics:
+  ; CHECK: firrtl.module @GenericIntrinsics
+  public module GenericIntrinsics:
+    input clock : Clock
+    input data : UInt<32>
+    input c : UInt<1>
+
+    ; Statements
+    ; CHECK-NEXT: firrtl.int.generic "circt_verif_assert" %c : (!firrtl.uint<1>) -> ()
+    intrinsic(circt_verif_assert, c)
+    ; CHECK-NEXT: firrtl.int.generic "circt_fpga_probe" %data, %clock : (!firrtl.uint<32>, !firrtl.clock) -> ()
+    intrinsic(circt_fpga_probe, data, clock)
+
+    ; Expressions
+    ; CHECK-NEXT: %[[PAV:.+]] = firrtl.int.generic "circt_plusargs_value" <FORMAT: none = "foo"> : () -> !firrtl.bundle<found: uint<1>, result: uint<5>>
+    ; CHECK-NEXT: %n = firrtl.node interesting_name %[[PAV]]
+    node n = intrinsic(circt_plusargs_value<FORMAT = "foo"> : { found : UInt<1>, result : UInt<5> })
+    ; CHECK-NEXT: %[[PAT:.+]] = firrtl.int.generic "circt_plusargs_test" <FORMAT: none = "bar"> : () -> !firrtl.uint<3>
+    ; CHECK-NEXT: %n2 = firrtl.node interesting_name %[[PAT]]
+    node n2 = intrinsic(circt_plusargs_test<FORMAT = "bar"> : UInt<3>)
+ 
+
+    ; Statement with unused return value.
+    ; CHECK-NEXT: firrtl.int.generic "circt_clock_gate" %clock, %c : (!firrtl.clock, !firrtl.uint<1>) -> !firrtl.clock
+    intrinsic(circt_clock_gate : Clock, clock, c)
+
+    ; CHECK-NEXT: %[[SZ:.+]] = firrtl.int.generic "circt_isX"
+    ; CHECK-NEXT: "circt_verif_assert" %[[SZ]]
+    intrinsic(circt_verif_assert, intrinsic(circt_isX: UInt<1>, data))

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1395,3 +1395,38 @@ circuit IntModuleBadIntrinsic:
     ; expected-error @below {{expected intrinsic name}}
     intrinsic = 0
   module IntModule:
+
+;// -----
+FIRRTL version 4.0.0
+circuit GenericIntExprNoRet:
+  public module GenericIntExprNoRet:
+    ; expected-error @below {{expected ':' in intrinsic expression}}
+    node n = intrinsic(dummy)
+
+;// -----
+FIRRTL version 4.0.0
+circuit GenericIntNotPassive:
+  public module GenericIntNotPassive:
+    ; expected-error @below {{must be a passive base type}}
+    intrinsic(dummy : { flip x : UInt<1> })
+
+;// -----
+FIRRTL version 4.0.0
+circuit GenericIntBadId:
+  public module GenericIntBadId:
+    ; expected-error @below {{expected intrinsic identifier}}
+    intrinsic(5)
+
+;// -----
+FIRRTL version 4.0.0
+circuit GenericIntUntermStr:
+  public module GenericIntUntermStr:
+    ; expected-error @below {{unterminated string}}
+    intrinsic<key = "val
+      " ; end for syntax highlighting
+;// -----
+FIRRTL version 4.0.0
+circuit GenericIntParamRedef:
+  public module GenericIntParamRedef:
+    ; expected-error @below {{redefinition of parameter 'x'}}
+    intrinsic(dummy<x = 5, x = 3>)


### PR DESCRIPTION
Add parsing and emitter support for FIRRTL intrinsic.

Refactor parameter parsing on (ext/int)modules as these use same syntax.

Snippet from parse-basic.fir without FileCheck directives:

```firrtl
circuit GenericIntrinsics:
  public module GenericIntrinsics:
    input clock : Clock
    input data : UInt<32>
    input c : UInt<1>

    ; Statements
    intrinsic(circt_verif_assert, c)
    intrinsic(circt_fpga_probe, data, clock)

    ; Expressions
    node n = intrinsic(circt_plusargs_value<FORMAT = "foo"> : { found : UInt<1>, result : UInt<5> })
    node n2 = intrinsic(circt_plusargs_test<FORMAT = "bar"> : UInt<3>)

    ; Statement with unused return value.
    intrinsic(circt_clock_gate : Clock, clock, c)

    ; Nesting, statement and expression forms.
    intrinsic(circt_verif_assert, intrinsic(circt_isX: UInt<1>, data))
```

And somewhat similarly from the emit-basic test:
```
  public module GenericIntrinsic :
    input clk : Clock
    input c : UInt<1>
    output s : UInt<32>
    output io1 : UInt<1>
    output io2 : UInt<1>
    output io3 : UInt<1>
    output io4 : UInt<5>

    connect s, intrinsic(circt_sizeof : UInt<32>, clk)
    connect io1, intrinsic(circt_isX : UInt<1>, clk)
    connect io2, intrinsic(circt_plusargs_test<FORMAT = "foo"> : UInt<1>)
    intrinsic(circt_clock_gate : Clock, clk, c)
    node _gen_int
      = intrinsic(circt_plusargs_value<FORMAT = "foo">
                    : { found : UInt<1>, result : UInt<5> })
    connect io3, _gen_int.found
    connect io4, _gen_int.result
    intrinsic(circt_verif_assert, intrinsic(circt_isX : UInt<1>, c))
    node _gen_int_0 = intrinsic(circt_isX : UInt<1>, c)
    intrinsic(circt_verif_assert, intrinsic(circt_isX : UInt<1>, _gen_int_0))
 ```