### PR TITLE
[HW][LTL][SV] Unify EventControl

### DIFF
--- a/include/circt/Dialect/LTL/CMakeLists.txt
+++ b/include/circt/Dialect/LTL/CMakeLists.txt
@@ -3,11 +3,6 @@ add_circt_doc(LTLOps Dialects/LTLOps -gen-op-doc)
 add_circt_doc(LTLTypes Dialects/LTLTypes -gen-typedef-doc -dialect ltl)
 
 set(LLVM_TARGET_DEFINITIONS LTL.td)
-mlir_tablegen(LTLEnums.h.inc -gen-enum-decls)
-mlir_tablegen(LTLEnums.cpp.inc -gen-enum-defs)
-add_public_tablegen_target(CIRCTLTLEnumsIncGen)
-add_dependencies(circt-headers CIRCTLTLEnumsIncGen)
-
 mlir_tablegen(LTLFolds.cpp.inc -gen-rewriters)
 add_public_tablegen_target(CIRCTLTLFoldsIncGen)
 add_dependencies(circt-headers CIRCTLTLFoldsIncGen)

--- a/include/circt/Dialect/LTL/LTLDialect.h
+++ b/include/circt/Dialect/LTL/LTLDialect.h
@@ -9,11 +9,11 @@
 #ifndef CIRCT_DIALECT_LTL_LTLDIALECT_H
 #define CIRCT_DIALECT_LTL_LTLDIALECT_H
 
+#include "circt/Dialect/HW/HWEnums.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"
 
 #include "circt/Dialect/LTL/LTLDialect.h.inc"
-#include "circt/Dialect/LTL/LTLEnums.h.inc"
 
 #endif // CIRCT_DIALECT_LTL_LTLDIALECT_H

--- a/include/circt/Dialect/LTL/LTLOps.td
+++ b/include/circt/Dialect/LTL/LTLOps.td
@@ -11,6 +11,7 @@
 
 include "circt/Dialect/LTL/LTLDialect.td"
 include "circt/Dialect/LTL/LTLTypes.td"
+include "circt/Dialect/HW/HWEnums.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/PatternBase.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -211,24 +212,12 @@ def EventuallyOp : LTLOp<"eventually", [Pure]> {
 // Clocking
 //===----------------------------------------------------------------------===//
 
