### PR TITLE
[MooreToCore] Fix the stack error caused by the uarray reftype.

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1247,6 +1247,14 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
                               type.getSize());
   });
 
+  // FIXME: In order to avoid the stack error caused by the conversion of
+  // "RefType" which can return "{}", such as "ref<uarray<4xi4>>", we can
+  // convert "moore::uarray" into "hw::array" temporarily.
+  typeConverter.addConversion([&](UnpackedArrayType type) {
+    return hw::UnpackedArrayType::get(
+        typeConverter.convertType(type.getElementType()), type.getSize());
+  });
+
   typeConverter.addConversion([&](StructType type) {
     SmallVector<hw::StructType::FieldInfo> fields;
     for (auto field : type.getMembers()) {


### PR DESCRIPTION
I attempted to convert `moore.uarray` into `hw.array`. However, there is an example that will trigger an error: 
```
error: 'llhd.sig.array_slice' op failed to verify that width of result type has to be smaller than or equal to the input type
  assign uarr[0][2] = 'b0;
         ^
/home/phoenix/work/HDLBits/uarray.sv:3:10: note: see current operation: %5 = "llhd.sig.array_slice"(%3, %4) : (!hw.inout<array<2xarray<4xarray<4xi2>>>>, i1) -> !hw.inout<array<4xarray<4xi2>>>
```
Case:
```
module UnpackedArray;
  logic [3:0][1:0] uarr [0:1][0:3];
  assign uarr[0][2] = 'b0;
endmodule
```

And due to the uarray type like `reg [31:0] Memory[0:31];` will lead to **stack error,** so I decide to convert `moore.uarray` into `hw.uarray`.