### PR TITLE
[Handshake] Add merge decomposition pattern

### DIFF
--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -447,12 +447,14 @@ def ControlMergeOp : Handshake_Op<"control_merge", [
   let results = (outs AnyType : $result, AnyType : $index);
   
   let builders = [OpBuilder<
-    (ins "ValueRange":$operands), [{
+    (ins "ValueRange":$operands, CArg<"Type", "{}">:$indexType), [{
       assert(!operands.empty() && "cmerge needs at least one operand");
       $_state.addOperands(operands);
+      if(!indexType)
+        indexType = $_builder.getIndexType();
       // By default, the index result has an Index type
       $_state.addTypes(ArrayRef<Type>{operands[0].getType(),
-                                      $_builder.getIndexType()});
+                                      indexType});
   }]>];
   
   let hasCustomAssemblyFormat = 1;

--- a/include/circt/Dialect/Handshake/HandshakePasses.h
+++ b/include/circt/Dialect/Handshake/HandshakePasses.h
@@ -42,6 +42,7 @@ std::unique_ptr<mlir::OperationPass<handshake::FuncOp>>
 createHandshakeInsertBuffersPass(const std::string &strategy = "all",
                                  unsigned bufferSize = 2);
 std::unique_ptr<mlir::Pass> createHandshakeLockFunctionsPass();
+std::unique_ptr<mlir::Pass> createHandshakeSplitMergesPass();
 
 /// Iterates over the handshake::FuncOp's in the program to build an instance
 /// graph. In doing so, we detect whether there are any cycles in this graph, as

--- a/include/circt/Dialect/Handshake/HandshakePasses.td
+++ b/include/circt/Dialect/Handshake/HandshakePasses.td
@@ -123,4 +123,15 @@ def HandshakeLegalizeMemrefs : Pass<"handshake-legalize-memrefs", "mlir::func::F
   let dependentDialects = ["mlir::scf::SCFDialect"];
 }
 
+def HandshakeSplitMerges : Pass<"handshake-split-merges", "handshake::FuncOp"> {
+  let summary = "Deconstruct >2 input merge operations into 2-input merges";
+  let description = [{
+    This pass deconstructs the (rather complex) semantics of a >2 input merge
+    and control merge operation into a series of 2-input merge operations +
+    supporting logic.
+  }];
+  let constructor = "circt::handshake::createHandshakeSplitMergesPass()";
+  let dependentDialects = ["mlir::arith::ArithDialect"];
+}
+
 #endif // CIRCT_DIALECT_HANDSHAKE_HANDSHAKEPASSES_TD

