### PR TITLE
[ESI][Runtime] Logging API

### DIFF
--- a/frontends/PyCDE/integration_test/esitester.py
+++ b/frontends/PyCDE/integration_test/esitester.py
@@ -29,6 +29,8 @@ from pycde.types import Bits, Channel, UInt
 
 import sys
 
+# CHECK: [INFO] [CONNECT] connecting to backend
+
 
 class PrintfExample(Module):
   """Call a printf function on the host once at startup."""
@@ -38,6 +40,8 @@ class PrintfExample(Module):
 
   @generator
   def construct(ports):
+    # CHECK: [DEBUG] [ESITESTER] Received PrintfExample message
+    # CHECK:                     data: 7000
     # CHECK: PrintfExample: 7
     arg_data = UInt(32)(7)
 

--- a/frontends/PyCDE/integration_test/test_software/esi_test.py
+++ b/frontends/PyCDE/integration_test/test_software/esi_test.py
@@ -4,6 +4,8 @@ from esiaccel.types import MMIORegion
 import sys
 import time
 
+esi.accelerator.ctxt.set_stdio_logger(esi.accelerator.cpp.LogLevel.Debug)
+
 platform = sys.argv[1]
 acc = esi.AcceleratorConnection(platform, sys.argv[2])
 

--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -100,6 +100,7 @@ set(ESICppRuntimeSources
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Context.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Common.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Design.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Logging.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Manifest.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Services.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Ports.cpp

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
@@ -80,6 +80,7 @@ public:
   AcceleratorConnection(Context &ctxt);
   virtual ~AcceleratorConnection();
   Context &getCtxt() const { return ctxt; }
+  Logger &getLogger() const { return ctxt.getLogger(); }
 
   /// Disconnect from the accelerator cleanly.
   virtual void disconnect();

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Common.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Common.h
@@ -119,6 +119,9 @@ public:
     return MessageData(reinterpret_cast<const uint8_t *>(&t), sizeof(T));
   }
 
+  /// Convert the data to a hex string.
+  std::string toHex() const;
+
 private:
   std::vector<uint8_t> data;
 };

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Context.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Context.h
@@ -16,6 +16,7 @@
 #ifndef ESI_CONTEXT_H
 #define ESI_CONTEXT_H
 
+#include "esi/Logging.h"
 #include "esi/Types.h"
 
 #include <exception>
