### PR TITLE
[FIRRTL][ModuleInliner] Add a prefix to memory instances

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -677,12 +677,9 @@ bool Inliner::rename(StringRef prefix, Operation *op, InliningLevel &il) {
 
   // Add a prefix to things that has a "name" attribute.  We don't prefix
   // memories since it will affect the name of the generated module.
-  // TODO: We should find a way to prefix the instance of a memory module.
-  if (!isa<MemOp, SeqMemOp, CombMemOp, MemoryPortOp>(op)) {
-    if (auto nameAttr = op->getAttrOfType<StringAttr>("name"))
-      op->setAttr("name", StringAttr::get(op->getContext(),
-                                          (prefix + nameAttr.getValue())));
-  }
+  if (auto nameAttr = op->getAttrOfType<StringAttr>("name"))
+    op->setAttr("name", StringAttr::get(op->getContext(),
+                                        (prefix + nameAttr.getValue())));
 
   // If the operation has an inner symbol, ensure that it is unique.  Record
   // renames for any NLAs that this participates in if the symbol was renamed.

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -675,8 +675,7 @@ bool Inliner::rename(StringRef prefix, Operation *op, InliningLevel &il) {
   if (auto scopeOp = dyn_cast<debug::ScopeOp>(op))
     return updateDebugScope(scopeOp), false;
 
-  // Add a prefix to things that has a "name" attribute.  We don't prefix
-  // memories since it will affect the name of the generated module.
+  // Add a prefix to things that has a "name" attribute.
   if (auto nameAttr = op->getAttrOfType<StringAttr>("name"))
     op->setAttr("name", StringAttr::get(op->getContext(),
                                         (prefix + nameAttr.getValue())));

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -256,11 +256,11 @@ firrtl.module @renaming() {
 }
 firrtl.module @declarations(in %clock : !firrtl.clock, in %u8 : !firrtl.uint<8>, in %reset : !firrtl.asyncreset) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
   %c0_ui8 = firrtl.constant 0 : !firrtl.uint<8>
-  // CHECK: %cmem = chirrtl.combmem : !chirrtl.cmemory<uint<8>, 8>
+  // CHECK: %myinst_cmem = chirrtl.combmem : !chirrtl.cmemory<uint<8>, 8>
   %cmem = chirrtl.combmem : !chirrtl.cmemory<uint<8>, 8>
-  // CHECK: %mem_read = firrtl.mem Undefined {depth = 1 : i64, name = "mem", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: sint<42>>
+  // CHECK: %myinst_mem_read = firrtl.mem Undefined {depth = 1 : i64, name = "myinst_mem", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: sint<42>>
   %mem_read = firrtl.mem Undefined {depth = 1 : i64, name = "mem", portNames = ["read"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: sint<42>>
-  // CHECK: %memoryport_data, %memoryport_port = chirrtl.memoryport Read %cmem {name = "memoryport"} : (!chirrtl.cmemory<uint<8>, 8>) -> (!firrtl.uint<8>, !chirrtl.cmemoryport)
+  // CHECK: %myinst_memoryport_data, %myinst_memoryport_port = chirrtl.memoryport Read %myinst_cmem {name = "myinst_memoryport"} : (!chirrtl.cmemory<uint<8>, 8>) -> (!firrtl.uint<8>, !chirrtl.cmemoryport)
   %memoryport_data, %memoryport_port = chirrtl.memoryport Read %cmem {name = "memoryport"} : (!chirrtl.cmemory<uint<8>, 8>) -> (!firrtl.uint<8>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %memoryport_port[%u8], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
   // CHECK: %myinst_node = firrtl.node %myinst_u8  : !firrtl.uint<8>
@@ -269,7 +269,7 @@ firrtl.module @declarations(in %clock : !firrtl.clock, in %u8 : !firrtl.uint<8>,
   %reg = firrtl.reg %clock {name = "reg"} : !firrtl.clock, !firrtl.uint<8>
   // CHECK: %myinst_regreset = firrtl.regreset %myinst_clock, %myinst_reset, %c0_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
   %regreset = firrtl.regreset %clock, %reset, %c0_ui8 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<8>, !firrtl.uint<8>
-  // CHECK: %smem = chirrtl.seqmem Undefined : !chirrtl.cmemory<uint<8>, 8>
+  // CHECK: %myinst_smem = chirrtl.seqmem Undefined : !chirrtl.cmemory<uint<8>, 8>
   %smem = chirrtl.seqmem Undefined : !chirrtl.cmemory<uint<8>, 8>
   // CHECK: %myinst_wire = firrtl.wire  : !firrtl.uint<1>
   %wire = firrtl.wire : !firrtl.uint<1>


### PR DESCRIPTION
This PR basically reverts https://github.com/llvm/circt/commit/4cf7bc9a300f9e05ddfc264e99526b4b88d5f93f to add a prefix to MemOp instances. Previously we changed to remove prefix since it broke prefixes created in PrefixModules. However https://github.com/llvm/circt/pull/4952 added `prefix` attribute to MemOp so we don't need the workaround anymore. This makes output verilog a lot more LEC friendly. I checked the PR doesn't break prefixes added by PrefixModules on internal designs.

```scala
//> using repository "sonatype-s01:snapshots"
//> using scala "2.13.12"
//> using dep "org.chipsalliance::chisel:7.0.0-M1+76-03ef61f3-SNAPSHOT"
//> using plugin "org.chipsalliance:::chisel-plugin:7.0.0-M1+76-03ef61f3-SNAPSHOT"
//> using options "-unchecked", "-deprecation", "-language:reflectiveCalls", "-feature", "-Xcheckinit", "-Ywarn-dead-code", "-Ywarn-unused", "-Ymacro-annotations"

import chisel3._
import chisel3.stage.ChiselGeneratorAnnotation
import chisel3.testers.BasicTester
import circt.stage.ChiselStage
import chisel3.util.circt._
import chisel3.util._



import scala.io.Source

trait InlineInstance { self: chisel3.experimental.BaseModule =>
  chisel3.experimental.annotate(new chisel3.experimental.ChiselAnnotation {
    def toFirrtl: firrtl.annotations.Annotation = firrtl.passes.InlineAnnotation(self.toNamed)
  })
}

class TestModule extends Module {
  val gen = UInt(4.W)
  val valid = IO(Input(Bool()))
  val ready = IO(Input(Bool())) 
  val bits = IO(Input(gen)) 
  val out = IO(Output(gen))


  val q0 = Module(new Queue(gen, 1) with InlineInstance)
  q0.io.enq.valid := valid
  q0.io.enq.bits := bits
  q0.io.deq.ready := ready
  val q1 = Module(new Queue(gen, 1) with InlineInstance)
  q1.io.enq.valid := valid
  q1.io.enq.bits := bits
  q1.io.deq.ready := ready

  out := q0.io.deq.bits + q1.io.deq.bits
}


object Main extends App {
  println(
      ChiselStage.emitCHIRRTL(
       new TestModule
    )
  )
}
```

before:
```verilog
reg [3:0] ram;        // src/main/scala/chisel3/util/Decoupled.scala:256:91
reg [3:0] ram_0;      // src/main/scala/chisel3/util/Decoupled.scala:256:91
```
after:
```verilog
reg [3:0] q1_ram;     // src/main/scala/chisel3/util/Decoupled.scala:256:91
reg [3:0] q0_ram;     // src/main/scala/chisel3/util/Decoupled.scala:256:91
```