### PR TITLE
[FIRRTL] Don't force non-local trackers in Dedup.

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -114,7 +114,8 @@ std::unique_ptr<mlir::Pass> createVBToBVPass();
 
 std::unique_ptr<mlir::Pass> createAddSeqMemPortsPass();
 
-std::unique_ptr<mlir::Pass> createDedupPass();
+std::unique_ptr<mlir::Pass>
+createDedupPass(bool disableLocalAnnotations = false);
 
 std::unique_ptr<mlir::Pass> createEliminateWiresPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -269,6 +269,11 @@ def Dedup : Pass<"firrtl-dedup", "firrtl::CircuitOp"> {
     Statistic<"erasedModules", "num-erased-modules",
       "Number of modules which were erased by deduplication">
   ];
+  let options = [
+    Option<"disableLocalAnnotations", "disable-local-annotations", "bool",
+           "false", "Disable local annotations and revert to legacy behavior " #
+	            "of making annotations non-local">
+  ];
   let constructor = "circt::firrtl::createDedupPass()";
 }
 

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -101,6 +101,7 @@ public:
   bool shouldAdvancedLayerSink() const { return advancedLayerSink; }
   bool shouldLowerMemories() const { return lowerMemories; }
   bool shouldDedup() const { return !noDedup; }
+  bool shouldDisableLocalAnnotations() const { return disableLocalAnnotations; }
   bool shouldEnableDebugInfo() const { return enableDebugInfo; }
   bool shouldIgnoreReadEnableMemories() const { return ignoreReadEnableMem; }
   bool shouldEmitOMIR() const { return emitOMIR; }
@@ -209,6 +210,11 @@ public:
 
   FirtoolOptions &setNoDedup(bool value) {
     noDedup = value;
+    return *this;
+  }
+
+  FirtoolOptions &setDisableLocalAnnotations(bool value) {
+    disableLocalAnnotations = value;
     return *this;
   }
 
@@ -384,6 +390,7 @@ private:
   std::string chiselInterfaceOutDirectory;
   bool vbToBV;
   bool noDedup;
+  bool disableLocalAnnotations;
   firrtl::CompanionMode companionMode;
   bool disableAggressiveMergeConnections;
   bool emitOMIR;

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -1251,6 +1251,13 @@ private:
         targetMap[nla.getAttr()].insert(to);
         continue;
       }
+      // If the annotation is a local tracker, don't make it non-local. This
+      // allows trackers that refer to all instances when the user wants that.
+      if (anno.isClass("circt.tracker")) {
+        newAnnotations.push_back(anno);
+        continue;
+      }
+
       // Otherwise make the annotation non-local and add it to the set.
       makeAnnotationNonLocal(toModule.getModuleNameAttr(), to, fromModule, anno,
                              newAnnotations);

--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -916,12 +916,13 @@ struct Deduper {
   using RenameMap = DenseMap<StringAttr, StringAttr>;
 
   Deduper(InstanceGraph &instanceGraph, SymbolTable &symbolTable,
-          NLATable *nlaTable, CircuitOp circuit)
+          NLATable *nlaTable, CircuitOp circuit, bool disableLocalAnnotations)
       : context(circuit->getContext()), instanceGraph(instanceGraph),
         symbolTable(symbolTable), nlaTable(nlaTable),
         nlaBlock(circuit.getBodyBlock()),
         nonLocalString(StringAttr::get(context, "circt.nonlocal")),
