### PR TITLE
 [AddSeqMemPorts] Add hierpathop to verbatim, instead of raw instance path 

### DIFF
--- a/test/Dialect/FIRRTL/add-seqmem-ports.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports.mlir
@@ -156,18 +156,28 @@ firrtl.circuit "Complex" attributes {annotations = [
     input = false,
     width = 4
   }]} {
+
+  // CHECK:  hw.hierpath @memNLA [@DUT::@[[MWRITE_EXT:.+]]]
+  // CHECK:  hw.hierpath @memNLA_0 [@DUT::@[[CHILD:.+]], @Child::@[[CHILD_MWRITE_EXT:.+]]]
+  // CHECK:  hw.hierpath @memNLA_1 [@DUT::@[[MWRITE_EXT_0:.+]]]
   firrtl.memmodule @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>) attributes {dataWidth = 42 : ui32, depth = 12 : ui64, extraPorts = [], maskBits = 1 : ui32, numReadPorts = 0 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 1 : ui32, writeLatency = 1 : ui32}
   firrtl.module @Child() {
-    // CHECK: firrtl.instance MWrite_ext sym @[[CHILD_MWRITE_EXT:.+]] @MWrite_ext
+    // CHECK: firrtl.instance MWrite_ext sym @[[CHILD_MWRITE_EXT]] 
+    // CHECK-SAME: circt.nonlocal = @memNLA_0
+    // CHECK-SAME: @MWrite_ext
     %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
   }
   firrtl.module @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     // Double check that these instances now have symbols on them:
-    // CHECK: firrtl.instance MWrite_ext sym @[[MWRITE_EXT:.+]] @MWrite_ext(
+    // CHECK: firrtl.instance MWrite_ext sym @[[MWRITE_EXT]]
+    // CHECK-SAME: circt.nonlocal = @memNLA
+    // CHECK-SAME: @MWrite_ext(
     %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
-    // CHECK: firrtl.instance child sym @[[CHILD:.+]] @Child(
+    // CHECK: firrtl.instance child sym @[[CHILD]] @Child(
     firrtl.instance child @Child()
-    // CHECK: firrtl.instance MWrite_ext sym @[[MWRITE_EXT_0:.+]] @MWrite_ext(
+    // CHECK: firrtl.instance MWrite_ext sym @[[MWRITE_EXT_0]]
+    // CHECK-SAME: circt.nonlocal = @memNLA_1
+    // CHECK-SAME: @MWrite_ext(
     %1:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
   }
   firrtl.module @Complex() {
@@ -176,8 +186,8 @@ firrtl.circuit "Complex" attributes {annotations = [
   // CHECK:               emit.file "metadata{{/|\\\\}}sram.txt" {
   // CHECK-NEXT:            sv.verbatim
   // CHECK-SAME{LITERAL}:     0 -> {{0}}.{{1}}
-  // CHECK-SAME{LITERAL}:     1 -> {{0}}.{{2}}.{{3}}
-  // CHECK-SAME{LITERAL}:     2 -> {{0}}.{{4}}
-  // CHECK-SAME:              {symbols = [@DUT, #hw.innerNameRef<@DUT::@[[MWRITE_EXT]]>, #hw.innerNameRef<@DUT::@[[CHILD]]>, #hw.innerNameRef<@Child::@[[CHILD_MWRITE_EXT]]>, #hw.innerNameRef<@DUT::@[[MWRITE_EXT_0]]>]}
+  // CHECK-SAME{LITERAL}:     1 -> {{0}}.{{2}}
+  // CHECK-SAME{LITERAL}:     2 -> {{0}}.{{3}}
+  // CHECK-SAME:              {symbols = [@DUT, @memNLA, @memNLA_0, @memNLA_1]}
   // CHECK-NEXT:          }
 }


### PR DESCRIPTION
The annotation `AddSeqMemPortsFileAnnotation` causes the pass
 `AddSeqMemPort` to add verbatim ops for the SRAM metadata file.
The file lists each SRAM and provides the mapping to
where it is in the hierarchy, and gives its IO prefix at the DUT top level.

This PR updates the pass to use `HierPathOp` to print the SRAM instance path,
 instead of the raw list of symbol references. 
This is required to ensure that the instance path is valid, even if the hierarchy
is updated by following passes.

This fixes a `firtool` crash that is exposed when using `AddSeqMem` along with
 `ExtractSeqMem`. Which is due to invalid symbol references in the `varbatim`, after
 the hierarchy was updated. Even though, this particular use case is invalid, as these
 two SRAM annotations cannot be used together, it can still be triggered by other
transformations.

Note: This metadata will soon be moved to OM, in a followup PR.