### PR TITLE
[LowerIntmodules] Fix EICG_wrapper intrinsic lowering, swap en/test_en.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
@@ -181,6 +181,20 @@ void LowerIntmodulesPass::runOnOperation() {
         };
 
         auto inputs = replaceResults(builder, inst.getResults().drop_back());
+        // en and test_en are swapped between extmodule and intrinsic.
+        if (inputs.size() > 2) {
+          auto port1 = inst.getPortName(1);
+          auto port2 = inst.getPortName(2);
+          if (port1 != "test_en") {
+            mlir::emitError(op.getPortLocation(1),
+                            "expected port named 'test_en'");
+            return signalPassFailure();
+          } else if (port2 != "en") {
+            mlir::emitError(op.getPortLocation(2), "expected port named 'en'");
+            return signalPassFailure();
+          } else
+            std::swap(inputs[1], inputs[2]);
+        }
         auto intop = builder.create<GenericIntrinsicOp>(
             builder.getType<ClockType>(), "circt_clock_gate", inputs,
             op.getParameters());

--- a/test/Dialect/FIRRTL/lower-intmodules-eicg.mlir
+++ b/test/Dialect/FIRRTL/lower-intmodules-eicg.mlir
@@ -11,13 +11,37 @@ firrtl.circuit "FixupEICGWrapper" {
     annotations = [{class = "firrtl.transforms.DedupGroupAnnotation", group = "foo"}]}
 
   // CHECK: FixupEICGWrapper
-  firrtl.module @FixupEICGWrapper(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>) {
+  firrtl.module @FixupEICGWrapper(in %clock: !firrtl.clock, in %test_en: !firrtl.uint<1>, in %en: !firrtl.uint<1>) {
     // CHECK-NOEICG: firrtl.instance
     // CHECK-EICG-NOT: firrtl.instance
-    // CHECK-EICG: firrtl.int.generic "circt_clock_gate"
+    // CHECK-EICG-DAG: firrtl.matchingconnect %[[CLK:.+]], %clock : !firrtl.clock
+    // CHECK-EICG-DAG: firrtl.matchingconnect %[[TEST_EN:.+]], %test_en : !firrtl.uint<1>
+    // CHECK-EICG-DAG: firrtl.matchingconnect %[[EN:.+]], %en : !firrtl.uint<1>
+    // CHECK-EICG-DAG: %[[CLK]] = firrtl.wire : !firrtl.clock
+    // CHECK-EICG-DAG: %[[TEST_EN]] = firrtl.wire : !firrtl.uint<1>
+    // CHECK-EICG-DAG: %[[EN]] = firrtl.wire : !firrtl.uint<1>
+    // CHECK-EICG-DAG: %3 = firrtl.int.generic "circt_clock_gate"  %[[CLK]], %[[EN]], %[[TEST_EN]] : (!firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.clock
     %ckg_in, %ckg_test_en, %ckg_en, %ckg_out = firrtl.instance ckg @LegacyClockGate(in in: !firrtl.clock, in test_en: !firrtl.uint<1>, in en: !firrtl.uint<1>, out out: !firrtl.clock)
     firrtl.matchingconnect %ckg_in, %clock : !firrtl.clock
-    firrtl.matchingconnect %ckg_test_en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %ckg_test_en, %test_en : !firrtl.uint<1>
+    firrtl.matchingconnect %ckg_en, %en : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+firrtl.circuit "EICGWrapperPortName" {
+  firrtl.extmodule @BadClockGate(in in: !firrtl.clock,
+                                 // expected-error @below {{expected port named 'test_en'}}
+                                 in en: !firrtl.uint<1>,
+                                 in test_en: !firrtl.uint<1>,
+                                 out out: !firrtl.clock)
+    attributes { defname = "EICG_wrapper" }
+
+  firrtl.module @EICGWrapperPortName(in %clock: !firrtl.clock, in %test_en: !firrtl.uint<1>, in %en: !firrtl.uint<1>) {
+    %ckg_in, %ckg_en, %ckg_test_en, %ckg_out = firrtl.instance ckg @BadClockGate(in in: !firrtl.clock, in en: !firrtl.uint<1>, in test_en: !firrtl.uint<1>, out out: !firrtl.clock)
+    firrtl.matchingconnect %ckg_in, %clock : !firrtl.clock
+    firrtl.matchingconnect %ckg_test_en, %test_en : !firrtl.uint<1>
     firrtl.matchingconnect %ckg_en, %en : !firrtl.uint<1>
   }
 }


### PR DESCRIPTION
The extmodule and intrinsic disagree on port ordering, swap in LowerIntmodules.

Thanks to @prithayan for reporting this!