### PR TITLE
[ESI] Add verify connections pass

### DIFF
--- a/include/circt/Dialect/ESI/ESIPasses.h
+++ b/include/circt/Dialect/ESI/ESIPasses.h
@@ -32,7 +32,7 @@ struct Platform {
 #define GEN_PASS_DECL
 #include "circt/Dialect/ESI/ESIPasses.h.inc"
 
-std::unique_ptr<OperationPass<ModuleOp>> createESIVerifyConnectionsPass();
+std::unique_ptr<OperationPass<>> createESIVerifyConnectionsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESIPhysicalLoweringPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESIBundleLoweringPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESIPortLoweringPass();

--- a/include/circt/Dialect/ESI/ESIPasses.h
+++ b/include/circt/Dialect/ESI/ESIPasses.h
@@ -32,6 +32,7 @@ struct Platform {
 #define GEN_PASS_DECL
 #include "circt/Dialect/ESI/ESIPasses.h.inc"
 
+std::unique_ptr<OperationPass<ModuleOp>> createESIVerifyConnectionsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESIPhysicalLoweringPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESIBundleLoweringPass();
 std::unique_ptr<OperationPass<ModuleOp>> createESIPortLoweringPass();

--- a/include/circt/Dialect/ESI/ESIPasses.td
+++ b/include/circt/Dialect/ESI/ESIPasses.td
@@ -85,7 +85,7 @@ def LowerESItoHW: Pass<"lower-esi-to-hw", "mlir::ModuleOp"> {
   ];
 }
 
-def VerifyESIConnections: Pass<"verify-esi-connections", "mlir::ModuleOp"> {
+def VerifyESIConnections: Pass<"verify-esi-connections"> {
   let summary = "Verify that channels and bundles are only used once";
   let constructor = "circt::esi::createESIVerifyConnectionsPass()";
 }

--- a/include/circt/Dialect/ESI/ESIPasses.td
+++ b/include/circt/Dialect/ESI/ESIPasses.td
@@ -85,4 +85,9 @@ def LowerESItoHW: Pass<"lower-esi-to-hw", "mlir::ModuleOp"> {
   ];
 }
 
+def VerifyESIConnections: Pass<"verify-esi-connections", "mlir::ModuleOp"> {
+  let summary = "Verify that channels and bundles are only used once";
+  let constructor = "circt::esi::createESIVerifyConnectionsPass()";
+}
+
 #endif // CIRCT_DIALECT_ESI_ESIPASSES_TD

--- a/lib/Dialect/ESI/CMakeLists.txt
+++ b/lib/Dialect/ESI/CMakeLists.txt
@@ -22,6 +22,7 @@ set(srcs
   Passes/ESICleanMetadata.cpp
   Passes/ESIBuildManifest.cpp
   Passes/ESIAppIDHier.cpp
+  Passes/ESIVerifyConnections.cpp
 )
 
 set(ESI_LinkLibs

--- a/lib/Dialect/ESI/Passes/ESIVerifyConnections.cpp
+++ b/lib/Dialect/ESI/Passes/ESIVerifyConnections.cpp
@@ -1,0 +1,60 @@
+//===- ESIVerifyConnections.cpp ---------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/ESI/ESIPasses.h"
+#include "circt/Dialect/ESI/ESITypes.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Pass/Pass.h"
+
+namespace circt {
+namespace esi {
+#define GEN_PASS_DEF_VERIFYESICONNECTIONS
+#include "circt/Dialect/ESI/ESIPasses.h.inc"
+} // namespace esi
+} // namespace circt
+
+using namespace circt;
+using namespace circt::esi;
+
+namespace {
+struct ESIVerifyConnectionsPass
+    : public impl::VerifyESIConnectionsBase<ESIVerifyConnectionsPass> {
+  void runOnOperation() override;
+};
+} // anonymous namespace
+
+void ESIVerifyConnectionsPass::runOnOperation() {
+  // Walk the tree and look for ops which produce ESI types. Check each one.
+  getOperation().walk([this](Operation *op) {
+    for (const OpResult &v : op->getResults())
+      if (isa<ChannelBundleType>(v.getType())) {
+        if (v.hasOneUse())
+          continue;
+        mlir::InFlightDiagnostic error =
+            op->emitError("bundles must have exactly one use");
+        for (Operation *user : v.getUsers())
+          error.attachNote(user->getLoc()) << "bundle used here";
+        signalPassFailure();
+
+      } else if (isa<ChannelType>(v.getType())) {
+        if (std::distance(v.getUses().begin(), v.getUses().end()) <= 1)
+          continue;
+        mlir::InFlightDiagnostic error =
+            op->emitError("channels must have at most one use");
+        for (Operation *user : v.getUsers())
+          error.attachNote(user->getLoc()) << "channel used here";
+        signalPassFailure();
+      }
+  });
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+circt::esi::createESIVerifyConnectionsPass() {
+  return std::make_unique<ESIVerifyConnectionsPass>();
+}

--- a/lib/Dialect/ESI/Passes/ESIVerifyConnections.cpp
+++ b/lib/Dialect/ESI/Passes/ESIVerifyConnections.cpp
@@ -31,7 +31,7 @@ struct ESIVerifyConnectionsPass
 
 void ESIVerifyConnectionsPass::runOnOperation() {
   // Walk the tree and look for ops which produce ESI types. Check each one.
-  getOperation().walk([this](Operation *op) {
+  getOperation()->walk([this](Operation *op) {
     for (const OpResult &v : op->getResults())
       if (isa<ChannelBundleType>(v.getType())) {
         if (v.hasOneUse())
@@ -54,7 +54,6 @@ void ESIVerifyConnectionsPass::runOnOperation() {
   });
 }
 
-std::unique_ptr<OperationPass<ModuleOp>>
-circt::esi::createESIVerifyConnectionsPass() {
+std::unique_ptr<OperationPass<>> circt::esi::createESIVerifyConnectionsPass() {
   return std::make_unique<ESIVerifyConnectionsPass>();
 }


### PR DESCRIPTION
New pass to verify that channels and bundles are used the appropriate number of times. The wrap/unwrap, pack/unpack operations already have these checks, but when a channel/bundle is produced by a module (or some other op), it is not checked. A pass is the best way I could figure out how to implement the check.

Closes #7286.