### PR TITLE
[LowerClasses] Ensure classes are instantiated by an object.

### DIFF
--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -178,6 +178,10 @@ firrtl.circuit "PathModule" {
     // CHECK: %non_local = firrtl.wire sym [[NONLOCAL_SYM]] : !firrtl.uint<8>
     %non_local = firrtl.wire {annotations = [{circt.nonlocal = @NonLocal, class = "circt.tracker", id = distinct[3]<>}]} : !firrtl.uint<8>
   }
+  // CHECK: om.class @PathModule_Class(%basepath: !om.basepath) {
+  // CHECK:   om.basepath_create %basepath
+  // CHECK:   om.object @Child_Class
+  // CHECK:   om.object @PathTest
   // CHECK: om.class @PathTest(%basepath: !om.basepath)
   firrtl.class @PathTest() {
     


### PR DESCRIPTION
`LowerClass` creates an object for a corresponding instance only if the instantiated module has property ports. 
But a class can be created for a corresponding module based on other conditions like, if the module is  public, or instantiates other classes.
This results in un-instantiated classes that donot correspond to the module hierarchy.
This change ensures that if a class is created for a module, the object is also created from the corresponding instance.
Thus the module hierarchy is also preserved in the `om` IR.
Downstream tools parsing the  IR can assume a single top level class which is required for object model evaluation.