### PR TITLE
[circt-bmc] Add ExternaliseRegisters Pass

### DIFF
--- a/include/circt/InitAllPasses.h
+++ b/include/circt/InitAllPasses.h
@@ -36,6 +36,7 @@
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/Dialect/SystemC/SystemCPasses.h"
 #include "circt/Dialect/Verif/VerifPasses.h"
+#include "circt/Tools/circt-bmc/Passes.h"
 #include "circt/Tools/circt-lec/Passes.h"
 #include "circt/Transforms/Passes.h"
 
@@ -50,6 +51,9 @@ inline void registerAllPasses() {
 
   // LEC transformation passes
   registerLECTransformsPasses();
+
+  // BMC transformation passes
+  registerBMCTransformsPasses();
 
   // Standard Passes
   arc::registerPasses();

--- a/include/circt/Tools/CMakeLists.txt
+++ b/include/circt/Tools/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_subdirectory(circt-lec)
 add_subdirectory(circt-bmc)
+add_subdirectory(circt-lec)

--- a/include/circt/Tools/CMakeLists.txt
+++ b/include/circt/Tools/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(circt-lec)
+add_subdirectory(circt-bmc)

--- a/include/circt/Tools/circt-bmc/CMakeLists.txt
+++ b/include/circt/Tools/circt-bmc/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name BMCTransforms)
+mlir_tablegen(BMCTransforms.capi.h.inc -gen-pass-capi-header --prefix BMCTransforms)
+mlir_tablegen(BMCTransforms.capi.cpp.inc -gen-pass-capi-impl --prefix BMCTransforms)
+add_public_tablegen_target(CIRCTBMCTransformsIncGen)
+
+add_mlir_doc(Passes CIRCTBMCPasses ./ -gen-pass-doc)

--- a/include/circt/Tools/circt-bmc/Passes.h
+++ b/include/circt/Tools/circt-bmc/Passes.h
@@ -1,0 +1,31 @@
+//===- Passes.h - Pass Entrypoints ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes for CIRCT BMC transformation passes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_TOOLS_CIRCT_BMC_PASSES_H
+#define CIRCT_TOOLS_CIRCT_BMC_PASSES_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+
+//===----------------------------------------------------------------------===//
+// Registration
+//===----------------------------------------------------------------------===//
+
+/// Generate the code for registering passes.
+#define GEN_PASS_DECL_EXTERNALIZEREGISTERS
+#define GEN_PASS_REGISTRATION
+#include "circt/Tools/circt-bmc/Passes.h.inc"
+
+} // namespace circt
+
+#endif // CIRCT_TOOLS_CIRCT_BMC_PASSES_H

--- a/include/circt/Tools/circt-bmc/Passes.td
+++ b/include/circt/Tools/circt-bmc/Passes.td
@@ -20,8 +20,7 @@ def ExternalizeRegisters : Pass<"externalize-registers", "::mlir::ModuleOp"> {
   let summary = "Removes registers and adds corresponding input and output ports";
 
   let dependentDialects = [
-    "mlir::func::FuncDialect", "mlir::LLVM::LLVMDialect",
-    "circt::verif::VerifDialect"
+    "circt::seq::SeqDialect"
   ];
 }
 

--- a/include/circt/Tools/circt-bmc/Passes.td
+++ b/include/circt/Tools/circt-bmc/Passes.td
@@ -1,0 +1,29 @@
+//===-- Passes.td - BMC Transforms pass definition file ----*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains definitions for BMC transformation passes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_TOOLS_CIRCT_BMC_PASSES_TD
+#define CIRCT_TOOLS_CIRCT_BMC_PASSES_TD
+
+include "mlir/Pass/PassBase.td"
+include "mlir/Rewrite/PassUtil.td"
+
+def ExternalizeRegisters : Pass<"externalize-registers", "::mlir::ModuleOp"> {
+  let summary = "Removes registers and adds corresponding input and output ports";
+
+  let dependentDialects = [
+    "mlir::func::FuncDialect", "mlir::LLVM::LLVMDialect",
+    "circt::verif::VerifDialect"
+  ];
+}
+
+#endif // CIRCT_TOOLS_CIRCT_BMC_PASSES_TD
+

