### PR TITLE
[Seq] Fix ClockConstAttr definition to pass roundstrip test

### DIFF
--- a/include/circt/Dialect/Seq/SeqAttributes.td
+++ b/include/circt/Dialect/Seq/SeqAttributes.td
@@ -22,7 +22,7 @@ def ClockConstAttrImpl: I32EnumAttr<"ClockConst", "clock constant",
                                 [ClockLow, ClockHigh]> {
   let genSpecializedAttr = 0;
 }
-def ClockConstAttr : EnumAttr<SeqDialect, ClockConstAttrImpl, "clock constant">;
+def ClockConstAttr : EnumAttr<SeqDialect, ClockConstAttrImpl, "clock_constant">;
 
 // Read-under-write behavior
 def RUW_Undefined : I32EnumAttrCase<"Undefined", 0, "undefined">;

--- a/test/Dialect/Seq/clock-type.mlir
+++ b/test/Dialect/Seq/clock-type.mlir
@@ -1,4 +1,5 @@
 // RUN: circt-opt --lower-seq-to-sv %s | FileCheck %s
+// RUN: circt-opt %s --mlir-print-op-generic | circt-opt
 
 hw.generator.schema @Some_schema, "Some_schema", ["dummy"]
 


### PR DESCRIPTION
The 3rd argument of `EnumAttr` is used as an attribute mnemonic so it must not contain a whitespace.

Close https://github.com/llvm/circt/issues/7376. 