### PR TITLE
[Moore] Move array types into ODS

### DIFF
--- a/include/circt-c/Dialect/Moore.h
+++ b/include/circt-c/Dialect/Moore.h
@@ -40,32 +40,22 @@ MLIR_CAPI_EXPORTED MlirType mooreIntTypeGetLogic(MlirContext ctx,
                                                  unsigned width);
 /// Create a real type.
 MLIR_CAPI_EXPORTED MlirType mooreRealTypeGet(MlirContext ctx);
-/// Create a packed unsized dimension type.
-MLIR_CAPI_EXPORTED MlirType moorePackedUnsizedDimTypeGet(MlirType inner);
-/// Create a packed range dimension type.
-MLIR_CAPI_EXPORTED MlirType moorePackedRangeDimTypeGet(MlirType inner,
-                                                       unsigned size,
-                                                       bool upDir, int offset);
-/// Create a unpacked unsized dimension type.
-MLIR_CAPI_EXPORTED MlirType mooreUnpackedUnsizedDimTypeGet(MlirType inner);
-/// Create a unpacked array dimension type.
-MLIR_CAPI_EXPORTED MlirType mooreUnpackedArrayDimTypeGet(MlirType inner,
-                                                         unsigned size);
-/// Create a unpacked range dimension type.
-MLIR_CAPI_EXPORTED MlirType mooreUnpackedRangeDimTypeGet(MlirType inner,
-                                                         unsigned size,
-                                                         bool upDir,
-                                                         int offset);
-/// Create a unpacked assoc dimension type without index.
-MLIR_CAPI_EXPORTED MlirType mooreUnpackedAssocDimTypeGet(MlirType inner);
-/// Create a unpacked assoc dimension type width index.
-MLIR_CAPI_EXPORTED MlirType
-mooreUnpackedAssocDimTypeGetWithIndex(MlirType inner, MlirType indexType);
-/// Create a unpacked queue dimension type without bound.
-MLIR_CAPI_EXPORTED MlirType mooreUnpackedQueueDimTypeGet(MlirType inner);
-/// Create a unpacked queue dimension type with bound.
-MLIR_CAPI_EXPORTED MlirType
-mooreUnpackedQueueDimTypeGetWithBound(MlirType inner, unsigned bound);
+/// Create a packed open array type.
+MLIR_CAPI_EXPORTED MlirType mooreOpenArrayTypeGet(MlirType elementType);
+/// Create a packed array type.
+MLIR_CAPI_EXPORTED MlirType mooreArrayTypeGet(unsigned size,
+                                              MlirType elementType);
+/// Create an unpacked open array type.
+MLIR_CAPI_EXPORTED MlirType mooreOpenUnpackedArrayTypeGet(MlirType elementType);
+/// Create an unpacked array type.
+MLIR_CAPI_EXPORTED MlirType mooreUnpackedArrayTypeGet(unsigned size,
+                                                      MlirType elementType);
+/// Create an unpacked associative array type.
+MLIR_CAPI_EXPORTED MlirType mooreAssocArrayTypeGet(MlirType elementType,
+                                                   MlirType indexType);
+/// Create an unpacked queue type.
+MLIR_CAPI_EXPORTED MlirType mooreQueueTypeGet(MlirType elementType,
+                                              unsigned bound);
 /// Checks whether the passed UnpackedType is a two-valued type.
 MLIR_CAPI_EXPORTED bool mooreIsTwoValuedType(MlirType type);
 /// Checks whether the passed UnpackedType is a four-valued type.

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -117,6 +117,162 @@ def RealType : MooreTypeDef<"Real", [], "moore::UnpackedType"> {
 
 
 //===----------------------------------------------------------------------===//
+// Arrays
+//===----------------------------------------------------------------------===//
+
+def ArrayType : MooreTypeDef<"Array", [], "moore::PackedType"> {
+  let mnemonic = "array";
+  let summary = "a packed array type";
+  let description = [{
+    A packed array with a fixed number of elements. This type represents packed
+    range dimensions (`[a:b]`) in SystemVerilog.
+
+    | Verilog   | Moore Dialect         |
+    |-----------|-----------------------|
+    | `T [3:0]` | `!moore.array<4 x T>` |
+    | `T [2:4]` | `!moore.array<3 x T>` |
+  }];
+  let parameters = (ins "unsigned":$size, "PackedType":$elementType);
+  let assemblyFormat = [{
+    `<` $size `x` $elementType `>`
+  }];
+  let builders = [
+    AttrBuilderWithInferredContext<
+      (ins "unsigned":$size, "PackedType":$elementType), [{
+        return $_get(elementType.getContext(), size, elementType);
+      }]>
+  ];
+}
+
+def UnpackedArrayType : MooreTypeDef<"UnpackedArray", [],
+  "moore::UnpackedType"
+> {
+  let mnemonic = "uarray";
+  let summary = "an unpacked array type";
+  let description = [{
+    An unpacked array with a fixed number of elements. This type represents
+    unpacked range dimensions (`[a:b]`) and unpacked array dimensions (`[a]`) in
+    SystemVerilog.
+
+    | Verilog       | Moore Dialect          |
+    |---------------|------------------------|
+    | `T foo [3:0]` | `!moore.uarray<4 x T>` |
+    | `T foo [2:4]` | `!moore.uarray<3 x T>` |
+    | `T foo [2]`   | `!moore.uarray<2 x T>` |
+  }];
+  let parameters = (ins "unsigned":$size, "UnpackedType":$elementType);
+  let assemblyFormat = [{
+    `<` $size `x` $elementType `>`
+  }];
+  let builders = [
+    AttrBuilderWithInferredContext<
+      (ins "unsigned":$size, "UnpackedType":$elementType), [{
+        return $_get(elementType.getContext(), size, elementType);
+      }]>
+  ];
+}
+
+def OpenArrayType : MooreTypeDef<"OpenArray", [], "moore::PackedType"> {
+  let mnemonic = "open_array";
+  let summary = "an open packed array type";
+  let description = [{
+    A packed array with an unspecified number of elements. This type represents
+    unsized/open packed arrays (`[]`) in SystemVerilog.
+
+    | Verilog | Moore Dialect          |
+    |---------|------------------------|
+    | `T []`  | `!moore.open_array<T>` |
+  }];
+  let parameters = (ins "PackedType":$elementType);
+  let assemblyFormat = [{
+    `<` $elementType `>`
+  }];
+  let builders = [
+    AttrBuilderWithInferredContext<
+      (ins "PackedType":$elementType), [{
+        return $_get(elementType.getContext(), elementType);
+      }]>
+  ];
+}
+
+def OpenUnpackedArrayType : MooreTypeDef<"OpenUnpackedArray", [],
+  "moore::UnpackedType"
+> {
+  let mnemonic = "open_uarray";
+  let summary = "an open unpacked array type";
+  let description = [{
+    An unpacked array with an unspecified number of elements. This type
+    represents unsized/open unpacked arrays (`[]`) in SystemVerilog.
+
+    | Verilog    | Moore Dialect           |
+    |------------|-------------------------|
+    | `T foo []` | `!moore.open_uarray<T>` |
+  }];
+  let parameters = (ins "UnpackedType":$elementType);
+  let assemblyFormat = [{
+    `<` $elementType `>`
+  }];
+  let builders = [
+    AttrBuilderWithInferredContext<
+      (ins "UnpackedType":$elementType), [{
+        return $_get(elementType.getContext(), elementType);
+      }]>
+  ];
+}
+
+def AssocArrayType : MooreTypeDef<"AssocArray", [], "moore::UnpackedType"> {
+  let mnemonic = "assoc_array";
+  let summary = "an associative array type";
+  let description = [{
+    An associative array. This type represents associative arrays (`[T]`) in
+    SystemVerilog.
+
+    | Verilog     | Moore Dialect              |
+    |-------------|----------------------------|
+    | `T foo [K]` | `!moore.assoc_array<T, K>` |
+  }];
+  let parameters = (ins "UnpackedType":$elementType, "UnpackedType":$indexType);
+  let assemblyFormat = [{
+    `<` $elementType `,` $indexType `>`
+  }];
+  let builders = [
+    AttrBuilderWithInferredContext<
+      (ins "UnpackedType":$elementType, "UnpackedType":$indexType), [{
+        return $_get(elementType.getContext(), elementType, indexType);
+      }]>
+  ];
+}
+
+def QueueType : MooreTypeDef<"Queue", [], "moore::UnpackedType"> {
+  let mnemonic = "queue";
+  let summary = "a queue type";
+  let description = [{
+    A queue with an optional upper bound on the number of elements that it can
+    hold. This type represents queues (`[$]` and `[$:a]`) in SystemVerilog. A
+    `bound` of 0 indicates an unbounded queue.
+
+    | Verilog        | Moore Dialect         |
+    |----------------|-----------------------|
+    | `T foo [$]`    | `!moore.queue<T>`     |
+    | `T foo [$:42]` | `!moore.queue<T, 42>` |
+  }];
+  let parameters = (ins
+    "UnpackedType":$elementType,
+    "unsigned":$bound
+  );
+  let assemblyFormat = [{
+    `<` $elementType `,` $bound `>`
+  }];
+  let builders = [
+    AttrBuilderWithInferredContext<
+      (ins "UnpackedType":$elementType, "unsigned":$bound), [{
+        return $_get(elementType.getContext(), elementType, bound);
+      }]>
+  ];
+}
+
+
+//===----------------------------------------------------------------------===//
 // Constraints
 //===----------------------------------------------------------------------===//
 

--- a/lib/CAPI/Dialect/Moore.cpp
+++ b/lib/CAPI/Dialect/Moore.cpp
@@ -61,65 +61,37 @@ MlirType mooreRealTypeGet(MlirContext ctx) {
   return wrap(RealType::get(unwrap(ctx)));
 }
 
-/// Create a packed unsized dimension type.
-MlirType moorePackedUnsizedDimTypeGet(MlirType inner) {
-  return wrap(PackedUnsizedDim::get(cast<PackedType>(unwrap(inner))));
+MlirType mooreOpenArrayTypeGet(MlirType elementType) {
+  return wrap(OpenArrayType::get(cast<PackedType>(unwrap(elementType))));
 }
 
-/// Create a packed range dimension type.
-MlirType moorePackedRangeDimTypeGet(MlirType inner, unsigned size, bool upDir,
-                                    int offset) {
-  RangeDir dir = upDir ? RangeDir::Up : RangeDir::Down;
+MlirType mooreArrayTypeGet(unsigned size, MlirType elementType) {
+  return wrap(ArrayType::get(size, cast<PackedType>(unwrap(elementType))));
+}
+
+MlirType mooreOpenUnpackedArrayTypeGet(MlirType elementType) {
   return wrap(
-      PackedRangeDim::get(cast<PackedType>(unwrap(inner)), size, dir, offset));
+      OpenUnpackedArrayType::get(cast<UnpackedType>(unwrap(elementType))));
 }
 
-/// Create a unpacked unsized dimension type.
-MlirType mooreUnpackedUnsizedDimTypeGet(MlirType inner) {
-  return wrap(UnpackedUnsizedDim::get(cast<UnpackedType>(unwrap(inner))));
+MlirType mooreUnpackedArrayTypeGet(unsigned size, MlirType elementType) {
+  return wrap(
+      UnpackedArrayType::get(size, cast<UnpackedType>(unwrap(elementType))));
 }
 
-/// Create a unpacked array dimension type.
-MlirType mooreUnpackedArrayDimTypeGet(MlirType inner, unsigned size) {
-  return wrap(UnpackedArrayDim::get(cast<UnpackedType>(unwrap(inner)), size));
+MlirType mooreAssocArrayTypeGet(MlirType elementType, MlirType indexType) {
+  return wrap(AssocArrayType::get(cast<UnpackedType>(unwrap(elementType)),
+                                  cast<UnpackedType>(unwrap(indexType))));
 }
 
-/// Create a unpacked range dimension type.
-MlirType mooreUnpackedRangeDimTypeGet(MlirType inner, unsigned size, bool upDir,
-                                      int offset) {
-  RangeDir dir = upDir ? RangeDir::Up : RangeDir::Down;
-  return wrap(UnpackedRangeDim::get(cast<UnpackedType>(unwrap(inner)), size,
-                                    dir, offset));
+MlirType mooreQueueTypeGet(MlirType elementType, unsigned bound) {
+  return wrap(QueueType::get(cast<UnpackedType>(unwrap(elementType)), bound));
 }
 
-/// Create a unpacked assoc dimension type without index.
-MlirType mooreUnpackedAssocDimTypeGet(MlirType inner) {
-  return wrap(UnpackedAssocDim::get(cast<UnpackedType>(unwrap(inner))));
-}
-
-/// Create a unpacked assoc dimension type with index.
-MlirType mooreUnpackedAssocDimTypeGetWithIndex(MlirType inner,
-                                               MlirType indexType) {
-  return wrap(UnpackedAssocDim::get(cast<UnpackedType>(unwrap(inner)),
-                                    cast<UnpackedType>(unwrap(indexType))));
-}
-
-/// Create a unpacked queue dimension type without bound.
-MlirType mooreUnpackedQueueDimTypeGet(MlirType inner) {
-  return wrap(UnpackedQueueDim::get(cast<UnpackedType>(unwrap(inner))));
-}
-
-/// Create a unpacked queue dimension type with bound.
-MlirType mooreUnpackedQueueDimTypeGetWithBound(MlirType inner, unsigned bound) {
-  return wrap(UnpackedQueueDim::get(cast<UnpackedType>(unwrap(inner)), bound));
-}
-
-/// Checks whether the passed UnpackedType is a two-valued type.
 bool mooreIsTwoValuedType(MlirType type) {
   return cast<UnpackedType>(unwrap(type)).getDomain() == Domain::TwoValued;
 }
 
-/// Checks whether the passed UnpackedType is a four-valued type.
 bool mooreIsFourValuedType(MlirType type) {
   return cast<UnpackedType>(unwrap(type)).getDomain() == Domain::FourValued;
 }

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -49,17 +49,16 @@ struct TypeVisitor {
     if (!innerType)
       return {};
     // The Slang frontend guarantees the inner type to be packed.
-    auto packedInnerType = cast<moore::PackedType>(innerType);
-    return moore::PackedRangeDim::get(
-        packedInnerType, moore::Range(type.range.left, type.range.right));
+    return moore::ArrayType::get(type.range.width(),
+                                 cast<moore::PackedType>(innerType));
   }
 
   Type visit(const slang::ast::QueueType &type) {
     auto innerType = type.elementType.visit(*this);
     if (!innerType)
       return {};
-    return moore::UnpackedQueueDim::get(cast<moore::UnpackedType>(innerType),
-                                        type.maxBound);
+    return moore::QueueType::get(cast<moore::UnpackedType>(innerType),
+                                 type.maxBound);
   }
 
   Type visit(const slang::ast::AssociativeArrayType &type) {
@@ -69,24 +68,24 @@ struct TypeVisitor {
     auto indexType = type.indexType->visit(*this);
     if (!indexType)
       return {};
-    return moore::UnpackedAssocDim::get(cast<moore::UnpackedType>(innerType),
-                                        cast<moore::UnpackedType>(indexType));
+    return moore::AssocArrayType::get(cast<moore::UnpackedType>(innerType),
+                                      cast<moore::UnpackedType>(indexType));
   }
 
   Type visit(const slang::ast::FixedSizeUnpackedArrayType &type) {
     auto innerType = type.elementType.visit(*this);
     if (!innerType)
       return {};
-    return moore::UnpackedRangeDim::get(
-        cast<moore::UnpackedType>(innerType),
-        moore::Range(type.range.left, type.range.right));
+    return moore::UnpackedArrayType::get(type.range.width(),
+                                         cast<moore::UnpackedType>(innerType));
   }
 
   Type visit(const slang::ast::DynamicArrayType &type) {
     auto innerType = type.elementType.visit(*this);
     if (!innerType)
       return {};
-    return moore::UnpackedUnsizedDim::get(cast<moore::UnpackedType>(innerType));
+    return moore::OpenUnpackedArrayType::get(
+        cast<moore::UnpackedType>(innerType));
   }
 
   // Handle type defs.

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -415,16 +415,6 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
     return mlir::IntegerType::get(type.getContext(), type.getWidth());
   });
 
-  // Directly map simple bit vector types to a compact integer type. This needs
-  // to be added after all of the other conversions above, such that SBVs
-  // conversion gets tried first before any of the others.
-  typeConverter.addConversion([&](UnpackedType type) -> std::optional<Type> {
-    if (isa<UnpackedRangeDim, PackedRangeDim>(type))
-      return mlir::IntegerType::get(type.getContext(),
-                                    type.getBitSize().value());
-    return std::nullopt;
-  });
-
   // Valid target types.
   typeConverter.addConversion([](mlir::IntegerType type) { return type; });
 }

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -292,7 +292,7 @@ module Expressions;
   // CHECK: %b = moore.variable : !moore.i32
   // CHECK: %c = moore.variable : !moore.i32
   // CHECK: %u = moore.variable : !moore.i32
-  // CHECK: %v = moore.variable : !moore.packed<range<i4, 1:0>>
+  // CHECK: %v = moore.variable : !moore.array<2 x !moore.i4>
   // CHECK: %d = moore.variable : !moore.l32
   // CHECK: %e = moore.variable : !moore.l32
   // CHECK: %f = moore.variable : !moore.l32
@@ -364,9 +364,9 @@ module Expressions;
     // CHECK: moore.extract %vec_1 from %[[VAL_2]] : !moore.l32, !moore.i32 -> !moore.l1
     y = vec_1[1*a-:1];
     // CHECK: %[[VAL_1:.*]] = moore.constant 3 : !moore.i32
-    // CHECK: %[[VAL_2:.*]] = moore.extract %arr from %[[VAL_1]] : !moore.unpacked<range<range<i4, 2:7>, 1:3>>, !moore.i32 -> !moore.unpacked<range<i4, 2:7>>
+    // CHECK: %[[VAL_2:.*]] = moore.extract %arr from %[[VAL_1]] : !moore.uarray<3 x !moore.uarray<6 x !moore.i4>>, !moore.i32 -> !moore.uarray<6 x !moore.i4>
     // CHECK: %[[VAL_3:.*]] = moore.constant 7 : !moore.i32
-    // CHECK: %[[VAL_4:.*]] = moore.extract %[[VAL_2]] from %[[VAL_3]] : !moore.unpacked<range<i4, 2:7>>, !moore.i32 -> !moore.i4
+    // CHECK: %[[VAL_4:.*]] = moore.extract %[[VAL_2]] from %[[VAL_3]] : !moore.uarray<6 x !moore.i4>, !moore.i32 -> !moore.i4
     // CHECK: %[[VAL_5:.*]] = moore.constant 3 : !moore.i32
     // CHECK: moore.extract %[[VAL_4]] from %[[VAL_5]] : !moore.i4, !moore.i32 -> !moore.i2
     s = arr[3][7][4:3];
@@ -381,7 +381,7 @@ module Expressions;
     c = +a;
     // CHECK: moore.neg %a : !moore.i32
     c = -a;
-    // CHECK: [[TMP1:%.+]] = moore.conversion %v : !moore.packed<range<i4, 1:0>> -> !moore.i32
+    // CHECK: [[TMP1:%.+]] = moore.conversion %v : !moore.array<2 x !moore.i4> -> !moore.i32
     // CHECK: [[TMP2:%.+]] = moore.neg [[TMP1]] : !moore.i32
     // CHECK: [[TMP3:%.+]] = moore.conversion [[TMP2]] : !moore.i32 -> !moore.i32
     c = -v;
@@ -441,7 +441,7 @@ module Expressions;
     // CHECK: moore.add %a, %b : !moore.i32
     c = a + b;
     // CHECK: [[TMP1:%.+]] = moore.conversion %a : !moore.i32 -> !moore.i32
-    // CHECK: [[TMP2:%.+]] = moore.conversion %v : !moore.packed<range<i4, 1:0>> -> !moore.i32
+    // CHECK: [[TMP2:%.+]] = moore.conversion %v : !moore.array<2 x !moore.i4> -> !moore.i32
     // CHECK: [[TMP3:%.+]] = moore.add [[TMP1]], [[TMP2]] : !moore.i32
     // CHECK: [[TMP4:%.+]] = moore.conversion [[TMP3]] : !moore.i32 -> !moore.i32
     c = a + v;

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -76,34 +76,39 @@ module IntAtoms;
   time signed s8;
 endmodule
 
-// CHECK-LABEL: moore.module @MultiPackedRangeDim
-module MultiPackedRangeDim;
-  // CHECK-NEXT: %v0 = moore.variable : !moore.packed<range<l3, 5:0>>
-  // CHECK-NEXT: %v1 = moore.variable : !moore.packed<range<l3, 0:5>>
-  logic [5:0][2:0] v0;
-  logic [0:5][2:0] v1;
-endmodule
+// CHECK-LABEL: moore.module @Dimensions
+module Dimensions;
+  // CHECK-NEXT: %p0 = moore.variable : !moore.l3
+  logic [2:0] p0;
+  // CHECK-NEXT: %p1 = moore.variable : !moore.l3
+  logic [0:2] p1;
+  // CHECK-NEXT: %p2 = moore.variable : !moore.array<6 x !moore.l3>
+  logic [5:0][2:0] p2;
+  // CHECK-NEXT: %p3 = moore.variable : !moore.array<6 x !moore.l3>
+  logic [0:5][2:0] p3;
 
-// CHECK-LABEL: moore.module @MultiUnpackedRangeDim
-module MultiUnpackedRangeDim;
-  // CHECK-NEXT: %v0 = moore.variable : !moore.unpacked<range<range<l1, 2:0>, 5:0>>
-  // CHECK-NEXT: %v1 = moore.variable : !moore.unpacked<range<range<l1, 2:0>, 0:5>>
-  logic v0 [5:0][2:0];
-  logic v1 [0:5][2:0];
-endmodule
-
-// CHECK-LABEL: moore.module @MultiUnpackedUnsizedDim
-module MultiUnpackedUnsizedDim;
-  // CHECK-NEXT: %v0 = moore.variable : !moore.unpacked<unsized<unsized<l1>>>
-  logic v0 [][];
-endmodule
-
-// CHECK-LABEL: moore.module @PackedRangeDim
-module PackedRangeDim;
-  // CHECK-NEXT: %d0 = moore.variable : !moore.l3
-  // CHECK-NEXT: %d1 = moore.variable : !moore.l3
-  logic [2:0] d0;
-  logic [0:2] d1;
+  // CHECK-NEXT: %u0 = moore.variable : !moore.uarray<3 x !moore.l1>
+  logic u0 [2:0];
+  // CHECK-NEXT: %u1 = moore.variable : !moore.uarray<3 x !moore.l1>
+  logic u1 [0:2];
+  // CHECK-NEXT: %u2 = moore.variable : !moore.uarray<6 x !moore.uarray<3 x !moore.l1>>
+  logic u2 [5:0][2:0];
+  // CHECK-NEXT: %u3 = moore.variable : !moore.uarray<6 x !moore.uarray<3 x !moore.l1>>
+  logic u3 [0:5][2:0];
+  // CHECK-NEXT: %u4 = moore.variable : !moore.open_uarray<!moore.l1>
+  logic u4 [];
+  // CHECK-NEXT: %u5 = moore.variable : !moore.open_uarray<!moore.open_uarray<!moore.l1>>
+  logic u5 [][];
+  // CHECK-NEXT: %u6 = moore.variable : !moore.uarray<42 x !moore.l1>
+  logic u6 [42];
+  // CHECK-NEXT: %u7 = moore.variable : !moore.assoc_array<!moore.l1, !moore.i32>
+  logic u7 [int];
+  // CHECK-NEXT: %u8 = moore.variable : !moore.assoc_array<!moore.l1, !moore.l1>
+  logic u8 [logic];
+  //CHECK-NEXT: %u9 = moore.variable : !moore.queue<!moore.l1, 0>
+  logic u9 [$];
+  //CHECK-NEXT: %u10 = moore.variable : !moore.queue<!moore.l1, 2>
+  logic u10 [$:2];
 endmodule
 
 // CHECK-LABEL: moore.module @RealType
@@ -122,7 +127,7 @@ module Structs;
   typedef struct { byte x; int y; } myStructB;
 
   // CHECK-NEXT: %s0 = moore.variable : !moore.packed<struct<{foo: i1, bar: l1}>>
-  // CHECK-NEXT: %s1 = moore.variable : !moore.unpacked<struct<{many: assoc<i1, i32>}>>
+  // CHECK-NEXT: %s1 = moore.variable : !moore.unpacked<struct<{many: assoc_array<!moore.i1, !moore.i32>}>>
   // CHECK-NEXT: %s2 = moore.variable : !moore.packed<struct<{a: i8, b: i32}>>
   // CHECK-NEXT: %s3 = moore.variable : !moore.unpacked<struct<{x: i8, y: i32}>>
   struct packed { bit foo; logic bar; } s0;
@@ -137,37 +142,7 @@ module Typedefs;
   typedef logic myType2 [2:0];
 
   // CHECK-NEXT: %v0 = moore.variable : !moore.l3
-  // CHECK-NEXT: %v1 = moore.variable : !moore.unpacked<range<l1, 2:0>>
+  // CHECK-NEXT: %v1 = moore.variable : !moore.uarray<3 x !moore.l1>
   myType1 v0;
   myType2 v1;
-endmodule
-
-// CHECK-LABEL: moore.module @UnpackedAssocDim
-module UnpackedAssocDim;
-  // CHECK-NEXT: %d0 = moore.variable : !moore.unpacked<assoc<l1, i32>>
-  // CHECK-NEXT: %d1 = moore.variable : !moore.unpacked<assoc<l1, l1>>
-  logic d0 [int];
-  logic d1 [logic];
-endmodule
-
-// CHECK-LABEL: moore.module @UnpackedQueueDim
-module UnpackedQueueDim;
-  //CHECK-NEXT: %d0 = moore.variable : !moore.unpacked<queue<l1, 0>>
-  //CHECK-NEXT: %d1 = moore.variable : !moore.unpacked<queue<l1, 2>>
-  logic d0[$];
-  logic d1[$:2];
-endmodule
-
-// CHECK-LABEL: moore.module @UnpackedRangeDim
-module UnpackedRangeDim;
-  // CHECK-NEXT: %d0 = moore.variable : !moore.unpacked<range<l1, 2:0>>
-  // CHECK-NEXT: %d1 = moore.variable : !moore.unpacked<range<l1, 0:2>>
-  logic d0 [2:0];
-  logic d1 [0:2];
-endmodule
-
-// CHECK-LABEL: moore.module @UnpackedUnsizedDim
-module UnpackedUnsizedDim;
-  // CHECK-NEXT: %d0 = moore.variable : !moore.unpacked<unsized<l1>>
-  logic d0 [];
 endmodule

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -76,7 +76,7 @@ moore.module @Expressions {
   %int2 = moore.variable : !moore.i32
   %integer = moore.variable : !moore.l32
   %integer2 = moore.variable : !moore.l32
-  %arr = moore.variable : !moore.unpacked<range<range<i8, 0:3>, 0:1>>
+  %arr = moore.variable : !moore.uarray<2 x !moore.uarray<4 x !moore.i8>>
 
   // CHECK: moore.constant 0 : !moore.i32
   moore.constant 0 : !moore.i32
@@ -184,13 +184,13 @@ moore.module @Expressions {
   // CHECK: moore.extract %b5 from %b1 : !moore.i5, !moore.i1 -> !moore.i1
   moore.extract %b5 from %b1 : !moore.i5, !moore.i1 -> !moore.i1
   // CHECK: [[VAL1:%.*]] = moore.constant 0 : !moore.i32
-  // CHECK: [[VAL2:%.*]] = moore.extract %arr from [[VAL1]] : !moore.unpacked<range<range<i8, 0:3>, 0:1>>, !moore.i32 -> !moore.unpacked<range<i8, 0:3>>
+  // CHECK: [[VAL2:%.*]] = moore.extract %arr from [[VAL1]] : !moore.uarray<2 x !moore.uarray<4 x !moore.i8>>, !moore.i32 -> !moore.uarray<4 x !moore.i8>
   %1 = moore.constant 0 : !moore.i32
-  %2 = moore.extract %arr from %1 : !moore.unpacked<range<range<i8, 0:3>, 0:1>>, !moore.i32 -> !moore.unpacked<range<i8, 0:3>>
+  %2 = moore.extract %arr from %1 : !moore.uarray<2 x !moore.uarray<4 x !moore.i8>>, !moore.i32 -> !moore.uarray<4 x !moore.i8>
   // CHECK: [[VAL3:%.*]] = moore.constant 3 : !moore.i32
-  // CHECK: [[VAL4:%.*]] = moore.extract [[VAL2]] from [[VAL3]] : !moore.unpacked<range<i8, 0:3>>, !moore.i32 -> !moore.i8
+  // CHECK: [[VAL4:%.*]] = moore.extract [[VAL2]] from [[VAL3]] : !moore.uarray<4 x !moore.i8>, !moore.i32 -> !moore.i8
   %3 = moore.constant 3 : !moore.i32
-  %4 = moore.extract %2 from %3 : !moore.unpacked<range<i8, 0:3>>, !moore.i32 -> !moore.i8
+  %4 = moore.extract %2 from %3 : !moore.uarray<4 x !moore.i8>, !moore.i32 -> !moore.i8
   // CHECK: [[VAL5:%.*]] = moore.constant 2 : !moore.i32
   // CHECK: moore.extract [[VAL4]] from [[VAL5]] : !moore.i8, !moore.i32 -> !moore.i5
   %5 = moore.constant 2 : !moore.i32

--- a/test/Dialect/Moore/types-errors.mlir
+++ b/test/Dialect/Moore/types-errors.mlir
@@ -1,12 +1,15 @@
 // RUN: circt-opt --verify-diagnostics --split-input-file %s
 
-// expected-error @+1 {{ambiguous packing; wrap `unsized` in `packed<...>` or `unpacked<...>` to disambiguate}}
-func.func @Foo(%arg0: !moore.unsized<i1>) { return }
-
-// -----
-// expected-error @+1 {{ambiguous packing; wrap `range` in `packed<...>` or `unpacked<...>` to disambiguate}}
-func.func @Foo(%arg0: !moore.range<i1, 3:0>) { return }
-
 // -----
 // expected-error @+1 {{ambiguous packing; wrap `struct` in `packed<...>` or `unpacked<...>` to disambiguate}}
 func.func @Foo(%arg0: !moore.struct<{}, loc(unknown)>) { return }
+
+// -----
+// expected-error @below {{invalid kind of type specified}}
+// expected-error @below {{parameter 'elementType' which is to be a `PackedType`}}
+unrealized_conversion_cast to !moore.array<4 x !moore.string>
+
+// -----
+// expected-error @below {{invalid kind of type specified}}
+// expected-error @below {{parameter 'elementType' which is to be a `PackedType`}}
+unrealized_conversion_cast to !moore.open_array<!moore.string>

--- a/test/Dialect/Moore/types.mlir
+++ b/test/Dialect/Moore/types.mlir
@@ -1,54 +1,39 @@
 // RUN: circt-opt %s | circt-opt | FileCheck %s
 
-// CHECK-LABEL: func @UnitTypes(
-func.func @UnitTypes(
-  // CHECK-SAME: %arg0: !moore.void
-  // CHECK-SAME: %arg1: !moore.string
-  // CHECK-SAME: %arg2: !moore.chandle
-  // CHECK-SAME: %arg3: !moore.event
-  %arg0: !moore.void,
-  %arg1: !moore.string,
-  %arg2: !moore.chandle,
-  %arg3: !moore.event
-) { return }
+// CHECK: !moore.void
+unrealized_conversion_cast to !moore.void
+// CHECK: !moore.string
+unrealized_conversion_cast to !moore.string
+// CHECK: !moore.chandle
+unrealized_conversion_cast to !moore.chandle
+// CHECK: !moore.event
+unrealized_conversion_cast to !moore.event
 
-// CHECK-LABEL: func @IntTypes(
-func.func @IntTypes(
-  // CHECK-SAME: %arg0: !moore.i42
-  // CHECK-SAME: %arg1: !moore.l42
-  %arg0: !moore.i42,
-  %arg1: !moore.l42
-) { return }
+// CHECK: !moore.i42
+unrealized_conversion_cast to !moore.i42
+// CHECK: !moore.l42
+unrealized_conversion_cast to !moore.l42
 
-// CHECK-LABEL: func @RealTypes(
-func.func @RealTypes(
-  // CHECK-SAME: %arg0: !moore.real
-  %arg0: !moore.real
-) { return }
+// CHECK: !moore.real
+unrealized_conversion_cast to !moore.real
 
-// CHECK-LABEL: func @DimTypes(
-func.func @DimTypes(
-  // CHECK-SAME: %arg0: !moore.packed<unsized<i1>>,
-  // CHECK-SAME: %arg1: !moore.packed<range<i1, 4:-5>>,
-  %arg0: !moore.packed<unsized<i1>>,
-  %arg1: !moore.packed<range<i1, 4:-5>>,
-  // CHECK-SAME: %arg2: !moore.unpacked<unsized<i1>>,
-  // CHECK-SAME: %arg3: !moore.unpacked<array<i1, 42>>,
-  // CHECK-SAME: %arg4: !moore.unpacked<range<i1, 4:-5>>,
-  // CHECK-SAME: %arg5: !moore.unpacked<assoc<i1>>,
-  // CHECK-SAME: %arg6: !moore.unpacked<assoc<i1, string>>,
-  // CHECK-SAME: %arg7: !moore.unpacked<queue<i1>>,
-  // CHECK-SAME: %arg8: !moore.unpacked<queue<i1, 9001>>
-  %arg2: !moore.unpacked<unsized<i1>>,
-  %arg3: !moore.unpacked<array<i1, 42>>,
-  %arg4: !moore.unpacked<range<i1, 4:-5>>,
-  %arg5: !moore.unpacked<assoc<i1>>,
-  %arg6: !moore.unpacked<assoc<i1, string>>,
-  %arg7: !moore.unpacked<queue<i1>>,
-  %arg8: !moore.unpacked<queue<i1, 9001>>
-) {
-  return
-}
+// Packed Arrays
+// CHECK: !moore.array<4 x !moore.i42>
+unrealized_conversion_cast to !moore.array<4 x !moore.i42>
+// CHECK: !moore.open_array<!moore.i42>
+unrealized_conversion_cast to !moore.open_array<!moore.i42>
+
+// Unpacked arrays
+// CHECK: !moore.uarray<4 x !moore.i42>
+unrealized_conversion_cast to !moore.uarray<4 x !moore.i42>
+// CHECK: !moore.uarray<4 x !moore.string>
+unrealized_conversion_cast to !moore.uarray<4 x !moore.string>
+// CHECK: !moore.open_uarray<!moore.string>
+unrealized_conversion_cast to !moore.open_uarray<!moore.string>
+// CHECK: !moore.assoc_array<!moore.string, !moore.chandle>
+unrealized_conversion_cast to !moore.assoc_array<!moore.string, !moore.chandle>
+// CHECK: !moore.queue<!moore.string, 42>
+unrealized_conversion_cast to !moore.queue<!moore.string, 42>
 
 // CHECK-LABEL: func @StructTypes(
 func.func @StructTypes(


### PR DESCRIPTION
Move the definitions of all array types from C++ land into `MooreTypes.td`. This removes a significant amount of redundant code and simplifies the dialect's type system.

Replace packed and unpacked ranges (`T [4:3]` or `T [2:4]`) with a new type that discards the directionality and offset of the range. This information is no longer needed at the IR level. Any meaning that the offsets have can be encoded in the corresponding ops. Both ranges are now represented as `array<2 x T>` and `array<3 x T>`, respectively.

Combine unpacked ranges (`T foo [6:2]`) and unpacked arrays (`T foo [42]`) into a single `uarray<N x T>` type.