### PR TITLE
[FIRRTL] Add inline convention to layers

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
@@ -51,7 +51,9 @@ def ConventionAttr : EnumAttr<FIRRTLDialect, Convention, "convention">;
 //===----------------------------------------------------------------------===//
 
 def LayerConvention : I32EnumAttr<"LayerConvention", "layer convention", [
-  I32EnumAttrCase<"Bind", 0, "bind">]> {
+  I32EnumAttrCase<"Bind", 0, "bind">,
+  I32EnumAttrCase<"Inline", 1, "inline">
+]> {
 
   let genSpecializedAttr = 0;
 }

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -692,14 +692,14 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:    layer GroupB, bind :
   // CHECK-NEXT:      layer GroupC, bind :
   // CHECK-NEXT:      layer GroupD, bind :
-  // CHECK-NEXT:        layer GroupE, bind :
+  // CHECK-NEXT:        layer GroupE, inline :
   // CHECK-NEXT:    layer GroupF, bind :
   firrtl.layer @GroupA bind {
     firrtl.layer @GroupB bind {
       firrtl.layer @GroupC bind {
       }
       firrtl.layer @GroupD bind {
-        firrtl.layer @GroupE bind {
+        firrtl.layer @GroupE inline {
         }
       }
     }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1470,14 +1470,14 @@ circuit Layers:
     layer B, bind:
       layer C, bind:
       layer D, bind:
-        layer E, bind:
+        layer E, inline:
     layer F, bind:
     ; CHECK-NEXT: firrtl.layer @A bind {
     ; CHECK-NEXT:   firrtl.layer @B bind {
     ; CHECK-NEXT:     firrtl.layer @C bind {
     ; CHECK-NEXT:     }
     ; CHECK-NEXT:     firrtl.layer @D bind {
-    ; CHECK-NEXT:       firrtl.layer @E bind {
+    ; CHECK-NEXT:       firrtl.layer @E inline {
     ; CHECK-NEXT:       }
     ; CHECK-NEXT:     }
     ; CHECK-NEXT:   }

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -65,8 +65,10 @@ firrtl.module @Foo(in %clock: !firrtl.clock) {
   firrtl.strictconnect %inst_clock, %clock : !firrtl.clock
 }
 
+// CHECK-LABEL: firrtl.layer @LayerA bind
+// CHECK-NEXT:    firrtl.layer @LayerB inline
 firrtl.layer @LayerA bind {
-  firrtl.layer @LayerB bind {}
+  firrtl.layer @LayerB inline {}
 }
 
 // CHECK-LABEL: firrtl.module @Layers


### PR DESCRIPTION
Add an "inline" convention to layers by adding this to the existing enumeration.  By the nature of how the parser works, this automatically adds support to parse this attribute without modifications to the parser.

This does not add any support for this in the FIRRTL pipeline.