### PR TITLE
[FIRRTL][ExportVerilog] Emit integers on DPI function as two state C-compatible types and clarify ABI

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -222,6 +222,7 @@ def DPICallIntrinsicOp : FIRRTLOp<"int.dpi.call",
     $functionName `(` $inputs `)` (`clock` $clock^)? (`enable` $enable^)?
     attr-dict `:` functional-type($inputs, results)
   }];
+  let hasVerifier = 1;
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLINTRINSICS_TD

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -1435,7 +1435,8 @@ public:
   };
 
   void emitParameters(Operation *module, ArrayAttr params);
-  void emitPortList(Operation *module, const ModulePortInfo &portInfo);
+  void emitPortList(Operation *module, const ModulePortInfo &portInfo,
+                    bool emitAsTwoStateType = false);
 
   void emitHWModule(HWModuleOp module);
   void emitHWExternModule(HWModuleExternOp module);
@@ -1472,7 +1473,8 @@ public:
   /// This returns true if anything was printed.
   bool printPackedType(Type type, raw_ostream &os, Location loc,
                        Type optionalAliasType = {}, bool implicitIntType = true,
-                       bool singleBitDefaultType = true);
+                       bool singleBitDefaultType = true,
+                       bool emitAsTwoStateType = false);
 
   /// Output the unpacked array dimensions.  This is the part of the type that
   /// is to the right of the name.
@@ -1646,6 +1648,23 @@ void ModuleEmitter::emitTypeDims(Type type, Location loc, raw_ostream &os) {
   emitDims(dims, os, loc, *this);
 }
 
+/// Return a 2-state integer atom type name if the width matches. See Spec 6.8
+/// Variable declarations.
+static StringRef getTwoStateIntegerAtomType(size_t width) {
+  switch (width) {
+  case 8:
+    return "byte";
+  case 16:
+    return "shortint";
+  case 32:
+    return "int";
+  case 64:
+    return "longint";
+  default:
+    return "";
+  }
+}
+
 /// Output the basic type that consists of packed and primitive types.  This is
 /// those to the left of the name in verilog. implicitIntType controls whether
 /// to print a base type for (logic) for inteters or whether the caller will
@@ -1659,16 +1678,28 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
                                 SmallVectorImpl<Attribute> &dims,
                                 bool implicitIntType, bool singleBitDefaultType,
                                 ModuleEmitter &emitter,
