### PR TITLE
[Moore] Add AssignedVarOp and canonicalization for VariableOp.

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -198,6 +198,7 @@ def VariableOp : MooreOp<"variable", [
     `` custom<ImplicitSSAName>($name) ($initial^)? attr-dict
     `:` type($result)
   }];
+  let hasCanonicalizeMethod = true;
 }
 
 def NetKindAttr : I32EnumAttr<"NetKind", "Net type kind", [
@@ -249,8 +250,21 @@ def NetOp : MooreOp<"net", [
   );
   let results = (outs Res<RefType, "", [MemAlloc]>:$result);
   let assemblyFormat = [{
-    ``custom<ImplicitSSAName>($name) $kind ($assignment^)? attr-dict
+    `` custom<ImplicitSSAName>($name) $kind ($assignment^)? attr-dict
     `:` type($result)
+  }];
+}
+
+def AssignedVarOp : MooreOp<"assigned_variable", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+  TypesMatchWith<"initial value and variable types match",
+    "result", "initial", "cast<RefType>($_self).getNestedType()">
+]> {
+  let summary = "The copy of variable must have the initial value";
+  let arguments = (ins StrAttr:$name, UnpackedType:$initial);
+  let results = (outs Res<RefType, "", [MemAlloc]>:$result);
+  let assemblyFormat = [{
+    `` custom<ImplicitSSAName>($name) $initial attr-dict `:` type($result)
   }];
 }
 

--- a/test/Dialect/Moore/canonicalizers.mlir
+++ b/test/Dialect/Moore/canonicalizers.mlir
@@ -9,3 +9,31 @@ func.func @Casts(%arg0: !moore.i1) -> (!moore.i1, !moore.i1) {
   // CHECK: return %arg0, %arg0
   return %0, %1 : !moore.i1, !moore.i1
 }
+
+// CHECK-LABEL: moore.module @SingleAssign
+moore.module @SingleAssign() {
+  // CHECK-NOT: moore.variable
+  // CHECK: %a = moore.assigned_variable %0 : <i32>
+  %a = moore.variable : <i32>
+  // CHECK: %0 = moore.constant 32 : i32
+  %0 = moore.constant 32 : i32
+  // CHECK: moore.assign %a, %0 : i32
+  moore.assign %a, %0 : i32
+  moore.output
+}
+
+// CHECK-LABEL: moore.module @MultiAssign
+moore.module @MultiAssign() {
+  // CHECK-NOT: moore.assigned_variable
+  // CHECK: %a = moore.variable : <i32>
+  %a = moore.variable : <i32>
+  // CHECK: %0 = moore.constant 32 : i32
+  %0 = moore.constant 32 : i32
+  // CHECK: moore.assign %a, %0 : i32
+  moore.assign %a, %0 : i32
+  // CHECK: %1 = moore.constant 64 : i32
+  %1 = moore.constant 64 : i32
+  // CHECK: moore.assign %a, %1 : i32
+  moore.assign %a, %1 : i32
+  moore.output
+}

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -224,6 +224,7 @@ static LogicalResult populateMooreTransforms(mlir::PassManager &pm) {
   modulePM.addPass(moore::createLowerConcatRefPass());
   modulePM.addPass(moore::createSimplifyProceduresPass());
   pm.addPass(mlir::createMem2Reg());
+
   // TODO: like dedup pass.
 
   return success();


### PR DESCRIPTION
The canonicalization for VariableOp is aimed at merging the "easy use" of the variable and its value(continuous assignment) into a new op called `assigned_variable`. Don't handle `blocking_assign` and `nonBlocking_assign` due to the dominance. 
The "easy use" is assigning a value to a variable with the whole bit-width, in other words, exclude the bits slice, concatenation operator, etc.