### PR TITLE
[FIRRTL] Inliner: Support for ops with regions.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -497,7 +497,7 @@ public:
   Inliner(CircuitOp circuit, SymbolTable &symbolTable);
 
   /// Run the inliner.
-  void run();
+  LogicalResult run();
 
 private:
   /// Inlining context, one per module being inlined into.
@@ -574,23 +574,36 @@ private:
   /// Returns true if the operation is annotated to be inlined.
   bool shouldInline(Operation *op);
 
+  /// Check not inlining into anything other than layerblock or module.
+  /// In the future, could check this per-inlined-operation.
+  LogicalResult checkInstanceParents(InstanceOp instance);
+
+  /// Walk the specified block, invoking `process` for operations visited
+  /// forward+pre-order.  Handles cloning supported operations with regions,
+  /// so that `process` is only invoked on regionless operations.
+  LogicalResult
+  inliningWalk(OpBuilder &builder, Block *block, IRMapping &mapper,
+               llvm::function_ref<LogicalResult(Operation *op)> process);
+
   /// Flattens a target module into the insertion point of the builder,
   /// renaming all operations using the prefix.  This clones all operations from
   /// the target, and does not trigger inlining on the target itself.
-  void flattenInto(StringRef prefix, InliningLevel &il, IRMapping &mapper,
-                   DenseSet<Attribute> localSymbols);
+  LogicalResult flattenInto(StringRef prefix, InliningLevel &il,
+                            IRMapping &mapper,
+                            DenseSet<Attribute> localSymbols);
 
   /// Inlines a target module into the insertion point of the builder,
   /// prefixing all operations with prefix.  This clones all operations from
   /// the target, and does not trigger inlining on the target itself.
-  void inlineInto(StringRef prefix, InliningLevel &il, IRMapping &mapper,
-                  DenseMap<Attribute, Attribute> &symbolRenames);
+  LogicalResult inlineInto(StringRef prefix, InliningLevel &il,
+                           IRMapping &mapper,
+                           DenseMap<Attribute, Attribute> &symbolRenames);
 
   /// Recursively flatten all instances in a module.
-  void flattenInstances(FModuleOp module);
+  LogicalResult flattenInstances(FModuleOp module);
 
   /// Inline any instances in the module which were marked for inlining.
-  void inlineInstances(FModuleOp module);
+  LogicalResult inlineInstances(FModuleOp module);
 
   /// Create a debug scope for an inlined instance at the current insertion
   /// point of the `il.mic` builder.
@@ -897,26 +910,19 @@ void Inliner::cloneAndRename(
   }
 
   // Clone and rename.
-  auto *newOp = il.mic.b.clone(op, mapper);
+  assert(op.getNumRegions() == 0 &&
+         "operation with regions should not reach cloneAndRename");
+  auto *newOp = il.mic.b.cloneWithoutRegions(op, mapper);
 
-  // Rename the new operation and any contained operations.
+  // Rename the new operation.
   // (add prefix to it, if named, and unique-ify symbol, updating NLA's).
-  op.walk<mlir::WalkOrder::PreOrder>([&](Operation *origOp) {
-    auto *newOpToRename = mapper.lookup(origOp);
-    assert(newOpToRename);
-    // TODO: If want to work before ExpandWhen's, more work needed!
-    // Handle what we can for now.
-    assert((origOp == &op || !isa<InstanceOp>(origOp)) &&
-           "Cannot handle instances not at top-level");
 
-    // Instances require extra handling to update HierPathOp's if their symbols
-    // change.
-    if (auto oldInst = dyn_cast<InstanceOp>(origOp))
-      renameInstance(prefix, il, oldInst, cast<InstanceOp>(newOpToRename),
-                     symbolRenames);
-    else
-      rename(prefix, newOpToRename, il);
-  });
+  // Instances require extra handling to update HierPathOp's if their symbols
+  // change.
+  if (auto oldInst = dyn_cast<InstanceOp>(op))
+    renameInstance(prefix, il, oldInst, cast<InstanceOp>(newOp), symbolRenames);
+  else
+    rename(prefix, newOp, il);
 
   // We want to avoid attaching an empty annotation array on to an op that
   // never had an annotation array in the first place.
@@ -934,18 +940,122 @@ bool Inliner::shouldInline(Operation *op) {
   return AnnotationSet::hasAnnotation(op, inlineAnnoClass);
 }
 
