### PR TITLE
[firtool] Remove `LTLToCore` pass from `verification-falvor=immediate` pipeline

### DIFF
--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -264,8 +264,6 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
 
 LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
                                       const FirtoolOptions &opt) {
-  if (opt.getVerificationFlavor() == firrtl::VerificationFlavor::Immediate)
-    pm.addNestedPass<hw::HWModuleOp>(createLowerLTLToCorePass());
 
   if (opt.shouldExtractTestCode())
     pm.addPass(sv::createSVExtractTestCodePass(


### PR DESCRIPTION
The LTLToCore pass uses a flawed disable lowering, which I am working on fixing. In the meantime, we should remove the pass from the immediate lowering.