### PR TITLE
[FIRRTL] Use walk, InstanceInfo in AddSeqMemPorts

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Analysis/FIRRTLInstanceInfo.h"
 #include "circt/Dialect/Emit/EmitOps.h"
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h"
@@ -49,7 +50,7 @@ struct AddSeqMemPortsPass
   void createOutputFile(igraph::ModuleOpInterface moduleOp);
   InstanceGraphNode *findDUT();
   void processMemModule(FMemModuleOp mem);
-  LogicalResult processModule(FModuleOp moduleOp, bool isDUT);
+  LogicalResult processModule(FModuleOp moduleOp);
 
   /// Get the cached namespace for a module.
   hw::InnerSymbolNamespace &getModuleNamespace(FModuleLike moduleOp) {
@@ -83,6 +84,7 @@ struct AddSeqMemPortsPass
   DenseMap<Attribute, Operation *> innerRefToInstanceMap;
 
   InstanceGraph *instanceGraph;
+  InstanceInfo *instanceInfo;
 
   /// If the metadata output file was specified in an annotation.
   StringAttr outputFile;
@@ -187,18 +189,16 @@ void AddSeqMemPortsPass::processMemModule(FMemModuleOp mem) {
   size_t portIndex = mem.getNumPorts();
   auto &memInfo = memInfoMap[mem];
   auto &extraPorts = memInfo.extraPorts;
-  for (auto &p : userPorts)
+  for (auto const &p : userPorts)
     extraPorts.emplace_back(portIndex, p);
   mem.insertPorts(extraPorts);
   // Attach the extraPorts metadata.
   mem.setExtraPortsAttr(extraPortsAttr);
 }
 
-LogicalResult AddSeqMemPortsPass::processModule(FModuleOp moduleOp,
-                                                bool isDUT) {
+LogicalResult AddSeqMemPortsPass::processModule(FModuleOp moduleOp) {
   auto *context = &getContext();
-  // Insert the new port connections at the end of the module.
-  auto builder = OpBuilder::atBlockEnd(moduleOp.getBodyBlock());
+  auto builder = OpBuilder(moduleOp.getContext());
   auto &memInfo = memInfoMap[moduleOp];
   auto &extraPorts = memInfo.extraPorts;
   // List of ports added to submodules which must be connected to this module's
@@ -208,7 +208,7 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp moduleOp,
   // The base index to use when adding ports to the current module.
   unsigned firstPortIndex = moduleOp.getNumPorts();
 
-  for (auto &op : llvm::make_early_inc_range(*moduleOp.getBodyBlock())) {
+  auto result = moduleOp.walk([&](Operation *op) {
     if (auto inst = dyn_cast<InstanceOp>(op)) {
       auto submodule = inst.getReferencedModule(*instanceGraph);
 
@@ -216,7 +216,7 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp moduleOp,
       // If there are no extra ports, we don't have to do anything.
       if (subMemInfoIt == memInfoMap.end() ||
           subMemInfoIt->second.extraPorts.empty())
-        continue;
+        return WalkResult::advance();
       auto &subMemInfo = subMemInfoIt->second;
       // Find out how many memory ports we have to add.
       auto &subExtraPorts = subMemInfo.extraPorts;
@@ -234,7 +234,7 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp moduleOp,
         auto &[firstSubIndex, portInfo] = subExtraPorts[i];
         // This is the index of the user port we are adding.
         auto userIndex = i % userPorts.size();
-        auto &sramPort = userPorts[userIndex];
+        auto const &sramPort = userPorts[userIndex];
         // Construct a port name, e.g. "sram_0_user_inputs".
         auto sramIndex = extraPorts.size() / userPorts.size();
         auto portName =
@@ -248,7 +248,7 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp moduleOp,
              {portName, type_cast<FIRRTLType>(portType), portDirection}});
         // If this is the DUT, then add a DontTouchAnnotation to any added ports
         // to guarantee that it won't be removed.
-        if (isDUT)
+        if (instanceInfo->isEffectiveDut(moduleOp))
           extraPorts.back().second.annotations.addDontTouch();
         // Record the instance result for now, so that we can connect it to the
         // parent module port after we actually add the ports.
@@ -273,20 +273,35 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp moduleOp,
           instancePaths.back().push_back(ref);
         }
       }
+
+      return WalkResult::advance();
     }
-  }
+
+    return WalkResult::advance();
+  });
+
+  if (result.wasInterrupted())
+    return failure();
 
   // Add the extra ports to this module.
   moduleOp.insertPorts(extraPorts);
 
   // Connect the submodule ports to the parent module ports.
