### PR TITLE
[Seq] Introduce seq.initial, !seq.immutable and replace powerOn value with initial value in compreg

### DIFF
--- a/include/circt-c/Dialect/Seq.h
+++ b/include/circt-c/Dialect/Seq.h
@@ -24,6 +24,15 @@ MLIR_CAPI_EXPORTED bool seqTypeIsAClock(MlirType type);
 /// Creates an seq clock type
 MLIR_CAPI_EXPORTED MlirType seqClockTypeGet(MlirContext ctx);
 
+/// If the type is an immutable type
+MLIR_CAPI_EXPORTED bool seqTypeIsAImmutable(MlirType type);
+
+/// Creates a seq immutable type
+MLIR_CAPI_EXPORTED MlirType seqImmutableTypeGet(MlirType type);
+
+/// Creates a seq immutable type
+MLIR_CAPI_EXPORTED MlirType seqImmutableTypeGetInnerType(MlirType type);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/circt/Dialect/Seq/SeqOps.h
+++ b/include/circt/Dialect/Seq/SeqOps.h
@@ -59,6 +59,17 @@ struct FirMemory {
   FirMemory(hw::HWModuleGeneratedOp op);
 };
 
+// Helper functions to create constant initial values.
+mlir::TypedValue<seq::ImmutableType>
+createConstantInitialValue(OpBuilder builder, Location loc,
+                           mlir::IntegerAttr attr);
+mlir::TypedValue<seq::ImmutableType>
+createConstantInitialValue(OpBuilder builder, Operation *constantLike);
+
+// Helper function to unwrap an immutable type value and get yield value in
+// initial op.
+Value unwrapImmutableValue(mlir::TypedValue<seq::ImmutableType> immutableVal);
+
 } // namespace seq
 } // namespace circt
 

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -14,6 +14,7 @@
 
 include "circt/Dialect/HW/HWOpInterfaces.td"
 include "circt/Dialect/HW/HWTypes.td"
+include "circt/Dialect/Sim/SimTypes.td"
 include "circt/Dialect/Seq/SeqAttributes.td"
 include "circt/Dialect/Seq/SeqOpInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -39,16 +40,16 @@ def CompRegOp : SeqOp<"compreg",
     OptionalAttr<StrAttr>:$name,
     Optional<I1>:$reset,
     Optional<AnyType>:$resetValue,
-    Optional<AnyType>:$powerOnValue,
+    Optional<ImmutableType>:$initialValue,
     OptionalAttr<InnerSymAttr>:$inner_sym
   );
   let results = (outs AnyType:$data);
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<ImplicitSSAName>($name) $input `,` $clk
     (`reset` $reset^ `,` $resetValue)?
-    (`powerOn` $powerOnValue^)? attr-dict `:` type($data)
+    (`initial` $initialValue^)? attr-dict `:` type($data)
     custom<OptionalTypeMatch>(ref(type($data)), ref($resetValue), type($resetValue))
-    custom<OptionalTypeMatch>(ref(type($data)), ref($powerOnValue), type($powerOnValue))
+    custom<OptionalImmutableTypeMatch>(ref(type($data)), ref($initialValue), type($initialValue))
   }];
   let hasVerifier = 1;
 
@@ -58,22 +59,24 @@ def CompRegOp : SeqOp<"compreg",
       return build($_builder, $_state, input.getType(), input, clk,
                    /*name*/ StringAttr(),
                    /*reset*/ Value(), /*resetValue*/ Value(),
-                   /*powerOnValue*/ Value(), hw::InnerSymAttr());
+                    /*initialValue*/ Value(),
+                   hw::InnerSymAttr());
     }]>,
     /// Create a register with an inner_sym matching the register's name.
     OpBuilder<(ins "Value":$input, "Value":$clk, "StringAttrOrRef":$name), [{
       auto nameAttr = name.get($_builder.getContext());
       return build($_builder, $_state, input.getType(), input, clk, nameAttr,
                    /*reset*/ Value(), /*resetValue*/ Value(),
-                   /*powerOnValue*/ Value(), hw::InnerSymAttr::get(nameAttr));
+                   /*initialValue*/ Value(),
+                   hw::InnerSymAttr::get(nameAttr));
     }]>,
     /// Create a register with a reset, with an inner_sym matching the
