### PR TITLE
[NFC][Seq] Remove unnecessary dependency of Seq on SV

### DIFF
--- a/lib/Conversion/SeqToSV/CMakeLists.txt
+++ b/lib/Conversion/SeqToSV/CMakeLists.txt
@@ -13,4 +13,5 @@ add_circt_conversion_library(CIRCTSeqToSV
   LINK_LIBS PUBLIC
   CIRCTEmit
   CIRCTSeq
+  CIRCTSV
 )

--- a/lib/Dialect/Seq/CMakeLists.txt
+++ b/lib/Dialect/Seq/CMakeLists.txt
@@ -21,7 +21,6 @@ add_circt_dialect_library(CIRCTSeq
 
   DEPENDS
   CIRCTHW
-  CIRCTSV
   MLIRSeqIncGen
   MLIRSeqEnumsIncGen
   MLIRSeqAttributesIncGen
@@ -31,7 +30,6 @@ add_circt_dialect_library(CIRCTSeq
 
   LINK_LIBS PUBLIC
   CIRCTHW
-  CIRCTSV
   MLIRIR
   MLIRPass
   MLIRTransforms


### PR DESCRIPTION
Seq currently depends on SV according to CMake, which seems to be unnecessary (modulo a fix to the SVToSeq CMakeLists) and means adding certain dependencies will introduce unwanted cycles.