### PR TITLE
[ExportVerilog] Add a lowering option to fix up empty modules

### DIFF
--- a/docs/VerilogGeneration.md
+++ b/docs/VerilogGeneration.md
@@ -136,6 +136,9 @@ The current set of "lint warnings fix" Lowering Options is:
    collisions with Verilog keywords insensitively.  E.g., this will treat a
    variable called `WIRE` as a collision with the keyword and rename it to
    `WIRE_0` (or similar).  When set to `false`, then `WIRE` will not be renamed.
+ * `fixUpEmptyModules` (default=`false`). If true, then add a dummy wire to
+   empty modules since some vendor tools consider empty modules as a blackbox and
+   raise synthesis errors.
 
 ## Recommended `LoweringOptions` by Target
 

--- a/include/circt/Support/LoweringOptions.h
+++ b/include/circt/Support/LoweringOptions.h
@@ -166,6 +166,10 @@ struct LoweringOptions {
 
   /// If true, then update the the mlir to include output verilog locations.
   bool emitVerilogLocations = false;
+
+  /// If true, add a dummy wire to empty modules to prevent tools from regarding
+  /// the module as blackbox.
+  bool fixUpEmptyModules = false;
 };
 } // namespace circt
 

--- a/lib/Support/LoweringOptions.cpp
+++ b/lib/Support/LoweringOptions.cpp
@@ -121,6 +121,8 @@ void LoweringOptions::parse(StringRef text, ErrorHandlerT errorHandler) {
       caseInsensitiveKeywords = true;
     } else if (option == "emitVerilogLocations") {
       emitVerilogLocations = true;
+    } else if (option == "fixUpEmptyModules") {
+      fixUpEmptyModules = true;
     } else {
       errorHandler(llvm::Twine("unknown style option \'") + option + "\'");
       // We continue parsing options after a failure.
@@ -180,6 +182,8 @@ std::string LoweringOptions::toString() const {
     options += "caseInsensitiveKeywords,";
   if (emitVerilogLocations)
     options += "emitVerilogLocations,";
+  if (fixUpEmptyModules)
+    options += "fixUpEmptyModules,";
 
   // Remove a trailing comma if present.
   if (!options.empty()) {

--- a/test/Conversion/ExportVerilog/fixup-empty-modules.mlir
+++ b/test/Conversion/ExportVerilog/fixup-empty-modules.mlir
@@ -1,0 +1,19 @@
+// RUN: circt-opt --test-apply-lowering-options='options=fixUpEmptyModules' --export-verilog %s | FileCheck %s --check-prefixes=CHECK
+
+// CHECK-LABEL: module empty1
+hw.module @empty1() {
+    // CHECK-NEXT: /* This wire is added to avoid emitting empty modules. See `fixUpEmptyModules` lowering option in CIRCT. */ 
+    // CHECK-NEXT:  wire _GEN = 1'h1;
+}
+
+// CHECK-LABEL: module empty2
+hw.module @empty2(in %in: i1, in %in2: i32) {
+    // CHECK: /* This wire is added to avoid emitting empty modules. See `fixUpEmptyModules` lowering option in CIRCT. */ 
+    // CHECK-NEXT:  wire _GEN = 1'h1;
+}
+
+// CHECK-LABEL: module not_empty
+hw.module @not_empty(in %in: i1, out out: i1) {
+    // CHECK:  assign out = in;
+    hw.output %in : i1
+}


### PR DESCRIPTION
This commit adds a new lowering option to sanitize empty modules by creating a dummy wire in it.