### PR TITLE
Bump LLVM to 8193832fb988e3df1e8e726634783805dca8d9b6.

### DIFF
--- a/lib/Conversion/DCToHW/DCToHW.cpp
+++ b/lib/Conversion/DCToHW/DCToHW.cpp
@@ -111,29 +111,27 @@ public:
   ESITypeConverter() {
     addConversion([](Type type) -> Type { return toESIHWType(type); });
     addConversion([](esi::ChannelType t) -> Type { return t; });
-    addTargetMaterialization(
-        [](mlir::OpBuilder &builder, mlir::Type resultType,
-           mlir::ValueRange inputs,
-           mlir::Location loc) -> std::optional<mlir::Value> {
-          if (inputs.size() != 1)
-            return std::nullopt;
+    addTargetMaterialization([](mlir::OpBuilder &builder, mlir::Type resultType,
+                                mlir::ValueRange inputs,
+                                mlir::Location loc) -> mlir::Value {
+      if (inputs.size() != 1)
+        return Value();
 
-          return builder
-              .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
-              ->getResult(0);
-        });
+      return builder
+          .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+          ->getResult(0);
+    });
 
-    addSourceMaterialization(
-        [](mlir::OpBuilder &builder, mlir::Type resultType,
-           mlir::ValueRange inputs,
-           mlir::Location loc) -> std::optional<mlir::Value> {
-          if (inputs.size() != 1)
-            return std::nullopt;
+    addSourceMaterialization([](mlir::OpBuilder &builder, mlir::Type resultType,
+                                mlir::ValueRange inputs,
+                                mlir::Location loc) -> mlir::Value {
+      if (inputs.size() != 1)
+        return Value();
 
-          return builder
-              .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
-              ->getResult(0);
-        });
+      return builder
+          .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+          ->getResult(0);
+    });
   }
 };
 

