### PR TITLE
[Moore] Add FVIntegerAttr

### DIFF
--- a/include/circt/Dialect/Moore/CMakeLists.txt
+++ b/include/circt/Dialect/Moore/CMakeLists.txt
@@ -9,10 +9,8 @@ mlir_tablegen(MooreEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(CIRCTMooreEnumsIncGen)
 add_dependencies(circt-headers CIRCTMooreEnumsIncGen)
 
-mlir_tablegen(MooreAttributes.h.inc -gen-attrdef-decls
-  -attrdefs-dialect MooreDialect)
-mlir_tablegen(MooreAttributes.cpp.inc -gen-attrdef-defs
-  -attrdefs-dialect MooreDialect)
+mlir_tablegen(MooreAttributes.h.inc -gen-attrdef-decls -attrdefs-dialect moore)
+mlir_tablegen(MooreAttributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect moore)
 add_public_tablegen_target(CIRCTMooreAttributesIncGen)
 add_dependencies(circt-headers CIRCTMooreAttributesIncGen)
 

--- a/include/circt/Dialect/Moore/Moore.td
+++ b/include/circt/Dialect/Moore/Moore.td
@@ -15,6 +15,7 @@
 
 include "circt/Dialect/Moore/MooreDialect.td"
 include "circt/Dialect/Moore/MooreTypes.td"
+include "circt/Dialect/Moore/MooreAttributes.td"
 include "circt/Dialect/Moore/MooreOps.td"
 
 #endif // CIRCT_DIALECT_MOORE_MOORE

--- a/include/circt/Dialect/Moore/MooreAttributes.h
+++ b/include/circt/Dialect/Moore/MooreAttributes.h
@@ -1,0 +1,25 @@
+//===- MooreAttributes.h - Declare Moore dialect attributes ------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the attributes for the Moore dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_MOORE_MOOREATTRIBUTES_H
+#define CIRCT_DIALECT_MOORE_MOOREATTRIBUTES_H
+
+#include "circt/Support/FVInt.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+// Include generated attributes.
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/Moore/MooreAttributes.h.inc"
+
+#endif // CIRCT_DIALECT_MOORE_MOOREATTRIBUTES_H

--- a/include/circt/Dialect/Moore/MooreAttributes.td
+++ b/include/circt/Dialect/Moore/MooreAttributes.td
@@ -1,0 +1,22 @@
+//===- MooreAttributes.td - Moore attribute definitions ----*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_MOORE_MOOREATTRIBUTES
+#define CIRCT_DIALECT_MOORE_MOOREATTRIBUTES
+
+include "circt/Dialect/Moore/MooreDialect.td"
+include "mlir/IR/AttrTypeBase.td"
+
+def FVIntegerAttr : AttrDef<MooreDialect, "FVInteger"> {
+  let mnemonic = "fvint";
+  let summary = "An attribute containing a four-valued integer";
+  let parameters = (ins "FVInt":$value);
+  let hasCustomAssemblyFormat = 1;
+}
+
+#endif // CIRCT_DIALECT_MOORE_MOOREATTRIBUTES

--- a/include/circt/Dialect/Moore/MooreDialect.td
+++ b/include/circt/Dialect/Moore/MooreDialect.td
@@ -29,11 +29,14 @@ def MooreDialect : Dialect {
   let extraClassDeclaration = [{
     /// Register all Moore types.
     void registerTypes();
+    /// Register all Moore attributes.
+    void registerAttributes();
 
     /// Type parsing and printing.
     Type parseType(DialectAsmParser &parser) const override;
     void printType(Type, DialectAsmPrinter &) const override;
   }];
+  let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 0;
   let dependentDialects = ["hw::HWDialect"];
 }

--- a/include/circt/Support/FVInt.h
+++ b/include/circt/Support/FVInt.h
@@ -644,6 +644,33 @@ inline raw_ostream &operator<<(raw_ostream &os, const FVInt &value) {
 
 llvm::hash_code hash_value(const FVInt &a);
 
+/// Print a four-valued integer usign an `AsmPrinter`. This produces the
+/// following output formats:
+///
+/// - Decimal notation if the integer has no unknown bits. The sign bit is used
+///   to determine whether the value is printed as negative number or not.
+/// - Hexadecimal notation with a leading `h` if the integer the bits in each
+///   hex digit are either all known, all X, or all Z.
+/// - Binary notation with a leading `b` in all other cases.
+void printFVInt(AsmPrinter &p, const FVInt &value);
+
+/// Parse a four-valued integer using an `AsmParser`. This accepts the following
+/// formats:
+///
+/// - `42`/`-42`: positive or negative integer in decimal notation. The sign bit
+///   of the result indicates whether the value was negative. Cannot contain
+///   unknown X or Z digits.
+/// - `h123456789ABCDEF0XZ`: signless integer in hexadecimal notation. Can
+///   contain unknown X or Z digits.
+/// - `b10XZ`: signless integer in binary notation. Can contain unknown X or Z
+///   digits.
+///
+/// The result has enough bits to fully represent the parsed integer, and to
+/// have the sign bit encode whether the integer was written as a negative
+/// number in the input. The result's bit width may be larger than the minimum
+/// number of bits required to represent its value.
+ParseResult parseFVInt(AsmParser &p, FVInt &result);
+
 } // namespace circt
 
 #endif // CIRCT_SUPPORT_FVINT_H

--- a/lib/Dialect/Moore/CMakeLists.txt
+++ b/lib/Dialect/Moore/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_dialect_library(CIRCTMoore
+  MooreAttributes.cpp
   MooreDialect.cpp
   MooreOps.cpp
   MooreTypes.cpp

--- a/lib/Dialect/Moore/MooreAttributes.cpp
+++ b/lib/Dialect/Moore/MooreAttributes.cpp
@@ -1,0 +1,68 @@
+//===- MooreAttributes.cpp - Implement the Moore attributes ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the Moore dialect attributes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Moore/MooreAttributes.h"
+#include "circt/Dialect/Moore/MooreDialect.h"
+#include "circt/Dialect/Moore/MooreTypes.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace circt::moore;
+using mlir::AsmParser;
+using mlir::AsmPrinter;
+
+//===----------------------------------------------------------------------===//
+// FVIntegerAttr
+//===----------------------------------------------------------------------===//
+
+Attribute FVIntegerAttr::parse(AsmParser &p, Type) {
+  // Parse the value and width specifier.
+  FVInt value;
+  unsigned width;
+  llvm::SMLoc widthLoc;
+  if (p.parseLess() || parseFVInt(p, value) || p.parseColon() ||
+      p.getCurrentLocation(&widthLoc) || p.parseInteger(width) ||
+      p.parseGreater())
+    return {};
+
+  // Make sure the integer fits into the requested number of bits.
+  unsigned neededBits =
+      value.isNegative() ? value.getSignificantBits() : value.getActiveBits();
+  if (width < neededBits) {
+    p.emitError(widthLoc) << "integer literal requires at least " << neededBits
+                          << " bits, but attribute specifies only " << width;
+    return {};
+  }
+
+  return FVIntegerAttr::get(p.getContext(), value.sextOrTrunc(width));
+}
+
+void FVIntegerAttr::print(AsmPrinter &p) const {
+  p << "<";
+  printFVInt(p, getValue());
+  p << " : " << getValue().getBitWidth() << ">";
+}
+
+//===----------------------------------------------------------------------===//
+// Generated logic
+//===----------------------------------------------------------------------===//
+
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/Moore/MooreAttributes.cpp.inc"
+
+void MooreDialect::registerAttributes() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "circt/Dialect/Moore/MooreAttributes.cpp.inc"
+      >();
+}

--- a/lib/Dialect/Moore/MooreDialect.cpp
+++ b/lib/Dialect/Moore/MooreDialect.cpp
@@ -21,8 +21,9 @@ using namespace circt::moore;
 //===----------------------------------------------------------------------===//
 
 void MooreDialect::initialize() {
-  // Register types.
+  // Register types and attributes.
   registerTypes();
+  registerAttributes();
 
   // Register operations.
   addOperations<

--- a/test/Dialect/Moore/attrs-error.mlir
+++ b/test/Dialect/Moore/attrs-error.mlir
@@ -1,0 +1,4 @@
+// RUN: circt-opt --verify-diagnostics --split-input-file %s
+
+// expected-error @below {{integer literal requires at least 6 bits, but attribute specifies only 3}}
+hw.constant false {foo = #moore.fvint<42 : 3>}

--- a/test/Dialect/Moore/attrs.mlir
+++ b/test/Dialect/Moore/attrs.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt %s | circt-opt | FileCheck %s
+
+// CHECK: #moore.fvint<42 : 32>
+hw.constant false {foo = #moore.fvint<42 : 32>}
+// CHECK: #moore.fvint<-42 : 32>
+hw.constant false {foo = #moore.fvint<-42 : 32>}
+// CHECK: #moore.fvint<1234567890123456789012345678901234567890 : 131>
+hw.constant false {foo = #moore.fvint<1234567890123456789012345678901234567890 : 131>}
+// CHECK: #moore.fvint<hABCDEFXZ0123456789 : 72>
+hw.constant false {foo = #moore.fvint<hABCDEFXZ0123456789 : 72>}
+// CHECK: #moore.fvint<b1010XZ01 : 8>
+hw.constant false {foo = #moore.fvint<b1010XZ01 : 8>}


### PR DESCRIPTION
Add the `FVIntegerAttr`, an attribute containing an `FVInt` value. This allows four-valued integer constants to be used as attributes on operations and for constant folding to occur on such values. In contrast to the builtin `IntegerAttr`, `FVIntegerAttr` does not have a type yet. The type can be added later as soon as we have a concrete use case.

I expect us to eventually move `FVIntegerAttr` into the HW dialect once we are happy with its design. Other parts of CIRCT will eventually want to reason about four-valued integers as well.

The parsing and printing of the attribute tries to make the `FVInt` read like a plain old `APInt` when there are no X or Z bits present. Otherwise it falls back to printing as hexadecimal or binary number. To distinguish the different representations and to allow constants with X or Z to be parsed as keywords, a `h` and `b` prefix is used for the hexadecimal and binary formatting, respectively.

Examples of the attribute:

    #moore.fvint<42 : 32>
    #moore.fvint<-42 : 32>
    #moore.fvint<1234567890123456789012345678901234567890 : 131>
    #moore.fvint<hABCDEFXZ0123456789 : 72>
    #moore.fvint<b1010XZ01 : 8>