### PR TITLE
[FIRRTL] Ensure LowerClasses respects alt base path for local paths.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -657,8 +657,10 @@ PathTracker::processPathTrackers(const AnnoTarget &target) {
     // to the start of the annotation's NLA.
     InstanceGraphNode *node = instanceGraph.lookup(moduleName);
     while (true) {
-      // If it's not a non-local target, we don't have to append anything.
-      if (!hierPathOp)
+      // If it's not a non-local target, we don't have to append anything,
+      // unless it needs an alternative base path, in which case we do need to
+      // make a hierarchical path.
+      if (!hierPathOp && !needsAltBasePath.value())
         break;
 
       // If we get to the owning module or the top, we're done.

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -391,15 +391,20 @@ firrtl.circuit "IntegerArithmetic" {
 
 // CHECK-LABEL: firrtl.circuit "AltBasePath"
 firrtl.circuit "AltBasePath" {
+  // CHECK: hw.hierpath private [[FOO_NLA:@.+]] [@AltBasePath::[[FOO_SYM:@.+]]]
+
   firrtl.class private @Node(in %path: !firrtl.path) {
   }
+
+  // CHECK: firrtl.module @AltBasePath
+  // CHECK: firrtl.instance foo sym [[FOO_SYM]]
 
   // CHECK: om.class @OMIR(%basepath: !om.basepath, %alt_basepath_0: !om.basepath)
   firrtl.class private @OMIR() {
     %node = firrtl.object @Node(in path: !firrtl.path)
     %0 = firrtl.object.subfield %node[path] : !firrtl.class<@Node(in path: !firrtl.path)>
 
-    // CHECK: om.path_create member_instance %alt_basepath_0
+    // CHECK: om.path_create member_instance %alt_basepath_0 [[FOO_NLA]]
     %1 = firrtl.path member_reference distinct[0]<>
     firrtl.propassign %0, %1 : !firrtl.path
   }


### PR DESCRIPTION
We recently started supporting local-only paths in LowerClasses, but this logic erroneously disabled the alternative base path feature for paths whose targets were relocated outside the owning module. In the case that we need an alternative base path for a local target, convert it to a non-local target, so the alternative base path can be correctly prefixed.