### PR TITLE
[Moore] Move struct types into ODS

### DIFF
--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -273,6 +273,40 @@ def QueueType : MooreTypeDef<"Queue", [], "moore::UnpackedType"> {
 
 
 //===----------------------------------------------------------------------===//
+// Structs
+//===----------------------------------------------------------------------===//
+
+// Common pieces of struct-like types.
+class StructLikeType<
+  string name, list<Trait> traits = [], string baseCppClass = "::mlir::Type"
+> : MooreTypeDef<name, traits, baseCppClass> {
+  let parameters = (ins ArrayRefParameter<"StructMember">:$members);
+  let assemblyFormat = [{
+    `<` custom<Members>($members) `>`
+  }];
+}
+
+def StructType : StructLikeType<"Struct", [], "moore::PackedType"> {
+  let mnemonic = "struct";
+  let summary = "a packed struct type";
+  let description = [{
+    A packed struct. All members are guaranteed to be packed as well.
+  }];
+  let genVerifyDecl = 1;
+}
+
+def UnpackedStructType : StructLikeType<
+  "UnpackedStruct", [], "moore::UnpackedType"
+> {
+  let mnemonic = "ustruct";
+  let summary = "an unpacked struct type";
+  let description = [{
+    An unpacked struct.
+  }];
+}
+
+
+//===----------------------------------------------------------------------===//
 // Constraints
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Moore/MooreTypes.cpp
+++ b/lib/Dialect/Moore/MooreTypes.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file implement the Moore dialect type system.
+// This file implements the Moore dialect type system.
 //
 //===----------------------------------------------------------------------===//
 
@@ -20,49 +20,13 @@ using namespace circt;
 using namespace circt::moore;
 using mlir::AsmParser;
 using mlir::AsmPrinter;
-using mlir::LocationAttr;
-using mlir::OptionalParseResult;
-using mlir::StringSwitch;
-using mlir::TypeStorage;
-using mlir::TypeStorageAllocator;
 
-//===----------------------------------------------------------------------===//
-// Generated logic
-//===----------------------------------------------------------------------===//
+static LogicalResult parseMembers(AsmParser &parser,
+                                  SmallVector<StructMember> &members);
+static void printMembers(AsmPrinter &printer, ArrayRef<StructMember> members);
 
-#define GET_TYPEDEF_CLASSES
-#include "circt/Dialect/Moore/MooreTypes.cpp.inc"
-
-void MooreDialect::registerTypes() {
-  addTypes<PackedStructType, UnpackedStructType>();
-
-  addTypes<
-#define GET_TYPEDEF_LIST
-#include "circt/Dialect/Moore/MooreTypes.cpp.inc"
-      >();
-}
-
-//===----------------------------------------------------------------------===//
-// Utilities
-//===----------------------------------------------------------------------===//
-
-StringRef moore::getKeywordFromSign(const Sign &sign) {
-  switch (sign) {
-  case Sign::Unsigned:
-    return "unsigned";
-  case Sign::Signed:
-    return "signed";
-  }
-  llvm_unreachable("all signs should be handled");
-}
-
-struct Subset {
-  enum { None, Unpacked, Packed } implied = None;
-  bool allowUnpacked = true;
-};
-
-static ParseResult parseMooreType(AsmParser &parser, Subset subset, Type &type);
-static void printMooreType(Type type, AsmPrinter &printer, Subset subset);
+static ParseResult parseMooreType(AsmParser &parser, Type &type);
+static void printMooreType(Type type, AsmPrinter &printer);
 
 //===----------------------------------------------------------------------===//
 // Unpacked Type
@@ -74,8 +38,12 @@ Domain UnpackedType::getDomain() const {
       .Case<UnpackedArrayType, OpenUnpackedArrayType, AssocArrayType,
             QueueType>(
           [&](auto type) { return type.getElementType().getDomain(); })
-      .Case<UnpackedStructType>(
-          [](auto type) { return type.getStruct().domain; })
+      .Case<UnpackedStructType>([](auto type) {
+        for (const auto &member : type.getMembers())
+          if (member.type.getDomain() == Domain::FourValued)
+            return Domain::FourValued;
+        return Domain::TwoValued;
+      })
       .Default([](auto) { return Domain::TwoValued; });
 }
 
@@ -88,20 +56,29 @@ std::optional<unsigned> UnpackedType::getBitSize() const {
           return (*size) * type.getSize();
         return {};
       })
