### PR TITLE
Use properties for attributes for many dialects

### DIFF
--- a/include/circt/Dialect/Arc/ArcDialect.td
+++ b/include/circt/Dialect/Arc/ArcDialect.td
@@ -22,9 +22,6 @@ def ArcDialect : Dialect {
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
 
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
-
   let extraClassDeclaration = [{
     void registerTypes();
   }];

--- a/include/circt/Dialect/Calyx/Calyx.td
+++ b/include/circt/Dialect/Calyx/Calyx.td
@@ -39,9 +39,6 @@ def CalyxDialect : Dialect {
   // Depends on the HWDialect to support external primitives using hw.module.extern
   let dependentDialects = ["circt::hw::HWDialect"];
   let cppNamespace = "::circt::calyx";
-
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
 }
 
 class SameTypeConstraint<string lhs, string rhs>

--- a/include/circt/Dialect/Comb/Comb.td
+++ b/include/circt/Dialect/Comb/Comb.td
@@ -28,10 +28,6 @@ def CombDialect : Dialect {
   }];
   let hasConstantMaterializer = 1;
   let cppNamespace = "::circt::comb";
-
-  // This will be the default after next LLVM bump.
-  let usePropertiesForAttributes = 1;
-
 }
 
 // Base class for the operation in this dialect.

--- a/include/circt/Dialect/DC/DCDialect.td
+++ b/include/circt/Dialect/DC/DCDialect.td
@@ -19,13 +19,8 @@ def DCDialect : Dialect {
     handshaking semantics.
   }];
   let cppNamespace = "circt::dc";
-
   let useDefaultTypePrinterParser = 1;
   let dependentDialects = ["circt::esi::ESIDialect"];
-
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
-
   let extraClassDeclaration = [{
     void registerTypes();
   }];

