### PR TITLE
[Arc] Automatic module partition

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -465,6 +465,21 @@ def FinalOp : ClockTreeLikeOp<"final"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Partition
+//===----------------------------------------------------------------------===//
+
+def TaskOp : ArcOp<"task",  [
+    RecursiveMemoryEffects, NoTerminator, NoRegionArguments, SingleBlock,
+    // ParentOneOf<["ClockTreeOp", "ModelOp"]>
+]> {
+  let summary = "A region reserved after the computation of different partitions";
+  let arguments = (ins
+    OptionalAttr<SymbolNameAttr>:$task_name
+  );
+  let regions = (region SizedRegion<1>:$body);
+}
+
+//===----------------------------------------------------------------------===//
 // Storage Allocation
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/Arc/ArcPasses.h
+++ b/include/circt/Dialect/Arc/ArcPasses.h
@@ -43,6 +43,8 @@ std::unique_ptr<mlir::Pass> createLowerVectorizationsPass(
     LowerVectorizationsModeEnum mode = LowerVectorizationsModeEnum::Full);
 std::unique_ptr<mlir::Pass> createMakeTablesPass();
 std::unique_ptr<mlir::Pass> createMuxToControlFlowPass();
+std::unique_ptr<mlir::Pass>
+createPartitionPass(const PartitionOptions &opts = {});
 std::unique_ptr<mlir::Pass> createPrintCostModelPass();
 std::unique_ptr<mlir::Pass> createSimplifyVariadicOpsPass();
 std::unique_ptr<mlir::Pass> createSplitLoopsPass();

--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -318,6 +318,18 @@ def SimplifyVariadicOps : Pass<"arc-simplify-variadic-ops", "mlir::ModuleOp"> {
   ];
 }
 
