### PR TITLE
[FIRRTL] Add features, cleanup InstanceInfo (again)

### DIFF
--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -204,7 +204,27 @@ static llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const bool a) {
   return os << "false";
 }
 
-static void printInfo(firrtl::FModuleOp op, firrtl::InstanceInfo &iInfo) {
+static void printCircuitInfo(firrtl::CircuitOp op,
+                             firrtl::InstanceInfo &iInfo) {
+  OpPrintingFlags flags;
+  flags.skipRegions();
+  llvm::errs() << "  - operation: ";
+  op->print(llvm::errs(), flags);
+  llvm::errs() << "\n"
+               << "    hasDut: " << iInfo.hasDut() << "\n"
+               << "    dut: ";
+  if (auto *dutNode = iInfo.getDut())
+    dutNode->getModule()->print(llvm::errs(), flags);
+  else
+    llvm::errs() << "null";
+  llvm::errs() << "\n"
+               << "    effectiveDut: ";
+  iInfo.getEffectiveDut()->getModule()->print(llvm::errs(), flags);
+  llvm::errs() << "\n";
+}
+
+static void printModuleInfo(igraph::ModuleOpInterface op,
+                            firrtl::InstanceInfo &iInfo) {
   OpPrintingFlags flags;
   flags.skipRegions();
   llvm::errs() << "  - operation: ";
@@ -224,8 +244,10 @@ static void printInfo(firrtl::FModuleOp op, firrtl::InstanceInfo &iInfo) {
 void FIRRTLInstanceInfoPass::runOnOperation() {
   auto &iInfo = getAnalysis<firrtl::InstanceInfo>();
 
-  for (auto op : getOperation().getBodyBlock()->getOps<firrtl::FModuleOp>())
-    printInfo(op, iInfo);
+  printCircuitInfo(getOperation(), iInfo);
+  for (auto op :
+       getOperation().getBodyBlock()->getOps<igraph::ModuleOpInterface>())
+    printModuleInfo(op, iInfo);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
**This reverts a revert.**

Add a number of new features to FIRRTL's `InstanceInfo` analysis.  These changes were made after downstream efforts (uncommitted work) to use this in the `AddSeqMemPorts` pass.  These new features include:

  - `hasDut` to check if a circuit has a design-under-test
  - `getDut` to get the design-under-test if it exists
  - `getEffectiveDut` to get the "effective" design-under-test
  - `isEffectiveDut` to check if a module is the "effective" design-under-test

The "effective" design-under-test (DUT) is a weird artifact of how some SFC-derived passes have historically worked.  If a circuit has no DUT (indicated by a circuit which contains no module annotated with a `MarkDUTAnnotation`), then some passes will treat the top module as if it were the DUT.  This "effective" DUT concept shows up in `AddSeqMemPorts`, `GrandCentral`, and other passes.  For now, enshrine the _computation_ of this in the `InstanceInfo` analysis to avoid having to scatter logic for computing this across serverl passes.

Widen the accepted type of parameters that can be passed to `InstanceInfo` member functions from `FModuleOp` to `igraph::ModuleOpInterface`.  This already works without modifications and makes these member functions much more usable.