### PR TITLE
[DebugInfo][HGLDD] 

### DIFF
--- a/include/circt/Analysis/DebugInfo.h
+++ b/include/circt/Analysis/DebugInfo.h
@@ -23,6 +23,13 @@ namespace detail {
 struct DebugInfoBuilder;
 } // namespace detail
 
+struct DISourceLang {
+  /// The name of the type.
+  StringAttr typeName;
+  /// The constructor parameters of the type.
+  ArrayAttr params;
+};
+
 struct DIModule {
   /// The operation that generated this level of hierarchy.
   Operation *op = nullptr;
@@ -36,6 +43,10 @@ struct DIModule {
   bool isExtern = false;
   /// If this is an inline scope created by a `dbg.scope` operation.
   bool isInline = false;
+
+  // TODO: add support for source language type info to a module
+  // /// The source language type of this module.
+  // DISourceLang sourceLangType;
 };
 
 struct DIInstance {
@@ -54,6 +65,9 @@ struct DIVariable {
   LocationAttr loc;
   /// The SSA value representing the value of this variable.
   Value value = nullptr;
+
+  /// The source language type of this module.
+  DISourceLang sourceLangType;
 };
 
 /// Debug information attached to an operation and the operations nested within.

--- a/include/circt/Analysis/DebugInfo.h
+++ b/include/circt/Analysis/DebugInfo.h
@@ -44,9 +44,8 @@ struct DIModule {
   /// If this is an inline scope created by a `dbg.scope` operation.
   bool isInline = false;
 
-  // TODO: add support for source language type info to a module
-  // /// The source language type of this module.
-  // DISourceLang sourceLangType;
+  /// The source language type of this module.
+  DISourceLang sourceLangType;
 };
 
 struct DIInstance {

--- a/include/circt/Dialect/Debug/DebugOps.td
+++ b/include/circt/Dialect/Debug/DebugOps.td
@@ -150,4 +150,21 @@ def ArrayOp : DebugOp<"array", [Pure, SameTypeOperands]> {
   let hasCustomAssemblyFormat = 1;
 }
 
+
+def ModuleInfoOp : DebugOp<"moduleinfo"> {
+  let summary = "Define extra debug information for a module";
+  let description = [{
+    Creates debug information for a module. If present, this operations provides
+    extra information about the module type in the source language, such as its
+    type name and constructor parameters. 
+  }];
+
+  let arguments = (ins
+    StrAttr:$typeName,
+    OptionalAttr<ArrayAttr>:$params
+  );
+
+  let assemblyFormat = [{ attr-dict }];
+}
+
 #endif // CIRCT_DIALECT_DEBUG_DEBUGOPS_TD

--- a/include/circt/Dialect/Debug/DebugOps.td
+++ b/include/circt/Dialect/Debug/DebugOps.td
@@ -63,7 +63,10 @@ def VariableOp : DebugOp<"variable"> {
     compiler's pass pipelines. The debug info analysis uses this op to populate
     a module's scope with named source language values, and to establish how
     these source language values can be reconstituted from the actual IR values
-    present at the end of compilation.
+    present at the end of compilation. 
+    In addition, the `dbg.variable` operation may contain extra information about 
+    the variable, such as its source language type and eventual constructor 
+    parameters. This is allows to reconstruct more precisely the source language.
 
     See the rationale for examples and details. See the `dbg.scope` operation
     for additional details on how to use the `scope` operand.
@@ -71,13 +74,44 @@ def VariableOp : DebugOp<"variable"> {
   let arguments = (ins
     StrAttr:$name,
     AnyType:$value,
+    OptionalAttr<StrAttr>:$typeName,
+    OptionalAttr<ArrayAttr>:$params,
     Optional<ScopeType>:$scope
   );
+  // let results = (outs VariableType:$result);
   let assemblyFormat = [{
     $name `,` $value (`scope` $scope^)? attr-dict `:` type($value)
   }];
 }
 
+def SubFieldOp : DebugOp<"subfield"> {
+  let summary = "A named value to be captured in debug info which is a subfield of an aggregate";
+  let description = [{
+    Marks a subfield of aggregate to be tracked in DI under the given name. 
+    It is similar to `dbg.variable`, both store a value and contain source language name, type, 
+    and constructor parameters, but `dbg.subfield` returns also a value. Unlike a `dbg.variable`, 
+    it is contained in other debug operations like `dbg.struct` or `dbg.array` (here the usage of 
+    the returned value). It is only used to represent a subfield of an aggregate and it cannot be
+    used to represent a variable directly declared in a module.
+
+    The addition of support for source language type and constructor parameters for top variables 
+    and subfields (also nested) required to build this additional operation. The `dbg.variable` 
+    explicitly represents the "top" variable instances in a module. For this reason, it wasn't used to mark
+    and it cannot mark subfields of aggregates.
+
+    The `dbg.subfield` doesn't have a `scope` operand, because it is a descendant of a `dbg.variable`.
+  }];
+  let arguments = (ins
+    StrAttr:$name,
+    AnyType:$value,
+    OptionalAttr<StrAttr>:$typeName,
+    OptionalAttr<ArrayAttr>:$params
+  );
+  let results = (outs SubFieldType:$result);
+  let assemblyFormat = [{
+    $name `,` $value attr-dict `:` type($value)
+  }];
+}
 
 def StructOp : DebugOp<"struct", [
   Pure,

--- a/include/circt/Dialect/Debug/DebugTypes.td
+++ b/include/circt/Dialect/Debug/DebugTypes.td
@@ -32,4 +32,10 @@ def ArrayType : DebugTypeDef<"Array"> {
   let description = "The result of a `dbg.array` operation.";
 }
 
+def SubFieldType : DebugTypeDef<"SubField"> {
+  let mnemonic = "subfield";
+  let summary = "debug variable subfield of an aggregate";
+  let description = "The result of a `dbg.subfield` operation.";
+}
+
 #endif // CIRCT_DIALECT_DEBUG_DEBUGTYPES_TD

--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -201,6 +201,9 @@ constexpr const char *wiringSourceAnnoClass =
 // Attribute annotations.
 constexpr const char *attributeAnnoClass = "firrtl.AttributeAnnotation";
 
+// Tywaves Annotation: contains info about source level chisel extra information
+constexpr const char *tywavesAnnoClass = "chisel3.tywaves.TywavesAnnotation";
+
 } // namespace firrtl
 } // namespace circt
 

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -31,7 +31,8 @@ std::unique_ptr<mlir::Pass>
 createLowerFIRRTLAnnotationsPass(bool ignoreUnhandledAnnotations = false,
                                  bool ignoreClasslessAnnotations = false,
                                  bool noRefTypePorts = false,
-                                 bool allowAddingPortsOnPublic = false);
+                                 bool allowAddingPortsOnPublic = false, 
+                                 bool shouldEnableDebugInfo = false);
 
 std::unique_ptr<mlir::Pass> createLowerOpenAggsPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -43,6 +43,8 @@ def LowerFIRRTLAnnotations : Pass<"firrtl-lower-annotations", "firrtl::CircuitOp
       "Create normal ports, not ref type ports.">,
     Option<"allowAddingPortsOnPublic", "allow-adding-ports-on-public-modules", "bool", "false",
       "Allow public modules to gain additional ports as a result of wiring.">,
+    Option<"shouldEnableDebugInfo", "should-enable-debug-info", "bool", "true", 
+      "Enable to consume debug annotations.">
   ];
   let dependentDialects = ["hw::HWDialect"];
   let statistics = [

--- a/lib/Analysis/DebugInfo.cpp
+++ b/lib/Analysis/DebugInfo.cpp
@@ -107,6 +107,12 @@ void DebugInfoBuilder::visitModule(hw::HWModuleOp moduleOp, DIModule &module) {
       node->op = scopeOp;
       scopes.insert({scopeOp, node});
     }
+
+    // Add the source language information to the module
+    if (auto sourceLangType = dyn_cast<debug::ModuleInfoOp>(op)) {
+      module.sourceLangType.typeName = sourceLangType.getTypeNameAttr();
+      module.sourceLangType.params = sourceLangType.getParamsAttr();
+    }
   });
 
   // Helper function to resolve a `scope` operand on a variable to the

--- a/lib/Analysis/DebugInfo.cpp
+++ b/lib/Analysis/DebugInfo.cpp
@@ -57,7 +57,11 @@ void DebugInfoBuilder::visitRoot(Operation *op) {
                  << "Collect DI for module " << moduleOp.getNameAttr() << "\n");
       auto &module = getOrCreateModule(moduleOp.getNameAttr());
       module.op = op;
