### PR TITLE
[OM] Update FreezePaths to handle object fields with paths.

### DIFF
--- a/test/Dialect/OM/freeze-paths.mlir
+++ b/test/Dialect/OM/freeze-paths.mlir
@@ -112,3 +112,15 @@ om.class @PathListTest(%arg : !om.list<!om.path>) {
   // CHECK: om.object @PathListClass([[RES]]) : (!om.list<!om.frozenpath>)
   om.object @PathListClass(%0) : (!om.list<!om.path>) -> !om.class.type<@PathListClass>
 }
+
+// CHECK-LABEL: om.class @ObjectFieldTest
+om.class @ObjectFieldTest(%basepath : !om.basepath, %path : !om.path) {
+  // CHECK: [[OBJ:%.+]] = om.object @PathTest
+  %0 = om.object @PathTest(%basepath, %path) : (!om.basepath, !om.path) -> !om.class.type<@PathTest>
+
+  // CHECK: [[SUBFIELD:%.+]] = om.object.field [[OBJ]], [@nestedpath] : (!om.class.type<@PathTest>) -> !om.list<!om.list<!om.frozenpath>>
+  %1 = om.object.field %0, [@nestedpath] : (!om.class.type<@PathTest>) -> !om.list<!om.list<!om.path>>
+
+  // CHECK: om.class.field @subfield, [[SUBFIELD]] : !om.list<!om.list<!om.frozenpath>>
+  om.class.field @subfield, %1 : !om.list<!om.list<!om.path>>
+}


### PR DESCRIPTION
When we walk the IR and freeze paths, we previously didn't handle object field ops. This is totally valid IR, and is another case where we may encounter ops defining SSA values of path types that need to be frozen.

This adds a visitor for ObjectFieldOp, similar to the other visitors, which rewrites the result type to map any path types to frozen path types.