### PR TITLE
[FIRRTL][HW] Change default implementation of CombDataFlow and add it to DPI intrinsic 

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -239,7 +239,7 @@ def InstanceChoiceOp : HardwareDeclOp<"instance_choice", [
 }
 
 
-def MemOp : HardwareDeclOp<"mem", [CombDataflow]> {
+def MemOp : HardwareDeclOp<"mem", [DeclareOpInterfaceMethods<CombDataflow>]> {
   let summary = "Define a new mem";
   let arguments =
     (ins ConfinedAttr<I32Attr, [IntMinValue<0>]>:$readLatency,
@@ -333,8 +333,6 @@ def MemOp : HardwareDeclOp<"mem", [CombDataflow]> {
 
     // Extract the relevant attributes from the MemOp and return a FirMemory object.
     FirMemory getSummary();
-
-    SmallVector<std::pair<circt::FieldRef, circt::FieldRef>> computeDataFlow();
   }];
 }
 
@@ -394,7 +392,7 @@ def NodeOp : HardwareDeclOp<"node", [
   let hasFolder = 1;
 }
 
-def RegOp : HardwareDeclOp<"reg", [Forceable, CombDataflow]> {
+def RegOp : HardwareDeclOp<"reg", [Forceable, DeclareOpInterfaceMethods<CombDataflow>]> {
   let summary = "Define a new register";
   let description = [{
     Declare a new register:
@@ -486,7 +484,7 @@ def RegOp : HardwareDeclOp<"reg", [Forceable, CombDataflow]> {
   let hasCanonicalizeMethod = true;
 }
 
-def RegResetOp : HardwareDeclOp<"regreset", [Forceable, CombDataflow]> {
+def RegResetOp : HardwareDeclOp<"regreset", [Forceable, DeclareOpInterfaceMethods<CombDataflow>]> {
   let summary = "Define a new register with a reset";
   let description = [{
     Declare a new register:

--- a/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLIntrinsics.td
@@ -206,7 +206,7 @@ def HasBeenResetIntrinsicOp : FIRRTLOp<"int.has_been_reset", [Pure]> {
 
 
 def DPICallIntrinsicOp : FIRRTLOp<"int.dpi.call",
-    [AttrSizedOperandSegments]> {
+    [AttrSizedOperandSegments, DeclareOpInterfaceMethods<CombDataflow>]> {
   let summary = "Import and call DPI function";
   let description = [{
     The `int.dpi.call` intrinsic calls an external function.

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -561,12 +561,9 @@ def CombDataflow : OpInterface<"CombDataFlow"> {
      This returns a pair of ground type fieldrefs. The first element is the destination
      and the second is the source of the dependence. The default implementation returns
      an empty list, which implies that the operation is not combinational.}],
-     "void", "computeDataFlow",
-     (ins "llvm::function_ref<void(circt::FieldRef, circt::FieldRef)>":$callback)>,
+     "SmallVector<std::pair<circt::FieldRef, circt::FieldRef>>", "computeDataFlow",
+     (ins)>,
   ];
-  let extraSharedClassDeclaration = [{
-    using CombDataFlowCallbackTy = llvm::function_ref<void(circt::FieldRef, circt::FieldRef)>;
-  }];
 }
 
 #endif

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -556,17 +556,17 @@ def CombDataflow : OpInterface<"CombDataFlow"> {
     combinational dependence from each operand to each result.
   }];
   let methods = [
-    InterfaceMethod<"Get the combinational dataflow relations between the"
-     "operands and the results. This returns a pair of ground type fieldrefs."
-     "The first element is the destination and the second is the source of"
-     "the dependence."
-     "The default implementation returns an empty list, which implies that the"
-     "operation is not combinational.",
-     "SmallVector<std::pair<circt::FieldRef, circt::FieldRef>>",
-     "computeDataFlow", (ins), [{}], /*defaultImplementation=*/[{
-      return {};
-    }]>,
+    InterfaceMethod<[{
+     Get the combinational dataflow relations between the operands and the results.
+     This returns a pair of ground type fieldrefs. The first element is the destination
+     and the second is the source of the dependence. The default implementation returns
+     an empty list, which implies that the operation is not combinational.}],
+     "void", "computeDataFlow",
+     (ins "llvm::function_ref<void(circt::FieldRef, circt::FieldRef)>":$callback)>,
   ];
+  let extraSharedClassDeclaration = [{
+    using CombDataFlowCallbackTy = llvm::function_ref<void(circt::FieldRef, circt::FieldRef)>;
+  }];
 }
 
 #endif

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -98,9 +98,9 @@ public:
           .Case<hw::CombDataFlow>([&](hw::CombDataFlow df) {
             // computeDataFlow returns a pair of FieldRefs, first element is the
             // destination and the second is the source.
-            df.computeDataFlow([&](FieldRef dest, FieldRef source) {
+            for(auto [dest, source] : df.computeDataFlow())
               addDrivenBy(dest, source);
-            });
+
           })
           .Case<Forceable>([&](Forceable forceableOp) {
             // Any declaration that can be forced.

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -98,8 +98,9 @@ public:
           .Case<hw::CombDataFlow>([&](hw::CombDataFlow df) {
             // computeDataFlow returns a pair of FieldRefs, first element is the
             // destination and the second is the source.
-            for (auto &dep : df.computeDataFlow())
-              addDrivenBy(dep.first, dep.second);
+            df.computeDataFlow([&](FieldRef dest, FieldRef source) {
+              addDrivenBy(dest, source);
+            });
           })
           .Case<Forceable>([&](Forceable forceableOp) {
             // Any declaration that can be forced.

--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -98,7 +98,7 @@ public:
           .Case<hw::CombDataFlow>([&](hw::CombDataFlow df) {
             // computeDataFlow returns a pair of FieldRefs, first element is the
             // destination and the second is the source.
-            for(auto [dest, source] : df.computeDataFlow())
+            for (auto [dest, source] : df.computeDataFlow())
               addDrivenBy(dest, source);
 
           })

--- a/test/Dialect/FIRRTL/check-comb-loops.mlir
+++ b/test/Dialect/FIRRTL/check-comb-loops.mlir
@@ -1107,3 +1107,27 @@ firrtl.circuit "MultipleConnects"   {
     firrtl.connect %w, %in : !firrtl.uint<8>, !firrtl.uint<8>
   }
 }
+
+// -----
+
+firrtl.circuit "DPI"   {
+  firrtl.module @DPI(in %clock: !firrtl.clock, in %enable: !firrtl.uint<1>, out %out_0: !firrtl.uint<8>) attributes {convention = #firrtl<convention scalarized>} {
+    %in = firrtl.wire : !firrtl.uint<8>
+    %0 = firrtl.int.dpi.call "clocked_result"(%in) clock %clock enable %enable : (!firrtl.uint<8>) -> !firrtl.uint<8>
+    firrtl.matchingconnect %in, %0 : !firrtl.uint<8>
+    firrtl.matchingconnect %out_0, %0 : !firrtl.uint<8>
+  }
+}
+
+
+// -----
+
+firrtl.circuit "DPI"   {
+  // expected-error @below {{detected combinational cycle in a FIRRTL module, sample path: DPI.{in <- ... <- in}}}
+  firrtl.module @DPI(in %clock: !firrtl.clock, in %enable: !firrtl.uint<1>, out %out_0: !firrtl.uint<8>) attributes {convention = #firrtl<convention scalarized>} {
+    %in = firrtl.wire : !firrtl.uint<8>
+    %0 = firrtl.int.dpi.call "unclocked_result"(%in) enable %enable : (!firrtl.uint<8>) -> !firrtl.uint<8>
+    firrtl.matchingconnect %in, %0 : !firrtl.uint<8>
+    firrtl.matchingconnect %out_0, %0 : !firrtl.uint<8>
+  }
+}


### PR DESCRIPTION
 This PR removes default implementation of CombDataFlow which indicate an op was sequential. Also implement it for DPI intrinsic.

Close https://github.com/llvm/circt/issues/7229