### PR TITLE
[ImportVerilog] Fix the types mismatch for variable declarations.

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -82,6 +82,9 @@ struct MemberVisitor {
       initial = context.convertExpression(*init);
       if (!initial)
         return failure();
+
+      if (initial.getType() != type)
+        initial = builder.create<moore::ConversionOp>(loc, type, initial);
     }
 
     auto varOp = builder.create<moore::VariableOp>(

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -46,6 +46,12 @@ module Basic;
   int v1;
   int v2 = v1;
 
+  // CHECK: %b1 = moore.variable : !moore.packed<range<bit, 0:0>>
+  // CHECK: [[TMP:%.+]] = moore.conversion %b1 : !moore.packed<range<bit, 0:0>> -> !moore.bit
+  // CHECK: %b2 = moore.variable [[TMP]] : !moore.bit
+  bit [0:0] b1;
+  bit b2 = b1;
+
   // CHECK: moore.procedure initial {
   // CHECK: }
   initial;


### PR DESCRIPTION
When declaring a variable with an initial value, like `bit b = 1'b1;`, or `logic [3:0] l1; logic [1:0] l2 = l1[3:2];`. These all will trigger an error: 'moore.variable' op failed to verify that initial value and variable types match.
