### PR TITLE
[OM] Add list concatenation operation.

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -207,6 +207,23 @@ def ListCreateOp : OMOp<"list_create", [Pure, SameTypeOperands]> {
   let hasCustomAssemblyFormat = 1;
 }
 
+def ListConcatOp : OMOp<"list_concat", [Pure, SameOperandsAndResultType]> {
+  let summary = "Concatenate multiple lists to produce a new list";
+  let description = [{
+    Produces a value of list type by concatenating the provided lists.
+
+    Example:
+    ```
+    %3 = om.list_concat %0, %1, %2 : !om.list<string>
+    ```
+  }];
+
+  let arguments = (ins Variadic<ListType>:$subLists);
+  let results = (outs ListType:$result);
+
+  let assemblyFormat = "$subLists attr-dict `:` type($result)";
+}
+
 def TupleCreateOp : OMOp<"tuple_create", [Pure, InferTypeOpInterface]> {
   let summary = "Create a tuple of values";
   let description = [{

--- a/test/Dialect/OM/round-trip.mlir
+++ b/test/Dialect/OM/round-trip.mlir
@@ -158,6 +158,22 @@ om.class @ListCreate() {
   om.class.field @list_field, %list : !om.list<!om.class.type<@Widget>>
 }
 
+// CHECK-LABEL: @ListConcat
+om.class @ListConcat() {
+  %0 = om.constant #om.integer<0 : i8> : !om.integer
+  %1 = om.constant #om.integer<1 : i8> : !om.integer
+  %2 = om.constant #om.integer<2 : i8> : !om.integer
+
+  // CHECK: [[L0:%.+]] = om.list_create %0, %1
+  %l0 = om.list_create %0, %1 : !om.integer
+
+  // CHECK: [[L1:%.+]] = om.list_create %2
+  %l1 = om.list_create %2 : !om.integer
+
+  // CHECK: om.list_concat [[L0]], [[L1]]
+  %concat = om.list_concat %l0, %l1 : !om.list<!om.integer>
+}
+
 // CHECK-LABEL: @Integer
 om.class @IntegerConstant() {
   // CHECK: %[[const1:.+]] = om.constant #om.integer<36755551979133953793 : i67> : !om.integer


### PR DESCRIPTION
This operation produces a list by concatenating lists of the same type. The operation definition and a simple round trip test have been added. This is used to compose lists, which is a key feature to enable hierarchical composition of OM values.