### PR TITLE
[Moore] Support stripped type parsing and printing

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -236,7 +236,7 @@ def ReadLValueOp : MooreOp<"read_lvalue", [SameOperandsAndResultType]> {
 
 class AssignOpBase<string mnemonic, list<Trait> traits = []> :
     MooreOp<mnemonic, traits # [SameTypeOperands]> {
-  let arguments = (ins AnyType:$dst, AnyType:$src);
+  let arguments = (ins UnpackedType:$dst, UnpackedType:$src);
   let assemblyFormat = [{
     $dst `,` $src attr-dict `:` type($src)
   }];
@@ -262,7 +262,10 @@ def BlockingAssignOp : AssignOpBase<"blocking_assign"> {
 
     See IEEE 1800-2017 § 10.4.1 "Blocking procedural assignments".
   }];
-  let arguments = (ins Arg<AnyType, "", [MemWrite]>:$dst, AnyType:$src);
+  let arguments = (ins
+    Arg<UnpackedType, "", [MemWrite]>:$dst,
+    UnpackedType:$src
+  );
 }
 
 def NonBlockingAssignOp : AssignOpBase<"nonblocking_assign"> {
@@ -285,7 +288,7 @@ def NonBlockingAssignOp : AssignOpBase<"nonblocking_assign"> {
 def ConstantOp : MooreOp<"constant", [Pure]> {
   let summary = "A constant integer value";
   let arguments = (ins APIntAttr:$value);
-  let results = (outs SimpleBitVectorType:$result);
+  let results = (outs IntType:$result);
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
   let builders = [
@@ -721,10 +724,10 @@ def ConcatOp : MooreOp<"concat", [
     is the sum of the sizes of all operands. If any of the operands is
     four-valued, the result is four-valued; otherwise it is two-valued.
   }];
-  let arguments = (ins Variadic<SimpleBitVectorType>:$values);
-  let results = (outs SimpleBitVectorType:$result);
+  let arguments = (ins Variadic<IntType>:$values);
+  let results = (outs IntType:$result);
   let assemblyFormat = [{
-    $values attr-dict `:` functional-type($values, $result)
+    $values attr-dict `:` `(` type($values) `)` `->` type($result)
   }];
 }
 
@@ -746,10 +749,10 @@ def ReplicateOp : MooreOp<"replicate", [
     ```
     See IEEE 1800-2017 §11.4.12 "Concatenation operators".
   }];
-  let arguments = (ins SimpleBitVectorType:$value);
-  let results = (outs SimpleBitVectorType:$result);
+  let arguments = (ins IntType:$value);
+  let results = (outs IntType:$result);
   let assemblyFormat = [{
-    $value attr-dict `:` functional-type($value, $result)
+    $value attr-dict `:` type($value) `->` type($result)
   }];
 }
 

--- a/include/circt/Dialect/Moore/MooreTypes.h
+++ b/include/circt/Dialect/Moore/MooreTypes.h
@@ -54,12 +54,6 @@ namespace detail {
 struct StructTypeStorage;
 } // namespace detail
 
-/// Base class for all SystemVerilog types in the Moore dialect.
-class SVType : public Type {
-protected:
-  using Type::Type;
-};
-
 //===----------------------------------------------------------------------===//
 // Unpacked Type
 //===----------------------------------------------------------------------===//
@@ -99,7 +93,7 @@ class UnpackedStructType;
 /// - Ranges (`[x:y]`)
 /// - Associative (`[T]` or `[*]`)
 /// - Queues (`[$]` or `[$:x]`)
-class UnpackedType : public SVType {
+class UnpackedType : public Type {
 public:
   static bool classof(Type type) {
     return llvm::isa<PackedType, StringType, ChandleType, EventType, RealType,
@@ -116,8 +110,13 @@ public:
   /// a queue, or the core type itself has no known size.
   std::optional<unsigned> getBitSize() const;
 
+  // Support parsing and printing of unpacked types in their prefix-stripped
+  // form.
+  static Type parse(mlir::AsmParser &odsParser);
+  void print(mlir::AsmPrinter &odsPrinter) const;
+
 protected:
-  using SVType::SVType;
+  using Type::Type;
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -62,7 +62,7 @@ void ConstantOp::print(OpAsmPrinter &p) {
   p.printAttributeWithoutType(getValueAttr());
   p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{"value"});
   p << " : ";
-  p.printType(getType());
+  p.printStrippedAttrOrType(getType());
 }
 
 ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
@@ -76,7 +76,7 @@ ParseResult ConstantOp::parse(OpAsmParser &parser, OperationState &result) {
 
   // Parse the result type.
   IntType type;
-  if (parser.parseType(type))
+  if (parser.parseCustomTypeWithFallback(type))
     return failure();
 
   // Extend or truncate the constant value to match the size of the type.

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -39,42 +39,42 @@ endmodule
 
 // CHECK-LABEL: moore.module @Basic
 module Basic;
-  // CHECK: %v0 = moore.variable : !moore.l1
-  // CHECK: %v1 = moore.variable : !moore.i32
-  // CHECK: %v2 = moore.variable %v1 : !moore.i32
+  // CHECK: %v0 = moore.variable : l1
+  // CHECK: %v1 = moore.variable : i32
+  // CHECK: %v2 = moore.variable %v1 : i32
   var v0;
   int v1;
   int v2 = v1;
 
-  // CHECK: %w0 = moore.net wire : !moore.l1
-  // CHECK: %w1 = moore.net wire %w0 : !moore.l1
+  // CHECK: %w0 = moore.net wire : l1
+  // CHECK: %w1 = moore.net wire %w0 : l1
   wire w0;
   wire w1 = w0;
-  // CHECK: %w2 = moore.net uwire %w0 : !moore.l1
+  // CHECK: %w2 = moore.net uwire %w0 : l1
   uwire w2 = w0;
-  // CHECK: %w3 = moore.net tri %w0 : !moore.l1
+  // CHECK: %w3 = moore.net tri %w0 : l1
   tri w3 = w0;
-  // CHECK: %w4 = moore.net triand %w0 : !moore.l1
+  // CHECK: %w4 = moore.net triand %w0 : l1
   triand w4 = w0;
-  // CHECK: %w5 = moore.net trior %w0 : !moore.l1
+  // CHECK: %w5 = moore.net trior %w0 : l1
   trior w5 = w0;
-  // CHECK: %w6 = moore.net wand %w0 : !moore.l1
+  // CHECK: %w6 = moore.net wand %w0 : l1
   wand w6 = w0;
-  // CHECK: %w7 = moore.net wor %w0 : !moore.l1
+  // CHECK: %w7 = moore.net wor %w0 : l1
   wor w7 = w0;
-  // CHECK: %w8 = moore.net trireg %w0 : !moore.l1
+  // CHECK: %w8 = moore.net trireg %w0 : l1
   trireg w8 = w0;
-  // CHECK: %w9 = moore.net tri0 %w0 : !moore.l1
+  // CHECK: %w9 = moore.net tri0 %w0 : l1
   tri0 w9 = w0;
-  // CHECK: %w10 = moore.net tri1 %w0 : !moore.l1
+  // CHECK: %w10 = moore.net tri1 %w0 : l1
   tri1 w10 = w0;
-  // CHECK: %w11 = moore.net supply0 : !moore.l1
+  // CHECK: %w11 = moore.net supply0 : l1
   supply0 w11;
-  // CHECK: %w12 = moore.net supply1 : !moore.l1
+  // CHECK: %w12 = moore.net supply1 : l1
   supply1 w12;
 
-  // CHECK: %b1 = moore.variable : !moore.i1
-  // CHECK: %b2 = moore.variable %b1 : !moore.i1
+  // CHECK: %b1 = moore.variable : i1
+  // CHECK: %b2 = moore.variable %b1 : i1
   bit [0:0] b1;
   bit b2 = b1;
 
@@ -109,7 +109,7 @@ module Basic;
   // CHECK: }
   always_ff @* begin end
 
-  // CHECK: moore.assign %v1, %v2 : !moore.i32
+  // CHECK: moore.assign %v1, %v2 : i32
   assign v1 = v2;
 endmodule
 
@@ -118,9 +118,9 @@ module Statements;
   bit x, y, z;
   int i;
   initial begin
-    // CHECK: %a = moore.variable  : !moore.i32
+    // CHECK: %a = moore.variable  : i32
     automatic int a;
-    // CHECK moore.blocking_assign %i, %a : !moore.i32
+    // CHECK moore.blocking_assign %i, %a : i32
     i = a;
     
     //===------------------------------------------------------------------===//
@@ -169,46 +169,46 @@ module Statements;
     //===------------------------------------------------------------------===//
     // Case statements
 
-    // CHECK: [[TMP1:%.+]] = moore.eq %x, %x : !moore.i1 -> !moore.i1
+    // CHECK: [[TMP1:%.+]] = moore.eq %x, %x : i1 -> i1
     // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i1 -> i1
     // CHECK: scf.if [[TMP2]] {
-    // CHECK:   moore.blocking_assign %x, %x : !moore.i1
+    // CHECK:   moore.blocking_assign %x, %x : i1
     // CHECK: }
-    // CHECK: [[TMP3:%.+]] = moore.eq %x, %x : !moore.i1 -> !moore.i1
-    // CHECK: [[TMP4:%.+]] = moore.eq %x, %y : !moore.i1 -> !moore.i1
-    // CHECK: [[TMP5:%.+]] = moore.or [[TMP3]], [[TMP4]] : !moore.i1
+    // CHECK: [[TMP3:%.+]] = moore.eq %x, %x : i1 -> i1
+    // CHECK: [[TMP4:%.+]] = moore.eq %x, %y : i1 -> i1
+    // CHECK: [[TMP5:%.+]] = moore.or [[TMP3]], [[TMP4]] : i1
     // CHECK: [[TMP6:%.+]] = moore.conversion [[TMP5]] : !moore.i1 -> i1
     // CHECK: scf.if [[TMP6]] {
-    // CHECK:   moore.blocking_assign %x, %y : !moore.i1
+    // CHECK:   moore.blocking_assign %x, %y : i1
     // CHECK: }
     case (x)
       x: x = x;
       x, y: x = y;
     endcase
 
-    // CHECK: [[TMP1:%.+]] = moore.eq %x, %x : !moore.i1 -> !moore.i1
+    // CHECK: [[TMP1:%.+]] = moore.eq %x, %x : i1 -> i1
     // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i1 -> i1
     // CHECK: scf.if [[TMP2]] {
-    // CHECK:   moore.blocking_assign %x, %x : !moore.i1
+    // CHECK:   moore.blocking_assign %x, %x : i1
     // CHECK: }
-    // CHECK: [[TMP3:%.+]] = moore.eq %x, %x : !moore.i1 -> !moore.i1
-    // CHECK: [[TMP4:%.+]] = moore.eq %x, %y : !moore.i1 -> !moore.i1
-    // CHECK: [[TMP5:%.+]] = moore.or [[TMP3]], [[TMP4]] : !moore.i1
+    // CHECK: [[TMP3:%.+]] = moore.eq %x, %x : i1 -> i1
+    // CHECK: [[TMP4:%.+]] = moore.eq %x, %y : i1 -> i1
+    // CHECK: [[TMP5:%.+]] = moore.or [[TMP3]], [[TMP4]] : i1
     // CHECK: [[TMP6:%.+]] = moore.conversion [[TMP5]] : !moore.i1 -> i1
     // CHECK: scf.if [[TMP6]] {
-    // CHECK:   moore.blocking_assign %x, %y : !moore.i1
+    // CHECK:   moore.blocking_assign %x, %y : i1
     // CHECK: }
-    // CHECK: [[TMP7:%.+]] = moore.eq %x, %z : !moore.i1 -> !moore.i1
+    // CHECK: [[TMP7:%.+]] = moore.eq %x, %z : i1 -> i1
     // CHECK: [[TMP8:%.+]] = moore.conversion [[TMP7]] : !moore.i1 -> i1
     // CHECK: scf.if [[TMP8]] {
-    // CHECK:   moore.blocking_assign %x, %z : !moore.i1
+    // CHECK:   moore.blocking_assign %x, %z : i1
     // CHECK: }
-    // CHECK: [[TMP9:%.+]] = moore.or [[TMP5]], [[TMP7]] : !moore.i1
-    // CHECK: [[TMP10:%.+]] = moore.or [[TMP1]], [[TMP9]] : !moore.i1
-    // CHECK: [[TMP11:%.+]] = moore.not [[TMP10]] : !moore.i1
+    // CHECK: [[TMP9:%.+]] = moore.or [[TMP5]], [[TMP7]] : i1
+    // CHECK: [[TMP10:%.+]] = moore.or [[TMP1]], [[TMP9]] : i1
+    // CHECK: [[TMP11:%.+]] = moore.not [[TMP10]] : i1
     // CHECK: [[TMP12:%.+]] = moore.conversion [[TMP11]] : !moore.i1 -> i1
     // CHECK: scf.if [[TMP12]] {
-    // CHECK:   moore.blocking_assign %x, %x : !moore.i1
+    // CHECK:   moore.blocking_assign %x, %x : i1
     // CHECK: }
     case (x)
       x: x = x;
@@ -232,14 +232,14 @@ module Statements;
     for (y = x; x; x = z) x = y;
 
     // CHECK: scf.while (%arg0 = %i) : (!moore.i32) -> !moore.i32 {
-    // CHECK:   [[TMP0:%.+]] = moore.bool_cast %arg0 : !moore.i32 -> !moore.i1
+    // CHECK:   [[TMP0:%.+]] = moore.bool_cast %arg0 : i32 -> i1
     // CHECK:   [[TMP1:%.+]] = moore.conversion [[TMP0]] : !moore.i1 -> i1
     // CHECK:   scf.condition([[TMP1]]) %arg0 : !moore.i32
     // CHECK: } do {
     // CHECK: ^bb0(%arg0: !moore.i32):
     // CHECK:   moore.blocking_assign %x, %y
-    // CHECK:   [[TMP0:%.+]] = moore.constant 1 : !moore.i32
-    // CHECK:   [[TMP1:%.+]] = moore.sub %arg0, [[TMP0]] : !moore.i32
+    // CHECK:   [[TMP0:%.+]] = moore.constant 1 : i32
+    // CHECK:   [[TMP1:%.+]] = moore.sub %arg0, [[TMP0]] : i32
     // CHECK:   scf.yield [[TMP1]] : !moore.i32
     // CHECK: }
     repeat (i) x = y;
@@ -274,163 +274,164 @@ module Statements;
     //===------------------------------------------------------------------===//
     // Assignments
 
-    // CHECK: moore.blocking_assign %x, %y : !moore.i1
+    // CHECK: moore.blocking_assign %x, %y : i1
     x = y;
 
-    // CHECK: moore.blocking_assign %y, %z : !moore.i1
-    // CHECK: moore.blocking_assign %x, %z : !moore.i1
+    // CHECK: moore.blocking_assign %y, %z : i1
+    // CHECK: moore.blocking_assign %x, %z : i1
     x = (y = z);
 
-    // CHECK: moore.nonblocking_assign %x, %y : !moore.i1
+    // CHECK: moore.nonblocking_assign %x, %y : i1
     x <= y;
   end
 endmodule
 
 // CHECK-LABEL: moore.module @Expressions {
 module Expressions;
-  // CHECK: %a = moore.variable : !moore.i32
-  // CHECK: %b = moore.variable : !moore.i32
-  // CHECK: %c = moore.variable : !moore.i32
-  // CHECK: %u = moore.variable : !moore.i32
-  // CHECK: %v = moore.variable : !moore.array<2 x !moore.i4>
-  // CHECK: %d = moore.variable : !moore.l32
-  // CHECK: %e = moore.variable : !moore.l32
-  // CHECK: %f = moore.variable : !moore.l32
-  // CHECK: %x = moore.variable : !moore.i1
-  // CHECK: %y = moore.variable : !moore.l1
-  // CHECK: %vec_1 = moore.variable : !moore.l32
-  // CHECK: %vec_2 = moore.variable : !moore.l32
-  // CHECK: %myStruct = moore.variable  : !moore.packed<struct<{a: i32, b: i32}>>
-  // CHECK: %myStruct2 = moore.variable  : !moore.packed<struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>>
-  // CHECK: %myStruct3 = moore.variable  : !moore.packed<struct<{a: i32, b: i32}>>
+  // CHECK: %a = moore.variable : i32
+  // CHECK: %b = moore.variable : i32
+  // CHECK: %c = moore.variable : i32
   int a, b, c;
+  // CHECK: %u = moore.variable : i32
   int unsigned u, w;
+  // CHECK: %v = moore.variable : array<2 x i4>
   bit [1:0][3:0] v;
+  // CHECK: %d = moore.variable : l32
+  // CHECK: %e = moore.variable : l32
+  // CHECK: %f = moore.variable : l32
   integer d, e, f;
   integer unsigned g, h, k;
+  // CHECK: %x = moore.variable : i1
   bit x;
+  // CHECK: %y = moore.variable : l1
   logic y;
+  // CHECK: %vec_1 = moore.variable : l32
   logic [31:0] vec_1;
+  // CHECK: %vec_2 = moore.variable : l32
   logic [0:31] vec_2;
+  // CHECK: %arr = moore.variable : uarray<3 x uarray<6 x i4>>
   bit [4:1] arr [1:3][2:7];
-  bit [3:2] s;
-  typedef struct packed signed {int a, b;} structTemp;
-  structTemp myStruct;
-  typedef struct packed signed {structTemp c,d;} structTemp2;
-  structTemp2 myStruct2;
-  typedef struct packed unsigned {int a, b;} structTemp3;
-  structTemp3 myStruct3;
+  // CHECK: %struct0 = moore.variable : packed<struct<{a: i32, b: i32}>>
+  struct packed {
+    int a, b;
+  } struct0;
+  // CHECK: %struct1 = moore.variable : packed<struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>>
+  struct packed {
+    struct packed {
+      int a, b;
+    } c, d;
+  } struct1;
 
   initial begin
-    // CHECK: moore.constant 0 : !moore.i32
+    // CHECK: moore.constant 0 : i32
     c = '0;
-    // CHECK: moore.constant -1 : !moore.i32
+    // CHECK: moore.constant -1 : i32
     c = '1;
-    // CHECK: moore.constant 42 : !moore.i32
+    // CHECK: moore.constant 42 : i32
     c = 42;
-    // CHECK: moore.constant 42 : !moore.i19
+    // CHECK: moore.constant 42 : i19
     c = 19'd42;
-    // CHECK: moore.constant 42 : !moore.i19
+    // CHECK: moore.constant 42 : i19
     c = 19'sd42;
-    // CHECK: moore.concat %a, %b, %c : (!moore.i32, !moore.i32, !moore.i32) -> !moore.i96
+    // CHECK: moore.concat %a, %b, %c : (!moore.i32, !moore.i32, !moore.i32) -> i96
     a = {a, b, c};
-    // CHECK: moore.concat %d, %e : (!moore.l32, !moore.l32) -> !moore.l64
+    // CHECK: moore.concat %d, %e : (!moore.l32, !moore.l32) -> l64
     d = {d, e};
-    // CHECK: %[[VAL_1:.*]] = moore.constant false : !moore.i1
-    // CHECK: %[[VAL_2:.*]] = moore.concat %[[VAL_1]] : (!moore.i1) -> !moore.i1
-    // CHECK: %[[VAL_3:.*]] = moore.replicate %[[VAL_2]] : (!moore.i1) -> !moore.i32
+    // CHECK: %[[VAL_1:.*]] = moore.constant false : i1
+    // CHECK: %[[VAL_2:.*]] = moore.concat %[[VAL_1]] : (!moore.i1) -> i1
+    // CHECK: %[[VAL_3:.*]] = moore.replicate %[[VAL_2]] : i1 -> i32
     a = {32{1'b0}};
-    // CHECK: %[[VAL:.*]] = moore.constant 1 : !moore.i32
-    // CHECK: moore.extract %vec_1 from %[[VAL]] : !moore.l32, !moore.i32 -> !moore.l3
+    // CHECK: %[[VAL:.*]] = moore.constant 1 : i32
+    // CHECK: moore.extract %vec_1 from %[[VAL]] : l32, i32 -> l3
     y = vec_1[3:1];
-    // CHECK: %[[VAL:.*]] = moore.constant 2 : !moore.i32
-    // CHECK: moore.extract %vec_2 from %[[VAL]] : !moore.l32, !moore.i32 -> !moore.l2
+    // CHECK: %[[VAL:.*]] = moore.constant 2 : i32
+    // CHECK: moore.extract %vec_2 from %[[VAL]] : l32, i32 -> l2
     y = vec_2[2:3];
-    // CHECK: moore.extract %d from %x : !moore.l32, !moore.i1 -> !moore.l1
+    // CHECK: moore.extract %d from %x : l32, i1 -> l1
     y = d[x];
-    // CHECK: moore.extract %a from %x : !moore.i32, !moore.i1 -> !moore.i1
-    y = a[x];
-    // CHECK: %[[VAL:.*]] = moore.constant 15 : !moore.i32
-    // CHECK: moore.extract %vec_1 from %[[VAL]] : !moore.l32, !moore.i32 -> !moore.l1
+    // CHECK: moore.extract %a from %x : i32, i1 -> i1
+    x = a[x];
+    // CHECK: %[[VAL:.*]] = moore.constant 15 : i32
+    // CHECK: moore.extract %vec_1 from %[[VAL]] : l32, i32 -> l1
     y = vec_1[15];
-    // CHECK: %[[VAL:.*]] = moore.constant 15 : !moore.i32
-    // CHECK: moore.extract %vec_1 from %[[VAL]] : !moore.l32, !moore.i32 -> !moore.l1
+    // CHECK: %[[VAL:.*]] = moore.constant 15 : i32
+    // CHECK: moore.extract %vec_1 from %[[VAL]] : l32, i32 -> l1
     y = vec_1[15+:1];
-    // CHECK: %[[VAL:.*]] = moore.constant 0 : !moore.i32
-    // CHECK: moore.extract %vec_2 from %[[VAL]] : !moore.l32, !moore.i32 -> !moore.l1
+    // CHECK: %[[VAL:.*]] = moore.constant 0 : i32
+    // CHECK: moore.extract %vec_2 from %[[VAL]] : l32, i32 -> l1
     y = vec_2[0+:1];
-    // CHECK: %[[VAL_1:.*]] = moore.constant 1 : !moore.i32
-    // CHECK: %[[VAL_2:.*]] = moore.mul %[[VAL_1]], %a : !moore.i32
-    // CHECK: moore.extract %vec_1 from %[[VAL_2]] : !moore.l32, !moore.i32 -> !moore.l1
-    y = vec_1[1*a-:1];
-    // CHECK: %[[VAL_1:.*]] = moore.constant 3 : !moore.i32
-    // CHECK: %[[VAL_2:.*]] = moore.extract %arr from %[[VAL_1]] : !moore.uarray<3 x !moore.uarray<6 x !moore.i4>>, !moore.i32 -> !moore.uarray<6 x !moore.i4>
-    // CHECK: %[[VAL_3:.*]] = moore.constant 7 : !moore.i32
-    // CHECK: %[[VAL_4:.*]] = moore.extract %[[VAL_2]] from %[[VAL_3]] : !moore.uarray<6 x !moore.i4>, !moore.i32 -> !moore.i4
-    // CHECK: %[[VAL_5:.*]] = moore.constant 3 : !moore.i32
-    // CHECK: moore.extract %[[VAL_4]] from %[[VAL_5]] : !moore.i4, !moore.i32 -> !moore.i2
-    s = arr[3][7][4:3];
-    // CHECK: moore.extract %vec_1 from %s : !moore.l32, !moore.i2 -> !moore.l1
-    y = vec_1[s];
+    // CHECK: %[[VAL_1:.*]] = moore.constant 1 : i32
+    // CHECK: %[[VAL_2:.*]] = moore.mul %[[VAL_1]], %a : i32
+    // CHECK: moore.extract %vec_1 from %[[VAL_2]] : l32, i32 -> l1
+    c = vec_1[1*a-:1];
+    // CHECK: %[[VAL_1:.*]] = moore.constant 3 : i32
+    // CHECK: %[[VAL_2:.*]] = moore.extract %arr from %[[VAL_1]] : uarray<3 x uarray<6 x i4>>, i32 -> uarray<6 x i4>
+    // CHECK: %[[VAL_3:.*]] = moore.constant 7 : i32
+    // CHECK: %[[VAL_4:.*]] = moore.extract %[[VAL_2]] from %[[VAL_3]] : uarray<6 x i4>, i32 -> i4
+    // CHECK: %[[VAL_5:.*]] = moore.constant 3 : i32
+    // CHECK: moore.extract %[[VAL_4]] from %[[VAL_5]] : i4, i32 -> i2
+    c = arr[3][7][4:3];
+    // CHECK: moore.extract %vec_1 from %c : l32, i32 -> l1
+    y = vec_1[c];
 
 
     //===------------------------------------------------------------------===//
     // Unary operators
 
-    // CHECK: moore.blocking_assign %c, %a : !moore.i32
+    // CHECK: moore.blocking_assign %c, %a : i32
     c = +a;
-    // CHECK: moore.neg %a : !moore.i32
+    // CHECK: moore.neg %a : i32
     c = -a;
-    // CHECK: [[TMP1:%.+]] = moore.conversion %v : !moore.array<2 x !moore.i4> -> !moore.i32
-    // CHECK: [[TMP2:%.+]] = moore.neg [[TMP1]] : !moore.i32
+    // CHECK: [[TMP1:%.+]] = moore.conversion %v : !moore.array<2 x i4> -> !moore.i32
+    // CHECK: [[TMP2:%.+]] = moore.neg [[TMP1]] : i32
     // CHECK: [[TMP3:%.+]] = moore.conversion [[TMP2]] : !moore.i32 -> !moore.i32
     c = -v;
-    // CHECK: moore.not %a : !moore.i32
+    // CHECK: moore.not %a : i32
     c = ~a;
-    // CHECK: moore.reduce_and %a : !moore.i32 -> !moore.i1
+    // CHECK: moore.reduce_and %a : i32 -> i1
     x = &a;
-    // CHECK: moore.reduce_and %d : !moore.l32 -> !moore.l1
+    // CHECK: moore.reduce_and %d : l32 -> l1
     y = &d;
-    // CHECK: moore.reduce_or %a : !moore.i32 -> !moore.i1
+    // CHECK: moore.reduce_or %a : i32 -> i1
     x = |a;
-    // CHECK: moore.reduce_xor %a : !moore.i32 -> !moore.i1
+    // CHECK: moore.reduce_xor %a : i32 -> i1
     x = ^a;
-    // CHECK: [[TMP:%.+]] = moore.reduce_and %a : !moore.i32 -> !moore.i1
-    // CHECK: moore.not [[TMP]] : !moore.i1
+    // CHECK: [[TMP:%.+]] = moore.reduce_and %a : i32 -> i1
+    // CHECK: moore.not [[TMP]] : i1
     x = ~&a;
-    // CHECK: [[TMP:%.+]] = moore.reduce_or %a : !moore.i32 -> !moore.i1
-    // CHECK: moore.not [[TMP]] : !moore.i1
+    // CHECK: [[TMP:%.+]] = moore.reduce_or %a : i32 -> i1
+    // CHECK: moore.not [[TMP]] : i1
     x = ~|a;
-    // CHECK: [[TMP:%.+]] = moore.reduce_xor %a : !moore.i32 -> !moore.i1
-    // CHECK: moore.not [[TMP]] : !moore.i1
+    // CHECK: [[TMP:%.+]] = moore.reduce_xor %a : i32 -> i1
+    // CHECK: moore.not [[TMP]] : i1
     x = ~^a;
-    // CHECK: [[TMP:%.+]] = moore.reduce_xor %a : !moore.i32 -> !moore.i1
-    // CHECK: moore.not [[TMP]] : !moore.i1
+    // CHECK: [[TMP:%.+]] = moore.reduce_xor %a : i32 -> i1
+    // CHECK: moore.not [[TMP]] : i1
     x = ^~a;
-    // CHECK: [[TMP:%.+]] = moore.bool_cast %a : !moore.i32 -> !moore.i1
-    // CHECK: moore.not [[TMP]] : !moore.i1
+    // CHECK: [[TMP:%.+]] = moore.bool_cast %a : i32 -> i1
+    // CHECK: moore.not [[TMP]] : i1
     x = !a;
-    // CHECK: [[PRE:%.+]] = moore.read_lvalue %a : !moore.i32
-    // CHECK: [[TMP:%.+]] = moore.constant 1 : !moore.i32
-    // CHECK: [[POST:%.+]] = moore.add [[PRE]], [[TMP]] : !moore.i32
+    // CHECK: [[PRE:%.+]] = moore.read_lvalue %a : i32
+    // CHECK: [[TMP:%.+]] = moore.constant 1 : i32
+    // CHECK: [[POST:%.+]] = moore.add [[PRE]], [[TMP]] : i32
     // CHECK: moore.blocking_assign %a, [[POST]]
     // CHECK: moore.blocking_assign %c, [[PRE]]
     c = a++;
-    // CHECK: [[PRE:%.+]] = moore.read_lvalue %a : !moore.i32
-    // CHECK: [[TMP:%.+]] = moore.constant 1 : !moore.i32
-    // CHECK: [[POST:%.+]] = moore.sub [[PRE]], [[TMP]] : !moore.i32
+    // CHECK: [[PRE:%.+]] = moore.read_lvalue %a : i32
+    // CHECK: [[TMP:%.+]] = moore.constant 1 : i32
+    // CHECK: [[POST:%.+]] = moore.sub [[PRE]], [[TMP]] : i32
     // CHECK: moore.blocking_assign %a, [[POST]]
     // CHECK: moore.blocking_assign %c, [[PRE]]
     c = a--;
-    // CHECK: [[PRE:%.+]] = moore.read_lvalue %a : !moore.i32
-    // CHECK: [[TMP:%.+]] = moore.constant 1 : !moore.i32
-    // CHECK: [[POST:%.+]] = moore.add [[PRE]], [[TMP]] : !moore.i32
+    // CHECK: [[PRE:%.+]] = moore.read_lvalue %a : i32
+    // CHECK: [[TMP:%.+]] = moore.constant 1 : i32
+    // CHECK: [[POST:%.+]] = moore.add [[PRE]], [[TMP]] : i32
     // CHECK: moore.blocking_assign %a, [[POST]]
     // CHECK: moore.blocking_assign %c, [[POST]]
     c = ++a;
-    // CHECK: [[PRE:%.+]] = moore.read_lvalue %a : !moore.i32
-    // CHECK: [[TMP:%.+]] = moore.constant 1 : !moore.i32
-    // CHECK: [[POST:%.+]] = moore.sub [[PRE]], [[TMP]] : !moore.i32
+    // CHECK: [[PRE:%.+]] = moore.read_lvalue %a : i32
+    // CHECK: [[TMP:%.+]] = moore.constant 1 : i32
+    // CHECK: [[POST:%.+]] = moore.sub [[PRE]], [[TMP]] : i32
     // CHECK: moore.blocking_assign %a, [[POST]]
     // CHECK: moore.blocking_assign %c, [[POST]]
     c = --a;
@@ -438,136 +439,136 @@ module Expressions;
     //===------------------------------------------------------------------===//
     // Binary operators
 
-    // CHECK: moore.add %a, %b : !moore.i32
+    // CHECK: moore.add %a, %b : i32
     c = a + b;
     // CHECK: [[TMP1:%.+]] = moore.conversion %a : !moore.i32 -> !moore.i32
-    // CHECK: [[TMP2:%.+]] = moore.conversion %v : !moore.array<2 x !moore.i4> -> !moore.i32
-    // CHECK: [[TMP3:%.+]] = moore.add [[TMP1]], [[TMP2]] : !moore.i32
+    // CHECK: [[TMP2:%.+]] = moore.conversion %v : !moore.array<2 x i4> -> !moore.i32
+    // CHECK: [[TMP3:%.+]] = moore.add [[TMP1]], [[TMP2]] : i32
     // CHECK: [[TMP4:%.+]] = moore.conversion [[TMP3]] : !moore.i32 -> !moore.i32
     c = a + v;
-    // CHECK: moore.sub %a, %b : !moore.i32
+    // CHECK: moore.sub %a, %b : i32
     c = a - b;
-    // CHECK: moore.mul %a, %b : !moore.i32
+    // CHECK: moore.mul %a, %b : i32
     c = a * b;
-    // CHECK: moore.divu %h, %k : !moore.l32
+    // CHECK: moore.divu %h, %k : l32
     g = h / k;
-    // CHECK: moore.divs %d, %e : !moore.l32
+    // CHECK: moore.divs %d, %e : l32
     f = d / e;
-    // CHECK: moore.modu %h, %k : !moore.l32
+    // CHECK: moore.modu %h, %k : l32
     g = h % k;
-    // CHECK: moore.mods %d, %e : !moore.l32
+    // CHECK: moore.mods %d, %e : l32
     f = d % e;
 
-    // CHECK: moore.and %a, %b : !moore.i32
+    // CHECK: moore.and %a, %b : i32
     c = a & b;
-    // CHECK: moore.or %a, %b : !moore.i32
+    // CHECK: moore.or %a, %b : i32
     c = a | b;
-    // CHECK: moore.xor %a, %b : !moore.i32
+    // CHECK: moore.xor %a, %b : i32
     c = a ^ b;
-    // CHECK: [[TMP:%.+]] = moore.xor %a, %b : !moore.i32
-    // CHECK: moore.not [[TMP]] : !moore.i32
+    // CHECK: [[TMP:%.+]] = moore.xor %a, %b : i32
+    // CHECK: moore.not [[TMP]] : i32
     c = a ~^ b;
-    // CHECK: [[TMP:%.+]] = moore.xor %a, %b : !moore.i32
-    // CHECK: moore.not [[TMP]] : !moore.i32
+    // CHECK: [[TMP:%.+]] = moore.xor %a, %b : i32
+    // CHECK: moore.not [[TMP]] : i32
     c = a ^~ b;
 
-    // CHECK: moore.eq %a, %b : !moore.i32 -> !moore.i1
+    // CHECK: moore.eq %a, %b : i32 -> i1
     x = a == b;
-    // CHECK: moore.eq %d, %e : !moore.l32 -> !moore.l1
+    // CHECK: moore.eq %d, %e : l32 -> l1
     y = d == e;
-    // CHECK: moore.ne %a, %b : !moore.i32 -> !moore.i1
+    // CHECK: moore.ne %a, %b : i32 -> i1
     x = a != b ;
-    // CHECK: moore.case_eq %a, %b : !moore.i32
+    // CHECK: moore.case_eq %a, %b : i32
     x = a === b;
-    // CHECK: moore.case_ne %a, %b : !moore.i32
+    // CHECK: moore.case_ne %a, %b : i32
     x = a !== b;
-    // CHECK: moore.wildcard_eq %a, %b : !moore.i32 -> !moore.i1
+    // CHECK: moore.wildcard_eq %a, %b : i32 -> i1
     x = a ==? b;
     // CHECK: [[TMP:%.+]] = moore.conversion %a : !moore.i32 -> !moore.l32
-    // CHECK: moore.wildcard_eq [[TMP]], %d : !moore.l32 -> !moore.l1
+    // CHECK: moore.wildcard_eq [[TMP]], %d : l32 -> l1
     y = a ==? d;
     // CHECK: [[TMP:%.+]] = moore.conversion %b : !moore.i32 -> !moore.l32
-    // CHECK: moore.wildcard_eq %d, [[TMP]] : !moore.l32 -> !moore.l1
+    // CHECK: moore.wildcard_eq %d, [[TMP]] : l32 -> l1
     y = d ==? b;
-    // CHECK: moore.wildcard_eq %d, %e : !moore.l32 -> !moore.l1
+    // CHECK: moore.wildcard_eq %d, %e : l32 -> l1
     y = d ==? e;
-    // CHECK: moore.wildcard_ne %a, %b : !moore.i32 -> !moore.i1
+    // CHECK: moore.wildcard_ne %a, %b : i32 -> i1
     x = a !=? b;
 
-    // CHECK: moore.uge %u, %w : !moore.i32 -> !moore.i1
+    // CHECK: moore.uge %u, %w : i32 -> i1
     c = u >= w;
-    // CHECK: moore.ugt %u, %w : !moore.i32 -> !moore.i1
+    // CHECK: moore.ugt %u, %w : i32 -> i1
     c = u > w;
-    // CHECK: moore.ule %u, %w : !moore.i32 -> !moore.i1
+    // CHECK: moore.ule %u, %w : i32 -> i1
     c = u <= w;
-    // CHECK: moore.ult %u, %w : !moore.i32 -> !moore.i1
+    // CHECK: moore.ult %u, %w : i32 -> i1
     c = u < w;
-    // CHECK: moore.sge %a, %b : !moore.i32 -> !moore.i1
+    // CHECK: moore.sge %a, %b : i32 -> i1
     c = a >= b;
-    // CHECK: moore.sgt %a, %b : !moore.i32 -> !moore.i1
+    // CHECK: moore.sgt %a, %b : i32 -> i1
     c = a > b;
-    // CHECK: moore.sle %a, %b : !moore.i32 -> !moore.i1
+    // CHECK: moore.sle %a, %b : i32 -> i1
     c = a <= b;
-    // CHECK: moore.slt %a, %b : !moore.i32 -> !moore.i1
+    // CHECK: moore.slt %a, %b : i32 -> i1
     c = a < b;
 
-    // CHECK: [[A:%.+]] = moore.bool_cast %a : !moore.i32 -> !moore.i1
-    // CHECK: [[B:%.+]] = moore.bool_cast %b : !moore.i32 -> !moore.i1
-    // CHECK: moore.and [[A]], [[B]] : !moore.i1
+    // CHECK: [[A:%.+]] = moore.bool_cast %a : i32 -> i1
+    // CHECK: [[B:%.+]] = moore.bool_cast %b : i32 -> i1
+    // CHECK: moore.and [[A]], [[B]] : i1
     c = a && b;
-    // CHECK: [[A:%.+]] = moore.bool_cast %a : !moore.i32 -> !moore.i1
-    // CHECK: [[B:%.+]] = moore.bool_cast %b : !moore.i32 -> !moore.i1
-    // CHECK: moore.or [[A]], [[B]] : !moore.i1
+    // CHECK: [[A:%.+]] = moore.bool_cast %a : i32 -> i1
+    // CHECK: [[B:%.+]] = moore.bool_cast %b : i32 -> i1
+    // CHECK: moore.or [[A]], [[B]] : i1
     c = a || b;
-    // CHECK: [[A:%.+]] = moore.bool_cast %a : !moore.i32 -> !moore.i1
-    // CHECK: [[B:%.+]] = moore.bool_cast %b : !moore.i32 -> !moore.i1
-    // CHECK: [[NOT_A:%.+]] = moore.not [[A]] : !moore.i1
-    // CHECK: moore.or [[NOT_A]], [[B]] : !moore.i1
+    // CHECK: [[A:%.+]] = moore.bool_cast %a : i32 -> i1
+    // CHECK: [[B:%.+]] = moore.bool_cast %b : i32 -> i1
+    // CHECK: [[NOT_A:%.+]] = moore.not [[A]] : i1
+    // CHECK: moore.or [[NOT_A]], [[B]] : i1
     c = a -> b;
-    // CHECK: [[A:%.+]] = moore.bool_cast %a : !moore.i32 -> !moore.i1
-    // CHECK: [[B:%.+]] = moore.bool_cast %b : !moore.i32 -> !moore.i1
-    // CHECK: [[NOT_A:%.+]] = moore.not [[A]] : !moore.i1
-    // CHECK: [[NOT_B:%.+]] = moore.not [[B]] : !moore.i1
-    // CHECK: [[BOTH:%.+]] = moore.and [[A]], [[B]] : !moore.i1
-    // CHECK: [[NOT_BOTH:%.+]] = moore.and [[NOT_A]], [[NOT_B]] : !moore.i1
-    // CHECK: moore.or [[BOTH]], [[NOT_BOTH]] : !moore.i1
+    // CHECK: [[A:%.+]] = moore.bool_cast %a : i32 -> i1
+    // CHECK: [[B:%.+]] = moore.bool_cast %b : i32 -> i1
+    // CHECK: [[NOT_A:%.+]] = moore.not [[A]] : i1
+    // CHECK: [[NOT_B:%.+]] = moore.not [[B]] : i1
+    // CHECK: [[BOTH:%.+]] = moore.and [[A]], [[B]] : i1
+    // CHECK: [[NOT_BOTH:%.+]] = moore.and [[NOT_A]], [[NOT_B]] : i1
+    // CHECK: moore.or [[BOTH]], [[NOT_BOTH]] : i1
     c = a <-> b;
 
-    // CHECK: moore.shl %a, %b : !moore.i32, !moore.i32
+    // CHECK: moore.shl %a, %b : i32, i32
     c = a << b;
-    // CHECK: moore.shr %a, %b : !moore.i32, !moore.i32
+    // CHECK: moore.shr %a, %b : i32, i32
     c = a >> b;
-    // CHECK: moore.shl %a, %b : !moore.i32, !moore.i32
+    // CHECK: moore.shl %a, %b : i32, i32
     c = a <<< b;
-    // CHECK: moore.ashr %a, %b : !moore.i32, !moore.i32
+    // CHECK: moore.ashr %a, %b : i32, i32
     c = a >>> b;
-    // CHECK: moore.shr %u, %b : !moore.i32, !moore.i32
+    // CHECK: moore.shr %u, %b : i32, i32
     c = u >>> b;
 
-    // CHECK: moore.wildcard_eq %a, %a : !moore.i32 -> !moore.i1
+    // CHECK: moore.wildcard_eq %a, %a : i32 -> i1
     c = a inside { a };
 
-    // CHECK: [[TMP1:%.+]] = moore.wildcard_eq %a, %a : !moore.i32 -> !moore.i1
-    // CHECK: [[TMP2:%.+]] = moore.wildcard_eq %a, %b : !moore.i32 -> !moore.i1
-    // CHECK: moore.or [[TMP1]], [[TMP2]] : !moore.i1
+    // CHECK: [[TMP1:%.+]] = moore.wildcard_eq %a, %a : i32 -> i1
+    // CHECK: [[TMP2:%.+]] = moore.wildcard_eq %a, %b : i32 -> i1
+    // CHECK: moore.or [[TMP1]], [[TMP2]] : i1
     c = a inside { a, b };
 
-    // CHECK: [[TMP1:%.+]] = moore.wildcard_eq %a, %a : !moore.i32 -> !moore.i1
-    // CHECK: [[TMP2:%.+]] = moore.wildcard_eq %a, %b : !moore.i32 -> !moore.i1
-    // CHECK: [[TMP3:%.+]] = moore.wildcard_eq %a, %a : !moore.i32 -> !moore.i1
-    // CHECK: [[TMP4:%.+]] = moore.wildcard_eq %a, %b : !moore.i32 -> !moore.i1
-    // CHECK: [[TMP5:%.+]] = moore.or [[TMP3]], [[TMP4]] : !moore.i1
-    // CHECK: [[TMP6:%.+]] = moore.or [[TMP2]], [[TMP5]] : !moore.i1
-    // CHECK: moore.or [[TMP1]], [[TMP6]] : !moore.i1
+    // CHECK: [[TMP1:%.+]] = moore.wildcard_eq %a, %a : i32 -> i1
+    // CHECK: [[TMP2:%.+]] = moore.wildcard_eq %a, %b : i32 -> i1
+    // CHECK: [[TMP3:%.+]] = moore.wildcard_eq %a, %a : i32 -> i1
+    // CHECK: [[TMP4:%.+]] = moore.wildcard_eq %a, %b : i32 -> i1
+    // CHECK: [[TMP5:%.+]] = moore.or [[TMP3]], [[TMP4]] : i1
+    // CHECK: [[TMP6:%.+]] = moore.or [[TMP2]], [[TMP5]] : i1
+    // CHECK: moore.or [[TMP1]], [[TMP6]] : i1
     c = a inside { a, b, a, b };
 
-    // CHECK: [[TMP1:%.+]] = moore.wildcard_eq %a, %a : !moore.i32 -> !moore.i1
-    // CHECK: [[TMP2:%.+]] = moore.wildcard_eq %a, %b : !moore.i32 -> !moore.i1
-    // CHECK: [[TMP3:%.+]] = moore.sge %a, %a : !moore.i32 -> !moore.i1
-    // CHECK: [[TMP4:%.+]] = moore.sle %a, %b : !moore.i32 -> !moore.i1
-    // CHECK: [[TMP5:%.+]] = moore.and [[TMP3]], [[TMP4]] : !moore.i1
-    // CHECK: [[TMP6:%.+]] = moore.or [[TMP2]], [[TMP5]] : !moore.i1
-    // CHECK: moore.or [[TMP1]], [[TMP6]] : !moore.i1
+    // CHECK: [[TMP1:%.+]] = moore.wildcard_eq %a, %a : i32 -> i1
+    // CHECK: [[TMP2:%.+]] = moore.wildcard_eq %a, %b : i32 -> i1
+    // CHECK: [[TMP3:%.+]] = moore.sge %a, %a : i32 -> i1
+    // CHECK: [[TMP4:%.+]] = moore.sle %a, %b : i32 -> i1
+    // CHECK: [[TMP5:%.+]] = moore.and [[TMP3]], [[TMP4]] : i1
+    // CHECK: [[TMP6:%.+]] = moore.or [[TMP2]], [[TMP5]] : i1
+    // CHECK: moore.or [[TMP1]], [[TMP6]] : i1
     c = a inside { a, b, [a:b] };
 
     //===------------------------------------------------------------------===//
@@ -642,31 +643,23 @@ module Expressions;
     // CHECK: moore.blocking_assign %a, [[TMP2]]
     a += (a *= a--);
 
-    // CHECK: [[A_STRUCT:%.+]] = moore.struct_extract %myStruct, "a" : !moore.packed<struct<{a: i32, b: i32}>> -> !moore.i32
-    // CHECK: moore.blocking_assign [[A_STRUCT]], %a : !moore.i32
-    myStruct.a = a;
+    // CHECK: [[TMP:%.+]] = moore.struct_extract %struct0, "a" : packed<struct<{a: i32, b: i32}>> -> i32
+    // CHECK: moore.blocking_assign [[TMP]], %a : i32
+    struct0.a = a;
 
-    // CHECK: [[B_STRUCT:%.+]]  = moore.struct_extract %myStruct, "b" : !moore.packed<struct<{a: i32, b: i32}>> -> !moore.i32
-    // CHECK: moore.blocking_assign %b, [[B_STRUCT]] : !moore.i32
-    b = myStruct.b;
+    // CHECK: [[TMP:%.+]]  = moore.struct_extract %struct0, "b" : packed<struct<{a: i32, b: i32}>> -> i32
+    // CHECK: moore.blocking_assign %b, [[TMP]] : i32
+    b = struct0.b;
 
-    // CHECK: [[C_STRUCT:%.+]] = moore.struct_extract %myStruct2, "c" : !moore.packed<struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>> -> !moore.packed<struct<{a: i32, b: i32}>>
-    // CHECK: [[D_STRUCT:%.+]] = moore.struct_extract [[C_STRUCT]], "a" : !moore.packed<struct<{a: i32, b: i32}>> -> !moore.i32
-    // CHECK: moore.blocking_assign [[D_STRUCT]], %a : !moore.i32
-    myStruct2.c.a = a;
+    // CHECK: [[TMP1:%.+]] = moore.struct_extract %struct1, "c" : packed<struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>> -> packed<struct<{a: i32, b: i32}>>
+    // CHECK: [[TMP2:%.+]] = moore.struct_extract [[TMP1]], "a" : packed<struct<{a: i32, b: i32}>> -> i32
+    // CHECK: moore.blocking_assign [[TMP2]], %a : i32
+    struct1.c.a = a;
 
-    // CHECK: [[E_STRUCT:%.+]] = moore.struct_extract %myStruct2, "d" : !moore.packed<struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>> -> !moore.packed<struct<{a: i32, b: i32}>>
-    // CHECK: [[F_STRUCT:%.+]] = moore.struct_extract [[E_STRUCT]], "b" : !moore.packed<struct<{a: i32, b: i32}>> -> !moore.i32
-    // CHECK: moore.blocking_assign %b, [[F_STRUCT]] : !moore.i32
-    b = myStruct2.d.b;
-
-    // CHECK: [[G_STRUCT:%.+]] = moore.struct_extract %myStruct3, "a" : !moore.packed<struct<{a: i32, b: i32}>> -> !moore.i32
-    // CHECK: moore.blocking_assign [[G_STRUCT]], %a : !moore.i3
-    myStruct3.a = a;
-
-    // CHECK: [[H_STRUCT:%.+]] = moore.struct_extract %myStruct3, "b" : !moore.packed<struct<{a: i32, b: i32}>> -> !moore.i32
-    // CHECK: moore.blocking_assign %b, [[H_STRUCT]] : !moore.i32
-    b = myStruct3.b;
+    // CHECK: [[TMP1:%.+]] = moore.struct_extract %struct1, "d" : packed<struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>> -> packed<struct<{a: i32, b: i32}>>
+    // CHECK: [[TMP2:%.+]] = moore.struct_extract [[TMP1]], "b" : packed<struct<{a: i32, b: i32}>> -> i32
+    // CHECK: moore.blocking_assign %b, [[TMP2]] : i32
+    b = struct1.d.b;
   end
 endmodule
 

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -8,9 +8,9 @@
 module Enums;
   typedef enum shortint { MAGIC } myEnum;
 
-  // CHECK-NEXT: %e0 = moore.variable : !moore.i32
-  // CHECK-NEXT: %e1 = moore.variable : !moore.i8
-  // CHECK-NEXT: %e2 = moore.variable : !moore.i16
+  // CHECK-NEXT: %e0 = moore.variable : i32
+  // CHECK-NEXT: %e1 = moore.variable : i8
+  // CHECK-NEXT: %e2 = moore.variable : i16
   enum { FOO, BAR } e0;
   enum byte { HELLO = 0, WORLD = 1 } e1;
   myEnum e2;
@@ -18,15 +18,15 @@ endmodule
 
 // CHECK-LABEL: moore.module @IntAtoms
 module IntAtoms;
-  // CHECK-NEXT: %d0 = moore.variable : !moore.l1
-  // CHECK-NEXT: %d1 = moore.variable : !moore.i1
-  // CHECK-NEXT: %d2 = moore.variable : !moore.l1
-  // CHECK-NEXT: %d3 = moore.variable : !moore.i32
-  // CHECK-NEXT: %d4 = moore.variable : !moore.i16
-  // CHECK-NEXT: %d5 = moore.variable : !moore.i64
-  // CHECK-NEXT: %d6 = moore.variable : !moore.l32
-  // CHECK-NEXT: %d7 = moore.variable : !moore.i8
-  // CHECK-NEXT: %d8 = moore.variable : !moore.l64
+  // CHECK-NEXT: %d0 = moore.variable : l1
+  // CHECK-NEXT: %d1 = moore.variable : i1
+  // CHECK-NEXT: %d2 = moore.variable : l1
+  // CHECK-NEXT: %d3 = moore.variable : i32
+  // CHECK-NEXT: %d4 = moore.variable : i16
+  // CHECK-NEXT: %d5 = moore.variable : i64
+  // CHECK-NEXT: %d6 = moore.variable : l32
+  // CHECK-NEXT: %d7 = moore.variable : i8
+  // CHECK-NEXT: %d8 = moore.variable : l64
   logic d0;
   bit d1;
   reg d2;
@@ -37,15 +37,15 @@ module IntAtoms;
   byte d7;
   time d8;
 
-  // CHECK-NEXT: %u0 = moore.variable : !moore.l1
-  // CHECK-NEXT: %u1 = moore.variable : !moore.i1
-  // CHECK-NEXT: %u2 = moore.variable : !moore.l1
-  // CHECK-NEXT: %u3 = moore.variable : !moore.i32
-  // CHECK-NEXT: %u4 = moore.variable : !moore.i16
-  // CHECK-NEXT: %u5 = moore.variable : !moore.i64
-  // CHECK-NEXT: %u6 = moore.variable : !moore.l32
-  // CHECK-NEXT: %u7 = moore.variable : !moore.i8
-  // CHECK-NEXT: %u8 = moore.variable : !moore.l64
+  // CHECK-NEXT: %u0 = moore.variable : l1
+  // CHECK-NEXT: %u1 = moore.variable : i1
+  // CHECK-NEXT: %u2 = moore.variable : l1
+  // CHECK-NEXT: %u3 = moore.variable : i32
+  // CHECK-NEXT: %u4 = moore.variable : i16
+  // CHECK-NEXT: %u5 = moore.variable : i64
+  // CHECK-NEXT: %u6 = moore.variable : l32
+  // CHECK-NEXT: %u7 = moore.variable : i8
+  // CHECK-NEXT: %u8 = moore.variable : l64
   logic unsigned u0;
   bit unsigned u1;
   reg unsigned u2;
@@ -56,15 +56,15 @@ module IntAtoms;
   byte unsigned u7;
   time unsigned u8;
 
-  // CHECK-NEXT: %s0 = moore.variable : !moore.l1
-  // CHECK-NEXT: %s1 = moore.variable : !moore.i1
-  // CHECK-NEXT: %s2 = moore.variable : !moore.l1
-  // CHECK-NEXT: %s3 = moore.variable : !moore.i32
-  // CHECK-NEXT: %s4 = moore.variable : !moore.i16
-  // CHECK-NEXT: %s5 = moore.variable : !moore.i64
-  // CHECK-NEXT: %s6 = moore.variable : !moore.l32
-  // CHECK-NEXT: %s7 = moore.variable : !moore.i8
-  // CHECK-NEXT: %s8 = moore.variable : !moore.l64
+  // CHECK-NEXT: %s0 = moore.variable : l1
+  // CHECK-NEXT: %s1 = moore.variable : i1
+  // CHECK-NEXT: %s2 = moore.variable : l1
+  // CHECK-NEXT: %s3 = moore.variable : i32
+  // CHECK-NEXT: %s4 = moore.variable : i16
+  // CHECK-NEXT: %s5 = moore.variable : i64
+  // CHECK-NEXT: %s6 = moore.variable : l32
+  // CHECK-NEXT: %s7 = moore.variable : i8
+  // CHECK-NEXT: %s8 = moore.variable : l64
   logic signed s0;
   bit signed s1;
   reg signed s2;
@@ -78,46 +78,46 @@ endmodule
 
 // CHECK-LABEL: moore.module @Dimensions
 module Dimensions;
-  // CHECK-NEXT: %p0 = moore.variable : !moore.l3
+  // CHECK-NEXT: %p0 = moore.variable : l3
   logic [2:0] p0;
-  // CHECK-NEXT: %p1 = moore.variable : !moore.l3
+  // CHECK-NEXT: %p1 = moore.variable : l3
   logic [0:2] p1;
-  // CHECK-NEXT: %p2 = moore.variable : !moore.array<6 x !moore.l3>
+  // CHECK-NEXT: %p2 = moore.variable : array<6 x l3>
   logic [5:0][2:0] p2;
-  // CHECK-NEXT: %p3 = moore.variable : !moore.array<6 x !moore.l3>
+  // CHECK-NEXT: %p3 = moore.variable : array<6 x l3>
   logic [0:5][2:0] p3;
 
-  // CHECK-NEXT: %u0 = moore.variable : !moore.uarray<3 x !moore.l1>
+  // CHECK-NEXT: %u0 = moore.variable : uarray<3 x l1>
   logic u0 [2:0];
-  // CHECK-NEXT: %u1 = moore.variable : !moore.uarray<3 x !moore.l1>
+  // CHECK-NEXT: %u1 = moore.variable : uarray<3 x l1>
   logic u1 [0:2];
-  // CHECK-NEXT: %u2 = moore.variable : !moore.uarray<6 x !moore.uarray<3 x !moore.l1>>
+  // CHECK-NEXT: %u2 = moore.variable : uarray<6 x uarray<3 x l1>>
   logic u2 [5:0][2:0];
-  // CHECK-NEXT: %u3 = moore.variable : !moore.uarray<6 x !moore.uarray<3 x !moore.l1>>
+  // CHECK-NEXT: %u3 = moore.variable : uarray<6 x uarray<3 x l1>>
   logic u3 [0:5][2:0];
-  // CHECK-NEXT: %u4 = moore.variable : !moore.open_uarray<!moore.l1>
+  // CHECK-NEXT: %u4 = moore.variable : open_uarray<l1>
   logic u4 [];
-  // CHECK-NEXT: %u5 = moore.variable : !moore.open_uarray<!moore.open_uarray<!moore.l1>>
+  // CHECK-NEXT: %u5 = moore.variable : open_uarray<open_uarray<l1>>
   logic u5 [][];
-  // CHECK-NEXT: %u6 = moore.variable : !moore.uarray<42 x !moore.l1>
+  // CHECK-NEXT: %u6 = moore.variable : uarray<42 x l1>
   logic u6 [42];
-  // CHECK-NEXT: %u7 = moore.variable : !moore.assoc_array<!moore.l1, !moore.i32>
+  // CHECK-NEXT: %u7 = moore.variable : assoc_array<l1, i32>
   logic u7 [int];
-  // CHECK-NEXT: %u8 = moore.variable : !moore.assoc_array<!moore.l1, !moore.l1>
+  // CHECK-NEXT: %u8 = moore.variable : assoc_array<l1, l1>
   logic u8 [logic];
-  //CHECK-NEXT: %u9 = moore.variable : !moore.queue<!moore.l1, 0>
+  //CHECK-NEXT: %u9 = moore.variable : queue<l1, 0>
   logic u9 [$];
-  //CHECK-NEXT: %u10 = moore.variable : !moore.queue<!moore.l1, 2>
+  //CHECK-NEXT: %u10 = moore.variable : queue<l1, 2>
   logic u10 [$:2];
 endmodule
 
 // CHECK-LABEL: moore.module @RealType
 module RealType;
-  // CHECK-NEXT: %d0 = moore.variable : !moore.real
-  // CHECK-NEXT: %d1 = moore.variable : !moore.real
-  // CHECK-NEXT: %d2 = moore.variable : !moore.real
+  // CHECK-NEXT: %d0 = moore.variable : real
   real d0;
+  // CHECK-NEXT: %d1 = moore.variable : real
   realtime d1;
+  // CHECK-NEXT: %d2 = moore.variable : real
   shortreal d2;
 endmodule
 
@@ -126,10 +126,10 @@ module Structs;
   typedef struct packed { byte a; int b; } myStructA;
   typedef struct { byte x; int y; } myStructB;
 
-  // CHECK-NEXT: %s0 = moore.variable : !moore.packed<struct<{foo: i1, bar: l1}>>
-  // CHECK-NEXT: %s1 = moore.variable : !moore.unpacked<struct<{many: assoc_array<!moore.i1, !moore.i32>}>>
-  // CHECK-NEXT: %s2 = moore.variable : !moore.packed<struct<{a: i8, b: i32}>>
-  // CHECK-NEXT: %s3 = moore.variable : !moore.unpacked<struct<{x: i8, y: i32}>>
+  // CHECK-NEXT: %s0 = moore.variable : packed<struct<{foo: i1, bar: l1}>>
+  // CHECK-NEXT: %s1 = moore.variable : unpacked<struct<{many: assoc_array<i1, i32>}>>
+  // CHECK-NEXT: %s2 = moore.variable : packed<struct<{a: i8, b: i32}>>
+  // CHECK-NEXT: %s3 = moore.variable : unpacked<struct<{x: i8, y: i32}>>
   struct packed { bit foo; logic bar; } s0;
   struct { bit many[int]; } s1;
   myStructA s2;
@@ -141,8 +141,8 @@ module Typedefs;
   typedef logic [2:0] myType1;
   typedef logic myType2 [2:0];
 
-  // CHECK-NEXT: %v0 = moore.variable : !moore.l3
-  // CHECK-NEXT: %v1 = moore.variable : !moore.uarray<3 x !moore.l1>
+  // CHECK-NEXT: %v0 = moore.variable : l3
+  // CHECK-NEXT: %v1 = moore.variable : uarray<3 x l1>
   myType1 v0;
   myType2 v1;
 endmodule

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -54,8 +54,8 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
 
   // CHECK-NEXT: comb.replicate %arg0 : (i1) -> i2
   // CHECK-NEXT: comb.replicate %arg1 : (i1) -> i2
-  moore.replicate %arg0 : (!moore.i1) -> !moore.i2
-  moore.replicate %arg1 : (!moore.l1) -> !moore.l2
+  moore.replicate %arg0 : i1 -> i2
+  moore.replicate %arg1 : l1 -> l2
 
   // CHECK-NEXT: %c12_i32 = hw.constant 12 : i32
   // CHECK-NEXT: %c3_i6 = hw.constant 3 : i6

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -4,38 +4,38 @@
 moore.module @Foo {
   // CHECK: moore.instance "foo" @Foo
   moore.instance "foo" @Foo
-  // CHECK: %v1 = moore.variable : !moore.i1
-  %v1 = moore.variable : !moore.i1
-  %v2 = moore.variable : !moore.i1
-  // CHECK: [[TMP:%.+]] = moore.variable name "v1" %v2 : !moore.i1
-  moore.variable name "v1" %v2 : !moore.i1
+  // CHECK: %v1 = moore.variable : i1
+  %v1 = moore.variable : i1
+  %v2 = moore.variable : i1
+  // CHECK: [[TMP:%.+]] = moore.variable name "v1" %v2 : i1
+  moore.variable name "v1" %v2 : i1
 
-  // CHECK: %w0 = moore.net wire : !moore.l1
-  %w0 = moore.net wire : !moore.l1
-  // CHECK: %w1 = moore.net wire %w0 : !moore.l1
-  %w1 = moore.net wire %w0 : !moore.l1
-  // CHECK: %w2 = moore.net uwire %w0 : !moore.l1
-  %w2 = moore.net uwire %w0 : !moore.l1
-  // CHECK: %w3 = moore.net tri %w0 : !moore.l1
-  %w3 = moore.net tri %w0 : !moore.l1
-  // CHECK: %w4 = moore.net triand %w0 : !moore.l1
-  %w4 = moore.net triand %w0 : !moore.l1
-  // CHECK: %w5 = moore.net trior %w0 : !moore.l1
-  %w5 = moore.net trior %w0 : !moore.l1
-  // CHECK: %w6 = moore.net wand %w0 : !moore.l1
-  %w6 = moore.net wand %w0 : !moore.l1
-  // CHECK: %w7 = moore.net wor %w0 : !moore.l1
-  %w7 = moore.net wor %w0 : !moore.l1
-  // CHECK: %w8 = moore.net trireg %w0 : !moore.l1
-  %w8 = moore.net trireg %w0 : !moore.l1
-  // CHECK: %w9 = moore.net tri0 %w0 : !moore.l1
-  %w9 = moore.net tri0 %w0 : !moore.l1
-  // CHECK: %w10 = moore.net tri1 %w0 : !moore.l1
-  %w10 = moore.net tri1 %w0 : !moore.l1
-  // CHECK: %w11 = moore.net supply0 : !moore.l1
-  %w11 = moore.net supply0 : !moore.l1
-  // CHECK: %w12 = moore.net supply1 : !moore.l1
-  %w12 = moore.net supply1 : !moore.l1
+  // CHECK: %w0 = moore.net wire : l1
+  %w0 = moore.net wire : l1
+  // CHECK: %w1 = moore.net wire %w0 : l1
+  %w1 = moore.net wire %w0 : l1
+  // CHECK: %w2 = moore.net uwire %w0 : l1
+  %w2 = moore.net uwire %w0 : l1
+  // CHECK: %w3 = moore.net tri %w0 : l1
+  %w3 = moore.net tri %w0 : l1
+  // CHECK: %w4 = moore.net triand %w0 : l1
+  %w4 = moore.net triand %w0 : l1
+  // CHECK: %w5 = moore.net trior %w0 : l1
+  %w5 = moore.net trior %w0 : l1
+  // CHECK: %w6 = moore.net wand %w0 : l1
+  %w6 = moore.net wand %w0 : l1
+  // CHECK: %w7 = moore.net wor %w0 : l1
+  %w7 = moore.net wor %w0 : l1
+  // CHECK: %w8 = moore.net trireg %w0 : l1
+  %w8 = moore.net trireg %w0 : l1
+  // CHECK: %w9 = moore.net tri0 %w0 : l1
+  %w9 = moore.net tri0 %w0 : l1
+  // CHECK: %w10 = moore.net tri1 %w0 : l1
+  %w10 = moore.net tri1 %w0 : l1
+  // CHECK: %w11 = moore.net supply0 : l1
+  %w11 = moore.net supply0 : l1
+  // CHECK: %w12 = moore.net supply1 : l1
+  %w12 = moore.net supply1 : l1
 
   // CHECK: moore.procedure initial {
   // CHECK: moore.procedure final {
@@ -50,16 +50,16 @@ moore.module @Foo {
   moore.procedure always_latch {}
   moore.procedure always_ff {}
 
-  // CHECK: moore.assign %v1, %v2 : !moore.i1
-  moore.assign %v1, %v2 : !moore.i1
+  // CHECK: moore.assign %v1, %v2 : i1
+  moore.assign %v1, %v2 : i1
 
   moore.procedure always {
-    // CHECK: moore.blocking_assign %v1, %v2 : !moore.i1
-    moore.blocking_assign %v1, %v2 : !moore.i1
-    // CHECK: moore.nonblocking_assign %v1, %v2 : !moore.i1
-    moore.nonblocking_assign %v1, %v2 : !moore.i1
-    // CHECK: %a = moore.variable : !moore.i32
-    %a = moore.variable : !moore.i32
+    // CHECK: moore.blocking_assign %v1, %v2 : i1
+    moore.blocking_assign %v1, %v2 : i1
+    // CHECK: moore.nonblocking_assign %v1, %v2 : i1
+    moore.nonblocking_assign %v1, %v2 : i1
+    // CHECK: %a = moore.variable : i32
+    %a = moore.variable : i32
   }
 }
 
@@ -69,130 +69,130 @@ moore.module @Bar {
 
 // CHECK-LABEL: moore.module @Expressions
 moore.module @Expressions {
-  %b1 = moore.variable : !moore.i1
-  %l1 = moore.variable : !moore.l1
-  %b5 = moore.variable : !moore.i5
-  %int = moore.variable : !moore.i32
-  %int2 = moore.variable : !moore.i32
-  %integer = moore.variable : !moore.l32
-  %integer2 = moore.variable : !moore.l32
-  %arr = moore.variable : !moore.uarray<2 x !moore.uarray<4 x !moore.i8>>
+  %b1 = moore.variable : i1
+  %l1 = moore.variable : l1
+  %b5 = moore.variable : i5
+  %int = moore.variable : i32
+  %int2 = moore.variable : i32
+  %integer = moore.variable : l32
+  %integer2 = moore.variable : l32
+  %arr = moore.variable : uarray<2 x uarray<4 x i8>>
 
-  // CHECK: moore.constant 0 : !moore.i32
-  moore.constant 0 : !moore.i32
-  // CHECK: moore.constant -2 : !moore.i2
-  moore.constant 2 : !moore.i2
-  // CHECK: moore.constant -2 : !moore.i2
-  moore.constant -2 : !moore.i2
+  // CHECK: moore.constant 0 : i32
+  moore.constant 0 : i32
+  // CHECK: moore.constant -2 : i2
+  moore.constant 2 : i2
+  // CHECK: moore.constant -2 : i2
+  moore.constant -2 : i2
 
   // CHECK: moore.conversion %b5 : !moore.i5 -> !moore.l5
   moore.conversion %b5 : !moore.i5 -> !moore.l5
 
-  // CHECK: moore.neg %int : !moore.i32
-  moore.neg %int : !moore.i32
-  // CHECK: moore.not %int : !moore.i32
-  moore.not %int : !moore.i32
+  // CHECK: moore.neg %int : i32
+  moore.neg %int : i32
+  // CHECK: moore.not %int : i32
+  moore.not %int : i32
 
-  // CHECK: moore.reduce_and %int : !moore.i32 -> !moore.i1
-  moore.reduce_and %int : !moore.i32 -> !moore.i1
-  // CHECK: moore.reduce_or %int : !moore.i32 -> !moore.i1
-  moore.reduce_or %int : !moore.i32 -> !moore.i1
-  // CHECK: moore.reduce_xor %int : !moore.i32 -> !moore.i1
-  moore.reduce_xor %int : !moore.i32 -> !moore.i1
-  // CHECK: moore.reduce_xor %integer : !moore.l32 -> !moore.l1
-  moore.reduce_xor %integer : !moore.l32 -> !moore.l1
+  // CHECK: moore.reduce_and %int : i32 -> i1
+  moore.reduce_and %int : i32 -> i1
+  // CHECK: moore.reduce_or %int : i32 -> i1
+  moore.reduce_or %int : i32 -> i1
+  // CHECK: moore.reduce_xor %int : i32 -> i1
+  moore.reduce_xor %int : i32 -> i1
+  // CHECK: moore.reduce_xor %integer : l32 -> l1
+  moore.reduce_xor %integer : l32 -> l1
 
-  // CHECK: moore.bool_cast %int : !moore.i32 -> !moore.i1
-  moore.bool_cast %int : !moore.i32 -> !moore.i1
-  // CHECK: moore.bool_cast %integer : !moore.l32 -> !moore.l1
-  moore.bool_cast %integer : !moore.l32 -> !moore.l1
+  // CHECK: moore.bool_cast %int : i32 -> i1
+  moore.bool_cast %int : i32 -> i1
+  // CHECK: moore.bool_cast %integer : l32 -> l1
+  moore.bool_cast %integer : l32 -> l1
 
-  // CHECK: moore.add %int, %int2 : !moore.i32
-  moore.add %int, %int2 : !moore.i32
-  // CHECK: moore.sub %int, %int2 : !moore.i32
-  moore.sub %int, %int2 : !moore.i32
-  // CHECK: moore.mul %int, %int2 : !moore.i32
-  moore.mul %int, %int2 : !moore.i32
-  // CHECK: moore.divu %int, %int2 : !moore.i32
-  moore.divu %int, %int2 : !moore.i32
-  // CHECK: moore.divs %int, %int2 : !moore.i32
-  moore.divs %int, %int2 : !moore.i32
-  // CHECK: moore.modu %int, %int2 : !moore.i32
-  moore.modu %int, %int2 : !moore.i32
-  // CHECK: moore.mods %int, %int2 : !moore.i32
-  moore.mods %int, %int2 : !moore.i32
+  // CHECK: moore.add %int, %int2 : i32
+  moore.add %int, %int2 : i32
+  // CHECK: moore.sub %int, %int2 : i32
+  moore.sub %int, %int2 : i32
+  // CHECK: moore.mul %int, %int2 : i32
+  moore.mul %int, %int2 : i32
+  // CHECK: moore.divu %int, %int2 : i32
+  moore.divu %int, %int2 : i32
+  // CHECK: moore.divs %int, %int2 : i32
+  moore.divs %int, %int2 : i32
+  // CHECK: moore.modu %int, %int2 : i32
+  moore.modu %int, %int2 : i32
+  // CHECK: moore.mods %int, %int2 : i32
+  moore.mods %int, %int2 : i32
 
-  // CHECK: moore.and %int, %int2 : !moore.i32
-  moore.and %int, %int2 : !moore.i32
-  // CHECK: moore.or %int, %int2 : !moore.i32
-  moore.or %int, %int2 : !moore.i32
-  // CHECK: moore.xor %int, %int2 : !moore.i32
-  moore.xor %int, %int2 : !moore.i32
+  // CHECK: moore.and %int, %int2 : i32
+  moore.and %int, %int2 : i32
+  // CHECK: moore.or %int, %int2 : i32
+  moore.or %int, %int2 : i32
+  // CHECK: moore.xor %int, %int2 : i32
+  moore.xor %int, %int2 : i32
 
-  // CHECK: moore.shl %l1, %b1 : !moore.l1, !moore.i1
-  moore.shl %l1, %b1 : !moore.l1, !moore.i1
-  // CHECK: moore.shr %l1, %b1 : !moore.l1, !moore.i1
-  moore.shr %l1, %b1 : !moore.l1, !moore.i1
-  // CHECK: moore.ashr %b5, %b1 : !moore.i5, !moore.i1
-  moore.ashr %b5, %b1 : !moore.i5, !moore.i1
+  // CHECK: moore.shl %l1, %b1 : l1, i1
+  moore.shl %l1, %b1 : l1, i1
+  // CHECK: moore.shr %l1, %b1 : l1, i1
+  moore.shr %l1, %b1 : l1, i1
+  // CHECK: moore.ashr %b5, %b1 : i5, i1
+  moore.ashr %b5, %b1 : i5, i1
 
-  // CHECK: moore.eq %int, %int2 : !moore.i32 -> !moore.i1
-  moore.eq %int, %int2 : !moore.i32 -> !moore.i1
-  // CHECK: moore.ne %int, %int2 : !moore.i32 -> !moore.i1
-  moore.ne %int, %int2 : !moore.i32 -> !moore.i1
-  // CHECK: moore.ne %integer, %integer2 : !moore.l32 -> !moore.l1
-  moore.ne %integer, %integer2 : !moore.l32 -> !moore.l1
-  // CHECK: moore.case_eq %int, %int2 : !moore.i32
-  moore.case_eq %int, %int2 : !moore.i32
-  // CHECK: moore.case_ne %int, %int2 : !moore.i32
-  moore.case_ne %int, %int2 : !moore.i32
-  // CHECK: moore.wildcard_eq %int, %int2 : !moore.i32 -> !moore.i1
-  moore.wildcard_eq %int, %int2 : !moore.i32 -> !moore.i1
-  // CHECK: moore.wildcard_ne %int, %int2 : !moore.i32 -> !moore.i1
-  moore.wildcard_ne %int, %int2 : !moore.i32 -> !moore.i1
-  // CHECK: moore.wildcard_ne %integer, %integer2 : !moore.l32 -> !moore.l1
-  moore.wildcard_ne %integer, %integer2 : !moore.l32 -> !moore.l1
+  // CHECK: moore.eq %int, %int2 : i32 -> i1
+  moore.eq %int, %int2 : i32 -> i1
+  // CHECK: moore.ne %int, %int2 : i32 -> i1
+  moore.ne %int, %int2 : i32 -> i1
+  // CHECK: moore.ne %integer, %integer2 : l32 -> l1
+  moore.ne %integer, %integer2 : l32 -> l1
+  // CHECK: moore.case_eq %int, %int2 : i32
+  moore.case_eq %int, %int2 : i32
+  // CHECK: moore.case_ne %int, %int2 : i32
+  moore.case_ne %int, %int2 : i32
+  // CHECK: moore.wildcard_eq %int, %int2 : i32 -> i1
+  moore.wildcard_eq %int, %int2 : i32 -> i1
+  // CHECK: moore.wildcard_ne %int, %int2 : i32 -> i1
+  moore.wildcard_ne %int, %int2 : i32 -> i1
+  // CHECK: moore.wildcard_ne %integer, %integer2 : l32 -> l1
+  moore.wildcard_ne %integer, %integer2 : l32 -> l1
 
-  // CHECK: moore.ult %int, %int2 : !moore.i32 -> !moore.i1
-  moore.ult %int, %int2 : !moore.i32 -> !moore.i1
-  // CHECK: moore.ule %int, %int2 : !moore.i32 -> !moore.i1
-  moore.ule %int, %int2 : !moore.i32 -> !moore.i1
-  // CHECK: moore.ugt %int, %int2 : !moore.i32 -> !moore.i1
-  moore.ugt %int, %int2 : !moore.i32 -> !moore.i1
-  // CHECK: moore.uge %int, %int2 : !moore.i32 -> !moore.i1
-  moore.uge %int, %int2 : !moore.i32 -> !moore.i1
-  // CHECK: moore.slt %int, %int2 : !moore.i32 -> !moore.i1
-  moore.slt %int, %int2 : !moore.i32 -> !moore.i1
-  // CHECK: moore.sle %int, %int2 : !moore.i32 -> !moore.i1
-  moore.sle %int, %int2 : !moore.i32 -> !moore.i1
-  // CHECK: moore.sgt %int, %int2 : !moore.i32 -> !moore.i1
-  moore.sgt %int, %int2 : !moore.i32 -> !moore.i1
-  // CHECK: moore.sge %int, %int2 : !moore.i32 -> !moore.i1
-  moore.sge %int, %int2 : !moore.i32 -> !moore.i1
-  // CHECK: moore.uge %integer, %integer2 : !moore.l32 -> !moore.l1
-  moore.uge %integer, %integer2 : !moore.l32 -> !moore.l1
+  // CHECK: moore.ult %int, %int2 : i32 -> i1
+  moore.ult %int, %int2 : i32 -> i1
+  // CHECK: moore.ule %int, %int2 : i32 -> i1
+  moore.ule %int, %int2 : i32 -> i1
+  // CHECK: moore.ugt %int, %int2 : i32 -> i1
+  moore.ugt %int, %int2 : i32 -> i1
+  // CHECK: moore.uge %int, %int2 : i32 -> i1
+  moore.uge %int, %int2 : i32 -> i1
+  // CHECK: moore.slt %int, %int2 : i32 -> i1
+  moore.slt %int, %int2 : i32 -> i1
+  // CHECK: moore.sle %int, %int2 : i32 -> i1
+  moore.sle %int, %int2 : i32 -> i1
+  // CHECK: moore.sgt %int, %int2 : i32 -> i1
+  moore.sgt %int, %int2 : i32 -> i1
+  // CHECK: moore.sge %int, %int2 : i32 -> i1
+  moore.sge %int, %int2 : i32 -> i1
+  // CHECK: moore.uge %integer, %integer2 : l32 -> l1
+  moore.uge %integer, %integer2 : l32 -> l1
 
-  // CHECK: moore.concat %b1 : (!moore.i1) -> !moore.i1
-  moore.concat %b1 : (!moore.i1) -> !moore.i1
-  // CHECK: moore.concat %b5, %b1 : (!moore.i5, !moore.i1) -> !moore.i6
-  moore.concat %b5, %b1 : (!moore.i5, !moore.i1) -> !moore.i6
-  // CHECK: moore.concat %l1, %l1, %l1 : (!moore.l1, !moore.l1, !moore.l1) -> !moore.l3
-  moore.concat %l1, %l1, %l1 : (!moore.l1, !moore.l1, !moore.l1) -> !moore.l3
-  // CHECK: moore.replicate %b1 : (!moore.i1) -> !moore.i4
-  moore.replicate %b1 : (!moore.i1) -> !moore.i4
+  // CHECK: moore.concat %b1 : (!moore.i1) -> i1
+  moore.concat %b1 : (!moore.i1) -> i1
+  // CHECK: moore.concat %b5, %b1 : (!moore.i5, !moore.i1) -> i6
+  moore.concat %b5, %b1 : (!moore.i5, !moore.i1) -> i6
+  // CHECK: moore.concat %l1, %l1, %l1 : (!moore.l1, !moore.l1, !moore.l1) -> l3
+  moore.concat %l1, %l1, %l1 : (!moore.l1, !moore.l1, !moore.l1) -> l3
+  // CHECK: moore.replicate %b1 : i1 -> i4
+  moore.replicate %b1 : i1 -> i4
 
-  // CHECK: moore.extract %b5 from %b1 : !moore.i5, !moore.i1 -> !moore.i1
-  moore.extract %b5 from %b1 : !moore.i5, !moore.i1 -> !moore.i1
-  // CHECK: [[VAL1:%.*]] = moore.constant 0 : !moore.i32
-  // CHECK: [[VAL2:%.*]] = moore.extract %arr from [[VAL1]] : !moore.uarray<2 x !moore.uarray<4 x !moore.i8>>, !moore.i32 -> !moore.uarray<4 x !moore.i8>
-  %1 = moore.constant 0 : !moore.i32
-  %2 = moore.extract %arr from %1 : !moore.uarray<2 x !moore.uarray<4 x !moore.i8>>, !moore.i32 -> !moore.uarray<4 x !moore.i8>
-  // CHECK: [[VAL3:%.*]] = moore.constant 3 : !moore.i32
-  // CHECK: [[VAL4:%.*]] = moore.extract [[VAL2]] from [[VAL3]] : !moore.uarray<4 x !moore.i8>, !moore.i32 -> !moore.i8
-  %3 = moore.constant 3 : !moore.i32
-  %4 = moore.extract %2 from %3 : !moore.uarray<4 x !moore.i8>, !moore.i32 -> !moore.i8
-  // CHECK: [[VAL5:%.*]] = moore.constant 2 : !moore.i32
-  // CHECK: moore.extract [[VAL4]] from [[VAL5]] : !moore.i8, !moore.i32 -> !moore.i5
-  %5 = moore.constant 2 : !moore.i32
-  moore.extract %4 from %5 : !moore.i8, !moore.i32 -> !moore.i5
+  // CHECK: moore.extract %b5 from %b1 : i5, i1 -> i1
+  moore.extract %b5 from %b1 : i5, i1 -> i1
+  // CHECK: [[VAL1:%.*]] = moore.constant 0 : i32
+  // CHECK: [[VAL2:%.*]] = moore.extract %arr from [[VAL1]] : uarray<2 x uarray<4 x i8>>, i32 -> uarray<4 x i8>
+  %1 = moore.constant 0 : i32
+  %2 = moore.extract %arr from %1 : uarray<2 x uarray<4 x i8>>, i32 -> uarray<4 x i8>
+  // CHECK: [[VAL3:%.*]] = moore.constant 3 : i32
+  // CHECK: [[VAL4:%.*]] = moore.extract [[VAL2]] from [[VAL3]] : uarray<4 x i8>, i32 -> i8
+  %3 = moore.constant 3 : i32
+  %4 = moore.extract %2 from %3 : uarray<4 x i8>, i32 -> i8
+  // CHECK: [[VAL5:%.*]] = moore.constant 2 : i32
+  // CHECK: moore.extract [[VAL4]] from [[VAL5]] : i8, i32 -> i5
+  %5 = moore.constant 2 : i32
+  moore.extract %4 from %5 : i8, i32 -> i5
 }

--- a/test/Dialect/Moore/types-errors.mlir
+++ b/test/Dialect/Moore/types-errors.mlir
@@ -5,11 +5,11 @@
 func.func @Foo(%arg0: !moore.struct<{}, loc(unknown)>) { return }
 
 // -----
-// expected-error @below {{invalid kind of type specified}}
+// expected-error @below {{invalid kind of Type specified}}
 // expected-error @below {{parameter 'elementType' which is to be a `PackedType`}}
-unrealized_conversion_cast to !moore.array<4 x !moore.string>
+unrealized_conversion_cast to !moore.array<4 x string>
 
 // -----
-// expected-error @below {{invalid kind of type specified}}
+// expected-error @below {{invalid kind of Type specified}}
 // expected-error @below {{parameter 'elementType' which is to be a `PackedType`}}
-unrealized_conversion_cast to !moore.open_array<!moore.string>
+unrealized_conversion_cast to !moore.open_array<string>

--- a/test/Dialect/Moore/types.mlir
+++ b/test/Dialect/Moore/types.mlir
@@ -18,22 +18,22 @@ unrealized_conversion_cast to !moore.l42
 unrealized_conversion_cast to !moore.real
 
 // Packed Arrays
-// CHECK: !moore.array<4 x !moore.i42>
-unrealized_conversion_cast to !moore.array<4 x !moore.i42>
-// CHECK: !moore.open_array<!moore.i42>
-unrealized_conversion_cast to !moore.open_array<!moore.i42>
+// CHECK: !moore.array<4 x i42>
+unrealized_conversion_cast to !moore.array<4 x i42>
+// CHECK: !moore.open_array<i42>
+unrealized_conversion_cast to !moore.open_array<i42>
 
 // Unpacked arrays
-// CHECK: !moore.uarray<4 x !moore.i42>
-unrealized_conversion_cast to !moore.uarray<4 x !moore.i42>
-// CHECK: !moore.uarray<4 x !moore.string>
-unrealized_conversion_cast to !moore.uarray<4 x !moore.string>
-// CHECK: !moore.open_uarray<!moore.string>
-unrealized_conversion_cast to !moore.open_uarray<!moore.string>
-// CHECK: !moore.assoc_array<!moore.string, !moore.chandle>
-unrealized_conversion_cast to !moore.assoc_array<!moore.string, !moore.chandle>
-// CHECK: !moore.queue<!moore.string, 42>
-unrealized_conversion_cast to !moore.queue<!moore.string, 42>
+// CHECK: !moore.uarray<4 x i42>
+unrealized_conversion_cast to !moore.uarray<4 x i42>
+// CHECK: !moore.uarray<4 x string>
+unrealized_conversion_cast to !moore.uarray<4 x string>
+// CHECK: !moore.open_uarray<string>
+unrealized_conversion_cast to !moore.open_uarray<string>
+// CHECK: !moore.assoc_array<string, chandle>
+unrealized_conversion_cast to !moore.assoc_array<string, chandle>
+// CHECK: !moore.queue<string, 42>
+unrealized_conversion_cast to !moore.queue<string, 42>
 
 // CHECK-LABEL: func @StructTypes(
 func.func @StructTypes(


### PR DESCRIPTION
Operations defined through TableGen will use a version of type parsing and printing that strips away the dialect prefix in case this does not lead to ambiguities. If an op specifies a type like `UnpackedType`, the generated parser and printer will call `UnpackedType::parse` and `UnpackedType::print` in order to parse and print that type. This method usually prints the type without any dialect prefixes, and often also without the type name itself (as it is obvious given the type).

Add an implementation for `parse` and `print` to `UnpackedType` which performs this stripped printing. This makes the assembly more compact and in-line with what MLIR would generate by default if a TableGen-specified op would use a TableGen-specified type.

This makes the integer flavor of `IntType` look exactly like the builtin integer type, which will facilitate a future change from Moore's integer type to the builtin integer. Parsing is unambiguous, since the stripped form is only used when the type is clear from the op context.