### PR TITLE
[circt-bmc] Add `circt-bmc` tool

### DIFF
--- a/integration_test/CMakeLists.txt
+++ b/integration_test/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CIRCT_INTEGRATION_TEST_DEPENDS
   circt-translate
   circt-rtl-sim
   circt-lec
+  circt-bmc
   firtool
   hlstool
   ibistool

--- a/integration_test/circt-bmc/comb-errors.mlir
+++ b/integration_test/circt-bmc/comb-errors.mlir
@@ -1,0 +1,15 @@
+// REQUIRES: libz3
+// REQUIRES: circt-bmc-jit
+
+//  RUN: circt-bmc %s -b 10 --module OrEqAnd --shared-libs=%libz3 | FileCheck %s --check-prefix=OREQAND
+//  OREQAND: Assertion can be violated!
+
+module {
+  hw.module @OrEqAnd(in %i0: i1, in %i1: i1) {
+    %or = comb.or bin %i0, %i1 : i1
+    %and = comb.and bin %i0, %i1 : i1
+    // Condition
+    %cond = comb.icmp bin eq %or, %and : i1
+    verif.assert %cond : i1
+  }
+}

--- a/integration_test/circt-bmc/comb.mlir
+++ b/integration_test/circt-bmc/comb.mlir
@@ -1,0 +1,28 @@
+// REQUIRES: libz3
+// REQUIRES: circt-bmc-jit
+
+//  RUN: circt-bmc %s -b 10 --module OrCommutes --shared-libs=%libz3 | FileCheck %s --check-prefix=ORCOMMUTES
+//  ORCOMMUTES: Bound reached with no violations!
+
+hw.module @OrCommutes(in %i0: i1, in %i1: i1) {
+  %or0 = comb.or bin %i0, %i1 : i1
+  %or1 = comb.or bin %i1, %i0 : i1
+  // Condition
+  %cond = comb.icmp bin eq %or0, %or1 : i1
+  verif.assert %cond : i1
+}
+
+//  RUN: circt-bmc %s -b 10 --module demorgan --shared-libs=%libz3 | FileCheck %s --check-prefix=DEMORGAN
+//  DEMORGAN: Bound reached with no violations!
+
+hw.module @demorgan(in %i0: i1, in %i1: i1) {
+  %c1 = hw.constant 1 : i1
+  %ni0 = comb.xor bin %i0, %c1 : i1
+  %ni1 = comb.xor bin %i1, %c1 : i1
+  %or = comb.or bin %ni0, %ni1 : i1
+  // Condition
+  %and = comb.and bin %i0, %i1 : i1
+  %nand = comb.xor bin %and, %c1 : i1
+  %cond = comb.icmp bin eq %or, %nand : i1
+  verif.assert %cond : i1
+}

--- a/integration_test/circt-bmc/seq-errors.mlir
+++ b/integration_test/circt-bmc/seq-errors.mlir
@@ -1,0 +1,19 @@
+// REQUIRES: libz3
+// REQUIRES: circt-bmc-jit
+
+//  RUN: circt-bmc %s -b 10 --module Counter --shared-libs=%libz3 | FileCheck %s --check-prefix=COUNTER
+//  COUNTER: Assertion can be violated!
+
+hw.module @Counter(in %clk: !seq.clock, out count: i2) {
+  %c1_i2 = hw.constant 1 : i2
+  %regPlusOne = comb.add %reg, %c1_i2 : i2
+  %reg = seq.compreg %regPlusOne, %clk : i2
+  // Condition - count should never reach 3 (deliberately not true)
+  // FIXME: add an initial condition here once we support them, currently it
+  // can be violated on the first cycle as 3 is a potential initial value.
+  // Can also use this to check bounds are behaving as expected.
+  %c3_i2 = hw.constant 3 : i2
+  %lt = comb.icmp ult %reg, %c3_i2 : i2
+  verif.assert %lt : i1
+  hw.output %reg : i2
+}

