### PR TITLE
[SV] Add DPI import op

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -888,6 +888,17 @@ def MacroDefOp : SVOp<"macro.def",
 // Function/Call
 //===----------------------------------------------------------------------===//
 
+def FuncDPIImportOp: SVOp<"func.dpi.import",
+  [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = "Emit a dpi import statement. See SV spec 35.4";
+
+  let arguments = (ins FlatSymbolRefAttr:$callee,
+                       OptionalAttr<StrAttr>: $linkage_name);
+  let results = (outs);
+
+  let assemblyFormat = "(`linkage` $linkage_name^)? $callee attr-dict";
+}
+
 def FuncOp : SVOp<"func",
      [IsolatedFromAbove, Symbol, OpAsmOpInterface, ProceduralRegion,
       DeclareOpInterfaceMethods<HWModuleLike>,

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -890,7 +890,11 @@ def MacroDefOp : SVOp<"macro.def",
 
 def FuncDPIImportOp: SVOp<"func.dpi.import",
   [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
-  let summary = "Emit a dpi import statement. See SV spec 35.4";
+  let summary = "DPI import statement";
+  let description = [{
+     `sv.func.dpi.import` represents DPI function import statement defined in
+     IEEE 1800-2017 section 35.4.
+  }];
 
   let arguments = (ins FlatSymbolRefAttr:$callee,
                        OptionalAttr<StrAttr>: $linkage_name);

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -45,6 +45,7 @@ public:
             InterfaceOp, InterfaceSignalOp, InterfaceModportOp,
             InterfaceInstanceOp, GetModportOp, AssignInterfaceSignalOp,
             ReadInterfaceSignalOp, MacroDeclOp, MacroDefOp, FuncOp,
+            FuncDPIImportOp,
             // Verification statements.
             AssertOp, AssumeOp, CoverOp, AssertConcurrentOp, AssumeConcurrentOp,
             CoverConcurrentOp,
@@ -143,6 +144,7 @@ public:
   HANDLE(ReadInterfaceSignalOp, Unhandled);
   HANDLE(MacroDefOp, Unhandled);
   HANDLE(MacroDeclOp, Unhandled);
+  HANDLE(FuncDPIImportOp, Unhandled);
   HANDLE(FuncOp, Unhandled);
 
   // Verification statements.

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -2416,6 +2416,24 @@ LogicalResult FuncCallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
+// FuncDPIImportOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+FuncDPIImportOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto referencedOp = dyn_cast_or_null<sv::FuncOp>(
+      symbolTable.lookupNearestSymbolFrom(*this, getCalleeAttr()));
+
+  if (!referencedOp)
+    return emitError("cannot find function declaration '")
+           << getCallee() << "'";
+  if (!referencedOp.isDeclaration())
+    return emitError("imported function must be a declaration but '")
+           << getCallee() << "' is defined";
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -393,6 +393,8 @@ hw.module @XMRRefOp() {
 // Functions.
 // CHECK-LABEL: sv.func private @function_declare(in %in_0 : i2, in %in_1 : i2, out out_0 : i1, in %in_2 : !hw.array<2xi2>)
 sv.func private @function_declare(in %in_0 : i2, in %in_1 : i2, out out_0 : i1, in %in_2 : !hw.array<2xi2>)
+// CHECK-NEXT: sv.func.dpi.import linkage "c_func_name" @function_declare
+sv.func.dpi.import linkage "c_func_name" @function_declare
 
 // CHECK-LABEL: sv.func private @function_define(in %in_0 : i2, in %in_1 : i2, out out_0 : i1, in %in_2 : !hw.array<2xi2>)
 sv.func private @function_define(in %in_0 : i2, in %in_1 : i2, out out_0 : i1, in %in_2 : !hw.array<2xi2>) attributes {test = "foo"} {

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -272,3 +272,11 @@ hw.module private @call(){
   %0 = sv.func.call @func() : () -> (i1)
 }
 
+// -----
+
+sv.func private @func() {
+  sv.return
+}
+
+// expected-error @below {{imported function must be a declaration but 'func' is defined}}
+sv.func.dpi.import @func


### PR DESCRIPTION
This PR adds an op `sv.func.dpi.import` for "emitting" DPI import statement. `sv.func.dpi.import` doesn't declare function but it takes a function symbol to emit import statement. This design is similar to what `sv.macro.ref/def` does and it enables us to decouple function declaration and emission. 

```
// CHECK-LABEL: import "DPI-C" linkage_name = function void function_declare1(
// CHECK-NEXT:    input [1:0] in_0,
// CHECK-NEXT:                out_0,
// CHECK-NEXT:                in_1,
// CHECK-NEXT:    output out_1
// CHECK-NEXT: );
sv.func.dpi.import linkage "linkage_name" @function_declare1
```