### PR TITLE
[Verif] Generalize Formal Contracts

### DIFF
--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -365,7 +365,8 @@ def ContractOp : VerifOp<"contract", [
     and postconditions on a parent module. These are used as an abstraction to 
     better modularize formal verification such that each module containing a contract 
     is checked exactly once. The contract contains a single block where the block arguments 
-    represent the inputs and outputs in the same order as in the module signature.
+    represent the results of the code block that the contract is abstracting over. The 
+    operands represent the SSA values that this contract's results will replace.
           
     e.g. 
     ```

--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -251,7 +251,7 @@ def YieldOp : VerifOp<"yield", [
   Terminator,
   ParentOneOf<[
     "verif::LogicEquivalenceCheckingOp", "verif::BoundedModelCheckingOp",
-    "verif::InstanceOp"
+    "verif::ContractOp"
   ]>
 ]> {
   let summary = "yields values from a region";
@@ -313,7 +313,7 @@ def FormalOp : VerifOp<"formal", [
 //===----------------------------------------------------------------------===//
 
 def SymbolicInputOp : VerifOp<"symbolic_input", [
-  ParentOneOf<["verif::FormalOp", "verif::InstanceOp"]>
+  ParentOneOf<["verif::FormalOp"]>
 ]>{
   let summary = "declare a symbolic input for formal verification";
   let description = [{
@@ -354,14 +354,69 @@ def ConcreteInputOp : VerifOp<"concrete_input", [
 // Formal Contract Ops
 //===----------------------------------------------------------------------===//
 
-class ContractLikeOp<string mnemonic, list<Trait> traits = []> 
-  : VerifOp<mnemonic, traits # [
-    HasParent<"hw::HWModuleOp">, RegionKindInterface, IsolatedFromAbove
-  ]> {
+def ContractOp : VerifOp<"contract", [
+  SingleBlockImplicitTerminator<"verif::YieldOp">,
+  HasParent<"hw::HWModuleOp">, 
+  RegionKindInterface
+]>{
+  let summary = "declare a formal contract";
+  let description = [{
+    This operation declares a formal contract that is used to create precondition 
+    and postconditions on a parent module. These are used as an abstraction to 
+    better modularize formal verification such that each module containing a contract 
+    is checked exactly once. The contract contains a single block where the block arguments 
+    represent the inputs and outputs in the same order as in the module signature.
+          
+    e.g. 
+    ```
+    hw.module @Bar(in %foo : i8, out "" : i8, out "1" : i8) { 
+      %o0, %o1 = verif.contract (%to0, %to1) : (i8, i8) -> (i8, i8) {
+        ^bb0(%bar.0 : i8, %bar.1 : i8): 
+          %c0_8 = hw.constant 0 : i8 
+          %prec = comb.icmp bin ugt %foo, %c0_8 : i8
+          verif.require %prec : i1
+
+          %post = comb.icmp bin ugt %bar.0, %foo : i8
+          %post1 = comb.icmp bin ult %bar.1, %foo : i8
+          verif.ensure %post : i1
+          verif.ensure %post1 : i1
+          verif.yield %bar.0, %bar.1 : i8, i8
+      } 
+      /* ... Module definition ... */
+    }
+    ```
+
+    This later is used to replace any instance of Bar during verification:  
+    ```
+    %bar.0, %bar.1 = hw.instance "bar" @Bar("foo" : %c42_8 : i8)  -> ("" : i8, "1" : i8)
+
+    /* ... After PrepareForFormal Pass becomes ... */
+
+    %bar.0, %bar.1 = verif.contract (%c42_8) : (i8) -> (i8, i8) {
+      ^bb0(%arg1: i8):
+        %c0_8 = hw.constant 0 : i8
+        %prec = comb.icmp bin ugt %arg1, %c0_8 : i8
+        verif.assert %prec : i1
+
+        %bar.0 = verif.symbolic_input : i8
+        %bar.1 = verif.symbolic_input : i8
+        %post = comb.icmp bin ugt %bar.0, %arg1 : i8
+        %post1 = comb.icmp bin ult %bar.1, %arg1 : i8
+        verif.assume %post : i1
+        verif.assume %post1 : i1
+        verif.yield %bar.0, %bar.1 : i8, i8
+    }
+    
+    ```
+  }];
 
   let arguments = (ins Variadic<AnyType>:$inputs);
-
+  let results = (outs Variadic<AnyType>:$results);
   let regions = (region SizedRegion<1>:$body);
+
+  let assemblyFormat = [{
+    `(` $inputs `)` attr-dict `:` `(` type($inputs) `)` `->` `(` type($results) `)` $body
+  }];
 
   let extraClassDeclaration = [{
     /// Implement RegionKindInterface.
@@ -381,83 +436,6 @@ class ContractLikeOp<string mnemonic, list<Trait> traits = []>
   }];
 
   let hasRegionVerifier = 1;
-}
-
-
-def ContractOp : ContractLikeOp<"contract", [NoTerminator]>{
-  let summary = "declare a formal contract";
-  let description = [{
-    This operation declares a formal contract that is used to create precondition 
-    and postconditions on a parent module. These are used as an abstraction to 
-    better modularize formal verification such that each module containing a contract 
-    is checked exactly once. The contract contains a single block where the block arguments 
-    represent the inputs and outputs in the same order as in the module signature.
-          
-    e.g. 
-    ```
-    hw.module @Bar(in %foo : i8, out "" : i8, out "1" : i8) { 
-      verif.contract (%foo) : (i8) {
-        ^bb0(%arg1 : i8, %bar.0 : i8, %bar.1 : i8): 
-          %c0_8 = hw.constant 0 : i8 
-          %prec = comb.icmp bin ugt %arg1, %c0_8 : i8
-          verif.require %prec : i1
-
-          %post = comb.icmp bin ugt %bar.0, %arg1 : i8
-          %post1 = comb.icmp bin ult %bar.1, %arg1 : i8
-          verif.ensure %post : i1
-          verif.ensure %post1 : i1
-      }
-      /* ... Module definition ... */
-    }
-    ```
-
-    This later is used to replace any instance of Bar during verification:  
-    ```
-    %bar.0, %bar.1 = hw.instance "bar" @Bar("foo" : %foo : i8)  -> ("" : i8, "1" : i8)
-
-    /* ... After PrepareForFormal Pass becomes ... */
-
-    %bar.0, %bar.1 = verif.instance (%c42_8) : (i8) -> (i8, i8) {
-      ^bb0(%arg1: i8):
-        %c0_8 = hw.constant 0 : i8
-        %prec = comb.icmp bin ugt %arg1, %c0_8 : i8
-        verif.assert %prec : i1
-
-        %bar.0 = verif.symbolic_input : i8
-        %bar.1 = verif.symbolic_input : i8
-        %post = comb.icmp bin ugt %bar.0, %arg1 : i8
-        %post1 = comb.icmp bin ult %bar.1, %arg1 : i8
-        verif.assume %post : i1
-        verif.assume %post1 : i1
-        verif.yield %bar.0, %bar.1 : i8, i8
-    }
-    
-    ```
-  }];
-
-  let assemblyFormat = [{
-    `(` $inputs `)` attr-dict `:` `(` type($inputs) `)` $body
-  }];
-}
-
-def InstanceOp : ContractLikeOp<"instance", [
-  SingleBlockImplicitTerminator<"verif::YieldOp">
-]>{
-  let summary = "declare an instance of a formal contract (replace an hw.instance)";
-  let description = [{
-    This operation declares an instance of an `hw.module` that contains a 
-    `verif.contract` definition. The body of this op will be a modified version 
-    of the body of the referenced module's contract body, with `verif.require` 
-    ops being reoplaced with `verif.assert` and `verif.ensure` being replaced 
-    with `verif.assume`. The `verif.result` ops are converted into `verif.symbolic_input` 
-    and are yielded as a result of the region to be used in the rest of the module.
-  }];
-
-  let results = (outs Variadic<AnyType>:$results);
-
-  let assemblyFormat = [{
-    `(` $inputs `)` attr-dict `:` functional-type($inputs, $results) $body
-  }];
 }
 
 class RequireLikeOp<string mnemonic, list<Trait> traits = [

--- a/test/Dialect/Verif/basic.mlir
+++ b/test/Dialect/Verif/basic.mlir
@@ -58,69 +58,39 @@ verif.formal @formal1(k = 20) {
 
 // CHECK-LABEL: hw.module @Bar
 hw.module @Bar(in %foo : i8, out "" : i8, out "1" : i8) { 
-  // CHECK: verif.contract(%foo) : (i8) {
-  verif.contract (%foo) : (i8) {
-    // CHECK: ^bb0(%[[ARG:.+]]: i8, %[[OUT:.+]]: i8, %[[OUT1:.+]]: i8):
-    ^bb0(%arg1 : i8, %bar.0 : i8, %bar.1 : i8): 
+  // CHECK: %[[C1:.+]] = hw.constant
+  %c1_8 = hw.constant 1 : i8
+  // CHECK: %[[O1:.+]] = comb.add
+  %to0 = comb.add bin %foo, %c1_8 : i8
+  // CHECK: %[[O2:.+]] = comb.sub
+  %to1 = comb.sub bin %foo, %c1_8 : i8
+
+  // CHECK: %[[OUT:.+]]:2 = verif.contract(%[[O1]], %[[O2]]) : (i8, i8) -> (i8, i8) {
+  %o0, %o1 = verif.contract (%to0, %to1) : (i8, i8) -> (i8, i8) {
+    // CHECK: ^bb0(%[[BAR0:.+]]: i8, %[[BAR1:.+]]: i8):
+    ^bb0(%bar.0 : i8, %bar.1 : i8): 
       // CHECK: %[[C0:.+]] = hw.constant 0 : i8
       %c0_8 = hw.constant 0 : i8 
-      // CHECK: %[[PREC:.+]] = comb.icmp bin ugt %[[ARG]], %[[C0]] : i8
-      %prec = comb.icmp bin ugt %arg1, %c0_8 : i8
+      // CHECK: %[[PREC:.+]] = comb.icmp bin ugt %foo, %[[C0]] : i8
+      %prec = comb.icmp bin ugt %foo, %c0_8 : i8
       // CHECK: verif.require %[[PREC]] : i1
       verif.require %prec : i1
 
-      // CHECK: %[[P0:.+]] = comb.icmp bin ugt %[[OUT]], %[[ARG]] : i8
-      %post = comb.icmp bin ugt %bar.0, %arg1 : i8
-      // CHECK: %[[P1:.+]] = comb.icmp bin ult %[[OUT1]], %[[ARG]] : i8
-      %post1 = comb.icmp bin ult %bar.1, %arg1 : i8
+      // CHECK: %[[P0:.+]] = comb.icmp bin ugt %[[BAR0]], %foo : i8
+      %post = comb.icmp bin ugt %bar.0, %foo : i8
+      // CHECK: %[[P1:.+]] = comb.icmp bin ult %[[BAR1]], %foo : i8
+      %post1 = comb.icmp bin ult %bar.1, %foo : i8
       // CHECK: verif.ensure %[[P0]] : i1
       verif.ensure %post : i1
       // CHECK: verif.ensure %[[P1]] : i1
       verif.ensure %post1 : i1
-  }
-  // CHECK: %[[C1:.+]] = hw.constant
-  %c1_8 = hw.constant 1 : i8
-  // CHECK: %[[O1:.+]] = comb.add
-  %o0 = comb.add bin %foo, %c1_8 : i8
-  // CHECK: %[[O2:.+]] = comb.sub
-  %o1 = comb.sub bin %foo, %c1_8 : i8
+      // CHECK: verif.yield %[[BAR0]], %[[BAR1]] : i8, i8
+      verif.yield %bar.0, %bar.1 : i8, i8
+  } 
+  
   // CHECK-LABEL: hw.output
   hw.output %o0, %o1 : i8, i8
 }
-
-// CHECK-LABEL: hw.module @Foo1
-hw.module @Foo1(in %0 "0": i1, in %1 "1": i1, out "" : i8, out "1" : i8) {
-  // CHECK: %[[C42:.+]] = hw.constant 42 : i8
-  %c42_8 = hw.constant 42 : i8
-  // CHECK: %[[OUTS:.+]]:2 = verif.instance(%[[C42]]) : (i8) -> (i8, i8) {
-  %bar.0, %bar.1 = verif.instance (%c42_8) : (i8) -> (i8, i8) {
-    // CHECK: ^bb0(%[[ARG:.+]]: i8):
-    ^bb0(%arg1: i8):
-      // CHECK: %[[C0:.+]] = hw.constant 0 : i8
-      %c0_8 = hw.constant 0 : i8
-      // CHECK: %[[PREC:.+]] = comb.icmp bin ugt %[[ARG]], %[[C0]] : i8
-      %prec = comb.icmp bin ugt %arg1, %c0_8 : i8
-      // CHECK: verif.assert %[[PREC]] : i1
-      verif.assert %prec : i1
-
-      // CHECK: %[[OUT0:.+]] = verif.symbolic_input : i8
-      %bar.0 = verif.symbolic_input : i8
-      // CHECK: %[[OUT1:.+]] = verif.symbolic_input : i8
-      %bar.1 = verif.symbolic_input : i8
-      // CHECK: %[[P0:.+]] = comb.icmp bin ugt %[[OUT0]], %[[ARG]] : i8
-      %post = comb.icmp bin ugt %bar.0, %arg1 : i8
-      // CHECK: %[[P1:.+]] = comb.icmp bin ult %[[OUT1]], %[[ARG]] : i8
-      %post1 = comb.icmp bin ult %bar.1, %arg1 : i8
-      // CHECK: verif.assume %[[P0]] : i1
-      verif.assume %post : i1
-      // CHECK: verif.assume %[[P1]] : i1
-      verif.assume %post1 : i1
-      // CHECK: verif.yield %[[OUT0]], %[[OUT1]] : i8, i8
-      verif.yield %bar.0, %bar.1 : i8, i8
-  } 
-  // CHECK: hw.output %[[OUTS]]#0, %[[OUTS]]#1 : i8, i8
-  hw.output %bar.0, %bar.1 : i8, i8
- }
 
 //===----------------------------------------------------------------------===//
 // Print-related


### PR DESCRIPTION
This PR redesigns the recent formal contract ops to allow for them to be used within an arbitrary scope and not just at the level of an entire module. This also removes the need for the `verif.instance` op.