-      visitModule(moduleOp, module);
+
+      // TODO: add source language type info to the module (similarly to
+      // variables)
+
+      visitModule(moduleOp, module); // Visit the module
       return WalkResult::skip();
     }
 
@@ -139,6 +143,12 @@ void DebugInfoBuilder::visitModule(hw::HWModuleOp moduleOp, DIModule &module) {
       var->name = varOp.getNameAttr();
       var->loc = varOp.getLoc();
       var->value = varOp.getValue();
+
+      // Attach to the variable the type information from the source language
+      // type information.
+      var->sourceLangType.typeName = varOp.getTypeNameAttr();
+      var->sourceLangType.params = varOp.getParamsAttr();
+
       getScope(varOp.getScope()).variables.push_back(var);
       return;
     }

--- a/lib/Dialect/FIRRTL/Transforms/MaterializeDebugInfo.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MaterializeDebugInfo.cpp
@@ -52,6 +52,9 @@ struct MaterializeDebugInfoPass
   void materializeVariable(OpBuilder &builder, StringAttr name, Value value,
                            const mlir::ArrayAttr &annoList);
 
+  void materializeModuleInfo(OpBuilder &builder, const mlir::Location &loc,
+                             const mlir::ArrayAttr &annoList);
+
   std::optional<TywavesAnnotation> getTywavesInfo(Operation *op);
 
   std::optional<TywavesAnnotation>
@@ -262,6 +265,22 @@ void MaterializeDebugInfoPass::runOnOperation() {
           // op->removeAttr("annotations");
         });
   });
+
+  // Create DI variables for the module.
+  materializeModuleInfo(builder, module.getLoc(), module.getAnnotations());
+}
+
+/// Materialize debug information for a module.
+void MaterializeDebugInfoPass::materializeModuleInfo(
+    OpBuilder &builder, const mlir::Location &loc,
+    const mlir::ArrayAttr &annoList) {
+
+  // Get the tywaves annotation for the module
+  if (auto tywavesAnno = getTywavesInfo(annoList, loc)) {
+    // Create the module info
+    builder.create<debug::ModuleInfoOp>(loc, tywavesAnno->typeName,
+                                        /*params=*/tywavesAnno->params);
+  }
 }
 
 /// Materialize debug variable ops for a value.

--- a/lib/Dialect/FIRRTL/Transforms/MaterializeDebugInfo.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MaterializeDebugInfo.cpp
@@ -16,18 +16,219 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Parallel.h"
 
+#include "circt/Dialect/FIRRTL/AnnotationDetails.h"
+
+#include "llvm/Support/Debug.h"
+#define DEBUG_TYPE "materialize-di"
+
 using namespace mlir;
 using namespace circt;
 using namespace firrtl;
 
 namespace {
+/// Internal struct to represent a tywaves annotation.
+struct TywavesAnnotation {
+  // StringAttr target;// Used here?
+  StringAttr typeName;
+  ArrayAttr params;
+
+  TywavesAnnotation(StringAttr typeName)
+      : TywavesAnnotation(typeName, ArrayAttr()) {}
+
+  TywavesAnnotation(StringAttr typeName, ArrayAttr params)
+      : typeName(typeName), params(params) {}
+
+  // Define the << operator (debug)
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                       const TywavesAnnotation &tywavesAnno) {
+    os << "  TywavesAnnotation { " << "\n\ttypeName: " << tywavesAnno.typeName
+       << "\n\tparams  : " << tywavesAnno.params << "\n  }";
+    return os;
+  }
+};
 struct MaterializeDebugInfoPass
     : public MaterializeDebugInfoBase<MaterializeDebugInfoPass> {
   void runOnOperation() override;
-  void materializeVariable(OpBuilder &builder, StringAttr name, Value value);
-  Value convertToDebugAggregates(OpBuilder &builder, Value value);
+  void materializeVariable(OpBuilder &builder, StringAttr name, Value value,
+                           const mlir::ArrayAttr &annoList);
+
+  std::optional<TywavesAnnotation> getTywavesInfo(Operation *op);
+
+  std::optional<TywavesAnnotation>
+  getTywavesInfo(const mlir::ArrayAttr &annoList, const mlir::Location &loc);
+
+  std::pair<Value, std::optional<TywavesAnnotation>>
+  convertToDebugAggregates(OpBuilder &builder, Value value, StringAttr name,
+                           const mlir::ArrayAttr &annoList,
+                           const mlir::ArrayAttr &inputFilteredAnnoList,
+                           unsigned int circtSubFieldId = 0);
 };
+
+//===----------------------------------------------------------------------===//
+// Helper functions to process and filter annotations
+//===----------------------------------------------------------------------===//
+namespace annohelper {
+
+/// Get the list of firrtl annotations from an operation.
+mlir::ArrayAttr getAnnotationList(Operation *op) {
+  return dyn_cast_or_null<mlir::ArrayAttr>(op->getAttr("annotations"));
+}
+
+/// Filter the input list of annotations by a circt.fieldID attribute. The
+/// function returns the annotation (if any) from the input list that has the
+/// same fieldID passed as argument.
+/// This helps to find the annotation associated to a subfield target.
+mlir::ArrayAttr
+filterAnnotationsByCirctFieldID(OpBuilder &builder, int fieldId,
+                                const mlir::ArrayAttr &annoList) {
+
+  // Filter the annotation list through the index: fieldId == index
+  SmallVector<Attribute> filtered;
+  for (const auto &annoAttr : annoList)
+    // 1. Convert the attribute into a dictionary
+    if (const auto &annoDict = dyn_cast<mlir::DictionaryAttr>(annoAttr))
+      // 2. Compare the iterated fieldId with the input fieldId
+      if (const auto &idxAttr = annoDict.get("circt.fieldID"))
+        if (const auto &idx = dyn_cast<IntegerAttr>(idxAttr);
+            idx && idx.getInt() == fieldId) {
+          // 3. Add the matchin Id to the filtered annotation list
+          filtered.push_back(annoAttr);
+        }
+
+  auto result = builder.getArrayAttr(filtered);
+
+  // Debug
+  LLVM_DEBUG(llvm::dbgs() << " ============================================\n");
+  LLVM_DEBUG(llvm::dbgs() << "  - Filtering fieldId: " << fieldId << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "  - Filtered anno list: " << result << "\n");
+  LLVM_DEBUG(llvm::dbgs() << " ============================================\n");
+
+  return result;
+}
+
+/// Return the total numer of subfields nested into a FIRRTL type.
+int getNumSubFields(const FIRRTLBaseType &type) {
+  return FIRRTLTypeSwitch<Type, int>(type)
+      .Case<BundleType>([&](auto type) {
+        int count = 1;
+        // Count all the elements of a bundle: in face each element is marked
+        // with an annotation
+        for (const auto &element : type.getElements())
+          count += getNumSubFields(element.type);
+
+        return count;
+      })
+      .Case<FVectorType>([&](auto type) {
+        return 1 +
+               type.getNumElements() * getNumSubFields(type.getElementType());
+      })
+      .Case<FIRRTLBaseType>([&](auto type) { return 1; }) // Ground type
+      .Default([&](auto type) { return 0; });
+}
+} // namespace annohelper
 } // namespace
