### PR TITLE
[firtool] Run canonicalization before LowerLayers

### DIFF
--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -140,6 +140,13 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
     modulePM.addPass(firrtl::createLayerSinkPass());
   }
 
+  // Run canonicalization before LowerLayers.  LowerLayers creates modules which
+  // makes certain optimizations much harderd.  E.g., many trivial
+  // canonicalizers will not work after LowerLayers outlines module bodies.
+  if (!opt.shouldDisableOptimization())
+    pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
+        createSimpleCanonicalizerPass());
+
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerLayersPass());
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInlinerPass());

--- a/test/firtool/lower-layers.fir
+++ b/test/firtool/lower-layers.fir
@@ -177,3 +177,33 @@ circuit TestHarness:
 ; CHECK:   .reset     (reset)
 ; CHECK: );
 ; CHECK: `endif // layers_TestHarness_Verification
+
+; // -----
+
+; This is a test that the modules created from lowering layerblocks to modules
+; still have reasonable optimizations that are only possible with
+; canonicalization.  Creating modules from layers destroys a lot of optimization
+; opportunities and this test is ensuring that these are preserved.
+;
+; See: https://github.com/llvm/circt/issues/7533
+
+FIRRTL version 4.0.0
+
+circuit Foo: %[[
+  {"class": "firrtl.transforms.DontTouchAnnotation", "target": "~Foo|Foo>c"}
+]]
+  layer A, bind:
+  public module Foo:
+    input clock: Clock
+    input a: UInt<2>
+    output d: UInt<2>
+
+    node b = bits(a, 1, 0)
+    layerblock A :
+      node c = eq(a, b)
+
+    connect d, b
+
+; CHECK:     module Foo_A
+; CHECK-NOT: endmodule
+; CHECK:       wire c = 1'h1;


### PR DESCRIPTION
Run canonicalization before LowerLayers in order to optimize things which are difficult to do after layerblocks have been converted to modules.  The conversion to modules means that many trivial canonicalizers are now very difficult to do as they require inter-module analysis.

Ideally, it would be best if LowerLayers ran as late as possible.  (Generally any outlining should run as late as possible.) However, we aren't quite ready to make this harder move of pushing LowerLayers to the end of the FIRRTL pipeline.

Fixes #7533.