### PR TITLE
[LLHD] Align signals with other wire/variable ops

### DIFF
--- a/include/circt/Dialect/LLHD/IR/LLHDSignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDSignalOps.td
@@ -11,12 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 include "mlir/IR/EnumAttr.td"
+include "mlir/IR/OpAsmInterface.td"
 
-def SigOp : LLHDOp<"sig", [
-    TypesMatchWith<
-      "type of 'init' and underlying type of 'signal' have to match.",
-      "init", "result", "hw::InOutType::get($_self)">
-  ]> {
+def SignalOp : LLHDOp<"sig", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+  TypesMatchWith<
+    "type of 'init' and underlying type of 'signal' have to match.",
+    "init", "result", "hw::InOutType::get($_self)">
+]> {
   let summary = "Create a signal.";
   let description = [{
     The `llhd.sig` instruction introduces a new signal in the IR. The input
@@ -28,17 +30,22 @@ def SigOp : LLHDOp<"sig", [
 
     ```mlir
     %c123_i64 = hw.constant 123 : i64
-    %sig_i64 = llhd.sig "foo" %c123_i64 : i64
+    %foo = llhd.sig %c123_i64 : i64
+    %0 = llhd.sig name "foo" %c123_i64 : i64
     ```
 
     This example creates a new signal named "foo", carrying an `i64` type with
     initial value of 123.
   }];
-
-  let arguments = (ins StrAttr: $name, HWValueType: $init);
-  let results = (outs InOutType: $result);
-
-  let assemblyFormat = "$name $init attr-dict `:` qualified(type($init))";
+  let arguments = (ins
+    OptionalAttr<StrAttr>:$name,
+    HWValueType:$init
+  );
+  let results = (outs Res<InOutType, "", [MemAlloc]>:$result);
+  let assemblyFormat = [{
+    `` custom<ImplicitSSAName>($name) $init attr-dict
+    `:` type($init)
+  }];
 }
 
 def PrbOp : LLHDOp<"prb", [

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -337,8 +337,8 @@ struct VariableOpConversion : public OpConversionPattern<VariableOp> {
       init = rewriter.createOrFold<hw::BitcastOp>(loc, elementType, constZero);
     }
 
-    rewriter.replaceOpWithNewOp<llhd::SigOp>(op, resultType, op.getNameAttr(),
-                                             init);
+    rewriter.replaceOpWithNewOp<llhd::SignalOp>(op, resultType,
+                                                op.getNameAttr(), init);
     return success();
   }
 };

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -12,6 +12,7 @@
 
 #include "circt/Dialect/LLHD/IR/LLHDOps.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Support/CustomDirectiveImpl.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Matchers.h"
@@ -24,6 +25,7 @@
 
 using namespace circt;
 using namespace mlir;
