### PR TITLE
[FIRRTL] Add list concatenation conversion to LowerClasses.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -1385,6 +1385,22 @@ struct ListCreateOpConversion
   }
 };
 
+struct ListConcatOpConversion
+    : public OpConversionPattern<firrtl::ListConcatOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(firrtl::ListConcatOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto listType = getTypeConverter()->convertType<om::ListType>(op.getType());
+    if (!listType)
+      return failure();
+    rewriter.replaceOpWithNewOp<om::ListConcatOp>(op, listType,
+                                                  adaptor.getSubLists());
+    return success();
+  }
+};
+
 struct IntegerAddOpConversion
     : public OpConversionPattern<firrtl::IntegerAddOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -1864,6 +1880,7 @@ static void populateRewritePatterns(
   patterns.add<ObjectOpConversion>(converter, patterns.getContext());
   patterns.add<ObjectFieldOpConversion>(converter, patterns.getContext());
   patterns.add<ListCreateOpConversion>(converter, patterns.getContext());
+  patterns.add<ListConcatOpConversion>(converter, patterns.getContext());
   patterns.add<BoolConstantOpConversion>(converter, patterns.getContext());
   patterns.add<DoubleConstantOpConversion>(converter, patterns.getContext());
   patterns.add<IntegerAddOpConversion>(converter, patterns.getContext());

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -224,6 +224,13 @@ firrtl.circuit "PathModule" {
     // CHECK:  %[[c1:.+]] = om.list_create %propIn, %[[c0]] : !om.integer
     // CHECK:  om.class.field @propOut, %[[c1]] : !om.list<!om.integer>
   }
+
+   firrtl.module @ListConcat(in %propIn0: !firrtl.list<integer>, in %propIn1: !firrtl.list<integer>, out %propOut: !firrtl.list<integer>) {
+    // CHECK: [[CONCAT:%.+]] = om.list_concat %propIn0, %propIn1
+    %1 = firrtl.list.concat %propIn0, %propIn1 : !firrtl.list<integer>
+    // CHECK: om.class.field @propOut, [[CONCAT]]
+    firrtl.propassign %propOut, %1 : !firrtl.list<integer>
+  }
 }
 
 // CHECK-LABEL: firrtl.circuit "WireProp"


### PR DESCRIPTION
This is a straightforward 1:1 conversion from firrtl::ListConcatOp to om::ListConcatOp.