### PR TITLE
[FIRRTL] Remove validation from type inference code

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -42,20 +42,6 @@ class FIRRTLExprOp<string mnemonic, list<Trait> traits = []> :
                                       std::optional<Location> loc);
   }];
 
-  // The operation-specific validator for a parsed list of operands and
-  // constants. Operations can override this with an inline declaration for the
-  // class header, or just leave it as is and implement the function in a cpp
-  // file.
-  code parseValidator = "";
-  code parseValidatorDecl = [{
-    /// Check that the parser has consumed the correct number of operands and
-    /// constants.
-    static LogicalResult validateArguments(ValueRange operands,
-                                           ArrayRef<NamedAttribute> attrs,
-                                           Location loc)
-  }] # !if(!empty(parseValidator), ";", !subst("$_impl", parseValidator, [{ {
-    return $_impl(operands, attrs, loc);
-  } }]));
 
   // Additional class declarations to emit alongside the type inference.
   code firrtlExtraClassDeclaration = "";
@@ -80,17 +66,7 @@ class FIRRTLExprOp<string mnemonic, list<Trait> traits = []> :
   }];
 
   let extraClassDeclaration = firrtlExtraClassDeclaration # inferTypeDecl #
-      parseValidatorDecl # inferReturnTypesDecl # [{
-    /// Check that the parser has consumed the correct number of operands and
-    /// constants, and infer the appropriate return type for the operation.
-    static FIRRTLType validateAndInferReturnType(ValueRange operands,
-                                                 ArrayRef<NamedAttribute> attrs,
-                                                 Location loc) {
-      if (failed(validateArguments(operands, attrs, loc)))
-        return {};
-      return inferReturnType(operands, attrs, loc);
-    }
-
+      inferReturnTypesDecl # [{
     // Returns when two result types are compatible for this op; method used by
     // InferTypeOpInterface.
     static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
@@ -565,7 +541,6 @@ class BinaryPrimOp<string mnemonic, Type lhsType, Type rhsType, Type resultType,
                      loc);
     }
   }]);
-  let parseValidator = "impl::validateBinaryOpArguments";
 }
 
 // A binary operation on two integer-typed arguments of the same kind.
@@ -681,7 +656,6 @@ class UnaryPrimOp<string mnemonic, Type srcType, Type resultType,
     }
   }]);
 
-  let parseValidator = "impl::validateUnaryOpArguments";
 }
 
 def SizeOfIntrinsicOp : UnaryPrimOp<"int.sizeof", FIRRTLBaseType, UInt32Type>;
@@ -753,7 +727,6 @@ def HeadPrimOp : PrimOp<"head"> {
     "$input `,` $amount attr-dict `:` functional-type($input, $result)";
 
   let hasCanonicalizeMethod = true;
-  let parseValidator = "impl::validateOneOperandOneConst";
 }
 
 def MuxPrimOp : PrimOp<"mux"> {
@@ -780,7 +753,6 @@ def PadPrimOp : PrimOp<"pad"> {
     width of `input`, then input is unmodified.
   }];
 
-  let parseValidator = "impl::validateOneOperandOneConst";
 }
 
 class ShiftPrimOp<string mnemonic> : PrimOp<mnemonic> {
@@ -790,7 +762,6 @@ class ShiftPrimOp<string mnemonic> : PrimOp<mnemonic> {
   let assemblyFormat =
     "$input `,` $amount attr-dict `:` functional-type($input, $result)";
 
-  let parseValidator = "impl::validateOneOperandOneConst";
 }
 
 def ShlPrimOp : ShiftPrimOp<"shl"> {
@@ -825,7 +796,6 @@ def TailPrimOp : PrimOp<"tail"> {
   }];
 
   let hasCanonicalizeMethod = true;
-  let parseValidator = "impl::validateOneOperandOneConst";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/FIRRTLOps.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLOps.h
@@ -158,17 +158,6 @@ FIRRTLType inferElementwiseResult(FIRRTLType lhs, FIRRTLType rhs,
 FIRRTLType inferComparisonResult(FIRRTLType lhs, FIRRTLType rhs,
                                  std::optional<Location> loc);
 FIRRTLType inferReductionResult(FIRRTLType arg, std::optional<Location> loc);
-
-// Common parsed argument validation functions.
-LogicalResult validateBinaryOpArguments(ValueRange operands,
-                                        ArrayRef<NamedAttribute> attrs,
-                                        Location loc);
-LogicalResult validateUnaryOpArguments(ValueRange operands,
-                                       ArrayRef<NamedAttribute> attrs,
-                                       Location loc);
-LogicalResult validateOneOperandOneConst(ValueRange operands,
-                                         ArrayRef<NamedAttribute> attrs,
-                                         Location loc);
 } // namespace impl
 
 /// A binary operation where the operands have the same integer kind.

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4992,16 +4992,6 @@ LogicalResult impl::verifySameOperandsIntTypeKind(Operation *op) {
                                    rhsWidth, isConstResult, op->getLoc()));
 }
 
