### PR TITLE
[FIRRTL] Add InstanceInfo Analysis

### DIFF
--- a/include/circt/Analysis/FIRRTLInstanceInfo.h
+++ b/include/circt/Analysis/FIRRTLInstanceInfo.h
@@ -23,8 +23,6 @@
 namespace circt {
 namespace firrtl {
 
-using namespace detail;
-
 class InstanceInfo {
 
 public:
@@ -46,16 +44,13 @@ public:
     };
 
     /// Whether or not the property holds.
-    Kind kind = Unknown;
+    Kind kind = Kind::Unknown;
 
     /// The value of the property if `kind` is `Constant`.
     bool constant = false;
 
-    // Combine this lattice value with another lattice value.
-    void merge(LatticeValue that);
-
-    // Merge evidence that a property is true.
-    void merge(bool property);
+    /// Merge attributes from another LatticeValue into this one.
+    void mergeIn(LatticeValue that);
   };
 
   struct ModuleAttributes {

--- a/include/circt/Analysis/FIRRTLInstanceInfo.h
+++ b/include/circt/Analysis/FIRRTLInstanceInfo.h
@@ -68,18 +68,21 @@ public:
   /// Return true if this module is the design-under-test.
   bool isDut(FModuleOp op);
 
-  /// Return true if this module is instantiated under the design-under-test.
-  bool isUnderDut(FModuleOp op);
+  /// Return true if at least one instance of this module is under (or
+  /// transitively under) the design-under-test.
+  bool atLeastOneInstanceUnderDut(FModuleOp op);
 
-  /// Return true if all instantiations of this module are under the
-  /// design-under-test.
-  bool isFullyUnderDut(FModuleOp op);
+  /// Return true if all instances of this module are under (or transitively
+  /// under) the design-under-test.
+  bool allInstancesUnderDut(FModuleOp op);
 
-  /// Return true if this module is instantiated under a layer block.
-  bool isUnderLayer(FModuleOp op);
+  /// Return true if at least one instance of this module is under (or
+  /// transitively under) a layer.
+  bool atLeastOneInstanceUnderLayer(FModuleOp op);
 
-  /// Return true if all instantiations of this module are under layer blocks.
-  bool isFullyUnderLayer(FModuleOp op);
+  /// Return true if all instances of this module are under (or transitively
+  /// under) layer blocks.
+  bool allInstancesUnderLayer(FModuleOp op);
 
 private:
   /// Internal mapping of operations to module attributes.

--- a/include/circt/Analysis/FIRRTLInstanceInfo.h
+++ b/include/circt/Analysis/FIRRTLInstanceInfo.h
@@ -59,7 +59,7 @@ public:
   };
 
   struct ModuleAttributes {
-    /// Indicates that this module is the desgin-under-test.  This is indicated
+    /// Indicates that this module is the design-under-test.  This is indicated
     /// with a `sifive.enterprise.firrtl.MarkDUTAnnotation`.
     bool isDut;
 

--- a/include/circt/Analysis/FIRRTLInstanceInfo.h
+++ b/include/circt/Analysis/FIRRTLInstanceInfo.h
@@ -69,11 +69,13 @@ public:
   bool isDut(FModuleOp op);
 
   /// Return true if at least one instance of this module is under (or
-  /// transitively under) the design-under-test.
+  /// transitively under) the design-under-test.  This is true if the module is
+  /// the design-under-test.
   bool atLeastOneInstanceUnderDut(FModuleOp op);
 
   /// Return true if all instances of this module are under (or transitively
-  /// under) the design-under-test.
+  /// under) the design-under-test.  This is true if the module is the
+  /// design-under-test.
   bool allInstancesUnderDut(FModuleOp op);
 
   /// Return true if at least one instance of this module is under (or

--- a/include/circt/Analysis/FIRRTLInstanceInfo.h
+++ b/include/circt/Analysis/FIRRTLInstanceInfo.h
@@ -1,0 +1,115 @@
+//===- FIRRTLInstanceInfo.h - Instance info analysis ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the InstanceInfo analysis.  This is an analysis that
+// depends on the InstanceGraph analysis, but provides additional information
+// about FIRRTL operations.  This is useful if you find yourself needing to
+// selectively iterate over parts of the design.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_FIRRTL_FIRRTLINSTANCEINFO_H
+#define CIRCT_DIALECT_FIRRTL_FIRRTLINSTANCEINFO_H
+
+#include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/Pass/AnalysisManager.h"
+
+namespace circt {
+namespace firrtl {
+
+using namespace detail;
+
+class InstanceInfo {
+
+public:
+  explicit InstanceInfo(Operation *op, mlir::AnalysisManager &am);
+
+  /// A lattice value recording whether or not a property is true for a set of
+  /// operations.
+  struct LatticeValue {
+    enum Kind {
+      // Indicates that we have no information about this instance.  If the
+      // circuit has been completely analyzed, then this is equivalent to the
+      // property holds for zero instances.
+      Unknown = 0,
+      // Indicates that the property has a true or false value for all instances
+      // observed.
+      Constant,
+      // Indicates that the property holds for some, but not all instances.
+      Mixed
+    };
+
+    /// Whether or not the property holds.
+    Kind kind = Unknown;
+
+    /// The value of the property if `kind` is `Constant`.
+    bool constant = false;
+
+    // Combine this lattice value with another lattice value.
+    void merge(LatticeValue that);
+
+    // Merge evidence that a property is true.
+    void merge(bool property);
+  };
+
+  struct ModuleAttributes {
+    /// Indicates that this module is the desgin-under-test.  This is indicated
+    /// with a `sifive.enterprise.firrtl.MarkDUTAnnotation`.
+    bool isDut;
+
+    /// Indicates if this module is instantiated under the design-under-test.
+    InstanceInfo::LatticeValue underDut = {LatticeValue::Kind::Unknown};
+
+    /// Indicates if this module is instantiated under a layer.
+    InstanceInfo::LatticeValue underLayer = {LatticeValue::Kind::Unknown};
+  };
+
+  /// Return true if this module is the design-under-test.
+  bool isDut(FModuleOp op);
+
+  /// Return true if this module is instantiated under the design-under-test.
+  bool isUnderDut(FModuleOp op);
+
+  /// Return true if all instantiations of this module are under the
+  /// design-under-test.
+  bool isFullyUnderDut(FModuleOp op);
+
+  /// Return true if this module is instantiated under a layer block.
+  bool isUnderLayer(FModuleOp op);
+
+  /// Return true if all instantiations of this module are under layer blocks.
+  bool isFullyUnderLayer(FModuleOp op);
+
+private:
+  /// Internal mapping of operations to module attributes.
+  DenseMap<Operation *, ModuleAttributes> moduleAttributes;
+
+  /// Return the module attributes associated with a module.
+  const ModuleAttributes &getModuleAttributes(FModuleOp op);
+};
+
+#ifndef NDEBUG
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const InstanceInfo::LatticeValue &value) {
+  switch (value.kind) {
+  case InstanceInfo::LatticeValue::Kind::Unknown:
+    return os << "unknown";
+  case InstanceInfo::LatticeValue::Kind::Constant:
+    return os << "constant<" << (value.constant ? "true" : "false") << ">";
+  case InstanceInfo::LatticeValue::Kind::Mixed:
+    return os << "mixed";
+  }
+  return os;
+}
+#endif
+
+} // namespace firrtl
+} // namespace circt
+
+#endif // CIRCT_DIALECT_FIRRTL_FIRRTLINSTANCEINFO_H

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -37,21 +37,21 @@ add_circt_library(CIRCTSchedulingAnalysis
   CIRCTScheduling
 )
 
+add_circt_library(CIRCTFIRRTLAnalysis
+  FIRRTLInstanceInfo.cpp
+
+  LINK_LIBS PUBLIC
+  CIRCTFIRRTL
+)
+
 add_circt_library(CIRCTAnalysisTestPasses
   TestPasses.cpp
 
   LINK_LIBS PUBLIC
   CIRCTDebugAnalysis
   CIRCTDependenceAnalysis
+  CIRCTFIRRTLAnalysis
   CIRCTSchedulingAnalysis
   CIRCTHW
   MLIRPass
-)
-
-add_circt_library(CIRCTFIRRTLAnalysis
-  FIRRTLInstanceInfo.cpp
-
-  LINK_LIBS PUBLIC
-  CIRCTFIRRTL
-  CIRCTSupport
 )

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_OPTIONAL_SOURCES
   DebugAnalysis.cpp
   DebugInfo.cpp
   DependenceAnalysis.cpp
+  FIRRTLInstanceInfo.cpp
   SchedulingAnalysis.cpp
   TestPasses.cpp
 )
