### PR TITLE
[FIRRTL] Add list concatenation operation.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1154,6 +1154,23 @@ def ListCreateOp : FIRRTLOp<"list.create", [Pure, SameTypeOperands]> {
   let hasVerifier = 1;
 }
 
+def ListConcatOp : FIRRTLOp<"list.concat", [Pure, SameOperandsAndResultType]> {
+  let summary = "Concatenate multiple lists to produce a new list";
+  let description = [{
+    Produces a value of list type by concatenating the provided lists.
+
+    Example:
+    ```mlir
+    %3 = firrtl.list.concat %0, %1, %2 : !firrtl.list<string>
+    ```
+  }];
+
+  let arguments = (ins Variadic<ListType>:$subLists);
+  let results = (outs ListType:$result);
+
+  let assemblyFormat = "$subLists attr-dict `:` type($result)";
+}
+
 def BoolConstantOp : FIRRTLOp<"bool", [Pure, ConstantLike]> {
   let summary = "Produce a constant boolean value";
   let description = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -65,8 +65,8 @@ public:
             UninferredResetCastOp, ConstCastOp, RefCastOp,
             // Property expressions.
             StringConstantOp, FIntegerConstantOp, BoolConstantOp,
-            DoubleConstantOp, ListCreateOp, UnresolvedPathOp, PathOp,
-            IntegerAddOp, IntegerMulOp, IntegerShrOp>(
+            DoubleConstantOp, ListCreateOp, ListConcatOp, UnresolvedPathOp,
+            PathOp, IntegerAddOp, IntegerMulOp, IntegerShrOp>(
             [&](auto expr) -> ResultType {
               return thisCast->visitExpr(expr, args...);
             })
@@ -219,6 +219,7 @@ public:
   HANDLE(BoolConstantOp, Unhandled);
   HANDLE(DoubleConstantOp, Unhandled);
   HANDLE(ListCreateOp, Unhandled);
+  HANDLE(ListConcatOp, Unhandled);
   HANDLE(PathOp, Unhandled);
   HANDLE(UnresolvedPathOp, Unhandled);
   HANDLE(IntegerAddOp, Unhandled);

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -104,4 +104,20 @@ firrtl.module @PropertyArithmetic() {
   %4 = firrtl.integer.shr %0, %1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
 }
 
+// CHECK-LABEL: firrtl.module @PropertyListOps
+firrtl.module @PropertyListOps() {
+  %0 = firrtl.integer 0
+  %1 = firrtl.integer 1
+  %2 = firrtl.integer 2
+
+  // CHECK: [[L0:%.+]] = firrtl.list.create %0, %1
+  %l0 = firrtl.list.create %0, %1 : !firrtl.list<integer>
+
+  // CHECK: [[L1:%.+]] = firrtl.list.create %2
+  %l1 = firrtl.list.create %2 : !firrtl.list<integer>
+
+  // CHECK: firrtl.list.concat [[L0]], [[L1]] : !firrtl.list<integer>
+  %concat = firrtl.list.concat %l0, %l1 : !firrtl.list<integer>
+}
+
 }


### PR DESCRIPTION
This operation produces a list by concatenating lists of the same
type. The operation definition and a simple round trip test have been
added. This is used to compose lists, which is a key feature to enable
hierarchical composition of Properties.