### PR TITLE
[FIRRTL] Re-implement old EmitOMIR ports logic in LowerClasses.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -319,6 +319,8 @@ struct HierPathCache {
     return FlatSymbolRefAttr::get(getSymFor(attr));
   }
 
+  const SymbolTable &getSymbolTable() const { return symbolTable; }
+
 private:
   OpBuilder builder;
   DenseMap<ArrayAttr, hw::HierPathOp> cache;

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -213,7 +213,11 @@ private:
 
   // Create an OM Class op from a FIRRTL Class op.
   om::ClassLike createClass(FModuleLike moduleLike,
-                            const PathInfoTable &pathInfoTable);
+                            const PathInfoTable &pathInfoTable,
+                            std::mutex &intraPassMutex);
+
+  // Declare an RtlPort class on the fly.
+  void declareRtlPortClass(OpBuilder &builder, std::mutex &intraPassMutex);
 
   // Lower the FIRRTL Class to OM Class.
   void lowerClassLike(FModuleLike moduleLike, om::ClassLike classLike,
@@ -225,7 +229,10 @@ private:
   // Update Object instantiations in a FIRRTL Module or OM Class.
   LogicalResult updateInstances(Operation *op, InstanceGraph &instanceGraph,
                                 const LoweringState &state,
-                                const PathInfoTable &pathInfoTable);
+                                const PathInfoTable &pathInfoTable,
+                                hw::InnerSymbolNamespaceCollection &namespaces,
+                                HierPathCache &hierPathCache,
+                                std::mutex &intraPassMutex);
 
   // Convert to OM ops and types in Classes or Modules.
   LogicalResult dialectConversion(
@@ -234,6 +241,9 @@ private:
 
   // State to memoize repeated calls to shouldCreateClass.
   DenseMap<StringAttr, bool> shouldCreateClassMemo;
+
+  // Flag to track if we've declared the optional RtlPorts class.
+  bool isRtlPortClassDeclared = false;
 };
 
 struct PathTracker {
@@ -293,6 +303,113 @@ private:
   SmallVector<PathInfoTableEntry> entries;
   SetVector<StringAttr> altBasePathRoots;
 };
