### PR TITLE
[Moore] Add extra class declaration for RefType.

### DIFF
--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -346,6 +346,13 @@ def RefType : MooreTypeDef<"Ref", [], "moore::UnpackedType">{
       return $_get(nestedType.getContext(), nestedType);
     }]>
   ];
+
+  let extraClassDeclaration = [{
+    Domain getDomain() { return getNestedType().getDomain(); }
+    std::optional<unsigned> getBitSize() {
+      return getNestedType().getBitSize();
+    };
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/unittests/Dialect/Moore/TypesTest.cpp
+++ b/unittests/Dialect/Moore/TypesTest.cpp
@@ -174,4 +174,26 @@ TEST(TypesTest, Structs) {
   ASSERT_EQ(u3.getBitSize(), std::nullopt);
 }
 
+TEST(TypesTest, Refs) {
+  MLIRContext context;
+  context.loadDialect<MooreDialect>();
+
+  auto bitType = IntType::getInt(&context, 1);
+  auto logicType = IntType::getLogic(&context, 8);
+  auto bitRefType = RefType::get(&context, bitType);
+  auto logicRefType = RefType::get(&context, logicType);
+
+  // Value domain
+  ASSERT_EQ(bitRefType.getDomain(), Domain::TwoValued);
+  ASSERT_EQ(logicRefType.getDomain(), Domain::FourValued);
+
+  // Bit size
+  ASSERT_EQ(bitRefType.getBitSize(), 1u);
+  ASSERT_EQ(logicRefType.getBitSize(), 8u);
+
+  // Nested type
+  ASSERT_EQ(bitRefType.getNestedType(), bitType);
+  ASSERT_EQ(logicRefType.getNestedType(), logicType);
+}
+
 } // namespace


### PR DESCRIPTION
Add `getDomain()` and `getBitSize()` for `RefType`, now can directly get the domain and size of its nested type.