### PR TITLE
Add `verif.bmc` VerifToSMT lowering

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -699,7 +699,12 @@ def ConvertHWToSMT : Pass<"convert-hw-to-smt", "mlir::ModuleOp"> {
 
 def ConvertVerifToSMT : Pass<"convert-verif-to-smt", "mlir::ModuleOp"> {
   let summary = "Convert Verif ops to SMT ops";
-  let dependentDialects = ["smt::SMTDialect", "mlir::arith::ArithDialect"];
+  let dependentDialects = [
+    "smt::SMTDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::func::FuncDialect"
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Conversion/VerifToSMT.h
+++ b/include/circt/Conversion/VerifToSMT.h
@@ -13,13 +13,15 @@
 #include <memory>
 
 namespace circt {
+class Namespace;
 
 #define GEN_PASS_DECL_CONVERTVERIFTOSMT
 #include "circt/Conversion/Passes.h.inc"
 
 /// Get the Verif to SMT conversion patterns.
 void populateVerifToSMTConversionPatterns(TypeConverter &converter,
-                                          RewritePatternSet &patterns);
+                                          RewritePatternSet &patterns,
+                                          Namespace &names);
 
 } // namespace circt
 

--- a/include/circt/Conversion/VerifToSMT.h
+++ b/include/circt/Conversion/VerifToSMT.h
@@ -21,8 +21,7 @@ class Namespace;
 /// Get the Verif to SMT conversion patterns.
 void populateVerifToSMTConversionPatterns(TypeConverter &converter,
                                           RewritePatternSet &patterns,
-                                          Namespace &names,
-                                          SymbolTable &symbolTable);
+                                          Namespace &names);
 
 } // namespace circt
 

--- a/include/circt/Conversion/VerifToSMT.h
+++ b/include/circt/Conversion/VerifToSMT.h
@@ -21,7 +21,8 @@ class Namespace;
 /// Get the Verif to SMT conversion patterns.
 void populateVerifToSMTConversionPatterns(TypeConverter &converter,
                                           RewritePatternSet &patterns,
-                                          Namespace &names);
+                                          Namespace &names,
+                                          SymbolTable &symbolTable);
 
 } // namespace circt
 

