### PR TITLE
Reject '<=' and 'is invalid' if FIRRTL version >=3

### DIFF
--- a/integration_test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
+++ b/integration_test/Dialect/FIRRTL/SFCTests/GrandCentralInterfaces/Wire.fir
@@ -11,30 +11,30 @@ circuit Top :
     output out : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
 
     wire w : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
-    w.otherOther.other.sint <= in.otherOther.other.sint
-    w.otherOther.other.uint <= in.otherOther.other.uint
-    w.vecOfBundle[0].sint <= in.vecOfBundle[0].sint
-    w.vecOfBundle[0].uint <= in.vecOfBundle[0].uint
-    w.vecOfBundle[1].sint <= in.vecOfBundle[1].sint
-    w.vecOfBundle[1].uint <= in.vecOfBundle[1].uint
-    w.vec[0] <= in.vec[0]
-    w.vec[1] <= in.vec[1]
-    w.uint <= in.uint
-    out.otherOther.other.sint <= w.otherOther.other.sint
-    out.otherOther.other.uint <= w.otherOther.other.uint
-    out.vecOfBundle[0].sint <= w.vecOfBundle[0].sint
-    out.vecOfBundle[0].uint <= w.vecOfBundle[0].uint
-    out.vecOfBundle[1].sint <= w.vecOfBundle[1].sint
-    out.vecOfBundle[1].uint <= w.vecOfBundle[1].uint
-    out.vec[0] <= w.vec[0]
-    out.vec[1] <= w.vec[1]
-    out.uint <= w.uint
+    connect w.otherOther.other.sint, in.otherOther.other.sint
+    connect w.otherOther.other.uint, in.otherOther.other.uint
+    connect w.vecOfBundle[0].sint, in.vecOfBundle[0].sint
+    connect w.vecOfBundle[0].uint, in.vecOfBundle[0].uint
+    connect w.vecOfBundle[1].sint, in.vecOfBundle[1].sint
+    connect w.vecOfBundle[1].uint, in.vecOfBundle[1].uint
+    connect w.vec[0], in.vec[0]
+    connect w.vec[1], in.vec[1]
+    connect w.uint, in.uint
+    connect out.otherOther.other.sint, w.otherOther.other.sint
+    connect out.otherOther.other.uint, w.otherOther.other.uint
+    connect out.vecOfBundle[0].sint, w.vecOfBundle[0].sint
+    connect out.vecOfBundle[0].uint, w.vecOfBundle[0].uint
+    connect out.vecOfBundle[1].sint, w.vecOfBundle[1].sint
+    connect out.vecOfBundle[1].uint, w.vecOfBundle[1].uint
+    connect out.vec[0], w.vec[0]
+    connect out.vec[1], w.vec[1]
+    connect out.uint, w.uint
 
   module MyView_companion :
     output io : { }
 
     wire _WIRE : UInt<1>
-    _WIRE <= UInt<1>(0h0)
+    connect _WIRE, UInt<1>(0h0)
 
   module DUT :
     input clock : Clock
@@ -44,35 +44,35 @@ circuit Top :
 
     wire w : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
     inst submodule of Submodule
-    submodule.clock <= clock
-    submodule.reset <= reset
-    w.otherOther.other.sint <= in.otherOther.other.sint
-    w.otherOther.other.uint <= in.otherOther.other.uint
-    w.vecOfBundle[0].sint <= in.vecOfBundle[0].sint
-    w.vecOfBundle[0].uint <= in.vecOfBundle[0].uint
-    w.vecOfBundle[1].sint <= in.vecOfBundle[1].sint
-    w.vecOfBundle[1].uint <= in.vecOfBundle[1].uint
-    w.vec[0] <= in.vec[0]
-    w.vec[1] <= in.vec[1]
-    w.uint <= in.uint
-    submodule.in.otherOther.other.sint <= w.otherOther.other.sint
-    submodule.in.otherOther.other.uint <= w.otherOther.other.uint
-    submodule.in.vecOfBundle[0].sint <= w.vecOfBundle[0].sint
-    submodule.in.vecOfBundle[0].uint <= w.vecOfBundle[0].uint
-    submodule.in.vecOfBundle[1].sint <= w.vecOfBundle[1].sint
-    submodule.in.vecOfBundle[1].uint <= w.vecOfBundle[1].uint
-    submodule.in.vec[0] <= w.vec[0]
-    submodule.in.vec[1] <= w.vec[1]
-    submodule.in.uint <= w.uint
-    out.otherOther.other.sint <= submodule.out.otherOther.other.sint
-    out.otherOther.other.uint <= submodule.out.otherOther.other.uint
-    out.vecOfBundle[0].sint <= submodule.out.vecOfBundle[0].sint
-    out.vecOfBundle[0].uint <= submodule.out.vecOfBundle[0].uint
-    out.vecOfBundle[1].sint <= submodule.out.vecOfBundle[1].sint
-    out.vecOfBundle[1].uint <= submodule.out.vecOfBundle[1].uint
-    out.vec[0] <= submodule.out.vec[0]
-    out.vec[1] <= submodule.out.vec[1]
-    out.uint <= submodule.out.uint
+    connect submodule.clock, clock
+    connect submodule.reset, reset
+    connect w.otherOther.other.sint, in.otherOther.other.sint
+    connect w.otherOther.other.uint, in.otherOther.other.uint
+    connect w.vecOfBundle[0].sint, in.vecOfBundle[0].sint
+    connect w.vecOfBundle[0].uint, in.vecOfBundle[0].uint
+    connect w.vecOfBundle[1].sint, in.vecOfBundle[1].sint
+    connect w.vecOfBundle[1].uint, in.vecOfBundle[1].uint
+    connect w.vec[0], in.vec[0]
+    connect w.vec[1], in.vec[1]
+    connect w.uint, in.uint
+    connect submodule.in.otherOther.other.sint, w.otherOther.other.sint
+    connect submodule.in.otherOther.other.uint, w.otherOther.other.uint
+    connect submodule.in.vecOfBundle[0].sint, w.vecOfBundle[0].sint
+    connect submodule.in.vecOfBundle[0].uint, w.vecOfBundle[0].uint
+    connect submodule.in.vecOfBundle[1].sint, w.vecOfBundle[1].sint
+    connect submodule.in.vecOfBundle[1].uint, w.vecOfBundle[1].uint
+    connect submodule.in.vec[0], w.vec[0]
+    connect submodule.in.vec[1], w.vec[1]
+    connect submodule.in.uint, w.uint
+    connect out.otherOther.other.sint, submodule.out.otherOther.other.sint
+    connect out.otherOther.other.uint, submodule.out.otherOther.other.uint
+    connect out.vecOfBundle[0].sint, submodule.out.vecOfBundle[0].sint
+    connect out.vecOfBundle[0].uint, submodule.out.vecOfBundle[0].uint
+    connect out.vecOfBundle[1].sint, submodule.out.vecOfBundle[1].sint
+    connect out.vecOfBundle[1].uint, submodule.out.vecOfBundle[1].uint
+    connect out.vec[0], submodule.out.vec[0]
+    connect out.vec[1], submodule.out.vec[1]
+    connect out.uint, submodule.out.uint
     inst MyView_companion of MyView_companion
 
   public module Top :
@@ -82,23 +82,23 @@ circuit Top :
     output out : { uint : UInt<1>, vec : UInt<1>[2], vecOfBundle : { uint : UInt<4>, sint : SInt<2>}[2], otherOther : { other : { uint : UInt<4>, sint : SInt<2>}}}
 
     inst dut of DUT
