### PR TITLE
[ESI Runtime] Port connect: add optional buffer size arg

### DIFF
--- a/integration_test/Dialect/ESI/runtime/loopback.mlir.py
+++ b/integration_test/Dialect/ESI/runtime/loopback.mlir.py
@@ -30,7 +30,7 @@ assert appid.name == "loopback_inst"
 assert appid.idx == 0
 
 mysvc_send = loopback.ports[esiaccel.AppID("mysvc_recv")].write_port("recv")
-mysvc_send.connect()
+mysvc_send.connect(buffer_size=12)
 mysvc_send.write(None)
 print(f"mysvc_send.type: {mysvc_send.type}")
 assert isinstance(mysvc_send.type, types.VoidType)

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -35,7 +35,12 @@ public:
   ChannelPort(const Type *type) : type(type) {}
   virtual ~ChannelPort() { disconnect(); }
 
-  virtual void connect() { connectImpl(); }
+  /// Set up a connection to the accelerator. The buffer size is optional and
+  /// should be considered merely a hint. Individual implementations use it
+  /// however they like. The unit is number of messages of the port type.
+  virtual void connect(std::optional<size_t> bufferSize = std::nullopt) {
+    connectImpl(bufferSize);
+  }
   virtual void disconnect() {}
 
   const Type *getType() const { return type; }
@@ -45,7 +50,7 @@ private:
 
   /// Called by all connect methods to let backends initiate the underlying
   /// connections.
-  virtual void connectImpl() {}
+  virtual void connectImpl(std::optional<size_t> bufferSize) {}
 };
 
 /// A ChannelPort which sends data to the accelerator.
@@ -79,7 +84,8 @@ public:
   // wait, and be notified.
   //===--------------------------------------------------------------------===//
 
-  virtual void connect(std::function<bool(MessageData)> callback);
+  virtual void connect(std::function<bool(MessageData)> callback,
+                       std::optional<size_t> bufferSize = std::nullopt);
 
   //===--------------------------------------------------------------------===//
   // Polling mode methods: To use futures or blocking reads, connect without any
@@ -90,7 +96,8 @@ public:
   static constexpr uint64_t DefaultMaxDataQueueMsgs = 32;
 
   /// Connect to the channel in polling mode.
-  virtual void connect() override;
+  virtual void
+  connect(std::optional<size_t> bufferSize = std::nullopt) override;
 
   /// Asynchronous read.
   virtual std::future<MessageData> readAsync();
@@ -105,7 +112,10 @@ public:
 
   /// Set maximum number of messages to store in the dataQueue. 0 means no
   /// limit. This is only used in polling mode and is set to default of 32 upon
-  /// connect.
+  /// connect. While it may seem redundant to have this and bufferSize, there
+  /// may be (and are) backends which have a very small amount of memory which
+  /// are accelerator accessible and want to move messages out as quickly as
+  /// possible.
   void setMaxDataQueueMsgs(uint64_t maxMsgs) { maxDataQueueMsgs = maxMsgs; }
 
 protected:

--- a/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
@@ -41,15 +41,16 @@ ReadChannelPort &BundlePort::getRawRead(const std::string &name) const {
     throw std::runtime_error("Channel '" + name + "' is not a read channel");
   return *read;
 }
-void ReadChannelPort::connect(std::function<bool(MessageData)> callback) {
+void ReadChannelPort::connect(std::function<bool(MessageData)> callback,
+                              std::optional<size_t> bufferSize) {
   if (mode != Mode::Disconnected)
     throw std::runtime_error("Channel already connected");
   mode = Mode::Callback;
   this->callback = callback;
-  ChannelPort::connect();
+  ChannelPort::connect(bufferSize);
 }
 
-void ReadChannelPort::connect() {
+void ReadChannelPort::connect(std::optional<size_t> bufferSize) {
   mode = Mode::Polling;
   maxDataQueueMsgs = DefaultMaxDataQueueMsgs;
   this->callback = [this](MessageData data) {
@@ -70,7 +71,7 @@ void ReadChannelPort::connect() {
     }
     return true;
   };
-  ChannelPort::connect();
+  ChannelPort::connect(bufferSize);
 }
 
 std::future<MessageData> ReadChannelPort::readAsync() {

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -176,7 +176,7 @@ public:
       : WriteChannelPort(type), rpcClient(rpcClient), desc(desc), name(name) {}
   ~WriteCosimChannelPort() = default;
 
-  void connectImpl() override {
+  void connectImpl(std::optional<size_t> bufferSize) override {
     if (desc.type() != getType()->getID())
       throw std::runtime_error("Channel '" + name +
                                "' has wrong type. Expected " +
@@ -224,7 +224,7 @@ public:
         context(nullptr) {}
   virtual ~ReadCosimChannelPort() { disconnect(); }
 
-  void connectImpl() override {
+  void connectImpl(std::optional<size_t> bufferSize) override {
     // Sanity checking.
     if (desc.type() != getType()->getID())
       throw std::runtime_error("Channel '" + name +

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
@@ -207,7 +207,7 @@ public:
   }
 
 private:
-  void connectImpl() override {
+  void connectImpl(std::optional<size_t> bufferSize) override {
     assert(!dataPushThread.joinable() && "already connected");
     shutdown = false;
     dataPushThread = std::thread(&ReadTraceChannelPort::dataPushLoop, this);

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
@@ -175,7 +175,8 @@ PYBIND11_MODULE(esiCppAccel, m) {
       });
 
   py::class_<ChannelPort>(m, "ChannelPort")
-      .def("connect", &ChannelPort::connect)
+      .def("connect", &ChannelPort::connect,
+           py::arg("buffer_size") = std::nullopt)
       .def_property_readonly("type", &ChannelPort::getType,
                              py::return_value_policy::reference);
 

--- a/lib/Dialect/ESI/runtime/python/esiaccel/types.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/types.py
@@ -300,8 +300,8 @@ class Port:
     if not supports_host:
       raise TypeError(f"unsupported type: {reason}")
 
-  def connect(self):
-    self.cpp_port.connect()
+  def connect(self, buffer_size: Optional[int] = None):
+    self.cpp_port.connect(buffer_size)
     return self
 
 


### PR DESCRIPTION
It will not be unusual for customers to want to customize the size of the DMA host memory buffer. This provides the ability to do that, though none of the packaged backends use it.