### PR TITLE
[firtool] Run layer merge after inliner

### DIFF
--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -135,6 +135,8 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   if (opt.shouldConvertProbesToSignals())
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createProbesToSignalsPass());
 
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInlinerPass());
+
   pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
       firrtl::createLayerMergePass());
 
@@ -143,8 +145,6 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
   else
     pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
         firrtl::createLayerSinkPass());
-
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInlinerPass());
 
   // Preset the random initialization parameters for each module. The current
   // implementation assumes it can run at a time where every register is

--- a/test/firtool/layer-merge-across-inlined-submodule.fir
+++ b/test/firtool/layer-merge-across-inlined-submodule.fir
@@ -1,0 +1,46 @@
+; RUN: firtool %s | FileCheck %s
+
+FIRRTL version 4.0.0
+
+; Check that layerblocks inside an inline child module are merged with
+; layerblocks in the parent.
+
+; CHECK-NOT: module Child_Verification
+; CHECK-NOT: module Child
+
+; CHECK: module Top_Verification_Assert
+; CHECK:   assert(p) else $error("before child");
+; CHECK:   assert(p) else $error("in child");
+; CHECK:   assert(p) else $error("after child");
+; CHECK: endmodule
+
+circuit Top: %[[
+  { "class": "firrtl.passes.InlineAnnotation", "target": "~Top|Child" }
+]]
+
+  layer Verification, bind:
+    layer Assert, bind:
+
+  module Child:
+    input p : UInt<1>
+    input c : Clock
+
+    layerblock Verification:
+      layerblock Assert:
+        assert(c, p, p, "in child")
+        
+  public module Top:
+    input p : UInt<1>
+    input c : Clock
+
+    layerblock Verification:
+      layerblock Assert:
+        assert(c, p, p, "before child")
+    
+    inst child of Child
+    connect child.p, p
+    connect child.c, c
+
+    layerblock Verification:
+      layerblock Assert:
+        assert(c, p, p, "after child")


### PR DESCRIPTION
The inliner could create new opportunities to merge layers. Run layer merge afterwards, in order to merge more things.