### PR TITLE
[OM] Introduce API to interact with class fields

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -82,6 +82,15 @@ def ClassOp : OMClassLike<"class"> {
     static mlir::RegionKind getRegionKind(unsigned index) {
       return mlir::RegionKind::Graph;
     }
+
+    void addField(mlir::OpBuilder &builder, mlir::Location loc,
+                  llvm::StringRef name, mlir::Value src);
+
+    using fields_iterator =
+        llvm::mapped_iterator<mlir::detail::op_iterator<circt::om::ClassFieldOp,
+                                                        mlir::Region::OpIterator>,
+                              circt::om::Field (*)(circt::om::ClassFieldOp)>;
+    llvm::iterator_range<fields_iterator> getFields();
   }];
 }
 

--- a/include/circt/Dialect/OM/OMTypes.h
+++ b/include/circt/Dialect/OM/OMTypes.h
@@ -21,6 +21,12 @@ namespace circt::om {
 // integer.
 bool isMapKeyValuePairType(mlir::Type);
 
+struct Field {
+  mlir::StringAttr name;
+  mlir::Value value;
+  mlir::Location loc;
+};
+
 } // namespace circt::om
 
 #define GET_TYPEDEF_CLASSES

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -955,7 +955,7 @@ void LowerClassesPass::lowerClass(om::ClassOp classOp, FModuleLike moduleLike,
 
     // Get the original port name, create a Field, and erase the propassign.
     auto name = moduleLike.getPortName(outputPort.getArgNumber());
-    builder.create<ClassFieldOp>(op.getLoc(), name, op.getSrc());
+    classOp.addField(builder, op.getLoc(), name, op.getSrc());
     op.erase();
   }
 

--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -257,11 +257,12 @@ circt::om::Evaluator::evaluateObjectInstance(StringAttr className,
       worklist.push({result, actualParams});
     }
 
-  for (auto field : cls.getOps<ClassFieldOp>()) {
-    StringAttr name = field.getNameAttr();
-    Value value = field.getValue();
+  for (auto field : cls.getFields()) {
+    StringAttr name = field.name;
+    Value value = field.value;
+    Location loc = field.loc;
     FailureOr<evaluator::EvaluatorValuePtr> result =
-        evaluateValue(value, actualParams, field.getLoc());
+        evaluateValue(value, actualParams, loc);
     if (failed(result))
       return result;
 

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -225,6 +225,20 @@ void circt::om::ClassOp::getAsmBlockArgumentNames(
   getClassLikeAsmBlockArgumentNames(*this, region, setNameFn);
 }
 
+void circt::om::ClassOp::addField(OpBuilder &builder, Location loc,
+                                  StringRef name, Value src) {
+  builder.create<ClassFieldOp>(loc, name, src);
+}
+
+static circt::om::Field convertFieldOpToField(circt::om::ClassFieldOp field) {
+  return {field.getNameAttr(), field.getValue(), field.getLoc()};
+}
+
+llvm::iterator_range<circt::om::ClassOp::fields_iterator>
+circt::om::ClassOp::getFields() {
+  return llvm::map_range(this->getOps<ClassFieldOp>(), &convertFieldOpToField);
+}
+
 //===----------------------------------------------------------------------===//
 // ClassFieldOp
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The goal is to introduce an abstraction that allows us to change how fields are represented under the hood.  This is a step towards addressing https://github.com/llvm/circt/issues/7078 which aims to use a terminator op to declare and store the field name/type mapping.  With this API in place, we can change how the underlying fields are accessed without having to update the producers/consumers of this information.

Issues:
* We introduce a `Field` struct to provide the information required by the evaluator.  We could return the FieldOp instead since this just passes through the relevant data, but if we change to fetching this information from the terminator op instead, we'd need to update the consumer code, so introducing a new intermediate type abstracts how the information is stored/fetched (at the cost of introducing a layer of indirection).  If we think this will be a performance issue, we may want to passthrough the underlying representation (currently FieldOp) and update the references when the internal implementation is changed.
* The `addField` API will provide a hook to record field names and types for emitting the final terminator op, however is there a way for the `ClassOp` to run internal code at completion of the `lowerClass` logic? Otherwise, we will need to update the user code to run some kind of terminator function to tell the class to construct the final terminator op. E.g. some call here to "emit fields" https://github.com/llvm/circt/blob/e616cf1d327bd6748304f78755b034ba037224f0/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp#L972
* Is there a way for `getFields` to have a type specified as an "iterator emitting type Field"? That is, the interface should be any range iterator over a collection of `Field` members (not necessarily the mapped iterator implementation used here).  Hiding it behind a name helps enforce the interface, but if someone were to expect that mapped iterator type, it would fail if we changed the underlying implementation to emit the fields differently.  I think the appropriate type would be some `Iterator<Field>` type where any iterator producing a Field could be used.  Exploring various ways to approach this using strategies such as iterator_traits etc... did not reveal anything useful yet.