### PR TITLE
[FIRRTL] Support abstract reset in RWProbeOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1372,7 +1372,7 @@ def RWProbeOp : FIRRTLOp<"ref.rwprobe",
   }];
 
   let arguments = (ins InnerRefAttr:$target);
-  let results = (outs RWProbeConcreteReset:$result);
+  let results = (outs RWProbe:$result);
   let assemblyFormat = "$target attr-dict `:` type($result)";
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -104,12 +104,6 @@ def RWProbe : FIRRTLDialectType<
   CPred<"type_isa<RefType>($_self) && type_cast<RefType>($_self).getForceable()">,
    "rwprobe type", "::circt::firrtl::RefType">;
 
-def RWProbeConcreteReset : FIRRTLDialectType<
-  CPred<[{type_isa<RefType>($_self) &&
-         type_cast<RefType>($_self).getForceable() &&
-         !type_cast<RefType>($_self).hasUninferredReset()}]>,
-   "rwprobe type (with concrete resets only)", "::circt::firrtl::RefType">;
-
 def ConnectableType : AnyTypeOf<[FIRRTLBaseType, ForeignType]>;
 def MatchingConnectableType : AnyTypeOf<[SizedPassiveType, ForeignType]>;
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -2046,16 +2046,6 @@ firrtl.circuit "RWProbeTypes" {
 
 // -----
 
-firrtl.circuit "RWProbeUninferredReset" {
-  firrtl.module @RWProbeUninferredReset() {
-    %w = firrtl.wire sym @x : !firrtl.bundle<a: reset>
-    // expected-error @below {{op result #0 must be rwprobe type (with concrete resets only), but got '!firrtl.rwprobe<bundle<a: reset>>}}
-    %rw = firrtl.ref.rwprobe <@RWProbeUninferredReset::@x> : !firrtl.rwprobe<bundle<a: reset>>
-  }
-}
-
-// -----
-
 firrtl.circuit "RWProbeInstance" {
   firrtl.extmodule @Ext()
   firrtl.module @RWProbeInstance() {

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -1092,3 +1092,30 @@ firrtl.circuit "TraceThroughNodes" {
     %node2 = firrtl.node %localReset2 : !firrtl.reset
   }
 }
+
+// -----
+
+// CHECK-LABEL: "RWProbeOp"
+firrtl.circuit "RWProbeOp" {
+  // CHECK: <a: asyncreset, b: asyncreset>
+  // CHECK-NOT: firrtl.reset
+  firrtl.module @RWProbeOp(in %driver: !firrtl.asyncreset, out %out: !firrtl.bundle<a: reset, b: reset>, out %out2: !firrtl.reset) {
+    %r = firrtl.wire sym [<@r,0,public>,<@r_a,1,public>,<@r_b,2,public>] : !firrtl.bundle<a: reset, b flip: reset>
+
+    %r_a = firrtl.subfield %r[a] : !firrtl.bundle<a: reset, b flip: reset>
+    %r_b = firrtl.subfield %r[b] : !firrtl.bundle<a: reset, b flip: reset>
+    firrtl.connect %r_a, %driver : !firrtl.reset, !firrtl.asyncreset
+    firrtl.connect %r_b, %driver : !firrtl.reset, !firrtl.asyncreset
+
+    %r_a_rw = firrtl.ref.rwprobe <@RWProbeOp::@r_a> : !firrtl.rwprobe<reset>
+    %r_b_rw = firrtl.ref.rwprobe <@RWProbeOp::@r_b> : !firrtl.rwprobe<reset>
+    %r_rw = firrtl.ref.rwprobe <@RWProbeOp::@r> : !firrtl.rwprobe<bundle<a: reset, b: reset>>
+
+    %r_b_read = firrtl.ref.resolve %r_b_rw : !firrtl.rwprobe<reset>
+    %r_read = firrtl.ref.resolve %r_rw : !firrtl.rwprobe<bundle<a: reset, b: reset>>
+
+    firrtl.matchingconnect %out2, %r_b_read : !firrtl.reset
+    firrtl.matchingconnect %out, %r_read : !firrtl.bundle<a: reset, b: reset>
+  }
+}
+

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -1097,24 +1097,33 @@ firrtl.circuit "TraceThroughNodes" {
 
 // CHECK-LABEL: "RWProbeOp"
 firrtl.circuit "RWProbeOp" {
-  // CHECK: <a: asyncreset, b: asyncreset>
-  // CHECK-NOT: firrtl.reset
+  // CHECK: %out: !firrtl.bundle<a: asyncreset, b: asyncreset>
+  // CHECK-SAME: %out2: !firrtl.asyncreset
   firrtl.module @RWProbeOp(in %driver: !firrtl.asyncreset, out %out: !firrtl.bundle<a: reset, b: reset>, out %out2: !firrtl.reset) {
     %r = firrtl.wire sym [<@r,0,public>,<@r_a,1,public>,<@r_b,2,public>] : !firrtl.bundle<a: reset, b flip: reset>
 
+    // CHECK-COUNT-2: <a: asyncreset, b flip: asyncreset>
     %r_a = firrtl.subfield %r[a] : !firrtl.bundle<a: reset, b flip: reset>
     %r_b = firrtl.subfield %r[b] : !firrtl.bundle<a: reset, b flip: reset>
+    // CHECK-COUNT-2: %driver : !firrtl.asyncreset
     firrtl.connect %r_a, %driver : !firrtl.reset, !firrtl.asyncreset
     firrtl.connect %r_b, %driver : !firrtl.reset, !firrtl.asyncreset
 
+    // CHECK-NEXT: rwprobe<asyncreset>
     %r_a_rw = firrtl.ref.rwprobe <@RWProbeOp::@r_a> : !firrtl.rwprobe<reset>
+    // CHECK-NEXT: rwprobe<asyncreset>
     %r_b_rw = firrtl.ref.rwprobe <@RWProbeOp::@r_b> : !firrtl.rwprobe<reset>
+    // CHECK-NEXT: rwprobe<bundle<a: asyncreset, b: asyncreset>>
     %r_rw = firrtl.ref.rwprobe <@RWProbeOp::@r> : !firrtl.rwprobe<bundle<a: reset, b: reset>>
 
+    // CHECK-NEXT: rwprobe<asyncreset>
     %r_b_read = firrtl.ref.resolve %r_b_rw : !firrtl.rwprobe<reset>
+    // CHECK-NEXT: rwprobe<bundle<a: asyncreset, b: asyncreset>>
     %r_read = firrtl.ref.resolve %r_rw : !firrtl.rwprobe<bundle<a: reset, b: reset>>
 
+    // CHECK-NEXT: firrtl.asyncreset
     firrtl.matchingconnect %out2, %r_b_read : !firrtl.reset
+    // CHECK-NEXT: bundle<a: asyncreset, b: asyncreset>
     firrtl.matchingconnect %out, %r_read : !firrtl.bundle<a: reset, b: reset>
   }
 }


### PR DESCRIPTION
Simplification follows as no longer need forceable.