-    dut.clock <= clock
-    dut.reset <= reset
-    dut.in.otherOther.other.sint <= in.otherOther.other.sint
-    dut.in.otherOther.other.uint <= in.otherOther.other.uint
-    dut.in.vecOfBundle[0].sint <= in.vecOfBundle[0].sint
-    dut.in.vecOfBundle[0].uint <= in.vecOfBundle[0].uint
-    dut.in.vecOfBundle[1].sint <= in.vecOfBundle[1].sint
-    dut.in.vecOfBundle[1].uint <= in.vecOfBundle[1].uint
-    dut.in.vec[0] <= in.vec[0]
-    dut.in.vec[1] <= in.vec[1]
-    dut.in.uint <= in.uint
-    out.otherOther.other.sint <= dut.out.otherOther.other.sint
-    out.otherOther.other.uint <= dut.out.otherOther.other.uint
-    out.vecOfBundle[0].sint <= dut.out.vecOfBundle[0].sint
-    out.vecOfBundle[0].uint <= dut.out.vecOfBundle[0].uint
-    out.vecOfBundle[1].sint <= dut.out.vecOfBundle[1].sint
-    out.vecOfBundle[1].uint <= dut.out.vecOfBundle[1].uint
-    out.vec[0] <= dut.out.vec[0]
-    out.vec[1] <= dut.out.vec[1]
-    out.uint <= dut.out.uint
+    connect dut.clock, clock
+    connect dut.reset, reset
+    connect dut.in.otherOther.other.sint, in.otherOther.other.sint
+    connect dut.in.otherOther.other.uint, in.otherOther.other.uint
+    connect dut.in.vecOfBundle[0].sint, in.vecOfBundle[0].sint
+    connect dut.in.vecOfBundle[0].uint, in.vecOfBundle[0].uint
+    connect dut.in.vecOfBundle[1].sint, in.vecOfBundle[1].sint
+    connect dut.in.vecOfBundle[1].uint, in.vecOfBundle[1].uint
+    connect dut.in.vec[0], in.vec[0]
+    connect dut.in.vec[1], in.vec[1]
+    connect dut.in.uint, in.uint
+    connect out.otherOther.other.sint, dut.out.otherOther.other.sint
+    connect out.otherOther.other.uint, dut.out.otherOther.other.uint
+    connect out.vecOfBundle[0].sint, dut.out.vecOfBundle[0].sint
+    connect out.vecOfBundle[0].uint, dut.out.vecOfBundle[0].uint
+    connect out.vecOfBundle[1].sint, dut.out.vecOfBundle[1].sint
+    connect out.vecOfBundle[1].uint, dut.out.vecOfBundle[1].uint
+    connect out.vec[0], dut.out.vec[0]
+    connect out.vec[1], dut.out.vec[1]
+    connect out.uint, dut.out.uint

--- a/integration_test/EmitVerilog/verilog_equiv.fir
+++ b/integration_test/EmitVerilog/verilog_equiv.fir
@@ -14,7 +14,7 @@ circuit test_mod :
   public module test_mod :
     input a: UInt<1>
     output b: UInt<1>
-    b <= a
+    connect b, a
 
 ;--- test_mod.v
 
@@ -56,31 +56,31 @@ circuit test_unary :
     output out_tail_s: UInt<2>
     output out_neg_s: SInt<5>
     output out_neg_u: SInt<5>
