### PR TITLE
[FIRRTL][InferResets] Learn how to trace through nodes.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -767,6 +767,8 @@ void InferResetsPass::traceResets(CircuitOp circuit) {
                         op.getLoc());
           })
           .Case<Forceable>([&](Forceable op) {
+            if (auto node = dyn_cast<NodeOp>(op.getOperation()))
+              traceResets(node.getResult(), node.getInput(), node.getLoc());
             // Trace reset into rwprobe.  Avoid invalid IR.
             if (op.isForceable())
               traceResets(op.getDataType(), op.getData(), 0, op.getDataType(),

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -1069,3 +1069,26 @@ firrtl.circuit "InferToRWProbe" {
    firrtl.connect %r_b, %driver : !firrtl.reset, !firrtl.asyncreset
   }
 }
+
+// -----
+
+// Check resets are traced through nodes
+
+// CHECK-LABEL: "TraceThroughNodes"
+// CHECK-NOT: firrtl.reset
+firrtl.circuit "TraceThroughNodes" {
+  firrtl.module @TraceThroughNodes(in %reset: !firrtl.asyncreset) {
+    // CHECK: %node = firrtl.node %localReset : !firrtl.asyncreset
+    // CHECK-NOT: firrtl.reset
+    %localReset = firrtl.wire : !firrtl.reset
+    firrtl.connect %localReset, %reset : !firrtl.reset, !firrtl.asyncreset
+
+    %node = firrtl.node %localReset : !firrtl.reset
+
+    %localReset2 = firrtl.wire : !firrtl.reset
+    firrtl.matchingconnect %localReset2, %node: !firrtl.reset
+
+    // CHECK: %node2 = firrtl.node %localReset2 : !firrtl.asyncreset
+    %node2 = firrtl.node %localReset2 : !firrtl.reset
+  }
+}


### PR DESCRIPTION
Trace reset networks through nodes.

This seems like it was always reasonable to do but is now much more reachable with wire-to-node conversion happening.