+def Partition: Pass<"arc-partition", "arc::ModelOp"> {
+  let summary = "Partition the entire circuit into multiple chunks";
+  let options = [
+    Option<"chunks", "chunks", "unsigned", "1",
+      "Number of resulting chunks">
+  ];
+}
+
+def PartitionClone: Pass<"arc-partition-clone", "arc::ModelOp"> {
+  let summary = "Commit the planned partition by cloning models";
+}
+
 def SplitFuncs : Pass<"arc-split-funcs", "mlir::ModuleOp"> {
   let summary = "Split large funcs into multiple smaller funcs";
   let dependentDialects = ["mlir::func::FuncDialect"];

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -17,6 +17,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   MakeTables.cpp
   MergeIfs.cpp
   MuxToControlFlow.cpp
+  Partition.cpp
   PrintCostModel.cpp
   SimplifyVariadicOps.cpp
   SplitFuncs.cpp

--- a/lib/Dialect/Arc/Transforms/Partition.cpp
+++ b/lib/Dialect/Arc/Transforms/Partition.cpp
@@ -1,0 +1,442 @@
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/Debug.h"
+#include <random>
+
+#define DEBUG_TYPE "arc-partition"
+
+namespace circt {
+namespace arc {
+#define GEN_PASS_DEF_PARTITION
+#define GEN_PASS_DEF_PARTITIONCLONE
+#define GEN_PASS_DEF_PARTITIONTASKCANONICALIZE
+#include "circt/Dialect/Arc/ArcPasses.h.inc"
+} // namespace arc
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+
+using llvm::SmallMapVector;
+
+//===----------------------------------------------------------------------===//
+// Pass Implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct StateMap {
+  DenseMap<Value, size_t> lookup;
+  SmallVector<Value> ids;
+
+  size_t numStates;
+  size_t numOutputs;
+};
+
+// State -> state dependencies
+struct StateDep {
+  // deps[i] contains the dependency of state i (on other states). Inputs are
+  // not included.
+  SmallVector<BitVector> deps;
+
+  // Is this state depended by a control flow?
+  BitVector ctrlFlow;
+
+  void debug(const StateMap &map) const {
+    for (auto it : llvm::enumerate(map.ids)) {
+      it.value().dump();
+      llvm::dbgs() << "Depends on:\n";
+      for (auto dep : deps[it.index()].set_bits())
+        map.ids[dep].dump();
+      llvm::dbgs() << "=======\n";
+    }
+  }
+};
+
+struct StateWeight {
+  SmallVector<size_t> weights;
+
+  void debug(const StateMap &map) const {
+    for (auto it : llvm::enumerate(map.ids)) {
+      it.value().dump();
+      llvm::dbgs() << weights[it.index()] << "\n";
+    }
+  }
+};
+
+struct PartitionPlan {
+  // Which chunk is responsible for updating this state?
+  SmallVector<size_t> chunk;
+
+  // The shadow writeback should happen synchronously (in the output task)
+  BitVector syncWriteback;
+};
+
+struct PartitionPass : public arc::impl::PartitionBase<PartitionPass> {
+  void runOnOperation() override;
+  StateMap statAllStates(arc::ModelOp);
+  StateDep statAllStateDeps(arc::ModelOp, const StateMap &);
+  StateWeight statAllStateWeights(arc::ModelOp, const StateMap &);
+
+  PartitionPlan planPartition(arc::ModelOp, const StateMap &, const StateDep &,
+                              const StateWeight &);
+
+  void splitTasks(arc::ModelOp, const StateMap &, const StateDep &,
+                  const PartitionPlan &);
+
+  PartitionPass(const PartitionOptions &opts = {});
+
+  PartitionOptions _opts;
+};
+
+struct PartitionClonePass
+    : public arc::impl::PartitionCloneBase<PartitionClonePass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+PartitionPass::PartitionPass(const PartitionOptions &opts) : _opts(opts) {}
+
+void PartitionPass::runOnOperation() {
+  auto root = getOperation();
+  const auto &states = statAllStates(root);
+  const auto &deps = statAllStateDeps(root, states);
+  const auto &weights = statAllStateWeights(root, states);
+
+  LLVM_DEBUG(deps.debug(states));
+  LLVM_DEBUG(weights.debug(states));
+
+  const auto &partition = planPartition(root, states, deps, weights);
+  splitTasks(root, states, deps, partition);
+}
+
+StateMap PartitionPass::statAllStates(arc::ModelOp root) {
+  SmallVector<Value> collected;
+  DenseMap<Value, size_t> lookup;
+
+  // First pass: all IO & persistent state
+  root->walk([&](arc::AllocStateOp op) {
+    size_t id = collected.size();
+    auto result = op.getResult();
+    lookup.insert({result, id});
+    collected.push_back(result);
+  });
+
+  size_t numStates = collected.size();
+
+  root->walk([&](arc::RootOutputOp op) {
+    size_t id = collected.size();
+    auto result = op.getResult();
+    lookup.insert({result, id});
+    collected.push_back(result);
+  });
+
+  return StateMap{
+      .lookup = lookup,
+      .ids = collected,
+      .numStates = numStates,
+      .numOutputs = lookup.size() - numStates,
+  };
+}
+
+StateDep PartitionPass::statAllStateDeps(arc::ModelOp root,
+                                         const StateMap &map) {
+  // Operations' dependency on states.
+  // For control flow operations, this includes all parent control flow
+  // dependencies, and the dependency of the condition For ordinary
+  // computational operations, this includes all dependency carried by operands,
+  // adn the dependency carried by control flow
+
+  DenseMap<Operation *, BitVector> cache;
+  SmallVector<BitVector> result;
+  BitVector ctrlFlow(map.numStates);
+  result.resize(map.ids.size(), BitVector(map.numStates));
+
+  cache.insert({root, BitVector(map.numStates)});
+
+  root->walk<WalkOrder::PreOrder>([&](Operation *op) {
+    if (op == root)
+      return;
+    if (isa<arc::AllocStateOp>(op))
+      return;
+
+    BitVector implicits = cache.at(op->getBlock()->getParentOp());
+    ctrlFlow |= implicits;
+
+    if (auto stateWrite = dyn_cast<arc::StateWriteOp>(op)) {
+      auto state = stateWrite.getState();
+      auto val = stateWrite.getValue();
+      assert(val.getDefiningOp() && cache.contains(val.getDefiningOp()));
+      auto deps = cache.at(val.getDefiningOp());
+
+      if (isa<RootOutputOp>(state.getDefiningOp()))
+        return;
+
+      auto &slot = result[map.lookup.at(state)];
+      slot |= deps;
+      slot |= implicits;
+      return;
+    }
+
+    BitVector ret = implicits;
+    if (isa<arc::RootInputOp, arc::RootOutputOp>(op)) {
+      // Do nothing
+    } else if (isa<arc::StateReadOp>(op)) {
+      auto stateVal = op->getOperand(0);
+      if (map.lookup.contains(stateVal)) // Otherwise: is output
+        ret.set(map.lookup.at(stateVal));
+    } else {
+      for (const Value &v : op->getOperands()) {
+        if (Operation *def = v.getDefiningOp()) {
+          assert(cache.contains(def));
+          ret |= cache.at(def);
+        } else {
+          op->emitError("Unexpected block argument during partition");
+        }
+      }
+    }
+
+    cache.insert({op, ret});
+  });
+
+  return StateDep{
+      .deps = result,
+      .ctrlFlow = ctrlFlow,
+  };
+}
+
+namespace {
+size_t dfsWeight(Operation *op, DenseSet<Operation *> &visited) {
+  if (!op)
+    return 0; // Operand
+  if (isa<StateReadOp>(op))
+    return 0;
+  if (visited.contains(op))
+    return 0;
+
+  // Approximate the weight of the op by the largest width of all inputs and
+  // outputs
+  size_t maxWidth = 0;
+  size_t operandWidth = 0;
+  for (const auto &operand : op->getOperands()) {
+    size_t width = 0;
+    if (operand.getType().isInteger()) {
+      width = operand.getType().getIntOrFloatBitWidth();
+    } else if (isa<seq::ClockType>(operand.getType())) {
+      width = 1;
+    } else {
+      op->emitError("Use of non-integer operand");
+      continue;
+    }
+
+    if (width > maxWidth)
+      maxWidth = width;
+    operandWidth += dfsWeight(operand.getDefiningOp(), visited);
+  }
+
+  for (const auto &result : op->getResults()) {
+    if (!result.getType().isInteger())
+      op->emitError("Use of non-integer result");
+
+    auto width = result.getType().getIntOrFloatBitWidth();
+    if (width > maxWidth)
+      maxWidth = width;
+  }
+
+  visited.insert(op);
+  return maxWidth + operandWidth;
+}
+} // namespace
+
+StateWeight PartitionPass::statAllStateWeights(arc::ModelOp op,
+                                               const StateMap &map) {
+  SmallVector<std::pair<size_t, DenseSet<Operation *>>> ctx;
+  ctx.resize(map.ids.size());
+
+  op->walk([&](StateWriteOp op) {
+    size_t id = map.lookup.at(op.getState());
+    auto &slot = ctx[id];
+    slot.first += dfsWeight(op.getValue().getDefiningOp(), slot.second);
+  });
+
+  return StateWeight{
+      .weights = llvm::map_to_vector(ctx, [](auto e) { return e.first; })};
+}
+
+PartitionPlan PartitionPass::planPartition(arc::ModelOp, const StateMap &map,
+                                           const StateDep &deps,
+                                           const StateWeight &) {
+  // FIXME: impl
+  std::mt19937 gen(0x19260817);
+
+  std::uniform_int_distribution<size_t> dist(0, _opts.chunks - 1);
+
+  SmallVector<size_t> chunk;
+  chunk.reserve(map.ids.size());
+  for (size_t i = 0; i < map.ids.size(); ++i) {
+    chunk.push_back(dist(gen));
+  }
+
+  return PartitionPlan{
+      .chunk = chunk,
+      .syncWriteback = deps.ctrlFlow,
+  };
+}
+
+void PartitionPass::splitTasks(arc::ModelOp root, const StateMap &map,
+                               const StateDep &deps,
+                               const PartitionPlan &plan) {
+  OpBuilder builder(root);
+
+  // Create shadow storages for all chunks, after the last alloc
+  // FIXME: find last alloc
+  SmallVector<TypedValue<StorageType>> shadowStorages;
+  shadowStorages.reserve(_opts.chunks);
+  for (size_t t = 0; t < _opts.chunks; ++t) {
+    builder.setInsertionPointToStart(&root.getBodyBlock());
+    shadowStorages.push_back(builder.create<AllocStorageOp>(
+        root.getLoc(), StorageType::get(root.getContext(), 0),
+        root.getBody().getArgument(0)));
+  }
+
+  // States that are read by other chunks
+  BitVector globallyVisibleStates(map.numStates);
+  for (size_t i = 0; i < map.numStates; ++i) {
+    auto localChunk = plan.chunk[i];
+    for (auto dep : deps.deps[i].set_bits()) {
+      auto remoteChunk = plan.chunk[dep];
+      if (remoteChunk != localChunk)
+        globallyVisibleStates.set(dep);
+    }
+  }
+
+  // Allocate shadow states for globally visible states in their respective
+  // shadow storages
+  DenseMap<TypedValue<StateType>, TypedValue<StateType>> shadows;
+  root.walk([&](AllocStateOp alloc) {
+    auto state = alloc.getState();
+    if (!globallyVisibleStates.test(map.lookup.at(state)))
+      return;
+    auto chunk = plan.chunk[map.lookup.at(state)];
+
+    auto storage = shadowStorages[chunk];
+
+    builder.setInsertionPointAfter(alloc);
+    auto shadowAlloc =
+        builder.create<AllocStateOp>(alloc.getLoc(), alloc.getType(), storage);
+    shadows.insert({state, shadowAlloc.getState()});
+  });
+
+  // Re-map all state writes, create in-place shadow write pairs
+  root.walk([&](StateWriteOp write) {
+    auto state = write.getState();
+
+    // Is something we just inserted
+    if (isa<TaskOp>(write->getBlock()->getParentOp()))
+      return;
+
+    AllocStateOp alloc = dyn_cast<AllocStateOp>(state.getDefiningOp());
+    // TODO: extmod
+    if (!alloc) {
+      assert(write->getBlock() == &root.getBodyBlock() &&
+             "Writes to output should only happens at model root");
+
+      builder.setInsertionPointAfter(write);
+      auto mainTask = builder.create<TaskOp>(write.getLoc(),
+                                             builder.getStringAttr("output"));
+      mainTask.getBodyRegion().emplaceBlock();
+      write->moveBefore(&mainTask.getBody().front(),
+                        mainTask.getBody().front().end());
+
+      return;
+    }
+
+    // TODO: condition and enable
+    builder.setInsertionPointAfter(write);
+    auto mainTask = builder.create<TaskOp>(
+        write.getLoc(), builder.getStringAttr(
+                            std::to_string(plan.chunk[map.lookup.at(state)])));
+    mainTask.getBodyRegion().emplaceBlock();
+    if (!shadows.contains(
+            state)) { // Only locally visible. Safe to just directly write into
+      write->moveBefore(&mainTask.getBody().front(),
+                        mainTask.getBody().front().end());
+    } else { // Is globally visible state
+      // In main task, write into shadow
+      builder.setInsertionPointToStart(&mainTask.getBody().front());
+      builder.create<StateWriteOp>(write.getLoc(), shadows.at(state),
+                                   write.getValue(), Value());
+
+      // Create separate sync task, read from shadow, write into main
+      builder.setInsertionPointAfter(mainTask);
+      auto syncStage =
+          plan.syncWriteback.test(map.lookup.at(state))
+              ? std::string("output")
+              : std::to_string(plan.chunk[map.lookup.at(state)]) + "_sync";
+      auto syncTask = builder.create<TaskOp>(write.getLoc(),
+                                             builder.getStringAttr(syncStage));
+      auto syncBlock = &syncTask.getBodyRegion().emplaceBlock();
+      builder.setInsertionPointToStart(syncBlock);
+      auto readout =
+          builder.create<StateReadOp>(write.getLoc(), shadows.at(state));
+      builder.create<StateWriteOp>(write.getLoc(), state, readout.getValue(),
+                                   Value());
+      write.erase();
+    }
+  });
+}
+
+void PartitionClonePass::runOnOperation() {
+  ModelOp root = getOperation();
+  auto builder = OpBuilder(root);
+
+  // Collect all named tasks
+  DenseSet<StringRef> taskNames;
+  root->walk([&](TaskOp task) {
+    if (auto name = task.getTaskName())
+      taskNames.insert(*name);
+  });
+
+  // Rename all anonymous tasks
+  uint64_t anonCnt = 0;
+  root->walk([&](TaskOp task) {
+    if (!task.getTaskName()) {
+      while (taskNames.contains("__task" + std::to_string(anonCnt)))
+        anonCnt++;
+      auto name = "task__" + std::to_string(anonCnt);
+      auto nameAttr = builder.getStringAttr(name);
+      taskNames.insert(name);
+      task.setTaskName(nameAttr);
+    }
+  });
+
+  builder.setInsertionPointAfter(root);
+
+  for (const auto &taskName : taskNames) {
+    LLVM_DEBUG(llvm::dbgs() << "Creating clone: " << taskName << "\n");
+    std::string newName = root.getSymName().str();
+    newName += "_";
+    newName += taskName;
+
+    arc::ModelOp cloned = dyn_cast<arc::ModelOp>(builder.clone(*root));
+    cloned.setSymName(newName);
+    cloned.walk([&](TaskOp task) {
+      if (task.getTaskName() != taskName)
+        task.erase();
+    });
+
+    // Unwrap all tasks
+    cloned.walk([](TaskOp task) {
+      task.walk([&](Operation *op) { op->moveBefore(task); });
+      task.erase();
+    });
+  }
+
+  // Remote tasks in original model
+  root.walk([](TaskOp task) { task.erase(); });
+}

--- a/test/Dialect/Arc/allocate-state.mlir
+++ b/test/Dialect/Arc/allocate-state.mlir
@@ -3,12 +3,21 @@
 // CHECK-LABEL: arc.model @test
 arc.model @test io !hw.modty<input x : i1, output y : i1> {
 ^bb0(%arg0: !arc.storage):
-  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage<5780>):
+  // CHECK-NEXT: ([[PTR:%.+]]: !arc.storage<5796>):
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][0] : (!arc.storage<5780>) -> !arc.storage<1159>
+  // CHECK-NEXT: offset = 0
+  arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][1] : (!arc.storage<5796>) -> !arc.storage<1>
+  %substorage0 = arc.alloc_storage %arg0 : (!arc.storage) -> !arc.storage
+  // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][1]
+  // CHECK-NEXT: arc.alloc_state [[SUBPTR]]
+  // CHECK-SAME: offset = 0
+  arc.alloc_state %substorage0 : (!arc.storage) -> !arc.state<i1>
+
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][16] : (!arc.storage<5796>) -> !arc.storage<1159>
   // CHECK-NEXT: arc.initial {
   arc.initial {
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][0] : !arc.storage<5780> -> !arc.storage<1159>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][16] : !arc.storage<5796> -> !arc.storage<1159>
     %0 = arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i1>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i8>
     arc.alloc_state %arg0 : (!arc.storage) -> !arc.state<i16>