--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -387,27 +387,25 @@ HWArithToHWTypeConverter::HWArithToHWTypeConverter() {
   // Pass any type through the signedness remover.
   addConversion([this](Type type) { return removeSignedness(type); });
 
-  addTargetMaterialization(
-      [&](mlir::OpBuilder &builder, mlir::Type resultType,
-          mlir::ValueRange inputs,
-          mlir::Location loc) -> std::optional<mlir::Value> {
-        if (inputs.size() != 1)
-          return std::nullopt;
-        return builder
-            .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
-            ->getResult(0);
-      });
+  addTargetMaterialization([&](mlir::OpBuilder &builder, mlir::Type resultType,
+                               mlir::ValueRange inputs,
+                               mlir::Location loc) -> mlir::Value {
+    if (inputs.size() != 1)
+      return Value();
+    return builder
+        .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+        ->getResult(0);
+  });
 
-  addSourceMaterialization(
-      [&](mlir::OpBuilder &builder, mlir::Type resultType,
-          mlir::ValueRange inputs,
-          mlir::Location loc) -> std::optional<mlir::Value> {
-        if (inputs.size() != 1)
-          return std::nullopt;
-        return builder
-            .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
-            ->getResult(0);
-      });
+  addSourceMaterialization([&](mlir::OpBuilder &builder, mlir::Type resultType,
+                               mlir::ValueRange inputs,
+                               mlir::Location loc) -> mlir::Value {
+    if (inputs.size() != 1)
+      return Value();
+    return builder
+        .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+        ->getResult(0);
+  });
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
+++ b/lib/Conversion/HandshakeToDC/HandshakeToDC.cpp
@@ -75,49 +75,47 @@ public:
     addConversion([](ValueType type) { return type; });
     addConversion([](TokenType type) { return type; });
 
-    addTargetMaterialization(
-        [](mlir::OpBuilder &builder, mlir::Type resultType,
-           mlir::ValueRange inputs,
-           mlir::Location loc) -> std::optional<mlir::Value> {
-          if (inputs.size() != 1)
-            return std::nullopt;
+    addTargetMaterialization([](mlir::OpBuilder &builder, mlir::Type resultType,
+                                mlir::ValueRange inputs,
+                                mlir::Location loc) -> mlir::Value {
+      if (inputs.size() != 1)
+        return Value();
 
-          // Materialize !dc.value<> -> !dc.token
-          if (isa<dc::TokenType>(resultType) &&
-              isa<dc::ValueType>(inputs.front().getType()))
-            return unpack(builder, inputs.front()).token;
+      // Materialize !dc.value<> -> !dc.token
+      if (isa<dc::TokenType>(resultType) &&
+          isa<dc::ValueType>(inputs.front().getType()))
+        return unpack(builder, inputs.front()).token;
 
-          // Materialize !dc.token -> !dc.value<>
-          auto vt = dyn_cast<dc::ValueType>(resultType);
-          if (vt && !vt.getInnerType())
-            return pack(builder, inputs.front());
+      // Materialize !dc.token -> !dc.value<>
+      auto vt = dyn_cast<dc::ValueType>(resultType);
+      if (vt && !vt.getInnerType())
+        return pack(builder, inputs.front());
 
-          return builder
-              .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
-              ->getResult(0);
-        });
+      return builder
+          .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+          ->getResult(0);
+    });
 
-    addSourceMaterialization(
-        [](mlir::OpBuilder &builder, mlir::Type resultType,
-           mlir::ValueRange inputs,
-           mlir::Location loc) -> std::optional<mlir::Value> {
-          if (inputs.size() != 1)
-            return std::nullopt;
+    addSourceMaterialization([](mlir::OpBuilder &builder, mlir::Type resultType,
+                                mlir::ValueRange inputs,
+                                mlir::Location loc) -> mlir::Value {
+      if (inputs.size() != 1)
+        return Value();
 
-          // Materialize !dc.value<> -> !dc.token
-          if (isa<dc::TokenType>(resultType) &&
-              isa<dc::ValueType>(inputs.front().getType()))
-            return unpack(builder, inputs.front()).token;
+      // Materialize !dc.value<> -> !dc.token
+      if (isa<dc::TokenType>(resultType) &&
+          isa<dc::ValueType>(inputs.front().getType()))
+        return unpack(builder, inputs.front()).token;
 
-          // Materialize !dc.token -> !dc.value<>
-          auto vt = dyn_cast<dc::ValueType>(resultType);
-          if (vt && !vt.getInnerType())
-            return pack(builder, inputs.front());
+      // Materialize !dc.token -> !dc.value<>
+      auto vt = dyn_cast<dc::ValueType>(resultType);
+      if (vt && !vt.getInnerType())
+        return pack(builder, inputs.front());
 
-          return builder
-              .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
-              ->getResult(0);
-        });
+      return builder
+          .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+          ->getResult(0);
+    });
   }
 };
 

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -65,27 +65,25 @@ public:
   ESITypeConverter() {
     addConversion([](Type type) -> Type { return esiWrapper(type); });
 
-    addTargetMaterialization(
-        [&](mlir::OpBuilder &builder, mlir::Type resultType,
-            mlir::ValueRange inputs,
-            mlir::Location loc) -> std::optional<mlir::Value> {
-          if (inputs.size() != 1)
-            return std::nullopt;
-          return builder
-              .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
-              ->getResult(0);
-        });
+    addTargetMaterialization([&](mlir::OpBuilder &builder,
+                                 mlir::Type resultType, mlir::ValueRange inputs,
+                                 mlir::Location loc) -> mlir::Value {
+      if (inputs.size() != 1)
+        return Value();
+      return builder
+          .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+          ->getResult(0);
+    });
 
-    addSourceMaterialization(
-        [&](mlir::OpBuilder &builder, mlir::Type resultType,
-            mlir::ValueRange inputs,
-            mlir::Location loc) -> std::optional<mlir::Value> {
-          if (inputs.size() != 1)
-            return std::nullopt;
-          return builder
-              .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
-              ->getResult(0);
-        });
+    addSourceMaterialization([&](mlir::OpBuilder &builder,
+                                 mlir::Type resultType, mlir::ValueRange inputs,
+                                 mlir::Location loc) -> mlir::Value {
+      if (inputs.size() != 1)
+        return Value();
+      return builder
+          .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+          ->getResult(0);
+    });
   }
 };
 

