### PR TITLE
[ESI][Services] Type comparisons should account for 'any'

### DIFF
--- a/include/circt/Dialect/ESI/ESIOps.h
+++ b/include/circt/Dialect/ESI/ESIOps.h
@@ -33,6 +33,16 @@ struct ServicePortInfo {
   ChannelBundleType type;
 };
 
+// Check that the channels on two bundles match allowing for AnyType.
+// NOLINTNEXTLINE(misc-no-recursion)
+LogicalResult checkInnerTypeMatch(Type expected, Type actual);
+/// Check that the channels on two bundles match allowing for AnyType in the
+/// 'svc' bundle.
+LogicalResult checkBundleTypeMatch(Operation *req,
+                                   ChannelBundleType svcBundleType,
+                                   ChannelBundleType reqBundleType,
+                                   bool skipDirectionCheck);
+
 } // namespace esi
 } // namespace circt
 

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -371,15 +371,108 @@ getServicePortInfo(Operation *op, SymbolTableCollection &symbolTable,
   return portInfo;
 }
 
+namespace circt {
+namespace esi {
+// Check that the channels on two bundles match allowing for AnyType.
+// NOLINTNEXTLINE(misc-no-recursion)
+LogicalResult checkInnerTypeMatch(Type expected, Type actual) {
+  if (expected == actual)
+    return success();
+
+  // Check all of the 'container' or special case types.
+  return TypeSwitch<Type, LogicalResult>(expected)
+      // For 'any' types, we can match anything.
+      .Case<AnyType>([&](Type) { return success(); })
+      // If they're both channels, check the inner types.
+      .Case<ChannelType>([&](ChannelType expectedChannel) {
+        auto actualChannel = dyn_cast<ChannelType>(actual);
+        if (!actualChannel)
+          return failure();
+        return checkInnerTypeMatch(expectedChannel.getInner(),
+                                   actualChannel.getInner());
+      })
+      // For structs, check each field.
+      .Case<hw::StructType>([&](hw::StructType expectedStruct) {
+        auto actualStruct = dyn_cast<hw::StructType>(actual);
+        if (!actualStruct)
+          return failure();
+        auto expectedFields = expectedStruct.getElements();
+        auto actualFields = actualStruct.getElements();
+        if (expectedFields.size() != actualFields.size())
+          return failure();
+        for (size_t i = 0, e = expectedFields.size(); i != e; ++i) {
+          if (expectedFields[i].name != actualFields[i].name)
+            return failure();
+          if (failed(checkInnerTypeMatch(expectedFields[i].type,
+                                         actualFields[i].type)))
+            return failure();
+        }
+        return success();
+      })
+      // For arrays, check the element type and size.
+      .Case<hw::ArrayType>([&](hw::ArrayType expectedArray) {
+        auto actualArray = dyn_cast<hw::ArrayType>(actual);
+        if (!actualArray)
+          return failure();
+        if (expectedArray.getNumElements() != actualArray.getNumElements())
+          return failure();
+        return checkInnerTypeMatch(expectedArray.getElementType(),
+                                   actualArray.getElementType());
+      })
+      // For unions, check the element types and names.
+      .Case<hw::UnionType>([&](hw::UnionType expectedUnion) {
+        auto actualUnion = dyn_cast<hw::UnionType>(actual);
+        if (!actualUnion)
+          return failure();
+        auto expectedElements = expectedUnion.getElements();
+        auto actualElements = actualUnion.getElements();
+        if (expectedElements.size() != actualElements.size())
+          return failure();
+        for (size_t i = 0, e = expectedElements.size(); i != e; ++i) {
+          if (expectedElements[i].name != actualElements[i].name)
+            return failure();
+          if (expectedElements[i].offset != actualElements[i].offset)
+            return failure();
+          if (failed(checkInnerTypeMatch(expectedElements[i].type,
+                                         actualElements[i].type)))
+            return failure();
+        }
+        return success();
+      })
+      // For ESI lists, check the element type.
+      .Case<ListType>([&](ListType expectedList) {
+        auto actualList = dyn_cast<ListType>(actual);
+        if (!actualList)
+          return failure();
+        return checkInnerTypeMatch(expectedList.getElementType(),
+                                   actualList.getElementType());
+      })
+      // For ESI windows, unwrap and check the inner type.
+      .Case<WindowType>([&](WindowType expectedWindow) {
+        auto actualWindow = dyn_cast<WindowType>(actual);
+        if (!actualWindow)
+          return checkInnerTypeMatch(expectedWindow.getInto(), actual);
+        return checkInnerTypeMatch(expectedWindow.getInto(),
+                                   actualWindow.getInto());
+      })
+      // For type aliases, unwrap and check the aliased type.
+      .Case<hw::TypeAliasType>([&](hw::TypeAliasType expectedAlias) {
+        auto actualAlias = dyn_cast<hw::TypeAliasType>(actual);
+        if (!actualAlias)
+          return checkInnerTypeMatch(expectedAlias.getCanonicalType(), actual);
+        return checkInnerTypeMatch(expectedAlias.getCanonicalType(),
+                                   actualAlias.getCanonicalType());
+      })
+      // TODO: other container types.
+      .Default([&](Type) { return failure(); });
+}
+
 /// Check that the channels on two bundles match allowing for AnyType in the
 /// 'svc' bundle.
-static LogicalResult checkTypeMatch(Operation *req,
-                                    ChannelBundleType svcBundleType,
-                                    ChannelBundleType reqBundleType,
-                                    bool skipDirectionCheck) {
-  auto *ctxt = svcBundleType.getContext();
-  auto anyChannelType = ChannelType::get(ctxt, AnyType::get(ctxt));
-
+LogicalResult checkBundleTypeMatch(Operation *req,
+                                   ChannelBundleType svcBundleType,
+                                   ChannelBundleType reqBundleType,
+                                   bool skipDirectionCheck) {
   if (svcBundleType.getChannels().size() != reqBundleType.getChannels().size())
     return req->emitOpError(
         "Request port bundle channel count does not match service "
@@ -401,20 +494,27 @@ static LogicalResult checkTypeMatch(Operation *req,
           "Request channel direction does not match service "
           "port bundle channel direction");
 
-    if (f->second.type != bc.type && f->second.type != anyChannelType)
+    if (failed(checkInnerTypeMatch(f->second.type, bc.type)))
       return req->emitOpError(
-          "Request channel type does not match service port "
-          "bundle channel type");
+                    "Request channel type does not match service port "
+                    "bundle channel type")
+                 .attachNote()
+             << "Service port '" << bc.name.getValue()
+             << "' type: " << f->second.type;
   }
   return success();
 }
+
+} // namespace esi
+} // namespace circt
 
 LogicalResult
 RequestConnectionOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto svcPort = getServicePortInfo(*this, symbolTable, getServicePortAttr());
   if (failed(svcPort))
     return failure();
