### PR TITLE
[Moore] A new pass to delete local temporary variables.

### DIFF
--- a/include/circt/Dialect/Moore/CMakeLists.txt
+++ b/include/circt/Dialect/Moore/CMakeLists.txt
@@ -15,3 +15,7 @@ mlir_tablegen(MooreAttributes.cpp.inc -gen-attrdef-defs
   -attrdefs-dialect MooreDialect)
 add_public_tablegen_target(CIRCTMooreAttributesIncGen)
 add_dependencies(circt-headers CIRCTMooreAttributesIncGen)
+
+set(LLVM_TARGET_DEFINITIONS MoorePasses.td)
+mlir_tablegen(MoorePasses.h.inc -gen-pass-decls)
+add_public_tablegen_target(CIRCTMooreTransformsIncGen)

--- a/include/circt/Dialect/Moore/MoorePasses.h
+++ b/include/circt/Dialect/Moore/MoorePasses.h
@@ -1,0 +1,32 @@
+//===- Passes.h - Moore pass entry points -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes that expose pass constructors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_MOORE_MOOREPASSES_H
+#define CIRCT_DIALECT_MOORE_MOOREPASSES_H
+
+#include "circt/Dialect/Moore/MooreOps.h"
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace circt {
+namespace moore {
+
+std::unique_ptr<mlir::Pass> createDeleteLocalVarPass();
+
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "circt/Dialect/Moore/MoorePasses.h.inc"
+
+} // namespace moore
+} // namespace circt
+
+#endif // CIRCT_DIALECT_MOORE_MOOREPASSES_H

--- a/include/circt/Dialect/Moore/MoorePasses.td
+++ b/include/circt/Dialect/Moore/MoorePasses.td
@@ -1,0 +1,27 @@
+//===--- Passes.td - Moore pass definition file ------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the passes that work on the Moore dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_MOORE_MOOREPASSES_TD
+#define CIRCT_DIALECT_MOORE_MOOREPASSES_TD
+
+include "mlir/Pass/PassBase.td"
+
+def DeleteLocalVar : Pass<"delete-local-var", "moore::SVModuleOp"> {
+  let summary = "Delete local temporary variables";
+  let description = [{
+    This pass is aimed to delete local temporary variables and replace all
+    uses by directly using their value.
+  }];
+  let constructor = "circt::moore::createDeleteLocalVarPass()";
+}
+
+#endif // CIRCT_DIALECT_MOORE_MOOREPASSES_TD

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinDialect.h"
+#include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/TypeSwitch.h"
 

--- a/lib/Dialect/Moore/CMakeLists.txt
+++ b/lib/Dialect/Moore/CMakeLists.txt
@@ -21,3 +21,5 @@ add_circt_dialect_library(CIRCTMoore
 )
 
 add_dependencies(circt-headers MLIRMooreIncGen)
+
+add_subdirectory(Transforms)

--- a/lib/Dialect/Moore/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Moore/Transforms/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_circt_dialect_library(CIRCTMooreTransforms
+DeleteLocalVar.cpp
+
+  DEPENDS
+  CIRCTMooreTransformsIncGen
+
+  LINK_LIBS PUBLIC
+  CIRCTMoore
+  CIRCTSupport
+  MLIRIR
+  MLIRPass
+  MLIRTransformUtils
+)

