### PR TITLE
Make sure type conversion materialization callbacks return values of the correct type

### DIFF
--- a/lib/Conversion/DCToHW/DCToHW.cpp
+++ b/lib/Conversion/DCToHW/DCToHW.cpp
@@ -118,7 +118,9 @@ public:
           if (inputs.size() != 1)
             return std::nullopt;
 
-          return inputs[0];
+          return builder
+              .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+              ->getResult(0);
         });
 
     addSourceMaterialization(
@@ -128,7 +130,9 @@ public:
           if (inputs.size() != 1)
             return std::nullopt;
 
-          return inputs[0];
+          return builder
+              .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+              ->getResult(0);
         });
   }
 };

--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -393,7 +393,9 @@ HWArithToHWTypeConverter::HWArithToHWTypeConverter() {
           mlir::Location loc) -> std::optional<mlir::Value> {
         if (inputs.size() != 1)
           return std::nullopt;
-        return inputs[0];
+        return builder
+            .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+            ->getResult(0);
       });
 
   addSourceMaterialization(
@@ -402,7 +404,9 @@ HWArithToHWTypeConverter::HWArithToHWTypeConverter() {
           mlir::Location loc) -> std::optional<mlir::Value> {
         if (inputs.size() != 1)
           return std::nullopt;
-        return inputs[0];
+        return builder
+            .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+            ->getResult(0);
       });
 }
 

--- a/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
+++ b/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
@@ -92,7 +92,9 @@ public:
           if (vt && !vt.getInnerType())
             return pack(builder, inputs.front());
 
-          return inputs[0];
+          return builder
+              .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+              ->getResult(0);
         });
 
     addSourceMaterialization(
@@ -112,7 +114,9 @@ public:
           if (vt && !vt.getInnerType())
             return pack(builder, inputs.front());
 
-          return inputs[0];
+          return builder
+              .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+              ->getResult(0);
         });
   }
 };

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -71,7 +71,9 @@ public:
             mlir::Location loc) -> std::optional<mlir::Value> {
           if (inputs.size() != 1)
             return std::nullopt;
-          return inputs[0];
+          return builder
+              .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+              ->getResult(0);
         });
 
     addSourceMaterialization(
@@ -80,7 +82,9 @@ public:
             mlir::Location loc) -> std::optional<mlir::Value> {
           if (inputs.size() != 1)
             return std::nullopt;
-          return inputs[0];
+          return builder
+              .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+              ->getResult(0);
         });
   }
 };

--- a/lib/Conversion/LTLToCore/LTLToCore.cpp
+++ b/lib/Conversion/LTLToCore/LTLToCore.cpp
@@ -138,7 +138,9 @@ void LowerLTLToCorePass::runOnOperation() {
           mlir::Location loc) -> std::optional<mlir::Value> {
         if (inputs.size() != 1)
           return std::nullopt;
-        return inputs[0];
+        return builder
+            .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+            ->getResult(0);
       });
 
   converter.addSourceMaterialization(
@@ -147,7 +149,9 @@ void LowerLTLToCorePass::runOnOperation() {
           mlir::Location loc) -> std::optional<mlir::Value> {
         if (inputs.size() != 1)
           return std::nullopt;
-        return inputs[0];
+        return builder
+            .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+            ->getResult(0);
       });
 
   // Create the operation rewrite patters

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1301,7 +1301,9 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
           mlir::Location loc) -> std::optional<mlir::Value> {
         if (inputs.size() != 1)
           return std::nullopt;
-        return inputs[0];
+        return builder
+            .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+            ->getResult(0);
       });
 }
 

--- a/lib/Conversion/SeqToSV/SeqToSV.cpp
+++ b/lib/Conversion/SeqToSV/SeqToSV.cpp
@@ -363,7 +363,10 @@ struct SeqToSVTypeConverter : public TypeConverter {
             mlir::Location loc) -> std::optional<mlir::Value> {
           if (inputs.size() != 1)
             return std::nullopt;
-          return inputs[0];
+          return builder
+              .create<mlir::UnrealizedConversionCastOp>(loc, resultType,
+                                                        inputs[0])
+              ->getResult(0);
         });
 
     addSourceMaterialization(
@@ -372,7 +375,10 @@ struct SeqToSVTypeConverter : public TypeConverter {
             mlir::Location loc) -> std::optional<mlir::Value> {
           if (inputs.size() != 1)
             return std::nullopt;
-          return inputs[0];
+          return builder
+              .create<mlir::UnrealizedConversionCastOp>(loc, resultType,
+                                                        inputs[0])
+              ->getResult(0);
         });
   }
 };

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -1853,7 +1853,8 @@ static void populateTypeConverter(TypeConverter &converter) {
   converter.addConversion(
       [](DoubleType type) { return FloatType::getF64(type.getContext()); });
 
-  // Add a target materialization to fold away unrealized conversion casts.
+  // Add a target materialization such that the conversion does not fail when a
+  // type conversion could not be reconciled automatically by the framework.
   converter.addTargetMaterialization(
       [](OpBuilder &builder, Type type, ValueRange values, Location loc) {
         assert(values.size() == 1);
@@ -1861,7 +1862,8 @@ static void populateTypeConverter(TypeConverter &converter) {
             ->getResult(0);
       });
 
-  // Add a source materialization to fold away unrealized conversion casts.
+  // Add a source materialization such that the conversion does not fail when a
+  // type conversion could not be reconciled automatically by the framework.
   converter.addSourceMaterialization(
       [](OpBuilder &builder, Type type, ValueRange values, Location loc) {
         assert(values.size() == 1);

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -1857,14 +1857,16 @@ static void populateTypeConverter(TypeConverter &converter) {
   converter.addTargetMaterialization(
       [](OpBuilder &builder, Type type, ValueRange values, Location loc) {
         assert(values.size() == 1);
-        return values[0];
+        return builder.create<UnrealizedConversionCastOp>(loc, type, values[0])
+            ->getResult(0);
       });
 
   // Add a source materialization to fold away unrealized conversion casts.
   converter.addSourceMaterialization(
       [](OpBuilder &builder, Type type, ValueRange values, Location loc) {
         assert(values.size() == 1);
-        return values[0];
+        return builder.create<UnrealizedConversionCastOp>(loc, type, values[0])
+            ->getResult(0);
       });
 }
 


### PR DESCRIPTION
The materialization callbacks have to return either a `nullopt` or a value of the type provided as argument. This is not guaranteed by the ones changed in this PR.
This callback is invoked when an `unrealized_conversion_cast` operation inserted by the dialect conversion framework cannot be reconciled by the framework itself (e.g., if the input and output types of the op match, it gets folded away automatically).
This PR takes the conservative route, just telling the dialect conversion framework that it is fine to leave the conversion cast op in there if it cannot get rid of it. We could also return `nullopt` to tell it that it should fail in those cases.