### PR TITLE
[ESI] Add cmake switch to enable ESI_COSIM

### DIFF
--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -77,38 +77,46 @@ IF(MSVC)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
 ENDIF(MSVC)
 
-# If Cap'nProto hasn't been explicitly disabled, find it.
-option(CAPNP_DISABLE "Disable Cap'nProto (needed for cosimulation).")
-if (CAPNP_DISABLE)
-  message (STATUS "Disabling Cap'nProto (needed for cosimulation).")
-elseif(NOT CapnProto_FOUND) # Check if someone else already imported.
-  if(DEFINED CAPNP_PATH)
-    set(ENV{PKG_CONFIG_PATH}
-      "${CAPNP_PATH}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
-    find_package(CapnProto CONFIG PATHS ${CAPNP_PATH})
-  else()
-    set(ENV{PKG_CONFIG_PATH}
-      "${CMAKE_CURRENT_SOURCE_DIR}/ext/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
-    find_package(CapnProto CONFIG PATHS "${CMAKE_CURRENT_SOURCE_DIR}/ext")
+if(ESI_COSIM)
+  # If Cap'nProto hasn't been explicitly disabled, find it.
+  option(CAPNP_DISABLE "Disable Cap'nProto (needed for cosimulation).")
+  if (CAPNP_DISABLE)
+    message (STATUS "Disabling Cap'nProto (needed for cosimulation).")
+  elseif(NOT CapnProto_FOUND) # Check if someone else already imported.
+    if(DEFINED CAPNP_PATH)
+      set(ENV{PKG_CONFIG_PATH}
+        "${CAPNP_PATH}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+      find_package(CapnProto CONFIG PATHS ${CAPNP_PATH})
+    else()
+      set(ENV{PKG_CONFIG_PATH}
+        "${CMAKE_CURRENT_SOURCE_DIR}/ext/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+      find_package(CapnProto CONFIG PATHS "${CMAKE_CURRENT_SOURCE_DIR}/ext")
+    endif()
   endif()
-endif()
 
-# If Cap'nProto has been found, generate the headers and definitions.
-if(CapnProto_FOUND)
-  set(ESI_COSIM true)
-  message("-- ESI cosim enabled")
+  # If Cap'nProto has been found, generate the headers and definitions.
+  if(CapnProto_FOUND)
+    message("-- ESI cosim enabled")
 
-  message(STATUS "Found Cap'nProto at ${CapnProto_DIR}.")
-  add_subdirectory(cosim)
+    message(STATUS "Found Cap'nProto at ${CapnProto_DIR}.")
+    set(CMAKE_INSTALL_RPATH ${capnp_LIBDIR})
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-  set(ESIRuntimeSources
-    ${ESIRuntimeSources}
-    cpp/lib/backends/Cosim.cpp
-  )
-  set(ESIRuntimeLinkLibraries
-    ${ESIRuntimeLinkLibraries}
-    EsiCosimCapnp
-  )
+    add_subdirectory(cosim)
+
+    set(ESIRuntimeSources
+      ${ESIRuntimeSources}
+      cpp/lib/backends/Cosim.cpp
+    )
+    set(ESIRuntimeLinkLibraries
+      ${ESIRuntimeLinkLibraries}
+      EsiCosimCapnp
+    )
+  else()
+    message(FATAL_ERROR "Cap'nProto not found. Required for ESI_COSIM.")
+  endif()
+else()
+  message("-- ESI cosim disabled")
 endif()
 
 option(XRT_PATH "Path to XRT lib.")


### PR DESCRIPTION
It is mildly annoying to have cosim-related capabilities silently failing late in the ESI process (e.g. funky import errors due to linking issues:
```
ImportError: /home/mpetersen/Work/FPGAToolsAndCompilers/CIRCT/build-Debug/tools/circt/lib/Dialect/ESI/runtime/python/esi/esiCppAccel.cpython-310-x86_64-linux-gnu.so: undefined symbol: 
_ZTIN3esi8backends5cosim16CosimAcceleratorE
```
only to find out that cosimulation was not enabled in the build. Unless there's a good reason for ESI to implicitly decide when or when not to include cosim support, i think ESI_COSIM should be opt-in. If not, at least until the ESI cosim path is more fleshed out and robust s.t. the above errors don't occur at a late stage.