### PR TITLE
[Calyx] Sequential memory support floating point operations

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -150,7 +150,7 @@ def MemoryOp : CalyxPrimitive<"memory", []> {
   );
 
   let results = (outs
-    Variadic<AnySignlessInteger>:$results
+    Variadic<AnyTypeOf<[AnySignlessInteger, AnyFloat]>>:$results
   );
 
   let assemblyFormat = [{
@@ -220,7 +220,7 @@ def SeqMemoryOp : CalyxPrimitive<"seq_mem", []> {
   );
 
   let results = (outs
-    Variadic<AnySignlessInteger>:$results
+    Variadic<AnyTypeOf<[AnySignlessInteger, AnyFloat]>>:$results
   );
 
   let assemblyFormat = [{
@@ -233,6 +233,12 @@ def SeqMemoryOp : CalyxPrimitive<"seq_mem", []> {
     OpBuilder<(ins
       "StringRef":$sym_name,
       "int64_t":$width,
+      "ArrayRef<int64_t>":$sizes,
+      "ArrayRef<int64_t>":$addrSizes
+    )>,
+    OpBuilder<(ins
+      "StringRef":$sym_name,
+      "Type":$type,
       "ArrayRef<int64_t>":$sizes,
       "ArrayRef<int64_t>":$addrSizes
     )>

--- a/include/circt/Dialect/Calyx/CalyxPrimitives.td
+++ b/include/circt/Dialect/Calyx/CalyxPrimitives.td
@@ -232,12 +232,6 @@ def SeqMemoryOp : CalyxPrimitive<"seq_mem", []> {
   let builders = [
     OpBuilder<(ins
       "StringRef":$sym_name,
-      "int64_t":$width,
-      "ArrayRef<int64_t>":$sizes,
-      "ArrayRef<int64_t>":$addrSizes
-    )>,
-    OpBuilder<(ins
-      "StringRef":$sym_name,
       "Type":$type,
       "ArrayRef<int64_t>":$sizes,
       "ArrayRef<int64_t>":$addrSizes

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -570,17 +570,10 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
     // for sequential memories will cause a read to take at least 2 cycles,
     // but it will usually be better because combinational reads on memories
     // can significantly decrease the maximum achievable frequency.
-    calyx::RegisterOp reg;
-    if (isa<IntegerType>(loadOp.getMemRefType()))
-      reg = createRegister(
-          loadOp.getLoc(), rewriter, getComponent(),
-          loadOp.getMemRefType().getElementTypeBitWidth(),
-          getState<ComponentLoweringState>().getUniqueName("load"));
-    else
-      reg = createRegister(
-          loadOp.getLoc(), rewriter, getComponent(),
-          loadOp.getMemRefType().getElementType(),
-          getState<ComponentLoweringState>().getUniqueName("load"));
+    calyx::RegisterOp reg = createRegister(
+        loadOp.getLoc(), rewriter, getComponent(),
+        loadOp.getMemRefType().getElementType(),
+        getState<ComponentLoweringState>().getUniqueName("load"));
     rewriter.setInsertionPointToEnd(group.getBodyBlock());
     rewriter.create<calyx::AssignOp>(loadOp.getLoc(), reg.getIn(),
                                      memoryInterface.readData());
@@ -724,15 +717,9 @@ static LogicalResult buildAllocOp(ComponentLoweringState &componentState,
     sizes.push_back(1);
     addrSizes.push_back(1);
   }
-  calyx::SeqMemoryOp memoryOp;
-  if (isa<IntegerType>(memtype.getElementType()))
-    memoryOp = rewriter.create<calyx::SeqMemoryOp>(
-        allocOp.getLoc(), componentState.getUniqueName("mem"),
-        memtype.getElementType().getIntOrFloatBitWidth(), sizes, addrSizes);
-  else
-    memoryOp = rewriter.create<calyx::SeqMemoryOp>(
-        allocOp.getLoc(), componentState.getUniqueName("mem"),
-        memtype.getElementType(), sizes, addrSizes);
+  calyx::SeqMemoryOp memoryOp = rewriter.create<calyx::SeqMemoryOp>(
+      allocOp.getLoc(), componentState.getUniqueName("mem"),
+      memtype.getElementType(), sizes, addrSizes);
   // Externalize memories by default. This makes it easier for the native
   // compiler to provide initialized memories.
   memoryOp->setAttr("external",

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -2208,27 +2208,6 @@ SmallVector<DictionaryAttr> SeqMemoryOp::portAttributes() {
 }
 
 void SeqMemoryOp::build(OpBuilder &builder, OperationState &state,
-                        StringRef instanceName, int64_t width,
-                        ArrayRef<int64_t> sizes, ArrayRef<int64_t> addrSizes) {
-  state.addAttribute(SymbolTable::getSymbolAttrName(),
-                     builder.getStringAttr(instanceName));
-  state.addAttribute("width", builder.getI64IntegerAttr(width));
-  state.addAttribute("sizes", builder.getI64ArrayAttr(sizes));
-  state.addAttribute("addrSizes", builder.getI64ArrayAttr(addrSizes));
-  SmallVector<Type> types;
-  for (int64_t size : addrSizes)
-    types.push_back(builder.getIntegerType(size)); // Addresses
-  types.push_back(builder.getI1Type());            // Clk
-  types.push_back(builder.getI1Type());            // Reset
-  types.push_back(builder.getI1Type());            // Content enable
-  types.push_back(builder.getI1Type());            // Write enable
-  types.push_back(builder.getIntegerType(width));  // Write data
-  types.push_back(builder.getIntegerType(width));  // Read data
-  types.push_back(builder.getI1Type());            // Done
-  state.addTypes(types);
-}
-
-void SeqMemoryOp::build(OpBuilder &builder, OperationState &state,
                         StringRef instanceName, Type type,
                         ArrayRef<int64_t> sizes, ArrayRef<int64_t> addrSizes) {
   state.addAttribute(SymbolTable::getSymbolAttrName(),

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -2228,6 +2228,28 @@ void SeqMemoryOp::build(OpBuilder &builder, OperationState &state,
   state.addTypes(types);
 }
 
+void SeqMemoryOp::build(OpBuilder &builder, OperationState &state,
+                        StringRef instanceName, Type type,
+                        ArrayRef<int64_t> sizes, ArrayRef<int64_t> addrSizes) {
+  state.addAttribute(SymbolTable::getSymbolAttrName(),
+                     builder.getStringAttr(instanceName));
+  int64_t width = type.getIntOrFloatBitWidth();
+  state.addAttribute("width", builder.getI64IntegerAttr(width));
+  state.addAttribute("sizes", builder.getI64ArrayAttr(sizes));
+  state.addAttribute("addrSizes", builder.getI64ArrayAttr(addrSizes));
+  SmallVector<Type> types;
+  for (int64_t size : addrSizes)
+    types.push_back(builder.getIntegerType(size)); // Addresses
+  types.push_back(builder.getI1Type());            // Clk
+  types.push_back(builder.getI1Type());            // Reset
+  types.push_back(builder.getI1Type());            // Content enable
+  types.push_back(builder.getI1Type());            // Write enable
+  types.push_back(type);                           // Write data
+  types.push_back(type);                           // Read data
+  types.push_back(builder.getI1Type());            // Done
+  state.addTypes(types);
+}
+
 LogicalResult SeqMemoryOp::verify() {
   ArrayRef<Attribute> opSizes = getSizes().getValue();
   ArrayRef<Attribute> opAddrSizes = getAddrSizes().getValue();

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -723,3 +723,40 @@ module {
   }
 }
 
+// -----
+
+module {
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:.*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_4:.*]] = hw.constant true
+// CHECK:           %[[VAL_5:.*]] = hw.constant 1 : i32
+// CHECK:           %[[VAL_6:.*]] = calyx.constant {sym_name = "cst_0"} 1.200000e+00 : f32
+// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = calyx.std_slice @std_slice_0 : i32, i3
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.seq_mem @mem_0 <[5] x 32> [3] {external = true} : i3, i1, i1, i1, i1, f32, f32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.group @bb0_0 {
+// CHECK:               calyx.assign %[[VAL_7]] = %[[VAL_5]] : i32
+// CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_8]] : i3
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_6]] : f32
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_4]] : i1
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_4]] : i1
+// CHECK:               calyx.group_done %[[VAL_16]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.enable @bb0_0
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
+  func.func @main() {
+    %c1 = arith.constant 1 : index
+    %0 = memref.alloc() : memref<5xf32>
+    %1 = arith.constant 1.2 : f32
+    memref.store %1, %0[%c1] : memref<5xf32>
+    return
+  }
+}


### PR DESCRIPTION
This patch supports floating point operations with SeqMemory in SCFToCalyx.