### PR TITLE
[Analysis] Add OpCount Analysis

### DIFF
--- a/include/circt/Analysis/OpCountAnalysis.h
+++ b/include/circt/Analysis/OpCountAnalysis.h
@@ -25,11 +25,18 @@ class AnalysisManager;
 namespace circt {
 namespace analysis {
 
-struct OpCountAnalysis {
+class OpCountAnalysis {
+public:
   OpCountAnalysis(Operation *moduleOp, mlir::AnalysisManager &am);
 
+  /// Get the frequency of operations of a specific name
   size_t getOpCount(OperationName opName);
+
+  /// Get the names of all distinct operations found by the analysis
   SmallVector<OperationName> getFoundOpNames();
+
+  /// Get a map from number of operands to corresponding frequency for the given
+  /// operation
   DenseMap<size_t, size_t> getOperandCountMap(OperationName opName);
 
 private:

--- a/include/circt/Analysis/OpCountAnalysis.h
+++ b/include/circt/Analysis/OpCountAnalysis.h
@@ -1,0 +1,40 @@
+//===- OpCountAnalysis.h - operation count analyses -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes for methods that perform analysis
+// involving the quantity of different kinds of operation.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_ANALYSIS_OPCOUNT_ANALYSIS_H
+#define CIRCT_ANALYSIS_OPCOUNT_ANALYSIS_H
+
+#include "circt/Support/LLVM.h"
+#include "llvm/ADT/DenseMap.h"
+
+namespace mlir {
+class AnalysisManager;
+} // namespace mlir
+namespace circt {
+namespace analysis {
+
+struct OpCountAnalysis {
+  OpCountAnalysis(Operation *moduleOp, mlir::AnalysisManager &am);
+
+  size_t getOpCount(OperationName opName);
+  DenseMap<size_t, size_t> getOperandCountMap(OperationName opName);
+
+private:
+  DenseMap<OperationName, size_t> opCounts;
+  DenseMap<OperationName, DenseMap<size_t, size_t>> operandCounts;
+};
+
+} // namespace analysis
+} // namespace circt
+
+#endif // CIRCT_ANALYSIS_SCHEDULING_ANALYSIS_H

--- a/include/circt/Analysis/OpCountAnalysis.h
+++ b/include/circt/Analysis/OpCountAnalysis.h
@@ -7,7 +7,8 @@
 //===----------------------------------------------------------------------===//
 //
 // This header file defines prototypes for methods that perform analysis
-// involving the quantity of different kinds of operation.
+// involving the frequency of different kinds of operations found in a
+// builtin.module.
 //
 //===----------------------------------------------------------------------===//
 
@@ -15,6 +16,7 @@
 #define CIRCT_ANALYSIS_OPCOUNT_ANALYSIS_H
 
 #include "circt/Support/LLVM.h"
+#include "mlir/IR/Operation.h"
 #include "llvm/ADT/DenseMap.h"
 
 namespace mlir {
@@ -27,6 +29,7 @@ struct OpCountAnalysis {
   OpCountAnalysis(Operation *moduleOp, mlir::AnalysisManager &am);
 
   size_t getOpCount(OperationName opName);
+  SmallVector<OperationName> getFoundOpNames();
   DenseMap<size_t, size_t> getOperandCountMap(OperationName opName);
 
 private:

--- a/include/circt/Analysis/OpCountAnalysis.h
+++ b/include/circt/Analysis/OpCountAnalysis.h
@@ -47,4 +47,4 @@ private:
 } // namespace analysis
 } // namespace circt
 
-#endif // CIRCT_ANALYSIS_SCHEDULING_ANALYSIS_H
+#endif // CIRCT_ANALYSIS_OPCOUNT_ANALYSIS_H

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -58,6 +58,7 @@ add_circt_library(CIRCTAnalysisTestPasses
   LINK_LIBS PUBLIC
   CIRCTDebugAnalysis
   CIRCTDependenceAnalysis
+  CIRCTOpCountAnalysis
   CIRCTFIRRTLAnalysis
   CIRCTSchedulingAnalysis
   CIRCTHW

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_OPTIONAL_SOURCES
   DebugInfo.cpp
   DependenceAnalysis.cpp
   FIRRTLInstanceInfo.cpp
+  OpCountAnalysis.cpp
   SchedulingAnalysis.cpp
   TestPasses.cpp
 )
@@ -25,6 +26,13 @@ add_circt_library(CIRCTDependenceAnalysis
   MLIRIR
   MLIRAffineUtils
   MLIRTransformUtils
+)
+
+add_circt_library(CIRCTOpCountAnalysis
+  OpCountAnalysis.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRPass
 )
 
 add_circt_library(CIRCTSchedulingAnalysis

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -32,7 +32,7 @@ add_circt_library(CIRCTOpCountAnalysis
   OpCountAnalysis.cpp
 
   LINK_LIBS PUBLIC
-  MLIRPass
+  MLIRIR
 )
 
 add_circt_library(CIRCTSchedulingAnalysis

--- a/lib/Analysis/OpCountAnalysis.cpp
+++ b/lib/Analysis/OpCountAnalysis.cpp
@@ -23,17 +23,10 @@ OpCountAnalysis::OpCountAnalysis(Operation *moduleOp,
   moduleOp->walk([&](Operation *op) {
     auto opName = op->getName();
     // Update opCounts
-    if (opCounts.find(opName) == opCounts.end())
-      opCounts[opName] = 1;
-    else
-      opCounts[opName]++;
+    opCounts[opName]++;
 
     // Update operandCounts
-    auto &counts = operandCounts[opName];
-    if (counts.find(op->getNumOperands()) == counts.end())
-      counts[op->getNumOperands()] = 1;
-    else
-      counts[op->getNumOperands()]++;
+    operandCounts[opName][op->getNumOperands()]++;
   });
 }
 
@@ -45,9 +38,7 @@ SmallVector<OperationName> OpCountAnalysis::getFoundOpNames() {
 }
 
 size_t OpCountAnalysis::getOpCount(OperationName opName) {
-  if (opCounts.find(opName) != opCounts.end())
-    return opCounts[opName];
-  return 0;
+  return opCounts[opName];
 }
 
 DenseMap<size_t, size_t>

--- a/lib/Analysis/OpCountAnalysis.cpp
+++ b/lib/Analysis/OpCountAnalysis.cpp
@@ -1,0 +1,53 @@
+//===- OpCountAnalysis.cpp - operation count analyses -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the InstanceInfo analysis.  This is an analysis that
+// depends on the InstanceGraph analysis, but provides additional information
+// about FIRRTL operations.  This is useful if you find yourself needing to
+// selectively iterate over parts of the design.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Analysis/OpCountAnalysis.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/OperationSupport.h"
+
+using namespace circt;
+
+circt::analysis::OpCountAnalysis::OpCountAnalysis(Operation *moduleOp, mlir::AnalysisManager &am) {
+  moduleOp->walk([&](Operation *op) {
+    auto opName = op->getName();
+    // Update opCounts
+    if (opCounts.find(opName) == opCounts.end())
+      opCounts[opName] = 1;
+    else
+      opCounts[op->getName()]++;
+    
+    // Update operandCounts
+    if (operandCounts.find(opName) == operandCounts.end())
+      operandCounts[opName] = DenseMap<size_t, size_t>();
+    if (operandCounts[opName].find(op->getNumOperands()) == operandCounts[opName].end())
+      operandCounts[opName][op->getNumOperands()] = 1;
+    else
+      operandCounts[opName][op->getNumOperands()]++;
+  });
+}
+
+size_t circt::analysis::OpCountAnalysis::getOpCount(OperationName opName) {
+  size_t count = 0;
+  if (opCounts.find(opName) != opCounts.end())
+    count = opCounts[opName];
+  return count;
+}
+
+DenseMap<size_t, size_t> circt::analysis::OpCountAnalysis::getOperandCountMap(OperationName opName) {
+  auto map = DenseMap<size_t, size_t>();
+  if (operandCounts.find(opName) != operandCounts.end())
+    map = operandCounts[opName];
+  return map;
+}

--- a/lib/Analysis/OpCountAnalysis.cpp
+++ b/lib/Analysis/OpCountAnalysis.cpp
@@ -26,16 +26,14 @@ OpCountAnalysis::OpCountAnalysis(Operation *moduleOp,
     if (opCounts.find(opName) == opCounts.end())
       opCounts[opName] = 1;
     else
-      opCounts[op->getName()]++;
+      opCounts[opName]++;
 
     // Update operandCounts
-    if (operandCounts.find(opName) == operandCounts.end())
-      operandCounts[opName] = DenseMap<size_t, size_t>();
-    if (operandCounts[opName].find(op->getNumOperands()) ==
-        operandCounts[opName].end())
-      operandCounts[opName][op->getNumOperands()] = 1;
+    auto &counts = operandCounts[opName];
+    if (counts.find(op->getNumOperands()) == counts.end())
+      counts[op->getNumOperands()] = 1;
     else
-      operandCounts[opName][op->getNumOperands()]++;
+      counts[op->getNumOperands()]++;
   });
 }
 
@@ -47,16 +45,12 @@ SmallVector<OperationName> OpCountAnalysis::getFoundOpNames() {
 }
 
 size_t OpCountAnalysis::getOpCount(OperationName opName) {
-  size_t count = 0;
   if (opCounts.find(opName) != opCounts.end())
-    count = opCounts[opName];
-  return count;
+    return opCounts[opName];
+  return 0;
 }
 
 DenseMap<size_t, size_t>
 OpCountAnalysis::getOperandCountMap(OperationName opName) {
-  auto map = DenseMap<size_t, size_t>();
-  if (operandCounts.find(opName) != operandCounts.end())
-    map = operandCounts[opName];
-  return map;
+  return operandCounts[opName];
 }

--- a/lib/Analysis/OpCountAnalysis.cpp
+++ b/lib/Analysis/OpCountAnalysis.cpp
@@ -41,9 +41,8 @@ OpCountAnalysis::OpCountAnalysis(Operation *moduleOp,
 
 SmallVector<OperationName> OpCountAnalysis::getFoundOpNames() {
   SmallVector<OperationName> opNames;
-  for (auto pair : opCounts) {
+  for (auto pair : opCounts)
     opNames.push_back(pair.first);
-  }
   return opNames;
 }
 

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -283,10 +283,9 @@ void printOpAndOperandCounts(OpCountAnalysis &opCount) {
     for (auto pair : operandMap)
       keys.push_back(pair.first);
     llvm::sort(keys);
-    for (auto num : keys) {
+    for (auto num : keys)
       llvm::errs() << " with " << num << " operands: " << operandMap[num]
                    << "\n";
-    }
   }
 }
 

--- a/lib/Analysis/TestPasses.cpp
+++ b/lib/Analysis/TestPasses.cpp
@@ -13,6 +13,7 @@
 #include "circt/Analysis/DebugAnalysis.h"
 #include "circt/Analysis/DependenceAnalysis.h"
 #include "circt/Analysis/FIRRTLInstanceInfo.h"
+#include "circt/Analysis/OpCountAnalysis.h"
 #include "circt/Analysis/SchedulingAnalysis.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/HW/HWInstanceGraph.h"
@@ -251,6 +252,50 @@ void FIRRTLInstanceInfoPass::runOnOperation() {
 }
 
 //===----------------------------------------------------------------------===//
+// Op Count
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct TestOpCountAnalysisPass
+    : public PassWrapper<TestOpCountAnalysisPass, OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestOpCountAnalysisPass)
+
+  void runOnOperation() override;
+  StringRef getArgument() const override { return "test-op-count-analysis"; }
+  StringRef getDescription() const override {
+    return "Run OpCountAnalysis and show the results.  This pass "
+           "is intended to be used for testing purposes only.";
+  }
+};
+} // namespace
+
+void printOpAndOperandCounts(OpCountAnalysis &opCount) {
+  auto opNames = opCount.getFoundOpNames();
+  // Sort to account for non-deterministic DenseMap ordering
+  llvm::sort(opNames, [](OperationName name1, OperationName name2) {
+    return name1.getStringRef() < name2.getStringRef();
+  });
+  for (auto opName : opNames) {
+    llvm::errs() << opName << ": " << opCount.getOpCount(opName) << "\n";
+    auto operandMap = opCount.getOperandCountMap(opName);
+    // Sort for determinism again
+    llvm::SmallVector<size_t> keys;
+    for (auto pair : operandMap)
+      keys.push_back(pair.first);
+    llvm::sort(keys);
+    for (auto num : keys) {
+      llvm::errs() << " with " << num << " operands: " << operandMap[num]
+                   << "\n";
+    }
+  }
+}
+
+void TestOpCountAnalysisPass::runOnOperation() {
+  auto &opCount = getAnalysis<OpCountAnalysis>();
+  printOpAndOperandCounts(opCount);
+}
+
+//===----------------------------------------------------------------------===//
 // Pass registration
 //===----------------------------------------------------------------------===//
 
@@ -271,6 +316,9 @@ void registerAnalysisTestPasses() {
   });
   registerPass([]() -> std::unique_ptr<Pass> {
     return std::make_unique<FIRRTLInstanceInfoPass>();
+  });
+  registerPass([]() -> std::unique_ptr<Pass> {
+    return std::make_unique<TestOpCountAnalysisPass>();
   });
 }
 } // namespace test

