### PR TITLE
[FIRRTL] Error mixed DUT mems in AddSeqMemPorts

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -185,6 +185,26 @@ InstanceGraphNode *AddSeqMemPortsPass::findDUT() {
 }
 
 LogicalResult AddSeqMemPortsPass::processMemModule(FMemModuleOp mem) {
+  // Error if the circuit has a DUT and if the instances are not under the
+  // design-under-test.
+  if (instanceInfo->hasDut() && !instanceInfo->allInstancesUnderDut(mem)) {
+    auto diag = mem->emitOpError()
+                << "cannot have ports added to it because it is instantiated "
+                   "both under and not under the design-under-test (DUT)";
+    for (auto *instNode : instanceGraph->lookup(mem)->uses()) {
+      auto instanceOp = instNode->getInstance();
+      if (instanceInfo->anyInstanceUnderDut(
+              instNode->getParent()->getModule())) {
+        diag.attachNote(instanceOp.getLoc())
+            << "this instance is under the DUT";
+        continue;
+      }
+      diag.attachNote(instanceOp.getLoc())
+          << "this instance is not under the DUT";
+    }
+    return failure();
+  }
+
   // Error if the memory is partially under a layer.
   //
   // TODO: There are several ways to handle a memory being under a layer:

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -185,8 +185,7 @@ InstanceGraphNode *AddSeqMemPortsPass::findDUT() {
 }
 
 LogicalResult AddSeqMemPortsPass::processMemModule(FMemModuleOp mem) {
-  // Error if the circuit has a DUT and if the instances are not under the
-  // design-under-test.
+  // Error if all instances are not under the effective DUT.
   if (!instanceInfo->allInstancesUnderEffectiveDut(mem)) {
     auto diag = mem->emitOpError()
                 << "cannot have ports added to it because it is instantiated "

--- a/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/AddSeqMemPorts.cpp
@@ -187,7 +187,7 @@ InstanceGraphNode *AddSeqMemPortsPass::findDUT() {
 LogicalResult AddSeqMemPortsPass::processMemModule(FMemModuleOp mem) {
   // Error if the circuit has a DUT and if the instances are not under the
   // design-under-test.
-  if (instanceInfo->hasDut() && !instanceInfo->allInstancesUnderDut(mem)) {
+  if (!instanceInfo->allInstancesUnderEffectiveDut(mem)) {
     auto diag = mem->emitOpError()
                 << "cannot have ports added to it because it is instantiated "
                    "both under and not under the design-under-test (DUT)";

--- a/test/Dialect/FIRRTL/add-seqmem-ports-errors.mlir
+++ b/test/Dialect/FIRRTL/add-seqmem-ports-errors.mlir
@@ -184,3 +184,66 @@ firrtl.circuit "LayerBlock" attributes {
   }
 
 }
+
+// -----
+
+// Test that a memory that is instantiated under the design-under-test (DUT) and
+// _not_ under the DUT will error.
+//
+// See: https://github.com/llvm/circt/issues/7620
+firrtl.circuit "Foo" attributes {
+  annotations = [
+    {
+      class = "sifive.enterprise.firrtl.AddSeqMemPortAnnotation",
+      name = "user_input",
+      input = true,
+      width = 1
+    }
+  ]
+} {
+  firrtl.layer @A bind {}
+
+  // expected-error @below {{cannot have ports added to it}}
+  firrtl.memmodule @mem(
+    in waddr: !firrtl.uint<1>,
+    in wen: !firrtl.uint<1>,
+    in wclk: !firrtl.clock,
+    in wdata: !firrtl.uint<1>
+  ) attributes {
+    dataWidth = 1 : ui32,
+    depth = 2 : ui64,
+    extraPorts = [],
+    maskBits = 1 : ui32,
+    numReadPorts = 0 : ui32,
+    numReadWritePorts = 0 : ui32,
+    numWritePorts = 1 : ui32,
+    readLatency = 1 : ui32,
+    writeLatency = 1 : ui32
+  }
+
+  firrtl.module @Bar() attributes {
+    annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
+    ]
+  } {
+    // expected-note @below {{this instance is under the DUT}}
+    %0:4 = firrtl.instance mem @mem(
+      in waddr: !firrtl.uint<1>,
+      in wen: !firrtl.uint<1>,
+      in wclk: !firrtl.clock,
+      in wdata: !firrtl.uint<1>
+    )
+  }
+
+  firrtl.module @Foo() {
+    firrtl.instance bar @Bar()
+    // expected-note @below {{this instance is not under the DUT}}
+    %0:4 = firrtl.instance mem @mem(
+      in waddr: !firrtl.uint<1>,
+      in wen: !firrtl.uint<1>,
+      in wclk: !firrtl.clock,
+      in wdata: !firrtl.uint<1>
+    )
+  }
+
+}


### PR DESCRIPTION
Change AddSeqMemPorts to reject circuits where a memory is instantiated under both the design-under-test (DUT) and _not_ under the DUT.  This is a situation that indicates that ports should be added to one instance, but not the other.  While there are a number of ways that this could be solved (similarly to with mixed under layer / _not_ under layer) by transforming the design via recursive deduplication or by tying off the modified memory, these approaches are rejected for now in favor of just catching the error.  Mid-term I would prefer to delete this pass entirely as it has general composition problems with other passes and FIRRTL features.

Fixes #7620.