--- a/include/circt/Tools/circt-bmc/Passes.td
+++ b/include/circt/Tools/circt-bmc/Passes.td
@@ -20,7 +20,7 @@ def ExternalizeRegisters : Pass<"externalize-registers", "::mlir::ModuleOp"> {
   let summary = "Removes registers and adds corresponding input and output ports";
 
   let dependentDialects = [
-    "circt::seq::SeqDialect"
+    "circt::seq::SeqDialect", "circt::hw::HWDialect"
   ];
 }
 

--- a/lib/Tools/CMakeLists.txt
+++ b/lib/Tools/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(circt-bmc)
 add_subdirectory(circt-lec)

--- a/lib/Tools/circt-bmc/CMakeLists.txt
+++ b/lib/Tools/circt-bmc/CMakeLists.txt
@@ -5,12 +5,8 @@ add_circt_library(CIRCTBMCTransforms
   CIRCTBMCTransformsIncGen
 
   LINK_LIBS PUBLIC
-  CIRCTSMT
   CIRCTHW
   CIRCTSeq
-  CIRCTComb
-  CIRCTVerif
-  CIRCTCombToSMT
 
   MLIRIR
   MLIRSupport

--- a/lib/Tools/circt-bmc/CMakeLists.txt
+++ b/lib/Tools/circt-bmc/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_circt_library(CIRCTBMCTransforms
+  ExternalizeRegisters.cpp
+
+  DEPENDS
+  CIRCTBMCTransformsIncGen
+
+  LINK_LIBS PUBLIC
+  CIRCTSMT
+  CIRCTHW
+  CIRCTSeq
+  CIRCTComb
+  CIRCTVerif
+  CIRCTCombToSMT
+
+  MLIRIR
+  MLIRSupport
+  MLIRSCFDialect
+  MLIRTransforms
+)

--- a/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
+++ b/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
@@ -138,6 +138,7 @@ void ExternalizeRegistersPass::runOnOperation() {
           numRegs += newInputs.size();
           instanceOp.replaceAllUsesWith(
               newInst.getResults().take_front(instanceOp->getNumResults()));
+          instanceGraph.replaceInstance(instanceOp, newInst);
           instanceOp->erase();
           return;
         }

--- a/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
+++ b/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
@@ -73,7 +73,6 @@ void ExternalizeRegistersPass::runOnOperation() {
               regOp.getInput().getType());
 
           OpBuilder builder(regOp);
-          builder.create<seq::FromClockOp>(op->getLoc(), regOp.getClk());
           regOp.getResult().replaceAllUsesWith(
               module.appendInput("", regOp.getType()).second);
           module.appendOutput("", regOp.getInput());

--- a/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
+++ b/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
@@ -1,0 +1,114 @@
+//===- ExternalizeRegisters.cpp -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/HW/HWInstanceGraph.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Verif/VerifOps.h"
+#include "circt/Support/Namespace.h"
+#include "circt/Tools/circt-bmc/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/PostOrderIterator.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace hw;
+using namespace igraph;
+
+namespace circt {
+#define GEN_PASS_DEF_EXTERNALIZEREGISTERS
+#include "circt/Tools/circt-bmc/Passes.h.inc"
+} // namespace circt
+
+//===----------------------------------------------------------------------===//
+// Convert Lower To BMC pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct ExternalizeRegistersPass
+    : public circt::impl::ExternalizeRegistersBase<ExternalizeRegistersPass> {
+  using ExternalizeRegistersBase::ExternalizeRegistersBase;
+  void runOnOperation() override;
+};
+} // namespace
+
+void ExternalizeRegistersPass::runOnOperation() {
+  auto &instanceGraph = getAnalysis<hw::InstanceGraph>();
+  DenseSet<Operation *> handled;
+  DenseMap<StringAttr, SmallVector<Type>> addedInputs;
+  DenseMap<StringAttr, SmallVector<Type>> addedOutputs;
+
+  // Iterate over all instances in the instance graph. This ensures we visit
+  // every module, even private top modules (private and never instantiated).
+  for (auto *startNode : instanceGraph) {
+    if (handled.count(startNode->getModule().getOperation()))
+      continue;
+
+    // Visit the instance subhierarchy starting at the current module, in a
+    // depth-first manner. This allows us to inline child modules into parents
+    // before we attempt to inline parents into their parents.
+    for (InstanceGraphNode *node : llvm::post_order(startNode)) {
+      if (!handled.insert(node->getModule().getOperation()).second)
+        continue;
+
+      auto module =
+          dyn_cast_or_null<HWModuleOp>(node->getModule().getOperation());
+      if (!module)
+        continue;
+
+      unsigned numRegs = 0;
+      module->walk([&](Operation *op) {
+        if (auto regOp = dyn_cast<seq::CompRegOp>(op)) {
+          addedInputs[module.getSymNameAttr()].push_back(regOp.getType());
+          addedOutputs[module.getSymNameAttr()].push_back(
+              regOp.getInput().getType());
+
+          OpBuilder builder(regOp);
+          builder.create<seq::FromClockOp>(op->getLoc(), regOp.getClk());
+          regOp.getResult().replaceAllUsesWith(
+              module.appendInput("", regOp.getType()).second);
+          module.appendOutput("", regOp.getInput());
+          regOp->erase();
+          ++numRegs;
+          return;
+        }
+        if (auto instanceOp = dyn_cast<InstanceOp>(op)) {
+          auto newInputs =
+              addedInputs[instanceOp.getModuleNameAttr().getAttr()];
+          auto newOutputs =
+              addedOutputs[instanceOp.getModuleNameAttr().getAttr()];
+          addedInputs[module.getSymNameAttr()].append(newInputs);
+          addedOutputs[module.getSymNameAttr()].append(newOutputs);
+          for (auto input : newInputs)
+            instanceOp.getInputsMutable().append(
+                module.appendInput("", input).second);
+          OpBuilder builder(instanceOp);
+          SmallVector<Type> resTypes(instanceOp->getResultTypes());
+          resTypes.append(newOutputs);
+          auto newInst = builder.create<InstanceOp>(
+              instanceOp.getLoc(), resTypes, instanceOp.getInstanceNameAttr(),
+              instanceOp.getModuleNameAttr(), instanceOp.getInputs(),
+              instanceOp.getArgNamesAttr(), instanceOp.getResultNamesAttr(),
+              instanceOp.getParametersAttr(), instanceOp.getInnerSymAttr());
+          for (auto output : newInst->getResults().take_back(newOutputs.size()))
+            module.appendOutput("", output);
+          instanceOp.erase();
+          return;
+        }
+      });
+
+      module->setAttr(
+          "num_regs",
+          IntegerAttr::get(IntegerType::get(&getContext(), 32), numRegs));
+    }
+  }
+}

