### PR TITLE
[Comb] Officialize support for zero-width integers

### DIFF
--- a/docs/Dialects/Comb/RationaleComb.md
+++ b/docs/Dialects/Comb/RationaleComb.md
@@ -9,7 +9,6 @@ other [MLIR Rationale docs](https://mlir.llvm.org/docs/Rationale/).
 - [`comb` Dialect Rationale](#comb-dialect-rationale)
   - [Introduction to the `comb` Dialect](#introduction-to-the-comb-dialect)
   - [Type System for `comb` Dialect](#type-system-for-comb-dialect)
-    - [Zero-bit integer width is not supported](#zero-bit-integer-width-is-not-supported)
   - [Comb Operations](#comb-operations)
     - [Fully associative operations are variadic](#fully-associative-operations-are-variadic)
     - [Operators carry signs instead of types](#operators-carry-signs-instead-of-types)
@@ -32,30 +31,6 @@ substrate that may be extended with higher level dialects mixed into it.
 
 TODO: Simple integer types, eventually parametrically wide integer type
 `hw.int<width>`.  Supports type aliases.  See HW rationale for more info.
-
-### Zero-bit integer width is not supported
-
-Combinational operations like add and multiply work on values of signless
-standard integer types, e.g. `i42`, but they do not allow zero bit inputs.  This
-design point is motivated by a couple of reasons:
-
-1) The semantics of some operations (e.g. `comb.sext`) do not have an obvious
-   definition with a zero bit input.
-
-1) Zero bit operations are useless for operations that are definable, and their
-   presence makes the compiler more complicated.
-
-On the second point, consider an example like `comb.mux` which could allow zero
-bit inputs and therefore produce zero bit results.  Allowing that as a design
-point would require us to special case this in our cost models, and we would
-have that optimizes it away.
-
-By rejecting zero bit operations, we choose to put the complexity into the
-lowering passes that generate the HW dialect (e.g. LowerToHW from FIRRTL).
-
-Note that this decision only affects the core operations in the `comb` dialect
-itself - it is perfectly reasonable to define your operations and mix them into
-other `comb` constructs. 
 
 ## Comb Operations
 

--- a/test/Conversion/ExportVerilog/pruning.mlir
+++ b/test/Conversion/ExportVerilog/pruning.mlir
@@ -11,6 +11,7 @@ hw.module @zeroWidthPAssign(in %arg0 : i0, in %clk: i1, out out: i0) {
   %1 = sv.read_inout %0 : !hw.inout<i0>
   hw.output %1 : i0
 }
+
 // CHECK-LABEL: module zeroWidthLogic(
 // CHECK-NOT: reg
 hw.module @zeroWidthLogic(in %arg0 : i0, in %sel : i1, in %clk : i1, out out : i0) {
@@ -18,6 +19,14 @@ hw.module @zeroWidthLogic(in %arg0 : i0, in %sel : i1, in %clk : i1, out out : i
   %rr = sv.read_inout %r : !hw.inout<i0>
   %2 = comb.mux %sel, %rr, %arg0 : i0
   hw.output %2 : i0
+}
+
+// CHECK-LABEL: module zeroWidthArith(
+hw.module @zeroWidthArith(in %arg0 : i0, in %arg1 : i0, out out : i0) {
+  %add = comb.add %arg0, %arg1 : i0
+  %sub = comb.sub %arg0, %arg1 : i0
+  %and = comb.and %add, %sub : i0
+  hw.output %and : i0
 }
 
 // CHECK-LABEL: module Concat(

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -1662,3 +1662,58 @@ hw.module @cantCombineOppositeNonBinCmpIntoConstant(in %tag_0: i4, in %tag_1: i4
             %opposite_xor_or, %opposite_xor_and :
             i1, i1, i1, i1, i1, i1, i1, i1, i1, i1, i4, i4
 }
+
+// Ensure canonicalization is not confused by i0.
+// CHECK-LABEL: hw.module @i0checks
+// CHECK-SAME: in %[[I32_VAL:[^ ]*]] : i32, in %[[I1_VAL:[^ ]*]] : i1, in %[[I0_VAL:[^ ]*]] : i0
+// CHECK-DAG: %[[FALSE:.*]] = hw.constant false
+// CHECK-DAG: %[[ZERO:.*]] = hw.constant 0 : i0
+// CHECK-DAG: %[[CONCAT:.*]] = comb.concat %[[I0_VAL]], %[[I32_VAL]] : i0, i32
+// CHECK-DAG: %[[CONCAT_REVERSE:.*]] = comb.concat %[[I32_VAL]], %[[I0_VAL]] : i32, i0
+// CHECK-DAG: %[[CONCAT_REMAINS:.*]] = comb.concat %[[I32_VAL]], %[[I0_VAL]], %i1_val : i32, i0, i1
+// CHECK-DAG: %[[CONCAT_ITSELF:.*]] = comb.concat %[[I0_VAL]], %[[ZERO]] : i0, i0
+// CHECK-DAG: %[[DIVS:.*]] = comb.divs %[[I0_VAL]], %[[ZERO]] : i0
+// CHECK-DAG: %[[DIVU:.*]] = comb.divu %[[I0_VAL]], %[[ZERO]] : i0
+// CHECK-DAG: %[[ICMP_EQ:.*]] = comb.icmp eq %[[I0_VAL]], %[[ZERO]] : i0
+// CHECK-DAG: %[[ICMP_NE:.*]] = comb.icmp ne %[[I0_VAL]], %[[ZERO]] : i0
+// CHECK-DAG: %[[MODS:.*]] = comb.mods %[[I0_VAL]], %[[ZERO]] : i0
+// CHECK-DAG: %[[MODU:.*]] = comb.modu %[[I0_VAL]], %[[ZERO]] : i0
+// CHECK-DAG: hw.output %[[I0_VAL]], %[[I0_VAL]], %[[ZERO]], %[[ZERO]], %[[I0_VAL]], %[[ZERO]], %[[CONCAT]], %[[CONCAT_REVERSE]], %[[CONCAT_REMAINS]], %[[CONCAT_ITSELF]], %[[DIVS]], %[[DIVU]], %[[ICMP_EQ]], %[[ICMP_NE]], %[[MODS]], %[[MODU]], %[[FALSE]], %[[I0_VAL]], %[[I0_VAL]], %[[I0_VAL]] : i0, i0, i0, i0, i0, i0, i32, i32, i33, i0, i0, i0, i1, i1, i0, i0, i1, i0, i0, i0
+hw.module @i0checks(in %i32_val: i32, in %i1_val: i1, in %i0_val: i0, out add: i0, out sub: i0, out mul: i0, out or: i0, out xor: i0, out and: i0, out concat: i32, out concat_reverse: i32, out concat_remains: i33, out concat_itself: i0, out divs: i0, out divu: i0, out icmp_eq: i1, out icmp_ne: i1, out mods: i0, out modu: i0, out parity: i1, out shl: i0, out shrs: i0, out shru: i0) {
+  %zero = hw.constant 0 : i0
+
+  %add = comb.add %i0_val, %zero : i0
+  %sub = comb.sub %i0_val, %zero : i0
+  %mul = comb.mul %i0_val, %zero : i0
+
+  %or = comb.or %i0_val, %zero : i0
+  %xor = comb.xor %i0_val, %zero : i0
+  %and = comb.and %i0_val, %zero : i0
+
+  %concat = comb.concat %i0_val, %i32_val : i0, i32
+  %concat_reverse = comb.concat %i32_val, %i0_val : i32, i0
+  %concat_remains = comb.concat %i32_val, %i0_val, %i1_val : i32, i0, i1
+  %concat_itself = comb.concat %i0_val, %zero : i0, i0
+
+  %divs = comb.divs %i0_val, %zero : i0
+  %divu = comb.divu %i0_val, %zero : i0
+
+  %icmp_eq = comb.icmp eq %i0_val, %zero : i0
+  %icmp_ne = comb.icmp ne %i0_val, %zero : i0
+
+  %mods = comb.mods %i0_val, %zero : i0
+  %modu = comb.modu %i0_val, %zero : i0
+
+  %parity = comb.parity %zero : i0
+
+  %shl = comb.shl %i0_val, %zero : i0
+  %shrs = comb.shrs %i0_val, %zero : i0
+  %shru = comb.shru %i0_val, %zero : i0
+
+  hw.output %add, %sub, %mul, %or, %xor, %and, %concat,
+            %concat_reverse, %concat_remains, %concat_itself,
+            %divs, %divu, %icmp_eq, %icmp_ne, %mods, %modu,
+            %parity, %shl, %shrs, %shru :
+            i0, i0, i0, i0, i0, i0, i32, i32, i33, i0, i0,
+            i0, i1, i1, i0, i0, i1, i0, i0, i0
+}

--- a/test/Dialect/Comb/errors.mlir
+++ b/test/Dialect/Comb/errors.mlir
@@ -11,3 +11,17 @@ hw.module @err(in %a: i1, in %b: i1) {
   // expected-error @+1 {{Truth tables support a maximum of 63 inputs}}
   %0 = comb.truth_table %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b, %a, %b -> [false]
 }
+
+// -----
+
+hw.module @err(in %a: i0) {
+  // expected-error @+1 {{op replicate does not take zero bit integer}}
+  %0 = comb.replicate %a : (i0) -> i16
+}
+
+// -----
+
+hw.module @err(in %a: i0) {
+  // expected-error @+1 {{from bit too large for input}}
+  %0 = comb.extract %a from 0 : (i0) -> i0
+}


### PR DESCRIPTION
This PR makes the undocumented support of i0 in comb official by removing the documentation stating it is not supported and adding a few tests to the canonicalizer (and marginally to the lowering to SV which has already been testing it for the most part).

[Associated RFC](https://discourse.llvm.org/t/rfc-support-zero-width-integers-in-the-comb-dialect-circt/78492)