### PR TITLE
[LLHD][HW] Implement SROA interfaces

### DIFF
--- a/include/circt/Dialect/HW/HWTypes.h
+++ b/include/circt/Dialect/HW/HWTypes.h
@@ -16,6 +16,7 @@
 
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWTypeInterfaces.h"
+#include "mlir/Interfaces/MemorySlotInterfaces.h"
 
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/BuiltinTypes.h"

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -15,6 +15,7 @@
 
 include "circt/Dialect/HW/HWDialect.td"
 include "circt/Dialect/HW/HWTypeInterfaces.td"
+include "mlir/Interfaces/MemorySlotInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
 
 // Base class for other typedefs. Provides dialact-specific defaults.
@@ -50,7 +51,10 @@ def IntTypeImpl : HWType<"Int"> {
 }
 
 // A simple fixed size array. Declares the hw::ArrayType in C++.
-def ArrayTypeImpl : HWType<"Array", [DeclareTypeInterfaceMethods<FieldIDTypeInterface>]> {
+def ArrayTypeImpl : HWType<"Array", [
+  DeclareTypeInterfaceMethods<DestructurableTypeInterface>,
+  DeclareTypeInterfaceMethods<FieldIDTypeInterface>
+]> {
   let summary = "fixed-sized array";
   let description = [{
     Fixed sized HW arrays are roughly similar to C arrays. On the wire (vs.
@@ -128,7 +132,10 @@ def InOutTypeImpl : HWType<"InOut"> {
 }
 
 // A packed struct. Declares the hw::StructType in C++.
-def StructTypeImpl : HWType<"Struct", [DeclareTypeInterfaceMethods<FieldIDTypeInterface>]> {
+def StructTypeImpl : HWType<"Struct", [
+  DeclareTypeInterfaceMethods<DestructurableTypeInterface>,
+  DeclareTypeInterfaceMethods<FieldIDTypeInterface>
+]> {
   let summary = "HW struct type";
   let description = [{
     Represents a structure of name, value pairs.

--- a/include/circt/Dialect/LLHD/IR/LLHD.td
+++ b/include/circt/Dialect/LLHD/IR/LLHD.td
@@ -22,6 +22,7 @@ include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/FunctionInterfaces.td"
+include "mlir/Interfaces/MemorySlotInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
 
 include "circt/Dialect/LLHD/IR/LLHDDialect.td"

--- a/include/circt/Dialect/LLHD/IR/LLHDExtractOps.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDExtractOps.td
@@ -209,6 +209,8 @@ def PtrArraySliceOp : LLHDOp<"ptr.array_slice",
 
 def SigArrayGetOp : LLHDOp<"sig.array_get",
     [Pure,
+     DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
+     DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
      SigPtrIndexBitWidthConstraint<"index", "input">,
      SigArrayElementTypeConstraint<"result", "input">]> {
 
@@ -276,6 +278,8 @@ def PtrArrayGetOp : LLHDOp<"ptr.array_get",
 //===----------------------------------------------------------------------===//
 
 def SigStructExtractOp : LLHDOp<"sig.struct_extract", [Pure,
+  DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
+  DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
   DeclareOpInterfaceMethods<InferTypeOpInterface>, InferTypeOpInterface]> {
   let summary = "Extract a field from a signal of a struct.";
   let description = [{

--- a/include/circt/Dialect/LLHD/IR/LLHDOps.h
+++ b/include/circt/Dialect/LLHD/IR/LLHDOps.h
@@ -23,6 +23,7 @@
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Interfaces/MemorySlotInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 namespace circt {

--- a/include/circt/Dialect/LLHD/IR/LLHDSignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDSignalOps.td
@@ -14,6 +14,7 @@ include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
 
 def SignalOp : LLHDOp<"sig", [
+  DeclareOpInterfaceMethods<DestructurableAllocationOpInterface>,
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
   TypesMatchWith<
     "type of 'init' and underlying type of 'signal' have to match.",
@@ -49,6 +50,8 @@ def SignalOp : LLHDOp<"sig", [
 }
 
 def PrbOp : LLHDOp<"prb", [
+    DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
+    DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
     TypesMatchWith<
       "type of 'result' and underlying type of 'signal' have to match.",
       "signal", "result", "llvm::cast<hw::InOutType>($_self).getElementType()">
@@ -116,6 +119,8 @@ def OutputOp : LLHDOp<"output", [
 }
 
 def DrvOp : LLHDOp<"drv", [
+    DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
+    DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
     TypesMatchWith<
       "type of 'value' and underlying type of 'signal' have to match.",
       "signal", "value", "llvm::cast<hw::InOutType>($_self).getElementType()">

--- a/lib/Dialect/HW/CMakeLists.txt
+++ b/lib/Dialect/HW/CMakeLists.txt
@@ -39,6 +39,7 @@ add_circt_dialect_library(CIRCTHW
   CIRCTSupport
   MLIRIR
   MLIRInferTypeOpInterface
+  MLIRMemorySlotInterfaces
 )
 
 add_circt_library(CIRCTHWReductions

--- a/lib/Dialect/LLHD/IR/CMakeLists.txt
+++ b/lib/Dialect/LLHD/IR/CMakeLists.txt
@@ -17,6 +17,7 @@ add_circt_dialect_library(CIRCTLLHD
   MLIRSideEffectInterfaces
   MLIRControlFlowInterfaces
   MLIRInferTypeOpInterface
+  MLIRMemorySlotInterfaces
   MLIRCallInterfaces
   MLIRFuncDialect
 )

--- a/test/Dialect/LLHD/Transforms/sroa.mlir
+++ b/test/Dialect/LLHD/Transforms/sroa.mlir
@@ -1,0 +1,167 @@
+// RUN: circt-opt --sroa %s | FileCheck %s
+
+// CHECK-LABEL: @struct
+hw.module @struct(in %init : !hw.struct<a: i32, b: i32>, in %v1 : i32, in %v2 : i32, out out1 : !hw.struct<a: i32, b: i32>, out out2 : !hw.struct<a: i32, b: i32>) {
+  %time = llhd.constant_time <0ns, 0d, 1e>
+
+  //      CHECK: [[V0:%.+]] = hw.struct_extract %init["a"] : !hw.struct<a: i32, b: i32>
+  // CHECK-NEXT: [[V1:%.+]] = llhd.sig{{ }}
+  // CHECK-SAME: [[V0]]
+  // CHECK-NEXT: [[V2:%.+]] = hw.struct_extract %init["b"] : !hw.struct<a: i32, b: i32>
+  // CHECK-NEXT: [[V3:%.+]] = llhd.sig{{ }}
+  // CHECK-SAME: [[V2]]
+  %sig = llhd.sig %init : !hw.struct<a: i32, b: i32>
+
+  // CHECK-NEXT: [[V4:%.+]] = llhd.prb [[V1]]
+  // CHECK-NEXT: [[V5:%.+]] = llhd.prb [[V3]]
+  // CHECK-NEXT: [[V6:%.+]] = hw.struct_create ([[V4]], [[V5]]) : !hw.struct<a: i32, b: i32>
+  %prb = llhd.prb %sig : !hw.inout<!hw.struct<a: i32, b: i32>>
+
+  %a = llhd.sig.struct_extract %sig["a"] : !hw.inout<!hw.struct<a: i32, b: i32>>
+  %b = llhd.sig.struct_extract %sig["b"] : !hw.inout<!hw.struct<a: i32, b: i32>>
+
+  // CHECK-NEXT: llhd.drv [[V1]], %v1 after
+  // CHECK-NEXT: llhd.drv [[V3]], %v2 after
+  llhd.drv %a, %v1 after %time : !hw.inout<i32>
+  llhd.drv %b, %v2 after %time : !hw.inout<i32>
+
+  // CHECK-NEXT: [[V7:%.+]] = hw.struct_extract %init["a"] : !hw.struct<a: i32, b: i32>
+  // CHECK-NEXT: [[V8:%.+]] = llhd.sig{{ }}
+  // CHECK-SAME: [[V7]]
+  // CHECK-NEXT: [[V9:%.+]] = hw.struct_extract %init["b"] : !hw.struct<a: i32, b: i32>
+  // CHECK-NEXT: [[V10:%.+]] = llhd.sig{{ }}
+  // CHECK-SAME: [[V9]]
+  %sig2 = llhd.sig %init : !hw.struct<a: i32, b: i32>
+
+  // CHECK-NEXT: [[V11:%.+]] = llhd.prb [[V8]]
+  // CHECK-NEXT: [[V12:%.+]] = llhd.prb [[V10]]
+  // CHECK-NEXT: [[V13:%.+]] = hw.struct_create ([[V11]], [[V12]]) : !hw.struct<a: i32, b: i32>
+  %prb2 = llhd.prb %sig2 : !hw.inout<!hw.struct<a: i32, b: i32>>
+
+  //      CHECK: [[V14:%.+]] = hw.struct_extract %init["a"]
+  // CHECK-NEXT: llhd.drv [[V8]], [[V14]] after
+  //      CHECK: [[V15:%.+]] = hw.struct_extract %init["b"]
+  // CHECK-NEXT: llhd.drv [[V10]], [[V15]] after
+  llhd.drv %sig2, %init after %time : !hw.inout<!hw.struct<a: i32, b: i32>>
+
+  // CHECK-NEXT: hw.output [[V6]], [[V13]] : !hw.struct<a: i32, b: i32>, !hw.struct<a: i32, b: i32>
+  hw.output %prb, %prb2 : !hw.struct<a: i32, b: i32>, !hw.struct<a: i32, b: i32>
+}
+
+// CHECK-LABEL: @array
+hw.module @array(in %init : !hw.array<2xi32>, in %v1 : i32, in %v2 : i32, out out1 : !hw.array<2xi32>, out out2 : !hw.array<2xi32>) {
+  %time = llhd.constant_time <0ns, 0d, 1e>
+  %false = hw.constant false
+  %true = hw.constant true
+
+  //      CHECK: [[V0:%.+]] = hw.array_get %init[%false
+  // CHECK-NEXT: [[V1:%.+]] = llhd.sig
+  // CHECK-SAME: [[V0]]
+  //      CHECK: [[V2:%.+]] = hw.array_get %init[%true
+  // CHECK-NEXT: [[V3:%.+]] = llhd.sig
+  // CHECK-SAME: [[V2]]
+  %sig = llhd.sig %init : !hw.array<2xi32>
+
+  // CHECK-NEXT: [[V4:%.+]] = llhd.prb [[V1]]
+  // CHECK-NEXT: [[V5:%.+]] = llhd.prb [[V3]]
+  // CHECK-NEXT: [[V6:%.+]] = hw.array_create [[V4]], [[V5]] : i32
+  %prb = llhd.prb %sig : !hw.inout<!hw.array<2xi32>>
+
+  %a = llhd.sig.array_get %sig[%false] : !hw.inout<!hw.array<2xi32>>
+  %b = llhd.sig.array_get %sig[%true] : !hw.inout<!hw.array<2xi32>>
+
+  // CHECK-NEXT: llhd.drv [[V1]], %v1 after
+  // CHECK-NEXT: llhd.drv [[V3]], %v2 after
+  llhd.drv %a, %v1 after %time : !hw.inout<i32>
+  llhd.drv %b, %v2 after %time : !hw.inout<i32>
+
+  //      CHECK: [[V7:%.+]] = hw.array_get %init[%false
+  // CHECK-NEXT: [[V8:%.+]] = llhd.sig
+  // CHECK-SAME: [[V7]]
+  //      CHECK: [[V9:%.+]] = hw.array_get %init[%true
+  // CHECK-NEXT: [[V10:%.+]] = llhd.sig
+  // CHECK-SAME: [[V9]]
+  %sig2 = llhd.sig %init : !hw.array<2xi32>
+
+  // CHECK-NEXT: [[V11:%.+]] = llhd.prb [[V8]]
+  // CHECK-NEXT: [[V12:%.+]] = llhd.prb [[V10]]
+  // CHECK-NEXT: [[V13:%.+]] = hw.array_create [[V11]], [[V12]] : i32
+  %prb2 = llhd.prb %sig2 : !hw.inout<!hw.array<2xi32>>
+
+  //      CHECK: [[V14:%.+]] = hw.array_get %init[%false
+  // CHECK-NEXT: llhd.drv [[V8]], [[V14]] after
+  //      CHECK: [[V15:%.+]] = hw.array_get %init[%true
+  // CHECK-NEXT: llhd.drv [[V10]], [[V15]] after
+  llhd.drv %sig2, %init after %time : !hw.inout<!hw.array<2xi32>>
+
+  // CHECK-NEXT: hw.output [[V6]], [[V13]] : !hw.array<2xi32>, !hw.array<2xi32>
+  hw.output %prb, %prb2 : !hw.array<2xi32>, !hw.array<2xi32>
+}
+
+// CHECK-LABEL: @arrayDynamicAccess
+hw.module @arrayDynamicAccess(in %init : !hw.array<2xi32>, in %v1 : i32, in %idx : i1, out out : !hw.array<2xi32>) {
+  %time = llhd.constant_time <0ns, 0d, 1e>
+  %false = hw.constant false
+
+  // No SROA performed when array access indices are not statically known
+  //      CHECK: [[V0:%.+]] = llhd.sig %init
+  // CHECK-NEXT: [[V1:%.+]] = llhd.prb [[V0]]
+  // CHECK-NEXT: [[V2:%.+]] = llhd.sig.array_get [[V0]][%false
+  // CHECK-NEXT: [[V3:%.+]] = llhd.sig.array_get [[V0]][%idx
+  // CHECK-NEXT: llhd.drv [[V2]], %v1 after
+  // CHECK-NEXT: llhd.drv [[V3]], %v1 after
+  // CHECK-NEXT: hw.output [[V1]]
+  %sig = llhd.sig %init : !hw.array<2xi32>
+  %prb = llhd.prb %sig : !hw.inout<!hw.array<2xi32>>
+  %a = llhd.sig.array_get %sig[%false] : !hw.inout<!hw.array<2xi32>>
+  %b = llhd.sig.array_get %sig[%idx] : !hw.inout<!hw.array<2xi32>>
+  llhd.drv %a, %v1 after %time : !hw.inout<i32>
+  llhd.drv %b, %v1 after %time : !hw.inout<i32>
+
+  hw.output %prb : !hw.array<2xi32>
+}
+
+// CHECK-LABEL: @nested
+hw.module @nested(in %init : !hw.array<2x!hw.struct<a: i32, b: i32>>, out out : !hw.array<2x!hw.struct<a: i32, b: i32>>) {
+  %time = llhd.constant_time <0ns, 0d, 1e>
+
+  // CHECK: [[V0:%.+]] = hw.array_get %init[%false
+  // CHECK: [[V1:%.+]] = hw.struct_extract [[V0]]["a"]
+  // CHECK: [[V2:%.+]] = llhd.sig{{ }}
+  // CHECK-SAME: [[V1]]
+  // CHECK: [[V3:%.+]] = hw.struct_extract [[V0]]["b"]
+  // CHECK: [[V4:%.+]] = llhd.sig{{ }}
+  // CHECK-SAME: [[V3]]
+  // CHECK: [[V5:%.+]] = hw.array_get %init[%true
+  // CHECK: [[V6:%.+]] = hw.struct_extract [[V5]]["a"]
+  // CHECK: [[V7:%.+]] = llhd.sig{{ }}
+  // CHECK-SAME: [[V6]]
+  // CHECK: [[V8:%.+]] = hw.struct_extract [[V5]]["b"]
+  // CHECK: [[V9:%.+]] = llhd.sig{{ }}
+  // CHECK-SAME: [[V8]]
+  %sig = llhd.sig %init : !hw.array<2x!hw.struct<a: i32, b: i32>>
+
+  // CHECK: [[V10:%.+]] = llhd.prb [[V2]]
+  // CHECK: [[V11:%.+]] = llhd.prb [[V4]]
+  // CHECK: [[V12:%.+]] = hw.struct_create ([[V10]], [[V11]]) : !hw.struct<a: i32, b: i32>
+  // CHECK: [[V13:%.+]] = llhd.prb [[V7]]
+  // CHECK: [[V14:%.+]] = llhd.prb [[V9]]
+  // CHECK: [[V15:%.+]] = hw.struct_create ([[V13]], [[V14]]) : !hw.struct<a: i32, b: i32>
+  // CHECK: [[V16:%.+]] = hw.array_create [[V12]], [[V15]] :
+  %0 = llhd.prb %sig : !hw.inout<!hw.array<2x!hw.struct<a: i32, b: i32>>>
+
+  // CHECK: [[V17:%.+]] = hw.array_get %init[%false
+  // CHECK: [[V18:%.+]] = hw.struct_extract [[V17]]["a"]
+  // CHECK: llhd.drv [[V2]], [[V18]] after
+  // CHECK: [[V19:%.+]] = hw.struct_extract [[V17]]["b"]
+  // CHECK: llhd.drv [[V4]], [[V19]] after
+  // CHECK: [[V20:%.+]] = hw.array_get %init[%true
+  // CHECK: [[V21:%.+]] = hw.struct_extract [[V20]]["a"]
+  // CHECK: llhd.drv [[V7]], [[V21]] after
+  // CHECK: [[V22:%.+]] = hw.struct_extract [[V20]]["b"]
+  // CHECK: llhd.drv [[V9]], [[V22]] after
+  llhd.drv %sig, %init after %time : !hw.inout<!hw.array<2x!hw.struct<a: i32, b: i32>>>
+
+  // CHECK: hw.output [[V16]] : !hw.array<2xstruct<a: i32, b: i32>>
+  hw.output %0 : !hw.array<2x!hw.struct<a: i32, b: i32>>
+}


### PR DESCRIPTION
Implement SROA to destructure signals used by `llhd.sig.array_get` (with constant index) and `llhd.sig.struct_extract`.

Let me know if you'd prefer the interfaces implemented via external models.