### PR TITLE
[FIRRTL]  Don't allow foreign types in wires or connects.  

### DIFF
--- a/docs/Dialects/FIRRTL/RationaleFIRRTL.md
+++ b/docs/Dialects/FIRRTL/RationaleFIRRTL.md
@@ -567,20 +567,30 @@ include the following:
 
 - Ports on a `firrtl.module`, where the foreign types are treated as opaque values moving in and out of the module
 - Ports on a `firrtl.instance`
-- `firrtl.wire` to allow for def-after-use cases; the wire must have a single strict connect that uniquely defines the wire's value
-- `firrtl.matchingconnect` to module outputs, instance inputs, and wires
+- `firrtl.foreign_output` 
 
-The expected lowering for strict connects is for the connect to be eliminated
-and the right-hand-side source value of the connect being instead materialized
-in all places where the left hand side is used. Basically we want wires and
-connects to disappear, and all places where the wire is "read" should instead
-read the value that was driven onto the wire.
+Foreign types on ports are set with the connect-like operation 
+`firrtl.foreign_output`.  This may be the only use of a foreign-typed output 
+module port or the mirrored port on instances.  FIRRTL variables and storage
+(mems, regs, wires, nodes) do not understand the semantics of foreign types
+and thus are explicitly excluded from operating on them.  This is due to the 
+fact that some common uses for foreign types is to represent busses and 
+higher-level abstractions which do not have the "bag of bits" behavior of
+firrtl types.
+
+The expected solution to bag-of-bits foreign types which behave in a 
+firrtl-compatible way and are wanted to be stored in firrtl declaration
+operations is to provide a firrtl wrapper type which fills in the necessary
+properties to make a foreign type usable in firrtl declarations.  This does not
+currently exist and this description is not perscriptive.
+
 
 The reason we provide this foreign type support is to allow for partial lowering
 of FIRRTL to HW and other dialects. Passes might lower a subset of types and
 operations to the target dialect and we need a mechanism to have the lowered
 values be passed around the FIRRTL module hierarchy untouched alongside the
 FIRRTL ops that are yet to be lowered.
+
 
 ### Const Types
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -595,7 +595,7 @@ def WireOp : HardwareDeclOp<"wire", [
                        AnnotationArrayAttr:$annotations,
                        OptionalAttr<InnerSymAttr>:$inner_sym,
                        UnitAttr:$forceable); // ReferenceKinds
-  let results = (outs AnyType:$result, Optional<RefType>:$ref);
+  let results = (outs FIRRTLType:$result, Optional<RefType>:$ref);
 
   let hasCanonicalizer = true;
   let skipDefaultBuilders = true;
@@ -609,7 +609,7 @@ def WireOp : HardwareDeclOp<"wire", [
       assert(resultTypes.size() >= 1u && "mismatched number of return types");
       odsState.addTypes(resultTypes);
     }]>,
-    OpBuilder<(ins "::mlir::Type":$elementType,
+    OpBuilder<(ins "::circt::firrtl::FIRRTLType":$elementType,
                    "::mlir::StringAttr":$name,
                    "::circt::firrtl::NameKindEnumAttr":$nameKind,
                    "::mlir::ArrayAttr":$annotations,
@@ -628,7 +628,7 @@ def WireOp : HardwareDeclOp<"wire", [
           $_state.addTypes(type);
       }
     }]>,
-    OpBuilder<(ins "::mlir::Type":$elementType,
+    OpBuilder<(ins "::circt::firrtl::FIRRTLType":$elementType,
                    "::llvm::StringRef":$name,
                    "::circt::firrtl::NameKindEnum":$nameKind,
                    "::mlir::ArrayAttr":$annotations,
@@ -640,7 +640,7 @@ def WireOp : HardwareDeclOp<"wire", [
                    annotations, innerSym,
                    forceable ? $_builder.getUnitAttr() : nullptr);
     }]>,
-    OpBuilder<(ins "::mlir::Type":$elementType,
+    OpBuilder<(ins "::circt::firrtl::FIRRTLType":$elementType,
                       CArg<"StringRef", "{}">:$name,
                       CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
                       CArg<"ArrayRef<Attribute>","{}">:$annotations,
@@ -652,7 +652,7 @@ def WireOp : HardwareDeclOp<"wire", [
                    innerSym ? hw::InnerSymAttr::get(innerSym) : hw::InnerSymAttr(),
                    forceable);
     }]>,
