### PR TITLE
[FIRRTL][FIRParser] Check force source more.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3697,16 +3697,24 @@ ParseResult FIRStmtParser::parseRefForce() {
     return emitError(startTok.getLoc(),
                      "expected base-type for force source, got ")
            << src.getType();
+  if (!srcBaseType.isPassive())
+    return emitError(startTok.getLoc(),
+                     "expected passive value for force source, got ")
+           << srcBaseType;
 
   locationProcessor.setLoc(startTok.getLoc());
 
-  // Cast ref to accomodate uninferred sources.
+  // Cast ref to accommodate uninferred sources.
   auto noConstSrcType = srcBaseType.getAllConstDroppedType();
   if (noConstSrcType != ref.getType()) {
     // Try to cast destination to rwprobe of source type (dropping const).
-    auto compatibleRWProbe = RefType::get(noConstSrcType, true);
+    auto compatibleRWProbe = RefType::get(noConstSrcType, true, ref.getLayer());
     if (areTypesRefCastable(compatibleRWProbe, ref))
       dest = builder.create<RefCastOp>(compatibleRWProbe, dest);
+    else
+      return emitError(startTok.getLoc(), "incompatible force source of type ")
+             << src.getType() << " cannot target destination "
+             << dest.getType();
   }
 
   builder.create<RefForceOp>(clock, pred, dest, src);
@@ -3739,16 +3747,25 @@ ParseResult FIRStmtParser::parseRefForceInitial() {
                      "expected base-type expression for force_initial "
                      "source, got ")
            << src.getType();
+  if (!srcBaseType.isPassive())
+    return emitError(startTok.getLoc(),
+                     "expected passive value for force_initial source, got ")
+           << srcBaseType;
 
   locationProcessor.setLoc(startTok.getLoc());
 
-  // Cast ref to accomodate uninferred sources.
+  // Cast ref to accommodate uninferred sources.
   auto noConstSrcType = srcBaseType.getAllConstDroppedType();
   if (noConstSrcType != ref.getType()) {
     // Try to cast destination to rwprobe of source type (dropping const).
-    auto compatibleRWProbe = RefType::get(noConstSrcType, true);
+    auto compatibleRWProbe = RefType::get(noConstSrcType, true, ref.getLayer());
     if (areTypesRefCastable(compatibleRWProbe, ref))
       dest = builder.create<RefCastOp>(compatibleRWProbe, dest);
+    else
+      return emitError(startTok.getLoc(),
+                       "incompatible force_initial source of type ")
+             << src.getType() << " cannot target destination "
+             << dest.getType();
   }
 
   auto value = APInt::getAllOnes(1);

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -707,6 +707,27 @@ circuit ForceWithLiteral:
 ;// -----
 
 FIRRTL version 4.0.0
+circuit ForceBadTypes:
+  public module ForceBadTypes:
+    input in : { a : UInt<5>, b : UInt<4> }
+    node n = in
+    ; expected-error @below {{incompatible force_initial source of type '!firrtl.uint<4>' cannot target destination '!firrtl.rwprobe<bundle<a: uint<5>, b: uint<4>>>'}}
+    force_initial(rwprobe(n), in.b)
+
+;// -----
+
+FIRRTL version 4.0.0
+circuit ForceBadTypesWithFlips:
+  public module ForceBadTypesWithFlips:
+    output out : { flip a : UInt<5> }
+    wire w : { flip a : UInt<5> }
+    connect out, w
+    ; expected-error @below {{expected passive value for force_initial source, got '!firrtl.bundle<a flip: uint<5>>'}}
+    force_initial(rwprobe(w), out)
+
+;// -----
+
+FIRRTL version 4.0.0
 circuit RWProbeConst:
   extmodule RWProbeConst:
     output p : RWProbe<{a: const UInt}> ; expected-error {{rwprobe cannot contain const}}


### PR DESCRIPTION
* Must be passive
* Explicitly diagnose if source/dest diff cannot be cast away.

Add tests.  Second crashed attempting to construct invalid RefType before this change (non-passive base type).

While visiting, preserve layer "color" when inserting ref.cast.

Found via fuzzing.