--- a/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
+++ b/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
@@ -81,6 +81,10 @@ void ExternalizeRegistersPass::runOnOperation() {
             regOp.emitError("registers with reset signals not yet supported");
             return signalPassFailure();
           }
+          if (regOp.getPowerOnValue()) {
+            regOp.emitError("registers with power-on values not yet supported");
+            return signalPassFailure();
+          }
           addedInputs[module.getSymNameAttr()].push_back(regOp.getType());
           addedOutputs[module.getSymNameAttr()].push_back(
               regOp.getInput().getType());

--- a/test/Tools/circt-bmc/externalise-registers.mlir
+++ b/test/Tools/circt-bmc/externalise-registers.mlir
@@ -1,0 +1,31 @@
+// RUN: circt-opt --externalize-registers %s | FileCheck %s
+
+// CHECK:  hw.module @comb(in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, out {{.+}} : i32) attributes {num_regs = 0 : i32} {
+// CHECK:    [[ADD:%.+]] = comb.add [[IN0]], [[IN1]]
+// CHECK:    hw.output [[ADD]]
+// CHECK:  }
+hw.module @comb(in %in0: i32, in %in1: i32, out out: i32) {
+  %0 = comb.add %in0, %in1 : i32
+  hw.output %0 : i32
+}
+
+// CHECK:  hw.module @one_reg(in [[CLK:%.+]] : !seq.clock, in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, in [[OLD_REG:%.+]] : i32, out {{.+}} : i32, out {{.+}} : i32) attributes {num_regs = 1 : i32} {
+// CHECK:    [[ADD:%.+]] = comb.add [[IN0]], [[IN1]]
+// CHECK:    hw.output [[OLD_REG]], [[ADD]]
+// CHECK:  }
+hw.module @one_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
+  %0 = comb.add %in0, %in1 : i32
+  %1 = seq.compreg %0, %clk : i32
+  hw.output %1 : i32
+}
+
+// CHECK:  hw.module @two_reg(in [[CLK:%.+]] : !seq.clock, in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, in [[OLD_REG0:%.+]] : i32, in [[OLD_REG1:%.+]] : i32, out {{.+}} : i32, out {{.+}} : i32, out {{.+}} : i32) attributes {num_regs = 2 : i32} {
+// CHECK:    [[ADD:%.+]] = comb.add [[IN0]], [[IN1]]
+// CHECK:    hw.output [[OLD_REG1]], [[ADD]], [[OLD_REG0]]
+// CHECK:  }
+hw.module @two_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
+  %0 = comb.add %in0, %in1 : i32
+  %1 = seq.compreg %0, %clk : i32
+  %2 = seq.compreg %1, %clk : i32
+  hw.output %2 : i32
+}

