### PR TITLE
[StringDebugInfoPred] Workaround FusedLoc bytecode issue

### DIFF
--- a/lib/Transforms/StripDebugInfoWithPred.cpp
+++ b/lib/Transforms/StripDebugInfoWithPred.cpp
@@ -43,6 +43,9 @@ struct StripDebugInfoWithPred
       newLocations.reserve(fusedLoc.getLocations().size());
       for (auto loc : fusedLoc.getLocations())
         newLocations.push_back(getStrippedLoc(loc));
+      // NOTE: Don't use FusedLoc::get(&getContext(), newLocations,
+      //       fusedLoc.getMetadata()) to avoid a bytecode reader bug
+      //       llvm-project#99626.
       return FusedLoc::get(newLocations, fusedLoc.getMetadata(), &getContext());
     }
 

--- a/lib/Transforms/StripDebugInfoWithPred.cpp
+++ b/lib/Transforms/StripDebugInfoWithPred.cpp
@@ -43,7 +43,7 @@ struct StripDebugInfoWithPred
       newLocations.reserve(fusedLoc.getLocations().size());
       for (auto loc : fusedLoc.getLocations())
         newLocations.push_back(getStrippedLoc(loc));
-      return FusedLoc::get(&getContext(), newLocations, fusedLoc.getMetadata());
+      return FusedLoc::get(newLocations, fusedLoc.getMetadata(), &getContext());
     }
 
     // TODO: Handle other loc type.

--- a/test/Transforms/strip-debuginfo-pred.mlir
+++ b/test/Transforms/strip-debuginfo-pred.mlir
@@ -6,7 +6,8 @@ func.func @inline_notation() {
   // CHECK: "foo"() : () -> i32 loc(unknown)
   %1 = "foo"() : () -> i32 loc("foo.txt":0:0)
 
-// CHECK: loc(fused["foo", unknown]) 
+// CHECK: affine.for
+// CHECK-NEXT: loc("foo")
   affine.for %i0 = 0 to 8 {
   } loc(fused["foo", "foo.txt":10:8]) 
   return


### PR DESCRIPTION
This PR changes to use a different `FusedLoc::get` to avoid a bug https://github.com/llvm/llvm-project/issues/99626.