--- a/lib/Conversion/HWToSMT/CMakeLists.txt
+++ b/lib/Conversion/HWToSMT/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_conversion_library(CIRCTHWToSMT
   LINK_LIBS PUBLIC
   CIRCTHW
   CIRCTSMT
+  CIRCTSeq
   MLIRFuncDialect
   MLIRTransforms
   MLIRTransformUtils

--- a/lib/Conversion/VerifToSMT/CMakeLists.txt
+++ b/lib/Conversion/VerifToSMT/CMakeLists.txt
@@ -13,6 +13,7 @@ add_circt_conversion_library(CIRCTVerifToSMT
   CIRCTSMT
   CIRCTVerif
   MLIRArithDialect
+  MLIRFuncDialect
   MLIRSCFDialect
   MLIRTransforms
   MLIRTransformUtils

--- a/lib/Conversion/VerifToSMT/CMakeLists.txt
+++ b/lib/Conversion/VerifToSMT/CMakeLists.txt
@@ -13,6 +13,7 @@ add_circt_conversion_library(CIRCTVerifToSMT
   CIRCTSMT
   CIRCTVerif
   MLIRArithDialect
+  MLIRSCFDialect
   MLIRTransforms
   MLIRTransformUtils
   MLIRReconcileUnrealizedCasts

--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -9,12 +9,17 @@
 #include "circt/Conversion/VerifToSMT.h"
 #include "circt/Conversion/HWToSMT.h"
 #include "circt/Dialect/SMT/SMTOps.h"
+#include "circt/Dialect/Seq/SeqTypes.h"
 #include "circt/Dialect/Verif/VerifOps.h"
+#include "circt/Support/Namespace.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/ValueRange.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace circt {
 #define GEN_PASS_DEF_CONVERTVERIFTOSMT
@@ -30,7 +35,8 @@ using namespace hw;
 //===----------------------------------------------------------------------===//
 
 namespace {
-/// Lower a verif::AssertOp operation with an i1 operand to a smt::AssertOp.
+/// Lower a verif::AssertOp operation with an i1 operand to a smt::AssertOp,
+/// negated to check for unsatisfiability.
 struct VerifAssertOpConversion : OpConversionPattern<verif::AssertOp> {
   using OpConversionPattern<verif::AssertOp>::OpConversionPattern;
 
@@ -40,9 +46,72 @@ struct VerifAssertOpConversion : OpConversionPattern<verif::AssertOp> {
     Value cond = typeConverter->materializeTargetConversion(
         rewriter, op.getLoc(), smt::BoolType::get(getContext()),
         adaptor.getProperty());
+    Value notCond = rewriter.create<smt::NotOp>(op.getLoc(), cond);
+    rewriter.replaceOpWithNewOp<smt::AssertOp>(op, notCond);
+    return success();
+  }
+};
+
+/// Lower a verif::AssumeOp operation with an i1 operand to a smt::AssertOp
+struct VerifAssumeOpConversion : OpConversionPattern<verif::AssumeOp> {
+  using OpConversionPattern<verif::AssumeOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(verif::AssumeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value cond = typeConverter->materializeTargetConversion(
+        rewriter, op.getLoc(), smt::BoolType::get(getContext()),
+        adaptor.getProperty());
     rewriter.replaceOpWithNewOp<smt::AssertOp>(op, cond);
     return success();
   }
+};
+
+// Fail to convert unsupported verif ops to avoid silent failure
+struct VerifCoverOpConversion : OpConversionPattern<verif::CoverOp> {
+  using OpConversionPattern<verif::CoverOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(verif::CoverOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    return op.emitError("Conversion of CoverOps to SMT not yet supported");
+  };
+};
+
+struct VerifClockedAssertOpConversion
+    : OpConversionPattern<verif::ClockedAssertOp> {
+  using OpConversionPattern<verif::ClockedAssertOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(verif::ClockedAssertOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    return op.emitError(
+        "Conversion of ClockedAssertOps to SMT not yet supported");
+  };
+};
+
+struct VerifClockedCoverOpConversion
+    : OpConversionPattern<verif::ClockedCoverOp> {
+  using OpConversionPattern<verif::ClockedCoverOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(verif::ClockedCoverOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    return op.emitError(
+        "Conversion of ClockedCoverOps to SMT not yet supported");
+  };
+};
+
+struct VerifClockedAssumeOpConversion
+    : OpConversionPattern<verif::ClockedAssumeOp> {
+  using OpConversionPattern<verif::ClockedAssumeOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(verif::ClockedAssumeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    return op.emitError(
+        "Conversion of ClockedAssumeOps to SMT not yet supported");
+  };
 };
 
 /// Lower a verif::LecOp operation to a miter circuit encoded in SMT.
@@ -146,6 +215,204 @@ struct LogicEquivalenceCheckingOpConversion
   }
 };
 
+/// Lower a verif::BMCOp operation to an MLIR program that performs the bounded
+/// model check
+struct VerifBoundedModelCheckingOpConversion
+    : OpConversionPattern<verif::BoundedModelCheckingOp> {
+  using OpConversionPattern<verif::BoundedModelCheckingOp>::OpConversionPattern;
+
+  VerifBoundedModelCheckingOpConversion(TypeConverter &converter,
+                                        MLIRContext *context, Namespace &names)
+      : OpConversionPattern(converter, context), names(names) {}
+
+  LogicalResult
+  matchAndRewrite(verif::BoundedModelCheckingOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    SmallVector<Type> oldLoopInputTy(op.getLoop().getArgumentTypes());
+    SmallVector<Type> oldCircuitInputTy(op.getCircuit().getArgumentTypes());
+    SmallVector<Type> loopInputTy, circuitInputTy, initOutputTy, loopOutputTy,
+        circuitOutputTy;
+    if (failed(typeConverter->convertTypes(oldLoopInputTy, loopInputTy)))
+      return failure();
+    if (failed(typeConverter->convertTypes(oldCircuitInputTy, circuitInputTy)))
+      return failure();
+    if (failed(typeConverter->convertTypes(
+            op.getInit().front().back().getOperandTypes(), initOutputTy)))
+      return failure();
+    // loop and init should have same output types
+    loopOutputTy = initOutputTy;
+    if (failed(typeConverter->convertTypes(
+            op.getCircuit().front().back().getOperandTypes(), circuitOutputTy)))
+      return failure();
+    if (failed(rewriter.convertRegionTypes(&op.getInit(), *typeConverter)))
+      return failure();
+    if (failed(rewriter.convertRegionTypes(&op.getLoop(), *typeConverter)))
+      return failure();
+    if (failed(rewriter.convertRegionTypes(&op.getCircuit(), *typeConverter)))
+      return failure();
+
+    unsigned numRegs =
+        cast<IntegerAttr>(op->getAttr("num_regs")).getValue().getZExtValue();
+
+    auto initFuncTy = rewriter.getFunctionType({}, initOutputTy);
+    auto loopFuncTy = rewriter.getFunctionType(loopInputTy, loopOutputTy);
+    auto circuitFuncTy =
+        rewriter.getFunctionType(circuitInputTy, circuitOutputTy);
+
+    func::FuncOp initFuncOp, loopFuncOp, circuitFuncOp;
+
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToEnd(
+          op->getParentOfType<ModuleOp>().getBody());
+      initFuncOp = rewriter.create<func::FuncOp>(loc, names.newName("bmc_init"),
+                                                 initFuncTy);
+      rewriter.inlineRegionBefore(op.getInit(), initFuncOp.getFunctionBody(),
+                                  initFuncOp.end());
+      loopFuncOp = rewriter.create<func::FuncOp>(loc, names.newName("bmc_loop"),
+                                                 loopFuncTy);
+      rewriter.inlineRegionBefore(op.getLoop(), loopFuncOp.getFunctionBody(),
+                                  loopFuncOp.end());
+      circuitFuncOp = rewriter.create<func::FuncOp>(
+          loc, names.newName("bmc_circuit"), circuitFuncTy);
+      rewriter.inlineRegionBefore(op.getCircuit(),
+                                  circuitFuncOp.getFunctionBody(),
+                                  circuitFuncOp.end());
+      auto funcOps = {&initFuncOp, &loopFuncOp, &circuitFuncOp};
+      auto outputTys = {initOutputTy, loopOutputTy, circuitOutputTy};
+      for (auto [funcOp, outputTy] : llvm::zip(funcOps, outputTys)) {
+        auto operands = funcOp->getBody().front().back().getOperands();
+        rewriter.eraseOp(&funcOp->getFunctionBody().front().back());
+        rewriter.setInsertionPointToEnd(&funcOp->getBody().front());
+        SmallVector<Value> toReturn;
+        for (unsigned i = 0; i < outputTy.size(); ++i)
+          toReturn.push_back(typeConverter->materializeTargetConversion(
+              rewriter, loc, outputTy[i], operands[i]));
+        rewriter.create<func::ReturnOp>(loc, toReturn);
+      }
+    }
+
+    auto solver =
+        rewriter.create<smt::SolverOp>(loc, rewriter.getI1Type(), ValueRange{});
+    rewriter.createBlock(&solver.getBodyRegion());
+
+    // Call init func to get initial clock values
+    ValueRange initVals =
+        rewriter.create<func::CallOp>(loc, initFuncOp)->getResults();
+
+    // InputDecls order should be <circuit arguments> <state arguments>
+    // <wasViolated>
+    // Get list of clock indexes in circuit args
+    size_t initIndex = 0, curIndex = 0;
+    SmallVector<Value> inputDecls;
+    SmallVector<int> clockIndexes;
+    for (auto [oldTy, newTy] :
+         llvm::zip(oldCircuitInputTy, circuitInputTy)) {
+      if (isa<seq::ClockType>(oldTy)) {
+        inputDecls.push_back(initVals[initIndex++]);
+        clockIndexes.push_back(curIndex);
+      }
+      else
+        inputDecls.push_back(rewriter.create<smt::DeclareFunOp>(loc, newTy));
+      curIndex++;
+    }
+
+    auto numStateArgs = initVals.size() - initIndex;
+    // Add the rest of the init vals (state args)
+    for (; initIndex < initVals.size(); ++initIndex)
+      inputDecls.push_back(initVals[initIndex]);
+
+    Value lowerBound =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getI32IntegerAttr(0));
+    Value step =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getI32IntegerAttr(1));
+    Value upperBound =
+        rewriter.create<arith::ConstantOp>(loc, adaptor.getBoundAttr());
+    Value constFalse =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(false));
+    Value constTrue =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(true));
+    inputDecls.push_back(constFalse); // wasViolated?
+
+    // TODO: swapping to a whileOp here would allow early exit once the property
+    // is violated
+    // Perform model check up to the provided bound
+    auto forOp = rewriter.create<scf::ForOp>(
+        loc, lowerBound, upperBound, step, inputDecls,
+        [&](OpBuilder &builder, Location loc, Value i, ValueRange iterArgs) {
+          // Execute the circuit
+          ValueRange circuitCallOuts =
+              builder
+                  .create<func::CallOp>(
+                      loc, circuitFuncOp,
+                      iterArgs.take_front(circuitFuncOp.getNumArguments()))
+                  ->getResults();
+          auto checkOp =
+              rewriter.create<smt::CheckOp>(loc, builder.getI1Type());
+          {
+            OpBuilder::InsertionGuard guard(builder);
+            builder.createBlock(&checkOp.getSatRegion());
+            builder.create<smt::YieldOp>(loc, constTrue);
+            builder.createBlock(&checkOp.getUnknownRegion());
+            builder.create<smt::YieldOp>(loc, constTrue);
+            builder.createBlock(&checkOp.getUnsatRegion());
+            builder.create<smt::YieldOp>(loc, constFalse);
+          }
+
+          Value violated = builder.create<arith::OrIOp>(
+              loc, checkOp.getResult(0), iterArgs.back());
+
+          SmallVector<Value> newDecls;
+
+          // Call loop func to update clock & state arg values
+          SmallVector<Value> loopCallInputs;
+          // Get all clock inputs to module
+          // for (auto arg :
+          //      iterArgs.take_front(circuitFuncOp.getNumArguments())) {
+          // }
+          for (auto index: clockIndexes) {
+            loopCallInputs.push_back(iterArgs[index]);
+          }
+          for (auto stateArg: iterArgs.drop_back().take_back(numStateArgs)) {
+            loopCallInputs.push_back(stateArg);
+          }
+          ValueRange loopVals =
+              builder
+                  .create<func::CallOp>(loc, loopFuncOp, loopCallInputs)
+                  ->getResults();
+
+          size_t loopIndex = 0;
+          for (auto [oldTy, newTy] :
+               llvm::zip(TypeRange(oldCircuitInputTy).drop_back(numRegs),
+                         TypeRange(circuitInputTy).drop_back(numRegs))) {
+            if (isa<seq::ClockType>(oldTy))
+              newDecls.push_back(loopVals[loopIndex++]);
+            else
+              newDecls.push_back(builder.create<smt::DeclareFunOp>(loc, newTy));
+          }
+          newDecls.append(
+              SmallVector<Value>(circuitCallOuts.take_back(numRegs)));
+
+          // Add the rest of the loop state args
+          for (; loopIndex < loopVals.size(); ++loopIndex)
+            newDecls.push_back(loopVals[loopIndex]);
+
+          newDecls.push_back(violated);
+
+          builder.create<scf::YieldOp>(loc, newDecls);
+        });
+
+    Value res = rewriter.create<arith::XOrIOp>(loc, forOp->getResults().back(),
+                                               constTrue);
+    rewriter.create<smt::YieldOp>(loc, res);
+    rewriter.replaceOp(op, solver.getResults());
+    return success();
+  }
+
+  Namespace &names;
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -160,21 +427,33 @@ struct ConvertVerifToSMTPass
 } // namespace
 
 void circt::populateVerifToSMTConversionPatterns(TypeConverter &converter,
-                                                 RewritePatternSet &patterns) {
-  patterns.add<VerifAssertOpConversion, LogicEquivalenceCheckingOpConversion>(
-      converter, patterns.getContext());
+                                                 RewritePatternSet &patterns,
+                                                 Namespace &names) {
+  patterns.add<VerifAssertOpConversion, VerifAssumeOpConversion,
+               VerifCoverOpConversion, VerifClockedAssertOpConversion,
+               VerifClockedAssumeOpConversion, VerifClockedCoverOpConversion,
+               LogicEquivalenceCheckingOpConversion>(converter,
+                                                     patterns.getContext());
+  patterns.add<VerifBoundedModelCheckingOpConversion>(
+      converter, patterns.getContext(), names);
 }
 
 void ConvertVerifToSMTPass::runOnOperation() {
   ConversionTarget target(getContext());
   target.addIllegalDialect<verif::VerifDialect>();
-  target.addLegalDialect<smt::SMTDialect, arith::ArithDialect>();
+  target.addLegalDialect<smt::SMTDialect, arith::ArithDialect, scf::SCFDialect,
+                         func::FuncDialect>();
   target.addLegalOp<UnrealizedConversionCastOp>();
 
   RewritePatternSet patterns(&getContext());
   TypeConverter converter;
   populateHWToSMTTypeConverter(converter);
-  populateVerifToSMTConversionPatterns(converter, patterns);
+
+  SymbolCache symCache;
+  symCache.addDefinitions(getOperation());
+  Namespace names;
+  names.add(symCache);
+  populateVerifToSMTConversionPatterns(converter, patterns, names);
 
   if (failed(mlir::applyPartialConversion(getOperation(), target,
                                           std::move(patterns))))

--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -67,53 +67,6 @@ struct VerifAssumeOpConversion : OpConversionPattern<verif::AssumeOp> {
   }
 };
 