-    /// register's name, and optional power-on value.
+   /// register's name, and optional power-on value.
     OpBuilder<(ins "Value":$input, "Value":$clk, "Value":$reset, "Value":$rstValue,
-                   "StringAttrOrRef":$name, CArg<"Value", "{}">:$powerOnValue), [{
+                   "StringAttrOrRef":$name, CArg<"Value", "{}">:$initialValue), [{
       auto nameAttr = name.get($_builder.getContext());
       return build($_builder, $_state, input.getType(), input, clk, nameAttr,
-                   reset, rstValue, powerOnValue, hw::InnerSymAttr::get(nameAttr));
+                   reset, rstValue, initialValue, hw::InnerSymAttr::get(nameAttr));
     }]>
   ];
 }
@@ -96,16 +99,16 @@ def CompRegClockEnabledOp : SeqOp<"compreg.ce",
     OptionalAttr<StrAttr>:$name,
     Optional<I1>:$reset,
     Optional<AnyType>:$resetValue,
-    Optional<AnyType>:$powerOnValue,
+    Optional<ImmutableType>:$initialValue,
     OptionalAttr<InnerSymAttr>:$inner_sym
   );
   let results = (outs AnyType:$data);
   let assemblyFormat = [{
     (`sym` $inner_sym^)? `` custom<ImplicitSSAName>($name) $input `,` $clk `,` $clockEnable
     (`reset` $reset^ `,` $resetValue)?
-    (`powerOn` $powerOnValue^)? attr-dict `:` type($data)
+    (`initial` $initialValue^)? attr-dict `:` type($data)
     custom<OptionalTypeMatch>(ref(type($data)), ref($resetValue), type($resetValue))
-    custom<OptionalTypeMatch>(ref(type($data)), ref($powerOnValue), type($powerOnValue))
+    custom<OptionalImmutableTypeMatch>(ref(type($data)), ref($initialValue), type($initialValue))
   }];
   let hasVerifier = 1;
 
@@ -120,11 +123,11 @@ def CompRegClockEnabledOp : SeqOp<"compreg.ce",
     }]>,
     OpBuilder<(ins "Value":$input, "Value":$clk, "Value":$ce,
                    "Value":$reset, "Value":$rstValue, "StringRef":$name,
-                   CArg<"Value", "{}">:$powerOnValue),
+                   CArg<"Value", "{}">:$initialValue),
     [{
       auto nameAttr = StringAttr::get($_builder.getContext(), name);
       return build($_builder, $_state, input.getType(), input, clk, ce,
-                   nameAttr, reset, rstValue, powerOnValue,
+                   nameAttr, reset, rstValue, initialValue,
                    hw::InnerSymAttr::get(nameAttr));
     }]>,
   ];
@@ -696,4 +699,44 @@ def FromClockOp : SeqOp<"from_clock", [Pure]> {
 
   let hasFolder = 1;
   let hasCanonicalizeMethod = 1;
+}
+
+def InitialOp : SeqOp<"initial", [SingleBlock,
+      SingleBlockImplicitTerminator<"YieldOp">,
+      RecursivelySpeculatable,
+      RecursiveMemoryEffects, IsolatedFromAbove]> {
+  let summary = "Operation that produces values for initialization";
+  let description = [{
+    `seq.initial` op creates values wrapped types with !seq.immutable.
+    See the Seq dialect rationale for a longer description.
+  }];
+
+  let arguments = (ins);
+  let results = (outs Variadic<ImmutableType>); // seq.immutable values
+  let regions = (region SizedRegion<1>:$body);
+  let hasVerifier = 1;
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins CArg<"TypeRange", "{}">:$resultTypes, CArg<"std::function<void()>", "{}">:$ctor)>
+  ];
+
+  let assemblyFormat = [{
+    $body attr-dict `:` type(results)
+  }];
+
+  let extraClassDeclaration = [{
+    Block *getBodyBlock() { return &getBody().front(); }
+  }];
+}
+
+def YieldOp : SeqOp<"yield",
+                   [Pure, Terminator, HasParent<"InitialOp">]> {
+  let summary = "Yield values";
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+  let builders = [
+    OpBuilder<(ins), "build($_builder, $_state, std::nullopt);">
+  ];
+
+  let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
 }