+  DenseMap<Operation *, OpBuilder::InsertPoint> instToInsertionPoint;
   for (unsigned i = 0, e = values.size(); i < e; ++i) {
     auto &[firstArg, port] = extraPorts[i];
     Value modulePort = moduleOp.getArgument(firstArg + i);
     Value instPort = values[i];
+    Operation *instOp = instPort.getDefiningOp();
+    auto insertPoint = instToInsertionPoint.find(instOp);
+    if (insertPoint == instToInsertionPoint.end())
+      builder.setInsertionPointAfter(instOp);
+    else
+      builder.restoreInsertionPoint(insertPoint->getSecond());
     if (port.direction == Direction::In)
       std::swap(modulePort, instPort);
     builder.create<MatchingConnectOp>(port.loc, modulePort, instPort);
+    instToInsertionPoint[instOp] = builder.saveInsertionPoint();
   }
   return success();
 }
@@ -367,6 +382,7 @@ void AddSeqMemPortsPass::runOnOperation() {
   auto *context = &getContext();
   auto circuit = getOperation();
   instanceGraph = &getAnalysis<InstanceGraph>();
+  instanceInfo = &getAnalysis<InstanceInfo>();
   circtNamespace = CircuitNamespace(circuit);
   // Clear the state.
   userPorts.clear();
@@ -381,8 +397,6 @@ void AddSeqMemPortsPass::runOnOperation() {
   // SFC adds the ports in the opposite order they are attached, so we reverse
   // the list here to match exactly.
   std::reverse(userPorts.begin(), userPorts.end());
-
-  auto *dutNode = findDUT();
 
   // Process the extra ports so we can attach it as metadata on to each memory.
   SmallVector<Attribute> extraPorts;
@@ -403,27 +417,75 @@ void AddSeqMemPortsPass::runOnOperation() {
   }
   extraPortsAttr = ArrayAttr::get(context, extraPorts);
 
+  auto *effectiveDut = instanceInfo->getEffectiveDut();
+
   // If there are no user ports, don't do anything.
   if (!userPorts.empty()) {
     // Update ports statistic.
     numAddedPorts += userPorts.size();
 
-    // Visit the nodes in post-order.
-    for (auto *node : llvm::post_order(dutNode)) {
+    // Visit the modules in post-order in one of two ways:
+    //
+    //   1. If no design-under-test is specified, visit all modules.
+    //   2. If the design-under-test is specified, only visit modules under it.
+    //
+    // Additionally, skip any modules that are wholly instantiated under layers.
+    // If any memories are partially instantiated under a layer then error.
+    for (auto *node : llvm::post_order(instanceGraph)) {
       auto op = node->getModule();
+      // Skip the module if there is a DUT and no instances are under it.
+      if (instanceInfo->hasDut() && !instanceInfo->anyInstanceUnderDut(op))
+        continue;
+
+      // Skip anything wholly under a layer.
+      if (instanceInfo->allInstancesUnderLayer(op))
+        continue;
+
+      // Process the module or memory.  Error if the memory is partially under a
+      // layer.
+      //
+      // TODO: There are several ways to handle a memory being under a layer:
+      // duplication or tie-off.  However, it is unclear if either if these is
+      // intended or correct.  Additionally, this can be handled with pass order
+      // by preventing deduplication of memories that have this property in
+      // `LowerMemories`.
       if (auto moduleOp = dyn_cast<FModuleOp>(*op)) {
-        if (failed(processModule(moduleOp, /*isDUT=*/node == dutNode)))
+        if (failed(processModule(moduleOp)))
           return signalPassFailure();
       } else if (auto mem = dyn_cast<FMemModuleOp>(*op)) {
+        if (instanceInfo->anyInstanceUnderLayer(mem)) {
+          auto diag = op->emitOpError()
+                      << "cannot have ports added to it because it is "
+                         "instantiated under "
+                         "both the design-under-test and layer blocks";
+          for (auto *instNode : node->uses()) {
+            auto instanceOp = instNode->getInstance();
+            if (auto layerBlockOp =
+                    instanceOp->getParentOfType<LayerBlockOp>()) {
+              diag.attachNote(instanceOp.getLoc())
+                  << "this instance is under a layer block";
+              diag.attachNote(layerBlockOp.getLoc())
+                  << "the innermost layer block is here";
+              continue;
+            }
+            if (instanceInfo->anyInstanceUnderLayer(
+                    instNode->getParent()->getModule())) {
+              diag.attachNote(instanceOp.getLoc())
+                  << "this instance is inside a module that is instantiated "
+                     "under a layer block";
+            }
+          }
+          return signalPassFailure();
+        }
         processMemModule(mem);
       }
     }
 
     // We handle the DUT differently than the rest of the modules.
-    if (auto dut = dyn_cast<FModuleOp>(*dutNode->getModule())) {
+    if (auto dut = dyn_cast<FModuleOp>(effectiveDut->getModule())) {
       // For each instance of the dut, add the instance ports, but tie the port
       // to 0 instead of wiring them to the parent.
-      for (auto *instRec : dutNode->uses()) {
+      for (auto *instRec : effectiveDut->uses()) {
         auto inst = cast<InstanceOp>(*instRec->getInstance());
         auto &dutMemInfo = memInfoMap[dut];
         // Find out how many memory ports we have to add.
@@ -459,7 +521,7 @@ void AddSeqMemPortsPass::runOnOperation() {
 
   // If there is an output file, create it.
   if (outputFile)
-    createOutputFile(dutNode->getModule<igraph::ModuleOpInterface>());
+    createOutputFile(effectiveDut->getModule<igraph::ModuleOpInterface>());
 
   if (anythingChanged)
     markAnalysesPreserved<InstanceGraph>();

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -424,18 +424,12 @@ void AddSeqMemPortsPass::runOnOperation() {
     // Update ports statistic.
     numAddedPorts += userPorts.size();
 
-    // Visit the modules in post-order in one of two ways:
-    //
-    //   1. If no design-under-test is specified, visit all modules.
-    //   2. If the design-under-test is specified, only visit modules under it.
-    //
-    // Additionally, skip any modules that are wholly instantiated under layers.
-    // If any memories are partially instantiated under a layer then error.
-    for (auto *node : llvm::post_order(instanceGraph)) {
+    // Visit the modules in post-order starting from the effective
+    // design-under-test. Skip any modules that are wholly instantiated under
+    // layers.  If any memories are partially instantiated under a layer then
+    // error.
+    for (auto *node : llvm::post_order(instanceInfo->getEffectiveDut())) {
       auto op = node->getModule();
-      // Skip the module if there is a DUT and no instances are under it.
-      if (instanceInfo->hasDut() && !instanceInfo->anyInstanceUnderDut(op))
-        continue;
 
       // Skip anything wholly under a layer.
       if (instanceInfo->allInstancesUnderLayer(op))

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -230,7 +230,8 @@ LogicalResult AddSeqMemPortsPass::processMemModule(FMemModuleOp mem) {
 
 LogicalResult AddSeqMemPortsPass::processModule(FModuleOp moduleOp) {
   auto *context = &getContext();
-  auto builder = OpBuilder(moduleOp.getContext());
+  // Insert the new port connections at the end of the module.
+  auto builder = OpBuilder::atBlockEnd(moduleOp.getBodyBlock());
   auto &memInfo = memInfoMap[moduleOp];
   auto &extraPorts = memInfo.extraPorts;
   // List of ports added to submodules which must be connected to this module's
@@ -319,21 +320,13 @@ LogicalResult AddSeqMemPortsPass::processModule(FModuleOp moduleOp) {
   moduleOp.insertPorts(extraPorts);
 
   // Connect the submodule ports to the parent module ports.
-  DenseMap<Operation *, OpBuilder::InsertPoint> instToInsertionPoint;
   for (unsigned i = 0, e = values.size(); i < e; ++i) {
     auto &[firstArg, port] = extraPorts[i];
     Value modulePort = moduleOp.getArgument(firstArg + i);
     Value instPort = values[i];
-    Operation *instOp = instPort.getDefiningOp();
-    auto insertPoint = instToInsertionPoint.find(instOp);
-    if (insertPoint == instToInsertionPoint.end())
-      builder.setInsertionPointAfter(instOp);
-    else
-      builder.restoreInsertionPoint(insertPoint->getSecond());
     if (port.direction == Direction::In)
       std::swap(modulePort, instPort);
     builder.create<MatchingConnectOp>(port.loc, modulePort, instPort);
-    instToInsertionPoint[instOp] = builder.saveInsertionPoint();
   }
   return success();
 }

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -72,6 +72,7 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   LINK_LIBS PUBLIC
   CIRCTFIRRTLAnalysis
   CIRCTFIRRTL
+  CIRCTFIRRTLAnalysis
   CIRCTDebug
   CIRCTEmit
   CIRCTHW

--- a/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/Transforms/CMakeLists.txt
@@ -70,7 +70,6 @@ add_circt_dialect_library(CIRCTFIRRTLTransforms
   MLIROMOpInterfacesIncGen
 
   LINK_LIBS PUBLIC
-  CIRCTFIRRTLAnalysis
   CIRCTFIRRTL
   CIRCTFIRRTLAnalysis
   CIRCTDebug

--- a/test/Dialect/FIRRTL/add-seqmem-ports-errors.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports-errors.mlir
@@ -63,3 +63,124 @@ firrtl.circuit "Simple" attributes {annotations = [{
  }]} {
   firrtl.module @Simple() { }
 }
+
+// -----
+
+// This has a memory that is instantiated under the design-under-test _and_
+// under a layer block.
+firrtl.circuit "LayerBlock" attributes {
+  annotations = [
+    {
+      class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+      name = "user_input",
+      input = true,
+      width = 1
+    }
+  ]
+} {
+  firrtl.layer @A bind {}
+
+  // expected-error @below {{cannot have ports added to it}}
+  firrtl.memmodule @mem(
+    in W0_addr: !firrtl.uint<1>,
+    in W0_en: !firrtl.uint<1>,
+    in W0_clk: !firrtl.clock,
+    in W0_data: !firrtl.uint<1>
+  ) attributes {
+    dataWidth = 1 : ui32,
+    depth = 2 : ui64,
+    extraPorts = [],
+    maskBits = 1 : ui32,
+    numReadPorts = 0 : ui32,
+    numReadWritePorts = 0 : ui32,
+    numWritePorts = 1 : ui32,
+    readLatency = 1 : ui32,
+    writeLatency = 1 : ui32
+  }
+
+  firrtl.module @Foo() {
+    %0:4 = firrtl.instance mem @mem(
+      in W0_addr: !firrtl.uint<1>,
+      in W0_en: !firrtl.uint<1>,
+      in W0_clk: !firrtl.clock,
+      in W0_data: !firrtl.uint<1>
+    )
+  }
+
+  firrtl.module @LayerBlock() {
+    // expected-note @below {{the innermost layer block is here}}
+    firrtl.layerblock @A {
+      // expected-note @below {{this instance is under a layer block}}
+      %0:4 = firrtl.instance mem @mem(
+        in W0_addr: !firrtl.uint<1>,
+        in W0_en: !firrtl.uint<1>,
+        in W0_clk: !firrtl.clock,
+        in W0_data: !firrtl.uint<1>
+      )
+    }
+    firrtl.instance foo @Foo()
+  }
+
+}
+
+// -----
+
+// This has a memory that is instantiated under the design-under-test _and_
+// under a module that is under a layer block.
+firrtl.circuit "LayerBlock" attributes {
+  annotations = [
+    {
+      class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+      name = "user_input",
+      input = true,
+      width = 1
+    }
+  ]
+} {
+  firrtl.layer @A bind {}
+
+  // expected-error @below {{cannot have ports added to it}}
+  firrtl.memmodule @mem(
+    in W0_addr: !firrtl.uint<1>,
+    in W0_en: !firrtl.uint<1>,
+    in W0_clk: !firrtl.clock,
+    in W0_data: !firrtl.uint<1>
+  ) attributes {
+    dataWidth = 1 : ui32,
+    depth = 2 : ui64,
+    extraPorts = [],
+    maskBits = 1 : ui32,
+    numReadPorts = 0 : ui32,
+    numReadWritePorts = 0 : ui32,
+    numWritePorts = 1 : ui32,
+    readLatency = 1 : ui32,
+    writeLatency = 1 : ui32
+  }
+
+  firrtl.module @Foo() {
+    %0:4 = firrtl.instance mem @mem(
+      in W0_addr: !firrtl.uint<1>,
+      in W0_en: !firrtl.uint<1>,
+      in W0_clk: !firrtl.clock,
+      in W0_data: !firrtl.uint<1>
+    )
+  }
+
+  firrtl.module @Bar() {
+    // expected-note @below {{this instance is inside a module that is instantiated under a layer block}}
+    %0:4 = firrtl.instance mem @mem(
+      in W0_addr: !firrtl.uint<1>,
+      in W0_en: !firrtl.uint<1>,
+      in W0_clk: !firrtl.clock,
+      in W0_data: !firrtl.uint<1>
+    )
+  }
+
+  firrtl.module @LayerBlock() {
+    firrtl.layerblock @A {
+      firrtl.instance bar @Bar()
+    }
+    firrtl.instance foo @Foo()
+  }
+
+}

--- a/test/Dialect/FIRRTL/add-seqmem-ports.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports.mlir
@@ -100,9 +100,9 @@ firrtl.circuit "Two" attributes {annotations = [
     firrtl.instance child0 @Child()
     firrtl.instance child1 @Child()
     // CHECK: %child0_sram_0_user_output, %child0_sram_0_user_input = firrtl.instance child0  @Child
-    // CHECK: %child1_sram_0_user_output, %child1_sram_0_user_input = firrtl.instance child1  @Child
     // CHECK: firrtl.matchingconnect %sram_0_user_output, %child0_sram_0_user_output : !firrtl.uint<4>
     // CHECK: firrtl.matchingconnect %child0_sram_0_user_input, %sram_0_user_input : !firrtl.uint<3>
+    // CHECK: %child1_sram_0_user_output, %child1_sram_0_user_input = firrtl.instance child1  @Child
     // CHECK: firrtl.matchingconnect %sram_1_user_output, %child1_sram_0_user_output : !firrtl.uint<4>
     // CHECK: firrtl.matchingconnect %child1_sram_0_user_input, %sram_1_user_input : !firrtl.uint<3>
 

--- a/test/Dialect/FIRRTL/add-seqmem-ports.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports.mlir
@@ -100,9 +100,9 @@ firrtl.circuit "Two" attributes {annotations = [
     firrtl.instance child0 @Child()
     firrtl.instance child1 @Child()
     // CHECK: %child0_sram_0_user_output, %child0_sram_0_user_input = firrtl.instance child0  @Child
+    // CHECK: %child1_sram_0_user_output, %child1_sram_0_user_input = firrtl.instance child1  @Child
     // CHECK: firrtl.matchingconnect %sram_0_user_output, %child0_sram_0_user_output : !firrtl.uint<4>
     // CHECK: firrtl.matchingconnect %child0_sram_0_user_input, %sram_0_user_input : !firrtl.uint<3>
-    // CHECK: %child1_sram_0_user_output, %child1_sram_0_user_input = firrtl.instance child1  @Child
     // CHECK: firrtl.matchingconnect %sram_1_user_output, %child1_sram_0_user_output : !firrtl.uint<4>
     // CHECK: firrtl.matchingconnect %child1_sram_0_user_input, %sram_1_user_input : !firrtl.uint<3>
 


### PR DESCRIPTION
Change the `AddSeqMemPorts` pass (whic adds MBIST ports to memories) to
use a walk when adding ports to memories.  Practically, this causes the
pass to now be capable of adding MBIST to memories under `WhenOp`s or
`LayerBlockOp`s.  However, because this pass is intentionally _not_
supposed to add MBIST ports to anything that is not in the "design", this
will skip over any layers or modules that are instantiated wholly under
layers.

To do this, this pass was changed to use the new `InstanceInfo` analysis
instead of computing information about what modules are under the
design-under-test (DUT) manually.  Any checking related to layers is
similarly done using this analysis.

This change is prerequisite work to move the `LowerLayers` after
`AddSeqMemPorts` while still preserving the functionality of the original
pass order.  Unfortunately, layers do not compose sanely with
`AddSeqMemPorts`.  This is a failing of the original pass and its
assumptions about what is "design" vs. "verification" as opposed to any
fundamental issue with layers.  Generally, layers are intended as
verification features.  However, there is no actual requirement or
expectation that they will be used this way.  Going forward,
`AddSeqMemPorts` is intended to be removed and replaced with a feature in
Chisel.

Additionally, this this commit includes a small change to the pass output
where the connects created are placed immediately following the memory
instance.  This is necessary to create the connects inside the layer
blocks.  However, it is also slightly better output than before.  (This
changed one test superficially.)