### PR TITLE
[SV] Add `sv.reserve_names` op to disallow names

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -879,3 +879,17 @@ def MacroDefOp : SVOp<"macro.def",
     MacroDeclOp getReferencedMacro(const hw::HWSymbolCache *cache);
   }];
 }
+
+
+//===----------------------------------------------------------------------===//
+// SV output control.
+//===----------------------------------------------------------------------===//
+
+def ReserveNamesOp : SVOp<"reserve_names", []> {
+  let summary = "Disallow a set of names to be used during emission";
+
+  let arguments = (ins StrArrayAttr:$reservedNames);
+  let assemblyFormat = [{
+    $reservedNames attr-dict
+  }];
+}

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -885,7 +885,9 @@ def MacroDefOp : SVOp<"macro.def",
 // SV output control.
 //===----------------------------------------------------------------------===//
 
-def ReserveNamesOp : SVOp<"reserve_names", []> {
+def ReserveNamesOp : SVOp<"reserve_names", [
+  HasParent<"mlir::ModuleOp">
+]> {
   let summary = "Disallow a set of names to be used during emission";
 
   let arguments = (ins StrArrayAttr:$reservedNames);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -6344,6 +6344,9 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
         .Case<MacroDeclOp>([&](auto op) {
           symbolCache.addDefinition(op.getSymNameAttr(), op);
         })
+        .Case<sv::ReserveNamesOp>([](auto op) {
+          // This op was already used in gathering used names.
+        })
         .Case<om::ClassLike>([&](auto op) {
           symbolCache.addDefinition(op.getSymNameAttr(), op);
         })

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -82,7 +82,7 @@ private:
   DenseMap<Type, StringAttr> enumPrefixes;
 
   /// List of names which are marked as reserved for any name.
-  StringSet<> reservedNames;
+  DenseSet<StringAttr> reservedNames;
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -27,6 +27,7 @@ struct LoweringOptions;
 
 namespace ExportVerilog {
 class GlobalNameResolver;
+struct NameCollisionResolver;
 
 /// Check if the value is from read of a wire or reg or is a port.
 bool isSimpleReadOrPort(Value v);
@@ -57,6 +58,9 @@ struct GlobalNameTable {
     return it != enumPrefixes.end() ? it->second : StringAttr();
   }
 
+  // Add the set of reserved names to a resolver.
+  void addReservedNames(NameCollisionResolver &nameResolver) const;
+
 private:
   friend class GlobalNameResolver;
   GlobalNameTable() {}
@@ -76,6 +80,9 @@ private:
   // This contains prefixes for any typedecl'd enum types. Keys are type-aliases
   // of enum types.
   DenseMap<Type, StringAttr> enumPrefixes;
+
+  /// List of names which are marked as reserved for any name.
+  StringSet<> reservedNames;
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -25,6 +25,15 @@ using namespace hw;
 using namespace ExportVerilog;
 
 //===----------------------------------------------------------------------===//
+// GlobalNameTable
+//===----------------------------------------------------------------------===//
+
+void GlobalNameTable::addReservedNames(NameCollisionResolver &resolver) const {
+  for (auto &name : reservedNames)
+    resolver.insertUsedName(name.getKey());
+}
+
+//===----------------------------------------------------------------------===//
 // NameCollisionResolver
 //===----------------------------------------------------------------------===//
 
@@ -134,6 +143,8 @@ static void legalizeModuleLocalNames(HWModuleOp module,
                                      const GlobalNameTable &globalNameTable) {
   // A resolver for a local name collison.
   NameCollisionResolver nameResolver(options);
+  globalNameTable.addReservedNames(nameResolver);
+
   // Register names used by parameters.
   for (auto param : module.getParameters())
     nameResolver.insertUsedName(globalNameTable.getParameterVerilogName(
@@ -237,6 +248,12 @@ GlobalNameResolver::GlobalNameResolver(mlir::ModuleOp topLevel,
         op.emitError("name \"")
             << name << "\" is not allowed in Verilog output";
       globalNameResolver.insertUsedName(name);
+    } else if (auto reservedNamesOp = dyn_cast<sv::ReserveNamesOp>(op)) {
+      for (StringAttr name :
+           reservedNamesOp.getReservedNames().getAsRange<StringAttr>()) {
+        globalNameTable.reservedNames.insert(name);
+        globalNameResolver.insertUsedName(name);
+      }
     }
   }
 

--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -30,7 +30,7 @@ using namespace ExportVerilog;
 
 void GlobalNameTable::addReservedNames(NameCollisionResolver &resolver) const {
   for (auto &name : reservedNames)
-    resolver.insertUsedName(name.getKey());
+    resolver.insertUsedName(name);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -3,6 +3,14 @@
 sv.macro.decl @SYNTHESIS
 sv.macro.decl @VERILATOR
 
+// CHECK-NOT: module ReservedName1(
+// CHECK-NOT:   input reservedName2{{$}}
+// CHECK-NOT:   reg reservedName3;
+sv.reserve_names ["ReservedName1", "reservedName2", "reservedName3"]
+hw.module @ReservedName1 (in %reservedName2 : i1) {
+  %reservedName3 = sv.reg : !hw.inout<i1>
+}
+
 // CHECK-LABEL: module M1
 // CHECK-NEXT:    #(parameter [41:0] param1) (
 hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {


### PR DESCRIPTION
Introduce an op to specific a list of names which Export Verilog should never use anywhere. Applies to module names, port names, reg/wire/logic names, etc.