### PR TITLE
[ESI] Separate data delay from signaling standard

### DIFF
--- a/frontends/PyCDE/src/pycde/signals.py
+++ b/frontends/PyCDE/src/pycde/signals.py
@@ -714,7 +714,7 @@ class ChannelSignal(Signal):
       unwrap_op = esi.UnwrapValidReadyOp(self.type.inner_type, types.i1,
                                          self.value, ready.value)
       return unwrap_op[0], unwrap_op[1]
-    elif signaling == ChannelSignaling.FIFO0:
+    elif signaling == ChannelSignaling.FIFO:
       rden = types.i1(readyOrRden)
       wrap_op = esi.UnwrapFIFOOp(self.value, rden.value)
       return wrap_op[0], wrap_op[1]

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -9,8 +9,17 @@ from pycde.constructs import Wire
 from pycde.esi import MMIO
 from pycde.module import Metadata
 from pycde.types import (Bits, Bundle, BundledChannel, Channel,
-                         ChannelDirection, UInt, ClockType)
+                         ChannelDirection, ChannelSignaling, UInt, ClockType)
 from pycde.testing import unittestmodule
+
+# CHECK: Channel<UInt<4>, ValidReady>
+print(Channel(UInt(4)))
+
+# CHECK: Channel<UInt<4>, FIFO>
+print(Channel(UInt(4), ChannelSignaling.FIFO))
+
+# CHECK: Channel<UInt<4>, ValidReady(1)>
+print(Channel(UInt(4), ChannelSignaling.ValidReady, 1))
 
 TestBundle = Bundle([
     BundledChannel("resp", ChannelDirection.FROM, Bits(16)),

--- a/include/circt-c/Dialect/ESI.h
+++ b/include/circt-c/Dialect/ESI.h
@@ -20,9 +20,11 @@ MLIR_CAPI_EXPORTED void registerESIPasses(void);
 
 MLIR_CAPI_EXPORTED bool circtESITypeIsAChannelType(MlirType type);
 MLIR_CAPI_EXPORTED MlirType circtESIChannelTypeGet(MlirType inner,
-                                                   uint32_t signaling);
+                                                   uint32_t signaling,
+                                                   uint64_t dataDelay);
 MLIR_CAPI_EXPORTED MlirType circtESIChannelGetInner(MlirType channelType);
 MLIR_CAPI_EXPORTED uint32_t circtESIChannelGetSignaling(MlirType channelType);
+MLIR_CAPI_EXPORTED uint64_t circtESIChannelGetDataDelay(MlirType channelType);
 
 MLIR_CAPI_EXPORTED bool circtESITypeIsAnAnyType(MlirType type);
 MLIR_CAPI_EXPORTED MlirType circtESIAnyTypeGet(MlirContext);

--- a/include/circt/Dialect/ESI/ESIChannels.td
+++ b/include/circt/Dialect/ESI/ESIChannels.td
@@ -33,12 +33,12 @@ include "circt/Dialect/ESI/ESITypes.td"
 def ChannelSignalingValidReady : I32EnumAttrCase<"ValidReady", 0>;
 // FIFO interface with a read latency of zero. Very similiar to valid-ready, but
 // cannot assert ready if data is not available.
-def ChannelSignalingFIFO0      : I32EnumAttrCase<"FIFO0",      1>;
+def ChannelSignalingFIFO      : I32EnumAttrCase<"FIFO",      1>;
 
 def ChannelSignaling : I32EnumAttr<
     "ChannelSignaling",
     "ESI channel wire signaling standard",
-    [ChannelSignalingValidReady, ChannelSignalingFIFO0]>{
+    [ChannelSignalingValidReady, ChannelSignalingFIFO]>{
   let cppNamespace = "::circt::esi";
 }
 
@@ -49,6 +49,12 @@ def ChannelTypeImpl : ESI_Type<"Channel"> {
     point-to-point data stream. Channels are typed (like all of ESI). Said
     type can be any MLIR type, but must be lowered to something a backend
     knows how to output (i.e. something emitVerilog knows about).
+
+    Parameters:
+      signaling: the style of the control signals (valid/ready vs FIFO).
+      dataDelay: the number of cycles data takes to arrive after the control
+      indicates a transaction has occured. For instance, on a FIFO without read
+      ahead, this would be 1. Defaults to 0.
 
     Example:
 
@@ -63,14 +69,17 @@ def ChannelTypeImpl : ESI_Type<"Channel"> {
       "Type":$inner,
       DefaultValuedParameter<
         "::circt::esi::ChannelSignaling",
-        "::circt::esi::ChannelSignaling::ValidReady">:$signaling);
+        "::circt::esi::ChannelSignaling::ValidReady">:$signaling,
+      DefaultValuedParameter<"uint64_t", "0">:$dataDelay);
 
-  let assemblyFormat = "`<` $inner (`,` $signaling^)? `>`";
+  let assemblyFormat = [{
+    `<` $inner (`,` $signaling^ ( `(` $dataDelay^ `)` )? )? `>`
+  }];
 
   let builders = [
     TypeBuilder<(ins "Type":$type), [{
         return Base::get(type.getContext(), type,
-                         ::circt::esi::ChannelSignaling::ValidReady);
+                         ::circt::esi::ChannelSignaling::ValidReady, 0);
       }]>,
   ];
 }
