### PR TITLE
[Moore] Support the display system task.

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1329,4 +1329,40 @@ def YieldOp : MooreOp<"yield", [
   let hasVerifier = 1;
 }
 
+//===----------------------------------------------------------------------===//
+// Input/Output system tasks
+//===----------------------------------------------------------------------===//
+
+class PrintOpBase<string mnemonic, list<Trait> traits = []> :
+    MooreOp<mnemonic, traits # [
+      HasParent<"ProcedureOp">
+]> {
+  let arguments = (ins
+  OptionalAttr<StrAttr>:$information,
+  Variadic<UnpackedType>:$data
+  );
+
+  let assemblyFormat = [{
+    ($information^)? (`(` $data^ `)` `:`)?  attr-dict type($data)
+  }];
+}
+
+def DisplayOp : PrintOpBase<"display"> {
+  let description = [{
+    The $disply system task displays information with an implicit line feed.
+    It has four forms, such as $display, $displayb(binary), $displayo(octal),
+    and $displayh(hexadecimal).
+    See IEEE 1800-2017 § 21.2.1 "The display and write tasks".
+  }];
+}
+
+def WriteOp : PrintOpBase<"write"> {
+  let description = [{
+    The $write system task also displays information, but it doesn't have an
+    implicit line feed. It has $write, $writeb, $writeo, and $writeh forms.
+    See IEEE 1800-2017 § 21.2.1 "The display and write tasks".
+  }];
+}
+
+
 #endif // CIRCT_DIALECT_MOORE_MOOREOPS

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1904,3 +1904,41 @@ task automatic ImplicitEventControlExamples();
     x[a] = !b;
   end
 endtask
+
+// CHECK-LABEL: moore.module @Display() {
+module Display();
+  int a;
+  // CHECK: [[L:%.+]] = moore.variable : <uarray<8 x l1>>
+  logic l [7:0];
+  initial begin
+    // CHECK: [[READ_A1:%.+]] = moore.read %a : <i32>
+    // CHECK: [[READ_A2:%.+]] = moore.read %a : <i32>
+    // CHECK: [[READ_A3:%.+]] = moore.read %a : <i32>
+    // CHECK: moore.display "The values of a, a, a are: %d%d%d"([[READ_A1]], [[READ_A2]], [[READ_A3]]) : !moore.i32, !moore.i32, !moore.i32
+    $display("The values of a, a, a are: %d%d%d", a, a, a);
+
+    // CHECK: [[C100:%.+]] = moore.constant 100 : i32
+    // CHECK: moore.display([[C100]]) : !moore.i32
+    $displayb(100);
+
+    // CHECK: [[READ_A4:%.+]] = moore.read %a : <i32>
+    // CHECK: moore.display "The value of a is: %b"([[READ_A4]]) : !moore.i32
+    $displayo("The value of a is: %b", a);
+
+    // CHECK: moore.display "Wellcome to Moore!!!" 
+    $displayh("Wellcome to Moore!!!");
+
+    // CHECK: [[READ_L:%.+]] = moore.read [[L]] : <uarray<8 x l1>>
+    // CHECK: moore.display "l = %p"([[READ_L]]) : !moore.uarray<8 x l1>
+    $display("l = %p", l);
+
+    // CHECK-NOT: moore.display
+    $display();
+    // CHECK-NOT: moore.display
+    $display(,,);
+    
+    // CHECK: [[C520:%.+]] = moore.constant 520 : i32
+    // CHECK: moore.display([[C520]])
+    $display(,520,);
+  end
+endmodule


### PR DESCRIPTION
Add `moore.display` and `moore.write` to represent all `$display` and `$write` series ops. Such as `$display(boh)` and `$write(boh)`. `b` is binary; `o` is octal; `h` is hexadecimal. However, I noticed that slang didn't distinguish them. So I didn't distinguish them too.

I only implemented the `$diplay` system task for the time being. Others will be introduced later.