### PR TITLE
[Moore] Support four-valued integers in ConstantOp

### DIFF
--- a/include/circt/Dialect/Moore/MooreAttributes.td
+++ b/include/circt/Dialect/Moore/MooreAttributes.td
@@ -17,6 +17,8 @@ def FVIntegerAttr : AttrDef<MooreDialect, "FVInteger"> {
   let summary = "An attribute containing a four-valued integer";
   let parameters = (ins "FVInt":$value);
   let hasCustomAssemblyFormat = 1;
+  let convertFromStorage = "$_self.getValue()";
+  let returnType = "circt::FVInt";
 }
 
 #endif // CIRCT_DIALECT_MOORE_MOOREATTRIBUTES

--- a/include/circt/Dialect/Moore/MooreOps.h
+++ b/include/circt/Dialect/Moore/MooreOps.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_MOORE_MOOREOPS_H
 
 #include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/Moore/MooreAttributes.h"
 #include "circt/Dialect/Moore/MooreDialect.h"
 #include "circt/Dialect/Moore/MooreTypes.h"
 #include "mlir/IR/RegionKindInterface.h"

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -9,6 +9,7 @@
 #ifndef CIRCT_DIALECT_MOORE_MOOREOPS
 #define CIRCT_DIALECT_MOORE_MOOREOPS
 
+include "circt/Dialect/Moore/MooreAttributes.td"
 include "circt/Dialect/Moore/MooreDialect.td"
 include "circt/Dialect/Moore/MooreTypes.td"
 include "mlir/IR/OpAsmInterface.td"
