### PR TITLE
[ImportVerilog] Support for loop variables

### DIFF
--- a/lib/Conversion/ImportVerilog/Statements.cpp
+++ b/lib/Conversion/ImportVerilog/Statements.cpp
@@ -185,10 +185,6 @@ struct StmtVisitor {
 
   // Handle `for` loops.
   LogicalResult visit(const slang::ast::ForLoopStatement &stmt) {
-    if (!stmt.loopVars.empty())
-      return mlir::emitError(loc,
-                             "variables in for loop initializer not supported");
-
     // Generate the initializers.
     for (auto *initExpr : stmt.initializers)
       if (!context.convertRvalueExpression(*initExpr))

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -359,6 +359,21 @@ module Statements;
     // CHECK: }
     for (y = x; x; x = z) x = y;
 
+    // CHECK: [[TMP:%.+]] = moore.constant true : i1
+    // CHECK: %iv = moore.variable [[TMP]] : <i1>
+    // CHECK: scf.while : () -> () {
+    // CHECK:   [[TMP:%.+]] = moore.read %iv
+    // CHECK:   [[COND:%.+]] = moore.conversion [[TMP]] : !moore.i1 -> i1
+    // CHECK:   scf.condition([[COND]])
+    // CHECK: } do {
+    // CHECK:   [[TMP:%.+]] = moore.read %iv
+    // CHECK:   moore.blocking_assign %y, [[TMP]] : i1
+    // CHECK:   [[TMP:%.+]] = moore.read %iv
+    // CHECK:   moore.blocking_assign %x, [[TMP]] : i1
+    // CHECK:   scf.yield
+    // CHECK: }
+    for (bit iv = '1; iv; x = iv) y = iv;
+
     // CHECK: [[TMP1:%.+]] = moore.read %i
     // CHECK: scf.while (%arg0 = [[TMP1]]) : (!moore.i32) -> !moore.i32 {
     // CHECK:   [[TMP2:%.+]] = moore.bool_cast %arg0 : i32 -> i1

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -75,13 +75,6 @@ endmodule
 
 // -----
 module Foo;
-  bit y;
-  // expected-error @below {{variables in for loop initializer not supported}}
-  initial for (bit x = 0; x;) x = y;
-endmodule
-
-// -----
-module Foo;
   // expected-error @below {{literals with X or Z bits not supported}}
   logic a = 'x;
 endmodule


### PR DESCRIPTION
Add support for variables declared inside the for loop initializer, such as `for (int x = 0; ...)`. This is pretty straightforward, since Slang already creates corresponding variable declaration AST nodes in the surrounding scope. The only change needed is removing an error diagnostic.