### PR TITLE
[HW] Moved and renamed arc/inlineModules to hw/flattenModules

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.h
+++ b/include/circt/Dialect/Arc/ArcPasses.h
@@ -34,7 +34,6 @@ std::unique_ptr<mlir::Pass> createGroupResetsAndEnablesPass();
 std::unique_ptr<mlir::Pass>
 createInferMemoriesPass(const InferMemoriesOptions &options = {});
 std::unique_ptr<mlir::Pass> createInlineArcsPass();
-std::unique_ptr<mlir::Pass> createInlineModulesPass();
 std::unique_ptr<mlir::Pass> createIsolateClocksPass();
 std::unique_ptr<mlir::Pass> createLatencyRetimingPass();
 std::unique_ptr<mlir::Pass> createLegalizeStateUpdatePass();

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -97,20 +97,6 @@ def InlineArcs : Pass<"arc-inline" , "mlir::ModuleOp"> {
   ];
 }
 
-def InlineModules : Pass<"arc-inline-modules", "mlir::ModuleOp"> {
-  let summary = "Eagerly inline private modules";
-  let description = [{
-    This pass eagerly inlines private HW modules into their instantiation sites.
-    After outlining combinational logic and registers into arcs, module bodies
-    become fairly lightweight. Since arc definitions now fulfill the purpose of
-    code reuse by allowing a single definition to be called multiple times, the
-    module hierarchy degenerates into a purely cosmetic construct. At that point
-    it is beneficial to fully flatten the module hierarchy to simplify further
-    analysis and optimization of state transfer arcs.
-  }];
-  let constructor = "circt::arc::createInlineModulesPass()";
-}
-
 def InferStateProperties : Pass<"arc-infer-state-properties",
                                 "mlir::ModuleOp"> {
   let summary = "Add resets and enables explicitly to the state operations";

--- a/include/circt/Dialect/HW/HWPasses.h
+++ b/include/circt/Dialect/HW/HWPasses.h
@@ -28,6 +28,7 @@ std::unique_ptr<mlir::Pass> createFlattenIOPass(bool recursiveFlag = true,
                                                 bool flattenExternFlag = false,
                                                 char joinChar = '.');
 std::unique_ptr<mlir::Pass> createVerifyInnerRefNamespacePass();
+std::unique_ptr<mlir::Pass> createFlattenModulesPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -44,6 +44,20 @@ def FlattenIO : Pass<"hw-flatten-io", "mlir::ModuleOp"> {
   ];
 }
 
