### PR TITLE
[ExportVerilog] Add "context" to imported DPI functions

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4401,7 +4401,7 @@ LogicalResult StmtEmitter::visitSV(ReturnOp op) {
 LogicalResult StmtEmitter::visitSV(FuncDPIImportOp importOp) {
   startStatement();
 
-  ps << "import" << PP::nbsp << "\"DPI-C\"" << PP::nbsp;
+  ps << "import" << PP::nbsp << "\"DPI-C\"" << PP::nbsp << "context" << PP::nbsp;
 
   // Emit a linkage name if provided.
   if (auto linkageName = importOp.getLinkageName())

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4401,7 +4401,8 @@ LogicalResult StmtEmitter::visitSV(ReturnOp op) {
 LogicalResult StmtEmitter::visitSV(FuncDPIImportOp importOp) {
   startStatement();
 
-  ps << "import" << PP::nbsp << "\"DPI-C\"" << PP::nbsp << "context" << PP::nbsp;
+  ps << "import" << PP::nbsp << "\"DPI-C\"" << PP::nbsp << "context" 
+     << PP::nbsp;
 
   // Emit a linkage name if provided.
   if (auto linkageName = importOp.getLinkageName())

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4401,7 +4401,7 @@ LogicalResult StmtEmitter::visitSV(ReturnOp op) {
 LogicalResult StmtEmitter::visitSV(FuncDPIImportOp importOp) {
   startStatement();
 
-  ps << "import" << PP::nbsp << "\"DPI-C\"" << PP::nbsp << "context" 
+  ps << "import" << PP::nbsp << "\"DPI-C\"" << PP::nbsp << "context"
      << PP::nbsp;
 
   // Emit a linkage name if provided.

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1751,7 +1751,7 @@ sv.func @recurse_add(in %n : i32, out out : i32 {sv.func.explicitly_returned}) {
 
 // Emit DPI import.
 
-// CHECK-LABEL: import "DPI-C" linkage_name = function void function_declare1(
+// CHECK-LABEL: import "DPI-C" context linkage_name = function void function_declare1(
 // CHECK-NEXT:    input bit [1:0] in_0,
 // CHECK-NEXT:                    out_0,
 // CHECK-NEXT:                    in_1,
@@ -1759,13 +1759,13 @@ sv.func @recurse_add(in %n : i32, out out : i32 {sv.func.explicitly_returned}) {
 // CHECK-NEXT: );
 sv.func.dpi.import linkage "linkage_name" @function_declare1
 
-// CHECK-LABEL: import "DPI-C" function bit function_declare2(
+// CHECK-LABEL: import "DPI-C" context function bit function_declare2(
 // CHECK-NEXT:    input bit [1:0] in_0,
 // CHECK-NEXT:                    in_1
 // CHECK-NEXT: );
 sv.func.dpi.import @function_declare2
 
-// CHECK-LABEL: import "DPI-C" function void function_declare4(
+// CHECK-LABEL: import "DPI-C" context function void function_declare4(
 // CHECK-NEXT:   input bit         in,
 // CHECK-NEXT:   input byte        in_0,
 // CHECK-NEXT:   input shortint    in_1,

--- a/test/Conversion/SimToSV/dpi.mlir
+++ b/test/Conversion/SimToSV/dpi.mlir
@@ -7,7 +7,7 @@ sim.func.dpi @dpi(out arg0: i1, in %arg1: i1, out arg2: i1)
 // CHECK-NEXT:    sv.func.dpi.import @dpi
 // CHECK-NEXT:  }
 
-// VERILOG:      import "DPI-C" function void dpi( 
+// VERILOG:      import "DPI-C" context function void dpi(
 // VERILOG-NEXT:   output bit arg0,
 // VERILOG-NEXT:   input  bit arg1,
 // VERILOG-NEXT:   output bit arg2

--- a/test/firtool/dpi.fir
+++ b/test/firtool/dpi.fir
@@ -2,18 +2,18 @@
 
 FIRRTL version 4.0.0
 circuit DPI:
-; CHECK-LABEL: import "DPI-C" function void clocked_result(
+; CHECK-LABEL: import "DPI-C" context function void clocked_result(
 ; CHECK-NEXT:   input  byte foo,
 ; CHECK-NEXT:               bar,
 ; CHECK-NEXT:   output byte baz
 ; CHECK-NEXT: );
 
-; CHECK-LABEL: import "DPI-C" function void clocked_void(
+; CHECK-LABEL: import "DPI-C" context function void clocked_void(
 ; CHECK-NEXT:   input byte in_0,
 ; CHECK-NEXT:              in_1
 ; CHECK-NEXT: );
 
-; CHECK-LABEL: import "DPI-C" function void unclocked_result(
+; CHECK-LABEL: import "DPI-C" context function void unclocked_result(
 ; CHECK-NEXT:   input  byte in_0,
 ; CHECK-NEXT:                    in_1,
 ; CHECK-NEXT:   output byte out_0


### PR DESCRIPTION
This commit adds "context" property to DPI import statements to enable us to call exported functions from DPI functions. Ideally it's better to create an attribute to specify the property "context" or "pure" but "context" by default should be ok for now.