### PR TITLE
[SV] Add UnpackedArrayCreateOp

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.td
+++ b/include/circt/Dialect/HW/HWTypes.td
@@ -46,6 +46,10 @@ def ArrayType : DialectType<HWDialect,
     CPred<"::circt::hw::type_isa<circt::hw::ArrayType>($_self)">,
           "an ArrayType", "::circt::hw::TypeAliasOr<circt::hw::ArrayType>">;
 
+def UnpackedArrayType : DialectType<HWDialect,
+    CPred<"::circt::hw::type_isa<circt::hw::UnpackedArrayType>($_self)">,
+          "an Unpacked ArrayType", "::circt::hw::TypeAliasOr<circt::hw::UnpackedArrayType>">;
+
 // A handle to refer to circt::hw::StructType in ODS.
 def StructType : DialectType<HWDialect,
     CPred<"::circt::hw::type_isa<circt::hw::StructType>($_self)">,

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -80,7 +80,7 @@ def ArrayTypeImpl : HWType<"Array", [DeclareTypeInterfaceMethods<FieldIDTypeInte
 }
 
 // An 'unpacked' array of fixed size.
-def UnpackedArrayType : HWType<"UnpackedArray", [DeclareTypeInterfaceMethods<FieldIDTypeInterface>]> {
+def UnpackedArrayTypeImpl : HWType<"UnpackedArray", [DeclareTypeInterfaceMethods<FieldIDTypeInterface>]> {
   let summary = "SystemVerilog 'unpacked' fixed-sized array";
   let description = [{
     Unpacked arrays are a more flexible array representation than packed arrays,

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -265,3 +265,19 @@ def SampledOp : SVOp<"system.sampled", [Pure, SameOperandsAndResultType]> {
   let results = (outs AnyType:$sampledValue);
   let assemblyFormat = "$expression attr-dict `:` qualified(type($expression))";
 }
+
+def UnpackedArrayCreateOp : SVOp<"unpacked_array_create", [Pure, SameTypeOperands]> {
+  let summary = "Create an unpacked array";
+  let description = [{
+    Creates an unpacked array from a variable set of values. One or more values must be
+    listed.
+
+    See the HW-SV rationale document for details on operand ordering.
+  }];
+
+  let arguments = (ins Variadic<HWNonInOutType>:$inputs);
+  let results = (outs UnpackedArrayType:$result);
+
+  let assemblyFormat = "$inputs attr-dict `:` functional-type($inputs, $result)";
+}
+

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -31,7 +31,7 @@ public:
             ReadInOutOp, ArrayIndexInOutOp, VerbatimExprOp, VerbatimExprSEOp,
             IndexedPartSelectInOutOp, IndexedPartSelectOp, StructFieldInOutOp,
             ConstantXOp, ConstantZOp, ConstantStrOp, MacroRefExprOp,
-            MacroRefExprSEOp,
+            MacroRefExprSEOp, UnpackedArrayCreateOp,
             // Declarations.
             RegOp, WireOp, LogicOp, LocalParamOp, XMROp, XMRRefOp,
             // Control flow.
@@ -108,6 +108,7 @@ public:
   HANDLE(ConstantStrOp, Unhandled);
   HANDLE(MacroRefExprOp, Unhandled);
   HANDLE(MacroRefExprSEOp, Unhandled);
+  HANDLE(UnpackedArrayCreateOp, Unhandled);
 
   // Control flow.
   HANDLE(OrderedOutputOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -260,7 +260,7 @@ bool ExportVerilog::isVerilogExpression(Operation *op) {
   if (isa<ReadInOutOp, AggregateConstantOp, ArrayIndexInOutOp,
           IndexedPartSelectInOutOp, StructFieldInOutOp, IndexedPartSelectOp,
           ParamValueOp, XMROp, XMRRefOp, SampledOp, EnumConstantOp,
-          SystemFunctionOp>(op))
+          SystemFunctionOp, UnpackedArrayCreateOp>(op))
     return true;
 
   // All HW combinational logic ops and SV expression ops are Verilog
@@ -740,7 +740,7 @@ static bool isExpressionUnableToInline(Operation *op,
 
   // StructCreateOp needs to be assigning to a named temporary so that types
   // are inferred properly by verilog
-  if (isa<StructCreateOp, UnionCreateOp>(op))
+  if (isa<StructCreateOp, UnionCreateOp, UnpackedArrayCreateOp>(op))
     return true;
 
   // Aggregate literal syntax only works in an assignment expression, where
@@ -2315,6 +2315,7 @@ private:
   SubExprInfo visitSV(ConstantZOp op);
   SubExprInfo visitSV(ConstantStrOp op);
 
+  SubExprInfo visitSV(sv::UnpackedArrayCreateOp op);
   // Noop cast operators.
   SubExprInfo visitSV(ReadInOutOp op) {
     auto result = emitSubExpr(op->getOperand(0), LowestPrecedence);
@@ -3102,6 +3103,16 @@ SubExprInfo ExprEmitter::visitTypeOp(ArrayCreateOp op) {
         },
         [&]() { ps << "}"; });
   }
+  return {Unary, IsUnsigned};
+}
+
+SubExprInfo ExprEmitter::visitSV(UnpackedArrayCreateOp op) {
+  if (hasSVAttributes(op))
+    emitError(op, "SV attributes emission is unimplemented for the op");
+
+  emitBracedList(
+      llvm::reverse(op.getInputs()), [&]() { ps << "'{"; },
+      [&](Value v) { emitSubExprIBox2(v); }, [&]() { ps << "}"; });
   return {Unary, IsUnsigned};
 }
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -481,10 +481,11 @@ hw.module @Aliasing(inout %a : i42, inout %b : i42, inout %c : i42) {
   sv.alias %a, %b, %c : !hw.inout<i42>, !hw.inout<i42>, !hw.inout<i42>
 }
 
-hw.module @reg_0(in %in4: i4, in %in8: i8, out a: i8, out b: i8) {
+hw.module @reg_0(in %in4: i4, in %in8: i8, in %in8_2: i8, out a: i8, out b: i8) {
   // CHECK-LABEL: module reg_0(
   // CHECK-NEXT:   input  [3:0] in4, //
   // CHECK-NEXT:   input  [7:0] in8, //
+  // CHECK-NEXT:                in8_2, //
   // CHECK-NEXT:   output [7:0] a, //
   // CHECK-NEXT:                b //
   // CHECK-NEXT:  );
@@ -517,6 +518,11 @@ hw.module @reg_0(in %in4: i4, in %in8: i8, out a: i8, out b: i8) {
 
   %subscript2 = sv.array_index_inout %myRegArray1[%in4] : !hw.inout<array<42 x i8>>, i4
   %memout = sv.read_inout %subscript2 : !hw.inout<i8>
+
+  %unpacked_array = sv.unpacked_array_create %in8, %in8_2 : (i8, i8) -> !hw.uarray<2xi8>
+  %unpacked_wire = sv.wire : !hw.inout<uarray<2xi8>>
+  // CHECK: wire [7:0] unpacked_wire[0:1] = '{in8_2, in8};
+  sv.assign %unpacked_wire, %unpacked_array: !hw.uarray<2xi8>
 
   // CHECK-NEXT: assign a = myReg;
   // CHECK-NEXT: assign b = myRegArray1[in4];


### PR DESCRIPTION
This commit adds unpacked array create op that will be lowered into array literal
 `'{..}`.

Since array literal must be used in assignment-like context,`unpacked_array_create` is always spilled to a temporary wire.

The operand ordering follows HW array representation. This is currently tricky since we emit unpacked types slightly differently (`downTo`) but the correct ordering is emitted in ExportVeriliog.