### PR TITLE
[NFC][ExportVerilog] Rename generated `options` member.

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -88,7 +88,7 @@ def TestApplyLoweringOption : Pass<"test-apply-lowering-options",
     "circt::sv::SVDialect", "circt::comb::CombDialect", "circt::hw::HWDialect"
   ];
   let options = [
-    Option<"options", "options", "std::string", "", "Lowering Options">
+    Option<"optionsString", "options", "std::string", "", "Lowering Options">
   ];
 }
 

--- a/lib/Conversion/ExportVerilog/ApplyLoweringOptions.cpp
+++ b/lib/Conversion/ExportVerilog/ApplyLoweringOptions.cpp
@@ -25,11 +25,11 @@ struct TestApplyLoweringOptionPass
     : public TestApplyLoweringOptionBase<TestApplyLoweringOptionPass> {
   TestApplyLoweringOptionPass() = default;
   void runOnOperation() override {
-    if (!options.hasValue()) {
+    if (!optionsString.hasValue()) {
       markAllAnalysesPreserved();
       return;
     }
-    LoweringOptions opts(options, [this](llvm::Twine tw) {
+    LoweringOptions opts(optionsString, [this](llvm::Twine tw) {
       getOperation().emitError(tw);
       signalPassFailure();
     });


### PR DESCRIPTION
Side-step an issue that prevents transitioning the inclusion of TableGen defined passes to the new(er) style, see #7168 #3962.

Currently, in the generated constructor for `TestApplyLoweringOptionBase` the formal parameter is shadowing the `options` member. This won't compile if we try to include it:
```
TestApplyLoweringOptionBase(const TestApplyLoweringOptionOptions &options) : TestApplyLoweringOptionBase() {
    options = options.options;
  }
```

Arguably, this could be fixed in upstream by at least picking a less obvious formal parameter name. But I think this tiny change isn't hurting us. 