### PR TITLE
[ESI] MMIO read service implementation in PyCDE

### DIFF
--- a/frontends/PyCDE/integration_test/test_software/esi_test.py
+++ b/frontends/PyCDE/integration_test/test_software/esi_test.py
@@ -7,8 +7,39 @@ acc = esi.AcceleratorConnection(platform, sys.argv[2])
 
 mmio = acc.get_service_mmio()
 data = mmio.read(8)
-print(f"mmio data@8: {data:X}")
 assert data == 0x207D98E5E5100E51
+
+################################################################################
+# MMIOClient tests
+################################################################################
+
+
+def read_offset(mmio_offset: int, offset: int, add_amt: int):
+  data = mmio.read(mmio_offset + offset)
+  if data == add_amt + offset:
+    print(f"PASS: read_offset({mmio_offset}, {offset}, {add_amt}) -> {data}")
+  else:
+    assert False, f"read_offset({mmio_offset}, {offset}, {add_amt}) -> {data}"
+
+
+# MMIO offset into mmio_client[9]. TODO: get this from the manifest. API coming.
+mmio_client_9_offset = 131072
+read_offset(mmio_client_9_offset, 0, 9)
+read_offset(mmio_client_9_offset, 13, 9)
+
+# MMIO offset into mmio_client[4].
+mmio_client_4_offset = 65536
+read_offset(mmio_client_4_offset, 0, 4)
+read_offset(mmio_client_4_offset, 13, 4)
+
+# MMIO offset into mmio_client[14].
+mmio_client_14_offset = 196608
+read_offset(mmio_client_14_offset, 0, 14)
+read_offset(mmio_client_14_offset, 13, 14)
+
+################################################################################
+# Manifest tests
+################################################################################
 
 assert acc.sysinfo().esi_version() == 0
 m = acc.manifest()
@@ -22,6 +53,10 @@ recv.connect()
 
 send = d.ports[esi.AppID("loopback_add7")].write_port("arg")
 send.connect()
+
+################################################################################
+# Loopback add 7 tests
+################################################################################
 
 data = 10234
 send.write(data)

--- a/frontends/PyCDE/src/pycde/esi.py
+++ b/frontends/PyCDE/src/pycde/esi.py
@@ -664,7 +664,7 @@ def ChannelDemux2(data_type: Type):
 
 def ChannelDemux(input: ChannelSignal, sel: BitsSignal,
                  num_outs: int) -> List[ChannelSignal]:
