### PR TITLE
[firrtl] Add CheckLayers diagnostics pass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -214,6 +214,8 @@ std::unique_ptr<mlir::Pass> createLowerDPIPass();
 std::unique_ptr<mlir::Pass>
 createAssignOutputDirsPass(mlir::StringRef outputDir = "");
 
+std::unique_ptr<mlir::Pass> createCheckLayers();
+
 std::unique_ptr<mlir::Pass> createCheckRecursiveInstantiation();
 
 /// Generate the code for registering passes.

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -984,4 +984,13 @@ def CheckRecursiveInstantiation : Pass<"firrtl-check-recursive-instantiation",
   let constructor = "circt::firrtl::createCheckRecursiveInstantiation()";
 }
 
+def CheckLayers : Pass<"firrtl-check-layers", "firrtl::CircuitOp"> {
+  let summary = "Check for illegal layers instantiated under layers";
+  let description = [{
+    This pass checks for illegal instantiation of a module with a layer
+    underneath another layer.
+  }];
+  let constructor = "circt::firrtl::createCheckLayers()";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_PASSES_TD

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   AddSeqMemPorts.cpp
   BlackBoxReader.cpp
   CheckCombLoops.cpp
+  CheckLayers.cpp
   CheckRecursiveInstantiation.cpp
   CreateCompanionAssume.cpp
   CreateSiFiveMetadata.cpp

--- a/lib/Dialect/FIRRTL/Transforms/CheckLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckLayers.cpp
@@ -1,0 +1,121 @@
+//===- CheckLayers.cpp - check layer legality -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/PostOrderIterator.h"
+
+namespace circt {
+namespace firrtl {
+#define GEN_PASS_DEF_CHECKLAYERS
+#include "circt/Dialect/FIRRTL/Passes.h.inc"
+} // namespace firrtl
+} // namespace circt
+
+using namespace circt;
+using namespace firrtl;
+
+namespace {
+class CheckLayers {
+  CheckLayers(InstanceGraph &instanceGraph) : instanceGraph(instanceGraph) {}
+
+  /// Walk the LayerBlock and report any illegal instantiation found within.
+  void run(LayerBlockOp layerBlock) {
+    layerBlock.getBody()->walk([&](FInstanceLike instance) {
+      auto moduleName = instance.getReferencedModuleNameAttr();
+      auto *targetModule =
+          instanceGraph.lookup(moduleName)->getModule<Operation *>();
+      auto childLayerBlock = layerBlocks.lookup(targetModule);
+      if (childLayerBlock) {
+        auto diag = emitError(instance.getLoc())
+                    << "cannot instantiate " << moduleName
+                    << " under a layerblock, because " << moduleName
+                    << " contains a layerblock";
+        diag.attachNote(childLayerBlock.getLoc()) << "layerblock here";
+        error = true;
+      }
+    });
+  }
+
+  /// Walk a module, reporting any illegal instantation of layers under layers,
+  /// and record if this module contains any layerblocks.
+  void run(FModuleOp module) {
+    // If this module directly contains a layerblock, or instantiates another
+    // module with a layerblock, then this will point to the layerblock. We use
+    // this for error reporting. We keep track of only the first layerblock
+    // found.
+    LayerBlockOp firstLayerblock = nullptr;
+    module.getBodyBlock()->walk<mlir::WalkOrder::PreOrder>([&](Operation *op) {
+      // If we are instantiating a module, check if it contains a layerblock. If
+      // it does, mark this target layerblock as our layerblock.
+      if (auto instance = dyn_cast<FInstanceLike>(op)) {
+        // If this is the first layer block in this module, record it.
+        if (!firstLayerblock) {
+          auto moduleName = instance.getReferencedModuleNameAttr();
+          auto *targetModule =
+              instanceGraph.lookup(moduleName)->getModule().getOperation();
+          firstLayerblock = layerBlocks.lookup(targetModule);
+        }
+        return WalkResult::advance();
+      }
+      if (auto layerBlock = dyn_cast<LayerBlockOp>(op)) {
+        // If this is the first layer block in this module, record it.
+        if (!firstLayerblock)
+          firstLayerblock = layerBlock;
+        // Process the layerblock.
+        run(layerBlock);
+        // Don't recurse on elements of the layerblock.  If an instance within
+        // did contain a layerblock, then an error would have been reported for
+        // it already.
+        return WalkResult::skip();
+      }
+      // Do nothing for all other operations.
+      return WalkResult::advance();
+    });
+    // If this module contained a layerblock, then record it.
+    if (firstLayerblock)
+      layerBlocks.try_emplace(module, firstLayerblock);
+  }
+
+public:
+  static LogicalResult run(InstanceGraph &instanceGraph) {
+    CheckLayers checkLayers(instanceGraph);
+    DenseSet<InstanceGraphNode *> visited;
+    for (auto *root : instanceGraph) {
+      for (auto *node : llvm::post_order_ext(root, visited)) {
+        if (auto module = dyn_cast<FModuleOp>(node->getModule<Operation *>()))
+          checkLayers.run(module);
+      }
+    }
+    return failure(checkLayers.error);
+  }
+
+private:
+  InstanceGraph &instanceGraph;
+  /// A mapping from a module to the first layerblock that it contains,
+  /// transitively through instances.
+  DenseMap<Operation *, LayerBlockOp> layerBlocks;
+  bool error = false;
+};
+} // end anonymous namespace
+
+class CheckLayersPass
+    : public circt::firrtl::impl::CheckLayersBase<CheckLayersPass> {
+public:
+  void runOnOperation() override {
+    if (failed(CheckLayers::run(getAnalysis<InstanceGraph>())))
+      return signalPassFailure();
+    markAllAnalysesPreserved();
+  }
+};
+
+std::unique_ptr<mlir::Pass> circt::firrtl::createCheckLayers() {
+  return std::make_unique<CheckLayersPass>();
+}

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -28,6 +28,7 @@ LogicalResult firtool::populatePreprocessTransforms(mlir::PassManager &pm,
                                                     const FirtoolOptions &opt) {
   pm.nest<firrtl::CircuitOp>().addPass(
       firrtl::createCheckRecursiveInstantiation());
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createCheckLayers());
   // Legalize away "open" aggregates to hw-only versions.
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerOpenAggsPass());
 

