### PR TITLE
[FIRRTL][LowerClass] Pre-allocate namespaces before capturing references

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -289,6 +289,13 @@ PathTracker::run(CircuitOp circuit, InstanceGraph &instanceGraph,
                  const SymbolTable &symbolTable,
                  const DenseMap<DistinctAttr, FModuleOp> &owningModules) {
   SmallVector<PathTracker> trackers;
+
+  // First allocate module namespaces. Don't capture a namespace reference at
+  // this point since they could be invalidated when DenseMap grows.
+  for (auto *node : instanceGraph)
+    if (auto module = node->getModule<FModuleLike>())
+      (void)namespaces.get(module);
+
   // Prepare workers.
   for (auto *node : instanceGraph)
     if (auto module = node->getModule<FModuleLike>())


### PR DESCRIPTION
There has been a lifetime bug that caused an UAF crash. Heaps allocated by DenseMap could be invalided when DenseMap size grows. 