### PR TITLE
[Moore] Extend the operand of AssignOp and add PullNonBlockingUp pass.

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -296,9 +296,13 @@ def ReadOp : MooreOp<"read", [
 class AssignOpBase<string mnemonic, list<Trait> traits = []> :
     MooreOp<mnemonic, traits # [TypesMatchWith<"src and dst types match",
     "src", "dst", "RefType::get(cast<UnpackedType>($_self))">]> {
-  let arguments = (ins RefType:$dst, UnpackedType:$src);
+  let arguments = (ins
+    RefType:$dst, UnpackedType:$src,
+    Optional<AnySingleBitType>:$enable
+  );
   let assemblyFormat = [{
-    $dst `,` $src attr-dict `:` type($src)
+    $dst `,` $src (`if` $enable^)? attr-dict 
+    `:` type($src) (`,` type($enable)^)?
   }];
 }
 
@@ -326,7 +330,8 @@ def BlockingAssignOp : AssignOpBase<"blocking_assign", [
   }];
   let arguments = (ins
     Arg<RefType, "", [MemWrite]>:$dst,
-    UnpackedType:$src
+    UnpackedType:$src,
+    Optional<AnySingleBitType>:$enable
   );
 }
 

--- a/include/circt/Dialect/Moore/MoorePasses.h
+++ b/include/circt/Dialect/Moore/MoorePasses.h
@@ -22,8 +22,9 @@ namespace moore {
 #define GEN_PASS_DECL
 #include "circt/Dialect/Moore/MoorePasses.h.inc"
 
-std::unique_ptr<mlir::Pass> createSimplifyProceduresPass();
 std::unique_ptr<mlir::Pass> createLowerConcatRefPass();
+std::unique_ptr<mlir::Pass> createPullNonBlockingUpPass();
+std::unique_ptr<mlir::Pass> createSimplifyProceduresPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Moore/MoorePasses.td
+++ b/include/circt/Dialect/Moore/MoorePasses.td
@@ -15,6 +15,25 @@
 
 include "mlir/Pass/PassBase.td"
 
+def LowerConcatRef : Pass<"moore-lower-concatref", "moore::SVModuleOp"> {
+    let summary = "Lower moore.concat_ref ops";
+    let description = [{
+      It's used to disassemble the LHS of assignments that have a form like
+      "{a, b} = c" onto "a = c[9001:42];" and "b = c[41:0]". Aimed at
+      conveniently lowering this kind of assignment.
+    }];
+    let constructor = "circt::moore::createLowerConcatRefPass()";
+}
+
+def PullNonBlockingUp : Pass<"moore-pull-nonblocking-up", "moore::SVModuleOp"> {
+    let summary = "Pull non-blocking assignments upwards";
+    let description = [{
+      Improve the level of non-blocking assignments from the inner region to
+      its parent region, like from "{if(cond) x <= y;}" to "{x <= y if %cond;}"
+    }];
+    let constructor = "circt::moore::createPullNonBlockingUpPass()";
+}
+
 def SimplifyProcedures : Pass<"moore-simplify-procedures", "moore::SVModuleOp"> {
     let summary = "Simplify procedures";
     let description = [{
@@ -27,16 +46,6 @@ def SimplifyProcedures : Pass<"moore-simplify-procedures", "moore::SVModuleOp"> 
       variable.
     }];
     let constructor = "circt::moore::createSimplifyProceduresPass()";
-}
-
-def LowerConcatRef : Pass<"moore-lower-concatref", "moore::SVModuleOp"> {
-    let summary = "Lower moore.concat_ref ops";
-    let description = [{
-      It's used to disassemble the LHS of assignments that have a form like
-      "{a, b} = c" onto "a = c[9001:42];" and "b = c[41:0]". Aimed at
-      conveniently lowering this kind of assignment.
-    }];
-    let constructor = "circt::moore::createLowerConcatRefPass()";
 }
 
 #endif // CIRCT_DIALECT_MOORE_MOOREPASSES_TD

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -100,9 +100,9 @@ struct RvalueExprVisitor {
     }
 
     if (expr.isNonBlocking())
-      builder.create<moore::NonBlockingAssignOp>(loc, lhs, rhs);
+      builder.create<moore::NonBlockingAssignOp>(loc, lhs, rhs, Value{});
     else
-      builder.create<moore::BlockingAssignOp>(loc, lhs, rhs);
+      builder.create<moore::BlockingAssignOp>(loc, lhs, rhs, Value{});
     return rhs;
   }
 
