### PR TITLE
[ArcToLLVM] Add support for index dialect

### DIFF
--- a/lib/Conversion/ArcToLLVM/CMakeLists.txt
+++ b/lib/Conversion/ArcToLLVM/CMakeLists.txt
@@ -16,6 +16,7 @@ add_circt_conversion_library(CIRCTArcToLLVM
   MLIRArithToLLVM
   MLIRControlFlowToLLVM
   MLIRFuncToLLVM
+  MLIRIndexToLLVM
   MLIRLLVMCommonConversion
   MLIRSCFToControlFlow
   MLIRTransforms

--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -24,12 +24,17 @@ set(libs
   CIRCTSimTransforms
   CIRCTSupport
   CIRCTTransforms
+  MLIRArithDialect
   MLIRBuiltinToLLVMIRTranslation
+  MLIRControlFlowDialect
   MLIRDLTIDialect
+  MLIRFuncDialect
   MLIRFuncInlinerExtension
+  MLIRIndexDialect
   MLIRLLVMIRTransforms
   MLIRLLVMToLLVMIRTranslation
   MLIRParser
+  MLIRSCFDialect
   MLIRTargetLLVMIRExport
 )
 

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -40,6 +40,7 @@
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "mlir/Dialect/LLVMIR/Transforms/Passes.h"
@@ -596,6 +597,7 @@ static LogicalResult executeArcilator(MLIRContext &context) {
     mlir::cf::ControlFlowDialect,
     mlir::DLTIDialect,
     mlir::func::FuncDialect,
+    mlir::index::IndexDialect,
     mlir::LLVM::LLVMDialect,
     mlir::scf::SCFDialect,
     om::OMDialect,


### PR DESCRIPTION
Support the index dialect when lowering from Arc to LLVM. Also fix a minor issue in the lowering `SimGetPortOp`.