### PR TITLE
[MooreToCore] Add support for moore::string_constant #7628

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -555,6 +555,34 @@ struct ConstantOpConv : public OpConversionPattern<ConstantOp> {
   }
 };
 
+struct StringConstantOpConv : public OpConversionPattern<StringConstantOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(moore::StringConstantOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    const auto str = op.getValue();
+    const unsigned byteWidth = str.size() * 8;
+    const auto resultType =
+        typeConverter->convertType(op.getResult().getType());
+    if (const auto intType = mlir::dyn_cast<IntegerType>(resultType)) {
+      if (intType.getWidth() < byteWidth) {
+        return rewriter.notifyMatchFailure(op,
+                                           "invalid string constant type size");
+      }
+    } else {
+      return rewriter.notifyMatchFailure(op, "invalid string constant type");
+    }
+    APInt value(byteWidth, 0);
+    for (size_t i = 0; i < str.size(); ++i) {
+      const auto asciiChar = static_cast<uint8_t>(str[i]);
+      value |= APInt(byteWidth, asciiChar) << (8 * (str.size() - 1 - i));
+    }
+    rewriter.replaceOpWithNewOp<hw::ConstantOp>(
+        op, resultType, rewriter.getIntegerAttr(resultType, value));
+    return success();
+  }
+};
+
 struct ConcatOpConversion : public OpConversionPattern<ConcatOp> {
   using OpConversionPattern::OpConversionPattern;
   LogicalResult
@@ -1477,7 +1505,7 @@ static void populateOpConversion(RewritePatternSet &patterns,
     ConversionOpConversion, ReadOpConversion,
     StructExtractOpConversion, StructExtractRefOpConversion,
     ExtractRefOpConversion, StructCreateOpConversion, ConditionalOpConversion,
-    YieldOpConversion, OutputOpConversion,
+    YieldOpConversion, OutputOpConversion, StringConstantOpConv,
 
     // Patterns of unary operations.
     ReduceAndOpConversion, ReduceOrOpConversion, ReduceXorOpConversion,

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -868,3 +868,14 @@ moore.module @Assert(in %cond : !moore.l1)  {
   moore.return
   }
 }
+
+// CHECK-LABEL: hw.module @StringConstant
+moore.module @StringConstant() {
+  moore.procedure initial {
+    // CHECK: hw.constant 1415934836 : i32
+    %str = moore.string_constant "Test" : i32
+    // CHECK: hw.constant 0 : i0
+    %str_empty = moore.string_constant "" : i0
+    moore.return
+  }
+}

--- a/test/Conversion/MooreToCore/errors.mlir
+++ b/test/Conversion/MooreToCore/errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --convert-moore-to-core --split-input-file --verify-diagnostics
+// RUN: circt-opt %s --convert-moore-to-core --split-input-file --verify-diagnostics
 
 func.func @invalidType() {
   // expected-error @below {{failed to legalize operation 'moore.variable'}}

--- a/test/Conversion/MooreToCore/errors.mlir
+++ b/test/Conversion/MooreToCore/errors.mlir
@@ -6,3 +6,12 @@ func.func @invalidType() {
 
   return
 }
+
+// -----
+
+func.func @invalidStringContant() {
+  // expected-error @below {{failed to legalize operation 'moore.string_constant'}}
+  %str = moore.string_constant "Test" : i8
+
+  return
+}

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -302,6 +302,11 @@ moore.module @Expressions(
   // CHECK: moore.struct_inject [[STRUCT1]], "a", [[B]] : struct<{a: i32, b: i32}>, i32
   moore.struct_inject %struct1, "a", %b : struct<{a: i32, b: i32}>, i32
 
+  // CHECK: moore.string_constant "Test" : i128
+  moore.string_constant "Test" : i128
+  // CHECK: moore.string_constant "" : i128
+  moore.string_constant "" : i128
+
   moore.output
 }
 


### PR DESCRIPTION
Lower `StringConstantOp` to `hw::ConstantOp`. Encodes strings as `APInt` with byte-width based on string length, enabling representation of Moore string constant as bit vectors.
