### PR TITLE
[ESI Runtime] Read ports now invoke callbacks

### DIFF
--- a/frontends/PyCDE/integration_test/test_software/esi_ram.py
+++ b/frontends/PyCDE/integration_test/test_software/esi_ram.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional
+from typing import cast
 import esiaccel as esi
 import random
 import sys
@@ -31,10 +31,7 @@ assert info[1].name == "Dummy"
 
 def read(addr: int) -> bytearray:
   mem_read_addr.write([addr])
-  got_data = False
-  resp: Optional[bytearray] = None
-  while not got_data:
-    (got_data, resp) = mem_read_data.read()
+  resp = cast(bytearray, mem_read_data.read())
   print(f"resp: {resp}")
   return resp
 

--- a/frontends/PyCDE/integration_test/test_software/esi_test.py
+++ b/frontends/PyCDE/integration_test/test_software/esi_test.py
@@ -1,7 +1,6 @@
 import esiaccel as esi
 
 import sys
-from typing import Optional
 
 platform = sys.argv[1]
 acc = esi.AcceleratorConnection(platform, sys.argv[2])
@@ -22,10 +21,7 @@ send.connect()
 data = 10234
 send.write(data)
 got_data = False
-resp: Optional[int] = None
-# Reads are non-blocking, so we need to poll.
-while not got_data:
-  (got_data, resp) = recv.read()
+resp = recv.read()
 
 print(f"data: {data}")
 print(f"resp: {resp}")

--- a/lib/Dialect/ESI/runtime/cosim/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/cosim/CMakeLists.txt
@@ -38,7 +38,7 @@ install(FILES
   COMPONENT ESIRuntime
 )
 
-add_library(EsiCosimGRPC OBJECT "${CMAKE_CURRENT_LIST_DIR}/cosim.proto")
+add_library(EsiCosimGRPC SHARED "${CMAKE_CURRENT_LIST_DIR}/cosim.proto")
 target_link_libraries(EsiCosimGRPC PUBLIC protobuf::libprotobuf gRPC::grpc++)
 set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 target_include_directories(EsiCosimGRPC PUBLIC "$<BUILD_INTERFACE:${PROTO_BINARY_DIR}>")

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -18,7 +18,9 @@
 
 #include "esi/Common.h"
 #include "esi/Types.h"
+#include "esi/Utils.h"
 
