### PR TITLE
[FIRRTLUtils] Fix walkDrivers subfield id calculation

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -457,7 +457,13 @@ bool circt::firrtl::walkDrivers(FIRRTLBaseValue value, bool lookThroughWires,
         auto subRef = fieldRef.getSubField(subID);
         auto subOriginal = original.getSubField(subID);
         auto value = subfield.getResult();
-        workStack.emplace_back(subOriginal, subRef, value, fieldID - subID);
+        // If fieldID is zero, this points to entire subfields.
+        if (fieldID == 0)
+          workStack.emplace_back(subOriginal, subRef, value, 0);
+        else {
+          assert(fieldID >= subID);
+          workStack.emplace_back(subOriginal, subRef, value, fieldID - subID);
+        }
       } else if (auto subindex = dyn_cast<SubindexOp>(user)) {
         FVectorType vectorType = subindex.getInput().getType();
         auto index = subindex.getIndex();
@@ -468,7 +474,13 @@ bool circt::firrtl::walkDrivers(FIRRTLBaseValue value, bool lookThroughWires,
         auto subRef = fieldRef.getSubField(subID);
         auto subOriginal = original.getSubField(subID);
         auto value = subindex.getResult();
-        workStack.emplace_back(subOriginal, subRef, value, fieldID - subID);
+        // If fieldID is zero, this points to entire subfields.
+        if (fieldID == 0)
+          workStack.emplace_back(subOriginal, subRef, value, 0);
+        else {
+          assert(fieldID >= subID);
+          workStack.emplace_back(subOriginal, subRef, value, fieldID - subID);
+        }
       } else if (auto connect = dyn_cast<FConnectLike>(user)) {
         // Make sure that this connect is driving the value.
         if (connect.getDest() != current)

--- a/test/Dialect/FIRRTL/sfc-compat.mlir
+++ b/test/Dialect/FIRRTL/sfc-compat.mlir
@@ -34,7 +34,7 @@ firrtl.circuit "SFCCompatTests" {
   // converted to a reg.
   //
   // CHECK-LABEL: firrtl.module @AggregateInvalidThroughWire
-  firrtl.module @AggregateInvalidThroughWire(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %d: !firrtl.vector<bundle<a: uint<1>>, 2>, out %q: !firrtl.vector<bundle<a: uint<1>>, 2>) {
+  firrtl.module @AggregateInvalidThroughWire(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %d: !firrtl.vector<bundle<a: uint<1>>, 2>, out %q: !firrtl.vector<bundle<a: uint<1>>, 2>, in %foo: !firrtl.vector<uint<1>, 1>) {
     %inv = firrtl.wire : !firrtl.bundle<a: uint<1>>
     %inv_a = firrtl.subfield %inv[a] : !firrtl.bundle<a: uint<1>>
     %invalid = firrtl.invalidvalue : !firrtl.uint<1>
@@ -51,10 +51,6 @@ firrtl.circuit "SFCCompatTests" {
     firrtl.matchingconnect %r, %d : !firrtl.vector<bundle<a: uint<1>>, 2>
     firrtl.matchingconnect %q, %r : !firrtl.vector<bundle<a: uint<1>>, 2>
 
-    %foo = firrtl.wire : !firrtl.vector<uint<1>, 1>
-    %0 = firrtl.subindex %foo[0] : !firrtl.vector<uint<1>, 1>
-    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    firrtl.matchingconnect %0, %c1_ui1 : !firrtl.uint<1>
     %bar = firrtl.wire : !firrtl.vector<vector<uint<1>, 1>, 1>
     %1 = firrtl.subindex %bar[0] : !firrtl.vector<vector<uint<1>, 1>, 1>
     %2 = firrtl.subindex %foo[0] : !firrtl.vector<uint<1>, 1>

--- a/test/Dialect/FIRRTL/sfc-compat.mlir
+++ b/test/Dialect/FIRRTL/sfc-compat.mlir
@@ -50,6 +50,22 @@ firrtl.circuit "SFCCompatTests" {
     %r = firrtl.regreset %clock, %reset, %inv1  : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<bundle<a: uint<1>>, 2>, !firrtl.vector<bundle<a: uint<1>>, 2>
     firrtl.matchingconnect %r, %d : !firrtl.vector<bundle<a: uint<1>>, 2>
     firrtl.matchingconnect %q, %r : !firrtl.vector<bundle<a: uint<1>>, 2>
+
+    %foo = firrtl.wire : !firrtl.vector<uint<1>, 1>
+    %0 = firrtl.subindex %foo[0] : !firrtl.vector<uint<1>, 1>
+    %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+    firrtl.matchingconnect %0, %c1_ui1 : !firrtl.uint<1>
+    %bar = firrtl.wire : !firrtl.vector<vector<uint<1>, 1>, 1>
+    %1 = firrtl.subindex %bar[0] : !firrtl.vector<vector<uint<1>, 1>, 1>
+    %2 = firrtl.subindex %foo[0] : !firrtl.vector<uint<1>, 1>
+    %3 = firrtl.subindex %1[0] : !firrtl.vector<uint<1>, 1>
+    firrtl.matchingconnect %3, %2 : !firrtl.uint<1>
+    // Check that firrtl.regreset is not transformed into reg op if wire is not invalid
+    // CHECK: firrtl.regreset
+    %x = firrtl.regreset %clock, %reset, %bar : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<vector<uint<1>, 1>, 1>, !firrtl.vector<vector<uint<1>, 1>, 1>
+    %4 = firrtl.subindex %x[0] : !firrtl.vector<vector<uint<1>, 1>, 1>
+    %5 = firrtl.subindex %4[0] : !firrtl.vector<uint<1>, 1>
+    firrtl.matchingconnect %5, %5 : !firrtl.uint<1>
   }
 
   // A regreset invalidated via an output port should be converted to a reg.


### PR DESCRIPTION
This fixes an overflow in walkDrivers when field ID is zero.

Fix https://github.com/chipsalliance/chisel/issues/4354 and https://github.com/llvm/circt/issues/7423.