### PR TITLE
[FIRRTL] Change InferReadWrite to use a walk, error if it sees WhenOps

### DIFF
--- a/test/Dialect/FIRRTL/inferRW-errors.mlir
+++ b/test/Dialect/FIRRTL/inferRW-errors.mlir
@@ -1,0 +1,13 @@
+// RUN: circt-opt -verify-diagnostics -pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-infer-rw)))' %s
+
+firrtl.circuit "InferReadWriteErrors" {
+
+  firrtl.module public @InferReadWriteErrors() {}
+
+  firrtl.module @ContainsWhen() {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    // expected-error @below {{is unsupported by InferReadWrite}}
+    firrtl.when %c0_ui1 : !firrtl.uint<1> {}
+  }
+
+}


### PR DESCRIPTION
Fix the InferReadWrite pass to walk into nested regions instead of only
visiting the top-level ops immediately in an FModuleOp's body.  This has
the effect of allowing it to work on memories that are declared inside
layers.

Change the InferReadWrite pass to fail if it ever sees a WhenOp.  If this
happens, the pass can silently do the wrong thing when trying to determine
signal drivers.  This is a conservative check (with false positives), but
will have no false negatives.