### PR TITLE
[FIRRTL][Import] Remove support for printf-encoded verif.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRAnnotations.h
+++ b/lib/Dialect/FIRRTL/Import/FIRAnnotations.h
@@ -39,10 +39,9 @@ bool fromOMIRJSON(llvm::json::Value &value,
                   SmallVectorImpl<Attribute> &annotations,
                   llvm::json::Path path, MLIRContext *context);
 
-/// Handle verif intent captured in printf + when's.  Returns failure if any
-/// encountered, otherwise bool indicates whether the printf was encoding verif
-/// intent. Mutates the IR, and will delete the PrintFOp when returns true.
-FailureOr<bool> foldWhenEncodedVerifOp(PrintFOp printOp);
+/// Classifier for legacy verif intent captured in printf + when's.  Returns
+/// true if the printf encodes verif intent, false otherwise.
+bool isRecognizedPrintfEncodedVerif(PrintFOp printOp);
 
 } // namespace firrtl
 } // namespace circt

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -5390,36 +5390,27 @@ FIRCircuitParser::parseModuleBody(const SymbolTable &circuitSymTbl,
   if (failed(result))
     return result;
 
-  // Convert print-encoded verifications after parsing.
-
+  // Scan for printf-encoded verif's to error on their use, no longer supported.
   {
-    // Gather PrintFOps and then process to avoid walking while mutating.
-    SmallVector<PrintFOp> buffer;
-    deferredModule.moduleOp.walk(
-        [&buffer](PrintFOp printFOp) { buffer.push_back(printFOp); });
-
     size_t numVerifPrintfs = 0;
     std::optional<Location> printfLoc;
-    for (auto printFOp : buffer) {
-      auto loc = printFOp.getLoc();
-      auto result = circt::firrtl::foldWhenEncodedVerifOp(printFOp);
-      if (failed(result))
-        return failure();
-      if (*result) {
-        ++numVerifPrintfs;
-        if (!printfLoc)
-          printfLoc = loc;
-      }
-    }
+
+    deferredModule.moduleOp.walk([&](PrintFOp printFOp) {
+      if (!circt::firrtl::isRecognizedPrintfEncodedVerif(printFOp))
+        return;
+      ++numVerifPrintfs;
+      if (!printfLoc)
+        printfLoc = printFOp.getLoc();
+    });
+
     if (numVerifPrintfs > 0) {
       auto diag =
-          mlir::emitWarning(deferredModule.moduleOp.getLoc(),
-                            "module contains ")
+          mlir::emitError(deferredModule.moduleOp.getLoc(), "module contains ")
           << numVerifPrintfs
-          << " printf-encoded verification operation(s), which are deprecated "
-             "and will be removed in the future";
+          << " printf-encoded verification operation(s), which are no longer "
+             "supported.";
       diag.attachNote(*printfLoc)
-          << "example printf here, will just be a printf in the future";
+          << "example printf here, this is now just a printf and nothing more";
       diag.attachNote() << "For more information, see "
                            "https://github.com/llvm/circt/issues/6970";
     }

--- a/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParserAsserts.cpp
@@ -9,211 +9,23 @@
 // This file implements handling of printf-encoded verification operations
 // embedded in when blocks.
 //
+// While no longer supported, this file retains enough to classify printf
+// operations so that we may error on their unsupported use.
+//
 //===----------------------------------------------------------------------===//
 
 #include "FIRAnnotations.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
-#include "llvm/ADT/APSInt.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/JSON.h"
 
 using namespace circt;
 using namespace firrtl;
 
-namespace json = llvm::json;
-
-namespace {
-/// Helper class to destructure parsed JSON and emit appropriate error messages.
-/// This class should be treated with the same care as a Twine; it should never
-/// be assigned to a local variable and should only be passed by constant
-/// reference parameters.
-template <typename JsonType>
-class ExtractionSummaryCursor {
-
-  // Allow ExtractionSummaryCursor to construct other instances.
-  template <typename T>
-  friend class ExtractionSummaryCursor;
-
-  // This is a friend function since we have no public contructors.
-  template <typename T, typename FnType>
-  friend ParseResult parseJson(Location loc, const T &jsonValue, FnType fn);
-
-  // Private constructor and destructor.
-  ExtractionSummaryCursor(Location loc, Twine path, JsonType value)
-      : loc(loc), path(path), value(value) {}
-  ~ExtractionSummaryCursor() = default;
-
-  // Deleted constructors.
-  ExtractionSummaryCursor(const ExtractionSummaryCursor &) = delete;
-  ExtractionSummaryCursor &operator=(const ExtractionSummaryCursor &) = delete;
-
-public:
-  Location loc;
-  Twine path;
-  JsonType value;
-
-  /// Report an error about the current path.
-  InFlightDiagnostic emitError() const {
-    auto diag = mlir::emitError(loc, "extraction summary ");
-    if (!path.isTriviallyEmpty())
-      diag << "field `" << path << "` ";
-    return diag;
-  }
-
-  /// Access a field in an object.
-  ParseResult withField(StringRef field,
-                        llvm::function_ref<ParseResult(
-                            const ExtractionSummaryCursor<json::Value *> &)>
-                            fn,
-                        bool optional = false) const {
-    auto fieldValue = value->get(field);
-    if (!fieldValue) {
-      if (optional)
-        return success();
-      emitError() << "missing `" << field << "` field";
-      return failure();
-    }
-    return fn({loc, path.isTriviallyEmpty() ? field : path + "." + field,
-               fieldValue});
-  }
-
-  /// Access a JSON value as an object.
-  ParseResult withObject(llvm::function_ref<ParseResult(
-                             const ExtractionSummaryCursor<json::Object *> &)>
-                             fn) const {
-    auto obj = value->getAsObject();
-    if (!obj) {
-      emitError() << "must be an object";
-      return failure();
-    }
-    return fn({loc, path, obj});
-  }
-
-  /// Access a JSON value as a string.
-  ParseResult withString(llvm::function_ref<ParseResult(
-                             const ExtractionSummaryCursor<StringRef> &)>
-                             fn) const {
-    auto str = value->getAsString();
-    if (!str) {
-      emitError() << "must be a string";
-      return failure();
-    }
-    return fn({loc, path, *str});
-  }
-
-  /// Access a JSON value as an array.
-  ParseResult withArray(llvm::function_ref<ParseResult(
-                            const ExtractionSummaryCursor<json::Value *> &)>
-                            fn) const {
-    auto array = value->getAsArray();
-    if (!array) {
-      emitError() << "must be an array";
-      return failure();
-    }
-    for (size_t i = 0, e = array->size(); i < e; ++i)
-      if (fn({loc, path + "[" + Twine(i) + "]", &(*array)[i]}))
-        return failure();
-    return success();
-  }
-
-  /// Access an object field as an object.
-  ParseResult
-  withObjectField(StringRef field,
-                  llvm::function_ref<ParseResult(
-                      const ExtractionSummaryCursor<json::Object *> &)>
-                      fn,
-                  bool optional = false) const {
-    return withField(
-        field, [&](const auto &cursor) { return cursor.withObject(fn); },
-        optional);
-  }
-
-  /// Access an object field as a string.
-  ParseResult withStringField(StringRef field,
-                              llvm::function_ref<ParseResult(
-                                  const ExtractionSummaryCursor<StringRef> &)>
-                                  fn,
-                              bool optional = false) const {
-    return withField(
-        field, [&](const auto &cursor) { return cursor.withString(fn); },
-        optional);
-  }
-
-  /// Access an object field as an array.
-  ParseResult
-  withArrayField(StringRef field,
-                 llvm::function_ref<ParseResult(
-                     const ExtractionSummaryCursor<json::Value *> &)>
-                     fn,
-                 bool optional = true) const {
-    return withField(
-        field, [&](const auto &cursor) { return cursor.withArray(fn); },
-        optional);
-  }
-};
-
-/// Convenience function to create a `ExtractionSummaryCursor`.
-template <typename JsonType, typename FnType>
-ParseResult parseJson(Location loc, const JsonType &jsonValue, FnType fn) {
-  return fn(ExtractionSummaryCursor<JsonType>{loc, {}, jsonValue});
-}
-} // namespace
-
-/// A flavor of when-printf-encoded verification statement.
-enum class VerifFlavor {
-  VerifLibAssert, // contains "[verif-library-assert]"
-  VerifLibAssume, // contains "[verif-library-assume]"
-  VerifLibCover,  // contains "[verif-library-cover]"
-  Assert,         // begins with "assert:"
-  Assume,         // begins with "assume:"
-  Cover,          // begins with "cover:"
-  ChiselAssert,   // begins with "Assertion failed"
-  AssertNotX      // begins with "assertNotX:"
-};
-
-/// A modifier for an assertion predicate.
-enum class PredicateModifier { NoMod, TrueOrIsX };
-
-/// Parse a conditional compile toggle (e.g. "unrOnly") into the corresponding
-/// preprocessor guard macro name (e.g. "USE_UNR_ONLY_CONSTRAINTS"), or report
-/// an error.
-static std::optional<StringRef>
-parseConditionalCompileToggle(const ExtractionSummaryCursor<StringRef> &ex) {
-  if (ex.value == "formalOnly")
-    return {"USE_FORMAL_ONLY_CONSTRAINTS"};
-  else if (ex.value == "unrOnly")
-    return {"USE_UNR_ONLY_CONSTRAINTS"};
-  ex.emitError() << "must be `formalOnly` or `unrOnly`";
-  return std::nullopt;
-}
-
-/// Parse a string into a `PredicateModifier`.
-static std::optional<PredicateModifier>
-parsePredicateModifier(const ExtractionSummaryCursor<StringRef> &ex) {
-  if (ex.value == "noMod")
-    return PredicateModifier::NoMod;
-  else if (ex.value == "trueOrIsX")
-    return PredicateModifier::TrueOrIsX;
-  ex.emitError() << "must be `noMod` or `trueOrIsX`";
-  return std::nullopt;
-}
-
-/// Check that an assertion "format" is one of the admissible values, or report
-/// an error.
-static std::optional<StringRef>
-parseAssertionFormat(const ExtractionSummaryCursor<StringRef> &ex) {
-  if (ex.value == "sva" || ex.value == "ifElseFatal")
-    return ex.value;
-  ex.emitError() << "must be `sva` or `ifElseFatal`";
-  return std::nullopt;
-}
-
 /// Chisel has a tendency to emit complex assert/assume/cover statements encoded
 /// as print operations with special formatting and metadata embedded in the
-/// message literal. These always reside in a when block of the following form:
+/// message literal.  One variant looks like:
 ///
 ///     when invCond:
 ///       printf(clock, UInt<1>(1), "...[verif-library-assert]...")
@@ -222,8 +34,11 @@ parseAssertionFormat(const ExtractionSummaryCursor<StringRef> &ex) {
 /// Depending on the nature the verification operation, the `stop` may be
 /// optional. The Scala implementation simply removes all `stop`s that have the
 /// same condition as the printf.
-FailureOr<bool> circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
-  auto *context = printOp.getContext();
+///
+/// This is no longer supported.
+/// This method retains enough support to accurately detect when this is used
+/// and returns whether this is a recognized (legacy) printf+when-encoded verif.
+bool circt::firrtl::isRecognizedPrintfEncodedVerif(PrintFOp printOp) {
   auto whenStmt = dyn_cast<WhenOp>(printOp->getParentOp());
 
   // If the parent of printOp is not when, printOp doesn't encode a
@@ -241,382 +56,26 @@ FailureOr<bool> circt::firrtl::foldWhenEncodedVerifOp(PrintFOp printOp) {
   auto opIt = std::next(printOp->getIterator());
   auto opEnd = thenBlock.end();
 
-  // Detect if we're dealing with a verification statement, and what flavor of
-  // statement it is.
+  // Detect if we're dealing with a verification statement.
   auto fmt = printOp.getFormatString();
-  VerifFlavor flavor;
-  if (fmt.contains("[verif-library-assert]"))
-    flavor = VerifFlavor::VerifLibAssert;
-  else if (fmt.contains("[verif-library-assume]"))
-    flavor = VerifFlavor::VerifLibAssume;
-  else if (fmt.contains("[verif-library-cover]"))
-    flavor = VerifFlavor::VerifLibCover;
-  else if (fmt.consume_front("assert:"))
-    flavor = VerifFlavor::Assert;
-  else if (fmt.consume_front("assume:"))
-    flavor = VerifFlavor::Assume;
-  else if (fmt.consume_front("cover:"))
-    flavor = VerifFlavor::Cover;
-  else if (fmt.consume_front("assertNotX:"))
-    flavor = VerifFlavor::AssertNotX;
-  else if (fmt.starts_with("Assertion failed"))
-    flavor = VerifFlavor::ChiselAssert;
-  else
+  if (!(fmt.contains("[verif-library-assert]") ||
+        fmt.contains("[verif-library-assume]") ||
+        fmt.contains("[verif-library-cover]") || fmt.starts_with("assert:") ||
+        fmt.starts_with("assume:") || fmt.starts_with("cover:") ||
+        fmt.starts_with("assertNotX:") || fmt.starts_with("Assertion failed")))
     return false;
 
   // optional `stop(clock, enable, ...)`
   //
-  // FIXME: Currently, we can't detetct stopOp in the following IR:
-  //    when invCond:
-  //      printf(io.clock, UInt<1>(1), "assert: ..")
-  //      stop(io.clock, UInt<1>(1), 1)
-  // It is because `io.clock` will create another subfield op so StopOp is not
-  // the next operation. Also, we will have to modify `stopOp.clock() !=
-  // printOp.clock()` below since they are not CSEd.
+  // NOTE: This code is retained as-is from when these were fully supported,
+  // to maintain the classification portion.  Previously this code would then
+  // delete the "stop" operation, which it no longer does.
   if (opIt != opEnd) {
     auto stopOp = dyn_cast<StopOp>(*opIt++);
     if (!stopOp || opIt != opEnd || stopOp.getClock() != printOp.getClock() ||
         stopOp.getCond() != printOp.getCond())
       return false;
-    stopOp.erase();
+    // (This code used to erase the stop operation here)
   }
-
-  // Check if the condition of the `WhenOp` is a trivial inversion operation,
-  // and remove any immediately preceding verification ops that ensure this
-  // condition. This caters to the following pattern emitted by Chisel:
-  //
-  //     assert(clock, cond, enable, ...)
-  //     node N = eq(cond, UInt<1>(0))
-  //     when N:
-  //       printf(clock, enable, ...)
-  Value flippedCond = whenStmt.getCondition();
-  if (auto node = flippedCond.getDefiningOp<NodeOp>())
-    flippedCond = node.getInput();
-  if (auto notOp = flippedCond.getDefiningOp<NotPrimOp>()) {
-    flippedCond = notOp.getInput();
-  } else if (auto eqOp = flippedCond.getDefiningOp<EQPrimOp>()) {
-    auto isConst0 = [](Value v) {
-      if (auto constOp = v.getDefiningOp<ConstantOp>())
-        return constOp.getValue().isZero();
-      return false;
-    };
-    if (isConst0(eqOp.getLhs()))
-      flippedCond = eqOp.getRhs();
-    else if (isConst0(eqOp.getRhs()))
-      flippedCond = eqOp.getLhs();
-    else
-      flippedCond = {};
-  } else {
-    flippedCond = {};
-  }
-
-  // If we have found such a condition, erase any verification ops that use it
-  // and that match the op we are about to assemble. This is necessary since the
-  // `printf` op actually carries all the information we need for the assert,
-  // while the actual `assert` has none of it. This makes me sad.
-  if (flippedCond) {
-    // Use a set to catch cases where a verification op is a double user of the
-    // flipped condition.
-    SmallPtrSet<Operation *, 1> opsToErase;
-    for (const auto &user : flippedCond.getUsers()) {
-      TypeSwitch<Operation *>(user).Case<AssertOp, AssumeOp, CoverOp>(
-          [&](auto op) {
-            if (op.getClock() == printOp.getClock() &&
-                op.getEnable() == printOp.getCond() &&
-                op.getPredicate() == flippedCond && !op.getIsConcurrent())
-              opsToErase.insert(op);
-          });
-    }
-    for (auto op : opsToErase)
-      op->erase();
-  }
-
-  // A recursive function to move all the dependency in `printOp` operands.
-  std::function<void(Operation *)> moveOperationsToParent = [&](Operation *op) {
-    // If operation is not defined in when, it's ok.
-    if (!op || op->getBlock() != &whenStmt.getThenBlock())
-      return;
-
-    llvm::for_each(op->getOperands(), [&](Value value) {
-      moveOperationsToParent(value.getDefiningOp());
-    });
-
-    // `op` might be already moved to parent op by the previous recursive calls,
-    // so check again.
-    if (op->getBlock() != &whenStmt.getThenBlock())
-      return;
-
-    op->moveBefore(whenStmt);
-  };
-
-  // Move all operands in printOp to the parent block.
-  llvm::for_each(printOp->getOperands(), [&](Value value) {
-    moveOperationsToParent(value.getDefiningOp());
-  });
-
-  ImplicitLocOpBuilder builder(whenStmt.getLoc(), whenStmt);
-  builder.setInsertionPointAfter(whenStmt);
-  // CAREFUL: Since the assertions are encoded as "when something wrong, then
-  // print" an error message, we're actually asserting that something is *not*
-  // going wrong.
-  //
-  // In code:
-  //
-  //     when somethingGoingWrong:
-  //       printf("oops")
-  //
-  // Actually expresses:
-  //
-  //     assert(not(somethingGoingWrong), "oops")
-  //
-  // So you'll find quite a few inversions of the when condition below to
-  // represent this.
-
-  // TODO: None of the following ops preserve interpolated operands in the
-  // format string. SV allows this, and we might want to extend the
-  // `firrtl.{assert,assume,cover}` operations to deal with this.
-
-  switch (flavor) {
-    // Handle the case of property verification encoded as `<assert>:<msg>` or
-    // `<assert>:<label>:<msg>`.
-  case VerifFlavor::Assert:
-  case VerifFlavor::Assume:
-  case VerifFlavor::Cover:
-  case VerifFlavor::AssertNotX: {
-    // Extract label and message from the format string.
-    StringRef label;
-    StringRef message = fmt;
-    auto index = fmt.find(':');
-    if (index != StringRef::npos) {
-      label = fmt.slice(0, index);
-      message = fmt.slice(index + 1, StringRef::npos);
-    }
-
-    // AssertNotX has the special format `assertNotX:%d:msg`, where the `%d`
-    // would theoretically interpolate the value being check for X, but in
-    // practice the Scala impl of ExtractTestCode just discards that `%d` label
-    // and replaces it with `notX`. Also prepare the condition to be checked
-    // here.
-    Value predicate = whenStmt.getCondition();
-    if (flavor != VerifFlavor::Cover)
-      predicate = builder.create<NotPrimOp>(predicate);
-    if (flavor == VerifFlavor::AssertNotX) {
-      label = "notX";
-      if (printOp.getSubstitutions().size() != 1) {
-        return printOp.emitError(
-            "printf-encoded assertNotX requires one operand");
-        return failure();
-      }
-      // Construct a `!whenCond | (^value !== 1'bx)` predicate.
-      Value notCond = predicate;
-      predicate = builder.create<XorRPrimOp>(printOp.getSubstitutions()[0]);
-      predicate = builder.create<IsXIntrinsicOp>(predicate);
-      predicate = builder.create<NotPrimOp>(predicate);
-      predicate = builder.create<OrPrimOp>(notCond, predicate);
-    }
-
-    // CAVEAT: The Scala impl of ExtractTestCode explicitly sets `emitSVA` to
-    // false for these flavors of verification operations. I think it's a bad
-    // idea to decide at parse time if something becomes an SVA or a print+fatal
-    // process, so I'm not doing this here. If we ever come across this need, we
-    // may want to annotate the operation with an attribute to indicate that it
-    // wants to explicitly *not* be an SVA.
-
-    // TODO: Sanitize the label by replacing whitespace with "_" as done in the
-    // Scala impl of ExtractTestCode.
-    ValueRange args;
-    if (printOp.getSubstitutions().size())
-      args = printOp.getSubstitutions().drop_front();
-    if (args.size())
-      printOp.emitWarning()
-          << "printf-encoded assertion has format string arguments which may "
-             "cause lint warnings";
-    if (flavor == VerifFlavor::Assert || flavor == VerifFlavor::AssertNotX)
-      builder.create<AssertOp>(printOp.getClock(), predicate, printOp.getCond(),
-                               message, args, label, true);
-    else if (flavor == VerifFlavor::Assume)
-      builder.create<AssumeOp>(printOp.getClock(), predicate, printOp.getCond(),
-                               message, args, label, true);
-    else // VerifFlavor::Cover
-      builder.create<CoverOp>(printOp.getClock(), predicate, printOp.getCond(),
-                              message, args, label, true);
-    printOp.erase();
-    break;
-  }
-
-    // Handle the case of builtin Chisel assertions.
-  case VerifFlavor::ChiselAssert: {
-    auto op = builder.create<AssertOp>(
-        printOp.getClock(), builder.create<NotPrimOp>(whenStmt.getCondition()),
-        printOp.getCond(), fmt, printOp.getSubstitutions(), "chisel3_builtin",
-        true);
-    op->setAttr("format", StringAttr::get(context, "ifElseFatal"));
-    printOp.erase();
-    break;
-  }
-
-    // Handle the SiFive verification library asserts/assumes, which contain
-    // additional configuration attributes for the verification op, serialized
-    // to JSON and embedded in the print message within `<extraction-summary>`
-    // XML tags.
-  case VerifFlavor::VerifLibAssert:
-  case VerifFlavor::VerifLibAssume:
-  case VerifFlavor::VerifLibCover: {
-    // Isolate the JSON text in the `<extraction-summary>` XML tag.
-    StringRef prefix, exStr, suffix;
-    std::tie(prefix, exStr) = fmt.split("<extraction-summary>");
-    std::tie(exStr, suffix) = exStr.split("</extraction-summary>");
-
-    // The extraction summary is necessary for this kind of assertion, so we
-    // throw an error if it is missing.
-    if (exStr.empty()) {
-      auto diag = printOp.emitError(
-          "printf-encoded assert/assume requires extraction summary");
-      diag.attachNote(printOp.getLoc())
-          << "because printf message contains "
-             "`[verif-library-{assert,assume,cover}]` tag";
-      diag.attachNote(printOp.getLoc())
-          << "expected JSON-encoded extraction summary in "
-             "`<extraction-summary>` XML tag";
-      return failure();
-    }
-
-    // Parse the extraction summary, which contains additional parameters for
-    // the assertion.
-    auto ex = json::parse(exStr);
-    if (auto err = ex.takeError()) {
-      handleAllErrors(std::move(err), [&](const json::ParseError &a) {
-        printOp.emitError("failed to parse JSON extraction summary")
-                .attachNote()
-            << a.message();
-      });
-      return failure();
-    }
-
-    // The extraction summary must be an object.
-    auto exObj = ex->getAsObject();
-    if (!exObj) {
-      printOp.emitError("extraction summary must be a JSON object");
-      return failure();
-    }
-
-    // Extract and apply any predicate modifier.
-    PredicateModifier predMod;
-    if (parseJson(printOp.getLoc(), exObj, [&](const auto &ex) {
-          return ex.withObjectField("predicateModifier", [&](const auto &ex) {
-            return ex.withStringField("type", [&](const auto &ex) {
-              if (auto pm = parsePredicateModifier(ex)) {
-                predMod = *pm;
-                return success();
-              }
-              return failure();
-            });
-          });
-        }))
-      return failure();
-
-    Value predicate = whenStmt.getCondition();
-    predicate = builder.create<NotPrimOp>(
-        predicate); // assertion triggers when predicate fails
-    switch (predMod) {
-    case PredicateModifier::NoMod:
-      // Leave the predicate unmodified.
-      break;
-    case PredicateModifier::TrueOrIsX:
-      // Construct a `predicate | (^predicate === 1'bx)`.
-      Value isX =
-          builder.create<IsXIntrinsicOp>(builder.create<XorRPrimOp>(predicate));
-      predicate = builder.create<OrPrimOp>(predicate, isX);
-      break;
-    }
-
-    // Extract the preprocessor macro names that should guard this assertion.
-    SmallVector<Attribute> guards;
-    if (parseJson(printOp.getLoc(), exObj, [&](const auto &ex) {
-          return ex.withArrayField(
-              "conditionalCompileToggles", [&](const auto &ex) {
-                return ex.withObject([&](const auto &ex) {
-                  return ex.withStringField("type", [&](const auto &ex) {
-                    if (auto guard = parseConditionalCompileToggle(ex)) {
-                      guards.push_back(
-                          StringAttr::get(builder.getContext(), *guard));
-                      return success();
-                    }
-                    return failure();
-                  });
-                });
-              });
-        }))
-      return failure();
-
-    // Extract label additions and the message.
-    SmallString<32> label("verif_library");
-    if (parseJson(printOp.getLoc(), exObj, [&](const auto &ex) {
-          return ex.withArrayField("labelExts", [&](const auto &ex) {
-            return ex.withString([&](const auto &ex) {
-              label.push_back('_');
-              label.append(ex.value);
-              return success();
-            });
-          });
-        }))
-      return failure();
-
-    StringRef message = fmt;
-    if (parseJson(printOp.getLoc(), exObj, [&](const auto &ex) {
-          return ex.withStringField("baseMsg", [&](const auto &ex) {
-            message = ex.value;
-            return success();
-          });
-        }))
-      return failure();
-
-    // Assertions carry an additional `format` field.
-    std::optional<StringRef> format;
-    if (flavor == VerifFlavor::VerifLibAssert) {
-      if (parseJson(printOp.getLoc(), exObj, [&](const auto &ex) {
-            return ex.withObjectField("format", [&](const auto &ex) {
-              return ex.withStringField("type", [&](const auto &ex) {
-                if (auto f = parseAssertionFormat(ex)) {
-                  format = *f;
-                  return success();
-                }
-                return failure();
-              });
-            });
-          }))
-        return failure();
-    }
-
-    // Build the verification op itself.
-    Operation *op;
-    // TODO: The "ifElseFatal" variant isn't actually a concurrent assertion,
-    // but downstream logic assumes that isConcurrent is set.
-    if (flavor == VerifFlavor::VerifLibAssert)
-      op = builder.create<AssertOp>(printOp.getClock(), predicate,
-                                    printOp.getCond(), message,
-                                    printOp.getSubstitutions(), label, true);
-    else if (flavor == VerifFlavor::VerifLibAssume)
-      op = builder.create<AssumeOp>(printOp.getClock(), predicate,
-                                    printOp.getCond(), message,
-                                    printOp.getSubstitutions(), label, true);
-    else // VerifFlavor::VerifLibCover
-      op = builder.create<CoverOp>(printOp.getClock(), predicate,
-                                   printOp.getCond(), message,
-                                   printOp.getSubstitutions(), label, true);
-    printOp.erase();
-
-    // Attach additional attributes extracted from the JSON object.
-    op->setAttr("guards", ArrayAttr::get(context, guards));
-    if (format)
-      op->setAttr("format", StringAttr::get(context, *format));
-
-    break;
-  }
-  }
-
-  // Clean up the `WhenOp` if it has become completely empty.
-  if (thenBlock.empty())
-    whenStmt.erase();
   return true;
 }

--- a/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-asserts.fir
@@ -1,10 +1,10 @@
-; RUN: firtool --verify-diagnostics --verilog %s --lowering-options=emittedLineLength=200 --add-companion-assume | FileCheck %s
-; RUN: firtool --verify-diagnostics --verilog --verification-flavor=sva %s --lowering-options=emittedLineLength=200 --add-companion-assume | FileCheck %s --check-prefix=SVA
+; RUN: circt-translate -import-firrtl -verify-diagnostics %s
+
 ; Tests extracted from:
 ; - test/scala/firrtl/extractverif/ExtractAssertsSpec.scala
 
 circuit Foo:
-  ; expected-warning @below {{module contains 10 printf-encoded verification operation(s), which are deprecated and will be removed in the future}}
+  ; expected-error @below {{module contains 10 printf-encoded verification operation(s), which are no longer supported.}}
   ; expected-note @below {{For more information, see https://github.com/llvm/circt/issues/6970}}
   module Foo:
     input clock : Clock
@@ -23,151 +23,56 @@ circuit Foo:
     input other : UInt<1>
     input sum : UInt<42>
 
-    ; CHECK:      wire [[GEN:.+]] = predicate1 | reset;
-    ; CHECK-NEXT: wire [[GEN_0:.+]] = predicate2 | reset;
-    ; CHECK-NEXT: wire [[GEN_1:.+]] = predicate3 | reset;
-    ; CHECK-NEXT: wire [[GEN_2:.+]] = other & enable;
-    ; CHECK-NEXT: wire [[GEN_3:.+]] = predicate4 | reset;
 
-    ; CHECK: `ifndef SYNTHESIS
-    ; CHECK-NEXT: always @(posedge clock) begin
     ; assert with predicate only
-    ; CHECK-NEXT: if (enable & ~[[GEN]]) begin
-    ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
-    ; CHECK-NEXT:     $error("Assertion failed (verification library): ");
-    ; CHECK-NEXT:   if (`STOP_COND_)
-    ; CHECK-NEXT:     $fatal;
-    ; CHECK-NEXT: end
 
-    ; SVA: wire _GEN = ~enable | predicate1 | reset;
-    ; SVA-NEXT: assert__verif_library: assert property (@(posedge clock) _GEN) else $error("Assertion failed (verification library): ");
-    ; expected-note @+2 {{example printf here, will just be a printf in the future}}
+    ; expected-note @+2 {{example printf here, this is now just a printf and nothing more}}
     when not(or(predicate1, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"ifElseFatal\"},\"baseMsg\":\"Assertion failed (verification library): \"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
     ; assert with message
-    ; CHECK-NEXT: if (enable & ~[[GEN_0]]) begin
-    ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
-    ; CHECK-NEXT:     $error("Assertion failed (verification library): sum =/= 1.U");
-    ; CHECK-NEXT:   if (`STOP_COND_)
-    ; CHECK-NEXT:     $fatal;
-    ; CHECK-NEXT: end
     when not(or(predicate2, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"ifElseFatal\"},\"baseMsg\":\"Assertion failed (verification library): sum =/= 1.U\"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
     ; assert with when
-    ; CHECK-NEXT: if ([[GEN_2]] & ~[[GEN_1]]) begin
-    ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
-    ; CHECK-NEXT:     $error("Assertion failed (verification library): Assert with when");
-    ; CHECK-NEXT:   if (`STOP_COND_)
-    ; CHECK-NEXT:     $fatal;
-    ; CHECK-NEXT: end
     when other :
       when not(or(predicate3, asUInt(reset))) :
         printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"ifElseFatal\"},\"baseMsg\":\"Assertion failed (verification library): Assert with when\"}</extraction-summary> bar")
         stop(clock, enable, 1)
 
     ; assert with message with arguments
-    ; CHECK-NEXT: if (enable & ~[[GEN_3]]) begin
-    ; CHECK-NEXT:   if (`ASSERT_VERBOSE_COND_)
-    ; CHECK-NEXT:     $error("Assertion failed (verification library): expected sum === 2.U but got %d", sum);
-    ; CHECK-NEXT:   if (`STOP_COND_)
-    ; CHECK-NEXT:     $fatal;
-    ; CHECK-NEXT: end
     when not(or(predicate4, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"ifElseFatal\"},\"baseMsg\":\"Assertion failed (verification library): expected sum === 2.U but got %d\"}</extraction-summary> bar", sum)
       stop(clock, enable, 1)
 
-    ; CHECK-NEXT: end
-    ; CHECK-NEXT: `endif
-
-
     ; assert emitted as SVA
-    ; CHECK: wire [[GEN_4:.+]] = ~enable | predicate5 | reset;
-    ; CHECK-NEXT: assert__verif_library: assert property (@(posedge clock) [[GEN_4]])
-    ; CHECK-SAME:   else $error("Assertion failed (verification library): SVA assert example, sum was %d", $sampled(sum));
     when not(or(predicate5, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): SVA assert example, sum was %d\"}</extraction-summary> bar", sum)
       stop(clock, enable, 1)
 
     ; assert with custom label
-    ; CHECK: wire [[GEN_5:.+]] = ~enable | predicate6 | reset;
-    ; CHECK-NEXT: assert__verif_library_hello_world: assert property (@(posedge clock) [[GEN_5]])
-    ; CHECK-SAME:   else $error("Assertion failed (verification library): Custom label example");
     when not(or(predicate6, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"format\":{\"type\":\"sva\"},\"labelExts\":[\"hello\",\"world\"],\"baseMsg\":\"Assertion failed (verification library): Custom label example\"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
     ; assert with predicate option for X-passing
-    ; CHECK-NEXT: wire [[GEN_6:.+]] = ~enable | predicate7 | predicate7 === 1'bx;
-    ; CHECK-NEXT: assert__verif_library_0: assert property (@(posedge clock) [[GEN_6]])
-    ; CHECK-SAME:   else $error("Assertion failed (verification library): X-passing assert example");
     when not(predicate7) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): X-passing assert example\"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
-    ; CHECK-NEXT: wire [[GEN_7:.+]] = ~enable | predicate8 | reset;
-    ; CHECK-NEXT: wire [[GEN_8:.+]] = predicate9 | reset;
     ; assert with toggle option e.g. UNROnly
-    ; CHECK-NEXT: `ifdef USE_UNR_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:   assert__verif_library_1: assert property (@(posedge clock) [[GEN_7]])
-    ; CHECK-SAME:     else $error("Assertion failed (verification library): Conditional compilation example for UNR-only assert");
     when not(or(predicate8, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"}],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): Conditional compilation example for UNR-only assert\"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
     ; if-else-fatal style assert with conditional compilation toggles
-    ; CHECK-NEXT:  `ifndef SYNTHESIS
-    ; CHECK-NEXT:    always @(posedge clock) begin
-    ; CHECK-NEXT:     if (enable & ~[[GEN_8]]) begin
-    ; CHECK-NEXT:       if (`ASSERT_VERBOSE_COND_)
-    ; CHECK-NEXT:         $error("Assertion failed (verification library): Conditional compilation example with if-else-fatal style assert");
-    ; CHECK-NEXT:       if (`STOP_COND_)
-    ; CHECK-NEXT:         $fatal;
-    ; CHECK-NEXT:     end
-    ; CHECK-NEXT:    end
-    ; CHECK-NEXT:  `endif
-    ; CHECK-NEXT: `endif
     when not(or(predicate9, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"}],\"format\":{\"type\":\"ifElseFatal\"},\"baseMsg\":\"Assertion failed (verification library): Conditional compilation example with if-else-fatal style assert\"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
     ; assert with multiple toggle options
-    ; CHECK-NEXT:  wire [[GEN_9:.+]] = predicate10 | reset;
-    ; CHECK-NEXT: `ifdef USE_FORMAL_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:   `ifdef USE_UNR_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:     assert__verif_library_2: 
-    ; CHECK-NEXT:       assert property (@(posedge clock) ~enable | [[GEN_9]])
-    ; CHECK-SAME:       else $error("Assertion failed (verification library): Conditional compilation example for UNR-only and formal-only assert");
-    ; CHECK-NEXT:   `endif
-    ; CHECK-NEXT: `endif
     when not(or(predicate10, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"formalOnly\"},{\"type\":\"unrOnly\"}],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Assertion failed (verification library): Conditional compilation example for UNR-only and formal-only assert\"}</extraction-summary> bar")
       stop(clock, enable, 1)
-
-    ; The companion assumes get bunched up in an ifdef block.
-    ; CHECK-NEXT: `ifdef USE_PROPERTY_AS_CONSTRAINT
-    ; CHECK-NEXT:   assume__verif_library: assume property (@(posedge clock) ~enable | [[GEN]]);
-    ; CHECK-NEXT:   assume__verif_library_0: assume property (@(posedge clock) ~enable | [[GEN_0]]);
-    ; CHECK-NEXT:   assume__verif_library_1: assume property (@(posedge clock) ~[[GEN_2]] | [[GEN_1]]);
-    ; CHECK-NEXT:   assume__verif_library_2: assume property (@(posedge clock) ~enable | [[GEN_3]]);
-    ; CHECK-NEXT:   assume__verif_library_3: assume property (@(posedge clock) [[GEN_4]]);
-    ; CHECK-NEXT:   assume__verif_library_hello_world: assume property (@(posedge clock) [[GEN_5]]);
-    ; CHECK-NEXT:   assume__verif_library_4: assume property (@(posedge clock) [[GEN_6]]);
-    ; CHECK-NEXT:   `ifdef USE_UNR_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:   wire [[GEN_10:.+]] = ~enable | [[GEN_8]];
-    ; CHECK-NEXT:   always @(edge [[GEN_7]])
-    ; CHECK-NEXT:     assume__verif_library_5: assume([[GEN_7]]);
-    ; CHECK-NEXT:   always @(edge [[GEN_10]])
-    ; CHECK-NEXT:     assume__verif_library_6: assume([[GEN_10]]);
-    ; CHECK-NEXT:   `endif // USE_UNR_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:   `ifdef USE_FORMAL_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:     `ifdef USE_UNR_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:       wire [[GEN_11:.+]] = ~enable | [[GEN_9]];
-    ; CHECK-NEXT:       always @(edge [[GEN_11]])
-    ; CHECK-NEXT:         assume__verif_library_7: assume([[GEN_11]]);
-    ; CHECK-NEXT:     `endif // USE_UNR_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:   `endif // USE_FORMAL_ONLY_CONSTRAINTS
-    ; CHECK-NEXT: `endif

--- a/test/Dialect/FIRRTL/SFCTests/complex-assumes.fir
+++ b/test/Dialect/FIRRTL/SFCTests/complex-assumes.fir
@@ -1,9 +1,9 @@
-; RUN: firtool --verify-diagnostics --verilog %s --lowering-options=emittedLineLength=500 | FileCheck %s
+; RUN: circt-translate -import-firrtl -verify-diagnostics %s
 ; Tests extracted from:
 ; - test/scala/firrtl/extractverif/ExtractAssumesSpec.scala
 
 circuit Foo:
-  ; expected-warning @below {{module contains 8 printf-encoded verification operation(s), which are deprecated and will be removed in the future}}
+  ; expected-error @below {{module contains 8 printf-encoded verification operation(s), which are no longer supported.}}
   ; expected-note @below {{For more information, see https://github.com/llvm/circt/issues/6970}}
   module Foo:
     input clock : Clock
@@ -21,65 +21,43 @@ circuit Foo:
     input sum : UInt<42>
 
     ; assume with predicate only
-    ; CHECK: {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate1 | reset)
-    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): ");
-    ; expected-note @+2 {{example printf here, will just be a printf in the future}}
+    ; expected-note @+2 {{example printf here, this is now just a printf and nothing more}}
     when not(or(predicate1, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"baseMsg\":\"Assumption does not hold (verification library): \"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
     ; assume with message
-    ; CHECK-NEXT: {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate2 | reset)
-    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): sum =/= 1.U");
     when not(or(predicate2, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"baseMsg\":\"Assumption does not hold (verification library): sum =/= 1.U\"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
     ; assume with when
-    ; CHECK-NEXT: {{assume__verif_library.*}}: assume property (@(posedge clock) ~(other & enable) | predicate3 | reset)
-    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): assume with when");
     when other :
       when not(or(predicate3, asUInt(reset))) :
         printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"baseMsg\":\"Assumption does not hold (verification library): assume with when\"}</extraction-summary> bar")
         stop(clock, enable, 1)
 
     ; assume with message with arguments
-    ; CHECK-NEXT: {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate4 | reset)
-    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): expected sum === 2.U but got %d", $sampled(sum));
     when not(or(predicate4, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"baseMsg\":\"Assumption does not hold (verification library): expected sum === 2.U but got %d\"}</extraction-summary> bar", sum)
       stop(clock, enable, 1)
 
     ; assume with custom label
-    ; CHECK-NEXT: assume__verif_library_hello_world: assume property (@(posedge clock) ~enable | predicate5 | reset)
-    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): Custom label example");
     when not(or(predicate5, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"labelExts\":[\"hello\",\"world\"],\"baseMsg\":\"Assumption does not hold (verification library): Custom label example\"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
     ; assume with predicate option for X-passing
-    ; CHECK-NEXT: {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate6 | predicate6 === 1'bx)
-    ; CHECK-SAME:   else $error("Assumption does not hold (verification library): X-passing assume example");
     when not(predicate6) :
       printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"baseMsg\":\"Assumption does not hold (verification library): X-passing assume example\"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
     ; assume with toggle option e.g. UNROnly
-    ; CHECK-NEXT: `ifdef USE_UNR_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:   {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate7 | reset)
-    ; CHECK-SAME:     else $error("Assumption does not hold (verification library): Conditional compilation example for UNR-only assume");
-    ; CHECK-NEXT: `endif
     when not(or(predicate7, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"}],\"baseMsg\":\"Assumption does not hold (verification library): Conditional compilation example for UNR-only assume\"}</extraction-summary> bar")
       stop(clock, enable, 1)
 
     ; assume with multiple toggle options
-    ; CHECK-NEXT: `ifdef USE_FORMAL_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:   `ifdef USE_UNR_ONLY_CONSTRAINTS
-    ; CHECK-NEXT:     {{assume__verif_library.*}}: assume property (@(posedge clock) ~enable | predicate8 | reset)
-    ; CHECK-SAME:       else $error("Assumption does not hold (verification library): Conditional compilation example for UNR-only and formal-only assume");
-    ; CHECK-NEXT:   `endif
-    ; CHECK-NEXT: `endif
     when not(or(predicate8, asUInt(reset))) :
       printf(clock, enable, "foo [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"formalOnly\"},{\"type\":\"unrOnly\"}],\"baseMsg\":\"Assumption does not hold (verification library): Conditional compilation example for UNR-only and formal-only assume\"}</extraction-summary> bar")
       stop(clock, enable, 1)

--- a/test/Dialect/FIRRTL/when-encoded-verif.fir
+++ b/test/Dialect/FIRRTL/when-encoded-verif.fir
@@ -1,7 +1,6 @@
-; RUN: circt-translate -import-firrtl -verify-diagnostics -split-input-file %s | circt-opt | FileCheck %s
+; RUN: circt-translate -import-firrtl -verify-diagnostics %s
 circuit WhenEncodedVerification:
-  ; CHECK-LABEL: @WhenEncodedVerification
-  ; expected-warning @below {{module contains 23 printf-encoded verification operation(s), which are deprecated and will be removed in the future}}
+  ; expected-error @below {{module contains 23 printf-encoded verification operation(s), which are no longer supported.}}
   ; expected-note @below {{For more information, see https://github.com/llvm/circt/issues/6970}}
   module WhenEncodedVerification:
     input clock: Clock
@@ -10,92 +9,56 @@ circuit WhenEncodedVerification:
     input not_reset: UInt<1>
     input value: UInt<42>
 
-    ; expected-note @+3 {{example printf here, will just be a printf in the future}}
+    ; expected-note @+3 {{example printf here, this is now just a printf and nothing more}}
     ; rocket-chip properties
     when cond:
       printf(clock, enable, "assert:foo 0", value)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true}
 
     when cond:
       printf(clock, enable, "assume:foo 1", value)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "foo 1" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true}
 
     when cond:
       printf(clock, enable, "cover:foo 2", value)
-    ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "foo 2" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true}
 
     when cond:
       printf(clock, enable, "assert:foo_0:", value)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "foo_0"}
 
     when cond:
       printf(clock, enable, "assume:foo_1:", value)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "foo_1"}
 
     when cond:
       printf(clock, enable, "cover:foo_2:", value)
-    ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "foo_2"}
 
     when cond:
       printf(clock, enable, "assert:custom label 0:foo 3", value)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "foo 3" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "custom label 0"}
 
     when cond:
       printf(clock, enable, "assume:custom label 1:foo 4", value)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "foo 4" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "custom label 1"}
 
     when cond:
       printf(clock, enable, "cover:custom label 2:foo 5", value)
-    ; CHECK-NEXT: firrtl.cover %clock, %cond, %enable, "foo 5" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true, name = "custom label 2"}
 
     ; Optional `stop` with same clock and condition should be removed.
     when cond:
       printf(clock, enable, "assert:without_stop")
       stop(clock, enable, 1)
-    ; CHECK: firrtl.assert %clock, {{%.+}}, %enable, "without_stop" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
-    ; CHECK-NOT: firrtl.stop
 
     when cond:
-      ; expected-warning @+1 {{printf-encoded assertion has format string arguments which may cause lint warnings}}
       printf(clock, enable, "assert:foo 6, %d", value, value)
-    ; CHECK: firrtl.assert {{.+}} "foo 6, %d"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
 
     ; AssertNotX -- usually `cond` only checks for not-in-reset, and `enable` is
     ; just set to 1; the actual check `^value !== 'x` is implicit.
     when cond:
       printf(clock, enable, "assertNotX:%d:value must not be X!", value)
-    ; CHECK: [[TMP1:%.+]] = firrtl.not %cond
-    ; CHECK: [[TMP2:%.+]] = firrtl.xorr %value
-    ; CHECK: [[TMP3:%.+]] = firrtl.int.isX
-    ; CHECK: [[TMP4:%.+]] = firrtl.not
-    ; CHECK: [[TMP5:%.+]] = firrtl.or [[TMP1]], [[TMP4]]
-    ; CHECK: firrtl.assert %clock, [[TMP5]], %enable, "value must not be X!" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
-    ; CHECK-SAME: name = "notX"
 
     ; Chisel built-in assertions
     when cond:
       printf(clock, enable, "Assertion failed with value %d", value)
       stop(clock, enable, 1)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed with value %d"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
-    ; CHECK-SAME: format = "ifElseFatal"
-    ; CHECK-SAME: isConcurrent = true
-    ; CHECK-SAME: name = "chisel3_builtin"
 
     when cond:
       printf(clock, enable, "Assertion failed: some message with value %d", value)
       stop(clock, enable, 1)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: some message with value %d"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
-    ; CHECK-SAME: format = "ifElseFatal"
-    ; CHECK-SAME: isConcurrent = true
-    ; CHECK-SAME: name = "chisel3_builtin"
 
     ; Verification Library Assertions
 
@@ -103,24 +66,11 @@ circuit WhenEncodedVerification:
     when cond:
       printf(clock, enable, "Assertion failed: [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"magic\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Hello Assert\"}", value)
       stop(clock, enable, 1)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
-    ; CHECK-SAME: format = "sva"
-    ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
-    ; CHECK-SAME: name = "verif_library_label_magic"
 
     ; Predicate modifier `trueOrIsX`
     when cond:
       printf(clock, enable, "Assertion failed: [verif-library-assert]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"magic\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"Hello Assert\"}", value)
       stop(clock, enable, 1)
-    ; CHECK: [[CONDINV:%.+]] = firrtl.not %cond
-    ; CHECK: [[TMP1:%.+]] = firrtl.xorr [[CONDINV]]
-    ; CHECK-NEXT: [[TMP2:%.+]] = firrtl.int.isX [[TMP1]]
-    ; CHECK-NEXT: [[TMP:%.+]] = firrtl.or [[CONDINV]], [[TMP2]]
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Hello Assert"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
-    ; CHECK-SAME: format = "sva"
-    ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
-    ; CHECK-SAME: name = "verif_library_label_magic"
 
     ; Verification Library Assumptions
 
@@ -128,46 +78,23 @@ circuit WhenEncodedVerification:
     when cond:
       printf(clock, enable, "Assumption failed: [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"voodoo\"],\"baseMsg\":\"Hello Assume\"}", value)
       stop(clock, enable, 1)
-    ; CHECK: [[TMP:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
-    ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
-    ; CHECK-SAME: name = "verif_library_label_voodoo"
 
     ; Predicate modifier `trueOrIsX`
     when cond:
       printf(clock, enable, "Assumption failed: [verif-library-assume]<extraction-summary>{\"predicateModifier\":{\"type\":\"trueOrIsX\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"label\",\"voodoo\"],\"baseMsg\":\"Hello Assume\"}", value)
       stop(clock, enable, 1)
-    ; CHECK: [[CONDINV:%.+]] = firrtl.not %cond
-    ; CHECK: [[TMP1:%.+]] = firrtl.xorr [[CONDINV]]
-    ; CHECK-NEXT: [[TMP2:%.+]] = firrtl.int.isX [[TMP1]]
-    ; CHECK-NEXT: [[TMP:%.+]] = firrtl.or [[CONDINV]], [[TMP2]]
-    ; CHECK-NEXT: firrtl.assume %clock, [[TMP]], %enable, "Hello Assume"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
-    ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
-    ; CHECK-SAME: name = "verif_library_label_voodoo"
 
     ; New flavor of when-encoded verification that also includes an assert
     assert(clock, cond, enable, "hello")
     node not_cond = eq(cond, UInt<1>(0))
     when not_cond:
       printf(clock, enable, "Assertion failed: hello")
-    ; CHECK-NOT: firrtl.assert %clock, %cond, %enable, "hello" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
-    ; CHECK: [[TMP:%.+]] = firrtl.not %not_cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: hello" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
-    ; CHECK-SAME: format = "ifElseFatal"
-    ; CHECK-SAME: name = "chisel3_builtin"
 
     when not_reset:
       assert(clock, cond, enable, "hello outside reset")
       node not_cond2 = eq(cond, UInt<1>(0))
       when not_cond2:
         printf(clock, enable, "Assertion failed: hello outside reset")
-    ; CHECK: firrtl.when %not_reset : !firrtl.uint<1> {
-    ; CHECK-NOT: firrtl.assert %clock, %cond, %enable, "hello outside reset" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
-    ; CHECK: [[TMP:%.+]] = firrtl.not %not_cond2
-    ; CHECK-NEXT: firrtl.assert %clock, [[TMP]], %enable, "Assertion failed: hello outside reset" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
-    ; CHECK-SAME: format = "ifElseFatal"
-    ; CHECK-SAME: name = "chisel3_builtin"
-    ; CHECK: }
 
     ; Check that the above doesn't error if the assert is a double user of the
     ; condition.
@@ -176,13 +103,9 @@ circuit WhenEncodedVerification:
       node not_cond3 = eq(UInt<1>(1), UInt<1>(0))
       when not_cond3:
         printf(clock, UInt<1>(1), "Assertion failed: double user assert")
-    ; CHECK-NOT: firrtl.assert %clock, {{.+}} "double user assert" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
 
     when cond :
         printf(clock, not(enable), "assert: bar")
-    ; CHECK: [[NOT_ENABLE:%.+]] = firrtl.not %enable
-    ; CHECK-NEXT: [[NOT_COND:%.+]] = firrtl.not %cond
-    ; CHECK-NEXT: firrtl.assert %clock, [[NOT_COND]], [[NOT_ENABLE]], " bar" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = true}
 
     ; Verification Library Covers
 
@@ -190,11 +113,3 @@ circuit WhenEncodedVerification:
     when not(cond):
       printf(clock, enable, "Assertion failed: [verif-library-cover]<extraction-summary>{\"predicateModifier\":{\"type\":\"noMod\"},\"conditionalCompileToggles\":[{\"type\":\"unrOnly\"},{\"type\":\"formalOnly\"}],\"labelExts\":[\"cover\",\"label\"],\"format\":{\"type\":\"sva\"},\"baseMsg\":\"cover hello world\"}", value)
     assert(clock, cond, enable, "")
-    ; CHECK: [[TMP_INV:%.+]] = firrtl.not %cond
-    ; CHECK: [[TMP:%.+]] = firrtl.not [[TMP_INV]]
-    ; CHECK-NOT: firrtl.assert %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
-    ; CHECK: firrtl.cover %clock, [[TMP]], %enable, "cover hello world"(%value) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<42>
-    ; CHECK-SAME: guards = ["USE_UNR_ONLY_CONSTRAINTS", "USE_FORMAL_ONLY_CONSTRAINTS"]
-    ; CHECK-SAME: name = "verif_library_cover_label"
-
-


### PR DESCRIPTION
Retain logic to recognize (but not parse or diagnose) printf's of the various "flavors" previously supported so that we can reject designs that rely on this removed support (emit error).

Similar to https://github.com/llvm/circt/pull/7010, but retains logic for recognizing these printf's so we can reject designs with their use instead of silently handling them "incorrectly".

Good parts of this inspired by suggestion on that PR: https://github.com/llvm/circt/pull/7010#discussion_r1595421600 .

This still breaks usage with even recent Chisel, but compared to 7010 informs the user they've used something that doesn't work anymore.