### PR TITLE
[MooreToCore] Support ProcedureOp and sequential assign operations

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -516,7 +516,7 @@ def ConvertMooreToCore : Pass<"convert-moore-to-core", "mlir::ModuleOp"> {
   }];
   let constructor = "circt::createConvertMooreToCorePass()";
   let dependentDialects = ["comb::CombDialect", "hw::HWDialect",
-                           "llhd::LLHDDialect"];
+                           "llhd::LLHDDialect", "mlir::cf::ControlFlowDialect"];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/MooreToCore/CMakeLists.txt
+++ b/lib/Conversion/MooreToCore/CMakeLists.txt
@@ -15,4 +15,5 @@ add_circt_conversion_library(CIRCTMooreToCore
   MLIRControlFlowDialect
   MLIRFuncDialect
   MLIRTransforms
+  MLIRSideEffectInterfaces
 )


### PR DESCRIPTION
* Add a first lowering of ProcedureOp and EventOp
* Add support for blocking and non-blocking assigns
* Convert RefType to hw::InOutType instead of just the element type

@hailongSun2000 @fabianschuiki Would it make sense to take the `moore.ref` value as operand for the EventOp directly instead of the read value?