### PR TITLE
[ESI][Runtime] Remove C++ includes from wheels

### DIFF
--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -199,15 +199,15 @@ install(RUNTIME_DEPENDENCY_SET ESIRuntime_RUNTIME_DEPS
 )
 install(FILES ${ESIRuntimeHeaders}
   DESTINATION include/esi
-  COMPONENT ESIRuntime
+  COMPONENT ESIRuntime-dev
 )
 install(FILES ${ESIRuntimeBackendHeaders}
   DESTINATION include/esi/backends
-  COMPONENT ESIRuntime
+  COMPONENT ESIRuntime-dev
 )
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cpp/cmake/esiaccel.cmake
   DESTINATION cmake
-  COMPONENT ESIRuntime
+  COMPONENT ESIRuntime-dev
 )
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/lib/Dialect/ESI/runtime/python/esiaccel/utils.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/utils.py
@@ -24,8 +24,3 @@ def run_esi_cosim():
   cosim_import = importlib.util.module_from_spec(spec)
   spec.loader.exec_module(cosim_import)
   return cosim_import.__main__(sys.argv)
-
-
-def get_cpp_cmake() -> str:
-  """Return the path to the cmake file."""
-  return str(_thisdir / "cmake" / "esiaccel.cmake")


### PR DESCRIPTION
There is no good way to use the binaries included with the wheel. Essentially, they are built with the old `std::basic_string` but modern software uses `std::__cxx11::basic_string`. There is now way to change this behavior (AFAICT) in manylinux2014. Newer manylinux images have a way, but we need compatiblity back to glibc 2.17, which none of them provide.