### PR TITLE
[arcilator] Register Verif dialect

### DIFF
--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(arcilator
   CIRCTEmit
   CIRCTExportArc
   CIRCTOM
+  CIRCTVerif
   CIRCTSeqToSV
   CIRCTSeqTransforms
   CIRCTSimTransforms

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -24,6 +24,7 @@
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/Dialect/Sim/SimDialect.h"
 #include "circt/Dialect/Sim/SimPasses.h"
+#include "circt/Dialect/Verif/VerifDialect.h"
 #include "circt/InitAllDialects.h"
 #include "circt/InitAllPasses.h"
 #include "circt/Support/Passes.h"
@@ -595,7 +596,8 @@ static LogicalResult executeArcilator(MLIRContext &context) {
     om::OMDialect,
     seq::SeqDialect,
     sim::SimDialect,
-    sv::SVDialect
+    sv::SVDialect,
+    verif::VerifDialect
   >();
   // clang-format on
 


### PR DESCRIPTION
This PR registers `Verif` dialect for `Arcilator`. In some scenarios (e.g., t1), we need the `Verif` dialect to set up the verification flow.
