### PR TITLE
[Moore] Introduce Mem2Reg to eliminate local variables

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.h
+++ b/include/circt/Dialect/Moore/MooreOps.h
@@ -18,6 +18,7 @@
 #include "circt/Dialect/Moore/MooreTypes.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Interfaces/MemorySlotInterfaces.h"
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/Moore/MooreEnums.h.inc"

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -180,6 +180,7 @@ def ProcedureOp : MooreOp<"procedure", [
 //===----------------------------------------------------------------------===//
 
 def VariableOp : MooreOp<"variable", [
+  DeclareOpInterfaceMethods<PromotableAllocationOpInterface>,
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   OptionalTypesMatchWith<"initial value and variable types match",
     "result", "initial", "cast<RefType>($_self).getNestedType()">
@@ -251,6 +252,7 @@ def NetOp : MooreOp<"net", [
 }
 
 def ReadOp : MooreOp<"read", [
+  DeclareOpInterfaceMethods<PromotableMemOpInterface>,
   TypesMatchWith<"input and result types match",
     "result", "input", "RefType::get(cast<UnpackedType>($_self))">
 ]> {
@@ -291,7 +293,9 @@ def ContinuousAssignOp : AssignOpBase<"assign", [HasParent<"SVModuleOp">]> {
   }];
 }
 
-def BlockingAssignOp : AssignOpBase<"blocking_assign"> {
+def BlockingAssignOp : AssignOpBase<"blocking_assign", [
+  DeclareOpInterfaceMethods<PromotableMemOpInterface>
+]> {
   let summary = "Blocking procedural assignment";
   let description = [{
     A blocking procedural assignment in a sequential block, such as `x = y`. The

--- a/lib/Dialect/Moore/CMakeLists.txt
+++ b/lib/Dialect/Moore/CMakeLists.txt
@@ -19,6 +19,7 @@ add_circt_dialect_library(CIRCTMoore
   CIRCTSupport
   MLIRIR
   MLIRInferTypeOpInterface
+  MLIRMemorySlotInterfaces
 )
 
 add_dependencies(circt-headers MLIRMooreIncGen)

--- a/test/Dialect/Moore/mem2reg.mlir
+++ b/test/Dialect/Moore/mem2reg.mlir
@@ -1,0 +1,35 @@
+// RUN: circt-opt --mem2reg %s | FileCheck %s
+
+// CHECK-LABEL: moore.module @LocalVar() {
+moore.module @LocalVar() {
+// CHECK: %x = moore.variable : <i32>
+// CHECK: %y = moore.variable : <i32>
+// CHECK: %z = moore.variable : <i32>
+%x = moore.variable : <i32>
+%y = moore.variable : <i32>
+%z = moore.variable : <i32>
+moore.procedure always_comb {
+    // CHECK: %0 = moore.read %x : i32
+    // CHECK: %1 = moore.constant 1 : i32
+    // CHECK: %2 = moore.add %0, %1 : i32
+    // CHECK: moore.blocking_assign %z, %2 : i32
+    // CHECK: %3 = moore.constant 1 : i32
+    // CHECK: %4 = moore.add %2, %3 : i32
+    // CHECK: moore.blocking_assign %y, %4 : i32
+    %a = moore.variable : <i32>
+    %0 = moore.read %x : i32
+    %1 = moore.constant 1 : i32
+    %2 = moore.add %0, %1 : i32
+    moore.blocking_assign %a, %2 : i32
+    %3 = moore.read %a : i32
+    moore.blocking_assign %z, %3 : i32
+    %4 = moore.read %a : i32
+    %5 = moore.constant 1 : i32
+    %6 = moore.add %4, %5 : i32
+    moore.blocking_assign %a, %6 : i32
+    %7 = moore.read %a : i32
+    moore.blocking_assign %y, %7 : i32
+}
+// CHECK: moore.output
+moore.output
+}

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -72,6 +72,7 @@ int main(int argc, char **argv) {
 
   // Register test passes
   circt::test::registerAnalysisTestPasses();
+  mlir::registerMem2RegPass();
 
   return mlir::failed(mlir::MlirOptMain(
       argc, argv, "CIRCT modular optimizer driver", registry));

--- a/tools/circt-verilog/CMakeLists.txt
+++ b/tools/circt-verilog/CMakeLists.txt
@@ -6,6 +6,7 @@ llvm_update_compile_flags(circt-verilog)
 
 target_link_libraries(circt-verilog PRIVATE
   CIRCTImportVerilog
+  CIRCTMooreToCore
   CIRCTSupport
   MLIRIR
 )


### PR DESCRIPTION
## Please just view the `MooreOps.cpp` file to check the related implementation.
### First
```
module Foo;
  int x, y;
  always_comb begin
    int a;
    a = x + 1;
    y = a;
  end
endmodule
```
```cpp
/home/phoenix/work/HDLBits/test01.sv:2:7: error: all variables: %0 = "moore.variable"() <{name = "x"}> : () -> !moore.i32
  int x, y;
      ^
/home/phoenix/work/HDLBits/test01.sv:2:10: error: all variables: %1 = "moore.variable"() <{name = "y"}> : () -> !moore.i32
  int x, y;
         ^
/home/phoenix/work/HDLBits/test01.sv:4:9: error: all variables: %2 = "moore.variable"() <{name = "a"}> : () -> !moore.i32
    int a;
        ^
/home/phoenix/work/HDLBits/test01.sv:4:9: error: local varialbes: %2 = "moore.variable"() <{name = "a"}> : () -> !moore.i32
    int a;
        ^
/home/phoenix/work/HDLBits/test01.sv:5:5: error: blocking assignments: %2 = "moore.variable"() <{name = "a"}> : () -> !moore.i32
    a = x + 1;
    ^
/home/phoenix/work/HDLBits/test01.sv:6:5: error: blocking assignments: %2 = "moore.variable"() <{name = "a"}> : () -> !moore.i32
    y = a;
    ^
module {
  moore.module @Foo {
    %x = moore.variable  : !moore.i32
    %y = moore.variable  : !moore.i32
    moore.procedure always_comb {
      %a = moore.variable  : !moore.i32
      %0 = moore.constant 1 : !moore.i32
      %1 = moore.add %x, %0 : !moore.i32
      moore.blocking_assign %a, %1 : !moore.i32
      moore.blocking_assign %y, %a : !moore.i32
    }
  }
}
```
----
# Second
```
module Foo;
  int x, y;
  always_comb begin
    int a;
    a = x + 1;
   // y = a;
  end
endmodule
```
``` cpp
/home/phoenix/work/HDLBits/test01.sv:2:7: error: all variables: %0 = "moore.variable"() <{name = "x"}> : () -> !moore.i32
  int x, y;
      ^
/home/phoenix/work/HDLBits/test01.sv:2:10: error: all variables: %1 = "moore.variable"() <{name = "y"}> : () -> !moore.i32
  int x, y;
         ^
/home/phoenix/work/HDLBits/test01.sv:4:9: error: all variables: %2 = "moore.variable"() <{name = "a"}> : () -> !moore.i32
    int a;
        ^
/home/phoenix/work/HDLBits/test01.sv:4:9: error: local varialbes: %2 = "moore.variable"() <{name = "a"}> : () -> !moore.i32
    int a;
        ^
/home/phoenix/work/HDLBits/test01.sv:5:5: error: blocking assignments: %2 = "moore.variable"() <{name = "a"}> : () -> !moore.i32
    a = x + 1;
    ^
/home/phoenix/work/HDLBits/test01.sv:4:9: error: slot: %3 = "moore.variable"() <{name = "a"}> : () -> !moore.i32
    int a;
        ^
/home/phoenix/work/HDLBits/test01.sv:2:7: error: all variables: %0 = "moore.variable"() <{name = "x"}> : () -> !moore.i32
  int x, y;
      ^
/home/phoenix/work/HDLBits/test01.sv:2:10: error: all variables: %1 = "moore.variable"() <{name = "y"}> : () -> !moore.i32
  int x, y;
         ^
module {
  moore.module @Foo {
    %x = moore.variable  : !moore.i32
    %y = moore.variable  : !moore.i32
    moore.procedure always_comb {
      %0 = moore.constant 1 : !moore.i32
      %1 = moore.add %x, %0 : !moore.i32
    }
  }
}
```