### PR TITLE
[Moore][NFC] Fix warning when building Moore components

### DIFF
--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -518,18 +518,19 @@ LogicalResult AssignedVariableOp::canonicalize(AssignedVariableOp op,
 
   // Eliminate variables that feed an output port of the same name.
   for (auto &use : op->getUses()) {
-    auto outputOp = dyn_cast<OutputOp>(use.getOwner());
-    if (!outputOp)
+    auto *useOwner = use.getOwner();
+    if (auto outputOp = dyn_cast<OutputOp>(useOwner)) {
+      if (auto moduleOp = dyn_cast<SVModuleOp>(outputOp->getParentOp())) {
+        auto moduleType = moduleOp.getModuleType();
+        auto portName = moduleType.getOutputNameAttr(use.getOperandNumber());
+        if (portName == op.getNameAttr()) {
+          rewriter.replaceOp(op, op.getInput());
+          return success();
+        }
+      } else
+        break;
+    } else
       continue;
-    auto moduleOp = dyn_cast<SVModuleOp>(outputOp.getParentOp());
-    if (!moduleOp)
-      break;
-    auto moduleType = moduleOp.getModuleType();
-    auto portName = moduleType.getOutputNameAttr(use.getOperandNumber());
-    if (portName == op.getNameAttr()) {
-      rewriter.replaceOp(op, op.getInput());
-      return success();
-    }
   }
 
   return failure();

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -529,8 +529,7 @@ LogicalResult AssignedVariableOp::canonicalize(AssignedVariableOp op,
         }
       } else
         break;
-    } else
-      continue;
+    }
   }
 
   return failure();


### PR DESCRIPTION
The original building warning:
```bash
[814/1036] Building CXX object lib/Dialect/Moore/CMakeFiles/obj.CIRCTMoore.dir/MooreOps.cpp.o
In file included from /home/ursa/Projects/circt/lib/Dialect/Moore/MooreOps.cpp:13:
In file included from /home/ursa/Projects/circt/include/circt/Dialect/Moore/MooreOps.h:16:
In file included from /home/ursa/Projects/circt/include/circt/Dialect/HW/HWTypes.h:17:
In file included from /home/ursa/Projects/circt/include/circt/Dialect/HW/HWDialect.h:16:
In file included from /home/ursa/Projects/circt/include/circt/Support/LLVM.h:22:
In file included from /home/ursa/Projects/circt/llvm/mlir/include/mlir/Support/LLVM.h:23:
/home/ursa/Projects/circt/llvm/llvm/include/llvm/Support/Casting.h:490:69: warning: returning reference to local temporary object [-Wreturn-stack-address]
  490 |   static inline CastReturnType castFailed() { return CastReturnType(nullptr); }
      |                                                                     ^~~~~~~
/home/ursa/Projects/circt/llvm/llvm/include/llvm/Support/Casting.h:494:14: note: in instantiation of member function 'llvm::CastInfo<circt::moore::SVModuleOp, const circt::moore::SVModuleOp>::castFailed' requested here
  494 |       return castFailed();
      |              ^
/home/ursa/Projects/circt/llvm/llvm/include/llvm/Support/Casting.h:651:36: note: in instantiation of member function 'llvm::CastInfo<circt::moore::SVModuleOp, const circt::moore::SVModuleOp>::doCastIfPossible' requested here
  651 |   return CastInfo<To, const From>::doCastIfPossible(Val);
      |                                    ^
1 warning generated.

```
The main problem is handling the result coming from the cast function. To check if the pointer pointing to a module op is a nullptr. This commit rewrites the appropriate code to fix the warning.