### PR TITLE
[FIRRTL][InferResets] Generalize FART to support sync reset

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -474,7 +474,54 @@ Example:
 }
 ```
 
+### FullResetAnnotation
+
+| Property   | Type   | Description                      |
+| ---------- | ------ | -------------                    |
+| class      | string | `circt.FullAsyncResetAnnotation` |
+| target     | string | Reference target                 |
+| resetType  | string | "async" or "sync"                |
+
+
+The target must be a signal that is a reset. The type of the signal must be (or inferred
+to be) the same as the reset type specified in the annotation.
+
+Indicates that all reset-less registers which are children of the module containing
+the target will have the reset targeted attached, with a reset value of 0.
+
+The module containing the target of this annotation is not allowed to reside in multiple
+hierarchies.
+
+Example:
+```json
+{
+  "class": "circt.FullResetAnnotation",
+  "target": "~Foo|Bar/d:Baz>reset",
+  "resetType": "async"
+}
+```
+
+### ExcludeFromFullResetAnnotation
+
+| Property   | Type   | Description                            |
+| ---------- | ------ | -------------                          |
+| class      | string | `circt.ExcludeFromFullResetAnnotation` |
+| target     | string | Reference target                       |
+
+This annotation indicates that the target moudle should be excluded from the
+FullResetAnnotation of a parent module.
+
+Example:
+```json
+{
+  "class": "circt.IgnoreFullAsyncResetAnnotation",
+  "target": "~Foo|Bar/d:Baz"
+}
+```
+
 ### FullAsyncResetAnnotation
+
+**Deprecated, use FullResetAnnotation**
 
 | Property   | Type   | Description                                         |
 | ---------- | ------ | -------------                                       |
@@ -499,6 +546,8 @@ Example:
 ```
 
 ### IgnoreFullAsyncResetAnnotation
+
+**Deprecated, use ExcludeFromFullResetAnnotation**
 
 | Property   | Type   | Description                                               |
 | ---------- | ------ | -------------                                             |

--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -159,6 +159,11 @@ constexpr const char *elaborationArtefactsDirectoryAnnoClass =
 constexpr const char *testHarnessPathAnnoClass =
     "sifive.enterprise.firrtl.TestHarnessPathAnnotation";
 /// Annotation that marks a reset (port or wire) and domain.
+constexpr const char *fullResetAnnoClass = "circt.FullResetAnnotation";
+/// Annotation that marks a module as not belonging to any reset domain.
+constexpr const char *excludeFromFullResetAnnoClass =
+    "circt.ExcludeFromFullResetAnnotation";
+/// Annotation that marks a reset (port or wire) and domain.
 constexpr const char *fullAsyncResetAnnoClass =
     "sifive.enterprise.firrtl.FullAsyncResetAnnotation";
 /// Annotation that marks a module as not belonging to any reset domain.

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -397,11 +397,13 @@ def InferResets : Pass<"firrtl-infer-resets", "firrtl::CircuitOp"> {
   let summary = "Infer reset synchronicity and add implicit resets";
   let description = [{
     This pass infers whether resets are synchronous or asynchronous, and extends
-    reset-less registers with an asynchronous reset based on the following
+    reset-less registers with a reset based on the following
     annotations:
 
-    - `sifive.enterprise.firrtl.FullAsyncResetAnnotation`
-    - `sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation`
+    - `circt.FullResetAnnotation`
+    - `circt.ExcludeFromFullResetAnnotation`
+    - `sifive.enterprise.firrtl.FullAsyncResetAnnotation` (deprecated)
+    - `sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation` (deprecated)
   }];
   let constructor = "circt::firrtl::createInferResetsPass()";
 }

--- a/test/firtool/async-reset-anno.fir
+++ b/test/firtool/async-reset-anno.fir
@@ -1,22 +1,24 @@
 ; RUN: firtool %s -parse-only | circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-resets))'  | FileCheck %s --check-prefixes COMMON,POST-INFER-RESETS
 ; RUN: firtool %s -parse-only | circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-infer-resets,firrtl.module(firrtl-sfc-compat)))' | FileCheck %s --check-prefixes COMMON,POST-SFC-COMPAT
 
-; Check that FullAsyncResetAnnotation exists after infer-resets pass
+; Check that FullResetAnnotation exists after infer-resets pass
 ; but is deleted after sfc-compat
 
 FIRRTL version 3.3.0
 circuit test :%[[
-{ "class":"sifive.enterprise.firrtl.FullAsyncResetAnnotation",
-  "target":"~test|test>reset" },
-{ "class":"sifive.enterprise.firrtl.FullAsyncResetAnnotation",
-  "target":"~test|foo>r" }
+{ "class":"circt.FullResetAnnotation",
+  "target":"~test|test>reset",
+  "resetType":"async" },
+{ "class":"circt.FullResetAnnotation",
+  "target":"~test|foo>r",
+  "resetType":"async" }
 ]]
   ; COMMON-LABEL: module @test
   module test :
     input clock : Clock
     input reset : AsyncReset
-    ; POST-INFER-RESETS: [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]
-    ; POST-SFC-COMPAT-NOT: [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]
+    ; POST-INFER-RESETS: [{class = "circt.FullResetAnnotation", resetType = "async"}]
+    ; POST-SFC-COMPAT-NOT: [{class = "circt.FullResetAnnotation", resetType = "async"}]
     input in : { foo : UInt<8>, bar : UInt<8>}
     output out : { foo : UInt<8>, bar : UInt<8>}
     connect out, in
