### PR TITLE
[FIRRTL] Add list concatenation parser support.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -169,6 +169,7 @@ TOK_LPKEYWORD(assume)
 TOK_LPKEYWORD(cover)
 
 TOK_LPKEYWORD(path)
+TOK_LPKEYWORD(list_concat)
 
 TOK_LPKEYWORD(force)
 TOK_LPKEYWORD(force_initial)

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1671,6 +1671,20 @@ circuit IntegerArithmetic :
     propassign e, integer_shr(a, b)
 
 ;// -----
+FIRRTL version 4.0.0
+
+; CHECK-LABEL: firrtl.circuit "PropertyListOps"
+circuit PropertyListOps :
+  public module PropertyListOps :
+    input a : List<Integer>
+    input b : List<Integer>
+    output c : List<Integer>
+
+    ; CHECK: [[C:%.+]] = firrtl.list.concat %a, %b
+    ; CHECK: firrtl.propassign %c, [[C]]
+    propassign c, list_concat(a, b)
+
+;// -----
 FIRRTL version 3.1.0
 
 ; CHECK-LABEL: circuit "BundleOfProps"

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1027,6 +1027,42 @@ circuit Top:
     propassign c, integer_shr(a, b)
 
 ;// -----
+FIRRTL version 4.0.0
+
+; CHECK-LABEL: firrtl.circuit "Top"
+circuit Top :
+  public module Top :
+    input a : Integer
+    output b : List<Integer>
+
+    ; expected-error @below {{unexpected expression of type '!firrtl.integer' in List concat expression}}
+    propassign b, list_concat(a)
+
+;// -----
+FIRRTL version 4.0.0
+
+; CHECK-LABEL: firrtl.circuit "Top"
+circuit Top :
+  public module Top :
+    input a : List<Integer>
+    input b : List<String>
+    output c : List<Integer>
+
+    ; expected-error @below {{unexpected expression of type '!firrtl.list<string>' in List concat expression of type '!firrtl.list<integer>'}}
+    propassign c, list_concat(a, b)
+
+;// -----
+FIRRTL version 4.0.0
+
+; CHECK-LABEL: firrtl.circuit "Top"
+circuit Top :
+  public module Top :
+    output c : List<Integer>
+
+    ; expected-error @below {{need at least one List to concatenate}}
+    propassign c, list_concat()
+
+;// -----
 FIRRTL version 3.3.0
 
 circuit Top:


### PR DESCRIPTION
This parses `list_concat(exp+)` into the ListConcatOp. The type of the list is inferred during parsing, and all expressions must be the same. It is a parser error to not concatenate at least one list.