### PR TITLE
[PyCDE] Bundles: coerce method

### DIFF
--- a/frontends/PyCDE/src/pycde/types.py
+++ b/frontends/PyCDE/src/pycde/types.py
@@ -668,6 +668,35 @@ class Bundle(Type):
             _FromCirctType(ty)) for (name, dir, ty) in self._type.channels
     ])
 
+  def get_to_from(self) -> typing.Tuple[BundledChannel, BundledChannel]:
+    """In a bidirectional, two-channel bundle, it is often desirable to easily
+    have access to the from and to channels."""
+
+    bundle_channels = self.channels
+    if len(bundle_channels) != 2:
+      raise ValueError("Bundle must have exactly two channels.")
+
+    # Return vars.
+    to_channel_bc: typing.Optional[BundledChannel] = None
+    from_channel_bc: typing.Optional[BundledChannel] = None
+
+    # Look at the first channel.
+    if bundle_channels[0].direction == ChannelDirection.TO:
+      to_channel_bc = bundle_channels[0]
+    else:
+      from_channel_bc = bundle_channels[0]
+
+    # Look at the second channel.
+    if bundle_channels[1].direction == ChannelDirection.TO:
+      to_channel_bc = bundle_channels[1]
+    else:
+      from_channel_bc = bundle_channels[1]
+
+    # Check and return.
+    if to_channel_bc is None or from_channel_bc is None:
+      raise ValueError("Bundle must have one channel in each direction.")
+    return to_channel_bc, from_channel_bc
+
   # Easy accessor for channel types by name.
   def __getattr__(self, attrname: str):
     for channel in self.channels:

--- a/frontends/PyCDE/test/test_esi_errors.py
+++ b/frontends/PyCDE/test/test_esi_errors.py
@@ -2,10 +2,10 @@
 # RUN: mkdir %t && cd %t
 # RUN: %PYTHON% py-split-input-file.py %s 2>&1 | FileCheck %s
 
-from pycde import (Clock, Input, InputChannel, OutputChannel, Module, generator,
-                   types)
+from pycde import (Clock, Input, InputChannel, Output, OutputChannel, Module,
+                   generator, types)
 from pycde.common import SendBundle, RecvBundle
-from pycde.types import Bits, Bundle, BundledChannel, ChannelDirection
+from pycde.types import Bits, Bundle, BundledChannel, Channel, ChannelDirection
 from pycde import esi
 from pycde.testing import unittestmodule
 
@@ -149,3 +149,81 @@ class RecvBundleTest(Module):
   def build(self):
     to_channels = self.b_recv.unpack(resp=self.i1_in)
     # CHECK: TypeError: Expected channel type Channel<Bits<1>, ValidReady>, got Channel<Bits<4>, ValidReady> on channel 'resp'
+
+
+# -----
+
+try:
+  Bundle([]).get_to_from()
+  # CHECK: Bundle must have exactly two channels.
+except ValueError as e:
+  print(e)
+
+# -----
+
+try:
+  Bundle([
+      BundledChannel("req", ChannelDirection.TO, Channel(Bits(32))),
+      BundledChannel("resp", ChannelDirection.TO, Channel(Bits(8))),
+  ]).get_to_from()
+  # CHECK: Bundle must have one channel in each direction.
+except ValueError as e:
+  print(e)
+
+# -----
+
+try:
+  Bundle([
+      BundledChannel("req", ChannelDirection.FROM, Channel(Bits(32))),
+      BundledChannel("resp", ChannelDirection.FROM, Channel(Bits(8))),
+  ]).get_to_from()
+  # CHECK: Bundle must have one channel in each direction.
+except ValueError as e:
+  print(e)
+
+# -----
+
+
+@unittestmodule()
+class CoerceBundleTransformWrongToWidth(Module):
+  b_in = Input(
+      Bundle([
+          BundledChannel("req", ChannelDirection.TO, Channel(Bits(32))),
+          BundledChannel("resp", ChannelDirection.FROM, Channel(Bits(8))),
+      ]))
+  b_out = Output(
+      Bundle([
+          BundledChannel("arg", ChannelDirection.TO, Channel(Bits(24))),
+          BundledChannel("result", ChannelDirection.FROM, Channel(Bits(16))),
+      ]))
+
+  @generator
+  def build(ports):
+    ports.b_out = ports.b_in.coerce(
+        CoerceBundleTransformWrongToWidth.b_out.type, lambda x: x[0:30],
+        lambda x: x[0:8])
+    # CHECK: TypeError: Expected channel type Channel<Bits<24>, ValidReady>, got Channel<Bits<30>, ValidReady> on TO channel
+
+
+# -----
+
+
+@unittestmodule()
+class CoerceBundleTransformWrongFromWidth(Module):
+  b_in = Input(
+      Bundle([
+          BundledChannel("req", ChannelDirection.TO, Channel(Bits(32))),
+          BundledChannel("resp", ChannelDirection.FROM, Channel(Bits(8))),
+      ]))
+  b_out = Output(
+      Bundle([
+          BundledChannel("arg", ChannelDirection.TO, Channel(Bits(24))),
+          BundledChannel("result", ChannelDirection.FROM, Channel(Bits(16))),
+      ]))
+
+  @generator
+  def build(ports):
+    ports.b_out = ports.b_in.coerce(
+        CoerceBundleTransformWrongFromWidth.b_out.type, lambda x: x[0:24],
+        lambda x: x[0:10])
+    # CHECK: TypeError: Expected channel type Channel<Bits<8>, ValidReady>, got Channel<Bits<10>, ValidReady> on FROM channel


### PR DESCRIPTION
Coerce a two-channel, bidirectional bundle to a different two-channel, bidirectional bundle type. Transform functions can be provided to transform the individual channels for situations where the types do not match.