### PR TITLE
[FIRRTL] Ensure hierpath considers owning module in LowerClasses.

### DIFF
--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -430,3 +430,24 @@ firrtl.circuit "NonRootedPath" {
     %foo = firrtl.wire sym @wire {annotations = [{circt.nonlocal = @nla, class = "circt.tracker", id = distinct[0]<>}]} : !firrtl.uint<1>
   }
 }
+
+// CHECK-LABEL: firrtl.circuit "OwningModulePrefix"
+firrtl.circuit "OwningModulePrefix" {
+  // COM: Ensure the hierpath used in the path op starts at the owning module.
+  // CHECK: hw.hierpath private [[NLA:@.+]] [@OwningModule::{{.+}}]
+  hw.hierpath private @nla [@OwningModulePrefix::@sym0, @OwningModule::@sym1, @OwningModuleChild::@sym2]
+  firrtl.module @OwningModulePrefix() {
+    firrtl.instance owning_module sym @sym0 @OwningModule()
+  }
+  firrtl.module @OwningModule() {
+    firrtl.instance owning_module_child sym @sym1 @OwningModuleChild()
+    firrtl.object @OwningModuleClass()
+  }
+  firrtl.module @OwningModuleChild() {
+    %w = firrtl.wire sym @sym2 {annotations = [{class = "circt.tracker", id = distinct[0]<>, circt.nonlocal = @nla}]} : !firrtl.uint<0>
+  }
+  firrtl.class @OwningModuleClass() {
+    // CHECK: om.path_create reference %basepath [[NLA]]
+    firrtl.path reference distinct[0]<>
+  }
+}

--- a/test/firtool/classes-dedupe.fir
+++ b/test/firtool/classes-dedupe.fir
@@ -8,8 +8,8 @@ circuit Test : %[[
   "modules": ["~Test|CPU_1", "~Test|CPU_2"]
 }
 ]]
-  ; CHECK: hw.hierpath private [[NLA1:@.+]] [@Test::@sym, @CPU_1::[[SYM1:@.+]]]
-  ; CHECK: hw.hierpath private [[NLA2:@.+]] [@Test::@sym, @CPU_1::[[SYM2:@.+]], @Fetch_1::[[SYM3:@.+]]]
+  ; CHECK: hw.hierpath private [[NLA1:@.+]] [@CPU_1::[[SYM1:@.+]]]
+  ; CHECK: hw.hierpath private [[NLA2:@.+]] [@CPU_1::[[SYM2:@.+]], @Fetch_1::[[SYM3:@.+]]]
   module Test :
     input in : UInt<1>
     output out_1 : UInt<1>


### PR DESCRIPTION
We already had logic to detect if the owning module was in the middle of a hierarchical path, and build up the prefix just to the owning module in this case. However, we still used the entire original hierarchical path in the new path, which caused the prefix to the owning module to be duplicated. This is fixed by not only setting the moduleName to the owning module, but also trimming the prefix to the owning module in the original path.