### PR TITLE
[FIRRTL] Add new ModulePrefixAnnotation

### DIFF
--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -205,6 +205,9 @@ constexpr const char *wiringSourceAnnoClass =
 // Attribute annotations.
 constexpr const char *attributeAnnoClass = "firrtl.AttributeAnnotation";
 
+// Module Prefix Annotations.
+constexpr const char *modulePrefixAnnoClass = "chisel3.ModulePrefixAnnotation";
+
 } // namespace firrtl
 } // namespace circt
 

--- a/include/circt/Dialect/FIRRTL/CHIRRTLOps.td
+++ b/include/circt/Dialect/FIRRTL/CHIRRTLOps.td
@@ -40,7 +40,8 @@ def CombMemOp : CHIRRTLOp<"combmem", [HasCustomSSAName, DeclareOpInterfaceMethod
   let arguments = (ins StrAttr:$name, NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations,
                        OptionalAttr<InnerSymAttr>:$inner_sym,
-                       OptionalAttr<MemoryInitAttr>:$init);
+                       OptionalAttr<MemoryInitAttr>:$init,
+                       OptionalAttr<StrAttr>:$prefix);
   let results = (outs CMemoryType:$result);
   let assemblyFormat = [{(`sym` $inner_sym^)? `` custom<NameKind>($nameKind)
                          `` custom<CombMemOp>(attr-dict) `:` qualified(type($result))}];
@@ -62,7 +63,8 @@ def SeqMemOp : CHIRRTLOp<"seqmem", [HasCustomSSAName, DeclareOpInterfaceMethods<
   let arguments = (ins RUWAttr:$ruw, StrAttr:$name, NameKindAttr:$nameKind,
                        AnnotationArrayAttr:$annotations,
                        OptionalAttr<InnerSymAttr>:$inner_sym,
-                       OptionalAttr<MemoryInitAttr>:$init);
+                       OptionalAttr<MemoryInitAttr>:$init,
+                       OptionalAttr<StrAttr>:$prefix);
   let results = (outs CMemoryType:$result);
   let assemblyFormat = [{(`sym` $inner_sym^)? `` custom<NameKind>($nameKind) $ruw
                          custom<SeqMemOp>(attr-dict) `:` qualified(type($result))}];

--- a/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
+++ b/lib/Dialect/FIRRTL/CHIRRTLDialect.cpp
@@ -256,7 +256,8 @@ void CombMemOp::build(OpBuilder &builder, OperationState &result,
   build(builder, result,
         CMemoryType::get(builder.getContext(), elementType, numElements), name,
         nameKind, annotations,
-        innerSym ? hw::InnerSymAttr::get(innerSym) : hw::InnerSymAttr(), init);
+        innerSym ? hw::InnerSymAttr::get(innerSym) : hw::InnerSymAttr(), init,
+        {});
 }
 
 void CombMemOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
@@ -290,7 +291,8 @@ void SeqMemOp::build(OpBuilder &builder, OperationState &result,
   build(builder, result,
         CMemoryType::get(builder.getContext(), elementType, numElements), ruw,
         name, nameKind, annotations,
-        innerSym ? hw::InnerSymAttr::get(innerSym) : hw::InnerSymAttr(), init);
+        innerSym ? hw::InnerSymAttr::get(innerSym) : hw::InnerSymAttr(), init,
+        {});
 }
 
 void SeqMemOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
@@ -358,14 +358,14 @@ void LowerCHIRRTLPass::replaceMem(Operation *cmem, StringRef name,
   // Create the memory.
   ImplicitLocOpBuilder memBuilder(cmem->getLoc(), cmem);
   auto symOp = cast<hw::InnerSymbolOpInterface>(cmem);
-  auto prefixAttr = cmem->getAttrOfType<StringAttr>("prefix");
   auto memory = memBuilder.create<MemOp>(
       resultTypes, readLatency, writeLatency, depth, ruw,
       memBuilder.getArrayAttr(resultNames), name,
       cmem->getAttrOfType<firrtl::NameKindEnumAttr>("nameKind").getValue(),
       annotations, memBuilder.getArrayAttr(portAnnotations),
       symOp.getInnerSymAttr(),
-      cmem->getAttrOfType<firrtl::MemoryInitAttr>("init"), prefixAttr);
+      cmem->getAttrOfType<firrtl::MemoryInitAttr>("init"),
+      cmem->getAttrOfType<StringAttr>("prefix"));
   ++numCreatedMems;
 
   // Process each memory port, initializing the memory port and inferring when

