### PR TITLE
[Seq][Arc] Allow seq.initial to take immutable operands. Add a cast operation

### DIFF
--- a/include/circt/Dialect/Seq/SeqOps.h
+++ b/include/circt/Dialect/Seq/SeqOps.h
@@ -70,6 +70,12 @@ createConstantInitialValue(OpBuilder builder, Operation *constantLike);
 // initial op.
 Value unwrapImmutableValue(mlir::TypedValue<seq::ImmutableType> immutableVal);
 
+// Helper function to merge initial ops within the block into a single initial
+// op. Return failure if we cannot topologically sort the initial ops.
+// Return null if there is no initial op in the block. Return the initial op
+// otherwise.
+FailureOr<seq::InitialOp> mergeInitialOps(Block *block);
+
 } // namespace seq
 } // namespace circt
 

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -711,7 +711,7 @@ def InitialOp : SeqOp<"initial", [SingleBlock,
     See the Seq dialect rationale for a longer description.
   }];
 
-  let arguments = (ins);
+  let arguments = (ins Variadic<ImmutableType>: $inputs);
   let results = (outs Variadic<ImmutableType>); // seq.immutable values
   let regions = (region SizedRegion<1>:$body);
   let hasVerifier = 1;
@@ -721,7 +721,7 @@ def InitialOp : SeqOp<"initial", [SingleBlock,
   ];
 
   let assemblyFormat = [{
-    $body attr-dict `:` type(results)
+    `(` $inputs `)` $body attr-dict `:` functional-type($inputs, results)
   }];
 
   let extraClassDeclaration = [{
@@ -739,4 +739,13 @@ def YieldOp : SeqOp<"yield",
   ];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";
+}
+
+def FromImmutableOp : SeqOp<"from_immutable", [Pure]> {
+  let summary = "Cast from an immutable type to a wire type";
+
+  let arguments = (ins ImmutableType:$input);
+  let results = (outs AnyType:$output);
+
+  let assemblyFormat = "$input attr-dict `:` functional-type(operands, results)";
 }

--- a/integration_test/Bindings/Python/dialects/seq.py
+++ b/integration_test/Bindings/Python/dialects/seq.py
@@ -27,10 +27,10 @@ with Context() as ctx, Location.unknown():
       poweron_value = hw.ConstantOp.create(i32, 42).result
       # CHECK: %[[INPUT_VAL:.+]] = hw.constant 45
       reg_input = hw.ConstantOp.create(i32, 45).result
-      # CHECK-NEXT: %[[POWERON_VAL:.+]] = seq.initial {
+      # CHECK-NEXT: %[[POWERON_VAL:.+]] = seq.initial() {
       # CHECK-NEXT:   %[[C42:.+]] = hw.constant 42 : i32
       # CHECK-NEXT:   seq.yield %[[C42]] : i32
