### PR TITLE
[ImportVerilog] Support assignment patterns with integer type

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1443,7 +1443,7 @@ class Builtin<string mnemonic, list<Trait> traits = []> :
     MooreOp<"builtin." # mnemonic, traits>;
 
 //===----------------------------------------------------------------------===//
-// Simulation Control
+// Simulation Control Builtins
 //===----------------------------------------------------------------------===//
 
 def StopBIOp : Builtin<"stop"> {
@@ -1499,7 +1499,7 @@ def FinishMessageBIOp : Builtin<"finish_message"> {
 }
 
 //===----------------------------------------------------------------------===//
-// Severity and Display
+// Severity and Display Builtins
 //===----------------------------------------------------------------------===//
 
 def DisplayBIOp : Builtin<"display"> {
@@ -1542,6 +1542,28 @@ def SeverityBIOp : Builtin<"severity"> {
     FormatStringType:$message
   );
   let assemblyFormat = "$severity $message attr-dict";
+}
+
+//===----------------------------------------------------------------------===//
+// Math Builtins
+//===----------------------------------------------------------------------===//
+
+def Clog2BIOp : Builtin<"clog2", [SameOperandsAndResultType]> {
+  let summary = "Compute ceil(log2(x)) of x";
+  let description = [{
+    Computes the ceiling of the base-2 logarithm of the argument. The argument
+    is interpreted as unsigned. The result is 0 if the argument is 0. The result
+    corresponds to the minimum address width necessary to address a given number
+    of elements, or the number of bits necessary to represent a given number of
+    states.
+
+    If any of the bits in the argument are X or Z, the result is X.
+
+    See IEEE 1800-2017 § 20.8.1 "Integer math functions".
+  }];
+  let arguments = (ins IntType:$value);
+  let results = (outs IntType:$result);
+  let assemblyFormat = "$value attr-dict `:` type($value)";
 }
 
 #endif // CIRCT_DIALECT_MOORE_MOOREOPS

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -735,6 +735,13 @@ struct RvalueExprVisitor {
       for (unsigned elementIdx = 0; elementIdx < elementCount; ++elementIdx)
         elements.push_back(elements[elementIdx]);
 
+    // Handle integers.
+    if (auto intType = dyn_cast<moore::IntType>(type)) {
+      assert(intType.getWidth() == elements.size());
+      std::reverse(elements.begin(), elements.end());
+      return builder.create<moore::ConcatOp>(loc, intType, elements);
+    }
+
     // Handle packed structs.
     if (auto structType = dyn_cast<moore::StructType>(type)) {
       assert(structType.getMembers().size() == elements.size());

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -691,9 +691,18 @@ struct RvalueExprVisitor {
   Value visitCall(const slang::ast::CallExpression &expr,
                   const slang::ast::CallExpression::SystemCallInfo &info) {
     const auto &subroutine = *info.subroutine;
+    auto args = expr.arguments();
 
     if (subroutine.name == "$signed" || subroutine.name == "$unsigned")
-      return context.convertRvalueExpression(*expr.arguments()[0]);
+      return context.convertRvalueExpression(*args[0]);
+
+    if (subroutine.name == "$clog2") {
+      auto value = context.convertToSimpleBitVector(
+          context.convertRvalueExpression(*args[0]));
+      if (!value)
+        return {};
+      return builder.create<moore::Clog2BIOp>(loc, value);
+    }
 
     mlir::emitError(loc) << "unsupported system call `" << subroutine.name
                          << "`";

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -655,6 +655,8 @@ module Expressions;
   bit [1:0][31:0] arrayInt;
   // CHECK: %uarrayInt = moore.variable : <uarray<2 x i32>>
   bit [31:0] uarrayInt [2];
+  // CHECK: %m = moore.variable : <l4>
+  logic [3:0] m;
 
   initial begin
     // CHECK: moore.constant 0 : i32
@@ -1275,6 +1277,13 @@ module Expressions;
     // CHECK: [[TMP3:%.+]] = moore.array_create [[TMP0]], [[TMP1]], [[TMP2]], [[TMP0]], [[TMP1]], [[TMP2]] : !moore.i4, !moore.i4, !moore.i4, !moore.i4, !moore.i4, !moore.i4 -> uarray<6 x i4>
     // CHECK: moore.array_create [[TMP3]], [[TMP3]], [[TMP3]] : !moore.uarray<6 x i4>, !moore.uarray<6 x i4>, !moore.uarray<6 x i4> -> uarray<3 x uarray<6 x i4>>
     arr = '{3{'{2{4'd1, 4'd2, 4'd3}}}};
+
+    // CHECK: [[TMP0:%.+]] = moore.constant 0 :
+    // CHECK: [[TMP1:%.+]] = moore.constant 0 :
+    // CHECK: [[TMP2:%.+]] = moore.constant 1 :
+    // CHECK: [[TMP3:%.+]] = moore.constant 0 :
+    // CHECK: moore.concat [[TMP3]], [[TMP2]], [[TMP1]], [[TMP0]] : (!moore.l1, !moore.l1, !moore.l1, !moore.l1) -> l4
+    m = '{default: '0, 2: '1};
  
     //===------------------------------------------------------------------===//
     // Builtin Functions

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -5,6 +5,9 @@
 // Internal issue in Slang v3 about jump depending on uninitialised value.
 // UNSUPPORTED: valgrind
 
+function void dummyA(int x); endfunction
+
+// IEEE 1800-2017 § 20.2 "Simulation control system tasks"
 // CHECK-LABEL: func.func private @SimulationControlBuiltins(
 function void SimulationControlBuiltins(bit x);
   // CHECK: moore.builtin.finish_message false
@@ -35,6 +38,8 @@ function void SimulationControlBuiltins(bit x);
   $exit;
 endfunction
 
+// IEEE 1800-2017 § 20.10 "Severity tasks"
+// IEEE 1800-2017 § 21.2 "Display system tasks"
 // CHECK-LABEL: func.func private @DisplayAndSeverityBuiltins(
 // CHECK-SAME: [[X:%.+]]: !moore.i32
 function void DisplayAndSeverityBuiltins(int x);
@@ -180,4 +185,15 @@ function void DisplayAndSeverityBuiltins(int x);
   // CHECK: moore.builtin.severity fatal [[TMP]]
   // CHECK: moore.unreachable
   if (0) $fatal(1, "%d", x);
+endfunction
+
+// IEEE 1800-2017 § 20.8 "Math functions"
+// CHECK-LABEL: func.func private @MathBuiltins(
+// CHECK-SAME: [[X:%.+]]: !moore.i32
+// CHECK-SAME: [[Y:%.+]]: !moore.l42
+function void MathBuiltins(int x, logic [41:0] y);
+  // CHECK: moore.builtin.clog2 [[X]] : i32
+  dummyA($clog2(x));
+  // CHECK: moore.builtin.clog2 [[Y]] : l42
+  dummyA($clog2(y));
 endfunction

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -385,3 +385,12 @@ func.func @SeverityAndDisplayBuiltins(%arg0: !moore.format_string) {
   moore.builtin.severity fatal %arg0
   return
 }
+
+// CHECK-LABEL: func.func @MathBuiltins
+func.func @MathBuiltins(%arg0: !moore.i32, %arg1: !moore.l42) {
+  // CHECK: moore.builtin.clog2 %arg0 : i32
+  moore.builtin.clog2 %arg0 : i32
+  // CHECK: moore.builtin.clog2 %arg1 : l42
+  moore.builtin.clog2 %arg1 : l42
+  return
+}


### PR DESCRIPTION
Allow `'{...}` assignment patterns to be used to assign integer values. Slang already computes the value for each element in the resulting type. All that's needed is a concat with the right operand order.