### PR TITLE
[SV] Add MacroRefOp to represet macro statement

### DIFF
--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -100,7 +100,7 @@ def VerbatimExprSEOp : SVOp<"verbatim.expr.se", [HasCustomSSAName]> {
   ];
 }
 
-def MacroRefExprOp : SVOp<"macro.ref", [Pure, HasCustomSSAName,
+def MacroRefExprOp : SVOp<"macro.ref.expr", [Pure, HasCustomSSAName,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Expression to refer to a SystemVerilog macro";
   let description = [{
@@ -127,7 +127,7 @@ def MacroRefExprOp : SVOp<"macro.ref", [Pure, HasCustomSSAName,
   }];
 }
 
-def MacroRefExprSEOp : SVOp<"macro.ref.se", [HasCustomSSAName,
+def MacroRefExprSEOp : SVOp<"macro.ref.expr.se", [HasCustomSSAName,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Expression to refer to a SystemVerilog macro";
   let description = [{

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -550,7 +550,7 @@ def MacroRefOp : SVOp<"macro.ref", [
   let summary = "Statement to refer to a SystemVerilog macro";
   let description = [{
     This operation represent a statement by referencing a named macro.
-    }];
+  }];
 
   let arguments = (ins FlatSymbolRefAttr:$macroName, Variadic<AnyType>:$inputs);
   let results = (outs);

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -545,6 +545,29 @@ def VerbatimOp : SVOp<"verbatim"> {
   ];
 }
 
+def MacroRefOp : SVOp<"macro.ref", [
+        DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = "Statement to refer to a SystemVerilog macro";
+  let description = [{
+    This operation represent a statement by referencing a named macro.
+    }];
+
+  let arguments = (ins FlatSymbolRefAttr:$macroName, Variadic<AnyType>:$inputs);
+  let results = (outs);
+
+  let assemblyFormat = "$macroName (`(` $inputs^ `)` `:` type($inputs))? attr-dict";
+
+  let builders = [
+    OpBuilder<(ins "StringRef":$ident),
+               "build(odsBuilder, odsState, "
+                "FlatSymbolRefAttr::get($_builder.getContext(), ident), {});">
+  ];
+
+  let extraClassDeclaration = [{
+    MacroDeclOp getReferencedMacro(const hw::HWSymbolCache *cache);
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Bind Statements
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -39,7 +39,7 @@ public:
             AlwaysCombOp, AlwaysFFOp, InitialOp, CaseOp,
             // Other Statements.
             AssignOp, BPAssignOp, PAssignOp, ForceOp, ReleaseOp, AliasOp,
-            FWriteOp, SystemFunctionOp, VerbatimOp, FuncCallOp,
+            FWriteOp, SystemFunctionOp, VerbatimOp, MacroRefOp, FuncCallOp,
             FuncCallProceduralOp, ReturnOp,
             // Type declarations.
             InterfaceOp, InterfaceSignalOp, InterfaceModportOp,
@@ -136,6 +136,7 @@ public:
   HANDLE(FuncCallOp, Unhandled);
   HANDLE(ReturnOp, Unhandled);
   HANDLE(VerbatimOp, Unhandled);
+  HANDLE(MacroRefOp, Unhandled);
 
   // Type declarations.
   HANDLE(InterfaceOp, Unhandled);

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -176,6 +176,10 @@ MacroDeclOp MacroDefOp::getReferencedMacro(const hw::HWSymbolCache *cache) {
   return ::getReferencedMacro(cache, *this, getMacroNameAttr());
 }
 
+MacroDeclOp MacroRefOp::getReferencedMacro(const hw::HWSymbolCache *cache) {
+  return ::getReferencedMacro(cache, *this, getMacroNameAttr());
+}
+
 /// Ensure that the symbol being instantiated exists and is a MacroDefOp.
 LogicalResult
 MacroRefExprOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
@@ -190,6 +194,11 @@ MacroRefExprSEOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
 /// Ensure that the symbol being instantiated exists and is a MacroDefOp.
 LogicalResult MacroDefOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  return verifyMacroIdentSymbolUses(*this, getMacroNameAttr(), symbolTable);
+}
+
+/// Ensure that the symbol being instantiated exists and is a MacroDefOp.
+LogicalResult MacroRefOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return verifyMacroIdentSymbolUses(*this, getMacroNameAttr(), symbolTable);
 }
 

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -256,7 +256,7 @@ hw.module @ForStatement(in %aaaaaaaaaaa: i5, in %xxxxxxxxxxxxxxx : i2, in %yyyyy
     // CHECK-NEXT:      _RANDOM[iiiiiiiiiiiiiiiiiiiiiiiii] = `RANDOM;{{.*}}
     // CHECK-NEXT:    end{{.*}}
     sv.for %iiiiiiiiiiiiiiiiiiiiiiiii = %lowerBound to %upperBound step %step : i2 {
-      %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
+      %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
       %index = sv.array_index_inout %_RANDOM[%iiiiiiiiiiiiiiiiiiiiiiiii] : !hw.inout<uarray<3xi32>>, i2
       sv.bpassign %index, %RANDOM : i32
     }

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -265,8 +265,12 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
       // CHECK-NEXT: $fwrite(32'h80000002, "M: %x\n", `MACRO(8'(val + 8'h2A), val ^ 8'h2A));
       sv.fwrite %fd, "M: %x\n"(%text) : i8
 
+      // CHECK-NEXT: `INIT_RANDOM
+      sv.macro.ref @INIT_RANDOM
       // CHECK-NEXT: `INIT_RANDOM(val)
       sv.macro.ref @INIT_RANDOM (%val) : i8
+      // CHECK-NEXT: `INIT_RANDOM(val, val, val)
+      sv.macro.ref @INIT_RANDOM (%val, %val, %val) : i8, i8, i8
 
     }// CHECK-NEXT:   {{end$}}
   } {sv.attributes = [#sv.attribute<"sv attr">]}

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -49,7 +49,7 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
     sv.ifdef.procedural @SYNTHESIS {
     } else {
   // CHECK-NEXT:     if ((`PRINTF_COND_) & 1'bx & 1'bz & 1'bz & cond & forceWire)
-      %tmp = sv.macro.ref @PRINTF_COND_() : () -> i1
+      %tmp = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
       %verb_tmp = sv.verbatim.expr "{{0}}" : () -> i1 {symbols = [#hw.innerNameRef<@M1::@wire1>] }
       %tmp1 = sv.constantX : i1
       %tmp2 = sv.constantZ : i1
@@ -264,6 +264,9 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
 
       // CHECK-NEXT: $fwrite(32'h80000002, "M: %x\n", `MACRO(8'(val + 8'h2A), val ^ 8'h2A));
       sv.fwrite %fd, "M: %x\n"(%text) : i8
+
+      // CHECK-NEXT: `INIT_RANDOM(val)
+      sv.macro.ref @INIT_RANDOM (%val) : i8
 
     }// CHECK-NEXT:   {{end$}}
   } {sv.attributes = [#sv.attribute<"sv attr">]}
@@ -1838,6 +1841,7 @@ hw.module @ConditionalComments() {
 
 sv.macro.decl @RANDOM
 sv.macro.decl @PRINTF_COND_
+sv.macro.decl @INIT_RANDOM
 
 // CHECK-LABEL: module ForStatement
 hw.module @ForStatement(in %a: i5) {
@@ -1851,7 +1855,7 @@ hw.module @ForStatement(in %a: i5) {
     // CHECK-NEXT:   _RANDOM[i] = `RANDOM;
     // CHECK-NEXT: end
     sv.for %i = %c0_i2 to %c-1_i2 step %c1_i2 : i2 {
-      %RANDOM = sv.macro.ref.se @RANDOM() : ()->i32
+      %RANDOM = sv.macro.ref.expr.se @RANDOM() : ()->i32
       %index = sv.array_index_inout %_RANDOM[%i] : !hw.inout<uarray<3xi32>>, i2
       sv.bpassign %index, %RANDOM : i32
     }

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -558,7 +558,7 @@ hw.module @Print(in %clock: i1, in %reset: i1, in %a: i4, in %b: i4) {
   %0 = comb.concat %false, %a : i1, i4
   %1 = comb.shl %0, %c1_i5 : i5
   sv.always posedge %clock  {
-    %2 = sv.macro.ref @PRINTF_COND_() : () -> i1
+    %2 = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
     %3 = comb.and %2, %reset : i1
     sv.if %3  {
       sv.fwrite %fd, "Hi %x %x\0A"(%1, %b) : i5, i4

--- a/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
+++ b/test/Conversion/FIRRTLToHW/emit-chisel-asserts-as-sva.mlir
@@ -17,7 +17,7 @@ firrtl.circuit "ifElseFatalToSVA" {
 
     // IF_ELSE_FATAL:       sv.always posedge [[CLK]] {
     // IF_ELSE_FATAL-NEXT:    sv.if {{%.+}} {
-    // IF_ELSE_FATAL-NEXT:      %ASSERT_VERBOSE_COND_ = sv.macro.ref @ASSERT_VERBOSE_COND_()
+    // IF_ELSE_FATAL-NEXT:      %ASSERT_VERBOSE_COND_ = sv.macro.ref.expr @ASSERT_VERBOSE_COND_()
     // IF_ELSE_FATAL-NEXT:      sv.if %ASSERT_VERBOSE_COND_ {
     // IF_ELSE_FATAL-NEXT:        sv.error "assert0"
     // IF_ELSE_FATAL-NEXT:      }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -344,19 +344,19 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK:      sv.ifdef @SYNTHESIS {
     // CHECK-NEXT: } else  {
     // CHECK-NEXT:   sv.always posedge [[CLOCK]] {
-    // CHECK-NEXT:     %PRINTF_COND_ = sv.macro.ref @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     %PRINTF_COND_ = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
     // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND_, %reset
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       [[FD:%.+]] = hw.constant -2147483646 : i32
     // CHECK-NEXT:       sv.fwrite [[FD]], "No operands!\0A"
     // CHECK-NEXT:     }
-    // CHECK-NEXT:     %PRINTF_COND__0 = sv.macro.ref @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     %PRINTF_COND__0 = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
     // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND__0, %reset : i1
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       [[FD:%.+]] = hw.constant -2147483646 : i32
     // CHECK-NEXT:       sv.fwrite [[FD]], "Hi %x %x\0A"([[ADD]], %b) : i5, i4
     // CHECK-NEXT:     }
-    // CHECK-NEXT:     %PRINTF_COND__1 = sv.macro.ref @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     %PRINTF_COND__1 = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
     // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND__1, %reset : i1
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       [[FD:%.+]] = hw.constant -2147483646 : i32
@@ -391,12 +391,12 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-LABEL: hw.module private @Stop
   // CHECK-SAME: attributes {emit.fragments = [@STOP_COND_FRAGMENT]}
   firrtl.module private @Stop(in %clock1: !firrtl.clock, in %clock2: !firrtl.clock, in %reset: !firrtl.uint<1>) {
-    // CHECK-NEXT: [[STOP_COND_1:%.+]] = sv.macro.ref @STOP_COND_
+    // CHECK-NEXT: [[STOP_COND_1:%.+]] = sv.macro.ref.expr @STOP_COND_
     // CHECK-NEXT: [[COND:%.+]] = comb.and bin [[STOP_COND_1]], %reset : i1
     // CHECK-NEXT: sim.fatal %clock1, [[COND]]
     firrtl.stop %clock1, %reset, 42 : !firrtl.clock, !firrtl.uint<1>
 
-    // CHECK-NEXT: [[STOP_COND_2:%.+]] = sv.macro.ref @STOP_COND_
+    // CHECK-NEXT: [[STOP_COND_2:%.+]] = sv.macro.ref.expr @STOP_COND_
     // CHECK-NEXT: [[COND:%.+]] = comb.and bin [[STOP_COND_2:%.+]], %reset : i1
     // CHECK-NEXT: sim.finish %clock2, [[COND]]
     firrtl.stop %clock2, %reset, 0 : !firrtl.clock, !firrtl.uint<1>
@@ -593,21 +593,21 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: } else {
     // CHECK-NEXT:   sv.always posedge [[CLOCK]] {
     // CHECK-NEXT:     sv.if [[TMP2]] {
-    // CHECK-NEXT:       [[ASSERT_VERBOSE_COND:%.+]] = sv.macro.ref @ASSERT_VERBOSE_COND_
+    // CHECK-NEXT:       [[ASSERT_VERBOSE_COND:%.+]] = sv.macro.ref.expr @ASSERT_VERBOSE_COND_
     // CHECK-NEXT:       sv.if [[ASSERT_VERBOSE_COND]] {
     // CHECK-NEXT:         sv.error "assert1 %d, %d"(%value, %false) : i42, i1
     // CHECK-NEXT:       }
-    // CHECK-NEXT:       [[STOP_COND:%.+]] = sv.macro.ref @STOP_COND_
+    // CHECK-NEXT:       [[STOP_COND:%.+]] = sv.macro.ref.expr @STOP_COND_
     // CHECK-NEXT:       sv.if [[STOP_COND]] {
     // CHECK-NEXT:         sv.fatal
     // CHECK-NEXT:       }
     // CHECK-NEXT:     }
     // CHECK-NEXT:     sv.if [[TMP4]] {
-    // CHECK-NEXT:       [[ASSERT_VERBOSE_COND:%.+]] = sv.macro.ref @ASSERT_VERBOSE_COND_
+    // CHECK-NEXT:       [[ASSERT_VERBOSE_COND:%.+]] = sv.macro.ref.expr @ASSERT_VERBOSE_COND_
     // CHECK-NEXT:       sv.if [[ASSERT_VERBOSE_COND]] {
     // CHECK-NEXT:         sv.error "assert2 %d"([[SIGNEDVAL]]) : i24
     // CHECK-NEXT:       }
-    // CHECK-NEXT:       [[STOP_COND:%.+]] = sv.macro.ref @STOP_COND_
+    // CHECK-NEXT:       [[STOP_COND:%.+]] = sv.macro.ref.expr @STOP_COND_
     // CHECK-NEXT:       sv.if [[STOP_COND]] {
     // CHECK-NEXT:         sv.fatal
     // CHECK-NEXT:       }

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -24,7 +24,7 @@ hw.module @test1(in %arg0: i1, in %arg1: i1, in %arg8: i8) {
   sv.always posedge  %arg0 {
     sv.ifdef.procedural @SYNTHESIS {
     } else {
-      %tmp = sv.macro.ref @PRINTF_COND_() : () -> i1
+      %tmp = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
       %tmpx = sv.constantX : i1
       %tmpz = sv.constantZ : i1
       %tmp2 = comb.and %tmp, %tmpx, %tmpz, %arg1 : i1
@@ -43,7 +43,7 @@ hw.module @test1(in %arg0: i1, in %arg1: i1, in %arg8: i8) {
   // CHECK-NEXT: sv.always posedge %arg0 {
   // CHECK-NEXT:   sv.ifdef.procedural @SYNTHESIS {
   // CHECK-NEXT:   } else {
-  // CHECK-NEXT:     %PRINTF_COND_ = sv.macro.ref @PRINTF_COND
+  // CHECK-NEXT:     %PRINTF_COND_ = sv.macro.ref.expr @PRINTF_COND
   // CHECK-NEXT:     %x_i1 = sv.constantX : i1
   // CHECK-NEXT:     %z_i1 = sv.constantZ : i1
   // CHECK-NEXT:     [[COND:%.*]] = comb.and %PRINTF_COND_, %x_i1, %z_i1, %arg1 : i1

--- a/test/Dialect/SV/cse.mlir
+++ b/test/Dialect/SV/cse.mlir
@@ -3,24 +3,24 @@
 sv.macro.decl @PRINTF_COND_ 
 
 // CHECK-LABEL: @cse_macro_ref
-// CHECK: [[VAR:%.+]] = sv.macro.ref @PRINTF_COND_() : () -> i1
+// CHECK: [[VAR:%.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
 // CHECK: [[AND:%.+]] = comb.and [[VAR]], [[VAR]] : i1
 // CHECK: hw.output [[AND]] : i1
 hw.module @cse_macro_ref(out out: i1) {
-  %PRINTF_COND__0 = sv.macro.ref @PRINTF_COND_ () : () -> i1
-  %PRINTF_COND__1 = sv.macro.ref @PRINTF_COND_ () : () -> i1
+  %PRINTF_COND__0 = sv.macro.ref.expr @PRINTF_COND_ () : () -> i1
+  %PRINTF_COND__1 = sv.macro.ref.expr @PRINTF_COND_ () : () -> i1
   %0 = comb.and %PRINTF_COND__0, %PRINTF_COND__1 : i1
   hw.output %0 : i1
 }
 
 // CHECK-LABEL: @nocse_macro_ref
-// CHECK: [[VAR1:%.+]] = sv.macro.ref.se @PRINTF_COND_() : () -> i1
-// CHECK: [[VAR2:%.+]] = sv.macro.ref.se @PRINTF_COND_() : () -> i1
+// CHECK: [[VAR1:%.+]] = sv.macro.ref.expr.se @PRINTF_COND_() : () -> i1
+// CHECK: [[VAR2:%.+]] = sv.macro.ref.expr.se @PRINTF_COND_() : () -> i1
 // CHECK: [[AND:%.+]] = comb.and [[VAR1]], [[VAR2]] : i1
 // CHECK: hw.output [[AND]] : i1
 hw.module @nocse_macro_ref(out out: i1) {
-  %PRINTF_COND__0 = sv.macro.ref.se @PRINTF_COND_ () : () -> i1
-  %PRINTF_COND__1 = sv.macro.ref.se @PRINTF_COND_ () : () -> i1
+  %PRINTF_COND__0 = sv.macro.ref.expr.se @PRINTF_COND_ () : () -> i1
+  %PRINTF_COND__1 = sv.macro.ref.expr.se @PRINTF_COND_ () : () -> i1
   %0 = comb.and %PRINTF_COND__0, %PRINTF_COND__1 : i1
   hw.output %0 : i1
 }

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -129,7 +129,7 @@ hw.module @lowering(in %clk : !seq.clock, in %rst : i1, in %in : i32, out a : i3
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK-NEXT:         %_RANDOM = sv.logic : !hw.inout<uarray<8xi32>>
   // CHECK-NEXT:         sv.for %i = %c0_i4 to %c-8_i4 step %c1_i4 : i4 {
-  // CHECK-NEXT:           %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
+  // CHECK-NEXT:           %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
   // CHECK-NEXT:           %24 = comb.extract %i from 0 : (i4) -> i3
   // CHECK-NEXT:           %25 = sv.array_index_inout %_RANDOM[%24] : !hw.inout<uarray<8xi32>>, i3
   // CHECK-NEXT:           sv.bpassign %25, %RANDOM : i32
@@ -210,7 +210,7 @@ hw.module private @UninitReg1(in %clock : !seq.clock, in %reset : i1, in %cond :
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK-NEXT:         %_RANDOM = sv.logic : !hw.inout<uarray<1xi32>>
   // CHECK:              sv.for %i = %{{false.*}} to %{{true.*}} step %{{true.*}} : i1 {
-  // CHECK-NEXT:           %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
+  // CHECK-NEXT:           %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
   // CHECK-NEXT:           %6 = comb.extract %i from 0 : (i1) -> i0
   // CHECK-NEXT:           %7 = sv.array_index_inout %_RANDOM[%6] : !hw.inout<uarray<1xi32>>, i0
   // CHECK-NEXT:           sv.bpassign %7, %RANDOM : i32
@@ -317,7 +317,7 @@ hw.module private @InitReg1(in %clock: !seq.clock, in %reset: i1, in %io_d: i32,
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK-NEXT:          %_RANDOM = sv.logic : !hw.inout<uarray<3xi32>>
   // CHECK-NEXT:          sv.for %i = %c0_i2 to %c-1_i2 step %c1_i2 : i2 {
-  // CHECK-NEXT:            %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
+  // CHECK-NEXT:            %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
   // CHECK-NEXT:            %14 = sv.array_index_inout %_RANDOM[%i] : !hw.inout<uarray<3xi32>>, i2
   // CHECK-NEXT:            sv.bpassign %14, %RANDOM : i32
   // CHECK-NEXT:          }
@@ -366,7 +366,7 @@ hw.module private @UninitReg42(in %clock: !seq.clock, in %reset: i1, in %cond: i
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK-NEXT:         %_RANDOM = sv.logic : !hw.inout<uarray<2xi32>>
   // CHECK-NEXT:         sv.for %i = %c0_i2 to %c-2_i2 step %c1_i2 : i2 {
-  // CHECK-NEXT:           %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
+  // CHECK-NEXT:           %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
   // CHECK-NEXT:           %9 = comb.extract %i from 0 : (i2) -> i1
   // CHECK-NEXT:           %10 = sv.array_index_inout %_RANDOM[%9] : !hw.inout<uarray<2xi32>>, i1
   // CHECK-NEXT:           sv.bpassign %10, %RANDOM : i32
@@ -412,7 +412,7 @@ hw.module private @init1DVector(in %clock: !seq.clock, in %a: !hw.array<2xi1>, o
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK-NEXT:       %_RANDOM = sv.logic : !hw.inout<uarray<1xi32>>
   // CHECK-NEXT:       sv.for %i = %false to %true step %true : i1 {
-  // CHECK-NEXT:         %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
+  // CHECK-NEXT:         %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
   // CHECK-NEXT:         %8 = comb.extract %i from 0 : (i1) -> i0
   // CHECK-NEXT:         %9 = sv.array_index_inout %_RANDOM[%8] : !hw.inout<uarray<1xi32>>, i0
   // CHECK-NEXT:         sv.bpassign %9, %RANDOM : i32
@@ -459,7 +459,7 @@ hw.module private @init2DVector(in %clock: !seq.clock, in %a: !hw.array<1xarray<
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK-NEXT:         %_RANDOM = sv.logic : !hw.inout<uarray<1xi32>>
   // CHECK-NEXT:         sv.for %i = %false to %true step %true : i1 {
-  // CHECK-NEXT:           %RANDOM = sv.macro.ref.se @RANDOM() : () -> i32
+  // CHECK-NEXT:           %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
   // CHECK-NEXT:           %6 = comb.extract %i from 0 : (i1) -> i0
   // CHECK-NEXT:           %7 = sv.array_index_inout %_RANDOM[%6] : !hw.inout<uarray<1xi32>>, i0
   // CHECK-NEXT:           sv.bpassign %7, %RANDOM : i32

--- a/test/Dialect/Seq/hw-memsim.mlir
+++ b/test/Dialect/Seq/hw-memsim.mlir
@@ -130,7 +130,7 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(in %ro_addr_0: i4
 //CHECK-NEXT:      sv.ifdef.procedural @RANDOMIZE_MEM_INIT {
 //CHECK:             sv.for %i = %c0_i4 to %c-6_i4 step %c1_i4 : i4 {
 //CHECK:               sv.for %j = %c0_i6 to %c-32_i6 step %c-32_i6_2 : i6 {
-//CHECK:                 %RANDOM = sv.macro.ref.se @RANDOM
+//CHECK:                 %RANDOM = sv.macro.ref.expr.se @RANDOM
 //CHECK:                 %[[PART_SELECT:.+]] = sv.indexed_part_select_inout %_RANDOM_MEM[%j : 32] : !hw.inout<i32>, i6
 //CHECK:                 sv.bpassign %[[PART_SELECT]], %RANDOM : i32
 //CHECK:               }

--- a/test/firtool/print.fir
+++ b/test/firtool/print.fir
@@ -12,7 +12,7 @@ circuit PrintTest:
     ; CHECK:      sv.ifdef  @SYNTHESIS {
     ; CHECK-NEXT: } else {
     ; CHECK-NEXT:   sv.always posedge %clock {
-    ; CHECK-NEXT:     [[PRINTF_COND:%.+]] = sv.macro.ref @PRINTF_COND_() : () -> i1
+    ; CHECK-NEXT:     [[PRINTF_COND:%.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
     ; CHECK-NEXT:     [[COND:%.+]] = comb.and bin [[PRINTF_COND]], %cond : i1
     ; CHECK-NEXT:     sv.if [[COND]] {
     ; CHECK-NEXT:       sv.fwrite %c-2147483646_i32, "test %d\0A"(%var) : i32

--- a/test/firtool/stop.fir
+++ b/test/firtool/stop.fir
@@ -15,7 +15,7 @@ circuit StopAndFinishTest:
     input clock : Clock
     input cond : UInt<1>
 
-    ; CHECK: [[STOP_COND:%.+]] = sv.macro.ref @STOP_COND_() : () -> i1
+    ; CHECK: [[STOP_COND:%.+]] = sv.macro.ref.expr @STOP_COND_() : () -> i1
     ; CHECK: [[COND:%.+]] = comb.and bin [[STOP_COND:%.+]], %cond : i1
     ; CHECK: sv.ifdef @SYNTHESIS {
     ; CHECK: } else {


### PR DESCRIPTION
There has been MacroRefExprOp and MacroRefExprSEOp to use macro symbols as expressions but it was not possible to use macro as a statement. This commit adds `sv.macro.ref` op to represent a statement. Since `sv.macro.ref` mnemonic was used by MacroRefExprOp this commit also renames `sv.macro.ref` to `sv.macro.ref.expr` at the same time. 