@@ -132,7 +132,7 @@ struct RvalueExprVisitor {
     auto postValue =
         isInc ? builder.create<moore::AddOp>(loc, preValue, one).getResult()
               : builder.create<moore::SubOp>(loc, preValue, one).getResult();
-    builder.create<moore::BlockingAssignOp>(loc, arg, postValue);
+    builder.create<moore::BlockingAssignOp>(loc, arg, postValue, Value{});
     return isPost ? preValue : postValue;
   }
 

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -254,7 +254,7 @@ struct MemberVisitor {
     // Assign output values from the instance to the connected expression.
     for (auto [lvalue, output] : llvm::zip(outputValues, inst.getOutputs()))
       if (lvalue)
-        builder.create<moore::ContinuousAssignOp>(loc, lvalue, output);
+        builder.create<moore::ContinuousAssignOp>(loc, lvalue, output, Value{});
 
     return success();
   }
@@ -322,7 +322,7 @@ struct MemberVisitor {
     if (!lhs || !rhs)
       return failure();
 
-    builder.create<moore::ContinuousAssignOp>(loc, lhs, rhs);
+    builder.create<moore::ContinuousAssignOp>(loc, lhs, rhs, Value{});
     return success();
   }
 
@@ -600,7 +600,8 @@ Context::convertModuleBody(const slang::ast::InstanceBodySymbol *module) {
       portArg = builder.create<moore::ReadOp>(
           port.loc, cast<moore::RefType>(value.getType()).getNestedType(),
           port.arg);
-    builder.create<moore::ContinuousAssignOp>(port.loc, value, portArg);
+    builder.create<moore::ContinuousAssignOp>(port.loc, value, portArg,
+                                              Value{});
   }
   builder.create<moore::OutputOp>(lowering.op.getLoc(), outputs);
 

