### PR TITLE
[HW] Fix pattern returning success() without changing.

### DIFF
--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2226,7 +2226,7 @@ LogicalResult ArrayConcatOp::canonicalize(ArrayConcatOp op,
   if (mergeConcatSlices(op, rewriter))
     return success();
 
-  return success();
+  return failure();
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Detected by -DMLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON.

cc #7047.