### PR TITLE
[firtool] Add FlattenModulesPass to the btor2 emission pipeline

### DIFF
--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -386,8 +386,8 @@ LogicalResult firtool::populateFinalizeIR(mlir::PassManager &pm,
 LogicalResult firtool::populateHWToBTOR2(mlir::PassManager &pm,
                                          const FirtoolOptions &opt,
                                          llvm::raw_ostream &os) {
-  pm.addPass(circt::hw::createFlattenModulesPass());
   pm.addNestedPass<hw::HWModuleOp>(circt::createLowerLTLToCorePass());
+  pm.addPass(circt::hw::createFlattenModulesPass());
   pm.addNestedPass<hw::HWModuleOp>(circt::createConvertHWToBTOR2Pass(os));
   return success();
 }

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -386,6 +386,7 @@ LogicalResult firtool::populateFinalizeIR(mlir::PassManager &pm,
 LogicalResult firtool::populateHWToBTOR2(mlir::PassManager &pm,
                                          const FirtoolOptions &opt,
                                          llvm::raw_ostream &os) {
+  pm.addPass(circt::hw::createFlattenModulesPass());
   pm.addNestedPass<hw::HWModuleOp>(circt::createLowerLTLToCorePass());
   pm.addNestedPass<hw::HWModuleOp>(circt::createConvertHWToBTOR2Pass(os));
   return success();

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -710,7 +710,7 @@ int main(int argc, char **argv) {
     firrtl::registerPasses();
     om::registerPasses();
     sv::registerPasses();
-    hw::registerPasses();
+    hw::registerFlattenModulesPass();
 
     // Export passes:
     registerExportChiselInterfacePass();

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -710,6 +710,7 @@ int main(int argc, char **argv) {
     firrtl::registerPasses();
     om::registerPasses();
     sv::registerPasses();
+    hw::registerPasses();
 
     // Export passes:
     registerExportChiselInterfacePass();


### PR DESCRIPTION
In order to support multi-module designs in the formal backend, we need to inline the modules before converting them to btor2. 

This is a naive approach but will work just fine for now.