-    out_xorr_u <= xorr(uin4)
-    out_xorr_s <= xorr(sin4)
-    out_andr_u <= andr(uin4)
-    out_andr_s <= andr(sin4)
-    out_orr_u <= orr(uin4)
-    out_orr_s <= orr(sin4)
-    out_not_u <= not(uin4)
-    out_not_s <= not(sin4)
-    out_pad_u <= pad(uin4, 6)
-    out_pad_s <= pad(sin4, 6)
-    out_shl_u <= shl(uin4, 2)
-    out_shl_s <= shl(sin4, 2)
-    out_shr_u <= shr(uin4, 2)
-    out_shr_s <= shr(sin4, 2)
-    out_cvt_u <= cvt(uin4)
-    out_cvt_s <= cvt(sin4)
-    out_bits_u <= bits(uin4, 3,1)
-    out_bits_s <= bits(sin4, 3,1)
-    out_head_u <= head(uin4, 2)
-    out_head_s <= head(sin4, 2)
-    out_tail_u <= tail(uin4, 2)
-    out_tail_s <= tail(sin4, 2)
-    out_neg_s <= neg(sin4)
-    out_neg_u <= neg(uin4)
-    
+    connect out_xorr_u, xorr(uin4)
+    connect out_xorr_s, xorr(sin4)
+    connect out_andr_u, andr(uin4)
+    connect out_andr_s, andr(sin4)
+    connect out_orr_u, orr(uin4)
+    connect out_orr_s, orr(sin4)
+    connect out_not_u, not(uin4)
+    connect out_not_s, not(sin4)
+    connect out_pad_u, pad(uin4, 6)
+    connect out_pad_s, pad(sin4, 6)
+    connect out_shl_u, shl(uin4, 2)
+    connect out_shl_s, shl(sin4, 2)
+    connect out_shr_u, shr(uin4, 2)
+    connect out_shr_s, shr(sin4, 2)
+    connect out_cvt_u, cvt(uin4)
+    connect out_cvt_s, cvt(sin4)
+    connect out_bits_u, bits(uin4, 3,1)
+    connect out_bits_s, bits(sin4, 3,1)
+    connect out_head_u, head(uin4, 2)
+    connect out_head_s, head(sin4, 2)
+    connect out_tail_u, tail(uin4, 2)
+    connect out_tail_s, tail(sin4, 2)
+    connect out_neg_s, neg(sin4)
+    connect out_neg_u, neg(uin4)
+
 ;--- test_unary.v
 
 module test_unary(
@@ -133,7 +133,7 @@ module test_unary(
   assign out_head_s = sin4[3:2];
   assign out_tail_u = uin4[1:0];
   assign out_tail_s = sin4[1:0];
-  assign out_neg_s = 4'sh0 - $signed(sin4); 
+  assign out_neg_s = 4'sh0 - $signed(sin4);
   assign out_neg_u = 4'h0 - uin4;
 endmodule
 
@@ -180,41 +180,41 @@ circuit test_prim :
     output out_xor_s: UInt<4>
     output out_cat_u: UInt<8>
     output out_cat_s: UInt<8>
-    out_add_u <= add(uina4, uinb4)
-    out_add_s <= add(sina4, sinb4)
-    out_sub_u <= sub(uina4, uinb4)
-    out_sub_s <= sub(sina4, sinb4)
-    out_mul_u <= mul(uina4, uinb4)
-    out_mul_s <= mul(sina4, sinb4)
-    out_div_u <= div(uina4, uinb4)
-    out_div_s <= div(sina4, sinb4)
-    out_rem_u <= rem(uina4, uinb4)
-    out_rem_s <= rem(sina4, sinb4)
-    out_lt_u <= lt(uina4, uinb4)
-    out_lt_s <= lt(sina4, sinb4)
-    out_leq_u <= leq(uina4, uinb4)
-    out_leq_s <= leq(sina4, sinb4)
-    out_gt_u <= gt(uina4, uinb4)
-    out_gt_s <= gt(sina4, sinb4)
-    out_geq_u <= geq(uina4, uinb4)
-    out_geq_s <= geq(sina4, sinb4)
-    out_eq_u <= eq(uina4, uinb4)
-    out_eq_s <= eq(sina4, sinb4)
-    out_neq_u <= neq(uina4, uinb4)
-    out_neq_s <= neq(sina4, sinb4)
-    out_dshl_u <= dshl(uina4, uinb4)
-    out_dshl_s <= dshl(sina4, uinb4)
-    out_dshr_u <= dshr(uina4, uinb4)
-    out_dshr_s <= dshr(sina4, uinb4)
-    out_and_u <= and(uina4, uinb4)
-    out_and_s <= and(sina4, sinb4)
-    out_or_u <= or(uina4, uinb4)
-    out_or_s <= or(sina4, sinb4)
-    out_xor_u <= xor(uina4, uinb4)
-    out_xor_s <= xor(sina4, sinb4)
-    out_cat_u <= cat(uina4, uinb4)
-    out_cat_s <= cat(sina4, sinb4)
-    
+    connect out_add_u, add(uina4, uinb4)
+    connect out_add_s, add(sina4, sinb4)
+    connect out_sub_u, sub(uina4, uinb4)
+    connect out_sub_s, sub(sina4, sinb4)
+    connect out_mul_u, mul(uina4, uinb4)
+    connect out_mul_s, mul(sina4, sinb4)
+    connect out_div_u, div(uina4, uinb4)
+    connect out_div_s, div(sina4, sinb4)
+    connect out_rem_u, rem(uina4, uinb4)
+    connect out_rem_s, rem(sina4, sinb4)
+    connect out_lt_u, lt(uina4, uinb4)
+    connect out_lt_s, lt(sina4, sinb4)
+    connect out_leq_u, leq(uina4, uinb4)
+    connect out_leq_s, leq(sina4, sinb4)
+    connect out_gt_u, gt(uina4, uinb4)
+    connect out_gt_s, gt(sina4, sinb4)
+    connect out_geq_u, geq(uina4, uinb4)
+    connect out_geq_s, geq(sina4, sinb4)
+    connect out_eq_u, eq(uina4, uinb4)
+    connect out_eq_s, eq(sina4, sinb4)
+    connect out_neq_u, neq(uina4, uinb4)
+    connect out_neq_s, neq(sina4, sinb4)
+    connect out_dshl_u, dshl(uina4, uinb4)
+    connect out_dshl_s, dshl(sina4, uinb4)
+    connect out_dshr_u, dshr(uina4, uinb4)
+    connect out_dshr_s, dshr(sina4, uinb4)
+    connect out_and_u, and(uina4, uinb4)
+    connect out_and_s, and(sina4, sinb4)
+    connect out_or_u, or(uina4, uinb4)
+    connect out_or_s, or(sina4, sinb4)
+    connect out_xor_u, xor(uina4, uinb4)
+    connect out_xor_s, xor(sina4, sinb4)
+    connect out_cat_u, cat(uina4, uinb4)
+    connect out_cat_s, cat(sina4, sinb4)
+
 ;--- test_prim.v
 
 module test_prim(

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4017,6 +4017,9 @@ ParseResult FIRStmtParser::parseLeadingExpStmt(Value lhs) {
         parseOptionalInfo())
       return failure();
 
+    if (removedFeature({3, 0, 0}, "'is invalid' statements", loc))
+      return failure();
+
     locationProcessor.setLoc(loc);
     emitInvalidate(lhs);
     return success();

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4028,6 +4028,9 @@ ParseResult FIRStmtParser::parseLeadingExpStmt(Value lhs) {
   if (parseToken(FIRToken::less_equal, "expected '<=' in statement"))
     return failure();
 
+  if (removedFeature({3, 0, 0}, "'<=' connections", loc))
+    return failure();
+
   Value rhs;
   if (parseExp(rhs, "unexpected token in statement") || parseOptionalInfo())
     return failure();

--- a/test/Dialect/FIRRTL/SFCTests/async-reset-verilog.fir
+++ b/test/Dialect/FIRRTL/SFCTests/async-reset-verilog.fir
@@ -21,16 +21,16 @@ circuit Foo:
     regreset r2 : UInt<8>, clock0, asyncReset, UInt(123)
     regreset r3 : UInt<8>, clock0, asyncReset, UInt(123)
     regreset r4 : UInt<8>, clock1, asyncReset, UInt(123)
-    r0 <= x[0]
-    r1 <= x[1]
-    r2 <= x[2]
-    r3 <= x[3]
-    r4 <= x[4]
-    z[0] <= r0
-    z[1] <= r1
-    z[2] <= r2
-    z[3] <= r3
-    z[4] <= r4
+    connect r0, x[0]
+    connect r1, x[1]
+    connect r2, x[2]
+    connect r3, x[3]
+    connect r4, x[4]
+    connect z[0], r0
+    connect z[1], r1
+    connect z[2], r2
+    connect z[3], r3
+    connect z[4], r4
 
 ; CHECK:      always @(posedge clock0) begin
 ; CHECK:      if (syncReset)

--- a/test/Dialect/FIRRTL/SFCTests/directories.fir
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir
@@ -29,8 +29,10 @@ circuit TestHarness:
       write-latency => 1
       read-under-write => undefined
 
-    foo_m is invalid
-    foo_combmem is invalid
+    invalidate foo_m.r
+    invalidate foo_m.w
+    invalidate foo_combmem.r
+    invalidate foo_combmem.w
 
   extmodule Foo_BlackBox:
     defname = Foo_BlackBox
@@ -56,8 +58,10 @@ circuit TestHarness:
       write-latency => 1
       read-under-write => undefined
 
-    bar_m is invalid
-    bar_combmem is invalid
+    invalidate bar_m.r
+    invalidate bar_m.w
+    invalidate bar_combmem.r
+    invalidate bar_combmem.w
 
   extmodule Bar_BlackBox:
     defname = Bar_BlackBox
@@ -83,8 +87,10 @@ circuit TestHarness:
       write-latency => 1
       read-under-write => undefined
 
-    baz_m is invalid
-    baz_combmem is invalid
+    invalidate baz_m.r
+    invalidate baz_m.w
+    invalidate baz_combmem.r
+    invalidate baz_combmem.w
 
   extmodule Baz_BlackBox:
     defname = Baz_BlackBox
@@ -150,7 +156,7 @@ circuit TestHarness:
 ; MLIR_OUT:  }
 
 ; MLIR_OUT:  om.class @MemorySchema(%basepath: !om.basepath, %name_in: !om.string, %depth_in: !om.integer, %width_in: !om.integer, %maskBits_in: !om.integer, %readPorts_in: !om.integer, %writePorts_in: !om.integer, %readwritePorts_in: !om.integer, %writeLatency_in: !om.integer, %readLatency_in: !om.integer, %hierarchy_in: !om.list<!om.path>, %inDut_in: i1, %extraPorts_in: !om.list<!om.class.type<@ExtraPortsMemorySchema>>, %preExtInstName_in: !om.list<!om.string>) -> (name: !om.string, depth: !om.integer, width: !om.integer, maskBits: !om.integer, readPorts: !om.integer, writePorts: !om.integer, readwritePorts: !om.integer, writeLatency: !om.integer, readLatency: !om.integer, hierarchy: !om.list<!om.path>, inDut: i1, extraPorts: !om.list<!om.class.type<@ExtraPortsMemorySchema>>, preExtInstName: !om.list<!om.string>)
-; MLIR_OUT:    om.class.fields %name_in, %depth_in, %width_in, %maskBits_in, %readPorts_in, %writePorts_in, %readwritePorts_in, %writeLatency_in, %readLatency_in, %hierarchy_in, %inDut_in, %extraPorts_in, %preExtInstName_in : !om.string, !om.integer, !om.integer, !om.integer, !om.integer, !om.integer, !om.integer, !om.integer, !om.integer, !om.list<!om.path>, i1, !om.list<!om.class.type<@ExtraPortsMemorySchema>>, !om.list<!om.string> 
+; MLIR_OUT:    om.class.fields %name_in, %depth_in, %width_in, %maskBits_in, %readPorts_in, %writePorts_in, %readwritePorts_in, %writeLatency_in, %readLatency_in, %hierarchy_in, %inDut_in, %extraPorts_in, %preExtInstName_in : !om.string, !om.integer, !om.integer, !om.integer, !om.integer, !om.integer, !om.integer, !om.integer, !om.integer, !om.list<!om.path>, i1, !om.list<!om.class.type<@ExtraPortsMemorySchema>>, !om.list<!om.string>
 ; MLIR_OUT:  om.class @MemoryMetadata(%basepath: !om.basepath) -> (foo_m_ext_field: !om.class.type<@MemorySchema>, bar_m_ext_field: !om.class.type<@MemorySchema>, baz_m_ext_field: !om.class.type<@MemorySchema>)
 ; MLIR_OUT:     om.path_create instance %basepath @memNLA
 ; MLIR_OUT:     om.list_create

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -9,7 +9,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output out: UInt<8>
 
     ; CHECK: firrtl.matchingconnect %out, %in : !firrtl.uint<8>
-    out <= in
+    connect out, in
 
   ; CHECK: }
 
@@ -95,7 +95,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     wire _t_2 : UInt<1>[12]
 
     ; CHECK: firrtl.matchingconnect %_t, %_t_2 : !firrtl.vector<uint<1>, 12>
-    _t <= _t_2
+    connect _t, _t_2
 
     ; CHECK: [[INV:%.+]]  = firrtl.invalidvalue : !firrtl.uint<1>
     ; CHECK-NEXT: firrtl.matchingconnect %auto, [[INV]] : !firrtl.uint<1>
@@ -128,7 +128,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.matchingconnect [[A]], [[B]]
     wire _t_3 : UInt<1>[12] @[Nodes.scala 370:76]
     wire _t_4 : UInt<1>[12]
-    _t_3[0] <= _t_4[0] @[Xbar.scala 21:44]
+    connect _t_3[0], _t_4[0] @[Xbar.scala 21:44]
 
     ; CHECK: %n1 = firrtl.node interesting_name %i8 : !firrtl.uint<8>
     node n1 = i8
@@ -199,17 +199,17 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.add %c42_ui10, %c171_ui8
     ; CHECK: firrtl.constCast
     ; CHECK: firrtl.matchingconnect %auto
-    auto11 <= add(UInt<10>(42), UInt<8>(0hAB))
+    connect auto11, add(UInt<10>(42), UInt<8>(0hAB))
 
     ; CHECK: %c-85_si8 = firrtl.constant -85 : !firrtl.const.sint<8>
-    sauto <= add(s8, SInt<8>(-85))
+    connect sauto, add(s8, SInt<8>(-85))
 
     ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
     ; CHECK:   firrtl.matchingconnect %_t, %_t_2
     ; CHECK: } else {
     ; CHECK:   firrtl.matchingconnect %_t, %_t_2
     ; CHECK: }
-    when reset : _t <= _t_2 else : _t <= _t_2
+    when reset : connect _t, _t_2 else : connect _t, _t_2
 
     ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
     ; CHECK:   [[N4A:%.+]] = firrtl.node interesting_name %_t_2
@@ -220,10 +220,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: }
     when reset :
       node n4 = _t_2
