### PR TITLE
[ESI Runtime] Load backends as plugins

### DIFF
--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -101,11 +101,17 @@ target_include_directories(ESICppRuntime PUBLIC
 target_link_libraries(ESICppRuntime PRIVATE
   ZLIB::ZLIB
   nlohmann_json::nlohmann_json
-  dl
 )
-target_link_options(ESICppRuntime PRIVATE
-  -pthread
-)
+if(MSVC)
+  # TODO: does Windows need libraries for dynamic loading?
+else()
+  target_link_libraries(ESICppRuntime PRIVATE
+    dl
+  )
+  target_link_options(ESICppRuntime PRIVATE
+    -pthread
+  )
+endif()
 add_dependencies(ESIRuntime ESICppRuntime)
 install(TARGETS ESICppRuntime
   DESTINATION lib

--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -45,6 +45,14 @@ if (NOT TARGET nlohmann_json)
   FetchContent_MakeAvailable(json)
 endif()
 
+##===----------------------------------------------------------------------===//
+## Overall target to build everything.
+##===----------------------------------------------------------------------===//
+add_custom_target(ESIRuntime)
+
+##===----------------------------------------------------------------------===//
+## Core ESI runtime.
+##===----------------------------------------------------------------------===//
 
 set(ESICppRuntimeSources
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Accelerator.cpp
@@ -71,10 +79,6 @@ set(ESICppRuntimeHeaders
 set(ESICppRuntimeBackendHeaders
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/backends/Trace.h
 )
-set(ESICppRuntimeLinkLibraries
-  ZLIB::ZLIB
-  nlohmann_json::nlohmann_json
-)
 set(ESIPythonRuntimeSources
   python/esiaccel/__init__.py
   python/esiaccel/accelerator.py
@@ -82,96 +86,27 @@ set(ESIPythonRuntimeSources
   python/esiaccel/utils.py
   python/esiaccel/esiCppAccel.pyi
 )
-set(ESICppRuntimeIncludeDirs)
-set(ESICppRuntimeCxxFlags)
-set(ESICppRuntimeLinkFlags)
-set(ESICppRuntimeLibDirs)
 
 IF(MSVC)
     set(CMAKE_CXX_FLAGS "/EHa")
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
 ENDIF(MSVC)
 
-option(ESI_COSIM "Enable ESI cosimulation." ON)
-if(ESI_COSIM)
-  # gRPC for cosimulation. Local install required.
-  option(GRPC_PATH "Location of gRPC install.")
-  if (${GRPC_PATH})
-    find_package(Protobuf REQUIRED CONFIG HINTS ${GRPC_PATH})
-    find_package(gRPC REQUIRED CONFIG HINTS ${GRPC_PATH})
-  else()
-    find_package(Protobuf REQUIRED CONFIG)
-    find_package(gRPC REQUIRED CONFIG)
-  endif()
-
-  add_subdirectory(cosim_dpi_server)
-  # Inform the runtime code that Cosimulation is enabled. Kinda hacky since all
-  # backends should only need to be linked in.
-  # TODO: Once the hack in the python bindings is remidied, remove this.
-  add_compile_definitions(ESI_COSIM)
-  set(ESICppRuntimeSources
-    ${ESICppRuntimeSources}
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/backends/Cosim.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/backends/RpcServer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cosim.proto
-  )
-  set(ESICppRuntimeBackendHeaders
-    ${ESICppRuntimeBackendHeaders}
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/backends/Cosim.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/backends/RpcServer.h
-  )
-else()
-  message("-- ESI cosim disabled")
-endif()
-
-option(XRT_PATH "Path to XRT lib.")
-if (XRT_PATH)
-  message("-- XRT enabled with path ${XRT_PATH}")
-
-  set(ESICppRuntimeSources
-    ${ESICppRuntimeSources}
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/backends/Xrt.cpp
-  )
-  set(ESICppRuntimeBackendHeaders
-    ${ESICppRuntimeBackendHeaders}
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/backends/Xrt.h
-  )
-  set(ESICppRuntimeIncludeDirs
-    ${ESICppRuntimeIncludeDirs}
-    ${XRT_PATH}/include
-  )
-  set(ESICppRuntimeCxxFlags
-    ${ESICppRuntimeCxxFlags}
-    -fmessage-length=0
-    -Wno-nested-anon-types
-    -Wno-c++98-compat-extra-semi
-  )
-  set(ESICppRuntimeLinkLibraries
-    ${ESICppRuntimeLinkLibraries}
-    xrt_coreutil
-  )
-  set(ESICppRuntimeLinkFlags
-    ${ESICppRuntimeLinkFlags}
-    -pthread
-  )
-  set(ESICppRuntimeLibDirs
-    ${ESICppRuntimeLibDirs}
-    ${XRT_PATH}/lib
-  )
-endif()
-
 # The core API. For now, compile the backends into it directly.
-# TODO: make this a plugin architecture.
 add_library(ESICppRuntime SHARED
   ${ESICppRuntimeSources}
 )
 target_include_directories(ESICppRuntime PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include)
-target_link_libraries(ESICppRuntime PRIVATE ${ESICppRuntimeLinkLibraries})
-target_include_directories(ESICppRuntime PRIVATE ${ESICppRuntimeIncludeDirs})
-target_compile_options(ESICppRuntime PRIVATE ${ESICppRuntimeCxxFlags})
-target_link_directories(ESICppRuntime PRIVATE ${ESICppRuntimeLibDirs})
-target_link_options(ESICppRuntime PRIVATE ${ESICppRuntimeLinkFlags})
+target_link_libraries(ESICppRuntime PRIVATE
+  ZLIB::ZLIB
+  nlohmann_json::nlohmann_json
+  dl
+)
+target_link_options(ESICppRuntime PRIVATE
+  -pthread
+)
+add_dependencies(ESIRuntime ESICppRuntime)
 install(TARGETS ESICppRuntime
   DESTINATION lib
   COMPONENT ESIRuntime
@@ -180,10 +115,7 @@ install(FILES ${ESICppRuntimeHeaders}
   DESTINATION include/esi
   COMPONENT ESIRuntime-dev
 )
-install(FILES ${ESICppRuntimeBackendHeaders}
-  DESTINATION include/esi/backends
-  COMPONENT ESIRuntime-dev
-)
+
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cpp/cmake/esiaccel.cmake
   DESTINATION cmake
   COMPONENT ESIRuntime-dev
@@ -193,41 +125,39 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   target_compile_options(ESICppRuntime PRIVATE -Wno-covered-switch-default)
 endif()
 
-if(ESI_COSIM)
-  target_link_libraries(ESICppRuntime PUBLIC protobuf::libprotobuf gRPC::grpc++)
-  set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
-  target_include_directories(ESICppRuntime PUBLIC "$<BUILD_INTERFACE:${PROTO_BINARY_DIR}>")
-  protobuf_generate(
-      TARGET ESICppRuntime
-      PROTOC_OUT_DIR "${PROTO_BINARY_DIR}")
-  protobuf_generate(
-      TARGET ESICppRuntime
-      LANGUAGE grpc
-      GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc
-      PLUGIN "protoc-gen-grpc=\$<TARGET_FILE:gRPC::grpc_cpp_plugin>"
-      PROTOC_OUT_DIR "${PROTO_BINARY_DIR}")
-endif()
+# Global variable for the path to the ESI runtime for use by tests.
+set(ESICppRuntimePath "${CMAKE_CURRENT_BINARY_DIR}"
+  CACHE INTERNAL "Path to ESI runtime" FORCE)
 
-# The esiquery tool is a simple wrapper around the SysInfo API.
+
+##===----------------------------------------------------------------------===//
+## The esiquery tool is a simple wrapper around the SysInfo API.
+##===----------------------------------------------------------------------===//
+
 add_executable(esiquery
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/tools/esiquery.cpp
 )
 target_link_libraries(esiquery PRIVATE ESICppRuntime)
+add_dependencies(ESIRuntime esiquery)
 install(TARGETS esiquery
   DESTINATION bin
   COMPONENT ESIRuntime
 )
 
-# The esitester tool is both an example and test driver. As it is not intended
-# for production use, it is not installed.
+##===----------------------------------------------------------------------===//
+## The esitester tool is both an example and test driver. As it is not intended
+## for production use, it is not installed.
+##===----------------------------------------------------------------------===//
+
 add_executable(esitester
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/tools/esitester.cpp
 )
 target_link_libraries(esitester PRIVATE ESICppRuntime)
+add_dependencies(ESIRuntime esitester)
 
-# Global variable for the path to the ESI runtime for use by tests.
-set(ESICppRuntimePath "${CMAKE_CURRENT_BINARY_DIR}"
-  CACHE INTERNAL "Path to ESI runtime" FORCE)
+##===----------------------------------------------------------------------===//
+## Python bindings for the ESI runtime.
+##===----------------------------------------------------------------------===//
 
 option(WHEEL_BUILD "Set up the build for a Python wheel." OFF)
 if (WHEEL_BUILD)
@@ -339,18 +269,99 @@ if(Python3_FOUND)
         esiCppAccel
     )
 
-    # Overall target to build everything.
-    add_custom_target(ESIRuntime
-      DEPENDS
-        ESICppRuntime
-        ESIPythonRuntime
-        EsiCosimDpiServer
-        esiquery
-        esi-cosim
-    )
+    add_dependencies(ESIRuntime ESIPythonRuntime)
   endif()
 else() # Python not found.
   if (WHEEL_BUILD)
     message (FATAL_ERROR "python-dev is required for a wheel build.")
   endif()
 endif()
+
+
+
+##===----------------------------------------------------------------------===//
+## Backends are loaded dynamically as plugins.
+##===----------------------------------------------------------------------===//
+
+option(ESI_COSIM "Enable ESI cosimulation." ON)
+if(ESI_COSIM)
+  # gRPC for cosimulation. Local install required.
+  option(GRPC_PATH "Location of gRPC install.")
+  if (${GRPC_PATH})
+    find_package(Protobuf REQUIRED CONFIG HINTS ${GRPC_PATH})
+    find_package(gRPC REQUIRED CONFIG HINTS ${GRPC_PATH})
+  else()
+    find_package(Protobuf REQUIRED CONFIG)
+    find_package(gRPC REQUIRED CONFIG)
+  endif()
+
+  add_library(CosimBackend SHARED
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/backends/Cosim.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/backends/RpcServer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cosim.proto
+  )
+  set(ESICppRuntimeBackendHeaders
+    ${ESICppRuntimeBackendHeaders}
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/backends/Cosim.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/backends/RpcServer.h
+  )
+
+  target_link_libraries(CosimBackend PUBLIC
+    ESICppRuntime
+    protobuf::libprotobuf
+    gRPC::grpc++
+  )
+  set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+  target_include_directories(CosimBackend PUBLIC "$<BUILD_INTERFACE:${PROTO_BINARY_DIR}>")
+  protobuf_generate(
+      TARGET CosimBackend
+      PROTOC_OUT_DIR "${PROTO_BINARY_DIR}")
+  protobuf_generate(
+      TARGET CosimBackend
+      LANGUAGE grpc
+      GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc
+      PLUGIN "protoc-gen-grpc=\$<TARGET_FILE:gRPC::grpc_cpp_plugin>"
+      PROTOC_OUT_DIR "${PROTO_BINARY_DIR}")
+
+  add_dependencies(ESIRuntime CosimBackend)
+
+  # Build the RTL DPI cosim server.
+  add_subdirectory(cosim_dpi_server)
+else()
+  message("-- ESI cosim disabled")
+endif()
+
+option(XRT_PATH "Path to XRT lib.")
+if (XRT_PATH)
+  message("-- XRT enabled with path ${XRT_PATH}")
+
+  add_library(XrtBackend SHARED
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/backends/Xrt.cpp
+  )
+  set(ESICppRuntimeBackendHeaders
+    ${ESICppRuntimeBackendHeaders}
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/backends/Xrt.h
+  )
+  target_include_directories(XrtBackend PRIVATE
+    ${XRT_PATH}/include
+  )
+  target_compile_options(XrtBackend PRIVATE
+    -fmessage-length=0
+    -Wno-nested-anon-types
+    -Wno-c++98-compat-extra-semi
+  )
+  target_link_libraries(XrtBackend PRIVATE
+    ESICppRuntime
+    xrt_coreutil
+  )
+  target_link_options(XrtBackend PRIVATE
+    -pthread
+    -L${XRT_PATH}/lib
+  )
+  add_dependencies(ESIRuntime XrtBackend)
+endif()
+
+install(FILES ${ESICppRuntimeBackendHeaders}
+  DESTINATION include/esi/backends
+  COMPONENT ESIRuntime-dev
+)

--- a/lib/Dialect/ESI/runtime/cosim_dpi_server/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/cosim_dpi_server/CMakeLists.txt
@@ -25,9 +25,11 @@ add_dependencies(EsiCosimDpiServer ESICppRuntime MtiPli)
 target_link_libraries(EsiCosimDpiServer
   PUBLIC
     ESICppRuntime
+    CosimBackend
     MtiPli
 )
 
+add_dependencies(ESIRuntime EsiCosimDpiServer)
 install(TARGETS EsiCosimDpiServer
   DESTINATION lib
   COMPONENT ESIRuntime
@@ -71,5 +73,6 @@ install(FILES
               WORLD_EXECUTE WORLD_READ
   COMPONENT ESIRuntime
 )
+add_dependencies(ESIRuntime esi-cosim)
 set(ESI_COSIM_PATH $<TARGET_FILE:EsiCosimDpiServer>
       CACHE PATH "Path to Cosim DPI shared library")

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Cosim.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Cosim.h
@@ -25,10 +25,6 @@
 #include <memory>
 #include <set>
 
-// Only expose this backend class directly if the cosimulation backend is
-// enabled.
-#ifdef ESI_COSIM
-
 namespace esi {
 namespace cosim {
 class ChannelDesc;
@@ -91,7 +87,5 @@ private:
 } // namespace cosim
 } // namespace backends
 } // namespace esi
-
-#endif // ESI_COSIM
 
 #endif // ESI_BACKENDS_COSIM_H

--- a/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
@@ -82,7 +82,7 @@ static std::filesystem::path getLibPath() {
 #endif
 }
 
-static void loadDynamic(string backend) {
+static void loadBackend(std::string backend) {
   backend[0] = toupper(backend[0]);
 
   // Get the file name we are looking for.
@@ -96,6 +96,9 @@ static void loadDynamic(string backend) {
 #endif
 
   // Look for library using the C++ std API.
+  // TODO: once the runtime has a logging framework, log the paths we are
+  // trying.
+
   // First, try the current directory.
   std::filesystem::path backendPath = backendFileName;
   if (!std::filesystem::exists(backendPath)) {
@@ -138,7 +141,7 @@ unique_ptr<AcceleratorConnection> connect(Context &ctxt, string backend,
   auto f = internal::backendRegistry.find(backend);
   if (f == internal::backendRegistry.end()) {
     // If it's not already found in the registry, try to load it dynamically.
-    loadDynamic(backend);
+    loadBackend(backend);
     f = internal::backendRegistry.find(backend);
     if (f == internal::backendRegistry.end())
       throw runtime_error("Backend not found");

--- a/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
@@ -15,8 +15,17 @@
 #include "esi/Accelerator.h"
 
 #include <cassert>
+#include <filesystem>
 #include <map>
 #include <stdexcept>
+
+#include <iostream>
+
+#ifdef __linux__
+#include <dlfcn.h>
+#elif _WIN32
+// TODO: this.
+#endif
 
 using namespace std;
 
@@ -45,6 +54,74 @@ services::Service *AcceleratorConnection::getService(Service::Type svcType,
   return cacheEntry.get();
 }
 
+/// Get the path to the currently running executable.
+static std::filesystem::path getExePath() {
+#ifdef __linux__
+  char result[PATH_MAX];
+  ssize_t count = readlink("/proc/self/exe", result, PATH_MAX);
+  if (count == -1)
+    throw runtime_error("Could not get executable path");
+  return std::filesystem::path(std::string(result, count));
+#elif _WIN32
+  // TODO: this.
+#else
+#eror "Unsupported platform"
+#endif
+}
+
+/// Get the path to the currently running shared library.
+static std::filesystem::path getLibPath() {
+#ifdef __linux__
+  Dl_info dl_info;
+  dladdr((void *)getLibPath, &dl_info);
+  return std::filesystem::path(std::string(dl_info.dli_fname));
+#elif _WIN32
+  // TODO: this.
+#else
+#eror "Unsupported platform"
+#endif
+}
+
+static void loadDynamic(string backend) {
+  backend[0] = toupper(backend[0]);
+
+  // Get the file name we are looking for.
+#ifdef __linux__
+  std::string backendFileName = "lib" + backend + "Backend.so";
+#elif _WIN32
+  // TODO: this.
+  return;
+#else
+#eror "Unsupported platform"
+#endif
+
+  // Look for library using the C++ std API.
+  // First, try the current directory.
+  std::filesystem::path backendPath = backendFileName;
+  if (!std::filesystem::exists(backendPath)) {
+    // Next, try the directory of the executable.
+    backendPath = getExePath().parent_path().append(backendFileName);
+    if (!std::filesystem::exists(backendPath)) {
+      // Finally, try
+      backendPath = getLibPath().parent_path().append(backendFileName);
+      if (!std::filesystem::exists(backendPath))
+        throw std::runtime_error("Backend library not found");
+    }
+  }
+
+  // Attempt to load it.
+#ifdef __linux__
+  void *handle = dlopen(backendPath.c_str(), RTLD_NOW | RTLD_GLOBAL);
+  if (!handle)
+    throw std::runtime_error("While attempting to load backend plugin: " +
+                             std::string(dlerror()));
+#elif _WIN32
+  // TODO: this.
+#else
+#eror "Unsupported platform"
+#endif
+}
+
 namespace registry {
 namespace internal {
 
@@ -59,8 +136,13 @@ void registerBackend(string name, BackendCreate create) {
 unique_ptr<AcceleratorConnection> connect(Context &ctxt, string backend,
                                           string connection) {
   auto f = internal::backendRegistry.find(backend);
-  if (f == internal::backendRegistry.end())
-    throw runtime_error("Backend not found");
+  if (f == internal::backendRegistry.end()) {
+    // If it's not already found in the registry, try to load it dynamically.
+    loadDynamic(backend);
+    f = internal::backendRegistry.find(backend);
+    if (f == internal::backendRegistry.end())
+      throw runtime_error("Backend not found");
+  }
   return f->second(ctxt, connection);
 }
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Accelerator.cpp
@@ -82,6 +82,9 @@ static std::filesystem::path getLibPath() {
 #endif
 }
 
+/// Load a backend plugin dynamically. Plugins are expected to be named
+/// lib<BackendName>Backend.so and located in one of 1) CWD, 2) in the same
+/// directory as the application, or 3) in the same directory as this library.
 static void loadBackend(std::string backend) {
   backend[0] = toupper(backend[0]);
 

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
@@ -218,30 +218,6 @@ PYBIND11_MODULE(esiCppAccel, m) {
                          },
                          py::return_value_policy::reference);
 
-// Only include this cosim-only feature if cosim is enabled.It's a bit of a hack
-// to test both styles of manifest retrieval for cosim. Come up with a more
-// generic way to set accelerator-specific properties/configurations.
-#ifdef ESI_COSIM
-  py::enum_<backends::cosim::CosimAccelerator::ManifestMethod>(
-      m, "CosimManifestMethod")
-      .value("ManifestCosim",
-             backends::cosim::CosimAccelerator::ManifestMethod::Cosim)
-      .value("ManifestMMIO",
-             backends::cosim::CosimAccelerator::ManifestMethod::MMIO)
-      .export_values();
-
-  accConn.def(
-      "set_manifest_method",
-      [](AcceleratorConnection &acc,
-         backends::cosim::CosimAccelerator::ManifestMethod method) {
-        auto cosim = dynamic_cast<backends::cosim::CosimAccelerator *>(&acc);
-        if (!cosim)
-          throw std::runtime_error(
-              "set_manifest_method only supported for cosim connections");
-        cosim->setManifestMethod(method);
-      });
-#endif // ESI_COSIM
-
   py::class_<Manifest>(m, "Manifest")
       .def(py::init<Context &, std::string>())
       .def_property_readonly("api_version", &Manifest::getApiVersion)


### PR DESCRIPTION
If a backend isn't found in the registry, try to load it dynamically from some standard places. Note that if one doesn't want to keep the plugin shared lib in one of those places, one can LD_PRELOAD it.

Linux support only. Windows coming.