### PR TITLE
[Scheduling] Replace macro use in problem definitions

### DIFF
--- a/include/circt/Dialect/SSP/Utilities.h
+++ b/include/circt/Dialect/SSP/Utilities.h
@@ -142,7 +142,7 @@ ProblemT loadProblem(InstanceOp instOp,
                      std::tuple<OperatorTypePropertyTs...> oprProps,
                      std::tuple<DependencePropertyTs...> depProps,
                      std::tuple<InstancePropertyTs...> instProps) {
-  auto prob = ProblemT::get(instOp);
+  ProblemT prob(instOp);
 
   loadInstanceProperties<ProblemT, InstancePropertyTs...>(
       prob, instOp.getSspPropertiesAttr());
@@ -325,7 +325,7 @@ saveProblem(ProblemT &prob, std::tuple<OperationPropertyTs...> opProps,
 
   // Set up instance.
   auto instOp = b.create<InstanceOp>(
-      builder.getStringAttr(ProblemT::PROBLEM_NAME),
+      builder.getStringAttr(ProblemT::name),
       saveInstanceProperties<ProblemT, InstancePropertyTs...>(prob, b));
   if (auto instName = prob.getInstanceName())
     instOp.setSymNameAttr(instName);

--- a/lib/Analysis/SchedulingAnalysis.cpp
+++ b/lib/Analysis/SchedulingAnalysis.cpp
@@ -48,7 +48,7 @@ circt::analysis::CyclicSchedulingAnalysis::CyclicSchedulingAnalysis(
 void circt::analysis::CyclicSchedulingAnalysis::analyzeForOp(
     AffineForOp forOp, MemoryDependenceAnalysis memoryAnalysis) {
   // Create a cyclic scheduling problem.
-  CyclicProblem problem = CyclicProblem::get(forOp);
+  CyclicProblem problem(forOp);
 
   // Insert memory dependences into the problem.
   forOp.getBody()->walk([&](Operation *op) {

--- a/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
+++ b/lib/Conversion/AffineToLoopSchedule/AffineToLoopSchedule.cpp
@@ -78,7 +78,7 @@ private:
 } // namespace
 
 ModuloProblem AffineToLoopSchedule::getModuloProblem(CyclicProblem &prob) {
-  auto modProb = ModuloProblem::get(prob.getContainingOp());
+  ModuloProblem modProb(prob.getContainingOp());
   for (auto *op : prob.getOperations()) {
     auto opr = prob.getLinkedOperatorType(op);
     if (opr.has_value()) {

--- a/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
@@ -69,7 +69,7 @@ ScheduleLinearPipelinePass::schedulePipeline(UnscheduledPipelineOp pipeline) {
            << opLibAttr << "' not found";
 
   // Load operator info from attribute.
-  auto problem = Problem::get(pipeline);
+  Problem problem(pipeline);
 
   DenseMap<SymbolRefAttr, Problem::OperatorType> operatorTypes;
   SmallDenseMap<StringAttr, unsigned> oprIds;


### PR DESCRIPTION
Removes the `DEFINE_COMMON_MEMBERS` macro from the definitions of the built-in scheduling problems to address #6517. Inheriting the base class' constructors keeps the boilerplate code small, but unfortunately I still have to declare the default constructor as protected in each class in order to prevent user code from creating problem instances without the `containingOp`.

A useful side-effect of exposing the constructor is that is now possible to create problem instances on the heap.