### PR TITLE
[circt-bmc] Add initial_values attribute to BMC op

### DIFF
--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -203,7 +203,7 @@ def BoundedModelCheckingOp : VerifOp<"bmc", [
     match the types yielded by the `init` region).
   }];
 
-  let arguments = (ins I32Attr:$bound, I32Attr:$num_regs);
+  let arguments = (ins I32Attr:$bound, I32Attr:$num_regs, ArrayAttr:$initial_values);
   let regions = (region SizedRegion<1>:$init,
                         SizedRegion<1>:$loop,
                         SizedRegion<1>:$circuit);
@@ -211,7 +211,7 @@ def BoundedModelCheckingOp : VerifOp<"bmc", [
   let results = (outs I1:$result);
 
   let assemblyFormat = [{
-    `bound` $bound `num_regs` $num_regs attr-dict-with-keyword `init` $init `loop` $loop `circuit`
+    `bound` $bound `num_regs` $num_regs `initial_values` $initial_values attr-dict-with-keyword `init` $init `loop` $loop `circuit`
     $circuit
   }];
 

--- a/lib/Dialect/Verif/VerifOps.cpp
+++ b/lib/Dialect/Verif/VerifOps.cpp
@@ -178,6 +178,16 @@ LogicalResult BoundedModelCheckingOp::verifyRegions() {
                 "there are clock arguments in the circuit region "
                 "before any other values";
   }
+  auto initialValues = getInitialValues();
+  if (initialValues.size() != getNumRegs()) {
+    return emitOpError()
+           << "number of initial values must match the number of registers";
+  }
+  for (auto attr : initialValues) {
+    if (!isa<IntegerAttr, UnitAttr>(attr))
+      return emitOpError()
+             << "initial values must be integer or unit attributes";
+  }
   return success();
 }
 

--- a/lib/Tools/circt-bmc/LowerToBMC.cpp
+++ b/lib/Tools/circt-bmc/LowerToBMC.cpp
@@ -87,13 +87,16 @@ void LowerToBMCPass::runOnOperation() {
   // Double the bound given to the BMC op, as a clock cycle takes 2 BMC
   // iterations
   verif::BoundedModelCheckingOp bmcOp;
-  if (auto numRegs = hwModule->getAttrOfType<IntegerAttr>("num_regs"))
+  auto numRegs = hwModule->getAttrOfType<IntegerAttr>("num_regs");
+  auto initialValues = hwModule->getAttrOfType<ArrayAttr>("initial_values");
+  if (numRegs && initialValues)
     bmcOp = builder.create<verif::BoundedModelCheckingOp>(
-        loc, 2 * bound, cast<IntegerAttr>(numRegs).getValue().getZExtValue());
+        loc, 2 * bound, cast<IntegerAttr>(numRegs).getValue().getZExtValue(),
+        initialValues);
   else {
-    hwModule->emitOpError(
-        "no num_regs attribute found - please run externalize "
-        "registers pass first");
+    hwModule->emitOpError("no num_regs or initial_values attribute found - "
+                          "please run externalize "
+                          "registers pass first");
     return signalPassFailure();
   }
 

