### PR TITLE
[HW][HWTypes] Fix use of OptionalParseResult.

### DIFF
--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -181,8 +181,10 @@ static ParseResult parseHWElementType(AsmParser &p, Type &result) {
       typeString.starts_with("typealias<") || typeString.starts_with("int<") ||
       typeString.starts_with("enum<")) {
     llvm::StringRef mnemonic;
-    auto parseResult = generatedTypeParser(p, &mnemonic, result);
-    return parseResult.has_value() ? success() : failure();
+    if (auto parseResult = generatedTypeParser(p, &mnemonic, result);
+        parseResult.has_value())
+      return *parseResult;
+    return p.emitError(p.getNameLoc(), "invalid type `") << typeString << "`";
   }
 
   return p.parseType(result);

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -506,3 +506,11 @@ hw.module @Foo () {
 // Don't crash if hw.array attribute fails to parse as integer
 // expected-error @below {{floating point value not valid for specified type}}
 hw.module @arrayTypeError(in %in: !hw.array<44.44axi0>) { }
+
+// -----
+
+// Don't crash if element type of inout fails to parse.
+hw.module @elementTypeError() {
+  // expected-error @below {{expected ':'}}
+  "builtin.unrealized_conversion_cast"() : () -> !hw.inout<struct<foo>>
+}


### PR DESCRIPTION
Don't return success if there's a value, that value may be failure.  Fixes crash.

Emit diagnostic if no value found, to ensure something is produced.

Found via fuzzing.