### PR TITLE
[LLHD] Relax sig parent constraint

### DIFF
--- a/include/circt/Dialect/LLHD/IR/LLHDSignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDSignalOps.td
@@ -13,7 +13,6 @@
 include "mlir/IR/EnumAttr.td"
 
 def SigOp : LLHDOp<"sig", [
-    ParentOneOf<["hw::HWModuleOp", "llhd::ProcessOp"]>,
     TypesMatchWith<
       "type of 'init' and underlying type of 'signal' have to match.",
       "init", "result", "hw::InOutType::get($_self)">

--- a/test/Dialect/LLHD/IR/errors.mlir
+++ b/test/Dialect/LLHD/IR/errors.mlir
@@ -113,12 +113,3 @@ hw.module @check_illegal_drv(inout %sig : i1) {
   %time = llhd.constant_time #llhd.time<1ns, 0d, 0e>
   "llhd.drv"(%sig, %c, %time) {} : (!hw.inout<i1>, i32, !llhd.time) -> ()
 }
-
-// -----
-
-func.func @illegal_sig_parent(%arg0 : i1) {
-  // expected-error @+1 {{expects parent op to be one of 'hw.module, llhd.process'}}
-  %0 = llhd.sig "sig" %arg0 : i1
-
-  return
-}


### PR DESCRIPTION
This is necessary because the moore dialect does not enforce such constraints for its variables and thus they can occur in functions