### PR TITLE
Capitalize Mode in github workflow.  

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -145,12 +145,12 @@ jobs:
           # gcc   + debug   + assert   + shared
           - cc: clang
             cxx: clang++
-            mode: debug
+            mode: Debug
             assert: ON
             shared: ON
           - cc: gcc
             cxx: g++
-            mode: release
+            mode: Release
             assert: OFF
             shared: OFF
 

--- a/.github/workflows/uploadReleaseArtifacts.yml
+++ b/.github/workflows/uploadReleaseArtifacts.yml
@@ -29,10 +29,10 @@ on:
         required: true
         type: choice
         options:
-          - release
-          - relwithdebinfo
-          - debug
-        default: release
+          - Release
+          - RelWithDebInfo
+          - Debug
+        default: Release
 
   # Run every day at 0700 UTC which is:
   #   - 0000 PDT / 2300 PST


### PR DESCRIPTION
This might fix a new breakage on the gcc build complaining about DCMAKE_BUILD_TYPE

Should fix:
```
CMake Error at CMakeLists.txt:88 (message):
  

  No build type selected.  You need to pass -DCMAKE_BUILD_TYPE=<type> in
  order to configure LLVM.

  Available options are:

    * -DCMAKE_BUILD_TYPE=Release - For an optimized build with no assertions or debug info.
    * -DCMAKE_BUILD_TYPE=Debug - For an unoptimized build with assertions and debug info.
    * -DCMAKE_BUILD_TYPE=RelWithDebInfo - For an optimized build with no assertions but with debug info.
    * -DCMAKE_BUILD_TYPE=MinSizeRel - For a build optimized for size instead of speed.

```