### PR TITLE
[Moore] Simplify and move RealType definition into ODS

### DIFF
--- a/include/circt-c/Dialect/Moore.h
+++ b/include/circt-c/Dialect/Moore.h
@@ -25,15 +25,6 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Moore, moore);
 // Types
 //===----------------------------------------------------------------------===//
 
-enum MooreRealKind {
-  /// A `shortreal`.
-  MooreShortReal,
-  /// A `real`.
-  MooreReal,
-  /// A `realtime`.
-  MooreRealTime,
-};
-
 /// Create a void type.
 MLIR_CAPI_EXPORTED MlirType mooreVoidTypeGet(MlirContext ctx);
 /// Create a string type.
@@ -48,8 +39,7 @@ MLIR_CAPI_EXPORTED MlirType mooreIntTypeGetInt(MlirContext ctx, unsigned width);
 MLIR_CAPI_EXPORTED MlirType mooreIntTypeGetLogic(MlirContext ctx,
                                                  unsigned width);
 /// Create a real type.
-MLIR_CAPI_EXPORTED MlirType mooreRealTypeGet(MlirContext ctx,
-                                             enum MooreRealKind kind);
+MLIR_CAPI_EXPORTED MlirType mooreRealTypeGet(MlirContext ctx);
 /// Create a packed unsized dimension type.
 MLIR_CAPI_EXPORTED MlirType moorePackedUnsizedDimTypeGet(MlirType inner);
 /// Create a packed range dimension type.

