### PR TITLE
[Verif] Adjust contract ops to match documentation

### DIFF
--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -13,6 +13,7 @@ include "circt/Dialect/Verif/VerifDialect.td"
 include "circt/Dialect/LTL/LTLDialect.td"
 include "circt/Dialect/LTL/LTLTypes.td"
 include "circt/Dialect/HW/HWTypes.td"
+include "circt/Dialect/Seq/SeqTypes.td"
 include "circt/Dialect/HW/HWAttributes.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -328,123 +329,89 @@ def SymbolicValueOp : VerifOp<"symbolic_value", [
 }
 
 //===----------------------------------------------------------------------===//
-// Formal Contract Ops
+// Formal Contracts
 //===----------------------------------------------------------------------===//
 
 def ContractOp : VerifOp<"contract", [
-  SingleBlockImplicitTerminator<"verif::YieldOp">,
-  HasParent<"hw::HWModuleOp">, 
-  RegionKindInterface
+  AllTypesMatch<["inputs", "outputs"]>,
+  NoRegionArguments,
+  NoTerminator,
+  RegionKindInterface,
+  SingleBlock,
 ]>{
-  let summary = "declare a formal contract";
+  let summary = "A formal contract";
   let description = [{
-    This operation declares a formal contract that is used to create precondition 
-    and postconditions on a parent module. These are used as an abstraction to 
-    better modularize formal verification such that each module containing a contract 
-    is checked exactly once. The contract contains a single block where the block arguments 
-    represent the results of the code block that the contract is abstracting over. The 
-    operands represent the SSA values that this contract's results will replace.
-          
-    e.g. 
-    ```
-    hw.module @Bar(in %foo : i8, out "" : i8, out "1" : i8) { 
-      %o0, %o1 = verif.contract (%to0, %to1) : (i8, i8) -> (i8, i8) {
-        ^bb0(%bar.0 : i8, %bar.1 : i8): 
-          %c0_8 = hw.constant 0 : i8 
-          %prec = comb.icmp bin ugt %foo, %c0_8 : i8
-          verif.require %prec : i1
+    This operation creates a new formal contract which can be used to locally
+    verify a part of the IR and provide simplifying substitutions. Contracts
+    contain `verif.require` ops to establish conditions that must hold for a
+    piece of IR to work properly, and `verif.ensure` ops to describe the
+    properties that the piece of IR must guarantees when the requirements hold.
+    Outside of formal verification, operands are simply passed through to the
+    results.
 
-          %post = comb.icmp bin ugt %bar.0, %foo : i8
-          %post1 = comb.icmp bin ult %bar.1, %foo : i8
-          verif.ensure %post : i1
-          verif.ensure %post1 : i1
-          verif.yield %bar.0, %bar.1 : i8, i8
-      } 
-      /* ... Module definition ... */
-    }
-    ```
+    Contracts are checked by extracting them into their own `verif.formal` test
+    and replacing `require` with `assume` and `ensure` with `assert`. The
+    results of the contract are replaced with the operands of the contract.
 
-    This later is used to replace any instance of Bar during verification:  
-    ```
-    %bar.0, %bar.1 = hw.instance "bar" @Bar("foo" : %c42_8 : i8)  -> ("" : i8, "1" : i8)
+    Contracts are used as simplifications for other verification tasks by
+    inlining them and replacing `require` with `assert` and `ensure` with
+    `assume`. The results of the contract are replaced with symbolic values.
 
-    /* ... After PrepareForFormal Pass becomes ... */
-
-    %bar.0, %bar.1 = verif.contract (%c42_8) : (i8) -> (i8, i8) {
-      ^bb0(%arg1: i8):
-        %c0_8 = hw.constant 0 : i8
-        %prec = comb.icmp bin ugt %arg1, %c0_8 : i8
-        verif.assert %prec : i1
-
-        %bar.0 = verif.symbolic_value : i8
-        %bar.1 = verif.symbolic_value : i8
-        %post = comb.icmp bin ugt %bar.0, %arg1 : i8
-        %post1 = comb.icmp bin ult %bar.1, %arg1 : i8
-        verif.assume %post : i1
-        verif.assume %post1 : i1
-        verif.yield %bar.0, %bar.1 : i8, i8
-    }
-    
-    ```
+    See the documentation of the Verif dialect for more details.
   }];
-
   let arguments = (ins Variadic<AnyType>:$inputs);
-  let results = (outs Variadic<AnyType>:$results);
+  let results = (outs Variadic<AnyType>:$outputs);
   let regions = (region SizedRegion<1>:$body);
-
   let assemblyFormat = [{
-    `(` $inputs `)` attr-dict `:` `(` type($inputs) `)` `->` `(` type($results) `)` $body
+    ($inputs^ `:` type($inputs))? attr-dict-with-keyword $body
   }];
-
   let extraClassDeclaration = [{
-    /// Implement RegionKindInterface.
     static RegionKind getRegionKind(unsigned index) { 
       return RegionKind::Graph;
     }
-
-    /// Retrieves the region block arguments
-    BlockArgument getRegionArg(unsigned index) {
-      return getBody().front().getArguments()[index];
-    }
-
-    /// Retrieves the number of block arguments
-    unsigned getNumRegionArgs() {
-      return getBody().front().getNumArguments();
-    }
   }];
-
-  let hasRegionVerifier = 1;
 }
 
