### PR TITLE
[HW] Make module's doNotPrint a UnitAttr

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -502,6 +502,10 @@ def HWInstanceLike : OpInterface<"HWInstanceLike", [
     /*defaultImplementation=*/[{
       $_op.setResultNamesAttr(names);
     }]>,
+
+    InterfaceMethod<"True if this instance is a phony placeholder",
+      "bool", "getDoNotPrint", (ins)
+    >
   ];
 }
 

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -469,7 +469,8 @@ def InstanceOp : HWInstanceOpBase<"instance", [HWInstanceLike]> {
                        Variadic<AnyType>:$inputs,
                        StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,
-                       OptionalAttr<InnerSymAttr>:$inner_sym);
+                       OptionalAttr<InnerSymAttr>:$inner_sym,
+                       UnitAttr:$doNotPrint);
   let results = (outs Variadic<AnyType>:$results);
 
   let builders = [
@@ -541,7 +542,8 @@ def InstanceChoiceOp : HWInstanceOpBase<"instance_choice", [
                        Variadic<AnyType>:$inputs,
                        StrArrayAttr:$argNames, StrArrayAttr:$resultNames,
                        ParamDeclArrayAttr:$parameters,
-                       OptionalAttr<InnerSymAttr>:$inner_sym);
+                       OptionalAttr<InnerSymAttr>:$inner_sym,
+                       UnitAttr:$doNotPrint);
   let results = (outs Variadic<AnyType>:$results);
 
   let hasCustomAssemblyFormat = 1;

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -224,7 +224,8 @@ def InterfaceInstanceOp : SVOp<"interface.instance", [
   }];
 
   let arguments = (ins StrAttr:$name,
-                       OptionalAttr<InnerSymAttr>:$inner_sym);
+                       OptionalAttr<InnerSymAttr>:$inner_sym,
+                       UnitAttr:$doNotPrint);
   let results = (outs InterfaceType : $result);
 
   let assemblyFormat = [{

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -4216,7 +4216,7 @@ LogicalResult StmtEmitter::visitSV(AliasOp op) {
 }
 
 LogicalResult StmtEmitter::visitSV(InterfaceInstanceOp op) {
-  auto doNotPrint = op->hasAttr("doNotPrint");
+  auto doNotPrint = op.getDoNotPrint();
   if (doNotPrint && !state.options.emitBindComments)
     return success();
 
@@ -5334,7 +5334,7 @@ LogicalResult StmtEmitter::visitSV(CaseOp op) {
 }
 
 LogicalResult StmtEmitter::visitStmt(InstanceOp op) {
-  bool doNotPrint = op->hasAttr("doNotPrint");
+  bool doNotPrint = op.getDoNotPrint();
   if (doNotPrint && !state.options.emitBindComments)
     return success();
 

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -3308,7 +3308,7 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
       newModule, oldInstance.getNameAttr(), operands, parameters, innerSym);
 
   if (oldInstance.getLowerToBind())
-    newInstance->setAttr("doNotPrint", builder.getBoolAttr(true));
+    newInstance.setDoNotPrintAttr(builder.getUnitAttr());
 
   if (newInstance.getInnerSymAttr())
     if (auto forceName = circuitState.instanceForceNames.lookup(

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -166,7 +166,8 @@ struct InstanceOpConversion : public OpConversionPattern<InstanceOp> {
     auto instOp = rewriter.create<hw::InstanceOp>(
         op.getLoc(), op.getResultTypes(), instName, moduleName, op.getInputs(),
         op.getInputNamesAttr(), op.getOutputNamesAttr(),
-        /*Parameter*/ rewriter.getArrayAttr({}), /*InnerSymbol*/ nullptr);
+        /*Parameter*/ rewriter.getArrayAttr({}), /*InnerSymbol*/ nullptr,
+        /*doNotPrint*/ nullptr);
 
     // Replace uses chain and erase the original op.
     op.replaceAllUsesWith(instOp.getResults());

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -1476,7 +1476,7 @@ void InstanceOp::build(OpBuilder &builder, OperationState &result,
   FunctionType funcType = resolvedModType->getFuncType();
   build(builder, result, funcType.getResults(), name,
         FlatSymbolRefAttr::get(SymbolTable::getSymbolName(module)), inputs,
-        argNames, resultNames, parameters, innerSym);
+        argNames, resultNames, parameters, innerSym, /*doNotPrint=*/{});
 }
 
 std::optional<size_t> InstanceOp::getTargetResultIndex() {

--- a/lib/Dialect/HW/Transforms/FlattenIO.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenIO.cpp
@@ -123,7 +123,7 @@ struct InstanceOpConversion : public OpConversionPattern<hw::InstanceOp> {
         loc, newResultTypes, op.getInstanceNameAttr(),
         FlatSymbolRefAttr::get(referencedMod), convOperands,
         op.getArgNamesAttr(), op.getResultNamesAttr(), op.getParametersAttr(),
-        op.getInnerSymAttr());
+        op.getInnerSymAttr(), op.getDoNotPrintAttr());
 
     // re-create any structs in the result.
     llvm::SmallVector<Value> convResults;

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -1882,7 +1882,7 @@ LogicalResult BindOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   if (!inst)
     return emitError("Referenced instance doesn't exist ")
            << getInstance().getModule() << "::" << getInstance().getName();
-  if (!inst->getAttr("doNotPrint"))
+  if (!inst.getDoNotPrint())
     return emitError("Referenced instance isn't marked as doNotPrint");
   return success();
 }
@@ -1933,7 +1933,7 @@ BindInterfaceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   if (!inst)
     return emitError("Referenced interface doesn't exist ")
            << getInstance().getModule() << "::" << getInstance().getName();
-  if (!inst->getAttr("doNotPrint"))
+  if (!inst.getDoNotPrint())
     return emitError("Referenced interface isn't marked as doNotPrint");
   return success();
 }

--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -252,7 +252,7 @@ static hw::HWModuleOp createModuleForCut(hw::HWModuleOp op,
       hw::InnerSymAttr::get(b.getStringAttr(
           ("__ETC_" + getVerilogModuleNameAttr(op).getValue() + suffix)
               .str())));
-  inst->setAttr("doNotPrint", b.getBoolAttr(true));
+  inst.setDoNotPrintAttr(b.getUnitAttr());
   b = OpBuilder::atBlockEnd(
       &op->getParentOfType<mlir::ModuleOp>()->getRegion(0).front());
 
@@ -338,10 +338,11 @@ static void migrateOps(hw::HWModuleOp oldMod, hw::HWModuleOp newMod,
 static bool isBound(hw::HWModuleLike op, hw::InstanceGraph &instanceGraph) {
   auto *node = instanceGraph.lookup(op);
   return llvm::any_of(node->uses(), [](igraph::InstanceRecord *a) {
-    auto inst = a->getInstance();
+    auto inst = a->getInstance<hw::HWInstanceLike>();
     if (!inst)
       return false;
-    return inst->hasAttr("doNotPrint");
+
+    return inst.getDoNotPrint();
   });
 }
 

--- a/lib/Dialect/Seq/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/Seq/Transforms/HWMemSimImpl.cpp
@@ -546,7 +546,7 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
           "inner_sym",
           hw::InnerSymAttr::get(b.getStringAttr(
               moduleNamespace.newName(boundInstance.getInstanceName()))));
-      boundInstance->setAttr("doNotPrint", b.getBoolAttr(true));
+      boundInstance.setDoNotPrintAttr(b.getUnitAttr());
 
       // Build the file container and reference the module from it.
       b.setInsertionPointAfter(op);

--- a/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
+++ b/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
@@ -187,7 +187,8 @@ void ExternalizeRegistersPass::runOnOperation() {
               instanceOp.getLoc(), resTypes, instanceOp.getInstanceNameAttr(),
               instanceOp.getModuleNameAttr(), instanceOp.getInputs(),
               builder.getArrayAttr(argNames), builder.getArrayAttr(resultNames),
-              instanceOp.getParametersAttr(), instanceOp.getInnerSymAttr());
+              instanceOp.getParametersAttr(), instanceOp.getInnerSymAttr(),
+              instanceOp.getDoNotPrintAttr());
           for (auto [output, name] :
                zip(newInst->getResults().take_back(newOutputs.size()),
                    newOutputNames))

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -804,10 +804,10 @@ hw.module.extern @ExternDestMod(in %a: i1, in %b: i2, out c: i3, out d: i4)
 hw.module @InternalDestMod(in %a: i1, in %b: i3, in %c: i1) {}
 // CHECK-LABEL: module ABC
 hw.module @ABC(in %a: i1, in %b: i2, out c: i4) {
-  %0,%1 = hw.instance "whatever" sym @a1 @ExternDestMod(a: %a: i1, b: %b: i2) -> (c: i3, d: i4) {doNotPrint=1}
+  %0,%1 = hw.instance "whatever" sym @a1 @ExternDestMod(a: %a: i1, b: %b: i2) -> (c: i3, d: i4) {doNotPrint}
   %2 = sv.xmr "whatever", "a" : !hw.inout<i1>
   %3 = sv.read_inout %2: !hw.inout<i1>
-  hw.instance "yo" sym @b1 @InternalDestMod(a: %a: i1, b: %0: i3, c: %3: i1) -> () {doNotPrint=1}
+  hw.instance "yo" sym @b1 @InternalDestMod(a: %a: i1, b: %0: i3, c: %3: i1) -> () {doNotPrint}
   hw.output %1 : i4
 }
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1326,9 +1326,7 @@ hw.module @wait_order() {
   // CHECK-NEXT:   .b (wait_order_0.baz.x.y.z[42])
   // CHECK-NEXT: );
   // CHECK-NEXT: */
-  hw.instance "baz" sym @baz @XMRRef_Baz(a: %xmrRead: i2, b: %xmr2Read: i1) -> () {
-    doNotPrint = true
-  }
+  hw.instance "baz" sym @baz @XMRRef_Baz(a: %xmrRead: i2, b: %xmr2Read: i1) -> () {doNotPrint}
   // CHECK-NEXT: XMRRef_Qux qux (
   // CHECK-NEXT:   .a (wait_order_0.bar.new_0),
   // CHECK-NEXT:   .b (wait_order_0.baz.x.y.z[42])
@@ -1359,8 +1357,8 @@ hw.module @InlineBind(in %a_in: i8, out wire: i8){
   %0 = sv.wire : !hw.inout<i8>
   %1 = sv.read_inout %0: !hw.inout<i8>
   %2 = comb.add %a_in, %1 : i8
-  %3 = hw.instance "ext1" sym @foo1 @ExtModule(in: %2: i8) -> (out: i8) {doNotPrint=1}
-  %4 = hw.instance "ext2" sym @foo2 @ExtModule(in: %3: i8) -> (out: i8) {doNotPrint=1}
+  %3 = hw.instance "ext1" sym @foo1 @ExtModule(in: %2: i8) -> (out: i8) {doNotPrint}
+  %4 = hw.instance "ext2" sym @foo2 @ExtModule(in: %3: i8) -> (out: i8) {doNotPrint}
   hw.output %4: i8
 }
 
@@ -1411,9 +1409,9 @@ hw.module @remoteInstDut(in %i: i1, in %j: i1, in %z: i0) {
   %output = sv.reg : !hw.inout<i1>
   %myreg_rd1 = sv.read_inout %output: !hw.inout<i1>
   %0 = hw.constant 1 : i1
-  hw.instance "a1" sym @bindInst @extInst(_h: %mywire_rd: i1, _i: %myreg_rd: i1, _j: %j: i1, _k: %0: i1, _z: %z: i0) -> () {doNotPrint=1}
-  hw.instance "a2" sym @bindInst2 @extInst(_h: %mywire_rd: i1, _i: %myreg_rd: i1, _j: %j: i1, _k: %0: i1, _z: %z: i0) -> () {doNotPrint=1}
-  hw.instance "signed" sym @bindInst3 @extInst2(signed: %mywire_rd1 : i1, _i: %myreg_rd1 : i1, _j: %j: i1, _k: %0: i1, _z: %z: i0) -> () {doNotPrint=1}
+  hw.instance "a1" sym @bindInst @extInst(_h: %mywire_rd: i1, _i: %myreg_rd: i1, _j: %j: i1, _k: %0: i1, _z: %z: i0) -> () {doNotPrint}
+  hw.instance "a2" sym @bindInst2 @extInst(_h: %mywire_rd: i1, _i: %myreg_rd: i1, _j: %j: i1, _k: %0: i1, _z: %z: i0) -> () {doNotPrint}
+  hw.instance "signed" sym @bindInst3 @extInst2(signed: %mywire_rd1 : i1, _i: %myreg_rd1 : i1, _j: %j: i1, _k: %0: i1, _z: %z: i0) -> () {doNotPrint}
 // CHECK:      wire mywire
 // CHECK-NEXT: myreg
 // CHECK-NEXT: wire signed_0
@@ -1927,7 +1925,7 @@ sv.bind #hw.innerNameRef<@remoteInstDut::@bindInst2>
 // Regression test for a bug where bind emission would not use sanitized names.
 hw.module @NastyPortParent() {
   %false = hw.constant false
-  %0 = hw.instance "foo" sym @foo @NastyPort(".lots$of.dots": %false: i1) -> (".more.dots": i1) {doNotPrint = true}
+  %0 = hw.instance "foo" sym @foo @NastyPort(".lots$of.dots": %false: i1) -> (".more.dots": i1) {doNotPrint}
 }
 hw.module @NastyPort(in %.lots$of.dots: i1, out ".more.dots": i1) {
   %false = hw.constant false

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -698,7 +698,7 @@ hw.module @BindEmission() {
   // CHECK-NEXT: /* This instance is elsewhere emitted as a bind statement
   // CHECK-NEXT:    BindEmissionInstance BindEmissionInstance ();
   // CHECK-NEXT: */
-  hw.instance "BindEmissionInstance" sym @__BindEmissionInstance__ @BindEmissionInstance() -> ()  {doNotPrint = true}
+  hw.instance "BindEmissionInstance" sym @__BindEmissionInstance__ @BindEmissionInstance() -> ()  {doNotPrint}
   hw.output
 }
 
@@ -709,7 +709,7 @@ hw.module @BindEmission2() {
   // CHECK-NEXT: /* This instance is elsewhere emitted as a bind statement
   // CHECK-NEXT:    BindEmissionInstance BindEmissionInstance ();
   // CHECK-NEXT: */
-  hw.instance "BindEmissionInstance" sym @BindEmissionInstance @BindEmissionInstance() -> ()  {doNotPrint = true}
+  hw.instance "BindEmissionInstance" sym @BindEmissionInstance @BindEmissionInstance() -> ()  {doNotPrint}
   hw.output
 }
 
@@ -732,7 +732,7 @@ hw.module @bind_rename_port(in %.io_req_ready.output: i1, in %reset: i1 { hw.ver
 // CHECK-LABEL: module SiFive_MulDiv
 hw.module @SiFive_MulDiv(in %clock: i1, in %reset: i1, out io_req_ready: i1) {
   %false = hw.constant false
-  hw.instance "InvisibleBind_assert" sym @__ETC_SiFive_MulDiv_assert @bind_rename_port(".io_req_ready.output": %false: i1, reset: %reset: i1, clock: %clock: i1) -> () {doNotPrint = true}
+  hw.instance "InvisibleBind_assert" sym @__ETC_SiFive_MulDiv_assert @bind_rename_port(".io_req_ready.output": %false: i1, reset: %reset: i1, clock: %clock: i1) -> () {doNotPrint}
   hw.output %false : i1
   //      CHECK: bind_rename_port InvisibleBind_assert (
   // CHECK-NEXT:   ._io_req_ready_output (1'h0),
@@ -772,7 +772,7 @@ hw.module @W422_Foo() {
 }
 
 hw.module @BindInterface() {
-  %bar = sv.interface.instance sym @__Interface__ {doNotPrint = true} : !sv.interface<@Interface>
+  %bar = sv.interface.instance sym @__Interface__ {doNotPrint} : !sv.interface<@Interface>
   hw.output
 }
 

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -296,12 +296,12 @@ sv.bind <@AB::@b1>
 hw.module.extern @ExternDestMod(in %a: i1, in %b: i2)
 hw.module @InternalDestMod(in %a: i1, in %b: i2) {}
 //CHECK-LABEL: hw.module @AB(in %a : i1, in %b : i2) {
-//CHECK-NEXT:   hw.instance "whatever" sym @a1 @ExternDestMod(a: %a: i1, b: %b: i2) -> () {doNotPrint = 1 : i64}
-//CHECK-NEXT:   hw.instance "yo" sym @b1 @InternalDestMod(a: %a: i1, b: %b: i2) -> () {doNotPrint = 1 : i64}
+//CHECK-NEXT:   hw.instance "whatever" sym @a1 @ExternDestMod(a: %a: i1, b: %b: i2) -> () {doNotPrint}
+//CHECK-NEXT:   hw.instance "yo" sym @b1 @InternalDestMod(a: %a: i1, b: %b: i2) -> () {doNotPrint}
 
 hw.module @AB(in %a: i1, in %b: i2) {
-  hw.instance "whatever" sym @a1 @ExternDestMod(a: %a: i1, b: %b: i2) -> () {doNotPrint=1}
-  hw.instance "yo" sym @b1 @InternalDestMod(a: %a: i1, b: %b: i2) -> () {doNotPrint=1}
+  hw.instance "whatever" sym @a1 @ExternDestMod(a: %a: i1, b: %b: i2) -> () {doNotPrint}
+  hw.instance "yo" sym @b1 @InternalDestMod(a: %a: i1, b: %b: i2) -> () {doNotPrint}
 }
 
 //CHECK-LABEL: hw.module @XMR_src

--- a/test/Dialect/SV/hw-extract-test-code.mlir
+++ b/test/Dialect/SV/hw-extract-test-code.mlir
@@ -89,7 +89,7 @@ module attributes {firrtl.extract.assert =  #hw.output_file<"dir3/", excludeFrom
     }
   }
   hw.module @Top(in %clock: i1) {
-    hw.instance "submodule" @AlreadyExtracted(clock: %clock: i1) -> () {doNotPrint = true}
+    hw.instance "submodule" @AlreadyExtracted(clock: %clock: i1) -> () {doNotPrint}
   }
 }
 
@@ -219,7 +219,7 @@ module {
   }
 
   hw.module private @InputOnlyBind(in %clock: i1, in %cond: i1) {
-    hw.instance "already_bound" sym @already_bound @AlreadyBound() -> () {doNotPrint = true}
+    hw.instance "already_bound" sym @already_bound @AlreadyBound() -> () {doNotPrint}
     sv.always posedge %clock  {
       sv.cover %cond, immediate
       sv.assert %cond, immediate
@@ -508,7 +508,7 @@ module {
 
   // CHECK-LABEL: hw.module private @AssertWrapper(in %clock : i1, in %a : i1, out b : i1) {
   // CHECK-NEXT:  hw.instance "Assert_assert" sym @__ETC_Assert_assert @Assert_assert
-  // CHECK-SAME:  doNotPrint = true
+  // CHECK-SAME:  doNotPrint
   hw.module private @AssertWrapper(in %clock: i1, in %a: i1, out b: i1) {
     hw.instance "a3" @Assert(clock: %clock: i1, a: %a: i1) -> ()
     hw.output %a: i1
@@ -521,11 +521,11 @@ module {
 
   // CHECK-LABEL: hw.module @Top(in %clock : i1, in %a : i1, in %b : i1) {
   // CHECK-NEXT:  hw.instance "Assert_assert" sym @__ETC_Assert_assert_0 @Assert_assert
-  // CHECK-SAME:  doNotPrint = true
+  // CHECK-SAME:  doNotPrint
   // CHECK-NEXT:  hw.instance "Assert_assert" sym @__ETC_Assert_assert @Assert_assert
-  // CHECK-SAME:  doNotPrint = true
+  // CHECK-SAME:  doNotPrint
   // CHECK-NEXT:  hw.instance "Assert_assert" sym @__ETC_Assert_assert_1 @Assert_assert
-  // CHECK-SAME:  doNotPrint = true
+  // CHECK-SAME:  doNotPrint
   // CHECK-NEXT:  hw.instance "should_not_be_inlined" @ShouldNotBeInlined
   // CHECK-NOT: doNotPrint
   hw.module @Top(in %clock: i1, in %a: i1, in %b: i1) {


### PR DESCRIPTION
Currently, doNotPrint is a boolean attribute, but using an optional unit attribute is a more idiomatic way to represent a flag as an attribute.

Changes:
- Switch doNotPrint over to a unit attribute
- Replace getAttr("doNotPrint") with accessors like getDoNotPrint
- Add doNotPrint to the HW dialect's ModuleLike interface, so we can switch even more places over to use the accessor.