### PR TITLE
[ImportVerilog] Add basic function support

### DIFF
--- a/lib/Conversion/ImportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ImportVerilog/CMakeLists.txt
@@ -42,6 +42,7 @@ add_circt_translation_library(CIRCTImportVerilog
   LINK_LIBS PUBLIC
   CIRCTHW
   CIRCTMoore
+  MLIRFuncDialect
   MLIRSCFDialect
   MLIRTranslateLib
   PRIVATE

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -259,8 +259,8 @@ LogicalResult ImportDriver::importVerilog(ModuleOp module) {
   compileTimer.stop();
 
   // Traverse the parsed Verilog AST and map it to the equivalent CIRCT ops.
-  mlirContext
-      ->loadDialect<moore::MooreDialect, hw::HWDialect, scf::SCFDialect>();
+  mlirContext->loadDialect<moore::MooreDialect, hw::HWDialect, scf::SCFDialect,
+                           func::FuncDialect>();
   auto conversionTimer = ts.nest("Verilog to dialect mapping");
   Context context(*compilation, module, driver.sourceManager, bufferFilePaths);
   if (failed(context.convertCompilation()))


### PR DESCRIPTION
Add basic support for function definitions and calls to such functions.

Input function arguments are currently passed into the function by value, while output, inout, ref, and const ref arguments are passed by reference at the moment. Later on we may want to be more faithful to the SV spec and make output and inout arguments also pass by value.

Calls to void functions are slightly strange in that they don't really have a result value, but the `convertExpression` function really wants a valid `Value` to return. To work around this, these calls generate an additional `!moore.void` value using `unrealized_conversion_cast`, which gets deleted again by the statement conversion code.