### PR TITLE
[FIRRTL] ReplSeqMems: use the original mem name for the instance name

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -252,9 +252,9 @@ void LowerMemoryPass::lowerMemory(MemOp mem, const FirMemory &summary,
   auto memModule = getOrCreateMemModule(mem, summary, ports, shouldDedup);
   b.setInsertionPointToStart(wrapper.getBodyBlock());
 
-  auto memInst =
-      b.create<InstanceOp>(mem->getLoc(), memModule, memModule.getModuleName(),
-                           mem.getNameKind(), mem.getAnnotations().getValue());
+  auto memInst = b.create<InstanceOp>(
+      mem->getLoc(), memModule, (mem.getName() + "_ext").str(),
+      mem.getNameKind(), mem.getAnnotations().getValue());
 
   // Wire all the ports together.
   for (auto [dst, src] : llvm::zip(wrapper.getBodyBlock()->getArguments(),

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -52,7 +52,7 @@ firrtl.circuit "Collision1" {
 // @test_ext collides with the name of the external memory module.
 firrtl.extmodule @test_ext()
 // CHECK: firrtl.module private @test
-// CHECK-NEXT: firrtl.instance test_0_ext @test_0_ext
+// CHECK-NEXT: firrtl.instance test_ext @test_0_ext
 // CHECK: firrtl.memmodule private @test_0_ext
 firrtl.module @Collision1() {
   %MWrite_write = firrtl.mem Undefined {depth = 12 : i64, name = "test", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
@@ -69,7 +69,7 @@ firrtl.circuit "Dedup" {
 // CHECK: firrtl.memmodule private @mem0_ext
 
 // CHECK: firrtl.module private @mem1
-// CHECK-NEXT: firrtl.instance mem0_ext @mem0_ext
+// CHECK-NEXT: firrtl.instance mem1_ext @mem0_ext
 firrtl.module @Dedup() {
   %mem0_write = firrtl.mem Undefined {depth = 12 : i64, name = "mem0", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
   %mem1_write = firrtl.mem Undefined {depth = 12 : i64, name = "mem1", portNames = ["write"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
@@ -252,7 +252,7 @@ firrtl.module @NonLocalAnnotation()  {
 // CHECK: }
 
 // CHECK: firrtl.module private @mem1
-// CHECK:   firrtl.instance mem0_ext sym @mem0_ext
+// CHECK:   firrtl.instance mem1_ext sym @mem0_ext
 // CHECK-SAME:  {annotations = [{circt.nonlocal = @[[nla_1]], class = "test1"}]}
 // CHECK-SAME:  @mem0_ext(
 


### PR DESCRIPTION
This PR is currently more of an experiment, not sure if it is the direction we will go.