### PR TITLE
[Sim][NFC] Include InferTypeOpInterface in SimOps.td

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.h
+++ b/include/circt/Dialect/Sim/SimOps.h
@@ -13,18 +13,18 @@
 #ifndef CIRCT_DIALECT_SIM_SIMOPS_H
 #define CIRCT_DIALECT_SIM_SIMOPS_H
 
-#include "mlir/Bytecode/BytecodeOpInterface.h"
-#include "mlir/IR/OpImplementation.h"
-#include "mlir/IR/SymbolTable.h"
-
 #include "circt/Dialect/HW/HWOpInterfaces.h"
 #include "circt/Dialect/Seq/SeqDialect.h"
 #include "circt/Dialect/Seq/SeqTypes.h"
 #include "circt/Dialect/Sim/SimDialect.h"
 #include "circt/Dialect/Sim/SimTypes.h"
 #include "circt/Support/BuilderUtils.h"
+#include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/CallInterfaces.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
 
 #define GET_OP_CLASSES
 #include "circt/Dialect/Sim/Sim.h.inc"

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -13,13 +13,14 @@
 #ifndef CIRCT_DIALECT_SIM_SIMOPS_TD
 #define CIRCT_DIALECT_SIM_SIMOPS_TD
 
-include "mlir/Interfaces/SideEffectInterfaces.td"
-include "mlir/Interfaces/FunctionInterfaces.td"
-include "circt/Dialect/Sim/SimDialect.td"
-include "circt/Dialect/Sim/SimTypes.td"
-include "circt/Dialect/Seq/SeqTypes.td"
 include "circt/Dialect/HW/HWOpInterfaces.td"
 include "circt/Dialect/HW/HWTypes.td"
+include "circt/Dialect/Seq/SeqTypes.td"
+include "circt/Dialect/Sim/SimDialect.td"
+include "circt/Dialect/Sim/SimTypes.td"
+include "mlir/Interfaces/FunctionInterfaces.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 class SimOp<string mnemonic, list<Trait> traits = []> :
     Op<SimDialect, mnemonic, traits>;
@@ -278,7 +279,6 @@ def FormatCharOp : SimOp<"fmt.char", [Pure]> {
 
 def FormatStringConcatOp : SimOp<"fmt.concat", [Pure]> {
   let summary = "Concatenate format strings";
-
   let description = [{
     Concatenates an arbitrary number of format strings from
     left to right. If the argument list is empty, the empty string
@@ -287,7 +287,6 @@ def FormatStringConcatOp : SimOp<"fmt.concat", [Pure]> {
     Concatenations must not be recursive. I.e., a concatenated string should
     not contain itself directly or indirectly.
   }];
-
 
   let arguments = (ins Variadic<FormatStringType>:$inputs);
   let results = (outs FormatStringType:$result);
@@ -319,12 +318,6 @@ def FormatStringConcatOp : SimOp<"fmt.concat", [Pure]> {
     /// and flattening continues without recursing into the cycle.
     LogicalResult getFlattenedInputs(llvm::SmallVectorImpl<Value> &flatOperands);
   }];
-
-  let builders = [
-    OpBuilder<(ins "mlir::ValueRange":$inputs), [{
-      return build($_builder, $_state, circt::sim::FormatStringType::get($_builder.getContext()), inputs);
-    }]>
-  ];
 }
 
 def PrintFormattedOp : SimOp<"print"> {

--- a/lib/Dialect/Sim/Transforms/ProceduralizeSim.cpp
+++ b/lib/Dialect/Sim/Transforms/ProceduralizeSim.cpp
@@ -16,14 +16,12 @@
 #include "circt/Dialect/Sim/SimOps.h"
 #include "circt/Dialect/Sim/SimTypes.h"
 #include "circt/Support/Debug.h"
-
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Pass/Pass.h"
 #include "llvm/ADT/IndexedMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
-
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Pass/Pass.h"
 
 #define DEBUG_TYPE "proceduralize-sim"
 


### PR DESCRIPTION
Include the `InferTypeOpInterface.td` file in `SimOps.td`, which causes TableGen to automatically generate builders without result type for operations where the result type is either fixed or derived from the operands. This makes one of the builders obsolete.