### PR TITLE
SCF To Calyx Support Float Add and Float SeqMemory Read/Write

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxHelpers.h
+++ b/include/circt/Dialect/Calyx/CalyxHelpers.h
@@ -30,6 +30,10 @@ calyx::RegisterOp createRegister(Location loc, OpBuilder &builder,
                                  ComponentOp component, size_t width,
                                  Twine prefix);
 
+calyx::RegisterOp createRegister(Location loc, OpBuilder &builder,
+                                 ComponentOp component, Type type,
+                                 Twine prefix);
+
 /// A helper function to create constants in the HW dialect.
 hw::ConstantOp createConstant(Location loc, OpBuilder &builder,
                               ComponentOp component, size_t width,

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -103,6 +103,7 @@ struct MemoryInterface {
   explicit MemoryInterface(calyx::SeqMemoryOp memOp);
 
   // Getter methods for each memory interface port.
+  bool isSeqMem();
   Value readData();
   Value readEn();
   Value contentEn();

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -114,7 +114,7 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
   );
 
   let results = (outs
-    Variadic<AnySignlessInteger>:$results
+    Variadic<AnyTypeOf<[AnySignlessInteger, AnyFloat]>>:$results
   );
 
   let assemblyFormat = [{
@@ -184,7 +184,7 @@ def SeqMemoryOp : CalyxPrimitive<"seq_mem", []> {
   );
 
   let results = (outs
-    Variadic<AnySignlessInteger>:$results
+    Variadic<AnyTypeOf<[AnySignlessInteger, AnyFloat]>>:$results
   );
 
   let assemblyFormat = [{
@@ -197,6 +197,12 @@ def SeqMemoryOp : CalyxPrimitive<"seq_mem", []> {
     OpBuilder<(ins
       "StringRef":$sym_name,
       "int64_t":$width,
+      "ArrayRef<int64_t>":$sizes,
+      "ArrayRef<int64_t>":$addrSizes
+    )>,
+    OpBuilder<(ins 
+      "StringRef":$sym_name,
+      "Type":$type,
       "ArrayRef<int64_t>":$sizes,
       "ArrayRef<int64_t>":$addrSizes
     )>

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -331,6 +331,15 @@ class CombinationalArithBinaryLibraryOp<string mnemonic> :
   let results = (outs AnyType:$left, AnyType:$right, AnyType:$out);
 }
 
+class ArithBinaryFloatingPointLibraryOp<string mnemonic> : ArithBinaryLibraryOp<mnemonic, [
+  SameTypeConstraint<"left", "out">
+  ]> {
+    let results = (outs I1:$clk, I1:$reset, I1:$go, I1:$control, I1:$subOp,
+      AnyFloat:$left, AnyFloat:$right, AnySignlessInteger:$roundingMode, AnyFloat:$out,
+      AnySignlessInteger:$execptionalFlags, I1:$done);
+}
+
+def AddFNOp : ArithBinaryFloatingPointLibraryOp<"addFN"> {}
 def AddLibOp  : CombinationalArithBinaryLibraryOp<"add"> {}
 def SubLibOp  : CombinationalArithBinaryLibraryOp<"sub"> {}
 def ShruLibOp : CombinationalArithBinaryLibraryOp<"shru"> {}

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -10,12 +10,48 @@
 //
 //===----------------------------------------------------------------------===//
 
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+
 /// Base class for Calyx primitives.
 class CalyxPrimitive<string mnemonic, list<Trait> traits = []> :
   CalyxCell<mnemonic, traits> {
     let assemblyFormat = "$sym_name attr-dict `:` qualified(type(results))";
     let arguments = (ins SymbolNameAttr:$sym_name);
     let skipDefaultBuilders = 1;
+}
+
+def ConstantOp: CalyxOp<"constant",
+    [Pure, ConstantLike, FirstAttrDerivedResultType,
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+    AllTypesMatch<["value", "result"]>
+    ]> {
+  let summary = "integer or floating point constant";
+  let description = [{
+    The `constant` operation produces an SSA value equal to some integer or
+    floating-point constant specified by an attribute.
+
+    Example:
+
+    ```
+    // Integer constant
+    %1 = calyx.constant 42 : i32
+
+    // Equivalent generic form
+    %1 = "calyx.constant"() {value = 42 : i32} : () -> i32
+    ```
+  }];
+  let arguments = (ins TypedAttrInterface:$value);
+
+  let results = (outs SignlessIntegerOrFloatLike:$result);
+
+  let builders = [
+    /// Build a ConstantOp from a prebuilt attribute.
+    OpBuilder<(ins "FloatAttr":$attr)>
+  ];
+
+  let hasFolder = 1;
+  let assemblyFormat = "attr-dict $value";
+  let hasVerifier = 1;
 }
 
 /// The n-bit, undef op which only provides the out signal

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -1945,6 +1945,62 @@ ParseResult GroupDoneOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 //===----------------------------------------------------------------------===//
+// ConstantOp
+//===----------------------------------------------------------------------===//
+void ConstantOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  auto type = getType();
+  if (auto intCst = llvm::dyn_cast<IntegerAttr>(getValue())) {
+    auto intType = llvm::dyn_cast<IntegerType>(type);
+
+    // Sugar i1 constants with 'true' and 'false'.
+    if (intType && intType.getWidth() == 1)
+      return setNameFn(getResult(), (intCst.getInt() ? "true" : "false"));
+
+    // Otherwise, build a complex name with the value and type.
+    SmallString<32> specialNameBuffer;
+    llvm::raw_svector_ostream specialName(specialNameBuffer);
+    specialName << 'c' << intCst.getValue();
+    if (intType)
+      specialName << '_' << type;
+    setNameFn(getResult(), specialName.str());
+  } else {
+    setNameFn(getResult(), "cst");
+  }
+}
+
+LogicalResult ConstantOp::verify() {
+  auto type = getType();
+  // The value's type must match the return type.
+  if (getValue().getType() != type) {
+    return emitOpError() << "value type " << getValue().getType()
+                         << " must match return type: " << type;
+  }
+  // Integer values must be signless.
+  if (llvm::isa<IntegerType>(type) &&
+      !llvm::cast<IntegerType>(type).isSignless())
+    return emitOpError("integer return type must be signless");
+  // Any float or elements attribute are acceptable.
+  if (!llvm::isa<IntegerAttr, FloatAttr>(getValue())) {
+    return emitOpError("value must be an integer or float attribute");
+  }
+
+  return success();
+}
+
+OpFoldResult calyx::ConstantOp::fold(FoldAdaptor adaptor) {
+  return getValueAttr();
+}
+
+void calyx::ConstantOp::build(OpBuilder &builder, OperationState &state,
+                              FloatAttr attr) {
+  state.addAttribute("value", attr);
+  SmallVector<Type> types;
+  types.push_back(attr.getType()); // Out
+  state.addTypes(types);
+}
+
+//===----------------------------------------------------------------------===//
 // RegisterOp
 //===----------------------------------------------------------------------===//
 
@@ -2150,6 +2206,7 @@ void SeqMemoryOp::build(OpBuilder &builder, OperationState &state,
   types.push_back(builder.getI1Type());            // Done
   state.addTypes(types);
 }
+
 void SeqMemoryOp::build(OpBuilder &builder, OperationState &state,
                         StringRef instanceName, Type type,
                         ArrayRef<int64_t> sizes, ArrayRef<int64_t> addrSizes) {

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -2150,6 +2150,27 @@ void SeqMemoryOp::build(OpBuilder &builder, OperationState &state,
   types.push_back(builder.getI1Type());            // Done
   state.addTypes(types);
 }
+void SeqMemoryOp::build(OpBuilder &builder, OperationState &state,
+                        StringRef instanceName, Type type,
+                        ArrayRef<int64_t> sizes, ArrayRef<int64_t> addrSizes) {
+  state.addAttribute(SymbolTable::getSymbolAttrName(),
+                     builder.getStringAttr(instanceName));
+  int64_t width = type.getIntOrFloatBitWidth();
+  state.addAttribute("width", builder.getI64IntegerAttr(width));
+  state.addAttribute("sizes", builder.getI64ArrayAttr(sizes));
+  state.addAttribute("addrSizes", builder.getI64ArrayAttr(addrSizes));
+  SmallVector<Type> types;
+  for (int64_t size : addrSizes)
+    types.push_back(builder.getIntegerType(size)); // Addresses
+  types.push_back(builder.getI1Type());            // Clk
+  types.push_back(builder.getI1Type());            // Reset
+  types.push_back(builder.getI1Type());            // Content enable
+  types.push_back(builder.getI1Type());            // Write enable
+  types.push_back(type);                           // Write data
+  types.push_back(type);                           // Read data
+  types.push_back(builder.getI1Type());            // Done
+  state.addTypes(types);
+}
 
 LogicalResult SeqMemoryOp::verify() {
   ArrayRef<Attribute> opSizes = getSizes().getValue();

--- a/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
@@ -27,6 +27,14 @@ calyx::RegisterOp createRegister(Location loc, OpBuilder &builder,
   return builder.create<RegisterOp>(loc, (prefix + "_reg").str(), width);
 }
 
+calyx::RegisterOp createRegister(Location loc, OpBuilder &builder,
+                                 ComponentOp component, Type type,
+                                 Twine prefix) {
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointToStart(component.getBodyBlock());
+  return builder.create<RegisterOp>(loc, (prefix + "_reg").str(), type);
+}
+
 hw::ConstantOp createConstant(Location loc, OpBuilder &builder,
                               ComponentOp component, size_t width,
                               size_t value) {

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -667,7 +667,7 @@ void InlineCombGroups::recurseInlineCombGroups(
             calyx::ConstantOp, hw::ConstantOp, mlir::arith::ConstantOp,
             calyx::MultPipeLibOp, calyx::DivUPipeLibOp, calyx::DivSPipeLibOp,
             calyx::RemSPipeLibOp, calyx::RemUPipeLibOp, mlir::scf::WhileOp,
-            calyx::InstanceOp>(src.getDefiningOp()))
+            calyx::InstanceOp, calyx::AddFNOp>(src.getDefiningOp()))
       continue;
 
     auto srcCombGroup = dyn_cast<calyx::CombGroupOp>(

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -169,6 +169,13 @@ MemoryInterface::MemoryInterface(const MemoryPortsImpl &ports) : impl(ports) {
 MemoryInterface::MemoryInterface(calyx::MemoryOp memOp) : impl(memOp) {}
 MemoryInterface::MemoryInterface(calyx::SeqMemoryOp memOp) : impl(memOp) {}
 
+bool MemoryInterface::isSeqMem() {
+  if (auto *memOp = std::get_if<calyx::SeqMemoryOp>(&impl); memOp) {
+    return true;
+  }
+  return false;
+}
+
 Value MemoryInterface::readData() {
   auto readData = readDataOpt();
   assert(readData.has_value() && "Memory does not have readData");
@@ -657,10 +664,10 @@ void InlineCombGroups::recurseInlineCombGroups(
     //   LateSSAReplacement)
     if (isa<BlockArgument>(src) ||
         isa<calyx::RegisterOp, calyx::MemoryOp, calyx::SeqMemoryOp,
-            hw::ConstantOp, mlir::arith::ConstantOp, calyx::MultPipeLibOp,
-            calyx::DivUPipeLibOp, calyx::DivSPipeLibOp, calyx::RemSPipeLibOp,
-            calyx::RemUPipeLibOp, mlir::scf::WhileOp, calyx::InstanceOp>(
-            src.getDefiningOp()))
+            calyx::ConstantOp, hw::ConstantOp, mlir::arith::ConstantOp,
+            calyx::MultPipeLibOp, calyx::DivUPipeLibOp, calyx::DivSPipeLibOp,
+            calyx::RemSPipeLibOp, calyx::RemUPipeLibOp, mlir::scf::WhileOp,
+            calyx::InstanceOp>(src.getDefiningOp()))
       continue;
 
     auto srcCombGroup = dyn_cast<calyx::CombGroupOp>(

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -730,7 +730,8 @@ BuildBasicBlockRegs::partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
 
     for (auto arg : enumerate(block->getArguments())) {
       Type argType = arg.value().getType();
-      assert(isa<IntegerType>(argType) && "unsupported block argument type");
+      assert((isa<IntegerType>(argType) || isa<FloatType>(argType)) &&
+             "unsupported block argument type");
       unsigned width = argType.getIntOrFloatBitWidth();
       std::string index = std::to_string(arg.index());
       std::string name = loweringState().blockName(block) + "_arg" + index;
@@ -753,11 +754,11 @@ BuildReturnRegs::partiallyLowerFuncToComp(mlir::func::FuncOp funcOp,
 
   for (auto argType : enumerate(funcOp.getResultTypes())) {
     auto convArgType = calyx::convIndexType(rewriter, argType.value());
-    assert(isa<IntegerType>(convArgType) && "unsupported return type");
-    unsigned width = convArgType.getIntOrFloatBitWidth();
+    assert((isa<IntegerType>(convArgType) || isa<FloatType>(convArgType)) &&
+           "unsupported return type");
     std::string name = "ret_arg" + std::to_string(argType.index());
-    auto reg =
-        createRegister(funcOp.getLoc(), rewriter, getComponent(), width, name);
+    auto reg = createRegister(funcOp.getLoc(), rewriter, getComponent(),
+                              convArgType, name);
     getState().addReturnReg(reg, argType.index());
 
     rewriter.setInsertionPointToStart(

--- a/test/Conversion/SCFToCalyx/errors.mlir
+++ b/test/Conversion/SCFToCalyx/errors.mlir
@@ -1,15 +1,5 @@
 // RUN: circt-opt --lower-scf-to-calyx %s -split-input-file -verify-diagnostics
 
-module {
-  func.func @f(%arg0 : f32, %arg1 : f32) -> f32 {
-    // expected-error @+1 {{failed to legalize operation 'arith.addf' that was explicitly marked illegal}}
-    %2 = arith.addf %arg0, %arg1 : f32
-    return %2 : f32
-  }
-}
-
-// -----
-
 // expected-error @+1 {{Module contains multiple functions, but no top level function was set. Please see --top-level-function}}
 module {
   func.func @f1() {


### PR DESCRIPTION
This is the second patch stacking on #6952 

This patch tries to legalize `AddFOp` and support floating point `SeqMemory` read/write in SCFToCalyx.