-      _t <= n4
+      connect _t, n4
     else :
       node n4 = _t_2   ; 'n4' name is in unique scopes.
-      _t <= n4
+      connect _t, n4
 
     ; CHECK: [[TMP:%.+]] = firrtl.constant 4
     ; CHECK: [[COND:%.+]] = firrtl.lt %reset, [[TMP]]
@@ -232,7 +232,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: }
     ; CHECK-NOT: else
     when lt(reset, UInt(4)) :   ;; When with no else.
-      _t <= _t_2
+      connect _t, _t_2
 
     ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
     ; CHECK:   firrtl.matchingconnect %_t, %_t_2
@@ -243,9 +243,9 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK:   }
     ; CHECK: }
     when reset :
-      _t <= _t_2
+      connect _t, _t_2
     else when not(reset) :
-      _t <= _t_2
+      connect _t, _t_2
 
     ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
     ; CHECK:   firrtl.matchingconnect %_t, %_t
@@ -258,11 +258,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK:   }
     ; CHECK: }
     when reset:
-      _t <= _t_2
+      connect _t, _t_2
     else when not(reset) :
-      _t <= _t_2
+      connect _t, _t_2
     else :
-      _t <= _t_2
+      connect _t, _t_2
 
     ; CHECK: firrtl.printf %clock, %reset, "Something interesting!\0A %x %x" (%_t, %_t_2) : !firrtl.clock, !firrtl.uint<1>, !firrtl.vector<uint<1>, 12>, !firrtl.vector<uint<1>, 12>
     printf(clock, reset, "Something interesting!\n %x %x", _t, _t_2)
@@ -318,25 +318,25 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     inst xyz of circuit
     ; CHECK: [[PAD:%.*]] = firrtl.pad %i8, 80 : (!firrtl.uint<8>) -> !firrtl.uint<80>
     ; CHECK: firrtl.matchingconnect %xyz_in, [[PAD]] : !firrtl.uint<80>
-    xyz.in <= i8
+    connect xyz.in, i8
 
     ; CHECK: %myext_in, %myext_out = firrtl.instance myext interesting_name @MyExtModule(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
     inst myext of MyExtModule
-    myext.in <= i8
+    connect myext.in, i8
     printf(clock, reset, "Something interesting! %x", myext.out)
 
     ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
     when reset :
       ; CHECK: %reset_myext_in, %reset_myext_out = firrtl.instance reset_myext interesting_name @MyExtModule(in in: !firrtl.uint<8>, out out: !firrtl.uint<8>)
       inst reset_myext of MyExtModule
-      reset_myext.in <= i8
+      connect reset_myext.in, i8
     ; CHECK: }
 
     ; CHECK: firrtl.subaccess %_t[%i8] : !firrtl.vector<uint<1>, 12>, !firrtl.uint<8>
-    auto <= _t[i8]
+    connect auto, _t[i8]
 
     ; CHECK: firrtl.subaccess %_t[%auto] : !firrtl.vector<uint<1>, 12>, !firrtl.uint<1>
-    auto <= _t[auto]
+    connect auto, _t[auto]
 
     ; CHECK: %myMem = chirrtl.combmem interesting_name : !chirrtl.cmemory<bundle<id: uint<4>, resp: uint<2>>, 8>
     cmem myMem : { id : UInt<4>, resp : UInt<2>} [8] @[Decoupled.scala 209:24]
@@ -344,7 +344,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %memValue_data, %memValue_port = chirrtl.memoryport Infer %myMem {name = "memValue"} : (!chirrtl.cmemory<bundle<id: uint<4>, resp: uint<2>>, 8>) -> (!firrtl.bundle<id: uint<4>, resp: uint<2>>, !chirrtl.cmemoryport)
     ; CHECK: chirrtl.memoryport.access %memValue_port[%i8], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
     infer mport memValue = myMem[i8], clock
-    auto11 <= memValue.id
+    connect auto11, memValue.id
 
     ; CHECK: %base_table_0 = chirrtl.seqmem interesting_name Undefined : !chirrtl.cmemory<vector<uint<1>, 9>, 256>
     smem base_table_0 : UInt<1>[9] [256]
@@ -384,10 +384,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
         read-under-write => undefined
     invalidate _M._T_18.addr  @[Decoupled.scala 209:24]
     invalidate _M._T_18.clk  @[Decoupled.scala 209:24]
-    _M._T_18.en <= UInt<1>(0h0) @[Decoupled.scala 209:24]
+    connect _M._T_18.en, UInt<1>(0h0) @[Decoupled.scala 209:24]
     invalidate _M._T_10.addr  @[Decoupled.scala 209:24]
     invalidate _M._T_10.clk  @[Decoupled.scala 209:24]
-    _M._T_10.en <= UInt<1>(0h0) @[Decoupled.scala 209:24]
+    connect _M._T_10.en, UInt<1>(0h0) @[Decoupled.scala 209:24]
     invalidate _M._T_10.data  @[Decoupled.scala 209:24]
     invalidate _M._T_10.mask  @[Decoupled.scala 209:24]
 
