### PR TITLE
Reland "[FIRRTL][LowerClass] Pre-allocate namespaces before capturing refs (#7102)".

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -302,6 +302,12 @@ PathTracker::run(CircuitOp circuit, InstanceGraph &instanceGraph,
                  const DenseMap<DistinctAttr, FModuleOp> &owningModules) {
   SmallVector<PathTracker> trackers;
 
+  // First allocate module namespaces. Don't capture a namespace reference at
+  // this point since they could be invalidated when DenseMap grows.
+  for (auto *node : instanceGraph)
+    if (auto module = node->getModule<FModuleLike>())
+      (void)namespaces.get(module);
+
   for (auto *node : instanceGraph)
     if (auto module = node->getModule<FModuleLike>()) {
       PathTracker tracker(module, namespaces, instanceGraph, symbolTable,


### PR DESCRIPTION
This was originally added to avoid a use-after-free. However, it got removed as part of f4920aa. It seems this is still required, even when we process PathTrackers sequentially. I confirmed there was a use-after-free without this change, which is fixed after adding this back.

Closes https://github.com/llvm/circt/issues/7327.