@@ -417,12 +418,13 @@ def EventOp : MooreOp<"wait_event", [
 
 def ConstantOp : MooreOp<"constant", [Pure]> {
   let summary = "A constant integer value";
-  let arguments = (ins APIntAttr:$value);
+  let arguments = (ins FVIntegerAttr:$value);
   let results = (outs IntType:$result);
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
   let hasFolder = 1;
   let builders = [
+    OpBuilder<(ins "IntType":$type, "const FVInt &":$value)>,
     OpBuilder<(ins "IntType":$type, "const APInt &":$value)>,
     OpBuilder<(ins "IntType":$type, "int64_t":$value)>,
   ];

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -183,8 +183,11 @@ struct ConstantOpConv : public OpConversionPattern<ConstantOp> {
   LogicalResult
   matchAndRewrite(ConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-
-    rewriter.replaceOpWithNewOp<hw::ConstantOp>(op, op.getValueAttr());
+    // FIXME: Discard unknown bits and map them to 0 for now.
+    auto value = op.getValue().toAPInt(false);
+    auto type = rewriter.getIntegerType(value.getBitWidth());
+    rewriter.replaceOpWithNewOp<hw::ConstantOp>(
+        op, type, rewriter.getIntegerAttr(type, value));
     return success();
   }
 };

--- a/lib/Support/FVInt.cpp
+++ b/lib/Support/FVInt.cpp
@@ -146,7 +146,8 @@ llvm::hash_code circt::hash_value(const FVInt &a) {
 
 void circt::printFVInt(AsmPrinter &p, const FVInt &value) {
   SmallString<32> buffer;
-  if (value.isNegative() && (-value).tryToString(buffer)) {
+  if (value.getBitWidth() > 1 && value.isNegative() &&
+      (-value).tryToString(buffer)) {
     p << "-" << buffer;
   } else if (value.tryToString(buffer)) {
     p << buffer;

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -630,6 +630,10 @@ module Expressions;
     c = '0;
     // CHECK: moore.constant -1 : i32
     c = '1;
+    // CHECK: moore.constant hXXXXXXXX : l32
+    f = 'X;
+    // CHECK: moore.constant hZZZZZZZZ : l32
+    f = 'Z;
     // CHECK: moore.constant 42 : i32
     c = 42;
     // CHECK: moore.constant 42 : i19
@@ -638,6 +642,8 @@ module Expressions;
     c = 19'sd42;
     // CHECK: moore.constant 123456789123456789123456789123456789 : i128
     c = 128'd123456789123456789123456789123456789;
+    // CHECK: moore.constant h123XZ : l19
+    f = 19'h123XZ;
     // CHECK: [[TMP1:%.+]] = moore.read %a
     // CHECK: [[TMP2:%.+]] = moore.read %b
     // CHECK: [[TMP3:%.+]] = moore.read %c
@@ -651,7 +657,7 @@ module Expressions;
     {a, b, c} = a;
     // CHECK: moore.concat_ref %d, %e : (!moore.ref<l32>, !moore.ref<l32>) -> <l64>
     {d, e} = d;
-    // CHECK: [[TMP1:%.+]] = moore.constant false : i1
+    // CHECK: [[TMP1:%.+]] = moore.constant 0 : i1
     // CHECK: [[TMP2:%.+]] = moore.concat [[TMP1]] : (!moore.i1) -> i1
     // CHECK: moore.replicate [[TMP2]] : i1 -> i32
     a = {32{1'b0}};

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -75,41 +75,7 @@ endmodule
 
 // -----
 module Foo;
-  // expected-error @below {{literals with X or Z bits not supported}}
-  logic a = 'x;
-endmodule
-
-// -----
-module Foo;
-  // expected-error @below {{literals with X or Z bits not supported}}
-  logic a = 'z;
-endmodule
-
-// -----
-module Foo;
   int a, b[3];
   // expected-error @below {{unpacked arrays in 'inside' expressions not supported}}
   int c = a inside { b };
-endmodule
-
-// -----
-module Foo;
-  logic a, b;
-  initial begin
-    casez (a)
-    // expected-error @below {{literals with X or Z bits not supported}}
-    1'bz : b = 1'b1;
-    endcase
-  end
-endmodule
-
-// -----
-module Foo;
-  logic a;
-  initial begin
-    // expected-error @below {{literals with X or Z bits not supported}}
-    casez (1'bz)
-    1'bz : a = 1'b1;
-    endcase
-  end
 endmodule

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -267,7 +267,7 @@ moore.module @Variable() {
   %b2 = moore.variable %0 : <i8>
 
   // CHECK: %true = hw.constant true
-  %1 = moore.constant true : i1
+  %1 = moore.constant 1 : i1
   // CHECK: [[CAST:%.+]] = hw.bitcast %true : (i1) -> i1
   %2 = moore.conversion %1 : !moore.i1 -> !moore.l1
   // CHECK: llhd.sig "l" [[CAST]] : i1

--- a/test/Dialect/Moore/attrs-error.mlir
+++ b/test/Dialect/Moore/attrs-error.mlir
@@ -2,3 +2,8 @@
 
 // expected-error @below {{integer literal requires at least 6 bits, but attribute specifies only 3}}
 hw.constant false {foo = #moore.fvint<42 : 3>}
+
+// -----
+
+// expected-error @below {{integer literal requires at least 1 bits, but attribute specifies only 0}}
+hw.constant false {foo = #moore.fvint<1 : 0>}

--- a/test/Dialect/Moore/attrs.mlir
+++ b/test/Dialect/Moore/attrs.mlir
@@ -1,5 +1,7 @@
 // RUN: circt-opt %s | circt-opt | FileCheck %s
 
+// CHECK: #moore.fvint<0 : 0>
+hw.constant false {foo = #moore.fvint<0 : 0>}
 // CHECK: #moore.fvint<42 : 32>
 hw.constant false {foo = #moore.fvint<42 : 32>}
 // CHECK: #moore.fvint<-42 : 32>

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -140,12 +140,26 @@ moore.module @Expressions(
   // CHECK-SAME: in [[REF_STRUCT1:%.+]] : !moore.ref<struct<{a: i32, b: i32}>>
   in %refStruct1: !moore.ref<struct<{a: i32, b: i32}>>
 ) {
+  // CHECK: moore.constant 0 : i0
+  moore.constant 0 : i0
+  // CHECK: moore.constant 0 : i1
+  moore.constant 0 : i1
+  // CHECK: moore.constant 1 : i1
+  moore.constant 1 : i1
   // CHECK: moore.constant 0 : i32
   moore.constant 0 : i32
   // CHECK: moore.constant -2 : i2
   moore.constant 2 : i2
   // CHECK: moore.constant -2 : i2
   moore.constant -2 : i2
+  // CHECK: moore.constant 1311768467463790320 : i64
+  moore.constant h123456789ABCDEF0 : i64
+  // CHECK: moore.constant h123456789ABCDEF0XZ : l72
+  moore.constant h123456789ABCDEF0XZ : l72
+  // CHECK: moore.constant 10 : i8
+  moore.constant b1010 : i8
+  // CHECK: moore.constant b1010XZ : l8
+  moore.constant b1010XZ : l8
 
   // CHECK: moore.conversion [[A]] : !moore.i32 -> !moore.l32
   moore.conversion %a : !moore.i32 -> !moore.l32

--- a/test/Dialect/Moore/errors.mlir
+++ b/test/Dialect/Moore/errors.mlir
@@ -53,18 +53,23 @@ moore.module @Foo(out a: !moore.string) {
 
 // -----
 
-// expected-error @below {{constant out of range for result type '!moore.i1'}}
+// expected-error @below {{value requires 6 bits, but result type only has 1}}
 moore.constant 42 : !moore.i1
 
 // -----
 
-// expected-error @below {{constant out of range for result type '!moore.i1'}}
+// expected-error @below {{value requires 2 bits, but result type only has 1}}
 moore.constant -2 : !moore.i1
 
 // -----
 
+// expected-error @below {{value contains X or Z bits, but result type '!moore.i4' only allows two-valued bits}}
+moore.constant b10XZ : !moore.i4
+
+// -----
+
 // expected-error @below {{attribute width 9 does not match return type's width 8}}
-"moore.constant" () {value = 42 : i9} : () -> !moore.i8
+"moore.constant" () {value = #moore.fvint<42 : 9>} : () -> !moore.i8
 
 // -----
 
@@ -74,7 +79,7 @@ moore.yield %0 : i8
 
 // -----
 
-%0 = moore.constant true : i1
+%0 = moore.constant 1 : i1
 %1 = moore.constant 42 : i8
 %2 = moore.constant 42 : i32
 
@@ -87,7 +92,7 @@ moore.conditional %0 : i1 -> i32 {
 
 // -----
 
-%0 = moore.constant true : i1
+%0 = moore.constant 1 : i1
 %1 = moore.constant 42 : i32
 %2 = moore.constant 42 : i8
 


### PR DESCRIPTION
Extend Moore's `ConstantOp` to use the new `FVIntegerAttr`, which now allows us to materialize four-valued integer constants in the IR. Also adjust ImportVerilog to finally properly captured integer literals with X and Z bits.

With this change, `circt-verilog` is now capable of fully parsing the Snitch RISC-V core used as a benchmark in the original LLHD paper at PLDI 2020, and to produce a corresponding blob of IR.

Examples of the extended op:

    moore.constant 0 : i32
    moore.constant 2 : i2
    moore.constant -2 : i2
    moore.constant h123456789ABCDEF0 : i64
    moore.constant h123456789ABCDEF0XZ : l72
    moore.constant b1010 : i8
    moore.constant b1010XZ : l8