### PR TITLE
[FIRRTL] Fix width of attribute in MuxPadSel canonicalizations.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -658,7 +658,7 @@ def MuxPadSel : Pat<
   (MuxPrimOp:$old $cond, $a, $b),
   (MoveNameHint $old, (MuxPrimOp
     (ConstantOp
-      (NativeCodeCall<"$_builder.getUI32IntegerAttr(0)">),
+      (NativeCodeCall<"getIntZerosAttr($_builder.getType<UIntType>(1))">),
       (returnType "$_builder.getType<UIntType>(1)")),
     $a, $b)),
   [(IntTypeWidthLTX<1> $cond)]>;
@@ -668,7 +668,7 @@ def Mux2PadSel : Pat<
   (Mux2CellIntrinsicOp:$old $cond, $a, $b),
   (MoveNameHint $old, (Mux2CellIntrinsicOp
     (ConstantOp
-      (NativeCodeCall<"$_builder.getUI32IntegerAttr(0)">),
+      (NativeCodeCall<"getIntZerosAttr($_builder.getType<UIntType>(1))">),
       (returnType "$_builder.getType<UIntType>(1)")),
     $a, $b)),
   [(IntTypeWidthLTX<1> $cond)]>;


### PR DESCRIPTION
Detected by -DMLIR_ENABLE_EXPENSIVE_PATTERN_API_CHECKS=ON.

cc #7047.