### PR TITLE
[ESI] Make AcceleratorConnection::disconnect virtual

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
@@ -82,7 +82,7 @@ public:
   Context &getCtxt() const { return ctxt; }
 
   /// Disconnect from the accelerator cleanly.
-  void disconnect();
+  virtual void disconnect();
 
   /// Request the host side channel ports for a particular instance (identified
   /// by the AppID path). For convenience, provide the bundle type.


### PR DESCRIPTION
Currently, `AcceleratorConnection` implementations only have one "official" teardown entry point, being their destructors. However, this makes implementations susceptible to destructor race conditions, due to the various things that may be concurrently executing in implementation-owned resources.

To provide users with more control during teardown, mark `AcceleratorConnection::disconnect` as virtual, allowing implementations to tear things down before deconstruction.