### PR TITLE
[CAPI][Moore] Remove deprecated types

### DIFF
--- a/include/circt-c/Dialect/Moore.h
+++ b/include/circt-c/Dialect/Moore.h
@@ -114,13 +114,6 @@ MLIR_CAPI_EXPORTED MlirType mooreUnpackedQueueDimTypeGet(MlirType inner);
 /// Create a unpacked queue dimension type with bound.
 MLIR_CAPI_EXPORTED MlirType
 mooreUnpackedQueueDimTypeGetWithBound(MlirType inner, unsigned bound);
-/// Create a enum type without base.
-MLIR_CAPI_EXPORTED MlirType mooreEnumTypeGet(MlirAttribute name,
-                                             MlirLocation loc);
-/// Create a enum type with base.
-MLIR_CAPI_EXPORTED MlirType mooreEnumTypeGetWithBase(MlirAttribute name,
-                                                     MlirLocation loc,
-                                                     MlirType base);
 // TODO: PackedStructType
 // TODO: UnpackedStructType
 /// Create a simple bit-vector type.


### PR DESCRIPTION
Minor nitty remainder after https://github.com/llvm/circt/commit/a36c25834981f062ca930daa50fe045b2c4df0aa and 282bdb85b2d87833cf92efefb9a2cddb456edee9 @maerhart.