### PR TITLE
[SV][Verif] Extract clocked verif ops in ExtractTestCode pass

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -562,7 +562,7 @@ static bool isAssertOp(hw::HWSymbolCache &symCache, Operation *op) {
   }
 
   return isa<AssertOp, FinishOp, FWriteOp, AssertConcurrentOp, FatalOp,
-             verif::AssertOp>(op);
+             verif::AssertOp, verif::ClockedAssertOp>(op);
 }
 
 static bool isCoverOp(hw::HWSymbolCache &symCache, Operation *op) {
@@ -572,7 +572,8 @@ static bool isCoverOp(hw::HWSymbolCache &symCache, Operation *op) {
     if (auto *mod = symCache.getDefinition(inst.getModuleNameAttr()))
       if (mod->getAttr("firrtl.extract.cover.extra"))
         return true;
-  return isa<CoverOp, CoverConcurrentOp, verif::CoverOp>(op);
+  return isa<CoverOp, CoverConcurrentOp, verif::CoverOp, verif::ClockedCoverOp>(
+      op);
 }
 
 static bool isAssumeOp(hw::HWSymbolCache &symCache, Operation *op) {
@@ -583,7 +584,8 @@ static bool isAssumeOp(hw::HWSymbolCache &symCache, Operation *op) {
       if (mod->getAttr("firrtl.extract.assume.extra"))
         return true;
 
-  return isa<AssumeOp, AssumeConcurrentOp, verif::AssumeOp>(op);
+  return isa<AssumeOp, AssumeConcurrentOp, verif::AssumeOp,
+             verif::ClockedAssumeOp>(op);
 }
 
 /// Return true if the operation belongs to the design.

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -604,3 +604,18 @@ hw.module @VerifOps(in %a : i1, in %b : i1) {
   verif.cover %true : i1
   hw.output
 }
+
+// -----
+
+// Check that clocked verif ops are also extracted.
+
+// CHECK: hw.module private @ClockedVerifOps_assert
+// CHECK: hw.module private @ClockedVerifOps_assume
+// CHECK: hw.module private @ClockedVerifOps_cover
+hw.module @ClockedVerifOps(in %a : i1, in %en : i1, in %clock: i1) {
+  %true = hw.constant true
+  verif.clocked_assert %a if %en, posedge %clock : i1
+  verif.clocked_assume %a if %en, posedge %clock : i1
+  verif.clocked_cover %a if %en, posedge %clock : i1
+  hw.output
+}


### PR DESCRIPTION
This fixes a bug that clocked verif ops remain in designs.