### PR TITLE
[Calyx] Passing memories by reference

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -450,7 +450,7 @@ def InvokeOp : CalyxOp<"invoke", [
   let arguments = (ins FlatSymbolRefAttr:$callee,
                    Variadic<AnyType>:$ports,
                    Variadic<AnyType>:$inputs,
-                   DictionaryAttr:$refCellsMap,
+                   ArrayAttr:$refCellsMap,
                    ArrayAttr:$portNames,
                    ArrayAttr:$inputNames);
   let results = (outs);

--- a/include/circt/Dialect/Calyx/CalyxControl.td
+++ b/include/circt/Dialect/Calyx/CalyxControl.td
@@ -426,26 +426,31 @@ def InvokeOp : CalyxOp<"invoke", [
     call, which invokes a given component.
 
     The 'callee' attribute is the name of the component,
-    the 'ports' attribute The ports attribute specifies 
-    the input port of the component when it is invoked, 
-    and the 'inputs' attribute specifies the assignment on 
-    the corresponding port.
+    the 'ports' attribute specifies the input port of the component when it is invoked,
+    the 'inputs' attribute specifies the assignment on the corresponding port,
+    and the 'refCellsMap' attribute maps the reference cells in the `callee` with
+    the original cells in the caller.
 
     ```mlir
+      calyx.component @identity {
+        %mem.addr0, %mem.clk, ... = calyx.seq_mem @mem <[1] x 32> [1] {external = false}
+      }
       %id.in, %id.out, ... = calyx.instance @id of @identity : i32, i32, ...
       %r.in, ... = calyx.register @r : i32, ...
+      %mem_1.addr0, %mem_1.clk, ... = calyx.seq_mem @mem_1 <[1] x 32> [1] {external = true}
       ...
       calyx.control {
         calyx.seq {
-          calyx.invoke @id(%id.in = %c1_10, %r.in = %id.out) -> (i32, i32)
+          calyx.invoke @id[mem = mem_1](%id.in = %c1_10, %r.in = %id.out) -> (i32, i32)
         }
       }
     ```
   }];
 
