### PR TITLE
[FIRRTL] Allow local targets to be multiply-instantiated.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -385,8 +385,8 @@ PathTracker::getOrComputeNeedsAltBasePath(Location loc, StringAttr moduleName,
       needsAltBasePath = true;
       break;
     }
-    // If there is more than one instance of this module, then the path
-    // operation is ambiguous, which is an error.
+    // If there is more than one instance of this module, and the target is
+    // non-local, then the path operation is ambiguous, which is an error.
     if (isNonLocal && !node->hasOneUse()) {
       auto diag = mlir::emitError(loc)
                   << "unable to uniquely resolve target due "

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -275,7 +275,8 @@ private:
   // and `owningModule`.
   FailureOr<bool> getOrComputeNeedsAltBasePath(Location loc,
                                                StringAttr moduleName,
-                                               FModuleOp owningModule);
+                                               FModuleOp owningModule,
+                                               bool isNonLocal);
   FModuleLike module;
 
   // Local data structures.
@@ -364,7 +365,8 @@ LogicalResult PathTracker::runOnModule() {
 
 FailureOr<bool>
 PathTracker::getOrComputeNeedsAltBasePath(Location loc, StringAttr moduleName,
-                                          FModuleOp owningModule) {
+                                          FModuleOp owningModule,
+                                          bool isNonLocal) {
 
   auto it = needsAltBasePathCache.find({moduleName, owningModule});
   if (it != needsAltBasePathCache.end())
@@ -385,7 +387,7 @@ PathTracker::getOrComputeNeedsAltBasePath(Location loc, StringAttr moduleName,
     }
     // If there is more than one instance of this module, then the path
     // operation is ambiguous, which is an error.
-    if (!node->hasOneUse()) {
+    if (isNonLocal && !node->hasOneUse()) {
       auto diag = mlir::emitError(loc)
                   << "unable to uniquely resolve target due "
                      "to multiple instantiation";
@@ -517,8 +519,8 @@ PathTracker::processPathTrackers(const AnnoTarget &target) {
     }
 
     // Check if we need an alternative base path.
-    auto needsAltBasePath =
-        getOrComputeNeedsAltBasePath(op->getLoc(), moduleName, owningModule);
+    auto needsAltBasePath = getOrComputeNeedsAltBasePath(
+        op->getLoc(), moduleName, owningModule, hierPathOp);
     if (failed(needsAltBasePath)) {
       error = true;
       return false;
@@ -528,6 +530,10 @@ PathTracker::processPathTrackers(const AnnoTarget &target) {
     // to the start of the annotation's NLA.
     InstanceGraphNode *node = instanceGraph.lookup(moduleName);
     while (true) {
+      // If it's not a non-local target, we don't have to append anything.
+      if (!hierPathOp)
+        break;
+
       // If we get to the owning module or the top, we're done.
       if (node->getModule() == owningModule || node->noUses())
         break;
@@ -582,8 +588,10 @@ LogicalResult PathTracker::updatePathInfoTable(PathInfoTable &pathInfoTable,
     auto &pathInfo = it->second;
     if (!inserted) {
       assert(pathInfo.loc.has_value() && "all PathInfo should have a Location");
-      auto diag = emitError(pathInfo.loc.value(), "duplicate identifier found");
-      diag.attachNote(entry.op->getLoc()) << "other identifier here";
+      auto diag = emitError(pathInfo.loc.value(),
+                            "path identifier already found, paths must resolve "
+                            "to a unique target");
+      diag.attachNote(entry.op->getLoc()) << "other path identifier here";
       return failure();
     }
 

--- a/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
@@ -43,9 +43,8 @@ struct PathResolver {
 
     // If the path is empty then this is a local reference and we should not
     // construct a HierPathOp.
-    if (target.instances.empty()) {
+    if (target.instances.empty())
       return success();
-    }
 
     // We want to root this path at the top level module, or in the case of an
     // unreachable module, we settle for as high as we can get.

--- a/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
@@ -41,6 +41,12 @@ struct PathResolver {
                                 const AnnoPathValue &target,
                                 FlatSymbolRefAttr &result) {
 
+    // If the path is empty then this is a local reference and we should not
+    // construct a HierPathOp.
+    if (target.instances.empty()) {
+      return success();
+    }
+
     // We want to root this path at the top level module, or in the case of an
     // unreachable module, we settle for as high as we can get.
     auto module = target.ref.getModule();
@@ -67,12 +73,6 @@ struct PathResolver {
         return diag;
       }
       node = (*node->usesBegin())->getParent();
-    }
-
-    // If the path is empty then this is a local reference and we should not
-    // construct a HierPathOp.
-    if (target.instances.empty()) {
-      return success();
     }
 
     // Transform the instances into a list of FlatSymbolRefs.

--- a/test/Dialect/FIRRTL/lower-classes-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-classes-errors.mlir
@@ -32,9 +32,9 @@ firrtl.circuit "PathIllegalHierpath" {
 
 firrtl.circuit "PathDuplicateID" {
   firrtl.module @PathDuplicateID() {
-    // expected-error @below {{duplicate identifier found}}
+    // expected-error @below {{path identifier already found, paths must resolve to a unique target}}
     %a = firrtl.wire {annotations = [{class = "circt.tracker", id = distinct[0]<>}]} : !firrtl.uint<8>
-    // expected-note @below {{other identifier here}}
+    // expected-note @below {{other path identifier here}}
     %b = firrtl.wire {annotations = [{class = "circt.tracker", id = distinct[0]<>}]} : !firrtl.uint<8>
   }
 }

--- a/test/Dialect/FIRRTL/resolve-paths-errors.mlir
+++ b/test/Dialect/FIRRTL/resolve-paths-errors.mlir
@@ -75,13 +75,16 @@ firrtl.module @VectorTarget(in %a : !firrtl.vector<uint<1>, 1>) {
 firrtl.circuit "AmbiguousPath" {
 firrtl.module @AmbiguousPath() {
     // expected-error @below {{unable to uniquely resolve target due to multiple instantiation}}
-    %0 = firrtl.unresolved_path "OMReferenceTarget:~AmbiguousPath|Child"
+    %0 = firrtl.unresolved_path "OMReferenceTarget:~AmbiguousPath|Child/grandchild:GrandChild"
     // expected-note @below {{instance here}}
     firrtl.instance child0 @Child()
     // expected-note @below {{instance here}}
     firrtl.instance child1 @Child()
 }
-firrtl.module @Child() {}
+firrtl.module @Child() {
+    firrtl.instance grandchild @GrandChild()
+}
+firrtl.module @GrandChild() {}
 }
 
 // -----
@@ -102,18 +105,17 @@ firrtl.class @Test(){
 
 firrtl.circuit "UpwardPath" {
 firrtl.module @UpwardPath() {
-  %wire = firrtl.wire : !firrtl.uint<8>
   firrtl.instance child @Child()
 }
 
 firrtl.module @Child() {
   %om = firrtl.object @OM()
-
+  %wire = firrtl.wire : !firrtl.uint<8>
 }
 
 firrtl.class @OM(){
   // expected-error @below {{unable to resolve path relative to owning module "Child"}}
-  %0 = firrtl.unresolved_path "OMReferenceTarget:~UpwardPath|UpwardPath>wire"
+  %0 = firrtl.unresolved_path "OMReferenceTarget:~UpwardPath|UpwardPath/child:Child>wire"
 }
 }
 

--- a/test/Dialect/FIRRTL/resolve-paths.mlir
+++ b/test/Dialect/FIRRTL/resolve-paths.mlir
@@ -91,6 +91,30 @@ firrtl.module @Child() {
 
 // -----
 
+// CHECK-LABEL: firrtl.circuit "LocalPath"
+firrtl.circuit "LocalPath" {
+// CHECK: firrtl.module @LocalPath()
+firrtl.module @LocalPath() {
+    // CHECK: %0 = firrtl.path instance distinct[0]<>
+    %0 = firrtl.unresolved_path "OMInstanceTarget:~LocalPath|Child"
+
+    // CHECK: %1 = firrtl.path reference distinct[1]<>
+    %1 = firrtl.unresolved_path "OMReferenceTarget:~LocalPath|Child>wire"
+
+    // CHECK: firrtl.instance child0 @Child()
+    // CHECK: firrtl.instance child1 @Child()
+    firrtl.instance child0 @Child()
+    firrtl.instance child1 @Child()
+}
+// CHECK: firrtl.module @Child() attributes {annotations = [{class = "circt.tracker", id = distinct[0]<>}]}
+firrtl.module @Child() {
+    // CHECK: %wire = firrtl.wire {annotations = [{class = "circt.tracker", id = distinct[1]<>}]} : !firrtl.uint<8>
+    %wire = firrtl.wire : !firrtl.uint<8>
+}
+}
+
+// -----
+
 // CHECK-LABEL: firrtl.circuit "PathMinimization"
 firrtl.circuit "PathMinimization" {
 // CHECK: firrtl.module @PathMinimization()


### PR DESCRIPTION
The existing path support was built up based on the assumption that
every target is unique. That is true for FIRRTL produced by standard
Chisel code, which elaborates unique modules for each instance. We
definitely don't want to limit ourselves to this world, and we should
support targeting things that are multiply instantiated when it is not
ambiguous what we refer to.

This patch relaxes the single-instantiation constraints for local
targets, which refer to a module or something inside a module,
regardless of how many times or at what paths that particular module
was instantiated.

This required a couple changes through the pipeline:

ResolvePaths already had an early exit for the local path case, but
this needed to come before the single-instantiation check.

LowerClasses needed a couple small changes to not enforce the
single-instantiation check in the local path case, and to build a
hierpath that just has a single element.

While this is not a new requirement, we can still get ambiguous local
targets, for instance from nested module prefixing. The error message
in LowerClasses for this case was made a little more clear.