+#include <cassert>
 #include <future>
 
 namespace esi {
@@ -31,15 +33,19 @@ namespace esi {
 class ChannelPort {
 public:
   ChannelPort(const Type *type) : type(type) {}
-  virtual ~ChannelPort() = default;
+  virtual ~ChannelPort() { disconnect(); }
 
-  virtual void connect() {}
+  virtual void connect() { connectImpl(); }
   virtual void disconnect() {}
 
   const Type *getType() const { return type; }
 
 private:
   const Type *type;
+
+  /// Called by all connect methods to let backends initiate the underlying
+  /// connections.
+  virtual void connectImpl() {}
 };
 
 /// A ChannelPort which sends data to the accelerator.
@@ -51,21 +57,77 @@ public:
   virtual void write(const MessageData &) = 0;
 };
 
-/// A ChannelPort which reads data from the accelerator.
+/// A ChannelPort which reads data from the accelerator. It has two modes:
+/// Callback and Polling which cannot be used at the same time. The mode is set
+/// at connect() time. To change the mode, disconnect() and then connect()
+/// again.
 class ReadChannelPort : public ChannelPort {
+
 public:
-  using ChannelPort::ChannelPort;
+  ReadChannelPort(const Type *type) : ChannelPort(type) {}
+  virtual void disconnect() override { mode = Mode::Disconnected; }
 
-  /// Specify a buffer to read into. Non-blocking. Returns true if message
-  /// successfully recieved. Basic API, will likely change for performance
-  /// and functionality reasons.
-  virtual bool read(MessageData &) = 0;
+  //===--------------------------------------------------------------------===//
+  // Callback mode: To use a callback, connect with a callback function which
+  // will get called with incoming data. This function can be called from any
+  // thread. It shall return true to indicate that the data was consumed. False
+  // if it could not accept the data and should be tried again at some point in
+  // the future. Callback is not allowed to block and needs to execute quickly.
+  //
+  // TODO: Have the callback return something upon which the caller can check,
+  // wait, and be notified.
+  //===--------------------------------------------------------------------===//
 
-  /// Asynchronous read. Returns a future which will be set when the message is
-  /// recieved. Could this subsume the synchronous read API?
-  /// The default implementation of this is really bad and should be overridden.
-  /// It simply polls `read` in a loop.
+  virtual void connect(std::function<bool(MessageData)> callback);
+
+  //===--------------------------------------------------------------------===//
+  // Polling mode methods: To use futures or blocking reads, connect without any
+  // arguments. You will then be able to use readAsync() or read().
+  //===--------------------------------------------------------------------===//
+
+  /// Default max data queue size set at connect time.
+  static constexpr uint64_t DefaultMaxDataQueueMsgs = 32;
+
+  /// Connect to the channel in polling mode.
+  virtual void connect() override;
+
+  /// Asynchronous read.
   virtual std::future<MessageData> readAsync();
+
+  /// Specify a buffer to read into. Blocking. Basic API, will likely change
+  /// for performance and functionality reasons.
+  virtual void read(MessageData &outData) {
+    std::future<MessageData> f = readAsync();
+    f.wait();
+    outData = std::move(f.get());
+  }
+
+  /// Set maximum number of messages to store in the dataQueue. 0 means no
+  /// limit. This is only used in polling mode and is set to default of 32 upon
+  /// connect.
+  void setMaxDataQueueMsgs(uint64_t maxMsgs) { maxDataQueueMsgs = maxMsgs; }
+
+protected:
+  /// Indicates the current mode of the channel.
+  enum Mode { Disconnected, Callback, Polling };
+  Mode mode;
+
+  /// Backends call this callback when new data is available.
+  std::function<bool(MessageData)> callback;
+
+  //===--------------------------------------------------------------------===//
+  // Polling mode members.
+  //===--------------------------------------------------------------------===//
+
+  /// Mutex to protect the two queues used for polling.
+  std::mutex pollingM;
+  /// Store incoming data here if there are no outstanding promises to be
+  /// fulfilled.
+  std::queue<MessageData> dataQueue;
+  /// Maximum number of messages to store in dataQueue. 0 means no limit.
+  uint64_t maxDataQueueMsgs;
+  /// Promises to be fulfilled when data is available.
+  std::queue<std::promise<MessageData>> promiseQueue;
 };
 
 /// Services provide connections to 'bundles' -- collections of named,

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
@@ -135,6 +135,7 @@ public:
     std::future<MessageData> call(const MessageData &arg);
 
   private:
+    std::mutex callMutex;
     WriteChannelPort &arg;
     ReadChannelPort &result;
   };
@@ -161,7 +162,12 @@ public:
              const std::map<std::string, ChannelPort &> &channels);
 
   public:
-    void connect(std::function<MessageData(const MessageData &)> callback);
+    /// Connect a callback to code which will be executed when the accelerator
+    /// invokes the callback. The 'quick' flag indicates that the callback is
+    /// sufficiently fast that it could be called in the same thread as the
+    /// port callback.
+    void connect(std::function<MessageData(const MessageData &)> callback,
+                 bool quick = false);
 
   private:
     ReadChannelPort &arg;

--- a/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
@@ -42,15 +42,58 @@ ReadChannelPort &BundlePort::getRawRead(const string &name) const {
     throw runtime_error("Channel '" + name + "' is not a read channel");
   return *read;
 }
