### PR TITLE
[ExportVerilog] Avoid using interface pass for PrepareForEmission, NFCI

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -118,8 +118,7 @@ def HWLowerInstanceChoices : Pass<"hw-lower-instance-choices",
   ];
 }
 
-def PrepareForEmission : InterfacePass<"prepare-for-emission",
-                                       "hw::HWEmittableModuleLike"> {
+def PrepareForEmission : Pass<"prepare-for-emission"> {
   let summary = "Prepare IR for ExportVerilog";
   let description = [{
     This pass runs only PrepareForEmission.

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -1333,8 +1333,13 @@ namespace {
 
 struct PrepareForEmissionPass
     : public PrepareForEmissionBase<PrepareForEmissionPass> {
+
+  bool canScheduleOn(mlir::RegisteredOperationName opName) const final {
+    return opName.hasInterface<hw::HWEmittableModuleLike>();
+  }
+
   void runOnOperation() override {
-    auto module = getOperation();
+    auto module = cast<hw::HWEmittableModuleLike>(getOperation());
     LoweringOptions options(cast<mlir::ModuleOp>(module->getParentOp()));
     if (failed(prepareHWModule(module, options)))
       signalPassFailure();


### PR DESCRIPTION
ODS InterfacePass generates `canScheduleOn` method with a specified interface in a header file and currently we import every pass declaration through PassesDetail.h. Gcc/clang seem to compile when there is an unknown interface class but MSVC emits an error. So this PR avoids `InterfacePass` in ODS and manually implements `canScheduleOn` in PrepareForEmission. 

Windows CI: https://github.com/llvm/circt/actions/runs/9497120978