### PR TITLE
[FIRRTL] Drop dead ScalaClassAnnotation.

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -838,26 +838,6 @@ Example:
 }
 ```
 
-### ScalaClassAnnotation
-
-| Property   | Type   | Description                                     |
-| ---------- | ------ | -------------                                   |
-| class      | string | `sifive.enterprise.firrtl.ScalaClassAnnotation` |
-| target     | string | Reference target                                |
-| className  | string | The corresponding class name                    |
-
-This annotation records the name of the Java or Scala class which corresponds
-to the module.
-
-Example:
-```json
-{
-  "class":"sifive.enterprise.firrtl.ScalaClassAnnotation",
-  "target":"Top.ClockGroupAggregator",
-  "className":"freechips.rocketchip.prci.ClockGroupAggregator"
-}
-```
-
 ### SitestBlackBoxAnnotation
 
 | Property   | Type   | Description                                         |

--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -153,8 +153,6 @@ constexpr const char *prefixModulesAnnoClass =
     "sifive.enterprise.firrtl.NestedPrefixModulesAnnotation";
 constexpr const char *dontObfuscateModuleAnnoClass =
     "sifive.enterprise.firrtl.DontObfuscateModuleAnnotation";
-constexpr const char *scalaClassAnnoClass =
-    "sifive.enterprise.firrtl.ScalaClassAnnotation";
 constexpr const char *elaborationArtefactsDirectoryAnnoClass =
     "sifive.enterprise.firrtl.ElaborationArtefactsDirectory";
 constexpr const char *testHarnessPathAnnoClass =

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -519,7 +519,7 @@ void CircuitLoweringState::processRemainingAnnotations(
             // The following are inspected (but not consumed) by FIRRTL/GCT
             // passes that have all run by now. Since no one is responsible for
             // consuming these, they will linger around and can be ignored.
-            scalaClassAnnoClass, dutAnnoClass, metadataDirectoryAttrName,
+            dutAnnoClass, metadataDirectoryAttrName,
             elaborationArtefactsDirectoryAnnoClass, testBenchDirAnnoClass,
             // This annotation is used to mark which external modules are
             // imported blackboxes from the BlackBoxReader pass.

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -776,14 +776,6 @@ CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
         }))
       continue;
 
-    // If its a blacklisted scala class, skip it.
-    if (auto scalaAnno = annos.getAnnotation(scalaClassAnnoClass)) {
-      auto scalaClass = scalaAnno.getMember<StringAttr>("className");
-      if (scalaClass &&
-          llvm::is_contained(classBlackList, scalaClass.getValue()))
-        continue;
-    }
-
     // Record the defname of the module.
     if (!dutMod || dutModuleSet.contains(extModule)) {
       dutModules.push_back(*extModule.getDefname());
@@ -824,10 +816,6 @@ CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
 
   createOutput(testModules, testFilename);
   createOutput(dutModules, dutFilename);
-
-  // Clean up all ScalaClassAnnotations, which are no longer needed.
-  for (auto op : circuitOp.getOps<FModuleLike>())
-    AnnotationSet::removeAnnotations(op, scalaClassAnnoClass);
 
   return success();
 }

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -735,11 +735,8 @@ CreateSiFiveMetadataPass::emitRetimeModulesMetadata(ObjectModelIR &omir) {
 LogicalResult
 CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
 
-  // Any extmodule with these annotations or one of these ScalaClass classes
-  // should be excluded from the blackbox list.
-  std::array<StringRef, 3> classBlackList = {
-      "freechips.rocketchip.util.BlackBoxedROM",
-      "sifive.enterprise.grandcentral.MemTap"};
+  // Any extmodule with these annotations should be excluded from the blackbox
+  // list.
   std::array<StringRef, 6> blackListedAnnos = {
       blackBoxAnnoClass, blackBoxInlineAnnoClass, blackBoxPathAnnoClass,
       dataTapsBlackboxClass, memTapBlackboxClass};

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -122,7 +122,6 @@ firrtl.circuit "Foo" attributes {annotations = [
         {class = "firrtl.transforms.NoDedupAnnotation"},
         {class = "sifive.enterprise.firrtl.DontObfuscateModuleAnnotation"},
         {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"},
-        {class = "sifive.enterprise.firrtl.ScalaClassAnnotation"},
         {class = "firrtl.transforms.BlackBox", circt.nonlocal = @nla_1}
     ]} {}
     // Non-local annotations should not produce errors either.

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -122,14 +122,9 @@ firrtl.circuit "BasicBlackboxes" attributes { annotations = [{
   // These should all be ignored.
   firrtl.extmodule @ignored0() attributes {annotations = [{class = "firrtl.transforms.BlackBoxInlineAnno"}], defname = "ignored0"}
   firrtl.extmodule @ignored1() attributes {annotations = [{class = "firrtl.transforms.BlackBoxPathAnno"}], defname = "ignored1"}
-  firrtl.extmodule @ignored2() attributes {annotations = [{class = "sifive.enterprise.firrtl.ScalaClassAnnotation", className = "freechips.rocketchip.util.BlackBoxedROM"}], defname = "ignored2"}
-  firrtl.extmodule @ignored3() attributes {annotations = [{class = "sifive.enterprise.grandcentral.DataTapsAnnotation.blackbox"}], defname = "ignored3"}
-  firrtl.extmodule @ignored4() attributes {annotations = [{class = "sifive.enterprise.grandcentral.MemTapAnnotation.blackbox", id = 4 : i64}], defname = "ignored4"}
-  firrtl.extmodule @ignored5() attributes {annotations = [{class = "firrtl.transforms.BlackBox"}], defname = "ignored5"}
-
-  // ScalaClassAnnotation should be discarded after this pass.
-  // CHECK: firrtl.extmodule @ignored2()
-  // CHECK-NOT: sifive.enterprise.firrtl.ScalaClassAnnotation
+  firrtl.extmodule @ignored2() attributes {annotations = [{class = "sifive.enterprise.grandcentral.DataTapsAnnotation.blackbox"}], defname = "ignored2"}
+  firrtl.extmodule @ignored3() attributes {annotations = [{class = "sifive.enterprise.grandcentral.MemTapAnnotation.blackbox", id = 4 : i64}], defname = "ignored3"}
+  firrtl.extmodule @ignored4() attributes {annotations = [{class = "firrtl.transforms.BlackBox"}], defname = "ignored4"}
 
 // CHECK:    firrtl.class @SitestBlackBoxModulesSchema(in %[[moduleName_in:.+]]: !firrtl.string, out %moduleName: !firrtl.string) {
 // CHECK:      firrtl.propassign %moduleName, %[[moduleName_in]]


### PR DESCRIPTION
We've rejected this during LowerAnnotations since we've had LowerAnnotations, so it's safe to say this is thoroughly dead.

The internal source of this was removed in January.