### PR TITLE
[SV] Fix regop canonicalizer crashing.

### DIFF
--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -303,13 +303,13 @@ LogicalResult RegOp::canonicalize(RegOp op, PatternRewriter &rewriter) {
     return failure();
   // Check that all operations on the wire are sv.assigns. All other wire
   // operations will have been handled by other canonicalization.
-  for (auto &use : op.getResult().getUses())
-    if (!isa<AssignOp>(use.getOwner()))
+  for (auto *user : op.getResult().getUsers())
+    if (!isa<AssignOp>(user))
       return failure();
 
   // Remove all uses of the wire.
-  for (auto &use : op.getResult().getUses())
-    rewriter.eraseOp(use.getOwner());
+  for (auto *user : llvm::make_early_inc_range(op.getResult().getUsers()))
+    rewriter.eraseOp(user);
 
   // Remove the wire.
   rewriter.eraseOp(op);

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -321,3 +321,11 @@ hw.module @Sampled(in %in: i1) {
   %2 = sv.system.sampled %in : i1
   hw.output
 }
+
+// CHECK-LABEL: @Issue7563
+// CHECK-NEXT: hw.output
+hw.module @Issue7563(in %in: i8) {
+  %r = sv.reg : !hw.inout<i8>
+  sv.assign %r, %in : i8
+  hw.output
+}


### PR DESCRIPTION
Fixes #7563 .

Should drop a regression test in an appropriate place.