### PR TITLE
[CAPI] Add circt-capi target and build it in CI

### DIFF
--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -93,7 +93,7 @@ jobs:
             -DCIRCT_SLANG_FRONTEND_ENABLED=ON
       - name: Test CIRCT
         run: |
-          ninja -C build check-circt -j$(nproc)
+          ninja -C build check-circt circt-capi -j$(nproc)
       - name: Unit Test CIRCT
         run: |
           ninja -C build check-circt-unit -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,9 @@ add_custom_target(circt-headers)
 set_target_properties(circt-headers PROPERTIES FOLDER "Misc")
 add_custom_target(circt-doc)
 
+# Umbrella target that builds all C API bindings.
+add_custom_target(circt-capi)
+
 # Add MLIR and LLVM headers to the include path
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})

--- a/cmake/modules/AddCIRCT.cmake
+++ b/cmake/modules/AddCIRCT.cmake
@@ -10,6 +10,11 @@ function(add_circt_interface interface)
   add_dependencies(circt-headers MLIR${interface}IncGen)
 endfunction()
 
+function(add_circt_public_c_api_library name)
+  add_mlir_public_c_api_library(${ARGV})
+  add_dependencies(circt-capi ${name})
+endfunction()
+
 # Additional parameters are forwarded to tablegen.
 function(add_circt_doc tablegen_file output_path command)
   set(LLVM_TARGET_DEFINITIONS ${tablegen_file}.td)

