### PR TITLE
[FIRRTL] Add verifier of single MarkDUTAnnotation

### DIFF
--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -2561,3 +2561,33 @@ firrtl.circuit "MainNotModule" {
     return
   }
 }
+
+// -----
+
+firrtl.circuit "MultipleDUTModules" {
+  firrtl.module @MultipleDUTModules() {}
+  // expected-error @below {{is annotated as the design-under-test}}
+  firrtl.module @Foo() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {}
+  // expected-note @below {{is also annotated as the DUT}}
+  firrtl.module @Bar() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {}
+  // expected-note @below {{is also annotated as the DUT}}
+  firrtl.module @Baz() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {}
+}


### PR DESCRIPTION
Add a CircuitOp verifier that guarantees that there is zero or one modules annotated with a `MarkDUTAnnotation`.  This is important as many passes assume that this is the case.  Moving this check into a verifier means that logic checking this behavior in each pass can be removed.  I am slightly concerned of the performance cost of doing this as examining the annotations is non-trivial and this will cause that examination to now happen more often.