### PR TITLE
[FIRRTL] Limited invalid propagation.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -266,6 +266,7 @@ def InvalidValueOp : FIRRTLOp<"invalidvalue",
   let arguments = (ins);
   let results = (outs FIRRTLBaseType:$result);
   let hasCanonicalizeMethod = 1;
+  let hasFolder = 1;
 
   let assemblyFormat = "attr-dict `:` qualified(type($result))";
 }

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -3188,7 +3188,7 @@ LogicalResult InvalidValueOp::canonicalize(InvalidValueOp op,
   if (op->hasOneUse() &&
       isa<BitsPrimOp, HeadPrimOp, ShrPrimOp, TailPrimOp, SubfieldOp, SubindexOp,
           AsSIntPrimOp, AsUIntPrimOp, NotPrimOp>(*op->user_begin())) {
-    auto modop = *op->user_begin();
+    auto *modop = *op->user_begin();
     auto inv = rewriter.create<InvalidValueOp>(op.getLoc(),
                                                modop->getResult(0).getType());
     rewriter.replaceAllOpUsesWith(modop, inv);

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -3206,6 +3206,12 @@ LogicalResult InvalidValueOp::canonicalize(InvalidValueOp op,
   return failure();
 }
 
+OpFoldResult InvalidValueOp::fold(FoldAdaptor adaptor) {
+  if (getType().getBitWidthOrSentinel() == 0 && isa<IntType>(getType()))
+    return getIntAttr(getType(), APInt(0, 0, isa<SIntType>(getType())));
+  return {};
+}
+
 //===----------------------------------------------------------------------===//
 // ClockGateIntrinsicOp
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3098,7 +3098,7 @@ firrtl.module @RemoveUnusedInvalid() {
 // CHECK-NEXT: }
 
 // CHECK-LABEL: firrtl.module @PropInvalids
-firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint<4>) {
+firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint<4>, out %out1 : !firrtl.uint<1>) {
   // CHECK-NOT firrtl.not
   %inv = firrtl.invalidvalue : !firrtl.uint<4>
   %not = firrtl.not %inv : (!firrtl.uint<4>) -> !firrtl.uint<4>
@@ -3159,6 +3159,38 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
   %inv8 = firrtl.invalidvalue : !firrtl.vector<uint<4>, 6 >
   %subindex = firrtl.subindex %inv8[2] : !firrtl.vector<uint<4>, 6 >
   firrtl.strictconnect %out, %subindex : !firrtl.uint<4>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
+  // CHECK-NOT firrtl.bitcast
+  %inv9 = firrtl.invalidvalue : !firrtl.vector<uint<4>, 1 >
+  %bitcast = firrtl.bitcast %inv9 : (!firrtl.vector<uint<4>, 1 >) -> !firrtl.uint<4>
+  firrtl.strictconnect %out, %bitcast : !firrtl.uint<4>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
+  // CHECK-NOT firrtl.andr
+  %inva = firrtl.invalidvalue : !firrtl.uint<4>
+  %andr = firrtl.andr %inva : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  firrtl.strictconnect %out1, %andr : !firrtl.uint<1>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
+  // CHECK-NOT firrtl.orr
+  %invb = firrtl.invalidvalue : !firrtl.uint<4>
+  %orr = firrtl.orr %invb : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  firrtl.strictconnect %out1, %orr : !firrtl.uint<1>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
+  // CHECK-NOT firrtl.xorr
+  %invc = firrtl.invalidvalue : !firrtl.uint<4>
+  %xorr = firrtl.xorr %invc : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  firrtl.strictconnect %out1, %xorr : !firrtl.uint<1>
 
   // CHECK: firrtl.invalidvalue
   // CHECK-NEXT: firrtl.strictconnect

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3203,6 +3203,24 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
   firrtl.strictconnect %out1, %zbits : !firrtl.uint<1>
   // CHECK: firrtl.strictconnect %out1, %c0_ui1
 
+  // CHECK-NOT firrtl.cvt
+  %inve = firrtl.invalidvalue : !firrtl.uint<3>
+  %cvtu = firrtl.cvt %inve : (!firrtl.uint<3>) -> !firrtl.sint<4>
+  firrtl.strictconnect %outs, %cvtu : !firrtl.sint<4>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.pad
+  // CHECK-NEXT: firrtl.asSInt
+  // CHECK-NEXT: firrtl.strictconnect
+
+  // CHECK-NOT firrtl.cvt
+  %invf = firrtl.invalidvalue : !firrtl.sint<4>
+  %cvts = firrtl.cvt %invf : (!firrtl.sint<4>) -> !firrtl.sint<4>
+  firrtl.strictconnect %outs, %cvts : !firrtl.sint<4>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
 }
 
 // CHECK-LABEL: firrtl.module @AggregateCreate(

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3195,6 +3195,14 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
   // CHECK: firrtl.invalidvalue
   // CHECK-NEXT: firrtl.strictconnect
 
+  // This one depends on the folder
+  // CHECK-NOT firrtl.invalidvalue
+  // CHECK-NOT firrtl.xorr
+  %invd = firrtl.invalidvalue : !firrtl.uint<0>
+  %zbits = firrtl.xorr %invd : (!firrtl.uint<0>) -> !firrtl.uint<1>
+  firrtl.strictconnect %out1, %zbits : !firrtl.uint<1>
+  // CHECK: firrtl.strictconnect %out1, %c0_ui1
+
 }
 
 // CHECK-LABEL: firrtl.module @AggregateCreate(

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3097,6 +3097,74 @@ firrtl.module @RemoveUnusedInvalid() {
 }
 // CHECK-NEXT: }
 
+// CHECK-LABEL: firrtl.module @PropInvalids
+firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint<4>) {
+  // CHECK-NOT firrtl.not
+  %inv = firrtl.invalidvalue : !firrtl.uint<4>
+  %not = firrtl.not %inv : (!firrtl.uint<4>) -> !firrtl.uint<4>
+  firrtl.strictconnect %out, %not : !firrtl.uint<4>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
+  // CHECK-NOT firrtl.bits
+  %inv2 = firrtl.invalidvalue : !firrtl.uint<5>
+  %bits = firrtl.bits %inv2 3 to 0 : (!firrtl.uint<5>) -> !firrtl.uint<4>
+  firrtl.strictconnect %out, %bits : !firrtl.uint<4>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
+  // CHECK-NOT firrtl.head
+  %inv3 = firrtl.invalidvalue : !firrtl.uint<5>
+  %head = firrtl.head %inv3, 4 : (!firrtl.uint<5>) -> !firrtl.uint<4>
+  firrtl.strictconnect %out, %head : !firrtl.uint<4>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
+  // CHECK-NOT firrtl.tail
+  %inv4 = firrtl.invalidvalue : !firrtl.uint<5>
+  %tail = firrtl.tail %inv4, 1 : (!firrtl.uint<5>) -> !firrtl.uint<4>
+  firrtl.strictconnect %out, %tail : !firrtl.uint<4>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
+  // CHECK-NOT firrtl.asSInt
+  %inv5 = firrtl.invalidvalue : !firrtl.uint<4>
+  %assint = firrtl.asSInt %inv5 : (!firrtl.uint<4>) -> !firrtl.sint<4>
+  firrtl.strictconnect %outs, %assint : !firrtl.sint<4>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
+  // CHECK-NOT firrtl.asUInt
+  %inv6 = firrtl.invalidvalue : !firrtl.sint<4>
+  %asuint = firrtl.asUInt %inv6 : (!firrtl.sint<4>) -> !firrtl.uint<4>
+  firrtl.strictconnect %out, %asuint : !firrtl.uint<4>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
+  // CHECK-NOT firrtl.subfield
+  %inv7 = firrtl.invalidvalue : !firrtl.bundle<a: uint<4>, b: uint<5>>
+  %subfield = firrtl.subfield %inv7[a] : !firrtl.bundle<a: uint<4>, b: uint<5>>
+  firrtl.strictconnect %out, %subfield : !firrtl.uint<4>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
+  // CHECK-NOT firrtl.subindex
+  %inv8 = firrtl.invalidvalue : !firrtl.vector<uint<4>, 6 >
+  %subindex = firrtl.subindex %inv8[2] : !firrtl.vector<uint<4>, 6 >
+  firrtl.strictconnect %out, %subindex : !firrtl.uint<4>
+
+  // CHECK: firrtl.invalidvalue
+  // CHECK-NEXT: firrtl.strictconnect
+
+}
+
 // CHECK-LABEL: firrtl.module @AggregateCreate(
 firrtl.module @AggregateCreate(in %vector_in: !firrtl.vector<uint<1>, 2>,
                                in %bundle_in: !firrtl.bundle<a: uint<1>, b: uint<1>>,


### PR DESCRIPTION
Now that invalid is better defined, we can start propagating it when we can preserver semantics.  This means not breaking the one-op-is-one-consistent-value (e.g. not duplicating).  The only bit mutating op which is touched by this change is not, which is a pure all-bits inversion, which should be safe (tm).