### PR TITLE
[FIRRTL] Fix sub-* op in layer block verifier

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -18,9 +18,11 @@
 #include "circt/Dialect/FIRRTL/FIRRTLTypes.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/FIRRTLVisitors.h"
+#include "circt/Dialect/FIRRTL/FieldRefCache.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Support/CustomDirectiveImpl.h"
+#include "circt/Support/Utils.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -6284,6 +6286,7 @@ LogicalResult LayerBlockOp::verify() {
   }
 
   // Verify the body of the region.
+  FieldRefCache fieldRefCache;
   auto result = getBody(0)->walk<mlir::WalkOrder::PreOrder>(
       [&](Operation *op) -> WalkResult {
         // Skip nested layer blocks.  Those will be verified separately.
@@ -6307,17 +6310,6 @@ LogicalResult LayerBlockOp::verify() {
             diag.attachNote(op->getLoc()) << "operand is used here";
             return WalkResult::interrupt();
           }
-
-          // Capturing a non-passive type is illegal.
-          if (auto baseType = type_dyn_cast<FIRRTLBaseType>(type)) {
-            if (!baseType.isPassive()) {
-              auto diag = emitOpError()
-                          << "captures an operand which is not a passive type";
-              diag.attachNote(operand.getLoc()) << "operand is defined here";
-              diag.attachNote(op->getLoc()) << "operand is used here";
-              return WalkResult::interrupt();
-            }
-          }
         }
 
         // Ensure that the layer block does not drive any sinks outside.
@@ -6326,11 +6318,27 @@ LogicalResult LayerBlockOp::verify() {
           if (isa<RefDefineOp>(connect))
             return WalkResult::advance();
 
-          // We can drive any destination inside the current layerblock.
-          auto dest = getFieldRefFromValue(connect.getDest()).getValue();
-          if (auto *destOp = dest.getDefiningOp())
-            if (getOperation()->isAncestor(destOp))
-              return WalkResult::advance();
+          // Verify that connects only drive values declared in the layer block.
+          // If we see a non-passive connect destination, then verify that the
+          // source is in the same layer block so that the source is not driven.
+          auto dest =
+              fieldRefCache.getFieldRefFromValue(connect.getDest()).getValue();
+          bool passive = true;
+          if (auto type =
+                  type_dyn_cast<FIRRTLBaseType>(connect.getDest().getType()))
+            passive = type.isPassive();
+          // TODO: Improve this verifier.  This is intentionally _not_ verifying
+          // a non-passive ConnectLike because it is hugely annoying to do
+          // so---it requires a full understanding of if the connect is driving
+          // destination-to-source, source-to-destination, or bi-directionally
+          // which requires deep inspection of the type.  Eventually, the FIRRTL
+          // pass pipeline will remove all flips (e.g., canonicalize connect to
+          // matchingconnect) and this hole won't exist.
+          if (!passive)
+            return WalkResult::advance();
+
+          if (isAncestorOfValueOwner(getOperation(), dest))
+            return WalkResult::advance();
 
           auto diag =
               connect.emitOpError()

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1894,23 +1894,6 @@ firrtl.circuit "WrongLayerBlockNesting" {
 
 // -----
 
-// A layer block captures a non-passive type.
-firrtl.circuit "NonPassiveCapture" {
-  firrtl.layer @A bind {}
-  firrtl.module @NonPassiveCapture() {
-    // expected-note @below {{operand is defined here}}
-    %a = firrtl.wire : !firrtl.bundle<a flip: uint<1>>
-    // expected-error @below {{'firrtl.layerblock' op captures an operand which is not a passive type}}
-    firrtl.layerblock @A {
-      %b = firrtl.wire : !firrtl.bundle<a flip: uint<1>>
-      // expected-note @below {{operand is used here}}
-      firrtl.connect %b, %a : !firrtl.bundle<a flip: uint<1>>, !firrtl.bundle<a flip: uint<1>>
-    }
-  }
-}
-
-// -----
-
 // A layer block may not drive sinks outside the layer block.
 firrtl.circuit "LayerBlockDrivesSinksOutside" {
   firrtl.layer @A bind {}

--- a/test/Dialect/FIRRTL/layers.mlir
+++ b/test/Dialect/FIRRTL/layers.mlir
@@ -26,6 +26,47 @@ firrtl.circuit "Test" {
   }
 
   //===--------------------------------------------------------------------===//
+  // Capture Tests
+  //===--------------------------------------------------------------------===//
+
+  firrtl.module @CaptureTests() {
+    %a = firrtl.wire : !firrtl.vector<bundle<a: uint<1>, b flip: uint<1>>, 2>
+    %b = firrtl.wire : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
+    firrtl.layerblock @A {
+      %0 = firrtl.subindex %a[0] : !firrtl.vector<bundle<a: uint<1>, b flip: uint<1>>, 2>
+      %1 = firrtl.constant 0 : !firrtl.uint<1>
+      %2 = firrtl.subaccess %a[%1] : !firrtl.vector<bundle<a: uint<1>, b flip: uint<1>>, 2>, !firrtl.uint<1>
+      %3 = firrtl.subfield %b[a] : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
+      %4 = firrtl.ref.send %b : !firrtl.bundle<a: uint<1>, b flip: uint<2>>
+    }
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Connect Tests
+  //===--------------------------------------------------------------------===//
+
+  firrtl.module @ConnectTests() {
+    %a = firrtl.wire : !firrtl.uint<1>
+    %b = firrtl.wire : !firrtl.bundle<a: uint<1>>
+    %c = firrtl.wire : !firrtl.bundle<a flip: uint<1>>
+    %d = firrtl.wire : !firrtl.bundle<a : bundle< a flip : uint<1>>>
+    %e = firrtl.wire : !firrtl.bundle<a flip : bundle< a flip : uint<1>>>
+    firrtl.layerblock @A {
+      %_a = firrtl.wire : !firrtl.uint<1>
+      %_b = firrtl.wire : !firrtl.bundle<a: uint<1>>
+      %_c = firrtl.wire : !firrtl.bundle<a flip: uint<1>>
+      %_d = firrtl.wire : !firrtl.bundle<a : bundle< a flip : uint<1>>>
+      %_e = firrtl.wire : !firrtl.bundle<a flip : bundle< a flip : uint<1>>>
+
+      firrtl.connect %_a, %a : !firrtl.uint<1>
+      firrtl.connect %_b, %b : !firrtl.bundle<a: uint<1>>
+      firrtl.connect %c, %_c : !firrtl.bundle<a flip: uint<1>>
+      firrtl.connect %d, %_d : !firrtl.bundle<a : bundle< a flip : uint<1>>>
+      firrtl.connect %_e, %e : !firrtl.bundle<a flip : bundle< a flip : uint<1>>>
+    }
+  }
+
+  //===--------------------------------------------------------------------===//
   // Basic Casting Tests
   //===--------------------------------------------------------------------===//
 


### PR DESCRIPTION
Fix issues with verification of subfield, subindex, and subaccess
operations which appear in a layer block.  These operations are allowed to
occur in a layer block even if they capture non-passive operands.

This requires reworking layer block verification to no longer check for
operations using non-passive operands.  The spec requires that no
operation in a layer block _drives_ a value declared outside the layer
block.  However, this is exceedingly difficult to verify due to the fact
that non-passive destinations in ConnectLike operations can be
source-to-destination, destination-to-source, or bi-directional.  If the
verifier sees this, just allow it.  The FIRRTL pass pipeline will later
canonicalize away flips (i.e., make all types passive) which will then
allow the verifier to check these.  This should be revisited in the
future.

Fixes #7451.

#### Metadata

The commits are in logical order and can be reviewed independently.