### PR TITLE
[NFC][HW] Fix parsing of nullary `hw.triggered` ops

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -714,7 +714,7 @@ def TriggeredOp : HWOp<"triggered", [
   let results = (outs);
 
   let assemblyFormat = [{
-    $event $trigger  `(` $inputs `)` `:` type($inputs) $body attr-dict
+    $event $trigger  (`(` $inputs^ `)` `:` type($inputs))? $body attr-dict
   }];
 
   let extraClassDeclaration = [{

--- a/test/Conversion/HWToSV/test_trigger.mlir
+++ b/test/Conversion/HWToSV/test_trigger.mlir
@@ -9,3 +9,13 @@ hw.module @foo(in %trigger : i1, in %in : i32) {
       "some.user" (%arg0) : (i32) -> ()
   }
 }
+
+hw.module @bar(in %trigger : i1) {
+  // CHECK:       sv.always posedge %trigger {
+  // CHECK-NEXT:    "some.user"() : () -> ()
+  // CHECK-NEXT:  }
+  hw.triggered posedge %trigger {
+      "some.user"() : () -> ()
+  }
+
+}


### PR DESCRIPTION
Make the variadic  `inputs` argument of the `hw.triggered` operation optional in the declarative assembly format.  Without this change the generated parser fails on nullary instances due to the empty/missing type list.