### PR TITLE
Bump LLVM

### DIFF
--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -85,7 +85,7 @@ with Context() as ctx, Location.unknown():
   # CHECK-LABEL: === Verilog ===
   print("=== Verilog ===")
 
-  pm = PassManager.parse("builtin.module(lower-seq-to-sv)")
+  pm = PassManager.parse("builtin.module(lower-seq-to-sv,canonicalize)")
   pm.run(m.operation)
   # CHECK: always_ff @(posedge clk)
   # CHECK: my_reg <= {{.+}}


### PR DESCRIPTION
Currently fails because of https://github.com/llvm/llvm-project/pull/106778
@mikeurbach previously pointed out the issue in https://github.com/llvm/llvm-project/pull/101514 which wasn't reverted, thus exposing the issue again.