+
+/// Get the Tywaves annotation in a structured representation from a single
+/// target representation. It contains the source language type information.
+std::optional<TywavesAnnotation>
+MaterializeDebugInfoPass::getTywavesInfo(Operation *op) {
+  if (auto annoListArray = annohelper::getAnnotationList(op))
+    return getTywavesInfo(annoListArray, op->getLoc());
+
+  // No annotation found
+  return std::nullopt;
+}
+
+/// Get the Tywaves annotation from a list of annotations. It assumes the
+/// list comes from a single target operation.
+///
+/// The function should be called on the final target operation.
+/// For aggregates, it should be called on each sub-operation singularly.
+///
+/// @param annoList The list of annotations associated with the target
+/// operation.
+/// @param loc The location of the target operation. For error report.
+std::optional<TywavesAnnotation>
+MaterializeDebugInfoPass::getTywavesInfo(const mlir::ArrayAttr &annoList,
+                                         const mlir::Location &loc) {
+
+  auto foundOneTywavesAnnoClass = false;
+  std::optional<TywavesAnnotation> result = std::nullopt;
+
+  // 1. Filter tywaves annotations
+  for (const auto &annoAttr : annoList)
+    if (const auto &annoDict = dyn_cast<mlir::DictionaryAttr>(annoAttr))
+      if (annoDict.template getAs<mlir::StringAttr>("class") ==
+          tywavesAnnoClass) {
+
+        // Check: there should be only one tywave annotation per target
+        if (foundOneTywavesAnnoClass) {
+          mlir::emitError(loc)
+              << "Expected a single tywaves annotation. Found: "
+              << annoList.size() << "\n";
+          signalPassFailure();
+          return std::nullopt;
+        }
+        foundOneTywavesAnnoClass = true;
+
+        // 2. Extract useful information: target, typeName, params (if
+        // any)
+        if (!annoDict.contains("typeName")) {
+          mlir::emitError(loc)
+              << "Missing expected typeName in tywaves annotation.";
+          signalPassFailure();
+          return std::nullopt;
+        }
+        // const auto &target = annoDict.get("target").cast<StringAttr>();
+        const auto &typeName = cast<StringAttr>(annoDict.get("typeName"));
+        if (const auto &params = annoDict.get("params")) {
+
+          if (!isa<mlir::ArrayAttr>(params)) {
+
+            mlir::emitError(loc) << "Parameters are expressed in the wrong "
+                                    "format, expected array. Found: "
+                                 << params << "\n";
+            signalPassFailure();
+            return std::nullopt;
+          }
+
+          auto paramsArr = cast<mlir::ArrayAttr>(params);
+          // It must contain name, type, value: check them singularly
+          for (const auto &param : paramsArr) {
+            if (auto paramDict = dyn_cast<mlir::DictionaryAttr>(param);
+                !paramDict || (!paramDict.contains("name") ||
+                               !paramDict.contains("typeName"))) {
+              mlir::emitError(loc)
+                  << "Parameters are missing one of the following "
+                     "fields: name, typeName. Found: "
+                  << params << "\n";
+              signalPassFailure();
+              return std::nullopt;
+            }
+          }
+
+          // 3. Create the TywavesAnnotation: with params
+          result = TywavesAnnotation(typeName, paramsArr);
+        } else {
+          // 3. Create the TywavesAnnotation: without params
+          result = TywavesAnnotation(typeName);
+        }
+      }
+  // TODO: use this control outside the function
+  // if (!result) {
+  //   mlir::emitError(loc) << "Missing expected tywaves annotation for "
+  //   << op
+  //                        << "\n";
+  //   signalPassFailure();
+  // }
+
+  // Return the result or std::nullopt
+  return result;
+}
+
+//===----------------------------------------------------------------------===//
+// MaterializeDebugInfoPass
+//===----------------------------------------------------------------------===//
 
 void MaterializeDebugInfoPass::runOnOperation() {
   auto module = getOperation();
@@ -36,7 +237,16 @@ void MaterializeDebugInfoPass::runOnOperation() {
   // Create DI variables for each port.
   for (const auto &[port, value] :
        llvm::zip(module.getPorts(), module.getArguments())) {
-    materializeVariable(builder, port.name, value);
+
+    materializeVariable(builder, port.name, value,
+                        port.annotations.getArrayAttr());
+
+    // Remove all the tywaves annotations from the port: prevent errors during
+    // LowerSignatures transfomation
+    port.annotations.removePortAnnotations(
+        module, [&](int portId, Annotation anno) -> bool {
+          return anno.getClass().equals(tywavesAnnoClass);
+        });
   }
 
   // Create DI variables for each declaration in the module body.
@@ -44,68 +254,197 @@ void MaterializeDebugInfoPass::runOnOperation() {
     TypeSwitch<Operation *>(op).Case<WireOp, NodeOp, RegOp, RegResetOp>(
         [&](auto op) {
           builder.setInsertionPointAfter(op);
-          materializeVariable(builder, op.getNameAttr(), op.getResult());
+          materializeVariable(builder, op.getNameAttr(), op.getResult(),
+                              annohelper::getAnnotationList(op));
+
+          // TODO: Maybe remove the annotations from the operation since done
+          // with ports? clearAnnotationList(op);
+          // op->removeAttr("annotations");
         });
   });
 }
 
 /// Materialize debug variable ops for a value.