--- a/lib/Dialect/Moore/Transforms/DeleteLocalVar.cpp
+++ b/lib/Dialect/Moore/Transforms/DeleteLocalVar.cpp
@@ -1,0 +1,123 @@
+//===- DeleteLocalVar.cpp - Delete local temporary variables --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the DeleteLocalVar pass.
+// Use to collect net/variable declarations and bound a value to them.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "llvm/ADT/ScopedHashTable.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace moore;
+
+namespace {
+struct DeleteLocalVarPass : public DeleteLocalVarBase<DeleteLocalVarPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+namespace {
+struct DLV { // Delete Local Variables
+  /// All local temporary variables at the `moore.procedure`, `scf.if`,
+  /// `scf.while` body region/block need to be deleted, they won't be reserved
+  /// at the low level.
+  void deleteLocalVar(DenseSet<Operation *> &localVars,
+                      DenseSet<Operation *> &users, mlir::Region &region);
+
+  /// The `valueSymbols` used to collect nets/variables and their initial or
+  /// assignment values.
+  using ValueSymbols = llvm::ScopedHashTable<Operation *, Value>;
+  using ValueSymbolScope = ValueSymbols::ScopeTy;
+  ValueSymbols valueSymbols;
+};
+} // namespace
+
+void DLV::deleteLocalVar(DenseSet<Operation *> &localVars,
+                         DenseSet<Operation *> &users, mlir::Region &region) {
+  ValueSymbolScope scope(valueSymbols);
+
+  for (auto &op : region.getOps()) {
+    // Assume not to assign a new value to the local variable.
+    bool isNewValue = false;
+
+    TypeSwitch<Operation *, void>(&op)
+        // Collect all local variables and their initial values
+        // if exist and all users.
+        .Case<VariableOp>([&](auto op) {
+          valueSymbols.insert(op, op.getInitial());
+          localVars.insert(op);
+          for (auto *user : op->getUsers())
+            users.insert(user);
+        })
+        // Update the values of local variables.
+        .Case<BlockingAssignOp, NonBlockingAssignOp>([&](auto op) {
+          auto destOp = op.getDst().getDefiningOp();
+          auto srcOp = op.getSrc().getDefiningOp();
+
+          // For example, `a = 1`, `b = a`, `c = b` both are local variable.
+          // After updating: `a = 1`, `b = 1`, `c = 1`.
+          if (valueSymbols.count(destOp)) {
+            if (auto srcValue = valueSymbols.lookup(srcOp))
+              valueSymbols.insert(destOp, srcValue);
+            else
+              valueSymbols.insert(destOp, op.getSrc());
+
+            isNewValue = true;
+          }
+        })
+        // Delete the local variables defined in `if` statements.
+        .Case<mlir::scf::IfOp>([&](auto op) {
+          // Handle `then` region.
+          deleteLocalVar(localVars, users, op.getThenRegion());
+
+          // Handle `else` region.
+          deleteLocalVar(localVars, users, op.getElseRegion());
+        });
+
+    // Assume the `a` is a local variable, which one user is `b = a`.
+    // Replace `a` with its value, then erase this user from `users` container.
+    // Although `a = 1` is also the user of `a`, don't replace it.
+    if (users.contains(&op) && !isNewValue)
+      for (auto operand : op.getOperands())
+        if (auto value = valueSymbols.lookup(operand.getDefiningOp())) {
+          op.replaceUsesOfWith(operand, value);
+          users.erase(&op);
+        }
+  }
+}
+
+std::unique_ptr<mlir::Pass> circt::moore::createDeleteLocalVarPass() {
+  return std::make_unique<DeleteLocalVarPass>();
+}
+
+void DeleteLocalVarPass::runOnOperation() {
+  getOperation()->walk([&](ProcedureOp procedureOp) {
+    // Used to collect all users of local variables.
+    DenseSet<Operation *> users;
+
+    // Used to collect all local variables.
+    DenseSet<Operation *> localVars;
+
+    DLV dlv;
+    dlv.deleteLocalVar(localVars, users, procedureOp.getBodyRegion());
+
+    // Erase the redundant users of local varaibles.
+    for (auto *user : users)
+      user->erase();
+
+    // Erase the local variables.
+    for (auto *var : localVars)
+      var->erase();
+
+    return WalkResult::advance();
+  });
+}

--- a/lib/Dialect/Moore/Transforms/PassDetail.h
+++ b/lib/Dialect/Moore/Transforms/PassDetail.h
@@ -1,0 +1,32 @@
+//===- PassDetail.h - Morre pass class details ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Stuff shared between the different Moore passes.
+//
+//===----------------------------------------------------------------------===//
+
+// clang-tidy seems to expect the absolute path in the header guard on some
+// systems, so just disable it.
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef DIALECT_MOORE_TRANSFORMS_PASSDETAIL_H
+#define DIALECT_MOORE_TRANSFORMS_PASSDETAIL_H
+
+#include "circt/Dialect/Moore/MooreOps.h"
+#include "circt/Dialect/Moore/MoorePasses.h"
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+namespace moore {
+
+#define GEN_PASS_CLASSES
+#include "circt/Dialect/Moore/MoorePasses.h.inc"
+
+} // namespace moore
+} // namespace circt
+
+#endif // DIALECT_MOORE_TRANSFORMS_PASSDETAIL_H

