### PR TITLE
[FIRRTL] Set output dirs on annotated blackboxes

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -315,6 +315,13 @@ static ResultTy transformReduce(MLIRContext *context, RangeTy &&r,
                          transform);
 }
 
+//===----------------------------------------------------------------------===//
+// File utilities
+//===----------------------------------------------------------------------===//
+
+/// Truncate `a` to the common prefix of `a` and `b`.
+void makeCommonPrefix(SmallString<64> &a, StringRef b);
+
 } // namespace firrtl
 } // namespace circt
 

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -17,6 +17,7 @@
 #include "circt/Support/Naming.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Path.h"
 
 using namespace circt;
 using namespace firrtl;
@@ -1046,4 +1047,19 @@ Type circt::firrtl::lowerType(
     return IntegerType::get(type.getContext(), width);
 
   return {};
+}
+
+void circt::firrtl::makeCommonPrefix(SmallString<64> &a, StringRef b) {
+  // truncate 'a' to the common prefix of 'a' and 'b'.
+  size_t i = 0;
+  size_t e = std::min(a.size(), b.size());
+  for (; i < e; ++i)
+    if (a[i] != b[i])
+      break;
+  a.resize(i);
+
+  // truncate 'a' so it ends on a directory seperator.
+  auto sep = llvm::sys::path::get_separator();
+  while (!a.empty() && !a.ends_with(sep))
+    a.pop_back();
 }

--- a/lib/Dialect/FIRRTL/Transforms/AssignOutputDirs.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AssignOutputDirs.cpp
@@ -10,6 +10,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Support/Debug.h"
@@ -54,21 +55,6 @@ static void tryMakeRelative(StringRef outputDir,
   if (moduleOutputDir.starts_with(outputDir))
     moduleOutputDir.erase(moduleOutputDir.begin(),
                           moduleOutputDir.begin() + outputDir.size());
-}
-
-static void makeCommonPrefix(SmallString<64> &a, StringRef b) {
-  // truncate 'a' to the common prefix of 'a' and 'b'.
-  size_t i = 0;
-  size_t e = std::min(a.size(), b.size());
-  for (; i < e; ++i)
-    if (a[i] != b[i])
-      break;
-  a.resize(i);
-
-  // truncate 'a' so it ends on a directory seperator.
-  auto sep = path::get_separator();
-  while (!a.empty() && !a.ends_with(sep))
-    a.pop_back();
 }
 
 static void makeCommonPrefix(StringRef outputDir, SmallString<64> &a,

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -190,13 +190,6 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   pm.addNestedPass<firrtl::CircuitOp>(
       firrtl::createGrandCentralPass(opt.getCompanionMode()));
 
-  // Read black box source files into the IR.
-  StringRef blackBoxRoot = opt.getBlackBoxRootPath().empty()
-                               ? llvm::sys::path::parent_path(inputFilename)
-                               : opt.getBlackBoxRootPath();
-  pm.nest<firrtl::CircuitOp>().addPass(
-      firrtl::createBlackBoxReaderPass(blackBoxRoot));
-
   // Run SymbolDCE as late as possible, but before InnerSymbolDCE. This is for
   // hierpathop's and just for general cleanup.
   pm.addNestedPass<firrtl::CircuitOp>(mlir::createSymbolDCEPass());
@@ -237,6 +230,13 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
 
   pm.nest<firrtl::CircuitOp>().addPass(
       firrtl::createAssignOutputDirsPass(outputFilename));
+
+  // Read black box source files into the IR.
+  StringRef blackBoxRoot = opt.getBlackBoxRootPath().empty()
+                               ? llvm::sys::path::parent_path(inputFilename)
+                               : opt.getBlackBoxRootPath();
+  pm.nest<firrtl::CircuitOp>().addPass(
+      firrtl::createBlackBoxReaderPass(blackBoxRoot));
   return success();
 }
 

--- a/test/Dialect/FIRRTL/assign-output-dirs.mlir
+++ b/test/Dialect/FIRRTL/assign-output-dirs.mlir
@@ -128,3 +128,19 @@ firrtl.circuit "EmptyOutputDir2" {
   }
   firrtl.module @EmptyOutputDir2() {}
 }