+
+/// Constants and helpers for creating the RtlPorts on the fly.
+
+static constexpr StringRef kContainingModuleName = "containingModule";
+static constexpr StringRef kPortsName = "ports";
+static constexpr StringRef kRtlPortClassName = "RtlPort";
+
+static Type getRtlPortsType(MLIRContext *context) {
+  return om::ListType::get(om::ClassType::get(
+      context, FlatSymbolRefAttr::get(context, kRtlPortClassName)));
+}
+
+static om::ListCreateOp
+createRtlPorts(firrtl::PathOp containingModuleRef, Value basePath,
+               const PathInfoTable &pathInfoTable,
+               hw::InnerSymbolNamespaceCollection &namespaces,
+               HierPathCache &hierPathCache, OpBuilder &builder,
+               std::mutex &intraPassMutex) {
+  // Look up the module from the containingModuleRef.
+
+  FlatSymbolRefAttr containingModulePathRef =
+      pathInfoTable.table.at(containingModuleRef.getTarget()).symRef;
+
+  const SymbolTable &symbolTable = hierPathCache.getSymbolTable();
+
+  hw::HierPathOp containingModulePath =
+      symbolTable.lookup<hw::HierPathOp>(containingModulePathRef.getAttr());
+
+  assert(containingModulePath.isModule() &&
+         "expected containing module path to target a module");
+
+  StringAttr moduleName = containingModulePath.leafMod();
+
+  FModuleLike mod = symbolTable.lookup<FModuleLike>(moduleName);
+  MLIRContext *ctx = mod.getContext();
+  Location loc = mod.getLoc();
+
+  // Create the per-port information.
+
+  auto portClassName = StringAttr::get(ctx, kRtlPortClassName);
+  auto portClassType =
+      om::ClassType::get(ctx, FlatSymbolRefAttr::get(portClassName));
+
+  SmallVector<Value> ports;
+  for (unsigned i = 0, e = mod.getNumPorts(); i < e; ++i) {
+    // Only process ports that are not zero-width.
+    auto portType = type_dyn_cast<FIRRTLBaseType>(mod.getPortType(i));
+    if (!portType || portType.getBitWidthOrSentinel() == 0)
+      continue;
+
+    // Get a path to the port. This may modify port attributes or the global
+    // namespace of hierpaths, so use the mutex around those operations.
+
+    auto portTarget = PortAnnoTarget(mod, i);
+
+    FlatSymbolRefAttr portPathRef;
+    {
+      std::lock_guard<std::mutex> guard(intraPassMutex);
+
+      auto portSym =
+          getInnerRefTo({portTarget.getPortNo(), portTarget.getOp(), 0},
+                        [&](FModuleLike m) -> hw::InnerSymbolNamespace & {
+                          return namespaces[m];
+                        });
+
+      portPathRef = hierPathCache.getRefFor(ArrayAttr::get(ctx, {portSym}));
+    }
+
+    auto portPath = builder.create<om::PathCreateOp>(
+        loc, om::PathType::get(ctx),
+        om::TargetKindAttr::get(ctx, om::TargetKind::DontTouch), basePath,
+        portPathRef);
+
+    // Get a direction attribute.
+
+    StringRef portDirectionName =
+        mod.getPortDirection(i) == Direction::Out ? "Output" : "Input";
+
+    auto portDirection = builder.create<om::ConstantOp>(
+        loc, om::StringType::get(ctx),
+        StringAttr::get(portDirectionName, om::StringType::get(ctx)));
+
+    // Get a width attribute.
+
+    auto portWidth = builder.create<om::ConstantOp>(
+        loc, om::OMIntegerType::get(ctx),
+        om::IntegerAttr::get(
+            ctx, mlir::IntegerAttr::get(mlir::IntegerType::get(ctx, 64),
+                                        portType.getBitWidthOrSentinel())));
+
+    // Create an RtlPort object for this port, and add it to the list.
+
+    auto portObj = builder.create<om::ObjectOp>(
+        loc, portClassType, portClassName,
+        ArrayRef<Value>{portPath, portDirection, portWidth});
+
+    ports.push_back(portObj);
+  }
+
+  // Create a list of RtlPort objects to be included with the containingModule.
+
+  auto portsList = builder.create<om::ListCreateOp>(
+      UnknownLoc::get(builder.getContext()),
+      getRtlPortsType(builder.getContext()), ports);
+
+  return portsList;
+}
 
 } // namespace
 