@@ -45,4 +46,14 @@ add_circt_library(CIRCTAnalysisTestPasses
   CIRCTSchedulingAnalysis
   CIRCTHW
   MLIRPass
+)
+
+add_circt_library(CIRCTFIRRTLAnalysis
+  FIRRTLInstanceInfo.cpp
+
+  LINK_LIBS PUBLIC
+  CIRCTComb
+  CIRCTDebug
+  CIRCTHW
+  MLIRIR
 )

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -52,8 +52,6 @@ add_circt_library(CIRCTFIRRTLAnalysis
   FIRRTLInstanceInfo.cpp
 
   LINK_LIBS PUBLIC
-  CIRCTComb
-  CIRCTDebug
-  CIRCTHW
-  MLIRIR
+  CIRCTFIRRTL
+  CIRCTSupport
 )

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -106,13 +106,15 @@ InstanceInfo::getModuleAttributes(FModuleOp op) {
 bool InstanceInfo::isDut(FModuleOp op) { return getModuleAttributes(op).isDut; }
 
 bool InstanceInfo::atLeastOneInstanceUnderDut(FModuleOp op) {
-  return getModuleAttributes(op).underDut.kind == LatticeValue::Mixed ||
+  return isDut(op) ||
+         getModuleAttributes(op).underDut.kind == LatticeValue::Mixed ||
          allInstancesUnderDut(op);
 }
 
 bool InstanceInfo::allInstancesUnderDut(FModuleOp op) {
   auto underDut = getModuleAttributes(op).underDut;
-  return underDut.kind == LatticeValue::Constant && underDut.constant;
+  return isDut(op) ||
+         (underDut.kind == LatticeValue::Constant && underDut.constant);
 }
 
 bool InstanceInfo::atLeastOneInstanceUnderLayer(FModuleOp op) {

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -99,15 +99,6 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
                           /*underLayer=*/underLayer});
     }
   }
