### PR TITLE
[NFC, FIRRTL] Rename StrictConnect to MatchingConnect.  

### DIFF
--- a/docs/Dialects/FIRRTL/RationaleFIRRTL.md
+++ b/docs/Dialects/FIRRTL/RationaleFIRRTL.md
@@ -569,7 +569,7 @@ include the following:
 - Ports on a `firrtl.module`, where the foreign types are treated as opaque values moving in and out of the module
 - Ports on a `firrtl.instance`
 - `firrtl.wire` to allow for def-after-use cases; the wire must have a single strict connect that uniquely defines the wire's value
-- `firrtl.strictconnect` to module outputs, instance inputs, and wires
+- `firrtl.matchingconnect` to module outputs, instance inputs, and wires
 
 The expected lowering for strict connects is for the connect to be eliminated
 and the right-hand-side source value of the connect being instead materialized

--- a/docs/Dialects/Seq/RationaleSeq.md
+++ b/docs/Dialects/Seq/RationaleSeq.md
@@ -188,7 +188,7 @@ For example, a strict connect to a field of a structure:
 
 ```firrtl
 %field = firrtl.subfield %a[field]
-firrtl.strictconnect %field, %value
+firrtl.matchingconnect %field, %value
 ```
 Is converted into a `hw.struct_inject` operation:
 ```mlir

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -200,13 +200,13 @@ def NotGt : Pat <
 // connect(a:t,b:t) -> strictconnect(a,b)
 def ConnectSameType : Pat<
   (ConnectOp $dst, $src),
-  (StrictConnectOp $dst, $src),
+  (MatchingConnectOp $dst, $src),
   [(EqualTypes $dst, $src), (KnownWidth $dst)]>;
 
 // connect(a:t1,b:(t2<t1) -> strictconnect(a,(pad b))
 def ConnectExtension : Pat<
   (ConnectOp $dst, $src),
-  (StrictConnectOp $dst, (PadPrimOp $src,
+  (MatchingConnectOp $dst, (PadPrimOp $src,
     (NativeCodeCall<"type_cast<FIRRTLBaseType>($0.getType()).getBitWidthOrSentinel()"> $dst))),
   [(IntType $dst), (IntType $src), (KnownWidth $dst), (KnownWidth $src), (mismatchTypes $src, $dst)]>;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -33,7 +33,7 @@
 namespace circt {
 namespace firrtl {
 
-class StrictConnectOp;
+class MatchingConnectOp;
 
 // works for regs, nodes, and wires
 bool hasDroppableName(Operation *op);
@@ -131,7 +131,7 @@ bool hasDontTouch(Operation *op);
 /// after the definition of the value. Users of this function are likely
 /// interested in the source side of the returned connect, the definition of
 /// which does likely not dominate the original value.
-StrictConnectOp getSingleConnectUserOf(Value value);
+MatchingConnectOp getSingleConnectUserOf(Value value);
 
 // Out-of-line implementation of various trait verification methods and
 // functions commonly used among operations.

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -55,14 +55,15 @@ def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
 def SameAnonTypeOperands: PredOpTrait<
         "operands must be structurally equivalent",
         CPred<"areAnonymousTypesEquivalent(getOperand(0).getType(), getOperand(1).getType())">>;
-def StrictConnectOp : FIRRTLOp<"strictconnect", [FConnectLike,
+def MatchingConnectOp : FIRRTLOp<"matchingconnect", [FConnectLike,
                       SameAnonTypeOperands]> {
   let summary = "Connect two signals";
   let description =  [{
-    Connect two values with strict constraints:
+    Connect two values with strict type constraints.  The types of the lhs and
+    rhs must match:
     ```
-      firrtl.strictconnect %dest, %src : t1
-      firrtl.strictconnect %dest, %src : t1, !firrtl.alias<foo, t1>
+      firrtl.matchingconnect %dest, %src : t1
+      firrtl.matchingconnect %dest, %src : t1, !firrtl.alias<foo, t1>
     ```
     }];
 
@@ -246,7 +247,7 @@ def MatchOp : FIRRTLOp<"match", [SingleBlock, NoTerminator,
     ```mlir
       firrtl.match %in : !firrtl.enum<Some: uint<1>, None: uint<0>> {
         case Some(%arg0) {
-          !firrtl.strictconnect %w, %arg0 : !firrtl.uint<1>
+          !firrtl.matchingconnect %w, %arg0 : !firrtl.uint<1>
         }
         case None(%arg0) {
           !firrt.strictconnect %w, %c1 : !firrtl.uint<1>

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -237,7 +237,7 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<AttachOp, ConnectOp, StrictConnectOp, RefDefineOp,
+        .template Case<AttachOp, ConnectOp, MatchingConnectOp, RefDefineOp,
                        ForceOp, PrintFOp, SkipOp, StopOp, WhenOp, AssertOp,
                        AssumeOp, CoverOp, PropAssignOp, RefForceOp,
                        RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp,
@@ -271,7 +271,7 @@ public:
 
   HANDLE(AttachOp);
   HANDLE(ConnectOp);
-  HANDLE(StrictConnectOp);
+  HANDLE(MatchingConnectOp);
   HANDLE(RefDefineOp);
   HANDLE(ForceOp);
   HANDLE(PrintFOp);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1190,7 +1190,7 @@ tryEliminatingConnectsToValue(Value flipValue, Operation *insertPoint,
     // destination.
     if (use.getOperandNumber() != 0)
       return {};
-    if (!isa<ConnectOp, StrictConnectOp>(use.getOwner()))
+    if (!isa<ConnectOp, MatchingConnectOp>(use.getOwner()))
       return {};
 
     // We only support things with a single connect.
@@ -1668,7 +1668,7 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
 
   FailureOr<bool> lowerConnect(Value dest, Value srcVal);
   LogicalResult visitStmt(ConnectOp op);
-  LogicalResult visitStmt(StrictConnectOp op);
+  LogicalResult visitStmt(MatchingConnectOp op);
   LogicalResult visitStmt(ForceOp op);
   LogicalResult visitStmt(PrintFOp op);
   LogicalResult visitStmt(StopOp op);
@@ -4202,7 +4202,7 @@ LogicalResult FIRRTLLowering::visitStmt(ConnectOp op) {
   return success();
 }
 
-LogicalResult FIRRTLLowering::visitStmt(StrictConnectOp op) {
+LogicalResult FIRRTLLowering::visitStmt(MatchingConnectOp op) {
   auto dest = op.getDest();
   auto srcVal = getLoweredValue(op.getSrc());
   if (!srcVal)

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -77,7 +77,7 @@ struct Emitter {
   void emitStatement(SkipOp op);
   void emitStatement(PrintFOp op);
   void emitStatement(ConnectOp op);
-  void emitStatement(StrictConnectOp op);
+  void emitStatement(MatchingConnectOp op);
   void emitStatement(PropAssignOp op);
   void emitStatement(InstanceOp op);
   void emitStatement(InstanceChoiceOp op);
@@ -637,7 +637,7 @@ void Emitter::emitStatementsInBlock(Block &block) {
       continue;
     TypeSwitch<Operation *>(&bodyOp)
         .Case<WhenOp, WireOp, RegOp, RegResetOp, NodeOp, StopOp, SkipOp,
-              PrintFOp, AssertOp, AssumeOp, CoverOp, ConnectOp, StrictConnectOp,
+              PrintFOp, AssertOp, AssumeOp, CoverOp, ConnectOp, MatchingConnectOp,
               PropAssignOp, InstanceOp, InstanceChoiceOp, AttachOp, MemOp,
               InvalidValueOp, SeqMemOp, CombMemOp, MemoryPortOp,
               MemoryDebugPortOp, MemoryPortAccessOp, RefDefineOp, RefForceOp,
@@ -841,7 +841,7 @@ void Emitter::emitStatement(ConnectOp op) {
   emitLocationAndNewLine(op);
 }
 
-void Emitter::emitStatement(StrictConnectOp op) {
+void Emitter::emitStatement(MatchingConnectOp op) {
   startStatement();
   if (FIRVersion(3, 0, 0) <= version) {
     ps.scopedBox(PP::ibox2, [&]() {
@@ -1115,7 +1115,7 @@ void Emitter::emitStatement(InvalidValueOp op) {
   // a connect.
   if (llvm::all_of(op->getUses(), [&](OpOperand &use) {
         return use.getOperandNumber() == 1 &&
-               isa<ConnectOp, StrictConnectOp>(use.getOwner());
+               isa<ConnectOp, MatchingConnectOp>(use.getOwner());
       }))
     return;
 

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -637,11 +637,11 @@ void Emitter::emitStatementsInBlock(Block &block) {
       continue;
     TypeSwitch<Operation *>(&bodyOp)
         .Case<WhenOp, WireOp, RegOp, RegResetOp, NodeOp, StopOp, SkipOp,
-              PrintFOp, AssertOp, AssumeOp, CoverOp, ConnectOp, MatchingConnectOp,
-              PropAssignOp, InstanceOp, InstanceChoiceOp, AttachOp, MemOp,
-              InvalidValueOp, SeqMemOp, CombMemOp, MemoryPortOp,
-              MemoryDebugPortOp, MemoryPortAccessOp, RefDefineOp, RefForceOp,
-              RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp,
+              PrintFOp, AssertOp, AssumeOp, CoverOp, ConnectOp,
+              MatchingConnectOp, PropAssignOp, InstanceOp, InstanceChoiceOp,
+              AttachOp, MemOp, InvalidValueOp, SeqMemOp, CombMemOp,
+              MemoryPortOp, MemoryDebugPortOp, MemoryPortAccessOp, RefDefineOp,
+              RefForceOp, RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp,
               LayerBlockOp, GenericIntrinsicOp>(
             [&](auto op) { emitStatement(op); })
         .Default([&](auto op) {

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1699,8 +1699,8 @@ LogicalResult MultibitMuxOp::canonicalize(MultibitMuxOp op,
 /// after the definition of the value. Users of this function are likely
 /// interested in the source side of the returned connect, the definition of
 /// which does likely not dominate the original value.
-StrictConnectOp firrtl::getSingleConnectUserOf(Value value) {
-  StrictConnectOp connect;
+MatchingConnectOp firrtl::getSingleConnectUserOf(Value value) {
+  MatchingConnectOp connect;
   for (Operation *user : value.getUsers()) {
     // If we see an attach or aggregate sublements, just conservatively fail.
     if (isa<AttachOp, SubfieldOp, SubaccessOp, SubindexOp>(user))
@@ -1708,7 +1708,7 @@ StrictConnectOp firrtl::getSingleConnectUserOf(Value value) {
 
     if (auto aConnect = dyn_cast<FConnectLike>(user))
       if (aConnect.getDest() == value) {
-        auto strictConnect = dyn_cast<StrictConnectOp>(*aConnect);
+        auto strictConnect = dyn_cast<MatchingConnectOp>(*aConnect);
         // If this is not a strict connect, a second strict connect or in a
         // different block, fail.
         if (!strictConnect || (connect && connect != strictConnect) ||
@@ -1722,7 +1722,7 @@ StrictConnectOp firrtl::getSingleConnectUserOf(Value value) {
 }
 
 // Forward simple values through wire's and reg's.
-static LogicalResult canonicalizeSingleSetConnect(StrictConnectOp op,
+static LogicalResult canonicalizeSingleSetConnect(MatchingConnectOp op,
                                                   PatternRewriter &rewriter) {
   // While we can do this for nearly all wires, we currently limit it to simple
   // things.
@@ -1787,7 +1787,7 @@ void ConnectOp::getCanonicalizationPatterns(RewritePatternSet &results,
       context);
 }
 
-LogicalResult StrictConnectOp::canonicalize(StrictConnectOp op,
+LogicalResult MatchingConnectOp::canonicalize(MatchingConnectOp op,
                                             PatternRewriter &rewriter) {
   // TODO: Canonicalize towards explicit extensions and flips here.
 
@@ -1991,12 +1991,12 @@ struct AggOneShot : public mlir::RewritePattern {
     for (Operation *user : lhs->getResult(0).getUsers()) {
       if (user->getParentOp() != lhs->getParentOp())
         return {};
-      if (auto aConnect = dyn_cast<StrictConnectOp>(user)) {
+      if (auto aConnect = dyn_cast<MatchingConnectOp>(user)) {
         if (aConnect.getDest() == lhs->getResult(0))
           return {};
       } else if (auto subField = dyn_cast<SubfieldOp>(user)) {
         for (Operation *subuser : subField.getResult().getUsers()) {
-          if (auto aConnect = dyn_cast<StrictConnectOp>(subuser)) {
+          if (auto aConnect = dyn_cast<MatchingConnectOp>(subuser)) {
             if (aConnect.getDest() == subField) {
               if (subuser->getParentOp() != lhs->getParentOp())
                 return {};
@@ -2010,7 +2010,7 @@ struct AggOneShot : public mlir::RewritePattern {
         }
       } else if (auto subIndex = dyn_cast<SubindexOp>(user)) {
         for (Operation *subuser : subIndex.getResult().getUsers()) {
-          if (auto aConnect = dyn_cast<StrictConnectOp>(subuser)) {
+          if (auto aConnect = dyn_cast<MatchingConnectOp>(subuser)) {
             if (aConnect.getDest() == subIndex) {
               if (subuser->getParentOp() != lhs->getParentOp())
                 return {};
@@ -2057,18 +2057,18 @@ struct AggOneShot : public mlir::RewritePattern {
                                                                destType, values)
                        : rewriter.createOrFold<VectorCreateOp>(
                              op->getLoc(), destType, values);
-    rewriter.createOrFold<StrictConnectOp>(op->getLoc(), dest, newVal);
+    rewriter.createOrFold<MatchingConnectOp>(op->getLoc(), dest, newVal);
     for (Operation *user : dest.getUsers()) {
       if (auto subIndex = dyn_cast<SubindexOp>(user)) {
         for (Operation *subuser :
              llvm::make_early_inc_range(subIndex.getResult().getUsers()))
-          if (auto aConnect = dyn_cast<StrictConnectOp>(subuser))
+          if (auto aConnect = dyn_cast<MatchingConnectOp>(subuser))
             if (aConnect.getDest() == subIndex)
               rewriter.eraseOp(aConnect);
       } else if (auto subField = dyn_cast<SubfieldOp>(user)) {
         for (Operation *subuser :
              llvm::make_early_inc_range(subField.getResult().getUsers()))
-          if (auto aConnect = dyn_cast<StrictConnectOp>(subuser))
+          if (auto aConnect = dyn_cast<MatchingConnectOp>(subuser))
             if (aConnect.getDest() == subField)
               rewriter.eraseOp(aConnect);
       }
@@ -2408,7 +2408,7 @@ struct FoldZeroWidthMemory : public mlir::RewritePattern {
           auto zero = rewriter.create<firrtl::ConstantOp>(
               wire.getLoc(), firrtl::type_cast<IntType>(wire.getType()),
               APInt::getZero(0));
-          rewriter.create<StrictConnectOp>(wire.getLoc(), wire, zero);
+          rewriter.create<MatchingConnectOp>(wire.getLoc(), wire, zero);
         }
       }
     }
@@ -2680,7 +2680,7 @@ struct FoldUnusedBits : public mlir::RewritePattern {
     // Finds the users of write ports. This expects all the data/wdata fields
     // of the ports to be used solely as the destination of strict connects.
     // If a memory has ports with other uses, it is excluded from optimisation.
-    SmallVector<StrictConnectOp> writeOps;
+    SmallVector<MatchingConnectOp> writeOps;
     auto findWriteUsers = [&](Value port, StringRef field) -> LogicalResult {
       auto portTy = type_cast<BundleType>(port.getType());
       auto fieldIndex = portTy.getElementIndex(field);
@@ -2823,7 +2823,7 @@ struct FoldUnusedBits : public mlir::RewritePattern {
           catOfSlices = slice;
         }
       }
-      rewriter.replaceOpWithNewOp<StrictConnectOp>(writeOp, writeOp.getDest(),
+      rewriter.replaceOpWithNewOp<MatchingConnectOp>(writeOp, writeOp.getDest(),
                                                    catOfSlices);
     }
 
@@ -2917,7 +2917,7 @@ struct FoldRegMems : public mlir::RewritePattern {
                        .create<RegOp>(mem.getLoc(), value.getType(), clock,
                                       rewriter.getStringAttr(regName))
                        .getResult();
-        rewriter.create<StrictConnectOp>(value.getLoc(), reg, value);
+        rewriter.create<MatchingConnectOp>(value.getLoc(), reg, value);
         value = reg;
       }
       return value;
@@ -3009,7 +3009,7 @@ struct FoldRegMems : public mlir::RewritePattern {
 
       next = rewriter.create<MuxPrimOp>(next.getLoc(), en, masked, next);
     }
-    rewriter.create<StrictConnectOp>(reg.getLoc(), reg, next);
+    rewriter.create<MatchingConnectOp>(reg.getLoc(), reg, next);
 
     // Delete the fields and their associated connects.
     for (Operation *conn : connects)

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1788,7 +1788,7 @@ void ConnectOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 LogicalResult MatchingConnectOp::canonicalize(MatchingConnectOp op,
-                                            PatternRewriter &rewriter) {
+                                              PatternRewriter &rewriter) {
   // TODO: Canonicalize towards explicit extensions and flips here.
 
   // If there is a simple value connected to a foldable decl like a wire or reg,
@@ -2824,7 +2824,7 @@ struct FoldUnusedBits : public mlir::RewritePattern {
         }
       }
       rewriter.replaceOpWithNewOp<MatchingConnectOp>(writeOp, writeOp.getDest(),
-                                                   catOfSlices);
+                                                     catOfSlices);
     }
 
     return success();

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3562,7 +3562,7 @@ LogicalResult ConnectOp::verify() {
   return success();
 }
 
-LogicalResult StrictConnectOp::verify() {
+LogicalResult MatchingConnectOp::verify() {
   if (auto type = type_dyn_cast<FIRRTLType>(getDest().getType())) {
     auto baseType = type_cast<FIRRTLBaseType>(type);
 

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -63,7 +63,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
   // If the types are the exact same we can just connect them.
   if (dstType == srcType && dstType.isPassive() &&
       !dstType.hasUninferredWidth()) {
-    builder.create<StrictConnectOp>(dst, src);
+    builder.create<MatchingConnectOp>(dst, src);
     return;
   }
 
@@ -159,7 +159,7 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
   // connecting uint<1> to abstract reset types.
   if (dstType == src.getType() && dstType.isPassive() &&
       !dstType.hasUninferredWidth()) {
-    builder.create<StrictConnectOp>(dst, src);
+    builder.create<MatchingConnectOp>(dst, src);
   } else
     builder.create<ConnectOp>(dst, src);
 }

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -277,7 +277,7 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp module, bool isDUT) {
     Value instPort = values[i];
     if (port.direction == Direction::In)
       std::swap(modulePort, instPort);
-    builder.create<StrictConnectOp>(port.loc, modulePort, instPort);
+    builder.create<MatchingConnectOp>(port.loc, modulePort, instPort);
   }
   return success();
 }
@@ -442,7 +442,7 @@ void AddSeqMemPortsPass::runOnOperation() {
           auto type = value.getType();
           auto attr = getIntZerosAttr(type);
           auto zero = builder.create<ConstantOp>(portInfo.loc, type, attr);
-          builder.create<StrictConnectOp>(portInfo.loc, value, zero);
+          builder.create<MatchingConnectOp>(portInfo.loc, value, zero);
         }
       }
     }

--- a/lib/Dialect/FIRRTL/Transforms/EliminateWires.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/EliminateWires.cpp
@@ -43,7 +43,7 @@ void EliminateWiresPass::runOnOperation() {
   auto module = getOperation();
   auto &dominance = getAnalysis<mlir::DominanceInfo>();
 
-  std::deque<std::pair<WireOp, StrictConnectOp>> worklist;
+  std::deque<std::pair<WireOp, MatchingConnectOp>> worklist;
 
   for (auto wire : module.getOps<WireOp>()) {
     auto type = type_dyn_cast<FIRRTLBaseType>(wire.getResult().getType());

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -355,7 +355,7 @@ public:
     recordConnect(getFieldRefFromValue(op.getDest()), op);
   }
 
-  void visitStmt(StrictConnectOp op) {
+  void visitStmt(MatchingConnectOp op) {
     recordConnect(getFieldRefFromValue(op.getDest()), op);
   }
 
@@ -687,7 +687,7 @@ public:
   using LastConnectResolver<ModuleVisitor>::visitStmt;
   void visitStmt(WhenOp whenOp);
   void visitStmt(ConnectOp connectOp);
-  void visitStmt(StrictConnectOp connectOp);
+  void visitStmt(MatchingConnectOp connectOp);
   void visitStmt(LayerBlockOp layerBlockOp);
 
   bool run(FModuleLike op);
@@ -732,7 +732,7 @@ void ModuleVisitor::visitStmt(ConnectOp op) {
   anythingChanged |= recordConnect(getFieldRefFromValue(op.getDest()), op);
 }
 
-void ModuleVisitor::visitStmt(StrictConnectOp op) {
+void ModuleVisitor::visitStmt(MatchingConnectOp op) {
   anythingChanged |= recordConnect(getFieldRefFromValue(op.getDest()), op);
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -630,7 +630,7 @@ void ExtractInstancesPass::extractInstances() {
         auto src = newParentInst.getResult(numParentPorts + portIdx);
         if (newPorts[portIdx].second.direction == Direction::In)
           std::swap(src, dst);
-        builder.create<StrictConnectOp>(dst, src);
+        builder.create<MatchingConnectOp>(dst, src);
       }
 
       // Move the wiring prefix from the old to the new instance. We just look
@@ -981,7 +981,7 @@ void ExtractInstancesPass::groupInstances() {
         Value src = wrapper.getArgument(portIdx);
         if (ports[portIdx].direction == Direction::Out)
           std::swap(dst, src);
-        builder.create<StrictConnectOp>(result.getLoc(), dst, src);
+        builder.create<MatchingConnectOp>(result.getLoc(), dst, src);
         ++portIdx;
       }
     }

--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -164,13 +164,13 @@ struct InferReadWritePass : public InferReadWriteBase<InferReadWritePass> {
       auto writeClock =
           builder.create<WireOp>(ClockType::get(enb.getContext())).getResult();
       // addr = Mux(WriteEnable, WriteAddress, ReadAddress).
-      builder.create<StrictConnectOp>(
+      builder.create<MatchingConnectOp>(
           addr, builder.create<MuxPrimOp>(wEnWire, wAddr, rAddr));
       // Enable = Or(WriteEnable, ReadEnable).
-      builder.create<StrictConnectOp>(
+      builder.create<MatchingConnectOp>(
           enb, builder.create<OrPrimOp>(rEnWire, wEnWire));
       builder.setInsertionPointToEnd(wmode->getBlock());
-      builder.create<StrictConnectOp>(wmode, complementTerm);
+      builder.create<MatchingConnectOp>(wmode, complementTerm);
       // Now iterate over the original memory read and write ports.
       size_t dbgsIndex = 0;
       for (const auto &portIt : llvm::enumerate(memOp.getResults())) {
@@ -553,7 +553,7 @@ private:
           if (fName.contains("mask")) {
             WireOp dummy = builder.create<WireOp>(oldRes.getType());
             oldRes->replaceAllUsesWith(dummy);
-            builder.create<StrictConnectOp>(
+            builder.create<MatchingConnectOp>(
                 sf, builder.create<ConstantOp>(
                         UIntType::get(builder.getContext(), 1), APInt(1, 1)));
           } else

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -176,7 +176,7 @@ static bool insertResetMux(ImplicitLocOpBuilder &builder, Value target,
     TypeSwitch<Operation *>(useOp)
         // Insert a mux on the value connected to the target:
         // connect(dst, src) -> connect(dst, mux(reset, resetValue, src))
-        .Case<ConnectOp, StrictConnectOp>([&](auto op) {
+        .Case<ConnectOp, MatchingConnectOp>([&](auto op) {
           if (op.getDest() != target)
             return;
           LLVM_DEBUG(llvm::dbgs() << "  - Insert mux into " << op << "\n");

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1607,7 +1607,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         maximumOfTypes(op.getResult(), op.getResult(), op.getV0());
       })
 
-      .Case<ConnectOp, StrictConnectOp>(
+      .Case<ConnectOp, MatchingConnectOp>(
           [&](auto op) { constrainTypes(op.getDest(), op.getSrc()); })
       .Case<RefDefineOp>([&](auto op) {
         // Dest >= Src, but also check Src <= Dest for correctness
@@ -1615,7 +1615,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
         constrainTypes(op.getDest(), op.getSrc(), true);
       })
       // StrictConnect is an identify constraint
-      .Case<StrictConnectOp>([&](auto op) {
+      .Case<MatchingConnectOp>([&](auto op) {
         // This back-propagates width from destination to source,
         // causing source to sometimes be inferred wider than
         // it should be (https://github.com/llvm/circt/issues/5391).

--- a/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
@@ -46,7 +46,7 @@ struct LowerCHIRRTLPass : public LowerCHIRRTLPassBase<LowerCHIRRTLPass>,
   void visitExpr(SubfieldOp op);
   void visitExpr(SubindexOp op);
   void visitStmt(ConnectOp op);
-  void visitStmt(StrictConnectOp op);
+  void visitStmt(MatchingConnectOp op);
   void visitUnhandledOp(Operation *op);
 
   // Chain the CHIRRTL visitor to the FIRRTL visitor.
@@ -244,7 +244,7 @@ MemDirAttr LowerCHIRRTLPass::inferMemoryPortKind(MemoryPortOp memPort) {
         } else {
           element.mode |= MemDirAttr::Read;
         }
-      } else if (auto connectOp = dyn_cast<StrictConnectOp>(user)) {
+      } else if (auto connectOp = dyn_cast<MatchingConnectOp>(user)) {
         if (use.get() == connectOp.getDest()) {
           element.mode |= MemDirAttr::Write;
         } else {
@@ -459,7 +459,7 @@ void LowerCHIRRTLPass::replaceMem(Operation *cmem, StringRef name,
                 if (cmemoryPortAccess.getIndex() == connectOp.getDest())
                   return !dyn_cast_or_null<InvalidValueOp>(
                       connectOp.getSrc().getDefiningOp());
-              } else if (auto connectOp = dyn_cast<StrictConnectOp>(op)) {
+              } else if (auto connectOp = dyn_cast<MatchingConnectOp>(op)) {
                 if (cmemoryPortAccess.getIndex() == connectOp.getDest())
                   return !dyn_cast_or_null<InvalidValueOp>(
                       connectOp.getSrc().getDefiningOp());
@@ -536,7 +536,7 @@ void LowerCHIRRTLPass::visitStmt(ConnectOp connect) {
   }
 }
 
-void LowerCHIRRTLPass::visitStmt(StrictConnectOp connect) {
+void LowerCHIRRTLPass::visitStmt(MatchingConnectOp connect) {
   // Check if we are writing to a memory and, if we are, replace the
   // destination.
   auto writeIt = wdataValues.find(connect.getDest());

--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -584,8 +584,9 @@ void LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
         if (isa<RefType>(src.getType()))
           src = builder.create<RefResolveOp>(
               newModule.getPortLocationAttr(portNum), src);
-        builder.create<MatchingConnectOp>(newModule.getPortLocationAttr(portNum),
-                                        instanceOp.getResult(portNum), src);
+        builder.create<MatchingConnectOp>(
+            newModule.getPortLocationAttr(portNum),
+            instanceOp.getResult(portNum), src);
       } else if (isa<RefType>(instanceOp.getResult(portNum).getType()) &&
                  connectValues[portNum].kind == ConnectKind::Ref)
         builder.create<RefDefineOp>(getPortLoc(connectValues[portNum].value),

--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -493,12 +493,12 @@ void LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
       //     %1 = ...
       //     firrtl.layerblock {
       //       %2 = ref.resolve %0
-      //       firrtl.strictconnect %1, %2
+      //       firrtl.matchingconnect %1, %2
       //     }
       if (auto refResolve = dyn_cast<RefResolveOp>(op))
         if (refResolve.getResult().hasOneUse() &&
             refResolve.getRef().getParentBlock() != body)
-          if (auto connect = dyn_cast<StrictConnectOp>(
+          if (auto connect = dyn_cast<MatchingConnectOp>(
                   *refResolve.getResult().getUsers().begin()))
             if (connect.getDest().getParentBlock() != body) {
               refResolve->moveBefore(layerBlock);
@@ -584,7 +584,7 @@ void LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
         if (isa<RefType>(src.getType()))
           src = builder.create<RefResolveOp>(
               newModule.getPortLocationAttr(portNum), src);
-        builder.create<StrictConnectOp>(newModule.getPortLocationAttr(portNum),
+        builder.create<MatchingConnectOp>(newModule.getPortLocationAttr(portNum),
                                         instanceOp.getResult(portNum), src);
       } else if (isa<RefType>(instanceOp.getResult(portNum).getType()) &&
                  connectValues[portNum].kind == ConnectKind::Ref)
@@ -592,7 +592,7 @@ void LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
                                     connectValues[portNum].value,
                                     instanceOp.getResult(portNum));
       else
-        builder.create<StrictConnectOp>(
+        builder.create<MatchingConnectOp>(
             getPortLoc(connectValues[portNum].value),
             connectValues[portNum].value,
             builder.create<RefResolveOp>(newModule.getPortLocationAttr(portNum),

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -249,9 +249,9 @@ void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
   for (auto [dst, src] : llvm::zip(wrapper.getBodyBlock()->getArguments(),
                                    memInst.getResults())) {
     if (wrapper.getPortDirection(dst.getArgNumber()) == Direction::Out)
-      b.create<StrictConnectOp>(mem->getLoc(), dst, src);
+      b.create<MatchingConnectOp>(mem->getLoc(), dst, src);
     else
-      b.create<StrictConnectOp>(mem->getLoc(), src, dst);
+      b.create<MatchingConnectOp>(mem->getLoc(), src, dst);
   }
 
   // Create an instance of the wrapper memory module, which will replace the

--- a/lib/Dialect/FIRRTL/Transforms/LowerSignatures.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerSignatures.cpp
@@ -449,7 +449,7 @@ static void lowerModuleBody(FModuleOp mod,
     // Zero Width ports may have dangling connects since they are not preserved
     // and do not have bounce wires.
     for (auto *use : llvm::make_early_inc_range(inst->getUsers())) {
-      assert(isa<StrictConnectOp>(use) || isa<ConnectOp>(use));
+      assert(isa<MatchingConnectOp>(use) || isa<ConnectOp>(use));
       use->erase();
     }
     inst->erase();

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -377,7 +377,7 @@ struct TypeLoweringVisitor : public FIRRTLVisitor<TypeLoweringVisitor, bool> {
   bool visitExpr(RefResolveOp op);
   bool visitExpr(RefCastOp op);
   bool visitStmt(ConnectOp op);
-  bool visitStmt(StrictConnectOp op);
+  bool visitStmt(MatchingConnectOp op);
   bool visitStmt(RefDefineOp op);
   bool visitStmt(WhenOp op);
   bool visitStmt(LayerBlockOp op);
@@ -893,7 +893,7 @@ bool TypeLoweringVisitor::visitStmt(ConnectOp op) {
 }
 
 // Expand connects of aggregates
-bool TypeLoweringVisitor::visitStmt(StrictConnectOp op) {
+bool TypeLoweringVisitor::visitStmt(MatchingConnectOp op) {
   if (processSAPath(op))
     return true;
 
@@ -910,7 +910,7 @@ bool TypeLoweringVisitor::visitStmt(StrictConnectOp op) {
     Value dest = getSubWhatever(op.getDest(), field.index());
     if (field.value().isOutput)
       std::swap(src, dest);
-    builder->create<StrictConnectOp>(dest, src);
+    builder->create<MatchingConnectOp>(dest, src);
   }
   return true;
 }

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -99,9 +99,9 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
       auto reg = b.create<RegOp>(pipeInput.getType(), clock, name).getResult();
       if (gate) {
         b.create<WhenOp>(gate, /*withElseRegion*/ false,
-                         [&]() { b.create<StrictConnectOp>(reg, pipeInput); });
+                         [&]() { b.create<MatchingConnectOp>(reg, pipeInput); });
       } else
-        b.create<StrictConnectOp>(reg, pipeInput);
+        b.create<MatchingConnectOp>(reg, pipeInput);
 
       pipeInput = reg;
     }
@@ -167,15 +167,15 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     Value rdata = builder.create<SubaccessOp>(regOfVec, addr);
     if (!ignoreReadEnable) {
       // Initialize read data out with invalid.
-      builder.create<StrictConnectOp>(
+      builder.create<MatchingConnectOp>(
           data, builder.create<InvalidValueOp>(data.getType()));
       // If enable is true, then connect the data read from memory register.
       builder.create<WhenOp>(enable, /*withElseRegion*/ false, [&]() {
-        builder.create<StrictConnectOp>(data, rdata);
+        builder.create<MatchingConnectOp>(data, rdata);
       });
     } else {
       // Ignore read enable signal.
-      builder.create<StrictConnectOp>(data, rdata);
+      builder.create<MatchingConnectOp>(data, rdata);
     }
   }
 
@@ -228,7 +228,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
         auto maskField = std::get<2>(regDataMask);
         // If mask, then update the register field.
         builder.create<WhenOp>(maskField, /*withElseRegion*/ false, [&]() {
-          builder.create<StrictConnectOp>(regField, dataField);
+          builder.create<MatchingConnectOp>(regField, dataField);
         });
       }
     });
@@ -258,7 +258,7 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
       return;
     }
     // Initialize read data out with invalid.
-    builder.create<StrictConnectOp>(
+    builder.create<MatchingConnectOp>(
         rdataOut, builder.create<InvalidValueOp>(rdataOut.getType()));
     // If enable:
     builder.create<WhenOp>(enable, /*withElseRegion*/ false, [&]() {
@@ -275,12 +275,12 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
               // If mask true, then set the field.
               builder.create<WhenOp>(
                   maskField, /*withElseRegion*/ false, [&]() {
-                    builder.create<StrictConnectOp>(regField, dataField);
+                    builder.create<MatchingConnectOp>(regField, dataField);
                   });
             }
           },
           // Read block:
-          [&]() { builder.create<StrictConnectOp>(rdataOut, rdata); });
+          [&]() { builder.create<MatchingConnectOp>(rdataOut, rdata); });
     });
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -98,8 +98,9 @@ struct MemToRegOfVecPass : public MemToRegOfVecBase<MemToRegOfVecPass> {
     while (stages--) {
       auto reg = b.create<RegOp>(pipeInput.getType(), clock, name).getResult();
       if (gate) {
-        b.create<WhenOp>(gate, /*withElseRegion*/ false,
-                         [&]() { b.create<MatchingConnectOp>(reg, pipeInput); });
+        b.create<WhenOp>(gate, /*withElseRegion*/ false, [&]() {
+          b.create<MatchingConnectOp>(reg, pipeInput);
+        });
       } else
         b.create<MatchingConnectOp>(reg, pipeInput);
 

--- a/lib/Dialect/FIRRTL/Transforms/MergeConnections.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MergeConnections.cpp
@@ -61,11 +61,11 @@ struct MergeConnection {
   bool changed = false;
 
   // Return true if the given connect op is merged.
-  bool peelConnect(StrictConnectOp connect);
+  bool peelConnect(MatchingConnectOp connect);
 
   // A map from a destination FieldRef to a pair of (i) the number of
   // connections seen so far and (ii) the vector to store subconnections.
-  DenseMap<FieldRef, std::pair<unsigned, SmallVector<StrictConnectOp>>>
+  DenseMap<FieldRef, std::pair<unsigned, SmallVector<MatchingConnectOp>>>
       connections;
 
   FModuleOp moduleOp;
@@ -76,7 +76,7 @@ struct MergeConnection {
   bool enableAggressiveMerging = false;
 };
 
-bool MergeConnection::peelConnect(StrictConnectOp connect) {
+bool MergeConnection::peelConnect(MatchingConnectOp connect) {
   // Ignore connections between different types because it will produce a
   // partial connect. Also ignore non-passive connections or non-integer
   // connections.
@@ -237,7 +237,7 @@ bool MergeConnection::peelConnect(StrictConnectOp connect) {
   // Emit strict connect if possible, fallback to normal connect.
   // Don't use emitConnect(), will split the connect apart.
   if (!parentBaseTy.hasUninferredWidth())
-    builder->create<StrictConnectOp>(connect.getLoc(), parent, merged);
+    builder->create<MatchingConnectOp>(connect.getLoc(), parent, merged);
   else
     builder->create<ConnectOp>(connect.getLoc(), parent, merged);
 
@@ -250,7 +250,7 @@ bool MergeConnection::run() {
   auto *body = moduleOp.getBodyBlock();
   // Merge connections by forward iterations.
   for (auto it = body->begin(), e = body->end(); it != e;) {
-    auto connectOp = dyn_cast<StrictConnectOp>(*it);
+    auto connectOp = dyn_cast<MatchingConnectOp>(*it);
     if (!connectOp) {
       it++;
       continue;

--- a/lib/Dialect/FIRRTL/Transforms/PassiveWires.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/PassiveWires.cpp
@@ -53,7 +53,7 @@ void PassiveWiresPass::runOnOperation() {
         worklist.push_back(wire);
       return WalkResult::advance();
     }
-    if (!isa<ConnectOp, StrictConnectOp>(op))
+    if (!isa<ConnectOp, MatchingConnectOp>(op))
       return WalkResult::advance();
     // connect/strictconnect
     if (!hasFlip(op->getOperand(0).getType()))

--- a/lib/Dialect/FIRRTL/Transforms/VBToBV.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/VBToBV.cpp
@@ -60,7 +60,7 @@ public:
   void handleConnect(Op);
 
   LogicalResult visitStmt(ConnectOp);
-  LogicalResult visitStmt(StrictConnectOp);
+  LogicalResult visitStmt(MatchingConnectOp);
 
   LogicalResult visitExpr(AggregateConstantOp);
   LogicalResult visitExpr(VectorCreateOp);
@@ -689,7 +689,7 @@ LogicalResult Visitor::visitStmt(ConnectOp op) {
   return success();
 }
 
-LogicalResult Visitor::visitStmt(StrictConnectOp op) {
+LogicalResult Visitor::visitStmt(MatchingConnectOp op) {
   handleConnect(op);
   return success();
 }

--- a/test/Conversion/FIRRTLToHW/intrinsics-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics-errors.mlir
@@ -18,7 +18,7 @@ firrtl.circuit "Foo" {
     %1 = firrtl.and %0, %b : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     // expected-error @below {{verification operation used in a non-verification context}}
     %2 = firrtl.int.ltl.delay %a, 42 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %0, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %2 : !firrtl.uint<1>
   }
 }
 
@@ -30,6 +30,6 @@ firrtl.circuit "Foo" {
     // expected-note @below {{reset is of type '!firrtl.reset', should be '!firrtl.uint<1>' or '!firrtl.asyncreset'}}
     // expected-error @below {{couldn't handle this operation}}
     %0 = firrtl.int.has_been_reset %clock, %reset : !firrtl.reset
-    firrtl.strictconnect %hbr, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %hbr, %0 : !firrtl.uint<1>
   }
 }

--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -55,8 +55,8 @@ firrtl.circuit "Intrinsics" {
     // CHECK-NEXT: hw.output [[CLK0]], [[CLK1]]
     %0 = firrtl.int.clock_gate %clk, %enable
     %1 = firrtl.int.clock_gate %clk, %enable, %testEnable
-    firrtl.strictconnect %gated_clk0, %0 : !firrtl.clock
-    firrtl.strictconnect %gated_clk1, %1 : !firrtl.clock
+    firrtl.matchingconnect %gated_clk0, %0 : !firrtl.clock
+    firrtl.matchingconnect %gated_clk1, %1 : !firrtl.clock
   }
 
   // CHECK-LABEL: hw.module @LTLAndVerif
@@ -147,27 +147,27 @@ firrtl.circuit "Intrinsics" {
     // !ltl.property
     // CHECK-NEXT: [[G]] = ltl.implication [[E]], [[F]] : !ltl.sequence, !ltl.property
     %4 = firrtl.int.ltl.implication %e, %f : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %g, %4 : !firrtl.uint<1>
+    firrtl.matchingconnect %g, %4 : !firrtl.uint<1>
 
     // inferred as !ltl.property
     // CHECK-NEXT: [[F]] = ltl.or %b, [[D:%.+]] : i1, !ltl.property
     %3 = firrtl.int.ltl.or %b, %d : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %f, %3 : !firrtl.uint<1>
+    firrtl.matchingconnect %f, %3 : !firrtl.uint<1>
 
     // inferred as !ltl.sequence
     // CHECK-NEXT: [[E]] = ltl.and %b, [[C:%.+]] : i1, !ltl.sequence
     %2 = firrtl.int.ltl.and %b, %c : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %e, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %e, %2 : !firrtl.uint<1>
 
     // !ltl.property
     // CHECK-NEXT: [[D]] = ltl.not %b : i1
     %1 = firrtl.int.ltl.not %b : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %d, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %d, %1 : !firrtl.uint<1>
 
     // !ltl.sequence
     // CHECK-NEXT: [[C]] = ltl.delay %a, 42 : i1
     %0 = firrtl.int.ltl.delay %a, 42 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %c, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %0 : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: hw.module @HasBeenReset
@@ -184,8 +184,8 @@ firrtl.circuit "Intrinsics" {
     // CHECK-NEXT: hw.output [[TMP1]], [[TMP2]]
     %0 = firrtl.int.has_been_reset %clock, %reset1 : !firrtl.uint<1>
     %1 = firrtl.int.has_been_reset %clock, %reset2 : !firrtl.asyncreset
-    firrtl.strictconnect %hbr1, %0 : !firrtl.uint<1>
-    firrtl.strictconnect %hbr2, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %hbr1, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %hbr2, %1 : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: hw.module @FPGAProbe
@@ -206,10 +206,10 @@ firrtl.circuit "Intrinsics" {
   ) {
     // CHECK: seq.clock_inv %clock_in
     %clock_inv_out = firrtl.int.clock_inv %clock_in
-    firrtl.strictconnect %clock_inv, %clock_inv_out : !firrtl.clock
+    firrtl.matchingconnect %clock_inv, %clock_inv_out : !firrtl.clock
 
     // CHECK: seq.clock_div %clock_in
     %clock_div_out = firrtl.int.clock_div %clock_in by 4
-    firrtl.strictconnect %clock_div, %clock_div_out : !firrtl.clock
+    firrtl.matchingconnect %clock_div, %clock_div_out : !firrtl.clock
   }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-errors.mlir
@@ -76,9 +76,9 @@ firrtl.circuit "unprocessedAnnotations" {
     %_M_read.data = firrtl.subfield %_M_read[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<42>>
     %c0_i1 = firrtl.constant 0 : !firrtl.uint<1>
     %c0_i4 = firrtl.constant 0 : !firrtl.uint<4>
-    firrtl.strictconnect %_M_read.clk, %clock : !firrtl.clock
-    firrtl.strictconnect %_M_read.en, %c0_i1 : !firrtl.uint<1>
-    firrtl.strictconnect %_M_read.addr, %c0_i4 : !firrtl.uint<4>
+    firrtl.matchingconnect %_M_read.clk, %clock : !firrtl.clock
+    firrtl.matchingconnect %_M_read.en, %c0_i1 : !firrtl.uint<1>
+    firrtl.matchingconnect %_M_read.addr, %c0_i4 : !firrtl.uint<4>
 
     // expected-warning @+1 {{unprocessed annotation:'firrtl.transforms.RemainingAnnotation6'}}
     %5 = firrtl.instance fetch {annotations = [{class = "firrtl.transforms.RemainingAnnotation6"}]} @bar(in io_cpu_flush: !firrtl.uint<1>)
@@ -162,8 +162,8 @@ firrtl.circuit "ConnectDestSubfield" {
     %0 = firrtl.reg %clock : !firrtl.clock, !firrtl.bundle<a: uint<1>>
     // expected-error @below {{'hw.struct_extract' op used as connect destination}}
     %1 = firrtl.subfield %0[a] : !firrtl.bundle<a: uint<1>>
-    // expected-error @below {{'firrtl.strictconnect' op LowerToHW couldn't handle this operation}}
-    firrtl.strictconnect %1, %value : !firrtl.uint<1>
+    // expected-error @below {{'firrtl.matchingconnect' op LowerToHW couldn't handle this operation}}
+    firrtl.matchingconnect %1, %value : !firrtl.uint<1>
   }
 }
 
@@ -174,8 +174,8 @@ firrtl.circuit "ConnectDestSubindex" {
     %0 = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<uint<1>, 1>
     // expected-error @below {{'hw.array_get' op used as connect destination}}
     %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<1>, 1>
-    // expected-error @below {{'firrtl.strictconnect' op LowerToHW couldn't handle this operation}}
-    firrtl.strictconnect %1, %value : !firrtl.uint<1>
+    // expected-error @below {{'firrtl.matchingconnect' op LowerToHW couldn't handle this operation}}
+    firrtl.matchingconnect %1, %value : !firrtl.uint<1>
   }
 }
 
@@ -186,8 +186,8 @@ firrtl.circuit "ConnectDestSubaccess" {
     %0 = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<uint<1>, 1>
     // expected-error @below {{'hw.array_get' op used as connect destination}}
     %1 = firrtl.subaccess %0[%index] : !firrtl.vector<uint<1>, 1>, !firrtl.uint<1>
-    // expected-error @below {{'firrtl.strictconnect' op LowerToHW couldn't handle this operation}}
-    firrtl.strictconnect %1, %value : !firrtl.uint<1>
+    // expected-error @below {{'firrtl.matchingconnect' op LowerToHW couldn't handle this operation}}
+    firrtl.matchingconnect %1, %value : !firrtl.uint<1>
   }
 }
 
@@ -201,8 +201,8 @@ firrtl.circuit "UndrivenInputPort" {
     %0 = firrtl.instance blackbox @Blackbox(in inst : !firrtl.uint<1>)
     // expected-note @below {{through driver here}}
     %1 = firrtl.instance blackbox @Blackbox(in inst : !firrtl.uint<1>)
-    firrtl.strictconnect %0, %1 : !firrtl.uint<1>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %0 : !firrtl.uint<1>
   }
 }
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-memories.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-memories.mlir
@@ -20,9 +20,9 @@ firrtl.circuit "Foo" {
     %mem1_r.en = firrtl.subfield %mem1_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem1_r.addr = firrtl.subfield %mem1_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem1_r.data = firrtl.subfield %mem1_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
-    firrtl.strictconnect %mem1_r.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem1_r.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem1_r.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem1_r.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem1_r.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem1_r.addr, %addr : !firrtl.uint<4>
     %mem1_data = firrtl.node sym @mem1_data %mem1_r.data : !firrtl.uint<42>
 
     // CHECK-NEXT: %mem2 = seq.firmem 1, 2, old, port_order : <13 x 42, mask 2>
@@ -33,11 +33,11 @@ firrtl.circuit "Foo" {
     %mem2_w.addr = firrtl.subfield %mem2_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
     %mem2_w.data = firrtl.subfield %mem2_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
     %mem2_w.mask = firrtl.subfield %mem2_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<2>>
-    firrtl.strictconnect %mem2_w.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem2_w.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem2_w.addr, %addr : !firrtl.uint<4>
-    firrtl.strictconnect %mem2_w.data, %wdata : !firrtl.uint<42>
-    firrtl.strictconnect %mem2_w.mask, %mask2 : !firrtl.uint<2>
+    firrtl.matchingconnect %mem2_w.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem2_w.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem2_w.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem2_w.data, %wdata : !firrtl.uint<42>
+    firrtl.matchingconnect %mem2_w.mask, %mask2 : !firrtl.uint<2>
 
     // CHECK-NEXT: %mem3 = seq.firmem 3, 2, new, port_order : <14 x 42, mask 3>
     // CHECK-NEXT: [[RDATA:%.+]] = seq.firmem.read_write_port %mem3[%addr] = %wdata if %wmode, clock %clk enable %en mask %mask3 :
@@ -50,12 +50,12 @@ firrtl.circuit "Foo" {
     %mem3_rw.rdata = firrtl.subfield %mem3_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
     %mem3_rw.wmask = firrtl.subfield %mem3_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
     %mem3_rw.wmode = firrtl.subfield %mem3_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<3>>
-    firrtl.strictconnect %mem3_rw.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem3_rw.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem3_rw.addr, %addr : !firrtl.uint<4>
-    firrtl.strictconnect %mem3_rw.wdata, %wdata : !firrtl.uint<42>
-    firrtl.strictconnect %mem3_rw.wmask, %mask3 : !firrtl.uint<3>
-    firrtl.strictconnect %mem3_rw.wmode, %wmode : !firrtl.uint<1>
+    firrtl.matchingconnect %mem3_rw.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem3_rw.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem3_rw.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem3_rw.wdata, %wdata : !firrtl.uint<42>
+    firrtl.matchingconnect %mem3_rw.wmask, %mask3 : !firrtl.uint<3>
+    firrtl.matchingconnect %mem3_rw.wmode, %wmode : !firrtl.uint<1>
     %mem3_data = firrtl.node sym @mem3_data %mem3_rw.rdata : !firrtl.uint<42>
 
     // CHECK-NEXT: %mem4 = seq.firmem 4, 5, undefined, port_order : <15 x 42, mask 6>
@@ -81,20 +81,20 @@ firrtl.circuit "Foo" {
     %mem4_w.mask = firrtl.subfield %mem4_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<6>>
     %mem4_rw.wmask = firrtl.subfield %mem4_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
     %mem4_rw.wmode = firrtl.subfield %mem4_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<6>>
-    firrtl.strictconnect %mem4_r.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem4_w.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem4_rw.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem4_r.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem4_w.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem4_rw.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem4_r.addr, %addr : !firrtl.uint<4>
-    firrtl.strictconnect %mem4_w.addr, %addr : !firrtl.uint<4>
-    firrtl.strictconnect %mem4_rw.addr, %addr : !firrtl.uint<4>
-    firrtl.strictconnect %mem4_w.data, %wdata : !firrtl.uint<42>
-    firrtl.strictconnect %mem4_rw.wdata, %wdata : !firrtl.uint<42>
-    firrtl.strictconnect %mem4_w.mask, %mask6 : !firrtl.uint<6>
-    firrtl.strictconnect %mem4_rw.wmask, %mask6 : !firrtl.uint<6>
-    firrtl.strictconnect %mem4_rw.wmode, %wmode : !firrtl.uint<1>
+    firrtl.matchingconnect %mem4_r.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem4_w.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem4_rw.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem4_r.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem4_w.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem4_rw.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem4_r.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem4_w.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem4_rw.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem4_w.data, %wdata : !firrtl.uint<42>
+    firrtl.matchingconnect %mem4_rw.wdata, %wdata : !firrtl.uint<42>
+    firrtl.matchingconnect %mem4_w.mask, %mask6 : !firrtl.uint<6>
+    firrtl.matchingconnect %mem4_rw.wmask, %mask6 : !firrtl.uint<6>
+    firrtl.matchingconnect %mem4_rw.wmode, %wmode : !firrtl.uint<1>
     %mem4_data0 = firrtl.node sym @mem4_data0 %mem4_r.data : !firrtl.uint<42>
     %mem4_data1 = firrtl.node sym @mem4_data1 %mem4_rw.rdata : !firrtl.uint<42>
   }
@@ -111,11 +111,11 @@ firrtl.circuit "Foo" {
     %mem_w.addr = firrtl.subfield %mem_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>
     %mem_w.data = firrtl.subfield %mem_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>
     %mem_w.mask = firrtl.subfield %mem_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>
-    firrtl.strictconnect %mem_w.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem_w.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem_w.addr, %addr : !firrtl.uint<4>
-    firrtl.strictconnect %mem_w.data, %data : !firrtl.uint<0>
-    firrtl.strictconnect %mem_w.mask, %mask : !firrtl.uint<1>
+    firrtl.matchingconnect %mem_w.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem_w.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem_w.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem_w.data, %data : !firrtl.uint<0>
+    firrtl.matchingconnect %mem_w.mask, %mask : !firrtl.uint<1>
   }
 
   // FIRRTL memories with a single mask bit for the entire word should lower to
@@ -134,11 +134,11 @@ firrtl.circuit "Foo" {
     %mem_w.data = firrtl.subfield %mem_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     %mem_w.mask = firrtl.subfield %mem_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 
-    firrtl.strictconnect %mem_w.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem_w.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem_w.addr, %addr : !firrtl.uint<4>
-    firrtl.strictconnect %mem_w.data, %data : !firrtl.uint<42>
-    firrtl.strictconnect %mem_w.mask, %mask : !firrtl.uint<1>
+    firrtl.matchingconnect %mem_w.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem_w.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem_w.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem_w.data, %data : !firrtl.uint<42>
+    firrtl.matchingconnect %mem_w.mask, %mask : !firrtl.uint<1>
   }
 
   // FIRRTL memories with a single mask bit for the entire word should lower to
@@ -158,12 +158,12 @@ firrtl.circuit "Foo" {
     %mem_rw.rdata = firrtl.subfield %mem_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     %mem_rw.wmask = firrtl.subfield %mem_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     %mem_rw.wmode = firrtl.subfield %mem_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
-    firrtl.strictconnect %mem_rw.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem_rw.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem_rw.addr, %addr : !firrtl.uint<4>
-    firrtl.strictconnect %mem_rw.wdata, %wdata : !firrtl.uint<42>
-    firrtl.strictconnect %mem_rw.wmask, %wmask : !firrtl.uint<1>
-    firrtl.strictconnect %mem_rw.wmode, %wmode : !firrtl.uint<1>
+    firrtl.matchingconnect %mem_rw.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem_rw.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem_rw.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem_rw.wdata, %wdata : !firrtl.uint<42>
+    firrtl.matchingconnect %mem_rw.wmask, %wmask : !firrtl.uint<1>
+    firrtl.matchingconnect %mem_rw.wmode, %wmode : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: hw.module @MemInit
@@ -174,9 +174,9 @@ firrtl.circuit "Foo" {
     %mem1_r.clk = firrtl.subfield %mem1_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem1_r.en = firrtl.subfield %mem1_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem1_r.addr = firrtl.subfield %mem1_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
-    firrtl.strictconnect %mem1_r.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem1_r.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem1_r.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem1_r.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem1_r.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem1_r.addr, %addr : !firrtl.uint<4>
 
     // CHECK: %mem2 = seq.firmem
     // CHECK-SAME: init = #seq.firmem.init<"mem.txt", false, true>
@@ -184,9 +184,9 @@ firrtl.circuit "Foo" {
     %mem2_r.clk = firrtl.subfield %mem2_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem2_r.en = firrtl.subfield %mem2_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem2_r.addr = firrtl.subfield %mem2_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
-    firrtl.strictconnect %mem2_r.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem2_r.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem2_r.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem2_r.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem2_r.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem2_r.addr, %addr : !firrtl.uint<4>
 
     // CHECK: %mem3 = seq.firmem
     // CHECK-SAME: init = #seq.firmem.init<"mem.txt", true, false>
@@ -194,9 +194,9 @@ firrtl.circuit "Foo" {
     %mem3_r.clk = firrtl.subfield %mem3_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem3_r.en = firrtl.subfield %mem3_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem3_r.addr = firrtl.subfield %mem3_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
-    firrtl.strictconnect %mem3_r.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem3_r.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem3_r.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem3_r.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem3_r.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem3_r.addr, %addr : !firrtl.uint<4>
   }
 
   // CHECK-LABEL: hw.module @IncompleteRead
@@ -213,9 +213,9 @@ firrtl.circuit "Foo" {
     %mem_r.clk = firrtl.subfield %mem_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem_r.en = firrtl.subfield %mem_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem_r.addr = firrtl.subfield %mem_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
-    firrtl.strictconnect %mem_r.clk, %clock : !firrtl.clock
-    firrtl.strictconnect %mem_r.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem_r.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %mem_r.clk, %clock : !firrtl.clock
+    firrtl.matchingconnect %mem_r.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem_r.addr, %addr : !firrtl.uint<4>
   }
 
   // CHECK-LABEL: hw.module @Depth1
@@ -247,16 +247,16 @@ firrtl.circuit "Foo" {
     %mem_0.clk = firrtl.subfield %mem_0[clk] : !firrtl.bundle<addr: uint<31>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem_0.en = firrtl.subfield %mem_0[en] : !firrtl.bundle<addr: uint<31>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem_0.addr = firrtl.subfield %mem_0[addr] : !firrtl.bundle<addr: uint<31>, en: uint<1>, clk: clock, data flip: uint<42>>
-    firrtl.strictconnect %mem_0.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem_0.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem_0.addr, %addr31 : !firrtl.uint<31>
+    firrtl.matchingconnect %mem_0.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem_0.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem_0.addr, %addr31 : !firrtl.uint<31>
 
     %mem_1 = firrtl.mem Undefined {depth = 8589934592 : i64, name = "mem33", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<33>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem_1.clk = firrtl.subfield %mem_1[clk] : !firrtl.bundle<addr: uint<33>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem_1.en = firrtl.subfield %mem_1[en] : !firrtl.bundle<addr: uint<33>, en: uint<1>, clk: clock, data flip: uint<42>>
     %mem_1.addr = firrtl.subfield %mem_1[addr] : !firrtl.bundle<addr: uint<33>, en: uint<1>, clk: clock, data flip: uint<42>>
-    firrtl.strictconnect %mem_1.clk, %clk : !firrtl.clock
-    firrtl.strictconnect %mem_1.en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %mem_1.addr, %addr33 : !firrtl.uint<33>
+    firrtl.matchingconnect %mem_1.clk, %clk : !firrtl.clock
+    firrtl.matchingconnect %mem_1.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %mem_1.addr, %addr33 : !firrtl.uint<33>
   }
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -743,7 +743,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                               out %sink: !firrtl.enum<valid: uint<0>, ready: uint<0>, data: uint<0>>) {
     %0 = firrtl.istag %source valid : !firrtl.enum<valid: uint<0>, ready: uint<0>, data: uint<0>>
     %1 = firrtl.subtag %source[valid] : !firrtl.enum<valid: uint<0>, ready: uint<0>, data: uint<0>>
-    firrtl.strictconnect %sink, %source : !firrtl.enum<valid: uint<0>, ready: uint<0>, data: uint<0>>
+    firrtl.matchingconnect %sink, %source : !firrtl.enum<valid: uint<0>, ready: uint<0>, data: uint<0>>
   }
 
   // CHECK-LABEL: hw.module private @SimpleEnumCreate(out sink : !hw.enum<a, b, c>) {
@@ -753,7 +753,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module private @SimpleEnumCreate(in %input: !firrtl.uint<0>,
                                          out %sink: !firrtl.enum<a: uint<0>, b: uint<0>, c: uint<0>>) {
     %0 = firrtl.enumcreate a(%input) : (!firrtl.uint<0>) -> !firrtl.enum<a: uint<0>, b: uint<0>, c: uint<0>>
-    firrtl.strictconnect %sink, %0 : !firrtl.enum<a: uint<0>, b: uint<0>, c: uint<0>>
+    firrtl.matchingconnect %sink, %0 : !firrtl.enum<a: uint<0>, b: uint<0>, c: uint<0>>
   }
 
   // CHECK-LABEL:  hw.module private @DataEnum(in %source : !hw.struct<tag: !hw.enum<a, b, c>, body: !hw.union<a: i2, b: i1, c: i32>>, out sink : !hw.struct<tag: !hw.enum<a, b, c>, body: !hw.union<a: i2, b: i1, c: i32>>) {
@@ -768,7 +768,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                               out %sink: !firrtl.enum<a: uint<2>, b: uint<1>, c: uint<32>>) {
     %0 = firrtl.istag %source a : !firrtl.enum<a: uint<2>, b: uint<1>, c: uint<32>>
     %1 = firrtl.subtag %source[a] : !firrtl.enum<a: uint<2>, b: uint<1>, c: uint<32>>
-    firrtl.strictconnect %sink, %source : !firrtl.enum<a: uint<2>, b: uint<1>, c: uint<32>>
+    firrtl.matchingconnect %sink, %source : !firrtl.enum<a: uint<2>, b: uint<1>, c: uint<32>>
   }
 
   // CHECK-LABEL: hw.module private @DataEnumCreate(in %input : i2, out sink : !hw.struct<tag: !hw.enum<a, b, c>, body: !hw.union<a: i2, b: i1, c: i32>>) {
@@ -780,7 +780,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module private @DataEnumCreate(in %input: !firrtl.uint<2>,
                                        out %sink: !firrtl.enum<a: uint<2>, b: uint<1>, c: uint<32>>) {
     %0 = firrtl.enumcreate a (%input) : (!firrtl.uint<2>) -> !firrtl.enum<a: uint<2>, b: uint<1>, c: uint<32>>
-    firrtl.strictconnect %sink, %0 : !firrtl.enum<a: uint<2>, b: uint<1>, c: uint<32>>
+    firrtl.matchingconnect %sink, %0 : !firrtl.enum<a: uint<2>, b: uint<1>, c: uint<32>>
   }
 
   // CHECK-LABEL: IsInvalidIssue572
@@ -958,11 +958,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %memName_port.en = firrtl.subfield %memName_port[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     %memName_port.addr = firrtl.subfield %memName_port[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     %memName_port.data = firrtl.subfield %memName_port[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
-    firrtl.strictconnect %memName_port.clk, %clock : !firrtl.clock
+    firrtl.matchingconnect %memName_port.clk, %clock : !firrtl.clock
     %en = firrtl.constant 0 : !firrtl.uint<1>
-    firrtl.strictconnect %memName_port.en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %memName_port.en, %en : !firrtl.uint<1>
     %addr = firrtl.constant 0 : !firrtl.uint<4>
-    firrtl.strictconnect %memName_port.addr, %addr : !firrtl.uint<4>
+    firrtl.matchingconnect %memName_port.addr, %addr : !firrtl.uint<4>
 
     // CHECK: %memName = seq.firmem sym @memSym 0, 1, undefined, port_order : <12 x 42>
     firrtl.connect %out, %reset : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1117,7 +1117,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NOT:     [[WIRE:%.+]] = sv.wire
   // CHECK-NEXT:    hw.output %a : i1
   firrtl.module private @eliminateSingleOutputConnects(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
-    firrtl.strictconnect %b, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %a : !firrtl.uint<1>
   }
 
   // Check that modules with comments are lowered.
@@ -1154,9 +1154,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // No-op cast is removed, %cast lowered to point directly to the backedge.
     %cast = firrtl.asClock %inst : (!firrtl.uint<1>) -> !firrtl.clock
     // Finalize the backedge, replacing all uses with %clock.
-    firrtl.strictconnect %inst, %clock : !firrtl.uint<1>
+    firrtl.matchingconnect %inst, %clock : !firrtl.uint<1>
     // %cast accidentally still points to the back edge in the lowering table.
-    firrtl.strictconnect %out, %cast : !firrtl.clock
+    firrtl.matchingconnect %out, %cast : !firrtl.clock
   }
 
   // Check that when inputs are connected to other inputs, the backedges are
@@ -1168,9 +1168,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module @ChainedBackedges(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
     %a_inst = firrtl.instance a @Blackbox(in inst: !firrtl.uint<1>)
     %b_inst = firrtl.instance b @Blackbox(in inst: !firrtl.uint<1>)
-    firrtl.strictconnect %a_inst, %in : !firrtl.uint<1>
-    firrtl.strictconnect %b_inst, %a_inst : !firrtl.uint<1>
-    firrtl.strictconnect %out, %b_inst : !firrtl.uint<1>
+    firrtl.matchingconnect %a_inst, %in : !firrtl.uint<1>
+    firrtl.matchingconnect %b_inst, %a_inst : !firrtl.uint<1>
+    firrtl.matchingconnect %out, %b_inst : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: hw.module @LowerToFirReg(in %clock : !seq.clock, in %reset : i1, in %value : i2)
@@ -1181,8 +1181,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   ) {
     %regA = firrtl.reg %clock: !firrtl.clock, !firrtl.uint<2>
     %regB = firrtl.regreset %clock, %reset, %value: !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
-    firrtl.strictconnect %regA, %value : !firrtl.uint<2>
-    firrtl.strictconnect %regB, %value : !firrtl.uint<2>
+    firrtl.matchingconnect %regA, %value : !firrtl.uint<2>
+    firrtl.matchingconnect %regB, %value : !firrtl.uint<2>
     // CHECK-NEXT: %regA = seq.firreg %value clock %clock : i2
     // CHECK-NEXT: %regB = seq.firreg %value clock %clock reset sync %reset, %value : i2
   }
@@ -1197,7 +1197,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: %count = seq.firreg %count clock %clock reset sync %reset, %value : i2
     // CHECK: hw.output %count : i2
 
-    firrtl.strictconnect %result, %count : !firrtl.uint<2>
+    firrtl.matchingconnect %result, %count : !firrtl.uint<2>
   }
 
   // CHECK-LABEL: hw.module @AsyncReset(in %clock : !seq.clock, in %reset : i1, in %value : i2, out result : i2)
@@ -1210,8 +1210,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: %count = seq.firreg %value clock %clock reset async %reset, %value : i2
     // CHECK: hw.output %count : i2
 
-    firrtl.strictconnect %count, %value : !firrtl.uint<2>
-    firrtl.strictconnect %result, %count : !firrtl.uint<2>
+    firrtl.matchingconnect %count, %value : !firrtl.uint<2>
+    firrtl.matchingconnect %result, %count : !firrtl.uint<2>
   }
 
   // CHECK-LABEL: hw.module @NoConnect(in %clock : !seq.clock, in %reset : i1, out result : i2)
@@ -1221,7 +1221,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %count = firrtl.reg %clock: !firrtl.clock, !firrtl.uint<2>
     // CHECK: %count = seq.firreg %count clock %clock : i2
 
-    firrtl.strictconnect %result, %count : !firrtl.uint<2>
+    firrtl.matchingconnect %result, %count : !firrtl.uint<2>
 
     // CHECK: hw.output %count : i2
   }
@@ -1239,12 +1239,12 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // Declaration order intentionally reversed to enforce use-before-def in HW
     %sub2_foo, %sub2_bar = firrtl.instance sub2 @moreForeignTypes(in foo: index, out bar: index)
     %sub1_foo, %sub1_bar = firrtl.instance sub1 @moreForeignTypes(in foo: index, out bar: index)
-    firrtl.strictconnect %sub1_foo, %inOpaque : index
-    firrtl.strictconnect %sub2_foo, %sub1_bar : index
-    firrtl.strictconnect %outOpaque, %sub2_bar : index
+    firrtl.matchingconnect %sub1_foo, %inOpaque : index
+    firrtl.matchingconnect %sub2_foo, %sub1_bar : index
+    firrtl.matchingconnect %outOpaque, %sub2_bar : index
   }
   firrtl.module @moreForeignTypes(in %foo: index, out %bar: index) {
-    firrtl.strictconnect %bar, %foo : index
+    firrtl.matchingconnect %bar, %foo : index
   }
 
   // CHECK-LABEL: hw.module @foreignOpsOnForeignTypes
@@ -1254,7 +1254,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:  }
   firrtl.module @foreignOpsOnForeignTypes(in %x: f32, out %y: f32) {
     %0 = arith.addf %x, %x : f32
-    firrtl.strictconnect %y, %0 : f32
+    firrtl.matchingconnect %y, %0 : f32
   }
 
   // CHECK-LABEL: hw.module @wiresWithForeignTypes
@@ -1266,11 +1266,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module @wiresWithForeignTypes(in %in: f32, out %out: f32) {
     %w1 = firrtl.wire : f32
     %w2 = firrtl.wire : f32
-    firrtl.strictconnect %out, %w2 : f32
+    firrtl.matchingconnect %out, %w2 : f32
     %0 = arith.addf %w1, %w1 : f32
-    firrtl.strictconnect %w2, %0 : f32
+    firrtl.matchingconnect %w2, %0 : f32
     %1 = arith.addf %in, %w1 : f32
-    firrtl.strictconnect %w1, %1 : f32
+    firrtl.matchingconnect %w1, %1 : f32
   }
 
   // CHECK-LABEL: LowerReadArrayInoutIntoArrayGet
@@ -1280,16 +1280,16 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK:      %r = hw.wire %a : !hw.array<1xi10>
     // CHECK-NEXT: [[RET:%.+]] = hw.array_get %r[%false] : !hw.array<1xi10>, i1
     // CHECK-NEXT: hw.output [[RET]]
-    firrtl.strictconnect %r, %a : !firrtl.vector<uint<10>, 1>
-    firrtl.strictconnect %b, %0 : !firrtl.uint<10>
+    firrtl.matchingconnect %r, %a : !firrtl.vector<uint<10>, 1>
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<10>
   }
 
   // CHECK-LABEL: hw.module @MergeBundle
   firrtl.module @MergeBundle(out %o: !firrtl.bundle<valid: uint<1>, ready: uint<1>>, in %i: !firrtl.uint<1>) {
     %a = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
-    firrtl.strictconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+    firrtl.matchingconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
     %0 = firrtl.bundlecreate %i, %i : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.bundle<valid: uint<1>, ready: uint<1>>
-    firrtl.strictconnect %a, %0 : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+    firrtl.matchingconnect %a, %0 : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
     // CHECK:      %a = hw.wire [[BUNDLE:%.+]] : !hw.struct<valid: i1, ready: i1>
     // CHECK-NEXT: [[BUNDLE]] = hw.struct_create (%i, %i) : !hw.struct<valid: i1, ready: i1>
     // CHECK-NEXT: hw.output %a : !hw.struct<valid: i1, ready: i1>
@@ -1298,9 +1298,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-LABEL: hw.module @MergeVector
   firrtl.module @MergeVector(out %o: !firrtl.vector<uint<1>, 3>, in %i: !firrtl.uint<1>, in %j: !firrtl.uint<1>) {
     %a = firrtl.wire : !firrtl.vector<uint<1>, 3>
-    firrtl.strictconnect %o, %a : !firrtl.vector<uint<1>, 3>
+    firrtl.matchingconnect %o, %a : !firrtl.vector<uint<1>, 3>
     %0 = firrtl.vectorcreate %i, %i, %j : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 3>
-    firrtl.strictconnect %a, %0 : !firrtl.vector<uint<1>, 3>
+    firrtl.matchingconnect %a, %0 : !firrtl.vector<uint<1>, 3>
     // CHECK:      %a = hw.wire [[VECTOR:%.+]] : !hw.array<3xi1>
     // CHECK-NEXT: [[VECTOR]] = hw.array_create %j, %i, %i : i1
     // CHECK-NEXT: hw.output %a : !hw.array<3xi1>
@@ -1310,7 +1310,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module @aggregateconstant(out %out : !firrtl.bundle<a: vector<vector<uint<8>, 2>, 2>, b: vector<vector<uint<8>, 2>, 2>>) {
     %0 = firrtl.aggregateconstant [[[0 : ui8, 1: ui8], [2 : ui8, 3: ui8]], [[4: ui8, 5: ui8], [6: ui8, 7:ui8]]] :
       !firrtl.bundle<a: vector<vector<uint<8>, 2>, 2>, b: vector<vector<uint<8>, 2>, 2>>
-    firrtl.strictconnect %out, %0 : !firrtl.bundle<a: vector<vector<uint<8>, 2>, 2>, b: vector<vector<uint<8>, 2>, 2>>
+    firrtl.matchingconnect %out, %0 : !firrtl.bundle<a: vector<vector<uint<8>, 2>, 2>, b: vector<vector<uint<8>, 2>, 2>>
     // CHECK{LITERAL}:   %0 = hw.aggregate_constant [[[3 : i8, 2 : i8], [1 : i8, 0 : i8]], [[7 : i8, 6 : i8], [5 : i8, 4 : i8]]]
     // CHECK-SAME: !hw.struct<a: !hw.array<2xarray<2xi8>>, b: !hw.array<2xarray<2xi8>>>
     // CHECK: hw.output %0
@@ -1369,9 +1369,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %w, %w_ref = firrtl.wire forceable : !firrtl.uint<4>, !firrtl.rwprobe<uint<4>>
     %r, %r_ref = firrtl.reg %clk forceable : !firrtl.clock, !firrtl.uint<4>, !firrtl.rwprobe<uint<4>>
 
-    firrtl.strictconnect %w, %n : !firrtl.uint<4>
-    firrtl.strictconnect %r, %w : !firrtl.uint<4>
-    firrtl.strictconnect %out, %r : !firrtl.uint<4>
+    firrtl.matchingconnect %w, %n : !firrtl.uint<4>
+    firrtl.matchingconnect %r, %w : !firrtl.uint<4>
+    firrtl.matchingconnect %out, %r : !firrtl.uint<4>
   }
 
   // Check lowering force and release operations.
@@ -1422,20 +1422,20 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %w = firrtl.wire {sv.attributes = [#sv.attribute<"mark_debug = \22yes\22">]} : !firrtl.uint<1>
     %n = firrtl.node %w {sv.attributes = [#sv.attribute<"mark_debug = \22yes\22">]} : !firrtl.uint<1>
     %r = firrtl.reg %clock {firrtl.random_init_start = 0 : ui64, sv.attributes = [#sv.attribute<"keep = \22true\22", emitAsComment>]} : !firrtl.clock, !firrtl.uint<1>
-    firrtl.strictconnect %w, %a : !firrtl.uint<1>
-    firrtl.strictconnect %b1, %n : !firrtl.uint<1>
-    firrtl.strictconnect %r, %a : !firrtl.uint<1>
-    firrtl.strictconnect %b2, %r : !firrtl.uint<1>
+    firrtl.matchingconnect %w, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b1, %n : !firrtl.uint<1>
+    firrtl.matchingconnect %r, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b2, %r : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: Elementwise
   firrtl.module @Elementwise(in %a: !firrtl.vector<uint<1>, 2>, in %b: !firrtl.vector<uint<1>, 2>, out %c_0: !firrtl.vector<uint<1>, 2>, out %c_1: !firrtl.vector<uint<1>, 2>, out %c_2: !firrtl.vector<uint<1>, 2>) {
     %0 = firrtl.elementwise_or %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %c_0, %0 : !firrtl.vector<uint<1>, 2>
+    firrtl.matchingconnect %c_0, %0 : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.elementwise_and %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %c_1, %1 : !firrtl.vector<uint<1>, 2>
+    firrtl.matchingconnect %c_1, %1 : !firrtl.vector<uint<1>, 2>
     %2 = firrtl.elementwise_xor %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %c_2, %2 : !firrtl.vector<uint<1>, 2>
+    firrtl.matchingconnect %c_2, %2 : !firrtl.vector<uint<1>, 2>
 
     // CHECK-NEXT: %0 = hw.bitcast %a : (!hw.array<2xi1>) -> i2
     // CHECK-NEXT: %1 = hw.bitcast %b : (!hw.array<2xi1>) -> i2
@@ -1457,7 +1457,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-LABEL: @MuxIntrinsics
   firrtl.module @MuxIntrinsics(in %sel1: !firrtl.uint<1>, in %sel2: !firrtl.uint<2>, in %v3: !firrtl.uint<32>, in %v2: !firrtl.uint<32>, in %v1: !firrtl.uint<32>, in %v0: !firrtl.uint<32>, out %out1: !firrtl.uint<32>, out %out2: !firrtl.uint<32>) attributes {convention = #firrtl<convention scalarized>} {
     %0 = firrtl.int.mux2cell(%sel1, %v1, %v0) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
-    firrtl.strictconnect %out1, %0 : !firrtl.uint<32>
+    firrtl.matchingconnect %out1, %0 : !firrtl.uint<32>
     // CHECK-NEXT: %mux2cell_in0 = hw.wire %sel1 sym @{{.+}} : i1
     // CHECK-NEXT: %mux2cell_in1 = hw.wire %v1 sym @{{.+}} : i32
     // CHECK-NEXT: %mux2cell_in2 = hw.wire %v0 sym @{{.+}} : i32
@@ -1467,7 +1467,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: %2 = sv.read_inout %1 : !hw.inout<i32>
 
     %1 = firrtl.int.mux4cell(%sel2, %v3, %v2, %v1, %v0) : (!firrtl.uint<2>, !firrtl.uint<32>, !firrtl.uint<32>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
-    firrtl.strictconnect %out2, %1 : !firrtl.uint<32>
+    firrtl.matchingconnect %out2, %1 : !firrtl.uint<32>
     // CHECK:      %mux4cell_in0 = hw.wire %3 sym @{{.+}} : !hw.array<4xi32>
     // CHECK-NEXT: %mux4cell_in1 = hw.wire %sel2 sym @{{.+}} : i2
     // CHECK-NEXT: %4 = hw.array_get %mux4cell_in0[%mux4cell_in1] {sv.attributes = [#sv.attribute<"cadence map_to_mux", emitAsComment>]} : !hw.array<4xi32>, i2
@@ -1521,22 +1521,22 @@ firrtl.circuit "TypeAlias" {
                            in %const: !firrtl.const.alias<B, const.uint<1>>,
                            out %out: !firrtl.alias<C, alias<baz, uint<1>>>,
                            out %out2: !firrtl.const.alias<D, const.uint<1>>) {
-    firrtl.strictconnect %out, %in: !firrtl.alias<C, alias<baz, uint<1>>>,!firrtl.alias<A, uint<1>>
+    firrtl.matchingconnect %out, %in: !firrtl.alias<C, alias<baz, uint<1>>>,!firrtl.alias<A, uint<1>>
     %wire = firrtl.wire : !firrtl.alias<baz, uint<1>>
     firrtl.connect %wire, %in :!firrtl.alias<baz, uint<1>> , !firrtl.alias<A, uint<1>>
     %wire2 = firrtl.wire : !firrtl.const.alias<baf, const.uint<1>>
-    firrtl.strictconnect %wire2, %const :!firrtl.const.alias<baf, const.uint<1>> , !firrtl.const.alias<B, const.uint<1>>
-    firrtl.strictconnect %out2, %wire2 :!firrtl.const.alias<D, const.uint<1>> , !firrtl.const.alias<baf, const.uint<1>>
+    firrtl.matchingconnect %wire2, %const :!firrtl.const.alias<baf, const.uint<1>> , !firrtl.const.alias<B, const.uint<1>>
+    firrtl.matchingconnect %out2, %wire2 :!firrtl.const.alias<D, const.uint<1>> , !firrtl.const.alias<baf, const.uint<1>>
   }
   firrtl.module private @SimpleStruct(in %source: !firrtl.alias<bar, bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>>,
                               out %fldout: !firrtl.alias<bar, uint<64>>) {
     %wire = firrtl.wire : !firrtl.bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>
-    firrtl.strictconnect %wire, %source : !firrtl.bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>, !firrtl.alias<bar, bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>>
+    firrtl.matchingconnect %wire, %source : !firrtl.bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>, !firrtl.alias<bar, bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>>
     %2 = firrtl.subfield %wire[data] : !firrtl.bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>
     %wire2 = firrtl.wire : !firrtl.const.alias<baf, const.uint<1>>
     firrtl.connect %fldout, %2 : !firrtl.alias<bar, uint<64>>, !firrtl.uint<64>
     %0 = firrtl.subfield %wire[valid] : !firrtl.bundle<valid: const.uint<1>, ready: uint<1>, data: uint<64>>
-    firrtl.strictconnect %wire2, %0 : !firrtl.const.alias<baf, const.uint<1>>, !firrtl.const.uint<1>
+    firrtl.matchingconnect %wire2, %0 : !firrtl.const.alias<baf, const.uint<1>>, !firrtl.const.uint<1>
   }
 }
 
@@ -1550,7 +1550,7 @@ firrtl.circuit "Issue5011" {
     // CHECK: %[[OUT:.+]] = hw.wire %{{.+}} sym @
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c1_ui5 = firrtl.constant 1 : !firrtl.uint<5>
-    firrtl.strictconnect %out, %c1_ui5 : !firrtl.uint<5>
+    firrtl.matchingconnect %out, %c1_ui5 : !firrtl.uint<5>
     %0 = firrtl.eq %out, %c1_ui5 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<1>
     firrtl.assert %clock, %0, %c1_ui1, "out was changed" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>  {eventControl = 0 : i32, isConcurrent = false}
     // CHECK: hw.output %[[OUT]]
@@ -1567,7 +1567,7 @@ firrtl.circuit "Issue5011Sym" {
     // CHECK: %[[OUT:.+]] = hw.wire %{{.+}} sym @out_sym
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c1_ui5 = firrtl.constant 1 : !firrtl.uint<5>
-    firrtl.strictconnect %out, %c1_ui5 : !firrtl.uint<5>
+    firrtl.matchingconnect %out, %c1_ui5 : !firrtl.uint<5>
     %0 = firrtl.eq %out, %c1_ui5 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<1>
     firrtl.assert %clock, %0, %c1_ui1, "out was changed" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>  {eventControl = 0 : i32, isConcurrent = false}
     // CHECK: hw.output %[[OUT]]
@@ -1586,7 +1586,7 @@ firrtl.circuit "ClockMuxLowering" {
     // CHECK: [[OUT:%.+]] = seq.clock_mux %cond, %clockTrue, %clockFalse
     // CHECK: hw.output [[OUT]]
     %0 = firrtl.mux(%cond, %clockTrue, %clockFalse) : (!firrtl.uint<1>, !firrtl.clock, !firrtl.clock) -> !firrtl.clock
-    firrtl.strictconnect %out, %0 : !firrtl.clock
+    firrtl.matchingconnect %out, %0 : !firrtl.clock
   }
 }
 
@@ -1632,9 +1632,9 @@ firrtl.circuit "PortSym" {
     // CHECK: %[[OUT:.+]] = hw.wire %{{.+}} sym @out_sym
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c1_ui5 = firrtl.constant 1 : !firrtl.uint<5>
-    firrtl.strictconnect %out, %c1_ui5 : !firrtl.uint<5>
+    firrtl.matchingconnect %out, %c1_ui5 : !firrtl.uint<5>
     %e_a = firrtl.instance sub1 @Blackbox(out bar: !firrtl.uint<1>)
-    firrtl.strictconnect %a, %e_a : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %e_a : !firrtl.uint<1>
     %0 = firrtl.eq %out, %c1_ui5 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<1>
   }
 }
@@ -1682,12 +1682,12 @@ firrtl.circuit "Directories" attributes {
     } : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
     %c0_clock = firrtl.specialconstant 0 : !firrtl.clock
     %0 = firrtl.subfield %mem_r[clk] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    firrtl.strictconnect %0, %c0_clock : !firrtl.clock
+    firrtl.matchingconnect %0, %c0_clock : !firrtl.clock
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %1 = firrtl.subfield %mem_r[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    firrtl.strictconnect %1, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %c0_ui1 : !firrtl.uint<1>
     %2 = firrtl.subfield %mem_r[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
-    firrtl.strictconnect %2, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %2, %c0_ui1 : !firrtl.uint<1>
   }
   // CHECK:       hw.module @Directories
   firrtl.module @Directories() {

--- a/test/Dialect/FIRRTL/Reduction/issue-3555.mlir
+++ b/test/Dialect/FIRRTL/Reduction/issue-3555.mlir
@@ -9,8 +9,8 @@ firrtl.circuit "Foo"  {
   firrtl.module @Foo(in %x: !firrtl.uint<1>, out %y: !firrtl.uint<1>) {
     %x1_x = firrtl.wire   : !firrtl.uint<1>
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
-    // CHECK-NOT: firrtl.strictconnect %y
-    firrtl.strictconnect %y, %invalid_ui1 : !firrtl.uint<1>
+    // CHECK-NOT: firrtl.matchingconnect %y
+    firrtl.matchingconnect %y, %invalid_ui1 : !firrtl.uint<1>
   }
   // CHECK: }
 }

--- a/test/Dialect/FIRRTL/SFCTests/async-reset.fir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset.fir
@@ -113,10 +113,10 @@ circuit Foo:
     complex_literal[3] <= UInt<1>("h00")
     reg r : UInt<1>[4], clock with : (reset => (reset, complex_literal))
     z <= r
-    ; CHECK: firrtl.strictconnect %z_0, %c1_ui1
-    ; CHECK: firrtl.strictconnect %z_1, %c1_ui1
-    ; CHECK: firrtl.strictconnect %z_2, %c0_ui1
-    ; CHECK: firrtl.strictconnect %z_3, %c0_ui1
+    ; CHECK: firrtl.matchingconnect %z_0, %c1_ui1
+    ; CHECK: firrtl.matchingconnect %z_1, %c1_ui1
+    ; CHECK: firrtl.matchingconnect %z_2, %c0_ui1
+    ; CHECK: firrtl.matchingconnect %z_3, %c0_ui1
 
 // -----
 
@@ -130,7 +130,7 @@ circuit Foo:
     reg r : UInt<1>, clock with : (reset => (reset, r))
     r <= UInt(0)
     z <= r
-    ; CHECK: firrtl.strictconnect %z, %c0_ui1
+    ; CHECK: firrtl.matchingconnect %z, %c0_ui1
 
 // -----
 
@@ -144,4 +144,4 @@ circuit Foo:
     reg r : UInt<1>, clock with : (reset => (reset, UInt(0)))
     r <= UInt(0)
     z <= r
-    ; CHECK: firrtl.strictconnect %z, %c0_ui1
+    ; CHECK: firrtl.matchingconnect %z, %c0_ui1

--- a/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
@@ -13,7 +13,7 @@ firrtl.circuit "ConstInput"   {
   // CHECK-LABEL: firrtl.module private @Child
   firrtl.module private @Child(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
     %0 = firrtl.and %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %out, %in0 :
+    // CHECK: firrtl.matchingconnect %out, %in0 :
     firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
@@ -23,7 +23,7 @@ firrtl.circuit "InstanceInput"   {
   // CHECK-LABEL: firrtl.module private @Bottom1
   firrtl.module private @Bottom1(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
       // CHECK: %c1_ui1 = firrtl.constant 1
-      // CHECK: firrtl.strictconnect %out, %c1_ui1
+      // CHECK: firrtl.matchingconnect %out, %c1_ui1
     firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module private @Child1
@@ -32,7 +32,7 @@ firrtl.circuit "InstanceInput"   {
     %b0_in, %b0_out = firrtl.instance b0 @Bottom1(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     // CHECK: %[[C1:.+]] = firrtl.constant 1 :
-    // CHECK: firrtl.strictconnect %out, %[[C1]]
+    // CHECK: firrtl.matchingconnect %out, %[[C1]]
     firrtl.connect %out, %b0_out : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // CHECK-LABEL:  firrtl.module @InstanceInput
@@ -46,7 +46,7 @@ firrtl.circuit "InstanceInput"   {
     %0 = firrtl.and %b0_out, %b1_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %1 = firrtl.and %0, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     // CHECK: %[[C0:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %z, %[[C0]] : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %z, %[[C0]] : !firrtl.uint<1>
     firrtl.connect %z, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
@@ -55,7 +55,7 @@ firrtl.circuit "InstanceInput"   {
 firrtl.circuit "InstanceInput2"   {
   // CHECK-LABEL: firrtl.module private @Bottom2
   firrtl.module private @Bottom2(in %in: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-    // CHECK: firrtl.strictconnect %out, %in 
+    // CHECK: firrtl.matchingconnect %out, %in 
     firrtl.connect %out, %in : !firrtl.uint<1>, !firrtl.uint<1>
   }
  // CHECK-LABEL:  firrtl.module private @Child2
@@ -63,7 +63,7 @@ firrtl.circuit "InstanceInput2"   {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
     %b0_in, %b0_out = firrtl.instance b0 @Bottom2(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
-    // CHECK: firrtl.strictconnect %out, %b0_out
+    // CHECK: firrtl.matchingconnect %out, %b0_out
     firrtl.connect %out, %b0_out : !firrtl.uint<1>, !firrtl.uint<1>
   }
  // CHECK-LABEL:  firrtl.module @InstanceInput2
@@ -76,7 +76,7 @@ firrtl.circuit "InstanceInput2"   {
     firrtl.connect %b1_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     %0 = firrtl.and %b0_out, %b1_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %1 = firrtl.and %0, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-   // CHECK:  firrtl.strictconnect %z, %1
+   // CHECK:  firrtl.matchingconnect %z, %1
     firrtl.connect %z, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
@@ -91,7 +91,7 @@ firrtl.circuit "acrossWire"   {
     %0 = firrtl.mux(%x, %c0_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.connect %_z, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %[[C2:.+]] = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %y, %[[C2]] : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %y, %[[C2]] : !firrtl.uint<1>
   }
 }
 
@@ -107,7 +107,7 @@ firrtl.circuit "constOutput"   {
     firrtl.connect %z, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %[[C3_0:.+]] = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: %[[C3:.+]] = firrtl.constant 0 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %z, %[[C3:.+]] : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %z, %[[C3:.+]] : !firrtl.uint<1>
   }
 }
 
@@ -122,7 +122,7 @@ firrtl.circuit "optiMux"   {
     %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
     %0 = firrtl.mux(%c1_ui, %c0_ui2, %c0_ui4) : (!firrtl.uint, !firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<4>
     // CHECK: %[[C4:.+]] = firrtl.constant 0 :
-    // CHECK: firrtl.strictconnect %z, %[[C4]]
+    // CHECK: firrtl.matchingconnect %z, %[[C4]]
     firrtl.connect %z, %0 : !firrtl.uint<4>, !firrtl.uint<4>
   }
 }
@@ -133,7 +133,7 @@ firrtl.circuit "divFold"   {
     %0 = firrtl.div %a, %a : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
     firrtl.connect %b, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %[[C5:.+]] = firrtl.constant 1 : !firrtl.uint<8>
-    // CHECK: firrtl.strictconnect %b, %[[C5]] : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %b, %[[C5]] : !firrtl.uint<8>
   }
 }
 
@@ -149,7 +149,7 @@ firrtl.circuit "padConstWire"   {
     %0 = firrtl.cat %_w_a, %_w_b : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<16>
     firrtl.connect %z, %0 : !firrtl.uint<16>, !firrtl.uint<16>
     // CHECK: %[[C6:.+]] = firrtl.constant 771 : !firrtl.uint<16>
-    // CHECK-NEXT: firrtl.strictconnect %z, %[[C6]] : !firrtl.uint<16>
+    // CHECK-NEXT: firrtl.matchingconnect %z, %[[C6]] : !firrtl.uint<16>
   }
 }
 
@@ -165,7 +165,7 @@ firrtl.circuit "padConstReg"   {
     %0 = firrtl.cat %r_a, %r_b : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<16>
     firrtl.connect %z, %0 : !firrtl.uint<16>, !firrtl.uint<16>
     // CHECK: %[[C6:.+]] = firrtl.constant 771 : !firrtl.uint<16>
-    // CHECK-NEXT: firrtl.strictconnect %z, %[[C6]] : !firrtl.uint<16>
+    // CHECK-NEXT: firrtl.matchingconnect %z, %[[C6]] : !firrtl.uint<16>
   }
 }
 
@@ -181,7 +181,7 @@ firrtl.circuit "padConstOut"   {
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     %0 = firrtl.cat %c3_ui2, %c_x : (!firrtl.uint<2>, !firrtl.uint<8>) -> !firrtl.uint<10>
     // CHECK: %[[C8:.+]] = firrtl.constant 771 : !firrtl.uint<16>
-    // CHECK: firrtl.strictconnect %z, %[[C8]] : !firrtl.uint<16>
+    // CHECK: firrtl.matchingconnect %z, %[[C8]] : !firrtl.uint<16>
     firrtl.connect %z, %0 : !firrtl.uint<16>, !firrtl.uint<10>
   }
 }
@@ -193,7 +193,7 @@ firrtl.circuit "padConstIn"   {
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     %0 = firrtl.cat %c3_ui2, %x : (!firrtl.uint<2>, !firrtl.uint<8>) -> !firrtl.uint<10>
     // CHECK: %[[C9:.+]] = firrtl.constant 771 : !firrtl.uint<16>
-    // CHECK: firrtl.strictconnect %y, %[[C9]] : !firrtl.uint<16>
+    // CHECK: firrtl.matchingconnect %y, %[[C9]] : !firrtl.uint<16>
     firrtl.connect %y, %0 : !firrtl.uint<16>, !firrtl.uint<10>
   }
   // CHECK-LABEL: firrtl.module @padConstIn
@@ -203,7 +203,7 @@ firrtl.circuit "padConstIn"   {
     firrtl.connect %c_x, %c3_ui2 : !firrtl.uint<8>, !firrtl.uint<2>
     firrtl.connect %z, %c_y : !firrtl.uint<16>, !firrtl.uint<16>
     // CHECK: %[[C10:.+]] = firrtl.constant 771 : !firrtl.uint<16>
-    // CHECK: firrtl.strictconnect %z, %[[C10]] : !firrtl.uint<16>
+    // CHECK: firrtl.matchingconnect %z, %[[C10]] : !firrtl.uint<16>
   }
 }
 
@@ -212,7 +212,7 @@ firrtl.circuit "removePad"   {
   // CHECK-LABEL: firrtl.module @removePad
   firrtl.module @removePad(in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
     %0 = firrtl.pad %x, 6 : (!firrtl.uint<8>) -> !firrtl.uint<8>
-    // CHECK: firrtl.strictconnect %z, %x : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %z, %x : !firrtl.uint<8>
     firrtl.connect %z, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   }
 }
@@ -227,8 +227,8 @@ firrtl.circuit "asyncReset"   {
     %0 = firrtl.mux(%en, %c0_ui4, %r) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>) -> !firrtl.uint<8>
     firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
-    // CHECK: firrtl.strictconnect %r, %0 : !firrtl.uint<8>
-    // CHECK: firrtl.strictconnect %z, %r : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %r, %0 : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %z, %r : !firrtl.uint<8>
   }
 }
 
@@ -241,7 +241,7 @@ firrtl.circuit "constReg2"   {
     firrtl.connect %r, %c-5_si4 : !firrtl.sint<8>, !firrtl.sint<4>
     firrtl.connect %z, %r : !firrtl.sint<8>, !firrtl.sint<8>
     // CHECK: %[[C12:.+]] = firrtl.constant -5 : !firrtl.sint<8>
-    // CHECK: firrtl.strictconnect %z, %[[C12]] : !firrtl.sint<8>
+    // CHECK: firrtl.matchingconnect %z, %[[C12]] : !firrtl.sint<8>
   }
 }
 
@@ -256,7 +256,7 @@ firrtl.circuit "SignTester"   {
     %1 = firrtl.mux(%c0_ui1, %c0_si3, %0) : (!firrtl.uint<1>, !firrtl.sint<3>, !firrtl.sint<3>) -> !firrtl.sint<3>
     firrtl.connect %ref, %1 : !firrtl.sint<3>, !firrtl.sint<3>
     // CHECK:  %[[C14:.+]] = firrtl.constant -3 : !firrtl.sint<3>
-    // CHECK:  firrtl.strictconnect %ref, %[[C14]] : !firrtl.sint<3>
+    // CHECK:  firrtl.matchingconnect %ref, %[[C14]] : !firrtl.sint<3>
   }
 }
 
@@ -268,7 +268,7 @@ firrtl.circuit "AddTester"   {
     %0 = firrtl.add %c-1_si1, %c-1_si1 : (!firrtl.sint<1>, !firrtl.sint<1>) -> !firrtl.sint<2>
     firrtl.connect %ref, %0 : !firrtl.sint<2>, !firrtl.sint<2>
     // CHECK:  %[[C15:.+]] = firrtl.constant -2 : !firrtl.sint<2>
-    // CHECK:  firrtl.strictconnect %ref, %[[C15]]
+    // CHECK:  firrtl.matchingconnect %ref, %[[C15]]
   }
 }
 
@@ -285,9 +285,9 @@ firrtl.circuit "ConstPropReductionTester"   {
     firrtl.connect %out3, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-DAG:  %[[C16:.+]] = firrtl.constant 0
     // CHECK-DAG:  %[[C17:.+]] = firrtl.constant 1
-    // CHECK:  firrtl.strictconnect %out1, %[[C16]]
-    // CHECK:  firrtl.strictconnect %out2, %[[C17]]
-    // CHECK:  firrtl.strictconnect %out3, %[[C17]]
+    // CHECK:  firrtl.matchingconnect %out1, %[[C16]]
+    // CHECK:  firrtl.matchingconnect %out2, %[[C17]]
+    // CHECK:  firrtl.matchingconnect %out3, %[[C17]]
   }
 }
 
@@ -303,7 +303,7 @@ firrtl.circuit "TailTester"   {
     %2 = firrtl.tail %_head_temp, 2 : (!firrtl.uint<3>) -> !firrtl.uint<1>
     firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:  %[[C18:.+]] = firrtl.constant 0
-    // CHECK:  firrtl.strictconnect %out, %[[C18]]
+    // CHECK:  firrtl.matchingconnect %out, %[[C18]]
   }
 }
 
@@ -320,7 +320,7 @@ firrtl.circuit "TailTester2"   {
     %2 = firrtl.tail %_tail_temp, 4 : (!firrtl.uint<5>) -> !firrtl.uint<1>
     firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:  %[[C21:.+]] = firrtl.constant 1
-    // CHECK:  firrtl.strictconnect %out, %[[C21]]
+    // CHECK:  firrtl.matchingconnect %out, %[[C21]]
   }
 }
 
@@ -335,7 +335,7 @@ firrtl.circuit "ZeroWidthAdd"   {
     %2 = firrtl.tail %1, 13 : (!firrtl.uint<20>) -> !firrtl.uint<7>
     firrtl.connect %y, %2 : !firrtl.uint<7>, !firrtl.uint<7>
     // CHECK:  %[[C20:.+]] = firrtl.constant 0
-    // CHECK:  firrtl.strictconnect %y, %[[C20]]
+    // CHECK:  firrtl.matchingconnect %y, %[[C20]]
   }
 }
 
@@ -349,7 +349,7 @@ firrtl.circuit "regConstReset"   {
     firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %[[C22:.+]] = firrtl.constant 11 
-    // CHECK: firrtl.strictconnect %z, %[[C22]]
+    // CHECK: firrtl.matchingconnect %z, %[[C22]]
   }
 }
 
@@ -368,7 +368,7 @@ firrtl.circuit "constPropRegMux"   {
   %2 = firrtl.xor %r1, %r2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %[[C23:.+]] = firrtl.constant 1
-    // CHECK: firrtl.strictconnect %out, %[[C23]]
+    // CHECK: firrtl.matchingconnect %out, %[[C23]]
   }
 }
 
@@ -377,10 +377,10 @@ firrtl.circuit "uninitSelfReg"   {
   // CHECK-LABEL: firrtl.module @uninitSelfReg
   firrtl.module @uninitSelfReg(in %clock: !firrtl.clock, out %z: !firrtl.uint<8>) {
     %r = firrtl.reg %clock  :  !firrtl.clock, !firrtl.uint<8>
-    firrtl.strictconnect %r, %r : !firrtl.uint<8>
-    firrtl.strictconnect %z, %r : !firrtl.uint<8>
+    firrtl.matchingconnect %r, %r : !firrtl.uint<8>
+    firrtl.matchingconnect %z, %r : !firrtl.uint<8>
     // CHECK: %invalid_ui8 = firrtl.invalidvalue : !firrtl.uint<8>
-    // CHECK: firrtl.strictconnect %z, %invalid_ui8 : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %z, %invalid_ui8 : !firrtl.uint<8>
   }
 
 //"Registers with ONLY constant reset" should "be replaced with that constant" in {
@@ -388,10 +388,10 @@ firrtl.circuit "uninitSelfReg"   {
   firrtl.module @constResetReg(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
     %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
     %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
-    firrtl.strictconnect %r, %r : !firrtl.uint<8>
-    firrtl.strictconnect %z, %r : !firrtl.uint<8>
+    firrtl.matchingconnect %r, %r : !firrtl.uint<8>
+    firrtl.matchingconnect %z, %r : !firrtl.uint<8>
     // CHECK: %[[C11:.+]] = firrtl.constant 11 : !firrtl.uint<8>
-    // CHECK: firrtl.strictconnect %z, %[[C11]] : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %z, %[[C11]] : !firrtl.uint<8>
   }
 
 //"Registers with identical constant reset and connection" should "be replaced with that constant" in {
@@ -399,9 +399,9 @@ firrtl.circuit "uninitSelfReg"   {
   firrtl.module @regSameConstReset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
     %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
     %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
-    firrtl.strictconnect %r, %c11_ui4 : !firrtl.uint<8>
-    firrtl.strictconnect %z, %r : !firrtl.uint<8>
+    firrtl.matchingconnect %r, %c11_ui4 : !firrtl.uint<8>
+    firrtl.matchingconnect %z, %r : !firrtl.uint<8>
     // CHECK: %[[C13:.+]] = firrtl.constant 11 : !firrtl.uint<8>
-    // CHECK: firrtl.strictconnect %z, %[[C13]] : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %z, %[[C13]] : !firrtl.uint<8>
   }
 }

--- a/test/Dialect/FIRRTL/SFCTests/constantPropFail.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/constantPropFail.mlir
@@ -6,11 +6,11 @@
   // CHECK-LABEL: firrtl.module @padZeroReg
   firrtl.module @padZeroReg(in %clock: !firrtl.clock, out %z: !firrtl.uint<16>) {
       %_r = firrtl.reg droppable_name %clock  :  !firrtl.uint<8>
-      firrtl.strictconnect %_r, %_r : !firrtl.uint<8>
+      firrtl.matchingconnect %_r, %_r : !firrtl.uint<8>
       %c171_ui8 = firrtl.constant 171 : !firrtl.uint<8>
       %_n = firrtl.node droppable_name %c171_ui8  : !firrtl.uint<8>
       %1 = firrtl.cat %_n, %_r : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<16>
-      firrtl.strictconnect %z, %1 : !firrtl.uint<16>
+      firrtl.matchingconnect %z, %1 : !firrtl.uint<16>
     // CHECK: %[[TMP:.+]] = firrtl.constant 43776 : !firrtl.uint<16>
-    // CHECK-NEXT: firrtl.strictconnect %z, %[[TMP]] : !firrtl.uint<16>
+    // CHECK-NEXT: firrtl.matchingconnect %z, %[[TMP]] : !firrtl.uint<16>
   }

--- a/test/Dialect/FIRRTL/add-seqmem-ports.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports.mlir
@@ -92,8 +92,8 @@ firrtl.circuit "Two" attributes {annotations = [
   // CHECK: firrtl.module @Child(out %sram_0_user_output: !firrtl.uint<4>, in %sram_0_user_input: !firrtl.uint<3>)
   firrtl.module @Child() {
     %0:4 = firrtl.instance MWrite_ext  @MWrite_ext(in W0_addr: !firrtl.uint<4>, in W0_en: !firrtl.uint<1>, in W0_clk: !firrtl.clock, in W0_data: !firrtl.uint<42>)
-    // CHECK: firrtl.strictconnect %sram_0_user_output, %MWrite_ext_user_output : !firrtl.uint<4>
-    // CHECK: firrtl.strictconnect %MWrite_ext_user_input, %sram_0_user_input : !firrtl.uint<3>
+    // CHECK: firrtl.matchingconnect %sram_0_user_output, %MWrite_ext_user_output : !firrtl.uint<4>
+    // CHECK: firrtl.matchingconnect %MWrite_ext_user_input, %sram_0_user_input : !firrtl.uint<3>
   }
   // CHECK: firrtl.module @Two(out %sram_0_user_output: !firrtl.uint<4> [{class = "firrtl.transforms.DontTouchAnnotation"}], in %sram_0_user_input: !firrtl.uint<3> [{class = "firrtl.transforms.DontTouchAnnotation"}], out %sram_1_user_output: !firrtl.uint<4> [{class = "firrtl.transforms.DontTouchAnnotation"}], in %sram_1_user_input: !firrtl.uint<3> [{class = "firrtl.transforms.DontTouchAnnotation"}])
   firrtl.module @Two() {
@@ -101,10 +101,10 @@ firrtl.circuit "Two" attributes {annotations = [
     firrtl.instance child1 @Child()
     // CHECK: %child0_sram_0_user_output, %child0_sram_0_user_input = firrtl.instance child0  @Child
     // CHECK: %child1_sram_0_user_output, %child1_sram_0_user_input = firrtl.instance child1  @Child
-    // CHECK: firrtl.strictconnect %sram_0_user_output, %child0_sram_0_user_output : !firrtl.uint<4>
-    // CHECK: firrtl.strictconnect %child0_sram_0_user_input, %sram_0_user_input : !firrtl.uint<3>
-    // CHECK: firrtl.strictconnect %sram_1_user_output, %child1_sram_0_user_output : !firrtl.uint<4>
-    // CHECK: firrtl.strictconnect %child1_sram_0_user_input, %sram_1_user_input : !firrtl.uint<3>
+    // CHECK: firrtl.matchingconnect %sram_0_user_output, %child0_sram_0_user_output : !firrtl.uint<4>
+    // CHECK: firrtl.matchingconnect %child0_sram_0_user_input, %sram_0_user_input : !firrtl.uint<3>
+    // CHECK: firrtl.matchingconnect %sram_1_user_output, %child1_sram_0_user_output : !firrtl.uint<4>
+    // CHECK: firrtl.matchingconnect %child1_sram_0_user_input, %sram_1_user_input : !firrtl.uint<3>
 
   }
 }
@@ -134,7 +134,7 @@ firrtl.circuit "TestHarness" attributes {annotations = [
     firrtl.instance dut @DUT()
     // CHECK: %dut_sram_0_user_output, %dut_sram_0_user_input = firrtl.instance dut @DUT(out sram_0_user_output: !firrtl.uint<4> [{class = "firrtl.transforms.DontTouchAnnotation"}], in sram_0_user_input: !firrtl.uint<3> [{class = "firrtl.transforms.DontTouchAnnotation"}])
     // CHECK: %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
-    // CHECK: firrtl.strictconnect %dut_sram_0_user_input, %c0_ui3 : !firrtl.uint<3>
+    // CHECK: firrtl.matchingconnect %dut_sram_0_user_input, %c0_ui3 : !firrtl.uint<3>
   }
 }
 

--- a/test/Dialect/FIRRTL/annotations-generic.mlir
+++ b/test/Dialect/FIRRTL/annotations-generic.mlir
@@ -9,7 +9,7 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
   firrtl.extmodule @Bar(in bar: !firrtl.uint<1>)
   firrtl.module @Foo(in %foo: !firrtl.uint<1>) {
     %bar_bar = firrtl.instance bar @Bar(in bar: !firrtl.uint<1>)
-    firrtl.strictconnect %bar_bar, %foo : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_bar, %foo : !firrtl.uint<1>
   }
 }
 

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -488,7 +488,7 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
   firrtl.extmodule @Bar(in bar: !firrtl.uint<1>)
   firrtl.module @Foo(in %foo: !firrtl.uint<1>) {
     %bar_bar = firrtl.instance bar  @Bar(in bar: !firrtl.uint<1>)
-    firrtl.strictconnect %bar_bar, %foo : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_bar, %foo : !firrtl.uint<1>
   }
 }
 
@@ -585,7 +585,7 @@ firrtl.circuit "instportAnno" attributes {rawAnnotations = [
 ]} {
   firrtl.module @Baz(out %a: !firrtl.uint<1>) {
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
-    firrtl.strictconnect %a, %invalid_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %invalid_ui1 : !firrtl.uint<1>
   }
   firrtl.module @Bar() {
     %baz_a = firrtl.instance baz @Baz(out a: !firrtl.uint<1>)
@@ -1096,12 +1096,12 @@ firrtl.circuit "GCTInterface"  attributes {
 // CHECK:      %7 = firrtl.subfield %6[_0] : !firrtl.bundle<_0: uint<1>, _1: uint<1>>
 // CHECK:      %8 = firrtl.subfield %forceable_reg[_2] : !firrtl.bundle<_0: bundle<_0: uint<1>, _1: uint<1>>, _2: vector<uint<1>, 2>>
 // CHECK:      %9 = firrtl.subindex %8[1] : !firrtl.vector<uint<1>, 2>
-// CHECK:      firrtl.strictconnect %view_companion_view_register__2_0__bore, %1 : !firrtl.uint<1>
-// CHECK:      firrtl.strictconnect %view_companion_view_register__2_1__bore, %3 : !firrtl.uint<1>
-// CHECK:      firrtl.strictconnect %view_companion_view_register__0_inst__1__bore, %5 : !firrtl.uint<1>
-// CHECK:      firrtl.strictconnect %view_companion_view_register__0_inst__0__bore, %7 : !firrtl.uint<1>
-// CHECK:      firrtl.strictconnect %view_companion_view_forceable_reg_element__bore, %9 : !firrtl.uint<1>
-// CHECK:      firrtl.strictconnect %view_companion_view_port__bore, %a : !firrtl.uint<1>
+// CHECK:      firrtl.matchingconnect %view_companion_view_register__2_0__bore, %1 : !firrtl.uint<1>
+// CHECK:      firrtl.matchingconnect %view_companion_view_register__2_1__bore, %3 : !firrtl.uint<1>
+// CHECK:      firrtl.matchingconnect %view_companion_view_register__0_inst__1__bore, %5 : !firrtl.uint<1>
+// CHECK:      firrtl.matchingconnect %view_companion_view_register__0_inst__0__bore, %7 : !firrtl.uint<1>
+// CHECK:      firrtl.matchingconnect %view_companion_view_forceable_reg_element__bore, %9 : !firrtl.uint<1>
+// CHECK:      firrtl.matchingconnect %view_companion_view_port__bore, %a : !firrtl.uint<1>
 
 // -----
 
@@ -1267,12 +1267,12 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 // CHECK-DAG:    %tap_0 = firrtl.node %r
 //
 // CHECK-DAG:    %[[tap_1_0:[a-zA-Z0-9_]+]] = firrtl.subindex %tap_1[0]
-// CHECK-DAG:    firrtl.strictconnect %[[tap_1_0]], %r
+// CHECK-DAG:    firrtl.matchingconnect %[[tap_1_0]], %r
 //
 // CHECK-DAG:    %tap_2 = firrtl.node %[[w_a1]]
 //
 // CHECK-DAG:    %[[tap_3_0:[a-zA-Z0-9_]+]] = firrtl.subindex %tap_3[0]
-// CHECK-DAG:    firrtl.strictconnect %[[tap_3_0]], %[[w_a0]]
+// CHECK-DAG:    firrtl.matchingconnect %[[tap_3_0]], %[[w_a0]]
 //
 // CHECK-DAG:    %[[tap_4_port:[a-zA-Z0-9_]+]], %[[tap_5_port:[a-zA-Z0-9_]+]] = firrtl.instance BlackBox
 // CHECK-DAG:    %[[tap_4_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[tap_4_port]]
@@ -1280,7 +1280,7 @@ firrtl.circuit "GCTDataTap" attributes {rawAnnotations = [{
 //
 // CHECK-DAG:    %[[tap_5_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[tap_5_port]]
 // CHECK-DAG:    %[[tap_5_0:[a-zA-Z0-9_]+]] = firrtl.subindex %tap_5[0]
-// CHECK-DAG:    firrtl.strictconnect %[[tap_5_0]], %[[tap_5_resolve]]
+// CHECK-DAG:    firrtl.matchingconnect %[[tap_5_0]], %[[tap_5_resolve]]
 //
 // CHECK-DAG:    %[[tap_6_port:[a-zA-Z0-9_]+]] = firrtl.instance im @InnerMod
 // CHECK-DAG:    %[[tap_6_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[tap_6_port]]
@@ -1444,9 +1444,9 @@ firrtl.circuit "GrandCentralViewsBundle"  attributes {
     // CHECK-NEXT: %[[companion_port_0:[a-zA-Z0-9_]+]], %[[companion_port_1:[a-zA-Z0-9_]+]] = firrtl.instance companion
     firrtl.instance companion @Companion()
     // CHECK-NEXT: %[[bar_refPort_0_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[bar_refPort_0]]
-    // CHECK-NEXT: firrtl.strictconnect %[[companion_port_0]], %[[bar_refPort_0_resolve]]
+    // CHECK-NEXT: firrtl.matchingconnect %[[companion_port_0]], %[[bar_refPort_0_resolve]]
     // CHECK-NEXT: %[[bar_refPort_1_resolve:[a-zA-Z0-9_]+]] = firrtl.ref.resolve %[[bar_refPort_1]]
-    // CHECK-NEXT: firrtl.strictconnect %[[companion_port_1]], %[[bar_refPort_1_resolve]]
+    // CHECK-NEXT: firrtl.matchingconnect %[[companion_port_1]], %[[bar_refPort_1_resolve]]
   }
 }
 

--- a/test/Dialect/FIRRTL/bitcasts.mlir
+++ b/test/Dialect/FIRRTL/bitcasts.mlir
@@ -11,7 +11,7 @@ firrtl.module @BitcastIsANop1(
   // CHECK: hw.output %a_data, %a_strb, %a_last : i3, i2, i1
   %0 = firrtl.bitcast %a : (!firrtl.bundle<data: uint<3>, strb: uint<2>, last: uint<1>>) -> !firrtl.uint<6>
   %1 = firrtl.bitcast %0 : (!firrtl.uint<6>) -> !firrtl.bundle<data: uint<3>, strb: uint<2>, last: uint<1>>
-  firrtl.strictconnect %b, %1 : !firrtl.bundle<data: uint<3>, strb: uint<2>, last: uint<1>>
+  firrtl.matchingconnect %b, %1 : !firrtl.bundle<data: uint<3>, strb: uint<2>, last: uint<1>>
 }
 
 // Bitcasting bits -> bundle -> bits should be a nop and should not shuffle
@@ -24,7 +24,7 @@ firrtl.module @BitcastIsANop2(
   // CHECK: hw.output %a : i6
   %0 = firrtl.bitcast %a : (!firrtl.uint<6>) -> !firrtl.bundle<data: uint<3>, strb: uint<2>, last: uint<1>>
   %1 = firrtl.bitcast %0 : (!firrtl.bundle<data: uint<3>, strb: uint<2>, last: uint<1>>) -> !firrtl.uint<6>
-  firrtl.strictconnect %b, %1 : !firrtl.uint<6>
+  firrtl.matchingconnect %b, %1 : !firrtl.uint<6>
 }
 
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -18,48 +18,48 @@ firrtl.module @Casts(in %ui1 : !firrtl.uint<1>, in %si1 : !firrtl.sint<1>,
   %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
 
   // No effect
-  // CHECK: firrtl.strictconnect %out_ui1, %ui1 : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %out_ui1, %ui1 : !firrtl.uint<1>
   %0 = firrtl.asUInt %ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out_ui1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %out_si1, %si1 : !firrtl.sint<1>
+  // CHECK: firrtl.matchingconnect %out_si1, %si1 : !firrtl.sint<1>
   %1 = firrtl.asSInt %si1 : (!firrtl.sint<1>) -> !firrtl.sint<1>
   firrtl.connect %out_si1, %1 : !firrtl.sint<1>, !firrtl.sint<1>
-  // CHECK: firrtl.strictconnect %out_clock, %clock : !firrtl.clock
+  // CHECK: firrtl.matchingconnect %out_clock, %clock : !firrtl.clock
   %2 = firrtl.asClock %clock : (!firrtl.clock) -> !firrtl.clock
   firrtl.connect %out_clock, %2 : !firrtl.clock, !firrtl.clock
-  // CHECK: firrtl.strictconnect %out_asyncreset, %asyncreset : !firrtl.asyncreset
+  // CHECK: firrtl.matchingconnect %out_asyncreset, %asyncreset : !firrtl.asyncreset
   %3 = firrtl.asAsyncReset %asyncreset : (!firrtl.asyncreset) -> !firrtl.asyncreset
   firrtl.connect %out_asyncreset, %3 : !firrtl.asyncreset, !firrtl.asyncreset
 
   // Constant fold.
-  // CHECK: firrtl.strictconnect %out_ui1, %c1_ui1 : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %out_ui1, %c1_ui1 : !firrtl.uint<1>
   %4 = firrtl.asUInt %c1_si1 : (!firrtl.sint<1>) -> !firrtl.uint<1>
   firrtl.connect %out_ui1, %4 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %out_si1, %c-1_si1 : !firrtl.sint<1>
+  // CHECK: firrtl.matchingconnect %out_si1, %c-1_si1 : !firrtl.sint<1>
   %5 = firrtl.asSInt %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.sint<1>
   firrtl.connect %out_si1, %5 : !firrtl.sint<1>, !firrtl.sint<1>
-  // CHECK: firrtl.strictconnect %out_clock, %c1_clock : !firrtl.clock
+  // CHECK: firrtl.matchingconnect %out_clock, %c1_clock : !firrtl.clock
   %6 = firrtl.asClock %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.clock
   firrtl.connect %out_clock, %6 : !firrtl.clock, !firrtl.clock
-  // CHECK: firrtl.strictconnect %out_asyncreset, %c1_asyncreset : !firrtl.asyncreset
+  // CHECK: firrtl.matchingconnect %out_asyncreset, %c1_asyncreset : !firrtl.asyncreset
   %7 = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
   firrtl.connect %out_asyncreset, %7 : !firrtl.asyncreset, !firrtl.asyncreset
-  // CHECK: firrtl.strictconnect %outreset, %inreset : !firrtl.reset
+  // CHECK: firrtl.matchingconnect %outreset, %inreset : !firrtl.reset
   %8 = firrtl.resetCast %inreset : (!firrtl.reset) -> !firrtl.reset
-  firrtl.strictconnect %outreset, %8 : !firrtl.reset
+  firrtl.matchingconnect %outreset, %8 : !firrtl.reset
 
   // Transparent
-  // CHECK: firrtl.strictconnect %out2_si1, %si1
+  // CHECK: firrtl.matchingconnect %out2_si1, %si1
   %9 = firrtl.asUInt %si1 : (!firrtl.sint<1>) -> !firrtl.uint<1>
   %10 = firrtl.asSInt %9 : (!firrtl.uint<1>) -> !firrtl.sint<1>
-  firrtl.strictconnect %out2_si1, %10 : !firrtl.sint<1>
-  // CHECK: firrtl.strictconnect %out2_ui1, %ui1
+  firrtl.matchingconnect %out2_si1, %10 : !firrtl.sint<1>
+  // CHECK: firrtl.matchingconnect %out2_ui1, %ui1
   %11 = firrtl.asSInt %ui1 : (!firrtl.uint<1>) -> !firrtl.sint<1>
   %12 = firrtl.asUInt %11 : (!firrtl.sint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out2_ui1, %12 : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %out2_si1, %si1
+  firrtl.matchingconnect %out2_ui1, %12 : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %out2_si1, %si1
   %13 = firrtl.cvt %si1 : (!firrtl.sint<1>) -> !firrtl.sint<1>
-  firrtl.strictconnect %out2_si1, %13 : !firrtl.sint<1>
+  firrtl.matchingconnect %out2_si1, %13 : !firrtl.sint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Div
@@ -79,12 +79,12 @@ firrtl.module @Div(in %a: !firrtl.uint<4>,
   // CHECK-DAG: [[ONE_s2:%.+]] = firrtl.constant 1 : !firrtl.sint
 
   // Check that 'div(a, a) -> 1' works for known UInt widths.
-  // CHECK: firrtl.strictconnect %b, [[ONE_i4]]
+  // CHECK: firrtl.matchingconnect %b, [[ONE_i4]]
   %0 = firrtl.div %a, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %b, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // Check that 'div(c, c) -> 1' works for known SInt widths.
-  // CHECK: firrtl.strictconnect %d, [[ONE_s5]] : !firrtl.sint<5>
+  // CHECK: firrtl.matchingconnect %d, [[ONE_s5]] : !firrtl.sint<5>
   %1 = firrtl.div %c, %c : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.sint<5>
   firrtl.connect %d, %1 : !firrtl.sint<5>, !firrtl.sint<5>
 
@@ -99,12 +99,12 @@ firrtl.module @Div(in %a: !firrtl.uint<4>,
   firrtl.connect %h, %3 : !firrtl.sint, !firrtl.sint
 
   // Check that 'div(a, 1) -> a' for known UInt widths.
-  // CHECK: firrtl.strictconnect %b, %a
+  // CHECK: firrtl.matchingconnect %b, %a
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
   %4 = firrtl.div %a, %c1_ui2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<4>
   firrtl.connect %b, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %i, %c5_ui4
+  // CHECK: firrtl.matchingconnect %i, %c5_ui4
   %c1_ui4 = firrtl.constant 15 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
   %5 = firrtl.div %c1_ui4, %c3_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
@@ -121,7 +121,7 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
                    out %out6: !firrtl.uint<6>,
                    out %out5: !firrtl.uint<5>,
                    out %outz: !firrtl.uint<0>) {
-  // CHECK: firrtl.strictconnect %out, %c1_ui4
+  // CHECK: firrtl.matchingconnect %out, %c1_ui4
   %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
   %c3_si5 = firrtl.constant 3 : !firrtl.sint<5>
@@ -129,29 +129,29 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
   %0 = firrtl.and %c3_ui4, %c1_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %in
+  // CHECK: firrtl.matchingconnect %out, %in
   %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
   %1 = firrtl.and %in, %c15_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %c0_ui4
+  // CHECK: firrtl.matchingconnect %out, %c0_ui4
   %c1_ui0 = firrtl.constant 0 : !firrtl.uint<4>
   %2 = firrtl.and %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %c0_ui4
+  // CHECK: firrtl.matchingconnect %out, %c0_ui4
   %inv_2 = firrtl.and %c1_ui0, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %inv_2 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %in
+  // CHECK: firrtl.matchingconnect %out, %in
   %3 = firrtl.and %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %c0_ui4
-  // CHECK: firrtl.strictconnect %outz, %c0_ui0
+  // CHECK: firrtl.matchingconnect %out, %c0_ui4
+  // CHECK: firrtl.matchingconnect %outz, %c0_ui0
   %zw = firrtl.and %zin1, %zin2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
   firrtl.connect %out, %zw : !firrtl.uint<4>, !firrtl.uint<0>
-  firrtl.strictconnect %outz, %zw : !firrtl.uint<0>
+  firrtl.matchingconnect %outz, %zw : !firrtl.uint<0>
 
   // Mixed type inputs - the constant is zero extended, not sign extended, so it
   // cannot be folded!
@@ -159,41 +159,41 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
   // Narrows, then folds away
   // CHECK: %0 = firrtl.bits %in 1 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
   // CHECK-NEXT: %1 = firrtl.pad %0, 4 : (!firrtl.uint<2>) -> !firrtl.uint<4>
-  // CHECK-NEXT: firrtl.strictconnect %out, %1
+  // CHECK-NEXT: firrtl.matchingconnect %out, %1
   %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
   %4 = firrtl.and %in, %c3_ui2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<4>
   firrtl.connect %out, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // Mixed type input and outputs.
 
-  // CHECK: firrtl.strictconnect %out, %c1_ui4
+  // CHECK: firrtl.matchingconnect %out, %c1_ui4
   %c1_si4 = firrtl.constant 1 : !firrtl.sint<4>
   %5 = firrtl.and %c1_si4, %c1_si4 : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: %[[AND:.+]] = firrtl.asUInt %sin
-  // CHECK-NEXT: firrtl.strictconnect %out, %[[AND]]
+  // CHECK-NEXT: firrtl.matchingconnect %out, %[[AND]]
   %6 = firrtl.and %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %c0_ui4
+  // CHECK: firrtl.matchingconnect %out, %c0_ui4
   %c0_si2 = firrtl.constant 0 : !firrtl.sint<2>
   %7 = firrtl.and %sin, %c0_si2 : (!firrtl.sint<4>, !firrtl.sint<2>) -> !firrtl.uint<4>
-  firrtl.strictconnect %out, %7 : !firrtl.uint<4>
+  firrtl.matchingconnect %out, %7 : !firrtl.uint<4>
 
   // CHECK: %[[trunc:.*]] = firrtl.bits %in6
   // CHECK: %[[ANDPAD:.*]] = firrtl.and %[[trunc]], %in
   // CHECK: %[[POST:.*]] = firrtl.pad %[[ANDPAD]]
-  // CHECK: firrtl.strictconnect %out6, %[[POST]]
+  // CHECK: firrtl.matchingconnect %out6, %[[POST]]
   %8 = firrtl.pad %in, 6 : (!firrtl.uint<4>) -> !firrtl.uint<6>
   %9 = firrtl.and %in6, %8  : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
-  firrtl.strictconnect %out6, %9 : !firrtl.uint<6>
+  firrtl.matchingconnect %out6, %9 : !firrtl.uint<6>
 
   // CHECK: %[[AND:.*]] = firrtl.and %in, %c3_ui4
   // CHECK: firrtl.pad %[[AND]], 5
   %10 = firrtl.cvt %in : (!firrtl.uint<4>) -> !firrtl.sint<5>
   %11 = firrtl.and %10, %c3_si5 : (!firrtl.sint<5>, !firrtl.sint<5>) -> !firrtl.uint<5>
-  firrtl.strictconnect %out5, %11 : !firrtl.uint<5>
+  firrtl.matchingconnect %out5, %11 : !firrtl.uint<5>
 }
 
 // CHECK-LABEL: firrtl.module @Or
@@ -205,49 +205,49 @@ firrtl.module @Or(in %in: !firrtl.uint<4>,
                   out %out: !firrtl.uint<4>,
                   out %out6: !firrtl.uint<6>,
                   out %outz: !firrtl.uint<0>) {
-  // CHECK: firrtl.strictconnect %out, %c7_ui4
+  // CHECK: firrtl.matchingconnect %out, %c7_ui4
   %c4_ui4 = firrtl.constant 4 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
   %0 = firrtl.or %c3_ui4, %c4_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %c15_ui4
+  // CHECK: firrtl.matchingconnect %out, %c15_ui4
   %c1_ui15 = firrtl.constant 15 : !firrtl.uint<4>
   %1 = firrtl.or %in, %c1_ui15 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %in
+  // CHECK: firrtl.matchingconnect %out, %in
   %c1_ui0 = firrtl.constant 0 : !firrtl.uint<4>
   %2 = firrtl.or %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %in
+  // CHECK: firrtl.matchingconnect %out, %in
   %inv_2 = firrtl.or %c1_ui0, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %inv_2 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %in
+  // CHECK: firrtl.matchingconnect %out, %in
   %3 = firrtl.or %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %c0_ui4
-  // CHECK: firrtl.strictconnect %outz, %c0_ui0
+  // CHECK: firrtl.matchingconnect %out, %c0_ui4
+  // CHECK: firrtl.matchingconnect %outz, %c0_ui0
   %zw = firrtl.or %zin1, %zin2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
   firrtl.connect %out, %zw : !firrtl.uint<4>, !firrtl.uint<0>
-  firrtl.strictconnect %outz, %zw : !firrtl.uint<0>
+  firrtl.matchingconnect %outz, %zw : !firrtl.uint<0>
 
   // Mixed type input and outputs.
 
-  // CHECK: firrtl.strictconnect %out, %c1_ui4
+  // CHECK: firrtl.matchingconnect %out, %c1_ui4
   %c1_si4 = firrtl.constant 1 : !firrtl.sint<4>
   %5 = firrtl.or %c1_si4, %c1_si4 : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: [[OR:%.+]] = firrtl.asUInt %sin
-  // CHECK-NEXT: firrtl.strictconnect %out, [[OR]]
+  // CHECK-NEXT: firrtl.matchingconnect %out, [[OR]]
   %6 = firrtl.or %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %c15_ui4
+  // CHECK: firrtl.matchingconnect %out, %c15_ui4
   %c0_si2 = firrtl.constant -1 : !firrtl.sint<2>
   %7 = firrtl.or %sin, %c0_si2 : (!firrtl.sint<4>, !firrtl.sint<2>) -> !firrtl.uint<4>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -256,7 +256,7 @@ firrtl.module @Or(in %in: !firrtl.uint<4>,
   // CHECK: %[[trunc2:.*]] = firrtl.bits %in6
   // CHECK: %[[OR:.*]] = firrtl.or %[[trunc2]], %in
   // CHECK: %[[CAT:.*]] = firrtl.cat %[[trunc]], %[[OR]]
-  // CHECK: firrtl.strictconnect %out6, %[[CAT]]
+  // CHECK: firrtl.matchingconnect %out6, %[[CAT]]
   %8 = firrtl.pad %in, 6 : (!firrtl.uint<4>) -> !firrtl.uint<6>
   %9 = firrtl.or %in6, %8  : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
   firrtl.connect %out6, %9 : !firrtl.uint<6>, !firrtl.uint<6>
@@ -272,35 +272,35 @@ firrtl.module @Xor(in %in: !firrtl.uint<4>,
                    out %out: !firrtl.uint<4>,
                    out %out6: !firrtl.uint<6>,
                    out %outz: !firrtl.uint<0>) {
-  // CHECK: firrtl.strictconnect %out, %c2_ui4
+  // CHECK: firrtl.matchingconnect %out, %c2_ui4
   %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
   %0 = firrtl.xor %c3_ui4, %c1_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %in
+  // CHECK: firrtl.matchingconnect %out, %in
   %c1_ui0 = firrtl.constant 0 : !firrtl.uint<4>
   %2 = firrtl.xor %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %c0_ui4
+  // CHECK: firrtl.matchingconnect %out, %c0_ui4
   %3 = firrtl.xor %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %c0_ui4
-  // CHECK: firrtl.strictconnect %outz, %c0_ui0
+  // CHECK: firrtl.matchingconnect %out, %c0_ui4
+  // CHECK: firrtl.matchingconnect %outz, %c0_ui0
   %zw = firrtl.xor %zin1, %zin2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
   firrtl.connect %out, %zw : !firrtl.uint<4>, !firrtl.uint<0>
-  firrtl.strictconnect %outz, %zw : !firrtl.uint<0>
+  firrtl.matchingconnect %outz, %zw : !firrtl.uint<0>
 
   // Mixed type input and outputs.
 
-  // CHECK: firrtl.strictconnect %out, %c0_ui4
+  // CHECK: firrtl.matchingconnect %out, %c0_ui4
   %6 = firrtl.xor %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: %[[aui:.*]] = firrtl.asUInt %sin
-  // CHECK: firrtl.strictconnect %out, %[[aui]]
+  // CHECK: firrtl.matchingconnect %out, %[[aui]]
   %c0_si2 = firrtl.constant 0 : !firrtl.sint<2>
   %7 = firrtl.xor %sin, %c0_si2 : (!firrtl.sint<4>, !firrtl.sint<2>) -> !firrtl.uint<4>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -309,7 +309,7 @@ firrtl.module @Xor(in %in: !firrtl.uint<4>,
   // CHECK: %[[trunc2:.*]] = firrtl.bits %in6
   // CHECK: %[[XOR:.*]] = firrtl.xor %[[trunc2]], %in
   // CHECK: %[[CAT:.*]] = firrtl.cat %[[trunc]], %[[XOR]]
-  // CHECK: firrtl.strictconnect %out6, %[[CAT]]
+  // CHECK: firrtl.matchingconnect %out6, %[[CAT]]
   %8 = firrtl.pad %in, 6 : (!firrtl.uint<4>) -> !firrtl.uint<6>
   %9 = firrtl.xor %in6, %8  : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
   firrtl.connect %out6, %9 : !firrtl.uint<6>, !firrtl.uint<6>
@@ -328,46 +328,46 @@ firrtl.module @Not(in %in: !firrtl.uint<4>,
   %2 = firrtl.not %sin : (!firrtl.sint<4>) -> !firrtl.uint<4>
   %3 = firrtl.not %2 : (!firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %outs, %3 : !firrtl.uint<4>, !firrtl.uint<4>
-  // CHECK: firrtl.strictconnect %outu, %in
+  // CHECK: firrtl.matchingconnect %outu, %in
   // CHECK: %[[cast:.*]] = firrtl.asUInt %sin
-  // CHECK: firrtl.strictconnect %outs, %[[cast]]
+  // CHECK: firrtl.matchingconnect %outs, %[[cast]]
 
   %c5_ui4 = firrtl.constant 5 : !firrtl.uint<4>
   %5 = firrtl.eq %in, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   %6 = firrtl.not %5 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out1, %6 : !firrtl.uint<1>
+  firrtl.matchingconnect %out1, %6 : !firrtl.uint<1>
   // CHECK: firrtl.neq
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   %7 = firrtl.neq %in, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   %8 = firrtl.not %7 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out1, %8 : !firrtl.uint<1>
+  firrtl.matchingconnect %out1, %8 : !firrtl.uint<1>
   // CHECK: firrtl.eq
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   %9 = firrtl.lt %in, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   %10 = firrtl.not %9 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out1, %10 : !firrtl.uint<1>
+  firrtl.matchingconnect %out1, %10 : !firrtl.uint<1>
   // CHECK: firrtl.geq
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   %11 = firrtl.leq %in, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   %12 = firrtl.not %11 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out1, %12 : !firrtl.uint<1>
+  firrtl.matchingconnect %out1, %12 : !firrtl.uint<1>
   // CHECK: firrtl.gt
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   %13 = firrtl.gt %in, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   %14 = firrtl.not %13 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out1, %14 : !firrtl.uint<1>
+  firrtl.matchingconnect %out1, %14 : !firrtl.uint<1>
   // CHECK: firrtl.leq
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   %15 = firrtl.geq %in, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   %16 = firrtl.not %15 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out1, %16 : !firrtl.uint<1>
+  firrtl.matchingconnect %out1, %16 : !firrtl.uint<1>
   // CHECK: firrtl.lt
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
 }
 
@@ -375,7 +375,7 @@ firrtl.module @Not(in %in: !firrtl.uint<4>,
 firrtl.module @EQ(in %in1: !firrtl.uint<1>,
                   in %in4: !firrtl.uint<4>,
                   out %out: !firrtl.uint<1>) {
-  // CHECK: firrtl.strictconnect %out, %in1
+  // CHECK: firrtl.matchingconnect %out, %in1
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %0 = firrtl.eq %in1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -385,32 +385,32 @@ firrtl.module @EQ(in %in1: !firrtl.uint<1>,
   %1 = firrtl.eq %in1, %c3_ui2 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<1>
   firrtl.connect %out, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.eq %in1, %c3_ui2
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %2 = firrtl.eq %in1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.not %in1
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
   %3 = firrtl.eq %in4, %c15_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.andr %in4
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   %4 = firrtl.eq %in4, %c0_ui1 : (!firrtl.uint<4>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: [[ORR:%.+]] = firrtl.orr %in4
   // CHECK-NEXT: firrtl.not [[ORR]]
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   %c5_ui4 = firrtl.constant 5 : !firrtl.uint<4>
   %5 = firrtl.neq %in4, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   %6 = firrtl.eq %5, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out, %6 : !firrtl.uint<1>
+  firrtl.matchingconnect %out, %6 : !firrtl.uint<1>
   // CHECK: firrtl.eq
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
 }
 
@@ -418,7 +418,7 @@ firrtl.module @EQ(in %in1: !firrtl.uint<1>,
 firrtl.module @NEQ(in %in1: !firrtl.uint<1>,
                    in %in4: !firrtl.uint<4>,
                    out %out: !firrtl.uint<1>) {
-  // CHECK: firrtl.strictconnect %out, %in
+  // CHECK: firrtl.matchingconnect %out, %in
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %0 = firrtl.neq %in1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -427,26 +427,26 @@ firrtl.module @NEQ(in %in1: !firrtl.uint<1>,
   %1 = firrtl.neq %in1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.not %in1
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   %2 = firrtl.neq %in4, %c0_ui1 : (!firrtl.uint<4>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.orr %in4
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
   %4 = firrtl.neq %in4, %c15_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: [[ANDR:%.+]] = firrtl.andr %in4
   // CHECK-NEXT: firrtl.not [[ANDR]]
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   %c5_ui4 = firrtl.constant 5 : !firrtl.uint<4>
   %5 = firrtl.eq %in4, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   %6 = firrtl.neq %5, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out, %6 : !firrtl.uint<1>
+  firrtl.matchingconnect %out, %6 : !firrtl.uint<1>
   // CHECK: firrtl.neq
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 }
 
 // CHECK-LABEL: firrtl.module @Cat
@@ -462,22 +462,22 @@ firrtl.module @Cat(in %in4: !firrtl.uint<4>,
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %c0_si2 = firrtl.constant 0 : !firrtl.sint<2>
 
-  // CHECK: firrtl.strictconnect %out4, %in4
+  // CHECK: firrtl.matchingconnect %out4, %in4
   %0 = firrtl.bits %in4 3 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<2>
   %1 = firrtl.bits %in4 1 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
   %2 = firrtl.cat %0, %1 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
   firrtl.connect %out4, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %outcst, %c243_ui8
+  // CHECK: firrtl.matchingconnect %outcst, %c243_ui8
   %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
   %3 = firrtl.cat %c15_ui4, %c3_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<8>
   firrtl.connect %outcst, %3 : !firrtl.uint<8>, !firrtl.uint<8>
 
-  // CHECK: firrtl.strictconnect %outpt1, %in4
+  // CHECK: firrtl.matchingconnect %outpt1, %in4
   %5 = firrtl.cat %in0, %in4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %outpt1, %5 : !firrtl.uint<4>, !firrtl.uint<4>
-  // CHECK: firrtl.strictconnect %outpt2, %in4
+  // CHECK: firrtl.matchingconnect %outpt2, %in4
   %6 = firrtl.cat %in4, %in0 : (!firrtl.uint<4>, !firrtl.uint<0>) -> !firrtl.uint<4>
   firrtl.connect %outpt2, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 
@@ -493,10 +493,10 @@ firrtl.module @Cat(in %in4: !firrtl.uint<4>,
   firrtl.connect %outcst, %10 : !firrtl.uint<8>, !firrtl.uint<8>
 
   // CHECK: %[[fixedsign:.*]] = firrtl.cat %sin4, %sin4
-  // CHECK-NEXT: firrtl.strictconnect %outu8, %[[fixedsign]]
+  // CHECK-NEXT: firrtl.matchingconnect %outu8, %[[fixedsign]]
   %tcast = firrtl.asUInt %sin4 : (!firrtl.sint<4>) -> !firrtl.uint<4>
   %11 = firrtl.cat %tcast, %tcast : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<8>
-  firrtl.strictconnect %outu8, %11 : !firrtl.uint<8>
+  firrtl.matchingconnect %outu8, %11 : !firrtl.uint<8>
 }
 
 // CHECK-LABEL: firrtl.module @Bits
@@ -506,35 +506,35 @@ firrtl.module @Bits(in %in1: !firrtl.uint<1>,
                     out %out2: !firrtl.uint<2>,
                     out %out4: !firrtl.uint<4>,
                     out %out2b: !firrtl.uint<2>) {
-  // CHECK: firrtl.strictconnect %out1, %in1
+  // CHECK: firrtl.matchingconnect %out1, %in1
   %0 = firrtl.bits %in1 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.strictconnect %out4, %in4
+  // CHECK: firrtl.matchingconnect %out4, %in4
   %1 = firrtl.bits %in4 3 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out4, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out2, %c1_ui2
+  // CHECK: firrtl.matchingconnect %out2, %c1_ui2
   %c10_ui4 = firrtl.constant 10 : !firrtl.uint<4>
   %2 = firrtl.bits %c10_ui4 2 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
   firrtl.connect %out2, %2 : !firrtl.uint<2>, !firrtl.uint<2>
 
 
   // CHECK: firrtl.bits %in4 2 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %out1, %
+  // CHECK-NEXT: firrtl.matchingconnect %out1, %
   %3 = firrtl.bits %in4 3 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   %4 = firrtl.bits %3 1 to 1 : (!firrtl.uint<3>) -> !firrtl.uint<1>
   firrtl.connect %out1, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.strictconnect %out1, %in1
+  // CHECK: firrtl.matchingconnect %out1, %in1
   %5 = firrtl.bits %in1 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1, %5 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.strictconnect %out2b, %c1_ui2
+  // CHECK: firrtl.matchingconnect %out2b, %c1_ui2
   %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
   %6 = firrtl.mux( %in1, %c10_ui4, %c11_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   %7 = firrtl.bits %6 2 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
-  firrtl.strictconnect %out2b, %7 : !firrtl.uint<2>
+  firrtl.matchingconnect %out2b, %7 : !firrtl.uint<2>
 }
 
 // CHECK-LABEL: firrtl.module @Head
@@ -542,16 +542,16 @@ firrtl.module @Head(in %in4u: !firrtl.uint<4>,
                     out %out1u: !firrtl.uint<1>,
                     out %out3u: !firrtl.uint<3>) {
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 3
-  // CHECK-NEXT: firrtl.strictconnect %out1u, [[BITS]]
+  // CHECK-NEXT: firrtl.matchingconnect %out1u, [[BITS]]
   %0 = firrtl.head %in4u, 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 1
-  // CHECK-NEXT: firrtl.strictconnect %out3u, [[BITS]]
+  // CHECK-NEXT: firrtl.matchingconnect %out3u, [[BITS]]
   %1 = firrtl.head %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   firrtl.connect %out3u, %1 : !firrtl.uint<3>, !firrtl.uint<3>
 
-  // CHECK: firrtl.strictconnect %out3u, %c5_ui3
+  // CHECK: firrtl.matchingconnect %out3u, %c5_ui3
   %c10_ui4 = firrtl.constant 10 : !firrtl.uint<4>
   %2 = firrtl.head %c10_ui4, 3 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   firrtl.connect %out3u, %2 : !firrtl.uint<3>, !firrtl.uint<3>
@@ -570,68 +570,68 @@ firrtl.module @Mux(in %in: !firrtl.uint<4>,
                    out %out4: !firrtl.uint<4>,
                    out %out5: !firrtl.uint<1>,
                    out %out6: !firrtl.uint<1>) {
-  // CHECK: firrtl.strictconnect %out, %in
+  // CHECK: firrtl.matchingconnect %out, %in
   %0 = firrtl.int.mux2cell (%cond, %in, %in) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out, %c7_ui4
+  // CHECK: firrtl.matchingconnect %out, %c7_ui4
   %c7_ui4 = firrtl.constant 7 : !firrtl.uint<4>
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %2 = firrtl.mux (%c0_ui1, %in, %c7_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %out1, %cond
+  // CHECK: firrtl.matchingconnect %out1, %cond
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %3 = firrtl.mux (%cond, %c1_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1, %3 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.strictconnect %out, %invalid_ui4
+  // CHECK: firrtl.matchingconnect %out, %invalid_ui4
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   %7 = firrtl.mux (%cond, %invalid_ui4, %invalid_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
 
   %9 = firrtl.multibit_mux %c1_ui1, %c0_ui1, %cond : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %out1, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %out1, %c0_ui1
   firrtl.connect %out1, %9 : !firrtl.uint<1>, !firrtl.uint<1>
 
   %10 = firrtl.multibit_mux %cond, %val1, %val2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: %[[MUX:.+]] = firrtl.mux(%cond, %val1, %val2)
-  // CHECK-NEXT: firrtl.strictconnect %out1, %[[MUX]]
+  // CHECK-NEXT: firrtl.matchingconnect %out1, %[[MUX]]
   firrtl.connect %out1, %10 : !firrtl.uint<1>, !firrtl.uint<1>
 
   %11 = firrtl.multibit_mux %cond, %val1, %val1, %val1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %out1, %val1
+  // CHECK-NEXT: firrtl.matchingconnect %out1, %val1
   firrtl.connect %out1, %11 : !firrtl.uint<1>, !firrtl.uint<1>
 
   %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
   %12 = firrtl.multibit_mux %c0_ui0, %val1, %val1 :!firrtl.uint<0>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %out1, %val1
+  // CHECK-NEXT: firrtl.matchingconnect %out1, %val1
   firrtl.connect %out1, %12 : !firrtl.uint<1>, !firrtl.uint<1>
 
   %13 = firrtl.mux (%cond, %val0, %val0) : (!firrtl.uint<1>, !firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
-  // CHECK-NEXT: firrtl.strictconnect %out2, %c0_ui0
-  firrtl.strictconnect %out2, %13 : !firrtl.uint<0>
+  // CHECK-NEXT: firrtl.matchingconnect %out2, %c0_ui0
+  firrtl.matchingconnect %out2, %13 : !firrtl.uint<0>
 
   %14 = firrtl.mux (%cond, %c0_ui1, %c1_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   // CHECK-NEXT: [[V1:%.+]] = firrtl.not %cond
-  // CHECK-NEXT: firrtl.strictconnect %out3, [[V1]]
+  // CHECK-NEXT: firrtl.matchingconnect %out3, [[V1]]
   firrtl.connect %out3, %14 : !firrtl.uint<1>, !firrtl.uint<1>
 
   %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
   %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
   %15 = firrtl.mux (%cond, %c0_ui4, %c1_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   // CHECK-NEXT: [[V2:%.+]] = firrtl.mux(%cond
-  // CHECK-NEXT: firrtl.strictconnect %out4, [[V2]]
+  // CHECK-NEXT: firrtl.matchingconnect %out4, [[V2]]
   firrtl.connect %out4, %15 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK-NEXT: firrtl.strictconnect %out5, %val2
+  // CHECK-NEXT: firrtl.matchingconnect %out5, %val2
   %16 = firrtl.mux (%val0, %val1, %val2) : (!firrtl.uint<0>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out5, %16 : !firrtl.uint<1>
+  firrtl.matchingconnect %out5, %16 : !firrtl.uint<1>
 
   // CHECK-NEXT: %[[SEL:.+]] = firrtl.pad %val1, 2 : (!firrtl.uint<1>) -> !firrtl.uint<2>
   // CHECK-NEXT: mux4cell(%[[SEL]],
   %17 = firrtl.int.mux4cell (%val1, %val1, %val2, %val1, %val2) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out6, %17 : !firrtl.uint<1>
+  firrtl.matchingconnect %out6, %17 : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Pad
@@ -639,16 +639,16 @@ firrtl.module @Pad(in %in1u: !firrtl.uint<1>,
                    out %out1u: !firrtl.uint<1>,
                    out %outu: !firrtl.uint<4>,
                    out %outs: !firrtl.sint<4>) {
-  // CHECK: firrtl.strictconnect %out1u, %in1u
+  // CHECK: firrtl.matchingconnect %out1u, %in1u
   %0 = firrtl.pad %in1u, 1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.strictconnect %outu, %c1_ui4
+  // CHECK: firrtl.matchingconnect %outu, %c1_ui4
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %1 = firrtl.pad %c1_ui1, 4 : (!firrtl.uint<1>) -> !firrtl.uint<4>
   firrtl.connect %outu, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
-  // CHECK: firrtl.strictconnect %outs, %c-1_si4
+  // CHECK: firrtl.matchingconnect %outs, %c-1_si4
   %c1_si1 = firrtl.constant -1 : !firrtl.sint<1>
   %2 = firrtl.pad %c1_si1, 4 : (!firrtl.sint<1>) -> !firrtl.sint<4>
   firrtl.connect %outs, %2 : !firrtl.sint<4>, !firrtl.sint<4>
@@ -658,11 +658,11 @@ firrtl.module @Pad(in %in1u: !firrtl.uint<1>,
 firrtl.module @Shl(in %in1u: !firrtl.uint<1>,
                    out %out1u: !firrtl.uint<1>,
                    out %outu: !firrtl.uint<4>) {
-  // CHECK: firrtl.strictconnect %out1u, %in1u
+  // CHECK: firrtl.matchingconnect %out1u, %in1u
   %0 = firrtl.shl %in1u, 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.strictconnect %outu, %c8_ui4
+  // CHECK: firrtl.matchingconnect %outu, %c8_ui4
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %1 = firrtl.shl %c1_ui1, 3 : (!firrtl.uint<1>) -> !firrtl.uint<4>
   firrtl.connect %outu, %1 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -685,76 +685,76 @@ firrtl.module @Shr(in %in1u: !firrtl.uint<1>,
                    out %outu: !firrtl.uint,
                    out %outs: !firrtl.sint
                    ) {
-  // CHECK: firrtl.strictconnect %out1u, %in1u
+  // CHECK: firrtl.matchingconnect %out1u, %in1u
   %0 = firrtl.shr %in1u, 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.strictconnect %out1u, %c0_ui1
+  // CHECK: firrtl.matchingconnect %out1u, %c0_ui1
   %1 = firrtl.shr %in4u, 4 : (!firrtl.uint<4>) -> !firrtl.uint<0>
   firrtl.connect %out1u, %1 : !firrtl.uint<1>, !firrtl.uint<0>
 
-  // CHECK: firrtl.strictconnect %out1u, %c0_ui1
+  // CHECK: firrtl.matchingconnect %out1u, %c0_ui1
   %2 = firrtl.shr %in4u, 5 : (!firrtl.uint<4>) -> !firrtl.uint<0>
   firrtl.connect %out1u, %2 : !firrtl.uint<1>, !firrtl.uint<0>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
-  // CHECK-NEXT: firrtl.strictconnect %out1s, [[CAST]]
+  // CHECK-NEXT: firrtl.matchingconnect %out1s, [[CAST]]
   %3 = firrtl.shr %in4s, 3 : (!firrtl.sint<4>) -> !firrtl.sint<1>
   firrtl.connect %out1s, %3 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
-  // CHECK-NEXT: firrtl.strictconnect %out1s, [[CAST]]
+  // CHECK-NEXT: firrtl.matchingconnect %out1s, [[CAST]]
   %4 = firrtl.shr %in4s, 4 : (!firrtl.sint<4>) -> !firrtl.sint<1>
   firrtl.connect %out1s, %4 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
-  // CHECK-NEXT: firrtl.strictconnect %out1s, [[CAST]]
+  // CHECK-NEXT: firrtl.matchingconnect %out1s, [[CAST]]
   %5 = firrtl.shr %in4s, 5 : (!firrtl.sint<4>) -> !firrtl.sint<1>
   firrtl.connect %out1s, %5 : !firrtl.sint<1>, !firrtl.sint<1>
 
-  // CHECK: firrtl.strictconnect %out1u, %c1_ui1
+  // CHECK: firrtl.matchingconnect %out1u, %c1_ui1
   %c12_ui4 = firrtl.constant 12 : !firrtl.uint<4>
   %6 = firrtl.shr %c12_ui4, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %6 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 3
-  // CHECK-NEXT: firrtl.strictconnect %out1u, [[BITS]]
+  // CHECK-NEXT: firrtl.matchingconnect %out1u, [[BITS]]
   %7 = firrtl.shr %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %7 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // Issue #313: https://github.com/llvm/circt/issues/313
-  // CHECK: firrtl.strictconnect %out1s, %in1s : !firrtl.sint<1>
+  // CHECK: firrtl.matchingconnect %out1s, %in1s : !firrtl.sint<1>
   %8 = firrtl.shr %in1s, 42 : (!firrtl.sint<1>) -> !firrtl.sint<1>
   firrtl.connect %out1s, %8 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // Issue #1064: https://github.com/llvm/circt/issues/1064
-  // CHECK: firrtl.strictconnect %out1u, %c0_ui1
+  // CHECK: firrtl.matchingconnect %out1u, %c0_ui1
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %9 = firrtl.dshr %in0u, %c1_ui1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
   firrtl.connect %out1u, %9 : !firrtl.uint<1>, !firrtl.uint<0>
 
   // Issue #6608: https://github.com/llvm/circt/issues/6608
-  // CHECK: firrtl.strictconnect %out0u, %c0_ui0
+  // CHECK: firrtl.matchingconnect %out0u, %c0_ui0
   %10 = firrtl.shr %in0u, 0 : (!firrtl.uint<0>) -> !firrtl.uint<0>
-  firrtl.strictconnect %out0u, %10 : !firrtl.uint<0>
+  firrtl.matchingconnect %out0u, %10 : !firrtl.uint<0>
 
   // Issue #6608: https://github.com/llvm/circt/issues/6608
-  // CHECK: firrtl.strictconnect %out1s, %c0_si1
+  // CHECK: firrtl.matchingconnect %out1s, %c0_si1
   %11 = firrtl.shr %in0s, 0 : (!firrtl.sint<0>) -> !firrtl.sint<1>
-  firrtl.strictconnect %out1s, %11 : !firrtl.sint<1>
+  firrtl.matchingconnect %out1s, %11 : !firrtl.sint<1>
 
   // Issue #6608: https://github.com/llvm/circt/issues/6608
-  // CHECK: firrtl.strictconnect %out4u, %in4u
+  // CHECK: firrtl.matchingconnect %out4u, %in4u
   %12 = firrtl.shr %in4u, 0 : (!firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.strictconnect %out4u, %12 : !firrtl.uint<4>
+  firrtl.matchingconnect %out4u, %12 : !firrtl.uint<4>
 
   // Issue #6608: https://github.com/llvm/circt/issues/6608
-  // CHECK: firrtl.strictconnect %out4s, %in4s
+  // CHECK: firrtl.matchingconnect %out4s, %in4s
   %13 = firrtl.shr %in4s, 0 : (!firrtl.sint<4>) -> !firrtl.sint<4>
-  firrtl.strictconnect %out4s, %13 : !firrtl.sint<4>
+  firrtl.matchingconnect %out4s, %13 : !firrtl.sint<4>
 
   // Issue #6608: https://github.com/llvm/circt/issues/6608
   // Will change to drop op once FIRRTL spec changes sizeof(shr(uint))
@@ -776,16 +776,16 @@ firrtl.module @Tail(in %in4u: !firrtl.uint<4>,
                     out %out1u: !firrtl.uint<1>,
                     out %out3u: !firrtl.uint<3>) {
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 0 to 0
-  // CHECK-NEXT: firrtl.strictconnect %out1u, [[BITS]]
+  // CHECK-NEXT: firrtl.matchingconnect %out1u, [[BITS]]
   %0 = firrtl.tail %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 2 to 0
-  // CHECK-NEXT: firrtl.strictconnect %out3u, [[BITS]]
+  // CHECK-NEXT: firrtl.matchingconnect %out3u, [[BITS]]
   %1 = firrtl.tail %in4u, 1 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   firrtl.connect %out3u, %1 : !firrtl.uint<3>, !firrtl.uint<3>
 
-  // CHECK: firrtl.strictconnect %out3u, %c2_ui3
+  // CHECK: firrtl.matchingconnect %out3u, %c2_ui3
   %c10_ui4 = firrtl.constant 10 : !firrtl.uint<4>
   %2 = firrtl.tail %c10_ui4, 1 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   firrtl.connect %out3u, %2 : !firrtl.uint<3>, !firrtl.uint<3>
@@ -811,47 +811,47 @@ firrtl.module @Andr(in %in0 : !firrtl.uint<0>, in %in1 : !firrtl.sint<2>,
   %4 = firrtl.andr %in0 : (!firrtl.uint<0>) -> !firrtl.uint<1>
   // CHECK: %[[ZERO:.+]] = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK: %[[ONE:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %a, %[[ZERO]]
+  // CHECK: firrtl.matchingconnect %a, %[[ZERO]]
   firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %b, %[[ONE]]
+  // CHECK: firrtl.matchingconnect %b, %[[ONE]]
   firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %c, %[[ZERO]]
+  // CHECK: firrtl.matchingconnect %c, %[[ZERO]]
   firrtl.connect %c, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %d, %[[ONE]]
+  // CHECK: firrtl.matchingconnect %d, %[[ONE]]
   firrtl.connect %d, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %e, %[[ONE]]
+  // CHECK: firrtl.matchingconnect %e, %[[ONE]]
   firrtl.connect %e, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: %[[and1:.*]] = firrtl.andr %in1
-  // CHECK-NEXT: firrtl.strictconnect %e, %[[and1]]
+  // CHECK-NEXT: firrtl.matchingconnect %e, %[[and1]]
   %cat = firrtl.cat %in1, %cn1_si2 : (!firrtl.sint<2>, !firrtl.sint<2>) -> !firrtl.uint<4>
   %andrcat = firrtl.andr %cat : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %e, %andrcat : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.strictconnect %e, %[[ZERO]]
+  // CHECK: firrtl.matchingconnect %e, %[[ZERO]]
   %cat2 = firrtl.cat %in1, %cn2_si2 : (!firrtl.sint<2>, !firrtl.sint<2>) -> !firrtl.uint<4>
   %andrcat2 = firrtl.andr %cat2 : (!firrtl.uint<4>) -> !firrtl.uint<1>
   firrtl.connect %e, %andrcat2 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.strictconnect %g, %[[ZERO]]
+  // CHECK: firrtl.matchingconnect %g, %[[ZERO]]
   %5 = firrtl.asSInt %h : (!firrtl.uint<64>) -> !firrtl.sint<64>
   %6 = firrtl.asUInt %5 : (!firrtl.sint<64>) -> !firrtl.uint<64>
   %9 = firrtl.cvt %6 : (!firrtl.uint<64>) -> !firrtl.sint<65>
   %10 = firrtl.andr %9 : (!firrtl.sint<65>) -> !firrtl.uint<1>
-  firrtl.strictconnect %g, %10 : !firrtl.uint<1>
+  firrtl.matchingconnect %g, %10 : !firrtl.uint<1>
 
   // CHECK: %[[andr:.*]] = firrtl.andr %in1
-  // CHECK-NEXT: firrtl.strictconnect %i, %[[andr]]
+  // CHECK-NEXT: firrtl.matchingconnect %i, %[[andr]]
   %11 = firrtl.pad %in1, 3 : (!firrtl.sint<2>) -> !firrtl.sint<3>
   %12 = firrtl.andr %11 : (!firrtl.sint<3>) -> !firrtl.uint<1>
-  firrtl.strictconnect %i, %12 : !firrtl.uint<1>
+  firrtl.matchingconnect %i, %12 : !firrtl.uint<1>
 
   // CHECK: %[[cat:.*]] = firrtl.cat %in2, %h
   // CHECK-NEXT: firrtl.andr %[[cat]]
   %13 = firrtl.andr %in2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
   %14 = firrtl.cat %13, %h : (!firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<65>
   %15 = firrtl.andr %14 : (!firrtl.uint<65>) -> !firrtl.uint<1>
-  firrtl.strictconnect %j, %15 : !firrtl.uint<1>
+  firrtl.matchingconnect %j, %15 : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Orr
@@ -873,33 +873,33 @@ firrtl.module @Orr(in %in0 : !firrtl.uint<0>, in %in2 : !firrtl.uint<2>,
   %4 = firrtl.orr %in0 : (!firrtl.uint<0>) -> !firrtl.uint<1>
   // CHECK-DAG: %[[ZERO:.+]] = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK-DAG: %[[ONE:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %a, %[[ZERO]]
+  // CHECK: firrtl.matchingconnect %a, %[[ZERO]]
   firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %b, %[[ONE]]
+  // CHECK: firrtl.matchingconnect %b, %[[ONE]]
   firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %c, %[[ZERO]]
+  // CHECK: firrtl.matchingconnect %c, %[[ZERO]]
   firrtl.connect %c, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %d, %[[ONE]]
+  // CHECK: firrtl.matchingconnect %d, %[[ONE]]
   firrtl.connect %d, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %e, %[[ZERO]]
+  // CHECK: firrtl.matchingconnect %e, %[[ZERO]]
   firrtl.connect %e, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: %[[OR:.*]] = firrtl.orr %h
-  // CHECK: firrtl.strictconnect %g, %[[OR]]
+  // CHECK: firrtl.matchingconnect %g, %[[OR]]
   %5 = firrtl.asSInt %h : (!firrtl.uint<64>) -> !firrtl.sint<64>
   %6 = firrtl.asUInt %5 : (!firrtl.sint<64>) -> !firrtl.uint<64>
   %7 = firrtl.cat %6, %c0_ui2 : (!firrtl.uint<64>, !firrtl.uint<2>) -> !firrtl.uint<66>
   %8 = firrtl.cat %c0_ui2, %7 : (!firrtl.uint<2>, !firrtl.uint<66>) -> !firrtl.uint<68>
   %9 = firrtl.cvt %8 : (!firrtl.uint<68>) -> !firrtl.sint<69>
   %10 = firrtl.orr %9 : (!firrtl.sint<69>) -> !firrtl.uint<1>
-  firrtl.strictconnect %g, %10 : !firrtl.uint<1>
+  firrtl.matchingconnect %g, %10 : !firrtl.uint<1>
 
   // CHECK: %[[cat:.*]] = firrtl.cat %in2, %h
   // CHECK-NEXT: firrtl.orr %[[cat]]
   %13 = firrtl.orr %in2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
   %14 = firrtl.cat %13, %h : (!firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<65>
   %15 = firrtl.orr %14 : (!firrtl.uint<65>) -> !firrtl.uint<1>
-  firrtl.strictconnect %j, %15 : !firrtl.uint<1>
+  firrtl.matchingconnect %j, %15 : !firrtl.uint<1>
 
 }
 
@@ -923,33 +923,33 @@ firrtl.module @Xorr(in %in0 : !firrtl.uint<0>, in %in2 : !firrtl.uint<2>,
   %4 = firrtl.xorr %in0 : (!firrtl.uint<0>) -> !firrtl.uint<1>
   // CHECK-DAG: %[[ZERO:.+]] = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK-DAG: %[[ONE:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %a, %[[ZERO]]
+  // CHECK: firrtl.matchingconnect %a, %[[ZERO]]
   firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %b, %[[ONE]]
+  // CHECK: firrtl.matchingconnect %b, %[[ONE]]
   firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %c, %[[ZERO]]
+  // CHECK: firrtl.matchingconnect %c, %[[ZERO]]
   firrtl.connect %c, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %d, %[[ONE]]
+  // CHECK: firrtl.matchingconnect %d, %[[ONE]]
   firrtl.connect %d, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %e, %[[ZERO]]
+  // CHECK: firrtl.matchingconnect %e, %[[ZERO]]
   firrtl.connect %e, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: %[[XOR:.*]] = firrtl.xorr %h
-  // CHECK: firrtl.strictconnect %g, %[[OR]]
+  // CHECK: firrtl.matchingconnect %g, %[[OR]]
   %5 = firrtl.asSInt %h : (!firrtl.uint<64>) -> !firrtl.sint<64>
   %6 = firrtl.asUInt %5 : (!firrtl.sint<64>) -> !firrtl.uint<64>
   %7 = firrtl.cat %6, %c0_ui2 : (!firrtl.uint<64>, !firrtl.uint<2>) -> !firrtl.uint<66>
   %8 = firrtl.cat %c0_ui2, %7 : (!firrtl.uint<2>, !firrtl.uint<66>) -> !firrtl.uint<68>
   %9 = firrtl.cvt %8 : (!firrtl.uint<68>) -> !firrtl.sint<69>
   %10 = firrtl.xorr %9 : (!firrtl.sint<69>) -> !firrtl.uint<1>
-  firrtl.strictconnect %g, %10 : !firrtl.uint<1>
+  firrtl.matchingconnect %g, %10 : !firrtl.uint<1>
 
   // CHECK: %[[cat:.*]] = firrtl.cat %in2, %h
   // CHECK-NEXT: firrtl.xorr %[[cat]]
   %13 = firrtl.xorr %in2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
   %14 = firrtl.cat %13, %h : (!firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<65>
   %15 = firrtl.xorr %14 : (!firrtl.uint<65>) -> !firrtl.uint<1>
-  firrtl.strictconnect %j, %15 : !firrtl.uint<1>
+  firrtl.matchingconnect %j, %15 : !firrtl.uint<1>
 
 }
 
@@ -960,18 +960,18 @@ firrtl.module @Reduce(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>,
   %1 = firrtl.orr %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
   %2 = firrtl.xorr %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %b, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %b, %a
+  // CHECK: firrtl.matchingconnect %b, %a
   firrtl.connect %c, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %c, %a
+  // CHECK: firrtl.matchingconnect %c, %a
   firrtl.connect %d, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %d, %a
+  // CHECK: firrtl.matchingconnect %d, %a
 }
 
 
 // CHECK-LABEL: firrtl.module @subaccess
 firrtl.module @subaccess(out %result: !firrtl.uint<8>, in %vec0: !firrtl.vector<uint<8>, 16>) {
   // CHECK: [[TMP:%.+]] = firrtl.subindex %vec0[11]
-  // CHECK-NEXT: firrtl.strictconnect %result, [[TMP]]
+  // CHECK-NEXT: firrtl.matchingconnect %result, [[TMP]]
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
   %0 = firrtl.subaccess %vec0[%c11_ui8] : !firrtl.vector<uint<8>, 16>, !firrtl.uint<8>
   firrtl.connect %result, %0 :!firrtl.uint<8>, !firrtl.uint<8>
@@ -984,37 +984,37 @@ firrtl.module @subaccess(out %result: !firrtl.uint<8>, in %vec0: !firrtl.vector<
 // CHECK-LABEL: firrtl.module @subindex
 firrtl.module @subindex(out %out : !firrtl.uint<8>) {
   // CHECK: %c8_ui8 = firrtl.constant 8 : !firrtl.uint<8>
-  // CHECK: firrtl.strictconnect %out, %c8_ui8 : !firrtl.uint<8>
+  // CHECK: firrtl.matchingconnect %out, %c8_ui8 : !firrtl.uint<8>
   %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.vector<uint<8>, 1>
   %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<8>, 1>
-  firrtl.strictconnect %out, %1 : !firrtl.uint<8>
+  firrtl.matchingconnect %out, %1 : !firrtl.uint<8>
 }
 
 // CHECK-LABEL: firrtl.module @subindex_agg
 firrtl.module @subindex_agg(out %out : !firrtl.bundle<a: uint<8>>) {
   // CHECK: %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.bundle<a: uint<8>>
-  // CHECK: firrtl.strictconnect %out, %0 : !firrtl.bundle<a: uint<8>>
+  // CHECK: firrtl.matchingconnect %out, %0 : !firrtl.bundle<a: uint<8>>
   %0 = firrtl.aggregateconstant [[8 : ui8]] : !firrtl.vector<bundle<a: uint<8>>, 1>
   %1 = firrtl.subindex %0[0] : !firrtl.vector<bundle<a: uint<8>>, 1>
-  firrtl.strictconnect %out, %1 : !firrtl.bundle<a: uint<8>>
+  firrtl.matchingconnect %out, %1 : !firrtl.bundle<a: uint<8>>
 }
 
 // CHECK-LABEL: firrtl.module @subfield
 firrtl.module @subfield(out %out : !firrtl.uint<8>) {
   // CHECK: %c8_ui8 = firrtl.constant 8 : !firrtl.uint<8>
-  // CHECK: firrtl.strictconnect %out, %c8_ui8 : !firrtl.uint<8>
+  // CHECK: firrtl.matchingconnect %out, %c8_ui8 : !firrtl.uint<8>
   %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.bundle<a: uint<8>>
   %1 = firrtl.subfield %0[a] : !firrtl.bundle<a: uint<8>>
-  firrtl.strictconnect %out, %1 : !firrtl.uint<8>
+  firrtl.matchingconnect %out, %1 : !firrtl.uint<8>
 }
 
 // CHECK-LABEL: firrtl.module @subfield_agg
 firrtl.module @subfield_agg(out %out : !firrtl.vector<uint<8>, 1>) {
   // CHECK: %0 = firrtl.aggregateconstant [8 : ui8] : !firrtl.vector<uint<8>, 1>
-  // CHECK: firrtl.strictconnect %out, %0 : !firrtl.vector<uint<8>, 1>
+  // CHECK: firrtl.matchingconnect %out, %0 : !firrtl.vector<uint<8>, 1>
   %0 = firrtl.aggregateconstant [[8 : ui8]] : !firrtl.bundle<a: vector<uint<8>, 1>>
   %1 = firrtl.subfield %0[a] : !firrtl.bundle<a: vector<uint<8>, 1>>
-  firrtl.strictconnect %out, %1 : !firrtl.vector<uint<8>, 1>
+  firrtl.matchingconnect %out, %1 : !firrtl.vector<uint<8>, 1>
 }
 
 // CHECK-LABEL: firrtl.module @issue326
@@ -1039,7 +1039,7 @@ firrtl.module @issue432(out %tmp8: !firrtl.uint<10>) {
   %0 = firrtl.tail %c130_si10, 0 : (!firrtl.sint<10>) -> !firrtl.uint<10>
   firrtl.connect %tmp8, %0 : !firrtl.uint<10>, !firrtl.uint<10>
   // CHECK-NEXT: %c130_ui10 = firrtl.constant 130 : !firrtl.uint<10>
-  // CHECK-NEXT: firrtl.strictconnect %tmp8, %c130_ui10
+  // CHECK-NEXT: firrtl.matchingconnect %tmp8, %c130_ui10
 }
 
 // CHECK-LABEL: firrtl.module @issue437
@@ -1052,7 +1052,7 @@ firrtl.module @issue437(out %tmp19: !firrtl.uint<1>) {
 
 // CHECK-LABEL: firrtl.module @issue446
 // CHECK-NEXT: [[TMP:%.+]] = firrtl.constant 0 : !firrtl.uint<1>
-// CHECK-NEXT: firrtl.strictconnect %tmp10, [[TMP]] : !firrtl.uint<1>
+// CHECK-NEXT: firrtl.matchingconnect %tmp10, [[TMP]] : !firrtl.uint<1>
 firrtl.module @issue446(in %inp_1: !firrtl.sint<0>, out %tmp10: !firrtl.uint<1>) {
   %0 = firrtl.xor %inp_1, %inp_1 : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<0>
   firrtl.connect %tmp10, %0 : !firrtl.uint<1>, !firrtl.uint<0>
@@ -1068,7 +1068,7 @@ firrtl.module @xorUnsized(in %inp_1: !firrtl.sint, out %tmp10: !firrtl.uint) {
 // https://github.com/llvm/circt/issues/516
 // CHECK-LABEL: @issue516
 // CHECK-NEXT: [[TMP:%.+]] = firrtl.constant 0 : !firrtl.uint<0>
-// CHECK-NEXT: firrtl.strictconnect %tmp3, [[TMP]] : !firrtl.uint<0>
+// CHECK-NEXT: firrtl.matchingconnect %tmp3, [[TMP]] : !firrtl.uint<0>
 firrtl.module @issue516(in %inp_0: !firrtl.uint<0>, out %tmp3: !firrtl.uint<0>) {
   %0 = firrtl.div %inp_0, %inp_0 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
   firrtl.connect %tmp3, %0 : !firrtl.uint<0>, !firrtl.uint<0>
@@ -1077,7 +1077,7 @@ firrtl.module @issue516(in %inp_0: !firrtl.uint<0>, out %tmp3: !firrtl.uint<0>) 
 // https://github.com/llvm/circt/issues/591
 // CHECK-LABEL: @reg_cst_prop1
 // CHECK-NEXT:   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
-// CHECK-NEXT:   firrtl.strictconnect %out_b, %c5_ui8 : !firrtl.uint<8>
+// CHECK-NEXT:   firrtl.matchingconnect %out_b, %c5_ui8 : !firrtl.uint<8>
 // CHECK-NEXT:  }
 firrtl.module @reg_cst_prop1(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
@@ -1093,9 +1093,9 @@ firrtl.module @reg_cst_prop1(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<
 // CHECK-NEXT:      %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
 // CHECK-NEXT:      %tmp_a = firrtl.reg sym @reg1 %clock : !firrtl.clock, !firrtl.uint<8>
 // CHECK-NEXT:      %tmp_b = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<8>
-// CHECK-NEXT:      firrtl.strictconnect %tmp_a, %c5_ui8 : !firrtl.uint<8>
-// CHECK-NEXT:      firrtl.strictconnect %tmp_b, %tmp_a : !firrtl.uint<8>
-// CHECK-NEXT:      firrtl.strictconnect %out_b, %tmp_b : !firrtl.uint<8>
+// CHECK-NEXT:      firrtl.matchingconnect %tmp_a, %c5_ui8 : !firrtl.uint<8>
+// CHECK-NEXT:      firrtl.matchingconnect %tmp_b, %tmp_a : !firrtl.uint<8>
+// CHECK-NEXT:      firrtl.matchingconnect %out_b, %tmp_b : !firrtl.uint<8>
 
 firrtl.module @reg_cst_prop1_DontTouch(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
@@ -1107,7 +1107,7 @@ firrtl.module @reg_cst_prop1_DontTouch(in %clock: !firrtl.clock, out %out_b: !fi
 }
 // CHECK-LABEL: @reg_cst_prop2
 // CHECK-NEXT:   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
-// CHECK-NEXT:   firrtl.strictconnect %out_b, %c5_ui8 : !firrtl.uint<8>
+// CHECK-NEXT:   firrtl.matchingconnect %out_b, %c5_ui8 : !firrtl.uint<8>
 // CHECK-NEXT:  }
 firrtl.module @reg_cst_prop2(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %_tmp_b = firrtl.reg droppable_name %clock {name = "_tmp_b"} : !firrtl.clock, !firrtl.uint<8>
@@ -1121,7 +1121,7 @@ firrtl.module @reg_cst_prop2(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<
 
 // CHECK-LABEL: @reg_cst_prop3
 // CHECK-NEXT:   %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
-// CHECK-NEXT:   firrtl.strictconnect %out_b, %c0_ui8 : !firrtl.uint<8>
+// CHECK-NEXT:   firrtl.matchingconnect %out_b, %c0_ui8 : !firrtl.uint<8>
 // CHECK-NEXT:  }
 firrtl.module @reg_cst_prop3(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<8>) {
   %_tmp_a = firrtl.reg droppable_name %clock {name = "_tmp_a"} : !firrtl.clock, !firrtl.uint<8>
@@ -1169,7 +1169,7 @@ firrtl.module @AttachDeadWireDontTouch(in %a: !firrtl.analog<1>, in %b: !firrtl.
 
 // CHECK-LABEL: @wire_cst_prop1
 // CHECK-NEXT:   %c10_ui9 = firrtl.constant 10 : !firrtl.uint<9>
-// CHECK-NEXT:   firrtl.strictconnect %out_b, %c10_ui9 : !firrtl.uint<9>
+// CHECK-NEXT:   firrtl.matchingconnect %out_b, %c10_ui9 : !firrtl.uint<9>
 // CHECK-NEXT:  }
 firrtl.module @wire_cst_prop1(out %out_b: !firrtl.uint<9>) {
   %_tmp_a = firrtl.wire droppable_name : !firrtl.uint<8>
@@ -1181,7 +1181,7 @@ firrtl.module @wire_cst_prop1(out %out_b: !firrtl.uint<9>) {
 }
 
 // CHECK-LABEL: @wire_port_prop1
-// CHECK-NEXT:   firrtl.strictconnect %out_b, %in_a : !firrtl.uint<9>
+// CHECK-NEXT:   firrtl.matchingconnect %out_b, %in_a : !firrtl.uint<9>
 // CHECK-NEXT:  }
 firrtl.module @wire_port_prop1(in %in_a: !firrtl.uint<9>, out %out_b: !firrtl.uint<9>) {
   %_tmp = firrtl.wire droppable_name : !firrtl.uint<9>
@@ -1241,27 +1241,27 @@ firrtl.module @CompareWithSelf(
 
   %0 = firrtl.leq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y0, %c1_ui1
 
   %1 = firrtl.lt %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y1, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y1, %c0_ui1
 
   %2 = firrtl.geq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y2, %c1_ui1
 
   %3 = firrtl.gt %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y3, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y3, %c0_ui1
 
   %4 = firrtl.eq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y4, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y4, %c1_ui1
 
   %5 = firrtl.neq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y5, %c0_ui1
 }
 
 // CHECK-LABEL: @LEQOutsideBounds
@@ -1290,8 +1290,8 @@ firrtl.module @LEQOutsideBounds(
   %1 = firrtl.leq %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y0, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y1, %c1_ui1
 
   // b <= 3 -> 1
   // b <= 4 -> 1
@@ -1299,8 +1299,8 @@ firrtl.module @LEQOutsideBounds(
   %3 = firrtl.leq %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y3, %c1_ui1
 
   // b <= -5 -> 0
   // b <= -6 -> 0
@@ -1308,8 +1308,8 @@ firrtl.module @LEQOutsideBounds(
   %5 = firrtl.leq %b, %cm6_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y4, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y5, %c0_ui1
 }
 
 // CHECK-LABEL: @LTOutsideBounds
@@ -1338,8 +1338,8 @@ firrtl.module @LTOutsideBounds(
   %1 = firrtl.lt %a, %c9_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y0, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y1, %c1_ui1
 
   // b < 4 -> 1
   // b < 5 -> 1
@@ -1347,8 +1347,8 @@ firrtl.module @LTOutsideBounds(
   %3 = firrtl.lt %b, %c5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y3, %c1_ui1
 
   // b < -4 -> 0
   // b < -5 -> 0
@@ -1356,8 +1356,8 @@ firrtl.module @LTOutsideBounds(
   %5 = firrtl.lt %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y4, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y5, %c0_ui1
 }
 
 // CHECK-LABEL: @GEQOutsideBounds
@@ -1386,8 +1386,8 @@ firrtl.module @GEQOutsideBounds(
   %1 = firrtl.geq %a, %c9_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y0, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y1, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y0, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y1, %c0_ui1
 
   // b >= 4 -> 0
   // b >= 5 -> 0
@@ -1395,8 +1395,8 @@ firrtl.module @GEQOutsideBounds(
   %3 = firrtl.geq %b, %c5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y2, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y3, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y2, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y3, %c0_ui1
 
   // b >= -4 -> 1
   // b >= -5 -> 1
@@ -1404,8 +1404,8 @@ firrtl.module @GEQOutsideBounds(
   %5 = firrtl.geq %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y4, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y5, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y4, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y5, %c1_ui1
 }
 
 // CHECK-LABEL: @GTOutsideBounds
@@ -1434,8 +1434,8 @@ firrtl.module @GTOutsideBounds(
   %1 = firrtl.gt %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y0, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y1, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y0, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y1, %c0_ui1
 
   // b > 3 -> 0
   // b > 4 -> 0
@@ -1443,8 +1443,8 @@ firrtl.module @GTOutsideBounds(
   %3 = firrtl.gt %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y2, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y3, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y2, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y3, %c0_ui1
 
   // b > -5 -> 1
   // b > -6 -> 1
@@ -1452,8 +1452,8 @@ firrtl.module @GTOutsideBounds(
   %5 = firrtl.gt %b, %cm6_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y4, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y5, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y4, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y5, %c1_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfDifferentWidths
@@ -1503,18 +1503,18 @@ firrtl.module @ComparisonOfDifferentWidths(
   firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y0, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y1, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y3, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y4, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y6, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y7, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y8, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y9, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y10, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y11, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y6, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y7, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y8, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y9, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y10, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y11, %c1_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfUnsizedAndSized
@@ -1564,18 +1564,18 @@ firrtl.module @ComparisonOfUnsizedAndSized(
   firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y0, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y1, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y3, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y4, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y6, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y7, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y8, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y9, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y10, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y11, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y6, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y7, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y8, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y9, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y10, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y11, %c1_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfUnsized
@@ -1625,18 +1625,18 @@ firrtl.module @ComparisonOfUnsized(
   firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y0, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y1, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y3, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y4, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y6, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y7, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y8, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y9, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y10, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y11, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y0, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y3, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y6, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y7, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y8, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y9, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y10, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y11, %c1_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfZeroAndNonzeroWidths
@@ -1722,30 +1722,30 @@ firrtl.module @ComparisonOfZeroAndNonzeroWidths(
   firrtl.connect %y21, %21 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y22, %22 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y23, %23 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %y0, %c1_ui1
-  // CHECK: firrtl.strictconnect %y1, %c1_ui1
-  // CHECK: firrtl.strictconnect %y2, %c1_ui1
-  // CHECK: firrtl.strictconnect %y3, %c1_ui1
-  // CHECK: firrtl.strictconnect %y4, %c0_ui1
-  // CHECK: firrtl.strictconnect %y5, %c1_ui1
-  // CHECK: firrtl.strictconnect %y6, %c0_ui1
-  // CHECK: firrtl.strictconnect %y7, %c1_ui1
-  // CHECK: firrtl.strictconnect %y8, %c1_ui1
-  // CHECK: firrtl.strictconnect %y9, %c0_ui1
-  // CHECK: firrtl.strictconnect %y10, %c1_ui1
-  // CHECK: firrtl.strictconnect %y11, %c0_ui1
-  // CHECK: firrtl.strictconnect %y12, %c0_ui1
-  // CHECK: firrtl.strictconnect %y13, %c0_ui1
-  // CHECK: firrtl.strictconnect %y14, %c0_ui1
-  // CHECK: firrtl.strictconnect %y15, %c0_ui1
-  // CHECK: firrtl.strictconnect %y16, %c1_ui1
-  // CHECK: firrtl.strictconnect %y17, %c0_ui1
-  // CHECK: firrtl.strictconnect %y18, %c1_ui1
-  // CHECK: firrtl.strictconnect %y19, %c0_ui1
-  // CHECK: firrtl.strictconnect %y20, %c0_ui1
-  // CHECK: firrtl.strictconnect %y21, %c1_ui1
-  // CHECK: firrtl.strictconnect %y22, %c0_ui1
-  // CHECK: firrtl.strictconnect %y23, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y0, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y1, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y2, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y3, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y4, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y5, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y6, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y7, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y8, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y9, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y10, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y11, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y12, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y13, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y14, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y15, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y16, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y17, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y18, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y19, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y20, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y21, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y22, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y23, %c1_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfZeroWidths
@@ -1804,18 +1804,18 @@ firrtl.module @ComparisonOfZeroWidths(
   firrtl.connect %y9, %9 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y10, %10 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %y0, %c1_ui1
-  // CHECK: firrtl.strictconnect %y1, %c1_ui1
-  // CHECK: firrtl.strictconnect %y2, %c0_ui1
-  // CHECK: firrtl.strictconnect %y3, %c0_ui1
-  // CHECK: firrtl.strictconnect %y4, %c1_ui1
-  // CHECK: firrtl.strictconnect %y5, %c1_ui1
-  // CHECK: firrtl.strictconnect %y6, %c0_ui1
-  // CHECK: firrtl.strictconnect %y7, %c0_ui1
-  // CHECK: firrtl.strictconnect %y8, %c1_ui1
-  // CHECK: firrtl.strictconnect %y9, %c1_ui1
-  // CHECK: firrtl.strictconnect %y10, %c0_ui1
-  // CHECK: firrtl.strictconnect %y11, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y0, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y1, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y2, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y3, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y4, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y5, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y6, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y7, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y8, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y9, %c1_ui1
+  // CHECK: firrtl.matchingconnect %y10, %c0_ui1
+  // CHECK: firrtl.matchingconnect %y11, %c0_ui1
 }
 
 // CHECK-LABEL: @ComparisonOfConsts
@@ -1901,34 +1901,34 @@ firrtl.module @ComparisonOfConsts(
   firrtl.connect %y17, %17 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y18, %18 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y19, %19 : !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %y0, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y1, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y2, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y3, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y4, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y0, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y1, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y2, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y3, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y4, %c0_ui1
 
-  // CHECK-NEXT: firrtl.strictconnect %y5, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y6, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y7, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y8, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y9, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y5, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y6, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y7, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y8, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y9, %c0_ui1
 
-  // CHECK-NEXT: firrtl.strictconnect %y10, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y11, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y12, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y13, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y14, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y10, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y11, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y12, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y13, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y14, %c1_ui1
 
-  // CHECK-NEXT: firrtl.strictconnect %y15, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y16, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y17, %c0_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y18, %c1_ui1
-  // CHECK-NEXT: firrtl.strictconnect %y19, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y15, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y16, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y17, %c0_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y18, %c1_ui1
+  // CHECK-NEXT: firrtl.matchingconnect %y19, %c1_ui1
 }
 
 // CHECK-LABEL: @zeroWidth(
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
-// CHECK-NEXT:   firrtl.strictconnect %out, %c0_ui2 : !firrtl.uint<2>
+// CHECK-NEXT:   firrtl.matchingconnect %out, %c0_ui2 : !firrtl.uint<2>
 // CHECK-NEXT:  }
 firrtl.module @zeroWidth(out %out: !firrtl.uint<2>, in %in1 : !firrtl.uint<0>, in %in2 : !firrtl.uint<0>) {
   %add = firrtl.add %in1, %in2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
@@ -1952,16 +1952,16 @@ firrtl.module @zeroWidth(out %out: !firrtl.uint<2>, in %in1 : !firrtl.uint<0>, i
   %ret8 = firrtl.cat %ret7, %and : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
   %ret9 = firrtl.cat %ret8, %or : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
   %ret10 = firrtl.cat %ret9, %xor : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
-  firrtl.strictconnect %out, %ret10 : !firrtl.uint<2>
+  firrtl.matchingconnect %out, %ret10 : !firrtl.uint<2>
 }
 
 // CHECK-LABEL: @zeroWidthOperand(
 // CHECK-NEXT:   %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
-// CHECK-NEXT:   firrtl.strictconnect %y6, %c0_ui0 : !firrtl.uint<0>
-// CHECK-NEXT:   firrtl.strictconnect %y8, %c0_ui0 : !firrtl.uint<0>
-// CHECK-NEXT:   firrtl.strictconnect %y9, %c0_ui0 : !firrtl.uint<0>
-// CHECK-NEXT:   firrtl.strictconnect %y12, %c0_ui0 : !firrtl.uint<0>
-// CHECK-NEXT:   firrtl.strictconnect %y14, %c0_ui0 : !firrtl.uint<0>
+// CHECK-NEXT:   firrtl.matchingconnect %y6, %c0_ui0 : !firrtl.uint<0>
+// CHECK-NEXT:   firrtl.matchingconnect %y8, %c0_ui0 : !firrtl.uint<0>
+// CHECK-NEXT:   firrtl.matchingconnect %y9, %c0_ui0 : !firrtl.uint<0>
+// CHECK-NEXT:   firrtl.matchingconnect %y12, %c0_ui0 : !firrtl.uint<0>
+// CHECK-NEXT:   firrtl.matchingconnect %y14, %c0_ui0 : !firrtl.uint<0>
 // CHECK-NEXT:  }
 firrtl.module @zeroWidthOperand(
   in %in0 : !firrtl.uint<0>,
@@ -1978,16 +1978,16 @@ firrtl.module @zeroWidthOperand(
   %dshlw1 = firrtl.dshlw %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
   %dshr1 = firrtl.dshr %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
 
-  firrtl.strictconnect %y6, %div1 : !firrtl.uint<0>
-  firrtl.strictconnect %y8, %rem1 : !firrtl.uint<0>
-  firrtl.strictconnect %y9, %rem2 : !firrtl.uint<0>
-  firrtl.strictconnect %y12, %dshlw1 : !firrtl.uint<0>
-  firrtl.strictconnect %y14, %dshr1 : !firrtl.uint<0>
+  firrtl.matchingconnect %y6, %div1 : !firrtl.uint<0>
+  firrtl.matchingconnect %y8, %rem1 : !firrtl.uint<0>
+  firrtl.matchingconnect %y9, %rem2 : !firrtl.uint<0>
+  firrtl.matchingconnect %y12, %dshlw1 : !firrtl.uint<0>
+  firrtl.matchingconnect %y14, %dshr1 : !firrtl.uint<0>
 }
 
 // CHECK-LABEL: @add_cst_prop1
 // CHECK-NEXT:   %c11_ui9 = firrtl.constant 11 : !firrtl.uint<9>
-// CHECK-NEXT:   firrtl.strictconnect %out_b, %c11_ui9 : !firrtl.uint<9>
+// CHECK-NEXT:   firrtl.matchingconnect %out_b, %c11_ui9 : !firrtl.uint<9>
 // CHECK-NEXT:  }
 firrtl.module @add_cst_prop1(out %out_b: !firrtl.uint<9>) {
   %c6_ui7 = firrtl.constant 6 : !firrtl.uint<7>
@@ -2000,7 +2000,7 @@ firrtl.module @add_cst_prop1(out %out_b: !firrtl.uint<9>) {
 
 // CHECK-LABEL: @add_cst_prop2
 // CHECK-NEXT:   %c-1_si9 = firrtl.constant -1 : !firrtl.sint<9>
-// CHECK-NEXT:   firrtl.strictconnect %out_b, %c-1_si9 : !firrtl.sint<9>
+// CHECK-NEXT:   firrtl.matchingconnect %out_b, %c-1_si9 : !firrtl.sint<9>
 // CHECK-NEXT:  }
 firrtl.module @add_cst_prop2(out %out_b: !firrtl.sint<9>) {
   %c6_ui7 = firrtl.constant -6 : !firrtl.sint<7>
@@ -2013,7 +2013,7 @@ firrtl.module @add_cst_prop2(out %out_b: !firrtl.sint<9>) {
 
 // CHECK-LABEL: @add_cst_prop3
 // CHECK-NEXT:   %c-2_si4 = firrtl.constant -2 : !firrtl.sint<4>
-// CHECK-NEXT:   firrtl.strictconnect %out_b, %c-2_si4 : !firrtl.sint<4>
+// CHECK-NEXT:   firrtl.matchingconnect %out_b, %c-2_si4 : !firrtl.sint<4>
 // CHECK-NEXT:  }
 firrtl.module @add_cst_prop3(out %out_b: !firrtl.sint<4>) {
   %c1_si2 = firrtl.constant -1 : !firrtl.sint<2>
@@ -2026,9 +2026,9 @@ firrtl.module @add_cst_prop3(out %out_b: !firrtl.sint<4>) {
 
 // CHECK-LABEL: @add_cst_prop5
 // CHECK: %[[pad:.+]] = firrtl.pad %tmp_a, 5
-// CHECK-NEXT: firrtl.strictconnect %out_b, %[[pad]]
+// CHECK-NEXT: firrtl.matchingconnect %out_b, %[[pad]]
 // CHECK-NEXT: %[[pad:.+]] = firrtl.pad %tmp_a, 5
-// CHECK-NEXT: firrtl.strictconnect %out_b, %[[pad]]
+// CHECK-NEXT: firrtl.matchingconnect %out_b, %[[pad]]
 firrtl.module @add_cst_prop5(out %out_b: !firrtl.uint<5>) {
   %tmp_a = firrtl.wire : !firrtl.uint<4>
   %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
@@ -2040,7 +2040,7 @@ firrtl.module @add_cst_prop5(out %out_b: !firrtl.uint<5>) {
 
 // CHECK-LABEL: @add_double
 // CHECK: %[[shl:.+]] = firrtl.shl %in, 1
-// CHECK-NEXT: firrtl.strictconnect %out, %[[shl]]
+// CHECK-NEXT: firrtl.matchingconnect %out, %[[shl]]
 firrtl.module @add_double(out %out: !firrtl.uint<5>, in %in: !firrtl.uint<4>) {
   %add = firrtl.add %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
   firrtl.connect %out, %add : !firrtl.uint<5>, !firrtl.uint<5>
@@ -2053,18 +2053,18 @@ firrtl.module @add_double(out %out: !firrtl.uint<5>, in %in: !firrtl.uint<4>) {
 // CHECK-NEXT: %[[pad2:.+]] = firrtl.pad %[[add2]], 7
 // CHECK-NEXT: %[[add3:.+]] = firrtl.add %in1, %in2
 // CHECK-NEXT: %[[pad3:.+]] = firrtl.pad %[[add3]], 7
-// CHECK-NEXT: firrtl.strictconnect %out1, %[[pad1]]
-// CHECK-NEXT: firrtl.strictconnect %out2, %[[pad2]]
-// CHECK-NEXT: firrtl.strictconnect %out3, %[[pad3]]
+// CHECK-NEXT: firrtl.matchingconnect %out1, %[[pad1]]
+// CHECK-NEXT: firrtl.matchingconnect %out2, %[[pad2]]
+// CHECK-NEXT: firrtl.matchingconnect %out3, %[[pad3]]
 firrtl.module @add_narrow(out %out1: !firrtl.uint<7>, out %out2: !firrtl.uint<7>, out %out3: !firrtl.uint<7>, in %in1: !firrtl.uint<4>, in %in2: !firrtl.uint<2>) {
   %t1 = firrtl.pad %in1, 6 : (!firrtl.uint<4>) -> !firrtl.uint<6>
   %t2 = firrtl.pad %in2, 6 : (!firrtl.uint<2>) -> !firrtl.uint<6>
   %add1 = firrtl.add %t1, %t2 : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<7>
   %add2 = firrtl.add %in1, %t2 : (!firrtl.uint<4>, !firrtl.uint<6>) -> !firrtl.uint<7>
   %add3 = firrtl.add %t1, %in2 : (!firrtl.uint<6>, !firrtl.uint<2>) -> !firrtl.uint<7>
-  firrtl.strictconnect %out1, %add1 : !firrtl.uint<7>
-  firrtl.strictconnect %out2, %add2 : !firrtl.uint<7>
-  firrtl.strictconnect %out3, %add3 : !firrtl.uint<7>
+  firrtl.matchingconnect %out1, %add1 : !firrtl.uint<7>
+  firrtl.matchingconnect %out2, %add2 : !firrtl.uint<7>
+  firrtl.matchingconnect %out3, %add3 : !firrtl.uint<7>
 }
 
 // CHECK-LABEL: @adds_narrow
@@ -2074,18 +2074,18 @@ firrtl.module @add_narrow(out %out1: !firrtl.uint<7>, out %out2: !firrtl.uint<7>
 // CHECK-NEXT: %[[pad2:.+]] = firrtl.pad %[[add2]], 7
 // CHECK-NEXT: %[[add3:.+]] = firrtl.add %in1, %in2
 // CHECK-NEXT: %[[pad3:.+]] = firrtl.pad %[[add3]], 7
-// CHECK-NEXT: firrtl.strictconnect %out1, %[[pad1]]
-// CHECK-NEXT: firrtl.strictconnect %out2, %[[pad2]]
-// CHECK-NEXT: firrtl.strictconnect %out3, %[[pad3]]
+// CHECK-NEXT: firrtl.matchingconnect %out1, %[[pad1]]
+// CHECK-NEXT: firrtl.matchingconnect %out2, %[[pad2]]
+// CHECK-NEXT: firrtl.matchingconnect %out3, %[[pad3]]
 firrtl.module @adds_narrow(out %out1: !firrtl.sint<7>, out %out2: !firrtl.sint<7>, out %out3: !firrtl.sint<7>, in %in1: !firrtl.sint<4>, in %in2: !firrtl.sint<2>) {
   %t1 = firrtl.pad %in1, 6 : (!firrtl.sint<4>) -> !firrtl.sint<6>
   %t2 = firrtl.pad %in2, 6 : (!firrtl.sint<2>) -> !firrtl.sint<6>
   %add1 = firrtl.add %t1, %t2 : (!firrtl.sint<6>, !firrtl.sint<6>) -> !firrtl.sint<7>
   %add2 = firrtl.add %in1, %t2 : (!firrtl.sint<4>, !firrtl.sint<6>) -> !firrtl.sint<7>
   %add3 = firrtl.add %t1, %in2 : (!firrtl.sint<6>, !firrtl.sint<2>) -> !firrtl.sint<7>
-  firrtl.strictconnect %out1, %add1 : !firrtl.sint<7>
-  firrtl.strictconnect %out2, %add2 : !firrtl.sint<7>
-  firrtl.strictconnect %out3, %add3 : !firrtl.sint<7>
+  firrtl.matchingconnect %out1, %add1 : !firrtl.sint<7>
+  firrtl.matchingconnect %out2, %add2 : !firrtl.sint<7>
+  firrtl.matchingconnect %out3, %add3 : !firrtl.sint<7>
 }
 
 // CHECK-LABEL: @sub_narrow
@@ -2095,18 +2095,18 @@ firrtl.module @adds_narrow(out %out1: !firrtl.sint<7>, out %out2: !firrtl.sint<7
 // CHECK-NEXT: %[[pad2:.+]] = firrtl.pad %[[add2]], 7 : (!firrtl.uint<5>) -> !firrtl.uint<7>
 // CHECK-NEXT: %[[add3:.+]] = firrtl.sub %in1, %in2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<5>
 // CHECK-NEXT: %[[pad3:.+]] = firrtl.pad %[[add3]], 7 : (!firrtl.uint<5>) -> !firrtl.uint<7>
-// CHECK-NEXT: firrtl.strictconnect %out1, %[[pad1]]
-// CHECK-NEXT: firrtl.strictconnect %out2, %[[pad2]]
-// CHECK-NEXT: firrtl.strictconnect %out3, %[[pad3]]
+// CHECK-NEXT: firrtl.matchingconnect %out1, %[[pad1]]
+// CHECK-NEXT: firrtl.matchingconnect %out2, %[[pad2]]
+// CHECK-NEXT: firrtl.matchingconnect %out3, %[[pad3]]
 firrtl.module @sub_narrow(out %out1: !firrtl.uint<7>, out %out2: !firrtl.uint<7>, out %out3: !firrtl.uint<7>, in %in1: !firrtl.uint<4>, in %in2: !firrtl.uint<2>) {
   %t1 = firrtl.pad %in1, 6 : (!firrtl.uint<4>) -> !firrtl.uint<6>
   %t2 = firrtl.pad %in2, 6 : (!firrtl.uint<2>) -> !firrtl.uint<6>
   %add1 = firrtl.sub %t1, %t2 : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<7>
   %add2 = firrtl.sub %in1, %t2 : (!firrtl.uint<4>, !firrtl.uint<6>) -> !firrtl.uint<7>
   %add3 = firrtl.sub %t1, %in2 : (!firrtl.uint<6>, !firrtl.uint<2>) -> !firrtl.uint<7>
-  firrtl.strictconnect %out1, %add1 : !firrtl.uint<7>
-  firrtl.strictconnect %out2, %add2 : !firrtl.uint<7>
-  firrtl.strictconnect %out3, %add3 : !firrtl.uint<7>
+  firrtl.matchingconnect %out1, %add1 : !firrtl.uint<7>
+  firrtl.matchingconnect %out2, %add2 : !firrtl.uint<7>
+  firrtl.matchingconnect %out3, %add3 : !firrtl.uint<7>
 }
 
 // CHECK-LABEL: @subs_narrow
@@ -2116,23 +2116,23 @@ firrtl.module @sub_narrow(out %out1: !firrtl.uint<7>, out %out2: !firrtl.uint<7>
 // CHECK-NEXT: %[[pad2:.+]] = firrtl.pad %[[add2]], 7 : (!firrtl.sint<5>) -> !firrtl.sint<7>
 // CHECK-NEXT: %[[add3:.+]] = firrtl.sub %in1, %in2 : (!firrtl.sint<4>, !firrtl.sint<2>) -> !firrtl.sint<5>
 // CHECK-NEXT: %[[pad3:.+]] = firrtl.pad %[[add3]], 7 : (!firrtl.sint<5>) -> !firrtl.sint<7>
-// CHECK-NEXT: firrtl.strictconnect %out1, %[[pad1]]
-// CHECK-NEXT: firrtl.strictconnect %out2, %[[pad2]]
-// CHECK-NEXT: firrtl.strictconnect %out3, %[[pad3]]
+// CHECK-NEXT: firrtl.matchingconnect %out1, %[[pad1]]
+// CHECK-NEXT: firrtl.matchingconnect %out2, %[[pad2]]
+// CHECK-NEXT: firrtl.matchingconnect %out3, %[[pad3]]
 firrtl.module @subs_narrow(out %out1: !firrtl.sint<7>, out %out2: !firrtl.sint<7>, out %out3: !firrtl.sint<7>, in %in1: !firrtl.sint<4>, in %in2: !firrtl.sint<2>) {
   %t1 = firrtl.pad %in1, 6 : (!firrtl.sint<4>) -> !firrtl.sint<6>
   %t2 = firrtl.pad %in2, 6 : (!firrtl.sint<2>) -> !firrtl.sint<6>
   %add1 = firrtl.sub %t1, %t2 : (!firrtl.sint<6>, !firrtl.sint<6>) -> !firrtl.sint<7>
   %add2 = firrtl.sub %in1, %t2 : (!firrtl.sint<4>, !firrtl.sint<6>) -> !firrtl.sint<7>
   %add3 = firrtl.sub %t1, %in2 : (!firrtl.sint<6>, !firrtl.sint<2>) -> !firrtl.sint<7>
-  firrtl.strictconnect %out1, %add1 : !firrtl.sint<7>
-  firrtl.strictconnect %out2, %add2 : !firrtl.sint<7>
-  firrtl.strictconnect %out3, %add3 : !firrtl.sint<7>
+  firrtl.matchingconnect %out1, %add1 : !firrtl.sint<7>
+  firrtl.matchingconnect %out2, %add2 : !firrtl.sint<7>
+  firrtl.matchingconnect %out3, %add3 : !firrtl.sint<7>
 }
 
 // CHECK-LABEL: @sub_cst_prop1
 // CHECK-NEXT:      %c1_ui9 = firrtl.constant 1 : !firrtl.uint<9>
-// CHECK-NEXT:      firrtl.strictconnect %out_b, %c1_ui9 : !firrtl.uint<9>
+// CHECK-NEXT:      firrtl.matchingconnect %out_b, %c1_ui9 : !firrtl.uint<9>
 // CHECK-NEXT:  }
 firrtl.module @sub_cst_prop1(out %out_b: !firrtl.uint<9>) {
   %c6_ui7 = firrtl.constant 6 : !firrtl.uint<7>
@@ -2145,7 +2145,7 @@ firrtl.module @sub_cst_prop1(out %out_b: !firrtl.uint<9>) {
 
 // CHECK-LABEL: @sub_cst_prop2
 // CHECK-NEXT:      %c-11_si9 = firrtl.constant -11 : !firrtl.sint<9>
-// CHECK-NEXT:      firrtl.strictconnect %out_b, %c-11_si9 : !firrtl.sint<9>
+// CHECK-NEXT:      firrtl.matchingconnect %out_b, %c-11_si9 : !firrtl.sint<9>
 // CHECK-NEXT:  }
 firrtl.module @sub_cst_prop2(out %out_b: !firrtl.sint<9>) {
   %c6_ui7 = firrtl.constant -6 : !firrtl.sint<7>
@@ -2158,7 +2158,7 @@ firrtl.module @sub_cst_prop2(out %out_b: !firrtl.sint<9>) {
 
 // CHECK-LABEL: @sub_double
 // CHECK: %[[cst:.+]] = firrtl.constant 0 : !firrtl.uint<5>
-// CHECK-NEXT: firrtl.strictconnect %out, %[[cst]]
+// CHECK-NEXT: firrtl.matchingconnect %out, %[[cst]]
 firrtl.module @sub_double(out %out: !firrtl.uint<5>, in %in: !firrtl.uint<4>) {
   %add = firrtl.sub %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
   firrtl.connect %out, %add : !firrtl.uint<5>, !firrtl.uint<5>
@@ -2166,7 +2166,7 @@ firrtl.module @sub_double(out %out: !firrtl.uint<5>, in %in: !firrtl.uint<4>) {
 
 // CHECK-LABEL: @mul_cst_prop1
 // CHECK-NEXT:      %c30_ui15 = firrtl.constant 30 : !firrtl.uint<15>
-// CHECK-NEXT:      firrtl.strictconnect %out_b, %c30_ui15 : !firrtl.uint<15>
+// CHECK-NEXT:      firrtl.matchingconnect %out_b, %c30_ui15 : !firrtl.uint<15>
 // CHECK-NEXT:  }
 firrtl.module @mul_cst_prop1(out %out_b: !firrtl.uint<15>) {
   %c6_ui7 = firrtl.constant 6 : !firrtl.uint<7>
@@ -2179,7 +2179,7 @@ firrtl.module @mul_cst_prop1(out %out_b: !firrtl.uint<15>) {
 
 // CHECK-LABEL: @mul_cst_prop2
 // CHECK-NEXT:      %c-30_si15 = firrtl.constant -30 : !firrtl.sint<15>
-// CHECK-NEXT:      firrtl.strictconnect %out_b, %c-30_si15 : !firrtl.sint<15>
+// CHECK-NEXT:      firrtl.matchingconnect %out_b, %c-30_si15 : !firrtl.sint<15>
 // CHECK-NEXT:  }
 firrtl.module @mul_cst_prop2(out %out_b: !firrtl.sint<15>) {
   %c6_ui7 = firrtl.constant -6 : !firrtl.sint<7>
@@ -2192,7 +2192,7 @@ firrtl.module @mul_cst_prop2(out %out_b: !firrtl.sint<15>) {
 
 // CHECK-LABEL: @mul_cst_prop3
 // CHECK-NEXT:      %c30_si15 = firrtl.constant 30 : !firrtl.sint<15>
-// CHECK-NEXT:      firrtl.strictconnect %out_b, %c30_si15 : !firrtl.sint<15>
+// CHECK-NEXT:      firrtl.matchingconnect %out_b, %c30_si15 : !firrtl.sint<15>
 // CHECK-NEXT:  }
 firrtl.module @mul_cst_prop3(out %out_b: !firrtl.sint<15>) {
   %c6_ui7 = firrtl.constant -6 : !firrtl.sint<7>
@@ -2256,8 +2256,8 @@ firrtl.module @MuxShorten(
   // CHECK: %[[rem:.*]] = firrtl.mux(%c2, %[[rem1]], %d6)
   // CHECK: %[[n2:.*]] = firrtl.mux(%c2, %d5, %d6)
   // CHECK: %[[prim:.*]] = firrtl.mux(%c1, %[[n1]], %[[n2]])
-  // CHECK: firrtl.strictconnect %foo, %[[prim]]
-  // CHECK: firrtl.strictconnect %foo2, %[[rem]]
+  // CHECK: firrtl.matchingconnect %foo, %[[prim]]
+  // CHECK: firrtl.matchingconnect %foo2, %[[rem]]
 }
 
 
@@ -2268,11 +2268,11 @@ firrtl.module @RegresetToReg(in %clock: !firrtl.clock, in %dummy : !firrtl.uint<
   %zero_asyncreset = firrtl.asAsyncReset %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
   %one_asyncreset = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
   // CHECK: %bar1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %foo2, %dummy : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %foo2, %dummy : !firrtl.uint<1>
   %bar1 = firrtl.regreset %clock, %zero_asyncreset, %dummy : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
   %bar2 = firrtl.regreset %clock, %one_asyncreset, %dummy : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
 
-  firrtl.strictconnect %bar2, %bar1 : !firrtl.uint<1> // Force a use to trigger a crash on a sink replacement
+  firrtl.matchingconnect %bar2, %bar1 : !firrtl.uint<1> // Force a use to trigger a crash on a sink replacement
 
   firrtl.connect %foo1, %bar1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %foo2, %bar2 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -2306,7 +2306,7 @@ firrtl.module @MuxInvalidTypeOpt(in %in : !firrtl.uint<1>, out %out : !firrtl.ui
 // CHECK: firrtl.mux(%in, %c1_ui4, %c7_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
 
 // CHECK-LABEL: firrtl.module @issue1100
-// CHECK: firrtl.strictconnect %tmp62, %c1_ui1
+// CHECK: firrtl.matchingconnect %tmp62, %c1_ui1
   firrtl.module @issue1100(out %tmp62: !firrtl.uint<1>) {
     %c-1_si2 = firrtl.constant -1 : !firrtl.sint<2>
     %0 = firrtl.orr %c-1_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
@@ -2324,7 +2324,7 @@ firrtl.module @issue1116(out %z: !firrtl.uint<1>) {
   %c844336_ui = firrtl.constant 844336 : !firrtl.uint
   %c161_ui8 = firrtl.constant 161 : !firrtl.uint<8>
   %0 = firrtl.leq %c844336_ui, %c161_ui8 : (!firrtl.uint, !firrtl.uint<8>) -> !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %z, %c0_ui1
+  // CHECK: firrtl.matchingconnect %z, %c0_ui1
   firrtl.connect %z, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -2346,7 +2346,7 @@ firrtl.module @issue1118(out %z0: !firrtl.uint, out %z1: !firrtl.sint) {
 // CHECK-LABEL: firrtl.module @issue1139
 firrtl.module @issue1139(out %z: !firrtl.uint<4>) {
   // CHECK-NEXT: %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
-  // CHECK-NEXT: firrtl.strictconnect %z, %c0_ui4 : !firrtl.uint<4>
+  // CHECK-NEXT: firrtl.matchingconnect %z, %c0_ui4 : !firrtl.uint<4>
   %c4_ui4 = firrtl.constant 4 : !firrtl.uint<4>
   %c674_ui = firrtl.constant 674 : !firrtl.uint
   %0 = firrtl.dshr %c4_ui4, %c674_ui : (!firrtl.uint<4>, !firrtl.uint) -> !firrtl.uint<4>
@@ -2431,8 +2431,8 @@ firrtl.module @PadMuxOperands(
 firrtl.module @regsyncreset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %foo : !firrtl.uint<2>, out %bar: !firrtl.uint<2>) attributes {firrtl.random_init_width = 2 : ui64} {
   // CHECK: %[[const:.*]] = firrtl.constant 1
   // CHECK-NEXT: firrtl.regreset %clock, %reset, %[[const]] {firrtl.random_init_end = 1 : ui64, firrtl.random_init_start = 0 : ui64}
-  // CHECK-NEXT:  firrtl.strictconnect %bar, %d : !firrtl.uint<2>
-  // CHECK-NEXT:  firrtl.strictconnect %d, %foo : !firrtl.uint<2>
+  // CHECK-NEXT:  firrtl.matchingconnect %bar, %d : !firrtl.uint<2>
+  // CHECK-NEXT:  firrtl.matchingconnect %d, %foo : !firrtl.uint<2>
   // CHECK-NEXT: }
   %d = firrtl.reg %clock {firrtl.random_init_end = 1 : ui64, firrtl.random_init_start = 0 : ui64} : !firrtl.clock, !firrtl.uint<2>
   firrtl.connect %bar, %d : !firrtl.uint<2>, !firrtl.uint<2>
@@ -2467,14 +2467,14 @@ firrtl.module @dshifts_to_ishifts(in %a_in: !firrtl.sint<58>,
   // CHECK: %0 = firrtl.bits %a_in 57 to 4 : (!firrtl.sint<58>) -> !firrtl.uint<54>
   // CHECK: %1 = firrtl.asSInt %0 : (!firrtl.uint<54>) -> !firrtl.sint<54>
   // CHECK: %2 = firrtl.pad %1, 58 : (!firrtl.sint<54>) -> !firrtl.sint<58>
-  // CHECK: firrtl.strictconnect %a_out, %2 : !firrtl.sint<58>
+  // CHECK: firrtl.matchingconnect %a_out, %2 : !firrtl.sint<58>
   %c4_ui10 = firrtl.constant 4 : !firrtl.uint<10>
   %0 = firrtl.dshr %a_in, %c4_ui10 : (!firrtl.sint<58>, !firrtl.uint<10>) -> !firrtl.sint<58>
   firrtl.connect %a_out, %0 : !firrtl.sint<58>, !firrtl.sint<58>
 
   // CHECK: %3 = firrtl.shl %b_in, 4 : (!firrtl.uint<8>) -> !firrtl.uint<12>
   // CHECK: %4 = firrtl.pad %3, 23 : (!firrtl.uint<12>) -> !firrtl.uint<23>
-  // CHECK: firrtl.strictconnect %b_out, %4 : !firrtl.uint<23>
+  // CHECK: firrtl.matchingconnect %b_out, %4 : !firrtl.uint<23>
   %c4_ui4 = firrtl.constant 4 : !firrtl.uint<4>
   %1 = firrtl.dshl %b_in, %c4_ui4 : (!firrtl.uint<8>, !firrtl.uint<4>) -> !firrtl.uint<23>
   firrtl.connect %b_out, %1 : !firrtl.uint<23>, !firrtl.uint<23>
@@ -2482,7 +2482,7 @@ firrtl.module @dshifts_to_ishifts(in %a_in: !firrtl.sint<58>,
   // CHECK: %5 = firrtl.bits %c_in 57 to 57 : (!firrtl.sint<58>) -> !firrtl.uint<1>
   // CHECK: %6 = firrtl.asSInt %5 : (!firrtl.uint<1>) -> !firrtl.sint<1>
   // CHECK: %7 = firrtl.pad %6, 58 : (!firrtl.sint<1>) -> !firrtl.sint<58>
-  // CHECK: firrtl.strictconnect %c_out, %7 : !firrtl.sint<58>
+  // CHECK: firrtl.matchingconnect %c_out, %7 : !firrtl.sint<58>
   %c438_ui10 = firrtl.constant 438 : !firrtl.uint<10>
   %2 = firrtl.dshr %c_in, %c438_ui10 : (!firrtl.sint<58>, !firrtl.uint<10>) -> !firrtl.sint<58>
   firrtl.connect %c_out, %2 : !firrtl.sint<58>, !firrtl.sint<58>
@@ -2497,19 +2497,19 @@ firrtl.module @constReg(in %clock: !firrtl.clock,
   firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:  %[[C11:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK:  firrtl.strictconnect %out, %[[C11]]
+  // CHECK:  firrtl.matchingconnect %out, %[[C11]]
 }
 
 // CHECK-LABEL: firrtl.module @SingleConnectInWhen
 firrtl.module @SingleConnectInWhen(in %p1: !firrtl.uint<8>, in %p2: !firrtl.uint<1>, out %out: !firrtl.uint<8>) {
   %w = firrtl.wire : !firrtl.uint<8>
   // CHECK: firrtl.when
-  // CHECK-NEXT: firrtl.strictconnect %w, %p1
-  // CHECK: firrtl.strictconnect %out, %w
+  // CHECK-NEXT: firrtl.matchingconnect %w, %p1
+  // CHECK: firrtl.matchingconnect %out, %w
   firrtl.when %p2 : !firrtl.uint<1> {
-    firrtl.strictconnect %w, %p1 : !firrtl.uint<8>
+    firrtl.matchingconnect %w, %p1 : !firrtl.uint<8>
   }
-  firrtl.strictconnect %out, %w : !firrtl.uint<8>
+  firrtl.matchingconnect %out, %w : !firrtl.uint<8>
 }
 
 // CHECK-LABEL: firrtl.module @constReg
@@ -2526,7 +2526,7 @@ firrtl.module @constReg2(in %clock: !firrtl.clock,
   %2 = firrtl.xor %r1, %r2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:  %[[C12:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK:  firrtl.strictconnect %out, %[[C12]]
+  // CHECK:  firrtl.matchingconnect %out, %[[C12]]
 }
 
 // CHECK-LABEL: firrtl.module @constReg3
@@ -2536,7 +2536,7 @@ firrtl.module @constReg3(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C14:.+]] = firrtl.constant 11
-  // CHECK: firrtl.strictconnect %z, %[[C14]]
+  // CHECK: firrtl.matchingconnect %z, %[[C14]]
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
@@ -2548,7 +2548,7 @@ firrtl.module @constReg4(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C13:.+]] = firrtl.constant 11
-  // CHECK: firrtl.strictconnect %z, %[[C13]]
+  // CHECK: firrtl.matchingconnect %z, %[[C13]]
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
@@ -2561,7 +2561,7 @@ firrtl.module @constReg6(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C13:.+]] = firrtl.constant 11
-  // CHECK: firrtl.strictconnect %z, %[[C13]]
+  // CHECK: firrtl.matchingconnect %z, %[[C13]]
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
@@ -2573,7 +2573,7 @@ firrtl.module @constReg5(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
   // CHECK: %0 = firrtl.mux(%cond, %c11_ui8, %r)
   %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
-  // CHECK: firrtl.strictconnect %r, %0
+  // CHECK: firrtl.matchingconnect %r, %0
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
 }
@@ -2607,13 +2607,13 @@ firrtl.module @constReg8(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, o
 // CHECK-LABEL: @constReg9
 firrtl.module @constReg9(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %en_0: !firrtl.uint<1>, in %en_1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
   // CHECK-NOT: firrtl.reg
-  // CHECK: firrtl.strictconnect %out, %c0_ui1
+  // CHECK: firrtl.matchingconnect %out, %c0_ui1
   %r = firrtl.reg %clock {firrtl.random_init_start = 0 : ui64} : !firrtl.clock, !firrtl.uint<1>
   %0 = firrtl.and %en_0, %en_1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %1 = firrtl.mux(%0, %c0_ui1, %r) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.connect %r, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  firrtl.strictconnect %out, %r : !firrtl.uint<1>
+  firrtl.matchingconnect %out, %r : !firrtl.uint<1>
 }
 
 firrtl.module @BitCast(out %o:!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>> ) {
@@ -2622,7 +2622,7 @@ firrtl.module @BitCast(out %o:!firrtl.bundle<valid: uint<1>, ready: uint<1>, dat
   %b2 = firrtl.bitcast %b : (!firrtl.uint<3>) -> (!firrtl.uint<3>)
   %c = firrtl.bitcast %b2 :  (!firrtl.uint<3>)-> (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>)
   firrtl.connect %o, %c : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>, !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>
-  // CHECK: firrtl.strictconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>
+  // CHECK: firrtl.matchingconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<1>>
 }
 
 // Check that we can create bundles directly
@@ -2631,11 +2631,11 @@ firrtl.module @MergeBundle(out %o:!firrtl.bundle<valid: uint<1>, ready: uint<1>>
   %a = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
   %a0 = firrtl.subfield %a[valid] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
   %a1 = firrtl.subfield %a[ready] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
-  firrtl.strictconnect %a0, %i : !firrtl.uint<1>
-  firrtl.strictconnect %a1, %i : !firrtl.uint<1>
-  firrtl.strictconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+  firrtl.matchingconnect %a0, %i : !firrtl.uint<1>
+  firrtl.matchingconnect %a1, %i : !firrtl.uint<1>
+  firrtl.matchingconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
   // CHECK: %0 = firrtl.bundlecreate %i, %i
-  // CHECK-NEXT: firrtl.strictconnect %a, %0
+  // CHECK-NEXT: firrtl.matchingconnect %a, %0
 }
 
 // Check that we can create vectors directly
@@ -2645,12 +2645,12 @@ firrtl.module @MergeVector(out %o:!firrtl.vector<uint<1>, 3>, in %i:!firrtl.uint
   %a0 = firrtl.subindex %a[0] : !firrtl.vector<uint<1>, 3>
   %a1 = firrtl.subindex %a[1] : !firrtl.vector<uint<1>, 3>
   %a2 = firrtl.subindex %a[2] : !firrtl.vector<uint<1>, 3>
-  firrtl.strictconnect %a0, %i : !firrtl.uint<1>
-  firrtl.strictconnect %a1, %i : !firrtl.uint<1>
-  firrtl.strictconnect %a2, %i : !firrtl.uint<1>
-  firrtl.strictconnect %o, %a : !firrtl.vector<uint<1>, 3>
+  firrtl.matchingconnect %a0, %i : !firrtl.uint<1>
+  firrtl.matchingconnect %a1, %i : !firrtl.uint<1>
+  firrtl.matchingconnect %a2, %i : !firrtl.uint<1>
+  firrtl.matchingconnect %o, %a : !firrtl.vector<uint<1>, 3>
   // CHECK: %0 = firrtl.vectorcreate %i, %i, %i
-  // CHECK-NEXT: firrtl.strictconnect %a, %0
+  // CHECK-NEXT: firrtl.matchingconnect %a, %0
 }
 
 // Check that we can create vectors directly
@@ -2667,17 +2667,17 @@ firrtl.module @MergeAgg(out %o: !firrtl.vector<bundle<valid: uint<1>, ready: uin
   %a11 = firrtl.subfield %a1[ready] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
   %a20 = firrtl.subfield %a2[valid] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
   %a21 = firrtl.subfield %a2[ready] : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
-  firrtl.strictconnect %a00, %c : !firrtl.uint<1>
-  firrtl.strictconnect %a01, %c : !firrtl.uint<1>
-  firrtl.strictconnect %a10, %c : !firrtl.uint<1>
-  firrtl.strictconnect %a11, %c : !firrtl.uint<1>
-  firrtl.strictconnect %a20, %c : !firrtl.uint<1>
-  firrtl.strictconnect %a21, %c : !firrtl.uint<1>
-  firrtl.strictconnect %o, %a :  !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+  firrtl.matchingconnect %a00, %c : !firrtl.uint<1>
+  firrtl.matchingconnect %a01, %c : !firrtl.uint<1>
+  firrtl.matchingconnect %a10, %c : !firrtl.uint<1>
+  firrtl.matchingconnect %a11, %c : !firrtl.uint<1>
+  firrtl.matchingconnect %a20, %c : !firrtl.uint<1>
+  firrtl.matchingconnect %a21, %c : !firrtl.uint<1>
+  firrtl.matchingconnect %o, %a :  !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
 // CHECK: [0 : ui1, 0 : ui1], [0 : ui1, 0 : ui1], [0 : ui1, 0 : ui1]] : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
 // CHECK-NEXT: %a = firrtl.wire   : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
-// CHECK-NEXT: firrtl.strictconnect %o, %a : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
-// CHECK-NEXT: firrtl.strictconnect %a, %0 : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+// CHECK-NEXT: firrtl.matchingconnect %o, %a : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
+// CHECK-NEXT: firrtl.matchingconnect %a, %0 : !firrtl.vector<bundle<valid: uint<1>, ready: uint<1>>, 3>
 }
 
 // Don't collect connections in a when block.
@@ -2688,9 +2688,9 @@ firrtl.module @DontMergeVector(out %o:!firrtl.vector<uint<1>, 1>, in %i:!firrtl.
   firrtl.when %i : !firrtl.uint<1> {
     firrtl.connect %0, %i : !firrtl.uint<1>, !firrtl.uint<1>
   }
-  firrtl.strictconnect %o, %a : !firrtl.vector<uint<1>, 1>
+  firrtl.matchingconnect %o, %a : !firrtl.vector<uint<1>, 1>
   // CHECK:      firrtl.when %i
-  // CHECK-NEXT: firrtl.strictconnect %0, %i
+  // CHECK-NEXT: firrtl.matchingconnect %0, %i
 }
 
 // TODO: Move to an appropriate place
@@ -2698,7 +2698,7 @@ firrtl.module @DontMergeVector(out %o:!firrtl.vector<uint<1>, 1>, in %i:!firrtl.
 // CHECK-LABEL: @Issue2197
 firrtl.module @Issue2197(in %clock: !firrtl.clock, out %x: !firrtl.uint<2>) {
 //  // COM: CHECK: [[ZERO:%.+]] = firrtl.constant 0 : !firrtl.uint<2>
-//  // COM: CHECK-NEXT: firrtl.strictconnect %x, [[ZERO]] : !firrtl.uint<2>
+//  // COM: CHECK-NEXT: firrtl.matchingconnect %x, [[ZERO]] : !firrtl.uint<2>
 //  %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
 //  %_reg = firrtl.reg droppable_name %clock : !firrtl.clock, !firrtl.uint<2>
 //  %0 = firrtl.pad %invalid_ui1, 2 : (!firrtl.uint<1>) -> !firrtl.uint<2>
@@ -2715,7 +2715,7 @@ firrtl.module @ZeroWidthAdd(out %a: !firrtl.sint<1>) {
   %1 = firrtl.add %0, %zw : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.sint<1>
   firrtl.connect %a, %1 : !firrtl.sint<1>, !firrtl.sint<1>
   // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<1>
-  // CHECK-NEXT: firrtl.strictconnect %a, %[[zero]]
+  // CHECK-NEXT: firrtl.matchingconnect %a, %[[zero]]
 }
 
 // CHECK-LABEL: @ZeroWidthDshr
@@ -2724,7 +2724,7 @@ firrtl.module @ZeroWidthDshr(in %a: !firrtl.sint<0>, out %b: !firrtl.sint<0>) {
   %0 = firrtl.dshr %a, %zw : (!firrtl.sint<0>, !firrtl.uint<0>) -> !firrtl.sint<0>
   firrtl.connect %b, %0 : !firrtl.sint<0>, !firrtl.sint<0>
   // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<0>
-  // CHECK-NEXT: firrtl.strictconnect %b, %[[zero]]
+  // CHECK-NEXT: firrtl.matchingconnect %b, %[[zero]]
 }
 
 // CHECK-LABEL: @ZeroWidthPad
@@ -2733,7 +2733,7 @@ firrtl.module @ZeroWidthPad(out %b: !firrtl.sint<1>) {
   %0 = firrtl.pad %zw, 1 : (!firrtl.sint<0>) -> !firrtl.sint<1>
   firrtl.connect %b, %0 : !firrtl.sint<1>, !firrtl.sint<1>
   // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<1>
-  // CHECK-NEXT: firrtl.strictconnect %b, %[[zero]]
+  // CHECK-NEXT: firrtl.matchingconnect %b, %[[zero]]
 }
 
 // CHECK-LABEL: @ZeroWidthCat
@@ -2743,7 +2743,7 @@ firrtl.module @ZeroWidthCat(out %a: !firrtl.uint<1>) {
   %0 = firrtl.cat %one, %zw : (!firrtl.uint<1>, !firrtl.uint<0>) -> !firrtl.uint<1>
   firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:      %[[one:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-  // CHECK-NEXT: firrtl.strictconnect %a, %[[one]]
+  // CHECK-NEXT: firrtl.matchingconnect %a, %[[one]]
 }
 
 //TODO: Move to an appropriate place
@@ -2755,7 +2755,7 @@ firrtl.module @Issue2251(out %o: !firrtl.sint<15>) {
 //  %0 = firrtl.pad %invalid_si1, 15 : (!firrtl.sint<1>) -> !firrtl.sint<15>
 //  firrtl.connect %o, %0 : !firrtl.sint<15>, !firrtl.sint<15>
 //  // COM: CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<15>
-//  // COM: CHECK-NEXT: firrtl.strictconnect %o, %[[zero]]
+//  // COM: CHECK-NEXT: firrtl.matchingconnect %o, %[[zero]]
 }
 
 // Issue mentioned in #2289
@@ -2772,7 +2772,7 @@ firrtl.module @Issue2289(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, o
   // CHECK-NEXT: %[[neg:.+]] = firrtl.neg %[[dshl]]
   // CHECK-NEXT: %[[pad:.+]] = firrtl.pad %[[neg]], 5
   // CHECK-NEXT: %[[cast:.+]] = firrtl.asUInt %[[pad]]
-  // CHECK-NEXT: firrtl.strictconnect %out, %[[cast]]
+  // CHECK-NEXT: firrtl.matchingconnect %out, %[[cast]]
 }
 
 // Issue mentioned in #2291
@@ -2790,7 +2790,7 @@ firrtl.module @Issue3043(out %a: !firrtl.vector<uint<5>, 3>) {
   %_b = firrtl.wire  : !firrtl.vector<uint<5>, 3>
   %b = firrtl.node sym @b %_b  : !firrtl.vector<uint<5>, 3>
   %invalid = firrtl.invalidvalue : !firrtl.vector<uint<5>, 3>
-  firrtl.strictconnect %_b, %invalid : !firrtl.vector<uint<5>, 3>
+  firrtl.matchingconnect %_b, %invalid : !firrtl.vector<uint<5>, 3>
   firrtl.connect %a, %_b : !firrtl.vector<uint<5>, 3>, !firrtl.vector<uint<5>, 3>
 }
 
@@ -2827,56 +2827,56 @@ firrtl.module @Issue2514(
   %4 = firrtl.geq %t, %s : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
   %5 = firrtl.geq %u, %v : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
   %6 = firrtl.geq %v, %u : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  firrtl.strictconnect %geq_0, %3 : !firrtl.uint<1>
-  firrtl.strictconnect %geq_1, %4 : !firrtl.uint<1>
-  firrtl.strictconnect %geq_2, %5 : !firrtl.uint<1>
-  firrtl.strictconnect %geq_3, %6 : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %geq_0, %[[one_i1]]
-  // CHECK: firrtl.strictconnect %geq_1, %[[one_i1]]
-  // CHECK: firrtl.strictconnect %geq_2, %[[one_i1]]
-  // CHECK: firrtl.strictconnect %geq_3, %[[one_i1]]
+  firrtl.matchingconnect %geq_0, %3 : !firrtl.uint<1>
+  firrtl.matchingconnect %geq_1, %4 : !firrtl.uint<1>
+  firrtl.matchingconnect %geq_2, %5 : !firrtl.uint<1>
+  firrtl.matchingconnect %geq_3, %6 : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %geq_0, %[[one_i1]]
+  // CHECK: firrtl.matchingconnect %geq_1, %[[one_i1]]
+  // CHECK: firrtl.matchingconnect %geq_2, %[[one_i1]]
+  // CHECK: firrtl.matchingconnect %geq_3, %[[one_i1]]
 
   // gt(x, y) -> 0 when x and y are both zero-width (and here, one is a constant)
   %7 = firrtl.gt %s, %t : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
   %8 = firrtl.gt %t, %s : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
   %9 = firrtl.gt %u, %v : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
   %10 = firrtl.gt %v, %u : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  firrtl.strictconnect %gt_0, %7 : !firrtl.uint<1>
-  firrtl.strictconnect %gt_1, %8 : !firrtl.uint<1>
-  firrtl.strictconnect %gt_2, %9 : !firrtl.uint<1>
-  firrtl.strictconnect %gt_3, %10 : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %gt_0, %[[zero_i1]]
-  // CHECK: firrtl.strictconnect %gt_1, %[[zero_i1]]
-  // CHECK: firrtl.strictconnect %gt_2, %[[zero_i1]]
-  // CHECK: firrtl.strictconnect %gt_3, %[[zero_i1]]
+  firrtl.matchingconnect %gt_0, %7 : !firrtl.uint<1>
+  firrtl.matchingconnect %gt_1, %8 : !firrtl.uint<1>
+  firrtl.matchingconnect %gt_2, %9 : !firrtl.uint<1>
+  firrtl.matchingconnect %gt_3, %10 : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %gt_0, %[[zero_i1]]
+  // CHECK: firrtl.matchingconnect %gt_1, %[[zero_i1]]
+  // CHECK: firrtl.matchingconnect %gt_2, %[[zero_i1]]
+  // CHECK: firrtl.matchingconnect %gt_3, %[[zero_i1]]
 
   // lt(x, y) -> 0 when x and y are both zero-width (and here, one is a constant)
   %11 = firrtl.lt %s, %t : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
   %12 = firrtl.lt %t, %s : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
   %13 = firrtl.lt %u, %v : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
   %14 = firrtl.lt %v, %u : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  firrtl.strictconnect %lt_0, %11 : !firrtl.uint<1>
-  firrtl.strictconnect %lt_1, %12 : !firrtl.uint<1>
-  firrtl.strictconnect %lt_2, %13 : !firrtl.uint<1>
-  firrtl.strictconnect %lt_3, %14 : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %lt_0, %[[zero_i1]]
-  // CHECK: firrtl.strictconnect %lt_1, %[[zero_i1]]
-  // CHECK: firrtl.strictconnect %lt_2, %[[zero_i1]]
-  // CHECK: firrtl.strictconnect %lt_3, %[[zero_i1]]
+  firrtl.matchingconnect %lt_0, %11 : !firrtl.uint<1>
+  firrtl.matchingconnect %lt_1, %12 : !firrtl.uint<1>
+  firrtl.matchingconnect %lt_2, %13 : !firrtl.uint<1>
+  firrtl.matchingconnect %lt_3, %14 : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %lt_0, %[[zero_i1]]
+  // CHECK: firrtl.matchingconnect %lt_1, %[[zero_i1]]
+  // CHECK: firrtl.matchingconnect %lt_2, %[[zero_i1]]
+  // CHECK: firrtl.matchingconnect %lt_3, %[[zero_i1]]
 
   // leq(x, y) -> 1 when x and y are both zero-width (and here, one is a constant)
   %15 = firrtl.leq %s, %t : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
   %16 = firrtl.leq %t, %s : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
   %17 = firrtl.leq %u, %v : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
   %18 = firrtl.leq %v, %u : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  firrtl.strictconnect %leq_0, %15 : !firrtl.uint<1>
-  firrtl.strictconnect %leq_1, %16 : !firrtl.uint<1>
-  firrtl.strictconnect %leq_2, %17 : !firrtl.uint<1>
-  firrtl.strictconnect %leq_3, %18 : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %leq_0, %[[one_i1]]
-  // CHECK: firrtl.strictconnect %leq_1, %[[one_i1]]
-  // CHECK: firrtl.strictconnect %leq_2, %[[one_i1]]
-  // CHECK: firrtl.strictconnect %leq_3, %[[one_i1]]
+  firrtl.matchingconnect %leq_0, %15 : !firrtl.uint<1>
+  firrtl.matchingconnect %leq_1, %16 : !firrtl.uint<1>
+  firrtl.matchingconnect %leq_2, %17 : !firrtl.uint<1>
+  firrtl.matchingconnect %leq_3, %18 : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %leq_0, %[[one_i1]]
+  // CHECK: firrtl.matchingconnect %leq_1, %[[one_i1]]
+  // CHECK: firrtl.matchingconnect %leq_2, %[[one_i1]]
+  // CHECK: firrtl.matchingconnect %leq_3, %[[one_i1]]
 }
 
 // CHECK-LABEL: @NamePropagation
@@ -2884,14 +2884,14 @@ firrtl.module @NamePropagation(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, i
   // CHECK-NEXT: %e = firrtl.bits %c 1 to 0 {name = "e"}
   %1 = firrtl.bits %c 2 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<3>
   %e = firrtl.bits %1 1 to 0 {name = "e"}: (!firrtl.uint<3>) -> !firrtl.uint<2>
-  // CHECK-NEXT: firrtl.strictconnect %res1, %e
-  firrtl.strictconnect %res1, %e : !firrtl.uint<2>
+  // CHECK-NEXT: firrtl.matchingconnect %res1, %e
+  firrtl.matchingconnect %res1, %e : !firrtl.uint<2>
 
   // CHECK-NEXT: %name_node = firrtl.not %e {name = "name_node"} : (!firrtl.uint<2>) -> !firrtl.uint<2>
-  // CHECK-NEXT: firrtl.strictconnect %res2, %name_node
+  // CHECK-NEXT: firrtl.matchingconnect %res2, %name_node
   %2 = firrtl.not %e : (!firrtl.uint<2>) -> !firrtl.uint<2>
   %name_node = firrtl.node droppable_name %2 : !firrtl.uint<2>
-  firrtl.strictconnect %res2, %name_node : !firrtl.uint<2>
+  firrtl.matchingconnect %res2, %name_node : !firrtl.uint<2>
 }
 
 // Issue 3319: https://github.com/llvm/circt/issues/3319
@@ -2902,18 +2902,18 @@ firrtl.module @Foo3319(in %i: !firrtl.uint<1>, out %o : !firrtl.uint<1>) {
   %0 = firrtl.and %c0_ui1, %i : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   // CHECK: %n = firrtl.node interesting_name %c0_ui1
   %n = firrtl.node interesting_name %0  : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %o, %n
-  firrtl.strictconnect %o, %n : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %o, %n
+  firrtl.matchingconnect %o, %n : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: @WireByPass
 firrtl.module @WireByPass(in %i: !firrtl.uint<1>, out %o : !firrtl.uint<1>) {
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %n = firrtl.wire interesting_name : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %n, %c0_ui1
-  firrtl.strictconnect %n, %c0_ui1 : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %o, %n
-  firrtl.strictconnect %o, %n : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %n, %c0_ui1
+  firrtl.matchingconnect %n, %c0_ui1 : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %o, %n
+  firrtl.matchingconnect %o, %n : !firrtl.uint<1>
 }
 
 // Check that canonicalizeSingleSetConnect doesn't remove a wire with an
@@ -2926,8 +2926,8 @@ firrtl.module @AnnotationsBlockRemoval(
 ) {
   // CHECK: %w = firrtl.wire
   %w = firrtl.wire droppable_name {annotations = [{class = "Foo"}]} : !firrtl.uint<1>
-  firrtl.strictconnect %w, %a : !firrtl.uint<1>
-  firrtl.strictconnect %b, %w : !firrtl.uint<1>
+  firrtl.matchingconnect %w, %a : !firrtl.uint<1>
+  firrtl.matchingconnect %b, %w : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Verification
@@ -2956,18 +2956,18 @@ firrtl.module @Verification(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, ou
   firrtl.cover %clock, %c0, %p, "cover0" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NOT: firrtl.int.isX
   %x = firrtl.int.isX %c0 : !firrtl.uint<1>
-  firrtl.strictconnect %o, %x : !firrtl.uint<1>
+  firrtl.matchingconnect %o, %x : !firrtl.uint<1>
 }
 
 // COMMON-LABEL:  firrtl.module @MultibitMux
 // COMMON-NEXT:      %0 = firrtl.subaccess %a[%sel] : !firrtl.vector<uint<1>, 3>, !firrtl.uint<2>
-// COMMON-NEXT:      firrtl.strictconnect %b, %0 : !firrtl.uint<1>
+// COMMON-NEXT:      firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
 firrtl.module @MultibitMux(in %a: !firrtl.vector<uint<1>, 3>, in %sel: !firrtl.uint<2>, out %b: !firrtl.uint<1>) {
   %0 = firrtl.subindex %a[2] : !firrtl.vector<uint<1>, 3>
   %1 = firrtl.subindex %a[1] : !firrtl.vector<uint<1>, 3>
   %2 = firrtl.subindex %a[0] : !firrtl.vector<uint<1>, 3>
   %3 = firrtl.multibit_mux %sel, %0, %1, %2 : !firrtl.uint<2>, !firrtl.uint<1>
-  firrtl.strictconnect %b, %3 : !firrtl.uint<1>
+  firrtl.matchingconnect %b, %3 : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @NameProp
@@ -2977,8 +2977,8 @@ firrtl.module @NameProp(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out 
   %useful_name = firrtl.node %_useless_name_1  : !firrtl.uint<1>
   %_useless_name_2 = firrtl.node  %useful_name  : !firrtl.uint<1>
   // CHECK-NEXT: %useful_name = firrtl.or %in0, %in1
-  // CHECK-NEXT: firrtl.strictconnect %out, %useful_name
-  firrtl.strictconnect %out, %_useless_name_2 : !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.matchingconnect %out, %useful_name
+  firrtl.matchingconnect %out, %_useless_name_2 : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @CrashAllUnusedPorts
@@ -2986,16 +2986,16 @@ firrtl.module @CrashAllUnusedPorts() {
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %foo, %bar = firrtl.mem  Undefined  {depth = 3 : i64, groupID = 4 : ui32, name = "whatever", portNames = ["MPORT_1", "MPORT_5"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: uint<2>, mask: uint<1>>, !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data flip: uint<2>>
   %26 = firrtl.subfield %foo[en] : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: uint<2>, mask: uint<1>>
-  firrtl.strictconnect %26, %c0_ui1 : !firrtl.uint<1>
+  firrtl.matchingconnect %26, %c0_ui1 : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Issue6237
 // CHECK-NEXT:    %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
-// CHECK-NEXT:    firrtl.strictconnect %out, %c0_ui0 : !firrtl.uint<0>
+// CHECK-NEXT:    firrtl.matchingconnect %out, %c0_ui0 : !firrtl.uint<0>
 firrtl.module @Issue6237(out %out: !firrtl.uint<0>) {
   %foo, %bar = firrtl.mem  Undefined  {depth = 3 : i64, groupID = 4 : ui32, name = "whatever", portNames = ["MPORT_1", "MPORT_5"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: uint<0>, mask: uint<1>>, !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data flip: uint<0>>
   %a = firrtl.subfield %bar[data] : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data flip: uint<0>>
-  firrtl.strictconnect %out, %a : !firrtl.uint<0>
+  firrtl.matchingconnect %out, %a : !firrtl.uint<0>
 }
 
 
@@ -3037,21 +3037,21 @@ firrtl.module @ReadOnlyFileInitialized(
     !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data flip: uint<8>>
   %3 = firrtl.subfield %m_r[data] :
     !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data flip: uint<8>>
-  firrtl.strictconnect %0, %read_addr : !firrtl.uint<5>
-  firrtl.strictconnect %1, %read_en : !firrtl.uint<1>
-  firrtl.strictconnect %2, %clock : !firrtl.clock
-  firrtl.strictconnect %read_data, %3 : !firrtl.uint<8>
+  firrtl.matchingconnect %0, %read_addr : !firrtl.uint<5>
+  firrtl.matchingconnect %1, %read_en : !firrtl.uint<1>
+  firrtl.matchingconnect %2, %clock : !firrtl.clock
+  firrtl.matchingconnect %read_data, %3 : !firrtl.uint<8>
 }
 
 // CHECK-LABEL: @MuxCondWidth
 firrtl.module @MuxCondWidth(in %cond: !firrtl.uint<1>, out %foo: !firrtl.uint<3>) {
   // Don't canonicalize if the type is not UInt<1>
   // CHECK: %0 = firrtl.mux(%cond, %c0_ui3, %c1_ui3) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
-  // CHECK-NEXT:  firrtl.strictconnect %foo, %0
+  // CHECK-NEXT:  firrtl.matchingconnect %foo, %0
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
   %0 = firrtl.mux(%cond, %c0_ui1, %c1_ui3) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
-  firrtl.strictconnect %foo, %0 : !firrtl.uint<3>
+  firrtl.matchingconnect %foo, %0 : !firrtl.uint<3>
 }
 
 // CHECK-LABEL: @MuxEQ
@@ -3065,29 +3065,29 @@ firrtl.module @MuxEQ(in %a: !firrtl.uint<4>,
                      out %out5: !firrtl.uint<4>) {
   %eq = firrtl.eq %a, %b : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   %0 = firrtl.mux (%eq, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK-NEXT: firrtl.strictconnect %out1, %b
-  firrtl.strictconnect %out1, %0 : !firrtl.uint<4>
+  // CHECK-NEXT: firrtl.matchingconnect %out1, %b
+  firrtl.matchingconnect %out1, %0 : !firrtl.uint<4>
 
   %eq_swapped = firrtl.eq %b, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   %1 = firrtl.mux (%eq_swapped, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK-NEXT: firrtl.strictconnect %out2, %b
-  firrtl.strictconnect %out2, %1 : !firrtl.uint<4>
+  // CHECK-NEXT: firrtl.matchingconnect %out2, %b
+  firrtl.matchingconnect %out2, %1 : !firrtl.uint<4>
 
   %neq = firrtl.neq %a, %b : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   %2 = firrtl.mux (%neq, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK-NEXT: firrtl.strictconnect %out3, %a
-  firrtl.strictconnect %out3, %2 : !firrtl.uint<4>
+  // CHECK-NEXT: firrtl.matchingconnect %out3, %a
+  firrtl.matchingconnect %out3, %2 : !firrtl.uint<4>
 
   %neq_swapped = firrtl.neq %b, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   %3 = firrtl.mux (%neq_swapped, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK-NEXT: firrtl.strictconnect %out4, %a
-  firrtl.strictconnect %out4, %3 : !firrtl.uint<4>
+  // CHECK-NEXT: firrtl.matchingconnect %out4, %a
+  firrtl.matchingconnect %out4, %3 : !firrtl.uint<4>
 
   // CHECK-NEXT: [[EQ:%.+]] = firrtl.eq %a, %b : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
   // CHECK-NEXT: [[MUX:%.+]] = firrtl.mux([[EQ]], %c, %a) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  // CHECK-NEXT: firrtl.strictconnect %out5, [[MUX]]
+  // CHECK-NEXT: firrtl.matchingconnect %out5, [[MUX]]
   %4 = firrtl.mux (%neq, %a, %c) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.strictconnect %out5, %4 : !firrtl.uint<4>
+  firrtl.matchingconnect %out5, %4 : !firrtl.uint<4>
 }
 
 // CHECK-LABEL: firrtl.module @RemoveUnusedInvalid
@@ -3102,124 +3102,124 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
   // CHECK-NOT firrtl.not
   %inv = firrtl.invalidvalue : !firrtl.uint<4>
   %not = firrtl.not %inv : (!firrtl.uint<4>) -> !firrtl.uint<4>
-  firrtl.strictconnect %out, %not : !firrtl.uint<4>
+  firrtl.matchingconnect %out, %not : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // CHECK-NOT firrtl.bits
   %inv2 = firrtl.invalidvalue : !firrtl.uint<5>
   %bits = firrtl.bits %inv2 3 to 0 : (!firrtl.uint<5>) -> !firrtl.uint<4>
-  firrtl.strictconnect %out, %bits : !firrtl.uint<4>
+  firrtl.matchingconnect %out, %bits : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // CHECK-NOT firrtl.head
   %inv3 = firrtl.invalidvalue : !firrtl.uint<5>
   %head = firrtl.head %inv3, 4 : (!firrtl.uint<5>) -> !firrtl.uint<4>
-  firrtl.strictconnect %out, %head : !firrtl.uint<4>
+  firrtl.matchingconnect %out, %head : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // CHECK-NOT firrtl.tail
   %inv4 = firrtl.invalidvalue : !firrtl.uint<5>
   %tail = firrtl.tail %inv4, 1 : (!firrtl.uint<5>) -> !firrtl.uint<4>
-  firrtl.strictconnect %out, %tail : !firrtl.uint<4>
+  firrtl.matchingconnect %out, %tail : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // CHECK-NOT firrtl.asSInt
   %inv5 = firrtl.invalidvalue : !firrtl.uint<4>
   %assint = firrtl.asSInt %inv5 : (!firrtl.uint<4>) -> !firrtl.sint<4>
-  firrtl.strictconnect %outs, %assint : !firrtl.sint<4>
+  firrtl.matchingconnect %outs, %assint : !firrtl.sint<4>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // CHECK-NOT firrtl.asUInt
   %inv6 = firrtl.invalidvalue : !firrtl.sint<4>
   %asuint = firrtl.asUInt %inv6 : (!firrtl.sint<4>) -> !firrtl.uint<4>
-  firrtl.strictconnect %out, %asuint : !firrtl.uint<4>
+  firrtl.matchingconnect %out, %asuint : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // CHECK-NOT firrtl.subfield
   %inv7 = firrtl.invalidvalue : !firrtl.bundle<a: uint<4>, b: uint<5>>
   %subfield = firrtl.subfield %inv7[a] : !firrtl.bundle<a: uint<4>, b: uint<5>>
-  firrtl.strictconnect %out, %subfield : !firrtl.uint<4>
+  firrtl.matchingconnect %out, %subfield : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // CHECK-NOT firrtl.subindex
   %inv8 = firrtl.invalidvalue : !firrtl.vector<uint<4>, 6 >
   %subindex = firrtl.subindex %inv8[2] : !firrtl.vector<uint<4>, 6 >
-  firrtl.strictconnect %out, %subindex : !firrtl.uint<4>
+  firrtl.matchingconnect %out, %subindex : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // CHECK-NOT firrtl.bitcast
   %inv9 = firrtl.invalidvalue : !firrtl.vector<uint<4>, 1 >
   %bitcast = firrtl.bitcast %inv9 : (!firrtl.vector<uint<4>, 1 >) -> !firrtl.uint<4>
-  firrtl.strictconnect %out, %bitcast : !firrtl.uint<4>
+  firrtl.matchingconnect %out, %bitcast : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // CHECK-NOT firrtl.andr
   %inva = firrtl.invalidvalue : !firrtl.uint<4>
   %andr = firrtl.andr %inva : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out1, %andr : !firrtl.uint<1>
+  firrtl.matchingconnect %out1, %andr : !firrtl.uint<1>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // CHECK-NOT firrtl.orr
   %invb = firrtl.invalidvalue : !firrtl.uint<4>
   %orr = firrtl.orr %invb : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out1, %orr : !firrtl.uint<1>
+  firrtl.matchingconnect %out1, %orr : !firrtl.uint<1>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // CHECK-NOT firrtl.xorr
   %invc = firrtl.invalidvalue : !firrtl.uint<4>
   %xorr = firrtl.xorr %invc : (!firrtl.uint<4>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out1, %xorr : !firrtl.uint<1>
+  firrtl.matchingconnect %out1, %xorr : !firrtl.uint<1>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // This one depends on the folder
   // CHECK-NOT firrtl.invalidvalue
   // CHECK-NOT firrtl.xorr
   %invd = firrtl.invalidvalue : !firrtl.uint<0>
   %zbits = firrtl.xorr %invd : (!firrtl.uint<0>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out1, %zbits : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %out1, %c0_ui1
+  firrtl.matchingconnect %out1, %zbits : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %out1, %c0_ui1
 
   // CHECK-NOT firrtl.cvt
   %inve = firrtl.invalidvalue : !firrtl.uint<3>
   %cvtu = firrtl.cvt %inve : (!firrtl.uint<3>) -> !firrtl.sint<4>
-  firrtl.strictconnect %outs, %cvtu : !firrtl.sint<4>
+  firrtl.matchingconnect %outs, %cvtu : !firrtl.sint<4>
 
   // CHECK: firrtl.invalidvalue
   // CHECK-NEXT: firrtl.pad
   // CHECK-NEXT: firrtl.asSInt
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
   // CHECK-NOT firrtl.cvt
   %invf = firrtl.invalidvalue : !firrtl.sint<4>
   %cvts = firrtl.cvt %invf : (!firrtl.sint<4>) -> !firrtl.sint<4>
-  firrtl.strictconnect %outs, %cvts : !firrtl.sint<4>
+  firrtl.matchingconnect %outs, %cvts : !firrtl.sint<4>
 
   // CHECK: firrtl.invalidvalue
-  // CHECK-NEXT: firrtl.strictconnect
+  // CHECK-NEXT: firrtl.matchingconnect
 
 }
 
@@ -3231,14 +3231,14 @@ firrtl.module @AggregateCreate(in %vector_in: !firrtl.vector<uint<1>, 2>,
   %0 = firrtl.subindex %vector_in[0] : !firrtl.vector<uint<1>, 2>
   %1 = firrtl.subindex %vector_in[1] : !firrtl.vector<uint<1>, 2>
   %vector = firrtl.vectorcreate %0, %1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
-  firrtl.strictconnect %vector_out, %vector : !firrtl.vector<uint<1>, 2>
+  firrtl.matchingconnect %vector_out, %vector : !firrtl.vector<uint<1>, 2>
 
   %2 = firrtl.subfield %bundle_in["a"] : !firrtl.bundle<a: uint<1>, b: uint<1>>
   %3 = firrtl.subfield %bundle_in["b"] : !firrtl.bundle<a: uint<1>, b: uint<1>>
   %bundle = firrtl.bundlecreate %2, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
-  firrtl.strictconnect %bundle_out, %bundle : !firrtl.bundle<a: uint<1>, b: uint<1>>
-  // CHECK-NEXT: firrtl.strictconnect %vector_out, %vector_in : !firrtl.vector<uint<1>, 2>
-  // CHECK-NEXT: firrtl.strictconnect %bundle_out, %bundle_in : !firrtl.bundle<a: uint<1>, b: uint<1>>
+  firrtl.matchingconnect %bundle_out, %bundle : !firrtl.bundle<a: uint<1>, b: uint<1>>
+  // CHECK-NEXT: firrtl.matchingconnect %vector_out, %vector_in : !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: firrtl.matchingconnect %bundle_out, %bundle_in : !firrtl.bundle<a: uint<1>, b: uint<1>>
 }
 
 // CHECK-LABEL: firrtl.module @AggregateCreateSingle(
@@ -3249,13 +3249,13 @@ firrtl.module @AggregateCreateSingle(in %vector_in: !firrtl.vector<uint<1>, 1>,
 
   %0 = firrtl.subindex %vector_in[0] : !firrtl.vector<uint<1>, 1>
   %vector = firrtl.vectorcreate %0 : (!firrtl.uint<1>) -> !firrtl.vector<uint<1>, 1>
-  firrtl.strictconnect %vector_out, %vector : !firrtl.vector<uint<1>, 1>
+  firrtl.matchingconnect %vector_out, %vector : !firrtl.vector<uint<1>, 1>
 
   %2 = firrtl.subfield %bundle_in["a"] : !firrtl.bundle<a: uint<1>>
   %bundle = firrtl.bundlecreate %2 : (!firrtl.uint<1>) -> !firrtl.bundle<a: uint<1>>
-  firrtl.strictconnect %bundle_out, %bundle : !firrtl.bundle<a: uint<1>>
-  // CHECK-NEXT: firrtl.strictconnect %vector_out, %vector_in : !firrtl.vector<uint<1>, 1>
-  // CHECK-NEXT: firrtl.strictconnect %bundle_out, %bundle_in : !firrtl.bundle<a: uint<1>>
+  firrtl.matchingconnect %bundle_out, %bundle : !firrtl.bundle<a: uint<1>>
+  // CHECK-NEXT: firrtl.matchingconnect %vector_out, %vector_in : !firrtl.vector<uint<1>, 1>
+  // CHECK-NEXT: firrtl.matchingconnect %bundle_out, %bundle_in : !firrtl.bundle<a: uint<1>>
 }
 
 // CHECK-LABEL: firrtl.module @AggregateCreateEmpty(
@@ -3264,14 +3264,14 @@ firrtl.module @AggregateCreateEmpty(
                                out %bundle_out: !firrtl.bundle<>) {
 
   %vector = firrtl.vectorcreate : () -> !firrtl.vector<uint<1>, 0>
-  firrtl.strictconnect %vector_out, %vector : !firrtl.vector<uint<1>, 0>
+  firrtl.matchingconnect %vector_out, %vector : !firrtl.vector<uint<1>, 0>
 
   %bundle = firrtl.bundlecreate : () -> !firrtl.bundle<>
-  firrtl.strictconnect %bundle_out, %bundle : !firrtl.bundle<>
+  firrtl.matchingconnect %bundle_out, %bundle : !firrtl.bundle<>
   // CHECK-DAG: %[[VEC:.+]] = firrtl.aggregateconstant [] : !firrtl.vector<uint<1>, 0>
   // CHECK-DAG: %[[BUNDLE:.+]] = firrtl.aggregateconstant [] : !firrtl.bundle<>
-  // CHECK-DAG: firrtl.strictconnect %vector_out, %[[VEC]] : !firrtl.vector<uint<1>, 0>
-  // CHECK-DAG: firrtl.strictconnect %bundle_out, %[[BUNDLE]] : !firrtl.bundle<>
+  // CHECK-DAG: firrtl.matchingconnect %vector_out, %[[VEC]] : !firrtl.vector<uint<1>, 0>
+  // CHECK-DAG: firrtl.matchingconnect %bundle_out, %[[BUNDLE]] : !firrtl.bundle<>
 }
 
 // CHECK-LABEL: firrtl.module @AggregateCreateConst(
@@ -3281,14 +3281,14 @@ firrtl.module @AggregateCreateConst(
 
   %const = firrtl.constant 0 : !firrtl.uint<1>
   %vector = firrtl.vectorcreate %const, %const : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
-  firrtl.strictconnect %vector_out, %vector : !firrtl.vector<uint<1>, 2>
+  firrtl.matchingconnect %vector_out, %vector : !firrtl.vector<uint<1>, 2>
 
   %bundle = firrtl.bundlecreate %const, %const : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.bundle<a: uint<1>, b: uint<1>>
-  firrtl.strictconnect %bundle_out, %bundle : !firrtl.bundle<a: uint<1>, b: uint<1>>
+  firrtl.matchingconnect %bundle_out, %bundle : !firrtl.bundle<a: uint<1>, b: uint<1>>
   // CHECK-DAG: %[[VEC:.+]] = firrtl.aggregateconstant [0 : ui1, 0 : ui1] : !firrtl.vector<uint<1>, 2>
   // CHECK-DAG: %[[BUNDLE:.+]] = firrtl.aggregateconstant [0 : ui1, 0 : ui1] : !firrtl.bundle<a: uint<1>, b: uint<1>>
-  // CHECK-DAG: firrtl.strictconnect %vector_out, %[[VEC]] : !firrtl.vector<uint<1>, 2>
-  // CHECK-DAG: firrtl.strictconnect %bundle_out, %[[BUNDLE]] : !firrtl.bundle<a: uint<1>, b: uint<1>>
+  // CHECK-DAG: firrtl.matchingconnect %vector_out, %[[VEC]] : !firrtl.vector<uint<1>, 2>
+  // CHECK-DAG: firrtl.matchingconnect %bundle_out, %[[BUNDLE]] : !firrtl.bundle<a: uint<1>, b: uint<1>>
 }
 
 
@@ -3347,29 +3347,29 @@ firrtl.module @RefTypes(
   %b = firrtl.wire : !firrtl.uint<1>
   %a_ref = firrtl.ref.send  %a : !firrtl.uint<1>
   %a_read_ref = firrtl.ref.resolve %a_ref : !firrtl.probe<uint<1>>
-  // CHECK: firrtl.strictconnect %b, %a
-  firrtl.strictconnect %b, %a_read_ref : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %b, %a
+  firrtl.matchingconnect %b, %a_read_ref : !firrtl.uint<1>
 
   // Don't collapse if types don't match.
   // CHECK: ref.resolve
   %x_ref = firrtl.ref.send %x : !firrtl.bundle<a flip: uint<1>>
   %x_read = firrtl.ref.resolve %x_ref : !firrtl.probe<bundle<a: uint<1>>>
-  firrtl.strictconnect %y, %x_read : !firrtl.bundle<a: uint<1>>
+  firrtl.matchingconnect %y, %x_read : !firrtl.bundle<a: uint<1>>
 
   // CHECK-NOT: forceable
-  // CHECK: firrtl.strictconnect %f_wire, %b
+  // CHECK: firrtl.matchingconnect %f_wire, %b
   // CHECK-NOT: forceable
   %f, %f_rw = firrtl.node %b forceable : !firrtl.uint<1>
   %f_read = firrtl.ref.resolve %f_rw : !firrtl.rwprobe<uint<1>>
   %f_wire = firrtl.wire : !firrtl.uint<1>
-  firrtl.strictconnect %f_wire, %f_read : !firrtl.uint<1>
+  firrtl.matchingconnect %f_wire, %f_read : !firrtl.uint<1>
 
   // CHECK: firrtl.wire forceable
   // CHECK: ref.resolve
   %flipbundle, %flipbundle_rw = firrtl.wire forceable : !firrtl.bundle<a flip: uint<1>>, !firrtl.rwprobe<bundle<a: uint<1>>>
   %flipbundle_read = firrtl.ref.resolve %flipbundle_rw : !firrtl.rwprobe<bundle<a: uint<1>>>
   %flipbundle_wire = firrtl.wire : !firrtl.bundle<a : uint<1>>
-  firrtl.strictconnect %flipbundle_wire, %flipbundle_read : !firrtl.bundle<a: uint<1>>
+  firrtl.matchingconnect %flipbundle_wire, %flipbundle_read : !firrtl.bundle<a: uint<1>>
 }
 
 // Do not rename InstanceOp: https://github.com/llvm/circt/issues/5351
@@ -3378,7 +3378,7 @@ firrtl.module @DonotUpdateInstanceName(in %in: !firrtl.uint<1>, out %a: !firrtl.
   %system_foo = firrtl.instance system @System(out foo: !firrtl.uint<1>)
   // CHECK: firrtl.instance system
   %b = firrtl.node %system_foo : !firrtl.uint<1>
-  firrtl.strictconnect %a, %b : !firrtl.uint<1>
+  firrtl.matchingconnect %a, %b : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: @RefCastSame
@@ -3398,8 +3398,8 @@ firrtl.module @Issue5527(in %x: !firrtl.uint<1>, out %out: !firrtl.uint<2>) attr
   %c2_si4 = firrtl.constant 2 : !firrtl.sint<4>
   %1 = firrtl.and %0, %c2_si4 : (!firrtl.sint<2>, !firrtl.sint<4>) -> !firrtl.uint<4>
   %2 = firrtl.tail %1, 2 : (!firrtl.uint<4>) -> !firrtl.uint<2>
-  // CHECK: firrtl.strictconnect %out, %c0_ui2
-  firrtl.strictconnect %out, %2 : !firrtl.uint<2>
+  // CHECK: firrtl.matchingconnect %out, %c0_ui2
+  firrtl.matchingconnect %out, %2 : !firrtl.uint<2>
 }
 
 // Test dropping force/release statements with constant-zero predicates.
@@ -3427,10 +3427,10 @@ firrtl.module @ForceRelease(in %clock: !firrtl.clock, in %x: !firrtl.uint<4>) {
 firrtl.module @Issue5650(in %io_y: !firrtl.uint<1>, out %io_x: !firrtl.uint<1>) {
   %io = firrtl.wire : !firrtl.bundle<y flip: uint<1>, x: uint<1>>
   %2 = firrtl.subfield %io[y] : !firrtl.bundle<y flip: uint<1>, x: uint<1>>
-  firrtl.strictconnect %2, %io_y : !firrtl.uint<1>
+  firrtl.matchingconnect %2, %io_y : !firrtl.uint<1>
   %3 = firrtl.subfield %io[x] : !firrtl.bundle<y flip: uint<1>, x: uint<1>>
-  firrtl.strictconnect %io_x, %3 : !firrtl.uint<1>
-  firrtl.strictconnect %3, %2 : !firrtl.uint<1>
+  firrtl.matchingconnect %io_x, %3 : !firrtl.uint<1>
+  firrtl.matchingconnect %3, %2 : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: @HasBeenReset
@@ -3505,9 +3505,9 @@ firrtl.module @OMIRRemoval(in %source : !firrtl.uint<1>) {
       }
     ]} : !firrtl.uint<1>
   %a = firrtl.wire : !firrtl.uint<1>
-  firrtl.strictconnect %tmp_0, %source : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %a, %source
-  firrtl.strictconnect %a, %tmp_0 : !firrtl.uint<1>
+  firrtl.matchingconnect %tmp_0, %source : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %a, %source
+  firrtl.matchingconnect %a, %tmp_0 : !firrtl.uint<1>
 
   // CHECK-NOT: %tmp_1
   %tmp_1 = firrtl.wire {
@@ -3519,9 +3519,9 @@ firrtl.module @OMIRRemoval(in %source : !firrtl.uint<1>) {
       }
     ]} : !firrtl.uint<1>
   %b = firrtl.wire : !firrtl.uint<1>
-  firrtl.strictconnect %tmp_1, %source : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %b, %source
-  firrtl.strictconnect %b, %tmp_1 : !firrtl.uint<1>
+  firrtl.matchingconnect %tmp_1, %source : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %b, %source
+  firrtl.matchingconnect %b, %tmp_1 : !firrtl.uint<1>
 
   // CHECK-NOT: %tmp_2
   %tmp_2 = firrtl.wire {
@@ -3533,9 +3533,9 @@ firrtl.module @OMIRRemoval(in %source : !firrtl.uint<1>) {
       }
     ]} : !firrtl.uint<1>
   %c = firrtl.wire : !firrtl.uint<1>
-  firrtl.strictconnect %tmp_2, %source : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %c, %source
-  firrtl.strictconnect %c, %tmp_2 : !firrtl.uint<1>
+  firrtl.matchingconnect %tmp_2, %source : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %c, %source
+  firrtl.matchingconnect %c, %tmp_2 : !firrtl.uint<1>
 
   // Adding one additional annotation will block removal.
   //
@@ -3552,9 +3552,9 @@ firrtl.module @OMIRRemoval(in %source : !firrtl.uint<1>) {
       }
     ]} : !firrtl.uint<1>
   %d = firrtl.wire : !firrtl.uint<1>
-  firrtl.strictconnect %tmp_3, %source : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect %d, %tmp_3
-  firrtl.strictconnect %d, %tmp_3 : !firrtl.uint<1>
+  firrtl.matchingconnect %tmp_3, %source : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect %d, %tmp_3
+  firrtl.matchingconnect %d, %tmp_3 : !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Whens

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -141,9 +141,9 @@ firrtl.circuit "strictConnectAndConnect" {
   // expected-error @below {{strictConnectAndConnect.{a <- b <- a}}}
   firrtl.module @strictConnectAndConnect(out %a: !firrtl.uint<11>, out %b: !firrtl.uint<11>) {
     %w = firrtl.wire : !firrtl.uint<11>
-    firrtl.strictconnect %b, %w : !firrtl.uint<11>
+    firrtl.matchingconnect %b, %w : !firrtl.uint<11>
     firrtl.connect %a, %b : !firrtl.uint<11>, !firrtl.uint<11>
-    firrtl.strictconnect %b, %a : !firrtl.uint<11>
+    firrtl.matchingconnect %b, %a : !firrtl.uint<11>
   }
 }
 
@@ -198,8 +198,8 @@ firrtl.circuit "PortReadWrite"  {
   firrtl.module @PortReadWrite() {
     %a = firrtl.wire : !firrtl.uint<1>
     %bar_a = firrtl.instance bar interesting_name  @Bar(in a: !firrtl.uint<1>)
-    firrtl.strictconnect %bar_a, %a : !firrtl.uint<1>
-    firrtl.strictconnect %a, %bar_a : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %bar_a : !firrtl.uint<1>
   }
 }
 
@@ -210,8 +210,8 @@ firrtl.circuit "Foo"  {
   // expected-error @below {{Foo.{a <- bar.a <- a}}}
   firrtl.module @Foo(out %a: !firrtl.uint<1>) {
     %bar_a = firrtl.instance bar interesting_name  @Bar(in a: !firrtl.uint<1>)
-    firrtl.strictconnect %bar_a, %a : !firrtl.uint<1>
-    firrtl.strictconnect %a, %bar_a : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %bar_a : !firrtl.uint<1>
   }
 }
 
@@ -257,13 +257,13 @@ firrtl.circuit "hasloops"   {
     %bar_b = firrtl.wire : !firrtl.vector<uint<1>, 2>
     %0 = firrtl.subindex %b[0] : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.subindex %bar_a[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %0 : !firrtl.uint<1>
     %4 = firrtl.subindex %bar_b[0] : !firrtl.vector<uint<1>, 2>
     %5 = firrtl.subindex %b[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %5, %4 : !firrtl.uint<1>
+    firrtl.matchingconnect %5, %4 : !firrtl.uint<1>
     %v0 = firrtl.subindex %bar_a[0] : !firrtl.vector<uint<1>, 2>
     %v1 = firrtl.subindex %bar_b[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %v1, %v0 : !firrtl.uint<1>
+    firrtl.matchingconnect %v1, %v0 : !firrtl.uint<1>
   }
 }
 
@@ -277,19 +277,19 @@ firrtl.circuit "hasLoops"  {
     %bar_a, %bar_b = firrtl.instance bar  @Bar(in a: !firrtl.vector<uint<1>, 2>, out b: !firrtl.vector<uint<1>, 2>)
     %0 = firrtl.subindex %b[0] : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.subindex %bar_a[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %0 : !firrtl.uint<1>
     %4 = firrtl.subindex %bar_b[0] : !firrtl.vector<uint<1>, 2>
     %5 = firrtl.subindex %b[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %5, %4 : !firrtl.uint<1>
+    firrtl.matchingconnect %5, %4 : !firrtl.uint<1>
   }
 
   firrtl.module private @Bar(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 2>) {
     %0 = firrtl.subindex %a[0] : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.subindex %b[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %0 : !firrtl.uint<1>
     %2 = firrtl.subindex %a[1] : !firrtl.vector<uint<1>, 2>
     %3 = firrtl.subindex %b[1] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %3, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %2 : !firrtl.uint<1>
   }
 }
 
@@ -328,14 +328,14 @@ firrtl.circuit "hasLoops"  {
     %bar_a, %bar_b = firrtl.instance bar  @Bar(in a: !firrtl.vector<uint<1>, 2>, out b: !firrtl.vector<uint<1>, 2>)
     %0 = firrtl.subindex %b[0] : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.subindex %bar_a[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %0 : !firrtl.uint<1>
     %4 = firrtl.subindex %bar_b[0] : !firrtl.vector<uint<1>, 2>
     %5 = firrtl.subindex %b[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %5, %4 : !firrtl.uint<1>
+    firrtl.matchingconnect %5, %4 : !firrtl.uint<1>
   }
 
   firrtl.module private @Bar(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 2>) {
-    firrtl.strictconnect %b, %a : !firrtl.vector<uint<1>, 2>
+    firrtl.matchingconnect %b, %a : !firrtl.vector<uint<1>, 2>
   }
 }
 
@@ -461,7 +461,7 @@ firrtl.circuit "subaccess"   {
     %1 = firrtl.subfield %0[wo] : !firrtl.bundle<wo: uint<1>, wi: uint<1>>
     %2 = firrtl.subindex %b[0] : !firrtl.vector<bundle<wo: uint<1>, wi: uint<1>>, 4>
     %3 = firrtl.subfield %2[wo]: !firrtl.bundle<wo: uint<1>, wi: uint<1>>
-    firrtl.strictconnect %3, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %1 : !firrtl.uint<1>
   }
 }
 
@@ -474,7 +474,7 @@ firrtl.circuit "subaccess"   {
     %1 = firrtl.subfield %0[wo] : !firrtl.bundle<wo: uint<1>, wi: uint<1>>
     %2 = firrtl.subaccess %b[%sel2] : !firrtl.vector<bundle<wo: uint<1>, wi: uint<1>>, 4>, !firrtl.uint<2>
     %3 = firrtl.subfield %2[wo]: !firrtl.bundle<wo: uint<1>, wi: uint<1>>
-    firrtl.strictconnect %3, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %1 : !firrtl.uint<1>
   }
 }
 
@@ -487,7 +487,7 @@ firrtl.circuit "subaccess"   {
     %1 = firrtl.subfield %0[wo] : !firrtl.bundle<wo: uint<1>, wi: uint<1>>
     %2 = firrtl.subindex %b[0] : !firrtl.vector<bundle<wo: uint<1>, wi: uint<1>>, 4>
     %3 = firrtl.subfield %2[wi]: !firrtl.bundle<wo: uint<1>, wi: uint<1>>
-    firrtl.strictconnect %3, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %1 : !firrtl.uint<1>
   }
 }
 
@@ -500,7 +500,7 @@ firrtl.circuit "subaccess"   {
     %1 = firrtl.subfield %0[wo] : !firrtl.bundle<wo: uint<1>, wi: uint<1>>
     %2 = firrtl.subaccess %b[%sel2] : !firrtl.vector<bundle<wo: uint<1>, wi: uint<1>>, 4>, !firrtl.uint<2>
     %3 = firrtl.subfield %2[wi]: !firrtl.bundle<wo: uint<1>, wi: uint<1>>
-    firrtl.strictconnect %3, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %1 : !firrtl.uint<1>
   }
 }
 
@@ -513,7 +513,7 @@ firrtl.circuit "subaccess"   {
     %1 = firrtl.subfield %0[wo] : !firrtl.bundle<wo: uint<1>, wi: uint<1>>
     %2 = firrtl.subaccess %b[%sel1] : !firrtl.vector<bundle<wo: uint<1>, wi: uint<1>>, 4>, !firrtl.uint<2>
     %3 = firrtl.subfield %2[wi]: !firrtl.bundle<wo: uint<1>, wi: uint<1>>
-    firrtl.strictconnect %3, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %1 : !firrtl.uint<1>
   }
 }
 
@@ -616,7 +616,7 @@ firrtl.circuit "CycleWithoutNames"   {
   firrtl.module @CycleWithoutNames() {
     // expected-note @below {{cycle detected here}}
     %0 = firrtl.wire  : !firrtl.uint<1>
-    firrtl.strictconnect %0, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %0 : !firrtl.uint<1>
   }
 }
 
@@ -629,7 +629,7 @@ firrtl.circuit "CycleStartsUnnammed"   {
   firrtl.module @CycleStartsUnnammed() {
     %0 = firrtl.wire  : !firrtl.uint<1>
     %n = firrtl.node %0 : !firrtl.uint<1>
-    firrtl.strictconnect %0, %n : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %n : !firrtl.uint<1>
   }
 }
 
@@ -640,7 +640,7 @@ firrtl.circuit "CycleThroughForceable"   {
   firrtl.module @CycleThroughForceable() {
     %w, %w_ref = firrtl.wire forceable : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
     %n, %n_ref = firrtl.node %w forceable : !firrtl.uint<1>
-    firrtl.strictconnect %w, %n : !firrtl.uint<1>
+    firrtl.matchingconnect %w, %n : !firrtl.uint<1>
   }
 }
 
@@ -652,7 +652,7 @@ firrtl.circuit "CycleThroughForceableRef"   {
     %w, %w_ref = firrtl.wire forceable : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
     %n, %n_ref = firrtl.node %w forceable : !firrtl.uint<1>
     %read = firrtl.ref.resolve %n_ref : !firrtl.rwprobe<uint<1>>
-    firrtl.strictconnect %w, %read : !firrtl.uint<1>
+    firrtl.matchingconnect %w, %read : !firrtl.uint<1>
   }
 }
 
@@ -752,7 +752,7 @@ firrtl.circuit "RefSink" {
     %a_ref_send = firrtl.ref.send %b : !firrtl.uint<1>
     firrtl.ref.define %a_ref, %a_ref_send : !firrtl.probe<uint<1>>
     firrtl.ref.define %a_rwref, %_a_rwref : !firrtl.rwprobe<uint<1>>
-    firrtl.strictconnect %b, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %a : !firrtl.uint<1>
   }
 
 // expected-error @below {{detected combinational cycle in a FIRRTL module, sample path: RefSink.{b <- ... <- refSource.a_ref <- refSource.a_rwref <- b}}}
@@ -787,7 +787,7 @@ firrtl.circuit "RefSink" {
       !firrtl.rwprobe<uint<1>>
     firrtl.ref.define %b_ref, %_b_rwref : !firrtl.rwprobe<uint<1>>
     firrtl.ref.define %a_rwref, %_a_rwref : !firrtl.rwprobe<uint<1>>
-    firrtl.strictconnect %b, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %a : !firrtl.uint<1>
   }
 
 // expected-error @below {{detected combinational cycle in a FIRRTL module, sample path: RefSink.{b <- ... <- refSource.b_ref <- refSource.a_rwref <- b}}}
@@ -889,18 +889,18 @@ firrtl.circuit "RefSink" {
 // Incorrect visit of instance op results was resulting in missed cycles.
 firrtl.circuit "Bug5442" {
   firrtl.module private @Bar(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
-    firrtl.strictconnect %b, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %a : !firrtl.uint<1>
   }
   firrtl.module private @Baz(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>, out %c_d: !firrtl.uint<1>) {
-    firrtl.strictconnect %b, %a : !firrtl.uint<1>
-    firrtl.strictconnect %c_d, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %c_d, %a : !firrtl.uint<1>
   }
 // expected-error @below {{detected combinational cycle in a FIRRTL module, sample path: Bug5442.{bar.a <- baz.b <- baz.a <- bar.b <- bar.a}}}
   firrtl.module @Bug5442() attributes {convention = #firrtl<convention scalarized>} {
     %bar_a, %bar_b = firrtl.instance bar @Bar(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
     %baz_a, %baz_b, %baz_c_d = firrtl.instance baz @Baz(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>, out c_d: !firrtl.uint<1>)
-    firrtl.strictconnect %bar_a, %baz_b : !firrtl.uint<1>
-    firrtl.strictconnect %baz_a, %bar_b : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_a, %baz_b : !firrtl.uint<1>
+    firrtl.matchingconnect %baz_a, %bar_b : !firrtl.uint<1>
   }
 }
 
@@ -917,9 +917,9 @@ firrtl.circuit "RefSubLoop" {
     %0 = firrtl.ref.sub %c_p[1] : !firrtl.rwprobe<bundle<a: uint<1>, b: uint<1>>>
     %1 = firrtl.subfield %c_bundle[b] : !firrtl.bundle<a: uint<1>, b: uint<1>>
     %2 = firrtl.subfield %c_bundle[a] : !firrtl.bundle<a: uint<1>, b: uint<1>>
-    firrtl.strictconnect %2, %x : !firrtl.uint<1>
+    firrtl.matchingconnect %2, %x : !firrtl.uint<1>
     %3 = firrtl.ref.resolve %0 : !firrtl.rwprobe<uint<1>>
-    firrtl.strictconnect %1, %3 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %3 : !firrtl.uint<1>
   }
 }
 
@@ -935,7 +935,7 @@ firrtl.circuit "Issue4691" {
     %sub_val, %sub_x = firrtl.instance sub @Send(in val: !firrtl.uint<2>, out x: !firrtl.probe<uint<2>>)
     %res = firrtl.ref.resolve %sub_x : !firrtl.probe<uint<2>>
     firrtl.connect %sub_val, %res : !firrtl.uint<2>, !firrtl.uint<2>
-    firrtl.strictconnect %x, %sub_val : !firrtl.uint<2>
+    firrtl.matchingconnect %x, %sub_val : !firrtl.uint<2>
   }
 }
 
@@ -948,7 +948,7 @@ firrtl.circuit "Issue5462" {
     %n = firrtl.node %w : !firrtl.bundle<a: uint<8>>
     %0 = firrtl.subfield %n[a] : !firrtl.bundle<a: uint<8>>
     %1 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint<8>>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<8>
+    firrtl.matchingconnect %1, %0 : !firrtl.uint<8>
   }
 }
 
@@ -959,10 +959,10 @@ firrtl.circuit "Issue5462" {
     %n = firrtl.node %bundle : !firrtl.bundle<a: uint<1>, b: uint<1>>
     %0 = firrtl.subfield %n[a] : !firrtl.bundle<a: uint<1>, b: uint<1>>
     %1 = firrtl.subfield %p[a] : !firrtl.bundle<a: uint<1>, b: uint<1>>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %0 : !firrtl.uint<1>
     %2 = firrtl.subfield %n[b] : !firrtl.bundle<a: uint<1>, b: uint<1>>
     %3 = firrtl.subfield %p[b] : !firrtl.bundle<a: uint<1>, b: uint<1>>
-    firrtl.strictconnect %3, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %2 : !firrtl.uint<1>
   }
   // expected-error @below {{detected combinational cycle in a FIRRTL module, sample path: Issue5462.{c.bundle.b <- c.p.b <- c.bundle.b}}}
   firrtl.module @Issue5462(in %x: !firrtl.uint<1>) attributes {convention = #firrtl<convention scalarized>} {
@@ -970,8 +970,8 @@ firrtl.circuit "Issue5462" {
     %0 = firrtl.subfield %c_p[b] : !firrtl.bundle<a: uint<1>, b: uint<1>>
     %1 = firrtl.subfield %c_bundle[b] : !firrtl.bundle<a: uint<1>, b: uint<1>>
     %2 = firrtl.subfield %c_bundle[a] : !firrtl.bundle<a: uint<1>, b: uint<1>>
-    firrtl.strictconnect %2, %x : !firrtl.uint<1>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %2, %x : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %0 : !firrtl.uint<1>
   }
 }
 
@@ -986,9 +986,9 @@ firrtl.circuit "Issue5462" {
     %1 = firrtl.mux(%c, %n, %0) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>) -> !firrtl.bundle<a: uint<8>>
     %2 = firrtl.subfield %1[a] : !firrtl.bundle<a: uint<8>>
     %3 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint<8>>
-    firrtl.strictconnect %3, %2 : !firrtl.uint<8>
+    firrtl.matchingconnect %3, %2 : !firrtl.uint<8>
     %4 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint<8>>
-    firrtl.strictconnect %out_a, %4 : !firrtl.uint<8>
+    firrtl.matchingconnect %out_a, %4 : !firrtl.uint<8>
   }
 }
 
@@ -1003,7 +1003,7 @@ firrtl.circuit "FlipConnect1" {
     // w.a <= x.a
     %w_a = firrtl.subfield %w[a] : !firrtl.bundle<a flip: uint<8>>
     %x_a = firrtl.subfield %x[a] : !firrtl.bundle<a flip: uint<8>>
-    firrtl.strictconnect %w_a, %x_a : !firrtl.uint<8>
+    firrtl.matchingconnect %w_a, %x_a : !firrtl.uint<8>
   }
 }
 
@@ -1030,7 +1030,7 @@ firrtl.circuit "UnrealizedConversionCast" {
     // Casts have cast-like behavior
     %b = firrtl.wire   : !firrtl.uint<32>
     %a = builtin.unrealized_conversion_cast %b : !firrtl.uint<32> to !firrtl.uint<32>
-    firrtl.strictconnect %b, %a : !firrtl.uint<32>
+    firrtl.matchingconnect %b, %a : !firrtl.uint<32>
   }
 }
 
@@ -1045,7 +1045,7 @@ firrtl.circuit "OutsideDialect" {
     %a = "foo"(%b) : (!firrtl.uint<32>) -> !firrtl.uint<32>
     // Should only trigger once
     %c = "foo"(%b) : (!firrtl.uint<32>) -> !firrtl.uint<32>
-    firrtl.strictconnect %b, %a : !firrtl.uint<32>
+    firrtl.matchingconnect %b, %a : !firrtl.uint<32>
   }
 }
 
@@ -1070,7 +1070,7 @@ firrtl.circuit "OutsideDialectSource" {
     // ops from other dialects
     %b = firrtl.wire   : !firrtl.uint<32>
     %a = "foo"() : () -> !firrtl.uint<32>
-    firrtl.strictconnect %b, %a : !firrtl.uint<32>
+    firrtl.matchingconnect %b, %a : !firrtl.uint<32>
   }
 }
 
@@ -1085,7 +1085,7 @@ firrtl.circuit "Issue6820" {
   }
   firrtl.module @Issue6820(in %clock: !firrtl.clock, out %clockProbe: !firrtl.rwprobe<clock>) attributes {convention = #firrtl<convention scalarized>} {
     %foo_clock, %foo_clockProbe_bore = firrtl.instance foo @Foo(in clock: !firrtl.clock, out clockProbe_bore: !firrtl.rwprobe<clock>)
-    firrtl.strictconnect %foo_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %foo_clock, %clock : !firrtl.clock
     firrtl.ref.define %clockProbe, %foo_clockProbe_bore : !firrtl.rwprobe<clock>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/connect-errors.mlir
+++ b/test/Dialect/FIRRTL/connect-errors.mlir
@@ -617,7 +617,7 @@ firrtl.module @test(in %index: !firrtl.uint<1>, out %out: !firrtl.const.vector<u
   %c = firrtl.constant 0 : !firrtl.uint<1>
   %d = firrtl.subaccess %out[%index] : !firrtl.const.vector<uint<1>, 1>, !firrtl.uint<1>
   // expected-error @+1 {{assignment to non-'const' subaccess of 'const' type is disallowed}}
-  firrtl.strictconnect %d, %c : !firrtl.uint<1>
+  firrtl.matchingconnect %d, %c : !firrtl.uint<1>
 }
 }
 
@@ -732,7 +732,7 @@ firrtl.module @test(in %p: !firrtl.uint<1>, out %out: !firrtl.const.bundle<a: ui
     %f = firrtl.subfield %out[a] : !firrtl.const.bundle<a: uint<1>>
     %c = firrtl.constant 0 : !firrtl.const.uint<1>
     // expected-error @+1 {{assignment to 'const' type '!firrtl.const.uint<1>' is dependent on a non-'const' condition}}
-    firrtl.strictconnect %f, %c : !firrtl.const.uint<1>
+    firrtl.matchingconnect %f, %c : !firrtl.const.uint<1>
   }
 }
 }
@@ -746,7 +746,7 @@ firrtl.module @test(in %p: !firrtl.uint<1>, out %out: !firrtl.const.vector<uint<
     %e = firrtl.subindex %out[0] : !firrtl.const.vector<uint<1>, 1>
     %c = firrtl.constant 0 : !firrtl.const.uint<1>
     // expected-error @+1 {{assignment to 'const' type '!firrtl.const.uint<1>' is dependent on a non-'const' condition}}
-    firrtl.strictconnect %e, %c : !firrtl.const.uint<1>
+    firrtl.matchingconnect %e, %c : !firrtl.const.uint<1>
   }
 }
 }

--- a/test/Dialect/FIRRTL/connect.mlir
+++ b/test/Dialect/FIRRTL/connect.mlir
@@ -258,9 +258,9 @@ firrtl.module @NonConstToNonConstFlipFromConstSubaccess(in %in    : !firrtl.bund
 // CHECK-LABEL: firrtl.module @ConstConditionConstAssign
 firrtl.module @ConstConditionConstAssign(in %cond: !firrtl.const.uint<1>, in %in1: !firrtl.const.sint<2>, in %in2: !firrtl.const.sint<2>, out %out: !firrtl.const.sint<2>) {
   firrtl.when %cond : !firrtl.const.uint<1> {
-    firrtl.strictconnect %out, %in1 : !firrtl.const.sint<2>
+    firrtl.matchingconnect %out, %in1 : !firrtl.const.sint<2>
   } else {
-    firrtl.strictconnect %out, %in2 : !firrtl.const.sint<2>
+    firrtl.matchingconnect %out, %in2 : !firrtl.const.sint<2>
   }
 }
 
@@ -268,9 +268,9 @@ firrtl.module @ConstConditionConstAssign(in %cond: !firrtl.const.uint<1>, in %in
 // CHECK-LABEL: firrtl.module @ConstConditionNonConstAssign
 firrtl.module @ConstConditionNonConstAssign(in %cond: !firrtl.const.uint<1>, in %in1: !firrtl.sint<2>, in %in2: !firrtl.sint<2>, out %out: !firrtl.sint<2>) {
   firrtl.when %cond : !firrtl.const.uint<1> {
-    firrtl.strictconnect %out, %in1 : !firrtl.sint<2>
+    firrtl.matchingconnect %out, %in1 : !firrtl.sint<2>
   } else {
-    firrtl.strictconnect %out, %in2 : !firrtl.sint<2>
+    firrtl.matchingconnect %out, %in2 : !firrtl.sint<2>
   }
 }
 
@@ -280,7 +280,7 @@ firrtl.module @NonConstWhenLocalConstAssign(in %cond: !firrtl.uint<1>) {
   firrtl.when %cond : !firrtl.uint<1> {
     %w = firrtl.wire : !firrtl.const.uint<9>
     %c = firrtl.constant 0 : !firrtl.const.uint<9>
-    firrtl.strictconnect %w, %c : !firrtl.const.uint<9>
+    firrtl.matchingconnect %w, %c : !firrtl.const.uint<9>
   }
 }
 
@@ -292,10 +292,10 @@ firrtl.module @NonConstWhenLocalConstNestedConstWhenAssign(in %cond: !firrtl.uin
     %w = firrtl.wire : !firrtl.const.uint<9>
     firrtl.when %constCond : !firrtl.const.uint<1> {
       %c = firrtl.constant 0 : !firrtl.const.uint<9>
-      firrtl.strictconnect %w, %c : !firrtl.const.uint<9>
+      firrtl.matchingconnect %w, %c : !firrtl.const.uint<9>
     } else {
       %c = firrtl.constant 1 : !firrtl.const.uint<9>
-      firrtl.strictconnect %w, %c : !firrtl.const.uint<9>
+      firrtl.matchingconnect %w, %c : !firrtl.const.uint<9>
     }
   }
 }

--- a/test/Dialect/FIRRTL/const-prop-single-module.mlir
+++ b/test/Dialect/FIRRTL/const-prop-single-module.mlir
@@ -17,7 +17,7 @@ firrtl.module @Top01(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top01
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule x < 0 should never be true if x is a UInt
@@ -28,7 +28,7 @@ firrtl.module @Top02(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top02
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule 0 <= x should always be true if x is a UInt
@@ -39,7 +39,7 @@ firrtl.module @Top03(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top03
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule 0 > x should never be true if x is a UInt
@@ -50,7 +50,7 @@ firrtl.module @Top04(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top04
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule 1 < 3 should always be true
@@ -62,7 +62,7 @@ firrtl.module @Top05(out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top05
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule x < 8 should always be true if x only has 3 bits
@@ -73,7 +73,7 @@ firrtl.module @Top06(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top06
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule x <= 7 should always be true if x only has 3 bits
@@ -84,7 +84,7 @@ firrtl.module @Top07(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top07
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule 8 > x should always be true if x only has 3 bits
@@ -95,7 +95,7 @@ firrtl.module @Top08(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top08
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule 7 >= x should always be true if x only has 3 bits
@@ -106,7 +106,7 @@ firrtl.module @Top09(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top09
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule 10 == 10 should always be true
@@ -117,7 +117,7 @@ firrtl.module @Top10(out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top10
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 1
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule x == z should not be true even if they have the same number of bits
@@ -127,7 +127,7 @@ firrtl.module @Top11(in %x: !firrtl.uint<3>, in %z: !firrtl.uint<3>, out %y: !fi
 }
 // CHECK-LABEL: firrtl.module @Top11
 // CHECK-NEXT: %[[K:.+]] = firrtl.eq %x, %z
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule 10 != 10 should always be false
@@ -138,7 +138,7 @@ firrtl.module @Top12(out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top12
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule 1 >= 3 should always be false
@@ -150,7 +150,7 @@ firrtl.module @Top13(out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top13
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule x >= 8 should never be true if x only has 3 bits
@@ -161,7 +161,7 @@ firrtl.module @Top14(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top14
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule x > 7 should never be true if x only has 3 bits
@@ -172,7 +172,7 @@ firrtl.module @Top15(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top15
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule 8 <= x should never be true if x only has 3 bits
@@ -183,7 +183,7 @@ firrtl.module @Top16(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top16
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 
 // The rule 7 < x should never be true if x only has 3 bits
@@ -194,6 +194,6 @@ firrtl.module @Top17(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 }
 // CHECK-LABEL: firrtl.module @Top17
 // CHECK-NEXT: %[[K:.+]] = firrtl.constant 0
-// CHECK-NEXT: firrtl.strictconnect %y, %[[K]]
+// CHECK-NEXT: firrtl.matchingconnect %y, %[[K]]
 
 }

--- a/test/Dialect/FIRRTL/const.mlir
+++ b/test/Dialect/FIRRTL/const.mlir
@@ -137,19 +137,19 @@ firrtl.module @ConstRegResetValue(in %clock: !firrtl.clock, in %reset: !firrtl.a
 // CHECK-LABEL: firrtl.module @ConstCast
 firrtl.module @ConstCast(in %in: !firrtl.const.uint<1>, out %out: !firrtl.uint<1>) {
   %0 = firrtl.constCast %in : (!firrtl.const.uint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out, %0 : !firrtl.uint<1> 
+  firrtl.matchingconnect %out, %0 : !firrtl.uint<1> 
 }
 
 // CHECK-LABEL: firrtl.module @ConstCastToMixedConstBundle
 firrtl.module @ConstCastToMixedConstBundle(in %in: !firrtl.const.bundle<a: uint<1>>, out %out: !firrtl.bundle<a: const.uint<1>>) {
   %0 = firrtl.constCast %in : (!firrtl.const.bundle<a: uint<1>>) -> !firrtl.bundle<a: const.uint<1>>
-  firrtl.strictconnect %out, %0 : !firrtl.bundle<a: const.uint<1>>
+  firrtl.matchingconnect %out, %0 : !firrtl.bundle<a: const.uint<1>>
 }
 
 // CHECK-LABEL: firrtl.module @ConstCastToMixedConstVector
 firrtl.module @ConstCastToMixedConstVector(in %in: !firrtl.const.vector<uint<1>, 2>, out %out: !firrtl.vector<const.uint<1>, 2>) {
   %0 = firrtl.constCast %in : (!firrtl.const.vector<uint<1>, 2>) -> !firrtl.vector<const.uint<1>, 2>
-  firrtl.strictconnect %out, %0 : !firrtl.vector<const.uint<1>, 2>
+  firrtl.matchingconnect %out, %0 : !firrtl.vector<const.uint<1>, 2>
 }
 
 // Sub access of a ref to a const vector should always have a ref to a const result.

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -496,10 +496,10 @@ firrtl.circuit "Bundle" {
     // CHECK: [[A_B:%.+]] = firrtl.subfield %bundle1_a[b]
     // CHECK: [[A_F_G:%.+]] = firrtl.subfield %0[g]
     // CHECK: [[A_B_C:%.+]] = firrtl.subfield %1[c]
-    // CHECK: firrtl.strictconnect [[A_B_C]], [[A_F_G]]
+    // CHECK: firrtl.matchingconnect [[A_B_C]], [[A_F_G]]
     // CHECK: [[A_F_H:%.+]] = firrtl.subfield [[A_F]][h]
     // CHECK: [[A_B_D:%.+]] = firrtl.subfield [[A_B]][d]
-    // CHECK: firrtl.strictconnect [[A_F_H]], [[A_B_D]]
+    // CHECK: firrtl.matchingconnect [[A_F_H]], [[A_B_D]]
     %e = firrtl.instance bundle1 @Bundle1(out e: !firrtl.bundle<f: bundle<g flip: uint<1>, h: uint<1>>>)
 
     // CHECK: [[B:%.+]] = firrtl.subfield %bundle0_a[b]
@@ -520,11 +520,11 @@ firrtl.circuit "Bundle" {
 firrtl.circuit "MuxBundle" {
   firrtl.module private @Bar0(out %o: !firrtl.bundle<a: uint<1>>) {
     %invalid = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>>
-    firrtl.strictconnect %o, %invalid : !firrtl.bundle<a: uint<1>>
+    firrtl.matchingconnect %o, %invalid : !firrtl.bundle<a: uint<1>>
   }
   firrtl.module private @Bar1(out %o: !firrtl.bundle<b: uint<1>>) {
     %invalid = firrtl.invalidvalue : !firrtl.bundle<b: uint<1>>
-    firrtl.strictconnect %o, %invalid : !firrtl.bundle<b: uint<1>>
+    firrtl.matchingconnect %o, %invalid : !firrtl.bundle<b: uint<1>>
   }
   firrtl.module @MuxBundle(in %p: !firrtl.uint<1>, in %l: !firrtl.bundle<b: uint<1>>, out %o: !firrtl.bundle<b: uint<1>>) attributes {convention = #firrtl<convention scalarized>} {
     // CHECK: %bar0_o = firrtl.instance bar0 @Bar0(out o: !firrtl.bundle<a: uint<1>>)
@@ -534,13 +534,13 @@ firrtl.circuit "MuxBundle" {
     // CHECK: [[WIRE:%.+]] = firrtl.wire {name = "o"} : !firrtl.bundle<b: uint<1>>
     // CHECK: [[WIRE_B:%.+]] = firrtl.subfield [[WIRE]][b]
     // CHECK: [[PORT_A:%.+]] = firrtl.subfield %bar1_o[a]
-    // CHECK: firrtl.strictconnect [[WIRE_B]], [[PORT_A]]
+    // CHECK: firrtl.matchingconnect [[WIRE_B]], [[PORT_A]]
     %bar1_o = firrtl.instance bar1 @Bar1(out o: !firrtl.bundle<b: uint<1>>)
 
     // CHECK: %2 = firrtl.mux(%p, [[WIRE]], %l)
-    // CHECK: firrtl.strictconnect %o, %2 : !firrtl.bundle<b: uint<1>>
+    // CHECK: firrtl.matchingconnect %o, %2 : !firrtl.bundle<b: uint<1>>
     %0 = firrtl.mux(%p, %bar1_o, %l) : (!firrtl.uint<1>, !firrtl.bundle<b: uint<1>>, !firrtl.bundle<b: uint<1>>) -> !firrtl.bundle<b: uint<1>>
-    firrtl.strictconnect %o, %0 : !firrtl.bundle<b: uint<1>>
+    firrtl.matchingconnect %o, %0 : !firrtl.bundle<b: uint<1>>
   }
 }
 
@@ -576,13 +576,13 @@ firrtl.circuit "DelayedFixup"  {
   firrtl.module private @Foo(out %a: !firrtl.bundle<a: uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %a_a = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<1>>
-    firrtl.strictconnect %a_a, %zero : !firrtl.uint<1>
+    firrtl.matchingconnect %a_a, %zero : !firrtl.uint<1>
   }
   // CHECK-NOT: @Bar
   firrtl.module private @Bar(out %b: !firrtl.bundle<b: uint<1>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %b_b = firrtl.subfield %b[b] : !firrtl.bundle<b: uint<1>>
-    firrtl.strictconnect %b_b, %zero : !firrtl.uint<1>
+    firrtl.matchingconnect %b_b, %zero : !firrtl.uint<1>
   }
   // CHECK: firrtl.module private @Parent0
   firrtl.module private @Parent0(out %a: !firrtl.bundle<a: uint<1>>, out %b: !firrtl.bundle<b: uint<1>>) {

--- a/test/Dialect/FIRRTL/drop-const.mlir
+++ b/test/Dialect/FIRRTL/drop-const.mlir
@@ -57,12 +57,12 @@ firrtl.module @ConstPortModule(
     out g: !firrtl.probe<const.uint<1>>
   )
 
-  firrtl.strictconnect %a2, %a : !firrtl.const.uint<1>
-  firrtl.strictconnect %b2, %b : !firrtl.const.bundle<a: uint<1>>
-  firrtl.strictconnect %c2, %c : !firrtl.bundle<a: const.uint<1>>
-  firrtl.strictconnect %d2, %d : !firrtl.const.vector<uint<1>, 3>
-  firrtl.strictconnect %e2, %e : !firrtl.vector<const.uint<1>, 3>
-  firrtl.strictconnect %f2, %f : !firrtl.const.enum<a: uint<2>, b: uint<1>>
+  firrtl.matchingconnect %a2, %a : !firrtl.const.uint<1>
+  firrtl.matchingconnect %b2, %b : !firrtl.const.bundle<a: uint<1>>
+  firrtl.matchingconnect %c2, %c : !firrtl.bundle<a: const.uint<1>>
+  firrtl.matchingconnect %d2, %d : !firrtl.const.vector<uint<1>, 3>
+  firrtl.matchingconnect %e2, %e : !firrtl.vector<const.uint<1>, 3>
+  firrtl.matchingconnect %f2, %f : !firrtl.const.enum<a: uint<2>, b: uint<1>>
   firrtl.ref.define %g, %g2 : !firrtl.probe<const.uint<1>>
 }
 
@@ -70,9 +70,9 @@ firrtl.module @ConstPortModule(
 // CHECK-LABEL: firrtl.module @ConstCastErase
 firrtl.module @ConstCastErase(in %in: !firrtl.const.uint<1>, out %out: !firrtl.uint<1>) {
   // CHECK-NOT: firrtl.constCast
-  // CHECK-NEXT: firrtl.strictconnect %out, %in : !firrtl.uint<1>
+  // CHECK-NEXT: firrtl.matchingconnect %out, %in : !firrtl.uint<1>
   %0 = firrtl.constCast %in : (!firrtl.const.uint<1>) -> !firrtl.uint<1>
-  firrtl.strictconnect %out, %0 : !firrtl.uint<1> 
+  firrtl.matchingconnect %out, %0 : !firrtl.uint<1> 
 }
 
 // Const is dropped within when blocks
@@ -80,11 +80,11 @@ firrtl.module @ConstCastErase(in %in: !firrtl.const.uint<1>, out %out: !firrtl.u
 firrtl.module @ConstDropInWhenBlock(in %cond: !firrtl.const.uint<1>, in %in1: !firrtl.const.sint<2>, in %in2: !firrtl.const.sint<2>, out %out: !firrtl.const.sint<2>) {
   // CHECK: firrtl.when %cond : !firrtl.uint<1>
   firrtl.when %cond : !firrtl.const.uint<1> {
-    // CHECK: firrtl.strictconnect %out, %in1 : !firrtl.sint<2>
-    firrtl.strictconnect %out, %in1 : !firrtl.const.sint<2>
+    // CHECK: firrtl.matchingconnect %out, %in1 : !firrtl.sint<2>
+    firrtl.matchingconnect %out, %in1 : !firrtl.const.sint<2>
   } else {
-    // CHECK: firrtl.strictconnect %out, %in2 : !firrtl.sint<2>
-    firrtl.strictconnect %out, %in2 : !firrtl.const.sint<2>
+    // CHECK: firrtl.matchingconnect %out, %in2 : !firrtl.sint<2>
+    firrtl.matchingconnect %out, %in2 : !firrtl.const.sint<2>
   }
 }
 }

--- a/test/Dialect/FIRRTL/eliminate-wires.mlir
+++ b/test/Dialect/FIRRTL/eliminate-wires.mlir
@@ -7,12 +7,12 @@ firrtl.circuit "TopLevel" {
                              out %sink: !firrtl.uint<1>) {
     // CHECK-NOT: firrtl.wire
     %w = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %w, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %w, %source : !firrtl.uint<1>
     %wn = firrtl.not %w : (!firrtl.uint<1>) -> !firrtl.uint<1>
     %x = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %x, %wn : !firrtl.uint<1>
-    firrtl.strictconnect %sink, %x : !firrtl.uint<1>
-    firrtl.strictconnect %sink, %w : !firrtl.uint<1>
+    firrtl.matchingconnect %x, %wn : !firrtl.uint<1>
+    firrtl.matchingconnect %sink, %x : !firrtl.uint<1>
+    firrtl.matchingconnect %sink, %w : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: @Foo
@@ -20,8 +20,8 @@ firrtl.circuit "TopLevel" {
     %a = firrtl.wire : !firrtl.uint<3>
     %b = firrtl.wire : !firrtl.uint<3>
     %invalid_ui3 = firrtl.invalidvalue : !firrtl.uint<3>
-    firrtl.strictconnect %b, %invalid_ui3 : !firrtl.uint<3>
-    firrtl.strictconnect %a, %b : !firrtl.uint<3>
+    firrtl.matchingconnect %b, %invalid_ui3 : !firrtl.uint<3>
+    firrtl.matchingconnect %a, %b : !firrtl.uint<3>
     // CHECK: %[[inv:.*]] = firrtl.invalidvalue : !firrtl.uint<3>
     // CHECK-NEXT:  %b = firrtl.node %[[inv]] : !firrtl.uint<3>
     // CHECK-NEXT:  %a = firrtl.node %b : !firrtl.uint<3>

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -137,14 +137,14 @@ firrtl.circuit "Foo" {
     // CHECK-NOT: _invalid
     // CHECK: invalidate someOut
     %invalid_ui2 = firrtl.invalidvalue : !firrtl.uint<1>
-    firrtl.strictconnect %someOut, %invalid_ui2 : !firrtl.uint<1>
+    firrtl.matchingconnect %someOut, %invalid_ui2 : !firrtl.uint<1>
 
     // CHECK: connect unknownReset, knownReset
     %knownReset = firrtl.wire : !firrtl.asyncreset
     %unknownReset = firrtl.wire : !firrtl.reset
     %resetCast = firrtl.resetCast %knownReset :
       (!firrtl.asyncreset) -> !firrtl.reset
-    firrtl.strictconnect %unknownReset, %resetCast : !firrtl.reset
+    firrtl.matchingconnect %unknownReset, %resetCast : !firrtl.reset
 
     // CHECK: attach(an0, an1)
     %an0 = firrtl.wire : !firrtl.analog<1>
@@ -485,7 +485,7 @@ firrtl.circuit "Foo" {
     // Make sure literals strip the 'const' prefix
     // CHECK: connect b0, UInt<42>(1)
     %c = firrtl.constant 1 : !firrtl.const.uint<42>
-    firrtl.strictconnect %b0, %c : !firrtl.const.uint<42>
+    firrtl.matchingconnect %b0, %c : !firrtl.const.uint<42>
   }
 
   // Test that literal identifiers work.
@@ -551,7 +551,7 @@ firrtl.circuit "Foo" {
     // CHECK:      inst `0bar` of `0Bar`
     // CHECK-NEXT: connect `0bar`.`0`, `3`
     %_0bar_0 = firrtl.instance "0bar" @"0Bar"(in "0": !firrtl.uint<1>)
-    firrtl.strictconnect %_0bar_0, %_3 : !firrtl.uint<1>
+    firrtl.matchingconnect %_0bar_0, %_3 : !firrtl.uint<1>
 
     // CHECK:      mem `18` :
     // CHECK-NEXT:   data-type => UInt<8>
@@ -592,18 +592,18 @@ firrtl.circuit "Foo" {
     %10 = firrtl.subfield %_18_0[en] : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data flip: uint<8>>
     %11 = firrtl.subfield %_18_0[clk] : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, data flip: uint<8>>
 
-    firrtl.strictconnect %11, %_0 : !firrtl.clock
-    firrtl.strictconnect %10, %_3 : !firrtl.uint<1>
+    firrtl.matchingconnect %11, %_0 : !firrtl.clock
+    firrtl.matchingconnect %10, %_3 : !firrtl.uint<1>
     %12 = firrtl.pad %_3, 5 : (!firrtl.uint<1>) -> !firrtl.uint<5>
-    firrtl.strictconnect %9, %12 : !firrtl.uint<5>
+    firrtl.matchingconnect %9, %12 : !firrtl.uint<5>
     firrtl.connect %_11, %8 : !firrtl.uint, !firrtl.uint<8>
-    firrtl.strictconnect %7, %_0 : !firrtl.clock
-    firrtl.strictconnect %6, %_3 : !firrtl.uint<1>
+    firrtl.matchingconnect %7, %_0 : !firrtl.clock
+    firrtl.matchingconnect %6, %_3 : !firrtl.uint<1>
     %14 = firrtl.pad %_3, 8 : (!firrtl.uint<1>) -> !firrtl.uint<8>
-    firrtl.strictconnect %5, %14 : !firrtl.uint<8>
+    firrtl.matchingconnect %5, %14 : !firrtl.uint<8>
     %15 = firrtl.pad %_3, 5 : (!firrtl.uint<1>) -> !firrtl.uint<5>
-    firrtl.strictconnect %4, %15 : !firrtl.uint<5>
-    firrtl.strictconnect %3, %_3 : !firrtl.uint<1>
+    firrtl.matchingconnect %4, %15 : !firrtl.uint<5>
+    firrtl.matchingconnect %3, %_3 : !firrtl.uint<1>
 
     // CHECK-NEXT: cmem `19` : { `0` : UInt<8> }[32]
     // CHECK-NEXT: smem `20` : { `0` : UInt<8> }[32]
@@ -618,7 +618,7 @@ firrtl.circuit "Foo" {
     chirrtl.memoryport.access %_21_port[%c8_ui5], %_0 : !chirrtl.cmemoryport, !firrtl.const.uint<5>, !firrtl.clock
     %c0_ui8 = firrtl.constant 0 : !firrtl.const.uint<8>
     %17 = firrtl.constCast %c0_ui8 : (!firrtl.const.uint<8>) -> !firrtl.uint<8>
-    firrtl.strictconnect %16, %17 : !firrtl.uint<8>
+    firrtl.matchingconnect %16, %17 : !firrtl.uint<8>
 
     // CHECK-NEXT: stop(`0`, `3`, 1) : `22`
     // CHECK-NEXT: assert(`0`, `3`, `3`, "message") : `23`
@@ -829,13 +829,13 @@ firrtl.circuit "Foo" {
     // Common case should be emitted inline.
     // CHECK: connect s, intrinsic(circt_sizeof : UInt<32>, clk)
     %0 = firrtl.int.generic "circt_sizeof"  %clk : (!firrtl.clock) -> !firrtl.uint<32>
-    firrtl.strictconnect %s, %0 : !firrtl.uint<32>
+    firrtl.matchingconnect %s, %0 : !firrtl.uint<32>
     // CHECK-NEXT: connect io1, intrinsic(circt_isX : UInt<1>, clk)
     %1 = firrtl.int.generic "circt_isX"  %clk : (!firrtl.clock) -> !firrtl.uint<1>
-    firrtl.strictconnect %io1, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %io1, %1 : !firrtl.uint<1>
     // CHECK-NEXT: connect io2, intrinsic(circt_plusargs_test<FORMAT = "foo"> : UInt<1>)
     %2 = firrtl.int.generic "circt_plusargs_test" <FORMAT: none = "foo"> : () -> !firrtl.uint<1>
-    firrtl.strictconnect %io2, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %io2, %2 : !firrtl.uint<1>
 
     // CHECK-NOT: =
     // CHECK-NEXT: intrinsic(circt_clock_gate : Clock, clk, c)
@@ -850,8 +850,8 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT: connect io4, [[PAV]].result
     %4 = firrtl.subfield %3[found] : !firrtl.bundle<found: uint<1>, result: uint<5>>
     %5 = firrtl.subfield %3[result] : !firrtl.bundle<found: uint<1>, result: uint<5>>
-    firrtl.strictconnect %io3, %4 : !firrtl.uint<1>
-    firrtl.strictconnect %io4, %5 : !firrtl.uint<5>
+    firrtl.matchingconnect %io3, %4 : !firrtl.uint<1>
+    firrtl.matchingconnect %io4, %5 : !firrtl.uint<5>
 
     // Nested once should be inlined.
     // CHECK-NEXT: intrinsic(circt_verif_assert, intrinsic(circt_isX : UInt<1>, c))

--- a/test/Dialect/FIRRTL/emit-omir.mlir
+++ b/test/Dialect/FIRRTL/emit-omir.mlir
@@ -371,17 +371,17 @@ firrtl.circuit "Top"  attributes {annotations = [{
     %0 = firrtl.subfield %a_in1[io] : !firrtl.bundle<io: bundle<f0: uint<4>, f1: uint<4>>>
     %1 = firrtl.subfield %a_in0[io]: !firrtl.bundle<io: vector<uint<4>, 2>>
     %2 = firrtl.subindex %a_out0[0] : !firrtl.vector<uint<4>, 2>
-    firrtl.strictconnect %out0_0, %2 : !firrtl.uint<4>
+    firrtl.matchingconnect %out0_0, %2 : !firrtl.uint<4>
     %3 = firrtl.subindex %a_out0[1] : !firrtl.vector<uint<4>, 2>
-    firrtl.strictconnect %out0_1, %3 : !firrtl.uint<4>
+    firrtl.matchingconnect %out0_1, %3 : !firrtl.uint<4>
     %4 = firrtl.subfield %a_out1[f0] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
-    firrtl.strictconnect %out1_f0, %4 : !firrtl.uint<4>
+    firrtl.matchingconnect %out1_f0, %4 : !firrtl.uint<4>
     %5 = firrtl.subfield %a_out1[f1] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
-    firrtl.strictconnect %out1_f1, %5 : !firrtl.uint<4>
+    firrtl.matchingconnect %out1_f1, %5 : !firrtl.uint<4>
     %6 = firrtl.bundlecreate %in1_f0, %in1_f1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.bundle<f0: uint<4>, f1: uint<4>>
-    firrtl.strictconnect %0, %6 : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
+    firrtl.matchingconnect %0, %6 : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
     %7 = firrtl.vectorcreate %in0_0, %in0_1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.vector<uint<4>, 2>
-    firrtl.strictconnect %1, %7 : !firrtl.vector<uint<4>, 2>
+    firrtl.matchingconnect %1, %7 : !firrtl.vector<uint<4>, 2>
   }
   // CHECK-LABEL: firrtl.module private @A
   // CHECK-SAME:    %in0: !firrtl.bundle<io: vector<uint<4>, 2>> sym @[[in0_sym:[^ ]+]],
@@ -406,28 +406,28 @@ firrtl.circuit "Top"  attributes {annotations = [{
     %5 = firrtl.subfield %0[f1] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
     %6 = firrtl.subindex %w0[0] : !firrtl.vector<uint<4>, 2>
     %7 = firrtl.subindex %out0[0] : !firrtl.vector<uint<4>, 2>
-    firrtl.strictconnect %7, %6 : !firrtl.uint<4>
+    firrtl.matchingconnect %7, %6 : !firrtl.uint<4>
     %8 = firrtl.subindex %w0[1] : !firrtl.vector<uint<4>, 2>
     %9 = firrtl.subindex %out0[1] : !firrtl.vector<uint<4>, 2>
-    firrtl.strictconnect %9, %8 : !firrtl.uint<4>
+    firrtl.matchingconnect %9, %8 : !firrtl.uint<4>
     %10 = firrtl.subfield %w1[f0] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
     %11 = firrtl.subfield %out1[f0] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
-    firrtl.strictconnect %11, %10 : !firrtl.uint<4>
+    firrtl.matchingconnect %11, %10 : !firrtl.uint<4>
     %12 = firrtl.subfield %w1[f1] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
     %13 = firrtl.subfield %out1[f1] : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
-    firrtl.strictconnect %13, %12 : !firrtl.uint<4>
+    firrtl.matchingconnect %13, %12 : !firrtl.uint<4>
     %14 = firrtl.vectorcreate %2, %3 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.vector<uint<4>, 2>
-    firrtl.strictconnect %w0, %14 : !firrtl.vector<uint<4>, 2>
+    firrtl.matchingconnect %w0, %14 : !firrtl.vector<uint<4>, 2>
     %15 = firrtl.bundlecreate %4, %5 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.bundle<f0: uint<4>, f1: uint<4>>
-    firrtl.strictconnect %w1, %15 : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
+    firrtl.matchingconnect %w1, %15 : !firrtl.bundle<f0: uint<4>, f1: uint<4>>
 
     // CHECK: %wf, %wf_ref = firrtl.wire sym @[[wf_sym:[^ ]+]] forceable
     %wf, %wf_ref = firrtl.wire forceable {annotations = [{circt.fieldID = 2 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 9 : i64},
                                         {circt.fieldID = 1 : i32, circt.nonlocal = @nla, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 8 : i64}]} : !firrtl.vector<uint<4>, 2>, !firrtl.rwprobe<vector<uint<4>, 2>>
     %wf_0 = firrtl.subindex %wf[0] : !firrtl.vector<uint<4>, 2>
     %wf_1 = firrtl.subindex %wf[1] : !firrtl.vector<uint<4>, 2>
-    firrtl.strictconnect %wf_0, %2 : !firrtl.uint<4>
-    firrtl.strictconnect %wf_1, %3 : !firrtl.uint<4>
+    firrtl.matchingconnect %wf_0, %2 : !firrtl.uint<4>
+    firrtl.matchingconnect %wf_1, %3 : !firrtl.uint<4>
   }
 }
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -921,7 +921,7 @@ firrtl.circuit "Top" {
   firrtl.module @Top (in %in : !firrtl.uint) {
     %a = firrtl.wire : !firrtl.uint
     // expected-error @+1 {{op operand #0 must be a sized passive base type}}
-    firrtl.strictconnect %a, %in : !firrtl.uint
+    firrtl.matchingconnect %a, %in : !firrtl.uint
   }
 }
 
@@ -1161,7 +1161,7 @@ firrtl.circuit "Top" {
   firrtl.module @Top (out %out: !firrtl.probe<uint<2>>) {
     %foo_out = firrtl.instance foo @Foo(out out: !firrtl.probe<uint<2>>)
     // expected-error @below {{must be a sized passive base type}}
-    firrtl.strictconnect %out, %foo_out: !firrtl.probe<uint<2>>
+    firrtl.matchingconnect %out, %foo_out: !firrtl.probe<uint<2>>
   }
 }
 
@@ -1323,7 +1323,7 @@ firrtl.circuit "PropertyConnect" {
   firrtl.module @PropertyConnect(out %out: !firrtl.string) {
     %0 = firrtl.string "hello"
     // expected-error @below {{must be a sized passive base type}}
-    firrtl.strictconnect %out, %0 : !firrtl.string
+    firrtl.matchingconnect %out, %0 : !firrtl.string
   }
 }
 
@@ -1810,7 +1810,7 @@ firrtl.circuit "ConstOpenBundle" {
 firrtl.circuit "NonEquivalenctStrictConnect" {
   firrtl.module @NonEquivalenctStrictConnect(in %in: !firrtl.uint<1>, out %out: !firrtl.alias<foo, uint<2>>) {
     // expected-error @below {{op failed to verify that operands must be structurally equivalent}}
-    firrtl.strictconnect %out, %in: !firrtl.alias<foo, uint<2>>, !firrtl.uint<1>
+    firrtl.matchingconnect %out, %in: !firrtl.alias<foo, uint<2>>, !firrtl.uint<1>
   }
 }
 
@@ -1922,8 +1922,8 @@ firrtl.circuit "LayerBlockDrivesSinksOutside" {
     firrtl.layerblock @A {
       firrtl.when %cond : !firrtl.uint<1> {
         %b_c = firrtl.subfield %b[c] : !firrtl.bundle<c: uint<1>>
-        // expected-error @below {{'firrtl.strictconnect' op connects to a destination which is defined outside its enclosing layer block}}
-        firrtl.strictconnect %b_c, %a : !firrtl.uint<1>
+        // expected-error @below {{'firrtl.matchingconnect' op connects to a destination which is defined outside its enclosing layer block}}
+        firrtl.matchingconnect %b_c, %a : !firrtl.uint<1>
       }
     }
   }

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -582,9 +582,9 @@ firrtl.module @WhenInGroup(in %cond : !firrtl.uint<1>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %a = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %a, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %c0_ui1 : !firrtl.uint<1>
     firrtl.when %cond : !firrtl.uint<1> {
-      firrtl.strictconnect %a, %c1_ui1 : !firrtl.uint<1>
+      firrtl.matchingconnect %a, %c1_ui1 : !firrtl.uint<1>
     }
   }
 }

--- a/test/Dialect/FIRRTL/extract-instances.mlir
+++ b/test/Dialect/FIRRTL/extract-instances.mlir
@@ -20,7 +20,7 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
     // CHECK-NOT: firrtl.instance bb @MyBlackBox
     %bb_in, %bb_out = firrtl.instance bb @MyBlackBox(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
     %invalid_ui8 = firrtl.invalidvalue : !firrtl.uint<8>
-    firrtl.strictconnect %bb_in, %invalid_ui8 : !firrtl.uint<8>
+    firrtl.matchingconnect %bb_in, %invalid_ui8 : !firrtl.uint<8>
     // CHECK: firrtl.connect %out, %bb_0_out
     // CHECK: firrtl.connect %bb_0_in, %in
     firrtl.connect %out, %bb_out : !firrtl.uint<8>, !firrtl.uint<8>
@@ -32,8 +32,8 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
   firrtl.module private @DUTModule(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     // CHECK-NOT: firrtl.instance bb @MyBlackBox
     // CHECK: %mod_in, %mod_out, %mod_bb_0_in, %mod_bb_0_out = firrtl.instance mod sym [[WRAPPER_SYM:@.+]] @BBWrapper
-    // CHECK-NEXT: firrtl.strictconnect %bb_0_in, %mod_bb_0_in
-    // CHECK-NEXT: firrtl.strictconnect %mod_bb_0_out, %bb_0_out
+    // CHECK-NEXT: firrtl.matchingconnect %bb_0_in, %mod_bb_0_in
+    // CHECK-NEXT: firrtl.matchingconnect %mod_bb_0_out, %bb_0_out
     %mod_in, %mod_out = firrtl.instance mod @BBWrapper(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
     firrtl.connect %out, %mod_out : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %mod_in, %in : !firrtl.uint<8>, !firrtl.uint<8>
@@ -42,8 +42,8 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
   firrtl.module @ExtractBlackBoxesSimple(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
     // CHECK: %dut_in, %dut_out, %dut_bb_0_in, %dut_bb_0_out = firrtl.instance dut sym {{@.+}} @DUTModule
     // CHECK-NEXT: %bb_in, %bb_out = firrtl.instance bb @MyBlackBox
-    // CHECK-NEXT: firrtl.strictconnect %bb_in, %dut_bb_0_in
-    // CHECK-NEXT: firrtl.strictconnect %dut_bb_0_out, %bb_out
+    // CHECK-NEXT: firrtl.matchingconnect %bb_in, %dut_bb_0_in
+    // CHECK-NEXT: firrtl.matchingconnect %dut_bb_0_out, %bb_out
     %dut_in, %dut_out = firrtl.instance dut @DUTModule(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
     firrtl.connect %out, %dut_out : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %dut_in, %in : !firrtl.uint<8>, !firrtl.uint<8>
@@ -123,10 +123,10 @@ firrtl.circuit "ExtractBlackBoxesSimple2" attributes {annotations = [{class = "f
     // CHECK: %mod_in, %mod_out, %mod_prefix_0_in, %mod_prefix_0_out, %mod_prefix_1_in, %mod_prefix_1_out = firrtl.instance mod
     // CHECK-SAME: sym [[WRAPPER_SYM:@.+]] @BBWrapper
     // CHECK-NOT: annotations =
-    // CHECK-NEXT: firrtl.strictconnect %prefix_1_in, %mod_prefix_1_in
-    // CHECK-NEXT: firrtl.strictconnect %mod_prefix_1_out, %prefix_1_out
-    // CHECK-NEXT: firrtl.strictconnect %prefix_0_in, %mod_prefix_0_in
-    // CHECK-NEXT: firrtl.strictconnect %mod_prefix_0_out, %prefix_0_out
+    // CHECK-NEXT: firrtl.matchingconnect %prefix_1_in, %mod_prefix_1_in
+    // CHECK-NEXT: firrtl.matchingconnect %mod_prefix_1_out, %prefix_1_out
+    // CHECK-NEXT: firrtl.matchingconnect %prefix_0_in, %mod_prefix_0_in
+    // CHECK-NEXT: firrtl.matchingconnect %mod_prefix_0_out, %prefix_0_out
     %mod_in, %mod_out = firrtl.instance mod sym @mod @BBWrapper(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
     firrtl.connect %out, %mod_out : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %mod_in, %in : !firrtl.uint<8>, !firrtl.uint<8>
@@ -137,11 +137,11 @@ firrtl.circuit "ExtractBlackBoxesSimple2" attributes {annotations = [{class = "f
     // CHECK-NOT: annotations =
     // CHECK-SAME: sym {{@.+}} @DUTModule
     // CHECK-NEXT: %bb_in, %bb_out = firrtl.instance bb sym [[BB_SYM:@.+]] {annotations = [{class = "Old1"}, {class = "On1"}, {class = "Old2"}, {class = "On2"}]} @MyBlackBox
-    // CHECK-NEXT: firrtl.strictconnect %bb_in, %dut_prefix_1_in
-    // CHECK-NEXT: firrtl.strictconnect %dut_prefix_1_out, %bb_out
+    // CHECK-NEXT: firrtl.matchingconnect %bb_in, %dut_prefix_1_in
+    // CHECK-NEXT: firrtl.matchingconnect %dut_prefix_1_out, %bb_out
     // CHECK-NEXT: %bb2_in, %bb2_out = firrtl.instance bb2 @MyBlackBox2
-    // CHECK-NEXT: firrtl.strictconnect %bb2_in, %dut_prefix_0_in
-    // CHECK-NEXT: firrtl.strictconnect %dut_prefix_0_out, %bb2_out
+    // CHECK-NEXT: firrtl.matchingconnect %bb2_in, %dut_prefix_0_in
+    // CHECK-NEXT: firrtl.matchingconnect %dut_prefix_0_out, %bb2_out
     %dut_in, %dut_out = firrtl.instance dut sym @dut @DUTModule(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
     firrtl.connect %out, %dut_out : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %dut_in, %in : !firrtl.uint<8>, !firrtl.uint<8>
@@ -219,11 +219,11 @@ firrtl.circuit "ExtractBlackBoxesIntoDUTSubmodule"  {
   // CHECK-SAME:    out %bb_1_out: !firrtl.uint<8>
   // CHECK-SAME:  ) {
   // CHECK-NEXT:    %bb2_in, %bb2_out = firrtl.instance bb2 sym [[BB2_SYM:@.+]] {annotations = [{circt.nonlocal = @nla_new_0, class = "Dummy4"}, {circt.nonlocal = @nla_old2, class = "Dummy2"}]} @MyBlackBox(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
-  // CHECK-NEXT:    firrtl.strictconnect %bb2_in, %bb_0_in : !firrtl.uint<8>
-  // CHECK-NEXT:    firrtl.strictconnect %bb_0_out, %bb2_out : !firrtl.uint<8>
+  // CHECK-NEXT:    firrtl.matchingconnect %bb2_in, %bb_0_in : !firrtl.uint<8>
+  // CHECK-NEXT:    firrtl.matchingconnect %bb_0_out, %bb2_out : !firrtl.uint<8>
   // CHECK-NEXT:    %bb1_in, %bb1_out = firrtl.instance bb1 sym [[BB1_SYM:@.+]] {annotations = [{circt.nonlocal = @nla_new_1, class = "Dummy3"}, {circt.nonlocal = @nla_old1, class = "Dummy1"}]} @MyBlackBox(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
-  // CHECK-NEXT:    firrtl.strictconnect %bb1_in, %bb_1_in : !firrtl.uint<8>
-  // CHECK-NEXT:    firrtl.strictconnect %bb_1_out, %bb1_out : !firrtl.uint<8>
+  // CHECK-NEXT:    firrtl.matchingconnect %bb1_in, %bb_1_in : !firrtl.uint<8>
+  // CHECK-NEXT:    firrtl.matchingconnect %bb_1_out, %bb1_out : !firrtl.uint<8>
   // CHECK-NEXT:  }
   // CHECK-LABEL: firrtl.module private @DUTModule
   firrtl.module private @DUTModule(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
@@ -232,10 +232,10 @@ firrtl.circuit "ExtractBlackBoxesIntoDUTSubmodule"  {
     // CHECK-NEXT: %mod_in, %mod_out, %mod_bb_0_in, %mod_bb_0_out, %mod_bb_1_in, %mod_bb_1_out = firrtl.instance mod
     // CHECK-NOT: annotations =
     // CHECK-SAME: sym [[WRAPPER_SYM:@.+]] @BBWrapper
-    // CHECK-NEXT: firrtl.strictconnect %BlackBoxes_bb_1_in, %mod_bb_1_in
-    // CHECK-NEXT: firrtl.strictconnect %mod_bb_1_out, %BlackBoxes_bb_1_out
-    // CHECK-NEXT: firrtl.strictconnect %BlackBoxes_bb_0_in, %mod_bb_0_in
-    // CHECK-NEXT: firrtl.strictconnect %mod_bb_0_out, %BlackBoxes_bb_0_out
+    // CHECK-NEXT: firrtl.matchingconnect %BlackBoxes_bb_1_in, %mod_bb_1_in
+    // CHECK-NEXT: firrtl.matchingconnect %mod_bb_1_out, %BlackBoxes_bb_1_out
+    // CHECK-NEXT: firrtl.matchingconnect %BlackBoxes_bb_0_in, %mod_bb_0_in
+    // CHECK-NEXT: firrtl.matchingconnect %mod_bb_0_out, %BlackBoxes_bb_0_out
     %mod_in, %mod_out = firrtl.instance mod sym @mod @BBWrapper(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
     firrtl.connect %out, %mod_out : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %mod_in, %in : !firrtl.uint<8>, !firrtl.uint<8>
@@ -490,15 +490,15 @@ firrtl.circuit "InstSymConflict" {
         {circt.nonlocal = @nla_1, class = "DummyA"},
         {circt.nonlocal = @nla_2, class = "DummyB"}
       ]} @MyBlackBox(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
-    firrtl.strictconnect %bb_in, %in : !firrtl.uint<8>
-    firrtl.strictconnect %out, %bb_out : !firrtl.uint<8>
+    firrtl.matchingconnect %bb_in, %in : !firrtl.uint<8>
+    firrtl.matchingconnect %out, %bb_out : !firrtl.uint<8>
   }
   firrtl.module private @DUTModule(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     %mod1_in, %mod1_out = firrtl.instance mod1 sym @mod1 @BBWrapper(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
     %mod2_in, %mod2_out = firrtl.instance mod2 sym @mod2 @BBWrapper(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
-    firrtl.strictconnect %mod1_in, %in : !firrtl.uint<8>
-    firrtl.strictconnect %mod2_in, %mod1_out : !firrtl.uint<8>
-    firrtl.strictconnect %out, %mod2_out : !firrtl.uint<8>
+    firrtl.matchingconnect %mod1_in, %in : !firrtl.uint<8>
+    firrtl.matchingconnect %mod2_in, %mod1_out : !firrtl.uint<8>
+    firrtl.matchingconnect %out, %mod2_out : !firrtl.uint<8>
   }
   // CHECK-LABEL: firrtl.module @InstSymConflict
   firrtl.module @InstSymConflict(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
@@ -506,8 +506,8 @@ firrtl.circuit "InstSymConflict" {
     // CHECK: firrtl.instance bb sym @bb {annotations = [{class = "DummyB"}]} @MyBlackBox
     // CHECK: firrtl.instance bb sym @bb_0 {annotations = [{class = "DummyA"}]} @MyBlackBox
     %dut_in, %dut_out = firrtl.instance dut sym @dut @DUTModule(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
-    firrtl.strictconnect %dut_in, %in : !firrtl.uint<8>
-    firrtl.strictconnect %out, %dut_out : !firrtl.uint<8>
+    firrtl.matchingconnect %dut_in, %in : !firrtl.uint<8>
+    firrtl.matchingconnect %out, %dut_out : !firrtl.uint<8>
   }
   // CHECK:               emit.file "BlackBoxes.txt" {
   // CHECK-NEXT:            sv.verbatim "

--- a/test/Dialect/FIRRTL/flatten-memory.mlir
+++ b/test/Dialect/FIRRTL/flatten-memory.mlir
@@ -5,72 +5,72 @@ firrtl.circuit "Mem" {
   firrtl.module public  @Mem(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.bundle<a: uint<8>, b: uint<8>>, in %wAddr: !firrtl.uint<4>, in %wEn: !firrtl.uint<1>, in %wMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, in %wData: !firrtl.bundle<a: uint<8>, b: uint<8>>) {
     %memory_r, %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     %0 = firrtl.subfield %memory_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
-    firrtl.strictconnect %0, %clock : !firrtl.clock
+    firrtl.matchingconnect %0, %clock : !firrtl.clock
     %1 = firrtl.subfield %memory_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
-    firrtl.strictconnect %1, %rEn : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %rEn : !firrtl.uint<1>
     %2 = firrtl.subfield %memory_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
-    firrtl.strictconnect %2, %rAddr : !firrtl.uint<4>
+    firrtl.matchingconnect %2, %rAddr : !firrtl.uint<4>
     %3 = firrtl.subfield %memory_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
-    firrtl.strictconnect %rData, %3 : !firrtl.bundle<a: uint<8>, b: uint<8>>
+    firrtl.matchingconnect %rData, %3 : !firrtl.bundle<a: uint<8>, b: uint<8>>
     %4 = firrtl.subfield %memory_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    firrtl.strictconnect %4, %clock : !firrtl.clock
+    firrtl.matchingconnect %4, %clock : !firrtl.clock
     %5 = firrtl.subfield %memory_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    firrtl.strictconnect %5, %wEn : !firrtl.uint<1>
+    firrtl.matchingconnect %5, %wEn : !firrtl.uint<1>
     %6 = firrtl.subfield %memory_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    firrtl.strictconnect %6, %wAddr : !firrtl.uint<4>
+    firrtl.matchingconnect %6, %wAddr : !firrtl.uint<4>
     %7 = firrtl.subfield %memory_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    firrtl.strictconnect %7, %wMask : !firrtl.bundle<a: uint<1>, b: uint<1>>
+    firrtl.matchingconnect %7, %wMask : !firrtl.bundle<a: uint<1>, b: uint<1>>
     %8 = firrtl.subfield %memory_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    firrtl.strictconnect %8, %wData : !firrtl.bundle<a: uint<8>, b: uint<8>>
+    firrtl.matchingconnect %8, %wData : !firrtl.bundle<a: uint<8>, b: uint<8>>
     // ---------------------------------------------------------------------------------
     // After flattenning the memory data
     // CHECK: %[[memory_r:.+]], %[[memory_w:.+]] = firrtl.mem Undefined  {depth = 16 : i64, name = "memory", portNames = ["r", "w"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32}
     // CHECK-SAME: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<16>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<16>, mask: uint<2>>
     // CHECK: %[[memory_r_0:.+]] = firrtl.wire  {name = "memory_r"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
     // CHECK: %[[v0:.+]] = firrtl.subfield %[[memory_r]][addr]
-    // CHECK: firrtl.strictconnect %[[v0]], %[[memory_r_addr:.+]] :
+    // CHECK: firrtl.matchingconnect %[[v0]], %[[memory_r_addr:.+]] :
     // CHECK: %[[v1:.+]] = firrtl.subfield %[[memory_r]][en]
-    // CHECK: firrtl.strictconnect %[[v1]], %[[memory_r_en:.+]] :
+    // CHECK: firrtl.matchingconnect %[[v1]], %[[memory_r_en:.+]] :
     // CHECK: %[[v2:.+]] = firrtl.subfield %[[memory_r]][clk]
-    // CHECK: firrtl.strictconnect %[[v2]], %[[memory_r_clk:.+]] :
+    // CHECK: firrtl.matchingconnect %[[v2]], %[[memory_r_clk:.+]] :
     // CHECK: %[[v3:.+]] = firrtl.subfield %[[memory_r]][data]
     //
     // ---------------------------------------------------------------------------------
     // Read ports
     // CHECK:  %[[v4:.+]] = firrtl.bitcast %[[v3]] : (!firrtl.uint<16>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
-    // CHECK:  firrtl.strictconnect %[[memory_r_data:.+]], %[[v4]] :
+    // CHECK:  firrtl.matchingconnect %[[memory_r_data:.+]], %[[v4]] :
     // --------------------------------------------------------------------------------
     // Write Ports
     // CHECK:  %[[memory_w_1:.+]] = firrtl.wire  {name = "memory_w"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  %[[v9:.+]] = firrtl.subfield %[[memory_w]][data]
     // CHECK:  %[[v17:.+]] = firrtl.bitcast %[[v15:.+]] : (!firrtl.bundle<a: uint<8>, b: uint<8>>) -> !firrtl.uint<16>
-    // CHECK:  firrtl.strictconnect %[[v9]], %[[v17]]
+    // CHECK:  firrtl.matchingconnect %[[v9]], %[[v17]]
     //
     // --------------------------------------------------------------------------------
     // Mask Ports
     //  CHECK: %[[v11:.+]] = firrtl.subfield %[[memory_w]][mask]
     //  CHECK: %[[v12:.+]] = firrtl.bitcast %[[v18:.+]] : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<2>
-    //  CHECK: firrtl.strictconnect %[[v11]], %[[v12]]
+    //  CHECK: firrtl.matchingconnect %[[v11]], %[[v12]]
     // --------------------------------------------------------------------------------
     // Connections to module ports
     // CHECK:  %[[v21:.+]] = firrtl.subfield %[[memory_r_0]][clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
-    // CHECK:  firrtl.strictconnect %[[v21]], %clock :
+    // CHECK:  firrtl.matchingconnect %[[v21]], %clock :
     // CHECK:  %[[v22:.+]]  = firrtl.subfield %[[memory_r_0]][en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
-    // CHECK:  firrtl.strictconnect %[[v22]], %rEn : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %[[v22]], %rEn : !firrtl.uint<1>
     // CHECK:  %[[v23:.+]]  = firrtl.subfield %[[memory_r_0]][addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
-    // CHECK:  firrtl.strictconnect %[[v23]], %rAddr : !firrtl.uint<4>
+    // CHECK:  firrtl.matchingconnect %[[v23]], %rAddr : !firrtl.uint<4>
     // CHECK:  %[[v24:.+]]  = firrtl.subfield %[[memory_r_0]][data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
-    // CHECK:  firrtl.strictconnect %rData, %[[v24]] : !firrtl.bundle<a: uint<8>, b: uint<8>>
+    // CHECK:  firrtl.matchingconnect %rData, %[[v24]] : !firrtl.bundle<a: uint<8>, b: uint<8>>
     // CHECK:  %[[v25:.+]]  = firrtl.subfield %[[memory_w_1]][clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    // CHECK:  firrtl.strictconnect %[[v25]], %clock : !firrtl.clock
+    // CHECK:  firrtl.matchingconnect %[[v25]], %clock : !firrtl.clock
     // CHECK:  %[[v26:.+]]  = firrtl.subfield %[[memory_w_1]][en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    // CHECK:  firrtl.strictconnect %[[v26]], %wEn : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %[[v26]], %wEn : !firrtl.uint<1>
     // CHECK:  %[[v27:.+]]  = firrtl.subfield %[[memory_w_1]][addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    // CHECK:  firrtl.strictconnect %[[v27]], %wAddr : !firrtl.uint<4>
+    // CHECK:  firrtl.matchingconnect %[[v27]], %wAddr : !firrtl.uint<4>
     // CHECK:  %[[v28:.+]]  = firrtl.subfield %[[memory_w_1]][mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    // CHECK:  firrtl.strictconnect %[[v28]], %wMask : !firrtl.bundle<a: uint<1>, b: uint<1>>
+    // CHECK:  firrtl.matchingconnect %[[v28]], %wMask : !firrtl.bundle<a: uint<1>, b: uint<1>>
     // CHECK:  %[[v29:.+]]  = firrtl.subfield %[[memory_w_1]][data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    // CHECK:  firrtl.strictconnect %[[v29]], %wData : !firrtl.bundle<a: uint<8>, b: uint<8>>
+    // CHECK:  firrtl.matchingconnect %[[v29]], %wData : !firrtl.bundle<a: uint<8>, b: uint<8>>
   }
 
 firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>, in %rwMode: !firrtl.uint<1>, in %rwAddr: !firrtl.uint<4>, in %rwMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, in %rwDataIn: !firrtl.bundle<a: uint<8>, b: uint<9>>, out %rwDataOut: !firrtl.bundle<a: uint<8>, b: uint<9>>) {
@@ -94,14 +94,14 @@ firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>
   // CHECK:  %[[v6:.+]] = firrtl.subfield %[[memory_rw_0]][rdata] :
   // CHECK:  %[[v7:.+]] = firrtl.subfield %memory_rw[rdata] :
   // CHECK:  %[[v8:.+]] = firrtl.bitcast %[[v7]] :
-  // CHECK:  firrtl.strictconnect %[[v6]], %[[v8]] :
+  // CHECK:  firrtl.matchingconnect %[[v6]], %[[v8]] :
   // CHECK:  %[[v9:.+]] = firrtl.subfield %[[memory_rw_0]][wmode] :
   // CHECK:  %[[v10:.+]] = firrtl.subfield %memory_rw[wmode] :
-  // CHECK:  firrtl.strictconnect %[[v10]], %[[v9]] : !firrtl.uint<1>
+  // CHECK:  firrtl.matchingconnect %[[v10]], %[[v9]] : !firrtl.uint<1>
   // CHECK:  %[[v11:.+]] = firrtl.subfield %[[memory_rw_0]][wdata] :
   // CHECK:  %[[v12:.+]] = firrtl.subfield %memory_rw[wdata] :
   // CHECK:  %[[v13:.+]] = firrtl.bitcast %[[v11]] : (!firrtl.bundle<a: uint<8>, b: uint<9>>) -> !firrtl.uint<17>
-  // CHECK:  firrtl.strictconnect %[[v12]], %[[v13]] :
+  // CHECK:  firrtl.matchingconnect %[[v12]], %[[v13]] :
   // CHECK:  %[[v14:.+]] = firrtl.subfield %[[memory_rw_0]][wmask] :
   // CHECK:  %[[v15:.+]] = firrtl.subfield %memory_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<17>, wmode: uint<1>, wdata: uint<17>, wmask: uint<17>>
   // CHECK:  %[[v16:.+]] = firrtl.bitcast %14 : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<2>
@@ -114,7 +114,7 @@ firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>
   // CHECK:  %[[v27:.+]] = firrtl.cat %[[v25]], %[[v26]] : (!firrtl.uint<1>, !firrtl.uint<9>) -> !firrtl.uint<10>
   // CHECK:  %[[v28:.+]] = firrtl.cat %[[v25]], %[[v27]] : (!firrtl.uint<1>, !firrtl.uint<10>) -> !firrtl.uint<11>
   // CHECK:  %[[v34:.+]] = firrtl.cat %[[v25]], %[[v33:.+]] : (!firrtl.uint<1>, !firrtl.uint<16>) -> !firrtl.uint<17>
-  // CHECK:  firrtl.strictconnect %[[v15]], %[[v34]] :
+  // CHECK:  firrtl.matchingconnect %[[v15]], %[[v34]] :
   // Ensure 0 bit fields are handled properly.
   %ram_MPORT = firrtl.mem Undefined  {depth = 4 : i64, name = "ram", portNames = ["MPORT"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: bundle<entry: bundle<a: uint<0>, b: uint<1>, c: uint<2>>>, mask: bundle<entry: bundle<a: uint<1>, b: uint<1>, c: uint<1>>>>
   // CHECK: %ram_MPORT = firrtl.mem Undefined  {depth = 4 : i64, name = "ram", portNames = ["MPORT"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: uint<3>, mask: uint<3>>
@@ -127,23 +127,23 @@ firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>
     %invalid_0 = firrtl.invalidvalue : !firrtl.bundle<a: uint<0>, b: uint<20>>
     %ram_MPORT = firrtl.mem Undefined  {depth = 1 : i64, name = "ram", portNames = ["MPORT"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
     %3 = firrtl.subfield %ram_MPORT[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    firrtl.strictconnect %3, %invalid_0 : !firrtl.bundle<a: uint<0>, b: uint<20>>
+    firrtl.matchingconnect %3, %invalid_0 : !firrtl.bundle<a: uint<0>, b: uint<20>>
     %4 = firrtl.subfield %ram_MPORT[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    firrtl.strictconnect %4, %invalid : !firrtl.bundle<a: uint<1>, b: uint<1>>
+    firrtl.matchingconnect %4, %invalid : !firrtl.bundle<a: uint<1>, b: uint<1>>
     // CHECK:  %ram_MPORT = firrtl.mem Undefined  {depth = 1 : i64, name = "ram", portNames = ["MPORT"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<20>, mask: uint<1>>
     // CHECK:  %ram_MPORT_1 = firrtl.wire  {name = "ram_MPORT"} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  %[[v6:.+]] = firrtl.subfield %ram_MPORT_1[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  %[[v7:.+]] = firrtl.subfield %ram_MPORT[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<20>, mask: uint<1>>
     // CHECK:  %[[v8:.+]] = firrtl.bitcast %6 : (!firrtl.bundle<a: uint<0>, b: uint<20>>) -> !firrtl.uint<20>
-    // CHECK:  firrtl.strictconnect %7, %8 : !firrtl.uint<20>
+    // CHECK:  firrtl.matchingconnect %7, %8 : !firrtl.uint<20>
     // CHECK:  %[[v9:.+]] = firrtl.subfield %ram_MPORT_1[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  %[[v10:.+]] = firrtl.subfield %ram_MPORT[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<20>, mask: uint<1>>
     // CHECK:  %[[v11:.+]] = firrtl.bitcast %9 : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<2>
     // CHECK:  %[[v12:.+]] = firrtl.bits %11 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
     // CHECK:  %[[v13:.+]] = firrtl.bits %11 1 to 1 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %[[v10]], %[[v13]] : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %[[v10]], %[[v13]] : !firrtl.uint<1>
     // CHECK:  %[[v14:.+]] = firrtl.subfield %ram_MPORT_1[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    // CHECK:  firrtl.strictconnect %[[v14]], %invalid_0 : !firrtl.bundle<a: uint<0>, b: uint<20>>
+    // CHECK:  firrtl.matchingconnect %[[v14]], %invalid_0 : !firrtl.bundle<a: uint<0>, b: uint<20>>
     // CHECK:  %[[v15:.+]] = firrtl.subfield %ram_MPORT_1[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.connect %3, %io : !firrtl.bundle<a: uint<0>, b: uint<20>>, !firrtl.bundle<a: uint<0>, b: uint<20>>
   }

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1018,13 +1018,13 @@ firrtl.circuit "Top" attributes {
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %a_w1 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
-    firrtl.strictconnect %a_w1, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %a_w1, %c0_ui1 : !firrtl.uint<1>
     %a_w2 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<2>
-    firrtl.strictconnect %a_w2, %c0_ui2 : !firrtl.uint<2>
+    firrtl.matchingconnect %a_w2, %c0_ui2 : !firrtl.uint<2>
     %companion_w1__gen_uint = firrtl.instance companion_w1  @Companion_w1(in _gen_uint: !firrtl.uint<1>)
     %companion_w2__gen_uint = firrtl.instance companion_w2  @Companion_w2(in _gen_uint: !firrtl.uint<2>)
-    firrtl.strictconnect %companion_w1__gen_uint, %a_w1 : !firrtl.uint<1>
-    firrtl.strictconnect %companion_w2__gen_uint, %a_w2 : !firrtl.uint<2>
+    firrtl.matchingconnect %companion_w1__gen_uint, %a_w1 : !firrtl.uint<1>
+    firrtl.matchingconnect %companion_w2__gen_uint, %a_w2 : !firrtl.uint<2>
   }
   firrtl.module @Top() {
     firrtl.instance dut  @DUT()

--- a/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
+++ b/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
@@ -11,10 +11,10 @@ firrtl.circuit "VectorPropagation1" {
     %0 = firrtl.subindex %tmp[0] : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.subindex %tmp[1] : !firrtl.vector<uint<1>, 2>
     %2 = firrtl.xor %0, %1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %0, %c1_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %1, %c1_ui1 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %b, %c0_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %b, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %c1_ui1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %b, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %2 : !firrtl.uint<1>
   }
 }
 
@@ -44,28 +44,28 @@ firrtl.circuit "VectorPropagation2" {
     %tmp = firrtl.wire  : !firrtl.vector<vector<uint<6>, 2>, 3>
     %0 = firrtl.subindex %tmp[0] : !firrtl.vector<vector<uint<6>, 2>, 3>
     %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<6>, 2>
-    firrtl.strictconnect %1, %c1_ui6 : !firrtl.uint<6>
+    firrtl.matchingconnect %1, %c1_ui6 : !firrtl.uint<6>
     %2 = firrtl.subindex %0[1] : !firrtl.vector<uint<6>, 2>
-    firrtl.strictconnect %2, %c2_ui6 : !firrtl.uint<6>
+    firrtl.matchingconnect %2, %c2_ui6 : !firrtl.uint<6>
     %3 = firrtl.subindex %tmp[1] : !firrtl.vector<vector<uint<6>, 2>, 3>
     %4 = firrtl.subindex %3[0] : !firrtl.vector<uint<6>, 2>
-    firrtl.strictconnect %4, %c4_ui6 : !firrtl.uint<6>
+    firrtl.matchingconnect %4, %c4_ui6 : !firrtl.uint<6>
     %5 = firrtl.subindex %3[1] : !firrtl.vector<uint<6>, 2>
-    firrtl.strictconnect %5, %c8_ui6 : !firrtl.uint<6>
+    firrtl.matchingconnect %5, %c8_ui6 : !firrtl.uint<6>
     %6 = firrtl.subindex %tmp[2] : !firrtl.vector<vector<uint<6>, 2>, 3>
     %7 = firrtl.subindex %6[0] : !firrtl.vector<uint<6>, 2>
-    firrtl.strictconnect %7, %c16_ui6 : !firrtl.uint<6>
+    firrtl.matchingconnect %7, %c16_ui6 : !firrtl.uint<6>
     %8 = firrtl.subindex %6[1] : !firrtl.vector<uint<6>, 2>
-    firrtl.strictconnect %8, %c32_ui6 : !firrtl.uint<6>
+    firrtl.matchingconnect %8, %c32_ui6 : !firrtl.uint<6>
     %9 = firrtl.xor %1, %4 : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
-    firrtl.strictconnect %b1, %9 : !firrtl.uint<6>
+    firrtl.matchingconnect %b1, %9 : !firrtl.uint<6>
     %10 = firrtl.xor %8, %2 : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
-    firrtl.strictconnect %b2, %10 : !firrtl.uint<6>
+    firrtl.matchingconnect %b2, %10 : !firrtl.uint<6>
     %11 = firrtl.xor %7, %5 : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
-    firrtl.strictconnect %b3, %11 : !firrtl.uint<6>
-    // CHECK:      firrtl.strictconnect %b1, %c5_ui6 : !firrtl.uint<6>
-    // CHECK-NEXT: firrtl.strictconnect %b2, %c34_ui6 : !firrtl.uint<6>
-    // CHECK-NEXT: firrtl.strictconnect %b3, %c24_ui6 : !firrtl.uint<6>
+    firrtl.matchingconnect %b3, %11 : !firrtl.uint<6>
+    // CHECK:      firrtl.matchingconnect %b1, %c5_ui6 : !firrtl.uint<6>
+    // CHECK-NEXT: firrtl.matchingconnect %b2, %c34_ui6 : !firrtl.uint<6>
+    // CHECK-NEXT: firrtl.matchingconnect %b3, %c24_ui6 : !firrtl.uint<6>
   }
 }
 
@@ -81,13 +81,13 @@ firrtl.circuit "BundlePropagation1"   {
     %0 = firrtl.subfield %tmp[a] : !firrtl.bundle<a: uint<3>, b: uint<3>, c: uint<3>>
     %1 = firrtl.subfield %tmp[b] : !firrtl.bundle<a: uint<3>, b: uint<3>, c: uint<3>>
     %2 = firrtl.subfield %tmp[c] : !firrtl.bundle<a: uint<3>, b: uint<3>, c: uint<3>>
-    firrtl.strictconnect %0, %c1_ui3 : !firrtl.uint<3>
-    firrtl.strictconnect %1, %c2_ui3 : !firrtl.uint<3>
-    firrtl.strictconnect %2, %c4_ui3 : !firrtl.uint<3>
+    firrtl.matchingconnect %0, %c1_ui3 : !firrtl.uint<3>
+    firrtl.matchingconnect %1, %c2_ui3 : !firrtl.uint<3>
+    firrtl.matchingconnect %2, %c4_ui3 : !firrtl.uint<3>
     %3 = firrtl.xor %0, %1 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
     %4 = firrtl.xor %3, %2 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
-    firrtl.strictconnect %result, %4 : !firrtl.uint<3>
-    // CHECK:  firrtl.strictconnect %result, %c7_ui3 : !firrtl.uint<3>
+    firrtl.matchingconnect %result, %4 : !firrtl.uint<3>
+    // CHECK:  firrtl.matchingconnect %result, %c7_ui3 : !firrtl.uint<3>
   }
 }
 
@@ -99,13 +99,13 @@ firrtl.circuit "DontTouchAggregate" {
     %0 = firrtl.subindex %init[0] : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.subindex %init[1] : !firrtl.vector<uint<1>, 2>
     %true = firrtl.constant 1 : !firrtl.uint<1>
-    firrtl.strictconnect %0, %true : !firrtl.uint<1>
-    firrtl.strictconnect %1, %true : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %true : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %true : !firrtl.uint<1>
 
-    // CHECK:      firrtl.strictconnect %out1, %0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %out2, %1 : !firrtl.uint<1>
-    firrtl.strictconnect %out1, %0 : !firrtl.uint<1>
-    firrtl.strictconnect %out2, %1 : !firrtl.uint<1>
+    // CHECK:      firrtl.matchingconnect %out1, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %out2, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %out1, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %out2, %1 : !firrtl.uint<1>
   }
 }
 
@@ -119,16 +119,16 @@ firrtl.circuit "OutPortTop" {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %0 = firrtl.subindex %out[0] : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.subindex %out[1] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %0, %c0_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %1, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %c0_ui1 : !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module @OutPortTop
   firrtl.module @OutPortTop(out %out1: !firrtl.uint<1>, out %out2: !firrtl.uint<1>) {
     %c_out = firrtl.instance c @OutPortChild(out out: !firrtl.vector<uint<1>, 2>)
     %0 = firrtl.subindex %c_out[0] : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.subindex %c_out[1] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %out1, %0 : !firrtl.uint<1>
-    firrtl.strictconnect %out2, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %out1, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %out2, %1 : !firrtl.uint<1>
   }
 }
 
@@ -142,7 +142,7 @@ firrtl.circuit "InputPortTop"  {
     %1 = firrtl.subfield %in0[v] : !firrtl.bundle<v: uint<1>>
     %2 = firrtl.subfield %out[v] : !firrtl.bundle<v: uint<1>>
     %3 = firrtl.and %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %2, %3 : !firrtl.uint<1>
+    firrtl.matchingconnect %2, %3 : !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module private @InputPortChild
   firrtl.module private @InputPortChild(in %in0: !firrtl.bundle<v: uint<1>>,
@@ -154,7 +154,7 @@ firrtl.circuit "InputPortTop"  {
     %1 = firrtl.subfield %in0[v] : !firrtl.bundle<v: uint<1>>
     %2 = firrtl.subfield %out[v] : !firrtl.bundle<v: uint<1>>
     %3 = firrtl.and %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %2, %3 : !firrtl.uint<1>
+    firrtl.matchingconnect %2, %3 : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: firrtl.module @InputPortTop
@@ -171,12 +171,12 @@ firrtl.circuit "InputPortTop"  {
     %6 = firrtl.subfield %c2_in1[v] : !firrtl.bundle<v: uint<1>>
     %7 = firrtl.subfield %c2_in0[v] : !firrtl.bundle<v: uint<1>>
     %8 = firrtl.subfield %c2_out[v] : !firrtl.bundle<v: uint<1>>
-    firrtl.strictconnect %2, %5 : !firrtl.uint<1>
-    firrtl.strictconnect %4, %1 : !firrtl.uint<1>
-    firrtl.strictconnect %3, %c1_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %0, %8 : !firrtl.uint<1>
-    firrtl.strictconnect %7, %1 : !firrtl.uint<1>
-    firrtl.strictconnect %6, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %2, %5 : !firrtl.uint<1>
+    firrtl.matchingconnect %4, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %8 : !firrtl.uint<1>
+    firrtl.matchingconnect %7, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %6, %c1_ui1 : !firrtl.uint<1>
   }
 }
 
@@ -195,12 +195,12 @@ firrtl.circuit "rhs_sink_output_used_as_wire" {
     %1 = firrtl.subfield %a[v] : !firrtl.bundle<v: uint<1>>
     %2 = firrtl.subfield %b[v] : !firrtl.bundle<v: uint<1>>
     %3 = firrtl.subfield %c[v] : !firrtl.bundle<v: uint<1>>
-    firrtl.strictconnect %3, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %2 : !firrtl.uint<1>
     %_c = firrtl.wire  : !firrtl.bundle<v: uint<1>>
     %4 = firrtl.subfield %_c[v] : !firrtl.bundle<v: uint<1>>
     %5 = firrtl.xor %1, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %4, %5 : !firrtl.uint<1>
-    firrtl.strictconnect %0, %4 : !firrtl.uint<1>
+    firrtl.matchingconnect %4, %5 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %4 : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: firrtl.module @rhs_sink_output_used_as_wire
@@ -208,16 +208,16 @@ firrtl.circuit "rhs_sink_output_used_as_wire" {
     %bar_a, %bar_b, %bar_c, %bar_d = firrtl.instance bar  @Bar(in a: !firrtl.bundle<v: uint<1>>, in b: !firrtl.bundle<v: uint<1>>, out c: !firrtl.bundle<v: uint<1>>, out d: !firrtl.bundle<v: uint<1>>)
     %0 = firrtl.subfield %a[v] : !firrtl.bundle<v: uint<1>>
     %1 = firrtl.subfield %bar_a[v] : !firrtl.bundle<v: uint<1>>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %0 : !firrtl.uint<1>
     %2 = firrtl.subfield %b[v] : !firrtl.bundle<v: uint<1>>
     %3 = firrtl.subfield %bar_b[v] : !firrtl.bundle<v: uint<1>>
-    firrtl.strictconnect %3, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %2 : !firrtl.uint<1>
     %4 = firrtl.subfield %bar_c[v] : !firrtl.bundle<v: uint<1>>
     %5 = firrtl.subfield %c[v] : !firrtl.bundle<v: uint<1>>
-    firrtl.strictconnect %5, %4 : !firrtl.uint<1>
+    firrtl.matchingconnect %5, %4 : !firrtl.uint<1>
     %6 = firrtl.subfield %bar_d[v] : !firrtl.bundle<v: uint<1>>
     %7 = firrtl.subfield %d[v] : !firrtl.bundle<v: uint<1>>
-    firrtl.strictconnect %7, %6 : !firrtl.uint<1>
+    firrtl.matchingconnect %7, %6 : !firrtl.uint<1>
   }
 }
 
@@ -232,12 +232,12 @@ firrtl.circuit "dntOutput"  {
     %int_b = firrtl.instance int  @foo(out b: !firrtl.bundle<v: uint<3>>)
     %1 = firrtl.subfield %int_b[v] : !firrtl.bundle<v: uint<3>>
     %2 = firrtl.mux(%c, %1, %c2_ui3) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
-    firrtl.strictconnect %0, %2 : !firrtl.uint<3>
+    firrtl.matchingconnect %0, %2 : !firrtl.uint<3>
   }
   firrtl.module private @foo(out %b: !firrtl.bundle<v: uint<3>> sym @dntSym1){
     %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
     %0 = firrtl.subfield %b[v] : !firrtl.bundle<v: uint<3>>
-    firrtl.strictconnect %0, %c1_ui3 : !firrtl.uint<3>
+    firrtl.matchingconnect %0, %c1_ui3 : !firrtl.uint<3>
   }
 }
 
@@ -248,16 +248,16 @@ firrtl.circuit "Issue4369"  {
   firrtl.module private @Bar(in %in: !firrtl.vector<uint<1>, 1>, out %out: !firrtl.uint<1>) {
     %0 = firrtl.subindex %in[0] : !firrtl.vector<uint<1>, 1>
     %a = firrtl.wire   : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %a, %0
-    // CHECK-NEXT: firrtl.strictconnect %out, %a
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    firrtl.strictconnect %out, %a : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %a, %0
+    // CHECK-NEXT: firrtl.matchingconnect %out, %a
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %out, %a : !firrtl.uint<1>
   }
   firrtl.module @Issue4369(in %a_0: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     %bar_in, %bar_out = firrtl.instance bar  @Bar(in in: !firrtl.vector<uint<1>, 1>, out out: !firrtl.uint<1>)
     %0 = firrtl.subindex %bar_in[0] : !firrtl.vector<uint<1>, 1>
-    firrtl.strictconnect %0, %a_0 : !firrtl.uint<1>
-    firrtl.strictconnect %b, %bar_out : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %a_0 : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %bar_out : !firrtl.uint<1>
   }
 }
 
@@ -268,8 +268,8 @@ firrtl.circuit "AggregateConstant"  {
     %0 = firrtl.aggregateconstant [0 : ui1, 1 : ui1] : !firrtl.vector<uint<1>, 2>
     %w = firrtl.wire : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.subindex %w[1] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %out, %1 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %out, %c1_ui1
-    firrtl.strictconnect %w, %0 : !firrtl.vector<uint<1>, 2>
+    firrtl.matchingconnect %out, %1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %out, %c1_ui1
+    firrtl.matchingconnect %w, %0 : !firrtl.vector<uint<1>, 2>
   }
 }

--- a/test/Dialect/FIRRTL/imconstprop-crashers.mlir
+++ b/test/Dialect/FIRRTL/imconstprop-crashers.mlir
@@ -7,9 +7,9 @@ firrtl.circuit "Issue1187"  {
   firrtl.module @Issue1187(in %divisor: !firrtl.uint<1>, out %result: !firrtl.uint<0>) {
     %dividend = firrtl.wire  : !firrtl.uint<0>
     %invalid_ui0 = firrtl.invalidvalue : !firrtl.uint<0>
-    firrtl.strictconnect %dividend, %invalid_ui0 : !firrtl.uint<0>
+    firrtl.matchingconnect %dividend, %invalid_ui0 : !firrtl.uint<0>
     %0 = firrtl.div %dividend, %divisor : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
-    firrtl.strictconnect %result, %0 : !firrtl.uint<0>
+    firrtl.matchingconnect %result, %0 : !firrtl.uint<0>
   }
 }
 
@@ -22,6 +22,6 @@ firrtl.circuit "Issue4456"  {
   firrtl.module @Issue4456(in %i: !firrtl.sint<0>, out %o: !firrtl.uint<4>) {
     %c0_si4 = firrtl.constant 0 : !firrtl.sint<4>
     %0 = firrtl.cat %i, %c0_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<4>
-    firrtl.strictconnect %o, %0 : !firrtl.uint<4>
+    firrtl.matchingconnect %o, %0 : !firrtl.uint<4>
   }
 }

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -9,11 +9,11 @@ firrtl.circuit "Test" {
 
     %dontTouchWire = firrtl.wire sym @a1 : !firrtl.uint<1>
     // CHECK-NEXT: %dontTouchWire = firrtl.wire
-    firrtl.strictconnect %dontTouchWire, %source : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %dontTouchWire, %c0_ui1
+    firrtl.matchingconnect %dontTouchWire, %source : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %dontTouchWire, %c0_ui1
 
-    // CHECK-NEXT: firrtl.strictconnect %dest, %dontTouchWire
-    firrtl.strictconnect %dest, %dontTouchWire : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %dest, %dontTouchWire
+    firrtl.matchingconnect %dest, %dontTouchWire : !firrtl.uint<1>
     // CHECK-NEXT: }
   }
 
@@ -35,50 +35,50 @@ firrtl.circuit "Test" {
 
     // Trivial wire constant propagation.
     %someWire = firrtl.wire interesting_name : !firrtl.uint<1>
-    firrtl.strictconnect %someWire, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %someWire, %c0_ui1 : !firrtl.uint<1>
 
     // CHECK: %someWire = firrtl.wire
-    // CHECK: firrtl.strictconnect %someWire, %c0_ui1
-    // CHECK: firrtl.strictconnect %result1, %c0_ui1
-    firrtl.strictconnect %result1, %someWire : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %someWire, %c0_ui1
+    // CHECK: firrtl.matchingconnect %result1, %c0_ui1
+    firrtl.matchingconnect %result1, %someWire : !firrtl.uint<1>
 
     // Trivial wire special constant propagation.
     %c0_clock = firrtl.specialconstant 0 : !firrtl.clock
     %clockWire = firrtl.wire interesting_name : !firrtl.clock
-    firrtl.strictconnect %clockWire, %c0_clock : !firrtl.clock
+    firrtl.matchingconnect %clockWire, %c0_clock : !firrtl.clock
 
     // CHECK: %clockWire = firrtl.wire
-    // CHECK: firrtl.strictconnect %clockWire, %c0_clock
-    // CHECK: firrtl.strictconnect %result2, %c0_clock
-    firrtl.strictconnect %result2, %clockWire : !firrtl.clock
+    // CHECK: firrtl.matchingconnect %clockWire, %c0_clock
+    // CHECK: firrtl.matchingconnect %result2, %c0_clock
+    firrtl.matchingconnect %result2, %clockWire : !firrtl.clock
 
     // Not a constant.
     %nonconstWire = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %nonconstWire, %c0_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %nonconstWire, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %nonconstWire, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %nonconstWire, %c1_ui1 : !firrtl.uint<1>
 
-    // CHECK: firrtl.strictconnect %result3, %nonconstWire
-    firrtl.strictconnect %result3, %nonconstWire : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %result3, %nonconstWire
+    firrtl.matchingconnect %result3, %nonconstWire : !firrtl.uint<1>
 
     // Constant propagation through instance.
     %source, %dest = firrtl.instance "" sym @dm21 @PassThrough(in source: !firrtl.uint<1>, out dest: !firrtl.uint<1>)
 
-    // CHECK: firrtl.strictconnect %inst_source, %c0_ui1
-    firrtl.strictconnect %source, %c0_ui1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %inst_source, %c0_ui1
+    firrtl.matchingconnect %source, %c0_ui1 : !firrtl.uint<1>
 
-    // CHECK: firrtl.strictconnect %result4, %inst_dest
-    firrtl.strictconnect %result4, %dest : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %result4, %inst_dest
+    firrtl.matchingconnect %result4, %dest : !firrtl.uint<1>
 
     // Check connect extensions.
     %extWire = firrtl.wire : !firrtl.uint<2>
-    firrtl.strictconnect %extWire, %c0_ui2 : !firrtl.uint<2>
+    firrtl.matchingconnect %extWire, %c0_ui2 : !firrtl.uint<2>
 
     // Connects of invalid values should hurt.
     %invalid = firrtl.invalidvalue : !firrtl.uint<2>
-    firrtl.strictconnect %extWire, %invalid : !firrtl.uint<2>
+    firrtl.matchingconnect %extWire, %invalid : !firrtl.uint<2>
 
-    // CHECK-NOT: firrtl.strictconnect %result5, %c0_ui2
-    firrtl.strictconnect %result5, %extWire: !firrtl.uint<2>
+    // CHECK-NOT: firrtl.matchingconnect %result5, %c0_ui2
+    firrtl.matchingconnect %result5, %extWire: !firrtl.uint<2>
 
     // Constant propagation through instance.
     firrtl.instance ReadMem @ReadMem()
@@ -89,8 +89,8 @@ firrtl.circuit "Test" {
 
   // CHECK-LABEL: @UnusedModule(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>)
   firrtl.module private @UnusedModule(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>) {
-    // CHECK-NEXT: firrtl.strictconnect %dest, %source
-    firrtl.strictconnect %dest, %source : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %dest, %source
+    firrtl.matchingconnect %dest, %source : !firrtl.uint<1>
     // CHECK-NEXT: }
   }
 
@@ -104,9 +104,9 @@ firrtl.circuit "Test" {
 
     %1 = firrtl.subfield %0[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
     %2 = firrtl.subfield %0[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
-    firrtl.strictconnect %2, %c0_ui1 : !firrtl.uint<4>
+    firrtl.matchingconnect %2, %c0_ui1 : !firrtl.uint<4>
     %3 = firrtl.subfield %0[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
-    firrtl.strictconnect %3, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %c1_ui1 : !firrtl.uint<1>
     %4 = firrtl.subfield %0[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: sint<8>>
   }
 }
@@ -129,11 +129,11 @@ firrtl.circuit "Issue1188"  {
     %6 = firrtl.bits %D0123456 3 to 3 : (!firrtl.uint<6>) -> !firrtl.uint<1>
     %7 = firrtl.cat %5, %6 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
     %8 = firrtl.cat %7, %1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<3>
-    firrtl.strictconnect %io_out, %D0123456 : !firrtl.uint<6>
-    firrtl.strictconnect %io_out3, %8 : !firrtl.uint<3>
+    firrtl.matchingconnect %io_out, %D0123456 : !firrtl.uint<6>
+    firrtl.matchingconnect %io_out3, %8 : !firrtl.uint<3>
     // CHECK: firrtl.mux(%reset, %c1_ui6, %4)
     %9 = firrtl.mux(%reset, %c1_ui6, %4) : (!firrtl.uint<1>, !firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
-    firrtl.strictconnect %D0123456, %9 : !firrtl.uint<6>
+    firrtl.matchingconnect %D0123456, %9 : !firrtl.uint<6>
   }
 }
 
@@ -146,23 +146,23 @@ firrtl.circuit "testDontTouch"  {
     in %a: !firrtl.uint<1> sym @dntSym, out %b: !firrtl.uint<1>){
     //CHECK: %c = firrtl.reg
     %c = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
-    firrtl.strictconnect %c, %a : !firrtl.uint<1>
-    firrtl.strictconnect %b, %c : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %c : !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module private @allowProp
   firrtl.module private @allowProp(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     // CHECK: [[CONST:%.+]] = firrtl.constant 1 : !firrtl.uint<1>
     %c = firrtl.wire  : !firrtl.uint<1>
-    firrtl.strictconnect %c, %a : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %b, [[CONST]]
-    firrtl.strictconnect %b, %c : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %a : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %b, [[CONST]]
+    firrtl.matchingconnect %b, %c : !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module private @blockProp3
   firrtl.module private @blockProp3(in %clock: !firrtl.clock, in %a: !firrtl.uint<1> , out %b: !firrtl.uint<1>) {
     //CHECK: %c = firrtl.reg
     %c = firrtl.reg sym @s2 %clock : !firrtl.clock, !firrtl.uint<1>
-    firrtl.strictconnect %c, %a : !firrtl.uint<1>
-    firrtl.strictconnect %b, %c : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %c : !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module @testDontTouch
   firrtl.module @testDontTouch(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>, out %a1: !firrtl.uint<1>, out %a2: !firrtl.uint<1>) {
@@ -170,18 +170,18 @@ firrtl.circuit "testDontTouch"  {
     %blockProp1_clock, %blockProp1_a, %blockProp1_b = firrtl.instance blockProp1 sym @a1 @blockProp1(in clock: !firrtl.clock, in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
     %allowProp_clock, %allowProp_a, %allowProp_b = firrtl.instance allowProp sym @a2 @allowProp(in clock: !firrtl.clock, in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
     %blockProp3_clock, %blockProp3_a, %blockProp3_b = firrtl.instance blockProp3  sym @a3 @blockProp3(in clock: !firrtl.clock, in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
-    firrtl.strictconnect %blockProp1_clock, %clock : !firrtl.clock
-    firrtl.strictconnect %allowProp_clock, %clock : !firrtl.clock
-    firrtl.strictconnect %blockProp3_clock, %clock : !firrtl.clock
-    firrtl.strictconnect %blockProp1_a, %c1_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %allowProp_a, %c1_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %blockProp3_a, %c1_ui1 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %a, %blockProp1_b
-    firrtl.strictconnect %a, %blockProp1_b : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %a1, %c
-    firrtl.strictconnect %a1, %allowProp_b : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %a2, %blockProp3_b
-    firrtl.strictconnect %a2, %blockProp3_b : !firrtl.uint<1>
+    firrtl.matchingconnect %blockProp1_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %allowProp_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %blockProp3_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %blockProp1_a, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %allowProp_a, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %blockProp3_a, %c1_ui1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %a, %blockProp1_b
+    firrtl.matchingconnect %a, %blockProp1_b : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %a1, %c
+    firrtl.matchingconnect %a1, %allowProp_b : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %a2, %blockProp3_b
+    firrtl.matchingconnect %a2, %blockProp3_b : !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module @CheckNode
   firrtl.module @CheckNode(out %x: !firrtl.uint<1>, out %y: !firrtl.uint<1>, out %z: !firrtl.uint<1>) {
@@ -192,12 +192,12 @@ firrtl.circuit "testDontTouch"  {
     %d2 = firrtl.node interesting_name %c1_ui1 : !firrtl.uint<1>
     // CHECK: %d3 = firrtl.node
     %d3 = firrtl.node   sym @s2 %c1_ui1: !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %x, %c1_ui1
-    firrtl.strictconnect %x, %d1 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %y, %c1_ui1
-    firrtl.strictconnect %y, %d2 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %z, %d3
-    firrtl.strictconnect %z, %d3 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %x, %c1_ui1
+    firrtl.matchingconnect %x, %d1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %y, %c1_ui1
+    firrtl.matchingconnect %y, %d2 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %z, %d3
+    firrtl.matchingconnect %z, %d3 : !firrtl.uint<1>
   }
 
 }
@@ -207,11 +207,11 @@ firrtl.circuit "testDontTouch"  {
 firrtl.circuit "OutPortTop" {
     firrtl.module private @OutPortChild1(out %out: !firrtl.uint<1> sym @dntSym1) {
       %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-      firrtl.strictconnect %out, %c0_ui1 : !firrtl.uint<1>
+      firrtl.matchingconnect %out, %c0_ui1 : !firrtl.uint<1>
     }
     firrtl.module private @OutPortChild2(out %out: !firrtl.uint<1>) {
       %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-      firrtl.strictconnect %out, %c0_ui1 : !firrtl.uint<1>
+      firrtl.matchingconnect %out, %c0_ui1 : !firrtl.uint<1>
     }
   // CHECK-LABEL: firrtl.module @OutPortTop
     firrtl.module @OutPortTop(in %x: !firrtl.uint<1>, out %zc: !firrtl.uint<1>, out %zn: !firrtl.uint<1>) {
@@ -221,10 +221,10 @@ firrtl.circuit "OutPortTop" {
       // CHECK: %0 = firrtl.and %x, %c_out
       %0 = firrtl.and %x, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
       %1 = firrtl.and %x, %c_out_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-      // CHECK: firrtl.strictconnect %zn, %0
-      firrtl.strictconnect %zn, %0 : !firrtl.uint<1>
-      // CHECK: firrtl.strictconnect %zc, %c0_ui1
-      firrtl.strictconnect %zc, %1 : !firrtl.uint<1>
+      // CHECK: firrtl.matchingconnect %zn, %0
+      firrtl.matchingconnect %zn, %0 : !firrtl.uint<1>
+      // CHECK: firrtl.matchingconnect %zc, %c0_ui1
+      firrtl.matchingconnect %zc, %1 : !firrtl.uint<1>
     }
 }
 
@@ -236,25 +236,25 @@ firrtl.circuit "InputPortTop"   {
   firrtl.module private @InputPortChild2(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
     // CHECK: = firrtl.constant 1
     %0 = firrtl.and %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %out, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %out, %0 : !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module private @InputPortChild
   firrtl.module private @InputPortChild(in %in0: !firrtl.uint<1>,
     in %in1 : !firrtl.uint<1> sym @dntSym1, out %out: !firrtl.uint<1>) {
     // CHECK: %0 = firrtl.and %in0, %in1
     %0 = firrtl.and %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %out, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %out, %0 : !firrtl.uint<1>
   }
   firrtl.module @InputPortTop(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>, out %z2: !firrtl.uint<1>) {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c_in0, %c_in1, %c_out = firrtl.instance c @InputPortChild(in in0: !firrtl.uint<1>, in in1: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     %c2_in0, %c2_in1, %c2_out = firrtl.instance c2 @InputPortChild2(in in0: !firrtl.uint<1>, in in1: !firrtl.uint<1>, out out: !firrtl.uint<1>)
-    firrtl.strictconnect %z, %c_out : !firrtl.uint<1>
-    firrtl.strictconnect %c_in0, %x : !firrtl.uint<1>
-    firrtl.strictconnect %c_in1, %c1_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %z2, %c2_out : !firrtl.uint<1>
-    firrtl.strictconnect %c2_in0, %x : !firrtl.uint<1>
-    firrtl.strictconnect %c2_in1, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %z, %c_out : !firrtl.uint<1>
+    firrtl.matchingconnect %c_in0, %x : !firrtl.uint<1>
+    firrtl.matchingconnect %c_in1, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %z2, %c2_out : !firrtl.uint<1>
+    firrtl.matchingconnect %c2_in0, %x : !firrtl.uint<1>
+    firrtl.matchingconnect %c2_in1, %c1_ui1 : !firrtl.uint<1>
   }
 }
 
@@ -266,12 +266,12 @@ firrtl.circuit "InstanceOut"   {
   // CHECK-LABEL: firrtl.module @InstanceOut
   firrtl.module @InstanceOut(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     %ext_a = firrtl.instance ext @Ext(in a: !firrtl.uint<1>)
-    firrtl.strictconnect %ext_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %ext_a, %a : !firrtl.uint<1>
     %w = firrtl.wire  : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %w, %ext_a : !firrtl.uint<1>
-    firrtl.strictconnect %w, %ext_a : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %b, %w : !firrtl.uint<1>
-    firrtl.strictconnect %b, %w : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %w, %ext_a : !firrtl.uint<1>
+    firrtl.matchingconnect %w, %ext_a : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %b, %w : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %w : !firrtl.uint<1>
   }
 }
 
@@ -284,12 +284,12 @@ firrtl.circuit "InstanceOut2"   {
   // CHECK-LABEL: firrtl.module @InstanceOut2
   firrtl.module @InstanceOut2(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     %ext_a = firrtl.instance ext @Ext(in a: !firrtl.uint<1>)
-    firrtl.strictconnect %ext_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %ext_a, %a : !firrtl.uint<1>
     %w = firrtl.wire  : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %w, %ext_a : !firrtl.uint<1>
-    firrtl.strictconnect %w, %ext_a : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %b, %w : !firrtl.uint<1>
-    firrtl.strictconnect %b, %w : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %w, %ext_a : !firrtl.uint<1>
+    firrtl.matchingconnect %w, %ext_a : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %b, %w : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %w : !firrtl.uint<1>
   }
 }
 
@@ -301,10 +301,10 @@ firrtl.circuit "invalidReg1"   {
     %foobar = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
       //CHECK: %0 = firrtl.not %foobar : (!firrtl.uint<1>) -> !firrtl.uint<1>
       %0 = firrtl.not %foobar : (!firrtl.uint<1>) -> !firrtl.uint<1>
-      //CHECK: firrtl.strictconnect %foobar, %0 : !firrtl.uint<1>
-      firrtl.strictconnect %foobar, %0 : !firrtl.uint<1>
-      //CHECK: firrtl.strictconnect %a, %foobar : !firrtl.uint<1>
-      firrtl.strictconnect %a, %foobar : !firrtl.uint<1>
+      //CHECK: firrtl.matchingconnect %foobar, %0 : !firrtl.uint<1>
+      firrtl.matchingconnect %foobar, %0 : !firrtl.uint<1>
+      //CHECK: firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
+      firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
   }
 }
 
@@ -327,11 +327,11 @@ firrtl.circuit "Oscillators"   {
     // CHECK: firrtl.regreset
     %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %0 = firrtl.not %r : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %r, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %r, %0 : !firrtl.uint<1>
     %1 = firrtl.not %s : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %s, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %s, %1 : !firrtl.uint<1>
     %2 = firrtl.or %r, %s : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %a, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %2 : !firrtl.uint<1>
   }
   // CHECK: firrtl.module private @Bar
   firrtl.module private @Bar(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
@@ -342,11 +342,11 @@ firrtl.circuit "Oscillators"   {
     %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %0 = firrtl.xor %a, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %r, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %r, %0 : !firrtl.uint<1>
     %1 = firrtl.xor %a, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %s, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %s, %1 : !firrtl.uint<1>
     %2 = firrtl.or %r, %s : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %a, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %2 : !firrtl.uint<1>
   }
   // CHECK: firrtl.module private @Baz
   firrtl.module private @Baz(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %a: !firrtl.uint<1>) {
@@ -356,11 +356,11 @@ firrtl.circuit "Oscillators"   {
     // CHECK: firrtl.regreset
     %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %r, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %r, %0 : !firrtl.uint<1>
     %1 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %s, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %s, %1 : !firrtl.uint<1>
     %2 = firrtl.or %r, %s : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %a, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %2 : !firrtl.uint<1>
   }
   firrtl.extmodule @Ext(in a: !firrtl.uint<1>)
   // CHECK: firrtl.module private @Qux
@@ -372,30 +372,30 @@ firrtl.circuit "Oscillators"   {
     // CHECK: firrtl.regreset
     %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %0 = firrtl.not %ext_a : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %r, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %r, %0 : !firrtl.uint<1>
     %1 = firrtl.not %ext_a : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %s, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %s, %1 : !firrtl.uint<1>
     %2 = firrtl.or %r, %s : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %ext_a, %2 : !firrtl.uint<1>
-    firrtl.strictconnect %a, %ext_a : !firrtl.uint<1>
+    firrtl.matchingconnect %ext_a, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %ext_a : !firrtl.uint<1>
   }
   firrtl.module @Oscillators(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, out %foo_a: !firrtl.uint<1>, out %bar_a: !firrtl.uint<1>, out %baz_a: !firrtl.uint<1>, out %qux_a: !firrtl.uint<1>) {
     %foo_clock, %foo_reset, %foo_a_0 = firrtl.instance foo @Foo(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out a: !firrtl.uint<1>)
-    firrtl.strictconnect %foo_clock, %clock : !firrtl.clock
-    firrtl.strictconnect %foo_reset, %reset : !firrtl.asyncreset
-    firrtl.strictconnect %foo_a, %foo_a_0 : !firrtl.uint<1>
+    firrtl.matchingconnect %foo_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %foo_reset, %reset : !firrtl.asyncreset
+    firrtl.matchingconnect %foo_a, %foo_a_0 : !firrtl.uint<1>
     %bar_clock, %bar_reset, %bar_a_1 = firrtl.instance bar @Bar (in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out a: !firrtl.uint<1>)
-    firrtl.strictconnect %bar_clock, %clock : !firrtl.clock
-    firrtl.strictconnect %bar_reset, %reset : !firrtl.asyncreset
-    firrtl.strictconnect %bar_a, %bar_a_1 : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %bar_reset, %reset : !firrtl.asyncreset
+    firrtl.matchingconnect %bar_a, %bar_a_1 : !firrtl.uint<1>
     %baz_clock, %baz_reset, %baz_a_2 = firrtl.instance baz @Baz(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out a: !firrtl.uint<1>)
-    firrtl.strictconnect %baz_clock, %clock : !firrtl.clock
-    firrtl.strictconnect %baz_reset, %reset : !firrtl.asyncreset
-    firrtl.strictconnect %baz_a, %baz_a_2 : !firrtl.uint<1>
+    firrtl.matchingconnect %baz_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %baz_reset, %reset : !firrtl.asyncreset
+    firrtl.matchingconnect %baz_a, %baz_a_2 : !firrtl.uint<1>
     %qux_clock, %qux_reset, %qux_a_3 = firrtl.instance qux @Qux(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, out a: !firrtl.uint<1>)
-    firrtl.strictconnect %qux_clock, %clock : !firrtl.clock
-    firrtl.strictconnect %qux_reset, %reset : !firrtl.asyncreset
-    firrtl.strictconnect %qux_a, %qux_a_3 : !firrtl.uint<1>
+    firrtl.matchingconnect %qux_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %qux_reset, %reset : !firrtl.asyncreset
+    firrtl.matchingconnect %qux_a, %qux_a_3 : !firrtl.uint<1>
   }
 }
 
@@ -410,19 +410,19 @@ firrtl.circuit "Oscillators"   {
 firrtl.circuit "rhs_sink_output_used_as_wire" {
   // CHECK: firrtl.module private @Bar
   firrtl.module private @Bar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
-    firrtl.strictconnect %c, %b : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %b : !firrtl.uint<1>
     %_c = firrtl.wire  : !firrtl.uint<1>
     // CHECK: firrtl.xor %a, %c
     %0 = firrtl.xor %a, %c : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %_c, %0 : !firrtl.uint<1>
-    firrtl.strictconnect %d, %_c : !firrtl.uint<1>
+    firrtl.matchingconnect %_c, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %d, %_c : !firrtl.uint<1>
   }
   firrtl.module @rhs_sink_output_used_as_wire(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
     %bar_a, %bar_b, %bar_c, %bar_d = firrtl.instance bar @Bar(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d: !firrtl.uint<1>)
-    firrtl.strictconnect %bar_a, %a : !firrtl.uint<1>
-    firrtl.strictconnect %bar_b, %b : !firrtl.uint<1>
-    firrtl.strictconnect %c, %bar_c : !firrtl.uint<1>
-    firrtl.strictconnect %d, %bar_d : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_b, %b : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %bar_c : !firrtl.uint<1>
+    firrtl.matchingconnect %d, %bar_d : !firrtl.uint<1>
   }
 }
 
@@ -433,16 +433,16 @@ firrtl.circuit "rhs_sink_output_used_as_wire" {
 firrtl.circuit "dntOutput" {
   // CHECK-LABEL: firrtl.module @dntOutput
   // CHECK: %0 = firrtl.mux(%c, %int_b, %c2_ui3)
-  // CHECK-NEXT: firrtl.strictconnect %b, %0
+  // CHECK-NEXT: firrtl.matchingconnect %b, %0
   firrtl.module @dntOutput(out %b : !firrtl.uint<3>, in %c : !firrtl.uint<1>) {
     %const = firrtl.constant 2 : !firrtl.uint<3>
     %int_b = firrtl.instance int @foo(out b: !firrtl.uint<3>)
     %m = firrtl.mux(%c, %int_b, %const) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
-    firrtl.strictconnect %b, %m : !firrtl.uint<3>
+    firrtl.matchingconnect %b, %m : !firrtl.uint<3>
   }
   firrtl.module private @foo(out %b: !firrtl.uint<3>  sym @dntSym1) {
     %const = firrtl.constant 1 : !firrtl.uint<3>
-    firrtl.strictconnect %b, %const : !firrtl.uint<3>
+    firrtl.matchingconnect %b, %const : !firrtl.uint<3>
   }
 }
 
@@ -457,9 +457,9 @@ firrtl.circuit "AnnotationsBlockRemoval"  {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     // CHECK: %w = firrtl.wire
     %w = firrtl.wire droppable_name {annotations = [{class = "foo"}]} : !firrtl.uint<1>
-    firrtl.strictconnect %w, %c1_ui1 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %b, %c1_ui1
-    firrtl.strictconnect %b, %w : !firrtl.uint<1>
+    firrtl.matchingconnect %w, %c1_ui1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %b, %c1_ui1
+    firrtl.matchingconnect %b, %w : !firrtl.uint<1>
   }
 }
 
@@ -472,18 +472,18 @@ firrtl.circuit "Issue3372"  {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %other_zero = firrtl.instance other interesting_name  @Other(out zero: !firrtl.uint<1>)
     %shared = firrtl.regreset interesting_name %clock, %other_zero, %c1_ui1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.strictconnect %shared, %shared : !firrtl.uint<1>
+    firrtl.matchingconnect %shared, %shared : !firrtl.uint<1>
     %test = firrtl.wire interesting_name  : !firrtl.uint<1>
-    firrtl.strictconnect %test, %shared : !firrtl.uint<1>
-    firrtl.strictconnect %value, %test : !firrtl.uint<1>
+    firrtl.matchingconnect %test, %shared : !firrtl.uint<1>
+    firrtl.matchingconnect %value, %test : !firrtl.uint<1>
   }
 // CHECK:  %other_zero = firrtl.instance other interesting_name @Other(out zero: !firrtl.uint<1>)
 // CHECK:  %test = firrtl.wire interesting_name : !firrtl.uint<1>
-// CHECK:  firrtl.strictconnect %value, %test : !firrtl.uint<1>
+// CHECK:  firrtl.matchingconnect %value, %test : !firrtl.uint<1>
 
   firrtl.module private @Other(out %zero: !firrtl.uint<1>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    firrtl.strictconnect %zero, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %zero, %c0_ui1 : !firrtl.uint<1>
   }
 }
 
@@ -496,11 +496,11 @@ firrtl.circuit "SendThroughRef" {
     %ref_zero = firrtl.ref.send %zero : !firrtl.uint<1>
     firrtl.ref.define %_a, %ref_zero : !firrtl.probe<uint<1>>
   }
-  // CHECK:  firrtl.strictconnect %a, %c0_ui1 : !firrtl.uint<1>
+  // CHECK:  firrtl.matchingconnect %a, %c0_ui1 : !firrtl.uint<1>
   firrtl.module @SendThroughRef(out %a: !firrtl.uint<1>) {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.probe<uint<1>>)
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
   }
 }
 
@@ -517,11 +517,11 @@ firrtl.circuit "ForwardRef" {
     %fwd_2 = firrtl.instance fwd_2 @RefForward2(out _a: !firrtl.probe<uint<1>>)
     firrtl.ref.define %_a, %fwd_2 : !firrtl.probe<uint<1>>
   }
-  // CHECK:  firrtl.strictconnect %a, %c0_ui1 : !firrtl.uint<1>
+  // CHECK:  firrtl.matchingconnect %a, %c0_ui1 : !firrtl.uint<1>
   firrtl.module @ForwardRef(out %a: !firrtl.uint<1>) {
     %fwd_a = firrtl.instance fwd @RefForward(out _a: !firrtl.probe<uint<1>>)
     %0 = firrtl.ref.resolve %fwd_a : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
   }
 }
 
@@ -539,15 +539,15 @@ firrtl.circuit "SendThroughRWProbe" {
     %n, %n_ref = firrtl.node %zero forceable : !firrtl.uint<1>
     // CHECK: firrtl.node %[[N]]
     %user = firrtl.node %n : !firrtl.uint<1>
-    firrtl.strictconnect %out, %user : !firrtl.uint<1>
+    firrtl.matchingconnect %out, %user : !firrtl.uint<1>
     firrtl.ref.define %rw, %n_ref : !firrtl.rwprobe<uint<1>>
   }
-  // CHECK:  firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+  // CHECK:  firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
   firrtl.module @SendThroughRWProbe(out %a: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
     %bar_rw, %bar_out = firrtl.instance bar @Bar(out rw: !firrtl.rwprobe<uint<1>>, out out: !firrtl.uint<1>)
-    firrtl.strictconnect %out, %bar_out : !firrtl.uint<1>
+    firrtl.matchingconnect %out, %bar_out : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_rw : !firrtl.rwprobe<uint<1>>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
   }
 }
 
@@ -572,14 +572,14 @@ firrtl.circuit "Verbatim"  {
     // CHECK: %tap = firrtl.wire   : !firrtl.uint<1>
     %tap = firrtl.wire   : !firrtl.uint<1>
     %fizz = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
-    firrtl.strictconnect %fizz, %tap : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %tap, %[[v0]] : !firrtl.uint<1>
-    firrtl.strictconnect %tap, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %fizz, %tap : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %tap, %[[v0]] : !firrtl.uint<1>
+    firrtl.matchingconnect %tap, %0 : !firrtl.uint<1>
     // CHECK: firrtl.verbatim.wire "randomBar.b"
     %1 = firrtl.verbatim.wire "randomBar.b" : () -> !firrtl.uint<1> {symbols = []}
     // CHECK: %tap2 = firrtl.wire   : !firrtl.uint<1>
     %tap2 = firrtl.wire   : !firrtl.uint<1>
-    firrtl.strictconnect %tap2, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %tap2, %1 : !firrtl.uint<1>
   }
 }
 
@@ -595,7 +595,7 @@ firrtl.circuit "Issue4498"  {
   firrtl.module @Issue4498(in %clock: !firrtl.clock) {
     %a = firrtl.wire : !firrtl.uint<1>
     %r = firrtl.reg interesting_name %clock : !firrtl.clock, !firrtl.uint<1>
-    firrtl.strictconnect %r, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %r, %a : !firrtl.uint<1>
   }
 }
 
@@ -607,11 +607,11 @@ firrtl.circuit "Ordering" {
   firrtl.module public @Ordering(out %b: !firrtl.uint<1>) {
     %0 = firrtl.wire : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    firrtl.strictconnect %0, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %c1_ui1 : !firrtl.uint<1>
     %1 = firrtl.xor %0, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %b, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %1 : !firrtl.uint<1>
   }
-  // CHECK: firrtl.strictconnect %b, %c0_ui1
+  // CHECK: firrtl.matchingconnect %b, %c0_ui1
 }
 
 // -----
@@ -625,9 +625,9 @@ firrtl.circuit "Issue5722Test"  {
   firrtl.module @Issue5722Test(out %a: !firrtl.uint<1>) {
     %b = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.int.plusargs.test "parg"
-    firrtl.strictconnect %b, %0 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %b, %0
-    firrtl.strictconnect %a, %b : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %b, %0
+    firrtl.matchingconnect %a, %b : !firrtl.uint<1>
   }
 }
 
@@ -637,12 +637,12 @@ firrtl.circuit "Issue5722Value"  {
     %b = firrtl.wire : !firrtl.uint<1>
     %c = firrtl.wire : !firrtl.uint<32>
     %0:2 = firrtl.int.plusargs.value "parg" : !firrtl.uint<32>
-    firrtl.strictconnect %b, %0#0 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %b, %0#0
-    firrtl.strictconnect %c, %0#1 : !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %c, %0#1
-    firrtl.strictconnect %a, %b : !firrtl.uint<1>
-    firrtl.strictconnect %v, %c : !firrtl.uint<32>
+    firrtl.matchingconnect %b, %0#0 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %b, %0#0
+    firrtl.matchingconnect %c, %0#1 : !firrtl.uint<32>
+    // CHECK: firrtl.matchingconnect %c, %0#1
+    firrtl.matchingconnect %a, %b : !firrtl.uint<1>
+    firrtl.matchingconnect %v, %c : !firrtl.uint<32>
   }
 }
 
@@ -726,7 +726,7 @@ firrtl.circuit "KeepForceable" {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %b_c = firrtl.wire : !firrtl.rwprobe<uint<1>>
     %d, %d_ref = firrtl.wire forceable : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
-    firrtl.strictconnect %d, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %d, %c0_ui1 : !firrtl.uint<1>
     // CHECK-COUNT-2: ref.define
     firrtl.ref.define %b_c, %d_ref : !firrtl.rwprobe<uint<1>>
     firrtl.ref.define %a, %b_c : !firrtl.rwprobe<uint<1>>
@@ -785,16 +785,16 @@ firrtl.circuit "ConstPropAnno" {
     %w = firrtl.wire {annotations = [{class = "circt.test"}]} : !firrtl.uint<3>
     // CHECK-NOT: firrtl.wire
     %w2 = firrtl.wire : !firrtl.uint<3>
-    firrtl.strictconnect %w2, %zero : !firrtl.uint<3>
-    firrtl.strictconnect %w, %w2 : !firrtl.uint<3>
-    firrtl.strictconnect %val, %w : !firrtl.uint<3>
+    firrtl.matchingconnect %w2, %zero : !firrtl.uint<3>
+    firrtl.matchingconnect %w, %w2 : !firrtl.uint<3>
+    firrtl.matchingconnect %val, %w : !firrtl.uint<3>
 
     // CHECK: firrtl.node %[[ZERO]]
     %n = firrtl.node %w2 {annotations = [{class = "circt.test"}]} : !firrtl.uint<3>
     // CHECK-NOT: firrtl.wire
     %w3 = firrtl.wire : !firrtl.uint<3>
-    firrtl.strictconnect %w3, %n : !firrtl.uint<3>
-    firrtl.strictconnect %val2, %w3 : !firrtl.uint<3>
+    firrtl.matchingconnect %w3, %n : !firrtl.uint<3>
+    firrtl.matchingconnect %val2, %w3 : !firrtl.uint<3>
   }
 }
 
@@ -832,8 +832,8 @@ firrtl.circuit "RefSubOpPropagate" {
     %v1 = firrtl.subindex %w[1] : !firrtl.vector<uint<32>, 2>
     %val0 = firrtl.constant 123 : !firrtl.uint<32>
     %val1 = firrtl.constant 321 : !firrtl.uint<32>
-    firrtl.strictconnect %v0, %val0 : !firrtl.uint<32>
-    firrtl.strictconnect %v1, %val1 : !firrtl.uint<32>
+    firrtl.matchingconnect %v0, %val0 : !firrtl.uint<32>
+    firrtl.matchingconnect %v1, %val1 : !firrtl.uint<32>
 
     // Send out probe of entire vector.
     %vec_ref = firrtl.ref.send %w : !firrtl.vector<uint<32>, 2>
@@ -867,16 +867,16 @@ firrtl.circuit "RefSubOpPropagate" {
    firrtl.ref.define %w, %ref : !firrtl.probe<uint<32>>
    firrtl.ref.define %p, %w: !firrtl.probe<uint<32>>
 
-   // CHECK-NEXT: firrtl.strictconnect %w1_via_p, %[[C321]]
+   // CHECK-NEXT: firrtl.matchingconnect %w1_via_p, %[[C321]]
    %p_read = firrtl.ref.resolve %ref : !firrtl.probe<uint<32>>
-   firrtl.strictconnect %w1_via_p, %p_read : !firrtl.uint<32>
+   firrtl.matchingconnect %w1_via_p, %p_read : !firrtl.uint<32>
 
-   // CHECK-NEXT: firrtl.strictconnect %w0, %[[C123]]
-   // CHECK-NEXT: firrtl.strictconnect %w1, %[[C321]]
+   // CHECK-NEXT: firrtl.matchingconnect %w0, %[[C123]]
+   // CHECK-NEXT: firrtl.matchingconnect %w1, %[[C321]]
    %w0_read = firrtl.ref.resolve %c_w0 : !firrtl.probe<uint<32>>
    %w1_read = firrtl.ref.resolve %c_w1 : !firrtl.probe<uint<32>>
-   firrtl.strictconnect %w0, %w0_read : !firrtl.uint<32>
-   firrtl.strictconnect %w1, %w1_read : !firrtl.uint<32>
+   firrtl.matchingconnect %w0, %w0_read : !firrtl.uint<32>
+   firrtl.matchingconnect %w1, %w1_read : !firrtl.uint<32>
    // CHECK-NEXT: }
   }
 }
@@ -908,7 +908,7 @@ firrtl.circuit "OMIRRemoval" {
            type = "OMReferenceTarget"
         }
       ]} : !firrtl.uint<1>
-    firrtl.strictconnect %a, %tmp_0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %tmp_0 : !firrtl.uint<1>
 
     // CHECK-NOT: %tmp_1
     %tmp_1 = firrtl.node %c3_ui2 {
@@ -919,7 +919,7 @@ firrtl.circuit "OMIRRemoval" {
            type = "OMMemberReferenceTarget"
         }
       ]} : !firrtl.uint<2>
-    firrtl.strictconnect %b, %tmp_1 : !firrtl.uint<2>
+    firrtl.matchingconnect %b, %tmp_1 : !firrtl.uint<2>
 
     // CHECK-NOT: %tmp_2
     %tmp_2 = firrtl.node %c7_ui3 {
@@ -930,7 +930,7 @@ firrtl.circuit "OMIRRemoval" {
            type = "OMMemberInstanceTarget"
         }
       ]} : !firrtl.uint<3>
-    firrtl.strictconnect %c, %tmp_2 : !firrtl.uint<3>
+    firrtl.matchingconnect %c, %tmp_2 : !firrtl.uint<3>
 
     // Adding one additional annotation will block removal.
     //
@@ -946,7 +946,7 @@ firrtl.circuit "OMIRRemoval" {
            class = "circt.test"
         }
       ]} : !firrtl.uint<4>
-    // CHECK-NEXT: firrtl.strictconnect %d, %c15_ui4
-    firrtl.strictconnect %d, %tmp_3 : !firrtl.uint<4>
+    // CHECK-NEXT: firrtl.matchingconnect %d, %c15_ui4
+    firrtl.matchingconnect %d, %tmp_3 : !firrtl.uint<4>
   }
 }

--- a/test/Dialect/FIRRTL/imcp-locations.mlir
+++ b/test/Dialect/FIRRTL/imcp-locations.mlir
@@ -5,8 +5,8 @@ firrtl.circuit "Test" {
   firrtl.module private @Consts(out %c2 : !firrtl.uint<3>, out %c4 : !firrtl.uint<3>) {
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
     %c4_ui3 = firrtl.constant 4 : !firrtl.uint<3>
-    firrtl.strictconnect %c2, %c2_ui3 : !firrtl.uint<3>
-    firrtl.strictconnect %c4, %c4_ui3 : !firrtl.uint<3>
+    firrtl.matchingconnect %c2, %c2_ui3 : !firrtl.uint<3>
+    firrtl.matchingconnect %c4, %c4_ui3 : !firrtl.uint<3>
   }
   // CHECK-LABEL: module @Test
   firrtl.module @Test() {
@@ -22,8 +22,8 @@ firrtl.circuit "Test" {
     %add = firrtl.add %c2, %c4: (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<4>
     %addtrunc = firrtl.bits %add 2 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<3>
 
-    firrtl.strictconnect %w_or, %or : !firrtl.uint<3>
-    firrtl.strictconnect %w_add, %addtrunc : !firrtl.uint<3>
+    firrtl.matchingconnect %w_or, %or : !firrtl.uint<3>
+    firrtl.matchingconnect %w_add, %addtrunc : !firrtl.uint<3>
 
     // CHECK: %n_or = firrtl.node sym @n_or %[[SIX]]
     // CHECK: %n_add = firrtl.node sym @n_add %[[SIX]]

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -9,16 +9,16 @@ firrtl.circuit "top" {
     %dead_node = firrtl.node %source: !firrtl.uint<1>
 
     %dead_wire = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %dead_wire, %dead_node : !firrtl.uint<1>
+    firrtl.matchingconnect %dead_wire, %dead_node : !firrtl.uint<1>
 
     %dead_reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
-    firrtl.strictconnect %dead_reg, %dead_wire : !firrtl.uint<1>
+    firrtl.matchingconnect %dead_reg, %dead_wire : !firrtl.uint<1>
 
     %dead_reg_reset = firrtl.regreset %clock, %reset, %dead_reg  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.strictconnect %dead_reg_reset, %dead_reg : !firrtl.uint<1>
+    firrtl.matchingconnect %dead_reg_reset, %dead_reg : !firrtl.uint<1>
 
     %not = firrtl.not %dead_reg_reset : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    firrtl.strictconnect %dest, %not : !firrtl.uint<1>
+    firrtl.matchingconnect %dest, %not : !firrtl.uint<1>
   }
 
   // `%dontTouch` port has a symbol so it shouldn't be removed. `%sym_wire` also has a
@@ -26,10 +26,10 @@ firrtl.circuit "top" {
   // CHECK-LABEL: firrtl.module private @dontTouch(in %dontTouch: !firrtl.uint<1> sym @sym, in %source: !firrtl.uint<1>) {
   firrtl.module private @dontTouch(in %dontTouch: !firrtl.uint<1> sym @sym, in %source: !firrtl.uint<1>, in %dead: !firrtl.uint<1>) {
     // CHECK-NEXT: %sym_wire = firrtl.wire sym @sym2   : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %sym_wire, %source : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %sym_wire, %source : !firrtl.uint<1>
     // CHECK-NEXT: }
     %sym_wire = firrtl.wire sym @sym2 : !firrtl.uint<1>
-    firrtl.strictconnect %sym_wire, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %sym_wire, %source : !firrtl.uint<1>
 
   }
 
@@ -49,29 +49,29 @@ firrtl.circuit "top" {
   firrtl.module @top(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>,
                      in %clock:!firrtl.clock, in %reset:!firrtl.uint<1>) {
     // CHECK-NEXT: %tmp = firrtl.node %source
-    // CHECK-NEXT: firrtl.strictconnect %dest, %tmp
+    // CHECK-NEXT: firrtl.matchingconnect %dest, %tmp
     %tmp = firrtl.node %source: !firrtl.uint<1>
-    firrtl.strictconnect %dest, %tmp : !firrtl.uint<1>
+    firrtl.matchingconnect %dest, %tmp : !firrtl.uint<1>
 
     // CHECK-NOT: @dead_module
     %source1, %dest1, %clock1, %reset1  = firrtl.instance dead_module @dead_module(in source: !firrtl.uint<1>, out dest: !firrtl.uint<1>, in clock:!firrtl.clock, in reset:!firrtl.uint<1>)
-    firrtl.strictconnect %source1, %source : !firrtl.uint<1>
-    firrtl.strictconnect %clock1, %clock : !firrtl.clock
-    firrtl.strictconnect %reset1, %reset : !firrtl.uint<1>
+    firrtl.matchingconnect %source1, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %clock1, %clock : !firrtl.clock
+    firrtl.matchingconnect %reset1, %reset : !firrtl.uint<1>
 
     // Check that ports with dontTouch are not removed.
     // CHECK-NEXT: %testDontTouch_dontTouch, %testDontTouch_source = firrtl.instance testDontTouch @dontTouch(in dontTouch: !firrtl.uint<1>, in source: !firrtl.uint<1>)
-    // CHECK-NEXT: firrtl.strictconnect %testDontTouch_dontTouch, %source
-    // CHECK-NEXT: firrtl.strictconnect %testDontTouch_source, %source
+    // CHECK-NEXT: firrtl.matchingconnect %testDontTouch_dontTouch, %source
+    // CHECK-NEXT: firrtl.matchingconnect %testDontTouch_source, %source
     %testDontTouch_dontTouch, %testDontTouch_source,  %dead = firrtl.instance testDontTouch @dontTouch(in dontTouch: !firrtl.uint<1>, in source: !firrtl.uint<1>, in dead:!firrtl.uint<1>)
-    firrtl.strictconnect %testDontTouch_dontTouch, %source : !firrtl.uint<1>
-    firrtl.strictconnect %testDontTouch_source, %source : !firrtl.uint<1>
-    firrtl.strictconnect %dead, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %testDontTouch_dontTouch, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %testDontTouch_source, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %dead, %source : !firrtl.uint<1>
 
     // CHECK-NEXT: %mem_source = firrtl.instance mem @mem(in source: !firrtl.uint<1>)
-    // CHECK-NEXT: firrtl.strictconnect %mem_source, %source : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %mem_source, %source : !firrtl.uint<1>
     %mem_source  = firrtl.instance mem @mem(in source: !firrtl.uint<1>)
-    firrtl.strictconnect %mem_source, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %mem_source, %source : !firrtl.uint<1>
     // CHECK-NEXT: }
   }
 }
@@ -82,13 +82,13 @@ firrtl.circuit "top" {
 firrtl.circuit "top"  {
   // CHECK-NOT: @Child1
   firrtl.module private @Child1(in %input: !firrtl.uint<1>, out %output: !firrtl.uint<1>) {
-    firrtl.strictconnect %output, %input : !firrtl.uint<1>
+    firrtl.matchingconnect %output, %input : !firrtl.uint<1>
   }
   // CHECK-NOT: @Child2
   firrtl.module private @Child2(in %input: !firrtl.uint<1>, in %clock: !firrtl.clock, out %output: !firrtl.uint<1>) {
     %r = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
-    firrtl.strictconnect %r, %input : !firrtl.uint<1>
-    firrtl.strictconnect %output, %r : !firrtl.uint<1>
+    firrtl.matchingconnect %r, %input : !firrtl.uint<1>
+    firrtl.matchingconnect %output, %r : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: firrtl.module @top(in %clock: !firrtl.clock, in %input: !firrtl.uint<1>) {
@@ -96,11 +96,11 @@ firrtl.circuit "top"  {
   // expected-warning @below {{module `top` is empty but cannot be removed because the module is public}}
   firrtl.module @top(in %clock: !firrtl.clock, in %input: !firrtl.uint<1>) {
     %tile_input, %tile_output = firrtl.instance tile  @Child1(in input: !firrtl.uint<1>, out output: !firrtl.uint<1>)
-    firrtl.strictconnect %tile_input, %input : !firrtl.uint<1>
+    firrtl.matchingconnect %tile_input, %input : !firrtl.uint<1>
     %named = firrtl.node  %tile_output  : !firrtl.uint<1>
     %bar_input, %bar_clock, %bar_output = firrtl.instance bar  @Child2(in input: !firrtl.uint<1>, in clock: !firrtl.clock, out output: !firrtl.uint<1>)
-    firrtl.strictconnect %bar_clock, %clock : !firrtl.clock
-    firrtl.strictconnect %bar_input, %named : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %bar_input, %named : !firrtl.uint<1>
   }
 }
 
@@ -112,19 +112,19 @@ firrtl.circuit "UnusedOutput"  {
   // CHECK-NOT:     out %c
   firrtl.module private @SingleDriver(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
     // CHECK-NEXT: %[[c_wire:.+]] = firrtl.wire
-    // CHECK-NEXT: firrtl.strictconnect %b, %[[c_wire]]
-    firrtl.strictconnect %b, %c : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %b, %[[c_wire]]
+    firrtl.matchingconnect %b, %c : !firrtl.uint<1>
     // CHECK-NEXT: %[[not_a:.+]] = firrtl.not %a
     %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %[[c_wire]], %[[not_a]]
-    firrtl.strictconnect %c, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %[[c_wire]], %[[not_a]]
+    firrtl.matchingconnect %c, %0 : !firrtl.uint<1>
   }
   // CHECK-LABEL: @UnusedOutput
   firrtl.module @UnusedOutput(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     // CHECK: %singleDriver_a, %singleDriver_b = firrtl.instance singleDriver
     %singleDriver_a, %singleDriver_b, %singleDriver_c = firrtl.instance singleDriver @SingleDriver(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
-    firrtl.strictconnect %singleDriver_a, %a : !firrtl.uint<1>
-    firrtl.strictconnect %b, %singleDriver_b : !firrtl.uint<1>
+    firrtl.matchingconnect %singleDriver_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %singleDriver_b : !firrtl.uint<1>
   }
 }
 
@@ -176,14 +176,14 @@ firrtl.circuit "ForwardConstant" {
   // CHECK-NOT: Zero
   firrtl.module private @Zero(out %zero: !firrtl.uint<1>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    firrtl.strictconnect %zero, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %zero, %c0_ui1 : !firrtl.uint<1>
   }
   // CHECK-LABEL: @ForwardConstant
   firrtl.module @ForwardConstant(out %zero: !firrtl.uint<1>) {
     // CHECK: %c0_ui1 = firrtl.constant 0
     %sub_zero = firrtl.instance sub @Zero(out zero: !firrtl.uint<1>)
-    // CHECK-NEXT: firrtl.strictconnect %zero, %c0_ui1
-    firrtl.strictconnect %zero, %sub_zero : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %zero, %c0_ui1
+    firrtl.matchingconnect %zero, %sub_zero : !firrtl.uint<1>
   }
 }
 
@@ -204,7 +204,7 @@ firrtl.circuit "RefPorts" {
   firrtl.module private @dead_ref_port(in %source: !firrtl.uint<1>, out %dest: !firrtl.uint<1>, out %ref_dest: !firrtl.probe<uint<1>>) {
     %ref_not = firrtl.ref.send %source: !firrtl.uint<1>
     firrtl.ref.define %ref_dest, %ref_not : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %dest, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %dest, %source : !firrtl.uint<1>
   }
 
   // CHECK: @live_ref
@@ -218,28 +218,28 @@ firrtl.circuit "RefPorts" {
     // Delete send's that aren't resolved, and check deletion of modules with ref ops + ports.
     // CHECK-NOT: @dead_ref_send
     %source1, %dest1 = firrtl.instance dead_ref_send @dead_ref_send(in source: !firrtl.uint<1>, out dest: !firrtl.probe<uint<1>>)
-    firrtl.strictconnect %source1, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %source1, %source : !firrtl.uint<1>
 
     // Check that an unused resolve doesn't keep send alive, and test ref port removal.
     // CHECK: @dead_ref_port
     // CHECK-NOT: firrtl.ref
     %source2, %dest2, %ref_dest2 = firrtl.instance dead_ref_port @dead_ref_port(in source: !firrtl.uint<1>, out dest: !firrtl.uint<1>, out ref_dest: !firrtl.probe<uint<1>>)
-    firrtl.strictconnect %source2, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %source2, %source : !firrtl.uint<1>
     %unused = firrtl.ref.resolve %ref_dest2 : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %dest, %dest2 : !firrtl.uint<1>
+    firrtl.matchingconnect %dest, %dest2 : !firrtl.uint<1>
 
     // Check not deleted if live.
     // CHECK: @live_ref
     %source3, %dest3 = firrtl.instance live_ref @live_ref(in source: !firrtl.uint<1>, out dest: !firrtl.probe<uint<1>>)
-    firrtl.strictconnect %source3, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %source3, %source : !firrtl.uint<1>
     // CHECK: firrtl.ref.resolve
     %dest3_resolved = firrtl.ref.resolve %dest3 : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %dest, %dest3_resolved : !firrtl.uint<1>
+    firrtl.matchingconnect %dest, %dest3_resolved : !firrtl.uint<1>
 
     // Check dead resolve is deleted.
     // CHECK-NOT: dead_instance
     %source4, %dest4 = firrtl.instance dead_instance @live_ref(in source: !firrtl.uint<1>, out dest: !firrtl.probe<uint<1>>)
-    firrtl.strictconnect %source4, %source : !firrtl.uint<1>
+    firrtl.matchingconnect %source4, %source : !firrtl.uint<1>
     // CHECK-NOT: firrtl.ref.resolve
     %unused5 = firrtl.ref.resolve %dest4 : !firrtl.probe<uint<1>>
   }
@@ -307,11 +307,11 @@ firrtl.circuit "DeadInputPort"  {
   // CHECK-LABEL: firrtl.module @DeadInputPort
   firrtl.module @DeadInputPort(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     // CHECK-NEXT: %0 = firrtl.wire
-    // CHECK-NEXT: firrtl.strictconnect %0, %a
-    // CHECK-NEXT: firrtl.strictconnect %b, %0
+    // CHECK-NEXT: firrtl.matchingconnect %0, %a
+    // CHECK-NEXT: firrtl.matchingconnect %b, %0
     %bar_a = firrtl.instance bar  @Bar(in a: !firrtl.uint<1>)
-    firrtl.strictconnect %bar_a, %a : !firrtl.uint<1>
-    firrtl.strictconnect %b, %bar_a : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %bar_a : !firrtl.uint<1>
   }
 }
 
@@ -327,11 +327,11 @@ firrtl.circuit "DeleteInstance" {
   }
   firrtl.module private @SideEffect2(in %a: !firrtl.uint<1>, in %clock: !firrtl.clock) {
     %s1_a, %s1_clock = firrtl.instance s1 @SideEffect1(in a: !firrtl.uint<1>, in clock: !firrtl.clock)
-    firrtl.strictconnect %s1_a, %a : !firrtl.uint<1>
-    firrtl.strictconnect %s1_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %s1_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %s1_clock, %clock : !firrtl.clock
   }
   firrtl.module private @PassThrough(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
-    firrtl.strictconnect %b, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %a : !firrtl.uint<1>
   }
   // CHECK-LABEL: DeleteInstance
   firrtl.module @DeleteInstance(in %a: !firrtl.uint<1>, in %clock: !firrtl.clock, out %b: !firrtl.uint<1>) {
@@ -343,15 +343,15 @@ firrtl.circuit "DeleteInstance" {
     %p1_a, %p1_b = firrtl.instance p1 @PassThrough(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
     %p2_a, %p2_b = firrtl.instance p2 @PassThrough(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>)
     %s_a, %s_clock = firrtl.instance s @SideEffect2(in a: !firrtl.uint<1>, in clock: !firrtl.clock)
-    // CHECK-NEXT: firrtl.strictconnect %s_a, %a : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %s_clock, %clock : !firrtl.clock
-    // CHECK-NEXT: firrtl.strictconnect %p2_a, %a : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %b, %p2_b : !firrtl.uint<1>
-    firrtl.strictconnect %s_a, %a : !firrtl.uint<1>
-    firrtl.strictconnect %s_clock, %clock : !firrtl.clock
-    firrtl.strictconnect %p1_a, %a : !firrtl.uint<1>
-    firrtl.strictconnect %p2_a, %a : !firrtl.uint<1>
-    firrtl.strictconnect %b, %p2_b : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %s_a, %a : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %s_clock, %clock : !firrtl.clock
+    // CHECK-NEXT: firrtl.matchingconnect %p2_a, %a : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %b, %p2_b : !firrtl.uint<1>
+    firrtl.matchingconnect %s_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %s_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %p1_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %p2_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %p2_b : !firrtl.uint<1>
   }
 }
 
@@ -365,29 +365,29 @@ firrtl.circuit "Top" {
   // CHECK-NOT: @nla_1
   // CHECK-SAME: @nla_2
   firrtl.module private @EncodingModule(in %in: !firrtl.uint<1>, out %a: !firrtl.uint<1> [{circt.nonlocal = @nla_1, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 0 : i64, type = "OMReferenceTarget"}, {circt.nonlocal = @nla_2, class = "freechips.rocketchip.objectmodel.OMIRTracker", id = 1 : i64, type = "OMReferenceTarget"}]) {
-    firrtl.strictconnect %a, %in : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %in : !firrtl.uint<1>
   }
   // CHECK-NOT: @Foo1
   firrtl.module private @Foo1(in %in: !firrtl.uint<1>) {
     %c_in, %c_a = firrtl.instance c sym @dead @EncodingModule(in in: !firrtl.uint<1>, out a: !firrtl.uint<1>)
-    firrtl.strictconnect %c_in, %in : !firrtl.uint<1>
+    firrtl.matchingconnect %c_in, %in : !firrtl.uint<1>
   }
   // CHECK-LABEL: @Foo2
   firrtl.module private @Foo2(in %in: !firrtl.uint<1>, out %a: !firrtl.uint<1>) {
     %c_in, %c_a = firrtl.instance c sym @live @EncodingModule(in in: !firrtl.uint<1>, out a: !firrtl.uint<1>)
-    firrtl.strictconnect %a, %c_a : !firrtl.uint<1>
-    firrtl.strictconnect %c_in, %in : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %c_a : !firrtl.uint<1>
+    firrtl.matchingconnect %c_in, %in : !firrtl.uint<1>
   }
   // CHECK-LABEL: @Top
   // CHECK-NOT: @Foo1
-  // CHECK-NOT: firrtl.strictconnect %foo1_in, %in
+  // CHECK-NOT: firrtl.matchingconnect %foo1_in, %in
   // CHECK: @Foo2
   firrtl.module @Top(in %in: !firrtl.uint<1>, out %a: !firrtl.uint<1>) {
     %foo1_in = firrtl.instance foo1 @Foo1(in in: !firrtl.uint<1>)
-    firrtl.strictconnect %foo1_in, %in : !firrtl.uint<1>
+    firrtl.matchingconnect %foo1_in, %in : !firrtl.uint<1>
     %foo2_in, %foo2_a = firrtl.instance foo2 @Foo2(in in: !firrtl.uint<1>, out a: !firrtl.uint<1>)
-    firrtl.strictconnect %a, %foo2_a : !firrtl.uint<1>
-    firrtl.strictconnect %foo2_in, %in : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %foo2_a : !firrtl.uint<1>
+    firrtl.matchingconnect %foo2_in, %in : !firrtl.uint<1>
 
   }
 }
@@ -414,9 +414,9 @@ firrtl.circuit "Top" {
   // CHECK-LABEL: firrtl.module @Top
   firrtl.module @Top(in %in: !firrtl.uint<1>) {
     %c_in1, %c_in2, %c_in3 = firrtl.instance c sym @foo1 @Bar(in in1: !firrtl.uint<1>, in in2: !firrtl.uint<1>, in in3: !firrtl.uint<1>)
-    firrtl.strictconnect %c_in1, %in : !firrtl.uint<1>
-    firrtl.strictconnect %c_in2, %in : !firrtl.uint<1>
-    firrtl.strictconnect %c_in3, %in : !firrtl.uint<1>
+    firrtl.matchingconnect %c_in1, %in : !firrtl.uint<1>
+    firrtl.matchingconnect %c_in2, %in : !firrtl.uint<1>
+    firrtl.matchingconnect %c_in3, %in : !firrtl.uint<1>
     // CHECK: sv.verbatim "foo" {some = #hw.innerNameRef<@Top::@baz1>}
     sv.verbatim "foo" {some = #hw.innerNameRef<@Top::@baz1>}
     // Don't remove the instance if there is an unknown use of inner reference.
@@ -440,7 +440,7 @@ firrtl.circuit "Test" {
   // CHECK: firrtl.module private @Blah() {
   firrtl.module private @Blah(out %out : !firrtl.uint<1>) {
     %extmodule_out = firrtl.instance extmodule @ExtModule(out out : !firrtl.uint<1>)
-    firrtl.strictconnect %out, %extmodule_out : !firrtl.uint<1>
+    firrtl.matchingconnect %out, %extmodule_out : !firrtl.uint<1>
   }
   firrtl.module @Test() attributes {convention = #firrtl<convention scalarized>} {
     // CHECK: firrtl.instance blah interesting_name @Blah()
@@ -450,7 +450,7 @@ firrtl.circuit "Test" {
   // CHECK-NOT: firrtl.module private @Other
   firrtl.module private @Other(out %out : !firrtl.uint<1>) {
     %blah_out = firrtl.instance blah interesting_name @Blah(out out : !firrtl.uint<1>)
-    firrtl.strictconnect %out, %blah_out : !firrtl.uint<1>
+    firrtl.matchingconnect %out, %blah_out : !firrtl.uint<1>
   }
 }
 
@@ -535,7 +535,7 @@ firrtl.circuit "Issue5898" {
   firrtl.module @Issue5898(in %x: !firrtl.uint<5>, out %p: !firrtl.rwprobe<uint<5>>) {
     // CHECK: connect
     %w, %w_ref = firrtl.wire forceable : !firrtl.uint<5>, !firrtl.rwprobe<uint<5>>
-    firrtl.strictconnect %w, %x : !firrtl.uint<5>
+    firrtl.matchingconnect %w, %x : !firrtl.uint<5>
     firrtl.ref.define %p, %w_ref : !firrtl.rwprobe<uint<5>>
   }
 }

--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -179,7 +179,7 @@ firrtl.circuit "top" {
    // expected-error @below {{'FullAsyncResetAnnotation' must target async reset, but targets '!firrtl.uint<1>'}}
     %innerReset = firrtl.wire {annotations = [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]} : !firrtl.reset
     %invalid = firrtl.invalidvalue : !firrtl.reset
-    firrtl.strictconnect %innerReset, %invalid : !firrtl.reset
+    firrtl.matchingconnect %innerReset, %invalid : !firrtl.reset
   }
 }
 

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -20,27 +20,27 @@ firrtl.module @Foo() {}
 firrtl.module @MergeNetsChild1(in %reset: !firrtl.reset) {
   // CHECK: %localReset = firrtl.wire : !firrtl.asyncreset
   %localReset = firrtl.wire : !firrtl.reset
-  firrtl.strictconnect %localReset, %reset : !firrtl.reset
+  firrtl.matchingconnect %localReset, %reset : !firrtl.reset
 }
 // CHECK-LABEL: firrtl.module @MergeNetsChild2
 // CHECK-SAME: in %reset: !firrtl.asyncreset
 firrtl.module @MergeNetsChild2(in %reset: !firrtl.reset) {
   // CHECK: %localReset = firrtl.wire : !firrtl.asyncreset
   %localReset = firrtl.wire : !firrtl.reset
-  firrtl.strictconnect %localReset, %reset : !firrtl.reset
+  firrtl.matchingconnect %localReset, %reset : !firrtl.reset
 }
 // CHECK-LABEL: firrtl.module @MergeNetsTop
 firrtl.module @MergeNetsTop(in %reset: !firrtl.asyncreset) {
   // CHECK: %localReset = firrtl.wire : !firrtl.asyncreset
   %localReset = firrtl.wire : !firrtl.reset
   %t = firrtl.resetCast %reset : (!firrtl.asyncreset) -> !firrtl.reset
-  firrtl.strictconnect %localReset, %t : !firrtl.reset
+  firrtl.matchingconnect %localReset, %t : !firrtl.reset
   // CHECK: %c1_reset = firrtl.instance c1 @MergeNetsChild1(in reset: !firrtl.asyncreset)
   // CHECK: %c2_reset = firrtl.instance c2 @MergeNetsChild2(in reset: !firrtl.asyncreset)
   %c1_reset = firrtl.instance c1 @MergeNetsChild1(in reset: !firrtl.reset)
   %c2_reset = firrtl.instance c2 @MergeNetsChild2(in reset: !firrtl.reset)
-  firrtl.strictconnect %c1_reset, %localReset : !firrtl.reset
-  firrtl.strictconnect %c2_reset, %localReset : !firrtl.reset
+  firrtl.matchingconnect %c1_reset, %localReset : !firrtl.reset
+  firrtl.matchingconnect %c2_reset, %localReset : !firrtl.reset
 }
 
 // Should support casting to other types
@@ -53,11 +53,11 @@ firrtl.module @CastingToOtherTypes(in %a: !firrtl.uint<1>, out %v: !firrtl.uint<
   %2 = firrtl.asClock %r : (!firrtl.reset) -> !firrtl.clock
   %3 = firrtl.asAsyncReset %r : (!firrtl.reset) -> !firrtl.asyncreset
   %4 = firrtl.resetCast %a : (!firrtl.uint<1>) -> !firrtl.reset
-  firrtl.strictconnect %r, %4 : !firrtl.reset
-  firrtl.strictconnect %v, %0 : !firrtl.uint<1>
-  firrtl.strictconnect %w, %1 : !firrtl.sint<1>
-  firrtl.strictconnect %x, %2 : !firrtl.clock
-  firrtl.strictconnect %y, %3 : !firrtl.asyncreset
+  firrtl.matchingconnect %r, %4 : !firrtl.reset
+  firrtl.matchingconnect %v, %0 : !firrtl.uint<1>
+  firrtl.matchingconnect %w, %1 : !firrtl.sint<1>
+  firrtl.matchingconnect %x, %2 : !firrtl.clock
+  firrtl.matchingconnect %y, %3 : !firrtl.asyncreset
 }
 
 // Should support const-casts
@@ -67,7 +67,7 @@ firrtl.module @ConstCast(in %a: !firrtl.const.uint<1>) {
   %r = firrtl.wire : !firrtl.reset
   %0 = firrtl.resetCast %a : (!firrtl.const.uint<1>) -> !firrtl.const.reset
   %1 = firrtl.constCast %0 : (!firrtl.const.reset) -> !firrtl.reset
-  firrtl.strictconnect %r, %1 : !firrtl.reset
+  firrtl.matchingconnect %r, %1 : !firrtl.reset
 }
 
 // Should work across Module boundaries
@@ -77,17 +77,17 @@ firrtl.module @ModuleBoundariesChild(in %clock: !firrtl.clock, in %childReset: !
   %c123_ui = firrtl.constant 123 : !firrtl.uint
   // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
   %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
-  firrtl.strictconnect %r, %x : !firrtl.uint<8>
-  firrtl.strictconnect %z, %r : !firrtl.uint<8>
+  firrtl.matchingconnect %r, %x : !firrtl.uint<8>
+  firrtl.matchingconnect %z, %r : !firrtl.uint<8>
 }
 // CHECK-LABEL: firrtl.module @ModuleBoundariesTop
 firrtl.module @ModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
   // CHECK: {{.*}} = firrtl.instance c @ModuleBoundariesChild(in clock: !firrtl.clock, in childReset: !firrtl.uint<1>, in x: !firrtl.uint<8>, out z: !firrtl.uint<8>)
   %c_clock, %c_childReset, %c_x, %c_z = firrtl.instance c @ModuleBoundariesChild(in clock: !firrtl.clock, in childReset: !firrtl.reset, in x: !firrtl.uint<8>, out z: !firrtl.uint<8>)
-  firrtl.strictconnect %c_clock, %clock : !firrtl.clock
+  firrtl.matchingconnect %c_clock, %clock : !firrtl.clock
   firrtl.connect %c_childReset, %reset : !firrtl.reset, !firrtl.uint<1>
-  firrtl.strictconnect %c_x, %x : !firrtl.uint<8>
-  firrtl.strictconnect %z, %c_z : !firrtl.uint<8>
+  firrtl.matchingconnect %c_x, %x : !firrtl.uint<8>
+  firrtl.matchingconnect %z, %c_z : !firrtl.uint<8>
 }
 
 // Should work across multiple Module boundaries
@@ -95,7 +95,7 @@ firrtl.module @ModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: !firrtl.
 // CHECK-SAME: in %resetIn: !firrtl.uint<1>
 // CHECK-SAME: out %resetOut: !firrtl.uint<1>
 firrtl.module @MultipleModuleBoundariesChild(in %resetIn: !firrtl.reset, out %resetOut: !firrtl.reset) {
-  firrtl.strictconnect %resetOut, %resetIn : !firrtl.reset
+  firrtl.matchingconnect %resetOut, %resetIn : !firrtl.reset
 }
 // CHECK-LABEL: firrtl.module @MultipleModuleBoundariesTop
 firrtl.module @MultipleModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
@@ -105,8 +105,8 @@ firrtl.module @MultipleModuleBoundariesTop(in %clock: !firrtl.clock, in %reset: 
   %c123_ui = firrtl.constant 123 : !firrtl.uint
   // CHECK: %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
   %r = firrtl.regreset %clock, %c_resetOut, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
-  firrtl.strictconnect %r, %x : !firrtl.uint<8>
-  firrtl.strictconnect %z, %r : !firrtl.uint<8>
+  firrtl.matchingconnect %r, %x : !firrtl.uint<8>
+  firrtl.matchingconnect %z, %r : !firrtl.uint<8>
 }
 
 // Should work in nested and flipped aggregates with connect
@@ -136,7 +136,7 @@ firrtl.module @DontCrashIfNoDrivers(out %out: !firrtl.reset) {
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK: %w = firrtl.wire : !firrtl.uint<1>
   %w = firrtl.wire : !firrtl.reset
-  firrtl.strictconnect %out, %w : !firrtl.reset
+  firrtl.matchingconnect %out, %w : !firrtl.reset
   // TODO: Enable the following once #1303 is fixed.
   // firrtl.connect %out, %c1_ui : !firrtl.reset, !firrtl.uint
   firrtl.connect %out, %c1_ui1 : !firrtl.reset, !firrtl.uint<1>
@@ -148,7 +148,7 @@ firrtl.module @DontCrashIfNoDrivers(out %out: !firrtl.reset) {
 firrtl.module @ConcreteResetOverruleInvalid(in %in: !firrtl.asyncreset, out %out: !firrtl.reset) {
   // CHECK: %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
   %invalid_reset = firrtl.invalidvalue : !firrtl.reset
-  firrtl.strictconnect %out, %invalid_reset : !firrtl.reset
+  firrtl.matchingconnect %out, %invalid_reset : !firrtl.reset
   firrtl.connect %out, %in : !firrtl.reset, !firrtl.asyncreset
 }
 
@@ -158,7 +158,7 @@ firrtl.module @ConcreteResetOverruleInvalid(in %in: !firrtl.asyncreset, out %out
 firrtl.module @DefaultToBool(out %out: !firrtl.reset) {
   // CHECK: %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
   %invalid_reset = firrtl.invalidvalue : !firrtl.reset
-  firrtl.strictconnect %out, %invalid_reset : !firrtl.reset
+  firrtl.matchingconnect %out, %invalid_reset : !firrtl.reset
 }
 
 // Should not error if component of ResetType is invalidated and connected to an AsyncResetType
@@ -167,7 +167,7 @@ firrtl.module @DefaultToBool(out %out: !firrtl.reset) {
 firrtl.module @OverrideInvalidWithDifferentResetType(in %cond: !firrtl.uint<1>, in %in: !firrtl.asyncreset, out %out: !firrtl.reset) {
   // CHECK: %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
   %invalid_reset = firrtl.invalidvalue : !firrtl.reset
-  firrtl.strictconnect %out, %invalid_reset : !firrtl.reset
+  firrtl.matchingconnect %out, %invalid_reset : !firrtl.reset
   firrtl.when %cond : !firrtl.uint<1>  {
     firrtl.connect %out, %in : !firrtl.reset, !firrtl.asyncreset
   }
@@ -203,8 +203,8 @@ firrtl.module @DedupDifferentlyChild1(in %clock: !firrtl.clock, in %childReset: 
   %c123_ui = firrtl.constant 123 : !firrtl.uint
   // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<8>
   %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
-  firrtl.strictconnect %r, %x : !firrtl.uint<8>
-  firrtl.strictconnect %z, %r : !firrtl.uint<8>
+  firrtl.matchingconnect %r, %x : !firrtl.uint<8>
+  firrtl.matchingconnect %z, %r : !firrtl.uint<8>
 }
 // CHECK-LABEL: firrtl.module @DedupDifferentlyChild2
 // CHECK-SAME: in %childReset: !firrtl.asyncreset
@@ -212,27 +212,27 @@ firrtl.module @DedupDifferentlyChild2(in %clock: !firrtl.clock, in %childReset: 
   %c123_ui = firrtl.constant 123 : !firrtl.uint
   // CHECK: %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint, !firrtl.uint<8>
   %r = firrtl.regreset %clock, %childReset, %c123_ui : !firrtl.clock, !firrtl.reset, !firrtl.uint, !firrtl.uint<8>
-  firrtl.strictconnect %r, %x : !firrtl.uint<8>
-  firrtl.strictconnect %z, %r : !firrtl.uint<8>
+  firrtl.matchingconnect %r, %x : !firrtl.uint<8>
+  firrtl.matchingconnect %z, %r : !firrtl.uint<8>
 }
 // CHECK-LABEL: firrtl.module @DedupDifferentlyTop
 firrtl.module @DedupDifferentlyTop(in %clock: !firrtl.clock, in %reset1: !firrtl.uint<1>, in %reset2: !firrtl.asyncreset, in %x: !firrtl.vector<uint<8>, 2>, out %z: !firrtl.vector<uint<8>, 2>) {
   // CHECK: {{.*}} = firrtl.instance c1 @DedupDifferentlyChild1(in clock: !firrtl.clock, in childReset: !firrtl.uint<1>
   %c1_clock, %c1_childReset, %c1_x, %c1_z = firrtl.instance c1 @DedupDifferentlyChild1(in clock: !firrtl.clock, in childReset: !firrtl.reset, in x: !firrtl.uint<8>, out z: !firrtl.uint<8>)
-  firrtl.strictconnect %c1_clock, %clock : !firrtl.clock
+  firrtl.matchingconnect %c1_clock, %clock : !firrtl.clock
   firrtl.connect %c1_childReset, %reset1 : !firrtl.reset, !firrtl.uint<1>
   %0 = firrtl.subindex %x[0] : !firrtl.vector<uint<8>, 2>
-  firrtl.strictconnect %c1_x, %0 : !firrtl.uint<8>
+  firrtl.matchingconnect %c1_x, %0 : !firrtl.uint<8>
   %1 = firrtl.subindex %z[0] : !firrtl.vector<uint<8>, 2>
-  firrtl.strictconnect %1, %c1_z : !firrtl.uint<8>
+  firrtl.matchingconnect %1, %c1_z : !firrtl.uint<8>
   // CHECK: {{.*}} = firrtl.instance c2 @DedupDifferentlyChild2(in clock: !firrtl.clock, in childReset: !firrtl.asyncreset
   %c2_clock, %c2_childReset, %c2_x, %c2_z = firrtl.instance c2 @DedupDifferentlyChild2(in clock: !firrtl.clock, in childReset: !firrtl.reset, in x: !firrtl.uint<8>, out z: !firrtl.uint<8>)
-  firrtl.strictconnect %c2_clock, %clock : !firrtl.clock
+  firrtl.matchingconnect %c2_clock, %clock : !firrtl.clock
   firrtl.connect %c2_childReset, %reset2 : !firrtl.reset, !firrtl.asyncreset
   %2 = firrtl.subindex %x[1] : !firrtl.vector<uint<8>, 2>
-  firrtl.strictconnect %c2_x, %2 : !firrtl.uint<8>
+  firrtl.matchingconnect %c2_x, %2 : !firrtl.uint<8>
   %3 = firrtl.subindex %z[1] : !firrtl.vector<uint<8>, 2>
-  firrtl.strictconnect %3, %c2_z : !firrtl.uint<8>
+  firrtl.matchingconnect %3, %c2_z : !firrtl.uint<8>
 }
 
 // Should infer based on what a component *drives* not just what drives it
@@ -243,8 +243,8 @@ firrtl.module @InferBasedOnDriven(in %in: !firrtl.asyncreset, out %out: !firrtl.
   // CHECK: %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
   %w = firrtl.wire : !firrtl.reset
   %invalid_reset = firrtl.invalidvalue : !firrtl.reset
-  firrtl.strictconnect %w, %invalid_reset : !firrtl.reset
-  firrtl.strictconnect %out, %w : !firrtl.reset
+  firrtl.matchingconnect %w, %invalid_reset : !firrtl.reset
+  firrtl.matchingconnect %out, %w : !firrtl.reset
   firrtl.connect %out, %in : !firrtl.reset, !firrtl.asyncreset
 }
 
@@ -255,7 +255,7 @@ firrtl.module @InferIgnoreInvalidation(in %in: !firrtl.asyncreset, out %out: !fi
   // CHECK: %invalid_asyncreset = firrtl.invalidvalue : !firrtl.asyncreset
   %invalid_reset = firrtl.invalidvalue : !firrtl.reset
   firrtl.connect %out, %in : !firrtl.reset, !firrtl.asyncreset
-  firrtl.strictconnect %out, %invalid_reset : !firrtl.reset
+  firrtl.matchingconnect %out, %invalid_reset : !firrtl.reset
 }
 
 // Should not propagate type info from downstream across a cast
@@ -266,10 +266,10 @@ firrtl.module @DontPropagateUpstreamAcrossCast(in %in0: !firrtl.asyncreset, in %
   // CHECK: %w = firrtl.wire : !firrtl.uint<1>
   %w = firrtl.wire : !firrtl.reset
   %invalid_reset = firrtl.invalidvalue : !firrtl.reset
-  firrtl.strictconnect %w, %invalid_reset : !firrtl.reset
+  firrtl.matchingconnect %w, %invalid_reset : !firrtl.reset
   %0 = firrtl.asAsyncReset %w : (!firrtl.reset) -> !firrtl.asyncreset
   firrtl.connect %out0, %0 : !firrtl.reset, !firrtl.asyncreset
-  firrtl.strictconnect %out1, %w : !firrtl.reset
+  firrtl.matchingconnect %out1, %w : !firrtl.reset
   firrtl.connect %out0, %in0 : !firrtl.reset, !firrtl.asyncreset
   firrtl.connect %out1, %in1 : !firrtl.reset, !firrtl.uint<1>
 }
@@ -284,7 +284,7 @@ firrtl.module @InternalAndExternalChild(in %i: !firrtl.asyncreset, out %o: !firr
 firrtl.module @InternalAndExternalTop(in %in: !firrtl.asyncreset, out %out: !firrtl.asyncreset) {
   // CHECK: {{.*}} = firrtl.instance c @InternalAndExternalChild(in i: !firrtl.asyncreset, out o: !firrtl.asyncreset)
   %c_i, %c_o = firrtl.instance c @InternalAndExternalChild(in i: !firrtl.asyncreset, out o: !firrtl.reset)
-  firrtl.strictconnect %c_i, %in : !firrtl.asyncreset
+  firrtl.matchingconnect %c_i, %in : !firrtl.asyncreset
   firrtl.connect %out, %c_o : !firrtl.asyncreset, !firrtl.reset
 }
 
@@ -295,8 +295,8 @@ firrtl.module @NoCrashOnCombLoop(in %in: !firrtl.asyncreset, out %out: !firrtl.r
   %w0 = firrtl.wire : !firrtl.reset
   %w1 = firrtl.wire : !firrtl.reset
   firrtl.connect %w0, %in : !firrtl.reset, !firrtl.asyncreset
-  firrtl.strictconnect %w0, %w1 : !firrtl.reset
-  firrtl.strictconnect %w1, %w0 : !firrtl.reset
+  firrtl.matchingconnect %w0, %w1 : !firrtl.reset
+  firrtl.matchingconnect %w1, %w0 : !firrtl.reset
   firrtl.connect %out, %in : !firrtl.reset, !firrtl.asyncreset
 }
 
@@ -316,10 +316,10 @@ firrtl.module @InvalidValueShouldNotConnect(
   out %r3: !firrtl.reset
 ) {
   %invalid_reset = firrtl.invalidvalue : !firrtl.reset
-  firrtl.strictconnect %r0, %invalid_reset : !firrtl.reset
-  firrtl.strictconnect %r1, %invalid_reset : !firrtl.reset
-  firrtl.strictconnect %r2, %invalid_reset : !firrtl.reset
-  firrtl.strictconnect %r3, %invalid_reset : !firrtl.reset
+  firrtl.matchingconnect %r0, %invalid_reset : !firrtl.reset
+  firrtl.matchingconnect %r1, %invalid_reset : !firrtl.reset
+  firrtl.matchingconnect %r2, %invalid_reset : !firrtl.reset
+  firrtl.matchingconnect %r3, %invalid_reset : !firrtl.reset
   firrtl.connect %r0, %ar : !firrtl.reset, !firrtl.asyncreset
   firrtl.connect %r1, %ar : !firrtl.reset, !firrtl.asyncreset
   firrtl.connect %r2, %sr : !firrtl.reset, !firrtl.uint<1>
@@ -343,10 +343,10 @@ firrtl.module @ShouldAdjustExtModule2() {
 firrtl.module @ForeignTypes(out %out: !firrtl.reset) {
   %0 = firrtl.wire : index
   %1 = firrtl.wire : index
-  firrtl.strictconnect %0, %1 : index
+  firrtl.matchingconnect %0, %1 : index
   // CHECK-NEXT: [[W0:%.+]] = firrtl.wire : index
   // CHECK-NEXT: [[W1:%.+]] = firrtl.wire : index
-  // CHECK-NEXT: firrtl.strictconnect [[W0]], [[W1]] : index
+  // CHECK-NEXT: firrtl.matchingconnect [[W0]], [[W1]] : index
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   firrtl.connect %out, %c1_ui1 : !firrtl.reset, !firrtl.uint<1>
 }
@@ -373,20 +373,20 @@ firrtl.circuit "Top" {
     %c1_ui8 = firrtl.constant 1 : !firrtl.uint<8>
     // CHECK: %reg1 = firrtl.regreset sym @reg1 %clock, %extraReset, %c0_ui8
     %reg1 = firrtl.reg sym @reg1 %clock : !firrtl.clock, !firrtl.uint<8>
-    firrtl.strictconnect %reg1, %in : !firrtl.uint<8>
+    firrtl.matchingconnect %reg1, %in : !firrtl.uint<8>
 
     // Existing async reset remains untouched.
     // CHECK: %reg2 = firrtl.regreset %clock, %reset, %c1_ui8
     %reg2 = firrtl.regreset %clock, %reset, %c1_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
-    firrtl.strictconnect %reg2, %in : !firrtl.uint<8>
+    firrtl.matchingconnect %reg2, %in : !firrtl.uint<8>
 
     // Existing sync reset is moved to mux.
     // CHECK: %reg3 = firrtl.regreset %clock, %extraReset, %c0_ui8
     // CHECK: %0 = firrtl.mux(%init, %c1_ui8, %reg3)
     // CHECK: %1 = firrtl.mux(%init, %c1_ui8, %in)
-    // CHECK: firrtl.strictconnect %reg3, %1
+    // CHECK: firrtl.matchingconnect %reg3, %1
     %reg3 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
-    firrtl.strictconnect %reg3, %in : !firrtl.uint<8>
+    firrtl.matchingconnect %reg3, %in : !firrtl.uint<8>
 
     // Factoring of sync reset into mux works through subfield op.
     // CHECK: %reg4 = firrtl.regreset %clock, %extraReset, %2
@@ -394,37 +394,37 @@ firrtl.circuit "Top" {
     // CHECK: %5 = firrtl.subfield %reset4[a]
     // CHECK: %6 = firrtl.subfield %reg4[a]
     // CHECK: %7 = firrtl.mux(%init, %5, %in)
-    // CHECK: firrtl.strictconnect %6, %7
+    // CHECK: firrtl.matchingconnect %6, %7
     %reset4 = firrtl.wire : !firrtl.bundle<a: uint<8>>
     %reg4 = firrtl.regreset %clock, %init, %reset4 : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
     %0 = firrtl.subfield %reg4[a] : !firrtl.bundle<a: uint<8>>
-    firrtl.strictconnect %0, %in : !firrtl.uint<8>
+    firrtl.matchingconnect %0, %in : !firrtl.uint<8>
 
     // Factoring of sync reset into mux works through subindex op.
     // CHECK: %reg5 = firrtl.regreset %clock, %extraReset, %8
     // CHECK: %10 = firrtl.mux(%init, %reset5, %reg5)
-    // CHECK: firrtl.strictconnect %reg5, %10
+    // CHECK: firrtl.matchingconnect %reg5, %10
     // CHECK: %11 = firrtl.subindex %reset5[0]
     // CHECK: %12 = firrtl.subindex %reg5[0]
     // CHECK: %13 = firrtl.mux(%init, %11, %in)
-    // CHECK: firrtl.strictconnect %12, %13
+    // CHECK: firrtl.matchingconnect %12, %13
     %reset5 = firrtl.wire : !firrtl.vector<uint<8>, 1>
     %reg5 = firrtl.regreset %clock, %init, %reset5 : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
     %1 = firrtl.subindex %reg5[0] : !firrtl.vector<uint<8>, 1>
-    firrtl.strictconnect %1, %in : !firrtl.uint<8>
+    firrtl.matchingconnect %1, %in : !firrtl.uint<8>
 
     // Factoring of sync reset into mux works through subaccess op.
     // CHECK: %reg6 = firrtl.regreset %clock, %extraReset, %14 
     // CHECK: %16 = firrtl.mux(%init, %reset6, %reg6)
-    // CHECK: firrtl.strictconnect %reg6, %16
+    // CHECK: firrtl.matchingconnect %reg6, %16
     // CHECK: %17 = firrtl.subaccess %reset6[%in]
     // CHECK: %18 = firrtl.subaccess %reg6[%in]
     // CHECK: %19 = firrtl.mux(%init, %17, %in)
-    // CHECK: firrtl.strictconnect %18, %19
+    // CHECK: firrtl.matchingconnect %18, %19
     %reset6 = firrtl.wire : !firrtl.vector<uint<8>, 1>
     %reg6 = firrtl.regreset %clock, %init, %reset6 : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<8>, 1>, !firrtl.vector<uint<8>, 1>
     %2 = firrtl.subaccess %reg6[%in] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<8>
-    firrtl.strictconnect %2, %in : !firrtl.uint<8>
+    firrtl.matchingconnect %2, %in : !firrtl.uint<8>
 
     // Subfields that are never assigned to should not leave unused reset
     // subfields behind.
@@ -450,26 +450,26 @@ firrtl.circuit "Top" {
     // CHECK: %0 = firrtl.wire : !firrtl.const.bundle<a: uint<8>, b: bundle<x: uint<8>, y: uint<8>>>
     // CHECK: %c0_ui8 = firrtl.constant 0 : !firrtl.const.uint<8>
     // CHECK: %1 = firrtl.subfield %0[a]
-    // CHECK: firrtl.strictconnect %1, %c0_ui8
+    // CHECK: firrtl.matchingconnect %1, %c0_ui8
     // CHECK: %2 = firrtl.wire : !firrtl.const.bundle<x: uint<8>, y: uint<8>>
     // CHECK: %3 = firrtl.subfield %2[x]
-    // CHECK: firrtl.strictconnect %3, %c0_ui8
+    // CHECK: firrtl.matchingconnect %3, %c0_ui8
     // CHECK: %4 = firrtl.subfield %2[y]
-    // CHECK: firrtl.strictconnect %4, %c0_ui8
+    // CHECK: firrtl.matchingconnect %4, %c0_ui8
     // CHECK: %5 = firrtl.subfield %0[b]
-    // CHECK: firrtl.strictconnect %5, %2
+    // CHECK: firrtl.matchingconnect %5, %2
     // CHECK: %reg_bundle = firrtl.regreset %clock, %reset, %0
     %reg_bundle = firrtl.reg %clock : !firrtl.clock, !firrtl.bundle<a: uint<8>, b: bundle<x: uint<8>, y: uint<8>>>
     // CHECK: %6 = firrtl.wire : !firrtl.const.vector<uint<8>, 4>
     // CHECK: %c0_ui8_0 = firrtl.constant 0 : !firrtl.const.uint<8>
     // CHECK: %7 = firrtl.subindex %6[0]
-    // CHECK: firrtl.strictconnect %7, %c0_ui8_0
+    // CHECK: firrtl.matchingconnect %7, %c0_ui8_0
     // CHECK: %8 = firrtl.subindex %6[1]
-    // CHECK: firrtl.strictconnect %8, %c0_ui8_0
+    // CHECK: firrtl.matchingconnect %8, %c0_ui8_0
     // CHECK: %9 = firrtl.subindex %6[2]
-    // CHECK: firrtl.strictconnect %9, %c0_ui8_0
+    // CHECK: firrtl.matchingconnect %9, %c0_ui8_0
     // CHECK: %10 = firrtl.subindex %6[3]
-    // CHECK: firrtl.strictconnect %10, %c0_ui8_0
+    // CHECK: firrtl.matchingconnect %10, %c0_ui8_0
     // CHECK: %reg_vector = firrtl.regreset %clock, %reset, %6
     %reg_vector = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<uint<8>, 4>
   }
@@ -505,11 +505,11 @@ firrtl.circuit "ReusePorts" {
   firrtl.module @ReusePorts(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) attributes {
     portAnnotations = [[],[{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     // CHECK: %child_clock, %child_reset = firrtl.instance child
-    // CHECK: firrtl.strictconnect %child_reset, %reset
+    // CHECK: firrtl.matchingconnect %child_reset, %reset
     // CHECK: %badName_reset, %badName_clock, %badName_existingReset = firrtl.instance badName
-    // CHECK: firrtl.strictconnect %badName_reset, %reset
+    // CHECK: firrtl.matchingconnect %badName_reset, %reset
     // CHECK: %badType_reset_0, %badType_clock, %badType_reset = firrtl.instance badType
-    // CHECK: firrtl.strictconnect %badType_reset_0, %reset
+    // CHECK: firrtl.matchingconnect %badType_reset_0, %reset
     %child_clock, %child_reset = firrtl.instance child @Child(in clock: !firrtl.clock, in reset: !firrtl.asyncreset)
     %badName_clock, %badName_existingReset = firrtl.instance badName @BadName(in clock: !firrtl.clock, in existingReset: !firrtl.asyncreset)
     %badType_clock, %badType_reset = firrtl.instance badType @BadType(in clock: !firrtl.clock, in reset: !firrtl.uint<1>)
@@ -524,32 +524,32 @@ firrtl.circuit "FullAsyncNested" {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     // CHECK: %io_out_REG = firrtl.regreset %clock, %reset, %c1_ui1
     %io_out_REG = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<8>
-    firrtl.strictconnect %io_out_REG, %io_in : !firrtl.uint<8>
-    firrtl.strictconnect %io_out, %io_out_REG : !firrtl.uint<8>
+    firrtl.matchingconnect %io_out_REG, %io_in : !firrtl.uint<8>
+    firrtl.matchingconnect %io_out, %io_out_REG : !firrtl.uint<8>
   }
   // CHECK-LABEL: firrtl.module @FullAsyncNestedChild
   firrtl.module @FullAsyncNestedChild(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) {
     %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance inst @FullAsyncNestedDeeper(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, in io_in: !firrtl.uint<8>, out io_out: !firrtl.uint<8>)
-    firrtl.strictconnect %inst_clock, %clock : !firrtl.clock
-    firrtl.strictconnect %inst_reset, %reset : !firrtl.asyncreset
-    firrtl.strictconnect %inst_io_in, %io_in : !firrtl.uint<8>
+    firrtl.matchingconnect %inst_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %inst_reset, %reset : !firrtl.asyncreset
+    firrtl.matchingconnect %inst_io_in, %io_in : !firrtl.uint<8>
     // CHECK: %io_out_REG = firrtl.regreset %clock, %reset, %c0_ui8
     %io_out_REG = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
     // CHECK: %io_out_REG_NO = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
     %io_out_REG_NO = firrtl.reg %clock {annotations = [{class = "sifive.enterprise.firrtl.ExcludeMemFromMemToRegOfVec"}]}: !firrtl.clock, !firrtl.uint<8>
-    firrtl.strictconnect %io_out_REG, %io_in : !firrtl.uint<8>
+    firrtl.matchingconnect %io_out_REG, %io_in : !firrtl.uint<8>
     %0 = firrtl.add %io_out_REG, %inst_io_out : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<9>
     %1 = firrtl.bits %0 7 to 0 : (!firrtl.uint<9>) -> !firrtl.uint<8>
-    firrtl.strictconnect %io_out, %1 : !firrtl.uint<8>
+    firrtl.matchingconnect %io_out, %1 : !firrtl.uint<8>
   }
   // CHECK-LABEL: firrtl.module @FullAsyncNested
   firrtl.module @FullAsyncNested(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) attributes {
     portAnnotations=[[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}], [], []] } {
     %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance inst @FullAsyncNestedChild(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, in io_in: !firrtl.uint<8>, out io_out: !firrtl.uint<8>)
-    firrtl.strictconnect %inst_clock, %clock : !firrtl.clock
-    firrtl.strictconnect %inst_reset, %reset : !firrtl.asyncreset
-    firrtl.strictconnect %io_out, %inst_io_out : !firrtl.uint<8>
-    firrtl.strictconnect %inst_io_in, %io_in : !firrtl.uint<8>
+    firrtl.matchingconnect %inst_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %inst_reset, %reset : !firrtl.asyncreset
+    firrtl.matchingconnect %io_out, %inst_io_out : !firrtl.uint<8>
+    firrtl.matchingconnect %inst_io_in, %io_in : !firrtl.uint<8>
   }
 }
 
@@ -563,18 +563,18 @@ firrtl.circuit "FullAsyncExcluded" {
   firrtl.module @FullAsyncExcludedChild(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>) attributes {annotations = [{class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation"}]} {
     // CHECK: %io_out_REG = firrtl.reg %clock
     %io_out_REG = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
-    firrtl.strictconnect %io_out_REG, %io_in : !firrtl.uint<8>
-    firrtl.strictconnect %io_out, %io_out_REG : !firrtl.uint<8>
+    firrtl.matchingconnect %io_out_REG, %io_in : !firrtl.uint<8>
+    firrtl.matchingconnect %io_out, %io_out_REG : !firrtl.uint<8>
   }
   // CHECK-LABEL: firrtl.module @FullAsyncExcluded
   firrtl.module @FullAsyncExcluded(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %io_in: !firrtl.uint<8>, out %io_out: !firrtl.uint<8>, in %extraReset: !firrtl.asyncreset) attributes {
      portAnnotations = [[],[],[],[],[{class = "firrtl.transforms.DontTouchAnnotation"}, {class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]]} {
     // CHECK: %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance inst @FullAsyncExcludedChild
     %inst_clock, %inst_reset, %inst_io_in, %inst_io_out = firrtl.instance inst @FullAsyncExcludedChild(in clock: !firrtl.clock, in reset: !firrtl.asyncreset, in io_in: !firrtl.uint<8>, out io_out: !firrtl.uint<8>)
-    firrtl.strictconnect %inst_clock, %clock : !firrtl.clock
-    firrtl.strictconnect %inst_reset, %reset : !firrtl.asyncreset
-    firrtl.strictconnect %io_out, %inst_io_out : !firrtl.uint<8>
-    firrtl.strictconnect %inst_io_in, %io_in : !firrtl.uint<8>
+    firrtl.matchingconnect %inst_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %inst_reset, %reset : !firrtl.asyncreset
+    firrtl.matchingconnect %io_out, %inst_io_out : !firrtl.uint<8>
+    firrtl.matchingconnect %inst_io_in, %io_in : !firrtl.uint<8>
   }
 }
 
@@ -625,7 +625,7 @@ firrtl.circuit "UnmovableNodeShouldDominate" {
     // CHECK-NEXT: [[RV:%.+]] = firrtl.constant 0
     // CHECK-NEXT: %reg = firrtl.regreset %clock, %localReset, [[RV]]
     // CHECK-NEXT: %0 = firrtl.asAsyncReset %ui1
-    // CHECK-NEXT: firrtl.strictconnect %localReset, %0
+    // CHECK-NEXT: firrtl.matchingconnect %localReset, %0
   }
 }
 
@@ -642,7 +642,7 @@ firrtl.circuit "UnmovableForceableNodeShouldDominate" {
     // CHECK-NEXT: [[RV:%.+]] = firrtl.constant 0
     // CHECK-NEXT: %reg = firrtl.regreset %clock, %localReset, [[RV]]
     // CHECK-NEXT: %0 = firrtl.asAsyncReset %ui1
-    // CHECK-NEXT: firrtl.strictconnect %localReset, %0
+    // CHECK-NEXT: firrtl.matchingconnect %localReset, %0
   }
 }
 
@@ -667,7 +667,7 @@ firrtl.circuit "MoveAcrossBlocks1" {
     // CHECK-NEXT: }
     // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
     // CHECK-NEXT:   [[TMP:%.+]] = firrtl.asAsyncReset %ui1
-    // CHECK-NEXT:   firrtl.strictconnect %localReset, [[TMP]]
+    // CHECK-NEXT:   firrtl.matchingconnect %localReset, [[TMP]]
     // CHECK-NEXT: }
   }
 }
@@ -688,7 +688,7 @@ firrtl.circuit "MoveAcrossBlocks2" {
     // CHECK-NEXT: %localReset = firrtl.wire
     // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
     // CHECK-NEXT:   [[TMP:%.+]] = firrtl.asAsyncReset %ui1
-    // CHECK-NEXT:   firrtl.strictconnect %localReset, [[TMP]]
+    // CHECK-NEXT:   firrtl.matchingconnect %localReset, [[TMP]]
     // CHECK-NEXT: }
     // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
     // CHECK-NEXT:   [[RV:%.+]] = firrtl.constant 0
@@ -713,7 +713,7 @@ firrtl.circuit "MoveAcrossBlocks3" {
     // CHECK-NEXT: %reg = firrtl.regreset %clock, %localReset, [[RV]]
     // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
     // CHECK-NEXT:   [[TMP:%.+]] = firrtl.asAsyncReset %ui1
-    // CHECK-NEXT:   firrtl.strictconnect %localReset, [[TMP]]
+    // CHECK-NEXT:   firrtl.matchingconnect %localReset, [[TMP]]
     // CHECK-NEXT: }
   }
 }
@@ -735,7 +735,7 @@ firrtl.circuit "MoveAcrossBlocks4" {
     // CHECK-NEXT:   %reg = firrtl.regreset %clock, %localReset, [[RV]]
     // CHECK-NEXT: }
     // CHECK-NEXT: [[TMP:%.+]] = firrtl.asAsyncReset %ui1
-    // CHECK-NEXT: firrtl.strictconnect %localReset, [[TMP]]
+    // CHECK-NEXT: firrtl.matchingconnect %localReset, [[TMP]]
   }
 }
 
@@ -749,12 +749,12 @@ firrtl.circuit "SubAccess" {
     %arr = firrtl.wire : !firrtl.vector<uint<8>, 1>
     %reg6 = firrtl.regreset %clock, %init, %c1_ui8 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
     %2 = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
-    firrtl.strictconnect %2, %in : !firrtl.uint<8>
+    firrtl.matchingconnect %2, %in : !firrtl.uint<8>
     // CHECK:  %reg6 = firrtl.regreset %clock, %extraReset, %c0_ui2  : !firrtl.clock, !firrtl.asyncreset, !firrtl.const.uint<2>, !firrtl.uint<2>
     // CHECK-NEXT: %0 = firrtl.mux(%init, %c1_ui2, %reg6)
-    // CHECK: firrtl.strictconnect %reg6, %0
+    // CHECK: firrtl.matchingconnect %reg6, %0
     // CHECK-NEXT:  %[[v0:.+]] = firrtl.subaccess %arr[%reg6] : !firrtl.vector<uint<8>, 1>, !firrtl.uint<2>
-    // CHECK-NEXT:  firrtl.strictconnect %[[v0]], %in : !firrtl.uint<8>
+    // CHECK-NEXT:  firrtl.matchingconnect %[[v0]], %in : !firrtl.uint<8>
 
   }
 }
@@ -782,10 +782,10 @@ firrtl.circuit "ZeroLengthVectorInBundle1"  {
   firrtl.module @ZeroLengthVectorInBundle1(out %out: !firrtl.bundle<resets: vector<reset, 0>, data flip: uint<3>>) {
     %0 = firrtl.subfield %out[resets] : !firrtl.bundle<resets: vector<reset, 0>, data flip: uint<3>>
     %invalid = firrtl.invalidvalue : !firrtl.vector<reset, 0>
-    firrtl.strictconnect %0, %invalid : !firrtl.vector<reset, 0>
+    firrtl.matchingconnect %0, %invalid : !firrtl.vector<reset, 0>
     // CHECK-NEXT: %0 = firrtl.subfield %out[resets] : !firrtl.bundle<resets: vector<uint<1>, 0>, data flip: uint<3>>
     // CHECK-NEXT: %invalid = firrtl.invalidvalue : !firrtl.vector<uint<1>, 0>
-    // CHECK-NEXT: firrtl.strictconnect %0, %invalid : !firrtl.vector<uint<1>, 0>
+    // CHECK-NEXT: firrtl.matchingconnect %0, %invalid : !firrtl.vector<uint<1>, 0>
   }
 }
 
@@ -796,10 +796,10 @@ firrtl.circuit "ZeroLengthVectorInBundle2"  {
   firrtl.module @ZeroLengthVectorInBundle2(out %out: !firrtl.bundle<resets: vector<bundle<a: reset>, 0>, data flip: uint<3>>) {
     %0 = firrtl.subfield %out[resets] : !firrtl.bundle<resets: vector<bundle<a: reset>, 0>, data flip: uint<3>>
     %invalid = firrtl.invalidvalue : !firrtl.vector<bundle<a: reset>, 0>
-    firrtl.strictconnect %0, %invalid : !firrtl.vector<bundle<a: reset>, 0>
+    firrtl.matchingconnect %0, %invalid : !firrtl.vector<bundle<a: reset>, 0>
     // CHECK-NEXT: %0 = firrtl.subfield %out[resets] : !firrtl.bundle<resets: vector<bundle<a: uint<1>>, 0>, data flip: uint<3>>
     // CHECK-NEXT: %invalid = firrtl.invalidvalue : !firrtl.vector<bundle<a: uint<1>>, 0>
-    // CHECK-NEXT: firrtl.strictconnect %0, %invalid : !firrtl.vector<bundle<a: uint<1>>, 0>
+    // CHECK-NEXT: firrtl.matchingconnect %0, %invalid : !firrtl.vector<bundle<a: uint<1>>, 0>
   }
 }
 
@@ -812,9 +812,9 @@ firrtl.circuit "ZeroLengthVectorInBundle2"  {
 firrtl.circuit "ZeroVecBundle"  {
   firrtl.module @ZeroVecBundle(in %a: !firrtl.vector<bundle<x: uint<1>>, 0>, out %b: !firrtl.vector<bundle<x: reset>, 0>) {
     %w = firrtl.wire : !firrtl.vector<bundle<x: reset>, 0>
-    firrtl.strictconnect %b, %w : !firrtl.vector<bundle<x: reset>, 0>
+    firrtl.matchingconnect %b, %w : !firrtl.vector<bundle<x: reset>, 0>
     // CHECK-NEXT: %w = firrtl.wire : !firrtl.vector<bundle<x: uint<1>>, 0>
-    // CHECK-NEXT: firrtl.strictconnect %b, %w : !firrtl.vector<bundle<x: uint<1>>, 0>
+    // CHECK-NEXT: firrtl.matchingconnect %b, %w : !firrtl.vector<bundle<x: uint<1>>, 0>
   }
 }
 
@@ -826,8 +826,8 @@ firrtl.circuit "ZeroVecBundle"  {
 // CHECK-SAME: out %b: !firrtl.bundle<x: vector<uint<1>, 0>>
 firrtl.circuit "ZeroVec"  {
   firrtl.module @ZeroVec(in %a: !firrtl.bundle<x: vector<reset, 0>>, out %b: !firrtl.bundle<x: vector<reset, 0>>) {
-    firrtl.strictconnect %b, %a : !firrtl.bundle<x: vector<reset, 0>>
-    // CHECK-NEXT: firrtl.strictconnect %b, %a : !firrtl.bundle<x: vector<uint<1>, 0>>
+    firrtl.matchingconnect %b, %a : !firrtl.bundle<x: vector<reset, 0>>
+    // CHECK-NEXT: firrtl.matchingconnect %b, %a : !firrtl.bundle<x: vector<uint<1>, 0>>
   }
 }
 
@@ -877,7 +877,7 @@ firrtl.circuit "RefCastReset" {
   // CHECK-NEXT: %s_ref : !firrtl.probe<asyncreset>
   firrtl.module @RefCastReset(in %r: !firrtl.asyncreset) {
     %s_r, %s_ref = firrtl.instance s @SendCastReset(in r: !firrtl.asyncreset, out ref: !firrtl.probe<reset>)
-    firrtl.strictconnect %s_r, %r : !firrtl.asyncreset
+    firrtl.matchingconnect %s_r, %r : !firrtl.asyncreset
     %reset = firrtl.ref.resolve %s_ref : !firrtl.probe<reset>
   }
 }
@@ -894,22 +894,22 @@ firrtl.circuit "RefCastAggReset" {
   firrtl.module private @ResetAggSource(in %r: !firrtl.asyncreset, out %p: !firrtl.rwprobe<bundle<a: reset, b: reset>>, out %pconst: !firrtl.probe<bundle<a: reset, b: const.reset>>) {
     %x = firrtl.wire : !firrtl.reset
     %0 = firrtl.resetCast %r : (!firrtl.asyncreset) -> !firrtl.reset
-    firrtl.strictconnect %x, %0 : !firrtl.reset
+    firrtl.matchingconnect %x, %0 : !firrtl.reset
     %c0_ui1 = firrtl.constant 0 : !firrtl.const.uint<1>
     %zero = firrtl.node %c0_ui1 : !firrtl.const.uint<1>
     %bundle, %bundle_ref = firrtl.wire forceable : !firrtl.bundle<a: reset, b: reset>, !firrtl.rwprobe<bundle<a: reset, b: reset>>
     %1 = firrtl.subfield %bundle[b] : !firrtl.bundle<a: reset, b: reset>
     %2 = firrtl.subfield %bundle[a] : !firrtl.bundle<a: reset, b: reset>
-    firrtl.strictconnect %2, %x : !firrtl.reset
+    firrtl.matchingconnect %2, %x : !firrtl.reset
     %3 = firrtl.resetCast %zero : (!firrtl.const.uint<1>) -> !firrtl.const.reset
     %4 = firrtl.constCast %3 : (!firrtl.const.reset) -> !firrtl.reset
-    firrtl.strictconnect %1, %4 : !firrtl.reset
+    firrtl.matchingconnect %1, %4 : !firrtl.reset
     firrtl.ref.define %p, %bundle_ref : !firrtl.rwprobe<bundle<a: reset, b: reset>>
     %bundle_const = firrtl.wire : !firrtl.bundle<a: reset, b: const.reset>
     %5 = firrtl.subfield %bundle_const[b] : !firrtl.bundle<a: reset, b: const.reset>
     %6 = firrtl.subfield %bundle_const[a] : !firrtl.bundle<a: reset, b: const.reset>
-    firrtl.strictconnect %6, %x : !firrtl.reset
-    firrtl.strictconnect %5, %3 : !firrtl.const.reset
+    firrtl.matchingconnect %6, %x : !firrtl.reset
+    firrtl.matchingconnect %5, %3 : !firrtl.const.reset
     %7 = firrtl.ref.send %bundle_const : !firrtl.bundle<a: reset, b: const.reset>
     firrtl.ref.define %pconst, %7 : !firrtl.probe<bundle<a: reset, b: const.reset>>
   }
@@ -923,7 +923,7 @@ firrtl.circuit "RefCastAggReset" {
     %s_r, %s_p, %s_pconst = firrtl.instance s @ResetAggSource(in r: !firrtl.asyncreset, out p: !firrtl.rwprobe<bundle<a: reset, b: reset>>, out pconst: !firrtl.probe<bundle<a: reset, b: const.reset>>)
     %0 = firrtl.ref.sub %s_p[1] : !firrtl.rwprobe<bundle<a: reset, b: reset>>
     %1 = firrtl.ref.sub %s_p[0] : !firrtl.rwprobe<bundle<a: reset, b: reset>>
-    firrtl.strictconnect %s_r, %r : !firrtl.asyncreset
+    firrtl.matchingconnect %s_r, %r : !firrtl.asyncreset
     %2 = firrtl.ref.cast %1 : (!firrtl.rwprobe<reset>) -> !firrtl.probe<reset>
     firrtl.ref.define %a, %2 : !firrtl.probe<reset>
     %3 = firrtl.ref.cast %0 : (!firrtl.rwprobe<reset>) -> !firrtl.probe<reset>
@@ -944,7 +944,7 @@ firrtl.circuit "RefResetBundle" {
   %r = firrtl.wire : !firrtl.bundle<a: reset, b flip: reset> 
   %ref_r = firrtl.ref.send %r : !firrtl.bundle<a: reset, b flip: reset>
   %reset = firrtl.ref.resolve %ref_r : !firrtl.probe<bundle<a: reset, b: reset>>
-  firrtl.strictconnect %out, %reset : !firrtl.bundle<a: reset, b: reset>
+  firrtl.matchingconnect %out, %reset : !firrtl.bundle<a: reset, b: reset>
 
    %r_a = firrtl.subfield %r[a] : !firrtl.bundle<a: reset, b flip: reset>
    %r_b = firrtl.subfield %r[b] : !firrtl.bundle<a: reset, b flip: reset>
@@ -970,8 +970,8 @@ firrtl.circuit "RefResetSub" {
   %ref_r_b = firrtl.ref.sub %ref_r[1] : !firrtl.probe<bundle<a: reset, b : vector<reset, 2>>>
   %reset_b = firrtl.ref.resolve %ref_r_b : !firrtl.probe<vector<reset, 2>>
 
-  firrtl.strictconnect %out_a, %reset_a : !firrtl.reset
-  firrtl.strictconnect %out_b, %reset_b : !firrtl.vector<reset, 2>
+  firrtl.matchingconnect %out_a, %reset_a : !firrtl.reset
+  firrtl.matchingconnect %out_b, %reset_b : !firrtl.vector<reset, 2>
 
    %r_a = firrtl.subfield %r[a] : !firrtl.bundle<a: reset, b flip: vector<reset, 2>>
    %r_b = firrtl.subfield %r[b] : !firrtl.bundle<a: reset, b flip: vector<reset, 2>>
@@ -1023,10 +1023,10 @@ firrtl.circuit "ConstAggReset" {
     %in_a = firrtl.subfield %in[a] : !firrtl.const.bundle<a: reset, b: uint<1>>
     %in_a_asyncreset = firrtl.resetCast %in_a : (!firrtl.const.reset) -> !firrtl.const.asyncreset
     %in_a_asyncreset_noconst = firrtl.constCast %in_a_asyncreset : (!firrtl.const.asyncreset) -> !firrtl.asyncreset
-    firrtl.strictconnect %out_a, %in_a_asyncreset_noconst : !firrtl.asyncreset
+    firrtl.matchingconnect %out_a, %in_a_asyncreset_noconst : !firrtl.asyncreset
 
     %in_noconst = firrtl.constCast %in : (!firrtl.const.bundle<a: reset, b: uint<1>>) -> !firrtl.bundle<a: reset, b : uint<1>>
-    firrtl.strictconnect %out2, %in_noconst : !firrtl.bundle<a: reset, b: uint<1>>
+    firrtl.matchingconnect %out2, %in_noconst : !firrtl.bundle<a: reset, b: uint<1>>
   }
 }
 
@@ -1042,11 +1042,11 @@ firrtl.circuit "ConstAggCastReset" {
     // CHECK: constCast %{{.+}} : (!firrtl.const.asyncreset) -> !firrtl.asyncreset
     %in_a_noconst = firrtl.constCast %in_a : (!firrtl.const.reset) -> !firrtl.reset
     %in_a_asyncreset = firrtl.resetCast %in_a_noconst : (!firrtl.reset) -> !firrtl.asyncreset
-    // CHECK-NEXT: strictconnect
-    firrtl.strictconnect %out_a, %in_a_asyncreset : !firrtl.asyncreset
+    // CHECK-NEXT: matchingconnect
+    firrtl.matchingconnect %out_a, %in_a_asyncreset : !firrtl.asyncreset
     // CHECK-NOT: : reset
     %in_noconst = firrtl.constCast %in : (!firrtl.const.bundle<a: reset, b: uint<1>>) -> !firrtl.bundle<a: reset, b : uint<1>>
-    firrtl.strictconnect %out2, %in_noconst : !firrtl.bundle<a: reset, b: uint<1>>
+    firrtl.matchingconnect %out2, %in_noconst : !firrtl.bundle<a: reset, b: uint<1>>
   }
 }
 
@@ -1061,7 +1061,7 @@ firrtl.circuit "InferToRWProbe" {
   firrtl.module @InferToRWProbe(in %driver: !firrtl.asyncreset, out %out: !firrtl.bundle<a: reset, b: reset>) {
   %r, %r_rw = firrtl.wire forceable : !firrtl.bundle<a: reset, b flip: reset>, !firrtl.rwprobe<bundle<a: reset, b : reset>>
   %reset = firrtl.ref.resolve %r_rw : !firrtl.rwprobe<bundle<a: reset, b: reset>>
-  firrtl.strictconnect %out, %reset : !firrtl.bundle<a: reset, b: reset>
+  firrtl.matchingconnect %out, %reset : !firrtl.bundle<a: reset, b: reset>
 
    %r_a = firrtl.subfield %r[a] : !firrtl.bundle<a: reset, b flip: reset>
    %r_b = firrtl.subfield %r[b] : !firrtl.bundle<a: reset, b flip: reset>

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -921,11 +921,11 @@ firrtl.circuit "Foo" {
   firrtl.module @ForeignTypes(in %a: !firrtl.uint<42>, out %b: !firrtl.uint) {
     %0 = firrtl.wire : index
     %1 = firrtl.wire : index
-    firrtl.strictconnect %0, %1 : index
+    firrtl.matchingconnect %0, %1 : index
     firrtl.connect %b, %a : !firrtl.uint, !firrtl.uint<42>
     // CHECK-NEXT: [[W0:%.+]] = firrtl.wire : index
     // CHECK-NEXT: [[W1:%.+]] = firrtl.wire : index
-    // CHECK-NEXT: firrtl.strictconnect [[W0]], [[W1]] : index
+    // CHECK-NEXT: firrtl.matchingconnect [[W0]], [[W1]] : index
   }
 
   // CHECK-LABEL: @Issue4859

--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -38,9 +38,9 @@ firrtl.circuit "TLRAM" {
 
 // CHECK: %mem_0_dbgs, %mem_0_rw = firrtl.mem  Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["dbgs", "rw"], prefix = "foo_", readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.probe<vector<uint<8>, 16>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
 // CHECK:  %[[v7:.+]] = firrtl.mux(%[[writeEnable:.+]], %[[writeAddr:.+]], %[[readAddr:.+]]) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-// CHECK:  firrtl.strictconnect %[[v0:.+]], %[[v7]] : !firrtl.uint<4>
+// CHECK:  firrtl.matchingconnect %[[v0:.+]], %[[v7]] : !firrtl.uint<4>
 // CHECK:  %[[v8:.+]] = firrtl.or %[[readEnable:.+]], %[[writeEnable]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK:  firrtl.strictconnect %[[v1:.+]], %[[v8]] : !firrtl.uint<1>
+// CHECK:  firrtl.matchingconnect %[[v1:.+]], %[[v8]] : !firrtl.uint<1>
 // CHECK:  firrtl.ref.define %dbg_0, %mem_0_dbgs : !firrtl.probe<vector<uint<8>, 16>>
 // CHECK:  firrtl.connect %[[readAddr]], %[[index2:.+]] : !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK:  firrtl.connect %[[readEnable]], %mem_MPORT_en : !firrtl.uint<1>, !firrtl.uint<1>
@@ -48,7 +48,7 @@ firrtl.circuit "TLRAM" {
 // CHECK:  firrtl.connect %[[writeEnable]], %wen : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:  %[[v10:.+]] = firrtl.not %wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK:  firrtl.connect %mem_MPORT_en, %[[v10]] : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK:  firrtl.strictconnect %[[v4:.+]], %wen : !firrtl.uint<1>
+// CHECK:  firrtl.matchingconnect %[[v4:.+]], %wen : !firrtl.uint<1>
     }
 
 // Test the pattern of enable  with Mux (sel, high, 0)
@@ -78,7 +78,7 @@ firrtl.circuit "TLRAM" {
     firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
     firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %io_dataOut, %8 : !firrtl.uint<32>, !firrtl.uint<32>
-    // CHECK:   firrtl.strictconnect %4, %io_wen : !firrtl.uint<1>
+    // CHECK:   firrtl.matchingconnect %4, %io_wen : !firrtl.uint<1>
   }
 
 // Test the pattern of enable  with an And tree and Mux (sel, high, 0)
@@ -89,7 +89,7 @@ firrtl.circuit "TLRAM" {
     %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
 // CHECK: %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
 // CHECK:   %[[v7:.+]] = firrtl.mux(%writeEnable, %writeAddr, %readAddr) : (!firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<11>) -> !firrtl.uint<11>
-// CHECK:   firrtl.strictconnect %[[v0:.+]], %[[v7]]
+// CHECK:   firrtl.matchingconnect %[[v0:.+]], %[[v7]]
 // CHECK:   %[[v8:.+]] = firrtl.or %readEnable, %writeEnable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     %0 = firrtl.subfield %mem__T_14[addr] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     %1 = firrtl.subfield %mem__T_14[en] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
@@ -114,7 +114,7 @@ firrtl.circuit "TLRAM" {
     firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
     firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %io_dataOut, %8 : !firrtl.uint<32>, !firrtl.uint<32>
-    // CHECK:  firrtl.strictconnect %4, %io_write : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %4, %io_write : !firrtl.uint<1>
   }
 
 // Cannot merge read and write, since the pattern is enable = Mux (sel, high, 1)
@@ -209,7 +209,7 @@ firrtl.circuit "TLRAM" {
     firrtl.connect %6, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %8, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %7, %io_wdata : !firrtl.uint<32>, !firrtl.uint<32>
-    // CHECK:  firrtl.strictconnect %4, %io_wen : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %4, %io_wen : !firrtl.uint<1>
   }
 
 // Check for indirect connection to clock
@@ -251,7 +251,7 @@ firrtl.circuit "TLRAM" {
       // CHECK: %mem_0_rw = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
       // CHECK: %[[v6:.+]] = firrtl.subfield %mem_0_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
       // CHECK: %[[c1_ui1:.+]] = firrtl.constant 1 : !firrtl.uint<1>
-      // CHECK: firrtl.strictconnect %[[v6]], %[[c1_ui1]]
+      // CHECK: firrtl.matchingconnect %[[v6]], %[[c1_ui1]]
       %0 = firrtl.subfield %mem_0_MPORT[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
       firrtl.connect %0, %index2 : !firrtl.uint<4>, !firrtl.uint<4>
       %1 = firrtl.subfield %mem_0_MPORT[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
@@ -293,14 +293,14 @@ firrtl.circuit "TLRAM" {
       %mem_rwPort_readData_rw_wmode = firrtl.wire : !firrtl.uint<1>
       %0 = firrtl.subfield %mem_rwPort_readData_rw[addr] : !firrtl.bundle<addr: uint<6>, en: uint<1>, clk: clock, rdata flip: uint<10>, wmode: uint<1>, wdata: uint<10>, wmask: uint<5>>
       %1 = firrtl.subfield %mem_rwPort_readData_rw[en] : !firrtl.bundle<addr: uint<6>, en: uint<1>, clk: clock, rdata flip: uint<10>, wmode: uint<1>, wdata: uint<10>, wmask: uint<5>>
-      firrtl.strictconnect %1, %rwPort_enable : !firrtl.uint<1>
+      firrtl.matchingconnect %1, %rwPort_enable : !firrtl.uint<1>
       %2 = firrtl.subfield %mem_rwPort_readData_rw[clk] : !firrtl.bundle<addr: uint<6>, en: uint<1>, clk: clock, rdata flip: uint<10>, wmode: uint<1>, wdata: uint<10>, wmask: uint<5>>
       %3 = firrtl.subfield %mem_rwPort_readData_rw[rdata] : !firrtl.bundle<addr: uint<6>, en: uint<1>, clk: clock, rdata flip: uint<10>, wmode: uint<1>, wdata: uint<10>, wmask: uint<5>>
       %6 = firrtl.subfield %mem_rwPort_readData_rw[wmode] : !firrtl.bundle<addr: uint<6>, en: uint<1>, clk: clock, rdata flip: uint<10>, wmode: uint<1>, wdata: uint<10>, wmask: uint<5>>
-      firrtl.strictconnect %6, %mem_rwPort_readData_rw_wmode : !firrtl.uint<1>
+      firrtl.matchingconnect %6, %mem_rwPort_readData_rw_wmode : !firrtl.uint<1>
       %7 = firrtl.subfield %mem_rwPort_readData_rw[wdata] : !firrtl.bundle<addr: uint<6>, en: uint<1>, clk: clock, rdata flip: uint<10>, wmode: uint<1>, wdata: uint<10>, wmask: uint<5>>
       %9 = firrtl.subfield %mem_rwPort_readData_rw[wmask] : !firrtl.bundle<addr: uint<6>, en: uint<1>, clk: clock, rdata flip: uint<10>, wmode: uint<1>, wdata: uint<10>, wmask: uint<5>>
-      firrtl.strictconnect %mem_rwPort_readData_rw_wmode, %18 : !firrtl.uint<1>
+      firrtl.matchingconnect %mem_rwPort_readData_rw_wmode, %18 : !firrtl.uint<1>
     }
 
   // CHECK: firrtl.module @InferUnmasked
@@ -318,7 +318,7 @@ firrtl.circuit "TLRAM" {
     %14 = firrtl.bits %10 1 to 1 : (!firrtl.uint<2>) -> !firrtl.uint<1>
     %15 = firrtl.cat %14, %13 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<4>
     %16 = firrtl.cat %14, %15 : (!firrtl.uint<1>, !firrtl.uint<4>) -> !firrtl.uint<5>
-    firrtl.strictconnect %9, %16 : !firrtl.uint<5>
+    firrtl.matchingconnect %9, %16 : !firrtl.uint<5>
     firrtl.connect %syncreadmem_singleport_readwritePortA_readData_rw_wmask_x, %readwritePortA_isWrite_2 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %syncreadmem_singleport_readwritePortA_readData_rw_wmask_y, %readwritePortA_isWrite_2 : !firrtl.uint<1>, !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -676,17 +676,17 @@ firrtl.circuit "Inline"  {
     // CHECK:  = firrtl.instance foo_bar sym @[[bar_0]]  @Bar(in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
     %bar_i, %bar_o = firrtl.instance bar sym @bar  @Bar(in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
     // CHECK:  = firrtl.instance bar sym @bar  @Bar(in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
-    firrtl.strictconnect %foo_i, %bar_i : !firrtl.uint<1>
-    firrtl.strictconnect %bar_i, %i : !firrtl.uint<1>
-    firrtl.strictconnect %o, %foo_o : !firrtl.uint<1>
+    firrtl.matchingconnect %foo_i, %bar_i : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_i, %i : !firrtl.uint<1>
+    firrtl.matchingconnect %o, %foo_o : !firrtl.uint<1>
   }
   firrtl.module private @Bar(in %i: !firrtl.uint<1> sym @i [{circt.nonlocal = @nla_1, class = "test_1"}, {circt.nonlocal = @nla_2, class = "test_2"}], out %o: !firrtl.uint<1>) {
-    firrtl.strictconnect %o, %i : !firrtl.uint<1>
+    firrtl.matchingconnect %o, %i : !firrtl.uint<1>
   }
   firrtl.module private @Foo(in %i: !firrtl.uint<1>, out %o: !firrtl.uint<1>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
     %bar_i, %bar_o = firrtl.instance bar sym @bar  @Bar(in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
-    firrtl.strictconnect %bar_i, %i : !firrtl.uint<1>
-    firrtl.strictconnect %o, %bar_o : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_i, %i : !firrtl.uint<1>
+    firrtl.matchingconnect %o, %bar_o : !firrtl.uint<1>
   }
 }
 
@@ -697,18 +697,18 @@ firrtl.circuit "Inline2"  {
   firrtl.module @Inline2(in %i: !firrtl.uint<1>, out %o: !firrtl.uint<1>) {
     %foo_i, %foo_o = firrtl.instance foo sym @foo  @Foo(in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
     %bar = firrtl.wire sym @bar  : !firrtl.uint<1>
-    firrtl.strictconnect %foo_i, %bar : !firrtl.uint<1>
-    firrtl.strictconnect %bar, %i : !firrtl.uint<1>
-    firrtl.strictconnect %o, %foo_o : !firrtl.uint<1>
+    firrtl.matchingconnect %foo_i, %bar : !firrtl.uint<1>
+    firrtl.matchingconnect %bar, %i : !firrtl.uint<1>
+    firrtl.matchingconnect %o, %foo_o : !firrtl.uint<1>
   }
   firrtl.module private @Bar(in %i: !firrtl.uint<1> sym @i [{circt.nonlocal = @nla_1, class = "testing"}], out %o: !firrtl.uint<1>) {
-    firrtl.strictconnect %o, %i : !firrtl.uint<1>
+    firrtl.matchingconnect %o, %i : !firrtl.uint<1>
   }
   firrtl.module private @Foo(in %i: !firrtl.uint<1>, out %o: !firrtl.uint<1>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
     %bar_i, %bar_o = firrtl.instance bar sym @bar  @Bar(in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
     // CHECK:  = firrtl.instance foo_bar sym @[[bar_0]]  @Bar(in i: !firrtl.uint<1>, out o: !firrtl.uint<1>)
-    firrtl.strictconnect %bar_i, %i : !firrtl.uint<1>
-    firrtl.strictconnect %o, %bar_o : !firrtl.uint<1>
+    firrtl.matchingconnect %bar_i, %i : !firrtl.uint<1>
+    firrtl.matchingconnect %o, %bar_o : !firrtl.uint<1>
   }
 }
 
@@ -901,7 +901,7 @@ firrtl.circuit "HierarchicalRefType" {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
     // CHECK:       %bar__a = firrtl.wire : !firrtl.probe<uint<1>>
     // CHECK-NEXT:  %bar_bar__a = firrtl.wire : !firrtl.probe<uint<1>>
     // CHECK-NEXT:  %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -910,7 +910,7 @@ firrtl.circuit "HierarchicalRefType" {
     // CHECK-NEXT:  firrtl.ref.define %bar__a, %bar_bar__a : !firrtl.probe<uint<1>>
     // CHECK-NEXT:  %a = firrtl.wire : !firrtl.uint<1>
     // CHECK-NEXT:  %1 = firrtl.ref.resolve %bar__a : !firrtl.probe<uint<1>>
-    // CHECK-NEXT:  firrtl.strictconnect %a, %1 : !firrtl.uint<1>
+    // CHECK-NEXT:  firrtl.matchingconnect %a, %1 : !firrtl.uint<1>
   }
 }
 
@@ -936,7 +936,7 @@ firrtl.circuit "InlineRefSend" {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
     // CHECK:      %bar__a = firrtl.wire : !firrtl.probe<uint<1>>
     // CHECK-NEXT: %bar_bar_pa = firrtl.wire : !firrtl.uint<1>
     // CHECK-NEXT: %bar_bar__a = firrtl.wire : !firrtl.probe<uint<1>>
@@ -963,14 +963,14 @@ firrtl.circuit "MultReadInstRefType" {
     firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
     %a = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     firrtl.ref.define %_a, %xmr   : !firrtl.probe<uint<1>>
     %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
     %a = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
   }
   firrtl.module @MultReadInstRefType() attributes {annotations = [{class = "firrtl.transforms.FlattenAnnotation"}]}{
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -982,7 +982,7 @@ firrtl.circuit "MultReadInstRefType" {
     // CHECK-NEXT: firrtl.ref.define %bar__a, %bar_bar__a : !firrtl.probe<uint<1>>
     // CHECK-NEXT: %1 = firrtl.ref.resolve %bar_bar__a : !firrtl.probe<uint<1>>
     // CHECK-NEXT: %bar_a = firrtl.wire : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %bar_a, %1 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %bar_a, %1 : !firrtl.uint<1>
     %foo_a = firrtl.instance foo sym @foo @Foo(out _a: !firrtl.probe<uint<1>>)
     // CHECK-NEXT: %foo__a = firrtl.wire : !firrtl.probe<uint<1>>
     // CHECK-NEXT: %foo_bar__a = firrtl.wire : !firrtl.probe<uint<1>>
@@ -992,7 +992,7 @@ firrtl.circuit "MultReadInstRefType" {
     // CHECK-NEXT: firrtl.ref.define %foo__a, %foo_bar__a : !firrtl.probe<uint<1>>
     // CHECK-NEXT: %3 = firrtl.ref.resolve %foo_bar__a : !firrtl.probe<uint<1>>
     // CHECK-NEXT: %foo_a = firrtl.wire : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %foo_a, %3 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %foo_a, %3 : !firrtl.uint<1>
     %xmr_a = firrtl.instance xmr sym @xmr @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
     // CHECK-NEXT: %xmr__a = firrtl.wire : !firrtl.probe<uint<1>>
     // CHECK-NEXT: %c0_ui1_1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -1010,12 +1010,12 @@ firrtl.circuit "MultReadInstRefType" {
     // CHECK-NEXT: %5 = firrtl.ref.resolve %bar__a : !firrtl.probe<uint<1>>
     // CHECK-NEXT: %6 = firrtl.ref.resolve %foo__a : !firrtl.probe<uint<1>>
     // CHECK-NEXT: %7 = firrtl.ref.resolve %xmr__a : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    firrtl.strictconnect %b, %1 : !firrtl.uint<1>
-    firrtl.strictconnect %c, %2 : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %a, %5 : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %b, %6 : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %c, %7 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %2 : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %a, %5 : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %b, %6 : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %c, %7 : !firrtl.uint<1>
   }
 }
 
@@ -1127,13 +1127,13 @@ firrtl.circuit "RWProbePort" {
     %c1_in, %c1_p = firrtl.instance c1 @Child(in in: !firrtl.vector<uint<1>, 2>, out p: !firrtl.rwprobe<uint<1>>)
     %c2_in, %c2_p = firrtl.instance c2 @Child(in in: !firrtl.vector<uint<1>, 2>, out p: !firrtl.rwprobe<uint<1>>)
     %0 = firrtl.subindex %c1_in[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %0, %in_0 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %in_0 : !firrtl.uint<1>
     %1 = firrtl.subindex %c1_in[1] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %1, %in_1 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %in_1 : !firrtl.uint<1>
     %2 = firrtl.subindex %c2_in[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %2, %in_0 : !firrtl.uint<1>
+    firrtl.matchingconnect %2, %in_0 : !firrtl.uint<1>
     %3 = firrtl.subindex %c2_in[1] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %3, %in_1 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %in_1 : !firrtl.uint<1>
     // CHECK: firrtl.ref.define %p_0, %[[C1_P_WIRE]]
     firrtl.ref.define %p_0, %c1_p : !firrtl.rwprobe<uint<1>>
     // CHECK: firrtl.ref.define %p_1, %[[C2_P_WIRE]]
@@ -1199,10 +1199,10 @@ firrtl.circuit "InlinerRefs" {
     %0 = firrtl.subfield %in[a] : !firrtl.bundle<a: uint<1>, b: uint<2>>
     %co_in, %co_out = firrtl.instance co interesting_name @ChildOut(in in: !firrtl.bundle<a: uint<1>, b: uint<2>>, out out: !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>)
     %1 = firrtl.ref.sub %co_out[0] : !firrtl.probe<bundle<a: uint<1>, b: uint<2>>>
-    firrtl.strictconnect %co_in, %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    firrtl.matchingconnect %co_in, %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
     firrtl.when %0 : !firrtl.uint<1> {
       %2 = firrtl.ref.resolve %1 : !firrtl.probe<uint<1>>
-      firrtl.strictconnect %out, %2 : !firrtl.uint<1>
+      firrtl.matchingconnect %out, %2 : !firrtl.uint<1>
     }
   }
 }

--- a/test/Dialect/FIRRTL/inner-symbol-dce.mlir
+++ b/test/Dialect/FIRRTL/inner-symbol-dce.mlir
@@ -43,13 +43,13 @@ firrtl.circuit "Simple" attributes {
     %w5 = firrtl.wire sym @w5 : !firrtl.uint<1>
 
     %c0_ui1 = firrtl.constant 0: !firrtl.uint<1>
-    firrtl.strictconnect %out, %c0_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %out2, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %out, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %out2, %c0_ui1 : !firrtl.uint<1>
 
     // CHECK: @x
     // CHECK-NOT: @y
     %wire = firrtl.wire sym [<@x,1,public>,<@y,2,public>] : !firrtl.vector<uint<1>,2>
-    firrtl.strictconnect %out3, %wire : !firrtl.vector<uint<1>,2>
+    firrtl.matchingconnect %out3, %wire : !firrtl.vector<uint<1>,2>
   }
 
   // CHECK-LABEL: firrtl.extmodule @ExtChild

--- a/test/Dialect/FIRRTL/layers.mlir
+++ b/test/Dialect/FIRRTL/layers.mlir
@@ -164,7 +164,7 @@ firrtl.circuit "Test" {
     firrtl.layerblock @A {
       %w = firrtl.wire : !firrtl.uint<1>
       firrtl.when %test : !firrtl.uint<1> {
-        firrtl.strictconnect %w, %c0_ui1 : !firrtl.uint<1>
+        firrtl.matchingconnect %w, %c0_ui1 : !firrtl.uint<1>
       }
     }
   }

--- a/test/Dialect/FIRRTL/legacy-wiring-errors.mlir
+++ b/test/Dialect/FIRRTL/legacy-wiring-errors.mlir
@@ -80,14 +80,14 @@ firrtl.circuit "Foo" attributes {
     // expected-error @below {{Wiring Problem source type '!firrtl.bundle<a: uint<1>, b: uint<2>>' does not match sink type '!firrtl.uint<1>'}}
     %y = firrtl.wire interesting_name : !firrtl.bundle<a: uint<1>, b: uint<2>>
     %invalid_reset = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>, b: uint<2>>
-    firrtl.strictconnect %y, %invalid_reset : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    firrtl.matchingconnect %y, %invalid_reset : !firrtl.bundle<a: uint<1>, b: uint<2>>
   }
   firrtl.module @Foo() {
     firrtl.instance bar interesting_name @Bar()
     // expected-note @below {{The sink is here.}}
     %x = firrtl.wire interesting_name : !firrtl.uint<1>
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
-    firrtl.strictconnect %x, %invalid_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %x, %invalid_ui1 : !firrtl.uint<1>
   }
 }
 
@@ -112,12 +112,12 @@ firrtl.circuit "FooBar" attributes {
   // expected-error @below {{cannot wire port through this public module}}
   firrtl.module public @Bar(out %out: !firrtl.uint<1>) {
       %foo_out = firrtl.instance foo interesting_name  @Foo(out out: !firrtl.uint<1>)
-      firrtl.strictconnect %out, %foo_out : !firrtl.uint<1>
+      firrtl.matchingconnect %out, %foo_out : !firrtl.uint<1>
   }
   // expected-note @below {{source here}}
   firrtl.module @FooBar(out %io: !firrtl.bundle<in flip: uint<1>, out: uint<1>>) {
       %0 = firrtl.subfield %io[out] : !firrtl.bundle<in flip: uint<1>, out: uint<1>>
       %bar_out = firrtl.instance bar interesting_name  @Bar(out out: !firrtl.uint<1>)
-      firrtl.strictconnect %0, %bar_out : !firrtl.uint<1>
+      firrtl.matchingconnect %0, %bar_out : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/legacy-wiring.mlir
+++ b/test/Dialect/FIRRTL/legacy-wiring.mlir
@@ -29,7 +29,7 @@ firrtl.circuit "FooBar" attributes {
       // CHECK-SAME: in io_out__bore: !firrtl.uint<1>
       %foo_io = firrtl.instance foo interesting_name  @Foo(out io: !firrtl.bundle<out: uint<1>>)
       %1 = firrtl.subfield %foo_io[out] : !firrtl.bundle<out: uint<1>>
-      firrtl.strictconnect %0, %1 : !firrtl.uint<1>
+      firrtl.matchingconnect %0, %1 : !firrtl.uint<1>
   }
   // CHECK: firrtl.module @FooBar
   firrtl.module @FooBar(out %io: !firrtl.bundle<in flip: uint<1>, out: uint<1>>) {
@@ -38,7 +38,7 @@ firrtl.circuit "FooBar" attributes {
       // CHECK-SAME: in foo_io_out__bore: !firrtl.uint<1>
       %bar_io = firrtl.instance bar interesting_name  @Bar(out io: !firrtl.bundle<out: uint<1>>)
       %1 = firrtl.subfield %bar_io[out] : !firrtl.bundle<out: uint<1>>
-      firrtl.strictconnect %0, %1 : !firrtl.uint<1>
+      firrtl.matchingconnect %0, %1 : !firrtl.uint<1>
   }
 }
 
@@ -73,21 +73,21 @@ firrtl.circuit "FooBar" attributes {
   firrtl.module private @Foo(out %io: !firrtl.bundle<out: uint<1>>) {
     firrtl.skip
     // CHECK: %0 = firrtl.subfield %io[out] : !firrtl.bundle<out: uint<1>>
-    // CHECK: firrtl.strictconnect %0, %io_out__bore : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %0, %io_out__bore : !firrtl.uint<1>
   }
   // CHECK: firrtl.module private @Foo_1
   // CHECK-SAME: in %io_out__bore: !firrtl.uint<1>
   firrtl.module private @Foo_1(out %io: !firrtl.bundle<out: uint<1>>) {
     firrtl.skip
     // CHECK: %0 = firrtl.subfield %io[out] : !firrtl.bundle<out: uint<1>>
-    // CHECK: firrtl.strictconnect %0, %io_out__bore : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %0, %io_out__bore : !firrtl.uint<1>
   }
   // CHECK: firrtl.module private @Bar
   // CHECK-SAME: in %io_out__bore: !firrtl.uint<1>
   firrtl.module private @Bar(out %io: !firrtl.bundle<out: uint<1>>) {
     firrtl.skip
     // CHECK: %0 = firrtl.subfield %io[out] : !firrtl.bundle<out: uint<1>>
-    // CHECK: firrtl.strictconnect %0, %io_out__bore : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %0, %io_out__bore : !firrtl.uint<1>
   }
   // CHECK: firrtl.module @FooBar
   firrtl.module @FooBar(out %io: !firrtl.bundle<in flip: uint<1>, out_foo0: uint<1>, out_foo1: uint<1>, out_bar: uint<1>>) {
@@ -107,12 +107,12 @@ firrtl.circuit "FooBar" attributes {
     // CHECK-SAME: in io_out__bore: !firrtl.uint<1>
     %bar_io = firrtl.instance bar interesting_name  @Bar(out io: !firrtl.bundle<out: uint<1>>)
     %5 = firrtl.subfield %bar_io[out] : !firrtl.bundle<out: uint<1>>
-    firrtl.strictconnect %2, %3 : !firrtl.uint<1>
-    firrtl.strictconnect %1, %4 : !firrtl.uint<1>
-    firrtl.strictconnect %0, %5 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %foo0_io_out__bore, %0 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %foo1_io_out__bore, %0 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %bar_io_out__bore, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %2, %3 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %4 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %5 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %foo0_io_out__bore, %0 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %foo1_io_out__bore, %0 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %bar_io_out__bore, %0 : !firrtl.uint<1>
   }
 }
 
@@ -162,16 +162,16 @@ firrtl.circuit "ResetToI1" attributes {
   firrtl.module private @Bar() {
     %y = firrtl.wire interesting_name : !firrtl.reset
     %invalid_reset = firrtl.invalidvalue : !firrtl.reset
-    firrtl.strictconnect %y, %invalid_reset : !firrtl.reset
+    firrtl.matchingconnect %y, %invalid_reset : !firrtl.reset
   }
   // CHECK-LABEL: module @ResetToI1
   firrtl.module @ResetToI1() {
     // CHECK: %[[r1:.+]] = firrtl.resetCast %{{[^ ]*}}
-    // CHECK-NEXT: firrtl.strictconnect %x, %[[r1]] : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %x, %[[r1]] : !firrtl.uint<1>
     firrtl.instance bar interesting_name @Bar()
     %x = firrtl.wire interesting_name : !firrtl.uint<1>
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
-    firrtl.strictconnect %x, %invalid_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %x, %invalid_ui1 : !firrtl.uint<1>
   }
 }
 
@@ -195,7 +195,7 @@ firrtl.circuit "IntWidths" attributes {
   firrtl.module private @Bar() {
     %y = firrtl.wire interesting_name : !firrtl.uint<4>
     %invalid_reset = firrtl.invalidvalue : !firrtl.uint<4>
-    firrtl.strictconnect %y, %invalid_reset : !firrtl.uint<4>
+    firrtl.matchingconnect %y, %invalid_reset : !firrtl.uint<4>
   }
   // CHECK-LABEL: module @IntWidths
   firrtl.module @IntWidths() {

--- a/test/Dialect/FIRRTL/lower-chirrtl.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl.mlir
@@ -26,19 +26,19 @@ firrtl.module @UnusedMemPort(in %clock: !firrtl.clock, in %addr : !firrtl.uint<1
 firrtl.module @InferRead(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, out %out : !firrtl.uint<1>, in %vec : !firrtl.vector<uint<1>, 2>) {
   // CHECK: %ram_ramport = firrtl.mem sym @s1 Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, data flip: uint<1>>
   // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport[addr]
-  // CHECK: firrtl.strictconnect [[ADDR]], %invalid_ui8
+  // CHECK: firrtl.matchingconnect [[ADDR]], %invalid_ui8
   // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport[en]
-  // CHECK: firrtl.strictconnect [[EN]], %c0_ui1
+  // CHECK: firrtl.matchingconnect [[EN]], %c0_ui1
   // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport[clk]
-  // CHECK: firrtl.strictconnect [[CLOCK]], %invalid_clock
+  // CHECK: firrtl.matchingconnect [[CLOCK]], %invalid_clock
   // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport[data]
   %ram = chirrtl.combmem  sym @s1 : !chirrtl.cmemory<uint<1>, 256>
   %ramport_data, %ramport_port = chirrtl.memoryport Infer %ram {name = "ramport"} : (!chirrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
 
   // CHECK: firrtl.when %cond : !firrtl.uint<1> {
-  // CHECK:   firrtl.strictconnect [[ADDR]], %addr
-  // CHECK:   firrtl.strictconnect [[EN]], %c1_ui1
-  // CHECK:   firrtl.strictconnect [[CLOCK]], %clock
+  // CHECK:   firrtl.matchingconnect [[ADDR]], %addr
+  // CHECK:   firrtl.matchingconnect [[EN]], %c1_ui1
+  // CHECK:   firrtl.matchingconnect [[CLOCK]], %clock
   // CHECK: }
   firrtl.when %cond : !firrtl.uint<1> {
     chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
@@ -58,33 +58,33 @@ firrtl.module @InferRead(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in
 firrtl.module @InferWrite(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %in : !firrtl.uint<1>) {
   // CHECK: %ram_ramport = firrtl.mem Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, data: uint<1>, mask: uint<1>>
   // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport[addr]
-  // CHECK: firrtl.strictconnect [[ADDR]], %invalid_ui8
+  // CHECK: firrtl.matchingconnect [[ADDR]], %invalid_ui8
   // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport[en]
-  // CHECK: firrtl.strictconnect [[EN]], %c0_ui1
+  // CHECK: firrtl.matchingconnect [[EN]], %c0_ui1
   // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport[clk]
-  // CHECK: firrtl.strictconnect [[CLOCK]], %invalid_clock
+  // CHECK: firrtl.matchingconnect [[CLOCK]], %invalid_clock
   // CHECK: [[DATA:%.*]] = firrtl.subfield %ram_ramport[data]
-  // CHECK: firrtl.strictconnect [[DATA]], %invalid_ui1
+  // CHECK: firrtl.matchingconnect [[DATA]], %invalid_ui1
   // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport[mask]
-  // CHECK: firrtl.strictconnect [[MASK]], %invalid_ui1
+  // CHECK: firrtl.matchingconnect [[MASK]], %invalid_ui1
   %ram = chirrtl.combmem : !chirrtl.cmemory<uint<1>, 256>
   %ramport_data, %ramport_port = chirrtl.memoryport Infer %ram {name = "ramport"} : (!chirrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
 
   // CHECK: firrtl.when %cond : !firrtl.uint<1> {
-  // CHECK:   firrtl.strictconnect [[ADDR]], %addr
-  // CHECK:   firrtl.strictconnect [[EN]], %c1_ui1
-  // CHECK:   firrtl.strictconnect [[CLOCK]], %clock
-  // CHECK:   firrtl.strictconnect [[MASK]], %c0_ui1
+  // CHECK:   firrtl.matchingconnect [[ADDR]], %addr
+  // CHECK:   firrtl.matchingconnect [[EN]], %c1_ui1
+  // CHECK:   firrtl.matchingconnect [[CLOCK]], %clock
+  // CHECK:   firrtl.matchingconnect [[MASK]], %c0_ui1
   // CHECK: }
   firrtl.when %cond : !firrtl.uint<1> {
     chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
   }
 
-  // CHECK: firrtl.strictconnect [[MASK]], %c1_ui1
+  // CHECK: firrtl.matchingconnect [[MASK]], %c1_ui1
   // CHECK: firrtl.connect [[DATA]], %in
   firrtl.connect %ramport_data, %in : !firrtl.uint<1>, !firrtl.uint<1>
 
-  // CHECK: firrtl.strictconnect [[MASK]], %c1_ui1
+  // CHECK: firrtl.matchingconnect [[MASK]], %c1_ui1
   // CHECK: firrtl.connect [[DATA]], %in
   firrtl.connect %ramport_data, %in : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -92,29 +92,29 @@ firrtl.module @InferWrite(in %cond: !firrtl.uint<1>, in %clock: !firrtl.clock, i
 firrtl.module @InferReadWrite(in %clock: !firrtl.clock, in %addr: !firrtl.uint<8>, in %in : !firrtl.uint<1>, out %out : !firrtl.uint<1>) {
   // CHECK: %ram_ramport = firrtl.mem Undefined {depth = 256 : i64, name = "ram", portNames = ["ramport"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<8>, en: uint<1>, clk: clock, rdata flip: uint<1>, wmode: uint<1>, wdata: uint<1>, wmask: uint<1>>
   // CHECK: [[ADDR:%.*]] = firrtl.subfield %ram_ramport[addr]
-  // CHECK: firrtl.strictconnect [[ADDR]], %invalid
+  // CHECK: firrtl.matchingconnect [[ADDR]], %invalid
   // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport[en]
-  // CHECK: firrtl.strictconnect [[EN]], %c0_ui1
+  // CHECK: firrtl.matchingconnect [[EN]], %c0_ui1
   // CHECK: [[CLOCK:%.*]] = firrtl.subfield %ram_ramport[clk]
-  // CHECK: firrtl.strictconnect [[CLOCK]], %invalid_clock
+  // CHECK: firrtl.matchingconnect [[CLOCK]], %invalid_clock
   // CHECK: [[RDATA:%.*]] = firrtl.subfield %ram_ramport[rdata]
   // CHECK: [[WMODE:%.*]] = firrtl.subfield %ram_ramport[wmode]
-  // CHECK: firrtl.strictconnect [[WMODE]], %c0_ui1
+  // CHECK: firrtl.matchingconnect [[WMODE]], %c0_ui1
   // CHECK: [[WDATA:%.*]] = firrtl.subfield %ram_ramport[wdata]
-  // CHECK: firrtl.strictconnect [[WDATA]], %invalid_ui1
+  // CHECK: firrtl.matchingconnect [[WDATA]], %invalid_ui1
   // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport[wmask]
-  // CHECK: firrtl.strictconnect [[WMASK]], %invalid
+  // CHECK: firrtl.matchingconnect [[WMASK]], %invalid
   %ram = chirrtl.combmem : !chirrtl.cmemory<uint<1>, 256>
 
-  // CHECK: firrtl.strictconnect [[ADDR]], %addr : !firrtl.uint<8>
-  // CHECK: firrtl.strictconnect [[EN]], %c1_ui1
-  // CHECK: firrtl.strictconnect [[CLOCK]], %clock
-  // CHECK: firrtl.strictconnect [[WMASK]], %c0_ui1
+  // CHECK: firrtl.matchingconnect [[ADDR]], %addr : !firrtl.uint<8>
+  // CHECK: firrtl.matchingconnect [[EN]], %c1_ui1
+  // CHECK: firrtl.matchingconnect [[CLOCK]], %clock
+  // CHECK: firrtl.matchingconnect [[WMASK]], %c0_ui1
   %ramport_data, %ramport_port = chirrtl.memoryport Read %ram {name = "ramport"} : (!chirrtl.cmemory<uint<1>, 256>) -> (!firrtl.uint<1>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %ramport_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 
-  // CHECK: firrtl.strictconnect [[WMASK]], %c1_ui1
-  // CHECK: firrtl.strictconnect [[WMODE]], %c1_ui1
+  // CHECK: firrtl.matchingconnect [[WMASK]], %c1_ui1
+  // CHECK: firrtl.matchingconnect [[WMODE]], %c1_ui1
   // CHECK: firrtl.connect [[WDATA]], %in
   firrtl.connect %ramport_data, %in : !firrtl.uint<1>, !firrtl.uint<1>
 
@@ -133,7 +133,7 @@ firrtl.module @WriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrtl.uint<
   // CHECK: [[MASK:%.*]] = firrtl.subfield %ram_ramport[mask]
   // CHECK: [[DATA_B:%.*]] = firrtl.subfield [[DATA]][b]
   // CHECK: [[MASK_B:%.*]] = firrtl.subfield [[MASK]][b]
-  // CHECK: firrtl.strictconnect [[MASK_B]], %c1_ui1
+  // CHECK: firrtl.matchingconnect [[MASK_B]], %c1_ui1
   // CHECK: firrtl.connect [[DATA_B]], %value
   firrtl.connect %ramport_b, %value : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -151,8 +151,8 @@ firrtl.module @ReadAndWriteToSubfield(in %clock: !firrtl.clock, in %addr: !firrt
   // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport[wmask]
   // CHECK: [[WDATA_A:%.*]] = firrtl.subfield [[WDATA]][a]
   // CHECK: [[WMASK_A:%.*]] = firrtl.subfield [[WMASK]][a]
-  // CHECK: firrtl.strictconnect [[WMASK_A]], %c1_ui1
-  // CHECK: firrtl.strictconnect [[WMODE]], %c1_ui1
+  // CHECK: firrtl.matchingconnect [[WMASK_A]], %c1_ui1
+  // CHECK: firrtl.matchingconnect [[WMODE]], %c1_ui1
   // CHECK: firrtl.connect [[WDATA_A]], %in
   %port_a = firrtl.subfield %ramport_data[a] : !firrtl.bundle<a: uint<1>, b: uint<1>>
   firrtl.connect %port_a, %in : !firrtl.uint<1>, !firrtl.uint<1>
@@ -176,8 +176,8 @@ firrtl.module @ReadAndWriteToSubindex(in %clock: !firrtl.clock, in %addr: !firrt
   // CHECK: [[WMASK:%.*]] = firrtl.subfield %ram_ramport[wmask]
   // CHECK: [[WDATA_0:%.*]] = firrtl.subindex [[WDATA]][0]
   // CHECK: [[WMASK_0:%.*]] = firrtl.subindex [[WMASK]][0]
-  // CHECK: firrtl.strictconnect [[WMASK_0]], %c1_ui1 : !firrtl.uint<1>
-  // CHECK: firrtl.strictconnect [[WMODE]], %c1_ui1 : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect [[WMASK_0]], %c1_ui1 : !firrtl.uint<1>
+  // CHECK: firrtl.matchingconnect [[WMODE]], %c1_ui1 : !firrtl.uint<1>
   // CHECK: firrtl.connect [[WDATA_0]], %in : !firrtl.uint<1>, !firrtl.uint<1>
   %port_a = firrtl.subindex %ramport_data[0] : !firrtl.vector<uint<1>, 10>
   firrtl.connect %port_a, %in : !firrtl.uint<1>, !firrtl.uint<1>
@@ -234,7 +234,7 @@ firrtl.module @EnableInference0(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
 
   // CHECK: firrtl.when %p : !firrtl.uint<1> {
   firrtl.when %p : !firrtl.uint<1> {
-    // CHECK-NEXT: firrtl.strictconnect [[EN]], %c1_ui1
+    // CHECK-NEXT: firrtl.matchingconnect [[EN]], %c1_ui1
     // CHECK-NEXT: firrtl.connect %w, %addr
     firrtl.connect %w, %addr : !firrtl.uint<4>, !firrtl.uint<4>
   }
@@ -250,10 +250,10 @@ firrtl.module @EnableInference1(in %p: !firrtl.uint<1>, in %addr: !firrtl.uint<4
   // CHECK: [[EN:%.*]] = firrtl.subfield %ram_ramport[en]
   // CHECK: firrtl.when %p : !firrtl.uint<1>
   firrtl.when %p : !firrtl.uint<1> {
-   // CHECK-NEXT: firrtl.strictconnect [[EN]], %c1_ui1
+   // CHECK-NEXT: firrtl.matchingconnect [[EN]], %c1_ui1
    // CHECK-NEXT: %n = firrtl.node %addr
-   // CHECK-NEXT: firrtl.strictconnect [[ADDR]], %n
-   // CHECK-NEXT: firrtl.strictconnect %2, %clock
+   // CHECK-NEXT: firrtl.matchingconnect [[ADDR]], %n
+   // CHECK-NEXT: firrtl.matchingconnect %2, %clock
    // CHECK-NEXT: firrtl.connect %v, %3
     %n = firrtl.node %addr : !firrtl.uint<4>
     %ramport_data, %ramport_port = chirrtl.memoryport Read %ram {name = "ramport"} : (!chirrtl.cmemory<uint<32>, 16>) -> (!firrtl.uint<32>, !chirrtl.cmemoryport)
@@ -272,8 +272,8 @@ firrtl.module @EnableInference2(in %clock: !firrtl.clock, in %io: !firrtl.bundle
   chirrtl.memoryport.access %read_port[%0], %clock : !chirrtl.cmemoryport, !firrtl.uint<3>, !firrtl.clock
   firrtl.connect %out, %read_data : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK: [[EN:%.*]] = firrtl.subfield %mem_read[en]
-  // CHECK: firrtl.strictconnect [[EN]], %c0_ui1
-  // CHECK: firrtl.strictconnect [[EN]], %c1_ui1
+  // CHECK: firrtl.matchingconnect [[EN]], %c0_ui1
+  // CHECK: firrtl.matchingconnect [[EN]], %c1_ui1
 }
 
 // When the address line is larger than the size of the address port, the port
@@ -285,7 +285,7 @@ firrtl.module @AddressLargerThanPort(in %clock: !firrtl.clock, in %addr: !firrtl
   // CHECK: [[ADDR:%.+]] = firrtl.subfield %mem_r[addr]
   %addr_node = firrtl.node %addr  : !firrtl.uint<3>
   // CHECK: [[TRUNC:%.+]] = firrtl.tail %addr_node, 1
-  // CHECK: firrtl.strictconnect [[ADDR]], [[TRUNC]]
+  // CHECK: firrtl.matchingconnect [[ADDR]], [[TRUNC]]
   chirrtl.memoryport.access %r_port[%addr_node], %clock : !chirrtl.cmemoryport, !firrtl.uint<3>, !firrtl.clock
   // CHECK: firrtl.connect
   firrtl.connect %out, %r_data : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -90,7 +90,7 @@ firrtl.circuit "Component" {
   firrtl.module @Component(in %input: !firrtl.uint<1>, out %output: !firrtl.uint<1>, out %omir_out: !firrtl.class<@ClassEntrypoint(out obj_0_out: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>)>) attributes {convention = #firrtl<convention scalarized>} {
     %0 = firrtl.object @ClassEntrypoint(out obj_0_out: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>)
     firrtl.propassign %omir_out, %0 : !firrtl.class<@ClassEntrypoint(out obj_0_out: !firrtl.class<@Class_1(out someInt: !firrtl.integer)>)>
-    firrtl.strictconnect %output, %input : !firrtl.uint<1>
+    firrtl.matchingconnect %output, %input : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: om.class @ClassTest
@@ -268,8 +268,8 @@ firrtl.circuit "ModuleInstances" {
 
   // CHECK: firrtl.module private @Module(in %[[IN_WIRE0:.+]]: !firrtl.uint<1>, out %[[OUT_WIRE0:.+]]: !firrtl.uint<1>)
   firrtl.module private @Module(in %inputWire: !firrtl.uint<1>, in %inputProp: !firrtl.string, out %outputWire: !firrtl.uint<1>, out %outputProp: !firrtl.string) {
-    // CHECK: firrtl.strictconnect %[[OUT_WIRE0]], %[[IN_WIRE0]]
-    firrtl.strictconnect %outputWire, %inputWire : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %[[OUT_WIRE0]], %[[IN_WIRE0]]
+    firrtl.matchingconnect %outputWire, %inputWire : !firrtl.uint<1>
     // CHECK-NEXT: }
     firrtl.propassign %outputProp, %inputProp : !firrtl.string
   }
@@ -283,12 +283,12 @@ firrtl.circuit "ModuleInstances" {
     // CHECK: %[[MOD_IN_WIRE:.+]], %[[MOD_OUT_WIRE:.+]] = firrtl.instance mod sym @[[MOD_SYM]] @Module
     %mod.inputWire, %mod.inputProp, %mod.outputWire, %mod.outputProp = firrtl.instance mod @Module(in inputWire: !firrtl.uint<1>, in inputProp: !firrtl.string, out outputWire: !firrtl.uint<1>, out outputProp: !firrtl.string)
 
-    // CHECK: firrtl.strictconnect %[[EXT_IN_WIRE]], %[[IN_WIRE1]]
-    firrtl.strictconnect %ext.inputWire, %inputWire : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %[[MOD_IN_WIRE]], %[[EXT_OUT_WIRE]]
-    firrtl.strictconnect %mod.inputWire, %ext.outputWire : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %[[OUT_WIRE1]], %[[MOD_OUT_WIRE]]
-    firrtl.strictconnect %outputWire, %mod.outputWire : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %[[EXT_IN_WIRE]], %[[IN_WIRE1]]
+    firrtl.matchingconnect %ext.inputWire, %inputWire : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %[[MOD_IN_WIRE]], %[[EXT_OUT_WIRE]]
+    firrtl.matchingconnect %mod.inputWire, %ext.outputWire : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %[[OUT_WIRE1]], %[[MOD_OUT_WIRE]]
+    firrtl.matchingconnect %outputWire, %mod.outputWire : !firrtl.uint<1>
 
     // CHECK-NEXT: }
     firrtl.propassign %ext.inputProp, %inputProp : !firrtl.string

--- a/test/Dialect/FIRRTL/lower-intmodules-eicg.mlir
+++ b/test/Dialect/FIRRTL/lower-intmodules-eicg.mlir
@@ -16,9 +16,9 @@ firrtl.circuit "FixupEICGWrapper" {
     // CHECK-EICG-NOT: firrtl.instance
     // CHECK-EICG: firrtl.int.generic "circt_clock_gate"
     %ckg_in, %ckg_test_en, %ckg_en, %ckg_out = firrtl.instance ckg @LegacyClockGate(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
-    firrtl.strictconnect %ckg_in, %clock : !firrtl.clock
-    firrtl.strictconnect %ckg_test_en, %en : !firrtl.uint<1>
-    firrtl.strictconnect %ckg_en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %ckg_in, %clock : !firrtl.clock
+    firrtl.matchingconnect %ckg_test_en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %ckg_en, %en : !firrtl.uint<1>
   }
 }
 
@@ -36,8 +36,8 @@ firrtl.circuit "FixupEICGWrapper2" {
     // CHECK-EICG-NOT: firrtl.instance
     // CHECK-EICG: firrtl.int.generic "circt_clock_gate"
     %ckg_in, %ckg_en, %ckg_out = firrtl.instance ckg @LegacyClockGateNoTestEn(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock)
-    firrtl.strictconnect %ckg_in, %clock : !firrtl.clock
-    firrtl.strictconnect %ckg_en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %ckg_in, %clock : !firrtl.clock
+    firrtl.matchingconnect %ckg_en, %en : !firrtl.uint<1>
   }
 }
 

--- a/test/Dialect/FIRRTL/lower-intmodules.mlir
+++ b/test/Dialect/FIRRTL/lower-intmodules.mlir
@@ -20,25 +20,25 @@ firrtl.circuit "BasicIntmoduleInstances" {
     %i1, %size = firrtl.instance "" @NameDoesNotMatter5(in i : !firrtl.clock, out size : !firrtl.uint<32>)
     // CHECK-NOT: NameDoesNotMatter5
     // CHECK: firrtl.int.generic "circt.sizeof"
-    firrtl.strictconnect %i1, %clk : !firrtl.clock
-    firrtl.strictconnect %s, %size : !firrtl.uint<32>
+    firrtl.matchingconnect %i1, %clk : !firrtl.clock
+    firrtl.matchingconnect %s, %size : !firrtl.uint<32>
 
     %i2, %found2 = firrtl.instance "" @NameDoesNotMatter6(in i : !firrtl.clock, out found : !firrtl.uint<1>)
     // CHECK-NOT: NameDoesNotMatter6
     // CHECK: firrtl.int.generic "circt.isX"
-    firrtl.strictconnect %i2, %clk : !firrtl.clock
-    firrtl.strictconnect %io1, %found2 : !firrtl.uint<1>
+    firrtl.matchingconnect %i2, %clk : !firrtl.clock
+    firrtl.matchingconnect %io1, %found2 : !firrtl.uint<1>
 
     %found3 = firrtl.instance "" @NameDoesNotMatter7(out found : !firrtl.uint<1>)
     // CHECK-NOT: NameDoesNotMatter7
     // CHECK: firrtl.int.generic "circt.plusargs.test"
-    firrtl.strictconnect %io2, %found3 : !firrtl.uint<1>
+    firrtl.matchingconnect %io2, %found3 : !firrtl.uint<1>
 
     %found4, %result1 = firrtl.instance "" @NameDoesNotMatter8(out found : !firrtl.uint<1>, out result: !firrtl.uint<5>)
     // CHECK-NOT: NameDoesNotMatter8
     // CHECK: firrtl.int.generic "circt.plusargs.value" <FORMAT: none = "foo"> : () -> !firrtl.bundle<found: uint<1>, result: uint<5>>
-    firrtl.strictconnect %io3, %found4 : !firrtl.uint<1>
-    firrtl.strictconnect %io4, %result1 : !firrtl.uint<5>
+    firrtl.matchingconnect %io3, %found4 : !firrtl.uint<1>
+    firrtl.matchingconnect %io4, %result1 : !firrtl.uint<5>
   }
 }
 
@@ -54,10 +54,10 @@ firrtl.circuit "ProbeIntrinsicTest" {
     // CHECK:      [[DATA:%.+]] = firrtl.wire : !firrtl.uint
     // CHECK-NEXT: [[CLOCK:%.+]] = firrtl.wire : !firrtl.clock
     // CHECK-NEXT: firrtl.int.generic "circt_fpga_probe" [[DATA]], [[CLOCK]] : (!firrtl.uint, !firrtl.clock) -> ()
-    // CHECK-NEXT: firrtl.strictconnect [[CLOCK]], %clock : !firrtl.clock
+    // CHECK-NEXT: firrtl.matchingconnect [[CLOCK]], %clock : !firrtl.clock
     // CHECK-NEXT: firrtl.connect [[DATA]], %data : !firrtl.uint, !firrtl.uint<32>
     %mod_data, %mod_clock = firrtl.instance mod @FPGAProbeIntrinsic(in data: !firrtl.uint, in clock: !firrtl.clock)
-    firrtl.strictconnect %mod_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %mod_clock, %clock : !firrtl.clock
     firrtl.connect %mod_data, %data : !firrtl.uint, !firrtl.uint<32>
   }
 }

--- a/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
@@ -6,7 +6,7 @@ firrtl.circuit "UnknownIntrinsic" {
     // expected-error @below {{unknown intrinsic}}
     // expected-error @below {{failed to legalize}}
     firrtl.int.generic "unknown_intrinsic" %0 : (!firrtl.uint<32>) -> ()
-    firrtl.strictconnect %0, %data : !firrtl.uint<32>
+    firrtl.matchingconnect %0, %data : !firrtl.uint<32>
   }
 }
 

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -6,22 +6,22 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo(in %clk : !firrtl.clock, out %s : !firrtl.uint<32>, out %io1 : !firrtl.uint<1>, out %io2 : !firrtl.uint<1>, out %io3 : !firrtl.uint<1>, out %io4 : !firrtl.uint<5>) {
     // CHECK: firrtl.int.sizeof %clk
     %size = firrtl.int.generic "circt.sizeof"  %clk : (!firrtl.clock) -> !firrtl.uint<32>
-    firrtl.strictconnect %s, %size : !firrtl.uint<32>
+    firrtl.matchingconnect %s, %size : !firrtl.uint<32>
 
     // CHECK: firrtl.int.isX
     %isX = firrtl.int.generic "circt.isX"  %clk : (!firrtl.clock) -> !firrtl.uint<1>
-    firrtl.strictconnect %io1, %isX : !firrtl.uint<1>
+    firrtl.matchingconnect %io1, %isX : !firrtl.uint<1>
 
     // CHECK: firrtl.int.plusargs.test "foo"
     %foo = firrtl.int.generic "circt.plusargs.test" <FORMAT: none = "foo"> : () -> !firrtl.uint<1>
-    firrtl.strictconnect %io2, %foo : !firrtl.uint<1>
+    firrtl.matchingconnect %io2, %foo : !firrtl.uint<1>
 
     // CHECK: firrtl.int.plusargs.value "foo" : !firrtl.uint<5>
     %pav = firrtl.int.generic "circt.plusargs.value" <FORMAT: none = "foo"> : () -> !firrtl.bundle<found: uint<1>, result: uint<5>>
     %found = firrtl.subfield %pav[found] : !firrtl.bundle<found: uint<1>, result: uint<5>>
     %result = firrtl.subfield %pav[result] : !firrtl.bundle<found: uint<1>, result: uint<5>>
-    firrtl.strictconnect %io3, %found : !firrtl.uint<1>
-    firrtl.strictconnect %io4, %result : !firrtl.uint<5>
+    firrtl.matchingconnect %io3, %found : !firrtl.uint<1>
+    firrtl.matchingconnect %io4, %result : !firrtl.uint<5>
   }
   // CHECK-LABEL: @ClockGate
   firrtl.module @ClockGate(in %clk: !firrtl.clock, in %en: !firrtl.uint<1>) {

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -89,8 +89,8 @@ firrtl.circuit "Test" {
   // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK:   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK:   %[[p:.+]], %[[q:.+]] = firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers_Test_A.sv", excludeFromFileList>} @[[A]]
-  // CHECK:   firrtl.strictconnect %[[q]], %c1_ui1 : !firrtl.uint<1>
-  // CHECK:   firrtl.strictconnect %[[p]], %c0_ui1 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[q]], %c1_ui1 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[p]], %c0_ui1 : !firrtl.uint<1>
   // CHECK: }
   firrtl.module @CaptureHardware() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -105,7 +105,7 @@ firrtl.circuit "Test" {
   // CHECK: }
   // CHECK: firrtl.module @CapturePort(in %in: !firrtl.uint<1>) {
   // CHECK:   %[[p:.+]] = firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers_Test_A.sv", excludeFromFileList>} @[[A]]
-  // CHECK:   firrtl.strictconnect %[[p]], %in : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[p]], %in : !firrtl.uint<1>
   // CHECK: }
   firrtl.module @CapturePort(in %in: !firrtl.uint<1>){
     firrtl.layerblock @A {
@@ -120,7 +120,7 @@ firrtl.circuit "Test" {
   // CHECK: firrtl.module @CaptureHardwareViaConnect() {
   // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK:   %[[p:.+]] = firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers_Test_A.sv", excludeFromFileList>} @[[A]]
-  // CHECK:   firrtl.strictconnect %[[p]], %c0_ui1 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[p]], %c0_ui1 : !firrtl.uint<1>
   // CHECK: }
   firrtl.module @CaptureHardwareViaConnect() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -140,7 +140,7 @@ firrtl.circuit "Test" {
   // CHECK:   %0 = firrtl.ref.send %w : !firrtl.uint<1>
   // CHECK:   %[[p:.+]] = firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers_Test_A.sv", excludeFromFileList>} @[[A]]
   // CHECK:   %1 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
-  // CHECK:   firrtl.strictconnect %[[p]], %1 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[p]], %1 : !firrtl.uint<1>
   // CHECK: }
   firrtl.module @CaptureProbeSrc() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -166,9 +166,9 @@ firrtl.circuit "Test" {
   // CHECK:   %[[b1:.+]], %[[b2:.+]] = firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers_Test_A_B.sv", excludeFromFileList>} @[[B]]
   // CHECK:   %[[a1:.+]], %[[a2:.+]] = firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers_Test_A.sv", excludeFromFileList>} @[[A]]
   // CHECK:   %0 = firrtl.ref.resolve %[[a2]] : !firrtl.probe<uint<1>>
-  // CHECK:   firrtl.strictconnect %[[b1]], %0 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[b1]], %0 : !firrtl.uint<1>
   // CHECK:   %1 = firrtl.ref.resolve %[[a1]] : !firrtl.probe<uint<1>>
-  // CHECK:   firrtl.strictconnect %[[b2]], %1 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[b2]], %1 : !firrtl.uint<1>
   // CHECK: }
   firrtl.module @NestedCaptureHardware() {
     firrtl.layerblock @A {
@@ -189,7 +189,7 @@ firrtl.circuit "Test" {
   // CHECK: firrtl.module @WhenUnderLayer() {
   // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK:   %[[p:.+]] = firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers_Test_A.sv", excludeFromFileList>} @[[A]]
-  // CHECK:   firrtl.strictconnect %[[p]], %c0_ui1 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[p]], %c0_ui1 : !firrtl.uint<1>
   // CHECK: }
   firrtl.module @WhenUnderLayer() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -234,7 +234,7 @@ firrtl.circuit "Test" {
   // CHECK:   %0 = firrtl.wire : !firrtl.probe<uint<1>>
   // CHECK:   %[[p:.+]] = firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers_Test_A.sv", excludeFromFileList>} @[[A]]
   // CHECK:   %1 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
-  // CHECK:   firrtl.strictconnect %[[p]], %1 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[p]], %1 : !firrtl.uint<1>
   // CHECK: }
   firrtl.module @SrcOutside() {
     %0 = firrtl.wire : !firrtl.probe<uint<1>, @A>
@@ -293,7 +293,7 @@ firrtl.circuit "Test" {
   // CHECK:   %w = firrtl.wire : !firrtl.probe<uint<1>>
   // CHECK:   %[[p:.+]] = firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers_Test_A.sv", excludeFromFileList>} @[[A]]
   // CHECK:   %0 = firrtl.ref.resolve %w : !firrtl.probe<uint<1>>
-  // CHECK:   firrtl.strictconnect %[[p]], %0 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[p]], %0 : !firrtl.uint<1>
   // CHECK: }
   firrtl.module @ResolveColoredRefUnderLayerBlock() {
     %w = firrtl.wire : !firrtl.probe<uint<1>, @A>
@@ -319,7 +319,7 @@ firrtl.circuit "Test" {
   // CHECK:   %foo_o = firrtl.instance foo @Foo(out o: !firrtl.probe<uint<1>>)
   // CHECK:   %[[p:.+]] = firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers_Test_A.sv", excludeFromFileList>} @[[A]]
   // CHECK:   %0 = firrtl.ref.resolve %foo_o : !firrtl.probe<uint<1>>
-  // CHECK:   firrtl.strictconnect %[[p]], %0 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[p]], %0 : !firrtl.uint<1>
   // CHECK: }
   firrtl.module @ResolveColoredRefPortUnderLayerBlock1() {
     %foo_o = firrtl.instance foo @Foo(out o : !firrtl.probe<uint<1>, @A>)
@@ -432,15 +432,15 @@ firrtl.circuit "Simple" {
 // CHECK-SAME:     output_file = #hw.output_file<"layers_Simple_A_B.sv", excludeFromFileList>
 // CHECK-SAME:     @Simple_A_B(
 // CHECK-NEXT:   %[[A_B_cc_resolve:[_a-zA-Z0-9]+]] = firrtl.ref.resolve %[[A_B_cc]]
-// CHECK-NEXT:   firrtl.strictconnect %[[A_B_C_cc]], %[[A_B_cc_resolve]]
-// CHECK-NEXT:   firrtl.strictconnect %[[A_B_b]], %b
+// CHECK-NEXT:   firrtl.matchingconnect %[[A_B_C_cc]], %[[A_B_cc_resolve]]
+// CHECK-NEXT:   firrtl.matchingconnect %[[A_B_b]], %b
 // CHECK-NEXT:   %[[A_a:[_a-zA-Z0-9]+]], %[[A_c:[_a-zA-Z0-9]+]] = firrtl.instance a {
 // CHECK-SAME:     lowerToBind
 // CHECK-SAME:     output_file = #hw.output_file<"layers_Simple_A.sv", excludeFromFileList>
 // CHECK-SAME:     @Simple_A(
 // CHECK-NEXT:   %[[A_c_resolve:[_a-zA-Z0-9]+]] = firrtl.ref.resolve %[[A_c]]
-// CHECK-NEXT:   firrtl.strictconnect %[[A_B_c]], %[[A_c_resolve]]
-// CHECK-NEXT:   firrtl.strictconnect %[[A_a]], %a
+// CHECK-NEXT:   firrtl.matchingconnect %[[A_B_c]], %[[A_c_resolve]]
+// CHECK-NEXT:   firrtl.matchingconnect %[[A_a]], %a
 // CHECK:      }
 //
 // CHECK-DAG:  sv.verbatim "`endif // layers_Simple_A"
@@ -489,7 +489,7 @@ firrtl.circuit "CaptureHardwareMultipleTimes" {
   // CHECK: firrtl.module @CaptureSrcTwice() {
   // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK:   %[[p:.+]] = firrtl.instance {{.+}} @[[A]]
-  // CHECK:   firrtl.strictconnect %[[p]], %c0_ui1 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[p]], %c0_ui1 : !firrtl.uint<1>
   // CHECK: }
   firrtl.module @CaptureSrcTwice() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -508,7 +508,7 @@ firrtl.circuit "CaptureHardwareMultipleTimes" {
   // CHECK:   %w1 = firrtl.wire : !firrtl.probe<uint<1>>
   // CHECK:   %[[out:.+]], %[[in:.+]] = firrtl.instance {{.+}} @[[A]](out {{.+}}: !firrtl.probe<uint<1>>, in {{.+}}: !firrtl.uint<1>)
   // CHECK:   %0 = firrtl.ref.resolve %w1 : !firrtl.probe<uint<1>>
-  // CHECK:   firrtl.strictconnect %[[in]], %0 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[in]], %0 : !firrtl.uint<1>
   // CHECK:   firrtl.ref.define %w1, %[[out]] : !firrtl.probe<uint<1>>
   // CHECK: }
   firrtl.module @CaptureAsDstThenSrc() {
@@ -533,7 +533,7 @@ firrtl.circuit "CaptureHardwareMultipleTimes" {
   // CHECK:   %[[in:.+]], %[[out:.+]] = firrtl.instance {{.+}} @[[A]]
   // CHECK:   firrtl.ref.define %w1, %[[out]] : !firrtl.probe<uint<1>>
   // CHECK:   %0 = firrtl.ref.resolve %w1 : !firrtl.probe<uint<1>>
-  // CHECK:   firrtl.strictconnect %[[in]], %0 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %[[in]], %0 : !firrtl.uint<1>
   // CHECK: }
   firrtl.module @CaptureAsSrcThenDst() {
     %w1 = firrtl.wire : !firrtl.probe<uint<1>, @A>

--- a/test/Dialect/FIRRTL/lower-matches.mlir
+++ b/test/Dialect/FIRRTL/lower-matches.mlir
@@ -12,10 +12,10 @@ firrtl.module @EmptyEnum(in %enum : !firrtl.enum<>) {
 // CHECK-LABEL: firrtl.module @OneVariant
 firrtl.module @OneVariant(in %enum : !firrtl.enum<a: uint<8>>, out %out : !firrtl.uint<8>) {
   // CHECK: %0 = firrtl.subtag %enum[a] : !firrtl.enum<a: uint<8>>
-  // CHECK: firrtl.strictconnect %out, %0 : !firrtl.uint<8>
+  // CHECK: firrtl.matchingconnect %out, %0 : !firrtl.uint<8>
   firrtl.match %enum : !firrtl.enum<a: uint<8>> {
     case a(%arg0) {
-      firrtl.strictconnect %out, %arg0 : !firrtl.uint<8>
+      firrtl.matchingconnect %out, %arg0 : !firrtl.uint<8>
     }
   }
 }
@@ -26,26 +26,26 @@ firrtl.module @LowerMatches(in %enum : !firrtl.enum<a: uint<8>, b: uint<8>, c: u
    // CHECK-NEXT: %0 = firrtl.istag %enum a : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>>
    // CHECK-NEXT: firrtl.when %0 : !firrtl.uint<1> {
    // CHECK-NEXT:   %1 = firrtl.subtag %enum[a] : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>>
-   // CHECK-NEXT:   firrtl.strictconnect %out, %1 : !firrtl.uint<8>
+   // CHECK-NEXT:   firrtl.matchingconnect %out, %1 : !firrtl.uint<8>
    // CHECK-NEXT: } else {
    // CHECK-NEXT:   %1 = firrtl.istag %enum b : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>>
    // CHECK-NEXT:   firrtl.when %1 : !firrtl.uint<1> {
    // CHECK-NEXT:     %2 = firrtl.subtag %enum[b] : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>>
-   // CHECK-NEXT:     firrtl.strictconnect %out, %2 : !firrtl.uint<8>
+   // CHECK-NEXT:     firrtl.matchingconnect %out, %2 : !firrtl.uint<8>
    // CHECK-NEXT:   } else {
    // CHECK-NEXT:     %2 = firrtl.subtag %enum[c] : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>>
-   // CHECK-NEXT:     firrtl.strictconnect %out, %2 : !firrtl.uint<8>
+   // CHECK-NEXT:     firrtl.matchingconnect %out, %2 : !firrtl.uint<8>
    // CHECK-NEXT:   }
    // CHECK-NEXT: }
   firrtl.match %enum : !firrtl.enum<a: uint<8>, b: uint<8>, c: uint<8>> {
     case a(%arg0) {
-      firrtl.strictconnect %out, %arg0 : !firrtl.uint<8>
+      firrtl.matchingconnect %out, %arg0 : !firrtl.uint<8>
     }
     case b(%arg0) {
-      firrtl.strictconnect %out, %arg0 : !firrtl.uint<8>
+      firrtl.matchingconnect %out, %arg0 : !firrtl.uint<8>
     }
     case c(%arg0) {
-      firrtl.strictconnect %out, %arg0 : !firrtl.uint<8>
+      firrtl.matchingconnect %out, %arg0 : !firrtl.uint<8>
     }
   }
 
@@ -57,26 +57,26 @@ firrtl.module @ConstLowerMatches(in %enum : !firrtl.const.enum<a: uint<8>, b: ui
    // CHECK-NEXT: %0 = firrtl.istag %enum a : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>>
    // CHECK-NEXT: firrtl.when %0 : !firrtl.const.uint<1> {
    // CHECK-NEXT:   %1 = firrtl.subtag %enum[a] : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>>
-   // CHECK-NEXT:   firrtl.strictconnect %out, %1 : !firrtl.const.uint<8>
+   // CHECK-NEXT:   firrtl.matchingconnect %out, %1 : !firrtl.const.uint<8>
    // CHECK-NEXT: } else {
    // CHECK-NEXT:   %1 = firrtl.istag %enum b : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>>
    // CHECK-NEXT:   firrtl.when %1 : !firrtl.const.uint<1> {
    // CHECK-NEXT:     %2 = firrtl.subtag %enum[b] : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>>
-   // CHECK-NEXT:     firrtl.strictconnect %out, %2 : !firrtl.const.uint<8>
+   // CHECK-NEXT:     firrtl.matchingconnect %out, %2 : !firrtl.const.uint<8>
    // CHECK-NEXT:   } else {
    // CHECK-NEXT:     %2 = firrtl.subtag %enum[c] : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>>
-   // CHECK-NEXT:     firrtl.strictconnect %out, %2 : !firrtl.const.uint<8>
+   // CHECK-NEXT:     firrtl.matchingconnect %out, %2 : !firrtl.const.uint<8>
    // CHECK-NEXT:   }
    // CHECK-NEXT: }
   firrtl.match %enum : !firrtl.const.enum<a: uint<8>, b: uint<8>, c: uint<8>> {
     case a(%arg0) {
-      firrtl.strictconnect %out, %arg0 : !firrtl.const.uint<8>
+      firrtl.matchingconnect %out, %arg0 : !firrtl.const.uint<8>
     }
     case b(%arg0) {
-      firrtl.strictconnect %out, %arg0 : !firrtl.const.uint<8>
+      firrtl.matchingconnect %out, %arg0 : !firrtl.const.uint<8>
     }
     case c(%arg0) {
-      firrtl.strictconnect %out, %arg0 : !firrtl.const.uint<8>
+      firrtl.matchingconnect %out, %arg0 : !firrtl.const.uint<8>
     }
   }
 

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -9,8 +9,8 @@ firrtl.module @ReadWrite() {
 }
 // CHECK: firrtl.module private @MReadWrite
 // CHECK:   firrtl.instance MReadWrite_ext  @MReadWrite_ext
-// CHECK:   firrtl.strictconnect %MReadWrite_ext_RW0_addr, %RW0_addr
-// CHECK:   firrtl.strictconnect %RW0_rdata, %MReadWrite_ext_RW0_rdata
+// CHECK:   firrtl.matchingconnect %MReadWrite_ext_RW0_addr, %RW0_addr
+// CHECK:   firrtl.matchingconnect %RW0_rdata, %MReadWrite_ext_RW0_rdata
 // CHECK: }
 }
 

--- a/test/Dialect/FIRRTL/lower-open-aggs-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs-errors.mlir
@@ -41,7 +41,7 @@ firrtl.circuit "MixedAnnotation" {
     %r_p = firrtl.opensubfield %r[p] : !firrtl.openbundle<a: uint<1>, p: probe<uint<1>>>
     firrtl.ref.define %r_p, %ref : !firrtl.probe<uint<1>>
     %r_a = firrtl.opensubfield %r[a] : !firrtl.openbundle<a: uint<1>, p: probe<uint<1>>>
-    firrtl.strictconnect %r_a, %zero : !firrtl.uint<1>
+    firrtl.matchingconnect %r_a, %zero : !firrtl.uint<1>
   }
 }
 

--- a/test/Dialect/FIRRTL/lower-open-aggs.mlir
+++ b/test/Dialect/FIRRTL/lower-open-aggs.mlir
@@ -48,20 +48,20 @@ firrtl.circuit "Bundle" {
     %17 = firrtl.ref.sub %c1_r[0] : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
     %c2_in, %c2_r = firrtl.instance c2 interesting_name @Child(in in: !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>, out r: !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>)
     %18 = firrtl.ref.sub %c2_r[0] : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
-    firrtl.strictconnect %c1_in, %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
-    firrtl.strictconnect %c2_in, %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.matchingconnect %c1_in, %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.matchingconnect %c2_in, %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
     firrtl.ref.define %15, %c1_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
     firrtl.ref.define %14, %c2_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
     %19 = firrtl.ref.resolve %17 : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %13, %19 : !firrtl.uint<1>
+    firrtl.matchingconnect %13, %19 : !firrtl.uint<1>
     %20 = firrtl.ref.resolve %16 : !firrtl.probe<vector<uint<1>, 2>>
-    firrtl.strictconnect %12, %20 : !firrtl.vector<uint<1>, 2>
+    firrtl.matchingconnect %12, %20 : !firrtl.vector<uint<1>, 2>
     firrtl.ref.define %11, %c1_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
     firrtl.ref.define %8, %c2_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
     %21 = firrtl.ref.resolve %17 : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %10, %21 : !firrtl.uint<1>
+    firrtl.matchingconnect %10, %21 : !firrtl.uint<1>
     %22 = firrtl.ref.resolve %18 : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %7, %22 : !firrtl.uint<1>
+    firrtl.matchingconnect %7, %22 : !firrtl.uint<1>
     firrtl.ref.define %4, %c1_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
     firrtl.ref.define %2, %c2_r : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
   }
@@ -84,21 +84,21 @@ firrtl.circuit "Bundle" {
     %13 = firrtl.opensubfield %12[p] : !firrtl.openbundle<p flip: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, data flip: uint<1>>
     %14 = firrtl.opensubfield %p_r[b] : !firrtl.openbundle<a: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, b: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>
     %15 = firrtl.opensubfield %p_r[a] : !firrtl.openbundle<a: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>, b: probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>>
-    firrtl.strictconnect %p_in, %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.matchingconnect %p_in, %in : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
     %16 = firrtl.ref.resolve %15 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
-    firrtl.strictconnect %out1, %16 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.matchingconnect %out1, %16 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
     %17 = firrtl.ref.resolve %14 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
-    firrtl.strictconnect %out2, %17 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.matchingconnect %out2, %17 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
     %18 = firrtl.ref.resolve %13 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
-    firrtl.strictconnect %out3, %18 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.matchingconnect %out3, %18 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
     %19 = firrtl.ref.resolve %11 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
-    firrtl.strictconnect %out4, %19 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.matchingconnect %out4, %19 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
     %20 = firrtl.ref.resolve %8 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
-    firrtl.strictconnect %out5, %20 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.matchingconnect %out5, %20 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
     %21 = firrtl.ref.resolve %6 : !firrtl.probe<bundle<a: uint<1>, b: vector<uint<1>, 2>>>
-    firrtl.strictconnect %out6, %21 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
-    firrtl.strictconnect %1, %3 : !firrtl.uint<1>
-    firrtl.strictconnect %0, %2 : !firrtl.vector<uint<1>, 2>
+    firrtl.matchingconnect %out6, %21 : !firrtl.bundle<a: uint<1>, b: vector<uint<1>, 2>>
+    firrtl.matchingconnect %1, %3 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %2 : !firrtl.vector<uint<1>, 2>
   }
 
 // CHECK-LABEL: extmodule @ExtProbes
@@ -136,8 +136,8 @@ firrtl.circuit "RefsOnlyAggFirstLevel" {
     %4 = firrtl.opensubfield %2[x] : !firrtl.openbundle<x: probe<uint<5>>, y: probe<uint<1>>>
     %5 = firrtl.opensubfield %c_foo[y] : !firrtl.openbundle<x: uint<5>, refs flip: openbundle<x: probe<uint<5>>, y: probe<uint<1>>>, y: uint<1>>
     %6 = firrtl.opensubfield %c_foo[x] : !firrtl.openbundle<x: uint<5>, refs flip: openbundle<x: probe<uint<5>>, y: probe<uint<1>>>, y: uint<1>>
-    firrtl.strictconnect %6, %x : !firrtl.uint<5>
-    firrtl.strictconnect %5, %y : !firrtl.uint<1>
+    firrtl.matchingconnect %6, %x : !firrtl.uint<5>
+    firrtl.matchingconnect %5, %y : !firrtl.uint<1>
     firrtl.ref.define %1, %4 : !firrtl.probe<uint<5>>
     firrtl.ref.define %0, %3 : !firrtl.probe<uint<1>>
   }
@@ -230,7 +230,7 @@ firrtl.circuit "BundleOfProps" {
     %str = firrtl.string "test"
     %list = firrtl.list.create %x_a, %str : !firrtl.list<string>
     firrtl.propassign %y_b_c_l, %list : !firrtl.list<string>
-    firrtl.strictconnect %y_a, %x_b : !firrtl.uint<5>
+    firrtl.matchingconnect %y_a, %x_b : !firrtl.uint<5>
   }
 }
 

--- a/test/Dialect/FIRRTL/lower-signatures.mlir
+++ b/test/Dialect/FIRRTL/lower-signatures.mlir
@@ -10,7 +10,7 @@ firrtl.circuit "Prop" {
   }
 
   firrtl.module private @emptyVec(in %vi : !firrtl.vector<uint<4>, 0>, out %vo : !firrtl.vector<uint<4>, 0>) attributes {convention = #firrtl<convention scalarized>} {
-    firrtl.strictconnect %vo, %vi : !firrtl.vector<uint<4>, 0>
+    firrtl.matchingconnect %vo, %vi : !firrtl.vector<uint<4>, 0>
   }
 
   // CHECK-LABEL: @Annos

--- a/test/Dialect/FIRRTL/lower-types-remat.mlir
+++ b/test/Dialect/FIRRTL/lower-types-remat.mlir
@@ -19,7 +19,7 @@ firrtl.circuit "Bar" {
 
 // No agg preservation:
 // CHECK-COUNT-3: firrtl.mux
-// CHECK-COUNT-3: firrtl.strictconnect
+// CHECK-COUNT-3: firrtl.matchingconnect
 
 // 1d-vec preservation:
 // (recreate the vector leaves, but that's it)
@@ -36,6 +36,6 @@ firrtl.circuit "Bar" {
 // ALL-NEXT: mux
   firrtl.module @Bar(in %a1: !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>, in %a2: !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>, in %cond: !firrtl.uint<1>, out %b: !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>) attributes {convention = #firrtl<convention scalarized>} {
     %0 = firrtl.mux(%cond, %a1, %a2) : (!firrtl.uint<1>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>) -> !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
-    firrtl.strictconnect %b, %0 : !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
+    firrtl.matchingconnect %b, %0 : !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
   }
 }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -51,12 +51,12 @@ firrtl.circuit "TopLevel" {
     %sourceV, %sinkV = firrtl.instance "" @Simple(in source: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>,
                         out sink: !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>)
 
-    // LT-NEXT: firrtl.strictconnect %inst_source_valid, %source_valid
-    // LT-NEXT: firrtl.strictconnect %source_ready, %inst_source_ready
-    // LT-NEXT: firrtl.strictconnect %inst_source_data, %source_data
-    // LT-NEXT: firrtl.strictconnect %sink_valid, %inst_sink_valid
-    // LT-NEXT: firrtl.strictconnect %inst_sink_ready, %sink_ready
-    // LT-NEXT: firrtl.strictconnect %sink_data, %inst_sink_data
+    // LT-NEXT: firrtl.matchingconnect %inst_source_valid, %source_valid
+    // LT-NEXT: firrtl.matchingconnect %source_ready, %inst_source_ready
+    // LT-NEXT: firrtl.matchingconnect %inst_source_data, %source_data
+    // LT-NEXT: firrtl.matchingconnect %sink_valid, %inst_sink_valid
+    // LT-NEXT: firrtl.matchingconnect %inst_sink_ready, %sink_ready
+    // LT-NEXT: firrtl.matchingconnect %sink_data, %inst_sink_data
     firrtl.connect %sourceV, %source : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 
     firrtl.connect %sink, %sinkV : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
@@ -104,8 +104,8 @@ firrtl.circuit "TopLevel" {
   // CHECK-LABEL: firrtl.module private @Top
   firrtl.module private @Top(in %in : !firrtl.bundle<a: uint<1>, b: uint<1>>,
                      out %out : !firrtl.bundle<a: uint<1>, b: uint<1>>) {
-    // CHECK: firrtl.strictconnect %out_a, %in_a : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %out_b, %in_b : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %out_a, %in_a : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %out_b, %in_b : !firrtl.uint<1>
     // SIG: firrtl.connect %out, %in : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
     firrtl.connect %out, %in : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
   }
@@ -114,7 +114,7 @@ firrtl.circuit "TopLevel" {
   // CHECK-SAME: in %[[FLAT_ARG_INPUT_NAME:a_b_c]]: [[FLAT_ARG_INPUT_TYPE:!firrtl.uint<1>]]
   // CHECK-SAME: out %[[FLAT_ARG_OUTPUT_NAME:b_b_c]]: [[FLAT_ARG_OUTPUT_TYPE:!firrtl.uint<1>]]
   firrtl.module private @Foo(in %a: !firrtl.bundle<b: bundle<c: uint<1>>>, out %b: !firrtl.bundle<b: bundle<c: uint<1>>>) {
-    // CHECK: firrtl.strictconnect %[[FLAT_ARG_OUTPUT_NAME]], %[[FLAT_ARG_INPUT_NAME]] : [[FLAT_ARG_OUTPUT_TYPE]]
+    // CHECK: firrtl.matchingconnect %[[FLAT_ARG_OUTPUT_NAME]], %[[FLAT_ARG_INPUT_NAME]] : [[FLAT_ARG_OUTPUT_TYPE]]
     // SIG: firrtl.connect %b, %a : !firrtl.bundle<b: bundle<c: uint<1>>>, !firrtl.bundle<b: bundle<c: uint<1>>>
     firrtl.connect %b, %a : !firrtl.bundle<b: bundle<c: uint<1>>>, !firrtl.bundle<b: bundle<c: uint<1>>>
   }
@@ -183,57 +183,57 @@ firrtl.circuit "TopLevel" {
     // ---------------------------------------------------------------------------------
     // Read ports
     // CHECK-NEXT: %[[MEMORY_A_R_ADDR:.+]] = firrtl.subfield %[[MEMORY_A_R]][addr]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_R_ADDR]], %[[MEMORY_R_ADDR:.+]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_A_R_ADDR]], %[[MEMORY_R_ADDR:.+]] :
     // CHECK-NEXT: %[[MEMORY_B_R_ADDR:.+]] = firrtl.subfield %[[MEMORY_B_R]][addr]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_R_ADDR]], %[[MEMORY_R_ADDR]]
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_B_R_ADDR]], %[[MEMORY_R_ADDR]]
     // CHECK-NEXT: %[[MEMORY_A_R_EN:.+]] = firrtl.subfield %[[MEMORY_A_R]][en]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_R_EN]], %[[MEMORY_R_EN:.+]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_A_R_EN]], %[[MEMORY_R_EN:.+]] :
     // CHECK-NEXT: %[[MEMORY_B_R_EN:.+]] = firrtl.subfield %[[MEMORY_B_R]][en]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_R_EN]], %[[MEMORY_R_EN]]
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_B_R_EN]], %[[MEMORY_R_EN]]
     // CHECK-NEXT: %[[MEMORY_A_R_CLK:.+]] = firrtl.subfield %[[MEMORY_A_R]][clk]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_R_CLK]], %[[MEMORY_R_CLK:.+]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_A_R_CLK]], %[[MEMORY_R_CLK:.+]] :
     // CHECK-NEXT: %[[MEMORY_B_R_CLK:.+]] = firrtl.subfield %[[MEMORY_B_R]][clk]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_R_CLK]], %[[MEMORY_R_CLK]]
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_B_R_CLK]], %[[MEMORY_R_CLK]]
     // CHECK-NEXT: %[[MEMORY_A_R_DATA:.+]] = firrtl.subfield %[[MEMORY_A_R]][data]
-    // CHECK-NEXT: firrtl.strictconnect %[[WIRE_A_R_DATA:.+]], %[[MEMORY_A_R_DATA]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[WIRE_A_R_DATA:.+]], %[[MEMORY_A_R_DATA]] :
     // CHECK-NEXT: %[[MEMORY_B_R_DATA:.+]] = firrtl.subfield %[[MEMORY_B_R]][data]
-    // CHECK-NEXT: firrtl.strictconnect %[[WIRE_B_R_DATA:.+]], %[[MEMORY_B_R_DATA]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[WIRE_B_R_DATA:.+]], %[[MEMORY_B_R_DATA]] :
     // ---------------------------------------------------------------------------------
     // Write Ports
     // CHECK-NEXT: %[[MEMORY_A_W_ADDR:.+]] = firrtl.subfield %[[MEMORY_A_W]][addr]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_W_ADDR]], %[[MEMORY_W_ADDR:.+]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_A_W_ADDR]], %[[MEMORY_W_ADDR:.+]] :
     // CHECK-NEXT: %[[MEMORY_B_W_ADDR:.+]] = firrtl.subfield %[[MEMORY_B_W]][addr]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_W_ADDR]], %[[MEMORY_W_ADDR]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_B_W_ADDR]], %[[MEMORY_W_ADDR]] :
     // CHECK-NEXT: %[[MEMORY_A_W_EN:.+]] = firrtl.subfield %[[MEMORY_A_W]][en]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_W_EN]], %[[MEMORY_W_EN:.+]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_A_W_EN]], %[[MEMORY_W_EN:.+]] :
     // CHECK-NEXT: %[[MEMORY_B_W_EN:.+]] = firrtl.subfield %[[MEMORY_B_W]][en]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_W_EN]], %[[MEMORY_W_EN]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_B_W_EN]], %[[MEMORY_W_EN]] :
     // CHECK-NEXT: %[[MEMORY_A_W_CLK:.+]] = firrtl.subfield %[[MEMORY_A_W]][clk]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_W_CLK]], %[[MEMORY_W_CLK:.+]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_A_W_CLK]], %[[MEMORY_W_CLK:.+]] :
     // CHECK-NEXT: %[[MEMORY_B_W_CLK:.+]] = firrtl.subfield %[[MEMORY_B_W]][clk]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_W_CLK]], %[[MEMORY_W_CLK]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_B_W_CLK]], %[[MEMORY_W_CLK]] :
     // CHECK-NEXT: %[[MEMORY_A_W_DATA:.+]] = firrtl.subfield %[[MEMORY_A_W]][data]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_W_DATA]], %[[WIRE_A_W_DATA:.+]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_A_W_DATA]], %[[WIRE_A_W_DATA:.+]] :
     // CHECK-NEXT: %[[MEMORY_B_W_DATA:.+]] = firrtl.subfield %[[MEMORY_B_W]][data]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_W_DATA]], %[[WIRE_B_W_DATA:.+]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_B_W_DATA]], %[[WIRE_B_W_DATA:.+]] :
     // CHECK-NEXT: %[[MEMORY_A_W_MASK:.+]] = firrtl.subfield %[[MEMORY_A_W]][mask]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_A_W_MASK]], %[[WIRE_A_W_MASK:.+]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_A_W_MASK]], %[[WIRE_A_W_MASK:.+]] :
     // CHECK-NEXT: %[[MEMORY_B_W_MASK:.+]] = firrtl.subfield %[[MEMORY_B_W]][mask]
-    // CHECK-NEXT: firrtl.strictconnect %[[MEMORY_B_W_MASK]], %[[WIRE_B_W_MASK:.+]] :
+    // CHECK-NEXT: firrtl.matchingconnect %[[MEMORY_B_W_MASK]], %[[WIRE_B_W_MASK:.+]] :
     //
     // Connections to module ports
     // CHECK-NEXT: firrtl.connect %[[MEMORY_R_CLK]], %clock
     // CHECK-NEXT: firrtl.connect %[[MEMORY_R_EN]], %rEn
     // CHECK-NEXT: firrtl.connect %[[MEMORY_R_ADDR]], %rAddr
-    // CHECK-NEXT: firrtl.strictconnect %rData_a, %[[WIRE_A_R_DATA]]
-    // CHECK-NEXT: firrtl.strictconnect %rData_b, %[[WIRE_B_R_DATA]]
+    // CHECK-NEXT: firrtl.matchingconnect %rData_a, %[[WIRE_A_R_DATA]]
+    // CHECK-NEXT: firrtl.matchingconnect %rData_b, %[[WIRE_B_R_DATA]]
     // CHECK-NEXT: firrtl.connect %[[MEMORY_W_CLK]], %clock
     // CHECK-NEXT: firrtl.connect %[[MEMORY_W_EN]], %wEn
     // CHECK-NEXT: firrtl.connect %[[MEMORY_W_ADDR]], %wAddr
-    // CHECK-NEXT: firrtl.strictconnect %[[WIRE_A_W_MASK]], %wMask_a
-    // CHECK-NEXT: firrtl.strictconnect %[[WIRE_B_W_MASK]], %wMask_b
-    // CHECK-NEXT: firrtl.strictconnect %[[WIRE_A_W_DATA]], %wData_a
-    // CHECK-NEXT: firrtl.strictconnect %[[WIRE_B_W_DATA]], %wData_b
+    // CHECK-NEXT: firrtl.matchingconnect %[[WIRE_A_W_MASK]], %wMask_a
+    // CHECK-NEXT: firrtl.matchingconnect %[[WIRE_B_W_MASK]], %wMask_b
+    // CHECK-NEXT: firrtl.matchingconnect %[[WIRE_A_W_DATA]], %wData_a
+    // CHECK-NEXT: firrtl.matchingconnect %[[WIRE_B_W_DATA]], %wData_b
   }
 
 
@@ -257,7 +257,7 @@ firrtl.circuit "TopLevel" {
 //CHECK-NEXT:      %invalid_clock = firrtl.invalidvalue : !firrtl.clock
 //CHECK-NEXT:      firrtl.connect %U0_clock, %invalid_clock : !firrtl.clock, !firrtl.clock
 //CHECK-NEXT:      %invalid_ui14 = firrtl.invalidvalue : !firrtl.uint<14>
-//CHECK-NEXT:      firrtl.strictconnect %U0_inp_a_inp_d, %invalid_ui14 : !firrtl.uint<14>
+//CHECK-NEXT:      firrtl.matchingconnect %U0_inp_a_inp_d, %invalid_ui14 : !firrtl.uint<14>
 
 //AGGREGATE-LABEL: firrtl.module private @mod_2(in %clock: !firrtl.clock, in %inp_a: !firrtl.bundle<inp_d: uint<14>>)
 //AGGREGATE:    firrtl.module private @top_mod(in %clock: !firrtl.clock)
@@ -267,7 +267,7 @@ firrtl.circuit "TopLevel" {
 //AGGREGATE-NEXT:  %invalid = firrtl.invalidvalue : !firrtl.bundle<inp_d: uint<14>>
 //AGGREGATE-NEXT:  %0 = firrtl.subfield %invalid[inp_d] : !firrtl.bundle<inp_d: uint<14>>
 //AGGREGATE-NEXT:  %1 = firrtl.subfield %U0_inp_a[inp_d] : !firrtl.bundle<inp_d: uint<14>>
-//AGGREGATE-NEXT:  firrtl.strictconnect %1, %0 : !firrtl.uint<14>
+//AGGREGATE-NEXT:  firrtl.matchingconnect %1, %0 : !firrtl.uint<14>
 //SIG-LABEL: firrtl.module private @mod_2(in %clock: !firrtl.clock, in %inp_a: !firrtl.bundle<inp_d: uint<14>>)
 //SIG:    firrtl.module private @top_mod(in %clock: !firrtl.clock)
 
@@ -293,7 +293,7 @@ firrtl.circuit "TopLevel" {
     // COMMON-LABEL: firrtl.module private @MuxBundle
     firrtl.module private @MuxBundle(in %p: !firrtl.uint<1>, in %a: !firrtl.bundle<a: uint<1>>, in %b: !firrtl.bundle<a: uint<1>>, out %c: !firrtl.bundle<a: uint<1>>) {
       // CHECK-NEXT: %0 = firrtl.mux(%p, %a_a, %b_a) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-      // CHECK-NEXT: firrtl.strictconnect %c_a, %0 : !firrtl.uint<1>
+      // CHECK-NEXT: firrtl.matchingconnect %c_a, %0 : !firrtl.uint<1>
       // SIG:        firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>) -> !firrtl.bundle<a: uint<1>>
       %0 = firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>) -> !firrtl.bundle<a: uint<1>>
       firrtl.connect %c, %0 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
@@ -327,8 +327,8 @@ firrtl.circuit "TopLevel" {
     // CHECK-LABEL: firrtl.module private @RegBundleWithBulkConnect(in %a_a: !firrtl.uint<1>, in %clk: !firrtl.clock, out %b_a: !firrtl.uint<1>)
     firrtl.module private @RegBundleWithBulkConnect(in %a: !firrtl.bundle<a: uint<1>>, in %clk: !firrtl.clock, out %b: !firrtl.bundle<a: uint<1>>) {
       // CHECK-NEXT: %x_a = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<1>
-      // CHECK-NEXT: firrtl.strictconnect %x_a, %a_a : !firrtl.uint<1>
-      // CHECK-NEXT: firrtl.strictconnect %b_a, %x_a : !firrtl.uint<1>
+      // CHECK-NEXT: firrtl.matchingconnect %x_a, %a_a : !firrtl.uint<1>
+      // CHECK-NEXT: firrtl.matchingconnect %b_a, %x_a : !firrtl.uint<1>
       %x = firrtl.reg %clk {name = "x"} : !firrtl.clock, !firrtl.bundle<a: uint<1>>
       firrtl.connect %x, %a : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
       firrtl.connect %b, %x : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
@@ -355,13 +355,13 @@ firrtl.circuit "TopLevel" {
     // CHECK: %w_ready = firrtl.wire  : !firrtl.uint<1>
     // CHECK: %w_data = firrtl.wire  : !firrtl.uint<64>
     %w = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
-    // CHECK: firrtl.strictconnect %w_valid, %source_valid : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %source_ready, %w_ready : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %w_data, %source_data : !firrtl.uint<64>
+    // CHECK: firrtl.matchingconnect %w_valid, %source_valid : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %source_ready, %w_ready : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %w_data, %source_data : !firrtl.uint<64>
     firrtl.connect %w, %source : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
-    // CHECK: firrtl.strictconnect %sink_valid, %w_valid : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %w_ready, %sink_ready : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %sink_data, %w_data : !firrtl.uint<64>
+    // CHECK: firrtl.matchingconnect %sink_valid, %w_valid : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %w_ready, %sink_ready : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %sink_data, %w_data : !firrtl.uint<64>
     firrtl.connect %sink, %w : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>, !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
   }
 
@@ -370,24 +370,24 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %b, %a: !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
   // CHECK-LABEL: firrtl.module private @LowerVectors(in %a_0: !firrtl.uint<1>, in %a_1: !firrtl.uint<1>, out %b_0: !firrtl.uint<1>, out %b_1: !firrtl.uint<1>)
-  // CHECK: firrtl.strictconnect %b_0, %a_0
-  // CHECK: firrtl.strictconnect %b_1, %a_1
+  // CHECK: firrtl.matchingconnect %b_0, %a_0
+  // CHECK: firrtl.matchingconnect %b_1, %a_1
   // AGGREGATE-LABEL: firrtl.module private @LowerVectors(in %a: !firrtl.vector<uint<1>, 2>, out %b: !firrtl.vector<uint<1>, 2>)
   // AGGREGATE-NEXT: %0 = firrtl.subindex %a[0] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT: %1 = firrtl.subindex %b[0] : !firrtl.vector<uint<1>, 2>
-  // AGGREGATE-NEXT: firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+  // AGGREGATE-NEXT: firrtl.matchingconnect %1, %0 : !firrtl.uint<1>
   // AGGREGATE-NEXT: %2 = firrtl.subindex %a[1] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT: %3 = firrtl.subindex %b[1] : !firrtl.vector<uint<1>, 2>
-  // AGGREGATE-NEXT: firrtl.strictconnect %3, %2 : !firrtl.uint<1>
+  // AGGREGATE-NEXT: firrtl.matchingconnect %3, %2 : !firrtl.uint<1>
 
 // Test vector of bundles lowering
   // COMMON-LABEL: firrtl.module private @LowerVectorsOfBundles(in %in_0_a: !firrtl.uint<1>, out %in_0_b: !firrtl.uint<1>, in %in_1_a: !firrtl.uint<1>, out %in_1_b: !firrtl.uint<1>, out %out_0_a: !firrtl.uint<1>, in %out_0_b: !firrtl.uint<1>, out %out_1_a: !firrtl.uint<1>, in %out_1_b: !firrtl.uint<1>)
   firrtl.module private @LowerVectorsOfBundles(in %in: !firrtl.vector<bundle<a : uint<1>, b  flip: uint<1>>, 2>,
                                        out %out: !firrtl.vector<bundle<a : uint<1>, b  flip: uint<1>>, 2>) {
-    // LT:      firrtl.strictconnect %out_0_a, %in_0_a : !firrtl.uint<1>
-    // LT-NEXT: firrtl.strictconnect %in_0_b, %out_0_b : !firrtl.uint<1>
-    // LT-NEXT: firrtl.strictconnect %out_1_a, %in_1_a : !firrtl.uint<1>
-    // LT-NEXT: firrtl.strictconnect %in_1_b, %out_1_b : !firrtl.uint<1>
+    // LT:      firrtl.matchingconnect %out_0_a, %in_0_a : !firrtl.uint<1>
+    // LT-NEXT: firrtl.matchingconnect %in_0_b, %out_0_b : !firrtl.uint<1>
+    // LT-NEXT: firrtl.matchingconnect %out_1_a, %in_1_a : !firrtl.uint<1>
+    // LT-NEXT: firrtl.matchingconnect %in_1_b, %out_1_b : !firrtl.uint<1>
     firrtl.connect %out, %in: !firrtl.vector<bundle<a : uint<1>, b flip: uint<1>>, 2>, !firrtl.vector<bundle<a : uint<1>, b flip: uint<1>>, 2>
   }
 
@@ -418,10 +418,10 @@ firrtl.circuit "TopLevel" {
   // CHECK:   firrtl.connect %init_1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   %r_0 = firrtl.regreset %clock, %reset, %init_0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   %r_1 = firrtl.regreset %clock, %reset, %init_1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   firrtl.strictconnect %r_0, %a_d_0 : !firrtl.uint<1>
-  // CHECK:   firrtl.strictconnect %r_1, %a_d_1 : !firrtl.uint<1>
-  // CHECK:   firrtl.strictconnect %a_q_0, %r_0 : !firrtl.uint<1>
-  // CHECK:   firrtl.strictconnect %a_q_1, %r_1 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %r_0, %a_d_0 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %r_1, %a_d_1 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %a_q_0, %r_0 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %a_q_1, %r_1 : !firrtl.uint<1>
   // AGGREGATE:       %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   // AGGREGATE-NEXT:  %init = firrtl.wire  : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  %0 = firrtl.subindex %init[0] : !firrtl.vector<uint<1>, 2>
@@ -431,16 +431,16 @@ firrtl.circuit "TopLevel" {
   // AGGREGATE-NEXT:  %r = firrtl.regreset %clock, %reset, %init  : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  %2 = firrtl.subindex %a_d[0] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  %3 = firrtl.subindex %r[0] : !firrtl.vector<uint<1>, 2>
-  // AGGREGATE-NEXT:  firrtl.strictconnect %3, %2 : !firrtl.uint<1>
+  // AGGREGATE-NEXT:  firrtl.matchingconnect %3, %2 : !firrtl.uint<1>
   // AGGREGATE-NEXT:  %4 = firrtl.subindex %a_d[1] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  %5 = firrtl.subindex %r[1] : !firrtl.vector<uint<1>, 2>
-  // AGGREGATE-NEXT:  firrtl.strictconnect %5, %4 : !firrtl.uint<1>
+  // AGGREGATE-NEXT:  firrtl.matchingconnect %5, %4 : !firrtl.uint<1>
   // AGGREGATE-NEXT:  %6 = firrtl.subindex %r[0] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  %7 = firrtl.subindex %a_q[0] : !firrtl.vector<uint<1>, 2>
-  // AGGREGATE-NEXT:  firrtl.strictconnect %7, %6 : !firrtl.uint<1>
+  // AGGREGATE-NEXT:  firrtl.matchingconnect %7, %6 : !firrtl.uint<1>
   // AGGREGATE-NEXT:  %8 = firrtl.subindex %r[1] : !firrtl.vector<uint<1>, 2>
   // AGGREGATE-NEXT:  %9 = firrtl.subindex %a_q[1] : !firrtl.vector<uint<1>, 2>
-  // AGGREGATE-NEXT:  firrtl.strictconnect %9, %8 : !firrtl.uint<1>
+  // AGGREGATE-NEXT:  firrtl.matchingconnect %9, %8 : !firrtl.uint<1>
 
 // Test RegResetOp lowering without name attribute
 // https://github.com/llvm/circt/issues/795
@@ -463,10 +463,10 @@ firrtl.circuit "TopLevel" {
   // CHECK:   firrtl.connect %init_1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   %0 = firrtl.regreset %clock, %reset, %init_0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   %1 = firrtl.regreset %clock, %reset, %init_1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-  // CHECK:   firrtl.strictconnect %0, %a_d_0 : !firrtl.uint<1>
-  // CHECK:   firrtl.strictconnect %1, %a_d_1 : !firrtl.uint<1>
-  // CHECK:   firrtl.strictconnect %a_q_0, %0 : !firrtl.uint<1>
-  // CHECK:   firrtl.strictconnect %a_q_1, %1 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %0, %a_d_0 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %1, %a_d_1 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %a_q_0, %0 : !firrtl.uint<1>
+  // CHECK:   firrtl.matchingconnect %a_q_1, %1 : !firrtl.uint<1>
 
 // Test RegOp lowering without name attribute
 // https://github.com/llvm/circt/issues/795
@@ -478,10 +478,10 @@ firrtl.circuit "TopLevel" {
   }
  // CHECK:    %0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
  // CHECK:    %1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
- // CHECK:    firrtl.strictconnect %0, %a_d_0 : !firrtl.uint<1>
- // CHECK:    firrtl.strictconnect %1, %a_d_1 : !firrtl.uint<1>
- // CHECK:    firrtl.strictconnect %a_q_0, %0 : !firrtl.uint<1>
- // CHECK:    firrtl.strictconnect %a_q_1, %1 : !firrtl.uint<1>
+ // CHECK:    firrtl.matchingconnect %0, %a_d_0 : !firrtl.uint<1>
+ // CHECK:    firrtl.matchingconnect %1, %a_d_1 : !firrtl.uint<1>
+ // CHECK:    firrtl.matchingconnect %a_q_0, %0 : !firrtl.uint<1>
+ // CHECK:    firrtl.matchingconnect %a_q_1, %1 : !firrtl.uint<1>
 
 // Test that InstanceOp Annotations are copied to the new instance.
   firrtl.module private @Bar(out %a: !firrtl.vector<uint<1>, 2>) {
@@ -542,19 +542,19 @@ firrtl.circuit "TopLevel" {
                          out %out : !firrtl.bundle<a: uint<1>, b: uint<1>>) {
     // No else region.
     firrtl.when %p : !firrtl.uint<1> {
-      // CHECK: firrtl.strictconnect %out_a, %in_a : !firrtl.uint<1>
-      // CHECK: firrtl.strictconnect %out_b, %in_b : !firrtl.uint<1>
+      // CHECK: firrtl.matchingconnect %out_a, %in_a : !firrtl.uint<1>
+      // CHECK: firrtl.matchingconnect %out_b, %in_b : !firrtl.uint<1>
       firrtl.connect %out, %in : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
     }
 
     // Else region.
     firrtl.when %p : !firrtl.uint<1> {
-      // CHECK: firrtl.strictconnect %out_a, %in_a : !firrtl.uint<1>
-      // CHECK: firrtl.strictconnect %out_b, %in_b : !firrtl.uint<1>
+      // CHECK: firrtl.matchingconnect %out_a, %in_a : !firrtl.uint<1>
+      // CHECK: firrtl.matchingconnect %out_b, %in_b : !firrtl.uint<1>
       firrtl.connect %out, %in : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
     } else {
-      // CHECK: firrtl.strictconnect %out_a, %in_a : !firrtl.uint<1>
-      // CHECK: firrtl.strictconnect %out_b, %in_b : !firrtl.uint<1>
+      // CHECK: firrtl.matchingconnect %out_a, %in_a : !firrtl.uint<1>
+      // CHECK: firrtl.matchingconnect %out_b, %in_b : !firrtl.uint<1>
       firrtl.connect %out, %in : !firrtl.bundle<a: uint<1>, b: uint<1>>, !firrtl.bundle<a: uint<1>, b: uint<1>>
     }
   }
@@ -634,12 +634,12 @@ firrtl.circuit "TopLevel" {
     // CHECK-NEXT:  %ax_a_a = firrtl.wire
     firrtl.connect %a, %ax : !firrtl.bundle<a: bundle<a: uint<1>>>, !firrtl.bundle<a: bundle<a: uint<1>>>
     // a <= ax
-    // CHECK-NEXT: firrtl.strictconnect %a_a_a, %ax_a_a : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %a_a_a, %ax_a_a : !firrtl.uint<1>
     %0 = firrtl.subfield %a[a] : !firrtl.bundle<a: bundle<a: uint<1>>>
     %1 = firrtl.subfield %ax[a] : !firrtl.bundle<a: bundle<a: uint<1>>>
     firrtl.connect %0, %1 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
     // a.a <= ax.a
-    // CHECK: firrtl.strictconnect %a_a_a, %ax_a_a : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %a_a_a, %ax_a_a : !firrtl.uint<1>
     %2 = firrtl.subfield %a[a] : !firrtl.bundle<a: bundle<a: uint<1>>>
     %3 = firrtl.subfield %2[a] : !firrtl.bundle<a: uint<1>>
     %4 = firrtl.subfield %ax[a] : !firrtl.bundle<a: bundle<a: uint<1>>>
@@ -653,12 +653,12 @@ firrtl.circuit "TopLevel" {
     // CHECK: %bx_a_a = firrtl.wire
     firrtl.connect %b, %bx : !firrtl.bundle<a: bundle<a flip: uint<1>>>, !firrtl.bundle<a: bundle<a flip: uint<1>>>
     // b <= bx
-    // CHECK: firrtl.strictconnect %bx_a_a, %b_a_a
+    // CHECK: firrtl.matchingconnect %bx_a_a, %b_a_a
     %6 = firrtl.subfield %b[a] : !firrtl.bundle<a: bundle<a flip: uint<1>>>
     %7 = firrtl.subfield %bx[a] : !firrtl.bundle<a: bundle<a flip: uint<1>>>
     firrtl.connect %6, %7 : !firrtl.bundle<a flip: uint<1>>, !firrtl.bundle<a flip: uint<1>>
     // b.a <= bx.a
-    // CHECK: firrtl.strictconnect %bx_a_a, %b_a_a
+    // CHECK: firrtl.matchingconnect %bx_a_a, %b_a_a
     %8 = firrtl.subfield %b[a] : !firrtl.bundle<a: bundle<a flip: uint<1>>>
     %9 = firrtl.subfield %8[a] : !firrtl.bundle<a flip: uint<1>>
     %10 = firrtl.subfield %bx[a] : !firrtl.bundle<a: bundle<a flip: uint<1>>>
@@ -672,12 +672,12 @@ firrtl.circuit "TopLevel" {
     // CHECK-NEXT: %cx_a_a = firrtl.wire : !firrtl.uint<1>
     firrtl.connect %c, %cx : !firrtl.bundle<a flip: bundle<a: uint<1>>>, !firrtl.bundle<a flip: bundle<a: uint<1>>>
     // c <= cx
-    // CHECK: firrtl.strictconnect %cx_a_a, %c_a_a
+    // CHECK: firrtl.matchingconnect %cx_a_a, %c_a_a
     %12 = firrtl.subfield %c[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
     %13 = firrtl.subfield %cx[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
     firrtl.connect %12, %13 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
     // c.a <= cx.a
-    // CHECK: firrtl.strictconnect %c_a_a, %cx_a_a
+    // CHECK: firrtl.matchingconnect %c_a_a, %cx_a_a
     %14 = firrtl.subfield %c[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
     %15 = firrtl.subfield %14[a] : !firrtl.bundle<a: uint<1>>
     %16 = firrtl.subfield %cx[a] : !firrtl.bundle<a flip: bundle<a: uint<1>>>
@@ -691,12 +691,12 @@ firrtl.circuit "TopLevel" {
     // CHECK-NEXT: %dx_a_a = firrtl.wire : !firrtl.uint<1>
     firrtl.connect %d, %dx : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>, !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
     // d <= dx
-    // CHECK: firrtl.strictconnect %d_a_a, %dx_a_a
+    // CHECK: firrtl.matchingconnect %d_a_a, %dx_a_a
     %18 = firrtl.subfield %d[a] : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
     %19 = firrtl.subfield %dx[a] : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
     firrtl.connect %18, %19 : !firrtl.bundle<a flip: uint<1>>, !firrtl.bundle<a flip: uint<1>>
     // d.a <= dx.a
-    // CHECK: firrtl.strictconnect %dx_a_a, %d_a_a
+    // CHECK: firrtl.matchingconnect %dx_a_a, %d_a_a
     %20 = firrtl.subfield %d[a] : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
     %21 = firrtl.subfield %20[a] : !firrtl.bundle<a flip: uint<1>>
     %22 = firrtl.subfield %dx[a] : !firrtl.bundle<a flip: bundle<a flip: uint<1>>>
@@ -788,17 +788,17 @@ firrtl.circuit "TopLevel" {
     firrtl.connect %0, %b : !firrtl.uint<1>, !firrtl.uint<1>
   }
 // CHECK-LABEL:    firrtl.module private @write1D(in %b: !firrtl.uint<1>, in %sel: !firrtl.uint<2>, in %default_0: !firrtl.uint<1>, in %default_1: !firrtl.uint<1>, out %a_0: !firrtl.uint<1>, out %a_1: !firrtl.uint<1>) {
-// CHECK-NEXT:      firrtl.strictconnect %a_0, %default_0 : !firrtl.uint<1>
-// CHECK-NEXT:      firrtl.strictconnect %a_1, %default_1 : !firrtl.uint<1>
+// CHECK-NEXT:      firrtl.matchingconnect %a_0, %default_0 : !firrtl.uint<1>
+// CHECK-NEXT:      firrtl.matchingconnect %a_1, %default_1 : !firrtl.uint<1>
 // CHECK-NEXT:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %0 : !firrtl.uint<1> {
-// CHECK-NEXT:        firrtl.strictconnect %a_0, %b : !firrtl.uint<1>
+// CHECK-NEXT:        firrtl.matchingconnect %a_0, %b : !firrtl.uint<1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 // CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %1 : !firrtl.uint<1> {
-// CHECK-NEXT:        firrtl.strictconnect %a_1, %b : !firrtl.uint<1>
+// CHECK-NEXT:        firrtl.matchingconnect %a_1, %b : !firrtl.uint<1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 
@@ -823,12 +823,12 @@ firrtl.circuit "TopLevel" {
 // CHECK-NEXT:        %c0_ui1_0 = firrtl.constant 0 : !firrtl.uint<1>
 // CHECK-NEXT:        %2 = firrtl.eq %sel, %c0_ui1_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:        firrtl.when %2 : !firrtl.uint<1> {
-// CHECK-NEXT:          firrtl.strictconnect %a_0_0, %b : !firrtl.uint<2>
+// CHECK-NEXT:          firrtl.matchingconnect %a_0_0, %b : !firrtl.uint<2>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %c1_ui1_1 = firrtl.constant 1 : !firrtl.uint<1>
 // CHECK-NEXT:        %3 = firrtl.eq %sel, %c1_ui1_1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:        firrtl.when %3 : !firrtl.uint<1> {
-// CHECK-NEXT:          firrtl.strictconnect %a_0_1, %b : !firrtl.uint<2>
+// CHECK-NEXT:          firrtl.matchingconnect %a_0_1, %b : !firrtl.uint<2>
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
@@ -837,12 +837,12 @@ firrtl.circuit "TopLevel" {
 // CHECK-NEXT:        %c0_ui1_0 = firrtl.constant 0 : !firrtl.uint<1>
 // CHECK-NEXT:        %2 = firrtl.eq %sel, %c0_ui1_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:        firrtl.when %2 : !firrtl.uint<1> {
-// CHECK-NEXT:          firrtl.strictconnect %a_1_0, %b : !firrtl.uint<2>
+// CHECK-NEXT:          firrtl.matchingconnect %a_1_0, %b : !firrtl.uint<2>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %c1_ui1_1 = firrtl.constant 1 : !firrtl.uint<1>
 // CHECK-NEXT:        %3 = firrtl.eq %sel, %c1_ui1_1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:        firrtl.when %3 : !firrtl.uint<1> {
-// CHECK-NEXT:          firrtl.strictconnect %a_1_1, %b : !firrtl.uint<2>
+// CHECK-NEXT:          firrtl.matchingconnect %a_1_1, %b : !firrtl.uint<2>
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
@@ -865,19 +865,19 @@ firrtl.circuit "TopLevel" {
   }
 
 // CHECK-LABEL:    firrtl.module private @writeVectorOfBundle1D(in %a_wo: !firrtl.uint<1>, in %a_valid: !firrtl.uint<2>, in %def_0_wo: !firrtl.uint<1>, in %def_0_valid: !firrtl.uint<2>, in %def_1_wo: !firrtl.uint<1>, in %def_1_valid: !firrtl.uint<2>, in %sel: !firrtl.uint<2>, out %b_0_wo: !firrtl.uint<1>, out %b_0_valid: !firrtl.uint<2>, out %b_1_wo: !firrtl.uint<1>, out %b_1_valid: !firrtl.uint<2>) {
-// CHECK-NEXT:      firrtl.strictconnect %b_0_wo, %def_0_wo : !firrtl.uint<1>
-// CHECK-NEXT:      firrtl.strictconnect %b_0_valid, %def_0_valid : !firrtl.uint<2>
-// CHECK-NEXT:      firrtl.strictconnect %b_1_wo, %def_1_wo : !firrtl.uint<1>
-// CHECK-NEXT:      firrtl.strictconnect %b_1_valid, %def_1_valid : !firrtl.uint<2>
+// CHECK-NEXT:      firrtl.matchingconnect %b_0_wo, %def_0_wo : !firrtl.uint<1>
+// CHECK-NEXT:      firrtl.matchingconnect %b_0_valid, %def_0_valid : !firrtl.uint<2>
+// CHECK-NEXT:      firrtl.matchingconnect %b_1_wo, %def_1_wo : !firrtl.uint<1>
+// CHECK-NEXT:      firrtl.matchingconnect %b_1_valid, %def_1_valid : !firrtl.uint<2>
 // CHECK-NEXT:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
 // CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %0 : !firrtl.uint<1> {
-// CHECK-NEXT:        firrtl.strictconnect %b_0_wo, %a_wo : !firrtl.uint<1>
+// CHECK-NEXT:        firrtl.matchingconnect %b_0_wo, %a_wo : !firrtl.uint<1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 // CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %1 : !firrtl.uint<1> {
-// CHECK-NEXT:        firrtl.strictconnect %b_1_wo, %a_wo : !firrtl.uint<1>
+// CHECK-NEXT:        firrtl.matchingconnect %b_1_wo, %a_wo : !firrtl.uint<1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 
@@ -1010,9 +1010,9 @@ firrtl.module private @is1436_FOO() {
     // CHECK-NEXT:  %d_ready = firrtl.wire  : !firrtl.uint<1>
     // CHECK-NEXT:  %d_data = firrtl.wire  : !firrtl.uint<2>
     firrtl.connect %d , %c: !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<2>>, !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<2>>
-    // CHECK-NEXT:  firrtl.strictconnect %d_valid, %[[v3]] : !firrtl.uint<1>
-    // CHECK-NEXT:  firrtl.strictconnect %d_ready, %[[v4]] : !firrtl.uint<1>
-    // CHECK-NEXT:  firrtl.strictconnect %d_data, %[[v5]] : !firrtl.uint<2>
+    // CHECK-NEXT:  firrtl.matchingconnect %d_valid, %[[v3]] : !firrtl.uint<1>
+    // CHECK-NEXT:  firrtl.matchingconnect %d_ready, %[[v4]] : !firrtl.uint<1>
+    // CHECK-NEXT:  firrtl.matchingconnect %d_data, %[[v5]] : !firrtl.uint<2>
     %e = firrtl.bitcast %d : (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<2>>) -> (!firrtl.bundle<addr: uint<2>, data : vector<uint<1>, 2>>)
     // CHECK-NEXT:  %[[v6:.+]] = firrtl.cat %d_ready, %d_valid : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
     // CHECK-NEXT:  %[[v7:.+]] = firrtl.cat %d_data, %[[v6]] : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
@@ -1035,10 +1035,10 @@ firrtl.module private @is1436_FOO() {
    //CHECK: %[[d2_valid_aa:.+]] = firrtl.wire  : !firrtl.uint<1>
    //CHECK: %[[d2_ready:.+]] = firrtl.wire  : !firrtl.uint<1>
    //CHECK: %[[d2_data:.+]] = firrtl.wire  : !firrtl.uint<1>
-   //CHECK: firrtl.strictconnect %[[d2_valid_re_a]], %[[v14]] : !firrtl.uint<1>
-   //CHECK: firrtl.strictconnect %[[d2_valid_aa]], %[[v15]] : !firrtl.uint<1>
-   //CHECK: firrtl.strictconnect %[[d2_ready]], %[[v16]] : !firrtl.uint<1>
-   //CHECK: firrtl.strictconnect %[[d2_data]], %[[v17]] : !firrtl.uint<1>
+   //CHECK: firrtl.matchingconnect %[[d2_valid_re_a]], %[[v14]] : !firrtl.uint<1>
+   //CHECK: firrtl.matchingconnect %[[d2_valid_aa]], %[[v15]] : !firrtl.uint<1>
+   //CHECK: firrtl.matchingconnect %[[d2_ready]], %[[v16]] : !firrtl.uint<1>
+   //CHECK: firrtl.matchingconnect %[[d2_data]], %[[v17]] : !firrtl.uint<1>
 
   }
 
@@ -1098,9 +1098,9 @@ firrtl.module private @is1436_FOO() {
     %1 = firrtl.ref.resolve %0 : !firrtl.probe<vector<uint<1>, 2>>
     // CHECK:  %2 = firrtl.ref.resolve %0 : !firrtl.probe<uint<1>>
     // CHECK:  %3 = firrtl.ref.resolve %1 : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %c, %1 : !firrtl.vector<uint<1>, 2>
-    // CHECK:  firrtl.strictconnect %c_0, %2 : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %c_1, %3 : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %1 : !firrtl.vector<uint<1>, 2>
+    // CHECK:  firrtl.matchingconnect %c_0, %2 : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %c_1, %3 : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: firrtl.module private @RefTypeBV_RW
@@ -1128,12 +1128,12 @@ firrtl.module private @is1436_FOO() {
     // CHECK-NEXT: %[[X_REF_A:.+]] = firrtl.ref.sub %[[X_REF]][0]
     // CHECK-NEXT: %[[X_A:.+]] = firrtl.ref.resolve %[[X_REF_A]]
     // CHECK-NEXT: %[[v_0:.+]] = firrtl.subindex %[[X_A]][0]
-    // CHECK-NEXT: firrtl.strictconnect %vec_0, %[[v_0]]
+    // CHECK-NEXT: firrtl.matchingconnect %vec_0, %[[v_0]]
     // CHECK-NEXT: %[[v_1:.+]] = firrtl.subindex %[[X_A]][1]
-    // CHECK-NEXT: firrtl.strictconnect %vec_1, %[[v_1]]
+    // CHECK-NEXT: firrtl.matchingconnect %vec_1, %[[v_1]]
     %x_ref_a = firrtl.ref.sub %x_ref[0] : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
     %x_a = firrtl.ref.resolve %x_ref_a : !firrtl.rwprobe<vector<uint<1>, 2>>
-    firrtl.strictconnect %vec, %x_a : !firrtl.vector<uint<1>, 2>
+    firrtl.matchingconnect %vec, %x_a : !firrtl.vector<uint<1>, 2>
 
     // Check chained ref.sub's work.
     // CHECK-NEXT: %[[X_A_1_REF:.+]] = firrtl.ref.sub %[[X_REF_A]][1]
@@ -1174,11 +1174,11 @@ firrtl.module private @is1436_FOO() {
 
     // Check resolve of rwprobe is preserved.
     // CHECK-NEXT: = firrtl.ref.resolve %[[X_REF]]
-    // CHECK: firrtl.strictconnect %bov_a_0,
-    // CHECK: firrtl.strictconnect %bov_a_1,
-    // CHECK: firrtl.strictconnect %bov_b,
+    // CHECK: firrtl.matchingconnect %bov_a_0,
+    // CHECK: firrtl.matchingconnect %bov_a_1,
+    // CHECK: firrtl.matchingconnect %bov_b,
     %x_read = firrtl.ref.resolve %x_ref : !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
-    firrtl.strictconnect %bov, %x_read : !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
+    firrtl.matchingconnect %bov, %x_read : !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
     // CHECK-NEXT: }
   }
   // Check how rwprobe's of aggregates in instances are handled.
@@ -1222,15 +1222,15 @@ firrtl.module private @is1436_FOO() {
   firrtl.module @MergeBundle(out %o: !firrtl.bundle<valid: uint<1>, ready: uint<1>>, in %i: !firrtl.uint<1>)
   {
     %a = firrtl.wire   : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
-    firrtl.strictconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+    firrtl.matchingconnect %o, %a : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
     %0 = firrtl.bundlecreate %i, %i : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.bundle<valid: uint<1>, ready: uint<1>>
-    firrtl.strictconnect %a, %0 : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
+    firrtl.matchingconnect %a, %0 : !firrtl.bundle<valid: uint<1>, ready: uint<1>>
     // CHECK:  %a_valid = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  %a_ready = firrtl.wire   : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %o_valid, %a_valid : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %o_ready, %a_ready : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %a_valid, %i : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %a_ready, %i : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %o_valid, %a_valid : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %o_ready, %a_ready : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %a_valid, %i : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %a_ready, %i : !firrtl.uint<1>
     // AGGREGATE: firrtl.bundlecreate
     // SIG: firrtl.bundlecreate
   }
@@ -1238,18 +1238,18 @@ firrtl.module private @is1436_FOO() {
   // COMMON-LABEL: firrtl.module @MergeVector
   firrtl.module @MergeVector(out %o: !firrtl.vector<uint<1>, 3>, in %i: !firrtl.uint<1>) {
     %a = firrtl.wire   : !firrtl.vector<uint<1>, 3>
-    firrtl.strictconnect %o, %a : !firrtl.vector<uint<1>, 3>
+    firrtl.matchingconnect %o, %a : !firrtl.vector<uint<1>, 3>
     %0 = firrtl.vectorcreate %i, %i, %i : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 3>
-    firrtl.strictconnect %a, %0 : !firrtl.vector<uint<1>, 3>
+    firrtl.matchingconnect %a, %0 : !firrtl.vector<uint<1>, 3>
     // CHECK:  %a_0 = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  %a_1 = firrtl.wire   : !firrtl.uint<1>
     // CHECK:  %a_2 = firrtl.wire   : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %o_0, %a_0 : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %o_1, %a_1 : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %o_2, %a_2 : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %a_0, %i : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %a_1, %i : !firrtl.uint<1>
-    // CHECK:  firrtl.strictconnect %a_2, %i : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %o_0, %a_0 : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %o_1, %a_1 : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %o_2, %a_2 : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %a_0, %i : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %a_1, %i : !firrtl.uint<1>
+    // CHECK:  firrtl.matchingconnect %a_2, %i : !firrtl.uint<1>
     // AGGREGATE: firrtl.vectorcreate
     // SIG: firrtl.vectorcreate
   }
@@ -1273,11 +1273,11 @@ firrtl.module private @is1436_FOO() {
   // COMMON-LABEL: firrtl.module @ElementWise
   firrtl.module @ElementWise(in %a: !firrtl.vector<uint<1>, 1>, in %b: !firrtl.vector<uint<1>, 1>, out %c_0: !firrtl.vector<uint<1>, 1>, out %c_1: !firrtl.vector<uint<1>, 1>, out %c_2: !firrtl.vector<uint<1>, 1>) {
     // CHECK-NEXT: %0 = firrtl.or %a_0, %b_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %c_0_0, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %c_0_0, %0 : !firrtl.uint<1>
     // CHECK-NEXT: %1 = firrtl.and %a_0, %b_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %c_1_0, %1 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %c_1_0, %1 : !firrtl.uint<1>
     // CHECK-NEXT: %2 = firrtl.xor %a_0, %b_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %c_2_0, %2 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %c_2_0, %2 : !firrtl.uint<1>
     // Check that elementwise_* are preserved.
     // AGGREGATE: firrtl.elementwise_or
     // AGGREGATE: firrtl.elementwise_and
@@ -1286,21 +1286,21 @@ firrtl.module private @is1436_FOO() {
     // SIG: firrtl.elementwise_and
     // SIG: firrtl.elementwise_xor
     %0 = firrtl.elementwise_or %a, %b : (!firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>) -> !firrtl.vector<uint<1>, 1>
-    firrtl.strictconnect %c_0, %0 : !firrtl.vector<uint<1>, 1>
+    firrtl.matchingconnect %c_0, %0 : !firrtl.vector<uint<1>, 1>
     %1 = firrtl.elementwise_and %a, %b : (!firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>) -> !firrtl.vector<uint<1>, 1>
-    firrtl.strictconnect %c_1, %1 : !firrtl.vector<uint<1>, 1>
+    firrtl.matchingconnect %c_1, %1 : !firrtl.vector<uint<1>, 1>
     %2 = firrtl.elementwise_xor %a, %b : (!firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>) -> !firrtl.vector<uint<1>, 1>
-    firrtl.strictconnect %c_2, %2 : !firrtl.vector<uint<1>, 1>
+    firrtl.matchingconnect %c_2, %2 : !firrtl.vector<uint<1>, 1>
   }
 
   // COMMON-LABEL: firrtl.module @MuxInt
   firrtl.module @MuxInt(in %sel1: !firrtl.uint<1>, in %sel2: !firrtl.uint<2>, in %v1: !firrtl.bundle<a: uint<5>>, in %v0: !firrtl.bundle<a: uint<5>>, out %out1: !firrtl.bundle<a: uint<5>>, out %out2: !firrtl.bundle<a: uint<5>>) {
     // CHECK: firrtl.int.mux4cell(%sel2, %v1_a, %v0_a, %v1_a, %v0_a) : (!firrtl.uint<2>, !firrtl.uint<5>, !firrtl.uint<5>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
     %0 = firrtl.int.mux4cell(%sel2, %v1, %v0, %v1, %v0) : (!firrtl.uint<2>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>) -> !firrtl.bundle<a: uint<5>>
-    firrtl.strictconnect %out1, %0 : !firrtl.bundle<a: uint<5>>
+    firrtl.matchingconnect %out1, %0 : !firrtl.bundle<a: uint<5>>
     // CHECK: firrtl.int.mux2cell(%sel1, %v1_a, %v0_a) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
     %1 = firrtl.int.mux2cell(%sel1, %v1, %v0) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>) -> !firrtl.bundle<a: uint<5>>
-    firrtl.strictconnect %out2, %0 : !firrtl.bundle<a: uint<5>>
+    firrtl.matchingconnect %out2, %0 : !firrtl.bundle<a: uint<5>>
     // SIG: firrtl.int.mux4cell(%sel2, %v1, %v0, %v1, %v0) : (!firrtl.uint<2>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>) -> !firrtl.bundle<a: uint<5>>
     // SIG: firrtl.int.mux2cell(%sel1, %v1, %v0) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>) -> !firrtl.bundle<a: uint<5>>
   }
@@ -1351,7 +1351,7 @@ firrtl.circuit "Foo"  {
   firrtl.module @Foo() {
     %bar_a = firrtl.instance bar sym @bar @Bar(in a: !firrtl.bundle<b: uint<1>>)
     %invalid = firrtl.invalidvalue : !firrtl.bundle<b: uint<1>>
-    firrtl.strictconnect %bar_a, %invalid : !firrtl.bundle<b: uint<1>>
+    firrtl.matchingconnect %bar_a, %invalid : !firrtl.bundle<b: uint<1>>
   }
 }
 
@@ -1401,6 +1401,6 @@ firrtl.circuit "UnrealizedConversion" {
     %a = "d.w"() : () -> (!hw.struct<data: i64, tag: i1>)
     %b = builtin.unrealized_conversion_cast %a : !hw.struct<data: i64, tag: i1> to !firrtl.bundle<data: uint<64>, tag: uint<1>>
     %w = firrtl.wire : !firrtl.bundle<data: uint<64>, tag: uint<1>>
-    firrtl.strictconnect %w, %b : !firrtl.bundle<data: uint<64>, tag: uint<1>>
+    firrtl.matchingconnect %w, %b : !firrtl.bundle<data: uint<64>, tag: uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -10,11 +10,11 @@ firrtl.circuit "xmr" {
     %1 = firrtl.ref.send %w : !firrtl.uint<2>
     %x = firrtl.ref.resolve %1 : !firrtl.probe<uint<2>>
     // CHECK-NOT: firrtl.ref.resolve
-    firrtl.strictconnect %o, %x : !firrtl.uint<2>
+    firrtl.matchingconnect %o, %x : !firrtl.uint<2>
     // CHECK:      %w = firrtl.wire : !firrtl.uint<2>
     // CHECK:      %w_probe = firrtl.node sym @[[wSym]] interesting_name %w : !firrtl.uint<2>
     // CHECK-NEXT: %[[#xmr:]] = firrtl.xmr.deref @xmrPath : !firrtl.uint<2>
-    // CHECK:      firrtl.strictconnect %o, %[[#xmr]] : !firrtl.uint<2>
+    // CHECK:      firrtl.matchingconnect %o, %[[#xmr]] : !firrtl.uint<2>
   }
 }
 
@@ -44,8 +44,8 @@ firrtl.circuit "Top" {
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]] : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %a, %[[#xmr]] : !firrtl.uint<1>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %a, %[[#xmr]] : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
   }
 }
 
@@ -60,14 +60,14 @@ firrtl.circuit "Top" {
     %a = firrtl.wire : !firrtl.uint<0>
     %0 = firrtl.ref.resolve %t_bar_a : !firrtl.probe<uint<0>>
     // CHECK:  %[[c0_ui0:.+]] = firrtl.constant 0 : !firrtl.uint<0>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<0>
-    // CHECK:  firrtl.strictconnect %a, %[[c0_ui0]] : !firrtl.uint<0>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<0>
+    // CHECK:  firrtl.matchingconnect %a, %[[c0_ui0]] : !firrtl.uint<0>
     %b = firrtl.wire : !firrtl.vector<uint<0>,10>
     %1 = firrtl.ref.resolve %t_bar_b : !firrtl.probe<vector<uint<0>,10>>
-    firrtl.strictconnect %b, %1 : !firrtl.vector<uint<0>,10>
+    firrtl.matchingconnect %b, %1 : !firrtl.vector<uint<0>,10>
     // CHECK:	%[[c0_ui0_0:.+]] = firrtl.constant 0 : !firrtl.uint<0>
     // CHECK:  %[[v2:.+]] = firrtl.bitcast %[[c0_ui0_0]] : (!firrtl.uint<0>) -> !firrtl.vector<uint<0>, 10>
-    // CHECK:  firrtl.strictconnect %b, %[[v2]] : !firrtl.vector<uint<0>, 10>
+    // CHECK:  firrtl.matchingconnect %b, %[[v2]] : !firrtl.vector<uint<0>, 10>
   }
   // CHECK: TopPriv()
   firrtl.module private @TopPriv(out %bar_a : !firrtl.probe<uint<0>>, out %bar_b : !firrtl.probe<vector<uint<0>,10>>) {
@@ -103,8 +103,8 @@ firrtl.circuit "Top" {
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]] : !firrtl.uint<1>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %a, %[[#xmr]]
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %a, %[[#xmr]]
   }
 }
 
@@ -133,8 +133,8 @@ firrtl.circuit "Top" {
     %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path_0]]
     %a = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK:      firrtl.strictconnect %a, %[[#xmr]]
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    // CHECK:      firrtl.matchingconnect %a, %[[#xmr]]
   }
   firrtl.module @Bar(out %_a: !firrtl.probe<uint<1>>) {
     %xmr   = firrtl.instance bar sym @barXMR @XmrSrcMod(out _a: !firrtl.probe<uint<1>>)
@@ -143,8 +143,8 @@ firrtl.circuit "Top" {
     %0 = firrtl.ref.resolve %xmr   : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path_1]]
     %a = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK:      firrtl.strictconnect %a, %[[#xmr]]
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    // CHECK:      firrtl.matchingconnect %a, %[[#xmr]]
   }
   firrtl.module @Top() {
     %bar_a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<1>>)
@@ -162,12 +162,12 @@ firrtl.circuit "Top" {
     // CHECK:      %[[#xmr_3:]] = firrtl.xmr.deref @[[path_3]]
     %2 = firrtl.ref.resolve %xmr_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr_4:]] = firrtl.xmr.deref @[[path_4]]
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %a, %[[#xmr_2]]
-    firrtl.strictconnect %b, %1 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %b, %[[#xmr_3]]
-    firrtl.strictconnect %c, %2 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %c, %[[#xmr_4]]
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %a, %[[#xmr_2]]
+    firrtl.matchingconnect %b, %1 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %b, %[[#xmr_3]]
+    firrtl.matchingconnect %c, %2 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %c, %[[#xmr_4]]
   }
 }
 
@@ -190,15 +190,15 @@ firrtl.circuit "Top"  {
     %6 = firrtl.subfield %rf_write[clk] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %7 = firrtl.subfield %rf_write[data] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     %8 = firrtl.subfield %rf_write[mask] : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
-    firrtl.strictconnect %0, %io_addr : !firrtl.uint<3>
-    firrtl.strictconnect %1, %c1_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %2, %clock : !firrtl.clock
-    firrtl.strictconnect %io_dataOut, %3 : !firrtl.uint<8>
-    firrtl.strictconnect %4, %io_addr : !firrtl.uint<3>
-    firrtl.strictconnect %5, %io_wen : !firrtl.uint<1>
-    firrtl.strictconnect %6, %clock : !firrtl.clock
-    firrtl.strictconnect %8, %c1_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %7, %io_dataIn : !firrtl.uint<8>
+    firrtl.matchingconnect %0, %io_addr : !firrtl.uint<3>
+    firrtl.matchingconnect %1, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %2, %clock : !firrtl.clock
+    firrtl.matchingconnect %io_dataOut, %3 : !firrtl.uint<8>
+    firrtl.matchingconnect %4, %io_addr : !firrtl.uint<3>
+    firrtl.matchingconnect %5, %io_wen : !firrtl.uint<1>
+    firrtl.matchingconnect %6, %clock : !firrtl.clock
+    firrtl.matchingconnect %8, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %7, %io_dataIn : !firrtl.uint<8>
     firrtl.ref.define %_gen_memTap, %rf_memTap : !firrtl.probe<vector<uint<8>, 8>>
   }
   // CHECK: firrtl.module @Top
@@ -207,7 +207,7 @@ firrtl.circuit "Top"  {
     %dut_clock, %dut_io_addr, %dut_io_dataIn, %dut_io_wen, %dut_io_dataOut, %dut__gen_memTap = firrtl.instance dut  @DUTModule(in clock: !firrtl.clock, in io_addr: !firrtl.uint<3>, in io_dataIn: !firrtl.uint<8>, in io_wen: !firrtl.uint<1>, out io_dataOut: !firrtl.uint<8>, out _gen_memTap: !firrtl.probe<vector<uint<8>, 8>>)
     %0 = firrtl.ref.resolve %dut__gen_memTap : !firrtl.probe<vector<uint<8>, 8>>
     // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]], ".Memory"
-    firrtl.strictconnect %dut_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %dut_clock, %clock : !firrtl.clock
     %memTap_0 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
     %memTap_1 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
     %memTap_2 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
@@ -216,42 +216,42 @@ firrtl.circuit "Top"  {
     %memTap_5 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
     %memTap_6 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
     %memTap_7 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
-    firrtl.strictconnect %io_dataOut, %dut_io_dataOut : !firrtl.uint<8>
-    firrtl.strictconnect %dut_io_wen, %io_wen : !firrtl.uint<1>
-    firrtl.strictconnect %dut_io_dataIn, %io_dataIn : !firrtl.uint<8>
-    firrtl.strictconnect %dut_io_addr, %io_addr : !firrtl.uint<3>
+    firrtl.matchingconnect %io_dataOut, %dut_io_dataOut : !firrtl.uint<8>
+    firrtl.matchingconnect %dut_io_wen, %io_wen : !firrtl.uint<1>
+    firrtl.matchingconnect %dut_io_dataIn, %io_dataIn : !firrtl.uint<8>
+    firrtl.matchingconnect %dut_io_addr, %io_addr : !firrtl.uint<3>
     %1 = firrtl.subindex %0[0] : !firrtl.vector<uint<8>, 8>
     // CHECK: %[[#cast_0:]] = firrtl.subindex %[[#xmr]][0]
-    firrtl.strictconnect %memTap_0, %1 : !firrtl.uint<8>
-    // CHECK:  firrtl.strictconnect %memTap_0, %[[#cast_0]] : !firrtl.uint<8>
+    firrtl.matchingconnect %memTap_0, %1 : !firrtl.uint<8>
+    // CHECK:  firrtl.matchingconnect %memTap_0, %[[#cast_0]] : !firrtl.uint<8>
     %2 = firrtl.subindex %0[1] : !firrtl.vector<uint<8>, 8>
     // CHECK: %[[#cast_1:]] = firrtl.subindex %[[#xmr]][1]
-    firrtl.strictconnect %memTap_1, %2 : !firrtl.uint<8>
-    // CHECK:  firrtl.strictconnect %memTap_1, %[[#cast_1]] : !firrtl.uint<8>
+    firrtl.matchingconnect %memTap_1, %2 : !firrtl.uint<8>
+    // CHECK:  firrtl.matchingconnect %memTap_1, %[[#cast_1]] : !firrtl.uint<8>
     %3 = firrtl.subindex %0[2] : !firrtl.vector<uint<8>, 8>
     // CHECK: %[[#cast_2:]] = firrtl.subindex %[[#xmr]][2]
-    firrtl.strictconnect %memTap_2, %3 : !firrtl.uint<8>
-    // CHECK:  firrtl.strictconnect %memTap_2, %[[#cast_2]] : !firrtl.uint<8>
+    firrtl.matchingconnect %memTap_2, %3 : !firrtl.uint<8>
+    // CHECK:  firrtl.matchingconnect %memTap_2, %[[#cast_2]] : !firrtl.uint<8>
     %4 = firrtl.subindex %0[3] : !firrtl.vector<uint<8>, 8>
     // CHECK: %[[#cast_3:]] = firrtl.subindex %[[#xmr]][3]
-    firrtl.strictconnect %memTap_3, %4 : !firrtl.uint<8>
-    // CHECK:  firrtl.strictconnect %memTap_3, %[[#cast_3]] : !firrtl.uint<8>
+    firrtl.matchingconnect %memTap_3, %4 : !firrtl.uint<8>
+    // CHECK:  firrtl.matchingconnect %memTap_3, %[[#cast_3]] : !firrtl.uint<8>
     %5 = firrtl.subindex %0[4] : !firrtl.vector<uint<8>, 8>
     // CHECK: %[[#cast_4:]] = firrtl.subindex %[[#xmr]][4]
-    firrtl.strictconnect %memTap_4, %5 : !firrtl.uint<8>
-    // CHECK:  firrtl.strictconnect %memTap_4, %[[#cast_4]] : !firrtl.uint<8>
+    firrtl.matchingconnect %memTap_4, %5 : !firrtl.uint<8>
+    // CHECK:  firrtl.matchingconnect %memTap_4, %[[#cast_4]] : !firrtl.uint<8>
     %6 = firrtl.subindex %0[5] : !firrtl.vector<uint<8>, 8>
     // CHECK: %[[#cast_5:]] = firrtl.subindex %[[#xmr]][5]
-    firrtl.strictconnect %memTap_5, %6 : !firrtl.uint<8>
-    // CHECK:  firrtl.strictconnect %memTap_5, %[[#cast_5]] : !firrtl.uint<8>
+    firrtl.matchingconnect %memTap_5, %6 : !firrtl.uint<8>
+    // CHECK:  firrtl.matchingconnect %memTap_5, %[[#cast_5]] : !firrtl.uint<8>
     %7 = firrtl.subindex %0[6] : !firrtl.vector<uint<8>, 8>
     // CHECK: %[[#cast_6:]] = firrtl.subindex %[[#xmr]][6]
-    firrtl.strictconnect %memTap_6, %7 : !firrtl.uint<8>
-    // CHECK:  firrtl.strictconnect %memTap_6, %[[#cast_6]] : !firrtl.uint<8>
+    firrtl.matchingconnect %memTap_6, %7 : !firrtl.uint<8>
+    // CHECK:  firrtl.matchingconnect %memTap_6, %[[#cast_6]] : !firrtl.uint<8>
     %8 = firrtl.subindex %0[7] : !firrtl.vector<uint<8>, 8>
     // CHECK: %[[#cast_7:]] = firrtl.subindex %[[#xmr]][7]
-    firrtl.strictconnect %memTap_7, %8 : !firrtl.uint<8>
-    // CHECK:  firrtl.strictconnect %memTap_7, %[[#cast_7]] : !firrtl.uint<8>
+    firrtl.matchingconnect %memTap_7, %8 : !firrtl.uint<8>
+    // CHECK:  firrtl.matchingconnect %memTap_7, %[[#cast_7]] : !firrtl.uint<8>
     }
 }
 
@@ -277,13 +277,13 @@ firrtl.circuit "Top"  {
     // CHECK:      %[[#xmr_0:]] = firrtl.xmr.deref @[[path]], ".Memory[0]"
     %1 = firrtl.ref.resolve %dut__gen_memTap_1 : !firrtl.probe<uint<8>>
     // CHECK:      %[[#xmr_1:]] = firrtl.xmr.deref @[[path]], ".Memory[1]"
-    firrtl.strictconnect %dut_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %dut_clock, %clock : !firrtl.clock
     %memTap_0 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
     %memTap_1 = firrtl.wire   {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<8>
-    firrtl.strictconnect %memTap_0, %0 : !firrtl.uint<8>
-    // CHECK:      firrtl.strictconnect %memTap_0, %[[#xmr_0]]
-    firrtl.strictconnect %memTap_1, %1 : !firrtl.uint<8>
-    // CHECK:      firrtl.strictconnect %memTap_1, %[[#xmr_1]]
+    firrtl.matchingconnect %memTap_0, %0 : !firrtl.uint<8>
+    // CHECK:      firrtl.matchingconnect %memTap_0, %[[#xmr_0]]
+    firrtl.matchingconnect %memTap_1, %1 : !firrtl.uint<8>
+    // CHECK:      firrtl.matchingconnect %memTap_1, %[[#xmr_1]]
   }
 }
 
@@ -311,8 +311,8 @@ firrtl.circuit "Top" {
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]], ".internal.path"
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %a, %[[#xmr]]
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %a, %[[#xmr]]
   }
 }
 
@@ -341,8 +341,8 @@ firrtl.circuit "Top" {
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
     // CHECK:      %[[#xmr:]] = firrtl.xmr.deref @[[path]]
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %a, %[[#xmr]]
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %a, %[[#xmr]]
   }
 }
 
@@ -363,9 +363,9 @@ firrtl.circuit "Top"  {
     %bar__a = firrtl.instance bar sym @bar  @Bar(out _a: !firrtl.probe<uint<0>>)
     %a = firrtl.wire   : !firrtl.uint<0>
     %0 = firrtl.ref.resolve %bar__a : !firrtl.probe<uint<0>>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<0>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<0>
     // CHECK: %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
-    // CHECK: firrtl.strictconnect %a, %c0_ui0 : !firrtl.uint<0>
+    // CHECK: firrtl.matchingconnect %a, %c0_ui0 : !firrtl.uint<0>
   }
 }
 
@@ -398,10 +398,10 @@ firrtl.circuit "ReadForceable" {
     %w, %w_ref = firrtl.wire forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
     %x = firrtl.ref.resolve %w_ref : !firrtl.rwprobe<uint<2>>
     // CHECK-NOT: firrtl.ref.resolve
-    firrtl.strictconnect %o, %x : !firrtl.uint<2>
+    firrtl.matchingconnect %o, %x : !firrtl.uint<2>
     // CHECK:      %w, %w_ref = firrtl.wire sym @[[wSym]] forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
     // CHECK-NEXT: %[[#xmr:]] = firrtl.xmr.deref @xmrPath : !firrtl.uint<2>
-    // CHECK:      firrtl.strictconnect %o, %[[#xmr]] : !firrtl.uint<2>
+    // CHECK:      firrtl.matchingconnect %o, %[[#xmr]] : !firrtl.uint<2>
   }
 }
 
@@ -416,10 +416,10 @@ firrtl.circuit "RefCast" {
     %w, %w_ref = firrtl.wire forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
     %w_ro = firrtl.ref.cast %w_ref : (!firrtl.rwprobe<uint<2>>) -> !firrtl.probe<uint<2>>
     %x = firrtl.ref.resolve %w_ro : !firrtl.probe<uint<2>>
-    firrtl.strictconnect %o, %x : !firrtl.uint<2>
+    firrtl.matchingconnect %o, %x : !firrtl.uint<2>
     // CHECK-NEXT: %w, %w_ref = firrtl.wire sym @[[wSym]] forceable : !firrtl.uint<2>, !firrtl.rwprobe<uint<2>>
     // CHECK-NEXT: %[[#xmr:]] = firrtl.xmr.deref @xmrPath : !firrtl.uint<2>
-    // CHECK-NEXT: firrtl.strictconnect %o, %[[#xmr]] : !firrtl.uint<2>
+    // CHECK-NEXT: firrtl.matchingconnect %o, %[[#xmr]] : !firrtl.uint<2>
   }
 }
 
@@ -538,7 +538,7 @@ firrtl.circuit "InternalPaths" {
                                       out r: !firrtl.probe<uint<1>>,
                                       out data: !firrtl.uint<3>,
                                       out r2: !firrtl.probe<vector<bundle<a: uint<3>>, 3>>)
-   firrtl.strictconnect %ext_in, %in : !firrtl.uint<1>
+   firrtl.matchingconnect %ext_in, %in : !firrtl.uint<1>
 
    // CHECK: %[[XMR_R:.+]] = firrtl.xmr.deref @xmrPath, ".path.to.internal.signal" : !firrtl.uint<1>
    // CHECK: %node_r = firrtl.node %[[XMR_R]]
@@ -569,7 +569,7 @@ firrtl.circuit "RefABI" {
                                       out r: !firrtl.probe<uint<1>>,
                                       out data: !firrtl.uint<3>,
                                       out r2: !firrtl.probe<vector<bundle<a: uint<3>>, 3>>)
-   firrtl.strictconnect %ext_in, %in : !firrtl.uint<1>
+   firrtl.matchingconnect %ext_in, %in : !firrtl.uint<1>
 
    // CHECK: %[[XMR_R:.+]] = firrtl.xmr.deref @xmrPath, ".`ref_RefExtMore_r" : !firrtl.uint<1>
    // CHECK: %node_r = firrtl.node %[[XMR_R]]
@@ -600,10 +600,10 @@ firrtl.circuit "BasicRefSub" {
   firrtl.module @BasicRefSub(in %in : !firrtl.bundle<a: uint<1>, b: uint<2>>, out %out : !firrtl.uint<2>) {
     // CHECK: firrtl.instance c sym @[[C_SYM]]
     %c_in, %c_out = firrtl.instance c @Child(in in : !firrtl.bundle<a: uint<1>, b: uint<2>>, out out : !firrtl.probe<uint<2>>)
-    firrtl.strictconnect %c_in, %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
+    firrtl.matchingconnect %c_in, %in : !firrtl.bundle<a: uint<1>, b: uint<2>>
     // CHECK: firrtl.xmr.deref @[[XMRPATH]], ".b"
     %res = firrtl.ref.resolve %c_out : !firrtl.probe<uint<2>>
-    firrtl.strictconnect %out, %res : !firrtl.uint<2>
+    firrtl.matchingconnect %out, %res : !firrtl.uint<2>
   }
 }
 

--- a/test/Dialect/FIRRTL/materialize-debug-info.mlir
+++ b/test/Dialect/FIRRTL/materialize-debug-info.mlir
@@ -33,8 +33,8 @@ firrtl.module @Ports(
 
   // CHECK-NEXT: dbg.variable "outA", %outA
 
-  // CHECK-NEXT: firrtl.strictconnect
-  firrtl.strictconnect %outA, %inA : !firrtl.uint<42>
+  // CHECK-NEXT: firrtl.matchingconnect
+  firrtl.matchingconnect %outA, %inA : !firrtl.uint<42>
 }
 
 // CHECK-LABEL: firrtl.module @Decls
@@ -62,8 +62,8 @@ firrtl.module @Decls() {
   // CHECK-NEXT: dbg.variable "someReg2", %someReg2
   %someReg2 = firrtl.regreset %c0_clock, %c0_ui1, %c0_ui17 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<17>
 
-  // CHECK-NEXT: firrtl.strictconnect
-  firrtl.strictconnect %someWire, %c0_ui17 : !firrtl.uint<17>
+  // CHECK-NEXT: firrtl.matchingconnect
+  firrtl.matchingconnect %someWire, %c0_ui17 : !firrtl.uint<17>
 }
 
 }

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -26,9 +26,9 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     // CHECK:           %mem = firrtl.reg %[[v6:.+]]  : !firrtl.clock, !firrtl.vector<uint<8>, 8>
     // CHECK:           %[[v23:.+]] = firrtl.subaccess %mem[%[[v4:.+]]]
     // CHECK:           %invalid_ui8 = firrtl.invalidvalue : !firrtl.uint<8>
-    // CHECK:           firrtl.strictconnect %[[v3]], %invalid_ui8 : !firrtl.uint<8>
+    // CHECK:           firrtl.matchingconnect %[[v3]], %invalid_ui8 : !firrtl.uint<8>
     // CHECK:           firrtl.when %[[v1]] : !firrtl.uint<1> {
-    // CHECK:             firrtl.strictconnect %[[v3]], %[[v23]]
+    // CHECK:             firrtl.matchingconnect %[[v3]], %[[v23]]
     // CHECK:           }
     // CHECK:           %mem_write = firrtl.wire  : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
     // CHECK:           %[[v5:.+]] = firrtl.subfield %mem_write[addr]
@@ -39,7 +39,7 @@ firrtl.circuit "Mem" attributes {annotations = [{class = "sifive.enterprise.firr
     // CHECK:           %[[v10:.+]] = firrtl.subaccess %mem[%[[v5]]]
     // CHECK:           firrtl.when %[[v6]] : !firrtl.uint<1> {
     // CHECK:             firrtl.when %[[v9]] : !firrtl.uint<1> {
-    // CHECK:               firrtl.strictconnect %[[v10]], %[[v8]] : !firrtl.uint<8>
+    // CHECK:               firrtl.matchingconnect %[[v10]], %[[v8]] : !firrtl.uint<8>
     // CHECK:             }
     // CHECK:           }
     // CHECK:           %11 = firrtl.ref.send %mem : !firrtl.vector<uint<8>, 8>
@@ -186,10 +186,10 @@ firrtl.circuit "WriteMask" attributes {annotations = [
     // CHECK:         %[[v16:.+]] = firrtl.subindex
     // CHECK:         firrtl.when %[[v6]] : !firrtl.uint<1> {
     // CHECK:           firrtl.when %[[v13]] : !firrtl.uint<1> {
-    // CHECK:             firrtl.strictconnect %[[v11]], %[[v12]] : !firrtl.uint<8>
+    // CHECK:             firrtl.matchingconnect %[[v11]], %[[v12]] : !firrtl.uint<8>
     // CHECK:           }
     // CHECK:           firrtl.when %[[v16]] : !firrtl.uint<1> {
-    // CHECK:             firrtl.strictconnect %[[v14]], %[[v15]] : !firrtl.uint<8>
+    // CHECK:             firrtl.matchingconnect %[[v14]], %[[v15]] : !firrtl.uint<8>
     // CHECK:           }
     %mem_read1, %mem_write1 = firrtl.mem Undefined {
       annotations = [

--- a/test/Dialect/FIRRTL/merge-connections.mlir
+++ b/test/Dialect/FIRRTL/merge-connections.mlir
@@ -8,25 +8,25 @@ firrtl.circuit "Test"   {
   //     output b : {c: {clock: Clock, valid:UInt<1>}[2]}
   //     b <= a
   // COMMON-LABEL: firrtl.module @Test(
-  // COMMON-NEXT:    firrtl.strictconnect %b, %a
+  // COMMON-NEXT:    firrtl.matchingconnect %b, %a
   // COMMON-NEXT:  }
   firrtl.module @Test(in %a: !firrtl.vector<bundle<clock: clock, valid: uint<1>>, 2>, out %b: !firrtl.vector<bundle<clock: clock, valid: uint<1>>, 2>) {
      %0 = firrtl.subindex %a[0] : !firrtl.vector<bundle<clock: clock, valid: uint<1>>, 2>
      %1 = firrtl.subindex %b[0] : !firrtl.vector<bundle<clock: clock, valid: uint<1>>, 2>
      %2 = firrtl.subfield %0[clock] : !firrtl.bundle<clock: clock, valid: uint<1>>
      %3 = firrtl.subfield %1[clock] : !firrtl.bundle<clock: clock, valid: uint<1>>
-     firrtl.strictconnect %3, %2 : !firrtl.clock
+     firrtl.matchingconnect %3, %2 : !firrtl.clock
      %4 = firrtl.subfield %0[valid] : !firrtl.bundle<clock: clock, valid: uint<1>>
      %5 = firrtl.subfield %1[valid] : !firrtl.bundle<clock: clock, valid: uint<1>>
-     firrtl.strictconnect %5, %4 : !firrtl.uint<1>
+     firrtl.matchingconnect %5, %4 : !firrtl.uint<1>
      %6 = firrtl.subindex %a[1] : !firrtl.vector<bundle<clock: clock, valid: uint<1>>, 2>
      %7 = firrtl.subindex %b[1] : !firrtl.vector<bundle<clock: clock, valid: uint<1>>, 2>
      %8 = firrtl.subfield %6[clock] : !firrtl.bundle<clock: clock, valid: uint<1>>
      %9 = firrtl.subfield %7[clock] : !firrtl.bundle<clock: clock, valid: uint<1>>
-     firrtl.strictconnect %9, %8 : !firrtl.clock
+     firrtl.matchingconnect %9, %8 : !firrtl.clock
      %10 = firrtl.subfield %6[valid] : !firrtl.bundle<clock: clock, valid: uint<1>>
      %11 = firrtl.subfield %7[valid] : !firrtl.bundle<clock: clock, valid: uint<1>>
-     firrtl.strictconnect %11, %10 : !firrtl.uint<1>
+     firrtl.matchingconnect %11, %10 : !firrtl.uint<1>
   }
 
   // circuit Bar :
@@ -36,54 +36,54 @@ firrtl.circuit "Test"   {
   //     a.c <= UInt<1>(1)
   // COMMON-LABEL: firrtl.module @Constant(
   // COMMON-NEXT:    %0 = firrtl.aggregateconstant [0 : ui1, 1 : ui1]
-  // COMMON-NEXT:    firrtl.strictconnect %a, %0
+  // COMMON-NEXT:    firrtl.matchingconnect %a, %0
   // COMMON-NEXT:  }
   firrtl.module @Constant(out %a: !firrtl.bundle<b: uint<1>, c: uint<1>>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %0 = firrtl.subfield %a[b] : !firrtl.bundle<b: uint<1>, c: uint<1>>
     %1 = firrtl.subfield %a[c] : !firrtl.bundle<b: uint<1>, c: uint<1>>
-    firrtl.strictconnect %0, %c0_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %1, %c1_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %c1_ui1 : !firrtl.uint<1>
   }
 
   // AGGRESSIVE-LABEL:  firrtl.module @ConcatToVector(
   // AGGRESSIVE-NEXT:     %0 = firrtl.vectorcreate %s1, %s2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
-  // AGGRESSIVE-NEXT:     firrtl.strictconnect %sink, %0
+  // AGGRESSIVE-NEXT:     firrtl.matchingconnect %sink, %0
   // AGGRESSIVE-NEXT:   }
   // CHECK-LABEL:       firrtl.module @ConcatToVector(
   // CHECK-NEXT:          %0 = firrtl.subindex %sink[1]
   // CHECK-NEXT:          %1 = firrtl.subindex %sink[0]
-  // CHECK-NEXT:          firrtl.strictconnect %1, %s1
-  // CHECK-NEXT:          firrtl.strictconnect %0, %s2
+  // CHECK-NEXT:          firrtl.matchingconnect %1, %s1
+  // CHECK-NEXT:          firrtl.matchingconnect %0, %s2
   // CHECK-NEXT:        }
 
   firrtl.module @ConcatToVector(in %s1: !firrtl.uint<1>, in %s2: !firrtl.uint<1>, out %sink: !firrtl.vector<uint<1>, 2>) {
     %0 = firrtl.subindex %sink[1] : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.subindex %sink[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %1, %s1 : !firrtl.uint<1>
-    firrtl.strictconnect %0, %s2 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %s1 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %s2 : !firrtl.uint<1>
   }
 
   // Check that we don't use %s1 as a source value.
   // AGGRESSIVE-LABEL:   firrtl.module @FailedToUseAggregate(
   // AGGRESSIVE-NEXT:    %0 = firrtl.subindex %s1[0]
   // AGGRESSIVE-NEXT:    %1 = firrtl.vectorcreate %0, %s2
-  // AGGRESSIVE-NEXT:    firrtl.strictconnect %sink, %1
+  // AGGRESSIVE-NEXT:    firrtl.matchingconnect %sink, %1
   // AGGRESSIVE-NEXT:   }
   // CHECK-LABEL:       firrtl.module @FailedToUseAggregate(
   // CHECK-NEXT:         %0 = firrtl.subindex %sink[1]
   // CHECK-NEXT:         %1 = firrtl.subindex %s1[0]
   // CHECK-NEXT:         %2 = firrtl.subindex %sink[0]
-  // CHECK-NEXT:         firrtl.strictconnect %2, %1
-  // CHECK-NEXT:         firrtl.strictconnect %0, %s2
+  // CHECK-NEXT:         firrtl.matchingconnect %2, %1
+  // CHECK-NEXT:         firrtl.matchingconnect %0, %s2
   // CHECK-NEXT:        }
   firrtl.module @FailedToUseAggregate(in %s1: !firrtl.vector<uint<1>, 2>, in %s2: !firrtl.uint<1>, out %sink: !firrtl.vector<uint<1>, 2>) {
     %0 = firrtl.subindex %sink[1] : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.subindex %s1[0] : !firrtl.vector<uint<1>, 2>
     %2 = firrtl.subindex %sink[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %2, %1 : !firrtl.uint<1>
-    firrtl.strictconnect %0, %s2 : !firrtl.uint<1>
+    firrtl.matchingconnect %2, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %s2 : !firrtl.uint<1>
   }
 
 
@@ -91,11 +91,11 @@ firrtl.circuit "Test"   {
   // COMMON-LABEL: firrtl.module private @DUT
   // COMMON-NEXT:    %p = firrtl.wire
   // COMMON-NEXT:    %0 = firrtl.subfield
-  // COMMON-NEXT:    firrtl.strictconnect %0, %x_a
+  // COMMON-NEXT:    firrtl.matchingconnect %0, %x_a
   // COMMON-NEXT:    %1 = firrtl.subfield
-  // COMMON-NEXT:    firrtl.strictconnect %x_b, %1
-  // COMMON-NEXT:    firrtl.strictconnect %y_a, %0
-  // COMMON-NEXT:    firrtl.strictconnect %1, %y_b
+  // COMMON-NEXT:    firrtl.matchingconnect %x_b, %1
+  // COMMON-NEXT:    firrtl.matchingconnect %y_a, %0
+  // COMMON-NEXT:    firrtl.matchingconnect %1, %y_b
   // COMMON-NEXT:  }
   firrtl.module private @DUT(in %x_a: !firrtl.uint<2>,
                              out %x_b: !firrtl.uint<2>,
@@ -103,11 +103,11 @@ firrtl.circuit "Test"   {
                              in %y_b: !firrtl.uint<2>) {
     %p = firrtl.wire : !firrtl.bundle<a: uint<2>, b flip: uint<2>>
     %0 = firrtl.subfield %p[a] : !firrtl.bundle<a: uint<2>, b flip: uint<2>>
-    firrtl.strictconnect %0, %x_a : !firrtl.uint<2>
+    firrtl.matchingconnect %0, %x_a : !firrtl.uint<2>
     %1 = firrtl.subfield %p[b] : !firrtl.bundle<a: uint<2>, b flip: uint<2>>
-    firrtl.strictconnect %x_b, %1 : !firrtl.uint<2>
-    firrtl.strictconnect %y_a, %0 : !firrtl.uint<2>
-    firrtl.strictconnect %1, %y_b : !firrtl.uint<2>
+    firrtl.matchingconnect %x_b, %1 : !firrtl.uint<2>
+    firrtl.matchingconnect %y_a, %0 : !firrtl.uint<2>
+    firrtl.matchingconnect %1, %y_b : !firrtl.uint<2>
   }
 
   // Don't create aggregateconstant of non-passive. #6259.
@@ -120,20 +120,20 @@ firrtl.circuit "Test"   {
     %w, %w_ref = firrtl.wire forceable {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.bundle<a: uint<1>, b flip: uint<2>>, !firrtl.rwprobe<bundle<a: uint<1>, b: uint<2>>>
     %0 = firrtl.subfield %w[b] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
     %1 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
-    firrtl.strictconnect %1, %c0_ui1 : !firrtl.uint<1>
-    firrtl.strictconnect %0, %c0_ui2 : !firrtl.uint<2>
+    firrtl.matchingconnect %1, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %c0_ui2 : !firrtl.uint<2>
     firrtl.ref.define %a, %w_ref : !firrtl.rwprobe<bundle<a: uint<1>, b: uint<2>>>
   }
 
   // COMMON-LABEL: @Alias
   firrtl.module @Alias(in %i: !firrtl.alias<MyBundle, bundle<f: uint<1>, b: uint<1>>>, out %o: !firrtl.alias<MyBundle, bundle<f: uint<1>, b: uint<1>>>) {
-    // CHECK-NEXT:  firrtl.strictconnect %o, %i
+    // CHECK-NEXT:  firrtl.matchingconnect %o, %i
     %0 = firrtl.subfield %i[f] : !firrtl.alias<MyBundle, bundle<f: uint<1>, b: uint<1>>>
     %1 = firrtl.subfield %o[f] : !firrtl.alias<MyBundle, bundle<f: uint<1>, b: uint<1>>>
-    firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %1, %0 : !firrtl.uint<1>
     %2 = firrtl.subfield %i[b] : !firrtl.alias<MyBundle, bundle<f: uint<1>, b: uint<1>>>
     %3 = firrtl.subfield %o[b] : !firrtl.alias<MyBundle, bundle<f: uint<1>, b: uint<1>>>
-    firrtl.strictconnect %3, %2 : !firrtl.uint<1>
+    firrtl.matchingconnect %3, %2 : !firrtl.uint<1>
   }
 }
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -122,11 +122,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %_t_2 = firrtl.wire interesting_name : !firrtl.vector<uint<1>, 12>
     wire _t_2 : UInt<1>[12]
 
-    ; CHECK: firrtl.strictconnect %_t, %_t_2 : !firrtl.vector<uint<1>, 12>
+    ; CHECK: firrtl.matchingconnect %_t, %_t_2 : !firrtl.vector<uint<1>, 12>
     _t <= _t_2
 
     ; CHECK: [[INV:%.+]]  = firrtl.invalidvalue : !firrtl.uint<1>
-    ; CHECK-NEXT: firrtl.strictconnect %auto, [[INV]] : !firrtl.uint<1>
+    ; CHECK-NEXT: firrtl.matchingconnect %auto, [[INV]] : !firrtl.uint<1>
     auto is invalid
 
     ; CHECK-NOT: firrtl.attach %a1
@@ -139,11 +139,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     skip  @[SKipLoc.scala 42:24]
 
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.uint<1>
-    ; CHECK-NEXT: firrtl.strictconnect %auto, [[INV]] : !firrtl.uint<1>
+    ; CHECK-NEXT: firrtl.matchingconnect %auto, [[INV]] : !firrtl.uint<1>
     auto is invalid
 
     ; CHECK-NOT: firrtl.connect %reset
-    ; CHECK-NOT: firrtl.strictconnect %reset
+    ; CHECK-NOT: firrtl.matchingconnect %reset
     reset is invalid
 
     ; CHECK: %out_0 = firrtl.wire interesting_name : !firrtl.bundle<member: bundle<"0": bundle<clock: clock, reset: uint<1>>>>
@@ -153,7 +153,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[A:%.+]] = firrtl.subindex %_t_3[0] : !firrtl.vector<uint<1>, 12>
     ; CHECK: %_t_4 = firrtl.wire interesting_name : !firrtl.vector<uint<1>, 12>
     ; CHECK: [[B:%.+]] = firrtl.subindex %_t_4[0] : !firrtl.vector<uint<1>, 12>
-    ; CHECK: firrtl.strictconnect [[A]], [[B]]
+    ; CHECK: firrtl.matchingconnect [[A]], [[B]]
     wire _t_3 : UInt<1>[12] @[Nodes.scala 370:76]
     wire _t_4 : UInt<1>[12]
     _t_3[0] <= _t_4[0] @[Xbar.scala 21:44]
@@ -226,25 +226,25 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %c171_ui8 = firrtl.constant 171 : !firrtl.const.uint<8>
     ; CHECK: firrtl.add %c42_ui10, %c171_ui8
     ; CHECK: firrtl.constCast
-    ; CHECK: firrtl.strictconnect %auto
+    ; CHECK: firrtl.matchingconnect %auto
     auto11 <= add(UInt<10>(42), UInt<8>("hAB"))
 
     ; CHECK: %c-85_si8 = firrtl.constant -85 : !firrtl.const.sint<8>
     sauto <= add(s8, SInt<8>(-85))
 
     ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
-    ; CHECK:   firrtl.strictconnect %_t, %_t_2
+    ; CHECK:   firrtl.matchingconnect %_t, %_t_2
     ; CHECK: } else {
-    ; CHECK:   firrtl.strictconnect %_t, %_t_2
+    ; CHECK:   firrtl.matchingconnect %_t, %_t_2
     ; CHECK: }
     when reset : _t <= _t_2 else : _t <= _t_2
 
     ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
     ; CHECK:   [[N4A:%.+]] = firrtl.node interesting_name %_t_2
-    ; CHECK:   firrtl.strictconnect %_t, [[N4A]]
+    ; CHECK:   firrtl.matchingconnect %_t, [[N4A]]
     ; CHECK: } else {
     ; CHECK:   [[N4B:%.+]] = firrtl.node interesting_name %_t_2
-    ; CHECK:   firrtl.strictconnect %_t, [[N4B]]
+    ; CHECK:   firrtl.matchingconnect %_t, [[N4B]]
     ; CHECK: }
     when reset :
       node n4 = _t_2
@@ -256,18 +256,18 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[TMP:%.+]] = firrtl.constant 4
     ; CHECK: [[COND:%.+]] = firrtl.lt %reset, [[TMP]]
     ; CHECK: firrtl.when [[COND]] : !firrtl.uint<1> {
-    ; CHECK:   firrtl.strictconnect %_t, %_t_2
+    ; CHECK:   firrtl.matchingconnect %_t, %_t_2
     ; CHECK: }
     ; CHECK-NOT: else
     when lt(reset, UInt(4)) :   ;; When with no else.
       _t <= _t_2
 
     ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
-    ; CHECK:   firrtl.strictconnect %_t, %_t_2
+    ; CHECK:   firrtl.matchingconnect %_t, %_t_2
     ; CHECK: } else  {
     ; CHECK:   [[COND:%.+]] = firrtl.not %reset
     ; CHECK:   firrtl.when [[COND]] : !firrtl.uint<1> {
-    ; CHECK:     firrtl.strictconnect %_t, %_t_2
+    ; CHECK:     firrtl.matchingconnect %_t, %_t_2
     ; CHECK:   }
     ; CHECK: }
     when reset :
@@ -276,13 +276,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       _t <= _t_2
 
     ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
-    ; CHECK:   firrtl.strictconnect %_t, %_t
+    ; CHECK:   firrtl.matchingconnect %_t, %_t
     ; CHECK: } else  {
     ; CHECK:   [[COND:%.+]] = firrtl.not %reset
     ; CHECK:   firrtl.when [[COND]] : !firrtl.uint<1> {
-    ; CHECK:     firrtl.strictconnect %_t, %_t_2
+    ; CHECK:     firrtl.matchingconnect %_t, %_t_2
     ; CHECK:   } else  {
-    ; CHECK:     firrtl.strictconnect %_t, %_t_2
+    ; CHECK:     firrtl.matchingconnect %_t, %_t_2
     ; CHECK:   }
     ; CHECK: }
     when reset:
@@ -351,7 +351,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %xyz_in = firrtl.instance xyz interesting_name @circuit(in in: !firrtl.uint<80>)
     inst xyz of circuit
     ; CHECK: [[PAD:%.*]] = firrtl.pad %i8, 80 : (!firrtl.uint<8>) -> !firrtl.uint<80>
-    ; CHECK: firrtl.strictconnect %xyz_in, [[PAD]] : !firrtl.uint<80>
+    ; CHECK: firrtl.matchingconnect %xyz_in, [[PAD]] : !firrtl.uint<80>
     xyz.in <= i8
 
     ; CHECK: %myext_in, %myext_out = firrtl.instance myext interesting_name @MyExtModule(in in: !firrtl.uint, out out: !firrtl.uint<8>)
@@ -590,10 +590,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; Check that invalidation reuses subfields
     wire w: {a: UInt<1>}[1]
     ; CHECK: %invalid = firrtl.invalidvalue : !firrtl.vector<bundle<a: uint<1>>, 1>
-    ; CHECK: firrtl.strictconnect %w, %invalid
+    ; CHECK: firrtl.matchingconnect %w, %invalid
     w is invalid
     ; CHECK: %invalid_0 = firrtl.invalidvalue : !firrtl.vector<bundle<a: uint<1>>, 1>
-    ; CHECK: firrtl.strictconnect %w, %invalid_0
+    ; CHECK: firrtl.matchingconnect %w, %invalid_0
     w is invalid
 
   ; CHECK-LABEL: firrtl.module private @flip_one
@@ -640,7 +640,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     tmp5 <= SInt<19>(8)
      ; CHECK: %c8_si19 = firrtl.constant 8 : !firrtl.const.sint<19>
      ; CHECK: [[VAL:%.*]] = firrtl.constCast %c8_si19 : (!firrtl.const.sint<19>) -> !firrtl.sint<19>
-     ; CHECK: firrtl.strictconnect %tmp5, [[VAL]] : !firrtl.sint<19>
+     ; CHECK: firrtl.matchingconnect %tmp5, [[VAL]] : !firrtl.sint<19>
 
    ; CHECK-LABEL: firrtl.module private @issue347
   module issue347 :
@@ -716,27 +716,27 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module TrickyIssue559:
     input input: UInt<1>
     output output: UInt<1>
-    ; CHECK: firrtl.strictconnect %output, %input
+    ; CHECK: firrtl.matchingconnect %output, %input
     output <= input
 
   ; CHECK-LABEL: firrtl.module private @CheckInvalids
   module CheckInvalids_in0 :
     input in0 : UInt<1>
     ; CHECK-NOT: firrtl.connect %in0
-    ; CHECK-NOT: firrtl.strictconnect %in0
+    ; CHECK-NOT: firrtl.matchingconnect %in0
     in0 is invalid
 
   module CheckInvalids_in1 :
     input in1 : { a : UInt<1>, b : UInt<1> }
     ; CHECK-NOT: firrtl.connect %in1
-    ; CHECK-NOT: firrtl.strictconnect %in1
+    ; CHECK-NOT: firrtl.matchingconnect %in1
     in1 is invalid
 
   module CheckInvalids_in2 :
     input in2 : { a : UInt<1>, flip b : UInt<1>}
     ; CHECK: [[IN2_B:%.+]] = firrtl.subfield %in2[b]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.strictconnect [[IN2_B]], [[INV]]
+    ; CHECK: firrtl.matchingconnect [[IN2_B]], [[INV]]
     in2 is invalid
 
   module CheckInvalids_in3 :
@@ -744,26 +744,26 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[IN3_A:%.+]] = firrtl.subfield %in3[a]
     ; CHECK: [[IN3_A_C:%.+]] = firrtl.subfield [[IN3_A]][c]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.strictconnect [[IN3_A_C]], [[INV]]
+    ; CHECK: firrtl.matchingconnect [[IN3_A_C]], [[INV]]
     in3 is invalid
 
   module CheckInvalids_out0 :
     output out0 : UInt<1>
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.strictconnect %out0, [[INV]]
+    ; CHECK: firrtl.matchingconnect %out0, [[INV]]
     out0 is invalid
 
   module CheckInvalids_out1 :
     output out1 : { a : UInt<1>, b : UInt<1> }
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>, b: uint<1>>
-    ; CHECK: firrtl.strictconnect %out1, [[INV]]
+    ; CHECK: firrtl.matchingconnect %out1, [[INV]]
     out1 is invalid
 
   module CheckInvalids_out2 :
     output out2 : { a : UInt<1>, flip b : UInt<1>}
     ; CHECK: [[OUT2_A:%.+]] = firrtl.subfield %out2[a]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.strictconnect [[OUT2_A]], [[INV]]
+    ; CHECK: firrtl.matchingconnect [[OUT2_A]], [[INV]]
     out2 is invalid
 
   module CheckInvalids_out3 :
@@ -771,13 +771,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[OUT3_A:%.+]] = firrtl.subfield %out3[a]
     ; CHECK: [[OUT3_A_B:%.+]] = firrtl.subfield [[OUT3_A]][b]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.strictconnect [[OUT3_A_B]], [[INV]]
+    ; CHECK: firrtl.matchingconnect [[OUT3_A_B]], [[INV]]
     out3 is invalid
 
   module CheckInvalids_wires :
     ; CHECK: %wire0 = firrtl.wire
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.strictconnect %wire0, [[INV]]
+    ; CHECK: firrtl.matchingconnect %wire0, [[INV]]
     wire wire0 : UInt<1>
     wire0 is invalid
 
@@ -785,9 +785,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[WIRE1_B:%.+]] = firrtl.subfield %wire1[b]
     ; CHECK: [[WIRE1_A:%.+]] = firrtl.subfield %wire1[a]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.strictconnect [[WIRE1_A]], [[INV]]
+    ; CHECK: firrtl.matchingconnect [[WIRE1_A]], [[INV]]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.strictconnect [[WIRE1_B]], [[INV]]
+    ; CHECK: firrtl.matchingconnect [[WIRE1_B]], [[INV]]
     wire wire1 : {a : UInt<1>, flip b : UInt<1> }
     wire1 is invalid
 
@@ -797,7 +797,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[WIRE2_X_B:%.+]] = firrtl.subfield [[WIRE2_X]][b]
     ; CHECK: [[WIRE2_X_A:%.+]] = firrtl.subfield [[WIRE2_X]][a]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.strictconnect [[WIRE2_X_A]], [[INV]]
+    ; CHECK: firrtl.matchingconnect [[WIRE2_X_A]], [[INV]]
     ; CHECK-NOT: firrtl.attach [[WIRE2_X_B]], [[INV]]
     wire wire2 : {x : {flip a : UInt<1>, flip b: Analog<1> } }
     wire2 is invalid
@@ -807,9 +807,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     inst U0 of mod_0_563
 
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
-    ; CHECK: firrtl.strictconnect %U0_in0, [[INV]]
+    ; CHECK: firrtl.matchingconnect %U0_in0, [[INV]]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.bundle<a: uint<5>>
-    ; CHECK: firrtl.strictconnect %U0_in1, [[INV]]
+    ; CHECK: firrtl.matchingconnect %U0_in1, [[INV]]
     U0 is invalid
 
   ; This reference is declared after its first use.
@@ -828,7 +828,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output io : UInt<1>[8]
     ; CHECK:  %0 = firrtl.subindex %io[0] : !firrtl.vector<uint<1>, 8>
     ; CHECK: [[VAL:%.*]] = firrtl.constCast %c0_ui1 : (!firrtl.const.uint<1>) -> !firrtl.uint<1>
-    ; CHECK: firrtl.strictconnect %0, [[VAL]] : !firrtl.uint<1>
+    ; CHECK: firrtl.matchingconnect %0, [[VAL]] : !firrtl.uint<1>
     io[0] <= UInt<1>("h00")
 
 
@@ -867,11 +867,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     cmem a: UInt<1>[8]
 
-    ; CHECK: firrtl.strictconnect %rData, %r
+    ; CHECK: firrtl.matchingconnect %rData, %r
     infer mport r = a[rAddr], clock
     rData <= r
 
-    ; CHECK: firrtl.strictconnect %w_data, %wData
+    ; CHECK: firrtl.matchingconnect %w_data, %wData
     infer mport w = a[wAddr], clock
     w <= wData
 
@@ -920,7 +920,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %[[c1:.*]] = firrtl.constant 1 : !firrtl.const.uint
     ; CHECK-NEXT: %[[c2:.*]] = firrtl.resetCast %[[c1]]
     ; CHECK-NEXT: %[[c3:.*]] = firrtl.constCast %[[c2]]
-    ; CHECK-NEXT: firrtl.strictconnect %out, %[[c3]] : !firrtl.reset
+    ; CHECK-NEXT: firrtl.matchingconnect %out, %[[c3]] : !firrtl.reset
 
 
   ; CHECK-LABEL: @resetBundle
@@ -931,11 +931,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     b <= a
     ; CHECK: %1 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<1>, b: asyncreset>
     ; CHECK: %[[r1:.*]] = firrtl.resetCast %1
-    ; CHECK: firrtl.strictconnect %0, %[[r1]] : !firrtl.reset
+    ; CHECK: firrtl.matchingconnect %0, %[[r1]] : !firrtl.reset
     ; CHECK: %3 = firrtl.subfield %b[b] : !firrtl.bundle<a: reset, b: reset>
     ; CHECK: %4 = firrtl.subfield %a[b] : !firrtl.bundle<a: uint<1>, b: asyncreset>
     ; CHECK: %[[r4:.*]] = firrtl.resetCast %4
-    ; CHECK: firrtl.strictconnect %3, %[[r4]] : !firrtl.reset
+    ; CHECK: firrtl.matchingconnect %3, %[[r4]] : !firrtl.reset
 
   module LargeMem :
     input clock : Clock
@@ -973,13 +973,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.match %i : !firrtl.enum<Some: uint<8>, None: uint<0>> {
     match i:
       ; CHECK: case Some(%arg0) {
-      ; CHECK:   firrtl.strictconnect %o, %arg0 : !firrtl.uint<8>
+      ; CHECK:   firrtl.matchingconnect %o, %arg0 : !firrtl.uint<8>
       ; CHECK: }
       Some(x):
         o <= x
       ; CHECK: case None(%arg0) {
       ; CHECK:   %invalid_ui8 = firrtl.invalidvalue : !firrtl.uint<8>
-      ; CHECK:   firrtl.strictconnect %o, %invalid_ui8 : !firrtl.uint<8>
+      ; CHECK:   firrtl.matchingconnect %o, %invalid_ui8 : !firrtl.uint<8>
       ; CHECK: }
       None:
         o is invalid
@@ -1103,13 +1103,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
    ; CHECK-NEXT: %inst_rw2 = firrtl.wire : !firrtl.rwprobe<uint<1>>
    ; CHECK-NEXT: %rc2_in_bounce = firrtl.wire sym @[[RC2_IN_BOUNCE_SYM:[^ ]+]]
    ; CHECK-NEXT: %rc2_in, %rc2_r, %rc2_rw = firrtl.instance rc2
-   ; CHECK-NEXT: firrtl.strictconnect %rc2_in, %rc2_in_bounce
+   ; CHECK-NEXT: firrtl.matchingconnect %rc2_in, %rc2_in_bounce
     wire inst_rw : RWProbe<UInt<1>>
     wire inst_rw2 : RWProbe<UInt<1>>
     inst rc2 of RefsChild
 
     ; CHECK: %[[IN_CAST:[^ ]+]] = firrtl.constCast %in :
-    ; CHECK: firrtl.strictconnect %rc2_in_bounce, %[[IN_CAST]]
+    ; CHECK: firrtl.matchingconnect %rc2_in_bounce, %[[IN_CAST]]
     rc2.in <= in
    ; CHECK-NEXT: firrtl.when %rc2_in_bounce :
    ; CHECK-NEXT:   %[[RWPROBE_RC2_IN_BOUNCE_1:[^ ]+]] = firrtl.ref.rwprobe <@Refs::@[[RC2_IN_BOUNCE_SYM]]>
@@ -1117,7 +1117,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
    ; CHECK-NEXT: }
     when rc2.in:
       define inst_rw = rwprobe(rc2.in)
-   ; CHECK-NEXT: firrtl.strictconnect %rc2_in_bounce,
+   ; CHECK-NEXT: firrtl.matchingconnect %rc2_in_bounce,
     rc2.in <= rc.in
    ; CHECK-NEXT: %[[RWPROBE_RC2_IN_BOUNCE_2:[^ ]+]] = firrtl.ref.rwprobe <@Refs::@[[RC2_IN_BOUNCE_SYM]]>
    ; CHECK-NEXT: firrtl.ref.define %inst_rw2, %[[RWPROBE_RC2_IN_BOUNCE_2]]
@@ -1221,8 +1221,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NEXT: %6 = firrtl.subfield %5[bar]
     b <= a.0.0.bar
     d <= c.0.0.0.bar
-    ; CHECK-NEXT: firrtl.strictconnect %b, %6
-    ; CHECK-NEXT: firrtl.strictconnect %d, %3
+    ; CHECK-NEXT: firrtl.matchingconnect %b, %6
+    ; CHECK-NEXT: firrtl.matchingconnect %d, %3
 
   ; CHECK-LABEL: firrtl.module private @ConstTypes(
   module ConstTypes:
@@ -1246,12 +1246,12 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK-NEXT: %w = firrtl.wire interesting_name : !firrtl.const.sint<4>
     wire w: const SInt<4>
-    ; CHECK-NEXT: firrtl.strictconnect %w, %s4 : !firrtl.const.sint<4>
+    ; CHECK-NEXT: firrtl.matchingconnect %w, %s4 : !firrtl.const.sint<4>
     w <= s4
     ; CHECK-NEXT: %nonconst_w = firrtl.wire interesting_name : !firrtl.sint<4>
     wire nonconst_w: SInt<4>
     ; CHECK-NEXT: [[CAST:%.+]] = firrtl.constCast %s4 : (!firrtl.const.sint<4>) -> !firrtl.sint<4>
-    ; CHECK-NEXT: firrtl.strictconnect %nonconst_w, [[CAST]] : !firrtl.sint<4>
+    ; CHECK-NEXT: firrtl.matchingconnect %nonconst_w, [[CAST]] : !firrtl.sint<4>
     nonconst_w <= s4
 
 ;// -----
@@ -1265,11 +1265,11 @@ circuit Foo_v3p0p0:
     input a: UInt<1>
     output b: UInt<1>
 
-    ; CHECK: firrtl.strictconnect %b, %a
+    ; CHECK: firrtl.matchingconnect %b, %a
     connect b, a
 
     ; CHECK: [[INV:%.+]]  = firrtl.invalidvalue : !firrtl.uint<1>
-    ; CHECK-NEXT: firrtl.strictconnect %b, [[INV]] : !firrtl.uint<1>
+    ; CHECK-NEXT: firrtl.matchingconnect %b, [[INV]] : !firrtl.uint<1>
     invalidate b
 
     ; CHECK:      %[[zero:[0-9A-Za-z_]+]] = firrtl.constant 0
@@ -1286,7 +1286,7 @@ circuit Foo_v3p0p0:
 
     ; CHECK-NEXT: %0 = firrtl.subfield %_0["1"] : !firrtl.bundle<"1": uint<1>>
     ; CHECK-NEXT: %1 = firrtl.subfield %_2["3"] : !firrtl.bundle<"3": uint<1>>
-    ; CHECK-NEXT: firrtl.strictconnect %1, %0 : !firrtl.uint<1>
+    ; CHECK-NEXT: firrtl.matchingconnect %1, %0 : !firrtl.uint<1>
     `2`.`3` <= `0`.`1`
 
     ; Ensure that `a` is equivalent to a.
@@ -1304,7 +1304,7 @@ circuit Foo_v1p9p9:
     output b: UInt<1>
     output auto : UInt<1>
 
-    ; CHECK: firrtl.strictconnect %b, %a
+    ; CHECK: firrtl.matchingconnect %b, %a
     b <- a
 
     ; CHECK: [[a0:%.+]] = firrtl.subfield %bundleWithAnalog[a]
@@ -1317,7 +1317,7 @@ circuit Foo_v1p9p9:
     ; CHECK: [[A:%.+]] = firrtl.subfield %out_0[member] : !firrtl.bundle<member: bundle<"0": bundle<clock: clock, reset: uint<1>>>>
     ; CHECK: [[B:%.+]] = firrtl.subfield [[A]]["0"] : !firrtl.bundle<"0": bundle<clock: clock, reset: uint<1>>>
     ; CHECK: [[C:%.+]] = firrtl.subfield [[B]][reset] : !firrtl.bundle<clock: clock, reset: uint<1>>
-    ; CHECK: firrtl.strictconnect %auto, [[C]] : !firrtl.uint<1>
+    ; CHECK: firrtl.matchingconnect %auto, [[C]] : !firrtl.uint<1>
     wire out_0 : { member : { 0 : { clock : Clock, reset : UInt<1>}}}
     auto <- out_0.member.0.reset @[Field 173:49]
 
@@ -1446,7 +1446,7 @@ circuit Top:
 
   ; CHECK-NEXT: %[[RESULT:.+]] = firrtl.subfield %in_data[valid] : !firrtl.alias<Data, bundle<w: const.vector<const.alias<WordType, const.uint<32>>, 2>, valid: alias<ValidType, uint<1>>, ready flip: uint<1>>>
   ; CHECK-NEXT: %c = firrtl.wire interesting_name : !firrtl.alias<Complex_id, alias<Complex, bundle<real: sint<10>, imag: sint<10>>>>
-  ; CHECK-NEXT: firrtl.strictconnect %out_valid, %[[RESULT]] : !firrtl.alias<ValidType, uint<1>>
+  ; CHECK-NEXT: firrtl.matchingconnect %out_valid, %[[RESULT]] : !firrtl.alias<ValidType, uint<1>>
   module Top:
     input in_data: Data
     input in_complex: Complex

--- a/test/Dialect/FIRRTL/parse-locations.fir
+++ b/test/Dialect/FIRRTL/parse-locations.fir
@@ -45,7 +45,7 @@ circuit MyModule :  @[CIRCUIT.scala 127]
     ; CHECK: %1 = firrtl.subfield %out_0[member] {{.*}} loc("Field":173:49)
     ; CHECK: %2 = firrtl.subfield %1["0"] {{.*}} loc("Field":173:49)
     ; CHECK: %3 = firrtl.subfield %2[reset] : {{.*}} loc("Field":173:49)
-    ; CHECK: firrtl.strictconnect %0, %3 : {{.*}} loc("Field":173:49)
+    ; CHECK: firrtl.matchingconnect %0, %3 : {{.*}} loc("Field":173:49)
     auto.out_0 <- out_0.member.0.reset @[Field 173:49]
 
     ; Fused locators: https://github.com/llvm/circt/issues/224

--- a/test/Dialect/FIRRTL/parse-name-preservation.fir
+++ b/test/Dialect/FIRRTL/parse-name-preservation.fir
@@ -10,7 +10,7 @@ circuit Bar :
 
     ; Should use the non-tap wire in expressions.
     a <= in
-    ; CHECK: firrtl.strictconnect %a, %in
+    ; CHECK: firrtl.matchingconnect %a, %in
 
     ; When the type is not passive, the tap should be a wire with the passive
     ; type of the original wire.

--- a/test/Dialect/FIRRTL/passive-wire.mlir
+++ b/test/Dialect/FIRRTL/passive-wire.mlir
@@ -12,22 +12,22 @@ firrtl.circuit "TopLevel" {
 // CHECK: %w = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>> 
 // CHECK: %0 = firrtl.subfield %w[valid] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
 // CHECK: %1 = firrtl.subfield %source[valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
-// CHECK: firrtl.strictconnect %0, %1 : !firrtl.uint<1>
+// CHECK: firrtl.matchingconnect %0, %1 : !firrtl.uint<1>
 // CHECK: %2 = firrtl.subfield %w[ready] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
 // CHECK: %3 = firrtl.subfield %source[ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
-// CHECK: firrtl.strictconnect %3, %2 : !firrtl.uint<1>
+// CHECK: firrtl.matchingconnect %3, %2 : !firrtl.uint<1>
 // CHECK: %4 = firrtl.subfield %w[data] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
 // CHECK: %5 = firrtl.subfield %source[data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
-// CHECK: firrtl.strictconnect %4, %5 : !firrtl.uint<64>
+// CHECK: firrtl.matchingconnect %4, %5 : !firrtl.uint<64>
 // CHECK: %6 = firrtl.subfield %sink[valid] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK: %7 = firrtl.subfield %w[valid] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
-// CHECK: firrtl.strictconnect %6, %7 : !firrtl.uint<1>
+// CHECK: firrtl.matchingconnect %6, %7 : !firrtl.uint<1>
 // CHECK: %8 = firrtl.subfield %sink[ready] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK: %9 = firrtl.subfield %w[ready] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
-// CHECK: firrtl.strictconnect %9, %8 : !firrtl.uint<1>
+// CHECK: firrtl.matchingconnect %9, %8 : !firrtl.uint<1>
 // CHECK: %10 = firrtl.subfield %sink[data] : !firrtl.bundle<valid: uint<1>, ready flip: uint<1>, data: uint<64>>
 // CHECK: %11 = firrtl.subfield %w[data] : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<64>>
-// CHECK: firrtl.strictconnect %10, %11 : !firrtl.uint<64>
+// CHECK: firrtl.matchingconnect %10, %11 : !firrtl.uint<64>
   }
 
 

--- a/test/Dialect/FIRRTL/ref.mlir
+++ b/test/Dialect/FIRRTL/ref.mlir
@@ -7,7 +7,7 @@ firrtl.circuit "xmr" {
   firrtl.module private @Test(out %x: !firrtl.probe<uint<2>>) {
     %w = firrtl.wire : !firrtl.uint<2>
     %zero = firrtl.constant 0 : !firrtl.uint<2>
-    firrtl.strictconnect %w, %zero : !firrtl.uint<2>
+    firrtl.matchingconnect %w, %zero : !firrtl.uint<2>
     %1 = firrtl.ref.send %w : !firrtl.uint<2>
     firrtl.ref.define %x, %1 : !firrtl.probe<uint<2>>
   }
@@ -30,7 +30,7 @@ firrtl.circuit "SimpleRead" {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
   }
 }
 
@@ -51,7 +51,7 @@ firrtl.circuit "ForwardToInstance" {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
   }
 }
 
@@ -70,14 +70,14 @@ firrtl.circuit "ForwardToInstance" {
     // Reader 1
     %0 = firrtl.ref.resolve %bar_2 : !firrtl.probe<uint<1>>
     %a = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
   }
   firrtl.module @ForwardToInstance() {
     %bar_a = firrtl.instance bar @Bar(out _a: !firrtl.probe<uint<1>>)
     %a = firrtl.wire : !firrtl.uint<1>
     // Reader 2
     %0 = firrtl.ref.resolve %bar_a : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %a, %0 : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %0 : !firrtl.uint<1>
   }
 }
 
@@ -88,12 +88,12 @@ firrtl.circuit "DUT" {
   firrtl.module private @Submodule (out %ref_out1: !firrtl.probe<uint<1>>, out %ref_out2: !firrtl.probe<uint<4>>) {
     %zero = firrtl.constant 0 : !firrtl.uint<1>
     %w_data1 = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %w_data1, %zero : !firrtl.uint<1>
+    firrtl.matchingconnect %w_data1, %zero : !firrtl.uint<1>
     %1 = firrtl.ref.send %w_data1 : !firrtl.uint<1>
     firrtl.ref.define %ref_out1, %1 : !firrtl.probe<uint<1>>
     %w_data2 = firrtl.wire : !firrtl.uint<4>
     %zero4 = firrtl.constant 0 : !firrtl.uint<4>
-    firrtl.strictconnect %w_data2, %zero4 : !firrtl.uint<4>
+    firrtl.matchingconnect %w_data2, %zero4 : !firrtl.uint<4>
     %2 = firrtl.ref.send %w_data2 : !firrtl.uint<4>
     firrtl.ref.define %ref_out2, %2 : !firrtl.probe<uint<4>>
   }
@@ -103,14 +103,14 @@ firrtl.circuit "DUT" {
 
     %1 = firrtl.ref.resolve %view_out1 : !firrtl.probe<uint<1>>
     %2 = firrtl.ref.resolve %view_out2 : !firrtl.probe<uint<4>>
-    firrtl.strictconnect %view_in1, %1 : !firrtl.uint<1>
-    firrtl.strictconnect %view_in2, %2 : !firrtl.uint<4>
+    firrtl.matchingconnect %view_in1, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %view_in2, %2 : !firrtl.uint<4>
   }
 
   firrtl.module private @MyView_companion (in %ref_in1: !firrtl.uint<1>, in %ref_in2: !firrtl.uint<4>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %_WIRE = firrtl.wire sym @_WIRE : !firrtl.uint<1>
-    firrtl.strictconnect %_WIRE, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %_WIRE, %c0_ui1 : !firrtl.uint<1>
     %iface = sv.interface.instance sym @__MyView_MyInterface__  : !sv.interface<@MyInterface>
   }
 
@@ -137,7 +137,7 @@ firrtl.circuit "RefTypeVector" {
     %rb = firrtl.ref.resolve %12 : !firrtl.probe<uint<2>>
     %bundle_b = firrtl.subfield %bundle[b] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
     %zero2 = firrtl.constant 0 : !firrtl.uint<2>
-    firrtl.strictconnect %bundle_b, %zero2 : !firrtl.uint<2>
+    firrtl.matchingconnect %bundle_b, %zero2 : !firrtl.uint<2>
   }
 }
 
@@ -151,12 +151,12 @@ firrtl.circuit "Issue3715" {
       %w = firrtl.wire : !firrtl.uint<2>
       %1 = firrtl.ref.send %w : !firrtl.uint<2>
       firrtl.ref.define %x, %1 : !firrtl.probe<uint<2>>
-      firrtl.strictconnect %w, %zero : !firrtl.uint<2>
+      firrtl.matchingconnect %w, %zero : !firrtl.uint<2>
     }
   }
   firrtl.module @Issue3715(in %p: !firrtl.uint<1>) {
     %test_in, %test_x = firrtl.instance test @Test(in p: !firrtl.uint<1>, out x: !firrtl.probe<uint<2>>)
-    firrtl.strictconnect %test_in, %p : !firrtl.uint<1>
+    firrtl.matchingconnect %test_in, %p : !firrtl.uint<1>
     %x = firrtl.ref.resolve %test_x : !firrtl.probe<uint<2>>
   }
 }
@@ -177,7 +177,7 @@ firrtl.circuit "UseRefsWithSinkFlow" {
     %0 = firrtl.ref.send %x : !firrtl.uint<1>
     firrtl.ref.define %p, %0 : !firrtl.probe<uint<1>>
     %1 = firrtl.ref.resolve %p : !firrtl.probe<uint<1>>
-    firrtl.strictconnect %y, %1 : !firrtl.uint<1>
+    firrtl.matchingconnect %y, %1 : !firrtl.uint<1>
     %oc_x, %oc_y, %oc_p = firrtl.instance oc interesting_name @OutChild(in x: !firrtl.uint, out y: !firrtl.uint, out p: !firrtl.probe<uint>)
     firrtl.connect %oc_x, %x : !firrtl.uint, !firrtl.uint<1>
     firrtl.connect %zz, %oc_y : !firrtl.uint<1>, !firrtl.uint

--- a/test/Dialect/FIRRTL/register-optimizer.mlir
+++ b/test/Dialect/FIRRTL/register-optimizer.mlir
@@ -4,22 +4,22 @@ firrtl.circuit "invalidReg"   {
   // CHECK-LABEL: @invalidReg
   firrtl.module @invalidReg(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
     %foobar = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
-    firrtl.strictconnect %foobar, %foobar : !firrtl.uint<1>
+    firrtl.matchingconnect %foobar, %foobar : !firrtl.uint<1>
     //CHECK-NOT: firrtl.connect %foobar, %foobar
     //CHECK: %[[inv:.*]] = firrtl.invalidvalue
-    //CHECK: firrtl.strictconnect %a, %[[inv]]
-    firrtl.strictconnect %a, %foobar : !firrtl.uint<1>
+    //CHECK: firrtl.matchingconnect %a, %[[inv]]
+    firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: @constantRegWrite
   firrtl.module @constantRegWrite(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
     %c = firrtl.constant 0 : !firrtl.uint<1>
     %foobar = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
-    firrtl.strictconnect %foobar, %c : !firrtl.uint<1>
+    firrtl.matchingconnect %foobar, %c : !firrtl.uint<1>
     //CHECK-NOT: firrtl.connect %foobar, %c
     //CHECK: %[[const:.*]] = firrtl.constant
-    //CHECK: firrtl.strictconnect %a, %[[const]]
-    firrtl.strictconnect %a, %foobar : !firrtl.uint<1>
+    //CHECK: firrtl.matchingconnect %a, %[[const]]
+    firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: @constantRegWriteDom
@@ -27,32 +27,32 @@ firrtl.circuit "invalidReg"   {
     %foobar = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
     //CHECK-NOT: firrtl.connect %foobar, %c
     //CHECK: %[[const:.*]] = firrtl.constant
-    //CHECK: firrtl.strictconnect %a, %[[const]]
-    firrtl.strictconnect %a, %foobar : !firrtl.uint<1>
+    //CHECK: firrtl.matchingconnect %a, %[[const]]
+    firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
     %c = firrtl.constant 0 : !firrtl.uint<1>
-    firrtl.strictconnect %foobar, %c : !firrtl.uint<1>
+    firrtl.matchingconnect %foobar, %c : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: @constantRegResetWrite
   firrtl.module @constantRegResetWrite(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %a: !firrtl.uint<1>) {
     %c = firrtl.constant 0 : !firrtl.uint<1>
     %foobar = firrtl.regreset %clock, %reset, %c  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.strictconnect %foobar, %c : !firrtl.uint<1>
+    firrtl.matchingconnect %foobar, %c : !firrtl.uint<1>
     //CHECK-NOT: firrtl.connect %foobar, %c
     //CHECK: %[[const:.*]] = firrtl.constant
-    //CHECK: firrtl.strictconnect %a, %[[const]]
-    firrtl.strictconnect %a, %foobar : !firrtl.uint<1>
+    //CHECK: firrtl.matchingconnect %a, %[[const]]
+    firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: @constantRegResetWriteSelf
   firrtl.module @constantRegResetWriteSelf(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %a: !firrtl.uint<1>) {
     %c = firrtl.constant 0 : !firrtl.uint<1>
     %foobar = firrtl.regreset %clock, %reset, %c  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.strictconnect %foobar, %foobar : !firrtl.uint<1>
+    firrtl.matchingconnect %foobar, %foobar : !firrtl.uint<1>
     //CHECK-NOT: firrtl.connect %foobar, %c
     //CHECK: %[[const:.*]] = firrtl.constant
-    //CHECK: firrtl.strictconnect %a, %[[const]]
-    firrtl.strictconnect %a, %foobar : !firrtl.uint<1>
+    //CHECK: firrtl.matchingconnect %a, %[[const]]
+    firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: @movedFromIMCP
@@ -69,16 +69,16 @@ firrtl.circuit "invalidReg"   {
     // regreset
     %regreset = firrtl.regreset %clock, %reset, %c0_ui2 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
 
-    firrtl.strictconnect %regreset, %c0_ui2 : !firrtl.uint<2>
+    firrtl.matchingconnect %regreset, %c0_ui2 : !firrtl.uint<2>
 
-    // CHECK: firrtl.strictconnect %result6, %c0_ui2
-    firrtl.strictconnect %result6, %regreset: !firrtl.uint<2>
+    // CHECK: firrtl.matchingconnect %result6, %c0_ui2
+    firrtl.matchingconnect %result6, %regreset: !firrtl.uint<2>
 
     // reg
     %reg = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<4>
-    firrtl.strictconnect %reg, %c0_ui4 : !firrtl.uint<4>
-    // CHECK: firrtl.strictconnect %result7, %c0_ui4
-    firrtl.strictconnect %result7, %reg: !firrtl.uint<4>
+    firrtl.matchingconnect %reg, %c0_ui4 : !firrtl.uint<4>
+    // CHECK: firrtl.matchingconnect %result7, %c0_ui4
+    firrtl.matchingconnect %result7, %reg: !firrtl.uint<4>
   }
 
   // CHECK-LABEL: RegResetImplicitExtOrTrunc
@@ -87,7 +87,7 @@ firrtl.circuit "invalidReg"   {
     %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
     %r = firrtl.regreset %clock, %reset, %c0_ui3 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<2>
     %0 = firrtl.cat %r, %r : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
-    firrtl.strictconnect %r, %r : !firrtl.uint<2>
-    firrtl.strictconnect %out, %0 : !firrtl.uint<4>
+    firrtl.matchingconnect %r, %r : !firrtl.uint<2>
+    firrtl.matchingconnect %out, %0 : !firrtl.uint<4>
   }
 }

--- a/test/Dialect/FIRRTL/remove-unused-ports.mlir
+++ b/test/Dialect/FIRRTL/remove-unused-ports.mlir
@@ -77,31 +77,31 @@ firrtl.circuit "Top"   {
                      out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
     %A_a, %A_b, %A_c, %A_d_unused, %A_d_invalid, %A_d_constant = firrtl.instance A  @UseBar(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d_unused: !firrtl.uint<1>, out d_invalid: !firrtl.uint<1>, out d_constant: !firrtl.uint<1>)
     // CHECK: %A_b, %A_c = firrtl.instance A @UseBar(in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
-    // CHECK-NEXT: firrtl.strictconnect %A_b, %b
-    // CHECK-NEXT: firrtl.strictconnect %c, %A_c
-    // CHECK-NEXT: firrtl.strictconnect %d_unused, %{{invalid_ui1.*}}
-    // CHECK-NEXT: firrtl.strictconnect %d_invalid, %{{invalid_ui1.*}}
-    // CHECK-NEXT: firrtl.strictconnect %d_constant, %{{c1_ui1.*}}
-    firrtl.strictconnect %A_a, %a : !firrtl.uint<1>
-    firrtl.strictconnect %A_b, %b : !firrtl.uint<1>
-    firrtl.strictconnect %c, %A_c : !firrtl.uint<1>
-    firrtl.strictconnect %d_unused, %A_d_unused : !firrtl.uint<1>
-    firrtl.strictconnect %d_invalid, %A_d_invalid : !firrtl.uint<1>
-    firrtl.strictconnect %d_constant, %A_d_constant : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %A_b, %b
+    // CHECK-NEXT: firrtl.matchingconnect %c, %A_c
+    // CHECK-NEXT: firrtl.matchingconnect %d_unused, %{{invalid_ui1.*}}
+    // CHECK-NEXT: firrtl.matchingconnect %d_invalid, %{{invalid_ui1.*}}
+    // CHECK-NEXT: firrtl.matchingconnect %d_constant, %{{c1_ui1.*}}
+    firrtl.matchingconnect %A_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %A_b, %b : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %A_c : !firrtl.uint<1>
+    firrtl.matchingconnect %d_unused, %A_d_unused : !firrtl.uint<1>
+    firrtl.matchingconnect %d_invalid, %A_d_invalid : !firrtl.uint<1>
+    firrtl.matchingconnect %d_constant, %A_d_constant : !firrtl.uint<1>
   }
 
   // Check that %a, %d_unused, %d_invalid and %d_constant are removed.
   // CHECK-LABEL: firrtl.module private @Bar(in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
-  // CHECK-NEXT:    firrtl.strictconnect %c, %b
+  // CHECK-NEXT:    firrtl.matchingconnect %c, %b
   // CHECK-NEXT:  }
   firrtl.module private @Bar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
                      out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
-    firrtl.strictconnect %c, %b : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %b : !firrtl.uint<1>
 
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
-    firrtl.strictconnect %d_invalid, %invalid_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %d_invalid, %invalid_ui1 : !firrtl.uint<1>
     %c1_i1 = firrtl.constant 1 : !firrtl.uint<1>
-    firrtl.strictconnect %d_constant, %c1_i1 : !firrtl.uint<1>
+    firrtl.matchingconnect %d_constant, %c1_i1 : !firrtl.uint<1>
   }
 
   // Check that %a, %d_unused, %d_invalid and %d_constant are removed.
@@ -109,13 +109,13 @@ firrtl.circuit "Top"   {
   firrtl.module private @UseBar(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>,
                         out %d_unused: !firrtl.uint<1>, out %d_invalid: !firrtl.uint<1>, out %d_constant: !firrtl.uint<1>) {
     %A_a, %A_b, %A_c, %A_d_unused, %A_d_invalid, %A_d_constant = firrtl.instance A  @Bar(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d_unused: !firrtl.uint<1>, out d_invalid: !firrtl.uint<1>, out d_constant: !firrtl.uint<1>)
-    firrtl.strictconnect %A_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %A_a, %a : !firrtl.uint<1>
     // CHECK: %A_b, %A_c = firrtl.instance A  @Bar(in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
-    firrtl.strictconnect %A_b, %b : !firrtl.uint<1>
-    firrtl.strictconnect %c, %A_c : !firrtl.uint<1>
-    firrtl.strictconnect %d_unused, %A_d_unused : !firrtl.uint<1>
-    firrtl.strictconnect %d_invalid, %A_d_invalid : !firrtl.uint<1>
-    firrtl.strictconnect %d_constant, %A_d_constant : !firrtl.uint<1>
+    firrtl.matchingconnect %A_b, %b : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %A_c : !firrtl.uint<1>
+    firrtl.matchingconnect %d_unused, %A_d_unused : !firrtl.uint<1>
+    firrtl.matchingconnect %d_invalid, %A_d_invalid : !firrtl.uint<1>
+    firrtl.matchingconnect %d_constant, %A_d_constant : !firrtl.uint<1>
   }
 
   // Make sure that %a, %b and %c are not erased because they have an annotation or a symbol.
@@ -123,18 +123,18 @@ firrtl.circuit "Top"   {
   firrtl.module private @Foo(in %a: !firrtl.uint<1> sym @dntSym, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1> sym @dntSym2) attributes {
     portAnnotations = [[], [{a = "a"}], []]}
   {
-    // CHECK: firrtl.strictconnect %c, %{{invalid_ui1.*}}
+    // CHECK: firrtl.matchingconnect %c, %{{invalid_ui1.*}}
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
-    firrtl.strictconnect %c, %invalid_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %invalid_ui1 : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: firrtl.module private @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>)
   firrtl.module private @UseFoo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
     %A_a, %A_b, %A_c = firrtl.instance A  @Foo(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
     // CHECK: %A_a, %A_b, %A_c = firrtl.instance A @Foo(in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
-    firrtl.strictconnect %A_a, %a : !firrtl.uint<1>
-    firrtl.strictconnect %A_b, %b : !firrtl.uint<1>
-    firrtl.strictconnect %c, %A_c : !firrtl.uint<1>
+    firrtl.matchingconnect %A_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %A_b, %b : !firrtl.uint<1>
+    firrtl.matchingconnect %c, %A_c : !firrtl.uint<1>
   }
 }
 
@@ -165,19 +165,19 @@ firrtl.circuit "UnusedOutput"  {
   // CHECK-NOT:     out %c
   firrtl.module private @SingleDriver(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
     // CHECK-NEXT: %[[c_wire:.+]] = firrtl.wire
-    // CHECK-NEXT: firrtl.strictconnect %b, %[[c_wire]]
-    firrtl.strictconnect %b, %c : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %b, %[[c_wire]]
+    firrtl.matchingconnect %b, %c : !firrtl.uint<1>
     // CHECK-NEXT: %[[not_a:.+]] = firrtl.not %a
     %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK-NEXT: firrtl.strictconnect %[[c_wire]], %[[not_a]]
-    firrtl.strictconnect %c, %0 : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.matchingconnect %[[c_wire]], %[[not_a]]
+    firrtl.matchingconnect %c, %0 : !firrtl.uint<1>
   }
   // CHECK-LABEL: @UnusedOutput
   firrtl.module @UnusedOutput(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
     // CHECK: %singleDriver_a, %singleDriver_b = firrtl.instance singleDriver
     %singleDriver_a, %singleDriver_b, %singleDriver_c = firrtl.instance singleDriver @SingleDriver(in a: !firrtl.uint<1>, out b: !firrtl.uint<1>, out c: !firrtl.uint<1>)
-    firrtl.strictconnect %singleDriver_a, %a : !firrtl.uint<1>
-    firrtl.strictconnect %b, %singleDriver_b : !firrtl.uint<1>
+    firrtl.matchingconnect %singleDriver_a, %a : !firrtl.uint<1>
+    firrtl.matchingconnect %b, %singleDriver_b : !firrtl.uint<1>
   }
 }
 

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -62,7 +62,7 @@ firrtl.module @Foo(in %clock: !firrtl.clock) {
   // CHECK-SAME: { @FPGA -> @FPGATarget, @ASIC -> @ASICTarget } (in clock: !firrtl.clock)
   %inst_clock = firrtl.instance_choice inst interesting_name @DefaultTarget alternatives @Platform
     { @FPGA -> @FPGATarget, @ASIC -> @ASICTarget } (in clock: !firrtl.clock)
-  firrtl.strictconnect %inst_clock, %clock : !firrtl.clock
+  firrtl.matchingconnect %inst_clock, %clock : !firrtl.clock
 }
 
 // CHECK-LABEL: firrtl.layer @LayerA bind

--- a/test/Dialect/FIRRTL/sfc-compat.mlir
+++ b/test/Dialect/FIRRTL/sfc-compat.mlir
@@ -38,18 +38,18 @@ firrtl.circuit "SFCCompatTests" {
     %inv = firrtl.wire : !firrtl.bundle<a: uint<1>>
     %inv_a = firrtl.subfield %inv[a] : !firrtl.bundle<a: uint<1>>
     %invalid = firrtl.invalidvalue : !firrtl.uint<1>
-    firrtl.strictconnect %inv_a, %invalid : !firrtl.uint<1>
+    firrtl.matchingconnect %inv_a, %invalid : !firrtl.uint<1>
 
     %inv1 = firrtl.wire : !firrtl.vector<bundle<a: uint<1>>, 2>
     %inv1_0 = firrtl.subindex %inv1[0] : !firrtl.vector<bundle<a: uint<1>>, 2>
-    firrtl.strictconnect %inv1_0, %inv : !firrtl.bundle<a: uint<1>>
+    firrtl.matchingconnect %inv1_0, %inv : !firrtl.bundle<a: uint<1>>
     %inv1_1 = firrtl.subindex %inv1[0] : !firrtl.vector<bundle<a: uint<1>>, 2>
-    firrtl.strictconnect %inv1_1, %inv : !firrtl.bundle<a: uint<1>>
+    firrtl.matchingconnect %inv1_1, %inv : !firrtl.bundle<a: uint<1>>
 
     // CHECK: firrtl.reg %clock : !firrtl.clock, !firrtl.vector<bundle<a: uint<1>>, 2>
     %r = firrtl.regreset %clock, %reset, %inv1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<bundle<a: uint<1>>, 2>, !firrtl.vector<bundle<a: uint<1>>, 2>
-    firrtl.strictconnect %r, %d : !firrtl.vector<bundle<a: uint<1>>, 2>
-    firrtl.strictconnect %q, %r : !firrtl.vector<bundle<a: uint<1>>, 2>
+    firrtl.matchingconnect %r, %d : !firrtl.vector<bundle<a: uint<1>>, 2>
+    firrtl.matchingconnect %q, %r : !firrtl.vector<bundle<a: uint<1>>, 2>
   }
 
   // A regreset invalidated via an output port should be converted to a reg.
@@ -127,7 +127,7 @@ firrtl.circuit "SFCCompatTests" {
   firrtl.module @ConstantAsyncReset(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %r0_init = firrtl.wire sym @r0_init : !firrtl.uint<1>
-    firrtl.strictconnect %r0_init, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %r0_init, %c0_ui1 : !firrtl.uint<1>
     %r0 = firrtl.regreset %clock, %reset, %r0_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
 
     %r1_init = firrtl.node %c0_ui1 : !firrtl.uint<1>
@@ -135,7 +135,7 @@ firrtl.circuit "SFCCompatTests" {
 
     %inv_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
     %r2_init = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %r2_init, %inv_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %r2_init, %inv_ui1 : !firrtl.uint<1>
     %r2 = firrtl.regreset %clock, %reset, %r2_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
 
     %c0_si1 = firrtl.asSInt %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.sint<1>
@@ -155,7 +155,7 @@ firrtl.circuit "SFCCompatTests" {
     %0 = firrtl.pad %c0_ui1, 3 : (!firrtl.uint<1>) -> !firrtl.uint<3>
     %1 = firrtl.tail %0, 2 : (!firrtl.uint<3>) -> !firrtl.uint<1>
     %r0_init = firrtl.wire sym @r0_init : !firrtl.uint<1>
-    firrtl.strictconnect %r0_init, %1: !firrtl.uint<1>
+    firrtl.matchingconnect %r0_init, %1: !firrtl.uint<1>
     %r0 = firrtl.regreset %clock, %reset, %r0_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
@@ -188,7 +188,7 @@ firrtl.circuit "NonConstantAsyncReset_Aggregate0" {
   // expected-note @below {{reset driver is "x"}}
   firrtl.module @NonConstantAsyncReset_Aggregate0(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %x : !firrtl.vector<uint<1>, 2>) {
     %value = firrtl.wire : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %value, %x : !firrtl.vector<uint<1>, 2>
+    firrtl.matchingconnect %value, %x : !firrtl.vector<uint<1>, 2>
     // expected-error @below {{register "r0" has an async reset, but its reset value "value" is not driven with a constant value through wires, nodes, or connects}}
     %r0 = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   }
@@ -206,14 +206,14 @@ firrtl.circuit "NonConstantAsyncReset_Aggregate1" {
     // Connect a constant 0 to value[0].
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %value_0 = firrtl.subindex %value[0] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %value_0, %c0_ui1 : !firrtl.uint<1>
+    firrtl.matchingconnect %value_0, %c0_ui1 : !firrtl.uint<1>
 
     // Connect a complex chain of operations leading to the port to value[1].
     %subindex = firrtl.subindex %x[0] : !firrtl.vector<bundle<y : uint<1>>, 1>
     %node = firrtl.node %subindex : !firrtl.bundle<y : uint<1>>
     %subfield = firrtl.subfield %node[y] : !firrtl.bundle<y : uint<1>>
     %value_1 = firrtl.subindex %value[1] : !firrtl.vector<uint<1>, 2>
-    firrtl.strictconnect %value_1, %subfield : !firrtl.uint<1>
+    firrtl.matchingconnect %value_1, %subfield : !firrtl.uint<1>
 
     // expected-error @below {{register "r0" has an async reset, but its reset value "value[1]" is not driven with a constant value through wires, nodes, or connects}}
     %r0 = firrtl.regreset %clock, %reset, %value : !firrtl.clock, !firrtl.asyncreset, !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>

--- a/test/Dialect/FIRRTL/simplify-mems.mlir
+++ b/test/Dialect/FIRRTL/simplify-mems.mlir
@@ -84,12 +84,12 @@ firrtl.circuit "ReadWriteToWrite" {
     // CHECK: [[DATA:%.+]] = firrtl.subfield %Memory_rw[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     // CHECK: [[MASK:%.+]] = firrtl.subfield %Memory_rw[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     // CHECK: [[DUMMY_WMODE:%.+]] = firrtl.wire : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect [[ADDR]], %addr : !firrtl.uint<4>
-    // CHECK: firrtl.strictconnect [[END]], %c1_ui1 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect [[CLK]], %clock : !firrtl.clock
-    // CHECK: firrtl.strictconnect [[DUMMY_WMODE]], %c1_ui1 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect [[DATA]], %indata : !firrtl.uint<42>
-    // CHECK: firrtl.strictconnect [[MASK]], %c1_ui1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect [[ADDR]], %addr : !firrtl.uint<4>
+    // CHECK: firrtl.matchingconnect [[END]], %c1_ui1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect [[CLK]], %clock : !firrtl.clock
+    // CHECK: firrtl.matchingconnect [[DUMMY_WMODE]], %c1_ui1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect [[DATA]], %indata : !firrtl.uint<42>
+    // CHECK: firrtl.matchingconnect [[MASK]], %c1_ui1 : !firrtl.uint<1>
 
     %0 = firrtl.subfield %Memory_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %0, %addr : !firrtl.uint<4>, !firrtl.uint<4>
@@ -148,7 +148,7 @@ firrtl.circuit "UnusedPorts" {
 
     // CHECK: [[REG1:%.+]] = firrtl.reg %c0_clock : !firrtl.clock, !firrtl.uint<42>
     // CHECK: [[REG2:%.+]] = firrtl.reg %c0_clock : !firrtl.clock, !firrtl.uint<42>
-    // CHECK: firrtl.strictconnect %result_read, [[REG1]] : !firrtl.uint<42>
+    // CHECK: firrtl.matchingconnect %result_read, [[REG1]] : !firrtl.uint<42>
     %read_addr = firrtl.subfield %Memory_read[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %read_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
     %read_en = firrtl.subfield %Memory_read[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
@@ -158,7 +158,7 @@ firrtl.circuit "UnusedPorts" {
     %read_data = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %result_read, %read_data : !firrtl.uint<42>, !firrtl.uint<42>
 
-    // CHECK: firrtl.strictconnect %result_rw, [[REG2]] : !firrtl.uint<42>
+    // CHECK: firrtl.matchingconnect %result_rw, [[REG2]] : !firrtl.uint<42>
     %rw_addr = firrtl.subfield %Memory_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %rw_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
     %rw_en = firrtl.subfield %Memory_rw[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
@@ -245,13 +245,13 @@ firrtl.circuit "UnusedBits" {
     // CHECK-DAG: [[RW_SLICE_LO:%.+]] = firrtl.bits %in_data 7 to 3 : (!firrtl.uint<42>) -> !firrtl.uint<5>
     // CHECK-DAG: [[RW_SLICE_HI:%.+]] = firrtl.bits %in_data 24 to 20 : (!firrtl.uint<42>) -> !firrtl.uint<5>
     // CHECK-DAG: [[RW_SLICE_JOIN:%.+]] = firrtl.cat [[RW_SLICE_HI]], [[RW_SLICE_LO]] : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<10>
-    // CHECK-DAG: firrtl.strictconnect [[RW_FIELD]], [[RW_SLICE_JOIN]] : !firrtl.uint<10>
+    // CHECK-DAG: firrtl.matchingconnect [[RW_FIELD]], [[RW_SLICE_JOIN]] : !firrtl.uint<10>
 
     // CHECK-DAG: [[W_FIELD:%.+]] = firrtl.subfield %Memory_write[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<10>, mask: uint<1>>
     // CHECK-DAG: [[W_SLICE_LO:%.+]] = firrtl.bits %in_data 7 to 3 : (!firrtl.uint<42>) -> !firrtl.uint<5>
     // CHECK-DAG: [[W_SLICE_HI:%.+]] = firrtl.bits %in_data 24 to 20 : (!firrtl.uint<42>) -> !firrtl.uint<5>
     // CHECK-DAG: [[W_SLICE_JOIN:%.+]] = firrtl.cat [[W_SLICE_HI]], [[W_SLICE_LO]] : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<10>
-    // CHECK-DAG: firrtl.strictconnect [[W_FIELD]], [[W_SLICE_JOIN]] : !firrtl.uint<10>
+    // CHECK-DAG: firrtl.matchingconnect [[W_FIELD]], [[W_SLICE_JOIN]] : !firrtl.uint<10>
 
     %rw_addr = firrtl.subfield %Memory_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %rw_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
@@ -309,7 +309,7 @@ firrtl.circuit "UnusedBitsAtEnd" {
         !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
 
     // CHECK: [[RDATA:%.+]] = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<5>>
-    // CHECK: firrtl.strictconnect %result_read, [[RDATA]] : !firrtl.uint<5>
+    // CHECK: firrtl.matchingconnect %result_read, [[RDATA]] : !firrtl.uint<5>
     %read_addr = firrtl.subfield %Memory_read[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %read_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
     %read_en = firrtl.subfield %Memory_read[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
@@ -360,7 +360,7 @@ firrtl.circuit "OneAddressMasked" {
         !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<2>>
     // CHECK: %Memory = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
 
-    // CHECK: firrtl.strictconnect %result_read, %Memory : !firrtl.uint<32>
+    // CHECK: firrtl.matchingconnect %result_read, %Memory : !firrtl.uint<32>
 
     %read_addr = firrtl.subfield %Memory_read[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
     firrtl.connect %read_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
@@ -381,7 +381,7 @@ firrtl.circuit "OneAddressMasked" {
     // CHECK: [[CHUNK_1:%.+]] = firrtl.mux([[MASK_1]], [[DATA_1]], [[NEXT_1]]) : (!firrtl.uint<1>, !firrtl.uint<16>, !firrtl.uint<16>) -> !firrtl.uint<16>
     // CHECK: [[NEXT:%.+]] = firrtl.cat [[CHUNK_1]], [[CHUNK_0]] : (!firrtl.uint<16>, !firrtl.uint<16>) -> !firrtl.uint<32>
     // CHECK: [[NEXT_EN:%.+]] = firrtl.mux(%in_wen, [[NEXT]], %Memory) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %Memory, [[NEXT_EN]] : !firrtl.uint<32>
+    // CHECK: firrtl.matchingconnect %Memory, [[NEXT_EN]] : !firrtl.uint<32>
 
     %write_addr = firrtl.subfield %Memory_write[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<2>>
     firrtl.connect %write_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
@@ -413,25 +413,25 @@ firrtl.circuit "OneAddressNoMask" {
     // TODO: It would be good to de-duplicate these either in the pass or in a canonicalizer.
 
     // CHECK: %Memory_write_en_0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %Memory_write_en_0, %in_wen : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %Memory_write_en_0, %in_wen : !firrtl.uint<1>
     // CHECK: %Memory_write_en_1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %Memory_write_en_1, %Memory_write_en_0 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %Memory_write_en_1, %Memory_write_en_0 : !firrtl.uint<1>
     // CHECK: %Memory_write_en_2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %Memory_write_en_2, %Memory_write_en_1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %Memory_write_en_2, %Memory_write_en_1 : !firrtl.uint<1>
 
     // CHECK: %Memory_write_data_0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %Memory_write_data_0, %in_data : !firrtl.uint<32>
+    // CHECK: firrtl.matchingconnect %Memory_write_data_0, %in_data : !firrtl.uint<32>
     // CHECK: %Memory_write_data_1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %Memory_write_data_1, %Memory_write_data_0 : !firrtl.uint<32>
+    // CHECK: firrtl.matchingconnect %Memory_write_data_1, %Memory_write_data_0 : !firrtl.uint<32>
     // CHECK: %Memory_write_data_2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %Memory_write_data_2, %Memory_write_data_1 : !firrtl.uint<32>
+    // CHECK: firrtl.matchingconnect %Memory_write_data_2, %Memory_write_data_1 : !firrtl.uint<32>
 
     // CHECK: %Memory_rw_wdata_0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %Memory_rw_wdata_0, %in_data : !firrtl.uint<32>
+    // CHECK: firrtl.matchingconnect %Memory_rw_wdata_0, %in_data : !firrtl.uint<32>
     // CHECK: %Memory_rw_wdata_1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %Memory_rw_wdata_1, %Memory_rw_wdata_0 : !firrtl.uint<32>
+    // CHECK: firrtl.matchingconnect %Memory_rw_wdata_1, %Memory_rw_wdata_0 : !firrtl.uint<32>
     // CHECK: %Memory_rw_wdata_2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %Memory_rw_wdata_2, %Memory_rw_wdata_1 : !firrtl.uint<32>
+    // CHECK: firrtl.matchingconnect %Memory_rw_wdata_2, %Memory_rw_wdata_1 : !firrtl.uint<32>
 
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 
@@ -449,7 +449,7 @@ firrtl.circuit "OneAddressNoMask" {
 
     // CHECK: %Memory = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<32>
 
-    // CHECK: firrtl.strictconnect %result_read, %Memory : !firrtl.uint<32>
+    // CHECK: firrtl.matchingconnect %result_read, %Memory : !firrtl.uint<32>
     %read_addr = firrtl.subfield %Memory_read[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
     firrtl.connect %read_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
     %read_en = firrtl.subfield %Memory_read[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
@@ -459,7 +459,7 @@ firrtl.circuit "OneAddressNoMask" {
     %read_data = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
     firrtl.connect %result_read, %read_data : !firrtl.uint<32>, !firrtl.uint<32>
 
-    // CHECK: firrtl.strictconnect %result_rw, %Memory : !firrtl.uint<32>
+    // CHECK: firrtl.matchingconnect %result_rw, %Memory : !firrtl.uint<32>
     %rw_addr = firrtl.subfield %Memory_rw[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
     firrtl.connect %rw_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
     %rw_en = firrtl.subfield %Memory_rw[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
@@ -477,14 +477,14 @@ firrtl.circuit "OneAddressNoMask" {
 
     // CHECK: [[WRITING:%.+]] = firrtl.and %in_rwen, %wmode_rw : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     // CHECK: %Memory_rw_wen_0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %Memory_rw_wen_0, [[WRITING]] : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %Memory_rw_wen_0, [[WRITING]] : !firrtl.uint<1>
     // CHECK: %Memory_rw_wen_1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %Memory_rw_wen_1, %Memory_rw_wen_0 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %Memory_rw_wen_1, %Memory_rw_wen_0 : !firrtl.uint<1>
     // CHECK: %Memory_rw_wen_2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %Memory_rw_wen_2, %Memory_rw_wen_1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %Memory_rw_wen_2, %Memory_rw_wen_1 : !firrtl.uint<1>
     // CHECK: [[WRITE_RW:%.+]] = firrtl.mux(%Memory_rw_wen_2, %Memory_rw_wdata_2, %Memory) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
     // CHECK: [[WRITE_W:%.+]] = firrtl.mux(%Memory_write_en_2, %Memory_write_data_2, [[WRITE_RW]]) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
-    // CHECK: firrtl.strictconnect %Memory, [[WRITE_W]] : !firrtl.uint<32>
+    // CHECK: firrtl.matchingconnect %Memory, [[WRITE_W]] : !firrtl.uint<32>
     %write_addr = firrtl.subfield %Memory_write[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     firrtl.connect %write_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>
     %write_en = firrtl.subfield %Memory_write[en] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -197,8 +197,8 @@ firrtl.module @EnumTest(in %in : !firrtl.enum<a: uint<1>, b: uint<2>>,
   %t = firrtl.tagextract %in : !firrtl.enum<a: uint<1>, b: uint<2>>
   // CHECK: = firrtl.tagextract %in : !firrtl.enum<a: uint<1>, b: uint<2>>
 
-  firrtl.strictconnect %out, %v : !firrtl.uint<2>
-  firrtl.strictconnect %tag, %t : !firrtl.uint<1>
+  firrtl.matchingconnect %out, %v : !firrtl.uint<2>
+  firrtl.matchingconnect %tag, %t : !firrtl.uint<1>
 
   %p = firrtl.istag %in a : !firrtl.enum<a: uint<1>, b: uint<2>>
   // CHECK: = firrtl.istag %in a : !firrtl.enum<a: uint<1>, b: uint<2>>
@@ -357,13 +357,13 @@ firrtl.module @AnyRefTest(in %in: !firrtl.anyref, out %out: !firrtl.anyref, in %
 // CHECK-SAME: %const: !firrtl.const.alias<baz, const.uint<1>>
 // CHECK-SAME: %r: !firrtl.openbundle<a: alias<baz, uint<1>>>
 // CHECK-SAME: %out: !firrtl.alias<foo, uint<1>>
-// CHECK-NEXT: firrtl.strictconnect %out, %in : !firrtl.alias<foo, uint<1>>, !firrtl.alias<bar, uint<1>>
+// CHECK-NEXT: firrtl.matchingconnect %out, %in : !firrtl.alias<foo, uint<1>>, !firrtl.alias<bar, uint<1>>
 
 firrtl.module @TypeAlias(in %in: !firrtl.alias<bar, uint<1>>,
                          in %const: !firrtl.const.alias<baz, const.uint<1>>,
                          out %r : !firrtl.openbundle<a: alias<baz, uint<1>>>,
                          out %out: !firrtl.alias<foo, uint<1>>) {
-  firrtl.strictconnect %out, %in: !firrtl.alias<foo, uint<1>>, !firrtl.alias<bar, uint<1>>
+  firrtl.matchingconnect %out, %in: !firrtl.alias<foo, uint<1>>, !firrtl.alias<bar, uint<1>>
 }
 
 }

--- a/test/Dialect/FIRRTL/vb-to-bv.mlir
+++ b/test/Dialect/FIRRTL/vb-to-bv.mlir
@@ -244,17 +244,17 @@ firrtl.circuit "Test" {
   firrtl.module @TestBasicConnects() {
     // CHECK: %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     // CHECK: %w0 = firrtl.wire : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %w0, %c1_ui1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %w0, %c1_ui1 : !firrtl.uint<1>
     %c1 = firrtl.constant 1 : !firrtl.uint<1>
     %w0 = firrtl.wire : !firrtl.uint<1>
-    firrtl.strictconnect %w0, %c1 : !firrtl.uint<1>
+    firrtl.matchingconnect %w0, %c1 : !firrtl.uint<1>
 
     // CHECK: %w1 = firrtl.wire : !firrtl.bundle<a: bundle<>>
     // CHECK: %w2 = firrtl.wire : !firrtl.bundle<a: bundle<>>
-    // CHECK: firrtl.strictconnect %w1, %w2 : !firrtl.bundle<a: bundle<>>
+    // CHECK: firrtl.matchingconnect %w1, %w2 : !firrtl.bundle<a: bundle<>>
     %w1 = firrtl.wire : !firrtl.bundle<a: bundle<>>
     %w2 = firrtl.wire : !firrtl.bundle<a: bundle<>>
-    firrtl.strictconnect %w1, %w2 : !firrtl.bundle<a: bundle<>>
+    firrtl.matchingconnect %w1, %w2 : !firrtl.bundle<a: bundle<>>
 
     // CHECK: %w3 = firrtl.wire : !firrtl.bundle<a flip: uint<1>>
     // CHECK: %w4 = firrtl.wire : !firrtl.bundle<a flip: uint<1>>
@@ -302,8 +302,8 @@ firrtl.circuit "Test" {
     %w9_a_b = firrtl.subfield %w9_a[b] : !firrtl.bundle<b flip: uint<8>>
     %w10_a_b = firrtl.subfield %w10_a[b] : !firrtl.bundle<b flip: uint<8>>
 
-    // CHECK: firrtl.strictconnect %1, %3 : !firrtl.uint<8>
-    firrtl.strictconnect %w9_a_b, %w10_a_b : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %1, %3 : !firrtl.uint<8>
+    firrtl.matchingconnect %w9_a_b, %w10_a_b : !firrtl.uint<8>
   }
 
   //===--------------------------------------------------------------------===//
@@ -316,12 +316,12 @@ firrtl.circuit "Test" {
     // CHECK: %0 = firrtl.subfield %b1[a] : !firrtl.bundle<a: uint<1>>
     // CHECK: %b2 = firrtl.wire : !firrtl.bundle<b: uint<1>>
     // CHECK: %1 = firrtl.subfield %b2[b] : !firrtl.bundle<b: uint<1>>
-    // CHECK: firrtl.strictconnect %0, %1 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %0, %1 : !firrtl.uint<1>
     %b1 = firrtl.wire : !firrtl.bundle<a: uint<1>>
     %b2 = firrtl.wire : !firrtl.bundle<b: uint<1>>
     %a = firrtl.subfield %b1[a] : !firrtl.bundle<a: uint<1>>
     %b = firrtl.subfield %b2[b] : !firrtl.bundle<b: uint<1>>
-    firrtl.strictconnect %a, %b : !firrtl.uint<1>
+    firrtl.matchingconnect %a, %b : !firrtl.uint<1>
   }
 
   // CHECK-LABEL: @TestSubindex
@@ -355,8 +355,8 @@ firrtl.circuit "Test" {
     %b1 = firrtl.subindex %v1[0] : !firrtl.vector<bundle<a: vector<uint<8>, 8>>, 2>
     %b2 = firrtl.subindex %v2[0] : !firrtl.vector<bundle<a: vector<uint<8>, 8>>, 2>
   
-    // CHECK: firrtl.strictconnect %3, %5 : !firrtl.vector<uint<8>, 8>
-    firrtl.strictconnect %b1, %b2 : !firrtl.bundle<a: vector<uint<8>, 8>>
+    // CHECK: firrtl.matchingconnect %3, %5 : !firrtl.vector<uint<8>, 8>
+    firrtl.matchingconnect %b1, %b2 : !firrtl.bundle<a: vector<uint<8>, 8>>
   }
 
   // CHECK-LABEL: TestSubaccess
@@ -369,8 +369,8 @@ firrtl.circuit "Test" {
     %dst = firrtl.wire : !firrtl.uint<8>
     // CHECK: %1 = firrtl.subaccess %0[%c0_ui8] : !firrtl.vector<uint<8>, 2>, !firrtl.uint<8>
     %src = firrtl.subaccess %v[%0] : !firrtl.vector<uint<8>, 2>, !firrtl.uint<8>
-    // CHECK: firrtl.strictconnect %dst, %1 : !firrtl.uint<8>
-    firrtl.strictconnect %dst, %src : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %dst, %1 : !firrtl.uint<8>
+    firrtl.matchingconnect %dst, %src : !firrtl.uint<8>
   }
 
   // CHECK-LABEL: TestSubaccess2
@@ -385,8 +385,8 @@ firrtl.circuit "Test" {
     %dst = firrtl.wire : !firrtl.uint<8>
     // CHECK: %1 = firrtl.subaccess %0[%c0_ui8_0] : !firrtl.vector<uint<8>, 2>, !firrtl.uint<8>
     %src = firrtl.subaccess %v[%i] : !firrtl.vector<uint<8>, 2>, !firrtl.uint<8>
-    // CHECK: firrtl.strictconnect %dst, %1 : !firrtl.uint<8>
-    firrtl.strictconnect %dst, %src : !firrtl.uint<8>
+    // CHECK: firrtl.matchingconnect %dst, %1 : !firrtl.uint<8>
+    firrtl.matchingconnect %dst, %src : !firrtl.uint<8>
   }
 
   // CHECK-LABEL: @TestPathCaching()
@@ -421,13 +421,13 @@ firrtl.circuit "Test" {
     // CHECK: %8 = firrtl.subfield %7[d] : !firrtl.bundle<c: uint<1>, d: uint<1>>
     // CHECK: %9 = firrtl.subfield %7[c] : !firrtl.bundle<c: uint<1>, d: uint<1>>
     // CHECK: %10 = firrtl.subfield %rhs[a] : !firrtl.bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>
-    // CHECK: firrtl.strictconnect %6, %10 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %4, %9 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %2, %8 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %6, %10 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %4, %9 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %2, %8 : !firrtl.uint<1>
     %lhs_storage  = firrtl.wire : !firrtl.vector<bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>, 2>
     %lhs = firrtl.subindex %lhs_storage[0] : !firrtl.vector<bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>, 2>
     %rhs = firrtl.wire : !firrtl.bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>
-    firrtl.strictconnect %lhs, %rhs : !firrtl.bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>
+    firrtl.matchingconnect %lhs, %rhs : !firrtl.bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>
   }
 
   // CHECK-LABEL: @TestLhsExplodedWhenLhsHasFlips
@@ -461,11 +461,11 @@ firrtl.circuit "Test" {
     // CHECK: %6 = firrtl.subindex %5[0] : !firrtl.vector<uint<1>, 2>
     // CHECK: %7 = firrtl.bundlecreate %4, %2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.bundle<c: uint<1>, d: uint<1>>
     // CHECK: %8 = firrtl.bundlecreate %6, %7 : (!firrtl.uint<1>, !firrtl.bundle<c: uint<1>, d: uint<1>>) -> !firrtl.bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>
-    // CHECK: firrtl.strictconnect %lhs, %8 : !firrtl.bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>
+    // CHECK: firrtl.matchingconnect %lhs, %8 : !firrtl.bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>
     %lhs = firrtl.wire : !firrtl.bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>
     %rhs_storage = firrtl.wire : !firrtl.vector<bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>, 2>
     %rhs = firrtl.subindex %rhs_storage[0] : !firrtl.vector<bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>, 2>
-    firrtl.strictconnect %lhs, %rhs : !firrtl.bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>
+    firrtl.matchingconnect %lhs, %rhs : !firrtl.bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>
   }
 
   // CHECK-LABEL: @TestRhsExplodedWhenLhsHasFlips
@@ -510,14 +510,14 @@ firrtl.circuit "Test" {
     // CHECK: %11 = firrtl.subindex %10[0] : !firrtl.vector<uint<1>, 2>
     // CHECK: %12 = firrtl.subfield %v2[a] : !firrtl.bundle<a: vector<uint<1>, 2>, b: bundle<c: vector<uint<1>, 2>, d: vector<uint<1>, 2>>>
     // CHECK: %13 = firrtl.subindex %12[0] : !firrtl.vector<uint<1>, 2>
-    // CHECK: firrtl.strictconnect %6, %13 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %4, %11 : !firrtl.uint<1>
-    // CHECK: firrtl.strictconnect %2, %9 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %6, %13 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %4, %11 : !firrtl.uint<1>
+    // CHECK: firrtl.matchingconnect %2, %9 : !firrtl.uint<1>
     %v1 = firrtl.wire : !firrtl.vector<bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>, 2>
     %v2 = firrtl.wire : !firrtl.vector<bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>, 2>
     %b2 = firrtl.subindex %v1[0] : !firrtl.vector<bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>, 2>
     %b3 = firrtl.subindex %v2[0] : !firrtl.vector<bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>, 2>
-    firrtl.strictconnect %b2, %b3 : !firrtl.bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>
+    firrtl.matchingconnect %b2, %b3 : !firrtl.bundle<a: uint<1>, b: bundle<c: uint<1>, d: uint<1>>>
   }
 
   // firrtl.module @TestExplodedNode 
@@ -709,12 +709,12 @@ firrtl.circuit "Test" {
     // CHECK: %5 = firrtl.ref.resolve %1 : !firrtl.probe<uint<8>>
     // CHECK: %6 = firrtl.bundlecreate %4, %5 : (!firrtl.uint<4>, !firrtl.uint<8>) -> !firrtl.bundle<a: uint<4>, b: uint<8>>
     // CHECK: %w = firrtl.wire : !firrtl.bundle<a: uint<4>, b: uint<8>>
-    // CHECK: firrtl.strictconnect %w, %6 : !firrtl.bundle<a: uint<4>, b: uint<8>>
+    // CHECK: firrtl.matchingconnect %w, %6 : !firrtl.bundle<a: uint<4>, b: uint<8>>
     %vector_ref = firrtl.instance sender @RefSender(out port: !firrtl.probe<vector<bundle<a: uint<4>, b: uint<8>>, 2>>)
     %bundle_ref = firrtl.ref.sub     %vector_ref[1] : !firrtl.probe<vector<bundle<a: uint<4>, b: uint<8>>, 2>>
     %bundle_val = firrtl.ref.resolve %bundle_ref    : !firrtl.probe<bundle<a: uint<4>, b: uint<8>>>
     %w = firrtl.wire: !firrtl.bundle<a: uint<4>, b: uint<8>>
-    firrtl.strictconnect %w, %bundle_val : !firrtl.bundle<a: uint<4>, b: uint<8>>
+    firrtl.matchingconnect %w, %bundle_val : !firrtl.bundle<a: uint<4>, b: uint<8>>
   }
 
   //===--------------------------------------------------------------------===//

--- a/test/Dialect/FIRRTL/vectorization.mlir
+++ b/test/Dialect/FIRRTL/vectorization.mlir
@@ -4,11 +4,11 @@ firrtl.circuit "ElementWise" {
 // CHECK-LABEL: @ElementWise
 firrtl.module @ElementWise(in %a: !firrtl.vector<uint<1>, 2>, in %b: !firrtl.vector<uint<1>, 2>, out %c_0: !firrtl.vector<uint<1>, 2>, out %c_1: !firrtl.vector<uint<1>, 2>, out %c_2: !firrtl.vector<uint<1>, 2>) {
   // CHECK-NEXT: %0 = firrtl.elementwise_or %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
-  // CHECK-NEXT: firrtl.strictconnect %c_0, %0 : !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: firrtl.matchingconnect %c_0, %0 : !firrtl.vector<uint<1>, 2>
   // CHECK-NEXT: %1 = firrtl.elementwise_and %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
-  // CHECK-NEXT: firrtl.strictconnect %c_1, %1 : !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: firrtl.matchingconnect %c_1, %1 : !firrtl.vector<uint<1>, 2>
   // CHECK-NEXT: %2 = firrtl.elementwise_xor %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
-  // CHECK-NEXT: firrtl.strictconnect %c_2, %2 : !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: firrtl.matchingconnect %c_2, %2 : !firrtl.vector<uint<1>, 2>
   %0 = firrtl.subindex %b[1] : !firrtl.vector<uint<1>, 2>
   %1 = firrtl.subindex %a[1] : !firrtl.vector<uint<1>, 2>
   %2 = firrtl.subindex %b[0] : !firrtl.vector<uint<1>, 2>
@@ -16,15 +16,15 @@ firrtl.module @ElementWise(in %a: !firrtl.vector<uint<1>, 2>, in %b: !firrtl.vec
   %4 = firrtl.or %3, %2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   %5 = firrtl.or %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   %6 = firrtl.vectorcreate %4, %5 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
-  firrtl.strictconnect %c_0, %6 : !firrtl.vector<uint<1>, 2>
+  firrtl.matchingconnect %c_0, %6 : !firrtl.vector<uint<1>, 2>
   %7 = firrtl.and %3, %2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   %8 = firrtl.and %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   %9 = firrtl.vectorcreate %7, %8 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
-  firrtl.strictconnect %c_1, %9 : !firrtl.vector<uint<1>, 2>
+  firrtl.matchingconnect %c_1, %9 : !firrtl.vector<uint<1>, 2>
   %10 = firrtl.xor %3, %2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   %11 = firrtl.xor %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   %12 = firrtl.vectorcreate %10, %11 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
-  firrtl.strictconnect %c_2, %12 : !firrtl.vector<uint<1>, 2>
+  firrtl.matchingconnect %c_2, %12 : !firrtl.vector<uint<1>, 2>
 }
 }
 

--- a/test/circt-as-dis/basic-firrtl.mlir
+++ b/test/circt-as-dis/basic-firrtl.mlir
@@ -5,12 +5,12 @@
 firrtl.circuit "Top" {
   firrtl.module @Top(in %in : !firrtl.uint<8>,
                      out %out : !firrtl.uint<8>) {
-    firrtl.strictconnect %out, %in : !firrtl.uint<8>
+    firrtl.matchingconnect %out, %in : !firrtl.uint<8>
   }
 }
 
 // CHECK-LABEL: firrtl.circuit "Top" {
 // CHECK-NEXT:    firrtl.module @Top(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
-// CHECK-NEXT:      firrtl.strictconnect %out, %in : !firrtl.uint<8>
+// CHECK-NEXT:      firrtl.matchingconnect %out, %in : !firrtl.uint<8>
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/test/firtool/connect.fir
+++ b/test/firtool/connect.fir
@@ -4,7 +4,7 @@
 
 ; CHECK-LABEL: @regularConnect
 ; CHECK: %0 = firrtl.pad %b, 5 : (!firrtl.uint<3>) -> !firrtl.uint<5>
-; CHECK: firrtl.strictconnect %a, %0 : !firrtl.uint<5>
+; CHECK: firrtl.matchingconnect %a, %0 : !firrtl.uint<5>
 circuit regularConnect :
  module regularConnect :
    output a: UInt<5>
@@ -13,7 +13,7 @@ circuit regularConnect :
 
 ; CHECK-LABEL: @truncatingIntegerConnect
 ; CHECK: %0 = firrtl.tail %b, 2 : (!firrtl.uint<5>) -> !firrtl.uint<3>
-; CHECK: firrtl.strictconnect %a, %0 : !firrtl.uint<3>
+; CHECK: firrtl.matchingconnect %a, %0 : !firrtl.uint<3>
 circuit truncatingIntegerConnect :
  module truncatingIntegerConnect :
    output a: UInt<3>
@@ -24,11 +24,11 @@ circuit truncatingIntegerConnect :
 ; CHECK: %0 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<5>, b: uint<3>>
 ; CHECK: %1 = firrtl.subfield %b[a] : !firrtl.bundle<a: uint<3>, b: uint<2>>
 ; CHECK: %2 = firrtl.pad %1, 5 : (!firrtl.uint<3>) -> !firrtl.uint<5>
-; CHECK: firrtl.strictconnect %0, %2 : !firrtl.uint<5>
+; CHECK: firrtl.matchingconnect %0, %2 : !firrtl.uint<5>
 ; CHECK: %3 = firrtl.subfield %a[b] : !firrtl.bundle<a: uint<5>, b: uint<3>>
 ; CHECK: %4 = firrtl.subfield %b[b] : !firrtl.bundle<a: uint<3>, b: uint<2>>
 ; CHECK: %5 = firrtl.pad %4, 3 : (!firrtl.uint<2>) -> !firrtl.uint<3>
-; CHECK: firrtl.strictconnect %3, %5 : !firrtl.uint<3>
+; CHECK: firrtl.matchingconnect %3, %5 : !firrtl.uint<3>
 circuit regularBundleConnect :
  module regularBundleConnect :
    output a: { a: UInt<5>, b: UInt<3> }
@@ -39,11 +39,11 @@ circuit regularBundleConnect :
 ; CHECK: %0 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<5>, b: uint<3>>
 ; CHECK: %1 = firrtl.subfield %b[a] : !firrtl.bundle<a: uint<6>, b: uint<1>>
 ; CHECK: %2 = firrtl.tail %1, 1 : (!firrtl.uint<6>) -> !firrtl.uint<5>
-; CHECK: firrtl.strictconnect %0, %2 : !firrtl.uint<5>
+; CHECK: firrtl.matchingconnect %0, %2 : !firrtl.uint<5>
 ; CHECK: %3 = firrtl.subfield %a[b] : !firrtl.bundle<a: uint<5>, b: uint<3>>
 ; CHECK: %4 = firrtl.subfield %b[b] : !firrtl.bundle<a: uint<6>, b: uint<1>>
 ; CHECK: %5 = firrtl.pad %4, 3 : (!firrtl.uint<1>) -> !firrtl.uint<3>
-; CHECK: firrtl.strictconnect %3, %5 : !firrtl.uint<3>
+; CHECK: firrtl.matchingconnect %3, %5 : !firrtl.uint<3>
 circuit truncatingBundleConnect :
  module truncatingBundleConnect :
    output a: { a: UInt<5>, b: UInt<3> }

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -111,29 +111,29 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
 
 ; MLIR-LABEL: firrtl.module @test_mod(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %c: !firrtl.uint<1>, in %vec_0: !firrtl.uint<1>, in %vec_1: !firrtl.uint<1>, in %vec_2: !firrtl.uint<1>, out %out_implicitTrunc: !firrtl.uint<1>, out %out_prettifyExample: !firrtl.uint<1>, out %out_multibitMux: !firrtl.uint<1>, out %out_mux2cell_0: !firrtl.uint<1>, out %out_mux2cell_1: !firrtl.uint<1>) {{.*}}{
 ; MLIR:         %cat_a, %cat_b, %cat_c, %cat_d = firrtl.instance cat @Cat(in a: !firrtl.uint<2>, in b: !firrtl.uint<2>, in c: !firrtl.uint<2>, out d: !firrtl.uint<6>)
-; MLIR-NEXT:    firrtl.strictconnect %cat_a, %b : !firrtl.uint<2>
-; MLIR-NEXT:    firrtl.strictconnect %cat_b, %b : !firrtl.uint<2>
-; MLIR-NEXT:    firrtl.strictconnect %cat_c, %b : !firrtl.uint<2>
+; MLIR-NEXT:    firrtl.matchingconnect %cat_a, %b : !firrtl.uint<2>
+; MLIR-NEXT:    firrtl.matchingconnect %cat_b, %b : !firrtl.uint<2>
+; MLIR-NEXT:    firrtl.matchingconnect %cat_c, %b : !firrtl.uint<2>
 ; MLIR-NEXT:    %implicitTrunc_inp_1, %implicitTrunc_inp_2, %implicitTrunc_out1, %implicitTrunc_out2 = firrtl.instance implicitTrunc @ImplicitTrunc(in inp_1: !firrtl.uint<1>, in inp_2: !firrtl.sint<5>, out out1: !firrtl.sint<3>, out out2: !firrtl.sint<3>)
-; MLIR-NEXT:    firrtl.strictconnect %implicitTrunc_inp_1, %a : !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.matchingconnect %implicitTrunc_inp_1, %a : !firrtl.uint<1>
 ; MLIR-NEXT:    %0 = firrtl.asSInt %cat_d : (!firrtl.uint<6>) -> !firrtl.sint<6>
 ; MLIR-NEXT:    %1 = firrtl.bits %0 4 to 0 : (!firrtl.sint<6>) -> !firrtl.uint<5>
 ; MLIR-NEXT:    %2 = firrtl.asSInt %1 : (!firrtl.uint<5>) -> !firrtl.sint<5>
-; MLIR-NEXT:    firrtl.strictconnect %implicitTrunc_inp_2, %2 : !firrtl.sint<5>
+; MLIR-NEXT:    firrtl.matchingconnect %implicitTrunc_inp_2, %2 : !firrtl.sint<5>
 ; MLIR:         %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance prettifyExample @PrettifyExample(in inp_1: !firrtl.uint<5>, in inp_2: !firrtl.uint<5>, in inp_3: !firrtl.uint<5>, out out1: !firrtl.uint<10>, out out2: !firrtl.uint<10>)
 ; MLIR-NEXT:    %3 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
-; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_1, %3 : !firrtl.uint<5>
-; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_2, %3 : !firrtl.uint<5>
-; MLIR-NEXT:    firrtl.strictconnect %prettifyExample_inp_3, %3 : !firrtl.uint<5>
+; MLIR-NEXT:    firrtl.matchingconnect %prettifyExample_inp_1, %3 : !firrtl.uint<5>
+; MLIR-NEXT:    firrtl.matchingconnect %prettifyExample_inp_2, %3 : !firrtl.uint<5>
+; MLIR-NEXT:    firrtl.matchingconnect %prettifyExample_inp_3, %3 : !firrtl.uint<5>
 ; MLIR-NEXT:    %flipFlop_clock, %flipFlop_a_d, %flipFlop_a_q = firrtl.instance flipFlop @FlipFlop(in clock: !firrtl.clock, in a_d: !firrtl.uint<1>, out a_q: !firrtl.uint<1>)
-; MLIR-NEXT:    firrtl.strictconnect %flipFlop_clock, %clock : !firrtl.clock
-; MLIR-NEXT:    firrtl.strictconnect %flipFlop_a_d, %a : !firrtl.uint<1>
-; MLIR-NEXT:    firrtl.strictconnect %c, %flipFlop_a_q : !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.matchingconnect %flipFlop_clock, %clock : !firrtl.clock
+; MLIR-NEXT:    firrtl.matchingconnect %flipFlop_a_d, %a : !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.matchingconnect %c, %flipFlop_a_q : !firrtl.uint<1>
 ; MLIR-NEXT:    %multibitMux_a_0, %multibitMux_a_1, %multibitMux_a_2, %multibitMux_sel, %multibitMux_b = firrtl.instance multibitMux @MultibitMux(in a_0: !firrtl.uint<1>, in a_1: !firrtl.uint<1>, in a_2: !firrtl.uint<1>, in sel: !firrtl.uint<2>, out b: !firrtl.uint<1>)
-; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_0, %vec_0 : !firrtl.uint<1>
-; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_1, %vec_1 : !firrtl.uint<1>
-; MLIR-NEXT:    firrtl.strictconnect %multibitMux_a_2, %vec_2 : !firrtl.uint<1>
-; MLIR-NEXT:    firrtl.strictconnect %multibitMux_sel, %b : !firrtl.uint<2>
+; MLIR-NEXT:    firrtl.matchingconnect %multibitMux_a_0, %vec_0 : !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.matchingconnect %multibitMux_a_1, %vec_1 : !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.matchingconnect %multibitMux_a_2, %vec_2 : !firrtl.uint<1>
+; MLIR-NEXT:    firrtl.matchingconnect %multibitMux_sel, %b : !firrtl.uint<2>
 
 ; ANNOTATIONS-LABEL: firrtl.module @test_mod
 ; ANNOTATIONS-SAME: {class = "circt.test", info = "a ModuleTarget Annotation"}

--- a/test/firtool/firtool.mlir
+++ b/test/firtool/firtool.mlir
@@ -16,7 +16,7 @@ firrtl.circuit "Top" {
 }
 
 // MLIR-LABEL: firrtl.module @Top(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
-// MLIR-NEXT:    firrtl.strictconnect %out, %in : !firrtl.uint<8>
+// MLIR-NEXT:    firrtl.matchingconnect %out, %in : !firrtl.uint<8>
 // MLIR-NEXT:  }
 
 // VERILOG-LABEL: module Top(

--- a/test/firtool/optimizations.fir
+++ b/test/firtool/optimizations.fir
@@ -19,25 +19,25 @@ circuit test_cse :
 
 ; Only one add.
 ; OPT: %0 = firrtl.add %a1, %a2
-; OPT: firrtl.strictconnect %b, %0
-; OPT: firrtl.strictconnect %c, %0
+; OPT: firrtl.matchingconnect %b, %0
+; OPT: firrtl.matchingconnect %c, %0
 
 ; Connect with zero and one directly.
-; OPT: firrtl.strictconnect %d, %c0_ui5
-; OPT: firrtl.strictconnect %e, %c1_ui5
+; OPT: firrtl.matchingconnect %d, %c0_ui5
+; OPT: firrtl.matchingconnect %e, %c1_ui5
 
 ; Both adds persist.
 ; NOOPT: %0 = firrtl.add %a1, %a2
-; NOOPT: firrtl.strictconnect %b, %0
+; NOOPT: firrtl.matchingconnect %b, %0
 ; NOOPT: %1 = firrtl.add %a1, %a2
-; NOOPT: firrtl.strictconnect %c, %1
+; NOOPT: firrtl.matchingconnect %c, %1
 
 ; Ands persist.
 ; NOOPT: %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
 ; NOOPT: firrtl.and %a1, %c0_ui4
-; NOOPT: firrtl.strictconnect %d,
+; NOOPT: firrtl.matchingconnect %d,
 
 ; NOOPT-DAG: %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
 ; NOOPT-DAG: %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
 ; NOOPT: firrtl.and %c3_ui4, %c1_ui4
-; NOOPT: firrtl.strictconnect %e,
+; NOOPT: firrtl.matchingconnect %e,

--- a/test/firtool/phase-ordering.fir
+++ b/test/firtool/phase-ordering.fir
@@ -8,7 +8,7 @@
 ; CHECK:       %[[memory_0:.+]] = firrtl.reg %clock {{.*}}: !firrtl.clock, !firrtl.uint<8>
 ; CHECK:       firrtl.mux(%[[v14:.+]], %wData_0, %[[memory_0]])
 ; CHECK:       firrtl.mux(%[[v19:.+]], %wData_1, %[[v5:.+]])
-; CHECK:       firrtl.strictconnect %[[memory_0]], %[[v22:.+]]
+; CHECK:       firrtl.matchingconnect %[[memory_0]], %[[v22:.+]]
 circuit Issue794: %[[{
     "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
     "target":"~Issue794|Issue794"


### PR DESCRIPTION
This is to reserve "Strict" for LHSType connects in the future.