### PR TITLE
[docs] Remove confusing reset in Seq docs SV example

### DIFF
--- a/docs/Dialects/Seq/RationaleSeq.md
+++ b/docs/Dialects/Seq/RationaleSeq.md
@@ -146,7 +146,7 @@ Examples of registers:
 A register without a reset lowers directly to an always block:
 
 ```
-always @(posedge clk or [posedge reset]) begin
+always @(posedge clk) begin
   a <= [%input]
 end
 ```


### PR DESCRIPTION
These docs give an example of a SV lowering of a firreg without a reset, but then the SV snippet has a reset in it, which is a bit confusing.