--- a/test/Tools/circt-bmc/externalize-registers-errors.mlir
+++ b/test/Tools/circt-bmc/externalize-registers-errors.mlir
@@ -2,7 +2,14 @@
 
 hw.module @two_clks(in %clk0: !seq.clock, in %clk1: !seq.clock, in %in: i32, out out: i32) {
   %1 = seq.compreg %in, %clk0 : i32
-  // expected-warning @below {{multiple clocks not yet supported - all registers will be assumed to be clocked together}}
+  // expected-error @below {{multiple clocks not yet supported - all registers will be assumed to be clocked together}}
   %2 = seq.compreg %1, %clk1 : i32
   hw.output %2 : i32
+}
+
+hw.module @reg_with_reset(in %clk: !seq.clock, in %rst: i1, in %in: i32, out out: i32) {
+  %c0_i32 = hw.constant 0 : i32
+  // expected-error @below {{registers with reset signals not yet supported}}
+  %1 = seq.compreg %in, %clk reset %rst, %c0_i32 : i32
+  hw.output %1 : i32
 }

--- a/test/Tools/circt-bmc/externalize-registers-errors.mlir
+++ b/test/Tools/circt-bmc/externalize-registers-errors.mlir
@@ -1,0 +1,8 @@
+// RUN: circt-opt --externalize-registers --split-input-file --verify-diagnostics %s
+
+hw.module @two_clks(in %clk0: !seq.clock, in %clk1: !seq.clock, in %in: i32, out out: i32) {
+  %1 = seq.compreg %in, %clk0 : i32
+  // expected-warning @below {{multiple clocks not yet supported - all registers will be assumed to be clocked together}}
+  %2 = seq.compreg %1, %clk1 : i32
+  hw.output %2 : i32
+}

--- a/test/Tools/circt-bmc/externalize-registers-errors.mlir
+++ b/test/Tools/circt-bmc/externalize-registers-errors.mlir
@@ -1,11 +1,22 @@
 // RUN: circt-opt --externalize-registers --split-input-file --verify-diagnostics %s
 
+// expected-error @below {{modules with multiple clocks not yet supported}}
 hw.module @two_clks(in %clk0: !seq.clock, in %clk1: !seq.clock, in %in: i32, out out: i32) {
   %1 = seq.compreg %in, %clk0 : i32
-  // expected-error @below {{multiple clocks not yet supported - all registers will be assumed to be clocked together}}
   %2 = seq.compreg %1, %clk1 : i32
   hw.output %2 : i32
 }
