### PR TITLE
[FIRRTL][FIRParser] Tokenize Commas

### DIFF
--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -1003,7 +1003,7 @@ void Emitter::emitStatement(SeqMemOp op) {
   ps.scopedBox(PP::ibox2, [&]() {
     ps << "smem " << PPExtString(legalize(op.getNameAttr()));
     emitTypeWithColon(op.getType());
-    ps << PP::space;
+    ps << "," << PP::space;
     emitAttribute(op.getRuw());
   });
   emitLocationAndNewLine(op);

--- a/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
@@ -186,9 +186,7 @@ std::optional<unsigned> FIRLexer::getIndentation(const FIRToken &tok) const {
   // Count the number of horizontal whitespace characters before the token.
   auto *bufStart = curBuffer.begin();
 
-  auto isHorizontalWS = [](char c) -> bool {
-    return c == ' ' || c == '\t' || c == ',';
-  };
+  auto isHorizontalWS = [](char c) -> bool { return c == ' ' || c == '\t'; };
   auto isVerticalWS = [](char c) -> bool {
     return c == '\n' || c == '\r' || c == '\f' || c == '\v';
   };
@@ -233,7 +231,6 @@ FIRToken FIRLexer::lexTokenImpl() {
     case '\t':
     case '\n':
     case '\r':
-    case ',':
       // Handle whitespace.
       continue;
 
@@ -244,6 +241,8 @@ FIRToken FIRLexer::lexTokenImpl() {
 
     case '.':
       return formToken(FIRToken::period, tokStart);
+    case ',':
+      return formToken(FIRToken::comma, tokStart);
     case ':':
       return formToken(FIRToken::colon, tokStart);
     case '(':

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -248,7 +248,7 @@ struct FIRParser {
   /// output a diagnostic and return failure.
   ParseResult parseToken(FIRToken::Kind expectedToken, const Twine &message);
 
-  //// Parse a comma-separated list of elements, terminated with an arbitrary
+  /// Parse a comma-separated list of elements, terminated with an arbitrary
   /// token.
   ParseResult parseListUntil(FIRToken::Kind rightToken,
                              const std::function<ParseResult()> &parseElement);
@@ -343,9 +343,8 @@ ParseResult FIRParser::parseToken(FIRToken::Kind expectedToken,
 ParseResult
 FIRParser::parseListUntil(FIRToken::Kind rightToken,
                           const std::function<ParseResult()> &parseElement) {
-  if (consumeIf(rightToken)) {
+  if (consumeIf(rightToken))
     return success();
-  }
 
   if (parseElement())
     return failure();
@@ -355,9 +354,9 @@ FIRParser::parseListUntil(FIRToken::Kind rightToken,
       return failure();
   }
 
-  if (parseToken(rightToken, "expected ','")) {
+  if (parseToken(rightToken, "expected ','"))
     return failure();
-  }
+
   return success();
 }
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4167,8 +4167,12 @@ ParseResult FIRStmtParser::parseSeqMem() {
     return failure();
 
   if (consumeIf(FIRToken::comma)) {
-    if (parseRUW(ruw) || parseOptionalInfo())
+    if (parseRUW(ruw))
       return failure();
+  }
+
+  if (parseOptionalInfo()) {
+    return failure();
   }
 
   locationProcessor.setLoc(startTok.getLoc());

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -62,6 +62,7 @@ TOK_LITERAL(inlineannotation) // %[{"foo":"bar"}]
 
 // Punctuation.
 TOK_PUNCTUATION(period, ".")
+TOK_PUNCTUATION(comma, ",")
 TOK_PUNCTUATION(colon, ":")
 TOK_PUNCTUATION(question, "?")
 TOK_PUNCTUATION(l_paren, "(")

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -791,10 +791,10 @@ circuit Top15 : %[[
   ; CHECK-SAME:   [@Top15::@[[topaSym:[_a-zA-Z0-9]+]], @a]
   ; CHECK: firrtl.module @Top15
   public module Top15:
-    input ia: {z: {y: {x: UInt<1>}}, a: UInt<1> un: UInt<2>}
-    input ib: {a: {b: {c: UInt<1>}}, z: UInt<1> un: UInt<2>}
-    output oa: {z: {y: {x: UInt<1>}}, a: UInt<1> un: UInt<2>}
-    output ob: {a: {b: {c: UInt<1>}}, z: UInt<1> un: UInt<2>}
+    input ia: {z: {y: {x: UInt<1>}}, a: UInt<1>, un: UInt<2>}
+    input ib: {a: {b: {c: UInt<1>}}, z: UInt<1>, un: UInt<2>}
+    output oa: {z: {y: {x: UInt<1>}}, a: UInt<1>, un: UInt<2>}
+    output ob: {a: {b: {c: UInt<1>}}, z: UInt<1>, un: UInt<2>}
     ; CHECK:      firrtl.instance a sym @[[topaSym]]
     inst a of a
     a.i.z.y.x <= ia.z.y.x

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -333,7 +333,7 @@ firrtl.circuit "Foo" {
     firrtl.when %ui1 : !firrtl.uint<1> {
       chirrtl.memoryport.access %port1_port[%someAddr], %someClock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
     }
-    // CHECK:      smem seqmem : UInt<3>[256] undefined
+    // CHECK:      smem seqmem : UInt<3>[256], undefined
     // CHECK-NEXT: when ui1 :
     // CHECK-NEXT:   infer mport port1 = seqmem[someAddr], someClock
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -25,7 +25,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   ; CHECK-NOT: {
   extmodule MyExtModule :
     input in: UInt
-    output ,,, out ,,: ,, UInt,<,8,>  ; Commas are whitespace
+    output out : UInt<8>
     defname = myextmodule
 
   ; CHECK-LABEL: firrtl.extmodule private @MyParameterizedExtModule
@@ -383,7 +383,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %base_table_0 = chirrtl.seqmem interesting_name Undefined : !chirrtl.cmemory<vector<uint<1>, 9>, 256>
     smem base_table_0 : UInt<1>[9] [256]
     ; CHECK: %base_table_1 = chirrtl.seqmem interesting_name Old : !chirrtl.cmemory<vector<uint<1>, 9>, 256>
-    smem base_table_1 : UInt<1>[9] [256] old
+    smem base_table_1 : UInt<1>[9] [256], old
 
     ; CHECK: %tableValue_data, %tableValue_port = chirrtl.memoryport Read %base_table_1 {name = "tableValue"} : (!chirrtl.cmemory<vector<uint<1>, 9>, 256>) -> (!firrtl.vector<uint<1>, 9>, !chirrtl.cmemoryport)
     ; CHECK: chirrtl.memoryport.access %tableValue_port[%i8], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -657,6 +657,18 @@ circuit ProbeSMem:
     infer mport read = mem[io.addr], clock
     io.dataOut <= read
     define out = probe(read) ; expected-error {{cannot probe memories or their ports}}
+;// -----
+
+FIRRTL version 3.0.0
+circuit SmemNoRuwInfo:
+  module SmemNoRuwInfo:
+    input clock : Clock
+    input reset : Reset
+    output io : { flip addr : UInt<3>, dataOut : UInt<8>}
+
+    smem mem : UInt<8> [8] @[foo.fir 1:1]
+    infer mport read = mem[io.addr], clock
+    io.dataOut <= read
 
 
 ;// -----

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -137,6 +137,25 @@ circuit invalid_add :
    input c : Clock
    ; expected-error @+1 {{second operand must be an integer type, not '!firrtl.clock'}}
    node n = add(in, c)
+;// -----
+
+FIRRTL version 4.0.0
+circuit trailing_comma :
+  public module trailing_comma :
+   input in0 : SInt<8>
+   input in1 : SInt<8>
+   ; expected-error @+1 {{expected expression in primitive operand}}
+   node n = add(in0, in1,)
+
+;// -----
+
+FIRRTL version 4.0.0
+circuit no_commas :
+  public module no_commas :
+   input in0 : SInt<8>
+   input in1 : SInt<8>
+   ; expected-error @+1 {{expected ','}}
+   node n = add(in0 in1)
 
 ;// -----
 
@@ -363,6 +382,27 @@ circuit NestedProbes:
     output p : Probe<Probe<UInt>> ; expected-error {{invalid probe inner type, must be base-type}}
 
 ;// -----
+
+FIRRTL version 4.0.0
+circuit BadCommas:
+  public module BadCommas:
+    output p : Probe<UInt<1>,> ; expected-error {{expected layer name}}
+    wire w : UInt<1>
+    invalidate w
+    define p = probe(w)
+
+;// -----
+
+FIRRTL version 4.0.0
+circuit BadCommas2:
+  public module BadCommas2:
+    output p : Probe<UInt<1>, A,> ; expected-error {{expected '>' to end reference type}}
+    wire w : UInt<1>
+    invalidate w
+    define p = probe(w)
+
+;// -----
+
 FIRRTL version 3.1.0
 
 circuit ProbeOfProp:

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1371,14 +1371,14 @@ circuit Foo:
 ;// -----
 FIRRTL version 4.0.0
 circuit Foo:
-  layer A bind:
+  layer A, bind:
   public module Foo:
     output a: Probe<
     ; expected-error @below {{expected probe data type}}
 ;// -----
 FIRRTL version 4.0.0
 circuit Foo:
-  layer A bind:
+  layer A, bind:
   public module Foo:
     ; expected-error @below {{expected '<' in reference type}}
     output a: Probe X
@@ -1386,14 +1386,14 @@ circuit Foo:
 ;// -----
 FIRRTL version 4.0.0
 circuit Foo:
-  layer A bind:
+  layer A, bind:
   public module Foo:
     output a: Probe
     ; expected-error @below {{expected '<' in reference type}}
 ;// -----
 FIRRTL version 4.0.0
 circuit Foo:
-  layer A bind:
+  layer A, bind:
   public module Foo:
     ; expected-error @below {{expected probe data type}}
     output a: Probe<>
@@ -1401,25 +1401,25 @@ circuit Foo:
 ;// -----
 FIRRTL version 4.0.0
 circuit Foo:
-  layer A bind:
+  layer A, bind:
   public module Foo:
     ; expected-error @below {{expected '>' to end reference type}}
     output a: Probe<UInt<1>
 ;// -----
 FIRRTL version 4.0.0
 circuit Foo:
-  layer A bind:
+  layer A, bind:
   public module Foo:
     ; expected-error @below {{expected '>' to end reference type}}
-    output a: Probe<UInt<1> A
+    output a: Probe<UInt<1>, A
 
 ;// -----
 FIRRTL version 4.0.0
 circuit Foo:
-  layer A bind:
+  layer A, bind:
   public module Foo:
     ; expected-error @below {{expected layer name}}
-    output a: Probe<UInt<1> A.>
+    output a: Probe<UInt<1>, A.>
 
 ;// -----
 FIRRTL version 4.0.0

--- a/test/firtool/annotation-openaggs-error.fir
+++ b/test/firtool/annotation-openaggs-error.fir
@@ -10,7 +10,7 @@ circuit OpenAgg : %[[
   ; expected-error @below {{cannot resolve field 'p'}}
   public module OpenAgg:
     output out : {a : UInt<1>,
-                  p : Probe<UInt<1>>
+                  p : Probe<UInt<1>>,
                   b : UInt<1>}
 
     out.a <= UInt<1>(1)

--- a/test/firtool/annotation-openaggs.fir
+++ b/test/firtool/annotation-openaggs.fir
@@ -17,7 +17,7 @@ circuit OpenAgg : %[[
   ; CHECK-SAME: , out %out_p: !firrtl.probe<uint<1>>)
   public module OpenAgg:
     output out : {a : UInt<1>,
-                  p : Probe<UInt<1>>
+                  p : Probe<UInt<1>>,
                   b : UInt<1>}
 
     out.a <= UInt<1>(1)

--- a/test/firtool/import-ref.fir
+++ b/test/firtool/import-ref.fir
@@ -18,7 +18,7 @@ circuit TestHarness:
 
     ; CHECK: fwrite
     ; CHECK-SAME: "%x", TestHarness.dut.`ref_DUT_read)
-    printf(clock, UInt<1>(1) "%x", read(dut.read))
+    printf(clock, UInt<1>(1), "%x", read(dut.read))
     ; CHECK: initial
     ; CHECK: force TestHarness.dut.`ref_DUT_write = 32'hDEADBEEF;
     force_initial(dut.write, UInt<32>(0hdeadbeef))

--- a/test/firtool/lower-layers2.fir
+++ b/test/firtool/lower-layers2.fir
@@ -8,7 +8,7 @@ FIRRTL version 4.0.0
 
 circuit TestHarness:
 
-  layer Verification bind:
+  layer Verification, bind:
 
   ; CHECK: module DUT_Verification(
   ; CHECK:   input        clock,

--- a/test/firtool/phase-ordering.fir
+++ b/test/firtool/phase-ordering.fir
@@ -31,7 +31,8 @@ circuit Issue794: %[[{
       data-type => UInt<8>
       depth => 4
       reader => r
-      writer => w0,w1
+      writer => w0
+      writer => w1
       read-latency => 0
       write-latency => 1
       read-under-write => undefined


### PR DESCRIPTION
Due to historical circumstances, the SFC parser for FIRRTL treated commas (`,`) as whitespace. This behavior was carried over into the CIRCT implementation of `firtool`.

This behavior is utterly bizarre. 

Moreover, the FIRRTL spec has indicated comma tokens (`,`) for at least every version since last year. 

This PR removes this quirk and properly tokenizes commas, requiring them in the places dictated by the FIRRTL spec.

The impact of this PR should be low, but it may break code (in CIRCT, in Chisel, and elsewhere) in places where FIRRTL was being emitted with a loose interpretation, or where the spec was ambiguous.

Changes:
* Update several tests which were leaning into the "commas-are-whitespace" behavior.
* Removed `','` from the list of "horizontal whitespace" and added an explicit `FIRToken::comma` token.
* Made changes to the various `parse*()` methods to consume the tokens.
* Note the use of a pattern I found useful in several places where I use a boolean `first` to skip parsing comma tokens on the first iteration. Please check me here, since I learned C++ before lambdas were a thing.
* Made a few judgment calls around unspeced constructs (`smem`).
* * I changed the FIRRTL emitter in one place where the syntax was unspeced, and there seemed to be conflicting examples.
* @seldridge For some reason, it seemed ambiguous whether `layer` decls need commas. I opted *for* commas. I can swap if I got this backwards.
* I added `parseRUW()` as a non-optional variant of `parseOptionalRUW()`, since the comma token can be used to determine optionality in one case.