### PR TITLE
[circt-bmc] Add LowerToBMC Pass

### DIFF
--- a/include/circt/Tools/circt-bmc/Passes.h
+++ b/include/circt/Tools/circt-bmc/Passes.h
@@ -22,6 +22,7 @@ namespace circt {
 //===----------------------------------------------------------------------===//
 
 /// Generate the code for registering passes.
+#define GEN_PASS_DECL_LOWERTOBMC
 #define GEN_PASS_DECL_EXTERNALIZEREGISTERS
 #define GEN_PASS_REGISTRATION
 #include "circt/Tools/circt-bmc/Passes.h.inc"

--- a/include/circt/Tools/circt-bmc/Passes.td
+++ b/include/circt/Tools/circt-bmc/Passes.td
@@ -16,6 +16,28 @@
 include "mlir/Pass/PassBase.td"
 include "mlir/Rewrite/PassUtil.td"
 
+def LowerToBMC : Pass<"lower-to-bmc", "::mlir::ModuleOp"> {
+  let summary = "Lower CIRCTs core dialects to a BMC problem statement";
+  let description = [{
+  }];
+  let options = [
+    Option<"topModule", "top-module", "std::string",
+           /*default=*/"",
+           "Name of the top module to verify.">,
+    Option<"bound", "bound", "unsigned",
+           /*default=*/"",
+           "Cycle bound.">,
+    Option<"insertMainFunc", "insert-main", "bool",
+           /*default=*/"false",
+           "Whether a main function should be inserted for AOT compilation.">,
+  ];
+
+  let dependentDialects = [
+    "mlir::func::FuncDialect", "mlir::LLVM::LLVMDialect",
+    "circt::verif::VerifDialect"
+  ];
+}
+
 def ExternalizeRegisters : Pass<"externalize-registers", "::mlir::ModuleOp"> {
   let summary = "Removes registers and adds corresponding input and output ports";
 

--- a/lib/Tools/circt-bmc/CMakeLists.txt
+++ b/lib/Tools/circt-bmc/CMakeLists.txt
@@ -1,12 +1,17 @@
 add_circt_library(CIRCTBMCTransforms
   ExternalizeRegisters.cpp
+  LowerToBMC.cpp
 
   DEPENDS
   CIRCTBMCTransformsIncGen
 
   LINK_LIBS PUBLIC
+  CIRCTSMT
   CIRCTHW
   CIRCTSeq
+  CIRCTComb
+  CIRCTVerif
+  CIRCTCombToSMT
 
   MLIRIR
   MLIRSupport

--- a/lib/Tools/circt-bmc/CMakeLists.txt
+++ b/lib/Tools/circt-bmc/CMakeLists.txt
@@ -6,13 +6,12 @@ add_circt_library(CIRCTBMCTransforms
   CIRCTBMCTransformsIncGen
 
   LINK_LIBS PUBLIC
-  CIRCTSMT
   CIRCTHW
   CIRCTSeq
   CIRCTComb
   CIRCTVerif
-  CIRCTCombToSMT
 
+  MLIRFuncDialect
   MLIRIR
   MLIRSupport
   MLIRSCFDialect

--- a/lib/Tools/circt-bmc/LowerToBMC.cpp
+++ b/lib/Tools/circt-bmc/LowerToBMC.cpp
@@ -1,0 +1,189 @@
+//===- LowerToBMC.cpp -----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+
+#include "circt/Dialect/Seq/SeqTypes.h"
+#include "circt/Dialect/Verif/VerifOps.h"
+#include "circt/Support/Namespace.h"
+#include "circt/Tools/circt-bmc/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Location.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/APInt.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace hw;
+
+namespace circt {
+#define GEN_PASS_DEF_LOWERTOBMC
+#include "circt/Tools/circt-bmc/Passes.h.inc"
+} // namespace circt
+
+//===----------------------------------------------------------------------===//
+// Convert Lower To BMC pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LowerToBMCPass : public circt::impl::LowerToBMCBase<LowerToBMCPass> {
+  using LowerToBMCBase::LowerToBMCBase;
+  void runOnOperation() override;
+};
+} // namespace
+
+static Value lookupOrCreateStringGlobal(OpBuilder &builder, ModuleOp moduleOp,
+                                        StringRef str) {
+  Location loc = moduleOp.getLoc();
+  auto global = moduleOp.lookupSymbol<LLVM::GlobalOp>(str);
+  if (!global) {
+    OpBuilder b = OpBuilder::atBlockEnd(moduleOp.getBody());
+    auto arrayTy = LLVM::LLVMArrayType::get(b.getI8Type(), str.size() + 1);
+    global = b.create<LLVM::GlobalOp>(
+        loc, arrayTy, /*isConstant=*/true, LLVM::linkage::Linkage::Private, str,
+        StringAttr::get(b.getContext(), Twine(str).concat(Twine('\00'))));
+  }
+
+  // FIXME: sanity check the fetched global: do all the attributes match what
+  // we expect?
+
+  return builder.create<LLVM::AddressOfOp>(loc, global);
+}
+
+void LowerToBMCPass::runOnOperation() {
+  Namespace names;
+
+  // Fetch the 'hw.module' operation to model check.
+  Operation *expectedModule = getOperation().lookupSymbol(topModule);
+  if (!expectedModule) {
+    getOperation().emitError("module named '") << topModule << "' not found";
+    return signalPassFailure();
+  }
+  auto hwModule = dyn_cast<hw::HWModuleOp>(expectedModule);
+  if (!hwModule) {
+    expectedModule->emitError("must be a 'hw.module'");
+    return signalPassFailure();
+  }
+
+  if (hwModule.getOps<verif::AssertOp>().empty()) {
+    hwModule.emitError("no property provided to check in module");
+    return signalPassFailure();
+  }
+
+  // Create necessary function declarations and globals
+  OpBuilder builder(&getContext());
+  Location loc = getOperation()->getLoc();
+  builder.setInsertionPointToEnd(getOperation().getBody());
+  auto ptrTy = LLVM::LLVMPointerType::get(builder.getContext());
+  auto voidTy = LLVM::LLVMVoidType::get(builder.getContext());
+
+  // Lookup or declare printf function.
+  auto printfFunc =
+      LLVM::lookupOrCreateFn(getOperation(), "printf", ptrTy, voidTy, true);
+
+  // Replace the top-module with a function performing the BMC
+  Type i32Ty = builder.getI32Type();
+  auto entryFunc = builder.create<func::FuncOp>(
+      loc, topModule, builder.getFunctionType({}, {}));
+  builder.createBlock(&entryFunc.getBody());
+
+  {
+    OpBuilder::InsertionGuard guard(builder);
+    auto *terminator = hwModule.getBody().front().getTerminator();
+    builder.setInsertionPoint(terminator);
+    builder.create<verif::YieldOp>(loc, terminator->getOperands());
+    terminator->erase();
+  }
+
+  // Double the bound given to the BMC op, as a clock cycle takes 2 BMC
+  // iterations
+  verif::BMCOp bmcOp;
+  if (auto numRegs = hwModule->getAttr("num_regs"))
+    bmcOp = builder.create<verif::BMCOp>(
+        loc, 2 * bound, cast<IntegerAttr>(numRegs).getValue().getZExtValue());
+  else {
+    hwModule->emitOpError(
+        "No num_regs attribute found - please run externalise "
+        "registers pass first.");
+    return signalPassFailure();
+  }
+
+  // Check that there's only one clock input to the module
+  // TODO: supporting multiple clocks isn't too hard, an interleaving of clock
+  // toggles just needs to be generated
+  std::optional<unsigned long> clkIndex;
+  for (auto [i, input] : llvm::enumerate(hwModule.getInputTypes())) {
+    if (isa<seq::ClockType>(input)) {
+      if (clkIndex) {
+        hwModule.emitError("Designs with multiple clocks not yet supported.");
+        return signalPassFailure();
+      }
+      clkIndex = i;
+    }
+  }
+  {
+    OpBuilder::InsertionGuard guard(builder);
+    // Initialize clock to 0 if it exists, otherwise just yield nothing
+    auto *initBlock = builder.createBlock(&bmcOp.getInit());
+    builder.setInsertionPointToStart(initBlock);
+    if (clkIndex) {
+      auto initVal =
+          builder.create<hw::ConstantOp>(loc, builder.getI1Type(), 0);
+      auto toClk = builder.create<seq::ToClockOp>(loc, initVal);
+      builder.create<verif::YieldOp>(loc, ValueRange{toClk});
+    } else {
+      builder.create<verif::YieldOp>(loc, ValueRange{});
+    }
+
+    // Toggle clock in loop region if it exists, otherwise just yield nothing
+    auto *loopBlock = builder.createBlock(&bmcOp.getLoop());
+    builder.setInsertionPointToStart(loopBlock);
+    SmallVector<Location> locs(
+        hwModule.getBodyBlock()->getArgumentTypes().size(), loc);
+    loopBlock->addArguments(hwModule.getBodyBlock()->getArgumentTypes(), locs);
+    if (clkIndex) {
+      auto fromClk = builder.create<seq::FromClockOp>(
+          loc, loopBlock->getArgument(clkIndex.value()));
+      auto cNeg1 = builder.create<hw::ConstantOp>(loc, builder.getI1Type(), -1);
+      auto nClk = builder.create<comb::XorOp>(loc, fromClk, cNeg1);
+      auto toClk = builder.create<seq::ToClockOp>(loc, nClk);
+      // Only yield clock value
+      builder.create<verif::YieldOp>(loc, ValueRange{toClk});
+    } else {
+      builder.create<verif::YieldOp>(loc, ValueRange{});
+    }
+  }
+  bmcOp.getCircuit().takeBody(hwModule.getBody());
+  hwModule->erase();
+
+  auto successString = lookupOrCreateStringGlobal(
+      builder, getOperation(), "Bound reached with no violations!\n");
+  auto failureString = lookupOrCreateStringGlobal(
+      builder, getOperation(), "Assertion can be violated!\n");
+  auto formatString = builder.create<LLVM::SelectOp>(
+      loc, bmcOp.getResult(), successString, failureString);
+  builder.create<LLVM::CallOp>(loc, printfFunc, ValueRange{formatString});
+  builder.create<func::ReturnOp>(loc);
+
+  if (insertMainFunc) {
+    builder.setInsertionPointToEnd(getOperation().getBody());
+    auto mainFunc = builder.create<func::FuncOp>(
+        loc, "main", builder.getFunctionType({i32Ty, ptrTy}, {i32Ty}));
+    builder.createBlock(&mainFunc.getBody(), {}, {i32Ty, ptrTy}, {loc, loc});
+    builder.create<func::CallOp>(loc, entryFunc, ValueRange{});
+    // TODO: don't use LLVM here
+    Value constZero = builder.create<LLVM::ConstantOp>(loc, i32Ty, 0);
+    builder.create<func::ReturnOp>(loc, constZero);
+  }
+}

--- a/test/Tools/circt-bmc/lower-to-bmc-errors.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc-errors.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt --externalize-registers --lower-to-bmc="top-module=twoClocks bound=10" --split-input-file --verify-diagnostics %s
 
-// expected-error @below {{Designs with multiple clocks not yet supported.}}
+// expected-error @below {{modules with multiple clocks not yet supported}}
 hw.module @twoClocks(in %clk0: !seq.clock, in %clk1: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
   %reg0 = seq.compreg %in0, %clk0 : i32
   %reg1 = seq.compreg %in1, %clk1 : i32

--- a/test/Tools/circt-bmc/lower-to-bmc-errors.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc-errors.mlir
@@ -1,0 +1,11 @@
+// RUN: circt-opt --externalize-registers --lower-to-bmc="top-module=twoClocks bound=10" --split-input-file --verify-diagnostics %s
+
+// expected-error @below {{Designs with multiple clocks not yet supported.}}
+hw.module @twoClocks(in %clk0: !seq.clock, in %clk1: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
+  %reg0 = seq.compreg %in0, %clk0 : i32
+  %reg1 = seq.compreg %in1, %clk1 : i32
+  %0 = comb.add %reg0, %reg1 : i32
+  %prop = comb.icmp eq %0, %in0 : i32
+  verif.assert %prop : i1
+  hw.output %0 : i32
+}

--- a/test/Tools/circt-bmc/lower-to-bmc.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc.mlir
@@ -4,7 +4,6 @@
 // CHECK:  func.func @comb() {
 // CHECK:    [[BMC:%.+]] = verif.bmc bound 20 num_regs 0 init {
 // CHECK:    } loop {
-// CHECK:    ^bb0({{%.+}}: i32, {{%.+}}: i32):
 // CHECK:    } circuit {
 // CHECK:    ^bb0([[ARG0:%.+]]: i32, [[ARG1:%.+]]: i32):
 // CHECK:      [[OP0:%.+]] = comb.add [[ARG0]], [[ARG1]]
@@ -37,7 +36,7 @@ hw.module @comb(in %in0: i32, in %in1: i32, out out: i32) {
 // CHECK1:      [[INIT_CLK:%.+]] = seq.to_clock [[FALSE]]
 // CHECK1:      verif.yield [[INIT_CLK]]
 // CHECK1:    } loop {
-// CHECK1:    ^bb0([[CLK:%.+]]: !seq.clock, [[ARG1:%.+]]: i32, [[ARG2:%.+]]: i32, [[ARG3:%.+]]: i32):
+// CHECK1:    ^bb0([[CLK:%.+]]: !seq.clock):
 // CHECK1:      [[FROM_CLK:%.+]] = seq.from_clock [[CLK]]
 // CHECK1:      [[TRUE:%.+]] = hw.constant true
 // CHECK1:      [[NCLK:%.+]] = comb.xor [[FROM_CLK]], [[TRUE]]
@@ -46,7 +45,6 @@ hw.module @comb(in %in0: i32, in %in1: i32, out out: i32) {
 // CHECK1:    } circuit {
 // CHECK1:    ^bb0([[CLK:%.+]]: !seq.clock, [[ARG1:%.+]]: i32, [[ARG2:%.+]]: i32, [[ARG3:%.+]]: i32):
 // CHECK1:      [[OP0:%.+]] = comb.add [[ARG1]], [[ARG2]]
-// CHECK1:      [[OP1:%.+]] = seq.from_clock [[CLK]]
 // CHECK1:      [[OP2:%.+]] = comb.icmp eq [[OP0]], [[ARG1]]
 // CHECK1:      verif.assert [[OP2]]
 // CHECK1:      verif.yield [[ARG3]], [[OP0]]

--- a/test/Tools/circt-bmc/lower-to-bmc.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc.mlir
@@ -1,0 +1,69 @@
+// RUN: circt-opt --externalize-registers --lower-to-bmc="top-module=comb bound=10" %s | FileCheck %s
+
+// CHECK:  llvm.func @printf(!llvm.ptr, ...)
+// CHECK:  func.func @comb() {
+// CHECK:    [[BMC:%.+]] = verif.bmc bound 20 num_regs 0 init {
+// CHECK:    } loop {
+// CHECK:    ^bb0({{%.+}}: i32, {{%.+}}: i32):
+// CHECK:    } circuit {
+// CHECK:    ^bb0([[ARG0:%.+]]: i32, [[ARG1:%.+]]: i32):
+// CHECK:      [[OP0:%.+]] = comb.add [[ARG0]], [[ARG1]]
+// CHECK:      [[OP1:%.+]] = comb.icmp eq [[OP0]], [[ARG0]]
+// CHECK:      verif.assert [[OP1]]
+// CHECK:      verif.yield [[OP0]]
+// CHECK:    }
+// CHECK:    [[SSTR:%.+]] = llvm.mlir.addressof @"Bound reached with no violations!\0A"
+// CHECK:    [[FSTR:%.+]] = llvm.mlir.addressof @"Assertion can be violated!\0A"
+// CHECK:    [[SEL:%.+]] = llvm.select [[BMC]], [[SSTR]], [[FSTR]]
+// CHECK:    llvm.call @printf([[SEL]])
+// CHECK:    return
+// CHECK:  }
+// CHECK:  llvm.mlir.global private constant @"Bound reached with no violations!\0A"("Bound reached with no violations!\0A\00") {addr_space = 0 : i32}
+// CHECK:  llvm.mlir.global private constant @"Assertion can be violated!\0A"("Assertion can be violated!\0A\00") {addr_space = 0 : i32}
+
+hw.module @comb(in %in0: i32, in %in1: i32, out out: i32) {
+  %0 = comb.add %in0, %in1 : i32
+  %prop = comb.icmp eq %0, %in0 : i32
+  verif.assert %prop : i1
+  hw.output %0 : i32
+}
+
+// RUN: circt-opt --externalize-registers --lower-to-bmc="top-module=seq bound=10" %s | FileCheck %s --check-prefix=CHECK1
+
+// CHECK1:  llvm.func @printf(!llvm.ptr, ...)
+// CHECK1:  func.func @seq() {
+// CHECK1:    [[BMC:%.+]] = verif.bmc bound 20 num_regs 1 init {
+// CHECK1:      [[FALSE:%.+]] = hw.constant false
+// CHECK1:      [[INIT_CLK:%.+]] = seq.to_clock [[FALSE]]
+// CHECK1:      verif.yield [[INIT_CLK]]
+// CHECK1:    } loop {
+// CHECK1:    ^bb0([[CLK:%.+]]: !seq.clock, [[ARG1:%.+]]: i32, [[ARG2:%.+]]: i32, [[ARG3:%.+]]: i32):
+// CHECK1:      [[FROM_CLK:%.+]] = seq.from_clock [[CLK]]
+// CHECK1:      [[TRUE:%.+]] = hw.constant true
+// CHECK1:      [[NCLK:%.+]] = comb.xor [[FROM_CLK]], [[TRUE]]
+// CHECK1:      [[NEW_CLOCK:%.+]] = seq.to_clock [[NCLK]]
+// CHECK1:      verif.yield [[NEW_CLOCK]]
+// CHECK1:    } circuit {
+// CHECK1:    ^bb0([[CLK:%.+]]: !seq.clock, [[ARG1:%.+]]: i32, [[ARG2:%.+]]: i32, [[ARG3:%.+]]: i32):
+// CHECK1:      [[OP0:%.+]] = comb.add [[ARG1]], [[ARG2]]
+// CHECK1:      [[OP1:%.+]] = seq.from_clock [[CLK]]
+// CHECK1:      [[OP2:%.+]] = comb.icmp eq [[OP0]], [[ARG1]]
+// CHECK1:      verif.assert [[OP2]]
+// CHECK1:      verif.yield [[ARG3]], [[OP0]]
+// CHECK1:    }
+// CHECK1:    [[SSTR:%.+]] = llvm.mlir.addressof @"Bound reached with no violations!\0A"
+// CHECK1:    [[FSTR:%.+]] = llvm.mlir.addressof @"Assertion can be violated!\0A"
+// CHECK1:    [[SEL:%.+]] = llvm.select [[BMC]], [[SSTR]], [[FSTR]]
+// CHECK1:    llvm.call @printf([[SEL]])
+// CHECK1:    return
+// CHECK1:  }
+// CHECK1:  llvm.mlir.global private constant @"Bound reached with no violations!\0A"("Bound reached with no violations!\0A\00") {addr_space = 0 : i32}
+// CHECK1:  llvm.mlir.global private constant @"Assertion can be violated!\0A"("Assertion can be violated!\0A\00") {addr_space = 0 : i32}
+
+hw.module @seq(in %clk: !seq.clock, in %in0: i32, in %in1: i32, out out: i32) {
+  %0 = comb.add %in0, %in1 : i32
+  %reg = seq.compreg %0, %clk : i32
+  %prop = comb.icmp eq %0, %in0 : i32
+  verif.assert %prop : i1
+  hw.output %reg : i32
+}


### PR DESCRIPTION
This adds a pass (again based on a first draft by @maerhart) that takes a `hw.module` and converts it into a corresponding `verif.bmc` operation. Currently only supports modules with one clock.