+
+// -----
+
+hw.module @two_clks(in %clk_i1: i1, in %in: i32, out out: i32) {
+  %clk = seq.to_clock %clk_i1
+  // expected-error @below {{only clocks directly given as block arguments are supported}}
+  %1 = seq.compreg %in, %clk : i32
+  hw.output %1 : i32
+}
+
+// -----
 
 hw.module @reg_with_reset(in %clk: !seq.clock, in %rst: i1, in %in: i32, out out: i32) {
   %c0_i32 = hw.constant 0 : i32
@@ -13,6 +24,8 @@ hw.module @reg_with_reset(in %clk: !seq.clock, in %rst: i1, in %in: i32, out out
   %1 = seq.compreg %in, %clk reset %rst, %c0_i32 : i32
   hw.output %1 : i32
 }
+
+// -----
 
 hw.module @reg_with_poweron(in %clk: !seq.clock, in %in: i32, out out: i32) {
   %c0_i32 = hw.constant 0 : i32

--- a/test/Tools/circt-bmc/externalize-registers-errors.mlir
+++ b/test/Tools/circt-bmc/externalize-registers-errors.mlir
@@ -13,3 +13,10 @@ hw.module @reg_with_reset(in %clk: !seq.clock, in %rst: i1, in %in: i32, out out
   %1 = seq.compreg %in, %clk reset %rst, %c0_i32 : i32
   hw.output %1 : i32
 }
+
+hw.module @reg_with_poweron(in %clk: !seq.clock, in %in: i32, out out: i32) {
+  %c0_i32 = hw.constant 0 : i32
+  // expected-error @below {{registers with power-on values not yet supported}}
+  %1 = seq.compreg %in, %clk powerOn %c0_i32 : i32
+  hw.output %1 : i32
+}

--- a/test/Tools/circt-bmc/externalize-registers.mlir
+++ b/test/Tools/circt-bmc/externalize-registers.mlir
@@ -29,3 +29,14 @@ hw.module @two_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32
   %2 = seq.compreg %1, %clk : i32
   hw.output %2 : i32
 }
+
+// CHECK:  hw.module @named_regs(in [[CLK:%.+]] : !seq.clock, in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, in [[OLD_REG0:%.+]] : i32, in [[OLD_REG1:%.+]] : i32, out {{.+}} : i32, out {{.+}} : i32, out {{.+}} : i32) attributes {num_regs = 2 : i32} {
+// CHECK:    [[ADD:%.+]] = comb.add [[IN0]], [[IN1]]
+// CHECK:    hw.output [[OLD_REG1]], [[ADD]], [[OLD_REG0]]
+// CHECK:  }
+hw.module @named_regs(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
+  %0 = comb.add %in0, %in1 : i32
+  %1 = seq.compreg sym @reg1 %0, %clk : i32
+  %2 = seq.compreg sym @reg2 %1, %clk : i32
+  hw.output %2 : i32
+}

--- a/test/Tools/circt-bmc/externalize-registers.mlir
+++ b/test/Tools/circt-bmc/externalize-registers.mlir
@@ -15,8 +15,8 @@ hw.module @comb(in %in0: i32, in %in1: i32, out out: i32) {
 // CHECK:  }
 hw.module @one_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
   %0 = comb.add %in0, %in1 : i32
-  %1 = seq.compreg %0, %clk : i32
-  hw.output %1 : i32
+  %single_reg = seq.compreg %0, %clk : i32
+  hw.output %single_reg : i32
 }
 
 // CHECK:  hw.module @two_reg(in [[CLK:%.+]] : !seq.clock, in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, in [[OLD_REG0:%.+]] : i32, in [[OLD_REG1:%.+]] : i32, out {{.+}} : i32, out {{.+}} : i32, out {{.+}} : i32) attributes {num_regs = 2 : i32} {
@@ -50,12 +50,12 @@ hw.module @nested_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: 
   hw.output %0 : i32
 }
 
-// CHECK:  hw.module @nested_nested_reg(in [[CLK:%.+]] : !seq.clock, in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, in [[OLD_REG0:%.+]] : i32, in [[OLD_REG1:%.+]] : i32, out {{.+}} : i32, out {{.+}} : i32, out {{.+}} : i32) attributes {num_regs = 2 : i32} {
-// CHECK:    [[INSTOUT:%.+]], [[INSTREG:%.+]] = hw.instance "nested_reg" @nested_reg(clk: [[CLK]]: !seq.clock, in0: [[IN0]]: i32, in1: [[IN1]]: i32, {{.+}}: [[OLD_REG0]]: i32) -> ({{.+}}: i32, {{.+}}: i32)
-// CHECK:    hw.output [[OLD_REG1]], [[INSTREG]], [[INSTOUT]]
+// CHECK:  hw.module @nested_nested_reg(in [[CLK:%.+]] : !seq.clock, in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, in %single_reg_state : i32, in %top_reg_state : i32, out {{.+}} : i32, out single_reg_input : i32, out top_reg_input : i32) attributes {num_regs = 2 : i32} {
+// CHECK:    [[INSTOUT:%.+]], [[INSTREG:%.+]] = hw.instance "nested_reg" @nested_reg(clk: [[CLK]]: !seq.clock, in0: [[IN0]]: i32, in1: [[IN1]]: i32, single_reg_state: %single_reg_state: i32) -> ({{.+}}: i32, single_reg_input: i32)
+// CHECK:    hw.output %top_reg_state, [[INSTREG]], [[INSTOUT]]
 // CHECK:  }
 hw.module @nested_nested_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
   %0 = hw.instance "nested_reg" @nested_reg(clk: %clk: !seq.clock, in0: %in0: i32, in1: %in1: i32) ->  (out: i32)
