### PR TITLE
[FIRRTL] Generate memportaccess op index as UInt.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -812,6 +812,7 @@ LogicalResult circt::firrtl::applyGCTMemTaps(const AnnoPathValue &target,
 
     // Add one port per memory address.
     SmallVector<Value> data;
+    Type uintType = builder.getType<UIntType>();
     for (uint64_t i = 0, e = combMem.getType().getNumElements(); i != e; ++i) {
       auto port = builder.create<chirrtl::MemoryPortOp>(
           combMem.getType().getElementType(),
@@ -819,7 +820,8 @@ LogicalResult circt::firrtl::applyGCTMemTaps(const AnnoPathValue &target,
           MemDirAttr::Read, builder.getStringAttr("memTap_" + Twine(i)),
           builder.getArrayAttr({}));
       builder.create<chirrtl::MemoryPortAccessOp>(
-          port.getPort(), builder.create<ConstantOp>(APSInt::get(i)), clock);
+          port.getPort(),
+          builder.create<ConstantOp>(uintType, APSInt::getUnsigned(i)), clock);
       data.push_back(port.getData());
     }
 


### PR DESCRIPTION
Create these constants as unsigned of unknown width, instead of s64.

This way when connecting to the address, we don't emit a connnect between s64 and something like u3
(requiring casts/trim/etc).