### PR TITLE
[FIRRTL] Add condition expansion for ExpandWhens on Property intrinsics

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -544,10 +544,10 @@ private:
   // the corner case where value is an implication.
   Value impliesLTLCondition(Operation *op, Value value) {
     OpBuilder builder = OpBuilder(op);
-    Value not_cond = builder.createOrFold<LTLNotIntrinsicOp>(
+    Value notCond = builder.createOrFold<LTLNotIntrinsicOp>(
         condition.getLoc(), condition.getType(), condition);
     return builder.createOrFold<LTLOrIntrinsicOp>(
-        condition.getLoc(), condition.getType(), not_cond, value);
+        condition.getLoc(), condition.getType(), notCond, value);
   }
 
 private:

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -514,6 +514,9 @@ public:
   void process(Block &block);
 
   /// Simulation Constructs.
+  void visitStmt(VerifAssertIntrinsicOp op);
+  void visitStmt(VerifAssumeIntrinsicOp op);
+  void visitStmt(VerifCoverIntrinsicOp op);
   void visitStmt(AssertOp op);
   void visitStmt(AssumeOp op);
   void visitStmt(UnclockedAssumeIntrinsicOp op);
@@ -536,6 +539,17 @@ private:
         condition.getLoc(), condition.getType(), condition, value);
   }
 
+  // Create an implication from the condition to the given value
+  // This is implemented as (or (not condition) value) to avoid
+  // the corner case where value is an implication.
+  Value impliesLTLCondition(Operation *op, Value value) {
+    OpBuilder builder = OpBuilder(op);
+    Value not_cond = builder.createOrFold<LTLNotIntrinsicOp>(
+        condition.getLoc(), condition.getType(), condition);
+    return builder.createOrFold<LTLOrIntrinsicOp>(
+        condition.getLoc(), condition.getType(), not_cond, value);
+  }
+
 private:
   /// The current wrapping condition. If null, we are in the outer scope.
   Value condition;
@@ -554,6 +568,18 @@ void WhenOpVisitor::visitStmt(PrintFOp op) {
 
 void WhenOpVisitor::visitStmt(StopOp op) {
   op.getCondMutable().assign(andWithCondition(op, op.getCond()));
+}
+
+void WhenOpVisitor::visitStmt(VerifAssertIntrinsicOp op) {
+  op.getPropertyMutable().assign(impliesLTLCondition(op, op.getProperty()));
+}
+
+void WhenOpVisitor::visitStmt(VerifAssumeIntrinsicOp op) {
+  op.getPropertyMutable().assign(impliesLTLCondition(op, op.getProperty()));
+}
+
+void WhenOpVisitor::visitStmt(VerifCoverIntrinsicOp op) {
+  op.getPropertyMutable().assign(impliesLTLCondition(op, op.getProperty()));
 }
 
 void WhenOpVisitor::visitStmt(AssertOp op) {

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -636,4 +636,40 @@ firrtl.module @ModuleWithObjectWire(in %in: !firrtl.class<@ClassWithInput(in in:
   firrtl.propassign %0, %in : !firrtl.class<@ClassWithInput(in in: !firrtl.string)>
 }
 
+// Test all verif assert/assume/cover constructs
+// CHECK:   firrtl.module @verif(in %clock: !firrtl.clock, in %cond: !firrtl.uint<1>, in %prop: !firrtl.uint<1>, in %enable: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
+firrtl.module @verif(
+  in %clock : !firrtl.clock, in %cond : !firrtl.uint<1>, in %prop : !firrtl.uint<1>,
+  in %enable : !firrtl.uint<1>, in %reset : !firrtl.uint<1>
+) {
+  firrtl.when %cond : !firrtl.uint<1> {
+    // CHECK:   %0 = firrtl.int.ltl.not %cond : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   %1 = firrtl.int.ltl.or %0, %prop : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   firrtl.int.verif.assert %1 : !firrtl.uint<1>
+    firrtl.int.verif.assert %prop : !firrtl.uint<1>
+    // CHECK:   %2 = firrtl.int.ltl.not %cond : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   %3 = firrtl.int.ltl.or %2, %prop : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   firrtl.int.verif.assume %3 : !firrtl.uint<1>
+    firrtl.int.verif.assume %prop : !firrtl.uint<1>
+    // CHECK:   %4 = firrtl.int.ltl.not %cond : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   %5 = firrtl.int.ltl.or %4, %prop : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   firrtl.int.verif.cover %5 : !firrtl.uint<1>
+    firrtl.int.verif.cover %prop : !firrtl.uint<1>
+  } else {
+    // CHECK:   %6 = firrtl.not %cond : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   %7 = firrtl.int.ltl.not %6 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   %8 = firrtl.int.ltl.or %7, %prop : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   firrtl.int.verif.assert %8 : !firrtl.uint<1>
+    firrtl.int.verif.assert %prop : !firrtl.uint<1>
+    // CHECK:   %9 = firrtl.int.ltl.not %6 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   %10 = firrtl.int.ltl.or %9, %prop : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   firrtl.int.verif.assume %10 : !firrtl.uint<1>
+    firrtl.int.verif.assume %prop : !firrtl.uint<1>
+    // CHECK:   %11 = firrtl.int.ltl.not %6 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   %12 = firrtl.int.ltl.or %11, %prop : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   firrtl.int.verif.cover %12 : !firrtl.uint<1>
+    firrtl.int.verif.cover %prop : !firrtl.uint<1>
+  }
+}
+
 }

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -643,9 +643,9 @@ firrtl.module @verif(
   in %enable : !firrtl.uint<1>, in %reset : !firrtl.uint<1>
 ) {
   firrtl.when %cond : !firrtl.uint<1> {
-    // CHECK:   %0 = firrtl.int.ltl.not %cond : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK:   %1 = firrtl.int.ltl.or %0, %prop : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK:   firrtl.int.verif.assert %1 : !firrtl.uint<1>
+    // CHECK:   [[TMP0:%.+]] = firrtl.int.ltl.not %cond : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   [[TMP1:%.+]] = firrtl.int.ltl.or [[TMP0]], %prop : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   firrtl.int.verif.assert [[TMP1]] : !firrtl.uint<1>
     firrtl.int.verif.assert %prop : !firrtl.uint<1>
     // CHECK:   %2 = firrtl.int.ltl.not %cond : (!firrtl.uint<1>) -> !firrtl.uint<1>
     // CHECK:   %3 = firrtl.int.ltl.or %2, %prop : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>


### PR DESCRIPTION
This PR corrects when expansions for `[Assert, Assume, Cover]Poperty` by creating an `implies` statement between the condition of the when and the property itself.
Basically in the case of the following:
```
when(cond): 
    AssertProperty(prop)
```
is currently being expanded to simply  
```
AssertProperty(prop)
```
which is wrong, so this PR makes so that it gets expanded to
```
AssertProperty(cond implies prop)
```