### PR TITLE
[Arc] Hoist reset value in CompReg when lowering for simulation

### DIFF
--- a/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
+++ b/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
@@ -560,6 +560,12 @@ CompRegCanonicalizer::matchAndRewrite(seq::CompRegOp op,
   if (!op.getReset())
     return failure();
 
+  // Because Arcilator supports constant zero reset values, skip them.
+  if (auto *resetValueDefiningOp = op.getResetValue().getDefiningOp())
+    if (auto constant = dyn_cast<hw::ConstantOp>(resetValueDefiningOp))
+      if (constant.getValue() == 0)
+        return failure();
+
   Value newInput = rewriter.create<comb::MuxOp>(
       op->getLoc(), op.getReset(), op.getResetValue(), op.getInput());
   rewriter.modifyOpInPlace(op, [&]() {

--- a/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
+++ b/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/Arc/ArcPasses.h"
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Support/Namespace.h"
 #include "circt/Support/SymCache.h"
 #include "mlir/IR/Matchers.h"
@@ -237,6 +238,12 @@ struct RemoveUnusedArcs : public SymOpRewritePattern<DefineOp> {
 struct ICMPCanonicalizer : public OpRewritePattern<comb::ICmpOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(comb::ICmpOp op,
+                                PatternRewriter &rewriter) const final;
+};
+
+struct CompRegCanonicalizer : public OpRewritePattern<seq::CompRegOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(seq::CompRegOp op,
                                 PatternRewriter &rewriter) const final;
 };
 
@@ -547,6 +554,23 @@ SinkArcInputsPattern::matchAndRewrite(DefineOp op,
   return success(toDelete.any());
 }
 
+LogicalResult
+CompRegCanonicalizer::matchAndRewrite(seq::CompRegOp op,
+                                      PatternRewriter &rewriter) const {
+  if (!op.getReset())
+    return failure();
+
+  Value newInput = rewriter.create<comb::MuxOp>(
+      op->getLoc(), op.getReset(), op.getResetValue(), op.getInput());
+  rewriter.modifyOpInPlace(op, [&]() {
+    op.getInputMutable().set(newInput);
+    op.getResetMutable().clear();
+    op.getResetValueMutable().clear();
+  });
+
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // ArcCanonicalizerPass implementation
 //===----------------------------------------------------------------------===//
@@ -594,7 +618,7 @@ void ArcCanonicalizerPass::runOnOperation() {
     dialect->getCanonicalizationPatterns(patterns);
   for (mlir::RegisteredOperationName op : ctxt.getRegisteredOperations())
     op.getCanonicalizationPatterns(patterns, &ctxt);
-  patterns.add<ICMPCanonicalizer>(&getContext());
+  patterns.add<ICMPCanonicalizer, CompRegCanonicalizer>(&getContext());
 
   // Don't test for convergence since it is often not reached.
   (void)mlir::applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),

--- a/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
+++ b/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
@@ -561,10 +561,10 @@ CompRegCanonicalizer::matchAndRewrite(seq::CompRegOp op,
     return failure();
 
   // Because Arcilator supports constant zero reset values, skip them.
-  if (auto *resetValueDefiningOp = op.getResetValue().getDefiningOp())
-    if (auto constant = dyn_cast<hw::ConstantOp>(resetValueDefiningOp))
-      if (constant.getValue() == 0)
-        return failure();
+  APInt constant;
+  if (mlir::matchPattern(op.getResetValue(), mlir::m_ConstantInt(&constant)))
+    if (constant.isZero())
+      return failure();
 
   Value newInput = rewriter.create<comb::MuxOp>(
       op->getLoc(), op.getReset(), op.getResetValue(), op.getInput());

--- a/test/Dialect/Arc/arc-canonicalizer.mlir
+++ b/test/Dialect/Arc/arc-canonicalizer.mlir
@@ -127,6 +127,21 @@ hw.module @icmpNeCanonicalizer(in %arg0: i1, in %arg1: i1, in %arg2: i1, in %arg
 }
 
 //===----------------------------------------------------------------------===//
+// CompRegCanonicalizer
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: hw.module @HoistCompRegReset
+// CHECK-SAME: in %[[CLOCK:[^ ]*]] : !seq.clock, in %[[INPUT:[^ ]*]] : i32, in %[[RESET:[^ ]*]] : i1, in %[[RESET_VALUE:[^ ]*]] : i32
+hw.module @HoistCompRegReset(in %clock: !seq.clock, in %input: i32, in %reset: i1, in %resetValue: i32, out out: i32) {
+  // CHECK: %[[NEW_INPUT:.*]] = comb.mux %[[RESET]], %[[RESET_VALUE]], %[[INPUT]] : i32
+  // CHECK: %[[REG:.*]] = seq.compreg %[[NEW_INPUT]], %[[CLOCK]] : i32
+  %reg = seq.compreg %input, %clock reset %reset, %resetValue : i32
+
+  // CHECK: hw.output %[[REG]] : i32
+  hw.output %reg : i32
+}
+
+//===----------------------------------------------------------------------===//
 // RemoveUnusedArcArguments
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/Arc/arc-canonicalizer.mlir
+++ b/test/Dialect/Arc/arc-canonicalizer.mlir
@@ -141,6 +141,19 @@ hw.module @HoistCompRegReset(in %clock: !seq.clock, in %input: i32, in %reset: i
   hw.output %reg : i32
 }
 
+// CHECK-LABEL: hw.module @NoHoistCompRegZeroResetValue
+// CHECK-SAME: in %[[CLOCK:[^ ]*]] : !seq.clock, in %[[INPUT:[^ ]*]] : i32, in %[[RESET:[^ ]*]] : i1
+hw.module @NoHoistCompRegZeroResetValue(in %clock: !seq.clock, in %input: i32, in %reset: i1, out out: i32) {
+  // CHECK: %[[ZERO:.*]] = hw.constant 0 : i32
+  %zero = hw.constant 0 : i32
+
+  // CHECK: %[[REG:.*]] = seq.compreg %[[INPUT]], %[[CLOCK]] reset %[[RESET]], %[[ZERO]] : i32
+  %reg = seq.compreg %input, %clock reset %reset, %zero : i32
+
+  // CHECK: hw.output %[[REG]] : i32
+  hw.output %reg : i32
+}
+
 //===----------------------------------------------------------------------===//
 // RemoveUnusedArcArguments
 //===----------------------------------------------------------------------===//

--- a/test/arcilator/compreg.mlir
+++ b/test/arcilator/compreg.mlir
@@ -1,0 +1,9 @@
+// RUN: arcilator %s
+
+// This test ensures that the pipeline completes, without checking the result.
+// This is to make sure compatibility for some constructs does not regress.
+
+hw.module @arbitrary_reset_value(in %value: i32, in %clock: !seq.clock, in %reset: i1, in %resetValue: i32, out out: i32) {
+    %reg = seq.compreg %value, %clock reset %reset, %resetValue : i32
+    hw.output %reg : i32
+}


### PR DESCRIPTION
Arcilator currently does not support non-zero reset values for compreg. This change canonicalizes reset values to a mux on the input, as it currently makes no difference for simulation purposes, and sidesteps the reset value limitations.