@@ -28,7 +37,7 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
     // CHECK-NEXT: scf.execute_region {
     scf.execute_region {
       arc.state_read %0 : <i1>
-      // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][0] : !arc.storage<5780> -> !arc.storage<1159>
+      // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][16] : !arc.storage<5796> -> !arc.storage<1159>
       // CHECK-NEXT: [[STATE:%.+]] = arc.storage.get [[SUBPTR]][0] : !arc.storage<1159> -> !arc.state<i1>
       // CHECK-NEXT: arc.state_read [[STATE]] : <i1>
       arc.state_read %1 : <i1>
@@ -41,10 +50,10 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][1168] : (!arc.storage<5780>) -> !arc.storage<4609>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][1184] : (!arc.storage<5796>) -> !arc.storage<4609>
   // CHECK-NEXT: arc.initial {
   arc.initial {
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][1168] : !arc.storage<5780> -> !arc.storage<4609>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][1184] : !arc.storage<5796> -> !arc.storage<4609>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i1, i1>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i8, i1>
     arc.alloc_memory %arg0 : (!arc.storage) -> !arc.memory<4 x i16, i1>
@@ -68,12 +77,12 @@ arc.model @test io !hw.modty<input x : i1, output y : i1> {
   }
   // CHECK-NEXT: }
 
