### PR TITLE
[FIRRTL] Cast to AnyRefType for metadata output port.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -856,11 +856,12 @@ void CreateSiFiveMetadataPass::runOnOperation() {
       SmallVector<std::pair<unsigned, PortInfo>> ports = {
           {portIndex,
            PortInfo(StringAttr::get(objectOp->getContext(), "metadataObj"),
-                    objectOp.getType(), Direction::Out)}};
+                    AnyRefType::get(objectOp->getContext()), Direction::Out)}};
       topMod.insertPorts(ports);
       auto builderOM = mlir::ImplicitLocOpBuilder::atBlockEnd(
           topMod->getLoc(), topMod.getBodyBlock());
-      builderOM.create<PropAssignOp>(topMod.getArgument(portIndex), objectOp);
+      auto objectCast = builderOM.create<ObjectAnyRefCastOp>(objectOp);
+      builderOM.create<PropAssignOp>(topMod.getArgument(portIndex), objectCast);
     }
 
   // This pass modifies the hierarchy, InstanceGraph is not preserved.

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -39,8 +39,10 @@ firrtl.circuit "retime0" attributes { annotations = [{
   }]} { }
 }
 // CHECK-LABEL: firrtl.circuit "retime0"   {
-// CHECK:         firrtl.module @retime0(out %metadataObj: !firrtl.class<@SiFive_Metadata
-// CHECK:           %sifive_metadata = firrtl.object @SiFive_Metadata
+// CHECK:         firrtl.module @retime0(out %metadataObj: !firrtl.any
+// CHECK:           [[SIFIVE_METADATA:%.+]] = firrtl.object @SiFive_Metadata
+// CHECK:           [[METADATA_OBJ:%.+]] = firrtl.object.anyref_cast [[SIFIVE_METADATA]]
+// CHECK:           propassign %metadataObj, [[METADATA_OBJ]]
 // CHECK:         firrtl.module @retime1() {
 // CHECK:         firrtl.module @retime2()
 


### PR DESCRIPTION
We generally type-erase objects at the boundary, to avoid needing to declare the objects' classes as part of the interface. This adds a cast for the metadataObj reference, so we don't have to declare its class as part of the interface. The evaluator and any tooling built on it already know how to "see through" this cast.