### PR TITLE
[LowerDPI] Defer deletion of call ops to prevent inavlid access.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerDPI.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerDPI.cpp
@@ -126,7 +126,6 @@ void LowerDPIPass::runOnOperation() {
                           ->getResult(0);
         dpiOp.getResult().replaceAllUsesWith(result);
       }
-      dpiOp.erase();
     };
 
     lowerCall(firstDPICallop);
@@ -150,6 +149,9 @@ void LowerDPIPass::runOnOperation() {
       }
       lowerCall(dpiOp);
     }
+
+    for (auto callOp : calls)
+      callOp.erase();
   }
 }
 


### PR DESCRIPTION
The [lower-dpi-error.mlir](https://github.com/llvm/circt/pull/7139/files#diff-b9efcb02f7785b4bd52265c695cc5f2a6b00750101ea9abcd346e8bc161cd6db) test added in #7139 crashes on my local macOS debug build. This appears to be caused by [an invalid access in the lowering loop](https://github.com/llvm/circt/pull/7139/files#diff-8897e1920c98c76b3006af5bfe97e5313243e455253463acb99ffa55b924ef96R137). The iterator stored in `inputTypes` references the operand range of the first call op. However, after calling `lowerCall(firstDPICallop);` this op has been deleted. Deferring op erasure until after the current batch of call operations has been checked and lowered has fixed the problem for me.

Close https://github.com/llvm/circt/issues/7169