--- a/lib/Dialect/Handshake/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Handshake/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@ add_circt_dialect_library(CIRCTHandshakeTransforms
   LockFunctions.cpp
   LowerExtmemToHW.cpp
   LegalizeMemrefs.cpp
+  SplitMerges.cpp
 
   DEPENDS
   CIRCTHandshakeTransformsIncGen

--- a/lib/Dialect/Handshake/Transforms/SplitMerges.cpp
+++ b/lib/Dialect/Handshake/Transforms/SplitMerges.cpp
@@ -1,0 +1,136 @@
+//===- SplitMerges.cpp - handshake merge deconstruction pass --*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Contains the definitions of the handshake merge deconstruction pass.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "circt/Dialect/Handshake/HandshakeOps.h"
+#include "circt/Dialect/Handshake/HandshakePasses.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace circt;
+using namespace handshake;
+using namespace mlir;
+
+namespace {
+
+struct DeconstructMergePattern : public OpRewritePattern<handshake::MergeOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(handshake::MergeOp mergeOp,
+                                PatternRewriter &rewriter) const override {
+    if (mergeOp.getNumOperands() <= 2)
+      return failure();
+
+    llvm::SmallVector<Value> mergeInputs;
+    llvm::copy(mergeOp.getOperands(), std::back_inserter(mergeInputs));
+
+    // Recursively build a balanced 2-input merge tree.
+    while (mergeInputs.size() > 1) {
+      llvm::SmallVector<Value> newMergeInputs;
+      for (unsigned i = 0, e = mergeInputs.size(); i < ((e / 2) * 2); i += 2) {
+        auto cm2 = rewriter.create<handshake::MergeOp>(
+            mergeOp.getLoc(), ValueRange{mergeInputs[i], mergeInputs[i + 1]});
+        newMergeInputs.push_back(cm2.getResult());
+      }
+      if (mergeInputs.size() % 2 != 0)
+        newMergeInputs.push_back(mergeInputs.back());
+
+      mergeInputs = newMergeInputs;
+    }
+
+    assert(mergeInputs.size() == 1);
+    rewriter.replaceOp(mergeOp, mergeInputs[0]);
+
+    return success();
+  }
+};
+
+struct DeconstructCMergePattern
+    : public OpRewritePattern<handshake::ControlMergeOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(handshake::ControlMergeOp cmergeOp,
+                                PatternRewriter &rewriter) const override {
+    if (cmergeOp.getNumOperands() <= 2)
+      return failure();
+
+    Type cmergeIndexType = cmergeOp.getIndex().getType();
+    auto loc = cmergeOp.getLoc();
+
+    // Function for create a cmerge-pack structure which generates a
+    // tuple<index, data> from two operands and an index offset.
+    auto mergeTwoOperands = [&](Value op0, Value op1,
+                                unsigned idxOffset) -> Value {
+      auto cm2 = rewriter.create<handshake::ControlMergeOp>(
+          loc, ValueRange{op0, op1}, cmergeIndexType);
+      Value idxOperand = cm2.getIndex();
+      if (idxOffset != 0) {
+        // Non-zero index offset; add it to the index operand.
+        idxOperand = rewriter.create<arith::AddIOp>(
+            loc, idxOperand,
+            rewriter.create<arith::ConstantOp>(
+                loc, rewriter.getIntegerAttr(cmergeIndexType, idxOffset)));
+      }
+
+      // Pack index and data into a tuple s.t. they share control.
+      return rewriter.create<handshake::PackOp>(
+          loc, ValueRange{cm2.getResult(), idxOperand});
+    };
+
+    llvm::SmallVector<Value> packedTuples;
+    // Perform the two-operand merges.
+    for (unsigned i = 0, e = cmergeOp.getNumOperands(); i < ((e / 2) * 2);
+         i += 2) {
+      packedTuples.push_back(mergeTwoOperands(cmergeOp.getOperand(i),
+                                              cmergeOp.getOperand(i + 1), i));
+    }
+    if (cmergeOp.getNumOperands() % 2 != 0) {
+      // If there is an odd number of operands, the last operand becomes a tuple
+      // of itself with an index of the number of operands - 1.
+      unsigned lastIdx = cmergeOp.getNumOperands() - 1;
+      packedTuples.push_back(rewriter.create<handshake::PackOp>(
+          loc, ValueRange{cmergeOp.getOperand(lastIdx),
+                          rewriter.create<arith::ConstantOp>(
+                              loc, rewriter.getIntegerAttr(cmergeIndexType,
+                                                           lastIdx))}));
+    }
+
+    // Non-deterministically merge the tuples and unpack the result.
+    auto mergedTuple =
+        rewriter.create<handshake::MergeOp>(loc, ValueRange(packedTuples));
+
+    // And finally, replace the original cmerge with the unpacked result.
+    rewriter.replaceOpWithNewOp<handshake::UnpackOp>(cmergeOp,
+                                                     mergedTuple.getResult());
+    return success();
+  }
+};
+
+struct HandshakeSplitMerges
+    : public HandshakeSplitMergesBase<HandshakeSplitMerges> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.insert<DeconstructCMergePattern, DeconstructMergePattern>(
+        &getContext());
+
+    if (failed(
+            applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  };
+};
+} // namespace
+
+std::unique_ptr<mlir::Pass> circt::handshake::createHandshakeSplitMergesPass() {
+  return std::make_unique<HandshakeSplitMerges>();
+}