--- a/include/circt/Dialect/FIRRTL/CHIRRTLDialect.td
+++ b/include/circt/Dialect/FIRRTL/CHIRRTLDialect.td
@@ -30,9 +30,6 @@ def CHIRRTLDialect : Dialect {
 
   let useDefaultTypePrinterParser = 1;
 
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
-  
   let extraClassDeclaration = [{
 
     /// Register all FIRRTL types.

--- a/include/circt/Dialect/FSM/FSM.td
+++ b/include/circt/Dialect/FSM/FSM.td
@@ -25,9 +25,6 @@ def FSMDialect : Dialect {
 
   let useDefaultTypePrinterParser = 1;
 
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
-
   let dependentDialects = [
     "circt::seq::SeqDialect"
   ];

--- a/include/circt/Dialect/HW/HWDialect.td
+++ b/include/circt/Dialect/HW/HWDialect.td
@@ -28,9 +28,6 @@ def HWDialect : Dialect {
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
 
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
-
   let extraClassDeclaration = [{
     /// Register all HW types.
     void registerTypes();

--- a/include/circt/Dialect/HWArith/HWArithDialect.td
+++ b/include/circt/Dialect/HWArith/HWArithDialect.td
@@ -16,10 +16,6 @@
 def HWArithDialect : Dialect {
   let name = "hwarith";
   let cppNamespace = "::circt::hwarith";
-
-  // This will be the default after next LLVM bump.
-  let usePropertiesForAttributes = 1;
-
   let summary = "Types and operations for the HWArith dialect";
   let description = [{
     This dialect defines the `HWArith` dialect, modeling bit-width aware

--- a/include/circt/Dialect/Handshake/Handshake.td
+++ b/include/circt/Dialect/Handshake/Handshake.td
@@ -35,9 +35,6 @@ def Handshake_Dialect : Dialect {
 
   let useDefaultAttributePrinterParser = 1;
 
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
-
   let dependentDialects = [
     "circt::esi::ESIDialect",
     "circt::seq::SeqDialect"

--- a/include/circt/Dialect/Ibis/IbisDialect.td
+++ b/include/circt/Dialect/Ibis/IbisDialect.td
@@ -22,10 +22,6 @@ def IbisDialect : Dialect {
   }];
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;
-
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
-
   let extraClassDeclaration = [{
     void registerTypes();
     void registerAttributes();

--- a/include/circt/Dialect/Ibis/IbisOps.td
+++ b/include/circt/Dialect/Ibis/IbisOps.td
@@ -761,9 +761,9 @@ class PortLikeOp<string mnemonic, list<Trait> traits = []> :
                                           mlir::OpaqueProperties properties,
                                           mlir::RegionRange regions,
                                           SmallVectorImpl<Type> &results) {
-      results.push_back(PortRefType::get(context,
-        llvm::cast<TypeAttr>(attrs.get("type")).getValue(),
-        getPortDirection()));
+      Adaptor adaptor(operands, attrs, properties, regions);
+      results.push_back(PortRefType::get(context, adaptor.getType(),
+                        getPortDirection()));
       return success();
     }
 

--- a/include/circt/Dialect/LLHD/IR/LLHDDialect.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDDialect.td
@@ -32,9 +32,6 @@ def LLHDDialect : Dialect {
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;
 
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
-
   let extraClassDeclaration = [{
     /// Register all LLHD types.
     void registerTypes();

--- a/include/circt/Dialect/LTL/LTLDialect.td
+++ b/include/circt/Dialect/LTL/LTLDialect.td
@@ -18,9 +18,6 @@ def LTLDialect : Dialect {
   let cppNamespace = "circt::ltl";
   let useDefaultTypePrinterParser = 1;
   let dependentDialects = ["hw::HWDialect", "comb::CombDialect"];
-
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
 }
 
 #endif // CIRCT_DIALECT_LTL_LTLDIALECT_TD

--- a/include/circt/Dialect/LoopSchedule/LoopSchedule.td
+++ b/include/circt/Dialect/LoopSchedule/LoopSchedule.td
@@ -16,9 +16,6 @@ def LoopSchedule_Dialect : Dialect {
   let name = "loopschedule";
   let cppNamespace = "::circt::loopschedule";
   let summary = "Representation of scheduled loops";
-
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
 }
 
 include "circt/Dialect/LoopSchedule/LoopScheduleOps.td"

--- a/include/circt/Dialect/OM/OMDialect.td
+++ b/include/circt/Dialect/OM/OMDialect.td
@@ -32,9 +32,6 @@ def OMDialect : Dialect {
   let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;
 
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
-
   let dependentDialects = [
     "circt::hw::HWDialect"
   ];

--- a/include/circt/Dialect/Pipeline/PipelineDialect.td
+++ b/include/circt/Dialect/Pipeline/PipelineDialect.td
@@ -14,10 +14,6 @@ include "mlir/IR/OpBase.td"
 def Pipeline_Dialect : Dialect {
   let name = "pipeline";
   let cppNamespace = "::circt::pipeline";
-
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
-
   let dependentDialects = [
     "circt::seq::SeqDialect"
   ];

--- a/include/circt/Dialect/SSP/SSP.td
+++ b/include/circt/Dialect/SSP/SSP.td
@@ -32,9 +32,6 @@ def SSPDialect : Dialect {
 
   let useDefaultAttributePrinterParser = true;
 
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
-
   let extraClassDeclaration = [{
     /// Register all SSP attributes.
     void registerAttributes();

--- a/include/circt/Dialect/SSP/SSPOps.h
+++ b/include/circt/Dialect/SSP/SSPOps.h
@@ -16,6 +16,7 @@
 #include "circt/Dialect/SSP/SSPAttributes.h"
 #include "circt/Dialect/SSP/SSPDialect.h"
 
+#include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/IR/SymbolTable.h"

--- a/include/circt/Dialect/SV/SVDialect.td
+++ b/include/circt/Dialect/SV/SVDialect.td
@@ -28,9 +28,6 @@ def SVDialect : Dialect {
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;
 
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
-
   let extraClassDeclaration = [{
     /// Register all SV types.
     void registerTypes();

--- a/include/circt/Dialect/Seq/SeqDialect.td
+++ b/include/circt/Dialect/Seq/SeqDialect.td
@@ -25,9 +25,6 @@ def SeqDialect : Dialect {
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;
 
-  // This will be the default after next LLVM bump.
-  let usePropertiesForAttributes = 1;
-
   let cppNamespace = "::circt::seq";
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/SystemC/SystemCDialect.td
+++ b/include/circt/Dialect/SystemC/SystemCDialect.td
@@ -35,9 +35,6 @@ def SystemCDialect : Dialect {
   }];
 
   let useDefaultTypePrinterParser = 0;
-
-  // Opt-out of properties for now, must migrate by LLVM 19.  #5273.
-  let usePropertiesForAttributes = 0;
 }
 
 #endif // CIRCT_DIALECT_SYSTEMC_SYSTEMCDIALECT

--- a/include/circt/Dialect/Verif/VerifDialect.td
+++ b/include/circt/Dialect/Verif/VerifDialect.td
@@ -18,9 +18,6 @@ def VerifDialect : Dialect {
   let cppNamespace = "circt::verif";
   let hasConstantMaterializer = 1;
 
-  // This will be the default after next LLVM bump.
-  let usePropertiesForAttributes = 1;
-
   let dependentDialects = [
     "circt::seq::SeqDialect", "circt::hw::HWDialect"
   ];

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -2780,10 +2780,10 @@ LogicalResult UnionExtractOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::OpaqueProperties properties,
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
+  Adaptor adaptor(operands, attrs, properties, regions);
   auto unionElements =
-      hw::type_cast<UnionType>((operands[0].getType())).getElements();
-  unsigned fieldIndex =
-      attrs.getAs<IntegerAttr>("fieldIndex").getValue().getZExtValue();
+      hw::type_cast<UnionType>((adaptor.getInput().getType())).getElements();
+  unsigned fieldIndex = adaptor.getFieldIndexAttr().getValue().getZExtValue();
   if (fieldIndex >= unionElements.size()) {
     if (loc)
       mlir::emitError(*loc, "field index " + Twine(fieldIndex) +

--- a/lib/Dialect/Ibis/IbisOps.cpp
+++ b/lib/Dialect/Ibis/IbisOps.cpp
@@ -410,7 +410,8 @@ LogicalResult PathOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::OpaqueProperties properties,
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
-  auto path = cast<ArrayAttr>(attrs.get("path"));
+  Adaptor adaptor(operands, attrs, properties, regions);
+  auto path = adaptor.getPathAttr();
   if (path.empty())
     return failure();
 

--- a/lib/Dialect/OM/OMOps.cpp
+++ b/lib/Dialect/OM/OMOps.cpp
@@ -510,13 +510,14 @@ LogicalResult TupleCreateOp::inferReturnTypes(
 
 LogicalResult TupleGetOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location, ValueRange operands,
-    DictionaryAttr attributes, OpaqueProperties, RegionRange regions,
+    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
     llvm::SmallVectorImpl<Type> &inferredReturnTypes) {
-  auto idx = attributes.getAs<mlir::IntegerAttr>("index");
+  Adaptor adaptor(operands, attributes, properties, regions);
+  auto idx = adaptor.getIndexAttr();
   if (operands.empty() || !idx)
     return failure();
 
-  auto tupleTypes = cast<TupleType>(operands[0].getType()).getTypes();
+  auto tupleTypes = cast<TupleType>(adaptor.getInput().getType()).getTypes();
   if (tupleTypes.size() <= idx.getValue().getLimitedValue()) {
     if (location)
       mlir::emitError(*location,

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1703,13 +1703,13 @@ LogicalResult IndexedPartSelectInOutOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::OpaqueProperties properties,
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
-  auto width = attrs.get("width");
+  Adaptor adaptor(operands, attrs, properties, regions);
+  auto width = adaptor.getWidthAttr();
   if (!width)
     return failure();
 
-  auto typ =
-      getElementTypeOfWidth(operands[0].getType(),
-                            cast<IntegerAttr>(width).getValue().getZExtValue());
+  auto typ = getElementTypeOfWidth(operands[0].getType(),
+                                   width.getValue().getZExtValue());
   if (!typ)
     return failure();
   results.push_back(typ);
@@ -1756,12 +1756,12 @@ LogicalResult IndexedPartSelectOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::OpaqueProperties properties,
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
-  auto width = attrs.get("width");
+  Adaptor adaptor(operands, attrs, properties, regions);
+  auto width = adaptor.getWidthAttr();
   if (!width)
     return failure();
 
-  results.push_back(
-      IntegerType::get(context, cast<IntegerAttr>(width).getInt()));
+  results.push_back(IntegerType::get(context, width.getInt()));
   return success();
 }
 
@@ -1786,12 +1786,13 @@ LogicalResult StructFieldInOutOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attrs, mlir::OpaqueProperties properties,
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
-  auto field = attrs.get("field");
+  Adaptor adaptor(operands, attrs, properties, regions);
+  auto field = adaptor.getFieldAttr();
   if (!field)
     return failure();
   auto structType =
       hw::type_cast<hw::StructType>(getInOutElementType(operands[0].getType()));
-  auto resultType = structType.getFieldType(cast<StringAttr>(field));
+  auto resultType = structType.getFieldType(field);
   if (!resultType)
     return failure();
 


### PR DESCRIPTION
This change enables the use of operation properties for more dialects in CIRCT. The option to *not* use properties is going to be removed in a future release of MLIR, but as well we expect this change to bring a performance improvement.

For all these dialects, the only change required was to properly infer return types.  Some operations were hardcoded to search through the attributes, and the attribute was moved to the property storage. By using the generated adaptor classes, we can abstract over where the interesting attribute is stored.

For future work, some code may be refactored for further performance wins now that we are using properties. In particular usages `setAttr` and `getAttr` may be made faster by using a less generic op transformation interface.