### PR TITLE
[CreateSifiveMetadata] Fix a typo in the field name

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -108,7 +108,7 @@ struct ObjectModelIR {
         StringType::get(context),  // direction
         FIntegerType::get(context) // Width
     };
-    StringRef extraPortFields[3] = {"name", "drection", "width"};
+    StringRef extraPortFields[3] = {"name", "direction", "width"};
 
     extraPortsClass =
         buildSimpleClassOp(builderOM, unknownLoc, "ExtraPortsMemorySchema",


### PR DESCRIPTION
Fixes a typo in the field names for the memory metadata that is generated in the `seq_mems.json`.