### PR TITLE
[Arc] Implement memory initializers

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -330,7 +330,7 @@ def InitializeMemoryOp : ArcOp<"initialize_memory", [
   let arguments = (ins MemoryInitializerType:$initializer, MemoryType:$memory);
   let assemblyFormat = [{
    $initializer `->` $memory attr-dict
-    `:` type($initializer) `,` type($memory)
+    `:` qualified(type($initializer)) `,` qualified(type($memory))
   }];
 }
 

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -281,10 +281,47 @@ def CallOp : ArcOp<"call", [
   }];
 }
 
-def MemoryOp : ArcOp<"memory", [MemoryEffects<[MemAlloc]>]> {
+class MemoryInitializerIsCompatible<string mem, string init> : PredOpTrait<
+  "initializer type is compatible with memory type",
+  CPred< !strconcat("!$", init, " ||",
+           "(::llvm::cast<::circt::arc::MemoryInitializerType>($",
+           init, ".getType()).isCompatible(",
+           "::llvm::cast<::circt::arc::MemoryType>($",
+           mem, ".getType())))" )>
+>;
+
+def MemoryOp : ArcOp<"memory", [
+  MemoryEffects<[MemAlloc]>,
+  MemoryInitializerIsCompatible<"memory", "initializer">
+]> {
   let summary = "Memory";
+  let arguments = (ins Optional<MemoryInitializerType>:$initializer);
   let results = (outs MemoryType:$memory);
-  let assemblyFormat = "type($memory) attr-dict";
+  let assemblyFormat = [{
+    type($memory) attr-dict (`initial`  $initializer^ `:` type($initializer))?
+  }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$memType), [{
+      build($_builder, $_state, memType, {});
+    }]>];
+}
+
+def InitMemoryFilledOp : ArcOp<"init_memory_filled", [Pure]> {
+  let arguments = (ins APIntAttr:$value, UnitAttr:$repeat);
+  let results = (outs GenericMemoryInitializerType:$result);
+  let hasCustomAssemblyFormat = true;
+}
+
+def InitializeMemoryOp : ArcOp<"initialize_memory", [
+  MemoryEffects<[MemWrite]>,
+  MemoryInitializerIsCompatible<"memory", "initializer">
+]> {
+  let arguments = (ins MemoryInitializerType:$initializer, MemoryType:$memory);
+  let assemblyFormat = [{
+   $initializer `->` $memory attr-dict
+    `:` type($initializer) `,` type($memory)
+  }];
 }
 
 class MemoryAndDataTypesMatch<string mem, string data> : TypesMatchWith<

--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -281,18 +281,23 @@ def CallOp : ArcOp<"call", [
   }];
 }
 
-class MemoryInitializerIsCompatible<string mem, string init> : PredOpTrait<
+class OptionalMemoryInitializerIsCompatible
+<string predicate, string mem, string init> : PredOpTrait<
   "initializer type is compatible with memory type",
-  CPred< !strconcat("!$", init, " ||",
+  CPred< !strconcat("!(", predicate, ") ||",
            "(::llvm::cast<::circt::arc::MemoryInitializerType>($",
            init, ".getType()).isCompatible(",
            "::llvm::cast<::circt::arc::MemoryType>($",
            mem, ".getType())))" )>
 >;
 
+class MemoryInitializerIsCompatible<string mem, string init>
+  : OptionalMemoryInitializerIsCompatible <"true", mem, init>;
+
 def MemoryOp : ArcOp<"memory", [
   MemoryEffects<[MemAlloc]>,
-  MemoryInitializerIsCompatible<"memory", "initializer">
+  OptionalMemoryInitializerIsCompatible<
+    "$_op.getNumOperands() > 0", "memory", "initializer">
 ]> {
   let summary = "Memory";
   let arguments = (ins Optional<MemoryInitializerType>:$initializer);
@@ -307,10 +312,15 @@ def MemoryOp : ArcOp<"memory", [
     }]>];
 }
 