-      .Case<UnpackedStructType>(
-          [](auto type) { return type.getStruct().bitSize; })
+      .Case<UnpackedStructType>([](auto type) -> std::optional<unsigned> {
+        unsigned size = 0;
+        for (const auto &member : type.getMembers()) {
+          if (auto memberSize = member.type.getBitSize()) {
+            size += *memberSize;
+          } else {
+            return std::nullopt;
+          }
+        }
+        return size;
+      })
       .Default([](auto) { return std::nullopt; });
 }
 
 Type UnpackedType::parse(mlir::AsmParser &parser) {
   Type type;
-  if (parseMooreType(parser, {Subset::None, true}, type))
+  if (parseMooreType(parser, type))
     return {};
   return type;
 }
 
 void UnpackedType::print(mlir::AsmPrinter &printer) const {
-  printMooreType(*this, printer, {Subset::None, true});
+  printMooreType(*this, printer);
 }
 
 //===----------------------------------------------------------------------===//
@@ -114,8 +91,12 @@ Domain PackedType::getDomain() const {
       .Case<IntType>([&](auto type) { return type.getDomain(); })
       .Case<ArrayType, OpenArrayType>(
           [&](auto type) { return type.getElementType().getDomain(); })
-      .Case<PackedStructType>(
-          [](auto type) { return type.getStruct().domain; });
+      .Case<StructType>([](auto type) {
+        for (const auto &member : type.getMembers())
+          if (member.type.getDomain() == Domain::FourValued)
+            return Domain::FourValued;
+        return Domain::TwoValued;
+      });
 }
 
 std::optional<unsigned> PackedType::getBitSize() const {
@@ -128,160 +109,88 @@ std::optional<unsigned> PackedType::getBitSize() const {
         return {};
       })
       .Case<OpenArrayType>([](auto) { return std::nullopt; })
-      .Case<PackedStructType>(
-          [](auto type) { return type.getStruct().bitSize; });
+      .Case<StructType>([](auto type) -> std::optional<unsigned> {
+        unsigned size = 0;
+        for (const auto &member : type.getMembers()) {
+          if (auto memberSize = member.type.getBitSize()) {
+            size += *memberSize;
+          } else {
+            return std::nullopt;
+          }
+        }
+        return size;
+      });
 }
 
 //===----------------------------------------------------------------------===//
-// Packed and Unpacked Structs
+// Structs
 //===----------------------------------------------------------------------===//
 