--- a/test/Conversion/HandshakeToDC/basic.mlir
+++ b/test/Conversion/HandshakeToDC/basic.mlir
@@ -171,6 +171,23 @@ handshake.func @test_control_merge_data(%arg0 : i2, %arg1 : i2) -> (i2, index) {
   return %out, %idx : i2, index
 }
 
+// CHECK-LABEL:   hw.module @test_control_fixed_index_type(in 
+// CHECK-SAME:                    %[[VAL_0:.*]] : !dc.value<i4>, in %[[VAL_1:.*]] : !dc.value<i4>, out out0 : !dc.value<i4>, out out1 : !dc.value<i32>) {
+// CHECK:           %[[VAL_2:.*]], %[[VAL_3:.*]] = dc.unpack %[[VAL_0]] : !dc.value<i4>
+// CHECK:           %[[VAL_4:.*]], %[[VAL_5:.*]] = dc.unpack %[[VAL_1]] : !dc.value<i4>
+// CHECK:           %[[VAL_6:.*]] = dc.merge %[[VAL_2]], %[[VAL_4]]
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = dc.unpack %[[VAL_6]] : !dc.value<i1>
+// CHECK:           %[[VAL_9:.*]] = arith.select %[[VAL_8]], %[[VAL_3]], %[[VAL_5]] : i4
+// CHECK:           %[[VAL_10:.*]] = dc.pack %[[VAL_7]], %[[VAL_9]] : i4
+// CHECK:           %[[VAL_11:.*]] = arith.extui %[[VAL_8]] : i1 to i32
+// CHECK:           %[[VAL_12:.*]] = dc.pack %[[VAL_7]], %[[VAL_11]] : i32
+// CHECK:           hw.output %[[VAL_10]], %[[VAL_12]] : !dc.value<i4>, !dc.value<i32>
+// CHECK:         }
+handshake.func @test_control_fixed_index_type(%arg0 : i4, %arg1 : i4) -> (i4, i32) {
+  %out, %idx = control_merge %arg0, %arg1 : i4, i32
+  return %out, %idx : i4, i32
+}
+
 // CHECK:   hw.module @branch_and_merge(in %[[VAL_0:.*]] : !dc.value<i1>, in %[[VAL_1:.*]] : !dc.token, out out0 : !dc.token, out out1 : !dc.value<index>) {
 // CHECK:           %[[VAL_2:.*]] = dc.merge %[[VAL_3:.*]], %[[VAL_4:.*]]
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = dc.unpack %[[VAL_2]] : !dc.value<i1>

