### PR TITLE
[HW][CAPI] Add a function to get an empty `InnerSymAttr`

### DIFF
--- a/include/circt-c/Dialect/HW.h
+++ b/include/circt-c/Dialect/HW.h
@@ -161,6 +161,7 @@ MLIR_CAPI_EXPORTED MlirStringRef hwTypeAliasTypeGetScope(MlirType typeAlias);
 
 MLIR_CAPI_EXPORTED bool hwAttrIsAInnerSymAttr(MlirAttribute);
 MLIR_CAPI_EXPORTED MlirAttribute hwInnerSymAttrGet(MlirAttribute symName);
+MLIR_CAPI_EXPORTED MlirAttribute hwInnerSymAttrGetEmpty(MlirContext ctx);
 MLIR_CAPI_EXPORTED MlirAttribute hwInnerSymAttrGetSymName(MlirAttribute);
 
 MLIR_CAPI_EXPORTED bool hwAttrIsAInnerRefAttr(MlirAttribute);

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -217,6 +217,10 @@ MlirAttribute hwInnerSymAttrGet(MlirAttribute symName) {
   return wrap(InnerSymAttr::get(cast<StringAttr>(unwrap(symName))));
 }
 
+MlirAttribute hwInnerSymAttrGetEmpty(MlirContext ctx) {
+  return wrap(InnerSymAttr::get(unwrap(ctx)));
+}
+
 MlirAttribute hwInnerSymAttrGetSymName(MlirAttribute innerSymAttr) {
   return wrap((Attribute)cast<InnerSymAttr>(unwrap(innerSymAttr)).getSymName());
 }


### PR DESCRIPTION
This allows us to set sym for partial ports - something like this pseudo-code:

```c
mlirOperationSetInherentAttributeByName(
    moduleOp, // The module has 3 ports created
    "portSyms",
    mlirArrayAttrGet({ hwInnerSymAttrGetEmpty(ctx), hwInnerSymAttrGet("name"), hwInnerSymAttrGetEmpty(ctx) })
);
```