### PR TITLE
[FIRRTL] Don't prefix an empty label for unclocked assume.

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -4599,7 +4599,7 @@ LogicalResult FIRRTLLowering::visitStmt(UnclockedAssumeIntrinsicOp op) {
 
   auto label = op.getNameAttr();
   StringAttr assumeLabel;
-  if (label)
+  if (label && !label.empty())
     assumeLabel =
         StringAttr::get(builder.getContext(), "assume__" + label.getValue());
   auto predicate = getLoweredValue(op.getPredicate());

--- a/test/firtool/unr-only.fir
+++ b/test/firtool/unr-only.fir
@@ -1,0 +1,43 @@
+; RUN: firtool %s --add-companion-assume --split-input-file | FileCheck %s
+
+FIRRTL version 4.0.0
+; CHECK-LABEL: module UnrOnly(
+circuit UnrOnly:
+  public module UnrOnly:
+    input clock : Clock
+    input pred : UInt<1>
+    input en : UInt<1>
+
+    ; CHECK:      `ifdef USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:   assert property (@(posedge clock) ~en | pred);
+    ; CHECK-NEXT: `endif // USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT: `ifdef USE_PROPERTY_AS_CONSTRAINT
+    ; CHECK-NEXT:   `ifdef USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:     wire _GEN = ~en | pred;
+    ; CHECK-NEXT:     always @(edge _GEN)
+    ; CHECK-NEXT:       assume(_GEN);
+    ; CHECK-NEXT:   `endif // USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT: `endif // USE_PROPERTY_AS_CONSTRAINT
+    intrinsic(circt_chisel_assert<guards="USE_UNR_ONLY_CONSTRAINTS">, clock, pred, en)
+
+;// -----
+
+FIRRTL version 4.0.0
+; CHECK-LABEL: module UnrOnlyLabel(
+circuit UnrOnlyLabel:
+  public module UnrOnlyLabel:
+    input clock : Clock
+    input pred : UInt<1>
+    input en : UInt<1>
+
+    ; CHECK:      `ifdef USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:   assert__test: assert property (@(posedge clock) ~en | pred);
+    ; CHECK-NEXT: `endif // USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT: `ifdef USE_PROPERTY_AS_CONSTRAINT
+    ; CHECK-NEXT:   `ifdef USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT:     wire _GEN = ~en | pred;
+    ; CHECK-NEXT:     always @(edge _GEN)
+    ; CHECK-NEXT:       assume__test: assume(_GEN);
+    ; CHECK-NEXT:   `endif // USE_UNR_ONLY_CONSTRAINTS
+    ; CHECK-NEXT: `endif // USE_PROPERTY_AS_CONSTRAINT
+    intrinsic(circt_chisel_assert<guards="USE_UNR_ONLY_CONSTRAINTS", label="test">, clock, pred, en)


### PR DESCRIPTION
Add FIR -> SV test for "unclocked_assert" since we care about ensuring it has a specific shape re:output.

Test extracted from #7010.