### PR TITLE
FileCheck directive fixup, now filecheck_lint-clean.

### DIFF
--- a/test/Dialect/Ibis/Transforms/scoperef_tunneling.mlir
+++ b/test/Dialect/Ibis/Transforms/scoperef_tunneling.mlir
@@ -221,12 +221,12 @@ ibis.container @C {
 // cannot live within an ibis.design, but we need to run this pass on the
 // ibis.design op. I don't think it's critical that we support this case currently.
 
-// CHECKx-LABEL:   hw.module @AccessChildFromHW() {
-// CHECKx:           %[[VAL_0:.*]] = ibis.container.instance @c, <@D::@C>
-// CHECKx:           %[[VAL_1:.*]] = ibis.get_port %[[VAL_0]], @out : !ibis.scoperef<@D::@C> -> !ibis.portref<out i1>
-// CHECKx:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_0]], @in : !ibis.scoperef<@D::@C> -> !ibis.portref<in i1>
-// CHECKx:           hw.output
-// CHECKx:         }
+// COM: CHECK-LABEL:   hw.module @AccessChildFromHW() {
+// COM: CHECK:           %[[VAL_0:.*]] = ibis.container.instance @c, <@D::@C>
+// COM: CHECK:           %[[VAL_1:.*]] = ibis.get_port %[[VAL_0]], @out : !ibis.scoperef<@D::@C> -> !ibis.portref<out i1>
+// COM: CHECK:           %[[VAL_2:.*]] = ibis.get_port %[[VAL_0]], @in : !ibis.scoperef<@D::@C> -> !ibis.portref<in i1>
+// COM: CHECK:           hw.output
+// COM: CHECK:         }
 
 }
 

--- a/test/Scheduling/problems.mlir
+++ b/test/Scheduling/problems.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s -ssp-roundtrip=verify
 // RUN: circt-opt %s -ssp-schedule=scheduler=asap | FileCheck %s -check-prefixes=CHECK,ASAP
 // RUN: circt-opt %s -ssp-schedule=scheduler=simplex | FileCheck %s -check-prefixes=CHECK,SIMPLEX
-// RUN: %if or-tools %{ circt-opt %s -ssp-schedule=scheduler=lp | FileCheck %s -check-prefixes=CHECK,LP %} 
+// RUN: %if or-tools %{ circt-opt %s -ssp-schedule=scheduler=lp | FileCheck %s -check-prefixes=CHECK,LINEAR %}
 
 // CHECK-LABEL: unit_latencies
 ssp.instance @unit_latencies of "Problem" {
@@ -26,7 +26,7 @@ ssp.instance @unit_latencies of "Problem" {
     %6 = operation<@_1>(%3, %4, %5) [t<5>]
     // ASAP-NEXT: [t<6>]
     // SIMPLEX: @last(%{{.*}}) [t<6>]
-    // LP: @last(%{{.*}}) [t<6>]
+    // LINEAR: @last(%{{.*}}) [t<6>]
     operation<@_1> @last(%6) [t<6>]
   }
 }
@@ -56,7 +56,7 @@ ssp.instance @arbitrary_latencies of "Problem" {
     %5 = operation<@_10>(%4) [t<50>]
     // ASAP-NEXT: [t<19>]
     // SIMPLEX: @last(%{{.*}}) [t<19>]
-    // LP: @last(%{{.*}}) [t<19>]
+    // LINEAR: @last(%{{.*}}) [t<19>]
     operation<@_1> @last(%5) [t<60>]
   }
 }
@@ -82,7 +82,7 @@ ssp.instance @auxiliary_dependences of "Problem" {
     operation<@_1> @op5(@op4) [t<4>]
     // ASAP-NEXT: [t<5>]
     // SIMPLEX: @last(@op3, @op5) [t<5>]
-    // LP: @last(@op3, @op5) [t<5>]
+    // LINEAR: @last(@op3, @op5) [t<5>]
     operation<@_1> @last(@op3, @op5) [t<5>]
   }
 }

--- a/test/firtool/convention.fir
+++ b/test/firtool/convention.fir
@@ -31,7 +31,7 @@ circuit Top :
   ; SCALARIZE_TTF:     attributes {convention = #firrtl<convention scalarized>}
   ; SCALARIZE_FFT-NOT: attributes {convention = #firrtl<convention scalarized>}
   ; SCALARIZE_TFT-NOT: attributes {convention = #firrtl<convention scalarized>}
-  ; SCALARIZE_FTT   :  attributes {convention = #firrtl<convention scalarized>}
+  ; SCALARIZE_FTT:     attributes {convention = #firrtl<convention scalarized>}
   ; SCALARIZE_TTT:     attributes {convention = #firrtl<convention scalarized>}
   extmodule External :
     output port: UInt<8>[2]


### PR DESCRIPTION
Only one actual typo in this PR, others are slight alterations so lint is clean and could be added as a CI check moving forward.

Don't want to bend too far to appease a lint tool, but would be great to have this flagged on PR's.