### PR TITLE
[HWToSMT] Proper error message for 0-bit constants

### DIFF
--- a/lib/Conversion/HWToSMT/HWToSMT.cpp
+++ b/lib/Conversion/HWToSMT/HWToSMT.cpp
@@ -35,6 +35,9 @@ struct HWConstantOpConversion : OpConversionPattern<ConstantOp> {
   LogicalResult
   matchAndRewrite(ConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    if (adaptor.getValue().getBitWidth() < 1)
+      return rewriter.notifyMatchFailure(op.getLoc(),
+                                         "0-bit constants not supported");
     rewriter.replaceOpWithNewOp<smt::BVConstantOp>(op, adaptor.getValue());
     return success();
   }

--- a/test/Conversion/HWToSMT/hw-to-smt-errors.mlir
+++ b/test/Conversion/HWToSMT/hw-to-smt-errors.mlir
@@ -1,0 +1,7 @@
+// RUN: circt-opt --convert-hw-to-smt --split-input-file --verify-diagnostics %s
+
+hw.module @zeroBitConstant() {
+  // expected-error @below {{failed to legalize operation 'hw.constant' that was explicitly marked illegal}}
+  %c0_i0 = hw.constant 0 : i0
+  hw.output
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/circt/issues/7725