### PR TITLE
[FIRRTL] SpecializeLayers: fix race condition

### DIFF
--- a/test/Dialect/FIRRTL/specialize-layers.mlir
+++ b/test/Dialect/FIRRTL/specialize-layers.mlir
@@ -389,22 +389,22 @@ firrtl.circuit "HierPathDelete" attributes {
   firrtl.extmodule @Deleted() attributes {layers = [@Layer]}
 }
 
-// CHECK-LABEL: firrtl.circuit "HierPathDelete"
-firrtl.circuit "HierPathDelete" attributes {
+// CHECK-LABEL: firrtl.circuit "HierPathDelete2"
+firrtl.circuit "HierPathDelete2" attributes {
   disable_layers = [@Layer]
 } {
   firrtl.layer @Layer bind { }
 
-  // CHECK-NOT: hw.hierpath private @hierpath1 [@HierPathDelete::@middle, @Middle::@leaf, @Leaf]
-  hw.hierpath private @hierpath1 [@HierPathDelete::@middle, @Middle::@leaf, @Leaf]
-  // CHECK-NOT: hw.hierpath private @hierpath2 [@HierPathDelete::@middle, @Middle::@leaf]
-  hw.hierpath private @hierpath2 [@HierPathDelete::@middle, @Middle::@leaf]
+  // CHECK-NOT: hw.hierpath private @hierpath1 [@HierPathDelete2::@middle, @Middle::@leaf, @Leaf]
+  hw.hierpath private @hierpath1 [@HierPathDelete2::@middle, @Middle::@leaf, @Leaf]
+  // CHECK-NOT: hw.hierpath private @hierpath2 [@HierPathDelete2::@middle, @Middle::@leaf]
+  hw.hierpath private @hierpath2 [@HierPathDelete2::@middle, @Middle::@leaf]
   // CHECK-NOT: hw.hierpath private @hierpath3 [@Middle::@leaf, @Leaf]
   hw.hierpath private @hierpath3 [@Middle::@leaf, @Leaf]
   // CHECK-NOT: hw.hierpath private @hierpath4 [@Middle::@leaf]
   hw.hierpath private @hierpath4 [@Middle::@leaf]
 
-  firrtl.module @HierPathDelete() {
+  firrtl.module @HierPathDelete2() {
     firrtl.layerblock @Layer {
       firrtl.instance middle sym @middle @Middle()
     }

--- a/test/Dialect/FIRRTL/specialize-layers.mlir
+++ b/test/Dialect/FIRRTL/specialize-layers.mlir
@@ -93,6 +93,20 @@ firrtl.circuit "LayerDisableB" attributes {
   firrtl.extmodule @LayerDisableB()
 }
 
+// CHECK-LABEL: firrtl.circuit "LayerDisableInARow"
+firrtl.circuit "LayerDisableInARow" attributes {
+    disable_layers = [@A, @B, @C]
+  } {
+  // CHECK-NOT: firrtl.layer @A bind { }
+  firrtl.layer @A bind { }
+  // CHECK-NOT: firrtl.layer @B bind { }
+  firrtl.layer @B bind { }
+  // CHECK-NOT: firrtl.layer @C bind { }
+  firrtl.layer @C bind { }
+  firrtl.extmodule @LayerDisableInARow()
+}
+
+
 //===----------------------------------------------------------------------===//
 // LayerBlock Specialization
 //===----------------------------------------------------------------------===//
@@ -182,7 +196,7 @@ firrtl.circuit "LayerblockDisableB" attributes {
 }
 
 //===----------------------------------------------------------------------===//
-// Module Required Layers
+// Module Enable Layers
 //===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: firrtl.circuit "EnableLayerB"
@@ -226,6 +240,10 @@ firrtl.circuit "DisableLayerA" attributes {
   firrtl.layer @A bind { }
   // CHECK-NOT: firrtl.extmodule @Test0()
   firrtl.extmodule @Test0() attributes {layers = [@A]}
+  // CHECK-NOT: firrtl.extmodule @Test1() attributes {layers = [@A]}
+  firrtl.extmodule @Test1() attributes {layers = [@A]}
+  // CHECK-NOT: firrtl.extmodule @Test2() attributes {layers = [@A]}
+  firrtl.extmodule @Test2() attributes {layers = [@A]}
 
   // Top level module, which can't be deleted by the pass.
   firrtl.extmodule @DisableLayerA()


### PR DESCRIPTION
This pass processes all modules and layers in parallel, and since this
could result in the operation being deleted, could lead to crash when
two side-by-side ops are removed at the same time and try to modify each
other's next and previous pointers.  This changes the pass to handle the
part of the specialization which can delete the operation in serial.