-  // CHECK-NEXT: arc.alloc_storage [[PTR]][5778] : (!arc.storage<5780>) -> !arc.storage<2>
+  // CHECK-NEXT: arc.alloc_storage [[PTR]][5794] : (!arc.storage<5796>) -> !arc.storage<2>
   // CHECK-NEXT: arc.initial {
   arc.initial {
     arc.root_input "x", %arg0 : (!arc.storage) -> !arc.state<i1>
     arc.root_output "y", %arg0 : (!arc.storage) -> !arc.state<i1>
-    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][5778] : !arc.storage<5780> -> !arc.storage<2>
+    // CHECK-NEXT: [[SUBPTR:%.+]] = arc.storage.get [[PTR]][5794] : !arc.storage<5796> -> !arc.storage<2>
     // CHECK-NEXT: arc.root_input "x", [[SUBPTR]] {offset = 0 : i32}
     // CHECK-NEXT: arc.root_output "y", [[SUBPTR]] {offset = 1 : i32}
   }

--- a/test/arcilator/partition-driver.cpp
+++ b/test/arcilator/partition-driver.cpp
@@ -1,0 +1,134 @@
+#include <atomic>
+#include <iostream>
+#include <optional>
+#include <random>
+#include <thread>
+#include <vector>
+
+#include "partition.state.h"
+
+extern "C" void gcd_0_eval(gcd_state *);
+extern "C" void gcd_1_eval(gcd_state *);
+extern "C" void gcd_0_sync_eval(gcd_state *);
+extern "C" void gcd_1_sync_eval(gcd_state *);
+extern "C" void gcd_output_eval(gcd_state *);
+
+void dump_state(gcd_state &state) {}
+
+uint16_t gcd_std(uint16_t a, uint16_t b) {
+  while (true) {
+    uint16_t tmp = b;
+    b = a % b;
+    a = tmp;
+
+    if (b == 0)
+      return tmp;
+  }
+}
+
+const size_t TICK_UNTIL = 10000000;
+std::mt19937 gen(0x19260817);
+std::uniform_int_distribution<uint16_t> dist(1, 0xFFFF);
+
+using case_t = std::tuple<uint16_t, uint16_t, uint16_t>;
+case_t generate_case() {
+  uint16_t a = dist(gen);
+  uint16_t b = dist(gen);
+
+  return std::make_tuple(a, b, gcd_std(a, b));
+}
+
+int main() {
+  gcd_state state;
+
+  std::optional<case_t> last;
+  case_t testcase = generate_case();
+
+  std::atomic<size_t> ticket = 0;
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 2; ++i) {
+    threads.emplace_back([&, i]() {
+      size_t tick = 0;
+      bool leader = i == 0;
+      while (tick < TICK_UNTIL) {
+        if (leader) {
+          state.io.i_clk = tick % 2 == 0;
+          state.io.i_rst = tick < 10;
+
+          auto &[a, b, r] = testcase;
+          state.io.i_in_a = a;
+          state.io.i_in_b = b;
+          state.io.i_in_valid = tick > 20;
+
+          // o_in_ready doesn't depend on input, so we can skip a eval here
+          // fire and is posedge
+          if (tick > 20 && state.io.o_in_ready && tick % 2 == 0) {
+            std::cout << "Accept " << a << ", " << b << std::endl;
+            if (last) {
+              std::cerr << "Last gcd not completed" << std::endl;
+              std::exit(1);
+            }
+            last = testcase;
+            testcase = generate_case();
+          }
+        }
+
+        if (i == 0) {
+          size_t cur_ticket = ticket.fetch_add(1, std::memory_order_acq_rel);
+          while (cur_ticket < tick * 6 + 2)
+            cur_ticket = ticket.load(std::memory_order_acquire);
+
+          gcd_0_eval(&state);
+          cur_ticket = ticket.fetch_add(1, std::memory_order_acq_rel);
+          while (cur_ticket < tick * 6 + 4)
+            cur_ticket = ticket.load(std::memory_order_acquire);
+
+          gcd_0_sync_eval(&state);
+          cur_ticket = ticket.fetch_add(1, std::memory_order_acq_rel);
+          while (cur_ticket < tick * 6 + 6)
+            cur_ticket = ticket.load(std::memory_order_acquire);
+        } else {
+          size_t cur_ticket = ticket.fetch_add(1, std::memory_order_acq_rel);
+          while (cur_ticket < tick * 6 + 2)
+            cur_ticket = ticket.load(std::memory_order_acquire);
+
+          gcd_1_eval(&state);
+          cur_ticket = ticket.fetch_add(1, std::memory_order_acq_rel);
+          while (cur_ticket < tick * 6 + 4)
+            cur_ticket = ticket.load(std::memory_order_acquire);
+
+          gcd_1_sync_eval(&state);
+          cur_ticket = ticket.fetch_add(1, std::memory_order_acq_rel);
+          while (cur_ticket < tick * 6 + 6)
+            cur_ticket = ticket.load(std::memory_order_acquire);
+        }
+
+        if (leader)
+          gcd_output_eval(&state);
+
+        if (leader && tick >= 15 && tick % 2 == 0 && state.io.o_out_valid) {
+          // New output generated
+          if (!last) {
+            std::cerr << "Unexpected valid output" << std::endl;
+            std::exit(1);
+          }
+
+          auto &[la, lb, lr] = *last;
+          std::cout << la << ", " << lb << " -> " << state.io.o_out << " # "
+                    << lr << std::endl;
+
+          if (lr != state.io.o_out) {
+            std::cerr << "Mismatched output" << std::endl;
+            std::exit(1);
+          }
+
+          last = {};
+        }
+        ++tick;
+      }
+    });
+  }
+
+  for (auto &t : threads)
+    t.join();
+}

