### PR TITLE
[OM] Add ClassOp region verifier

### DIFF
--- a/include/circt/Dialect/OM/OMOps.td
+++ b/include/circt/Dialect/OM/OMOps.td
@@ -143,6 +143,8 @@ def ClassOp : OMClassLike<"class", [
     // assertion error
     mlir::Location getFieldLocByIndex(size_t i);
   }];
+
+  let hasRegionVerifier = 1;
 }
 
 def ClassFieldsOp : OMOp<"class.fields", [Terminator, ReturnLike, Pure,

--- a/test/Dialect/OM/errors.mlir
+++ b/test/Dialect/OM/errors.mlir
@@ -161,3 +161,20 @@ om.class @UnknownClass(%arg: !om.class.type<@Unknwon>) {
   om.object.field %arg, [@unknown]: (!om.class.type<@Unknwon>) -> i1
   om.class.fields
 }
+
+// -----
+
+// expected-error @+1 {{returns '0' fields, but its terminator returned '1' fields}}
+om.class @A(%arg: i1) {
+  // expected-note @+1 {{see terminator:}}
+  om.class.fields %arg : i1
+}
+
+
+// -----
+
+// expected-error @+1 {{returns different field types than its terminator}}
+om.class @A(%arg: i1) -> (a: i2) {
+  // expected-note @+1 {{see terminator:}}
+  om.class.fields %arg : i1
+}


### PR DESCRIPTION
Add a region verifier to OM dialect's Class Op.  This verifies that the terminator returns the right number of fields with the correct types that match the declared type of the Class Op.

Fixes #7736.