### PR TITLE
[Moore] Fix the stacking fault caused by cast and remove unused headers

### DIFF
--- a/include/circt/Dialect/Moore/MoorePasses.td
+++ b/include/circt/Dialect/Moore/MoorePasses.td
@@ -15,10 +15,10 @@
 
 include "mlir/Pass/PassBase.td"
 
-def SimplifyProcedures : Pass<"simplify-procedures", "moore::SVModuleOp"> {
+def SimplifyProcedures : Pass<"moore-simplify-procedures", "moore::SVModuleOp"> {
     let summary = "Simplify procedures";
     let description = [{
-      Cause we want to introduce mem2reg in the moore dialect to eliminate the
+      Because we want to introduce mem2reg in the moore dialect to eliminate the
       local temporary variables, if the local variabels exist in the procedure
       body, it can be promoted by mem2reg. But global/module-level variables
       don't be promoted. So this pass is aimed at inserting a local "shadow"

--- a/test/Dialect/Moore/simplify-procedures.mlir
+++ b/test/Dialect/Moore/simplify-procedures.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --simplify-procedures %s | FileCheck %s
+// RUN: circt-opt --moore-simplify-procedures %s | FileCheck %s
 
 // CHECK-LABEL: moore.module @Foo()
 moore.module @Foo() {


### PR DESCRIPTION
Cause every variable/net has been used by other ops. We must first read it. For example:
```
module foo(input clk, en, cin);
  reg q;
  always@(posedge clk) begin
          if(en) begin
             q <= cin;
          end
  end
endmodule      
```
```
moore.module @foo(in %clk : !moore.l1, in %en : !moore.l1, in %cin : !moore.l1) {
    %clk_0 = moore.net name "clk" wire : <l1>
    %en_1 = moore.net name "en" wire : <l1>
    %cin_2 = moore.net name "cin" wire : <l1>
    %q = moore.variable : <l1>
    moore.procedure always {
      %0 = moore.read %clk_0 : l1
      moore.wait_event posedge %0 : l1
      %1 = moore.read %en_1 : l1
      %2 = moore.conversion %1 : !moore.l1 -> i1
      scf.if %2 {
        %3 = moore.read %cin_2 : l1
        moore.nonblocking_assign %q, %3 : l1
      }
    }
    moore.assign %clk_0, %clk : l1
    moore.assign %en_1, %en : l1
    moore.assign %cin_2, %cin : l1
    moore.output
  }
```
`SimplifyProcedures` is through visit `moore.read` to get the user, but the user may be `moore.net` such as "clk". This situation will cause a segmentation fault.