### PR TITLE
[MooreToCore] Lower moore operators into comb or hw.

### DIFF
--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -46,11 +46,24 @@ func.func @UnrealizedConversionCast(%arg0: !moore.byte) -> !moore.shortint {
 }
 
 // CHECK-LABEL: func @Expressions
-func.func @Expressions(%arg0: !moore.bit, %arg1: !moore.logic, %arg2: !moore.packed<range<bit, 5:0>>, %arg3: !moore.packed<range<bit<signed>, 4:0>>) {
+func.func @Expressions(%arg0: !moore.bit, %arg1: !moore.logic, %arg2: !moore.packed<range<bit, 5:0>>, %arg3: !moore.packed<range<bit<signed>, 4:0>>, %arg4: !moore.bit<signed>) {
   // CHECK-NEXT: %0 = comb.concat %arg0, %arg0 : i1, i1
   // CHECK-NEXT: %1 = comb.concat %arg1, %arg1 : i1, i1
   moore.concat %arg0, %arg0 : (!moore.bit, !moore.bit) -> !moore.packed<range<bit, 1:0>>
   moore.concat %arg1, %arg1 : (!moore.logic, !moore.logic) -> !moore.packed<range<logic, 1:0>>
+
+  // CHECK-NEXT: comb.replicate %arg0 : (i1) -> i2
+  // CHECK-NEXT: comb.replicate %arg1 : (i1) -> i2
+  moore.replicate %arg0 : (!moore.bit) -> !moore.packed<range<bit, 1:0>>
+  moore.replicate %arg1 : (!moore.logic) -> !moore.packed<range<logic, 1:0>>
+
+  // CHECK-NEXT: %c12_i32 = hw.constant 12 : i32
+  // CHECK-NEXT: %c3_i6 = hw.constant 3 : i6
+  moore.constant 12 : !moore.int
+  moore.constant 3 : !moore.packed<range<bit, 5:0>>
+
+  // CHECK-NEXT: hw.bitcast %arg0 : (i1) -> i1
+  moore.conversion %arg0 : !moore.bit -> !moore.logic
 
   // CHECK-NEXT: [[V0:%.+]] = hw.constant 0 : i5
   // CHECK-NEXT: [[V1:%.+]] = comb.concat [[V0]], %arg0 : i5, i1
@@ -82,6 +95,100 @@ func.func @Expressions(%arg0: !moore.bit, %arg1: !moore.logic, %arg2: !moore.pac
   // CHECK-NEXT: [[V15:%.+]] = comb.mux [[V12]], [[V13]], [[V14]] : i5
   // CHECK-NEXT: comb.shrs %arg3, [[V15]] : i5
   moore.ashr %arg3, %arg2 : !moore.packed<range<bit<signed>, 4:0>>, !moore.packed<range<bit, 5:0>>
+
+  // CHECK-NEXT: %c2_i32 = hw.constant 2 : i32
+  %2 = moore.constant 2 : !moore.int
+
+  // CHECK-NEXT: [[V16:%.+]] = comb.extract %c2_i32 from 6 : (i32) -> i26
+  // CHECK-NEXT: %c0_i26 = hw.constant 0 : i26
+  // CHECK-NEXT: [[V17:%.+]] = comb.icmp eq [[V16]], %c0_i26 : i26
+  // CHECK-NEXT: [[V18:%.+]] = comb.extract %c2_i32 from 0 : (i32) -> i6
+  // CHECK-NEXT: %c-1_i6 = hw.constant -1 : i6
+  // CHECK-NEXT: [[V19:%.+]] = comb.mux [[V17]], [[V18]], %c-1_i6 : i6
+  // CHECK-NEXT: [[V20:%.+]] = comb.shru %arg2, [[V19]] : i6
+  // CHECK-NEXT: comb.extract [[V20]] from 0 : (i6) -> i2
+  moore.extract %arg2 from %2 : !moore.packed<range<bit, 5:0>>, !moore.int -> !moore.packed<range<bit, 3:2>>
+
+  // CHECK-NEXT: [[V21:%.+]] = comb.extract %c2_i32 from 6 : (i32) -> i26
+  // CHECK-NEXT: %c0_i26_3 = hw.constant 0 : i26
+  // CHECK-NEXT: [[V22:%.+]] = comb.icmp eq [[V21]], %c0_i26_3 : i26
+  // CHECK-NEXT: [[V23:%.+]] = comb.extract %c2_i32 from 0 : (i32) -> i6
+  // CHECK-NEXT: %c-1_i6_4 = hw.constant -1 : i6
+  // CHECK-NEXT: [[V24:%.+]] = comb.mux [[V22]], [[V23]], %c-1_i6_4 : i6
+  // CHECK-NEXT: [[V25:%.+]] = comb.shru %arg2, [[V24]] : i6
+  // CHECK-NEXT: comb.extract [[V25]] from 0 : (i6) -> i1
+  moore.extract %arg2 from %2 : !moore.packed<range<bit, 5:0>>, !moore.int -> !moore.bit
+
+  // CHECK-NEXT: [[V26:%.+]] = hw.constant -1 : i6
+  // CHECK-NEXT: comb.icmp eq %arg2, [[V26]] : i6
+  moore.reduce_and %arg2 : !moore.packed<range<bit, 5:0>> -> !moore.bit
+
+  // CHECK-NEXT: [[V27:%.+]] = hw.constant false
+  // CHECK-NEXT: comb.icmp ne %arg0, [[V27]] : i1
+  moore.reduce_or %arg0 : !moore.bit -> !moore.bit
+
+  // CHECK-NEXT: comb.parity %arg1 : i1
+  moore.reduce_xor %arg1 : !moore.logic -> !moore.logic
+
+  // CHECK-NEXT: [[V28:%.+]] = hw.constant 0 : i6
+  // CHECK-NEXT: comb.icmp ne %arg2, [[V28]] : i6
+  moore.bool_cast %arg2 : !moore.packed<range<bit, 5:0>> -> !moore.bit
+
+  // CHECK-NEXT: [[V29:%.+]] = hw.constant -1 : i6
+  // CHECK-NEXT: comb.xor %arg2, [[V29]] : i6
+  moore.not %arg2 : !moore.packed<range<bit, 5:0>>
+
+  // CHECK-NEXT: comb.add %arg1, %arg1 : i1
+  // CHECK-NEXT: comb.sub %arg1, %arg1 : i1
+  // CHECK-NEXT: comb.mul %arg1, %arg1 : i1
+  // CHECK-NEXT: comb.divu %arg0, %arg0 : i1
+  // CHECK-NEXT: comb.divs %arg4, %arg4 : i1
+  // CHECK-NEXT: comb.modu %arg0, %arg0 : i1
+  // CHECK-NEXT: comb.mods %arg4, %arg4 : i1
+  // CHECK-NEXT: comb.and %arg0, %arg0 : i1
+  // CHECK-NEXT: comb.or %arg0, %arg0 : i1
+  // CHECK-NEXT: comb.xor %arg0, %arg0 : i1
+  moore.add %arg1, %arg1 : !moore.logic
+  moore.sub %arg1, %arg1 : !moore.logic
+  moore.mul %arg1, %arg1 : !moore.logic
+  moore.div %arg0, %arg0 : !moore.bit
+  moore.div %arg4, %arg4 : !moore.bit<signed>
+  moore.mod %arg0, %arg0 : !moore.bit
+  moore.mod %arg4, %arg4 : !moore.bit<signed>
+  moore.and %arg0, %arg0 : !moore.bit
+  moore.or %arg0, %arg0 : !moore.bit
+  moore.xor %arg0, %arg0 : !moore.bit
+
+  // CHECK-NEXT: comb.icmp ult %arg1, %arg1 : i1
+  // CHECK-NEXT: comb.icmp ule %arg0, %arg0 : i1
+  // CHECK-NEXT: comb.icmp ugt %arg0, %arg0 : i1
+  // CHECK-NEXT: comb.icmp uge %arg0, %arg0 : i1
+  moore.lt %arg1, %arg1 : !moore.logic -> !moore.logic
+  moore.le %arg0, %arg0 : !moore.bit -> !moore.bit
+  moore.gt %arg0, %arg0 : !moore.bit -> !moore.bit
+  moore.ge %arg0, %arg0 : !moore.bit -> !moore.bit
+
+  // CHECK-NEXT: comb.icmp slt %arg4, %arg4 : i1
+  // CHECK-NEXT: comb.icmp sle %arg4, %arg4 : i1
+  // CHECK-NEXT: comb.icmp sgt %arg4, %arg4 : i1
+  // CHECK-NEXT: comb.icmp sge %arg4, %arg4 : i1
+  moore.lt %arg4, %arg4 : !moore.bit<signed> -> !moore.bit
+  moore.le %arg4, %arg4 : !moore.bit<signed> -> !moore.bit
+  moore.gt %arg4, %arg4 : !moore.bit<signed> -> !moore.bit
+  moore.ge %arg4, %arg4 : !moore.bit<signed> -> !moore.bit
+
+  // CHECK-NEXT: comb.icmp eq %arg1, %arg1 : i1
+  // CHECK-NEXT: comb.icmp ne %arg0, %arg0 : i1
+  // CHECK-NEXT: comb.icmp ceq %arg0, %arg0 : i1
+  // CHECK-NEXT: comb.icmp cne %arg0, %arg0 : i1
+  // CHECK-NEXT: comb.icmp weq %arg0, %arg0 : i1
+  // CHECK-NEXT: comb.icmp wne %arg0, %arg0 : i1
+  moore.eq %arg1, %arg1 : !moore.logic -> !moore.logic
+  moore.ne %arg0, %arg0 : !moore.bit -> !moore.bit
+  moore.case_eq %arg0, %arg0 : !moore.bit 
+  moore.case_ne %arg0, %arg0 : !moore.bit
+  moore.wildcard_eq %arg0, %arg0 : !moore.bit -> !moore.bit
+  moore.wildcard_ne %arg0, %arg0 : !moore.bit -> !moore.bit
 
   // CHECK-NEXT: return
   return


### PR DESCRIPTION
Aim to lower `moore` elementary operators into `comb` or `hw`, excluding `assignments` and `variable declarations`. The latter needs to analyze the entire IR to map variables and their values. And `moore` without `mux(?  :)`, which is substituted by `scf.if`.
The elementary operators include `unary, binary, relational, shift, constant, concatenation, extract, and conversion` operations.
The `moore.extract` operation receives a variable as its operand, but `comb.extract` does not. I asked @fabianschuiki for help. He taught me maybe I could use `comb.shr` to bring a variable down to bit position 0, and then capture the correct number of bits from 0 with `comb.extract`.