### PR TITLE
[firrtl] Fix bug in sibling layer specialization

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/SpecializeLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SpecializeLayers.cpp
@@ -605,6 +605,7 @@ struct SpecializeLayers {
                  llvm::make_early_inc_range(block->getOps<LayerOp>())) {
               nestedRefs.push_back(SymbolRefAttr::get(nested));
               handleLayer(nested, Block::iterator(nested), "");
+              nestedRefs.pop_back();
             }
             return;
           }
@@ -617,6 +618,7 @@ struct SpecializeLayers {
               nestedRefs.push_back(SymbolRefAttr::get(nested));
               handleLayer(nested, insertionPoint,
                           prefix + layer.getSymName() + "_");
+              nestedRefs.pop_back();
             }
             // Erase the now empty layer.
             layer->erase();

--- a/test/Dialect/FIRRTL/specialize-layers.mlir
+++ b/test/Dialect/FIRRTL/specialize-layers.mlir
@@ -115,6 +115,21 @@ firrtl.circuit "LayerDisableInARow" attributes {
   firrtl.extmodule @LayerDisableInARow()
 }
 
+// CHECK:     firrtl.circuit "LayerblockEnableNestedChildren"
+// CHECK-NOT:   firrtl.layer
+firrtl.circuit "LayerblockEnableNestedChildren" attributes {
+  enable_layers = [@A, @A::@B, @A::@C]
+} {
+  firrtl.layer @A bind {
+    firrtl.layer @B bind {
+    }
+    firrtl.layer @C bind {
+    }
+  }
+  firrtl.module @LayerblockEnableNestedChildren() {
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // LayerBlock Specialization
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Fix a bug in the `SpecializeLayers` pass where sibling layers would not be enabled/disabled correctly if an earlier sibling layer was also enabled/disabled.

Fixes #7525.