-LogicalResult impl::validateBinaryOpArguments(ValueRange operands,
-                                              ArrayRef<NamedAttribute> attrs,
-                                              Location loc) {
-  if (operands.size() != 2 || !attrs.empty()) {
-    mlir::emitError(loc, "operation requires two operands and no constants");
-    return failure();
-  }
-  return success();
-}
-
 FIRRTLType impl::inferAddSubResult(FIRRTLType lhs, FIRRTLType rhs,
                                    std::optional<Location> loc) {
   int32_t lhsWidth, rhsWidth, resultWidth = -1;
@@ -5170,16 +5160,6 @@ FIRRTLType DShrPrimOp::inferBinaryReturnType(FIRRTLType lhs, FIRRTLType rhs,
 // Unary Primitives
 //===----------------------------------------------------------------------===//
 
-LogicalResult impl::validateUnaryOpArguments(ValueRange operands,
-                                             ArrayRef<NamedAttribute> attrs,
-                                             Location loc) {
-  if (operands.size() != 1 || !attrs.empty()) {
-    mlir::emitError(loc, "operation requires one operand and no constants");
-    return failure();
-  }
-  return success();
-}
-
 FIRRTLType
 SizeOfIntrinsicOp::inferUnaryReturnType(FIRRTLType input,
                                         std::optional<Location> loc) {
@@ -5272,16 +5252,6 @@ FIRRTLType impl::inferReductionResult(FIRRTLType input,
 // Other Operations
 //===----------------------------------------------------------------------===//
 
-LogicalResult BitsPrimOp::validateArguments(ValueRange operands,
-                                            ArrayRef<NamedAttribute> attrs,
-                                            Location loc) {
-  if (operands.size() != 1 || attrs.size() != 2) {
-    mlir::emitError(loc, "operation requires one operand and two constants");
-    return failure();
-  }
-  return success();
-}
-
 FIRRTLType BitsPrimOp::inferReturnType(ValueRange operands,
                                        ArrayRef<NamedAttribute> attrs,
                                        std::optional<Location> loc) {
@@ -5315,16 +5285,6 @@ FIRRTLType BitsPrimOp::inferReturnType(ValueRange operands,
   return UIntType::get(input.getContext(), high - low + 1, inputi.isConst());
 }
 
-LogicalResult impl::validateOneOperandOneConst(ValueRange operands,
-                                               ArrayRef<NamedAttribute> attrs,
-                                               Location loc) {
-  if (operands.size() != 1 || attrs.size() != 1) {
-    mlir::emitError(loc, "operation requires one operand and one constant");
-    return failure();
-  }
-  return success();
-}
-
 FIRRTLType HeadPrimOp::inferReturnType(ValueRange operands,
                                        ArrayRef<NamedAttribute> attrs,
                                        std::optional<Location> loc) {
@@ -5341,16 +5301,6 @@ FIRRTLType HeadPrimOp::inferReturnType(ValueRange operands,
     return emitInferRetTypeError(loc, "amount larger than input width");
 
   return UIntType::get(input.getContext(), amount, inputi.isConst());
-}
-
-LogicalResult MuxPrimOp::validateArguments(ValueRange operands,
-                                           ArrayRef<NamedAttribute> attrs,
-                                           Location loc) {
-  if (operands.size() != 3 || attrs.size() != 0) {
-    mlir::emitError(loc, "operation requires three operands and no constants");
-    return failure();
-  }
-  return success();
 }
 
 /// Infer the result type for a multiplexer given its two operand types, which

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2417,8 +2417,7 @@ ParseResult FIRStmtParser::parsePrimExp(Value &result) {
     auto resultTy = CLASS::inferReturnType(operands, attrs, {});               \
     if (!resultTy) {                                                           \
       /* only call translateLocation on an error case, it is expensive. */     \
-      (void)CLASS::validateAndInferReturnType(operands, attrs,                 \
-                                              translateLocation(loc));         \
+      CLASS::inferReturnType(operands, attrs, translateLocation(loc));         \
       return failure();                                                        \
     }                                                                          \
     result = builder.create<CLASS>(resultTy, operands, attrs);                 \


### PR DESCRIPTION
In FIRRTL, all expression operations have a `validate` hook which can be used to check operands and attributes before passing them in to `inferResultTypes`.  FIRParser will verify the same invariants right before calling `validate`, making it redundant.  Since `validate` is only called from the parser, we can delete the entire hook.