### PR TITLE
 [FIRRTL] Add a new op interface for combinational loop detection.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -330,8 +330,7 @@ def MemOp : HardwareDeclOp<"mem", [CombDataflow]> {
     // Extract the relevant attributes from the MemOp and return a FirMemory object.
     FirMemory getSummary();
 
-    SmallVector<std::pair<circt::FieldRef, circt::FieldRef>>
-      computeDataFlow ();
+    SmallVector<std::pair<circt::FieldRef, circt::FieldRef>> computeDataFlow();
   }];
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -235,7 +235,7 @@ def InstanceChoiceOp : HardwareDeclOp<"instance_choice", [
 }
 
 
-def MemOp : HardwareDeclOp<"mem"> {
+def MemOp : HardwareDeclOp<"mem", [CombDataflow]> {
   let summary = "Define a new mem";
   let arguments =
     (ins ConfinedAttr<I32Attr, [IntMinValue<0>]>:$readLatency,
@@ -329,6 +329,9 @@ def MemOp : HardwareDeclOp<"mem"> {
 
     // Extract the relevant attributes from the MemOp and return a FirMemory object.
     FirMemory getSummary();
+
+    SmallVector<std::pair<circt::FieldRef, circt::FieldRef>>
+      computeDataFlow ();
   }];
 }
 
@@ -388,7 +391,7 @@ def NodeOp : HardwareDeclOp<"node", [
   let hasFolder = 1;
 }
 
-def RegOp : HardwareDeclOp<"reg", [Forceable, Sequential]> {
+def RegOp : HardwareDeclOp<"reg", [Forceable, CombDataflow]> {
   let summary = "Define a new register";
   let description = [{
     Declare a new register:
@@ -480,7 +483,7 @@ def RegOp : HardwareDeclOp<"reg", [Forceable, Sequential]> {
   let hasCanonicalizeMethod = true;
 }
 
-def RegResetOp : HardwareDeclOp<"regreset", [Forceable, Sequential]> {
+def RegResetOp : HardwareDeclOp<"regreset", [Forceable, CombDataflow]> {
   let summary = "Define a new register with a reset";
   let description = [{
     Declare a new register:

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -388,7 +388,7 @@ def NodeOp : HardwareDeclOp<"node", [
   let hasFolder = 1;
 }
 
-def RegOp : HardwareDeclOp<"reg", [Forceable]> {
+def RegOp : HardwareDeclOp<"reg", [Forceable, Sequential]> {
   let summary = "Define a new register";
   let description = [{
     Declare a new register:
@@ -480,7 +480,7 @@ def RegOp : HardwareDeclOp<"reg", [Forceable]> {
   let hasCanonicalizeMethod = true;
 }
 
-def RegResetOp : HardwareDeclOp<"regreset", [Forceable]> {
+def RegResetOp : HardwareDeclOp<"regreset", [Forceable, Sequential]> {
   let summary = "Define a new register with a reset";
   let description = [{
     Declare a new register:

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -19,6 +19,7 @@
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/InnerSymbolTable.h"
+#include "circt/Support/FieldRef.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -537,8 +537,8 @@ def CombDataflow : OpInterface<"CombDataFlow"> {
      "element is the destination and the second is the source of the dependence."
      "The default implementation returns an empty list, which implies that the"
      "operation is not combinational.",
-    "SmallVector<std::pair<circt::FieldRef, circt::FieldRef>> ",
-    "computeDataFlow", (ins), [{}], /*defaultImplementation=*/[{
+     "SmallVector<std::pair<circt::FieldRef, circt::FieldRef>>",
+     "computeDataFlow", (ins), [{}], /*defaultImplementation=*/[{
       return {};
     }]>,
   ];

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -523,14 +523,24 @@ def Forceable : OpInterface<"Forceable"> {
   }];
 }
 
-def Sequential : OpInterface<"Sequential"> {
+def CombDataflow : OpInterface<"CombDataFlow"> {
   let cppNamespace = "circt::firrtl";
   let description = [{
-    This interface is used for sequentional ops, for which the output depends on
-    the current and previous input values. This can be used to denote ops that
-    should be ignored when checking for combinational loops.
-    Memory is not considered a sequential op since it has inputs like the enable
-    and address ports which can form a combinational loop with the result.
+    This interface is used for specifying the combinational dataflow that exists
+    in the results and operands of an operation.
+    Any operation that doesn't implement this interface is assumed to have a
+    combinational dependence from each operand to each result.
   }];
+  let methods = [
+    InterfaceMethod<"Get the combinational dataflow relations between the"
+     "operands and the results. This returns a pair of fieldrefs. The first" 
+     "element is the destination and the second is the source of the dependence."
+     "The default implementation returns an empty list, which implies that the"
+     "operation is not combinational.",
+    "SmallVector<std::pair<circt::FieldRef, circt::FieldRef>> ",
+    "computeDataFlow", (ins), [{}], /*defaultImplementation=*/[{
+      return {};
+    }]>,
+  ];
 }
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -523,4 +523,14 @@ def Forceable : OpInterface<"Forceable"> {
   }];
 }
 
+def Sequential : OpInterface<"Sequential"> {
+  let cppNamespace = "circt::firrtl";
+  let description = [{
+    This interface is used for sequentional ops, for which the output depends on
+    the current and previous input values. This can be used to denote ops that
+    should be ignored when checking for combinational loops.
+    Memory is not considered a sequential op since it has inputs like the enable
+    and address ports which can form a combinational loop with the result.
+  }];
+}
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_TD

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -129,8 +129,8 @@ MemOp::computeDataFlow() {
       auto dataFieldId = type.getFieldID((unsigned)ReadPortSubfield::data);
       deps.push_back({FieldRef(memPort, static_cast<unsigned>(dataFieldId)),
                       FieldRef(memPort, static_cast<unsigned>(enableFieldId))});
-      deps.push_back({{memPort, static_cast<unsigned int>(dataFieldId)},
-                      {memPort, static_cast<unsigned int>(addressFieldId)}});
+      deps.push_back({{memPort, static_cast<unsigned>(dataFieldId)},
+                      {memPort, static_cast<unsigned>(addressFieldId)}});
     }
   return deps;
 }

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -113,6 +113,28 @@ bool firrtl::isDuplexValue(Value val) {
   return false;
 }
 
+SmallVector<std::pair<circt::FieldRef, circt::FieldRef>>
+MemOp::computeDataFlow() {
+  // If read result has non-zero latency, then no combinational dependency
+  // exists.
+  if (getReadLatency() > 0)
+    return {};
+
+  SmallVector<std::pair<circt::FieldRef, circt::FieldRef>> deps;
+  // Add a dependency from the enable and address fields to the data field.
+  for (auto memPort : getResults())
+    if (auto type = type_dyn_cast<BundleType>(memPort.getType())) {
+      auto enableFieldId = type.getFieldID((unsigned)ReadPortSubfield::en);
+      auto addressFieldId = type.getFieldID((unsigned)ReadPortSubfield::addr);
+      auto dataFieldId = type.getFieldID((unsigned)ReadPortSubfield::data);
+      deps.push_back({FieldRef(memPort, static_cast<unsigned>(dataFieldId)),
+                      FieldRef(memPort, static_cast<unsigned>(enableFieldId))});
+      deps.push_back({{memPort, static_cast<unsigned int>(dataFieldId)},
+                      {memPort, static_cast<unsigned int>(addressFieldId)}});
+    }
+  return deps;
+}
+
 /// Return the kind of port this is given the port type from a 'mem' decl.
 static MemOp::PortKind getMemPortKindFromType(FIRRTLType type) {
   constexpr unsigned int addr = 1 << 0;

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -86,10 +86,9 @@ public:
                       });
     }
 
-    bool foreignOps = false;
     walk(module, [&](Operation *op) {
       llvm::TypeSwitch<Operation *>(op)
-          .Case<RegOp, RegResetOp>([&](auto) {})
+          .Case<Sequential>([&](auto) {})
           .Case<Forceable>([&](Forceable forceableOp) {
             // Any declaration that can be forced.
             if (auto node = dyn_cast<NodeOp>(op))
@@ -165,33 +164,12 @@ public:
           .Case<FConnectLike>([&](FConnectLike connect) {
             recordDataflow(connect.getDest(), connect.getSrc());
           })
-          .Case<mlir::UnrealizedConversionCastOp>([&](auto) {
-            // Casts are cast-like regardless of source.
-            // UnrealizedConversionCastOp doesn't implement CastOpInterace,
-            // otherwise we would use it here.
+          .Default([&](Operation *op) {
+            // All other expressions are assumed to be combinational, so record
+            // the dataflow between all inputs to outputs.
             for (auto res : op->getResults())
               for (auto src : op->getOperands())
                 recordDataflow(res, src);
-          })
-          .Default([&](Operation *op) {
-            // Non FIRRTL ops are not checked
-            if (!op->getDialect() ||
-                !isa<FIRRTLDialect, chirrtl::CHIRRTLDialect>(
-                    op->getDialect())) {
-              if (!foreignOps && op->getNumResults() > 0 &&
-                  op->getNumOperands() > 0) {
-                op->emitRemark("Non-firrtl operations detected, combinatorial "
-                               "loop checking may miss some loops.");
-                foreignOps = true;
-              }
-              return;
-            }
-            // All other expressions.
-            if (op->getNumResults() == 1) {
-              auto res = op->getResult(0);
-              for (auto src : op->getOperands())
-                recordDataflow(res, src);
-            }
           });
     });
   }

--- a/test/Dialect/FIRRTL/check-comb-cycles.mlir
+++ b/test/Dialect/FIRRTL/check-comb-cycles.mlir
@@ -1036,46 +1036,6 @@ firrtl.circuit "UnrealizedConversionCast" {
 
 // -----
 
-firrtl.circuit "OutsideDialect" {
-  firrtl.module @OutsideDialect() {
-    // Other dialects might need to close loops in their own ops. Ignore 
-    // ops from other dialects
-    %b = firrtl.wire   : !firrtl.uint<32>
-    // expected-remark @below {{Non-firrtl operations detected, combinatorial loop checking may miss some loops.}}
-    %a = "foo"(%b) : (!firrtl.uint<32>) -> !firrtl.uint<32>
-    // Should only trigger once
-    %c = "foo"(%b) : (!firrtl.uint<32>) -> !firrtl.uint<32>
-    firrtl.matchingconnect %b, %a : !firrtl.uint<32>
-  }
-}
-
-// -----
-
-// Foreign op looks sink like, no loop
-firrtl.circuit "OutsideDialectSink" {
-  firrtl.module @OutsideDialectSink() {
-    // Other dialects might need to close loops in their own ops. Ignore 
-    // ops from other dialects
-    %b = firrtl.wire   : !firrtl.uint<32>
-    "foo"(%b) : (!firrtl.uint<32>) -> ()
-  }
-}
-
-// -----
-
-// Foreign op looks source like, no loop
-firrtl.circuit "OutsideDialectSource" {
-  firrtl.module @OutsideDialectSource() {
-    // Other dialects might need to close loops in their own ops. Ignore 
-    // ops from other dialects
-    %b = firrtl.wire   : !firrtl.uint<32>
-    %a = "foo"() : () -> !firrtl.uint<32>
-    firrtl.matchingconnect %b, %a : !firrtl.uint<32>
-  }
-}
-
-// -----
-
 // Check RWProbeOp + force doesn't crash.
 // No loop here.
 firrtl.circuit "Issue6820" {


### PR DESCRIPTION
Add a new `CombDataflow` op interface to `FIRRTL`. 
This interface is used for specifying the combinational dataflow that exists
 in the results and operands of an operation. Any operation that doesn't
 implement this interface is assumed to have a  combinational dependence
 from each operand to each result. 

Only `FIRRTL` register and memory ops implement this interface, but it can be used in other
dialects that intend to use the `CheckCombCycles` pass.