### PR TITLE
[FIRRTL] Fix use-after-free in InferReset

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1723,6 +1723,11 @@ LogicalResult InferResetsPass::implementAsyncReset(FModuleOp module,
         // Don't delete the node, since it might be in use in worklists.
         nodeOp->replaceAllUsesWith(wireOp);
         nodeOp->removeAttr(nodeOp.getInnerSymAttrName());
+        nodeOp.setName("");
+        // Leave forcable alone, since we cannot remove a result.  It will be
+        // cleaned up in canonicalization since it is dead.  As will this node.
+        nodeOp.setNameKind(NameKindEnum::DroppableName);
+        nodeOp.setAnnotationsAttr(ArrayAttr::get(builder.getContext(), {}));
         builder.setInsertionPointAfter(nodeOp);
         emitConnect(builder, wireOp.getResult(), nodeOp.getResult());
         resetOp = wireOp;

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1714,14 +1714,17 @@ LogicalResult InferResetsPass::implementAsyncReset(FModuleOp module,
       if (nodeOp && !dom.dominates(nodeOp.getInput(), opsToUpdate[0])) {
         LLVM_DEBUG(llvm::dbgs()
                    << "- Promoting node to wire for move: " << nodeOp << "\n");
-        ImplicitLocOpBuilder builder(nodeOp.getLoc(), nodeOp);
+        auto builder = ImplicitLocOpBuilder::atBlockBegin(nodeOp.getLoc(),
+                                                          nodeOp->getBlock());
         auto wireOp = builder.create<WireOp>(
             nodeOp.getResult().getType(), nodeOp.getNameAttr(),
             nodeOp.getNameKindAttr(), nodeOp.getAnnotationsAttr(),
             nodeOp.getInnerSymAttr(), nodeOp.getForceableAttr());
-        emitConnect(builder, wireOp.getResult(), nodeOp.getInput());
+        // Don't delete the node, since it might be in use in worklists.
         nodeOp->replaceAllUsesWith(wireOp);
-        nodeOp.erase();
+        nodeOp->removeAttr(nodeOp.getInnerSymAttrName());
+        builder.setInsertionPointAfter(nodeOp);
+        emitConnect(builder, wireOp.getResult(), nodeOp.getResult());
         resetOp = wireOp;
         actualReset = wireOp.getResult();
         domain.existingValue = wireOp.getResult();


### PR DESCRIPTION
As @youngar explains well, a node was being deleted when it had references.  Just route the node through the bounce wire instead of trying to replace it.

Closes #7225