### PR TITLE
[SCFToCalyx] Memory banking for Calyx

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -182,7 +182,9 @@ def SCFToCalyx : Pass<"lower-scf-to-calyx", "mlir::ModuleOp"> {
             "Identifier of top-level function to be the entry-point component"
             " of the Calyx program.">,
     Option<"ciderSourceLocationMetadata", "cider-source-location-metadata", "bool", "",
-            "Whether to track source location for the Cider debugger.">
+            "Whether to track source location for the Cider debugger.">,
+    Option<"numAvailBanksOpt", "num-avail-banks", "std::string", "",
+            "Json file name that stores  the number of available banks for memories.">
   ];
 }
 

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -182,9 +182,7 @@ def SCFToCalyx : Pass<"lower-scf-to-calyx", "mlir::ModuleOp"> {
             "Identifier of top-level function to be the entry-point component"
             " of the Calyx program.">,
     Option<"ciderSourceLocationMetadata", "cider-source-location-metadata", "bool", "",
-            "Whether to track source location for the Cider debugger.">,
-    Option<"numAvailBanksOpt", "num-avail-banks", "std::string", "",
-            "Json file name that stores  the number of available banks for memories.">
+            "Whether to track source location for the Cider debugger.">
   ];
 }
 

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1390,8 +1390,10 @@ private:
 
           // Create switchOp to select the bank
           SmallVector<Type> resultTypes = {};
-          if (auto loadOp = cast<memref::LoadOp>(memUseOp))
+          if (isa<memref::LoadOp>(memUseOp)) {
+            auto loadOp = cast<memref::LoadOp>(memUseOp);
             resultTypes = {loadOp.getType()};
+          }
 
           SmallVector<int64_t> caseValues;
           for (unsigned i = 0; i < numBanks; ++i)
@@ -1423,7 +1425,8 @@ private:
           assert(defaultRegion.empty() && "Default region should be empty");
           rewriter.setInsertionPointToStart(&defaultRegion.emplaceBlock());
 
-          if (auto loadOp = cast<memref::LoadOp>(memUseOp)) {
+          if (isa<memref::LoadOp>(memUseOp)) {
+            auto loadOp = cast<memref::LoadOp>(memUseOp);
             Type loadType = loadOp.getType();
             TypedAttr zeroAttr =
                 cast<TypedAttr>(rewriter.getZeroAttr(loadType));


### PR DESCRIPTION
Breaking down #7409 

This patch will support memory banking in Calyx by user specifying the number of available banks for each memory (in the order they are declared in the source `.mlir` file) in a `json` file