-    OpBuilder<(ins "::mlir::Type":$elementType, "StringRef":$name,
+    OpBuilder<(ins "::circt::firrtl::FIRRTLType":$elementType, "StringRef":$name,
                    "NameKindEnum":$nameKind, "::mlir::ArrayAttr":$annotations,
                    CArg<"StringAttr", "StringAttr()">:$innerSym,
                    CArg<"bool", "false">:$forceable), [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -42,7 +42,7 @@ def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
     ```
     }];
 
-  let arguments = (ins ConnectableType:$dest, ConnectableType:$src);
+  let arguments = (ins FIRRTLBaseType:$dest, FIRRTLBaseType:$src);
   let results = (outs);
 
   let assemblyFormat =
@@ -51,6 +51,28 @@ def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
   let hasVerifier = 1;
   let hasCanonicalizer = true;
 }
+
+def ForeignOutputOp : FIRRTLOp<"foreign_output", [HasParent<"FModuleOp">, AllTypesMatch<["dest", "src"]>]> {
+  let summary = "Outputs a foreign value to an output port";
+  let description = [{
+    Output Operation of Foreign Value:
+    ```
+      firrtl.foreign_output %dest, %src : t1
+    ```
+    Dest must be an output port.  Only one foreign_output can be connected to
+    each output port.
+    }];
+
+  let arguments = (ins ForeignType:$dest, ForeignType:$src);
+  let results = (outs);
+
+  let assemblyFormat =
+    "$dest `,` $src  attr-dict `:` type($dest)";
+
+  let hasVerifier = 1;
+}
+
+
 
 def SameAnonTypeOperands: PredOpTrait<
         "operands must be structurally equivalent",

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -53,14 +53,14 @@ def ConnectOp : FIRRTLOp<"connect", [FConnectLike]> {
 }
 
 def ForeignOutputOp : FIRRTLOp<"foreign_output", [HasParent<"FModuleOp">, AllTypesMatch<["dest", "src"]>]> {
-  let summary = "Outputs a foreign value to an output port";
+  let summary = "Outputs a foreign value to an output port or instance port";
   let description = [{
-    Output Operation of Foreign Value:
+    Transport Foreign Values at module boundaries:
     ```
       firrtl.foreign_output %dest, %src : t1
     ```
-    Dest must be an output port.  Only one foreign_output can be connected to
-    each output port.
+    Dest must be an output port of a module or an input port of an instance.  
+    Only one foreign_output can be connected to each of these types of values.
     }];
 
   let arguments = (ins ForeignType:$dest, ForeignType:$src);

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -27,6 +27,10 @@ namespace firrtl {
 void emitConnect(OpBuilder &builder, Location loc, Value lhs, Value rhs);
 void emitConnect(ImplicitLocOpBuilder &builder, Value lhs, Value rhs);
 
+/// Find the op which writes to a foreign type either of an instance or an
+/// output module port.
+ForeignOutputOp getForeignOutputOf(Value value);
+
 /// Utiility for generating a constant attribute.
 IntegerAttr getIntAttr(Type type, const APInt &value);
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -235,9 +235,9 @@ public:
   ResultType dispatchStmtVisitor(Operation *op, ExtraArgs... args) {
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
-        .template Case<AttachOp, ConnectOp, MatchingConnectOp, RefDefineOp,
-                       ForceOp, PrintFOp, SkipOp, StopOp, WhenOp, AssertOp,
-                       AssumeOp, CoverOp, PropAssignOp, RefForceOp,
+        .template Case<AttachOp, ConnectOp, MatchingConnectOp, ForeignOutputOp,
+                       RefDefineOp, ForceOp, PrintFOp, SkipOp, StopOp, WhenOp,
+                       AssertOp, AssumeOp, CoverOp, PropAssignOp, RefForceOp,
                        RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp,
                        FPGAProbeIntrinsicOp, VerifAssertIntrinsicOp,
                        VerifAssumeIntrinsicOp, UnclockedAssumeIntrinsicOp,
@@ -270,6 +270,7 @@ public:
   HANDLE(AttachOp);
   HANDLE(ConnectOp);
   HANDLE(MatchingConnectOp);
+  HANDLE(ForeignOutputOp);
   HANDLE(RefDefineOp);
   HANDLE(ForceOp);
   HANDLE(PrintFOp);

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -3654,6 +3654,18 @@ LogicalResult MatchingConnectOp::verify() {
   return success();
 }
 
+LogicalResult ForeignOutputOp::verify() {
+  // Check that the flows make sense.
+  if (failed(checkConnectFlow(*this)))
+    return failure();
+
+  if (!isa<BlockArgument>(getDest()) &&
+      !isa<InstanceOp>(getDest().getDefiningOp()))
+    return emitError("foreign output destination must be an instance or port");
+
+  return success();
+}
+
 LogicalResult RefDefineOp::verify() {
   // Check that the flows make sense.
   if (failed(checkConnectFlow(*this)))

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -1551,6 +1551,12 @@ LogicalResult FModuleOp::verify() {
           "block argument locations should match signature locations");
   }
 
+  for (auto arg : body->getArguments())
+    if (!isa<FIRRTLType>(arg.getType()) &&
+        getPortDirection(arg.getArgNumber()) == Direction::Out &&
+        !arg.hasOneUse())
+      return emitOpError("output foreign port should have exactly one use");
+
   return success();
 }
 
@@ -3662,6 +3668,10 @@ LogicalResult ForeignOutputOp::verify() {
   if (!isa<BlockArgument>(getDest()) &&
       !isa<InstanceOp>(getDest().getDefiningOp()))
     return emitError("foreign output destination must be an instance or port");
+
+  if (!getDest().hasOneUse())
+    return emitError(
+        "foreign value in instance or module must have only one user");
 
   return success();
 }

--- a/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLReductions.cpp
@@ -373,12 +373,12 @@ struct InstanceStubber : public OpReduction<firrtl::InstanceOp> {
       auto result = instOp.getResult(i);
       auto name = builder.getStringAttr(Twine(instOp.getName()) + "_" +
                                         instOp.getPortNameStr(i));
-      auto wire =
-          builder
-              .create<firrtl::WireOp>(result.getType(), name,
-                                      firrtl::NameKindEnum::DroppableName,
-                                      instOp.getPortAnnotation(i), StringAttr{})
-              .getResult();
+      auto wire = builder
+                      .create<firrtl::WireOp>(
+                          cast<::circt::firrtl::FIRRTLType>(result.getType()),
+                          name, firrtl::NameKindEnum::DroppableName,
+                          instOp.getPortAnnotation(i), StringAttr{})
+                      .getResult();
       invalidateOutputs(builder, wire, invalidCache,
                         instOp.getPortDirection(i) == firrtl::Direction::In);
       result.replaceAllUsesWith(wire);
@@ -423,12 +423,12 @@ struct MemoryStubber : public OpReduction<firrtl::MemOp> {
       auto result = memOp.getResult(i);
       auto name = builder.getStringAttr(Twine(memOp.getName()) + "_" +
                                         memOp.getPortNameStr(i));
-      auto wire =
-          builder
-              .create<firrtl::WireOp>(result.getType(), name,
-                                      firrtl::NameKindEnum::DroppableName,
-                                      memOp.getPortAnnotation(i), StringAttr{})
-              .getResult();
+      auto wire = builder
+                      .create<firrtl::WireOp>(
+                          cast<firrtl::FIRRTLType>(result.getType()), name,
+                          firrtl::NameKindEnum::DroppableName,
+                          memOp.getPortAnnotation(i), StringAttr{})
+                      .getResult();
       invalidateOutputs(builder, wire, invalidCache, true);
       result.replaceAllUsesWith(wire);
 
@@ -671,7 +671,7 @@ struct ExtmoduleInstanceRemover : public OpReduction<firrtl::InstanceOp> {
       auto wire =
           builder
               .create<firrtl::WireOp>(
-                  info.type,
+                  cast<firrtl::FIRRTLType>(info.type),
                   (Twine(instOp.getName()) + "_" + info.getName()).str())
               .getResult();
       if (info.isOutput()) {
@@ -785,8 +785,9 @@ struct ConnectSourceOperandForwarder : public Reduction {
     Value newDest;
     if (auto wire = dyn_cast<firrtl::WireOp>(destOp))
       newDest = builder
-                    .create<firrtl::WireOp>(forwardedOperand.getType(),
-                                            wire.getName())
+                    .create<firrtl::WireOp>(
+                        cast<firrtl::FIRRTLType>(forwardedOperand.getType()),
+                        wire.getName())
                     .getResult();
     else {
       auto regName = destOp->getAttrOfType<StringAttr>("name");
@@ -850,7 +851,7 @@ struct DetachSubaccesses : public Reduction {
           op->getLoc(), firrtl::ClockType::get(op->getContext()));
     for (Operation *user : llvm::make_early_inc_range(op->getUsers())) {
       builder.setInsertionPoint(user);
-      auto type = user->getResult(0).getType();
+      auto type = cast<circt::firrtl::FIRRTLType>(user->getResult(0).getType());
       Operation *replOp;
       if (isWire)
         replOp = builder.create<firrtl::WireOp>(user->getLoc(), type);
@@ -911,12 +912,12 @@ struct EagerInliner : public OpReduction<firrtl::InstanceOp> {
       auto result = instOp.getResult(i);
       auto name = builder.getStringAttr(Twine(instOp.getName()) + "_" +
                                         instOp.getPortNameStr(i));
-      auto wire =
-          builder
-              .create<firrtl::WireOp>(result.getType(), name,
-                                      firrtl::NameKindEnum::DroppableName,
-                                      instOp.getPortAnnotation(i), StringAttr{})
-              .getResult();
+      auto wire = builder
+                      .create<firrtl::WireOp>(
+                          cast<firrtl::FIRRTLType>(result.getType()), name,
+                          firrtl::NameKindEnum::DroppableName,
+                          instOp.getPortAnnotation(i), StringAttr{})
+                      .getResult();
       result.replaceAllUsesWith(wire);
       argReplacements.push_back(wire);
     }

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -164,6 +164,24 @@ void circt::firrtl::emitConnect(ImplicitLocOpBuilder &builder, Value dst,
     builder.create<ConnectOp>(dst, src);
 }
 
+ForeignOutputOp circt::firrtl::getForeignOutputOf(Value value) {
+  ForeignOutputOp result;
+  for (auto &use : value.getUses()) {
+    auto match = dyn_cast<ForeignOutputOp>(use.getOwner());
+    // any non-output uses cancel this.
+    if (!match)
+      return {};
+    // Must be the dest, not the src
+    if (use.getOperandNumber() != 0)
+      return {};
+    // Multiple outputs
+    if (result)
+      return {};
+    result = match;
+  }
+  return result;
+}
+
 IntegerAttr circt::firrtl::getIntAttr(Type type, const APInt &value) {
   auto intType = type_cast<IntType>(type);
   assert((!intType.hasWidth() ||

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3204,7 +3204,7 @@ ParseResult FIRStmtParser::parseRWProbeStaticRefExp(FieldRef &refResult,
         }
 
         // Otherwise, replace with bounce wire.
-        auto type = instResult.getType();
+        auto type = type_cast<FIRRTLType>(instResult.getType());
 
         // Either entire instance result is forceable + bounce wire, or reject.
         // (even if rwprobe is of a portion of the port)

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1520,8 +1520,10 @@ void fixupAllModules(InstanceGraph &instanceGraph) {
           continue;
         // If the type changed we transform it back to the old type with an
         // intermediate wire.
-        auto wire =
-            builder.create<WireOp>(oldType, inst.getPortName(i)).getResult();
+        auto wire = builder
+                        .create<WireOp>(type_cast<FIRRTLType>(oldType),
+                                        inst.getPortName(i))
+                        .getResult();
         result.replaceAllUsesWith(wire);
         result.setType(newType);
         if (inst.getPortDirection(i) == Direction::Out)

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -124,12 +124,13 @@ struct FlattenMemoryPass
       for (size_t index = 0, rend = memOp.getNumResults(); index < rend;
            ++index) {
         auto result = memOp.getResult(index);
-        auto wire = builder
-                        .create<WireOp>(result.getType(),
-                                        (memOp.getName() + "_" +
-                                         memOp.getPortName(index).getValue())
-                                            .str())
-                        .getResult();
+        auto wire =
+            builder
+                .create<WireOp>(type_cast<FIRRTLBaseType>(result.getType()),
+                                (memOp.getName() + "_" +
+                                 memOp.getPortName(index).getValue())
+                                    .str())
+                .getResult();
         result.replaceAllUsesWith(wire);
         result = wire;
         auto newResult = flatMem.getResult(index);

--- a/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMDeadCodeElim.cpp
@@ -612,7 +612,8 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
       return;
     }
 
-    Value wire = builder.create<WireOp>(result.getType()).getResult();
+    Value wire =
+        builder.create<WireOp>(cast<FIRRTLType>(result.getType())).getResult();
     result.replaceAllUsesWith(wire);
     // If a module port is dead but its instance result is alive, the port
     // is used as a temporary wire so make sure that a replaced wire is
@@ -673,7 +674,8 @@ void IMDeadCodeElimPass::rewriteModuleSignature(FModuleOp module) {
 
       // Ok, this port is used only within its defined module. So we can replace
       // the port with a wire.
-      auto wire = builder.create<WireOp>(argument.getType()).getResult();
+      auto wire = builder.create<WireOp>(cast<FIRRTLType>(argument.getType()))
+                      .getResult();
 
       // Since `liveSet` contains the port, we have to erase it from the set.
       liveElements.erase(argument);

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
@@ -89,7 +89,9 @@ void LowerIntmodulesPass::runOnOperation() {
       for (auto [idx, result] : llvm::enumerate(inst.getResults())) {
         // Replace inputs with wires that will be used as operands.
         if (inst.getPortDirection(idx) != Direction::Out) {
-          auto w = builder.create<WireOp>(result.getLoc(), result.getType())
+          auto w = builder
+                       .create<WireOp>(result.getLoc(),
+                                       cast<FIRRTLType>(result.getType()))
                        .getResult();
           result.replaceAllUsesWith(w);
           inputs.push_back(w);
@@ -174,7 +176,9 @@ void LowerIntmodulesPass::runOnOperation() {
         ImplicitLocOpBuilder builder(op.getLoc(), inst);
         auto replaceResults = [](OpBuilder &b, auto &&range) {
           return llvm::map_to_vector(range, [&b](auto v) {
-            auto w = b.create<WireOp>(v.getLoc(), v.getType()).getResult();
+            Value w =
+                b.create<WireOp>(v.getLoc(), cast<FIRRTLType>(v.getType()))
+                    .getResult();
             v.replaceAllUsesWith(w);
             return w;
           });

--- a/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerOpenAggs.cpp
@@ -69,7 +69,7 @@ struct NonHWField {
 };
 
 /// Structure that describes how a given operation with a type (which may or may
-/// not contain non-hw typess) should be lowered to one or more operations with
+/// not contain non-hw types) should be lowered to one or more operations with
 /// other types.
 struct MappingInfo {
   /// Preserve this type.  Map any uses of old directly to new.
@@ -78,7 +78,7 @@ struct MappingInfo {
   // When not identity, the type will be split:
 
   /// Type of the hardware-only portion.  May be null, indicating all non-hw.
-  Type hwType;
+  FIRRTLType hwType;
 
   /// List of the individual non-hw fields to be split out.
   SmallVector<NonHWField, 0> fields;

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -404,7 +404,7 @@ struct MemToRegOfVecPass
       // Create a temporary wire to replace the memory port. This makes it
       // simpler to delete the memOp.
       auto wire = builder.create<WireOp>(
-          result.getType(),
+          type_cast<FIRRTLBaseType>(result.getType()),
           (memOp.getName() + "_" + memOp.getPortName(index).getValue()).str(),
           memOp.getNameKind());
       result.replaceAllUsesWith(wire.getResult());

--- a/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RemoveUnusedPorts.cpp
@@ -106,7 +106,7 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
         // Replace the port with a wire if it is unused.
         auto builder = ImplicitLocOpBuilder::atBlockBegin(
             arg.getLoc(), module.getBodyBlock());
-        auto wire = builder.create<WireOp>(arg.getType());
+        auto wire = builder.create<WireOp>(cast<FIRRTLType>(arg.getType()));
         arg.replaceAllUsesWith(wire.getResult());
         outputPortConstants.push_back(std::nullopt);
       } else if (arg.hasOneUse()) {
@@ -163,7 +163,8 @@ void RemoveUnusedPortsPass::removeUnusedModulePorts(
       // If the port is input, replace the port with an unwritten wire
       // so that we can remove use-chains in SV dialect canonicalization.
       if (ports[index].isInput()) {
-        WireOp wire = builder.create<WireOp>(result.getType());
+        WireOp wire =
+            builder.create<WireOp>(cast<FIRRTLType>(result.getType()));
 
         // Check that the input port is only written. Sometimes input ports are
         // used as temporary wires. In that case, we cannot erase connections.

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1257,20 +1257,12 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.matchingconnect %y, %0 : f32
   }
 
-  // CHECK-LABEL: hw.module @wiresWithForeignTypes
+  // CHECK-LABEL: hw.module @WithForeignTypes
   // CHECK-SAME:      (in %in : f32, out out : f32) {
-  // CHECK-NEXT:    [[ADD1:%.+]] = arith.addf [[ADD2:%.+]], [[ADD2]] : f32
-  // CHECK-NEXT:    [[ADD2]] = arith.addf %in, [[ADD2]] : f32
-  // CHECK-NEXT:    hw.output [[ADD1]] : f32
+  // CHECK-NEXT:    hw.output %in : f32
   // CHECK-NEXT:  }
-  firrtl.module @wiresWithForeignTypes(in %in: f32, out %out: f32) {
-    %w1 = firrtl.wire : f32
-    %w2 = firrtl.wire : f32
-    firrtl.matchingconnect %out, %w2 : f32
-    %0 = arith.addf %w1, %w1 : f32
-    firrtl.matchingconnect %w2, %0 : f32
-    %1 = arith.addf %in, %w1 : f32
-    firrtl.matchingconnect %w1, %1 : f32
+  firrtl.module @WithForeignTypes(in %in: f32, out %out: f32) {
+    firrtl.foreign_output %out, %in : f32
   }
 
   // CHECK-LABEL: LowerReadArrayInoutIntoArrayGet

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -340,15 +340,12 @@ firrtl.module @ShouldAdjustExtModule2() {
 
 // Should not crash if there are connects with foreign types.
 // CHECK-LABEL: firrtl.module @ForeignTypes
-firrtl.module @ForeignTypes(out %out: !firrtl.reset) {
-  %0 = firrtl.wire : index
-  %1 = firrtl.wire : index
-  firrtl.matchingconnect %0, %1 : index
-  // CHECK-NEXT: [[W0:%.+]] = firrtl.wire : index
-  // CHECK-NEXT: [[W1:%.+]] = firrtl.wire : index
-  // CHECK-NEXT: firrtl.matchingconnect [[W0]], [[W1]] : index
+firrtl.module @ForeignTypes(in %in: index, out %out: index, out %rout: !firrtl.reset) {
+  firrtl.foreign_output %out, %in : index
+  // CHECK-NEXT: firrtl.foreign_output %out, %in : index
+  // CHECK: firrtl.connect %rout
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  firrtl.connect %out, %c1_ui1 : !firrtl.reset, !firrtl.uint<1>
+  firrtl.connect %rout, %c1_ui1 : !firrtl.reset, !firrtl.uint<1>
 }
 
 

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -918,14 +918,9 @@ firrtl.circuit "Foo" {
   }
 
   // CHECK-LABEL: @ForeignTypes
-  firrtl.module @ForeignTypes(in %a: !firrtl.uint<42>, out %b: !firrtl.uint) {
-    %0 = firrtl.wire : index
-    %1 = firrtl.wire : index
-    firrtl.matchingconnect %0, %1 : index
-    firrtl.connect %b, %a : !firrtl.uint, !firrtl.uint<42>
-    // CHECK-NEXT: [[W0:%.+]] = firrtl.wire : index
-    // CHECK-NEXT: [[W1:%.+]] = firrtl.wire : index
-    // CHECK-NEXT: firrtl.matchingconnect [[W0]], [[W1]] : index
+  firrtl.module @ForeignTypes(in %a: index, out %b: index) {
+    firrtl.foreign_output %b, %a : index
+    // CHECK-NEXT: firrtl.foreign_output %b, %a : index
   }
 
   // CHECK-LABEL: @Issue4859

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1213,9 +1213,9 @@ firrtl.module private @is1436_FOO() {
   }
 
   // COMMON-LABEL: firrtl.module private @ForeignTypes
-  firrtl.module private @ForeignTypes() {
-    // COMMON-NEXT: firrtl.wire : index
-    %0 = firrtl.wire : index
+  firrtl.module private @ForeignTypes(in %in : index, out %out : index) {
+    // COMMON-NEXT: firrtl.foreign_output %out, %in : index
+    firrtl.foreign_output %out, %in : index
   }
 
   // CHECK-LABEL: firrtl.module @MergeBundle


### PR DESCRIPTION
This forces dialects to handle storing their own types in their own ops and not tie them to firrtl connect semantics.  To make this a bit easier, a new connect-like operation exists only for setting the value of foreign-typed output ports and instance inputs.

With this, no foreign types may appear ONLY as module port types and will not appear in any (except foreign_output) firrtl operation or type.

There's a fair amount of simplification this will allow in the various passes' logic.