### PR TITLE
[FIRRTL] Don't fail compilation when Dedup group annotation is on EICG_wrapper

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetails.h"
+#include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "mlir/IR/Diagnostics.h"
@@ -143,6 +144,14 @@ void LowerIntmodulesPass::runOnOperation() {
          llvm::make_early_inc_range(getOperation().getOps<FExtModuleOp>())) {
       if (op.getDefname() != eicgName)
         continue;
+
+      // FIXME: Dedup group annotation could be annotated to EICG_wrapper but
+      //        it causes an error with `fixupEICGWrapper`. For now drop the
+      //        annotation until we fully migrate into EICG intrinsic.
+      if (AnnotationSet::removeAnnotations(op, firrtl::dedupGroupAnnoClass))
+        op.emitWarning() << "Annotation " << firrtl::dedupGroupAnnoClass
+                         << " on EICG_wrapper is dropped";
+
       if (failed(checkModForAnnotations(op, eicgName)))
         return signalPassFailure();
 

--- a/test/Dialect/FIRRTL/lower-intmodules-eicg.mlir
+++ b/test/Dialect/FIRRTL/lower-intmodules-eicg.mlir
@@ -1,11 +1,14 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-intmodules))' --split-input-file %s | FileCheck %s --check-prefixes=CHECK,CHECK-NOEICG
-// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-intmodules{fixup-eicg-wrapper}))' --split-input-file %s | FileCheck %s --check-prefixes=CHECK,CHECK-EICG
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-intmodules{fixup-eicg-wrapper}))' --split-input-file %s  --verify-diagnostics | FileCheck %s --check-prefixes=CHECK,CHECK-EICG
 
 // CHECK-LABEL: "FixupEICGWrapper"
 firrtl.circuit "FixupEICGWrapper" {
   // CHECK-NOEICG: LegacyClockGate
   // CHECK-EICG-NOT: LegacyClockGate
-  firrtl.extmodule @LegacyClockGate(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
+  // expected-warning @below {{Annotation firrtl.transforms.DedupGroupAnnotation on EICG_wrapper is dropped}}
+  firrtl.extmodule @LegacyClockGate(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {
+    defname = "EICG_wrapper",
+    annotations = [{class = "firrtl.transforms.DedupGroupAnnotation", group = "foo"}]}
 
   // CHECK: FixupEICGWrapper
   firrtl.module @FixupEICGWrapper(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>) {


### PR DESCRIPTION
Currently `DedupGroup` is added to almost every module including `EICG_wrapper`. However EICG_wrapper later becomes intrinsic when a compiler option `fixup-eicg-wrapper` is given. This causes a compilation error since annotation is added to an intrinsic. The right fix is to use to EICG intrinsic in the first place but there are still a few things to migrate ( ExtractInstances).  Since dropping DedupGroup annotation on EICG_wrapper is practically safe this PR removes the annotation with a warning. 