### PR TITLE
[Ibis] Don't include design name in namespace in IbisContainersToHW

### DIFF
--- a/lib/Dialect/Ibis/Transforms/IbisContainersToHW.cpp
+++ b/lib/Dialect/Ibis/Transforms/IbisContainersToHW.cpp
@@ -369,6 +369,13 @@ void ContainersToHWPass::runOnOperation() {
   target.addIllegalOp<ContainerOp, ContainerInstanceOp, ThisOp>();
   target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 
+  // Remove the name of the ibis.design's from the namespace - The ibis.design
+  // op will be removed after this pass, and there may be ibis.component's
+  // inside the design that have the same name as the design; we want that
+  // name to persist, and not be falsely considered a duplicate.
+  for (auto designOp : getOperation().getOps<DesignOp>())
+    modNamespace.erase(designOp.getSymName());
+
   // Parts of the conversion patterns will update operations in place, which in
   // turn requires the updated operations to be legalizeable. These in-place ops
   // also include ibis ops that eventually will get replaced once all of the

--- a/test/Dialect/Ibis/Transforms/containers_to_hw.mlir
+++ b/test/Dialect/Ibis/Transforms/containers_to_hw.mlir
@@ -163,3 +163,16 @@ ibis.container "Foo" sym @B top_level {
 
 hw.module.extern @D_Foo(in %theExternModule : i1)
 hw.module.extern @Foo(in %theExternModule : i1)
+
+// -----
+
+// Test that containers with names that alias with the design op are not
+// de-aliased.
+
+// CHECK: hw.module @D
+
+ibis.design @D {
+  ibis.container "D" sym @D top_level {
+    %this = ibis.this <@D::@D>
+  }
+}


### PR DESCRIPTION
The ibis.design op will be removed after the IbisContainersToHW pass, and there may be ibis.component's inside the design that have the same name as the design; we want that name to persist, and not be falsely considered a duplicate.