### PR TITLE
[MooreToCore] Add support for format strings and display task

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -512,12 +512,18 @@ def HandshakeToHW : Pass<"lower-handshake-to-hw", "mlir::ModuleOp"> {
 def ConvertMooreToCore : Pass<"convert-moore-to-core", "mlir::ModuleOp"> {
   let summary = "Convert Moore to Core";
   let description = [{
-    This pass translates Moore to the core dialects (Comb/HW/LLHD).
+    This pass translates Moore to the core dialects.
   }];
   let constructor = "circt::createConvertMooreToCorePass()";
-  let dependentDialects = ["comb::CombDialect", "hw::HWDialect",
-                           "llhd::LLHDDialect", "mlir::cf::ControlFlowDialect",
-                           "mlir::scf::SCFDialect", "verif::VerifDialect"];
+  let dependentDialects = [
+    "comb::CombDialect",
+    "hw::HWDialect",
+    "llhd::LLHDDialect",
+    "mlir::cf::ControlFlowDialect",
+    "mlir::scf::SCFDialect",
+    "sim::SimDialect",
+    "verif::VerifDialect",
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/MooreToCore/CMakeLists.txt
+++ b/lib/Conversion/MooreToCore/CMakeLists.txt
@@ -13,6 +13,7 @@ add_circt_conversion_library(CIRCTMooreToCore
   CIRCTHW
   CIRCTLLHD
   CIRCTMoore
+  CIRCTSim
   CIRCTVerif
   MLIRControlFlowDialect
   MLIRFuncDialect

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -320,6 +320,25 @@ func.func @Statements(%arg0: !moore.i42) {
   return
 }
 
+// CHECK-LABEL: func @FormatStrings
+func.func @FormatStrings(%arg0: !moore.i42) {
+  // CHECK: [[TMP:%.+]] = sim.fmt.lit "hello"
+  %0 = moore.fmt.literal "hello"
+  // CHECK: sim.fmt.concat ([[TMP]], [[TMP]])
+  %1 = moore.fmt.concat (%0, %0)
+  // CHECK: sim.fmt.dec %arg0 : i42
+  moore.fmt.int decimal %arg0, width 42, align right, pad space : i42
+  // CHECK: sim.fmt.bin %arg0 : i42
+  moore.fmt.int binary %arg0, width 42, align right, pad space : i42
+  // CHECK: sim.fmt.hex %arg0 : i42
+  moore.fmt.int hex_lower %arg0, width 42, align right, pad space : i42
+  // CHECK: sim.fmt.hex %arg0 : i42
+  moore.fmt.int hex_upper %arg0, width 42, align right, pad space : i42
+  // CHECK: sim.proc.print [[TMP]]
+  moore.builtin.display %0
+  return
+}
+
 // CHECK-LABEL: hw.module @InstanceNull() {
 moore.module @InstanceNull() {
 


### PR DESCRIPTION
Lower the format string ops and the `moore.builtin.display` task to the corresponding ops in the Sim dialect. This is not perfect yet, since Sim does not support some of the formatting options. They will be easy to add in the future though.