### PR TITLE
[LLHD] Add `llhd.delay` operation

### DIFF
--- a/include/circt/Dialect/LLHD/IR/SignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/SignalOps.td
@@ -307,3 +307,19 @@ def LLHD_RegOp : LLHD_Op<"reg", [
 
   let hasVerifier = 1;
 }
+
+def DelayOp : LLHD_Op<"delay", [Pure, SameOperandsAndResultType]> {
+  let summary = "specifies value propagation delay";
+  let description = [{
+    This operation propagates all value changes of the input to the output after
+    the specified time delay.
+    Reference values are not supported (e.g., pointers, inout, etc.)
+    since the store-like operation used for those types should encode a delayed
+    store.
+  }];
+
+  let arguments = (ins HWNonInOutType:$input, LLHD_TimeAttr:$delay);
+  let results = (outs HWNonInOutType:$result);
+
+  let assemblyFormat = "$input `by` $delay attr-dict `:` type($result)";
+}

--- a/test/Dialect/LLHD/IR/basic.mlir
+++ b/test/Dialect/LLHD/IR/basic.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt %s | circt-opt | FileCheck %s
+
+// CHECK-LABEL: @basic
+// CHECK-SAME: (in [[IN0:%.+]] : i32, out out0 : i32)
+hw.module @basic(in %in0 : i32, out out0 : i32) {
+  // CHECK: %{{.*}} = llhd.delay [[IN0]] by <0ns, 1d, 0e> : i32
+  %0 = llhd.delay %in0 by <0ns, 1d, 0e> : i32
+  hw.output %0 : i32
+}

--- a/test/Dialect/LLHD/IR/errors.mlir
+++ b/test/Dialect/LLHD/IR/errors.mlir
@@ -1,0 +1,7 @@
+// RUN: circt-opt %s --split-input-file --verify-diagnostics
+
+hw.module @errors(in %in0: i32, out out0: i8) {
+  // expected-error @below {{requires the same type for all operands and results}}
+  %0 = "llhd.delay"(%in0) {delay = #llhd.time<0ns, 1d, 0e>} : (i32) -> i8
+  hw.output %0 : i8
+}


### PR DESCRIPTION
Add an operation that delays the propagation of value changes from its input to its output. This allows mem2reg of LLHD signals with a unique driver with a delay. For example
```
%sig = llhd.sig
llhd.drv %sig, %val after <1ns, 0d, 0e>
%res = llhd.prb %sig
```
can become
```
%res = llhd.delay %val by <1ns, 0d, 0e>
```