### PR TITLE
[SimToSV] Add include guards to DPI import

### DIFF
--- a/test/Conversion/SimToSV/dpi.mlir
+++ b/test/Conversion/SimToSV/dpi.mlir
@@ -3,8 +3,13 @@
 
 sim.func.dpi @dpi(out arg0: i1, in %arg1: i1, out arg2: i1)
 // CHECK:       sv.func private @dpi(out arg0 : i1, in %arg1 : i1, out arg2 : i1)
+// CHECK-NEXT:  sv.macro.decl @__CIRCT_DPI_IMPORT_DPI
 // CHECK-NEXT:  emit.fragment @dpi_dpi_import_fragument {
-// CHECK-NEXT:    sv.func.dpi.import @dpi
+// CHECK-NEXT:    sv.ifdef @__CIRCT_DPI_IMPORT_DPI {
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      sv.func.dpi.import @dpi
+// CHECK-NEXT:      sv.macro.def @__CIRCT_DPI_IMPORT_DPI ""
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
 // VERILOG:      import "DPI-C" context function void dpi(

--- a/test/firtool/dpi.fir
+++ b/test/firtool/dpi.fir
@@ -2,23 +2,33 @@
 
 FIRRTL version 4.0.0
 circuit DPI:
-; CHECK-LABEL: import "DPI-C" context function void clocked_result(
+; CHECK-LABEL: `ifndef __CIRCT_DPI_IMPORT_CLOCKED_RESULT
+; CHECK-NEXT: import "DPI-C" context function void clocked_result(
 ; CHECK-NEXT:   input  byte foo,
 ; CHECK-NEXT:               bar,
 ; CHECK-NEXT:   output byte baz
 ; CHECK-NEXT: );
+; CHECK:      `define __CIRCT_DPI_IMPORT_CLOCKED_RESULT
+; CHECK-NEXT: `endif
 
-; CHECK-LABEL: import "DPI-C" context function void clocked_void(
+; CHECK-LABEL: `ifndef __CIRCT_DPI_IMPORT_CLOCKED_VOID
+; CHECK-NEXT: import "DPI-C" context function void clocked_void(
 ; CHECK-NEXT:   input byte in_0,
 ; CHECK-NEXT:              in_1,
 ; CHECK-NEXT:              in_2[]
 ; CHECK-NEXT: );
+; CHECK:      `define __CIRCT_DPI_IMPORT_CLOCKED_VOID
+; CHECK-NEXT: `endif
 
-; CHECK-LABEL: import "DPI-C" context function void unclocked_result(
+
+; CHECK-LABEL: `ifndef __CIRCT_DPI_IMPORT_UNCLOCKED_RESULT
+; CHECK-NEXT: import "DPI-C" context function void unclocked_result(
 ; CHECK-NEXT:   input  byte in_0,
 ; CHECK-NEXT:                    in_1,
 ; CHECK-NEXT:   output byte out_0
 ; CHECK-NEXT: );
+; CHECK:      `define __CIRCT_DPI_IMPORT_UNCLOCKED_RESULT
+; CHECK-NEXT: `endif
 
 ; CHECK-LABEL: module DPI(
 ; CHECK:        logic [7:0] [[TMP:_.+]];


### PR DESCRIPTION
This adds include guards `__CIRCT_DPI_IMPORT_*` to DPI import statements generated in SimToSV. 

Fix https://github.com/llvm/circt/issues/7458.