--- a/test/Analysis/op-count-analysis.mlir
+++ b/test/Analysis/op-count-analysis.mlir
@@ -1,0 +1,36 @@
+// RUN: circt-opt -test-op-count-analysis %s 2>&1 | FileCheck %s
+
+// CHECK: builtin.module: 1
+// CHECK:  with 0 operands: 1
+// CHECK: comb.add: 4
+// CHECK:  with 1 operands: 1
+// CHECK:  with 2 operands: 1
+// CHECK:  with 3 operands: 2
+// CHECK: comb.icmp: 1
+// CHECK:  with 2 operands: 1
+// CHECK: comb.xor: 1
+// CHECK:  with 1 operands: 1
+// CHECK: hw.module: 1
+// CHECK:  with 0 operands: 1
+// CHECK: hw.output: 1
+// CHECK:  with 0 operands: 1
+// CHECK: scf.if: 1
+// CHECK:  with 1 operands: 1
+// CHECK: scf.yield: 2
+// CHECK:  with 1 operands: 2
+
+module {
+  hw.module @bar(in %in1: i8, in %in2: i8, in %in3: i8) {
+    %add2 = comb.add %in1, %in2 : i8
+    %add3 = comb.add %in1, %in2, %in3 : i8
+    %add3again = comb.add %in1, %in3, %in3 : i8
+    %gt = comb.icmp ult %in1, %in2 : i8
+    %x = scf.if %gt -> (i8) {
+        %add1 = comb.add %in1 : i8
+        scf.yield %add1 : i8
+    } else {
+        %xor = comb.xor %add2 : i8
+        scf.yield %xor : i8
+    }
+  }
+}


### PR DESCRIPTION
Adds a very simple analysis pass to collect information about the kinds of operations (and operand counts) found in a `hw.module` so we can look at operation usage across big designs. Once this is upstream I'll add a pass to export this info as JSON.