### PR TITLE
[ESI][Runtime] Refactor cosim backend to be thread safe

### DIFF
--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -129,6 +129,10 @@ if(ESI_COSIM)
       ${ESIRuntimeLinkLibraries}
       EsiCosimCapnp
     )
+    set(ESIRuntimeIncludeDirs
+      ${ESIRuntimeIncludeDirs}
+      ${CMAKE_CURRENT_SOURCE_DIR}/cosim/include
+    )
   else()
     message(FATAL_ERROR "ESI cosimulation requires Cap'nProto. Either install
                         Cap'nProto or disable ESI cosim with -DESI_COSIM=OFF.")

--- a/lib/Dialect/ESI/runtime/cosim/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/cosim/CMakeLists.txt
@@ -20,11 +20,14 @@ add_library(EsiCosimCapnp SHARED
   ${COSIM_SCHEMA_HDR}
 
   lib/CapnpThreads.cpp
+  lib/Client.cpp
   lib/Endpoint.cpp
   lib/Server.cpp
 )
 target_include_directories(EsiCosimCapnp PUBLIC ${CAPNPC_OUTPUT_DIR})
 target_include_directories(EsiCosimCapnp PUBLIC ${CAPNP_INCLUDE_DIRS})
+target_include_directories(EsiCosimCapnp PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/../cpp/include)
 target_link_libraries(EsiCosimCapnp PUBLIC
   CapnProto::kj CapnProto::kj-async CapnProto::kj-gzip
   CapnProto::capnp CapnProto::capnp-rpc 

--- a/lib/Dialect/ESI/runtime/cosim/lib/Client.cpp
+++ b/lib/Dialect/ESI/runtime/cosim/lib/Client.cpp
@@ -1,0 +1,160 @@
+//===- Client.cpp - Cosim RPC client ----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CosimDpi.capnp.h"
+#include "cosim/CapnpThreads.h"
+#include <capnp/ez-rpc.h>
+
+#include <cassert>
+#include <thread>
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+using namespace capnp;
+using namespace esi::cosim;
+
+/// Internal implementation to hide all the capnp details.
+struct esi::cosim::RpcClient::Impl {
+
+  Impl(RpcClient &client, capnp::EzRpcClient &rpcClient)
+      : client(client), waitScope(rpcClient.getWaitScope()), cosim(nullptr),
+        lowLevel(nullptr) {
+    // Get the main interface.
+    cosim = rpcClient.getMain<CosimDpiServer>();
+
+    // Grab a reference to the low level interface.
+    auto llReq = cosim.openLowLevelRequest();
+    auto llPromise = llReq.send();
+    lowLevel = llPromise.wait(waitScope).getLowLevel();
+
+    // Get the ESI version and compressed manifest.
+    auto maniResp = cosim.getCompressedManifestRequest().send().wait(waitScope);
+    capnp::Data::Reader data = maniResp.getCompressedManifest();
+    client.esiVersion = maniResp.getVersion();
+    client.compressedManifest = std::vector<uint8_t>(data.begin(), data.end());
+
+    // Iterate through the endpoints and register them.
+    auto capnpEndpointsResp = cosim.listRequest().send().wait(waitScope);
+    for (const auto &capnpEndpoint : capnpEndpointsResp.getIfaces()) {
+      assert(capnpEndpoint.hasEndpointID() &&
+             "Response did not contain endpoint ID not found!");
+      std::string fromHostType, toHostType;
+      if (capnpEndpoint.hasFromHostType())
+        fromHostType = capnpEndpoint.getFromHostType();
+      if (capnpEndpoint.hasToHostType())
+        toHostType = capnpEndpoint.getToHostType();
+      bool rc = client.endpoints.registerEndpoint(capnpEndpoint.getEndpointID(),
+                                                  fromHostType, toHostType);
+      assert(rc && "Endpoint ID already exists!");
+      Endpoint *ep = client.endpoints[capnpEndpoint.getEndpointID()];
+      // TODO: delay opening until client calls connect().
+      auto openReq = cosim.openRequest();
+      openReq.setIface(capnpEndpoint);
+      EsiDpiEndpoint::Client dpiEp =
+          openReq.send().wait(waitScope).getEndpoint();
+      endpointMap.emplace(ep, dpiEp);
+    }
+  }
+
+  RpcClient &client;
+  kj::WaitScope &waitScope;
+  CosimDpiServer::Client cosim;
+  EsiLowLevel::Client lowLevel;
+  std::map<Endpoint *, EsiDpiEndpoint::Client> endpointMap;
+
+  /// Called from the event loop periodically.
+  // TODO: try to reduce work in here. Ideally, eliminate polling altogether
+  // though I can't figure out how with libkj's event loop.
+  void pollInternal();
+};
+
+void esi::cosim::RpcClient::Impl::pollInternal() {
+  // Iterate through the endpoints checking for messages.
+  for (auto &[ep, capnpEp] : endpointMap) {
+    // Process writes to the simulation.
+    Endpoint::MessageDataPtr msg;
+    if (!ep->getSendTypeId().empty() && ep->getMessageToSim(msg)) {
+      auto req = capnpEp.sendFromHostRequest();
+      req.setMsg(capnp::Data::Reader(msg->getBytes(), msg->getSize()));
+      req.send().detach([](kj::Exception &&e) -> void {
+        throw std::runtime_error("Error sending message to simulation: " +
+                                 std::string(e.getDescription().cStr()));
+      });
+    }
+
+    // Process reads from the simulation.
+    // TODO: polling for a response is horribly slow and inefficient. Rework
+    // the capnp protocol to avoid it.
+    if (!ep->getRecvTypeId().empty()) {
+      auto resp = capnpEp.recvToHostRequest().send().wait(waitScope);
+      if (resp.getHasData()) {
+        auto data = resp.getResp();
+        ep->pushMessageToClient(
+            std::make_unique<MessageData>(data.begin(), data.size()));
+      }
+    }
+  }
+
+  // Process MMIO read requests.
+  if (auto readReq = client.lowLevelBridge.readReqs.pop()) {
+    auto req = lowLevel.readMMIORequest();
+    req.setAddress(*readReq);
+    auto respPromise = req.send();
+    respPromise
+        .then([&](auto resp) -> void {
+          client.lowLevelBridge.readResps.push(
+              std::make_pair(resp.getData(), 0));
+        })
+        .detach([&](kj::Exception &&e) -> void {
+          client.lowLevelBridge.readResps.push(std::make_pair(0, 1));
+        });
+  }
+
+  // Process MMIO write requests.
+  if (auto writeReq = client.lowLevelBridge.writeReqs.pop()) {
+    auto req = lowLevel.writeMMIORequest();
+    req.setAddress(writeReq->first);
+    req.setData(writeReq->second);
+    req.send()
+        .then([&](auto resp) -> void {
+          client.lowLevelBridge.writeResps.push(0);
+        })
+        .detach([&](kj::Exception &&e) -> void {
+          client.lowLevelBridge.writeResps.push(1);
+        });
+  }
+}
+
+void RpcClient::mainLoop(std::string host, uint16_t port) {
+  capnp::EzRpcClient rpcClient(host, port);
+  kj::WaitScope &waitScope = rpcClient.getWaitScope();
+  Impl impl(*this, rpcClient);
+
+  // Signal that we're good to go.
+  started.store(true);
+
+  // Start the event loop. Does not return until stop() is called.
+  loop(waitScope, [&]() { impl.pollInternal(); });
+}
+
+/// Start the client if not already started.
+void RpcClient::run(std::string host, uint16_t port) {
+  Lock g(m);
+  if (myThread == nullptr) {
+    started.store(false);
+    myThread = new std::thread(&RpcClient::mainLoop, this, host, port);
+    // Spin until the capnp thread is started and ready to go.
+    while (!started.load())
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
+  } else {
+    fprintf(stderr, "Warning: cannot Run() RPC client more than once!");
+  }
+}

--- a/lib/Dialect/ESI/runtime/cosim/lib/Endpoint.cpp
+++ b/lib/Dialect/ESI/runtime/cosim/lib/Endpoint.cpp
@@ -14,8 +14,7 @@
 
 using namespace esi::cosim;
 
-Endpoint::Endpoint(std::string fromHostTypeId, int fromHostTypeMaxSize,
-                   std::string toHostTypeId, int toHostTypeMaxSize)
+Endpoint::Endpoint(std::string fromHostTypeId, std::string toHostTypeId)
     : fromHostTypeId(fromHostTypeId), toHostTypeId(toHostTypeId), inUse(false) {
 }
 Endpoint::~Endpoint() {}
@@ -37,9 +36,7 @@ void Endpoint::returnForUse() {
 
 bool EndpointRegistry::registerEndpoint(std::string epId,
                                         std::string fromHostTypeId,
-                                        int fromHostTypeMaxSize,
-                                        std::string toHostTypeId,
-                                        int toHostTypeMaxSize) {
+                                        std::string toHostTypeId) {
   Lock g(m);
   if (endpoints.find(epId) != endpoints.end()) {
     fprintf(stderr, "Endpoint ID already exists!\n");
@@ -51,8 +48,7 @@ bool EndpointRegistry::registerEndpoint(std::string epId,
                     // Map key.
                     std::forward_as_tuple(epId),
                     // Endpoint constructor args.
-                    std::forward_as_tuple(fromHostTypeId, fromHostTypeMaxSize,
-                                          toHostTypeId, toHostTypeMaxSize));
+                    std::forward_as_tuple(fromHostTypeId, toHostTypeId));
   return true;
 }
 

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Common.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Common.h
@@ -87,6 +87,7 @@ public:
   /// Adopts the data vector buffer.
   MessageData() = default;
   MessageData(std::vector<uint8_t> &data) : data(std::move(data)) {}
+  MessageData(const uint8_t *data, size_t size) : data(data, data + size) {}
   ~MessageData() = default;
 
   const uint8_t *getBytes() const { return data.data(); }

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -16,8 +16,7 @@
 #include "esi/backends/Cosim.h"
 #include "esi/Services.h"
 
-#include "CosimDpi.capnp.h"
-#include <capnp/ez-rpc.h>
+#include "cosim/CapnpThreads.h"
 
 #include <fstream>
 #include <iostream>
@@ -76,219 +75,161 @@ CosimAccelerator::connect(Context &ctxt, string connectionString) {
   return make_unique<CosimAccelerator>(ctxt, host, port);
 }
 
-namespace {
-class CosimChannelPort;
-}
-
-struct esi::backends::cosim::CosimAccelerator::Impl {
-  capnp::EzRpcClient rpcClient;
-  kj::WaitScope &waitScope;
-  CosimDpiServer::Client cosim;
-  EsiLowLevel::Client lowLevel;
-
-  // We own all channels connected to rpcClient since their lifetime is tied to
-  // rpcClient.
-  set<unique_ptr<ChannelPort>> channels;
-
-  // Map from client path to channel assignments for that client.
-  map<AppIDPath, map<string, string>> clientChannelAssignments;
-
-  Impl(string hostname, uint16_t port)
-      : rpcClient(hostname, port), waitScope(rpcClient.getWaitScope()),
-        cosim(rpcClient.getMain<CosimDpiServer>()), lowLevel(nullptr) {
-    auto llReq = cosim.openLowLevelRequest();
-    auto llPromise = llReq.send();
-    lowLevel = llPromise.wait(waitScope).getLowLevel();
-  }
-  ~Impl();
-
-  /// Request the host side channel ports for a particular instance (identified
-  /// by the AppID path). For convenience, provide the bundle type and direction
-  /// of the bundle port.
-  std::map<std::string, ChannelPort &> requestChannelsFor(AppIDPath,
-                                                          const BundleType *);
-};
-
 /// Construct and connect to a cosim server.
 CosimAccelerator::CosimAccelerator(Context &ctxt, string hostname,
                                    uint16_t port)
     : AcceleratorConnection(ctxt) {
-  impl = make_unique<Impl>(hostname, port);
+  // Connect to the simulation.
+  rpcClient = std::make_unique<esi::cosim::RpcClient>();
+  rpcClient->run(hostname, port);
 }
 
 namespace {
 class CosimMMIO : public MMIO {
 public:
-  CosimMMIO(EsiLowLevel::Client &llClient, kj::WaitScope &waitScope)
-      : llClient(llClient), waitScope(waitScope) {}
+  CosimMMIO(esi::cosim::LowLevel *lowLevel) : lowLevel(lowLevel) {}
 
+  // Push the read request into the LowLevel capnp bridge and wait for the
+  // response.
   uint32_t read(uint32_t addr) const override {
-    auto req = llClient.readMMIORequest();
-    req.setAddress(addr);
-    return req.send().wait(waitScope).getData();
+    lowLevel->readReqs.push(addr);
+
+    std::optional<std::pair<uint64_t, uint8_t>> resp;
+    while (resp = lowLevel->readResps.pop(), !resp.has_value())
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
+    if (resp->second != 0)
+      throw runtime_error("MMIO read error" + to_string(resp->second));
+    return resp->first;
   }
+
+  // Push the write request into the LowLevel capnp bridge and wait for the ack
+  // or error.
   void write(uint32_t addr, uint32_t data) override {
-    auto req = llClient.writeMMIORequest();
-    req.setAddress(addr);
-    req.setData(data);
-    req.send().wait(waitScope);
+    lowLevel->writeReqs.push(make_pair(addr, data));
+
+    std::optional<uint8_t> resp;
+    while (resp = lowLevel->writeResps.pop(), !resp.has_value())
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
+    if (*resp != 0)
+      throw runtime_error("MMIO write error" + to_string(*resp));
   }
 
 private:
-  EsiLowLevel::Client &llClient;
-  kj::WaitScope &waitScope;
+  esi::cosim::LowLevel *lowLevel;
 };
 } // namespace
 
 namespace {
 class CosimSysInfo : public SysInfo {
 public:
-  CosimSysInfo(CosimDpiServer::Client &client, kj::WaitScope &waitScope)
-      : client(client), waitScope(waitScope) {}
+  CosimSysInfo(const std::unique_ptr<esi::cosim::RpcClient> &rpcClient)
+      : rpcClient(rpcClient) {}
 
   uint32_t getEsiVersion() const override {
-    auto maniResp =
-        client.getCompressedManifestRequest().send().wait(waitScope);
-    return maniResp.getVersion();
+    unsigned int esiVersion;
+    std::vector<uint8_t> compressedManifest;
+    if (!rpcClient->getCompressedManifest(esiVersion, compressedManifest))
+      throw runtime_error("Could not get ESI version from cosim");
+    return esiVersion;
   }
 
   vector<uint8_t> getCompressedManifest() const override {
-    auto maniResp =
-        client.getCompressedManifestRequest().send().wait(waitScope);
-    capnp::Data::Reader data = maniResp.getCompressedManifest();
-    return vector<uint8_t>(data.begin(), data.end());
+    unsigned int esiVersion;
+    std::vector<uint8_t> compressedManifest;
+    if (!rpcClient->getCompressedManifest(esiVersion, compressedManifest))
+      throw runtime_error("Could not get ESI version from cosim");
+    return compressedManifest;
   }
 
 private:
-  CosimDpiServer::Client &client;
-  kj::WaitScope &waitScope;
+  const std::unique_ptr<esi::cosim::RpcClient> &rpcClient;
 };
 } // namespace
-
-namespace {
-/// Parent class for read and write channel ports.
-class CosimChannelPort {
-public:
-  CosimChannelPort(CosimAccelerator::Impl &impl, string name)
-      : impl(impl), name(name), isConnected(false), ep(nullptr) {}
-  virtual ~CosimChannelPort() {}
-
-  void connect();
-  void disconnect();
-  void write(const MessageData &);
-  bool read(MessageData &);
-
-protected:
-  CosimAccelerator::Impl &impl;
-  string name;
-  bool isConnected;
-  EsiDpiEndpoint::Client ep;
-};
-} // namespace
-
-void CosimChannelPort::write(const MessageData &data) {
-  if (!isConnected)
-    throw runtime_error("Cannot write to a channel port that is not connected");
-
-  auto req = ep.sendFromHostRequest();
-  req.setMsg(capnp::Data::Reader(data.getBytes(), data.getSize()));
-  req.send().wait(impl.waitScope);
-}
-
-bool CosimChannelPort::read(MessageData &data) {
-  auto req = ep.recvToHostRequest();
-  auto resp = req.send().wait(impl.waitScope);
-  if (!resp.getHasData())
-    return false;
-  capnp::Data::Reader msg = resp.getResp();
-  size_t size = msg.size();
-  std::vector<uint8_t> vec(size);
-  memcpy(vec.data(), msg.begin(), size);
-  data = MessageData(vec);
-  return true;
-}
-
-esi::backends::cosim::CosimAccelerator::Impl::~Impl() {
-  // Make sure all channels are disconnected before rpcClient gets deconstructed
-  // or it'll throw an exception.
-  for (auto &ccp : channels)
-    ccp->disconnect();
-}
-
-void CosimChannelPort::connect() {
-  if (isConnected)
-    return;
-
-  // Linear search through the list of cosim endpoints. Slow, but good enough as
-  // connect isn't expected to be called often.
-  auto listResp = impl.cosim.listRequest().send().wait(impl.waitScope);
-  for (auto iface : listResp.getIfaces())
-    if (iface.getEndpointID() == name) {
-      auto openReq = impl.cosim.openRequest();
-      openReq.setIface(iface);
-      auto openResp = openReq.send().wait(impl.waitScope);
-      ep = openResp.getEndpoint();
-      isConnected = true;
-      return;
-    }
-  throw runtime_error("Could not find channel '" + name + "' in cosimulation");
-}
-
-void CosimChannelPort::disconnect() {
-  if (!isConnected)
-    return;
-  ep.closeRequest().send().wait(impl.waitScope);
-  ep = nullptr;
-  isConnected = false;
-}
 
 namespace {
 class WriteCosimChannelPort : public WriteChannelPort {
 public:
-  WriteCosimChannelPort(CosimAccelerator::Impl &impl, const Type *type,
-                        string name)
-      : WriteChannelPort(type),
-        cosim(make_unique<CosimChannelPort>(impl, name)) {}
-
+  WriteCosimChannelPort(esi::cosim::Endpoint *ep, const Type *type, string name)
+      : WriteChannelPort(type), ep(ep), name(name) {}
   virtual ~WriteCosimChannelPort() = default;
 
-  virtual void connect() override { cosim->connect(); }
-  virtual void disconnect() override { cosim->disconnect(); }
+  // TODO: Replace this with a request to connect to the capnp thread.
+  virtual void connect() override {
+    if (!ep)
+      throw runtime_error("Could not find channel '" + name +
+                          "' in cosimulation");
+    if (ep->getSendTypeId() == "")
+      throw runtime_error("Channel '" + name + "' is not a read channel");
+    // TODO: disabled since the generated hardware uses a different type id
+    // system. if (ep->getSendTypeId() != getType()->getID())
+    //   throw runtime_error("Channel '" + name + "' has wrong type. Expected "
+    //   +
+    //                       getType()->getID() + ", got " +
+    //                       ep->getSendTypeId());
+    ep->setInUse();
+  }
+  virtual void disconnect() override {
+    if (ep)
+      ep->returnForUse();
+  }
   virtual void write(const MessageData &) override;
 
 protected:
-  std::unique_ptr<CosimChannelPort> cosim;
+  esi::cosim::Endpoint *ep;
+  string name;
 };
 } // namespace
 
 void WriteCosimChannelPort::write(const MessageData &data) {
-  cosim->write(data);
+  ep->pushMessageToSim(make_unique<esi::MessageData>(data));
 }
 
 namespace {
 class ReadCosimChannelPort : public ReadChannelPort {
 public:
-  ReadCosimChannelPort(CosimAccelerator::Impl &impl, const Type *type,
-                       string name)
-      : ReadChannelPort(type), cosim(new CosimChannelPort(impl, name)) {}
-
+  ReadCosimChannelPort(esi::cosim::Endpoint *ep, const Type *type, string name)
+      : ReadChannelPort(type), ep(ep), name(name) {}
   virtual ~ReadCosimChannelPort() = default;
 
-  virtual void connect() override { cosim->connect(); }
-  virtual void disconnect() override { cosim->disconnect(); }
+  // TODO: Replace this with a request to connect to the capnp thread.
+  virtual void connect() override {
+    if (!ep)
+      throw runtime_error("Could not find channel '" + name +
+                          "' in cosimulation");
+    if (ep->getRecvTypeId() == "")
+      throw runtime_error("Channel '" + name + "' is not a read channel");
+    // TODO: disabled since the generated hardware uses a different type id
+    // system. if (ep->getRecvTypeId() != getType()->getID())
+    //   throw runtime_error("Channel '" + name + "' has wrong type. Expected "
+    //   +
+    //                       getType()->getID() + ", got " +
+    //                       ep->getRecvTypeId());
+    ep->setInUse();
+  }
+  virtual void disconnect() override {
+    if (ep)
+      ep->returnForUse();
+  }
   virtual bool read(MessageData &) override;
 
 protected:
-  std::unique_ptr<CosimChannelPort> cosim;
+  esi::cosim::Endpoint *ep;
+  string name;
 };
 
 } // namespace
 
-bool ReadCosimChannelPort::read(MessageData &data) { return cosim->read(data); }
+bool ReadCosimChannelPort::read(MessageData &data) {
+  esi::cosim::Endpoint::MessageDataPtr msg;
+  if (!ep->getMessageToClient(msg))
+    return false;
+  data = *msg;
+  return true;
+}
 
 map<string, ChannelPort &>
-CosimAccelerator::Impl::requestChannelsFor(AppIDPath idPath,
-                                           const BundleType *bundleType) {
+CosimAccelerator::requestChannelsFor(AppIDPath idPath,
+                                     const BundleType *bundleType) {
   map<string, ChannelPort &> channelResults;
 
   // Find the client details for the port at 'fullPath'.
@@ -305,22 +246,20 @@ CosimAccelerator::Impl::requestChannelsFor(AppIDPath idPath,
                           idPath.toStr() + "." + name + "'");
     string channelName = f->second;
 
+    // Get the endpoint, which may or may not exist. Construct the port.
+    // Everything is validated when the client calls 'connect()' on the port.
+    esi::cosim::Endpoint *ep = rpcClient->getEndpoint(channelName);
     ChannelPort *port;
     if (BundlePort::isWrite(dir))
-      port = new WriteCosimChannelPort(*this, type, channelName);
+      port = new WriteCosimChannelPort(ep, type, channelName);
     else
-      port = new ReadCosimChannelPort(*this, type, channelName);
+      port = new ReadCosimChannelPort(ep, type, channelName);
     channels.emplace(port);
     channelResults.emplace(name, *port);
   }
   return channelResults;
 }
 
-map<string, ChannelPort &>
-CosimAccelerator::requestChannelsFor(AppIDPath idPath,
-                                     const BundleType *bundleType) {
-  return impl->requestChannelsFor(idPath, bundleType);
-}
 Service *CosimAccelerator::createService(Service::Type svcType,
                                          AppIDPath idPath, std::string implName,
                                          const ServiceImplDetails &details,
@@ -339,17 +278,16 @@ Service *CosimAccelerator::createService(Service::Type svcType,
                client.implOptions.at("channel_assignments")))
         channelAssignments[assignment.first] =
             any_cast<string>(assignment.second);
-      impl->clientChannelAssignments[fullClientPath] =
-          std::move(channelAssignments);
+      clientChannelAssignments[fullClientPath] = std::move(channelAssignments);
     }
   }
 
   if (svcType == typeid(services::MMIO)) {
-    return new CosimMMIO(impl->lowLevel, impl->waitScope);
+    return new CosimMMIO(rpcClient->getLowLevel());
   } else if (svcType == typeid(SysInfo)) {
     switch (manifestMethod) {
     case ManifestMethod::Cosim:
-      return new CosimSysInfo(impl->cosim, impl->waitScope);
+      return new CosimSysInfo(rpcClient);
     case ManifestMethod::MMIO:
       return new MMIOSysInfo(getService<services::MMIO>());
     }


### PR DESCRIPTION
Previously, the cosim backend only supported single threaded workloads since the RPC calls would happen in the client calling thread. Now, spin up a "capnp" thread to do all of the RPC interactions.