### PR TITLE
[FIRRTL][Lexer] Don't crash on trailing slash in inline anno.

### DIFF
--- a/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRLexer.cpp
@@ -352,9 +352,6 @@ FIRToken FIRLexer::lexInlineAnnotation(const char *tokStart) {
   bool stringMode = false;
   while (1) {
     switch (*curPtr++) {
-    case '\\':
-      ++curPtr;
-      break;
     case '"':
       stringMode = !stringMode;
       break;
@@ -370,6 +367,9 @@ FIRToken FIRLexer::lexInlineAnnotation(const char *tokStart) {
         break;
       ++depth;
       break;
+    case '\\':
+      ++curPtr;
+      [[fallthrough]];
     case 0:
       if (curPtr - 1 != curBuffer.end())
         break;

--- a/test/Dialect/FIRRTL/annotations-errors-lex-unterminated.fir
+++ b/test/Dialect/FIRRTL/annotations-errors-lex-unterminated.fir
@@ -1,0 +1,10 @@
+; RUN: circt-translate -import-firrtl -verify-diagnostics %s
+
+; This must end the file, need a `\` directly before EOF (no newline).
+; Put other tests in annotations-errors.fir
+FIRRTL version 4.0.0
+
+; expected-error @below {{unterminated inline annotation}}
+circuit test :%[[{
+
+\


### PR DESCRIPTION
Add test.

Found via fuzzing.