--- a/include/circt/Dialect/Seq/SeqTypes.td
+++ b/include/circt/Dialect/Seq/SeqTypes.td
@@ -93,4 +93,25 @@ def ClockType : SeqType<"Clock"> {
   let mnemonic = "clock";
 }
 
+def ImmutableTypeImpl : SeqType<"Immutable"> {
+  let mnemonic = "immutable";
+
+  let summary = "Value type that is immutable after initialization";
+  let parameters = (ins "::mlir::Type":$innerType);
+
+  let assemblyFormat = "`<` $innerType `>`";
+
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "Type":$innerType), [{
+      auto *ctx = innerType.getContext();
+      return $_get(ctx, innerType);
+    }]>
+  ];
+}
+
+// A handle to refer to circt::seq::ImmutableType in ODS.
+def ImmutableType : DialectType<SeqDialect,
+    CPred<"isa<circt::seq::ImmutableType>($_self)">,
+          "an ImmutableType", "::circt::seq::ImmutableType">;
+
 #endif // CIRCT_DIALECT_SEQ_SEQTYPES

--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -24,11 +24,14 @@ with Context() as ctx, Location.unknown():
     def top(module):
       # CHECK: %[[RESET_VAL:.+]] = hw.constant 0
       reg_reset = hw.ConstantOp.create(i32, 0).result
-      # CHECK: %[[POWERON_VAL:.+]] = hw.constant 42
       poweron_value = hw.ConstantOp.create(i32, 42).result
       # CHECK: %[[INPUT_VAL:.+]] = hw.constant 45
       reg_input = hw.ConstantOp.create(i32, 45).result
-      # CHECK: %[[DATA_VAL:.+]] = seq.compreg %[[INPUT_VAL]], %clk reset %rst, %[[RESET_VAL]] powerOn %[[POWERON_VAL]]
+      # CHECK-NEXT: %[[POWERON_VAL:.+]] = seq.initial {
+      # CHECK-NEXT:   %[[C42:.+]] = hw.constant 42 : i32
+      # CHECK-NEXT:   seq.yield %[[C42]] : i32
+      # CHECK-NEXT: } : !seq.immutable<i32>
+      # CHECK: %[[DATA_VAL:.+]] = seq.compreg %[[INPUT_VAL]], %clk reset %rst, %[[RESET_VAL]] initial %[[POWERON_VAL]]
       reg = seq.CompRegOp(i32,
                           reg_input,
                           module.clk,

--- a/lib/Bindings/Python/SeqModule.cpp
+++ b/lib/Bindings/Python/SeqModule.cpp
@@ -33,4 +33,13 @@ void circt::python::populateDialectSeqSubmodule(py::module &m) {
             return cls(seqClockTypeGet(ctx));
           },
           py::arg("cls"), py::arg("context") = py::none());
+
+  mlir_type_subclass(m, "ImmutableType", seqTypeIsAImmutable)
+      .def_classmethod("get",
+                       [](py::object cls, MlirType innerType) {
+                         return cls(seqImmutableTypeGet(innerType));
+                       })
+      .def_property_readonly("inner_type", [](MlirType self) {
+        return seqImmutableTypeGetInnerType(self);
+      });
 }

