### PR TITLE
[MooreToCore] More extract op lowerings

### DIFF
--- a/include/circt/Dialect/LLHD/IR/ExtractOps.td
+++ b/include/circt/Dialect/LLHD/IR/ExtractOps.td
@@ -18,8 +18,8 @@ class SigPtrIndexBitWidthConstraint<string index, string input>
   : TypesMatchWith<"Index width should be exactly clog2 (size of array)",
                    input, index,
                    [{
-                     IntegerType::get($_self.getContext(), std::max<uint64_t>(
-                       llvm::Log2_64_Ceil(llhd::getLLHDTypeWidth($_self)), 1))
+                      IntegerType::get($_self.getContext(), 
+                        llvm::Log2_64_Ceil(llhd::getLLHDTypeWidth($_self)))
                    }]>;
 
 class SigArrayElementTypeConstraint<string result, string input>


### PR DESCRIPTION
We need to inset runtime checks for out-of-bound accesses because the semantics of the core dialects don't match the ones of SystemVerilog. I left this for a future PR since there are a few interesting cases to consider and it would increase the size of this PR considerably.