### PR TITLE
[FIRRTL][Intrinsics] source materialization for inferred types.

### DIFF
--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -314,5 +314,5 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
     wire w: UInt<1>
     inst ext of Val
     w <= ext.v
-    out[0] <= intrinsic(circt_mux2cell : UInt<1>, xor(cond, UInt<1>(1)), w, low)
-    out[1] <= intrinsic(circt_mux2cell : UInt<1>, xor(cond, UInt<1>(1)), ext.v, low)
+    out[0] <= intrinsic(circt_mux2cell : UInt, xor(cond, UInt<1>(1)), w, low)
+    out[1] <= intrinsic(circt_mux2cell : UInt, xor(cond, UInt<1>(1)), ext.v, low)


### PR DESCRIPTION
If the new op's result doesn't match, insert a wire + connect (if valid) to handle the mismatch.

For intrinsics that lower to ops with return type inference, the inferred type may be different than the declared type (e.g., `UInt` vs `UInt<1>`).