### PR TITLE
[FIRRTL] Reject intrinsic modules >= 4.0.0

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -5199,6 +5199,8 @@ ParseResult FIRCircuitParser::parseToplevelDefinition(CircuitOp circuit,
   case FIRToken::kw_extmodule:
     return parseExtModule(circuit, indent);
   case FIRToken::kw_intmodule:
+    if (removedFeature({4, 0, 0}, "intrinsic modules"))
+      return failure();
     return parseIntModule(circuit, indent);
   case FIRToken::kw_layer:
     if (requireFeature({4, 0, 0}, "layers"))

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1430,3 +1430,11 @@ circuit GenericIntParamRedef:
   public module GenericIntParamRedef:
     ; expected-error @below {{redefinition of parameter 'x'}}
     intrinsic(dummy<x = 5, x = 3>)
+
+;// -----
+FIRRTL version 4.0.0
+circuit IntrinsicModule:
+  ; expected-error @below {{intrinsic modules were removed in FIRRTL 4.0.0}}
+  intmodule MyIntModule :
+    intrinsic = testIntrinsic1
+


### PR DESCRIPTION
https://github.com/chipsalliance/firrtl-spec/pull/210

Should not merge until/if they're removed from spec, but it's ready when we are.

Follow-on "eventually" would be dropping them from our IR / rejecting on all versions.