@@ -28,8 +29,16 @@ class AcceleratorConnection;
 /// AcceleratorConnections, Accelerators, and Manifests must all share a
 /// context. It owns all the types, uniquifying them.
 class Context {
-
 public:
+  Context() : logger(std::make_unique<NullLogger>()) {}
+  Context(std::unique_ptr<Logger> logger) : logger(std::move(logger)) {}
+
+  /// Create a context with a specific logger type.
+  template <typename T, typename... Args>
+  static Context withLogger(Args &&...args) {
+    return Context(std::make_unique<T>(args...));
+  }
+
   /// Resolve a type id to the type.
   std::optional<const Type *> getType(Type::ID id) const {
     if (auto f = types.find(id); f != types.end())
@@ -43,6 +52,17 @@ public:
   /// Connect to an accelerator backend.
   std::unique_ptr<AcceleratorConnection> connect(std::string backend,
                                                  std::string connection);
+
+  /// Register a logger with the accelerator. Assumes ownership of the logger.
+  void setLogger(std::unique_ptr<Logger> logger) {
+    if (!logger)
+      throw std::invalid_argument("logger must not be null");
+    this->logger = std::move(logger);
+  }
+  inline Logger &getLogger() { return *logger; }
+
+private:
+  std::unique_ptr<Logger> logger;
 
 private:
   using TypeCache = std::map<Type::ID, std::unique_ptr<Type>>;

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Logging.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Logging.h
@@ -1,0 +1,160 @@
+//===- Logging.h - ESI Runtime logging --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// ESI runtime logging is very simple but very flexible. Rather than mandating a
+// particular logging library, it allows users to hook into their existing
+// logging system by implementing a simple interface.
+//
+//===----------------------------------------------------------------------===//
+//
+// DO NOT EDIT!
+// This file is distributed as part of an ESI package. The source for this file
+// should always be modified within CIRCT.
+//
+//===----------------------------------------------------------------------===//
+
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef ESI_LOGGING_H
+#define ESI_LOGGING_H
+
+#include <any>
+#include <functional>
+#include <iosfwd>
+#include <map>
+#include <memory>
+#include <string>
+
+namespace esi {
+
+class Logger {
+public:
+  enum class Level {
+    Error,   // Many errors will be followed by exceptions which may get caught.
+    Warning, // May indicate a problem.
+    Info,    // General information, like connecting to an accelerator.
+    Debug,   // Everything and the kitchen sink, possibly including _all_
+             // messages written and read.
+  };
+  Logger(bool debugEnabled) : debugEnabled(debugEnabled) {}
+  virtual ~Logger() = default;
+  bool getDebugEnabled() { return debugEnabled; }
+
+  /// Report a log message.
+  /// Arguments:
+  ///   level: The log level as defined by the 'Level' enum above.
+  ///   subsystem: The subsystem that generated the log message.
+  ///   msg: The log message.
+  ///   details: Optional additional structured details to include in the log
+  ///            message. If there are no details, this should be nullptr.
+  virtual void
+  log(Level level, const std::string &subsystem, const std::string &msg,
+      const std::map<std::string, std::any> *details = nullptr) = 0;
+
+  /// Report an error.
+  virtual void error(const std::string &subsystem, const std::string &msg,
+                     const std::map<std::string, std::any> *details = nullptr) {
+    log(Level::Error, subsystem, msg, details);
+  }
+  /// Report a warning.
+  virtual void
+  warning(const std::string &subsystem, const std::string &msg,
+          const std::map<std::string, std::any> *details = nullptr) {
+    log(Level::Warning, subsystem, msg, details);
+  }
+  /// Report an informational message.
+  virtual void info(const std::string &subsystem, const std::string &msg,
+                    const std::map<std::string, std::any> *details = nullptr) {
+    log(Level::Info, subsystem, msg, details);
+  }
+
+  /// Report a debug message. This is not virtual so that it can be inlined to
+  /// minimize performance impact that debug messages have, allowing debug
+  /// messages in Release builds.
+  inline void debug(const std::string &subsystem, const std::string &msg,
+                    const std::map<std::string, std::any> *details = nullptr) {
+    if (debugEnabled)
+      debugImpl(subsystem, msg, details);
+  }
+  /// Call the debug function callback only if debug is enabled then log a debug
+  /// message. Allows users to run heavy weight debug message generation code
+  /// only when debug is enabled, which in turns allows users to provide
+  /// fully-featured debug messages in Release builds with minimal performance
+  /// impact. Not virtual so that it can be inlined.
+  inline void
+  debug(std::function<
+        void(std::string &subsystem, std::string &msg,
+             std::unique_ptr<std::map<std::string, std::any>> &details)>
+            debugFunc) {
+    if (debugEnabled)
+      debugImpl(debugFunc);
+  }
+
+protected:
+  /// Overrideable version of debug. Only gets called if debug is enabled.
+  virtual void debugImpl(const std::string &subsystem, const std::string &msg,
+                         const std::map<std::string, std::any> *details) {
+    log(Level::Debug, subsystem, msg, details);
+  }
+  /// Overrideable version of debug. Only gets called if debug is enabled.
+  virtual void
+  debugImpl(std::function<
+            void(std::string &subsystem, std::string &msg,
+                 std::unique_ptr<std::map<std::string, std::any>> &details)>
+                debugFunc) {
+    if (!debugEnabled)
+      return;
+    std::string subsystem;
+    std::string msg;
+    std::unique_ptr<std::map<std::string, std::any>> details = nullptr;
+    debugFunc(subsystem, msg, details);
+    debugImpl(subsystem, msg, details.get());
+  }
+
+  /// Enable or disable debug messages.
+  bool debugEnabled = false;
+};
+
+/// A logger that writes to a C++ std::ostream.
+class StreamLogger : public Logger {
+public:
+  /// Create a stream logger that logs to the given output stream and error
+  /// output stream.
+  StreamLogger(Level minLevel, std::ostream &out, std::ostream &error)
+      : Logger(minLevel == Level::Debug), minLevel(minLevel), outStream(out),
+        errorStream(error) {}
+  /// Create a stream logger that logs to stdout, stderr.
+  StreamLogger(Level minLevel);
+  void log(Level level, const std::string &subsystem, const std::string &msg,
+           const std::map<std::string, std::any> *details) override;
+
+private:
+  /// The minimum log level to emit.
+  Level minLevel;
+
+  /// Mutex to protect the stream from interleaved logging writes.
+  std::mutex mutex;
+  /// Everything except errors goes here.
+  std::ostream &outStream;
+  /// Just for errors.
+  std::ostream &errorStream;
+};
+
+/// A logger that does nothing.
+class NullLogger : public Logger {
+public:
+  NullLogger() : Logger(false) {}
+  void log(Level, const std::string &, const std::string &,
+           const std::map<std::string, std::any> *) override {}
+};
+
+/// 'Stringify' a std::any. This is used to log std::any values by some loggers.
+std::string toString(const std::any &a);
+
+} // namespace esi
+
+#endif // ESI_LOGGING_H

--- a/lib/Dialect/ESI/runtime/cpp/lib/Common.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Common.cpp
@@ -17,6 +17,23 @@
 #include <iostream>
 #include <sstream>
 
+using namespace esi;
+
+std::string MessageData::toHex() const {
+  std::ostringstream ss;
+  ss << std::hex;
+  for (size_t i = 0, e = data.size(); i != e; ++i) {
+    // Add spaces every 8 bytes.
+    if (i % 8 == 0 && i != 0)
+      ss << ' ';
+    // Add an extra space every 64 bytes.
+    if (i % 64 == 0 && i != 0)
+      ss << ' ';
+    ss << static_cast<unsigned>(data[i]);
+  }
+  return ss.str();
+}
+
 std::string esi::toHex(uint32_t val) {
   std::ostringstream ss;
   ss << std::hex << val;

--- a/lib/Dialect/ESI/runtime/cpp/lib/Logging.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Logging.cpp
@@ -20,22 +20,20 @@
 
 using namespace esi;
 
-// Necessary in some versions of the c++ standard library to avoid warnings
-// about scoped_lock deduction guides.
-struct allow_ctad_t;
-namespace std {
-scoped_lock(allow_ctad_t) -> scoped_lock<void>;
-lock_guard(allow_ctad_t) -> lock_guard<void>;
-} // namespace std
+void TSLogger::log(Level level, const std::string &subsystem,
+                   const std::string &msg,
+                   const std::map<std::string, std::any> *details) {
+  std::scoped_lock<std::mutex> lock(mutex);
+  logImpl(level, subsystem, msg, details);
+}
 
 StreamLogger::StreamLogger(Level minLevel)
-    : Logger(minLevel == Level::Debug), minLevel(minLevel),
+    : TSLogger(minLevel == Level::Debug), minLevel(minLevel),
       outStream(std::cout), errorStream(std::cerr) {}
 
-void StreamLogger::log(Level level, const std::string &subsystem,
-                       const std::string &msg,
-                       const std::map<std::string, std::any> *details) {
-  std::scoped_lock lock(mutex);
+void StreamLogger::logImpl(Level level, const std::string &subsystem,
+                           const std::string &msg,
+                           const std::map<std::string, std::any> *details) {
   std::ostream &os = level == Level::Error ? errorStream : outStream;
   unsigned indentSpaces = 0;
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/Logging.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Logging.cpp
@@ -1,0 +1,98 @@
+//===- Logging.cpp - ESI logging system API implementation ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// DO NOT EDIT!
+// This file is distributed as part of an ESI package. The source for this file
+// should always be modified within CIRCT (lib/dialect/ESI/runtime/cpp/).
+//
+//===----------------------------------------------------------------------===//
+
+#include "esi/Logging.h"
+#include "esi/Common.h"
+
+#include <iostream>
+#include <mutex>
+
+using namespace esi;
+
+// Necessary in some versions of the c++ standard library to avoid warnings
+// about scoped_lock deduction guides.
+struct allow_ctad_t;
+namespace std {
+scoped_lock(allow_ctad_t) -> scoped_lock<void>;
+lock_guard(allow_ctad_t) -> lock_guard<void>;
+} // namespace std
+
+StreamLogger::StreamLogger(Level minLevel)
+    : Logger(minLevel == Level::Debug), minLevel(minLevel),
+      outStream(std::cout), errorStream(std::cerr) {}
+
+void StreamLogger::log(Level level, const std::string &subsystem,
+                       const std::string &msg,
+                       const std::map<std::string, std::any> *details) {
+  std::scoped_lock lock(mutex);
+  std::ostream &os = level == Level::Error ? errorStream : outStream;
+  unsigned indentSpaces = 0;
+
+  switch (level) {
+  case Level::Error:
+    os << "[ERROR] ";
+    indentSpaces = 8;
+    break;
+  case Level::Warning:
+    os << "[WARNING] ";
+    indentSpaces = 10;
+    break;
+  case Level::Info:
+    os << "[INFO] ";
+    indentSpaces = 7;
+    break;
+  case Level::Debug:
+    os << "[DEBUG] ";
+    indentSpaces = 8;
+    break;
+  }
+
+  if (!subsystem.empty()) {
+    os << "[" << subsystem << "] ";
+    indentSpaces += subsystem.size() + 3;
+  }
+  os << msg << std::endl;
+
+  if (!details)
+    return;
+  std::string indent(indentSpaces, ' ');
+  for (const auto &detail : *details)
+    os << indent << detail.first << ": " << toString(detail.second) << "\n";
+}
+
+std::string esi::toString(const std::any &value) {
+  if (value.type() == typeid(std::string))
+    return std::any_cast<std::string>(value);
+  if (value.type() == typeid(int))
+    return std::to_string(std::any_cast<int>(value));
+  if (value.type() == typeid(long))
+    return std::to_string(std::any_cast<long>(value));
+  if (value.type() == typeid(unsigned))
+    return std::to_string(std::any_cast<unsigned>(value));
+  if (value.type() == typeid(unsigned long))
+    return std::to_string(std::any_cast<unsigned long>(value));
+  if (value.type() == typeid(bool))
+    return std::any_cast<bool>(value) ? "true" : "false";
+  if (value.type() == typeid(double))
+    return std::to_string(std::any_cast<double>(value));
+  if (value.type() == typeid(float))
+    return std::to_string(std::any_cast<float>(value));
+  if (value.type() == typeid(const char *))
+    return std::string(std::any_cast<const char *>(value));
+  if (value.type() == typeid(char))
+    return std::string(1, std::any_cast<char>(value));
+  if (value.type() == typeid(MessageData))
+    return std::any_cast<MessageData>(value).toHex();
+  return "<unknown>";
+}

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
@@ -180,6 +180,14 @@ PYBIND11_MODULE(esiCppAccel, m) {
         return os.str();
       });
 
+  py::enum_<Logger::Level>(m, "LogLevel")
+      .value("Debug", Logger::Level::Debug)
+      .value("Info", Logger::Level::Info)
+      .value("Warning", Logger::Level::Warning)
+      .value("Error", Logger::Level::Error)
+      .export_values();
+  py::class_<Logger>(m, "Logger");
+
   py::class_<services::Service>(m, "Service");
 
   py::class_<SysInfo, services::Service>(m, "SysInfo")
@@ -339,7 +347,10 @@ PYBIND11_MODULE(esiCppAccel, m) {
 
   py::class_<Context>(m, "Context")
       .def(py::init<>())
-      .def("connect", &Context::connect);
+      .def("connect", &Context::connect)
+      .def("set_stdio_logger", [](Context &ctxt, Logger::Level level) {
+        ctxt.setLogger(std::make_unique<StreamLogger>(level));
+      });
 
   accConn.def(py::init(&registry::connect))
       .def(


### PR DESCRIPTION
The ESI logging API is intended to be agnostic of the application's logging framework. In other words, it can be adapted to the application's logging method with ease -- users must only extend one class. It also comes with a simple text logger.

It is also designed to enable debug logging in Release builds with (very) minimal performance overhead if the user does not set the log level to debug.

This PR introduces the API, but doesn't use it much. More plumbing will be required to actually use it. In the interest of keeping this PR small, this is left for future work.