### PR TITLE
[FIRRTL] Convert CheckLayers to use InstanceInfo

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CheckLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckLayers.cpp
@@ -12,8 +12,8 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Support/InstanceGraphInterface.h"
 #include "mlir/Pass/Pass.h"
-#include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/DepthFirstIterator.h"
+#include "llvm/ADT/PostOrderIterator.h"
 
 namespace circt {
 namespace firrtl {


### PR DESCRIPTION
Change the `CheckLayers` pass to use the `InstanceInfo` analysis.  This
new analysis makes the error checking trivial.  However, the error
reporting is still somewhat tedious.