### PR TITLE
[FIRRTL][SFCCompat] Fix tests and handling of fullasyncreset on non-port.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
@@ -46,13 +46,22 @@ void SFCCompatPass::runOnOperation() {
   bool madeModifications = false;
   SmallVector<InvalidValueOp> invalidOps;
 
-  bool fullAsyncResetExists = false;
-  AnnotationSet::removePortAnnotations(
+  auto fullAsyncResetAttr =
+      StringAttr::get(&getContext(), fullAsyncResetAnnoClass);
+  auto isFullAsyncResetAnno = [fullAsyncResetAttr](Annotation anno) {
+    return anno.getClassAttr() == fullAsyncResetAttr;
+  };
+  bool fullAsyncResetExists = AnnotationSet::removePortAnnotations(
       getOperation(), [&](unsigned argNum, Annotation anno) {
-        if (!anno.isClass(fullAsyncResetAnnoClass))
-          return false;
-        return fullAsyncResetExists = true;
+        return isFullAsyncResetAnno(anno);
       });
+  if (!fullAsyncResetExists) {
+    getOperation()->walk([&](Operation *op) {
+      fullAsyncResetExists |=
+          AnnotationSet::removeAnnotations(op, isFullAsyncResetAnno);
+    });
+  }
+  madeModifications |= fullAsyncResetExists;
 
   auto result = getOperation()->walk([&](Operation *op) {
     // Populate invalidOps for later handling.

--- a/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SFCCompat.cpp
@@ -55,12 +55,11 @@ void SFCCompatPass::runOnOperation() {
       getOperation(), [&](unsigned argNum, Annotation anno) {
         return isFullAsyncResetAnno(anno);
       });
-  if (!fullAsyncResetExists) {
-    getOperation()->walk([&](Operation *op) {
-      fullAsyncResetExists |=
-          AnnotationSet::removeAnnotations(op, isFullAsyncResetAnno);
-    });
-  }
+  getOperation()->walk(
+      [isFullAsyncResetAnno, &fullAsyncResetExists](Operation *op) {
+        fullAsyncResetExists |=
+            AnnotationSet::removeAnnotations(op, isFullAsyncResetAnno);
+      });
   madeModifications |= fullAsyncResetExists;
 
   auto result = getOperation()->walk([&](Operation *op) {

--- a/test/firtool/async-reset-anno.fir
+++ b/test/firtool/async-reset-anno.fir
@@ -1,14 +1,17 @@
-; RUN: firtool %s -parse-only | circt-opt -firrtl-infer-resets | FileCheck %s --check-prefix POST-INFER-RESETS
-; RUN: firtool %s -parse-only | circt-opt -firrtl-infer-resets -firrtl-sfc-compat | FileCheck %s --implicit-check-not POST-SFC-COMPAT-NOT
+; RUN: firtool %s -parse-only | circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-resets))'  | FileCheck %s --check-prefixes COMMON,POST-INFER-RESETS
+; RUN: firtool %s -parse-only | circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-resets,firrtl.module(firrtl-sfc-compat)))' | FileCheck %s --check-prefixes COMMON,POST-SFC-COMPAT
 
 ; Check that FullAsyncResetAnnotation exists after infer-resets pass
 ; but is deleted after sfc-compat
 
 FIRRTL version 3.3.0
-circuit test :%[[{
-  "class":"sifive.enterprise.firrtl.FullAsyncResetAnnotation",
-    "target":"~test|test>reset"
-    }]]
+circuit test :%[[
+{ "class":"sifive.enterprise.firrtl.FullAsyncResetAnnotation",
+  "target":"~test|test>reset" },
+{ "class":"sifive.enterprise.firrtl.FullAsyncResetAnnotation",
+  "target":"~test|foo>r" }
+]]
+  ; COMMON-LABEL: module @test
   module test :
     input clock : Clock
     input reset : AsyncReset
@@ -16,4 +19,16 @@ circuit test :%[[{
     ; POST-SFC-COMPAT-NOT: [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]
     input in : { foo : UInt<8>, bar : UInt<8>}
     output out : { foo : UInt<8>, bar : UInt<8>}
+    connect out, in
+
+  ; COMMON-LABEL: module private @foo
+  module foo :
+    input clock : Clock
+    input reset : AsyncReset
+    input in : { foo : UInt<8>, bar : UInt<8>}
+    output out : { foo : UInt<8>, bar : UInt<8>}
+
+    ; POST-INFER-RESETS: [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]
+    ; POST-SFC-COMPAT-NOT: [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]
+     wire r : AsyncReset
     connect out, in

--- a/test/firtool/async-reset.fir
+++ b/test/firtool/async-reset.fir
@@ -1,6 +1,7 @@
-; RUN: firtool %s | FileCheck %s
+; RUN: firtool --split-input-file %s | FileCheck %s
 
 FIRRTL version 3.3.0
+; CHECK-LABEL: module test(
 circuit test :%[[{
   "class":"sifive.enterprise.firrtl.FullAsyncResetAnnotation",
     "target":"~test|test>reset"
@@ -10,6 +11,36 @@ circuit test :%[[{
     input reset : AsyncReset
     input in : { foo : UInt<8>, bar : UInt<8>}
     output out : { foo : UInt<8>, bar : UInt<8>}
+
+    wire reg1_w : { foo : UInt<8>, bar : UInt<8>}
+    invalidate reg1_w.bar
+    invalidate reg1_w.foo
+    ; CHECK: reg1_foo <= 8'hC;
+    ; CHECK: reg1_bar <= 8'h0;
+    connect reg1_w.foo, UInt<8>(0hc)
+    invalidate reg1_w.bar
+    ; CHECK: reg1_foo = 8'hC;
+    ; CHECK: reg1_bar = 8'h0;
+    regreset reg1 : { foo : UInt<8>, bar : UInt<8>}, clock, reset, reg1_w
+    wire reg2 : { foo : UInt<8>, bar : UInt<8>}
+    connect reg1, in
+    connect reg2, reg1
+    connect out, reg2
+
+;// -----
+; CHECK-LABEL: module test_wire(
+FIRRTL version 3.3.0
+circuit test_wire :%[[{
+  "class":"sifive.enterprise.firrtl.FullAsyncResetAnnotation",
+    "target":"~test_wire|test_wire>reset"
+  }]]
+  module test_wire :
+    input clock : Clock
+    input r : AsyncReset
+    input in : { foo : UInt<8>, bar : UInt<8>}
+    output out : { foo : UInt<8>, bar : UInt<8>}
+
+    node reset = r
 
     wire reg1_w : { foo : UInt<8>, bar : UInt<8>}
     invalidate reg1_w.bar


### PR DESCRIPTION
Fix test and extend to cover non-port case:
* Fix async-reset-anno test to fail with its backing change reverted, as-is the passes weren't run and the FileCheck command was wrong for the "did it remove the annotation" check.
* Extend async-reset-anno.fir and async-reset.fir tests to cover use of the fullasyncreset annotation on non-ports, which presently fails.

Fix handling of non-port fullasyncreset in SFCCompat (including annotation removal)
* Modify SFCCompat to look for (and remove) fullasyncreset annotations anywhere, not limited to ports.

cc #6912 .