### PR TITLE
[FIRRTL][CAPI] Add function for getting mask type

### DIFF
--- a/include/circt-c/Dialect/FIRRTL.h
+++ b/include/circt-c/Dialect/FIRRTL.h
@@ -114,6 +114,8 @@ MLIR_CAPI_EXPORTED MlirType
 firrtlTypeGetClass(MlirContext ctx, MlirAttribute name, size_t numberOfElements,
                    const FIRRTLClassElement *elements);
 
+MLIR_CAPI_EXPORTED MlirType firrtlTypeGetMaskType(MlirType type);
+
 //===----------------------------------------------------------------------===//
 // Attribute API.
 //===----------------------------------------------------------------------===//

--- a/lib/CAPI/Dialect/FIRRTL.cpp
+++ b/lib/CAPI/Dialect/FIRRTL.cpp
@@ -163,6 +163,12 @@ MlirType firrtlTypeGetClass(MlirContext ctx, MlirAttribute name,
   return wrap(ClassType::get(unwrap(ctx), nameSymbol, classElements));
 }
 
+MlirType firrtlTypeGetMaskType(MlirType type) {
+  auto baseType = type_dyn_cast<FIRRTLBaseType>(unwrap(type));
+  assert(baseType && "unexpected type, must be base type");
+  return wrap(baseType.getMaskType());
+}
+
 //===----------------------------------------------------------------------===//
 // Attribute API.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Used for building `firrtl.mem` from external programs.

https://github.com/llvm/circt/blob/db973f13193728d082cb8bd8873ae524575291e0/lib/Dialect/FIRRTL/FIRRTLOps.cpp#L2982