-  for (auto *node : llvm::depth_first(iGraph.getTopLevelNode())) {
-    auto moduleOp = node->getModule();
-
-    auto &attributes = moduleAttributes[moduleOp];
-
-    if (AnnotationSet(moduleOp).hasAnnotation(dutAnnoClass)) {
-      attributes.isDut = true;
-    }
-  }
 
   LLVM_DEBUG({
     llvm::dbgs() << "InstanceInfo Analysis Results:\n";

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -131,9 +131,7 @@ InstanceInfo::getModuleAttributes(FModuleOp op) {
   return moduleAttributes.find(op)->getSecond();
 }
 
-bool InstanceInfo::isDut(FModuleOp op) {
-  return getModuleAttributes(op).isDut;
-}
+bool InstanceInfo::isDut(FModuleOp op) { return getModuleAttributes(op).isDut; }
 
 bool InstanceInfo::isUnderDut(FModuleOp op) {
   auto underDut = getModuleAttributes(op).underDut;

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -62,7 +62,7 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
         auto parentAttrs =
             moduleAttributes.find(useIt->getParent()->getModule())->getSecond();
         // Merge underDut.
-        if (parentAttrs.isDut)
+        if (parentAttrs.isDut || attributes.isDut)
           attributes.underDut.mergeIn({LatticeValue::Constant, true});
         else
           attributes.underDut.mergeIn(parentAttrs.underDut);
@@ -106,15 +106,13 @@ InstanceInfo::getModuleAttributes(FModuleOp op) {
 bool InstanceInfo::isDut(FModuleOp op) { return getModuleAttributes(op).isDut; }
 
 bool InstanceInfo::atLeastOneInstanceUnderDut(FModuleOp op) {
-  return isDut(op) ||
-         getModuleAttributes(op).underDut.kind == LatticeValue::Mixed ||
+  return getModuleAttributes(op).underDut.kind == LatticeValue::Mixed ||
          allInstancesUnderDut(op);
 }
 
 bool InstanceInfo::allInstancesUnderDut(FModuleOp op) {
   auto underDut = getModuleAttributes(op).underDut;
-  return isDut(op) ||
-         (underDut.kind == LatticeValue::Constant && underDut.constant);
+  return underDut.kind == LatticeValue::Constant && underDut.constant;
 }
 
 bool InstanceInfo::atLeastOneInstanceUnderLayer(FModuleOp op) {

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -106,9 +106,8 @@ InstanceInfo::getModuleAttributes(FModuleOp op) {
 bool InstanceInfo::isDut(FModuleOp op) { return getModuleAttributes(op).isDut; }
 
 bool InstanceInfo::atLeastOneInstanceUnderDut(FModuleOp op) {
-  auto underDut = getModuleAttributes(op).underDut;
-  return underDut.kind == LatticeValue::Mixed ||
-         (underDut.kind == LatticeValue::Constant && underDut.constant);
+  return getModuleAttributes(op).underDut.kind == LatticeValue::Mixed ||
+         allInstancesUnderDut(op);
 }
 
 bool InstanceInfo::allInstancesUnderDut(FModuleOp op) {
@@ -117,9 +116,8 @@ bool InstanceInfo::allInstancesUnderDut(FModuleOp op) {
 }
 
 bool InstanceInfo::atLeastOneInstanceUnderLayer(FModuleOp op) {
-  auto underLayer = getModuleAttributes(op).underLayer;
-  return underLayer.kind == LatticeValue::Mixed ||
-         (underLayer.kind == LatticeValue::Constant && underLayer.constant);
+  return getModuleAttributes(op).underLayer.kind == LatticeValue::Mixed ||
+         allInstancesUnderLayer(op);
 }
 
 bool InstanceInfo::allInstancesUnderLayer(FModuleOp op) {

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -1,0 +1,158 @@
+//===- FIRRTLInstanceInfo.cpp - Instance info analysis ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the InstanceInfo analysis.  This is an analysis that
+// depends on the InstanceGraph analysis, but provides additional information
+// about FIRRTL operations.  This is useful if you find yourself needing to
+// selectively iterate over parts of the design.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Analysis/FIRRTLInstanceInfo.h"
+#include "circt/Dialect/FIRRTL/AnnotationDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "firrtl-analysis-instanceinfo"
+
+using namespace circt;
+using namespace firrtl;
+using namespace detail;
+
+void InstanceInfo::LatticeValue::merge(LatticeValue that) {
+  if (kind > that.kind)
+    return;
+
+  if (kind < that.kind) {
+    kind = that.kind;
+    constant = that.constant;
+    return;
+  }
+
+  if (kind == Constant && constant != that.constant)
+    kind = Mixed;
+}
+
+void InstanceInfo::LatticeValue::merge(bool property) {
+  merge({/*kind=*/Constant, /*constant=*/property});
+}
+
+namespace {
+/// This struct is one frame of a worklist.  This is used to track what instance
+/// is being visited and with what information about its instantiation needs to
+/// be known.
+struct Frame {
+
+  /// The instance that will be visited.
+  InstanceGraphNode *node;
+
+  /// Indicates that the current hierarchy is under the DUT.
+  bool underDut = false;
+
+  /// Indicates that the current hierarchy is under a layer.
+  bool underLayer = false;
+};
+} // namespace
+
+InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
+  auto &iGraph = am.getAnalysis<InstanceGraph>();
+
+  SmallVector<Frame> worklist({{iGraph.getTopLevelNode()}});
+  while (!worklist.empty()) {
+    auto frame = worklist.pop_back_val();
+    auto *node = frame.node;
+    auto moduleOp = node->getModule();
+
+    // Compute information about this instance.
+    bool isDut = AnnotationSet(moduleOp).hasAnnotation(dutAnnoClass);
+
+    // Set the baseline attributes.  This is what the attributes will be if
+    // there is no other, existing attributes.
+    ModuleAttributes attributes({/*isDut=*/isDut});
+    attributes.underDut.merge(frame.underDut);
+    attributes.underLayer.merge(frame.underLayer);
+
+    // Merge the baseline attributes with the existing attributes, if they
+    // exist.
+    auto it = moduleAttributes.find(moduleOp);
+    if (it == moduleAttributes.end())
+      moduleAttributes[moduleOp] = attributes;
+    else {
+      auto &oldAttributes = it->getSecond();
+      oldAttributes.underDut.merge(attributes.underDut);
+      oldAttributes.underLayer.merge(attributes.underLayer);
+      attributes = oldAttributes;
+    }
+
+    for (auto *inst : *frame.node) {
+      auto underDut = frame.underDut || isDut;
+      auto underLayer = frame.underLayer ||
+                        inst->getInstance()->getParentOfType<LayerBlockOp>();
+      worklist.push_back({inst->getTarget(),
+                          /*underDut=*/underDut,
+                          /*underLayer=*/underLayer});
+    }
+  }
+  for (auto *node : llvm::depth_first(iGraph.getTopLevelNode())) {
+    auto moduleOp = node->getModule();
+
+    auto &attributes = moduleAttributes[moduleOp];
+
+    if (AnnotationSet(moduleOp).hasAnnotation(dutAnnoClass)) {
+      attributes.isDut = true;
+    }
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "InstanceInfo Analysis Results:\n";
+    DenseSet<Operation *> visited;
+    for (auto *node : llvm::depth_first(iGraph.getTopLevelNode())) {
+      auto moduleOp = node->getModule();
+      if (!visited.insert(moduleOp.getOperation()).second)
+        continue;
+      auto attributes = moduleAttributes[moduleOp];
+      llvm::dbgs() << "  - module: " << moduleOp.getModuleName() << "\n"
+                   << "    isDut:      "
+                   << (attributes.isDut ? "true" : "false") << "\n"
+                   << "    underDut:   " << attributes.underDut << "\n"
+                   << "    underLayer: " << attributes.underLayer << "\n";
+    }
+  });
+}
+
+const InstanceInfo::ModuleAttributes &
+InstanceInfo::getModuleAttributes(FModuleOp op) {
+  return moduleAttributes.find(op)->getSecond();
+}
+
+bool InstanceInfo::isDut(FModuleOp op) {
+  return getModuleAttributes(op).isDut;
+}
+
+bool InstanceInfo::isUnderDut(FModuleOp op) {
+  auto underDut = getModuleAttributes(op).underDut;
+  return underDut.kind == LatticeValue::Mixed ||
+         (underDut.kind == LatticeValue::Constant && underDut.constant);
+}
+
+bool InstanceInfo::isFullyUnderDut(FModuleOp op) {
+  auto underDut = getModuleAttributes(op).underDut;
+  return underDut.kind == LatticeValue::Constant && underDut.constant;
+}
+
+bool InstanceInfo::isUnderLayer(FModuleOp op) {
+  auto underLayer = getModuleAttributes(op).underLayer;
+  return underLayer.kind == LatticeValue::Mixed ||
+         (underLayer.kind == LatticeValue::Constant && underLayer.constant);
+}
+
+bool InstanceInfo::isFullyUnderLayer(FModuleOp op) {
+  auto underLayer = getModuleAttributes(op).underLayer;
+  return underLayer.kind == LatticeValue::Constant && underLayer.constant;
+}

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -86,11 +86,8 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
 
   LLVM_DEBUG({
     llvm::dbgs() << "InstanceInfo Analysis Results:\n";
-    DenseSet<Operation *> visited;
     for (auto *node : llvm::depth_first(iGraph.getTopLevelNode())) {
       auto moduleOp = node->getModule();
-      if (!visited.insert(moduleOp.getOperation()).second)
-        continue;
       auto attributes = moduleAttributes[moduleOp];
       llvm::dbgs() << "  - module: " << moduleOp.getModuleName() << "\n"
                    << "    isDut:      "

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -105,24 +105,24 @@ InstanceInfo::getModuleAttributes(FModuleOp op) {
 
 bool InstanceInfo::isDut(FModuleOp op) { return getModuleAttributes(op).isDut; }
 
-bool InstanceInfo::isUnderDut(FModuleOp op) {
+bool InstanceInfo::atLeastOneInstanceUnderDut(FModuleOp op) {
   auto underDut = getModuleAttributes(op).underDut;
   return underDut.kind == LatticeValue::Mixed ||
          (underDut.kind == LatticeValue::Constant && underDut.constant);
 }
 
-bool InstanceInfo::isFullyUnderDut(FModuleOp op) {
+bool InstanceInfo::allInstancesUnderDut(FModuleOp op) {
   auto underDut = getModuleAttributes(op).underDut;
   return underDut.kind == LatticeValue::Constant && underDut.constant;
 }
 
-bool InstanceInfo::isUnderLayer(FModuleOp op) {
+bool InstanceInfo::atLeastOneInstanceUnderLayer(FModuleOp op) {
   auto underLayer = getModuleAttributes(op).underLayer;
   return underLayer.kind == LatticeValue::Mixed ||
          (underLayer.kind == LatticeValue::Constant && underLayer.constant);
 }
 
-bool InstanceInfo::isFullyUnderLayer(FModuleOp op) {
+bool InstanceInfo::allInstancesUnderLayer(FModuleOp op) {
   auto underLayer = getModuleAttributes(op).underLayer;
   return underLayer.kind == LatticeValue::Constant && underLayer.constant;
 }

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -211,11 +211,14 @@ static void printInfo(firrtl::FModuleOp op, firrtl::InstanceInfo &iInfo) {
   op->print(llvm::errs(), flags);
   llvm::errs() << "\n"
                << "    isDut: " << iInfo.isDut(op) << "\n"
-               << "    isUnderDut: " << iInfo.isUnderDut(op) << "\n"
-               << "    isFullyUnderDut: " << iInfo.isFullyUnderDut(op) << "\n"
-               << "    isUnderLayer: " << iInfo.isUnderLayer(op) << "\n"
-               << "    isFullyUnderLayer: " << iInfo.isFullyUnderLayer(op)
-               << "\n";
+               << "    atLeastOneInstanceUnderDut: "
+               << iInfo.atLeastOneInstanceUnderDut(op) << "\n"
+               << "    allInstancesUnderDut: " << iInfo.allInstancesUnderDut(op)
+               << "\n"
+               << "    atLeastOneInstanceUnderLayer: "
+               << iInfo.atLeastOneInstanceUnderLayer(op) << "\n"
+               << "    allInstancesUnderLayer: "
+               << iInfo.allInstancesUnderLayer(op) << "\n";
 }
 
 void FIRRTLInstanceInfoPass::runOnOperation() {

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -12,7 +12,9 @@
 
 #include "circt/Analysis/DebugAnalysis.h"
 #include "circt/Analysis/DependenceAnalysis.h"
+#include "circt/Analysis/FIRRTLInstanceInfo.h"
 #include "circt/Analysis/SchedulingAnalysis.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/HW/HWInstanceGraph.h"
 #include "circt/Scheduling/Problems.h"
 #include "mlir/Dialect/Affine/IR/AffineMemoryOpInterfaces.h"
@@ -21,6 +23,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DepthFirstIterator.h"
 #include "llvm/Support/Debug.h"
 
 using namespace mlir;
@@ -177,6 +180,51 @@ void InferTopModulePass::runOnOperation() {
 }
 
 //===----------------------------------------------------------------------===//
+// FIRRTL Instance Info
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct FIRRTLInstanceInfoPass
+    : public PassWrapper<FIRRTLInstanceInfoPass,
+                         OperationPass<firrtl::CircuitOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(FIRRTLInstanceInfoPass)
+
+  void runOnOperation() override;
+  StringRef getArgument() const override { return "test-firrtl-instance-info"; }
+  StringRef getDescription() const override {
+    return "Run firrtl::InstanceInfo analysis and show the results.  This pass "
+           "is intended to be used for testing purposes only.";
+  }
+};
+} // namespace
+
+static llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const bool a) {
+  if (a)
+    return os << "true";
+  return os << "false";
+}
+
+static void printInfo(firrtl::FModuleOp op, firrtl::InstanceInfo &iInfo) {
+  OpPrintingFlags flags;
+  flags.skipRegions();
+  llvm::errs() << "  - operation: ";
+  op->print(llvm::errs(), flags);
+  llvm::errs() << "\n"
+               << "    isDut: " << iInfo.isDut(op) << "\n"
+               << "    isUnderDut: " << iInfo.isUnderDut(op) << "\n"
+               << "    isFullyUnderDut: " << iInfo.isFullyUnderDut(op) << "\n"
+               << "    isUnderLayer: " << iInfo.isUnderLayer(op) << "\n"
+               << "    isFullyUnderLayer: " << iInfo.isFullyUnderLayer(op)
+               << "\n";
+}
+
+void FIRRTLInstanceInfoPass::runOnOperation() {
+  auto &iInfo = getAnalysis<firrtl::InstanceInfo>();
+
+  getOperation()->walk([&](firrtl::FModuleOp op) { printInfo(op, iInfo); });
+}
+
+//===----------------------------------------------------------------------===//
 // Pass registration
 //===----------------------------------------------------------------------===//
 
@@ -194,6 +242,9 @@ void registerAnalysisTestPasses() {
   });
   registerPass([]() -> std::unique_ptr<Pass> {
     return std::make_unique<InferTopModulePass>();
+  });
+  registerPass([]() -> std::unique_ptr<Pass> {
+    return std::make_unique<FIRRTLInstanceInfoPass>();
   });
 }
 } // namespace test

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -221,7 +221,8 @@ static void printInfo(firrtl::FModuleOp op, firrtl::InstanceInfo &iInfo) {
 void FIRRTLInstanceInfoPass::runOnOperation() {
   auto &iInfo = getAnalysis<firrtl::InstanceInfo>();
 
-  getOperation()->walk([&](firrtl::FModuleOp op) { printInfo(op, iInfo); });
+  for (auto op : getOperation().getBodyBlock()->getOps<firrtl::FModuleOp>())
+    printInfo(op, iInfo);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -42,7 +42,6 @@ add_circt_dialect_library(CIRCTFIRRTL
 
   LINK_LIBS PUBLIC
   CIRCTSupport
-  CIRCTFIRRTLAnalysis
   CIRCTHW
   CIRCTOM
   CIRCTSeq

--- a/lib/Dialect/FIRRTL/CMakeLists.txt
+++ b/lib/Dialect/FIRRTL/CMakeLists.txt
@@ -42,6 +42,7 @@ add_circt_dialect_library(CIRCTFIRRTL
 
   LINK_LIBS PUBLIC
   CIRCTSupport
+  CIRCTFIRRTLAnalysis
   CIRCTHW
   CIRCTOM
   CIRCTSeq

--- a/test/Analysis/firrtl-test-instance-info.mlir
+++ b/test/Analysis/firrtl-test-instance-info.mlir
@@ -33,8 +33,8 @@ firrtl.circuit "Foo" {
   firrtl.module private @Baz() {}
   // CHECK:      @Bar
   // CHECK-NEXT:   isDut: true
-  // CHECK-NEXT:   atLeastOneInstanceUnderDut: false
-  // CHECK-NEXT:   allInstancesUnderDut: false
+  // CHECK-NEXT:   atLeastOneInstanceUnderDut: true
+  // CHECK-NEXT:   allInstancesUnderDut: true
   // CHECK-NEXT:   atLeastOneInstanceUnderLayer: false
   // CHECK-NEXT:   allInstancesUnderLayer: false
   firrtl.module private @Bar() attributes {

--- a/test/Analysis/firrtl-test-instance-info.mlir
+++ b/test/Analysis/firrtl-test-instance-info.mlir
@@ -3,45 +3,49 @@
 firrtl.circuit "Foo" {
   firrtl.layer @A bind {
   }
-  // CHECK:      firrtl.module @Corge
+  // CHECK:      @Corge
   // CHECK-NEXT:   isDut: false
   // CHECK-NEXT:   isUnderDut: false
   // CHECK-NEXT:   isFullyUnderDut: false
   // CHECK-NEXT:   isUnderLayer: true
   // CHECK-NEXT:   isFullyUnderLayer: false
-  firrtl.module @Corge() {}
-  // CHECK:      firrtl.module @Quz
+  firrtl.module private @Corge() {}
+  // CHECK:      @Quz
   // CHECK-NEXT:   isDut: false
   // CHECK-NEXT:   isUnderDut: false
   // CHECK-NEXT:   isFullyUnderDut: false
   // CHECK-NEXT:   isUnderLayer: true
   // CHECK-NEXT:   isFullyUnderLayer: true
-  firrtl.module @Quz() {}
-  // CHECK:      firrtl.module @Qux
+  firrtl.module private @Quz() {}
+  // CHECK:      @Qux
   // CHECK-NEXT:   isDut: false
   // CHECK-NEXT:   isUnderDut: true
   // CHECK-NEXT:   isFullyUnderDut: false
   // CHECK-NEXT:   isUnderLayer: false
   // CHECK-NEXT:   isFullyUnderLayer: false
-  firrtl.module @Qux() {}
-  // CHECK:      firrtl.module @Baz
+  firrtl.module private @Qux() {}
+  // CHECK:      @Baz
   // CHECK-NEXT:   isDut: false
   // CHECK-NEXT:   isUnderDut: true
   // CHECK-NEXT:   isFullyUnderDut: true
   // CHECK-NEXT:   isUnderLayer: false
   // CHECK-NEXT:   isFullyUnderLayer: false
-  firrtl.module @Baz() {}
-  // CHECK:      firrtl.module @Bar
+  firrtl.module private @Baz() {}
+  // CHECK:      @Bar
   // CHECK-NEXT:   isDut: true
   // CHECK-NEXT:   isUnderDut: false
   // CHECK-NEXT:   isFullyUnderDut: false
   // CHECK-NEXT:   isUnderLayer: false
   // CHECK-NEXT:   isFullyUnderLayer: false
-  firrtl.module @Bar() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+  firrtl.module private @Bar() attributes {
+    annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
+    ]
+  } {
     firrtl.instance baz interesting_name @Baz()
     firrtl.instance qux interesting_name @Qux()
   }
-  // CHECK: firrtl.module @Foo
+  // CHECK:      @Foo
   // CHECK-NEXT:   isDut: false
   // CHECK-NEXT:   isUnderDut: false
   // CHECK-NEXT:   isFullyUnderDut: false

--- a/test/Analysis/firrtl-test-instance-info.mlir
+++ b/test/Analysis/firrtl-test-instance-info.mlir
@@ -42,8 +42,8 @@ firrtl.circuit "Foo" {
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
     ]
   } {
-    firrtl.instance baz interesting_name @Baz()
-    firrtl.instance qux interesting_name @Qux()
+    firrtl.instance baz @Baz()
+    firrtl.instance qux @Qux()
   }
   // CHECK:      @Foo
   // CHECK-NEXT:   isDut: false
@@ -52,12 +52,12 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT:   isUnderLayer: false
   // CHECK-NEXT:   isFullyUnderLayer: false
   firrtl.module @Foo() {
-    firrtl.instance bar interesting_name @Bar()
-    firrtl.instance qux interesting_name @Qux()
+    firrtl.instance bar @Bar()
+    firrtl.instance qux @Qux()
     firrtl.layerblock @A {
-      firrtl.instance quz interesting_name @Quz()
-      firrtl.instance corge interesting_name @Corge()
+      firrtl.instance quz @Quz()
+      firrtl.instance corge @Corge()
     }
-    firrtl.instance corge2 interesting_name @Corge()
+    firrtl.instance corge2 @Corge()
   }
 }

--- a/test/Analysis/firrtl-test-instance-info.mlir
+++ b/test/Analysis/firrtl-test-instance-info.mlir
@@ -5,38 +5,38 @@ firrtl.circuit "Foo" {
   }
   // CHECK:      @Corge
   // CHECK-NEXT:   isDut: false
-  // CHECK-NEXT:   isUnderDut: false
-  // CHECK-NEXT:   isFullyUnderDut: false
-  // CHECK-NEXT:   isUnderLayer: true
-  // CHECK-NEXT:   isFullyUnderLayer: false
+  // CHECK-NEXT:   atLeastOneInstanceUnderDut: false
+  // CHECK-NEXT:   allInstancesUnderDut: false
+  // CHECK-NEXT:   atLeastOneInstanceUnderLayer: true
+  // CHECK-NEXT:   allInstancesUnderLayer: false
   firrtl.module private @Corge() {}
   // CHECK:      @Quz
   // CHECK-NEXT:   isDut: false
-  // CHECK-NEXT:   isUnderDut: false
-  // CHECK-NEXT:   isFullyUnderDut: false
-  // CHECK-NEXT:   isUnderLayer: true
-  // CHECK-NEXT:   isFullyUnderLayer: true
+  // CHECK-NEXT:   atLeastOneInstanceUnderDut: false
+  // CHECK-NEXT:   allInstancesUnderDut: false
+  // CHECK-NEXT:   atLeastOneInstanceUnderLayer: true
+  // CHECK-NEXT:   allInstancesUnderLayer: true
   firrtl.module private @Quz() {}
   // CHECK:      @Qux
   // CHECK-NEXT:   isDut: false
-  // CHECK-NEXT:   isUnderDut: true
-  // CHECK-NEXT:   isFullyUnderDut: false
-  // CHECK-NEXT:   isUnderLayer: false
-  // CHECK-NEXT:   isFullyUnderLayer: false
+  // CHECK-NEXT:   atLeastOneInstanceUnderDut: true
+  // CHECK-NEXT:   allInstancesUnderDut: false
+  // CHECK-NEXT:   atLeastOneInstanceUnderLayer: false
+  // CHECK-NEXT:   allInstancesUnderLayer: false
   firrtl.module private @Qux() {}
   // CHECK:      @Baz
   // CHECK-NEXT:   isDut: false
-  // CHECK-NEXT:   isUnderDut: true
-  // CHECK-NEXT:   isFullyUnderDut: true
-  // CHECK-NEXT:   isUnderLayer: false
-  // CHECK-NEXT:   isFullyUnderLayer: false
+  // CHECK-NEXT:   atLeastOneInstanceUnderDut: true
+  // CHECK-NEXT:   allInstancesUnderDut: true
+  // CHECK-NEXT:   atLeastOneInstanceUnderLayer: false
+  // CHECK-NEXT:   allInstancesUnderLayer: false
   firrtl.module private @Baz() {}
   // CHECK:      @Bar
   // CHECK-NEXT:   isDut: true
-  // CHECK-NEXT:   isUnderDut: false
-  // CHECK-NEXT:   isFullyUnderDut: false
-  // CHECK-NEXT:   isUnderLayer: false
-  // CHECK-NEXT:   isFullyUnderLayer: false
+  // CHECK-NEXT:   atLeastOneInstanceUnderDut: false
+  // CHECK-NEXT:   allInstancesUnderDut: false
+  // CHECK-NEXT:   atLeastOneInstanceUnderLayer: false
+  // CHECK-NEXT:   allInstancesUnderLayer: false
   firrtl.module private @Bar() attributes {
     annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
@@ -47,10 +47,10 @@ firrtl.circuit "Foo" {
   }
   // CHECK:      @Foo
   // CHECK-NEXT:   isDut: false
-  // CHECK-NEXT:   isUnderDut: false
-  // CHECK-NEXT:   isFullyUnderDut: false
-  // CHECK-NEXT:   isUnderLayer: false
-  // CHECK-NEXT:   isFullyUnderLayer: false
+  // CHECK-NEXT:   atLeastOneInstanceUnderDut: false
+  // CHECK-NEXT:   allInstancesUnderDut: false
+  // CHECK-NEXT:   atLeastOneInstanceUnderLayer: false
+  // CHECK-NEXT:   allInstancesUnderLayer: false
   firrtl.module @Foo() {
     firrtl.instance bar @Bar()
     firrtl.instance qux @Qux()

--- a/test/Analysis/firrtl-test-instance-info.mlir
+++ b/test/Analysis/firrtl-test-instance-info.mlir
@@ -1,0 +1,59 @@
+// RUN: circt-opt %s -test-firrtl-instance-info 2>&1 | FileCheck %s
+
+firrtl.circuit "Foo" {
+  firrtl.layer @A bind {
+  }
+  // CHECK:      firrtl.module @Corge
+  // CHECK-NEXT:   isDut: false
+  // CHECK-NEXT:   isUnderDut: false
+  // CHECK-NEXT:   isFullyUnderDut: false
+  // CHECK-NEXT:   isUnderLayer: true
+  // CHECK-NEXT:   isFullyUnderLayer: false
+  firrtl.module @Corge() {}
+  // CHECK:      firrtl.module @Quz
+  // CHECK-NEXT:   isDut: false
+  // CHECK-NEXT:   isUnderDut: false
+  // CHECK-NEXT:   isFullyUnderDut: false
+  // CHECK-NEXT:   isUnderLayer: true
+  // CHECK-NEXT:   isFullyUnderLayer: true
+  firrtl.module @Quz() {}
+  // CHECK:      firrtl.module @Qux
+  // CHECK-NEXT:   isDut: false
+  // CHECK-NEXT:   isUnderDut: true
+  // CHECK-NEXT:   isFullyUnderDut: false
+  // CHECK-NEXT:   isUnderLayer: false
+  // CHECK-NEXT:   isFullyUnderLayer: false
+  firrtl.module @Qux() {}
+  // CHECK:      firrtl.module @Baz
+  // CHECK-NEXT:   isDut: false
+  // CHECK-NEXT:   isUnderDut: true
+  // CHECK-NEXT:   isFullyUnderDut: true
+  // CHECK-NEXT:   isUnderLayer: false
+  // CHECK-NEXT:   isFullyUnderLayer: false
+  firrtl.module @Baz() {}
+  // CHECK:      firrtl.module @Bar
+  // CHECK-NEXT:   isDut: true
+  // CHECK-NEXT:   isUnderDut: false
+  // CHECK-NEXT:   isFullyUnderDut: false
+  // CHECK-NEXT:   isUnderLayer: false
+  // CHECK-NEXT:   isFullyUnderLayer: false
+  firrtl.module @Bar() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
+    firrtl.instance baz interesting_name @Baz()
+    firrtl.instance qux interesting_name @Qux()
+  }
+  // CHECK: firrtl.module @Foo
+  // CHECK-NEXT:   isDut: false
+  // CHECK-NEXT:   isUnderDut: false
+  // CHECK-NEXT:   isFullyUnderDut: false
+  // CHECK-NEXT:   isUnderLayer: false
+  // CHECK-NEXT:   isFullyUnderLayer: false
+  firrtl.module @Foo() {
+    firrtl.instance bar interesting_name @Bar()
+    firrtl.instance qux interesting_name @Qux()
+    firrtl.layerblock @A {
+      firrtl.instance quz interesting_name @Quz()
+      firrtl.instance corge interesting_name @Corge()
+    }
+    firrtl.instance corge2 interesting_name @Corge()
+  }
+}


### PR DESCRIPTION
Add a new InstanceInfo analysis.  This analysis provides common information which can be computed from a single walk of the InstanceGraph. The idea behind this is that there are a large amount of common information that different passes want to compute which all follows this same walk (and therefore has the same algorithmic complexity to compute it).  Move all this information into a single, common analysis.

This analysis currently enables O(1) queries of if something is the DUT, is instantiated under the DUT, or is instantiated under a layer.  More queries can be added as they are identified.

This new analysis naturally depends on the InstanceGraph analysis.