-  %1 = seq.compreg %0, %clk : i32
-  hw.output %1 : i32
+  %top_reg = seq.compreg %0, %clk : i32
+  hw.output %top_reg : i32
 }

--- a/test/Tools/circt-bmc/externalize-registers.mlir
+++ b/test/Tools/circt-bmc/externalize-registers.mlir
@@ -40,3 +40,12 @@ hw.module @named_regs(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: 
   %2 = seq.compreg sym @reg2 %1, %clk : i32
   hw.output %2 : i32
 }
+
+// CHECK:  hw.module @nested_reg(in [[CLK:%.+]] : !seq.clock, in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, in [[OLD_REG:%.+]] : i32, out {{.+}} : i32, out {{.+}} : i32) attributes {num_regs = 1 : i32} {
+// CHECK:    [[INSTOUT:%.+]], [[INSTREG:%.+]] = hw.instance "one_reg" @one_reg(clk: [[CLK]]: !seq.clock, in0: [[IN0]]: i32, in1: [[IN1]]: i32, _0: [[OLD_REG]]: i32) -> ({{.+}}: i32, {{.+}}: i32)
+// CHECK:    hw.output [[INSTOUT]], [[INSTREG]]
+// CHECK:  }
+hw.module @nested_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
+  %0 = hw.instance "one_reg" @one_reg(clk: %clk: !seq.clock, in0: %in0: i32, in1: %in1: i32) ->  (out: i32)
+  hw.output %0 : i32
+}

--- a/test/Tools/circt-bmc/externalize-registers.mlir
+++ b/test/Tools/circt-bmc/externalize-registers.mlir
@@ -30,19 +30,19 @@ hw.module @two_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32
   hw.output %2 : i32
 }
 
-// CHECK:  hw.module @named_regs(in [[CLK:%.+]] : !seq.clock, in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, in [[OLD_REG0:%.+]] : i32, in [[OLD_REG1:%.+]] : i32, out {{.+}} : i32, out {{.+}} : i32, out {{.+}} : i32) attributes {num_regs = 2 : i32} {
+// CHECK:  hw.module @named_regs(in [[CLK:%.+]] : !seq.clock, in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, in %firstreg_state : i32, in %secondreg_state : i32, out {{.+}} : i32, out {{.+}} : i32, out {{.+}} : i32) attributes {num_regs = 2 : i32} {
 // CHECK:    [[ADD:%.+]] = comb.add [[IN0]], [[IN1]]
-// CHECK:    hw.output [[OLD_REG1]], [[ADD]], [[OLD_REG0]]
+// CHECK:    hw.output %secondreg_state, [[ADD]], %firstreg_state
 // CHECK:  }
 hw.module @named_regs(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
   %0 = comb.add %in0, %in1 : i32
-  %1 = seq.compreg sym @reg1 %0, %clk : i32
-  %2 = seq.compreg sym @reg2 %1, %clk : i32
-  hw.output %2 : i32
+  %firstreg = seq.compreg %0, %clk : i32
+  %secondreg = seq.compreg %firstreg, %clk : i32
+  hw.output %secondreg : i32
 }
 
 // CHECK:  hw.module @nested_reg(in [[CLK:%.+]] : !seq.clock, in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, in [[OLD_REG:%.+]] : i32, out {{.+}} : i32, out {{.+}} : i32) attributes {num_regs = 1 : i32} {