--- a/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
@@ -20,7 +20,7 @@ func.func @assert_with_unsupported_property_type(%arg0: !smt.bv<1>) {
 
 func.func @multiple_assertions_bmc() -> (i1) {
   // expected-error @below {{bounded model checking problems with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
-  %bmc = verif.bmc bound 10 num_regs 1
+  %bmc = verif.bmc bound 10 num_regs 1 initial_values [unit]
   init {}
   loop {}
   circuit {
@@ -40,7 +40,7 @@ func.func @multiple_assertions_bmc() -> (i1) {
 
 func.func @multiple_asserting_modules_bmc() -> (i1) {
   // expected-error @below {{bounded model checking problems with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
-  %bmc = verif.bmc bound 10 num_regs 1
+  %bmc = verif.bmc bound 10 num_regs 1 initial_values [unit]
   init {}
   loop {}
   circuit {
@@ -61,7 +61,7 @@ hw.module @OneAssertion(in %x: i1) {
 
 func.func @two_separated_assertions() -> (i1) {
   // expected-error @below {{bounded model checking problems with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
-  %bmc = verif.bmc bound 10 num_regs 1
+  %bmc = verif.bmc bound 10 num_regs 1 initial_values [unit]
   init {}
   loop {}
   circuit {
@@ -82,7 +82,7 @@ hw.module @OneAssertion(in %x: i1) {
 
 func.func @multiple_nested_assertions() -> (i1) {
   // expected-error @below {{bounded model checking problems with multiple assertions are not yet correctly handled - instead, you can assert the conjunction of your assertions}}
-  %bmc = verif.bmc bound 10 num_regs 1
+  %bmc = verif.bmc bound 10 num_regs 1 initial_values [unit]
   init {}
   loop {}
   circuit {

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -147,7 +147,7 @@ func.func @test_lec(%arg0: !smt.bv<1>) -> (i1, i1, i1) {
 // CHECK:  }
 
 func.func @test_bmc() -> (i1) {
-  %bmc = verif.bmc bound 10 num_regs 1
+  %bmc = verif.bmc bound 10 num_regs 1 initial_values [unit]
   init {
     %c0_i1 = hw.constant 0 : i1
     %clk = seq.to_clock %c0_i1

--- a/test/Dialect/Verif/basic.mlir
+++ b/test/Dialect/Verif/basic.mlir
@@ -156,13 +156,13 @@ verif.lec {verif.some_attr} first {
 // Bounded Model Checking related operations
 //===----------------------------------------------------------------------===//
 
-// CHECK: verif.bmc bound 10 num_regs 0 attributes {verif.some_attr} init {
+// CHECK: verif.bmc bound 10 num_regs 0 initial_values [] attributes {verif.some_attr} init {
 // CHECK: } loop {
 // CHECK: } circuit {
 // CHECK: ^bb0(%{{.*}}):
 // CHECK: verif.yield %{{.*}} : i32
 // CHECK: }
-verif.bmc bound 10 num_regs 0 attributes {verif.some_attr} init {
+verif.bmc bound 10 num_regs 0 initial_values [] attributes {verif.some_attr} init {
 } loop {
 } circuit {
 ^bb0(%arg0: i32):
@@ -172,7 +172,7 @@ verif.bmc bound 10 num_regs 0 attributes {verif.some_attr} init {
   verif.yield %arg0 : i32
 }
 
-//CHECK: verif.bmc bound 10 num_regs 1 attributes {verif.some_attr}
+//CHECK: verif.bmc bound 10 num_regs 1 initial_values [unit] attributes {verif.some_attr}
 //CHECK: init {
 //CHECK:   %{{.*}} = hw.constant false
 //CHECK:   %{{.*}} = seq.to_clock %{{.*}}
@@ -194,7 +194,7 @@ verif.bmc bound 10 num_regs 0 attributes {verif.some_attr} init {
 //CHECK:   %{{.*}} = comb.xor %{{.*}}, %{{.*}} : i32
 //CHECK:   verif.yield %{{.*}}, %{{.*}} : i32, i32
 //CHECK: }
-verif.bmc bound 10 num_regs 1 attributes {verif.some_attr}
+verif.bmc bound 10 num_regs 1 initial_values [unit] attributes {verif.some_attr}
 init {
   %c0_i1 = hw.constant 0 : i1
   %clk = seq.to_clock %c0_i1

--- a/test/Dialect/Verif/errors.mlir
+++ b/test/Dialect/Verif/errors.mlir
@@ -23,7 +23,7 @@ verif.lec first {
 // -----
 
 // expected-error @below {{init region must have no arguments}}
-verif.bmc bound 10 num_regs 0 init {
+verif.bmc bound 10 num_regs 0 initial_values [] init {
 ^bb0(%clk: !seq.clock):
 } loop {
 ^bb0(%clk: !seq.clock):
@@ -37,7 +37,7 @@ verif.bmc bound 10 num_regs 0 init {
 // -----
 
 // expected-error @below {{init and loop regions must yield the same types of values}}
-verif.bmc bound 10 num_regs 0 init {
+verif.bmc bound 10 num_regs 0 initial_values [] init {
   %clkInit = hw.constant false
   %toClk = seq.to_clock %clkInit
   verif.yield %toClk, %toClk : !seq.clock, !seq.clock
@@ -54,7 +54,7 @@ verif.bmc bound 10 num_regs 0 init {
 // -----
 
 // expected-error @below {{init and loop regions must yield the same types of values}}
-verif.bmc bound 10 num_regs 0 init {
+verif.bmc bound 10 num_regs 0 initial_values [] init {
   %clkInit = hw.constant false
   %toClk = seq.to_clock %clkInit
   %c1_i2 = hw.constant 2 : i2
@@ -72,7 +72,7 @@ verif.bmc bound 10 num_regs 0 init {
 // -----
 
 // expected-error @below {{loop region arguments must match the types of the values yielded by the init and loop regions}}
-verif.bmc bound 10 num_regs 0 init {
+verif.bmc bound 10 num_regs 0 initial_values [] init {
   %clkInit = hw.constant false
   %toClk = seq.to_clock %clkInit
   %c1_i2 = hw.constant 2 : i2
@@ -90,7 +90,7 @@ verif.bmc bound 10 num_regs 0 init {
 // -----
 
 // expected-error @below {{init and loop regions must yield at least as many clock values as there are clock arguments to the circuit region}}
-verif.bmc bound 10 num_regs 0 init {
+verif.bmc bound 10 num_regs 0 initial_values [] init {
   %clkInit = hw.constant false
   %toClk = seq.to_clock %clkInit
   verif.yield %toClk: !seq.clock
@@ -107,7 +107,7 @@ verif.bmc bound 10 num_regs 0 init {
 // -----
 
 // expected-error @below {{init and loop regions must yield as many clock values as there are clock arguments in the circuit region before any other values}}
-verif.bmc bound 10 num_regs 0 init {
+verif.bmc bound 10 num_regs 0 initial_values [] init {
   %clkInit = hw.constant false
   %toClk = seq.to_clock %clkInit
   verif.yield %toClk, %clkInit, %toClk: !seq.clock, i1, !seq.clock
@@ -118,5 +118,44 @@ verif.bmc bound 10 num_regs 0 init {
 ^bb0(%clk1: !seq.clock, %clk2: !seq.clock, %arg0: i32):
   %true = hw.constant true
   verif.assert %true : i1
+  verif.yield %arg0 : i32
+}
+
+// -----
+
+// expected-error @below {{number of initial values must match the number of registers}}
+verif.bmc bound 10 num_regs 0 initial_values [unit] attributes {verif.some_attr} init {
+} loop {
+} circuit {
+^bb0(%arg0: i32):
+  %false = hw.constant false
+  // Arbitrary assertion so op verifies
+  verif.assert %false : i1
+  verif.yield %arg0 : i32
+}
+
+// -----
+
+// expected-error @below {{number of initial values must match the number of registers}}
+verif.bmc bound 10 num_regs 1 initial_values [] attributes {verif.some_attr} init {
+} loop {
+} circuit {
+^bb0(%arg0: i32):
+  %false = hw.constant false
+  // Arbitrary assertion so op verifies
+  verif.assert %false : i1
+  verif.yield %arg0 : i32
+}
+
+// -----
+
+// expected-error @below {{initial values must be integer or unit attributes}}
+verif.bmc bound 10 num_regs 1 initial_values ["foo"] attributes {verif.some_attr} init {
+} loop {
+} circuit {
+^bb0(%arg0: i32):
+  %false = hw.constant false
+  // Arbitrary assertion so op verifies
+  verif.assert %false : i1
   verif.yield %arg0 : i32
 }

--- a/test/Tools/circt-bmc/lower-to-bmc-errors.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc-errors.mlir
@@ -15,14 +15,14 @@ module {
 // -----
 
 // expected-error @below {{no property provided to check in module}}
-hw.module @testModule(in %in0 : i32, in %in1 : i32, out out : i32) attributes {num_regs = 0 : i32} {
+hw.module @testModule(in %in0 : i32, in %in1 : i32, out out : i32) attributes {num_regs = 0 : i32, initial_values = []} {
   %0 = comb.add %in0, %in1 : i32
   hw.output %0 : i32
 }
 
 // -----
 
-// expected-error @below {{no num_regs attribute found - please run externalize registers pass first}}
+// expected-error @below {{no num_regs or initial_values attribute found - please run externalize registers pass first}}
 hw.module @testModule(in %in0 : i32, in %in1 : i32, out out : i32) {
   %0 = comb.add %in0, %in1 : i32
   %1 = comb.icmp eq %in0, %in1 : i32
@@ -32,8 +32,28 @@ hw.module @testModule(in %in0 : i32, in %in1 : i32, out out : i32) {
 
 // -----
 
+// expected-error @below {{no num_regs or initial_values attribute found - please run externalize registers pass first}}
+hw.module @testModule(in %in0 : i32, in %in1 : i32, out out : i32) attributes {num_regs = 0 : i32} {
+  %0 = comb.add %in0, %in1 : i32
+  %1 = comb.icmp eq %in0, %in1 : i32
+  verif.assert %1 : i1
+  hw.output %0 : i32
+}
+
+// -----
+
+// expected-error @below {{no num_regs or initial_values attribute found - please run externalize registers pass first}}
+hw.module @testModule(in %in0 : i32, in %in1 : i32, out out : i32) attributes {initial_values = []} {
+  %0 = comb.add %in0, %in1 : i32
+  %1 = comb.icmp eq %in0, %in1 : i32
+  verif.assert %1 : i1
+  hw.output %0 : i32
+}
+
+// -----
+
 // expected-error @below {{designs with multiple clocks not yet supported}}
-hw.module @testModule(in %clk0 : !seq.clock, in %clk1 : !seq.clock, in %in0 : i32, in %in1 : i32, in %reg0_state : i32, in %reg1_state : i32, out out : i32, out reg0_input : i32, out reg1_input : i32) attributes {num_regs = 2 : i32} {
+hw.module @testModule(in %clk0 : !seq.clock, in %clk1 : !seq.clock, in %in0 : i32, in %in1 : i32, in %reg0_state : i32, in %reg1_state : i32, out out : i32, out reg0_input : i32, out reg1_input : i32) attributes {num_regs = 2 : i32, initial_values = [unit, unit]} {
   %0 = comb.add %reg0_state, %reg1_state : i32
   %1 = comb.icmp eq %0, %in0 : i32
   verif.assert %1 : i1
@@ -43,7 +63,7 @@ hw.module @testModule(in %clk0 : !seq.clock, in %clk1 : !seq.clock, in %in0 : i3
 // -----
 
 // expected-error @below {{designs with multiple clocks not yet supported}}
-hw.module @testModule(in %clk0 : !seq.clock, in %clkStruct : !hw.struct<clk: !seq.clock>, in %in0 : i32, in %in1 : i32, in %reg0_state : i32, in %reg1_state : i32, out out : i32, out reg0_input : i32, out reg1_input : i32) attributes {num_regs = 2 : i32} {
+hw.module @testModule(in %clk0 : !seq.clock, in %clkStruct : !hw.struct<clk: !seq.clock>, in %in0 : i32, in %in1 : i32, in %reg0_state : i32, in %reg1_state : i32, out out : i32, out reg0_input : i32, out reg1_input : i32) attributes {num_regs = 2 : i32, initial_values = [unit, unit]} {
   %0 = comb.add %reg0_state, %reg1_state : i32
   %1 = comb.icmp eq %0, %in0 : i32
   verif.assert %1 : i1

--- a/test/Tools/circt-bmc/lower-to-bmc.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc.mlir
@@ -2,7 +2,7 @@
 
 // CHECK:  llvm.func @printf(!llvm.ptr, ...)
 // CHECK:  func.func @comb() {
-// CHECK:    [[BMC:%.+]] = verif.bmc bound 20 num_regs 0 init {
+// CHECK:    [[BMC:%.+]] = verif.bmc bound 20 num_regs 0 initial_values [] init {
 // CHECK:    } loop {
 // CHECK:    } circuit {
 // CHECK:    ^bb0([[ARG0:%.+]]: i32, [[ARG1:%.+]]: i32):
@@ -20,7 +20,7 @@
 // CHECK:  llvm.mlir.global private constant [[SSTR]]("Bound reached with no violations!\0A\00") {addr_space = 0 : i32}
 // CHECK:  llvm.mlir.global private constant [[FSTR]]("Assertion can be violated!\0A\00") {addr_space = 0 : i32}
 
-hw.module @comb(in %in0: i32, in %in1: i32, out out: i32) attributes {num_regs = 0 : i32} {
+hw.module @comb(in %in0: i32, in %in1: i32, out out: i32) attributes {num_regs = 0 : i32, initial_values = []} {
   %0 = comb.add %in0, %in1 : i32
   %prop = comb.icmp eq %0, %in0 : i32
   verif.assert %prop : i1
@@ -31,7 +31,7 @@ hw.module @comb(in %in0: i32, in %in1: i32, out out: i32) attributes {num_regs =
 
 // CHECK1:  llvm.func @printf(!llvm.ptr, ...)
 // CHECK1:  func.func @seq() {
-// CHECK1:    [[BMC:%.+]] = verif.bmc bound 20 num_regs 1 init {
+// CHECK1:    [[BMC:%.+]] = verif.bmc bound 20 num_regs 1 initial_values [unit] init {
 // CHECK1:      [[FALSE:%.+]] = hw.constant false
 // CHECK1:      [[INIT_CLK:%.+]] = seq.to_clock [[FALSE]]
 // CHECK1:      verif.yield [[INIT_CLK]]
@@ -57,7 +57,7 @@ hw.module @comb(in %in0: i32, in %in1: i32, out out: i32) attributes {num_regs =
 // CHECK1:  }
 // CHECK1:  llvm.mlir.global private constant [[SSTR]]("Bound reached with no violations!\0A\00") {addr_space = 0 : i32}
 // CHECK1:  llvm.mlir.global private constant [[FSTR]]("Assertion can be violated!\0A\00") {addr_space = 0 : i32}
-hw.module @seq(in %clk : !seq.clock, in %in0 : i32, in %in1 : i32, in %reg_state : i32, out out : i32, out reg_input : i32) attributes {num_regs = 1 : i32} {
+hw.module @seq(in %clk : !seq.clock, in %in0 : i32, in %in1 : i32, in %reg_state : i32, out out : i32, out reg_input : i32) attributes {num_regs = 1 : i32, initial_values = [unit]} {
   %0 = comb.add %in0, %in1 : i32
   %1 = comb.icmp eq %0, %in0 : i32
   verif.assert %1 : i1


### PR DESCRIPTION
Adds an initial_values attribute to the verif.bmc op and carries the attribute through from the externalize registers version introduced in #7728. Eventually it would be nice to let the init region handle this (along with letting it control input values and letting the loop region set them), but I think this does the trick for now