@@ -28,7 +30,7 @@ circuit test :%[[
     input in : { foo : UInt<8>, bar : UInt<8>}
     output out : { foo : UInt<8>, bar : UInt<8>}
 
-    ; POST-INFER-RESETS: [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]
-    ; POST-SFC-COMPAT-NOT: [{class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation"}]
+    ; POST-INFER-RESETS: [{class = "circt.FullResetAnnotation", resetType = "async"}]
+    ; POST-SFC-COMPAT-NOT: [{class = "circt.FullResetAnnotation", resetType = "async"}]
      wire r : AsyncReset
     connect out, in

--- a/test/firtool/async-reset.fir
+++ b/test/firtool/async-reset.fir
@@ -3,8 +3,9 @@
 FIRRTL version 3.3.0
 ; CHECK-LABEL: module test(
 circuit test :%[[{
-  "class":"sifive.enterprise.firrtl.FullAsyncResetAnnotation",
-    "target":"~test|test>reset"
+  "class":"circt.FullResetAnnotation",
+    "target":"~test|test>reset",
+    "resetType":"async"
   }]]
   module test :
     input clock : Clock
@@ -31,8 +32,9 @@ circuit test :%[[{
 ; CHECK-LABEL: module test_wire(
 FIRRTL version 3.3.0
 circuit test_wire :%[[{
-  "class":"sifive.enterprise.firrtl.FullAsyncResetAnnotation",
-    "target":"~test_wire|test_wire>reset"
+  "class":"circt.FullResetAnnotation",
+    "target":"~test_wire|test_wire>reset",
+    "resetType":"async"
   }]]
   module test_wire :
     input clock : Clock
@@ -51,6 +53,66 @@ circuit test_wire :%[[{
     invalidate reg1_w.bar
     ; CHECK: reg1_foo = 8'hC;
     ; CHECK: reg1_bar = 8'h0;
+    regreset reg1 : { foo : UInt<8>, bar : UInt<8>}, clock, reset, reg1_w
+    wire reg2 : { foo : UInt<8>, bar : UInt<8>}
+    connect reg1, in
+    connect reg2, reg1
+    connect out, reg2
+
+;// -----
+; CHECK-LABEL: module test_sync(
+FIRRTL version 3.3.0
+circuit test_sync :%[[{
+  "class":"circt.FullResetAnnotation",
+    "target":"~test_sync|test_sync>reset",
+    "resetType":"sync"
+  }]]
+  module test_sync :
+    input clock : Clock
+    input reset : UInt<1>
+    input in : { foo : UInt<8>, bar : UInt<8>}
+    output out : { foo : UInt<8>, bar : UInt<8>}
+
+    wire reg1_w : { foo : UInt<8>, bar : UInt<8>}
+    invalidate reg1_w.bar
+    invalidate reg1_w.foo
+    connect reg1_w.foo, UInt<8>(0hc)
+    invalidate reg1_w.bar
+    ; CHECK:      always @(posedge clock) begin
+    ; CHECK-NEXT:   if (reset) begin
+    ; CHECK-NEXT:     reg1_foo <= 8'hC;
+    ; CHECK-NEXT:     reg1_bar <= 8'h0;
+    regreset reg1 : { foo : UInt<8>, bar : UInt<8>}, clock, reset, reg1_w
+    wire reg2 : { foo : UInt<8>, bar : UInt<8>}
+    connect reg1, in
+    connect reg2, reg1
+    connect out, reg2
+
+;// -----
+; CHECK-LABEL: module test_wire_sync(
+FIRRTL version 3.3.0
+circuit test_wire_sync :%[[{
+  "class":"circt.FullResetAnnotation",
+    "target":"~test_wire_sync|test_wire_sync>reset",
+    "resetType":"sync"
+  }]]
+  module test_wire_sync :
+    input clock : Clock
+    input rst : UInt<1>
+    input in : { foo : UInt<8>, bar : UInt<8>}
+    output out : { foo : UInt<8>, bar : UInt<8>}
+
+    node reset = rst
+
+    wire reg1_w : { foo : UInt<8>, bar : UInt<8>}
+    invalidate reg1_w.bar
+    invalidate reg1_w.foo
+    connect reg1_w.foo, UInt<8>(0hc)
+    invalidate reg1_w.bar
+    ; CHECK:      always @(posedge clock) begin
+    ; CHECK-NEXT:   if (rst) begin
+    ; CHECK-NEXT:     reg1_foo <= 8'hC;
+    ; CHECK-NEXT:     reg1_bar <= 8'h0;
     regreset reg1 : { foo : UInt<8>, bar : UInt<8>}, clock, reset, reg1_w
     wire reg2 : { foo : UInt<8>, bar : UInt<8>}
     connect reg1, in


### PR DESCRIPTION
The FullAsyncResetAnnotation is deprecated and replaced by FullResetAnnotation which includes a resetType argument that must be 'sync' or 'async'.  IgnoreFullAsyncResetAnnotation is deprecated and replaced by ExcludeFromFullResetAnnotation. The new annotations are in package circt.

The behavior of FullResetAnnotation with resetType = 'async' is identical to that of the old FullAsyncResetAnnotation. The behavior of FullResetAnnotation with resetType = 'sync' is very similar, except the type of the reset wired through will be UInt<1>, and any registers with an existing reset at all (both sync or async) will be left unchanged (resetType = 'async' will add async resets to registers with existing sync resets).