### PR TITLE
[ARC][CAPI] Add basic C API for initializing ARC

### DIFF
--- a/include/circt-c/Dialect/Arc.h
+++ b/include/circt-c/Dialect/Arc.h
@@ -1,0 +1,25 @@
+//===- Arc.h - C interface for the Arc dialect ------------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_C_DIALECT_ARC_H
+#define CIRCT_C_DIALECT_ARC_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Arc, arc);
+MLIR_CAPI_EXPORTED void registerArcPasses(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CIRCT_C_DIALECT_ARC_H

--- a/lib/CAPI/Dialect/Arc.cpp
+++ b/lib/CAPI/Dialect/Arc.cpp
@@ -1,0 +1,18 @@
+//===- Arc.cpp - C interface for the Arc dialect ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt-c/Dialect/Arc.h"
+#include "circt/Dialect/Arc/ArcDialect.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Registration.h"
+#include "mlir/CAPI/Support.h"
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Arc, arc, circt::arc::ArcDialect)
+
+void registerArcPasses() { circt::arc::registerPasses(); }

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -1,5 +1,6 @@
 # TODO: Make the check source feature optional as an argument on *_add_library.
 set(LLVM_OPTIONAL_SOURCES
+  Arc.cpp
   CHIRRTL.cpp
   Comb.cpp
   Debug.cpp
@@ -18,6 +19,15 @@ set(LLVM_OPTIONAL_SOURCES
   SV.cpp
   Seq.cpp
   Verif.cpp
+)
+
+add_circt_public_c_api_library(CIRCTCAPIArc
+  Arc.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  CIRCTArc
+  CIRCTArcTransforms
 )
 
 add_circt_public_c_api_library(CIRCTCAPIComb

--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -56,3 +56,16 @@ target_link_libraries(circt-capi-firtool-test
   CIRCTCAPIFIRRTL
   CIRCTCAPIFirtool
 )
+
+add_llvm_executable(circt-capi-arc-test
+  PARTIAL_SOURCES_INTENDED
+  arc.c
+)
+llvm_update_compile_flags(circt-capi-arc-test)
+
+target_link_libraries(circt-capi-arc-test
+  PRIVATE
+
+  MLIRCAPIIR
+  CIRCTCAPIArc
+)

--- a/test/CAPI/arc.c
+++ b/test/CAPI/arc.c
@@ -1,0 +1,67 @@
+/*===- arc.c - Simple test of Arc Dialect C APIs  -------------------------===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+/* RUN: circt-capi-ir-test 2>&1 | FileCheck %s
+ */
+
+#include "circt-c/Dialect/Arc.h"
+
+#include <stdio.h>
+#include <string.h>
+
+int registerOnlyArc(void) {
+  MlirContext ctx = mlirContextCreate();
+  // The built-in dialect is always loaded.
+  if (mlirContextGetNumLoadedDialects(ctx) != 1)
+    return 1;
+
+  // Arc dialect tests.
+  MlirDialectHandle arcHandle = mlirGetDialectHandle__arc__();
+
+  MlirDialect arc = mlirContextGetOrLoadDialect(
+      ctx, mlirDialectHandleGetNamespace(arcHandle));
+  if (!mlirDialectIsNull(arc))
+    return 2;
+
+  mlirDialectHandleRegisterDialect(arcHandle, ctx);
+  if (mlirContextGetNumRegisteredDialects(ctx) != 2)
+    return 3;
+  if (mlirContextGetNumLoadedDialects(ctx) != 1)
+    return 4;
+
+  arc = mlirContextGetOrLoadDialect(ctx,
+                                    mlirDialectHandleGetNamespace(arcHandle));
+  if (mlirDialectIsNull(arc))
+    return 5;
+  if (mlirContextGetNumLoadedDialects(ctx) != 2)
+    return 6;
+
+  MlirDialect alsoArc = mlirDialectHandleLoadDialect(arcHandle, ctx);
+  if (!mlirDialectEqual(arc, alsoArc))
+    return 7;
+
+  registerArcPasses();
+
+  mlirContextDestroy(ctx);
+
+  return 0;
+}
+
+int main(void) {
+  fprintf(stderr, "@registration\n");
+  int errcode = registerOnlyArc();
+  fprintf(stderr, "%d\n", errcode);
+
+  // clang-format off
+  // CHECK-LABEL: @registration
+  // CHECK: 0
+  // clang-format on
+
+  return 0;
+}


### PR DESCRIPTION
This PR doesn't add full API coverage for Arc types and such, but it's enough to allow Arc to be used for cross language projects such as the CIRCT bindings for Rust through the melior crate.