### PR TITLE
[CMake] Consistently declare conversion libraries and simplify circt-opt link target list

### DIFF
--- a/lib/Conversion/AffineToLoopSchedule/CMakeLists.txt
+++ b/lib/Conversion/AffineToLoopSchedule/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_circt_library(CIRCTAffineToLoopSchedule
+add_circt_conversion_library(CIRCTAffineToLoopSchedule
   AffineToLoopSchedule.cpp
 
   DEPENDS

--- a/lib/Conversion/CFToHandshake/CMakeLists.txt
+++ b/lib/Conversion/CFToHandshake/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_circt_library(CIRCTCFToHandshake
+add_circt_conversion_library(CIRCTCFToHandshake
   CFToHandshake.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Conversion/CalyxNative/CMakeLists.txt
+++ b/lib/Conversion/CalyxNative/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_circt_library(CIRCTCalyxNative
+add_circt_conversion_library(CIRCTCalyxNative
   CalyxNative.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Conversion/CalyxToFSM/CMakeLists.txt
+++ b/lib/Conversion/CalyxToFSM/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_circt_library(CIRCTCalyxToFSM
+add_circt_conversion_library(CIRCTCalyxToFSM
   CalyxToFSM.cpp
   MaterializeFSM.cpp
   RemoveGroupsFromFSM.cpp

--- a/lib/Conversion/CalyxToHW/CMakeLists.txt
+++ b/lib/Conversion/CalyxToHW/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_circt_library(CIRCTCalyxToHW
+add_circt_conversion_library(CIRCTCalyxToHW
   CalyxToHW.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Conversion/DCToHW/CMakeLists.txt
+++ b/lib/Conversion/DCToHW/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_circt_library(CIRCTDCToHW
+add_circt_conversion_library(CIRCTDCToHW
     DCToHW.cpp
 
     ADDITIONAL_HEADER_DIRS

--- a/lib/Conversion/HandshakeToDC/CMakeLists.txt
+++ b/lib/Conversion/HandshakeToDC/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_circt_library(CIRCTHandshakeToDC
+add_circt_conversion_library(CIRCTHandshakeToDC
     HandshakeToDC.cpp
 
     ADDITIONAL_HEADER_DIRS

--- a/lib/Conversion/HandshakeToHW/CMakeLists.txt
+++ b/lib/Conversion/HandshakeToHW/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_circt_library(CIRCTHandshakeToHW
+add_circt_conversion_library(CIRCTHandshakeToHW
   HandshakeToHW.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Conversion/PipelineToHW/CMakeLists.txt
+++ b/lib/Conversion/PipelineToHW/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_circt_library(CIRCTPipelineToHW
+add_circt_conversion_library(CIRCTPipelineToHW
   PipelineToHW.cpp
 
   DEPENDS

--- a/tools/circt-opt/CMakeLists.txt
+++ b/tools/circt-opt/CMakeLists.txt
@@ -1,3 +1,6 @@
+get_property(dialect_libs GLOBAL PROPERTY CIRCT_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY CIRCT_CONVERSION_LIBS)
+
 set(LLVM_LINK_COMPONENTS
   Support
 )
@@ -8,95 +11,20 @@ add_circt_tool(circt-opt
   DEPENDS
   SUPPORT_PLUGINS
 )
+
 llvm_update_compile_flags(circt-opt)
+
 target_link_libraries(circt-opt
   PRIVATE
-  CIRCTAffineToLoopSchedule
+  ${dialect_libs}
+  ${conversion_libs}
+
   CIRCTAnalysisTestPasses
-  CIRCTArc
-  CIRCTArcToLLVM
-  CIRCTArcTransforms
   CIRCTBMCTransforms
-  CIRCTCalyx
-  CIRCTCalyxToHW
-  CIRCTCalyxNative
-  CIRCTCalyxToFSM
-  CIRCTCalyxTransforms
-  CIRCTComb
-  CIRCTCombToSMT
-  CIRCTCombTransforms
-  CIRCTConvertToArcs
-  CIRCTDC
-  CIRCTDCToHW
-  CIRCTDCTransforms
-  CIRCTDebug
-  CIRCTEmit
-  CIRCTESI
   CIRCTExportChiselInterface
   CIRCTExportVerilog
-  CIRCTFIRRTL
-  CIRCTFIRRTLToHW
-  CIRCTFIRRTLTransforms
-  CIRCTFSM
-  CIRCTFSMTransforms
-  CIRCTFSMToSV
-  CIRCTHandshake
-  CIRCTHandshakeToDC
-  CIRCTHandshakeToHW
-  CIRCTHandshakeTransforms
   CIRCTLECTransforms
-  CIRCTLLHD
-  CIRCTHWToLLVM
-  CIRCTCombToArith
-  CIRCTCombToLLVM
-  CIRCTLLHDTransforms
-  CIRCTMoore
-  CIRCTMooreTransforms
-  CIRCTMooreToCore
-  CIRCTMSFT
-  CIRCTMSFTTransforms
-  CIRCTHW
-  CIRCTHWArith
-  CIRCTHWArithToHW
-  CIRCTHWToBTOR2
-  CIRCTIbis
-  CIRCTIbisTransforms
-  CIRCTInteropDialect
-  CIRCTHWToSMT
-  CIRCTHWToSystemC
-  CIRCTHWToSV
-  CIRCTHWTransforms
-  CIRCTLoopSchedule
-  CIRCTLoopScheduleToCalyx
-  CIRCTLTL
-  CIRCTSCFToCalyx
-  CIRCTScheduling
-  CIRCTSeq
-  CIRCTSeqToSV
-  CIRCTSeqTransforms
-  CIRCTSimToSV
-  CIRCTSimTransforms
-  CIRCTSSP
-  CIRCTSSPTransforms
-  CIRCTCFToHandshake
-  CIRCTOM
-  CIRCTOMTransforms
-  CIRCTPipelineOps
-  CIRCTPipelineToHW
-  CIRCTPipelineTransforms
-  CIRCTSMT
-  CIRCTSMTToZ3LLVM
-  CIRCTSV
-  CIRCTSVTransforms
-  CIRCTHWArith
-  CIRCTSystemC
-  CIRCTSystemCTransforms
   CIRCTTransforms
-  CIRCTVerif
-  CIRCTVerifTransforms
-  CIRCTVerifToSMT
-  CIRCTVerifToSV
-  CIRCTLTLToCore
 
   MLIRIR
   MLIRLLVMDialect


### PR DESCRIPTION
* Use `add_circt_conversion_library` to define the libraries in `lib/Conversion`. Currently some already do that and others just declare them as regular libraries. `ExportChiselInterface`, `ExportVerilog`, and `ImportVerilog` are registered as translation libraries which makes sense, but makes me wonder: shouldn't they exist in another directory (e.g., `lib/Target` for the export passes)?
* Use the CMake property to add them as link targets to circt-opt. When adding a new dialect, it will then be linked against it automatically as with the other non-dialect-specific tools.