--- a/test/arcilator/partition.mlir
+++ b/test/arcilator/partition.mlir
@@ -1,0 +1,32 @@
+// RUN: arcilator %s --partition-chunks=2
+
+module {
+  hw.module @gcd(in %clk : !seq.clock, in %rst : i1, in %in_a : i64, in %in_b : i64, in %in_valid : i1, out in_ready : i1, out out : i64, out out_valid : i64) {
+    %c0_i63 = hw.constant 0 : i63
+    %true = hw.constant true
+    %c0_i64 = hw.constant 0 : i64
+    %false = hw.constant false
+    %smaller = seq.firreg %13 clock %clk {firrtl.random_init_start = 0 : ui64} : i64
+    %larger = seq.firreg %11 clock %clk {firrtl.random_init_start = 64 : ui64} : i64
+    %working = seq.firreg %15 clock %clk reset sync %rst, %false {firrtl.random_init_start = 128 : ui64} : i1
+    %0 = comb.icmp bin eq %smaller, %c0_i64 : i64
+    %1 = comb.and bin %0, %working {sv.namehint = "done"} : i1
+    %2 = comb.concat %false, %larger : i1, i64
+    %3 = comb.concat %false, %smaller : i1, i64
+    %4 = comb.sub bin %2, %3 : i65
+    %5 = comb.concat %false, %in_a : i1, i64
+    %6 = comb.mux bin %working, %4, %5 {sv.namehint = "na"} : i65
+    %7 = comb.mux bin %working, %smaller, %in_b {sv.namehint = "nb"} : i64
+    %8 = comb.concat %false, %7 : i1, i64
+    %9 = comb.icmp bin ugt %6, %8 : i65
+    %10 = comb.extract %6 from 0 : (i65) -> i64
+    %11 = comb.mux %9, %10, %7 {sv.namehint = "nlarger"} : i64
+    %12 = comb.extract %6 from 0 : (i65) -> i64
+    %13 = comb.mux %9, %7, %12 {sv.namehint = "nsmaller"} : i64
+    %14 = comb.xor bin %1, %true : i1
+    %15 = comb.mux bin %working, %14, %in_valid {sv.namehint = "nworking"} : i1
+    %16 = comb.concat %c0_i63, %1 : i63, i1
+    %17 = comb.xor bin %working, %true : i1
+    hw.output %17, %larger, %16 : i1, i64, i64
+  }
+}