-        classString(StringAttr::get(context, "class")) {
+        classString(StringAttr::get(context, "class")),
+        disableLocalAnnotations(disableLocalAnnotations) {
     // Populate the NLA cache.
     for (auto nla : circuit.getOps<hw::HierPathOp>())
       nlaCache[nla.getNamepathAttr()] = nla.getSymNameAttr();
@@ -1254,12 +1255,15 @@ private:
       }
       // If the annotation is a local tracker, don't make it non-local. This
       // allows trackers that refer to all instances when the user wants that.
-      if (anno.isClass("circt.tracker")) {
-        auto [it, inserted] =
-            localTrackerIds.insert(anno.getMember<DistinctAttr>("id"));
-        if (inserted)
-          newAnnotations.push_back(anno);
-        continue;
+      // Check the flag to revert to the previous behavior if necessary.
+      if (!disableLocalAnnotations) {
+        if (anno.isClass("circt.tracker")) {
+          auto [it, inserted] =
+              localTrackerIds.insert(anno.getMember<DistinctAttr>("id"));
+          if (inserted)
+            newAnnotations.push_back(anno);
+          continue;
+        }
       }
 
       // Otherwise make the annotation non-local and add it to the set.
@@ -1449,6 +1453,10 @@ private:
 
   /// A module namespace cache.
   DenseMap<Operation *, hw::InnerSymbolNamespace> moduleNamespaces;
+
+  // Disable local annotations and revert to legacy behavior of making
+  // annotations non-local.
+  bool disableLocalAnnotations;
 };
 
 //===----------------------------------------------------------------------===//
@@ -1646,7 +1654,8 @@ class DedupPass : public circt::firrtl::impl::DedupBase<DedupPass> {
     auto &instanceGraph = getAnalysis<InstanceGraph>();
     auto *nlaTable = &getAnalysis<NLATable>();
     auto &symbolTable = getAnalysis<SymbolTable>();
-    Deduper deduper(instanceGraph, symbolTable, nlaTable, circuit);
+    Deduper deduper(instanceGraph, symbolTable, nlaTable, circuit,
+                    disableLocalAnnotations);
     Equivalence equiv(context, instanceGraph);
     auto anythingChanged = false;
 
@@ -1851,9 +1860,15 @@ class DedupPass : public circt::firrtl::impl::DedupBase<DedupPass> {
     if (!anythingChanged)
       markAllAnalysesPreserved();
   }
+
+public:
+  DedupPass(bool disableLocalAnnotations) {
+    this->disableLocalAnnotations = disableLocalAnnotations;
+  }
 };
 } // end anonymous namespace
 
