### PR TITLE
Update clang to 17.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -14,7 +14,7 @@ jobs:
     name: Sanity Check
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/circt/images/circt-ci-build:20240213211952
+      image: ghcr.io/circt/images/circt-ci-build:v14.1
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.


### PR DESCRIPTION
clang-format-17 makes a few different choices than clang-format-13.  v13 is almost 3 years old.  Given that slang builds are already installing v16, let's just unify on v17 for CI.