### PR TITLE
Lower MemRef GetGlobal and write data to json files

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -182,7 +182,9 @@ def SCFToCalyx : Pass<"lower-scf-to-calyx", "mlir::ModuleOp"> {
             "Identifier of top-level function to be the entry-point component"
             " of the Calyx program.">,
     Option<"ciderSourceLocationMetadata", "cider-source-location-metadata", "bool", "",
-            "Whether to track source location for the Cider debugger.">
+            "Whether to track source location for the Cider debugger.">,
+    Option<"writeJsonOpt", "write-json", "bool", "",
+            "Whether to write memory contents to the json file.">
   ];
 }
 

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -183,7 +183,7 @@ def SCFToCalyx : Pass<"lower-scf-to-calyx", "mlir::ModuleOp"> {
             " of the Calyx program.">,
     Option<"ciderSourceLocationMetadata", "cider-source-location-metadata", "bool", "",
             "Whether to track source location for the Cider debugger.">,
-    Option<"writeJsonOpt", "write-json", "bool", "",
+    Option<"writeJsonOpt", "write-json", "std::string", "",
             "Whether to write memory contents to the json file.">
   ];
 }

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -520,7 +520,8 @@ private:
   /// A mapping between the callee and the instance.
   llvm::StringMap<calyx::InstanceOp> instanceMap;
 
