### PR TITLE
[Scheduling] computeStartTimesInCycle: clear before recomputation

### DIFF
--- a/include/circt/Scheduling/Problems.h
+++ b/include/circt/Scheduling/Problems.h
@@ -373,6 +373,7 @@ public:
   void setStartTimeInCycle(Operation *op, float time) {
     startTimeInCycle[op] = time;
   }
+  void clearStartTimeInCycle() { startTimeInCycle.clear(); }
 
   virtual PropertyStringVector getProperties(Operation *op) override;
   virtual PropertyStringVector getProperties(OperatorType opr) override;

--- a/lib/Scheduling/ChainingSupport.cpp
+++ b/lib/Scheduling/ChainingSupport.cpp
@@ -91,6 +91,7 @@ LogicalResult scheduling::computeChainBreakingDependences(
 }
 
 LogicalResult scheduling::computeStartTimesInCycle(ChainingProblem &prob) {
+  prob.clearStartTimeInCycle();
   return handleOperationsInTopologicalOrder(prob, [&](Operation *op) {
     // `op` will start within its abstract time step as soon as all operand
     // values have reached it.


### PR DESCRIPTION
Currently, `computeStartTimesInCycle()` potentially computes wrong start times given the following pseudo code:

```C++
ChainingProblem prob;
scheduleAlgorithm1(prob);
computeStartTimesInCycle(prob);
// do something with the first solution
schedlueAlgorithm2(prob); // Compute a different solution based on the same problem
computeStartTimesInCycle(prob); // <- computes wrong results
```

The issue here is that `computeStartTimesInCycle()` checks whether the ChainingProblem already contains a value for `getStartTimeInCycle` for every predecessor of an operation and if so computes the *startTimeInCycle* for this operation.
Otherwise, the *startTimeInCycle* of the predecessors must be computed first.
After the first call to `computeStartTimesInCycle`, all operations and thereby their predecessors have a *startTimeInCycle*.
Since the *startTimeInCycle*s were previously not cleared in `computeStartTimesInCycle()`, results from the first scheduling solution are potentially used for the second solution and might cause invalid *startTimesInCycle*.