### PR TITLE
[SimToSV] Fix DPICall lowering to use `replaceOp`

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -808,6 +808,7 @@ def LowerSimToSV: Pass<"lower-sim-to-sv",  "mlir::ModuleOp"> {
   let dependentDialects = [
     "circt::comb::CombDialect",
     "circt::emit::EmitDialect",
+    "circt::seq::SeqDialect",
     "circt::sv::SVDialect",
     "circt::hw::HWDialect"
   ];

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -176,12 +176,12 @@ public:
     bool hasEnable = !!op.getEnable();
 
     SmallVector<sv::RegOp> temporaries;
+    SmallVector<Value> reads;
     for (auto [type, result] :
          llvm::zip(op.getResultTypes(), op.getResults())) {
       temporaries.push_back(rewriter.create<sv::RegOp>(op.getLoc(), type));
-      auto read =
-          rewriter.create<sv::ReadInOutOp>(op.getLoc(), temporaries.back());
-      rewriter.replaceAllUsesWith(result, read);
+      reads.push_back(
+          rewriter.create<sv::ReadInOutOp>(op.getLoc(), temporaries.back()));
     }
 
     auto emitCall = [&]() {
@@ -225,7 +225,7 @@ public:
       });
     }
 
-    rewriter.eraseOp(op);
+    rewriter.replaceOp(op, reads);
     return success();
   }
 };

--- a/test/Conversion/SimToSV/dpi.mlir
+++ b/test/Conversion/SimToSV/dpi.mlir
@@ -92,3 +92,16 @@ hw.module @dpi_call(in %clock : !seq.clock, in %enable : i1, in %in: i1,
   // VERILOG-NEXT: assign o8 = [[RESULT_7]]; 
   hw.output %0, %1, %2, %3, %4, %5, %6, %7: i1, i1, i1, i1, i1, i1, i1, i1
 }
+
+sim.func.dpi private @increment_counter(in %in_0 : i64, out out_0 : i32)
+sim.func.dpi private @create_counter(out out_0 : i64)
+// CHECK-LABEL: hw.module @Issue7191
+// Check lowering successes.
+hw.module @Issue7191(out result : i32) {
+  // CHECK: call.procedural @create_counter
+  // CHECK: call.procedural @increment_counter
+
+  %0 = sim.func.dpi.call @create_counter() : () -> i64
+  %1 = sim.func.dpi.call @increment_counter(%0) : (i64) -> i32
+  hw.output %1 : i32
+}


### PR DESCRIPTION
Previously DPICallLowering called `rewriter.replaceAllUsesWith` for individual
results but it seems that is not equivalent to `replaceOp`. 

This also adds missing dialect dependency to seq

Close #7191