### PR TITLE
[FIRRTL][LowerLayers] Remove handling of some ref ops

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -539,22 +539,6 @@ LogicalResult LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
         return WalkResult::interrupt();
       }
 
-      // Beyond this point, we are handling operations which capture values
-      // defined outside the layerblock.  Whenever we see this, we need to
-      // create ports for the module that this layerblock will become.
-      if (auto refSend = dyn_cast<RefSendOp>(op)) {
-        auto src = refSend.getBase();
-        if (!isAncestorOfValueOwner(layerBlock, src))
-          createInputPort(src, op.getLoc());
-        continue;
-      }
-
-      if (auto refCast = dyn_cast<RefCastOp>(op)) {
-        if (!isAncestorOfValueOwner(layerBlock, refCast))
-          createInputPort(refCast.getInput(), op.getLoc());
-        continue;
-      }
-
       if (auto rwprobe = dyn_cast<RWProbeOp>(op)) {
         rwprobes.push_back(rwprobe);
         continue;


### PR DESCRIPTION
Remove code that handles the capturing of ref cast and ref send operands specially, since this code is doing only what the generic capture-handling code does just a few lines [below](https://github.com/llvm/circt/blob/main/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp#L611-L616).

There is a bug in the handling of ref.cast which is removed by this change: We are accidentally checking that the cast op itself is within the layerblock, when we should actually be checking if its operand is defined within the layerblock. This causes us to skip converting the captured operand of a ref.cast op into a port. The generic codepath works fine.