### PR TITLE
[MooreToCore] Ignore ConstantLike values in wait op

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -185,6 +185,9 @@ static void getValuesToObserve(Region *region,
         for (auto value : operation->getOperands()) {
           if (region->isAncestor(value.getParentRegion()))
             continue;
+          if (auto *defOp = value.getDefiningOp();
+              defOp && defOp->hasTrait<OpTrait::ConstantLike>())
+            continue;
           if (!alreadyObserved.insert(value).second)
             continue;
 

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -691,7 +691,6 @@ moore.module @WaitEvent() {
     moore.return
   }
 
-  // CHECK: [[FALSE:%.+]] = hw.constant false
   // CHECK: [[PRB_A:%.+]] = llhd.prb %a
   // CHECK: [[PRB_B:%.+]] = llhd.prb %b
   // CHECK: llhd.process {
@@ -703,7 +702,7 @@ moore.module @WaitEvent() {
     // CHECK:   llhd.prb %b
     // CHECK:   cf.br ^[[BB2:.+]]
     // CHECK: ^[[BB2]]:
-    // CHECK:   llhd.wait ([[FALSE]], [[PRB_A]], [[PRB_B]] : {{.*}}), ^[[BB1]]
+    // CHECK:   llhd.wait ([[PRB_A]], [[PRB_B]] : {{.*}}), ^[[BB1]]
     %1 = moore.conditional %cond : i1 -> i1 {
       %2 = moore.read %a : <i1>
       moore.yield %2 : !moore.i1


### PR DESCRIPTION
Skip values defined by `ConstantLike` ops when collecting the list of values to observe in `llhd.wait` ops. Constants will never cause an `llhd.wait` to resume execution since they never change value.