-  """Build a pipelined demultiplexer of ESI channels. Ideally, this would be a
+  """Build a demultiplexer of ESI channels. Ideally, this would be a
   parameterized module with an array of output channels, but the current ESI
   channel-port lowering doesn't deal with arrays of channels. Independent of the
   signaling protocol."""

--- a/frontends/PyCDE/src/pycde/esi.py
+++ b/frontends/PyCDE/src/pycde/esi.py
@@ -3,13 +3,14 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .common import (AppID, Input, Output, _PyProxy, PortError)
-from .constructs import AssignableSignal
-from .module import Generator, Module, ModuleLikeBuilderBase, PortProxyBase
-from .signals import BundleSignal, ChannelSignal, Signal, _FromCirctValue
+from .constructs import AssignableSignal, Mux, Wire
+from .module import generator, Module, ModuleLikeBuilderBase, PortProxyBase
+from .signals import (BitsSignal, BundleSignal, ChannelSignal, Signal,
+                      _FromCirctValue)
 from .support import get_user_loc
 from .system import System
-from .types import (Bits, Bundle, BundledChannel, ChannelDirection, Type, types,
-                    _FromCirctType)
+from .types import (Bits, Bundle, BundledChannel, Channel, ChannelDirection,
+                    Type, UInt, types, _FromCirctType)
 
 from .circt import ir
 from .circt.dialects import esi as raw_esi, hw, msft
@@ -467,16 +468,18 @@ class PureModule(Module):
     esi.ESIPureModuleParamOp(name, type_attr)
 
 
-MMIOReadDataResponse = Bits(64)
+MMIODataType = Bits(64)
 
 
 @ServiceDecl
 class MMIO:
-  """ESI standard service to request access to an MMIO region."""
+  """ESI standard service to request access to an MMIO region.
+  
+  For now, each client request gets a 1KB region of memory."""
 
   read = Bundle([
-      BundledChannel("offset", ChannelDirection.TO, Bits(32)),
-      BundledChannel("data", ChannelDirection.FROM, MMIOReadDataResponse)
+      BundledChannel("offset", ChannelDirection.TO, UInt(32)),
+      BundledChannel("data", ChannelDirection.FROM, MMIODataType)
   ])
 
   @staticmethod
@@ -624,3 +627,120 @@ def package(sys: System):
     circt_lib_dir = build_dir / "tools" / "circt" / "lib"
     esi_lib_dir = circt_lib_dir / "Dialect" / "ESI"
   # shutil.copy(esi_lib_dir / "ESIPrimitives.sv", sys.hw_output_dir)
+
+
+def ChannelDemux2(data_type: Type):
+
+  class ChannelDemux2(Module):
+    """Combinational 2-way channel demultiplexer for valid/ready signaling."""
+
+    sel = Input(Bits(1))
+    inp = Input(Channel(data_type))
+    output0 = Output(Channel(data_type))
+    output1 = Output(Channel(data_type))
+
+    @generator
+    def generate(ports) -> None:
+      input_ready = Wire(Bits(1))
+      input, input_valid = ports.inp.unwrap(input_ready)
+
+      output0 = input
+      output0_valid = input_valid & (ports.sel == Bits(1)(0))
+      output0_ch, output0_ready = Channel(data_type).wrap(
+          output0, output0_valid)
+      ports.output0 = output0_ch
+
+      output1 = input
+      output1_valid = input_valid & (ports.sel == Bits(1)(1))
+      output1_ch, output1_ready = Channel(data_type).wrap(
+          output1, output1_valid)
+      ports.output1 = output1_ch
+
+      input_ready.assign((output0_ready & (ports.sel == Bits(1)(0))) |
+                         (output1_ready & (ports.sel == Bits(1)(1))))
+
+  return ChannelDemux2
+
+
+def ChannelDemux(input: ChannelSignal, sel: BitsSignal,
+                 num_outs: int) -> List[ChannelSignal]:
+  """Build a pipelined demultiplexer of ESI channels. Ideally, this would be a
+  parameterized module with an array of output channels, but the current ESI
+  channel-port lowering doesn't deal with arrays of channels. Independent of the
+  signaling protocol."""
+
+  dmux2 = ChannelDemux2(input.type)
+
+  def build_tree(inter_input: ChannelSignal, inter_sel: BitsSignal,
+                 inter_num_outs: int, path: str) -> List[ChannelSignal]:
+    """Builds a binary tree of demuxes to demux the input channel."""
+    if inter_num_outs == 0:
+      return []
+    if inter_num_outs == 1:
+      return [inter_input]
+
+    demux2 = dmux2(sel=inter_sel[-1].as_bits(),
+                   inp=inter_input,
+                   instance_name=f"demux2_path{path}")
+    next_sel = inter_sel[:-1].as_bits()
+    tree0 = build_tree(demux2.output0, next_sel, (inter_num_outs + 1) // 2,
+                       path + "0")
+    tree1 = build_tree(demux2.output1, next_sel, (inter_num_outs + 1) // 2,
+                       path + "1")
+    return tree0 + tree1
+
+  return build_tree(input, sel, num_outs, "")
+
+
+def ChannelMux2(data_type: Channel):
+
+  class ChannelMux2(Module):
+    """2 channel arbiter with priority given to input0. Valid/ready only.
+    Combinational."""
+    # TODO: implement some fairness.
+
+    input0 = Input(data_type)
+    input1 = Input(data_type)
+    output_channel = Output(data_type)
+
+    @generator
+    def generate(ports):
+      input0_ready = Wire(Bits(1))
+      input0_data, input0_valid = ports.input0.unwrap(input0_ready)
+      input1_ready = Wire(Bits(1))
+      input1_data, input1_valid = ports.input1.unwrap(input1_ready)
+
+      output_idx = ~input0_valid
+      data_mux = Mux(output_idx, input0_data, input1_data)
+      valid_mux = Mux(output_idx, input0_valid, input1_valid)
+      output_channel, output_ready = data_type.wrap(data_mux, valid_mux)
+      ports.output_channel = output_channel
+
+      input0_ready.assign(output_ready & ~output_idx)
+      input1_ready.assign(output_ready & output_idx)
+
+  return ChannelMux2
+
+
+def ChannelMux(input_channels: List[ChannelSignal]) -> ChannelSignal:
+  """Build a channel multiplexer of ESI channels. Ideally, this would be a
+  parameterized module with an array of output channels, but the current ESI
+  channel-port lowering doesn't deal with arrays of channels. Independent of the
+  signaling protocol."""
+
+  assert len(input_channels) > 0
+  mux2 = ChannelMux2(input_channels[0].type)
+
+  def build_tree(inter_input_channels: List[ChannelSignal]) -> ChannelSignal:
+    assert len(inter_input_channels) > 0
+    if len(inter_input_channels) == 1:
+      return inter_input_channels[0]
+    if len(inter_input_channels) == 2:
+      m = mux2(input0=inter_input_channels[0], input1=inter_input_channels[1])
+      return m.output_channel
+    m0_out = build_tree(inter_input_channels[:len(inter_input_channels) // 2])
+    m1_out = build_tree(inter_input_channels[len(inter_input_channels) // 2:])
+    m = mux2(input0=m0_out, input1=m1_out)
+    return m.output_channel
+
+  return build_tree(input_channels)

--- a/frontends/PyCDE/src/pycde/support.py
+++ b/frontends/PyCDE/src/pycde/support.py
@@ -4,6 +4,13 @@ from .circt import ir
 import os
 
 
+def clog2(x: int) -> int:
+  """Return the ceiling log base 2 of x."""
+  if x == 0:
+    return 0
+  return (x - 1).bit_length()
+
+
 # PyCDE needs a custom version of this to support python classes.
 def _obj_to_attribute(obj) -> ir.Attribute:
   """Create an MLIR attribute from a Python object for a few common cases."""

--- a/frontends/PyCDE/src/pycde/types.py
+++ b/frontends/PyCDE/src/pycde/types.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections import OrderedDict
 from functools import singledispatchmethod
 
-from .support import get_user_loc
+from .support import clog2, get_user_loc
 
 from .circt import ir, support
 from .circt.dialects import esi, hw, seq, sv
@@ -84,7 +84,7 @@ class Type:
     return self
 
   @property
-  def bitwidth(self):
+  def bitwidth(self) -> int:
     return hw.get_bitwidth(self._type)
 
   @property
@@ -310,6 +310,10 @@ class Array(Type):
   @property
   def size(self):
     return self._type.size
+
+  @property
+  def select_bits(self) -> int:
+    return clog2(self.size)
 
   @property
   def shape(self):

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -183,9 +183,9 @@ class RecvBundleTest(Module):
 # CHECK-LABEL:  hw.module @MMIOReq()
 # CHECK-NEXT:     %c0_i64 = hw.constant 0 : i64
 # CHECK-NEXT:     %false = hw.constant false
-# CHECK-NEXT:     [[B:%.+]] = esi.service.req <@MMIO::@read>(#esi.appid<"mmio_req">) : !esi.bundle<[!esi.channel<i32> to "offset", !esi.channel<i64> from "data"]>
+# CHECK-NEXT:     [[B:%.+]] = esi.service.req <@MMIO::@read>(#esi.appid<"mmio_req">) : !esi.bundle<[!esi.channel<ui32> to "offset", !esi.channel<i64> from "data"]>
 # CHECK-NEXT:     %chanOutput, %ready = esi.wrap.vr %c0_i64, %false : i64
-# CHECK-NEXT:     %offset = esi.bundle.unpack %chanOutput from [[B]] : !esi.bundle<[!esi.channel<i32> to "offset", !esi.channel<i64> from "data"]>
+# CHECK-NEXT:     %offset = esi.bundle.unpack %chanOutput from [[B]] : !esi.bundle<[!esi.channel<ui32> to "offset", !esi.channel<i64> from "data"]>
 @unittestmodule(esi_sys=True)
 class MMIOReq(Module):
 

--- a/frontends/PyCDE/test/test_xrt.py
+++ b/frontends/PyCDE/test/test_xrt.py
@@ -59,7 +59,7 @@ s.package()
 # TOP:         output        s_axi_control_BVALID,
 # TOP:         output [1:0]  s_axi_control_BRESP
 
-# TOP:         __ESI_Manifest_ROM ESI_Manifest_ROM (
+# TOP:         ESI_Manifest_ROM_Wrapper ESI_Manifest_ROM_Wrapper (
 # TOP:           .clk     (ap_clk),
 # TOP:           .address (rom_address),
 # TOP:           .data    (_ESI_Manifest_ROM_data)

--- a/lib/Dialect/ESI/ESIStdServices.cpp
+++ b/lib/Dialect/ESI/ESIStdServices.cpp
@@ -99,8 +99,12 @@ void MMIOServiceDeclOp::getPortList(SmallVectorImpl<ServicePortInfo> &ports) {
       hw::InnerRefAttr::get(getSymNameAttr(), StringAttr::get(ctxt, "read")),
       ChannelBundleType::get(
           ctxt,
-          {BundledChannel{StringAttr::get(ctxt, "offset"), ChannelDirection::to,
-                          ChannelType::get(ctxt, IntegerType::get(ctxt, 32))},
+          {BundledChannel{
+               StringAttr::get(ctxt, "offset"), ChannelDirection::to,
+               ChannelType::get(
+                   ctxt,
+                   IntegerType::get(
+                       ctxt, 32, IntegerType::SignednessSemantics::Unsigned))},
            BundledChannel{StringAttr::get(ctxt, "data"), ChannelDirection::from,
                           ChannelType::get(ctxt, IntegerType::get(ctxt, 64))}},
           /*resettable=*/UnitAttr())});

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -205,14 +205,14 @@ hw.module @CallableAccel1(in %clk: !seq.clock, in %rst: i1) {
 }
 
 esi.service.std.mmio @mmio
-!mmioReq = !esi.bundle<[!esi.channel<i32> to "offset", !esi.channel<i64> from "data"]>
+!mmioReq = !esi.bundle<[!esi.channel<ui32> to "offset", !esi.channel<i64> from "data"]>
 
-// CONN-LABEL:  hw.module @MMIOManifest(in %clk : !seq.clock, in %rst : i1, in %manifest : !esi.bundle<[!esi.channel<i32> to "offset", !esi.channel<i64> from "data"]>) {
+// CONN-LABEL:  hw.module @MMIOManifest(in %clk : !seq.clock, in %rst : i1, in %manifest : !esi.bundle<[!esi.channel<ui32> to "offset", !esi.channel<i64> from "data"]>) {
 // CONN-NEXT:     %true = hw.constant true
 // CONN-NEXT:     %c0_i64 = hw.constant 0 : i64
-// CONN-NEXT:     esi.manifest.req #esi.appid<"manifest">, <@mmio::@read> std "esi.service.std.mmio", !esi.bundle<[!esi.channel<i32> to "offset", !esi.channel<i64> from "data"]>
+// CONN-NEXT:     esi.manifest.req #esi.appid<"manifest">, <@mmio::@read> std "esi.service.std.mmio", !esi.bundle<[!esi.channel<ui32> to "offset", !esi.channel<i64> from "data"]>
 // CONN-NEXT:     %chanOutput, %ready = esi.wrap.vr %c0_i64, %true : i64
-// CONN-NEXT:     %offset = esi.bundle.unpack %chanOutput from %manifest : !esi.bundle<[!esi.channel<i32> to "offset", !esi.channel<i64> from "data"]>
+// CONN-NEXT:     %offset = esi.bundle.unpack %chanOutput from %manifest : !esi.bundle<[!esi.channel<ui32> to "offset", !esi.channel<i64> from "data"]>
 hw.module @MMIOManifest(in %clk: !seq.clock, in %rst: i1) {
   %req = esi.service.req <@mmio::@read> (#esi.appid<"manifest">) : !mmioReq
   %data = hw.constant 0 : i64


### PR DESCRIPTION
Implements a channel-based MMIO read service generator. Changes the offset type on the MMIO std service to `ui32` from `i32`.