### PR TITLE
[OM] Support list concatenation in the Evaluator.

### DIFF
--- a/include/circt/Dialect/OM/Evaluator/Evaluator.h
+++ b/include/circt/Dialect/OM/Evaluator/Evaluator.h
@@ -481,6 +481,9 @@ private:
   FailureOr<EvaluatorValuePtr> evaluateListCreate(ListCreateOp op,
                                                   ActualParameters actualParams,
                                                   Location loc);
+  FailureOr<EvaluatorValuePtr> evaluateListConcat(ListConcatOp op,
+                                                  ActualParameters actualParams,
+                                                  Location loc);
   FailureOr<EvaluatorValuePtr>
   evaluateTupleCreate(TupleCreateOp op, ActualParameters actualParams,
                       Location loc);


### PR DESCRIPTION
List concatenation is implemented by first ensuring all the sub-lists are evaluated, and then appending the elements of each sub-list into the final ListValue that represents the concatenation of the lists.