### PR TITLE
[HandshakeToDC] Fix constant unit-rate op lowering

### DIFF
--- a/include/circt/Dialect/DC/DCOps.td
+++ b/include/circt/Dialect/DC/DCOps.td
@@ -94,6 +94,14 @@ def JoinOp : DCOp<"join", [Commutative]> {
 
   let assemblyFormat = "$tokens attr-dict";
   let hasFolder = 1;
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "mlir::ValueRange":$ins), [{
+      assert(ins.size() > 0 && "expected at least one input");
+      $_state.addOperands(ins);
+      $_state.addTypes(dc::TokenType::get($_builder.getContext()));
+    }]>
+  ];
 }
 
 def ForkOp : DCOp<"fork"> {

--- a/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
+++ b/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
@@ -308,15 +308,27 @@ public:
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
     llvm::SmallVector<Value, 4> inputData;
-    llvm::SmallVector<Value, 4> inputTokens;
-    for (auto input : operands) {
-      auto dct = unpack(rewriter, input);
-      inputData.push_back(dct.data);
-      inputTokens.push_back(dct.token);
-    }
+    Value outToken;
+    if (operands.empty()) {
+      if (!op->hasTrait<OpTrait::ConstantLike>())
+        return op->emitOpError(
+            "no-operand operation which isn't constant-like. Too dangerous "
+            "to assume semantics - won't convert");
 
-    // Join the tokens of the inputs.
-    auto join = rewriter.create<dc::JoinOp>(op->getLoc(), inputTokens);
+      // Constant-like operation; assume the token can be represented as a
+      // constant `dc.source`.
+      outToken = rewriter.create<dc::SourceOp>(op->getLoc());
+    } else {
+      llvm::SmallVector<Value, 4> inputTokens;
+      for (auto input : operands) {
+        auto dct = unpack(rewriter, input);
+        inputData.push_back(dct.data);
+        inputTokens.push_back(dct.token);
+      }
+      // Join the tokens of the inputs.
+      assert(!inputTokens.empty() && "Expected at least one input token");
+      outToken = rewriter.create<dc::JoinOp>(op->getLoc(), inputTokens);
+    }
 
     // Patchwork to fix bad IR design in Handshake.
     auto opName = op->getName();
@@ -336,7 +348,7 @@ public:
     // Pack the result token with the output data, and replace the uses.
     llvm::SmallVector<Value> results;
     for (auto result : newOp->getResults())
-      results.push_back(pack(rewriter, join, result));
+      results.push_back(pack(rewriter, outToken, result));
 
     rewriter.replaceOp(op, results);
 

--- a/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
+++ b/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
@@ -307,7 +307,8 @@ public:
   LogicalResult
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    llvm::SmallVector<Value, 4> inputData;
+    llvm::SmallVector<Value> inputData;
+
     Value outToken;
     if (operands.empty()) {
       if (!op->hasTrait<OpTrait::ConstantLike>())
@@ -319,7 +320,7 @@ public:
       // constant `dc.source`.
       outToken = rewriter.create<dc::SourceOp>(op->getLoc());
     } else {
-      llvm::SmallVector<Value, 4> inputTokens;
+      llvm::SmallVector<Value> inputTokens;
       for (auto input : operands) {
         auto dct = unpack(rewriter, input);
         inputData.push_back(dct.data);

--- a/test/Conversion/HandshakeToDC/basic.mlir
+++ b/test/Conversion/HandshakeToDC/basic.mlir
@@ -47,6 +47,17 @@ handshake.func @top(%arg0: i64, %arg1: i64, %arg8: none, ...) -> (i64, none) {
     return %1, %arg8 : i64, none
 }
 
+// CHECK-LABEL:   hw.module @constant(out out0 : !dc.value<i32>) {
+// CHECK:           %[[VAL_1:.*]] = dc.source
+// CHECK:           %[[VAL_2:.*]] = arith.constant 42 : i32
+// CHECK:           %[[VAL_3:.*]] = dc.pack %[[VAL_1]], %[[VAL_2]] : i32
+// CHECK:           hw.output %[[VAL_3]] : !dc.value<i32>
+// CHECK:         }
+handshake.func @constant() -> (i32) {
+  %0 = arith.constant 42 : i32
+  return %0 : i32
+}
+
 // CHECK:   hw.module @mux(in %[[VAL_0:.*]] : !dc.value<i1>, in %[[VAL_1:.*]] : !dc.value<i64>, in %[[VAL_2:.*]] : !dc.value<i64>, out out0 : !dc.value<i64>) {
 // CHECK:           %[[VAL_3:.*]], %[[VAL_4:.*]] = dc.unpack %[[VAL_0]] : !dc.value<i1>
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = dc.unpack %[[VAL_1]] : !dc.value<i64>


### PR DESCRIPTION
Constant-like unit-rate operations didn't have any output tokens assigned. Fixed s.t. constant-like operations (with no inputs) are emitted using a `dc.source`.