### PR TITLE
[MooreToCore] Support four-valued VariableOp without init

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -320,18 +320,18 @@ struct VariableOpConversion : public OpConversionPattern<VariableOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     Type resultType = typeConverter->convertType(op.getResult().getType());
-    Value init = adaptor.getInitial();
-    // TODO: Unsupport x/z, so the initial value is 0.
-    if (!init && cast<RefType>(op.getResult().getType()).getDomain() ==
-                     Domain::FourValued)
-      return failure();
 
+    // Determine the initial value of the signal.
+    Value init = adaptor.getInitial();
     if (!init) {
       Type elementType = cast<hw::InOutType>(resultType).getElementType();
       int64_t width = hw::getBitWidth(elementType);
       if (width == -1)
         return failure();
 
+      // TODO: Once the core dialects support four-valued integers, this code
+      // will additionally need to generate an all-X value for four-valued
+      // variables.
       Value constZero = rewriter.create<hw::ConstantOp>(loc, APInt(width, 0));
       init = rewriter.createOrFold<hw::BitcastOp>(loc, elementType, constZero);
     }

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -353,6 +353,9 @@ moore.module @Variable() {
   %1 = moore.constant 1 : l1
   // CHECK: llhd.sig "l" %true : i1
   %l = moore.variable %1 : <l1>
+  // CHECK: [[TMP:%.+]] = hw.constant 0 : i19
+  // CHECK: llhd.sig "m" [[TMP]] : i19
+  %m = moore.variable : <l19>
 
   // CHECK: [[TMP2:%.+]] = hw.constant 10 : i32
   %3 = moore.constant 10 : i32


### PR DESCRIPTION
Initialize `VariableOp`s of a four-valued type with a zero. This is in line with the rest of `MooreToCore` which maps all X/Z to zero at the moment, either implicitly by mapping to `comb.*` ops, or explicitly by conjuring up zero constants.