--- a/lib/CAPI/Dialect/Seq.cpp
+++ b/lib/CAPI/Dialect/Seq.cpp
@@ -26,3 +26,15 @@ bool seqTypeIsAClock(MlirType type) {
 MlirType seqClockTypeGet(MlirContext ctx) {
   return wrap(ClockType::get(unwrap(ctx)));
 }
+
+bool seqTypeIsAImmutable(MlirType type) {
+  return llvm::isa<ImmutableType>(unwrap(type));
+}
+
+MlirType seqImmutableTypeGet(MlirType innerType) {
+  return wrap(ImmutableType::get(unwrap(innerType)));
+}
+
+MlirType seqImmutableTypeGetInnerType(MlirType type) {
+  return wrap(llvm::cast<ImmutableType>(unwrap(type)).getInnerType());
+}

--- a/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
+++ b/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
@@ -26,8 +26,25 @@ using llvm::MapVector;
 static bool isArcBreakingOp(Operation *op) {
   return op->hasTrait<OpTrait::ConstantLike>() ||
          isa<hw::InstanceOp, seq::CompRegOp, MemoryOp, ClockedOpInterface,
-             seq::ClockGateOp, sim::DPICallOp>(op) ||
+             seq::InitialOp, seq::ClockGateOp, sim::DPICallOp>(op) ||
          op->getNumResults() > 1;
+}
+
+static LogicalResult convertInitialValue(seq::CompRegOp reg,
+                                         SmallVectorImpl<Value> &values) {
+  if (!reg.getInitialValue())
+    return values.push_back({}), success();
+
+  auto init = circt::seq::unwrapImmutableValue(reg.getInitialValue());
+  if (!init.getDefiningOp<hw::ConstantOp>())
+    return reg.emitError() << "non-constant initial value not supported";
+
+  // Clone the initial value to the top-level.
+  auto *op = init.getDefiningOp()->clone();
+  reg->getBlock()->getOperations().insert(Block::iterator(reg), op);
+  auto result = op->getResult(0);
+  values.push_back(result);
+  return success();
 }
 
 //===----------------------------------------------------------------------===//
@@ -83,7 +100,12 @@ LogicalResult Converter::runOnModule(HWModuleOp module) {
   // Find all arc-breaking operations in this module and assign them an index.
   arcBreakers.clear();
   arcBreakerIndices.clear();
+  SmallVector<seq::InitialOp> initialOps;
   for (Operation &op : *module.getBodyBlock()) {
+    if (isa<seq::InitialOp>(&op)) {
+      initialOps.push_back(cast<seq::InitialOp>(&op));
+      continue;
+    }
     if (op.getNumRegions() > 0)
       return op.emitOpError("has regions; not supported by ConvertToArcs");
     if (!isArcBreakingOp(&op) && !isa<hw::OutputOp>(&op))
@@ -109,6 +131,10 @@ LogicalResult Converter::runOnModule(HWModuleOp module) {
   extractArcs(module);
   if (failed(absorbRegs(module)))
     return failure();
+
+  for (auto init : initialOps)
+    init->erase();
+
   return success();
 }
 
@@ -308,7 +334,8 @@ LogicalResult Converter::absorbRegs(HWModuleOp module) {
         }
       }
 
-      initialValues.push_back(regOp.getPowerOnValue());
+      if (failed(convertInitialValue(regOp, initialValues)))
+        return failure();
 
       absorbedRegs.push_back(regOp);
       // If we absorb a register into the arc, the arc effectively produces that
@@ -421,7 +448,8 @@ LogicalResult Converter::absorbRegs(HWModuleOp module) {
         types.push_back(regOp.getType());
         outputs.push_back(block->addArgument(regOp.getType(), regOp.getLoc()));
         names.push_back(regOp->getAttrOfType<StringAttr>("name"));
-        initialValues.push_back(regOp.getPowerOnValue());
+        if (failed(convertInitialValue(regOp, initialValues)))
+          return failure();
       }
       regToOutputMapping.push_back(it->second);
     }

--- a/lib/Conversion/LTLToCore/LTLToCore.cpp
+++ b/lib/Conversion/LTLToCore/LTLToCore.cpp
@@ -53,7 +53,8 @@ struct HasBeenResetOpConversion : OpConversionPattern<verif::HasBeenResetOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto i1 = rewriter.getI1Type();
     // Generate the constant used to set the register value
-    Value constZero = rewriter.create<hw::ConstantOp>(op.getLoc(), i1, 0);
+    Value constZero = seq::createConstantInitialValue(
+        rewriter, op->getLoc(), rewriter.getIntegerAttr(i1, 0));
 
     // Generate the constant used to enegate the
     Value constOne = rewriter.create<hw::ConstantOp>(op.getLoc(), i1, 1);

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -374,8 +374,8 @@ public:
     } else {
       auto stageRegPrefix = getStagePrefix(stageIndex);
       auto enableRegName = (stageRegPrefix.strref() + "_enable").str();
-      Value enableRegResetVal =
-          builder.create<hw::ConstantOp>(loc, APInt(1, 0, false)).getResult();
+      hw::ConstantOp enableRegResetVal =
+          builder.create<hw::ConstantOp>(loc, APInt(1, 0, false));
 
       switch (stageKind) {
       case StageKind::Continuous:
@@ -406,7 +406,9 @@ public:
       if (enablePowerOnValues) {
         llvm::TypeSwitch<Operation *, void>(stageEnabled.getDefiningOp())
             .Case<seq::CompRegOp, seq::CompRegClockEnabledOp>([&](auto op) {
-              op.getPowerOnValueMutable().assign(enableRegResetVal);
+              op.getInitialValueMutable().assign(
+                  circt::seq::createConstantInitialValue(builder,
+                                                         enableRegResetVal));
             });
       }
     }

--- a/lib/Dialect/Arc/Transforms/StripSV.cpp
+++ b/lib/Dialect/Arc/Transforms/StripSV.cpp
@@ -156,13 +156,14 @@ void StripSVPass::runOnOperation() {
         if (reg.getPreset() && !reg.getPreset()->isZero()) {
           assert(hw::type_isa<IntegerType>(reg.getType()) &&
                  "cannot lower non integer preset");
-          presetValue = builder.createOrFold<hw::ConstantOp>(
-              reg.getLoc(), IntegerAttr::get(reg.getType(), *reg.getPreset()));
+          presetValue = circt::seq::createConstantInitialValue(
+              builder, reg.getLoc(),
+              IntegerAttr::get(reg.getType(), *reg.getPreset()));
         }
 
         Value compReg = builder.create<seq::CompRegOp>(
             reg.getLoc(), next.getType(), next, reg.getClk(), reg.getNameAttr(),
-            Value{}, Value{}, /*powerOnValue*/ presetValue,
+            Value{}, Value{}, /*initialValue*/ presetValue,
             reg.getInnerSymAttr());
         reg.replaceAllUsesWith(compReg);
         opsToDelete.push_back(reg);

--- a/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
+++ b/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
@@ -93,8 +93,8 @@ void ExternalizeRegistersPass::runOnOperation() {
             regOp.emitError("registers with reset signals not yet supported");
             return signalPassFailure();
           }
-          if (regOp.getPowerOnValue()) {
-            regOp.emitError("registers with power-on values not yet supported");
+          if (regOp.getInitialValue()) {
+            regOp.emitError("registers with initial values not yet supported");
             return signalPassFailure();
           }
           addedInputs[module.getSymNameAttr()].push_back(regOp.getType());

--- a/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
@@ -120,22 +120,26 @@ hw.module.extern private @Reshuffling2(out z0: i4, out z1: i4, out z2: i4, out z
 
 // CHECK-LABEL: hw.module @ReshufflingInit
 hw.module @ReshufflingInit(in %clockA: !seq.clock, in %clockB: !seq.clock, out z0: i4, out z1: i4, out z2: i4, out z3: i4) {
+  // CHECK-NEXT: hw.instance "x" @Reshuffling2()
   // CHECK-NEXT: [[C1:%.+]] = hw.constant 1 : i4
   // CHECK-NEXT: [[C2:%.+]] = hw.constant 2 : i4
   // CHECK-NEXT: [[C3:%.+]] = hw.constant 3 : i4
-  // CHECK-NEXT: hw.instance "x" @Reshuffling2()
   // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i4
   // CHECK-NEXT: arc.state @ReshufflingInit_arc(%x.z0, %x.z1) clock %clockA initial ([[C0]], [[C1]] : i4, i4) latency 1
   // CHECK-NEXT: arc.state @ReshufflingInit_arc_0(%x.z2, %x.z3) clock %clockB initial ([[C2]], [[C3]] : i4, i4) latency 1
   // CHECK-NEXT: hw.output
-  %cst1 = hw.constant 1 : i4
-  %cst2 = hw.constant 2 : i4
-  %cst3 = hw.constant 3 : i4
+
   %x.z0, %x.z1, %x.z2, %x.z3 = hw.instance "x" @Reshuffling2() -> (z0: i4, z1: i4, z2: i4, z3: i4)
   %4 = seq.compreg %x.z0, %clockA : i4
-  %5 = seq.compreg %x.z1, %clockA powerOn %cst1 : i4
-  %6 = seq.compreg %x.z2, %clockB powerOn %cst2 : i4
-  %7 = seq.compreg %x.z3, %clockB powerOn %cst3 : i4
+  %init0, %init1, %init2 = seq.initial {
+    %cst1 = hw.constant 1 : i4
+    %cst2 = hw.constant 2 : i4
+    %cst3 = hw.constant 3 : i4
+    seq.yield %cst1, %cst2, %cst3 : i4, i4, i4
+  } : !seq.immutable<i4>, !seq.immutable<i4>, !seq.immutable<i4>
+  %5 = seq.compreg %x.z1, %clockA initial %init0 : i4
+  %6 = seq.compreg %x.z2, %clockB initial %init1 : i4
+  %7 = seq.compreg %x.z3, %clockB initial %init2 : i4
   hw.output %4, %5, %6, %7 : i4, i4, i4, i4
 }
 // CHECK-NEXT: }
@@ -236,8 +240,11 @@ hw.module @TrivialWithInit(in %clock: !seq.clock, in %i0: i4, in %reset: i1, out
   // CHECK: [[RES0:%.+]] = arc.state @[[TRIVIALINIT_ARC]](%i0) clock %clock reset %reset initial ([[CST2]] : i4) latency 1 {names = ["foo"]
   // CHECK-NEXT: hw.output [[RES0:%.+]]
   %0 = hw.constant 0 : i4
-  %cst2 = hw.constant 2 : i4
-  %foo = seq.compreg %i0, %clock reset %reset, %0 powerOn %cst2: i4
+  %init = seq.initial {
+    %cst2 = hw.constant 2 : i4
+    seq.yield %cst2: i4
+  } : !seq.immutable<i4>
+  %foo = seq.compreg %i0, %clock reset %reset, %0 initial %init: i4
   hw.output %foo : i4
 }
 // CHECK-NEXT: }

--- a/test/Conversion/HWToBTOR2/init.mlir
+++ b/test/Conversion/HWToBTOR2/init.mlir
@@ -10,9 +10,14 @@ module {
     //CHECK:    [[NID3:[0-9]+]] constd [[NID0]] 0
     %false = hw.constant false
     //CHECK:    [[INIT:[0-9]+]] init [[NID0]] [[NID2]] [[NID3]]
-    %reg = seq.compreg %false, %clock reset %reset, %false powerOn %false : i1  
+    %init = seq.initial {
+      %false_0 = hw.constant false
+      seq.yield %false_0 : i1
+    } : !seq.immutable<i1>
+    //CHECK:    [[RESET:[0-9]+]] constd [[NID0]] 0
+    %reg = seq.compreg %false, %clock reset %reset, %false initial %init : i1
 
-    //CHECK:    [[NID4:[0-9]+]] eq [[NID0]] [[NID2]] [[NID3]]
+    //CHECK:    [[NID4:[0-9]+]] eq [[NID0]] [[NID2]] [[RESET]]
     %10 = comb.icmp bin eq %reg, %false : i1
 
     sv.always posedge %0 {
@@ -20,7 +25,7 @@ module {
         //CHECK:    [[NID6:[0-9]+]] bad [[NID5]]
         sv.assert %10, immediate
     }
-    //CHECK:    [[NID7:[0-9]+]] ite [[NID0]] [[NID1]] [[NID3]] [[NID3]]
+    //CHECK:    [[NID7:[0-9]+]] ite [[NID0]] [[NID1]] [[RESET]] [[RESET]]
     //CHECK:    [[NID8:[0-9]+]] next [[NID0]] [[NID2]] [[NID7]]
   }
 

--- a/test/Conversion/LTLToCore/assertproperty.mlir
+++ b/test/Conversion/LTLToCore/assertproperty.mlir
@@ -6,11 +6,14 @@ module {
   hw.module @test(in %clock : !seq.clock, in %reset : i1, in %a : i1) {
     //CHECK:  [[CLK:%.+]] = seq.from_clock %clock
     %0 = seq.from_clock %clock 
+    // CHECK-NEXT: %[[INIT:.+]] = seq.initial {
+    // CHECK-NEXT:   %false = hw.constant false
+    // CHECK-NEXT:   seq.yield %false : i1
+    // CHECK-NEXT: } : !seq.immutable<i1>
 
-    //CHECK:  %false = hw.constant false
     //CHECK:  %true = hw.constant true
     //CHECK:  [[TMP:%.+]] = comb.or %reset, %hbr : i1
-    //CHECK:  %hbr = seq.compreg [[TMP]], %clock powerOn %false : i1  
+    //CHECK:  %hbr = seq.compreg [[TMP]], %clock initial %[[INIT]] : i1
     %1 = verif.has_been_reset %0, sync %reset
 
     //CHECK:  [[TMP1:%.+]] = comb.xor %reset, %true : i1

--- a/test/Conversion/PipelineToHW/test_poweron.mlir
+++ b/test/Conversion/PipelineToHW/test_poweron.mlir
@@ -1,17 +1,21 @@
 // RUN: circt-opt --lower-pipeline-to-hw="enable-poweron-values" %s | FileCheck %s
 
-// CHECK-LABEL:   hw.module @testPowerOn(in 
+// CHECK-LABEL:   hw.module @testinitial(in 
 // CHECK-SAME:            %[[VAL_0:.*]] : i32, in %[[VAL_1:.*]] : i32, in %[[VAL_2:.*]] : i1, in %[[VAL_3:.*]] : !seq.clock, in %[[VAL_4:.*]] : i1, out out0 : i32, out out1 : i1) {
 // CHECK:           %[[VAL_5:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_5]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
-// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[VAL_3]] reset %[[VAL_4]], %[[VAL_8]]  powerOn %[[VAL_8]] : i1
+// CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[VAL_3]] reset %[[VAL_4]], %[[VAL_8]]  initial %[[INIT:.+]] : i1
+// CHECK:           %[[INIT]] = seq.initial {
+// CHECK:             %false_0 = hw.constant false
+// CHECK:             seq.yield %false_0 : i1
+// CHECK:           } : !seq.immutable<i1>
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
 // CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
 // CHECK:         }
 
-hw.module @testPowerOn(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk: !seq.clock, in %rst: i1, out out0: i32, out out1: i1) {
+hw.module @testinitial(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk: !seq.clock, in %rst: i1, out out0: i32, out out1: i1) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %1 = comb.sub %a0,%a1 : i32
     pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)

--- a/test/Dialect/Seq/errors.mlir
+++ b/test/Dialect/Seq/errors.mlir
@@ -18,3 +18,23 @@ hw.module @fifo3(in %clk : !seq.clock, in %rst : i1, in %in : i32, in %rdEn : i1
   // expected-error @+1 {{'seq.fifo' op almost empty threshold must be <= FIFO depth}}
   %out, %full, %empty, %almostFull, %almostEmpty = seq.fifo depth 3 almost_full 1 almost_empty 4 in %in rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
 }
+
+// -----
+
+hw.module @init() {
+  // expected-error @+1 {{result type doesn't match with the terminator}}
+  %0 = seq.initial {
+    %1 = hw.constant 32: i32
+    seq.yield %1, %1: i32, i32
+  }: !seq.immutable<i32>
+}
+
+// -----
+
+hw.module @init() {
+  // expected-error @+1 {{'i32' is expected but got 'i16'}}
+  %0 = seq.initial {
+    %1 = hw.constant 32: i16
+    seq.yield %1: i16
+  }: !seq.immutable<i32>
+}

--- a/test/Dialect/Seq/round-trip.mlir
+++ b/test/Dialect/Seq/round-trip.mlir
@@ -97,3 +97,12 @@ hw.module @clock_inv(in %clock: !seq.clock) {
   // CHECK: seq.clock_inv %clock
   %inv = seq.clock_inv %clock
 }
+
+// CHECK-LABEL: @init
+hw.module @init() {
+  // CHECK-NEXT: seq.initial
+  %0 = seq.initial {
+    %1 = hw.constant 32: i32
+    seq.yield %1: i32
+  }: !seq.immutable<i32>
+}

--- a/test/Dialect/Seq/shiftreg.mlir
+++ b/test/Dialect/Seq/shiftreg.mlir
@@ -7,9 +7,13 @@
 // LO:    %r0_sh1 = seq.compreg.ce sym @r0_sh1  %i, %clk, %ce : i32  
 // LO:    %r0_sh2 = seq.compreg.ce sym @r0_sh2  %r0_sh1, %clk, %ce : i32  
 // LO:    %r0_sh3 = seq.compreg.ce sym @r0_sh3  %r0_sh2, %clk, %ce : i32  
-// LO:    %myShiftReg_sh1 = seq.compreg.ce sym @myShiftReg_sh1  %i, %clk, %ce reset %rst, %c0_i32 powerOn %c0_i32 : i32  
-// LO:    %myShiftReg_sh2 = seq.compreg.ce sym @myShiftReg_sh2  %myShiftReg_sh1, %clk, %ce reset %rst, %c0_i32 powerOn %c0_i32 : i32  
-// LO:    %myShiftReg_sh3 = seq.compreg.ce sym @myShiftReg_sh3  %myShiftReg_sh2, %clk, %ce reset %rst, %c0_i32 powerOn %c0_i32 : i32  
+// LO     %0 = seq.initial {
+// LO       %c0_i32_0 = hw.constant 0 : i32
+// LO       seq.yield %c0_i32_0 : i32
+// LO     } : !seq.immutable<i32>
+// LO:    %myShiftReg_sh1 = seq.compreg.ce sym @myShiftReg_sh1  %i, %clk, %ce reset %rst, %c0_i32 initial %0 : i32
+// LO:    %myShiftReg_sh2 = seq.compreg.ce sym @myShiftReg_sh2  %myShiftReg_sh1, %clk, %ce reset %rst, %c0_i32 initial %0 : i32
+// LO:    %myShiftReg_sh3 = seq.compreg.ce sym @myShiftReg_sh3  %myShiftReg_sh2, %clk, %ce reset %rst, %c0_i32 initial %0 : i32
 // LO:    hw.output %r0_sh3, %myShiftReg_sh3 : i32, i32
 
 hw.module @top(in %clk: !seq.clock, in %rst: i1, in %ce: i1, in %i: i32, out out1 : i32, out out2 : i32) {

--- a/test/Tools/circt-bmc/externalize-registers-errors.mlir
+++ b/test/Tools/circt-bmc/externalize-registers-errors.mlir
@@ -27,9 +27,13 @@ hw.module @reg_with_reset(in %clk: !seq.clock, in %rst: i1, in %in: i32, out out
 
 // -----
 
-hw.module @reg_with_poweron(in %clk: !seq.clock, in %in: i32, out out: i32) {
-  %c0_i32 = hw.constant 0 : i32
-  // expected-error @below {{registers with power-on values not yet supported}}
-  %1 = seq.compreg %in, %clk powerOn %c0_i32 : i32
+hw.module @reg_with_initial(in %clk: !seq.clock, in %in: i32, out out: i32) {
+  %init = seq.initial {
+    %c0_i32 = hw.constant 0 : i32
+    seq.yield %c0_i32 : i32
+  } : !seq.immutable<i32>
+
+  // expected-error @below {{registers with initial values not yet supported}}
+  %1 = seq.compreg %in, %clk initial %init : i32
   hw.output %1 : i32
 }


### PR DESCRIPTION
This PR extends compreg's powerOnValue operand to be able to capture more complicated initialization such as firreg's randomized initialization or DPI calls. This change should make register initialization more modular and a step forward towards https://github.com/llvm/circt/issues/7213. 

While ASICs might not have explicit initial values, they are crucial for simulation
and FPGA implementation. FPGA designs often require constant initial values, while
simulation allows for more complex initialization using expressions like function calls
`$random`, `$readmem`, and `$fopen`.

seq.compreg has a (optional) powerOn operand that is lowered into inlined assignment in SV which allows users to initialize registers with user-specified values. However this representation is not sufficient for initialization with function calls. 

In order to represent various kinds of initialization, `seq.initial` op and `!seq.immutable` type
are introduced. The `seq.initial` operation produces values with types wrapped in `!seq.immutable`.
The `!seq.immutable` type wrapper prevents initial values from depending on time-variant values.
Stateful operations typically require corresponding initial values with the `!seq.immutable` type.
This ensures that the initial state of the operation is well-defined and independent of time-variant factors.

Example Input:
```mlir
%r_init, %u_init = seq.initial {
  %rand = sv.macro.ref.se @RANDOM() : () -> i32
  %c0_i32 = hw.constant 0 : i32
  seq.yield %rand, %c0_i32 : i32, i32
} : !seq.immutable<i32>, !seq.immutable<i32>
%r = seq.compreg %i, %clk initial %r_init : i32
%u = seq.compreg %i, %clk initial %u_init : i32
```

Output Verilog:
```verilog
reg [31:0] r;
initial
  r = `RANDOM;
reg [31:0] u = 32'h0;
```