--- a/include/circt/Dialect/Moore/MooreTypes.h
+++ b/include/circt/Dialect/Moore/MooreTypes.h
@@ -126,7 +126,6 @@ Os &operator<<(Os &os, const Range &range) {
 class PackedType;
 
 namespace detail {
-struct RealTypeStorage;
 struct DimStorage;
 struct UnsizedDimStorage;
 struct RangeDimStorage;
@@ -246,46 +245,6 @@ public:
 
 protected:
   using UnpackedType::UnpackedType;
-};
-
-//===----------------------------------------------------------------------===//
-// Unpacked Reals
-//===----------------------------------------------------------------------===//
-
-/// A real type.
-class RealType
-    : public Type::TypeBase<RealType, UnpackedType, detail::RealTypeStorage> {
-public:
-  enum Kind {
-    /// A `shortreal`.
-    ShortReal,
-    /// A `real`.
-    Real,
-    /// A `realtime`.
-    RealTime,
-  };
-
-  /// Get the integer type that corresponds to a keyword (like `bit`).
-  static std::optional<Kind> getKindFromKeyword(StringRef keyword);
-  /// Get the keyword (like `bit`) for one of the integer types.
-  static StringRef getKeyword(Kind kind);
-  /// Get the size of one of the integer types.
-  static unsigned getBitSize(Kind kind);
-
-  static RealType get(MLIRContext *context, Kind kind);
-
-  /// Get the concrete integer vector or atom type.
-  Kind getKind() const;
-
-  /// Get the keyword (like `bit`) for this type.
-  StringRef getKeyword() const { return getKeyword(getKind()); }
-  /// Get the size of this type.
-  unsigned getBitSize() const { return getBitSize(getKind()); }
-
-  static constexpr StringLiteral name = "moore.real";
-
-protected:
-  using Base::Base;
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -53,7 +53,7 @@ def EventType : MooreTypeDef<"Event", [], "moore::UnpackedType"> {
 
 
 //===----------------------------------------------------------------------===//
-// Packed Types
+// IntType
 //===----------------------------------------------------------------------===//
 
 def IntType : MooreTypeDef<"Int", [], "moore::PackedType"> {
@@ -88,6 +88,30 @@ def IntType : MooreTypeDef<"Int", [], "moore::PackedType"> {
     static IntType getLogic(MLIRContext *context, unsigned width) {
       return get(context, width, Domain::FourValued);
     }
+  }];
+}
+
+
+//===----------------------------------------------------------------------===//
+// RealType
+//===----------------------------------------------------------------------===//
+
+def RealType : MooreTypeDef<"Real", [], "moore::UnpackedType"> {
+  let mnemonic = "real";
+  let summary = "a SystemVerilog real type";
+  let description = [{
+    This type represents the SystemVerilog real type. Since the Moore dialect
+    does not fully handle real-valued expressions properly yet, we coalesce the
+    `shortreal`, `real`, and `realtime` types in the SystemVerilgo standard to
+    this common `!moore.real` type. The standard specifies these types to be of
+    at least 32, 64, and 64 bits, respectively. The `!moore.real` type is 64
+    bits wide.
+
+    | Verilog     | Moore Dialect |
+    |-------------|---------------|
+    | `shortreal` | `!moore.real` |
+    | `real`      | `!moore.real` |
+    | `realtime`  | `!moore.real` |
   }];
 }
 

--- a/lib/CAPI/Dialect/Moore.cpp
+++ b/lib/CAPI/Dialect/Moore.cpp
@@ -26,18 +26,6 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Moore, moore, MooreDialect)
 // Types
 //===----------------------------------------------------------------------===//
 
-static RealType::Kind convertMooreRealKind(enum MooreRealKind kind) {
-  switch (kind) {
-  case MooreRealKind::MooreShortReal:
-    return circt::moore::RealType::ShortReal;
-  case MooreRealKind::MooreReal:
-    return circt::moore::RealType::Real;
-  case MooreRealKind::MooreRealTime:
-    return circt::moore::RealType::RealTime;
-  }
-  llvm_unreachable("All cases should be covered.");
-}
-
 /// Create a void type.
 MlirType mooreVoidTypeGet(MlirContext ctx) {
   return wrap(VoidType::get(unwrap(ctx)));
@@ -69,8 +57,8 @@ MlirType mooreIntTypeGetLogic(MlirContext ctx, unsigned width) {
 }
 
 /// Create a real type.
-MlirType mooreRealTypeGet(MlirContext ctx, enum MooreRealKind kind) {
-  return wrap(RealType::get(unwrap(ctx), convertMooreRealKind(kind)));
+MlirType mooreRealTypeGet(MlirContext ctx) {
+  return wrap(RealType::get(unwrap(ctx)));
 }
 
 /// Create a packed unsized dimension type.

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -32,20 +32,7 @@ struct TypeVisitor {
   }
 
   Type visit(const slang::ast::FloatingType &type) {
-    moore::RealType::Kind kind;
-    switch (type.floatKind) {
-    case slang::ast::FloatingType::Real:
-      kind = moore::RealType::Real;
-      break;
-    case slang::ast::FloatingType::ShortReal:
-      kind = moore::RealType::ShortReal;
-      break;
-    case slang::ast::FloatingType::RealTime:
-      kind = moore::RealType::RealTime;
-      break;
-    }
-
-    return moore::RealType::get(context.getContext(), kind);
+    return moore::RealType::get(context.getContext());
   }
 
   Type visit(const slang::ast::PredefinedIntegerType &type) {

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -109,8 +109,8 @@ endmodule
 // CHECK-LABEL: moore.module @RealType
 module RealType;
   // CHECK-NEXT: %d0 = moore.variable : !moore.real
-  // CHECK-NEXT: %d1 = moore.variable : !moore.realtime
-  // CHECK-NEXT: %d2 = moore.variable : !moore.shortreal
+  // CHECK-NEXT: %d1 = moore.variable : !moore.real
+  // CHECK-NEXT: %d2 = moore.variable : !moore.real
   real d0;
   realtime d1;
   shortreal d2;

--- a/test/Dialect/Moore/types.mlir
+++ b/test/Dialect/Moore/types.mlir
@@ -22,12 +22,8 @@ func.func @IntTypes(
 
 // CHECK-LABEL: func @RealTypes(
 func.func @RealTypes(
-  // CHECK-SAME: %arg0: !moore.shortreal
-  // CHECK-SAME: %arg1: !moore.real
-  // CHECK-SAME: %arg2: !moore.realtime
-  %arg0: !moore.shortreal,
-  %arg1: !moore.real,
-  %arg2: !moore.realtime
+  // CHECK-SAME: %arg0: !moore.real
+  %arg0: !moore.real
 ) { return }
 
 // CHECK-LABEL: func @DimTypes(

--- a/unittests/Dialect/Moore/TypesTest.cpp
+++ b/unittests/Dialect/Moore/TypesTest.cpp
@@ -82,17 +82,9 @@ TEST(TypesTest, Reals) {
   MLIRContext context;
   context.loadDialect<MooreDialect>();
 
-  auto t0 = RealType::get(&context, RealType::ShortReal);
-  auto t1 = RealType::get(&context, RealType::Real);
-  auto t2 = RealType::get(&context, RealType::RealTime);
-
+  auto t0 = RealType::get(&context);
   ASSERT_EQ(t0.getDomain(), Domain::TwoValued);
-  ASSERT_EQ(t1.getDomain(), Domain::TwoValued);
-  ASSERT_EQ(t2.getDomain(), Domain::TwoValued);
-
-  ASSERT_EQ(t0.getBitSize(), 32u);
-  ASSERT_EQ(t1.getBitSize(), 64u);
-  ASSERT_EQ(t2.getBitSize(), 64u);
+  ASSERT_EQ(t0.getBitSize(), 64u);
 }
 
 TEST(TypesTest, PackedDim) {


### PR DESCRIPTION
Coalesce SystemVerilog's `shortreal`, `real`, and `realtime` types into a single `!moore.real` type understood to be 64 bits wide, and move the definition from C++ land into `MooreTypes.td`. Once ImportVerilog actually supports expressions on real values we may want to revisit this type and either replace it with the standard `f32` and `f64` types, or create dedicated types for `shortreal`, `real`, and `realtime`.