### PR TITLE
[FIRRTL] Canonicalize multibit_mux with narrow index

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1660,7 +1660,7 @@ LogicalResult MultibitMuxOp::canonicalize(MultibitMuxOp op,
   // elements.
   auto indexWidth = op.getIndex().getType().getBitWidthOrSentinel();
   uint64_t inputSize = op.getInputs().size();
-  if (indexWidth < 64 && 1ull << indexWidth < inputSize) {
+  if (indexWidth >= 0 && indexWidth < 64 && 1ull << indexWidth < inputSize) {
     rewriter.modifyOpInPlace(op, [&]() {
       op.getInputsMutable().erase(0, inputSize - (1ull << indexWidth));
     });

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1656,6 +1656,17 @@ LogicalResult MultibitMuxOp::canonicalize(MultibitMuxOp op,
     return success();
   }
 
+  // If the index width is narrower than the size of inputs, drop front
+  // elements.
+  auto indexWidth = op.getIndex().getType().getBitWidthOrSentinel();
+  uint64_t inputSize = op.getInputs().size();
+  if (indexWidth < 64 && 1ull << indexWidth < inputSize) {
+    rewriter.modifyOpInPlace(op, [&]() {
+      op.getInputsMutable().erase(0, inputSize - (1ull << indexWidth));
+    });
+    return success();
+  }
+
   // If the op is a vector indexing (e.g. `multbit_mux idx, a[n-1], a[n-2], ...,
   // a[0]`), we can fold the op into subaccess op `a[idx]`.
   if (auto lastSubindex = op.getInputs().back().getDefiningOp<SubindexOp>()) {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3619,5 +3619,15 @@ firrtl.module @sizeof(in %clock: !firrtl.clock,
   %n_bundle = firrtl.node interesting_name %s_bundle : !firrtl.uint<32>
 }
 
+// CHECK-LABEL: @multibit_mux_drop_front
+firrtl.module @multibit_mux_drop_front(in %vec_0: !firrtl.uint<8>, in %vec_1: !firrtl.uint<8>,
+                                       in %vec_2: !firrtl.uint<8>, in %vec_3: !firrtl.uint<8>,
+                                       in %vec_4: !firrtl.uint<8>, in %vec_5: !firrtl.uint<8>,
+                                       in %vec_6: !firrtl.uint<8>, in %vec_7: !firrtl.uint<8>,
+                                       in %index: !firrtl.uint<2>, out %b: !firrtl.uint<8>) {
+  // CHECK-NEXT:  %0 = firrtl.multibit_mux %index, %vec_3, %vec_2, %vec_1, %vec_0
+  %0 = firrtl.multibit_mux %index, %vec_7, %vec_6, %vec_5, %vec_4, %vec_3, %vec_2, %vec_1, %vec_0 : !firrtl.uint<2>, !firrtl.uint<8>
+  firrtl.matchingconnect %b, %0 : !firrtl.uint<8>
+}
 
 }

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3624,10 +3624,15 @@ firrtl.module @multibit_mux_drop_front(in %vec_0: !firrtl.uint<8>, in %vec_1: !f
                                        in %vec_2: !firrtl.uint<8>, in %vec_3: !firrtl.uint<8>,
                                        in %vec_4: !firrtl.uint<8>, in %vec_5: !firrtl.uint<8>,
                                        in %vec_6: !firrtl.uint<8>, in %vec_7: !firrtl.uint<8>,
-                                       in %index: !firrtl.uint<2>, out %b: !firrtl.uint<8>) {
+                                       in %index: !firrtl.uint<2>, in %index_unknown_width: !firrtl.uint,
+                                       out %b: !firrtl.uint<8>, out %c: !firrtl.uint<8>) {
   // CHECK-NEXT:  %0 = firrtl.multibit_mux %index, %vec_3, %vec_2, %vec_1, %vec_0
   %0 = firrtl.multibit_mux %index, %vec_7, %vec_6, %vec_5, %vec_4, %vec_3, %vec_2, %vec_1, %vec_0 : !firrtl.uint<2>, !firrtl.uint<8>
   firrtl.matchingconnect %b, %0 : !firrtl.uint<8>
+
+  // CHECK:  %1 = firrtl.multibit_mux %index_unknown_width, %vec_7
+  %1 = firrtl.multibit_mux %index_unknown_width, %vec_7, %vec_6, %vec_5, %vec_4, %vec_3, %vec_2, %vec_1, %vec_0 : !firrtl.uint, !firrtl.uint<8>
+  firrtl.matchingconnect %c, %1 : !firrtl.uint<8>
 }
 
 }


### PR DESCRIPTION
This adds a canonicalization to optimize multibit_mux whose index has narrow width. Close https://github.com/llvm/circt/issues/7361