### PR TITLE
[MooreToCore] Lower var, read, and assign into LLHD.

### DIFF
--- a/include/circt/Dialect/LLHD/IR/SignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/SignalOps.td
@@ -13,7 +13,6 @@
 include "mlir/IR/EnumAttr.td"
 
 def LLHD_SigOp : LLHD_Op<"sig", [
-    ParentOneOf<["llhd::EntityOp", "llhd::ProcOp"]>,
     TypesMatchWith<
       "type of 'init' and underlying type of 'signal' have to match.",
       "init", "result", "SigType::get($_self)">

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -254,3 +254,35 @@ moore.module @ParamTest(){
   %2 = moore.constant 3 : l32
   %sp1 = moore.named_constant specparam %2 : l32
 }
+
+moore.module @Variable() {
+  // CHECK: [[TMP0:%.+]] = hw.constant 0 : i32
+  // CHECK: [[A:%.+]] = llhd.sig "a" [[TMP0]] : i32
+  %a = moore.variable : <i32>
+
+  // CHECK: [[TMP1:%.+]] = hw.constant 0 : i8
+  // CHECK: [[B:%.+]] = llhd.sig "b1" [[TMP1]] : i8
+  %b1 = moore.variable : <i8>
+
+  // CHECK: [[PRB:%.+]] = llhd.prb [[B]] : !llhd.sig<i8>
+  %0 = moore.read %b1 : i8
+  // CHECK: llhd.sig "b2" [[PRB]] : i8
+  %b2 = moore.variable %0 : <i8>
+
+  // CHECK: %true = hw.constant true
+  %1 = moore.constant true : i1
+  // CHECK: [[CAST:%.+]] = hw.bitcast %true : (i1) -> i1
+  %2 = moore.conversion %1 : !moore.i1 -> !moore.l1
+  // CHECK: llhd.sig "l" [[CAST]] : i1
+  %l = moore.variable %2 : <l1>
+
+  // CHECK: [[TMP2:%.+]] = hw.constant 10 : i32
+  %3 = moore.constant 10 : i32
+  
+  // CHECK: [[TIME:%.+]] = llhd.constant_time <0ns, 0d, 0e>
+  // CHECK: llhd.drv [[A]], [[TMP2]] after [[TIME]] : !llhd.sig<i32>
+  moore.assign %a, %3 : i32
+
+  // CHECK: hw.output
+  moore.output
+}

--- a/test/Dialect/LLHD/IR/signal-errors.mlir
+++ b/test/Dialect/LLHD/IR/signal-errors.mlir
@@ -40,10 +40,3 @@ llhd.entity @check_unique_sig_names2 () -> () {
   %sig1 = llhd.sig "sigI1" %cI1 : i1
   %sig2 = llhd.output "sigI1" %cI1 after %time : i1
 }
-
-// -----
-
-func.func @illegal_sig_parent (%arg0: i1) {
-  // expected-error @+1 {{expects parent op to be one of 'llhd.entity, llhd.proc'}}
-  %0 = llhd.sig "sig" %arg0 : i1
-}


### PR DESCRIPTION
Lowering as the follow:
`moore.variable` ---> `llhd.sig`
`moore.read`      ---> `llhd.prb`
`moore.assign`   ---> `llhd.drv`
And I remove the trait(`ParentOneOf<["llhd::EntityOp", "llhd::ProcOp"]>`) of `LLHD_SigOp`.