### PR TITLE
Revert "[FIRRTL] Enable Wire Elimination (#7073)"

### DIFF
--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -62,9 +62,6 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
       firrtl::createDropNamesPass(opt.getPreserveMode()));
 
-  pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
-      firrtl::createEliminateWiresPass());
-
   if (!opt.shouldDisableOptimization())
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         mlir::createCSEPass());
@@ -122,7 +119,6 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   {
     auto &modulePM = pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>();
     modulePM.addPass(firrtl::createExpandWhensPass());
-    modulePM.addPass(firrtl::createEliminateWiresPass());
     modulePM.addPass(firrtl::createSFCCompatPass());
   }
 

--- a/test/Dialect/FIRRTL/SFCTests/data-taps.fir
+++ b/test/Dialect/FIRRTL/SFCTests/data-taps.fir
@@ -203,10 +203,10 @@ circuit Top : %[[
 
     ; CHECK:      module Top
     ; TODO: fix having constants carry names
-    ; CHECK:        wire k = 1'h0
+    ; CHECK:        wire inv = 1'h0
     ; CHECK:        io_b = Top.foo.f_probe;
     ; CHECK-NEXT:   io_c = Top.foo.g_probe;
-    ; CHECK-NEXT:   io_d = k;
+    ; CHECK-NEXT:   io_d = inv;
 
 ; // -----
 
@@ -516,12 +516,12 @@ circuit Top : %[[
 ; CHECK-NEXT:          [[DUT_tap_8_port:[a-zA-Z0-9_]+]]
 ; CHECK-NEXT:          [[DUT_tap_11_port:[a-zA-Z0-9_]+]]
 ;
-; CHECK-DAG:     tap_8 = [[DUT_tap_8_port]];
-; CHECK-DAG:     tap_11 = [[DUT_tap_11_port]];
-; CHECK-DAG:     tap_10 = 1'h0;
-; CHECK-DAG:     tap_9 = 1'h0;
+; CHECK-DAG:     tap_6 = DUT.submodule.wire_Submodule_probe;
 ; CHECK-DAG:     tap_7 = inv;
-; CHECK-DAG:     tap_6 = DUT.submodule.inv_probe;
+; CHECK-DAG:     tap_8 = [[DUT_tap_8_port]];
+; CHECK-DAG:     tap_9 = 1'h0;
+; CHECK-DAG:     tap_10 = 1'h0;
+; CHECK-DAG:     tap_11 = [[DUT_tap_11_port]];
 ;
 ; CHECK:         Submodule submodule (
 ; CHECK-DAG:       .[[Submodule_tap_1_port]] (inv)
@@ -530,8 +530,8 @@ circuit Top : %[[
 
 ; CHECK-LABEL: module Top
 ;
-; CHECK-DAG:     tap_12_0 = Top.dut.submodule.inv_probe
-; CHECK-DAG:     tap_12_1 = Top.dut.inv_probe
+; CHECK-DAG:     tap_12_0 = Top.dut.submodule.wire_Submodule
+; CHECK-DAG:     tap_12_1 = Top.dut.wire_DUT
 ; CHECK-DAG:     tap_12_2 = inv;
 ; CHECK-DAG:     tap_12_3 = 1'h0
 ; CHECK-DAG:     tap_12_4 = 1'h0

--- a/test/Dialect/FIRRTL/SFCTests/dedup.fir
+++ b/test/Dialect/FIRRTL/SFCTests/dedup.fir
@@ -341,7 +341,7 @@ circuit Top9 : %[[
   ; CHECK: module private @A(
   module A :
     output x: UInt<1>
-    ; CHECK: firrtl.node %c0_ui1 {annotations = [{circt.nonlocal = @[[nlaSym]], class = "circt.test"}]}
+    ; CHECK-NEXT: firrtl.wire {annotations = [{circt.nonlocal = @[[nlaSym]], class = "circt.test"}]}
     wire b: UInt<1>
     b is invalid
     x <= b
@@ -381,7 +381,7 @@ circuit Top10 : %[[
   ; CHECK: module private @A(
   module A :
     output x: UInt<1>
-    ; CHECK: firrtl.node %c0_ui1 {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "circt.test", data = "hello"}, {circt.nonlocal = @[[nlaSym2]], class = "circt.test", data = "world"}]}
+    ; CHECK-NEXT: firrtl.wire {annotations = [{circt.nonlocal = @[[nlaSym1]], class = "circt.test", data = "hello"}, {circt.nonlocal = @[[nlaSym2]], class = "circt.test", data = "world"}]}
     wire b: UInt<1>
     b is invalid
     x <= b
@@ -886,7 +886,7 @@ circuit Top17 : %[[
   ; CHECK: module private @A(
   module A :
     output x: UInt<1>
-    ; CHECK: firrtl.node %c0_ui1 {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
+    ; CHECK-NEXT: firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]}
     wire b: UInt<1>
     b is invalid
     x <= b
@@ -927,7 +927,7 @@ circuit Top18 : %[[
   ; CHECK: module private @A(
   module A :
     output x: UInt<1>
-    ; CHECK: firrtl.node
+    ; CHECK: firrtl.wire
     ; CHECK-SAME: [{class = "firrtl.transforms.DontTouchAnnotation"}]
     wire b: UInt<1>
     b is invalid

--- a/test/firtool/name-preservation.fir
+++ b/test/firtool/name-preservation.fir
@@ -15,9 +15,8 @@ circuit Foo:
     _x <= a
 
     ; Default behavior is to preserve named wires.
-    ; CHECK:        wire x_b
-    ; CHECK:        wire y
     ; CHECK:        wire x_a
+    ; CHECK:        wire x_b
     wire x: {a: UInt<1>, flip b: UInt<1>}
     x <= _x
 
@@ -26,6 +25,7 @@ circuit Foo:
     node _y_b = x.b
 
     ; Default behavior is to preserve named nodes.
+    ; CHECK:        wire y
     node y = _y_b
 
     b.a <= y


### PR DESCRIPTION
This reverts commit f5a0969fbebc3a7195111620b178b5cfbcd6b7f3.

Wire Elimination is causing some issues where wire names are overriding register names in an undesirable way. I think we just need to tweak our heuristic a bit then re-enable, but we would like to get a firtool release out ASAP so I think we should revert temporarily.

Example FIRRTL:
```firrtl
FIRRTL version 3.3.0
circuit Foo :
  module Foo :
    input clock : Clock
    input reset : UInt<1>
    input in : { fizz : { foo : UInt<8>}, buzz : { foo : UInt<8>}}
    output out1 : { foo : UInt<8>}
    output out2 : { foo : UInt<8>}

    reg myReg : { fizz : { foo : UInt<8>}, buzz : { foo : UInt<8>}}, clock
    wire w1 : { foo : UInt<8>}
    wire w2 : { foo : UInt<8>}
    connect myReg.buzz.foo, in.buzz.foo
    connect myReg.fizz.foo, in.fizz.foo
    connect w1.foo, myReg.fizz.foo
    connect w2.foo, myReg.buzz.foo
    connect out1.foo, w1.foo
    connect out2.foo, w2.foo
```

Before this revert:
```verilog
// Generated by CIRCT firtool-1.76.0-171-g961bad58f
module Foo(
  input        clock,
               reset,
  input  [7:0] in_fizz_foo,
               in_buzz_foo,
  output [7:0] out1_foo,
               out2_foo
);

  reg [7:0] w1_foo;
  reg [7:0] w2_foo;
  always @(posedge clock) begin
    w1_foo <= in_fizz_foo;
    w2_foo <= in_buzz_foo;
  end // always @(posedge)
  assign out1_foo = w1_foo;
  assign out2_foo = w2_foo;
endmodule
```

After this revert:
```verilog
// Generated by CIRCT firtool-1.76.0-172-gd6f349bed
module Foo(
  input        clock,
               reset,
  input  [7:0] in_fizz_foo,
               in_buzz_foo,
  output [7:0] out1_foo,
               out2_foo
);

  reg [7:0] myReg_fizz_foo;
  reg [7:0] myReg_buzz_foo;
  always @(posedge clock) begin
    myReg_fizz_foo <= in_fizz_foo;
    myReg_buzz_foo <= in_buzz_foo;
  end // always @(posedge)
  assign out1_foo = myReg_fizz_foo;
  assign out2_foo = myReg_buzz_foo;
endmodule
```