### PR TITLE
[FIRRTL] Fix folding of when conditions into LTL properties

### DIFF
--- a/include/circt/Dialect/LTL/LTLOps.td
+++ b/include/circt/Dialect/LTL/LTLOps.td
@@ -39,6 +39,7 @@ def AndOp : AssocLTLOp<"and"> {
     If any of the `$inputs` is of type `!ltl.property`, the result of the op is
     an `!ltl.property`. Otherwise it is an `!ltl.sequence`.
   }];
+  let hasCanonicalizeMethod = 1;
 }
 
 def OrOp : AssocLTLOp<"or"> {
@@ -47,6 +48,7 @@ def OrOp : AssocLTLOp<"or"> {
     If any of the `$inputs` is of type `!ltl.property`, the result of the op is
     an `!ltl.property`. Otherwise it is an `!ltl.sequence`.
   }];
+  let hasCanonicalizeMethod = 1;
 }
 
 def IntersectOp : AssocLTLOp<"intersect"> {
@@ -56,6 +58,7 @@ def IntersectOp : AssocLTLOp<"intersect"> {
     and have the same start and end times. This differs from `ltl.and` which doesn't 
     consider the timings of each operand, only their results. 
   }];
+  let hasCanonicalizeMethod = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/LTL/LTLFolds.cpp
+++ b/lib/Dialect/LTL/LTLFolds.cpp
@@ -47,6 +47,35 @@ namespace patterns {
 } // namespace patterns
 
 //===----------------------------------------------------------------------===//
+// AndOp / OrOp / IntersectOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult AndOp::canonicalize(AndOp op, PatternRewriter &rewriter) {
+  if (op.getType() == rewriter.getI1Type()) {
+    rewriter.replaceOpWithNewOp<comb::AndOp>(op, op.getInputs(), true);
+    return success();
+  }
+  return failure();
+}
+
+LogicalResult OrOp::canonicalize(OrOp op, PatternRewriter &rewriter) {
+  if (op.getType() == rewriter.getI1Type()) {
+    rewriter.replaceOpWithNewOp<comb::OrOp>(op, op.getInputs(), true);
+    return success();
+  }
+  return failure();
+}
+
+LogicalResult IntersectOp::canonicalize(IntersectOp op,
+                                        PatternRewriter &rewriter) {
+  if (op.getType() == rewriter.getI1Type()) {
+    rewriter.replaceOpWithNewOp<comb::AndOp>(op, op.getInputs(), true);
+    return success();
+  }
+  return failure();
+}
+
+//===----------------------------------------------------------------------===//
 // DelayOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/LTL/LTLOps.cpp