@@ -443,6 +452,7 @@ def ChannelBufferOp : ESI_Abstract_Op<"buffer", [
     OptionalAttr<StrAttr>:$name);
   let results = (outs ChannelType:$output);
   let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
 }
 
 def PipelineStageOp : ESI_Physical_Op<"stage", [

--- a/lib/Bindings/Python/ESIModule.cpp
+++ b/lib/Bindings/Python/ESIModule.cpp
@@ -88,16 +88,21 @@ void circt::python::populateDialectESISubmodule(py::module &m) {
   mlir_type_subclass(m, "ChannelType", circtESITypeIsAChannelType)
       .def_classmethod(
           "get",
-          [](py::object cls, MlirType inner, uint32_t signaling = 0) {
+          [](py::object cls, MlirType inner, uint32_t signaling = 0,
+             uint64_t dataDelay = 0) {
             if (circtESITypeIsAChannelType(inner))
               return cls(inner);
-            return cls(circtESIChannelTypeGet(inner, signaling));
+            return cls(circtESIChannelTypeGet(inner, signaling, dataDelay));
           },
-          py::arg("cls"), py::arg("inner"), py::arg("signaling") = 0)
+          py::arg("cls"), py::arg("inner"), py::arg("signaling") = 0,
+          py::arg("dataDelay") = 0)
       .def_property_readonly(
           "inner", [](MlirType self) { return circtESIChannelGetInner(self); })
-      .def_property_readonly("signaling", [](MlirType self) {
-        return circtESIChannelGetSignaling(self);
+      .def_property_readonly(
+          "signaling",
+          [](MlirType self) { return circtESIChannelGetSignaling(self); })
+      .def_property_readonly("data_delay", [](MlirType self) {
+        return circtESIChannelGetDataDelay(self);
       });
 
   mlir_type_subclass(m, "AnyType", circtESITypeIsAnAnyType)

--- a/lib/Bindings/Python/dialects/esi.py
+++ b/lib/Bindings/Python/dialects/esi.py
@@ -16,7 +16,7 @@ from typing import Dict, List, Optional, Sequence, Type
 
 class ChannelSignaling:
   ValidReady = 0
-  FIFO0 = 1
+  FIFO = 1
 
 
 @_ods_cext.register_operation(_Dialect, replace=True)

--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -30,12 +30,14 @@ bool circtESITypeIsAChannelType(MlirType type) {
   return isa<ChannelType>(unwrap(type));
 }
 
-MlirType circtESIChannelTypeGet(MlirType inner, uint32_t signaling) {
+MlirType circtESIChannelTypeGet(MlirType inner, uint32_t signaling,
+                                uint64_t dataDelay) {
   auto signalEnum = symbolizeChannelSignaling(signaling);
   if (!signalEnum)
     return {};
   auto cppInner = unwrap(inner);
-  return wrap(ChannelType::get(cppInner.getContext(), cppInner, *signalEnum));
+  return wrap(ChannelType::get(cppInner.getContext(), cppInner, *signalEnum,
+                               dataDelay));
 }
 
 MlirType circtESIChannelGetInner(MlirType channelType) {
@@ -43,6 +45,9 @@ MlirType circtESIChannelGetInner(MlirType channelType) {
 }
 uint32_t circtESIChannelGetSignaling(MlirType channelType) {
   return (uint32_t)cast<ChannelType>(unwrap(channelType)).getSignaling();
+}
+uint64_t circtESIChannelGetDataDelay(MlirType channelType) {
+  return cast<ChannelType>(unwrap(channelType)).getDataDelay();
 }
 
 bool circtESITypeIsAnAnyType(MlirType type) {

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -64,6 +64,14 @@ circt::esi::ChannelType ChannelBufferOp::channelType() {
   return cast<circt::esi::ChannelType>(getInput().getType());
 }
 
+LogicalResult ChannelBufferOp::verify() {
+  if (getInput().getType().getSignaling() != ChannelSignaling::ValidReady)
+    return emitOpError("currently only supports valid-ready signaling");
+  if (getOutput().getType().getDataDelay() != 0)
+    return emitOpError("currently only supports channels with zero data delay");
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // PipelineStageOp functions.
 //===----------------------------------------------------------------------===//
@@ -202,7 +210,7 @@ ParseResult parseWrapFIFOType(OpAsmParser &p, Type &dataType,
   ChannelType chType;
   if (p.parseType(chType))
     return failure();
-  if (chType.getSignaling() != ChannelSignaling::FIFO0)
+  if (chType.getSignaling() != ChannelSignaling::FIFO)
     return p.emitError(loc, "can only wrap into FIFO type");
   dataType = chType.getInner();
   chanInputType = chType;
@@ -215,7 +223,7 @@ void printWrapFIFOType(OpAsmPrinter &p, WrapFIFOOp wrap, Type dataType,
 }
 
 LogicalResult WrapFIFOOp::verify() {
-  if (getChanOutput().getType().getSignaling() != ChannelSignaling::FIFO0)
+  if (getChanOutput().getType().getSignaling() != ChannelSignaling::FIFO)
     return emitOpError("only supports FIFO signaling");
   return success();
 }
@@ -225,7 +233,7 @@ circt::esi::ChannelType UnwrapFIFOOp::channelType() {
 }
 
 LogicalResult UnwrapFIFOOp::verify() {
-  if (getChanInput().getType().getSignaling() != ChannelSignaling::FIFO0)
+  if (getChanInput().getType().getSignaling() != ChannelSignaling::FIFO)
     return emitOpError("only supports FIFO signaling");
   return success();
 }

--- a/lib/Dialect/ESI/Passes/ESILowerPorts.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerPorts.cpp
@@ -107,7 +107,7 @@ public:
           if (signaling == ChannelSignaling::ValidReady)
             return {std::make_unique<ValidReady>(converter, port)};
 
-          if (signaling == ChannelSignaling::FIFO0)
+          if (signaling == ChannelSignaling::FIFO)
             return {std::make_unique<FIFO>(converter, port)};
 
           auto error = converter.getModule().emitOpError(

--- a/test/Dialect/ESI/connectivity.mlir
+++ b/test/Dialect/ESI/connectivity.mlir
@@ -99,14 +99,14 @@ hw.module @i0Typed(in %a: !esi.channel<i0>, in %clk : !seq.clock, in %rst : i1, 
   hw.output %ch : !esi.channel<i0>
 }
 
-hw.module.extern @i1Fifo0(in %in: !esi.channel<i1, FIFO0>, out out: !esi.channel<i1, FIFO0>)
+hw.module.extern @i1Fifo(in %in: !esi.channel<i1, FIFO>, out out: !esi.channel<i1, FIFO>)
 
-// CHECK-LABEL:  hw.module @fifo0WrapUnwrap()
-// CHECK-NEXT:     %chanOutput, %rden = esi.wrap.fifo %data, %empty : !esi.channel<i1, FIFO0>
-// CHECK-NEXT:     %foo.out = hw.instance "foo" @i1Fifo0(in: %chanOutput: !esi.channel<i1, FIFO0>) -> (out: !esi.channel<i1, FIFO0>)
-// CHECK-NEXT:     %data, %empty = esi.unwrap.fifo %foo.out, %rden : !esi.channel<i1, FIFO0>
-hw.module @fifo0WrapUnwrap() {
-  %in, %rden = esi.wrap.fifo %data, %empty : !esi.channel<i1, FIFO0>
-  %out = hw.instance "foo" @i1Fifo0(in: %in: !esi.channel<i1, FIFO0>) -> (out: !esi.channel<i1, FIFO0>)
-  %data, %empty = esi.unwrap.fifo %out, %rden : !esi.channel<i1, FIFO0>
+// CHECK-LABEL:  hw.module @fifoWrapUnwrap()
+// CHECK-NEXT:     %chanOutput, %rden = esi.wrap.fifo %data, %empty : !esi.channel<i1, FIFO>
+// CHECK-NEXT:     %foo.out = hw.instance "foo" @i1Fifo(in: %chanOutput: !esi.channel<i1, FIFO>) -> (out: !esi.channel<i1, FIFO>)
+// CHECK-NEXT:     %data, %empty = esi.unwrap.fifo %foo.out, %rden : !esi.channel<i1, FIFO>
+hw.module @fifoWrapUnwrap() {
+  %in, %rden = esi.wrap.fifo %data, %empty : !esi.channel<i1, FIFO>
+  %out = hw.instance "foo" @i1Fifo(in: %in: !esi.channel<i1, FIFO>) -> (out: !esi.channel<i1, FIFO>)
+  %data, %empty = esi.unwrap.fifo %out, %rden : !esi.channel<i1, FIFO>
 }

--- a/test/Dialect/ESI/lowering.mlir
+++ b/test/Dialect/ESI/lowering.mlir
@@ -138,44 +138,54 @@ hw.module @ServiceWrapper(in %clock: i1, in %reset: i1, in %ctrl: !esi.channel<i
   hw.output %HandshakeToESIWrapper.out_ctrl, %HandshakeToESIWrapper.in0_ld_addr0, %HandshakeToESIWrapper.in1_ld_addr0 : !esi.channel<i0>, !esi.channel<i64>, !esi.channel<i64>
 }
 
-// IFACE-LABEL:  hw.module @i1Fifo0Loopback(in %in : i3, in %in_empty : i1, in %out_rden : i1, out in_rden : i1, out out : i3, out out_empty : i1)
-// IFACE-NEXT:     %chanOutput, %rden = esi.wrap.fifo %in, %in_empty : !esi.channel<i3, FIFO0>
-// IFACE-NEXT:     %data, %empty = esi.unwrap.fifo %chanOutput, %out_rden : !esi.channel<i3, FIFO0>
+// IFACE-LABEL:  hw.module @i1FifoLoopback(in %in : i3, in %in_empty : i1, in %out_rden : i1, out in_rden : i1, out out : i3, out out_empty : i1)
+// IFACE-NEXT:     %chanOutput, %rden = esi.wrap.fifo %in, %in_empty : !esi.channel<i3, FIFO>
+// IFACE-NEXT:     %data, %empty = esi.unwrap.fifo %chanOutput, %out_rden : !esi.channel<i3, FIFO>
 // IFACE-NEXT:     hw.output %rden, %data, %empty : i1, i3, i1
-// HW-LABEL:     hw.module @i1Fifo0Loopback(in %in : i3, in %in_empty : i1, in %out_rden : i1, out in_rden : i1, out out : i3, out out_empty : i1)
+// HW-LABEL:     hw.module @i1FifoLoopback(in %in : i3, in %in_empty : i1, in %out_rden : i1, out in_rden : i1, out out : i3, out out_empty : i1)
 // HW-NEXT:        hw.output %out_rden, %in, %in_empty : i1, i3, i1
-hw.module @i1Fifo0Loopback(in %in: !esi.channel<i3, FIFO0>, out out: !esi.channel<i3, FIFO0>) {
-  hw.output %in : !esi.channel<i3, FIFO0>
+hw.module @i1FifoLoopback(in %in: !esi.channel<i3, FIFO>, out out: !esi.channel<i3, FIFO>) {
+  hw.output %in : !esi.channel<i3, FIFO>
 }
 
-// IFACE-LABEL:  hw.module @fifo0LoopbackTop()
-// IFACE-NEXT:     %data, %empty = esi.unwrap.fifo %chanOutput, %foo.in_rden : !esi.channel<i3, FIFO0>
-// IFACE-NEXT:     %chanOutput, %rden = esi.wrap.fifo %foo.out, %foo.out_empty : !esi.channel<i3, FIFO0>
-// IFACE-NEXT:     %foo.in_rden, %foo.out, %foo.out_empty = hw.instance "foo" @i1Fifo0Loopback(in: %data: i3, in_empty: %empty: i1, out_rden: %rden: i1) -> (in_rden: i1, out: i3, out_empty: i1)
-// HW-LABEL:     hw.module @fifo0LoopbackTop()
-// HW-NEXT:        %foo.in_rden, %foo.out, %foo.out_empty = hw.instance "foo" @i1Fifo0Loopback(in: %foo.out: i3, in_empty: %foo.out_empty: i1, out_rden: %foo.in_rden: i1) -> (in_rden: i1, out: i3, out_empty: i1)
-hw.module @fifo0LoopbackTop() {
-  %chan = hw.instance "foo" @i1Fifo0Loopback(in: %chan: !esi.channel<i3, FIFO0>) -> (out: !esi.channel<i3, FIFO0>)
+// IFACE-LABEL:  hw.module @fifoLoopbackTop()
+// IFACE-NEXT:     %data, %empty = esi.unwrap.fifo %chanOutput, %foo.in_rden : !esi.channel<i3, FIFO>
+// IFACE-NEXT:     %chanOutput, %rden = esi.wrap.fifo %foo.out, %foo.out_empty : !esi.channel<i3, FIFO>
+// IFACE-NEXT:     %foo.in_rden, %foo.out, %foo.out_empty = hw.instance "foo" @i1FifoLoopback(in: %data: i3, in_empty: %empty: i1, out_rden: %rden: i1) -> (in_rden: i1, out: i3, out_empty: i1)
+// HW-LABEL:     hw.module @fifoLoopbackTop()
+// HW-NEXT:        %foo.in_rden, %foo.out, %foo.out_empty = hw.instance "foo" @i1FifoLoopback(in: %foo.out: i3, in_empty: %foo.out_empty: i1, out_rden: %foo.in_rden: i1) -> (in_rden: i1, out: i3, out_empty: i1)
+hw.module @fifoLoopbackTop() {
+  %chan = hw.instance "foo" @i1FifoLoopback(in: %chan: !esi.channel<i3, FIFO>) -> (out: !esi.channel<i3, FIFO>)
 }
 
-// IFACE-LABEL:  hw.module @structFifo0Loopback(in %in_in : !hw.struct<a: i3, b: i7>, in %in_flatBroke_in : i1, in %out_readEnable_in : i1, out in_readEnable : i1, out out : !hw.struct<a: i3, b: i7>, out out_flatBroke : i1)
-// IFACE-NEXT:     %chanOutput, %rden = esi.wrap.fifo %in_in, %in_flatBroke_in : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO0>
-// IFACE-NEXT:     %data, %empty = esi.unwrap.fifo %chanOutput, %out_readEnable_in : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO0>
+// IFACE-LABEL:  hw.module @structFifoLoopback(in %in_in : !hw.struct<a: i3, b: i7>, in %in_flatBroke_in : i1, in %out_readEnable_in : i1, out in_readEnable : i1, out out : !hw.struct<a: i3, b: i7>, out out_flatBroke : i1)
+// IFACE-NEXT:     %chanOutput, %rden = esi.wrap.fifo %in_in, %in_flatBroke_in : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO>
+// IFACE-NEXT:     %data, %empty = esi.unwrap.fifo %chanOutput, %out_readEnable_in : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO>
 // IFACE-NEXT:     hw.output %rden, %data, %empty : i1, !hw.struct<a: i3, b: i7>, i1
 !st1 = !hw.struct<a: i3, b: i7>
-hw.module @structFifo0Loopback(in %in: !esi.channel<!st1, FIFO0>, out out: !esi.channel<!st1, FIFO0>)
+hw.module @structFifoLoopback(in %in: !esi.channel<!st1, FIFO>, out out: !esi.channel<!st1, FIFO>)
     attributes {esi.portFlattenStructs, esi.portRdenSuffix="_readEnable",
                 esi.portEmptySuffix="_flatBroke", esi.portInSuffix="_in"} {
-  hw.output %in : !esi.channel<!st1, FIFO0>
+  hw.output %in : !esi.channel<!st1, FIFO>
 }
 
-// IFACE-LABEL:  hw.module @structFifo0LoopbackTop()
-// IFACE-NEXT:    %data, %empty = esi.unwrap.fifo %chanOutput, %foo.in_readEnable : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO0>
-// IFACE-NEXT:    %chanOutput, %rden = esi.wrap.fifo %foo.out, %foo.out_flatBroke : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO0>
-// IFACE-NEXT:    %foo.in_readEnable, %foo.out, %foo.out_flatBroke = hw.instance "foo" @structFifo0Loopback(in_in: %data: !hw.struct<a: i3, b: i7>, in_flatBroke_in: %empty: i1, out_readEnable_in: %rden: i1) -> (in_readEnable: i1, out: !hw.struct<a: i3, b: i7>, out_flatBroke: i1)
+// IFACE-LABEL:  hw.module @structFifoLoopbackTop()
+// IFACE-NEXT:    %data, %empty = esi.unwrap.fifo %chanOutput, %foo.in_readEnable : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO>
+// IFACE-NEXT:    %chanOutput, %rden = esi.wrap.fifo %foo.out, %foo.out_flatBroke : !esi.channel<!hw.struct<a: i3, b: i7>, FIFO>
+// IFACE-NEXT:    %foo.in_readEnable, %foo.out, %foo.out_flatBroke = hw.instance "foo" @structFifoLoopback(in_in: %data: !hw.struct<a: i3, b: i7>, in_flatBroke_in: %empty: i1, out_readEnable_in: %rden: i1) -> (in_readEnable: i1, out: !hw.struct<a: i3, b: i7>, out_flatBroke: i1)
 // IFACE-NEXT:    hw.output
-hw.module @structFifo0LoopbackTop() {
-  %chan = hw.instance "foo" @structFifo0Loopback(in: %chan: !esi.channel<!st1, FIFO0>) -> (out: !esi.channel<!st1, FIFO0>)
+hw.module @structFifoLoopbackTop() {
+  %chan = hw.instance "foo" @structFifoLoopback(in: %chan: !esi.channel<!st1, FIFO>) -> (out: !esi.channel<!st1, FIFO>)
+}
+
+// IFACE-LABEL:  hw.module @i1FifoDelay1Loopback(in %in : i3, in %in_empty : i1, in %out_rden : i1, out in_rden : i1, out out : i3, out out_empty : i1)
+// IFACE-NEXT:     %chanOutput, %rden = esi.wrap.fifo %in, %in_empty : !esi.channel<i3, FIFO(1)>
+// IFACE-NEXT:     %data, %empty = esi.unwrap.fifo %chanOutput, %out_rden : !esi.channel<i3, FIFO(1)>
+// IFACE-NEXT:     hw.output %rden, %data, %empty : i1, i3, i1
+// HW-LABEL:     hw.module @i1FifoDelay1Loopback(in %in : i3, in %in_empty : i1, in %out_rden : i1, out in_rden : i1, out out : i3, out out_empty : i1)
+// HW-NEXT:        hw.output %out_rden, %in, %in_empty : i1, i3, i1
+hw.module @i1FifoDelay1Loopback(in %in: !esi.channel<i3, FIFO(1)>, out out: !esi.channel<i3, FIFO(1)>) {
+  hw.output %in : !esi.channel<i3, FIFO(1)>
 }
 
 // IFACE-LABEL:  hw.module @i3LoopbackOddNames(in %in : i3, in %in_good : i1, in %out_letErRip : i1, out in_letErRip_out : i1, out out_out : i3, out out_good_out : i1) attributes {esi.portFlattenStructs, esi.portOutSuffix = "_out", esi.portReadySuffix = "_letErRip", esi.portValidSuffix = "_good"} {


### PR DESCRIPTION
The control signaling is (for valid/ready and FIFO) orthogonal to the number of cycles data is delayed. Separate it out.