### PR TITLE
[Moore] Add more AssignedVariableOp canonicalizations

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -266,19 +266,20 @@ def NetOp : MooreOp<"net", [
     `` custom<ImplicitSSAName>($name) $kind ($assignment^)? attr-dict
     `:` type($result)
   }];
+  let hasCanonicalizeMethod = true;
 }
 
-def AssignedVarOp : MooreOp<"assigned_variable", [
+def AssignedVariableOp : MooreOp<"assigned_variable", [
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-  TypesMatchWith<"initial value and variable types match",
-    "result", "initial", "cast<RefType>($_self).getNestedType()">
+  SameOperandsAndResultType
 ]> {
-  let summary = "The copy of variable must have the initial value";
-  let arguments = (ins OptionalAttr<StrAttr>:$name, UnpackedType:$initial);
-  let results = (outs Res<RefType, "", [MemAlloc]>:$result);
+  let summary = "A variable with a unique continuously assigned value";
+  let arguments = (ins OptionalAttr<StrAttr>:$name, UnpackedType:$input);
+  let results = (outs UnpackedType:$result);
   let assemblyFormat = [{
-    `` custom<ImplicitSSAName>($name) $initial attr-dict `:` type($result)
+    `` custom<ImplicitSSAName>($name) $input attr-dict `:` type($input)
   }];
+  let hasCanonicalizeMethod = true;
 }
 
 def ReadOp : MooreOp<"read", [


### PR DESCRIPTION
Change the `AssignedVariableOp` to directly return type `T` instead of the `ref<T>`. This removes the implied allocation and assignment, and makes this op behave essentially like `hw.wire`.

The canonicalizers for `VariableOp` and `NetOp` can now replace all reads from the old variable or net with the value of `AssignedVariableOp` directly, since there is no more `ref<T>` type involved. This also allows us to fully eliminate unnamed variables and nets that have a unique continuous assignment.

Also add canonicalizers that remove `AssignedVariableOp` if they shadow an input or output port of the same name, or if there are multiple such variables with the same name in a chain.

At a later stage we may want to replace `AssignedVariableOp` entirely with `dbg.variable`.