### PR TITLE
[ImportVerilog] Add $display/$write/$info/$warning/$error/$fatal

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1358,6 +1358,84 @@ def CoverOp : ImmediateAssertOp<"cover">{
 }
 
 //===----------------------------------------------------------------------===//
+// Format Strings
+//===----------------------------------------------------------------------===//
+
+def FormatLiteralOp : MooreOp<"fmt.literal", [Pure]> {
+  let summary = "A constant string fragment";
+  let description = [{
+    Creates a constant string fragment to be used as a format string. The
+    literal is printed as is, without any further escaping or processing of its
+    characters.
+  }];
+  let arguments = (ins StrAttr:$literal);
+  let results = (outs FormatStringType:$result);
+  let assemblyFormat = "$literal attr-dict";
+}
+
+def FormatConcatOp : MooreOp<"fmt.concat", [Pure]> {
+  let summary = "Concatenate string fragments";
+  let description = [{
+    Concatenates an arbitrary number of format string into one larger format
+    string. The strings are concatenated from left to right, with the first
+    operand appearing at the left start of the result string, and the last
+    operand appearing at the right end. Produces an empty string if no inputs
+    are provided.
+  }];
+  let arguments = (ins Variadic<FormatStringType>:$inputs);
+  let results = (outs FormatStringType:$result);
+  let assemblyFormat = "` ` `(` $inputs `)` attr-dict";
+}
+
+def FmtDec : I32EnumAttrCase<"Decimal", 0, "decimal">;
+def FmtBin : I32EnumAttrCase<"Binary", 1, "binary">;
+def FmtOct : I32EnumAttrCase<"Octal", 2, "octal">;
+def FmtHexL : I32EnumAttrCase<"HexLower", 3, "hex_lower">;
+def FmtHexU : I32EnumAttrCase<"HexUpper", 4, "hex_upper">;
+def IntFormatAttr : I32EnumAttr<"IntFormat", "Integer format",
+                               [FmtDec, FmtBin, FmtOct, FmtHexL, FmtHexU]> {
+  let cppNamespace = "circt::moore";
+}
+
+def AlignRight : I32EnumAttrCase<"Right", 0, "right">;
+def AlignLeft : I32EnumAttrCase<"Left", 1, "left">;
+def IntAlignAttr : I32EnumAttr<"IntAlign", "Integer alignment",
+                              [AlignRight, AlignLeft]> {
+  let cppNamespace = "circt::moore";
+}
+
+def PadSpace : I32EnumAttrCase<"Space", 0, "space">;
+def PadZero : I32EnumAttrCase<"Zero", 1, "zero">;
+def IntPaddingAttr : I32EnumAttr<"IntPadding", "Integer alignment",
+                                 [PadSpace, PadZero]> {
+  let cppNamespace = "circt::moore";
+}
+
+def FormatIntOp : MooreOp<"fmt.int", [Pure]> {
+  let summary = "Format an integer value";
+  let description = [{
+    Format an integer value as a string according to the specified format.
+
+    See IEEE 1800-2017 § 21.2.1.2 "Format specifications".
+  }];
+  let arguments = (ins
+    IntType:$value,
+    IntFormatAttr:$format,
+    I32Attr:$width,
+    IntAlignAttr:$alignment,
+    IntPaddingAttr:$padding
+  );
+  let results = (outs FormatStringType:$result);
+  let assemblyFormat = [{
+    $format $value `,`
+    `width` $width `,`
+    `align` $alignment `,`
+    `pad` $padding
+    attr-dict `:` type($value)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Builtin System Tasks and Functions
 //===----------------------------------------------------------------------===//
 
@@ -1418,6 +1496,52 @@ def FinishMessageBIOp : Builtin<"finish_message"> {
   }];
   let arguments = (ins I1Attr:$withStats);
   let assemblyFormat = "$withStats attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// Severity and Display
+//===----------------------------------------------------------------------===//
+
+def DisplayBIOp : Builtin<"display"> {
+  let summary = "Print a text message";
+  let description = [{
+    Prints the given format string to the standard text output of the simulator.
+    In most cases this should be stdout. This corresponds to the `$display` and
+    `$write` system tasks. Message formatting is handled by `moore.fmt.*` ops.
+
+    See IEEE 1800-2017 § 21.2 "Display system tasks".
+  }];
+  let arguments = (ins FormatStringType:$message);
+  let assemblyFormat = "$message attr-dict";
+}
+
+def SeverityInfo : I32EnumAttrCase<"Info", 0, "info">;
+def SeverityWarning : I32EnumAttrCase<"Warning", 1, "warning">;
+def SeverityError : I32EnumAttrCase<"Error", 2, "error">;
+def SeverityFatal : I32EnumAttrCase<"Fatal", 3, "fatal">;
+def SeverityAttr : I32EnumAttr<"Severity", "Diagnostic severity", [
+  SeverityInfo, SeverityWarning, SeverityError, SeverityFatal
+]> {
+  let cppNamespace = "circt::moore";
+}
+
+def SeverityBIOp : Builtin<"severity"> {
+  let summary = "Print a diagnostic message";
+  let description = [{
+    Prints the given format string to the standard diagnostic output of the
+    simulator. In most cases this should be stderr. This corresponds to the
+    `$info`, `$warning`, `$error`, and `$fatal` system tasks. Message formatting
+    is handled by `moore.fmt.*` ops. This only handles the message printing of
+    `$fatal`; printing of the additional statistics and the call to `$finish`
+    must be done through the `finish_message` and `finish` ops.
+
+    See IEEE 1800-2017 § 20.10 "Severity tasks".
+  }];
+  let arguments = (ins
+    SeverityAttr:$severity,
+    FormatStringType:$message
+  );
+  let assemblyFormat = "$severity $message attr-dict";
 }
 
 #endif // CIRCT_DIALECT_MOORE_MOOREOPS

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -375,6 +375,21 @@ def RefType : MooreTypeDef<"Ref", [
 }
 
 //===----------------------------------------------------------------------===//
+// Format String
+//===----------------------------------------------------------------------===//
+
+def FormatStringType : MooreTypeDef<"FormatString"> {
+  let mnemonic = "format_string";
+  let summary = "a format string type";
+  let description = [{
+    An interpolated string produced by one of the string formatting operations.
+    It is used to parse format strings present in Verilog source text and
+    represent them as a sequence of IR operations that specify the formatting of
+    individual arguments.
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Constraints
 //===----------------------------------------------------------------------===//
 

--- a/lib/Conversion/ImportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ImportVerilog/CMakeLists.txt
@@ -30,6 +30,7 @@ endif ()
 
 add_circt_translation_library(CIRCTImportVerilog
   Expressions.cpp
+  FormatStrings.cpp
   ImportVerilog.cpp
   Statements.cpp
   Structure.cpp

--- a/lib/Conversion/ImportVerilog/FormatStrings.cpp
+++ b/lib/Conversion/ImportVerilog/FormatStrings.cpp
@@ -1,0 +1,199 @@
+//===- FormatStrings.cpp - Verilog format string conversion ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ImportVerilogInternals.h"
+#include "slang/text/SFormat.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace ImportVerilog;
+using moore::IntAlign;
+using moore::IntFormat;
+using moore::IntPadding;
+using slang::SFormat::FormatOptions;
+
+namespace {
+struct FormatStringParser {
+  Context &context;
+  OpBuilder &builder;
+  /// The remaining arguments to be parsed.
+  ArrayRef<const slang::ast::Expression *> arguments;
+  /// The current location to use for ops and diagnostics.
+  Location loc;
+  /// The default format for integer arguments not covered by a format string
+  /// literal.
+  IntFormat defaultFormat;
+  /// The interpolated string fragments that will be concatenated using a
+  /// `moore.fmt.concat` op.
+  SmallVector<Value> fragments;
+
+  FormatStringParser(Context &context,
+                     ArrayRef<const slang::ast::Expression *> arguments,
+                     Location loc, IntFormat defaultFormat)
+      : context(context), builder(context.builder), arguments(arguments),
+        loc(loc), defaultFormat(defaultFormat) {}
+
+  /// Entry point to the format string parser.
+  FailureOr<Value> parse(bool appendNewline) {
+    while (!arguments.empty()) {
+      const auto &arg = *arguments[0];
+      arguments = arguments.drop_front();
+      if (arg.kind == slang::ast::ExpressionKind::EmptyArgument)
+        continue;
+      loc = context.convertLocation(arg.sourceRange);
+      if (auto *lit = arg.as_if<slang::ast::StringLiteral>()) {
+        if (failed(parseFormat(lit->getValue())))
+          return failure();
+      } else {
+        if (failed(emitDefault(arg)))
+          return failure();
+      }
+    }
+
+    // Append the optional newline.
+    if (appendNewline)
+      emitLiteral("\n");
+
+    // Concatenate all string fragments into one formatted string, or return an
+    // empty literal if no fragments were generated.
+    if (fragments.empty())
+      return Value{};
+    if (fragments.size() == 1)
+      return fragments[0];
+    return builder.create<moore::FormatConcatOp>(loc, fragments).getResult();
+  }
+
+  /// Parse a format string literal and consume and format the arguments
+  /// corresponding to the format specifiers it contains.
+  LogicalResult parseFormat(StringRef format) {
+    bool anyFailure = false;
+    auto onText = [&](auto text) {
+      if (anyFailure)
+        return;
+      emitLiteral(text);
+    };
+    auto onArg = [&](auto specifier, auto offset, auto len,
+                     const auto &options) {
+      if (anyFailure)
+        return;
+      if (failed(emitArgument(specifier, format.substr(offset, len), options)))
+        anyFailure = true;
+    };
+    auto onError = [&](auto, auto, auto, auto) {
+      assert(false && "Slang should have already reported all errors");
+    };
+    slang::SFormat::parse(format, onText, onArg, onError);
+    return failure(anyFailure);
+  }
+
+  /// Emit a string literal that requires no additional formatting.
+  void emitLiteral(StringRef literal) {
+    fragments.push_back(builder.create<moore::FormatLiteralOp>(loc, literal));
+  }
+
+  /// Consume the next argument from the list and emit it according to the given
+  /// format specifier.
+  LogicalResult emitArgument(char specifier, StringRef fullSpecifier,
+                             const FormatOptions &options) {
+    auto specifierLower = std::tolower(specifier);
+
+    // Special handling for format specifiers that consume no argument.
+    if (specifierLower == 'm' || specifierLower == 'l')
+      return mlir::emitError(loc)
+             << "unsupported format specifier `" << fullSpecifier << "`";
+
+    // Consume the next argument, which will provide the value to be
+    // formatted.
+    assert(!arguments.empty() && "Slang guarantees correct arg count");
+    const auto &arg = *arguments[0];
+    arguments = arguments.drop_front();
+    auto argLoc = context.convertLocation(arg.sourceRange);
+
+    // Handle the different formatting options.
+    // See IEEE 1800-2017 § 21.2.1.2 "Format specifications".
+    switch (specifierLower) {
+    case 'b':
+      return emitInteger(arg, options, IntFormat::Binary);
+    case 'o':
+      return emitInteger(arg, options, IntFormat::Octal);
+    case 'd':
+      return emitInteger(arg, options, IntFormat::Decimal);
+    case 'h':
+    case 'x':
+      return emitInteger(arg, options,
+                         std::isupper(specifier) ? IntFormat::HexUpper
+                                                 : IntFormat::HexLower);
+
+    case 's':
+      // Simplified handling for literals.
+      if (auto *lit = arg.as_if<slang::ast::StringLiteral>()) {
+        if (options.width)
+          return mlir::emitError(loc)
+                 << "string format specifier with width not supported";
+        emitLiteral(lit->getValue());
+        return success();
+      }
+      return mlir::emitError(argLoc)
+             << "expression cannot be formatted as string";
+
+    default:
+      return mlir::emitError(loc)
+             << "unsupported format specifier `" << fullSpecifier << "`";
+    }
+  }
+
+  /// Emit an integer value with the given format.
+  LogicalResult emitInteger(const slang::ast::Expression &arg,
+                            const FormatOptions &options, IntFormat format) {
+    auto value =
+        context.convertToSimpleBitVector(context.convertRvalueExpression(arg));
+    if (!value)
+      return failure();
+
+    // Determine the width to which the formatted integer should be padded.
+    unsigned width;
+    if (options.width) {
+      width = *options.width;
+    } else {
+      width = cast<moore::IntType>(value.getType()).getWidth();
+      if (format == IntFormat::Octal)
+        // 3 bits per octal digit
+        width = (width + 2) / 3;
+      else if (format == IntFormat::HexLower || format == IntFormat::HexUpper)
+        // 4 bits per hex digit
+        width = (width + 3) / 4;
+      else if (format == IntFormat::Decimal)
+        // ca. 3.322 bits per decimal digit (ln(10)/ln(2))
+        width = std::ceil(width * std::log(2) / std::log(10));
+    }
+
+    // Determine the alignment and padding.
+    auto alignment = options.leftJustify ? IntAlign::Left : IntAlign::Right;
+    auto padding =
+        format == IntFormat::Decimal ? IntPadding::Space : IntPadding::Zero;
+
+    fragments.push_back(builder.create<moore::FormatIntOp>(
+        loc, value, format, width, alignment, padding));
+    return success();
+  }
+
+  /// Emit an expression argument with the appropriate default formatting.
+  LogicalResult emitDefault(const slang::ast::Expression &expr) {
+    FormatOptions options;
+    return emitInteger(expr, options, defaultFormat);
+  }
+};
+} // namespace
+
+FailureOr<Value> Context::convertFormatString(
+    slang::span<const slang::ast::Expression *const> arguments, Location loc,
+    IntFormat defaultFormat, bool appendNewline) {
+  FormatStringParser parser(*this, ArrayRef(arguments.data(), arguments.size()),
+                            loc, defaultFormat);
+  return parser.parse(appendNewline);
+}

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -116,6 +116,11 @@ struct Context {
   /// convert it to the given domain.
   Value convertToBool(Value value, Domain domain);
 
+  /// Helper function to convert a value to its simple bit vector
+  /// representation, if it has one. Otherwise returns null. Also returns null
+  /// if the given value is null.
+  Value convertToSimpleBitVector(Value value);
+
   /// Helper function to materialize an `SVInt` as an SSA value.
   Value materializeSVInt(const slang::SVInt &svint,
                          const slang::ast::Type &type, Location loc);
@@ -124,6 +129,15 @@ struct Context {
   /// null if the constant cannot be materialized.
   Value materializeConstant(const slang::ConstantValue &constant,
                             const slang::ast::Type &type, Location loc);
+
+  /// Convert a list of string literal arguments with formatting specifiers and
+  /// arguments to be interpolated into a `!moore.format_string` value. Returns
+  /// failure if an error occurs. Returns a null value if the formatted string
+  /// is trivially empty. Otherwise returns the formatted string.
+  FailureOr<Value> convertFormatString(
+      slang::span<const slang::ast::Expression *const> arguments, Location loc,
+      moore::IntFormat defaultFormat = moore::IntFormat::Decimal,
+      bool appendNewline = false);
 
   /// Evaluate the constant value of an expression.
   slang::ConstantValue evaluateConstant(const slang::ast::Expression &expr);

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -2055,3 +2055,150 @@ function void SimulationControlBuiltins(bit x);
   // CHECK-NOT: moore.builtin.finish
   $exit;
 endfunction
+
+// CHECK-LABEL: func.func private @DisplayAndSeverityBuiltins(
+// CHECK-SAME: [[X:%.+]]: !moore.i32
+function void DisplayAndSeverityBuiltins(int x);
+  // CHECK: [[TMP:%.+]] = moore.fmt.literal "\0A"
+  // CHECK: moore.builtin.display [[TMP]]
+  $display;
+  // CHECK: [[TMP1:%.+]] = moore.fmt.literal "hello"
+  // CHECK: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK: moore.builtin.display [[TMP3]]
+  $display("hello");
+
+  // CHECK-NOT: moore.builtin.display
+  $write;
+  $write(,);
+  // CHECK: [[TMP:%.+]] = moore.fmt.literal "hello\0A world \\ foo ! bar % \22"
+  // CHECK: moore.builtin.display [[TMP]]
+  $write("hello\n world \\ foo \x21 bar %% \042");
+
+  // CHECK: [[TMP1:%.+]] = moore.fmt.literal "foo "
+  // CHECK: [[TMP2:%.+]] = moore.fmt.literal "bar"
+  // CHECK: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK: moore.builtin.display [[TMP3]]
+  $write("foo %s", "bar");
+
+  // CHECK: moore.fmt.int binary [[X]], width 32, align right, pad zero : i32
+  $write("%b", x);
+  // CHECK: moore.fmt.int binary [[X]], width 32, align right, pad zero : i32
+  $write("%B", x);
+  // CHECK: moore.fmt.int binary [[X]], width 0, align right, pad zero : i32
+  $write("%0b", x);
+  // CHECK: moore.fmt.int binary [[X]], width 42, align right, pad zero : i32
+  $write("%42b", x);
+  // CHECK: moore.fmt.int binary [[X]], width 42, align left, pad zero : i32
+  $write("%-42b", x);
+
+  // CHECK: moore.fmt.int octal [[X]], width 11, align right, pad zero : i32
+  $write("%o", x);
+  // CHECK: moore.fmt.int octal [[X]], width 11, align right, pad zero : i32
+  $write("%O", x);
+  // CHECK: moore.fmt.int octal [[X]], width 0, align right, pad zero : i32
+  $write("%0o", x);
+  // CHECK: moore.fmt.int octal [[X]], width 19, align right, pad zero : i32
+  $write("%19o", x);
+  // CHECK: moore.fmt.int octal [[X]], width 19, align left, pad zero : i32
+  $write("%-19o", x);
+
+  // CHECK: moore.fmt.int decimal [[X]], width 10, align right, pad space : i32
+  $write("%d", x);
+  // CHECK: moore.fmt.int decimal [[X]], width 10, align right, pad space : i32
+  $write("%D", x);
+  // CHECK: moore.fmt.int decimal [[X]], width 0, align right, pad space : i32
+  $write("%0d", x);
+  // CHECK: moore.fmt.int decimal [[X]], width 19, align right, pad space : i32
+  $write("%19d", x);
+  // CHECK: moore.fmt.int decimal [[X]], width 19, align left, pad space : i32
+  $write("%-19d", x);
+
+  // CHECK: moore.fmt.int hex_lower [[X]], width 8, align right, pad zero : i32
+  $write("%h", x);
+  // CHECK: moore.fmt.int hex_lower [[X]], width 8, align right, pad zero : i32
+  $write("%x", x);
+  // CHECK: moore.fmt.int hex_upper [[X]], width 8, align right, pad zero : i32
+  $write("%H", x);
+  // CHECK: moore.fmt.int hex_upper [[X]], width 8, align right, pad zero : i32
+  $write("%X", x);
+  // CHECK: moore.fmt.int hex_lower [[X]], width 0, align right, pad zero : i32
+  $write("%0h", x);
+  // CHECK: moore.fmt.int hex_lower [[X]], width 19, align right, pad zero : i32
+  $write("%19h", x);
+  // CHECK: moore.fmt.int hex_lower [[X]], width 19, align right, pad zero : i32
+  $write("%019h", x);
+  // CHECK: moore.fmt.int hex_lower [[X]], width 19, align left, pad zero : i32
+  $write("%-19h", x);
+  // CHECK: moore.fmt.int hex_lower [[X]], width 19, align left, pad zero : i32
+  $write("%-019h", x);
+
+  // CHECK: [[TMP:%.+]] = moore.fmt.int decimal [[X]], width 10, align right, pad space : i32
+  // CHECK: moore.builtin.display [[TMP]]
+  $write(x);
+  // CHECK: [[TMP:%.+]] = moore.fmt.int binary [[X]], width 32, align right, pad zero : i32
+  // CHECK: moore.builtin.display [[TMP]]
+  $writeb(x);
+  // CHECK: [[TMP:%.+]] = moore.fmt.int octal [[X]], width 11, align right, pad zero : i32
+  // CHECK: moore.builtin.display [[TMP]]
+  $writeo(x);
+  // CHECK: [[TMP:%.+]] = moore.fmt.int hex_lower [[X]], width 8, align right, pad zero : i32
+  // CHECK: moore.builtin.display [[TMP]]
+  $writeh(x);
+
+  // CHECK: [[TMP1:%.+]] = moore.fmt.int decimal [[X]], width 10, align right, pad space : i32
+  // CHECK: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK: moore.builtin.display [[TMP3]]
+  $display(x);
+  // CHECK: [[TMP1:%.+]] = moore.fmt.int binary [[X]], width 32, align right, pad zero : i32
+  // CHECK: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK: moore.builtin.display [[TMP3]]
+  $displayb(x);
+  // CHECK: [[TMP1:%.+]] = moore.fmt.int octal [[X]], width 11, align right, pad zero : i32
+  // CHECK: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK: moore.builtin.display [[TMP3]]
+  $displayo(x);
+  // CHECK: [[TMP1:%.+]] = moore.fmt.int hex_lower [[X]], width 8, align right, pad zero : i32
+  // CHECK: [[TMP2:%.+]] = moore.fmt.literal "\0A"
+  // CHECK: [[TMP3:%.+]] = moore.fmt.concat ([[TMP1]], [[TMP2]])
+  // CHECK: moore.builtin.display [[TMP3]]
+  $displayh(x);
+
+  // CHECK: [[TMP:%.+]] = moore.fmt.literal ""
+  // CHECK: moore.builtin.severity info [[TMP]]
+  $info;
+  // CHECK: [[TMP:%.+]] = moore.fmt.int
+  // CHECK: moore.builtin.severity info [[TMP]]
+  $info("%d", x);
+  // CHECK: [[TMP:%.+]] = moore.fmt.literal ""
+  // CHECK: moore.builtin.severity warning [[TMP]]
+  $warning;
+  // CHECK: [[TMP:%.+]] = moore.fmt.int
+  // CHECK: moore.builtin.severity warning [[TMP]]
+  $warning("%d", x);
+  // CHECK: [[TMP:%.+]] = moore.fmt.literal ""
+  // CHECK: moore.builtin.severity error [[TMP]]
+  $error;
+  // CHECK: [[TMP:%.+]] = moore.fmt.int
+  // CHECK: moore.builtin.severity error [[TMP]]
+  $error("%d", x);
+  // CHECK: [[TMP:%.+]] = moore.fmt.literal ""
+  // CHECK: moore.builtin.severity fatal [[TMP]]
+  // CHECK: moore.builtin.finish_message false
+  // CHECK: moore.builtin.finish 1
+  // CHECK: moore.unreachable
+  if (0) $fatal;
+  // CHECK-NOT: moore.builtin.finish_message
+  // CHECK: moore.unreachable
+  if (0) $fatal(0);
+  // CHECK: moore.builtin.finish_message true
+  // CHECK: moore.unreachable
+  if (0) $fatal(2);
+  // CHECK: [[TMP:%.+]] = moore.fmt.int
+  // CHECK: moore.builtin.severity fatal [[TMP]]
+  // CHECK: moore.unreachable
+  if (0) $fatal(1, "%d", x);
+endfunction

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -92,3 +92,17 @@ module Foo;
   // expected-error @below {{hello}}
   $fatal(0, "hello");
 endmodule
+
+// -----
+module Top; endmodule
+function Foo;
+  // expected-error @below {{unsupported format specifier `%l`}}
+  $write("%l");
+endfunction
+
+// -----
+module Top; endmodule
+function Foo;
+  // expected-error @below {{string format specifier with width not supported}}
+  $write("%42s", "foo");
+endfunction

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -330,6 +330,35 @@ func.func @WaitEvent(%arg0: !moore.i1, %arg1: !moore.i1) {
   return
 }
 
+
+// CHECK-LABEL: func.func @FormatStrings
+// CHECK-SAME: %arg0: !moore.format_string
+func.func @FormatStrings(%arg0: !moore.format_string, %arg1: !moore.i42) {
+  // CHECK: moore.fmt.literal "hello"
+  moore.fmt.literal "hello"
+  // CHECK: moore.fmt.concat ()
+  moore.fmt.concat ()
+  // CHECK: moore.fmt.concat (%arg0)
+  moore.fmt.concat (%arg0)
+  // CHECK: moore.fmt.concat (%arg0, %arg0)
+  moore.fmt.concat (%arg0, %arg0)
+  // CHECK: moore.fmt.int binary %arg1, width 42, align left, pad zero : i42
+  moore.fmt.int binary %arg1, width 42, align left, pad zero : i42
+  // CHECK: moore.fmt.int binary %arg1, width 42, align right, pad zero : i42
+  moore.fmt.int binary %arg1, width 42, align right, pad zero : i42
+  // CHECK: moore.fmt.int binary %arg1, width 42, align right, pad space : i42
+  moore.fmt.int binary %arg1, width 42, align right, pad space : i42
+  // CHECK: moore.fmt.int octal %arg1, width 42, align left, pad zero : i42
+  moore.fmt.int octal %arg1, width 42, align left, pad zero : i42
+  // CHECK: moore.fmt.int decimal %arg1, width 42, align left, pad zero : i42
+  moore.fmt.int decimal %arg1, width 42, align left, pad zero : i42
+  // CHECK: moore.fmt.int hex_lower %arg1, width 42, align left, pad zero : i42
+  moore.fmt.int hex_lower %arg1, width 42, align left, pad zero : i42
+  // CHECK: moore.fmt.int hex_upper %arg1, width 42, align left, pad zero : i42
+  moore.fmt.int hex_upper %arg1, width 42, align left, pad zero : i42
+  return
+}
+
 // CHECK-LABEL: func.func @SimulationControlBuiltins
 func.func @SimulationControlBuiltins() {
   // CHECK: moore.builtin.stop
@@ -340,4 +369,19 @@ func.func @SimulationControlBuiltins() {
   moore.builtin.finish_message false
   // CHECK: moore.unreachable
   moore.unreachable
+}
+
+// CHECK-LABEL: func.func @SeverityAndDisplayBuiltins
+func.func @SeverityAndDisplayBuiltins(%arg0: !moore.format_string) {
+  // CHECK: moore.builtin.display %arg0
+  moore.builtin.display %arg0
+  // CHECK: moore.builtin.severity info %arg0
+  moore.builtin.severity info %arg0
+  // CHECK: moore.builtin.severity warning %arg0
+  moore.builtin.severity warning %arg0
+  // CHECK: moore.builtin.severity error %arg0
+  moore.builtin.severity error %arg0
+  // CHECK: moore.builtin.severity fatal %arg0
+  moore.builtin.severity fatal %arg0
+  return
 }


### PR DESCRIPTION
Add support for the `$display`, `$write`, `$info`, `$warning`, `$error`, and `$fatal` system tasks.

These tasks are pretty complicated since they involve string formatting. Verilog has quite a few format specifiers and very strange rules for them. Luckily, Slang contains a handy utility that parses format strings and delegates handling of arguments and intermittent pieces of text to callbacks.

I've decided to follow the same IR design as the printing op in the Sim dialect: each format specifier is turned into a dedicated op that captures all relevant format options, plus additional literals for the text in between interpolated values, and concatenate everything into a single `!moore.format_string`. (Shoutout to @fzi-hielscher for trailblazing the nice design for `sim.print`!) This is handled in a new `FormatStrings.cpp` file inside of ImportVerilog.

The actual system tasks are mapped to new `moore.builtin.display` and `moore.builtin.severity` ops. These handle only the printing of the message in question, plus potential error bookkeeping. The `$fatal` system task creates additional `moore.builtin.finish_message` and `moore.builtin.finish` ops to represent its implicit call to `$finish`.

The implementation also handles the strange `$displayb`, `$displayo`, `$displayh`, `$writeb`, `$writeo`, and `$writeh` flavors of the tasks, where the suffix indicates the default format to use for arguments that are not covered by a format string literal. SystemVerilog is weird.

Thanks @hailongSun2000 for your prior work on this!