-// Fail to convert unsupported verif ops to avoid silent failure
-struct VerifCoverOpConversion : OpConversionPattern<verif::CoverOp> {
-  using OpConversionPattern<verif::CoverOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(verif::CoverOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    return op.emitError("Conversion of CoverOps to SMT not yet supported");
-  };
-};
-
-struct VerifClockedAssertOpConversion
-    : OpConversionPattern<verif::ClockedAssertOp> {
-  using OpConversionPattern<verif::ClockedAssertOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(verif::ClockedAssertOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    return op.emitError(
-        "Conversion of ClockedAssertOps to SMT not yet supported");
-  };
-};
-
-struct VerifClockedCoverOpConversion
-    : OpConversionPattern<verif::ClockedCoverOp> {
-  using OpConversionPattern<verif::ClockedCoverOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(verif::ClockedCoverOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    return op.emitError(
-        "Conversion of ClockedCoverOps to SMT not yet supported");
-  };
-};
-
-struct VerifClockedAssumeOpConversion
-    : OpConversionPattern<verif::ClockedAssumeOp> {
-  using OpConversionPattern<verif::ClockedAssumeOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(verif::ClockedAssumeOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    return op.emitError(
-        "Conversion of ClockedAssumeOps to SMT not yet supported");
-  };
-};
-
 /// Lower a verif::LecOp operation to a miter circuit encoded in SMT.
 /// More information on miter circuits can be found, e.g., in this paper:
 /// Brand, D., 1993, November. Verification of large synthesized designs. In