+using namespace llhd;
 
 unsigned circt::llhd::getLLHDTypeWidth(Type type) {
   if (auto sig = dyn_cast<hw::InOutType>(type))
@@ -62,6 +64,15 @@ void llhd::ConstantTimeOp::build(OpBuilder &builder, OperationState &result,
   auto *ctx = builder.getContext();
   auto attr = TimeAttr::get(ctx, time, timeUnit, delta, epsilon);
   return build(builder, result, TimeType::get(ctx), attr);
+}
+
+//===----------------------------------------------------------------------===//
+// SignalOp
+//===----------------------------------------------------------------------===//
+
+void SignalOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  if (getName() && !getName()->empty())
+    setNameFn(getResult(), *getName());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/LLHD/Transforms/EarlyCodeMotionPass.cpp
+++ b/lib/Dialect/LLHD/Transforms/EarlyCodeMotionPass.cpp
@@ -70,7 +70,7 @@ void EarlyCodeMotionPass::runOnProcess(llhd::ProcessOp proc) {
     for (auto iter = block->getOperations().begin();
          iter != block->getOperations().end(); ++iter) {
       Operation &op = *iter;
-      if (!isa<llhd::PrbOp>(op) && !isa<llhd::SigOp>(op) &&
+      if (!isa<llhd::PrbOp>(op) && !isa<llhd::SignalOp>(op) &&
           (!mlir::isMemoryEffectFree(&op) ||
            op.hasTrait<OpTrait::IsTerminator>()))
         continue;

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -369,31 +369,31 @@ moore.module @ParamTest(){
 
 moore.module @Variable() {
   // CHECK: [[TMP0:%.+]] = hw.constant 0 : i32
-  // CHECK: [[A:%.+]] = llhd.sig "a" [[TMP0]] : i32
+  // CHECK: %a = llhd.sig [[TMP0]] : i32
   %a = moore.variable : <i32>
 
   // CHECK: [[TMP1:%.+]] = hw.constant 0 : i8
-  // CHECK: [[B:%.+]] = llhd.sig "b1" [[TMP1]] : i8
+  // CHECK: %b1 = llhd.sig [[TMP1]] : i8
   %b1 = moore.variable : <i8>
 
-  // CHECK: [[PRB:%.+]] = llhd.prb [[B]] : !hw.inout<i8>
+  // CHECK: [[PRB:%.+]] = llhd.prb %b1 : !hw.inout<i8>
   %0 = moore.read %b1 : <i8>
-  // CHECK: llhd.sig "b2" [[PRB]] : i8
+  // CHECK: %b2 = llhd.sig [[PRB]] : i8
   %b2 = moore.variable %0 : <i8>
 
   // CHECK: %true = hw.constant true
   %1 = moore.constant 1 : l1
-  // CHECK: llhd.sig "l" %true : i1
+  // CHECK: %l = llhd.sig %true : i1
   %l = moore.variable %1 : <l1>
   // CHECK: [[TMP:%.+]] = hw.constant 0 : i19
-  // CHECK: llhd.sig "m" [[TMP]] : i19
+  // CHECK: %m = llhd.sig [[TMP]] : i19
   %m = moore.variable : <l19>
 
   // CHECK: [[TMP2:%.+]] = hw.constant 10 : i32
   %3 = moore.constant 10 : i32
   
   // CHECK: [[TIME:%.+]] = llhd.constant_time <0ns, 0d, 1e>
-  // CHECK: llhd.drv [[A]], [[TMP2]] after [[TIME]] : !hw.inout<i32>
+  // CHECK: llhd.drv %a, [[TMP2]] after [[TIME]] : !hw.inout<i32>
   moore.assign %a, %3 : i32
 
   // CHECK: hw.output
@@ -411,8 +411,8 @@ moore.module @Struct(in %a : !moore.i32, in %b : !moore.i32, in %arg0 : !moore.s
   
   // CHECK: [[C0:%.+]] = hw.constant 0 : i64
   // CHECK: [[INIT:%.+]] = hw.bitcast [[C0]] : (i64) -> !hw.struct<exp_bits: i32, man_bits: i32>
-  // CHECK: llhd.sig "" [[INIT]] : !hw.struct<exp_bits: i32, man_bits: i32>
-  // CHECK: llhd.sig "" %arg0 : !hw.struct<exp_bits: i32, man_bits: i32>
+  // CHECK: llhd.sig [[INIT]] : !hw.struct<exp_bits: i32, man_bits: i32>
+  // CHECK: llhd.sig %arg0 : !hw.struct<exp_bits: i32, man_bits: i32>
   %1 = moore.variable : <struct<{exp_bits: i32, man_bits: i32}>>
   %2 = moore.variable %arg0 : <struct<{exp_bits: i32, man_bits: i32}>>
 
@@ -427,10 +427,10 @@ moore.module @Struct(in %a : !moore.i32, in %b : !moore.i32, in %arg0 : !moore.s
 
 // CHECK-LABEL: hw.module @Process
 moore.module @Process(in %cond : i1) {
-  // CHECK: [[B:%.+]] = llhd.sig "b"
-  // CHECK: [[C:%.+]] = llhd.sig "c"
-  // CHECK: [[D:%.+]] = llhd.sig "d"
-  // CHECK: [[E:%.+]] = llhd.sig "e"
+  // CHECK: [[B:%b]] = llhd.sig
+  // CHECK: [[C:%c]] = llhd.sig
+  // CHECK: [[D:%d]] = llhd.sig
+  // CHECK: [[E:%e]] = llhd.sig
   %b = moore.variable : <i1>
   %c = moore.variable : <i1>
   %d = moore.variable : <i1>

--- a/test/Dialect/LLHD/IR/basic.mlir
+++ b/test/Dialect/LLHD/IR/basic.mlir
@@ -90,22 +90,22 @@ func.func @check_store(%int : !llhd.ptr<i32>, %intC : i32 , %array : !llhd.ptr<!
 hw.module @checkSigInst() {
   // CHECK: %[[CI1:.*]] = hw.constant
   %cI1 = hw.constant 0 : i1
-  // CHECK-NEXT: %{{.*}} = llhd.sig "sigI1" %[[CI1]] : i1
-  %sigI1 = llhd.sig "sigI1" %cI1 : i1
+  // CHECK-NEXT: %sigI1 = llhd.sig %[[CI1]] : i1
+  %sigI1 = llhd.sig %cI1 : i1
   // CHECK-NEXT: %[[CI64:.*]] = hw.constant
   %cI64 = hw.constant 0 : i64
-  // CHECK-NEXT: %{{.*}} = llhd.sig "sigI64" %[[CI64]] : i64
-  %sigI64 = llhd.sig "sigI64" %cI64 : i64
+  // CHECK-NEXT: %sigI64 = llhd.sig %[[CI64]] : i64
+  %sigI64 = llhd.sig %cI64 : i64
 
   // CHECK-NEXT: %[[TUP:.*]] = hw.struct_create
   %tup = hw.struct_create (%cI1, %cI64) : !hw.struct<foo: i1, bar: i64>
-  // CHECK-NEXT: %{{.*}} = llhd.sig "sigTup" %[[TUP]] : !hw.struct<foo: i1, bar: i64>
-  %sigTup = llhd.sig "sigTup" %tup : !hw.struct<foo: i1, bar: i64>
+  // CHECK-NEXT: %sigTup = llhd.sig %[[TUP]] : !hw.struct<foo: i1, bar: i64>
+  %sigTup = llhd.sig %tup : !hw.struct<foo: i1, bar: i64>
 
   // CHECK-NEXT: %[[ARRAY:.*]] = hw.array_create
   %array = hw.array_create %cI1, %cI1 : i1
-  // CHECK-NEXT: %{{.*}} = llhd.sig "sigArray" %[[ARRAY]] : !hw.array<2xi1>
-  %sigArray = llhd.sig "sigArray" %array : !hw.array<2xi1>
+  // CHECK-NEXT: %sigArray = llhd.sig %[[ARRAY]] : !hw.array<2xi1>
+  %sigArray = llhd.sig %array : !hw.array<2xi1>
 }
 
 // CHECK-LABEL: @checkPrb

--- a/test/Dialect/LLHD/Transforms/temporal-code-motion.mlir
+++ b/test/Dialect/LLHD/Transforms/temporal-code-motion.mlir
@@ -9,36 +9,28 @@ hw.module @basic(in %cond: i1) {
   // CHECK: [[V1:%.+]] = llhd.constant_time <0ns, 0d, 1e>
   %0 = llhd.constant_time <0ns, 1d, 0e>
   %1 = llhd.constant_time <0ns, 0d, 1e>
-  // CHECK: [[V2:%.+]] = llhd.sig "a"
-  // CHECK: [[V3:%.+]] = llhd.sig "b"
-  // CHECK: [[V4:%.+]] = llhd.sig "c"
-  // CHECK: [[V5:%.+]] = llhd.sig "d"
-  // CHECK: [[V6:%.+]] = llhd.sig "e"
-  // CHECK: [[V7:%.+]] = llhd.sig "f"
-  // CHECK: [[V8:%.+]] = llhd.sig "g"
-  // CHECK: [[V9:%.+]] = llhd.sig "h"
-  // CHECK: [[V10:%.+]] = llhd.sig "i"
-  // CHECK: [[V11:%.+]] = llhd.sig "j"
-  // CHECK: [[V12:%.+]] = llhd.sig "k"
-  // CHECK: [[V13:%.+]] = llhd.sig "l"
-  // CHECK: [[V13_1:%.+]] = llhd.sig "m"
-  // CHECK: [[V13_2:%.+]] = llhd.sig "n"
-  // CHECK: [[V13_3:%.+]] = llhd.sig "o"
-  %2 = llhd.sig "a" %false : i1
-  %3 = llhd.sig "b" %false : i1
-  %4 = llhd.sig "c" %false : i1
-  %5 = llhd.sig "d" %false : i1
-  %6 = llhd.sig "e" %false : i1
-  %7 = llhd.sig "f" %false : i1
-  %8 = llhd.sig "g" %c0_i4 : i4
-  %9 = llhd.sig "h" %c0_i4 : i4
-  %10 = llhd.sig "i" %c0_i4 : i4
-  %11 = llhd.sig "j" %false : i1
-  %12 = llhd.sig "k" %c0_i5 : i5
-  %13 = llhd.sig "l" %c0_i5 : i5
-  %14 = llhd.sig "m" %c0_i5 : i5
-  %15 = llhd.sig "n" %c0_i5 : i5
-  %16 = llhd.sig "o" %c0_i5 : i5
+  // CHECK: %c = llhd.sig
+  // CHECK: %d = llhd.sig
+  // CHECK: %e = llhd.sig
+  // CHECK: %f = llhd.sig
+  // CHECK: %g = llhd.sig
+  // CHECK: %h = llhd.sig
+  // CHECK: %k = llhd.sig
+  // CHECK: %l = llhd.sig
+  // CHECK: %m = llhd.sig
+  // CHECK: %n = llhd.sig
+  // CHECK: %o = llhd.sig
+  %c = llhd.sig %false : i1
+  %d = llhd.sig %false : i1
+  %e = llhd.sig %false : i1
+  %f = llhd.sig %false : i1
+  %g = llhd.sig %c0_i4 : i4
+  %h = llhd.sig %c0_i4 : i4
+  %k = llhd.sig %c0_i5 : i5
+  %l = llhd.sig %c0_i5 : i5
+  %m = llhd.sig %c0_i5 : i5
+  %n = llhd.sig %c0_i5 : i5
+  %o = llhd.sig %c0_i5 : i5
 
   // COM: Check that an auxillary block is created and all drives are moved to
   // COM: the exit block with the correct enable condition
@@ -49,45 +41,45 @@ hw.module @basic(in %cond: i1) {
   // CHECK: ^[[BB1]]:
   ^bb1:
     // CHECK: llhd.wait ({{.*}}), ^[[BB2:.+]]
-    llhd.wait (%12, %4, %6, %9, %5, %7, %8 : !hw.inout<i5>, !hw.inout<i1>, !hw.inout<i1>, !hw.inout<i4>, !hw.inout<i1>, !hw.inout<i1>, !hw.inout<i4>), ^bb2
+    llhd.wait (%k, %c, %e, %h, %d, %f, %g : !hw.inout<i5>, !hw.inout<i1>, !hw.inout<i1>, !hw.inout<i4>, !hw.inout<i1>, !hw.inout<i1>, !hw.inout<i4>), ^bb2
   // CHECK: ^[[BB2]]:
   ^bb2:
-    // CHECK: [[V14:%.+]] = llhd.prb [[V12]]
-    // CHECK: [[V15:%.+]] = llhd.prb [[V4]]
-    // CHECK: [[V16:%.+]] = llhd.prb [[V6]]
-    // CHECK: [[V17:%.+]] = llhd.prb [[V9]]
+    // CHECK: [[V14:%.+]] = llhd.prb %k
+    // CHECK: [[V15:%.+]] = llhd.prb %c
+    // CHECK: [[V16:%.+]] = llhd.prb %e
+    // CHECK: [[V17:%.+]] = llhd.prb %h
     // CHECK: [[V18:%.+]] = comb.concat %false{{.*}}, [[V17]] : i1, i4
-    // CHECK: [[V19:%.+]] = llhd.prb [[V5]]
-    // CHECK: [[V20:%.+]] = llhd.prb [[V7]]
-    // CHECK: [[V21:%.+]] = llhd.prb [[V12]]
-    // CHECK: [[V22:%.+]] = llhd.prb [[V8]]
+    // CHECK: [[V19:%.+]] = llhd.prb %d
+    // CHECK: [[V20:%.+]] = llhd.prb %f
+    // CHECK: [[V21:%.+]] = llhd.prb %k
+    // CHECK: [[V22:%.+]] = llhd.prb %g
     // CHECK: [[V23:%.+]] = comb.concat %false{{.*}}, [[V22]] : i1, i4
     // CHECK: [[V24:%.+]] = comb.sub [[V21]], [[V23]] : i5
-    // CHECK: [[V25:%.+]] = llhd.prb [[V12]]
-    // CHECK: [[V26:%.+]] = llhd.prb [[V8]]
+    // CHECK: [[V25:%.+]] = llhd.prb %k
+    // CHECK: [[V26:%.+]] = llhd.prb %g
     // CHECK: [[V27:%.+]] = comb.concat %false{{.*}}, [[V26]] : i1, i4
     // CHECK: [[V28:%.+]] = comb.add [[V25]], [[V27]] : i5
     // CHECK: cf.cond_br [[V15]], ^[[BB3:.+]], ^[[BB4:.+]]
-    %25 = llhd.prb %12 : !hw.inout<i5>
-    llhd.drv %12, %25 after %1 : !hw.inout<i5>
-    %26 = llhd.prb %4 : !hw.inout<i1>
-    %27 = llhd.prb %6 : !hw.inout<i1>
-    %28 = llhd.prb %9 : !hw.inout<i4>
+    %25 = llhd.prb %k : !hw.inout<i5>
+    llhd.drv %k, %25 after %1 : !hw.inout<i5>
+    %26 = llhd.prb %c : !hw.inout<i1>
+    %27 = llhd.prb %e : !hw.inout<i1>
+    %28 = llhd.prb %h : !hw.inout<i4>
     %29 = comb.concat %false, %28 : i1, i4
-    %30 = llhd.prb %5 : !hw.inout<i1>
-    %31 = llhd.prb %7 : !hw.inout<i1>
-    %32 = llhd.prb %12 : !hw.inout<i5>
-    %33 = llhd.prb %8 : !hw.inout<i4>
+    %30 = llhd.prb %d : !hw.inout<i1>
+    %31 = llhd.prb %f : !hw.inout<i1>
+    %32 = llhd.prb %k : !hw.inout<i5>
+    %33 = llhd.prb %g : !hw.inout<i4>
     %34 = comb.concat %false, %33 : i1, i4
     %35 = comb.sub %32, %34 : i5
-    %36 = llhd.prb %12 : !hw.inout<i5>
-    %37 = llhd.prb %8 : !hw.inout<i4>
+    %36 = llhd.prb %k : !hw.inout<i5>
+    %37 = llhd.prb %g : !hw.inout<i4>
     %38 = comb.concat %false, %37 : i1, i4
     %39 = comb.add %36, %38 : i5
     cf.cond_br %26, ^bb3, ^bb4
   // CHECK: ^[[BB3]]:
   ^bb3:
-    llhd.drv %13, %c0_i5 after %1 if %cond : !hw.inout<i5>
+    llhd.drv %l, %c0_i5 after %1 if %cond : !hw.inout<i5>
     // CHECK: cf.br ^[[BB10:.+]]
     cf.br ^bb1
   // CHECK: ^[[BB4]]:
@@ -96,7 +88,7 @@ hw.module @basic(in %cond: i1) {
     cf.cond_br %27, ^bb5, ^bb6
   // CHECK: ^[[BB5]]:
   ^bb5:
-    llhd.drv %14, %29 after %1 : !hw.inout<i5>
+    llhd.drv %m, %29 after %1 : !hw.inout<i5>
     // CHECK: cf.br ^[[BB10]]
     cf.br ^bb1
   // CHECK: ^[[BB6]]:
@@ -109,28 +101,28 @@ hw.module @basic(in %cond: i1) {
     cf.cond_br %31, ^bb8, ^bb9
   // CHECK: ^[[BB8]]:
   ^bb8:
-    llhd.drv %15, %35 after %1 : !hw.inout<i5>
+    llhd.drv %n, %35 after %1 : !hw.inout<i5>
     // CHECK: cf.br ^[[BB10]]
     cf.br ^bb1
   // CHECK: ^[[BB9]]:
   ^bb9:
-    llhd.drv %16, %39 after %1 : !hw.inout<i5>
+    llhd.drv %o, %39 after %1 : !hw.inout<i5>
     // CHECK: cf.br ^[[BB10]]
     cf.br ^bb1
     // CHECK: ^[[BB10]]:
-    // CHECK: llhd.drv [[V12]], [[V14]] after [[V1]] if %true{{.*}} : !hw.inout<i5>
+    // CHECK: llhd.drv %k, [[V14]] after [[V1]] if %true{{.*}} : !hw.inout<i5>
 
     // CHECK: [[V29:%.+]] = comb.and %true{{.*}}, [[V15]] : i1
     // CHECK: [[V30:%.+]] = comb.or %false{{.*}}, [[V29]] : i1
     // CHECK: [[V31:%.+]] = comb.and %cond, [[V30]] : i1
-    // CHECK: llhd.drv [[V13]], %c0_i5 after [[V1]] if [[V31]] : !hw.inout<i5>
+    // CHECK: llhd.drv %l, %c0_i5 after [[V1]] if [[V31]] : !hw.inout<i5>
 
     // CHECK: [[V33:%.+]] = comb.xor [[V15]], %true{{.*}} : i1
     // CHECK: [[V34:%.+]] = comb.and %true{{.*}}, [[V33]] : i1
     // CHECK: [[V35:%.+]] = comb.or %false{{.*}}, [[V34]] : i1
     // CHECK: [[V36:%.+]] = comb.and [[V35]], [[V16]] : i1
     // CHECK: [[V37:%.+]] = comb.or %false{{.*}}, [[V36]] : i1
-    // CHECK: llhd.drv [[V13_1]], [[V18]] after [[V1]] if [[V37]] : !hw.inout<i5>
+    // CHECK: llhd.drv %m, [[V18]] after [[V1]] if [[V37]] : !hw.inout<i5>
 
     // CHECK: [[V40:%.+]] = comb.xor [[V16]], %true{{.*}} : i1
     // CHECK: [[V41:%.+]] = comb.and [[V35]], [[V40]] : i1
@@ -139,12 +131,12 @@ hw.module @basic(in %cond: i1) {
     // CHECK: [[V44:%.+]] = comb.or %false{{.*}}, [[V43]] : i1
     // CHECK: [[V45:%.+]] = comb.and [[V44]], [[V20]] : i1
     // CHECK: [[V46:%.+]] = comb.or %false{{.*}}, [[V45]] : i1
-    // CHECK: llhd.drv [[V13_2]], [[V24]] after [[V1]] if [[V46]] : !hw.inout<i5>
+    // CHECK: llhd.drv %n, [[V24]] after [[V1]] if [[V46]] : !hw.inout<i5>
 
     // CHECK: [[V49:%.+]] = comb.xor [[V20]], %true{{.*}} : i1
     // CHECK: [[V50:%.+]] = comb.and [[V44]], [[V49]] : i1
     // CHECK: [[V51:%.+]] = comb.or %false{{.*}}, [[V50]] : i1
-    // CHECK: llhd.drv [[V13_3]], [[V28]] after [[V1]] if [[V51]] : !hw.inout<i5>
+    // CHECK: llhd.drv %o, [[V28]] after [[V1]] if [[V51]] : !hw.inout<i5>
     // CHECK: cf.br ^[[BB1]]
   }
 
@@ -154,27 +146,27 @@ hw.module @basic(in %cond: i1) {
   ^bb1:
     llhd.wait ^bb2
   ^bb2:
-    // CHECK:      [[V20:%.+]] = llhd.prb [[V13]]
-    // CHECK-NEXT: [[V21:%.+]] = llhd.prb [[V13_1]]
-    %20 = llhd.prb %13 : !hw.inout<i5>
-    %21 = llhd.prb %14 : !hw.inout<i5>
+    // CHECK:      [[V20:%.+]] = llhd.prb %l
+    // CHECK-NEXT: [[V21:%.+]] = llhd.prb %m
+    %20 = llhd.prb %l : !hw.inout<i5>
+    %21 = llhd.prb %m : !hw.inout<i5>
 
-    // CHECK-NEXT: llhd.drv [[V12]], [[V21]] after [[V1]] : !hw.inout<i5>
-    llhd.drv %12, %20 after %1 : !hw.inout<i5>
-    llhd.drv %12, %21 after %1 : !hw.inout<i5>
+    // CHECK-NEXT: llhd.drv %k, [[V21]] after [[V1]] : !hw.inout<i5>
+    llhd.drv %k, %20 after %1 : !hw.inout<i5>
+    llhd.drv %k, %21 after %1 : !hw.inout<i5>
 
     // CHECK-NEXT: [[V22:%.+]] = comb.mux %cond, [[V21]], [[V20]]
-    // CHECK-NEXT: llhd.drv [[V13]], [[V22]] after [[V1]] : !hw.inout<i5>
-    llhd.drv %13, %20 after %1 : !hw.inout<i5>
-    llhd.drv %13, %21 after %1 if %cond : !hw.inout<i5>
+    // CHECK-NEXT: llhd.drv %l, [[V22]] after [[V1]] : !hw.inout<i5>
+    llhd.drv %l, %20 after %1 : !hw.inout<i5>
+    llhd.drv %l, %21 after %1 if %cond : !hw.inout<i5>
 
     // CHECK-NEXT: [[V23:%.+]] = comb.xor %cond, %true
     // CHECK-NEXT: [[V24:%.+]] = comb.mux %cond, [[V21]], [[V20]]
     // CHECK-NEXT: [[V25:%.+]] = comb.or %cond, [[V23]]
-    // CHECK-NEXT: llhd.drv [[V13_1]], [[V24]] after [[V1]] if [[V25]] : !hw.inout<i5>
+    // CHECK-NEXT: llhd.drv %m, [[V24]] after [[V1]] if [[V25]] : !hw.inout<i5>
     %22 = comb.xor %cond, %true : i1
-    llhd.drv %14, %20 after %1 if %22 : !hw.inout<i5>
-    llhd.drv %14, %21 after %1 if %cond : !hw.inout<i5>
+    llhd.drv %m, %20 after %1 if %22 : !hw.inout<i5>
+    llhd.drv %m, %21 after %1 if %cond : !hw.inout<i5>
 
     // CHECK-NEXT: cf.br
     cf.br ^bb1


### PR DESCRIPTION
Make the `llhd.sig` op use the same naming pattern as HW wires, Moore variables, Seq registers, and a handful of other operations in CIRCT. These all use the `custom<ImplicitSSAName>` parser to provide uniform handling of optional names.

Make the signal name optional to align with other ops.

Rename the class to `SignalOp` for clarity.