### PR TITLE
[CI] Drop macos-11 runners, use macos-12 in uploadReleaseArtifacts

### DIFF
--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -12,7 +12,6 @@ on:
           - ubuntu-20.04
           - macos-13
           - macos-12
-          - macos-11
           - windows-2022
           - windows-2019
       cmake_build_type:

--- a/.github/workflows/uploadReleaseArtifacts.yml
+++ b/.github/workflows/uploadReleaseArtifacts.yml
@@ -101,7 +101,7 @@ jobs:
         if: github.event_name == 'release' || ( github.event_name == 'workflow_dispatch' && inputs.os == 'macos' )
         env:
           os: macos
-          runner: macos-11
+          runner: macos-12
           arch: x64
           tar: gtar czf
           archive: tar.gz


### PR DESCRIPTION
macos-11 runners are no longer available: https://github.com/actions/runner-images?tab=readme-ov-file#available-images

According to this blog post from January, they were planned to be phased out by June 2024 (incidentally the previous firtool release was June 5th): https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available.