### PR TITLE
LowerLayers: fix how we emit layer bindfile headers

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -789,7 +789,7 @@ void LowerLayersPass::runOnOperation() {
   StringRef circuitName = circuitOp.getName();
   circuitOp.walk<mlir::WalkOrder::PreOrder>([&](LayerOp layerOp) {
     auto parentOp = layerOp->getParentOfType<LayerOp>();
-    while (parentOp && parentOp != layers.back().first)
+    while (!layers.empty() && parentOp != layers.back().first)
       layers.pop_back();
 
     if (layerOp.getConvention() == LayerConvention::Inline) {

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -694,3 +694,22 @@ firrtl.circuit "Foo" attributes {
 //
 // CHECK:       sv.verbatim
 // CHECK-SAME:    #hw.output_file<"testbench{{/|\\\\}}layers_Foo_A.sv", excludeFromFileList>
+
+
+// -----
+// Check that we correctly implement the verilog header and footer for B.
+
+firrtl.circuit "Foo" {
+  firrtl.layer @A bind {
+    firrtl.layer @X bind {}
+  }
+  firrtl.layer @B bind {}
+  firrtl.module @Foo() {}
+}
+
+// CHECK: firrtl.circuit "Foo" {
+// CHECK:   sv.verbatim "`ifndef layers_Foo_B\0A`define layers_Foo_B" {output_file = #hw.output_file<"layers_Foo_B.sv", excludeFromFileList>}
+// CHECK:   firrtl.module @Foo() {
+// CHECK:   }
+// CHECK:   sv.verbatim "`endif // layers_Foo_B" {output_file = #hw.output_file<"layers_Foo_B.sv", excludeFromFileList>}
+// CHECK: }


### PR DESCRIPTION
For each layer, we emit a bindfile. Each bindfile has a header consisting of an include guard, and an include for each parent layer's bindfile. To emit the bindfile's headers, we walk the layer declarations, and keep track of a stack of parent layers, which we use to emit the includes.

Unfortunately, a bug in the stack management code means that we forget to unwind the stack of parent layers, when the curent layer has no parents. This caused us to emit an include from one layer to the previous layer, when the previous layer had any children.

This PR fixes the stack unwind loop to correctly clear the stack, when the current layer has no parents.