### PR TITLE
[OM] Add IntegerAttr -> Python int conversion

### DIFF
--- a/lib/Bindings/Python/OMModule.cpp
+++ b/lib/Bindings/Python/OMModule.cpp
@@ -366,6 +366,15 @@ Map::dunderGetItem(std::variant<intptr_t, std::string, MlirAttribute> key) {
 // Convert a generic MLIR Attribute to a PythonValue. This is basically a C++
 // fast path of the parts of attribute_to_var that we use in the OM dialect.
 static PythonPrimitive omPrimitiveToPythonValue(MlirAttribute attr) {
+  if (mlirAttributeIsAInteger(attr)) {
+    MlirType type = mlirAttributeGetType(attr);
+    if (mlirTypeIsAIndex(type) || mlirIntegerTypeIsSignless(type))
+      return py::int_(mlirIntegerAttrGetValueInt(attr));
+    if (mlirIntegerTypeIsSigned(type))
+      return py::int_(mlirIntegerAttrGetValueSInt(attr));
+    return py::int_(mlirIntegerAttrGetValueUInt(attr));
+  }
+
   if (omAttrIsAIntegerAttr(attr)) {
     auto strRef = omIntegerAttrToString(attr);
     return py::int_(py::str(strRef.data, strRef.length));


### PR DESCRIPTION
Add a missing conversion for OM to Python conversion where only OM integers and not arbitrary MLIR integers would be converted to Python. This could result in failures in Python scripts that needed to consume OM.

This fixes a bug introduced in: 17c036f87c4c9e103160b207e18ad595911945e8