### PR TITLE
[Arc] Fully support initialization through seq.initial

### DIFF
--- a/integration_test/arcilator/JIT/reg.mlir
+++ b/integration_test/arcilator/JIT/reg.mlir
@@ -1,0 +1,66 @@
+// RUN: arcilator %s --run --jit-entry=main | FileCheck %s
+// REQUIRES: arcilator-jit
+
+// CHECK: o1 = 10
+// CHECK-NEXT: o2 = 5
+// CHECK-NEXT: o1 = 11
+// CHECK-NEXT: o2 = 6
+// CHECK-NEXT: o1 = 12
+// CHECK-NEXT: o2 = 7
+
+func.func private @random() -> i32 {
+  %0 = arith.constant 16 : i32
+  func.return %0: i32
+}
+
+hw.module @counter(in %clk: i1, out o1: i8, out o2: i8) {
+  %seq_clk = seq.to_clock %clk
+  %c0_i8 = hw.constant 0 : i8
+
+  %r0 = seq.compreg %added1, %seq_clk initial %0#0 : i8
+  %r1 = seq.compreg %added2, %seq_clk initial %0#1 : i8
+  %0:2 = seq.initial {
+    %1 = func.call @random() : () -> i32
+    %2 = comb.extract %1 from 0 : (i32) -> i8
+    %3 = hw.constant 5 : i8
+    seq.yield %2, %3: i8, i8
+  } : !seq.immutable<i8>, !seq.immutable<i8>
+
+  %one = hw.constant 1 : i8
+  %added1 = comb.add %r0, %one : i8
+  %added2 = comb.add %r1, %one : i8
+
+  hw.output %r0, %r1 : i8, i8
+}
+
+func.func @main() {
+  %zero = arith.constant 0 : i1
+  %one = arith.constant 1 : i1
+  %lb = arith.constant 0 : index
+  %ub = arith.constant 2 : index
+  %step = arith.constant 1 : index
+
+  arc.sim.instantiate @counter as %model {
+    %init_val1 = arc.sim.get_port %model, "o1" : i8, !arc.sim.instance<@counter>
+    %init_val2 = arc.sim.get_port %model, "o2" : i8, !arc.sim.instance<@counter>
+
+    arc.sim.emit "o1", %init_val1 : i8
+    arc.sim.emit "o2", %init_val2 : i8
+
+    scf.for %i = %lb to %ub step %step {
+      arc.sim.set_input %model, "clk" = %one : i1, !arc.sim.instance<@counter>
+      arc.sim.step %model : !arc.sim.instance<@counter>
+      arc.sim.set_input %model, "clk" = %zero : i1, !arc.sim.instance<@counter>
+      arc.sim.step %model : !arc.sim.instance<@counter>
+
+      %counter_val1 = arc.sim.get_port %model, "o1" : i8, !arc.sim.instance<@counter>
+      arc.sim.emit "o1", %counter_val1 : i8
+
+      %counter_val2 = arc.sim.get_port %model, "o2" : i8, !arc.sim.instance<@counter>
+      arc.sim.emit "o2", %counter_val2 : i8
+
+    }
+  }
+
+  return
+}

--- a/integration_test/arcilator/JIT/reg.mlir
+++ b/integration_test/arcilator/JIT/reg.mlir
@@ -1,15 +1,15 @@
 // RUN: arcilator %s --run --jit-entry=main | FileCheck %s
 // REQUIRES: arcilator-jit
 
-// CHECK: o1 = 10
+// CHECK: o1 = 2
 // CHECK-NEXT: o2 = 5
-// CHECK-NEXT: o1 = 11
+// CHECK-NEXT: o1 = 3
 // CHECK-NEXT: o2 = 6
-// CHECK-NEXT: o1 = 12
+// CHECK-NEXT: o1 = 4
 // CHECK-NEXT: o2 = 7
 
 func.func private @random() -> i32 {
-  %0 = arith.constant 16 : i32
+  %0 = arith.constant 2 : i32
   func.return %0: i32
 }
 