--- a/test/arcilator/partition.state.h
+++ b/test/arcilator/partition.state.h
@@ -1,0 +1,26 @@
+// Auto-generated from gcd.state.json
+#include <cstddef>
+#include <cstdint>
+struct gcd_state {
+  struct IO {
+    volatile uint8_t _padding_0[25];
+    bool i_clk;
+    bool i_rst;
+    uint64_t i_in_a;
+    uint64_t i_in_b;
+    bool i_in_valid;
+    volatile uint8_t _padding_1[25];
+    bool o_in_ready;
+    uint64_t o_out;
+    uint64_t o_out_valid;
+  } io;
+  volatile uint8_t _tail[20];
+};
+static_assert(offsetof(gcd_state, io.i_clk) == 25);
+static_assert(offsetof(gcd_state, io.i_rst) == 26);
+static_assert(offsetof(gcd_state, io.i_in_a) == 32);
+static_assert(offsetof(gcd_state, io.i_in_b) == 40);
+static_assert(offsetof(gcd_state, io.i_in_valid) == 48);
+static_assert(offsetof(gcd_state, io.o_in_ready) == 74);
+static_assert(offsetof(gcd_state, io.o_out) == 80);
+static_assert(offsetof(gcd_state, io.o_out_valid) == 88);


### PR DESCRIPTION
**This is a draft PR, which mostly serves the purpose of gathering feedbacks. Implemention is imcomplete and very hacky in places. See the "Unresolved issues" section below.**