-  let arguments = (ins FlatSymbolRefAttr:$callee, 
+  let arguments = (ins FlatSymbolRefAttr:$callee,
                    Variadic<AnyType>:$ports,
                    Variadic<AnyType>:$inputs,
+                   DictionaryAttr:$refCellsMap,
                    ArrayAttr:$portNames,
                    ArrayAttr:$inputNames);
   let results = (outs);

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -84,6 +84,7 @@ void buildAssignmentsForRegisterWrite(OpBuilder &builder,
 // A structure representing a set of ports which act as a memory interface for
 // external memories.
 struct MemoryPortsImpl {
+  StringRef memName;
   std::optional<Value> readData;
   std::optional<Value> readOrContentEn;
   std::optional<Value> writeData;
@@ -103,6 +104,7 @@ struct MemoryInterface {
   explicit MemoryInterface(calyx::SeqMemoryOp memOp);
 
   // Getter methods for each memory interface port.
+  StringRef memName();
   Value readData();
   Value readEn();
   Value contentEn();

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -84,7 +84,7 @@ void buildAssignmentsForRegisterWrite(OpBuilder &builder,
 // A structure representing a set of ports which act as a memory interface for
 // external memories.
 struct MemoryPortsImpl {
-  StringRef memName;
+  std::string memName;
   std::optional<Value> readData;
   std::optional<Value> readOrContentEn;
   std::optional<Value> writeData;
@@ -104,7 +104,7 @@ struct MemoryInterface {
   explicit MemoryInterface(calyx::SeqMemoryOp memOp);
 
   // Getter methods for each memory interface port.
-  StringRef memName();
+  std::string memName();
   Value readData();
   Value readEn();
   Value contentEn();

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1233,8 +1233,9 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
     std::string funcName = "func_" + funcOp.getSymName().str();
     rewriter.modifyOpInPlace(funcOp, [&]() { funcOp.setSymName(funcName); });
 
-    /// Mark this component as the toplevel.
-    compOp->setAttr("toplevel", rewriter.getUnitAttr());
+    /// Mark this component as the toplevel if it's the top-level function of the module.
+    if (compOp.getName() == loweringState().getTopLevelFunction())
+      compOp->setAttr("toplevel", rewriter.getUnitAttr());
 
     /// Store the function-to-component mapping.
     functionMapping[funcOp] = compOp;

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -2022,14 +2022,13 @@ private:
         moduleOp.emitError() << "Symbol 'main' exists but is not a function";
         return nullptr;
       }
-        unsigned counter = 0;
-        std::string newOldName = baseName;
-        while (SymbolTable::lookupSymbolIn(moduleOp, newOldName))
-          newOldName =
-              llvm::join_items("_", baseName, std::to_string(++counter));
-        existingMainFunc.setName(newOldName);
-        if (baseName == "main")
-          baseName = newOldName;
+      unsigned counter = 0;
+      std::string newOldName = baseName;
+      while (SymbolTable::lookupSymbolIn(moduleOp, newOldName))
+        newOldName = llvm::join_items("_", baseName, std::to_string(++counter));
+      existingMainFunc.setName(newOldName);
+      if (baseName == "main")
+        baseName = newOldName;
     }
 
     // Create the new "main" function

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -2111,9 +2111,12 @@ private:
     }
 
     SmallVector<memref::AllocOp, 4> calleeAllocOps;
+    SmallVector<memref::GetGlobalOp, 4> calleeGetGlobalOps;
     for (auto &op : callee.getBody().getOps()) {
       if (auto allocOp = dyn_cast<memref::AllocOp>(&op)) {
         calleeAllocOps.push_back(allocOp);
+      } else if (auto getGlobalOp = dyn_cast<memref::GetGlobalOp>(op)) {
+        calleeGetGlobalOps.push_back(getGlobalOp);
       }
     }
 
@@ -2121,6 +2124,13 @@ private:
       auto allocType = cast<MemRefType>(allocOp.getType());
       auto alloc = builder.create<memref::AllocOp>(caller.getLoc(), allocType);
       memRefArgs.push_back(alloc);
+    }
+
+    for (auto getGlobalOp : calleeGetGlobalOps) {
+      auto globalType = getGlobalOp.getType();
+      auto newGetGlobal = builder.create<memref::GetGlobalOp>(
+          caller.getLoc(), globalType, getGlobalOp.getName());
+      memRefArgs.push_back(newGetGlobal);
     }
 
     auto calleeName =

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -2864,8 +2864,8 @@ LogicalResult InvokeOp::verify() {
   // The argument list of invoke is empty.
   if (getInputs().empty() && getRefCellsMap().empty()) {
     return emitOpError() << "'@" << callee
-                         << "' has zero input and output port connections; "
-                            " and has not passing-by-reference cells; "
+                         << "' has zero input and output port connections and "
+                            "has no passing-by-reference cells; "
                             "expected at least one.";
   }
   size_t goPortNum = 0, donePortNum = 0;

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -2686,22 +2686,23 @@ ParseResult InvokeOp::parse(OpAsmParser &parser, OperationState &result) {
   SMLoc loc = parser.getCurrentLocation();
 
   SmallVector<NamedAttribute, 4> refCellSymbols;
-  if (parser.parseLSquare() ||
-      parser.parseCommaSeparatedList([&]() -> ParseResult {
-        std::string refCellName;
-        std::string externalMem;
-        if (parser.parseKeywordOrString(&refCellName) || parser.parseEqual() ||
-            parser.parseKeywordOrString(&externalMem))
-          return failure();
-        auto externalMemAttr =
-            SymbolRefAttr::get(parser.getContext(), externalMem);
-        refCellSymbols.push_back(
-            NamedAttribute(StringAttr::get(parser.getContext(), refCellName),
-                           externalMemAttr));
-        return success();
-      }) ||
-      parser.parseRSquare())
-    return failure();
+  if (succeeded(parser.parseOptionalLSquare())) {
+    if (parser.parseCommaSeparatedList([&]() -> ParseResult {
+          std::string refCellName;
+          std::string externalMem;
+          if (parser.parseKeywordOrString(&refCellName) ||
+              parser.parseEqual() || parser.parseKeywordOrString(&externalMem))
+            return failure();
+          auto externalMemAttr =
+              SymbolRefAttr::get(parser.getContext(), externalMem);
+          refCellSymbols.push_back(
+              NamedAttribute(StringAttr::get(parser.getContext(), refCellName),
+                             externalMemAttr));
+          return success();
+        }) ||
+        parser.parseRSquare())
+      return failure();
+  }
   result.addAttribute("refCellsMap",
                       DictionaryAttr::get(parser.getContext(), refCellSymbols));
 
@@ -2729,6 +2730,7 @@ void InvokeOp::print(OpAsmPrinter &p) {
     p << refCellName << " = " << externalMem;
   });
   p << "](";
+
   auto ports = getPorts();
   auto inputs = getInputs();
   llvm::interleaveComma(llvm::zip(ports, inputs), p, [&](auto arg) {

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -2700,7 +2700,14 @@ ParseResult InvokeOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 void InvokeOp::print(OpAsmPrinter &p) {
-  p << " @" << getCallee() << "(";
+  p << " @" << getCallee() << "[";
+  auto refCellNamesMap = getRefCellsMap();
+  llvm::interleaveComma(refCellNamesMap, p, [&](auto arg) {
+    auto refCellName = arg.getName().str();
+    auto externalMem = cast<FlatSymbolRefAttr>(arg.getValue()).getValue();
+    p << refCellName << " = " << externalMem;
+  });
+  p << "](";
   auto ports = getPorts();
   auto inputs = getInputs();
   llvm::interleaveComma(llvm::zip(ports, inputs), p, [&](auto arg) {
@@ -2826,10 +2833,12 @@ LogicalResult InvokeOp::verify() {
     return emitOpError() << "with instance '@" << callee
                          << "', which does not exist.";
   // The argument list of invoke is empty.
-  if (getInputs().empty())
+  if (getInputs().empty() && getRefCellsMap().empty()) {
     return emitOpError() << "'@" << callee
                          << "' has zero input and output port connections; "
+                            " and has not passing-by-reference cells; "
                             "expected at least one.";
+  }
   size_t goPortNum = 0, donePortNum = 0;
   // They both have a go port and a done port, but the "go" port for
   // registers and memrey should be "write_en" port.

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -2684,6 +2684,27 @@ ParseResult InvokeOp::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
   FlatSymbolRefAttr callee = FlatSymbolRefAttr::get(componentName);
   SMLoc loc = parser.getCurrentLocation();
+
+  SmallVector<NamedAttribute, 4> refCellSymbols;
+  if (parser.parseLSquare() ||
+      parser.parseCommaSeparatedList([&]() -> ParseResult {
+        std::string refCellName;
+        std::string externalMem;
+        if (parser.parseKeywordOrString(&refCellName) || parser.parseEqual() ||
+            parser.parseKeywordOrString(&externalMem))
+          return failure();
+        auto externalMemAttr =
+            SymbolRefAttr::get(parser.getContext(), externalMem);
+        refCellSymbols.push_back(
+            NamedAttribute(StringAttr::get(parser.getContext(), refCellName),
+                           externalMemAttr));
+        return success();
+      }) ||
+      parser.parseRSquare())
+    return failure();
+  result.addAttribute("refCellsMap",
+                      DictionaryAttr::get(parser.getContext(), refCellSymbols));
+
   result.addAttribute("callee", callee);
   if (parseParameterList(parser, result, ports, inputs, portNames, inputNames,
                          types))

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -869,6 +869,14 @@ void Emitter::emitSeqMemory(SeqMemoryOp memory) {
 void Emitter::emitInvoke(InvokeOp invoke) {
   StringRef callee = invoke.getCallee();
   indent() << "invoke " << callee;
+  auto refCellsMap = invoke.getRefCellsMap();
+  os << "[";
+  llvm::interleaveComma(refCellsMap, os, [&](auto refCell) {
+    auto refCellName = refCell.getName().str();
+    auto externalMem = cast<FlatSymbolRefAttr>(refCell.getValue()).getValue();
+    os << refCellName << " = " << externalMem;
+  });
+  os << "]";
   ArrayAttr portNames = invoke.getPortNames();
   ArrayAttr inputNames = invoke.getInputNames();
   /// Because the ports of all components of calyx.invoke are inside a (),

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -875,10 +875,14 @@ void Emitter::emitInvoke(InvokeOp invoke) {
   auto refCellsMap = invoke.getRefCellsMap();
   if (!refCellsMap.empty()) {
     os << "[";
-    llvm::interleaveComma(refCellsMap, os, [&](auto refCell) {
-      auto refCellName = refCell.getName().str();
-      auto externalMem = cast<FlatSymbolRefAttr>(refCell.getValue()).getValue();
-      os << refCellName << " = " << externalMem;
+    llvm::interleaveComma(refCellsMap, os, [&](Attribute attr) {
+      auto dictAttr = cast<DictionaryAttr>(attr);
+      llvm::interleaveComma(dictAttr, os, [&](NamedAttribute namedAttr) {
+        auto refCellName = namedAttr.getName().str();
+        auto externalMem =
+            cast<FlatSymbolRefAttr>(namedAttr.getValue()).getValue();
+        os << refCellName << " = " << externalMem;
+      });
     });
     os << "]";
   }

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -845,10 +845,13 @@ void Emitter::emitSeqMemory(SeqMemoryOp memory) {
                         "supported by the native Calyx compiler.");
     return;
   }
-  indent() << getAttributes(memory, /*atFormat=*/true) << memory.instanceName()
-           << space() << equals() << space() << "seq_mem_d"
-           << std::to_string(dimension) << LParen() << memory.getWidth()
-           << comma();
+  bool isRef = !memory->hasAttr("external");
+  indent();
+  if (isRef)
+    os << "ref ";
+  os << getAttributes(memory, /*atFormat=*/true) << memory.instanceName()
+     << space() << equals() << space() << "seq_mem_d"
+     << std::to_string(dimension) << LParen() << memory.getWidth() << comma();
   for (Attribute size : memory.getSizes()) {
     APInt memSize = cast<IntegerAttr>(size).getValue();
     memSize.print(os, /*isSigned=*/false);

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -873,13 +873,15 @@ void Emitter::emitInvoke(InvokeOp invoke) {
   StringRef callee = invoke.getCallee();
   indent() << "invoke " << callee;
   auto refCellsMap = invoke.getRefCellsMap();
-  os << "[";
-  llvm::interleaveComma(refCellsMap, os, [&](auto refCell) {
-    auto refCellName = refCell.getName().str();
-    auto externalMem = cast<FlatSymbolRefAttr>(refCell.getValue()).getValue();
-    os << refCellName << " = " << externalMem;
-  });
-  os << "]";
+  if (!refCellsMap.empty()) {
+    os << "[";
+    llvm::interleaveComma(refCellsMap, os, [&](auto refCell) {
+      auto refCellName = refCell.getName().str();
+      auto externalMem = cast<FlatSymbolRefAttr>(refCell.getValue()).getValue();
+      os << refCellName << " = " << externalMem;
+    });
+    os << "]";
+  }
   ArrayAttr portNames = invoke.getPortNames();
   ArrayAttr inputNames = invoke.getInputNames();
   /// Because the ports of all components of calyx.invoke are inside a (),

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -205,6 +205,17 @@ Value MemoryInterface::done() {
   return done.value();
 }
 
+StringRef MemoryInterface::memName() {
+  if (auto *memOp = std::get_if<calyx::MemoryOp>(&impl); memOp) {
+    return memOp->getName();
+  }
+
+  if (auto *memOp = std::get_if<calyx::SeqMemoryOp>(&impl); memOp) {
+    return memOp->getName();
+  }
+  return std::get<MemoryPortsImpl>(impl).memName;
+}
+
 std::optional<Value> MemoryInterface::readDataOpt() {
   if (auto *memOp = std::get_if<calyx::MemoryOp>(&impl); memOp) {
     return memOp->readData();

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -205,13 +205,13 @@ Value MemoryInterface::done() {
   return done.value();
 }
 
-StringRef MemoryInterface::memName() {
+std::string MemoryInterface::memName() {
   if (auto *memOp = std::get_if<calyx::MemoryOp>(&impl); memOp) {
-    return memOp->getName();
+    return memOp->getName().str();
   }
 
   if (auto *memOp = std::get_if<calyx::SeqMemoryOp>(&impl); memOp) {
-    return memOp->getName();
+    return memOp->getName().str();
   }
   return std::get<MemoryPortsImpl>(impl).memName;
 }

--- a/test/Conversion/SCFToCalyx/convert_func.mlir
+++ b/test/Conversion/SCFToCalyx/convert_func.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s --lower-scf-to-calyx="top-level-function=main" -canonicalize -split-input-file | FileCheck %s
 
 // CHECK-LABEL:   calyx.enable @init_func_instance
-// CHECK:         calyx.invoke @func_instance(%[[VAL_0:.*]] = %[[VAL_1:.*]]) -> (i32)
+// CHECK:         calyx.invoke @func_instance[](%[[VAL_0:.*]] = %[[VAL_1:.*]]) -> (i32)
 
 module {
   func.func @func(%0 : i32) -> i32 {
@@ -18,7 +18,7 @@ module {
 // -----
 
 // CHECK-LABEL:   calyx.enable @init_func_instance
-// CHECK:         calyx.invoke @func_instance(%[[VAL_0:.*]] = %[[VAL_1:.*]]) -> (i32)
+// CHECK:         calyx.invoke @func_instance[](%[[VAL_0:.*]] = %[[VAL_1:.*]]) -> (i32)
 
 module {
   func.func @func(%0 : i32) -> i32 {
@@ -49,7 +49,7 @@ module {
 // -----
 
 // CHECK-LABEL:   calyx.enable @init_fun_instance
-// CHECK:         calyx.invoke @fun_instance(%[[VAL_0:.*]] = %[[VAL_1:.*]]) -> (i32)
+// CHECK:         calyx.invoke @fun_instance[](%[[VAL_0:.*]] = %[[VAL_1:.*]]) -> (i32)
 
 module {
   func.func @fun(%0 : i32) -> i32 {
@@ -73,9 +73,9 @@ module {
 // -----
 
 // CHECK-LABEL:   calyx.enable @init_func_instance
-// CHECK:         calyx.invoke @func_instance(%[[VAL_0:.*]] = %[[VAL_1:.*]]) -> (i32)
+// CHECK:         calyx.invoke @func_instance[](%[[VAL_0:.*]] = %[[VAL_1:.*]]) -> (i32)
 // CHECK:         calyx.enable @init_func_instance
-// CHECK:         calyx.invoke @func_instance(%[[VAL_2:.*]] = %[[VAL_3:.*]]) -> (i32)
+// CHECK:         calyx.invoke @func_instance[](%[[VAL_2:.*]] = %[[VAL_3:.*]]) -> (i32)
 
 module {
   func.func @func(%0 : i32) -> i32 { 

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -372,27 +372,49 @@ module {
 // External memory store.
 
 module {
+// CHECK-LABEL:   calyx.component @main_1(
+// CHECK-SAME:                            %[[VAL_0:in0]]: i32,
+// CHECK-SAME:                            %[[VAL_1:in1]]: i32,
+// CHECK-SAME:                            %[[VAL_2:.*]]: i1 {clk},
+// CHECK-SAME:                            %[[VAL_3:.*]]: i1 {reset},
+// CHECK-SAME:                            %[[VAL_4:.*]]: i1 {go}) -> (
+// CHECK-SAME:                            %[[VAL_5:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant true
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.instance @main_instance of @main : i32, i32, i1, i1, i1, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.group @init_main_instance {
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_20]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @init_main_instance
+// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_0](%[[VAL_15]] = %[[VAL_0]], %[[VAL_16]] = %[[VAL_1]]) -> (i32, i32)
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
+
 // CHECK-LABEL:   calyx.component @main(
 // CHECK-SAME:                          %[[VAL_0:in0]]: i32,
-// CHECK-SAME:                          %[[VAL_1:.*]]: i32 {mem = {id = 0 : i32, tag = "read_data"}},
-// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {mem = {id = 0 : i32, tag = "done"}},
-// CHECK-SAME:                          %[[VAL_3:in2]]: i32,
-// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {clk},
-// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {reset},
-// CHECK-SAME:                          %[[VAL_6:.*]]: i1 {go}) -> (
-// CHECK-SAME:                          %[[VAL_7:.*]]: i32 {mem = {id = 0 : i32, tag = "write_data"}},
-// CHECK-SAME:                          %[[VAL_8:.*]]: i3 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}},
-// CHECK-SAME:                          %[[VAL_9:.*]]: i1 {mem = {id = 0 : i32, tag = "write_en"}},
-// CHECK-SAME:                          %[[VAL_10:.*]]: i1 {done}) {
-// CHECK:           %[[VAL_11:.*]] = hw.constant true
-// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.std_slice @std_slice_0 : i32, i3
+// CHECK-SAME:                          %[[VAL_1:in2]]: i32,
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant true
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = calyx.std_slice @std_slice_0 : i32, i3
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.group @bb0_0 {
-// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_3]] : i32
-// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_13]] : i3
-// CHECK:               calyx.assign %[[VAL_7]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_11]] : i1
-// CHECK:               calyx.group_done %[[VAL_2]] : i1
+// CHECK:               calyx.assign %[[VAL_7]] = %[[VAL_1]] : i32
+// CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_8]] : i3
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_16]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {
@@ -400,7 +422,7 @@ module {
 // CHECK:               calyx.enable @bb0_0
 // CHECK:             }
 // CHECK:           }
-// CHECK:         } {toplevel}
+// CHECK:         }  
   func.func @main(%arg0 : i32, %mem0 : memref<8xi32>, %i : index) {
     memref.store %arg0, %mem0[%i] : memref<8xi32>
     return
@@ -412,35 +434,55 @@ module {
 // External memory load.
 
 module {
-// CHECK-LABEL:   calyx.component @main(
-// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
-// CHECK-SAME:                          %[[VAL_1:.*]]: i32 {mem = {id = 0 : i32, tag = "read_data"}},
-// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {mem = {id = 0 : i32, tag = "done"}},
-// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {clk},
-// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {reset},
-// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {go}) -> (
-// CHECK-SAME:                          %[[VAL_6:.*]]: i32 {mem = {id = 0 : i32, tag = "write_data"}},
-// CHECK-SAME:                          %[[VAL_7:.*]]: i3 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}},
-// CHECK-SAME:                          %[[VAL_8:.*]]: i1 {mem = {id = 0 : i32, tag = "write_en"}},
-// CHECK-SAME:                          %[[VAL_9:.*]]: i32,
-// CHECK-SAME:                          %[[VAL_10:.*]]: i1 {done}) {
-// CHECK:           %[[VAL_11:.*]] = hw.constant true
-// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.std_slice @std_slice_0 : i32, i3
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-LABEL:   calyx.component @main_1(
+// CHECK-SAME:                            %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                            %[[VAL_1:.*]]: i1 {clk},
+// CHECK-SAME:                            %[[VAL_2:.*]]: i1 {reset},
+// CHECK-SAME:                            %[[VAL_3:.*]]: i1 {go}) -> (
+// CHECK-SAME:                            %[[VAL_4:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_5:.*]] = hw.constant true
+// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.instance @main_instance of @main : i32, i1, i1, i1, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.assign %[[VAL_9]] = %[[VAL_24]] : i32
-// CHECK:             calyx.group @bb0_0 {
-// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_7]] = %[[VAL_13]] : i3
-// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_1]] : i32
-// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_11]] : i1
+// CHECK:             calyx.group @init_main_instance {
+// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_5]] : i1
 // CHECK:               calyx.group_done %[[VAL_19]] : i1
 // CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @init_main_instance
+// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_0](%[[VAL_14]] = %[[VAL_0]]) -> (i32)
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
+
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
+// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_4:.*]]: i32,
+// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant false
+// CHECK:           %[[VAL_7:.*]] = hw.constant true
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_0 : i32, i3
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_14]] : i32
+// CHECK:             calyx.group @bb0_0 {
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_9]] : i3
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_7]] : i1
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:             }
 // CHECK:             calyx.group @ret_assign_0 {
-// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_18]] : i32
-// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_11]] : i1
-// CHECK:               calyx.group_done %[[VAL_25]] : i1
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_22]] : i32
+// CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_7]] : i1
+// CHECK:               calyx.group_done %[[VAL_15]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {
@@ -449,7 +491,7 @@ module {
 // CHECK:               calyx.enable @ret_assign_0
 // CHECK:             }
 // CHECK:           }
-// CHECK:         } {toplevel}
+// CHECK:         }
   func.func @main(%i : index, %mem0 : memref<8xi32>) -> i32 {
     %0 = memref.load %mem0[%i] : memref<8xi32>
     return %0 : i32
@@ -461,51 +503,77 @@ module {
 // External memory hazard.
 
 module {
+// CHECK-LABEL:   calyx.component @main_1(
+// CHECK-SAME:                            %[[VAL_0:in0]]: i32,
+// CHECK-SAME:                            %[[VAL_1:in1]]: i32,
+// CHECK-SAME:                            %[[VAL_2:.*]]: i1 {clk},
+// CHECK-SAME:                            %[[VAL_3:.*]]: i1 {reset},
+// CHECK-SAME:                            %[[VAL_4:.*]]: i1 {go}) -> (
+// CHECK-SAME:                            %[[VAL_5:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant true
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]] = calyx.instance @main_instance of @main : i32, i32, i1, i1, i1, i32, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.group @init_main_instance {
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_22]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @init_main_instance
+// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_0](%[[VAL_15]] = %[[VAL_0]], %[[VAL_16]] = %[[VAL_1]]) -> (i32, i32)
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
+
 // CHECK-LABEL:   calyx.component @main(
 // CHECK-SAME:                          %[[VAL_0:in0]]: i32,
 // CHECK-SAME:                          %[[VAL_1:in1]]: i32,
-// CHECK-SAME:                          %[[VAL_2:.*]]: i32 {mem = {id = 0 : i32, tag = "read_data"}},
-// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {mem = {id = 0 : i32, tag = "done"}},
-// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {clk},
-// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {reset},
-// CHECK-SAME:                          %[[VAL_6:.*]]: i1 {go}) -> (
-// CHECK-SAME:                          %[[VAL_7:.*]]: i32 {mem = {id = 0 : i32, tag = "write_data"}},
-// CHECK-SAME:                          %[[VAL_8:.*]]: i3 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}},
-// CHECK-SAME:                          %[[VAL_9:.*]]: i1 {mem = {id = 0 : i32, tag = "write_en"}},
-// CHECK-SAME:                          %[[VAL_10:out0]]: i32,
-// CHECK-SAME:                          %[[VAL_11:out1]]: i32,
-// CHECK-SAME:                          %[[VAL_12:.*]]: i1 {done}) {
-// CHECK:           %[[VAL_13:.*]] = hw.constant true
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]] = calyx.std_slice @std_slice_1 : i32, i3
-// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.std_slice @std_slice_0 : i32, i3
-// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.register @load_1_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]] = calyx.register @ret_arg1_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_36:.*]], %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_5:out0]]: i32,
+// CHECK-SAME:                          %[[VAL_6:out1]]: i32,
+// CHECK-SAME:                          %[[VAL_7:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_8:.*]] = hw.constant true
+// CHECK:           %[[VAL_9:.*]] = hw.constant false
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_1 : i32, i3
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.std_slice @std_slice_0 : i32, i3
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.register @load_1_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]] = calyx.register @ret_arg1_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]] = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.assign %[[VAL_11]] = %[[VAL_34]] : i32
-// CHECK:             calyx.assign %[[VAL_10]] = %[[VAL_40]] : i32
+// CHECK:             calyx.assign %[[VAL_6]] = %[[VAL_30]] : i32
+// CHECK:             calyx.assign %[[VAL_5]] = %[[VAL_36]] : i32
 // CHECK:             calyx.group @bb0_0 {
-// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_15]] : i3
-// CHECK:               calyx.assign %[[VAL_24]] = %[[VAL_2]] : i32
-// CHECK:               calyx.assign %[[VAL_25]] = %[[VAL_13]] : i1
-// CHECK:               calyx.group_done %[[VAL_29]] : i1
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_38]] = %[[VAL_11]] : i3
+// CHECK:               calyx.assign %[[VAL_41]] = %[[VAL_8]] : i1
+// CHECK:               calyx.assign %[[VAL_42]] = %[[VAL_9]] : i1
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_44]] : i32
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_45]] : i1
+// CHECK:               calyx.group_done %[[VAL_25]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_1 {
-// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_1]] : i32
-// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_17]] : i3
-// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_2]] : i32
-// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_13]] : i1
-// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_1]] : i32
+// CHECK:               calyx.assign %[[VAL_38]] = %[[VAL_13]] : i3
+// CHECK:               calyx.assign %[[VAL_41]] = %[[VAL_8]] : i1
+// CHECK:               calyx.assign %[[VAL_42]] = %[[VAL_9]] : i1
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_44]] : i32
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_45]] : i1
+// CHECK:               calyx.group_done %[[VAL_19]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @ret_assign_0 {
-// CHECK:               calyx.assign %[[VAL_36]] = %[[VAL_28]] : i32
-// CHECK:               calyx.assign %[[VAL_37]] = %[[VAL_13]] : i1
-// CHECK:               calyx.assign %[[VAL_30]] = %[[VAL_22]] : i32
-// CHECK:               calyx.assign %[[VAL_31]] = %[[VAL_13]] : i1
-// CHECK:               %[[VAL_42:.*]] = comb.and %[[VAL_35]], %[[VAL_41]] : i1
-// CHECK:               calyx.group_done %[[VAL_42]] ? %[[VAL_13]] : i1
+// CHECK:               calyx.assign %[[VAL_32]] = %[[VAL_24]] : i32
+// CHECK:               calyx.assign %[[VAL_33]] = %[[VAL_8]] : i1
+// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_18]] : i32
+// CHECK:               calyx.assign %[[VAL_27]] = %[[VAL_8]] : i1
+// CHECK:               %[[VAL_46:.*]] = comb.and %[[VAL_31]], %[[VAL_37]] : i1
+// CHECK:               calyx.group_done %[[VAL_46]] ? %[[VAL_8]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {
@@ -515,7 +583,7 @@ module {
 // CHECK:               calyx.enable @ret_assign_0
 // CHECK:             }
 // CHECK:           }
-// CHECK:         } {toplevel}
+// CHECK:         }
   func.func @main(%i0 : index, %i1 : index, %mem0 : memref<8xi32>) -> (i32, i32) {
     %0 = memref.load %mem0[%i0] : memref<8xi32>
     %1 = memref.load %mem0[%i1] : memref<8xi32>
@@ -590,35 +658,54 @@ module {
 // Load from memory with more elements than index width (32 bits).
 
 module {
-// CHECK-LABEL:   calyx.component @main(
-// CHECK-SAME:                          %[[VAL_0:.*]]: i32 {mem = {id = 0 : i32, tag = "read_data"}},
-// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {mem = {id = 0 : i32, tag = "done"}},
-// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {clk},
-// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {reset},
-// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {go}) -> (
-// CHECK-SAME:                          %[[VAL_5:.*]]: i32 {mem = {id = 0 : i32, tag = "write_data"}},
-// CHECK-SAME:                          %[[VAL_6:.*]]: i6 {mem = {addr_idx = 0 : i32, id = 0 : i32, tag = "addr"}},
-// CHECK-SAME:                          %[[VAL_7:.*]]: i1 {mem = {id = 0 : i32, tag = "write_en"}},
-// CHECK-SAME:                          %[[VAL_8:.*]]: i32,
-// CHECK-SAME:                          %[[VAL_9:.*]]: i1 {done}) {
-// CHECK:           %[[VAL_10:.*]] = hw.constant true
-// CHECK:           %[[VAL_11:.*]] = hw.constant 0 : i32
-// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.std_slice @std_slice_0 : i32, i6
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-LABEL:   calyx.component @main_1(
+// CHECK-SAME:                            %[[VAL_0:.*]]: i1 {clk},
+// CHECK-SAME:                            %[[VAL_1:.*]]: i1 {reset},
+// CHECK-SAME:                            %[[VAL_2:.*]]: i1 {go}) -> (
+// CHECK-SAME:                            %[[VAL_3:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_4:.*]] = hw.constant true
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = calyx.seq_mem @mem_0 <[33] x 32> [6] {external = true} : i6, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.instance @main_instance of @main : i1, i1, i1, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.assign %[[VAL_8]] = %[[VAL_24]] : i32
+// CHECK:             calyx.group @init_main_instance {
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_4]] : i1
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_17]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @init_main_instance
+// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_0]() -> ()
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
+
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_3:.*]]: i32,
+// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_5:.*]] = hw.constant false
+// CHECK:           %[[VAL_6:.*]] = hw.constant true
+// CHECK:           %[[VAL_7:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_0 : i32, i6
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.seq_mem @arg_mem_0 <[33] x 32> [6] : i6, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.assign %[[VAL_3]] = %[[VAL_14]] : i32
 // CHECK:             calyx.group @bb0_0 {
-// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_11]] : i32
-// CHECK:               calyx.assign %[[VAL_6]] = %[[VAL_13]] : i6
-// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_10]] : i1
-// CHECK:               calyx.group_done %[[VAL_19]] : i1
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_9]] : i6
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_5]] : i1
+// CHECK:               calyx.group_done %[[VAL_23]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @ret_assign_0 {
-// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_18]] : i32
-// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_10]] : i1
-// CHECK:               calyx.group_done %[[VAL_25]] : i1
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_22]] : i32
+// CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_15]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {
@@ -627,7 +714,7 @@ module {
 // CHECK:               calyx.enable @ret_assign_0
 // CHECK:             }
 // CHECK:           }
-// CHECK:         } {toplevel}
+// CHECK:         }
   func.func @main(%mem : memref<33xi32>) -> i32 {
     %c0 = arith.constant 0 : index
     %0 = memref.load %mem[%c0] : memref<33xi32>

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -810,3 +810,103 @@ module {
   }
 }
 
+// -----
+
+// Original top-level function's alloc-memories should be passed by reference
+module {
+// CHECK-LABEL:   calyx.component @main_1(
+// CHECK-SAME:                            %[[VAL_0:.*]]: i1 {clk},
+// CHECK-SAME:                            %[[VAL_1:.*]]: i1 {reset},
+// CHECK-SAME:                            %[[VAL_2:.*]]: i1 {go}) -> (
+// CHECK-SAME:                            %[[VAL_3:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_4:.*]] = hw.constant true
+// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = calyx.seq_mem @mem_1 <[1] x 32> [1] {external = true} : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.seq_mem @mem_0 <[1] x 32> [1] {external = true} : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.instance @main_instance of @main : i1, i1, i1, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.group @init_main_instance {
+// CHECK:               calyx.assign %[[VAL_22]] = %[[VAL_4]] : i1
+// CHECK:               calyx.assign %[[VAL_23]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_25]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @init_main_instance
+// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_0, mem_0 = mem_1]() -> ()
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
+
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_3:.*]]: i32,
+// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_5:.*]] = hw.constant true
+// CHECK:           %[[VAL_6:.*]] = hw.constant false
+// CHECK:           %[[VAL_7:.*]] = hw.constant 1 : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = calyx.std_slice @std_slice_2 : i32, i1
+// CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]] = calyx.std_slice @std_slice_1 : i32, i1
+// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.std_slice @std_slice_0 : i32, i1
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]] = calyx.seq_mem @mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]] = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.assign %[[VAL_3]] = %[[VAL_36]] : i32
+// CHECK:             calyx.group @bb0_0 {
+// CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_8]] : i32
+// CHECK:               calyx.assign %[[VAL_38]] = %[[VAL_10]] : i1
+// CHECK:               calyx.assign %[[VAL_41]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_42]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_45]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @bb0_1 {
+// CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_8]] : i32
+// CHECK:               calyx.assign %[[VAL_24]] = %[[VAL_12]] : i1
+// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_27]] = %[[VAL_5]] : i1
+// CHECK:               calyx.group_done %[[VAL_31]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @bb0_2 {
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_8]] : i32
+// CHECK:               calyx.assign %[[VAL_24]] = %[[VAL_14]] : i1
+// CHECK:               calyx.assign %[[VAL_27]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_30]] : i32
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_31]] : i1
+// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @ret_assign_0 {
+// CHECK:               calyx.assign %[[VAL_32]] = %[[VAL_17]] : i32
+// CHECK:               calyx.assign %[[VAL_33]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_44]] : i32
+// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_22]] : i32
+// CHECK:               calyx.group_done %[[VAL_37]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @bb0_0
+// CHECK:               calyx.enable @bb0_1
+// CHECK:               calyx.enable @bb0_2
+// CHECK:               calyx.enable @ret_assign_0
+// CHECK:             }
+// CHECK:           }
+// CHECK:         }
+  func.func @main(%arg0 : memref<1xi32>) -> (i32) {
+    %0 = arith.constant 0 : index
+    %one = arith.constant 1 : i32
+    %1 = memref.load %arg0[%0] : memref<1xi32>
+    %2 = memref.alloc() : memref<1xi32>
+    memref.store %one, %2[%0] : memref<1xi32>
+    %3 = memref.load %2[%0] : memref<1xi32>
+    %4 = arith.addi %1, %3 : i32
+    return %4 : i32
+  }
+}

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -833,7 +833,7 @@ module {
 // CHECK:           calyx.control {
 // CHECK:             calyx.seq {
 // CHECK:               calyx.enable @init_main_instance
-// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_1, arg_mem_1 = mem_0]() -> ()
+// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_0, arg_mem_1 = mem_1]() -> ()
 // CHECK:             }
 // CHECK:           }
 // CHECK:         } {toplevel}

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -833,7 +833,7 @@ module {
 // CHECK:           calyx.control {
 // CHECK:             calyx.seq {
 // CHECK:               calyx.enable @init_main_instance
-// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_0, mem_0 = mem_1]() -> ()
+// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_1, arg_mem_1 = mem_0]() -> ()
 // CHECK:             }
 // CHECK:           }
 // CHECK:         } {toplevel}
@@ -853,11 +853,11 @@ module {
 // CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.std_slice @std_slice_0 : i32, i1
 // CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
 // CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]] = calyx.seq_mem @mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]] = calyx.seq_mem @arg_mem_1 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]] = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.assign %[[VAL_3]] = %[[VAL_36]] : i32
+// CHECK:             calyx.assign %[[VAL_3]] = %[[VAL_28]] : i32
 // CHECK:             calyx.group @bb0_0 {
 // CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_8]] : i32
 // CHECK:               calyx.assign %[[VAL_38]] = %[[VAL_10]] : i1
@@ -867,27 +867,27 @@ module {
 // CHECK:             }
 // CHECK:             calyx.group @bb0_1 {
 // CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_8]] : i32
-// CHECK:               calyx.assign %[[VAL_24]] = %[[VAL_12]] : i1
-// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_7]] : i32
-// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_5]] : i1
-// CHECK:               calyx.assign %[[VAL_27]] = %[[VAL_5]] : i1
-// CHECK:               calyx.group_done %[[VAL_31]] : i1
+// CHECK:               calyx.assign %[[VAL_30]] = %[[VAL_12]] : i1
+// CHECK:               calyx.assign %[[VAL_35]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_34]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_33]] = %[[VAL_5]] : i1
+// CHECK:               calyx.group_done %[[VAL_37]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_2 {
 // CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_8]] : i32
-// CHECK:               calyx.assign %[[VAL_24]] = %[[VAL_14]] : i1
-// CHECK:               calyx.assign %[[VAL_27]] = %[[VAL_5]] : i1
-// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_6]] : i1
-// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_30]] : i32
-// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_31]] : i1
+// CHECK:               calyx.assign %[[VAL_30]] = %[[VAL_14]] : i1
+// CHECK:               calyx.assign %[[VAL_33]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_34]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_36]] : i32
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_37]] : i1
 // CHECK:               calyx.group_done %[[VAL_23]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @ret_assign_0 {
-// CHECK:               calyx.assign %[[VAL_32]] = %[[VAL_17]] : i32
-// CHECK:               calyx.assign %[[VAL_33]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_24]] = %[[VAL_17]] : i32
+// CHECK:               calyx.assign %[[VAL_25]] = %[[VAL_5]] : i1
 // CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_44]] : i32
 // CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_22]] : i32
-// CHECK:               calyx.group_done %[[VAL_37]] : i1
+// CHECK:               calyx.group_done %[[VAL_29]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -372,7 +372,7 @@ module {
 // External memory store.
 
 module {
-// CHECK-LABEL:   calyx.component @main_1(
+// CHECK-LABEL:   calyx.component @main(
 // CHECK-SAME:                            %[[VAL_0:in0]]: i32,
 // CHECK-SAME:                            %[[VAL_1:in1]]: i32,
 // CHECK-SAME:                            %[[VAL_2:.*]]: i1 {clk},
@@ -381,9 +381,9 @@ module {
 // CHECK-SAME:                            %[[VAL_5:.*]]: i1 {done}) {
 // CHECK:           %[[VAL_6:.*]] = hw.constant true
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.instance @main_instance of @main : i32, i32, i1, i1, i1, i1
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.instance @main_1_instance of @main_1 : i32, i32, i1, i1, i1, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.group @init_main_instance {
+// CHECK:             calyx.group @init_main_1_instance {
 // CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_6]] : i1
 // CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_6]] : i1
 // CHECK:               calyx.group_done %[[VAL_20]] : i1
@@ -391,13 +391,13 @@ module {
 // CHECK:           }
 // CHECK:           calyx.control {
 // CHECK:             calyx.seq {
-// CHECK:               calyx.enable @init_main_instance
-// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_0](%[[VAL_15]] = %[[VAL_0]], %[[VAL_16]] = %[[VAL_1]]) -> (i32, i32)
+// CHECK:               calyx.enable @init_main_1_instance
+// CHECK:               calyx.invoke @main_1_instance[arg_mem_0 = mem_0](%[[VAL_15]] = %[[VAL_0]], %[[VAL_16]] = %[[VAL_1]]) -> (i32, i32)
 // CHECK:             }
 // CHECK:           }
 // CHECK:         } {toplevel}
 
-// CHECK-LABEL:   calyx.component @main(
+// CHECK-LABEL:   calyx.component @main_1(
 // CHECK-SAME:                          %[[VAL_0:in0]]: i32,
 // CHECK-SAME:                          %[[VAL_1:in2]]: i32,
 // CHECK-SAME:                          %[[VAL_2:.*]]: i1 {clk},
@@ -434,7 +434,7 @@ module {
 // External memory load.
 
 module {
-// CHECK-LABEL:   calyx.component @main_1(
+// CHECK-LABEL:   calyx.component @main(
 // CHECK-SAME:                            %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                            %[[VAL_1:.*]]: i1 {clk},
 // CHECK-SAME:                            %[[VAL_2:.*]]: i1 {reset},
@@ -442,9 +442,9 @@ module {
 // CHECK-SAME:                            %[[VAL_4:.*]]: i1 {done}) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.instance @main_instance of @main : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.instance @main_1_instance of @main_1 : i32, i1, i1, i1, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.group @init_main_instance {
+// CHECK:             calyx.group @init_main_1_instance {
 // CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_5]] : i1
 // CHECK:               calyx.assign %[[VAL_17]] = %[[VAL_5]] : i1
 // CHECK:               calyx.group_done %[[VAL_19]] : i1
@@ -452,13 +452,13 @@ module {
 // CHECK:           }
 // CHECK:           calyx.control {
 // CHECK:             calyx.seq {
-// CHECK:               calyx.enable @init_main_instance
-// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_0](%[[VAL_14]] = %[[VAL_0]]) -> (i32)
+// CHECK:               calyx.enable @init_main_1_instance
+// CHECK:               calyx.invoke @main_1_instance[arg_mem_0 = mem_0](%[[VAL_14]] = %[[VAL_0]]) -> (i32)
 // CHECK:             }
 // CHECK:           }
 // CHECK:         } {toplevel}
 
-// CHECK-LABEL:   calyx.component @main(
+// CHECK-LABEL:   calyx.component @main_1(
 // CHECK-SAME:                          %[[VAL_0:in0]]: i32,
 // CHECK-SAME:                          %[[VAL_1:.*]]: i1 {clk},
 // CHECK-SAME:                          %[[VAL_2:.*]]: i1 {reset},
@@ -503,7 +503,7 @@ module {
 // External memory hazard.
 
 module {
-// CHECK-LABEL:   calyx.component @main_1(
+// CHECK-LABEL:   calyx.component @main(
 // CHECK-SAME:                            %[[VAL_0:in0]]: i32,
 // CHECK-SAME:                            %[[VAL_1:in1]]: i32,
 // CHECK-SAME:                            %[[VAL_2:.*]]: i1 {clk},
@@ -512,9 +512,9 @@ module {
 // CHECK-SAME:                            %[[VAL_5:.*]]: i1 {done}) {
 // CHECK:           %[[VAL_6:.*]] = hw.constant true
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]] = calyx.instance @main_instance of @main : i32, i32, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]] = calyx.instance @main_1_instance of @main_1 : i32, i32, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.group @init_main_instance {
+// CHECK:             calyx.group @init_main_1_instance {
 // CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_6]] : i1
 // CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_6]] : i1
 // CHECK:               calyx.group_done %[[VAL_22]] : i1
@@ -522,13 +522,13 @@ module {
 // CHECK:           }
 // CHECK:           calyx.control {
 // CHECK:             calyx.seq {
-// CHECK:               calyx.enable @init_main_instance
-// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_0](%[[VAL_15]] = %[[VAL_0]], %[[VAL_16]] = %[[VAL_1]]) -> (i32, i32)
+// CHECK:               calyx.enable @init_main_1_instance
+// CHECK:               calyx.invoke @main_1_instance[arg_mem_0 = mem_0](%[[VAL_15]] = %[[VAL_0]], %[[VAL_16]] = %[[VAL_1]]) -> (i32, i32)
 // CHECK:             }
 // CHECK:           }
 // CHECK:         } {toplevel}
 
-// CHECK-LABEL:   calyx.component @main(
+// CHECK-LABEL:   calyx.component @main_1(
 // CHECK-SAME:                          %[[VAL_0:in0]]: i32,
 // CHECK-SAME:                          %[[VAL_1:in1]]: i32,
 // CHECK-SAME:                          %[[VAL_2:.*]]: i1 {clk},
@@ -658,16 +658,16 @@ module {
 // Load from memory with more elements than index width (32 bits).
 
 module {
-// CHECK-LABEL:   calyx.component @main_1(
+// CHECK-LABEL:   calyx.component @main(
 // CHECK-SAME:                            %[[VAL_0:.*]]: i1 {clk},
 // CHECK-SAME:                            %[[VAL_1:.*]]: i1 {reset},
 // CHECK-SAME:                            %[[VAL_2:.*]]: i1 {go}) -> (
 // CHECK-SAME:                            %[[VAL_3:.*]]: i1 {done}) {
 // CHECK:           %[[VAL_4:.*]] = hw.constant true
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = calyx.seq_mem @mem_0 <[33] x 32> [6] {external = true} : i6, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.instance @main_instance of @main : i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.instance @main_1_instance of @main_1 : i1, i1, i1, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.group @init_main_instance {
+// CHECK:             calyx.group @init_main_1_instance {
 // CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_4]] : i1
 // CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_4]] : i1
 // CHECK:               calyx.group_done %[[VAL_17]] : i1
@@ -675,13 +675,13 @@ module {
 // CHECK:           }
 // CHECK:           calyx.control {
 // CHECK:             calyx.seq {
-// CHECK:               calyx.enable @init_main_instance
-// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_0]() -> ()
+// CHECK:               calyx.enable @init_main_1_instance
+// CHECK:               calyx.invoke @main_1_instance[arg_mem_0 = mem_0]() -> ()
 // CHECK:             }
 // CHECK:           }
 // CHECK:         } {toplevel}
 
-// CHECK-LABEL:   calyx.component @main(
+// CHECK-LABEL:   calyx.component @main_1(
 // CHECK-SAME:                          %[[VAL_0:.*]]: i1 {clk},
 // CHECK-SAME:                          %[[VAL_1:.*]]: i1 {reset},
 // CHECK-SAME:                          %[[VAL_2:.*]]: i1 {go}) -> (
@@ -814,7 +814,7 @@ module {
 
 // Original top-level function's alloc-memories should be passed by reference
 module {
-// CHECK-LABEL:   calyx.component @main_1(
+// CHECK-LABEL:   calyx.component @main(
 // CHECK-SAME:                            %[[VAL_0:.*]]: i1 {clk},
 // CHECK-SAME:                            %[[VAL_1:.*]]: i1 {reset},
 // CHECK-SAME:                            %[[VAL_2:.*]]: i1 {go}) -> (
@@ -822,9 +822,9 @@ module {
 // CHECK:           %[[VAL_4:.*]] = hw.constant true
 // CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = calyx.seq_mem @mem_1 <[1] x 32> [1] {external = true} : i1, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.seq_mem @mem_0 <[1] x 32> [1] {external = true} : i1, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.instance @main_instance of @main : i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.instance @main_1_instance of @main_1 : i1, i1, i1, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.group @init_main_instance {
+// CHECK:             calyx.group @init_main_1_instance {
 // CHECK:               calyx.assign %[[VAL_22]] = %[[VAL_4]] : i1
 // CHECK:               calyx.assign %[[VAL_23]] = %[[VAL_4]] : i1
 // CHECK:               calyx.group_done %[[VAL_25]] : i1
@@ -832,13 +832,13 @@ module {
 // CHECK:           }
 // CHECK:           calyx.control {
 // CHECK:             calyx.seq {
-// CHECK:               calyx.enable @init_main_instance
-// CHECK:               calyx.invoke @main_instance[arg_mem_0 = mem_0, arg_mem_1 = mem_1]() -> ()
+// CHECK:               calyx.enable @init_main_1_instance
+// CHECK:               calyx.invoke @main_1_instance[arg_mem_0 = mem_0, arg_mem_1 = mem_1]() -> ()
 // CHECK:             }
 // CHECK:           }
 // CHECK:         } {toplevel}
 
-// CHECK-LABEL:   calyx.component @main(
+// CHECK-LABEL:   calyx.component @main_1(
 // CHECK-SAME:                          %[[VAL_0:.*]]: i1 {clk},
 // CHECK-SAME:                          %[[VAL_1:.*]]: i1 {reset},
 // CHECK-SAME:                          %[[VAL_2:.*]]: i1 {go}) -> (

--- a/test/Dialect/Calyx/emit-invoke-with-ref.mlir
+++ b/test/Dialect/Calyx/emit-invoke-with-ref.mlir
@@ -1,0 +1,68 @@
+// RUN: circt-translate --export-calyx --split-input-file --verify-diagnostics %s | FileCheck %s --strict-whitespace
+
+module attributes {calyx.entrypoint = "main"} {
+  calyx.component @func(%in1: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
+    %true = hw.constant true
+    %false = hw.constant false
+    %c0_i32 = hw.constant 0 : i32
+    %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i1
+    %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+    %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+    // CHECK: ref arg_mem_0 = seq_mem_d1(32, 1, 1);
+    %arg_mem_0.addr0, %arg_mem_0.clk, %arg_mem_0.reset, %arg_mem_0.content_en, %arg_mem_0.write_en, %arg_mem_0.write_data, %arg_mem_0.read_data, %arg_mem_0.done = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
+    calyx.wires {
+      calyx.assign %out0 = %ret_arg0_reg.out : i32
+      calyx.group @bb0_0 {
+        calyx.assign %std_slice_0.in = %c0_i32 : i32
+        calyx.assign %arg_mem_0.addr0 = %std_slice_0.out : i1
+        calyx.assign %arg_mem_0.content_en = %true : i1
+        calyx.assign %arg_mem_0.write_en = %false : i1
+        calyx.group_done %arg_mem_0.done : i1
+      }
+      calyx.group @ret_assign_0 {
+        calyx.assign %ret_arg0_reg.in = %std_add_0.out : i32
+        calyx.assign %ret_arg0_reg.write_en = %true : i1
+        calyx.assign %std_add_0.left = %arg_mem_0.read_data : i32
+        calyx.assign %std_add_0.right = %in1 : i32
+        calyx.group_done %ret_arg0_reg.done : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.enable @bb0_0
+        calyx.enable @ret_assign_0
+      }
+    }
+  }
+  calyx.component @main(%clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
+    %c0_i32 = hw.constant 0 : i32
+    %true = hw.constant true
+    // CHECK: @external(1) mem_0 = seq_mem_d1(32, 1, 1);
+    %mem_0.addr0, %mem_0.clk, %mem_0.reset, %mem_0.content_en, %mem_0.write_en, %mem_0.write_data, %mem_0.read_data, %mem_0.done = calyx.seq_mem @mem_0 <[1] x 32> [1] {external = true} : i1, i1, i1, i1, i1, i32, i32, i1
+    %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+    %func_instance.in1, %func_instance.clk, %func_instance.reset, %func_instance.go, %func_instance.out0, %func_instance.done = calyx.instance @func_instance of @func : i32, i1, i1, i1, i32, i1
+    calyx.wires {
+      calyx.assign %out0 = %ret_arg0_reg.out : i32
+      calyx.group @init_func_instance {
+        calyx.assign %func_instance.reset = %true : i1
+        calyx.assign %func_instance.go = %true : i1
+        calyx.group_done %func_instance.done : i1
+      }
+      calyx.group @ret_assign_0 {
+        calyx.assign %ret_arg0_reg.in = %func_instance.out0 : i32
+        calyx.assign %ret_arg0_reg.write_en = %true : i1
+        calyx.group_done %ret_arg0_reg.done : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.seq {
+          calyx.enable @init_func_instance
+          // CHECK: invoke func_instance[arg_mem_0 = mem_0](in1 = 32'd0)();
+          calyx.invoke @func_instance[arg_mem_0 = mem_0](%func_instance.in1 = %c0_i32) -> (i32)
+        }
+        calyx.enable @ret_assign_0
+      }
+    }
+  } {toplevel}
+}

--- a/test/Dialect/Calyx/emit-invoke.mlir
+++ b/test/Dialect/Calyx/emit-invoke.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-translate --export-calyx --split-input-file --verify-diagnostics %s | FileCheck %s --strict-whitespace
 
-module attributes {calyx.entrypoint = "main"} { 
+module attributes {calyx.entrypoint = "main"} {
 calyx.component @identity(%in: i32, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out: i32, %done: i1 {done}) {
   %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i32, i1, i1, i1, i32, i1
   calyx.wires {

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -1108,7 +1108,7 @@ module attributes {calyx.entrypoint = "main"} {
 
     }
     calyx.control {
-      // expected-error @+1 {{'calyx.invoke' op '@r' has zero input and output port connections; expected at least one.}}
+      // expected-error @+1 {{'calyx.invoke' op '@r' has zero input and output port connections;  and has not passing-by-reference cells; expected at least one.}}
       calyx.invoke @r() -> ()
     }
   }

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -1108,7 +1108,7 @@ module attributes {calyx.entrypoint = "main"} {
 
     }
     calyx.control {
-      // expected-error @+1 {{'calyx.invoke' op '@r' has zero input and output port connections;  and has not passing-by-reference cells; expected at least one.}}
+      // expected-error @+1 {{'calyx.invoke' op '@r' has zero input and output port connections and has no passing-by-reference cells; expected at least one.}}
       calyx.invoke @r() -> ()
     }
   }

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -444,3 +444,90 @@ module attributes {calyx.entrypoint = "main"} {
     }
   }
 }
+
+// -----
+
+module attributes {calyx.entrypoint = "main"} {
+  // CHECK-LABEL:   calyx.component @main(%in0: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
+  calyx.component @main(%in0: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
+    %true = hw.constant true
+    %mem_1.addr0, %mem_1.clk, %mem_1.reset, %mem_1.content_en, %mem_1.write_en, %mem_1.write_data, %mem_1.read_data, %mem_1.done = calyx.seq_mem @mem_1 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
+    %mem_0.addr0, %mem_0.clk, %mem_0.reset, %mem_0.content_en, %mem_0.write_en, %mem_0.write_data, %mem_0.read_data, %mem_0.done = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
+    %main_1_instance.in1, %main_1_instance.clk, %main_1_instance.reset, %main_1_instance.go, %main_1_instance.done = calyx.instance @main_1_instance of @main_1 : i32, i1, i1, i1, i1
+    calyx.wires {
+      calyx.group @init_main_1_instance {
+        calyx.assign %main_1_instance.reset = %true : i1
+        calyx.assign %main_1_instance.go = %true : i1
+        calyx.group_done %main_1_instance.done : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.seq {
+          calyx.enable @init_main_1_instance
+          // CHECK: calyx.invoke @main_1_instance[arg_mem_0 = mem_0, arg_mem_1 = mem_1](%main_1_instance.in1 = %in0) -> (i32)
+          calyx.invoke @main_1_instance[arg_mem_0 = mem_0, arg_mem_1 = mem_1](%main_1_instance.in1 = %in0) -> (i32)
+        }
+      }
+    }
+  } {toplevel}
+  // CHECK-LABEL: calyx.component @main_1(%in1: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
+  calyx.component @main_1(%in1: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
+    %true = hw.constant true
+    %c1_i32 = hw.constant 1 : i32
+    %func_1_instance.in0, %func_1_instance.in2, %func_1_instance.clk, %func_1_instance.reset, %func_1_instance.go, %func_1_instance.done = calyx.instance @func_1_instance of @func_1 : i32, i32, i1, i1, i1, i1
+    %arg_mem_1.addr0, %arg_mem_1.clk, %arg_mem_1.reset, %arg_mem_1.content_en, %arg_mem_1.write_en, %arg_mem_1.write_data, %arg_mem_1.read_data, %arg_mem_1.done = calyx.seq_mem @arg_mem_1 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+    %arg_mem_0.addr0, %arg_mem_0.clk, %arg_mem_0.reset, %arg_mem_0.content_en, %arg_mem_0.write_en, %arg_mem_0.write_data, %arg_mem_0.read_data, %arg_mem_0.done = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+    calyx.wires {
+      calyx.group @init_func_1_instance {
+        calyx.assign %func_1_instance.reset = %true : i1
+        calyx.assign %func_1_instance.go = %true : i1
+        calyx.group_done %func_1_instance.done : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.seq {
+          calyx.enable @init_func_1_instance
+          // CHECK: calyx.invoke @func_1_instance[arg_mem_0 = arg_mem_0, arg_mem_1 = arg_mem_1](%func_1_instance.in0 = %c1_i32, %func_1_instance.in2 = %in1) -> (i32, i32)
+          calyx.invoke @func_1_instance[arg_mem_0 = arg_mem_0, arg_mem_1 = arg_mem_1](%func_1_instance.in0 = %c1_i32, %func_1_instance.in2 = %in1) -> (i32, i32)
+        }
+      }
+    }
+  }
+  // CHECK-LABEL: calyx.component @func_1(%in0: i32, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
+  calyx.component @func_1(%in0: i32, %in2: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
+    %true = hw.constant true
+    %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i3
+    %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i3
+    %arg_mem_1.addr0, %arg_mem_1.clk, %arg_mem_1.reset, %arg_mem_1.content_en, %arg_mem_1.write_en, %arg_mem_1.write_data, %arg_mem_1.read_data, %arg_mem_1.done = calyx.seq_mem @arg_mem_1 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+    %arg_mem_0.addr0, %arg_mem_0.clk, %arg_mem_0.reset, %arg_mem_0.content_en, %arg_mem_0.write_en, %arg_mem_0.write_data, %arg_mem_0.read_data, %arg_mem_0.done = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+    calyx.wires {
+      calyx.group @bb0_0 {
+        calyx.assign %std_slice_1.in = %in2 : i32
+        calyx.assign %arg_mem_1.addr0 = %std_slice_1.out : i3
+        calyx.assign %arg_mem_1.write_data = %in0 : i32
+        calyx.assign %arg_mem_1.write_en = %true : i1
+        calyx.assign %arg_mem_1.content_en = %true : i1
+        calyx.group_done %arg_mem_1.done : i1
+      }
+      calyx.group @bb0_1 {
+        calyx.assign %std_slice_0.in = %in2 : i32
+        calyx.assign %arg_mem_0.addr0 = %std_slice_0.out : i3
+        calyx.assign %arg_mem_0.write_data = %in0 : i32
+        calyx.assign %arg_mem_0.write_en = %true : i1
+        calyx.assign %arg_mem_0.content_en = %true : i1
+        calyx.group_done %arg_mem_0.done : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.seq {
+          calyx.enable @bb0_0
+          calyx.enable @bb0_1
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
This patch addresses #4831 .

If the `main` `FuncOp` has `memref`s in its arguments, we create a new `main` component and make it the new entry point.