### PR TITLE
[ImportVerilog] Fix unknown name caused by local variables.

### DIFF
--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -63,8 +63,11 @@ struct StmtVisitor {
         return failure();
     }
 
-    builder.create<moore::VariableOp>(loc, type,
-                                      builder.getStringAttr(var.name), initial);
+    // Collect local temporary variables.
+    auto varOp = builder.create<moore::VariableOp>(
+        loc, type, builder.getStringAttr(var.name), initial);
+    context.valueSymbols.insertIntoScope(context.valueSymbols.getCurScope(),
+                                         &var, varOp);
     return success();
   }
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -120,6 +120,12 @@ module Statements;
   int i;
   initial begin
     //===------------------------------------------------------------------===//
+    // local variables
+
+    // CHECK: %a = moore.variable  : !moore.int
+    automatic int a;
+    
+    //===------------------------------------------------------------------===//
     // Conditional statements
 
     // CHECK: [[COND:%.+]] = moore.conversion %x : !moore.bit -> i1

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -163,3 +163,17 @@ module Foo;
     b = a[1-:-1];
   end
 endmodule
+
+// -----
+
+module Foo;
+  int x;
+  initial begin
+    // expected-remark @below {{declared here}}
+    automatic int a;
+    // expected-error @below {{nonblocking assignment to automatic variable 'a' is not allowed}}
+    a <= x;
+    // expected-error @below {{declaration must come before all statements in the block}}
+    automatic int b;
+  end
+endmodule

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -58,6 +58,8 @@ moore.module @Foo {
     moore.blocking_assign %v1, %v2 : !moore.bit
     // CHECK: moore.nonblocking_assign %v1, %v2 : !moore.bit
     moore.nonblocking_assign %v1, %v2 : !moore.bit
+    // CHECK: %a = moore.variable  : !moore.int
+    %a = moore.variable  : !moore.int
   }
 }
 


### PR DESCRIPTION
If we don't collect the local temporary variables, it triggers the following error:
For example:
```
module Temporary();
  int x, y, z;
  always_comb begin
    automatic int a;
    a = x + 1;
    y = a;
    a = a + 1;
    z = a;
  end
endmodule
```
```cpp
Temporary.sv:5:5: error: unknown name `a`
    a = x + 1;
```