### PR TITLE
[ExportVerilog] Drop external module emission

### DIFF
--- a/integration_test/Bindings/Python/dialects/rtl.py
+++ b/integration_test/Bindings/Python/dialects/rtl.py
@@ -116,5 +116,5 @@ with Context() as ctx, Location.unknown():
   pm = PassManager.parse("builtin.module(hw.module(hw-cleanup))")
   pm.run(m.operation)
   # CHECK: module MyWidget
-  # CHECK: external module FancyThing
+  # CHECK-NOT: module FancyThing
   circt.export_verilog(m, sys.stdout)

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s --test-apply-lowering-options='options=emittedLineLength=100,emitBindComments' -export-verilog -verify-diagnostics -o %t.mlir | FileCheck %s
 
-// CHECK-LABEL: // external module E
+// CHECK-NOT: module E
 hw.module.extern @E(in %a: i1, in %b: i1, in %c: i1)
 hw.module.extern @Array(in %a: !hw.array<2xi4>)
 
@@ -11,19 +11,19 @@ hw.module @TESTSIMPLE(in %a: i4, in %b: i4, in %c: i2, in %cond: i1,
                         in %structA: !hw.struct<foo: i2, bar:i4>,
                         in %arrOfStructA: !hw.array<5 x struct<foo: i2>>,
                         in %array1: !hw.array<1xi1>,
-  out r0: i4, out r2: i4, out r4: i4, out r6: i4, out r7: i4, 
+  out r0: i4, out r2: i4, out r4: i4, out r6: i4, out r7: i4,
   out r8: i4, out r9: i4, out r10: i4, out r11: i4,
-  out r12: i4, out r13: i4, out r14: i4, out r15: i4, 
+  out r12: i4, out r13: i4, out r14: i4, out r15: i4,
   out r16: i1, out r17: i1, out r18: i1, out r19: i1,
-  out r20: i1, out r21: i1, out r22: i1, out r23: i1, 
+  out r20: i1, out r21: i1, out r22: i1, out r23: i1,
   out r24: i1, out r25: i1, out r26: i1, out r27: i1,
-  out r28: i1, out r29: i12, out r30: i2, out r31: i9, 
+  out r28: i1, out r29: i12, out r30: i2, out r31: i9,
   out r33: i4, out r34: i4, out r35: !hw.array<3xi4>,
-  out r36: !hw.array<6xi4>, out r37: i4, out r38: i12, 
-  out r39: !hw.struct<a: i1, b: i1>, out r40: !hw.array<4xi2>, 
-  out r41: !hw.uarray<1xi1>, out r42: !hw.struct<a: !hw.array<1xi1>>, 
-  out r43: i4, out r44: !hw.struct<foo: i2, bar: i4>, 
-  out r45: !hw.struct<foo: i2, bar: i4>, 
+  out r36: !hw.array<6xi4>, out r37: i4, out r38: i12,
+  out r39: !hw.struct<a: i1, b: i1>, out r40: !hw.array<4xi2>,
+  out r41: !hw.uarray<1xi1>, out r42: !hw.struct<a: !hw.array<1xi1>>,
+  out r43: i4, out r44: !hw.struct<foo: i2, bar: i4>,
+  out r45: !hw.struct<foo: i2, bar: i4>,
   out r46: !hw.struct<foo: i2, bar: i4>, out r47: i1
   ) attributes {sv.attributes = [#sv.attribute<"svAttr">]} {
 
@@ -95,15 +95,15 @@ hw.module @TESTSIMPLE(in %a: i4, in %b: i4, in %c: i2, in %cond: i1,
   %none = hw.constant 0 : i0
   %47 = hw.array_get %array1[%none] : !hw.array<1xi1>, i0
 
-  hw.output %0, %2, %4, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, 
+  hw.output %0, %2, %4, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17,
             %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30,
             %31, %33, %34, %35, %36, %37, %38, %39, %40, %41, %42, %43, %44,
             %45, %46, %47:
     i4, i4, i4, i4, i4, i4, i4, i4, i4, i4, i4, i4, i4, i1, i1, i1, i1, i1, i1,
     i1, i1, i1, i1, i1, i1, i1, i12, i2, i9, i4, i4, !hw.array<3xi4>,
     !hw.array<6xi4>, i4, i12, !hw.struct<a: i1, b: i1>, !hw.array<4xi2>,
-    !hw.uarray<1xi1>, !hw.struct<a: !hw.array<1xi1>>, i4, 
-    !hw.struct<foo: i2, bar: i4>, !hw.struct<foo: i2, bar: i4>, 
+    !hw.uarray<1xi1>, !hw.struct<a: !hw.array<1xi1>>, i4,
+    !hw.struct<foo: i2, bar: i4>, !hw.struct<foo: i2, bar: i4>,
     !hw.struct<foo: i2, bar: i4>, i1
 }
 
@@ -549,7 +549,7 @@ hw.module @zeroElements(in %in0: i0, in %in1: i32, out out0: !hw.struct<z1: i0, 
   // CHECK-SAME: _GEN = '{};
   // CHECK-NEXT: wire struct packed {logic [31:0] d1; /*z: Zero Width;*/ } _GEN_0 = '{d1: in1};
   //      CHECK: wire
-  // CHECK-NEXT:   struct packed {/*z1: Zero Width;*/ logic [31:0] a; /*z2: Zero Width;*/ logic [31:0] b; /*c: Zero Width;*/ struct packed {logic [31:0] d1; /*z: Zero Width;*/ } d; } 
+  // CHECK-NEXT:   struct packed {/*z1: Zero Width;*/ logic [31:0] a; /*z2: Zero Width;*/ logic [31:0] b; /*c: Zero Width;*/ struct packed {logic [31:0] d1; /*z: Zero Width;*/ } d; }
   // CHECK-NEXT:   _GEN_1 = '{a: in1, b: in1, d: _GEN_0};
   // CHECK-NEXT: assign out0 = '{a: in1, b: _GEN_1.b, d: _GEN_1.d};
   %0 = hw.struct_create (%in0) : !hw.struct<z: i0>
@@ -584,9 +584,9 @@ hw.module @TestZeroStructInstance(in %structZero: !hw.struct<>, in %structZeroNe
 // CHECK-NEXT:   // output /*Zero Width*/ out2
 // CHECK-NEXT:  );
 
-// CHECK:   assign out = arg1[/*Zero width*/ 1'b0];	
-// CHECK-NEXT:   assign out1 = arg1[/*Zero width*/ 1'b0];	
-// CHECK-NEXT:   // Zero width: assign out2 = arg0;	
+// CHECK:   assign out = arg1[/*Zero width*/ 1'b0];
+// CHECK-NEXT:   assign out1 = arg1[/*Zero width*/ 1'b0];
+// CHECK-NEXT:   // Zero width: assign out2 = arg0;
 
 hw.module @testZeroArrayGet(in %arg0: i0, in %arg1 : !hw.array<1xi32>, out out: i32, out out1: i32, out out2: i0) {
   // Using an expression as index.
@@ -1081,7 +1081,7 @@ hw.module @renameKeyword(in %a: !hw.struct<repeat: i1, repeat_0: i1>, out r1: !h
 // CHECK-NEXT:  inout  struct packed {logic repeat_0; logic repeat_0_0; } a,
 // CHECK-NEXT:  output                                                    r1,
 // CHECK-NEXT:                                                            r2,
-// CHECK-NEXT:  output struct packed {logic repeat_0; logic repeat_0_0; } r3, 
+// CHECK-NEXT:  output struct packed {logic repeat_0; logic repeat_0_0; } r3,
 // CHECK-NEXT:                                                            r4
 // CHECK-NEXT:  );
 hw.module @useRenamedStruct(inout %a: !hw.struct<repeat: i1, repeat_0: i1>, out r1: i1, out r2: i1, out r3: !hw.struct<repeat: i1, repeat_0: i1>, out r4: !hw.struct<repeat: i1, repeat_0: i1>) {

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1372,7 +1372,7 @@ hw.module @MoveInstances(in %a_in: i8, out outc : i8){
   hw.output %outc : i8
 }
 
-// CHECK-LABEL: module extInst
+// CHECK-NOT: module extInst
 hw.module.extern @extInst(in %_h: i1, in %_i: i1, in %_j: i1, in %_k: i1, in %_z :i0)
 
 // CHECK-LABEL: module extInst2

--- a/test/Conversion/ExportVerilog/verilog-locations.mlir
+++ b/test/Conversion/ExportVerilog/verilog-locations.mlir
@@ -10,7 +10,7 @@ hw.module @MultiUseExpr(in %a: i4, out b0: i1) {
 //   input  [3:0] a,
 //   output       b0
 // );
-// 
+//
 //   assign b0 = ^a;
 // endmodule
 
@@ -61,7 +61,7 @@ hw.module @SimpleConstPrintReset(in %clock: i1, in %reset: i1, in %in4: i4) {
 //               reset,
 //   input [3:0] in4
 // );
-// 
+//
 //   wire [3:0] w = 4'h1;
 //   reg  [3:0] q;
 //   always @(posedge clock or posedge reset) begin
@@ -156,11 +156,11 @@ hw.module @InlineDeclAssignment(in %a: i1) {
 // module InlineDeclAssignment(
 //   input a
 // );
-// 
+//
 //   wire b = a;
 //   wire c = a + a;
 // endmodule
-// 
+//
 // CHECK:   hw.module @InlineDeclAssignment
 // CHECK:     %b = sv.wire {hw.verilogName = "b"} : !hw.inout<i1> loc(#loc25)
 // CHECK:     sv.assign %b, %a : i1 loc(#loc8)
@@ -205,19 +205,10 @@ module attributes {circt.loweringOptions = "emitVerilogLocations"} {
 hw.module.extern @MyExtModule()
 hw.module.extern @AParameterizedExtModule<CFG: none>()
 }
-// CHECK:   hw.module.extern @MyExtModule() loc(#loc11)
-// CHECK:   hw.module.extern @AParameterizedExtModule<CFG: none>() loc(#loc12)
+// CHECK:   hw.module.extern @MyExtModule() loc(#loc1)
+// CHECK:   hw.module.extern @AParameterizedExtModule<CFG: none>() loc(#loc2)
 
 // CHECK: #loc = loc("{{.*}}verilog-locations.mlir{{.*}})
 // CHECK: #loc1 = loc("{{.*}}verilog-locations.mlir{{.*}})
-// CHECK: #loc2 = loc("":2:0)
-// CHECK: #loc3 = loc("":3:0)
-// CHECK: #loc4 = loc("{{.*}}verilog-locations.mlir{{.*}})
-// CHECK: #loc5 = loc("":4:0)
-// CHECK: #loc6 = loc("":5:0)
-// CHECK: #loc7 = loc(fused<"Range">[#loc2, #loc3])
-// CHECK: #loc8 = loc(fused<"Range">[#loc5, #loc6])
-// CHECK: #loc9 = loc(fused<"verilogLocations">[#loc7])
-// CHECK: #loc10 = loc(fused<"verilogLocations">[#loc8])
-// CHECK: #loc11 = loc(fused[#loc1, #loc9])
-// CHECK: #loc12 = loc(fused[#loc4, #loc10])
+// CHECK: #loc2 = loc("{{.*}}verilog-locations.mlir{{.*}})
+// CHECK-NOT: #loc

--- a/test/firtool/memoryLowering.fir
+++ b/test/firtool/memoryLowering.fir
@@ -32,7 +32,7 @@ circuit test:
     memory.w.mask <= wMask
     memory.w.data <= wData
 
-; CHECK: external module memory_ext
+; CHECK-NOT: module memory_ext
 
 ; CHECK-LABEL: FILE "metadata{{[/\]}}seq_mems.json"
 ; CHECK:      [

--- a/test/firtool/memoryMetadata.fir
+++ b/test/firtool/memoryMetadata.fir
@@ -171,9 +171,9 @@ circuit test:
 ; CHECK: dutModule2 [[m:.+]] (
 
 
-; CHECK-LABEL: external module tbMemoryKind1_ext
-; CHECK-LABEL: external module dutMemory_ext
-; CHECK-LABEL: external module tbMemoryKind1_0_ext
+; CHECK-NOT: module tbMemoryKind1_ext
+; CHECK-NOT: module dutMemory_ext
+; CHECK-NOT: module tbMemoryKind1_0_ext
 
 
 ; CHECK-LABEL: FILE "metadata{{[/\]}}seq_mems.json"

--- a/test/firtool/split-verilog.mlir
+++ b/test/firtool/split-verilog.mlir
@@ -50,7 +50,6 @@ sv.verbatim "// Bar" {output_file = #hw.output_file<"custom2.sv", excludeFromFil
 // LIST:      {{^}}foo.sv{{$}}
 // LIST-NEXT: {{^}}bar.sv{{$}}
 // LIST-NEXT: {{^}}usb.sv{{$}}
-// LIST-NEXT: {{^}}extern_modules.sv{{$}}
 // LIST-NEXT: {{^}}inout_3.sv{{$}}
 // LIST-NEXT: {{^}}custom1.sv{{$}}
 // LIST-NOT:  custom2.sv
@@ -111,10 +110,10 @@ sv.verbatim "// Bar" {output_file = #hw.output_file<"custom2.sv", excludeFromFil
 // VERILOG:       endmodule
 // VERILOG-LABEL: interface usb;
 // VERILOG:       endinterface
-// VERILOG:       // external module pll
-// VERILOG:       // external module inout_0
-// VERILOG:       // external module inout_1
-// VERILOG:       // external module inout_2
+// VERILOG-NOT:   module pll
+// VERILOG-NOT:   module inout_0
+// VERILOG-NOT:   module inout_1
+// VERILOG-NOT:   module inout_2
 // VERILOG-LABEL: FILE "custom1.sv"
 // VERILOG:       // Foo
 // VERILOG-LABEL: FILE "custom2.sv"


### PR DESCRIPTION
Stop emitting external modules entirely in single file emission and drop the creation of "extern_modules.sv" in split file emission.  This is done because it creates problems/confusion for Verilog generation flows which are trying to hide the existence of some modules.  E.g., the existence of "extern_modules.sv" will leak what external modules were instantiated under a FIRRTL layerblock.

Alternatively, this could be revived by creating these files by respecting the output file attributes on external modules such that each significant directory got such a file.