### PR TITLE
[ImportVerilog] Fix the segmentation fault caused by the case statement.

### DIFF
--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -117,6 +117,9 @@ struct StmtVisitor {
   // Handle case statements.
   LogicalResult visit(const slang::ast::CaseStatement &caseStmt) {
     auto caseExpr = context.convertRvalueExpression(caseStmt.expr);
+    if (!caseExpr)
+      return failure();
+
     auto items = caseStmt.items;
     // Used to generate the condition of the default case statement.
     SmallVector<Value> defaultConds;
@@ -127,6 +130,9 @@ struct StmtVisitor {
       SmallVector<Value> allConds;
       for (const auto *expr : item.expressions) {
         auto itemExpr = context.convertRvalueExpression(*expr);
+        if (!itemExpr)
+          return failure();
+
         auto newEqOp = builder.create<moore::EqOp>(loc, caseExpr, itemExpr);
         allConds.push_back(newEqOp);
       }

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -107,3 +107,25 @@ module Foo;
   // expected-error @below {{unpacked arrays in 'inside' expressions not supported}}
   int c = a inside { b };
 endmodule
+
+// -----
+module Foo;
+  logic a, b;
+  initial begin
+    casez (a)
+    // expected-error @below {{literals with X or Z bits not supported}}
+    1'bz : b = 1'b1;
+    endcase
+  end
+endmodule
+
+// -----
+module Foo;
+  logic a;
+  initial begin
+    // expected-error @below {{literals with X or Z bits not supported}}
+    casez (1'bz)
+    1'bz : a = 1'b1;
+    endcase
+  end
+endmodule


### PR DESCRIPTION
Because the return of `convertRvalueExpression()` can return `{}`. For example, when we handle the `x`/`z` value, it will emit an error and return `{}`, so we must estimate whether the return of `convertRvalueExpression()` is `{}`. Otherwise, it will cause a segmentation fault.