This PR introduces a new pass (`--hw-partition`) into CIRCT to partition HW top-level modules into two or more parts. Each parts contains parts of the logic and states of the original circuit. Additional ports are created for signals that crosses partition bondaries. The pass tries to perserve origional modules and hierarchies.

## Motivation

The primary motivation is multithreaded simulation with Arcilator. To be more concrete, the targeted typical usecase of this pass is high performance multithreaded simulation using Arcilator, with HW modules compiled from FIRRTL, on a single CPU, with (mostly) static scheduling. Time stepping happens in a lock-step style.

However, doing this on the HW level may also benifit other use cases, e.g. large scale verification with multiple FPGAs.

## Unresolved Issues

- How do we deal with `inout`?
- How do we utilize operation duplication, i.e. a single operation appears in multiple parts to reduce communication? Currently no operation is duplicated. We can also approach this from the other end: partition by only by states first, duplicate the entire combinatory subtree, and then do optimization.
- What graph paritioning optimization goal should we use? Most graph partitioning algorithm / library only optimize for cut-size (or total width of cross module ports in our case, or amount of communication), while the size of each component serves as constraints. METIS supports 
- The implementation of combinaory path is incorrect. Currently it directly edits existing modules. When there are multiple nesting instances of a same module, this approach will fail.

## Acknowledgement

Thanks to @CircuitCoder for mentoring this work.