--- a/lib/Dialect/Moore/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Moore/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_dialect_library(CIRCTMooreTransforms
 LowerConcatRef.cpp
+PullNonBlockingUp.cpp
 SimplifyProcedures.cpp
 
 

--- a/lib/Dialect/Moore/Transforms/LowerConcatRef.cpp
+++ b/lib/Dialect/Moore/Transforms/LowerConcatRef.cpp
@@ -74,7 +74,7 @@ struct ConcatRefLowering : public OpConversionPattern<OpTy> {
       // description mentioned.
       srcWidth = srcWidth - width;
 
-      rewriter.create<OpTy>(op.getLoc(), operand, extract);
+      rewriter.create<OpTy>(op.getLoc(), operand, extract, Value{});
     }
     rewriter.eraseOp(op);
     return success();

--- a/lib/Dialect/Moore/Transforms/PullNonBlockingUp.cpp
+++ b/lib/Dialect/Moore/Transforms/PullNonBlockingUp.cpp
@@ -1,0 +1,151 @@
+//===- PullNonBlockingUp.cpp - Pull non-blocking assignments upwards ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass is aimed at pulling non-blokcing assignments upwards.
+// For example:
+
+// From:
+// moore.procedure {
+//   scf.if not(%rst) {
+//     ...
+//   } else {
+//     scf.if eq(cond1, a1) {
+//       %0 = moore.constant 1
+//       %1 = moore.extract_ref %q, %0
+//       moore.nonblokcing %1, %0
+//     }
+
+//     scf.if eq(cond2, a2) {
+//        %0 = moore.constant 1
+//        %1 = moore.extract_ref %q, %0
+//        moore.nonblokcing %1, %0
+//     }
+//    }
+// }
+
+// To:
+// moore.procedure {
+//   scf.if not(%rst) {
+//     ...
+//   } else {
+//     %0 = moore.constant 1
+//     %1 = moore.extract_ref %q, %0
+//     moore.nonblokcing %1, %0 if eq(cond1, a1)
+
+//     %2 = moore.constant 1
+//     %3 = moore.extract_ref %q, %0
+//     moore.nonblokcing %3, %2 if eq(cond2, a2)
+//    }
+// }
+
+// Round and round until 'scf.if' doesn't exist.
+
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Moore/MooreOps.h"
+#include "circt/Dialect/Moore/MoorePasses.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+namespace circt {
+namespace moore {
+#define GEN_PASS_DEF_PULLNONBLOCKINGUP
+#include "circt/Dialect/Moore/MoorePasses.h.inc"
+} // namespace moore
+} // namespace circt
+
+using namespace circt;
+using namespace mlir;
+using namespace moore;
+
+namespace {
+static LogicalResult lowerSCFIfOp(scf::IfOp ifOp, PatternRewriter &rewriter) {
+  SmallVector<Operation *> assignOps;
+  auto cond = ifOp.getCondition().getDefiningOp()->getOperand(0);
+
+  // First to traverse else-region.
+  for (auto &elseOp : ifOp.getElseRegion().getOps()) {
+    // Handle the nested if-else statements.
+    if (isa<scf::IfOp>(elseOp))
+      if (failed(lowerSCFIfOp(cast<scf::IfOp>(elseOp), rewriter)))
+        return failure();
+
+    // Handle non-blocking assignments.
+    if (auto assignOp = llvm::dyn_cast_or_null<NonBlockingAssignOp>(elseOp)) {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPoint(assignOp);
+
+      // The condition of the else-region is contrary to the one of the
+      // then-region.
+      Value elseCond = rewriter.create<NotOp>(assignOp.getLoc(), cond);
+
+      // When there are nested if-else statements, we need to guarantee the
+      // nested non-blocking assignments have the correct conditions.
+      if (auto en = assignOp.getEnable())
+        elseCond = rewriter.create<AndOp>(assignOp->getLoc(), en, elseCond);
+      rewriter.create<NonBlockingAssignOp>(
+          assignOp->getLoc(), assignOp.getDst(), assignOp.getSrc(), elseCond);
+      assignOps.push_back(assignOp);
+    }
+  }
+
+  // Seconde to traverse then region.
+  for (auto &thenOp : ifOp.getThenRegion().getOps()) {
+    // Handle the nested if-else statements.
+    if (isa<scf::IfOp>(thenOp)) {
+      if (failed(lowerSCFIfOp(cast<scf::IfOp>(thenOp), rewriter)))
+        return failure();
+    }
+
+    // Handle non-blocking assignments.
+    if (auto assignOp = llvm::dyn_cast_or_null<NonBlockingAssignOp>(thenOp)) {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPoint(assignOp);
+      Value thenCond = cond;
+
+      // As above.
+      if (auto en = assignOp.getEnable())
+        thenCond = rewriter.create<AndOp>(assignOp->getLoc(), en, cond);
+      rewriter.create<NonBlockingAssignOp>(
+          assignOp->getLoc(), assignOp.getDst(), assignOp.getSrc(), thenCond);
+      assignOps.push_back(assignOp);
+    }
+  }
+
+  for (auto *assignOp : assignOps)
+    assignOp->erase();
+
+  // After merging conditions on the non-blocking assignment, we need to move
+  // these nested operations in the if-else body outside to this body.
+  // Meanwhile, erase the scf.yield. Then erase scf.if.
+  rewriter.eraseOp(ifOp.thenYield());
+  rewriter.inlineBlockBefore(&ifOp.getThenRegion().front(), ifOp);
+  if (!ifOp.getElseRegion().empty()) {
+    rewriter.eraseOp(ifOp.elseYield());
+    rewriter.inlineBlockBefore(&ifOp.getElseRegion().front(), ifOp);
+  }
+  rewriter.eraseOp(ifOp);
+  return success();
+}
+
+struct PullNonBlockingUpPass
+    : public circt::moore::impl::PullNonBlockingUpBase<PullNonBlockingUpPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+std::unique_ptr<mlir::Pass> circt::moore::createPullNonBlockingUpPass() {
+  return std::make_unique<PullNonBlockingUpPass>();
+}
+
+void PullNonBlockingUpPass::runOnOperation() {
+  getOperation()->walk([](scf::IfOp op) {
+    PatternRewriter rewriter(op.getContext());
+    if (failed(lowerSCFIfOp(op, rewriter)))
+      return;
+  });
+}

--- a/lib/Dialect/Moore/Transforms/SimplifyProcedures.cpp
+++ b/lib/Dialect/Moore/Transforms/SimplifyProcedures.cpp
@@ -94,7 +94,8 @@ void SimplifyProceduresPass::runOnOperation() {
               localVarOp.getResult());
           builder.create<BlockingAssignOp>(
               nestedOp.getLoc(),
-              localVarOp.getInitial().getDefiningOp()->getOperand(0), readOp);
+              localVarOp.getInitial().getDefiningOp()->getOperand(0), readOp,
+              Value{});
           builder.clearInsertionPoint();
           assignOps.erase(assignOp);
         }