--- a/test/Dialect/FIRRTL/check-layers-errors.mlir
+++ b/test/Dialect/FIRRTL/check-layers-errors.mlir
@@ -1,0 +1,140 @@
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-check-layers))' %s --verify-diagnostics --split-input-file
+
+firrtl.circuit "Simple" {
+  firrtl.layer @A bind {}
+  firrtl.module @Simple() {
+    firrtl.layerblock @A {
+      // expected-error @below {{cannot instantiate "Layers" under a layerblock, because "Layers" contains a layerblock}}
+      firrtl.instance layers @Layers()
+    }
+  }
+  firrtl.module @Layers() {
+    // expected-note @below {{layerblock here}}
+    firrtl.layerblock @A {}
+  }
+}
+
+// -----
+
+firrtl.circuit "Transitive" {
+  firrtl.layer @A bind {}
+  firrtl.module @Transitive() {
+    firrtl.layerblock @A {
+      // expected-error @below {{cannot instantiate "Middle" under a layerblock, because "Middle" contains a layerblock}}
+      firrtl.instance middle @Middle()
+    }
+  }
+  firrtl.module @Middle() {
+    firrtl.instance layers @Layers()
+  }
+  firrtl.module @Layers() {
+    // expected-note @below {{layerblock here}}
+    firrtl.layerblock @A {}
+  }
+}
+
+// -----
+
+firrtl.circuit "FirstLayerBLockFound" {
+  firrtl.layer @A bind {}
+  firrtl.module @FirstLayerBLockFound() {
+    firrtl.layerblock @A {
+      // expected-error @below {{cannot instantiate "Layers" under a layerblock, because "Layers" contains a layerblock}}
+      firrtl.instance layers @Layers()
+    }
+  }
+  firrtl.module @Layers() {
+    // expected-note @below {{layerblock here}}
+    firrtl.layerblock @A {}
+    firrtl.layerblock @A {}
+  }
+}
+
+// -----
+
+firrtl.circuit "MultipleErrors" {
+  firrtl.layer @A bind {}
+  firrtl.module @MultipleErrors() {
+    firrtl.layerblock @A {
+      // expected-error @below {{cannot instantiate "Layers1" under a layerblock, because "Layers1" contains a layerblock}}
+      firrtl.instance layers1 @Layers1()
+      // expected-error @below {{cannot instantiate "Layers2" under a layerblock, because "Layers2" contains a layerblock}}
+      firrtl.instance layers2 @Layers2()
+    }
+  }
+  firrtl.module @Layers1() {
+    // expected-note @below {{layerblock here}}
+    firrtl.layerblock @A {}
+  }
+  firrtl.module @Layers2() {
+    // expected-note @below {{layerblock here}}
+    firrtl.layerblock @A {}
+  }
+}
+
+// -----
+
+firrtl.circuit "MultipleErrors" {
+  firrtl.layer @A bind {}
+  firrtl.module @MultipleErrors() {
+    firrtl.layerblock @A {
+      // expected-error @below {{cannot instantiate "Layers" under a layerblock, because "Layers" contains a layerblock}}
+      firrtl.instance layers1 @Layers()
+    }
+  }
+  firrtl.module @OtherTop() {
+    firrtl.layerblock @A {
+      // expected-error @below {{cannot instantiate "Layers" under a layerblock, because "Layers" contains a layerblock}}
+      firrtl.instance layers1 @Layers()
+    }
+  }
+  firrtl.module @Layers() {
+    // expected-note @+1 {{layerblock here}}
+    firrtl.layerblock @A {}
+  }
+}
+
+// -----
+
+firrtl.circuit "NestedLayers" {
+  firrtl.layer @A bind {}
+  firrtl.module @NestedLayers() {
+    firrtl.layerblock @A {
+      // expected-error @below {{cannot instantiate "LayerA" under a layerblock, because "LayerA" contains a layerblock}}
+      firrtl.instance layera @LayerA()
+    }
+  }
+  firrtl.module @LayerA() {
+    // expected-note @below {{layerblock here}}
+    firrtl.layerblock @A {
+      // expected-error @below {{cannot instantiate "LayerB" under a layerblock, because "LayerB" contains a layerblock}}
+      firrtl.instance layerb @LayerB()
+    }
+  }
+  firrtl.module @LayerB() {
+    // expected-note @below {{layerblock here}}
+    firrtl.layerblock @A {}
+  }
+}
+
+// -----
+
+firrtl.circuit "RegionOps" {
+  firrtl.layer @A bind {}
+  firrtl.module @RegionOps(in %in : !firrtl.uint<1>) {
+    firrtl.when %in : !firrtl.uint<1> {
+      firrtl.layerblock @A {
+        // expected-error @below {{cannot instantiate "Layers" under a layerblock, because "Layers" contains a layerblock}}
+        %layers_in = firrtl.instance layers @Layers(in in : !firrtl.enum<a: uint<1>>)
+      }
+    }
+  }
+  firrtl.module @Layers(in %in : !firrtl.enum<a: uint<1>>) {
+    firrtl.match %in : !firrtl.enum<a: uint<1>> {
+      case a(%arg0) {
+        // expected-note @below {{layerblock here}}
+        firrtl.layerblock @A {}
+      }
+    }
+  }
+}

--- a/test/Dialect/FIRRTL/check-layers.mlir
+++ b/test/Dialect/FIRRTL/check-layers.mlir
@@ -1,0 +1,16 @@
+// RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-check-layers))' %s | FileCheck %s
+
+// CHECK-LABEL: firrtl.circuit "CheckLayers"
+firrtl.circuit "CheckLayers" {
+  firrtl.layer @A bind {}
+  firrtl.module @CheckLayers() {
+    firrtl.layerblock @A {
+      firrtl.instance nolayers @NoLayers()
+    }
+    firrtl.instance layers @Layers()
+  }
+  firrtl.module @NoLayers() { }
+  firrtl.module @Layers() {
+    firrtl.layerblock @A {}
+  }
+}


### PR DESCRIPTION
This adds a pass to check for illegal instantiation of a module with
layers underneath a layer.  This is a situation that leads to
bind-unde-bind when emitted to Verilog, which is illegal.  This does not
differentiate between inline layers and bind layers, although
theoretically this is only a problem for bind layers. This does not
create errors on extmodules, as we have no way of knowing whether they
contain a layer or not, and we don't want false positives.