### PR TITLE
[FIRRTL] Reject abstract resets on extmodule's.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4948,6 +4948,8 @@ ParseResult FIRCircuitParser::parseExtModule(CircuitOp circuit,
       if (auto ftype = type_dyn_cast<FIRRTLType>(pi.type)) {
         if (ftype.hasUninferredWidth())
           return emitError(loc, "extmodule port must have known width");
+        if (ftype.hasUninferredReset())
+          return emitError(loc, "extmodule port must have concrete reset type");
       }
     }
   }

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1444,6 +1444,13 @@ circuit AbstractResetPublic:
 
 ;// -----
 FIRRTL version 4.0.0
+circuit AbstractResetExt:
+  extmodule AbstractResetExt:
+    ; expected-error @below {{extmodule port must have concrete reset type}}
+    input r: Reset
+
+;// -----
+FIRRTL version 4.0.0
 circuit PrivateMainModule:
   ; expected-error @below {{private main modules were removed in FIRRTL 4.0.0}}
   module PrivateMainModule:


### PR DESCRIPTION
When parsing FIRRTL >= 4.0.0, check and reject use of abstract reset on extmodule's.

https://github.com/chipsalliance/firrtl-spec/pull/181

Previously implemented as part of #6731, but used in practice so deferred.  Let's revisit now.