### PR TITLE
[FIRRTL][Metadata] Add the path to the DUT, in the SiFive metadata class.

### DIFF
--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -271,8 +271,9 @@ firrtl.circuit "ReadOnlyMemory" {
 
 // CHECK-LABEL: firrtl.circuit "top"
 firrtl.circuit "top" {
+    // CHECK: hw.hierpath @[[DUTNLA:.+]] [@top::@sym]
     firrtl.module @top()  {
-      // CHECK: firrtl.instance dut sym @[[DUT_SYM:.+]] @DUT
+      // CHECK: firrtl.instance dut sym @[[DUT_SYM:.+]] {annotations = [{circt.nonlocal = @dutNLA, class = "circt.tracker", id = distinct[0]<>}]} @DUT() 
       firrtl.instance dut @DUT()
       firrtl.instance mem1 @Mem1()
       firrtl.instance mem2 @Mem2()
@@ -306,4 +307,9 @@ firrtl.circuit "top" {
   // CHECK-NEXT{LITERAL}:   sv.verbatim "name {{0}} depth 20 width 5 ports write\0Aname {{1}} depth 20 width 5 ports write\0Aname {{2}} depth 16 width 8 ports read,rw\0Aname {{3}} depth 20 width 5 ports write,read\0A"
   // CHECK-SAME:              {symbols = [@head_ext, @head_0_ext, @memory_ext, @dumm_ext]}
   // CHECK-NEXT:          }
+
+  // CHECK:  firrtl.class @SiFive_Metadata
+  // CHECK:    %[[V0:.+]] = firrtl.path instance distinct[0]<>
+  // CHECK-NEXT:    %[[V1:.+]] = firrtl.list.create %[[V0]] : !firrtl.list<path>
+  // CHECK-NEXT:    firrtl.propassign %dutModulePath_field_1, %[[V1]] : !firrtl.list<path>
 }


### PR DESCRIPTION
Add the instance path to the DUT module to the `SiFive_Metadata` class.
This instance path is required to ensure proper hierarchy paths can be generated from the OMIR with respect to the DUT.
This commit creates a list of paths, to handle multiple DUTs even though the current designs will have a unique DUT.