### PR TITLE
[LTL] Canonicalize ltl.and to comb.and for i1 properties

### DIFF
--- a/include/circt/Dialect/LTL/LTLOps.td
+++ b/include/circt/Dialect/LTL/LTLOps.td
@@ -39,6 +39,7 @@ def AndOp : AssocLTLOp<"and"> {
     If any of the `$inputs` is of type `!ltl.property`, the result of the op is
     an `!ltl.property`. Otherwise it is an `!ltl.sequence`.
   }];
+  let hasCanonicalizeMethod = 1;
 }
 
 def OrOp : AssocLTLOp<"or"> {
@@ -47,6 +48,7 @@ def OrOp : AssocLTLOp<"or"> {
     If any of the `$inputs` is of type `!ltl.property`, the result of the op is
     an `!ltl.property`. Otherwise it is an `!ltl.sequence`.
   }];
+  let hasCanonicalizeMethod = 1;
 }
 
 def IntersectOp : AssocLTLOp<"intersect"> {
@@ -56,6 +58,7 @@ def IntersectOp : AssocLTLOp<"intersect"> {
     and have the same start and end times. This differs from `ltl.and` which doesn't 
     consider the timings of each operand, only their results. 
   }];
+  let hasCanonicalizeMethod = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/LTL/LTLFolds.cpp
+++ b/lib/Dialect/LTL/LTLFolds.cpp
@@ -47,6 +47,35 @@ namespace patterns {
 } // namespace patterns
 
 //===----------------------------------------------------------------------===//
+// AndOp / OrOp / IntersectOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult AndOp::canonicalize(AndOp op, PatternRewriter &rewriter) {
+  if (op.getType() == rewriter.getI1Type()) {
+    rewriter.replaceOpWithNewOp<comb::AndOp>(op, op.getInputs(), true);
+    return success();
+  }
+  return failure();
+}
+
+LogicalResult OrOp::canonicalize(OrOp op, PatternRewriter &rewriter) {
+  if (op.getType() == rewriter.getI1Type()) {
+    rewriter.replaceOpWithNewOp<comb::OrOp>(op, op.getInputs(), true);
+    return success();
+  }
+  return failure();
+}
+
+LogicalResult IntersectOp::canonicalize(IntersectOp op,
+                                        PatternRewriter &rewriter) {
+  if (op.getType() == rewriter.getI1Type()) {
+    rewriter.replaceOpWithNewOp<comb::AndOp>(op, op.getInputs(), true);
+    return success();
+  }
+  return failure();
+}
+
+//===----------------------------------------------------------------------===//
 // DelayOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/LTL/LTLOps.cpp
+++ b/lib/Dialect/LTL/LTLOps.cpp
@@ -33,9 +33,12 @@ static LogicalResult inferAndLikeReturnTypes(MLIRContext *context,
         return isa<PropertyType>(operand.getType());
       })) {
     results.push_back(PropertyType::get(context));
-  } else {
-
+  } else if (llvm::any_of(operands, [](auto operand) {
+               return isa<SequenceType>(operand.getType());
+             })) {
     results.push_back(SequenceType::get(context));
+  } else {
+    results.push_back(IntegerType::get(context, 1));
   }
   return success();
 }

--- a/test/Dialect/LTL/basic.mlir
+++ b/test/Dialect/LTL/basic.mlir
@@ -38,7 +38,7 @@ ltl.or %p, %p : !ltl.property, !ltl.property
 %p1 = ltl.and %p, %true : !ltl.property, i1
 %p2 = ltl.and %s, %p : !ltl.sequence, !ltl.property
 %p3 = ltl.and %p, %s : !ltl.property, !ltl.sequence
-unrealized_conversion_cast %s0 : !ltl.sequence to index
+unrealized_conversion_cast %s0 : i1 to index
 unrealized_conversion_cast %s1 : !ltl.sequence to index
 unrealized_conversion_cast %s2 : !ltl.sequence to index
 unrealized_conversion_cast %p0 : !ltl.property to index

--- a/test/Dialect/LTL/canonicalization.mlir
+++ b/test/Dialect/LTL/canonicalization.mlir
@@ -128,3 +128,18 @@ func.func @NonConsecutiveRepeatFolds(%arg0: !ltl.sequence) {
 
   return
 }
+
+// CHECK-LABEL: @CanonicalizeToComb
+func.func @CanonicalizeToComb(%arg0: i1, %arg1: i1, %arg2: i1) {
+  // CHECK-NEXT: comb.and bin %arg0, %arg1, %arg2 : i1
+  %0 = ltl.and %arg0, %arg1, %arg2 : i1, i1, i1
+  // CHECK-NEXT: comb.or bin %arg0, %arg1, %arg2 : i1
+  %1 = ltl.or %arg0, %arg1, %arg2 : i1, i1, i1
+  // CHECK-NEXT: comb.and bin %arg0, %arg1, %arg2 : i1
+  %2 = ltl.intersect %arg0, %arg1, %arg2 : i1, i1, i1
+
+  call @Bool(%0) : (i1) -> ()
+  call @Bool(%1) : (i1) -> ()
+  call @Bool(%2) : (i1) -> ()
+  return
+}


### PR DESCRIPTION
Extend `ltl.and`, `ltl.or`, and `ltl.intersect` to infer their return type as `i1` if all operands are `i1`. Also add a canonicalization method that replaces these ops with `comb.and` and `comb.or` if they operate entirely on `i1`.