### PR TITLE
[calyx] fix calyx canonicalization.

### DIFF
--- a/lib/Dialect/Calyx/CMakeLists.txt
+++ b/lib/Dialect/Calyx/CMakeLists.txt
@@ -21,6 +21,7 @@ add_circt_dialect_library(CIRCTCalyx
   CIRCTComb
   CIRCTSV
   CIRCTHW
+  CIRCTFSM
   MLIRArithDialect
   MLIRIR
   MLIRMemRefDialect

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -761,7 +761,7 @@ return WalkResult::interrupt();
                "The component currently does nothing. It needs to either have "
                "continuous assignments in the Wires region or control "
                "constructs in "
-               "the Control region.The Control region should involve ")
+               "the Control region. The Control region should contain at least one of ")
            << "'" << EnableOp::getOperationName() << "' , "
            << "'" << InvokeOp::getOperationName() << "' or "
            << "'" << fsm::MachineOp::getOperationName() << "'.";

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -769,7 +769,6 @@ LogicalResult ComponentOp::verify() {
            << "'" << EnableOp::getOperationName() << "' , "
            << "'" << InvokeOp::getOperationName() << "' or "
            << "'" << fsm::MachineOp::getOperationName() << "'.";
-
   return success();
 }
 

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -748,15 +748,11 @@ LogicalResult ComponentOp::verify() {
   // region, or continuous assignments.
   bool hasNoControlConstructs = true;
   getControlOp().walk<WalkOrder::PreOrder>([&](Operation *op) {
-    if (dyn_cast<EnableOp>(op))
-      hasNoControlConstructs = false;
-    if (dyn_cast<InvokeOp>(op))
-      hasNoControlConstructs = false;
-    if (dyn_cast<fsm::MachineOp>(op))
-      hasNoControlConstructs = false;
-    if (hasNoControlConstructs == false)
-      return WalkResult::interrupt();
-    return WalkResult::advance();
+if (isa<EnableOp, InvokeOp, fsm::MachineOp>(op)) {
+  hasNoControlConstructs = false;
+  return WalkResult::advance();
+}
+return WalkResult::interrupt();
   });
   bool hasNoAssignments =
       getWiresOp().getBodyBlock()->getOps<AssignOp>().empty();

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -748,11 +748,11 @@ LogicalResult ComponentOp::verify() {
   // region, or continuous assignments.
   bool hasNoControlConstructs = true;
   getControlOp().walk<WalkOrder::PreOrder>([&](Operation *op) {
-if (isa<EnableOp, InvokeOp, fsm::MachineOp>(op)) {
-  hasNoControlConstructs = false;
-  return WalkResult::advance();
-}
-return WalkResult::interrupt();
+    if (isa<EnableOp, InvokeOp, fsm::MachineOp>(op)) {
+      hasNoControlConstructs = false;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
   });
   bool hasNoAssignments =
       getWiresOp().getBodyBlock()->getOps<AssignOp>().empty();
@@ -761,7 +761,8 @@ return WalkResult::interrupt();
                "The component currently does nothing. It needs to either have "
                "continuous assignments in the Wires region or control "
                "constructs in "
-               "the Control region. The Control region should contain at least one of ")
+               "the Control region. The Control region should contain at least "
+               "one of ")
            << "'" << EnableOp::getOperationName() << "' , "
            << "'" << InvokeOp::getOperationName() << "' or "
            << "'" << fsm::MachineOp::getOperationName() << "'.";

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -2236,6 +2236,8 @@ template <typename OpTy>
 static std::optional<EnableOp> getLastEnableOp(OpTy parent) {
   static_assert(IsAny<OpTy, SeqOp, StaticSeqOp>(),
                 "Should be a StaticSeqOp or SeqOp.");
+  if (parent.getBodyBlock()->empty())
+    return std::nullopt;
   auto &lastOp = parent.getBodyBlock()->back();
   if (auto enableOp = dyn_cast<EnableOp>(lastOp))
     return enableOp;

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -760,9 +760,8 @@ LogicalResult ComponentOp::verify() {
     return emitOpError(
                "The component currently does nothing. It needs to either have "
                "continuous assignments in the Wires region or control "
-               "constructs in "
-               "the Control region. The Control region should contain at least "
-               "one of ")
+               "constructs in the Control region. The Control region "
+               "should contain at least one of ")
            << "'" << EnableOp::getOperationName() << "' , "
            << "'" << InvokeOp::getOperationName() << "' or "
            << "'" << fsm::MachineOp::getOperationName() << "'.";

--- a/test/Conversion/CalyxToFSM/materialize-errors.mlir
+++ b/test/Conversion/CalyxToFSM/materialize-errors.mlir
@@ -1,7 +1,8 @@
 // RUN: circt-opt -pass-pipeline='builtin.module(calyx.component(materialize-calyx-to-fsm))' -split-input-file -verify-diagnostics %s
-
 calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
+  %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i32, i1, i1, i1, i32, i1
   calyx.wires {
+    calyx.assign %r.clk = %clk : i1
   }
 // expected-error @+1 {{'calyx.control' op expected an 'fsm.machine' operation as the top-level operation within the control region of this component.}}
   calyx.control {
@@ -9,10 +10,7 @@ calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%don
   }
 }
 
-
-
 // -----
-
 calyx.component @main(%go: i1 {go}, %reset: i1 {reset}, %clk: i1 {clk}) -> (%done: i1 {done}) {
   calyx.wires {
   }

--- a/test/Dialect/Calyx/clk-insertion.mlir
+++ b/test/Dialect/Calyx/clk-insertion.mlir
@@ -6,7 +6,7 @@ module attributes {calyx.entrypoint = "main"} {
     calyx.wires { calyx.assign %done = %c1_1 : i1 }
     calyx.control {}
   }
-  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+  calyx.component @main(%in: i8, %go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%out: i8, %done: i1 {done}) {
     %c0.in, %c0.go, %c0.clk, %c0.reset, %c0.out, %c0.done = calyx.instance @c0 of @A : i8, i1, i1, i1, i8, i1
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
 // CHECK: calyx.wires {
@@ -16,6 +16,8 @@ module attributes {calyx.entrypoint = "main"} {
 // CHECK:   calyx.assign %r.clk = %clk : i1
 // CHECK: }
     calyx.wires {
+      calyx.assign %c0.in = %in : i8
+      calyx.assign %out = %c0.out : i8
     }
     calyx.control {
       calyx.seq { }

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -886,7 +886,7 @@ module attributes {calyx.entrypoint = "main"} {
 // -----
 
 module attributes {calyx.entrypoint = "main"} {
-  // expected-error @+1 {{'calyx.component' op The component currently does nothing. It needs to either have continuous assignments in the Wires region or control constructs in the Control region.}}
+  // expected-error @+1 {{'calyx.component' op The component currently does nothing. It needs to either have continuous assignments in the Wires region or control constructs in the Control region.The Control region should involve 'calyx.enable' , 'calyx.invoke' or 'fsm.machine'.}}
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %std_lt_0.left, %std_lt_0.right, %std_lt_0.out = calyx.std_lt @std_lt_0 : i32, i32, i1
     %c64_i32 = hw.constant 64 : i32
@@ -895,6 +895,30 @@ module attributes {calyx.entrypoint = "main"} {
     calyx.wires {
     }
     calyx.control {
+    }
+  }
+}
+
+// -----
+
+module attributes {calyx.entrypoint = "main"} {
+   // expected-error @+1 {{'calyx.component' op The component currently does nothing. It needs to either have continuous assignments in the Wires region or control constructs in the Control region.The Control region should involve 'calyx.enable' , 'calyx.invoke' or 'fsm.machine'.}}
+  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+    %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
+    %c1_1 = hw.constant 1 : i1
+    calyx.wires {
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.if %eq.out {
+          calyx.seq {
+          }
+        } else {
+          calyx.seq {
+          }
+        }
+      }
     }
   }
 }
@@ -988,7 +1012,7 @@ module attributes {calyx.entrypoint = "main"} {
 // -----
 
 module attributes {calyx.entrypoint = "main"} {
-  // expected-error @+1 {{'calyx.comb_component' op The component currently does nothing. It needs to either have continuous assignments in the Wires region or control constructs in the Control region.}}
+  // expected-error @+1 {{'calyx.comb_component' op The component currently does nothing. It needs to either have continuous assignments in the Wires region.}}
   calyx.comb_component @main() -> () {
     %std_lt_0.left, %std_lt_0.right, %std_lt_0.out = calyx.std_lt @std_lt_0 : i32, i32, i1
     %c64_i32 = hw.constant 64 : i32

--- a/test/Dialect/Calyx/errors.mlir
+++ b/test/Dialect/Calyx/errors.mlir
@@ -886,7 +886,7 @@ module attributes {calyx.entrypoint = "main"} {
 // -----
 
 module attributes {calyx.entrypoint = "main"} {
-  // expected-error @+1 {{'calyx.component' op The component currently does nothing. It needs to either have continuous assignments in the Wires region or control constructs in the Control region.The Control region should involve 'calyx.enable' , 'calyx.invoke' or 'fsm.machine'.}}
+  // expected-error @+1 {{'calyx.component' op The component currently does nothing. It needs to either have continuous assignments in the Wires region or control constructs in the Control region. The Control region should contain at least one of 'calyx.enable' , 'calyx.invoke' or 'fsm.machine'.}}
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %std_lt_0.left, %std_lt_0.right, %std_lt_0.out = calyx.std_lt @std_lt_0 : i32, i32, i1
     %c64_i32 = hw.constant 64 : i32
@@ -902,7 +902,7 @@ module attributes {calyx.entrypoint = "main"} {
 // -----
 
 module attributes {calyx.entrypoint = "main"} {
-   // expected-error @+1 {{'calyx.component' op The component currently does nothing. It needs to either have continuous assignments in the Wires region or control constructs in the Control region.The Control region should involve 'calyx.enable' , 'calyx.invoke' or 'fsm.machine'.}}
+   // expected-error @+1 {{'calyx.component' op The component currently does nothing. It needs to either have continuous assignments in the Wires region or control constructs in the Control region. The Control region should contain at least one of 'calyx.enable' , 'calyx.invoke' or 'fsm.machine'.}}
   calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
     %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
     %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
@@ -916,6 +916,30 @@ module attributes {calyx.entrypoint = "main"} {
           }
         } else {
           calyx.seq {
+          }
+        }
+      }
+    }
+  }
+}
+
+// -----
+
+module attributes {calyx.entrypoint = "main"} {
+   // expected-error @+1 {{'calyx.component' op The component currently does nothing. It needs to either have continuous assignments in the Wires region or control constructs in the Control region. The Control region should contain at least one of 'calyx.enable' , 'calyx.invoke' or 'fsm.machine'.}}
+  calyx.component @main(%go: i1 {go}, %clk: i1 {clk}, %reset: i1 {reset}) -> (%done: i1 {done}) {
+    %r.in, %r.write_en, %r.clk, %r.reset, %r.out, %r.done = calyx.register @r : i1, i1, i1, i1, i1, i1
+    %eq.left, %eq.right, %eq.out = calyx.std_eq @eq : i1, i1, i1
+    %c1_1 = hw.constant 1 : i1
+    calyx.wires {
+    }
+    calyx.control {
+      calyx.par {
+        calyx.if %eq.out {
+          calyx.par {
+          }
+        } else {
+          calyx.par {
           }
         }
       }


### PR DESCRIPTION
See [issue](https://github.com/llvm/circt/issues/7051).
Honestly, I saw this bug a few months ago and I think I fixed it, just like this PR did. But I don't think it was enough.
```
test.mlir:2:3: note: see current operation: 
"calyx.component"() ({
^bb0(%arg0: i1, %arg1: i1, %arg2: i1, %arg3: i1):
  %0:6 = "calyx.register"() {sym_name = "r"} : () -> (i1, i1, i1, i1, i1, i1)
  "calyx.wires"() ({
  ^bb0:
  }) : () -> ()
  "calyx.control"() ({
  ^bb0:
  }) : () -> ()
}) {function_type = (i1, i1, i1, i1) -> (), portAttributes = [{go}, {clk}, {reset}, {done}], portDirections = -8 : i4, portNames = ["go", "clk", "reset", "done"], sym_name = "main"} : () -> ()
```
The problem is as I said in the issue, solved he still reports an error because now `calyx.control` is empty after `-canonicalize`.
So a few months ago I tried to include stricter restrictions, but I didn't have too good an idea.
Now my idea, when checking calyx.control, that op must have `calyx.enable,calyx.invoke alive fsm.machine` present. but it also causes other problems.
On the one hand, I want to discuss it, and on the other hand, I think this PR makes sense.There is no test file because there are no examples of errors reported after -canonicalise in the existing test file.