### PR TITLE
[PyCDE][ESI] Manifest: add record about client

### DIFF
--- a/frontends/PyCDE/test/test_esi_servicegens.py
+++ b/frontends/PyCDE/test/test_esi_servicegens.py
@@ -56,6 +56,7 @@ class MultiplexerService(esi.ServiceImplementation):
     assert len(
         bundles.to_client_reqs) == 1, "Only one connection request supported"
     bundle = bundles.to_client_reqs[0]
+    bundle.add_record({"foo": 5})
     to_req_types = {}
     for bundled_chan in bundle.type.channels:
       if bundled_chan.direction == ChannelDirection.TO:

--- a/include/circt-c/Dialect/ESI.h
+++ b/include/circt-c/Dialect/ESI.h
@@ -62,7 +62,8 @@ circtESIBundleTypeGetChannel(MlirType bundle, size_t idx);
 //===----------------------------------------------------------------------===//
 
 typedef MlirLogicalResult (*CirctESIServiceGeneratorFunc)(
-    MlirOperation serviceImplementReqOp, MlirOperation declOp, void *userData);
+    MlirOperation serviceImplementReqOp, MlirOperation declOp,
+    MlirOperation recordOp, void *userData);
 MLIR_CAPI_EXPORTED void circtESIRegisterGlobalServiceGenerator(
     MlirStringRef impl_type, CirctESIServiceGeneratorFunc, void *userData);
 

--- a/integration_test/Bindings/Python/dialects/esi.py
+++ b/integration_test/Bindings/Python/dialects/esi.py
@@ -41,13 +41,23 @@ with Context() as ctx:
   assert (bundle_type.resettable)
   print()
 
+# CHECK-LABEL: === testGen called with ops:
+# CHECK-NEXT:  [[R0:%.+]]:2 = esi.service.impl_req #esi.appid<"mstop"> svc @HostComms impl as "test"(%clk) : (i1) -> (i8, !esi.bundle<[!esi.channel<i8> to "recv"]>) {
+# CHECK-NEXT:    [[R2:%.+]] = esi.service.impl_req.req <@HostComms::@Recv>([#esi.appid<"loopback_tohw">]) : !esi.bundle<[!esi.channel<i8> to "recv"]>
+# CHECK-NEXT:  }
+# CHECK-NEXT:  esi.service.decl @HostComms {
+# CHECK-NEXT:    esi.service.port @Recv : !esi.bundle<[!esi.channel<i8> to "recv"]>
+# CHECK-NEXT:  }
+# CHECK-NEXT:  esi.manifest.service_impl #esi.appid<"mstop"> svc @HostComms by "test" with {}
 
-# CHECK-LABEL: === testGen called with op:
-# CHECK:       [[R0:%.+]]:2 = esi.service.impl_req #esi.appid<"mstop"> svc @HostComms impl as "test"(%clk) : (i1) -> (i8, !esi.bundle<[!esi.channel<i8> to "recv"]>) {
-# CHECK:         [[R2:%.+]] = esi.service.impl_req.req <@HostComms::@Recv>([#esi.appid<"loopback_tohw">]) : !esi.bundle<[!esi.channel<i8> to "recv"]>
-def testGen(reqOp: esi.ServiceImplementReqOp) -> bool:
-  print("=== testGen called with op:")
+
+def testGen(reqOp: Operation, decl_op: Operation, rec_op: Operation) -> bool:
+  print("=== testGen called with ops:")
   reqOp.print()
+  print()
+  decl_op.print()
+  print()
+  rec_op.print()
   print()
   return True
 

--- a/lib/Bindings/Python/ESIModule.cpp
+++ b/lib/Bindings/Python/ESIModule.cpp
@@ -35,11 +35,12 @@ using namespace circt::esi;
 // pointers since we also need to allocate memory for the string.
 llvm::DenseMap<std::string *, PyObject *> serviceGenFuncLookup;
 static MlirLogicalResult serviceGenFunc(MlirOperation reqOp,
-                                        MlirOperation declOp, void *userData) {
+                                        MlirOperation declOp,
+                                        MlirOperation recOp, void *userData) {
   std::string *name = static_cast<std::string *>(userData);
   py::handle genFunc(serviceGenFuncLookup[name]);
   py::gil_scoped_acquire();
-  py::object rc = genFunc(reqOp);
+  py::object rc = genFunc(reqOp, declOp, recOp);
   return rc.cast<bool>() ? mlirLogicalResultSuccess()
                          : mlirLogicalResultFailure();
 }

--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -86,10 +86,11 @@ void circtESIRegisterGlobalServiceGenerator(
     MlirStringRef impl_type, CirctESIServiceGeneratorFunc genFunc,
     void *userData) {
   ServiceGeneratorDispatcher::globalDispatcher().registerGenerator(
-      unwrap(impl_type),
-      [genFunc, userData](ServiceImplementReqOp req,
-                          ServiceDeclOpInterface decl, ServiceImplRecordOp) {
-        return unwrap(genFunc(wrap(req), wrap(decl.getOperation()), userData));
+      unwrap(impl_type), [genFunc, userData](ServiceImplementReqOp req,
+                                             ServiceDeclOpInterface decl,
+                                             ServiceImplRecordOp record) {
+        return unwrap(genFunc(wrap(req), wrap(decl.getOperation()),
+                              wrap(record.getOperation()), userData));
       });
 }
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Call to add a record to the manifest about a particular client. Required plumbing through the record op to python.