### PR TITLE
[PrepareForEmission] Hoist registers in a procedural region with `disallowLocalVariables`

### DIFF
--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -975,9 +975,9 @@ static LogicalResult legalizeHWModule(Block &block,
     if (auto call = dyn_cast<mlir::CallOpInterface>(op))
       lowerFunctionCallResults(call);
 
-    // If logic op is located in a procedural region, we have to move the logic
+    // If a reg or logic is located in a procedural region, we have to move the
     // op declaration to a valid program point.
-    if (isProceduralRegion && isa<LogicOp>(op)) {
+    if (isProceduralRegion && isa<LogicOp, RegOp>(op)) {
       if (options.disallowLocalVariables) {
         // When `disallowLocalVariables` is enabled, "automatic logic" is
         // prohibited so hoist the op to a non-procedural region.

--- a/test/Conversion/ExportVerilog/disallow-local-vars.mlir
+++ b/test/Conversion/ExportVerilog/disallow-local-vars.mlir
@@ -239,3 +239,24 @@ hw.module @AggregateInline(in %clock: i1) {
   // CHECK: assign [[GEN]] = register.a[15:0]
   hw.output
 }
+
+// CHECK-LABEL: module hoist_reg
+// DISALLOW-LABEL: module hoist_reg
+hw.module @hoist_reg(in %dummy : i32, out out : i17) {
+  %res_reg = sv.reg : !hw.inout<i17>
+  // CHECK: initial
+  // CHECK: reg  [31:0] tmp;
+  // CHECK end // initial
+  // DISALLOW: reg  [31:0] tmp;
+  // DISALLOW: initial
+  sv.initial {
+    %tmp = sv.reg : !hw.inout<i32>
+    %17 = sv.read_inout %tmp : !hw.inout<i32>
+    %29 = comb.xor %dummy, %17 : i32
+    %32 = comb.extract %29 from 3 : (i32) -> i17
+    sv.passign %res_reg, %32 : i17
+  }
+
+  %res_reg_data = sv.read_inout %res_reg : !hw.inout<i17>
+  hw.output %res_reg_data : i17
+}


### PR DESCRIPTION
Fix https://github.com/llvm/circt/issues/7399