+LogicalResult Inliner::inliningWalk(
+    OpBuilder &builder, Block *block, IRMapping &mapper,
+    llvm::function_ref<LogicalResult(Operation *op)> process) {
+  struct IPs {
+    OpBuilder::InsertPoint target;
+    Block::iterator source;
+  };
+  // Invariant: no Block::iterator == end(), can't getBlock().
+  SmallVector<IPs> inliningStack;
+  if (block->empty())
+    return success();
+
+  inliningStack.push_back(IPs{builder.saveInsertionPoint(), block->begin()});
+  OpBuilder::InsertionGuard guard(builder);
+  while (!inliningStack.empty()) {
+    auto &ips = inliningStack.back();
+    builder.restoreInsertionPoint(ips.target);
+    auto end = ips.source->getBlock()->end();
+    for (; ips.source != end; ++ips.source) {
+      auto &source = *ips.source;
+
+      // Handle ops with regions below.
+      if (source.getNumRegions() != 0)
+        break;
+
+      assert(builder.saveInsertionPoint().getPoint() == ips.target.getPoint());
+      // Clone source into insertion point 'target'.
+      if (failed(process(&source)))
+        return failure();
+      assert(builder.saveInsertionPoint().getPoint() == ips.target.getPoint());
+    }
+
+    // If we've finished inlining this block, pop and continue to next.
+    if (ips.source == end) {
+      inliningStack.pop_back();
+      continue;
+    }
+
+    // Otherwise, we have an operation with regions.
+    auto &sourceWithRegions = *ips.source;
+    assert(builder.saveInsertionPoint().getPoint() == ips.target.getPoint());
+
+    // Advance source iterator, we'll handle this operation below.
+    // If this is the last operation of current level, pop off stack.
+    if (++ips.source == end)
+      inliningStack.pop_back();
+
+    // Limited support for region-containing operations.
+    if (!isa<LayerBlockOp, WhenOp, MatchOp>(sourceWithRegions))
+      return sourceWithRegions.emitError("unsupported operation '")
+             << sourceWithRegions.getName() << "' cannot be inlined";
+
+    // Note: This does not use cloneAndRename for simplicity,
+    // as there are no annotations, symbols to rename, or names
+    // to prefix.  This does mean these operations do not appear
+    // in `il.newOps` for inner-ref renaming walk, FWIW.
+    auto *newOp = builder.cloneWithoutRegions(sourceWithRegions, mapper);
+    for (auto [newRegion, oldRegion] : llvm::reverse(llvm::zip_equal(
+             newOp->getRegions(), sourceWithRegions.getRegions()))) {
+      // If region has no blocks, skip.
+      if (oldRegion.empty()) {
+        assert(newRegion.empty());
+        continue;
+      }
+      // Otherwise, assert single block.  Multiple blocks is trickier.
+      assert(oldRegion.hasOneBlock());
+
+      // Create new block and add to inlining stack for processing.
+      auto &oldBlock = oldRegion.getBlocks().front();
+      auto &newBlock = newRegion.emplaceBlock();
+      mapper.map(&oldBlock, &newBlock);
+
+      // Copy block arguments, and add mapping for each.
+      for (auto arg : oldBlock.getArguments())
+        mapper.map(arg, newBlock.addArgument(arg.getType(), arg.getLoc()));
+
+      if (oldBlock.empty())
+        continue;
+
+      inliningStack.push_back(
+          IPs{OpBuilder::InsertPoint(&newBlock, newBlock.begin()),
+              oldBlock.begin()});
+    }
+  }
+  return success();
+}
+
+LogicalResult Inliner::checkInstanceParents(InstanceOp instance) {
+  auto *parent = instance->getParentOp();
+  while (!isa<FModuleLike>(parent)) {
+    if (!isa<LayerBlockOp>(parent))
+      return instance->emitError("cannot inline instance")
+                 .attachNote(parent->getLoc())
+             << "containing operation '" << parent->getName()
+             << "' not safe to inline into";
+    parent = parent->getParentOp();
+  }
+  return success();
+}
+
 // NOLINTNEXTLINE(misc-no-recursion)
