### PR TITLE
[Comb] Fix MuxRewriter to eraseOperand in rewriter-aware way.

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -2211,7 +2211,8 @@ static Value extractOperandFromFullyAssociative(Operation *fullyAssoc,
 
   // If the operation has a single use, mutate it in place.
   if (fullyAssoc->hasOneUse()) {
-    fullyAssoc->eraseOperand(operandNo);
+    rewriter.modifyOpInPlace(fullyAssoc,
+                             [&]() { fullyAssoc->eraseOperand(operandNo); });
     return fullyAssoc->getResult(0);
   }
 


### PR DESCRIPTION
Detected by -DMLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON.

cc #7047.