@@ -430,8 +383,6 @@ void circt::populateVerifToSMTConversionPatterns(TypeConverter &converter,
                                                  RewritePatternSet &patterns,
                                                  Namespace &names) {
   patterns.add<VerifAssertOpConversion, VerifAssumeOpConversion,
-               VerifCoverOpConversion, VerifClockedAssertOpConversion,
-               VerifClockedAssumeOpConversion, VerifClockedCoverOpConversion,
                LogicEquivalenceCheckingOpConversion>(converter,
                                                      patterns.getContext());
   patterns.add<VerifBoundedModelCheckingOpConversion>(

--- a/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
@@ -53,6 +53,12 @@ func.func @multiple_asserting_modules_bmc() -> (i1) {
   func.return %bmc : i1
 }
 
+hw.module @OneAssertion(in %x: i1) {
+  verif.assert %x : i1
+}
+
+// -----
+
 func.func @two_separated_assertions() -> (i1) {
   // expected-error @below {{bounded model checking problems with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
   %bmc = verif.bmc bound 10 num_regs 1

--- a/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
@@ -15,3 +15,68 @@ func.func @assert_with_unsupported_property_type(%arg0: !smt.bv<1>) {
   verif.assert %0 : !ltl.property
   return
 }
+
+// -----
+
+func.func @multiple_assertions_bmc() -> (i1) {
+  // expected-error @below {{designs with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
+  // expected-error @below {{failed to legalize operation 'verif.bmc' that was explicitly marked illegal}}
+  %bmc = verif.bmc bound 10 num_regs 1
+  init {}
+  loop {}
+  circuit {
+  ^bb0(%arg0: i32, %arg1: i32):
+    %c1_i32 = hw.constant 1 : i32
+    %cond1 = comb.icmp ugt %arg0, %c1_i32 : i32
+    verif.assert %cond1 : i1
+    %cond2 = comb.icmp ugt %arg1, %c1_i32 : i32
+    verif.assert %cond2 : i1
+    %sum = comb.add %arg0, %arg1 : i32
+    verif.yield %sum : i32
+  }
+  func.return %bmc : i1
+}
+
+// -----
+
+func.func @multiple_asserting_modules_bmc() -> (i1) {
+  // expected-error @below {{designs with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
+  // expected-error @below {{failed to legalize operation 'verif.bmc' that was explicitly marked illegal}}
+  %bmc = verif.bmc bound 10 num_regs 1
+  init {}
+  loop {}
+  circuit {
+  ^bb0(%arg0: i32, %arg1: i1, %arg2: i1):
+    hw.instance "" @OneAssertion(x: %arg1: i1) -> ()
+    hw.instance "" @OneAssertion(x: %arg2: i1) -> ()
+    %sum = comb.add %arg0, %arg0 : i32
+    verif.yield %sum : i32
+  }
+  func.return %bmc : i1
+}
+
+hw.module @OneAssertion(in %x: i1) {
+  verif.assert %x : i1
+}
+
+// -----
+
+func.func @multiple_nested_assertions() -> (i1) {
+  // expected-error @below {{designs with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
+  // expected-error @below {{failed to legalize operation 'verif.bmc' that was explicitly marked illegal}}
+  %bmc = verif.bmc bound 10 num_regs 1
+  init {}
+  loop {}
+  circuit {
+  ^bb0(%arg0: i32, %arg1: i1, %arg2: i1):
+    hw.instance "" @TwoAssertions(x: %arg1: i1, y: %arg2: i1) -> ()
+    %sum = comb.add %arg0, %arg0 : i32
+    verif.yield %sum : i32
+  }
+  func.return %bmc : i1
+}
+
+hw.module @TwoAssertions(in %x: i1, in %y: i1) {
+  verif.assert %x : i1
+  verif.assert %y : i1
+}

--- a/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
@@ -19,8 +19,7 @@ func.func @assert_with_unsupported_property_type(%arg0: !smt.bv<1>) {
 // -----
 
 func.func @multiple_assertions_bmc() -> (i1) {
-  // expected-error @below {{designs with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
-  // expected-error @below {{failed to legalize operation 'verif.bmc' that was explicitly marked illegal}}
+  // expected-error @below {{bounded model checking problems with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
   %bmc = verif.bmc bound 10 num_regs 1
   init {}
   loop {}
@@ -40,8 +39,7 @@ func.func @multiple_assertions_bmc() -> (i1) {
 // -----
 
 func.func @multiple_asserting_modules_bmc() -> (i1) {
-  // expected-error @below {{designs with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
-  // expected-error @below {{failed to legalize operation 'verif.bmc' that was explicitly marked illegal}}
+  // expected-error @below {{bounded model checking problems with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
   %bmc = verif.bmc bound 10 num_regs 1
   init {}
   loop {}
@@ -55,6 +53,21 @@ func.func @multiple_asserting_modules_bmc() -> (i1) {
   func.return %bmc : i1
 }
 
+func.func @two_separated_assertions() -> (i1) {
+  // expected-error @below {{bounded model checking problems with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
+  %bmc = verif.bmc bound 10 num_regs 1
+  init {}
+  loop {}
+  circuit {
+  ^bb0(%arg0: i32, %arg1: i1, %arg2: i1):
+    hw.instance "" @OneAssertion(x: %arg1: i1) -> ()
+    verif.assert %arg2 : i1
+    %sum = comb.add %arg0, %arg0 : i32
+    verif.yield %sum : i32
+  }
+  func.return %bmc : i1
+}
+
 hw.module @OneAssertion(in %x: i1) {
   verif.assert %x : i1
 }
@@ -62,8 +75,7 @@ hw.module @OneAssertion(in %x: i1) {
 // -----
 
 func.func @multiple_nested_assertions() -> (i1) {
-  // expected-error @below {{designs with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
-  // expected-error @below {{failed to legalize operation 'verif.bmc' that was explicitly marked illegal}}
+  // expected-error @below {{bounded model checking problems with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
   %bmc = verif.bmc bound 10 num_regs 1
   init {}
   loop {}

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -116,12 +116,6 @@ func.func @test_lec(%arg0: !smt.bv<1>) -> (i1, i1, i1) {
 // CHECK:    [[CN1_I32:%.+]] = hw.constant -1 : i32
 // CHECK:    [[ADD:%.+]] = comb.add [[C7]], [[C6]]
 // CHECK:    [[XOR:%.+]] = comb.xor [[C6]], [[CN1_I32]]
-// CHECK:    [[FALSE:%.+]] = hw.constant false
-// CHECK:    [[C8:%.+]] = builtin.unrealized_conversion_cast [[FALSE]] : i1 to !smt.bv<1>
-// CHECK:    [[CN1_BV:%.+]] = smt.bv.constant #smt.bv<-1> : !smt.bv<1>
-// CHECK:    [[EQ:%.+]] = smt.eq [[C8]], [[CN1_BV]]
-// CHECK:    [[NOT:%.+]] = smt.not [[EQ]]
-// CHECK:    smt.assert [[NOT]]
 // CHECK:    [[C9:%.+]] = builtin.unrealized_conversion_cast [[XOR]] : i32 to !smt.bv<32>
 // CHECK:    [[C10:%.+]] = builtin.unrealized_conversion_cast [[ADD]] : i32 to !smt.bv<32>
 // CHECK:    return [[C9]], [[C10]]
@@ -149,9 +143,6 @@ func.func @test_bmc() -> (i1) {
     %0 = comb.add %arg0, %state0 : i32
     // %state0 is the result of a seq.compreg taking %0 as input
     %2 = comb.xor %state0, %c-1_i32 : i32
-    %false = hw.constant false
-    // Arbitrary assertion so op verifies
-    verif.assert %false : i1
     verif.yield %2, %0 : i32, i32
   }
   func.return %bmc : i1

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -1,12 +1,13 @@
 // RUN: circt-opt %s --convert-verif-to-smt --reconcile-unrealized-casts -allow-unregistered-dialect | FileCheck %s
 
-// CHECK-LABEL: func @test
+// CHECK-LABEL: func @test_lec
 // CHECK-SAME:  ([[ARG0:%.+]]: !smt.bv<1>)
-func.func @test(%arg0: !smt.bv<1>) -> (i1, i1, i1) {
+func.func @test_lec(%arg0: !smt.bv<1>) -> (i1, i1, i1) {
   %0 = builtin.unrealized_conversion_cast %arg0 : !smt.bv<1> to i1
   // CHECK: [[C0:%.+]] = smt.bv.constant #smt.bv<-1> : !smt.bv<1>
   // CHECK: [[V0:%.+]] = smt.eq %arg0, [[C0]] : !smt.bv<1>
-  // CHECK: smt.assert [[V0]]
+  // CHECK: [[V1:%.+]] = smt.not [[V0]]
+  // CHECK: smt.assert [[V1]]
   verif.assert %0 : i1
 
   // CHECK: [[EQ:%.+]] = smt.solver() : () -> i1
@@ -59,4 +60,99 @@ func.func @test(%arg0: !smt.bv<1>) -> (i1, i1, i1) {
 
   // CHECK: return [[EQ]], [[EQ2]], %true
   return %1, %2, %3 : i1, i1, i1
+}
+
+// CHECK-LABEL:  func.func @test_bmc() -> i1 {
+// CHECK:    [[BMC:%.+]] = smt.solver
+// CHECK:      [[INIT:%.+]]:2 = func.call @bmc_init()
+// CHECK:      [[F0:%.+]] = smt.declare_fun : !smt.bv<32>
+// CHECK:      [[F1:%.+]] = smt.declare_fun : !smt.bv<32>
+// CHECK:      [[C0_I32:%.+]] = arith.constant 0 : i32
+// CHECK:      [[C1_I32:%.+]] = arith.constant 1 : i32
+// CHECK:      [[C10_I32:%.+]] = arith.constant 10 : i32
+// CHECK:      [[FALSE:%.+]] = arith.constant false
+// CHECK:      [[TRUE:%.+]] = arith.constant true
+// CHECK:      [[FOR:%.+]]:5 = scf.for [[ARG0:%.+]] = [[C0_I32]] to [[C10_I32]] step [[C1_I32]] iter_args([[ARG1:%.+]] = [[INIT]]#0, [[ARG2:%.+]] = [[F0]], [[ARG3:%.+]] = [[F1]], [[ARG4:%.+]] = [[INIT]]#1, [[ARG5:%.+]] = [[FALSE]])
+// CHECK:        [[CIRCUIT:%.+]]:2 = func.call @bmc_circuit([[ARG1]], [[ARG2]], [[ARG3]])
+// CHECK:        [[SMTCHECK:%.+]] = smt.check sat {
+// CHECK:          smt.yield [[TRUE]]
+// CHECK:        } unknown {
+// CHECK:          smt.yield [[TRUE]]
+// CHECK:        } unsat {
+// CHECK:          smt.yield [[FALSE]]
+// CHECK:        }
+// CHECK:        [[ORI:%.+]] = arith.ori [[SMTCHECK]], [[ARG5]]
+// CHECK:        [[LOOP:%.+]]:2 = func.call @bmc_loop([[ARG1]], [[ARG4]])
+// CHECK:        [[F2:%.+]] = smt.declare_fun : !smt.bv<32>
+// CHECK:        scf.yield [[LOOP]]#0, [[F2]], [[CIRCUIT]]#1, [[LOOP]]#1, [[ORI]]
+// CHECK:      }
+// CHECK:      [[XORI:%.+]] = arith.xori [[FOR]]#4, [[TRUE]]
+// CHECK:      smt.yield [[XORI]]
+// CHECK:    }
+// CHECK:    return [[BMC]]
+// CHECK:  }
+// CHECK-LABEL:  func.func @bmc_init() -> (!smt.bv<1>, !smt.bv<1>) {
+// CHECK:    [[FALSE:%.+]] = hw.constant false
+// CHECK:    [[TOCLOCK:%.+]] = seq.to_clock %false
+// CHECK:    [[C0:%.+]] = builtin.unrealized_conversion_cast [[TOCLOCK]] : !seq.clock to !smt.bv<1>
+// CHECK:    [[C1:%.+]] = builtin.unrealized_conversion_cast [[FALSE]] : i1 to !smt.bv<1>
+// CHECK:    return [[C0]], [[C1]]
+// CHECK:  }
+// CHECK:  func.func @bmc_loop([[ARGO:%.+]]: !smt.bv<1>, [[ARG1:%.+]]: !smt.bv<1>)
+// CHECK:    [[C2:%.+]] = builtin.unrealized_conversion_cast [[ARG1]] : !smt.bv<1> to i1
+// CHECK:    [[C3:%.+]] = builtin.unrealized_conversion_cast [[ARG0]] : !smt.bv<1> to !seq.clock
+// CHECK:    [[FROMCLOCK:%.+]] = seq.from_clock [[C3]]
+// CHECK:    [[TRUE]] = hw.constant true
+// CHECK:    [[NCLOCK:%.+]] = comb.xor [[FROMCLOCK]], [[TRUE]]
+// CHECK:    [[NARG:%.+]] = comb.xor [[C2]], [[TRUE]]
+// CHECK:    [[TOCLOCK:%.+]] = seq.to_clock [[NCLOCK]]
+// CHECK:    [[C4:%.+]] = builtin.unrealized_conversion_cast [[TOCLOCK]] : !seq.clock to !smt.bv<1>
+// CHECK:    [[C5:%.+]] = builtin.unrealized_conversion_cast [[NARG]] : i1 to !smt.bv<1>
+// CHECK:    return [[C4]], [[C5]]
+// CHECK:  }
+// CHECK:  func.func @bmc_circuit([[ARGO:%.+]]: !smt.bv<1>, [[ARG1:%.+]]: !smt.bv<32>, [[ARG2:%.+]]: !smt.bv<32>)
+// CHECK:    [[C6:%.+]] = builtin.unrealized_conversion_cast [[ARG2]] : !smt.bv<32> to i32
+// CHECK:    [[C7:%.+]] = builtin.unrealized_conversion_cast [[ARG1]] : !smt.bv<32> to i32
+// CHECK:    [[CN1_I32:%.+]] = hw.constant -1 : i32
+// CHECK:    [[ADD:%.+]] = comb.add [[C7]], [[C6]]
+// CHECK:    [[XOR:%.+]] = comb.xor [[C6]], [[CN1_I32]]
+// CHECK:    [[FALSE:%.+]] = hw.constant false
+// CHECK:    [[C8:%.+]] = builtin.unrealized_conversion_cast [[FALSE]] : i1 to !smt.bv<1>
+// CHECK:    [[CN1_BV:%.+]] = smt.bv.constant #smt.bv<-1> : !smt.bv<1>
+// CHECK:    [[EQ:%.+]] = smt.eq [[C8]], [[CN1_BV]]
+// CHECK:    [[NOT:%.+]] = smt.not [[EQ]]
+// CHECK:    smt.assert [[NOT]]
+// CHECK:    [[C9:%.+]] = builtin.unrealized_conversion_cast [[XOR]] : i32 to !smt.bv<32>
+// CHECK:    [[C10:%.+]] = builtin.unrealized_conversion_cast [[ADD]] : i32 to !smt.bv<32>
+// CHECK:    return [[C9]], [[C10]]
+// CHECK:  }
+
+func.func @test_bmc() -> (i1) {
+  %bmc = verif.bmc bound 10 num_regs 1
+  init {
+    %c0_i1 = hw.constant 0 : i1
+    %clk = seq.to_clock %c0_i1
+    verif.yield %clk, %c0_i1 : !seq.clock, i1
+  }
+  loop {
+    ^bb0(%clk: !seq.clock, %stateArg: i1):
+    %from_clock = seq.from_clock %clk
+    %c-1_i1 = hw.constant -1 : i1
+    %neg_clock = comb.xor %from_clock, %c-1_i1 : i1
+    %newStateArg = comb.xor %stateArg, %c-1_i1 : i1
+    %newclk = seq.to_clock %neg_clock
+    verif.yield %newclk, %newStateArg : !seq.clock, i1
+  }
+  circuit {
+  ^bb0(%clk: !seq.clock, %arg0: i32, %state0: i32):
+    %c-1_i32 = hw.constant -1 : i32
+    %0 = comb.add %arg0, %state0 : i32
+    // %state0 is the result of a seq.compreg taking %0 as input
+    %2 = comb.xor %state0, %c-1_i32 : i32
+    %false = hw.constant false
+    // Arbitrary assertion so op verifies
+    verif.assert %false : i1
+    verif.yield %2, %0 : i32, i32
+  }
+  func.return %bmc : i1
 }

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -1,5 +1,30 @@
 // RUN: circt-opt %s --convert-verif-to-smt --reconcile-unrealized-casts -allow-unregistered-dialect | FileCheck %s
 
+// CHECK: func.func @lower_assert([[ARG0:%.+]]: i1)
+// CHECK:   [[CAST:%.+]] = builtin.unrealized_conversion_cast [[ARG0]] : i1 to !smt.bv<1>
+// CHECK:   [[Cn1_BV:%.+]] = smt.bv.constant #smt.bv<-1>
+// CHECK:   [[EQ:%.+]] = smt.eq [[CAST]], [[Cn1_BV]]
+// CHECK:   [[NEQ:%.+]] = smt.not [[EQ]]
+// CHECK:   smt.assert [[NEQ]]
+// CHECK:   return
+
+func.func @lower_assert(%arg0: i1) {
+  verif.assert %arg0 : i1
+  return
+}
+
+// CHECK: func.func @lower_assume([[ARG0:%.+]]: i1)
+// CHECK:   [[CAST:%.+]] = builtin.unrealized_conversion_cast [[ARG0]] : i1 to !smt.bv<1>
+// CHECK:   [[Cn1_BV:%.+]] = smt.bv.constant #smt.bv<-1>
+// CHECK:   [[EQ:%.+]] = smt.eq [[CAST]], [[Cn1_BV]]
+// CHECK:   smt.assert [[EQ]]
+// CHECK:   return
+
+func.func @lower_assume(%arg0: i1) {
+  verif.assume %arg0 : i1
+  return
+}
+
 // CHECK-LABEL: func @test_lec
 // CHECK-SAME:  ([[ARG0:%.+]]: !smt.bv<1>)
 func.func @test_lec(%arg0: !smt.bv<1>) -> (i1, i1, i1) {


### PR DESCRIPTION
This PR adds a pattern to lower the `verif.bmc` op into the program to actually perform the check (from the splitting up of #7259 - only the actual tool left after this!), similarly to what circt-lec currently does.