### PR TITLE
[ESI][Runtime] Poll method and optional service thread polling

### DIFF
--- a/integration_test/Dialect/ESI/runtime/loopback.mlir.py
+++ b/integration_test/Dialect/ESI/runtime/loopback.mlir.py
@@ -94,4 +94,7 @@ result: List[int] = result_chan.read()
 print(f"result: {result}")
 if platform != "trace":
   assert result == [-21, -22]
+
+acc = None
+
 print("PASS")

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
@@ -74,11 +74,11 @@ public:
 
 /// Abstract class representing a connection to an accelerator. Actual
 /// connections (e.g. to a co-simulation or actual device) are implemented by
-/// subclasses.
+/// subclasses. No methods in here are thread safe.
 class AcceleratorConnection {
 public:
   AcceleratorConnection(Context &ctxt);
-  virtual ~AcceleratorConnection() = default;
+  virtual ~AcceleratorConnection();
   Context &getCtxt() const { return ctxt; }
 
   /// Disconnect from the accelerator cleanly.
@@ -89,7 +89,12 @@ public:
   virtual std::map<std::string, ChannelPort &>
   requestChannelsFor(AppIDPath, const BundleType *) = 0;
 
-  AcceleratorServiceThread *getServiceThread() { return serviceThread.get(); }
+  /// Return a pointer to the accelerator 'service' thread (or threads). If the
+  /// thread(s) are not running, they will be started when this method is
+  /// called. `std::thread` is used. If users don't want the runtime to spin up
+  /// threads, don't call this method. `AcceleratorServiceThread` is owned by
+  /// AcceleratorConnection and governed by the lifetime of the this object.
+  AcceleratorServiceThread *getServiceThread();
 
   using Service = services::Service;
   /// Get a typed reference to a particular service type. Caller does *not* take
@@ -108,6 +113,10 @@ public:
                               std::string implName = {},
                               ServiceImplDetails details = {},
                               HWClientDetails clients = {});
+
+  /// Assume ownership of an accelerator object. Ties the lifetime of the
+  /// accelerator to this connection. Returns a raw pointer to the object.
+  Accelerator *takeOwnership(std::unique_ptr<Accelerator> accel);
 
 protected:
   /// Called by `getServiceImpl` exclusively. It wraps the pointer returned by
@@ -128,6 +137,10 @@ private:
   std::map<ServiceCacheKey, std::unique_ptr<Service>> serviceCache;
 
   std::unique_ptr<AcceleratorServiceThread> serviceThread;
+
+  /// List of accelerator objects owned by this connection. These are destroyed
+  /// when the connection dies or is shutdown.
+  std::vector<std::unique_ptr<Accelerator>> ownedAccelerators;
 };
 
 namespace registry {
@@ -172,6 +185,9 @@ public:
   void
   addListener(std::initializer_list<ReadChannelPort *> listenPorts,
               std::function<void(ReadChannelPort *, MessageData)> callback);
+
+  /// Poll this module.
+  void addPoll(HWModule &module);
 
   /// Instruct the service thread to stop running.
   void stop();

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Design.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Design.h
@@ -77,6 +77,11 @@ public:
     return portIndex;
   }
 
+  /// Master poll method. Calls the `poll` method on all locally owned ports and
+  /// the master `poll` method on all of the children. Returns true if any of
+  /// the `poll` calls returns true.
+  bool poll();
+
 protected:
   const std::optional<ModuleInfo> info;
   const std::vector<std::unique_ptr<Instance>> children;

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Manifest.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Manifest.h
@@ -48,9 +48,10 @@ public:
   // Modules which have designer specified metadata.
   std::vector<ModuleInfo> getModuleInfos() const;
 