+def FlattenModules : Pass<"hw-flatten-modules", "mlir::ModuleOp"> {
+  let summary = "Eagerly inline private modules";
+  let description = [{
+    This pass eagerly inlines private HW modules into their instantiation sites.
+    After outlining combinational logic and registers into arcs, module bodies
+    become fairly lightweight. Since arc definitions now fulfill the purpose of
+    code reuse by allowing a single definition to be called multiple times, the
+    module hierarchy degenerates into a purely cosmetic construct. At that point
+    it is beneficial to fully flatten the module hierarchy to simplify further
+    analysis and optimization of state transfer arcs.
+  }];
+  let constructor = "circt::hw::createFlattenModulesPass()";
+}
+
 def HWSpecialize : Pass<"hw-specialize", "mlir::ModuleOp"> {
   let summary = "Specializes instances of parametric hw.modules";
   let constructor = "circt::hw::createHWSpecializePass()";

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -48,12 +48,11 @@ def FlattenModules : Pass<"hw-flatten-modules", "mlir::ModuleOp"> {
   let summary = "Eagerly inline private modules";
   let description = [{
     This pass eagerly inlines private HW modules into their instantiation sites.
-    After outlining combinational logic and registers into arcs, module bodies
-    become fairly lightweight. Since arc definitions now fulfill the purpose of
-    code reuse by allowing a single definition to be called multiple times, the
-    module hierarchy degenerates into a purely cosmetic construct. At that point
-    it is beneficial to fully flatten the module hierarchy to simplify further
-    analysis and optimization of state transfer arcs.
+    This is necessary for verification purposes, as model checking backends do not 
+    require or support the use of module hierarchy. For simulation, module hierarchies 
+    degenerate into a purely cosmetic construct, at which point it is beneficial
+    to fully flatten the module hierarchy to simplify further analysis and 
+    optimization of state transfer arcs.
   }];
   let constructor = "circt::hw::createFlattenModulesPass()";
 }

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -7,7 +7,6 @@ add_circt_dialect_library(CIRCTArcTransforms
   InferMemories.cpp
   InferStateProperties.cpp
   InlineArcs.cpp
-  InlineModules.cpp
   IsolateClocks.cpp
   LatencyRetiming.cpp
   LegalizeStateUpdate.cpp

--- a/lib/Dialect/HW/Transforms/CMakeLists.txt
+++ b/lib/Dialect/HW/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_circt_dialect_library(CIRCTHWTransforms
   PrintHWModuleGraph.cpp
   FlattenIO.cpp
   VerifyInnerRefNamespace.cpp
+  FlattenModules.cpp
 
   DEPENDS
   CIRCTHWTransformsIncGen

--- a/lib/Dialect/HW/Transforms/FlattenModules.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenModules.cpp
@@ -1,4 +1,5 @@
-//===- InlineModules.cpp --------------------------------------------------===//
+//===- FlattenModules.cpp
+//--------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,10 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "circt/Dialect/Arc/ArcOps.h"
-#include "circt/Dialect/Arc/ArcPasses.h"
 #include "circt/Dialect/HW/HWInstanceGraph.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Support/BackedgeBuilder.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Pass/Pass.h"
@@ -17,24 +17,23 @@
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/Support/Debug.h"
 
-#define DEBUG_TYPE "arc-inline-modules"
+#define DEBUG_TYPE "hw-flatten-modules"
 
 namespace circt {
-namespace arc {
-#define GEN_PASS_DEF_INLINEMODULES
-#include "circt/Dialect/Arc/ArcPasses.h.inc"
-} // namespace arc
+namespace hw {
+#define GEN_PASS_DEF_FLATTENMODULES
+#include "circt/Dialect/HW/Passes.h.inc"
+} // namespace hw
 } // namespace circt
 
 using namespace circt;
-using namespace arc;
 using namespace hw;
 using namespace igraph;
 using mlir::InlinerInterface;
 
 namespace {
-struct InlineModulesPass
-    : public arc::impl::InlineModulesBase<InlineModulesPass> {
+struct FlattenModulesPass
+    : public circt::hw::impl::FlattenModulesBase<FlattenModulesPass> {
   void runOnOperation() override;
 };
 
@@ -90,7 +89,7 @@ struct PrefixingInliner : public InlinerInterface {
 };
 } // namespace
 
-void InlineModulesPass::runOnOperation() {
+void FlattenModulesPass::runOnOperation() {
   auto &instanceGraph = getAnalysis<hw::InstanceGraph>();
   DenseSet<Operation *> handled;
 
@@ -144,6 +143,6 @@ void InlineModulesPass::runOnOperation() {
   }
 }
 
-std::unique_ptr<Pass> arc::createInlineModulesPass() {
-  return std::make_unique<InlineModulesPass>();
+std::unique_ptr<Pass> circt::hw::createFlattenModulesPass() {
+  return std::make_unique<FlattenModulesPass>();
 }

--- a/test/Dialect/HW/flatten-modules.mlir
+++ b/test/Dialect/HW/flatten-modules.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --arc-inline-modules | FileCheck %s
+// RUN: circt-opt %s --hw-flatten-modules | FileCheck %s
 
 
 // CHECK-LABEL: hw.module @SimpleA

--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_tool(arcilator arcilator.cpp)
 target_link_libraries(arcilator
   PRIVATE
   CIRCTArc
+  CIRCTHWTransforms
   CIRCTArcToLLVM
   CIRCTArcTransforms
   CIRCTCombToArith

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -67,7 +67,6 @@
 
 using namespace mlir;
 using namespace circt;
-using namespace hw;
 using namespace arc;
 
 //===----------------------------------------------------------------------===//

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -20,6 +20,7 @@
 #include "circt/Dialect/Arc/ModelInfo.h"
 #include "circt/Dialect/Arc/ModelInfoExport.h"
 #include "circt/Dialect/Emit/EmitDialect.h"
+#include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/InitAllDialects.h"
 #include "circt/InitAllPasses.h"
@@ -66,6 +67,7 @@
 
 using namespace mlir;
 using namespace circt;
+using namespace hw;
 using namespace arc;
 
 //===----------------------------------------------------------------------===//
@@ -256,7 +258,7 @@ static void populateHwModuleToArcPipeline(PassManager &pm) {
   }
   if (shouldDedup)
     pm.addPass(arc::createDedupPass());
-  pm.addPass(arc::createInlineModulesPass());
+  pm.addPass(hw::createFlattenModulesPass());
   pm.addPass(createCSEPass());
   pm.addPass(arc::createArcCanonicalizerPass());
 


### PR DESCRIPTION
This PR moves the `arc::inlineModulesPass` to the HW dialect, all while renaming it to something more suitable for what it actually does, as per @fabianschuiki 's recommendation.