### PR TITLE
[ImportVerilog] Fix unbased unsized literals of packed aggregate type

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -361,9 +361,15 @@ struct RvalueExprVisitor {
           << value.getBitWidth() << " bits wide; only 64 supported";
       return {};
     }
+    auto intType =
+        moore::IntType::get(context.getContext(), value.getBitWidth(),
+                            value.hasUnknown() ? moore::Domain::FourValued
+                                               : moore::Domain::TwoValued);
     auto truncValue = value.as<uint64_t>().value();
-    return builder.create<moore::ConstantOp>(loc, cast<moore::IntType>(type),
-                                             truncValue);
+    Value result = builder.create<moore::ConstantOp>(loc, intType, truncValue);
+    if (result.getType() != type)
+      result = builder.create<moore::ConversionOp>(loc, type, result);
+    return result;
   }
 
   // Handle `'0`, `'1`, `'x`, and `'z` literals.

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -997,6 +997,12 @@ module Conversion;
   // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i32 -> !moore.i19
   // CHECK: %e = moore.variable [[TMP2]]
   bit signed [18:0] e = 19'(b);
+
+  // Implicit conversion for literals.
+  // CHECK: [[TMP1:%.+]] = moore.constant 0 : i64
+  // CHECK: [[TMP2:%.+]] = moore.conversion [[TMP1]] : !moore.i64 -> !moore.struct<{a: i32, b: i32}>
+  // CHECK: %f = moore.variable [[TMP2]]
+  struct packed { int a; int b; } f = '0;
 endmodule
 
 // CHECK-LABEL: moore.module @PortsTop


### PR DESCRIPTION
Fix an issue where ImportVerilog would currently crash if an unbased, unsized literal like `'0` is used to initialize or assign to a packed struct. Instead, the integer literal should be constructed and then converted to the packed aggregate type. In a later pass, this conversion can be lowered to a more careful `moore.struct_create`.