### PR TITLE
[ESI][Runtime] Pretty printing of service ports

### DIFF
--- a/integration_test/Dialect/ESI/runtime/loopback.mlir
+++ b/integration_test/Dialect/ESI/runtime/loopback.mlir
@@ -145,15 +145,9 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // QUERY-HIER:     internal_write:
 // QUERY-HIER:       ack: !esi.channel<i0>
 // QUERY-HIER:       req: !esi.channel<!hw.struct<address: i5, data: i64>>
-// QUERY-HIER:     func1:
-// QUERY-HIER:       arg: !esi.channel<i16>
-// QUERY-HIER:       result: !esi.channel<i16>
-// QUERY-HIER:     structFunc:
-// QUERY-HIER:       arg: !esi.channel<!hw.struct<a: ui16, b: si8>>
-// QUERY-HIER:       result: !esi.channel<!hw.struct<x: si8, y: si8>>
-// QUERY-HIER:     arrayFunc:
-// QUERY-HIER:       arg: !esi.channel<!hw.array<1xsi8>>
-// QUERY-HIER:       result: !esi.channel<!hw.array<2xsi8>>
+// QUERY-HIER:     func1: function i16(i16)
+// QUERY-HIER:     structFunc: function !hw.struct<x: si8, y: si8>(!hw.struct<a: ui16, b: si8>)
+// QUERY-HIER:     arrayFunc: function !hw.array<2xsi8>(!hw.array<1xsi8>)
 // QUERY-HIER: * Children:
 // QUERY-HIER:   * Instance:loopback_inst[0]
 // QUERY-HIER:   * Ports:

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
@@ -35,6 +35,8 @@ class ServicePort : public BundlePort {
 public:
   using BundlePort::BundlePort;
   virtual ~ServicePort() = default;
+  // Get a description of the service port.
+  virtual std::optional<std::string> toString() const { return std::nullopt; }
 };
 
 /// Parent class of all APIs modeled as 'services'. May or may not map to a
@@ -173,6 +175,14 @@ public:
 
     void connect();
     std::future<MessageData> call(const MessageData &arg);
+
+    virtual std::optional<std::string> toString() const override {
+      const esi::Type *argType =
+          dynamic_cast<const ChannelType *>(arg.getType())->getInner();
+      const esi::Type *resultType =
+          dynamic_cast<const ChannelType *>(result.getType())->getInner();
+      return "function " + resultType->getID() + "(" + argType->getID() + ")";
+    }
 
   private:
     std::mutex callMutex;

--- a/lib/Dialect/ESI/runtime/cpp/tools/esiquery.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esiquery.cpp
@@ -92,11 +92,16 @@ void printInfo(std::ostream &os, AcceleratorConnection &acc) {
 
 void printPort(std::ostream &os, const BundlePort &port,
                std::string indent = "") {
-  os << indent << "  " << port.getID() << ":" << std::endl;
-  for (const auto &[name, chan] : port.getChannels()) {
+  os << indent << "  " << port.getID() << ":";
+  if (auto svcPort = dynamic_cast<const services::ServicePort *>(&port))
+    if (auto svcPortStr = svcPort->toString()) {
+      os << " " << *svcPortStr << std::endl;
+      return;
+    }
+  os << std::endl;
+  for (const auto &[name, chan] : port.getChannels())
     os << indent << "    " << name << ": " << chan.getType()->getID()
        << std::endl;
-  }
 }
 
 void printInstance(std::ostream &os, const HWModule *d,


### PR DESCRIPTION
esiquery now displays the function signatures instead of the consistuent channels. More representative of the API which is exposed.