@@ -396,8 +396,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     wire pred: UInt <1>
     wire en: UInt <1>
-    pred <= eq(i8, i8)
-    en <= not(reset)
+    connect pred, eq(i8, i8)
+    connect en, not(reset)
     ; CHECK: firrtl.assert %clock, %pred, %en, "X equals Y when Z is valid" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false}
     assert(clock, pred, en, "X equals Y when Z is valid")
     ; CHECK: firrtl.assert %clock, %pred, %en, "X equals Y when Z is valid" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1> {eventControl = 0 : i32, isConcurrent = false, name = "assert_0"}
@@ -435,20 +435,20 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %reg = firrtl.wire interesting_name : !firrtl.uint
     wire reg : UInt
     ; CHECK: firrtl.connect %reg,
-    reg <= UInt(42)
+    connect reg, UInt(42)
 
     ; CHECK: %write = firrtl.wire
     wire write : { id : UInt<4>, resp : UInt<2>}
 
     ; CHECK: firrtl.subfield %write[id]
-    write.id <= UInt(1)
+    connect write.id, UInt(1)
 
   ; CHECK-LABEL: firrtl.module private @expr_stmt_ambiguity2(
   module expr_stmt_ambiguity2 :
     ; CHECK: firrtl.instance write interesting_name @circuit
     inst write of circuit
     ; CHECK: firrtl.connect %write_in
-    write.in <= UInt(1)
+    connect write.in, UInt(1)
 
   ; CHECK-LABEL: firrtl.module private @oversize_shift(
   module oversize_shift :
@@ -466,13 +466,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     when reset : @[Debug.scala 1176:37]
     ; CHECK: firrtl.when {{.*}} : !firrtl.uint<1> {
       when reset :
-        out <= in
+        connect out, in
     ; CHECK: }
     ; CHECK: } else {
     else :
         ; CHECK: firrtl.when {{.*}} : !firrtl.uint<1> {
       when reset : @[Debug.scala 1180:39]
-        out <= in
+        connect out, in
     ; CHECK: }
     ; CHECK: }
 
@@ -603,7 +603,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   ; CHECK-LABEL: firrtl.module private @issue354(out %tmp5: !firrtl.sint<19>) {
   module issue354 :
     output tmp5: SInt<19>
-    tmp5 <= SInt<19>(8)
+    connect tmp5, SInt<19>(8)
      ; CHECK: %c8_si19 = firrtl.constant 8 : !firrtl.const.sint<19>
      ; CHECK: [[VAL:%.*]] = firrtl.constCast %c8_si19 : (!firrtl.const.sint<19>) -> !firrtl.sint<19>
      ; CHECK: firrtl.matchingconnect %tmp5, [[VAL]] : !firrtl.sint<19>
@@ -611,7 +611,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
    ; CHECK-LABEL: firrtl.module private @issue347
   module issue347 :
     output tmp12: SInt<4>
-    tmp12 <= SInt<4>(-4)
+    connect tmp12, SInt<4>(-4)
     ; CHECK: %c-4_si4 = firrtl.constant -4 : !firrtl.const.sint<4>
 
   ; CHECK-LABEL: firrtl.extmodule private @issue183<A: si32 = -1>()
@@ -631,7 +631,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module register_clock_passive:
     input clkIn: Clock
     output clkOut: Clock
-    clkOut <= clkIn
+    connect clkOut, clkIn
     ; CHECK: firrtl.reg interesting_name %clkOut
     reg r: UInt<1>, clkOut
 
@@ -671,11 +671,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       write-latency => 1
       read-under-write => undefined
 
-    memory.w.clk <= clock
-    memory.w.en <= wEn
-    memory.w.addr <= wAddr
-    memory.w.mask <= wMask
-    memory.w.data <= wData
+    connect memory.w.clk, clock
+    connect memory.w.en, wEn
+    connect memory.w.addr, wAddr
+    connect memory.w.mask, wMask
+    connect memory.w.data, wData
 
   ; https://github.com/llvm/circt/issues/559
   ; CHECK-LABEL: firrtl.module private @TrickyIssue559
@@ -683,7 +683,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input input: UInt<1>
     output output: UInt<1>
     ; CHECK: firrtl.matchingconnect %output, %input
-    output <= input
+    connect output, input
 
   ; CHECK-LABEL: firrtl.module private @CheckInvalids
   module CheckInvalids_in0 :
@@ -786,8 +786,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input in1: { a : UInt<5> }
     output out0: UInt<5>
     output out1: { a : UInt<5> }
-    out0 <= in0
-    out1 <= in1
+    connect out0, in0
+    connect out1, in1
 
   ; https://github.com/llvm/circt/issues/606
   ; CHECK-LABEL: firrtl.module private @mutableSubIndex606
@@ -796,7 +796,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK:  %0 = firrtl.subindex %io[0] : !firrtl.vector<uint<1>, 8>
     ; CHECK: [[VAL:%.*]] = firrtl.constCast %c0_ui1 : (!firrtl.const.uint<1>) -> !firrtl.uint<1>
     ; CHECK: firrtl.matchingconnect %0, [[VAL]] : !firrtl.uint<1>
-    io[0] <= UInt<1>(0h00)
+    connect io[0], UInt<1>(0h00)
 
 
   ; https://github.com/llvm/circt/issues/782
@@ -816,10 +816,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       write-latency => 1
       read-under-write => undefined
 
-    mem.r.clk <= clock
-    mem.r.en <= rEn
-    mem.r.addr <= rAddr
-    rData <= mem.r.data
+    connect mem.r.clk, clock
+    connect mem.r.en, rEn
+    connect mem.r.addr, rAddr
+    connect rData, mem.r.data
 
   ; Test that behavioral memory reads and writes both work and that flow checks
   ; don't fail here.  (A memory port should have duplex flow.)
@@ -836,11 +836,11 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: firrtl.matchingconnect %rData, %r
     infer mport r = a[rAddr], clock
-    rData <= r
+    connect rData, r
 
     ; CHECK: firrtl.matchingconnect %w_data, %wData
     infer mport w = a[wAddr], clock
-    w <= wData
+    connect w, wData
 
   ; Test that a mux with an unknown width select line parses.  This is a check
   ; of the predicate enforced on UInt1Type.
@@ -850,7 +850,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input b: UInt<1>
     input sel: UInt
     output c: UInt<8>
-    c <= mux(sel, a, b)
+    connect c, mux(sel, a, b)
 
   ; Test that a mux with aggregate type is still compatible even if the leaf
   ; types disagree in their width.
@@ -867,8 +867,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-SAME: -> !firrtl.vector<uint<32>, 1>
     ; CHECK: firrtl.mux(%sel, %x, %y)
     ; CHECK-SAME: -> !firrtl.bundle<u: uint<32>, v: uint<2>>
-    c <= mux(sel, a, b)
-    z <= mux(sel, x, y)
+    connect c, mux(sel, a, b)
+    connect z, mux(sel, x, y)
 
   ; CHECK-LABEL: firrtl.extmodule private @VerbatimStringParam
   ; CHECK-SAME:    <TYPE: none = #hw.param.verbatim<"bit">,
@@ -883,7 +883,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   ; CHECK-LABEL: firrtl.module private @issue1303
   module issue1303:
     output out: Reset
-    out <= UInt(1)
+    connect out, UInt(1)
     ; CHECK: %[[c1:.*]] = firrtl.constant 1 : !firrtl.const.uint
     ; CHECK-NEXT: %[[c2:.*]] = firrtl.resetCast %[[c1]]
     ; CHECK-NEXT: %[[c3:.*]] = firrtl.constCast %[[c2]]
@@ -895,7 +895,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input a: {a: UInt<1>, b: AsyncReset}
     output b: {a: Reset, b: Reset}
 
-    b <= a
+    connect b, a
     ; CHECK: %1 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<1>, b: asyncreset>
     ; CHECK: %[[r1:.*]] = firrtl.resetCast %1
     ; CHECK: firrtl.matchingconnect %0, %[[r1]] : !firrtl.reset
@@ -920,7 +920,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module ModuleAsIdentifier:
     inst module of SomeModule
     ; CHECK: firrtl.instance module interesting_name @SomeModule
-    module.in <= UInt(1)
+    connect module.in, UInt(1)
 
   ; CHECK-LABEL: firrtl.module private @EnumTypes
   module EnumTypes:
@@ -943,7 +943,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       ; CHECK:   firrtl.matchingconnect %o, %arg0 : !firrtl.uint<8>
       ; CHECK: }
       Some(x):
-        o <= x
+        connect o, x
       ; CHECK: case None(%arg0) {
       ; CHECK:   %invalid_ui8 = firrtl.invalidvalue : !firrtl.uint<8>
       ; CHECK:   firrtl.matchingconnect %o, %invalid_ui8 : !firrtl.uint<8>
@@ -957,7 +957,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output o : {| A: UInt, None |}
 
     ; CHECK: connect %o, %i
-    o <= i
+    connect o, i
 
   ; CHECK-LABEL: module private @RefsChild(
   ; CHECK-SAME: out %r: !firrtl.probe<uint<1>>
@@ -1000,7 +1000,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK-NEXT: %[[RC_IN:.+]], %[[RC_R:.+]], %[[RC_RW:.+]] = firrtl.instance rc
     inst rc of RefsChild
-    rc.in <= in
+    connect rc.in, in
     ; CHECK: %[[OUTREF:.+]] = firrtl.ref.send %outconst
     ; CHECK-NEXT: %[[OUTREF_CAST:.+]] = firrtl.ref.cast %[[OUTREF]] : (!firrtl.probe<const.uint<1>>) -> !firrtl.probe<const.uint>
     ; CHECK-NEXT: ref.define %r, %[[OUTREF_CAST]]
@@ -1017,10 +1017,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK-NEXT: %[[READ_RC_R:.+]] = firrtl.ref.resolve %[[RC_R]]
     ; CHECK-NEXT: connect %out, %[[READ_RC_R]]
-    out <= read(rc.r)
+    connect out, read(rc.r)
     ; CHECK-NEXT: %[[READ_RC_RW:.+]] = firrtl.ref.resolve %[[RC_RW]]
     ; CHECK-NEXT: connect %out, %[[READ_RC_RW]]
-    out <= read(rc.rw)
+    connect out, read(rc.rw)
 
     ; ref.sub parsing
     ; CHECK-DAG: %[[AGG:.+]] = firrtl.wire interesting_name : !firrtl.bundle<a flip: const.uint<1>, b: uint>
@@ -1031,12 +1031,12 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-DAG: %[[AGG_B_PROBE:.+]] = firrtl.ref.send %[[AGG_B]]
     ; CHECK-DAG: %[[READ_AGG_B_PROBE:.+]] = firrtl.ref.resolve %[[AGG_B_PROBE]]
     ; CHECK-DAG: connect %out2, %[[READ_AGG_B_PROBE]]
-    out2 <= read(probe(agg.b))
+    connect out2, read(probe(agg.b))
     ; CHECK-DAG: %[[AGG2_PROBE:.+]] = firrtl.ref.send %[[AGG2]]
     ; CHECK-DAG: %[[READ_AGG2_PROBE:.+]] = firrtl.ref.resolve %[[AGG2_PROBE]]
     ; CHECK-DAG: %[[READ_AGG2_PROBE__B:.+]] = firrtl.subfield %[[READ_AGG2_PROBE]][b]
     ; CHECK-DAG: connect %out2, %[[READ_AGG2_PROBE__B]]
-    out2 <= read(probe(agg2)).b
+    connect out2, read(probe(agg2)).b
 
     ; CHECK: %[[AGG3:.+]] = firrtl.wire
     wire agg3 : const { a : UInt<1>, b : UInt }
@@ -1048,7 +1048,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %[[PROBE_IN:.+]] = firrtl.ref.send %in
     ; CHECK-DAG: %[[READ_PROBE_IN:.+]] = firrtl.ref.resolve %[[PROBE_IN]]
     ; CHECK-DAG: %[[SUM:.+]] = firrtl.and %[[READ_PROBE_IN]],
-    outconst <= and(read(probe(in)), UInt(1))
+    connect outconst, and(read(probe(in)), UInt(1))
 
     ; CHECK: %[[AGG4:.+]] = firrtl.wire sym [<@[[AGG4_0_b_x_SYM:[^ ]+]],4,public>]
     wire agg4 : { a : UInt, flip b : {x : UInt<1>} }[2]
@@ -1068,7 +1068,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: %[[IN_CAST:[^ ]+]] = firrtl.constCast %in :
     ; CHECK: firrtl.matchingconnect %rc2_in_bounce, %[[IN_CAST]]
-    rc2.in <= in
+    connect rc2.in, in
    ; CHECK-NEXT: firrtl.when %rc2_in_bounce :
    ; CHECK-NEXT:   %[[RWPROBE_RC2_IN_BOUNCE_1:[^ ]+]] = firrtl.ref.rwprobe <@Refs::@[[RC2_IN_BOUNCE_SYM]]>
    ; CHECK-NEXT:   firrtl.ref.define %inst_rw, %[[RWPROBE_RC2_IN_BOUNCE_1]]
@@ -1076,7 +1076,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     when rc2.in:
       define inst_rw = rwprobe(rc2.in)
    ; CHECK-NEXT: firrtl.matchingconnect %rc2_in_bounce,
-    rc2.in <= rc.in
+    connect rc2.in, rc.in
    ; CHECK-NEXT: %[[RWPROBE_RC2_IN_BOUNCE_2:[^ ]+]] = firrtl.ref.rwprobe <@Refs::@[[RC2_IN_BOUNCE_SYM]]>
    ; CHECK-NEXT: firrtl.ref.define %inst_rw2, %[[RWPROBE_RC2_IN_BOUNCE_2]]
     define inst_rw2 = rwprobe(rc2.in)
@@ -1089,7 +1089,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK-NEXT: %{{.+}}, %{{.+}}, %[[RC_RW:.+]] = firrtl.instance rc
     inst rc of RefsChild
-    rc.in <= in
+    connect rc.in, in
 
     ; Check (const) literal works, even if uninferred width.
     ; Cast reference to more general form as needed.
@@ -1105,7 +1105,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK-NEXT: %{{.+}}, %{{.+}}, %[[RC2_RW:.+]] = firrtl.instance rc2
     inst rc2 of RefsChild
-    rc2.in <= in
+    connect rc2.in, in
     ; CHECK: firrtl.ref.release_initial %[[TRUE]], %[[RC2_RW]] : !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
     release_initial(rc2.rw)
 
@@ -1162,8 +1162,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NEXT: %4 = firrtl.subfield %a["0"]
     ; CHECK-NEXT: %5 = firrtl.subfield %4["0"]
     ; CHECK-NEXT: %6 = firrtl.subfield %5[bar]
-    b <= a.0.0.bar
-    d <= c.0.0.0.bar
+    connect b, a.0.0.bar
+    connect d, c.0.0.0.bar
     ; CHECK-NEXT: firrtl.matchingconnect %b, %6
     ; CHECK-NEXT: firrtl.matchingconnect %d, %3
 
@@ -1190,12 +1190,12 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NEXT: %w = firrtl.wire interesting_name : !firrtl.const.sint<4>
     wire w: const SInt<4>
     ; CHECK-NEXT: firrtl.matchingconnect %w, %s4 : !firrtl.const.sint<4>
-    w <= s4
+    connect w, s4
     ; CHECK-NEXT: %nonconst_w = firrtl.wire interesting_name : !firrtl.sint<4>
     wire nonconst_w: SInt<4>
     ; CHECK-NEXT: [[CAST:%.+]] = firrtl.constCast %s4 : (!firrtl.const.sint<4>) -> !firrtl.sint<4>
     ; CHECK-NEXT: firrtl.matchingconnect %nonconst_w, [[CAST]] : !firrtl.sint<4>
-    nonconst_w <= s4
+    connect nonconst_w, s4
 
 ;// -----
 
@@ -1966,7 +1966,7 @@ circuit Foo:
     ; CHECK-NEXT: %[[READ_REM_R2_1_A:.+]] = firrtl.ref.resolve %[[REM_R2_1_A]]
     ; CHECK-NEXT: connect %out3, %[[READ_REM_R2_1_A]]
     inst rem of RefExtMore
-    out3 <= read(rem.r2[1].a)
+    connect out3, read(rem.r2[1].a)
 
 ;// -----
 FIRRTL version 2.9.0
@@ -1975,6 +1975,8 @@ circuit Foo:
     input a: UInt<1>
 
   module Foo:
+    input a: UInt<1>
+    output b: UInt<1>
 
     node binary = UInt<4>("b1010")
     node octal = UInt<4>("o12")
@@ -1983,3 +1985,5 @@ circuit Foo:
 
     inst bar of Bar
     bar is invalid
+
+    b <= a

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -99,24 +99,24 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: [[INV:%.+]]  = firrtl.invalidvalue : !firrtl.uint<1>
     ; CHECK-NEXT: firrtl.matchingconnect %auto, [[INV]] : !firrtl.uint<1>
-    auto is invalid
+    invalidate auto
 
     ; CHECK-NOT: firrtl.attach %a1
-    a1 is invalid
+    invalidate a1
 
     ; CHECK-NOT: firrtl.attach %ab
-    ab is invalid
+    invalidate ab
 
     ; CHECK: firrtl.skip
     skip  @[SKipLoc.scala 42:24]
 
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.uint<1>
     ; CHECK-NEXT: firrtl.matchingconnect %auto, [[INV]] : !firrtl.uint<1>
-    auto is invalid
+    invalidate auto
 
     ; CHECK-NOT: firrtl.connect %reset
     ; CHECK-NOT: firrtl.matchingconnect %reset
-    reset is invalid
+    invalidate reset
 
     ; CHECK: %out_0 = firrtl.wire interesting_name : !firrtl.bundle<member: bundle<"0": bundle<clock: clock, reset: uint<1>>>>
     wire out_0 : { member : { 0 : { clock : Clock, reset : UInt<1>}}}
@@ -382,14 +382,14 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
         reader => _T_18
         writer => _T_10 _T_11
         read-under-write => undefined
-    _M._T_18.addr is invalid @[Decoupled.scala 209:24]
-    _M._T_18.clk is invalid @[Decoupled.scala 209:24]
+    invalidate _M._T_18.addr  @[Decoupled.scala 209:24]
+    invalidate _M._T_18.clk  @[Decoupled.scala 209:24]
     _M._T_18.en <= UInt<1>(0h0) @[Decoupled.scala 209:24]
-    _M._T_10.addr is invalid @[Decoupled.scala 209:24]
-    _M._T_10.clk is invalid @[Decoupled.scala 209:24]
+    invalidate _M._T_10.addr  @[Decoupled.scala 209:24]
+    invalidate _M._T_10.clk  @[Decoupled.scala 209:24]
     _M._T_10.en <= UInt<1>(0h0) @[Decoupled.scala 209:24]
-    _M._T_10.data is invalid @[Decoupled.scala 209:24]
-    _M._T_10.mask is invalid @[Decoupled.scala 209:24]
+    invalidate _M._T_10.data  @[Decoupled.scala 209:24]
+    invalidate _M._T_10.mask  @[Decoupled.scala 209:24]
 
     ; CHECK: firrtl.attach %a8, %a8, %a8 :
     attach (a8, a8, a8)
@@ -557,10 +557,10 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     wire w: {a: UInt<1>}[1]
     ; CHECK: %invalid = firrtl.invalidvalue : !firrtl.vector<bundle<a: uint<1>>, 1>
     ; CHECK: firrtl.matchingconnect %w, %invalid
-    w is invalid
+    invalidate w
     ; CHECK: %invalid_0 = firrtl.invalidvalue : !firrtl.vector<bundle<a: uint<1>>, 1>
     ; CHECK: firrtl.matchingconnect %w, %invalid_0
-    w is invalid
+    invalidate w
 
   ; CHECK-LABEL: firrtl.module private @flip_one
   module flip_one :
@@ -640,7 +640,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   module register_reset_passive:
     input clk: Clock
     output rst: UInt<1>
-    rst is invalid
+    invalidate rst
     ; CHECK: firrtl.regreset interesting_name %clk, %rst
     regreset r: UInt<1>, clk, rst, UInt<1>(0)
 
@@ -650,7 +650,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input clk: Clock
     input rst: UInt<1>
     output init: UInt<1>
-    init is invalid
+    invalidate init
     ; CHECK: firrtl.regreset interesting_name %clk, %rst, %init
     regreset r: UInt<1>, clk, rst, init
 
@@ -690,20 +690,20 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     input in0 : UInt<1>
     ; CHECK-NOT: firrtl.connect %in0
     ; CHECK-NOT: firrtl.matchingconnect %in0
-    in0 is invalid
+    invalidate in0
 
   module CheckInvalids_in1 :
     input in1 : { a : UInt<1>, b : UInt<1> }
     ; CHECK-NOT: firrtl.connect %in1
     ; CHECK-NOT: firrtl.matchingconnect %in1
-    in1 is invalid
+    invalidate in1
 
   module CheckInvalids_in2 :
     input in2 : { a : UInt<1>, flip b : UInt<1>}
     ; CHECK: [[IN2_B:%.+]] = firrtl.subfield %in2[b]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.matchingconnect [[IN2_B]], [[INV]]
-    in2 is invalid
+    invalidate in2
 
   module CheckInvalids_in3 :
     input in3 : {a : { b : UInt<1>, flip c : UInt<1>}}
@@ -711,26 +711,26 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[IN3_A_C:%.+]] = firrtl.subfield [[IN3_A]][c]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.matchingconnect [[IN3_A_C]], [[INV]]
-    in3 is invalid
+    invalidate in3
 
   module CheckInvalids_out0 :
     output out0 : UInt<1>
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.matchingconnect %out0, [[INV]]
-    out0 is invalid
+    invalidate out0
 
   module CheckInvalids_out1 :
     output out1 : { a : UInt<1>, b : UInt<1> }
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>, b: uint<1>>
     ; CHECK: firrtl.matchingconnect %out1, [[INV]]
-    out1 is invalid
+    invalidate out1
 
   module CheckInvalids_out2 :
     output out2 : { a : UInt<1>, flip b : UInt<1>}
     ; CHECK: [[OUT2_A:%.+]] = firrtl.subfield %out2[a]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.matchingconnect [[OUT2_A]], [[INV]]
-    out2 is invalid
+    invalidate out2
 
   module CheckInvalids_out3 :
     output out3 : {a : { b : UInt<1>, flip c : UInt<1>}}
@@ -738,14 +738,14 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[OUT3_A_B:%.+]] = firrtl.subfield [[OUT3_A]][b]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.matchingconnect [[OUT3_A_B]], [[INV]]
-    out3 is invalid
+    invalidate out3
 
   module CheckInvalids_wires :
     ; CHECK: %wire0 = firrtl.wire
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.matchingconnect %wire0, [[INV]]
     wire wire0 : UInt<1>
-    wire0 is invalid
+    invalidate wire0
 
     ; CHECK: %wire1 = firrtl.wire
     ; CHECK: [[WIRE1_B:%.+]] = firrtl.subfield %wire1[b]
@@ -755,7 +755,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue
     ; CHECK: firrtl.matchingconnect [[WIRE1_B]], [[INV]]
     wire wire1 : {a : UInt<1>, flip b : UInt<1> }
-    wire1 is invalid
+    invalidate wire1
 
     ; An analog in the leaf of a wire should be attached not connected.
     ; CHECK: %wire2 = firrtl.wire
@@ -766,7 +766,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.matchingconnect [[WIRE2_X_A]], [[INV]]
     ; CHECK-NOT: firrtl.attach [[WIRE2_X_B]], [[INV]]
     wire wire2 : {x : {flip a : UInt<1>, flip b: Analog<1> } }
-    wire2 is invalid
+    invalidate wire2
 
     ; https://github.com/llvm/circt/issues/563
     ; CHECK: %U0_in0, %U0_in1, %U0_out0, %U0_out1 = firrtl.instance U0 interesting_name @mod_0_563
@@ -776,7 +776,8 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.matchingconnect %U0_in0, [[INV]]
     ; CHECK: [[INV:%.+]] = firrtl.invalidvalue : !firrtl.bundle<a: uint<5>>
     ; CHECK: firrtl.matchingconnect %U0_in1, [[INV]]
-    U0 is invalid
+    invalidate U0.in0
+    invalidate U0.in1
 
   ; This reference is declared after its first use.
   ; https://github.com/llvm/circt/issues/163
@@ -948,7 +949,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
       ; CHECK:   firrtl.matchingconnect %o, %invalid_ui8 : !firrtl.uint<8>
       ; CHECK: }
       None:
-        o is invalid
+        invalidate o
 
   ; CHECK-LABEL: firrtl.module private @EnumInfer(
   module EnumInfer:
@@ -1144,7 +1145,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   ; CHECK-NEXT: }
   module ProbeInvalidate:
     output p : Probe<UInt<1>>
-    p is invalid
+    invalidate p
 
   ; CHECK-LABEL: module private @NumericFields
   ; See: https://github.com/llvm/circt/issues/5110
@@ -1970,9 +1971,15 @@ circuit Foo:
 ;// -----
 FIRRTL version 2.9.0
 circuit Foo:
+  module Bar:
+    input a: UInt<1>
+
   module Foo:
 
     node binary = UInt<4>("b1010")
     node octal = UInt<4>("o12")
     node decimal = UInt<4>(10)
     node hexadecimal = UInt<4>("ha")
+
+    inst bar of Bar
+    bar is invalid

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1634,3 +1634,12 @@ circuit RegWith:
     ; expected-error @below {{'reg with' registers were removed in FIRRTL 3.0.0}}
     reg r_0 : UInt<5>, clock with :
       reset => (UInt<1>(0h0), r_0)
+
+;// -----
+FIRRTL version 3.0.0
+circuit IsInvalid:
+  module IsInvalid:
+    output a: UInt<1>
+
+    ; expected-error @below {{'is invalid' statements were removed in FIRRTL 3.0.0}}
+    a is invalid

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1643,3 +1643,13 @@ circuit IsInvalid:
 
     ; expected-error @below {{'is invalid' statements were removed in FIRRTL 3.0.0}}
     a is invalid
