### PR TITLE
[MooreToCore] Add conversion support for conditional and yield.

### DIFF
--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -190,6 +190,17 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
   moore.wildcard_eq %arg0, %arg0 : !moore.i1 -> !moore.i1
   moore.wildcard_ne %arg0, %arg0 : !moore.i1 -> !moore.i1
 
+  // CHECK-NEXT: [[TMP1:%.+]] = comb.add %arg2, %arg2 : i6
+  // CHECK-NEXT: [[TMP2:%.+]] = comb.sub %arg2, %arg2 : i6
+  // CHECK-NEXT: comb.mux %arg0, [[TMP1]], [[TMP2]] : i6
+  moore.conditional %arg0 : !moore.i1 -> !moore.i6 {
+    %3 = moore.add %arg2, %arg2 : !moore.i6
+    moore.yield %3 : !moore.i6
+  } { 
+    %3 = moore.sub %arg2, %arg2 : !moore.i6
+    moore.yield %3 : !moore.i6
+  }
+
   // CHECK-NEXT: return
   return
 }


### PR DESCRIPTION
Convert `moore.conditional` to `comb.mux` by moving the bodies of the true and false regions outside.
It also remains doubt that it can not just evaluate one of the expressions depending on the situation, and will evaluate both. is it acceptable, or is there a more suitable way to lower `conditional` op?