+void ReadChannelPort::connect(std::function<bool(MessageData)> callback) {
+  if (mode != Mode::Disconnected)
+    throw std::runtime_error("Channel already connected");
+  mode = Mode::Callback;
+  this->callback = callback;
+  ChannelPort::connect();
+}
+
+void ReadChannelPort::connect() {
+  mode = Mode::Polling;
+  maxDataQueueMsgs = DefaultMaxDataQueueMsgs;
+  this->callback = [this](MessageData data) {
+    std::scoped_lock<std::mutex> lock(pollingM);
+    assert(!(!promiseQueue.empty() && !dataQueue.empty()) &&
+           "Both queues are in use.");
+
+    if (!promiseQueue.empty()) {
+      // If there are promises waiting, fulfill the first one.
+      std::promise<MessageData> p = std::move(promiseQueue.front());
+      promiseQueue.pop();
+      p.set_value(std::move(data));
+    } else {
+      // If not, add it to the data queue, unless the queue is full.
+      if (dataQueue.size() >= maxDataQueueMsgs && maxDataQueueMsgs != 0)
+        return false;
+      dataQueue.push(std::move(data));
+    }
+    return true;
+  };
+  ChannelPort::connect();
+}
 
 std::future<MessageData> ReadChannelPort::readAsync() {
-  // TODO: running this deferred is a horrible idea considering that it blocks!
-  // It's a hack since Capnp RPC refuses to work with multiple threads.
-  return std::async(std::launch::deferred, [this]() {
-    MessageData output;
-    while (!read(output)) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
-    return output;
-  });
+  if (mode == Mode::Callback)
+    throw std::runtime_error(
+        "Cannot read from a callback channel. `connect()` without a callback "
+        "specified to use polling mode.");
+
+  std::scoped_lock<std::mutex> lock(pollingM);
+  assert(!(!promiseQueue.empty() && !dataQueue.empty()) &&
+         "Both queues are in use.");
+
+  if (!dataQueue.empty()) {
+    // If there's data available, fulfill the promise immediately.
+    std::promise<MessageData> p;
+    std::future<MessageData> f = p.get_future();
+    p.set_value(std::move(dataQueue.front()));
+    dataQueue.pop();
+    return f;
+  } else {
+    // Otherwise, add a promise to the queue and return the future.
+    promiseQueue.emplace();
+    return promiseQueue.back().get_future();
+  }
 }

--- a/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
@@ -80,9 +80,11 @@ void registerCallbacks(Accelerator *accel) {
   if (f != ports.end()) {
     auto callPort = f->second.getAs<services::CallService::Callback>();
     if (callPort)
-      callPort->connect([](const MessageData &data) -> MessageData {
-        cout << "PrintfExample: " << *data.as<uint32_t>() << endl;
-        return MessageData();
-      });
+      callPort->connect(
+          [](const MessageData &data) -> MessageData {
+            cout << "PrintfExample: " << *data.as<uint32_t>() << endl;
+            return MessageData();
+          },
+          true);
   }
 }

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
@@ -150,14 +150,14 @@ PYBIND11_MODULE(esiCppAccel, m) {
         p.write(dataVec);
       });
   py::class_<ReadChannelPort, ChannelPort>(m, "ReadChannelPort")
-      .def("read",
-           [](ReadChannelPort &p) -> py::object {
-             MessageData data;
-             if (!p.read(data))
-               return py::none();
-             return py::bytearray((const char *)data.getBytes(),
-                                  data.getSize());
-           })
+      .def(
+          "read",
+          [](ReadChannelPort &p) -> py::bytearray {
+            MessageData data;
+            p.read(data);
+            return py::bytearray((const char *)data.getBytes(), data.getSize());
+          },
+          "Read data from the channel. Blocking.")
       .def("read_async", &ReadChannelPort::readAsync);
 
   py::class_<BundlePort>(m, "BundlePort")

--- a/lib/Dialect/ESI/runtime/python/esiaccel/types.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/types.py
@@ -333,17 +333,15 @@ class ReadPort(Port):
     super().__init__(owner, cpp_port)
     self.cpp_port: cpp.ReadChannelPort = cpp_port
 
-  def read(self) -> Tuple[bool, Optional[object]]:
+  def read(self) -> object:
     """Read a typed message from the channel. Returns a deserialized object of a
     type defined by the port type."""
 
     buffer = self.cpp_port.read()
-    if buffer is None:
-      return (False, None)
     (msg, leftover) = self.type.deserialize(buffer)
     if len(leftover) != 0:
       raise ValueError(f"leftover bytes: {leftover}")
-    return (True, msg)
+    return msg
 
 
 class BundlePort:


### PR DESCRIPTION
We've switched from a polling 'pull' method to a callback-based 'push'
mechanism for read ports. Polling (via std::futures) is built on top of
the push mechanism.

The read-ordering problem has also been fixed by using std::futures
exclusively for polling schemes. They also allow for poll-wait-notify
schemes without any changes on our part.