### PR TITLE
 [ExtractInstances] Add the extract instances metadata to OM Classes

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -356,13 +356,18 @@ def ClassOp : FIRRTLModuleLike<"class", [
   let builders = [
     OpBuilder<(ins
       "StringAttr":$name,
-      "ArrayRef<PortInfo>":$ports)>];
+      "ArrayRef<PortInfo>":$ports)>,
+    // This builds a ClassOp, with the specified fieldNames and fieldTypes as
+    // ports. The output property is set from the input property port.
+    OpBuilder<(ins
+      "Twine":$name,
+      "mlir::ArrayRef<mlir::StringRef>":$fieldNames,
+      "mlir::ArrayRef<mlir::Type>":$fieldTypes)>
+    ];
 
   let extraModuleClassDeclaration = [{
     Block *getBodyBlock() { return &getBody().front(); }
 
-    // This builds a ClassOp, with the specified fieldNames and fieldTypes as
-    // ports. The output property is set from the input property port.
     ClassOp static buildSimpleClassOp(
       mlir::OpBuilder &odsBuilder, mlir::Location loc, mlir::Twine name,
       mlir::ArrayRef<mlir::StringRef> fieldNames,

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -361,6 +361,13 @@ def ClassOp : FIRRTLModuleLike<"class", [
   let extraModuleClassDeclaration = [{
     Block *getBodyBlock() { return &getBody().front(); }
 
+    // This builds a ClassOp, with the specified fieldNames and fieldTypes as
+    // ports. The output property is set from the input property port.
+    ClassOp static buildSimpleClassOp(
+    mlir::OpBuilder &odsBuilder, mlir::Location loc, mlir::Twine name,
+    mlir::ArrayRef<mlir::StringRef> fieldNames,
+    mlir::ArrayRef<mlir::Type> fieldTypes);
+
     using iterator = Block::iterator;
     iterator begin() { return getBodyBlock()->begin(); }
     iterator end() { return getBodyBlock()->end(); }

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -364,9 +364,9 @@ def ClassOp : FIRRTLModuleLike<"class", [
     // This builds a ClassOp, with the specified fieldNames and fieldTypes as
     // ports. The output property is set from the input property port.
     ClassOp static buildSimpleClassOp(
-    mlir::OpBuilder &odsBuilder, mlir::Location loc, mlir::Twine name,
-    mlir::ArrayRef<mlir::StringRef> fieldNames,
-    mlir::ArrayRef<mlir::Type> fieldTypes);
+      mlir::OpBuilder &odsBuilder, mlir::Location loc, mlir::Twine name,
+      mlir::ArrayRef<mlir::StringRef> fieldNames,
+      mlir::ArrayRef<mlir::Type> fieldTypes);
 
     using iterator = Block::iterator;
     iterator begin() { return getBodyBlock()->begin(); }

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -228,7 +228,8 @@ inline FIRRTLBaseType getBaseType(Type type) {
 }
 
 /// Get base type if isa<> the requested type, else null.
-template <typename T> inline T getBaseOfType(Type type) {
+template <typename T>
+inline T getBaseOfType(Type type) {
   return dyn_cast_or_null<T>(getBaseType(type));
 }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -228,8 +228,7 @@ inline FIRRTLBaseType getBaseType(Type type) {
 }
 
 /// Get base type if isa<> the requested type, else null.
-template <typename T>
-inline T getBaseOfType(Type type) {
+template <typename T> inline T getBaseOfType(Type type) {
   return dyn_cast_or_null<T>(getBaseType(type));
 }
 
@@ -323,7 +322,7 @@ static ResultTy transformReduce(MLIRContext *context, RangeTy &&r,
 void makeCommonPrefix(SmallString<64> &a, StringRef b);
 
 //===----------------------------------------------------------------------===//
-// OM dialect utilities
+// Object related utilities
 //===----------------------------------------------------------------------===//
 
 /// Add the tracker annotation to the op and get a PathOp to the op.

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -228,8 +228,7 @@ inline FIRRTLBaseType getBaseType(Type type) {
 }
 
 /// Get base type if isa<> the requested type, else null.
-template <typename T>
-inline T getBaseOfType(Type type) {
+template <typename T> inline T getBaseOfType(Type type) {
   return dyn_cast_or_null<T>(getBaseType(type));
 }
 
@@ -321,6 +320,20 @@ static ResultTy transformReduce(MLIRContext *context, RangeTy &&r,
 
 /// Truncate `a` to the common prefix of `a` and `b`.
 void makeCommonPrefix(SmallString<64> &a, StringRef b);
+
+//===----------------------------------------------------------------------===//
+// OM dialect utilities
+//===----------------------------------------------------------------------===//
+
+/// Create a ClassOp, with the specified fieldNames and fieldTypes as ports. The
+/// output property is set from the input property port.
+ClassOp buildSimpleClassOp(OpBuilder &odsBuilder, Location loc, Twine name,
+                           ArrayRef<StringRef> fieldNames,
+                           ArrayRef<Type> fieldTypes);
+
+/// Add the tracker annotation to the op and get a PathOp to the op.
+PathOp createPathRef(Operation *op, hw::HierPathOp nla,
+                     mlir::ImplicitLocOpBuilder &builderOM);
 
 } // namespace firrtl
 } // namespace circt

--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -228,8 +228,7 @@ inline FIRRTLBaseType getBaseType(Type type) {
 }
 
 /// Get base type if isa<> the requested type, else null.
-template <typename T>
-inline T getBaseOfType(Type type) {
+template <typename T> inline T getBaseOfType(Type type) {
   return dyn_cast_or_null<T>(getBaseType(type));
 }
 
@@ -325,12 +324,6 @@ void makeCommonPrefix(SmallString<64> &a, StringRef b);
 //===----------------------------------------------------------------------===//
 // OM dialect utilities
 //===----------------------------------------------------------------------===//
-
-/// Create a ClassOp, with the specified fieldNames and fieldTypes as ports. The
-/// output property is set from the input property port.
-ClassOp buildSimpleClassOp(OpBuilder &odsBuilder, Location loc, Twine name,
-                           ArrayRef<StringRef> fieldNames,
-                           ArrayRef<Type> fieldTypes);
 
 /// Add the tracker annotation to the op and get a PathOp to the op.
 PathOp createPathRef(Operation *op, hw::HierPathOp nla,

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4618,7 +4618,8 @@ void SubtagOp::print(::mlir::OpAsmPrinter &printer) {
   printer << " : " << getInput().getType();
 }
 
-template <typename OpTy> static LogicalResult verifySubfieldLike(OpTy op) {
+template <typename OpTy>
+static LogicalResult verifySubfieldLike(OpTy op) {
   if (op.getFieldIndex() >=
       firrtl::type_cast<typename OpTy::InputType>(op.getInput().getType())
           .getNumElements())

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4619,7 +4619,8 @@ void SubtagOp::print(::mlir::OpAsmPrinter &printer) {
   printer << " : " << getInput().getType();
 }
 
-template <typename OpTy> static LogicalResult verifySubfieldLike(OpTy op) {
+template <typename OpTy>
+static LogicalResult verifySubfieldLike(OpTy op) {
   if (op.getFieldIndex() >=
       firrtl::type_cast<typename OpTy::InputType>(op.getInput().getType())
           .getNumElements())

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -1076,32 +1076,6 @@ void circt::firrtl::makeCommonPrefix(SmallString<64> &a, StringRef b) {
     a.pop_back();
 }
 
-ClassOp circt::firrtl::buildSimpleClassOp(OpBuilder &odsBuilder, Location loc,
-                                          Twine name,
-                                          ArrayRef<StringRef> fieldNames,
-                                          ArrayRef<Type> fieldTypes) {
-  SmallVector<PortInfo, 10> ports;
-  for (auto [fieldName, fieldType] : llvm::zip(fieldNames, fieldTypes)) {
-    ports.emplace_back(odsBuilder.getStringAttr(fieldName + "_in"), fieldType,
-                       Direction::In);
-    ports.emplace_back(odsBuilder.getStringAttr(fieldName), fieldType,
-                       Direction::Out);
-  }
-
-  ClassOp classOp =
-      odsBuilder.create<ClassOp>(loc, odsBuilder.getStringAttr(name), ports);
-  Block *body = classOp.getBodyBlock();
-  auto prevLoc = odsBuilder.saveInsertionPoint();
-  odsBuilder.setInsertionPointToEnd(body);
-  auto args = body->getArguments();
-  for (unsigned i = 0, e = ports.size(); i != e; i += 2)
-    odsBuilder.create<PropAssignOp>(loc, args[i + 1], args[i]);
-
-  odsBuilder.restoreInsertionPoint(prevLoc);
-
-  return classOp;
-}
-
 PathOp circt::firrtl::createPathRef(Operation *op, hw::HierPathOp nla,
                                     mlir::ImplicitLocOpBuilder &builderOM) {
 

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -75,33 +75,6 @@ struct ObjectModelIR {
     return builderOM.create<PathOp>(kind, id);
   }
 
-  // Create a ClassOp, with the specified fieldNames and fieldTypes as ports.
-  // The output property is set from the input property port.
-  ClassOp buildSimpleClassOp(OpBuilder &odsBuilder, Location loc, Twine name,
-                             ArrayRef<StringRef> fieldNames,
-                             ArrayRef<Type> fieldTypes) {
-    SmallVector<PortInfo, 10> ports;
-    for (auto [fieldName, fieldType] : llvm::zip(fieldNames, fieldTypes)) {
-      ports.emplace_back(odsBuilder.getStringAttr(fieldName + "_in"), fieldType,
-                         Direction::In);
-      ports.emplace_back(odsBuilder.getStringAttr(fieldName), fieldType,
-                         Direction::Out);
-    }
-
-    ClassOp classOp =
-        odsBuilder.create<ClassOp>(loc, odsBuilder.getStringAttr(name), ports);
-    Block *body = classOp.getBodyBlock();
-    auto prevLoc = odsBuilder.saveInsertionPoint();
-    odsBuilder.setInsertionPointToEnd(body);
-    auto args = body->getArguments();
-    for (unsigned i = 0, e = ports.size(); i != e; i += 2)
-      odsBuilder.create<PropAssignOp>(loc, args[i + 1], args[i]);
-
-    odsBuilder.restoreInsertionPoint(prevLoc);
-
-    return classOp;
-  }
-
   void createMemorySchema() {
 
     auto unknownLoc = mlir::UnknownLoc::get(context);

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -91,9 +91,8 @@ struct ObjectModelIR {
     };
     StringRef extraPortFields[3] = {"name", "direction", "width"};
 
-    extraPortsClass = ClassOp::buildSimpleClassOp(
-        builderOM, unknownLoc, "ExtraPortsMemorySchema", extraPortFields,
-        extraPortsType);
+    extraPortsClass = builderOM.create<ClassOp>(
+        "ExtraPortsMemorySchema", extraPortFields, extraPortsType);
 
     mlir::Type classFieldTypes[13] = {
         StringType::get(context),
@@ -113,9 +112,8 @@ struct ObjectModelIR {
         ListType::get(context, cast<PropertyType>(StringType::get(context))),
     };
 
-    memorySchemaClass =
-        ClassOp::buildSimpleClassOp(builderOM, unknownLoc, "MemorySchema",
-                                    memoryParamNames, classFieldTypes);
+    memorySchemaClass = builderOM.create<ClassOp>(
+        "MemorySchema", memoryParamNames, classFieldTypes);
 
     // Now create the class that will instantiate metadata class with all the
     // memories of the circt.
@@ -129,9 +127,8 @@ struct ObjectModelIR {
     auto builderOM = mlir::ImplicitLocOpBuilder::atBlockEnd(
         unknownLoc, circtOp.getBodyBlock());
     Type classFieldTypes[] = {StringType::get(context)};
-    retimeModulesSchemaClass = ClassOp::buildSimpleClassOp(
-        builderOM, unknownLoc, "RetimeModulesSchema", retimeModulesParamNames,
-        classFieldTypes);
+    retimeModulesSchemaClass = builderOM.create<ClassOp>(
+        "RetimeModulesSchema", retimeModulesParamNames, classFieldTypes);
 
     SmallVector<PortInfo> mports;
     retimeModulesMetadataClass = builderOM.create<ClassOp>(
@@ -168,9 +165,9 @@ struct ObjectModelIR {
     auto builderOM = mlir::ImplicitLocOpBuilder::atBlockEnd(
         unknownLoc, circtOp.getBodyBlock());
     Type classFieldTypes[] = {StringType::get(context)};
-    blackBoxModulesSchemaClass = ClassOp::buildSimpleClassOp(
-        builderOM, unknownLoc, "SitestBlackBoxModulesSchema",
-        blackBoxModulesParamNames, classFieldTypes);
+    blackBoxModulesSchemaClass =
+        builderOM.create<ClassOp>("SitestBlackBoxModulesSchema",
+                                  blackBoxModulesParamNames, classFieldTypes);
     SmallVector<PortInfo> mports;
     blackBoxMetadataClass = builderOM.create<ClassOp>(
         builderOM.getStringAttr("SitestBlackBoxMetadata"), mports);

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -91,9 +91,9 @@ struct ObjectModelIR {
     };
     StringRef extraPortFields[3] = {"name", "direction", "width"};
 
-    extraPortsClass =
-        buildSimpleClassOp(builderOM, unknownLoc, "ExtraPortsMemorySchema",
-                           extraPortFields, extraPortsType);
+    extraPortsClass = ClassOp::buildSimpleClassOp(
+        builderOM, unknownLoc, "ExtraPortsMemorySchema", extraPortFields,
+        extraPortsType);
 
     mlir::Type classFieldTypes[13] = {
         StringType::get(context),
@@ -114,8 +114,8 @@ struct ObjectModelIR {
     };
 
     memorySchemaClass =
-        buildSimpleClassOp(builderOM, unknownLoc, "MemorySchema",
-                           memoryParamNames, classFieldTypes);
+        ClassOp::buildSimpleClassOp(builderOM, unknownLoc, "MemorySchema",
+                                    memoryParamNames, classFieldTypes);
 
     // Now create the class that will instantiate metadata class with all the
     // memories of the circt.
@@ -129,9 +129,9 @@ struct ObjectModelIR {
     auto builderOM = mlir::ImplicitLocOpBuilder::atBlockEnd(
         unknownLoc, circtOp.getBodyBlock());
     Type classFieldTypes[] = {StringType::get(context)};
-    retimeModulesSchemaClass =
-        buildSimpleClassOp(builderOM, unknownLoc, "RetimeModulesSchema",
-                           retimeModulesParamNames, classFieldTypes);
+    retimeModulesSchemaClass = ClassOp::buildSimpleClassOp(
+        builderOM, unknownLoc, "RetimeModulesSchema", retimeModulesParamNames,
+        classFieldTypes);
 
     SmallVector<PortInfo> mports;
     retimeModulesMetadataClass = builderOM.create<ClassOp>(
@@ -168,9 +168,9 @@ struct ObjectModelIR {
     auto builderOM = mlir::ImplicitLocOpBuilder::atBlockEnd(
         unknownLoc, circtOp.getBodyBlock());
     Type classFieldTypes[] = {StringType::get(context)};
-    blackBoxModulesSchemaClass =
-        buildSimpleClassOp(builderOM, unknownLoc, "SitestBlackBoxModulesSchema",
-                           blackBoxModulesParamNames, classFieldTypes);
+    blackBoxModulesSchemaClass = ClassOp::buildSimpleClassOp(
+        builderOM, unknownLoc, "SitestBlackBoxModulesSchema",
+        blackBoxModulesParamNames, classFieldTypes);
     SmallVector<PortInfo> mports;
     blackBoxMetadataClass = builderOM.create<ClassOp>(
         builderOM.getStringAttr("SitestBlackBoxMetadata"), mports);

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -1195,8 +1195,8 @@ void ExtractInstancesPass::createSchema() {
   };
   StringRef portFields[] = {"name", "path", "filename"};
 
-  schemaClass = ClassOp::buildSimpleClassOp(
-      builderOM, unknownLoc, "ExtractInstancesSchema", portFields, portsType);
+  schemaClass = builderOM.create<ClassOp>("ExtractInstancesSchema", portFields,
+                                          portsType);
 
   // Now create the class that will instantiate the schema objects.
   SmallVector<PortInfo> mports;

--- a/test/Dialect/FIRRTL/extract-instances-inject-dut-hier.mlir
+++ b/test/Dialect/FIRRTL/extract-instances-inject-dut-hier.mlir
@@ -22,8 +22,8 @@ firrtl.circuit "ExtractClockGatesMultigrouping" attributes {annotations = [{clas
   // CHECK: firrtl.instance inst1 sym [[INST1_SYM:@.+]] @SomeModule
 
   // CHECK-LABEL: firrtl.module private @ClockGatesGroup
-  // CHECK: firrtl.instance gate @EICG_wrapper
-  // CHECK: firrtl.instance gate @EICG_wrapper
+  // CHECK: firrtl.instance gate sym @sym @EICG_wrapper
+  // CHECK: firrtl.instance gate sym @sym_0 @EICG_wrapper
 
   // CHECK-LABEL: firrtl.module private @DUTModule
   firrtl.module private @DUTModule(in %clock: !firrtl.clock, in %foo_en: !firrtl.uint<1>, in %bar_en: !firrtl.uint<1>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {

--- a/test/Dialect/FIRRTL/extract-instances.mlir
+++ b/test/Dialect/FIRRTL/extract-instances.mlir
@@ -31,7 +31,11 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
   // CHECK-SAME: in %bb_0_out: !firrtl.uint<8>
   firrtl.module private @DUTModule(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
     // CHECK-NOT: firrtl.instance bb @MyBlackBox
-    // CHECK: %mod_in, %mod_out, %mod_bb_0_in, %mod_bb_0_out = firrtl.instance mod sym [[WRAPPER_SYM:@.+]] @BBWrapper
+    // CHECK: %mod_in, %mod_out, %mod_bb_0_in, %mod_bb_0_out = firrtl.instance mod
+    // CHECK-SAME: sym [[WRAPPER_SYM:@.+]] {annotations =
+    // CHECK-SAME: circt.nonlocal
+    // CHECK-SAME: id = distinct[0]<>
+    // CHECK-SAME: @BBWrapper
     // CHECK-NEXT: firrtl.matchingconnect %bb_0_in, %mod_bb_0_in
     // CHECK-NEXT: firrtl.matchingconnect %mod_bb_0_out, %bb_0_out
     %mod_in, %mod_out = firrtl.instance mod @BBWrapper(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
@@ -39,7 +43,7 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
     firrtl.connect %mod_in, %in : !firrtl.uint<8>, !firrtl.uint<8>
   }
   // CHECK-LABEL: firrtl.module @ExtractBlackBoxesSimple
-  firrtl.module @ExtractBlackBoxesSimple(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
+  firrtl.module @ExtractBlackBoxesSimple(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>, out %metadataObj: !firrtl.anyref) {
     // CHECK: %dut_in, %dut_out, %dut_bb_0_in, %dut_bb_0_out = firrtl.instance dut sym {{@.+}} @DUTModule
     // CHECK-NEXT: %bb_in, %bb_out = firrtl.instance bb @MyBlackBox
     // CHECK-NEXT: firrtl.matchingconnect %bb_in, %dut_bb_0_in
@@ -47,7 +51,40 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
     %dut_in, %dut_out = firrtl.instance dut @DUTModule(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
     firrtl.connect %out, %dut_out : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %dut_in, %in : !firrtl.uint<8>, !firrtl.uint<8>
+    %sifive_metadata = firrtl.object @SiFive_Metadata()
+    // CHECK:  firrtl.object @SiFive_Metadata(out extractedInstances_field_0: !firrtl.class<@ExtractInstancesMetadata
+    %0 = firrtl.object.anyref_cast %sifive_metadata : !firrtl.class<@SiFive_Metadata()>
+    firrtl.propassign %metadataObj, %0 : !firrtl.anyref
   }
+  firrtl.class @SiFive_Metadata() {}
+  // CHECK:  firrtl.class @SiFive_Metadata(
+  // CHECK-SAME: out %extractedInstances_field_0: !firrtl.class<@ExtractInstancesMetadata
+  // CHECK-SAME: {
+  // CHECK:    %extract_instances_metadata = firrtl.object @ExtractInstancesMetadata(out bb_0_field: !firrtl.class<@ExtractInstancesSchema
+  // CHECK:    firrtl.propassign %extractedInstances_field_0, %extract_instances_metadata : !firrtl.class<@ExtractInstancesMetadata
+  // CHECK:  }
+
+  // CHECK:  firrtl.class @ExtractInstancesSchema(in %name_in: !firrtl.string, out %name: !firrtl.string, in %path_in: !firrtl.path, out %path: !firrtl.path, in %filename_in: !firrtl.string, out %filename: !firrtl.string) {
+  // CHECK:    firrtl.propassign %name, %name_in : !firrtl.string
+  // CHECK:    firrtl.propassign %path, %path_in : !firrtl.path
+  // CHECK:    firrtl.propassign %filename, %filename_in : !firrtl.string
+  // CHECK:  }
+
+  // CHECK:  firrtl.class @ExtractInstancesMetadata(out %bb_0_field: !firrtl.class<@ExtractInstancesSchema 
+  // CHECK-SAME: {
+  // CHECK:    %[[V0:.+]] = firrtl.string "bb_0"
+  // CHECK:    %[[bb_0:.+]] = firrtl.object @ExtractInstancesSchema
+  // CHECK:    %[[V1:.+]] = firrtl.object.subfield %[[bb_0]][name_in]
+  // CHECK:    firrtl.propassign %[[V1]], %[[V0]] : !firrtl.string
+  // CHECK:    %[[V2:.+]] = firrtl.path instance distinct[0]<>
+  // CHECK:    %[[V3:.+]] = firrtl.object.subfield %[[bb_0]][path_in]
+  // CHECK:    firrtl.propassign %[[V3]], %[[V2]] : !firrtl.path
+  // CHECK:    %[[V4:.+]] = firrtl.object.subfield %[[bb_0]][filename_in]
+  // CHECK:    %[[V5:.+]] = firrtl.string "BlackBoxes.txt"
+  // CHECK:    firrtl.propassign %[[V4]], %[[V5]] : !firrtl.string
+  // CHECK:    firrtl.propassign %bb_0_field, %[[bb_0]]
+  // CHECK:  }
+
   // CHECK:               emit.file "BlackBoxes.txt" {
   // CHECK-NEXT:            sv.verbatim "
   // CHECK-SAME{LITERAL}:     bb_0 -> {{0}}.{{1}}\0A
@@ -139,7 +176,7 @@ firrtl.circuit "ExtractBlackBoxesSimple2" attributes {annotations = [{class = "f
     // CHECK-NEXT: %bb_in, %bb_out = firrtl.instance bb sym [[BB_SYM:@.+]] {annotations = [{class = "Old1"}, {class = "On1"}, {class = "Old2"}, {class = "On2"}]} @MyBlackBox
     // CHECK-NEXT: firrtl.matchingconnect %bb_in, %dut_prefix_1_in
     // CHECK-NEXT: firrtl.matchingconnect %dut_prefix_1_out, %bb_out
-    // CHECK-NEXT: %bb2_in, %bb2_out = firrtl.instance bb2 @MyBlackBox2
+    // CHECK-NEXT: %bb2_in, %bb2_out = firrtl.instance bb2 sym @sym @MyBlackBox2
     // CHECK-NEXT: firrtl.matchingconnect %bb2_in, %dut_prefix_0_in
     // CHECK-NEXT: firrtl.matchingconnect %dut_prefix_0_out, %bb2_out
     %dut_in, %dut_out = firrtl.instance dut sym @dut @DUTModule(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)

--- a/test/Dialect/FIRRTL/extract-instances.mlir
+++ b/test/Dialect/FIRRTL/extract-instances.mlir
@@ -52,16 +52,16 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
     firrtl.connect %out, %dut_out : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %dut_in, %in : !firrtl.uint<8>, !firrtl.uint<8>
     %sifive_metadata = firrtl.object @SiFive_Metadata()
-    // CHECK:  firrtl.object @SiFive_Metadata(out extractedInstances_field_0: !firrtl.class<@ExtractInstancesMetadata
+    // CHECK:  firrtl.object @SiFive_Metadata(out [[extractedInstances_field_0:.+]]: !firrtl.class<@ExtractInstancesMetadata
     %0 = firrtl.object.anyref_cast %sifive_metadata : !firrtl.class<@SiFive_Metadata()>
     firrtl.propassign %metadataObj, %0 : !firrtl.anyref
   }
   firrtl.class @SiFive_Metadata() {}
   // CHECK:  firrtl.class @SiFive_Metadata(
-  // CHECK-SAME: out %extractedInstances_field_0: !firrtl.class<@ExtractInstancesMetadata
+  // CHECK-SAME: out %[[extractedInstances_field_0]]: !firrtl.class<@ExtractInstancesMetadata
   // CHECK-SAME: {
-  // CHECK:    %extract_instances_metadata = firrtl.object @ExtractInstancesMetadata(out bb_0_field: !firrtl.class<@ExtractInstancesSchema
-  // CHECK:    firrtl.propassign %extractedInstances_field_0, %extract_instances_metadata : !firrtl.class<@ExtractInstancesMetadata
+  // CHECK:    %extract_instances_metadata = firrtl.object @ExtractInstancesMetadata(out [[bb_0_field:.+]]: !firrtl.class<@ExtractInstancesSchema
+  // CHECK:    firrtl.propassign %[[extractedInstances_field_0]], %extract_instances_metadata : !firrtl.class<@ExtractInstancesMetadata
   // CHECK:  }
 
   // CHECK:  firrtl.class @ExtractInstancesSchema(in %name_in: !firrtl.string, out %name: !firrtl.string, in %path_in: !firrtl.path, out %path: !firrtl.path, in %filename_in: !firrtl.string, out %filename: !firrtl.string) {
@@ -70,7 +70,7 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
   // CHECK:    firrtl.propassign %filename, %filename_in : !firrtl.string
   // CHECK:  }
 
-  // CHECK:  firrtl.class @ExtractInstancesMetadata(out %bb_0_field: !firrtl.class<@ExtractInstancesSchema 
+  // CHECK:  firrtl.class @ExtractInstancesMetadata(out %[[bb_0_field]]: !firrtl.class<@ExtractInstancesSchema 
   // CHECK-SAME: {
   // CHECK:    %[[V0:.+]] = firrtl.string "bb_0"
   // CHECK:    %[[bb_0:.+]] = firrtl.object @ExtractInstancesSchema
@@ -82,7 +82,7 @@ firrtl.circuit "ExtractBlackBoxesSimple" attributes {annotations = [{class = "fi
   // CHECK:    %[[V4:.+]] = firrtl.object.subfield %[[bb_0]][filename_in]
   // CHECK:    %[[V5:.+]] = firrtl.string "BlackBoxes.txt"
   // CHECK:    firrtl.propassign %[[V4]], %[[V5]] : !firrtl.string
-  // CHECK:    firrtl.propassign %bb_0_field, %[[bb_0]]
+  // CHECK:    firrtl.propassign %[[bb_0_field]], %[[bb_0]]
   // CHECK:  }
 
   // CHECK:               emit.file "BlackBoxes.txt" {
@@ -433,14 +433,23 @@ firrtl.circuit "ExtractClockGatesComposed" attributes {annotations = [
     firrtl.connect %child_en, %en : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module @ExtractClockGatesComposed
-  firrtl.module @ExtractClockGatesComposed(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>) {
+  firrtl.module @ExtractClockGatesComposed(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>, out %metadataObj: !firrtl.anyref) {
     // CHECK: firrtl.instance gate sym [[SYM0]] @EICG_wrapper
     // CHECK: firrtl.instance gate sym [[SYM1]] @EICG_wrapper
     // CHECK: firrtl.instance mem_ext @mem_ext
     %dut_clock, %dut_en = firrtl.instance dut @DUTModule(in clock: !firrtl.clock, in en: !firrtl.uint<1>)
     firrtl.connect %dut_clock, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %dut_en, %en : !firrtl.uint<1>, !firrtl.uint<1>
+    %sifive_metadata = firrtl.object @SiFive_Metadata()
+    // CHECK:  firrtl.object @SiFive_Metadata(
+    // CHECK-SAME: out extractedInstances_field0: !firrtl.class<@ExtractInstancesMetadata
+    // CHECK-SAME: (out mem_wiring_0_field0: !firrtl.class<@ExtractInstancesSchema(in name_in: !firrtl.string, out name: !firrtl.string, in path_in: !firrtl.path, out path: !firrtl.path, in filename_in: !firrtl.string, out filename: !firrtl.string)>
+    // CHECK-SAME: out clock_gate_0_field1: !firrtl.class<@ExtractInstancesSchema(in name_in: !firrtl.string, out name: !firrtl.string, in path_in: !firrtl.path, out path: !firrtl.path, in filename_in: !firrtl.string, out filename: !firrtl.string)>
+    // CHECK-SAME: out clock_gate_1_field3: !firrtl.class<@ExtractInstancesSchema(in name_in: !firrtl.string, out name: !firrtl.string, in path_in: !firrtl.path, out path: !firrtl.path, in filename_in: !firrtl.string, out filename: !firrtl.string)>)>)
+    %0 = firrtl.object.anyref_cast %sifive_metadata : !firrtl.class<@SiFive_Metadata()>
+    firrtl.propassign %metadataObj, %0 : !firrtl.anyref
   }
+  firrtl.class @SiFive_Metadata() {}
 
   // CHECK:               emit.file "SeqMems.txt" {
   // CHECK-NEXT:            sv.verbatim "


### PR DESCRIPTION
This change adds the `ExtractInstances` metadata to the OM classes. The OM dialect can then be parsed to generate the respective metadata files.
This change enables to move all the metadata to the OM dialect, instead of existing as verbatim ops.