### PR TITLE
[FIRRTL][LowerAnnotations] Reject non-local fullasyncreset anno's.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -494,7 +494,7 @@ static llvm::StringMap<AnnoRecord> annotationRecords{{
     {addSeqMemPortsFileAnnoClass, NoTargetAnnotation},
     {extractClockGatesAnnoClass, NoTargetAnnotation},
     {extractBlackBoxAnnoClass, {stdResolve, applyWithoutTarget<false>}},
-    {fullAsyncResetAnnoClass, {stdResolve, applyWithoutTarget<true>}},
+    {fullAsyncResetAnnoClass, {stdResolve, applyWithoutTarget<false>}},
     {ignoreFullAsyncResetAnnoClass,
      {stdResolve, applyWithoutTarget<true, FModuleOp>}},
     {decodeTableAnnotation, {noResolve, drop}},


### PR DESCRIPTION
These are not understood in a non-local way, reject them.

Docs say this annotation cannot be used on a module instantiated multiple times (apparently) so non-local should never be needed.