### PR TITLE
[ImportVerilog] Support large integer constants

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -379,17 +379,14 @@ struct RvalueExprVisitor {
       mlir::emitError(loc, "literals with X or Z bits not supported");
       return {};
     }
-    if (value.getBitWidth() > 64) {
-      mlir::emitError(loc, "unsupported bit width: literal is ")
-          << value.getBitWidth() << " bits wide; only 64 supported";
-      return {};
-    }
     auto intType =
         moore::IntType::get(context.getContext(), value.getBitWidth(),
                             value.hasUnknown() ? moore::Domain::FourValued
                                                : moore::Domain::TwoValued);
-    auto truncValue = value.as<uint64_t>().value();
-    Value result = builder.create<moore::ConstantOp>(loc, intType, truncValue);
+    Value result = builder.create<moore::ConstantOp>(
+        loc, intType,
+        APInt(value.getBitWidth(),
+              ArrayRef<uint64_t>(value.getRawPtr(), value.getNumWords())));
     if (result.getType() != type)
       result = builder.create<moore::ConversionOp>(loc, type, result);
     return result;

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -484,6 +484,8 @@ module Expressions;
     c = 19'd42;
     // CHECK: moore.constant 42 : i19
     c = 19'sd42;
+    // CHECK: moore.constant 123456789123456789123456789123456789 : i128
+    c = 128'd123456789123456789123456789123456789;
     // CHECK: [[TMP1:%.+]] = moore.read %a
     // CHECK: [[TMP2:%.+]] = moore.read %b
     // CHECK: [[TMP3:%.+]] = moore.read %c


### PR DESCRIPTION
Remove the 64 bit limitation on SV integer constants and allow for arbitrary Slang `SVInt`s to be converted to MLIR `APInt`s.