-  // Build a dynamic design hierarchy from the manifest.
-  std::unique_ptr<Accelerator>
-  buildAccelerator(AcceleratorConnection &acc) const;
+  // Build a dynamic design hierarchy from the manifest. The
+  // AcceleratorConnection owns the returned pointer so its lifetime is
+  // determined by the connection.
+  Accelerator *buildAccelerator(AcceleratorConnection &acc) const;
 
   /// The Type Table is an ordered list of types. The offset can be used to
   /// compactly and uniquely within a design. It does not include all of the

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -42,14 +42,14 @@ public:
   virtual void disconnect() = 0;
   virtual bool isConnected() const = 0;
 
-  /// Poll for incoming data. Returns true if data was read into a buffer as a
-  /// result of the poll. Calling the call back could (will) also happen in that
-  /// case. Some backends need this to be called periodically. In the usual
-  /// case, this will be called by a background thread, but the ESI runtime does
-  /// not want to assume that the host processes use standard threads. If the
-  /// user wants to provide their own threads, they need to call this on each
-  /// port occasionally. This is also called from the 'master' poll method in
-  /// the Accelerator class.
+  /// Poll for incoming data. Returns true if data was read or written into a
+  /// buffer as a result of the poll. Calling the call back could (will) also
+  /// happen in that case. Some backends need this to be called periodically. In
+  /// the usual case, this will be called by a background thread, but the ESI
+  /// runtime does not want to assume that the host processes use standard
+  /// threads. If the user wants to provide their own threads, they need to call
+  /// this on each port occasionally. This is also called from the 'master' poll
+  /// method in the Accelerator class.
   bool poll() {
     if (isConnected())
       return pollImpl();

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -33,20 +33,37 @@ namespace esi {
 class ChannelPort {
 public:
   ChannelPort(const Type *type) : type(type) {}
-  virtual ~ChannelPort() { disconnect(); }
+  virtual ~ChannelPort() {}
 
   /// Set up a connection to the accelerator. The buffer size is optional and
   /// should be considered merely a hint. Individual implementations use it
   /// however they like. The unit is number of messages of the port type.
-  virtual void connect(std::optional<unsigned> bufferSize = std::nullopt) {
-    connectImpl(bufferSize);
+  virtual void connect(std::optional<unsigned> bufferSize = std::nullopt) = 0;
+  virtual void disconnect() = 0;
+  virtual bool isConnected() const = 0;
+
+  /// Poll for incoming data. Returns true if data was read into a buffer as a
+  /// result of the poll. Calling the call back could (will) also happen in that
+  /// case. Some backends need this to be called periodically. In the usual
+  /// case, this will be called by a background thread, but the ESI runtime does
+  /// not want to assume that the host processes use standard threads. If the
+  /// user wants to provide their own threads, they need to call this on each
+  /// port occasionally. This is also called from the 'master' poll method in
+  /// the Accelerator class.
+  bool poll() {
+    if (isConnected())
+      return pollImpl();
+    return false;
   }
-  virtual void disconnect() {}
 
   const Type *getType() const { return type; }
 
-private:
+protected:
   const Type *type;
+
+  /// Method called by poll() to actually poll the channel if the channel is
+  /// connected.
+  virtual bool pollImpl() { return false; }
 
   /// Called by all connect methods to let backends initiate the underlying
   /// connections.
@@ -58,8 +75,19 @@ class WriteChannelPort : public ChannelPort {
 public:
   using ChannelPort::ChannelPort;
 
+  virtual void
+  connect(std::optional<unsigned> bufferSize = std::nullopt) override {
+    connectImpl(bufferSize);
+    connected = true;
+  }
+  virtual void disconnect() override { connected = false; }
+  virtual bool isConnected() const override { return connected; }
+
   /// A very basic write API. Will likely change for performance reasons.
   virtual void write(const MessageData &) = 0;
+
+private:
+  volatile bool connected = false;
 };
 
 /// A ChannelPort which reads data from the accelerator. It has two modes:
@@ -72,6 +100,9 @@ public:
   ReadChannelPort(const Type *type)
       : ChannelPort(type), mode(Mode::Disconnected) {}
   virtual void disconnect() override { mode = Mode::Disconnected; }
+  virtual bool isConnected() const override {
+    return mode != Mode::Disconnected;
+  }
 
   //===--------------------------------------------------------------------===//
   // Callback mode: To use a callback, connect with a callback function which
@@ -121,7 +152,7 @@ public:
 protected:
   /// Indicates the current mode of the channel.
   enum Mode { Disconnected, Callback, Polling };
-  Mode mode;
+  volatile Mode mode;
 
   /// Backends call this callback when new data is available.
   std::function<bool(MessageData)> callback;
@@ -176,6 +207,15 @@ public:
   template <typename T>
   T *getAs() const {
     return const_cast<T *>(dynamic_cast<const T *>(this));
+  }
+
+  /// Calls `poll` on all channels in the bundle and returns true if any of them
+  /// returned true.
+  bool poll() {
+    bool result = false;
+    for (auto &channel : channels)
+      result |= channel.second.poll();
+    return result;
   }
 
 private:

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Trace.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Trace.h
@@ -52,6 +52,7 @@ public:
   ///   is opened for writing. For 'Read' mode, this file is opened for reading.
   TraceAccelerator(Context &, Mode mode, std::filesystem::path manifestJson,
                    std::filesystem::path traceFile);
+  ~TraceAccelerator() override;
 
   /// Parse the connection string and instantiate the accelerator. Format is:
   /// "<mode>:<manifest path>[:<traceFile>]".

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Xrt.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Xrt.h
@@ -33,6 +33,7 @@ public:
   struct Impl;
 
   XrtAccelerator(Context &, std::string xclbin, std::string kernelName);
+  ~XrtAccelerator();
   static std::unique_ptr<AcceleratorConnection>
   connect(Context &, std::string connectionString);
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/Design.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Design.cpp
@@ -47,4 +47,13 @@ HWModule::HWModule(std::optional<ModuleInfo> info,
       childIndex(buildIndex(this->children)), services(services),
       ports(std::move(ports)), portIndex(buildIndex(this->ports)) {}
 
+bool HWModule::poll() {
+  bool result = false;
+  for (auto &port : ports)
+    result |= port->poll();
+  for (auto &child : children)
+    result |= child->poll();
+  return result;
+}
+
 } // namespace esi

--- a/lib/Dialect/ESI/runtime/cpp/lib/Manifest.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Manifest.cpp
@@ -534,9 +534,8 @@ std::vector<ModuleInfo> Manifest::getModuleInfos() const {
   return ret;
 }
 
-std::unique_ptr<Accelerator>
-Manifest::buildAccelerator(AcceleratorConnection &acc) const {
-  return impl->buildAccelerator(acc);
+Accelerator *Manifest::buildAccelerator(AcceleratorConnection &acc) const {
+  return acc.takeOwnership(impl->buildAccelerator(acc));
 }
 
 const std::vector<const Type *> &Manifest::getTypeTable() const {

--- a/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
@@ -47,7 +47,7 @@ void ReadChannelPort::connect(std::function<bool(MessageData)> callback,
     throw std::runtime_error("Channel already connected");
   mode = Mode::Callback;
   this->callback = callback;
-  ChannelPort::connect(bufferSize);
+  connectImpl(bufferSize);
 }
 
 void ReadChannelPort::connect(std::optional<unsigned> bufferSize) {
@@ -71,7 +71,7 @@ void ReadChannelPort::connect(std::optional<unsigned> bufferSize) {
     }
     return true;
   };
-  ChannelPort::connect(bufferSize);
+  connectImpl(bufferSize);
 }
 
 std::future<MessageData> ReadChannelPort::readAsync() {

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -126,6 +126,7 @@ CosimAccelerator::CosimAccelerator(Context &ctxt, std::string hostname,
   rpcClient = new StubContainer(ChannelServer::NewStub(channel));
 }
 CosimAccelerator::~CosimAccelerator() {
+  disconnect();
   if (rpcClient)
     delete rpcClient;
   channels.clear();
@@ -418,23 +419,23 @@ public:
       this->size = size;
     }
     virtual ~CosimHostMemRegion() { free(ptr); }
-    virtual void *getPtr() const { return ptr; }
-    virtual std::size_t getSize() const { return size; }
+    virtual void *getPtr() const override { return ptr; }
+    virtual std::size_t getSize() const override { return size; }
 
   private:
     void *ptr;
     std::size_t size;
   };
 
-  virtual std::unique_ptr<HostMemRegion> allocate(std::size_t size,
-                                                  HostMem::Options opts) const {
+  virtual std::unique_ptr<HostMemRegion>
+  allocate(std::size_t size, HostMem::Options opts) const override {
     return std::unique_ptr<HostMemRegion>(new CosimHostMemRegion(size));
   }
   virtual bool mapMemory(void *ptr, std::size_t size,
-                         HostMem::Options opts) const {
+                         HostMem::Options opts) const override {
     return true;
   }
-  virtual void unmapMemory(void *ptr) const {}
+  virtual void unmapMemory(void *ptr) const override {}
 };
 
 } // namespace

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
@@ -135,6 +135,7 @@ TraceAccelerator::TraceAccelerator(Context &ctxt, Mode mode,
     : AcceleratorConnection(ctxt) {
   impl = std::make_unique<Impl>(mode, manifestJson, traceFile);
 }
+TraceAccelerator::~TraceAccelerator() { disconnect(); }
 
 Service *TraceAccelerator::createService(Service::Type svcType,
                                          AppIDPath idPath, std::string implName,
@@ -197,22 +198,7 @@ public:
       : ReadChannelPort(type) {}
   ~ReadTraceChannelPort() { disconnect(); }
 
-  void disconnect() override {
-    ReadChannelPort::disconnect();
-    if (!dataPushThread.joinable())
-      return;
-    shutdown = true;
-    shutdownCV.notify_all();
-    dataPushThread.join();
-  }
-
 private:
-  void connectImpl(std::optional<unsigned> bufferSize) override {
-    assert(!dataPushThread.joinable() && "already connected");
-    shutdown = false;
-    dataPushThread = std::thread(&ReadTraceChannelPort::dataPushLoop, this);
-  }
-
   MessageData genMessage() {
     std::ptrdiff_t numBits = getType()->getBitWidth();
     if (numBits < 0)
@@ -227,19 +213,7 @@ private:
     return MessageData(bytes);
   }
 
-  void dataPushLoop() {
-    std::mutex m;
-    std::unique_lock<std::mutex> lock(m);
-    while (!shutdown) {
-      shutdownCV.wait_for(lock, std::chrono::milliseconds(100));
-      while (this->callback(genMessage()))
-        shutdownCV.wait_for(lock, std::chrono::milliseconds(10));
-    }
-  }
-
-  std::thread dataPushThread;
-  std::condition_variable shutdownCV;
-  std::atomic<bool> shutdown;
+  bool pollImpl() override { return callback(genMessage()); }
 };
 } // namespace
 
@@ -289,8 +263,8 @@ public:
       impl.write("HostMem") << "free " << ptr << std::endl;
       free(ptr);
     }
-    virtual void *getPtr() const { return ptr; }
-    virtual std::size_t getSize() const { return size; }
+    virtual void *getPtr() const override { return ptr; }
+    virtual std::size_t getSize() const override { return size; }
 
   private:
     void *ptr;
@@ -298,8 +272,8 @@ public:
     TraceAccelerator::Impl &impl;
   };
 
-  virtual std::unique_ptr<HostMemRegion> allocate(std::size_t size,
-                                                  HostMem::Options opts) const {
+  virtual std::unique_ptr<HostMemRegion>
+  allocate(std::size_t size, HostMem::Options opts) const override {
     auto ret =
         std::unique_ptr<HostMemRegion>(new TraceHostMemRegion(size, impl));
     impl.write("HostMem 0x")
@@ -309,14 +283,14 @@ public:
     return ret;
   }
   virtual bool mapMemory(void *ptr, std::size_t size,
-                         HostMem::Options opts) const {
+                         HostMem::Options opts) const override {
     impl.write("HostMem") << "map 0x" << ptr << " size " << size
                           << " bytes. Writeable: " << opts.writeable
                           << ", useLargePages: " << opts.useLargePages
                           << std::endl;
     return true;
   }
-  virtual void unmapMemory(void *ptr) const {
+  virtual void unmapMemory(void *ptr) const override {
     impl.write("HostMem") << "unmap 0x" << ptr << std::endl;
   }
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Xrt.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Xrt.cpp
@@ -78,6 +78,7 @@ XrtAccelerator::XrtAccelerator(Context &ctxt, std::string xclbin,
     : AcceleratorConnection(ctxt) {
   impl = make_unique<Impl>(xclbin, device_id);
 }
+XrtAccelerator::~XrtAccelerator() { disconnect(); }
 
 namespace {
 class XrtMMIO : public MMIO {

--- a/lib/Dialect/ESI/runtime/cpp/tools/esiquery.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esiquery.cpp
@@ -121,10 +121,10 @@ void printInstance(std::ostream &os, const HWModule *d,
 void printHier(std::ostream &os, AcceleratorConnection &acc) {
   Manifest manifest(acc.getCtxt(),
                     acc.getService<services::SysInfo>()->getJsonManifest());
-  std::unique_ptr<Accelerator> design = manifest.buildAccelerator(acc);
+  Accelerator *design = manifest.buildAccelerator(acc);
   os << "********************************" << std::endl;
   os << "* Design hierarchy" << std::endl;
   os << "********************************" << std::endl;
   os << std::endl;
-  printInstance(os, design.get());
+  printInstance(os, design);
 }

--- a/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
@@ -50,9 +50,10 @@ int main(int argc, const char *argv[]) {
     std::unique_ptr<AcceleratorConnection> acc = ctxt.connect(backend, conn);
     const auto &info = *acc->getService<services::SysInfo>();
     Manifest manifest(ctxt, info.getJsonManifest());
-    std::unique_ptr<Accelerator> accel = manifest.buildAccelerator(*acc);
+    Accelerator *accel = manifest.buildAccelerator(*acc);
+    acc->getServiceThread()->addPoll(*accel);
 
-    registerCallbacks(accel.get());
+    registerCallbacks(accel);
 
     if (cmd == "loop") {
       while (true) {

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
@@ -270,8 +270,14 @@ PYBIND11_MODULE(esiCppAccel, m) {
   py::class_<Manifest>(m, "Manifest")
       .def(py::init<Context &, std::string>())
       .def_property_readonly("api_version", &Manifest::getApiVersion)
-      .def("build_accelerator", &Manifest::buildAccelerator,
-           py::return_value_policy::take_ownership)
+      .def(
+          "build_accelerator",
+          [&](Manifest &m, AcceleratorConnection &conn) {
+            auto acc = m.buildAccelerator(conn);
+            conn.getServiceThread()->addPoll(*acc);
+            return acc;
+          },
+          py::return_value_policy::reference)
       .def_property_readonly("type_table", &Manifest::getTypeTable)
       .def_property_readonly("module_infos", &Manifest::getModuleInfos);
 }


### PR DESCRIPTION
Add a poll method to ports, a master poll method to the Accelerator, and the ability to poll from the service thread. Also, only spin up the service thread if it's requested.

The service thread polling (in particular) required some ownership changes: Accelerator objects now belong to the AcceleratorConnection so that the ports aren't destructed before the service thread gets shutdown (which causes an invalid memory access). This particular binding isn't ideal, is brittle, and will be an issue for anything doing the polling. Resolving #7457 should mitigate this issue.

Backends are now _required_ to call `disconnect` in their destructor.