-  /// A json file to store external global memory data
+  /// A json file to store external global memory data. See
+  /// https://docs.calyxir.org/lang/data-format.html?highlight=json#the-data-format
   llvm::json::Value extMemData;
 };
 

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -33,6 +33,8 @@
 namespace circt {
 namespace calyx {
 
+using json = nlohmann::ordered_json;
+
 void appendPortsForExternalMemref(PatternRewriter &rewriter, StringRef memName,
                                   Value memref, unsigned memoryID,
                                   SmallVectorImpl<calyx::PortInfo> &inPorts,

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -450,6 +450,20 @@ public:
     return builder.create<TLibraryOp>(loc, getUniqueName(name), resTypes);
   }
 
+  json &getExtMemData() { return extMemData; }
+
+  const json &getExtMemData() const { return extMemData; }
+
+  void setDataField(StringRef name, const json::array_t &data) {
+    extMemData[name]["data"] = data;
+  }
+
+  void setFormat(StringRef name, std::string numType, bool isSigned,
+                 unsigned width) {
+    extMemData[name]["format"] = {
+        {"numeric_type", numType}, {"is_signed", true}, {"width", width}};
+  }
+
 private:
   /// The component which this lowering state is associated to.
   calyx::ComponentOp component;

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -27,13 +27,12 @@
 #include "mlir/IR/PatternMatch.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/JSON.h"
 
 #include <variant>
 
 namespace circt {
 namespace calyx {
-
-using json = nlohmann::ordered_json;
 
 void appendPortsForExternalMemref(PatternRewriter &rewriter, StringRef memName,
                                   Value memref, unsigned memoryID,
@@ -452,18 +451,36 @@ public:
     return builder.create<TLibraryOp>(loc, getUniqueName(name), resTypes);
   }
 
-  json &getExtMemData() { return extMemData; }
+  llvm::json::Value &getExtMemData() { return extMemData; }
 
-  const json &getExtMemData() const { return extMemData; }
+  const llvm::json::Value &getExtMemData() const { return extMemData; }
 
-  void setDataField(StringRef name, const json::array_t &data) {
-    extMemData[name]["data"] = data;
+  void setDataField(StringRef name, llvm::json::Array data) {
+    auto *extMemDataObj = extMemData.getAsObject();
+    assert(extMemDataObj && "extMemData should be an object");
+
+    auto &value = (*extMemDataObj)[name.str()];
+    llvm::json::Object *obj = value.getAsObject();
+    if (!obj) {
+      value = llvm::json::Object{};
+      obj = value.getAsObject();
+    }
+    (*obj)["data"] = llvm::json::Value(std::move(data));
   }
 
   void setFormat(StringRef name, std::string numType, bool isSigned,
                  unsigned width) {
-    extMemData[name]["format"] = {
-        {"numeric_type", numType}, {"is_signed", true}, {"width", width}};
+    auto *extMemDataObj = extMemData.getAsObject();
+    assert(extMemDataObj && "extMemData should be an object");
+
+    auto &value = (*extMemDataObj)[name.str()];
+    llvm::json::Object *obj = value.getAsObject();
+    if (!obj) {
+      value = llvm::json::Object{};
+      obj = value.getAsObject();
+    }
+    (*obj)["format"] = llvm::json::Object{
+        {"numeric_type", numType}, {"is_signed", isSigned}, {"width", width}};
   }
 
 private:
@@ -502,6 +519,9 @@ private:
 
   /// A mapping between the callee and the instance.
   llvm::StringMap<calyx::InstanceOp> instanceMap;
+
+  /// A json file to store external global memory data
+  llvm::json::Value extMemData;
 };
 
 /// An interface for conversion passes that lower Calyx programs. This handles

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -47,7 +47,7 @@ namespace circt {
 class ComponentLoweringStateInterface;
 namespace scftocalyx {
 
-using json = nlohmann::json;
+using json = nlohmann::ordered_json;
 
 //===----------------------------------------------------------------------===//
 // Utility types

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1078,7 +1078,7 @@ static LogicalResult buildAllocOp(ComponentLoweringState &componentState,
     numType = "bitnum";
     isSigned = false;
   } else {
-    numType = "floating_point";
+    numType = "ieee754_float";
     isSigned = true;
   }
   componentState.setFormat(memoryOp.getName(), numType, isSigned, width);

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -328,8 +328,10 @@ public:
           jsonOS.value(getState<ComponentLoweringState>().getExtMemData());
           jsonOS.flush();
           outFile.close();
-        } else
+        } else {
           llvm::errs() << "Unable to open file for writing\n";
+          return failure();
+        }
       }
     }
 
@@ -967,6 +969,11 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 void insertNestedArrayValue(llvm::json::Array &array,
                             const std::vector<int> &indices, size_t index,
                             llvm::json::Value value) {
+  if (indices.empty()) {
+    array.emplace_back(std::move(value));
+    return;
+  }
+
   if (index == indices.size() - 1) {
     // ensure the array is big enough
     while (array.size() <= static_cast<size_t>(indices[index])) {

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -316,8 +316,9 @@ class BuildOpGroups : public calyx::FuncOpPartialLoweringPattern {
 
         if (outFile.is_open()) {
           llvm::raw_os_ostream llvmOut(outFile);
-          llvm::json::OStream JOS(llvmOut, 2);
-          JOS.value(getState<ComponentLoweringState>().getExtMemData());
+          llvm::json::OStream jsonOS(llvmOut, 2);
+          jsonOS.value(getState<ComponentLoweringState>().getExtMemData());
+          jsonOS.flush();
           outFile.close();
         } else
           llvm::errs() << "Unable to open file for writing\n";

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -268,6 +268,14 @@ public:
 /// Iterate through the operations of a source function and instantiate
 /// components or primitives based on the type of the operations.
 class BuildOpGroups : public calyx::FuncOpPartialLoweringPattern {
+public:
+  BuildOpGroups(MLIRContext *context, LogicalResult &resRef,
+                calyx::PatternApplicationState &patternState,
+                DenseMap<mlir::func::FuncOp, calyx::ComponentOp> &map,
+                calyx::CalyxLoweringState &state,
+                mlir::Pass::Option<bool> &writeJsonOpt)
+      : FuncOpPartialLoweringPattern(context, resRef, patternState, map, state),
+        writeJson(writeJsonOpt) {}
   using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
 
   LogicalResult
@@ -329,6 +337,7 @@ class BuildOpGroups : public calyx::FuncOpPartialLoweringPattern {
   }
 
 private:
+  mlir::Pass::Option<bool> &writeJson;
   /// Op builder specializations.
   LogicalResult buildOp(PatternRewriter &rewriter, scf::YieldOp yieldOp) const;
   LogicalResult buildOp(PatternRewriter &rewriter,
@@ -2762,7 +2771,7 @@ void SCFToCalyxPass::runOnOperation() {
   /// having a distinct group for each operation, groups are analogous to SSA
   /// values in the source program.
   addOncePattern<BuildOpGroups>(loweringPatterns, patternState, funcMap,
-                                *loweringState);
+                                *loweringState, writeJsonOpt);
 
   /// This pattern traverses the CFG of the program and generates a control
   /// schedule based on the calyx::GroupOp's which were registered for each

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -318,7 +318,7 @@ BasicLoopInterface::~BasicLoopInterface() = default;
 
 ComponentLoweringStateInterface::ComponentLoweringStateInterface(
     calyx::ComponentOp component)
-    : component(component) {}
+    : component(component), extMemData(llvm::json::Object{}) {}
 
 ComponentLoweringStateInterface::~ComponentLoweringStateInterface() = default;
 

--- a/test/Conversion/SCFToCalyx/write_memory.mlir
+++ b/test/Conversion/SCFToCalyx/write_memory.mlir
@@ -20,8 +20,8 @@
 // CHECK:           ],
 // CHECK:           "format": {
 // CHECK:             "is_signed": true,
-// CHECK:             "numeric_type": "ieee754_float",
-// CHECK:             "width": 32
+// CHECK:             "numeric_type": "bitnum",
+// CHECK:             "width": 8
 // CHECK:           }
 // CHECK:         },
 
@@ -56,14 +56,27 @@
 // CHECK:             "numeric_type": "ieee754_float",
 // CHECK:             "width": 32
 // CHECK:           }
+// CHECK:         },
+
+// CHECK-LABEL:   "mem_4": {
+// CHECK:           "data": [
+// CHECK:             -42,
+// CHECK:             35
+// CHECK:           ],
+// CHECK:           "format": {
+// CHECK:             "is_signed": true,
+// CHECK:             "numeric_type": "bitnum",
+// CHECK:             "width": 8
+// CHECK:           }
 // CHECK:         }
 
 module {
   memref.global "private" constant @constant_10xi32_0 : memref<10xi32> = dense<[43, 8, -39, -19, 70, -64, -7, -27, -57, 5]>
+  memref.global "private" constant @constant_2xsi8_0 : memref<2xsi8> = dense<[-42, 35]>
   memref.global "private" constant @constant_3xf32 : memref<3xf32> = dense<[0.7, -4.2, 0.0]>
   func.func @main(%arg_idx : index) -> i32 {
     %alloc = memref.alloc() : memref<4xf32>
-    %zero_dim_mem = memref.alloca() : memref<f32>
+    %zero_dim_mem = memref.alloca() : memref<si8>
     %c2 = arith.constant 2 : index
     %c1 = arith.constant 1 : index
     %0 = memref.get_global @constant_10xi32_0 : memref<10xi32>
@@ -71,7 +84,9 @@ module {
     %1 = memref.get_global @constant_3xf32 : memref<3xf32>
     %2 = memref.load %1[%c1] : memref<3xf32>
     memref.store %2, %alloc[%c2] : memref<4xf32>
-    memref.store %2, %zero_dim_mem[] : memref<f32>
+    %3 = memref.get_global @constant_2xsi8_0 : memref<2xsi8>
+    %4 = memref.load %3[%c1] : memref<2xsi8>
+    memref.store %4, %zero_dim_mem[] : memref<si8>
     return %ret : i32
   }
 }

--- a/test/Conversion/SCFToCalyx/write_memory.mlir
+++ b/test/Conversion/SCFToCalyx/write_memory.mlir
@@ -1,51 +1,51 @@
-// RUN: circt-opt %s --lower-scf-to-calyx="write-json=data" -canonicalize -split-input-file>/dev/null && cat ./data.json | FileCheck %s
+// RUN: circt-opt %s --lower-scf-to-calyx="write-json=data" -canonicalize>/dev/null && cat $(dirname %s)/data.json | FileCheck %s
 
 // CHECK-LABEL:   "mem_0": {
-// CHECK:           "data": [
-// CHECK:             0,
-// CHECK:             0,
-// CHECK:             0,
-// CHECK:             0
-// CHECK:           ],
-// CHECK:           "format": {
-// CHECK:             "is_signed": true,
-// CHECK:             "numeric_type": "ieee754_float",
-// CHECK:             "width": 32
-// CHECK:           }
-// CHECK:         },
+// CHECK-DAG:           "data": [
+// CHECK-DAG:             0,
+// CHECK-DAG:             0,
+// CHECK-DAG:             0,
+// CHECK-DAG:             0
+// CHECK-DAG:           ],
+// CHECK-DAG:           "format": {
+// CHECK-DAG:             "is_signed": false,
+// CHECK-DAG:             "numeric_type": "ieee754_float",
+// CHECK-DAG:             "width": 32
+// CHECK-DAG:           }
+// CHECK-DAG:         },
 
 // CHECK-LABEL:   "mem_1": {
-// CHECK:           "data": [
-// CHECK:             43,
-// CHECK:             8,
-// CHECK:             -39,
-// CHECK:             -19,
-// CHECK:             70,
-// CHECK:             -64,
-// CHECK:             -7,
-// CHECK:             -27,
-// CHECK:             -57,
-// CHECK:             5
-// CHECK:           ],
-// CHECK:           "format": {
-// CHECK:             "is_signed": false,
-// CHECK:             "numeric_type": "bitnum",
-// CHECK:             "width": 32
-// CHECK:           }
-// CHECK:         },
+// CHECK-DAG:           "data": [
+// CHECK-DAG:             43,
+// CHECK-DAG:             8,
+// CHECK-DAG:             -39,
+// CHECK-DAG:             -19,
+// CHECK-DAG:             70,
+// CHECK-DAG:             -64,
+// CHECK-DAG:             -7,
+// CHECK-DAG:             -27,
+// CHECK-DAG:             -57,
+// CHECK-DAG:             5
+// CHECK-DAG:           ],
+// CHECK-DAG:           "format": {
+// CHECK-DAG:             "is_signed": true,
+// CHECK-DAG:             "numeric_type": "bitnum",
+// CHECK-DAG:             "width": 32
+// CHECK-DAG:           }
+// CHECK-DAG:         },
 
 // CHECK-LABEL:   "mem_2": {
-// CHECK:           "data": [
-// CHECK:             0.69999998807907104,
-// CHECK:             -4.1999998092651367,
-// CHECK:             0
-// CHECK:           ],
-// CHECK:           "format": {
-// CHECK:             "is_signed": true,
-// CHECK:             "numeric_type": "ieee754_float",
-// CHECK:             "width": 32
-// CHECK:           }
-// CHECK:         }
+// CHECK-DAG:           "data": [
+// CHECK-DAG:             0.69999998807907104,
+// CHECK-DAG:             -4.1999998092651367,
+// CHECK-DAG:             0
+// CHECK-DAG:           ],
+// CHECK-DAG:           "format": {
+// CHECK-DAG:             "is_signed": true,
+// CHECK-DAG:             "numeric_type": "ieee754_float",
+// CHECK-DAG:             "width": 32
+// CHECK-DAG:           }
+// CHECK-DAG:         }
 
 module {
   memref.global "private" constant @constant_10xi32_0 : memref<10xi32> = dense<[43, 8, -39, -19, 70, -64, -7, -27, -57, 5]>

--- a/test/Conversion/SCFToCalyx/write_memory.mlir
+++ b/test/Conversion/SCFToCalyx/write_memory.mlir
@@ -1,57 +1,69 @@
 // RUN: circt-opt %s --lower-scf-to-calyx="write-json=data" -canonicalize>/dev/null && cat $(dirname %s)/data.json | FileCheck %s
 
 // CHECK-LABEL:   "mem_0": {
-// CHECK-DAG:           "data": [
-// CHECK-DAG:             0,
-// CHECK-DAG:             0,
-// CHECK-DAG:             0,
-// CHECK-DAG:             0
-// CHECK-DAG:           ],
-// CHECK-DAG:           "format": {
-// CHECK-DAG:             "is_signed": false,
-// CHECK-DAG:             "numeric_type": "ieee754_float",
-// CHECK-DAG:             "width": 32
-// CHECK-DAG:           }
-// CHECK-DAG:         },
+// CHECK:           "data": [
+// CHECK:             0,
+// CHECK:             0,
+// CHECK:             0,
+// CHECK:             0
+// CHECK:           ],
+// CHECK:           "format": {
+// CHECK:             "is_signed": false,
+// CHECK:             "numeric_type": "ieee754_float",
+// CHECK:             "width": 32
+// CHECK:           }
+// CHECK:         },
 
 // CHECK-LABEL:   "mem_1": {
-// CHECK-DAG:           "data": [
-// CHECK-DAG:             43,
-// CHECK-DAG:             8,
-// CHECK-DAG:             -39,
-// CHECK-DAG:             -19,
-// CHECK-DAG:             70,
-// CHECK-DAG:             -64,
-// CHECK-DAG:             -7,
-// CHECK-DAG:             -27,
-// CHECK-DAG:             -57,
-// CHECK-DAG:             5
-// CHECK-DAG:           ],
-// CHECK-DAG:           "format": {
-// CHECK-DAG:             "is_signed": true,
-// CHECK-DAG:             "numeric_type": "bitnum",
-// CHECK-DAG:             "width": 32
-// CHECK-DAG:           }
-// CHECK-DAG:         },
+// CHECK:           "data": [
+// CHECK:             0
+// CHECK:           ],
+// CHECK:           "format": {
+// CHECK:             "is_signed": false,
+// CHECK:             "numeric_type": "ieee754_float",
+// CHECK:             "width": 32
+// CHECK:           }
+// CHECK:         },
 
 // CHECK-LABEL:   "mem_2": {
-// CHECK-DAG:           "data": [
-// CHECK-DAG:             0.69999998807907104,
-// CHECK-DAG:             -4.1999998092651367,
-// CHECK-DAG:             0
-// CHECK-DAG:           ],
-// CHECK-DAG:           "format": {
-// CHECK-DAG:             "is_signed": true,
-// CHECK-DAG:             "numeric_type": "ieee754_float",
-// CHECK-DAG:             "width": 32
-// CHECK-DAG:           }
-// CHECK-DAG:         }
+// CHECK:           "data": [
+// CHECK:             43,
+// CHECK:             8,
+// CHECK:             -39,
+// CHECK:             -19,
+// CHECK:             70,
+// CHECK:             -64,
+// CHECK:             -7,
+// CHECK:             -27,
+// CHECK:             -57,
+// CHECK:             5
+// CHECK:           ],
+// CHECK:           "format": {
+// CHECK:             "is_signed": true,
+// CHECK:             "numeric_type": "bitnum",
+// CHECK:             "width": 32
+// CHECK:           }
+// CHECK:         },
+
+// CHECK-LABEL:   "mem_3": {
+// CHECK:           "data": [
+// CHECK:             0.69999998807907104,
+// CHECK:             -4.1999998092651367,
+// CHECK:             0
+// CHECK:           ],
+// CHECK:           "format": {
+// CHECK:             "is_signed": true,
+// CHECK:             "numeric_type": "ieee754_float",
+// CHECK:             "width": 32
+// CHECK:           }
+// CHECK:         }
 
 module {
   memref.global "private" constant @constant_10xi32_0 : memref<10xi32> = dense<[43, 8, -39, -19, 70, -64, -7, -27, -57, 5]>
   memref.global "private" constant @constant_3xf32 : memref<3xf32> = dense<[0.7, -4.2, 0.0]>
   func.func @main(%arg_idx : index) -> i32 {
     %alloc = memref.alloc() : memref<4xf32>
+    %zero_dim_mem = memref.alloca() : memref<f32>
     %c2 = arith.constant 2 : index
     %c1 = arith.constant 1 : index
     %0 = memref.get_global @constant_10xi32_0 : memref<10xi32>
@@ -59,6 +71,7 @@ module {
     %1 = memref.get_global @constant_3xf32 : memref<3xf32>
     %2 = memref.load %1[%c1] : memref<3xf32>
     memref.store %2, %alloc[%c2] : memref<4xf32>
+    memref.store %2, %zero_dim_mem[] : memref<f32>
     return %ret : i32
   }
 }

--- a/test/Conversion/SCFToCalyx/write_memory.mlir
+++ b/test/Conversion/SCFToCalyx/write_memory.mlir
@@ -8,7 +8,7 @@
 // CHECK:             0
 // CHECK:           ],
 // CHECK:           "format": {
-// CHECK:             "is_signed": false,
+// CHECK:             "is_signed": true,
 // CHECK:             "numeric_type": "ieee754_float",
 // CHECK:             "width": 32
 // CHECK:           }
@@ -19,7 +19,7 @@
 // CHECK:             0
 // CHECK:           ],
 // CHECK:           "format": {
-// CHECK:             "is_signed": false,
+// CHECK:             "is_signed": true,
 // CHECK:             "numeric_type": "ieee754_float",
 // CHECK:             "width": 32
 // CHECK:           }
@@ -29,17 +29,17 @@
 // CHECK:           "data": [
 // CHECK:             43,
 // CHECK:             8,
-// CHECK:             -39,
-// CHECK:             -19,
+// CHECK:             4294967257,
+// CHECK:             4294967277,
 // CHECK:             70,
-// CHECK:             -64,
-// CHECK:             -7,
-// CHECK:             -27,
-// CHECK:             -57,
+// CHECK:             4294967232,
+// CHECK:             4294967289,
+// CHECK:             4294967269,
+// CHECK:             4294967239,
 // CHECK:             5
 // CHECK:           ],
 // CHECK:           "format": {
-// CHECK:             "is_signed": true,
+// CHECK:             "is_signed": false,
 // CHECK:             "numeric_type": "bitnum",
 // CHECK:             "width": 32
 // CHECK:           }

--- a/test/Conversion/SCFToCalyx/write_memory.mlir
+++ b/test/Conversion/SCFToCalyx/write_memory.mlir
@@ -1,0 +1,65 @@
+// RUN: circt-opt %s --lower-scf-to-calyx="write-json=data" -canonicalize -split-input-file>/dev/null && cat ./data.json | FileCheck %s
+
+// CHECK-LABEL:   "mem_0": {
+// CHECK:           "data": [
+// CHECK:             0,
+// CHECK:             0,
+// CHECK:             0,
+// CHECK:             0
+// CHECK:           ],
+// CHECK:           "format": {
+// CHECK:             "is_signed": true,
+// CHECK:             "numeric_type": "ieee754_float",
+// CHECK:             "width": 32
+// CHECK:           }
+// CHECK:         },
+
+// CHECK-LABEL:   "mem_1": {
+// CHECK:           "data": [
+// CHECK:             43,
+// CHECK:             8,
+// CHECK:             -39,
+// CHECK:             -19,
+// CHECK:             70,
+// CHECK:             -64,
+// CHECK:             -7,
+// CHECK:             -27,
+// CHECK:             -57,
+// CHECK:             5
+// CHECK:           ],
+// CHECK:           "format": {
+// CHECK:             "is_signed": false,
+// CHECK:             "numeric_type": "bitnum",
+// CHECK:             "width": 32
+// CHECK:           }
+// CHECK:         },
+
+// CHECK-LABEL:   "mem_2": {
+// CHECK:           "data": [
+// CHECK:             0.69999998807907104,
+// CHECK:             -4.1999998092651367,
+// CHECK:             0
+// CHECK:           ],
+// CHECK:           "format": {
+// CHECK:             "is_signed": true,
+// CHECK:             "numeric_type": "ieee754_float",
+// CHECK:             "width": 32
+// CHECK:           }
+// CHECK:         }
+
+module {
+  memref.global "private" constant @constant_10xi32_0 : memref<10xi32> = dense<[43, 8, -39, -19, 70, -64, -7, -27, -57, 5]>
+  memref.global "private" constant @constant_3xf32 : memref<3xf32> = dense<[0.7, -4.2, 0.0]>
+  func.func @main(%arg_idx : index) -> i32 {
+    %alloc = memref.alloc() : memref<4xf32>
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %0 = memref.get_global @constant_10xi32_0 : memref<10xi32>
+    %ret = memref.load %0[%arg_idx] : memref<10xi32>
+    %1 = memref.get_global @constant_3xf32 : memref<3xf32>
+    %2 = memref.load %1[%c1] : memref<3xf32>
+    memref.store %2, %alloc[%c2] : memref<4xf32>
+    return %ret : i32
+  }
+}
+


### PR DESCRIPTION
This patch lowers `memref::GetGlobalOp` and write data that it carries to corresponding json files, so that they can be used later by Calyx. Json data will be written to the same directory as the source file. Since there might be situations where users don't wish to do so, writing to json will only be carried out if users specify `--lower-scf-to-calyx="write-json=true"`.