### PR TITLE
[NFC][clang-tidy] Disallow global 'using' directives in headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,7 @@ Checks: >
         bugprone-terminating-continue,
         bugprone-unused-raii,
         bugprone-unused-return-value,
+        google-global-names-in-headers,
         modernize-use-bool-literals,
         modernize-loop-convert,
         modernize-make-unique,


### PR DESCRIPTION
Add the [google-global-names-in-headers](https://clang.llvm.org/extra/clang-tidy/checks/google/global-names-in-headers.html) rule to the list of clang-tidy checks to prevent namespace pollution.

This is intended to flag global using-directives in header files during PR checks. Collisions between the `llvm` and the `mlir` namespace have caused obscure build failures on Windows in the past. #6844 should have removed all existing occurrences in the CIRCT code base.