### PR TITLE
[FIRRTL] Add --log-firrtl-dedup option

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -82,7 +82,7 @@ std::unique_ptr<mlir::Pass> createVBToBVPass();
 
 std::unique_ptr<mlir::Pass> createAddSeqMemPortsPass();
 
-std::unique_ptr<mlir::Pass> createDedupPass();
+std::unique_ptr<mlir::Pass> createDedupPass(bool logDedup = false);
 
 std::unique_ptr<mlir::Pass>
 createEmitOMIRPass(mlir::StringRef outputFilename = "");

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -266,6 +266,11 @@ def Dedup : Pass<"firrtl-dedup", "firrtl::CircuitOp"> {
       "Number of modules which were erased by deduplication">
   ];
   let constructor = "circt::firrtl::createDedupPass()";
+  let options = [
+    Option<"logDedup", "log-firrtl-dedup",
+           "bool", "false",
+    "Emit logging information when modules deduplicate">
+  ];
 }
 
 def EmitOMIR : Pass<"firrtl-emit-omir", "firrtl::CircuitOp"> {

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -96,6 +96,7 @@ public:
   bool shouldDisableOptimization() const { return disableOptimization; }
   bool shouldLowerMemories() const { return lowerMemories; }
   bool shouldDedup() const { return !noDedup; }
+  bool shouldLogDedup() const { return logDedup; }
   bool shouldEnableDebugInfo() const { return enableDebugInfo; }
   bool shouldIgnoreReadEnableMemories() const { return ignoreReadEnableMem; }
   bool shouldEmitOMIR() const { return emitOMIR; }
@@ -197,6 +198,11 @@ public:
 
   FirtoolOptions &setNoDedup(bool value) {
     noDedup = value;
+    return *this;
+  }
+
+  FirtoolOptions &setLogDedup(bool value) {
+    logDedup = value;
     return *this;
   }
 
@@ -370,6 +376,7 @@ private:
   std::string chiselInterfaceOutDirectory;
   bool vbToBV;
   bool noDedup;
+  bool logDedup;
   firrtl::CompanionMode companionMode;
   bool disableAggressiveMergeConnections;
   bool disableHoistingHWPassthrough;

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -101,7 +101,8 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createProbeDCEPass());
 
   if (opt.shouldDedup())
-    pm.nest<firrtl::CircuitOp>().addPass(firrtl::createDedupPass());
+    pm.nest<firrtl::CircuitOp>().addPass(
+        firrtl::createDedupPass(opt.shouldLogDedup()));
 
   if (opt.shouldConvertVecOfBundle()) {
     pm.addNestedPass<firrtl::CircuitOp>(firrtl::createLowerFIRRTLTypesPass(
@@ -486,6 +487,11 @@ struct FirtoolCmdOptions {
       llvm::cl::desc("Disable deduplication of structurally identical modules"),
       llvm::cl::init(false)};
 
+  llvm::cl::opt<bool> logFirrtlDedup{
+      "log-firrtl-dedup",
+      llvm::cl::desc("Emit logging information when modules deduplicate"),
+      llvm::cl::init(false)};
+
   llvm::cl::opt<firrtl::CompanionMode> companionMode{
       "grand-central-companion-mode",
       llvm::cl::desc("Specifies the handling of Grand Central companions"),
@@ -700,7 +706,8 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       preserveMode(firrtl::PreserveValues::None), enableDebugInfo(false),
       buildMode(BuildModeRelease), disableOptimization(false),
       exportChiselInterface(false), chiselInterfaceOutDirectory(""),
-      vbToBV(false), noDedup(false), companionMode(firrtl::CompanionMode::Bind),
+      vbToBV(false), noDedup(false), logDedup(false),
+      companionMode(firrtl::CompanionMode::Bind),
       disableAggressiveMergeConnections(false),
       disableHoistingHWPassthrough(true), emitOMIR(true), omirOutFile(""),
       lowerMemories(false), blackBoxRootPath(""), replSeqMem(false),
@@ -731,6 +738,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   chiselInterfaceOutDirectory = clOptions->chiselInterfaceOutDirectory;
   vbToBV = clOptions->vbToBV;
   noDedup = clOptions->noDedup;
+  logDedup = clOptions->logFirrtlDedup;
   companionMode = clOptions->companionMode;
   disableAggressiveMergeConnections =
       clOptions->disableAggressiveMergeConnections;


### PR DESCRIPTION
This option enables logging of all deduplicated modules.

Still needs a test but wanted to get some eyes on this.