### PR TITLE
[NFC][SV] Remove unnecessary dependency of SV on Verif

### DIFF
--- a/lib/Conversion/HWToBTOR2/CMakeLists.txt
+++ b/lib/Conversion/HWToBTOR2/CMakeLists.txt
@@ -12,5 +12,6 @@ add_circt_conversion_library(CIRCTHWToBTOR2
   CIRCTSV
   CIRCTComb
   CIRCTSeq
+  CIRCTVerif
   MLIRTransforms
 )

--- a/lib/Dialect/SV/CMakeLists.txt
+++ b/lib/Dialect/SV/CMakeLists.txt
@@ -17,7 +17,6 @@ add_circt_dialect_library(CIRCTSV
   CIRCTComb
   CIRCTHW
   CIRCTSupport
-  CIRCTVerif
   MLIRIR
 )
 

--- a/tools/om-linker/CMakeLists.txt
+++ b/tools/om-linker/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(om-linker PRIVATE
   CIRCTOMTransforms
   CIRCTSV
   CIRCTSupport
+  CIRCTVerif
 
   MLIRBytecodeReader
   MLIRBytecodeWriter


### PR DESCRIPTION
Same situation as #7247, SV depends on Verif but that seems to be unnecessary as long as om-linker and HWToBTOR2 CMakeLists are updated to link in Verif