### PR TITLE
[SV][ExportVerilog] Add sv.func, sv.func.call{.procedural}, sv.func.dpi.import

### DIFF
--- a/include/circt/Conversion/ExportVerilog.h
+++ b/include/circt/Conversion/ExportVerilog.h
@@ -17,6 +17,9 @@
 #include "mlir/Pass/Pass.h"
 
 namespace circt {
+namespace hw {
+class HWModuleLike;
+} // namespace hw
 
 std::unique_ptr<mlir::Pass>
 createTestApplyLoweringOptionPass(llvm::StringRef options);

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -118,8 +118,8 @@ def HWLowerInstanceChoices : Pass<"hw-lower-instance-choices",
   ];
 }
 
-def PrepareForEmission : Pass<"prepare-for-emission",
-                              "hw::HWModuleOp"> {
+def PrepareForEmission : InterfacePass<"prepare-for-emission",
+                              "hw::HWModuleLike"> {
   let summary = "Prepare IR for ExportVerilog";
   let description = [{
     This pass runs only PrepareForEmission.

--- a/include/circt/Dialect/HW/ModuleImplementation.h
+++ b/include/circt/Dialect/HW/ModuleImplementation.h
@@ -18,6 +18,7 @@
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/OpImplementation.h"
 
 namespace circt {
 namespace hw {
@@ -50,7 +51,16 @@ void printModuleSignature(OpAsmPrinter &p, Operation *op,
 ParseResult parseModuleSignature(OpAsmParser &parser,
                                  SmallVectorImpl<PortParse> &args,
                                  TypeAttr &modType);
+
+void printModuleSignatureNew(OpAsmPrinter &p, Region &body,
+                             hw::ModuleType modType,
+                             ArrayRef<Attribute> portAttrs,
+                             ArrayRef<Location> locAttrs);
 void printModuleSignatureNew(OpAsmPrinter &p, HWModuleLike op);
+void getAsmBlockArgumentNamesImpl(mlir::Region &region,
+                                  OpAsmSetValueNameFn setNameFn);
+
+SmallVector<Location> getAllPortLocsImpl(hw::ModuleType modType);
 
 } // namespace module_like_impl
 } // namespace hw

--- a/include/circt/Dialect/SV/SVDialect.td
+++ b/include/circt/Dialect/SV/SVDialect.td
@@ -22,7 +22,7 @@ def SVDialect : Dialect {
     This dialect defines the `sv` dialect, which represents various
     SystemVerilog-specific constructs in an AST-like representation.
   }];
-  let dependentDialects = ["circt::comb::CombDialect"];
+  let dependentDialects = ["circt::comb::CombDialect", "circt::hw::HWDialect"];
 
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -12,6 +12,9 @@
 
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
+include "mlir/Interfaces/FunctionInterfaces.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "circt/Dialect/Emit/EmitOpInterfaces.td"
 
 //===----------------------------------------------------------------------===//
 // Control flow like-operations
@@ -878,4 +881,179 @@ def MacroDefOp : SVOp<"macro.def",
   let extraClassDeclaration = [{
     MacroDeclOp getReferencedMacro(const hw::HWSymbolCache *cache);
   }];
+}
+
+
+//===----------------------------------------------------------------------===//
+// Function/Call
+//===----------------------------------------------------------------------===//
+
+def FuncDPIImportOp: SVOp<"func.dpi.import", 
+  [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = "Emit a dpi import statement. See SV spec 35.4";
+
+  let arguments = (ins FlatSymbolRefAttr:$callee,
+                       OptionalAttr<StrAttr>: $linkage_name);
+  let results = (outs);
+
+  let assemblyFormat = "(`linkage` $linkage_name^)? $callee attr-dict";
+}
+
+def FuncOp : SVOp<"func", 
+     [IsolatedFromAbove, Symbol, OpAsmOpInterface, ProceduralRegion,
+      DeclareOpInterfaceMethods<HWModuleLike>,
+      DeclareOpInterfaceMethods<PortList>,
+      FunctionOpInterface, HasParent<"mlir::ModuleOp">]> {
+  let summary = "A System Verilog function";
+  let description = [{
+    `sv.func` reresents System Verilog function in SV spec 13.4.
+    Similar to HW module, it's allowed to mix the order of input
+    and output arguments. `sv.func` can be used for both function
+    declaration and definition, i.e. a function without a body
+    region is a declaration.
+
+    In SV there are two representations for function results,
+    "output argument" and "return value". Currently an output argument
+    is considered as as a return value if it's is the last argument
+    and has a special attribute `sv.func.explicitly_returned`.
+  }];
+
+  let arguments = (ins 
+    SymbolNameAttr:$sym_name,
+    TypeAttrOf<ModuleType>:$module_type,
+    OptionalAttr<DictArrayAttr>:$per_argument_attrs,
+    OptionalAttr<LocationArrayAttr>:$input_locs, // Null for actual definition.
+    OptionalAttr<LocationArrayAttr>:$result_locs,
+    OptionalAttr<StrAttr>:$verilogName
+  );
+
+  let results = (outs);
+  let regions = (region AnyRegion:$body);
+
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDeclaration = [{
+    static mlir::StringRef getExplicitlyReturnedAttrName() {
+      return "sv.func.explicitly_returned";
+    }
+
+    mlir::FunctionType getFunctionType() {
+      return getModuleType().getFuncType();
+    }
+
+    void setFunctionTypeAttr(mlir::TypeAttr mlirType) {
+      setModuleType(cast<hw::ModuleType>(mlirType.getValue()));
+    }
+
+    /// Returns the argument types of this function.
+    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+
+    /// Returns the result types of this function.
+    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+
+    Type getExplicitlyReturnedType();
+    
+    size_t getNumOutputs() {
+      return getResultTypes().size();
+    }
+
+    size_t getNumInputs() {
+      return getArgumentTypes().size();
+    }
+
+    ::mlir::Region *getCallableRegion() { return isExternal() ? nullptr : &getBody(); }
+    bool isDeclaration() { return isExternal(); }
+
+    /// OpAsmInterface
+    void getAsmBlockArgumentNames(mlir::Region &region,
+                                          mlir::OpAsmSetValueNameFn setNameFn);
+    SmallVector<hw::PortInfo> getPortList(bool excludeExplicitReturn);
+  }];
+  let extraClassDefinition = [{
+    hw::ModuleType $cppClass::getHWModuleType() {
+      return getModuleType();
+    }
+    void $cppClass::setHWModuleType(hw::ModuleType type) {
+      return setModuleType(type);
+    }
+    void $cppClass::setAllPortNames(llvm::ArrayRef<mlir::Attribute>) {
+    }
+
+    size_t $cppClass::getNumPorts() {
+      auto modty = getHWModuleType();
+      return modty.getNumPorts();
+    }
+
+    size_t $cppClass::getNumInputPorts() {
+      auto modty = getHWModuleType();
+      return modty.getNumInputs();
+    }
+
+    size_t $cppClass::getNumOutputPorts() {
+      auto modty = getHWModuleType();
+      return modty.getNumOutputs();
+    }
+
+    size_t $cppClass::getPortIdForInputId(size_t idx) {
+      auto modty = getHWModuleType();
+      return modty.getPortIdForInputId(idx);
+    }
+
+    size_t $cppClass::getPortIdForOutputId(size_t idx) {
+      auto modty = getHWModuleType();
+      return modty.getPortIdForOutputId(idx);
+    }
+  }];
+}
+
+class SVFuncCallBase<string mnemonic, list<Trait> traits = []>: SVOp<mnemonic, 
+  traits # [CallOpInterface, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+
+  let arguments = (ins FlatSymbolRefAttr:$callee, Variadic<AnyType>:$inputs);
+  let results = (outs Variadic<AnyType>);
+
+  let assemblyFormat = 
+      "$callee `(` $inputs `)` attr-dict `:` functional-type($inputs, results)";
+  
+  let extraClassDeclaration = [{
+    Value getExplicitlyReturnedValue(sv::FuncOp op);
+    
+    operand_range getArgOperands() {
+      return getInputs();
+    }
+    MutableOperandRange getArgOperandsMutable() {
+      return getInputsMutable();
+    }
+    mlir::CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<mlir::SymbolRefAttr>("callee");
+    }
+
+    /// Set the callee for this operation.
+    void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
+      (*this)->setAttr(getCalleeAttrName(), callee.get<mlir::SymbolRefAttr>());
+    }
+  }];
+}
+
+def FuncCallProceduralOp : SVFuncCallBase<"func.call.procedural", [ProceduralOp]> {
+  let summary = "Function call in a procedural region";
+}
+
+def FuncCallOp : SVFuncCallBase<"func.call", [NonProceduralOp]> {
+  let summary = "Function call in a non-procedural region";
+  let description = [{
+    This op represents a function call in a non-procedural region.
+    A function call in a non-procedural region must have a return
+    value and no output argument.
+  }];
+}
+
+def ReturnOp : SVOp<"return",
+                   [Pure, ReturnLike, Terminator, HasParent<"FuncOp">]> {
+  let summary = "Function return operation";
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+
+  let hasCustomAssemblyFormat = 1;
+  let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
+  let hasVerifier = 1;
 }

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -39,11 +39,13 @@ public:
             AlwaysCombOp, AlwaysFFOp, InitialOp, CaseOp,
             // Other Statements.
             AssignOp, BPAssignOp, PAssignOp, ForceOp, ReleaseOp, AliasOp,
