### PR TITLE
[FreezePaths] Add an optional argument, to get the operation name

### DIFF
--- a/include/circt/Dialect/OM/OMPasses.h
+++ b/include/circt/Dialect/OM/OMPasses.h
@@ -9,6 +9,7 @@
 #ifndef CIRCT_DIALECT_OM_OMPASSES_H
 #define CIRCT_DIALECT_OM_OMPASSES_H
 
+#include "circt/Support/LLVM.h"
 #include "mlir/Pass/Pass.h"
 #include <memory>
 
@@ -20,7 +21,8 @@ namespace circt {
 namespace om {
 
 std::unique_ptr<mlir::Pass> createOMLinkModulesPass();
-std::unique_ptr<mlir::Pass> createFreezePathsPass();
+std::unique_ptr<mlir::Pass>
+createFreezePathsPass(std::function<StringAttr(Operation *)> getOpName = {});
 std::unique_ptr<mlir::Pass> createVerifyObjectFieldsPass();
 
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/OM/OMPasses.h
+++ b/include/circt/Dialect/OM/OMPasses.h
@@ -21,8 +21,8 @@ namespace circt {
 namespace om {
 
 std::unique_ptr<mlir::Pass> createOMLinkModulesPass();
-std::unique_ptr<mlir::Pass>
-createFreezePathsPass(std::function<StringAttr(Operation *)> getOpName = {});
+std::unique_ptr<mlir::Pass> createFreezePathsPass(
+    std::function<StringAttr(Operation *)> getOpNameFallback = {});
 std::unique_ptr<mlir::Pass> createVerifyObjectFieldsPass();
 
 #define GEN_PASS_REGISTRATION

--- a/lib/Dialect/OM/Transforms/FreezePaths.cpp
+++ b/lib/Dialect/OM/Transforms/FreezePaths.cpp
@@ -32,7 +32,7 @@ namespace {
 struct PathVisitor {
   PathVisitor(hw::InstanceGraph &instanceGraph, hw::InnerRefNamespace &irn,
               std::function<StringAttr(Operation *)> &getOpName)
-      : instanceGraph(instanceGraph), irn(irn), getOpName(getOpName) {}
+      : instanceGraph(instanceGraph), irn(irn), getOpNameFallback(getOpName) {}
 
   StringAttr field;
   LogicalResult processPath(Location loc, hw::HierPathOp hierPathOp,
@@ -45,7 +45,7 @@ struct PathVisitor {
   LogicalResult run(ModuleOp module);
   hw::InstanceGraph &instanceGraph;
   hw::InnerRefNamespace &irn;
-  std::function<StringAttr(Operation *)> getOpName;
+  std::function<StringAttr(Operation *)> getOpNameFallback;
 };
 } // namespace
 
@@ -120,8 +120,8 @@ LogicalResult PathVisitor::processPath(Location loc, hw::HierPathOp hierPathOp,
     auto *op = target.getOp();
     // Get the verilog name of the target.
     auto verilogName = op->getAttrOfType<StringAttr>("hw.verilogName");
-    if (!verilogName && getOpName)
-      verilogName = getOpName(op);
+    if (!verilogName && getOpNameFallback)
+      verilogName = getOpNameFallback(op);
     if (!verilogName) {
       auto diag = emitError(loc, "component does not have verilog name");
       diag.attachNote(op->getLoc()) << "component here";
@@ -151,8 +151,8 @@ LogicalResult PathVisitor::processPath(Location loc, hw::HierPathOp hierPathOp,
       auto currentModule = innerRef.getModule();
       // Get the verilog name of the target.
       auto verilogName = op->getAttrOfType<StringAttr>("hw.verilogName");
-      if (!verilogName && getOpName)
-        verilogName = getOpName(op);
+      if (!verilogName && getOpNameFallback)
+        verilogName = getOpNameFallback(op);
       if (!verilogName) {
         auto diag = emitError(loc, "component does not have verilog name");
         diag.attachNote(op->getLoc()) << "component here";

--- a/lib/Dialect/OM/Transforms/FreezePaths.cpp
+++ b/lib/Dialect/OM/Transforms/FreezePaths.cpp
@@ -30,8 +30,9 @@ using namespace om;
 
 namespace {
 struct PathVisitor {
-  PathVisitor(hw::InstanceGraph &instanceGraph, hw::InnerRefNamespace &irn)
-      : instanceGraph(instanceGraph), irn(irn) {}
+  PathVisitor(hw::InstanceGraph &instanceGraph, hw::InnerRefNamespace &irn,
+              std::function<StringAttr(Operation *)> &getOpName)
+      : instanceGraph(instanceGraph), irn(irn), getOpName(getOpName) {}
 
   StringAttr field;
   LogicalResult processPath(Location loc, hw::HierPathOp hierPathOp,
@@ -44,6 +45,7 @@ struct PathVisitor {
   LogicalResult run(ModuleOp module);
   hw::InstanceGraph &instanceGraph;
   hw::InnerRefNamespace &irn;
+  std::function<StringAttr(Operation *)> getOpName;
 };
 } // namespace
 
@@ -118,6 +120,8 @@ LogicalResult PathVisitor::processPath(Location loc, hw::HierPathOp hierPathOp,
     auto *op = target.getOp();
     // Get the verilog name of the target.
     auto verilogName = op->getAttrOfType<StringAttr>("hw.verilogName");
+    if (!verilogName && getOpName)
+      verilogName = getOpName(op);
     if (!verilogName) {
       auto diag = emitError(loc, "component does not have verilog name");
       diag.attachNote(op->getLoc()) << "component here";
@@ -147,6 +151,8 @@ LogicalResult PathVisitor::processPath(Location loc, hw::HierPathOp hierPathOp,
       auto currentModule = innerRef.getModule();
       // Get the verilog name of the target.
       auto verilogName = op->getAttrOfType<StringAttr>("hw.verilogName");
+      if (!verilogName && getOpName)
+        verilogName = getOpName(op);
       if (!verilogName) {
         auto diag = emitError(loc, "component does not have verilog name");
         diag.attachNote(op->getLoc()) << "component here";
@@ -299,7 +305,11 @@ LogicalResult PathVisitor::run(ModuleOp module) {
 namespace {
 struct FreezePathsPass
     : public circt::om::impl::FreezePathsBase<FreezePathsPass> {
+  FreezePathsPass(std::function<StringAttr(Operation *)> getOpName)
+      : getOpName(std::move(getOpName)) {}
   void runOnOperation() override;
+
+  std::function<StringAttr(Operation *)> getOpName;
 };
 } // namespace
 
@@ -310,10 +320,11 @@ void FreezePathsPass::runOnOperation() {
   auto &symbolTable = getAnalysis<SymbolTable>();
   hw::InnerSymbolTableCollection collection(module);
   hw::InnerRefNamespace irn{symbolTable, collection};
-  if (failed(PathVisitor(instanceGraph, irn).run(module)))
+  if (failed(PathVisitor(instanceGraph, irn, getOpName).run(module)))
     signalPassFailure();
 }
 
-std::unique_ptr<mlir::Pass> circt::om::createFreezePathsPass() {
-  return std::make_unique<FreezePathsPass>();
+std::unique_ptr<mlir::Pass> circt::om::createFreezePathsPass(
+    std::function<StringAttr(Operation *)> getOpName) {
+  return std::make_unique<FreezePathsPass>(getOpName);
 }


### PR DESCRIPTION
`FreezePaths` pass may sometimes need to be invoked before `ExportVerilog`. 
This change removes the dependency of the pass on the `hw.verilogName` attribute, and adds an optional get operation name function, that can be invoked if the verilog name is absent. 
This enables any tool to invoke it earlier by providing an appropriate name-getter function. 
But as is expected, the names used to freeze the paths, may not match the verilog names. This should be used with caution, only when the path will not be used and its okay to be incorrect.