--- a/lib/CAPI/Conversion/CMakeLists.txt
+++ b/lib/CAPI/Conversion/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_public_c_api_library(CIRCTCAPIConversion
+add_circt_public_c_api_library(CIRCTCAPIConversion
   Passes.cpp
 
   LINK_LIBS PUBLIC

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -20,7 +20,7 @@ set(LLVM_OPTIONAL_SOURCES
   Verif.cpp
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIComb
+add_circt_public_c_api_library(CIRCTCAPIComb
   Comb.cpp
 
   LINK_LIBS PUBLIC
@@ -29,7 +29,7 @@ add_mlir_public_c_api_library(CIRCTCAPIComb
   CIRCTCombTransforms
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIDebug
+add_circt_public_c_api_library(CIRCTCAPIDebug
   Debug.cpp
 
   LINK_LIBS PUBLIC
@@ -37,7 +37,7 @@ add_mlir_public_c_api_library(CIRCTCAPIDebug
   CIRCTDebug
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIESI
+add_circt_public_c_api_library(CIRCTCAPIESI
   ESI.cpp
 
   LINK_LIBS PUBLIC
@@ -45,7 +45,7 @@ add_mlir_public_c_api_library(CIRCTCAPIESI
   CIRCTESI
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIFIRRTL
+add_circt_public_c_api_library(CIRCTCAPIFIRRTL
   FIRRTL.cpp
 
   LINK_LIBS PUBLIC
@@ -54,7 +54,7 @@ add_mlir_public_c_api_library(CIRCTCAPIFIRRTL
   CIRCTImportFIRFile
 )
 
-add_mlir_public_c_api_library(CIRCTCAPICHIRRTL
+add_circt_public_c_api_library(CIRCTCAPICHIRRTL
   CHIRRTL.cpp
 
   LINK_LIBS PUBLIC
@@ -62,7 +62,7 @@ add_mlir_public_c_api_library(CIRCTCAPICHIRRTL
   CIRCTFIRRTL
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIMSFT
+add_circt_public_c_api_library(CIRCTCAPIMSFT
   MSFT.cpp
 
   DEPENDS
@@ -75,7 +75,7 @@ add_mlir_public_c_api_library(CIRCTCAPIMSFT
   CIRCTMSFTTransforms
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIHW
+add_circt_public_c_api_library(CIRCTCAPIHW
   HW.cpp
 
   LINK_LIBS PUBLIC
@@ -83,7 +83,7 @@ add_mlir_public_c_api_library(CIRCTCAPIHW
   CIRCTHW
 )
 
-add_mlir_public_c_api_library(CIRCTCAPILLHD
+add_circt_public_c_api_library(CIRCTCAPILLHD
   LLHD.cpp
 
   LINK_LIBS PUBLIC
@@ -91,7 +91,7 @@ add_mlir_public_c_api_library(CIRCTCAPILLHD
   CIRCTLLHD
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIMoore
+add_circt_public_c_api_library(CIRCTCAPIMoore
   Moore.cpp
 
   LINK_LIBS PUBLIC
@@ -99,7 +99,7 @@ add_mlir_public_c_api_library(CIRCTCAPIMoore
   CIRCTMoore
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIOM
+add_circt_public_c_api_library(CIRCTCAPIOM
   OM.cpp
 
   LINK_LIBS PUBLIC
@@ -108,7 +108,7 @@ add_mlir_public_c_api_library(CIRCTCAPIOM
   CIRCTOMEvaluator
 )
 
-add_mlir_public_c_api_library(CIRCTCAPISeq
+add_circt_public_c_api_library(CIRCTCAPISeq
   Seq.cpp
 
   LINK_LIBS PUBLIC
@@ -117,7 +117,7 @@ add_mlir_public_c_api_library(CIRCTCAPISeq
   CIRCTSeqTransforms
 )
 
-add_mlir_public_c_api_library(CIRCTCAPISV
+add_circt_public_c_api_library(CIRCTCAPISV
   SV.cpp
 
   LINK_LIBS PUBLIC
@@ -126,7 +126,7 @@ add_mlir_public_c_api_library(CIRCTCAPISV
   CIRCTSVTransforms
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIFSM
+add_circt_public_c_api_library(CIRCTCAPIFSM
   FSM.cpp
 
   DEPENDS
@@ -139,7 +139,7 @@ add_mlir_public_c_api_library(CIRCTCAPIFSM
   CIRCTFSMToSV
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIHandshake
+add_circt_public_c_api_library(CIRCTCAPIHandshake
   Handshake.cpp
 
   LINK_LIBS PUBLIC
@@ -150,7 +150,7 @@ add_mlir_public_c_api_library(CIRCTCAPIHandshake
   CIRCTCFToHandshake
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIHWArith
+add_circt_public_c_api_library(CIRCTCAPIHWArith
   HWArith.cpp
 
   LINK_LIBS PUBLIC
@@ -159,7 +159,7 @@ add_mlir_public_c_api_library(CIRCTCAPIHWArith
   CIRCTHWArithToHW
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIVerif
+add_circt_public_c_api_library(CIRCTCAPIVerif
   Verif.cpp
 
   LINK_LIBS PUBLIC
@@ -168,7 +168,7 @@ add_mlir_public_c_api_library(CIRCTCAPIVerif
   CIRCTVerifToSV
 )
 
-add_mlir_public_c_api_library(CIRCTCAPILTL
+add_circt_public_c_api_library(CIRCTCAPILTL
   LTL.cpp
 
   LINK_LIBS PUBLIC
@@ -176,7 +176,7 @@ add_mlir_public_c_api_library(CIRCTCAPILTL
   CIRCTLTL
 )
 
-add_mlir_public_c_api_library(CIRCTCAPIEmit
+add_circt_public_c_api_library(CIRCTCAPIEmit
   Emit.cpp
 
   LINK_LIBS PUBLIC

--- a/lib/CAPI/ExportFIRRTL/CMakeLists.txt
+++ b/lib/CAPI/ExportFIRRTL/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_public_c_api_library(CIRCTCAPIExportFIRRTL
+add_circt_public_c_api_library(CIRCTCAPIExportFIRRTL
   ExportFIRRTL.cpp
 
   LINK_LIBS PUBLIC

--- a/lib/CAPI/ExportVerilog/CMakeLists.txt
+++ b/lib/CAPI/ExportVerilog/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_public_c_api_library(CIRCTCAPIExportVerilog
+add_circt_public_c_api_library(CIRCTCAPIExportVerilog
   ExportVerilog.cpp
 
   LINK_LIBS PUBLIC

--- a/lib/CAPI/Firtool/CMakeLists.txt
+++ b/lib/CAPI/Firtool/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_public_c_api_library(CIRCTCAPIFirtool
+add_circt_public_c_api_library(CIRCTCAPIFirtool
   Firtool.cpp
 
   LINK_LIBS PUBLIC


### PR DESCRIPTION
Add a `circt-capi` target that depends on all C API libraries. Introduce a new `add_circt_public_c_api_library` CMake function that wraps around the MLIR equivalent, but also adds a dependency from `circt-capi`. Make at least the short integration tests CI job build the `circt-capi` target to ensure it has a bit of CI coverage.