### PR TITLE
Replaced 'replicate' to correctly named 'replace' flags

### DIFF
--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -96,7 +96,7 @@ public:
     return allowAddingPortsOnPublic;
   }
   bool shouldConvertProbesToSignals() const { return probesToSignals; }
-  bool shouldReplicateSequentialMemories() const { return replSeqMem; }
+  bool shouldReplaceSequentialMemories() const { return replSeqMem; }
   bool shouldDisableOptimization() const { return disableOptimization; }
   bool shouldLowerMemories() const { return lowerMemories; }
   bool shouldDedup() const { return !noDedup; }

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -78,7 +78,7 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferWidthsPass());
 
   pm.nest<firrtl::CircuitOp>().addPass(
-      firrtl::createMemToRegOfVecPass(opt.shouldReplicateSequentialMemories(),
+      firrtl::createMemToRegOfVecPass(opt.shouldReplaceSequentialMemories(), 
                                       opt.shouldIgnoreReadEnableMemories()));
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferResetsPass());
@@ -161,7 +161,7 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         firrtl::createInferReadWritePass());
 
-  if (opt.shouldReplicateSequentialMemories())
+  if (opt.shouldReplaceSequentialMemories())
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerMemoryPass());
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createPrefixModulesPass());
@@ -176,7 +176,7 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createAddSeqMemPortsPass());
 
   pm.addPass(firrtl::createCreateSiFiveMetadataPass(
-      opt.shouldReplicateSequentialMemories(),
+      opt.shouldReplaceSequentialMemories(),
       opt.getReplaceSequentialMemoriesFile()));
 
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createExtractInstancesPass());
@@ -303,7 +303,7 @@ LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
            FirtoolOptions::RandomKind::Mem),
        /*disableRegRandomization=*/
        !opt.isRandomEnabled(FirtoolOptions::RandomKind::Reg),
-       /*replSeqMem=*/opt.shouldReplicateSequentialMemories(),
+       /*replSeqMem=*/opt.shouldReplaceSequentialMemories(),
        /*readEnableMode=*/opt.shouldIgnoreReadEnableMemories()
            ? seq::ReadEnableMode::Ignore
            : seq::ReadEnableMode::Undefined,

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -78,7 +78,7 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferWidthsPass());
 
   pm.nest<firrtl::CircuitOp>().addPass(
-      firrtl::createMemToRegOfVecPass(opt.shouldReplaceSequentialMemories(), 
+      firrtl::createMemToRegOfVecPass(opt.shouldReplaceSequentialMemories(),
                                       opt.shouldIgnoreReadEnableMemories()));
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInferResetsPass());


### PR DESCRIPTION
**Renamed and replaced shouldReplicateSequentialMemories to shouldReplaceSequentialMemories per issue #7384**

**MLIR Tests**:
[0/1] Running the MLIR regression tests

Testing Time: 53.62s

Total Discovered Tests: 2877
  Unsupported      :  506 (17.59%)
  Passed           : 2370 (82.38%)
  Expectedly Failed:    1 (0.03%)

**CIRCT Tests**:
[0/1] Running the CIRCT regression tests

Testing Time: 12.50s

Total Discovered Tests: 824
  Unsupported      :  21 (2.55%)
  Passed           : 797 (96.72%)
  Expectedly Failed:   6 (0.73%)

**CIRCT integration tests**:
[1/2] Running the CIRCT integration tests

Testing Time: 15.29s

Total Discovered Tests: 98
  Unsupported      : 63 (64.29%)
  Passed           : 34 (34.69%)
  Expectedly Failed:  1 (1.02%)