-// CHECK:    [[INSTOUT:%.+]], [[INSTREG:%.+]] = hw.instance "one_reg" @one_reg(clk: [[CLK]]: !seq.clock, in0: [[IN0]]: i32, in1: [[IN1]]: i32, _0: [[OLD_REG]]: i32) -> ({{.+}}: i32, {{.+}}: i32)
+// CHECK:    [[INSTOUT:%.+]], [[INSTREG:%.+]] = hw.instance "one_reg" @one_reg(clk: [[CLK]]: !seq.clock, in0: [[IN0]]: i32, in1: [[IN1]]: i32, {{.+}}: [[OLD_REG]]: i32) -> ({{.+}}: i32, {{.+}}: i32)
 // CHECK:    hw.output [[INSTOUT]], [[INSTREG]]
 // CHECK:  }
 hw.module @nested_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
@@ -51,7 +51,7 @@ hw.module @nested_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: 
 }
 
 // CHECK:  hw.module @nested_nested_reg(in [[CLK:%.+]] : !seq.clock, in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, in [[OLD_REG0:%.+]] : i32, in [[OLD_REG1:%.+]] : i32, out {{.+}} : i32, out {{.+}} : i32, out {{.+}} : i32) attributes {num_regs = 2 : i32} {
-// CHECK:    [[INSTOUT:%.+]], [[INSTREG:%.+]] = hw.instance "nested_reg" @nested_reg(clk: [[CLK]]: !seq.clock, in0: [[IN0]]: i32, in1: [[IN1]]: i32, _0: [[OLD_REG0]]: i32) -> ({{.+}}: i32, {{.+}}: i32)
+// CHECK:    [[INSTOUT:%.+]], [[INSTREG:%.+]] = hw.instance "nested_reg" @nested_reg(clk: [[CLK]]: !seq.clock, in0: [[IN0]]: i32, in1: [[IN1]]: i32, {{.+}}: [[OLD_REG0]]: i32) -> ({{.+}}: i32, {{.+}}: i32)
 // CHECK:    hw.output [[OLD_REG1]], [[INSTREG]], [[INSTOUT]]
 // CHECK:  }
 hw.module @nested_nested_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {

--- a/test/Tools/circt-bmc/externalize-registers.mlir
+++ b/test/Tools/circt-bmc/externalize-registers.mlir
@@ -49,3 +49,13 @@ hw.module @nested_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: 
   %0 = hw.instance "one_reg" @one_reg(clk: %clk: !seq.clock, in0: %in0: i32, in1: %in1: i32) ->  (out: i32)
   hw.output %0 : i32
 }
+
+// CHECK:  hw.module @nested_nested_reg(in [[CLK:%.+]] : !seq.clock, in [[IN0:%.+]] : i32, in [[IN1:%.+]] : i32, in [[OLD_REG0:%.+]] : i32, in [[OLD_REG1:%.+]] : i32, out {{.+}} : i32, out {{.+}} : i32, out {{.+}} : i32) attributes {num_regs = 2 : i32} {
+// CHECK:    [[INSTOUT:%.+]], [[INSTREG:%.+]] = hw.instance "nested_reg" @nested_reg(clk: [[CLK]]: !seq.clock, in0: [[IN0]]: i32, in1: [[IN1]]: i32, _0: [[OLD_REG0]]: i32) -> ({{.+}}: i32, {{.+}}: i32)
+// CHECK:    hw.output [[OLD_REG1]], [[INSTREG]], [[INSTOUT]]
+// CHECK:  }
+hw.module @nested_nested_reg(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
+  %0 = hw.instance "nested_reg" @nested_reg(clk: %clk: !seq.clock, in0: %in0: i32, in1: %in1: i32) ->  (out: i32)
+  %1 = seq.compreg %0, %clk : i32
+  hw.output %1 : i32
+}

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(circt-opt
   CIRCTArc
   CIRCTArcToLLVM
   CIRCTArcTransforms
+  CIRCTBMCTransforms
   CIRCTCalyx
   CIRCTCalyxToHW
   CIRCTCalyxNative


### PR DESCRIPTION
This PR adds a pass (pass itself written by @maerhart, I'm just PRing as part of the splitting of #7259) that extracts `seq.compreg`s within modules, and replaces them with additional inputs and outputs such that register states are fed as module outputs, then fed back in as inputs. This simplifies model checking as the state can be provided directly as an input to a function checking the design, rather than having to walk the IR to calculate the state.