-// Edge behavior enum for always block.  See SV Spec 9.4.2.
-
-/// AtPosEdge triggers on a rise from 0 to 1/X/Z, or X/Z to 1.
-def AtPosEdge: I32EnumAttrCase<"Pos", 0, "posedge">;
-/// AtNegEdge triggers on a drop from 1 to 0/X/Z, or X/Z to 0.
-def AtNegEdge: I32EnumAttrCase<"Neg", 1, "negedge">;
-/// AtEdge is syntactic sugar for AtPosEdge or AtNegEdge.
-def AtEdge   : I32EnumAttrCase<"Both", 2, "edge">;
-
-def ClockEdgeAttr : I32EnumAttr<"ClockEdge", "clock edge",
-                                [AtPosEdge, AtNegEdge, AtEdge]> {
-  let cppNamespace = "circt::ltl";
-}
-
 def ClockOp : LTLOp<"clock", [
   Pure, InferTypeOpInterface, DeclareOpInterfaceMethods<InferTypeOpInterface>
 ]> {
-  let arguments = (ins LTLAnyPropertyType:$input, ClockEdgeAttr:$edge, I1:$clock);
+  let arguments = (ins LTLAnyPropertyType:$input,
+                       EventControlAttr:$edge,
+                       I1:$clock);
   let results = (outs LTLSequenceOrPropertyType:$result);
   let assemblyFormat = [{
     $input `,` $edge $clock attr-dict `:` type($input)

--- a/include/circt/Dialect/SV/CMakeLists.txt
+++ b/include/circt/Dialect/SV/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_circt_dialect(SV sv)
 add_circt_dialect_doc(SV sv)
 
-set(LLVM_TARGET_DEFINITIONS SV.td)
-
+set(LLVM_TARGET_DEFINITIONS SVEnums.td)
 mlir_tablegen(SVEnums.h.inc -gen-enum-decls)
 mlir_tablegen(SVEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(MLIRSVEnumsIncGen)
 add_dependencies(circt-headers MLIRSVEnumsIncGen)
 
+set(LLVM_TARGET_DEFINITIONS SV.td)
 mlir_tablegen(SVAttributes.h.inc -gen-attrdef-decls --attrdefs-dialect=sv)
 mlir_tablegen(SVAttributes.cpp.inc -gen-attrdef-defs --attrdefs-dialect=sv)
 add_public_tablegen_target(MLIRSVAttributesIncGen)

--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -44,6 +44,7 @@ def VendorExtension : NativeOpTrait<"VendorExtension"> {
 
 include "circt/Dialect/HW/HWTypes.td"
 include "circt/Dialect/HW/HWAttributesNaming.td"
+include "circt/Dialect/SV/SVEnums.td"
 include "circt/Dialect/SV/SVAttributes.td"
 include "circt/Dialect/SV/SVTypes.td"
 include "circt/Dialect/SV/SVExpressions.td"

--- a/include/circt/Dialect/SV/SVEnums.td
+++ b/include/circt/Dialect/SV/SVEnums.td
@@ -1,0 +1,80 @@
+//===- SVEnums.td - Enums for SV dialect -------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines SV dialect specific enums.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SV_SVENUM_TD
+#define CIRCT_DIALECT_SV_SVENUM_TD
+
+include "mlir/IR/EnumAttr.td"
+
+let cppNamespace = "circt::sv" in {
+
+def NoReset: I32EnumAttrCase<"NoReset", 0, "noreset">;
+def SyncReset: I32EnumAttrCase<"SyncReset", 1, "syncreset">;
+def AsyncReset: I32EnumAttrCase<"AsyncReset", 2, "asyncreset">;
+
+def ResetTypeAttr : I32EnumAttr<"ResetType", "reset type",
+                                   [NoReset, SyncReset, AsyncReset]>;
+
+}
+
+def CaseStmt: I32EnumAttrCase<"CaseStmt", 0, "case">;
+def CaseXStmt: I32EnumAttrCase<"CaseXStmt", 1, "casex">;
+def CaseZStmt: I32EnumAttrCase<"CaseZStmt", 2, "casez">;
+
+def CaseStmtTypeAttr : I32EnumAttr<"CaseStmtType", "case type",
+                                   [CaseStmt, CaseXStmt, CaseZStmt]>;
+
+def ValidationQualifierPlain: I32EnumAttrCase<"ValidationQualifierPlain", 0, "plain">;
+def ValidationQualifierUnique: I32EnumAttrCase<"ValidationQualifierUnique", 1, "unique">;
+def ValidationQualifierUnique0: I32EnumAttrCase<"ValidationQualifierUnique0", 2, "unique0">;
+def ValidationQualifierPriority: I32EnumAttrCase<"ValidationQualifierPriority", 3, "priority">;
+
+def ValidationQualifierTypeEnum: I32EnumAttr<"ValidationQualifierTypeEnum", "validation qualifier type",
+              [ValidationQualifierPlain, ValidationQualifierUnique,
+               ValidationQualifierUnique0, ValidationQualifierPriority]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::circt::sv";
+}
+
+def MemBaseBin: I32EnumAttrCase<"MemBaseBin", 0>;
+def MemBaseHex: I32EnumAttrCase<"MemBaseHex", 1>;
+def MemBaseTypeAttr :
+    I32EnumAttr<"MemBaseTypeAttr", "the numeric base of a memory file",
+                [MemBaseBin, MemBaseHex]>;
+
+def ModportDirectionInput : I32EnumAttrCase<"input", 0>;
+def ModportDirectionOutput : I32EnumAttrCase<"output", 1>;
+def ModportDirectionInOut : I32EnumAttrCase<"inout", 2>;
+
+def ModportDirection : I32EnumAttr<"ModportDirection",
+  "Defines direction in a modport",
+  [ModportDirectionInput, ModportDirectionOutput, ModportDirectionInOut]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::circt::sv";
+}
+
+/// Immediate assertions, like `assert`.
+def ImmediateAssert: I32EnumAttrCase<"Immediate", 0, "immediate">;
+/// Observed deferred assertions, like `assert #0`.
+def ObservedAssert: I32EnumAttrCase<"Observed", 1, "observed">;
+/// Final deferred assertions, like `assert final`.
+def FinalAssert: I32EnumAttrCase<"Final", 2, "final">;
+
+/// A mode specifying how immediate/deferred assertions operate.
+def DeferAssertAttr : I32EnumAttr<
+  "DeferAssert", "assertion deferring mode",
+  [ImmediateAssert, ObservedAssert, FinalAssert]>
+{
+  let cppNamespace = "circt::sv";
+}
+
+#endif // CIRCT_DIALECT_SV_SVENUM_TD

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
+include "circt/Dialect/HW/HWEnums.td"
 
 //===----------------------------------------------------------------------===//
 // Control flow like-operations
@@ -186,21 +186,6 @@ def IfOp : SVOp<"if", [SingleBlock, NoTerminator, NoRegionArguments,
   }];
 }
 
-// Edge behavior enum for always block.  See SV Spec 9.4.2.
-
-/// AtPosEdge triggers on a rise from 0 to 1/X/Z, or X/Z to 1.
-def AtPosEdge: I32EnumAttrCase<"AtPosEdge", 0, "posedge">;
-/// AtNegEdge triggers on a drop from 1 to 0/X/Z, or X/Z to 0.
-def AtNegEdge: I32EnumAttrCase<"AtNegEdge", 1, "negedge">;
-/// AtEdge(v) is syntactic sugar for "AtPosEdge(v) or AtNegEdge(v)".
-def AtEdge   : I32EnumAttrCase<"AtEdge", 2, "edge">;
-
-def EventControlAttr : I32EnumAttr<"EventControl", "edge control trigger",
-                                   [AtPosEdge, AtNegEdge, AtEdge]> {
-  let cppNamespace = "circt::sv";
-}
-
-
 def AlwaysOp : SVOp<"always", [SingleBlock, NoTerminator, NoRegionArguments,
                                RecursiveMemoryEffects, RecursivelySpeculatable,
                                ProceduralRegion, NonProceduralOp]> {
@@ -216,7 +201,7 @@ def AlwaysOp : SVOp<"always", [SingleBlock, NoTerminator, NoRegionArguments,
 
   let skipDefaultBuilders = 1;
   let builders = [
-    OpBuilder<(ins "ArrayRef<EventControl>":$event, "ArrayRef<Value>":$cond,
+    OpBuilder<(ins "ArrayRef<hw::EventControl>":$event, "ArrayRef<Value>":$cond,
                       CArg<"std::function<void()>", "{}">:$bodyCtor)>
   ];
 
@@ -224,7 +209,7 @@ def AlwaysOp : SVOp<"always", [SingleBlock, NoTerminator, NoRegionArguments,
     Block *getBodyBlock() { return &getBody().front(); }
 
     struct Condition {
-      EventControl event;
+      hw::EventControl event;
       Value value;
     };
 
@@ -260,13 +245,6 @@ def AlwaysCombOp : SVOp<"alwayscomb", [SingleBlock, NoTerminator,
   }];
 }
 
-def NoReset: I32EnumAttrCase<"NoReset", 0, "noreset">;
-def SyncReset: I32EnumAttrCase<"SyncReset", 1, "syncreset">;
-def AsyncReset: I32EnumAttrCase<"AsyncReset", 2, "asyncreset">;
-
-def ResetTypeAttr : I32EnumAttr<"ResetType", "reset type",
-                                   [NoReset, SyncReset, AsyncReset]>;
-
 
 def AlwaysFFOp : SVOp<"alwaysff", [SingleBlock, NoTerminator, NoRegionArguments,
                                    RecursiveMemoryEffects, RecursivelySpeculatable,
@@ -297,11 +275,11 @@ def AlwaysFFOp : SVOp<"alwaysff", [SingleBlock, NoTerminator, NoRegionArguments,
 
   let skipDefaultBuilders = 1;
   let builders = [
-    OpBuilder<(ins "EventControl":$clockEdge, "Value":$clock,
+    OpBuilder<(ins "hw::EventControl":$clockEdge, "Value":$clock,
                       CArg<"std::function<void()>", "{}">:$bodyCtor)>,
-    OpBuilder<(ins "EventControl":$clockEdge, "Value":$clock,
+    OpBuilder<(ins "hw::EventControl":$clockEdge, "Value":$clock,
                       "ResetType":$resetStyle,
-                      "EventControl":$resetEdge, "Value":$reset,
+                      "hw::EventControl":$resetEdge, "Value":$reset,
                       CArg<"std::function<void()>", "{}">:$bodyCtor,
                       CArg<"std::function<void()>", "{}">:$resetCtor)>
   ];
@@ -336,25 +314,6 @@ def InitialOp : SVOp<"initial", [SingleBlock, NoTerminator, NoRegionArguments,
   let extraClassDeclaration = [{
     Block *getBodyBlock() { return &getBody().front(); }
   }];
-}
-
-def CaseStmt: I32EnumAttrCase<"CaseStmt", 0, "case">;
-def CaseXStmt: I32EnumAttrCase<"CaseXStmt", 1, "casex">;
-def CaseZStmt: I32EnumAttrCase<"CaseZStmt", 2, "casez">;
-
-def CaseStmtTypeAttr : I32EnumAttr<"CaseStmtType", "case type",
-                                   [CaseStmt, CaseXStmt, CaseZStmt]>;
-
-def ValidationQualifierPlain: I32EnumAttrCase<"ValidationQualifierPlain", 0, "plain">;
-def ValidationQualifierUnique: I32EnumAttrCase<"ValidationQualifierUnique", 1, "unique">;
-def ValidationQualifierUnique0: I32EnumAttrCase<"ValidationQualifierUnique0", 2, "unique0">;
-def ValidationQualifierPriority: I32EnumAttrCase<"ValidationQualifierPriority", 3, "priority">;
-
-def ValidationQualifierTypeEnum: I32EnumAttr<"ValidationQualifierTypeEnum", "validation qualifier type",
-              [ValidationQualifierPlain, ValidationQualifierUnique,
-               ValidationQualifierUnique0, ValidationQualifierPriority]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::circt::sv";
 }
 
 def ValidationQualifierTypeAttr: EnumAttr<SVDialect, ValidationQualifierTypeEnum, "validation_qualifier">;
@@ -736,12 +695,6 @@ def DepositOp : SVOp<"nonstandard.deposit",
 //===----------------------------------------------------------------------===//
 // Memory loading system tasks
 //===----------------------------------------------------------------------===//
-
-def MemBaseBin: I32EnumAttrCase<"MemBaseBin", 0>;
-def MemBaseHex: I32EnumAttrCase<"MemBaseHex", 1>;
-def MemBaseTypeAttr :
-    I32EnumAttr<"MemBaseTypeAttr", "the numeric base of a memory file",
-                [MemBaseBin, MemBaseHex]>;
 
 def ReadMemOp : SVOp<"readmem", [ProceduralOp]> {
   let summary = "load a memory from a file in either binary or hex format";

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 include "circt/Dialect/HW/HWOpInterfaces.td"
-include "mlir/IR/EnumAttr.td"
 
 //===----------------------------------------------------------------------===//
 // Interface operations
@@ -108,17 +107,6 @@ def InterfaceSignalOp : SVOp<"interface.signal",
   let builders = [
     OpBuilder<(ins "::llvm::StringRef":$name, "::mlir::Type":$type)>
   ];
-}
-
-def ModportDirectionInput : I32EnumAttrCase<"input", 0>;
-def ModportDirectionOutput : I32EnumAttrCase<"output", 1>;
-def ModportDirectionInOut : I32EnumAttrCase<"inout", 2>;
-
-def ModportDirection : I32EnumAttr<"ModportDirection",
-  "Defines direction in a modport",
-  [ModportDirectionInput, ModportDirectionOutput, ModportDirectionInOut]> {
-  let genSpecializedAttr = 0;
-  let cppNamespace = "::circt::sv";
 }
 
 def ModportDirectionAttr : EnumAttr<SVDialect, ModportDirection,

--- a/include/circt/Dialect/SV/SVVerification.td
+++ b/include/circt/Dialect/SV/SVVerification.td
@@ -11,21 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Immediate assertions, like `assert`.
-def ImmediateAssert: I32EnumAttrCase<"Immediate", 0, "immediate">;
-/// Observed deferred assertions, like `assert #0`.
-def ObservedAssert: I32EnumAttrCase<"Observed", 1, "observed">;
-/// Final deferred assertions, like `assert final`.
-def FinalAssert: I32EnumAttrCase<"Final", 2, "final">;
-
-/// A mode specifying how immediate/deferred assertions operate.
-def DeferAssertAttr : I32EnumAttr<
-  "DeferAssert", "assertion deferring mode",
-  [ImmediateAssert, ObservedAssert, FinalAssert]>
-{
-  let cppNamespace = "circt::sv";
-}
-
 /// A constraint checking no substitutions if no message.
 def NoSubstitutionsIfNoMessage : PredOpTrait<"has message if has substitutions",
   CPred<"($message && !$message->empty()) || $substitutions.empty()">>;

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3601,7 +3601,7 @@ EmittedProperty PropertyEmitter::visitLTL(ltl::EventuallyOp op) {
 EmittedProperty PropertyEmitter::visitLTL(ltl::ClockOp op) {
   ps << "@(";
   ps.scopedBox(PP::ibox2, [&] {
-    ps << PPExtString(stringifyClockEdge(op.getEdge())) << PP::space;
+    ps << PPExtString(stringifyEventControl(op.getEdge())) << PP::space;
     emitNestedProperty(op.getClock(), PropertyPrecedence::Lowest);
     ps << ")";
   });
@@ -4791,7 +4791,7 @@ LogicalResult StmtEmitter::visitSV(AlwaysOp op) {
     llvm::interleave(
         op.getEvents(),
         [&](Attribute eventAttr) {
-          auto event = sv::EventControl(cast<IntegerAttr>(eventAttr).getInt());
+          auto event = hw::EventControl(cast<IntegerAttr>(eventAttr).getInt());
           comment += stringifyEventControl(event);
         },
         [&]() { comment += ", "; });
@@ -4863,7 +4863,7 @@ LogicalResult StmtEmitter::visitSV(AlwaysFFOp op) {
       // Negative edge async resets need to invert the reset condition. This
       // is noted in the op description.
       if (op.getResetStyle() == ResetType::AsyncReset &&
-          *op.getResetEdge() == sv::EventControl::AtNegEdge)
+          *op.getResetEdge() == hw::EventControl::AtNegEdge)
         ps << "!";
       emitExpression(op.getReset(), ops);
       ps << ")";

--- a/lib/Conversion/HWToSV/HWToSV.cpp
+++ b/lib/Conversion/HWToSV/HWToSV.cpp
@@ -22,14 +22,14 @@ using namespace circt;
 using namespace hw;
 using namespace sv;
 
-static sv::EventControl hwToSvEventControl(hw::EventControl ec) {
+static hw::EventControl hwToSvEventControl(hw::EventControl ec) {
   switch (ec) {
   case hw::EventControl::AtPosEdge:
-    return sv::EventControl::AtPosEdge;
+    return hw::EventControl::AtPosEdge;
   case hw::EventControl::AtNegEdge:
-    return sv::EventControl::AtNegEdge;
+    return hw::EventControl::AtNegEdge;
   case hw::EventControl::AtEdge:
-    return sv::EventControl::AtEdge;
+    return hw::EventControl::AtEdge;
   }
   llvm_unreachable("Unknown event control kind");
 }
@@ -47,7 +47,7 @@ struct TriggeredOpConversionPattern : public OpConversionPattern<TriggeredOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto alwaysOp = rewriter.create<AlwaysOp>(
         op.getLoc(),
-        llvm::SmallVector<sv::EventControl>{hwToSvEventControl(op.getEvent())},
+        llvm::SmallVector<hw::EventControl>{hwToSvEventControl(op.getEvent())},
         llvm::SmallVector<Value>{op.getTrigger()});
     rewriter.mergeBlocks(op.getBodyBlock(), alwaysOp.getBodyBlock(),
                          operands.getInputs());

--- a/lib/Conversion/LTLToCore/LTLToCore.cpp
+++ b/lib/Conversion/LTLToCore/LTLToCore.cpp
@@ -33,18 +33,6 @@ using namespace mlir;
 using namespace circt;
 using namespace hw;
 
-static sv::EventControl ltlToSVEventControl(ltl::ClockEdge ce) {
-  switch (ce) {
-  case ltl::ClockEdge::Pos:
-    return sv::EventControl::AtPosEdge;
-  case ltl::ClockEdge::Neg:
-    return sv::EventControl::AtNegEdge;
-  case ltl::ClockEdge::Both:
-    return sv::EventControl::AtEdge;
-  }
-  llvm_unreachable("Unknown event control kind");
-}
-
 //===----------------------------------------------------------------------===//
 // Conversion patterns
 //===----------------------------------------------------------------------===//
@@ -186,8 +174,7 @@ struct AssertOpConversionPattern : OpConversionPattern<verif::AssertOp> {
     // Generate the parenting sv.always posedge clock from the ltl
     // clock, containing the generated sv.assert
     rewriter.create<sv::AlwaysOp>(
-        clockOp.getLoc(), ltlToSVEventControl(clockOp.getEdge()), ltlClock,
-        [&] {
+        clockOp.getLoc(), clockOp.getEdge(), ltlClock, [&] {
           // Generate the sv assertion using the input to the
           // parenting clock
           rewriter.replaceOpWithNewOp<sv::AssertOp>(

--- a/lib/Conversion/SeqToSV/FirRegLowering.h
+++ b/lib/Conversion/SeqToSV/FirRegLowering.h
@@ -105,10 +105,10 @@ private:
   tryRestoringSubaccess(OpBuilder &builder, Value reg, Value term,
                         hw::ArrayCreateOp nextRegValue);
 
-  void addToAlwaysBlock(Block *block, sv::EventControl clockEdge, Value clock,
+  void addToAlwaysBlock(Block *block, hw::EventControl clockEdge, Value clock,
                         const std::function<void(OpBuilder &)> &body,
-                        ResetType resetStyle = {},
-                        sv::EventControl resetEdge = {}, Value reset = {},
+                        sv::ResetType resetStyle = {},
+                        hw::EventControl resetEdge = {}, Value reset = {},
                         const std::function<void(OpBuilder &)> &resetBody = {});
 
   void addToIfBlock(OpBuilder &builder, Value cond,
@@ -127,8 +127,8 @@ private:
     return constant;
   }
 
-  using AlwaysKeyType = std::tuple<Block *, sv::EventControl, Value, ResetType,
-                                   sv::EventControl, Value>;
+  using AlwaysKeyType = std::tuple<Block *, hw::EventControl, Value,
+                                   sv::ResetType, hw::EventControl, Value>;
   llvm::SmallDenseMap<AlwaysKeyType, std::pair<sv::AlwaysOp, sv::IfOp>>
       alwaysBlocks;
 

--- a/lib/Conversion/SeqToSV/SeqToSV.cpp
+++ b/lib/Conversion/SeqToSV/SeqToSV.cpp
@@ -97,22 +97,22 @@ public:
     if (adaptor.getReset() && adaptor.getResetValue()) {
       if (lowerToAlwaysFF) {
         rewriter.create<sv::AlwaysFFOp>(
-            loc, sv::EventControl::AtPosEdge, adaptor.getClk(),
-            ResetType::SyncReset, sv::EventControl::AtPosEdge,
+            loc, hw::EventControl::AtPosEdge, adaptor.getClk(),
+            sv::ResetType::SyncReset, hw::EventControl::AtPosEdge,
             adaptor.getReset(), assignValue, assignReset);
       } else {
         rewriter.create<sv::AlwaysOp>(
-            loc, sv::EventControl::AtPosEdge, adaptor.getClk(), [&] {
+            loc, hw::EventControl::AtPosEdge, adaptor.getClk(), [&] {
               rewriter.create<sv::IfOp>(loc, adaptor.getReset(), assignReset,
                                         assignValue);
             });
       }
     } else {
       if (lowerToAlwaysFF) {
-        rewriter.create<sv::AlwaysFFOp>(loc, sv::EventControl::AtPosEdge,
+        rewriter.create<sv::AlwaysFFOp>(loc, hw::EventControl::AtPosEdge,
                                         adaptor.getClk(), assignValue);
       } else {
-        rewriter.create<sv::AlwaysOp>(loc, sv::EventControl::AtPosEdge,
+        rewriter.create<sv::AlwaysOp>(loc, hw::EventControl::AtPosEdge,
                                       adaptor.getClk(), assignValue);
       }
     }
@@ -169,7 +169,7 @@ public:
 
     // Latch the enable signal using an always @* block.
     rewriter.create<sv::AlwaysOp>(
-        loc, llvm::SmallVector<sv::EventControl>{}, llvm::SmallVector<Value>{},
+        loc, llvm::SmallVector<hw::EventControl>{}, llvm::SmallVector<Value>{},
         [&]() {
           rewriter.create<sv::IfOp>(
               loc, comb::createOrFoldNot(loc, clk, rewriter), [&]() {
@@ -339,7 +339,7 @@ public:
       regs.push_back(reg);
 
       rewriter.create<sv::AlwaysOp>(
-          loc, sv::EventControl::AtPosEdge, output, [&] {
+          loc, hw::EventControl::AtPosEdge, output, [&] {
             Value outputVal = rewriter.create<sv::ReadInOutOp>(loc, reg);
             Value inverted = rewriter.create<comb::XorOp>(loc, outputVal, one);
             rewriter.create<sv::BPAssignOp>(loc, reg, inverted);

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -145,7 +145,7 @@ public:
         loc, "SYNTHESIS", [&] {},
         [&] {
           rewriter.create<sv::AlwaysOp>(
-              loc, sv::EventControl::AtPosEdge, clockCast, [&] {
+              loc, hw::EventControl::AtPosEdge, clockCast, [&] {
                 rewriter.create<sv::IfOp>(loc, adaptor.getCond(),
                                           [&] { rewriter.create<ToOp>(loc); });
               });

--- a/lib/Conversion/VerifToSV/VerifToSV.cpp
+++ b/lib/Conversion/VerifToSV/VerifToSV.cpp
@@ -96,7 +96,7 @@ struct HasBeenResetConversion : public OpConversionPattern<HasBeenResetOp> {
     // for sync resets this happens on the clock's posedge if the reset is set.
     Value triggerOn = op.getAsync() ? reset : clock;
     rewriter.create<sv::AlwaysOp>(
-        op.getLoc(), sv::EventControl::AtPosEdge, triggerOn, [&] {
+        op.getLoc(), hw::EventControl::AtPosEdge, triggerOn, [&] {
           auto assignOne = [&] {
             rewriter.create<sv::PAssignOp>(op.getLoc(), reg, constOne);
           };

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -271,8 +271,8 @@ instantiateSystemVerilogMemory(ServiceImplementReqOp implReq,
   // Now construct the memory writes.
   auto hwClk = b.create<seq::FromClockOp>(clk);
   b.create<sv::AlwaysFFOp>(
-      sv::EventControl::AtPosEdge, hwClk, ResetType::SyncReset,
-      sv::EventControl::AtPosEdge, rst, [&] {
+      hw::EventControl::AtPosEdge, hwClk, sv::ResetType::SyncReset,
+      hw::EventControl::AtPosEdge, rst, [&] {
         for (auto [go, address, data] : writeGoAddressData) {
           Value a = address, d = data; // So the lambda can capture.
           // If we're told to go, do the write.

--- a/lib/Dialect/LTL/CMakeLists.txt
+++ b/lib/Dialect/LTL/CMakeLists.txt
@@ -7,7 +7,6 @@ add_circt_dialect_library(CIRCTLTL
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/LTL
 
   DEPENDS
-  CIRCTLTLEnumsIncGen
   MLIRLTLIncGen
 
   LINK_COMPONENTS

--- a/lib/Dialect/LTL/LTLDialect.cpp
+++ b/lib/Dialect/LTL/LTLDialect.cpp
@@ -29,7 +29,6 @@ void LTLDialect::initialize() {
 }
 
 #include "circt/Dialect/LTL/LTLDialect.cpp.inc"
-#include "circt/Dialect/LTL/LTLEnums.cpp.inc"
 
 #define GET_TYPEDEF_CLASSES
 #include "circt/Dialect/LTL/LTLTypes.cpp.inc"

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -558,12 +558,13 @@ LogicalResult IfOp::canonicalize(IfOp op, PatternRewriter &rewriter) {
 //===----------------------------------------------------------------------===//
 
 AlwaysOp::Condition AlwaysOp::getCondition(size_t idx) {
-  return Condition{EventControl(cast<IntegerAttr>(getEvents()[idx]).getInt()),
-                   getOperand(idx)};
+  return Condition{
+      hw::EventControl(cast<IntegerAttr>(getEvents()[idx]).getInt()),
+      getOperand(idx)};
 }
 
 void AlwaysOp::build(OpBuilder &builder, OperationState &result,
-                     ArrayRef<sv::EventControl> events, ArrayRef<Value> clocks,
+                     ArrayRef<hw::EventControl> events, ArrayRef<Value> clocks,
                      std::function<void()> bodyCtor) {
   assert(events.size() == clocks.size() &&
          "mismatch between event and clock list");
@@ -602,7 +603,7 @@ static ParseResult parseEventList(
   StringRef keyword;
   if (!p.parseOptionalKeyword(&keyword)) {
     while (1) {
-      auto kind = sv::symbolizeEventControl(keyword);
+      auto kind = hw::symbolizeEventControl(keyword);
       if (!kind.has_value())
         return p.emitError(loc, "expected 'posedge', 'negedge', or 'edge'");
       auto eventEnum = static_cast<int32_t>(*kind);
@@ -639,7 +640,7 @@ static void printEventList(OpAsmPrinter &p, AlwaysOp op, ArrayAttr portsAttr,
 //===----------------------------------------------------------------------===//
 
 void AlwaysFFOp::build(OpBuilder &builder, OperationState &result,
-                       EventControl clockEdge, Value clock,
+                       hw::EventControl clockEdge, Value clock,
                        std::function<void()> bodyCtor) {
   OpBuilder::InsertionGuard guard(builder);
 
@@ -661,8 +662,8 @@ void AlwaysFFOp::build(OpBuilder &builder, OperationState &result,
 }
 
 void AlwaysFFOp::build(OpBuilder &builder, OperationState &result,
-                       EventControl clockEdge, Value clock,
-                       ResetType resetStyle, EventControl resetEdge,
+                       hw::EventControl clockEdge, Value clock,
+                       ResetType resetStyle, hw::EventControl resetEdge,
                        Value reset, std::function<void()> bodyCtor,
                        std::function<void()> resetCtor) {
   OpBuilder::InsertionGuard guard(builder);

--- a/lib/Dialect/Seq/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/Seq/Transforms/HWMemSimImpl.cpp
@@ -145,7 +145,7 @@ Value HWMemSimImpl::addPipelineStages(ImplicitLocOpBuilder &b,
       alwaysOp = {};
   }
   if (!alwaysOp)
-    alwaysOp = b.create<sv::AlwaysOp>(sv::EventControl::AtPosEdge, clock);
+    alwaysOp = b.create<sv::AlwaysOp>(hw::EventControl::AtPosEdge, clock);
 
   // Add the necessary registers.
   auto savedIP = b.saveInsertionPoint();
@@ -374,7 +374,7 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
 
     // Write logic gaurded by the corresponding mask bit.
     for (auto wmask : llvm::enumerate(maskValues)) {
-      b.create<sv::AlwaysOp>(sv::EventControl::AtPosEdge, clock, [&]() {
+      b.create<sv::AlwaysOp>(hw::EventControl::AtPosEdge, clock, [&]() {
         auto wcond = b.createOrFold<comb::AndOp>(
             writeEn,
             b.createOrFold<comb::AndOp>(wmask.value(), writeWMode, false),
@@ -451,7 +451,7 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
 
     // Build a new always block with write port logic.
     auto alwaysBlock = [&] {
-      return b.create<sv::AlwaysOp>(sv::EventControl::AtPosEdge, clock,
+      return b.create<sv::AlwaysOp>(hw::EventControl::AtPosEdge, clock,
                                     [&]() { writeLogic(); });
     };
 

--- a/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
@@ -93,8 +93,8 @@ public:
 
     auto hwClk = rewriter.create<seq::FromClockOp>(clk.getLoc(), clk);
     rewriter.create<sv::AlwaysFFOp>(
-        mem.getLoc(), sv::EventControl::AtPosEdge, hwClk, ResetType::SyncReset,
-        sv::EventControl::AtPosEdge, rst, [&] {
+        mem.getLoc(), hw::EventControl::AtPosEdge, hwClk,
+        sv::ResetType::SyncReset, hw::EventControl::AtPosEdge, rst, [&] {
           for (auto [loc, address, data, en] : writeTuples) {
             Value a = address, d = data; // So the lambda can capture.
             Location l = loc;


### PR DESCRIPTION
So, I've taken a closer look at this again following the discussion in #7022 and it turns out that there were CMake options added to support this for types and attributes (see `-attrdefs-dialect <DialectName>`) but not for enums. Probably the most elegant solution would be to add something similar upstream for enums, but this draft shows an alternative workaround solution.