### PR TITLE
[CombFolds] Relax block optimization barrier by pulling constants

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -36,6 +36,56 @@ static bool hasOperandsOutsideOfBlock(Operation *op) {
   });
 }
 
+/// If _all_ of the operation's operands, which are defined outside of the
+/// operation's own block, are ConstantLike, rematerialize them inside of the
+/// operation's block. This relaxes the conservativeness incurred by the
+/// 'hasOperandsOutsideOfBlock' checks.
+static LogicalResult
+materializeConstantOperandsLocally(Operation *op, PatternRewriter &rewriter) {
+  SmallVector<Value> newOperands;
+  newOperands.reserve(op->getNumOperands());
+  bool doOpRewrite = false;
+
+  for (auto operand : op->getOperands()) {
+    auto defOp = operand.getDefiningOp();
+
+    if (!defOp || defOp->getBlock() == op->getBlock()) {
+      // Keep local operands
+      newOperands.push_back(operand);
+      continue;
+    }
+
+    if (!defOp->hasTrait<OpTrait::ConstantLike>()) {
+      // Optimization will remain blocked, so don't bother changing the op.
+      doOpRewrite = false;
+      break;
+    }
+
+    // Pull the constant into the op's block.
+    PatternRewriter::InsertionGuard g(rewriter);
+    rewriter.setInsertionPointToStart(op->getBlock());
+    auto cloned = rewriter.clone(*defOp);
+
+    for (unsigned resultIdx = 0; resultIdx < defOp->getNumResults();
+         ++resultIdx) {
+      if (operand == defOp->getResult(resultIdx)) {
+        newOperands.push_back(cloned->getResult(resultIdx));
+        break;
+      }
+    }
+    doOpRewrite = true;
+  }
+
+  if (!doOpRewrite)
+    return failure();
+
+  assert(newOperands.size() == op->getNumOperands() &&
+         "Incorrect number of new operands");
+  rewriter.modifyOpInPlace(op, [&]() { op->setOperands(newOperands); });
+
+  return success();
+}
+
 /// Create a new instance of a generic operation that only has value operands,
 /// and has a single result value whose type matches the first operand.
 ///