+
+// An external module should get an output file if it doesn't have one.  This
+// external module may be implemented by something else, e.g., an inline black
+// box annotation.
+//
+// See: https://github.com/llvm/circt/issues/7538
+//
+// CHECK-LABEL: firrtl.circuit "ExtModule"
+firrtl.circuit "ExtModule" {
+  // CHECK: firrtl.extmodule private @Foo
+  // CHECK-SAME: output_file = #hw.output_file<"path{{/|\\\\}}">
+  firrtl.extmodule private @Foo()
+  firrtl.module @ExtModule() attributes {output_file = #hw.output_file<"path/">} {
+    firrtl.instance foo @Foo()
+  }
+}

--- a/test/firtool/blackbox-directories.fir
+++ b/test/firtool/blackbox-directories.fir
@@ -1,4 +1,4 @@
-; RUN: firtool %s | FileCheck %s
+; RUN: firtool -split-input-file %s | FileCheck %s
 
 ; This test is checking that FIRRTL external modules which have BlackBoxInline
 ; annotations want to write to the same file write to the proper output
@@ -18,29 +18,29 @@
 ;
 ;            T D G Output
 ;     --------------------
-;     Foo    0 0 1 gct/Foo.sv
+;     Foo    0 0 1 verification/gct/Foo.sv
 ;     Bar    0 1 0 Bar.sv
 ;     Baz    0 1 1 Baz.sv
-;     Qux    1 0 0 testbench/Qux.sv
-;     Quz    1 0 1 gct/Quz.sv
+;     Qux    1 0 0 verification/testbench/Qux.sv
+;     Quz    1 0 1 verification/Quz.sv
 ;     Corge  1 1 0 Corge.sv
 ;     Grault 1 1 1 Grault
-;     Bazola 0 L 0 testbench/Bazola.sv
-;     Ztesch L 0 0 testbench/Ztesch.sv
-;     Thud   L L 0 testbench/Thud.sv
+;     Bazola 0 L 0 Bazola.sv
+;     Ztesch L 0 0 verification/testbench/Ztesch.sv
+;     Thud   L L 0 Thud.sv
 ;
 ; CHECK-LABEL: module DUT
 ;
-; CHECK: FILE "gct{{[/\]}}Foo.sv"
+; CHECK: FILE "verification{{[/\]}}gct{{[/\]}}Foo.sv"
 ; CHECK: FILE ".{{[/\]}}Bar.sv"
