### PR TITLE
[ImportVerilog] Fix use after free

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -116,10 +116,9 @@ struct RvalueExprVisitor {
     if (auto refOp = lhs.getDefiningOp<moore::StructExtractRefOp>()) {
       auto input = refOp.getInput();
       if (isa<moore::SVModuleOp>(input.getDefiningOp()->getParentOp())) {
-        refOp.getInputMutable();
-        refOp->erase();
         builder.create<moore::StructInjectOp>(loc, input.getType(), input,
                                               refOp.getFieldNameAttr(), rhs);
+        refOp->erase();
         return rhs;
       }
     }

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -410,10 +410,9 @@ struct ModuleVisitor : public BaseVisitor {
     if (auto refOp = lhs.getDefiningOp<moore::StructExtractRefOp>()) {
       auto input = refOp.getInput();
       if (isa<moore::SVModuleOp>(input.getDefiningOp()->getParentOp())) {
-        refOp.getInputMutable();
-        refOp->erase();
         builder.create<moore::StructInjectOp>(loc, input.getType(), input,
                                               refOp.getFieldNameAttr(), rhs);
+        refOp->erase();
         return success();
       }
     }


### PR DESCRIPTION
Avoid accessing an erased operation in ImportVerilog. Also removed an unused `getInputMutable`.

Note that I don't really know what is happening here. I cannot judge how safe this erasure is. E.g., can we guarantee that `refOp` is not still in use somewhere else?