--- a/integration_test/circt-bmc/seq.mlir
+++ b/integration_test/circt-bmc/seq.mlir
@@ -1,0 +1,34 @@
+// REQUIRES: libz3
+// REQUIRES: circt-bmc-jit
+
+//  RUN: circt-bmc %s -b 10 --module ClkProp --shared-libs=%libz3 | FileCheck %s --check-prefix=CLKPROP
+//  CLKPROP: Bound reached with no violations!
+
+hw.module @ClkProp(in %clk: !seq.clock, in %i0: i1) {
+  %reg = seq.compreg %i0, %clk : i1
+  // Condition (equivalent to %clk -> %reg == %i0)
+  %c-1_i1 = hw.constant -1 : i1
+  %clk_i1 = seq.from_clock %clk
+  %nclk = comb.xor bin %clk_i1, %c-1_i1 : i1
+  %eq = comb.icmp bin eq %i0, %reg : i1
+  %imp = comb.or bin %nclk, %eq : i1
+  verif.assert %imp : i1
+}
+
+// Check propagation of state through comb ops
+
+//  RUN: circt-bmc %s -b 10 --module StateProp --shared-libs=%libz3 | FileCheck %s --check-prefix=STATEPROP
+//  STATEPROP: Bound reached with no violations!
+
+hw.module @StateProp(in %clk: !seq.clock, in %i0: i1) {
+  %c-1_i1 = hw.constant -1 : i1
+  %reg = seq.compreg %i0, %clk : i1
+  %not_reg = comb.xor bin %reg, %c-1_i1 : i1
+  %not_not_reg = comb.xor bin %not_reg, %c-1_i1 : i1
+  // Condition (equivalent to %clk -> %reg == %not_not_reg)
+  %clk_i1 = seq.from_clock %clk
+  %nclk = comb.xor bin %clk_i1, %c-1_i1 : i1
+  %eq = comb.icmp bin eq %not_not_reg, %reg : i1
+  %imp = comb.or bin %nclk, %eq : i1
+  verif.assert %imp : i1
+}

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -79,7 +79,8 @@ tool_dirs = [
 ]
 tools = [
     'arcilator', 'circt-opt', 'circt-translate', 'firtool', 'circt-rtl-sim.py',
-    'equiv-rtl.sh', 'handshake-runner', 'hlstool', 'ibistool', 'circt-lec'
+    'equiv-rtl.sh', 'handshake-runner', 'hlstool', 'ibistool', 'circt-lec',
+    'circt-bmc'
 ]
 
 # Enable python if its path was configured
@@ -216,6 +217,7 @@ if config.z3_library != "":
 if config.mlir_enable_execution_engine:
   config.available_features.add('mlir-cpu-runner')
   config.available_features.add('circt-lec-jit')
+  config.available_features.add('circt-bmc-jit')
   tools.append('mlir-cpu-runner')
 
 # Add circt-verilog if the Slang frontend is enabled.

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(arcilator)
 add_subdirectory(circt-as)
+add_subdirectory(circt-bmc)
 add_subdirectory(circt-cocotb-driver)
 add_subdirectory(circt-dis)
 add_subdirectory(circt-lec)