-void MaterializeDebugInfoPass::materializeVariable(OpBuilder &builder,
-                                                   StringAttr name,
-                                                   Value value) {
+void MaterializeDebugInfoPass::materializeVariable(
+    OpBuilder &builder, StringAttr name, Value value,
+    const mlir::ArrayAttr &annoList) {
   if (!name || isUselessName(name.getValue()))
     return;
   if (name.getValue().starts_with("_"))
     return;
-  if (auto dbgValue = convertToDebugAggregates(builder, value))
+
+  if (auto [dbgValue, tywavesAnno] = convertToDebugAggregates(
+          builder, value, name, annoList, mlir::ArrayAttr{}, 0);
+      dbgValue) {
+    // LLVM creating variable
+    LLVM_DEBUG(llvm::dbgs() << "  - CREATING TOP VARIABLE: " << name << "\n");
+
+    auto typeName = tywavesAnno ? tywavesAnno->typeName : StringAttr{};
+    auto params = tywavesAnno ? tywavesAnno->params : ArrayAttr{};
     builder.create<debug::VariableOp>(value.getLoc(), name, dbgValue,
+                                      /*typeName=*/typeName,
+                                      /*params=*/params,
                                       /*scope=*/Value{});
+  }
 }
 
-/// Unpack all aggregates in a FIRRTL value and repack them as debug aggregates.
-/// For example, converts a FIRRTL vector `v` into `dbg.array [v[0],v[1],...]`.
-Value MaterializeDebugInfoPass::convertToDebugAggregates(OpBuilder &builder,
-                                                         Value value) {
-  return FIRRTLTypeSwitch<Type, Value>(value.getType())
-      .Case<BundleType>([&](auto type) {
-        SmallVector<Value> fields;
-        SmallVector<Attribute> names;
-        SmallVector<Operation *> subOps;
-        for (auto [index, element] : llvm::enumerate(type.getElements())) {
-          auto subOp = builder.create<SubfieldOp>(value.getLoc(), value, index);
-          subOps.push_back(subOp);
-          if (auto dbgValue = convertToDebugAggregates(builder, subOp)) {
-            fields.push_back(dbgValue);
-            names.push_back(element.name);
-          }
-        }
-        auto result = builder.create<debug::StructOp>(
-            value.getLoc(), fields, builder.getArrayAttr(names));
-        for (auto *subOp : subOps)
-          if (subOp->use_empty())
-            subOp->erase();
-        return result;
-      })
-      .Case<FVectorType>([&](auto type) -> Value {
-        SmallVector<Value> elements;
-        SmallVector<Operation *> subOps;
-        for (unsigned index = 0; index < type.getNumElements(); ++index) {
-          auto subOp = builder.create<SubindexOp>(value.getLoc(), value, index);
-          subOps.push_back(subOp);
-          if (auto dbgValue = convertToDebugAggregates(builder, subOp))
-            elements.push_back(dbgValue);
-        }
-        Value result;
-        if (!elements.empty() && elements.size() == type.getNumElements())
-          result = builder.create<debug::ArrayOp>(value.getLoc(), elements);
-        for (auto *subOp : subOps)
-          if (subOp->use_empty())
-            subOp->erase();
-        return result;
-      })
-      .Case<FIRRTLBaseType>(
-          [&](auto type) { return type.isGround() ? value : Value{}; })
-      .Default({});
+/// Unpack all aggregates in a FIRRTL value and repack them as debug
+/// aggregates. For example, converts a FIRRTL vector `v` into `dbg.array
+/// [v[0],v[1],...]`.
+///
+/// @param annoList is the fill list of annotations for the current value.
+/// @param maybeSingleAnno the candidate annotation for the current value used
+/// in the recursive call (should contain only one element).
+/// @param circtSubFieldId the current searched field ID of the current value.
+std::pair<Value, std::optional<TywavesAnnotation>>
+MaterializeDebugInfoPass::convertToDebugAggregates(
+    OpBuilder &builder, Value value, StringAttr name,
+    const mlir::ArrayAttr &annoList, const mlir::ArrayAttr &maybeSingleAnno,
+    unsigned int circtSubFieldId) {
+
+  // 1. Extract the tywaves annotation from the current value
+  std::optional<TywavesAnnotation> tywavesAnno = std::nullopt;
+  if (maybeSingleAnno && !maybeSingleAnno.empty()) {
+    // If maybeSingleAnno is not empty, it means that the current value may be
+    // part of an aggregate, and maybeSingleAnno has been filtered during a
+    // previous recursive call.
+    tywavesAnno = getTywavesInfo(maybeSingleAnno, value.getLoc());
+  } else {
+    // If maybeSingleAnno is empty or not defined, it means that the current
+    // value is either a ground type or the aggregate itself, for example:
+    //  - a of --> x : !firrtl.uint<8>
+    //  - b of --> b : !firrtl.bundle<a: uint<8>, b: sint<8>>
+    SmallVector<Attribute> filteredAnnoList;
+    if (annoList)
+      for (const auto &annoAttr : annoList) {
+        if (const auto &annoDict = dyn_cast<mlir::DictionaryAttr>(annoAttr);
+            annoDict && !annoDict.contains("circt.fieldID"))
+          filteredAnnoList.push_back(annoAttr);
+      }
+
+    tywavesAnno =
+        getTywavesInfo(builder.getArrayAttr(filteredAnnoList), value.getLoc());
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "  - CURRENT VALUE: " << value << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "  - EXTRACTED TYWAVES INFO:\n"
+                          << tywavesAnno << "\n");
+
+  // 2. Extract the source language type information
+  const auto typeName = tywavesAnno ? tywavesAnno->typeName : StringAttr{};
+  const auto params = tywavesAnno ? tywavesAnno->params : ArrayAttr();
+  // This enables the creation of a SubFieldOp for the current value (only if
+  // child of an aggregate and tywavesAnno is not null/none)
+  auto isChildOfAggregate = circtSubFieldId && tywavesAnno;
+
+  // 3. Generate the result
+
+  // Lambda function to generate the result or create a SubFieldOp if it is a
+  // subfield of an aggregate.
+  auto generateResult = [&builder, &typeName,
+                         &params](bool buildSubFieldOp, const Value &result,
+                                  const Location &loc, const StringAttr &name) {
+    if (buildSubFieldOp) {
+      Value x = builder.create<debug::SubFieldOp>(loc, name, result,
+                                                  /*typeName=*/typeName,
+                                                  /*params=*/params);
+      return x;
+    }
+    return result;
+  };
+
+  auto result =
+      FIRRTLTypeSwitch<Type, Value>(value.getType())
+          .Case<BundleType>([&](auto type) {
+            SmallVector<Value> fields;
+            SmallVector<Attribute> names;
+            SmallVector<Operation *> subOps;
+
+            for (auto [index, element] : llvm::enumerate(type.getElements())) {
+              auto subOp =
+                  builder.create<SubfieldOp>(value.getLoc(), value, index);
+              subOps.push_back(subOp);
+
+              // Filter the annotation list through the index:
+              // circtSubFieldId == index
+              auto filteredAnnoList =
+                  annohelper::filterAnnotationsByCirctFieldID(
+                      builder, circtSubFieldId + 1, annoList);
+              // TODO: Now I'm using the full name, I may want just the
+              // variable name, since I can build it while inspecting the
+              // hierarchy of the elements
+              auto completeName = builder.getStringAttr(
+                  name.getValue() + "." + element.name.getValue());
+
+              if (auto dbgValue = convertToDebugAggregates(
+                                      builder, subOp, completeName, annoList,
+                                      filteredAnnoList, circtSubFieldId + 1)
+                                      .first) {
+                fields.push_back(dbgValue);
+                names.push_back(element.name);
+              }
+              // Update the circtSubFieldId with the number of subfields of
+              // the current element
+              circtSubFieldId += annohelper::getNumSubFields(element.type);
+            }
+
+            Value result = builder.create<debug::StructOp>(
+                value.getLoc(), fields, builder.getArrayAttr(names));
+            for (auto *subOp : subOps)
+              if (subOp->use_empty())
+                subOp->erase();
+
+            return generateResult(isChildOfAggregate, result, value.getLoc(),
+                                  name);
+          })
+          .Case<FVectorType>([&](auto type) -> Value {
+            SmallVector<Value> elements;
+            SmallVector<Operation *> subOps;
+
+            for (unsigned index = 0; index < type.getNumElements(); ++index) {
+              auto subOp =
+                  builder.create<SubindexOp>(value.getLoc(), value, index);
+              subOps.push_back(subOp);
+
+              // Filter the annotation list through the index:
+              // circtSubFieldId == index
+              if (index == 0)
+                circtSubFieldId++;
+              auto filteredAnnoList =
+                  annohelper::filterAnnotationsByCirctFieldID(
+                      builder, circtSubFieldId, annoList);
+              auto completeName =
+                  name.getValue() + "[" + std::to_string(index) + "]";
+
+              if (auto dbgValue =
+                      convertToDebugAggregates(
+                          builder, subOp, builder.getStringAttr(completeName),
+                          annoList, filteredAnnoList, circtSubFieldId)
+                          .first)
+                elements.push_back(dbgValue);
+            }
+
+            Value result;
+            if (!elements.empty() && elements.size() == type.getNumElements())
+              result = builder.create<debug::ArrayOp>(value.getLoc(), elements);
+            for (auto *subOp : subOps)
+              if (subOp->use_empty())
+                subOp->erase();
+
+            return generateResult(isChildOfAggregate, result, value.getLoc(),
+                                  name);
+          })
+          .Case<FIRRTLBaseType>([&](auto type) {
+            if (type.getBitWidthOrSentinel() < 1)
+              return Value{};
+            // Emit the result directly
+            return type.isGround() ? generateResult(isChildOfAggregate, value,
+                                                    value.getLoc(), name)
+                                   : Value{};
+          })
+          .Default({});
+
+  return std::make_pair(result, tywavesAnno);
 }
 
 std::unique_ptr<Pass> firrtl::createMaterializeDebugInfoPass() {

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -34,7 +34,7 @@ LogicalResult firtool::populatePreprocessTransforms(mlir::PassManager &pm,
       opt.shouldDisableUnknownAnnotations(),
       opt.shouldDisableClasslessAnnotations(),
       opt.shouldLowerNoRefTypePortAnnotations(),
-      opt.shouldAllowAddingPortsOnPublic()));
+      opt.shouldAllowAddingPortsOnPublic(), opt.shouldEnableDebugInfo()));
 
   if (opt.shouldEnableDebugInfo())
     pm.nest<firrtl::CircuitOp>().addNestedPass<firrtl::FModuleOp>(

--- a/lib/Target/DebugInfo/EmitHGLDD.cpp
+++ b/lib/Target/DebugInfo/EmitHGLDD.cpp
@@ -608,7 +608,11 @@ void FileEmitter::emitModule(JOStream &json, DIModule *module) {
     findAndEmitLocOrGuess(json, "hgl_loc", op, false);
     findAndEmitLoc(json, "hdl_loc", op->getLoc(), true);
   }
-  // TODO: emit source language type information
+  
+  // Emit source language type information for a module
+  auto sourceLangTypeInfo = emitSourceLangTypeInfo(module->sourceLangType);
+  if (!sourceLangTypeInfo.empty())
+    json.attribute("source_lang_type_info", std::move(sourceLangTypeInfo));
 
   emitModuleBody(json, module);
   json.objectEnd();

--- a/test/Dialect/Debug/basic.mlir
+++ b/test/Dialect/Debug/basic.mlir
@@ -26,6 +26,28 @@ func.func @Foo(%arg0: i32, %arg1: index, %arg2: f64) {
   dbg.variable "x", %arg0 scope %2 : i32
   dbg.scope "y", "Baz" scope %2
 
+  // CHECK-NEXT: [[SUBFIELD0:%.+]] = dbg.subfield "subfield0", %arg0 : i32
+  // CHECK-NEXT: [[SUBFIELD1:%.+]] = dbg.subfield "subfield1", %arg1 : index
+  // CHECK-NEXT: [[SUBFIELD2:%.+]] = dbg.subfield "subfield2", %arg2 : f64
+  %subfield0 = dbg.subfield "subfield0",  %arg0 : i32
+  %subfield1 = dbg.subfield "subfield1",  %arg1 : index
+  %subfield2 = dbg.subfield "subfield2",  %arg2 : f64
+
+  // CHECK-NEXT: [[TMP:%.+]] = dbg.struct {"subfield0": [[SUBFIELD0]], "subfield1": [[SUBFIELD1]], "subfield2": [[SUBFIELD2]]} : !dbg.subfield, !dbg.subfield, !dbg.subfield
+  // CHECK-NEXT: [[FOO:%.+]] = dbg.subfield "megasubfieldFoo", [[TMP]] : !dbg.struct
+  %megasubfieldFoo = dbg.struct {"subfield0": %subfield0, "subfield1": %subfield1, "subfield2": %subfield2} : !dbg.subfield, !dbg.subfield, !dbg.subfield
+  %3 = dbg.subfield "megasubfieldFoo", %megasubfieldFoo : !dbg.struct
+
+  // CHECK-NEXT: [[TMP:%.+]] = dbg.array [[[SUBFIELD1]], [[SUBFIELD1]]] : !dbg.subfield
+  // CHECK-NEXT: [[BAR:%.+]] = dbg.subfield "megasubfieldBar", [[TMP]] : !dbg.array
+  %megasubfieldBar = dbg.array [%subfield1, %subfield1] : !dbg.subfield
+  %4 = dbg.subfield "megasubfieldBar", %megasubfieldBar : !dbg.array
+  
+  // CHECK-NEXT: [[TMP:%.+]] = dbg.array [[[FOO]], [[BAR]]] : !dbg.subfield
+  // CHECK-NEXT: dbg.variable "megaVar", [[TMP]] : !dbg.array
+  %5 = dbg.array [%3, %4] : !dbg.subfield
+  dbg.variable "megaVar", %5 : !dbg.array
+
   return
 }
 

--- a/test/Dialect/Debug/basic.mlir
+++ b/test/Dialect/Debug/basic.mlir
@@ -48,6 +48,9 @@ func.func @Foo(%arg0: i32, %arg1: index, %arg2: f64) {
   %5 = dbg.array [%3, %4] : !dbg.subfield
   dbg.variable "megaVar", %5 : !dbg.array
 
+  // CHECK-NEXT: dbg.moduleinfo {params = [{name = "foo", type = "i32"}, {name = "bar", type = "index", value = "18"}], typeName = "FooType"}
+  dbg.moduleinfo {typeName = "FooType", params = [{name = "foo", type = "i32"}, {name = "bar", type = "index", value = "18"}]}
+
   return
 }
 

--- a/test/Dialect/FIRRTL/materialize-debug-info-errors.mlir
+++ b/test/Dialect/FIRRTL/materialize-debug-info-errors.mlir
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+// Diagnostics
+//===----------------------------------------------------------------------===//
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-materialize-debug-info)))' --verify-diagnostics %s 
+
+firrtl.circuit "ExpectedError" {
+// CHECK-LABEL: @ExpectedError
+firrtl.module @ExpectedError() {
+  // expected-error @below {{Missing expected typeName in tywaves annotation.}}
+  %a = firrtl.wire {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeNam = "Wire[SInt<17>]"}]} : !firrtl.uint<17> 
+  
+  // expected-error @below {{Parameters are expressed in the wrong format, expected array. Found: {name = "size", typeName = "int", value = "17"}}}
+  %b = firrtl.wire {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Wire[SInt<17>]", params = {name="size", typeName="int", value="17"}}]} : !firrtl.uint<17>
+  // expected-error @below {{Parameters are missing one of the following fields: name, typeName. Found: ["a", 10]}}
+  %b2 = firrtl.wire {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Wire[SInt<17>]", params = ["a", 10]}]} : !firrtl.uint<17>
+  // expected-error @below {{Parameters are missing one of the following fields: name, typeName. Found: [{nam = "size", typeName = "int", value = "17"}]}}
+  %c = firrtl.wire {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Wire[SInt<17>]", params = [{nam="size", typeName="int", value="17"}]}]} : !firrtl.uint<17>
+  // expected-error @below {{Parameters are missing one of the following fields: name, typeName. Found: [{name = "size", typ = "int", value = "17"}]}}
+  %d = firrtl.wire {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Wire[SInt<17>]", params = [{name="size", typ="int", value="17"}]}]} : !firrtl.uint<17>
+  // no error
+  %e = firrtl.wire {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Wire[SInt<17>]", params = [{name="size", typeName="int", value="17"}]}]} : !firrtl.uint<17>
+  // no error: value is optional
+  %f = firrtl.wire {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Wire[SInt<17>]", params = [{name="size", typeName="int"}]}]} : !firrtl.uint<17>
+  
+  // expected-error @below {{Expected a single tywaves annotation. Found: 3}}
+  %g = firrtl.wire {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Wire[SInt<17>]"},
+                                   {class = "chisel3.tywaves.TywavesAnnotation", typeName = "Wire[UInt<17>]"},
+                                   {class = "chisel3.tywaves.TywavesAnnotation", typeName = "Wire[SInt<17>]", params = [{name="size", typeName="int", value="17"}]}]} : !firrtl.uint<17>
+}
+}

--- a/test/Dialect/FIRRTL/materialize-debug-info.mlir
+++ b/test/Dialect/FIRRTL/materialize-debug-info.mlir
@@ -153,3 +153,32 @@ firrtl.module @ConstructorParams() {
 
 }
 }
+firrtl.circuit "TopCircuitMultiModule" {
+    // CHECK-LABEL: firrtl.module private @MyModule()
+    // CHECK-NEXT: dbg.moduleinfo {typeName = "MyModule"}
+    firrtl.module private @MyModule() attributes {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", target = "~TopCircuitMultiModule|MyModule", typeName = "MyModule"}]} {
+      firrtl.skip
+    }
+    // CHECK-LABEL: firrtl.module private @MyModule_1()
+    // CHECK-NEXT: dbg.moduleinfo {typeName = "MyModule"}
+    firrtl.module private @MyModule_1() attributes {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", target = "~TopCircuitMultiModule|MyModule_1", typeName = "MyModule"}]} {
+      firrtl.skip
+    }
+    // CHECK-LABEL: firrtl.module private @MyModule_2()
+    // CHECK-NEXT: dbg.moduleinfo {typeName = "MyModule"}
+    firrtl.module private @MyModule_2() attributes {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", target = "~TopCircuitMultiModule|MyModule_2", typeName = "MyModule"}]} {
+      firrtl.skip
+    }
+    // CHECK-LABEL: firrtl.module private @MyModule_3()
+    // CHECK-NEXT: dbg.moduleinfo {typeName = "MyModule"}
+    firrtl.module private @MyModule_3() attributes {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", target = "~TopCircuitMultiModule|MyModule_3", typeName = "MyModule"}]} {
+      firrtl.skip
+    }
+    firrtl.module @TopCircuitMultiModule() attributes {annotations = [{class = "firrtl.transforms.DedupGroupAnnotation", group = "TopCircuitMultiModule"}, {class = "chisel3.tywaves.TywavesAnnotation", target = "~TopCircuitMultiModule|TopCircuitMultiModule", typeName = "TopCircuitMultiModule"}], convention = #firrtl<convention scalarized>} {
+      firrtl.instance mod    interesting_name @MyModule()
+      firrtl.instance mod1   interesting_name @MyModule()
+      firrtl.instance mod2   interesting_name @MyModule_1()
+      firrtl.instance mods_0 interesting_name @MyModule_2()
+      firrtl.instance mods_1 interesting_name @MyModule_3()
+    }
+}

--- a/test/Dialect/FIRRTL/materialize-debug-info.mlir
+++ b/test/Dialect/FIRRTL/materialize-debug-info.mlir
@@ -8,7 +8,21 @@ firrtl.module @Ports(
   in %inB: !firrtl.bundle<a: sint<19>, b: clock>,
   in %inC: !firrtl.vector<asyncreset, 2>,
   in %inD: !firrtl.bundle<clocks: vector<clock, 4>>,
-  out %outA: !firrtl.uint<42>
+  out %outA: !firrtl.uint<42>,
+
+  //===----------------------------------------------------------------------===//
+  // Type annotation for the ports
+  //===----------------------------------------------------------------------===//
+  in %inTypedA: !firrtl.uint<42> [{class = "chisel3.tywaves.TywavesAnnotation", target = "~Ports|Ports>inTypedA", typeName = "IO[UInt<42>]"}],
+  in %inTypedB: !firrtl.bundle<a: sint<19>, b: clock> [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "IO[MyBundle]"},  // Target is not required anymore in this pass
+                                                       {circt.fieldID = 1 : i32, class = "chisel3.tywaves.TywavesAnnotation", typeName = "IO[AinMyBundle]"},
+                                                       {circt.fieldID = 2 : i32, class = "chisel3.tywaves.TywavesAnnotation", typeName = "IO[ClockInMyBundle]"}],
+  in %inTypedC: !firrtl.vector<asyncreset, 2> [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "IO[Vec<AsyncReset>]"},
+                                               {circt.fieldID = 1 : i32, class = "chisel3.tywaves.TywavesAnnotation", typeName = "IO[AsyncReset]"}],
+  in %inTypedD: !firrtl.bundle<clocks: vector<clock, 4>> [{class = "chisel3.tywaves.TywavesAnnotation", target = "~Ports|Ports>inTypedD", typeName = "IO[BundleVecClock]"},
+                                                          {circt.fieldID = 1 : i32, class = "chisel3.tywaves.TywavesAnnotation", target = "~Ports|Ports>inTypedD.clocks", typeName = "IO[Clock[4]]"},
+                                                          {circt.fieldID = 2 : i32, class = "chisel3.tywaves.TywavesAnnotation", target = "~Ports|Ports>inTypedD.clocks[0]", typeName = "IO[Clock]"}],
+  out %outTypedA: !firrtl.uint<42> [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Any Custom string"}]
 ) {
   // CHECK-NEXT: dbg.variable "inA", %inA
 
@@ -33,8 +47,48 @@ firrtl.module @Ports(
 
   // CHECK-NEXT: dbg.variable "outA", %outA
 
+  //===----------------------------------------------------------------------===//
+  // Check the type annotations
+  //===----------------------------------------------------------------------===//
+
+  // CHECK-NEXT: dbg.variable "inTypedA", %inTypedA {typeName = "IO[UInt<42>]"}
+
+  // CHECK-NEXT: [[TMP0:%.+]] = firrtl.subfield %inTypedB[a]
+  // CHECK-NEXT: [[TMP1:%.+]] = dbg.subfield "inTypedB.a", [[TMP0]] {typeName = "IO[AinMyBundle]"}
+  // CHECK-NEXT: [[TMP2:%.+]] = firrtl.subfield %inTypedB[b]
+  // CHECK-NEXT: [[TMP3:%.+]] = dbg.subfield "inTypedB.b", [[TMP2]] {typeName = "IO[ClockInMyBundle]"}
+  // CHECK-NEXT: [[TMP:%.+]] = dbg.struct {"a": [[TMP1]], "b": [[TMP3]]}
+  // CHECK-NEXT: dbg.variable "inTypedB", [[TMP]] {typeName = "IO[MyBundle]"}
+
+  // CHECK-NEXT: [[TMP0:%.+]] = firrtl.subindex %inTypedC[0]
+  // CHECK-NEXT: [[TMP1:%.+]] = dbg.subfield "inTypedC[0]", [[TMP0]] {typeName = "IO[AsyncReset]"}
+  // CHECK-NEXT: [[TMP2:%.+]] = firrtl.subindex %inTypedC[1]
+  // CHECK-NEXT: [[TMP3:%.+]] = dbg.subfield "inTypedC[1]", [[TMP2]] {typeName = "IO[AsyncReset]"}
+  // CHECK-NEXT: [[TMP:%.+]] = dbg.array [[[TMP1]], [[TMP3]]] 
+  // CHECK-NEXT: dbg.variable "inTypedC", [[TMP]] {typeName = "IO[Vec<AsyncReset>]"}
+  
+  // CHECK-NEXT: [[TMP0:%.+]] = firrtl.subfield %inTypedD[clocks]
+  // CHECK-NEXT: [[TMP1:%.+]] = firrtl.subindex [[TMP0]][0]
+  // CHECK-NEXT: [[TMP2:%.+]] = dbg.subfield "inTypedD.clocks[0]", [[TMP1]] {typeName = "IO[Clock]"}
+  // CHECK-NEXT: [[TMP3:%.+]] = firrtl.subindex [[TMP0]][1]
+  // CHECK-NEXT: [[TMP4:%.+]] = dbg.subfield "inTypedD.clocks[1]", [[TMP3]] {typeName = "IO[Clock]"}
+  // CHECK-NEXT: [[TMP5:%.+]] = firrtl.subindex [[TMP0]][2]
+  // CHECK-NEXT: [[TMP6:%.+]] = dbg.subfield "inTypedD.clocks[2]", [[TMP5]] {typeName = "IO[Clock]"}
+  // CHECK-NEXT: [[TMP7:%.+]] = firrtl.subindex [[TMP0]][3]
+  // CHECK-NEXT: [[TMP8:%.+]] = dbg.subfield "inTypedD.clocks[3]", [[TMP7]] {typeName = "IO[Clock]"}
+  // CHECK-NEXT: [[TMP9:%.+]] = dbg.array [[[TMP2]], [[TMP4]], [[TMP6]], [[TMP8]]] 
+  // CHECK-NEXT: [[TMP10:%.+]] = dbg.subfield "inTypedD.clocks", [[TMP9]] {typeName = "IO[Clock[4]]"}
+  // CHECK-NEXT: [[TMP:%.+]] = dbg.struct {"clocks": [[TMP10]]}
+  // CHECK-NEXT: dbg.variable "inTypedD", [[TMP]] {typeName = "IO[BundleVecClock]"} 
+  
+  // CHECK-NEXT: dbg.variable "outTypedA", %outTypedA {typeName = "Any Custom string"}
+
   // CHECK-NEXT: firrtl.strictconnect
   firrtl.strictconnect %outA, %inA : !firrtl.uint<42>
+
+  // The type annotations do not compromise the rest of the code
+  // CHECK-NEXT: firrtl.strictconnect
+  firrtl.strictconnect %outTypedA, %inTypedA : !firrtl.uint<42>
 }
 
 // CHECK-LABEL: firrtl.module @Decls
@@ -48,22 +102,54 @@ firrtl.module @Decls() {
 
   // CHECK-NEXT: firrtl.wire
   // CHECK-NEXT: dbg.variable "someWire", %someWire
+  // CHECK-NEXT: firrtl.wire
+  // CHECK-NEXT: dbg.variable "someTypedWire", %someTypedWire {typeName = "Wire[SInt<17>]"}
   %someWire = firrtl.wire : !firrtl.uint<17>
+  %someTypedWire = firrtl.wire {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Wire[SInt<17>]"}]} : !firrtl.uint<17>
 
   // CHECK-NEXT: firrtl.node
   // CHECK-NEXT: dbg.variable "someNode", %someNode
+  // CHECK-NEXT: firrtl.node
+  // CHECK-NEXT: dbg.variable "someTypedNode", %someTypedNode {typeName = "UInt<17>"}
   %someNode = firrtl.node %c0_ui17 : !firrtl.uint<17>
+  %someTypedNode = firrtl.node %c0_ui17 {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "UInt<17>"}]} : !firrtl.uint<17>
 
   // CHECK-NEXT: firrtl.reg
   // CHECK-NEXT: dbg.variable "someReg1", %someReg1
+  // CHECK-NEXT: firrtl.reg
+  // CHECK-NEXT: dbg.variable "someTypedReg1", %someTypedReg1 {typeName = "Reg[SInt<17>]"}
   %someReg1 = firrtl.reg %c0_clock : !firrtl.clock, !firrtl.uint<17>
+  %someTypedReg1 = firrtl.reg %c0_clock {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Reg[SInt<17>]"}]} : !firrtl.clock, !firrtl.uint<17>
 
   // CHECK-NEXT: firrtl.regreset
   // CHECK-NEXT: dbg.variable "someReg2", %someReg2
+  // CHECK-NEXT: firrtl.regreset
+  // CHECK-NEXT: dbg.variable "someTypedReg2", %someTypedReg2 {typeName = "Reg[SInt<17>]"}
   %someReg2 = firrtl.regreset %c0_clock, %c0_ui1, %c0_ui17 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<17>
+  %someTypedReg2 = firrtl.regreset %c0_clock, %c0_ui1, %c0_ui17 {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Reg[SInt<17>]"}]} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<17>
 
   // CHECK-NEXT: firrtl.strictconnect
-  firrtl.strictconnect %someWire, %c0_ui17 : !firrtl.uint<17>
+  firrtl.strictconnect %someWire, %c0_ui17 : !firrtl.uint<17>  
+
+  // CHECK-NEXT: firrtl.strictconnect
+  firrtl.strictconnect %someTypedWire, %someWire : !firrtl.uint<17>
 }
 
+// CHECK-LABEL: firrtl.module @ConstructorParams
+firrtl.module @ConstructorParams() {
+  // CHECK-NEXT: firrtl.constant
+  %c0_ui17 = firrtl.constant 0 : !firrtl.uint<17>
+
+  // CHECK-NEXT: firrtl.wire
+  // CHECK-NEXT: dbg.variable "someTypedWire", %someTypedWire {params = [{name = "size", typeName = "int", value = "17"}], typeName = "Wire[SInt<17>]"}
+  %someTypedWire = firrtl.wire {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Wire[SInt<17>]", params = [{name="size", typeName="int", value="17"}]}]} : !firrtl.uint<17>
+  
+  // CHECK-NEXT: firrtl.wire
+  // CHECK-NEXT: dbg.variable "anotherTypedWire", %anotherTypedWire {params = [{name = "p", typeName = "char"}], typeName = "Wire[SInt<17>]"}
+  %anotherTypedWire = firrtl.wire {annotations = [{class = "chisel3.tywaves.TywavesAnnotation", typeName = "Wire[SInt<17>]", params = [{name="p", typeName="char"}]}]} : !firrtl.uint<17>
+  
+  // CHECK-NEXT: firrtl.strictconnect
+  firrtl.strictconnect %someTypedWire, %c0_ui17 : !firrtl.uint<17>  
+
+}
 }

--- a/test/Dialect/FIRRTL/tywaves-annotations.mlir
+++ b/test/Dialect/FIRRTL/tywaves-annotations.mlir
@@ -1,0 +1,90 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-annotations{should-enable-debug-info=true}))' --split-input-file %s | FileCheck --check-prefix=CHECK_DBG %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-lower-annotations{should-enable-debug-info=false}))' --split-input-file %s | FileCheck --check-prefix=CHECK_NO_DBG %s
+
+
+// Annotating a module
+// Test tywaves annotations
+// CHECK-LABEL: firrtl.circuit "TywavesTop"
+firrtl.circuit "TywavesTop" attributes {
+  rawAnnotations = [
+    {
+      class = "chisel3.tywaves.TywavesAnnotation",
+      target = "~TywavesTop|DUT",
+      typeName = "TywavesDut",
+      params=[
+        { "name"="size", "typeName"="Int", "value"="10" },
+        { "name"="n", "typeName"="Int" }
+      ]
+    }]
+  } {
+    // CHECK_DBG:  firrtl.module private @DUT() attributes
+    // CHECK_NO_DBG:  firrtl.module private @DUT() {
+    // CHECK_DBG:        annotations = [{
+    // CHECK_DBG:           class = "chisel3.tywaves.TywavesAnnotation"
+    // CHECK_DBG:           params = [{name = "size", typeName = "Int", value = "10"}, {name = "n", typeName = "Int"}
+    // CHECK_DBG:           target = "~TywavesTop|DUT"
+    // CHECK_DBG:           typeName = "TywavesDut"
+  firrtl.module private @DUT() {}
+    // CHECK-LABEL:  firrtl.module @TywavesTop
+    // CHECK-NEXT:   firrtl.instance dut @DUT
+    firrtl.module @TywavesTop() {
+    firrtl.instance dut @DUT()
+  }
+}
+
+// CHECK-LABEL: firrtl.circuit "Foo"
+// CHECK-NOT:     rawAnnotations
+firrtl.circuit "Foo" attributes {rawAnnotations = [
+    {
+        class = "chisel3.tywaves.TywavesAnnotation",
+        target = "~Foo|Foo>bar.a",
+        typeName = "UInt<1>"
+    },
+    {
+        class = "chisel3.tywaves.TywavesAnnotation",
+        target = "~Foo|Foo>bar.b.baz",
+        typeName = "UInt<1>"
+    },
+    {
+        class = "chisel3.tywaves.TywavesAnnotation",
+        target = "~Foo|Foo/bar:Bar>b.qux",
+        typeName = "UInt<1>"
+    },
+    {
+        class = "chisel3.tywaves.TywavesAnnotation",
+        target = "~Foo|Foo/bar:Bar>d.qux",
+        typeName = "UInt<1>"
+    },
+    {
+        class = "chisel3.tywaves.TywavesAnnotation",
+        target = "~Foo|Foo>bar.c",
+        typeName = "Bool"
+    }
+]} {
+  // CHECK_DBG: firrtl.module @Bar attributes
+  // CHECK_NO_DBG: firrtl.module @Bar() {
+  // CHECK-SAME:   in %a
+  // CHECK_DBG:     {class = "chisel3.tywaves.TywavesAnnotation", target = "~Foo|Foo>bar.a", typeName = "UInt<1>"}
+  // CHECK-SAME:   out %b
+  // CHECK_DBG:     {circt.fieldID = 1 : i32, class = "chisel3.tywaves.TywavesAnnotation", target = "~Foo|Foo>bar.b.baz", typeName = "UInt<1>"}
+  // CHECK_DBG:     {circt.fieldID = 2 : i32, class = "chisel3.tywaves.TywavesAnnotation", target = "~Foo|Foo/bar:Bar>b.qux", typeName = "UInt<1>"}
+  // CHECK-SAME:   out %c
+  // CHECK_DBG:     {class = "chisel3.tywaves.TywavesAnnotation", target = "~Foo|Foo>bar.c", typeName = "Bool"}
+  firrtl.module @Bar(
+    in %a: !firrtl.uint<1>,
+    out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>>,
+    out %c: !firrtl.uint<1>
+  ) {
+    // CHECK-NEXT: %d = firrtl.wire
+    // CHECK_DBG:   {circt.fieldID = 2 : i32, class = "chisel3.tywaves.TywavesAnnotation", target = "~Foo|Foo/bar:Bar>d.qux", typeName = "UInt<1>"}
+    %d = firrtl.wire : !firrtl.bundle<baz: uint<1>, qux: uint<1>>
+  }
+  // CHECK: firrtl.module @Foo
+  firrtl.module @Foo() {
+    %bar_a, %bar_b, %bar_c = firrtl.instance bar @Bar(
+      in a: !firrtl.uint<1>,
+      out b: !firrtl.bundle<baz: uint<1>, qux: uint<1>>,
+      out c: !firrtl.uint<1>
+    )
+  }
+}

--- a/test/Dialect/FIRRTL/tywaves-annotations.mlir
+++ b/test/Dialect/FIRRTL/tywaves-annotations.mlir
@@ -32,8 +32,7 @@ firrtl.circuit "TywavesTop" attributes {
   }
 }
 
