### PR TITLE
[ImportVerilog] Skip defparams which have been handled by slang.

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -195,6 +195,9 @@ struct ModuleVisitor : public BaseVisitor {
     return success();
   }
 
+  // Skip defparams which have been handled by slang.
+  LogicalResult visit(const slang::ast::DefParamSymbol &) { return success(); }
+
   // Ignore type parameters. These have already been handled by Slang's type
   // checking.
   LogicalResult visit(const slang::ast::TypeParameterSymbol &) {

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -27,13 +27,6 @@ endmodule
 
 // -----
 module Foo;
-  parameter a = 1;
-  // expected-error @below {{unsupported module member}}
-  defparam a = 2;
-endmodule
-
-// -----
-module Foo;
   // expected-error @below {{unsupported module member}}
   nettype real x;
 endmodule


### PR DESCRIPTION
For `defparam`, slang has propagated its value for the corresponding parameter. Such as:
```
module Top;
  Foo #(1) foo();
endmodule

module Foo #(
  parameter P = 32
);
  int a = P;
endmodule

module Bar;
  defparam Top.foo.P  = 4;
endmodule
```
On the AST, `P` and `a` both are 4. So we can skip `defparam`.