--- a/test/Dialect/Moore/pull-nonblocking-up.mlir
+++ b/test/Dialect/Moore/pull-nonblocking-up.mlir
@@ -1,0 +1,86 @@
+// RUN: circt-opt --moore-pull-nonblocking-up %s | FileCheck %s
+
+// CHECK-LABEL: moore.module @Foo(in %clk : !moore.l1)
+moore.module @Foo(in %clk : !moore.l1) {
+  %clk_0 = moore.net name "clk" wire : <l1>
+  %0 = moore.constant 0 : i8
+  %1 = moore.conversion %0 : !moore.i8 -> !moore.l8
+  %2 = moore.conversion %1 : !moore.l8 -> !moore.l4
+  %arr = moore.variable %2 : <l4>
+  moore.procedure always {
+    %3 = moore.read %clk_0 : l1
+    moore.wait_event posedge %3 : l1
+    // CHECK: %4 = moore.constant 1 : i32
+    // CHECK: %5 = moore.bool_cast %4 : i32 -> i1
+    %4 = moore.constant 1 : i32
+    %5 = moore.bool_cast %4 : i32 -> i1
+    %6 = moore.conversion %5 : !moore.i1 -> i1
+    
+    // CHECK-NOT: scf.if
+    scf.if %6 {
+    // CHECK-NOT: else
+    } else {
+      // CHECK: %7 = moore.constant 2 : i32
+      // CHECK: %8 = moore.bool_cast %7 : i32 -> i1
+      %7 = moore.constant 2 : i32
+      %8 = moore.bool_cast %7 : i32 -> i1
+      %9 = moore.conversion %8 : !moore.i1 -> i1
+      // CHECK-NOT: scf.if
+      scf.if %9 {
+        %13 = moore.constant 0 : i32
+        // CHECK: %11 = moore.extract_ref %arr
+        %14 = moore.extract_ref %arr from %13 : <l4>, i32 -> <l1>
+        %15 = moore.constant true : i1
+        %16 = moore.conversion %15 : !moore.i1 -> !moore.l1
+
+        // CHECK: %14 = moore.not %5 : i1
+        // CHECK: %15 = moore.and %8, %14 : i1
+        // CHECK: moore.nonblocking_assign %11, %13 if %15 : l1, !moore.i1
+        moore.nonblocking_assign %14, %16 : l1
+        %17 = moore.constant 1 : i32
+        // CHECK: %17 = moore.extract_ref %arr
+        %18 = moore.extract_ref %arr from %17 : <l4>, i32 -> <l1>
+        %19 = moore.constant true : i1
+        %20 = moore.conversion %19 : !moore.i1 -> !moore.l1
+
+        // CHECK: %20 = moore.not %5 : i1
+        // CHECK: %21 = moore.and %8, %20 : i1
+        // CHECK: moore.nonblocking_assign %17, %19 if %21 : l1, !moore.i1
+        moore.nonblocking_assign %18, %20 : l1
+      }
+      // CHECK: %22 = moore.constant 3 : i32
+      // CHECK: %23 = moore.bool_cast %22 : i32 -> i1
+      %10 = moore.constant 3 : i32
+      %11 = moore.bool_cast %10 : i32 -> i1
+      %12 = moore.conversion %11 : !moore.i1 -> i1
+      // CHECK-NOT: scf.if
+      scf.if %12 {
+        %13 = moore.constant 2 : i32
+        // CHECK: %26 = moore.extract_ref %arr
+        %14 = moore.extract_ref %arr from %13 : <l4>, i32 -> <l1>
+        %15 = moore.constant true : i1
+        %16 = moore.conversion %15 : !moore.i1 -> !moore.l1
+
+        // CHECK: %29 = moore.not %5 : i1
+        // CHECK: %30 = moore.and %23, %29 : i1
+        // CHECK: moore.nonblocking_assign %26, %28 if %30 : l1, !moore.i1
+        moore.nonblocking_assign %14, %16 : l1
+        %17 = moore.constant 3 : i32
+        // CHECK: %32 = moore.extract_ref %arr
+        %18 = moore.extract_ref %arr from %17 : <l4>, i32 -> <l1>
+        %19 = moore.constant true : i1
+        %20 = moore.conversion %19 : !moore.i1 -> !moore.l1
+
+        // CHECK: %35 = moore.not %5 : i1
+        // CHECK: %36 = moore.and %23, %35 : i1
+        // CHECK: moore.nonblocking_assign %32, %34 if %36 : l1, !moore.i1 
+        moore.nonblocking_assign %18, %20 : l1
+      }
+    }
+  }
+  // CHECK: moore.assign %clk_0, %clk : l1
+  // CHECK: moore.output
+
+  moore.assign %clk_0, %clk : l1
+  moore.output
+}


### PR DESCRIPTION
`moore.*assign` has a new extra operand--`enable` to capture the if condition, like `moore.assign %dst, %src if %enable`
`PullNonBlockingUp` pass is aimed at pulling non-blokcing assignments upwards.
From:
```
moore.procedure {
  scf.if not(%rst) {
    ...
  } else {
    scf.if eq(cond1, a1) {
      %0 = moore.constant 1
      %1 = moore.extract_ref %q, %0
      moore.nonblokcing %1, %0
    }

    scf.if eq(cond2, a2) {
       %0 = moore.constant 1
       %1 = moore.extract_ref %q, %0
       moore.nonblokcing %1, %0
    }
   }
}
```
To:
```
moore.procedure {
  scf.if not(%rst) {
    ...
  } else {
    %0 = moore.constant 1
    %1 = moore.extract_ref %q, %0
    moore.nonblokcing %1, %0 if eq(cond1, a1)
    %2 = moore.constant 1
    %3 = moore.extract_ref %q, %0
    moore.nonblokcing %3, %2 if eq(cond2, a2)
   }
}
```
@fabianschuiki mentioned at this PR(https://github.com/llvm/circt/pull/7075).