--- a/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
+++ b/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
@@ -100,9 +100,8 @@ LogicalResult Converter::runOnModule(HWModuleOp module) {
   arcBreakers.clear();
   arcBreakerIndices.clear();
   for (Operation &op : *module.getBodyBlock()) {
-    if (isa<seq::InitialOp>(&op)) {
+    if (isa<seq::InitialOp>(&op))
       continue;
-    }
     if (op.getNumRegions() > 0)
       return op.emitOpError("has regions; not supported by ConvertToArcs");
     if (!isArcBreakingOp(&op) && !isa<hw::OutputOp>(&op))

--- a/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
@@ -121,12 +121,18 @@ hw.module.extern private @Reshuffling2(out z0: i4, out z1: i4, out z2: i4, out z
 // CHECK-LABEL: hw.module @ReshufflingInit
 hw.module @ReshufflingInit(in %clockA: !seq.clock, in %clockB: !seq.clock, out z0: i4, out z1: i4, out z2: i4, out z3: i4) {
   // CHECK-NEXT: hw.instance "x" @Reshuffling2()
-  // CHECK-NEXT: [[C1:%.+]] = hw.constant 1 : i4
-  // CHECK-NEXT: [[C2:%.+]] = hw.constant 2 : i4
-  // CHECK-NEXT: [[C3:%.+]] = hw.constant 3 : i4
-  // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i4
-  // CHECK-NEXT: arc.state @ReshufflingInit_arc(%x.z0, %x.z1) clock %clockA initial ([[C0]], [[C1]] : i4, i4) latency 1
-  // CHECK-NEXT: arc.state @ReshufflingInit_arc_0(%x.z2, %x.z3) clock %clockB initial ([[C2]], [[C3]] : i4, i4) latency 1
+  // CHECK-NEXT:  %[[INITIAL:.+]]:3 = seq.initial {
+  // CHECK-NEXT:    %c1_i4 = hw.constant 1 : i4
+  // CHECK-NEXT:    %c2_i4 = hw.constant 2 : i4
+  // CHECK-NEXT:    %c3_i4 = hw.constant 3 : i4
+  // CHECK-NEXT:    seq.yield %c1_i4, %c2_i4, %c3_i4 : i4, i4, i4
+  // CHECK-NEXT:  } : !seq.immutable<i4>, !seq.immutable<i4>, !seq.immutable<i4>
+  // CHECK-NEXT: %[[C1:.+]] = builtin.unrealized_conversion_cast %[[INITIAL]]#0 : !seq.immutable<i4> to i4
+  // CHECK-NEXT: %[[C2:.+]] = builtin.unrealized_conversion_cast %[[INITIAL]]#1 : !seq.immutable<i4> to i4
+  // CHECK-NEXT: %[[C3:.+]] = builtin.unrealized_conversion_cast %[[INITIAL]]#2 : !seq.immutable<i4> to i4
+  // CHECK-NEXT: %[[C0:.+]] = hw.constant 0 : i4
+  // CHECK-NEXT: arc.state @ReshufflingInit_arc(%x.z0, %x.z1) clock %clockA initial (%[[C0]], %[[C1]] : i4, i4) latency 1
+  // CHECK-NEXT: arc.state @ReshufflingInit_arc_0(%x.z2, %x.z3) clock %clockB initial (%[[C2]], %[[C3]] : i4, i4) latency 1
   // CHECK-NEXT: hw.output
 
   %x.z0, %x.z1, %x.z2, %x.z3 = hw.instance "x" @Reshuffling2() -> (z0: i4, z1: i4, z2: i4, z3: i4)
@@ -236,8 +242,9 @@ hw.module @Trivial(in %clock: !seq.clock, in %i0: i4, in %reset: i1, out out: i4
 
 // CHECK-LABEL: hw.module @TrivialWithInit(
 hw.module @TrivialWithInit(in %clock: !seq.clock, in %i0: i4, in %reset: i1, out out: i4) {
-  // CHECK: [[CST2:%.+]] = hw.constant 2 : i4
-  // CHECK: [[RES0:%.+]] = arc.state @[[TRIVIALINIT_ARC]](%i0) clock %clock reset %reset initial ([[CST2]] : i4) latency 1 {names = ["foo"]
+  // CHECK:      %[[INIT:.+]] = seq.initial {
+  // CHECK: %[[CAST:.+]] = builtin.unrealized_conversion_cast %[[INIT]]
+  // CHECK: [[RES0:%.+]] = arc.state @[[TRIVIALINIT_ARC]](%i0) clock %clock reset %reset initial (%[[CAST]] : i4) latency 1 {names = ["foo"]
   // CHECK-NEXT: hw.output [[RES0:%.+]]
   %0 = hw.constant 0 : i4
   %init = seq.initial {

--- a/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
@@ -242,7 +242,7 @@ hw.module @Trivial(in %clock: !seq.clock, in %i0: i4, in %reset: i1, out out: i4
 
 // CHECK-LABEL: hw.module @TrivialWithInit(
 hw.module @TrivialWithInit(in %clock: !seq.clock, in %i0: i4, in %reset: i1, out out: i4) {
-  // CHECK:      %[[INIT:.+]] = seq.initial {
+  // CHECK: %[[INIT:.+]] = seq.initial {
   // CHECK: %[[CAST:.+]] = builtin.unrealized_conversion_cast %[[INIT]]
   // CHECK: [[RES0:%.+]] = arc.state @[[TRIVIALINIT_ARC]](%i0) clock %clock reset %reset initial (%[[CAST]] : i4) latency 1 {names = ["foo"]
   // CHECK-NEXT: hw.output [[RES0:%.+]]


### PR DESCRIPTION
This PR implements state initialization using `seq.initial` not limited to constants. Combined with https://github.com/llvm/circt/pull/7606 we can perform random initialization in arcilator