### PR TITLE
[Verif] Add `verif.bmc` operation

### DIFF
--- a/include/circt/Dialect/Verif/VerifDialect.td
+++ b/include/circt/Dialect/Verif/VerifDialect.td
@@ -20,6 +20,10 @@ def VerifDialect : Dialect {
 
   // This will be the default after next LLVM bump.
   let usePropertiesForAttributes = 1;
+
+  let dependentDialects = [
+    "circt::seq::SeqDialect"
+  ];
 }
 
 #endif // CIRCT_DIALECT_VERIF_VERIFDIALECT_TD

--- a/include/circt/Dialect/Verif/VerifOps.h
+++ b/include/circt/Dialect/Verif/VerifOps.h
@@ -11,6 +11,7 @@
 
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/Seq/SeqTypes.h"
 #include "circt/Dialect/Verif/VerifDialect.h"
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"

--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -176,8 +176,14 @@ def BMCOp : VerifOp<"bmc", [
   let summary = "Perform a bounded model check";
   let description = [{
     This operation represents a bounded model checking problem explicitly in
-    the IR. The `circuit` region contains the circuit (alongside the `verif`
-    property checking operations) to be checked.
+    the IR. The `bound` attribute indicates how many times the `circuit` region
+    should be executed, and `num_regs` indicates the number of registers in the
+    design that have been externalised and appended to the region's
+    inputs/outputs (these values are fed from each `circuit` region execution
+    to the next, as they represent register state, rather than being
+    overwritten with fresh variables like other inputs). The `circuit` region
+    contains the circuit (alongside the `verif` property checking operations)
+    to be checked.
 
     The `init` region contains the logic to initialize the clock signals, and
     will be executed once before any other region - it cannot take any

--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -169,7 +169,7 @@ def HasBeenResetOp : VerifOp<"has_been_reset", [Pure]> {
 // Logical Equivalence Checking and Model Checking
 //===----------------------------------------------------------------------===//
 
-def BMCOp : VerifOp<"bmc", [
+def BoundedModelCheckingOp : VerifOp<"bmc", [
   IsolatedFromAbove,
   SingleBlockImplicitTerminator<"verif::YieldOp">,
 ]> {
@@ -246,7 +246,7 @@ def LogicEquivalenceCheckingOp : VerifOp<"lec", [
 
 def YieldOp : VerifOp<"yield", [
   Terminator,
-  ParentOneOf<["verif::LogicEquivalenceCheckingOp", "verif::BMCOp"]>
+  ParentOneOf<["verif::LogicEquivalenceCheckingOp", "verif::BoundedModelCheckingOp"]>
 ]> {
   let summary = "yields values from a region";
 

--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -169,6 +169,46 @@ def HasBeenResetOp : VerifOp<"has_been_reset", [Pure]> {
 // Logical Equivalence Checking and Model Checking
 //===----------------------------------------------------------------------===//
 
+def BMCOp : VerifOp<"bmc", [
+  IsolatedFromAbove,
+  SingleBlockImplicitTerminator<"verif::YieldOp">,
+]> {
+  let summary = "Perform a bounded model check";
+  let description = [{
+    This operation represents a bounded model checking problem explicitly in
+    the IR. The `circuit` region contains the circuit (alongside the `verif`
+    property checking operations) to be checked.
+
+    The `init` region contains the logic to initialize the clock signals, and
+    will be executed once before any other region - it cannot take any
+    arguments, and should return as many `!seq.clock` values as the `circuit`
+    region has `!seq.clock` arguments, followed by any initial arguments of
+    'state' arguments to be fed to the `loop` region (see below).
+
+    The `loop` region contains the logic to advance the clock signals, and will
+    be executed after each execution of the `circuit` region. It must have all
+    the arguments that the `circuit` region has, but these can be followed by
+    additional 'state' arguments to represent e.g. which clock should be
+    toggled next. The `loop` region should yield as many `!seq.clock` values as
+    the `circuit` region has `!seq.clock` arguments, followed by the updated
+    values of all 'state' arguments.
+  }];
+
+  let arguments = (ins I32Attr:$bound, I32Attr:$num_regs);
+  let regions = (region SizedRegion<1>:$init,
+                        SizedRegion<1>:$loop,
+                        SizedRegion<1>:$circuit);
+
+  let results = (outs I1:$result);
+
+  let assemblyFormat = [{
+    `bound` $bound `num_regs` $num_regs attr-dict-with-keyword `init` $init `loop` $loop `circuit`
+    $circuit
+  }];
+
+  let hasRegionVerifier = true;
+}
+
 def LogicEquivalenceCheckingOp : VerifOp<"lec", [
   IsolatedFromAbove,
   SingleBlockImplicitTerminator<"verif::YieldOp">,
@@ -200,7 +240,7 @@ def LogicEquivalenceCheckingOp : VerifOp<"lec", [
 
 def YieldOp : VerifOp<"yield", [
   Terminator,
-  ParentOneOf<["verif::LogicEquivalenceCheckingOp"]>
+  ParentOneOf<["verif::LogicEquivalenceCheckingOp", "verif::BMCOp"]>
 ]> {
   let summary = "yields values from a region";
 

--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -192,12 +192,12 @@ def BMCOp : VerifOp<"bmc", [
     'state' arguments to be fed to the `loop` region (see below).
 
     The `loop` region contains the logic to advance the clock signals, and will
-    be executed after each execution of the `circuit` region. It must have all
-    the arguments that the `circuit` region has, but these can be followed by
-    additional 'state' arguments to represent e.g. which clock should be
-    toggled next. The `loop` region should yield as many `!seq.clock` values as
-    the `circuit` region has `!seq.clock` arguments, followed by the updated
-    values of all 'state' arguments.
+    be executed after each execution of the `circuit` region. It should take as
+    arguments as many `!seq.clock` values as the `circuit` region has, and
+    these can be followed by additional 'state' arguments to represent e.g.
+    which clock should be toggled next. The types yielded should be the same,
+    as this region yields the updated clock and state values (this should also
+    match the types yielded by the `init` region).
   }];
 
   let arguments = (ins I32Attr:$bound, I32Attr:$num_regs);

--- a/lib/Dialect/Verif/CMakeLists.txt
+++ b/lib/Dialect/Verif/CMakeLists.txt
@@ -14,6 +14,7 @@ add_circt_dialect_library(CIRCTVerif
   LINK_LIBS PUBLIC
   CIRCTHW
   CIRCTLTL
+  CIRCTSeq
   MLIRIR
   MLIRTransforms
 )

--- a/lib/Dialect/Verif/VerifOps.cpp
+++ b/lib/Dialect/Verif/VerifOps.cpp
@@ -9,12 +9,14 @@
 #include "circt/Dialect/Verif/VerifOps.h"
 #include "circt/Dialect/LTL/LTLOps.h"
 #include "circt/Dialect/LTL/LTLTypes.h"
+#include "circt/Dialect/Seq/SeqTypes.h"
 #include "circt/Support/CustomDirectiveImpl.h"
 #include "circt/Support/FoldUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/TypeRange.h"
 #include "mlir/Interfaces/FunctionImplementation.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "llvm/ADT/MapVector.h"
@@ -104,6 +106,60 @@ LogicalResult LogicEquivalenceCheckingOp::verifyRegions() {
     return emitOpError()
            << "types of the yielded values of both regions must match";
 
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// BMCOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult BMCOp::verifyRegions() {
+  if (getInit().getArgumentTypes().size() != 0)
+    return emitOpError() << "init region must have no arguments";
+  if (getInit().front().getTerminator()->getOperandTypes() !=
+      getLoop().front().getTerminator()->getOperandTypes())
+    return emitOpError()
+           << "init and loop regions must yield the same types of values";
+  size_t totalClocks = 0;
+  for (auto input : getCircuit().getArgumentTypes())
+    if (isa<seq::ClockType>(input))
+      totalClocks++;
+  auto initYields = getInit().front().getTerminator()->getOperands();
+  // We know init and loop yields match, so only need to check one
+  if (initYields.size() < totalClocks)
+    return emitOpError()
+           << "init and loop regions must yield at least as many clock "
+              "values as there are clock arguments to the circuit region";
+  for (size_t i = 0; i < totalClocks; i++) {
+    if (!isa<seq::ClockType>(
+            getInit().front().getTerminator()->getOperand(i).getType()))
+      return emitOpError()
+             << "init and loop regions must yield as many clock values as "
+                "there are clock arguments in the circuit region "
+                "before any other values";
+  }
+  auto circuitArgTy = getCircuit().getArgumentTypes();
+  auto loopArgTy = getLoop().getArgumentTypes();
+  if (circuitArgTy.size() > loopArgTy.size())
+    return emitOpError()
+           << "loop region must have at least as many arguments as the circuit "
+              "region";
+  for (size_t i = 0; i < circuitArgTy.size(); i++)
+    if (circuitArgTy[i] != loopArgTy[i])
+      return emitOpError()
+             << "loop region must have the same arguments as the circuit "
+                "region before any state arguments";
+  auto loopYieldTy = getLoop().front().getTerminator()->getOperandTypes();
+  for (size_t i = 0; i < loopArgTy.size() - circuitArgTy.size(); i++)
+    if (loopArgTy[i + circuitArgTy.size()] != loopYieldTy[totalClocks + i])
+      return emitOpError() << "additional loop region arguments must match the "
+                              "types of the non-clock "
+                              "values yielded by the init and loop regions";
+  // Any model with no Assert or Cover ops is trivially satisfiable
+  if (getCircuit().getOps<AssertOp>().empty() &&
+      getCircuit().getOps<CoverOp>().empty())
+    return emitOpError() << "no property checked in circuit region, so model "
+                            "will be trivially satisfiable";
   return success();
 }
 

--- a/lib/Dialect/Verif/VerifOps.cpp
+++ b/lib/Dialect/Verif/VerifOps.cpp
@@ -143,11 +143,6 @@ LogicalResult BMCOp::verifyRegions() {
                 "there are clock arguments in the circuit region "
                 "before any other values";
   }
-  // Any model with no Assert or Cover ops is trivially satisfiable
-  if (getCircuit().getOps<AssertOp>().empty() &&
-      getCircuit().getOps<CoverOp>().empty())
-    return emitOpError() << "no property checked in circuit region, so model "
-                            "will be trivially satisfiable";
   return success();
 }
 

--- a/lib/Dialect/Verif/VerifOps.cpp
+++ b/lib/Dialect/Verif/VerifOps.cpp
@@ -110,10 +110,10 @@ LogicalResult LogicEquivalenceCheckingOp::verifyRegions() {
 }
 
 //===----------------------------------------------------------------------===//
-// BMCOp
+// BoundedModelCheckingOp
 //===----------------------------------------------------------------------===//
 
-LogicalResult BMCOp::verifyRegions() {
+LogicalResult BoundedModelCheckingOp::verifyRegions() {
   if (!getInit().getArgumentTypes().empty())
     return emitOpError() << "init region must have no arguments";
   auto *initYieldOp = getInit().front().getTerminator();

--- a/test/Dialect/Verif/basic.mlir
+++ b/test/Dialect/Verif/basic.mlir
@@ -96,7 +96,6 @@ verif.lec {verif.some_attr} first {
 // CHECK: }
 verif.bmc bound 10 num_regs 0 attributes {verif.some_attr} init {
 } loop {
-^bb0(%arg0: i32):
 } circuit {
 ^bb0(%arg0: i32):
   %false = hw.constant false
@@ -112,7 +111,7 @@ verif.bmc bound 10 num_regs 0 attributes {verif.some_attr} init {
 //CHECK:   verif.yield %{{.*}}, %{{.*}} : !seq.clock, i1
 //CHECK: }
 //CHECK: loop {
-//CHECK:   ^bb0(%{{.*}}: !seq.clock, %{{.*}}: i32, %{{.*}}: i32, %{{.*}}: i1):
+//CHECK:   ^bb0(%{{.*}}: !seq.clock, %{{.*}}: i1):
 //CHECK:   %{{.*}} = seq.from_clock %{{.*}}
 //CHECK:   %{{.*}} = hw.constant true
 //CHECK:   %{{.*}} = comb.xor %{{.*}}, %{{.*}} : i1
@@ -134,7 +133,7 @@ init {
   verif.yield %clk, %c0_i1 : !seq.clock, i1
 }
 loop {
-  ^bb0(%clk: !seq.clock, %arg0: i32, %state0: i32, %stateArg: i1):
+  ^bb0(%clk: !seq.clock, %stateArg: i1):
   %from_clock = seq.from_clock %clk
   %c-1_i1 = hw.constant -1 : i1
   %neg_clock = comb.xor %from_clock, %c-1_i1 : i1

--- a/test/Dialect/Verif/basic.mlir
+++ b/test/Dialect/Verif/basic.mlir
@@ -83,3 +83,73 @@ verif.lec {verif.some_attr} first {
 ^bb0(%arg0: i32, %arg1: i32):
   verif.yield %arg0, %arg1 : i32, i32 {verif.some_attr}
 }
+
+//===----------------------------------------------------------------------===//
+// Bounded Model Checking related operations
+//===----------------------------------------------------------------------===//
+
+// CHECK: verif.bmc bound 10 num_regs 0 attributes {verif.some_attr} init {
+// CHECK: } loop {
+// CHECK: } circuit {
+// CHECK: ^bb0(%{{.*}}):
+// CHECK: verif.yield %{{.*}} : i32
+// CHECK: }
+verif.bmc bound 10 num_regs 0 attributes {verif.some_attr} init {
+} loop {
+^bb0(%arg0: i32):
+} circuit {
+^bb0(%arg0: i32):
+  %false = hw.constant false
+  // Arbitrary assertion so op verifies
+  verif.assert %false : i1
+  verif.yield %arg0 : i32
+}
+
+//CHECK: verif.bmc bound 10 num_regs 1 attributes {verif.some_attr}
+//CHECK: init {
+//CHECK:   %{{.*}} = hw.constant false
+//CHECK:   %{{.*}} = seq.to_clock %{{.*}}
+//CHECK:   verif.yield %{{.*}}, %{{.*}} : !seq.clock, i1
+//CHECK: }
+//CHECK: loop {
+//CHECK:   ^bb0(%{{.*}}: !seq.clock, %{{.*}}: i32, %{{.*}}: i32, %{{.*}}: i1):
+//CHECK:   %{{.*}} = seq.from_clock %{{.*}}
+//CHECK:   %{{.*}} = hw.constant true
+//CHECK:   %{{.*}} = comb.xor %{{.*}}, %{{.*}} : i1
+//CHECK:   %{{.*}} = comb.xor %{{.*}}, %{{.*}} : i1
+//CHECK:   %{{.*}} = seq.to_clock %{{.*}}
+//CHECK:   verif.yield %{{.*}}, %{{.*}} : !seq.clock, i1
+//CHECK: }
+//CHECK: circuit {
+//CHECK: ^bb0(%{{.*}}: !seq.clock, %{{.*}}: i32, %{{.*}}: i32):
+//CHECK:   %{{.*}} = hw.constant -1 : i32
+//CHECK:   %{{.*}} = comb.add %{{.*}}, %{{.*}} : i32
+//CHECK:   %{{.*}} = comb.xor %{{.*}}, %{{.*}} : i32
+//CHECK:   verif.yield %{{.*}}, %{{.*}} : i32, i32
+//CHECK: }
+verif.bmc bound 10 num_regs 1 attributes {verif.some_attr}
+init {
+  %c0_i1 = hw.constant 0 : i1
+  %clk = seq.to_clock %c0_i1
+  verif.yield %clk, %c0_i1 : !seq.clock, i1
+}
+loop {
+  ^bb0(%clk: !seq.clock, %arg0: i32, %state0: i32, %stateArg: i1):
+  %from_clock = seq.from_clock %clk
+  %c-1_i1 = hw.constant -1 : i1
+  %neg_clock = comb.xor %from_clock, %c-1_i1 : i1
+  %newStateArg = comb.xor %stateArg, %c-1_i1 : i1
+  %newclk = seq.to_clock %neg_clock
+  verif.yield %newclk, %newStateArg : !seq.clock, i1
+}
+circuit {
+^bb0(%clk: !seq.clock, %arg0: i32, %state0: i32):
+  %c-1_i32 = hw.constant -1 : i32
+  %0 = comb.add %arg0, %state0 : i32
+  // %state0 is the result of a seq.compreg taking %0 as input
+  %2 = comb.xor %state0, %c-1_i32 : i32
+  %false = hw.constant false
+  // Arbitrary assertion so op verifies
+  verif.assert %false : i1
+  verif.yield %2, %0 : i32, i32
+}

--- a/test/Dialect/Verif/errors.mlir
+++ b/test/Dialect/Verif/errors.mlir
@@ -24,9 +24,9 @@ verif.lec first {
 
 // expected-error @below {{init region must have no arguments}}
 verif.bmc bound 10 num_regs 0 init {
-^bb0(%clk: !seq.clock, %arg0: i32):
+^bb0(%clk: !seq.clock):
 } loop {
-^bb0(%clk: !seq.clock, %arg0: i32):
+^bb0(%clk: !seq.clock):
 } circuit {
 ^bb0(%clk: !seq.clock, %arg0: i32):
   %true = hw.constant true
@@ -71,13 +71,31 @@ verif.bmc bound 10 num_regs 0 init {
 
 // -----
 
+// expected-error @below {{loop region arguments must match the types of the values yielded by the init and loop regions}}
+verif.bmc bound 10 num_regs 0 init {
+  %clkInit = hw.constant false
+  %toClk = seq.to_clock %clkInit
+  %c1_i2 = hw.constant 2 : i2
+  verif.yield %toClk, %c1_i2 : !seq.clock, i2
+} loop {
+^bb0(%clk1: !seq.clock, %state: i2, %arg0: i32):
+  verif.yield %clk1, %state : !seq.clock, i2
+} circuit {
+^bb0(%clk1: !seq.clock, %arg0: i32, %state: i1):
+  %true = hw.constant true
+  verif.assert %true : i1
+  verif.yield %arg0 : i32
+}
+
+// -----
+
 // expected-error @below {{init and loop regions must yield at least as many clock values as there are clock arguments to the circuit region}}
 verif.bmc bound 10 num_regs 0 init {
   %clkInit = hw.constant false
   %toClk = seq.to_clock %clkInit
   verif.yield %toClk: !seq.clock
 } loop {
-^bb0(%clk1: !seq.clock, %clk2: !seq.clock, %arg0: i32):
+^bb0(%clk1: !seq.clock):
   verif.yield %clk1 : !seq.clock
 } circuit {
 ^bb0(%clk1: !seq.clock, %clk2: !seq.clock, %arg0: i32):
@@ -94,79 +112,10 @@ verif.bmc bound 10 num_regs 0 init {
   %toClk = seq.to_clock %clkInit
   verif.yield %toClk, %clkInit, %toClk: !seq.clock, i1, !seq.clock
 } loop {
-^bb0(%clk1: !seq.clock, %clk2: !seq.clock, %arg0: i32, %state: i1):
+^bb0(%clk1: !seq.clock, %state: i1, %clk2: !seq.clock):
   verif.yield %clk1, %state, %clk2 : !seq.clock, i1, !seq.clock
 } circuit {
-^bb0(%clk1: !seq.clock, %clk2: !seq.clock, %arg0: i32, %state: i1):
-  %true = hw.constant true
-  verif.assert %true : i1
-  verif.yield %arg0 : i32
-}
-
-// -----
-
-// expected-error @below {{loop region must have at least as many arguments as the circuit region}}
-verif.bmc bound 10 num_regs 0 init {
-  %clkInit = hw.constant false
-  %toClk = seq.to_clock %clkInit
-  verif.yield %toClk:  !seq.clock
-} loop {
-^bb0(%clk1: !seq.clock):
-  verif.yield %clk1 : !seq.clock
-} circuit {
-^bb0(%clk1: !seq.clock, %state: i1):
-  %true = hw.constant true
-  verif.assert %true : i1
-  verif.yield
-}
-
-// -----
-
-// expected-error @below {{loop region must have the same arguments as the circuit region before any state arguments}}
-verif.bmc bound 10 num_regs 0 init {
-  %clkInit = hw.constant false
-  %toClk = seq.to_clock %clkInit
-  verif.yield %toClk: !seq.clock
-} loop {
-^bb0(%clk1: !seq.clock, %arg0: i32, %arg1: i1):
-  verif.yield %clk1 : !seq.clock
-} circuit {
-^bb0(%clk1: !seq.clock, %arg0: i32, %arg1: i32):
-  %true = hw.constant true
-  verif.assert %true : i1
-  verif.yield %arg0 : i32
-}
-
-// -----
-
-// expected-error @below {{loop region must have the same arguments as the circuit region before any state arguments}}
-verif.bmc bound 10 num_regs 0 init {
-  %clkInit = hw.constant false
-  %toClk = seq.to_clock %clkInit
-  verif.yield %toClk: !seq.clock
-} loop {
-^bb0(%clk1: !seq.clock, %arg0: i32, %arg1: i32):
-  verif.yield %clk1 : !seq.clock
-} circuit {
-^bb0(%clk1: !seq.clock, %arg0: i1, %arg1: i32):
-  %true = hw.constant true
-  verif.assert %true : i1
-  verif.yield %arg1 : i32
-}
-
-// -----
-
-// expected-error @below {{additional loop region arguments must match the types of the non-clock values yielded by the init and loop regions}}
-verif.bmc bound 10 num_regs 0 init {
-  %clkInit = hw.constant false
-  %toClk = seq.to_clock %clkInit
-  verif.yield %toClk, %clkInit: !seq.clock, i1
-} loop {
-^bb0(%clk1: !seq.clock, %arg0: i32, %arg1: i2):
-  %true = hw.constant true
-  verif.yield %clk1, %true : !seq.clock, i1
-} circuit {
-^bb0(%clk1: !seq.clock, %arg0: i32):
+^bb0(%clk1: !seq.clock, %clk2: !seq.clock, %arg0: i32):
   %true = hw.constant true
   verif.assert %true : i1
   verif.yield %arg0 : i32

--- a/test/Dialect/Verif/errors.mlir
+++ b/test/Dialect/Verif/errors.mlir
@@ -120,11 +120,3 @@ verif.bmc bound 10 num_regs 0 init {
   verif.assert %true : i1
   verif.yield %arg0 : i32
 }
-
-// -----
-
-// expected-error @below {{no property checked in circuit region, so model will be trivially satisfiable}}
-verif.bmc bound 10 num_regs 0 init {
-} loop {
-} circuit {
-}

--- a/test/Dialect/Verif/errors.mlir
+++ b/test/Dialect/Verif/errors.mlir
@@ -19,3 +19,163 @@ verif.lec first {
 ^bb0(%arg0: i32):
   verif.yield %arg0 : i32
 }
+
+// -----
+
+// expected-error @below {{init region must have no arguments}}
+verif.bmc bound 10 num_regs 0 init {
+^bb0(%clk: !seq.clock, %arg0: i32):
+} loop {
+^bb0(%clk: !seq.clock, %arg0: i32):
+} circuit {
+^bb0(%clk: !seq.clock, %arg0: i32):
+  %true = hw.constant true
+  verif.assert %true : i1
+  verif.yield %arg0 : i32
+}
+
+// -----
+
+// expected-error @below {{init and loop regions must yield the same types of values}}
+verif.bmc bound 10 num_regs 0 init {
+  %clkInit = hw.constant false
+  %toClk = seq.to_clock %clkInit
+  verif.yield %toClk, %toClk : !seq.clock, !seq.clock
+} loop {
+^bb0(%clk1: !seq.clock, %clk2: !seq.clock, %arg0: i32):
+  verif.yield %clk1, %arg0 : !seq.clock, i32
+} circuit {
+^bb0(%clk1: !seq.clock, %clk2: !seq.clock, %arg0: i32):
+  %true = hw.constant true
+  verif.assert %true : i1
+  verif.yield %arg0 : i32
+}
+
+// -----
+
+// expected-error @below {{init and loop regions must yield the same types of values}}
+verif.bmc bound 10 num_regs 0 init {
+  %clkInit = hw.constant false
+  %toClk = seq.to_clock %clkInit
+  %c1_i2 = hw.constant 2 : i2
+  verif.yield %toClk, %c1_i2 : !seq.clock, i2
+} loop {
+^bb0(%clk1: !seq.clock, %arg0: i32, %state: i1):
+  verif.yield %clk1, %state : !seq.clock, i1
+} circuit {
+^bb0(%clk1: !seq.clock, %arg0: i32, %state: i1):
+  %true = hw.constant true
+  verif.assert %true : i1
+  verif.yield %arg0 : i32
+}
+
+// -----
+
+// expected-error @below {{init and loop regions must yield at least as many clock values as there are clock arguments to the circuit region}}
+verif.bmc bound 10 num_regs 0 init {
+  %clkInit = hw.constant false
+  %toClk = seq.to_clock %clkInit
+  verif.yield %toClk: !seq.clock
+} loop {
+^bb0(%clk1: !seq.clock, %clk2: !seq.clock, %arg0: i32):
+  verif.yield %clk1 : !seq.clock
+} circuit {
+^bb0(%clk1: !seq.clock, %clk2: !seq.clock, %arg0: i32):
+  %true = hw.constant true
+  verif.assert %true : i1
+  verif.yield %arg0 : i32
+}
+
+// -----
+
+// expected-error @below {{init and loop regions must yield as many clock values as there are clock arguments in the circuit region before any other values}}
+verif.bmc bound 10 num_regs 0 init {
+  %clkInit = hw.constant false
+  %toClk = seq.to_clock %clkInit
+  verif.yield %toClk, %clkInit, %toClk: !seq.clock, i1, !seq.clock
+} loop {
+^bb0(%clk1: !seq.clock, %clk2: !seq.clock, %arg0: i32, %state: i1):
+  verif.yield %clk1, %state, %clk2 : !seq.clock, i1, !seq.clock
+} circuit {
+^bb0(%clk1: !seq.clock, %clk2: !seq.clock, %arg0: i32, %state: i1):
+  %true = hw.constant true
+  verif.assert %true : i1
+  verif.yield %arg0 : i32
+}
+
+// -----
+
+// expected-error @below {{loop region must have at least as many arguments as the circuit region}}
+verif.bmc bound 10 num_regs 0 init {
+  %clkInit = hw.constant false
+  %toClk = seq.to_clock %clkInit
+  verif.yield %toClk:  !seq.clock
+} loop {
+^bb0(%clk1: !seq.clock):
+  verif.yield %clk1 : !seq.clock
+} circuit {
+^bb0(%clk1: !seq.clock, %state: i1):
+  %true = hw.constant true
+  verif.assert %true : i1
+  verif.yield
+}
+
+// -----
+
+// expected-error @below {{loop region must have the same arguments as the circuit region before any state arguments}}
+verif.bmc bound 10 num_regs 0 init {
+  %clkInit = hw.constant false
+  %toClk = seq.to_clock %clkInit
+  verif.yield %toClk: !seq.clock
+} loop {
+^bb0(%clk1: !seq.clock, %arg0: i32, %arg1: i1):
+  verif.yield %clk1 : !seq.clock
+} circuit {
+^bb0(%clk1: !seq.clock, %arg0: i32, %arg1: i32):
+  %true = hw.constant true
+  verif.assert %true : i1
+  verif.yield %arg0 : i32
+}
+
+// -----
+
+// expected-error @below {{loop region must have the same arguments as the circuit region before any state arguments}}
+verif.bmc bound 10 num_regs 0 init {
+  %clkInit = hw.constant false
+  %toClk = seq.to_clock %clkInit
+  verif.yield %toClk: !seq.clock
+} loop {
+^bb0(%clk1: !seq.clock, %arg0: i32, %arg1: i32):
+  verif.yield %clk1 : !seq.clock
+} circuit {
+^bb0(%clk1: !seq.clock, %arg0: i1, %arg1: i32):
+  %true = hw.constant true
+  verif.assert %true : i1
+  verif.yield %arg1 : i32
+}
+
+// -----
+
+// expected-error @below {{additional loop region arguments must match the types of the non-clock values yielded by the init and loop regions}}
+verif.bmc bound 10 num_regs 0 init {
+  %clkInit = hw.constant false
+  %toClk = seq.to_clock %clkInit
+  verif.yield %toClk, %clkInit: !seq.clock, i1
+} loop {
+^bb0(%clk1: !seq.clock, %arg0: i32, %arg1: i2):
+  %true = hw.constant true
+  verif.yield %clk1, %true : !seq.clock, i1
+} circuit {
+^bb0(%clk1: !seq.clock, %arg0: i32):
+  %true = hw.constant true
+  verif.assert %true : i1
+  verif.yield %arg0 : i32
+}
+
+// -----
+
+// expected-error @below {{no property checked in circuit region, so model will be trivially satisfiable}}
+verif.bmc bound 10 num_regs 0 init {
+} loop {
+} circuit {
+}


### PR DESCRIPTION
This PR adds a `verif.bmc` op to encode bounded model checking problems. This op has three regions - the circuit to be checked (also necessarily containing a property to verify) and init and loop regions that allow clocks to be controlled as desired (to allow designs with multiple clocks to be checked down the line). These regions are allowed some extra state arguments, as is likely necessary for specifying clock interleavings (e.g. to say which clock's turn it is to be toggled next).