--- a/tools/circt-verilog/CMakeLists.txt
+++ b/tools/circt-verilog/CMakeLists.txt
@@ -6,6 +6,8 @@ llvm_update_compile_flags(circt-verilog)
 
 target_link_libraries(circt-verilog PRIVATE
   CIRCTImportVerilog
+  CIRCTMooreTransforms
+  CIRCTMooreToCore
   CIRCTSupport
   MLIRIR
 )

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -13,6 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Conversion/ImportVerilog.h"
+#include "circt/Conversion/MooreToCore.h"
+#include "circt/Dialect/Moore/MoorePasses.h"
 #include "circt/Support/Version.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/PassManager.h"
@@ -31,7 +33,14 @@ using namespace circt;
 //===----------------------------------------------------------------------===//
 
 namespace {
-enum class LoweringMode { OnlyPreprocess, OnlyLint, OnlyParse, Full };
+enum class LoweringMode {
+  OnlyPreprocess,
+  OnlyLint,
+  OnlyParse,
+  OutputIRMoore,
+  OutputIRHW,
+  Full
+};
 
 struct CLOptions {
   cl::OptionCategory cat{"Verilog Frontend Options"};
@@ -60,7 +69,13 @@ struct CLOptions {
                      "CIRCT IR"),
           clEnumValN(LoweringMode::OnlyParse, "parse-only",
                      "Only parse and elaborate the input, without mapping to "
-                     "CIRCT IR")),
+                     "CIRCT IR"),
+          clEnumValN(LoweringMode::OutputIRMoore, "ir-moore",
+                     "Run the entire pass manager to just before MooreToCore "
+                     "conversion, and emit the resulting Moore dialect IR"),
+          clEnumValN(LoweringMode::OutputIRHW, "ir-hw",
+                     "Run the MooreToCore conversion and emit the resulting "
+                     "core dialect IR")),
       cl::init(LoweringMode::Full), cl::cat(cat)};
 
   //===--------------------------------------------------------------------===//
@@ -200,6 +215,25 @@ struct CLOptions {
 
 static CLOptions opts;
 
+/// Parse specified files that had been translated into Moore dialect IR. After
+/// that simplify these files like deleting local variables, and then emit the
+/// resulting Moore dialect IR .
+static LogicalResult populateMooreTransforms(mlir::PassManager &pm) {
+
+  pm.addNestedPass<moore::SVModuleOp>(circt::moore::createDeleteLocalVarPass());
+  // TODO: like dedup pass.
+
+  return success();
+}
+
+/// Convert Moore dialect IR into core dialect IR
+static LogicalResult populateLowMooreToCore(mlir::PassManager &pm) {
+
+  pm.addPass(createConvertMooreToCorePass());
+
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Implementation
 //===----------------------------------------------------------------------===//
@@ -267,6 +301,23 @@ static LogicalResult executeWithSources(MLIRContext *context,
   // Parse the Verilog input into an MLIR module.
   OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(context)));
   if (failed(importVerilog(sourceMgr, context, ts, module.get(), &options)))
+    return failure();
+
+  PassManager pm(context);
+  if (opts.loweringMode == LoweringMode::OutputIRMoore ||
+      opts.loweringMode == LoweringMode::OutputIRHW) {
+
+    // Simplify the Moore dialect IR.
+    if (failed(populateMooreTransforms(pm)))
+      return failure();
+
+    if (opts.loweringMode == LoweringMode::OutputIRHW)
+      // Convert Moore IR into core IR.
+      if (failed(populateLowMooreToCore(pm)))
+        return failure();
+  }
+
+  if (failed(pm.run(module.get())))
     return failure();
 
   // Print the final MLIR.


### PR DESCRIPTION
Hey, @fabianschuiki! Please review this at your convenience! Thanks in advance!
This PR is about deleting local variables.
For example:
```
int x, y, z;
always_comb begin
  automatic int a;
  a = x + 1;
  y = a;
  a = a + 1;
  z = a;
end
```
To
```
int x, y, z;
y = x + 1;
z = (x + 1) + 1;
```
Anything about code details could be pointed out.