### PR TITLE
[HW][SV] Allow procedural SV ops in hw::TriggeredOp

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -730,6 +730,9 @@ def TriggeredOp : HWOp<"triggered", [
   let builders = [
     OpBuilder<(ins "EventControlAttr":$event, "Value":$trigger, "ValueRange":$inputs)>
   ];
+
+  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
 }
 
 #endif // CIRCT_DIALECT_HW_HWSTRUCTURE_TD

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -3349,6 +3349,22 @@ void TriggeredOp::build(OpBuilder &builder, OperationState &odsState,
   b->addArguments(inputs.getTypes(), argLocs);
 }
 
+LogicalResult TriggeredOp::verify() {
+  if (!!getOperation()->getParentOfType<hw::TriggeredOp>())
+    return emitOpError("must not be nested under another TriggeredOp.");
+  return success();
+}
+
+LogicalResult TriggeredOp::verifyRegions() {
+  auto numInputs = getInputs().size();
+  auto numArgs = getBodyBlock()->getNumArguments();
+  if (numInputs != numArgs)
+    return emitOpError("number of inputs (" + Twine(numInputs) +
+                       ") does not match number of body arguments (" +
+                       Twine(numArgs) + ").");
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -54,14 +54,16 @@ bool sv::isExpression(Operation *op) {
 }
 
 LogicalResult sv::verifyInProceduralRegion(Operation *op) {
-  if (op->getParentOp()->hasTrait<sv::ProceduralRegion>())
+  if (op->getParentOp()->hasTrait<sv::ProceduralRegion>() ||
+      llvm::isa<hw::TriggeredOp>(op->getParentOp()))
     return success();
   op->emitError() << op->getName() << " should be in a procedural region";
   return failure();
 }
 
 LogicalResult sv::verifyInNonProceduralRegion(Operation *op) {
-  if (!op->getParentOp()->hasTrait<sv::ProceduralRegion>())
+  if (!op->getParentOp()->hasTrait<sv::ProceduralRegion>() &&
+      !llvm::isa<hw::TriggeredOp>(op->getParentOp()))
     return success();
   op->emitError() << op->getName() << " should be in a non-procedural region";
   return failure();

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -501,3 +501,22 @@ hw.module @Foo () {
   hw.instance_choice "inst" option "foo" @DoesNotExist () -> ()
 }
 
+// -----
+
+hw.module @Nested_Triggered(in %trg1 : i1, in %trg2 : i1) {
+  hw.triggered posedge %trg1(%trg2) : i1 {
+  ^bb0(%arg0: i1):
+    // expected-error @below {{op must not be nested under another TriggeredOp.}}
+    hw.triggered posedge %arg0 {
+    }
+  }
+}
+
+// -----
+
+hw.module @Triggered_Arguments(in %trg1 : i1, in %trg2 : i1) {
+  // expected-error @below {{number of inputs (1) does not match number of body arguments (2).}}
+  hw.triggered posedge %trg1(%trg2) : i1 {
+  ^bb0(%arg0: i1, %arg1: i1):
+  }
+}


### PR DESCRIPTION
Adapt the SV dialect `ProceduralOp` / `NonProceduralOp` traits to consider `hw::TriggeredOp` a procedural region. This should enable us to lower the procedural operations within a `hw::TriggeredOp` region before lowering the entire module.

See the discussion in #7292. We currently do not have a cross-dialect notion of procedural regions. However, the description of `hw::TriggeredOp` states bluntly that it creates a procedural region, so I think this is a relatively intuitive change.

Piggybacked are two sanity checks for `hw::TriggeredOp`:
- Don't allow nesting of TriggeredOps
- Ensure the number of input arguments matches the number of block arguments