--- a/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerCHIRRTL.cpp
@@ -358,13 +358,14 @@ void LowerCHIRRTLPass::replaceMem(Operation *cmem, StringRef name,
   // Create the memory.
   ImplicitLocOpBuilder memBuilder(cmem->getLoc(), cmem);
   auto symOp = cast<hw::InnerSymbolOpInterface>(cmem);
+  auto prefixAttr = cmem->getAttrOfType<StringAttr>("prefix");
   auto memory = memBuilder.create<MemOp>(
       resultTypes, readLatency, writeLatency, depth, ruw,
       memBuilder.getArrayAttr(resultNames), name,
       cmem->getAttrOfType<firrtl::NameKindEnumAttr>("nameKind").getValue(),
       annotations, memBuilder.getArrayAttr(portAnnotations),
       symOp.getInnerSymAttr(),
-      cmem->getAttrOfType<firrtl::MemoryInitAttr>("init"), StringAttr());
+      cmem->getAttrOfType<firrtl::MemoryInitAttr>("init"), prefixAttr);
   ++numCreatedMems;
 
   // Process each memory port, initializing the memory port and inferring when

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -193,7 +193,11 @@ FMemModuleOp
 LowerMemoryPass::emitMemoryModule(MemOp op, const FirMemory &mem,
                                   const SmallVectorImpl<PortInfo> &ports) {
   // Get a non-colliding name for the memory module, and update the summary.
-  auto newName = circuitNamespace.newName(mem.modName.getValue(), "ext");
+  StringRef prefix = "";
+  if (mem.prefix)
+    prefix = mem.prefix.getValue();
+  auto newName =
+      circuitNamespace.newName(prefix + mem.modName.getValue(), "ext");
   auto moduleName = StringAttr::get(&getContext(), newName);
 
   // Insert the memory module just above the current module.
@@ -237,7 +241,11 @@ void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
   auto ports = getMemoryModulePorts(summary);
 
   // Get a non-colliding name for the memory module, and update the summary.
-  auto newName = circuitNamespace.newName(mem.getName());
+  StringRef prefix = "";
+  if (summary.prefix)
+    prefix = summary.prefix.getValue();
+  auto newName = circuitNamespace.newName(prefix + mem.getName());
+
   auto wrapperName = StringAttr::get(&getContext(), newName);
 
   // Create the wrapper module, inserting it just before the current module.
@@ -251,10 +259,9 @@ void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
   // same name as the target module.
   auto memModule = getOrCreateMemModule(mem, summary, ports, shouldDedup);
   b.setInsertionPointToStart(wrapper.getBodyBlock());
-
-  auto memInst = b.create<InstanceOp>(
-      mem->getLoc(), memModule, (mem.getName() + "_ext").str(),
-      mem.getNameKind(), mem.getAnnotations().getValue());
+  auto memInst =
+      b.create<InstanceOp>(mem->getLoc(), memModule, memModule.getModuleName(),
+                           mem.getNameKind(), mem.getAnnotations().getValue());
 
   // Wire all the ports together.
   for (auto [dst, src] : llvm::zip(wrapper.getBodyBlock()->getArguments(),

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -259,9 +259,9 @@ void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
   // same name as the target module.
   auto memModule = getOrCreateMemModule(mem, summary, ports, shouldDedup);
   b.setInsertionPointToStart(wrapper.getBodyBlock());
-  auto memInst =
-      b.create<InstanceOp>(mem->getLoc(), memModule, memModule.getModuleName(),
-                           mem.getNameKind(), mem.getAnnotations().getValue());
+  auto memInst = b.create<InstanceOp>(
+      mem->getLoc(), memModule, (mem.getName() + "_ext").str(),
+      mem.getNameKind(), mem.getAnnotations().getValue());
 
   // Wire all the ports together.
   for (auto [dst, src] : llvm::zip(wrapper.getBodyBlock()->getArguments(),

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -742,6 +742,23 @@ firrtl.circuit "Test" attributes {rawAnnotations =[
 
 // -----
 
+firrtl.circuit "Test" attributes {rawAnnotations =[
+  {class = "chisel3.ModulePrefixAnnotation", target = "~Test|Test>comb", prefix = "Prefix_"},
+  {class = "chisel3.ModulePrefixAnnotation", target = "~Test|Test>seq", prefix = "Prefix_"},
+  {class = "chisel3.ModulePrefixAnnotation", target = "~Test|Test>mem", prefix = "Prefix_"}
+  ]} {
+  firrtl.module @Test() {
+    // CHECK: %comb = chirrtl.combmem {prefix = "Prefix_"} : !chirrtl.cmemory<vector<uint<1>, 2>, 256>
+    %comb = chirrtl.combmem : !chirrtl.cmemory<vector<uint<1>, 2>, 256>
+    // CHECK: %seq = chirrtl.seqmem Undefined {prefix = "Prefix_"} : !chirrtl.cmemory<vector<uint<1>, 2>, 256>
+    %seq = chirrtl.seqmem Undefined : !chirrtl.cmemory<vector<uint<1>, 2>, 256>
+    // CHECK: %mem_w = firrtl.mem Undefined {depth = 8 : i64, name = "mem", portNames = ["w"], prefix = "Prefix_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<4>, mask: uint<1>> 
+    %mem_w = firrtl.mem Undefined  {depth = 8 : i64, name = "mem", portNames = ["w"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: uint<4>, mask: uint<1>>
+  }
+}
+
+// -----
+
 // DontTouchAnnotations are placed on the things they target.
 
 firrtl.circuit "Foo"  attributes {

--- a/test/Dialect/FIRRTL/lower-chirrtl.mlir
+++ b/test/Dialect/FIRRTL/lower-chirrtl.mlir
@@ -200,8 +200,8 @@ firrtl.module @SortedPorts(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>)
   chirrtl.memoryport.access %b_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
 }
 
-// Check that annotations are preserved.
-firrtl.module @Annotations(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>) {
+// Check that important attributes are preserved.
+firrtl.module @Attributes(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>) {
   // CHECK: firrtl.mem Undefined
   // CHECK-SAME: annotations = [{a = "a"}]
   // CHECK-SAME: portAnnotations = [
@@ -209,7 +209,8 @@ firrtl.module @Annotations(in %clock: !firrtl.clock, in %addr : !firrtl.uint<8>)
   // CHECK-SAME:   [{c = "c"}]
   // CHECK-SAME: ]
   // CHECK-SAME: portNames = ["port0", "port1"]
-  %ram = chirrtl.combmem {annotations = [{a = "a"}]} : !chirrtl.cmemory<vector<uint<1>, 2>, 256>
+  // CHECK-SAME: prefix = "Prefix_"
+  %ram = chirrtl.combmem {annotations = [{a = "a"}], prefix = "Prefix_"} : !chirrtl.cmemory<vector<uint<1>, 2>, 256>
   %port0_data, %port0_port = chirrtl.memoryport Read %ram  {annotations = [{b = "b"}], name = "port0"} : (!chirrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !chirrtl.cmemoryport)
   chirrtl.memoryport.access %port0_port[%addr], %clock : !chirrtl.cmemoryport, !firrtl.uint<8>, !firrtl.clock
   %port1_data, %port1_port = chirrtl.memoryport Read %ram {annotations = [{c = "c"}], name = "port1"} : (!chirrtl.cmemory<vector<uint<1>, 2>, 256>) -> (!firrtl.vector<uint<1>, 2>, !chirrtl.cmemoryport)

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -78,6 +78,24 @@ firrtl.module @Dedup() {
 }
 }
 
+// Test that the memory modules with different prefixes are not deduplicated.
+// CHECK-LABEL: firrtl.circuit "Prefix"
+firrtl.circuit "Prefix" {
+// CHECK: firrtl.module private @A_mem0
+// CHECK-NEXT: firrtl.instance A_mem0_ext  @A_mem0_ext
+
+// CHECK: firrtl.memmodule private @A_mem0_ext
+
+// CHECK: firrtl.module private @B_mem1
+// CHECK-NEXT: firrtl.instance B_mem1_ext @B_mem1_ext
+firrtl.module @Prefix() {
+  %mem0_write = firrtl.mem Undefined {depth = 12 : i64, name = "mem0", portNames = ["write"], prefix = "A_", readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+  %mem1_write = firrtl.mem Undefined {depth = 12 : i64, name = "mem1", portNames = ["write"], prefix = "B_", readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
+  // CHECK: firrtl.instance mem0  @A_mem0(
+  // CHECK: firrtl.instance mem1  @B_mem1(
+}
+}
+
 // Test that memories in the testharness are not deduped with other memories in
 // the test harness.
 // CHECK-LABEL: firrtl.circuit "NoTestharnessDedup0"

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -82,12 +82,12 @@ firrtl.module @Dedup() {
 // CHECK-LABEL: firrtl.circuit "Prefix"
 firrtl.circuit "Prefix" {
 // CHECK: firrtl.module private @A_mem0
-// CHECK-NEXT: firrtl.instance A_mem0_ext  @A_mem0_ext
+// CHECK-NEXT: firrtl.instance mem0_ext  @A_mem0_ext
 
 // CHECK: firrtl.memmodule private @A_mem0_ext
 
 // CHECK: firrtl.module private @B_mem1
-// CHECK-NEXT: firrtl.instance B_mem1_ext @B_mem1_ext
+// CHECK-NEXT: firrtl.instance mem1_ext @B_mem1_ext
 firrtl.module @Prefix() {
   %mem0_write = firrtl.mem Undefined {depth = 12 : i64, name = "mem0", portNames = ["write"], prefix = "A_", readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
   %mem1_write = firrtl.mem Undefined {depth = 12 : i64, name = "mem1", portNames = ["write"], prefix = "B_", readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>


### PR DESCRIPTION
We are in the process of reimplementing the `NestedPrefixModulesAnnotation` directly in Chisel, however there are still some things that Chisel can't do itself and needs to communicate more information to CIRCT. This adds a new `ModulePrefixAnnotation` annotation which can only target memories, which enables firtool to generate memories with correct names.