-            FWriteOp, SystemFunctionOp, VerbatimOp,
+            FWriteOp, SystemFunctionOp, VerbatimOp, FuncCallOp,
+            FuncCallProceduralOp, ReturnOp,
             // Type declarations.
             InterfaceOp, InterfaceSignalOp, InterfaceModportOp,
             InterfaceInstanceOp, GetModportOp, AssignInterfaceSignalOp,
-            ReadInterfaceSignalOp, MacroDeclOp, MacroDefOp,
+            ReadInterfaceSignalOp, MacroDeclOp, MacroDefOp, FuncDPIImportOp,
+            FuncOp,
             // Verification statements.
             AssertOp, AssumeOp, CoverOp, AssertConcurrentOp, AssumeConcurrentOp,
             CoverConcurrentOp,
@@ -127,6 +129,9 @@ public:
   HANDLE(AliasOp, Unhandled);
   HANDLE(FWriteOp, Unhandled);
   HANDLE(SystemFunctionOp, Unhandled);
+  HANDLE(FuncCallProceduralOp, Unhandled);
+  HANDLE(FuncCallOp, Unhandled);
+  HANDLE(ReturnOp, Unhandled);
   HANDLE(VerbatimOp, Unhandled);
 
   // Type declarations.
@@ -139,6 +144,8 @@ public:
   HANDLE(ReadInterfaceSignalOp, Unhandled);
   HANDLE(MacroDefOp, Unhandled);
   HANDLE(MacroDeclOp, Unhandled);
+  HANDLE(FuncDPIImportOp, Unhandled);
+  HANDLE(FuncOp, Unhandled);
 
   // Verification statements.
   HANDLE(AssertOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -445,10 +445,10 @@ LogicalResult lowerHWInstanceChoices(mlir::ModuleOp module);
 /// For each module we emit, do a prepass over the structure, pre-lowering and
 /// otherwise rewriting operations we don't want to emit.
 LogicalResult prepareHWModule(Block &block, const LoweringOptions &options);
-LogicalResult prepareHWModule(hw::HWModuleOp module,
+LogicalResult prepareHWModule(hw::HWModuleLike module,
                               const LoweringOptions &options);
 
-void pruneZeroValuedLogic(hw::HWModuleOp module);
+void pruneZeroValuedLogic(Operation *module);
 
 /// Rewrite module names and interfaces to not conflict with each other or with
 /// Verilog keywords.

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -25,6 +25,7 @@
 #include "circt/Dialect/LTL/LTLDialect.h"
 #include "circt/Dialect/Verif/VerifDialect.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Interfaces/CallInterfaces.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -103,6 +104,38 @@ static void spillWiresForInstanceInputs(HWInstanceLike op) {
   }
 }
 