-// CHECK-LABEL: firrtl.circuit "Foo"
-// CHECK-NOT:     rawAnnotations
+// CHECK_DBG: firrtl.circuit "Foo"
 firrtl.circuit "Foo" attributes {rawAnnotations = [
     {
         class = "chisel3.tywaves.TywavesAnnotation",
@@ -61,8 +60,8 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
         typeName = "Bool"
     }
 ]} {
-  // CHECK_DBG: firrtl.module @Bar attributes
-  // CHECK_NO_DBG: firrtl.module @Bar() {
+  // CHECK-LABEL:    firrtl.module @Bar
+  // CHECK_NO_DBG: in %a: !firrtl.uint<1>, out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>>, out %c: !firrtl.uint<1>
   // CHECK-SAME:   in %a
   // CHECK_DBG:     {class = "chisel3.tywaves.TywavesAnnotation", target = "~Foo|Foo>bar.a", typeName = "UInt<1>"}
   // CHECK-SAME:   out %b
@@ -70,6 +69,7 @@ firrtl.circuit "Foo" attributes {rawAnnotations = [
   // CHECK_DBG:     {circt.fieldID = 2 : i32, class = "chisel3.tywaves.TywavesAnnotation", target = "~Foo|Foo/bar:Bar>b.qux", typeName = "UInt<1>"}
   // CHECK-SAME:   out %c
   // CHECK_DBG:     {class = "chisel3.tywaves.TywavesAnnotation", target = "~Foo|Foo>bar.c", typeName = "Bool"}
+
   firrtl.module @Bar(
     in %a: !firrtl.uint<1>,
     out %b: !firrtl.bundle<baz: uint<1>, qux: uint<1>>,

--- a/test/Dialect/FIRRTL/tywaves-annotations.mlir
+++ b/test/Dialect/FIRRTL/tywaves-annotations.mlir
@@ -8,6 +8,7 @@
 firrtl.circuit "TywavesTop" attributes {
   rawAnnotations = [
     {
+      // Annotation of a module
       class = "chisel3.tywaves.TywavesAnnotation",
       target = "~TywavesTop|DUT",
       typeName = "TywavesDut",

--- a/test/Target/DebugInfo/emit-hgldd.mlir
+++ b/test/Target/DebugInfo/emit-hgldd.mlir
@@ -64,6 +64,10 @@
 // CHECK-NEXT:     "end_line": 42
 // CHECK-NEXT:     "file": 2
 // CHECK-NEXT:   }
+// CHECK-NEXT:   "source_lang_type_info"
+// CHECK-NOT:         "params"
+// CHECK-NEXT:        "type_name": "Foo_SourceLangTypeName"
+// CHECK-NEXT:   }
 // CHECK-NEXT:   "port_vars"
 // CHECK:          "var_name": "inA"
 // CHECK:          "source_lang_type_info"
@@ -107,6 +111,7 @@
 // CHECK:          "hgl_loc"
 // CHECK:            "file": 3
 hw.module @Foo(in %a: i32 loc(#loc2), out b: i32 loc(#loc3)) {
+  dbg.moduleinfo { typeName = "Foo_SourceLangTypeName" }
   dbg.variable "inA", %a { typeName = "SInt<32>" }: i32 loc(#loc2)
   dbg.variable "outB", %b1.y { params = [{name = "size", type = "uint", value = "32"}] }: i32 loc(#loc3)
   %c42_i8 = hw.constant 42 : i8
@@ -120,11 +125,27 @@ hw.module @Foo(in %a: i32 loc(#loc2), out b: i32 loc(#loc3)) {
 
 // CHECK-LABEL: FILE "Bar.dd"
 // CHECK: "module_name": "Bar"
+// CHECK:   "source_lang_type_info"
+// CHECK-NEXT:        "params": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "name": "size"
+// CHECK-NEXT:            "type": "int"
+// CHECK-NEXT:            "value": "32"
+// CHECK-NEXT:          },
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "name": "other"
+// CHECK-NEXT:            "type": "bool"
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NEXT:        "type_name": "BarType"
+// CHECK-NEXT:   }
 // CHECK:   "port_vars"
 // CHECK:     "var_name": "inX"
 // CHECK:     "var_name": "outY"
 // CHECK:     "var_name": "varZ"
 hw.module private @Bar(in %x: i32 loc(#loc7), out y: i32 loc(#loc8)) {
+  dbg.moduleinfo { typeName = "BarType", params = [{name = "size", type="int", value="32"}, {name="other", type="bool"}] }
+
   %0 = comb.mul %x, %x : i32 loc(#loc9)
   dbg.variable "inX", %x : i32 loc(#loc7)
   dbg.variable "outY", %0 : i32 loc(#loc8)

--- a/test/Target/DebugInfo/emit-hgldd.mlir
+++ b/test/Target/DebugInfo/emit-hgldd.mlir
@@ -66,7 +66,35 @@
 // CHECK-NEXT:   }
 // CHECK-NEXT:   "port_vars"
 // CHECK:          "var_name": "inA"
+// CHECK:          "source_lang_type_info"
+// CHECK-NOT:         "params"
+// CHECK-NEXT:        "type_name": "SInt<32>"
 // CHECK:          "var_name": "outB"
+// CHECK:          "source_lang_type_info"
+// CHECK-NEXT:        "params": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "name": "size"
+// CHECK-NEXT:            "type": "uint"
+// CHECK-NEXT:            "value": "32"
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NOT:         "type_name"
+// CHECK:          "var_name": "var1"
+// CHECK:          "source_lang_type_info"
+// CHECK-NEXT:        "params": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "name": "n"
+// CHECK-NEXT:            "type": "int"
+// CHECK-NEXT:            "value": "42"
+// CHECK-NEXT:          },
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "name": "a"
+// CHECK-NEXT:            "type": "myType"
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NEXT:        "type_name": "UInt<8>"
+// CHECK:          "var_name": "var2"
+// CHECK-NOT:      "source_lang_type_info"
 // CHECK:        "children"
 // CHECK-LABEL:    "name": "b0"
 // CHECK:          "obj_name": "Bar"
@@ -79,10 +107,12 @@
 // CHECK:          "hgl_loc"
 // CHECK:            "file": 3
 hw.module @Foo(in %a: i32 loc(#loc2), out b: i32 loc(#loc3)) {
-  dbg.variable "inA", %a : i32 loc(#loc2)
-  dbg.variable "outB", %b1.y : i32 loc(#loc3)
+  dbg.variable "inA", %a { typeName = "SInt<32>" }: i32 loc(#loc2)
+  dbg.variable "outB", %b1.y { params = [{name = "size", type = "uint", value = "32"}] }: i32 loc(#loc3)
   %c42_i8 = hw.constant 42 : i8
-  dbg.variable "var1", %c42_i8 : i8 loc(#loc3)
+  dbg.variable "var1", %c42_i8 { typeName = "UInt<8>", params = [{name = "n", type = "int", value = "42" }, {name="a", type="myType"}] }: i8 loc(#loc3)
+   %c21_i8 = hw.constant 21 : i8
+  dbg.variable "var2", %c21_i8 : i8 loc(#loc3)
   %b0.y = hw.instance "b0" @Bar(x: %a: i32) -> (y: i32) loc(#loc4)
   %b1.y = hw.instance "b1" @Bar(x: %b0.y: i32) -> (y: i32) loc(#loc5)
   hw.output %b1.y : i32 loc(#loc1)
@@ -106,16 +136,33 @@ hw.module private @Bar(in %x: i32 loc(#loc7), out y: i32 loc(#loc8)) {
 
 // CHECK-LABEL: FILE "global.dd"
 // CHECK-LABEL: "obj_name": "Aggregates_data"
+// CHECK:         "source_lang_type_info"
+// CHECK-NOT:       "params"
+// CHECK-NEXT:      "type_name": "i32"
 // CHECK:         "var_name": "a"
+// CHECK:         "source_lang_type_info"
+// CHECK-NOT:       "params"
+// CHECK-NEXT:      "type_name": "i42"
 // CHECK:         "var_name": "b"
+// CHECK:         "source_lang_type_info"
+// CHECK-NOT:       "params"
+// CHECK-NEXT:      "type_name": "i17[2]"
 // CHECK:         "var_name": "c"
 // CHECK-LABEL: "obj_name": "Aggregates"
 // CHECK:       "module_name": "Aggregates"
 // CHECK:         "var_name": "data"
+// CHECK:         "source_lang_type_info"
+// CHECK-NOT:       "params"
+// CHECK-NEXT:      "type_name": "abc_struct"
 hw.module @Aggregates(in %data_a: i32, in %data_b: i42, in %data_c_0: i17, in %data_c_1: i17) {
-  %0 = dbg.array [%data_c_0, %data_c_1] : i17
-  %1 = dbg.struct {"a": %data_a, "b": %data_b, "c": %0} : i32, i42, !dbg.array
-  dbg.variable "data", %1 : !dbg.struct
+  %0 = dbg.subfield "data_a_dbg", %data_a {typeName = "i32"}: i32
+  %1 = dbg.subfield "data_b_dbg", %data_b {typeName = "i42"}: i42
+  %2 = dbg.subfield "data_c_dbg", %data_c_0 {typeName = "i17"}: i17
+  %3 = dbg.subfield "data_c_dbg", %data_c_1 {typeName = "i17"}: i17
+  %4 = dbg.array [%2, %3] : !dbg.subfield
+  %5 = dbg.subfield "c", %4 {typeName = "i17[2]"}: !dbg.array
+  %6 = dbg.struct {"a": %0, "b": %1, "c": %5} : !dbg.subfield, !dbg.subfield, !dbg.subfield
+  dbg.variable "data", %6 {typeName = "abc_struct"}: !dbg.struct
 }
 
 // CHECK-LABEL: "obj_name": "EmptyAggregates"


### PR DESCRIPTION
This PR adds new functionality to CIRCT for emitting source language type information in HGLDD 
https://github.com/llvm/circt/issues/6983.

This new functionality support the new backend of my project. [Tywaves: a type-based waveform viewer](https://github.com/rameloni/tywaves-chisel-demo/wiki). Tywaves adds support for Chisel to [Surfer](https://gitlab.com/surfer-project) through HGLDD, however it misses of Chisel-type information and a proper documentation.

So, in addition to the [changes I made to CIRCT](https://github.com/rameloni/tywaves-chisel-demo/wiki/Changes-in-CIRCT), I also created a library for reading and [documenting HGLDD in rust](https://github.com/rameloni/tywaves-chisel-demo/wiki/Waveform-GUI:-Tywaves%E2%80%90rs-and-Surfer#hgldd-documentation). I noticed that HGLDD misses a formal specification, so the rust documentation is a first attempt to provide more formal description of the fields contained in the file. 