### PR TITLE
[FIRRTL] InferResets: properly lower FART'd registers

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1685,6 +1685,14 @@ LogicalResult InferResetsPass::implementFullReset(FModuleOp module,
     return success();
   }
 
+  // Add an annotation indicating that this module belongs to a reset domain.
+  auto *context = module.getContext();
+  AnnotationSet annotations(module);
+  annotations.addAnnotations(DictionaryAttr::get(
+      context, NamedAttribute(StringAttr::get(context, "class"),
+                              StringAttr::get(context, fullResetAnnoClass))));
+  annotations.applyToOperation(module);
+
   // If needed, add a reset port to the module.
   Value actualReset = domain.existingValue;
   if (domain.newPortName) {


### PR DESCRIPTION
This is quick fix for https://github.com/llvm/circt/issues/7675.

The way this is supposed to work is, FRT is not supposed to add a reset if a register already has one, but it isn't smart enough to understand that an invalid value corresponds to a register without a reset. As a result, it will not add a reset to this register. Later on, in SFCCompat, when choosing how to lower the Invalid value, it should "see" that the registers should all have a reset, by looking for the FRT annotation, and choose to lower the reset value to 0 or remove the reset accordingly. The "bug" is that the FRT annotation on a parent module won't be discovered on the child module.

This attaches the annotation on to every module in a reset domain, so that it can be found.