### PR TITLE
[FIRRTL] AnnoTarget: use LLVM style casts

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -67,7 +67,7 @@ struct AnnoPathValue {
 
   template <typename... T>
   bool isOpOfType() const {
-    if (auto opRef = ref.dyn_cast<OpAnnoTarget>())
+    if (auto opRef = dyn_cast<OpAnnoTarget>(ref))
       return isa<T...>(opRef.getOp());
     return false;
   }
@@ -127,9 +127,9 @@ static T &operator<<(T &os, const PortAnnoTarget &target) {
 
 template <typename T>
 static T &operator<<(T &os, const AnnoTarget &target) {
-  if (auto op = target.dyn_cast<OpAnnoTarget>())
+  if (auto op = dyn_cast<OpAnnoTarget>(target))
     os << op;
-  else if (auto port = target.dyn_cast<PortAnnoTarget>())
+  else if (auto port = dyn_cast<PortAnnoTarget>(target))
     os << port;
   else
     os << "<<Unknown Anno Target>>";
@@ -481,7 +481,7 @@ template <bool allowNonLocal, bool allowPortAnnoTarget, typename T,
 static LogicalResult applyWithoutTarget(const AnnoPathValue &target,
                                         DictionaryAttr anno,
                                         ApplyState &state) {
-  if (target.ref.isa<PortAnnoTarget>()) {
+  if (isa<PortAnnoTarget>(target.ref)) {
     if (!allowPortAnnoTarget)
       return failure();
   } else if (!target.isOpOfType<T, Tr...>())

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotations.h
@@ -507,23 +507,18 @@ namespace llvm {
 template <typename To, typename From>
 struct CastInfo<
     To, From,
-    std::enable_if_t<
-        std::is_same_v<circt::firrtl::AnnoTarget, std::remove_const_t<From>> ||
-        std::is_base_of_v<circt::firrtl::AnnoTarget, From>>>
+    std::enable_if_t<std::is_base_of_v<::circt::firrtl::AnnoTarget, From>>>
     : NullableValueCastFailed<To>,
       DefaultDoCastIfPossible<To, From, CastInfo<To, From>> {
   static inline bool isPossible(From target) {
-    /// Return a constant true instead of a dynamic true when casting to self or
-    /// up the hierarchy.
-    if constexpr (std::is_base_of_v<To, From>) {
+    // Allow constant upcasting.  This also gets around the fact that AnnoTarget
+    // does not implement classof.
+    if constexpr (std::is_base_of_v<To, From>)
       return true;
-    } else {
+    else
       return To::classof(target);
-    }
   }
-  static inline To doCast(circt::firrtl::AnnoTarget target) {
-    return To(target.getImpl());
-  }
+  static inline To doCast(From target) { return To(target.getImpl()); }
 };
 
 /// Make `Annotation` behave like a `Attribute` in terms of pointer-likeness.

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -225,7 +225,7 @@ firrtl::resolveEntities(TokenAnnoTarget path, CircuitOp circuit,
     // AnnoTarget::getType() is not safe (CHIRRTL ops crash, null if instance),
     // avoid. For now, only references in ports can be targets, check that.
     // TODO: containsReference().
-    if (ref.isa<PortAnnoTarget>() && isa<RefType>(ref.getType())) {
+    if (isa<PortAnnoTarget>(ref) && isa<RefType>(ref.getType())) {
       mlir::emitError(circuit.getLoc())
           << "cannot target reference-type '" << path.name << "' in "
           << mod.getModuleName();

--- a/lib/Dialect/FIRRTL/Transforms/LegacyWiring.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LegacyWiring.cpp
@@ -30,7 +30,7 @@ LogicalResult circt::firrtl::applyWiring(const AnnoPathValue &target,
 
   // Convert target to Value
   Value targetValue;
-  if (auto portTarget = target.ref.dyn_cast<PortAnnoTarget>()) {
+  if (auto portTarget = dyn_cast<PortAnnoTarget>(target.ref)) {
     auto portNum = portTarget.getImpl().getPortNo();
     if (auto module = dyn_cast<FModuleOp>(portTarget.getOp())) {
       if (clazz == wiringSourceAnnoClass) {
@@ -63,7 +63,7 @@ LogicalResult circt::firrtl::applyWiring(const AnnoPathValue &target,
       return mlir::emitError(state.circuit.getLoc())
              << "Annotation has invalid target: " << anno;
     }
-  } else if (auto opResult = target.ref.dyn_cast<OpAnnoTarget>()) {
+  } else if (auto opResult = dyn_cast<OpAnnoTarget>(target.ref)) {
     if (target.isOpOfType<WireOp, RegOp, RegResetOp>()) {
       auto *targetBase = opResult.getOp();
       builder.setInsertionPointAfter(targetBase);

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -83,13 +83,13 @@ static void addAnnotation(AnnoTarget ref, unsigned fieldIdx,
     annotation = DictionaryAttr::get(context, anno);
   }
 
-  if (ref.isa<OpAnnoTarget>()) {
+  if (isa<OpAnnoTarget>(ref)) {
     auto newAnno = appendArrayAttr(getAnnotationsFrom(ref.getOp()), annotation);
     ref.getOp()->setAttr(getAnnotationAttrName(), newAnno);
     return;
   }
 
-  auto portRef = ref.cast<PortAnnoTarget>();
+  auto portRef = cast<PortAnnoTarget>(ref);
   auto portAnnoRaw = ref.getOp()->getAttr(getPortAnnotationAttrName());
   ArrayAttr portAnno = dyn_cast_or_null<ArrayAttr>(portAnnoRaw);
   if (!portAnno || portAnno.size() != getNumPorts(ref.getOp())) {
@@ -244,7 +244,7 @@ static LogicalResult applyDUTAnno(const AnnoPathValue &target,
   if (!target.isLocal())
     return mlir::emitError(loc) << "must be local";
 
-  if (!target.ref.isa<OpAnnoTarget>() || !isa<FModuleOp>(op))
+  if (!isa<OpAnnoTarget>(target.ref) || !isa<FModuleOp>(op))
     return mlir::emitError(loc) << "can only target to a module";
 
   auto moduleOp = cast<FModuleOp>(op);
@@ -277,7 +277,7 @@ static LogicalResult applyConventionAnno(const AnnoPathValue &target,
     return diag;
   };
 
-  auto opTarget = target.ref.dyn_cast<OpAnnoTarget>();
+  auto opTarget = dyn_cast<OpAnnoTarget>(target.ref);
   if (!opTarget)
     return error() << "must target a module object";
 
@@ -320,7 +320,7 @@ static LogicalResult applyAttributeAnnotation(const AnnoPathValue &target,
     return diag;
   };
 
-  if (!target.ref.isa<OpAnnoTarget>())
+  if (!isa<OpAnnoTarget>(target.ref))
     return error()
            << "must target an operation. Currently ports are not supported";
 

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -264,7 +264,7 @@ LogicalResult LowerClassesPass::processPaths(
 
       // Attach an inner sym to the operation.
       Attribute targetSym;
-      if (auto portTarget = target.dyn_cast<PortAnnoTarget>()) {
+      if (auto portTarget = dyn_cast<PortAnnoTarget>(target)) {
         targetSym = getInnerRefTo(
             {portTarget.getPortNo(), portTarget.getOp(), fieldID},
             [&](FModuleLike module) -> hw::InnerSymbolNamespace & {

--- a/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
@@ -137,7 +137,7 @@ private:
 
     // If this targets a module or an instance, then we're done.  There is no
     // "reference" part of the FIRRTL target.
-    if (path.ref.isa<OpAnnoTarget>() &&
+    if (isa<OpAnnoTarget>(path.ref) &&
         path.isOpOfType<FModuleOp, FExtModuleOp, InstanceOp>())
       return;
 


### PR DESCRIPTION
This changes AnnoTargets to use LLVM style casts instead of "trailing" member functions. The LLVM style casts are now usable with AnnoTargets with improvements to the upstream framework.  The current style of cast used with AnnoTargets will no longer be supported by TypeSwitch, so this PR switches to the recommended idiom.