+
+;// -----
+FIRRTL version 3.0.0
+circuit IsInvalid:
+  module IsInvalid:
+    input a: UInt<1>
+    output b: UInt<1>
+
+    ; expected-error @below {{'<=' connections were removed in FIRRTL 3.0.0}}
+    b <= a

--- a/test/firtool/annotation-error.fir
+++ b/test/firtool/annotation-error.fir
@@ -11,5 +11,4 @@ FIRRTL version 4.0.0
 circuit Test:
   public module Test:
     output o : UInt<1>
-    o <= UInt<1>(0)
-    
+    connect o, UInt<1>(0)

--- a/test/firtool/memoryMetadataRenameFail.fir
+++ b/test/firtool/memoryMetadataRenameFail.fir
@@ -21,17 +21,17 @@ circuit test:
       read-under-write => undefined
 
     ; All of these are unified together
-    memory.r.clk <= clock
-    memory.r.en <= rEn
-    memory.r.addr <= rAddr
-    rData <= memory.r.data
+    connect memory.r.clk, clock
+    connect memory.r.en, rEn
+    connect memory.r.addr, rAddr
+    connect rData, memory.r.data
 
-    memory.w.clk <= clock
-    memory.w.en <= rEn
-    memory.w.addr <= rAddr
+    connect memory.w.clk, clock
+    connect memory.w.en, rEn
+    connect memory.w.addr, rAddr
     ; These two are split