--- a/lib/Conversion/LTLToCore/LTLToCore.cpp
+++ b/lib/Conversion/LTLToCore/LTLToCore.cpp
@@ -134,10 +134,9 @@ void LowerLTLToCorePass::runOnOperation() {
   // Basic materializations
   converter.addTargetMaterialization(
       [&](mlir::OpBuilder &builder, mlir::Type resultType,
-          mlir::ValueRange inputs,
-          mlir::Location loc) -> std::optional<mlir::Value> {
+          mlir::ValueRange inputs, mlir::Location loc) -> mlir::Value {
         if (inputs.size() != 1)
-          return std::nullopt;
+          return Value();
         return builder
             .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
             ->getResult(0);
@@ -145,10 +144,9 @@ void LowerLTLToCorePass::runOnOperation() {
 
   converter.addSourceMaterialization(
       [&](mlir::OpBuilder &builder, mlir::Type resultType,
-          mlir::ValueRange inputs,
-          mlir::Location loc) -> std::optional<mlir::Value> {
+          mlir::ValueRange inputs, mlir::Location loc) -> mlir::Value {
         if (inputs.size() != 1)
-          return std::nullopt;
+          return Value();
         return builder
             .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
             ->getResult(0);

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1441,10 +1441,9 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
 
   typeConverter.addTargetMaterialization(
       [&](mlir::OpBuilder &builder, mlir::Type resultType,
-          mlir::ValueRange inputs,
-          mlir::Location loc) -> std::optional<mlir::Value> {
+          mlir::ValueRange inputs, mlir::Location loc) -> mlir::Value {
         if (inputs.size() != 1 || !inputs[0])
-          return std::nullopt;
+          return Value();
         return builder
             .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
             .getResult(0);
@@ -1452,10 +1451,9 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
 
   typeConverter.addSourceMaterialization(
       [&](mlir::OpBuilder &builder, mlir::Type resultType,
-          mlir::ValueRange inputs,
-          mlir::Location loc) -> std::optional<mlir::Value> {
+          mlir::ValueRange inputs, mlir::Location loc) -> mlir::Value {
         if (inputs.size() != 1)
-          return std::nullopt;
+          return Value();
         return builder
             .create<UnrealizedConversionCastOp>(loc, resultType, inputs[0])
             ->getResult(0);

--- a/lib/Conversion/SeqToSV/SeqToSV.cpp
+++ b/lib/Conversion/SeqToSV/SeqToSV.cpp
@@ -405,29 +405,25 @@ struct SeqToSVTypeConverter : public TypeConverter {
       return arrayTy;
     });
 
-    addTargetMaterialization(
-        [&](mlir::OpBuilder &builder, mlir::Type resultType,
-            mlir::ValueRange inputs,
-            mlir::Location loc) -> std::optional<mlir::Value> {
-          if (inputs.size() != 1)
-            return std::nullopt;
-          return builder
-              .create<mlir::UnrealizedConversionCastOp>(loc, resultType,
-                                                        inputs[0])
-              ->getResult(0);
-        });
+    addTargetMaterialization([&](mlir::OpBuilder &builder,
+                                 mlir::Type resultType, mlir::ValueRange inputs,
+                                 mlir::Location loc) -> mlir::Value {
+      if (inputs.size() != 1)
+        return Value();
+      return builder
+          .create<mlir::UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+          ->getResult(0);
+    });
 
-    addSourceMaterialization(
-        [&](mlir::OpBuilder &builder, mlir::Type resultType,
-            mlir::ValueRange inputs,
-            mlir::Location loc) -> std::optional<mlir::Value> {
-          if (inputs.size() != 1)
-            return std::nullopt;
-          return builder
-              .create<mlir::UnrealizedConversionCastOp>(loc, resultType,
-                                                        inputs[0])
-              ->getResult(0);
-        });
+    addSourceMaterialization([&](mlir::OpBuilder &builder,
+                                 mlir::Type resultType, mlir::ValueRange inputs,
+                                 mlir::Location loc) -> mlir::Value {
+      if (inputs.size() != 1)
+        return Value();
+      return builder
+          .create<mlir::UnrealizedConversionCastOp>(loc, resultType, inputs[0])
+          ->getResult(0);
+    });
   }
 };
 

--- a/lib/Dialect/ESI/Passes/ESILowerTypes.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerTypes.cpp
@@ -53,21 +53,19 @@ public:
   }
 
 private:
-  static std::optional<mlir::Value> wrapMaterialization(OpBuilder &b,
-                                                        WindowType resultType,
-                                                        ValueRange inputs,
-                                                        Location loc) {
+  static mlir::Value wrapMaterialization(OpBuilder &b, WindowType resultType,
+                                         ValueRange inputs, Location loc) {
     if (inputs.size() != 1)
-      return std::nullopt;
+      return mlir::Value();
     auto wrap = b.create<WrapWindow>(loc, resultType, inputs[0]);
     return wrap.getWindow();
   }
 
-  static std::optional<mlir::Value>
-  unwrapMaterialization(OpBuilder &b, hw::UnionType resultType,
-                        ValueRange inputs, Location loc) {
+  static mlir::Value unwrapMaterialization(OpBuilder &b,
+                                           hw::UnionType resultType,
+                                           ValueRange inputs, Location loc) {
     if (inputs.size() != 1 || !isa<WindowType>(inputs[0].getType()))
-      return std::nullopt;
+      return mlir::Value();
     auto unwrap = b.create<UnwrapWindow>(loc, resultType, inputs[0]);
     return unwrap.getFrame();
   }


### PR DESCRIPTION
This is mostly a straightforward integration of LLVM. One minor change was that DialectConversion materializations have a slightly altered signature since
https://github.com/llvm/llvm-project/commit/f18c3e4e7335df282c468b6dff3d29be1822a96d.

The commit message includes this, but now we return `Value()` in the case where we previously returned `std::nullopt`. Otherwise, this should behave the same.