### PR TITLE
cmake: circt install directory for CAPI

### DIFF
--- a/cmake/modules/AddCIRCT.cmake
+++ b/cmake/modules/AddCIRCT.cmake
@@ -11,8 +11,9 @@ function(add_circt_interface interface)
 endfunction()
 
 function(add_circt_public_c_api_library name)
-  add_mlir_public_c_api_library(${ARGV})
+  add_mlir_public_c_api_library(${ARGV} DISABLE_INSTALL)
   add_dependencies(circt-capi ${name})
+  add_circt_library_install(${name})
 endfunction()
 
 # Additional parameters are forwarded to tablegen.


### PR DESCRIPTION
Use our install macro, in same way that `add_circt_library` works.

Ensures CAPI bits have same installation logic as other libraries.