### PR TITLE
[FIRRTL] Verify RWProbeOp target has layer requirements.

### DIFF
--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -2072,6 +2072,20 @@ firrtl.circuit "RWProbeUseDef" {
 
 // -----
 
+firrtl.circuit "RWProbeLayerRequirements" {
+  firrtl.layer @A bind { }
+  firrtl.module @RWProbeLayerRequirements(in %cond : !firrtl.uint<1>) {
+    // expected-note @below {{target is missing layer requirements: @A}}
+    %w = firrtl.wire sym @x : !firrtl.uint<1>
+    firrtl.layerblock @A {
+      // expected-error @below {{target has insufficient layer requirements}}
+      %rw = firrtl.ref.rwprobe <@RWProbeLayerRequirements::@x> : !firrtl.rwprobe<uint<1>>
+    }
+  }
+}
+
+// -----
+
 firrtl.circuit "MissingClassForObjectPortInModule" {
   // expected-error @below {{'firrtl.module' op references unknown class @Missing}}
   firrtl.module @MissingClassForObjectPortInModule(out %o: !firrtl.class<@Missing()>) {}

--- a/test/Dialect/FIRRTL/layers.mlir
+++ b/test/Dialect/FIRRTL/layers.mlir
@@ -201,4 +201,16 @@ firrtl.circuit "Test" {
       firrtl.propassign %foo_in, %str : !firrtl.string
     }
   }
+
+  //===--------------------------------------------------------------------===//
+  // RWProbe under Layer
+  //===--------------------------------------------------------------------===//
+
+  firrtl.module @RWProbeInLayer() {
+    firrtl.layerblock @A {
+      %w = firrtl.wire sym @sym : !firrtl.uint<1>
+      %rwp = firrtl.ref.rwprobe <@RWProbeInLayer::@sym> : !firrtl.rwprobe<uint<1>>
+    }
+  }
+
 }


### PR DESCRIPTION
RWProbe conservatively means a write to the target, so check that the target is indeed writeable from where the rwprobe is.