-      # CHECK-NEXT: } : !seq.immutable<i32>
+      # CHECK-NEXT: } : () -> !seq.immutable<i32>
       # CHECK: %[[DATA_VAL:.+]] = seq.compreg %[[INPUT_VAL]], %clk reset %rst, %[[RESET_VAL]] initial %[[POWERON_VAL]]
       reg = seq.CompRegOp(i32,
                           reg_input,

--- a/integration_test/arcilator/JIT/reg.mlir
+++ b/integration_test/arcilator/JIT/reg.mlir
@@ -19,12 +19,12 @@ hw.module @counter(in %clk: i1, out o1: i8, out o2: i8) {
 
   %r0 = seq.compreg %added1, %seq_clk initial %0#0 : i8
   %r1 = seq.compreg %added2, %seq_clk initial %0#1 : i8
-  %0:2 = seq.initial {
+  %0:2 = seq.initial () {
     %1 = func.call @random() : () -> i32
     %2 = comb.extract %1 from 0 : (i32) -> i8
     %3 = hw.constant 5 : i8
     seq.yield %2, %3: i8, i8
-  } : !seq.immutable<i8>, !seq.immutable<i8>
+  } : () -> (!seq.immutable<i8>, !seq.immutable<i8>)
 
   %one = hw.constant 1 : i8
   %added1 = comb.add %r0, %one : i8

--- a/lib/Bindings/Python/dialects/seq.py
+++ b/lib/Bindings/Python/dialects/seq.py
@@ -99,7 +99,7 @@ class CompRegLike:
         if power_on_value.owner is None:
           assert False, "Initial value must not be port"
         elif isinstance(power_on_value.owner.opview, hw.ConstantOp):
-          init = InitialOp([seq.ImmutableType.get(power_on_value.type)])
+          init = InitialOp([seq.ImmutableType.get(power_on_value.type)], [])
           init.body.blocks.append()
           with InsertionPoint(init.body.blocks[0]):
             cloned_constant = power_on_value.owner.clone()

--- a/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
+++ b/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
@@ -35,12 +35,11 @@ static LogicalResult convertInitialValue(seq::CompRegOp reg,
   if (!reg.getInitialValue())
     return values.push_back({}), success();
 
-  // unrealized_conversion_cast to normal type
+  // Use from_immutable cast to convert the seq.immutable type to the reg's
+  // type.
   OpBuilder builder(reg);
-  auto init = builder
-                  .create<mlir::UnrealizedConversionCastOp>(
-                      reg.getLoc(), reg.getType(), reg.getInitialValue())
-                  .getResult(0);
+  auto init = builder.create<seq::FromImmutableOp>(reg.getLoc(), reg.getType(),
+                                                   reg.getInitialValue());
 
   values.push_back(init);
   return success();

--- a/lib/Conversion/SeqToSV/SeqToSV.cpp
+++ b/lib/Conversion/SeqToSV/SeqToSV.cpp
@@ -23,6 +23,7 @@
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Support/Naming.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -59,11 +60,10 @@ struct SeqToSVPass : public impl::LowerSeqToSVBase<SeqToSVPass> {
 namespace {
 struct ModuleLoweringState {
   ModuleLoweringState(HWModuleOp module)
-      : initalOpLowering(module), module(module) {}
+      : immutableValueLowering(module), module(module) {}
 
-  struct InitialOpLowering {
-    InitialOpLowering(hw::HWModuleOp module)
-        : builder(module.getModuleBody()), module(module) {}
+  struct ImmutableValueLowering {
+    ImmutableValueLowering(hw::HWModuleOp module) : module(module) {}
 
     // Lower initial ops.
     LogicalResult lower();
@@ -82,9 +82,8 @@ struct ModuleLoweringState {
     // defined in SV initial op.
     MapVector<mlir::TypedValue<seq::ImmutableType>, Value> mapping;
 
-    OpBuilder builder;
     hw::HWModuleOp module;
-  } initalOpLowering;
+  } immutableValueLowering;
 
   struct FragmentInfo {
     bool needsRegFragment = false;
@@ -94,21 +93,27 @@ struct ModuleLoweringState {
   HWModuleOp module;
 };
 
-LogicalResult ModuleLoweringState::InitialOpLowering::lower() {
-  auto loweringFailed = module
-                            .walk([&](seq::InitialOp initialOp) {
-                              if (failed(lower(initialOp)))
-                                return mlir::WalkResult::interrupt();
-                              return mlir::WalkResult::advance();
-                            })
-                            .wasInterrupted();
-  return LogicalResult::failure(loweringFailed);
+LogicalResult ModuleLoweringState::ImmutableValueLowering::lower() {
+  auto result = mergeInitialOps(module.getBodyBlock());
+  if (failed(result))
+    return failure();
+
+  auto initialOp = *result;
+  if (!initialOp)
+    return success();
+
+  return lower(initialOp);
 }
 
 LogicalResult
-ModuleLoweringState::InitialOpLowering::lower(seq::InitialOp initialOp) {
+ModuleLoweringState::ImmutableValueLowering::lower(seq::InitialOp initialOp) {
+  OpBuilder builder = OpBuilder::atBlockBegin(module.getBodyBlock());
   if (!svInitialOp)
     svInitialOp = builder.create<sv::InitialOp>(initialOp->getLoc());
+  // Initial ops are merged to single one and must not have operands.
+  assert(initialOp.getNumOperands() == 0 &&
+         "initial op should have no operands");
+
   auto loc = initialOp.getLoc();
   llvm::SmallVector<Value> results;
 
@@ -127,10 +132,10 @@ ModuleLoweringState::InitialOpLowering::lower(seq::InitialOp initialOp) {
   }
 
   svInitialOp.getBodyBlock()->getOperations().splice(
-      svInitialOp.begin(), initialOp.getBodyBlock()->getOperations());
+      svInitialOp.end(), initialOp.getBodyBlock()->getOperations());
 
   assert(initialOp->use_empty());
-  initialOp->erase();
+  initialOp.erase();
   yieldOp->erase();
   return success();
 }
@@ -200,7 +205,7 @@ public:
       auto module = reg->template getParentOfType<hw::HWModuleOp>();
       const auto &initial =
           moduleLoweringStates.find(module.getModuleNameAttr())
-              ->second.initalOpLowering;
+              ->second.immutableValueLowering;
 
       Value initialValue = initial.lookupImmutableValue(init);
 
@@ -247,6 +252,49 @@ void CompRegLower<CompRegClockEnabledOp>::createAssign(
   });
 }
 
+/// Lower FromImmutable to `sv.reg` and `sv.initial`.
+class FromImmutableLowering : public OpConversionPattern<FromImmutableOp> {
+public:
+  FromImmutableLowering(
+      TypeConverter &typeConverter, MLIRContext *context,
+      const MapVector<StringAttr, ModuleLoweringState> &moduleLoweringStates)
+      : OpConversionPattern<FromImmutableOp>(typeConverter, context),
+        moduleLoweringStates(moduleLoweringStates) {}
+
+  using OpAdaptor = typename OpConversionPattern<FromImmutableOp>::OpAdaptor;
+
+  LogicalResult
+  matchAndRewrite(FromImmutableOp fromImmutableOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Location loc = fromImmutableOp.getLoc();
+
+    auto regTy = ConversionPattern::getTypeConverter()->convertType(
+        fromImmutableOp.getType());
+    auto svReg = rewriter.create<sv::RegOp>(loc, regTy);
+
+    auto regVal = rewriter.create<sv::ReadInOutOp>(loc, svReg);
+
+    // Lower initial values.
+    auto module = fromImmutableOp->template getParentOfType<hw::HWModuleOp>();
+    const auto &initial = moduleLoweringStates.find(module.getModuleNameAttr())
+                              ->second.immutableValueLowering;
+
+    Value initialValue =
+        initial.lookupImmutableValue(fromImmutableOp.getInput());
+
+    OpBuilder::InsertionGuard guard(rewriter);
+    auto in = initial.getSVInitial();
+    rewriter.setInsertionPointToEnd(in.getBodyBlock());
+    rewriter.create<sv::BPAssignOp>(fromImmutableOp->getLoc(), svReg,
+                                    initialValue);
+
+    rewriter.replaceOp(fromImmutableOp, regVal);
+    return success();
+  }
+
+private:
+  const MapVector<StringAttr, ModuleLoweringState> &moduleLoweringStates;
+};
 // Lower seq.clock_gate to a fairly standard clock gate implementation.
 //
 class ClockGateLowering : public OpConversionPattern<ClockGateOp> {
@@ -537,7 +585,7 @@ void SeqToSVPass::runOnOperation() {
     moduleLoweringStates.try_emplace(module.getModuleNameAttr(),
                                      ModuleLoweringState(module));
 
-  mlir::parallelForEach(
+  auto result = mlir::failableParallelForEach(
       &getContext(), moduleLoweringStates, [&](auto &moduleAndState) {
         auto &state = moduleAndState.second;
         auto module = state.module;
@@ -561,8 +609,11 @@ void SeqToSVPass::runOnOperation() {
           }
           needsMemRandomization = true;
         }
-        (void)state.initalOpLowering.lower();
+        return state.immutableValueLowering.lower();
       });
+
+  if (failed(result))
+    return signalPassFailure();
 
   auto randomInitFragmentName =
       FlatSymbolRefAttr::get(context, "RANDOM_INIT_FRAGMENT");
@@ -605,6 +656,8 @@ void SeqToSVPass::runOnOperation() {
                                         moduleLoweringStates);
   patterns.add<CompRegLower<CompRegClockEnabledOp>>(
       typeConverter, context, lowerToAlwaysFF, moduleLoweringStates);
+  patterns.add<FromImmutableLowering>(typeConverter, context,
+                                      moduleLoweringStates);
   patterns.add<ClockCastLowering<seq::FromClockOp>>(typeConverter, context);
   patterns.add<ClockCastLowering<seq::ToClockOp>>(typeConverter, context);
   patterns.add<ClockGateLowering>(typeConverter, context);

--- a/lib/Dialect/Arc/Transforms/LowerState.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerState.cpp
@@ -190,6 +190,10 @@ Value ClockLowering::materializeValue(Value value) {
     return {};
   if (auto mapped = materializedValues.lookupOrNull(value))
     return mapped;
+  if (auto fromImmutable = value.getDefiningOp<seq::FromImmutableOp>())
+    // Immutable value is pre-materialized so directly lookup the input.
+    return materializedValues.lookup(fromImmutable.getInput());
+
   if (!shouldMaterialize(value))
     return value;
 
@@ -427,19 +431,27 @@ LogicalResult ModuleLowering::lowerPrimaryOutputs() {
 }
 
 LogicalResult ModuleLowering::lowerInitials() {
-  // Move all operations except for seq.yield to arc.initial op.
-  for (auto op : moduleOp.getOps<seq::InitialOp>()) {
-    auto terminator = cast<seq::YieldOp>(op.getBodyBlock()->getTerminator());
-    getInitial().builder.getBlock()->getOperations().splice(
-        getInitial().builder.getBlock()->begin(),
-        op.getBodyBlock()->getOperations());
+  // Merge all seq.initial ops into a single seq.initial op.
+  auto result = circt::seq::mergeInitialOps(moduleOp.getBodyBlock());
+  if (failed(result))
+    return moduleOp.emitError() << "initial ops cannot be topologically sorted";
 
-    // Map seq.initial results to operands of the seq.yield op.
-    for (auto [result, operand] :
-         llvm::zip(op.getResults(), terminator.getOperands()))
-      getInitial().materializedValues.map(result, operand);
-    terminator.erase();
-  }
+  auto initialOp = *result;
+  if (!initialOp) // There is no seq.initial op.
+    return success();
+
+  // Move the operations of the merged initial op into the builder's block.
+  auto terminator =
+      cast<seq::YieldOp>(initialOp.getBodyBlock()->getTerminator());
+  getInitial().builder.getBlock()->getOperations().splice(
+      getInitial().builder.getBlock()->begin(),
+      initialOp.getBodyBlock()->getOperations());
+
+  // Map seq.initial results to their corresponding operands.
+  for (auto [result, operand] :
+       llvm::zip(initialOp.getResults(), terminator.getOperands()))
+    getInitial().materializedValues.map(result, operand);
+  terminator.erase();
 
   return success();
 }

--- a/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
+++ b/test/Conversion/ConvertToArcs/convert-to-arcs.mlir
@@ -121,15 +121,15 @@ hw.module.extern private @Reshuffling2(out z0: i4, out z1: i4, out z2: i4, out z
 // CHECK-LABEL: hw.module @ReshufflingInit
 hw.module @ReshufflingInit(in %clockA: !seq.clock, in %clockB: !seq.clock, out z0: i4, out z1: i4, out z2: i4, out z3: i4) {
   // CHECK-NEXT: hw.instance "x" @Reshuffling2()
-  // CHECK-NEXT:  %[[INITIAL:.+]]:3 = seq.initial {
+  // CHECK-NEXT:  %[[INITIAL:.+]]:3 = seq.initial() {
   // CHECK-NEXT:    %c1_i4 = hw.constant 1 : i4
   // CHECK-NEXT:    %c2_i4 = hw.constant 2 : i4
   // CHECK-NEXT:    %c3_i4 = hw.constant 3 : i4
   // CHECK-NEXT:    seq.yield %c1_i4, %c2_i4, %c3_i4 : i4, i4, i4
-  // CHECK-NEXT:  } : !seq.immutable<i4>, !seq.immutable<i4>, !seq.immutable<i4>
-  // CHECK-NEXT: %[[C1:.+]] = builtin.unrealized_conversion_cast %[[INITIAL]]#0 : !seq.immutable<i4> to i4
-  // CHECK-NEXT: %[[C2:.+]] = builtin.unrealized_conversion_cast %[[INITIAL]]#1 : !seq.immutable<i4> to i4
-  // CHECK-NEXT: %[[C3:.+]] = builtin.unrealized_conversion_cast %[[INITIAL]]#2 : !seq.immutable<i4> to i4
+  // CHECK-NEXT:  } : () -> (!seq.immutable<i4>, !seq.immutable<i4>, !seq.immutable<i4>)
+  // CHECK-NEXT: %[[C1:.+]] = seq.from_immutable %[[INITIAL]]#0
+  // CHECK-NEXT: %[[C2:.+]] = seq.from_immutable %[[INITIAL]]#1
+  // CHECK-NEXT: %[[C3:.+]] = seq.from_immutable %[[INITIAL]]#2
   // CHECK-NEXT: %[[C0:.+]] = hw.constant 0 : i4
   // CHECK-NEXT: arc.state @ReshufflingInit_arc(%x.z0, %x.z1) clock %clockA initial (%[[C0]], %[[C1]] : i4, i4) latency 1
   // CHECK-NEXT: arc.state @ReshufflingInit_arc_0(%x.z2, %x.z3) clock %clockB initial (%[[C2]], %[[C3]] : i4, i4) latency 1
@@ -137,12 +137,12 @@ hw.module @ReshufflingInit(in %clockA: !seq.clock, in %clockB: !seq.clock, out z
 
   %x.z0, %x.z1, %x.z2, %x.z3 = hw.instance "x" @Reshuffling2() -> (z0: i4, z1: i4, z2: i4, z3: i4)
   %4 = seq.compreg %x.z0, %clockA : i4
-  %init0, %init1, %init2 = seq.initial {
+  %init0, %init1, %init2 = seq.initial () {
     %cst1 = hw.constant 1 : i4
     %cst2 = hw.constant 2 : i4
     %cst3 = hw.constant 3 : i4
     seq.yield %cst1, %cst2, %cst3 : i4, i4, i4
-  } : !seq.immutable<i4>, !seq.immutable<i4>, !seq.immutable<i4>
+  } : () -> (!seq.immutable<i4>, !seq.immutable<i4>, !seq.immutable<i4>)
   %5 = seq.compreg %x.z1, %clockA initial %init0 : i4
   %6 = seq.compreg %x.z2, %clockB initial %init1 : i4
   %7 = seq.compreg %x.z3, %clockB initial %init2 : i4
@@ -242,15 +242,15 @@ hw.module @Trivial(in %clock: !seq.clock, in %i0: i4, in %reset: i1, out out: i4
 
 // CHECK-LABEL: hw.module @TrivialWithInit(
 hw.module @TrivialWithInit(in %clock: !seq.clock, in %i0: i4, in %reset: i1, out out: i4) {
-  // CHECK: %[[INIT:.+]] = seq.initial {
-  // CHECK: %[[CAST:.+]] = builtin.unrealized_conversion_cast %[[INIT]]
+  // CHECK: %[[INIT:.+]] = seq.initial() {
+  // CHECK: %[[CAST:.+]] = seq.from_immutable %[[INIT]]
   // CHECK: [[RES0:%.+]] = arc.state @[[TRIVIALINIT_ARC]](%i0) clock %clock reset %reset initial (%[[CAST]] : i4) latency 1 {names = ["foo"]
   // CHECK-NEXT: hw.output [[RES0:%.+]]
   %0 = hw.constant 0 : i4
-  %init = seq.initial {
+  %init = seq.initial() {
     %cst2 = hw.constant 2 : i4
     seq.yield %cst2: i4
-  } : !seq.immutable<i4>
+  } : () -> !seq.immutable<i4>
   %foo = seq.compreg %i0, %clock reset %reset, %0 initial %init: i4
   hw.output %foo : i4
 }

--- a/test/Conversion/HWToBTOR2/init.mlir
+++ b/test/Conversion/HWToBTOR2/init.mlir
@@ -10,10 +10,10 @@ module {
     //CHECK:    [[NID3:[0-9]+]] constd [[NID0]] 0
     %false = hw.constant false
     //CHECK:    [[INIT:[0-9]+]] init [[NID0]] [[NID2]] [[NID3]]
-    %init = seq.initial {
+    %init = seq.initial() {
       %false_0 = hw.constant false
       seq.yield %false_0 : i1
-    } : !seq.immutable<i1>
+    } : () -> !seq.immutable<i1>
     //CHECK:    [[RESET:[0-9]+]] constd [[NID0]] 0
     %reg = seq.compreg %false, %clock reset %reset, %false initial %init : i1
 

--- a/test/Conversion/LTLToCore/assertproperty.mlir
+++ b/test/Conversion/LTLToCore/assertproperty.mlir
@@ -6,10 +6,10 @@ module {
   hw.module @test(in %clock : !seq.clock, in %reset : i1, in %a : i1) {
     //CHECK:  [[CLK:%.+]] = seq.from_clock %clock
     %0 = seq.from_clock %clock 
-    // CHECK-NEXT: %[[INIT:.+]] = seq.initial {
+    // CHECK-NEXT: %[[INIT:.+]] = seq.initial() {
     // CHECK-NEXT:   %false = hw.constant false
     // CHECK-NEXT:   seq.yield %false : i1
-    // CHECK-NEXT: } : !seq.immutable<i1>
+    // CHECK-NEXT: } : () -> !seq.immutable<i1>
 
     //CHECK:  %true = hw.constant true
     //CHECK:  [[TMP:%.+]] = comb.or %reset, %hbr : i1

--- a/test/Conversion/PipelineToHW/test_poweron.mlir
+++ b/test/Conversion/PipelineToHW/test_poweron.mlir
@@ -7,10 +7,10 @@
 // CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
 // CHECK:           %[[VAL_8:.*]] = hw.constant false
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[VAL_3]] reset %[[VAL_4]], %[[VAL_8]]  initial %[[INIT:.+]] : i1
-// CHECK:           %[[INIT]] = seq.initial {
+// CHECK:           %[[INIT]] = seq.initial() {
 // CHECK:             %false_0 = hw.constant false
 // CHECK:             seq.yield %false_0 : i1
-// CHECK:           } : !seq.immutable<i1>
+// CHECK:           } : () -> !seq.immutable<i1>
 // CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_6]], %[[VAL_7]] : i32
 // CHECK:           hw.output %[[VAL_10]], %[[VAL_9]] : i32, i1
 // CHECK:         }

--- a/test/Conversion/SeqToSV/error.mlir
+++ b/test/Conversion/SeqToSV/error.mlir
@@ -1,0 +1,19 @@
+// RUN: circt-opt %s -verify-diagnostics --lower-seq-to-sv
+
+// TODO: Improve the error message
+// expected-error @+1 {{initial ops cannot be topologically sorted}}
+hw.module @toposort_failure(in %clk: !seq.clock, in %rst: i1, in %i: i32) {
+  %init = seq.initial (%add) {
+    ^bb0(%arg0: i32):
+    seq.yield %arg0 : i32
+  } : (!seq.immutable<i32>) -> !seq.immutable<i32>
+
+  %add = seq.initial (%init) {
+    ^bb0(%arg0 : i32):
+    seq.yield %arg0 : i32
+  } : (!seq.immutable<i32>) -> !seq.immutable<i32>
+
+  %reg = seq.compreg %i, %clk initial %init : i32
+  %reg2 = seq.compreg %i, %clk initial %add : i32
+}
+

--- a/test/Dialect/Arc/lower-state-errors.mlir
+++ b/test/Dialect/Arc/lower-state-errors.mlir
@@ -22,3 +22,18 @@ hw.module @argInit(in %clk: !seq.clock, in %input: i42) {
   %0 = arc.state @DummyArc(%0) clock %clk latency 1 : (i42) -> i42
   %1 = arc.state @DummyArc(%1) clock %clk initial (%0 : i42) latency 1 : (i42) -> i42
 }
+
+// -----
+
+// expected-error @+1 {{initial ops cannot be topologically sorted}}
+hw.module @toposort_failure(in %clk: !seq.clock, in %rst: i1, in %i: i32) {
+  %init = seq.initial (%add) {
+    ^bb0(%arg0: i32):
+    seq.yield %arg0 : i32
+  } : (!seq.immutable<i32>) -> !seq.immutable<i32>
+
+  %add = seq.initial (%init) {
+    ^bb0(%arg0 : i32):
+    seq.yield %arg0 : i32
+  } : (!seq.immutable<i32>) -> !seq.immutable<i32>
+}

--- a/test/Dialect/Seq/errors.mlir
+++ b/test/Dialect/Seq/errors.mlir
@@ -23,18 +23,18 @@ hw.module @fifo3(in %clk : !seq.clock, in %rst : i1, in %in : i32, in %rdEn : i1
 
 hw.module @init() {
   // expected-error @+1 {{result type doesn't match with the terminator}}
-  %0 = seq.initial {
+  %0 = seq.initial () {
     %1 = hw.constant 32: i32
     seq.yield %1, %1: i32, i32
-  }: !seq.immutable<i32>
+  }: () -> !seq.immutable<i32>
 }
 
 // -----
 
 hw.module @init() {
   // expected-error @+1 {{'i32' is expected but got 'i16'}}
-  %0 = seq.initial {
+  %0 = seq.initial () {
     %1 = hw.constant 32: i16
     seq.yield %1: i16
-  }: !seq.immutable<i32>
+  }: () -> !seq.immutable<i32>
 }

--- a/test/Dialect/Seq/round-trip.mlir
+++ b/test/Dialect/Seq/round-trip.mlir
@@ -100,9 +100,18 @@ hw.module @clock_inv(in %clock: !seq.clock) {
 
 // CHECK-LABEL: @init
 hw.module @init() {
-  // CHECK-NEXT: seq.initial
-  %0 = seq.initial {
+  // CHECK-NEXT: %[[VAL:.+]] = seq.initial()
+  %0 = seq.initial () {
     %1 = hw.constant 32: i32
     seq.yield %1: i32
-  }: !seq.immutable<i32>
+  }: () -> !seq.immutable<i32>
+
+  // CHECK:       seq.initial(%[[VAL]]) {
+  // CHECK-NEXT:  ^bb0(%arg0: i32):
+  // CHECK-NEXT:  seq.yield %arg0 : i32
+  %1 = seq.initial (%0) {
+    ^bb0(%arg0: i32):
+    seq.yield %arg0: i32
+  }: (!seq.immutable<i32>) -> !seq.immutable<i32>
+
 }

--- a/test/Dialect/Seq/shiftreg.mlir
+++ b/test/Dialect/Seq/shiftreg.mlir
@@ -7,10 +7,10 @@
 // LO:    %r0_sh1 = seq.compreg.ce sym @r0_sh1  %i, %clk, %ce : i32  
 // LO:    %r0_sh2 = seq.compreg.ce sym @r0_sh2  %r0_sh1, %clk, %ce : i32  
 // LO:    %r0_sh3 = seq.compreg.ce sym @r0_sh3  %r0_sh2, %clk, %ce : i32  
-// LO     %0 = seq.initial {
+// LO     %0 = seq.initial () {
 // LO       %c0_i32_0 = hw.constant 0 : i32
 // LO       seq.yield %c0_i32_0 : i32
-// LO     } : !seq.immutable<i32>
+// LO     } : () -> !seq.immutable<i32>
 // LO:    %myShiftReg_sh1 = seq.compreg.ce sym @myShiftReg_sh1  %i, %clk, %ce reset %rst, %c0_i32 initial %0 : i32
 // LO:    %myShiftReg_sh2 = seq.compreg.ce sym @myShiftReg_sh2  %myShiftReg_sh1, %clk, %ce reset %rst, %c0_i32 initial %0 : i32
 // LO:    %myShiftReg_sh3 = seq.compreg.ce sym @myShiftReg_sh3  %myShiftReg_sh2, %clk, %ce reset %rst, %c0_i32 initial %0 : i32

--- a/test/Tools/circt-bmc/externalize-registers-errors.mlir
+++ b/test/Tools/circt-bmc/externalize-registers-errors.mlir
@@ -28,10 +28,10 @@ hw.module @reg_with_reset(in %clk: !seq.clock, in %rst: i1, in %in: i32, out out
 // -----
 
 hw.module @reg_with_initial(in %clk: !seq.clock, in %in: i32, out out: i32) {
-  %init = seq.initial {
+  %init = seq.initial () {
     %c0_i32 = hw.constant 0 : i32
     seq.yield %c0_i32 : i32
-  } : !seq.immutable<i32>
+  } : () -> !seq.immutable<i32>
 
   // expected-error @below {{registers with initial values not yet supported}}
   %1 = seq.compreg %in, %clk initial %init : i32


### PR DESCRIPTION

This is a PR based on https://github.com/llvm/circt/pull/7638 w/o controversial to_immutable op. 

This commit adds support for seq.initial ops to take immutable operands and introduces a new cast operation:

- Update InitialOp to accept input operands of ImmutableType
- Add FromImmutableOp for casting from immutable to regular types
- Add mergeInitialOps helper to handle operands and topological sorting of initial ops when lowering (SV flow -> SeqToSV, Arc flow -> LowerState).
- Update lowering passes and dialects to work with new initial op