### PR TITLE
[FIRRTL][SpecializeLayers] Fix incorrect CF leading to double free

### DIFF
--- a/test/Dialect/FIRRTL/specialize-layers.mlir
+++ b/test/Dialect/FIRRTL/specialize-layers.mlir
@@ -371,6 +371,41 @@ firrtl.circuit "HierPathDelete" attributes {
   firrtl.extmodule @Deleted() attributes {layers = [@Layer]}
 }
 
+// CHECK-LABEL: firrtl.circuit "HierPathDelete"
+firrtl.circuit "HierPathDelete" attributes {
+  disable_layers = [@Layer]
+} {
+  firrtl.layer @Layer bind { }
+
+  // CHECK-NOT: hw.hierpath private @hierpath1 [@HierPathDelete::@middle, @Middle::@leaf, @Leaf]
+  hw.hierpath private @hierpath1 [@HierPathDelete::@middle, @Middle::@leaf, @Leaf]
+  // CHECK-NOT: hw.hierpath private @hierpath2 [@HierPathDelete::@middle, @Middle::@leaf]
+  hw.hierpath private @hierpath2 [@HierPathDelete::@middle, @Middle::@leaf]
+  // CHECK-NOT: hw.hierpath private @hierpath3 [@Middle::@leaf, @Leaf]
+  hw.hierpath private @hierpath3 [@Middle::@leaf, @Leaf]
+  // CHECK-NOT: hw.hierpath private @hierpath4 [@Middle::@leaf]
+  hw.hierpath private @hierpath4 [@Middle::@leaf]
+
+  firrtl.module @HierPathDelete() {
+    firrtl.layerblock @Layer {
+      firrtl.instance middle sym @middle @Middle()
+    }
+  }
+  
+  firrtl.module @Middle() {
+    firrtl.layerblock @Layer {
+      firrtl.instance leaf sym @leaf @Leaf()
+    }
+  }
+  
+  firrtl.extmodule @Leaf()
+
+  // CHECK-NOT: hw.hierpath private @DeletedPath [@Deleted]
+  hw.hierpath private @DeletedPath [@Deleted]
+  firrtl.extmodule @Deleted() attributes {layers = [@Layer]}
+}
+
+
 //===----------------------------------------------------------------------===//
 // Annotations
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
As a part of specializing layers we have to remove any HierPathOps which included a reference to deleted instances.  If any member of the path array is contained in the deleted references list, we need to delete the op.  There was incorrect use of `continue` which caused us to continue processing the path instead of skipping to the next path operation, which could lead to a double free when multiple instances in the path were removed.