### PR TITLE
[FIRRTL] Support layer-colored probes in force, force_initial.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -312,17 +312,19 @@ def ForceOp : FIRRTLOp<"force", [SameTypeOperands]> {
 
 //===- Reference force/release --------------------------------------------===//
 
-class ForceRefTypeConstraint<string ref, string base>
-  : TypesMatchWith<"reference type of " # ref # " should be RWProbe of " # base,
-                   base, ref,
-                   "RefType::get(firrtl::type_cast<FIRRTLBaseType>($_self).getAllConstDroppedType(), true)">;
+class ForceRefTypeConstraint<string ref, string base> : PredOpTrait<
+        "reference type of " # ref # " should be RWProbe of " # base,
+        CPred<[{
+          firrtl::type_cast<RefType>($}] # ref # [{.getType()).getType() ==
+          firrtl::type_cast<FIRRTLBaseType>($}] # base # [{.getType()).getAllConstDroppedType()
+        }]>>;
 
 def RefForceOp : FIRRTLOp<"ref.force",[ForceRefTypeConstraint<"dest", "src">]> {
   let summary = "FIRRTL force statement";
   let description = "Force a RWProbe to the specified value using the specified clock and predicate.";
   let arguments = (ins ClockType:$clock, UInt1Type:$predicate, RWProbe:$dest, FIRRTLBaseType:$src);
   let assemblyFormat =
-    "$clock `,` $predicate `,` $dest `,` $src attr-dict `:` type($clock) `,` type($predicate) `,` qualified(type($src))";
+    "$clock `,` $predicate `,` $dest `,` $src attr-dict `:` type($clock) `,` type($predicate) `,` qualified(type($dest)) `,` qualified(type($src))";
   let hasCanonicalizer = 1;
 }
 def RefForceInitialOp : FIRRTLOp<"ref.force_initial",[ForceRefTypeConstraint<"dest", "src">]> {
@@ -330,7 +332,7 @@ def RefForceInitialOp : FIRRTLOp<"ref.force_initial",[ForceRefTypeConstraint<"de
   let description = "Force a RWProbe to the specified value continuously.";
   let arguments = (ins UInt1Type:$predicate, RWProbe:$dest, FIRRTLBaseType:$src);
   let assemblyFormat =
-    "$predicate `,` $dest `,` $src attr-dict `:` type($predicate) `,` qualified(type($src))";
+    "$predicate `,` $dest `,` $src attr-dict `:` type($predicate) `,` qualified(type($dest)) `,` qualified(type($src))";
   let hasCanonicalizer = 1;
 }
 def RefReleaseOp : FIRRTLOp<"ref.release"> {

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1387,9 +1387,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module @ForceRelease(in %c: !firrtl.uint<1>, in %clock: !firrtl.clock, in %x: !firrtl.uint<4>) {
     firrtl.instance r sym @xmr_sym @RefMe()
     %0 = firrtl.xmr.ref @xmrPath : !firrtl.rwprobe<uint<4>>
-    firrtl.ref.force %clock, %c, %0, %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
+    firrtl.ref.force %clock, %c, %0, %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>, !firrtl.uint<4>
     %1 = firrtl.xmr.ref @xmrPath : !firrtl.rwprobe<uint<4>>
-    firrtl.ref.force_initial %c, %1, %x : !firrtl.uint<1>, !firrtl.uint<4>
+    firrtl.ref.force_initial %c, %1, %x : !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>, !firrtl.uint<4>
     %2 = firrtl.xmr.ref @xmrPath : !firrtl.rwprobe<uint<4>>
     firrtl.ref.release %clock, %c, %2 : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
     %3 = firrtl.xmr.ref @xmrPath : !firrtl.rwprobe<uint<4>>

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3415,8 +3415,8 @@ firrtl.module @ForceRelease(in %clock: !firrtl.clock, in %x: !firrtl.uint<4>) {
     %r_p = firrtl.instance r @RefMe(out p: !firrtl.rwprobe<uint<4>>)
 
     // CHECK-NOT: firrtl.ref
-    firrtl.ref.force %clock, %c, %r_p, %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
-    firrtl.ref.force_initial %c, %r_p, %x : !firrtl.uint<1>, !firrtl.uint<4>
+    firrtl.ref.force %clock, %c, %r_p, %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>, !firrtl.uint<4>
+    firrtl.ref.force_initial %c, %r_p, %x : !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>, !firrtl.uint<4>
     firrtl.ref.release %clock, %c, %r_p : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
     firrtl.ref.release_initial %c, %r_p : !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
     // CHECK-NEXT: }

--- a/test/Dialect/FIRRTL/check-comb-loops.mlir
+++ b/test/Dialect/FIRRTL/check-comb-loops.mlir
@@ -663,7 +663,7 @@ firrtl.circuit "Force"   {
   firrtl.module @Force(in %clock: !firrtl.clock, in %x: !firrtl.uint<4>) {
     %c = firrtl.constant 0 : !firrtl.uint<1>
     %w, %w_ref = firrtl.wire forceable : !firrtl.uint<4>, !firrtl.rwprobe<uint<4>>
-    firrtl.ref.force %clock, %c, %w_ref, %w : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
+    firrtl.ref.force %clock, %c, %w_ref, %w : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>, !firrtl.uint<4>
   }
 }
 
@@ -696,7 +696,7 @@ firrtl.circuit "hasnoloops"   {
   firrtl.module @thru(in %clk: !firrtl.clock, in %in1: !firrtl.uint<1>, in %in2: !firrtl.uint<1>, out %out1: !firrtl.uint<1>, out %out2: !firrtl.uint<1>) {
     %a, %w_ref = firrtl.wire forceable : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
     firrtl.connect %out1, %a : !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.ref.force %clk, %a, %w_ref, %in1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.ref.force %clk, %a, %w_ref, %in1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>, !firrtl.uint<1>
     firrtl.connect %out2, %in2 : !firrtl.uint<1>, !firrtl.uint<1>
   }
   firrtl.module @hasnoloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
@@ -730,7 +730,7 @@ firrtl.circuit "forceLoop" {
     %inner2_clk, %inner2_in, %w_ref = firrtl.instance inner2  @thru2(in clk: !firrtl.clock, in in: !firrtl.uint<1>, out out: !firrtl.rwprobe<uint<1>>)
     firrtl.connect %inner2_clk, %clk : !firrtl.clock, !firrtl.clock
     firrtl.connect %inner2_in, %y : !firrtl.uint<1>, !firrtl.uint<1>
-    firrtl.ref.force %clk, %c, %w_ref, %inner2_in : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.ref.force %clk, %c, %w_ref, %inner2_in : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>, !firrtl.uint<1>
     %inner2_out = firrtl.ref.resolve %w_ref : !firrtl.rwprobe<uint<1>>
     firrtl.connect %z, %inner2_out : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
@@ -771,7 +771,7 @@ firrtl.circuit "RefSink" {
       firrtl.ref.resolve %refSource_a_ref : !firrtl.probe<uint<1>>
     %b = firrtl.node %a_ref_resolve : !firrtl.uint<1>
     firrtl.ref.force_initial %c1_ui1, %refSource_a_rwref, %b :
-      !firrtl.uint<1>, !firrtl.uint<1>
+      !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>, !firrtl.uint<1>
   }
 }
 
@@ -806,7 +806,7 @@ firrtl.circuit "RefSink" {
       firrtl.ref.resolve %refSource_b_ref : !firrtl.rwprobe<uint<1>>
     %b = firrtl.node %a_ref_resolve : !firrtl.uint<1>
     firrtl.ref.force_initial %c1_ui1, %refSource_a_rwref, %b :
-      !firrtl.uint<1>, !firrtl.uint<1>
+      !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>, !firrtl.uint<1>
   }
 }
 
@@ -838,7 +838,7 @@ firrtl.circuit "RefSink" {
       firrtl.ref.resolve %refSource_a_rwref2 : !firrtl.rwprobe<uint<1>>
     %b = firrtl.node %a_ref_resolve : !firrtl.uint<1>
     firrtl.ref.force_initial %c1_ui1, %refSource_a_rwref1, %b :
-      !firrtl.uint<1>, !firrtl.uint<1>
+      !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>, !firrtl.uint<1>
   }
 }
 
@@ -880,7 +880,7 @@ firrtl.circuit "RefSink" {
       firrtl.ref.resolve %rwref2 : !firrtl.rwprobe<uint<1>>
     %b = firrtl.node %a_ref_resolve : !firrtl.uint<1>
     firrtl.ref.force_initial %c1_ui1, %rwref5, %b :
-      !firrtl.uint<1>, !firrtl.uint<1>
+      !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>, !firrtl.uint<1>
   }
 }
 
@@ -1050,7 +1050,7 @@ firrtl.circuit "Issue6820" {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %0 = firrtl.asClock %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.clock
-    firrtl.ref.force %clock, %c1_ui1, %clockProbe, %0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.clock
+    firrtl.ref.force %clock, %c1_ui1, %clockProbe, %0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<clock>, !firrtl.clock
   }
 }
 

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -377,7 +377,7 @@ firrtl.circuit "Foo" {
     %b = firrtl.node %a_ref_resolve : !firrtl.uint<1>
     // CHECK-NEXT: force_initial(refSource.a_rwref, UInt<1>(0))
     firrtl.ref.force_initial %c1_ui1, %refSource_a_rwref, %c0_ui1 :
-      !firrtl.uint<1>, !firrtl.uint<1>
+      !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>, !firrtl.uint<1>
     // CHECK-NEXT: release_initial(refSource.a_rwref)
     firrtl.ref.release_initial %c1_ui1, %refSource_a_rwref :
       !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
@@ -385,7 +385,7 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT:   force_initial(refSource.a_rwref, UInt<1>(0))
     firrtl.when %enable : !firrtl.uint<1> {
       firrtl.ref.force_initial %c1_ui1, %refSource_a_rwref, %c0_ui1 :
-        !firrtl.uint<1>, !firrtl.uint<1>
+        !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>, !firrtl.uint<1>
     }
     // CHECK-NEXT: when enable :
     // CHECK-NEXT:   release_initial(refSource.a_rwref)
@@ -395,7 +395,7 @@ firrtl.circuit "Foo" {
     }
     // CHECK-NEXT: force(clock, enable, refSource.a_rwref, UInt<1>(1))
     firrtl.ref.force %clock, %enable, %refSource_a_rwref, %c1_ui1 :
-      !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+      !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>, !firrtl.uint<1>
     // CHECK-NEXT: release(clock, enable, refSource.a_rwref)
     firrtl.ref.release %clock, %enable, %refSource_a_rwref :
       !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1461,7 +1461,7 @@ firrtl.circuit "RefForceProbe" {
     %1 = firrtl.ref.send %a : !firrtl.uint<1>
     // expected-note @above {{prior use here}}
     // expected-error @below {{use of value '%1' expects different type than prior uses: '!firrtl.rwprobe<uint<1>>' vs '!firrtl.probe<uint<1>>'}}
-    firrtl.ref.force_initial %a, %1, %a : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.ref.force_initial %a, %1, %a : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>, !firrtl.uint<1>
   }
 }
 

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -555,9 +555,9 @@ firrtl.module @WhenCForce(in %c: !firrtl.uint<1>, in %clock : !firrtl.clock, in 
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   firrtl.when %c : !firrtl.uint<1> {
     // CHECK: firrtl.ref.force %clock, %c, %n_ref, %x :
-    firrtl.ref.force %clock, %c1_ui1, %n_ref, %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
+    firrtl.ref.force %clock, %c1_ui1, %n_ref, %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>, !firrtl.uint<4>
     // CHECK: firrtl.ref.force_initial %c, %n_ref, %x :
-    firrtl.ref.force_initial %c1_ui1, %n_ref, %x : !firrtl.uint<1>, !firrtl.uint<4>
+    firrtl.ref.force_initial %c1_ui1, %n_ref, %x : !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>, !firrtl.uint<4>
     // CHECK: firrtl.ref.release %clock, %c, %n_ref :
     firrtl.ref.release %clock, %c1_ui1, %n_ref : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
     // CHECK: firrtl.ref.release_initial %c, %n_ref :

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -1202,9 +1202,9 @@ firrtl.module private @is1436_FOO() {
     // CHECK: vectorcreate
     // CHECK: bundlecreate
     // CHECK: firrtl.ref.force %clock, %pred, %[[BOV_REF]],
-    firrtl.ref.force %clock, %pred, %inst_bov_ref, %inst_bov : !firrtl.clock, !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
+    firrtl.ref.force %clock, %pred, %inst_bov_ref, %inst_bov : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
     // CHECK: firrtl.ref.force_initial %pred, %[[BOV_REF]],
-    firrtl.ref.force_initial %pred, %inst_bov_ref, %inst_bov : !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
+    firrtl.ref.force_initial %pred, %inst_bov_ref, %inst_bov : !firrtl.uint<1>, !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
     // CHECK: firrtl.ref.release %clock, %pred, %[[BOV_REF]] :
     firrtl.ref.release %clock, %pred, %inst_bov_ref : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<bundle<a: vector<uint<1>, 2>, b: uint<2>>>
     // CHECK: firrtl.ref.release_initial %pred, %[[BOV_REF]] :

--- a/test/Dialect/FIRRTL/lowerXMR.mlir
+++ b/test/Dialect/FIRRTL/lowerXMR.mlir
@@ -440,11 +440,11 @@ firrtl.circuit "ForceRelease" {
       // CHECK-NEXT: firrtl.instance r sym @[[INST_SYM]] @RefMe()
       %r_p = firrtl.instance r @RefMe(out p: !firrtl.rwprobe<uint<4>>)
       // CHECK-NEXT: %[[REF1:.+]] = firrtl.xmr.ref @[[XMRPATH]] : !firrtl.rwprobe<uint<4>>
-      // CHECK-NEXT: firrtl.ref.force %clock, %c, %[[REF1]], %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
-      firrtl.ref.force %clock, %c, %r_p, %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>
+      // CHECK-NEXT: firrtl.ref.force %clock, %c, %[[REF1]], %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>, !firrtl.uint<4>
+      firrtl.ref.force %clock, %c, %r_p, %x : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>, !firrtl.uint<4>
       // CHECK-NEXT: %[[REF2:.+]] = firrtl.xmr.ref @[[XMRPATH]] : !firrtl.rwprobe<uint<4>>
-      // CHECK-NEXT: firrtl.ref.force_initial %c, %[[REF2]], %x : !firrtl.uint<1>, !firrtl.uint<4>
-      firrtl.ref.force_initial %c, %r_p, %x : !firrtl.uint<1>, !firrtl.uint<4>
+      // CHECK-NEXT: firrtl.ref.force_initial %c, %[[REF2]], %x : !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>, !firrtl.uint<4>
+      firrtl.ref.force_initial %c, %r_p, %x : !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>, !firrtl.uint<4>
       // CHECK-NEXT: %[[REF3:.+]] = firrtl.xmr.ref @[[XMRPATH]] : !firrtl.rwprobe<uint<4>>
       // CHECK-NEXT: firrtl.ref.release %clock, %c, %[[REF3]] : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
       firrtl.ref.release %clock, %c, %r_p : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<4>>
@@ -675,7 +675,7 @@ firrtl.circuit "DropForceOp" {
     %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %x, %x_ref = firrtl.wire forceable : !firrtl.uint<0>, !firrtl.rwprobe<uint<0>>
-    firrtl.ref.force_initial %c1_ui1, %x_ref, %c0_ui0 : !firrtl.uint<1>, !firrtl.uint<0>
+    firrtl.ref.force_initial %c1_ui1, %x_ref, %c0_ui0 : !firrtl.uint<1>, !firrtl.rwprobe<uint<0>>, !firrtl.uint<0>
   }
 }
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1136,10 +1136,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; Check (const) literal works, even if uninferred width.
     ; Cast reference to more general form as needed.
     ; CHECK: %[[RC_RW_CAST:.+]] = firrtl.ref.cast %[[RC_RW]] : (!firrtl.rwprobe<uint<1>>) -> !firrtl.rwprobe<uint>
-    ; CHECK: firrtl.ref.force_initial %[[TRUE:.+]], %[[RC_RW_CAST]], %{{.+}} : !firrtl.uint<1>, !firrtl.const.uint
+    ; CHECK: firrtl.ref.force_initial %[[TRUE:.+]], %[[RC_RW_CAST]], %{{.+}} : !firrtl.uint<1>, !firrtl.rwprobe<uint>, !firrtl.const.uint
     force_initial(rc.rw, UInt(0))
 
-    ; CHECK: firrtl.ref.force %clock, %cond, %[[RC_RW]], %{{.+}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.const.uint<1>
+    ; CHECK: firrtl.ref.force %clock, %cond, %[[RC_RW]], %{{.+}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>, !firrtl.const.uint<1>
     force(clock, cond, rc.rw, UInt<1>(1))
     ; CHECK: %[[NOT_COND:.+]] = firrtl.not %cond
     ; CHECK: firrtl.ref.release %clock, %[[NOT_COND]], %[[RC_RW]] : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>


### PR DESCRIPTION
With addition of probe colors, no longer can infer the rwprobe type so make it explicit and update tests and verify accordingly.

Fixes #7370.