@@ -365,7 +415,7 @@ OpFoldResult ShlOp::fold(FoldAdaptor adaptor) {
 
 LogicalResult ShlOp::canonicalize(ShlOp op, PatternRewriter &rewriter) {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   // ShlOp(x, cst) -> Concat(Extract(x), zeros)
   APInt value;
@@ -408,7 +458,7 @@ OpFoldResult ShrUOp::fold(FoldAdaptor adaptor) {
 
 LogicalResult ShrUOp::canonicalize(ShrUOp op, PatternRewriter &rewriter) {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   // ShrUOp(x, cst) -> Concat(zeros, Extract(x))
   APInt value;
@@ -446,7 +496,7 @@ OpFoldResult ShrSOp::fold(FoldAdaptor adaptor) {
 
 LogicalResult ShrSOp::canonicalize(ShrSOp op, PatternRewriter &rewriter) {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   // ShrSOp(x, cst) -> Concat(replicate(extract(x, topbit)),extract(x))
   APInt value;
@@ -609,7 +659,7 @@ static bool extractFromReplicate(ExtractOp op, ReplicateOp replicate,
 
 LogicalResult ExtractOp::canonicalize(ExtractOp op, PatternRewriter &rewriter) {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   auto *inputOp = op.getInput().getDefiningOp();
 
@@ -969,7 +1019,7 @@ static bool canonicalizeIdempotentInputs(Op op, PatternRewriter &rewriter) {
 
 LogicalResult AndOp::canonicalize(AndOp op, PatternRewriter &rewriter) {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   auto inputs = op.getInputs();
   auto size = inputs.size();
@@ -1256,7 +1306,7 @@ static bool canonicalizeOrOfConcatsWithCstOperands(OrOp op, size_t concatIdx1,
 
 LogicalResult OrOp::canonicalize(OrOp op, PatternRewriter &rewriter) {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   auto inputs = op.getInputs();
   auto size = inputs.size();
@@ -1414,7 +1464,7 @@ static void canonicalizeXorIcmpTrue(XorOp op, unsigned icmpOperand,
 
 LogicalResult XorOp::canonicalize(XorOp op, PatternRewriter &rewriter) {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   auto inputs = op.getInputs();
   auto size = inputs.size();
@@ -1525,7 +1575,7 @@ OpFoldResult SubOp::fold(FoldAdaptor adaptor) {
 
 LogicalResult SubOp::canonicalize(SubOp op, PatternRewriter &rewriter) {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   // sub(x, cst) -> add(x, -cst)
   APInt value;
@@ -1559,7 +1609,7 @@ OpFoldResult AddOp::fold(FoldAdaptor adaptor) {
 
 LogicalResult AddOp::canonicalize(AddOp op, PatternRewriter &rewriter) {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   auto inputs = op.getInputs();
   auto size = inputs.size();
@@ -1689,7 +1739,7 @@ OpFoldResult MulOp::fold(FoldAdaptor adaptor) {
 
 LogicalResult MulOp::canonicalize(MulOp op, PatternRewriter &rewriter) {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   auto inputs = op.getInputs();
   auto size = inputs.size();
@@ -1838,7 +1888,7 @@ OpFoldResult ConcatOp::fold(FoldAdaptor adaptor) {
 
 LogicalResult ConcatOp::canonicalize(ConcatOp op, PatternRewriter &rewriter) {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   auto inputs = op.getInputs();
   auto size = inputs.size();
@@ -2460,7 +2510,7 @@ struct MuxRewriter : public mlir::OpRewritePattern<MuxOp> {
 LogicalResult MuxRewriter::matchAndRewrite(MuxOp op,
                                            PatternRewriter &rewriter) const {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   // If the op has a SV attribute, don't optimize it.
   if (hasSVAttributes(op))
@@ -2753,7 +2803,7 @@ struct ArrayRewriter : public mlir::OpRewritePattern<hw::ArrayCreateOp> {
   LogicalResult matchAndRewrite(hw::ArrayCreateOp op,
                                 PatternRewriter &rewriter) const override {
     if (hasOperandsOutsideOfBlock(&*op))
-      return failure();
+      return materializeConstantOperandsLocally(&*op, rewriter);
 
     if (foldArrayOfMuxes(op, rewriter))
       return success();
@@ -3113,7 +3163,7 @@ static void combineEqualityICmpWithXorOfConstant(ICmpOp cmpOp, XorOp xorOp,
 
 LogicalResult ICmpOp::canonicalize(ICmpOp op, PatternRewriter &rewriter) {
   if (hasOperandsOutsideOfBlock(&*op))
-    return failure();
+    return materializeConstantOperandsLocally(&*op, rewriter);
 
   APInt lhs, rhs;
 

--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -55,11 +55,9 @@ materializeConstantOperandsLocally(Operation *op, PatternRewriter &rewriter) {
       continue;
     }
 
-    if (!defOp->hasTrait<OpTrait::ConstantLike>()) {
+    if (!defOp->hasTrait<OpTrait::ConstantLike>())
       // Optimization will remain blocked, so don't bother changing the op.
-      doOpRewrite = false;
-      break;
-    }
+      return failure();
 
     // Pull the constant into the op's block.
     PatternRewriter::InsertionGuard g(rewriter);

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -1553,6 +1553,23 @@ hw.module @OrMuxSameTrueValueAndZero(in %tag_0: i1, in %tag_1: i1, in %tag_2: i1
     "terminator"(%add2) : (i32) -> ()
 }) : () -> ()
 
+// CHECK-LABEL:   "test.acrossBlockCanonicalizationPullConstants"() ({
+// CHECK:         ^bb0(%[[A:.*]]: i1):
+// CHECK:           %[[CST_FALSE:.*]] = hw.constant false
+// CHECK:           "terminator"(%[[A]]) : (i1) -> ()
+// CHECK:         ^bb1(%{{.+}}: i1):
+// CHECK:           "terminator"(%[[CST_FALSE]]) : (i1) -> ()
+// CHECK:         }) : () -> ()
+"test.acrossBlockCanonicalizationPullConstants"() ({
+  ^bb0(%a: i1):
+    %cstFalse = hw.constant false
+    "terminator"(%a) : (i1) -> ()
+  ^bb1(%b: i1):
+    // Canonicalization _should_ pull constants across block boundaries.
+    %and = comb.and bin %b, %cstFalse : i1
+    "terminator"(%and) : (i1) -> ()
+}) : () -> ()
+
 // CHECK-LABEL: hw.module @combineOppositeBinCmpIntoConstant
 // CHECK: %[[TRUE:.+]] = hw.constant true
 // CHECK: %[[FALSE:.+]] = hw.constant false

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -82,10 +82,10 @@ func.func @empy_op(%arg0: i1) {
 }
 
 // CHECK-LABEL: func @invert_if(%arg0: i1, %arg1: i1) {
-// CHECK-NEXT:    %true = hw.constant true
 // CHECK-NEXT:    [[FD:%.*]] = hw.constant -2147483646 : i32
 // CHECK-NEXT:    sv.initial  {
-// CHECK-NEXT:        %0 = comb.xor %arg0, %arg1, %true : i1
+// CHECK-NEXT:      %true = hw.constant true
+// CHECK-NEXT:      %0 = comb.xor %arg0, %arg1, %true : i1
 // CHECK-NEXT:      sv.if %0  {
 // CHECK-NEXT:        sv.fwrite [[FD]], "Foo"
 // CHECK-NEXT:      }

--- a/test/firtool/plusargs.fir
+++ b/test/firtool/plusargs.fir
@@ -30,9 +30,10 @@ circuit PlusArgTest:
     ; CHECK-NEXT:   sv.assign [[FOUND_BAR_REG]], %false : i1
     ; CHECK-NEXT: } else {
     ; CHECK-NEXT:   sv.initial {
+    ; CHECK-NEXT:     [[CST_ZERO:%.+]] = hw.constant 0 : i32
     ; CHECK-NEXT:     [[FORMAT_BAR:%.+]] = sv.constantStr "foo=%d"
     ; CHECK-NEXT:     [[TMP_BAR:%.+]] = sv.system "value$plusargs"([[FORMAT_BAR]], [[RESULT_BAR_REG]]) : (!hw.string, !hw.inout<i32>) -> i32
-    ; CHECK-NEXT:     [[FOUND_BAR_VAL:%.+]] = comb.icmp bin ne [[TMP_BAR]], %c0_i32 : i32
+    ; CHECK-NEXT:     [[FOUND_BAR_VAL:%.+]] = comb.icmp bin ne [[TMP_BAR]], [[CST_ZERO]] : i32
     ; CHECK-NEXT:     sv.bpassign [[FOUND_BAR_REG]], [[FOUND_BAR_VAL]] : i1
     ; CHECK-NEXT:   }
     ; CHECK-NEXT: }


### PR DESCRIPTION
This is an attempt at reducing the conservativeness of the cross-block optimization barrier introduced in #6235. See also #6523.

If canonicalization of an operation is prevented due to an operand defined outside of its block, check if all of these operands are `ConstantLike`. If so, create a copy of them inside of the operation's block, in the hope that this enables optimization in the next iteration.
I do not love this approach, as it causes movements/duplications even if doesn't have any benefit. But I feel this is the lesser evil compared to leaving chunks of dead code float around because a trivial fold like `a & false -> false`  is being prevented.

Is this relaxation acceptable for your use case, @mortbopet @teqdruid ? Am I missing a more elegant solution?