-def InitMemoryFilledOp : ArcOp<"init_memory_filled", [Pure]> {
+def InitMemoryFilledOp : ArcOp<"initmem.filled", [Pure]> {
   let arguments = (ins APIntAttr:$value, UnitAttr:$repeat);
   let results = (outs GenericMemoryInitializerType:$result);
   let hasCustomAssemblyFormat = true;
+}
+
+def InitMemoryRandomizedOp : ArcOp<"initmem.randomized", [Pure]> {
+  let results = (outs GenericMemoryInitializerType:$result);
+  let assemblyFormat = "attr-dict";
 }
 
 def InitializeMemoryOp : ArcOp<"initialize_memory", [
@@ -940,6 +950,76 @@ def VectorizeReturnOp : ArcOp<"vectorize.return", [
   let summary = "arc.vectorized terminator";
   let arguments = (ins AnyType:$value);
   let assemblyFormat = "operands attr-dict `:` qualified(type(operands))";
+}
+
+def EnvironmentCallOp : ArcOp<"environment_call", [
+    FunctionOpInterface, IsolatedFromAbove, HasParent<"mlir::ModuleOp">
+  ]> {
+
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    TypeAttrOf<FunctionType>:$function_type,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
+  );
+  let regions = (region AnyRegion:$body);
+
+  let extraClassDeclaration = [{
+
+    static constexpr ::llvm::StringLiteral fillRandomizedSymName =
+      "_arc_env_fill_randomized";
+
+    static ::mlir::FunctionType getFillRandomizedType(::mlir::MLIRContext *ctx);
+
+    //===------------------------------------------------------------------===//
+    // FunctionOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// Returns the argument types of this function.
+    ArrayRef<Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+
+    /// Returns the result types of this function.
+    ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
+
+    /// Returns the region on the function operation that is callable.
+    Region *getCallableRegion() {  return nullptr; }
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+}
+
+def CallEnvironmentOp : ArcOp<"call_environment", [
+  Pure,
+  CallOpInterface,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+
+  let arguments = (ins FlatSymbolRefAttr:$callee, Variadic<AnyType>:$operands);
+  let results = (outs Variadic<AnyType>);
+
+  let extraClassDeclaration = [{
+
+    operand_range getArgOperands() {
+      return getOperands();
+    }
+    MutableOperandRange getArgOperandsMutable() {
+      return getOperandsMutable();
+    }
+
+    mlir::CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<mlir::FlatSymbolRefAttr>("callee");
+    }
+
+    /// Set the callee for this operation.
+    void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
+      (*this)->setAttr(getCalleeAttrName(), callee.get<mlir::SymbolRefAttr>());
+    }
+  }];
+
+  let assemblyFormat = [{
+    $callee `(` $operands `)` attr-dict `:` functional-type($operands, results)
+  }];
+
 }
 
 #endif // CIRCT_DIALECT_ARC_ARCOPS_TD

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -194,6 +194,14 @@ def LowerLUT : Pass<"arc-lower-lut", "arc::DefineOp"> {
   let dependentDialects = ["hw::HWDialect", "comb::CombDialect"];
 }
 
+def LowerMemoryInitializers : Pass<"arc-lower-memory-initializers",
+                                   "mlir::ModuleOp"> {
+  let summary = "Converts InitializeMemory ops to state writes";
+  let dependentDialects = [
+    "hw::HWDialect", "arc::ArcDialect", "mlir::scf::SCFDialect"
+  ];
+}
+
 def LowerState : Pass<"arc-lower-state", "mlir::ModuleOp"> {
   let summary = "Split state into read and write ops grouped by clock tree";
   let constructor = "circt::arc::createLowerStatePass()";
@@ -219,7 +227,7 @@ def LowerVectorizations : Pass<"arc-lower-vectorizations", "mlir::ModuleOp"> {
     This pass lowers `arc.vectorize` operations. By default, the operation will
     be fully lowered (i.e., the op disappears in the IR). Alternatively, it can
     be partially lowered.
-    
+
     The "mode" pass option allows to only lower the boundary, only the body, or
     only inline the body given that both the boundary and the body are already
     lowered.

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -198,7 +198,7 @@ def LowerMemoryInitializers : Pass<"arc-lower-memory-initializers",
                                    "mlir::ModuleOp"> {
   let summary = "Converts InitializeMemory ops to state writes";
   let dependentDialects = [
-    "hw::HWDialect", "arc::ArcDialect", "mlir::scf::SCFDialect"
+    "arc::ArcDialect", "mlir::arith::ArithDialect", "mlir::scf::SCFDialect"
   ];
 }
 

--- a/include/circt/Dialect/Arc/ArcTypes.td
+++ b/include/circt/Dialect/Arc/ArcTypes.td
@@ -43,6 +43,37 @@ def MemoryType : ArcTypeDef<"Memory"> {
   }];
 }
 
+def MemoryInitializerType : ArcTypeDef<"MemoryInitializer"> {
+  let mnemonic = "memory_initializer";
+
+  let parameters = (ins OptionalParameter<"unsigned">:$numWords,
+                        OptionalParameter<"::mlir::IntegerType">:$wordType);
+
+  let hasCustomAssemblyFormat = true;
+
+  let extraClassDeclaration = [{
+    bool isCompatible(::circt::arc::MemoryType memType) const {
+      if (getNumWords() > 0 && getNumWords() != memType.getNumWords())
+        return false;
+      if (!!getWordType() && getWordType() != memType.getWordType())
+        return false;
+      return true;
+    }
+
+    bool isGeneric() const { return getNumWords() == 0 && !getWordType(); }
+
+  }];
+}
+
+def GenericMemoryInitializerType : DialectType<ArcDialect,
+  CPred<[{
+    ::llvm::isa<::circt::arc::MemoryInitializerType>($_self) &&
+    ::llvm::cast<::circt::arc::MemoryInitializerType>($_self).isGeneric()
+  }]>, "must be a generic memory initializer type">,
+  BuildableType<
+    "::circt::arc::MemoryInitializerType::get($_builder.getContext(), 0, {})"
+> {}
+
 def StorageType : ArcTypeDef<"Storage"> {
   let mnemonic = "storage";
   let parameters = (ins OptionalParameter<"unsigned">:$size);

--- a/integration_test/arcilator/JIT/initial-ram.mlir
+++ b/integration_test/arcilator/JIT/initial-ram.mlir
@@ -1,0 +1,155 @@
+// RUN: arcilator %s --run --jit-entry=main | FileCheck %s
+// REQUIRES: arcilator-jit
+
+// Lit testing random values is iffy, but the runtime environment should ensure
+// reproducible results across runs and platforms.
+
+// CHECK-LABEL: - addr = 21
+// CHECK-NEXT: rndA = 707ca895977cf11
+// CHECK-NEXT: rndB = 28e9cfdfcf6b898
+// CHECK-NEXT: fill = cafe
+// CHECK-NEXT: rept = 8000400020001
+// CHECK-NEXT: - addr = 0
+// CHECK-NEXT: rndA = 5160879eac03cbb
+// CHECK-NEXT: rndB = d78aeb0b84b4823
+// CHECK-NEXT: fill = cafe
+// CHECK-NEXT: rept = 8000400020001
+// CHECK-NEXT: - addr = 1ff
+// CHECK-NEXT: rndA = 198ecb046b4841d
+// CHECK-NEXT: rndB = 357020a9a09635b
+// CHECK-NEXT: fill = cafe
+// CHECK-NEXT: rept = 8000400020001
+// CHECK-NEXT: - addr = aa
+// CHECK-NEXT: rndA = 16b4a44c8c8ce64
+// CHECK-NEXT: rndB = 476fc6a9fd6fb83
+// CHECK-NEXT: fill = cafe
+// CHECK-NEXT: rept = 8000400020001
+
+module {
+  arc.define @mem_write(%arg0: i9, %arg1: i60, %arg2: i1) -> (i9, i60, i1) {
+    arc.output %arg0, %arg1, %arg2 : i9, i60, i1
+  }
+  hw.module @SyncRAM(
+     in %clk : i1, in %reset : i1, in %en : i1, in %addr : i9, in %din : i60, in %wen : i1,
+     out dout0 : i60, out dout1 : i60, out dout2 : i60, out dout3 : i60, out addrOut : i9) {
+    %clock = seq.to_clock %clk
+
+    %cst33_i9 = hw.constant 33 : i9
+
+    %randInit = arc.initmem.randomized
+    // Check that identical memories get different initial values
+    %mem0 = arc.memory <512 x i60, i9> initial %randInit : !arc.memory_initializer<* x *>
+    %mem3 = arc.memory <512 x i60, i9> initial %randInit : !arc.memory_initializer<* x *>
+
+    %fillInit = arc.initmem.filled 0xcafe : i16
+    %mem1 = arc.memory <512 x i60, i9> initial %fillInit : !arc.memory_initializer<* x *>
+
+    %repeatInit = arc.initmem.filled repeat 1 : i17
+    %mem2 = arc.memory <512 x i60, i9> initial %repeatInit : !arc.memory_initializer<* x *>
+
+
+
+    %addrReg = seq.compreg %0, %clock powerOn %cst33_i9 : i9
+    %0 = comb.mux bin %en, %addr, %addrReg : i9
+
+    %3 = seq.compreg %en, %clock : i1
+
+    %rd0 = arc.memory_read_port %mem0[%addrReg] : <512 x i60, i9>
+    %rd1 = arc.memory_read_port %mem1[%addrReg] : <512 x i60, i9>
+    %rd2 = arc.memory_read_port %mem2[%addrReg] : <512 x i60, i9>
+    %rd3 = arc.memory_read_port %mem3[%addrReg] : <512 x i60, i9>
+
+    %c0_i60 = hw.constant 0 : i60
+
+    arc.memory_write_port %mem0, @mem_write(%addrReg, %din, %wen) clock %clock enable latency 1 : <512 x i60, i9>, i9, i60, i1
+    arc.memory_write_port %mem1, @mem_write(%addrReg, %din, %wen) clock %clock enable latency 1 : <512 x i60, i9>, i9, i60, i1
+    arc.memory_write_port %mem2, @mem_write(%addrReg, %din, %wen) clock %clock enable latency 1 : <512 x i60, i9>, i9, i60, i1
+    arc.memory_write_port %mem3, @mem_write(%addrReg, %din, %wen) clock %clock enable latency 1 : <512 x i60, i9>, i9, i60, i1
+
+    hw.output %rd0, %rd1, %rd2, %rd3, %addrReg : i60, i60, i60, i60 , i9
+  }
+
+  func.func @main() {
+    %cst0 = arith.constant 0 : i9
+    %cst1ff = arith.constant 0x1FF : i9
+    %cstaa = arith.constant 0xAA : i9
+
+    %false = arith.constant 0 : i1
+    %true = arith.constant 1 : i1
+
+    arc.sim.instantiate @SyncRAM as %model {
+      %addr0  = arc.sim.get_port %model, "addrOut" : i9, !arc.sim.instance<@SyncRAM>
+      %res0_0 = arc.sim.get_port %model, "dout0" : i60, !arc.sim.instance<@SyncRAM>
+      %res1_0 = arc.sim.get_port %model, "dout1" : i60, !arc.sim.instance<@SyncRAM>
+      %res2_0 = arc.sim.get_port %model, "dout2" : i60, !arc.sim.instance<@SyncRAM>
+      %res3_0 = arc.sim.get_port %model, "dout3" : i60, !arc.sim.instance<@SyncRAM>
+      arc.sim.emit " - addr", %addr0 : i9
+      arc.sim.emit "rndA", %res0_0 : i60
+      arc.sim.emit "rndB", %res3_0 : i60
+      arc.sim.emit "fill", %res1_0 : i60
+      arc.sim.emit "rept", %res2_0 : i60
+
+      arc.sim.set_input %model, "en" = %true : i1, !arc.sim.instance<@SyncRAM>
+      arc.sim.set_input %model, "wen" = %false : i1, !arc.sim.instance<@SyncRAM>
+      arc.sim.set_input %model, "reset" = %false : i1, !arc.sim.instance<@SyncRAM>
+
+      arc.sim.set_input %model, "addr" = %cst0 : i9, !arc.sim.instance<@SyncRAM>
+
+      arc.sim.set_input %model, "clk" = %false : i1, !arc.sim.instance<@SyncRAM>
+      arc.sim.step %model : !arc.sim.instance<@SyncRAM>
+
+      arc.sim.set_input %model, "clk" = %true : i1, !arc.sim.instance<@SyncRAM>
+      arc.sim.step %model : !arc.sim.instance<@SyncRAM>
+      arc.sim.set_input %model, "clk" = %false : i1, !arc.sim.instance<@SyncRAM>
+      arc.sim.step %model : !arc.sim.instance<@SyncRAM>
+
+      %addr1  = arc.sim.get_port %model, "addrOut" : i9, !arc.sim.instance<@SyncRAM>
+      %res0_1 = arc.sim.get_port %model, "dout0" : i60, !arc.sim.instance<@SyncRAM>
+      %res1_1 = arc.sim.get_port %model, "dout1" : i60, !arc.sim.instance<@SyncRAM>
+      %res2_1 = arc.sim.get_port %model, "dout2" : i60, !arc.sim.instance<@SyncRAM>
+      %res3_1 = arc.sim.get_port %model, "dout3" : i60, !arc.sim.instance<@SyncRAM>
+      arc.sim.emit " - addr", %addr1 : i9
+      arc.sim.emit "rndA", %res0_1 : i60
+      arc.sim.emit "rndB", %res3_1 : i60
+      arc.sim.emit "fill", %res1_1 : i60
+      arc.sim.emit "rept", %res2_1 : i60
+
+      arc.sim.set_input %model, "addr" = %cst1ff : i9, !arc.sim.instance<@SyncRAM>
+
+      arc.sim.set_input %model, "clk" = %true : i1, !arc.sim.instance<@SyncRAM>
+      arc.sim.step %model : !arc.sim.instance<@SyncRAM>
+      arc.sim.set_input %model, "clk" = %false : i1, !arc.sim.instance<@SyncRAM>
+      arc.sim.step %model : !arc.sim.instance<@SyncRAM>
+
+      %addr2  = arc.sim.get_port %model, "addrOut" : i9, !arc.sim.instance<@SyncRAM>
+      %res0_2 = arc.sim.get_port %model, "dout0" : i60, !arc.sim.instance<@SyncRAM>
+      %res1_2 = arc.sim.get_port %model, "dout1" : i60, !arc.sim.instance<@SyncRAM>
+      %res2_2 = arc.sim.get_port %model, "dout2" : i60, !arc.sim.instance<@SyncRAM>
+      %res3_2 = arc.sim.get_port %model, "dout3" : i60, !arc.sim.instance<@SyncRAM>
+      arc.sim.emit " - addr", %addr2 : i9
+      arc.sim.emit "rndA", %res0_2 : i60
+      arc.sim.emit "rndB", %res3_2 : i60
+      arc.sim.emit "fill", %res1_2 : i60
+      arc.sim.emit "rept", %res2_2 : i60
+
+      arc.sim.set_input %model, "addr" = %cstaa : i9, !arc.sim.instance<@SyncRAM>
+
+      arc.sim.set_input %model, "clk" = %true : i1, !arc.sim.instance<@SyncRAM>
+      arc.sim.step %model : !arc.sim.instance<@SyncRAM>
+      arc.sim.set_input %model, "clk" = %false : i1, !arc.sim.instance<@SyncRAM>
+      arc.sim.step %model : !arc.sim.instance<@SyncRAM>
+
+      %addr3  = arc.sim.get_port %model, "addrOut" : i9, !arc.sim.instance<@SyncRAM>
+      %res0_3 = arc.sim.get_port %model, "dout0" : i60, !arc.sim.instance<@SyncRAM>
+      %res1_3 = arc.sim.get_port %model, "dout1" : i60, !arc.sim.instance<@SyncRAM>
+      %res2_3 = arc.sim.get_port %model, "dout2" : i60, !arc.sim.instance<@SyncRAM>
+      %res3_3 = arc.sim.get_port %model, "dout3" : i60, !arc.sim.instance<@SyncRAM>
+      arc.sim.emit " - addr", %addr3 : i9
+      arc.sim.emit "rndA", %res0_3 : i60
+      arc.sim.emit "rndB", %res3_3 : i60
+      arc.sim.emit "fill", %res1_3 : i60
+      arc.sim.emit "rept", %res2_3 : i60
+    }
+    return
+  }
+}

--- a/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
+++ b/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
@@ -25,8 +25,8 @@ using llvm::MapVector;
 
 static bool isArcBreakingOp(Operation *op) {
   return op->hasTrait<OpTrait::ConstantLike>() ||
-         isa<hw::InstanceOp, seq::CompRegOp, MemoryOp, ClockedOpInterface,
-             seq::ClockGateOp, sim::DPICallOp>(op) ||
+         isa<hw::InstanceOp, seq::CompRegOp, MemoryOp, InitMemoryFilledOp,
+             ClockedOpInterface, seq::ClockGateOp, sim::DPICallOp>(op) ||
          op->getNumResults() > 1;
 }
 

--- a/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
+++ b/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
@@ -26,7 +26,8 @@ using llvm::MapVector;
 static bool isArcBreakingOp(Operation *op) {
   return op->hasTrait<OpTrait::ConstantLike>() ||
          isa<hw::InstanceOp, seq::CompRegOp, MemoryOp, InitMemoryFilledOp,
-             ClockedOpInterface, seq::ClockGateOp, sim::DPICallOp>(op) ||
+             InitMemoryRandomizedOp, ClockedOpInterface, seq::ClockGateOp,
+             sim::DPICallOp>(op) ||
          op->getNumResults() > 1;
 }
 

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -634,6 +634,30 @@ LogicalResult SimStepOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return success();
 }
 
+void InitMemoryFilledOp::print(OpAsmPrinter &p) {
+  if (getRepeat())
+    p << " repeat";
+  p << " ";
+  p.printAttribute(getValueAttr());
+  p.printOptionalAttrDict((*this)->getAttrs(),
+                          /*elidedAttrs=*/{"value", "repeat"});
+}
+
+ParseResult InitMemoryFilledOp::parse(OpAsmParser &parser,
+                                      OperationState &result) {
+  IntegerAttr valueAttr;
+
+  if (!parser.parseOptionalKeyword("repeat"))
+    result.addAttribute("repeat", UnitAttr::get(parser.getContext()));
+
+  if (parser.parseAttribute(valueAttr, "value", result.attributes) ||
+      parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  result.addTypes(MemoryInitializerType::get(parser.getContext(), 0, {}));
+  return success();
+}
+
 #include "circt/Dialect/Arc/ArcInterfaces.cpp.inc"
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/Arc/ArcOps.cpp
+++ b/lib/Dialect/Arc/ArcOps.cpp
@@ -658,6 +658,58 @@ ParseResult InitMemoryFilledOp::parse(OpAsmParser &parser,
   return success();
 }
 
+ParseResult EnvironmentCallOp::parse(OpAsmParser &parser,
+                                     OperationState &result) {
+  auto buildFuncType =
+      [](Builder &builder, ArrayRef<Type> argTypes, ArrayRef<Type> results,
+         function_interface_impl::VariadicFlag,
+         std::string &) { return builder.getFunctionType(argTypes, results); };
+
+  return function_interface_impl::parseFunctionOp(
+      parser, result, /*allowVariadic=*/false,
+      getFunctionTypeAttrName(result.name), buildFuncType,
+      getArgAttrsAttrName(result.name), getResAttrsAttrName(result.name));
+}
+
+void EnvironmentCallOp::print(OpAsmPrinter &p) {
+  function_interface_impl::printFunctionOp(
+      p, *this, /*isVariadic=*/false, "function_type", getArgAttrsAttrName(),
+      getResAttrsAttrName());
+}
+
+FunctionType EnvironmentCallOp::getFillRandomizedType(MLIRContext *ctxt) {
+  auto i64Type = IntegerType::get(ctxt, 64);
+  auto i32Type = IntegerType::get(ctxt, 32);
+  auto storageType = StorageType::get(ctxt, 0);
+
+  std::array<Type, 4> args;
+  args[0] = storageType; // Memory reference
+  args[1] = i64Type;     // Num Words
+  args[2] = i32Type;     // Word bits
+  args[3] = i32Type;     // Stride
+
+  return FunctionType::get(ctxt, args, TypeRange{});
+}
+
+LogicalResult
+CallEnvironmentOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto referencedOp =
+      symbolTable.lookupNearestSymbolFrom(*this, getCalleeAttr());
+
+  if (!referencedOp)
+    return emitError("Cannot find declaration of environment call '")
+           << getCallee() << "'.";
+  auto envCallOp = dyn_cast<EnvironmentCallOp>(referencedOp);
+  if (!envCallOp) {
+    auto diag =
+        emitError("Referenced operation must be an 'arc.environment_call' op.");
+    diag.attachNote(referencedOp->getLoc()) << "Symbol declared here:";
+    return diag;
+  }
+  // TODO : Verify argument and return types
+  return success();
+}
+
 #include "circt/Dialect/Arc/ArcInterfaces.cpp.inc"
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -14,6 +14,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   LowerArcsToFuncs.cpp
   LowerClocksToFuncs.cpp
   LowerLUT.cpp
+  LowerMemoryInitializers.cpp
   LowerState.cpp
   LowerVectorizations.cpp
   MakeTables.cpp

--- a/lib/Dialect/Arc/Transforms/LowerMemoryInitializers.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerMemoryInitializers.cpp
@@ -1,0 +1,143 @@
+//===- LowerMemoryInitializers.cpp ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/HW/HWOps.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/TypeSwitch.h"
+
+#define DEBUG_TYPE "arc-lower-memory-initializers"
+
+namespace circt {
+namespace arc {
+#define GEN_PASS_DEF_LOWERMEMORYINITIALIZERS
+#include "circt/Dialect/Arc/ArcPasses.h.inc"
+} // namespace arc
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+
+namespace {
+struct LowerMemoryInitializersPass
+    : public arc::impl::LowerMemoryInitializersBase<
+          LowerMemoryInitializersPass> {
+  void runOnOperation() override;
+  LogicalResult processInitializerFunction(func::FuncOp funcOp);
+  LogicalResult lowerFilledInitialization(InitializeMemoryOp initOp,
+                                          InitMemoryFilledOp fillOp);
+
+  SymbolTable *symbolTable;
+};
+} // namespace
+
+LogicalResult LowerMemoryInitializersPass::lowerFilledInitialization(
+    InitializeMemoryOp initOp, InitMemoryFilledOp fillOp) {
+  auto loc =
+      FusedLoc::get(initOp.getContext(),
+                    std::array<Location, 2>{initOp.getLoc(), fillOp.getLoc()});
+  ImplicitLocOpBuilder builder(loc, initOp);
+
+  auto wordType = initOp.getMemory().getType().getWordType();
+  auto addrType = initOp.getMemory().getType().getAddressType();
+  auto indexType = builder.getIndexType();
+
+  auto destBits = wordType.getIntOrFloatBitWidth();
+  APInt constVal = fillOp.getValue().zextOrTrunc(destBits);
+
+  if (fillOp.getRepeat()) {
+    auto sourceBits = fillOp.getValueAttr().getType().getIntOrFloatBitWidth();
+    unsigned shiftWidth = sourceBits;
+    while (shiftWidth <= destBits) {
+      constVal |= constVal << shiftWidth;
+      shiftWidth *= 2;
+    }
+  }
+
+  auto fillValue = builder.create<arith::ConstantOp>(
+      builder.getIntegerAttr(wordType, constVal));
+  auto zero =
+      builder.create<arith::ConstantOp>(builder.getIntegerAttr(indexType, 0));
+  auto one =
+      builder.create<arith::ConstantOp>(builder.getIntegerAttr(indexType, 1));
+  auto limit = builder.create<arith::ConstantOp>(builder.getIntegerAttr(
+      indexType, initOp.getMemory().getType().getNumWords()));
+  auto forOp = builder.create<scf::ForOp>(zero, limit, one);
+  builder.setInsertionPointToStart(forOp.getBody());
+  auto addr = builder.createOrFold<arith::IndexCastUIOp>(
+      addrType, forOp.getInductionVar());
+  builder.create<MemoryWriteOp>(initOp.getMemory(), addr, /*enable*/ Value{},
+                                fillValue);
+
+  return success();
+}
+
+LogicalResult
+LowerMemoryInitializersPass::processInitializerFunction(func::FuncOp funcOp) {
+  SmallVector<InitializeMemoryOp> initOps;
+  SmallPtrSet<Operation *, 4> cleanupSet;
+
+  funcOp.walk(
+      [&](InitializeMemoryOp initMemOp) { initOps.push_back(initMemOp); });
+
+  bool hasFailed = false;
+
+  for (auto initOp : initOps) {
+    auto defOp = initOp.getInitializer().getDefiningOp();
+    if (!defOp) {
+      initOp.emitError("Cannot lower initializer passed as argument.");
+      return failure();
+    }
+
+    cleanupSet.insert(defOp);
+
+    TypeSwitch<Operation *>(defOp)
+        .Case<InitMemoryFilledOp>([&](auto op) {
+          hasFailed |= failed(lowerFilledInitialization(initOp, op));
+        })
+        .Default([&](auto) {
+          defOp->emitOpError("is not a supported memory intitializer.");
+          hasFailed = true;
+        });
+  }
+
+  if (hasFailed)
+    return failure();
+
+  for (auto initOp : initOps)
+    initOp->erase();
+  for (auto cleanupOp : cleanupSet)
+    if (cleanupOp->getResult(0).getUses().empty())
+      cleanupOp->erase();
+
+  return success();
+}
+
+void LowerMemoryInitializersPass::runOnOperation() {
+  symbolTable = nullptr;
+  auto theModule = getOperation();
+  for (auto modelOp : theModule.getOps<arc::ModelOp>()) {
+    if (auto intitFnAttr = modelOp.getInitialFnAttr()) {
+      if (!symbolTable)
+        symbolTable = &getAnalysis<SymbolTable>();
+      auto initFn = llvm::dyn_cast_or_null<func::FuncOp>(
+          symbolTable->lookupSymbolIn(theModule, intitFnAttr));
+      assert(!!initFn && "Failed to look-up initializer function.");
+      if (failed(processInitializerFunction(initFn))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+}

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -176,7 +176,7 @@ static bool canBeMaterializedInInitializer(Operation *op) {
     return true;
   if (isa<comb::CombDialect>(op->getDialect()))
     return true;
-  if (isa<InitMemoryFilledOp>(op))
+  if (isa<InitMemoryFilledOp, InitMemoryRandomizedOp>(op))
     return true;
   // TODO: There are some other ops we probably want to allow
   return false;

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -356,6 +356,7 @@ static void populateArcToLLVMPipeline(PassManager &pm) {
   if (untilReached(UntilLLVMLowering))
     return;
   pm.addPass(createConvertCombToArithPass());
+  pm.addPass(arc::createLowerMemoryInitializers());
   pm.addPass(createLowerArcToLLVMPass());
   pm.addPass(createCSEPass());
   pm.addPass(arc::createArcCanonicalizerPass());


### PR DESCRIPTION
Following #7480, This PR adds support for initialization of arcilator memories.  The code still needs tidying and testing. But, as always, I appreciate early feedback on the overall approach.

Specifically, it adds the `arc.initmem.filled` and `arc.initmem.randomized` operations, enabling initialization with a constant value and runtime generated random values respectively. Both ops produce a SSA value of the newly added `!arc.memory_initializer<* x *>` type, indicating that they can be used to initialize memories irrespective of size and word type. Sadly, there is currently no front or middle end equivalent of these operations, so for the moment they mostly serve as a template showing how initialization can be handled with and without help from the runtime environment.

The `memory_initializer` value is passed as an optional argument to the `arc.memory` op. During `LowerState` it gets moved to the 'initital' pseudo clock-tree and a `arc.initialize_memory` op is inserted to associate the initializer with the memory's state. Finally, the newly added `LowerMemoryInitializers` pass converts the initializers to the low level state writes, which, depending on the initializer, may involve invoking the runtime environment with a reference to the storage. This utilizes the also newly added `arc.call_environment` caller and `arc.environment_call` callee op pair. Right now they don't do anything special, but I think it makes sense to separate calls to the runtime environment from generic function calls.

Speaking of the runtime environment: As discussed in #7445, the increasing complexity makes implementing it as effectively a header library impractical. I'm still working on restructuring it and it probably doesn't make much sense to land this PR here before that has been done (the new call ops also don't really belong in this PR). In the end, this should allow us to add an initializer op for `.mem` files, with the static reading and parsing logic stashed away in the runtime library. 