### PR TITLE
[FIRRTL] Improve Layer Merge Performance

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LayerMerge.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LayerMerge.cpp
@@ -13,6 +13,7 @@
 
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
+#include "mlir/IR/Iterators.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/Support/Debug.h"
@@ -42,41 +43,31 @@ void LayerMerge::runOnOperation() {
                       "--------------------------------------------------===\n"
                    << "Module: '" << getOperation().getName() << "'\n";);
 
-  // Track the last layer block that we saw which referenced a specific layer
-  // definition.  Because this pass operates as a single walk of the IR, it is
-  // only ever possible that there is one prior layer block that references a
-  // given layer definition.
-  llvm::DenseMap<SymbolRefAttr, LayerBlockOp> priorLayerBlocks;
+  // Track the last layer block in a module associated with a specific layer.
+  llvm::DenseMap<SymbolRefAttr, LayerBlockOp> lastBlock;
 
-  // Recursively walk LayerBlockOps in the module.  Whenever we see a layer
-  // block, check to see if there is a prior layer block that references the
-  // same declaration.  If not, this layer block becomes the prior layer block
-  // and we continue.  If there is a prior layer block, then splice the prior
-  // layer block's body into the beginning of this layer block and erase the
-  // prior layer block.  This layer block then becomes the new prior layer
-  // block.
+  // Recursively visit LayerBlockOps in reverse order.  Merge all earlier layer
+  // blocks into the last layer blocks of the same layer definition.
   //
   // The recursive walk will cause nested layer blocks to also be merged.
   auto moduleOp = getOperation();
   mlir::IRRewriter rewriter(moduleOp.getContext());
-  moduleOp.walk([&](LayerBlockOp layerBlock) {
-    auto layerName = layerBlock.getLayerName();
-    // If we haven't seen this layer before, then just insert it into
-    // priorLayerBlocks.
-    auto priorLayerBlockIt = priorLayerBlocks.find(layerName);
-    if (priorLayerBlockIt == priorLayerBlocks.end()) {
-      priorLayerBlocks[layerName] = layerBlock;
-      return WalkResult::advance();
-    }
+  moduleOp.walk<mlir::WalkOrder::PostOrder, mlir::ReverseIterator>(
+      [&](LayerBlockOp layerBlock) {
+        auto layerName = layerBlock.getLayerName();
+        // If we haven't seen this block before, then mark it as the last.
+        auto [last, inserted] = lastBlock.try_emplace(layerName, layerBlock);
+        if (inserted)
+          return WalkResult::advance();
 
-    auto &priorLayerBlock = priorLayerBlockIt->getSecond();
-    rewriter.inlineBlockBefore(priorLayerBlock.getBody(), layerBlock.getBody(),
-                               layerBlock.getBody()->begin());
-    priorLayerBlock->erase();
-    priorLayerBlocks[layerName] = layerBlock;
-    numMerged++;
-    return WalkResult::advance();
-  });
+        auto &priorLayerBlock = last->getSecond();
+        rewriter.inlineBlockBefore(layerBlock.getBody(),
+                                   priorLayerBlock.getBody(),
+                                   priorLayerBlock.getBody()->begin());
+        layerBlock->erase();
+        numMerged++;
+        return WalkResult::advance();
+      });
 }
 
 std::unique_ptr<mlir::Pass> circt::firrtl::createLayerMergePass() {


### PR DESCRIPTION
Fix a performance issue in the `LayerMerge` pass [[1]].  Apparently, repeated use of `inlineBlockBefore` can be a performance issue.  Fix this, by using `mergeBlocks` which will append at the end of a block as opposed to prepend.  This requires an additional move, however, this empirically doesn't matter.

For details of the algorithm, see the updated comments in the pass.

h/t @youngar for algorithmic suggestions.

[1]: https://github.com/llvm/circt/issues/7551