### PR TITLE
[MooreToCore] Support CaseZEq and CaseXZEq ops

### DIFF
--- a/include/circt/Support/FVInt.h
+++ b/include/circt/Support/FVInt.h
@@ -208,6 +208,9 @@ public:
   /// Compute a mask of all the Z bits in this integer.
   APInt getZBits() const { return value & unknown; }
 
+  /// Compute a mask of all the X and Z bits in this integer.
+  APInt getUnknownBits() const { return unknown; }
+
   /// Set the value of all bits in the mask to 0.
   template <typename T>
   void setZeroBits(const T &mask) {

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -718,13 +718,57 @@ struct ICmpOpConversion : public OpConversionPattern<SourceOp> {
   using OpAdaptor = typename SourceOp::Adaptor;
 
   LogicalResult
-  matchAndRewrite(SourceOp op, OpAdaptor adapter,
+  matchAndRewrite(SourceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType =
         ConversionPattern::typeConverter->convertType(op.getResult().getType());
 
     rewriter.replaceOpWithNewOp<comb::ICmpOp>(
-        op, resultType, pred, adapter.getLhs(), adapter.getRhs());
+        op, resultType, pred, adaptor.getLhs(), adaptor.getRhs());
+    return success();
+  }
+};
+
+template <typename SourceOp, bool withoutX>
+struct CaseXZEqOpConversion : public OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+  using OpAdaptor = typename SourceOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Check each operand if it is a known constant and extract the X and/or Z
+    // bits to be ignored.
+    // TODO: Once the core dialects support four-valued integers, we will have
+    // to create ops that extract X and Z bits from the operands, since we also
+    // have to do the right casez/casex comparison on non-constant inputs.
+    unsigned bitWidth = op.getLhs().getType().getWidth();
+    auto ignoredBits = APInt::getZero(bitWidth);
+    auto detectIgnoredBits = [&](Value value) {
+      auto constOp = value.getDefiningOp<ConstantOp>();
+      if (!constOp)
+        return;
+      auto constValue = constOp.getValue();
+      if (withoutX)
+        ignoredBits |= constValue.getZBits();
+      else
+        ignoredBits |= constValue.getUnknownBits();
+    };
+    detectIgnoredBits(op.getLhs());
+    detectIgnoredBits(op.getRhs());
+
+    // If we have detected any bits to be ignored, mask them in the operands for
+    // the comparison.
+    Value lhs = adaptor.getLhs();
+    Value rhs = adaptor.getRhs();
+    if (!ignoredBits.isZero()) {
+      ignoredBits.flipAllBits();
+      auto maskOp = rewriter.create<hw::ConstantOp>(op.getLoc(), ignoredBits);
+      lhs = rewriter.createOrFold<comb::AndOp>(op.getLoc(), lhs, maskOp);
+      rhs = rewriter.createOrFold<comb::AndOp>(op.getLoc(), rhs, maskOp);
+    }
+
+    rewriter.replaceOpWithNewOp<comb::ICmpOp>(op, ICmpPredicate::ceq, lhs, rhs);
     return success();
   }
 };
@@ -1114,6 +1158,8 @@ static void populateOpConversion(RewritePatternSet &patterns,
     ICmpOpConversion<CaseNeOp, ICmpPredicate::cne>,
     ICmpOpConversion<WildcardEqOp, ICmpPredicate::weq>,
     ICmpOpConversion<WildcardNeOp, ICmpPredicate::wne>,
+    CaseXZEqOpConversion<CaseZEqOp, true>,
+    CaseXZEqOpConversion<CaseXZEqOp, false>,
     
     // Patterns of structural operations.
     SVModuleOpConversion, InstanceOpConversion, ProcedureOpConversion,

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -517,3 +517,47 @@ moore.module @Process(in %cond : i1) {
     moore.return
   }
 }
+
+// CHECK-LABEL: func.func @CaseXZ(
+func.func @CaseXZ(%arg0: !moore.l8, %arg1: !moore.l8) {
+  // CHECK: hw.constant -124 : i8
+  // CHECK: hw.constant -120 : i8
+  %0 = moore.constant b10XX01ZZ : l8
+  %1 = moore.constant b1XX01ZZ0 : l8
+
+  // CHECK: comb.icmp ceq %arg0, %arg1 : i8
+  moore.casez_eq %arg0, %arg1 : l8
+  // CHECK: [[MASK:%.+]] = hw.constant -7 : i8
+  // CHECK: [[TMP1:%.+]] = comb.and %arg0, [[MASK]]
+  // CHECK: [[TMP2:%.+]] = hw.constant -120 : i8
+  // CHECK: comb.icmp ceq [[TMP1]], [[TMP2]] : i8
+  moore.casez_eq %arg0, %1 : l8
+  // CHECK: [[MASK:%.+]] = hw.constant -4 : i8
+  // CHECK: [[TMP1:%.+]] = comb.and %arg1, [[MASK]]
+  // CHECK: [[TMP2:%.+]] = hw.constant -124 : i8
+  // CHECK: comb.icmp ceq [[TMP1]], [[TMP2]] : i8
+  moore.casez_eq %0, %arg1 : l8
+  // CHECK: [[TMP1:%.+]] = hw.constant -128 : i8
+  // CHECK: [[TMP2:%.+]] = hw.constant -120 : i8
+  // CHECK: comb.icmp ceq [[TMP1]], [[TMP2]] : i8
+  moore.casez_eq %0, %1 : l8
+
+  // CHECK: comb.icmp ceq %arg0, %arg1 : i8
+  moore.casexz_eq %arg0, %arg1 : l8
+  // CHECK: [[MASK:%.+]] = hw.constant -103 : i8
+  // CHECK: [[TMP1:%.+]] = comb.and %arg0, [[MASK]]
+  // CHECK: [[TMP2:%.+]] = hw.constant -120 : i8
+  // CHECK: comb.icmp ceq [[TMP1]], [[TMP2]] : i8
+  moore.casexz_eq %arg0, %1 : l8
+  // CHECK: [[MASK:%.+]] = hw.constant -52 : i8
+  // CHECK: [[TMP1:%.+]] = comb.and %arg1, [[MASK]]
+  // CHECK: [[TMP2:%.+]] = hw.constant -124 : i8
+  // CHECK: comb.icmp ceq [[TMP1]], [[TMP2]] : i8
+  moore.casexz_eq %0, %arg1 : l8
+  // CHECK: [[TMP1:%.+]] = hw.constant -128 : i8
+  // CHECK: [[TMP2:%.+]] = hw.constant -120 : i8
+  // CHECK: comb.icmp ceq [[TMP1]], [[TMP2]] : i8
+  moore.casexz_eq %0, %1 : l8
+
+  return
+}


### PR DESCRIPTION
Add a conversion for `moore.casez_eq` and `moore.casexz_eq` operations. These only really make sense if the operands are four-valued integers, since the X and Z bits indicate which bits to ignore during the equality check. We don't have support for four-valued integers in the core dialects yet. However, the vast majority of uses of this op are comparing an SSA value against a `moore.constant`. This case we can handle properly by looking at the constant, identifying the unknown bits, and then masking them before performing a regular two-valued comparison between the two operands.