### PR TITLE
[FIRRTL][ExpandWhens] Add StmtExprVisitor to Visitor and Support DPI intrinsic in ExpandWhens

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -406,13 +406,6 @@ public:
     return this->dispatchExprVisitor(op, args...);
   }
 
-  /// Special handling for generic intrinsic op which aren't quite expressions
-  /// nor statements in the usual FIRRTL sense.
-  /// Refactor into specific visitor instead of adding more here.
-  ResultType visitIntrinsicOp(GenericIntrinsicOp op, ExtraArgs... args) {
-    return static_cast<ConcreteType *>(this)->visitUnhandledOp(op, args...);
-  }
-
   // Chain from each visitor onto the next one.
   ResultType visitInvalidExpr(Operation *op, ExtraArgs... args) {
     return this->dispatchStmtVisitor(op, args...);
@@ -424,11 +417,7 @@ public:
     return this->dispatchStmtExprVisitor(op, args...);
   }
   ResultType visitInvalidStmtExpr(Operation *op, ExtraArgs... args) {
-    auto *thisCast = static_cast<ConcreteType *>(this);
-    return TypeSwitch<Operation *, ResultType>(op).Default(
-        [&](auto expr) -> ResultType {
-          return thisCast->visitInvalidOp(op, args...);
-        });
+    return static_cast<ConcreteType *>(this)->visitInvalidOp(op, args...);
   }
 
   // Default to chaining visitUnhandledXXX to visitUnhandledOp.

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -344,6 +344,48 @@ public:
 #undef HANDLE
 };
 
+/// StmtExprVisitor is a visitor for FIRRTL operation that has an optional
+/// result.
+template <typename ConcreteType, typename ResultType = void,
+          typename... ExtraArgs>
+class StmtExprVisitor {
+public:
+  ResultType dispatchStmtExprVisitor(Operation *op, ExtraArgs... args) {
+    auto *thisCast = static_cast<ConcreteType *>(this);
+    return TypeSwitch<Operation *, ResultType>(op)
+        .template Case<GenericIntrinsicOp, DPICallIntrinsicOp>(
+            [&](auto expr) -> ResultType {
+              return thisCast->visitStmtExpr(expr, args...);
+            })
+        .Default([&](auto expr) -> ResultType {
+          return thisCast->visitInvalidStmtExpr(op, args...);
+        });
+  }
+
+  /// This callback is invoked on any non-StmtExpr operations.
+  ResultType visitInvalidStmtExpr(Operation *op, ExtraArgs... args) {
+    op->emitOpError("unknown FIRRTL stmt expression");
+    abort();
+  }
+
+  /// This callback is invoked on any StmtExpr operations that are not handled
+  /// by the concrete visitor.
+  ResultType visitUnhandledStmtExpr(Operation *op, ExtraArgs... args) {
+    return ResultType();
+  }
+
+#define HANDLE(OPTYPE, OPKIND)                                                 \
+  ResultType visitStmtExpr(OPTYPE op, ExtraArgs... args) {                     \
+    return static_cast<ConcreteType *>(this)->visit##OPKIND##StmtExpr(         \
+        op, args...);                                                          \
+  }
+
+  // Statement expressions.
+  HANDLE(DPICallIntrinsicOp, Unhandled);
+  HANDLE(GenericIntrinsicOp, Unhandled);
+#undef HANDLE
+};
+
 /// FIRRTLVisitor allows you to visit all of the expr/stmt/decls with one class
 /// declaration.
 ///
@@ -356,7 +398,8 @@ template <typename ConcreteType, typename ResultType = void,
 class FIRRTLVisitor
     : public ExprVisitor<ConcreteType, ResultType, ExtraArgs...>,
       public StmtVisitor<ConcreteType, ResultType, ExtraArgs...>,
