### PR TITLE
[HW] Move the CombDataFlow op interface from FIRRTL to HW

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.h
@@ -19,7 +19,6 @@
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/HW/InnerSymbolTable.h"
-#include "circt/Support/FieldRef.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpDefinition.h"

--- a/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOpInterfaces.td
@@ -522,25 +522,4 @@ def Forceable : OpInterface<"Forceable"> {
     return detail::verifyForceableOp(cast<::circt::firrtl::Forceable>($_op));
   }];
 }
-
-def CombDataflow : OpInterface<"CombDataFlow"> {
-  let cppNamespace = "circt::firrtl";
-  let description = [{
-    This interface is used for specifying the combinational dataflow that exists
-    in the results and operands of an operation.
-    Any operation that doesn't implement this interface is assumed to have a
-    combinational dependence from each operand to each result.
-  }];
-  let methods = [
-    InterfaceMethod<"Get the combinational dataflow relations between the"
-     "operands and the results. This returns a pair of fieldrefs. The first" 
-     "element is the destination and the second is the source of the dependence."
-     "The default implementation returns an empty list, which implies that the"
-     "operation is not combinational.",
-     "SmallVector<std::pair<circt::FieldRef, circt::FieldRef>>",
-     "computeDataFlow", (ins), [{}], /*defaultImplementation=*/[{
-      return {};
-    }]>,
-  ];
-}
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLOPINTERFACES_TD

--- a/include/circt/Dialect/HW/HWOpInterfaces.h
+++ b/include/circt/Dialect/HW/HWOpInterfaces.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/HW/HWInstanceImplementation.h"
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/HW/InnerSymbolTable.h"
+#include "circt/Support/FieldRef.h"
 #include "circt/Support/InstanceGraphInterface.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/OpDefinition.h"

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -547,4 +547,26 @@ def InnerRefUserOpInterface : OpInterface<"InnerRefUserOpInterface"> {
   ];
 }
 
+def CombDataflow : OpInterface<"CombDataFlow"> {
+  let cppNamespace = "circt::hw";
+  let description = [{
+    This interface is used for specifying the combinational dataflow that exists
+    in the results and operands of an operation.
+    Any operation that doesn't implement this interface is assumed to have a
+    combinational dependence from each operand to each result.
+  }];
+  let methods = [
+    InterfaceMethod<"Get the combinational dataflow relations between the"
+     "operands and the results. This returns a pair of ground type fieldrefs."
+     "The first element is the destination and the second is the source of"
+     "the dependence."
+     "The default implementation returns an empty list, which implies that the"
+     "operation is not combinational.",
+     "SmallVector<std::pair<circt::FieldRef, circt::FieldRef>>",
+     "computeDataFlow", (ins), [{}], /*defaultImplementation=*/[{
+      return {};
+    }]>,
+  ];
+}
+
 #endif

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -95,7 +95,7 @@ public:
 
     walk(module, [&](Operation *op) {
       llvm::TypeSwitch<Operation *>(op)
-          .Case<CombDataFlow>([&](CombDataFlow df) {
+          .Case<hw::CombDataFlow>([&](hw::CombDataFlow df) {
             // computeDataFlow returns a pair of FieldRefs, first element is the
             // destination and the second is the source.
             for (auto &dep : df.computeDataFlow())


### PR DESCRIPTION
Move the `CombDataFlow` op interface from `FIRRTL` to `HW` dialect.
The op interface is better suited to reside in the `HW` dialect, along with other interfaces like the `HWModuleLike`.
This makes it more convenient for non-`FIRRTL` dialects to implement ops using this interface, without introducing a new dependence on the `FIRRTL` dialect, assuming  `HW` dependence already exists. 