### PR TITLE
Transform Flatten Memref Load

### DIFF
--- a/lib/Transforms/FlattenMemRefs.cpp
+++ b/lib/Transforms/FlattenMemRefs.cpp
@@ -65,7 +65,8 @@ static Value flattenIndices(ConversionPatternRewriter &rewriter, Operation *op,
     int64_t indexMulFactor = 1;
 
     // Calculate the product of the i'th index and the [0:i-1] shape dims.
-    for (unsigned i = 0; i <= memIdx.index(); ++i) {
+    for (unsigned i = memIdx.index() + 1; i < memrefType.getShape().size();
+         ++i) {
       int64_t dimSize = memrefType.getShape()[i];
       indexMulFactor *= dimSize;
     }
@@ -77,15 +78,15 @@ static Value flattenIndices(ConversionPatternRewriter &rewriter, Operation *op,
               .create<arith::ConstantOp>(
                   loc, rewriter.getIndexAttr(llvm::Log2_64(indexMulFactor)))
               .getResult();
-      partialIdx =
-          rewriter.create<arith::ShLIOp>(loc, partialIdx, constant).getResult();
+      finalIdx =
+          rewriter.create<arith::ShLIOp>(loc, finalIdx, constant).getResult();
     } else {
       auto constant = rewriter
                           .create<arith::ConstantOp>(
                               loc, rewriter.getIndexAttr(indexMulFactor))
                           .getResult();
-      partialIdx =
-          rewriter.create<arith::MulIOp>(loc, partialIdx, constant).getResult();
+      finalIdx =
+          rewriter.create<arith::MulIOp>(loc, finalIdx, constant).getResult();
     }
 
     // Sum up with the prior lower dimension accessors.

--- a/test/Transforms/flatten_memref.mlir
+++ b/test/Transforms/flatten_memref.mlir
@@ -1,15 +1,15 @@
 // RUN: circt-opt -split-input-file --flatten-memref %s | FileCheck %s
 
 // CHECK-LABEL:   func @as_func_arg(
-// CHECK:                      %[[VAL_0:.*]]: memref<16xi32>,
-// CHECK:                      %[[VAL_1:.*]]: index) -> i32 {
+// CHECK-SAME:                           %[[VAL_0:.*]]: memref<16xi32>,
+// CHECK-SAME:                           %[[VAL_1:.*]]: index) -> i32 {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : index
 // CHECK:           %[[VAL_3:.*]] = arith.shli %[[VAL_1]], %[[VAL_2]] : index
-// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_1]], %[[VAL_3]] : index
+// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_3]], %[[VAL_1]] : index
 // CHECK:           %[[VAL_5:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_4]]] : memref<16xi32>
 // CHECK:           %[[VAL_6:.*]] = arith.constant 2 : index
 // CHECK:           %[[VAL_7:.*]] = arith.shli %[[VAL_1]], %[[VAL_6]] : index
-// CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_1]], %[[VAL_7]] : index
+// CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_7]], %[[VAL_1]] : index
 // CHECK:           memref.store %[[VAL_5]], %[[VAL_0]]{{\[}}%[[VAL_8]]] : memref<16xi32>
 // CHECK:           return %[[VAL_5]] : i32
 // CHECK:         }
@@ -23,12 +23,12 @@ func.func @as_func_arg(%a : memref<4x4xi32>, %i : index) -> i32 {
 
 // CHECK-LABEL:   func @multidim3(
 // CHECK:                    %[[VAL_0:.*]]: memref<210xi32>, %[[VAL_1:.*]]: index, %[[VAL_2:.*]]: index, %[[VAL_3:.*]]: index) -> i32 {
-// CHECK:           %[[VAL_4:.*]] = arith.constant 5 : index
-// CHECK:           %[[VAL_5:.*]] = arith.muli %[[VAL_2]], %[[VAL_4]] : index
-// CHECK:           %[[VAL_6:.*]] = arith.addi %[[VAL_1]], %[[VAL_5]] : index
-// CHECK:           %[[VAL_7:.*]] = arith.constant 30 : index
-// CHECK:           %[[VAL_8:.*]] = arith.muli %[[VAL_3]], %[[VAL_7]] : index
-// CHECK:           %[[VAL_9:.*]] = arith.addi %[[VAL_6]], %[[VAL_8]] : index
+// CHECK:           %[[VAL_4:.*]] = arith.constant 42 : index
+// CHECK:           %[[VAL_5:.*]] = arith.muli %[[VAL_1]], %[[VAL_4]] : index
+// CHECK:           %[[VAL_6:.*]] = arith.addi %[[VAL_5]], %[[VAL_2]] : index
+// CHECK:           %[[VAL_7:.*]] = arith.constant 7 : index
+// CHECK:           %[[VAL_8:.*]] = arith.muli %[[VAL_6]], %[[VAL_7]] : index
+// CHECK:           %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_3]] : index
 // CHECK:           %[[VAL_10:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_9]]] : memref<210xi32>
 // CHECK:           return %[[VAL_10]] : i32
 // CHECK:         }
@@ -40,20 +40,19 @@ func.func @multidim3(%a : memref<5x6x7xi32>, %i1 : index, %i2 : index, %i3 : ind
 // -----
 
 // CHECK-LABEL:   func @multidim5(
-// CHECK:                    %[[VAL_0:.*]]: memref<18900xi32>,
-// CHECK:                    %[[VAL_1:.*]]: index) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.constant 5 : index
+// CHECK:                    %[[VAL_0:.*]]: memref<18900xi32>, %[[VAL_1:.*]]: index) -> i32 {
+// CHECK:           %[[VAL_2:.*]] = arith.constant 3780 : index
 // CHECK:           %[[VAL_3:.*]] = arith.muli %[[VAL_1]], %[[VAL_2]] : index
-// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_1]], %[[VAL_3]] : index
-// CHECK:           %[[VAL_5:.*]] = arith.constant 30 : index
-// CHECK:           %[[VAL_6:.*]] = arith.muli %[[VAL_1]], %[[VAL_5]] : index
-// CHECK:           %[[VAL_7:.*]] = arith.addi %[[VAL_4]], %[[VAL_6]] : index
-// CHECK:           %[[VAL_8:.*]] = arith.constant 210 : index
-// CHECK:           %[[VAL_9:.*]] = arith.muli %[[VAL_1]], %[[VAL_8]] : index
-// CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_7]], %[[VAL_9]] : index
-// CHECK:           %[[VAL_11:.*]] = arith.constant 1890 : index
-// CHECK:           %[[VAL_12:.*]] = arith.muli %[[VAL_1]], %[[VAL_11]] : index
-// CHECK:           %[[VAL_13:.*]] = arith.addi %[[VAL_10]], %[[VAL_12]] : index
+// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_3]], %[[VAL_1]] : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 630 : index
+// CHECK:           %[[VAL_6:.*]] = arith.muli %[[VAL_4]], %[[VAL_5]] : index
+// CHECK:           %[[VAL_7:.*]] = arith.addi %[[VAL_6]], %[[VAL_1]] : index
+// CHECK:           %[[VAL_8:.*]] = arith.constant 90 : index
+// CHECK:           %[[VAL_9:.*]] = arith.muli %[[VAL_7]], %[[VAL_8]] : index
+// CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_9]], %[[VAL_1]] : index
+// CHECK:           %[[VAL_11:.*]] = arith.constant 10 : index
+// CHECK:           %[[VAL_12:.*]] = arith.muli %[[VAL_10]], %[[VAL_11]] : index
+// CHECK:           %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_1]] : index
 // CHECK:           %[[VAL_14:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_13]]] : memref<18900xi32>
 // CHECK:           return %[[VAL_14]] : i32
 // CHECK:         }
@@ -65,20 +64,19 @@ func.func @multidim5(%a : memref<5x6x7x9x10xi32>, %i : index) -> i32 {
 // -----
 
 // CHECK-LABEL:   func @multidim5_p2(
-// CHECK:                       %[[VAL_0:.*]]: memref<512xi32>,
-// CHECK:                       %[[VAL_1:.*]]: index) -> i32 {
-// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : index
+// CHECK:                    %[[VAL_0:.*]]: memref<512xi32>, %[[VAL_1:.*]]: index) -> i32 {
+// CHECK:           %[[VAL_2:.*]] = arith.constant 8 : index
 // CHECK:           %[[VAL_3:.*]] = arith.shli %[[VAL_1]], %[[VAL_2]] : index
-// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_1]], %[[VAL_3]] : index
-// CHECK:           %[[VAL_5:.*]] = arith.constant 3 : index
-// CHECK:           %[[VAL_6:.*]] = arith.shli %[[VAL_1]], %[[VAL_5]] : index
-// CHECK:           %[[VAL_7:.*]] = arith.addi %[[VAL_4]], %[[VAL_6]] : index
-// CHECK:           %[[VAL_8:.*]] = arith.constant 6 : index
-// CHECK:           %[[VAL_9:.*]] = arith.shli %[[VAL_1]], %[[VAL_8]] : index
-// CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_7]], %[[VAL_9]] : index
-// CHECK:           %[[VAL_11:.*]] = arith.constant 7 : index
-// CHECK:           %[[VAL_12:.*]] = arith.shli %[[VAL_1]], %[[VAL_11]] : index
-// CHECK:           %[[VAL_13:.*]] = arith.addi %[[VAL_10]], %[[VAL_12]] : index
+// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_3]], %[[VAL_1]] : index
+// CHECK:           %[[VAL_5:.*]] = arith.constant 6 : index
+// CHECK:           %[[VAL_6:.*]] = arith.shli %[[VAL_4]], %[[VAL_5]] : index
+// CHECK:           %[[VAL_7:.*]] = arith.addi %[[VAL_6]], %[[VAL_1]] : index
+// CHECK:           %[[VAL_8:.*]] = arith.constant 3 : index
+// CHECK:           %[[VAL_9:.*]] = arith.shli %[[VAL_7]], %[[VAL_8]] : index
+// CHECK:           %[[VAL_10:.*]] = arith.addi %[[VAL_9]], %[[VAL_1]] : index
+// CHECK:           %[[VAL_11:.*]] = arith.constant 2 : index
+// CHECK:           %[[VAL_12:.*]] = arith.shli %[[VAL_10]], %[[VAL_11]] : index
+// CHECK:           %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_1]] : index
 // CHECK:           %[[VAL_14:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_13]]] : memref<512xi32>
 // CHECK:           return %[[VAL_14]] : i32
 // CHECK:         }
@@ -117,12 +115,12 @@ func.func @allocs() -> memref<4x4xi32> {
 // CHECK:           cf.cond_br %[[VAL_2]], ^bb1(%[[VAL_3]], %[[VAL_4]] : memref<16xi32>, memref<16xi32>), ^bb1(%[[VAL_4]], %[[VAL_3]] : memref<16xi32>, memref<16xi32>)
 // CHECK:         ^bb1(%[[VAL_5:.*]]: memref<16xi32>, %[[VAL_6:.*]]: memref<16xi32>):
 // CHECK:           %[[VAL_7:.*]] = arith.constant 2 : index
-// CHECK:           %[[VAL_8:.*]] = arith.shli %[[VAL_1]], %[[VAL_7]] : index
-// CHECK:           %[[VAL_9:.*]] = arith.addi %[[VAL_0]], %[[VAL_8]] : index
+// CHECK:           %[[VAL_8:.*]] = arith.shli %[[VAL_0]], %[[VAL_7]] : index
+// CHECK:           %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_1]] : index
 // CHECK:           %[[VAL_10:.*]] = memref.load %[[VAL_5]]{{\[}}%[[VAL_9]]] : memref<16xi32>
 // CHECK:           %[[VAL_11:.*]] = arith.constant 2 : index
-// CHECK:           %[[VAL_12:.*]] = arith.shli %[[VAL_1]], %[[VAL_11]] : index
-// CHECK:           %[[VAL_13:.*]] = arith.addi %[[VAL_0]], %[[VAL_12]] : index
+// CHECK:           %[[VAL_12:.*]] = arith.shli %[[VAL_0]], %[[VAL_11]] : index
+// CHECK:           %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_1]] : index
 // CHECK:           memref.store %[[VAL_10]], %[[VAL_6]]{{\[}}%[[VAL_13]]] : memref<16xi32>
 // CHECK:           return
 // CHECK:         }


### PR DESCRIPTION
Caught a small issue with flattening the load.

Say we have an example:
```mlir
module {
  func.func @main(%arg0: memref<3x4xi32>) {
    %c1 = arith.constant 1 : index
    %c2 = arith.constant 2 : index
    %c3 = arith.constant 3 : index
    %c4 = arith.constant 4 : index
    %c0 = arith.constant 0 : index
    %alloc = memref.alloc() {alignment = 64 : i64} : memref<4x2xi32>
    scf.for %arg1 = %c0 to %c3 step %c1 {
      scf.for %arg2 = %c0 to %c2 step %c1 {
        scf.for %arg3 = %c0 to %c4 step %c1 {
          %0 = memref.load %arg0[%arg1, %arg3] : memref<3x4xi32>
          %1 = memref.load %alloc[%arg3, %arg2] : memref<4x2xi32>
          %2 = arith.muli %1, %2 : i32
        }
      }
    }
    return
  }
}
```

Previously, it gives:
```mlir
module {
  func.func @main(%arg0: memref<12xi32>) {
    %c1 = arith.constant 1 : index
    %c2 = arith.constant 2 : index
    %c3 = arith.constant 3 : index
    %c4 = arith.constant 4 : index
    %c0 = arith.constant 0 : index
    %alloc = memref.alloc() : memref<8xi32>
    scf.for %arg1 = %c0 to %c3 step %c1 {
      scf.for %arg2 = %c0 to %c2 step %c1 {
        scf.for %arg3 = %c0 to %c4 step %c1 {
          %c3_1 = arith.constant 3 : index
          %1 = arith.muli %arg3, %c3_1 : index
          %2 = arith.addi %arg1, %1 : index
          %3 = memref.load %arg0[%2] : memref<12xi32>
          %c2_2 = arith.constant 2 : index
          %4 = arith.shli %arg2, %c2_2 : index
          %5 = arith.addi %arg3, %4 : index
          %6 = memref.load %alloc[%5] : memref<8xi32>
          %7 = arith.muli %3, %6 : i32
        }
      }
    }
    return
  }
}
```

It is wrong because it's doing:
```mlir
  %1 = arith.muli %arg3, %c3_1 : index
  %2 = arith.addi %arg1, %1 : index
```
And the order of accessing the memory is:
```
%arg1 = 0, %arg3 = 0 -> access 0 * 3 + 0 = 0;
%arg1 = 0, %arg3 = 1 -> access 1 * 3 + 0 = 0; (oops, wrong because we should access address 1)
```

What it should be, which is also the result after fixing it, is:
```mlir
module {
  func.func @main(%arg0: memref<12xi32>) {
    %c1 = arith.constant 1 : index
    %c2 = arith.constant 2 : index
    %c3 = arith.constant 3 : index
    %c4 = arith.constant 4 : index
    %c0 = arith.constant 0 : index
    %alloc = memref.alloc() : memref<8xi32>
    scf.for %arg1 = %c0 to %c3 step %c1 {
      scf.for %arg2 = %c0 to %c2 step %c1 {
        scf.for %arg3 = %c0 to %c4 step %c1 {
          %c2_1 = arith.constant 2 : index
          %1 = arith.shli %arg1, %c2_1 : index
          %2 = arith.addi %1, %arg3 : index
          %3 = memref.load %arg0[%2] : memref<12xi32>
          %c1_2 = arith.constant 1 : index
          %4 = arith.shli %arg3, %c1_2 : index
          %5 = arith.addi %4, %arg2 : index
          %6 = memref.load %alloc[%5] : memref<8xi32>
          %7 = arith.muli %3, %6 : i32
        }
      }
    }
    return
  }
}
```