--- a/test/Dialect/Handshake/split-merge.mlir
+++ b/test/Dialect/Handshake/split-merge.mlir
@@ -1,0 +1,62 @@
+// RUN: circt-opt --handshake-split-merges %s | FileCheck %s
+
+// CHECK-LABEL:   handshake.func @cm4(
+// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, ...) -> (i32, index)
+// CHECK:           %[[VAL_4:.*]] = arith.constant 2 : index
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = control_merge %[[VAL_0]], %[[VAL_1]] : i32, index
+// CHECK:           %[[VAL_7:.*]] = pack %[[VAL_5]], %[[VAL_6]] : tuple<i32, index>
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = control_merge %[[VAL_2]], %[[VAL_3]] : i32, index
+// CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_9]], %[[VAL_4]] : index
+// CHECK:           %[[VAL_11:.*]] = pack %[[VAL_8]], %[[VAL_10]] : tuple<i32, index>
+// CHECK:           %[[VAL_12:.*]] = merge %[[VAL_7]], %[[VAL_11]] : tuple<i32, index>
+// CHECK:           %[[VAL_13:.*]]:2 = unpack %[[VAL_12]] : tuple<i32, index>
+// CHECK:           return %[[VAL_13]]#0, %[[VAL_13]]#1 : i32, index
+// CHECK:         }
+handshake.func @cm4(%in0 : i32, %in1 : i32, %in2 : i32, %in3 : i32) -> (i32, index) {
+    %d0, %idx0 = handshake.control_merge %in0, %in1, %in2, %in3 : i32, index
+    return %d0, %idx0 : i32, index
+}
+
+// CHECK-LABEL:   handshake.func @cm5(
+// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, ...) -> (i32, index)
+// CHECK:           %[[VAL_5:.*]] = arith.constant 4 : index
+// CHECK:           %[[VAL_6:.*]] = arith.constant 2 : index
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = control_merge %[[VAL_0]], %[[VAL_1]] : i32, index
+// CHECK:           %[[VAL_9:.*]] = pack %[[VAL_7]], %[[VAL_8]] : tuple<i32, index>
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = control_merge %[[VAL_2]], %[[VAL_3]] : i32, index
+// CHECK:           %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_6]] : index
+// CHECK:           %[[VAL_13:.*]] = pack %[[VAL_10]], %[[VAL_12]] : tuple<i32, index>
+// CHECK:           %[[VAL_14:.*]] = pack %[[VAL_4]], %[[VAL_5]] : tuple<i32, index>
+// CHECK:           %[[VAL_15:.*]] = merge %[[VAL_9]], %[[VAL_13]] : tuple<i32, index>
+// CHECK:           %[[VAL_16:.*]] = merge %[[VAL_15]], %[[VAL_14]] : tuple<i32, index>
+// CHECK:           %[[VAL_17:.*]]:2 = unpack %[[VAL_16]] : tuple<i32, index>
+// CHECK:           return %[[VAL_17]]#0, %[[VAL_17]]#1 : i32, index
+// CHECK:         }
+handshake.func @cm5(%in0 : i32, %in1 : i32, %in2 : i32, %in3 : i32, %in4 : i32) -> (i32, index) {
+    %d0, %idx0 = handshake.control_merge %in0, %in1, %in2, %in3, %in4 : i32, index
+    return %d0, %idx0 : i32, index
+}
+
+// CHECK-LABEL:   handshake.func @m3(
+// CHECK-SAME:           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, ...) -> i32
+// CHECK:           %[[VAL_3:.*]] = merge %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_4:.*]] = merge %[[VAL_3]], %[[VAL_2]] : i32
+// CHECK:           return %[[VAL_4]] : i32
+// CHECK:         }
+handshake.func @m3(%in0 : i32, %in1 : i32, %in2 : i32) -> (i32) {
+    %out = handshake.merge %in0, %in1, %in2 : i32
+    return %out : i32
+}
+
+// CHECK-LABEL:   handshake.func @m5(
+// CHECK-SAME:             %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, ...) -> i32
+// CHECK:           %[[VAL_5:.*]] = merge %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = merge %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = merge %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           %[[VAL_8:.*]] = merge %[[VAL_7]], %[[VAL_4]] : i32
+// CHECK:           return %[[VAL_8]] : i32
+// CHECK:         }
+handshake.func @m5(%in0 : i32, %in1 : i32, %in2 : i32, %in3 : i32, %in4 : i32) -> (i32) {
+    %out = handshake.merge %in0, %in1, %in2, %in3, %in4 : i32
+    return %out : i32
+}


### PR DESCRIPTION
This pass decomposes the (rather complex) semantics of a >2 input cmerge operation into a series of 2-input cmerge operations + supporting logic. This simpler structure is better suited for `dc` lowering, which only supports lowering 2-input control merge operations.  

Also decomposes >2 input `handshake.merge` operations into 2-input merges.

In pictures:
![image](https://github.com/llvm/circt/assets/16338943/21bd1af3-3efa-4efc-a479-0b8dca1451d5)