--- a/tools/circt-bmc/CMakeLists.txt
+++ b/tools/circt-bmc/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(circt-bmc
   MLIRTargetLLVMIRExport
   MLIRFuncInlinerExtension
   MLIRBuiltinToLLVMIRTranslation
-  MLIRLLVMToLLVMIRTranslation
   LLVMSupport
 
   ${CIRCT_BMC_JIT_DEPS}

--- a/tools/circt-bmc/CMakeLists.txt
+++ b/tools/circt-bmc/CMakeLists.txt
@@ -1,0 +1,41 @@
+if(MLIR_ENABLE_EXECUTION_ENGINE)
+  add_compile_definitions(CIRCT_BMC_ENABLE_JIT)
+  set(CIRCT_BMC_JIT_LLVM_COMPONENTS native)
+  set(CIRCT_BMC_JIT_DEPS
+    MLIRExecutionEngine
+    MLIRExecutionEngineUtils
+  )
+endif()
+
+set(LLVM_LINK_COMPONENTS Support ${CIRCT_BMC_JIT_LLVM_COMPONENTS})
+
+add_circt_tool(circt-bmc circt-bmc.cpp)
+target_link_libraries(circt-bmc
+  PRIVATE
+  CIRCTBMCTransforms
+  CIRCTSMTToZ3LLVM
+  CIRCTHWToSMT
+  CIRCTCombToSMT
+  CIRCTVerifToSMT
+  CIRCTComb
+  CIRCTHW
+  CIRCTSeq
+  CIRCTSMT
+  CIRCTVerif
+  CIRCTSupport
+  MLIRIR
+  MLIRFuncDialect
+  MLIRArithDialect
+  MLIRLLVMIRTransforms
+  MLIRLLVMToLLVMIRTranslation
+  MLIRTargetLLVMIRExport
+  MLIRFuncInlinerExtension
+  MLIRBuiltinToLLVMIRTranslation
+  MLIRLLVMToLLVMIRTranslation
+  LLVMSupport
+
+  ${CIRCT_BMC_JIT_DEPS}
+)
+
+llvm_update_compile_flags(circt-bmc)
+mlir_check_all_link_libraries(circt-bmc)

--- a/tools/circt-bmc/circt-bmc.cpp
+++ b/tools/circt-bmc/circt-bmc.cpp
@@ -98,7 +98,7 @@ static cl::opt<OutputFormat> outputFormat(
     cl::desc("Specify output format"),
     cl::values(clEnumValN(OutputMLIR, "emit-mlir", "Emit LLVM MLIR dialect"),
                clEnumValN(OutputLLVM, "emit-llvm", "Emit LLVM"),
-               clEnumValN(OutputSMTLIB, "emit-smtlib", "Emit object file"),
+               clEnumValN(OutputSMTLIB, "emit-smtlib", "Emit SMT-LIB file"),
                clEnumValN(OutputRunJIT, "run",
                           "Perform BMC and output result")),
     cl::init(OutputRunJIT), cl::cat(mainCategory));
@@ -123,7 +123,7 @@ static cl::opt<OutputFormat> outputFormat(
 // Tool implementation
 //===----------------------------------------------------------------------===//
 
-/// This functions initializes the various components of the tool and
+/// This function initializes the various components of the tool and
 /// orchestrates the work to be done.
 static LogicalResult executeBMC(MLIRContext &context) {
   // Create the timing manager we use to sample execution times.
@@ -173,7 +173,6 @@ static LogicalResult executeBMC(MLIRContext &context) {
 
   if (outputFormat != OutputMLIR && outputFormat != OutputSMTLIB) {
     LowerSMTToZ3LLVMOptions options;
-    options.debug = true;
     pm.addPass(createLowerSMTToZ3LLVM(options));
     pm.addPass(createCSEPass());
     pm.addPass(createSimpleCanonicalizerPass());

--- a/tools/circt-bmc/circt-bmc.cpp
+++ b/tools/circt-bmc/circt-bmc.cpp
@@ -114,7 +114,7 @@ static cl::opt<OutputFormat> outputFormat(
     cl::desc("Specify output format"),
     cl::values(clEnumValN(OutputMLIR, "emit-mlir", "Emit LLVM MLIR dialect"),
                clEnumValN(OutputLLVM, "emit-llvm", "Emit LLVM"),
-               clEnumValN(OutputSMTLIB, "emit-smtlib", "Emit object file")),
+               clEnumValN(OutputSMTLIB, "emit-smtlib", "Emit SMT-LIB file")),
     cl::init(OutputLLVM), cl::cat(mainCategory));
 
 #endif

--- a/tools/circt-bmc/circt-bmc.cpp
+++ b/tools/circt-bmc/circt-bmc.cpp
@@ -1,0 +1,322 @@
+//===- circt-bmc.cpp - The circt-bmc bounded model checker ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the 'circt-bmc' tool
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Conversion/CombToSMT.h"
+#include "circt/Conversion/HWToSMT.h"
+#include "circt/Conversion/SMTToZ3LLVM.h"
+#include "circt/Conversion/VerifToSMT.h"
+#include "circt/Dialect/Comb/CombDialect.h"
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/SMT/SMTDialect.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Verif/VerifDialect.h"
+#include "circt/Support/Passes.h"
+#include "circt/Support/Version.h"
+#include "circt/Tools/circt-bmc/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/Transforms/Passes.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Export.h"
+#include "mlir/Transforms/Passes.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/PrettyStackTrace.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ToolOutputFile.h"
+
+#ifdef CIRCT_BMC_ENABLE_JIT
+#include "mlir/ExecutionEngine/ExecutionEngine.h"
+#include "mlir/ExecutionEngine/OptUtils.h"
+#include "llvm/Support/TargetSelect.h"
+#endif
+
+namespace cl = llvm::cl;
+
+using namespace mlir;
+using namespace circt;
+
+//===----------------------------------------------------------------------===//
+// Command-line options declaration
+//===----------------------------------------------------------------------===//
+
+static cl::OptionCategory mainCategory("circt-bmc Options");
+
+static cl::opt<std::string>
+    moduleName("module",
+               cl::desc("Specify a named module to verify properties over."),
+               cl::value_desc("module name"), cl::cat(mainCategory));
+
+static cl::opt<int> clockBound(
+    "b", cl::Required,
+    cl::desc("Specify a number of clock cycles to model check up to."),
+    cl::value_desc("clock cycle count"), cl::cat(mainCategory));
+
+static cl::opt<std::string> inputFilename(cl::Positional, cl::Required,
+                                          cl::desc("<input file>"),
+                                          cl::cat(mainCategory));
+
+static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
+                                           cl::value_desc("filename"),
+                                           cl::init("-"),
+                                           cl::cat(mainCategory));
+
+static cl::opt<bool>
+    verifyPasses("verify-each",
+                 cl::desc("Run the verifier after each transformation pass"),
+                 cl::init(true), cl::cat(mainCategory));
+
+static cl::opt<bool>
+    verbosePassExecutions("verbose-pass-executions",
+                          cl::desc("Log executions of toplevel module passes"),
+                          cl::init(false), cl::cat(mainCategory));
+
+#ifdef CIRCT_BMC_ENABLE_JIT
+
+enum OutputFormat { OutputMLIR, OutputLLVM, OutputSMTLIB, OutputRunJIT };
+static cl::opt<OutputFormat> outputFormat(
+    cl::desc("Specify output format"),
+    cl::values(clEnumValN(OutputMLIR, "emit-mlir", "Emit LLVM MLIR dialect"),
+               clEnumValN(OutputLLVM, "emit-llvm", "Emit LLVM"),
+               clEnumValN(OutputSMTLIB, "emit-smtlib", "Emit object file"),
+               clEnumValN(OutputRunJIT, "run",
+                          "Perform BMC and output result")),
+    cl::init(OutputRunJIT), cl::cat(mainCategory));
+
+static cl::list<std::string> sharedLibs{
+    "shared-libs", llvm::cl::desc("Libraries to link dynamically"),
+    cl::MiscFlags::CommaSeparated, llvm::cl::cat(mainCategory)};
+
+#elif
+
+enum OutputFormat { OutputMLIR, OutputLLVM, OutputSMTLIB };
+static cl::opt<OutputFormat> outputFormat(
+    cl::desc("Specify output format"),
+    cl::values(clEnumValN(OutputMLIR, "emit-mlir", "Emit LLVM MLIR dialect"),
+               clEnumValN(OutputLLVM, "emit-llvm", "Emit LLVM"),
+               clEnumValN(OutputSMTLIB, "emit-smtlib", "Emit object file")),
+    cl::init(OutputLLVM), cl::cat(mainCategory));
+
+#endif
+
+//===----------------------------------------------------------------------===//
+// Tool implementation
+//===----------------------------------------------------------------------===//
+
+/// This functions initializes the various components of the tool and
+/// orchestrates the work to be done.
+static LogicalResult executeBMC(MLIRContext &context) {
+  // Create the timing manager we use to sample execution times.
+  DefaultTimingManager tm;
+  applyDefaultTimingManagerCLOptions(tm);
+  auto ts = tm.getRootScope();
+
+  OwningOpRef<ModuleOp> module;
+  {
+    auto parserTimer = ts.nest("Parse MLIR input");
+    // Parse the provided input files.
+    module = parseSourceFile<ModuleOp>(inputFilename, &context);
+  }
+  if (!module)
+    return failure();
+
+  // Create the output directory or output file depending on our mode.
+  std::optional<std::unique_ptr<llvm::ToolOutputFile>> outputFile;
+  std::string errorMessage;
+  // Create an output file.
+  outputFile.emplace(openOutputFile(outputFilename, &errorMessage));
+  if (!outputFile.value()) {
+    llvm::errs() << errorMessage << "\n";
+    return failure();
+  }
+
+  PassManager pm(&context);
+  pm.enableVerifier(verifyPasses);
+  pm.enableTiming(ts);
+  if (failed(applyPassManagerCLOptions(pm)))
+    return failure();
+
+  if (verbosePassExecutions)
+    pm.addInstrumentation(
+        std::make_unique<VerbosePassInstrumentation<mlir::ModuleOp>>(
+            "circt-bmc"));
+
+  pm.addPass(createExternalizeRegisters());
+  LowerToBMCOptions lowerToBMCOptions;
+  lowerToBMCOptions.bound = clockBound;
+  lowerToBMCOptions.topModule = moduleName;
+  pm.addPass(createLowerToBMC(lowerToBMCOptions));
+  pm.addPass(createConvertHWToSMT());
+  pm.addPass(createConvertCombToSMT());
+  pm.addPass(createConvertVerifToSMT());
+  pm.addPass(createSimpleCanonicalizerPass());
+
+  if (outputFormat != OutputMLIR && outputFormat != OutputSMTLIB) {
+    LowerSMTToZ3LLVMOptions options;
+    options.debug = true;
+    pm.addPass(createLowerSMTToZ3LLVM(options));
+    pm.addPass(createCSEPass());
+    pm.addPass(createSimpleCanonicalizerPass());
+    pm.addPass(LLVM::createDIScopeForLLVMFuncOpPass());
+  }
+
+  if (failed(pm.run(module.get())))
+    return failure();
+
+  if (outputFormat == OutputMLIR) {
+    auto timer = ts.nest("Print MLIR output");
+    OpPrintingFlags printingFlags;
+    module->print(outputFile.value()->os(), printingFlags);
+    outputFile.value()->keep();
+    return success();
+  }
+
+  if (outputFormat == OutputSMTLIB) {
+    auto timer = ts.nest("Print SMT-LIB output");
+    llvm::errs() << "Printing SMT-LIB not yet supported!\n";
+    return failure();
+  }
+
+  if (outputFormat == OutputLLVM) {
+    auto timer = ts.nest("Translate to and print LLVM output");
+    llvm::LLVMContext llvmContext;
+    auto llvmModule = mlir::translateModuleToLLVMIR(module.get(), llvmContext);
+    if (!llvmModule)
+      return failure();
+    llvmModule->print(outputFile.value()->os(), nullptr);
+    outputFile.value()->keep();
+    return success();
+  }
+
+#ifdef CIRCT_BMC_ENABLE_JIT
+
+  auto handleErr = [](llvm::Error error) -> LogicalResult {
+    llvm::handleAllErrors(std::move(error),
+                          [](const llvm::ErrorInfoBase &info) {
+                            llvm::errs() << "Error: ";
+                            info.log(llvm::errs());
+                            llvm::errs() << '\n';
+                          });
+    return failure();
+  };
+
+  std::unique_ptr<mlir::ExecutionEngine> engine;
+  {
+    auto timer = ts.nest("Setting up the JIT");
+    auto entryPoint =
+        dyn_cast_or_null<LLVM::LLVMFuncOp>(module->lookupSymbol(moduleName));
+    if (!entryPoint || entryPoint.empty()) {
+      llvm::errs() << "no valid entry point found, expected 'llvm.func' named '"
+                   << moduleName << "'\n";
+      return failure();
+    }
+
+    if (entryPoint.getNumArguments() != 0) {
+      llvm::errs() << "entry point '" << moduleName
+                   << "' must have no arguments";
+      return failure();
+    }
+
+    llvm::InitializeNativeTarget();
+    llvm::InitializeNativeTargetAsmPrinter();
+
+    SmallVector<StringRef, 4> sharedLibraries(sharedLibs.begin(),
+                                              sharedLibs.end());
+    mlir::ExecutionEngineOptions engineOptions;
+    engineOptions.transformer = mlir::makeOptimizingTransformer(
+        /*optLevel*/ 3, /*sizeLevel=*/0, /*targetMachine=*/nullptr);
+    engineOptions.jitCodeGenOptLevel = llvm::CodeGenOptLevel::Aggressive;
+    engineOptions.sharedLibPaths = sharedLibraries;
+    engineOptions.enableObjectDump = true;
+
+    auto expectedEngine =
+        mlir::ExecutionEngine::create(module.get(), engineOptions);
+    if (!expectedEngine)
+      return handleErr(expectedEngine.takeError());
+
+    engine = std::move(*expectedEngine);
+  }
+
+  auto timer = ts.nest("JIT Execution");
+  if (auto err = engine->invokePacked(moduleName))
+    return handleErr(std::move(err));
+
+  return success();
+#else
+  return failure();
+#endif
+}
+
+/// The entry point for the `circt-bmc` tool:
+/// configures and parses the command-line options,
+/// registers all dialects within a MLIR context,
+/// and calls the `executeBMC` function to do the actual work.
+int main(int argc, char **argv) {
+  llvm::InitLLVM y(argc, argv);
+
+  // Hide default LLVM options, other than for this tool.
+  // MLIR options are added below.
+  cl::HideUnrelatedOptions(mainCategory);
+
+  // Register any pass manager command line options.
+  registerMLIRContextCLOptions();
+  registerPassManagerCLOptions();
+  registerDefaultTimingManagerCLOptions();
+  registerAsmPrinterCLOptions();
+  cl::AddExtraVersionPrinter(
+      [](llvm::raw_ostream &os) { os << circt::getCirctVersion() << '\n'; });
+
+  // Parse the command-line options provided by the user.
+  cl::ParseCommandLineOptions(
+      argc, argv,
+      "circt-bmc - bounded model checker\n\n"
+      "\tThis tool checks all possible executions of a hardware module up to a "
+      "given time bound to check whether any asserted properties can be "
+      "violated.\n");
+
+  // Set the bug report message to indicate users should file issues on
+  // llvm/circt and not llvm/llvm-project.
+  llvm::setBugReportMsg(circt::circtBugReportMsg);
+
+  // Register the supported CIRCT dialects and create a context to work with.
+  DialectRegistry registry;
+  registry.insert<circt::comb::CombDialect, circt::hw::HWDialect,
+                  circt::seq::SeqDialect, circt::smt::SMTDialect,
+                  mlir::func::FuncDialect, circt::verif::VerifDialect,
+                  mlir::LLVM::LLVMDialect, mlir::arith::ArithDialect,
+                  mlir::BuiltinDialect>();
+  mlir::func::registerInlinerExtension(registry);
+  mlir::registerBuiltinDialectTranslation(registry);
+  mlir::registerLLVMDialectTranslation(registry);
+  MLIRContext context(registry);
+
+  // Setup of diagnostic handling.
+  llvm::SourceMgr sourceMgr;
+  SourceMgrDiagnosticHandler sourceMgrHandler(sourceMgr, &context);
+  // Avoid printing a superfluous note on diagnostic emission.
+  context.printOpOnDiagnostic(false);
+
+  // Perform the logical equivalence checking; using `exit` to avoid the slow
+  // teardown of the MLIR context.
+  exit(failed(executeBMC(context)));
+}


### PR DESCRIPTION
This is the final split part of #7259, and adds a `circt-bmc` tool to use all of the BMC op infrastructure to perform bounded model checks!