### PR TITLE
[HW][Seq] Allow typed attr to be an element of aggregate_constant and make seq.const_clock typed attr

### DIFF
--- a/include/circt/Dialect/Seq/SeqAttributes.td
+++ b/include/circt/Dialect/Seq/SeqAttributes.td
@@ -22,7 +22,13 @@ def ClockConstAttrImpl: I32EnumAttr<"ClockConst", "clock constant",
                                 [ClockLow, ClockHigh]> {
   let genSpecializedAttr = 0;
 }
-def ClockConstAttr : EnumAttr<SeqDialect, ClockConstAttrImpl, "clock_constant">;
+
+def ClockConstAttr : EnumAttr<SeqDialect, ClockConstAttrImpl,
+                       "clock_constant",  [TypedAttrInterface]> {
+ let extraClassDeclaration = [{
+    mlir::Type getType();
+ }];
+}
 
 // Read-under-write behavior
 def RUW_Undefined : I32EnumAttrCase<"Undefined", 0, "undefined">;

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -460,8 +460,12 @@ static LogicalResult checkAttributes(Operation *op, Attribute attr, Type type) {
     if (intAttr.getValue().getBitWidth() != intType.getWidth())
       return op->emitOpError("hw.constant attribute bitwidth "
                              "doesn't match return type");
+  } else if (auto typedAttr = dyn_cast<TypedAttr>(attr)) {
+    if (typedAttr.getType() != type)
+      return op->emitOpError("typed attr doesn't match the return type ")
+             << type;
   } else {
-    return op->emitOpError("unknown element type") << type;
+    return op->emitOpError("unknown element type ") << type;
   }
   return success();
 }

--- a/lib/Dialect/Seq/SeqAttributes.cpp
+++ b/lib/Dialect/Seq/SeqAttributes.cpp
@@ -8,6 +8,7 @@
 
 #include "circt/Dialect/Seq/SeqAttributes.h"
 #include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Seq/SeqTypes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -18,6 +19,8 @@ using namespace seq;
 #include "circt/Dialect/Seq/SeqEnums.cpp.inc"
 #define GET_ATTRDEF_CLASSES
 #include "circt/Dialect/Seq/SeqAttributes.cpp.inc"
+
+Type ClockConstAttr::getType() { return seq::ClockType::get(getContext()); }
 
 void SeqDialect::registerAttributes() {
   addAttributes<

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -514,3 +514,17 @@ hw.module @elementTypeError() {
   // expected-error @below {{expected ':'}}
   "builtin.unrealized_conversion_cast"() : () -> !hw.inout<struct<foo>>
 }
+
+// -----
+
+hw.module @elementTypeError() {
+  // expected-error @below {{'hw.aggregate_constant' op unknown element type '!seq.clock'}}
+  %0 = hw.aggregate_constant [#hw.output_file<"dummy.sv">] : !hw.array<1x!seq.clock>
+}
+
+// -----
+
+hw.module @elementTypeError() {
+  // expected-error @below {{'hw.aggregate_constant' op typed attr doesn't match the return type '!seq.clock'}}
+  %0 = hw.aggregate_constant [32: i16] : !hw.array<1x!seq.clock>
+}

--- a/test/Dialect/HW/round-trip.mlir
+++ b/test/Dialect/HW/round-trip.mlir
@@ -19,3 +19,9 @@ hw.module public @top(in %a: i32) {
   hw.instance_choice "inst2" option "baz" @TargetDefault(a: %a: i32) -> (b: i32)
 }
 
+// CHECK-LABEL: @aggregate_const
+hw.module @aggregate_const(out o : !hw.array<1x!seq.clock>) {
+  // CHECK-NEXT: hw.aggregate_constant [#seq<clock_constant high> : !seq.clock] : !hw.array<1x!seq.clock>
+  %0 = hw.aggregate_constant [#seq<clock_constant high> : !seq.clock] : !hw.array<1x!seq.clock>
+  hw.output %0 : !hw.array<1x!seq.clock>
+}

--- a/test/Dialect/Seq/clock-type.mlir
+++ b/test/Dialect/Seq/clock-type.mlir
@@ -101,3 +101,11 @@ hw.module @ClockCastUse() {
   hw.instance "" @ClockSink(clock : %clk : !seq.clock) -> ()
   %clk = hw.instance "clk" @ClockSource() -> (clock : !seq.clock)
 }
+
+// CHECK-LABEL: @aggregate_const
+hw.module @aggregate_const(out o : !hw.array<1x!seq.clock>) {
+  // CHECK-NEXT: %[[CLOCK:.+]] = hw.aggregate_constant [true] : !hw.array<1xi1>
+  // CHECK-NEXT: hw.output %[[CLOCK]] : !hw.array<1xi1>
+  %0 = hw.aggregate_constant [#seq<clock_constant high> : !seq.clock] : !hw.array<1x!seq.clock>
+  hw.output %0 : !hw.array<1x!seq.clock>
+}


### PR DESCRIPTION
This fixes https://github.com/llvm/circt/issues/7716. Aggregate constant verifier rejects unknown attributes hence hw.aggregate_constant cannot be used for attributes defined by other dialects (in this case seq.const_clock) was rejected even when hw.aggregate_create allows users to create clock type arrays. This PR loosen the restriction by allowing TypedAttribute. 

This PR also adds TypedAttrInterface to seq.const_clock and support its lowering. 