### PR TITLE
[HW] Fix crash when error encountered parsing hw.array.

### DIFF
--- a/lib/Dialect/HW/HWTypes.cpp
+++ b/lib/Dialect/HW/HWTypes.cpp
@@ -558,10 +558,16 @@ static ParseResult parseHWArray(AsmParser &p, Attribute &dim, Type &inner) {
   uint64_t dimLiteral;
   auto int64Type = p.getBuilder().getIntegerType(64);
 
-  if (auto res = p.parseOptionalInteger(dimLiteral); res.has_value())
+  if (auto res = p.parseOptionalInteger(dimLiteral); res.has_value()) {
+    if (failed(*res))
+      return failure();
     dim = p.getBuilder().getI64IntegerAttr(dimLiteral);
-  else if (!p.parseOptionalAttribute(dim, int64Type).has_value())
-    return failure();
+  } else if (auto res64 = p.parseOptionalAttribute(dim, int64Type);
+             res64.has_value()) {
+    if (failed(*res64))
+      return failure();
+  } else
+    return p.emitError(p.getNameLoc(), "expected integer");
 
   if (!isa<IntegerAttr, ParamExprAttr, ParamDeclRefAttr>(dim)) {
     p.emitError(p.getNameLoc(), "unsupported dimension kind in hw.array");

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -501,3 +501,8 @@ hw.module @Foo () {
   hw.instance_choice "inst" option "foo" @DoesNotExist () -> ()
 }
 
+// -----
+
+// Don't crash if hw.array attribute fails to parse as integer
+// expected-error @below {{floating point value not valid for specified type}}
+hw.module @arrayTypeError(in %in: !hw.array<44.44axi0>) { }


### PR DESCRIPTION
Fix checking of OptionalParseResult, having value does not mean that the parsing succeeded.

Add test.

Found via fuzzing.