+// Introduces a wire to replace an output port SSA wire. If the operation
+// is in a procedural region, it creates a temporary logic, otherwise it
+// places a wire. The connecting op is inserted in the op's region.
+static void replacePortWithWire(ImplicitLocOpBuilder &builder, Operation *op,
+                                Value result, StringRef name) {
+
+  bool isProcedural = op->getParentOp()->hasTrait<ProceduralRegion>();
+
+  Value newTarget;
+  if (isProcedural) {
+    newTarget = builder.create<sv::LogicOp>(result.getType(),
+                                            builder.getStringAttr(name));
+  } else {
+    newTarget = builder.create<sv::WireOp>(result.getType(), name);
+  }
+
+  while (!result.use_empty()) {
+    auto newRead = builder.create<sv::ReadInOutOp>(newTarget);
+    OpOperand &use = *result.getUses().begin();
+    use.set(newRead);
+    newRead->moveBefore(use.getOwner());
+  }
+
+  Operation *connect;
+  if (isProcedural) {
+    connect = builder.create<sv::BPAssignOp>(newTarget, result);
+  } else {
+    connect = builder.create<sv::AssignOp>(newTarget, result);
+  }
+  connect->moveAfter(op);
+}
+
 static StringAttr getResName(Operation *op, size_t idx) {
   if (auto inst = dyn_cast<hw::InstanceOp>(op))
     return inst.getResultName(idx);
@@ -156,6 +189,33 @@ static void lowerInstanceResults(HWInstanceLike op) {
 
     auto connect = builder.create<AssignOp>(newWire, result);
     connect->moveAfter(op);
+  }
+}
+
+// Ensure that each output of a function call is used only by a wire or reg.
+static void lowerFunctionCallResults(Operation *op) {
+  Block *block = op->getParentOfType<HWModuleLike>().getBodyBlock();
+  auto builder = ImplicitLocOpBuilder::atBlockBegin(op->getLoc(), block);
+  auto callee = op->getAttrOfType<FlatSymbolRefAttr>("callee");
+  assert(callee);
+  SmallString<32> nameTmp{"_", callee.getValue(), "_"};
+
+  auto namePrefixSize = nameTmp.size();
+
+  for (auto [i, result] : llvm::enumerate(op->getResults())) {
+    if (result.hasOneUse()) {
+      Operation *user = *result.getUsers().begin();
+      if (isa<BPAssignOp, PAssignOp, AssignOp>(user)) {
+        // Move assign op after instance to resolve cyclic dependencies.
+        user->moveAfter(op);
+        continue;
+      }
+    }
+
+    nameTmp.resize(namePrefixSize);
+    // TODO: Use a result name as suffix.
+    nameTmp += std::to_string(i);
+    replacePortWithWire(builder, op, result, nameTmp);
   }
 }
 
@@ -906,6 +966,9 @@ static LogicalResult legalizeHWModule(Block &block,
         spillWiresForInstanceInputs(inst);
     }
 
