### PR TITLE
[Moore] Move IntType definition into ODS

### DIFF
--- a/include/circt/Dialect/Moore/MooreTypes.h
+++ b/include/circt/Dialect/Moore/MooreTypes.h
@@ -127,7 +127,6 @@ class PackedType;
 
 namespace detail {
 struct RealTypeStorage;
-struct IntTypeStorage;
 struct DimStorage;
 struct UnsizedDimStorage;
 struct RangeDimStorage;
@@ -247,38 +246,6 @@ public:
 
 protected:
   using UnpackedType::UnpackedType;
-};
-
-//===----------------------------------------------------------------------===//
-// Packed Integers
-//===----------------------------------------------------------------------===//
-
-/// A signed or unsigned, two- or four-valued bit vector. SystemVerilog calls
-/// these "simple bit vectors".
-class IntType
-    : public Type::TypeBase<IntType, PackedType, detail::IntTypeStorage> {
-public:
-  /// Return the width of the integer.
-  unsigned getWidth() const;
-  /// Return whether this is a two- or four-valued integer.
-  Domain getDomain() const;
-
-  static IntType get(MLIRContext *context, unsigned width, Domain domain);
-
-  /// Create a signless `bit [width-1:0]` type.
-  static IntType getInt(MLIRContext *context, unsigned width) {
-    return get(context, width, Domain::TwoValued);
-  }
-
-  /// Create a signless `logic [width-1:0]` type.
-  static IntType getLogic(MLIRContext *context, unsigned width) {
-    return get(context, width, Domain::FourValued);
-  }
-
-  static constexpr StringLiteral name = "moore.int";
-
-protected:
-  using Base::Base;
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -53,6 +53,46 @@ def EventType : MooreTypeDef<"Event", [], "moore::UnpackedType"> {
 
 
 //===----------------------------------------------------------------------===//
+// Packed Types
+//===----------------------------------------------------------------------===//
+
+def IntType : MooreTypeDef<"Int", [], "moore::PackedType"> {
+  let typeName = "moore.int";
+  let summary = "a simple bit vector type";
+  let description = [{
+    The `!moore.iN` and `!moore.lN` types represent a two-valued or four-valued
+    simple bit vector of width `N`. The predefined SystemVerilog integer types
+    map to this as follows:
+
+    | Verilog    | Moore Dialect |
+    |------------|---------------|
+    | `bit`      | `!moore.i1`   |
+    | `logic`    | `!moore.l1`   |
+    | `reg`      | `!moore.l1`   |
+    | `byte`     | `!moore.i8`   |
+    | `shortint` | `!moore.i16`  |
+    | `int`      | `!moore.i32`  |
+    | `integer`  | `!moore.l32`  |
+    | `longint`  | `!moore.i64`  |
+    | `time`     | `!moore.l64`  |
+  }];
+  let parameters = (ins "unsigned":$width, "Domain":$domain);
+
+  let extraClassDeclaration = [{
+    /// Create a signless `bit [width-1:0]` type.
+    static IntType getInt(MLIRContext *context, unsigned width) {
+      return get(context, width, Domain::TwoValued);
+    }
+
+    /// Create a signless `logic [width-1:0]` type.
+    static IntType getLogic(MLIRContext *context, unsigned width) {
+      return get(context, width, Domain::FourValued);
+    }
+  }];
+}
+
+
+//===----------------------------------------------------------------------===//
 // Constraints
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Replace the C++ definition of `IntType` with a corresponding table-gen definition in `MooreTypes.td`.