### PR TITLE
[Support] Allow erasing names in Namespace

### DIFF
--- a/include/circt/Support/Namespace.h
+++ b/include/circt/Support/Namespace.h
@@ -59,6 +59,10 @@ public:
         nextIndex.insert({strAttr.getValue(), 0});
   }
 
+  /// Removes a symbol from the namespace. Returns true if the symbol was
+  /// removed, false if the symbol was not found.
+  bool erase(llvm::StringRef symbol) { return nextIndex.erase(symbol); }
+
   /// Empty the namespace.
   void clear() { nextIndex.clear(); }
 


### PR DESCRIPTION
Allowing erasing names in a namespace seems more sane than micro-managing which names gets added to a namespace. E.g., it's convenient to use `Namespace::add(SymbolCache &` to efficiently prime a namespace, and then surgically removing some known identifier,, instead of having to re-implement how symbols are added to the namespace.