### PR TITLE
[FIRRTL] Emulate tap-as-passive for no-ref-ports option.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -704,12 +704,20 @@ LogicalResult LowerAnnotationsPass::solveWiringProblems(ApplyState &state) {
     }
 
     // If the sink is a wire with no users, then convert this to a node.
-    auto destOp = dyn_cast_or_null<WireOp>(dest.getDefiningOp());
-    if (destOp && dest.getUses().empty()) {
-      builder.create<NodeOp>(src, destOp.getName())
-          .setAnnotationsAttr(destOp.getAnnotations());
-      opsToErase.push_back(destOp);
-      return success();
+    // This is done to convert the undriven wires created for GCView's
+    // into the NodeOp's they're required to be in GrandCentral.cpp.
+    if (auto destOp = dyn_cast_or_null<WireOp>(dest.getDefiningOp());
+        destOp && dest.getUses().empty()) {
+      // Only perform this if the type is suitable (passive).
+      if (auto baseType = dyn_cast<FIRRTLBaseType>(src.getType());
+          baseType && baseType.isPassive()) {
+        // Note that the wire is replaced with the source type
+        // regardless, continue this behavior.
+        builder.create<NodeOp>(src, destOp.getName())
+            .setAnnotationsAttr(destOp.getAnnotations());
+        opsToErase.push_back(destOp);
+        return success();
+      }
     }
 
     // Otherwise, just connect to the source.

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-flip.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-flip.fir
@@ -1,5 +1,7 @@
 ; RUN: firtool --parse-only %s -verify-each=true | FileCheck %s
 ; RUN: firtool --verilog %s
+; RUN: firtool --parse-only %s --lower-annotations-no-ref-type-ports | FileCheck %s --check-prefixes NOREF --implicit-check-not firrtl.ref
+; RUN: firtool --verilog %s --lower-annotations-no-ref-type-ports
 
 ; Test tapping a bundle with flips, tap sink is passive.
 
@@ -9,6 +11,13 @@
 ; CHECK-LABEL: module @Top(
 ; CHECK: firrtl.ref.resolve
 ; CHECK-SAME: !firrtl.probe<bundle<a: uint<2>, b: uint<2>>>
+
+; NOREF-LABEL: module private @Child(
+; NOREF-SAME: out %[[OUT_PORT:.+]]: !firrtl.bundle<a: uint<2>, b: uint<2>>
+; NOREF-DAG: %[[A:.+]] = firrtl.subfield %[[OUT_PORT]][a]
+; NOREF-DAG: firrtl.strictconnect %[[A]],
+; NOREF-DAG: %[[B:.+]] = firrtl.subfield %[[OUT_PORT]][b]
+; NOREF-DAG: firrtl.strictconnect %[[B]],
 circuit Top : %[[
   {
     "class": "sifive.enterprise.grandcentral.DataTapsAnnotation",

--- a/test/Dialect/FIRRTL/SFCTests/data-taps-flip.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps-flip.fir
@@ -1,7 +1,7 @@
-; RUN: firtool --parse-only %s -verify-each=true | FileCheck %s
-; RUN: firtool --verilog %s
-; RUN: firtool --parse-only %s --lower-annotations-no-ref-type-ports | FileCheck %s --check-prefixes NOREF --implicit-check-not firrtl.ref
-; RUN: firtool --verilog %s --lower-annotations-no-ref-type-ports
+; RUN: firtool --parse-only --split-input-file %s | FileCheck %s
+; RUN: firtool --verilog --split-input-file %s
+; RUN: firtool --parse-only --lower-annotations-no-ref-type-ports --split-input-file %s | FileCheck %s --check-prefixes NOREF --implicit-check-not firrtl.ref
+; RUN: firtool --verilog --lower-annotations-no-ref-type-ports --split-input-file %s
 
 ; Test tapping a bundle with flips, tap sink is passive.
 
@@ -44,4 +44,36 @@ circuit Top : %[[
     wire sink : {a : UInt<2>, b: UInt<2>}
     tap <= sink
 
+; // -----
 
+; Check same but where no ports are inserted.
+
+; CHECK-LABEL: circuit "Local"
+; NOREF-LABEL: circuit "Local"
+circuit Local: %[[
+  {
+    "class": "sifive.enterprise.grandcentral.DataTapsAnnotation",
+    "keys": [
+      {
+        "class": "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source": "~Local|Local>x",
+        "sink": "~Local|Local>sink"
+      },
+      {
+        "class": "sifive.enterprise.grandcentral.ReferenceDataTapKey",
+        "source": "~Local|Local>x",
+        "sink": "~Local|Local>unused_sink"
+      }
+    ]
+  }
+]]
+  module Local:
+    input x: {a : UInt<2>, flip b: UInt<2>}
+    output tap : {a : UInt<2>, b: UInt<2>}
+
+    x.b <= x.a
+
+    wire sink : {a : UInt<2>, b: UInt<2>}
+    tap <= sink
+
+    wire unused_sink : {a : UInt<2>, b: UInt<2>}


### PR DESCRIPTION
Taps (using probes) support a non-passive source with a passive sink (by their nature), but the hidden option to avoid probes does not.

Detect this specifically and fix by using passive type for wiring from source.

This allows taps of non-ground (non-passive) that work with probes to also work with this option.