### PR TITLE
[CI] Report failure of clang-tidy

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -268,19 +268,19 @@ jobs:
       - name: clang-tidy
         if: ${{ always() }}
         run: |
-          git diff -U0 $DIFF_COMMIT...HEAD | \
-            clang-tidy-diff -path build -p1 -fix -j$(nproc)
-          git clang-format -f $DIFF_COMMIT
-          git diff --ignore-submodules > clang-tidy.patch
-          if [ -s clang-tidy.patch ]; then
-            echo "Clang-tidy problems in the following files. " \
-              "See diff in the clang-tidy.patch artifact."
-            git diff --ignore-submodules --name-only
-            git checkout .
+          if git diff -U0 $DIFF_COMMIT...HEAD | clang-tidy-diff -path build -p1 -fix -j$(nproc); then
+            exit 0
+          fi
+          if git diff --quiet --ignore-submodules; then
             exit 1
           fi
-          echo "Clang-tidy found no problems"
-          exit 0
+          git clang-format -f $DIFF_COMMIT
+          echo "Fixups available for the following files:"
+          git diff --ignore-submodules --name-only
+          echo "See diff in the clang-tidy.patch artifact."
+          git diff --ignore-submodules > clang-tidy.patch
+          git checkout .
+          exit 1
 
       # Upload the tidy patches to an artifact (zip'd) associated
       # with the workflow run. Only run this on a failure.


### PR DESCRIPTION
Correctly detect that clang-tidy found problems, by looking at its status-code, not whether it produced any fixups.