### PR TITLE
[ImportVerilog] Add support for elaboration system tasks

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -69,6 +69,11 @@ struct BaseVisitor {
     return success();
   }
 
+  // Skip elaboration system tasks. These are reported directly by Slang.
+  LogicalResult visit(const slang::ast::ElabSystemTaskSymbol &) {
+    return success();
+  }
+
   // Handle parameters.
   LogicalResult visit(const slang::ast::ParameterSymbol &param) {
     visitParameter(param);

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -72,3 +72,23 @@ module Foo;
   // expected-error @below {{unpacked arrays in 'inside' expressions not supported}}
   int c = a inside { b };
 endmodule
+
+// -----
+module Foo;
+  // expected-remark @below {{hello}}
+  $info("hello");
+  // expected-warning @below {{hello}}
+  $warning("hello");
+endmodule
+
+// -----
+module Foo;
+  // expected-error @below {{hello}}
+  $error("hello");
+endmodule
+
+// -----
+module Foo;
+  // expected-error @below {{hello}}
+  $fatal(0, "hello");
+endmodule


### PR DESCRIPTION
Simply skip the elaboration system tasks `$info`, `$warning`, `$error`, and `$fatal` outside procedural code. Slang already processes these tasks and generates the corresponding diagnostics for us.