+    if (auto call = dyn_cast<mlir::CallOpInterface>(op))
+      lowerFunctionCallResults(call);
+
     // If logic op is located in a procedural region, we have to move the logic
     // op declaration to a valid program point.
     if (isProceduralRegion && isa<LogicOp>(op)) {
@@ -1247,8 +1310,12 @@ static LogicalResult legalizeHWModule(Block &block,
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-LogicalResult ExportVerilog::prepareHWModule(hw::HWModuleOp module,
+LogicalResult ExportVerilog::prepareHWModule(hw::HWModuleLike module,
                                              const LoweringOptions &options) {
+  // Don't need to legalize modules without a body.
+  if (!module.getBodyBlock())
+    return success();
+
   // Zero-valued logic pruning.
   pruneZeroValuedLogic(module);
 
@@ -1267,7 +1334,7 @@ namespace {
 struct PrepareForEmissionPass
     : public PrepareForEmissionBase<PrepareForEmissionPass> {
   void runOnOperation() override {
-    HWModuleOp module = getOperation();
+    auto module = getOperation();
     LoweringOptions options(cast<mlir::ModuleOp>(module->getParentOp()));
     if (failed(prepareHWModule(module, options)))
       signalPassFailure();

--- a/lib/Conversion/ExportVerilog/PruneZeroValuedLogic.cpp
+++ b/lib/Conversion/ExportVerilog/PruneZeroValuedLogic.cpp
@@ -14,6 +14,7 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWPasses.h"
+#include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/PatternMatch.h"
@@ -241,9 +242,10 @@ static void addNoI0ResultPruningPattern(ConversionTarget &target,
 
 } // namespace
 
-void ExportVerilog::pruneZeroValuedLogic(hw::HWModuleOp module) {
-  ConversionTarget target(*module.getContext());
-  RewritePatternSet patterns(module.getContext());
+void ExportVerilog::pruneZeroValuedLogic(Operation *module) {
+  assert((isa<hw::HWModuleOp, sv::FuncOp>(module)));
+  ConversionTarget target(*module->getContext());
+  RewritePatternSet patterns(module->getContext());
   PruneTypeConverter typeConverter;
 
   target.addLegalDialect<sv::SVDialect, comb::CombDialect, hw::HWDialect>();

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -108,6 +108,7 @@ class EmitDialect;
 namespace hw {
 class HWDialect;
 class HWModuleOp;
+class HWModuleLike;
 } // namespace hw
 
 namespace hwarith {

--- a/lib/Conversion/VerifToSV/VerifToSV.cpp
+++ b/lib/Conversion/VerifToSV/VerifToSV.cpp
@@ -13,6 +13,7 @@
 #include "circt/Conversion/VerifToSV.h"
 #include "../PassDetail.h"
 #include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Verif/VerifOps.h"

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1731,7 +1731,7 @@ LogicalResult OutputOp::verify() {
   auto modResults = modType.getOutputTypes();
   OperandRange outputValues = getOperands();
   if (modResults.size() != outputValues.size()) {
-    emitOpError("must have same number of operands as region results.");
+    emitOpError("must have same number of operands as region results");
     return failure();
   }
 
@@ -1741,7 +1741,7 @@ LogicalResult OutputOp::verify() {
       emitOpError("output types must match module. In "
                   "operand ")
           << i << ", expected " << modResults[i] << ", but got "
-          << outputValues[i].getType() << ".";
+          << outputValues[i].getType();
       return failure();
     }
   }

--- a/lib/Dialect/HW/ModuleImplementation.cpp
+++ b/lib/Dialect/HW/ModuleImplementation.cpp
@@ -391,20 +391,21 @@ static const char *directionAsString(ModulePort::Direction dir) {
   abort();
   return "unknown";
 }
-
 void module_like_impl::printModuleSignatureNew(OpAsmPrinter &p,
-                                               HWModuleLike op) {
+                                               hw::HWModuleLike op) {
+  module_like_impl::printModuleSignatureNew(
+      p, op.getModuleBody(), op.getHWModuleType(), op.getAllPortAttrs(),
+      op.getAllPortLocs());
+}
 
-  Region &body = op.getModuleBody();
+void module_like_impl::printModuleSignatureNew(OpAsmPrinter &p, Region &body,
+                                               hw::ModuleType modType,
+                                               ArrayRef<Attribute> portAttrs,
+                                               ArrayRef<Location> locAttrs) {
   bool isExternal = body.empty();
   SmallString<32> resultNameStr;
   mlir::OpPrintingFlags flags;
   unsigned curArg = 0;
-
-  auto modType = op.getHWModuleType();
-  auto portAttrs = op.getAllPortAttrs();
-  auto locAttrs = op.getAllPortLocs();
-
   p << '(';
   for (auto [i, port] : llvm::enumerate(modType.getPorts())) {
     if (i > 0)
@@ -448,4 +449,21 @@ void module_like_impl::printModuleSignatureNew(OpAsmPrinter &p,
   }
 
   p << ')';
+}
+
+/// Get a special name to use when printing the entry block arguments of the
+/// region contained by an operation in this dialect.
+void module_like_impl::getAsmBlockArgumentNamesImpl(
+    mlir::Region &region, OpAsmSetValueNameFn setNameFn) {
+  if (region.empty())
+    return;
+  // Assign port names to the bbargs.
+  auto module = cast<HWModuleOp>(region.getParentOp());
+
+  auto *block = &region.front();
+  for (size_t i = 0, e = block->getNumArguments(); i != e; ++i) {
+    auto name = module.getInputName(i);
+    // Let mlir deterministically convert names to valid identifiers
+    setNameFn(block->getArgument(i), name);
+  }
 }

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -16,12 +16,14 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWSymCache.h"
 #include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/HW/ModuleImplementation.h"
 #include "circt/Dialect/SV/SVAttributes.h"
 #include "circt/Support/CustomDirectiveImpl.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/FunctionImplementation.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -2104,6 +2106,331 @@ ModportStructAttr ModportStructAttr::get(MLIRContext *context,
                                          ModportDirection direction,
                                          FlatSymbolRefAttr signal) {
   return get(context, ModportDirectionAttr::get(context, direction), signal);
+}
+
+//===----------------------------------------------------------------------===//
+// FuncOp
+//===----------------------------------------------------------------------===//
+
+ParseResult FuncOp::parse(OpAsmParser &parser, OperationState &result) {
+  auto builder = parser.getBuilder();
+  // Parse visibility.
+  (void)mlir::impl::parseOptionalVisibilityKeyword(parser, result.attributes);
+
+  // Parse the name as a symbol.
+  StringAttr nameAttr;
+  if (parser.parseSymbolName(nameAttr, SymbolTable::getSymbolAttrName(),
+                             result.attributes))
+    return failure();
+
+  SmallVector<hw::module_like_impl::PortParse> ports;
+  TypeAttr modType;
+  if (failed(
+          hw::module_like_impl::parseModuleSignature(parser, ports, modType)))
+    return failure();
+
+  result.addAttribute(FuncOp::getModuleTypeAttrName(result.name), modType);
+
+  // Convert the specified array of dictionary attrs (which may have null
+  // entries) to an ArrayAttr of dictionaries.
+  auto unknownLoc = builder.getUnknownLoc();
+  SmallVector<Attribute> attrs, inputLocs, outputLocs;
+  auto nonEmptyLocsFn = [unknownLoc](Attribute attr) {
+    return attr && cast<Location>(attr) != unknownLoc;
+  };
+
+  for (auto &port : ports) {
+    attrs.push_back(port.attrs ? port.attrs : builder.getDictionaryAttr({}));
+    auto loc = port.sourceLoc ? Location(*port.sourceLoc) : unknownLoc;
+    (port.direction == hw::PortInfo::Direction::Output ? outputLocs : inputLocs)
+        .push_back(loc);
+  }
+
+  result.addAttribute(FuncOp::getPerArgumentAttrsAttrName(result.name),
+                      builder.getArrayAttr(attrs));
+
+  if (llvm::any_of(outputLocs, nonEmptyLocsFn))
+    result.addAttribute(FuncOp::getResultLocsAttrName(result.name),
+                        builder.getArrayAttr(outputLocs));
+  // Parse the attribute dict.
+  if (failed(parser.parseOptionalAttrDictWithKeyword(result.attributes)))
+    return failure();
+
+  // Add the entry block arguments.
+  SmallVector<OpAsmParser::Argument, 4> entryArgs;
+  for (auto &port : ports)
+    if (port.direction != hw::ModulePort::Direction::Output)
+      entryArgs.push_back(port);
+
+  // Parse the optional function body. The printer will not print the body if
+  // its empty, so disallow parsing of empty body in the parser.
+  auto *body = result.addRegion();
+  llvm::SMLoc loc = parser.getCurrentLocation();
+
+  mlir::OptionalParseResult parseResult =
+      parser.parseOptionalRegion(*body, entryArgs,
+                                 /*enableNameShadowing=*/false);
+  if (parseResult.has_value()) {
+    if (failed(*parseResult))
+      return failure();
+    // Function body was parsed, make sure its not empty.
+    if (body->empty())
+      return parser.emitError(loc, "expected non-empty function body");
+  } else {
+    if (llvm::any_of(inputLocs, nonEmptyLocsFn))
+      result.addAttribute(FuncOp::getInputLocsAttrName(result.name),
+                          builder.getArrayAttr(inputLocs));
+  }
+
+  return success();
+}
+
+void FuncOp::getAsmBlockArgumentNames(mlir::Region &region,
+                                      mlir::OpAsmSetValueNameFn setNameFn) {
+  if (region.empty())
+    return;
+  // Assign port names to the bbargs.
+  auto func = cast<FuncOp>(region.getParentOp());
+
+  auto *block = &region.front();
+
+  auto names = func.getModuleType().getInputNames();
+  for (size_t i = 0, e = block->getNumArguments(); i != e; ++i) {
+    // Let mlir deterministically convert names to valid identifiers
+    setNameFn(block->getArgument(i), cast<StringAttr>(names[i]));
+  }
+}
+
+Type FuncOp::getExplicitlyReturnedType() {
+  if (!getPerArgumentAttrs() || getNumOutputs() == 0)
+    return {};
+
+  // Check if the last port is used as an explicit return.
+  auto lastArgument = getModuleType().getPorts().back();
+  auto lastArgumentAttr = dyn_cast<DictionaryAttr>(
+      getPerArgumentAttrsAttr()[getPerArgumentAttrsAttr().size() - 1]);
+
+  if (lastArgument.dir == hw::ModulePort::Output && lastArgumentAttr &&
+      lastArgumentAttr.getAs<UnitAttr>(getExplicitlyReturnedAttrName()))
+    return lastArgument.type;
+  return {};
+}
+
+ArrayRef<Attribute> FuncOp::getAllPortAttrs() {
+  if (getPerArgumentAttrs())
+    return getPerArgumentAttrs()->getValue();
+  return {};
+}
+
+void FuncOp::setAllPortAttrs(ArrayRef<Attribute> attrs) {
+  setPerArgumentAttrsAttr(ArrayAttr::get(getContext(), attrs));
+}
+
+void FuncOp::removeAllPortAttrs() { setPerArgumentAttrsAttr({}); }
+SmallVector<Location> FuncOp::getAllPortLocs() {
+  SmallVector<Location> portLocs;
+  portLocs.reserve(getNumPorts());
+  auto resultLocs = getResultLocsAttr();
+  unsigned inputCount = 0;
+  auto modType = getModuleType();
+  auto unknownLoc = UnknownLoc::get(getContext());
+  auto *body = getBodyBlock();
+  auto inputLocs = getInputLocsAttr();
+  for (unsigned i = 0, e = getNumPorts(); i < e; ++i) {
+    if (modType.isOutput(i)) {
+      auto loc = resultLocs
+                     ? cast<Location>(
+                           resultLocs.getValue()[portLocs.size() - inputCount])
+                     : unknownLoc;
+      portLocs.push_back(loc);
+    } else {
+      auto loc = body ? body->getArgument(inputCount).getLoc()
+                      : (inputLocs ? cast<Location>(inputLocs[inputCount])
+                                   : unknownLoc);
+      portLocs.push_back(loc);
+      ++inputCount;
+    }
+  }
+  return portLocs;
+}
+
+void FuncOp::setAllPortLocsAttrs(llvm::ArrayRef<mlir::Attribute> locs) {
+  SmallVector<Attribute> resultLocs, inputLocs;
+  unsigned inputCount = 0;
+  auto modType = getModuleType();
+  auto *body = getBodyBlock();
+  for (unsigned i = 0, e = getNumPorts(); i < e; ++i) {
+    if (modType.isOutput(i))
+      resultLocs.push_back(locs[i]);
+    else if (body)
+      body->getArgument(inputCount++).setLoc(cast<Location>(locs[i]));
+    else // Need to store locations in an attribute if declaration.
+      inputLocs.push_back(locs[i]);
+  }
+  setResultLocsAttr(ArrayAttr::get(getContext(), resultLocs));
+  if (!body)
+    setInputLocsAttr(ArrayAttr::get(getContext(), inputLocs));
+}
+
+SmallVector<hw::PortInfo> FuncOp::getPortList() { return getPortList(false); }
+
+hw::PortInfo FuncOp::getPort(size_t idx) {
+  auto modTy = getHWModuleType();
+  auto emptyDict = DictionaryAttr::get(getContext());
+  LocationAttr loc = getPortLoc(idx);
+  DictionaryAttr attrs = dyn_cast_or_null<DictionaryAttr>(getPortAttrs(idx));
+  if (!attrs)
+    attrs = emptyDict;
+  return {modTy.getPorts()[idx],
+          modTy.isOutput(idx) ? modTy.getOutputIdForPortId(idx)
+                              : modTy.getInputIdForPortId(idx),
+          attrs, loc};
+}
+
+SmallVector<hw::PortInfo> FuncOp::getPortList(bool excludeExplicitReturn) {
+  auto modTy = getModuleType();
+  auto emptyDict = DictionaryAttr::get(getContext());
+  auto skipLastArgument = getExplicitlyReturnedType() && excludeExplicitReturn;
+  SmallVector<hw::PortInfo> retval;
+  auto portAttr = getAllPortLocs();
+  for (unsigned i = 0, e = skipLastArgument ? modTy.getNumPorts() - 1
+                                            : modTy.getNumPorts();
+       i < e; ++i) {
+    DictionaryAttr attrs = emptyDict;
+    if (auto perArgumentAttr = getPerArgumentAttrs())
+      if (auto argumentAttr =
+              dyn_cast_or_null<DictionaryAttr>((*perArgumentAttr)[i]))
+        attrs = argumentAttr;
+
+    retval.push_back({modTy.getPorts()[i],
+                      modTy.isOutput(i) ? modTy.getOutputIdForPortId(i)
+                                        : modTy.getInputIdForPortId(i),
+                      attrs, portAttr[i]});
+  }
+  return retval;
+}
+
+void FuncOp::print(OpAsmPrinter &p) {
+  FuncOp op = *this;
+  // Print the operation and the function name.
+  auto funcName =
+      op->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())
+          .getValue();
+  p << ' ';
+
+  StringRef visibilityAttrName = SymbolTable::getVisibilityAttrName();
+  if (auto visibility = op->getAttrOfType<StringAttr>(visibilityAttrName))
+    p << visibility.getValue() << ' ';
+  p.printSymbolName(funcName);
+  hw::module_like_impl::printModuleSignatureNew(
+      p, op.getBody(), op.getModuleType(),
+      op.getPerArgumentAttrsAttr()
+          ? ArrayRef<Attribute>(op.getPerArgumentAttrsAttr().getValue())
+          : ArrayRef<Attribute>{},
+      getAllPortLocs());
+
+  mlir::function_interface_impl::printFunctionAttributes(
+      p, op,
+      {visibilityAttrName, getModuleTypeAttrName(),
+       getPerArgumentAttrsAttrName(), getInputLocsAttrName(),
+       getResultLocsAttrName()});
+  // Print the body if this is not an external function.
+  Region &body = op->getRegion(0);
+  if (!body.empty()) {
+    p << ' ';
+    p.printRegion(body, /*printEntryBlockArgs=*/false,
+                  /*printBlockTerminators=*/true);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// ReturnOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ReturnOp::verify() {
+  auto func = getParentOp<sv::FuncOp>();
+  auto funcResults = func.getResultTypes();
+  auto returnedValues = getOperands();
+  if (funcResults.size() != returnedValues.size())
+    return emitOpError("must have same number of operands as region results.");
+  // Check that the types of our operands and the region's results match.
+  for (size_t i = 0, e = funcResults.size(); i < e; ++i) {
+    if (funcResults[i] != returnedValues[i].getType()) {
+      emitOpError("output types must match function. In "
+                  "operand ")
+          << i << ", expected " << funcResults[i] << ", but got "
+          << returnedValues[i].getType() << ".";
+      return failure();
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Call Ops
+//===----------------------------------------------------------------------===//
+
+static Value
+getExplicitlyReturnedValueImpl(sv::FuncOp op,
+                               mlir::Operation::result_range results) {
+  if (!op.getExplicitlyReturnedType())
+    return {};
+  return results.back();
+}
+
+Value FuncCallOp::getExplicitlyReturnedValue(sv::FuncOp op) {
+  return getExplicitlyReturnedValueImpl(op, getResults());
+}
+
+Value FuncCallProceduralOp::getExplicitlyReturnedValue(sv::FuncOp op) {
+  return getExplicitlyReturnedValueImpl(op, getResults());
+}
+
+LogicalResult
+FuncCallProceduralOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto referencedOp = dyn_cast_or_null<sv::FuncOp>(
+      symbolTable.lookupNearestSymbolFrom(*this, getCalleeAttr()));
+  if (!referencedOp)
+    return emitError("cannot find function declaration '")
+           << getCallee() << "'";
+  return success();
+}
+
+LogicalResult FuncCallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto referencedOp = dyn_cast_or_null<sv::FuncOp>(
+      symbolTable.lookupNearestSymbolFrom(*this, getCalleeAttr()));
+  if (!referencedOp)
+    return emitError("cannot find function declaration '")
+           << getCallee() << "'";
+
+  // Non-procedural call cannot have output arguments.
+  if (referencedOp.getNumOutputs() != 1 ||
+      !referencedOp.getExplicitlyReturnedType()) {
+    auto diag = emitError()
+                << "function called in a non-procedural region must "
+                   "return a single result";
+    diag.attachNote(referencedOp.getLoc()) << "doesn't satisfy the constraint";
+    return failure();
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// FuncDPIImportOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+FuncDPIImportOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto referencedOp = dyn_cast_or_null<sv::FuncOp>(
+      symbolTable.lookupNearestSymbolFrom(*this, getCalleeAttr()));
+
+  if (!referencedOp)
+    return emitError("cannot find function declaration '")
+           << getCallee() << "'";
+  if (!referencedOp.isDeclaration())
+    return emitError("imported function must be a declaration but '")
+           << getCallee() << "' is defined";
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -prepare-for-emission --split-input-file -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s --pass-pipeline='builtin.module(any(prepare-for-emission))' --split-input-file -verify-diagnostics | FileCheck %s
 // RUN: circt-opt %s -export-verilog -split-input-file
 
 // CHECK: @namehint_variadic

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1662,6 +1662,98 @@ hw.module @IndexPartSelect(out a : i3) {
   hw.output %c : i3
 }
 
+// Functions.
+sv.func private @function_declare1(in %in_0 : i2, out out_0: i2, in %in_1 : i2, out out_1 : i1)
+sv.func private @function_declare2(in %in_0 : i2, in %in_1 : i2, out out_0 : i1 {sv.func.explicitly_returned})
+sv.func private @function_declare3(in %in_0 : i2, out out_0 : i2, out out_1 : i1 {sv.func.explicitly_returned})
+
+// CHECK-LABEL: func_call
+hw.module @func_call(in %in_0 : i2, in %in_1 : i2, in %in_2: i1, out out: i1) {
+  %fd = hw.constant 0x80000002 : i32
+  // CHECK:      wire        _function_declare2_0;
+  // CHECK-NEXT: logic [1:0] _function_declare3_0;
+  // CHECK-NEXT: logic       _function_declare3_1;
+  // CHECK-NEXT: logic [1:0] _function_declare1_0;
+  // CHECK-NEXT: logic       _function_declare1_1;
+  // CHECK-NEXT: _function_declare2_0 = function_declare2(in_0, in_1);
+  %u1 = sv.func.call @function_declare2 (%in_0, %in_1) : (i2, i2) -> i1
+  // CHECK:      initial begin
+  // CHECK-NEXT:  function_declare1(in_0, _function_declare1_0, in_1, _function_declare1_1);
+  // CHECK-NEXT:  _function_declare3_1 = function_declare3(in_0, _function_declare3_0);
+  // CHECK-NEXT:  $fwrite(32'h80000002, "%x %x %x %x\n", _function_declare1_0, _function_declare1_1,
+  // CHECK-NEXT:          _function_declare3_0, _function_declare3_1);
+  // CHECK-NEXT: end
+  sv.initial {
+    %v1, %v2 = sv.func.call.procedural @function_declare1 (%in_0, %in_1) : (i2, i2) -> (i2, i1)
+    %v3, %v4 = sv.func.call.procedural @function_declare3 (%in_0, %in_1) : (i2, i2) -> (i2, i1)
+    sv.fwrite %fd, "%x %x %x %x\n"(%v1, %v2, %v3, %v4) : i2, i1, i2, i1
+  }
+  hw.output %u1: i1
+}
+
+// CHECK-LABEL: function automatic logic func_def(
+// CHECK-NEXT:    input  [1:0] in_0,
+// CHECK-NEXT:    output       out_0,
+// CHECK-NEXT:    input  [1:0] in_1
+// CHECK-NEXT:  );
+// CHECK-EMPTY:
+// CHECK-NEXT:    logic [1:0] _GEN = 2'(in_0 + in_1);
+// CHECK-NEXT:    out_0 = _GEN[0];
+// CHECK-NEXT:    func_def = _GEN[1];
+// CHECK-NEXT:  endfunction
+sv.func @func_def(in %in_0 : i2, out out_0: i1, in %in_1: i2, out out_1 : i1 {sv.func.explicitly_returned}) {
+  %add = comb.add %in_0, %in_1: i2
+  %v0 =  comb.extract %add from 0 : (i2) -> i1
+  %v1 =  comb.extract %add from 1 : (i2) -> i1
+  sv.return %v0, %v1: i1, i1
+}
+
+// CHECK-LABEL: function automatic logic [31:0] recurse_add(
+// CHECK-NEXT:   input [31:0] n
+// CHECK-NEXT: );
+// CHECK-EMPTY:
+// CHECK-NEXT:   logic           [31:0] _recurse_add_0;
+// CHECK-NEXT:   logic           [31:0] result;
+// CHECK-NEXT:   if (n <= 32'h1)
+// CHECK-NEXT:     result = n;
+// CHECK-NEXT:   else begin
+// CHECK-NEXT:     _recurse_add_0 = recurse_add(32'(n - 32'h1));
+// CHECK-NEXT:     result = 32'(n + _recurse_add_0);
+// CHECK-NEXT:   end
+// CHECK-NEXT:   recurse_add = result
+// CHECK-NEXT: endfunction
+sv.func @recurse_add(in %n : i32, out out : i32 {sv.func.explicitly_returned}) {
+  %one = hw.constant 1 : i32
+  %cond = comb.icmp bin ule %n, %one: i32
+  %result = sv.logic : !hw.inout<i32>
+  sv.if %cond {
+    sv.bpassign %result, %n: i32
+  } else {
+    %n1 = comb.sub %n, %one: i32
+    %v = sv.func.call.procedural @recurse_add(%n1) : (i32) -> i32
+    %add = comb.add %n, %v: i32
+    sv.bpassign %result, %add: i32
+  }
+  %read = sv.read_inout %result: !hw.inout<i32>
+  sv.return %read : i32
+}
+
+// Emit DPI import.
+
+// CHECK-LABEL: import "DPI-C" linkage_name = function void function_declare1(
+// CHECK-NEXT:    input [1:0] in_0,
+// CHECK-NEXT:                out_0,
+// CHECK-NEXT:                in_1,
+// CHECK-NEXT:    output out_1
+// CHECK-NEXT: );
+sv.func.dpi.import linkage "linkage_name" @function_declare1
+
+// CHECK-LABEL: import "DPI-C" function logic function_declare2(
+// CHECK-NEXT:    input [1:0] in_0,
+// CHECK-NEXT:                in_1
+// CHECK-NEXT: );
+sv.func.dpi.import @function_declare2
+
 sv.macro.decl @FOO
 sv.macro.decl @BAR
 

--- a/test/Dialect/HW/locations.mlir
+++ b/test/Dialect/HW/locations.mlir
@@ -12,6 +12,14 @@ hw.module.extern @test4(in %input: i7, out output: i7)
 hw.module.extern @test5(in %input: i7 {hw.arg = "arg"}, out output: i7 {hw.res = "res"})
 hw.module.extern @test6(in %input: i7 loc("arg"), out output: i7 loc("res"))
 hw.module.extern @test7(in %input: i7 {hw.arg = "arg"} loc("arg"), out output: i7 {hw.res = "res"} loc("res"))
+sv.func @test8(in %input: i7, out output: i7) { sv.return %input : i7 }
+sv.func @test9(in %input: i7 {hw.arg = "arg"}, out output: i7 {hw.res = "res"}) { sv.return %input : i7 }
+sv.func @test10(in %input: i7 loc("arg"), out output: i7 loc("res")) { sv.return %input : i7 }
+sv.func @test11(in %input: i7 {hw.arg = "arg"} loc("arg"), out output: i7 {hw.res = "res"} loc("res")) { sv.return %input : i7 }
+sv.func private @test12(in %input: i7, out output: i7)
+sv.func private @test13(in %input: i7 {hw.arg = "arg"}, out output: i7 {hw.res = "res"})
+sv.func private @test14(in %input: i7 loc("arg"), out output: i7 loc("res"))
+sv.func private @test15(in %input: i7 {hw.arg = "arg"} loc("arg"), out output: i7 {hw.res = "res"} loc("res"))
 
 // BASIC: hw.module @test0(in %input : i7, out output : i7)
 // BASIC: hw.module @test1(in %input : i7 {hw.arg = "arg"}, out output : i7 {hw.res = "res"})
@@ -21,6 +29,14 @@ hw.module.extern @test7(in %input: i7 {hw.arg = "arg"} loc("arg"), out output: i
 // BASIC: hw.module.extern @test5(in %input : i7 {hw.arg = "arg"}, out output : i7 {hw.res = "res"})
 // BASIC: hw.module.extern @test6(in %input : i7, out output : i7)
 // BASIC: hw.module.extern @test7(in %input : i7 {hw.arg = "arg"}, out output : i7 {hw.res = "res"})
+// BASIC: sv.func @test8(in %input : i7, out output : i7)
+// BASIC: sv.func @test9(in %input : i7 {hw.arg = "arg"}, out output : i7 {hw.res = "res"})
+// BASIC: sv.func @test10(in %input : i7, out output : i7)
+// BASIC: sv.func @test11(in %input : i7 {hw.arg = "arg"}, out output : i7 {hw.res = "res"})
+// BASIC: sv.func private @test12(in %input : i7, out output : i7)
+// BASIC: sv.func private @test13(in %input : i7 {hw.arg = "arg"}, out output : i7 {hw.res = "res"})
+// BASIC: sv.func private @test14(in %input : i7, out output : i7)
+// BASIC: sv.func private @test15(in %input : i7 {hw.arg = "arg"}, out output : i7 {hw.res = "res"})
 
 // DEBUG: hw.module @test0(in %input : i7 loc({{.+}}), out output : i7 loc({{.+}}))
 // DEBUG: hw.module @test1(in %input : i7 {hw.arg = "arg"} loc({{.+}}), out output : i7 {hw.res = "res"} loc({{.+}}))
@@ -30,3 +46,11 @@ hw.module.extern @test7(in %input: i7 {hw.arg = "arg"} loc("arg"), out output: i
 // DEBUG: hw.module.extern @test5(in %input : i7 {hw.arg = "arg"} loc({{.+}}), out output : i7 {hw.res = "res"} loc({{.+}}))
 // DEBUG: hw.module.extern @test6(in %input : i7 loc("arg"), out output : i7 loc("res"))
 // DEBUG: hw.module.extern @test7(in %input : i7 {hw.arg = "arg"} loc("arg"), out output : i7 {hw.res = "res"} loc("res"))
+// DEBUG: sv.func @test8(in %input : i7 loc({{.+}}), out output : i7 loc({{.+}}))
+// DEBUG: sv.func @test9(in %input : i7 {hw.arg = "arg"} loc({{.+}}), out output : i7 {hw.res = "res"} loc({{.+}}))
+// DEBUG: sv.func @test10(in %input : i7 loc("arg"), out output : i7 loc("res"))
+// DEBUG: sv.func @test11(in %input : i7 {hw.arg = "arg"} loc("arg"), out output : i7 {hw.res = "res"} loc("res"))
+// DEBUG: sv.func private @test12(in %input : i7 loc({{.+}}), out output : i7 loc({{.+}}))
+// DEBUG: sv.func private @test13(in %input : i7 {hw.arg = "arg"} loc({{.+}}), out output : i7 {hw.res = "res"} loc({{.+}}))
+// DEBUG: sv.func private @test14(in %input : i7 loc("arg"), out output : i7 loc("res"))
+// DEBUG: sv.func private @test15(in %input : i7 {hw.arg = "arg"} loc("arg"), out output : i7 {hw.res = "res"} loc("res"))

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -389,3 +389,22 @@ hw.module @XMRRefOp() {
   // CHECK: %1 = sv.xmr.ref @ref2 ".x.y.z[42]" : !hw.inout<i8>
   %1 = sv.xmr.ref @ref2 ".x.y.z[42]" : !hw.inout<i8>
 }
+
+// Functions.
+// CHECK-LABEL: sv.func private @function_declare(in %in_0 : i2, in %in_1 : i2, out out_0 : i1, in %in_2 : !hw.array<2xi2>)
+sv.func private @function_declare(in %in_0 : i2, in %in_1 : i2, out out_0 : i1, in %in_2 : !hw.array<2xi2>)
+
+// CHECK-LABEL: sv.func private @function_define(in %in_0 : i2, in %in_1 : i2, out out_0 : i1, in %in_2 : !hw.array<2xi2>)
+sv.func private @function_define(in %in_0 : i2, in %in_1 : i2, out out_0 : i1, in %in_2 : !hw.array<2xi2>) attributes {test = "foo"} {
+  %0 = comb.icmp eq %in_0, %in_1: i2
+  // CHECK: sv.return %{{.+}} : i1
+  sv.return %0 : i1
+}
+
+// CHECK-LABEL: sv.func @recurse(in %n : i32, out out : i32) {
+// CHECK: %0 = sv.func.call.procedural @recurse(%n) : (i32) -> i32
+// CHECK-NEXT:  sv.return %0
+sv.func @recurse(in %n : i32, out out : i32) {
+  %v = sv.func.call.procedural @recurse(%n) : (i32) -> i32
+  sv.return %v : i32
+}

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -238,3 +238,45 @@ hw.module @NoMessage(in %clock: i1, in %value : i4) {
    "sv.assert"(%clock, %value) { defer = 0 : i32 } : (i1, i4) -> ()
   }
 }
+
+// -----
+
+sv.func private @function() {
+  %0 = hw.constant true
+  // expected-error @below {{'sv.return' op must have same number of operands as region results}}
+  sv.return %0 : i1
+}
+
+// -----
+
+sv.func private @function(out out: i2) {
+  %0 = hw.constant true
+  // expected-error @below {{'sv.return' op output types must match function. In operand 0, expected 'i2', but got 'i1'}}
+  sv.return %0 : i1
+}
+
+// -----
+
+hw.module private @module(out out: i2) {
+  %0 = hw.constant true
+  // expected-error @below {{'sv.return' op expects parent op 'sv.func'}}
+  sv.return %0 : i1
+}
+
+// -----
+
+// expected-note @below {{doesn't satisfy the constraint}}
+sv.func private @func(out out: i1)
+hw.module private @call(){
+  // expected-error @below {{function called in a non-procedural region must return a single result}}
+  %0 = sv.func.call @func() : () -> (i1)
+}
+
+// -----
+
+sv.func private @func() {
+  sv.return
+}
+
+// expected-error @below {{imported function must be a declaration but 'func' is defined}}
+sv.func.dpi.import @func


### PR DESCRIPTION

This PR adds operations sv.func, sv.func.call{.procedural} and sv.func.dpi.import to SV. 

sv.func op is model as a mixture of func.func and hw.module. Similar to hw.module, sv.func can mix the order of input and output arguments. sv.func implements FunctionOpInterface and can declare a function by an empty body region like func.func

Code around PrepareForEmission is ported from https://github.com/llvm/circt/pull/6559.



```mlir
sv.func @fib(in %n : i32, out out : i32 {sv.func.explicitly_returned}) {
  %one = hw.constant 1 : i32
  %two = hw.constant 2 : i32
  %cond = comb.icmp bin ule %n, %one: i32
  %result = sv.logic : !hw.inout<i32>
  sv.if %cond {
    sv.bpassign %result, %n: i32 
  } else {
    %n1 = comb.sub %n, %one: i32
    %result1 = sv.func.call.procedural @fib(%n1) : (i32) -> i32
    %n2 = comb.sub %n, %two: i32
    %result2 = sv.func.call.procedural @fib(%n2) : (i32) -> i32
    %add = comb.add %n1, %n2: i32
    sv.bpassign %result, %add: i32 
  }
  %read = sv.read_inout %result: !hw.inout<i32>
  sv.return %read : i32
}
```

 
```verilog
function automatic logic [31:0] fib(    // test.mlir:1:1
  input [31:0] n        // test.mlir:1:17
);

  logic           [31:0] _fib_0;        // test.mlir:12:16
  logic           [31:0] _fib_0_0;      // test.mlir:10:16
  logic           [31:0] result;        // test.mlir:5:13
  if (n <= 32'h1)       // test.mlir:2:10, :4:11, :6:3
    result = n; // test.mlir:7:5
  else begin    // test.mlir:6:3
    logic           [31:0] _GEN = n - 32'h1;    // test.mlir:2:10, :9:11
    logic           [31:0] _GEN_0 = n - 32'h2;  // test.mlir:3:10, :11:11
    _fib_0_0 = fib(_GEN);       // test.mlir:9:11, :10:16
    _fib_0 = fib(_GEN_0);       // test.mlir:11:11, :12:16
    result = _GEN + _GEN_0;     // test.mlir:9:11, :11:11, :13:12, :14:5
  end
  fib = result; // test.mlir:16:11, :17:3
endfunction
```