-class RequireLikeOp<string mnemonic, list<Trait> traits = [
-  HasParent<"verif::ContractOp">, AttrSizedOperandSegments
-]> : VerifOp<mnemonic, traits> {
-  let arguments = (ins LTLAnyPropertyType:$property,
-                      OptionalAttr<ClockEdgeAttr>:$edge, Optional<I1>:$clock,
-                      Optional<I1>:$enable,
-                      OptionalAttr<StrAttr>:$label);
+class RequireLikeOp<string mnemonic> : VerifOp<mnemonic, [
+  AttrSizedOperandSegments,
+  HasParent<"verif::ContractOp">,
+]> {
+  let arguments = (ins
+    LTLAnyPropertyType:$property,
+    Optional<ClockType>:$clock,
+    Optional<I1>:$enable,
+    OptionalAttr<StrAttr>:$label
+  );
   let assemblyFormat = [{
-    $property (`if` $enable^)? (`,` $edge^ $clock)? 
-    (`label` $label^)? attr-dict `:` type($property)
+    $property
+    (`if` $enable^)?
+    (`clock` $clock^)?
+    (`label` $label^)?
+    attr-dict `:` type($property)
   }];
 }
 
 def RequireOp : RequireLikeOp<"require"> {
-  let summary = "define a precondition for the given contract";
+  let summary = "A precondition of a contract";
   let description = [{
-    This operation defines a precondition for the parent contract. 
-    Preconditions are assumed during the verification of a module and 
-    asserted during the verification of an instance of a module.
+    This operation specifies a condition that is assumed when checking against
+    the contract, and asserted when applying the contract as a simplification.
+
+    The `verif.require` op is commonly used to specify the conditions that input
+    values into a part of the IR must fulfill in order for the IR to work as
+    expected, i.e., as outlined in the contract.
   }];
 }
 
-
 def EnsureOp : RequireLikeOp<"ensure">{
-  let summary = "define a postcondition for the given contract";
+  let summary = "A postcondition of a contract";
   let description = [{
-    This operation defines a postcondition for the parent contract. 
-    Postconditions are asserted during the verification of a module and 
-    assumed during the verification of an instance of a module.
+    This operation specifies a condition that is asserted when checking a
+    contract, and assumed when applying the contract as a simplification.
+
+    The `verif.ensure` op is commonly used to specify the conditions that output
+    values from a part of the IR are guaranteed to fulfill, under the condition
+    that all requirements are fulfilled.
   }];
 }
 

--- a/lib/Dialect/Verif/VerifOps.cpp
+++ b/lib/Dialect/Verif/VerifOps.cpp
@@ -94,41 +94,6 @@ LogicalResult CoverOp::canonicalize(CoverOp op, PatternRewriter &rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
-// Formal contract verifiers
-//===----------------------------------------------------------------------===//
-
-LogicalResult ContractOp::verifyRegions() {
-  // Retrieve the number of inputs from the parent module
-  auto parent = (*this)->getParentOfType<hw::HWModuleOp>();
-  // Sanity check: parent should always be a hw.module
-  if (!parent)
-    return emitOpError() << "parent of contract must be an hw.module!";
-
-  auto nRes = (*this)->getNumResults();
-  auto resTypes = (*this)->getResultTypes();
-  auto *yield = getBody().front().getTerminator();
-
-  // Check that the region terminator yields the same number of ops as the
-  // number of results
-  if (yield->getNumOperands() != nRes)
-    return emitOpError() << "region terminator must yield the same number of "
-                         << "operands as there are results!";
-
-  // Check that the region terminator yields the same types of ops as the
-  // types of results
-  if (yield->getOperandTypes() != resTypes)
-    return emitOpError() << "region terminator must yield the same types of "
-                         << "operands as the result types!";
-
-  // Check that the region block arguments share the same types as the results
-  if (getBody().front().getArgumentTypes() != resTypes)
-    return emitOpError() << "region must have the same type of arguments "
-                         << "as the type of results!";
-
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // LogicalEquivalenceCheckingOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/Verif/basic.mlir
+++ b/test/Dialect/Verif/basic.mlir
@@ -68,40 +68,48 @@ verif.formal @FormalTestBody {
 // Contracts
 //===----------------------------------------------------------------------===//
 
-// CHECK-LABEL: hw.module @Bar
-hw.module @Bar(in %foo : i8, out "" : i8, out "1" : i8) { 
-  // CHECK: %[[C1:.+]] = hw.constant
-  %c1_8 = hw.constant 1 : i8
-  // CHECK: %[[O1:.+]] = comb.add
-  %to0 = comb.add bin %foo, %c1_8 : i8
-  // CHECK: %[[O2:.+]] = comb.sub
-  %to1 = comb.sub bin %foo, %c1_8 : i8
+// CHECK: [[A:%.+]] = unrealized_conversion_cast to i42
+%a = unrealized_conversion_cast to i42
+// CHECK: [[B:%.+]] = unrealized_conversion_cast to i1337
+%b = unrealized_conversion_cast to i1337
+// CHECK: [[C:%.+]] = unrealized_conversion_cast to i9001
+%c = unrealized_conversion_cast to i9001
+// CHECK: [[CLOCK:%.+]] = unrealized_conversion_cast to !seq.clock
+%d = unrealized_conversion_cast to !seq.clock
 
-  // CHECK: %[[OUT:.+]]:2 = verif.contract(%[[O1]], %[[O2]]) : (i8, i8) -> (i8, i8) {
-  %o0, %o1 = verif.contract (%to0, %to1) : (i8, i8) -> (i8, i8) {
-    // CHECK: ^bb0(%[[BAR0:.+]]: i8, %[[BAR1:.+]]: i8):
-    ^bb0(%bar.0 : i8, %bar.1 : i8): 
-      // CHECK: %[[C0:.+]] = hw.constant 0 : i8
-      %c0_8 = hw.constant 0 : i8 
-      // CHECK: %[[PREC:.+]] = comb.icmp bin ugt %foo, %[[C0]] : i8
-      %prec = comb.icmp bin ugt %foo, %c0_8 : i8
-      // CHECK: verif.require %[[PREC]] : i1
-      verif.require %prec : i1
+// CHECK: verif.contract {
+verif.contract {}
+// CHECK: {{%.+}} = verif.contract [[A]] : i42 {
+%q0 = verif.contract %a : i42 {}
+// CHECK: {{%.+}}:3 = verif.contract [[A]], [[B]], [[C]] : i42, i1337, i9001 {
+%q1:3 = verif.contract %a, %b, %c : i42, i1337, i9001 {}
 
-      // CHECK: %[[P0:.+]] = comb.icmp bin ugt %[[BAR0]], %foo : i8
-      %post = comb.icmp bin ugt %bar.0, %foo : i8
-      // CHECK: %[[P1:.+]] = comb.icmp bin ult %[[BAR1]], %foo : i8
-      %post1 = comb.icmp bin ult %bar.1, %foo : i8
-      // CHECK: verif.ensure %[[P0]] : i1
-      verif.ensure %post : i1
-      // CHECK: verif.ensure %[[P1]] : i1
-      verif.ensure %post1 : i1
-      // CHECK: verif.yield %[[BAR0]], %[[BAR1]] : i8, i8
-      verif.yield %bar.0, %bar.1 : i8, i8
-  } 
-  
-  // CHECK-LABEL: hw.output
-  hw.output %o0, %o1 : i8, i8
+verif.contract {
+  // CHECK: verif.require {{%.+}} : i1
+  // CHECK: verif.require {{%.+}} if {{%.+}} : i1
+  // CHECK: verif.require {{%.+}} clock {{%.+}} : i1
+  // CHECK: verif.require {{%.+}} label "foo" : i1
+  // CHECK: verif.require {{%.+}} : !ltl.sequence
+  // CHECK: verif.require {{%.+}} : !ltl.property
+  verif.require %true : i1
+  verif.require %true if %true : i1
+  verif.require %true clock %d : i1
+  verif.require %true label "foo" : i1
+  verif.require %s : !ltl.sequence
+  verif.require %p : !ltl.property
+
+  // CHECK: verif.ensure {{%.+}} : i1
+  // CHECK: verif.ensure {{%.+}} if {{%.+}} : i1
+  // CHECK: verif.ensure {{%.+}} clock {{%.+}} : i1
+  // CHECK: verif.ensure {{%.+}} label "foo" : i1
+  // CHECK: verif.ensure {{%.+}} : !ltl.sequence
+  // CHECK: verif.ensure {{%.+}} : !ltl.property
+  verif.ensure %true : i1
+  verif.ensure %true if %true : i1
+  verif.ensure %true clock %d : i1
+  verif.ensure %true label "foo" : i1
+  verif.ensure %s : !ltl.sequence
+  verif.ensure %p : !ltl.property
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Slightly tweak the `verif.contract`, `verif.require`, and `verif.ensure` ops to match the usage outlined in the Verif dialect documentation. This also adjusts the operands and constraints slightly.