### PR TITLE
[FIRRTL] add default case for EventControl instantiation

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -4580,6 +4580,9 @@ LogicalResult FIRRTLLowering::lowerVerificationStatement(
       case EventControl::AtNegEdge:
         event = circt::sv::EventControl::AtNegEdge;
         break;
+      default:
+        event = circt::sv::EventControl::AtPosEdge;
+        break;
       }
 
       buildConcurrentVerifOp(


### PR DESCRIPTION
This patch fix the compiler warning maybe-uninitialized
