### PR TITLE
[FIRRTL] Add CheckRecursiveInstantiation diagnostic pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -214,6 +214,8 @@ std::unique_ptr<mlir::Pass> createLowerDPIPass();
 std::unique_ptr<mlir::Pass>
 createAssignOutputDirsPass(mlir::StringRef outputDir = "");
 
+std::unique_ptr<mlir::Pass> createCheckRecursiveInstantiation();
+
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "circt/Dialect/FIRRTL/Passes.h.inc"

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -970,4 +970,18 @@ def ProbesToSignals : Pass<"firrtl-probes-to-signals", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createProbesToSignalsPass()";
 }
 
+def CheckRecursiveInstantiation : Pass<"firrtl-check-recursive-instantiation",
+    "firrtl::CircuitOp"> {
+  let summary = "Check for illegal recursive instantiation";
+  let description = [{
+    This pass checks for illegal recursive module instantion.  Recursive
+    instantiation is when a module instantiates itself, either directly or
+    indirectly through other modules it instantiates.  Recursive module 
+    instantiation is illegal because it would require infinite hardware to
+    synthesize. Recursive class instantiation is illegal as it would create an
+    infinite loop.
+  }];
+  let constructor = "circt::firrtl::createCheckRecursiveInstantiation()";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/FIRRTLInstanceImplementation.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLInstanceImplementation.cpp
@@ -16,7 +16,6 @@ LogicalResult
 instance_like_impl::verifyReferencedModule(Operation *instanceOp,
                                            SymbolTableCollection &symbolTable,
                                            mlir::FlatSymbolRefAttr moduleName) {
-  auto module = instanceOp->getParentOfType<FModuleOp>();
   auto referencedModule =
       symbolTable.lookupNearestSymbolFrom<FModuleLike>(instanceOp, moduleName);
   if (!referencedModule) {
@@ -28,15 +27,6 @@ instance_like_impl::verifyReferencedModule(Operation *instanceOp,
     return instanceOp->emitOpError("must instantiate a module not a class")
                .attachNote(referencedModule.getLoc())
            << "class declared here";
-
-  // Check that this instance doesn't recursively instantiate its wrapping
-  // module.
-  if (referencedModule == module) {
-    auto diag = instanceOp->emitOpError()
-                << "is a recursive instantiation of its containing module";
-    return diag.attachNote(module.getLoc())
-           << "containing module declared here";
-  }
 
   // Small helper add a note to the original declaration.
   auto emitNote = [&](InFlightDiagnostic &&diag) -> InFlightDiagnostic && {

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   AddSeqMemPorts.cpp
   BlackBoxReader.cpp
   CheckCombLoops.cpp
+  CheckRecursiveInstantiation.cpp
   CreateCompanionAssume.cpp
   CreateSiFiveMetadata.cpp
   Dedup.cpp

--- a/lib/Dialect/FIRRTL/Transforms/CheckRecursiveInstantiation.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckRecursiveInstantiation.cpp
@@ -1,0 +1,66 @@
+//===- CheckRecursiveInstantiation.cpp - Check recurisve instantiation ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SCCIterator.h"
+
+namespace circt {
+namespace firrtl {
+#define GEN_PASS_DEF_CHECKRECURSIVEINSTANTIATION
+#include "circt/Dialect/FIRRTL/Passes.h.inc"
+} // namespace firrtl
+} // namespace circt
+
+using namespace circt;
+using namespace firrtl;
+
+static void printPath(InstanceGraph &instanceGraph,
+                      ArrayRef<InstanceGraphNode *> nodes) {
+  assert(nodes.size() > 0 && "an scc should have at least one node");
+  auto diag =
+      emitError(nodes.front()->getModule().getLoc(), "recursive instantiation");
+  llvm::SmallPtrSet<InstanceGraphNode *, 8> scc(nodes.begin(), nodes.end());
+  for (auto *node : nodes) {
+    for (auto *record : *node) {
+      auto *target = record->getTarget();
+      if (!scc.contains(target))
+        continue;
+      auto &note = diag.attachNote(record->getInstance().getLoc());
+      note << record->getParent()->getModule().getModuleName();
+      note << " instantiates "
+           << record->getTarget()->getModule().getModuleName() << " here";
+    }
+  }
+}
+
+namespace {
+class CheckRecursiveInstantiationPass
+    : public impl::CheckRecursiveInstantiationBase<
+          CheckRecursiveInstantiationPass> {
+public:
+  void runOnOperation() override {
+    auto &instanceGraph = getAnalysis<InstanceGraph>();
+    for (auto it = llvm::scc_begin(&instanceGraph),
+              end = llvm::scc_end(&instanceGraph);
+         it != end; ++it) {
+      if (it.hasCycle()) {
+        printPath(instanceGraph, *it);
+        signalPassFailure();
+      }
+    }
+    markAllAnalysesPreserved();
+  }
+};
+} // namespace
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createCheckRecursiveInstantiation() {
+  return std::make_unique<CheckRecursiveInstantiationPass>();
+}

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -26,6 +26,8 @@ using namespace circt;
 
 LogicalResult firtool::populatePreprocessTransforms(mlir::PassManager &pm,
                                                     const FirtoolOptions &opt) {
+  pm.nest<firrtl::CircuitOp>().addPass(
+      firrtl::createCheckRecursiveInstantiation());
   // Legalize away "open" aggregates to hw-only versions.
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerOpenAggsPass());
 

--- a/test/Dialect/FIRRTL/check-recursive-instantiation-errors.mlir
+++ b/test/Dialect/FIRRTL/check-recursive-instantiation-errors.mlir
@@ -1,0 +1,89 @@
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-check-recursive-instantiation))' %s --verify-diagnostics --split-input-file
+
+firrtl.circuit "SelfLoop0" {
+  // expected-error @below {{recursive instantiation}}
+  firrtl.module @SelfLoop0() {
+    // expected-note @below {{SelfLoop0 instantiates SelfLoop0 here}}
+    firrtl.instance inst @SelfLoop0()
+  }
+}
+
+// -----
+
+firrtl.circuit "SelfLoop1" {
+  // expected-error @below {{recursive instantiation}}
+  firrtl.module @SelfLoop1() {
+    // expected-note @below {{SelfLoop1 instantiates SelfLoop1 here}}
+    firrtl.instance inst @SelfLoop1()
+    // expected-note @below {{SelfLoop1 instantiates SelfLoop1 here}}
+    firrtl.instance inst @SelfLoop1()
+  }
+}
+
+// -----
+
+firrtl.circuit "TwoLoops" {
+  // expected-error @below {{recursive instantiation}}
+  firrtl.module @TwoLoops() {
+    // expected-note @below {{TwoLoops instantiates TwoLoops here}}
+    firrtl.instance inst @TwoLoops()
+    firrtl.instance inst @OtherModule()
+  }
+  // expected-error @below {{recursive instantiation}}
+  firrtl.module @OtherModule() {
+    // expected-note @below {{OtherModule instantiates OtherModule here}}
+    firrtl.instance inst @OtherModule()
+  }
+}
+
+// -----
+
+firrtl.circuit "MutualLoop" {
+  firrtl.module @MutualLoop() {
+    firrtl.instance a @A()
+  }
+  firrtl.module @A() {
+    // expected-note @below {{A instantiates B here}}
+    firrtl.instance b @B()
+  }
+  // expected-error @below {{recursive instantiation}}
+  firrtl.module @B() {
+    // expected-note @below {{B instantiates A here}}
+    firrtl.instance a @A()
+  }
+}
+
+// -----
+
+// Should disallow recursive class instantiation.
+firrtl.circuit "Classes" {
+  firrtl.module @Classes() {
+    firrtl.object @RecursiveClass()
+  }
+
+  // expected-error @below {{recursive instantiation}}
+  firrtl.class @RecursiveClass() {
+    // expected-note @below {{RecursiveClass instantiates RecursiveClass here}}
+    %0 = firrtl.object @RecursiveClass()
+  }
+}
+
+// -----
+
+firrtl.circuit "A" {
+  firrtl.module @A() {
+    // expected-note @below {{A instantiates B here}}
+    firrtl.instance b @B()
+  }
+  firrtl.module @B() {
+    // expected-note @below {{B instantiates C here}}
+    firrtl.instance c @C()
+    // expected-note @below {{B instantiates A here}}
+    firrtl.instance a @A()
+  }
+  // expected-error @below {{recursive instantiation}}
+  firrtl.module @C() {
+    // expected-note @below {{C instantiates B here}}
+    firrtl.instance b @B()
+  }
+}

--- a/test/Dialect/FIRRTL/check-recursive-instantiation.mlir
+++ b/test/Dialect/FIRRTL/check-recursive-instantiation.mlir
@@ -1,0 +1,6 @@
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-check-recursive-instantiation))' %s | FileCheck %s
+
+// CHECK-LABEL: firrtl.circuit "NoLoop"
+firrtl.circuit "NoLoop" {
+  firrtl.module @NoLoop() { }
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -286,16 +286,6 @@ firrtl.circuit "Foo" {
 // -----
 
 firrtl.circuit "Foo" {
-  // expected-note @+1 {{containing module declared here}}
-  firrtl.module @Foo() {
-    // expected-error @+1 {{'firrtl.instance' op is a recursive instantiation of its containing module}}
-    firrtl.instance "" @Foo()
-  }
-}
-
-// -----
-
-firrtl.circuit "Foo" {
   // expected-note @+1 {{original module declared here}}
   firrtl.module @Callee(in %arg0: !firrtl.uint<1>) { }
   firrtl.module @Foo() {


### PR DESCRIPTION
This adds a pass to FIRRTL to check for recursive module instantiation,
which is illegal because it corresponds to infinitely sized hardware.
This uses the path based strongly connected component (SCC) algorithm
with some extra book keeping to track if there was a loop in the current
SCC or not.  This is especially helpful to detect if a single-element
SCC actually contains a loop or not.

This does not use the upstream SCCIterator because we hope that this
version of the algorithm is faster by a constant factor, we don't need
to visit the SCCs in post-order, and hopefully faster handling of cycles
in single-element SCCs (which requires re-scanning all edges from a node
using the upstream version).