@@ -701,6 +818,7 @@ LogicalResult LowerClassesPass::processPaths(
 /// Lower FIRRTL Class and Object ops to OM Class and Object ops
 void LowerClassesPass::runOnOperation() {
   MLIRContext *ctx = &getContext();
+  auto intraPassMutex = std::mutex();
 
   // Get the CircuitOp.
   CircuitOp circuit = getOperation();
@@ -742,7 +860,7 @@ void LowerClassesPass::runOnOperation() {
       continue;
 
     if (shouldCreateClass(moduleLike.getModuleNameAttr())) {
-      auto omClass = createClass(moduleLike, pathInfoTable);
+      auto omClass = createClass(moduleLike, pathInfoTable, intraPassMutex);
       auto &classLoweringState = loweringState.classLoweringStateTable[omClass];
       classLoweringState.moduleLike = moduleLike;
 
@@ -804,7 +922,8 @@ void LowerClassesPass::runOnOperation() {
   if (failed(
           mlir::failableParallelForEach(ctx, objectContainers, [&](auto *op) {
             return updateInstances(op, instanceGraph, loweringState,
-                                   pathInfoTable);
+                                   pathInfoTable, namespaces, cache,
+                                   intraPassMutex);
           })))
     return signalPassFailure();
 
@@ -817,6 +936,9 @@ void LowerClassesPass::runOnOperation() {
 
   // We keep the instance graph up to date, so mark that analysis preserved.
   markAnalysesPreserved<InstanceGraph>();
+
+  // Reset pass state.
+  isRtlPortClassDeclared = false;
 }
 
 std::unique_ptr<mlir::Pass> circt::firrtl::createLowerClassesPass() {
@@ -830,9 +952,9 @@ bool LowerClassesPass::shouldCreateClass(StringAttr modName) {
 }
 
 // Create an OM Class op from a FIRRTL Class op or Module op with properties.
-om::ClassLike
-LowerClassesPass::createClass(FModuleLike moduleLike,
-                              const PathInfoTable &pathInfoTable) {
+om::ClassLike LowerClassesPass::createClass(FModuleLike moduleLike,
+                                            const PathInfoTable &pathInfoTable,
+                                            std::mutex &intraPassMutex) {
   // Collect the parameter names from input properties.
   SmallVector<StringRef> formalParamNames;
   // Every class gets a base path as its first parameter.
@@ -845,11 +967,28 @@ LowerClassesPass::createClass(FModuleLike moduleLike,
     formalParamNames.push_back(StringAttr::get(
         moduleLike->getContext(), "alt_basepath_" + llvm::Twine(i)));
 
-  for (auto [index, port] : llvm::enumerate(moduleLike.getPorts()))
-    if (port.isInput() && isa<PropertyType>(port.type))
+  // Collect the input parameters.
+  bool hasContainingModule = false;
+  for (auto [index, port] : llvm::enumerate(moduleLike.getPorts())) {
+    if (port.isInput() && isa<PropertyType>(port.type)) {
       formalParamNames.push_back(port.name);
 
+      // Check if we have a 'containingModule' field.
+      if (port.name.strref().starts_with(kContainingModuleName))
+        hasContainingModule = true;
+    }
+  }
+
   OpBuilder builder = OpBuilder::atBlockEnd(getOperation().getBodyBlock());
+
+  // If there is a 'containingModule', add a parameter for 'ports'.
+  if (hasContainingModule) {
+    formalParamNames.push_back(kPortsName);
+
+    // If we do need to add 'ports', ensure an RtlPort class is declared now,
+    // for use later.
+    declareRtlPortClass(builder, intraPassMutex);
+  }
 
   // Take the name from the FIRRTL Class or Module to create the OM Class name.
   StringRef className = moduleLike.getName();
@@ -876,6 +1015,23 @@ LowerClassesPass::createClass(FModuleLike moduleLike,
   return loweredClassOp;
 }
 
+void LowerClassesPass::declareRtlPortClass(OpBuilder &builder,
+                                           std::mutex &intraPassMutex) {
+  // Guard the variable read, modify, write and the global op creation by mutex.
+  std::lock_guard<std::mutex> guard(intraPassMutex);
+
+  if (isRtlPortClassDeclared)
+    return;
+
+  isRtlPortClassDeclared = true;
+
+  om::ClassOp::buildSimpleClassOp(
+      builder, UnknownLoc::get(&getContext()), kRtlPortClassName,
+      {"ref", "direction", "width"}, {"ref", "direction", "width"},
+      {om::PathType::get(&getContext()), om::StringType::get(&getContext()),
+       om::OMIntegerType::get(&getContext())});
+}
+
 void LowerClassesPass::lowerClassLike(FModuleLike moduleLike,
                                       om::ClassLike classLike,
                                       const PathInfoTable &pathInfoTable) {
@@ -898,14 +1054,20 @@ void LowerClassesPass::lowerClass(om::ClassOp classOp, FModuleLike moduleLike,
   // Collect information about property ports.
   SmallVector<Property> inputProperties;
   BitVector portsToErase(moduleLike.getNumPorts());
+  bool hasContainingModule = false;
   for (auto [index, port] : llvm::enumerate(moduleLike.getPorts())) {
     // For Module ports that aren't property types, move along.
     if (!isa<PropertyType>(port.type))
       continue;
 
     // Remember input properties to create the OM Class formal parameters.
-    if (port.isInput())
+    if (port.isInput()) {
       inputProperties.push_back({index, port.name, port.type, port.loc});
+
+      // Check if we have a 'containingModule' field.
+      if (port.name.strref().starts_with(kContainingModuleName))
+        hasContainingModule = true;
+    }
 
     // In case this is a Module, remember to erase this port.
     portsToErase.set(index);
@@ -976,6 +1138,14 @@ void LowerClassesPass::lowerClass(om::ClassOp classOp, FModuleLike moduleLike,
     op.erase();
   }
 
+  // If there is a 'containingModule', add an argument for 'ports', and a field.
+  if (hasContainingModule) {
+    BlockArgument argumentValue = classBody->addArgument(
+        getRtlPortsType(&getContext()), UnknownLoc::get(&getContext()));
+    builder.create<ClassFieldOp>(argumentValue.getLoc(), kPortsName,
+                                 argumentValue);
+  }
+
   // If the module-like is a Class, it will be completely erased later.
   // Otherwise, erase just the property ports and ops.
   if (!isa<firrtl::ClassLike>(moduleLike.getOperation())) {
@@ -1032,6 +1202,8 @@ void LowerClassesPass::lowerClassExtern(ClassExternOp classExternOp,
 static LogicalResult
 updateObjectInClass(firrtl::ObjectOp firrtlObject,
                     const PathInfoTable &pathInfoTable,
+                    hw::InnerSymbolNamespaceCollection &namespaces,
+                    HierPathCache &hierPathCache, std::mutex &intraPassMutex,
                     SmallVectorImpl<Operation *> &opsToErase) {
   // The 0'th argument is the base path.
   auto basePath = firrtlObject->getBlock()->getArgument(0);
@@ -1067,6 +1239,7 @@ updateObjectInClass(firrtl::ObjectOp firrtlObject,
   for (auto [i, altBasePath] : llvm::enumerate(altBasePaths))
     args[1 + i] = altBasePath; // + 1 to skip default base path
 
+  firrtl::PathOp containingModuleRef;
   for (auto *user : llvm::make_early_inc_range(firrtlObject->getUsers())) {
     if (auto subfield = dyn_cast<ObjectSubfieldOp>(user)) {
       auto index = subfield.getIndex();
@@ -1088,6 +1261,16 @@ updateObjectInClass(firrtl::ObjectOp firrtlObject,
           if (dst == subfield.getResult()) {
             args[argIndexTable[index]] = src;
             opsToErase.push_back(propassign);
+
+            // Check if we have a 'containingModule' field.
+            if (firrtlClassType.getElement(index).name.strref().starts_with(
+                    kContainingModuleName)) {
+              assert(!containingModuleRef &&
+                     "expected exactly one containingModule");
+              assert(isa_and_nonnull<firrtl::PathOp>(src.getDefiningOp()) &&
+                     "expected containingModule to be a PathOp");
+              containingModuleRef = src.getDefiningOp<firrtl::PathOp>();
+            }
           }
         }
       }
@@ -1112,8 +1295,15 @@ updateObjectInClass(firrtl::ObjectOp firrtlObject,
   auto className = firrtlObject.getType().getNameAttr();
   auto classType = om::ClassType::get(firrtlObject->getContext(), className);
 
-  // Create the new Object op.
   OpBuilder builder(firrtlObject);
+
+  // If there is a 'containingModule', Add the extra 'ports' argument.
+  if (containingModuleRef)
+    args.push_back(createRtlPorts(containingModuleRef, basePath, pathInfoTable,
+                                  namespaces, hierPathCache, builder,
+                                  intraPassMutex));
+
+  // Create the new Object op.
   auto object = builder.create<om::ObjectOp>(
       firrtlObject.getLoc(), classType, firrtlObject.getClassNameAttr(), args);
 
@@ -1275,13 +1465,21 @@ updateInstancesInModule(FModuleOp moduleOp, InstanceGraph &instanceGraph,
 static LogicalResult updateObjectsAndInstancesInClass(
     om::ClassOp classOp, InstanceGraph &instanceGraph,
     const LoweringState &state, const PathInfoTable &pathInfoTable,
+    hw::InnerSymbolNamespaceCollection &namespaces,
+    HierPathCache &hierPathCache, std::mutex &intraPassMutex,
     SmallVectorImpl<Operation *> &opsToErase) {
+  // If this is a synthetic ClassOp we created, nothing else to do.
+  if (classOp.getSymName().starts_with(kRtlPortClassName))
+    return success();
+
   OpBuilder builder(classOp);
   auto &classState = state.classLoweringStateTable.at(classOp);
   auto it = classState.paths.begin();
   for (auto &op : classOp->getRegion(0).getOps()) {
     if (auto objectOp = dyn_cast<firrtl::ObjectOp>(op)) {
-      if (failed(updateObjectInClass(objectOp, pathInfoTable, opsToErase)))
+      if (failed(updateObjectInClass(objectOp, pathInfoTable, namespaces,
+                                     hierPathCache, intraPassMutex,
+                                     opsToErase)))
         return failure();
     } else if (auto instanceOp = dyn_cast<InstanceOp>(op)) {
       if (failed(updateInstanceInClass(instanceOp, *it++, instanceGraph,
@@ -1293,10 +1491,11 @@ static LogicalResult updateObjectsAndInstancesInClass(
 }
 
 // Update Object or Module instantiations in a FIRRTL Module or OM Class.
-LogicalResult
-LowerClassesPass::updateInstances(Operation *op, InstanceGraph &instanceGraph,
-                                  const LoweringState &state,
-                                  const PathInfoTable &pathInfoTable) {
+LogicalResult LowerClassesPass::updateInstances(
+    Operation *op, InstanceGraph &instanceGraph, const LoweringState &state,
+    const PathInfoTable &pathInfoTable,
+    hw::InnerSymbolNamespaceCollection &namespaces,
+    HierPathCache &hierPathCache, std::mutex &intraPassMutex) {
 
   // Track ops to erase at the end. We can't do this eagerly, since we want to
   // loop over each op in the container's body, and we may end up removing some
@@ -1314,7 +1513,8 @@ LowerClassesPass::updateInstances(Operation *op, InstanceGraph &instanceGraph,
             // Convert FIRRTL Module instance within a Class to OM
             // Object instance.
             return updateObjectsAndInstancesInClass(
-                classOp, instanceGraph, state, pathInfoTable, opsToErase);
+                classOp, instanceGraph, state, pathInfoTable, namespaces,
+                hierPathCache, intraPassMutex, opsToErase);
           })
           .Default([](auto *op) { return success(); });
   if (failed(result))
@@ -1831,6 +2031,9 @@ static void populateTypeConverter(TypeConverter &converter) {
 
   // Convert FIRRTL List type to OM List type.
   auto convertListType = [&converter](auto type) -> std::optional<mlir::Type> {
+    // If the element type is already in the OM dialect, there's nothing to do.
+    if (isa<om::OMDialect>(type.getElementType().getDialect()))
+      return type;
     auto elementType = converter.convertType(type.getElementType());
     if (!elementType)
       return {};

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -494,3 +494,53 @@ firrtl.circuit "LocalPath" {
     firrtl.instance child1 @Child()
   }
 }
+
+// CHECK-LABEL: firrtl.circuit "RTLPorts"
+firrtl.circuit "RTLPorts" {
+  // CHECK: hw.hierpath private [[INPUT_NLA:@.+]] [@SomeModule::[[INPUT_SYM:@.+]]]
+  // CHECK: hw.hierpath private [[OUTPUT_NLA:@.+]] [@SomeModule::[[OUTPUT_SYM:@.+]]]
+
+  // CHECK: firrtl.module @SomeModule
+  // CHECK-SAME: in %input: !firrtl.uint<1> sym [[INPUT_SYM]]
+  // CHECK-SAME: out %output: !firrtl.uint<8> sym [[OUTPUT_SYM]]
+  firrtl.module @SomeModule(in %input: !firrtl.uint<1>, out %output: !firrtl.uint<8>) attributes {annotations = [{class = "circt.tracker", id = distinct[0]<>}]} {
+  }
+
+  firrtl.module @RTLPorts() {
+    firrtl.instance inst @SomeModule(in input: !firrtl.uint<1>, out output: !firrtl.uint<8>)
+
+    // CHECK: [[MODULE_PATH:%.+]] = om.path_create instance %basepath {{.+}}
+    %path = firrtl.path instance distinct[0]<>
+
+    // CHECK: [[INPUT_REF:%.+]] = om.path_create dont_touch %basepath [[INPUT_NLA]]
+    // CHECK: [[INPUT_DIR:%.+]] = om.constant "Input"
+    // CHECK: [[INPUT_WIDTH:%.+]] = om.constant #om.integer<1 : i64>
+    // CHECK: [[INPUT_OBJ:%.+]] = om.object @RtlPort([[INPUT_REF]], [[INPUT_DIR]], [[INPUT_WIDTH]])
+
+    // CHECK: [[OUTPUT_REF:%.+]] = om.path_create dont_touch %basepath [[OUTPUT_NLA]]
+    // CHECK: [[OUTPUT_DIR:%.+]] = om.constant "Output"
+    // CHECK: [[OUTPUT_WIDTH:%.+]] = om.constant #om.integer<8 : i64>
+    // CHECK: [[OUTPUT_OBJ:%.+]] = om.object @RtlPort([[OUTPUT_REF]], [[OUTPUT_DIR]], [[OUTPUT_WIDTH]])
+
+    // CHECK: [[PORTS_LIST:%.+]] = om.list_create [[INPUT_OBJ]], [[OUTPUT_OBJ]]
+
+    // CHECK: om.object @NeedsRTLPorts(%basepath, [[MODULE_PATH]], [[PORTS_LIST]])
+    %object = firrtl.object @NeedsRTLPorts(in containingModule_in: !firrtl.path, out containingModule: !firrtl.path)
+    %field = firrtl.object.subfield %object[containingModule_in] : !firrtl.class<@NeedsRTLPorts(in containingModule_in: !firrtl.path, out containingModule: !firrtl.path)>
+    firrtl.propassign %field, %path : !firrtl.path
+
+    // Add a second instance to ensure the RtlPorts class is only declared once.
+    %object2 = firrtl.object @NeedsRTLPorts(in containingModule_in: !firrtl.path, out containingModule: !firrtl.path)
+    %field2 = firrtl.object.subfield %object2[containingModule_in] : !firrtl.class<@NeedsRTLPorts(in containingModule_in: !firrtl.path, out containingModule: !firrtl.path)>
+    firrtl.propassign %field2, %path : !firrtl.path
+  }
+
+  // CHECK-COUNT-1: om.class @RtlPort
+
+  // CHECK: om.class @NeedsRTLPorts
+  // CHECK-NEXT: om.class.field @containingModule
+  // CHECK-NEXT: om.class.field @ports
+  firrtl.class @NeedsRTLPorts(in %containingModule_in: !firrtl.path, out %containingModule: !firrtl.path) {
+    firrtl.propassign %containingModule, %containingModule_in : !firrtl.path
+  }
+}

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -535,12 +535,12 @@ firrtl.circuit "RTLPorts" {
     firrtl.propassign %field2, %path : !firrtl.path
   }
 
-  // CHECK-COUNT-1: om.class @RtlPort
-
   // CHECK: om.class @NeedsRTLPorts
   // CHECK-NEXT: om.class.field @containingModule
   // CHECK-NEXT: om.class.field @ports
   firrtl.class @NeedsRTLPorts(in %containingModule_in: !firrtl.path, out %containingModule: !firrtl.path) {
     firrtl.propassign %containingModule, %containingModule_in : !firrtl.path
   }
+
+  // CHECK-COUNT-1: om.class @RtlPort
 }


### PR DESCRIPTION
This transformation used to exist in EmitOMIR to detect the presence of a specific field, and use it to add another specific field on the fly. While we could do this through other means downstream, for full compatibility we are re-implementing this logic.

Because we are already doing many expensive passes through the object IR, this is implemented throughout the existing methods in LowerClasses, rather than adding a new pass or a new traversal to an existing pass.

One consequence of this choice is we do need to perform some global mutation to, e.g., allocate new hierpath ops in a method that was previously parallelized internally to the pass. Rather than reworking things or executing that method serially, this patch adds a mutex to each instance of the pass, and uses the mutex around those global mutations. This should be a fair tradeoff, because in practice we actually only add this new field to one or two objects in the entire IR.

Otherwise, this is fairly straightforward. When we are declaring classes, we check if we need to add the extra field. When we are adding class bodies, we check if we need to add the extra block argument. When we are converting object instances, we check if we need to supply the extra argument. It is in this final case that we actually make a list of objects. Now that we are off the JSON based OMIR, this is the proper way to add a new field with the same type.