-                                Type optionalAliasType = {}) {
+                                Type optionalAliasType = {},
+                                bool emitAsTwoStateType = false) {
   return TypeSwitch<Type, bool>(type)
       .Case<IntegerType>([&](IntegerType integerType) {
-        if (!implicitIntType)
-          os << "logic";
+        if (emitAsTwoStateType) {
+          auto typeName = getTwoStateIntegerAtomType(integerType.getWidth());
+          if (!typeName.empty()) {
+            os << typeName;
+            return true;
+          }
+        }
         if (integerType.getWidth() != 1 || !singleBitDefaultType)
           dims.push_back(
               getInt32Attr(type.getContext(), integerType.getWidth()));
-        if (!dims.empty() && !implicitIntType)
-          os << ' ';
+
+        StringRef typeName =
+            (emitAsTwoStateType ? "bit" : (implicitIntType ? "" : "logic"));
+        if (!typeName.empty()) {
+          os << typeName;
+          if (!dims.empty())
+            os << ' ';
+        }
 
         emitDims(dims, os, loc, emitter);
         return !dims.empty() || !implicitIntType;
@@ -1750,7 +1781,8 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
           if (needsPadding) {
             os << " struct packed {";
             if (element.offset) {
-              os << "logic [" << element.offset - 1 << ":0] "
+              os << (emitAsTwoStateType ? "bit" : "logic") << " ["
+                 << element.offset - 1 << ":0] "
                  << "__pre_padding_" << element.name.getValue() << "; ";
             }
           }
@@ -1766,7 +1798,7 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
 
           if (needsPadding) {
             if (elementWidth + (int64_t)element.offset < unionWidth) {
-              os << " logic ["
+              os << " " << (emitAsTwoStateType ? "bit" : "logic") << " ["
                  << unionWidth - (elementWidth + element.offset) - 1 << ":0] "
                  << "__post_padding_" << element.name.getValue() << ";";
             }
@@ -1815,15 +1847,19 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
 ///        struct fields and typedefs.
 ///  * When `singleBitDefaultType` is false, single bit values are printed as
 ///       `[0:0]`.  This is used in parameter lists.
+///  * When `emitAsTwoStateType` is true, a "bit" is printed. This is used in
+///        DPI function import statement.
 ///
 /// This returns true if anything was printed.
 bool ModuleEmitter::printPackedType(Type type, raw_ostream &os, Location loc,
                                     Type optionalAliasType,
                                     bool implicitIntType,
-                                    bool singleBitDefaultType) {
+                                    bool singleBitDefaultType,
+                                    bool emitAsTwoStateType) {
   SmallVector<Attribute, 8> packedDimensions;
   return printPackedTypeImpl(type, os, loc, packedDimensions, implicitIntType,
-                             singleBitDefaultType, *this, optionalAliasType);
+                             singleBitDefaultType, *this, optionalAliasType,
+                             emitAsTwoStateType);
 }
 
 /// Output the unpacked array dimensions.  This is the part of the type that is
@@ -4351,21 +4387,23 @@ LogicalResult StmtEmitter::visitSV(FuncCallOp op) {
 
 template <typename PPS>
 void emitFunctionSignature(ModuleEmitter &emitter, PPS &ps, FuncOp op,
-                           bool isAutomatic = false) {
+                           bool isAutomatic = false,
+                           bool emitAsTwoStateType = false) {
   ps << "function" << PP::nbsp;
   if (isAutomatic)
     ps << "automatic" << PP::nbsp;
   auto retType = op.getExplicitlyReturnedType();
   if (retType) {
     ps.invokeWithStringOS([&](auto &os) {
-      emitter.printPackedType(retType, os, op->getLoc(), {}, false);
+      emitter.printPackedType(retType, os, op->getLoc(), {}, false, true,
+                              emitAsTwoStateType);
     });
   } else
     ps << "void";
   ps << PP::nbsp << PPExtString(getSymOpName(op));
 
   emitter.emitPortList(
-      op, ModulePortInfo(op.getPortList(/*excludeExplicitReturn=*/true)));
+      op, ModulePortInfo(op.getPortList(/*excludeExplicitReturn=*/true)), true);
 }
 
 LogicalResult StmtEmitter::visitSV(ReturnOp op) {
@@ -4385,7 +4423,8 @@ LogicalResult StmtEmitter::visitSV(FuncDPIImportOp importOp) {
   auto op =
       cast<FuncOp>(state.symbolCache.getDefinition(importOp.getCalleeAttr()));
   assert(op.isDeclaration() && "function must be a declaration");
-  emitFunctionSignature(emitter, ps, op);
+  emitFunctionSignature(emitter, ps, op, /*isAutomatic=*/false,
+                        /*emitAsTwoStateType=*/true);
   assert(state.pendingNewline);
   ps << PP::newline;
 
@@ -6190,7 +6229,8 @@ void ModuleEmitter::emitParameters(Operation *module, ArrayAttr params) {
 }
 
 void ModuleEmitter::emitPortList(Operation *module,
-                                 const ModulePortInfo &portInfo) {
+                                 const ModulePortInfo &portInfo,
+                                 bool emitAsTwoStateType) {
   ps << "(";
   if (portInfo.size())
     emitLocationInfo(module->getLoc());
@@ -6213,7 +6253,7 @@ void ModuleEmitter::emitPortList(Operation *module,
     {
       llvm::raw_svector_ostream stringStream(portTypeStrings.back());
       printPackedType(stripUnpackedTypes(port.type), stringStream,
-                      module->getLoc());
+                      module->getLoc(), {}, true, true, emitAsTwoStateType);
     }
 
     maxTypeWidth = std::max(portTypeStrings.back().size(), maxTypeWidth);

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1674,6 +1674,7 @@ hw.module @IndexPartSelect(out a : i3) {
 sv.func private @function_declare1(in %in_0 : i2, out out_0: i2, in %in_1 : i2, out out_1 : i1)
 sv.func private @function_declare2(in %in_0 : i2, in %in_1 : i2, out out_0 : i1 {sv.func.explicitly_returned})
 sv.func private @function_declare3(in %in_0 : i2, out out_0 : i2, out out_1 : i1 {sv.func.explicitly_returned})
+sv.func private @function_declare4(in %in: i1, in %in_0 : i8, in %in_1 : i16, in %in_2: i32, in %in_3: i64, in %in_4: i128)
 
 // CHECK-LABEL: func_call
 hw.module @func_call(in %in_0 : i2, in %in_1 : i2, in %in_2: i1, out out: i1) {
@@ -1700,9 +1701,9 @@ hw.module @func_call(in %in_0 : i2, in %in_1 : i2, in %in_2: i1, out out: i1) {
 }
 
 // CHECK-LABEL: function automatic logic func_def(
-// CHECK-NEXT:    input  [1:0] in_0,
-// CHECK-NEXT:    output       out_0,
-// CHECK-NEXT:    input  [1:0] in_1
+// CHECK-NEXT:    input  bit [1:0] in_0,
+// CHECK-NEXT:    output bit out_0,
+// CHECK-NEXT:    input  bit [1:0] in_1
 // CHECK-NEXT:  );
 // CHECK-EMPTY:
 // CHECK-NEXT:    logic [1:0] _GEN = 2'(in_0 + in_1);
@@ -1717,7 +1718,7 @@ sv.func @func_def(in %in_0 : i2, out out_0: i1, in %in_1: i2, out out_1 : i1 {sv
 }
 
 // CHECK-LABEL: function automatic logic [31:0] recurse_add(
-// CHECK-NEXT:   input [31:0] n
+// CHECK-NEXT:   input int n
 // CHECK-NEXT: );
 // CHECK-EMPTY:
 // CHECK-NEXT:   logic           [31:0] _recurse_add_0;
@@ -1749,18 +1750,28 @@ sv.func @recurse_add(in %n : i32, out out : i32 {sv.func.explicitly_returned}) {
 // Emit DPI import.
 
 // CHECK-LABEL: import "DPI-C" linkage_name = function void function_declare1(
-// CHECK-NEXT:    input [1:0] in_0,
-// CHECK-NEXT:                out_0,
-// CHECK-NEXT:                in_1,
-// CHECK-NEXT:    output out_1
+// CHECK-NEXT:    input bit [1:0] in_0,
+// CHECK-NEXT:                    out_0,
+// CHECK-NEXT:                    in_1,
+// CHECK-NEXT:    output bit      out_1
 // CHECK-NEXT: );
 sv.func.dpi.import linkage "linkage_name" @function_declare1
 
-// CHECK-LABEL: import "DPI-C" function logic function_declare2(
-// CHECK-NEXT:    input [1:0] in_0,
-// CHECK-NEXT:                in_1
+// CHECK-LABEL: import "DPI-C" function bit function_declare2(
+// CHECK-NEXT:    input bit [1:0] in_0,
+// CHECK-NEXT:                    in_1
 // CHECK-NEXT: );
 sv.func.dpi.import @function_declare2
+
+// CHECK-LABEL: import "DPI-C" function void function_declare4(
+// CHECK-NEXT:   input bit         in,
+// CHECK-NEXT:   input byte        in_0,
+// CHECK-NEXT:   input shortint    in_1,
+// CHECK-NEXT:   input int         in_2,
+// CHECK-NEXT:   input longint     in_3,
+// CHECK-NEXT:   input bit [127:0] in_4
+// CHECK-NEXT: );
+sv.func.dpi.import @function_declare4
 
 sv.macro.decl @FOO
 sv.macro.decl @BAR

--- a/test/Conversion/SimToSV/dpi.mlir
+++ b/test/Conversion/SimToSV/dpi.mlir
@@ -8,9 +8,9 @@ sim.func.dpi @dpi(out arg0: i1, in %arg1: i1, out arg2: i1)
 // CHECK-NEXT:  }
 
 // VERILOG:      import "DPI-C" function void dpi( 
-// VERILOG-NEXT:   output arg0,
-// VERILOG-NEXT:   input  arg1,
-// VERILOG-NEXT:   output arg2
+// VERILOG-NEXT:   output bit arg0,
+// VERILOG-NEXT:   input  bit arg1,
+// VERILOG-NEXT:   output bit arg2
 // VERILOG-NEXT: );
 
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -2462,3 +2462,21 @@ firrtl.circuit "Top" {
   }
 }
 
+// -----
+
+firrtl.circuit "DPI" {
+  firrtl.module @DPI(in %clock : !firrtl.clock, in %enable : !firrtl.uint<1>, in %in_0: !firrtl.uint<4>, in %in_1: !firrtl.uint) {
+    // expected-error @below {{unknown width is not allowed for DPI}}
+    %1 = firrtl.int.dpi.call "clocked_result"(%in_1) clock %clock enable %enable : (!firrtl.uint) -> !firrtl.uint<8>
+  }
+}
+
+
+// -----
+
+firrtl.circuit "DPI" {
+  firrtl.module @DPI(in %clock : !firrtl.clock, in %enable : !firrtl.uint<1>, in %in_0: !firrtl.uint<4>, in %in_1: !firrtl.uint) {
+    // expected-error @below {{integer types used by DPI functions must have a specific bit width; it must be equal to 1(bit), 8(byte), 16(shortint), 32(int), 64(longint) or greater than 64, but got '!firrtl.uint<4>'}}
+    %0 = firrtl.int.dpi.call "clocked_result"(%in_0) clock %clock enable %enable : (!firrtl.uint<4>) -> !firrtl.uint<8>
+  }
+}

--- a/test/Dialect/FIRRTL/lower-dpi.mlir
+++ b/test/Dialect/FIRRTL/lower-dpi.mlir
@@ -2,33 +2,33 @@
 
 // CHECK-LABEL: firrtl.circuit "DPI" {
 firrtl.circuit "DPI" {
-  // CHECK-NEXT: sim.func.dpi private @unclocked_result(in %in_0 : i2, in %in_1 : i2, out out_0 : i2) attributes {verilogName = "unclocked_result"}
-  // CHECK-NEXT: sim.func.dpi private @clocked_void(in %in_0 : i2, in %in_1 : i2) attributes {verilogName = "clocked_void"}
-  // CHECK-NEXT: sim.func.dpi private @clocked_result(in %in_0 : i2, in %in_1 : i2, out out_0 : i2) attributes {verilogName = "clocked_result"}
+  // CHECK-NEXT: sim.func.dpi private @unclocked_result(in %in_0 : i8, in %in_1 : i8, out out_0 : i8) attributes {verilogName = "unclocked_result"}
+  // CHECK-NEXT: sim.func.dpi private @clocked_void(in %in_0 : i8, in %in_1 : i8) attributes {verilogName = "clocked_void"}
+  // CHECK-NEXT: sim.func.dpi private @clocked_result(in %in_0 : i8, in %in_1 : i8, out out_0 : i8) attributes {verilogName = "clocked_result"}
   // CHECK-LABEL: firrtl.module @DPI
-  firrtl.module @DPI(in %clock: !firrtl.clock, in %enable: !firrtl.uint<1>, in %in_0: !firrtl.uint<2>, in %in_1: !firrtl.uint<2>, out %out_0: !firrtl.uint<2>, out %out_1: !firrtl.uint<2>) attributes {convention = #firrtl<convention scalarized>} {
+  firrtl.module @DPI(in %clock: !firrtl.clock, in %enable: !firrtl.uint<1>, in %in_0: !firrtl.uint<8>, in %in_1: !firrtl.uint<8>, out %out_0: !firrtl.uint<8>, out %out_1: !firrtl.uint<8>) attributes {convention = #firrtl<convention scalarized>} {
     // CHECK-NEXT: %0 = builtin.unrealized_conversion_cast %clock : !firrtl.clock to !seq.clock
     // CHECK-NEXT: %1 = builtin.unrealized_conversion_cast %enable : !firrtl.uint<1> to i1
-    // CHECK-NEXT: %2 = builtin.unrealized_conversion_cast %in_0 : !firrtl.uint<2> to i2
-    // CHECK-NEXT: %3 = builtin.unrealized_conversion_cast %in_1 : !firrtl.uint<2> to i2
-    // CHECK-NEXT: %4 = sim.func.dpi.call @clocked_result(%2, %3) clock %0 enable %1 : (i2, i2) -> i2
-    // CHECK-NEXT: %5 = builtin.unrealized_conversion_cast %4 : i2 to !firrtl.uint<2>
+    // CHECK-NEXT: %2 = builtin.unrealized_conversion_cast %in_0 : !firrtl.uint<8> to i8
+    // CHECK-NEXT: %3 = builtin.unrealized_conversion_cast %in_1 : !firrtl.uint<8> to i8
+    // CHECK-NEXT: %4 = sim.func.dpi.call @clocked_result(%2, %3) clock %0 enable %1 : (i8, i8) -> i8
+    // CHECK-NEXT: %5 = builtin.unrealized_conversion_cast %4 : i8 to !firrtl.uint<8>
     // CHECK-NEXT: %6 = builtin.unrealized_conversion_cast %clock : !firrtl.clock to !seq.clock
     // CHECK-NEXT: %7 = builtin.unrealized_conversion_cast %enable : !firrtl.uint<1> to i1
-    // CHECK-NEXT: %8 = builtin.unrealized_conversion_cast %in_0 : !firrtl.uint<2> to i2
-    // CHECK-NEXT: %9 = builtin.unrealized_conversion_cast %in_1 : !firrtl.uint<2> to i2
-    // CHECK-NEXT: sim.func.dpi.call @clocked_void(%8, %9) clock %6 enable %7 : (i2, i2) -> ()
+    // CHECK-NEXT: %8 = builtin.unrealized_conversion_cast %in_0 : !firrtl.uint<8> to i8
+    // CHECK-NEXT: %9 = builtin.unrealized_conversion_cast %in_1 : !firrtl.uint<8> to i8
+    // CHECK-NEXT: sim.func.dpi.call @clocked_void(%8, %9) clock %6 enable %7 : (i8, i8) -> ()
     // CHECK-NEXT: %10 = builtin.unrealized_conversion_cast %enable : !firrtl.uint<1> to i1
-    // CHECK-NEXT: %11 = builtin.unrealized_conversion_cast %in_0 : !firrtl.uint<2> to i2
-    // CHECK-NEXT: %12 = builtin.unrealized_conversion_cast %in_1 : !firrtl.uint<2> to i2
-    // CHECK-NEXT: %13 = sim.func.dpi.call @unclocked_result(%11, %12) enable %10 : (i2, i2) -> i2
-    // CHECK-NEXT: %14 = builtin.unrealized_conversion_cast %13 : i2 to !firrtl.uint<2>
-    // CHECK-NEXT:firrtl.matchingconnect %out_0, %5 : !firrtl.uint<2>
-    // CHECK-NEXT:firrtl.matchingconnect %out_1, %14 : !firrtl.uint<2>
-    %0 = firrtl.int.dpi.call "clocked_result"(%in_0, %in_1) clock %clock enable %enable {name = "result1"} : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-    firrtl.int.dpi.call "clocked_void"(%in_0, %in_1) clock %clock enable %enable : (!firrtl.uint<2>, !firrtl.uint<2>) -> ()
-    %1 = firrtl.int.dpi.call "unclocked_result"(%in_0, %in_1) enable %enable {name = "result2"} : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-   firrtl.matchingconnect %out_0, %0 : !firrtl.uint<2>
-   firrtl.matchingconnect %out_1, %1 : !firrtl.uint<2>
+    // CHECK-NEXT: %11 = builtin.unrealized_conversion_cast %in_0 : !firrtl.uint<8> to i8
+    // CHECK-NEXT: %12 = builtin.unrealized_conversion_cast %in_1 : !firrtl.uint<8> to i8
+    // CHECK-NEXT: %13 = sim.func.dpi.call @unclocked_result(%11, %12) enable %10 : (i8, i8) -> i8
+    // CHECK-NEXT: %14 = builtin.unrealized_conversion_cast %13 : i8 to !firrtl.uint<8>
+    // CHECK-NEXT: firrtl.matchingconnect %out_0, %5 : !firrtl.uint<8>
+    // CHECK-NEXT: firrtl.matchingconnect %out_1, %14 : !firrtl.uint<8>
+    %0 = firrtl.int.dpi.call "clocked_result"(%in_0, %in_1) clock %clock enable %enable {name = "result1"} : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    firrtl.int.dpi.call "clocked_void"(%in_0, %in_1) clock %clock enable %enable : (!firrtl.uint<8>, !firrtl.uint<8>) -> ()
+    %1 = firrtl.int.dpi.call "unclocked_result"(%in_0, %in_1) enable %enable {name = "result2"} : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    firrtl.matchingconnect %out_0, %0 : !firrtl.uint<8>
+    firrtl.matchingconnect %out_1, %1 : !firrtl.uint<8>
   }
 }

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -157,13 +157,13 @@ firrtl.circuit "Foo" {
     firrtl.int.generic "circt_fpga_probe"  %data, %clock : (!firrtl.uint<32>, !firrtl.clock) -> ()
   }
 
-  // CHECK-LABEL: firrtl.module private @DPIIntrinsicTest(in %clock: !firrtl.clock, in %enable: !firrtl.uint<1>, in %in1: !firrtl.uint<2>, in %in2: !firrtl.uint<2>)
-  firrtl.module private @DPIIntrinsicTest(in %clock : !firrtl.clock, in %enable : !firrtl.uint<1>, in %in1: !firrtl.uint<2>, in %in2: !firrtl.uint<2>) {
-    // CHECK-NEXT: %0 = firrtl.int.dpi.call "clocked_result"(%in1, %in2) clock %clock enable %enable : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-    %0 = firrtl.int.generic "circt_dpi_call" <isClocked: ui32 = 1, functionName: none = "clocked_result"> %clock, %enable, %in1, %in2 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-    // CHECK-NEXT: firrtl.int.dpi.call "clocked_void"(%in1, %in2) clock %clock enable %enable : (!firrtl.uint<2>, !firrtl.uint<2>) -> ()
-    firrtl.int.generic "circt_dpi_call" <isClocked: ui32 = 1, functionName: none = "clocked_void"> %clock, %enable, %in1, %in2 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> ()
-    // CHECK-NEXT:  %1 = firrtl.int.dpi.call "unclocked_result"(%in1, %in2) enable %enable : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-    %1 = firrtl.int.generic "circt_dpi_call" <isClocked: ui32 = 0, functionName: none = "unclocked_result"> %enable, %in1, %in2 : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+  // CHECK-LABEL: firrtl.module private @DPIIntrinsicTest(in %clock: !firrtl.clock, in %enable: !firrtl.uint<1>, in %in1: !firrtl.uint<8>, in %in2: !firrtl.uint<8>)
+  firrtl.module private @DPIIntrinsicTest(in %clock : !firrtl.clock, in %enable : !firrtl.uint<1>, in %in1: !firrtl.uint<8>, in %in2: !firrtl.uint<8>) {
+    // CHECK-NEXT: %0 = firrtl.int.dpi.call "clocked_result"(%in1, %in2) clock %clock enable %enable : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    %0 = firrtl.int.generic "circt_dpi_call" <isClocked: ui32 = 1, functionName: none = "clocked_result"> %clock, %enable, %in1, %in2 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    // CHECK-NEXT: firrtl.int.dpi.call "clocked_void"(%in1, %in2) clock %clock enable %enable : (!firrtl.uint<8>, !firrtl.uint<8>) -> ()
+    firrtl.int.generic "circt_dpi_call" <isClocked: ui32 = 1, functionName: none = "clocked_void"> %clock, %enable, %in1, %in2 : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> ()
+    // CHECK-NEXT:  %1 = firrtl.int.dpi.call "unclocked_result"(%in1, %in2) enable %enable : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    %1 = firrtl.int.generic "circt_dpi_call" <isClocked: ui32 = 0, functionName: none = "unclocked_result"> %enable, %in1, %in2 : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   }
 }

--- a/test/firtool/dpi.fir
+++ b/test/firtool/dpi.fir
@@ -3,25 +3,25 @@
 FIRRTL version 4.0.0
 circuit DPI:
 ; CHECK-LABEL: import "DPI-C" function void clocked_result(
-; CHECK-NEXT:   input  [1:0] in_0,
-; CHECK-NEXT:                in_1,
-; CHECK-NEXT:   output [1:0] out_0
+; CHECK-NEXT:   input  byte in_0,
+; CHECK-NEXT:                    in_1,
+; CHECK-NEXT:   output byte out_0
 ; CHECK-NEXT: );
 
 ; CHECK-LABEL: import "DPI-C" function void clocked_void(
-; CHECK-NEXT:   input [1:0] in_0,
-; CHECK-NEXT:               in_1
+; CHECK-NEXT:   input byte in_0,
+; CHECK-NEXT:              in_1
 ; CHECK-NEXT: );
 
 ; CHECK-LABEL: import "DPI-C" function void unclocked_result(
-; CHECK-NEXT:   input  [1:0] in_0,
-; CHECK-NEXT:                in_1,
-; CHECK-NEXT:   output [1:0] out_0
+; CHECK-NEXT:   input  byte in_0,
+; CHECK-NEXT:                    in_1,
+; CHECK-NEXT:   output byte out_0
 ; CHECK-NEXT: );
 
 ; CHECK-LABEL: module DPI(
-; CHECK:        logic [1:0] [[TMP:_.+]];
-; CHECK-NEXT:   reg   [1:0] [[RESULT1:_.+]];
+; CHECK:        logic [7:0] [[TMP:_.+]];
+; CHECK-NEXT:   reg   [7:0] [[RESULT1:_.+]];
 ; CHECK-NEXT:   always @(posedge clock) begin
 ; CHECK-NEXT:     if (enable) begin
 ; CHECK-NEXT:       clocked_result(in_0, in_1, [[TMP]]);
@@ -29,13 +29,13 @@ circuit DPI:
 ; CHECK-NEXT:       clocked_void(in_0, in_1);
 ; CHECK-NEXT:     end
 ; CHECK-NEXT:   end // always @(posedge)
-; CHECK-NEXT:   reg   [1:0] [[RESULT2:_.+]];
+; CHECK-NEXT:   reg   [7:0] [[RESULT2:_.+]];
 ; CHECK-NEXT:   always_comb begin
 ; CHECK-NEXT:     if (enable) begin
 ; CHECK-NEXT:       unclocked_result(in_0, in_1, [[RESULT2]]);
 ; CHECK-NEXT:     end
 ; CHECK-NEXT:     else
-; CHECK-NEXT:       [[RESULT2]] = 2'bx;
+; CHECK-NEXT:       [[RESULT2]] = 8'bx;
 ; CHECK-NEXT:   end // always_comb
 ; CHECK-NEXT:   assign out_0 = [[RESULT1]];
 ; CHECK-NEXT:   assign out_1 = [[RESULT2]];
@@ -43,12 +43,12 @@ circuit DPI:
   public module DPI :
     input clock: Clock
     input enable: UInt<1>
-    input in: UInt<2>[2]
-    output out : UInt<2>[2]
+    input in: UInt<8>[2]
+    output out : UInt<8>[2]
 
-    node result1 = intrinsic(circt_dpi_call<isClocked = 1, functionName="clocked_result"> : UInt<2>, clock, enable, in[0], in[1])
+    node result1 = intrinsic(circt_dpi_call<isClocked = 1, functionName="clocked_result"> : UInt<8>, clock, enable, in[0], in[1])
     intrinsic(circt_dpi_call<isClocked = 1, functionName="clocked_void">, clock, enable, in[0], in[1])
-    node result2 = intrinsic(circt_dpi_call<isClocked = 0, functionName="unclocked_result"> : UInt<2>,  enable, in[0], in[1])
+    node result2 = intrinsic(circt_dpi_call<isClocked = 0, functionName="unclocked_result"> : UInt<8>,  enable, in[0], in[1])
 
     out[0] <= result1
     out[1] <= result2


### PR DESCRIPTION
This PR modifies ExportVerilog to emit two state types (`bit` in general) for DPI import op. Furthermore, for specific bit width (8, 16, 32 and 64) it emits C-types (byte, shortint, int and longint). 

This PR also rejects small integer types other than 8, 16, 32 and 64 bit width since  otherwise we have to use`bit` but they are passed by references in DPI. So this PR defines the ABI as "small integers are passed by values, and larger integers are passed by references.