### PR TITLE
[FIRRTL] Remove unused and expensive API, NFC

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -156,11 +156,6 @@ def InstanceOp : HardwareDeclOp<"instance", [
       Operation *moduleOp = node->getModule();
       return dyn_cast_or_null<T>(moduleOp);
     }
-
-    //===------------------------------------------------------------------===//
-    // PortList Methods
-    //===------------------------------------------------------------------===//
-    SmallVector<::circt::hw::PortInfo> getPortList();
   }];
 
   let hasVerifier = true;

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -2092,13 +2092,6 @@ bool ExtClassOp::canDiscardOnUseEmpty() {
 // InstanceOp
 //===----------------------------------------------------------------------===//
 
-SmallVector<::circt::hw::PortInfo> InstanceOp::getPortList() {
-  auto circuit = (*this)->getParentOfType<CircuitOp>();
-  if (!circuit)
-    llvm::report_fatal_error("instance op not in circuit");
-  return circuit.lookupSymbol<hw::PortList>(getModuleNameAttr()).getPortList();
-}
-
 void InstanceOp::build(
     OpBuilder &builder, OperationState &result, TypeRange resultTypes,
     StringRef moduleName, StringRef name, NameKindEnum nameKind,


### PR DESCRIPTION
InstanceOp::getPortList is a foot-gun that walks entire circuits. We could rewrite it with instance graph version but apparently there is no user so just delete it.