### PR TITLE
[FIRRTL] Tweak printing of layers to avoid extra space.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -445,7 +445,7 @@ def LayerOp : FIRRTLOp<
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = [{
-    $sym_name $convention attr-dict-with-keyword $body
+    $sym_name `` $convention attr-dict-with-keyword $body
   }];
 }
 


### PR DESCRIPTION
Before:

```mlir
firrtl.layer @A  inline
```

After:

```mlir
firrtl.layer @A inline
```