-    memory.w.mask <= wMask
-    memory.w.data <= wData
+    connect memory.w.mask, wMask
+    connect memory.w.data, wData
 
   module memoryTest2:
     input clock: Clock
@@ -51,20 +51,20 @@ circuit test:
       read-under-write => undefined
 
     ; All of these are unified together
-    memory.r.clk <= clock
-    memory.r.en <= rEn
-    memory.r.addr <= rAddr
-    rData <= memory.r.data
+    connect memory.r.clk, clock
+    connect memory.r.en, rEn
+    connect memory.r.addr, rAddr
+    connect rData, memory.r.data
 
-    memory.w.clk <= clock
-    memory.w.en <= rEn
-    memory.w.addr <= rAddr
+    connect memory.w.clk, clock
+    connect memory.w.en, rEn
+    connect memory.w.addr, rAddr
     ; These two are split
-    memory.w.mask <= wMask
-    memory.w.data <= wData
+    connect memory.w.mask, wMask
+    connect memory.w.data, wData
 
 
-  public module test: 
+  public module test:
     input clock: Clock
     input rAddr: UInt<4>
     input rEn: UInt<1>
@@ -74,20 +74,20 @@ circuit test:
 
 
     inst m of memoryTest1
-    m.clock <= clock
-    m.rAddr <= rAddr
-    m.rEn <= rEn
-    rData <= m.rData
-    m.wMask <= wMask
-    m.wData <= wData
+    connect m.clock, clock
+    connect m.rAddr, rAddr
+    connect m.rEn, rEn
+    connect rData, m.rData
+    connect m.wMask, wMask
+    connect m.wData, wData
 
     inst signed of memoryP
-    signed.clock <= clock
-    signed.rAddr <= rAddr
-    signed.rEn <= rEn
-    rData <= signed.rData
-    signed.wMask <= wMask
-    signed.wData <= wData
+    connect signed.clock, clock
+    connect signed.rAddr, rAddr
+    connect signed.rEn, rEn
+    connect rData, signed.rData
+    connect signed.wMask, wMask
+    connect signed.wData, wData
 
 
   module memoryP:
@@ -100,12 +100,12 @@ circuit test:
 
 
     inst m of memoryTest2
-    m.clock <= clock
-    m.rAddr <= rAddr
-    m.rEn <= rEn
-    rData <= m.rData
-    m.wMask <= wMask
-    m.wData <= wData
+    connect m.clock, clock
+    connect m.rAddr, rAddr
+    connect m.rEn, rEn
+    connect rData, m.rData
+    connect m.wMask, wMask
+    connect m.wData, wData
 
 ; CHECK-LABEL: module test
 ; CHECK: memoryP [[signed:.+]] (
@@ -127,4 +127,3 @@ circuit test:
 ; CHECK-SAME:  "verification_only_data":{
 ; CHECK-SAME:  "test.[[signed]].[[m]]":{"baseAddress":1073741824,
 ; CHECK-SAME:  "dataBits":8,"eccBits":0,"eccIndices":[],"eccScheme":"none"}}}]
-


### PR DESCRIPTION
Change CIRCT's FIRRTL parser to reject statements which are supposed to be disallowed in FIRRTL 3.

Fixes #7731.