### PR TITLE
[ImportVerilog] Distinguish the index up or down on the range selection.

### DIFF
--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -476,7 +476,9 @@ module Expressions;
     // CHECK: [[TMP2:%.+]] = moore.constant 1 : i32
     // CHECK: [[TMP3:%.+]] = moore.read %a : i32
     // CHECK: [[TMP4:%.+]] = moore.mul [[TMP2]], [[TMP3]] : i32
-    // CHECK: moore.extract [[TMP1]] from [[TMP4]] : l32, i32 -> l1
+    // CHECK: [[TMP5:%.+]] = moore.constant 0 : i32
+    // CHECK: [[TMP6:%.+]] = moore.sub [[TMP4]], [[TMP5]] : i32
+    // CHECK: moore.extract [[TMP1]] from [[TMP6]] : l32, i32 -> l1
     c = vec_1[1*a-:1];
     // CHECK: [[TMP1:%.+]] = moore.read %arr : uarray<3 x uarray<6 x i4>>
     // CHECK: [[TMP2:%.+]] = moore.constant 3 : i32
@@ -504,6 +506,12 @@ module Expressions;
     // CHECK: [[X_READ:%.+]] = moore.read %x : i1
     // CHECK: moore.extract_ref %vec_1 from [[X_READ]] : <l32>, i1 -> <l1>
     vec_1[x] = y;
+    
+    // CHECK: [[CONST_15:%.+]] = moore.constant 15 : i32
+    // CHECK: [[CONST_2:%.+]] = moore.constant 2 : i32
+    // CHECK: [[SUB:%.+]] = moore.sub [[CONST_15]], [[CONST_2]] : i32
+    // CHECK: moore.extract_ref %vec_1 from [[SUB]] : <l32>, i32 -> <l3>
+    vec_1[15-:3] = y;
 
     //===------------------------------------------------------------------===//
     // Unary operators


### PR DESCRIPTION
For example:
```
  byte by;
  logic [7:0] b;
  assign by = b[7-:8];
```
Now:
```
    %by = moore.variable : <i8>
    %b = moore.variable : <l8>
    %0 = moore.read %b : l8
    %1 = moore.constant 7 : i32

    %2 = moore.constant 7 : i32
    %3 = moore.sub %1, %2 : i32

    %4 = moore.extract %0 from %3 : l8, i32 -> l8              // low bit is "0"
    %5 = moore.conversion %4 : !moore.l8 -> !moore.i8
    moore.assign %by, %5 : i8
```
----
Previous:
```
    %by = moore.variable : <i8>
    %b = moore.variable : <l8>
    %0 = moore.read %b : l8

    %1 = moore.constant 7 : i32
    %2 = moore.extract %0 from %1 : l8, i32 -> l8              // low bit is "7";

    %3 = moore.conversion %2 : !moore.l8 -> !moore.i8
    moore.assign %by, %3 : i8
```