### PR TITLE
[FIRRTL][Folds] Fix mux fold if result type doesn't match operands.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1269,7 +1269,7 @@ static OpFoldResult foldMux(OpTy op, typename OpTy::FoldAdaptor adaptor) {
                       APInt(0, 0, op.getType().isSignedInteger()));
 
   // mux(cond, x, x) -> x
-  if (op.getHigh() == op.getLow())
+  if (op.getHigh() == op.getLow() && op.getHigh().getType() == op.getType())
     return op.getHigh();
 
   // The following folds require that the result has a known width. Otherwise

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3635,4 +3635,9 @@ firrtl.module @multibit_mux_drop_front(in %vec_0: !firrtl.uint<8>, in %vec_1: !f
   firrtl.matchingconnect %c, %1 : !firrtl.uint<8>
 }
 
+firrtl.module private @Issue7562(in %sel : !firrtl.uint<1>, in %a : !firrtl.const.uint<1>, out %out : !firrtl.uint) {
+  %res = firrtl.mux(%sel, %a, %a) : (!firrtl.uint<1>, !firrtl.const.uint<1>, !firrtl.const.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out, %res : !firrtl.uint, !firrtl.uint<1>
+}
+
 }


### PR DESCRIPTION
Fixes #7562.