### PR TITLE
[ImportVerilog] Handle $signed/$unsigned system tasks

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ImportVerilogInternals.h"
+#include "slang/ast/SystemSubroutine.h"
 #include "slang/syntax/AllSyntax.h"
 
 using namespace circt;
@@ -578,6 +579,38 @@ struct RvalueExprVisitor {
     builder.create<moore::YieldOp>(loc, falseValue);
 
     return conditionalOp.getResult();
+  }
+
+  /// Handle calls.
+  Value visit(const slang::ast::CallExpression &expr) {
+    // Class method calls are currently not supported.
+    if (expr.thisClass()) {
+      mlir::emitError(loc, "unsupported class method call");
+      return {};
+    }
+    return std::visit(
+        [&](auto &subroutine) { return visitCall(expr, subroutine); },
+        expr.subroutine);
+  }
+
+  /// Handle subroutine calls.
+  Value visitCall(const slang::ast::CallExpression &expr,
+                  const slang::ast::SubroutineSymbol *subroutine) {
+    mlir::emitError(loc, "unsupported subroutine call");
+    return {};
+  }
+
+  /// Handle system calls.
+  Value visitCall(const slang::ast::CallExpression &expr,
+                  const slang::ast::CallExpression::SystemCallInfo &info) {
+    const auto &subroutine = *info.subroutine;
+
+    if (subroutine.name == "$signed" || subroutine.name == "$unsigned")
+      return context.convertRvalueExpression(*expr.arguments()[0]);
+
+    mlir::emitError(loc) << "unsupported system call `" << subroutine.name
+                         << "`";
+    return {};
   }
 
   /// Emit an error for all other expressions.

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -962,6 +962,18 @@ module Expressions;
     // CHECK: moore.blocking_assign %a, [[TMP2]]
     a += (a *= a--);
  
+    //===------------------------------------------------------------------===//
+    // Builtin Functions
+
+    // The following functions are handled by Slang's type checking and don't
+    // convert into any IR operations.
+
+    // CHECK: [[TMP:%.+]] = moore.read %u
+    // CHECK: moore.blocking_assign %a, [[TMP]]
+    a = $signed(u);
+    // CHECK: [[TMP:%.+]] = moore.read %a
+    // CHECK: moore.blocking_assign %u, [[TMP]]
+    u = $unsigned(a);
   end
 endmodule
 


### PR DESCRIPTION
Handle calls to the `$signed` and `$unsigned` system tasks by simply passing through the argument. The casting is handled by Slang during type checking and is materialized as a type conversion node in the AST. The call itself has no function after that.

The `visitCall` function is going to be the place to add handling for other system calls in the future. IEEE 1800-2017 section 20 defines a fairly substantial list of builtin system tasks. Most of these will want to have a dedicated `moore.builtin.*` op in the future.