-StringRef moore::getMnemonicFromStructKind(StructKind kind) {
-  switch (kind) {
-  case StructKind::Struct:
-    return "struct";
-  case StructKind::Union:
-    return "union";
-  case StructKind::TaggedUnion:
-    return "tagged_union";
-  }
-  llvm_unreachable("all struct kinds should be handled");
-}
+/// Parse a list of struct members.
+static LogicalResult parseMembers(AsmParser &parser,
+                                  SmallVector<StructMember> &members) {
+  return parser.parseCommaSeparatedList(AsmParser::Delimiter::Braces, [&]() {
+    std::string name;
+    UnpackedType type;
+    if (parser.parseKeywordOrString(&name) || parser.parseColon() ||
+        parser.parseCustomTypeWithFallback(type))
+      return failure();
 
-std::optional<StructKind> moore::getStructKindFromMnemonic(StringRef mnemonic) {
-  return StringSwitch<std::optional<StructKind>>(mnemonic)
-      .Case("struct", StructKind::Struct)
-      .Case("union", StructKind::Union)
-      .Case("tagged_union", StructKind::TaggedUnion)
-      .Default({});
-}
-
-Struct::Struct(StructKind kind, ArrayRef<StructMember> members)
-    : kind(kind), members(members.begin(), members.end()) {
-  // The struct's value domain is two-valued if all members are two-valued.
-  // Otherwise it is four-valued.
-  domain = llvm::all_of(members,
-                        [](auto &member) {
-                          return member.type.getDomain() == Domain::TwoValued;
-                        })
-               ? Domain::TwoValued
-               : Domain::FourValued;
-
-  // The bit size is the sum of all member bit sizes, or `None` if any of the
-  // member bit sizes are `None`.
-  bitSize = 0;
-  for (const auto &member : members) {
-    if (auto memberSize = member.type.getBitSize()) {
-      *bitSize += *memberSize;
-    } else {
-      bitSize = std::nullopt;
-      break;
-    }
-  }
-}
-
-namespace circt {
-namespace moore {
-namespace detail {
-
-struct StructTypeStorage : TypeStorage {
-  using KeyTy = std::tuple<unsigned, ArrayRef<StructMember>>;
-
-  StructTypeStorage(KeyTy key)
-      : strukt(static_cast<StructKind>(std::get<0>(key)), std::get<1>(key)) {}
-  bool operator==(const KeyTy &key) const {
-    return std::get<0>(key) == static_cast<unsigned>(strukt.kind) &&
-           std::get<1>(key) == ArrayRef<StructMember>(strukt.members);
-  }
-  static StructTypeStorage *construct(TypeStorageAllocator &allocator,
-                                      const KeyTy &key) {
-    return new (allocator.allocate<StructTypeStorage>()) StructTypeStorage(key);
-  }
-
-  Struct strukt;
-};
-
-} // namespace detail
-} // namespace moore
-} // namespace circt
-
-PackedStructType PackedStructType::get(MLIRContext *context, StructKind kind,
-                                       ArrayRef<StructMember> members) {
-  assert(llvm::all_of(members,
-                      [](const StructMember &member) {
-                        return llvm::isa<PackedType>(member.type);
-                      }) &&
-         "packed struct members must be packed");
-  return Base::get(context, static_cast<unsigned>(kind), members);
-}
-
-const Struct &PackedStructType::getStruct() const { return getImpl()->strukt; }
-
-UnpackedStructType UnpackedStructType::get(MLIRContext *context,
-                                           StructKind kind,
-                                           ArrayRef<StructMember> members) {
-  return Base::get(context, static_cast<unsigned>(kind), members);
-}
-
-const Struct &UnpackedStructType::getStruct() const {
-  return getImpl()->strukt;
-}
-
-//===----------------------------------------------------------------------===//
-// Parsing and Printing
-//===----------------------------------------------------------------------===//
-
-/// Parse a type with custom syntax.
-static OptionalParseResult customTypeParser(AsmParser &parser,
-                                            StringRef mnemonic, Subset subset,
-                                            llvm::SMLoc loc, Type &type) {
-  auto *context = parser.getContext();
-
-  auto yieldPacked = [&](PackedType x) {
-    type = x;
+    members.push_back({StringAttr::get(parser.getContext(), name), type});
     return success();
-  };
-  auto yieldUnpacked = [&](UnpackedType x) {
-    if (!subset.allowUnpacked) {
-      parser.emitError(loc)
-          << "unpacked type " << x << " where only packed types are allowed";
-      return failure();
-    }
-    type = x;
-    return success();
-  };
-  auto yieldImplied =
-      [&](llvm::function_ref<PackedType()> ifPacked,
-          llvm::function_ref<UnpackedType()> ifUnpacked) {
-        if (subset.implied == Subset::Packed)
-          return yieldPacked(ifPacked());
-        if (subset.implied == Subset::Unpacked)
-          return yieldUnpacked(ifUnpacked());
-        parser.emitError(loc)
-            << "ambiguous packing; wrap `" << mnemonic
-            << "` in `packed<...>` or `unpacked<...>` to disambiguate";
-        return failure();
-      };
+  });
+}
 
-  // Explicit packing indicators, like `unpacked.named`.
-  if (mnemonic == "unpacked") {
-    UnpackedType inner;
-    if (parser.parseLess() ||
-        parseMooreType(parser, {Subset::Unpacked, true}, inner) ||
-        parser.parseGreater())
-      return failure();
-    return yieldUnpacked(inner);
-  }
-  if (mnemonic == "packed") {
-    PackedType inner;
-    if (parser.parseLess() ||
-        parseMooreType(parser, {Subset::Packed, false}, inner) ||
-        parser.parseGreater())
-      return failure();
-    return yieldPacked(inner);
-  }
+/// Print a list of struct members.
+static void printMembers(AsmPrinter &printer, ArrayRef<StructMember> members) {
+  printer << "{";
+  llvm::interleaveComma(members, printer.getStream(),
+                        [&](const StructMember &member) {
+                          printer.printKeywordOrString(member.name);
+                          printer << ": ";
+                          printer.printStrippedAttrOrType(member.type);
+                        });
+  printer << "}";
+}
 
-  // Packed primary types.
+LogicalResult StructType::verify(function_ref<InFlightDiagnostic()> emitError,
+                                 ArrayRef<StructMember> members) {
+  if (!llvm::all_of(members, [](const auto &member) {
+        return llvm::isa<PackedType>(member.type);
+      }))
+    return emitError() << "StructType members must be packed types";
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Generated logic
+//===----------------------------------------------------------------------===//
+
+#define GET_TYPEDEF_CLASSES
+#include "circt/Dialect/Moore/MooreTypes.cpp.inc"
+
+void MooreDialect::registerTypes() {
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "circt/Dialect/Moore/MooreTypes.cpp.inc"
+      >();
+}
+
+//===----------------------------------------------------------------------===//
+// Parsing and printing
+//===----------------------------------------------------------------------===//
+
+/// Parse a type registered with this dialect.
+static ParseResult parseMooreType(AsmParser &parser, Type &type) {
+  llvm::SMLoc loc = parser.getCurrentLocation();
+
+  // Try the generated parser first.
+  StringRef mnemonic;
+  if (auto result = generatedTypeParser(parser, &mnemonic, type);
+      result.has_value())
+    return result.value();
+
+  // Handle abbreviated integer types such as `i42` and `l42`.
   if (mnemonic.size() > 1 && (mnemonic[0] == 'i' || mnemonic[0] == 'l') &&
       isdigit(mnemonic[1])) {
     auto domain = mnemonic[0] == 'i' ? Domain::TwoValued : Domain::FourValued;
@@ -289,102 +198,9 @@ static OptionalParseResult customTypeParser(AsmParser &parser,
     unsigned width;
     if (spelling.getAsInteger(10, width))
       return parser.emitError(loc, "integer width invalid");
-    return yieldPacked(IntType::get(context, width, domain));
+    type = IntType::get(parser.getContext(), width, domain);
+    return success();
   }
-
-  // Everything that follows can be packed or unpacked. The packing is inferred
-  // from the last `packed<...>` or `unpacked<...>` that we've seen. The
-  // `yieldImplied` function will call the first lambda to construct a packed
-  // type, or the second lambda to construct an unpacked type. If the
-  // `subset.implied` field is not set, which means there hasn't been any prior
-  // `packed` or `unpacked`, the function will emit an error properly.
-
-  // Structs
-  if (auto kind = getStructKindFromMnemonic(mnemonic)) {
-    if (parser.parseLess())
-      return failure();
-
-    StringRef keyword;
-    SmallVector<StructMember> members;
-    auto result2 =
-        parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Braces, [&]() {
-          if (parser.parseKeyword(&keyword))
-            return failure();
-          UnpackedType type;
-          if (parser.parseColon() || parseMooreType(parser, subset, type))
-            return failure();
-          members.push_back(
-              {StringAttr::get(parser.getContext(), keyword), type});
-          return success();
-        });
-    if (result2)
-      return failure();
-
-    return yieldImplied(
-        [&]() {
-          return PackedStructType::get(parser.getContext(), *kind, members);
-        },
-        [&]() {
-          return UnpackedStructType::get(parser.getContext(), *kind, members);
-        });
-  }
-
-  return {};
-}
-
-/// Print a type with custom syntax.
-static LogicalResult customTypePrinter(Type type, AsmPrinter &printer,
-                                       Subset subset) {
-  // If we are printing a type that may be both packed or unpacked, emit a
-  // wrapping `packed<...>` or `unpacked<...>` accordingly if not done so
-  // previously, in order to disambiguate between the two.
-  if (llvm::isa<PackedStructType>(type) ||
-      llvm::isa<UnpackedStructType>(type)) {
-    auto needed =
-        llvm::isa<PackedType>(type) ? Subset::Packed : Subset::Unpacked;
-    if (needed != subset.implied) {
-      printer << (needed == Subset::Packed ? "packed" : "unpacked") << "<";
-      printMooreType(type, printer, {needed, true});
-      printer << ">";
-      return success();
-    }
-  }
-
-  return TypeSwitch<Type, LogicalResult>(type)
-      // Integers and reals
-      .Case<IntType>([&](auto type) {
-        printer << (type.getDomain() == Domain::TwoValued ? "i" : "l");
-        printer << type.getWidth();
-        return success();
-      })
-
-      // Structs
-      .Case<PackedStructType, UnpackedStructType>([&](auto type) {
-        const auto &strukt = type.getStruct();
-        printer << getMnemonicFromStructKind(strukt.kind) << "<{";
-        llvm::interleaveComma(strukt.members, printer, [&](const auto &member) {
-          printer << member.name.getValue() << ": ";
-          printMooreType(member.type, printer, subset);
-        });
-        printer << "}>";
-        return success();
-      })
-
-      .Default([](auto) { return failure(); });
-}
-
-/// Parse a type registered with this dialect.
-static ParseResult parseMooreType(AsmParser &parser, Subset subset,
-                                  Type &type) {
-  llvm::SMLoc loc = parser.getCurrentLocation();
-  StringRef mnemonic;
-  if (auto result = generatedTypeParser(parser, &mnemonic, type);
-      result.has_value())
-    return result.value();
-
-  if (auto result = customTypeParser(parser, mnemonic, subset, loc, type);
-      result.has_value())
-    return result.value();
 
   parser.emitError(loc) << "unknown type `" << mnemonic
                         << "` in dialect `moore`";
@@ -392,10 +208,16 @@ static ParseResult parseMooreType(AsmParser &parser, Subset subset,
 }
 
 /// Print a type registered with this dialect.
-static void printMooreType(Type type, AsmPrinter &printer, Subset subset) {
-  if (succeeded(generatedTypePrinter(type, printer)))
+static void printMooreType(Type type, AsmPrinter &printer) {
+  // Handle abbreviated integer types such as `i42` and `l42`.
+  if (auto intType = dyn_cast<IntType>(type)) {
+    printer << (intType.getDomain() == Domain::TwoValued ? "i" : "l");
+    printer << intType.getWidth();
     return;
-  if (succeeded(customTypePrinter(type, printer, subset)))
+  }
+
+  // Otherwise fall back to the generated printer.
+  if (succeeded(generatedTypePrinter(type, printer)))
     return;
   assert(false && "no printer for unknown `moore` dialect type");
 }
@@ -403,12 +225,12 @@ static void printMooreType(Type type, AsmPrinter &printer, Subset subset) {
 /// Parse a type registered with this dialect.
 Type MooreDialect::parseType(DialectAsmParser &parser) const {
   Type type;
-  if (parseMooreType(parser, {Subset::None, true}, type))
+  if (parseMooreType(parser, type))
     return {};
   return type;
 }
 
 /// Print a type registered with this dialect.
 void MooreDialect::printType(Type type, DialectAsmPrinter &printer) const {
-  printMooreType(type, printer, {Subset::None, true});
+  printMooreType(type, printer);
 }

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -311,11 +311,11 @@ module Expressions;
   logic [0:31] vec_2;
   // CHECK: %arr = moore.variable : uarray<3 x uarray<6 x i4>>
   bit [4:1] arr [1:3][2:7];
-  // CHECK: %struct0 = moore.variable : packed<struct<{a: i32, b: i32}>>
+  // CHECK: %struct0 = moore.variable : struct<{a: i32, b: i32}>
   struct packed {
     int a, b;
   } struct0;
-  // CHECK: %struct1 = moore.variable : packed<struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>>
+  // CHECK: %struct1 = moore.variable : struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>
   struct packed {
     struct packed {
       int a, b;
@@ -643,21 +643,21 @@ module Expressions;
     // CHECK: moore.blocking_assign %a, [[TMP2]]
     a += (a *= a--);
 
-    // CHECK: [[TMP:%.+]] = moore.struct_extract %struct0, "a" : packed<struct<{a: i32, b: i32}>> -> i32
+    // CHECK: [[TMP:%.+]] = moore.struct_extract %struct0, "a" : struct<{a: i32, b: i32}> -> i32
     // CHECK: moore.blocking_assign [[TMP]], %a : i32
     struct0.a = a;
 
-    // CHECK: [[TMP:%.+]]  = moore.struct_extract %struct0, "b" : packed<struct<{a: i32, b: i32}>> -> i32
+    // CHECK: [[TMP:%.+]]  = moore.struct_extract %struct0, "b" : struct<{a: i32, b: i32}> -> i32
     // CHECK: moore.blocking_assign %b, [[TMP]] : i32
     b = struct0.b;
 
-    // CHECK: [[TMP1:%.+]] = moore.struct_extract %struct1, "c" : packed<struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>> -> packed<struct<{a: i32, b: i32}>>
-    // CHECK: [[TMP2:%.+]] = moore.struct_extract [[TMP1]], "a" : packed<struct<{a: i32, b: i32}>> -> i32
+    // CHECK: [[TMP1:%.+]] = moore.struct_extract %struct1, "c" : struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}> -> struct<{a: i32, b: i32}>
+    // CHECK: [[TMP2:%.+]] = moore.struct_extract [[TMP1]], "a" : struct<{a: i32, b: i32}> -> i32
     // CHECK: moore.blocking_assign [[TMP2]], %a : i32
     struct1.c.a = a;
 
-    // CHECK: [[TMP1:%.+]] = moore.struct_extract %struct1, "d" : packed<struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>> -> packed<struct<{a: i32, b: i32}>>
-    // CHECK: [[TMP2:%.+]] = moore.struct_extract [[TMP1]], "b" : packed<struct<{a: i32, b: i32}>> -> i32
+    // CHECK: [[TMP1:%.+]] = moore.struct_extract %struct1, "d" : struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}> -> struct<{a: i32, b: i32}>
+    // CHECK: [[TMP2:%.+]] = moore.struct_extract [[TMP1]], "b" : struct<{a: i32, b: i32}> -> i32
     // CHECK: moore.blocking_assign %b, [[TMP2]] : i32
     b = struct1.d.b;
   end

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -126,10 +126,10 @@ module Structs;
   typedef struct packed { byte a; int b; } myStructA;
   typedef struct { byte x; int y; } myStructB;
 
-  // CHECK-NEXT: %s0 = moore.variable : packed<struct<{foo: i1, bar: l1}>>
-  // CHECK-NEXT: %s1 = moore.variable : unpacked<struct<{many: assoc_array<i1, i32>}>>
-  // CHECK-NEXT: %s2 = moore.variable : packed<struct<{a: i8, b: i32}>>
-  // CHECK-NEXT: %s3 = moore.variable : unpacked<struct<{x: i8, y: i32}>>
+  // CHECK-NEXT: %s0 = moore.variable : struct<{foo: i1, bar: l1}>
+  // CHECK-NEXT: %s1 = moore.variable : ustruct<{many: assoc_array<i1, i32>}>
+  // CHECK-NEXT: %s2 = moore.variable : struct<{a: i8, b: i32}>
+  // CHECK-NEXT: %s3 = moore.variable : ustruct<{x: i8, y: i32}>
   struct packed { bit foo; logic bar; } s0;
   struct { bit many[int]; } s1;
   myStructA s2;

--- a/test/Dialect/Moore/types-errors.mlir
+++ b/test/Dialect/Moore/types-errors.mlir
@@ -1,10 +1,6 @@
 // RUN: circt-opt --verify-diagnostics --split-input-file %s
 
 // -----
-// expected-error @+1 {{ambiguous packing; wrap `struct` in `packed<...>` or `unpacked<...>` to disambiguate}}
-func.func @Foo(%arg0: !moore.struct<{}, loc(unknown)>) { return }
-
-// -----
 // expected-error @below {{invalid kind of Type specified}}
 // expected-error @below {{parameter 'elementType' which is to be a `PackedType`}}
 unrealized_conversion_cast to !moore.array<4 x string>
@@ -13,3 +9,7 @@ unrealized_conversion_cast to !moore.array<4 x string>
 // expected-error @below {{invalid kind of Type specified}}
 // expected-error @below {{parameter 'elementType' which is to be a `PackedType`}}
 unrealized_conversion_cast to !moore.open_array<string>
+
+// -----
+// expected-error @below {{StructType members must be packed types}}
+unrealized_conversion_cast to !moore.struct<{foo: string}>

--- a/test/Dialect/Moore/types.mlir
+++ b/test/Dialect/Moore/types.mlir
@@ -35,14 +35,22 @@ unrealized_conversion_cast to !moore.assoc_array<string, chandle>
 // CHECK: !moore.queue<string, 42>
 unrealized_conversion_cast to !moore.queue<string, 42>
 
-// CHECK-LABEL: func @StructTypes(
-func.func @StructTypes(
-  // CHECK-SAME: %arg0: !moore.packed<struct<{}>>
-  // CHECK-SAME: %arg1: !moore.packed<struct<{foo: i1, bar: i32}>>
-  %arg0: !moore.packed<struct<{}>>,
-  %arg1: !moore.packed<struct<{foo: i1, bar: i32}>>,
-  // CHECK-SAME: %arg2: !moore.unpacked<struct<{}>>
-  // CHECK-SAME: %arg3: !moore.unpacked<struct<{foo: string, bar: event}>>
-  %arg2: !moore.unpacked<struct<{}>>,
-  %arg3: !moore.unpacked<struct<{foo: string, bar: event}>>
-) { return }
+// Packed structs
+// CHECK: !moore.struct<{}>
+unrealized_conversion_cast to !moore.struct<{}>
+// CHECK: !moore.struct<{foo: i42}>
+unrealized_conversion_cast to !moore.struct<{foo: i42}>
+// CHECK: !moore.struct<{foo: i42, bar: i1337}>
+unrealized_conversion_cast to !moore.struct<{foo: i42, bar: i1337}>
+// CHECK: !moore.struct<{"a b": i42}>
+unrealized_conversion_cast to !moore.struct<{"a b": i42}>
+
+// Unpacked structs
+// CHECK: !moore.ustruct<{}>
+unrealized_conversion_cast to !moore.ustruct<{}>
+// CHECK: !moore.ustruct<{foo: string}>
+unrealized_conversion_cast to !moore.ustruct<{foo: string}>
+// CHECK: !moore.ustruct<{foo: i42, bar: string}>
+unrealized_conversion_cast to !moore.ustruct<{foo: i42, bar: string}>
+// CHECK: !moore.ustruct<{"a b": string}>
+unrealized_conversion_cast to !moore.ustruct<{"a b": string}>

--- a/unittests/Dialect/Moore/TypesTest.cpp
+++ b/unittests/Dialect/Moore/TypesTest.cpp
@@ -131,17 +131,14 @@ TEST(TypesTest, Structs) {
   auto bit8Type = IntType::getInt(&context, 8);
   auto bitDynArrayType = OpenUnpackedArrayType::get(bitType);
 
-  auto s0 = UnpackedStructType::get(&context, StructKind::Struct,
-                                    {StructMember{foo, bitType}});
-  auto s1 = UnpackedStructType::get(
-      &context, StructKind::Struct,
-      {StructMember{foo, bitType}, StructMember{bar, bit8Type}});
-  auto s2 = UnpackedStructType::get(
-      &context, StructKind::Struct,
-      {StructMember{foo, bitType}, StructMember{bar, logicType}});
-  auto s3 = UnpackedStructType::get(
-      &context, StructKind::Struct,
-      {StructMember{foo, bitType}, StructMember{bar, bitDynArrayType}});
+  auto s0 = StructType::get(&context, {StructMember{foo, bitType}});
+  auto s1 = StructType::get(
+      &context, {StructMember{foo, bitType}, StructMember{bar, bit8Type}});
+  auto s2 = StructType::get(
+      &context, {StructMember{foo, bitType}, StructMember{bar, logicType}});
+  auto s3 =
+      UnpackedStructType::get(&context, {StructMember{foo, bitType},
+                                         StructMember{bar, bitDynArrayType}});
 
   // Value domain
   ASSERT_EQ(s0.getDomain(), Domain::TwoValued);


### PR DESCRIPTION
Move the definitions of packed and unpacked struct types from C++ land into `MooreTypes.td`. This removes a significant amount of complexity.

With all types moved into the TableGen file, a lot of redundant code can finally be removed and the parsing/printing can be streamlined significantly.

This change also drops the `StructKind` enum which was used to discern structs, unions, and tagged unions, although the ImportVerilog conversion never generated anything besides structs. Once we add support for unions in the future, the intention is to define new types in ODS for the unions and reuse the `StructMember`.