### PR TITLE
[FIRRTL] Make IMCP work with Layers

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -483,6 +483,8 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
         .Case<InstanceOp>([&](auto instance) { markInstanceOp(instance); })
         .Case<ObjectOp>([&](auto obj) { markObjectOp(obj); })
         .Case<MemOp>([&](auto mem) { markMemOp(mem); })
+        .Case<LayerBlockOp>(
+            [&](auto layer) { markBlockExecutable(layer.getBody(0)); })
         .Default([&](auto _) {
           if (isa<mlir::UnrealizedConversionCastOp, VerbatimExprOp,
                   VerbatimWireOp, SubaccessOp>(op) ||

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -950,3 +950,20 @@ firrtl.circuit "OMIRRemoval" {
     firrtl.matchingconnect %d, %tmp_3 : !firrtl.uint<4>
   }
 }
+
+
+// -----
+
+firrtl.circuit "Layers" {
+  // CHECK-LABEL: firrtl.module @Layers
+  firrtl.layer @A bind {}
+  firrtl.module @Layers() {
+    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
+    // CHECK: firrtl.layerblock
+    firrtl.layerblock @A {
+      %a = firrtl.node %c0_ui1 : !firrtl.uint<1>
+      // CHECK-NEXT: %b = firrtl.node sym @sym_b %c0_ui1
+      %b = firrtl.node sym @sym_b %a : !firrtl.uint<1>
+    }
+  }
+}


### PR DESCRIPTION
Change IMCP's module update to use a walk instead of only visiting
top-level ops.  This is intended to be an entirely mechanical change and
is broken out in a separate commit because of its mechanical nature.

Change IMCP to recurse into layers.  This has the effect of allowing IMCP
to sink constants into layers and to properly visit instances which are
instantiated under layers.