### PR TITLE
[Ibis] Divorce port name (hints) from port symbol names

### DIFF
--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -749,10 +749,10 @@ class PortLikeOp<string mnemonic, list<Trait> traits = []> :
     related, and all references to a port is done through the port symbol.
   }];
 
-  let arguments = (ins StrAttr:$name, InnerSymAttr:$inner_sym, TypeAttrOf<AnyType>:$type);
+  let arguments = (ins OptionalAttr<StrAttr>:$name, InnerSymAttr:$inner_sym, TypeAttrOf<AnyType>:$type);
   let results = (outs PortRefType:$port);
   let assemblyFormat = [{
-    $name `sym` $inner_sym `:` $type attr-dict
+    ($name^)? `sym` $inner_sym `:` $type attr-dict
   }];
 
   let extraClassDeclaration = [{
@@ -785,9 +785,6 @@ class PortLikeOp<string mnemonic, list<Trait> traits = []> :
   code extraPortClassDefinition = ?;
   let extraClassDefinition =  extraPortClassDefinition # [{
     LogicalResult $cppClass::verify() {
-      if(getName().empty())
-        return emitOpError("port name cannot be empty");
-
       if(getType().isa<ScopeRefType>())
         return emitOpError("port type cannot be a scope reference");
 

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -742,10 +742,17 @@ class PortLikeOp<string mnemonic, list<Trait> traits = []> :
       HasCustomSSAName,
       DeclareOpInterfaceMethods<InnerSymbol,["getTargetResultIndex"]>
   ])> {
-  let arguments = (ins InnerSymAttr:$inner_sym, TypeAttrOf<AnyType>:$type);
+
+  let description = [{
+    An ibis port has an attached 'name' attribute. This is a name-hint used
+    to generate the final port name. The port name and port symbol are not
+    related, and all references to a port is done through the port symbol.
+  }];
+
+  let arguments = (ins StrAttr:$name, InnerSymAttr:$inner_sym, TypeAttrOf<AnyType>:$type);
   let results = (outs PortRefType:$port);
   let assemblyFormat = [{
-    $inner_sym `:` $type attr-dict
+    $name `sym` $inner_sym `:` $type attr-dict
   }];
 
   let extraClassDeclaration = [{
@@ -778,6 +785,9 @@ class PortLikeOp<string mnemonic, list<Trait> traits = []> :
   code extraPortClassDefinition = ?;
   let extraClassDefinition =  extraPortClassDefinition # [{
     LogicalResult $cppClass::verify() {
+      if(getName().empty())
+        return emitOpError("port name cannot be empty");
+
       if(getType().isa<ScopeRefType>())
         return emitOpError("port type cannot be a scope reference");
 

--- a/integration_test/Dialect/Ibis/end_to_end.mlir
+++ b/integration_test/Dialect/Ibis/end_to_end.mlir
@@ -8,7 +8,7 @@ ibis.design @foo {
 
 ibis.class @C1 {
   %this = ibis.this <@foo::@C1>
-  %out = ibis.port.input "out" sym @out : i32
+  %out = ibis.port.output "out" sym @out : i32
   %c0 = hw.constant 42 : i32
   ibis.port.write %out, %c0 : !ibis.portref<out i32>
 }
@@ -19,8 +19,8 @@ ibis.class @C2 {
   %go_port = ibis.port.input "go" sym @go : i1
   %clk_port = ibis.port.input "clk" sym @clk : !seq.clock
   %rst_port = ibis.port.input "rst" sym @rst : i1
-  %done_port = ibis.port.input "done" sym @done : i1
-  %out_port = ibis.port.input "out" sym @out : i32
+  %done_port = ibis.port.output "done" sym @done : i1
+  %out_port = ibis.port.output "out" sym @out : i32
 
   ibis.container @MyMethod {
     %t = ibis.this <@foo::@MyMethod>
@@ -77,8 +77,8 @@ ibis.class @Parent {
   %clk = ibis.port.input "clk" sym @clk : !seq.clock
   %rst = ibis.port.input "rst" sym @rst : i1
 
-  %done = ibis.port.input "done" sym @done : i1
-  %out = ibis.port.input "out" sym @out : i32
+  %done = ibis.port.output "done" sym @done : i1
+  %out = ibis.port.output "out" sym @out : i32
 
   // Wire up to c2
   %go_ref = ibis.get_port %c2, @go : !ibis.scoperef<@foo::@C2> -> !ibis.portref<in i1>

--- a/integration_test/Dialect/Ibis/end_to_end.mlir
+++ b/integration_test/Dialect/Ibis/end_to_end.mlir
@@ -8,7 +8,7 @@ ibis.design @foo {
 
 ibis.class @C1 {
   %this = ibis.this <@foo::@C1>
-  %out = ibis.port.output @out : i32
+  %out = ibis.port.input "out" sym @out : i32
   %c0 = hw.constant 42 : i32
   ibis.port.write %out, %c0 : !ibis.portref<out i32>
 }
@@ -16,11 +16,11 @@ ibis.class @C1 {
 ibis.class @C2 {
   %this = ibis.this <@foo::@C2>
 
-  %go_port = ibis.port.input @go : i1
-  %clk_port = ibis.port.input @clk : !seq.clock
-  %rst_port = ibis.port.input @rst : i1
-  %done_port = ibis.port.output @done : i1
-  %out_port = ibis.port.output @out : i32
+  %go_port = ibis.port.input "go" sym @go : i1
+  %clk_port = ibis.port.input "clk" sym @clk : !seq.clock
+  %rst_port = ibis.port.input "rst" sym @rst : i1
+  %done_port = ibis.port.input "done" sym @done : i1
+  %out_port = ibis.port.input "out" sym @out : i32
 
   ibis.container @MyMethod {
     %t = ibis.this <@foo::@MyMethod>
@@ -73,12 +73,12 @@ ibis.class @Parent {
   %c1 = ibis.instance @c1, <@foo::@C1>
   %c2 = ibis.instance @c2, <@foo::@C2>
 
-  %go = ibis.port.input @go : i1
-  %clk = ibis.port.input @clk : !seq.clock
-  %rst = ibis.port.input @rst : i1
+  %go = ibis.port.input "go" sym @go : i1
+  %clk = ibis.port.input "clk" sym @clk : !seq.clock
+  %rst = ibis.port.input "rst" sym @rst : i1
 
-  %done = ibis.port.output @done : i1
-  %out = ibis.port.output @out : i32
+  %done = ibis.port.input "done" sym @done : i1
+  %out = ibis.port.input "out" sym @out : i32
 
   // Wire up to c2
   %go_ref = ibis.get_port %c2, @go : !ibis.scoperef<@foo::@C2> -> !ibis.portref<in i1>

--- a/lib/Dialect/Ibis/Transforms/IbisCleanSelfdrivers.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisCleanSelfdrivers.cpp
@@ -165,7 +165,7 @@ struct InputPortOpConversionPattern : public OpConversionPattern<InputPortOp> {
 
       if (anyOutsideReads) {
         auto outputPort = rewriter.create<OutputPortOp>(
-            op.getLoc(), op.getName(), op.getInnerSym(), op.getType());
+            op.getLoc(), op.getNameAttr(), op.getInnerSym(), op.getType());
         rewriter.create<PortWriteOp>(op.getLoc(), outputPort, wire);
       }
     }

--- a/lib/Dialect/Ibis/Transforms/IbisCleanSelfdrivers.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisCleanSelfdrivers.cpp
@@ -165,7 +165,7 @@ struct InputPortOpConversionPattern : public OpConversionPattern<InputPortOp> {
 
       if (anyOutsideReads) {
         auto outputPort = rewriter.create<OutputPortOp>(
-            op.getLoc(), op.getInnerSym(), op.getType());
+            op.getLoc(), op.getName(), op.getInnerSym(), op.getType());
         rewriter.create<PortWriteOp>(op.getLoc(), outputPort, wire);
       }
     }

--- a/lib/Dialect/Ibis/Transforms/IbisContainersToHW.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisContainersToHW.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/Ibis/IbisPasses.h"
 #include "circt/Dialect/Ibis/IbisTypes.h"
 
+#include "circt/Support/Namespace.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -34,30 +35,40 @@ struct ContainerPortInfo {
   // A mapping between the port name and the port op within the container.
   llvm::DenseMap<StringAttr, OutputPortOp> opOutputs;
 
+  // A mapping between port symbols and their corresponding port name.
+  llvm::DenseMap<StringAttr, StringAttr> portSymbolsToPortName;
+
   ContainerPortInfo() = default;
   ContainerPortInfo(ContainerOp container) {
     SmallVector<hw::PortInfo, 4> inputs, outputs;
+    auto ctx = container.getContext();
 
-    // Copies all attributes from a port, except for the port symbol and type.
-    auto copyPortAttrs = [](auto port) {
+    // Copies all attributes from a port, except for the port symbol, name, and
+    // type.
+    auto copyPortAttrs = [ctx](auto port) {
       llvm::DenseSet<StringAttr> elidedAttrs;
       elidedAttrs.insert(port.getInnerSymAttrName());
       elidedAttrs.insert(port.getTypeAttrName());
+      elidedAttrs.insert(port.getNameAttrName());
       llvm::SmallVector<NamedAttribute> attrs;
       for (NamedAttribute namedAttr : port->getAttrs()) {
         if (elidedAttrs.contains(namedAttr.getName()))
           continue;
         attrs.push_back(namedAttr);
       }
-      return DictionaryAttr::get(port.getContext(), attrs);
+      return DictionaryAttr::get(ctx, attrs);
     };
 
-    // Gather in and output port ops.
+    // Gather in and output port ops to define the hw.module interface. Here, we
+    // also perform uniqueing of the port names.
+    Namespace portNs;
     for (auto input : container.getBodyBlock()->getOps<InputPortOp>()) {
-      opInputs[input.getInnerSym().getSymName()] = input;
-
+      auto uniquePortName =
+          StringAttr::get(ctx, portNs.newName(input.getNameAttr().getValue()));
+      opInputs[uniquePortName] = input;
       hw::PortInfo portInfo;
-      portInfo.name = input.getInnerSym().getSymName();
+      portInfo.name = uniquePortName;
+      portSymbolsToPortName[input.getInnerSym().getSymName()] = uniquePortName;
       portInfo.type = cast<PortOpInterface>(input.getOperation()).getPortType();
       portInfo.dir = hw::ModulePort::Direction::Input;
       portInfo.attrs = copyPortAttrs(input);
@@ -65,10 +76,13 @@ struct ContainerPortInfo {
     }
 
     for (auto output : container.getBodyBlock()->getOps<OutputPortOp>()) {
-      opOutputs[output.getInnerSym().getSymName()] = output;
+      auto uniquePortName =
+          StringAttr::get(ctx, portNs.newName(output.getNameAttr().getValue()));
+      opOutputs[uniquePortName] = output;
 
       hw::PortInfo portInfo;
-      portInfo.name = output.getInnerSym().getSymName();
+      portInfo.name = uniquePortName;
+      portSymbolsToPortName[output.getInnerSym().getSymName()] = uniquePortName;
       portInfo.type =
           cast<PortOpInterface>(output.getOperation()).getPortType();
       portInfo.dir = hw::ModulePort::Direction::Output;
@@ -193,6 +207,9 @@ struct ContainerInstanceOpConversionPattern
     rewriter.setInsertionPoint(op);
     llvm::SmallVector<Value> operands;
 
+    const ContainerPortInfo &cpi =
+        portOrder.at(op.getResult().getType().getScopeRef());
+
     // Gather the get_port ops that target the instance
     llvm::DenseMap<StringAttr, PortReadOp> outputReadsToReplace;
     llvm::DenseMap<StringAttr, PortWriteOp> inputWritesToUse;
@@ -208,7 +225,9 @@ struct ContainerInstanceOpConversionPattern
             llvm::TypeSwitch<Operation *, LogicalResult>(user)
                 .Case<PortReadOp>([&](auto read) {
                   auto [it, inserted] = outputReadsToReplace.insert(
-                      {getPort.getPortSymbolAttr().getAttr(), read});
+                      {cpi.portSymbolsToPortName.at(
+                           getPort.getPortSymbolAttr().getAttr()),
+                       read});
                   if (!inserted)
                     return rewriter.notifyMatchFailure(
                         read, "expected only one ibis.port.read op of the "
@@ -217,7 +236,9 @@ struct ContainerInstanceOpConversionPattern
                 })
                 .Case<PortWriteOp>([&](auto write) {
                   auto [it, inserted] = inputWritesToUse.insert(
-                      {getPort.getPortSymbolAttr().getAttr(), write});
+                      {cpi.portSymbolsToPortName.at(
+                           getPort.getPortSymbolAttr().getAttr()),
+                       write});
                   if (!inserted)
                     return rewriter.notifyMatchFailure(
                         write,
@@ -238,8 +259,6 @@ struct ContainerInstanceOpConversionPattern
     }
 
     // Grab the operands in the order of the hw.module ports.
-    const ContainerPortInfo &cpi =
-        portOrder.at(op.getResult().getType().getScopeRef());
     size_t nInputPorts = std::distance(cpi.hwPorts->getInputs().begin(),
                                        cpi.hwPorts->getInputs().end());
     if (nInputPorts != inputWritesToUse.size()) {

--- a/lib/Dialect/Ibis/Transforms/IbisContainersToHW.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisContainersToHW.cpp
@@ -41,7 +41,7 @@ struct ContainerPortInfo {
   ContainerPortInfo() = default;
   ContainerPortInfo(ContainerOp container) {
     SmallVector<hw::PortInfo, 4> inputs, outputs;
-    auto ctx = container.getContext();
+    auto *ctx = container.getContext();
 
     // Copies all attributes from a port, except for the port symbol, name, and
     // type.

--- a/lib/Dialect/Ibis/Transforms/IbisMethodsToContainers.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisMethodsToContainers.cpp
@@ -45,18 +45,16 @@ struct DataflowMethodOpConversion
     for (auto [arg, name] : llvm::zip_equal(
              op.getArguments(), op.getArgNames().getAsRange<StringAttr>())) {
       auto port = rewriter.create<InputPortOp>(
-          arg.getLoc(), hw::InnerSymAttr::get(name), arg.getType());
+          arg.getLoc(), name, hw::InnerSymAttr::get(name), arg.getType());
       argValues.push_back(rewriter.create<PortReadOp>(arg.getLoc(), port));
     }
 
     ReturnOp returnOp = cast<ReturnOp>(op.getBodyBlock()->getTerminator());
     for (auto [idx, resType] : llvm::enumerate(
              cast<MethodLikeOpInterface>(op.getOperation()).getResultTypes())) {
+      auto portName = rewriter.getStringAttr("out" + std::to_string(idx));
       auto port = rewriter.create<OutputPortOp>(
-          op.getLoc(),
-          hw::InnerSymAttr::get(
-              rewriter.getStringAttr("out" + std::to_string(idx))),
-          resType);
+          op.getLoc(), portName, hw::InnerSymAttr::get(portName), resType);
       rewriter.create<PortWriteOp>(op.getLoc(), port, returnOp.getOperand(idx));
     }
 

--- a/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
@@ -66,7 +66,7 @@ public:
     if (d == Direction::Input) {
       // references to inputs becomes outputs (write from this container)
       auto rawOutput = rewriter.create<OutputPortOp>(
-          op.getLoc(), op.getInnerSym(), innerType);
+          op.getLoc(), op.getName(), op.getInnerSym(), innerType);
 
       // Replace writes to the unwrapped port with writes to the new port.
       for (auto *unwrappedPortUser :
@@ -81,7 +81,7 @@ public:
       }
     } else {
       // References to outputs becomes inputs (read from this container)
-      auto rawInput = rewriter.create<InputPortOp>(op.getLoc(),
+      auto rawInput = rewriter.create<InputPortOp>(op.getLoc(), op.getName(),
                                                    op.getInnerSym(), innerType);
       // TODO: RewriterBase::replaceAllUsesWith is not currently supported by
       // DialectConversion. Using it may lead to assertions about mutating
@@ -146,7 +146,7 @@ public:
       // Outputs of inputs are inputs (external driver into this container).
       // Create the raw input port and write the input port reference with a
       // read of the raw input port.
-      auto rawInput = rewriter.create<InputPortOp>(op.getLoc(),
+      auto rawInput = rewriter.create<InputPortOp>(op.getLoc(), op.getName(),
                                                    op.getInnerSym(), innerType);
       rewriter.create<PortWriteOp>(
           op.getLoc(), portWrapper.getValue(),
@@ -155,7 +155,7 @@ public:
       // Outputs of outputs are outputs (external driver out of this container).
       // Create the raw output port and do a read of the input port reference.
       auto rawOutput = rewriter.create<OutputPortOp>(
-          op.getLoc(), op.getInnerSym(), innerType);
+          op.getLoc(), op.getName(), op.getInnerSym(), innerType);
       rewriter.create<PortWriteOp>(
           op.getLoc(), rawOutput,
           rewriter.create<PortReadOp>(op.getLoc(), portWrapper.getValue()));
@@ -296,10 +296,9 @@ class GetPortConversionPattern : public OpConversionPattern<GetPortOp> {
           // this pattern to recurse and eventually reach the case where the
           // forwarding is resolved through reading/writing the intermediate
           // inputs.
+          auto fwPortName = rewriter.getStringAttr(portName.strref() + "_fw");
           auto forwardedInputPort = rewriter.create<InputPortOp>(
-              op.getLoc(),
-              hw::InnerSymAttr::get(
-                  rewriter.getStringAttr(portName.strref() + "_fw")),
+              op.getLoc(), fwPortName, hw::InnerSymAttr::get(fwPortName),
               innerType);
 
           // TODO: RewriterBase::replaceAllUsesWith is not currently supported

--- a/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisPortrefLowering.cpp
@@ -66,7 +66,7 @@ public:
     if (d == Direction::Input) {
       // references to inputs becomes outputs (write from this container)
       auto rawOutput = rewriter.create<OutputPortOp>(
-          op.getLoc(), op.getName(), op.getInnerSym(), innerType);
+          op.getLoc(), op.getNameAttr(), op.getInnerSym(), innerType);
 
       // Replace writes to the unwrapped port with writes to the new port.
       for (auto *unwrappedPortUser :
@@ -81,8 +81,8 @@ public:
       }
     } else {
       // References to outputs becomes inputs (read from this container)
-      auto rawInput = rewriter.create<InputPortOp>(op.getLoc(), op.getName(),
-                                                   op.getInnerSym(), innerType);
+      auto rawInput = rewriter.create<InputPortOp>(
+          op.getLoc(), op.getNameAttr(), op.getInnerSym(), innerType);
       // TODO: RewriterBase::replaceAllUsesWith is not currently supported by
       // DialectConversion. Using it may lead to assertions about mutating
       // replaced/erased ops. For now, do this RAUW directly, until
@@ -146,8 +146,8 @@ public:
       // Outputs of inputs are inputs (external driver into this container).
       // Create the raw input port and write the input port reference with a
       // read of the raw input port.
-      auto rawInput = rewriter.create<InputPortOp>(op.getLoc(), op.getName(),
-                                                   op.getInnerSym(), innerType);
+      auto rawInput = rewriter.create<InputPortOp>(
+          op.getLoc(), op.getNameAttr(), op.getInnerSym(), innerType);
       rewriter.create<PortWriteOp>(
           op.getLoc(), portWrapper.getValue(),
           rewriter.create<PortReadOp>(op.getLoc(), rawInput));
@@ -155,7 +155,7 @@ public:
       // Outputs of outputs are outputs (external driver out of this container).
       // Create the raw output port and do a read of the input port reference.
       auto rawOutput = rewriter.create<OutputPortOp>(
-          op.getLoc(), op.getName(), op.getInnerSym(), innerType);
+          op.getLoc(), op.getNameAttr(), op.getInnerSym(), innerType);
       rewriter.create<PortWriteOp>(
           op.getLoc(), rawOutput,
           rewriter.create<PortReadOp>(op.getLoc(), portWrapper.getValue()));

--- a/lib/Dialect/Ibis/Transforms/IbisTunneling.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisTunneling.cpp
@@ -296,7 +296,8 @@ LogicalResult Tunneler::tunnelDown(InstanceGraphNode *currentContainer,
   llvm::DenseMap<StringAttr, OutputPortOp> outputPortOps;
   for (PortInfo &pi : portInfos) {
     outputPortOps[pi.portName] = rewriter.create<OutputPortOp>(
-        op.getLoc(), circt::hw::InnerSymAttr::get(pi.portName), pi.getType());
+        op.getLoc(), pi.portName, circt::hw::InnerSymAttr::get(pi.portName),
+        pi.getType());
   }
 
   // Recurse into the tunnel instance container.
@@ -375,7 +376,8 @@ LogicalResult Tunneler::tunnelUp(InstanceGraphNode *currentContainer,
   rewriter.setInsertionPointToEnd(scopeOp.getBodyBlock());
   for (PortInfo &pi : portInfos) {
     auto inputPort = rewriter.create<InputPortOp>(
-        op.getLoc(), hw::InnerSymAttr::get(pi.portName), pi.getType());
+        op.getLoc(), pi.portName, hw::InnerSymAttr::get(pi.portName),
+        pi.getType());
     // Read the input port of the current container to forward the portref.
 
     portMapping[&pi] =

--- a/test/Dialect/Ibis/Transforms/clean_selfdrivers.mlir
+++ b/test/Dialect/Ibis/Transforms/clean_selfdrivers.mlir
@@ -4,14 +4,14 @@ ibis.design @D {
 // CHECK-LABEL:   ibis.container @C {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@D::@C>
 // CHECK:           %[[VAL_1:.*]] = hw.wire %[[VAL_2:.*]]  : i1
-// CHECK:           %[[VAL_3:.*]] = ibis.port.output @out : i1
+// CHECK:           %[[VAL_3:.*]] = ibis.port.output "out" sym @out : i1
 // CHECK:           %[[VAL_2]] = hw.constant true
 // CHECK:           ibis.port.write %[[VAL_3]], %[[VAL_1]] : !ibis.portref<out i1>
 // CHECK:         }
 ibis.container @C {
     %this = ibis.this <@D::@C>
-    %in = ibis.port.input @in : i1
-    %out = ibis.port.output @out : i1
+    %in = ibis.port.input "in" sym @in : i1
+    %out = ibis.port.output "out" sym @out : i1
     %true = hw.constant 1 : i1
     ibis.port.write %in, %true : !ibis.portref<in i1>
     %v = ibis.port.read %in : !ibis.portref<in i1>
@@ -26,7 +26,7 @@ ibis.design @D {
 // CHECK-LABEL:   ibis.container @Selfdriver {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@D::@Selfdriver>
 // CHECK:           %[[VAL_1:.*]] = hw.wire %[[VAL_2:.*]]  : i1
-// CHECK:           %[[VAL_3:.*]] = ibis.port.output @in : i1
+// CHECK:           %[[VAL_3:.*]] = ibis.port.output "in" sym @in : i1
 // CHECK:           ibis.port.write %[[VAL_3]], %[[VAL_1]] : !ibis.portref<out i1>
 // CHECK:           %[[VAL_2]] = hw.constant true
 // CHECK:         }
@@ -40,7 +40,7 @@ ibis.design @D {
 
 ibis.container @Selfdriver {
   %this = ibis.this <@D::@Selfdriver>
-  %in = ibis.port.input @in : i1
+  %in = ibis.port.input "in" sym @in : i1
   %true = hw.constant 1 : i1
   ibis.port.write %in, %true : !ibis.portref<in i1>
 }
@@ -60,7 +60,7 @@ ibis.design @D {
 
 ibis.container @Foo {
   %this = ibis.this <@D::@Foo>
-  %in = ibis.port.input @in : i1
+  %in = ibis.port.input "in" sym @in : i1
 }
 
 // CHECK-LABEL:   ibis.container @ParentReaderWriter {

--- a/test/Dialect/Ibis/Transforms/containerize.mlir
+++ b/test/Dialect/Ibis/Transforms/containerize.mlir
@@ -8,7 +8,7 @@ ibis.design @foo {
 // CHECK-LABEL:   ibis.container @A_C
 // CHECK-LABEL:   ibis.container @A {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@foo::@A>
-// CHECK:           ibis.port.input @A_in : i1
+// CHECK:           ibis.port.input "A_in" sym @A_in : i1
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @myClass, <@foo::@MyClass>
 // CHECK:           %[[VAL_2:.*]] = ibis.container.instance @A_B_0, <@foo::@A_B_0>
 // CHECK:           %[[VAL_3:.*]] = ibis.container.instance @A_C, <@foo::@A_C>
@@ -25,7 +25,7 @@ ibis.class @MyClass {
 
 ibis.class @A {
   %this = ibis.this <@foo::@A>
-  ibis.port.input @A_in : i1
+  ibis.port.input "A_in" sym @A_in : i1
   %myClass = ibis.instance @myClass, <@foo::@MyClass>
   ibis.container @B {
     %B_this = ibis.this <@foo::@B>

--- a/test/Dialect/Ibis/Transforms/methods_to_containers.mlir
+++ b/test/Dialect/Ibis/Transforms/methods_to_containers.mlir
@@ -4,9 +4,9 @@
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@foo::@ToContainers>
 // CHECK:           ibis.container @foo {
 // CHECK:             %[[VAL_1:.*]] = ibis.this <@foo::@foo>
-// CHECK:             %[[VAL_2:.*]] = ibis.port.input @arg0 : !dc.value<i32>
+// CHECK:             %[[VAL_2:.*]] = ibis.port.input "arg0" sym @arg0 : !dc.value<i32>
 // CHECK:             %[[VAL_3:.*]] = ibis.port.read %[[VAL_2]] : !ibis.portref<in !dc.value<i32>>
-// CHECK:             %[[VAL_4:.*]] = ibis.port.output @out0 : !dc.value<i32>
+// CHECK:             %[[VAL_4:.*]] = ibis.port.output "out0" sym @out0 : !dc.value<i32>
 // CHECK:             ibis.port.write %[[VAL_4]], %[[VAL_5:.*]] : !ibis.portref<out !dc.value<i32>>
 // CHECK:             %[[VAL_6:.*]], %[[VAL_7:.*]] = dc.unpack %[[VAL_3]] : !dc.value<i32>
 // CHECK:             %[[VAL_8:.*]]:2 = dc.fork [2] %[[VAL_6]]

--- a/test/Dialect/Ibis/Transforms/path_end_to_end.mlir
+++ b/test/Dialect/Ibis/Transforms/path_end_to_end.mlir
@@ -65,8 +65,8 @@ ibis.container @C_down {
 }
 ibis.container @D_down {
   %this = ibis.this <@foo::@D_down>
-  %clk = ibis.port.input @clk_in : i1
-  %clk_out = ibis.port.output @clk_out : i1
+  %clk = ibis.port.input "clk_in" sym @clk_in : i1
+  %clk_out = ibis.port.output "clk_out" sym @clk_out : i1
   %clk.val = ibis.port.read %clk : !ibis.portref<in i1>
   ibis.port.write %clk_out, %clk.val : !ibis.portref<out i1>
 }

--- a/test/Dialect/Ibis/Transforms/portref_lowering.mlir
+++ b/test/Dialect/Ibis/Transforms/portref_lowering.mlir
@@ -4,22 +4,22 @@ ibis.design @D {
 
 ibis.container @C {
   %this = ibis.this <@D::@C> 
-  %in = ibis.port.input @in : i1
-  %out = ibis.port.output @out : i1
+  %in = ibis.port.input "in" sym @in : i1
+  %out = ibis.port.output "out" sym @out : i1
 }
 
 // CHECK-LABEL:   ibis.container @AccessSibling {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@D::@AccessSibling>
-// CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_b_out : i1
-// CHECK:           %[[VAL_2:.*]] = ibis.port.output @p_b_in : i1
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input "p_b_out" sym @p_b_out : i1
+// CHECK:           %[[VAL_2:.*]] = ibis.port.output "p_b_in" sym @p_b_in : i1
 // CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_3:.*]] : !ibis.portref<out i1>
 // CHECK:           %[[VAL_3]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in i1>
 // CHECK:         }
 ibis.container @AccessSibling {
   %this = ibis.this <@D::@AccessSibling> 
-  %p_b_out = ibis.port.input @p_b_out : !ibis.portref<out i1>
+  %p_b_out = ibis.port.input "p_b_out" sym @p_b_out : !ibis.portref<out i1>
   %p_b_out_val = ibis.port.read %p_b_out : !ibis.portref<in !ibis.portref<out i1>>
-  %p_b_in = ibis.port.input @p_b_in : !ibis.portref<in i1>
+  %p_b_in = ibis.port.input "p_b_in" sym @p_b_in : !ibis.portref<in i1>
   %p_b_in_val = ibis.port.read %p_b_in : !ibis.portref<in !ibis.portref<in i1>>
 
   // Loopback to ensure that value replacement is performed.
@@ -61,14 +61,14 @@ ibis.design @D {
 
 // CHECK-LABEL:   ibis.container @ParentPortAccess {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@D::@ParentPortAccess>
-// CHECK:           %[[VAL_1:.*]] = ibis.port.output @p_in : i1
-// CHECK:           %[[VAL_2:.*]] = ibis.port.input @p_out : i1
+// CHECK:           %[[VAL_1:.*]] = ibis.port.output "p_in" sym @p_in : i1
+// CHECK:           %[[VAL_2:.*]] = ibis.port.input "p_out" sym @p_out : i1
 // CHECK:         }
 ibis.container @ParentPortAccess {
   %this = ibis.this <@D::@ParentPortAccess> 
-  %p_in = ibis.port.input @p_in : !ibis.portref<in i1>
+  %p_in = ibis.port.input "p_in" sym @p_in : !ibis.portref<in i1>
   %p_in_val = ibis.port.read %p_in : !ibis.portref<in !ibis.portref<in i1>>
-  %p_out = ibis.port.input @p_out : !ibis.portref<out i1>
+  %p_out = ibis.port.input "p_out" sym @p_out : !ibis.portref<out i1>
   %p_out_val = ibis.port.read %p_out : !ibis.portref<in !ibis.portref<out i1>>
 }
 
@@ -81,8 +81,8 @@ ibis.container @ParentPortAccess {
 // CHECK:           %[[VAL_5:.*]] = ibis.get_port %[[VAL_1]], @p_out : !ibis.scoperef<@D::@ParentPortAccess> -> !ibis.portref<in i1>
 // CHECK:           %[[VAL_6:.*]] = ibis.port.read %[[VAL_7:.*]] : !ibis.portref<out i1>
 // CHECK:           ibis.port.write %[[VAL_5]], %[[VAL_6]] : !ibis.portref<in i1>
-// CHECK:           %[[VAL_4]] = ibis.port.input @in : i1
-// CHECK:           %[[VAL_7]] = ibis.port.output @out : i1
+// CHECK:           %[[VAL_4]] = ibis.port.input "in" sym @in : i1
+// CHECK:           %[[VAL_7]] = ibis.port.output "out" sym @out : i1
 // CHECK:         }
 ibis.container @Parent {
   %this = ibis.this <@D::@Parent> 
@@ -91,8 +91,8 @@ ibis.container @Parent {
   ibis.port.write %c.p_in, %in : !ibis.portref<in !ibis.portref<in i1>>
   %c.p_out = ibis.get_port %c, @p_out : !ibis.scoperef<@D::@ParentPortAccess> -> !ibis.portref<in !ibis.portref<out i1>>
   ibis.port.write %c.p_out, %out : !ibis.portref<in !ibis.portref<out i1>>
-  %in = ibis.port.input @in : i1
-  %out = ibis.port.output @out : i1
+  %in = ibis.port.input "in" sym @in : i1
+  %out = ibis.port.output "out" sym @out : i1
 }
 
 }
@@ -106,15 +106,15 @@ ibis.design @D {
 
 // CHECK-LABEL:   ibis.container @C1 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@D::@C1>
-// CHECK:           %[[VAL_1:.*]] = ibis.port.output @parent_parent_c2_c3_in : i1
+// CHECK:           %[[VAL_1:.*]] = ibis.port.output "parent_parent_c2_c3_in" sym @parent_parent_c2_c3_in : i1
 // CHECK:           ibis.port.write %[[VAL_1]], %[[VAL_2:.*]] : !ibis.portref<out i1>
-// CHECK:           %[[VAL_3:.*]] = ibis.port.input @parent_parent_c2_c3_out : i1
+// CHECK:           %[[VAL_3:.*]] = ibis.port.input "parent_parent_c2_c3_out" sym @parent_parent_c2_c3_out : i1
 // CHECK:           %[[VAL_2]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in i1>
 // CHECK:         }
 ibis.container @C1 {
   %this = ibis.this <@D::@C1> 
-  %parent_parent_c2_c3_in = ibis.port.input @parent_parent_c2_c3_in : !ibis.portref<in i1>
-  %parent_parent_c2_c3_out = ibis.port.input @parent_parent_c2_c3_out : !ibis.portref<out i1>
+  %parent_parent_c2_c3_in = ibis.port.input "parent_parent_c2_c3_in" sym @parent_parent_c2_c3_in : !ibis.portref<in i1>
+  %parent_parent_c2_c3_out = ibis.port.input "parent_parent_c2_c3_out" sym @parent_parent_c2_c3_out : !ibis.portref<out i1>
 
   // Assignment drivers - unwrap the ports and roundtrip read-write.
   %parent_b_in_unwrapped = ibis.port.read %parent_parent_c2_c3_in : !ibis.portref<in !ibis.portref<in i1>>
@@ -128,10 +128,10 @@ ibis.container @C1 {
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c3, <@D::@C>
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @in : !ibis.scoperef<@D::@C> -> !ibis.portref<in i1>
 // CHECK:           %[[VAL_3:.*]] = ibis.get_port %[[VAL_1]], @out : !ibis.scoperef<@D::@C> -> !ibis.portref<out i1>
-// CHECK:           %[[VAL_4:.*]] = ibis.port.input @parent_parent_c2_c3_in : i1
+// CHECK:           %[[VAL_4:.*]] = ibis.port.input "parent_parent_c2_c3_in" sym @parent_parent_c2_c3_in : i1
 // CHECK:           %[[VAL_5:.*]] = ibis.port.read %[[VAL_4]] : !ibis.portref<in i1>
 // CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_5]] : !ibis.portref<in i1>
-// CHECK:           %[[VAL_6:.*]] = ibis.port.output @parent_parent_c2_c3_out : i1
+// CHECK:           %[[VAL_6:.*]] = ibis.port.output "parent_parent_c2_c3_out" sym @parent_parent_c2_c3_out : i1
 // CHECK:           %[[VAL_7:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<out i1>
 // CHECK:           ibis.port.write %[[VAL_6]], %[[VAL_7]] : !ibis.portref<out i1>
 // CHECK:         }
@@ -140,15 +140,15 @@ ibis.container @C2 {
   %c3 = ibis.container.instance @c3, <@D::@C> 
   %c3.in = ibis.get_port %c3, @in : !ibis.scoperef<@D::@C> -> !ibis.portref<in i1>
   %c3.out = ibis.get_port %c3, @out : !ibis.scoperef<@D::@C> -> !ibis.portref<out i1>
-  %parent_parent_c2_c3_in = ibis.port.output @parent_parent_c2_c3_in : !ibis.portref<in i1>
-  %parent_parent_c2_c3_out = ibis.port.output @parent_parent_c2_c3_out : !ibis.portref<out i1>
+  %parent_parent_c2_c3_in = ibis.port.output "parent_parent_c2_c3_in" sym @parent_parent_c2_c3_in : !ibis.portref<in i1>
+  %parent_parent_c2_c3_out = ibis.port.output "parent_parent_c2_c3_out" sym @parent_parent_c2_c3_out : !ibis.portref<out i1>
   ibis.port.write %parent_parent_c2_c3_in, %c3.in : !ibis.portref<out !ibis.portref<in i1>>
   ibis.port.write %parent_parent_c2_c3_out, %c3.out : !ibis.portref<out !ibis.portref<out i1>>
 }
 ibis.container @C {
   %this = ibis.this <@D::@C> 
-  %in = ibis.port.input @in : i1
-  %out = ibis.port.output @out : i1
+  %in = ibis.port.input "in" sym @in : i1
+  %out = ibis.port.output "out" sym @out : i1
 }
 
 // CHECK-LABEL:   ibis.container @P1 {
@@ -159,9 +159,9 @@ ibis.container @C {
 // CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @parent_parent_c2_c3_out : !ibis.scoperef<@D::@C1> -> !ibis.portref<in i1>
 // CHECK:           %[[VAL_5:.*]] = ibis.port.read %[[VAL_6:.*]] : !ibis.portref<in i1>
 // CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_5]] : !ibis.portref<in i1>
-// CHECK:           %[[VAL_7:.*]] = ibis.port.output @parent_parent_c2_c3_in : i1
+// CHECK:           %[[VAL_7:.*]] = ibis.port.output "parent_parent_c2_c3_in" sym @parent_parent_c2_c3_in : i1
 // CHECK:           ibis.port.write %[[VAL_7]], %[[VAL_3]] : !ibis.portref<out i1>
-// CHECK:           %[[VAL_6]] = ibis.port.input @parent_parent_c2_c3_out : i1
+// CHECK:           %[[VAL_6]] = ibis.port.input "parent_parent_c2_c3_out" sym @parent_parent_c2_c3_out : i1
 // CHECK:         }
 ibis.container @P1 {
   %this = ibis.this <@D::@P1> 
@@ -170,9 +170,9 @@ ibis.container @P1 {
   ibis.port.write %c1.parent_parent_c2_c3_in, %0 : !ibis.portref<in !ibis.portref<in i1>>
   %c1.parent_parent_c2_c3_out = ibis.get_port %c1, @parent_parent_c2_c3_out : !ibis.scoperef<@D::@C1> -> !ibis.portref<in !ibis.portref<out i1>>
   ibis.port.write %c1.parent_parent_c2_c3_out, %1 : !ibis.portref<in !ibis.portref<out i1>>
-  %parent_parent_c2_c3_in = ibis.port.input @parent_parent_c2_c3_in : !ibis.portref<in i1>
+  %parent_parent_c2_c3_in = ibis.port.input "parent_parent_c2_c3_in" sym @parent_parent_c2_c3_in : !ibis.portref<in i1>
   %0 = ibis.port.read %parent_parent_c2_c3_in : !ibis.portref<in !ibis.portref<in i1>>
-  %parent_parent_c2_c3_out = ibis.port.input @parent_parent_c2_c3_out : !ibis.portref<out i1>
+  %parent_parent_c2_c3_out = ibis.port.input "parent_parent_c2_c3_out" sym @parent_parent_c2_c3_out : !ibis.portref<out i1>
   %1 = ibis.port.read %parent_parent_c2_c3_out : !ibis.portref<in !ibis.portref<out i1>>
 }
 
@@ -187,7 +187,7 @@ ibis.container @P1 {
 // CHECK:           ibis.port.write %[[VAL_5]], %[[VAL_6]] : !ibis.portref<in i1>
 // CHECK:           %[[VAL_8:.*]] = ibis.container.instance @c2, <@D::@C2>
 // CHECK:           %[[VAL_7]] = ibis.get_port %[[VAL_8]], @parent_parent_c2_c3_out : !ibis.scoperef<@D::@C2> -> !ibis.portref<out i1>
-// CHECK:           %[[VAL_4]] = ibis.port.input @parent_parent_c2_c3_in_fw : i1
+// CHECK:           %[[VAL_4]] = ibis.port.input "parent_parent_c2_c3_in_fw" sym @parent_parent_c2_c3_in_fw : i1
 // CHECK:           %[[VAL_9:.*]] = ibis.port.read %[[VAL_4]] : !ibis.portref<in i1>
 // CHECK:           %[[VAL_10:.*]] = ibis.get_port %[[VAL_8]], @parent_parent_c2_c3_in : !ibis.scoperef<@D::@C2> -> !ibis.portref<in i1>
 // CHECK:           ibis.port.write %[[VAL_10]], %[[VAL_9]] : !ibis.portref<in i1>
@@ -215,23 +215,23 @@ ibis.design @D {
 
 // CHECK-LABEL:   ibis.container @AccessParent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@D::@AccessParent>
-// CHECK:           %[[VAL_1:.*]] = ibis.port.output @p_out : i1
-// CHECK:           %[[VAL_2:.*]] = ibis.port.input @p_in : i1
+// CHECK:           %[[VAL_1:.*]] = ibis.port.output "p_out" sym @p_out : i1
+// CHECK:           %[[VAL_2:.*]] = ibis.port.input "p_in" sym @p_in : i1
 // CHECK:         }
 ibis.container @AccessParent {
   %this = ibis.this <@D::@AccessParent> 
-  %p_out = ibis.port.input @p_out : !ibis.portref<in i1>
+  %p_out = ibis.port.input "p_out" sym @p_out : !ibis.portref<in i1>
   %p_out.val = ibis.port.read %p_out : !ibis.portref<in !ibis.portref<in i1>>
-  %p_in = ibis.port.input @p_in : !ibis.portref<out i1>
+  %p_in = ibis.port.input "p_in" sym @p_in : !ibis.portref<out i1>
   %p_in.val = ibis.port.read %p_in : !ibis.portref<in !ibis.portref<out i1>>
 }
 
 // CHECK-LABEL:   ibis.container @Parent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@D::@Parent>
-// CHECK:           %[[VAL_1:.*]] = ibis.port.input @in : i1
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input "in" sym @in : i1
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in i1>
 // CHECK:           %[[VAL_3:.*]] = ibis.wire.output @in.rd, %[[VAL_2]] : i1
-// CHECK:           %[[VAL_4:.*]] = ibis.port.output @out : i1
+// CHECK:           %[[VAL_4:.*]] = ibis.port.output "out" sym @out : i1
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = ibis.wire.input @out.wr : i1
 // CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_6]] : !ibis.portref<out i1>
 // CHECK:           %[[VAL_7:.*]] = ibis.container.instance @c, <@D::@AccessParent>
@@ -244,10 +244,10 @@ ibis.container @AccessParent {
 // CHECK:         }
 ibis.container @Parent {
   %this = ibis.this <@D::@Parent> 
-  %in = ibis.port.input @in : i1
+  %in = ibis.port.input "in" sym @in : i1
   %in.val = ibis.port.read %in : !ibis.portref<in i1>
   %in.rd = ibis.wire.output @in.rd, %in.val : i1
-  %out = ibis.port.output @out : i1
+  %out = ibis.port.output "out" sym @out : i1
   %out.wr, %out.wr.out = ibis.wire.input @out.wr : i1
   ibis.port.write %out, %out.wr.out : !ibis.portref<out i1>
   %c = ibis.container.instance @c, <@D::@AccessParent> 

--- a/test/Dialect/Ibis/Transforms/scoperef_tunneling.mlir
+++ b/test/Dialect/Ibis/Transforms/scoperef_tunneling.mlir
@@ -4,8 +4,8 @@ ibis.design @D {
 
 ibis.container @C {
   %this = ibis.this <@D::@C>
-  %in = ibis.port.input @in : i1
-%out = ibis.port.output @out : i1
+  %in = ibis.port.input "in" sym @in : i1
+  %out = ibis.port.output "out" sym @out : i1
 }
 
 // CHECK-LABEL:   ibis.container @AccessChild {
@@ -33,15 +33,15 @@ ibis.container @AccessChild {
 ibis.design @D {
 ibis.container @C {
   %this = ibis.this <@D::@C>
-  %in = ibis.port.input @in : i1
-  %out = ibis.port.output @out : i1
+  %in = ibis.port.input "in" sym @in : i1
+  %out = ibis.port.output "out" sym @out : i1
 }
 
 // CHECK-LABEL:   ibis.container @AccessSibling {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@D::@AccessSibling>
-// CHECK:           %[[VAL_1:.*]] = ibis.port.input @[[VAL_1]] : !ibis.portref<out i1>
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input "[[VAL_1]]" sym @[[VAL_1]] : !ibis.portref<out i1>
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in !ibis.portref<out i1>>
-// CHECK:           %[[VAL_3:.*]] = ibis.port.input @[[VAL_3]] : !ibis.portref<in i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.input "[[VAL_3]]" sym @[[VAL_3]] : !ibis.portref<in i1>
 // CHECK:           %[[VAL_4:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:         }
 ibis.container @AccessSibling {
@@ -82,9 +82,9 @@ ibis.container @Parent {
 ibis.design @D {
 // CHECK-LABEL:   ibis.container @C1 {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@D::@C1>
-// CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_p_c2_c3_out.rd : !ibis.portref<out i1>
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input "p_p_c2_c3_out.rd" sym @p_p_c2_c3_out.rd : !ibis.portref<out i1>
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in !ibis.portref<out i1>>
-// CHECK:           %[[VAL_3:.*]] = ibis.port.input @p_p_c2_c3_in.wr : !ibis.portref<in i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.input "p_p_c2_c3_in.wr" sym @p_p_c2_c3_in.wr : !ibis.portref<in i1>
 // CHECK:           %[[VAL_4:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:         }
 ibis.container @C1 {
@@ -104,8 +104,8 @@ ibis.container @C1 {
 // CHECK:           %[[VAL_1:.*]] = ibis.container.instance @c3, <@D::@C>
 // CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_1]], @out : !ibis.scoperef<@D::@C> -> !ibis.portref<out i1>
 // CHECK:           %[[VAL_3:.*]] = ibis.get_port %[[VAL_1]], @in : !ibis.scoperef<@D::@C> -> !ibis.portref<in i1>
-// CHECK:           %[[VAL_4:.*]] = ibis.port.output @p_p_c2_c3_out.rd : !ibis.portref<out i1>
-// CHECK:           %[[VAL_5:.*]] = ibis.port.output @p_p_c2_c3_in.wr : !ibis.portref<in i1>
+// CHECK:           %[[VAL_4:.*]] = ibis.port.output "p_p_c2_c3_out.rd" sym @p_p_c2_c3_out.rd : !ibis.portref<out i1>
+// CHECK:           %[[VAL_5:.*]] = ibis.port.output "p_p_c2_c3_in.wr" sym @p_p_c2_c3_in.wr : !ibis.portref<in i1>
 // CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_2]] : !ibis.portref<out !ibis.portref<out i1>>
 // CHECK:           ibis.port.write %[[VAL_5]], %[[VAL_3]] : !ibis.portref<out !ibis.portref<in i1>>
 // CHECK:         }
@@ -116,8 +116,8 @@ ibis.container @C2 {
 
 ibis.container @C {
   %this = ibis.this <@D::@C>
-  %in = ibis.port.input @in : i1
-  %out = ibis.port.output @out : i1
+  %in = ibis.port.input "in" sym @in : i1
+  %out = ibis.port.output "out" sym @out : i1
 }
 
 // CHECK-LABEL:   ibis.container @P1 {
@@ -127,9 +127,9 @@ ibis.container @C {
 // CHECK:           ibis.port.write %[[VAL_2]], %[[VAL_3:.*]] : !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:           %[[VAL_4:.*]] = ibis.get_port %[[VAL_1]], @p_p_c2_c3_in.wr : !ibis.scoperef<@D::@C1> -> !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_5:.*]] : !ibis.portref<in !ibis.portref<in i1>>
-// CHECK:           %[[VAL_6:.*]] = ibis.port.input @p_p_c2_c3_out.rd : !ibis.portref<out i1>
+// CHECK:           %[[VAL_6:.*]] = ibis.port.input "p_p_c2_c3_out.rd" sym @p_p_c2_c3_out.rd : !ibis.portref<out i1>
 // CHECK:           %[[VAL_3]] = ibis.port.read %[[VAL_6]] : !ibis.portref<in !ibis.portref<out i1>>
-// CHECK:           %[[VAL_7:.*]] = ibis.port.input @p_p_c2_c3_in.wr : !ibis.portref<in i1>
+// CHECK:           %[[VAL_7:.*]] = ibis.port.input "p_p_c2_c3_in.wr" sym @p_p_c2_c3_in.wr : !ibis.portref<in i1>
 // CHECK:           %[[VAL_5]] = ibis.port.read %[[VAL_7]] : !ibis.portref<in !ibis.portref<in i1>>
 // CHECK:         }
 ibis.container @P1 {
@@ -164,9 +164,9 @@ ibis.container @P2 {
 ibis.design @D {
 // CHECK-LABEL:   ibis.container @AccessParent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@D::@AccessParent>
-// CHECK:           %[[VAL_1:.*]] = ibis.port.input @p_out.wr : !ibis.portref<in i1>
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input "p_out.wr" sym @p_out.wr : !ibis.portref<in i1>
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in !ibis.portref<in i1>>
-// CHECK:           %[[VAL_3:.*]] = ibis.port.input @p_in.rd : !ibis.portref<out i1>
+// CHECK:           %[[VAL_3:.*]] = ibis.port.input "p_in.rd" sym @p_in.rd : !ibis.portref<out i1>
 // CHECK:           %[[VAL_4:.*]] = ibis.port.read %[[VAL_3]] : !ibis.portref<in !ibis.portref<out i1>>
 // CHECK:         }
 ibis.container @AccessParent {
@@ -185,10 +185,10 @@ ibis.container @AccessParent {
 
 // CHECK-LABEL:   ibis.container @Parent {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@D::@Parent>
-// CHECK:           %[[VAL_1:.*]] = ibis.port.input @in : i1
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input "in" sym @in : i1
 // CHECK:           %[[VAL_2:.*]] = ibis.port.read %[[VAL_1]] : !ibis.portref<in i1>
 // CHECK:           %[[VAL_3:.*]] = ibis.wire.output @in.rd, %[[VAL_2]] : i1
-// CHECK:           %[[VAL_4:.*]] = ibis.port.output @out : i1
+// CHECK:           %[[VAL_4:.*]] = ibis.port.output "out" sym @out : i1
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = ibis.wire.input @out.wr : i1
 // CHECK:           ibis.port.write %[[VAL_4]], %[[VAL_6]] : !ibis.portref<out i1>
 // CHECK:           %[[VAL_7:.*]] = ibis.container.instance @c, <@D::@AccessParent>
@@ -199,8 +199,8 @@ ibis.container @AccessParent {
 // CHECK:         }
 ibis.container @Parent {
   %this = ibis.this <@D::@Parent>
-  %in = ibis.port.input @in : i1
-  %out = ibis.port.output @out : i1
+  %in = ibis.port.input "in" sym @in : i1
+  %out = ibis.port.output "out" sym @out : i1
   %c = ibis.container.instance @c, <@D::@AccessParent>
 }
 
@@ -213,8 +213,8 @@ ibis.design @D {
 
 ibis.container @C {
   %this = ibis.this <@D::@C>
-  %in = ibis.port.input @in : i1
-  %out = ibis.port.output @out : i1
+  %in = ibis.port.input "in" sym @in : i1
+  %out = ibis.port.output "out" sym @out : i1
 }
 
 // TODO: support this case. Too hard to support now. Problem is that hw.module
@@ -306,8 +306,8 @@ ibis.container @C_down {
 }
 ibis.container @D_down {
   %this = ibis.this <@D::@D_down>
-  %clk = ibis.port.input @clk_in : i1
-  %clk_out = ibis.port.output @clk_out : i1
+  %clk = ibis.port.input "clk_in" sym @clk_in : i1
+  %clk_out = ibis.port.output "clk_out" sym @clk_out : i1
   %clk.val = ibis.port.read %clk : !ibis.portref<in i1>
   ibis.port.write %clk_out, %clk.val : !ibis.portref<out i1>
 }

--- a/test/Dialect/Ibis/Transforms/tunneling_errors.mlir
+++ b/test/Dialect/Ibis/Transforms/tunneling_errors.mlir
@@ -3,7 +3,7 @@
 ibis.design @foo {
 ibis.container @Parent {
   %this = ibis.this <@foo::@Parent>
-  %in = ibis.port.input @in : i1
+  %in = ibis.port.input "in" sym @in : i1
 }
 
 ibis.container @Orphan {
@@ -27,7 +27,7 @@ ibis.container @Parent {
 
 ibis.container @Child {
   %this = ibis.this <@foo::@Child>
-  %in = ibis.port.input @in : i1
+  %in = ibis.port.input "in" sym @in : i1
 }
 
 ibis.container @MissingChild {

--- a/test/Dialect/Ibis/canonicalization.mlir
+++ b/test/Dialect/Ibis/canonicalization.mlir
@@ -4,12 +4,12 @@ ibis.design @foo {
 
 // CHECK-LABEL:   ibis.container @GetPortOnThis {
 // CHECK:           %[[VAL_0:.*]] = ibis.this <@foo::@GetPortOnThis>
-// CHECK:           %[[VAL_1:.*]] = ibis.port.input @in : i1
+// CHECK:           %[[VAL_1:.*]] = ibis.port.input "in" sym @in : i1
 // CHECK:           "foo.user"(%[[VAL_1]]) : (!ibis.portref<in i1>) -> ()
 // CHECK:         }
 ibis.container @GetPortOnThis {
   %this = ibis.this <@foo::@GetPortOnThis>
-  %p = ibis.port.input @in : i1
+  %p = ibis.port.input "in" sym @in : i1
   %p2 = ibis.get_port %this, @in : !ibis.scoperef<@foo::@GetPortOnThis> -> !ibis.portref<in i1>
   "foo.user"(%p2) : (!ibis.portref<in i1>) -> ()
 }

--- a/test/Dialect/Ibis/errors.mlir
+++ b/test/Dialect/Ibis/errors.mlir
@@ -94,13 +94,3 @@ ibis.class @InvalidReturn {
   }
 }
 }
-
-// -----
-
-ibis.design @foo {
-ibis.container @B {
-  %this = ibis.this <@foo::@B>
-  // expected-error @+1 {{'ibis.port.input' op port name cannot be empty}}
-  %in = ibis.port.input "" sym @in : i1
-}
-}

--- a/test/Dialect/Ibis/errors.mlir
+++ b/test/Dialect/Ibis/errors.mlir
@@ -94,3 +94,13 @@ ibis.class @InvalidReturn {
   }
 }
 }
+
+// -----
+
+ibis.design @foo {
+ibis.container @B {
+  %this = ibis.this <@foo::@B>
+  // expected-error @+1 {{'ibis.port.input' op port name cannot be empty}}
+  %in = ibis.port.input "" sym @in : i1
+}
+}

--- a/test/Dialect/Ibis/inner_ref_errors.mlir
+++ b/test/Dialect/Ibis/inner_ref_errors.mlir
@@ -47,7 +47,7 @@ ibis.class @InvalidGetVar {
 ibis.design @foo {
 ibis.class @PortTypeMismatch {
   %this = ibis.this <@foo::@PortTypeMismatch>
-  ibis.port.input @in : i1
+  ibis.port.input "in" sym @in : i1
   // expected-error @+1 {{'ibis.get_port' op symbol '@in' refers to a port of type 'i1', but this op has type 'i2'}}
   %c_in = ibis.get_port %this, @in : !ibis.scoperef<@foo::@PortTypeMismatch> -> !ibis.portref<in i2>
 }

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -56,14 +56,14 @@ ibis.class @HighLevel {
 
 // CHECK-LABEL:  ibis.class @A {
 // CHECK-NEXT:    %this = ibis.this <@foo::@A> 
-// CHECK-NEXT:    %in = ibis.port.input @in : i1
-// CHECK-NEXT:    %out = ibis.port.output @out : i1
+// CHECK-NEXT:    %in = ibis.port.input "in" sym @in : i1
+// CHECK-NEXT:    %out = ibis.port.output "out" sym @out : i1
 // CHECK-NEXT:  }
 
 // CHECK-LABEL:  ibis.class @LowLevel {
 // CHECK-NEXT:    %this = ibis.this <@foo::@LowLevel> 
-// CHECK-NEXT:    %LowLevel_in = ibis.port.input @LowLevel_in : i1
-// CHECK-NEXT:    %LowLevel_out = ibis.port.output @LowLevel_out : i1
+// CHECK-NEXT:    %LowLevel_in = ibis.port.input "LowLevel_in" sym @LowLevel_in : i1
+// CHECK-NEXT:    %LowLevel_out = ibis.port.output "LowLevel_out" sym @LowLevel_out : i1
 // CHECK-NEXT:    %in_wire, %in_wire.out = ibis.wire.input @in_wire : i1
 // CHECK-NEXT:    %true = hw.constant true
 // CHECK-NEXT:    %out_wire = ibis.wire.output @out_wire, %true : i1
@@ -87,14 +87,14 @@ ibis.class @HighLevel {
 
 ibis.class @A {
   %this = ibis.this <@foo::@A>
-  ibis.port.input @in : i1
-  ibis.port.output @out : i1
+  ibis.port.input "in" sym @in : i1
+  ibis.port.output "out" sym @out : i1
 }
 
 ibis.class @LowLevel {
   %this = ibis.this <@foo::@LowLevel>
-  ibis.port.input @LowLevel_in : i1
-  ibis.port.output @LowLevel_out : i1
+  ibis.port.input "LowLevel_in" sym @LowLevel_in : i1
+  ibis.port.output "LowLevel_out" sym @LowLevel_out : i1
 
   %in_wire, %in_wire.val = ibis.wire.input @in_wire : i1
   %true = hw.constant 1 : i1

--- a/test/Dialect/Ibis/round-trip.mlir
+++ b/test/Dialect/Ibis/round-trip.mlir
@@ -58,6 +58,7 @@ ibis.class @HighLevel {
 // CHECK-NEXT:    %this = ibis.this <@foo::@A> 
 // CHECK-NEXT:    %in = ibis.port.input "in" sym @in : i1
 // CHECK-NEXT:    %out = ibis.port.output "out" sym @out : i1
+// CHECK-NEXT:    %AnonymousPort = ibis.port.input sym @AnonymousPort : i1
 // CHECK-NEXT:  }
 
 // CHECK-LABEL:  ibis.class @LowLevel {
@@ -89,6 +90,7 @@ ibis.class @A {
   %this = ibis.this <@foo::@A>
   ibis.port.input "in" sym @in : i1
   ibis.port.output "out" sym @out : i1
+  ibis.port.input sym @AnonymousPort : i1
 }
 
 ibis.class @LowLevel {

--- a/test/ibistool/output_format.mlir
+++ b/test/ibistool/output_format.mlir
@@ -58,9 +58,9 @@
 ibis.design @foo {
 ibis.class @A {
   %this = ibis.this @A
-  ibis.port.input @in : i1
-  ibis.port.output @out : i1
-  ibis.port.input @clk : !seq.clock
+  ibis.port.input "in" sym @in : i1
+  ibis.port.output "out" sym @out : i1
+  ibis.port.input "clk" sym @clk : !seq.clock
   
   ibis.container@B {
     %B_this = ibis.this @B


### PR DESCRIPTION
Port symbols now have no effect on the eventual port name of a module. This also implies that multiple ports can have the same namehint, and will be uniqued when lowering `ibis.container` to `hw.module` (see new test in `containers_to_hw.mlir`).
