### PR TITLE
[Seq] Add a new op interface for clock transformation ops. NFC

### DIFF
--- a/include/circt/Dialect/Seq/SeqOpInterfaces.td
+++ b/include/circt/Dialect/Seq/SeqOpInterfaces.td
@@ -24,6 +24,15 @@ def Clocked : OpInterface<"Clocked"> {
   ];
 }
 
+def ClockTransformation : OpInterface<"ClockTransformation"> {
+  let cppNamespace = "circt::seq";
+  let description = "Trait for a clock transformation operation";
+
+  let methods = [
+    InterfaceMethod<"Get the input clock signal", "Value", "getClk", (ins)>
+  ];
+}
+
 def Resettable : OpInterface<"Resettable"> {
   let cppNamespace = "circt::seq";
   let description = "Trait for Resettable elements";

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -368,7 +368,7 @@ def WritePortOp : SeqOp<"write", [
 //===----------------------------------------------------------------------===//
 
 def ClockGateOp : SeqOp<"clock_gate", [
-  Pure,
+  Pure, ClockTransformation,
   DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>,
   AllTypesMatch<["input", "output"]>
 ]> {
@@ -405,6 +405,11 @@ def ClockGateOp : SeqOp<"clock_gate", [
   let results = (outs ClockType:$output);
   let hasFolder = 1;
   let hasCanonicalizeMethod = 1;
+
+  let extraClassDeclaration = [{
+    Value getClk() { return getInput(); }
+  }];
+
   let assemblyFormat = [{
     $input `,` $enable (`,` $test_enable^)? (`sym` $inner_sym^)? attr-dict
   }];
@@ -440,7 +445,7 @@ def ClockMuxOp : SeqOp<"clock_mux", [Pure]> {
 // Clock Dividers
 //===----------------------------------------------------------------------===//
 
-def ClockDividerOp : SeqOp<"clock_div", [Pure]> {
+def ClockDividerOp : SeqOp<"clock_div", [Pure, ClockTransformation]> {
   let summary = "Produces a clock divided by a power of two";
   let description = [{
     The output clock is phase-aligned to the input clock.
@@ -453,6 +458,10 @@ def ClockDividerOp : SeqOp<"clock_div", [Pure]> {
   let arguments = (ins ClockType:$input, I64Attr:$pow2);
   let results = (outs ClockType:$output);
 
+  let extraClassDeclaration = [{
+    Value getClk() { return getInput(); }
+  }];
+
   let assemblyFormat = [{
     $input `by` $pow2 attr-dict
   }];
@@ -462,7 +471,7 @@ def ClockDividerOp : SeqOp<"clock_div", [Pure]> {
 // Clock Inverter and Buffer
 //===----------------------------------------------------------------------===//
 
-def ClockInverterOp : SeqOp<"clock_inv", [Pure]> {
+def ClockInverterOp : SeqOp<"clock_inv", [Pure, ClockTransformation]> {
   let summary = "Inverts the clock signal";
   let description = [{
     Note that the compiler can optimize inverters away, preventing their
@@ -477,6 +486,10 @@ def ClockInverterOp : SeqOp<"clock_inv", [Pure]> {
   let results = (outs ClockType:$output);
 
   let hasFolder = 1;
+
+  let extraClassDeclaration = [{
+    Value getClk() { return getInput(); }
+  }];
 
   let assemblyFormat = [{
     $input attr-dict


### PR DESCRIPTION
Add the clock gate, clock inverter and clock divider ops to a new clock transformation interface.
This makes it easier to handle them and get the input clock directly.