-std::unique_ptr<mlir::Pass> circt::firrtl::createDedupPass() {
-  return std::make_unique<DedupPass>();
+std::unique_ptr<mlir::Pass>
+circt::firrtl::createDedupPass(bool disableLocalAnnotations) {
+  return std::make_unique<DedupPass>(disableLocalAnnotations);
 }

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -538,6 +538,12 @@ struct FirtoolCmdOptions {
       llvm::cl::desc("Disable deduplication of structurally identical modules"),
       llvm::cl::init(false)};
 
+  llvm::cl::opt<bool> disableLocalAnnotations{
+      "disable-local-annotations",
+      llvm::cl::desc("Disable local annotations and revert to legacy behavior "
+                     "of making annotations non-local in internal passes"),
+      llvm::cl::init(false)};
+
   llvm::cl::opt<firrtl::CompanionMode> companionMode{
       "grand-central-companion-mode",
       llvm::cl::desc("Specifies the handling of Grand Central companions"),
@@ -753,7 +759,8 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       preserveMode(firrtl::PreserveValues::None), enableDebugInfo(false),
       buildMode(BuildModeRelease), disableOptimization(false),
       exportChiselInterface(false), chiselInterfaceOutDirectory(""),
-      vbToBV(false), noDedup(false), companionMode(firrtl::CompanionMode::Bind),
+      vbToBV(false), noDedup(false), disableLocalAnnotations(false),
+      companionMode(firrtl::CompanionMode::Bind),
       disableAggressiveMergeConnections(false), emitOMIR(true), omirOutFile(""),
       advancedLayerSink(false), lowerMemories(false), blackBoxRootPath(""),
       replSeqMem(false), replSeqMemFile(""), extractTestCode(false),
@@ -786,6 +793,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   chiselInterfaceOutDirectory = clOptions->chiselInterfaceOutDirectory;
   vbToBV = clOptions->vbToBV;
   noDedup = clOptions->noDedup;
+  disableLocalAnnotations = clOptions->disableLocalAnnotations;
   companionMode = clOptions->companionMode;
   disableAggressiveMergeConnections =
       clOptions->disableAggressiveMergeConnections;

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -773,3 +773,27 @@ firrtl.circuit "NoDedupPublic" {
   firrtl.module @DUTLike() {}
   firrtl.module @NotDUT() {}
 }
+
+// CHECK-LABEL: "AllowLocalTrackers"
+// If the user requested local trackers, don't make them non-local.
+firrtl.circuit "AllowLocalTrackers" {
+  firrtl.module @AllowLocalTrackers() {
+    firrtl.instance foo0 @Foo0()
+    firrtl.instance foo1 @Foo1()
+  }
+
+  // CHECK-NOT: hw.hierpath
+
+  // CHECK: firrtl.module private @Foo0
+  // CHECK: firrtl.mem
+  // CHECK-SAME: {class = "circt.tracker", id = distinct[0]<>}
+  // CHECK-SAME: {class = "circt.tracker", id = distinct[1]<>}
+  firrtl.module private @Foo0() {
+      %mem_RW0 = firrtl.mem Undefined {annotations = [{class = "circt.tracker", id = distinct[0]<>}], depth = 24 : i64, name = "mem", portNames = ["RW0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, rdata flip: uint<72>, wmode: uint<1>, wdata: uint<72>, wmask: uint<1>>
+  }
+
+  // CHECK-NOT: @Foo1
+  firrtl.module private @Foo1() {
+      %mem_RW0 = firrtl.mem Undefined {annotations = [{class = "circt.tracker", id = distinct[1]<>}], depth = 24 : i64, name = "mem", portNames = ["RW0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, rdata flip: uint<72>, wmode: uint<1>, wdata: uint<72>, wmask: uint<1>>
+  }
+}

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -780,6 +780,7 @@ firrtl.circuit "AllowLocalTrackers" {
   firrtl.module @AllowLocalTrackers() {
     firrtl.instance foo0 @Foo0()
     firrtl.instance foo1 @Foo1()
+    firrtl.instance foo2 @Foo2()
   }
 
   // CHECK-NOT: hw.hierpath
@@ -788,12 +789,18 @@ firrtl.circuit "AllowLocalTrackers" {
   // CHECK: firrtl.mem
   // CHECK-SAME: {class = "circt.tracker", id = distinct[0]<>}
   // CHECK-SAME: {class = "circt.tracker", id = distinct[1]<>}
+  // CHECK-NOT: {class = "circt.tracker", id = distinct[1]<>}
   firrtl.module private @Foo0() {
       %mem_RW0 = firrtl.mem Undefined {annotations = [{class = "circt.tracker", id = distinct[0]<>}], depth = 24 : i64, name = "mem", portNames = ["RW0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, rdata flip: uint<72>, wmode: uint<1>, wdata: uint<72>, wmask: uint<1>>
   }
 
   // CHECK-NOT: @Foo1
   firrtl.module private @Foo1() {
+      %mem_RW0 = firrtl.mem Undefined {annotations = [{class = "circt.tracker", id = distinct[1]<>}], depth = 24 : i64, name = "mem", portNames = ["RW0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, rdata flip: uint<72>, wmode: uint<1>, wdata: uint<72>, wmask: uint<1>>
+  }
+
+  // CHECK-NOT: @Foo2
+  firrtl.module private @Foo2() {
       %mem_RW0 = firrtl.mem Undefined {annotations = [{class = "circt.tracker", id = distinct[1]<>}], depth = 24 : i64, name = "mem", portNames = ["RW0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, rdata flip: uint<72>, wmode: uint<1>, wdata: uint<72>, wmask: uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -1,4 +1,5 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-dedup))' %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-dedup{disable-local-annotations=true}))' %s | FileCheck --check-prefix=DISABLE-LOCAL %s
 
 // CHECK-LABEL: firrtl.circuit "Empty"
 firrtl.circuit "Empty" {
@@ -784,6 +785,8 @@ firrtl.circuit "AllowLocalTrackers" {
   }
 
   // CHECK-NOT: hw.hierpath
+
+  // DISABLE-LOCAL-COUNT-3: hw.hierpath
 
   // CHECK: firrtl.module private @Foo0
   // CHECK: firrtl.mem


### PR DESCRIPTION
The previous behavior for local trackers would be to clone the tracker into duplicate copies for each unique instance. This will fail in LowerClasses, because one path op that used to refer to a single entity as a local reference would now refer to every hierarchical instance of that entity. One path can't refer to multiple things, so if the user specified a local reference, allow that to pass through without expanding it into every hierarchical instance.