-  return checkTypeMatch(*this, svcPort->type, getToClient().getType(), false);
+  return checkBundleTypeMatch(*this, svcPort->type, getToClient().getType(),
+                              false);
 }
 
 LogicalResult ServiceImplementConnReqOp::verifySymbolUses(
@@ -422,7 +522,8 @@ LogicalResult ServiceImplementConnReqOp::verifySymbolUses(
   auto svcPort = getServicePortInfo(*this, symbolTable, getServicePortAttr());
   if (failed(svcPort))
     return failure();
-  return checkTypeMatch(*this, svcPort->type, getToClient().getType(), true);
+  return checkBundleTypeMatch(*this, svcPort->type, getToClient().getType(),
+                              true);
 }
 
 void CustomServiceDeclOp::getPortList(SmallVectorImpl<ServicePortInfo> &ports) {

--- a/test/Dialect/ESI/errors.mlir
+++ b/test/Dialect/ESI/errors.mlir
@@ -51,7 +51,8 @@ esi.service.decl @HostComms {
 }
 
 hw.module @Loopback (in %clk: i1) {
-  // expected-error @+1 {{Request channel type does not match service port bundle channel type}}
+  // expected-error @+2 {{Request channel type does not match service port bundle channel type}}
+  // expected-note @+1 {{Service port 'send' type: '!esi.channel<i16>'}}
   %dataIn = esi.service.req <@HostComms::@Send> (#esi.appid<"loopback_fromhw">) : !esi.bundle<[!esi.channel<i8> from "send"]>
 }
 

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -1,12 +1,13 @@
 // RUN: circt-opt --esi-connect-services --canonicalize %s | circt-opt | FileCheck %s --check-prefix=CONN
 // RUN: circt-opt --esi-connect-services --lower-esi-bundles %s
 
+!sendAny = !esi.bundle<[!esi.channel<!esi.any> from "send"]>
 !sendI8 = !esi.bundle<[!esi.channel<i8> from "send"]>
 !recvI8 = !esi.bundle<[!esi.channel<i8> to "recv"]>
 !reqResp = !esi.bundle<[!esi.channel<i16> to "req", !esi.channel<i8> from "resp"]>
 
 esi.service.decl @HostComms {
-  esi.service.port @Send : !sendI8
+  esi.service.port @Send : !sendAny
   esi.service.port @Recv : !recvI8
   esi.service.port @ReqResp : !reqResp
 }

--- a/unittests/Dialect/CMakeLists.txt
+++ b/unittests/Dialect/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(Moore)
 add_subdirectory(FIRRTL)
+add_subdirectory(ESI)
 add_subdirectory(HW)
 add_subdirectory(OM)
 add_subdirectory(SMT)

--- a/unittests/Dialect/ESI/CMakeLists.txt
+++ b/unittests/Dialect/ESI/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_circt_unittest(CIRCTESITests
+  OpTest.cpp
+)
+
+target_link_libraries(CIRCTESITests
+  PRIVATE
+  CIRCTHW
+  CIRCTESI
+)

--- a/unittests/Dialect/ESI/OpTest.cpp
+++ b/unittests/Dialect/ESI/OpTest.cpp
@@ -1,0 +1,89 @@
+//===- GraphFixutre.cpp - A fixture for instance graph unit tests ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/ESI/ESIOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "gtest/gtest.h"
+
+using namespace mlir;
+using namespace circt;
+using namespace esi;
+
+#define EXPECT_SUCCESS(expr) EXPECT_TRUE(succeeded(expr))
+#define EXPECT_FAILURE(expr) EXPECT_FALSE(succeeded(expr))
+
+namespace {
+TEST(ESIOpTest, TypeMatching) {
+  MLIRContext ctxt;
+  ImplicitLocOpBuilder b(UnknownLoc::get(&ctxt), &ctxt);
+  ctxt.loadDialect<hw::HWDialect>();
+  ctxt.loadDialect<esi::ESIDialect>();
+  auto aStr = b.getStringAttr("a");
+  IntegerType i1Type = b.getI1Type();
+
+  // Channel type tests
+  EXPECT_SUCCESS(checkInnerTypeMatch(b.getType<ChannelType>(i1Type),
+                                     b.getType<ChannelType>(i1Type)));
+  EXPECT_FAILURE(checkInnerTypeMatch(b.getType<ChannelType>(i1Type), i1Type));
+
+  // Any type tests
+  EXPECT_SUCCESS(checkInnerTypeMatch(b.getType<AnyType>(), i1Type));
+
+  // Struct type tests
+  auto structAny = hw::StructType::get(&ctxt, {{aStr, b.getType<AnyType>()}});
+  EXPECT_SUCCESS(checkInnerTypeMatch(
+      structAny, hw::StructType::get(&ctxt, {{aStr, i1Type}})));
+  EXPECT_FAILURE(checkInnerTypeMatch(structAny, i1Type));
+  EXPECT_FAILURE(checkInnerTypeMatch(
+      structAny, hw::StructType::get(
+                     &ctxt, {{aStr, i1Type}, {b.getStringAttr("b"), i1Type}})));
+
+  // Array type tests
+  auto arrayAny = hw::ArrayType::get(b.getType<AnyType>(), 1);
+  EXPECT_SUCCESS(checkInnerTypeMatch(arrayAny, hw::ArrayType::get(i1Type, 1)));
+  EXPECT_FAILURE(checkInnerTypeMatch(arrayAny, i1Type));
+  EXPECT_FAILURE(checkInnerTypeMatch(arrayAny, hw::ArrayType::get(i1Type, 2)));
+
+  // Union type tests
+  auto unionAny = hw::UnionType::get(&ctxt, {{aStr, b.getType<AnyType>(), 0}});
+  EXPECT_SUCCESS(checkInnerTypeMatch(
+      unionAny, hw::UnionType::get(&ctxt, {{aStr, i1Type, 0}})));
+  EXPECT_FAILURE(checkInnerTypeMatch(unionAny, i1Type));
+  EXPECT_FAILURE(checkInnerTypeMatch(
+      unionAny, hw::UnionType::get(&ctxt, {{aStr, i1Type, 1}})));
+  EXPECT_FAILURE(checkInnerTypeMatch(
+      unionAny,
+      hw::UnionType::get(
+          &ctxt, {{aStr, i1Type, 0}, {b.getStringAttr("b"), i1Type, 1}})));
+
+  // ESI list tests
+  auto esiListAny = b.getType<ListType>(b.getType<AnyType>());
+  EXPECT_FAILURE(checkInnerTypeMatch(esiListAny, i1Type));
+  EXPECT_SUCCESS(checkInnerTypeMatch(esiListAny, b.getType<ListType>(i1Type)));
+
+  // ESI window tests
+  auto esiWindowAny = WindowType::get(
+      &ctxt, b.getStringAttr("aWindow"), structAny,
+      {WindowFrameType::get(&ctxt, aStr,
+                            {WindowFieldType::get(&ctxt, aStr, 0)})});
+  EXPECT_SUCCESS(checkInnerTypeMatch(
+      esiWindowAny, hw::StructType::get(&ctxt, {{aStr, i1Type}})));
+  EXPECT_SUCCESS(checkInnerTypeMatch(
+      esiWindowAny,
+      WindowType::get(&ctxt, b.getStringAttr("aWindow"),
+                      hw::StructType::get(&ctxt, {{aStr, i1Type}}),
+                      {WindowFrameType::get(&ctxt, aStr, {})})));
+  EXPECT_FAILURE(checkInnerTypeMatch(esiWindowAny, i1Type));
+
+  // Type alias type tests
+  auto typeAliasAny =
+      b.getType<hw::TypeAliasType>(b.getType<SymbolRefAttr>("foo"),
+                                   b.getType<AnyType>(), b.getType<AnyType>());
+  EXPECT_SUCCESS(checkInnerTypeMatch(typeAliasAny, i1Type));
+}
+} // namespace


### PR DESCRIPTION
Allow the 'esi.any' type to appear in container types.