-; CHECK: FILE ".{{[/\]}}Baz.sv"
-; CHECK: FILE "testbench{{[/\]}}Qux.sv"
-; CHECK: FILE "gct{{[/\]}}Quz.sv"
-; CHECK: FILE ".{{[/\]}}Corge.sv"
-; CHECK: FILE ".{{[/\]}}Grault.sv"
-; CHECK: FILE "testbench{{[/\]}}Bazola.sv"
-; CHECK: FILE "testbench{{[/\]}}Ztesch.sv"
-; CHECK: FILE "testbench{{[/\]}}Thud.sv"
+; CHECK: FILE "Baz.sv"
+; CHECK: FILE "verification{{[/\]}}testbench{{[/\]}}Qux.sv"
+; CHECK: FILE "verification{{[/\]}}Quz.sv"
+; CHECK: FILE "Corge.sv"
+; CHECK: FILE "Grault.sv"
+; CHECK: FILE "verification{{[/\]}}assert{{[/\]}}Bazola.sv"
+; CHECK: FILE "verification{{[/\]}}assert{{[/\]}}Ztesch.sv"
+; CHECK: FILE "verification{{[/\]}}assert{{[/\]}}Thud.sv"
 
 FIRRTL version 4.0.0
 circuit TestHarness: %[[
@@ -79,12 +79,12 @@ circuit TestHarness: %[[
   },
   {
     "class": "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
-    "directory": "gct",
+    "directory": "verification/gct",
     "filename": "bindings.sv"
   },
   {
     "class": "sifive.enterprise.firrtl.TestBenchDirAnnotation",
-    "dirname": "testbench"
+    "dirname": "verification/testbench"
   },
   {
     "class": "firrtl.transforms.BlackBoxInlineAnno",
@@ -183,7 +183,7 @@ circuit TestHarness: %[[
     "text": "module Thud #(parameter X=hello)(output a);\nendmodule"
   }
 ]]
-  layer Verification, bind:
+  layer Assert, bind, "verification/assert":
 
   extmodule BlackBox_Foo_GCT:
     output a: UInt<1>
@@ -268,7 +268,7 @@ circuit TestHarness: %[[
     inst blackBox_Corge_TestHarness of BlackBox_Corge_TestHarness
     inst blackBox_Grault_TestHarness of BlackBox_Grault_TestHarness
 
-    layerblock Verification:
+    layerblock Assert:
       inst blackBox_Ztesch_TestHarness of BlackBox_Ztesch_TestHarness
       inst blackBox_Thud_TestHarness of BlackBox_Thud_TestHarness
 
@@ -284,7 +284,7 @@ circuit TestHarness: %[[
     inst blackBox_Corge_DUT of BlackBox_Corge_DUT
     inst blackBox_Grault_DUT of BlackBox_Grault_DUT
 
-    layerblock Verification:
+    layerblock Assert:
       inst blackBox_Bazola_DUT of BlackBox_Bazola_DUT
       inst blackBox_Thud_DUT of BlackBox_Thud_DUT
 
@@ -294,3 +294,57 @@ circuit TestHarness: %[[
     inst blackBox_Baz_GCT of BlackBox_Baz_GCT
     inst blackBox_Quz_GCT of BlackBox_Quz_GCT
     inst blackBox_Grault_GCT of BlackBox_Grault_GCT
+
+; // -----
+
+; This test is checking the behavior of how blackboxes which _cannot_
+; deduplicate with each other because they have differing parameters, but must
+; be "deduplicated" on disk.  The only thing marking them as needing to
+; deduplicate is that the have the same "name" field in their annotations.  This
+; should write files to the LCA of the two directories that the external modules
+; are supposed to be written to.  Specifically, this is checking for correct
+; interactions between `AssignOutputDirs` and `BlackBoxReader`.
+;
+; CHECK-LABEL: module BlackBoxLCA
+;
+; CHECK: FILE "Bar.sv"
+
+FIRRTL version 4.0.0
+circuit BlackBoxLCA: %[[
+  {
+    "class": "firrtl.transforms.BlackBoxInlineAnno",
+    "target": "~BlackBoxLCA|Foo",
+    "name": "Bar.sv",
+    "text": "Bar definition that takes parameters"
+  },
+  {
+    "class": "firrtl.transforms.BlackBoxInlineAnno",
+    "target": "~BlackBoxLCA|Bar",
+    "name": "Bar.sv",
+    "text": "Bar definition that takes parameters"
+  }
+]]
+  layer A, bind, "A":
+  layer B, bind, "B":
+
+  extmodule Bar:
+    input a: UInt<1>
+    defname = Bar
+    parameter x = 1
+
+  extmodule Foo:
+    input a: UInt<1>
+    defname = Bar
+    parameter x = 0
+
+
+  public module BlackBoxLCA:
+    input a: UInt<1>
+
+    layerblock A:
+      inst foo of Foo
+      connect foo.a, a
+
+    layerblock B:
+      inst bar of Bar
+      connect bar.a, a


### PR DESCRIPTION
Change the `AssignOutputDirs` pass to add `hw::output_file` attributes on
external modules in the same way that these attributes are added to normal
modules.  While this has no effect on an external module which has no
implementation, this fixes a bug where the external module _does_ have an
implementation that the compiler will later resolve.

This is specifically done to make output directories compose correctly
with Chisel inline blackboxes where the body of the external module is in
an annotation and is supposed to be written to a file.

Reorder the FIRRTL pass pipeline so that Chisel blackboxes (represented by
a `firrtl.extmodule` and one of two blackbox annotations) will be assigned
an output directory based on their instantiation location.

Fixes #7538.