### PR TITLE
[Moore] Introduce RefType and tweak the related ops.

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -182,14 +182,14 @@ def ProcedureOp : MooreOp<"procedure", [
 def VariableOp : MooreOp<"variable", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   OptionalTypesMatchWith<"initial value and variable types match",
-    "result", "initial", "$_self">,
+    "result", "initial", "cast<RefType>($_self).getNestedType()">
 ]> {
   let summary = "A variable declaration";
   let description = [{
     See IEEE 1800-2017 § 6.8 "Variable declarations".
   }];
   let arguments = (ins StrAttr:$name, Optional<UnpackedType>:$initial);
-  let results = (outs Res<UnpackedType, "", [MemAlloc]>:$result);
+  let results = (outs Res<RefType, "", [MemAlloc]>:$result);
   let assemblyFormat = [{
     `` custom<ImplicitSSAName>($name) ($initial^)? attr-dict
     `:` type($result)
@@ -219,7 +219,7 @@ def NetKindAttr : I32EnumAttr<"NetKind", "Net type kind", [
 def NetOp : MooreOp<"net", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   OptionalTypesMatchWith<"assigned value and variable types match",
-    "result", "assignment", "$_self">,
+    "result", "assignment", "cast<RefType>($_self).getNestedType()">,
 ]> {
   let summary = "A net declaration";
   let description = [{
@@ -243,21 +243,24 @@ def NetOp : MooreOp<"net", [
     NetKindAttr:$kind,
     Optional<UnpackedType>:$assignment
   );
-  let results = (outs UnpackedType:$result);
+  let results = (outs Res<RefType, "", [MemAlloc]>:$result);
   let assemblyFormat = [{
     ``custom<ImplicitSSAName>($name) $kind ($assignment^)? attr-dict
     `:` type($result)
   }];
 }
 
-def ReadLValueOp : MooreOp<"read_lvalue", [SameOperandsAndResultType]> {
+def ReadOp : MooreOp<"read", [
+  TypesMatchWith<"input and result types match",
+    "result", "input", "RefType::get(cast<UnpackedType>($_self))">
+]> {
   let summary = "Read the current value of a declaration";
   let description = [{
     Samples the current value of a declaration. This is a helper to capture the
-    exact point at which declarations that can be targeted by assignments are
-    read.
+    exact point at which declarations that can be targeted by all possible 
+    expressions are read. It's similar to llvm.load.
   }];
-  let arguments = (ins Arg<UnpackedType, "", [MemRead]>:$input);
+  let arguments = (ins Arg<RefType, "", [MemRead]>:$input);
   let results = (outs UnpackedType:$result);
   let assemblyFormat = [{
     $input attr-dict `:` type($result)
@@ -269,8 +272,9 @@ def ReadLValueOp : MooreOp<"read_lvalue", [SameOperandsAndResultType]> {
 //===----------------------------------------------------------------------===//
 
 class AssignOpBase<string mnemonic, list<Trait> traits = []> :
-    MooreOp<mnemonic, traits # [SameTypeOperands]> {
-  let arguments = (ins UnpackedType:$dst, UnpackedType:$src);
+    MooreOp<mnemonic, traits # [TypesMatchWith<"src and dst types match",
+    "src", "dst", "RefType::get(cast<UnpackedType>($_self))">]> {
+  let arguments = (ins RefType:$dst, UnpackedType:$src);
   let assemblyFormat = [{
     $dst `,` $src attr-dict `:` type($src)
   }];
@@ -297,7 +301,7 @@ def BlockingAssignOp : AssignOpBase<"blocking_assign"> {
     See IEEE 1800-2017 § 10.4.1 "Blocking procedural assignments".
   }];
   let arguments = (ins
-    Arg<UnpackedType, "", [MemWrite]>:$dst,
+    Arg<RefType, "", [MemWrite]>:$dst,
     UnpackedType:$src
   );
 }
@@ -795,6 +799,17 @@ def ConcatOp : MooreOp<"concat", [
   }];
 }
 
+def ConcatRefOp : MooreOp<"concat_ref", [
+    Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>
+]> {
+  let summary = "The copy of concat that explicitly works on the ref type.";
+  let arguments = (ins Variadic<RefType>:$values);
+  let results = (outs RefType:$result);
+  let assemblyFormat = [{
+    $values attr-dict `:` `(` type($values) `)` `->` type($result)
+  }];
+}
+
 def ReplicateOp : MooreOp<"replicate", [
   Pure
 ]> {
@@ -850,6 +865,16 @@ def ExtractOp : MooreOp<"extract"> {
   }];
   let arguments = (ins UnpackedType:$input, UnpackedType:$lowBit);
   let results = (outs UnpackedType:$result);
+  let assemblyFormat = [{
+    $input `from` $lowBit attr-dict `:`
+    type($input) `,` type($lowBit) `->` type($result)
+  }];
+}
+
+def ExtractRefOp : MooreOp<"extract_ref"> {
+  let summary = "The copy of extract that explicitly works on the ref type.";
+  let arguments = (ins RefType:$input, UnpackedType:$lowBit);
+  let results = (outs RefType:$result);
   let assemblyFormat = [{
     $input `from` $lowBit attr-dict `:`
     type($input) `,` type($lowBit) `->` type($result)

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -326,6 +326,29 @@ def UnpackedUnionType : StructLikeType<
 }
 
 //===----------------------------------------------------------------------===//
+// Reference type wrapper
+//===----------------------------------------------------------------------===//
+
+def RefType : MooreTypeDef<"Ref", [], "moore::UnpackedType">{
+  let mnemonic = "ref";
+  let description = [{
+    A wrapper is used to wrap any SystemVerilog type. It's aimed to work for
+    'moore.variable', 'moore.blocking_assign', and 'moore.read', which are
+    related to memory, like alloca/write/read.
+  }];
+  let parameters = (ins "UnpackedType":$nestedType);
+  let assemblyFormat = [{
+    `<` $nestedType `>`
+  }];
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins "UnpackedType":$nestedType), [{
+      return $_get(nestedType.getContext(), nestedType);
+    }]>
+  ];
+}
+
+//===----------------------------------------------------------------------===//
 // Constraints
 //===----------------------------------------------------------------------===//
 

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -76,7 +76,8 @@ struct Context {
   LogicalResult convertStatement(const slang::ast::Statement &stmt);
 
   // Convert an expression AST node to MLIR ops.
-  Value convertExpression(const slang::ast::Expression &expr);
+  Value convertRvalueExpression(const slang::ast::Expression &expr);
+  Value convertLvalueExpression(const slang::ast::Expression &expr);
 
   mlir::ModuleOp intoModuleOp;
   const slang::SourceManager &sourceManager;

--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -46,7 +46,7 @@ struct StmtVisitor {
 
   // Handle expression statements.
   LogicalResult visit(const slang::ast::ExpressionStatement &stmt) {
-    return failure(!context.convertExpression(stmt.expr));
+    return failure(!context.convertRvalueExpression(stmt.expr));
   }
 
   // Handle variable declarations.
@@ -58,14 +58,15 @@ struct StmtVisitor {
 
     Value initial;
     if (const auto *init = var.getInitializer()) {
-      initial = context.convertExpression(*init);
+      initial = context.convertRvalueExpression(*init);
       if (!initial)
         return failure();
     }
 
     // Collect local temporary variables.
     auto varOp = builder.create<moore::VariableOp>(
-        loc, type, builder.getStringAttr(var.name), initial);
+        loc, moore::RefType::get(cast<moore::UnpackedType>(type)),
+        builder.getStringAttr(var.name), initial);
     context.valueSymbols.insertIntoScope(context.valueSymbols.getCurScope(),
                                          &var, varOp);
     return success();
@@ -80,7 +81,7 @@ struct StmtVisitor {
       if (condition.pattern)
         return mlir::emitError(loc,
                                "match patterns in if conditions not supported");
-      auto cond = context.convertExpression(*condition.expr);
+      auto cond = context.convertRvalueExpression(*condition.expr);
       if (!cond)
         return failure();
       cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
@@ -115,7 +116,7 @@ struct StmtVisitor {
 
   // Handle case statements.
   LogicalResult visit(const slang::ast::CaseStatement &caseStmt) {
-    auto caseExpr = context.convertExpression(caseStmt.expr);
+    auto caseExpr = context.convertRvalueExpression(caseStmt.expr);
     auto items = caseStmt.items;
     // Used to generate the condition of the default case statement.
     SmallVector<Value> defaultConds;
@@ -125,7 +126,7 @@ struct StmtVisitor {
       // Like case(cond) 0, 1 : y = x; endcase.
       SmallVector<Value> allConds;
       for (const auto *expr : item.expressions) {
-        auto itemExpr = context.convertExpression(*expr);
+        auto itemExpr = context.convertRvalueExpression(*expr);
         auto newEqOp = builder.create<moore::EqOp>(loc, caseExpr, itemExpr);
         allConds.push_back(newEqOp);
       }
@@ -174,7 +175,7 @@ struct StmtVisitor {
 
     // Generate the initializers.
     for (auto *initExpr : stmt.initializers)
-      if (!context.convertExpression(*initExpr))
+      if (!context.convertRvalueExpression(*initExpr))
         return failure();
 
     // Create the while op.
@@ -183,7 +184,7 @@ struct StmtVisitor {
 
     // In the "before" region, check that the condition holds.
     builder.createBlock(&whileOp.getBefore());
-    auto cond = context.convertExpression(*stmt.stopExpr);
+    auto cond = context.convertRvalueExpression(*stmt.stopExpr);
     if (!cond)
       return failure();
     cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
@@ -195,7 +196,7 @@ struct StmtVisitor {
     if (failed(context.convertStatement(stmt.body)))
       return failure();
     for (auto *stepExpr : stmt.steps)
-      if (!context.convertExpression(*stepExpr))
+      if (!context.convertRvalueExpression(*stepExpr))
         return failure();
     builder.create<mlir::scf::YieldOp>(loc);
 
@@ -206,7 +207,7 @@ struct StmtVisitor {
   LogicalResult visit(const slang::ast::RepeatLoopStatement &stmt) {
     // Create the while op and feed in the repeat count as the initial counter
     // value.
-    auto count = context.convertExpression(stmt.count);
+    auto count = context.convertRvalueExpression(stmt.count);
     if (!count)
       return failure();
     auto type = cast<moore::IntType>(count.getType());
@@ -240,7 +241,7 @@ struct StmtVisitor {
 
     // In the "before" region, check that the condition holds.
     builder.createBlock(&whileOp.getBefore());
-    auto cond = context.convertExpression(stmt.cond);
+    auto cond = context.convertRvalueExpression(stmt.cond);
     if (!cond)
       return failure();
     cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);
@@ -267,7 +268,7 @@ struct StmtVisitor {
     builder.createBlock(&whileOp.getBefore());
     if (failed(context.convertStatement(stmt.body)))
       return failure();
-    auto cond = context.convertExpression(stmt.cond);
+    auto cond = context.convertRvalueExpression(stmt.cond);
     if (!cond)
       return failure();
     cond = builder.createOrFold<moore::BoolCastOp>(loc, cond);

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -133,8 +133,10 @@ struct MemberVisitor {
       // either attach it to the instance as an operand (for input, inout, and
       // ref ports), or assign an instance output to it (for output ports).
       if (auto *port = con->port.as_if<PortSymbol>()) {
-        // TODO: Convert as rvalue for inputs, lvalue for all others.
-        auto value = context.convertExpression(*expr);
+        // Convert as rvalue for inputs, lvalue for all others.
+        auto value = (port->direction == slang::ast::ArgumentDirection::In)
+                         ? context.convertRvalueExpression(*expr)
+                         : context.convertLvalueExpression(*expr);
         if (!value)
           return failure();
         portValues.insert({port, value});
@@ -145,8 +147,8 @@ struct MemberVisitor {
       // it up into multiple sub-values, one for each of the ports in the
       // multi-port.
       if (const auto *multiPort = con->port.as_if<MultiPortSymbol>()) {
-        // TODO: Convert as lvalue.
-        auto value = context.convertExpression(*expr);
+        // Convert as lvalue.
+        auto value = context.convertLvalueExpression(*expr);
         if (!value)
           return failure();
         unsigned offset = 0;
@@ -157,9 +159,12 @@ struct MemberVisitor {
           auto sliceType = context.convertType(port->getType());
           if (!sliceType)
             return failure();
-          auto slice =
-              builder.create<moore::ExtractOp>(loc, sliceType, value, index);
-          // TODO: Read to map to rvalue for input ports.
+          Value slice = builder.create<moore::ExtractRefOp>(
+              loc, moore::RefType::get(cast<moore::UnpackedType>(sliceType)),
+              value, index);
+          // Read to map to rvalue for input ports.
+          if (port->direction == slang::ast::ArgumentDirection::In)
+            slice = builder.create<moore::ReadOp>(loc, sliceType, slice);
           portValues.insert({port, slice});
           offset += width;
         }
@@ -210,17 +215,14 @@ struct MemberVisitor {
 
     Value initial;
     if (const auto *init = varNode.getInitializer()) {
-      initial = context.convertExpression(*init);
+      initial = context.convertRvalueExpression(*init);
       if (!initial)
         return failure();
-
-      if (initial.getType() != loweredType)
-        initial =
-            builder.create<moore::ConversionOp>(loc, loweredType, initial);
     }
 
     auto varOp = builder.create<moore::VariableOp>(
-        loc, loweredType, builder.getStringAttr(varNode.name), initial);
+        loc, moore::RefType::get(cast<moore::UnpackedType>(loweredType)),
+        builder.getStringAttr(varNode.name), initial);
     context.valueSymbols.insert(&varNode, varOp);
     return success();
   }
@@ -233,7 +235,7 @@ struct MemberVisitor {
 
     Value assignment;
     if (netNode.getInitializer()) {
-      assignment = context.convertExpression(*netNode.getInitializer());
+      assignment = context.convertRvalueExpression(*netNode.getInitializer());
       if (!assignment)
         return failure();
     }
@@ -246,8 +248,8 @@ struct MemberVisitor {
              << netNode.netType.name << "`";
 
     auto netOp = builder.create<moore::NetOp>(
-        loc, loweredType, builder.getStringAttr(netNode.name), netkind,
-        assignment);
+        loc, moore::RefType::get(cast<moore::UnpackedType>(loweredType)),
+        builder.getStringAttr(netNode.name), netkind, assignment);
     context.valueSymbols.insert(&netNode, netOp);
     return success();
   }
@@ -263,13 +265,10 @@ struct MemberVisitor {
     const auto &expr =
         assignNode.getAssignment().as<slang::ast::AssignmentExpression>();
 
-    auto lhs = context.convertExpression(expr.left());
-    auto rhs = context.convertExpression(expr.right());
+    auto lhs = context.convertLvalueExpression(expr.left());
+    auto rhs = context.convertRvalueExpression(expr.right());
     if (!lhs || !rhs)
       return failure();
-
-    if (lhs.getType() != rhs.getType())
-      rhs = builder.create<moore::ConversionOp>(loc, lhs.getType(), rhs);
 
     builder.create<moore::ContinuousAssignOp>(loc, lhs, rhs);
     return success();
@@ -296,7 +295,7 @@ struct MemberVisitor {
     // skip parameters without value.
     if (!init)
       return success();
-    Value initial = context.convertExpression(*init);
+    Value initial = context.convertRvalueExpression(*init);
     if (!initial)
       return failure();
 
@@ -322,7 +321,7 @@ struct MemberVisitor {
     // skip specparam without value.
     if (!init)
       return success();
-    Value initial = context.convertExpression(*init);
+    Value initial = context.convertRvalueExpression(*init);
     if (!initial)
       return failure();
 
@@ -437,8 +436,10 @@ Context::convertModuleHeader(const slang::ast::InstanceBodySymbol *module) {
       if (port.direction == ArgumentDirection::Out) {
         modulePorts.push_back({portName, type, hw::ModulePort::Output});
       } else {
-        // TODO: Once we have net/ref type wrappers, wrap `inout` and `ref`
-        // ports in the corresponding type wrapper.
+        // Only the ref type wrapper exists for the time being, the net type
+        // wrapper for inout may be introduced later if necessary.
+        if (port.direction != slang::ast::ArgumentDirection::In)
+          type = moore::RefType::get(cast<moore::UnpackedType>(type));
         modulePorts.push_back({portName, type, hw::ModulePort::Input});
         arg = block->addArgument(type, portLoc);
       }
@@ -509,9 +510,7 @@ Context::convertModuleBody(const slang::ast::InstanceBodySymbol *module) {
   for (auto &port : lowering.ports) {
     Value value;
     if (auto *expr = port.ast.getInternalExpr()) {
-      // TODO: Once we have separate lvalue/rvalue lowering, this should use
-      // rvalue lowering for outputs and lvalue lowering for everything else.
-      value = convertExpression(*expr);
+      value = convertLvalueExpression(*expr);
     } else if (port.ast.internalSymbol) {
       if (const auto *sym =
               port.ast.internalSymbol->as_if<slang::ast::ValueSymbol>())
@@ -524,13 +523,22 @@ Context::convertModuleBody(const slang::ast::InstanceBodySymbol *module) {
 
     // Collect output port values to be returned in the terminator.
     if (port.ast.direction == slang::ast::ArgumentDirection::Out) {
+      if (isa<moore::RefType>(value.getType()))
+        value = builder.create<moore::ReadOp>(
+            value.getLoc(),
+            cast<moore::RefType>(value.getType()).getNestedType(), value);
       outputs.push_back(value);
       continue;
     }
 
     // Assign the value coming in through the port to the internal net or symbol
     // of that port.
-    builder.create<moore::ContinuousAssignOp>(port.loc, value, port.arg);
+    Value portArg = port.arg;
+    if (port.ast.direction != slang::ast::ArgumentDirection::In)
+      portArg = builder.create<moore::ReadOp>(
+          port.loc, cast<moore::RefType>(value.getType()).getNestedType(),
+          port.arg);
+    builder.create<moore::ContinuousAssignOp>(port.loc, value, portArg);
   }
   builder.create<moore::OutputOp>(lowering.op.getLoc(), outputs);
 

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -354,6 +354,26 @@ LogicalResult ConcatOp::inferReturnTypes(
 }
 
 //===----------------------------------------------------------------------===//
+// ConcatRefOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ConcatRefOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::OpaqueProperties properties,
+    mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
+  Domain domain = Domain::TwoValued;
+  unsigned width = 0;
+  for (auto operand : operands) {
+    auto type = cast<IntType>(cast<RefType>(operand.getType()).getNestedType());
+    if (type.getDomain() == Domain::FourValued)
+      domain = Domain::FourValued;
+    width += type.getWidth();
+  }
+  results.push_back(RefType::get(IntType::get(context, width, domain)));
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // YieldOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -39,42 +39,54 @@ endmodule
 
 // CHECK-LABEL: moore.module @Basic
 module Basic;
-  // CHECK: %v0 = moore.variable : l1
-  // CHECK: %v1 = moore.variable : i32
-  // CHECK: %v2 = moore.variable %v1 : i32
+  // CHECK: %v0 = moore.variable : <l1>
+  // CHECK: %v1 = moore.variable : <i32>
+  // CHECK: [[TMP1:%.+]] = moore.read %v1 : i32
+  // CHECK: %v2 = moore.variable [[TMP1]] : <i32>
   var v0;
   int v1;
   int v2 = v1;
 
-  // CHECK: %w0 = moore.net wire : l1
-  // CHECK: %w1 = moore.net wire %w0 : l1
+  // CHECK: %w0 = moore.net wire : <l1>
   wire w0;
+  // CHECK: [[TMP1:%.+]] = moore.read %w0 : l1
+  // CHECK: %w1 = moore.net wire [[TMP1]] : <l1>
   wire w1 = w0;
-  // CHECK: %w2 = moore.net uwire %w0 : l1
+  // CHECK: [[TMP1:%.+]] = moore.read %w0 : l1
+  // CHECK: %w2 = moore.net uwire [[TMP1]] : <l1>
   uwire w2 = w0;
-  // CHECK: %w3 = moore.net tri %w0 : l1
+  // CHECK: [[TMP1:%.+]] = moore.read %w0 : l1
+  // CHECK: %w3 = moore.net tri [[TMP1]] : <l1>
   tri w3 = w0;
-  // CHECK: %w4 = moore.net triand %w0 : l1
+  // CHECK: [[TMP1:%.+]] = moore.read %w0 : l1
+  // CHECK: %w4 = moore.net triand [[TMP1]] : <l1>
   triand w4 = w0;
-  // CHECK: %w5 = moore.net trior %w0 : l1
+  // CHECK: [[TMP1:%.+]] = moore.read %w0 : l1
+  // CHECK: %w5 = moore.net trior [[TMP1]] : <l1>
   trior w5 = w0;
-  // CHECK: %w6 = moore.net wand %w0 : l1
+  // CHECK: [[TMP1:%.+]] = moore.read %w0 : l1
+  // CHECK: %w6 = moore.net wand [[TMP1]] : <l1>
   wand w6 = w0;
-  // CHECK: %w7 = moore.net wor %w0 : l1
+  // CHECK: [[TMP1:%.+]] = moore.read %w0 : l1
+  // CHECK: %w7 = moore.net wor [[TMP1]] : <l1>
   wor w7 = w0;
-  // CHECK: %w8 = moore.net trireg %w0 : l1
+  // CHECK: [[TMP1:%.+]] = moore.read %w0 : l1
+  // CHECK: %w8 = moore.net trireg [[TMP1]] : <l1>
   trireg w8 = w0;
-  // CHECK: %w9 = moore.net tri0 %w0 : l1
+  // CHECK: [[TMP1:%.+]] = moore.read %w0 : l1
+  // CHECK: %w9 = moore.net tri0 [[TMP1]] : <l1>
   tri0 w9 = w0;
-  // CHECK: %w10 = moore.net tri1 %w0 : l1
+  // CHECK: [[TMP1:%.+]] = moore.read %w0 : l1
+  // CHECK: %w10 = moore.net tri1 [[TMP1]] : <l1>
   tri1 w10 = w0;
-  // CHECK: %w11 = moore.net supply0 : l1
+  // CHECK: %w11 = moore.net supply0 : <l1>
   supply0 w11;
-  // CHECK: %w12 = moore.net supply1 : l1
+  // CHECK: %w12 = moore.net supply1 : <l1>
   supply1 w12;
 
-  // CHECK: %b1 = moore.variable : i1
-  // CHECK: %b2 = moore.variable %b1 : i1
+  // CHECK: %b1 = moore.variable : <i1>
+  // CHECK: [[TMP1:%.+]] = moore.read %b1 : i1
+  // CHECK: %b2 = moore.variable [[TMP1]] : <i1>
   bit [0:0] b1;
   bit b2 = b1;
 
@@ -128,7 +140,8 @@ module Basic;
   // CHECK: }
   always_ff @* begin end
 
-  // CHECK: moore.assign %v1, %v2 : i32
+  // CHECK: [[TMP1:%.+]] = moore.read %v2 : i32
+  // CHECK: moore.assign %v1, [[TMP1]] : i32
   assign v1 = v2;
 endmodule
 
@@ -137,44 +150,58 @@ module Statements;
   bit x, y, z;
   int i;
   initial begin
-    // CHECK: %a = moore.variable  : i32
+    // CHECK: %a = moore.variable  : <i32>
     automatic int a;
-    // CHECK moore.blocking_assign %i, %a : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK moore.blocking_assign %i, [[TMP1]] : i32
     i = a;
 
     //===------------------------------------------------------------------===//
     // Conditional statements
 
-    // CHECK: [[COND:%.+]] = moore.conversion %x : !moore.i1 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %x : i1 
+    // CHECK: [[COND:%.+]] = moore.conversion [[TMP1]] : !moore.i1 -> i1
     // CHECK: scf.if [[COND]] {
-    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK:   [[TMP2:%.+]] = moore.read %y : i1  
+    // CHECK:   moore.blocking_assign %x, [[TMP2]] : i1
     // CHECK: }
     if (x) x = y;
-
-    // CHECK: [[COND0:%.+]] = moore.and %x, %y
+    
+    // CHECK: [[TMP1:%.+]] = moore.read %x : i1
+    // CHECK: [[TMP2:%.+]] = moore.read %y : i1
+    // CHECK: [[COND0:%.+]] = moore.and [[TMP1]], [[TMP2]]
     // CHECK: [[COND1:%.+]] = moore.conversion [[COND0]] : !moore.i1 -> i1
     // CHECK: scf.if [[COND1]] {
-    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK:   [[TMP3:%.+]] = moore.read %y : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP3]]
     // CHECK: }
     if (x &&& y) x = y;
-
-    // CHECK: [[COND:%.+]] = moore.conversion %x : !moore.i1 -> i1
+    
+    // CHECK: [[TMP1:%.+]] = moore.read %x : i1
+    // CHECK: [[COND:%.+]] = moore.conversion [[TMP1]] : !moore.i1 -> i1
     // CHECK: scf.if [[COND]] {
-    // CHECK:   moore.blocking_assign %x, %z
+    // CHECK:   [[TMP2:%.+]] = moore.read %z : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP2]]
     // CHECK: } else {
-    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK:   [[TMP3:%.+]] = moore.read %y : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP3]]
     // CHECK: }
     if (x) x = z; else x = y;
 
-    // CHECK: [[COND:%.+]] = moore.conversion %x : !moore.i1 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %x : i1
+    // CHECK: [[COND:%.+]] = moore.conversion [[TMP1]] : !moore.i1 -> i1
     // CHECK: scf.if [[COND]] {
-    // CHECK:   moore.blocking_assign %x, %x
+    // CHECK:   [[TMP2:%.+]] = moore.read %x : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP2]]
     // CHECK: } else {
-    // CHECK:   [[COND:%.+]] = moore.conversion %y : !moore.i1 -> i1
+    // CHECK:   [[TMP3:%.+]] = moore.read %y : i1
+    // CHECK:   [[COND:%.+]] = moore.conversion [[TMP3]] : !moore.i1 -> i1
     // CHECK:   scf.if [[COND]] {
-    // CHECK:     moore.blocking_assign %x, %y
+    // CHECK:     [[TMP4:%.+]] = moore.read %y : i1
+    // CHECK:     moore.blocking_assign %x, [[TMP4]]
     // CHECK:   } else {
-    // CHECK:     moore.blocking_assign %x, %z
+    // CHECK:     [[TMP5:%.+]] = moore.read %z : i1
+    // CHECK:     moore.blocking_assign %x, [[TMP5]]
     // CHECK:   }
     // CHECK: }
     if (x) begin
@@ -188,46 +215,62 @@ module Statements;
     //===------------------------------------------------------------------===//
     // Case statements
 
-    // CHECK: [[TMP1:%.+]] = moore.eq %x, %x : i1 -> i1
-    // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i1 -> i1
-    // CHECK: scf.if [[TMP2]] {
-    // CHECK:   moore.blocking_assign %x, %x : i1
+
+    // CHECK: [[TMP1:%.+]] = moore.read %x : i1
+    // CHECK: [[TMP2:%.+]] = moore.read %x : i1
+    // CHECK: [[TMP3:%.+]] = moore.eq [[TMP1]], [[TMP2]] : i1 -> i1
+    // CHECK: [[TMP4:%.+]] = moore.conversion [[TMP3]] : !moore.i1 -> i1
+    // CHECK: scf.if [[TMP4]] {
+    // CHECK:   [[TMP5:%.+]] = moore.read %x : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP5]] : i1
     // CHECK: }
-    // CHECK: [[TMP3:%.+]] = moore.eq %x, %x : i1 -> i1
-    // CHECK: [[TMP4:%.+]] = moore.eq %x, %y : i1 -> i1
-    // CHECK: [[TMP5:%.+]] = moore.or [[TMP3]], [[TMP4]] : i1
-    // CHECK: [[TMP6:%.+]] = moore.conversion [[TMP5]] : !moore.i1 -> i1
-    // CHECK: scf.if [[TMP6]] {
-    // CHECK:   moore.blocking_assign %x, %y : i1
+    // CHECK: [[TMP6:%.+]] = moore.read %x : i1
+    // CHECK: [[TMP7:%.+]] = moore.eq [[TMP1]], [[TMP6]] : i1 -> i1
+    // CHECK: [[TMP8:%.+]] = moore.read %y : i1
+    // CHECK: [[TMP9:%.+]] = moore.eq [[TMP1]], [[TMP8]] : i1 -> i1
+    // CHECK: [[TMP10:%.+]] = moore.or [[TMP7]], [[TMP9]] : i1
+    // CHECK: [[TMP11:%.+]] = moore.conversion [[TMP10]] : !moore.i1 -> i1
+    // CHECK: scf.if [[TMP11]] {
+    // CHECK:   [[TMP12:%.+]] = moore.read %y : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP12]] : i1
     // CHECK: }
     case (x)
       x: x = x;
       x, y: x = y;
     endcase
 
-    // CHECK: [[TMP1:%.+]] = moore.eq %x, %x : i1 -> i1
-    // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i1 -> i1
-    // CHECK: scf.if [[TMP2]] {
-    // CHECK:   moore.blocking_assign %x, %x : i1
+    // CHECK: [[TMP1:%.+]] = moore.read %x : i1
+    // CHECK: [[TMP2:%.+]] = moore.read %x : i1
+    // CHECK: [[TMP3:%.+]] = moore.eq [[TMP1]], [[TMP2]] : i1 -> i1
+    // CHECK: [[TMP4:%.+]] = moore.conversion [[TMP3]] : !moore.i1 -> i1
+    // CHECK: scf.if [[TMP4]] {
+    // CHECK:   [[TMP5:%.+]] = moore.read %x : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP5]] : i1
     // CHECK: }
-    // CHECK: [[TMP3:%.+]] = moore.eq %x, %x : i1 -> i1
-    // CHECK: [[TMP4:%.+]] = moore.eq %x, %y : i1 -> i1
-    // CHECK: [[TMP5:%.+]] = moore.or [[TMP3]], [[TMP4]] : i1
-    // CHECK: [[TMP6:%.+]] = moore.conversion [[TMP5]] : !moore.i1 -> i1
-    // CHECK: scf.if [[TMP6]] {
-    // CHECK:   moore.blocking_assign %x, %y : i1
+    // CHECK: [[TMP6:%.+]] = moore.read %x : i1
+    // CHECK: [[TMP7:%.+]] = moore.eq [[TMP1]], [[TMP6]] : i1 -> i1
+    // CHECK: [[TMP8:%.+]] = moore.read %y : i1
+    // CHECK: [[TMP9:%.+]] = moore.eq [[TMP1]], [[TMP8]] : i1 -> i1
+    // CHECK: [[TMP10:%.+]] = moore.or [[TMP7]], [[TMP9]] : i1
+    // CHECK: [[TMP11:%.+]] = moore.conversion [[TMP10]] : !moore.i1 -> i1
+    // CHECK: scf.if [[TMP11]] {
+    // CHECK:   [[TMP12:%.+]] = moore.read %y : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP12]] : i1
     // CHECK: }
-    // CHECK: [[TMP7:%.+]] = moore.eq %x, %z : i1 -> i1
-    // CHECK: [[TMP8:%.+]] = moore.conversion [[TMP7]] : !moore.i1 -> i1
-    // CHECK: scf.if [[TMP8]] {
-    // CHECK:   moore.blocking_assign %x, %z : i1
+    // CHECK: [[TMP13:%.+]] = moore.read %z : i1
+    // CHECK: [[TMP14:%.+]] = moore.eq [[TMP1]], [[TMP13]] : i1 -> i1
+    // CHECK: [[TMP15:%.+]] = moore.conversion [[TMP14]] : !moore.i1 -> i1
+    // CHECK: scf.if [[TMP15]] {
+    // CHECK:   [[TMP16:%.+]] = moore.read %z : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP16]] : i1
     // CHECK: }
-    // CHECK: [[TMP9:%.+]] = moore.or [[TMP5]], [[TMP7]] : i1
-    // CHECK: [[TMP10:%.+]] = moore.or [[TMP1]], [[TMP9]] : i1
-    // CHECK: [[TMP11:%.+]] = moore.not [[TMP10]] : i1
-    // CHECK: [[TMP12:%.+]] = moore.conversion [[TMP11]] : !moore.i1 -> i1
-    // CHECK: scf.if [[TMP12]] {
-    // CHECK:   moore.blocking_assign %x, %x : i1
+    // CHECK: [[TMP17:%.+]] = moore.or [[TMP10]], [[TMP14]] : i1
+    // CHECK: [[TMP18:%.+]] = moore.or [[TMP3]], [[TMP17]] : i1
+    // CHECK: [[TMP19:%.+]] = moore.not [[TMP18]] : i1
+    // CHECK: [[TMP20:%.+]] = moore.conversion [[TMP19]] : !moore.i1 -> i1
+    // CHECK: scf.if [[TMP20]] {
+    // CHECK:   [[TMP21:%.+]] = moore.read %x : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP21]] : i1
     // CHECK: }
     case (x)
       x: x = x;
@@ -239,42 +282,52 @@ module Statements;
     //===------------------------------------------------------------------===//
     // Loop statements
 
-    // CHECK: moore.blocking_assign %y, %x
+    // CHECK: [[TMP1:%.+]] = moore.read %x : i1
+    // CHECK: moore.blocking_assign %y, [[TMP1]] : i1
     // CHECK: scf.while : () -> () {
-    // CHECK:   [[COND:%.+]] = moore.conversion %x : !moore.i1 -> i1
+    // CHECK:   [[TMP2:%.+]] = moore.read %x : i1
+    // CHECK:   [[COND:%.+]] = moore.conversion [[TMP2]] : !moore.i1 -> i1
     // CHECK:   scf.condition([[COND]])
     // CHECK: } do {
-    // CHECK:   moore.blocking_assign %x, %y
-    // CHECK:   moore.blocking_assign %x, %z
+    // CHECK:   [[TMP3:%.+]] = moore.read %y : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP3]] : i1
+    // CHECK:   [[TMP4:%.+]] = moore.read %z : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP4]] : i1
     // CHECK:   scf.yield
     // CHECK: }
     for (y = x; x; x = z) x = y;
-
-    // CHECK: scf.while (%arg0 = %i) : (!moore.i32) -> !moore.i32 {
-    // CHECK:   [[TMP0:%.+]] = moore.bool_cast %arg0 : i32 -> i1
-    // CHECK:   [[TMP1:%.+]] = moore.conversion [[TMP0]] : !moore.i1 -> i1
-    // CHECK:   scf.condition([[TMP1]]) %arg0 : !moore.i32
+    
+    // CHECK: [[TMP1:%.+]] = moore.read %i : i32
+    // CHECK: scf.while (%arg0 = [[TMP1]]) : (!moore.i32) -> !moore.i32 {
+    // CHECK:   [[TMP2:%.+]] = moore.bool_cast %arg0 : i32 -> i1
+    // CHECK:   [[TMP3:%.+]] = moore.conversion [[TMP2]] : !moore.i1 -> i1
+    // CHECK:   scf.condition([[TMP3]]) %arg0 : !moore.i32
     // CHECK: } do {
     // CHECK: ^bb0(%arg0: !moore.i32):
-    // CHECK:   moore.blocking_assign %x, %y
-    // CHECK:   [[TMP0:%.+]] = moore.constant 1 : i32
-    // CHECK:   [[TMP1:%.+]] = moore.sub %arg0, [[TMP0]] : i32
-    // CHECK:   scf.yield [[TMP1]] : !moore.i32
+    // CHECK:   [[TMP4:%.+]] = moore.read %y : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP4]] : i1
+    // CHECK:   [[TMP5:%.+]] = moore.constant 1 : i32
+    // CHECK:   [[TMP6:%.+]] = moore.sub %arg0, [[TMP5]] : i32
+    // CHECK:   scf.yield [[TMP6]] : !moore.i32
     // CHECK: }
     repeat (i) x = y;
 
     // CHECK: scf.while : () -> () {
-    // CHECK:   [[COND:%.+]] = moore.conversion %x : !moore.i1 -> i1
+    // CHECK:   [[TMP1:%.+]] = moore.read %x : i1
+    // CHECK:   [[COND:%.+]] = moore.conversion [[TMP1]] : !moore.i1 -> i1
     // CHECK:   scf.condition([[COND]])
     // CHECK: } do {
-    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK:   [[TMP2:%.+]] = moore.read %y : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP2]] : i1
     // CHECK:   scf.yield
     // CHECK: }
     while (x) x = y;
 
     // CHECK: scf.while : () -> () {
-    // CHECK:   moore.blocking_assign %x, %y
-    // CHECK:   [[COND:%.+]] = moore.conversion %x : !moore.i1 -> i1
+    // CHECK:   [[TMP1:%.+]] = moore.read %y : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP1]] : i1
+    // CHECK:   [[TMP2:%.+]] = moore.read %x : i1
+    // CHECK:   [[COND:%.+]] = moore.conversion [[TMP2]] : !moore.i1 -> i1
     // CHECK:   scf.condition([[COND]])
     // CHECK: } do {
     // CHECK:   scf.yield
@@ -285,7 +338,8 @@ module Statements;
     // CHECK:   %true = hw.constant true
     // CHECK:   scf.condition(%true)
     // CHECK: } do {
-    // CHECK:   moore.blocking_assign %x, %y
+    // CHECK:   [[TMP1:%.+]] = moore.read %y : i1
+    // CHECK:   moore.blocking_assign %x, [[TMP1]] : i1
     // CHECK:   scf.yield
     // CHECK: }
     forever x = y;
@@ -293,65 +347,68 @@ module Statements;
     //===------------------------------------------------------------------===//
     // Assignments
 
-    // CHECK: moore.blocking_assign %x, %y : i1
+    // CHECK: [[TMP1:%.+]] = moore.read %y : i1
+    // CHECK: moore.blocking_assign %x, [[TMP1]] : i1
     x = y;
 
-    // CHECK: moore.blocking_assign %y, %z : i1
-    // CHECK: moore.blocking_assign %x, %z : i1
+    // CHECK: [[TMP1:%.+]] = moore.read %z : i1
+    // CHECK: moore.blocking_assign %y, [[TMP1]] : i1
+    // CHECK: moore.blocking_assign %x, [[TMP1]] : i1
     x = (y = z);
-
-    // CHECK: moore.nonblocking_assign %x, %y : i1
+    
+    // CHECK: [[TMP1:%.+]] = moore.read %y : i1
+    // CHECK: moore.nonblocking_assign %x, [[TMP1]] : i1
     x <= y;
   end
 endmodule
 
 // CHECK-LABEL: moore.module @Expressions
 module Expressions;
-  // CHECK: %a = moore.variable : i32
-  // CHECK: %b = moore.variable : i32
-  // CHECK: %c = moore.variable : i32
+  // CHECK: %a = moore.variable : <i32>
+  // CHECK: %b = moore.variable : <i32>
+  // CHECK: %c = moore.variable : <i32>
   int a, b, c;
-  // CHECK: %u = moore.variable : i32
+  // CHECK: %u = moore.variable : <i32>
   int unsigned u, w;
-  // CHECK: %v = moore.variable : array<2 x i4>
+  // CHECK: %v = moore.variable : <array<2 x i4>>
   bit [1:0][3:0] v;
-  // CHECK: %d = moore.variable : l32
-  // CHECK: %e = moore.variable : l32
-  // CHECK: %f = moore.variable : l32
+  // CHECK: %d = moore.variable : <l32>
+  // CHECK: %e = moore.variable : <l32>
+  // CHECK: %f = moore.variable : <l32>
   integer d, e, f;
   integer unsigned g, h, k;
-  // CHECK: %x = moore.variable : i1
+  // CHECK: %x = moore.variable : <i1>
   bit x;
-  // CHECK: %y = moore.variable : l1
+  // CHECK: %y = moore.variable : <l1>
   logic y;
-  // CHECK: %vec_1 = moore.variable : l32
+  // CHECK: %vec_1 = moore.variable : <l32>
   logic [31:0] vec_1;
-  // CHECK: %vec_2 = moore.variable : l32
+  // CHECK: %vec_2 = moore.variable : <l32>
   logic [0:31] vec_2;
-  // CHECK: %arr = moore.variable : uarray<3 x uarray<6 x i4>>
+  // CHECK: %arr = moore.variable : <uarray<3 x uarray<6 x i4>>>
   bit [4:1] arr [1:3][2:7];
-  // CHECK: %struct0 = moore.variable : struct<{a: i32, b: i32}>
+  // CHECK: %struct0 = moore.variable : <struct<{a: i32, b: i32}>>
   struct packed {
     int a, b;
   } struct0;
-  // CHECK: %struct1 = moore.variable : struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>
+  // CHECK: %struct1 = moore.variable : <struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>>
   struct packed {
     struct packed {
       int a, b;
     } c, d;
   } struct1;
-  // CHECK: %union0 = moore.variable : union<{a: i32, b: i32}>
+  // CHECK: %union0 = moore.variable : <union<{a: i32, b: i32}>>
   union packed {
     int a, b;
   } union0;
-  // CHECK: %union1 = moore.variable : union<{c: union<{a: i32, b: i32}>, d: union<{a: i32, b: i32}>}>
+  // CHECK: %union1 = moore.variable : <union<{c: union<{a: i32, b: i32}>, d: union<{a: i32, b: i32}>}>>
   union packed {
     union packed {
       int a, b;
     } c, d;
   } union1;
-  // CHECK: %r1 = moore.variable : real
-  // CHECK: %r2 = moore.variable : real
+  // CHECK: %r1 = moore.variable : <real>
+  // CHECK: %r2 = moore.variable : <real>
   real r1,r2;
 
   initial begin
@@ -365,103 +422,152 @@ module Expressions;
     c = 19'd42;
     // CHECK: moore.constant 42 : i19
     c = 19'sd42;
-    // CHECK: moore.concat %a, %b, %c : (!moore.i32, !moore.i32, !moore.i32) -> i96
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: [[TMP3:%.+]] = moore.read %c : i32
+    // CHECK: moore.concat [[TMP1]], [[TMP2]], [[TMP3]] : (!moore.i32, !moore.i32, !moore.i32) -> i96
     a = {a, b, c};
-    // CHECK: moore.concat %d, %e : (!moore.l32, !moore.l32) -> l64
+    // CHECK: [[TMP1:%.+]] = moore.read %d : l32
+    // CHECK: [[TMP2:%.+]] = moore.read %e : l32
+    // CHECK: moore.concat [[TMP1]], [[TMP2]] : (!moore.l32, !moore.l32) -> l64
     d = {d, e};
-    // CHECK: %[[VAL_1:.*]] = moore.constant false : i1
-    // CHECK: %[[VAL_2:.*]] = moore.concat %[[VAL_1]] : (!moore.i1) -> i1
-    // CHECK: %[[VAL_3:.*]] = moore.replicate %[[VAL_2]] : i1 -> i32
+    // CHECK: moore.concat_ref %a, %b, %c : (!moore.ref<i32>, !moore.ref<i32>, !moore.ref<i32>) -> <i96>
+    {a, b, c} = a;
+    // CHECK: moore.concat_ref %d, %e : (!moore.ref<l32>, !moore.ref<l32>) -> <l64>
+    {d, e} = d;
+    // CHECK: [[TMP1:%.+]] = moore.constant false : i1
+    // CHECK: [[TMP2:%.+]] = moore.concat [[TMP1]] : (!moore.i1) -> i1
+    // CHECK: moore.replicate [[TMP2]] : i1 -> i32
     a = {32{1'b0}};
-    // CHECK: %[[VAL:.*]] = moore.constant 1 : i32
-    // CHECK: moore.extract %vec_1 from %[[VAL]] : l32, i32 -> l3
+    // CHECK: [[TMP1:%.+]] = moore.read %vec_1 : l32
+    // CHECK: [[TMP2:%.+]] = moore.constant 1 : i32
+    // CHECK: moore.extract [[TMP1]] from [[TMP2]] : l32, i32 -> l3
     y = vec_1[3:1];
-    // CHECK: %[[VAL:.*]] = moore.constant 2 : i32
-    // CHECK: moore.extract %vec_2 from %[[VAL]] : l32, i32 -> l2
+    // CHECK: [[TMP1:%.+]] = moore.read %vec_2 : l32
+    // CHECK: [[TMP2:%.+]] = moore.constant 2 : i32
+    // CHECK: moore.extract [[TMP1]] from [[TMP2]] : l32, i32 -> l2
     y = vec_2[2:3];
-    // CHECK: moore.extract %d from %x : l32, i1 -> l1
+    // CHECK: [[TMP1:%.+]] = moore.read %d : l32
+    // CHECK: [[TMP2:%.+]] = moore.read %x : i1
+    // CHECK: moore.extract [[TMP1]] from [[TMP2]] : l32, i1 -> l1
     y = d[x];
-    // CHECK: moore.extract %a from %x : i32, i1 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %x : i1
+    // CHECK: moore.extract [[TMP1]] from [[TMP2]] : i32, i1 -> i1
     x = a[x];
-    // CHECK: %[[VAL:.*]] = moore.constant 15 : i32
-    // CHECK: moore.extract %vec_1 from %[[VAL]] : l32, i32 -> l1
+    // CHECK: [[TMP1:%.+]] = moore.read %vec_1 : l32
+    // CHECK: [[TMP2:%.+]] = moore.constant 15 : i32
+    // CHECK: moore.extract [[TMP1]] from [[TMP2]] : l32, i32 -> l1
     y = vec_1[15];
-    // CHECK: %[[VAL:.*]] = moore.constant 15 : i32
-    // CHECK: moore.extract %vec_1 from %[[VAL]] : l32, i32 -> l1
+    // CHECK: [[TMP1:%.+]] = moore.read %vec_1 : l32
+    // CHECK: [[TMP2:%.+]] = moore.constant 15 : i32
+    // CHECK: moore.extract [[TMP1]] from [[TMP2]] : l32, i32 -> l1
     y = vec_1[15+:1];
-    // CHECK: %[[VAL:.*]] = moore.constant 0 : i32
-    // CHECK: moore.extract %vec_2 from %[[VAL]] : l32, i32 -> l1
+    // CHECK: [[TMP1:%.+]] = moore.read %vec_2 : l32
+    // CHECK: [[TMP2:%.+]] = moore.constant 0 : i32
+    // CHECK: moore.extract [[TMP1]] from [[TMP2]] : l32, i32 -> l1
     y = vec_2[0+:1];
-    // CHECK: %[[VAL_1:.*]] = moore.constant 1 : i32
-    // CHECK: %[[VAL_2:.*]] = moore.mul %[[VAL_1]], %a : i32
-    // CHECK: moore.extract %vec_1 from %[[VAL_2]] : l32, i32 -> l1
+    // CHECK: [[TMP1:%.+]] = moore.read %vec_1 : l32
+    // CHECK: [[TMP2:%.+]] = moore.constant 1 : i32
+    // CHECK: [[TMP3:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP4:%.+]] = moore.mul [[TMP2]], [[TMP3]] : i32
+    // CHECK: moore.extract [[TMP1]] from [[TMP4]] : l32, i32 -> l1
     c = vec_1[1*a-:1];
-    // CHECK: %[[VAL_1:.*]] = moore.constant 3 : i32
-    // CHECK: %[[VAL_2:.*]] = moore.extract %arr from %[[VAL_1]] : uarray<3 x uarray<6 x i4>>, i32 -> uarray<6 x i4>
-    // CHECK: %[[VAL_3:.*]] = moore.constant 7 : i32
-    // CHECK: %[[VAL_4:.*]] = moore.extract %[[VAL_2]] from %[[VAL_3]] : uarray<6 x i4>, i32 -> i4
-    // CHECK: %[[VAL_5:.*]] = moore.constant 3 : i32
-    // CHECK: moore.extract %[[VAL_4]] from %[[VAL_5]] : i4, i32 -> i2
+    // CHECK: [[TMP1:%.+]] = moore.read %arr : uarray<3 x uarray<6 x i4>>
+    // CHECK: [[TMP2:%.+]] = moore.constant 3 : i32
+    // CHECK: [[TMP3:%.+]] = moore.extract [[TMP1]] from [[TMP2]] : uarray<3 x uarray<6 x i4>>, i32 -> uarray<6 x i4>
+    // CHECK: [[TMP4:%.+]] = moore.constant 7 : i32
+    // CHECK: [[TMP5:%.+]] = moore.extract [[TMP3]] from [[TMP4]] : uarray<6 x i4>, i32 -> i4
+    // CHECK: [[TMP6:%.+]] = moore.constant 3 : i32
+    // CHECK: moore.extract [[TMP5]] from [[TMP6]] : i4, i32 -> i2
     c = arr[3][7][4:3];
-    // CHECK: moore.extract %vec_1 from %c : l32, i32 -> l1
+    // CHECK: [[TMP1:%.+]] = moore.read %vec_1 : l32
+    // CHECK: [[TMP2:%.+]] = moore.read %c : i32
+    // CHECK: moore.extract [[TMP1]] from [[TMP2]] : l32, i32 -> l1
     y = vec_1[c];
 
+    // CHECK: [[TMP1:%.+]] = moore.constant 1 : i32
+    // CHECK: [[TMP2:%.+]] = moore.extract_ref %v from [[TMP1]] : <array<2 x i4>>, i32 -> <i4>
+    // CHECK: [[TMP3:%.+]] = moore.constant 3 : i32
+    // CHECK: moore.extract_ref [[TMP2]] from [[TMP3]] : <i4>, i32 -> <i1>
+    v[1][3] = x;
+
+    // CHECK: [[TMP1:%.+]] = moore.constant 1 : i32
+    // CHECK: moore.extract_ref %vec_1 from [[TMP1]] : <l32>, i32 -> <l2>
+    vec_1[2:1] = y;
+
+    // CHECK: [[X_READ:%.+]] = moore.read %x : i1
+    // CHECK: moore.extract_ref %vec_1 from [[X_READ]] : <l32>, i1 -> <l1>
+    vec_1[x] = y;
 
     //===------------------------------------------------------------------===//
     // Unary operators
 
-    // CHECK: moore.blocking_assign %c, %a : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: moore.blocking_assign %c, [[TMP1]] : i32
     c = +a;
-    // CHECK: moore.neg %a : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: moore.neg [[TMP1]] : i32
     c = -a;
-    // CHECK: [[TMP1:%.+]] = moore.conversion %v : !moore.array<2 x i4> -> !moore.i32
-    // CHECK: [[TMP2:%.+]] = moore.neg [[TMP1]] : i32
-    // CHECK: [[TMP3:%.+]] = moore.conversion [[TMP2]] : !moore.i32 -> !moore.i32
+    // CHECK: [[TMP1:%.+]] = moore.read %v : array<2 x i4>
+    // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.array<2 x i4> -> !moore.i32
+    // CHECK: [[TMP3:%.+]] = moore.neg [[TMP2]] : i32
+    // CHECK: [[TMP4:%.+]] = moore.conversion [[TMP3]] : !moore.i32 -> !moore.i32
     c = -v;
-    // CHECK: moore.not %a : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: moore.not [[TMP1]] : i32
     c = ~a;
-    // CHECK: moore.reduce_and %a : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: moore.reduce_and [[TMP1]] : i32 -> i1
     x = &a;
-    // CHECK: moore.reduce_and %d : l32 -> l1
+    // CHECK: [[TMP1:%.+]] = moore.read %d : l32
+    // CHECK: moore.reduce_and [[TMP1]] : l32 -> l1
     y = &d;
-    // CHECK: moore.reduce_or %a : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: moore.reduce_or [[TMP1]] : i32 -> i1
     x = |a;
-    // CHECK: moore.reduce_xor %a : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: moore.reduce_xor [[TMP1]] : i32 -> i1
     x = ^a;
-    // CHECK: [[TMP:%.+]] = moore.reduce_and %a : i32 -> i1
-    // CHECK: moore.not [[TMP]] : i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.reduce_and [[TMP1]] : i32 -> i1
+    // CHECK: moore.not [[TMP2]] : i1
     x = ~&a;
-    // CHECK: [[TMP:%.+]] = moore.reduce_or %a : i32 -> i1
-    // CHECK: moore.not [[TMP]] : i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.reduce_or [[TMP1]] : i32 -> i1
+    // CHECK: moore.not [[TMP2]] : i1
     x = ~|a;
-    // CHECK: [[TMP:%.+]] = moore.reduce_xor %a : i32 -> i1
-    // CHECK: moore.not [[TMP]] : i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.reduce_xor [[TMP1]] : i32 -> i1
+    // CHECK: moore.not [[TMP2]] : i1
     x = ~^a;
-    // CHECK: [[TMP:%.+]] = moore.reduce_xor %a : i32 -> i1
-    // CHECK: moore.not [[TMP]] : i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.reduce_xor [[TMP1]] : i32 -> i1
+    // CHECK: moore.not [[TMP2]] : i1
     x = ^~a;
-    // CHECK: [[TMP:%.+]] = moore.bool_cast %a : i32 -> i1
-    // CHECK: moore.not [[TMP]] : i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.bool_cast [[TMP1]] : i32 -> i1
+    // CHECK: moore.not [[TMP2]] : i1
     x = !a;
-    // CHECK: [[PRE:%.+]] = moore.read_lvalue %a : i32
+    // CHECK: [[PRE:%.+]] = moore.read %a : i32
     // CHECK: [[TMP:%.+]] = moore.constant 1 : i32
     // CHECK: [[POST:%.+]] = moore.add [[PRE]], [[TMP]] : i32
     // CHECK: moore.blocking_assign %a, [[POST]]
     // CHECK: moore.blocking_assign %c, [[PRE]]
     c = a++;
-    // CHECK: [[PRE:%.+]] = moore.read_lvalue %a : i32
+    // CHECK: [[PRE:%.+]] = moore.read %a : i32
     // CHECK: [[TMP:%.+]] = moore.constant 1 : i32
     // CHECK: [[POST:%.+]] = moore.sub [[PRE]], [[TMP]] : i32
     // CHECK: moore.blocking_assign %a, [[POST]]
     // CHECK: moore.blocking_assign %c, [[PRE]]
     c = a--;
-    // CHECK: [[PRE:%.+]] = moore.read_lvalue %a : i32
+    // CHECK: [[PRE:%.+]] = moore.read %a : i32
     // CHECK: [[TMP:%.+]] = moore.constant 1 : i32
     // CHECK: [[POST:%.+]] = moore.add [[PRE]], [[TMP]] : i32
     // CHECK: moore.blocking_assign %a, [[POST]]
     // CHECK: moore.blocking_assign %c, [[POST]]
     c = ++a;
-    // CHECK: [[PRE:%.+]] = moore.read_lvalue %a : i32
+    // CHECK: [[PRE:%.+]] = moore.read %a : i32
     // CHECK: [[TMP:%.+]] = moore.constant 1 : i32
     // CHECK: [[POST:%.+]] = moore.sub [[PRE]], [[TMP]] : i32
     // CHECK: moore.blocking_assign %a, [[POST]]
@@ -471,94 +577,163 @@ module Expressions;
     //===------------------------------------------------------------------===//
     // Binary operators
 
-    // CHECK: moore.add %a, %b : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.add [[TMP1]], [[TMP2]] : i32
     c = a + b;
-    // CHECK: [[TMP1:%.+]] = moore.conversion %a : !moore.i32 -> !moore.i32
-    // CHECK: [[TMP2:%.+]] = moore.conversion %v : !moore.array<2 x i4> -> !moore.i32
-    // CHECK: [[TMP3:%.+]] = moore.add [[TMP1]], [[TMP2]] : i32
-    // CHECK: [[TMP4:%.+]] = moore.conversion [[TMP3]] : !moore.i32 -> !moore.i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i32 -> !moore.i32
+    // CHECK: [[TMP3:%.+]] = moore.read %v : array<2 x i4>
+    // CHECK: [[TMP4:%.+]] = moore.conversion [[TMP3]] : !moore.array<2 x i4> -> !moore.i32
+    // CHECK: moore.add [[TMP2]], [[TMP4]] : i32
     c = a + v;
-    // CHECK: moore.sub %a, %b : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.sub [[TMP1]], [[TMP2]] : i32
     c = a - b;
-    // CHECK: moore.mul %a, %b : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.mul [[TMP1]], [[TMP2]] : i32
     c = a * b;
-    // CHECK: moore.divu %h, %k : l32
+    // CHECK: [[TMP1:%.+]] = moore.read %h : l32
+    // CHECK: [[TMP2:%.+]] = moore.read %k : l32
+    // CHECK: moore.divu [[TMP1]], [[TMP2]] : l32
     g = h / k;
-    // CHECK: moore.divs %d, %e : l32
+    // CHECK: [[TMP1:%.+]] = moore.read %d : l32
+    // CHECK: [[TMP2:%.+]] = moore.read %e : l32
+    // CHECK: moore.divs [[TMP1]], [[TMP2]] : l32
     f = d / e;
-    // CHECK: moore.modu %h, %k : l32
+    // CHECK: [[TMP1:%.+]] = moore.read %h : l32
+    // CHECK: [[TMP2:%.+]] = moore.read %k : l32
+    // CHECK: moore.modu [[TMP1]], [[TMP2]] : l32
     g = h % k;
-    // CHECK: moore.mods %d, %e : l32
+    // CHECK: [[TMP1:%.+]] = moore.read %d : l32
+    // CHECK: [[TMP2:%.+]] = moore.read %e : l32
+    // CHECK: moore.mods [[TMP1]], [[TMP2]] : l32
     f = d % e;
 
-    // CHECK: moore.and %a, %b : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.and [[TMP1]], [[TMP2]] : i32
     c = a & b;
-    // CHECK: moore.or %a, %b : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.or [[TMP1]], [[TMP2]] : i32
     c = a | b;
-    // CHECK: moore.xor %a, %b : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.xor [[TMP1]], [[TMP2]] : i32
     c = a ^ b;
-    // CHECK: [[TMP:%.+]] = moore.xor %a, %b : i32
-    // CHECK: moore.not [[TMP]] : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: [[TMP3:%.+]] = moore.xor [[TMP1]], [[TMP2]] : i32
+    // CHECK: moore.not [[TMP3]] : i32
     c = a ~^ b;
-    // CHECK: [[TMP:%.+]] = moore.xor %a, %b : i32
-    // CHECK: moore.not [[TMP]] : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: [[TMP3:%.+]] = moore.xor [[TMP1]], [[TMP2]] : i32
+    // CHECK: moore.not [[TMP3]] : i32
     c = a ^~ b;
 
-    // CHECK: moore.eq %a, %b : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.eq [[TMP1]], [[TMP2]] : i32 -> i1
     x = a == b;
-    // CHECK: moore.eq %d, %e : l32 -> l1
+    // CHECK: [[TMP1:%.+]] = moore.read %d : l32
+    // CHECK: [[TMP2:%.+]] = moore.read %e : l32
+    // CHECK: moore.eq [[TMP1]], [[TMP2]] : l32 -> l1
     y = d == e;
-    // CHECK: moore.ne %a, %b : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.ne [[TMP1]], [[TMP2]] : i32 -> i1
     x = a != b ;
-    // CHECK: moore.case_eq %a, %b : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.case_eq [[TMP1]], [[TMP2]] : i32
     x = a === b;
-    // CHECK: moore.case_ne %a, %b : i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.case_ne [[TMP1]], [[TMP2]] : i32
     x = a !== b;
-    // CHECK: moore.wildcard_eq %a, %b : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.wildcard_eq [[TMP1]], [[TMP2]] : i32 -> i1
     x = a ==? b;
-    // CHECK: [[TMP:%.+]] = moore.conversion %a : !moore.i32 -> !moore.l32
-    // CHECK: moore.wildcard_eq [[TMP]], %d : l32 -> l1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i32 -> !moore.l32
+    // CHECK: [[TMP3:%.+]] = moore.read %d : l32
+    // CHECK: moore.wildcard_eq [[TMP2]], [[TMP3]] : l32 -> l1
     y = a ==? d;
-    // CHECK: [[TMP:%.+]] = moore.conversion %b : !moore.i32 -> !moore.l32
-    // CHECK: moore.wildcard_eq %d, [[TMP]] : l32 -> l1
+    // CHECK: [[TMP1:%.+]] = moore.read %d : l32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: [[TMP3:%.+]] = moore.conversion [[TMP2]] : !moore.i32 -> !moore.l32
+    // CHECK: moore.wildcard_eq [[TMP1]], [[TMP3]] : l32 -> l1
     y = d ==? b;
-    // CHECK: moore.wildcard_eq %d, %e : l32 -> l1
+    // CHECK: [[TMP1:%.+]] = moore.read %d : l32
+    // CHECK: [[TMP2:%.+]] = moore.read %e : l32
+    // CHECK: moore.wildcard_eq [[TMP1]], [[TMP2]] : l32 -> l1
     y = d ==? e;
-    // CHECK: moore.wildcard_ne %a, %b : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.wildcard_ne [[TMP1]], [[TMP2]] : i32 -> i1
     x = a !=? b;
 
-    // CHECK: moore.uge %u, %w : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %u : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %w : i32
+    // CHECK: moore.uge [[TMP1]], [[TMP2]] : i32 -> i1
     c = u >= w;
-    // CHECK: moore.ugt %u, %w : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %u : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %w : i32
+    // CHECK: moore.ugt [[TMP1]], [[TMP2]] : i32 -> i1
     c = u > w;
-    // CHECK: moore.ule %u, %w : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %u : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %w : i32
+    // CHECK: moore.ule [[TMP1]], [[TMP2]] : i32 -> i1
     c = u <= w;
-    // CHECK: moore.ult %u, %w : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %u : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %w : i32
+    // CHECK: moore.ult [[TMP1]], [[TMP2]] : i32 -> i1
     c = u < w;
-    // CHECK: moore.sge %a, %b : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.sge [[TMP1]], [[TMP2]] : i32 -> i1
     c = a >= b;
-    // CHECK: moore.sgt %a, %b : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.sgt [[TMP1]], [[TMP2]] : i32 -> i1
     c = a > b;
-    // CHECK: moore.sle %a, %b : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.sle [[TMP1]], [[TMP2]] : i32 -> i1
     c = a <= b;
-    // CHECK: moore.slt %a, %b : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.slt [[TMP1]], [[TMP2]] : i32 -> i1
     c = a < b;
 
-    // CHECK: [[A:%.+]] = moore.bool_cast %a : i32 -> i1
-    // CHECK: [[B:%.+]] = moore.bool_cast %b : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: [[A:%.+]] = moore.bool_cast [[TMP1]] : i32 -> i1
+    // CHECK: [[B:%.+]] = moore.bool_cast [[TMP2]] : i32 -> i1
     // CHECK: moore.and [[A]], [[B]] : i1
     c = a && b;
-    // CHECK: [[A:%.+]] = moore.bool_cast %a : i32 -> i1
-    // CHECK: [[B:%.+]] = moore.bool_cast %b : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: [[A:%.+]] = moore.bool_cast [[TMP1]] : i32 -> i1
+    // CHECK: [[B:%.+]] = moore.bool_cast [[TMP2]] : i32 -> i1
     // CHECK: moore.or [[A]], [[B]] : i1
     c = a || b;
-    // CHECK: [[A:%.+]] = moore.bool_cast %a : i32 -> i1
-    // CHECK: [[B:%.+]] = moore.bool_cast %b : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: [[A:%.+]] = moore.bool_cast [[TMP1]] : i32 -> i1
+    // CHECK: [[B:%.+]] = moore.bool_cast [[TMP2]] : i32 -> i1
     // CHECK: [[NOT_A:%.+]] = moore.not [[A]] : i1
     // CHECK: moore.or [[NOT_A]], [[B]] : i1
     c = a -> b;
-    // CHECK: [[A:%.+]] = moore.bool_cast %a : i32 -> i1
-    // CHECK: [[B:%.+]] = moore.bool_cast %b : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: [[A:%.+]] = moore.bool_cast [[TMP1]] : i32 -> i1
+    // CHECK: [[B:%.+]] = moore.bool_cast [[TMP2]] : i32 -> i1
     // CHECK: [[NOT_A:%.+]] = moore.not [[A]] : i1
     // CHECK: [[NOT_B:%.+]] = moore.not [[B]] : i1
     // CHECK: [[BOTH:%.+]] = moore.and [[A]], [[B]] : i1
@@ -566,74 +741,114 @@ module Expressions;
     // CHECK: moore.or [[BOTH]], [[NOT_BOTH]] : i1
     c = a <-> b;
 
-    // CHECK: moore.shl %a, %b : i32, i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.shl [[TMP1]], [[TMP2]] : i32, i32
     c = a << b;
-    // CHECK: moore.shr %a, %b : i32, i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.shr [[TMP1]], [[TMP2]] : i32, i32
     c = a >> b;
-    // CHECK: moore.shl %a, %b : i32, i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.shl [[TMP1]], [[TMP2]] : i32, i32
     c = a <<< b;
-    // CHECK: moore.ashr %a, %b : i32, i32
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.ashr [[TMP1]], [[TMP2]] : i32, i32
     c = a >>> b;
-    // CHECK: moore.shr %u, %b : i32, i32
+    // CHECK: [[TMP1:%.+]] = moore.read %u : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %b : i32
+    // CHECK: moore.shr [[TMP1]], [[TMP2]] : i32, i32
     c = u >>> b;
 
-    // CHECK: moore.wildcard_eq %a, %a : i32 -> i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %a : i32
+    // CHECK: moore.wildcard_eq [[TMP1]], [[TMP2]] : i32 -> i1
     c = a inside { a };
 
-    // CHECK: [[TMP1:%.+]] = moore.wildcard_eq %a, %a : i32 -> i1
-    // CHECK: [[TMP2:%.+]] = moore.wildcard_eq %a, %b : i32 -> i1
-    // CHECK: moore.or [[TMP1]], [[TMP2]] : i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP3:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP2]] : i32 -> i1
+    // CHECK: [[TMP4:%.+]] = moore.read %b : i32
+    // CHECK: [[TMP5:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP4]] : i32 -> i1
+    // CHECK: moore.or [[TMP3]], [[TMP5]] : i1
     c = a inside { a, b };
 
-    // CHECK: [[TMP1:%.+]] = moore.wildcard_eq %a, %a : i32 -> i1
-    // CHECK: [[TMP2:%.+]] = moore.wildcard_eq %a, %b : i32 -> i1
-    // CHECK: [[TMP3:%.+]] = moore.wildcard_eq %a, %a : i32 -> i1
-    // CHECK: [[TMP4:%.+]] = moore.wildcard_eq %a, %b : i32 -> i1
-    // CHECK: [[TMP5:%.+]] = moore.or [[TMP3]], [[TMP4]] : i1
-    // CHECK: [[TMP6:%.+]] = moore.or [[TMP2]], [[TMP5]] : i1
-    // CHECK: moore.or [[TMP1]], [[TMP6]] : i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP3:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP2]] : i32 -> i1
+    // CHECK: [[TMP4:%.+]] = moore.read %b : i32
+    // CHECK: [[TMP5:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP4]] : i32 -> i1
+    // CHECK: [[TMP6:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP7:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP6]] : i32 -> i1
+    // CHECK: [[TMP8:%.+]] = moore.read %b : i32
+    // CHECK: [[TMP9:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP8]] : i32 -> i1
+    // CHECK: [[TMP10:%.+]] = moore.or [[TMP7]], [[TMP9]] : i1
+    // CHECK: [[TMP11:%.+]] = moore.or [[TMP5]], [[TMP10]] : i1
+    // CHECK: moore.or [[TMP3]], [[TMP11]] : i1
     c = a inside { a, b, a, b };
 
-    // CHECK: [[TMP1:%.+]] = moore.wildcard_eq %a, %a : i32 -> i1
-    // CHECK: [[TMP2:%.+]] = moore.wildcard_eq %a, %b : i32 -> i1
-    // CHECK: [[TMP3:%.+]] = moore.sge %a, %a : i32 -> i1
-    // CHECK: [[TMP4:%.+]] = moore.sle %a, %b : i32 -> i1
-    // CHECK: [[TMP5:%.+]] = moore.and [[TMP3]], [[TMP4]] : i1
-    // CHECK: [[TMP6:%.+]] = moore.or [[TMP2]], [[TMP5]] : i1
-    // CHECK: moore.or [[TMP1]], [[TMP6]] : i1
+    // CHECK: [[TMP1:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP2:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP3:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP2]] : i32 -> i1
+    // CHECK: [[TMP4:%.+]] = moore.read %b : i32
+    // CHECK: [[TMP5:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP4]] : i32 -> i1
+    // CHECK: [[TMP6:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP7:%.+]] = moore.read %b : i32
+    // CHECK: [[TMP8:%.+]] = moore.sge [[TMP1]], [[TMP6]] : i32 -> i1
+    // CHECK: [[TMP9:%.+]] = moore.sle [[TMP1]], [[TMP7]] : i32 -> i1
+    // CHECK: [[TMP10:%.+]] = moore.and [[TMP8]], [[TMP9]] : i1
+    // CHECK: [[TMP11:%.+]] = moore.or [[TMP5]], [[TMP10]] : i1
+    // CHECK: moore.or [[TMP3]], [[TMP11]] : i1
     c = a inside { a, b, [a:b] };
 
     //===------------------------------------------------------------------===//
     // Conditional operator
 
-    // CHECK: moore.conditional %x : i1 -> i32 {
-    // CHECK:   moore.yield %a : i32
+    // CHECK: [[X_COND:%.+]] = moore.read %x : i1
+    // CHECK: moore.conditional [[X_COND]] : i1 -> i32 {
+    // CHECK:   [[A_READ:%.+]] = moore.read %a : i32
+    // CHECK:   moore.yield [[A_READ]] : i32
     // CHECK: } {
-    // CHECK:   moore.yield %b : i32
+    // CHECK:   [[B_READ:%.+]] = moore.read %b : i32
+    // CHECK:   moore.yield [[B_READ]] : i32
     // CHECK: }
     c = x ? a : b;
 
-    // CHECK: moore.conditional %x : i1 -> real {
-    // CHECK:   moore.yield %r1 : real
+    // CHECK: [[X_COND:%.+]] = moore.read %x : i1
+    // CHECK: moore.conditional [[X_COND]] : i1 -> real {
+    // CHECK:   [[R1_READ:%.+]] = moore.read %r1 : real
+    // CHECK:   moore.yield [[R1_READ]] : real
     // CHECK: } {
-    // CHECK:   moore.yield %r2 : real
+    // CHECK:   [[R2_READ:%.+]] = moore.read %r2 : real
+    // CHECK:   moore.yield [[R2_READ]] : real
     // CHECK: }
     r1 = x ? r1 : r2;
 
-    // CHECK: [[TMP1:%.+]] = moore.bool_cast %a : i32 -> i1
+    // CHECK: [[A_COND:%.+]] = moore.read %a : i32
+    // CHECK: [[TMP1:%.+]] = moore.bool_cast [[A_COND]] : i32 -> i1
     // CHECK: moore.conditional [[TMP1]] : i1 -> i32 {
-    // CHECK:   moore.yield %a : i32
+    // CHECK:   [[A_READ:%.+]] = moore.read %a : i32
+    // CHECK:   moore.yield [[A_READ]] : i32
     // CHECK: } {
-    // CHECK:   moore.yield %b : i32
+    // CHECK:   [[B_READ:%.+]] = moore.read %b : i32
+    // CHECK:   moore.yield [[B_READ]] : i32
     // CHECK: }
     c = a ? a : b;
 
-    // CHECK: [[TMP1:%.+]] = moore.sgt %a, %b : i32 -> i1
+    // CHECK: [[A_SGT:%.+]] = moore.read %a : i32
+    // CHECK: [[B_SGT:%.+]] = moore.read %b : i32
+    // CHECK: [[TMP1:%.+]] = moore.sgt [[A_SGT]], [[B_SGT]] : i32 -> i1
     // CHECK: moore.conditional [[TMP1]] : i1 -> i32 {
-    // CHECK:   [[TMP2:%.+]] = moore.add %a, %b : i32
+    // CHECK:   [[A_ADD:%.+]] = moore.read %a : i32
+    // CHECK:   [[B_ADD:%.+]] = moore.read %b : i32
+    // CHECK:   [[TMP2:%.+]] = moore.add [[A_ADD]], [[B_ADD]] : i32
     // CHECK:   moore.yield [[TMP2]] : i32
     // CHECK: } {
-    // CHECK:   [[TMP2:%.+]] = moore.sub %a, %b : i32
+    // CHECK:   [[A_SUB:%.+]] = moore.read %a : i32
+    // CHECK:   [[B_SUB:%.+]] = moore.read %b : i32
+    // CHECK:   [[TMP2:%.+]] = moore.sub [[A_SUB]], [[B_SUB]] : i32
     // CHECK:   moore.yield [[TMP2]] : i32
     // CHECK: }
     c = (a > b) ? (a + b) : (a - b);
@@ -641,66 +856,80 @@ module Expressions;
     //===------------------------------------------------------------------===//
     // Assign operators
 
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %a
-    // CHECK: [[TMP2:%.+]] = moore.add [[TMP1]], %b
-    // CHECK: moore.blocking_assign %a, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %a
+    // CHECK: [[TMP2:%.+]] = moore.read %b
+    // CHECK: [[TMP3:%.+]] = moore.add [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %a, [[TMP3]]
     a += b;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %a
-    // CHECK: [[TMP2:%.+]] = moore.sub [[TMP1]], %b
-    // CHECK: moore.blocking_assign %a, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %a
+    // CHECK: [[TMP2:%.+]] = moore.read %b
+    // CHECK: [[TMP3:%.+]] = moore.sub [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %a, [[TMP3]]
     a -= b;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %a
-    // CHECK: [[TMP2:%.+]] = moore.mul [[TMP1]], %b
-    // CHECK: moore.blocking_assign %a, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %a
+    // CHECK: [[TMP2:%.+]] = moore.read %b
+    // CHECK: [[TMP3:%.+]] = moore.mul [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %a, [[TMP3]]
     a *= b;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %f
-    // CHECK: [[TMP2:%.+]] = moore.divs [[TMP1]], %d
-    // CHECK: moore.blocking_assign %f, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %f
+    // CHECK: [[TMP2:%.+]] = moore.read %d
+    // CHECK: [[TMP3:%.+]] = moore.divs [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %f, [[TMP3]]
     f /= d;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %g
-    // CHECK: [[TMP2:%.+]] = moore.divu [[TMP1]], %h
-    // CHECK: moore.blocking_assign %g, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %g
+    // CHECK: [[TMP2:%.+]] = moore.read %h
+    // CHECK: [[TMP3:%.+]] = moore.divu [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %g, [[TMP3]]
     g /= h;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %f
-    // CHECK: [[TMP2:%.+]] = moore.mods [[TMP1]], %d
-    // CHECK: moore.blocking_assign %f, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %f
+    // CHECK: [[TMP2:%.+]] = moore.read %d
+    // CHECK: [[TMP3:%.+]] = moore.mods [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %f, [[TMP3]]
     f %= d;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %g
-    // CHECK: [[TMP2:%.+]] = moore.modu [[TMP1]], %h
-    // CHECK: moore.blocking_assign %g, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %g
+    // CHECK: [[TMP2:%.+]] = moore.read %h
+    // CHECK: [[TMP3:%.+]] = moore.modu [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %g, [[TMP3]]
     g %= h;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %a
-    // CHECK: [[TMP2:%.+]] = moore.and [[TMP1]], %b
-    // CHECK: moore.blocking_assign %a, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %a
+    // CHECK: [[TMP2:%.+]] = moore.read %b
+    // CHECK: [[TMP3:%.+]] = moore.and [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %a, [[TMP3]]
     a &= b;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %a
-    // CHECK: [[TMP2:%.+]] = moore.or [[TMP1]], %b
-    // CHECK: moore.blocking_assign %a, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %a
+    // CHECK: [[TMP2:%.+]] = moore.read %b
+    // CHECK: [[TMP3:%.+]] = moore.or [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %a, [[TMP3]]
     a |= b;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %a
-    // CHECK: [[TMP2:%.+]] = moore.xor [[TMP1]], %b
-    // CHECK: moore.blocking_assign %a, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %a
+    // CHECK: [[TMP2:%.+]] = moore.read %b
+    // CHECK: [[TMP3:%.+]] = moore.xor [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %a, [[TMP3]]
     a ^= b;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %a
-    // CHECK: [[TMP2:%.+]] = moore.shl [[TMP1]], %b
-    // CHECK: moore.blocking_assign %a, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %a
+    // CHECK: [[TMP2:%.+]] = moore.read %b
+    // CHECK: [[TMP3:%.+]] = moore.shl [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %a, [[TMP3]]
     a <<= b;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %a
-    // CHECK: [[TMP2:%.+]] = moore.shl [[TMP1]], %b
-    // CHECK: moore.blocking_assign %a, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %a
+    // CHECK: [[TMP2:%.+]] = moore.read %b
+    // CHECK: [[TMP3:%.+]] = moore.shl [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %a, [[TMP3]]
     a <<<= b;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %a
-    // CHECK: [[TMP2:%.+]] = moore.shr [[TMP1]], %b
-    // CHECK: moore.blocking_assign %a, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %a
+    // CHECK: [[TMP2:%.+]] = moore.read %b
+    // CHECK: [[TMP3:%.+]] = moore.shr [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %a, [[TMP3]]
     a >>= b;
-    // CHECK: [[TMP1:%.+]] = moore.read_lvalue %a
-    // CHECK: [[TMP2:%.+]] = moore.ashr [[TMP1]], %b
-    // CHECK: moore.blocking_assign %a, [[TMP2]]
+    // CHECK: [[TMP1:%.+]] = moore.read %a
+    // CHECK: [[TMP2:%.+]] = moore.read %b
+    // CHECK: [[TMP3:%.+]] = moore.ashr [[TMP1]], [[TMP2]]
+    // CHECK: moore.blocking_assign %a, [[TMP3]]
     a >>>= b;
 
-    // CHECK: [[A_ADD:%.+]] = moore.read_lvalue %a
-    // CHECK: [[A_MUL:%.+]] = moore.read_lvalue %a
-    // CHECK: [[A_DEC:%.+]] = moore.read_lvalue %a
+    // CHECK: [[A_ADD:%.+]] = moore.read %a
+    // CHECK: [[A_MUL:%.+]] = moore.read %a
+    // CHECK: [[A_DEC:%.+]] = moore.read %a
     // CHECK: [[TMP1:%.+]] = moore.constant 1
     // CHECK: [[TMP2:%.+]] = moore.sub [[A_DEC]], [[TMP1]]
     // CHECK: moore.blocking_assign %a, [[TMP2]]
@@ -709,42 +938,7 @@ module Expressions;
     // CHECK: [[TMP2:%.+]] = moore.add [[A_ADD]], [[TMP1]]
     // CHECK: moore.blocking_assign %a, [[TMP2]]
     a += (a *= a--);
-
-    // CHECK: [[TMP:%.+]] = moore.struct_extract %struct0, "a" : struct<{a: i32, b: i32}> -> i32
-    // CHECK: moore.blocking_assign [[TMP]], %a : i32
-    struct0.a = a;
-
-    // CHECK: [[TMP:%.+]]  = moore.struct_extract %struct0, "b" : struct<{a: i32, b: i32}> -> i32
-    // CHECK: moore.blocking_assign %b, [[TMP]] : i32
-    b = struct0.b;
-
-    // CHECK: [[TMP1:%.+]] = moore.struct_extract %struct1, "c" : struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}> -> struct<{a: i32, b: i32}>
-    // CHECK: [[TMP2:%.+]] = moore.struct_extract [[TMP1]], "a" : struct<{a: i32, b: i32}> -> i32
-    // CHECK: moore.blocking_assign [[TMP2]], %a : i32
-    struct1.c.a = a;
-
-    // CHECK: [[TMP1:%.+]] = moore.struct_extract %struct1, "d" : struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}> -> struct<{a: i32, b: i32}>
-    // CHECK: [[TMP2:%.+]] = moore.struct_extract [[TMP1]], "b" : struct<{a: i32, b: i32}> -> i32
-    // CHECK: moore.blocking_assign %b, [[TMP2]] : i32
-    b = struct1.d.b;
-
-    // CHECK: [[TMP:%.+]] = moore.union_extract %union0, "a" : union<{a: i32, b: i32}> -> i32
-    // CHECK: moore.blocking_assign [[TMP]], %a : i32
-    union0.a = a;
-
-    // CHECK: [[TMP:%.+]]  = moore.union_extract %union0, "b" : union<{a: i32, b: i32}> -> i32
-    // CHECK: moore.blocking_assign %b, [[TMP]] : i32
-    b = union0.b;
-
-    // CHECK: [[TMP1:%.+]] = moore.union_extract %union1, "c" : union<{c: union<{a: i32, b: i32}>, d: union<{a: i32, b: i32}>}> -> union<{a: i32, b: i32}>
-    // CHECK: [[TMP2:%.+]] = moore.union_extract [[TMP1]], "a" : union<{a: i32, b: i32}> -> i32
-    // CHECK: moore.blocking_assign [[TMP2]], %a : i32
-    union1.c.a = a;
-
-    // CHECK: [[TMP1:%.+]] = moore.union_extract %union1, "d" : union<{c: union<{a: i32, b: i32}>, d: union<{a: i32, b: i32}>}> -> union<{a: i32, b: i32}>
-    // CHECK: [[TMP2:%.+]] = moore.union_extract [[TMP1]], "b" : union<{a: i32, b: i32}> -> i32
-    // CHECK: moore.blocking_assign %b, [[TMP2]] : i32
-    b = union1.d.b;
+ 
   end
 endmodule
 
@@ -752,28 +946,33 @@ endmodule
 module Conversion;
   // Implicit conversion.
   // CHECK: %a = moore.variable
-  // CHECK: [[TMP:%.+]] = moore.conversion %a : !moore.i16 -> !moore.i32
-  // CHECK: %b = moore.variable [[TMP]]
+  // CHECK: [[TMP1:%.+]] = moore.read %a : i16
+  // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i16 -> !moore.i32
+  // CHECK: %b = moore.variable [[TMP2]]
   shortint a;
   int b = a;
 
   // Explicit conversion.
-  // CHECK: [[TMP1:%.+]] = moore.conversion %a : !moore.i16 -> !moore.i8
-  // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i8 -> !moore.i32
-  // CHECK: %c = moore.variable [[TMP2]]
+  // CHECK: [[TMP1:%.+]] = moore.read %a : i16
+  // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i16 -> !moore.i8
+  // CHECK: [[TMP3:%.+]] = moore.conversion [[TMP2]] : !moore.i8 -> !moore.i32
+  // CHECK: %c = moore.variable [[TMP3]]
   int c = byte'(a);
 
   // Sign conversion.
-  // CHECK: [[TMP:%.+]] = moore.conversion %b : !moore.i32 -> !moore.i32
-  // CHECK: %d1 = moore.variable [[TMP]]
-  // CHECK: [[TMP:%.+]] = moore.conversion %b : !moore.i32 -> !moore.i32
-  // CHECK: %d2 = moore.variable [[TMP]]
+  // CHECK: [[TMP1:%.+]] = moore.read %b : i32
+  // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i32 -> !moore.i32
+  // CHECK: %d1 = moore.variable [[TMP2]]
+  // CHECK: [[TMP3:%.+]] = moore.read %b : i32
+  // CHECK: [[TMP4:%.+]] = moore.conversion [[TMP3]] : !moore.i32 -> !moore.i32
+  // CHECK: %d2 = moore.variable [[TMP4]]
   bit signed [31:0] d1 = signed'(b);
   bit [31:0] d2 = unsigned'(b);
 
   // Width conversion.
-  // CHECK: [[TMP:%.+]] = moore.conversion %b : !moore.i32 -> !moore.i19
-  // CHECK: %e = moore.variable [[TMP]]
+  // CHECK: [[TMP1:%.+]] = moore.read %b : i32
+  // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i32 -> !moore.i19
+  // CHECK: %e = moore.variable [[TMP2]]
   bit signed [18:0] e = 19'(b);
 endmodule
 
@@ -781,20 +980,22 @@ endmodule
 module PortsTop;
   wire x0, y0, z0;
   logic w0;
+  // CHECK: [[x0:%.+]] = moore.read %x0 : l1
   // CHECK: [[B:%.+]] = moore.instance "p0" @PortsAnsi(
-  // CHECK-SAME:   a: %x0: !moore.l1
-  // CHECK-SAME:   c: %z0: !moore.l1
-  // CHECK-SAME:   d: %w0: !moore.l1
+  // CHECK-SAME:   a: [[x0]]: !moore.l1
+  // CHECK-SAME:   c: %z0: !moore.ref<l1>
+  // CHECK-SAME:   d: %w0: !moore.ref<l1>
   // CHECK-SAME: ) -> (b: !moore.l1)
   // CHECK-NEXT: moore.assign %y0, [[B]]
   PortsAnsi p0(x0, y0, z0, w0);
 
   wire x1, y1, z1;
   logic w1;
+  // CHECK: [[x1:%.+]] = moore.read %x1 : l1
   // CHECK: [[B:%.+]] = moore.instance "p1" @PortsNonAnsi(
-  // CHECK-SAME:   a: %x1: !moore.l1
-  // CHECK-SAME:   c: %z1: !moore.l1
-  // CHECK-SAME:   d: %w1: !moore.l1
+  // CHECK-SAME:   a: [[x1]]: !moore.l1
+  // CHECK-SAME:   c: %z1: !moore.ref<l1>
+  // CHECK-SAME:   d: %w1: !moore.ref<l1>
   // CHECK-SAME: ) -> (b: !moore.l1)
   // CHECK-NEXT: moore.assign %y1, [[B]]
   PortsNonAnsi p1(x1, y1, z1, w1);
@@ -803,9 +1004,11 @@ module PortsTop;
   wire [1:0] y2;
   int z2;
   wire w2, v2;
+  // CHECK: [[X2:%.+]] = moore.read %x2
+  // CHECK: [[Y2:%.+]] = moore.read %y2
   // CHECK: [[B0:%.+]], [[B1:%.+]], [[B2:%.+]] = moore.instance "p2" @PortsExplicit(
-  // CHECK-SAME:   a0: %x2: !moore.l1
-  // CHECK-SAME:   a1: %y2: !moore.l2
+  // CHECK-SAME:   a0: [[X2]]: !moore.l1
+  // CHECK-SAME:   a1: [[Y2]]: !moore.l2
   // CHECK-SAME: ) -> (
   // CHECK-SAME:   b0: !moore.i32
   // CHECK-SAME:   b1: !moore.l1
@@ -819,22 +1022,26 @@ module PortsTop;
   wire x3, y3;
   wire [2:0] z3;
   wire [1:0] w3;
+  // CHECK: [[X3:%.+]] = moore.read %x3
+  // CHECK: [[Y3:%.+]] = moore.read %y3
   // CHECK: [[TMP:%.+]] = moore.constant 0 :
-  // CHECK: [[V2:%.+]] = moore.extract %z3 from [[TMP]]
+  // CHECK: [[V2:%.+]] = moore.extract_ref %z3 from [[TMP]]
   // CHECK: [[TMP:%.+]] = moore.constant 1 :
-  // CHECK: [[V1:%.+]] = moore.extract %z3 from [[TMP]]
+  // CHECK: [[V1:%.+]] = moore.extract_ref %z3 from [[TMP]]
   // CHECK: [[TMP:%.+]] = moore.constant 2 :
-  // CHECK: [[V0:%.+]] = moore.extract %z3 from [[TMP]]
+  // CHECK: [[V0:%.+]] = moore.extract_ref %z3 from [[TMP]]
+  // CHECK: [[V0_READ:%.+]] = moore.read [[V0]]
   // CHECK: [[TMP:%.+]] = moore.constant 0 :
-  // CHECK: [[C1:%.+]] = moore.extract %w3 from [[TMP]]
+  // CHECK: [[C1:%.+]] = moore.extract_ref %w3 from [[TMP]]
   // CHECK: [[TMP:%.+]] = moore.constant 1 :
-  // CHECK: [[C0:%.+]] = moore.extract %w3 from [[TMP]]
+  // CHECK: [[C0:%.+]] = moore.extract_ref %w3 from [[TMP]]
+  // CHECK: [[C0_READ:%.+]] = moore.read [[C0]]
   // CHECK: [[V1_VALUE:%.+]], [[C1_VALUE:%.+]] = moore.instance "p3" @MultiPorts(
-  // CHECK-SAME:   a0: %x3: !moore.l1
-  // CHECK-SAME:   a1: %y3: !moore.l1
-  // CHECK-SAME:   v0: [[V0]]: !moore.l1
-  // CHECK-SAME:   v2: [[V2]]: !moore.l1
-  // CHECK-SAME:   c0: [[C0]]: !moore.l1
+  // CHECK-SAME:   a0: [[X3]]: !moore.l1
+  // CHECK-SAME:   a1: [[Y3]]: !moore.l1
+  // CHECK-SAME:   v0: [[V0_READ]]: !moore.l1
+  // CHECK-SAME:   v2: [[V2]]: !moore.ref<l1>
+  // CHECK-SAME:   c0: [[C0_READ]]: !moore.l1
   // CHECK-SAME: ) -> (
   // CHECK-SAME:   v1: !moore.l1
   // CHECK-SAME:   c1: !moore.l1
@@ -850,29 +1057,32 @@ module PortsAnsi(
   input a,
   // CHECK-SAME: out b : !moore.l1
   output b,
-  // CHECK-SAME: in %c : !moore.l1
+  // CHECK-SAME: in %c : !moore.ref<l1>
   inout c,
-  // CHECK-SAME: in %d : !moore.l1
+  // CHECK-SAME: in %d : !moore.ref<l1>
   ref d
 );
   // Internal nets and variables created by Slang for each port.
-  // CHECK: [[A_INT:%.+]] = moore.net name "a" wire : l1
-  // CHECK: [[B_INT:%.+]] = moore.net wire : l1
-  // CHECK: [[C_INT:%.+]] = moore.net name "c" wire : l1
-  // CHECK: [[D_INT:%.+]] = moore.variable name "d" : l1
+  // CHECK: [[A_INT:%.+]] = moore.net name "a" wire : <l1>
+  // CHECK: [[B_INT:%.+]] = moore.net wire : <l1>
+  // CHECK: [[C_INT:%.+]] = moore.net name "c" wire : <l1>
+  // CHECK: [[D_INT:%.+]] = moore.variable name "d" : <l1>
 
   // Mapping ports to local declarations.
   // CHECK: moore.assign [[A_INT]], %a : l1
-  // CHECK: moore.assign [[C_INT]], %c : l1
-  // CHECK: moore.assign [[D_INT]], %d : l1
-  // CHECK: moore.output [[B_INT]] : !moore.l1
+  // CHECK: [[B_READ:%.+]] = moore.read %b : l1
+  // CHECK: [[C_READ:%.+]] = moore.read %c : l1
+  // CHECK: moore.assign [[C_INT]], [[C_READ]] : l1
+  // CHECK: [[D_READ:%.+]] = moore.read %d : l1
+  // CHECK: moore.assign [[D_INT]], [[D_READ]] : l1
+  // CHECK: moore.output [[B_READ]] : !moore.l1
 endmodule
 
 // CHECK-LABEL: moore.module @PortsNonAnsi
 // CHECK-SAME: in %a : !moore.l1
 // CHECK-SAME: out b : !moore.l1
-// CHECK-SAME: in %c : !moore.l1
-// CHECK-SAME: in %d : !moore.l1
+// CHECK-SAME: in %c : !moore.ref<l1>
+// CHECK-SAME: in %d : !moore.ref<l1>
 module PortsNonAnsi(a, b, c, d);
   input a;
   output b;
@@ -897,13 +1107,16 @@ module PortsExplicit(
 
   // Input mappings
   // CHECK: moore.assign %x, %a0
-  // CHECK: [[TMP:%.+]] = moore.concat %y, %z
+  // CHECK: [[TMP:%.+]] = moore.concat_ref %y, %z
   // CHECK: moore.assign [[TMP]], %a1
 
   // Output mappings
   // CHECK: [[B0:%.+]] = moore.constant 42
-  // CHECK: [[B2:%.+]] = moore.xor %y, %z
-  // CHECK: moore.output [[B0]], %x, [[B2]]
+  // CHECK: [[X_READ:%.+]] = moore.read %x : l1
+  // CHECK: [[Y_READ:%.+]] = moore.read %y : l1
+  // CHECK: [[Z_READ:%.+]] = moore.read %z : l1
+  // CHECK: [[B2:%.+]] = moore.xor [[Y_READ]], [[Z_READ]]
+  // CHECK: moore.output [[B0]], [[X_READ]], [[B2]]
 endmodule
 
 // CHECK-LABEL: moore.module @MultiPorts
@@ -914,7 +1127,7 @@ module MultiPorts(
   .a1(u[1]),
   // CHECK-SAME: in %v0 : !moore.l1
   // CHECK-SAME: out v1 : !moore.l1
-  // CHECK-SAME: in %v2 : !moore.l1
+  // CHECK-SAME: in %v2 : !moore.ref<l1>
   .b({v0, v1, v2}),
   // CHECK-SAME: in %c0 : !moore.l1
   // CHECK-SAME: out c1 : !moore.l1
@@ -933,15 +1146,18 @@ module MultiPorts(
   output c1;
 
   // CHECK: [[TMP1:%.+]] = moore.constant 0 :
-  // CHECK: [[TMP2:%.+]] = moore.extract %u from [[TMP1]]
+  // CHECK: [[TMP2:%.+]] = moore.extract_ref %u from [[TMP1]]
   // CHECK: moore.assign [[TMP2]], %a0
 
   // CHECK: [[TMP1:%.+]] = moore.constant 1 :
-  // CHECK: [[TMP2:%.+]] = moore.extract %u from [[TMP1]]
+  // CHECK: [[TMP2:%.+]] = moore.extract_ref %u from [[TMP1]]
   // CHECK: moore.assign [[TMP2]], %a1
 
   // CHECK: moore.assign [[V0]], %v0
-  // CHECK: moore.assign [[V2]], %v2
+  // CHECK: [[V1_READ:%.+]] = moore.read %v1
+  // CHECK: [[V2_READ:%.+]] = moore.read %v2
+  // CHECK: moore.assign [[V2]], [[V2_READ]]
   // CHECK: moore.assign [[C0]], %c0
-  // CHECK: moore.output [[V1]], [[C1]]
+  // CHECK: [[C1_READ:%.+]] = moore.read %c1
+  // CHECK: moore.output [[V1_READ]], [[C1_READ]]
 endmodule

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -8,9 +8,9 @@
 module Enums;
   typedef enum shortint { MAGIC } myEnum;
 
-  // CHECK-NEXT: %e0 = moore.variable : i32
-  // CHECK-NEXT: %e1 = moore.variable : i8
-  // CHECK-NEXT: %e2 = moore.variable : i16
+  // CHECK-NEXT: %e0 = moore.variable : <i32>
+  // CHECK-NEXT: %e1 = moore.variable : <i8>
+  // CHECK-NEXT: %e2 = moore.variable : <i16>
   enum { FOO, BAR } e0;
   enum byte { HELLO = 0, WORLD = 1 } e1;
   myEnum e2;
@@ -18,15 +18,15 @@ endmodule
 
 // CHECK-LABEL: moore.module @IntAtoms
 module IntAtoms;
-  // CHECK-NEXT: %d0 = moore.variable : l1
-  // CHECK-NEXT: %d1 = moore.variable : i1
-  // CHECK-NEXT: %d2 = moore.variable : l1
-  // CHECK-NEXT: %d3 = moore.variable : i32
-  // CHECK-NEXT: %d4 = moore.variable : i16
-  // CHECK-NEXT: %d5 = moore.variable : i64
-  // CHECK-NEXT: %d6 = moore.variable : l32
-  // CHECK-NEXT: %d7 = moore.variable : i8
-  // CHECK-NEXT: %d8 = moore.variable : l64
+  // CHECK-NEXT: %d0 = moore.variable : <l1>
+  // CHECK-NEXT: %d1 = moore.variable : <i1>
+  // CHECK-NEXT: %d2 = moore.variable : <l1>
+  // CHECK-NEXT: %d3 = moore.variable : <i32>
+  // CHECK-NEXT: %d4 = moore.variable : <i16>
+  // CHECK-NEXT: %d5 = moore.variable : <i64>
+  // CHECK-NEXT: %d6 = moore.variable : <l32>
+  // CHECK-NEXT: %d7 = moore.variable : <i8>
+  // CHECK-NEXT: %d8 = moore.variable : <l64>
   logic d0;
   bit d1;
   reg d2;
@@ -37,15 +37,15 @@ module IntAtoms;
   byte d7;
   time d8;
 
-  // CHECK-NEXT: %u0 = moore.variable : l1
-  // CHECK-NEXT: %u1 = moore.variable : i1
-  // CHECK-NEXT: %u2 = moore.variable : l1
-  // CHECK-NEXT: %u3 = moore.variable : i32
-  // CHECK-NEXT: %u4 = moore.variable : i16
-  // CHECK-NEXT: %u5 = moore.variable : i64
-  // CHECK-NEXT: %u6 = moore.variable : l32
-  // CHECK-NEXT: %u7 = moore.variable : i8
-  // CHECK-NEXT: %u8 = moore.variable : l64
+  // CHECK-NEXT: %u0 = moore.variable : <l1>
+  // CHECK-NEXT: %u1 = moore.variable : <i1>
+  // CHECK-NEXT: %u2 = moore.variable : <l1>
+  // CHECK-NEXT: %u3 = moore.variable : <i32>
+  // CHECK-NEXT: %u4 = moore.variable : <i16>
+  // CHECK-NEXT: %u5 = moore.variable : <i64>
+  // CHECK-NEXT: %u6 = moore.variable : <l32>
+  // CHECK-NEXT: %u7 = moore.variable : <i8>
+  // CHECK-NEXT: %u8 = moore.variable : <l64>
   logic unsigned u0;
   bit unsigned u1;
   reg unsigned u2;
@@ -56,15 +56,15 @@ module IntAtoms;
   byte unsigned u7;
   time unsigned u8;
 
-  // CHECK-NEXT: %s0 = moore.variable : l1
-  // CHECK-NEXT: %s1 = moore.variable : i1
-  // CHECK-NEXT: %s2 = moore.variable : l1
-  // CHECK-NEXT: %s3 = moore.variable : i32
-  // CHECK-NEXT: %s4 = moore.variable : i16
-  // CHECK-NEXT: %s5 = moore.variable : i64
-  // CHECK-NEXT: %s6 = moore.variable : l32
-  // CHECK-NEXT: %s7 = moore.variable : i8
-  // CHECK-NEXT: %s8 = moore.variable : l64
+  // CHECK-NEXT: %s0 = moore.variable : <l1>
+  // CHECK-NEXT: %s1 = moore.variable : <i1>
+  // CHECK-NEXT: %s2 = moore.variable : <l1>
+  // CHECK-NEXT: %s3 = moore.variable : <i32>
+  // CHECK-NEXT: %s4 = moore.variable : <i16>
+  // CHECK-NEXT: %s5 = moore.variable : <i64>
+  // CHECK-NEXT: %s6 = moore.variable : <l32>
+  // CHECK-NEXT: %s7 = moore.variable : <i8>
+  // CHECK-NEXT: %s8 = moore.variable : <l64>
   logic signed s0;
   bit signed s1;
   reg signed s2;
@@ -78,46 +78,46 @@ endmodule
 
 // CHECK-LABEL: moore.module @Dimensions
 module Dimensions;
-  // CHECK-NEXT: %p0 = moore.variable : l3
+  // CHECK-NEXT: %p0 = moore.variable : <l3>
   logic [2:0] p0;
-  // CHECK-NEXT: %p1 = moore.variable : l3
+  // CHECK-NEXT: %p1 = moore.variable : <l3>
   logic [0:2] p1;
-  // CHECK-NEXT: %p2 = moore.variable : array<6 x l3>
+  // CHECK-NEXT: %p2 = moore.variable : <array<6 x l3>>
   logic [5:0][2:0] p2;
-  // CHECK-NEXT: %p3 = moore.variable : array<6 x l3>
+  // CHECK-NEXT: %p3 = moore.variable : <array<6 x l3>>
   logic [0:5][2:0] p3;
 
-  // CHECK-NEXT: %u0 = moore.variable : uarray<3 x l1>
+  // CHECK-NEXT: %u0 = moore.variable : <uarray<3 x l1>>
   logic u0 [2:0];
-  // CHECK-NEXT: %u1 = moore.variable : uarray<3 x l1>
+  // CHECK-NEXT: %u1 = moore.variable : <uarray<3 x l1>>
   logic u1 [0:2];
-  // CHECK-NEXT: %u2 = moore.variable : uarray<6 x uarray<3 x l1>>
+  // CHECK-NEXT: %u2 = moore.variable : <uarray<6 x uarray<3 x l1>>>
   logic u2 [5:0][2:0];
-  // CHECK-NEXT: %u3 = moore.variable : uarray<6 x uarray<3 x l1>>
+  // CHECK-NEXT: %u3 = moore.variable : <uarray<6 x uarray<3 x l1>>>
   logic u3 [0:5][2:0];
-  // CHECK-NEXT: %u4 = moore.variable : open_uarray<l1>
+  // CHECK-NEXT: %u4 = moore.variable : <open_uarray<l1>>
   logic u4 [];
-  // CHECK-NEXT: %u5 = moore.variable : open_uarray<open_uarray<l1>>
+  // CHECK-NEXT: %u5 = moore.variable : <open_uarray<open_uarray<l1>>>
   logic u5 [][];
-  // CHECK-NEXT: %u6 = moore.variable : uarray<42 x l1>
+  // CHECK-NEXT: %u6 = moore.variable : <uarray<42 x l1>>
   logic u6 [42];
-  // CHECK-NEXT: %u7 = moore.variable : assoc_array<l1, i32>
+  // CHECK-NEXT: %u7 = moore.variable : <assoc_array<l1, i32>>
   logic u7 [int];
-  // CHECK-NEXT: %u8 = moore.variable : assoc_array<l1, l1>
+  // CHECK-NEXT: %u8 = moore.variable : <assoc_array<l1, l1>>
   logic u8 [logic];
-  //CHECK-NEXT: %u9 = moore.variable : queue<l1, 0>
+  //CHECK-NEXT: %u9 = moore.variable : <queue<l1, 0>>
   logic u9 [$];
-  //CHECK-NEXT: %u10 = moore.variable : queue<l1, 2>
+  //CHECK-NEXT: %u10 = moore.variable : <queue<l1, 2>>
   logic u10 [$:2];
 endmodule
 
 // CHECK-LABEL: moore.module @RealType
 module RealType;
-  // CHECK-NEXT: %d0 = moore.variable : real
+  // CHECK-NEXT: %d0 = moore.variable : <real>
   real d0;
-  // CHECK-NEXT: %d1 = moore.variable : real
+  // CHECK-NEXT: %d1 = moore.variable : <real>
   realtime d1;
-  // CHECK-NEXT: %d2 = moore.variable : real
+  // CHECK-NEXT: %d2 = moore.variable : <real>
   shortreal d2;
 endmodule
 
@@ -126,10 +126,10 @@ module Structs;
   typedef struct packed { byte a; int b; } myStructA;
   typedef struct { byte x; int y; } myStructB;
 
-  // CHECK-NEXT: %s0 = moore.variable : struct<{foo: i1, bar: l1}>
-  // CHECK-NEXT: %s1 = moore.variable : ustruct<{many: assoc_array<i1, i32>}>
-  // CHECK-NEXT: %s2 = moore.variable : struct<{a: i8, b: i32}>
-  // CHECK-NEXT: %s3 = moore.variable : ustruct<{x: i8, y: i32}>
+  // CHECK-NEXT: %s0 = moore.variable : <struct<{foo: i1, bar: l1}>>
+  // CHECK-NEXT: %s1 = moore.variable : <ustruct<{many: assoc_array<i1, i32>}>>
+  // CHECK-NEXT: %s2 = moore.variable : <struct<{a: i8, b: i32}>>
+  // CHECK-NEXT: %s3 = moore.variable : <ustruct<{x: i8, y: i32}>>
   struct packed { bit foo; logic bar; } s0;
   struct { bit many[int]; } s1;
   myStructA s2;
@@ -141,8 +141,8 @@ module Typedefs;
   typedef logic [2:0] myType1;
   typedef logic myType2 [2:0];
 
-  // CHECK-NEXT: %v0 = moore.variable : l3
-  // CHECK-NEXT: %v1 = moore.variable : uarray<3 x l1>
+  // CHECK-NEXT: %v0 = moore.variable : <l3>
+  // CHECK-NEXT: %v1 = moore.variable : <uarray<3 x l1>>
   myType1 v0;
   myType2 v1;
 endmodule

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -25,43 +25,51 @@ moore.module @Module() {
   // CHECK: moore.instance "empty" @Empty() -> ()
   moore.instance "empty" @Empty() -> ()
 
-  // CHECK: moore.instance "ports" @Ports(a: %i1: !moore.string, c: %i2: !moore.event) -> (b: !moore.string, d: !moore.event)
-  %i1 = moore.variable : !moore.string
-  %i2 = moore.variable : !moore.event
-  %o1, %o2 = moore.instance "ports" @Ports(a: %i1: !moore.string, c: %i2: !moore.event) -> (b: !moore.string, d: !moore.event)
+  // CHECK: %[[I1_READ:.+]] = moore.read %i1
+  // CHECK: %[[I2_READ:.+]] = moore.read %i2 
+  // CHECK: moore.instance "ports" @Ports(a: %[[I1_READ]]: !moore.string, c: %[[I2_READ]]: !moore.event) -> (b: !moore.string, d: !moore.event)
+  %i1 = moore.variable : <!moore.string>
+  %i2 = moore.variable : <!moore.event>
+  %5 = moore.read %i1 : !moore.string
+  %6 = moore.read %i2 : !moore.event
+  %o1, %o2 = moore.instance "ports" @Ports(a: %5: !moore.string, c: %6: !moore.event) -> (b: !moore.string, d: !moore.event)
 
-  // CHECK: %v1 = moore.variable : i1
-  %v1 = moore.variable : i1
-  %v2 = moore.variable : i1
-  // CHECK: [[TMP:%.+]] = moore.variable name "v1" %v2 : i1
-  moore.variable name "v1" %v2 : i1
+  // CHECK: %v1 = moore.variable : <i1>
+  %v1 = moore.variable : <i1>
+  %v2 = moore.variable : <i1>
+  // CHECK: %[[TMP1:.+]] = moore.read %v2 : i1
+  // CHECK: %[[TMP2:.+]] = moore.variable name "v1" %[[TMP1]] : <i1>
+  %0 = moore.read %v2 : i1
+  moore.variable name "v1" %0 : <i1>
 
-  // CHECK: %w0 = moore.net wire : l1
-  %w0 = moore.net wire : l1
-  // CHECK: %w1 = moore.net wire %w0 : l1
-  %w1 = moore.net wire %w0 : l1
-  // CHECK: %w2 = moore.net uwire %w0 : l1
-  %w2 = moore.net uwire %w0 : l1
-  // CHECK: %w3 = moore.net tri %w0 : l1
-  %w3 = moore.net tri %w0 : l1
-  // CHECK: %w4 = moore.net triand %w0 : l1
-  %w4 = moore.net triand %w0 : l1
-  // CHECK: %w5 = moore.net trior %w0 : l1
-  %w5 = moore.net trior %w0 : l1
-  // CHECK: %w6 = moore.net wand %w0 : l1
-  %w6 = moore.net wand %w0 : l1
-  // CHECK: %w7 = moore.net wor %w0 : l1
-  %w7 = moore.net wor %w0 : l1
-  // CHECK: %w8 = moore.net trireg %w0 : l1
-  %w8 = moore.net trireg %w0 : l1
-  // CHECK: %w9 = moore.net tri0 %w0 : l1
-  %w9 = moore.net tri0 %w0 : l1
-  // CHECK: %w10 = moore.net tri1 %w0 : l1
-  %w10 = moore.net tri1 %w0 : l1
-  // CHECK: %w11 = moore.net supply0 : l1
-  %w11 = moore.net supply0 : l1
-  // CHECK: %w12 = moore.net supply1 : l1
-  %w12 = moore.net supply1 : l1
+  // CHECK: %w0 = moore.net wire : <l1>
+  %w0 = moore.net wire : <l1>
+  // CHECK: %[[W0:.+]] = moore.read %w0 : l1
+  %1 = moore.read %w0 : l1
+  // CHECK: %w1 = moore.net wire %[[W0]] : <l1>
+  %w1 = moore.net wire %1 : <l1>
+  // CHECK: %w2 = moore.net uwire %[[W0]] : <l1>
+  %w2 = moore.net uwire %1 : <l1>
+  // CHECK: %w3 = moore.net tri %[[W0]] : <l1>
+  %w3 = moore.net tri %1 : <l1>
+  // CHECK: %w4 = moore.net triand %[[W0]] : <l1>
+  %w4 = moore.net triand %1 : <l1>
+  // CHECK: %w5 = moore.net trior %[[W0]] : <l1>
+  %w5 = moore.net trior %1 : <l1>
+  // CHECK: %w6 = moore.net wand %[[W0]] : <l1>
+  %w6 = moore.net wand %1 : <l1>
+  // CHECK: %w7 = moore.net wor %[[W0]] : <l1>
+  %w7 = moore.net wor %1 : <l1>
+  // CHECK: %w8 = moore.net trireg %[[W0]] : <l1>
+  %w8 = moore.net trireg %1 : <l1>
+  // CHECK: %w9 = moore.net tri0 %[[W0]] : <l1>
+  %w9 = moore.net tri0 %1 : <l1>
+  // CHECK: %w10 = moore.net tri1 %[[W0]] : <l1>
+  %w10 = moore.net tri1 %1 : <l1>
+  // CHECK: %w11 = moore.net supply0 : <l1>
+  %w11 = moore.net supply0 : <l1>
+  // CHECK: %w12 = moore.net supply1 : <l1>
+  %w12 = moore.net supply1 : <l1>
 
   // CHECK: moore.procedure initial {
   // CHECK: moore.procedure final {
@@ -76,29 +84,52 @@ moore.module @Module() {
   moore.procedure always_latch {}
   moore.procedure always_ff {}
 
-  // CHECK: moore.assign %v1, %v2 : i1
-  moore.assign %v1, %v2 : i1
+  // CHECK: %[[TMP1:.+]] = moore.read %v2 : i1
+  // CHECK: moore.assign %v1, %[[TMP1]] : i1
+  %2 = moore.read %v2 : i1
+  moore.assign %v1, %2 : i1
 
   moore.procedure always {
-    // CHECK: moore.blocking_assign %v1, %v2 : i1
-    moore.blocking_assign %v1, %v2 : i1
-    // CHECK: moore.nonblocking_assign %v1, %v2 : i1
-    moore.nonblocking_assign %v1, %v2 : i1
-    // CHECK: %a = moore.variable : i32
-    %a = moore.variable : i32
+    // CHECK: %[[TMP1:.+]] = moore.read %v2 : i1
+    // CHECK: moore.blocking_assign %v1, %[[TMP1]] : i1
+    %3 = moore.read %v2 : i1
+    moore.blocking_assign %v1, %3 : i1
+    // CHECK: %[[TMP2:.+]] = moore.read %v2 : i1
+    // CHECK: moore.nonblocking_assign %v1, %[[TMP2]] : i1
+    %4 = moore.read %v2 : i1
+    moore.nonblocking_assign %v1, %4 : i1
+    // CHECK: %a = moore.variable : <i32>
+    %a = moore.variable : <i32>
   }
 }
 
 // CHECK-LABEL: moore.module @Expressions
 moore.module @Expressions() {
-  %b1 = moore.variable : i1
-  %l1 = moore.variable : l1
-  %b5 = moore.variable : i5
-  %int = moore.variable : i32
-  %int2 = moore.variable : i32
-  %integer = moore.variable : l32
-  %integer2 = moore.variable : l32
-  %arr = moore.variable : uarray<2 x uarray<4 x i8>>
+  %b1 = moore.variable : <i1>
+  %l1 = moore.variable : <l1>
+  %b5 = moore.variable : <i5>
+  %int = moore.variable : <i32>
+  %int2 = moore.variable : <i32>
+  %integer = moore.variable : <l32>
+  %integer2 = moore.variable : <l32>
+  %arr = moore.variable : <uarray<2 x uarray<4 x i8>>>
+
+  // CHECK: %[[b1:.+]] = moore.read %b1 : i1
+  // CHECK: %[[l1:.+]] = moore.read %l1 : l1
+  // CHECK: %[[b5:.+]] = moore.read %b5 : i5
+  // CHECK: %[[int:.+]] = moore.read %int : i32
+  // CHECK: %[[int2:.+]] = moore.read %int2 : i32
+  // CHECK: %[[integer:.+]] = moore.read %integer : l32
+  // CHECK: %[[integer2:.+]] = moore.read %integer2 : l32
+  // CHECK: %[[arr:.+]] = moore.read %arr : uarray<2 x uarray<4 x i8>>
+  %0 = moore.read %b1 : i1
+  %1 = moore.read %l1 : l1
+  %2 = moore.read %b5 : i5
+  %3 = moore.read %int : i32
+  %4 = moore.read %int2 : i32
+  %5 = moore.read %integer : l32
+  %6 = moore.read %integer2 : l32
+  %7 = moore.read %arr : uarray<2 x uarray<4 x i8>>
 
   // CHECK: moore.constant 0 : i32
   moore.constant 0 : i32
@@ -107,125 +138,152 @@ moore.module @Expressions() {
   // CHECK: moore.constant -2 : i2
   moore.constant -2 : i2
 
-  // CHECK: moore.conversion %b5 : !moore.i5 -> !moore.l5
-  moore.conversion %b5 : !moore.i5 -> !moore.l5
+  // CHECK: moore.conversion %[[b5]] : !moore.i5 -> !moore.l5
+  moore.conversion %2 : !moore.i5 -> !moore.l5
 
-  // CHECK: moore.neg %int : i32
-  moore.neg %int : i32
-  // CHECK: moore.not %int : i32
-  moore.not %int : i32
+  // CHECK: moore.neg %[[int]] : i32
+  moore.neg %3 : i32
+  // CHECK: moore.not %[[int]] : i32
+  moore.not %3 : i32
 
-  // CHECK: moore.reduce_and %int : i32 -> i1
-  moore.reduce_and %int : i32 -> i1
-  // CHECK: moore.reduce_or %int : i32 -> i1
-  moore.reduce_or %int : i32 -> i1
-  // CHECK: moore.reduce_xor %int : i32 -> i1
-  moore.reduce_xor %int : i32 -> i1
-  // CHECK: moore.reduce_xor %integer : l32 -> l1
-  moore.reduce_xor %integer : l32 -> l1
+  // CHECK: moore.reduce_and %[[int]] : i32 -> i1
+  moore.reduce_and %3 : i32 -> i1
+  // CHECK: moore.reduce_or %[[int]] : i32 -> i1
+  moore.reduce_or %3 : i32 -> i1
+  // CHECK: moore.reduce_xor %[[int]] : i32 -> i1
+  moore.reduce_xor %3 : i32 -> i1
+  // CHECK: moore.reduce_xor %[[integer]] : l32 -> l1
+  moore.reduce_xor %5 : l32 -> l1
 
-  // CHECK: moore.bool_cast %int : i32 -> i1
-  moore.bool_cast %int : i32 -> i1
-  // CHECK: moore.bool_cast %integer : l32 -> l1
-  moore.bool_cast %integer : l32 -> l1
+  // CHECK: moore.bool_cast %[[int]] : i32 -> i1
+  moore.bool_cast %3 : i32 -> i1
+  // CHECK: moore.bool_cast %[[integer]] : l32 -> l1
+  moore.bool_cast %5 : l32 -> l1
 
-  // CHECK: moore.add %int, %int2 : i32
-  moore.add %int, %int2 : i32
-  // CHECK: moore.sub %int, %int2 : i32
-  moore.sub %int, %int2 : i32
-  // CHECK: moore.mul %int, %int2 : i32
-  moore.mul %int, %int2 : i32
-  // CHECK: moore.divu %int, %int2 : i32
-  moore.divu %int, %int2 : i32
-  // CHECK: moore.divs %int, %int2 : i32
-  moore.divs %int, %int2 : i32
-  // CHECK: moore.modu %int, %int2 : i32
-  moore.modu %int, %int2 : i32
-  // CHECK: moore.mods %int, %int2 : i32
-  moore.mods %int, %int2 : i32
+  // CHECK: moore.add %[[int]], %[[int2]] : i32
+  moore.add %3, %4 : i32
+  // CHECK: moore.sub %[[int]], %[[int2]] : i32
+  moore.sub %3, %4 : i32
+  // CHECK: moore.mul %[[int]], %[[int2]] : i32
+  moore.mul %3, %4 : i32
+  // CHECK: moore.divu %[[int]], %[[int2]] : i32
+  moore.divu %3, %4 : i32
+  // CHECK: moore.divs %[[int]], %[[int2]] : i32
+  moore.divs %3, %4 : i32
+  // CHECK: moore.modu %[[int]], %[[int2]] : i32
+  moore.modu %3, %4 : i32
+  // CHECK: moore.mods %[[int]], %[[int2]] : i32
+  moore.mods %3, %4 : i32
 
-  // CHECK: moore.and %int, %int2 : i32
-  moore.and %int, %int2 : i32
-  // CHECK: moore.or %int, %int2 : i32
-  moore.or %int, %int2 : i32
-  // CHECK: moore.xor %int, %int2 : i32
-  moore.xor %int, %int2 : i32
+  // CHECK: moore.and %[[int]], %[[int2]] : i32
+  moore.and %3, %4 : i32
+  // CHECK: moore.or %[[int]], %[[int2]] : i32
+  moore.or %3, %4 : i32
+  // CHECK: moore.xor %[[int]], %[[int2]] : i32
+  moore.xor %3, %4 : i32
 
-  // CHECK: moore.shl %l1, %b1 : l1, i1
-  moore.shl %l1, %b1 : l1, i1
-  // CHECK: moore.shr %l1, %b1 : l1, i1
-  moore.shr %l1, %b1 : l1, i1
-  // CHECK: moore.ashr %b5, %b1 : i5, i1
-  moore.ashr %b5, %b1 : i5, i1
+  // CHECK: moore.shl %[[l1]], %[[b1]] : l1, i1
+  moore.shl %1, %0 : l1, i1
+  // CHECK: moore.shr %[[l1]], %[[b1]] : l1, i1
+  moore.shr %1, %0 : l1, i1
+  // CHECK: moore.ashr %[[b5]], %[[b1]] : i5, i1
+  moore.ashr %2, %0 : i5, i1
 
-  // CHECK: moore.eq %int, %int2 : i32 -> i1
-  moore.eq %int, %int2 : i32 -> i1
-  // CHECK: moore.ne %int, %int2 : i32 -> i1
-  moore.ne %int, %int2 : i32 -> i1
-  // CHECK: moore.ne %integer, %integer2 : l32 -> l1
-  moore.ne %integer, %integer2 : l32 -> l1
-  // CHECK: moore.case_eq %int, %int2 : i32
-  moore.case_eq %int, %int2 : i32
-  // CHECK: moore.case_ne %int, %int2 : i32
-  moore.case_ne %int, %int2 : i32
-  // CHECK: moore.wildcard_eq %int, %int2 : i32 -> i1
-  moore.wildcard_eq %int, %int2 : i32 -> i1
-  // CHECK: moore.wildcard_ne %int, %int2 : i32 -> i1
-  moore.wildcard_ne %int, %int2 : i32 -> i1
-  // CHECK: moore.wildcard_ne %integer, %integer2 : l32 -> l1
-  moore.wildcard_ne %integer, %integer2 : l32 -> l1
+  // CHECK: moore.eq %[[int]], %[[int2]] : i32 -> i1
+  moore.eq %3, %4 : i32 -> i1
+  // CHECK: moore.ne %[[int]], %[[int2]] : i32 -> i1
+  moore.ne %3, %4 : i32 -> i1
+  // CHECK: moore.ne %[[integer]], %[[integer2]] : l32 -> l1
+  moore.ne %5, %6 : l32 -> l1
+  // CHECK: moore.case_eq %[[int]], %[[int2]] : i32
+  moore.case_eq %3, %4 : i32
+  // CHECK: moore.case_ne %[[int]], %[[int2]] : i32
+  moore.case_ne %3, %4 : i32
+  // CHECK: moore.wildcard_eq %[[int]], %[[int2]] : i32 -> i1
+  moore.wildcard_eq %3, %4 : i32 -> i1
+  // CHECK: moore.wildcard_ne %[[int]], %[[int2]] : i32 -> i1
+  moore.wildcard_ne %3, %4 : i32 -> i1
+  // CHECK: moore.wildcard_ne %[[integer]], %[[integer2]] : l32 -> l1
+  moore.wildcard_ne %5, %6 : l32 -> l1
 
-  // CHECK: moore.ult %int, %int2 : i32 -> i1
-  moore.ult %int, %int2 : i32 -> i1
-  // CHECK: moore.ule %int, %int2 : i32 -> i1
-  moore.ule %int, %int2 : i32 -> i1
-  // CHECK: moore.ugt %int, %int2 : i32 -> i1
-  moore.ugt %int, %int2 : i32 -> i1
-  // CHECK: moore.uge %int, %int2 : i32 -> i1
-  moore.uge %int, %int2 : i32 -> i1
-  // CHECK: moore.slt %int, %int2 : i32 -> i1
-  moore.slt %int, %int2 : i32 -> i1
-  // CHECK: moore.sle %int, %int2 : i32 -> i1
-  moore.sle %int, %int2 : i32 -> i1
-  // CHECK: moore.sgt %int, %int2 : i32 -> i1
-  moore.sgt %int, %int2 : i32 -> i1
-  // CHECK: moore.sge %int, %int2 : i32 -> i1
-  moore.sge %int, %int2 : i32 -> i1
-  // CHECK: moore.uge %integer, %integer2 : l32 -> l1
-  moore.uge %integer, %integer2 : l32 -> l1
+  // CHECK: moore.ult %[[int]], %[[int2]] : i32 -> i1
+  moore.ult %3, %4 : i32 -> i1
+  // CHECK: moore.ule %[[int]], %[[int2]] : i32 -> i1
+  moore.ule %3, %4 : i32 -> i1
+  // CHECK: moore.ugt %[[int]], %[[int2]] : i32 -> i1
+  moore.ugt %3, %4 : i32 -> i1
+  // CHECK: moore.uge %[[int]], %[[int2]] : i32 -> i1
+  moore.uge %3, %4 : i32 -> i1
+  // CHECK: moore.slt %[[int]], %[[int2]] : i32 -> i1
+  moore.slt %3, %4 : i32 -> i1
+  // CHECK: moore.sle %[[int]], %[[int2]] : i32 -> i1
+  moore.sle %3, %4 : i32 -> i1
+  // CHECK: moore.sgt %[[int]], %[[int2]] : i32 -> i1
+  moore.sgt %3, %4 : i32 -> i1
+  // CHECK: moore.sge %[[int]], %[[int2]] : i32 -> i1
+  moore.sge %3, %4 : i32 -> i1
+  // CHECK: moore.uge %[[integer]], %[[integer2]] : l32 -> l1
+  moore.uge %5, %6 : l32 -> l1
 
-  // CHECK: moore.concat %b1 : (!moore.i1) -> i1
-  moore.concat %b1 : (!moore.i1) -> i1
-  // CHECK: moore.concat %b5, %b1 : (!moore.i5, !moore.i1) -> i6
-  moore.concat %b5, %b1 : (!moore.i5, !moore.i1) -> i6
-  // CHECK: moore.concat %l1, %l1, %l1 : (!moore.l1, !moore.l1, !moore.l1) -> l3
-  moore.concat %l1, %l1, %l1 : (!moore.l1, !moore.l1, !moore.l1) -> l3
-  // CHECK: moore.replicate %b1 : i1 -> i4
-  moore.replicate %b1 : i1 -> i4
+  // CHECK: moore.concat %[[b1]] : (!moore.i1) -> i1
+  moore.concat %0 : (!moore.i1) -> i1
+  // CHECK: moore.concat %[[b5]], %[[b1]] : (!moore.i5, !moore.i1) -> i6
+  moore.concat %2, %0 : (!moore.i5, !moore.i1) -> i6
+  // CHECK: moore.concat %[[l1]], %[[l1]], %[[l1]] : (!moore.l1, !moore.l1, !moore.l1) -> l3
+  moore.concat %1, %1, %1 : (!moore.l1, !moore.l1, !moore.l1) -> l3
+  // CHECK: moore.concat_ref %b1 : (!moore.ref<i1>) -> <i1>
+  moore.concat_ref %b1 : (!moore.ref<i1>) -> <i1>
+  // CHECK: moore.concat_ref %b5, %b1 : (!moore.ref<i5>, !moore.ref<i1>) -> <i6>
+  moore.concat_ref %b5, %b1 : (!moore.ref<i5>, !moore.ref<i1>) -> <i6>
+  // CHECK: moore.concat_ref %l1, %l1, %l1 : (!moore.ref<l1>, !moore.ref<l1>, !moore.ref<l1>) -> <l3>
+  moore.concat_ref %l1, %l1, %l1 : (!moore.ref<l1>, !moore.ref<l1>, !moore.ref<l1>) -> <l3>
+  // CHECK: moore.replicate %[[b1]] : i1 -> i4
+  moore.replicate %0 : i1 -> i4
 
-  // CHECK: moore.extract %b5 from %b1 : i5, i1 -> i1
-  moore.extract %b5 from %b1 : i5, i1 -> i1
-  // CHECK: [[VAL1:%.*]] = moore.constant 0 : i32
-  // CHECK: [[VAL2:%.*]] = moore.extract %arr from [[VAL1]] : uarray<2 x uarray<4 x i8>>, i32 -> uarray<4 x i8>
-  %1 = moore.constant 0 : i32
-  %2 = moore.extract %arr from %1 : uarray<2 x uarray<4 x i8>>, i32 -> uarray<4 x i8>
-  // CHECK: [[VAL3:%.*]] = moore.constant 3 : i32
-  // CHECK: [[VAL4:%.*]] = moore.extract [[VAL2]] from [[VAL3]] : uarray<4 x i8>, i32 -> i8
-  %3 = moore.constant 3 : i32
-  %4 = moore.extract %2 from %3 : uarray<4 x i8>, i32 -> i8
-  // CHECK: [[VAL5:%.*]] = moore.constant 2 : i32
-  // CHECK: moore.extract [[VAL4]] from [[VAL5]] : i8, i32 -> i5
-  %5 = moore.constant 2 : i32
-  moore.extract %4 from %5 : i8, i32 -> i5
+  // CHECK: moore.extract %[[b5]] from %[[b1]] : i5, i1 -> i1
+  moore.extract %2 from %0 : i5, i1 -> i1
+  // CHECK: %[[VAL1:.*]] = moore.constant 0 : i32
+  // CHECK: %[[VAL2:.*]] = moore.extract %[[arr]] from %[[VAL1]] : uarray<2 x uarray<4 x i8>>, i32 -> uarray<4 x i8>
+  %11 = moore.constant 0 : i32
+  %12 = moore.extract %7 from %11 : uarray<2 x uarray<4 x i8>>, i32 -> uarray<4 x i8>
+  // CHECK: %[[VAL3:.*]] = moore.constant 3 : i32
+  // CHECK: %[[VAL4:.*]] = moore.extract %[[VAL2]] from %[[VAL3]] : uarray<4 x i8>, i32 -> i8
+  %13 = moore.constant 3 : i32
+  %14 = moore.extract %12 from %13 : uarray<4 x i8>, i32 -> i8
+  // CHECK: %[[VAL5:.*]] = moore.constant 2 : i32
+  // CHECK: moore.extract %[[VAL4]] from %[[VAL5]] : i8, i32 -> i5
+  %15 = moore.constant 2 : i32
+  moore.extract %14 from %15 : i8, i32 -> i5
 
-  // CHECK: moore.conditional %b1 : i1 -> i32 {
-  // CHECK:   moore.yield %int : i32
+  // CHECK: moore.extract_ref %b5 from %[[b1]] : <i5>, i1 -> <i1>
+  moore.extract_ref %b5 from %0 : <i5>, i1 -> <i1>
+  // CHECK: %[[TMP1:.+]] = moore.constant 0
+  // CHECK: %[[TMP2:.+]] = moore.extract_ref %arr from %[[TMP1]] : <uarray<2 x uarray<4 x i8>>>, i32 -> <uarray<4 x i8>>
+  %16 = moore.constant 0 : i32
+  %17 = moore.extract_ref %arr from %16 : <uarray<2 x uarray<4 x i8>>>, i32 -> <uarray<4 x i8>>
+  // CHECK: %[[TMP3:.+]] = moore.constant 3
+  // CHECK: %[[TMP4:.+]] = moore.extract_ref %[[TMP2]] from %[[TMP3]] : <uarray<4 x i8>>, i32 -> <i8>
+  %18 = moore.constant 3 : i32
+  %19 = moore.extract_ref %17 from %18 : <uarray<4 x i8>>, i32 -> <i8>
+  // CHECK: %[[TMP5:.+]] = moore.constant 2
+  // CHECK: extract_ref %[[TMP4]] from %[[TMP5]] : <i8>, i32 -> <i4>
+  %20 = moore.constant 2 : i32
+  moore.extract_ref %19 from %20 : <i8>, i32 -> <i4>
+
+  // CHECK: %[[B1_COND:.+]] = moore.read %b1
+  // CHECK: moore.conditional %[[B1_COND]] : i1 -> i32 {
+  // CHECK:   %[[INT_READ:.+]] = moore.read %int
+  // CHECK:   moore.yield %[[INT_READ]] : i32
   // CHECK: } {
-  // CHECK:   moore.yield %int2 : i32
+  // CHECK:   %[[INT2_READ:.+]] = moore.read %int2
+  // CHECK:   moore.yield %[[INT2_READ]] : i32
   // CHECK: }
-  moore.conditional %b1 : i1 -> i32 {
-    moore.yield %int : i32
+  %21 = moore.read %b1 : i1
+  moore.conditional %21 : i1 -> i32 {
+    %22 = moore.read %int : i32
+    moore.yield %22 : i32
   } {
-    moore.yield %int2 : i32
+    %22 = moore.read %int2 : i32
+    moore.yield %22 : i32
   }
 }

--- a/test/Dialect/Moore/errors.mlir
+++ b/test/Dialect/Moore/errors.mlir
@@ -68,22 +68,26 @@ moore.constant -2 : !moore.i1
 
 // -----
 
-%y = moore.variable : i8
+%y = moore.variable : <i8>
 
 moore.module @Cond() {
+  %0 = moore.read %y : i8
   // expected-error @below {{'moore.yield' op expects parent op 'moore.conditional'}}
-  moore.yield %y : i8
+  moore.yield %0 : i8
 }
 
 // -----
 
-%x = moore.variable : i1
-%t = moore.variable : i8
-%f = moore.variable : i8
+%x = moore.variable : <i1>
+%t = moore.variable : <i8>
+%f = moore.variable : <i8>
 
-moore.conditional %x : i1 -> i32 {
+%1 = moore.read %x : i1
+moore.conditional %1 : i1 -> i32 {
+  %2 = moore.read %t : i8
   // expected-error @below {{yield type must match conditional. Expected '!moore.i32', but got '!moore.i8'}}
-  moore.yield %t : i8
+  moore.yield %2 : i8
 } {
-  moore.yield %f : i8
+  %2 = moore.read %f : i8
+  moore.yield %2 : i8
 }


### PR DESCRIPTION
Add a wrapper type(`moore::RefType`) to work for `VariableOp/NetOp`, `ReadOp`, and `AssignOpBase`, and it can wrap any SystemVerilog types. We added `RefType` in order to introduce `Mem2Reg` into `moore` to eliminate the local temporary variables. Meanwhile, we added a new op named `moore.extract_ref` which is the copy of `moore.extract` that explicitly works on the ref type. And `moore.concat_ref` is the copy of `moore.concat`. Later, we will tweak `union/struct` ops like `moore.struct_create` in order to support the `ref` type.

`moore.variable/moore.net` will return a result with `ref<T>`, it's similar to `memref.alloca`.

Change `moore::ReadLValueOp` to `moore::ReadOp`, it's similar to `memref.load`.  Initially, we need `moore.read_lvalue` only to service for assigmen operations(like `+=`, `*=`, etc).  However, `moore. read` is not only for assignment operations but also to take a value with `RefType`(ref<T>) and return the current value with the nested type(`T`). For example, `a = b + c`, `moore.read` will take `b` and `c`(both are `ref<T>`), and then return a value with the nested type(`T`).

We think the `MooreLValueType` and `VariableDeclOp`(https://github.com/llvm/circt/commit/52a71a681e8cdd1d38936b8f5e1bb5716babf9e5) that had been removed eventually found their proper site.

We also divide `convertExpression()` into `convertLvalueExpression()` for the LHS of assignments and `convertRvalueExpression()` for the RHS of assignments. The former will return a value with `RefType` like `ref<i32>`, but the latter returns a value without `RefType` like `i32`.