-      public DeclVisitor<ConcreteType, ResultType, ExtraArgs...> {
+      public DeclVisitor<ConcreteType, ResultType, ExtraArgs...>,
+      public StmtExprVisitor<ConcreteType, ResultType, ExtraArgs...> {
 public:
   /// This is the main entrypoint for the FIRRTLVisitor.
   ResultType dispatchVisitor(Operation *op, ExtraArgs... args) {
@@ -378,13 +421,12 @@ public:
     return this->dispatchDeclVisitor(op, args...);
   }
   ResultType visitInvalidDecl(Operation *op, ExtraArgs... args) {
+    return this->dispatchStmtExprVisitor(op, args...);
+  }
+  ResultType visitInvalidStmtExpr(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
-    return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<GenericIntrinsicOp>(
-            [&](auto genIntrinsicOp) -> ResultType {
-              return thisCast->visitIntrinsicOp(genIntrinsicOp, args...);
-            })
-        .Default([&](auto expr) -> ResultType {
+    return TypeSwitch<Operation *, ResultType>(op).Default(
+        [&](auto expr) -> ResultType {
           return thisCast->visitInvalidOp(op, args...);
         });
   }
@@ -397,6 +439,9 @@ public:
     return static_cast<ConcreteType *>(this)->visitUnhandledOp(op, args...);
   }
   ResultType visitUnhandledDecl(Operation *op, ExtraArgs... args) {
+    return static_cast<ConcreteType *>(this)->visitUnhandledOp(op, args...);
+  }
+  ResultType visitUnhandledStmtExpr(Operation *op, ExtraArgs... args) {
     return static_cast<ConcreteType *>(this)->visitUnhandledOp(op, args...);
   }
 

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -509,6 +509,7 @@ public:
   using LastConnectResolver<WhenOpVisitor>::visitExpr;
   using LastConnectResolver<WhenOpVisitor>::visitDecl;
   using LastConnectResolver<WhenOpVisitor>::visitStmt;
+  using LastConnectResolver<WhenOpVisitor>::visitStmtExpr;
 
   /// Process a block, recording each declaration, and expanding all whens.
   void process(Block &block);
@@ -529,6 +530,7 @@ public:
   void visitStmt(RefForceInitialOp op);
   void visitStmt(RefReleaseOp op);
   void visitStmt(RefReleaseInitialOp op);
+  void visitStmtExpr(DPICallIntrinsicOp op);
 
 private:
   /// And a 1-bit value with the current condition.  If we are in the outer
@@ -616,6 +618,13 @@ void WhenOpVisitor::visitStmt(RefReleaseOp op) {
 
 void WhenOpVisitor::visitStmt(RefReleaseInitialOp op) {
   op.getPredicateMutable().assign(andWithCondition(op, op.getPredicate()));
+}
+
+void WhenOpVisitor::visitStmtExpr(DPICallIntrinsicOp op) {
+  if (op.getEnable())
+    op.getEnableMutable().assign(andWithCondition(op, op.getEnable()));
+  else
+    op.getEnableMutable().assign(condition);
 }
 
 /// This is a common helper that is dispatched to by the concrete visitors.

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -672,4 +672,24 @@ firrtl.module @verif(
   }
 }
 
+// CHECK-LABEL:   firrtl.module @dpi(in %clock: !firrtl.clock, in %cond: !firrtl.uint<1>, in %enable: !firrtl.uint<1>, in %in: !firrtl.uint<8>)
+firrtl.module @dpi(
+  in %clock: !firrtl.clock, in %cond: !firrtl.uint<1>, in %enable: !firrtl.uint<1>, in %in: !firrtl.uint<8>
+) {
+  firrtl.when %cond : !firrtl.uint<1> {
+    // CHECK-NEXT: firrtl.int.dpi.call "foo"(%in) enable %cond
+    firrtl.int.dpi.call "foo"(%in) : (!firrtl.uint<8>) -> ()
+    // CHECK-NEXT: %[[TMP:.+]] = firrtl.and %cond, %enable
+    // CHECK-NEXT: firrtl.int.dpi.call "foo"(%in) enable %[[TMP]]
+    firrtl.int.dpi.call "foo"(%in) enable %enable : (!firrtl.uint<8>) -> ()
+  } else {
+    // CHECK-NEXT: %[[TMP:.+]] = firrtl.not %cond
+    // CHECK-NEXT: firrtl.int.dpi.call "foo"(%in) enable %[[TMP]]
+    firrtl.int.dpi.call "foo"(%in) : (!firrtl.uint<8>) -> ()
+    // CHECK-NEXT: %[[AND:.+]] = firrtl.and %[[TMP]], %enable
+    // CHECK-NEXT: firrtl.int.dpi.call "foo"(%in) enable %[[AND]]
+    firrtl.int.dpi.call "foo"(%in) enable %enable : (!firrtl.uint<8>) -> ()
+  }
+}
+
 }


### PR DESCRIPTION
This adds `StmtExprVisitor` struct for visitor to handle operations with an optional result. Currently `GenericIntrinsicOp `and `DPICallIntrinsicOp` are added.

Besides that `ExpandWhens` is modified to handle DPI intrinsic.