### PR TITLE
Fix invalid rewriter API usages

### DIFF
--- a/lib/Dialect/HW/Transforms/FlattenIO.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenIO.cpp
@@ -63,8 +63,8 @@ struct OutputOpConversion : public OpConversionPattern<hw::OutputOp> {
     }
 
     // And replace.
-    rewriter.replaceOpWithNewOp<hw::OutputOp>(op, convOperands);
     opVisited->insert(op->getParentOp());
+    rewriter.replaceOpWithNewOp<hw::OutputOp>(op, convOperands);
     return success();
   }
   DenseSet<Operation *> *opVisited;


### PR DESCRIPTION
According to https://github.com/llvm/llvm-project/commit/6008cd40b7bbdc66555550c2e38648d5ce99cc78:
> This is invalid rewriter API usage: ops that were replaced/erased should not be accessed

I probably did not catch all invalid rewriter API usages since I have only checked `replaceOpWithNewOp` usages.
In general, one can create similar invalid API usages with `eraseOp` and `replaceOp`.