+++ b/lib/Dialect/LTL/LTLOps.cpp
@@ -33,9 +33,12 @@ static LogicalResult inferAndLikeReturnTypes(MLIRContext *context,
         return isa<PropertyType>(operand.getType());
       })) {
     results.push_back(PropertyType::get(context));
-  } else {
-
+  } else if (llvm::any_of(operands, [](auto operand) {
+               return isa<SequenceType>(operand.getType());
+             })) {
     results.push_back(SequenceType::get(context));
+  } else {
+    results.push_back(IntegerType::get(context, 1));
   }
   return success();
 }

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -650,70 +650,62 @@ firrtl.module @ModuleWithObjectWire(in %in: !firrtl.class<@ClassWithInput(in in:
   firrtl.propassign %0, %in : !firrtl.class<@ClassWithInput(in in: !firrtl.string)>
 }
 
-// Test all verif assert/assume/cover constructs
-// CHECK-LABEL: firrtl.module @verifassert
-firrtl.module @verifassert(
-  in %clock : !firrtl.clock, in %cond : !firrtl.uint<1>, in %prop : !firrtl.uint<1>, in %prop1 : !firrtl.uint<1>,
-  in %enable : !firrtl.uint<1>, in %enable1 : !firrtl.uint<1>, in %reset : !firrtl.uint<1>
+// Conditions of when blocks should be folded into the LHS of implications in
+// assert/assume ops, or int othe LHS of ands in cover ops.
+// CHECK-LABEL: firrtl.module @WhenAroundPropertyAssertAssumeCover
+firrtl.module @WhenAroundPropertyAssertAssumeCover(
+  in %clock: !firrtl.clock,
+  in %a: !firrtl.uint<1>,
+  in %b: !firrtl.uint<1>,
+  in %c: !firrtl.uint<1>,
+  in %d: !firrtl.uint<1>
 ) {
-  firrtl.when %cond : !firrtl.uint<1> {
-    // CHECK: [[TMP2A:%.+]] = firrtl.int.ltl.clock %prop, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
-    // CHECK: [[TMP0A:%.+]] = firrtl.int.ltl.implication %cond, [[TMP2A]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK: firrtl.int.verif.assert [[TMP0A]], %enable : !firrtl.uint<1>, !firrtl.uint<1>
-    %clk_prop = firrtl.int.ltl.clock %prop, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+  // b |-> c
+  // CHECK: [[P0:%.+]] = firrtl.int.ltl.implication %b, %c :
+  %0 = firrtl.int.ltl.implication %b, %c : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %p0 = firrtl.node interesting_name %0 : !firrtl.uint<1>
+  // @(posedge clock) b |-> c
+  %1 = firrtl.int.ltl.clock %p0, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
+  %p1 = firrtl.node interesting_name %1 : !firrtl.uint<1>
 
-    firrtl.int.verif.assert %clk_prop, %enable  : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK-NOT: firrtl.when
+  firrtl.when %a : !firrtl.uint<1> {
+    // CHECK: [[TMP1:%.+]] = firrtl.int.ltl.and %a, %b
+    // CHECK: [[TMP2:%.+]] = firrtl.int.ltl.implication [[TMP1]], %c
+    // CHECK: [[TMP3:%.+]] = firrtl.int.ltl.clock [[TMP2]], %clock
+    // CHECK: firrtl.int.verif.assert [[TMP3]], %d :
+    // CHECK: firrtl.int.verif.assert [[TMP3]] :
+    // CHECK: firrtl.int.verif.assume [[TMP3]], %d :
+    // CHECK: firrtl.int.verif.assume [[TMP3]] :
+    firrtl.int.verif.assert %p1, %d : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.int.verif.assert %p1 : !firrtl.uint<1>
+    firrtl.int.verif.assume %p1, %d : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.int.verif.assume %p1 : !firrtl.uint<1>
+    // CHECK: [[TMP1:%.+]] = firrtl.int.ltl.and %a, [[P0]]
+    // CHECK: [[TMP2:%.+]] = firrtl.int.ltl.clock [[TMP1]], %clock
+    // CHECK: firrtl.int.verif.cover [[TMP2]], %d :
+    // CHECK: firrtl.int.verif.cover [[TMP2]] :
+    firrtl.int.verif.cover %p1, %d : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.int.verif.cover %p1 : !firrtl.uint<1>
   } else {
-    // CHECK: [[TMP3A:%.+]] = firrtl.not %cond : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK: [[TMP6A:%.+]] = firrtl.int.ltl.clock %prop1, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
-    // CHECK: [[TMP4A:%.+]] = firrtl.int.ltl.implication [[TMP3A]], [[TMP6A]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK: firrtl.int.verif.assert [[TMP4A]], %enable1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %clk_prop = firrtl.int.ltl.clock %prop1, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
-    firrtl.int.verif.assert %clk_prop, %enable1 : !firrtl.uint<1>, !firrtl.uint<1>
-  }
-}
-
-// CHECK-LABEL: firrtl.module @verifassume
-firrtl.module @verifassume(
-  in %clock : !firrtl.clock, in %cond : !firrtl.uint<1>, in %prop : !firrtl.uint<1>, in %prop1 : !firrtl.uint<1>,
-  in %enable : !firrtl.uint<1>, in %enable1 : !firrtl.uint<1>, in %reset : !firrtl.uint<1>
-) {
-  firrtl.when %cond : !firrtl.uint<1> {
-    // CHECK: [[TMP2A:%.+]] = firrtl.int.ltl.clock %prop, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
-    // CHECK: [[TMP0A:%.+]] = firrtl.int.ltl.implication %cond, [[TMP2A]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK: firrtl.int.verif.assume [[TMP0A]], %enable : !firrtl.uint<1>, !firrtl.uint<1>
-    %clk_prop = firrtl.int.ltl.clock %prop, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
-
-    firrtl.int.verif.assume %clk_prop, %enable  : !firrtl.uint<1>, !firrtl.uint<1>
-  } else {
-    // CHECK: [[TMP3A:%.+]] = firrtl.not %cond : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK: [[TMP6A:%.+]] = firrtl.int.ltl.clock %prop1, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
-    // CHECK: [[TMP4A:%.+]] = firrtl.int.ltl.implication [[TMP3A]], [[TMP6A]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK: firrtl.int.verif.assume [[TMP4A]], %enable1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %clk_prop = firrtl.int.ltl.clock %prop1, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
-    firrtl.int.verif.assume %clk_prop, %enable1 : !firrtl.uint<1>, !firrtl.uint<1>
-  }
-}
-
-// CHECK-LABEL: firrtl.module @verifcover
-firrtl.module @verifcover(
-  in %clock : !firrtl.clock, in %cond : !firrtl.uint<1>, in %prop : !firrtl.uint<1>, in %prop1 : !firrtl.uint<1>,
-  in %enable : !firrtl.uint<1>, in %enable1 : !firrtl.uint<1>, in %reset : !firrtl.uint<1>
-) {
-  firrtl.when %cond : !firrtl.uint<1> {
-    // CHECK: [[TMP2A:%.+]] = firrtl.int.ltl.clock %prop, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
-    // CHECK: [[TMP0A:%.+]] = firrtl.int.ltl.and %cond, [[TMP2A]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK: firrtl.int.verif.cover [[TMP0A]], %enable : !firrtl.uint<1>, !firrtl.uint<1>
-    %clk_prop = firrtl.int.ltl.clock %prop, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
-
-    firrtl.int.verif.cover %clk_prop, %enable  : !firrtl.uint<1>, !firrtl.uint<1>
-  } else {
-    // CHECK: [[TMP3A:%.+]] = firrtl.not %cond : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK: [[TMP6A:%.+]] = firrtl.int.ltl.clock %prop1, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
-    // CHECK: [[TMP4A:%.+]] = firrtl.int.ltl.and [[TMP3A]], [[TMP6A]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    // CHECK: firrtl.int.verif.cover [[TMP4A]], %enable1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %clk_prop = firrtl.int.ltl.clock %prop1, %clock : (!firrtl.uint<1>, !firrtl.clock) -> !firrtl.uint<1>
-    firrtl.int.verif.cover %clk_prop, %enable1 : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK: [[NOTA:%.+]] = firrtl.not %a
+    // CHECK: [[TMP1:%.+]] = firrtl.int.ltl.and [[NOTA]], %b
+    // CHECK: [[TMP2:%.+]] = firrtl.int.ltl.implication [[TMP1]], %c
+    // CHECK: [[TMP3:%.+]] = firrtl.int.ltl.clock [[TMP2]], %clock
+    // CHECK: firrtl.int.verif.assert [[TMP3]], %d :
+    // CHECK: firrtl.int.verif.assert [[TMP3]] :
+    // CHECK: firrtl.int.verif.assume [[TMP3]], %d :
+    // CHECK: firrtl.int.verif.assume [[TMP3]] :
+    firrtl.int.verif.assert %p1, %d : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.int.verif.assert %p1 : !firrtl.uint<1>
+    firrtl.int.verif.assume %p1, %d : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.int.verif.assume %p1 : !firrtl.uint<1>
+    // CHECK: [[TMP1:%.+]] = firrtl.int.ltl.and [[NOTA]], [[P0]]
+    // CHECK: [[TMP2:%.+]] = firrtl.int.ltl.clock [[TMP1]], %clock
+    // CHECK: firrtl.int.verif.cover [[TMP2]], %d :
+    // CHECK: firrtl.int.verif.cover [[TMP2]] :
+    firrtl.int.verif.cover %p1, %d : !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.int.verif.cover %p1 : !firrtl.uint<1>
   }
 }
 

--- a/test/Dialect/LTL/basic.mlir
+++ b/test/Dialect/LTL/basic.mlir
@@ -38,7 +38,7 @@ ltl.or %p, %p : !ltl.property, !ltl.property
 %p1 = ltl.and %p, %true : !ltl.property, i1
 %p2 = ltl.and %s, %p : !ltl.sequence, !ltl.property
 %p3 = ltl.and %p, %s : !ltl.property, !ltl.sequence
-unrealized_conversion_cast %s0 : !ltl.sequence to index
+unrealized_conversion_cast %s0 : i1 to index
 unrealized_conversion_cast %s1 : !ltl.sequence to index
 unrealized_conversion_cast %s2 : !ltl.sequence to index
 unrealized_conversion_cast %p0 : !ltl.property to index

--- a/test/Dialect/LTL/canonicalization.mlir
+++ b/test/Dialect/LTL/canonicalization.mlir
@@ -128,3 +128,18 @@ func.func @NonConsecutiveRepeatFolds(%arg0: !ltl.sequence) {
 
   return
 }
+
+// CHECK-LABEL: @CanonicalizeToComb
+func.func @CanonicalizeToComb(%arg0: i1, %arg1: i1, %arg2: i1) {
+  // CHECK-NEXT: comb.and bin %arg0, %arg1, %arg2 : i1
+  %0 = ltl.and %arg0, %arg1, %arg2 : i1, i1, i1
+  // CHECK-NEXT: comb.or bin %arg0, %arg1, %arg2 : i1
+  %1 = ltl.or %arg0, %arg1, %arg2 : i1, i1, i1
+  // CHECK-NEXT: comb.and bin %arg0, %arg1, %arg2 : i1
+  %2 = ltl.intersect %arg0, %arg1, %arg2 : i1, i1, i1
+
+  call @Bool(%0) : (i1) -> ()
+  call @Bool(%1) : (i1) -> ()
+  call @Bool(%2) : (i1) -> ()
+  return
+}

--- a/test/firtool/verif-under-when.fir
+++ b/test/firtool/verif-under-when.fir
@@ -1,0 +1,59 @@
+; RUN: firtool %s | FileCheck %s
+FIRRTL version 4.0.0
+
+circuit Foo :
+  public module Foo :
+    input clock : Clock
+    input a : UInt<1>
+    input b : UInt<1>
+    input c : UInt<1>
+    input d : UInt<1>
+
+    ; b |-> c
+    node p0 = intrinsic(circt_ltl_implication : UInt<1>, b, c)
+    ; @(posedge clock) b |-> c
+    node p1 = intrinsic(circt_ltl_clock : UInt<1>, p0, clock)
+
+    when a :
+      ; CHECK: assert property (@(posedge clock) disable iff (d) a & b |-> c);
+      ; CHECK: assume property (@(posedge clock) disable iff (d) a & b |-> c);
+      ; CHECK: cover property (@(posedge clock) disable iff (d) a and (b |-> c));
+      intrinsic(circt_verif_assert, p1, not(d))
+      intrinsic(circt_verif_assume, p1, not(d))
+      intrinsic(circt_verif_cover, p1, not(d))
+
+      ; CHECK: assert property (@(posedge clock) a & b |-> c);
+      ; CHECK: assume property (@(posedge clock) a & b |-> c);
+      ; CHECK: cover property (@(posedge clock) a and (b |-> c));
+      intrinsic(circt_verif_assert, p1)
+      intrinsic(circt_verif_assume, p1)
+      intrinsic(circt_verif_cover, p1)
+
+    else :
+      ; CHECK: assert property (@(posedge clock) disable iff (d) ~a & b |-> c);
+      ; CHECK: assume property (@(posedge clock) disable iff (d) ~a & b |-> c);
+      ; CHECK: cover property (@(posedge clock) disable iff (d) ~a and (b |-> c));
+      intrinsic(circt_verif_assert, p1, not(d))
+      intrinsic(circt_verif_assume, p1, not(d))
+      intrinsic(circt_verif_cover, p1, not(d))
+
+      ; CHECK: assert property (@(posedge clock) ~a & b |-> c);
+      ; CHECK: assume property (@(posedge clock) ~a & b |-> c);
+      ; CHECK: cover property (@(posedge clock) ~a and (b |-> c));
+      intrinsic(circt_verif_assert, p1)
+      intrinsic(circt_verif_assume, p1)
+      intrinsic(circt_verif_cover, p1)
+
+    ; CHECK: assert property (@(posedge clock) disable iff (d) b |-> c);
+    ; CHECK: assume property (@(posedge clock) disable iff (d) b |-> c);
+    ; CHECK: cover property (@(posedge clock) disable iff (d) b |-> c);
+    intrinsic(circt_verif_assert, p1, not(d))
+    intrinsic(circt_verif_assume, p1, not(d))
+    intrinsic(circt_verif_cover, p1, not(d))
+
+    ; CHECK: assert property (@(posedge clock) b |-> c);
+    ; CHECK: assume property (@(posedge clock) b |-> c);
+    ; CHECK: cover property (@(posedge clock) b |-> c);
+    intrinsic(circt_verif_assert, p1)
+    intrinsic(circt_verif_assume, p1)
+    intrinsic(circt_verif_cover, p1)


### PR DESCRIPTION
Make ExpandWhen's folding of the when condition into LTL properties work for more inputs. This used to be very brittle and the condition would be mapped to a new implication around the entire property:

    when (a):
      assert(@(posedge clock) b |-> c)

used to become

    assert(a |-> @(posedge clock) b |-> c)

This commit improves on this by always pushing implications behind clocks, and by merging implications like `a |-> b |-> c` into a single `(a & b) |-> c`. As a result, ExpandWhens now produces the following output, which is more in line with what users expect:

    assert(@(posedge clock) a & b |-> c)

Also add a FIR-to-Verilog test to nail this behavior down and ensure we don't regress on user expectations.