-void Inliner::flattenInto(StringRef prefix, InliningLevel &il,
-                          IRMapping &mapper, DenseSet<Attribute> localSymbols) {
+LogicalResult Inliner::flattenInto(StringRef prefix, InliningLevel &il,
+                                   IRMapping &mapper,
+                                   DenseSet<Attribute> localSymbols) {
   auto target = il.childModule;
   auto moduleName = target.getNameAttr();
   DenseMap<Attribute, Attribute> symbolRenames;
-  for (auto &op : *target.getBodyBlock()) {
+
+  LLVM_DEBUG(llvm::dbgs() << "flattening " << target.getModuleName() << " into "
+                          << il.mic.module.getModuleName() << "\n");
+  auto visit = [&](Operation *op) {
     // If it's not an instance op, clone it and continue.
     auto instance = dyn_cast<InstanceOp>(op);
     if (!instance) {
-      cloneAndRename(prefix, il, mapper, op, symbolRenames, localSymbols);
-      continue;
+      cloneAndRename(prefix, il, mapper, *op, symbolRenames, localSymbols);
+      return success();
     }
 
     // If it's not a regular module we can't inline it. Mark it as live.
@@ -954,9 +1064,12 @@ void Inliner::flattenInto(StringRef prefix, InliningLevel &il,
     if (!childModule) {
       liveModules.insert(moduleOp);
 
-      cloneAndRename(prefix, il, mapper, op, symbolRenames, localSymbols);
-      continue;
+      cloneAndRename(prefix, il, mapper, *op, symbolRenames, localSymbols);
+      return success();
     }
+
+    if (failed(checkInstanceParents(instance)))
+      return failure();
 
     // Add any NLAs which start at this instance to the localSymbols set.
     // Anything in this set will be made local during the recursive flattenInto
@@ -976,29 +1089,31 @@ void Inliner::flattenInto(StringRef prefix, InliningLevel &il,
     mapResultsToWires(mapper, childIL.wires, instance);
 
     // Unconditionally flatten all instance operations.
-    flattenInto(nestedPrefix, childIL, mapper, localSymbols);
+    if (failed(flattenInto(nestedPrefix, childIL, mapper, localSymbols)))
+      return failure();
     currentPath.pop_back();
     activeHierpaths = parentActivePaths;
-  }
+    return success();
+  };
+  return inliningWalk(il.mic.b, target.getBodyBlock(), mapper, visit);
 }
 
-void Inliner::flattenInstances(FModuleOp module) {
+LogicalResult Inliner::flattenInstances(FModuleOp module) {
   auto moduleName = module.getNameAttr();
   ModuleInliningContext mic(module);
 
-  for (auto &op : llvm::make_early_inc_range(*module.getBodyBlock())) {
-    // If it's not an instance op, skip it.
-    auto instance = dyn_cast<InstanceOp>(op);
-    if (!instance)
-      continue;
-
+  auto visit = [&](InstanceOp instance) {
     // If it's not a regular module we can't inline it. Mark it as live.
     auto *targetModule = symbolTable.lookup(instance.getModuleName());
     auto target = dyn_cast<FModuleOp>(targetModule);
     if (!target) {
       liveModules.insert(targetModule);
-      continue;
+      return WalkResult::advance();
     }
+
+    if (failed(checkInstanceParents(instance)))
+      return WalkResult::interrupt();
+
     if (auto instSym = getInnerSymName(instance)) {
       auto innerRef = InnerRefAttr::get(moduleName, instSym);
       // Preorder update of any non-local annotations this instance participates
@@ -1032,28 +1147,37 @@ void Inliner::flattenInstances(FModuleOp module) {
       instance.getResult(i).replaceAllUsesWith(il.wires[i]);
 
     // Recursively flatten the target module.
-    flattenInto(nestedPrefix, il, mapper, localSymbols);
+    if (failed(flattenInto(nestedPrefix, il, mapper, localSymbols)))
+      return WalkResult::interrupt();
     currentPath.pop_back();
     activeHierpaths = parentActivePaths;
 
     // Erase the replaced instance.
     instance.erase();
-  }
+    return WalkResult::skip();
+  };
+  return failure(module.getBodyBlock()
+                     ->walk<mlir::WalkOrder::PreOrder>(visit)
+                     .wasInterrupted());
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)
-void Inliner::inlineInto(StringRef prefix, InliningLevel &il, IRMapping &mapper,
-                         DenseMap<Attribute, Attribute> &symbolRenames) {
+LogicalResult
+Inliner::inlineInto(StringRef prefix, InliningLevel &il, IRMapping &mapper,
+                    DenseMap<Attribute, Attribute> &symbolRenames) {
   auto target = il.childModule;
   auto inlineToParent = il.mic.module;
   auto moduleName = target.getNameAttr();
-  // Inline everything in the module's body.
-  for (auto &op : *target.getBodyBlock()) {
+
+  LLVM_DEBUG(llvm::dbgs() << "inlining " << target.getModuleName() << " into "
+                          << inlineToParent.getModuleName() << "\n");
+
+  auto visit = [&](Operation *op) {
     // If it's not an instance op, clone it and continue.
     auto instance = dyn_cast<InstanceOp>(op);
     if (!instance) {
-      cloneAndRename(prefix, il, mapper, op, symbolRenames, {});
-      continue;
+      cloneAndRename(prefix, il, mapper, *op, symbolRenames, {});
+      return success();
     }
 
     // If it's not a regular module we can't inline it. Mark it as live.
@@ -1061,8 +1185,8 @@ void Inliner::inlineInto(StringRef prefix, InliningLevel &il, IRMapping &mapper,
     auto childModule = dyn_cast<FModuleOp>(moduleOp);
     if (!childModule) {
       liveModules.insert(moduleOp);
-      cloneAndRename(prefix, il, mapper, op, symbolRenames, {});
-      continue;
+      cloneAndRename(prefix, il, mapper, *op, symbolRenames, {});
+      return success();
     }
 
     // If we aren't inlining the target, add it to the work list.
@@ -1070,9 +1194,12 @@ void Inliner::inlineInto(StringRef prefix, InliningLevel &il, IRMapping &mapper,
       if (liveModules.insert(childModule).second) {
         worklist.push_back(childModule);
       }
-      cloneAndRename(prefix, il, mapper, op, symbolRenames, {});
-      continue;
+      cloneAndRename(prefix, il, mapper, *op, symbolRenames, {});
+      return success();
     }
+
+    if (failed(checkInstanceParents(instance)))
+      return failure();
 
     auto toBeFlattened = shouldFlatten(childModule);
     if (auto instSym = getInnerSymName(instance)) {
@@ -1132,34 +1259,32 @@ void Inliner::inlineInto(StringRef prefix, InliningLevel &il, IRMapping &mapper,
 
     // Inline the module, it can be marked as flatten and inline.
     if (toBeFlattened) {
-      flattenInto(nestedPrefix, childIL, mapper, {});
+      if (failed(flattenInto(nestedPrefix, childIL, mapper, {})))
+        return failure();
     } else {
-      inlineInto(nestedPrefix, childIL, mapper, symbolRenames);
+      if (failed(inlineInto(nestedPrefix, childIL, mapper, symbolRenames)))
+        return failure();
     }
     currentPath.pop_back();
     activeHierpaths = parentActivePaths;
-  }
+    return success();
+  };
+
+  return inliningWalk(il.mic.b, target.getBodyBlock(), mapper, visit);
 }
 
-void Inliner::inlineInstances(FModuleOp module) {
+LogicalResult Inliner::inlineInstances(FModuleOp module) {
   // Generate a namespace for this module so that we can safely inline symbols.
   auto moduleName = module.getNameAttr();
-
-  SmallVector<Value> wires;
   ModuleInliningContext mic(module);
 
-  for (auto &op : llvm::make_early_inc_range(*module.getBodyBlock())) {
-    // If it's not an instance op, skip it.
-    auto instance = dyn_cast<InstanceOp>(op);
-    if (!instance)
-      continue;
-
+  auto visit = [&](InstanceOp instance) {
     // If it's not a regular module we can't inline it. Mark it as live.
     auto *childModule = symbolTable.lookup(instance.getModuleName());
     auto target = dyn_cast<FModuleOp>(childModule);
     if (!target) {
       liveModules.insert(childModule);
-      continue;
+      return WalkResult::advance();
     }
 
     // If we aren't inlining the target, add it to the work list.
@@ -1167,8 +1292,11 @@ void Inliner::inlineInstances(FModuleOp module) {
       if (liveModules.insert(target).second) {
         worklist.push_back(target);
       }
-      continue;
+      return WalkResult::advance();
     }
+
+    if (failed(checkInstanceParents(instance)))
+      return WalkResult::interrupt();
 
     auto toBeFlattened = shouldFlatten(target);
     if (auto instSym = getInnerSymName(instance)) {
@@ -1224,18 +1352,25 @@ void Inliner::inlineInstances(FModuleOp module) {
 
     // Inline the module, it can be marked as flatten and inline.
     if (toBeFlattened) {
-      flattenInto(nestedPrefix, childIL, mapper, {});
+      if (failed(flattenInto(nestedPrefix, childIL, mapper, {})))
+        return WalkResult::interrupt();
     } else {
       // Recursively inline all the child modules under `parent`, that are
       // marked to be inlined.
-      inlineInto(nestedPrefix, childIL, mapper, symbolRenames);
+      if (failed(inlineInto(nestedPrefix, childIL, mapper, symbolRenames)))
+        return WalkResult::interrupt();
     }
     currentPath.pop_back();
     activeHierpaths = parentActivePaths;
 
     // Erase the replaced instance.
     instance.erase();
-  }
+    return WalkResult::skip();
+  };
+
+  return failure(module.getBodyBlock()
+                     ->walk<mlir::WalkOrder::PreOrder>(visit)
+                     .wasInterrupted());
 }
 
 void Inliner::createDebugScope(InliningLevel &il, InstanceOp instance,
@@ -1316,7 +1451,7 @@ Inliner::Inliner(CircuitOp circuit, SymbolTable &symbolTable)
     : circuit(circuit), context(circuit.getContext()),
       symbolTable(symbolTable) {}
 
-void Inliner::run() {
+LogicalResult Inliner::run() {
   CircuitNamespace circuitNamespace(circuit);
 
   // Gather all NLA's, build information about the instance ops used:
@@ -1346,13 +1481,15 @@ void Inliner::run() {
   while (!worklist.empty()) {
     auto moduleOp = worklist.pop_back_val();
     if (shouldFlatten(moduleOp)) {
-      flattenInstances(moduleOp);
+      if (failed(flattenInstances(moduleOp)))
+        return failure();
       // Delete the flatten annotation, the transform was performed.
       // Even if visited again in our walk (for inlining),
       // we've just flattened it and so the annotation is no longer needed.
       AnnotationSet::removeAnnotations(moduleOp, flattenAnnoClass);
     } else {
-      inlineInstances(moduleOp);
+      if (failed(inlineInstances(moduleOp)))
+        return failure();
     }
   }
 
@@ -1468,6 +1605,7 @@ void Inliner::run() {
     fmodule->setAttr("portAnnotations",
                      ArrayAttr::get(context, newPortAnnotations));
   }
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -1479,7 +1617,8 @@ class InlinerPass : public circt::firrtl::impl::InlinerBase<InlinerPass> {
   void runOnOperation() override {
     LLVM_DEBUG(debugPassHeader(this) << "\n");
     Inliner inliner(getOperation(), getAnalysis<SymbolTable>());
-    inliner.run();
+    if (failed(inliner.run()))
+      signalPassFailure();
     LLVM_DEBUG(debugFooter() << "\n");
   }
 };

--- a/test/Dialect/FIRRTL/inliner-errors.mlir
+++ b/test/Dialect/FIRRTL/inliner-errors.mlir
@@ -1,0 +1,91 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-inliner))' -allow-unregistered-dialect -verify-diagnostics --split-input-file %s
+
+// Reject inlining into when (run ExpandWhens first).
+
+firrtl.circuit "InlineIntoWhen" {
+  firrtl.module private @Child () attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {}
+  firrtl.module @InlineIntoWhen(in %cond : !firrtl.uint<1>) {
+    // expected-note @below {{containing operation 'firrtl.when' not safe to inline into}}
+    firrtl.when %cond : !firrtl.uint<1> {
+      // expected-error @below {{cannot inline instance}}
+      firrtl.instance c @Child()
+    }
+  }
+}
+
+// -----
+
+// Reject flattening through when (run ExpandWhens first).
+
+firrtl.circuit "FlattenThroughWhen" {
+  firrtl.module private @GChild () {}
+  firrtl.module private @Child (in %cond : !firrtl.uint<1>) {
+    // expected-note @below {{containing operation 'firrtl.when' not safe to inline into}}
+    firrtl.when %cond : !firrtl.uint<1> {
+      // expected-error @below {{cannot inline instance}}
+      firrtl.instance c @GChild()
+    }
+  }
+  firrtl.module @FlattenThroughWhen(in %cond : !firrtl.uint<1>) attributes {annotations = [{class = "firrtl.transforms.FlattenAnnotation"}]} {
+    %c_cond = firrtl.instance c @Child(in cond : !firrtl.uint<1>)
+    firrtl.matchingconnect %c_cond, %cond : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+// Reject inlining into unrecognized operations.
+
+firrtl.circuit "InlineIntoIfdef" {
+  sv.macro.decl @A_0["A"]
+  firrtl.module private @Child () attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {}
+  firrtl.module @InlineIntoIfdef() {
+    // expected-note @below {{containing operation 'sv.ifdef' not safe to inline into}}
+    sv.ifdef @A_0 {
+      // expected-error @below {{cannot inline instance}}
+      firrtl.instance c @Child()
+    }
+  }
+}
+
+// -----
+
+// Conservatively reject cloning operations with regions that we don't recognize.
+
+firrtl.circuit "InlineIfdef" {
+  sv.macro.decl @A_0["A"]
+  firrtl.module private @Child () attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    // expected-error @below {{unsupported operation 'sv.ifdef' cannot be inlined}}
+    sv.ifdef @A_0 { }
+  }
+  firrtl.module @InlineIfdef() {
+    firrtl.instance c @Child()
+  }
+}
+
+// -----
+
+// Cannot inline layers into layers.
+// Presently the issue is detected by the verifier.
+
+firrtl.circuit "InlineLayerIntoLayer" {
+  firrtl.layer @I  inline {
+    firrtl.layer @J  inline {
+    }
+  }
+  firrtl.module private @MatchAgain(in %i: !firrtl.uint<8>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    // expected-error @below {{op has an un-nested layer symbol, but does not have a 'firrtl.module' op as a parent}}
+    firrtl.layerblock @I {
+      firrtl.layerblock @I::@J {
+        %n = firrtl.node interesting_name %i : !firrtl.uint<8>
+      }
+    }
+  }
+  firrtl.module @InlineLayerIntoLayer(in %i: !firrtl.uint<8>) attributes {convention = #firrtl<convention scalarized>} {
+    // expected-note @below {{illegal parent op defined here}}
+    firrtl.layerblock @I {
+      %c_i = firrtl.instance c interesting_name @MatchAgain(in i: !firrtl.uint<8>)
+      firrtl.matchingconnect %c_i, %i : !firrtl.uint<8>
+    }
+  }
+}

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1292,6 +1292,31 @@ firrtl.circuit "InlineLayerBlockSimple" {
 
 // -----
 
+// Check recurse into instances not at top-level.
+
+firrtl.circuit "WalkIntoInstancesUnderLayerBlock" {
+  firrtl.layer @I inline { }
+  // CHECK-NOT: @GChild
+  firrtl.module private @GChild() attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
+    %o = firrtl.wire interesting_name : !firrtl.uint<8>
+  }
+  // CHECK: @Child
+  firrtl.module private @Child() {
+    // CHECK-NEXT: %gc_o = firrtl.wire
+    firrtl.instance gc @GChild()
+  }
+  // CHECK: @WalkIntoInstancesUnderLayerBlock
+  firrtl.module @WalkIntoInstancesUnderLayerBlock() {
+    // CHECK-NEXT: layerblock @I
+    // CHECK-NEXT:   firrtl.instance c @Child
+    firrtl.layerblock @I {
+      firrtl.instance c @Child()
+    }
+  }
+}
+
+// -----
+
 // Test inlining into nested layer, and cloning operations with blocks + blockargs (match).
 
 firrtl.circuit "MatchInline" attributes {enable_layers = [@I]} {


### PR DESCRIPTION
inlineInstances/flattenInstances:
* Walk entire body, not only top-level operations.
  Fixes missing instances and allows inlining them
  when conservatively legal.
* Reject inlining instances under when/match.

inlineInto/flattenInto:
  Walk entire body using new `inliningWalk` method
  that drives the per-operations handling but also
  handles cloning "structure" operations that have
  regions (when/match/layer) and managing what
  should be cloned where.

  This allows inlining modules that contain these
  operations.

Inliner now may produce errors, thread throughout.

This allows the inliner to run earlier in the pipeline,
particularly before LowerLayers.