### PR TITLE
[FIRRTL] infer more return types in asm format

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -64,7 +64,7 @@ def FormalOp : FIRRTLOp<"formal", [
       %c42_8 = firrtl.constant 42 : !firrtl.uint<8>
       firrtl.connect %bar, %c42_8: !firrtl.uint<8>, !firrtl.uint<8>
       %c69_8 = firrtl.constant 69 : !firrtl.uint<8>
-      %cond = firrtl.eq %c69_8, %out : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<1>
+      %cond = firrtl.eq %c69_8, %out : !firrtl.uint<8>, !firrtl.uint<8>
       firrtl.assert %cond
     }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -419,7 +419,7 @@ def SubaccessOp : FIRRTLExprOp<"subaccess"> {
   let results = (outs FIRRTLBaseType:$result);
 
   let assemblyFormat =
-     "$input `[` $index `]` attr-dict `:` qualified(type($input)) `,` qualified(type($index))";
+     "$input `[` $index `]` attr-dict `:` qualified(type(operands))";
 
   let hasCanonicalizer = true;
   let inferTypeDecl = [{
@@ -582,10 +582,7 @@ class BinaryPrimOp<string mnemonic, Type lhsType, Type rhsType, Type resultType,
   let arguments = (ins lhsType:$lhs, rhsType:$rhs);
   let results = (outs resultType:$result);
 
-  let assemblyFormat = [{
-    $lhs `,` $rhs  attr-dict `:`
-       `(` qualified(type($lhs)) `,` qualified(type($rhs)) `)` `->` qualified(type($result))
-  }];
+  let assemblyFormat = "$lhs `,` $rhs  attr-dict `:` qualified(type(operands))";
 
   // Give concrete operations a chance to set a type inference callback. If left
   // empty, a declaration for `inferReturnType` will be emitted that the
@@ -709,8 +706,7 @@ class UnaryPrimOp<string mnemonic, Type srcType, Type resultType,
   let arguments = (ins srcType:$input);
   let results = (outs resultType:$result);
 
-  let assemblyFormat =
-    "$input attr-dict `:` functional-type($input, $result)";
+  let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
 
   // Give concrete operations a chance to set a type inference callback. If left
   // empty, a declaration for `inferReturnType` will be emitted that the
@@ -791,7 +787,7 @@ def BitsPrimOp : PrimOp<"bits"> {
   let results = (outs UIntType:$result);
 
   let assemblyFormat =
-    "$input $hi `to` $lo attr-dict `:` functional-type($input, $result)";
+    "$input $hi `to` $lo attr-dict `:` qualified(type($input))";
 
   let description = [{
     The `bits` operation extracts the bits between `hi` (inclusive) and `lo`
@@ -824,7 +820,7 @@ def HeadPrimOp : PrimOp<"head"> {
   let results = (outs UIntType:$result);
 
   let assemblyFormat =
-    "$input `,` $amount attr-dict `:` functional-type($input, $result)";
+    "$input `,` $amount attr-dict `:` qualified(type($input))";
 
   let inferTypeDecl = [{
     static FIRRTLType inferReturnType(FIRRTLType input, int64_t amount,
@@ -851,7 +847,7 @@ def MuxPrimOp : PrimOp<"mux"> {
   let results = (outs PassiveType:$result);
 
   let assemblyFormat =
-    "`(` operands `)` attr-dict `:` functional-type(operands, $result)";
+    "`(` $sel `,` $high `,` $low `)` attr-dict `:` qualified(type(operands))";
 
   let inferTypeDecl = [{
     static FIRRTLType inferReturnType(FIRRTLType sel, FIRRTLType high,
@@ -878,7 +874,7 @@ def PadPrimOp : PrimOp<"pad"> {
   let results = (outs IntType:$result);
 
   let assemblyFormat =
-    "$input `,` $amount attr-dict `:` functional-type($input, $result)";
+    "$input `,` $amount attr-dict `:` qualified(type($input))";
 
   let description = [{
     Pad the input out to an `amount` wide integer, sign extending or zero
@@ -908,7 +904,7 @@ class ShiftPrimOp<string mnemonic> : PrimOp<mnemonic> {
   let results = (outs IntType:$result);
 
   let assemblyFormat =
-    "$input `,` $amount attr-dict `:` functional-type($input, $result)";
+    "$input `,` $amount attr-dict `:` qualified(type($input))";
 
   let inferTypeDecl = [{
     static FIRRTLType inferReturnType(FIRRTLType input, int64_t amount,
@@ -950,7 +946,7 @@ def TailPrimOp : PrimOp<"tail"> {
   let results = (outs UIntType:$result);
 
   let assemblyFormat =
-    "$input `,` $amount attr-dict `:` functional-type($input, $result)";
+    "$input `,` $amount attr-dict `:` qualified(type($input))";
 
   let description = [{
     The `tail` operation truncates the `amount` most significant bits from
@@ -999,7 +995,7 @@ def Mux2CellIntrinsicOp : PrimOp<"int.mux2cell"> {
   let hasCanonicalizer = true;
 
   let assemblyFormat =
-    "`(` operands `)` attr-dict `:` functional-type(operands, $result)";
+    "`(` operands `)` attr-dict `:` qualified(type(operands))";
 }
 
 def Mux4CellIntrinsicOp : PrimOp<"int.mux4cell"> {
@@ -1021,7 +1017,7 @@ def Mux4CellIntrinsicOp : PrimOp<"int.mux4cell"> {
   let hasCanonicalizer = true;
 
   let assemblyFormat =
-    "`(` operands `)` attr-dict `:` functional-type(operands, $result)";
+    "`(` operands `)` attr-dict `:` qualified(type(operands))";
 }
 
 //===----------------------------------------------------------------------===//
@@ -1226,8 +1222,7 @@ def ObjectAnyRefCastOp : FIRRTLOp<"object.anyref_cast", [Pure]> {
   let arguments = (ins ClassType:$input);
   let results = (outs AnyRefType:$result);
 
-  let assemblyFormat =
-     "$input attr-dict `:` type($input)";
+  let assemblyFormat = "$input attr-dict `:` type($input)";
 }
 
 def StringConstantOp : FIRRTLOp<"string", [Pure, ConstantLike]> {
@@ -1485,8 +1480,7 @@ def RefCastOp : FIRRTLOp<"ref.cast",
   let hasFolder = 1;
   let hasVerifier = 1;
 
-  let assemblyFormat =
-     "$input attr-dict `:` functional-type($input, $result)";
+  let assemblyFormat = "$input attr-dict `:` functional-type($input, $result)";
 }
 
 def RefResolveOp: FIRRTLExprOp<"ref.resolve",

--- a/test/CAPI/firrtl.c
+++ b/test/CAPI/firrtl.c
@@ -39,7 +39,7 @@ void testExport(MlirContext ctx) {
     "  firrtl.module @ExportTestSimpleModule(in %in_1: !firrtl.uint<32>,\n"
     "                                        in %in_2: !firrtl.uint<32>,\n"
     "                                        out %out: !firrtl.uint<32>) {\n"
-    "    %0 = firrtl.and %in_1, %in_2 : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>\n"
+    "    %0 = firrtl.and %in_1, %in_2 : !firrtl.uint<32>, !firrtl.uint<32>\n"
     "    firrtl.connect %out, %0 : !firrtl.uint<32>, !firrtl.uint<32>\n"
     "  }\n"
     "}\n";

--- a/test/CAPI/firtool.c
+++ b/test/CAPI/firtool.c
@@ -32,8 +32,8 @@ void exportVerilog(MlirContext ctx, bool disableOptimization) {
     "  firrtl.module @ExportTestSimpleModule(in %in_1: !firrtl.uint<32>,\n"
     "                                        in %in_2: !firrtl.uint<32>,\n"
     "                                        out %out: !firrtl.uint<32>) {\n"
-    "    %0 = firrtl.and %in_1, %in_2 : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>\n"
-    "    %1 = firrtl.and %0, %in_2 : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>\n"
+    "    %0 = firrtl.and %in_1, %in_2 : !firrtl.uint<32>, !firrtl.uint<32>\n"
+    "    %1 = firrtl.and %0, %in_2 : !firrtl.uint<32>, !firrtl.uint<32>\n"
     "    firrtl.connect %out, %1 : !firrtl.uint<32>, !firrtl.uint<32>\n"
     "  }\n"
     "}\n";

--- a/test/Conversion/FIRRTLToHW/intrinsics-errors.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics-errors.mlir
@@ -5,7 +5,7 @@ firrtl.circuit "Foo" {
     %0 = firrtl.int.ltl.delay %a, 42 : (!firrtl.uint<1>) -> !firrtl.uint<1>
     // expected-error @below {{operand of type '!ltl.sequence' cannot be used as an integer}}
     // expected-error @below {{couldn't handle this operation}}
-    %1 = firrtl.and %0, %b : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.and %0, %b : !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 
@@ -15,7 +15,7 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>) {
     %0 = firrtl.wire : !firrtl.uint<1>
     // expected-note @below {{leaking outside verification context here}}
-    %1 = firrtl.and %0, %b : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.and %0, %b : !firrtl.uint<1>, !firrtl.uint<1>
     // expected-error @below {{verification operation used in a non-verification context}}
     %2 = firrtl.int.ltl.delay %a, 42 : (!firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.matchingconnect %0, %2 : !firrtl.uint<1>

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -27,20 +27,20 @@ firrtl.circuit "Simple" {
                          in %in3: !firrtl.sint<8>,
                          out %out4: !firrtl.uint<4>) {
 
-    %1 = firrtl.asUInt %in1 : (!firrtl.uint<4>) -> !firrtl.uint<4>
+    %1 = firrtl.asUInt %in1 : !firrtl.uint<4>
 
     // CHECK: comb.concat %false, %in1
     // CHECK: comb.concat %false, %in1
 
     // CHECK: comb.sub
-    %2 = firrtl.sub %1, %1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+    %2 = firrtl.sub %1, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
     // CHECK: %3 = comb.concat %false, %in2 : i1, i2
-    %3 = firrtl.pad %in2, 3 : (!firrtl.uint<2>) -> !firrtl.uint<3>
+    %3 = firrtl.pad %in2, 3 : !firrtl.uint<2>
     // CHECK: comb.concat %false, %3 : i1, i3
-    %4 = firrtl.pad %3, 4 : (!firrtl.uint<3>) -> !firrtl.uint<4>
+    %4 = firrtl.pad %3, 4 : !firrtl.uint<3>
     // CHECK: [[RESULT:%.+]] = comb.xor
-    %5 = firrtl.xor %in2, %4 : (!firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<4>
+    %5 = firrtl.xor %in2, %4 : !firrtl.uint<2>, !firrtl.uint<4>
 
     firrtl.connect %out4, %5 : !firrtl.uint<4>, !firrtl.uint<4>
     // CHECK-NEXT: hw.output [[RESULT]] : i4
@@ -115,7 +115,7 @@ firrtl.circuit "Simple" {
     // CHECK-NEXT: [[T0:%.+]] = comb.concat %false, %inA
     // CHECK-NEXT: [[T1:%.+]] = comb.concat %false, [[OUTC]]
     // CHECK-NEXT: comb.sub bin [[T0]], [[T1]]
-    %0 = firrtl.sub %inA, %outC : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+    %0 = firrtl.sub %inA, %outC : !firrtl.uint<4>, !firrtl.uint<4>
 
     // No connections to outD.
 
@@ -142,7 +142,7 @@ firrtl.circuit "Simple" {
   firrtl.module private @Analog(in %a1: !firrtl.analog<1>,
                         out %outClock: !firrtl.clock) {
 
-    %clock = firrtl.asClock %a1 : (!firrtl.analog<1>) -> !firrtl.clock
+    %clock = firrtl.asClock %a1 : !firrtl.analog<1>
     firrtl.connect %outClock, %clock : !firrtl.clock, !firrtl.clock
   }
 
@@ -160,10 +160,10 @@ firrtl.circuit "Simple" {
 
     // Calculation of input (the firrtl.add + firrtl.eq) happens after the
     // instance.
-    %0 = firrtl.add %arg0, %arg0 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<3>
+    %0 = firrtl.add %arg0, %arg0 : !firrtl.uint<2>, !firrtl.uint<2>
 
     // Multiple uses of the add.
-    %a = firrtl.eq %0, %arg2 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<1>
+    %a = firrtl.eq %0, %arg2 : !firrtl.uint<3>, !firrtl.uint<3>
     // CHECK-NEXT: [[ARG]] = comb.icmp bin eq [[ADD]], %arg2 : i3
     firrtl.connect %myext#0, %a : !firrtl.uint<1>, !firrtl.uint<1>
 
@@ -178,7 +178,7 @@ firrtl.circuit "Simple" {
     %myext:2 = firrtl.instance myext @MyParameterizedExtModule(in in: !firrtl.uint<1>, out out: !firrtl.uint<8>)
 
     // Output of the instance is fed into the input!
-    %11 = firrtl.bits %myext#1 2 to 2 : (!firrtl.uint<8>) -> !firrtl.uint<1>
+    %11 = firrtl.bits %myext#1 2 to 2 : !firrtl.uint<8>
     // CHECK: %0 = comb.extract %myext.out from 2 : (i8) -> i1
 
     firrtl.connect %myext#0, %11 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -190,10 +190,10 @@ firrtl.circuit "Simple" {
                                 in %inC: !firrtl.analog<0>,
                                 out %outa: !firrtl.uint<4>,
                                 out %outb: !firrtl.uint<0>) {
-     %0 = firrtl.mul %inA, %inB : (!firrtl.uint<4>, !firrtl.uint<0>) -> !firrtl.uint<4>
+     %0 = firrtl.mul %inA, %inB : !firrtl.uint<4>, !firrtl.uint<0>
     firrtl.connect %outa, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
-    %1 = firrtl.mul %inB, %inB : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
+    %1 = firrtl.mul %inB, %inB : !firrtl.uint<0>, !firrtl.uint<0>
     firrtl.connect %outb, %1 : !firrtl.uint<0>, !firrtl.uint<0>
 
     firrtl.attach %inC, %inC : !firrtl.analog<0>, !firrtl.analog<0>

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -77,39 +77,39 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     // CHECK: [[ZEXT:%.+]] = comb.concat %false, %in1 : i1, i4
     // CHECK: [[ADD:%.+]] = comb.add bin [[ZEXT]], %c12_i5 : i5
-    %0 = firrtl.add %c12_ui4, %in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+    %0 = firrtl.add %c12_ui4, %in1 : !firrtl.uint<4>, !firrtl.uint<4>
 
-    %1 = firrtl.asUInt %in1 : (!firrtl.uint<4>) -> !firrtl.uint<4>
+    %1 = firrtl.asUInt %in1 : !firrtl.uint<4>
 
     // CHECK: [[ZEXT1:%.+]] = comb.concat %false, [[ADD]] : i1, i5
     // CHECK: [[ZEXT2:%.+]] = comb.concat %c0_i2, %in1 : i2, i4
     // CHECK-NEXT: [[SUB:%.+]] = comb.sub bin [[ZEXT1]], [[ZEXT2]] : i6
-    %2 = firrtl.sub %0, %1 : (!firrtl.uint<5>, !firrtl.uint<4>) -> !firrtl.uint<6>
+    %2 = firrtl.sub %0, %1 : !firrtl.uint<5>, !firrtl.uint<4>
 
-    %in2s = firrtl.asSInt %in2 : (!firrtl.uint<2>) -> !firrtl.sint<2>
+    %in2s = firrtl.asSInt %in2 : !firrtl.uint<2>
 
     // CHECK: [[PADRES_SIGN:%.+]] = comb.extract %in2 from 1 : (i2) -> i1
     // CHECK: [[PADRES:%.+]] = comb.concat [[PADRES_SIGN]], %in2 : i1, i2
-    %3 = firrtl.pad %in2s, 3 : (!firrtl.sint<2>) -> !firrtl.sint<3>
+    %3 = firrtl.pad %in2s, 3 : !firrtl.sint<2>
 
     // CHECK: [[PADRES2:%.+]] = comb.concat %c0_i2, %in2 : i2, i2
-    %4 = firrtl.pad %in2, 4 : (!firrtl.uint<2>) -> !firrtl.uint<4>
+    %4 = firrtl.pad %in2, 4 : !firrtl.uint<2>
 
     // CHECK: [[IN2EXT:%.+]] = comb.concat %c0_i2, %in2 : i2, i2
     // CHECK: [[XOR:%.+]] = comb.xor bin [[IN2EXT]], [[PADRES2]] : i4
-    %5 = firrtl.xor %in2, %4 : (!firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<4>
+    %5 = firrtl.xor %in2, %4 : !firrtl.uint<2>, !firrtl.uint<4>
 
     // CHECK: comb.and bin [[XOR]]
-    %and = firrtl.and %5, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+    %and = firrtl.and %5, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 
     // CHECK: comb.or bin [[XOR]]
-    %or = firrtl.or %5, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+    %or = firrtl.or %5, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 
     // CHECK: [[CONCAT1:%.+]] = comb.concat [[PADRES2]], [[XOR]] : i4, i4
-    %6 = firrtl.cat %4, %5 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<8>
+    %6 = firrtl.cat %4, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
     // CHECK: comb.concat %in1, %in2
-    %7 = firrtl.cat %in1, %in2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<6>
+    %7 = firrtl.cat %in1, %in2 : !firrtl.uint<4>, !firrtl.uint<2>
 
     // CHECK: %out6 = hw.wire [[PADRES2]] sym @__Simple__out6 : i4
     %out6 = firrtl.wire sym @__Simple__out6 : !firrtl.uint<4>
@@ -140,53 +140,53 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %_t_3 = firrtl.wire droppable_name : !firrtl.vector<uint<2>, 13>
 
     // CHECK-NEXT: = comb.extract [[CONCAT1]] from 3 : (i8) -> i5
-    %8 = firrtl.bits %6 7 to 3 : (!firrtl.uint<8>) -> !firrtl.uint<5>
+    %8 = firrtl.bits %6 7 to 3 : !firrtl.uint<8>
 
     // CHECK-NEXT: = comb.extract [[CONCAT1]] from 5 : (i8) -> i3
-    %9 = firrtl.head %6, 3 : (!firrtl.uint<8>) -> !firrtl.uint<3>
+    %9 = firrtl.head %6, 3 : !firrtl.uint<8>
 
     // CHECK-NEXT: = comb.extract [[CONCAT1]] from 0 : (i8) -> i5
-    %10 = firrtl.tail %6, 3 : (!firrtl.uint<8>) -> !firrtl.uint<5>
+    %10 = firrtl.tail %6, 3 : !firrtl.uint<8>
 
     // CHECK-NEXT: = comb.extract [[CONCAT1]] from 3 : (i8) -> i5
-    %11 = firrtl.shr %6, 3 : (!firrtl.uint<8>) -> !firrtl.uint<5>
+    %11 = firrtl.shr %6, 3 : !firrtl.uint<8>
 
-    %12 = firrtl.shr %6, 8 : (!firrtl.uint<8>) -> !firrtl.uint<0>
+    %12 = firrtl.shr %6, 8 : !firrtl.uint<8>
 
     // CHECK-NEXT: = comb.extract %in3 from 7 : (i8) -> i1
-    %13 = firrtl.shr %in3, 8 : (!firrtl.sint<8>) -> !firrtl.sint<1>
+    %13 = firrtl.shr %in3, 8 : !firrtl.sint<8>
 
     // CHECK-NEXT: = comb.concat [[CONCAT1]], %c0_i3 : i8, i3
-    %14 = firrtl.shl %6, 3 : (!firrtl.uint<8>) -> !firrtl.uint<11>
+    %14 = firrtl.shl %6, 3 : !firrtl.uint<8>
 
     // CHECK-NEXT: = comb.parity bin [[CONCAT1]] : i8
-    %15 = firrtl.xorr %6 : (!firrtl.uint<8>) -> !firrtl.uint<1>
+    %15 = firrtl.xorr %6 : !firrtl.uint<8>
 
     // CHECK-NEXT: = comb.icmp bin eq  {{.*}}, %c-1_i8 : i8
-    %16 = firrtl.andr %6 : (!firrtl.uint<8>) -> !firrtl.uint<1>
+    %16 = firrtl.andr %6 : !firrtl.uint<8>
 
     // CHECK-NEXT: = comb.icmp bin ne {{.*}}, %c0_i8 : i8
-    %17 = firrtl.orr %6 : (!firrtl.uint<8>) -> !firrtl.uint<1>
+    %17 = firrtl.orr %6 : !firrtl.uint<8>
 
     // CHECK-NEXT: [[ZEXTC1:%.+]] = comb.concat %c0_i6, [[CONCAT1]] : i6, i8
     // CHECK-NEXT: [[ZEXT2:%.+]] = comb.concat %c0_i8, [[SUB]] : i8, i6
     // CHECK-NEXT: [[VAL18:%.+]] = comb.mul bin [[ZEXTC1]], [[ZEXT2]] : i14
-    %18 = firrtl.mul %6, %2 : (!firrtl.uint<8>, !firrtl.uint<6>) -> !firrtl.uint<14>
+    %18 = firrtl.mul %6, %2 : !firrtl.uint<8>, !firrtl.uint<6>
 
     // CHECK: [[IN3SEXT:%.+]] = comb.concat {{.*}}, %in3 : i1, i8
     // CHECK: [[PADRESSEXT:%.+]] = comb.concat {{.*}}, [[PADRES]] : i6, i3
     // CHECK-NEXT: = comb.divs bin [[IN3SEXT]], [[PADRESSEXT]] : i9
-    %19 = firrtl.div %in3, %3 : (!firrtl.sint<8>, !firrtl.sint<3>) -> !firrtl.sint<9>
+    %19 = firrtl.div %in3, %3 : !firrtl.sint<8>, !firrtl.sint<3>
 
     // CHECK: [[IN3EX:%.+]] = comb.concat {{.*}}, [[PADRES]] : i5, i3
     // CHECK-NEXT: [[MOD1:%.+]] = comb.mods bin %in3, [[IN3EX]] : i8
     // CHECK-NEXT: = comb.extract [[MOD1]] from 0 : (i8) -> i3
-    %20 = firrtl.rem %in3, %3 : (!firrtl.sint<8>, !firrtl.sint<3>) -> !firrtl.sint<3>
+    %20 = firrtl.rem %in3, %3 : !firrtl.sint<8>, !firrtl.sint<3>
 
     // CHECK: [[IN4EX:%.+]] = comb.concat {{.*}}, [[PADRES]] : i5, i3
     // CHECK-NEXT: [[MOD2:%.+]] = comb.mods bin [[IN4EX]], %in3 : i8
     // CHECK-NEXT: = comb.extract [[MOD2]] from 0 : (i8) -> i3
-    %21 = firrtl.rem %3, %in3 : (!firrtl.sint<3>, !firrtl.sint<8>) -> !firrtl.sint<3>
+    %21 = firrtl.rem %3, %in3 : !firrtl.sint<3>, !firrtl.sint<8>
 
     // Nodes with names become wires.
     // CHECK-NEXT: %n1 = hw.wire %in2
@@ -201,70 +201,70 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %n3 = firrtl.node sym @nodeSym %in2 : !firrtl.uint<2>
 
     // CHECK-NEXT: [[CVT:%.+]] = comb.concat %false, %in2 : i1, i2
-    %23 = firrtl.cvt %22 : (!firrtl.uint<2>) -> !firrtl.sint<3>
+    %23 = firrtl.cvt %22 : !firrtl.uint<2>
 
     // Will be dropped, here because this triggered a crash
-    %s23 = firrtl.cvt %in3 : (!firrtl.sint<8>) -> !firrtl.sint<8>
+    %s23 = firrtl.cvt %in3 : !firrtl.sint<8>
 
     // CHECK-NEXT: [[XOR:%.+]] = comb.xor bin [[CVT]], %c-1_i3 : i3
-    %24 = firrtl.not %23 : (!firrtl.sint<3>) -> !firrtl.uint<3>
+    %24 = firrtl.not %23 : !firrtl.sint<3>
 
-    %s24 = firrtl.asSInt %24 : (!firrtl.uint<3>) -> !firrtl.sint<3>
+    %s24 = firrtl.asSInt %24 : !firrtl.uint<3>
 
     // CHECK: [[SEXT:%.+]] = comb.concat {{.*}}, [[XOR]] : i1, i3
     // CHECK-NEXT: [[SUB:%.+]] = comb.sub bin %c0_i4, [[SEXT]] : i4
-    %25 = firrtl.neg %s24 : (!firrtl.sint<3>) -> !firrtl.sint<4>
+    %25 = firrtl.neg %s24 : !firrtl.sint<3>
 
     // CHECK: [[CVT4:%.+]] = comb.concat {{.*}}, [[CVT]] : i1, i3
     // CHECK-NEXT: comb.mux bin {{.*}}, [[CVT4]], [[SUB]] : i4
-    %26 = firrtl.mux(%17, %23, %25) : (!firrtl.uint<1>, !firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.sint<4>
+    %26 = firrtl.mux(%17, %23, %25) : !firrtl.uint<1>, !firrtl.sint<3>, !firrtl.sint<4>
 
     // CHECK-NEXT: = comb.icmp bin eq {{.*}}, %c-1_i14 : i14
-    %28 = firrtl.andr %18 : (!firrtl.uint<14>) -> !firrtl.uint<1>
+    %28 = firrtl.andr %18 : !firrtl.uint<14>
 
     // CHECK-NEXT: [[XOREXT:%.+]] = comb.concat %c0_i11, [[XOR]]
     // CHECK-NEXT: [[SHIFT:%.+]] = comb.shru bin [[XOREXT]], [[VAL18]] : i14
     // CHECK-NEXT: [[DSHR:%.+]] = comb.extract [[SHIFT]] from 0 : (i14) -> i3
-    %29 = firrtl.dshr %24, %18 : (!firrtl.uint<3>, !firrtl.uint<14>) -> !firrtl.uint<3>
+    %29 = firrtl.dshr %24, %18 : !firrtl.uint<3>, !firrtl.uint<14>
 
     // CHECK-NEXT: = comb.concat %c0_i5, {{.*}} : i5, i3
     // CHECK-NEXT: [[SHIFT:%.+]] = comb.shrs bin %in3, {{.*}} : i8
-    %a29 = firrtl.dshr %in3, %9 : (!firrtl.sint<8>, !firrtl.uint<3>) -> !firrtl.sint<8>
+    %a29 = firrtl.dshr %in3, %9 : !firrtl.sint<8>, !firrtl.uint<3>
 
     // CHECK: = comb.concat {{.*}}, %in3 : i7, i8
     // CHECK-NEXT: = comb.concat %c0_i12, [[DSHR]]
     // CHECK-NEXT: [[SHIFT:%.+]] = comb.shl bin {{.*}}, {{.*}} : i15
-    %30 = firrtl.dshl %in3, %29 : (!firrtl.sint<8>, !firrtl.uint<3>) -> !firrtl.sint<15>
+    %30 = firrtl.dshl %in3, %29 : !firrtl.sint<8>, !firrtl.uint<3>
 
     // CHECK-NEXT: = comb.shl bin [[DSHR]], [[DSHR]] : i3
-    %dshlw = firrtl.dshlw %29, %29 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
+    %dshlw = firrtl.dshlw %29, %29 : !firrtl.uint<3>, !firrtl.uint<3>
 
     // Issue #367: https://github.com/llvm/circt/issues/367
     // CHECK: = comb.concat {{.*}} : i10, i4
     // CHECK-NEXT: [[SHIFT:%.+]] = comb.shrs bin {{.*}}, {{.*}} : i14
     // CHECK-NEXT: = comb.extract [[SHIFT]] from 0 : (i14) -> i4
-    %31 = firrtl.dshr %25, %18 : (!firrtl.sint<4>, !firrtl.uint<14>) -> !firrtl.sint<4>
+    %31 = firrtl.dshr %25, %18 : !firrtl.sint<4>, !firrtl.uint<14>
 
     // Noop.
     %c0_ui1 = firrtl.constant 0 : !firrtl.const.uint<1>
-    %32 = firrtl.dshr %in1, %c0_ui1 { name = "test" } : (!firrtl.uint<4>, !firrtl.const.uint<1>) -> !firrtl.uint<4>
+    %32 = firrtl.dshr %in1, %c0_ui1 { name = "test" } : !firrtl.uint<4>, !firrtl.const.uint<1>
 
     // CHECK: comb.icmp bin ule {{.*}}, {{.*}} : i4
-    %41 = firrtl.leq %in1, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
+    %41 = firrtl.leq %in1, %4 : !firrtl.uint<4>, !firrtl.uint<4>
     // CHECK-NEXT: comb.icmp bin ult {{.*}}, {{.*}} : i4
-    %42 = firrtl.lt %in1, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
+    %42 = firrtl.lt %in1, %4 : !firrtl.uint<4>, !firrtl.uint<4>
     // CHECK-NEXT: comb.icmp bin uge {{.*}}, {{.*}} : i4
-    %43 = firrtl.geq %in1, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
+    %43 = firrtl.geq %in1, %4 : !firrtl.uint<4>, !firrtl.uint<4>
     // CHECK-NEXT: comb.icmp bin ugt {{.*}}, {{.*}} : i4
-    %44 = firrtl.gt %in1, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
+    %44 = firrtl.gt %in1, %4 : !firrtl.uint<4>, !firrtl.uint<4>
     // CHECK-NEXT: comb.icmp bin eq {{.*}}, {{.*}} : i4
-    %45 = firrtl.eq %in1, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
+    %45 = firrtl.eq %in1, %4 : !firrtl.uint<4>, !firrtl.uint<4>
     // CHECK-NEXT: comb.icmp bin ne {{.*}}, {{.*}} : i4
-    %46 = firrtl.neq %in1, %4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
+    %46 = firrtl.neq %in1, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 
     // Noop
-    %47 = firrtl.asClock %44 : (!firrtl.uint<1>) -> !firrtl.clock
-    %48 = firrtl.asAsyncReset %44 : (!firrtl.uint<1>) -> !firrtl.asyncreset
+    %47 = firrtl.asClock %44 : !firrtl.uint<1>
+    %48 = firrtl.asAsyncReset %44 : !firrtl.uint<1>
 
     // CHECK: [[VERB1:%.+]] = sv.verbatim.expr "MAGIC_CONSTANT" : () -> i42
     // CHECK: [[VERB2:%.+]] = sv.verbatim.expr "$bits({{[{][{]0[}][}]}}, {{[{][{]1[}][}]}})"([[VERB1]]) : (i42) -> i32 {symbols = [@Simple]}
@@ -279,33 +279,33 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %56 = firrtl.verbatim.expr "MAGIC_CONSTANT" : () -> !firrtl.uint<42>
     %57 = firrtl.verbatim.expr "$bits({{0}}, {{1}})"(%56) : (!firrtl.uint<42>) -> !firrtl.uint<32> {symbols = [@Simple]}
     %58 = firrtl.verbatim.wire "$size({{0}}, {{1}})"(%56) : (!firrtl.uint<42>) -> !firrtl.uint<32> {symbols = [@Simple]}
-    %59 = firrtl.add %56, %57 : (!firrtl.uint<42>, !firrtl.uint<32>) -> !firrtl.uint<43>
-    %60 = firrtl.add %58, %59 : (!firrtl.uint<32>, !firrtl.uint<43>) -> !firrtl.uint<44>
+    %59 = firrtl.add %56, %57 : !firrtl.uint<42>, !firrtl.uint<32>
+    %60 = firrtl.add %58, %59 : !firrtl.uint<32>, !firrtl.uint<43>
 
     // Issue #353
     // CHECK: [[PADRES_EXT:%.+]] = comb.concat {{.*}}, [[PADRES]] : i5, i3
     // CHECK: = comb.and bin %in3, [[PADRES_EXT]] : i8
-    %49 = firrtl.and %in3, %3 : (!firrtl.sint<8>, !firrtl.sint<3>) -> !firrtl.uint<8>
+    %49 = firrtl.and %in3, %3 : !firrtl.sint<8>, !firrtl.sint<3>
 
     // Issue #355: https://github.com/llvm/circt/issues/355
     // CHECK: [[IN1:%.+]] = comb.concat %c0_i6, %in1 : i6, i4
     // CHECK: [[DIV:%.+]] = comb.divu bin [[IN1]], %c306_i10 : i10
     // CHECK: = comb.extract [[DIV]] from 0 : (i10) -> i4
     %c306_ui10 = firrtl.constant 306 : !firrtl.uint<10>
-    %50 = firrtl.div %in1, %c306_ui10 : (!firrtl.uint<4>, !firrtl.uint<10>) -> !firrtl.uint<4>
+    %50 = firrtl.div %in1, %c306_ui10 : !firrtl.uint<4>, !firrtl.uint<10>
 
     %c1175_ui11 = firrtl.constant 1175 : !firrtl.uint<11>
-    %51 = firrtl.neg %c1175_ui11 : (!firrtl.uint<11>) -> !firrtl.sint<12>
+    %51 = firrtl.neg %c1175_ui11 : !firrtl.uint<11>
     // https://github.com/llvm/circt/issues/821
     // CHECK: [[CONCAT:%.+]] = comb.concat %false, %in1 : i1, i4
     // CHECK:  = comb.sub bin %c0_i5, [[CONCAT]] : i5
-    %52 = firrtl.neg %in1 : (!firrtl.uint<4>) -> !firrtl.sint<5>
-    %53 = firrtl.neg %in4 : (!firrtl.uint<0>) -> !firrtl.sint<1>
+    %52 = firrtl.neg %in1 : !firrtl.uint<4>
+    %53 = firrtl.neg %in4 : !firrtl.uint<0>
     // CHECK: [[SEXT:%.+]] = comb.concat {{.*}}, %in3 : i1, i8
     // CHECK: = comb.sub bin %c0_i9, [[SEXT]] : i9
-    %54 = firrtl.neg %in3 : (!firrtl.sint<8>) -> !firrtl.sint<9>
+    %54 = firrtl.neg %in3 : !firrtl.sint<8>
     firrtl.connect %out1, %53 : !firrtl.sint<1>, !firrtl.sint<1>
-    %55 = firrtl.neg %in5 : (!firrtl.sint<0>) -> !firrtl.sint<1>
+    %55 = firrtl.neg %in5 : !firrtl.sint<0>
 
     %61 = firrtl.multibit_mux %17, %55, %55, %55 : !firrtl.uint<1>, !firrtl.sint<1>
     // CHECK:      %[[ZEXT_INDEX:.+]] = comb.concat %false, {{.*}} : i1, i1
@@ -366,11 +366,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: }
     firrtl.printf %clock, %reset, "No operands!\0A" : !firrtl.clock, !firrtl.uint<1>
 
-    %0 = firrtl.add %a, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+    %0 = firrtl.add %a, %a : !firrtl.uint<4>, !firrtl.uint<4>
 
     firrtl.printf %clock, %reset, "Hi %x %x\0A"(%0, %b) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<4>
 
-    %1 = firrtl.add %c, %c : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.sint<5>
+    %1 = firrtl.add %c, %c : !firrtl.sint<4>, !firrtl.sint<4>
 
     firrtl.printf %clock, %reset, "Hi signed %d %d\0A"(%1, %d) : !firrtl.clock, !firrtl.uint<1>, !firrtl.sint<5>, !firrtl.sint<4>
 
@@ -669,7 +669,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     // CHECK-NEXT: %0 = comb.concat %c0_i38, %inp_2 : i38, i27
     // CHECK-NEXT: %1 = comb.divu bin %0, %inpi : i65
-    %0 = firrtl.div %inp_2, %inpi : (!firrtl.uint<27>, !firrtl.uint<65>) -> !firrtl.uint<27>
+    %0 = firrtl.div %inp_2, %inpi : !firrtl.uint<27>, !firrtl.uint<65>
     // CHECK-NEXT: %2 = comb.extract %1 from 0 : (i65) -> i27
     firrtl.connect %tmp48, %0 : !firrtl.uint<27>, !firrtl.uint<27>
   }
@@ -680,7 +680,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-NEXT:     hw.output %0
   firrtl.module private @test_rem(in %tmp85: !firrtl.uint<1>, in %tmp79: !firrtl.uint<1>,
        out %out: !firrtl.uint<1>) {
-    %2 = firrtl.rem %tmp79, %tmp85 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %2 = firrtl.rem %tmp79, %tmp85 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
@@ -709,7 +709,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
                         in %c1: !firrtl.analog<1>, out %outClock: !firrtl.clock) {
     firrtl.attach %a1, %b1, %c1 : !firrtl.analog<1>, !firrtl.analog<1>, !firrtl.analog<1>
 
-    %1 = firrtl.asClock %a1 : (!firrtl.analog<1>) -> !firrtl.clock
+    %1 = firrtl.asClock %a1 : !firrtl.analog<1>
     firrtl.connect %outClock, %1 : !firrtl.clock, !firrtl.clock
   }
 
@@ -721,10 +721,10 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   firrtl.module private @top_modx(out %tmp27: !firrtl.uint<23>) {
     %0 = firrtl.wire : !firrtl.uint<0>
     %c42_ui23 = firrtl.constant 42 : !firrtl.uint<23>
-    %1 = firrtl.tail %c42_ui23, 23 : (!firrtl.uint<23>) -> !firrtl.uint<0>
+    %1 = firrtl.tail %c42_ui23, 23 : !firrtl.uint<23>
     firrtl.connect %0, %1 : !firrtl.uint<0>, !firrtl.uint<0>
-    %2 = firrtl.head %c42_ui23, 0 : (!firrtl.uint<23>) -> !firrtl.uint<0>
-    %3 = firrtl.pad %2, 23 : (!firrtl.uint<0>) -> !firrtl.uint<23>
+    %2 = firrtl.head %c42_ui23, 0 : !firrtl.uint<23>
+    %3 = firrtl.pad %2, 23 : !firrtl.uint<0>
     firrtl.connect %tmp27, %3 : !firrtl.uint<23>, !firrtl.uint<23>
   }
 
@@ -834,7 +834,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // https://github.com/llvm/circt/issues/1115
   // CHECK-LABEL: hw.module private @issue1115
   firrtl.module private @issue1115(in %a: !firrtl.sint<20>, out %tmp59: !firrtl.sint<2>) {
-    %0 = firrtl.shr %a, 21 : (!firrtl.sint<20>) -> !firrtl.sint<1>
+    %0 = firrtl.shr %a, 21 : !firrtl.sint<20>
     firrtl.connect %tmp59, %0 : !firrtl.sint<2>, !firrtl.sint<1>
   }
 
@@ -1097,11 +1097,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-LABEL: hw.module private @PreserveName
   firrtl.module private @PreserveName(in %a : !firrtl.uint<1>, in %b : !firrtl.uint<1>, out %c : !firrtl.uint<1>) {
     // CHECK: comb.or bin %a, %b {sv.namehint = "myname"}
-    %foo = firrtl.or %a, %b {name = "myname"} : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %foo = firrtl.or %a, %b {name = "myname"} : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c, %foo : !firrtl.uint<1>, !firrtl.uint<1>
 
     // CHECK: comb.shl bin {{.*}} {sv.namehint = "anothername"}
-    %bar = firrtl.dshl %a, %b {name = "anothername"} : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+    %bar = firrtl.dshl %a, %b {name = "anothername"} : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
   // CHECK-LABEL: hw.module private @MultibitMux(in %source_0 : i1, in %source_1 : i1, in %source_2 : i1, out sink : i1, in %index : i2) {
@@ -1156,7 +1156,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // Blackbox input port creates a backedge.
     %inst = firrtl.instance blackbox @Blackbox(in inst: !firrtl.uint<1>)
     // No-op cast is removed, %cast lowered to point directly to the backedge.
-    %cast = firrtl.asClock %inst : (!firrtl.uint<1>) -> !firrtl.clock
+    %cast = firrtl.asClock %inst : !firrtl.uint<1>
     // Finalize the backedge, replacing all uses with %clock.
     firrtl.matchingconnect %inst, %clock : !firrtl.uint<1>
     // %cast accidentally still points to the back edge in the lowering table.
@@ -1434,11 +1434,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: Elementwise
   firrtl.module @Elementwise(in %a: !firrtl.vector<uint<1>, 2>, in %b: !firrtl.vector<uint<1>, 2>, out %c_0: !firrtl.vector<uint<1>, 2>, out %c_1: !firrtl.vector<uint<1>, 2>, out %c_2: !firrtl.vector<uint<1>, 2>) {
-    %0 = firrtl.elementwise_or %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+    %0 = firrtl.elementwise_or %a, %b : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
     firrtl.matchingconnect %c_0, %0 : !firrtl.vector<uint<1>, 2>
-    %1 = firrtl.elementwise_and %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+    %1 = firrtl.elementwise_and %a, %b : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
     firrtl.matchingconnect %c_1, %1 : !firrtl.vector<uint<1>, 2>
-    %2 = firrtl.elementwise_xor %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+    %2 = firrtl.elementwise_xor %a, %b : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
     firrtl.matchingconnect %c_2, %2 : !firrtl.vector<uint<1>, 2>
 
     // CHECK-NEXT: %0 = hw.bitcast %a : (!hw.array<2xi1>) -> i2
@@ -1460,7 +1460,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
   // CHECK-LABEL: @MuxIntrinsics
   firrtl.module @MuxIntrinsics(in %sel1: !firrtl.uint<1>, in %sel2: !firrtl.uint<2>, in %v3: !firrtl.uint<32>, in %v2: !firrtl.uint<32>, in %v1: !firrtl.uint<32>, in %v0: !firrtl.uint<32>, out %out1: !firrtl.uint<32>, out %out2: !firrtl.uint<32>) attributes {convention = #firrtl<convention scalarized>} {
-    %0 = firrtl.int.mux2cell(%sel1, %v1, %v0) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
+    %0 = firrtl.int.mux2cell(%sel1, %v1, %v0) : !firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>
     firrtl.matchingconnect %out1, %0 : !firrtl.uint<32>
     // CHECK-NEXT: %mux2cell_in0 = hw.wire %sel1 sym @{{.+}} : i1
     // CHECK-NEXT: %mux2cell_in1 = hw.wire %v1 sym @{{.+}} : i32
@@ -1470,7 +1470,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: sv.assign %1, %0 {sv.attributes = [#sv.attribute<"synopsys infer_mux_override", emitAsComment>]} : i32
     // CHECK-NEXT: %2 = sv.read_inout %1 : !hw.inout<i32>
 
-    %1 = firrtl.int.mux4cell(%sel2, %v3, %v2, %v1, %v0) : (!firrtl.uint<2>, !firrtl.uint<32>, !firrtl.uint<32>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
+    %1 = firrtl.int.mux4cell(%sel2, %v3, %v2, %v1, %v0) : !firrtl.uint<2>, !firrtl.uint<32>, !firrtl.uint<32>, !firrtl.uint<32>, !firrtl.uint<32>
     firrtl.matchingconnect %out2, %1 : !firrtl.uint<32>
     // CHECK:      %mux4cell_in0 = hw.wire %3 sym @{{.+}} : !hw.array<4xi32>
     // CHECK-NEXT: %mux4cell_in1 = hw.wire %sel2 sym @{{.+}} : i2
@@ -1555,7 +1555,7 @@ firrtl.circuit "Issue5011" {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c1_ui5 = firrtl.constant 1 : !firrtl.uint<5>
     firrtl.matchingconnect %out, %c1_ui5 : !firrtl.uint<5>
-    %0 = firrtl.eq %out, %c1_ui5 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<1>
+    %0 = firrtl.eq %out, %c1_ui5 : !firrtl.uint<5>, !firrtl.uint<5>
     firrtl.assert %clock, %0, %c1_ui1, "out was changed" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>  {eventControl = 0 : i32, isConcurrent = false}
     // CHECK: hw.output %[[OUT]]
   }
@@ -1572,7 +1572,7 @@ firrtl.circuit "Issue5011Sym" {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c1_ui5 = firrtl.constant 1 : !firrtl.uint<5>
     firrtl.matchingconnect %out, %c1_ui5 : !firrtl.uint<5>
-    %0 = firrtl.eq %out, %c1_ui5 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<1>
+    %0 = firrtl.eq %out, %c1_ui5 : !firrtl.uint<5>, !firrtl.uint<5>
     firrtl.assert %clock, %0, %c1_ui1, "out was changed" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>  {eventControl = 0 : i32, isConcurrent = false}
     // CHECK: hw.output %[[OUT]]
   }
@@ -1589,7 +1589,7 @@ firrtl.circuit "ClockMuxLowering" {
     out %out: !firrtl.clock) {
     // CHECK: [[OUT:%.+]] = seq.clock_mux %cond, %clockTrue, %clockFalse
     // CHECK: hw.output [[OUT]]
-    %0 = firrtl.mux(%cond, %clockTrue, %clockFalse) : (!firrtl.uint<1>, !firrtl.clock, !firrtl.clock) -> !firrtl.clock
+    %0 = firrtl.mux(%cond, %clockTrue, %clockFalse) : !firrtl.uint<1>, !firrtl.clock, !firrtl.clock
     firrtl.matchingconnect %out, %0 : !firrtl.clock
   }
 }
@@ -1617,7 +1617,7 @@ firrtl.circuit "ZeroWidthForeignOperand" {
     // CHECK-NEXT: dbg.variable "v1", %c0_i0 : i0
     // CHECK-NEXT: dbg.variable "v2", %c0_i0 : i0
     %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
-    %0 = firrtl.or %a, %c0_ui0 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
+    %0 = firrtl.or %a, %c0_ui0 : !firrtl.uint<0>, !firrtl.uint<0>
     dbg.variable "v0", %c0_ui0 : !firrtl.uint<0>
     dbg.variable "v1", %0 : !firrtl.uint<0>
     dbg.variable "v2", %a : !firrtl.uint<0>
@@ -1639,7 +1639,7 @@ firrtl.circuit "PortSym" {
     firrtl.matchingconnect %out, %c1_ui5 : !firrtl.uint<5>
     %e_a = firrtl.instance sub1 @Blackbox(out bar: !firrtl.uint<1>)
     firrtl.matchingconnect %a, %e_a : !firrtl.uint<1>
-    %0 = firrtl.eq %out, %c1_ui5 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<1>
+    %0 = firrtl.eq %out, %c1_ui5 : !firrtl.uint<5>, !firrtl.uint<5>
   }
 }
 

--- a/test/Conversion/FIRRTLToHW/zero-width.mlir
+++ b/test/Conversion/FIRRTLToHW/zero-width.mlir
@@ -10,30 +10,30 @@ firrtl.circuit "Arithmetic" {
   %uin0c = firrtl.wire : !firrtl.uint<0>
 
     // CHECK-DAG: [[MULZERO:%.+]] = hw.constant 0 : i3
-    %0 = firrtl.mul %uin0c, %uin3c : (!firrtl.uint<0>, !firrtl.uint<3>) -> !firrtl.uint<3>
+    %0 = firrtl.mul %uin0c, %uin3c : !firrtl.uint<0>, !firrtl.uint<3>
     firrtl.connect %out0, %0 : !firrtl.uint<3>, !firrtl.uint<3>
 
     // Lowers to nothing.
-    %m0 = firrtl.mul %uin0c, %uin0c : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
+    %m0 = firrtl.mul %uin0c, %uin0c : !firrtl.uint<0>, !firrtl.uint<0>
 
     // Lowers to nothing.
     %node = firrtl.node %m0 : !firrtl.uint<0>
 
     // Lowers to nothing.  Issue #429.
-    %div = firrtl.div %node, %uin3c : (!firrtl.uint<0>, !firrtl.uint<3>) -> !firrtl.uint<0>
+    %div = firrtl.div %node, %uin3c : !firrtl.uint<0>, !firrtl.uint<3>
 
     // CHECK-DAG: %c0_i4 = hw.constant 0 : i4
     // CHECK-DAG: %false = hw.constant false
     // CHECK-NEXT: [[UIN3EXT:%.+]] = comb.concat %false, %uin3c : i1, i3
     // CHECK-NEXT: [[ADDRES:%.+]] = comb.add bin [[UIN3EXT]], %c0_i4 : i4
-    %1 = firrtl.add %uin0c, %uin3c : (!firrtl.uint<0>, !firrtl.uint<3>) -> !firrtl.uint<4>
+    %1 = firrtl.add %uin0c, %uin3c : !firrtl.uint<0>, !firrtl.uint<3>
     firrtl.connect %out1, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
-    %2 = firrtl.shl %node, 4 : (!firrtl.uint<0>) -> !firrtl.uint<4>
+    %2 = firrtl.shl %node, 4 : !firrtl.uint<0>
     firrtl.connect %out2, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
     // Issue #436
-    %3 = firrtl.eq %uin0c, %uin0c : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
+    %3 = firrtl.eq %uin0c, %uin0c : !firrtl.uint<0>, !firrtl.uint<0>
     firrtl.connect %out3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
 
     // CHECK: hw.output %c0_i3, [[ADDRES]], %c0_i4, %true
@@ -46,23 +46,23 @@ firrtl.circuit "Arithmetic" {
     %uin0c = firrtl.wire : !firrtl.uint<0>
 
     // CHECK-DAG: = hw.constant true
-    %0 = firrtl.andr %uin0c : (!firrtl.uint<0>) -> !firrtl.uint<1>
+    %0 = firrtl.andr %uin0c : !firrtl.uint<0>
 
     // CHECK-DAG: = hw.constant false
-    %1 = firrtl.xorr %uin0c : (!firrtl.uint<0>) -> !firrtl.uint<1>
+    %1 = firrtl.xorr %uin0c : !firrtl.uint<0>
 
-    %2 = firrtl.orr %uin0c : (!firrtl.uint<0>) -> !firrtl.uint<1>
+    %2 = firrtl.orr %uin0c : !firrtl.uint<0>
 
     // Lowers to the uin3 value.
-    %3 = firrtl.cat %uin0c, %uin3c : (!firrtl.uint<0>, !firrtl.uint<3>) -> !firrtl.uint<3>
+    %3 = firrtl.cat %uin0c, %uin3c : !firrtl.uint<0>, !firrtl.uint<3>
     firrtl.connect %out0, %3 : !firrtl.uint<3>, !firrtl.uint<3>
 
     // Lowers to the uin3 value.
-    %4 = firrtl.cat %uin3c, %uin0c : (!firrtl.uint<3>, !firrtl.uint<0>) -> !firrtl.uint<3>
+    %4 = firrtl.cat %uin3c, %uin0c : !firrtl.uint<3>, !firrtl.uint<0>
     firrtl.connect %out1, %4 : !firrtl.uint<3>, !firrtl.uint<3>
 
     // Lowers to nothing.
-    %5 = firrtl.cat %uin0c, %uin0c : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
+    %5 = firrtl.cat %uin0c, %uin0c : !firrtl.uint<0>, !firrtl.uint<0>
 
     // CHECK: hw.output %uin3c, %uin3c : i3, i3
   }
@@ -83,7 +83,7 @@ firrtl.circuit "Arithmetic" {
   // See: https://github.com/llvm/circt/issues/6652
   // CHECK-LABEL: hw.module @ShrZW
   firrtl.module @ShrZW(in %x: !firrtl.uint<0>, out %out: !firrtl.uint<1>) attributes {convention = #firrtl<convention scalarized>} {
-    %0 = firrtl.shr %x, 5 : (!firrtl.uint<0>) -> !firrtl.uint<0>
+    %0 = firrtl.shr %x, 5 : !firrtl.uint<0>
     firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<0>
     // CHECK:      %[[false:.+]] = hw.constant false
     // CHECK-NEXT: hw.output %false

--- a/test/Dialect/FIRRTL/Reduction/connect-source-operand-forward.mlir
+++ b/test/Dialect/FIRRTL/Reduction/connect-source-operand-forward.mlir
@@ -7,7 +7,7 @@ firrtl.circuit "Foo" {
     %a = firrtl.wire : !firrtl.uint<1>
     %b = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     %c = firrtl.regreset %clock, %reset, %reset : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-    %0 = firrtl.bits %val 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
+    %0 = firrtl.bits %val 0 to 0 : !firrtl.uint<2>
     firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %b, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c, %0 : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/Reduction/port-pruner.mlir
+++ b/test/Dialect/FIRRTL/Reduction/port-pruner.mlir
@@ -12,8 +12,8 @@ firrtl.circuit "Foo" {
     %bar_a, %bar_b, %bar_c, %bar_d, %bar_e = firrtl.instance bar @Bar (in a: !firrtl.uint<1>, in b: !firrtl.uint<1>, out c: !firrtl.uint<1>, out d: !firrtl.uint<1>, out e: !firrtl.uint<1>)
     firrtl.connect %bar_a, %x : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %bar_b, %x : !firrtl.uint<1>, !firrtl.uint<1>
-    %0 = firrtl.add %bar_c, %bar_d : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-    %1 = firrtl.add %0, %bar_e : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<3>
+    %0 = firrtl.add %bar_c, %bar_d : !firrtl.uint<1>, !firrtl.uint<1>
+    %1 = firrtl.add %0, %bar_e : !firrtl.uint<2>, !firrtl.uint<1>
     firrtl.connect %y, %1 : !firrtl.uint<3>, !firrtl.uint<3>
   }
 
@@ -32,7 +32,7 @@ firrtl.circuit "Foo" {
     out %e: !firrtl.uint<1>
   ) {
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
-    %0 = firrtl.not %b : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.not %b : !firrtl.uint<1>
     firrtl.connect %c, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %d, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %e, %invalid_ui1 : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/constantProp.mlir
@@ -12,7 +12,7 @@ firrtl.circuit "ConstInput"   {
   }
   // CHECK-LABEL: firrtl.module private @Child
   firrtl.module private @Child(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-    %0 = firrtl.and %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.and %in0, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: firrtl.matchingconnect %out, %in0 :
     firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -43,8 +43,8 @@ firrtl.circuit "InstanceInput"   {
     firrtl.connect %b0_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
     %b1_in, %b1_out = firrtl.instance b1  @Bottom1(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b1_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
-    %0 = firrtl.and %b0_out, %b1_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %1 = firrtl.and %0, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.and %b0_out, %b1_out : !firrtl.uint<1>, !firrtl.uint<1>
+    %1 = firrtl.and %0, %c_out : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %[[C0:.+]] = firrtl.constant 1 : !firrtl.uint<1>
     // CHECK: firrtl.matchingconnect %z, %[[C0]] : !firrtl.uint<1>
     firrtl.connect %z, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -74,8 +74,8 @@ firrtl.circuit "InstanceInput2"   {
     firrtl.connect %b0_in, %x : !firrtl.uint<1>, !firrtl.uint<1>
     %b1_in, %b1_out = firrtl.instance b1 @Bottom2(in in: !firrtl.uint<1>, out out: !firrtl.uint<1>)
     firrtl.connect %b1_in, %c1_ui : !firrtl.uint<1>, !firrtl.uint
-    %0 = firrtl.and %b0_out, %b1_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %1 = firrtl.and %0, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.and %b0_out, %b1_out : !firrtl.uint<1>, !firrtl.uint<1>
+    %1 = firrtl.and %0, %c_out : !firrtl.uint<1>, !firrtl.uint<1>
    // CHECK:  firrtl.matchingconnect %z, %1
     firrtl.connect %z, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
@@ -88,7 +88,7 @@ firrtl.circuit "acrossWire"   {
     %_z = firrtl.wire droppable_name : !firrtl.uint<1>
     firrtl.connect %y, %_z : !firrtl.uint<1>, !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %0 = firrtl.mux(%x, %c0_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.mux(%x, %c0_ui1, %c0_ui1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %_z, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %[[C2:.+]] = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK-NEXT: firrtl.matchingconnect %y, %[[C2]] : !firrtl.uint<1>
@@ -103,7 +103,7 @@ firrtl.circuit "constOutput"   {
   }
   firrtl.module @constOutput(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>) {
     %c_out = firrtl.instance c @constOutChild(out out: !firrtl.uint<1>)
-    %0 = firrtl.and %x, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.and %x, %c_out : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %z, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %[[C3_0:.+]] = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: %[[C3:.+]] = firrtl.constant 0 : !firrtl.uint<1>
@@ -120,7 +120,7 @@ firrtl.circuit "optiMux"   {
     %c1_ui = firrtl.constant 1 : !firrtl.uint
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
     %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
-    %0 = firrtl.mux(%c1_ui, %c0_ui2, %c0_ui4) : (!firrtl.uint, !firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<4>
+    %0 = firrtl.mux(%c1_ui, %c0_ui2, %c0_ui4) : !firrtl.uint, !firrtl.uint<2>, !firrtl.uint<4>
     // CHECK: %[[C4:.+]] = firrtl.constant 0 :
     // CHECK: firrtl.matchingconnect %z, %[[C4]]
     firrtl.connect %z, %0 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -130,7 +130,7 @@ firrtl.circuit "optiMux"   {
 firrtl.circuit "divFold"   {
   // CHECK-LABEL: firrtl.module @divFold
   firrtl.module @divFold(in %a: !firrtl.uint<8>, out %b: !firrtl.uint<8>) {
-    %0 = firrtl.div %a, %a : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    %0 = firrtl.div %a, %a : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %b, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %[[C5:.+]] = firrtl.constant 1 : !firrtl.uint<8>
     // CHECK: firrtl.matchingconnect %b, %[[C5]] : !firrtl.uint<8>
@@ -146,7 +146,7 @@ firrtl.circuit "padConstWire"   {
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     firrtl.connect %_w_a, %c3_ui2 : !firrtl.uint<8>, !firrtl.uint<2>
     firrtl.connect %_w_b, %c3_ui2 : !firrtl.uint<8>, !firrtl.uint<2>
-    %0 = firrtl.cat %_w_a, %_w_b : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<16>
+    %0 = firrtl.cat %_w_a, %_w_b : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %0 : !firrtl.uint<16>, !firrtl.uint<16>
     // CHECK: %[[C6:.+]] = firrtl.constant 771 : !firrtl.uint<16>
     // CHECK-NEXT: firrtl.matchingconnect %z, %[[C6]] : !firrtl.uint<16>
@@ -162,7 +162,7 @@ firrtl.circuit "padConstReg"   {
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
     firrtl.connect %r_a, %c3_ui2 : !firrtl.uint<8>, !firrtl.uint<2>
     firrtl.connect %r_b, %c3_ui2 : !firrtl.uint<8>, !firrtl.uint<2>
-    %0 = firrtl.cat %r_a, %r_b : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<16>
+    %0 = firrtl.cat %r_a, %r_b : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %0 : !firrtl.uint<16>, !firrtl.uint<16>
     // CHECK: %[[C6:.+]] = firrtl.constant 771 : !firrtl.uint<16>
     // CHECK-NEXT: firrtl.matchingconnect %z, %[[C6]] : !firrtl.uint<16>
@@ -179,7 +179,7 @@ firrtl.circuit "padConstOut"   {
   firrtl.module @padConstOut(out %z: !firrtl.uint<16>) {
     %c_x = firrtl.instance c @padConstOutChild(out x: !firrtl.uint<8>)
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
-    %0 = firrtl.cat %c3_ui2, %c_x : (!firrtl.uint<2>, !firrtl.uint<8>) -> !firrtl.uint<10>
+    %0 = firrtl.cat %c3_ui2, %c_x : !firrtl.uint<2>, !firrtl.uint<8>
     // CHECK: %[[C8:.+]] = firrtl.constant 771 : !firrtl.uint<16>
     // CHECK: firrtl.matchingconnect %z, %[[C8]] : !firrtl.uint<16>
     firrtl.connect %z, %0 : !firrtl.uint<16>, !firrtl.uint<10>
@@ -191,7 +191,7 @@ firrtl.circuit "padConstIn"   {
   // CHECK-LABEL: firrtl.module private @padConstInChild
   firrtl.module private @padConstInChild(in %x: !firrtl.uint<8>, out %y: !firrtl.uint<16>) {
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
-    %0 = firrtl.cat %c3_ui2, %x : (!firrtl.uint<2>, !firrtl.uint<8>) -> !firrtl.uint<10>
+    %0 = firrtl.cat %c3_ui2, %x : !firrtl.uint<2>, !firrtl.uint<8>
     // CHECK: %[[C9:.+]] = firrtl.constant 771 : !firrtl.uint<16>
     // CHECK: firrtl.matchingconnect %y, %[[C9]] : !firrtl.uint<16>
     firrtl.connect %y, %0 : !firrtl.uint<16>, !firrtl.uint<10>
@@ -211,7 +211,7 @@ firrtl.circuit "padConstIn"   {
 firrtl.circuit "removePad"   {
   // CHECK-LABEL: firrtl.module @removePad
   firrtl.module @removePad(in %x: !firrtl.uint<8>, out %z: !firrtl.uint<8>) {
-    %0 = firrtl.pad %x, 6 : (!firrtl.uint<8>) -> !firrtl.uint<8>
+    %0 = firrtl.pad %x, 6 : !firrtl.uint<8>
     // CHECK: firrtl.matchingconnect %z, %x : !firrtl.uint<8>
     firrtl.connect %z, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   }
@@ -224,7 +224,7 @@ firrtl.circuit "asyncReset"   {
     %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
     %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<4>, !firrtl.uint<8>
     %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
-    %0 = firrtl.mux(%en, %c0_ui4, %r) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    %0 = firrtl.mux(%en, %c0_ui4, %r) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
     firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: firrtl.matchingconnect %r, %0 : !firrtl.uint<8>
@@ -252,8 +252,8 @@ firrtl.circuit "SignTester"   {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c0_si3 = firrtl.constant 0 : !firrtl.sint<3>
     %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
-    %0 = firrtl.neg %c3_ui2 : (!firrtl.uint<2>) -> !firrtl.sint<3>
-    %1 = firrtl.mux(%c0_ui1, %c0_si3, %0) : (!firrtl.uint<1>, !firrtl.sint<3>, !firrtl.sint<3>) -> !firrtl.sint<3>
+    %0 = firrtl.neg %c3_ui2 : !firrtl.uint<2>
+    %1 = firrtl.mux(%c0_ui1, %c0_si3, %0) : !firrtl.uint<1>, !firrtl.sint<3>, !firrtl.sint<3>
     firrtl.connect %ref, %1 : !firrtl.sint<3>, !firrtl.sint<3>
     // CHECK:  %[[C14:.+]] = firrtl.constant -3 : !firrtl.sint<3>
     // CHECK:  firrtl.matchingconnect %ref, %[[C14]] : !firrtl.sint<3>
@@ -265,7 +265,7 @@ firrtl.circuit "AddTester"   {
   // CHECK-LABEL: firrtl.module @AddTester
   firrtl.module @AddTester(out %ref: !firrtl.sint<2>) {
     %c-1_si1 = firrtl.constant -1 : !firrtl.sint<1>
-    %0 = firrtl.add %c-1_si1, %c-1_si1 : (!firrtl.sint<1>, !firrtl.sint<1>) -> !firrtl.sint<2>
+    %0 = firrtl.add %c-1_si1, %c-1_si1 : !firrtl.sint<1>, !firrtl.sint<1>
     firrtl.connect %ref, %0 : !firrtl.sint<2>, !firrtl.sint<2>
     // CHECK:  %[[C15:.+]] = firrtl.constant -2 : !firrtl.sint<2>
     // CHECK:  firrtl.matchingconnect %ref, %[[C15]]
@@ -277,11 +277,11 @@ firrtl.circuit "ConstPropReductionTester"   {
   // CHECK-LABEL: firrtl.module @ConstPropReductionTester
   firrtl.module @ConstPropReductionTester(out %out1: !firrtl.uint<1>, out %out2: !firrtl.uint<1>, out %out3: !firrtl.uint<1>) {
     %c-1_si2 = firrtl.constant -1 : !firrtl.sint<2>
-    %0 = firrtl.xorr %c-1_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
+    %0 = firrtl.xorr %c-1_si2 : !firrtl.sint<2>
     firrtl.connect %out1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-    %1 = firrtl.andr %c-1_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
+    %1 = firrtl.andr %c-1_si2 : !firrtl.sint<2>
     firrtl.connect %out2, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-    %2 = firrtl.orr %c-1_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
+    %2 = firrtl.orr %c-1_si2 : !firrtl.sint<2>
     firrtl.connect %out3, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-DAG:  %[[C16:.+]] = firrtl.constant 0
     // CHECK-DAG:  %[[C17:.+]] = firrtl.constant 1
@@ -296,11 +296,11 @@ firrtl.circuit "TailTester"   {
   firrtl.module @TailTester(out %out: !firrtl.uint<1>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c23_ui5 = firrtl.constant 23 : !firrtl.uint<5>
-    %0 = firrtl.add %c0_ui1, %c23_ui5 : (!firrtl.uint<1>, !firrtl.uint<5>) -> !firrtl.uint<6>
+    %0 = firrtl.add %c0_ui1, %c23_ui5 : !firrtl.uint<1>, !firrtl.uint<5>
     %_temp = firrtl.node droppable_name %0  : !firrtl.uint<6>
-    %1 = firrtl.head %_temp, 3 : (!firrtl.uint<6>) -> !firrtl.uint<3>
+    %1 = firrtl.head %_temp, 3 : !firrtl.uint<6>
     %_head_temp = firrtl.node droppable_name %1  : !firrtl.uint<3>
-    %2 = firrtl.tail %_head_temp, 2 : (!firrtl.uint<3>) -> !firrtl.uint<1>
+    %2 = firrtl.tail %_head_temp, 2 : !firrtl.uint<3>
     firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:  %[[C18:.+]] = firrtl.constant 0
     // CHECK:  firrtl.matchingconnect %out, %[[C18]]
@@ -313,11 +313,11 @@ firrtl.circuit "TailTester2"   {
   firrtl.module @TailTester2(out %out: !firrtl.uint<1>) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c23_ui5 = firrtl.constant 23 : !firrtl.uint<5>
-    %0 = firrtl.add %c0_ui1, %c23_ui5 : (!firrtl.uint<1>, !firrtl.uint<5>) -> !firrtl.uint<6>
+    %0 = firrtl.add %c0_ui1, %c23_ui5 : !firrtl.uint<1>, !firrtl.uint<5>
     %_temp = firrtl.node droppable_name %0  : !firrtl.uint<6>
-    %1 = firrtl.tail %_temp, 1 : (!firrtl.uint<6>) -> !firrtl.uint<5>
+    %1 = firrtl.tail %_temp, 1 : !firrtl.uint<6>
     %_tail_temp = firrtl.node droppable_name %1  : !firrtl.uint<5>
-    %2 = firrtl.tail %_tail_temp, 4 : (!firrtl.uint<5>) -> !firrtl.uint<1>
+    %2 = firrtl.tail %_tail_temp, 4 : !firrtl.uint<5>
     firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:  %[[C21:.+]] = firrtl.constant 1
     // CHECK:  firrtl.matchingconnect %out, %[[C21]]
@@ -329,10 +329,10 @@ firrtl.circuit "ZeroWidthAdd"   {
   // CHECK-LABEL: firrtl.module @ZeroWidthAdd
   firrtl.module @ZeroWidthAdd(in %x: !firrtl.uint<0>, out %y: !firrtl.uint<7>) {
     %c0_ui9 = firrtl.constant 0 : !firrtl.uint<9>
-    %0 = firrtl.add %x, %c0_ui9 : (!firrtl.uint<0>, !firrtl.uint<9>) -> !firrtl.uint<10>
+    %0 = firrtl.add %x, %c0_ui9 : !firrtl.uint<0>, !firrtl.uint<9>
     %_temp = firrtl.node droppable_name %0  : !firrtl.uint<10>
-    %1 = firrtl.cat %_temp, %_temp : (!firrtl.uint<10>, !firrtl.uint<10>) -> !firrtl.uint<20>
-    %2 = firrtl.tail %1, 13 : (!firrtl.uint<20>) -> !firrtl.uint<7>
+    %1 = firrtl.cat %_temp, %_temp : !firrtl.uint<10>, !firrtl.uint<10>
+    %2 = firrtl.tail %1, 13 : !firrtl.uint<20>
     firrtl.connect %y, %2 : !firrtl.uint<7>, !firrtl.uint<7>
     // CHECK:  %[[C20:.+]] = firrtl.constant 0
     // CHECK:  firrtl.matchingconnect %y, %[[C20]]
@@ -345,7 +345,7 @@ firrtl.circuit "regConstReset"   {
   firrtl.module @regConstReset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
     %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
     %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
-    %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+    %0 = firrtl.mux(%cond, %c11_ui8, %r) : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
     firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
     // CHECK: %[[C22:.+]] = firrtl.constant 11 
@@ -360,12 +360,12 @@ firrtl.circuit "constPropRegMux"   {
   %r1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
   %r2 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %0 = firrtl.mux(%en, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.mux(%en, %c1_ui1, %r1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %1 = firrtl.mux(%en, %r2, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %1 = firrtl.mux(%en, %r2, %c0_ui1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %r2, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  %2 = firrtl.xor %r1, %r2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %2 = firrtl.xor %r1, %r2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %[[C23:.+]] = firrtl.constant 1
     // CHECK: firrtl.matchingconnect %out, %[[C23]]

--- a/test/Dialect/FIRRTL/SFCTests/constantPropFail.mlir
+++ b/test/Dialect/FIRRTL/SFCTests/constantPropFail.mlir
@@ -9,7 +9,7 @@
       firrtl.matchingconnect %_r, %_r : !firrtl.uint<8>
       %c171_ui8 = firrtl.constant 171 : !firrtl.uint<8>
       %_n = firrtl.node droppable_name %c171_ui8  : !firrtl.uint<8>
-      %1 = firrtl.cat %_n, %_r : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<16>
+      %1 = firrtl.cat %_n, %_r : !firrtl.uint<8>, !firrtl.uint<8>
       firrtl.matchingconnect %z, %1 : !firrtl.uint<16>
     // CHECK: %[[TMP:.+]] = firrtl.constant 43776 : !firrtl.uint<16>
     // CHECK-NEXT: firrtl.matchingconnect %z, %[[TMP]] : !firrtl.uint<16>

--- a/test/Dialect/FIRRTL/advanced-layer-sink.mlir
+++ b/test/Dialect/FIRRTL/advanced-layer-sink.mlir
@@ -198,14 +198,14 @@ firrtl.circuit "Top" {
   // CHECK: firrtl.module @Top() {
   // CHECK:   firrtl.layerblock @A {
   // CHECK:     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  // CHECK:     %0 = firrtl.not %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  // CHECK:     %0 = firrtl.not %c0_ui1 : !firrtl.uint<1>
   // CHECK:     %node = firrtl.node %0 : !firrtl.uint<1>
   // CHECK:     "unknown"(%node) : (!firrtl.uint<1>) -> ()
   // CHECK:   }
   // CHECK: }
   firrtl.module @Top() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %0 = firrtl.not %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.not %c0_ui1 : !firrtl.uint<1>
     %node = firrtl.node %0 : !firrtl.uint<1>
     firrtl.layerblock @A {
       "unknown"(%node) : (!firrtl.uint<1>) -> ()
@@ -218,13 +218,13 @@ firrtl.circuit "Top" {
   firrtl.layer @A bind {}
   // CHECK: firrtl.module @Top(in %port: !firrtl.uint<1>) { 
   // CHECK:   firrtl.layerblock @A {
-  // CHECK:     %0 = firrtl.not %port : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  // CHECK:     %0 = firrtl.not %port : !firrtl.uint<1>
   // CHECK:     %node = firrtl.node %0 : !firrtl.uint<1>
   // CHECK:     "unknown"(%node) : (!firrtl.uint<1>) -> ()
   // CHECK:   }
   // CHECK: }
   firrtl.module @Top(in %port : !firrtl.uint<1>) {
-    %0 = firrtl.not %port : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.not %port : !firrtl.uint<1>
     %node = firrtl.node %0 : !firrtl.uint<1>
     firrtl.layerblock @A {
       "unknown"(%node) : (!firrtl.uint<1>) -> ()
@@ -269,7 +269,7 @@ firrtl.circuit "Top" {
  firrtl.layer @A bind {}
  firrtl.module @Top(out %port: !firrtl.uint<1>) {
    %c = firrtl.constant 0 : !firrtl.uint<1>
-   %0 = firrtl.not %port : (!firrtl.uint<1>) -> !firrtl.uint<1>
+   %0 = firrtl.not %port : !firrtl.uint<1>
    %node = firrtl.node %c : !firrtl.uint<1>
    firrtl.connect %port, %node : !firrtl.uint<1>, !firrtl.uint<1>
    firrtl.layerblock @A {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -19,30 +19,30 @@ firrtl.module @Casts(in %ui1 : !firrtl.uint<1>, in %si1 : !firrtl.sint<1>,
 
   // No effect
   // CHECK: firrtl.matchingconnect %out_ui1, %ui1 : !firrtl.uint<1>
-  %0 = firrtl.asUInt %ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.asUInt %ui1 : !firrtl.uint<1>
   firrtl.connect %out_ui1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.matchingconnect %out_si1, %si1 : !firrtl.sint<1>
-  %1 = firrtl.asSInt %si1 : (!firrtl.sint<1>) -> !firrtl.sint<1>
+  %1 = firrtl.asSInt %si1 : !firrtl.sint<1>
   firrtl.connect %out_si1, %1 : !firrtl.sint<1>, !firrtl.sint<1>
   // CHECK: firrtl.matchingconnect %out_clock, %clock : !firrtl.clock
-  %2 = firrtl.asClock %clock : (!firrtl.clock) -> !firrtl.clock
+  %2 = firrtl.asClock %clock : !firrtl.clock
   firrtl.connect %out_clock, %2 : !firrtl.clock, !firrtl.clock
   // CHECK: firrtl.matchingconnect %out_asyncreset, %asyncreset : !firrtl.asyncreset
-  %3 = firrtl.asAsyncReset %asyncreset : (!firrtl.asyncreset) -> !firrtl.asyncreset
+  %3 = firrtl.asAsyncReset %asyncreset : !firrtl.asyncreset
   firrtl.connect %out_asyncreset, %3 : !firrtl.asyncreset, !firrtl.asyncreset
 
   // Constant fold.
   // CHECK: firrtl.matchingconnect %out_ui1, %c1_ui1 : !firrtl.uint<1>
-  %4 = firrtl.asUInt %c1_si1 : (!firrtl.sint<1>) -> !firrtl.uint<1>
+  %4 = firrtl.asUInt %c1_si1 : !firrtl.sint<1>
   firrtl.connect %out_ui1, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.matchingconnect %out_si1, %c-1_si1 : !firrtl.sint<1>
-  %5 = firrtl.asSInt %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.sint<1>
+  %5 = firrtl.asSInt %c1_ui1 : !firrtl.uint<1>
   firrtl.connect %out_si1, %5 : !firrtl.sint<1>, !firrtl.sint<1>
   // CHECK: firrtl.matchingconnect %out_clock, %c1_clock : !firrtl.clock
-  %6 = firrtl.asClock %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.clock
+  %6 = firrtl.asClock %c1_ui1 : !firrtl.uint<1>
   firrtl.connect %out_clock, %6 : !firrtl.clock, !firrtl.clock
   // CHECK: firrtl.matchingconnect %out_asyncreset, %c1_asyncreset : !firrtl.asyncreset
-  %7 = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
+  %7 = firrtl.asAsyncReset %c1_ui1 : !firrtl.uint<1>
   firrtl.connect %out_asyncreset, %7 : !firrtl.asyncreset, !firrtl.asyncreset
   // CHECK: firrtl.matchingconnect %outreset, %inreset : !firrtl.reset
   %8 = firrtl.resetCast %inreset : (!firrtl.reset) -> !firrtl.reset
@@ -50,15 +50,15 @@ firrtl.module @Casts(in %ui1 : !firrtl.uint<1>, in %si1 : !firrtl.sint<1>,
 
   // Transparent
   // CHECK: firrtl.matchingconnect %out2_si1, %si1
-  %9 = firrtl.asUInt %si1 : (!firrtl.sint<1>) -> !firrtl.uint<1>
-  %10 = firrtl.asSInt %9 : (!firrtl.uint<1>) -> !firrtl.sint<1>
+  %9 = firrtl.asUInt %si1 : !firrtl.sint<1>
+  %10 = firrtl.asSInt %9 : !firrtl.uint<1>
   firrtl.matchingconnect %out2_si1, %10 : !firrtl.sint<1>
   // CHECK: firrtl.matchingconnect %out2_ui1, %ui1
-  %11 = firrtl.asSInt %ui1 : (!firrtl.uint<1>) -> !firrtl.sint<1>
-  %12 = firrtl.asUInt %11 : (!firrtl.sint<1>) -> !firrtl.uint<1>
+  %11 = firrtl.asSInt %ui1 : !firrtl.uint<1>
+  %12 = firrtl.asUInt %11 : !firrtl.sint<1>
   firrtl.matchingconnect %out2_ui1, %12 : !firrtl.uint<1>
   // CHECK: firrtl.matchingconnect %out2_si1, %si1
-  %13 = firrtl.cvt %si1 : (!firrtl.sint<1>) -> !firrtl.sint<1>
+  %13 = firrtl.cvt %si1 : !firrtl.sint<1>
   firrtl.matchingconnect %out2_si1, %13 : !firrtl.sint<1>
 }
 
@@ -80,34 +80,34 @@ firrtl.module @Div(in %a: !firrtl.uint<4>,
 
   // Check that 'div(a, a) -> 1' works for known UInt widths.
   // CHECK: firrtl.matchingconnect %b, [[ONE_i4]]
-  %0 = firrtl.div %a, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %0 = firrtl.div %a, %a : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %b, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // Check that 'div(c, c) -> 1' works for known SInt widths.
   // CHECK: firrtl.matchingconnect %d, [[ONE_s5]] : !firrtl.sint<5>
-  %1 = firrtl.div %c, %c : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.sint<5>
+  %1 = firrtl.div %c, %c : !firrtl.sint<4>, !firrtl.sint<4>
   firrtl.connect %d, %1 : !firrtl.sint<5>, !firrtl.sint<5>
 
   // Check that 'div(e, e) -> 1' works for unknown UInt widths.
   // CHECK: firrtl.connect %f, [[ONE_i2]]
-  %2 = firrtl.div %e, %e : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+  %2 = firrtl.div %e, %e : !firrtl.uint, !firrtl.uint
   firrtl.connect %f, %2 : !firrtl.uint, !firrtl.uint
 
   // Check that 'div(g, g) -> 1' works for unknown SInt widths.
   // CHECK: firrtl.connect %h, [[ONE_s2]]
-  %3 = firrtl.div %g, %g : (!firrtl.sint, !firrtl.sint) -> !firrtl.sint
+  %3 = firrtl.div %g, %g : !firrtl.sint, !firrtl.sint
   firrtl.connect %h, %3 : !firrtl.sint, !firrtl.sint
 
   // Check that 'div(a, 1) -> a' for known UInt widths.
   // CHECK: firrtl.matchingconnect %b, %a
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-  %4 = firrtl.div %a, %c1_ui2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<4>
+  %4 = firrtl.div %a, %c1_ui2 : !firrtl.uint<4>, !firrtl.uint<2>
   firrtl.connect %b, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %i, %c5_ui4
   %c1_ui4 = firrtl.constant 15 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
-  %5 = firrtl.div %c1_ui4, %c3_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %5 = firrtl.div %c1_ui4, %c3_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %i, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
@@ -126,30 +126,30 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
   %c3_si5 = firrtl.constant 3 : !firrtl.sint<5>
 
-  %0 = firrtl.and %c3_ui4, %c1_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %0 = firrtl.and %c3_ui4, %c1_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %in
   %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
-  %1 = firrtl.and %in, %c15_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %1 = firrtl.and %in, %c15_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %c0_ui4
   %c1_ui0 = firrtl.constant 0 : !firrtl.uint<4>
-  %2 = firrtl.and %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %2 = firrtl.and %in, %c1_ui0 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %c0_ui4
-  %inv_2 = firrtl.and %c1_ui0, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %inv_2 = firrtl.and %c1_ui0, %in : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %inv_2 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %in
-  %3 = firrtl.and %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %3 = firrtl.and %in, %in : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %c0_ui4
   // CHECK: firrtl.matchingconnect %outz, %c0_ui0
-  %zw = firrtl.and %zin1, %zin2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
+  %zw = firrtl.and %zin1, %zin2 : !firrtl.uint<0>, !firrtl.uint<0>
   firrtl.connect %out, %zw : !firrtl.uint<4>, !firrtl.uint<0>
   firrtl.matchingconnect %outz, %zw : !firrtl.uint<0>
 
@@ -157,42 +157,42 @@ firrtl.module @And(in %in: !firrtl.uint<4>,
   // cannot be folded!
 
   // Narrows, then folds away
-  // CHECK: %0 = firrtl.bits %in 1 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
-  // CHECK-NEXT: %1 = firrtl.pad %0, 4 : (!firrtl.uint<2>) -> !firrtl.uint<4>
+  // CHECK: %0 = firrtl.bits %in 1 to 0 : !firrtl.uint<4>
+  // CHECK-NEXT: %1 = firrtl.pad %0, 4 : !firrtl.uint<2>
   // CHECK-NEXT: firrtl.matchingconnect %out, %1
   %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
-  %4 = firrtl.and %in, %c3_ui2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<4>
+  %4 = firrtl.and %in, %c3_ui2 : !firrtl.uint<4>, !firrtl.uint<2>
   firrtl.connect %out, %4 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // Mixed type input and outputs.
 
   // CHECK: firrtl.matchingconnect %out, %c1_ui4
   %c1_si4 = firrtl.constant 1 : !firrtl.sint<4>
-  %5 = firrtl.and %c1_si4, %c1_si4 : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
+  %5 = firrtl.and %c1_si4, %c1_si4 : !firrtl.sint<4>, !firrtl.sint<4>
   firrtl.connect %out, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: %[[AND:.+]] = firrtl.asUInt %sin
   // CHECK-NEXT: firrtl.matchingconnect %out, %[[AND]]
-  %6 = firrtl.and %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
+  %6 = firrtl.and %sin, %sin : !firrtl.sint<4>, !firrtl.sint<4>
   firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %c0_ui4
   %c0_si2 = firrtl.constant 0 : !firrtl.sint<2>
-  %7 = firrtl.and %sin, %c0_si2 : (!firrtl.sint<4>, !firrtl.sint<2>) -> !firrtl.uint<4>
+  %7 = firrtl.and %sin, %c0_si2 : !firrtl.sint<4>, !firrtl.sint<2>
   firrtl.matchingconnect %out, %7 : !firrtl.uint<4>
 
   // CHECK: %[[trunc:.*]] = firrtl.bits %in6
   // CHECK: %[[ANDPAD:.*]] = firrtl.and %[[trunc]], %in
   // CHECK: %[[POST:.*]] = firrtl.pad %[[ANDPAD]]
   // CHECK: firrtl.matchingconnect %out6, %[[POST]]
-  %8 = firrtl.pad %in, 6 : (!firrtl.uint<4>) -> !firrtl.uint<6>
-  %9 = firrtl.and %in6, %8  : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
+  %8 = firrtl.pad %in, 6 : !firrtl.uint<4>
+  %9 = firrtl.and %in6, %8  : !firrtl.uint<6>, !firrtl.uint<6>
   firrtl.matchingconnect %out6, %9 : !firrtl.uint<6>
 
   // CHECK: %[[AND:.*]] = firrtl.and %in, %c3_ui4
   // CHECK: firrtl.pad %[[AND]], 5
-  %10 = firrtl.cvt %in : (!firrtl.uint<4>) -> !firrtl.sint<5>
-  %11 = firrtl.and %10, %c3_si5 : (!firrtl.sint<5>, !firrtl.sint<5>) -> !firrtl.uint<5>
+  %10 = firrtl.cvt %in : !firrtl.uint<4>
+  %11 = firrtl.and %10, %c3_si5 : !firrtl.sint<5>, !firrtl.sint<5>
   firrtl.matchingconnect %out5, %11 : !firrtl.uint<5>
 }
 
@@ -208,30 +208,30 @@ firrtl.module @Or(in %in: !firrtl.uint<4>,
   // CHECK: firrtl.matchingconnect %out, %c7_ui4
   %c4_ui4 = firrtl.constant 4 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
-  %0 = firrtl.or %c3_ui4, %c4_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %0 = firrtl.or %c3_ui4, %c4_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %c15_ui4
   %c1_ui15 = firrtl.constant 15 : !firrtl.uint<4>
-  %1 = firrtl.or %in, %c1_ui15 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %1 = firrtl.or %in, %c1_ui15 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %in
   %c1_ui0 = firrtl.constant 0 : !firrtl.uint<4>
-  %2 = firrtl.or %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %2 = firrtl.or %in, %c1_ui0 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %in
-  %inv_2 = firrtl.or %c1_ui0, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %inv_2 = firrtl.or %c1_ui0, %in : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %inv_2 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %in
-  %3 = firrtl.or %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %3 = firrtl.or %in, %in : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %c0_ui4
   // CHECK: firrtl.matchingconnect %outz, %c0_ui0
-  %zw = firrtl.or %zin1, %zin2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
+  %zw = firrtl.or %zin1, %zin2 : !firrtl.uint<0>, !firrtl.uint<0>
   firrtl.connect %out, %zw : !firrtl.uint<4>, !firrtl.uint<0>
   firrtl.matchingconnect %outz, %zw : !firrtl.uint<0>
 
@@ -239,17 +239,17 @@ firrtl.module @Or(in %in: !firrtl.uint<4>,
 
   // CHECK: firrtl.matchingconnect %out, %c1_ui4
   %c1_si4 = firrtl.constant 1 : !firrtl.sint<4>
-  %5 = firrtl.or %c1_si4, %c1_si4 : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
+  %5 = firrtl.or %c1_si4, %c1_si4 : !firrtl.sint<4>, !firrtl.sint<4>
   firrtl.connect %out, %5 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: [[OR:%.+]] = firrtl.asUInt %sin
   // CHECK-NEXT: firrtl.matchingconnect %out, [[OR]]
-  %6 = firrtl.or %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
+  %6 = firrtl.or %sin, %sin : !firrtl.sint<4>, !firrtl.sint<4>
   firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %c15_ui4
   %c0_si2 = firrtl.constant -1 : !firrtl.sint<2>
-  %7 = firrtl.or %sin, %c0_si2 : (!firrtl.sint<4>, !firrtl.sint<2>) -> !firrtl.uint<4>
+  %7 = firrtl.or %sin, %c0_si2 : !firrtl.sint<4>, !firrtl.sint<2>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: %[[trunc:.*]] = firrtl.bits %in6
@@ -257,8 +257,8 @@ firrtl.module @Or(in %in: !firrtl.uint<4>,
   // CHECK: %[[OR:.*]] = firrtl.or %[[trunc2]], %in
   // CHECK: %[[CAT:.*]] = firrtl.cat %[[trunc]], %[[OR]]
   // CHECK: firrtl.matchingconnect %out6, %[[CAT]]
-  %8 = firrtl.pad %in, 6 : (!firrtl.uint<4>) -> !firrtl.uint<6>
-  %9 = firrtl.or %in6, %8  : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
+  %8 = firrtl.pad %in, 6 : !firrtl.uint<4>
+  %9 = firrtl.or %in6, %8  : !firrtl.uint<6>, !firrtl.uint<6>
   firrtl.connect %out6, %9 : !firrtl.uint<6>, !firrtl.uint<6>
 
 }
@@ -275,34 +275,34 @@ firrtl.module @Xor(in %in: !firrtl.uint<4>,
   // CHECK: firrtl.matchingconnect %out, %c2_ui4
   %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
-  %0 = firrtl.xor %c3_ui4, %c1_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %0 = firrtl.xor %c3_ui4, %c1_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %in
   %c1_ui0 = firrtl.constant 0 : !firrtl.uint<4>
-  %2 = firrtl.xor %in, %c1_ui0 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %2 = firrtl.xor %in, %c1_ui0 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %c0_ui4
-  %3 = firrtl.xor %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %3 = firrtl.xor %in, %in : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %3 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %c0_ui4
   // CHECK: firrtl.matchingconnect %outz, %c0_ui0
-  %zw = firrtl.xor %zin1, %zin2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
+  %zw = firrtl.xor %zin1, %zin2 : !firrtl.uint<0>, !firrtl.uint<0>
   firrtl.connect %out, %zw : !firrtl.uint<4>, !firrtl.uint<0>
   firrtl.matchingconnect %outz, %zw : !firrtl.uint<0>
 
   // Mixed type input and outputs.
 
   // CHECK: firrtl.matchingconnect %out, %c0_ui4
-  %6 = firrtl.xor %sin, %sin : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.uint<4>
+  %6 = firrtl.xor %sin, %sin : !firrtl.sint<4>, !firrtl.sint<4>
   firrtl.connect %out, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: %[[aui:.*]] = firrtl.asUInt %sin
   // CHECK: firrtl.matchingconnect %out, %[[aui]]
   %c0_si2 = firrtl.constant 0 : !firrtl.sint<2>
-  %7 = firrtl.xor %sin, %c0_si2 : (!firrtl.sint<4>, !firrtl.sint<2>) -> !firrtl.uint<4>
+  %7 = firrtl.xor %sin, %c0_si2 : !firrtl.sint<4>, !firrtl.sint<2>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: %[[trunc:.*]] = firrtl.bits %in6
@@ -310,8 +310,8 @@ firrtl.module @Xor(in %in: !firrtl.uint<4>,
   // CHECK: %[[XOR:.*]] = firrtl.xor %[[trunc2]], %in
   // CHECK: %[[CAT:.*]] = firrtl.cat %[[trunc]], %[[XOR]]
   // CHECK: firrtl.matchingconnect %out6, %[[CAT]]
-  %8 = firrtl.pad %in, 6 : (!firrtl.uint<4>) -> !firrtl.uint<6>
-  %9 = firrtl.xor %in6, %8  : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
+  %8 = firrtl.pad %in, 6 : !firrtl.uint<4>
+  %9 = firrtl.xor %in6, %8  : !firrtl.uint<6>, !firrtl.uint<6>
   firrtl.connect %out6, %9 : !firrtl.uint<6>, !firrtl.uint<6>
 
 }
@@ -322,49 +322,49 @@ firrtl.module @Not(in %in: !firrtl.uint<4>,
                    out %out1: !firrtl.uint<1>,
                    out %outu: !firrtl.uint<4>,
                    out %outs: !firrtl.uint<4>) {
-  %0 = firrtl.not %in : (!firrtl.uint<4>) -> !firrtl.uint<4>
-  %1 = firrtl.not %0 : (!firrtl.uint<4>) -> !firrtl.uint<4>
+  %0 = firrtl.not %in : !firrtl.uint<4>
+  %1 = firrtl.not %0 : !firrtl.uint<4>
   firrtl.connect %outu, %1 : !firrtl.uint<4>, !firrtl.uint<4>
-  %2 = firrtl.not %sin : (!firrtl.sint<4>) -> !firrtl.uint<4>
-  %3 = firrtl.not %2 : (!firrtl.uint<4>) -> !firrtl.uint<4>
+  %2 = firrtl.not %sin : !firrtl.sint<4>
+  %3 = firrtl.not %2 : !firrtl.uint<4>
   firrtl.connect %outs, %3 : !firrtl.uint<4>, !firrtl.uint<4>
   // CHECK: firrtl.matchingconnect %outu, %in
   // CHECK: %[[cast:.*]] = firrtl.asUInt %sin
   // CHECK: firrtl.matchingconnect %outs, %[[cast]]
 
   %c5_ui4 = firrtl.constant 5 : !firrtl.uint<4>
-  %5 = firrtl.eq %in, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %6 = firrtl.not %5 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %5 = firrtl.eq %in, %c5_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
+  %6 = firrtl.not %5 : !firrtl.uint<1>
   firrtl.matchingconnect %out1, %6 : !firrtl.uint<1>
   // CHECK: firrtl.neq
   // CHECK-NEXT: firrtl.matchingconnect
 
-  %7 = firrtl.neq %in, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %8 = firrtl.not %7 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %7 = firrtl.neq %in, %c5_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
+  %8 = firrtl.not %7 : !firrtl.uint<1>
   firrtl.matchingconnect %out1, %8 : !firrtl.uint<1>
   // CHECK: firrtl.eq
   // CHECK-NEXT: firrtl.matchingconnect
 
-  %9 = firrtl.lt %in, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %10 = firrtl.not %9 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %9 = firrtl.lt %in, %c5_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
+  %10 = firrtl.not %9 : !firrtl.uint<1>
   firrtl.matchingconnect %out1, %10 : !firrtl.uint<1>
   // CHECK: firrtl.geq
   // CHECK-NEXT: firrtl.matchingconnect
 
-  %11 = firrtl.leq %in, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %12 = firrtl.not %11 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %11 = firrtl.leq %in, %c5_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
+  %12 = firrtl.not %11 : !firrtl.uint<1>
   firrtl.matchingconnect %out1, %12 : !firrtl.uint<1>
   // CHECK: firrtl.gt
   // CHECK-NEXT: firrtl.matchingconnect
 
-  %13 = firrtl.gt %in, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %14 = firrtl.not %13 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %13 = firrtl.gt %in, %c5_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
+  %14 = firrtl.not %13 : !firrtl.uint<1>
   firrtl.matchingconnect %out1, %14 : !firrtl.uint<1>
   // CHECK: firrtl.leq
   // CHECK-NEXT: firrtl.matchingconnect
 
-  %15 = firrtl.geq %in, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %16 = firrtl.not %15 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %15 = firrtl.geq %in, %c5_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
+  %16 = firrtl.not %15 : !firrtl.uint<1>
   firrtl.matchingconnect %out1, %16 : !firrtl.uint<1>
   // CHECK: firrtl.lt
   // CHECK-NEXT: firrtl.matchingconnect
@@ -377,37 +377,37 @@ firrtl.module @EQ(in %in1: !firrtl.uint<1>,
                   out %out: !firrtl.uint<1>) {
   // CHECK: firrtl.matchingconnect %out, %in1
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %0 = firrtl.eq %in1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.eq %in1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // Issue #368: https://github.com/llvm/circt/issues/368
   %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
-  %1 = firrtl.eq %in1, %c3_ui2 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<1>
+  %1 = firrtl.eq %in1, %c3_ui2 : !firrtl.uint<1>, !firrtl.uint<2>
   firrtl.connect %out, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.eq %in1, %c3_ui2
   // CHECK-NEXT: firrtl.matchingconnect
 
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %2 = firrtl.eq %in1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %2 = firrtl.eq %in1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.not %in1
   // CHECK-NEXT: firrtl.matchingconnect
 
   %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
-  %3 = firrtl.eq %in4, %c15_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
+  %3 = firrtl.eq %in4, %c15_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.andr %in4
   // CHECK-NEXT: firrtl.matchingconnect
 
-  %4 = firrtl.eq %in4, %c0_ui1 : (!firrtl.uint<4>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %4 = firrtl.eq %in4, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
   firrtl.connect %out, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: [[ORR:%.+]] = firrtl.orr %in4
   // CHECK-NEXT: firrtl.not [[ORR]]
   // CHECK-NEXT: firrtl.matchingconnect
 
   %c5_ui4 = firrtl.constant 5 : !firrtl.uint<4>
-  %5 = firrtl.neq %in4, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %6 = firrtl.eq %5, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %5 = firrtl.neq %in4, %c5_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
+  %6 = firrtl.eq %5, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.matchingconnect %out, %6 : !firrtl.uint<1>
   // CHECK: firrtl.eq
   // CHECK-NEXT: firrtl.matchingconnect
@@ -420,30 +420,30 @@ firrtl.module @NEQ(in %in1: !firrtl.uint<1>,
                    out %out: !firrtl.uint<1>) {
   // CHECK: firrtl.matchingconnect %out, %in
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %0 = firrtl.neq %in1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.neq %in1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %1 = firrtl.neq %in1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %1 = firrtl.neq %in1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.not %in1
   // CHECK-NEXT: firrtl.matchingconnect
 
-  %2 = firrtl.neq %in4, %c0_ui1 : (!firrtl.uint<4>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %2 = firrtl.neq %in4, %c0_ui1 : !firrtl.uint<4>, !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.orr %in4
   // CHECK-NEXT: firrtl.matchingconnect
 
   %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
-  %4 = firrtl.neq %in4, %c15_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
+  %4 = firrtl.neq %in4, %c15_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: [[ANDR:%.+]] = firrtl.andr %in4
   // CHECK-NEXT: firrtl.not [[ANDR]]
   // CHECK-NEXT: firrtl.matchingconnect
 
   %c5_ui4 = firrtl.constant 5 : !firrtl.uint<4>
-  %5 = firrtl.eq %in4, %c5_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %6 = firrtl.neq %5, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %5 = firrtl.eq %in4, %c5_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
+  %6 = firrtl.neq %5, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.matchingconnect %out, %6 : !firrtl.uint<1>
   // CHECK: firrtl.neq
   // CHECK-NEXT: firrtl.matchingconnect
@@ -463,39 +463,39 @@ firrtl.module @Cat(in %in4: !firrtl.uint<4>,
   %c0_si2 = firrtl.constant 0 : !firrtl.sint<2>
 
   // CHECK: firrtl.matchingconnect %out4, %in4
-  %0 = firrtl.bits %in4 3 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<2>
-  %1 = firrtl.bits %in4 1 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
-  %2 = firrtl.cat %0, %1 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
+  %0 = firrtl.bits %in4 3 to 2 : !firrtl.uint<4>
+  %1 = firrtl.bits %in4 1 to 0 : !firrtl.uint<4>
+  %2 = firrtl.cat %0, %1 : !firrtl.uint<2>, !firrtl.uint<2>
   firrtl.connect %out4, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %outcst, %c243_ui8
   %c15_ui4 = firrtl.constant 15 : !firrtl.uint<4>
   %c3_ui4 = firrtl.constant 3 : !firrtl.uint<4>
-  %3 = firrtl.cat %c15_ui4, %c3_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<8>
+  %3 = firrtl.cat %c15_ui4, %c3_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %outcst, %3 : !firrtl.uint<8>, !firrtl.uint<8>
 
   // CHECK: firrtl.matchingconnect %outpt1, %in4
-  %5 = firrtl.cat %in0, %in4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %5 = firrtl.cat %in0, %in4 : !firrtl.uint<0>, !firrtl.uint<4>
   firrtl.connect %outpt1, %5 : !firrtl.uint<4>, !firrtl.uint<4>
   // CHECK: firrtl.matchingconnect %outpt2, %in4
-  %6 = firrtl.cat %in4, %in0 : (!firrtl.uint<4>, !firrtl.uint<0>) -> !firrtl.uint<4>
+  %6 = firrtl.cat %in4, %in0 : !firrtl.uint<4>, !firrtl.uint<0>
   firrtl.connect %outpt2, %6 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.cat %c0_ui4, %in4
-  %7 = firrtl.cat %c0_ui2, %in4 : (!firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<6>
-  %8 = firrtl.cat %c0_ui2, %7 : (!firrtl.uint<2>, !firrtl.uint<6>) -> !firrtl.uint<8>
+  %7 = firrtl.cat %c0_ui2, %in4 : !firrtl.uint<2>, !firrtl.uint<4>
+  %8 = firrtl.cat %c0_ui2, %7 : !firrtl.uint<2>, !firrtl.uint<6>
   firrtl.connect %outcst, %8 : !firrtl.uint<8>, !firrtl.uint<8>
 
   // CHECK: firrtl.asUInt %sin4
   // CHECK-NEXT: firrtl.cat %c0_ui4
-  %9  = firrtl.cat %c0_si2, %sin4 : (!firrtl.sint<2>, !firrtl.sint<4>) -> !firrtl.uint<6>
-  %10 = firrtl.cat %c0_ui2, %9 : (!firrtl.uint<2>, !firrtl.uint<6>) -> !firrtl.uint<8>
+  %9  = firrtl.cat %c0_si2, %sin4 : !firrtl.sint<2>, !firrtl.sint<4>
+  %10 = firrtl.cat %c0_ui2, %9 : !firrtl.uint<2>, !firrtl.uint<6>
   firrtl.connect %outcst, %10 : !firrtl.uint<8>, !firrtl.uint<8>
 
   // CHECK: %[[fixedsign:.*]] = firrtl.cat %sin4, %sin4
   // CHECK-NEXT: firrtl.matchingconnect %outu8, %[[fixedsign]]
-  %tcast = firrtl.asUInt %sin4 : (!firrtl.sint<4>) -> !firrtl.uint<4>
-  %11 = firrtl.cat %tcast, %tcast : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<8>
+  %tcast = firrtl.asUInt %sin4 : !firrtl.sint<4>
+  %11 = firrtl.cat %tcast, %tcast : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.matchingconnect %outu8, %11 : !firrtl.uint<8>
 }
 
@@ -507,33 +507,33 @@ firrtl.module @Bits(in %in1: !firrtl.uint<1>,
                     out %out4: !firrtl.uint<4>,
                     out %out2b: !firrtl.uint<2>) {
   // CHECK: firrtl.matchingconnect %out1, %in1
-  %0 = firrtl.bits %in1 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.bits %in1 0 to 0 : !firrtl.uint<1>
   firrtl.connect %out1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.matchingconnect %out4, %in4
-  %1 = firrtl.bits %in4 3 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<4>
+  %1 = firrtl.bits %in4 3 to 0 : !firrtl.uint<4>
   firrtl.connect %out4, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out2, %c1_ui2
   %c10_ui4 = firrtl.constant 10 : !firrtl.uint<4>
-  %2 = firrtl.bits %c10_ui4 2 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
+  %2 = firrtl.bits %c10_ui4 2 to 1 : !firrtl.uint<4>
   firrtl.connect %out2, %2 : !firrtl.uint<2>, !firrtl.uint<2>
 
 
-  // CHECK: firrtl.bits %in4 2 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  // CHECK: firrtl.bits %in4 2 to 2 : !firrtl.uint<4>
   // CHECK-NEXT: firrtl.matchingconnect %out1, %
-  %3 = firrtl.bits %in4 3 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<3>
-  %4 = firrtl.bits %3 1 to 1 : (!firrtl.uint<3>) -> !firrtl.uint<1>
+  %3 = firrtl.bits %in4 3 to 1 : !firrtl.uint<4>
+  %4 = firrtl.bits %3 1 to 1 : !firrtl.uint<3>
   firrtl.connect %out1, %4 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.matchingconnect %out1, %in1
-  %5 = firrtl.bits %in1 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %5 = firrtl.bits %in1 0 to 0 : !firrtl.uint<1>
   firrtl.connect %out1, %5 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.matchingconnect %out2b, %c1_ui2
   %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
-  %6 = firrtl.mux( %in1, %c10_ui4, %c11_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-  %7 = firrtl.bits %6 2 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
+  %6 = firrtl.mux( %in1, %c10_ui4, %c11_ui4) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
+  %7 = firrtl.bits %6 2 to 1 : !firrtl.uint<4>
   firrtl.matchingconnect %out2b, %7 : !firrtl.uint<2>
 }
 
@@ -543,17 +543,17 @@ firrtl.module @Head(in %in4u: !firrtl.uint<4>,
                     out %out3u: !firrtl.uint<3>) {
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 3
   // CHECK-NEXT: firrtl.matchingconnect %out1u, [[BITS]]
-  %0 = firrtl.head %in4u, 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  %0 = firrtl.head %in4u, 1 : !firrtl.uint<4>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 1
   // CHECK-NEXT: firrtl.matchingconnect %out3u, [[BITS]]
-  %1 = firrtl.head %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<3>
+  %1 = firrtl.head %in4u, 3 : !firrtl.uint<4>
   firrtl.connect %out3u, %1 : !firrtl.uint<3>, !firrtl.uint<3>
 
   // CHECK: firrtl.matchingconnect %out3u, %c5_ui3
   %c10_ui4 = firrtl.constant 10 : !firrtl.uint<4>
-  %2 = firrtl.head %c10_ui4, 3 : (!firrtl.uint<4>) -> !firrtl.uint<3>
+  %2 = firrtl.head %c10_ui4, 3 : !firrtl.uint<4>
   firrtl.connect %out3u, %2 : !firrtl.uint<3>, !firrtl.uint<3>
 }
 
@@ -571,23 +571,23 @@ firrtl.module @Mux(in %in: !firrtl.uint<4>,
                    out %out5: !firrtl.uint<1>,
                    out %out6: !firrtl.uint<1>) {
   // CHECK: firrtl.matchingconnect %out, %in
-  %0 = firrtl.int.mux2cell (%cond, %in, %in) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %0 = firrtl.int.mux2cell (%cond, %in, %in) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out, %c7_ui4
   %c7_ui4 = firrtl.constant 7 : !firrtl.uint<4>
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %2 = firrtl.mux (%c0_ui1, %in, %c7_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %2 = firrtl.mux (%c0_ui1, %in, %c7_ui4) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %2 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %out1, %cond
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %3 = firrtl.mux (%cond, %c1_ui1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %3 = firrtl.mux (%cond, %c1_ui1, %c0_ui1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out1, %3 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.matchingconnect %out, %invalid_ui4
   %invalid_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
-  %7 = firrtl.mux (%cond, %invalid_ui4, %invalid_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %7 = firrtl.mux (%cond, %invalid_ui4, %invalid_ui4) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
 
   %9 = firrtl.multibit_mux %c1_ui1, %c0_ui1, %cond : !firrtl.uint<1>, !firrtl.uint<1>
@@ -608,29 +608,29 @@ firrtl.module @Mux(in %in: !firrtl.uint<4>,
   // CHECK-NEXT: firrtl.matchingconnect %out1, %val1
   firrtl.connect %out1, %12 : !firrtl.uint<1>, !firrtl.uint<1>
 
-  %13 = firrtl.mux (%cond, %val0, %val0) : (!firrtl.uint<1>, !firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
+  %13 = firrtl.mux (%cond, %val0, %val0) : !firrtl.uint<1>, !firrtl.uint<0>, !firrtl.uint<0>
   // CHECK-NEXT: firrtl.matchingconnect %out2, %c0_ui0
   firrtl.matchingconnect %out2, %13 : !firrtl.uint<0>
 
-  %14 = firrtl.mux (%cond, %c0_ui1, %c1_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %14 = firrtl.mux (%cond, %c0_ui1, %c1_ui1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: [[V1:%.+]] = firrtl.not %cond
   // CHECK-NEXT: firrtl.matchingconnect %out3, [[V1]]
   firrtl.connect %out3, %14 : !firrtl.uint<1>, !firrtl.uint<1>
 
   %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
   %c1_ui4 = firrtl.constant 1 : !firrtl.uint<4>
-  %15 = firrtl.mux (%cond, %c0_ui4, %c1_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %15 = firrtl.mux (%cond, %c0_ui4, %c1_ui4) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   // CHECK-NEXT: [[V2:%.+]] = firrtl.mux(%cond
   // CHECK-NEXT: firrtl.matchingconnect %out4, [[V2]]
   firrtl.connect %out4, %15 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK-NEXT: firrtl.matchingconnect %out5, %val2
-  %16 = firrtl.mux (%val0, %val1, %val2) : (!firrtl.uint<0>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %16 = firrtl.mux (%val0, %val1, %val2) : !firrtl.uint<0>, !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.matchingconnect %out5, %16 : !firrtl.uint<1>
 
-  // CHECK-NEXT: %[[SEL:.+]] = firrtl.pad %val1, 2 : (!firrtl.uint<1>) -> !firrtl.uint<2>
+  // CHECK-NEXT: %[[SEL:.+]] = firrtl.pad %val1, 2 : !firrtl.uint<1>
   // CHECK-NEXT: mux4cell(%[[SEL]],
-  %17 = firrtl.int.mux4cell (%val1, %val1, %val2, %val1, %val2) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %17 = firrtl.int.mux4cell (%val1, %val1, %val2, %val1, %val2) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.matchingconnect %out6, %17 : !firrtl.uint<1>
 }
 
@@ -640,17 +640,17 @@ firrtl.module @Pad(in %in1u: !firrtl.uint<1>,
                    out %outu: !firrtl.uint<4>,
                    out %outs: !firrtl.sint<4>) {
   // CHECK: firrtl.matchingconnect %out1u, %in1u
-  %0 = firrtl.pad %in1u, 1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.pad %in1u, 1 : !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.matchingconnect %outu, %c1_ui4
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %1 = firrtl.pad %c1_ui1, 4 : (!firrtl.uint<1>) -> !firrtl.uint<4>
+  %1 = firrtl.pad %c1_ui1, 4 : !firrtl.uint<1>
   firrtl.connect %outu, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK: firrtl.matchingconnect %outs, %c-1_si4
   %c1_si1 = firrtl.constant -1 : !firrtl.sint<1>
-  %2 = firrtl.pad %c1_si1, 4 : (!firrtl.sint<1>) -> !firrtl.sint<4>
+  %2 = firrtl.pad %c1_si1, 4 : !firrtl.sint<1>
   firrtl.connect %outs, %2 : !firrtl.sint<4>, !firrtl.sint<4>
 }
 
@@ -659,12 +659,12 @@ firrtl.module @Shl(in %in1u: !firrtl.uint<1>,
                    out %out1u: !firrtl.uint<1>,
                    out %outu: !firrtl.uint<4>) {
   // CHECK: firrtl.matchingconnect %out1u, %in1u
-  %0 = firrtl.shl %in1u, 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.shl %in1u, 0 : !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.matchingconnect %outu, %c8_ui4
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %1 = firrtl.shl %c1_ui1, 3 : (!firrtl.uint<1>) -> !firrtl.uint<4>
+  %1 = firrtl.shl %c1_ui1, 3 : !firrtl.uint<1>
   firrtl.connect %outu, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
@@ -686,87 +686,87 @@ firrtl.module @Shr(in %in1u: !firrtl.uint<1>,
                    out %outs: !firrtl.sint
                    ) {
   // CHECK: firrtl.matchingconnect %out1u, %in1u
-  %0 = firrtl.shr %in1u, 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.shr %in1u, 0 : !firrtl.uint<1>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.matchingconnect %out1u, %c0_ui1
-  %1 = firrtl.shr %in4u, 4 : (!firrtl.uint<4>) -> !firrtl.uint<0>
+  %1 = firrtl.shr %in4u, 4 : !firrtl.uint<4>
   firrtl.connect %out1u, %1 : !firrtl.uint<1>, !firrtl.uint<0>
 
   // CHECK: firrtl.matchingconnect %out1u, %c0_ui1
-  %2 = firrtl.shr %in4u, 5 : (!firrtl.uint<4>) -> !firrtl.uint<0>
+  %2 = firrtl.shr %in4u, 5 : !firrtl.uint<4>
   firrtl.connect %out1u, %2 : !firrtl.uint<1>, !firrtl.uint<0>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
   // CHECK-NEXT: firrtl.matchingconnect %out1s, [[CAST]]
-  %3 = firrtl.shr %in4s, 3 : (!firrtl.sint<4>) -> !firrtl.sint<1>
+  %3 = firrtl.shr %in4s, 3 : !firrtl.sint<4>
   firrtl.connect %out1s, %3 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
   // CHECK-NEXT: firrtl.matchingconnect %out1s, [[CAST]]
-  %4 = firrtl.shr %in4s, 4 : (!firrtl.sint<4>) -> !firrtl.sint<1>
+  %4 = firrtl.shr %in4s, 4 : !firrtl.sint<4>
   firrtl.connect %out1s, %4 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4s 3 to 3
   // CHECK-NEXT: [[CAST:%.+]] = firrtl.asSInt [[BITS]]
   // CHECK-NEXT: firrtl.matchingconnect %out1s, [[CAST]]
-  %5 = firrtl.shr %in4s, 5 : (!firrtl.sint<4>) -> !firrtl.sint<1>
+  %5 = firrtl.shr %in4s, 5 : !firrtl.sint<4>
   firrtl.connect %out1s, %5 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // CHECK: firrtl.matchingconnect %out1u, %c1_ui1
   %c12_ui4 = firrtl.constant 12 : !firrtl.uint<4>
-  %6 = firrtl.shr %c12_ui4, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  %6 = firrtl.shr %c12_ui4, 3 : !firrtl.uint<4>
   firrtl.connect %out1u, %6 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 3 to 3
   // CHECK-NEXT: firrtl.matchingconnect %out1u, [[BITS]]
-  %7 = firrtl.shr %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  %7 = firrtl.shr %in4u, 3 : !firrtl.uint<4>
   firrtl.connect %out1u, %7 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // Issue #313: https://github.com/llvm/circt/issues/313
   // CHECK: firrtl.matchingconnect %out1s, %in1s : !firrtl.sint<1>
-  %8 = firrtl.shr %in1s, 42 : (!firrtl.sint<1>) -> !firrtl.sint<1>
+  %8 = firrtl.shr %in1s, 42 : !firrtl.sint<1>
   firrtl.connect %out1s, %8 : !firrtl.sint<1>, !firrtl.sint<1>
 
   // Issue #1064: https://github.com/llvm/circt/issues/1064
   // CHECK: firrtl.matchingconnect %out1u, %c0_ui1
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %9 = firrtl.dshr %in0u, %c1_ui1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
+  %9 = firrtl.dshr %in0u, %c1_ui1 : !firrtl.uint<0>, !firrtl.uint<1>
   firrtl.connect %out1u, %9 : !firrtl.uint<1>, !firrtl.uint<0>
 
   // Issue #6608: https://github.com/llvm/circt/issues/6608
   // CHECK: firrtl.matchingconnect %out0u, %c0_ui0
-  %10 = firrtl.shr %in0u, 0 : (!firrtl.uint<0>) -> !firrtl.uint<0>
+  %10 = firrtl.shr %in0u, 0 : !firrtl.uint<0>
   firrtl.matchingconnect %out0u, %10 : !firrtl.uint<0>
 
   // Issue #6608: https://github.com/llvm/circt/issues/6608
   // CHECK: firrtl.matchingconnect %out1s, %c0_si1
-  %11 = firrtl.shr %in0s, 0 : (!firrtl.sint<0>) -> !firrtl.sint<1>
+  %11 = firrtl.shr %in0s, 0 : !firrtl.sint<0>
   firrtl.matchingconnect %out1s, %11 : !firrtl.sint<1>
 
   // Issue #6608: https://github.com/llvm/circt/issues/6608
   // CHECK: firrtl.matchingconnect %out4u, %in4u
-  %12 = firrtl.shr %in4u, 0 : (!firrtl.uint<4>) -> !firrtl.uint<4>
+  %12 = firrtl.shr %in4u, 0 : !firrtl.uint<4>
   firrtl.matchingconnect %out4u, %12 : !firrtl.uint<4>
 
   // Issue #6608: https://github.com/llvm/circt/issues/6608
   // CHECK: firrtl.matchingconnect %out4s, %in4s
-  %13 = firrtl.shr %in4s, 0 : (!firrtl.sint<4>) -> !firrtl.sint<4>
+  %13 = firrtl.shr %in4s, 0 : !firrtl.sint<4>
   firrtl.matchingconnect %out4s, %13 : !firrtl.sint<4>
 
   // Issue #6608: https://github.com/llvm/circt/issues/6608
   // Will change to drop op once FIRRTL spec changes sizeof(shr(uint))
   // CHECK: %[[UINT:.+]] = firrtl.shr %inu
   // CHECK: firrtl.connect %outu, %[[UINT]]
-  %14 = firrtl.shr %inu, 0 : (!firrtl.uint) -> !firrtl.uint
+  %14 = firrtl.shr %inu, 0 : !firrtl.uint
   firrtl.connect %outu, %14 : !firrtl.uint, !firrtl.uint
 
   // Issue #6608: https://github.com/llvm/circt/issues/6608
   // CHECK: %[[SINT:.+]] = firrtl.shr %ins
   // CHECK: firrtl.connect %outs, %[[SINT]]
-  %15 = firrtl.shr %ins, 0 : (!firrtl.sint) -> !firrtl.sint
+  %15 = firrtl.shr %ins, 0 : !firrtl.sint
   firrtl.connect %outs, %15 : !firrtl.sint, !firrtl.sint
 
 }
@@ -777,17 +777,17 @@ firrtl.module @Tail(in %in4u: !firrtl.uint<4>,
                     out %out3u: !firrtl.uint<3>) {
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 0 to 0
   // CHECK-NEXT: firrtl.matchingconnect %out1u, [[BITS]]
-  %0 = firrtl.tail %in4u, 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  %0 = firrtl.tail %in4u, 3 : !firrtl.uint<4>
   firrtl.connect %out1u, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: [[BITS:%.+]] = firrtl.bits %in4u 2 to 0
   // CHECK-NEXT: firrtl.matchingconnect %out3u, [[BITS]]
-  %1 = firrtl.tail %in4u, 1 : (!firrtl.uint<4>) -> !firrtl.uint<3>
+  %1 = firrtl.tail %in4u, 1 : !firrtl.uint<4>
   firrtl.connect %out3u, %1 : !firrtl.uint<3>, !firrtl.uint<3>
 
   // CHECK: firrtl.matchingconnect %out3u, %c2_ui3
   %c10_ui4 = firrtl.constant 10 : !firrtl.uint<4>
-  %2 = firrtl.tail %c10_ui4, 1 : (!firrtl.uint<4>) -> !firrtl.uint<3>
+  %2 = firrtl.tail %c10_ui4, 1 : !firrtl.uint<4>
   firrtl.connect %out3u, %2 : !firrtl.uint<3>, !firrtl.uint<3>
 }
 
@@ -804,11 +804,11 @@ firrtl.module @Andr(in %in0 : !firrtl.uint<0>, in %in1 : !firrtl.sint<2>,
   %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
   %cn2_si2 = firrtl.constant -2 : !firrtl.sint<2>
   %cn1_si2 = firrtl.constant -1 : !firrtl.sint<2>
-  %0 = firrtl.andr %c2_ui2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-  %1 = firrtl.andr %c3_ui2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-  %2 = firrtl.andr %cn2_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
-  %3 = firrtl.andr %cn1_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
-  %4 = firrtl.andr %in0 : (!firrtl.uint<0>) -> !firrtl.uint<1>
+  %0 = firrtl.andr %c2_ui2 : !firrtl.uint<2>
+  %1 = firrtl.andr %c3_ui2 : !firrtl.uint<2>
+  %2 = firrtl.andr %cn2_si2 : !firrtl.sint<2>
+  %3 = firrtl.andr %cn1_si2 : !firrtl.sint<2>
+  %4 = firrtl.andr %in0 : !firrtl.uint<0>
   // CHECK: %[[ZERO:.+]] = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK: %[[ONE:.+]] = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK: firrtl.matchingconnect %a, %[[ZERO]]
@@ -824,33 +824,33 @@ firrtl.module @Andr(in %in0 : !firrtl.uint<0>, in %in1 : !firrtl.sint<2>,
 
   // CHECK: %[[and1:.*]] = firrtl.andr %in1
   // CHECK-NEXT: firrtl.matchingconnect %e, %[[and1]]
-  %cat = firrtl.cat %in1, %cn1_si2 : (!firrtl.sint<2>, !firrtl.sint<2>) -> !firrtl.uint<4>
-  %andrcat = firrtl.andr %cat : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  %cat = firrtl.cat %in1, %cn1_si2 : !firrtl.sint<2>, !firrtl.sint<2>
+  %andrcat = firrtl.andr %cat : !firrtl.uint<4>
   firrtl.connect %e, %andrcat : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.matchingconnect %e, %[[ZERO]]
-  %cat2 = firrtl.cat %in1, %cn2_si2 : (!firrtl.sint<2>, !firrtl.sint<2>) -> !firrtl.uint<4>
-  %andrcat2 = firrtl.andr %cat2 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  %cat2 = firrtl.cat %in1, %cn2_si2 : !firrtl.sint<2>, !firrtl.sint<2>
+  %andrcat2 = firrtl.andr %cat2 : !firrtl.uint<4>
   firrtl.connect %e, %andrcat2 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.matchingconnect %g, %[[ZERO]]
-  %5 = firrtl.asSInt %h : (!firrtl.uint<64>) -> !firrtl.sint<64>
-  %6 = firrtl.asUInt %5 : (!firrtl.sint<64>) -> !firrtl.uint<64>
-  %9 = firrtl.cvt %6 : (!firrtl.uint<64>) -> !firrtl.sint<65>
-  %10 = firrtl.andr %9 : (!firrtl.sint<65>) -> !firrtl.uint<1>
+  %5 = firrtl.asSInt %h : !firrtl.uint<64>
+  %6 = firrtl.asUInt %5 : !firrtl.sint<64>
+  %9 = firrtl.cvt %6 : !firrtl.uint<64>
+  %10 = firrtl.andr %9 : !firrtl.sint<65>
   firrtl.matchingconnect %g, %10 : !firrtl.uint<1>
 
   // CHECK: %[[andr:.*]] = firrtl.andr %in1
   // CHECK-NEXT: firrtl.matchingconnect %i, %[[andr]]
-  %11 = firrtl.pad %in1, 3 : (!firrtl.sint<2>) -> !firrtl.sint<3>
-  %12 = firrtl.andr %11 : (!firrtl.sint<3>) -> !firrtl.uint<1>
+  %11 = firrtl.pad %in1, 3 : !firrtl.sint<2>
+  %12 = firrtl.andr %11 : !firrtl.sint<3>
   firrtl.matchingconnect %i, %12 : !firrtl.uint<1>
 
   // CHECK: %[[cat:.*]] = firrtl.cat %in2, %h
   // CHECK-NEXT: firrtl.andr %[[cat]]
-  %13 = firrtl.andr %in2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-  %14 = firrtl.cat %13, %h : (!firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<65>
-  %15 = firrtl.andr %14 : (!firrtl.uint<65>) -> !firrtl.uint<1>
+  %13 = firrtl.andr %in2 : !firrtl.uint<2>
+  %14 = firrtl.cat %13, %h : !firrtl.uint<1>, !firrtl.uint<64>
+  %15 = firrtl.andr %14 : !firrtl.uint<65>
   firrtl.matchingconnect %j, %15 : !firrtl.uint<1>
 }
 
@@ -866,11 +866,11 @@ firrtl.module @Orr(in %in0 : !firrtl.uint<0>, in %in2 : !firrtl.uint<2>,
   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
   %cn0_si2 = firrtl.constant 0 : !firrtl.sint<2>
   %cn2_si2 = firrtl.constant -2 : !firrtl.sint<2>
-  %0 = firrtl.orr %c0_ui2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-  %1 = firrtl.orr %c2_ui2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-  %2 = firrtl.orr %cn0_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
-  %3 = firrtl.orr %cn2_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
-  %4 = firrtl.orr %in0 : (!firrtl.uint<0>) -> !firrtl.uint<1>
+  %0 = firrtl.orr %c0_ui2 : !firrtl.uint<2>
+  %1 = firrtl.orr %c2_ui2 : !firrtl.uint<2>
+  %2 = firrtl.orr %cn0_si2 : !firrtl.sint<2>
+  %3 = firrtl.orr %cn2_si2 : !firrtl.sint<2>
+  %4 = firrtl.orr %in0 : !firrtl.uint<0>
   // CHECK-DAG: %[[ZERO:.+]] = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK-DAG: %[[ONE:.+]] = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK: firrtl.matchingconnect %a, %[[ZERO]]
@@ -886,19 +886,19 @@ firrtl.module @Orr(in %in0 : !firrtl.uint<0>, in %in2 : !firrtl.uint<2>,
 
   // CHECK: %[[OR:.*]] = firrtl.orr %h
   // CHECK: firrtl.matchingconnect %g, %[[OR]]
-  %5 = firrtl.asSInt %h : (!firrtl.uint<64>) -> !firrtl.sint<64>
-  %6 = firrtl.asUInt %5 : (!firrtl.sint<64>) -> !firrtl.uint<64>
-  %7 = firrtl.cat %6, %c0_ui2 : (!firrtl.uint<64>, !firrtl.uint<2>) -> !firrtl.uint<66>
-  %8 = firrtl.cat %c0_ui2, %7 : (!firrtl.uint<2>, !firrtl.uint<66>) -> !firrtl.uint<68>
-  %9 = firrtl.cvt %8 : (!firrtl.uint<68>) -> !firrtl.sint<69>
-  %10 = firrtl.orr %9 : (!firrtl.sint<69>) -> !firrtl.uint<1>
+  %5 = firrtl.asSInt %h : !firrtl.uint<64>
+  %6 = firrtl.asUInt %5 : !firrtl.sint<64>
+  %7 = firrtl.cat %6, %c0_ui2 : !firrtl.uint<64>, !firrtl.uint<2>
+  %8 = firrtl.cat %c0_ui2, %7 : !firrtl.uint<2>, !firrtl.uint<66>
+  %9 = firrtl.cvt %8 : !firrtl.uint<68>
+  %10 = firrtl.orr %9 : !firrtl.sint<69>
   firrtl.matchingconnect %g, %10 : !firrtl.uint<1>
 
   // CHECK: %[[cat:.*]] = firrtl.cat %in2, %h
   // CHECK-NEXT: firrtl.orr %[[cat]]
-  %13 = firrtl.orr %in2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-  %14 = firrtl.cat %13, %h : (!firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<65>
-  %15 = firrtl.orr %14 : (!firrtl.uint<65>) -> !firrtl.uint<1>
+  %13 = firrtl.orr %in2 : !firrtl.uint<2>
+  %14 = firrtl.cat %13, %h : !firrtl.uint<1>, !firrtl.uint<64>
+  %15 = firrtl.orr %14 : !firrtl.uint<65>
   firrtl.matchingconnect %j, %15 : !firrtl.uint<1>
 
 }
@@ -916,11 +916,11 @@ firrtl.module @Xorr(in %in0 : !firrtl.uint<0>, in %in2 : !firrtl.uint<2>,
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
   %cn1_si2 = firrtl.constant -1 : !firrtl.sint<2>
   %cn2_si2 = firrtl.constant -2 : !firrtl.sint<2>
-  %0 = firrtl.xorr %c3_ui2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-  %1 = firrtl.xorr %c2_ui2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-  %2 = firrtl.xorr %cn1_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
-  %3 = firrtl.xorr %cn2_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
-  %4 = firrtl.xorr %in0 : (!firrtl.uint<0>) -> !firrtl.uint<1>
+  %0 = firrtl.xorr %c3_ui2 : !firrtl.uint<2>
+  %1 = firrtl.xorr %c2_ui2 : !firrtl.uint<2>
+  %2 = firrtl.xorr %cn1_si2 : !firrtl.sint<2>
+  %3 = firrtl.xorr %cn2_si2 : !firrtl.sint<2>
+  %4 = firrtl.xorr %in0 : !firrtl.uint<0>
   // CHECK-DAG: %[[ZERO:.+]] = firrtl.constant 0 : !firrtl.uint<1>
   // CHECK-DAG: %[[ONE:.+]] = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK: firrtl.matchingconnect %a, %[[ZERO]]
@@ -936,19 +936,19 @@ firrtl.module @Xorr(in %in0 : !firrtl.uint<0>, in %in2 : !firrtl.uint<2>,
 
   // CHECK: %[[XOR:.*]] = firrtl.xorr %h
   // CHECK: firrtl.matchingconnect %g, %[[OR]]
-  %5 = firrtl.asSInt %h : (!firrtl.uint<64>) -> !firrtl.sint<64>
-  %6 = firrtl.asUInt %5 : (!firrtl.sint<64>) -> !firrtl.uint<64>
-  %7 = firrtl.cat %6, %c0_ui2 : (!firrtl.uint<64>, !firrtl.uint<2>) -> !firrtl.uint<66>
-  %8 = firrtl.cat %c0_ui2, %7 : (!firrtl.uint<2>, !firrtl.uint<66>) -> !firrtl.uint<68>
-  %9 = firrtl.cvt %8 : (!firrtl.uint<68>) -> !firrtl.sint<69>
-  %10 = firrtl.xorr %9 : (!firrtl.sint<69>) -> !firrtl.uint<1>
+  %5 = firrtl.asSInt %h : !firrtl.uint<64>
+  %6 = firrtl.asUInt %5 : !firrtl.sint<64>
+  %7 = firrtl.cat %6, %c0_ui2 : !firrtl.uint<64>, !firrtl.uint<2>
+  %8 = firrtl.cat %c0_ui2, %7 : !firrtl.uint<2>, !firrtl.uint<66>
+  %9 = firrtl.cvt %8 : !firrtl.uint<68>
+  %10 = firrtl.xorr %9 : !firrtl.sint<69>
   firrtl.matchingconnect %g, %10 : !firrtl.uint<1>
 
   // CHECK: %[[cat:.*]] = firrtl.cat %in2, %h
   // CHECK-NEXT: firrtl.xorr %[[cat]]
-  %13 = firrtl.xorr %in2 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-  %14 = firrtl.cat %13, %h : (!firrtl.uint<1>, !firrtl.uint<64>) -> !firrtl.uint<65>
-  %15 = firrtl.xorr %14 : (!firrtl.uint<65>) -> !firrtl.uint<1>
+  %13 = firrtl.xorr %in2 : !firrtl.uint<2>
+  %14 = firrtl.cat %13, %h : !firrtl.uint<1>, !firrtl.uint<64>
+  %15 = firrtl.xorr %14 : !firrtl.uint<65>
   firrtl.matchingconnect %j, %15 : !firrtl.uint<1>
 
 }
@@ -956,9 +956,9 @@ firrtl.module @Xorr(in %in0 : !firrtl.uint<0>, in %in2 : !firrtl.uint<2>,
 // CHECK-LABEL: firrtl.module @Reduce
 firrtl.module @Reduce(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>,
                       out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
-  %0 = firrtl.andr %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  %1 = firrtl.orr %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
-  %2 = firrtl.xorr %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.andr %a : !firrtl.uint<1>
+  %1 = firrtl.orr %a : !firrtl.uint<1>
+  %2 = firrtl.xorr %a : !firrtl.uint<1>
   firrtl.connect %b, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: firrtl.matchingconnect %b, %a
   firrtl.connect %c, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1020,7 +1020,7 @@ firrtl.module @subfield_agg(out %out : !firrtl.vector<uint<8>, 1>) {
 // CHECK-LABEL: firrtl.module @issue326
 firrtl.module @issue326(out %tmp57: !firrtl.sint<1>) {
   %c29_si7 = firrtl.constant 29 : !firrtl.sint<7>
-  %0 = firrtl.shr %c29_si7, 47 : (!firrtl.sint<7>) -> !firrtl.sint<1>
+  %0 = firrtl.shr %c29_si7, 47 : !firrtl.sint<7>
    // CHECK: c0_si1 = firrtl.constant 0 : !firrtl.sint<1>
    firrtl.connect %tmp57, %0 : !firrtl.sint<1>, !firrtl.sint<1>
 }
@@ -1029,14 +1029,14 @@ firrtl.module @issue326(out %tmp57: !firrtl.sint<1>) {
 firrtl.module @issue331(out %tmp81: !firrtl.sint<1>) {
   // CHECK: %c-1_si1 = firrtl.constant -1 : !firrtl.sint<1>
   %c-1_si1 = firrtl.constant -1 : !firrtl.sint<1>
-  %0 = firrtl.shr %c-1_si1, 3 : (!firrtl.sint<1>) -> !firrtl.sint<1>
+  %0 = firrtl.shr %c-1_si1, 3 : !firrtl.sint<1>
   firrtl.connect %tmp81, %0 : !firrtl.sint<1>, !firrtl.sint<1>
 }
 
 // CHECK-LABEL: firrtl.module @issue432
 firrtl.module @issue432(out %tmp8: !firrtl.uint<10>) {
   %c130_si10 = firrtl.constant 130 : !firrtl.sint<10>
-  %0 = firrtl.tail %c130_si10, 0 : (!firrtl.sint<10>) -> !firrtl.uint<10>
+  %0 = firrtl.tail %c130_si10, 0 : !firrtl.sint<10>
   firrtl.connect %tmp8, %0 : !firrtl.uint<10>, !firrtl.uint<10>
   // CHECK-NEXT: %c130_ui10 = firrtl.constant 130 : !firrtl.uint<10>
   // CHECK-NEXT: firrtl.matchingconnect %tmp8, %c130_ui10
@@ -1046,7 +1046,7 @@ firrtl.module @issue432(out %tmp8: !firrtl.uint<10>) {
 firrtl.module @issue437(out %tmp19: !firrtl.uint<1>) {
   // CHECK-NEXT: %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %c-1_si1 = firrtl.constant -1 : !firrtl.sint<1>
-  %0 = firrtl.bits %c-1_si1 0 to 0 : (!firrtl.sint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.bits %c-1_si1 0 to 0 : !firrtl.sint<1>
   firrtl.connect %tmp19, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -1054,14 +1054,14 @@ firrtl.module @issue437(out %tmp19: !firrtl.uint<1>) {
 // CHECK-NEXT: [[TMP:%.+]] = firrtl.constant 0 : !firrtl.uint<1>
 // CHECK-NEXT: firrtl.matchingconnect %tmp10, [[TMP]] : !firrtl.uint<1>
 firrtl.module @issue446(in %inp_1: !firrtl.sint<0>, out %tmp10: !firrtl.uint<1>) {
-  %0 = firrtl.xor %inp_1, %inp_1 : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<0>
+  %0 = firrtl.xor %inp_1, %inp_1 : !firrtl.sint<0>, !firrtl.sint<0>
   firrtl.connect %tmp10, %0 : !firrtl.uint<1>, !firrtl.uint<0>
 }
 
 // CHECK-LABEL: firrtl.module @xorUnsized
 // CHECK-NEXT: %c0_ui = firrtl.constant 0 : !firrtl.uint
 firrtl.module @xorUnsized(in %inp_1: !firrtl.sint, out %tmp10: !firrtl.uint) {
-  %0 = firrtl.xor %inp_1, %inp_1 : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint
+  %0 = firrtl.xor %inp_1, %inp_1 : !firrtl.sint, !firrtl.sint
   firrtl.connect %tmp10, %0 : !firrtl.uint, !firrtl.uint
 }
 
@@ -1070,7 +1070,7 @@ firrtl.module @xorUnsized(in %inp_1: !firrtl.sint, out %tmp10: !firrtl.uint) {
 // CHECK-NEXT: [[TMP:%.+]] = firrtl.constant 0 : !firrtl.uint<0>
 // CHECK-NEXT: firrtl.matchingconnect %tmp3, [[TMP]] : !firrtl.uint<0>
 firrtl.module @issue516(in %inp_0: !firrtl.uint<0>, out %tmp3: !firrtl.uint<0>) {
-  %0 = firrtl.div %inp_0, %inp_0 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
+  %0 = firrtl.div %inp_0, %inp_0 : !firrtl.uint<0>, !firrtl.uint<0>
   firrtl.connect %tmp3, %0 : !firrtl.uint<0>, !firrtl.uint<0>
 }
 
@@ -1128,7 +1128,7 @@ firrtl.module @reg_cst_prop3(in %clock: !firrtl.clock, out %out_b: !firrtl.uint<
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
   firrtl.connect %_tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
 
-  %xor = firrtl.xor %_tmp_a, %c5_ui8 : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  %xor = firrtl.xor %_tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %out_b, %xor : !firrtl.uint<8>, !firrtl.uint<8>
 }
 
@@ -1176,7 +1176,7 @@ firrtl.module @wire_cst_prop1(out %out_b: !firrtl.uint<9>) {
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
   firrtl.connect %_tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
 
-  %xor = firrtl.add %_tmp_a, %c5_ui8 : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<9>
+  %xor = firrtl.add %_tmp_a, %c5_ui8 : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %out_b, %xor : !firrtl.uint<9>, !firrtl.uint<9>
 }
 
@@ -1195,7 +1195,7 @@ firrtl.module @wire_port_prop1(in %in_a: !firrtl.uint<9>, out %out_b: !firrtl.ui
 // CHECK-NEXT: %e = firrtl.geq %a, %c42_ui
 firrtl.module @LEQWithConstLHS(in %a: !firrtl.uint, out %b: !firrtl.uint<1>) {
   %0 = firrtl.constant 42 : !firrtl.uint
-  %1 = firrtl.leq %0, %a {name = "e"} : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %1 = firrtl.leq %0, %a {name = "e"} : !firrtl.uint, !firrtl.uint
   firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -1204,7 +1204,7 @@ firrtl.module @LEQWithConstLHS(in %a: !firrtl.uint, out %b: !firrtl.uint<1>) {
 // CHECK-NEXT: %0 = firrtl.gt %a, %c42_ui
 firrtl.module @LTWithConstLHS(in %a: !firrtl.uint, out %b: !firrtl.uint<1>) {
   %0 = firrtl.constant 42 : !firrtl.uint
-  %1 = firrtl.lt %0, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %1 = firrtl.lt %0, %a : !firrtl.uint, !firrtl.uint
   firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -1213,7 +1213,7 @@ firrtl.module @LTWithConstLHS(in %a: !firrtl.uint, out %b: !firrtl.uint<1>) {
 // CHECK-NEXT: %0 = firrtl.leq %a, %c42_ui
 firrtl.module @GEQWithConstLHS(in %a: !firrtl.uint, out %b: !firrtl.uint<1>) {
   %0 = firrtl.constant 42 : !firrtl.uint
-  %1 = firrtl.geq %0, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %1 = firrtl.geq %0, %a : !firrtl.uint, !firrtl.uint
   firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -1222,7 +1222,7 @@ firrtl.module @GEQWithConstLHS(in %a: !firrtl.uint, out %b: !firrtl.uint<1>) {
 // CHECK-NEXT: %0 = firrtl.lt %a, %c42_ui
 firrtl.module @GTWithConstLHS(in %a: !firrtl.uint, out %b: !firrtl.uint<1>) {
   %0 = firrtl.constant 42 : !firrtl.uint
-  %1 = firrtl.gt %0, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %1 = firrtl.gt %0, %a : !firrtl.uint, !firrtl.uint
   firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -1239,27 +1239,27 @@ firrtl.module @CompareWithSelf(
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
 
-  %0 = firrtl.leq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.leq %a, %a : !firrtl.uint, !firrtl.uint
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y0, %c1_ui1
 
-  %1 = firrtl.lt %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %1 = firrtl.lt %a, %a : !firrtl.uint, !firrtl.uint
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y1, %c0_ui1
 
-  %2 = firrtl.geq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %2 = firrtl.geq %a, %a : !firrtl.uint, !firrtl.uint
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y2, %c1_ui1
 
-  %3 = firrtl.gt %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %3 = firrtl.gt %a, %a : !firrtl.uint, !firrtl.uint
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y3, %c0_ui1
 
-  %4 = firrtl.eq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %4 = firrtl.eq %a, %a : !firrtl.uint, !firrtl.uint
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y4, %c1_ui1
 
-  %5 = firrtl.neq %a, %a : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %5 = firrtl.neq %a, %a : !firrtl.uint, !firrtl.uint
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y5, %c0_ui1
 }
@@ -1286,8 +1286,8 @@ firrtl.module @LEQOutsideBounds(
 
   // a <= 7 -> 1
   // a <= 8 -> 1
-  %0 = firrtl.leq %a, %c7_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
-  %1 = firrtl.leq %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.leq %a, %c7_ui : !firrtl.uint<3>, !firrtl.uint
+  %1 = firrtl.leq %a, %c8_ui : !firrtl.uint<3>, !firrtl.uint
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y0, %c1_ui1
@@ -1295,8 +1295,8 @@ firrtl.module @LEQOutsideBounds(
 
   // b <= 3 -> 1
   // b <= 4 -> 1
-  %2 = firrtl.leq %b, %c3_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  %3 = firrtl.leq %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %2 = firrtl.leq %b, %c3_si : !firrtl.sint<3>, !firrtl.sint
+  %3 = firrtl.leq %b, %c4_si : !firrtl.sint<3>, !firrtl.sint
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y2, %c1_ui1
@@ -1304,8 +1304,8 @@ firrtl.module @LEQOutsideBounds(
 
   // b <= -5 -> 0
   // b <= -6 -> 0
-  %4 = firrtl.leq %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  %5 = firrtl.leq %b, %cm6_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %4 = firrtl.leq %b, %cm5_si : !firrtl.sint<3>, !firrtl.sint
+  %5 = firrtl.leq %b, %cm6_si : !firrtl.sint<3>, !firrtl.sint
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y4, %c0_ui1
@@ -1334,8 +1334,8 @@ firrtl.module @LTOutsideBounds(
 
   // a < 8 -> 1
   // a < 9 -> 1
-  %0 = firrtl.lt %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
-  %1 = firrtl.lt %a, %c9_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.lt %a, %c8_ui : !firrtl.uint<3>, !firrtl.uint
+  %1 = firrtl.lt %a, %c9_ui : !firrtl.uint<3>, !firrtl.uint
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y0, %c1_ui1
@@ -1343,8 +1343,8 @@ firrtl.module @LTOutsideBounds(
 
   // b < 4 -> 1
   // b < 5 -> 1
-  %2 = firrtl.lt %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  %3 = firrtl.lt %b, %c5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %2 = firrtl.lt %b, %c4_si : !firrtl.sint<3>, !firrtl.sint
+  %3 = firrtl.lt %b, %c5_si : !firrtl.sint<3>, !firrtl.sint
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y2, %c1_ui1
@@ -1352,8 +1352,8 @@ firrtl.module @LTOutsideBounds(
 
   // b < -4 -> 0
   // b < -5 -> 0
-  %4 = firrtl.lt %b, %cm4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  %5 = firrtl.lt %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %4 = firrtl.lt %b, %cm4_si : !firrtl.sint<3>, !firrtl.sint
+  %5 = firrtl.lt %b, %cm5_si : !firrtl.sint<3>, !firrtl.sint
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y4, %c0_ui1
@@ -1382,8 +1382,8 @@ firrtl.module @GEQOutsideBounds(
 
   // a >= 8 -> 0
   // a >= 9 -> 0
-  %0 = firrtl.geq %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
-  %1 = firrtl.geq %a, %c9_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.geq %a, %c8_ui : !firrtl.uint<3>, !firrtl.uint
+  %1 = firrtl.geq %a, %c9_ui : !firrtl.uint<3>, !firrtl.uint
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y0, %c0_ui1
@@ -1391,8 +1391,8 @@ firrtl.module @GEQOutsideBounds(
 
   // b >= 4 -> 0
   // b >= 5 -> 0
-  %2 = firrtl.geq %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  %3 = firrtl.geq %b, %c5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %2 = firrtl.geq %b, %c4_si : !firrtl.sint<3>, !firrtl.sint
+  %3 = firrtl.geq %b, %c5_si : !firrtl.sint<3>, !firrtl.sint
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y2, %c0_ui1
@@ -1400,8 +1400,8 @@ firrtl.module @GEQOutsideBounds(
 
   // b >= -4 -> 1
   // b >= -5 -> 1
-  %4 = firrtl.geq %b, %cm4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  %5 = firrtl.geq %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %4 = firrtl.geq %b, %cm4_si : !firrtl.sint<3>, !firrtl.sint
+  %5 = firrtl.geq %b, %cm5_si : !firrtl.sint<3>, !firrtl.sint
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y4, %c1_ui1
@@ -1430,8 +1430,8 @@ firrtl.module @GTOutsideBounds(
 
   // a > 7 -> 0
   // a > 8 -> 0
-  %0 = firrtl.gt %a, %c7_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
-  %1 = firrtl.gt %a, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.gt %a, %c7_ui : !firrtl.uint<3>, !firrtl.uint
+  %1 = firrtl.gt %a, %c8_ui : !firrtl.uint<3>, !firrtl.uint
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y0, %c0_ui1
@@ -1439,8 +1439,8 @@ firrtl.module @GTOutsideBounds(
 
   // b > 3 -> 0
   // b > 4 -> 0
-  %2 = firrtl.gt %b, %c3_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  %3 = firrtl.gt %b, %c4_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %2 = firrtl.gt %b, %c3_si : !firrtl.sint<3>, !firrtl.sint
+  %3 = firrtl.gt %b, %c4_si : !firrtl.sint<3>, !firrtl.sint
   firrtl.connect %y2, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y3, %3 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y2, %c0_ui1
@@ -1448,8 +1448,8 @@ firrtl.module @GTOutsideBounds(
 
   // b > -5 -> 1
   // b > -6 -> 1
-  %4 = firrtl.gt %b, %cm5_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
-  %5 = firrtl.gt %b, %cm6_si : (!firrtl.sint<3>, !firrtl.sint) -> !firrtl.uint<1>
+  %4 = firrtl.gt %b, %cm5_si : !firrtl.sint<3>, !firrtl.sint
+  %5 = firrtl.gt %b, %cm6_si : !firrtl.sint<3>, !firrtl.sint
   firrtl.connect %y4, %4 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y5, %5 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %y4, %c1_ui1
@@ -1478,18 +1478,18 @@ firrtl.module @ComparisonOfDifferentWidths(
   %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
   %c4_ui3 = firrtl.constant 4 : !firrtl.uint<3>
 
-  %0 = firrtl.leq %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %1 = firrtl.leq %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %2 = firrtl.lt %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %3 = firrtl.lt %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %4 = firrtl.geq %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %5 = firrtl.geq %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %6 = firrtl.gt %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %7 = firrtl.gt %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %8 = firrtl.eq %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %9 = firrtl.eq %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %10 = firrtl.neq %c3_ui2, %c4_ui3 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %11 = firrtl.neq %c3_si3, %c4_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %0 = firrtl.leq %c3_ui2, %c4_ui3 : !firrtl.uint<2>, !firrtl.uint<3>
+  %1 = firrtl.leq %c3_si3, %c4_si4 : !firrtl.sint<3>, !firrtl.sint<4>
+  %2 = firrtl.lt %c3_ui2, %c4_ui3 : !firrtl.uint<2>, !firrtl.uint<3>
+  %3 = firrtl.lt %c3_si3, %c4_si4 : !firrtl.sint<3>, !firrtl.sint<4>
+  %4 = firrtl.geq %c3_ui2, %c4_ui3 : !firrtl.uint<2>, !firrtl.uint<3>
+  %5 = firrtl.geq %c3_si3, %c4_si4 : !firrtl.sint<3>, !firrtl.sint<4>
+  %6 = firrtl.gt %c3_ui2, %c4_ui3 : !firrtl.uint<2>, !firrtl.uint<3>
+  %7 = firrtl.gt %c3_si3, %c4_si4 : !firrtl.sint<3>, !firrtl.sint<4>
+  %8 = firrtl.eq %c3_ui2, %c4_ui3 : !firrtl.uint<2>, !firrtl.uint<3>
+  %9 = firrtl.eq %c3_si3, %c4_si4 : !firrtl.sint<3>, !firrtl.sint<4>
+  %10 = firrtl.neq %c3_ui2, %c4_ui3 : !firrtl.uint<2>, !firrtl.uint<3>
+  %11 = firrtl.neq %c3_si3, %c4_si4 : !firrtl.sint<3>, !firrtl.sint<4>
 
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1539,18 +1539,18 @@ firrtl.module @ComparisonOfUnsizedAndSized(
   %c3_ui = firrtl.constant 3 : !firrtl.uint
   %c4_ui3 = firrtl.constant 4 : !firrtl.uint<3>
 
-  %0 = firrtl.leq %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %1 = firrtl.leq %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %2 = firrtl.lt %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %3 = firrtl.lt %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %4 = firrtl.geq %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %5 = firrtl.geq %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %6 = firrtl.gt %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %7 = firrtl.gt %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %8 = firrtl.eq %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %9 = firrtl.eq %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %10 = firrtl.neq %c3_ui, %c4_ui3 : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %11 = firrtl.neq %c3_si, %c4_si4 : (!firrtl.sint, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %0 = firrtl.leq %c3_ui, %c4_ui3 : !firrtl.uint, !firrtl.uint<3>
+  %1 = firrtl.leq %c3_si, %c4_si4 : !firrtl.sint, !firrtl.sint<4>
+  %2 = firrtl.lt %c3_ui, %c4_ui3 : !firrtl.uint, !firrtl.uint<3>
+  %3 = firrtl.lt %c3_si, %c4_si4 : !firrtl.sint, !firrtl.sint<4>
+  %4 = firrtl.geq %c3_ui, %c4_ui3 : !firrtl.uint, !firrtl.uint<3>
+  %5 = firrtl.geq %c3_si, %c4_si4 : !firrtl.sint, !firrtl.sint<4>
+  %6 = firrtl.gt %c3_ui, %c4_ui3 : !firrtl.uint, !firrtl.uint<3>
+  %7 = firrtl.gt %c3_si, %c4_si4 : !firrtl.sint, !firrtl.sint<4>
+  %8 = firrtl.eq %c3_ui, %c4_ui3 : !firrtl.uint, !firrtl.uint<3>
+  %9 = firrtl.eq %c3_si, %c4_si4 : !firrtl.sint, !firrtl.sint<4>
+  %10 = firrtl.neq %c3_ui, %c4_ui3 : !firrtl.uint, !firrtl.uint<3>
+  %11 = firrtl.neq %c3_si, %c4_si4 : !firrtl.sint, !firrtl.sint<4>
 
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1600,18 +1600,18 @@ firrtl.module @ComparisonOfUnsized(
   %c0_ui = firrtl.constant 0 : !firrtl.uint
   %c4_ui = firrtl.constant 4 : !firrtl.uint
 
-  %0 = firrtl.leq %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  %1 = firrtl.leq %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
-  %2 = firrtl.lt %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  %3 = firrtl.lt %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
-  %4 = firrtl.geq %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  %5 = firrtl.geq %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
-  %6 = firrtl.gt %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  %7 = firrtl.gt %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
-  %8 = firrtl.eq %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  %9 = firrtl.eq %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
-  %10 = firrtl.neq %c0_ui, %c4_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-  %11 = firrtl.neq %c0_si, %c4_si : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint<1>
+  %0 = firrtl.leq %c0_ui, %c4_ui : !firrtl.uint, !firrtl.uint
+  %1 = firrtl.leq %c0_si, %c4_si : !firrtl.sint, !firrtl.sint
+  %2 = firrtl.lt %c0_ui, %c4_ui : !firrtl.uint, !firrtl.uint
+  %3 = firrtl.lt %c0_si, %c4_si : !firrtl.sint, !firrtl.sint
+  %4 = firrtl.geq %c0_ui, %c4_ui : !firrtl.uint, !firrtl.uint
+  %5 = firrtl.geq %c0_si, %c4_si : !firrtl.sint, !firrtl.sint
+  %6 = firrtl.gt %c0_ui, %c4_ui : !firrtl.uint, !firrtl.uint
+  %7 = firrtl.gt %c0_si, %c4_si : !firrtl.sint, !firrtl.sint
+  %8 = firrtl.eq %c0_ui, %c4_ui : !firrtl.uint, !firrtl.uint
+  %9 = firrtl.eq %c0_si, %c4_si : !firrtl.sint, !firrtl.sint
+  %10 = firrtl.neq %c0_ui, %c4_ui : !firrtl.uint, !firrtl.uint
+  %11 = firrtl.neq %c0_si, %c4_si : !firrtl.sint, !firrtl.sint
 
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1673,30 +1673,30 @@ firrtl.module @ComparisonOfZeroAndNonzeroWidths(
   %c4_si4 = firrtl.constant 4 : !firrtl.sint<4>
   %c4_ui4 = firrtl.constant 4 : !firrtl.uint<4>
 
-  %0 = firrtl.leq %xu, %c0_ui4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %1 = firrtl.leq %xu, %c4_ui4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %2 = firrtl.leq %xs, %c0_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %3 = firrtl.leq %xs, %c4_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %4 = firrtl.lt %xu, %c0_ui4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %5 = firrtl.lt %xu, %c4_ui4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %6 = firrtl.lt %xs, %c0_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %7 = firrtl.lt %xs, %c4_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %8 = firrtl.geq %xu, %c0_ui4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %9 = firrtl.geq %xu, %c4_ui4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %10 = firrtl.geq %xs, %c0_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %11 = firrtl.geq %xs, %c4_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %12 = firrtl.gt %xu, %c0_ui4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %13 = firrtl.gt %xu, %c4_ui4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %14 = firrtl.gt %xs, %c0_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %15 = firrtl.gt %xs, %c4_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %16 = firrtl.eq %xu, %c0_ui4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %17 = firrtl.eq %xu, %c4_ui4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %18 = firrtl.eq %xs, %c0_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %19 = firrtl.eq %xs, %c4_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %20 = firrtl.neq %xu, %c0_ui4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %21 = firrtl.neq %xu, %c4_ui4 : (!firrtl.uint<0>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %22 = firrtl.neq %xs, %c0_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %23 = firrtl.neq %xs, %c4_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<1>
+  %0 = firrtl.leq %xu, %c0_ui4 : !firrtl.uint<0>, !firrtl.uint<4>
+  %1 = firrtl.leq %xu, %c4_ui4 : !firrtl.uint<0>, !firrtl.uint<4>
+  %2 = firrtl.leq %xs, %c0_si4 : !firrtl.sint<0>, !firrtl.sint<4>
+  %3 = firrtl.leq %xs, %c4_si4 : !firrtl.sint<0>, !firrtl.sint<4>
+  %4 = firrtl.lt %xu, %c0_ui4 : !firrtl.uint<0>, !firrtl.uint<4>
+  %5 = firrtl.lt %xu, %c4_ui4 : !firrtl.uint<0>, !firrtl.uint<4>
+  %6 = firrtl.lt %xs, %c0_si4 : !firrtl.sint<0>, !firrtl.sint<4>
+  %7 = firrtl.lt %xs, %c4_si4 : !firrtl.sint<0>, !firrtl.sint<4>
+  %8 = firrtl.geq %xu, %c0_ui4 : !firrtl.uint<0>, !firrtl.uint<4>
+  %9 = firrtl.geq %xu, %c4_ui4 : !firrtl.uint<0>, !firrtl.uint<4>
+  %10 = firrtl.geq %xs, %c0_si4 : !firrtl.sint<0>, !firrtl.sint<4>
+  %11 = firrtl.geq %xs, %c4_si4 : !firrtl.sint<0>, !firrtl.sint<4>
+  %12 = firrtl.gt %xu, %c0_ui4 : !firrtl.uint<0>, !firrtl.uint<4>
+  %13 = firrtl.gt %xu, %c4_ui4 : !firrtl.uint<0>, !firrtl.uint<4>
+  %14 = firrtl.gt %xs, %c0_si4 : !firrtl.sint<0>, !firrtl.sint<4>
+  %15 = firrtl.gt %xs, %c4_si4 : !firrtl.sint<0>, !firrtl.sint<4>
+  %16 = firrtl.eq %xu, %c0_ui4 : !firrtl.uint<0>, !firrtl.uint<4>
+  %17 = firrtl.eq %xu, %c4_ui4 : !firrtl.uint<0>, !firrtl.uint<4>
+  %18 = firrtl.eq %xs, %c0_si4 : !firrtl.sint<0>, !firrtl.sint<4>
+  %19 = firrtl.eq %xs, %c4_si4 : !firrtl.sint<0>, !firrtl.sint<4>
+  %20 = firrtl.neq %xu, %c0_ui4 : !firrtl.uint<0>, !firrtl.uint<4>
+  %21 = firrtl.neq %xu, %c4_ui4 : !firrtl.uint<0>, !firrtl.uint<4>
+  %22 = firrtl.neq %xs, %c0_si4 : !firrtl.sint<0>, !firrtl.sint<4>
+  %23 = firrtl.neq %xs, %c4_si4 : !firrtl.sint<0>, !firrtl.sint<4>
 
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1779,18 +1779,18 @@ firrtl.module @ComparisonOfZeroWidths(
   out %y22: !firrtl.uint<1>,
   out %y23: !firrtl.uint<1>
 ) {
-  %0 = firrtl.leq %xu0, %xu1 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  %1 = firrtl.leq %xs0, %xs1 : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %2 = firrtl.lt %xu0, %xu1 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  %3 = firrtl.lt %xs0, %xs1 : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %4 = firrtl.geq %xu0, %xu1 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  %5 = firrtl.geq %xs0, %xs1 : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %6 = firrtl.gt %xu0, %xu1 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  %7 = firrtl.gt %xs0, %xs1 : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %8 = firrtl.eq %xu0, %xu1 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  %9 = firrtl.eq %xs0, %xs1 : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %10 = firrtl.neq %xu0, %xu1 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  %11 = firrtl.neq %xs0, %xs1 : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
+  %0 = firrtl.leq %xu0, %xu1 : !firrtl.uint<0>, !firrtl.uint<0>
+  %1 = firrtl.leq %xs0, %xs1 : !firrtl.sint<0>, !firrtl.sint<0>
+  %2 = firrtl.lt %xu0, %xu1 : !firrtl.uint<0>, !firrtl.uint<0>
+  %3 = firrtl.lt %xs0, %xs1 : !firrtl.sint<0>, !firrtl.sint<0>
+  %4 = firrtl.geq %xu0, %xu1 : !firrtl.uint<0>, !firrtl.uint<0>
+  %5 = firrtl.geq %xs0, %xs1 : !firrtl.sint<0>, !firrtl.sint<0>
+  %6 = firrtl.gt %xu0, %xu1 : !firrtl.uint<0>, !firrtl.uint<0>
+  %7 = firrtl.gt %xs0, %xs1 : !firrtl.sint<0>, !firrtl.sint<0>
+  %8 = firrtl.eq %xu0, %xu1 : !firrtl.uint<0>, !firrtl.uint<0>
+  %9 = firrtl.eq %xs0, %xs1 : !firrtl.sint<0>, !firrtl.sint<0>
+  %10 = firrtl.neq %xu0, %xu1 : !firrtl.uint<0>, !firrtl.uint<0>
+  %11 = firrtl.neq %xs0, %xs1 : !firrtl.sint<0>, !firrtl.sint<0>
 
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1854,29 +1854,29 @@ firrtl.module @ComparisonOfConsts(
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
   // CHECK-NEXT: [[_:.+]] = firrtl.constant
 
-  %0 = firrtl.leq %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
-  %1 = firrtl.leq %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %2 = firrtl.leq %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %3 = firrtl.leq %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %4 = firrtl.leq %c2_si4, %c0_si0 : (!firrtl.sint<4>, !firrtl.sint<0>) -> !firrtl.uint<1>
+  %0 = firrtl.leq %c2_si4, %c-3_si3 : !firrtl.sint<4>, !firrtl.sint<3>
+  %1 = firrtl.leq %c-3_si3, %c2_si4 : !firrtl.sint<3>, !firrtl.sint<4>
+  %2 = firrtl.leq %c2_ui4, %c5_ui3 : !firrtl.uint<4>, !firrtl.uint<3>
+  %3 = firrtl.leq %c5_ui3, %c2_ui4 : !firrtl.uint<3>, !firrtl.uint<4>
+  %4 = firrtl.leq %c2_si4, %c0_si0 : !firrtl.sint<4>, !firrtl.sint<0>
 
-  %5 = firrtl.lt %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
-  %6 = firrtl.lt %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %7 = firrtl.lt %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %8 = firrtl.lt %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %9 = firrtl.lt %c2_si4, %c0_si0 : (!firrtl.sint<4>, !firrtl.sint<0>) -> !firrtl.uint<1>
+  %5 = firrtl.lt %c2_si4, %c-3_si3 : !firrtl.sint<4>, !firrtl.sint<3>
+  %6 = firrtl.lt %c-3_si3, %c2_si4 : !firrtl.sint<3>, !firrtl.sint<4>
+  %7 = firrtl.lt %c2_ui4, %c5_ui3 : !firrtl.uint<4>, !firrtl.uint<3>
+  %8 = firrtl.lt %c5_ui3, %c2_ui4 : !firrtl.uint<3>, !firrtl.uint<4>
+  %9 = firrtl.lt %c2_si4, %c0_si0 : !firrtl.sint<4>, !firrtl.sint<0>
 
-  %10 = firrtl.geq %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
-  %11 = firrtl.geq %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %12 = firrtl.geq %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %13 = firrtl.geq %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %14 = firrtl.geq %c2_si4, %c0_si0 : (!firrtl.sint<4>, !firrtl.sint<0>) -> !firrtl.uint<1>
+  %10 = firrtl.geq %c2_si4, %c-3_si3 : !firrtl.sint<4>, !firrtl.sint<3>
+  %11 = firrtl.geq %c-3_si3, %c2_si4 : !firrtl.sint<3>, !firrtl.sint<4>
+  %12 = firrtl.geq %c2_ui4, %c5_ui3 : !firrtl.uint<4>, !firrtl.uint<3>
+  %13 = firrtl.geq %c5_ui3, %c2_ui4 : !firrtl.uint<3>, !firrtl.uint<4>
+  %14 = firrtl.geq %c2_si4, %c0_si0 : !firrtl.sint<4>, !firrtl.sint<0>
 
-  %15 = firrtl.gt %c2_si4, %c-3_si3 : (!firrtl.sint<4>, !firrtl.sint<3>) -> !firrtl.uint<1>
-  %16 = firrtl.gt %c-3_si3, %c2_si4 : (!firrtl.sint<3>, !firrtl.sint<4>) -> !firrtl.uint<1>
-  %17 = firrtl.gt %c2_ui4, %c5_ui3 : (!firrtl.uint<4>, !firrtl.uint<3>) -> !firrtl.uint<1>
-  %18 = firrtl.gt %c5_ui3, %c2_ui4 : (!firrtl.uint<3>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %19 = firrtl.gt %c2_si4, %c0_si0 : (!firrtl.sint<4>, !firrtl.sint<0>) -> !firrtl.uint<1>
+  %15 = firrtl.gt %c2_si4, %c-3_si3 : !firrtl.sint<4>, !firrtl.sint<3>
+  %16 = firrtl.gt %c-3_si3, %c2_si4 : !firrtl.sint<3>, !firrtl.sint<4>
+  %17 = firrtl.gt %c2_ui4, %c5_ui3 : !firrtl.uint<4>, !firrtl.uint<3>
+  %18 = firrtl.gt %c5_ui3, %c2_ui4 : !firrtl.uint<3>, !firrtl.uint<4>
+  %19 = firrtl.gt %c2_si4, %c0_si0 : !firrtl.sint<4>, !firrtl.sint<0>
 
   firrtl.connect %y0, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %y1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -1931,27 +1931,27 @@ firrtl.module @ComparisonOfConsts(
 // CHECK-NEXT:   firrtl.matchingconnect %out, %c0_ui2 : !firrtl.uint<2>
 // CHECK-NEXT:  }
 firrtl.module @zeroWidth(out %out: !firrtl.uint<2>, in %in1 : !firrtl.uint<0>, in %in2 : !firrtl.uint<0>) {
-  %add = firrtl.add %in1, %in2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  %sub = firrtl.sub %in1, %in2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  %mul = firrtl.mul %in1, %in2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
-  %div = firrtl.div %in1, %in2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
-  %rem = firrtl.rem %in1, %in2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
-  %dshl = firrtl.dshl %in1, %in2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
-  %dshlw = firrtl.dshlw %in1, %in2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
-  %dshr = firrtl.dshr %in1, %in2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
-  %and = firrtl.and %in1, %in2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
-  %or = firrtl.or %in1, %in2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
-  %xor = firrtl.xor %in1, %in2 : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<0>
-  %ret1 = firrtl.cat %add, %sub : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-  %ret2 = firrtl.cat %ret1, %mul : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
-  %ret3 = firrtl.cat %ret2, %div : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
-  %ret4 = firrtl.cat %ret3, %rem : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
-  %ret5 = firrtl.cat %ret4, %dshl : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
-  %ret6 = firrtl.cat %ret5, %dshlw : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
-  %ret7 = firrtl.cat %ret6, %dshr : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
-  %ret8 = firrtl.cat %ret7, %and : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
-  %ret9 = firrtl.cat %ret8, %or : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
-  %ret10 = firrtl.cat %ret9, %xor : (!firrtl.uint<2>, !firrtl.uint<0>) -> !firrtl.uint<2>
+  %add = firrtl.add %in1, %in2 : !firrtl.uint<0>, !firrtl.uint<0>
+  %sub = firrtl.sub %in1, %in2 : !firrtl.uint<0>, !firrtl.uint<0>
+  %mul = firrtl.mul %in1, %in2 : !firrtl.uint<0>, !firrtl.uint<0>
+  %div = firrtl.div %in1, %in2 : !firrtl.uint<0>, !firrtl.uint<0>
+  %rem = firrtl.rem %in1, %in2 : !firrtl.uint<0>, !firrtl.uint<0>
+  %dshl = firrtl.dshl %in1, %in2 : !firrtl.uint<0>, !firrtl.uint<0>
+  %dshlw = firrtl.dshlw %in1, %in2 : !firrtl.uint<0>, !firrtl.uint<0>
+  %dshr = firrtl.dshr %in1, %in2 : !firrtl.uint<0>, !firrtl.uint<0>
+  %and = firrtl.and %in1, %in2 : !firrtl.uint<0>, !firrtl.uint<0>
+  %or = firrtl.or %in1, %in2 : !firrtl.uint<0>, !firrtl.uint<0>
+  %xor = firrtl.xor %in1, %in2 : !firrtl.uint<0>, !firrtl.uint<0>
+  %ret1 = firrtl.cat %add, %sub : !firrtl.uint<1>, !firrtl.uint<1>
+  %ret2 = firrtl.cat %ret1, %mul : !firrtl.uint<2>, !firrtl.uint<0>
+  %ret3 = firrtl.cat %ret2, %div : !firrtl.uint<2>, !firrtl.uint<0>
+  %ret4 = firrtl.cat %ret3, %rem : !firrtl.uint<2>, !firrtl.uint<0>
+  %ret5 = firrtl.cat %ret4, %dshl : !firrtl.uint<2>, !firrtl.uint<0>
+  %ret6 = firrtl.cat %ret5, %dshlw : !firrtl.uint<2>, !firrtl.uint<0>
+  %ret7 = firrtl.cat %ret6, %dshr : !firrtl.uint<2>, !firrtl.uint<0>
+  %ret8 = firrtl.cat %ret7, %and : !firrtl.uint<2>, !firrtl.uint<0>
+  %ret9 = firrtl.cat %ret8, %or : !firrtl.uint<2>, !firrtl.uint<0>
+  %ret10 = firrtl.cat %ret9, %xor : !firrtl.uint<2>, !firrtl.uint<0>
   firrtl.matchingconnect %out, %ret10 : !firrtl.uint<2>
 }
 
@@ -1972,11 +1972,11 @@ firrtl.module @zeroWidthOperand(
   out %y12: !firrtl.uint<0>,
   out %y14: !firrtl.uint<0>
 ) {
-  %div1 = firrtl.div %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
-  %rem1 = firrtl.rem %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
-  %rem2 = firrtl.rem %in1, %in0 : (!firrtl.uint<1>, !firrtl.uint<0>) -> !firrtl.uint<0>
-  %dshlw1 = firrtl.dshlw %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
-  %dshr1 = firrtl.dshr %in0, %in1 : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
+  %div1 = firrtl.div %in0, %in1 : !firrtl.uint<0>, !firrtl.uint<1>
+  %rem1 = firrtl.rem %in0, %in1 : !firrtl.uint<0>, !firrtl.uint<1>
+  %rem2 = firrtl.rem %in1, %in0 : !firrtl.uint<1>, !firrtl.uint<0>
+  %dshlw1 = firrtl.dshlw %in0, %in1 : !firrtl.uint<0>, !firrtl.uint<1>
+  %dshr1 = firrtl.dshr %in0, %in1 : !firrtl.uint<0>, !firrtl.uint<1>
 
   firrtl.matchingconnect %y6, %div1 : !firrtl.uint<0>
   firrtl.matchingconnect %y8, %rem1 : !firrtl.uint<0>
@@ -1994,7 +1994,7 @@ firrtl.module @add_cst_prop1(out %out_b: !firrtl.uint<9>) {
   %_tmp_a = firrtl.wire droppable_name : !firrtl.uint<7>
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
   firrtl.connect %_tmp_a, %c6_ui7 : !firrtl.uint<7>, !firrtl.uint<7>
-  %add = firrtl.add %_tmp_a, %c5_ui8 : (!firrtl.uint<7>, !firrtl.uint<8>) -> !firrtl.uint<9>
+  %add = firrtl.add %_tmp_a, %c5_ui8 : !firrtl.uint<7>, !firrtl.uint<8>
   firrtl.connect %out_b, %add : !firrtl.uint<9>, !firrtl.uint<9>
 }
 
@@ -2007,7 +2007,7 @@ firrtl.module @add_cst_prop2(out %out_b: !firrtl.sint<9>) {
   %_tmp_a = firrtl.wire droppable_name: !firrtl.sint<7>
   %c5_ui8 = firrtl.constant 5 : !firrtl.sint<8>
   firrtl.connect %_tmp_a, %c6_ui7 : !firrtl.sint<7>, !firrtl.sint<7>
-  %add = firrtl.add %_tmp_a, %c5_ui8 : (!firrtl.sint<7>, !firrtl.sint<8>) -> !firrtl.sint<9>
+  %add = firrtl.add %_tmp_a, %c5_ui8 : !firrtl.sint<7>, !firrtl.sint<8>
   firrtl.connect %out_b, %add : !firrtl.sint<9>, !firrtl.sint<9>
 }
 
@@ -2020,7 +2020,7 @@ firrtl.module @add_cst_prop3(out %out_b: !firrtl.sint<4>) {
   %_tmp_a = firrtl.wire droppable_name : !firrtl.sint<2>
   %c1_si3 = firrtl.constant -1 : !firrtl.sint<3>
   firrtl.connect %_tmp_a, %c1_si2 : !firrtl.sint<2>, !firrtl.sint<2>
-  %add = firrtl.add %_tmp_a, %c1_si3 : (!firrtl.sint<2>, !firrtl.sint<3>) -> !firrtl.sint<4>
+  %add = firrtl.add %_tmp_a, %c1_si3 : !firrtl.sint<2>, !firrtl.sint<3>
   firrtl.connect %out_b, %add : !firrtl.sint<4>, !firrtl.sint<4>
 }
 
@@ -2032,9 +2032,9 @@ firrtl.module @add_cst_prop3(out %out_b: !firrtl.sint<4>) {
 firrtl.module @add_cst_prop5(out %out_b: !firrtl.uint<5>) {
   %tmp_a = firrtl.wire : !firrtl.uint<4>
   %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
-  %add = firrtl.add %tmp_a, %c0_ui4 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+  %add = firrtl.add %tmp_a, %c0_ui4 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out_b, %add : !firrtl.uint<5>, !firrtl.uint<5>
-  %add2 = firrtl.add %c0_ui4, %tmp_a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+  %add2 = firrtl.add %c0_ui4, %tmp_a : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out_b, %add2 : !firrtl.uint<5>, !firrtl.uint<5>
 }
 
@@ -2042,7 +2042,7 @@ firrtl.module @add_cst_prop5(out %out_b: !firrtl.uint<5>) {
 // CHECK: %[[shl:.+]] = firrtl.shl %in, 1
 // CHECK-NEXT: firrtl.matchingconnect %out, %[[shl]]
 firrtl.module @add_double(out %out: !firrtl.uint<5>, in %in: !firrtl.uint<4>) {
-  %add = firrtl.add %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+  %add = firrtl.add %in, %in : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %add : !firrtl.uint<5>, !firrtl.uint<5>
 }
 
@@ -2057,11 +2057,11 @@ firrtl.module @add_double(out %out: !firrtl.uint<5>, in %in: !firrtl.uint<4>) {
 // CHECK-NEXT: firrtl.matchingconnect %out2, %[[pad2]]
 // CHECK-NEXT: firrtl.matchingconnect %out3, %[[pad3]]
 firrtl.module @add_narrow(out %out1: !firrtl.uint<7>, out %out2: !firrtl.uint<7>, out %out3: !firrtl.uint<7>, in %in1: !firrtl.uint<4>, in %in2: !firrtl.uint<2>) {
-  %t1 = firrtl.pad %in1, 6 : (!firrtl.uint<4>) -> !firrtl.uint<6>
-  %t2 = firrtl.pad %in2, 6 : (!firrtl.uint<2>) -> !firrtl.uint<6>
-  %add1 = firrtl.add %t1, %t2 : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<7>
-  %add2 = firrtl.add %in1, %t2 : (!firrtl.uint<4>, !firrtl.uint<6>) -> !firrtl.uint<7>
-  %add3 = firrtl.add %t1, %in2 : (!firrtl.uint<6>, !firrtl.uint<2>) -> !firrtl.uint<7>
+  %t1 = firrtl.pad %in1, 6 : !firrtl.uint<4>
+  %t2 = firrtl.pad %in2, 6 : !firrtl.uint<2>
+  %add1 = firrtl.add %t1, %t2 : !firrtl.uint<6>, !firrtl.uint<6>
+  %add2 = firrtl.add %in1, %t2 : !firrtl.uint<4>, !firrtl.uint<6>
+  %add3 = firrtl.add %t1, %in2 : !firrtl.uint<6>, !firrtl.uint<2>
   firrtl.matchingconnect %out1, %add1 : !firrtl.uint<7>
   firrtl.matchingconnect %out2, %add2 : !firrtl.uint<7>
   firrtl.matchingconnect %out3, %add3 : !firrtl.uint<7>
@@ -2078,53 +2078,53 @@ firrtl.module @add_narrow(out %out1: !firrtl.uint<7>, out %out2: !firrtl.uint<7>
 // CHECK-NEXT: firrtl.matchingconnect %out2, %[[pad2]]
 // CHECK-NEXT: firrtl.matchingconnect %out3, %[[pad3]]
 firrtl.module @adds_narrow(out %out1: !firrtl.sint<7>, out %out2: !firrtl.sint<7>, out %out3: !firrtl.sint<7>, in %in1: !firrtl.sint<4>, in %in2: !firrtl.sint<2>) {
-  %t1 = firrtl.pad %in1, 6 : (!firrtl.sint<4>) -> !firrtl.sint<6>
-  %t2 = firrtl.pad %in2, 6 : (!firrtl.sint<2>) -> !firrtl.sint<6>
-  %add1 = firrtl.add %t1, %t2 : (!firrtl.sint<6>, !firrtl.sint<6>) -> !firrtl.sint<7>
-  %add2 = firrtl.add %in1, %t2 : (!firrtl.sint<4>, !firrtl.sint<6>) -> !firrtl.sint<7>
-  %add3 = firrtl.add %t1, %in2 : (!firrtl.sint<6>, !firrtl.sint<2>) -> !firrtl.sint<7>
+  %t1 = firrtl.pad %in1, 6 : !firrtl.sint<4>
+  %t2 = firrtl.pad %in2, 6 : !firrtl.sint<2>
+  %add1 = firrtl.add %t1, %t2 : !firrtl.sint<6>, !firrtl.sint<6>
+  %add2 = firrtl.add %in1, %t2 : !firrtl.sint<4>, !firrtl.sint<6>
+  %add3 = firrtl.add %t1, %in2 : !firrtl.sint<6>, !firrtl.sint<2>
   firrtl.matchingconnect %out1, %add1 : !firrtl.sint<7>
   firrtl.matchingconnect %out2, %add2 : !firrtl.sint<7>
   firrtl.matchingconnect %out3, %add3 : !firrtl.sint<7>
 }
 
 // CHECK-LABEL: @sub_narrow
-// CHECK-NEXT: %[[add1:.+]] = firrtl.sub %in1, %in2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<5>
-// CHECK-NEXT: %[[pad1:.+]] = firrtl.pad %[[add1]], 7 : (!firrtl.uint<5>) -> !firrtl.uint<7>
-// CHECK-NEXT: %[[add2:.+]] = firrtl.sub %in1, %in2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<5>
-// CHECK-NEXT: %[[pad2:.+]] = firrtl.pad %[[add2]], 7 : (!firrtl.uint<5>) -> !firrtl.uint<7>
-// CHECK-NEXT: %[[add3:.+]] = firrtl.sub %in1, %in2 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<5>
-// CHECK-NEXT: %[[pad3:.+]] = firrtl.pad %[[add3]], 7 : (!firrtl.uint<5>) -> !firrtl.uint<7>
+// CHECK-NEXT: %[[add1:.+]] = firrtl.sub %in1, %in2 : !firrtl.uint<4>, !firrtl.uint<2>
+// CHECK-NEXT: %[[pad1:.+]] = firrtl.pad %[[add1]], 7 : !firrtl.uint<5>
+// CHECK-NEXT: %[[add2:.+]] = firrtl.sub %in1, %in2 : !firrtl.uint<4>, !firrtl.uint<2>
+// CHECK-NEXT: %[[pad2:.+]] = firrtl.pad %[[add2]], 7 : !firrtl.uint<5>
+// CHECK-NEXT: %[[add3:.+]] = firrtl.sub %in1, %in2 : !firrtl.uint<4>, !firrtl.uint<2>
+// CHECK-NEXT: %[[pad3:.+]] = firrtl.pad %[[add3]], 7 : !firrtl.uint<5>
 // CHECK-NEXT: firrtl.matchingconnect %out1, %[[pad1]]
 // CHECK-NEXT: firrtl.matchingconnect %out2, %[[pad2]]
 // CHECK-NEXT: firrtl.matchingconnect %out3, %[[pad3]]
 firrtl.module @sub_narrow(out %out1: !firrtl.uint<7>, out %out2: !firrtl.uint<7>, out %out3: !firrtl.uint<7>, in %in1: !firrtl.uint<4>, in %in2: !firrtl.uint<2>) {
-  %t1 = firrtl.pad %in1, 6 : (!firrtl.uint<4>) -> !firrtl.uint<6>
-  %t2 = firrtl.pad %in2, 6 : (!firrtl.uint<2>) -> !firrtl.uint<6>
-  %add1 = firrtl.sub %t1, %t2 : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<7>
-  %add2 = firrtl.sub %in1, %t2 : (!firrtl.uint<4>, !firrtl.uint<6>) -> !firrtl.uint<7>
-  %add3 = firrtl.sub %t1, %in2 : (!firrtl.uint<6>, !firrtl.uint<2>) -> !firrtl.uint<7>
+  %t1 = firrtl.pad %in1, 6 : !firrtl.uint<4>
+  %t2 = firrtl.pad %in2, 6 : !firrtl.uint<2>
+  %add1 = firrtl.sub %t1, %t2 : !firrtl.uint<6>, !firrtl.uint<6>
+  %add2 = firrtl.sub %in1, %t2 : !firrtl.uint<4>, !firrtl.uint<6>
+  %add3 = firrtl.sub %t1, %in2 : !firrtl.uint<6>, !firrtl.uint<2>
   firrtl.matchingconnect %out1, %add1 : !firrtl.uint<7>
   firrtl.matchingconnect %out2, %add2 : !firrtl.uint<7>
   firrtl.matchingconnect %out3, %add3 : !firrtl.uint<7>
 }
 
 // CHECK-LABEL: @subs_narrow
-// CHECK-NEXT: %[[add1:.+]] = firrtl.sub %in1, %in2 : (!firrtl.sint<4>, !firrtl.sint<2>) -> !firrtl.sint<5>
-// CHECK-NEXT: %[[pad1:.+]] = firrtl.pad %[[add1]], 7 : (!firrtl.sint<5>) -> !firrtl.sint<7>
-// CHECK-NEXT: %[[add2:.+]] = firrtl.sub %in1, %in2 : (!firrtl.sint<4>, !firrtl.sint<2>) -> !firrtl.sint<5>
-// CHECK-NEXT: %[[pad2:.+]] = firrtl.pad %[[add2]], 7 : (!firrtl.sint<5>) -> !firrtl.sint<7>
-// CHECK-NEXT: %[[add3:.+]] = firrtl.sub %in1, %in2 : (!firrtl.sint<4>, !firrtl.sint<2>) -> !firrtl.sint<5>
-// CHECK-NEXT: %[[pad3:.+]] = firrtl.pad %[[add3]], 7 : (!firrtl.sint<5>) -> !firrtl.sint<7>
+// CHECK-NEXT: %[[add1:.+]] = firrtl.sub %in1, %in2 : !firrtl.sint<4>, !firrtl.sint<2>
+// CHECK-NEXT: %[[pad1:.+]] = firrtl.pad %[[add1]], 7 : !firrtl.sint<5>
+// CHECK-NEXT: %[[add2:.+]] = firrtl.sub %in1, %in2 : !firrtl.sint<4>, !firrtl.sint<2>
+// CHECK-NEXT: %[[pad2:.+]] = firrtl.pad %[[add2]], 7 : !firrtl.sint<5>
+// CHECK-NEXT: %[[add3:.+]] = firrtl.sub %in1, %in2 : !firrtl.sint<4>, !firrtl.sint<2>
+// CHECK-NEXT: %[[pad3:.+]] = firrtl.pad %[[add3]], 7 : !firrtl.sint<5>
 // CHECK-NEXT: firrtl.matchingconnect %out1, %[[pad1]]
 // CHECK-NEXT: firrtl.matchingconnect %out2, %[[pad2]]
 // CHECK-NEXT: firrtl.matchingconnect %out3, %[[pad3]]
 firrtl.module @subs_narrow(out %out1: !firrtl.sint<7>, out %out2: !firrtl.sint<7>, out %out3: !firrtl.sint<7>, in %in1: !firrtl.sint<4>, in %in2: !firrtl.sint<2>) {
-  %t1 = firrtl.pad %in1, 6 : (!firrtl.sint<4>) -> !firrtl.sint<6>
-  %t2 = firrtl.pad %in2, 6 : (!firrtl.sint<2>) -> !firrtl.sint<6>
-  %add1 = firrtl.sub %t1, %t2 : (!firrtl.sint<6>, !firrtl.sint<6>) -> !firrtl.sint<7>
-  %add2 = firrtl.sub %in1, %t2 : (!firrtl.sint<4>, !firrtl.sint<6>) -> !firrtl.sint<7>
-  %add3 = firrtl.sub %t1, %in2 : (!firrtl.sint<6>, !firrtl.sint<2>) -> !firrtl.sint<7>
+  %t1 = firrtl.pad %in1, 6 : !firrtl.sint<4>
+  %t2 = firrtl.pad %in2, 6 : !firrtl.sint<2>
+  %add1 = firrtl.sub %t1, %t2 : !firrtl.sint<6>, !firrtl.sint<6>
+  %add2 = firrtl.sub %in1, %t2 : !firrtl.sint<4>, !firrtl.sint<6>
+  %add3 = firrtl.sub %t1, %in2 : !firrtl.sint<6>, !firrtl.sint<2>
   firrtl.matchingconnect %out1, %add1 : !firrtl.sint<7>
   firrtl.matchingconnect %out2, %add2 : !firrtl.sint<7>
   firrtl.matchingconnect %out3, %add3 : !firrtl.sint<7>
@@ -2139,7 +2139,7 @@ firrtl.module @sub_cst_prop1(out %out_b: !firrtl.uint<9>) {
   %_tmp_a = firrtl.wire droppable_name : !firrtl.uint<7>
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
   firrtl.connect %_tmp_a, %c6_ui7 : !firrtl.uint<7>, !firrtl.uint<7>
-  %add = firrtl.sub %_tmp_a, %c5_ui8 : (!firrtl.uint<7>, !firrtl.uint<8>) -> !firrtl.uint<9>
+  %add = firrtl.sub %_tmp_a, %c5_ui8 : !firrtl.uint<7>, !firrtl.uint<8>
   firrtl.connect %out_b, %add : !firrtl.uint<9>, !firrtl.uint<9>
 }
 
@@ -2152,7 +2152,7 @@ firrtl.module @sub_cst_prop2(out %out_b: !firrtl.sint<9>) {
   %_tmp_a = firrtl.wire droppable_name : !firrtl.sint<7>
   %c5_ui8 = firrtl.constant 5 : !firrtl.sint<8>
   firrtl.connect %_tmp_a, %c6_ui7 : !firrtl.sint<7>, !firrtl.sint<7>
-  %add = firrtl.sub %_tmp_a, %c5_ui8 : (!firrtl.sint<7>, !firrtl.sint<8>) -> !firrtl.sint<9>
+  %add = firrtl.sub %_tmp_a, %c5_ui8 : !firrtl.sint<7>, !firrtl.sint<8>
   firrtl.connect %out_b, %add : !firrtl.sint<9>, !firrtl.sint<9>
 }
 
@@ -2160,7 +2160,7 @@ firrtl.module @sub_cst_prop2(out %out_b: !firrtl.sint<9>) {
 // CHECK: %[[cst:.+]] = firrtl.constant 0 : !firrtl.uint<5>
 // CHECK-NEXT: firrtl.matchingconnect %out, %[[cst]]
 firrtl.module @sub_double(out %out: !firrtl.uint<5>, in %in: !firrtl.uint<4>) {
-  %add = firrtl.sub %in, %in : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
+  %add = firrtl.sub %in, %in : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %add : !firrtl.uint<5>, !firrtl.uint<5>
 }
 
@@ -2173,7 +2173,7 @@ firrtl.module @mul_cst_prop1(out %out_b: !firrtl.uint<15>) {
   %_tmp_a = firrtl.wire droppable_name : !firrtl.uint<7>
   %c5_ui8 = firrtl.constant 5 : !firrtl.uint<8>
   firrtl.connect %_tmp_a, %c6_ui7 : !firrtl.uint<7>, !firrtl.uint<7>
-  %add = firrtl.mul %_tmp_a, %c5_ui8 : (!firrtl.uint<7>, !firrtl.uint<8>) -> !firrtl.uint<15>
+  %add = firrtl.mul %_tmp_a, %c5_ui8 : !firrtl.uint<7>, !firrtl.uint<8>
   firrtl.connect %out_b, %add : !firrtl.uint<15>, !firrtl.uint<15>
 }
 
@@ -2186,7 +2186,7 @@ firrtl.module @mul_cst_prop2(out %out_b: !firrtl.sint<15>) {
   %_tmp_a = firrtl.wire droppable_name : !firrtl.sint<7>
   %c5_ui8 = firrtl.constant 5 : !firrtl.sint<8>
   firrtl.connect %_tmp_a, %c6_ui7 : !firrtl.sint<7>, !firrtl.sint<7>
-  %add = firrtl.mul %_tmp_a, %c5_ui8 : (!firrtl.sint<7>, !firrtl.sint<8>) -> !firrtl.sint<15>
+  %add = firrtl.mul %_tmp_a, %c5_ui8 : !firrtl.sint<7>, !firrtl.sint<8>
   firrtl.connect %out_b, %add : !firrtl.sint<15>, !firrtl.sint<15>
 }
 
@@ -2199,32 +2199,32 @@ firrtl.module @mul_cst_prop3(out %out_b: !firrtl.sint<15>) {
   %_tmp_a = firrtl.wire droppable_name : !firrtl.sint<7>
   %c5_ui8 = firrtl.constant -5 : !firrtl.sint<8>
   firrtl.connect %_tmp_a, %c6_ui7 : !firrtl.sint<7>, !firrtl.sint<7>
-  %add = firrtl.mul %_tmp_a, %c5_ui8 : (!firrtl.sint<7>, !firrtl.sint<8>) -> !firrtl.sint<15>
+  %add = firrtl.mul %_tmp_a, %c5_ui8 : !firrtl.sint<7>, !firrtl.sint<8>
   firrtl.connect %out_b, %add : !firrtl.sint<15>, !firrtl.sint<15>
 }
 
 // CHECK-LABEL: firrtl.module @MuxCanon
 firrtl.module @MuxCanon(in %c1: !firrtl.uint<1>, in %c2: !firrtl.uint<1>, in %d1: !firrtl.uint<5>, in %d2: !firrtl.uint<5>, in %d3: !firrtl.uint<5>, out %foo: !firrtl.uint<5>, out %foo2: !firrtl.uint<5>, out %foo3: !firrtl.uint<5>, out %foo4: !firrtl.uint<5>, out %foo5: !firrtl.uint<10>, out %foo6: !firrtl.uint<10>) {
-  %0 = firrtl.mux(%c1, %d2, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  %1 = firrtl.mux(%c1, %d1, %0) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  %2 = firrtl.mux(%c1, %0, %d1) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  %3 = firrtl.mux(%c1, %d1, %d2) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  %4 = firrtl.mux(%c2, %3, %d2) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  %5 = firrtl.mux(%c2, %d1, %3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  %6 = firrtl.cat %d1, %d2 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<10>
-  %7 = firrtl.cat %d1, %d3 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<10>
-  %8 = firrtl.cat %d1, %d2 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<10>
-  %9 = firrtl.cat %d3, %d2 : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<10>
-  %10 = firrtl.mux(%c1, %6, %7) : (!firrtl.uint<1>, !firrtl.uint<10>, !firrtl.uint<10>) -> !firrtl.uint<10>
-  %11 = firrtl.mux(%c2, %8, %9) : (!firrtl.uint<1>, !firrtl.uint<10>, !firrtl.uint<10>) -> !firrtl.uint<10>
+  %0 = firrtl.mux(%c1, %d2, %d3) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
+  %1 = firrtl.mux(%c1, %d1, %0) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
+  %2 = firrtl.mux(%c1, %0, %d1) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
+  %3 = firrtl.mux(%c1, %d1, %d2) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
+  %4 = firrtl.mux(%c2, %3, %d2) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
+  %5 = firrtl.mux(%c2, %d1, %3) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
+  %6 = firrtl.cat %d1, %d2 : !firrtl.uint<5>, !firrtl.uint<5>
+  %7 = firrtl.cat %d1, %d3 : !firrtl.uint<5>, !firrtl.uint<5>
+  %8 = firrtl.cat %d1, %d2 : !firrtl.uint<5>, !firrtl.uint<5>
+  %9 = firrtl.cat %d3, %d2 : !firrtl.uint<5>, !firrtl.uint<5>
+  %10 = firrtl.mux(%c1, %6, %7) : !firrtl.uint<1>, !firrtl.uint<10>, !firrtl.uint<10>
+  %11 = firrtl.mux(%c2, %8, %9) : !firrtl.uint<1>, !firrtl.uint<10>, !firrtl.uint<10>
   firrtl.connect %foo, %1 : !firrtl.uint<5>, !firrtl.uint<5>
   firrtl.connect %foo2, %2 : !firrtl.uint<5>, !firrtl.uint<5>
   firrtl.connect %foo3, %4 : !firrtl.uint<5>, !firrtl.uint<5>
   firrtl.connect %foo4, %5 : !firrtl.uint<5>, !firrtl.uint<5>
   firrtl.connect %foo5, %10 : !firrtl.uint<10>, !firrtl.uint<10>
   firrtl.connect %foo6, %11 : !firrtl.uint<10>, !firrtl.uint<10>
-  // CHECK: firrtl.mux(%c1, %d1, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  // CHECK: firrtl.mux(%c1, %d2, %d1) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  // CHECK: firrtl.mux(%c1, %d1, %d3) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
+  // CHECK: firrtl.mux(%c1, %d2, %d1) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
   // CHECK: %[[and:.*]] = firrtl.and %c2, %c1
   // CHECK: %[[andmux:.*]] = firrtl.mux(%[[and]], %d1, %d2)
   // CHECK: %[[or:.*]] = firrtl.or %c2, %c1
@@ -2243,11 +2243,11 @@ firrtl.module @MuxShorten(
   in %d5: !firrtl.uint<5>, in %d6: !firrtl.uint<5>,
   out %foo: !firrtl.uint<5>, out %foo2: !firrtl.uint<5>) {
 
-  %0 = firrtl.mux(%c1, %d2, %d3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  %1 = firrtl.mux(%c2, %0, %d1) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  %2 = firrtl.mux(%c1, %d4, %d5) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  %3 = firrtl.mux(%c2, %2, %d6) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-  %11 = firrtl.mux(%c1, %1, %3) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
+  %0 = firrtl.mux(%c1, %d2, %d3) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
+  %1 = firrtl.mux(%c2, %0, %d1) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
+  %2 = firrtl.mux(%c1, %d4, %d5) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
+  %3 = firrtl.mux(%c2, %2, %d6) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
+  %11 = firrtl.mux(%c1, %1, %3) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
   firrtl.connect %foo, %11 : !firrtl.uint<5>, !firrtl.uint<5>
   firrtl.connect %foo2, %3 : !firrtl.uint<5>, !firrtl.uint<5>
 
@@ -2265,8 +2265,8 @@ firrtl.module @MuxShorten(
 firrtl.module @RegresetToReg(in %clock: !firrtl.clock, in %dummy : !firrtl.uint<1>, out %foo1: !firrtl.uint<1>, out %foo2: !firrtl.uint<1>) {
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %zero_asyncreset = firrtl.asAsyncReset %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
-  %one_asyncreset = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
+  %zero_asyncreset = firrtl.asAsyncReset %c0_ui1 : !firrtl.uint<1>
+  %one_asyncreset = firrtl.asAsyncReset %c1_ui1 : !firrtl.uint<1>
   // CHECK: %bar1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
   // CHECK: firrtl.matchingconnect %foo2, %dummy : !firrtl.uint<1>
   %bar1 = firrtl.regreset %clock, %zero_asyncreset, %dummy : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
@@ -2282,7 +2282,7 @@ firrtl.module @RegresetToReg(in %clock: !firrtl.clock, in %dummy : !firrtl.uint<
 // Correctness, revisit if this is "valid" if forceable.
 firrtl.module @ForceableRegResetToNode(in %clock: !firrtl.clock, in %dummy : !firrtl.uint<1>, out %foo: !firrtl.uint<1>, out %ref : !firrtl.rwprobe<uint<1>>) {
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %one_asyncreset = firrtl.asAsyncReset %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
+  %one_asyncreset = firrtl.asAsyncReset %c1_ui1 : !firrtl.uint<1>
   // CHECK: %reg, %reg_ref = firrtl.node %dummy forceable : !firrtl.uint<1>
   %reg, %reg_f = firrtl.regreset %clock, %one_asyncreset, %dummy forceable : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.rwprobe<uint<1>>
   firrtl.ref.define %ref, %reg_f: !firrtl.rwprobe<uint<1>>
@@ -2297,19 +2297,19 @@ firrtl.module @MuxInvalidTypeOpt(in %in : !firrtl.uint<1>, out %out : !firrtl.ui
   %c7_ui4 = firrtl.constant 7 : !firrtl.uint<4>
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
-  %0 = firrtl.mux (%in, %c7_ui4, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<4>
-  %1 = firrtl.mux (%in, %c1_ui2, %c7_ui4) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %0 = firrtl.mux (%in, %c7_ui4, %c0_ui2) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<2>
+  %1 = firrtl.mux (%in, %c1_ui2, %c7_ui4) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 }
-// CHECK: firrtl.mux(%in, %c7_ui4, %c0_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
-// CHECK: firrtl.mux(%in, %c1_ui4, %c7_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+// CHECK: firrtl.mux(%in, %c7_ui4, %c0_ui4) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
+// CHECK: firrtl.mux(%in, %c1_ui4, %c7_ui4) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
 
 // CHECK-LABEL: firrtl.module @issue1100
 // CHECK: firrtl.matchingconnect %tmp62, %c1_ui1
   firrtl.module @issue1100(out %tmp62: !firrtl.uint<1>) {
     %c-1_si2 = firrtl.constant -1 : !firrtl.sint<2>
-    %0 = firrtl.orr %c-1_si2 : (!firrtl.sint<2>) -> !firrtl.uint<1>
+    %0 = firrtl.orr %c-1_si2 : !firrtl.sint<2>
     firrtl.connect %tmp62, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
@@ -2323,7 +2323,7 @@ firrtl.module @zeroWidthMem(in %clock: !firrtl.clock) {
 firrtl.module @issue1116(out %z: !firrtl.uint<1>) {
   %c844336_ui = firrtl.constant 844336 : !firrtl.uint
   %c161_ui8 = firrtl.constant 161 : !firrtl.uint<8>
-  %0 = firrtl.leq %c844336_ui, %c161_ui8 : (!firrtl.uint, !firrtl.uint<8>) -> !firrtl.uint<1>
+  %0 = firrtl.leq %c844336_ui, %c161_ui8 : !firrtl.uint, !firrtl.uint<8>
   // CHECK: firrtl.matchingconnect %z, %c0_ui1
   firrtl.connect %z, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -2331,14 +2331,14 @@ firrtl.module @issue1116(out %z: !firrtl.uint<1>) {
 // Sign casts must not be folded into unsized constants.
 // CHECK-LABEL: firrtl.module @issue1118
 firrtl.module @issue1118(out %z0: !firrtl.uint, out %z1: !firrtl.sint) {
-  // CHECK: %0 = firrtl.asUInt %c4232_si : (!firrtl.sint) -> !firrtl.uint
-  // CHECK: %1 = firrtl.asSInt %c4232_ui : (!firrtl.uint) -> !firrtl.sint
+  // CHECK: %0 = firrtl.asUInt %c4232_si : !firrtl.sint
+  // CHECK: %1 = firrtl.asSInt %c4232_ui : !firrtl.uint
   // CHECK: firrtl.connect %z0, %0 : !firrtl.uint
   // CHECK: firrtl.connect %z1, %1 : !firrtl.sint
   %c4232_si = firrtl.constant 4232 : !firrtl.sint
   %c4232_ui = firrtl.constant 4232 : !firrtl.uint
-  %0 = firrtl.asUInt %c4232_si : (!firrtl.sint) -> !firrtl.uint
-  %1 = firrtl.asSInt %c4232_ui : (!firrtl.uint) -> !firrtl.sint
+  %0 = firrtl.asUInt %c4232_si : !firrtl.sint
+  %1 = firrtl.asSInt %c4232_ui : !firrtl.uint
   firrtl.connect %z0, %0 : !firrtl.uint, !firrtl.uint
   firrtl.connect %z1, %1 : !firrtl.sint, !firrtl.sint
 }
@@ -2349,7 +2349,7 @@ firrtl.module @issue1139(out %z: !firrtl.uint<4>) {
   // CHECK-NEXT: firrtl.matchingconnect %z, %c0_ui4 : !firrtl.uint<4>
   %c4_ui4 = firrtl.constant 4 : !firrtl.uint<4>
   %c674_ui = firrtl.constant 674 : !firrtl.uint
-  %0 = firrtl.dshr %c4_ui4, %c674_ui : (!firrtl.uint<4>, !firrtl.uint) -> !firrtl.uint<4>
+  %0 = firrtl.dshr %c4_ui4, %c674_ui : !firrtl.uint<4>, !firrtl.uint
   firrtl.connect %z, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
@@ -2361,18 +2361,18 @@ firrtl.module @issue1142(in %cond: !firrtl.uint<1>, out %z: !firrtl.uint) {
   %c43_ui = firrtl.constant 43 : !firrtl.uint
 
   // Don't fold away constant selects if widths are unknown.
-  // CHECK: %0 = firrtl.mux(%c0_ui1, %c42_ui, %c43_ui) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
-  // CHECK: %1 = firrtl.mux(%c1_ui1, %c42_ui, %c43_ui) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
-  %0 = firrtl.mux(%c0_ui1, %c42_ui, %c43_ui) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
-  %1 = firrtl.mux(%c1_ui1, %c42_ui, %c43_ui) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
+  // CHECK: %0 = firrtl.mux(%c0_ui1, %c42_ui, %c43_ui) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
+  // CHECK: %1 = firrtl.mux(%c1_ui1, %c42_ui, %c43_ui) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
+  %0 = firrtl.mux(%c0_ui1, %c42_ui, %c43_ui) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
+  %1 = firrtl.mux(%c1_ui1, %c42_ui, %c43_ui) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
 
   // Don't fold nested muxes with same condition if widths are unknown.
-  // CHECK: %2 = firrtl.mux(%cond, %c42_ui, %c43_ui) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
-  // CHECK: %3 = firrtl.mux(%cond, %2, %c43_ui) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
-  // CHECK: %4 = firrtl.mux(%cond, %c42_ui, %2) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
-  %2 = firrtl.mux(%cond, %c42_ui, %c43_ui) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
-  %3 = firrtl.mux(%cond, %2, %c43_ui) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
-  %4 = firrtl.mux(%cond, %c42_ui, %2) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
+  // CHECK: %2 = firrtl.mux(%cond, %c42_ui, %c43_ui) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
+  // CHECK: %3 = firrtl.mux(%cond, %2, %c43_ui) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
+  // CHECK: %4 = firrtl.mux(%cond, %c42_ui, %2) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
+  %2 = firrtl.mux(%cond, %c42_ui, %c43_ui) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
+  %3 = firrtl.mux(%cond, %2, %c43_ui) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
+  %4 = firrtl.mux(%cond, %c42_ui, %2) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
 
   firrtl.connect %z, %0 : !firrtl.uint, !firrtl.uint
   firrtl.connect %z, %1 : !firrtl.uint, !firrtl.uint
@@ -2392,30 +2392,30 @@ firrtl.module @PadMuxOperands(
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
 
   // Smaller operand should pad to result width.
-  // CHECK: %0 = firrtl.pad %ui11, 17 : (!firrtl.uint<11>) -> !firrtl.uint<17>
-  // CHECK: %1 = firrtl.mux(%cond, %0, %ui17) : (!firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<17>) -> !firrtl.uint<17>
-  // CHECK: %2 = firrtl.pad %ui11, 17 : (!firrtl.uint<11>) -> !firrtl.uint<17>
-  // CHECK: %3 = firrtl.mux(%cond, %ui17, %2) : (!firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<17>) -> !firrtl.uint<17>
-  %0 = firrtl.mux(%cond, %ui11, %ui17) : (!firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<17>) -> !firrtl.uint<17>
-  %1 = firrtl.mux(%cond, %ui17, %ui11) : (!firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<11>) -> !firrtl.uint<17>
+  // CHECK: %0 = firrtl.pad %ui11, 17 : !firrtl.uint<11>
+  // CHECK: %1 = firrtl.mux(%cond, %0, %ui17) : !firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<17>
+  // CHECK: %2 = firrtl.pad %ui11, 17 : !firrtl.uint<11>
+  // CHECK: %3 = firrtl.mux(%cond, %ui17, %2) : !firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<17>
+  %0 = firrtl.mux(%cond, %ui11, %ui17) : !firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<17>
+  %1 = firrtl.mux(%cond, %ui17, %ui11) : !firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<11>
 
   // Unknown result width should prevent padding.
-  // CHECK: %4 = firrtl.mux(%cond, %ui11, %ui) : (!firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint) -> !firrtl.uint
-  // CHECK: %5 = firrtl.mux(%cond, %ui, %ui11) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint<11>) -> !firrtl.uint
-  %2 = firrtl.mux(%cond, %ui11, %ui) : (!firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint) -> !firrtl.uint
-  %3 = firrtl.mux(%cond, %ui, %ui11) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint<11>) -> !firrtl.uint
+  // CHECK: %4 = firrtl.mux(%cond, %ui11, %ui) : !firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint
+  // CHECK: %5 = firrtl.mux(%cond, %ui, %ui11) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<11>
+  %2 = firrtl.mux(%cond, %ui11, %ui) : !firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint
+  %3 = firrtl.mux(%cond, %ui, %ui11) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint<11>
 
   // Padding to equal width operands should enable constant-select folds.
-  // CHECK: %6 = firrtl.pad %ui11, 17 : (!firrtl.uint<11>) -> !firrtl.uint<17>
-  // CHECK: %7 = firrtl.pad %ui11, 17 : (!firrtl.uint<11>) -> !firrtl.uint<17>
+  // CHECK: %6 = firrtl.pad %ui11, 17 : !firrtl.uint<11>
+  // CHECK: %7 = firrtl.pad %ui11, 17 : !firrtl.uint<11>
   // CHECK: firrtl.connect %z, %ui17 : !firrtl.uint, !firrtl.uint<17>
   // CHECK: firrtl.connect %z, %6 : !firrtl.uint, !firrtl.uint<17>
   // CHECK: firrtl.connect %z, %7 : !firrtl.uint, !firrtl.uint<17>
   // CHECK: firrtl.connect %z, %ui17 : !firrtl.uint, !firrtl.uint<17>
-  %4 = firrtl.mux(%c0_ui1, %ui11, %ui17) : (!firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<17>) -> !firrtl.uint<17>
-  %5 = firrtl.mux(%c0_ui1, %ui17, %ui11) : (!firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<11>) -> !firrtl.uint<17>
-  %6 = firrtl.mux(%c1_ui1, %ui11, %ui17) : (!firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<17>) -> !firrtl.uint<17>
-  %7 = firrtl.mux(%c1_ui1, %ui17, %ui11) : (!firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<11>) -> !firrtl.uint<17>
+  %4 = firrtl.mux(%c0_ui1, %ui11, %ui17) : !firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<17>
+  %5 = firrtl.mux(%c0_ui1, %ui17, %ui11) : !firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<11>
+  %6 = firrtl.mux(%c1_ui1, %ui11, %ui17) : !firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<17>
+  %7 = firrtl.mux(%c1_ui1, %ui17, %ui11) : !firrtl.uint<1>, !firrtl.uint<17>, !firrtl.uint<11>
 
   firrtl.connect %z, %0 : !firrtl.uint, !firrtl.uint<17>
   firrtl.connect %z, %1 : !firrtl.uint, !firrtl.uint<17>
@@ -2437,7 +2437,7 @@ firrtl.module @regsyncreset(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>
   %d = firrtl.reg %clock {firrtl.random_init_end = 1 : ui64, firrtl.random_init_start = 0 : ui64} : !firrtl.clock, !firrtl.uint<2>
   firrtl.connect %bar, %d : !firrtl.uint<2>, !firrtl.uint<2>
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-  %1 = firrtl.mux(%reset, %c1_ui2, %foo) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+  %1 = firrtl.mux(%reset, %c1_ui2, %foo) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
   firrtl.connect %d, %1 : !firrtl.uint<2>, !firrtl.uint<2>
 }
 
@@ -2446,13 +2446,13 @@ firrtl.module @regsyncreset_no(in %clock: !firrtl.clock, in %reset: !firrtl.uint
   // CHECK: %[[const:.*]] = firrtl.constant 1
   // CHECK: firrtl.reg %clock
   // CHECK-NEXT:  firrtl.connect %bar, %d : !firrtl.uint
-  // CHECK-NEXT:  %0 = firrtl.mux(%reset, %[[const]], %foo) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
+  // CHECK-NEXT:  %0 = firrtl.mux(%reset, %[[const]], %foo) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
   // CHECK-NEXT:  firrtl.connect %d, %0 : !firrtl.uint
   // CHECK-NEXT: }
   %d = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint
   firrtl.connect %bar, %d : !firrtl.uint, !firrtl.uint
   %c1_ui2 = firrtl.constant 1 : !firrtl.uint
-  %1 = firrtl.mux(%reset, %c1_ui2, %foo) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
+  %1 = firrtl.mux(%reset, %c1_ui2, %foo) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
   firrtl.connect %d, %1 : !firrtl.uint, !firrtl.uint
 }
 
@@ -2464,27 +2464,27 @@ firrtl.module @dshifts_to_ishifts(in %a_in: !firrtl.sint<58>,
                                   out %b_out: !firrtl.uint<23>,
                                   in %c_in: !firrtl.sint<58>,
                                   out %c_out: !firrtl.sint<58>) {
-  // CHECK: %0 = firrtl.bits %a_in 57 to 4 : (!firrtl.sint<58>) -> !firrtl.uint<54>
-  // CHECK: %1 = firrtl.asSInt %0 : (!firrtl.uint<54>) -> !firrtl.sint<54>
-  // CHECK: %2 = firrtl.pad %1, 58 : (!firrtl.sint<54>) -> !firrtl.sint<58>
+  // CHECK: %0 = firrtl.bits %a_in 57 to 4 : !firrtl.sint<58>
+  // CHECK: %1 = firrtl.asSInt %0 : !firrtl.uint<54>
+  // CHECK: %2 = firrtl.pad %1, 58 : !firrtl.sint<54>
   // CHECK: firrtl.matchingconnect %a_out, %2 : !firrtl.sint<58>
   %c4_ui10 = firrtl.constant 4 : !firrtl.uint<10>
-  %0 = firrtl.dshr %a_in, %c4_ui10 : (!firrtl.sint<58>, !firrtl.uint<10>) -> !firrtl.sint<58>
+  %0 = firrtl.dshr %a_in, %c4_ui10 : !firrtl.sint<58>, !firrtl.uint<10>
   firrtl.connect %a_out, %0 : !firrtl.sint<58>, !firrtl.sint<58>
 
-  // CHECK: %3 = firrtl.shl %b_in, 4 : (!firrtl.uint<8>) -> !firrtl.uint<12>
-  // CHECK: %4 = firrtl.pad %3, 23 : (!firrtl.uint<12>) -> !firrtl.uint<23>
+  // CHECK: %3 = firrtl.shl %b_in, 4 : !firrtl.uint<8>
+  // CHECK: %4 = firrtl.pad %3, 23 : !firrtl.uint<12>
   // CHECK: firrtl.matchingconnect %b_out, %4 : !firrtl.uint<23>
   %c4_ui4 = firrtl.constant 4 : !firrtl.uint<4>
-  %1 = firrtl.dshl %b_in, %c4_ui4 : (!firrtl.uint<8>, !firrtl.uint<4>) -> !firrtl.uint<23>
+  %1 = firrtl.dshl %b_in, %c4_ui4 : !firrtl.uint<8>, !firrtl.uint<4>
   firrtl.connect %b_out, %1 : !firrtl.uint<23>, !firrtl.uint<23>
 
-  // CHECK: %5 = firrtl.bits %c_in 57 to 57 : (!firrtl.sint<58>) -> !firrtl.uint<1>
-  // CHECK: %6 = firrtl.asSInt %5 : (!firrtl.uint<1>) -> !firrtl.sint<1>
-  // CHECK: %7 = firrtl.pad %6, 58 : (!firrtl.sint<1>) -> !firrtl.sint<58>
+  // CHECK: %5 = firrtl.bits %c_in 57 to 57 : !firrtl.sint<58>
+  // CHECK: %6 = firrtl.asSInt %5 : !firrtl.uint<1>
+  // CHECK: %7 = firrtl.pad %6, 58 : !firrtl.sint<1>
   // CHECK: firrtl.matchingconnect %c_out, %7 : !firrtl.sint<58>
   %c438_ui10 = firrtl.constant 438 : !firrtl.uint<10>
-  %2 = firrtl.dshr %c_in, %c438_ui10 : (!firrtl.sint<58>, !firrtl.uint<10>) -> !firrtl.sint<58>
+  %2 = firrtl.dshr %c_in, %c438_ui10 : !firrtl.sint<58>, !firrtl.uint<10>
   firrtl.connect %c_out, %2 : !firrtl.sint<58>, !firrtl.sint<58>
 }
 
@@ -2493,7 +2493,7 @@ firrtl.module @constReg(in %clock: !firrtl.clock,
               in %en: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
   %r1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %0 = firrtl.mux(%en, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.mux(%en, %c1_ui1, %r1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:  %[[C11:.+]] = firrtl.constant 1 : !firrtl.uint<1>
@@ -2518,12 +2518,12 @@ firrtl.module @constReg2(in %clock: !firrtl.clock,
   %r1 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
   %r2 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %0 = firrtl.mux(%en, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.mux(%en, %c1_ui1, %r1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %1 = firrtl.mux(%en, %r2, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %1 = firrtl.mux(%en, %r2, %c0_ui1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %r2, %1 : !firrtl.uint<1>, !firrtl.uint<1>
-  %2 = firrtl.xor %r1, %r2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %2 = firrtl.xor %r1, %r2 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:  %[[C12:.+]] = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK:  firrtl.matchingconnect %out, %[[C12]]
@@ -2533,7 +2533,7 @@ firrtl.module @constReg2(in %clock: !firrtl.clock,
 firrtl.module @constReg3(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
   %r = firrtl.regreset %clock, %reset, %c11_ui8  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
-  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  %0 = firrtl.mux(%cond, %c11_ui8, %r) : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C14:.+]] = firrtl.constant 11
   // CHECK: firrtl.matchingconnect %z, %[[C14]]
@@ -2545,7 +2545,7 @@ firrtl.module @constReg4(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
   %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
   %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
-  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  %0 = firrtl.mux(%cond, %c11_ui8, %r) : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C13:.+]] = firrtl.constant 11
   // CHECK: firrtl.matchingconnect %z, %[[C13]]
@@ -2556,9 +2556,9 @@ firrtl.module @constReg4(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
 firrtl.module @constReg6(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %cond: !firrtl.uint<1>, out %z: !firrtl.uint<8>) {
   %c11_ui8 = firrtl.constant 11 : !firrtl.uint<8>
   %c11_ui4 = firrtl.constant 11 : !firrtl.uint<8>
-  %resCond = firrtl.and %reset, %cond : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %resCond = firrtl.and %reset, %cond : !firrtl.uint<1>, !firrtl.uint<1>
   %r = firrtl.regreset %clock, %resCond, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
-  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  %0 = firrtl.mux(%cond, %c11_ui8, %r) : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK:  %[[C13:.+]] = firrtl.constant 11
   // CHECK: firrtl.matchingconnect %z, %[[C13]]
@@ -2572,7 +2572,7 @@ firrtl.module @constReg5(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   %c11_ui4 = firrtl.constant 11 : !firrtl.uint<4>
   %r = firrtl.regreset %clock, %reset, %c11_ui4  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<8>
   // CHECK: %0 = firrtl.mux(%cond, %c11_ui8, %r)
-  %0 = firrtl.mux(%cond, %c11_ui8, %r) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+  %0 = firrtl.mux(%cond, %c11_ui8, %r) : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
   // CHECK: firrtl.matchingconnect %r, %0
   firrtl.connect %r, %0 : !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.connect %z, %r : !firrtl.uint<8>, !firrtl.uint<8>
@@ -2590,14 +2590,14 @@ firrtl.module @constReg8(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, o
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK: firrtl.regreset sym @s2
   %r1 = firrtl.regreset sym @s2 %clock, %reset, %c1_ui1 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-  %0 = firrtl.mux(%reset, %c1_ui1, %r1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.mux(%reset, %c1_ui1, %r1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %r1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out1, %r1 : !firrtl.uint<1>, !firrtl.uint<1>
 
   // CHECK: firrtl.regreset
   // CHECK-SAME: Foo
   %r2 = firrtl.regreset  %clock, %reset, %c1_ui1 {annotations = [{class = "Foo"}]} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
-  %1 = firrtl.mux(%reset, %c1_ui1, %r2) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %1 = firrtl.mux(%reset, %c1_ui1, %r2) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %r2, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %out2, %r2 : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -2609,9 +2609,9 @@ firrtl.module @constReg9(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, i
   // CHECK-NOT: firrtl.reg
   // CHECK: firrtl.matchingconnect %out, %c0_ui1
   %r = firrtl.reg %clock {firrtl.random_init_start = 0 : ui64} : !firrtl.clock, !firrtl.uint<1>
-  %0 = firrtl.and %en_0, %en_1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.and %en_0, %en_1 : !firrtl.uint<1>, !firrtl.uint<1>
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-  %1 = firrtl.mux(%0, %c0_ui1, %r) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %1 = firrtl.mux(%0, %c0_ui1, %r) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %r, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.matchingconnect %out, %r : !firrtl.uint<1>
 }
@@ -2701,7 +2701,7 @@ firrtl.module @Issue2197(in %clock: !firrtl.clock, out %x: !firrtl.uint<2>) {
 //  // COM: CHECK-NEXT: firrtl.matchingconnect %x, [[ZERO]] : !firrtl.uint<2>
 //  %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
 //  %_reg = firrtl.reg droppable_name %clock : !firrtl.clock, !firrtl.uint<2>
-//  %0 = firrtl.pad %invalid_ui1, 2 : (!firrtl.uint<1>) -> !firrtl.uint<2>
+//  %0 = firrtl.pad %invalid_ui1, 2 : !firrtl.uint<1>
 //  firrtl.connect %_reg, %0 : !firrtl.uint<2>, !firrtl.uint<2>
 //  firrtl.connect %x, %_reg : !firrtl.uint<2>, !firrtl.uint<2>
 }
@@ -2712,7 +2712,7 @@ firrtl.module @Issue2197(in %clock: !firrtl.clock, out %x: !firrtl.uint<2>) {
 firrtl.module @ZeroWidthAdd(out %a: !firrtl.sint<1>) {
   %zw = firrtl.constant 0 : !firrtl.sint<0>
   %0 = firrtl.constant 0 : !firrtl.sint<0>
-  %1 = firrtl.add %0, %zw : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.sint<1>
+  %1 = firrtl.add %0, %zw : !firrtl.sint<0>, !firrtl.sint<0>
   firrtl.connect %a, %1 : !firrtl.sint<1>, !firrtl.sint<1>
   // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<1>
   // CHECK-NEXT: firrtl.matchingconnect %a, %[[zero]]
@@ -2721,7 +2721,7 @@ firrtl.module @ZeroWidthAdd(out %a: !firrtl.sint<1>) {
 // CHECK-LABEL: @ZeroWidthDshr
 firrtl.module @ZeroWidthDshr(in %a: !firrtl.sint<0>, out %b: !firrtl.sint<0>) {
   %zw = firrtl.constant 0 : !firrtl.uint<0>
-  %0 = firrtl.dshr %a, %zw : (!firrtl.sint<0>, !firrtl.uint<0>) -> !firrtl.sint<0>
+  %0 = firrtl.dshr %a, %zw : !firrtl.sint<0>, !firrtl.uint<0>
   firrtl.connect %b, %0 : !firrtl.sint<0>, !firrtl.sint<0>
   // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<0>
   // CHECK-NEXT: firrtl.matchingconnect %b, %[[zero]]
@@ -2730,7 +2730,7 @@ firrtl.module @ZeroWidthDshr(in %a: !firrtl.sint<0>, out %b: !firrtl.sint<0>) {
 // CHECK-LABEL: @ZeroWidthPad
 firrtl.module @ZeroWidthPad(out %b: !firrtl.sint<1>) {
   %zw = firrtl.constant 0 : !firrtl.sint<0>
-  %0 = firrtl.pad %zw, 1 : (!firrtl.sint<0>) -> !firrtl.sint<1>
+  %0 = firrtl.pad %zw, 1 : !firrtl.sint<0>
   firrtl.connect %b, %0 : !firrtl.sint<1>, !firrtl.sint<1>
   // CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<1>
   // CHECK-NEXT: firrtl.matchingconnect %b, %[[zero]]
@@ -2740,7 +2740,7 @@ firrtl.module @ZeroWidthPad(out %b: !firrtl.sint<1>) {
 firrtl.module @ZeroWidthCat(out %a: !firrtl.uint<1>) {
   %one = firrtl.constant 1 : !firrtl.uint<1>
   %zw = firrtl.constant 0 : !firrtl.uint<0>
-  %0 = firrtl.cat %one, %zw : (!firrtl.uint<1>, !firrtl.uint<0>) -> !firrtl.uint<1>
+  %0 = firrtl.cat %one, %zw : !firrtl.uint<1>, !firrtl.uint<0>
   firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:      %[[one:.+]] = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK-NEXT: firrtl.matchingconnect %a, %[[one]]
@@ -2752,7 +2752,7 @@ firrtl.module @ZeroWidthCat(out %a: !firrtl.uint<1>) {
 firrtl.module @Issue2251(out %o: !firrtl.sint<15>) {
 //  // pad used to always return an unsigned constant
 //  %invalid_si1 = firrtl.invalidvalue : !firrtl.sint<1>
-//  %0 = firrtl.pad %invalid_si1, 15 : (!firrtl.sint<1>) -> !firrtl.sint<15>
+//  %0 = firrtl.pad %invalid_si1, 15 : !firrtl.sint<1>
 //  firrtl.connect %o, %0 : !firrtl.sint<15>, !firrtl.sint<15>
 //  // COM: CHECK:      %[[zero:.+]] = firrtl.constant 0 : !firrtl.sint<15>
 //  // COM: CHECK-NEXT: firrtl.matchingconnect %o, %[[zero]]
@@ -2765,8 +2765,8 @@ firrtl.module @Issue2289(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, o
   firrtl.connect %r, %r : !firrtl.uint<1>, !firrtl.uint<1>
   %c0_ui4 = firrtl.constant 0 : !firrtl.uint<4>
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %0 = firrtl.dshl %c1_ui1, %r : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-  %1 = firrtl.sub %c0_ui4, %0 : (!firrtl.uint<4>, !firrtl.uint<2>) -> !firrtl.uint<5>
+  %0 = firrtl.dshl %c1_ui1, %r : !firrtl.uint<1>, !firrtl.uint<1>
+  %1 = firrtl.sub %c0_ui4, %0 : !firrtl.uint<4>, !firrtl.uint<2>
   firrtl.connect %out, %1 : !firrtl.uint<5>, !firrtl.uint<5>
   // CHECK:      %[[dshl:.+]] = firrtl.dshl
   // CHECK-NEXT: %[[neg:.+]] = firrtl.neg %[[dshl]]
@@ -2779,8 +2779,8 @@ firrtl.module @Issue2289(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, o
 // CHECK-LABEL: @Issue2291
 firrtl.module @Issue2291(out %out: !firrtl.uint<1>) {
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %clock = firrtl.asClock %c1_ui1 : (!firrtl.uint<1>) -> !firrtl.clock
-  %0 = firrtl.asUInt %clock : (!firrtl.clock) -> !firrtl.uint<1>
+  %clock = firrtl.asClock %c1_ui1 : !firrtl.uint<1>
+  %0 = firrtl.asUInt %clock : !firrtl.clock
   firrtl.connect %out, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
@@ -2823,10 +2823,10 @@ firrtl.module @Issue2514(
   // CHECK-DAG: %[[one_i1:.+]] = firrtl.constant 1 : !firrtl.uint<1>
 
   // geq(x, y) -> 1 when x and y are both zero-width (and here, one is a constant)
-  %3 = firrtl.geq %s, %t : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %4 = firrtl.geq %t, %s : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %5 = firrtl.geq %u, %v : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  %6 = firrtl.geq %v, %u : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
+  %3 = firrtl.geq %s, %t : !firrtl.sint<0>, !firrtl.sint<0>
+  %4 = firrtl.geq %t, %s : !firrtl.sint<0>, !firrtl.sint<0>
+  %5 = firrtl.geq %u, %v : !firrtl.uint<0>, !firrtl.uint<0>
+  %6 = firrtl.geq %v, %u : !firrtl.uint<0>, !firrtl.uint<0>
   firrtl.matchingconnect %geq_0, %3 : !firrtl.uint<1>
   firrtl.matchingconnect %geq_1, %4 : !firrtl.uint<1>
   firrtl.matchingconnect %geq_2, %5 : !firrtl.uint<1>
@@ -2837,10 +2837,10 @@ firrtl.module @Issue2514(
   // CHECK: firrtl.matchingconnect %geq_3, %[[one_i1]]
 
   // gt(x, y) -> 0 when x and y are both zero-width (and here, one is a constant)
-  %7 = firrtl.gt %s, %t : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %8 = firrtl.gt %t, %s : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %9 = firrtl.gt %u, %v : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  %10 = firrtl.gt %v, %u : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
+  %7 = firrtl.gt %s, %t : !firrtl.sint<0>, !firrtl.sint<0>
+  %8 = firrtl.gt %t, %s : !firrtl.sint<0>, !firrtl.sint<0>
+  %9 = firrtl.gt %u, %v : !firrtl.uint<0>, !firrtl.uint<0>
+  %10 = firrtl.gt %v, %u : !firrtl.uint<0>, !firrtl.uint<0>
   firrtl.matchingconnect %gt_0, %7 : !firrtl.uint<1>
   firrtl.matchingconnect %gt_1, %8 : !firrtl.uint<1>
   firrtl.matchingconnect %gt_2, %9 : !firrtl.uint<1>
@@ -2851,10 +2851,10 @@ firrtl.module @Issue2514(
   // CHECK: firrtl.matchingconnect %gt_3, %[[zero_i1]]
 
   // lt(x, y) -> 0 when x and y are both zero-width (and here, one is a constant)
-  %11 = firrtl.lt %s, %t : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %12 = firrtl.lt %t, %s : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %13 = firrtl.lt %u, %v : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  %14 = firrtl.lt %v, %u : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
+  %11 = firrtl.lt %s, %t : !firrtl.sint<0>, !firrtl.sint<0>
+  %12 = firrtl.lt %t, %s : !firrtl.sint<0>, !firrtl.sint<0>
+  %13 = firrtl.lt %u, %v : !firrtl.uint<0>, !firrtl.uint<0>
+  %14 = firrtl.lt %v, %u : !firrtl.uint<0>, !firrtl.uint<0>
   firrtl.matchingconnect %lt_0, %11 : !firrtl.uint<1>
   firrtl.matchingconnect %lt_1, %12 : !firrtl.uint<1>
   firrtl.matchingconnect %lt_2, %13 : !firrtl.uint<1>
@@ -2865,10 +2865,10 @@ firrtl.module @Issue2514(
   // CHECK: firrtl.matchingconnect %lt_3, %[[zero_i1]]
 
   // leq(x, y) -> 1 when x and y are both zero-width (and here, one is a constant)
-  %15 = firrtl.leq %s, %t : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %16 = firrtl.leq %t, %s : (!firrtl.sint<0>, !firrtl.sint<0>) -> !firrtl.uint<1>
-  %17 = firrtl.leq %u, %v : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
-  %18 = firrtl.leq %v, %u : (!firrtl.uint<0>, !firrtl.uint<0>) -> !firrtl.uint<1>
+  %15 = firrtl.leq %s, %t : !firrtl.sint<0>, !firrtl.sint<0>
+  %16 = firrtl.leq %t, %s : !firrtl.sint<0>, !firrtl.sint<0>
+  %17 = firrtl.leq %u, %v : !firrtl.uint<0>, !firrtl.uint<0>
+  %18 = firrtl.leq %v, %u : !firrtl.uint<0>, !firrtl.uint<0>
   firrtl.matchingconnect %leq_0, %15 : !firrtl.uint<1>
   firrtl.matchingconnect %leq_1, %16 : !firrtl.uint<1>
   firrtl.matchingconnect %leq_2, %17 : !firrtl.uint<1>
@@ -2882,14 +2882,14 @@ firrtl.module @Issue2514(
 // CHECK-LABEL: @NamePropagation
 firrtl.module @NamePropagation(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, in %c: !firrtl.uint<4>, out %res1: !firrtl.uint<2>, out %res2: !firrtl.uint<2>) {
   // CHECK-NEXT: %e = firrtl.bits %c 1 to 0 {name = "e"}
-  %1 = firrtl.bits %c 2 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<3>
-  %e = firrtl.bits %1 1 to 0 {name = "e"}: (!firrtl.uint<3>) -> !firrtl.uint<2>
+  %1 = firrtl.bits %c 2 to 0 : !firrtl.uint<4>
+  %e = firrtl.bits %1 1 to 0 {name = "e"}: !firrtl.uint<3>
   // CHECK-NEXT: firrtl.matchingconnect %res1, %e
   firrtl.matchingconnect %res1, %e : !firrtl.uint<2>
 
-  // CHECK-NEXT: %name_node = firrtl.not %e {name = "name_node"} : (!firrtl.uint<2>) -> !firrtl.uint<2>
+  // CHECK-NEXT: %name_node = firrtl.not %e {name = "name_node"} : !firrtl.uint<2>
   // CHECK-NEXT: firrtl.matchingconnect %res2, %name_node
-  %2 = firrtl.not %e : (!firrtl.uint<2>) -> !firrtl.uint<2>
+  %2 = firrtl.not %e : !firrtl.uint<2>
   %name_node = firrtl.node droppable_name %2 : !firrtl.uint<2>
   firrtl.matchingconnect %res2, %name_node : !firrtl.uint<2>
 }
@@ -2899,7 +2899,7 @@ firrtl.module @NamePropagation(in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, i
 firrtl.module @Foo3319(in %i: !firrtl.uint<1>, out %o : !firrtl.uint<1>) {
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-  %0 = firrtl.and %c0_ui1, %i : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.and %c0_ui1, %i : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: %n = firrtl.node interesting_name %c0_ui1
   %n = firrtl.node interesting_name %0  : !firrtl.uint<1>
   // CHECK: firrtl.matchingconnect %o, %n
@@ -2972,7 +2972,7 @@ firrtl.module @MultibitMux(in %a: !firrtl.vector<uint<1>, 3>, in %sel: !firrtl.u
 
 // CHECK-LABEL: firrtl.module @NameProp
 firrtl.module @NameProp(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-  %0 = firrtl.or %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.or %in0, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
   %_useless_name_1 = firrtl.node  %0  : !firrtl.uint<1>
   %useful_name = firrtl.node %_useless_name_1  : !firrtl.uint<1>
   %_useless_name_2 = firrtl.node  %useful_name  : !firrtl.uint<1>
@@ -3004,7 +3004,7 @@ firrtl.module @CrashRegResetWithOneReset(in %clock: !firrtl.clock, in %reset: !f
   %c1_asyncreset = firrtl.specialconstant 1 : !firrtl.asyncreset
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %reg = firrtl.regreset  %clock, %c1_asyncreset, %c0_ui1  : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
-  %0 = firrtl.mux(%io_en, %io_d, %reg) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.mux(%io_en, %io_d, %reg) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %reg, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   firrtl.connect %io_q, %reg : !firrtl.uint<1>, !firrtl.uint<1>
 }
@@ -3046,11 +3046,11 @@ firrtl.module @ReadOnlyFileInitialized(
 // CHECK-LABEL: @MuxCondWidth
 firrtl.module @MuxCondWidth(in %cond: !firrtl.uint<1>, out %foo: !firrtl.uint<3>) {
   // Don't canonicalize if the type is not UInt<1>
-  // CHECK: %0 = firrtl.mux(%cond, %c0_ui3, %c1_ui3) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
+  // CHECK: %0 = firrtl.mux(%cond, %c0_ui3, %c1_ui3) : !firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>
   // CHECK-NEXT:  firrtl.matchingconnect %foo, %0
   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
   %c1_ui3 = firrtl.constant 1 : !firrtl.uint<3>
-  %0 = firrtl.mux(%cond, %c0_ui1, %c1_ui3) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<3>
+  %0 = firrtl.mux(%cond, %c0_ui1, %c1_ui3) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<3>
   firrtl.matchingconnect %foo, %0 : !firrtl.uint<3>
 }
 
@@ -3063,30 +3063,30 @@ firrtl.module @MuxEQ(in %a: !firrtl.uint<4>,
                      out %out3: !firrtl.uint<4>,
                      out %out4: !firrtl.uint<4>,
                      out %out5: !firrtl.uint<4>) {
-  %eq = firrtl.eq %a, %b : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %0 = firrtl.mux (%eq, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %eq = firrtl.eq %a, %b : !firrtl.uint<4>, !firrtl.uint<4>
+  %0 = firrtl.mux (%eq, %a, %b) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   // CHECK-NEXT: firrtl.matchingconnect %out1, %b
   firrtl.matchingconnect %out1, %0 : !firrtl.uint<4>
 
-  %eq_swapped = firrtl.eq %b, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %1 = firrtl.mux (%eq_swapped, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %eq_swapped = firrtl.eq %b, %a : !firrtl.uint<4>, !firrtl.uint<4>
+  %1 = firrtl.mux (%eq_swapped, %a, %b) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   // CHECK-NEXT: firrtl.matchingconnect %out2, %b
   firrtl.matchingconnect %out2, %1 : !firrtl.uint<4>
 
-  %neq = firrtl.neq %a, %b : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %2 = firrtl.mux (%neq, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %neq = firrtl.neq %a, %b : !firrtl.uint<4>, !firrtl.uint<4>
+  %2 = firrtl.mux (%neq, %a, %b) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   // CHECK-NEXT: firrtl.matchingconnect %out3, %a
   firrtl.matchingconnect %out3, %2 : !firrtl.uint<4>
 
-  %neq_swapped = firrtl.neq %b, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  %3 = firrtl.mux (%neq_swapped, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %neq_swapped = firrtl.neq %b, %a : !firrtl.uint<4>, !firrtl.uint<4>
+  %3 = firrtl.mux (%neq_swapped, %a, %b) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   // CHECK-NEXT: firrtl.matchingconnect %out4, %a
   firrtl.matchingconnect %out4, %3 : !firrtl.uint<4>
 
-  // CHECK-NEXT: [[EQ:%.+]] = firrtl.eq %a, %b : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<1>
-  // CHECK-NEXT: [[MUX:%.+]] = firrtl.mux([[EQ]], %c, %a) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  // CHECK-NEXT: [[EQ:%.+]] = firrtl.eq %a, %b : !firrtl.uint<4>, !firrtl.uint<4>
+  // CHECK-NEXT: [[MUX:%.+]] = firrtl.mux([[EQ]], %c, %a) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   // CHECK-NEXT: firrtl.matchingconnect %out5, [[MUX]]
-  %4 = firrtl.mux (%neq, %a, %c) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %4 = firrtl.mux (%neq, %a, %c) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.matchingconnect %out5, %4 : !firrtl.uint<4>
 }
 
@@ -3101,7 +3101,7 @@ firrtl.module @RemoveUnusedInvalid() {
 firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint<4>, out %out1 : !firrtl.uint<1>) {
   // CHECK-NOT firrtl.not
   %inv = firrtl.invalidvalue : !firrtl.uint<4>
-  %not = firrtl.not %inv : (!firrtl.uint<4>) -> !firrtl.uint<4>
+  %not = firrtl.not %inv : !firrtl.uint<4>
   firrtl.matchingconnect %out, %not : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
@@ -3109,7 +3109,7 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
 
   // CHECK-NOT firrtl.bits
   %inv2 = firrtl.invalidvalue : !firrtl.uint<5>
-  %bits = firrtl.bits %inv2 3 to 0 : (!firrtl.uint<5>) -> !firrtl.uint<4>
+  %bits = firrtl.bits %inv2 3 to 0 : !firrtl.uint<5>
   firrtl.matchingconnect %out, %bits : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
@@ -3117,7 +3117,7 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
 
   // CHECK-NOT firrtl.head
   %inv3 = firrtl.invalidvalue : !firrtl.uint<5>
-  %head = firrtl.head %inv3, 4 : (!firrtl.uint<5>) -> !firrtl.uint<4>
+  %head = firrtl.head %inv3, 4 : !firrtl.uint<5>
   firrtl.matchingconnect %out, %head : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
@@ -3125,7 +3125,7 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
 
   // CHECK-NOT firrtl.tail
   %inv4 = firrtl.invalidvalue : !firrtl.uint<5>
-  %tail = firrtl.tail %inv4, 1 : (!firrtl.uint<5>) -> !firrtl.uint<4>
+  %tail = firrtl.tail %inv4, 1 : !firrtl.uint<5>
   firrtl.matchingconnect %out, %tail : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
@@ -3133,7 +3133,7 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
 
   // CHECK-NOT firrtl.asSInt
   %inv5 = firrtl.invalidvalue : !firrtl.uint<4>
-  %assint = firrtl.asSInt %inv5 : (!firrtl.uint<4>) -> !firrtl.sint<4>
+  %assint = firrtl.asSInt %inv5 : !firrtl.uint<4>
   firrtl.matchingconnect %outs, %assint : !firrtl.sint<4>
 
   // CHECK: firrtl.invalidvalue
@@ -3141,7 +3141,7 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
 
   // CHECK-NOT firrtl.asUInt
   %inv6 = firrtl.invalidvalue : !firrtl.sint<4>
-  %asuint = firrtl.asUInt %inv6 : (!firrtl.sint<4>) -> !firrtl.uint<4>
+  %asuint = firrtl.asUInt %inv6 : !firrtl.sint<4>
   firrtl.matchingconnect %out, %asuint : !firrtl.uint<4>
 
   // CHECK: firrtl.invalidvalue
@@ -3173,7 +3173,7 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
 
   // CHECK-NOT firrtl.andr
   %inva = firrtl.invalidvalue : !firrtl.uint<4>
-  %andr = firrtl.andr %inva : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  %andr = firrtl.andr %inva : !firrtl.uint<4>
   firrtl.matchingconnect %out1, %andr : !firrtl.uint<1>
 
   // CHECK: firrtl.invalidvalue
@@ -3181,7 +3181,7 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
 
   // CHECK-NOT firrtl.orr
   %invb = firrtl.invalidvalue : !firrtl.uint<4>
-  %orr = firrtl.orr %invb : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  %orr = firrtl.orr %invb : !firrtl.uint<4>
   firrtl.matchingconnect %out1, %orr : !firrtl.uint<1>
 
   // CHECK: firrtl.invalidvalue
@@ -3189,7 +3189,7 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
 
   // CHECK-NOT firrtl.xorr
   %invc = firrtl.invalidvalue : !firrtl.uint<4>
-  %xorr = firrtl.xorr %invc : (!firrtl.uint<4>) -> !firrtl.uint<1>
+  %xorr = firrtl.xorr %invc : !firrtl.uint<4>
   firrtl.matchingconnect %out1, %xorr : !firrtl.uint<1>
 
   // CHECK: firrtl.invalidvalue
@@ -3199,13 +3199,13 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
   // CHECK-NOT firrtl.invalidvalue
   // CHECK-NOT firrtl.xorr
   %invd = firrtl.invalidvalue : !firrtl.uint<0>
-  %zbits = firrtl.xorr %invd : (!firrtl.uint<0>) -> !firrtl.uint<1>
+  %zbits = firrtl.xorr %invd : !firrtl.uint<0>
   firrtl.matchingconnect %out1, %zbits : !firrtl.uint<1>
   // CHECK: firrtl.matchingconnect %out1, %c0_ui1
 
   // CHECK-NOT firrtl.cvt
   %inve = firrtl.invalidvalue : !firrtl.uint<3>
-  %cvtu = firrtl.cvt %inve : (!firrtl.uint<3>) -> !firrtl.sint<4>
+  %cvtu = firrtl.cvt %inve : !firrtl.uint<3>
   firrtl.matchingconnect %outs, %cvtu : !firrtl.sint<4>
 
   // CHECK: firrtl.invalidvalue
@@ -3215,7 +3215,7 @@ firrtl.module @PropInvalids(out %out : !firrtl.uint<4>, out %outs : !firrtl.sint
 
   // CHECK-NOT firrtl.cvt
   %invf = firrtl.invalidvalue : !firrtl.sint<4>
-  %cvts = firrtl.cvt %invf : (!firrtl.sint<4>) -> !firrtl.sint<4>
+  %cvts = firrtl.cvt %invf : !firrtl.sint<4>
   firrtl.matchingconnect %outs, %cvts : !firrtl.sint<4>
 
   // CHECK: firrtl.invalidvalue
@@ -3394,10 +3394,10 @@ firrtl.module private @RefCastSame(in %in: !firrtl.uint<1>, out %out: !firrtl.pr
 
 // CHECK-LABEL: @Issue5527
 firrtl.module @Issue5527(in %x: !firrtl.uint<1>, out %out: !firrtl.uint<2>) attributes {convention = #firrtl<convention scalarized>} {
-  %0 = firrtl.cvt %x : (!firrtl.uint<1>) -> !firrtl.sint<2>
+  %0 = firrtl.cvt %x : !firrtl.uint<1>
   %c2_si4 = firrtl.constant 2 : !firrtl.sint<4>
-  %1 = firrtl.and %0, %c2_si4 : (!firrtl.sint<2>, !firrtl.sint<4>) -> !firrtl.uint<4>
-  %2 = firrtl.tail %1, 2 : (!firrtl.uint<4>) -> !firrtl.uint<2>
+  %1 = firrtl.and %0, %c2_si4 : !firrtl.sint<2>, !firrtl.sint<4>
+  %2 = firrtl.tail %1, 2 : !firrtl.uint<4>
   // CHECK: firrtl.matchingconnect %out, %c0_ui2
   firrtl.matchingconnect %out, %2 : !firrtl.uint<2>
 }
@@ -3611,11 +3611,11 @@ firrtl.module @sizeof(in %clock: !firrtl.clock,
   // CHECK: %n_c = firrtl.node interesting_name %c1_ui32 
   // CHECK: %n_vec = firrtl.node interesting_name %c9_ui32
   // CHECK: %n_bundle = firrtl.node interesting_name %c4_ui32
-  %s_c = firrtl.int.sizeof %clock : (!firrtl.clock) -> !firrtl.uint<32>
+  %s_c = firrtl.int.sizeof %clock : !firrtl.clock
   %n_c = firrtl.node interesting_name %s_c : !firrtl.uint<32>
-  %s_vec = firrtl.int.sizeof %vec : (!firrtl.vector<uint<3>,3>) -> !firrtl.uint<32>
+  %s_vec = firrtl.int.sizeof %vec : !firrtl.vector<uint<3>,3>
   %n_vec = firrtl.node interesting_name %s_vec : !firrtl.uint<32>
-  %s_bundle = firrtl.int.sizeof %bundle : (!firrtl.bundle<a: uint<2>, b: uint<2>>) -> !firrtl.uint<32>
+  %s_bundle = firrtl.int.sizeof %bundle : !firrtl.bundle<a: uint<2>, b: uint<2>>
   %n_bundle = firrtl.node interesting_name %s_bundle : !firrtl.uint<32>
 }
 
@@ -3636,7 +3636,7 @@ firrtl.module @multibit_mux_drop_front(in %vec_0: !firrtl.uint<8>, in %vec_1: !f
 }
 
 firrtl.module private @Issue7562(in %sel : !firrtl.uint<1>, in %a : !firrtl.const.uint<1>, out %out : !firrtl.uint) {
-  %res = firrtl.mux(%sel, %a, %a) : (!firrtl.uint<1>, !firrtl.const.uint<1>, !firrtl.const.uint<1>) -> !firrtl.uint<1>
+  %res = firrtl.mux(%sel, %a, %a) : !firrtl.uint<1>, !firrtl.const.uint<1>, !firrtl.const.uint<1>
   firrtl.connect %out, %res : !firrtl.uint, !firrtl.uint<1>
 }
 
@@ -3647,8 +3647,8 @@ firrtl.class @PropertyArithmetic(in %in: !firrtl.integer, out %out0: !firrtl.int
   %1 = firrtl.integer 1
   %2 = firrtl.integer 2
 
-  %3 = firrtl.integer.shl %1, %2 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
-  %4 = firrtl.integer.shl %in, %0 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+  %3 = firrtl.integer.shl %1, %2 : !firrtl.integer, !firrtl.integer
+  %4 = firrtl.integer.shl %in, %0 : !firrtl.integer, !firrtl.integer
 
   // CHECK: firrtl.propassign %out0, [[C4]]
   // CHECK: firrtl.propassign %out1, %in

--- a/test/Dialect/FIRRTL/check-comb-loops.mlir
+++ b/test/Dialect/FIRRTL/check-comb-loops.mlir
@@ -56,7 +56,7 @@ firrtl.circuit "hasloops"   {
   firrtl.module @hasloops(in %clk: !firrtl.clock, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>, out %d: !firrtl.uint<1>) {
     %y = firrtl.wire  : !firrtl.uint<1>
     firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-    %t = firrtl.and %c, %y : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %t = firrtl.and %c, %y : !firrtl.uint<1>, !firrtl.uint<1>
     %z = firrtl.node %t  : !firrtl.uint<1>
     firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
@@ -122,12 +122,12 @@ firrtl.circuit "hasloops"   {
     %c = firrtl.wire  : !firrtl.uint<1>
     %d = firrtl.wire  : !firrtl.uint<1>
     %e = firrtl.wire  : !firrtl.uint<1>
-    %0 = firrtl.and %c, %i : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.and %c, %i : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %a, %0 : !firrtl.uint<1>, !firrtl.uint<1>
-    %1 = firrtl.and %a, %d : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.and %a, %d : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %b, %1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-    %2 = firrtl.and %c, %e : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %2 = firrtl.and %c, %e : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %d, %2 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %e, %b : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %o, %e : !firrtl.uint<1>, !firrtl.uint<1>
@@ -239,7 +239,7 @@ firrtl.circuit "hasloops"   {
     %w = firrtl.wire  : !firrtl.vector<uint<1>,10>
     %y = firrtl.subindex %w[3]  : !firrtl.vector<uint<1>,10>
     firrtl.connect %c, %b : !firrtl.uint<1>, !firrtl.uint<1>
-    %0 = firrtl.and %c, %y : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.and %c, %y : !firrtl.uint<1>, !firrtl.uint<1>
     %z = firrtl.node %0  : !firrtl.uint<1>
     firrtl.connect %y, %z : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %d, %z : !firrtl.uint<1>, !firrtl.uint<1>
@@ -523,7 +523,7 @@ firrtl.circuit "subaccess"   {
 // CHECK-NOT: firrtl.circuit "revisitOps"
 firrtl.circuit "revisitOps"   {
   firrtl.module @thru(in %in1: !firrtl.uint<1>,in %in2: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
-    %1 = firrtl.mux(%in1, %in1, %in2)  : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.mux(%in1, %in1, %in2) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %out, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // expected-error @below {{revisitOps.{inner2.in2 <- x <- inner2.out <- inner2.in2}}}
@@ -545,7 +545,7 @@ firrtl.circuit "revisitOps"   {
     %in1_0 = firrtl.subindex %in1[0] : !firrtl.vector<uint<1>,2>
     %in2_1 = firrtl.subindex %in2[1] : !firrtl.vector<uint<1>,3>
     %out_1 = firrtl.subindex %out[1] : !firrtl.vector<uint<1>,2>
-    %1 = firrtl.mux(%w, %in1_0, %in2_1)  : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.mux(%w, %in1_0, %in2_1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %out_1, %1 : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // expected-error @below {{revisitOps.{inner2.in2[1] <- x <- inner2.out[1] <- inner2.in2[1]}}}
@@ -571,8 +571,8 @@ firrtl.circuit "revisitOps"   {
     %in1_0 = firrtl.subindex %in1[0] : !firrtl.vector<uint<1>,2>
     %in2_1 = firrtl.subindex %in2[1] : !firrtl.vector<uint<1>,3>
     %out_1 = firrtl.subindex %out[1] : !firrtl.vector<uint<1>,2>
-    %1 = firrtl.mux(%w, %in1_0, %in2_1)  : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %2 = firrtl.mux(%w, %in0_0, %1)  : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.mux(%w, %in1_0, %in2_1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    %2 = firrtl.mux(%w, %in0_0, %1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %out_1, %2 : !firrtl.uint<1>, !firrtl.uint<1>
   }
   // expected-error @below {{revisitOps.{inner2.in2[1] <- x <- inner2.out[1] <- inner2.in2[1]}}}
@@ -983,7 +983,7 @@ firrtl.circuit "Issue5462" {
     %w = firrtl.wire : !firrtl.bundle<a: uint<8>>
     %n = firrtl.node %w : !firrtl.bundle<a: uint<8>>
     %0 = firrtl.bundlecreate %in_a : (!firrtl.uint<8>) -> !firrtl.bundle<a: uint<8>>
-    %1 = firrtl.mux(%c, %n, %0) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>) -> !firrtl.bundle<a: uint<8>>
+    %1 = firrtl.mux(%c, %n, %0) : !firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
     %2 = firrtl.subfield %1[a] : !firrtl.bundle<a: uint<8>>
     %3 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint<8>>
     firrtl.matchingconnect %3, %2 : !firrtl.uint<8>
@@ -1049,7 +1049,7 @@ firrtl.circuit "Issue6820" {
     firrtl.ref.define %clockProbe, %foo_clockProbe_bore : !firrtl.rwprobe<clock>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %0 = firrtl.asClock %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.clock
+    %0 = firrtl.asClock %c0_ui1 : !firrtl.uint<1>
     firrtl.ref.force %clock, %c1_ui1, %clockProbe, %0 : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<clock>, !firrtl.clock
   }
 }

--- a/test/Dialect/FIRRTL/connect-errors.mlir
+++ b/test/Dialect/FIRRTL/connect-errors.mlir
@@ -276,7 +276,7 @@ firrtl.module @test(in %a : !firrtl.bundle<f1: uint<1>>, out %b : !firrtl.bundle
 firrtl.circuit "test" {
 firrtl.module @test(in %a : !firrtl.uint<1>, out %b : !firrtl.uint<1>) {
   // expected-note @below {{the destination was defined here}}
-  %0 = firrtl.and %a, %a: (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %0 = firrtl.and %a, %a : !firrtl.uint<1>, !firrtl.uint<1>
   // expected-error @below {{connect has invalid flow: the destination expression has source flow, expected sink or duplex flow}}
   firrtl.connect %0, %b : !firrtl.uint<1>, !firrtl.uint<1>
 }

--- a/test/Dialect/FIRRTL/const-prop-single-module.mlir
+++ b/test/Dialect/FIRRTL/const-prop-single-module.mlir
@@ -12,7 +12,7 @@ firrtl.module @ConstantPropagationSingleModule() {}
 // The rule x >= 0 should always be true if x is a UInt
 firrtl.module @Top01(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
   %c0_ui = firrtl.constant 0 : !firrtl.uint
-  %0 = firrtl.geq %x, %c0_ui : (!firrtl.uint<5>, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.geq %x, %c0_ui : !firrtl.uint<5>, !firrtl.uint
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top01
@@ -23,7 +23,7 @@ firrtl.module @Top01(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
 // The rule x < 0 should never be true if x is a UInt
 firrtl.module @Top02(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
   %c0_ui = firrtl.constant 0 : !firrtl.uint
-  %0 = firrtl.lt %x, %c0_ui : (!firrtl.uint<5>, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.lt %x, %c0_ui : !firrtl.uint<5>, !firrtl.uint
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top02
@@ -34,7 +34,7 @@ firrtl.module @Top02(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
 // The rule 0 <= x should always be true if x is a UInt
 firrtl.module @Top03(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
   %c0_ui = firrtl.constant 0 : !firrtl.uint
-  %0 = firrtl.leq %c0_ui, %x : (!firrtl.uint, !firrtl.uint<5>) -> !firrtl.uint<1>
+  %0 = firrtl.leq %c0_ui, %x : !firrtl.uint, !firrtl.uint<5>
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top03
@@ -45,7 +45,7 @@ firrtl.module @Top03(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
 // The rule 0 > x should never be true if x is a UInt
 firrtl.module @Top04(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
   %c0_ui = firrtl.constant 0 : !firrtl.uint
-  %0 = firrtl.gt %c0_ui, %x : (!firrtl.uint, !firrtl.uint<5>) -> !firrtl.uint<1>
+  %0 = firrtl.gt %c0_ui, %x : !firrtl.uint, !firrtl.uint<5>
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top04
@@ -57,7 +57,7 @@ firrtl.module @Top04(in %x: !firrtl.uint<5>, out %y: !firrtl.uint<1>) {
 firrtl.module @Top05(out %y: !firrtl.uint<1>) {
   %c1_ui = firrtl.constant 1 : !firrtl.uint
   %c3_ui = firrtl.constant 3 : !firrtl.uint
-  %0 = firrtl.lt %c1_ui, %c3_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.lt %c1_ui, %c3_ui : !firrtl.uint, !firrtl.uint
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top05
@@ -68,7 +68,7 @@ firrtl.module @Top05(out %y: !firrtl.uint<1>) {
 // The rule x < 8 should always be true if x only has 3 bits
 firrtl.module @Top06(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c8_ui = firrtl.constant 8 : !firrtl.uint
-  %0 = firrtl.lt %x, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.lt %x, %c8_ui : !firrtl.uint<3>, !firrtl.uint
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top06
@@ -79,7 +79,7 @@ firrtl.module @Top06(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 // The rule x <= 7 should always be true if x only has 3 bits
 firrtl.module @Top07(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c7_ui = firrtl.constant 7 : !firrtl.uint
-  %0 = firrtl.leq %x, %c7_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.leq %x, %c7_ui : !firrtl.uint<3>, !firrtl.uint
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top07
@@ -90,7 +90,7 @@ firrtl.module @Top07(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 // The rule 8 > x should always be true if x only has 3 bits
 firrtl.module @Top08(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c8_ui = firrtl.constant 8 : !firrtl.uint
-  %0 = firrtl.gt %c8_ui, %x : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %0 = firrtl.gt %c8_ui, %x : !firrtl.uint, !firrtl.uint<3>
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top08
@@ -101,7 +101,7 @@ firrtl.module @Top08(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 // The rule 7 >= x should always be true if x only has 3 bits
 firrtl.module @Top09(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c7_ui = firrtl.constant 7 : !firrtl.uint
-  %0 = firrtl.geq %c7_ui, %x : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %0 = firrtl.geq %c7_ui, %x : !firrtl.uint, !firrtl.uint<3>
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top09
@@ -112,7 +112,7 @@ firrtl.module @Top09(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 // The rule 10 == 10 should always be true
 firrtl.module @Top10(out %y: !firrtl.uint<1>) {
   %c10_ui = firrtl.constant 10 : !firrtl.uint
-  %0 = firrtl.eq %c10_ui, %c10_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.eq %c10_ui, %c10_ui : !firrtl.uint, !firrtl.uint
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top10
@@ -122,7 +122,7 @@ firrtl.module @Top10(out %y: !firrtl.uint<1>) {
 
 // The rule x == z should not be true even if they have the same number of bits
 firrtl.module @Top11(in %x: !firrtl.uint<3>, in %z: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
-  %0 = firrtl.eq %x, %z : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %0 = firrtl.eq %x, %z : !firrtl.uint<3>, !firrtl.uint<3>
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top11
@@ -133,7 +133,7 @@ firrtl.module @Top11(in %x: !firrtl.uint<3>, in %z: !firrtl.uint<3>, out %y: !fi
 // The rule 10 != 10 should always be false
 firrtl.module @Top12(out %y: !firrtl.uint<1>) {
   %c10_ui = firrtl.constant 10 : !firrtl.uint
-  %0 = firrtl.neq %c10_ui, %c10_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.neq %c10_ui, %c10_ui : !firrtl.uint, !firrtl.uint
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top12
@@ -145,7 +145,7 @@ firrtl.module @Top12(out %y: !firrtl.uint<1>) {
 firrtl.module @Top13(out %y: !firrtl.uint<1>) {
   %c1_ui = firrtl.constant 1 : !firrtl.uint
   %c3_ui = firrtl.constant 3 : !firrtl.uint
-  %0 = firrtl.geq %c1_ui, %c3_ui : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.geq %c1_ui, %c3_ui : !firrtl.uint, !firrtl.uint
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top13
@@ -156,7 +156,7 @@ firrtl.module @Top13(out %y: !firrtl.uint<1>) {
 // The rule x >= 8 should never be true if x only has 3 bits
 firrtl.module @Top14(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c8_ui = firrtl.constant 8 : !firrtl.uint
-  %0 = firrtl.geq %x, %c8_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.geq %x, %c8_ui : !firrtl.uint<3>, !firrtl.uint
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top14
@@ -167,7 +167,7 @@ firrtl.module @Top14(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 // The rule x > 7 should never be true if x only has 3 bits
 firrtl.module @Top15(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c7_ui = firrtl.constant 7 : !firrtl.uint
-  %0 = firrtl.gt %x, %c7_ui : (!firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint<1>
+  %0 = firrtl.gt %x, %c7_ui : !firrtl.uint<3>, !firrtl.uint
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top15
@@ -178,7 +178,7 @@ firrtl.module @Top15(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 // The rule 8 <= x should never be true if x only has 3 bits
 firrtl.module @Top16(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c8_ui = firrtl.constant 8 : !firrtl.uint
-  %0 = firrtl.leq %c8_ui, %x : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %0 = firrtl.leq %c8_ui, %x : !firrtl.uint, !firrtl.uint<3>
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top16
@@ -189,7 +189,7 @@ firrtl.module @Top16(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
 // The rule 7 < x should never be true if x only has 3 bits
 firrtl.module @Top17(in %x: !firrtl.uint<3>, out %y: !firrtl.uint<1>) {
   %c7_ui = firrtl.constant 7 : !firrtl.uint
-  %0 = firrtl.lt %c7_ui, %x : (!firrtl.uint, !firrtl.uint<3>) -> !firrtl.uint<1>
+  %0 = firrtl.lt %c7_ui, %x : !firrtl.uint, !firrtl.uint<3>
   firrtl.connect %y, %0 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 // CHECK-LABEL: firrtl.module @Top17

--- a/test/Dialect/FIRRTL/const.mlir
+++ b/test/Dialect/FIRRTL/const.mlir
@@ -169,57 +169,51 @@ firrtl.module @ConstRefBundleSub(in %a: !firrtl.const.bundle<a: uint<1>, b: sint
 
 // Primitive ops with all 'const' operands infer a 'const' result type.
 firrtl.module @PrimOpConstOperandsConstResult(in %a: !firrtl.const.uint<4>, in %b: !firrtl.const.uint<4>) {
-  %0 = firrtl.and %a, %b : (!firrtl.const.uint<4>, !firrtl.const.uint<4>) -> !firrtl.const.uint<4>
+  %0 = firrtl.and %a, %b : !firrtl.const.uint<4>, !firrtl.const.uint<4>
 }
 
 // Primitive ops with mixed 'const' operands infer a non-'const' result type.
 firrtl.module @PrimOpMixedConstOperandsNonConstResult(in %a: !firrtl.const.uint<4>, in %b: !firrtl.uint<4>) {
-  %0 = firrtl.and %a, %b : (!firrtl.const.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %0 = firrtl.and %a, %b : !firrtl.const.uint<4>, !firrtl.uint<4>
 }
 
 // Elementwise ops with 'const' operands infer 'const' result types, with 'const' propogating to the outer type when
 // both operand outer types are 'const'.
 firrtl.module @ElementwiseConstOperandsConstResult(in %a: !firrtl.const.vector<uint<1>, 2>, 
                                                    in %b: !firrtl.vector<const.uint<1>, 2>) {
-  %0 = firrtl.elementwise_or %a, %a : (!firrtl.const.vector<uint<1>, 2>, 
-                                       !firrtl.const.vector<uint<1>, 2>) 
-                                        -> !firrtl.const.vector<const.uint<1>, 2>
+  %0 = firrtl.elementwise_or %a, %a : !firrtl.const.vector<uint<1>, 2>,
+                                      !firrtl.const.vector<uint<1>, 2>
 
-  %1 = firrtl.elementwise_and %b, %b : (!firrtl.vector<const.uint<1>, 2>, 
-                                        !firrtl.vector<const.uint<1>, 2>) 
-                                         -> !firrtl.vector<const.uint<1>, 2>
+  %1 = firrtl.elementwise_and %b, %b : !firrtl.vector<const.uint<1>, 2>,
+                                       !firrtl.vector<const.uint<1>, 2>
 
-  %2 = firrtl.elementwise_xor %a, %b : (!firrtl.const.vector<uint<1>, 2>, 
-                                        !firrtl.vector<const.uint<1>, 2>) 
-                                         -> !firrtl.vector<const.uint<1>, 2>
+  %2 = firrtl.elementwise_xor %a, %b : !firrtl.const.vector<uint<1>, 2>,
+                                       !firrtl.vector<const.uint<1>, 2>
 }
 
 // Elementwise ops with mixed 'const' operands infer a non-'const' result type.
 firrtl.module @ElementwiseMixedConstOperandsNonConstResult(in %a: !firrtl.const.vector<uint<1>, 2>, 
                                                            in %b: !firrtl.vector<uint<1>, 2>) {
-  %0 = firrtl.elementwise_or %a, %b : (!firrtl.const.vector<uint<1>, 2>, 
-                                       !firrtl.vector<uint<1>, 2>) 
-                                        -> !firrtl.vector<uint<1>, 2>
+  %0 = firrtl.elementwise_or %a, %b : !firrtl.const.vector<uint<1>, 2>,
+                                      !firrtl.vector<uint<1>, 2>
 }
 
 // Mux result is const when all inputs are const.
 firrtl.module @MuxConstConditionConstBundlesConstResult(in %p: !firrtl.const.uint<1>, 
                                                         in %a: !firrtl.const.bundle<a: uint<1>>, 
                                                         in %b: !firrtl.const.bundle<a: uint<1>>) {
-  %0 = firrtl.mux(%p, %a, %b) : (!firrtl.const.uint<1>, 
-                                 !firrtl.const.bundle<a: uint<1>>, 
-                                 !firrtl.const.bundle<a: uint<1>>) 
-                                  -> !firrtl.const.bundle<a: uint<1>>
+  %0 = firrtl.mux(%p, %a, %b) : !firrtl.const.uint<1>,
+                                !firrtl.const.bundle<a: uint<1>>,
+                                !firrtl.const.bundle<a: uint<1>>
 }
 
 // Mux result in non-const when the condition is not const.
 firrtl.module @MuxNonConstConditionConstBundlesNonConstResult(in %p: !firrtl.uint<1>, 
                                                               in %a: !firrtl.const.bundle<a: const.uint<1>>, 
                                                               in %b: !firrtl.const.bundle<a: const.uint<1>>) {
-  %0 = firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, 
-                                 !firrtl.const.bundle<a: const.uint<1>>, 
-                                 !firrtl.const.bundle<a: const.uint<1>>) 
-                                  -> !firrtl.bundle<a: uint<1>>
+  %0 = firrtl.mux(%p, %a, %b) : !firrtl.uint<1>,
+                                !firrtl.const.bundle<a: const.uint<1>>,
+                                !firrtl.const.bundle<a: const.uint<1>>
 }
 
 // Mux result takes on the commonly const elements of a bundle when the condition is const.
@@ -227,30 +221,27 @@ firrtl.module @MuxConstConditionMixedConstElementBundlesConstElementResult(
     in %p: !firrtl.const.uint<1>, 
     in %a: !firrtl.const.bundle<a: uint<1>>, 
     in %b: !firrtl.bundle<a: const.uint<1>>) {
-  %0 = firrtl.mux(%p, %a, %b) : (!firrtl.const.uint<1>, 
-                                 !firrtl.const.bundle<a: uint<1>>, 
-                                 !firrtl.bundle<a: const.uint<1>>) 
-                                  -> !firrtl.bundle<a: const.uint<1>>
+  %0 = firrtl.mux(%p, %a, %b) : !firrtl.const.uint<1>,
+                                !firrtl.const.bundle<a: uint<1>>,
+                                !firrtl.bundle<a: const.uint<1>>
 }
 
 // Mux result is const when all inputs are const.
 firrtl.module @MuxConstConditionConstVectorsConstResult(in %p: !firrtl.const.uint<1>, 
                                                         in %a: !firrtl.const.vector<uint<1>, 2>, 
                                                         in %b: !firrtl.const.vector<uint<1>, 2>) {
-  %0 = firrtl.mux(%p, %a, %b) : (!firrtl.const.uint<1>, 
-                                 !firrtl.const.vector<uint<1>, 2>, 
-                                 !firrtl.const.vector<uint<1>, 2>) 
-                                  -> !firrtl.const.vector<uint<1>, 2>
+  %0 = firrtl.mux(%p, %a, %b) : !firrtl.const.uint<1>,
+                                !firrtl.const.vector<uint<1>, 2>,
+                                !firrtl.const.vector<uint<1>, 2>
 }
 
 // Mux result in non-const when the condition is not const.
 firrtl.module @MuxNonConstConditionConstVectorsNonConstResult(in %p: !firrtl.uint<1>, 
                                                               in %a: !firrtl.const.vector<const.uint<1>, 2>, 
                                                               in %b: !firrtl.const.vector<const.uint<1>, 2>) {
-  %0 = firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, 
-                                 !firrtl.const.vector<const.uint<1>, 2>, 
-                                 !firrtl.const.vector<const.uint<1>, 2>) 
-                                  -> !firrtl.vector<uint<1>, 2>
+  %0 = firrtl.mux(%p, %a, %b) : !firrtl.uint<1>,
+                                !firrtl.const.vector<const.uint<1>, 2>,
+                                !firrtl.const.vector<const.uint<1>, 2>
 }
 
 // Mux result takes on the commonly const elements of a vector when the condition is const.
@@ -258,10 +249,9 @@ firrtl.module @MuxConstConditionMixedConstElementVectorsConstElementResult(
     in %p: !firrtl.const.uint<1>, 
     in %a: !firrtl.const.vector<uint<1>, 2>, 
     in %b: !firrtl.vector<const.uint<1>, 2>) {
-  %0 = firrtl.mux(%p, %a, %b) : (!firrtl.const.uint<1>, 
-                                 !firrtl.const.vector<uint<1>, 2>, 
-                                 !firrtl.vector<const.uint<1>, 2>) 
-                                  -> !firrtl.vector<const.uint<1>, 2>
+  %0 = firrtl.mux(%p, %a, %b) : !firrtl.const.uint<1>,
+                                !firrtl.const.vector<uint<1>, 2>,
+                                !firrtl.vector<const.uint<1>, 2>
 }
 
 firrtl.module @NonConstBundleCreateConstOperands(in %a: !firrtl.const.uint<1>) {

--- a/test/Dialect/FIRRTL/cse.mlir
+++ b/test/Dialect/FIRRTL/cse.mlir
@@ -9,12 +9,12 @@ firrtl.module @And(in %in1: !firrtl.uint<4>, in %in2: !firrtl.uint<4>,
   // And operations should get CSE'd.
 
   // CHECK: %0 = firrtl.and %in1, %in2
-  %0 = firrtl.and %in1, %in2 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %0 = firrtl.and %in1, %in2 : !firrtl.uint<4>, !firrtl.uint<4>
   // CHECK-NEXT: firrtl.connect %out1, %0
   firrtl.connect %out1, %0 : !firrtl.uint<4>, !firrtl.uint<4>
 
   // CHECK-NEXT: firrtl.connect %out2, %0
-  %1 = firrtl.and %in1, %in2 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %1 = firrtl.and %in1, %in2 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out2, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 
@@ -38,7 +38,7 @@ firrtl.module @Invalid(in %cond: !firrtl.uint<1>,
   %invalid1_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
   // CHECK-NEXT: invalid_ui4_0
   %invalid2_ui4 = firrtl.invalidvalue : !firrtl.uint<4>
-  %7 = firrtl.mux (%cond, %invalid1_ui4, %invalid2_ui4) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %7 = firrtl.mux (%cond, %invalid1_ui4, %invalid2_ui4) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out, %7 : !firrtl.uint<4>, !firrtl.uint<4>
 
 }

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -44,7 +44,7 @@ firrtl.circuit "PrimOps" {
     %a_a = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>
     %a_b = firrtl.subfield %a[b] : !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>
     %a_c = firrtl.subfield %a[c] : !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>
-    %0 = firrtl.xor %a_a, %a_b: (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+    %0 = firrtl.xor %a_a, %a_b : !firrtl.uint<2>, !firrtl.uint<2>
     firrtl.connect %a_c, %a_b: !firrtl.uint<2>, !firrtl.uint<2>
   }
   // CHECK-NOT: firrtl.module private @PrimOps1
@@ -52,8 +52,8 @@ firrtl.circuit "PrimOps" {
     %b_a = firrtl.subfield %b[a] : !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>
     %b_b = firrtl.subfield %b[b] : !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>
     %b_c = firrtl.subfield %b[c] : !firrtl.bundle<a: uint<2>, b: uint<2>, c flip: uint<2>>
-    %0 = firrtl.xor %b_a, %b_b: (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-    firrtl.connect %b_c, %b_b: !firrtl.uint<2>, !firrtl.uint<2>
+    %0 = firrtl.xor %b_a, %b_b : !firrtl.uint<2>, !firrtl.uint<2>
+    firrtl.connect %b_c, %b_b : !firrtl.uint<2>, !firrtl.uint<2>
   }
   firrtl.module @PrimOps() {
     // CHECK: firrtl.instance primops0 @PrimOps0
@@ -539,7 +539,7 @@ firrtl.circuit "MuxBundle" {
 
     // CHECK: %2 = firrtl.mux(%p, [[WIRE]], %l)
     // CHECK: firrtl.matchingconnect %o, %2 : !firrtl.bundle<b: uint<1>>
-    %0 = firrtl.mux(%p, %bar1_o, %l) : (!firrtl.uint<1>, !firrtl.bundle<b: uint<1>>, !firrtl.bundle<b: uint<1>>) -> !firrtl.bundle<b: uint<1>>
+    %0 = firrtl.mux(%p, %bar1_o, %l) : !firrtl.uint<1>, !firrtl.bundle<b: uint<1>>, !firrtl.bundle<b: uint<1>>
     firrtl.matchingconnect %o, %0 : !firrtl.bundle<b: uint<1>>
   }
 }

--- a/test/Dialect/FIRRTL/eliminate-wires.mlir
+++ b/test/Dialect/FIRRTL/eliminate-wires.mlir
@@ -8,7 +8,7 @@ firrtl.circuit "TopLevel" {
     // CHECK-NOT: firrtl.wire
     %w = firrtl.wire : !firrtl.uint<1>
     firrtl.matchingconnect %w, %source : !firrtl.uint<1>
-    %wn = firrtl.not %w : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %wn = firrtl.not %w : !firrtl.uint<1>
     %x = firrtl.wire : !firrtl.uint<1>
     firrtl.matchingconnect %x, %wn : !firrtl.uint<1>
     firrtl.matchingconnect %sink, %x : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -209,24 +209,24 @@ firrtl.circuit "Foo" {
     // CHECK: node dShlPrimOp = dshl(x, y)
     // CHECK: node dShlwPrimOp = dshlw(x, y)
     // CHECK: node dShrPrimOp = dshr(x, y)
-    %addPrimOp_tmp = firrtl.add %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %subPrimOp_tmp = firrtl.sub %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %mulPrimOp_tmp = firrtl.mul %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %divPrimOp_tmp = firrtl.div %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %remPrimOp_tmp = firrtl.rem %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %andPrimOp_tmp = firrtl.and %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %orPrimOp_tmp = firrtl.or %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %xorPrimOp_tmp = firrtl.xor %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %leqPrimOp_tmp = firrtl.leq %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-    %ltPrimOp_tmp = firrtl.lt %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-    %geqPrimOp_tmp = firrtl.geq %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-    %gtPrimOp_tmp = firrtl.gt %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-    %eqPrimOp_tmp = firrtl.eq %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-    %neqPrimOp_tmp = firrtl.neq %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint<1>
-    %catPrimOp_tmp = firrtl.cat %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %dShlPrimOp_tmp = firrtl.dshl %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %dShlwPrimOp_tmp = firrtl.dshlw %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %dShrPrimOp_tmp = firrtl.dshr %x, %y : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %addPrimOp_tmp = firrtl.add %x, %y : !firrtl.uint, !firrtl.uint
+    %subPrimOp_tmp = firrtl.sub %x, %y : !firrtl.uint, !firrtl.uint
+    %mulPrimOp_tmp = firrtl.mul %x, %y : !firrtl.uint, !firrtl.uint
+    %divPrimOp_tmp = firrtl.div %x, %y : !firrtl.uint, !firrtl.uint
+    %remPrimOp_tmp = firrtl.rem %x, %y : !firrtl.uint, !firrtl.uint
+    %andPrimOp_tmp = firrtl.and %x, %y : !firrtl.uint, !firrtl.uint
+    %orPrimOp_tmp = firrtl.or %x, %y : !firrtl.uint, !firrtl.uint
+    %xorPrimOp_tmp = firrtl.xor %x, %y : !firrtl.uint, !firrtl.uint
+    %leqPrimOp_tmp = firrtl.leq %x, %y : !firrtl.uint, !firrtl.uint
+    %ltPrimOp_tmp = firrtl.lt %x, %y : !firrtl.uint, !firrtl.uint
+    %geqPrimOp_tmp = firrtl.geq %x, %y : !firrtl.uint, !firrtl.uint
+    %gtPrimOp_tmp = firrtl.gt %x, %y : !firrtl.uint, !firrtl.uint
+    %eqPrimOp_tmp = firrtl.eq %x, %y : !firrtl.uint, !firrtl.uint
+    %neqPrimOp_tmp = firrtl.neq %x, %y : !firrtl.uint, !firrtl.uint
+    %catPrimOp_tmp = firrtl.cat %x, %y : !firrtl.uint, !firrtl.uint
+    %dShlPrimOp_tmp = firrtl.dshl %x, %y : !firrtl.uint, !firrtl.uint
+    %dShlwPrimOp_tmp = firrtl.dshlw %x, %y : !firrtl.uint, !firrtl.uint
+    %dShrPrimOp_tmp = firrtl.dshr %x, %y : !firrtl.uint, !firrtl.uint
     %addPrimOp = firrtl.node %addPrimOp_tmp : !firrtl.uint
     %subPrimOp = firrtl.node %subPrimOp_tmp : !firrtl.uint
     %mulPrimOp = firrtl.node %mulPrimOp_tmp : !firrtl.uint
@@ -256,16 +256,16 @@ firrtl.circuit "Foo" {
     // CHECK: node andRPrimOp = andr(x)
     // CHECK: node orRPrimOp = orr(x)
     // CHECK: node xorRPrimOp = xorr(x)
-    %asSIntPrimOp_tmp = firrtl.asSInt %x : (!firrtl.uint) -> !firrtl.sint
-    %asUIntPrimOp_tmp = firrtl.asUInt %x : (!firrtl.uint) -> !firrtl.uint
-    %asAsyncResetPrimOp_tmp = firrtl.asAsyncReset %x : (!firrtl.uint) -> !firrtl.asyncreset
-    %asClockPrimOp_tmp = firrtl.asClock %x : (!firrtl.uint) -> !firrtl.clock
-    %cvtPrimOp_tmp = firrtl.cvt %x : (!firrtl.uint) -> !firrtl.sint
-    %negPrimOp_tmp = firrtl.neg %x : (!firrtl.uint) -> !firrtl.sint
-    %notPrimOp_tmp = firrtl.not %x : (!firrtl.uint) -> !firrtl.uint
-    %andRPrimOp_tmp = firrtl.andr %x : (!firrtl.uint) -> !firrtl.uint<1>
-    %orRPrimOp_tmp = firrtl.orr %x : (!firrtl.uint) -> !firrtl.uint<1>
-    %xorRPrimOp_tmp = firrtl.xorr %x : (!firrtl.uint) -> !firrtl.uint<1>
+    %asSIntPrimOp_tmp = firrtl.asSInt %x : !firrtl.uint
+    %asUIntPrimOp_tmp = firrtl.asUInt %x : !firrtl.uint
+    %asAsyncResetPrimOp_tmp = firrtl.asAsyncReset %x : !firrtl.uint
+    %asClockPrimOp_tmp = firrtl.asClock %x : !firrtl.uint
+    %cvtPrimOp_tmp = firrtl.cvt %x : !firrtl.uint
+    %negPrimOp_tmp = firrtl.neg %x : !firrtl.uint
+    %notPrimOp_tmp = firrtl.not %x : !firrtl.uint
+    %andRPrimOp_tmp = firrtl.andr %x : !firrtl.uint
+    %orRPrimOp_tmp = firrtl.orr %x : !firrtl.uint
+    %xorRPrimOp_tmp = firrtl.xorr %x : !firrtl.uint
     %asSIntPrimOp = firrtl.node %asSIntPrimOp_tmp : !firrtl.sint
     %asUIntPrimOp = firrtl.node %asUIntPrimOp_tmp : !firrtl.uint
     %asAsyncResetPrimOp = firrtl.node %asAsyncResetPrimOp_tmp : !firrtl.asyncreset
@@ -284,13 +284,13 @@ firrtl.circuit "Foo" {
     // CHECK: node muxPrimOp = mux(ui1, x, y)
     // CHECK: node shlPrimOp = shl(x, 4)
     // CHECK: node shrPrimOp = shr(x, 4)
-    %bitsPrimOp_tmp = firrtl.bits %x 4 to 2 : (!firrtl.uint) -> !firrtl.uint<3>
-    %headPrimOp_tmp = firrtl.head %x, 4 : (!firrtl.uint) -> !firrtl.uint<4>
-    %tailPrimOp_tmp = firrtl.tail %x, 4 : (!firrtl.uint) -> !firrtl.uint
-    %padPrimOp_tmp = firrtl.pad %x, 16 : (!firrtl.uint) -> !firrtl.uint
-    %muxPrimOp_tmp = firrtl.mux(%ui1, %x, %y) : (!firrtl.uint<1>, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %shlPrimOp_tmp = firrtl.shl %x, 4 : (!firrtl.uint) -> !firrtl.uint
-    %shrPrimOp_tmp = firrtl.shr %x, 4 : (!firrtl.uint) -> !firrtl.uint
+    %bitsPrimOp_tmp = firrtl.bits %x 4 to 2 : !firrtl.uint
+    %headPrimOp_tmp = firrtl.head %x, 4 : !firrtl.uint
+    %tailPrimOp_tmp = firrtl.tail %x, 4 : !firrtl.uint
+    %padPrimOp_tmp = firrtl.pad %x, 16 : !firrtl.uint
+    %muxPrimOp_tmp = firrtl.mux(%ui1, %x, %y) : !firrtl.uint<1>, !firrtl.uint, !firrtl.uint
+    %shlPrimOp_tmp = firrtl.shl %x, 4 : !firrtl.uint
+    %shrPrimOp_tmp = firrtl.shr %x, 4 : !firrtl.uint
     %bitsPrimOp = firrtl.node %bitsPrimOp_tmp : !firrtl.uint<3>
     %headPrimOp = firrtl.node %headPrimOp_tmp : !firrtl.uint<4>
     %tailPrimOp = firrtl.node %tailPrimOp_tmp : !firrtl.uint
@@ -594,14 +594,14 @@ firrtl.circuit "Foo" {
 
     firrtl.matchingconnect %11, %_0 : !firrtl.clock
     firrtl.matchingconnect %10, %_3 : !firrtl.uint<1>
-    %12 = firrtl.pad %_3, 5 : (!firrtl.uint<1>) -> !firrtl.uint<5>
+    %12 = firrtl.pad %_3, 5 : !firrtl.uint<1>
     firrtl.matchingconnect %9, %12 : !firrtl.uint<5>
     firrtl.connect %_11, %8 : !firrtl.uint, !firrtl.uint<8>
     firrtl.matchingconnect %7, %_0 : !firrtl.clock
     firrtl.matchingconnect %6, %_3 : !firrtl.uint<1>
-    %14 = firrtl.pad %_3, 8 : (!firrtl.uint<1>) -> !firrtl.uint<8>
+    %14 = firrtl.pad %_3, 8 : !firrtl.uint<1>
     firrtl.matchingconnect %5, %14 : !firrtl.uint<8>
-    %15 = firrtl.pad %_3, 5 : (!firrtl.uint<1>) -> !firrtl.uint<5>
+    %15 = firrtl.pad %_3, 5 : !firrtl.uint<1>
     firrtl.matchingconnect %4, %15 : !firrtl.uint<5>
     firrtl.matchingconnect %3, %_3 : !firrtl.uint<1>
 

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -393,9 +393,8 @@ firrtl.circuit "NoSymsSym" {
 firrtl.circuit "X" {
 
 firrtl.module @X(in %a : !firrtl.uint<4>) {
-  // expected-error @below {{failed to infer returned types}}
   // expected-error @+1 {{high must be equal or greater than low, but got high = 3, low = 4}}
-  %0 = firrtl.bits %a 3 to 4 : (!firrtl.uint<4>) -> !firrtl.uint<2>
+  %0 = firrtl.bits %a 3 to 4 : !firrtl.uint<4>
 }
 
 }
@@ -405,21 +404,8 @@ firrtl.module @X(in %a : !firrtl.uint<4>) {
 firrtl.circuit "X" {
 
 firrtl.module @X(in %a : !firrtl.uint<4>) {
-  // expected-error @below {{failed to infer returned types}}
   // expected-error @+1 {{high must be smaller than the width of input, but got high = 4, width = 4}}
-  %0 = firrtl.bits %a 4 to 3 : (!firrtl.uint<4>) -> !firrtl.uint<2>
-}
-
-}
-
-// -----
-
-firrtl.circuit "X" {
-
-firrtl.module @X(in %a : !firrtl.uint<4>) {
-  // expected-error @below {{failed to infer returned types}}
-  // expected-error @+1 {{'firrtl.bits' op inferred type(s) '!firrtl.uint<3>' are incompatible with return type(s) of operation '!firrtl.uint<2>'}}
-  %0 = firrtl.bits %a 3 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<2>
+  %0 = firrtl.bits %a 4 to 3 : !firrtl.uint<4>
 }
 
 }
@@ -430,16 +416,6 @@ firrtl.circuit "BadPort" {
   firrtl.module @BadPort(in %a : !firrtl.uint<1>) {
     // expected-error @+1 {{'firrtl.attach' op operand #0 must be variadic of analog type, but got '!firrtl.uint<1>'}}
     firrtl.attach %a, %a : !firrtl.uint<1>, !firrtl.uint<1>
-  }
-}
-
-// -----
-
-firrtl.circuit "BadAdd" {
-  firrtl.module @BadAdd(in %a : !firrtl.uint<1>) {
-    // expected-error @below {{failed to infer returned types}}
-    // expected-error @+1 {{'firrtl.add' op inferred type(s) '!firrtl.uint<2>' are incompatible with return type(s) of operation '!firrtl.uint<1>'}}
-    firrtl.add %a, %a : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   }
 }
 
@@ -478,9 +454,9 @@ firrtl.circuit "StructCast3" {
 firrtl.circuit "OutOfOrder" {
   firrtl.module @OutOfOrder(in %a: !firrtl.uint<32>) {
     // expected-error @+1 {{operand #0 does not dominate this use}}
-    %0 = firrtl.add %1, %1 : (!firrtl.uint<33>, !firrtl.uint<33>) -> !firrtl.uint<34>
+    %0 = firrtl.add %1, %1 : !firrtl.uint<33>, !firrtl.uint<33>
     // expected-note @+1 {{operand defined here}}
-    %1 = firrtl.add %a, %a : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<33>
+    %1 = firrtl.add %a, %a : !firrtl.uint<32>, !firrtl.uint<32>
   }
 }
 
@@ -1126,8 +1102,8 @@ firrtl.circuit "MuxRef" {
     %a, %b, %cond = firrtl.instance vals @MuxRefPrivate(out a: !firrtl.probe<uint<1>>,
                                                         out b: !firrtl.probe<uint<1>>,
                                                         out cond: !firrtl.uint<1>)
-    // expected-error @+1 {{'firrtl.mux' op operand #1 must be a passive base type (contain no flips), but got '!firrtl.probe<uint<1>>'}}
-    %a_or_b = firrtl.mux(%cond, %a, %b) : (!firrtl.uint<1>, !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>) -> !firrtl.probe<uint<1>>
+    // expected-error @below {{operands must be base type}}
+    %a_or_b = firrtl.mux(%cond, %a, %b) : !firrtl.uint<1>, !firrtl.probe<uint<1>>, !firrtl.probe<uint<1>>
   }
 }
 
@@ -1698,28 +1674,6 @@ firrtl.circuit "UninferredWidthCastNonConstToConst" {
     // expected-error @+1 {{operand constness must match}}
     %b = firrtl.resetCast %a : (!firrtl.reset) -> !firrtl.const.asyncreset
   }
-}
-
-// -----
-
-// Primitive ops with all 'const' operands must have a 'const' result type
-firrtl.circuit "PrimOpConstOperandsNonConstResult" {
-firrtl.module @PrimOpConstOperandsNonConstResult(in %a: !firrtl.const.uint<4>, in %b: !firrtl.const.uint<4>) {
-  // expected-error @below {{failed to infer returned types}}
-  // expected-error @+1 {{'firrtl.and' op inferred type(s) '!firrtl.const.uint<4>' are incompatible with return type(s) of operation '!firrtl.uint<4>'}}
-  %0 = firrtl.and %a, %b : (!firrtl.const.uint<4>, !firrtl.const.uint<4>) -> !firrtl.uint<4>
-}
-}
-
-// -----
-
-// Primitive ops with mixed 'const' operands must have a non-'const' result type
-firrtl.circuit "PrimOpMixedConstOperandsConstResult" {
-firrtl.module @PrimOpMixedConstOperandsConstResult(in %a: !firrtl.const.uint<4>, in %b: !firrtl.uint<4>) {
-  // expected-error @below {{failed to infer returned types}}
-  // expected-error @+1 {{'firrtl.and' op inferred type(s) '!firrtl.uint<4>' are incompatible with return type(s) of operation '!firrtl.const.uint<4>'}}
-  %0 = firrtl.and %a, %b : (!firrtl.const.uint<4>, !firrtl.uint<4>) -> !firrtl.const.uint<4>
-}
 }
 
 // -----

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -53,30 +53,30 @@ firrtl.module @simulation(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, in
   }
 }
 // CHECK-LABEL: firrtl.module @simulation(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, in %enable: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
-// CHECK-NEXT:   %0 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %0 = firrtl.and %p, %enable : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.printf %clock, %0, "CIRCT Rocks!"  : !firrtl.clock, !firrtl.uint<1>
-// CHECK-NEXT:   %1 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %1 = firrtl.and %p, %enable : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.stop %clock, %1, 0 : !firrtl.clock, !firrtl.uint<1>
-// CHECK-NEXT:   %2 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %2 = firrtl.and %p, %enable : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.assert %clock, %p, %2, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>  {eventControl = 0 : i32, isConcurrent = false}
-// CHECK-NEXT:   %3 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %3 = firrtl.and %p, %enable : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.assume %clock, %p, %3, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>  {eventControl = 0 : i32, isConcurrent = false}
-// CHECK-NEXT:   %4 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %4 = firrtl.and %p, %enable : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.cover %clock, %p, %4, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>  {eventControl = 0 : i32, isConcurrent = false}
-// CHECK-NEXT:   %5 = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %5 = firrtl.and %p, %enable : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.int.unclocked_assume %p, %5, "" : !firrtl.uint<1>, !firrtl.uint<1>
-// CHECK-NEXT:   %6 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %7 = firrtl.and %6, %reset : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %6 = firrtl.not %p : !firrtl.uint<1>
+// CHECK-NEXT:   %7 = firrtl.and %6, %reset : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.printf %clock, %7, "CIRCT Rocks!"  : !firrtl.clock, !firrtl.uint<1>
-// CHECK-NEXT:   %8 = firrtl.and %6, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %8 = firrtl.and %6, %enable : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.stop %clock, %8, 1 : !firrtl.clock, !firrtl.uint<1>
-// CHECK-NEXT:   %9 = firrtl.and %6, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %9 = firrtl.and %6, %enable : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.assert %clock, %p, %9, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>  {eventControl = 0 : i32, isConcurrent = false}
-// CHECK-NEXT:   %10 = firrtl.and %6, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %10 = firrtl.and %6, %enable : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.assume %clock, %p, %10, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>  {eventControl = 0 : i32, isConcurrent = false}
-// CHECK-NEXT:   %11 = firrtl.and %6, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %11 = firrtl.and %6, %enable : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.cover %clock, %p, %11, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>  {eventControl = 0 : i32, isConcurrent = false}
-// CHECK-NEXT:   %12 = firrtl.and %6, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %12 = firrtl.and %6, %enable : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.int.unclocked_assume %p, %12, "" : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   }
 
@@ -90,8 +90,8 @@ firrtl.module @nested_whens(in %clock : !firrtl.clock, in %p0 : !firrtl.uint<1>,
   }
 }
 // CHECK-LABEL: firrtl.module @nested_whens(in %clock: !firrtl.clock, in %p0: !firrtl.uint<1>, in %p1: !firrtl.uint<1>, in %enable: !firrtl.uint<1>, in %reset: !firrtl.uint<1>) {
-// CHECK-NEXT:   %0 = firrtl.and %p0, %p1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %1 = firrtl.and %0, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %0 = firrtl.and %p0, %p1 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK-NEXT:   %1 = firrtl.and %0, %enable : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.printf %clock, %1, "CIRCT Rocks!" : !firrtl.clock, !firrtl.uint<1>
 // CHECK-NEXT: }
 
@@ -109,9 +109,9 @@ firrtl.module @set_in_both(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, o
 }
 // CHECK-LABEL: firrtl.module @set_in_both(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
-// CHECK-NEXT:   %0 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %0 = firrtl.not %p : !firrtl.uint<1>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-// CHECK-NEXT:   %1 = firrtl.mux(%p, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+// CHECK-NEXT:   %1 = firrtl.mux(%p, %c0_ui2, %c1_ui2) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT:   firrtl.connect %out, %1 : !firrtl.uint<2>
 // CHECK-NEXT: }
 
@@ -133,8 +133,8 @@ firrtl.module @set_before_and_in_both(in %clock : !firrtl.clock, in %p : !firrtl
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
 // CHECK-NEXT:   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
-// CHECK-NEXT:   %0 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %1 = firrtl.mux(%p, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+// CHECK-NEXT:   %0 = firrtl.not %p : !firrtl.uint<1>
+// CHECK-NEXT:   %1 = firrtl.mux(%p, %c0_ui2, %c1_ui2) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT:   firrtl.connect %out, %1 : !firrtl.uint<2>
 // CHECK-NEXT: }
 
@@ -155,8 +155,8 @@ firrtl.module @set_after(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, out
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
 // CHECK-NEXT:   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
-// CHECK-NEXT:   %0 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %1 = firrtl.mux(%p, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+// CHECK-NEXT:   %0 = firrtl.not %p : !firrtl.uint<1>
+// CHECK-NEXT:   %1 = firrtl.mux(%p, %c0_ui2, %c1_ui2) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT:   firrtl.connect %out, %c2_ui2 : !firrtl.uint<2>
 // CHECK-NEXT: }
 
@@ -173,7 +173,7 @@ firrtl.module @set_in_then0(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, 
 // CHECK-LABEL: firrtl.module @set_in_then0(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-// CHECK-NEXT:   %0 = firrtl.mux(%p, %c1_ui2, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+// CHECK-NEXT:   %0 = firrtl.mux(%p, %c1_ui2, %c0_ui2) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT:   firrtl.connect %out, %0 : !firrtl.uint<2>
 // CHECK-NEXT: }
 
@@ -207,8 +207,8 @@ firrtl.module @set_in_else0(in %p : !firrtl.uint<1>, out %out : !firrtl.uint<2>)
 // CHECK-LABEL: firrtl.module @set_in_else0(in %p: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-// CHECK-NEXT:   %0 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %1 = firrtl.mux(%p, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+// CHECK-NEXT:   %0 = firrtl.not %p : !firrtl.uint<1>
+// CHECK-NEXT:   %1 = firrtl.mux(%p, %c0_ui2, %c1_ui2) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT:   firrtl.connect %out, %1 : !firrtl.uint<2>
 // CHECK-NEXT: }
 
@@ -222,7 +222,7 @@ firrtl.module @check_mux_return_type(in %p : !firrtl.uint<1>, out %out : !firrtl
   } else {
     firrtl.connect %out, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
-  // CHECK: firrtl.mux(%p, %c0_ui1, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<2>
+  // CHECK: firrtl.mux(%p, %c0_ui1, %c1_ui2) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<2>
 }
 
 // Test that wire written to in only the else block is resolved.
@@ -238,7 +238,7 @@ firrtl.module @set_in_else1(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, 
 // CHECK-LABEL: firrtl.module @set_in_else1(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, out %out: !firrtl.uint<2>) {
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-// CHECK-NEXT:   %0 = firrtl.not %p : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   %0 = firrtl.not %p : !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.connect %out, %c0_ui2 : !firrtl.uint<2>
 // CHECK-NEXT: }
 
@@ -259,9 +259,9 @@ firrtl.module @nested(in %clock : !firrtl.clock, in %p0 : !firrtl.uint<1>, in %p
 // CHECK-NEXT:   %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
 // CHECK-NEXT:   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
 // CHECK-NEXT:   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
-// CHECK-NEXT:   %0 = firrtl.and %p0, %p1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-// CHECK-NEXT:   %1 = firrtl.mux(%p1, %c1_ui2, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-// CHECK-NEXT:   %2 = firrtl.mux(%p0, %1, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+// CHECK-NEXT:   %0 = firrtl.and %p0, %p1 : !firrtl.uint<1>, !firrtl.uint<1>
+// CHECK-NEXT:   %1 = firrtl.mux(%p1, %c1_ui2, %c0_ui2) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+// CHECK-NEXT:   %2 = firrtl.mux(%p0, %1, %c0_ui2) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
 // CHECK-NEXT:   firrtl.connect %out, %2 : !firrtl.uint<2>
 // CHECK-NEXT: }
 
@@ -292,16 +292,16 @@ firrtl.module @nested2(in %clock : !firrtl.clock, in %p0 : !firrtl.uint<1>, in %
 //CHECK-NEXT:   %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
 //CHECK-NEXT:   %c2_ui2 = firrtl.constant 2 : !firrtl.uint<2>
 //CHECK-NEXT:   %c3_ui2 = firrtl.constant 3 : !firrtl.uint<2>
-//CHECK-NEXT:   %0 = firrtl.and %p0, %p1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-//CHECK-NEXT:   %1 = firrtl.not %p1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-//CHECK-NEXT:   %2 = firrtl.and %p0, %1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-//CHECK-NEXT:   %3 = firrtl.mux(%p1, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-//CHECK-NEXT:   %4 = firrtl.not %p0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-//CHECK-NEXT:   %5 = firrtl.and %4, %p1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-//CHECK-NEXT:   %6 = firrtl.not %p1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-//CHECK-NEXT:   %7 = firrtl.and %4, %6 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-//CHECK-NEXT:   %8 = firrtl.mux(%p1, %c2_ui2, %c3_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
-//CHECK-NEXT:   %9 = firrtl.mux(%p0, %3, %8) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+//CHECK-NEXT:   %0 = firrtl.and %p0, %p1 : !firrtl.uint<1>, !firrtl.uint<1>
+//CHECK-NEXT:   %1 = firrtl.not %p1 : !firrtl.uint<1>
+//CHECK-NEXT:   %2 = firrtl.and %p0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
+//CHECK-NEXT:   %3 = firrtl.mux(%p1, %c0_ui2, %c1_ui2) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+//CHECK-NEXT:   %4 = firrtl.not %p0 : !firrtl.uint<1>
+//CHECK-NEXT:   %5 = firrtl.and %4, %p1 : !firrtl.uint<1>, !firrtl.uint<1>
+//CHECK-NEXT:   %6 = firrtl.not %p1 : !firrtl.uint<1>
+//CHECK-NEXT:   %7 = firrtl.and %4, %6 : !firrtl.uint<1>, !firrtl.uint<1>
+//CHECK-NEXT:   %8 = firrtl.mux(%p1, %c2_ui2, %c3_ui2) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
+//CHECK-NEXT:   %9 = firrtl.mux(%p0, %3, %8) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
 //CHECK-NEXT:   firrtl.connect %out, %9 : !firrtl.uint<2>
 //CHECK-NEXT: }
 
@@ -444,7 +444,7 @@ firrtl.module @as_passive(in %p : !firrtl.uint<1>) {
   } else {
     firrtl.connect %simple1_in, %c3_ui3 : !firrtl.uint<3>, !firrtl.uint<3>
   }
-  // CHECK: [[MUX:%.*]] = firrtl.mux(%p, %test0_in, %c3_ui3) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
+  // CHECK: [[MUX:%.*]] = firrtl.mux(%p, %test0_in, %c3_ui3) : !firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>
   // CHECK: firrtl.connect %test0_in_0, [[MUX]] : !firrtl.uint<3>
 }
 
@@ -501,9 +501,9 @@ firrtl.module @multi_dim_vector(in %p : !firrtl.uint<1>) {
     firrtl.connect %1, %c1_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
     firrtl.connect %2, %c0_ui2 : !firrtl.uint<2>, !firrtl.uint<2>
   }
-  // CHECK:      [[MUX1:%.*]] = firrtl.mux(%p, %c0_ui2, %c1_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+  // CHECK:      [[MUX1:%.*]] = firrtl.mux(%p, %c0_ui2, %c1_ui2) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
   // CHECK-NEXT: firrtl.connect %1, [[MUX1]] : !firrtl.uint<2>
-  // CHECK-NEXT: [[MUX2:%.*]] = firrtl.mux(%p, %c1_ui2, %c0_ui2) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<2>
+  // CHECK-NEXT: [[MUX2:%.*]] = firrtl.mux(%p, %c1_ui2, %c0_ui2) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<2>
   // CHECK-NEXT: firrtl.connect %2, [[MUX2]] : !firrtl.uint<2>
 }
 

--- a/test/Dialect/FIRRTL/extract-instances.mlir
+++ b/test/Dialect/FIRRTL/extract-instances.mlir
@@ -332,9 +332,9 @@ firrtl.circuit "ExtractClockGatesSimple" attributes {annotations = [{class = "si
 firrtl.circuit "ExtractClockGatesTestHarnessOnly" attributes {annotations = [{class = "sifive.enterprise.firrtl.ExtractClockGatesFileAnnotation", filename = "ClockGates.txt"}]} {
   firrtl.extmodule private @EICG_wrapper(in in: !firrtl.clock, in en: !firrtl.uint<1>, out out: !firrtl.clock) attributes {defname = "EICG_wrapper"}
   firrtl.module private @DUTModule(in %clock: !firrtl.clock, in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>, in %en: !firrtl.uint<1>) attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {
-    %0 = firrtl.add %in, %en : (!firrtl.uint<8>, !firrtl.uint<1>) -> !firrtl.uint<9>
+    %0 = firrtl.add %in, %en : !firrtl.uint<8>, !firrtl.uint<1>
     %_io_out_T = firrtl.node %0 : !firrtl.uint<9>
-    %1 = firrtl.tail %_io_out_T, 1 : (!firrtl.uint<9>) -> !firrtl.uint<8>
+    %1 = firrtl.tail %_io_out_T, 1 : !firrtl.uint<9>
     %_io_out_T_1 = firrtl.node %1 : !firrtl.uint<8>
     firrtl.connect %out, %_io_out_T_1 : !firrtl.uint<8>, !firrtl.uint<8>
   }

--- a/test/Dialect/FIRRTL/flatten-memory.mlir
+++ b/test/Dialect/FIRRTL/flatten-memory.mlir
@@ -105,15 +105,15 @@ firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>
   // CHECK:  %[[v14:.+]] = firrtl.subfield %[[memory_rw_0]][wmask] :
   // CHECK:  %[[v15:.+]] = firrtl.subfield %memory_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<17>, wmode: uint<1>, wdata: uint<17>, wmask: uint<17>>
   // CHECK:  %[[v16:.+]] = firrtl.bitcast %14 : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<2>
-  // CHECK:  %[[v17:.+]] = firrtl.bits %16 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-  // CHECK:  %[[v18:.+]] = firrtl.cat %[[v17]], %[[v17]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-  // CHECK:  %[[v19:.+]] = firrtl.cat %[[v17]], %[[v18]] : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<3>
-  // CHECK:  %[[v24:.+]] = firrtl.cat %[[v17]], %[[v23:.+]] : (!firrtl.uint<1>, !firrtl.uint<7>) -> !firrtl.uint<8>
-  // CHECK:  %[[v25:.+]] = firrtl.bits %16 1 to 1 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-  // CHECK:  %[[v26:.+]] = firrtl.cat %[[v25]], %[[v24]] : (!firrtl.uint<1>, !firrtl.uint<8>) -> !firrtl.uint<9>
-  // CHECK:  %[[v27:.+]] = firrtl.cat %[[v25]], %[[v26]] : (!firrtl.uint<1>, !firrtl.uint<9>) -> !firrtl.uint<10>
-  // CHECK:  %[[v28:.+]] = firrtl.cat %[[v25]], %[[v27]] : (!firrtl.uint<1>, !firrtl.uint<10>) -> !firrtl.uint<11>
-  // CHECK:  %[[v34:.+]] = firrtl.cat %[[v25]], %[[v33:.+]] : (!firrtl.uint<1>, !firrtl.uint<16>) -> !firrtl.uint<17>
+  // CHECK:  %[[v17:.+]] = firrtl.bits %16 0 to 0 : !firrtl.uint<2>
+  // CHECK:  %[[v18:.+]] = firrtl.cat %[[v17]], %[[v17]] : !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK:  %[[v19:.+]] = firrtl.cat %[[v17]], %[[v18]] : !firrtl.uint<1>, !firrtl.uint<2>
+  // CHECK:  %[[v24:.+]] = firrtl.cat %[[v17]], %[[v23:.+]] : !firrtl.uint<1>, !firrtl.uint<7>
+  // CHECK:  %[[v25:.+]] = firrtl.bits %16 1 to 1 : !firrtl.uint<2>
+  // CHECK:  %[[v26:.+]] = firrtl.cat %[[v25]], %[[v24]] : !firrtl.uint<1>, !firrtl.uint<8>
+  // CHECK:  %[[v27:.+]] = firrtl.cat %[[v25]], %[[v26]] : !firrtl.uint<1>, !firrtl.uint<9>
+  // CHECK:  %[[v28:.+]] = firrtl.cat %[[v25]], %[[v27]] : !firrtl.uint<1>, !firrtl.uint<10>
+  // CHECK:  %[[v34:.+]] = firrtl.cat %[[v25]], %[[v33:.+]] : !firrtl.uint<1>, !firrtl.uint<16>
   // CHECK:  firrtl.matchingconnect %[[v15]], %[[v34]] :
   // Ensure 0 bit fields are handled properly.
   %ram_MPORT = firrtl.mem Undefined  {depth = 4 : i64, name = "ram", portNames = ["MPORT"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: bundle<entry: bundle<a: uint<0>, b: uint<1>, c: uint<2>>>, mask: bundle<entry: bundle<a: uint<1>, b: uint<1>, c: uint<1>>>>
@@ -139,8 +139,8 @@ firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>
     // CHECK:  %[[v9:.+]] = firrtl.subfield %ram_MPORT_1[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  %[[v10:.+]] = firrtl.subfield %ram_MPORT[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<20>, mask: uint<1>>
     // CHECK:  %[[v11:.+]] = firrtl.bitcast %9 : (!firrtl.bundle<a: uint<1>, b: uint<1>>) -> !firrtl.uint<2>
-    // CHECK:  %[[v12:.+]] = firrtl.bits %11 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-    // CHECK:  %[[v13:.+]] = firrtl.bits %11 1 to 1 : (!firrtl.uint<2>) -> !firrtl.uint<1>
+    // CHECK:  %[[v12:.+]] = firrtl.bits %11 0 to 0 : !firrtl.uint<2>
+    // CHECK:  %[[v13:.+]] = firrtl.bits %11 1 to 1 : !firrtl.uint<2>
     // CHECK:  firrtl.matchingconnect %[[v10]], %[[v13]] : !firrtl.uint<1>
     // CHECK:  %[[v14:.+]] = firrtl.subfield %ram_MPORT_1[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: bundle<a: uint<0>, b: uint<20>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  firrtl.matchingconnect %[[v14]], %invalid_0 : !firrtl.bundle<a: uint<0>, b: uint<20>>

--- a/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
+++ b/test/Dialect/FIRRTL/imconstprop-aggregate.mlir
@@ -10,7 +10,7 @@ firrtl.circuit "VectorPropagation1" {
     %tmp = firrtl.wire : !firrtl.vector<uint<1>, 2>
     %0 = firrtl.subindex %tmp[0] : !firrtl.vector<uint<1>, 2>
     %1 = firrtl.subindex %tmp[1] : !firrtl.vector<uint<1>, 2>
-    %2 = firrtl.xor %0, %1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %2 = firrtl.xor %0, %1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %0, %c1_ui1 : !firrtl.uint<1>
     firrtl.matchingconnect %1, %c1_ui1 : !firrtl.uint<1>
     // CHECK: firrtl.matchingconnect %b, %c0_ui1 : !firrtl.uint<1>
@@ -57,11 +57,11 @@ firrtl.circuit "VectorPropagation2" {
     firrtl.matchingconnect %7, %c16_ui6 : !firrtl.uint<6>
     %8 = firrtl.subindex %6[1] : !firrtl.vector<uint<6>, 2>
     firrtl.matchingconnect %8, %c32_ui6 : !firrtl.uint<6>
-    %9 = firrtl.xor %1, %4 : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
+    %9 = firrtl.xor %1, %4 : !firrtl.uint<6>, !firrtl.uint<6>
     firrtl.matchingconnect %b1, %9 : !firrtl.uint<6>
-    %10 = firrtl.xor %8, %2 : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
+    %10 = firrtl.xor %8, %2 : !firrtl.uint<6>, !firrtl.uint<6>
     firrtl.matchingconnect %b2, %10 : !firrtl.uint<6>
-    %11 = firrtl.xor %7, %5 : (!firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
+    %11 = firrtl.xor %7, %5 : !firrtl.uint<6>, !firrtl.uint<6>
     firrtl.matchingconnect %b3, %11 : !firrtl.uint<6>
     // CHECK:      firrtl.matchingconnect %b1, %c5_ui6 : !firrtl.uint<6>
     // CHECK-NEXT: firrtl.matchingconnect %b2, %c34_ui6 : !firrtl.uint<6>
@@ -84,8 +84,8 @@ firrtl.circuit "BundlePropagation1"   {
     firrtl.matchingconnect %0, %c1_ui3 : !firrtl.uint<3>
     firrtl.matchingconnect %1, %c2_ui3 : !firrtl.uint<3>
     firrtl.matchingconnect %2, %c4_ui3 : !firrtl.uint<3>
-    %3 = firrtl.xor %0, %1 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
-    %4 = firrtl.xor %3, %2 : (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
+    %3 = firrtl.xor %0, %1 : !firrtl.uint<3>, !firrtl.uint<3>
+    %4 = firrtl.xor %3, %2 : !firrtl.uint<3>, !firrtl.uint<3>
     firrtl.matchingconnect %result, %4 : !firrtl.uint<3>
     // CHECK:  firrtl.matchingconnect %result, %c7_ui3 : !firrtl.uint<3>
   }
@@ -141,7 +141,7 @@ firrtl.circuit "InputPortTop"  {
     %0 = firrtl.subfield %in1[v] : !firrtl.bundle<v: uint<1>>
     %1 = firrtl.subfield %in0[v] : !firrtl.bundle<v: uint<1>>
     %2 = firrtl.subfield %out[v] : !firrtl.bundle<v: uint<1>>
-    %3 = firrtl.and %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %3 = firrtl.and %1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %2, %3 : !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module private @InputPortChild
@@ -153,7 +153,7 @@ firrtl.circuit "InputPortTop"  {
     %0 = firrtl.subfield %in1[v] : !firrtl.bundle<v: uint<1>>
     %1 = firrtl.subfield %in0[v] : !firrtl.bundle<v: uint<1>>
     %2 = firrtl.subfield %out[v] : !firrtl.bundle<v: uint<1>>
-    %3 = firrtl.and %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %3 = firrtl.and %1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %2, %3 : !firrtl.uint<1>
   }
 
@@ -198,7 +198,7 @@ firrtl.circuit "rhs_sink_output_used_as_wire" {
     firrtl.matchingconnect %3, %2 : !firrtl.uint<1>
     %_c = firrtl.wire  : !firrtl.bundle<v: uint<1>>
     %4 = firrtl.subfield %_c[v] : !firrtl.bundle<v: uint<1>>
-    %5 = firrtl.xor %1, %3 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %5 = firrtl.xor %1, %3 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %4, %5 : !firrtl.uint<1>
     firrtl.matchingconnect %0, %4 : !firrtl.uint<1>
   }
@@ -231,7 +231,7 @@ firrtl.circuit "dntOutput"  {
     %0 = firrtl.subfield %b[v] : !firrtl.bundle<v: uint<3>>
     %int_b = firrtl.instance int  @foo(out b: !firrtl.bundle<v: uint<3>>)
     %1 = firrtl.subfield %int_b[v] : !firrtl.bundle<v: uint<3>>
-    %2 = firrtl.mux(%c, %1, %c2_ui3) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
+    %2 = firrtl.mux(%c, %1, %c2_ui3) : !firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>
     firrtl.matchingconnect %0, %2 : !firrtl.uint<3>
   }
   firrtl.module private @foo(out %b: !firrtl.bundle<v: uint<3>> sym @dntSym1){

--- a/test/Dialect/FIRRTL/imconstprop-crashers.mlir
+++ b/test/Dialect/FIRRTL/imconstprop-crashers.mlir
@@ -8,7 +8,7 @@ firrtl.circuit "Issue1187"  {
     %dividend = firrtl.wire  : !firrtl.uint<0>
     %invalid_ui0 = firrtl.invalidvalue : !firrtl.uint<0>
     firrtl.matchingconnect %dividend, %invalid_ui0 : !firrtl.uint<0>
-    %0 = firrtl.div %dividend, %divisor : (!firrtl.uint<0>, !firrtl.uint<1>) -> !firrtl.uint<0>
+    %0 = firrtl.div %dividend, %divisor : !firrtl.uint<0>, !firrtl.uint<1>
     firrtl.matchingconnect %result, %0 : !firrtl.uint<0>
   }
 }
@@ -21,7 +21,7 @@ firrtl.circuit "Issue1187"  {
 firrtl.circuit "Issue4456"  {
   firrtl.module @Issue4456(in %i: !firrtl.sint<0>, out %o: !firrtl.uint<4>) {
     %c0_si4 = firrtl.constant 0 : !firrtl.sint<4>
-    %0 = firrtl.cat %i, %c0_si4 : (!firrtl.sint<0>, !firrtl.sint<4>) -> !firrtl.uint<4>
+    %0 = firrtl.cat %i, %c0_si4 : !firrtl.sint<0>, !firrtl.sint<4>
     firrtl.matchingconnect %o, %0 : !firrtl.uint<4>
   }
 }

--- a/test/Dialect/FIRRTL/imconstprop.mlir
+++ b/test/Dialect/FIRRTL/imconstprop.mlir
@@ -120,19 +120,19 @@ firrtl.circuit "Issue1188"  {
   firrtl.module @Issue1188(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %io_out: !firrtl.uint<6>, out %io_out3: !firrtl.uint<3>) {
     %c1_ui6 = firrtl.constant 1 : !firrtl.uint<6>
     %D0123456 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<6>
-    %0 = firrtl.bits %D0123456 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
-    %1 = firrtl.bits %D0123456 5 to 5 : (!firrtl.uint<6>) -> !firrtl.uint<1>
-    %2 = firrtl.cat %0, %1 : (!firrtl.uint<5>, !firrtl.uint<1>) -> !firrtl.uint<6>
-    %3 = firrtl.bits %D0123456 4 to 4 : (!firrtl.uint<6>) -> !firrtl.uint<1>
-    %4 = firrtl.xor %2, %3 : (!firrtl.uint<6>, !firrtl.uint<1>) -> !firrtl.uint<6>
-    %5 = firrtl.bits %D0123456 1 to 1 : (!firrtl.uint<6>) -> !firrtl.uint<1>
-    %6 = firrtl.bits %D0123456 3 to 3 : (!firrtl.uint<6>) -> !firrtl.uint<1>
-    %7 = firrtl.cat %5, %6 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-    %8 = firrtl.cat %7, %1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<3>
+    %0 = firrtl.bits %D0123456 4 to 0 : !firrtl.uint<6>
+    %1 = firrtl.bits %D0123456 5 to 5 : !firrtl.uint<6>
+    %2 = firrtl.cat %0, %1 : !firrtl.uint<5>, !firrtl.uint<1>
+    %3 = firrtl.bits %D0123456 4 to 4 : !firrtl.uint<6>
+    %4 = firrtl.xor %2, %3 : !firrtl.uint<6>, !firrtl.uint<1>
+    %5 = firrtl.bits %D0123456 1 to 1 : !firrtl.uint<6>
+    %6 = firrtl.bits %D0123456 3 to 3 : !firrtl.uint<6>
+    %7 = firrtl.cat %5, %6 : !firrtl.uint<1>, !firrtl.uint<1>
+    %8 = firrtl.cat %7, %1 : !firrtl.uint<2>, !firrtl.uint<1>
     firrtl.matchingconnect %io_out, %D0123456 : !firrtl.uint<6>
     firrtl.matchingconnect %io_out3, %8 : !firrtl.uint<3>
     // CHECK: firrtl.mux(%reset, %c1_ui6, %4)
-    %9 = firrtl.mux(%reset, %c1_ui6, %4) : (!firrtl.uint<1>, !firrtl.uint<6>, !firrtl.uint<6>) -> !firrtl.uint<6>
+    %9 = firrtl.mux(%reset, %c1_ui6, %4) : !firrtl.uint<1>, !firrtl.uint<6>, !firrtl.uint<6>
     firrtl.matchingconnect %D0123456, %9 : !firrtl.uint<6>
   }
 }
@@ -219,8 +219,8 @@ firrtl.circuit "OutPortTop" {
       %c_out = firrtl.instance c  sym @a2 @OutPortChild1(out out: !firrtl.uint<1>)
       %c_out_0 = firrtl.instance c  sym @a1 @OutPortChild2(out out: !firrtl.uint<1>)
       // CHECK: %0 = firrtl.and %x, %c_out
-      %0 = firrtl.and %x, %c_out : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-      %1 = firrtl.and %x, %c_out_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      %0 = firrtl.and %x, %c_out : !firrtl.uint<1>, !firrtl.uint<1>
+      %1 = firrtl.and %x, %c_out_0 : !firrtl.uint<1>, !firrtl.uint<1>
       // CHECK: firrtl.matchingconnect %zn, %0
       firrtl.matchingconnect %zn, %0 : !firrtl.uint<1>
       // CHECK: firrtl.matchingconnect %zc, %c0_ui1
@@ -235,14 +235,14 @@ firrtl.circuit "InputPortTop"   {
   // CHECK-LABEL: firrtl.module private @InputPortChild2
   firrtl.module private @InputPortChild2(in %in0: !firrtl.uint<1>, in %in1: !firrtl.uint<1>, out %out: !firrtl.uint<1>) {
     // CHECK: = firrtl.constant 1
-    %0 = firrtl.and %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.and %in0, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %out, %0 : !firrtl.uint<1>
   }
   // CHECK-LABEL: firrtl.module private @InputPortChild
   firrtl.module private @InputPortChild(in %in0: !firrtl.uint<1>,
     in %in1 : !firrtl.uint<1> sym @dntSym1, out %out: !firrtl.uint<1>) {
     // CHECK: %0 = firrtl.and %in0, %in1
-    %0 = firrtl.and %in0, %in1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.and %in0, %in1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %out, %0 : !firrtl.uint<1>
   }
   firrtl.module @InputPortTop(in %x: !firrtl.uint<1>, out %z: !firrtl.uint<1>, out %z2: !firrtl.uint<1>) {
@@ -299,8 +299,8 @@ firrtl.circuit "invalidReg1"   {
   // CHECK-LABEL: @invalidReg1
   firrtl.module @invalidReg1(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
     %foobar = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
-      //CHECK: %0 = firrtl.not %foobar : (!firrtl.uint<1>) -> !firrtl.uint<1>
-      %0 = firrtl.not %foobar : (!firrtl.uint<1>) -> !firrtl.uint<1>
+      //CHECK: %0 = firrtl.not %foobar : !firrtl.uint<1>
+      %0 = firrtl.not %foobar : !firrtl.uint<1>
       //CHECK: firrtl.matchingconnect %foobar, %0 : !firrtl.uint<1>
       firrtl.matchingconnect %foobar, %0 : !firrtl.uint<1>
       //CHECK: firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
@@ -326,11 +326,11 @@ firrtl.circuit "Oscillators"   {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: firrtl.regreset
     %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
-    %0 = firrtl.not %r : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.not %r : !firrtl.uint<1>
     firrtl.matchingconnect %r, %0 : !firrtl.uint<1>
-    %1 = firrtl.not %s : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.not %s : !firrtl.uint<1>
     firrtl.matchingconnect %s, %1 : !firrtl.uint<1>
-    %2 = firrtl.or %r, %s : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %2 = firrtl.or %r, %s : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %a, %2 : !firrtl.uint<1>
   }
   // CHECK: firrtl.module private @Bar
@@ -341,11 +341,11 @@ firrtl.circuit "Oscillators"   {
     // CHECK: firrtl.regreset
     %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %0 = firrtl.xor %a, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.xor %a, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %r, %0 : !firrtl.uint<1>
-    %1 = firrtl.xor %a, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.xor %a, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %s, %1 : !firrtl.uint<1>
-    %2 = firrtl.or %r, %s : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %2 = firrtl.or %r, %s : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %a, %2 : !firrtl.uint<1>
   }
   // CHECK: firrtl.module private @Baz
@@ -355,11 +355,11 @@ firrtl.circuit "Oscillators"   {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: firrtl.regreset
     %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
-    %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.not %a : !firrtl.uint<1>
     firrtl.matchingconnect %r, %0 : !firrtl.uint<1>
-    %1 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.not %a : !firrtl.uint<1>
     firrtl.matchingconnect %s, %1 : !firrtl.uint<1>
-    %2 = firrtl.or %r, %s : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %2 = firrtl.or %r, %s : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %a, %2 : !firrtl.uint<1>
   }
   firrtl.extmodule @Ext(in a: !firrtl.uint<1>)
@@ -371,11 +371,11 @@ firrtl.circuit "Oscillators"   {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: firrtl.regreset
     %s = firrtl.regreset %clock, %reset, %c0_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
-    %0 = firrtl.not %ext_a : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.not %ext_a : !firrtl.uint<1>
     firrtl.matchingconnect %r, %0 : !firrtl.uint<1>
-    %1 = firrtl.not %ext_a : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.not %ext_a : !firrtl.uint<1>
     firrtl.matchingconnect %s, %1 : !firrtl.uint<1>
-    %2 = firrtl.or %r, %s : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %2 = firrtl.or %r, %s : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %ext_a, %2 : !firrtl.uint<1>
     firrtl.matchingconnect %a, %ext_a : !firrtl.uint<1>
   }
@@ -413,7 +413,7 @@ firrtl.circuit "rhs_sink_output_used_as_wire" {
     firrtl.matchingconnect %c, %b : !firrtl.uint<1>
     %_c = firrtl.wire  : !firrtl.uint<1>
     // CHECK: firrtl.xor %a, %c
-    %0 = firrtl.xor %a, %c : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.xor %a, %c : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %_c, %0 : !firrtl.uint<1>
     firrtl.matchingconnect %d, %_c : !firrtl.uint<1>
   }
@@ -437,7 +437,7 @@ firrtl.circuit "dntOutput" {
   firrtl.module @dntOutput(out %b : !firrtl.uint<3>, in %c : !firrtl.uint<1>) {
     %const = firrtl.constant 2 : !firrtl.uint<3>
     %int_b = firrtl.instance int @foo(out b: !firrtl.uint<3>)
-    %m = firrtl.mux(%c, %int_b, %const) : (!firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
+    %m = firrtl.mux(%c, %int_b, %const) : !firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<3>
     firrtl.matchingconnect %b, %m : !firrtl.uint<3>
   }
   firrtl.module private @foo(out %b: !firrtl.uint<3>  sym @dntSym1) {
@@ -608,7 +608,7 @@ firrtl.circuit "Ordering" {
     %0 = firrtl.wire : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     firrtl.matchingconnect %0, %c1_ui1 : !firrtl.uint<1>
-    %1 = firrtl.xor %0, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.xor %0, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %b, %1 : !firrtl.uint<1>
   }
   // CHECK: firrtl.matchingconnect %b, %c0_ui1

--- a/test/Dialect/FIRRTL/imcp-locations.mlir
+++ b/test/Dialect/FIRRTL/imcp-locations.mlir
@@ -18,9 +18,9 @@ firrtl.circuit "Test" {
     %w_or = firrtl.wire : !firrtl.uint<3> loc("test.txt":4:2)
     %w_add = firrtl.wire : !firrtl.uint<3> loc("test.txt":5:2)
 
-    %or = firrtl.or %c2, %c4: (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<3>
-    %add = firrtl.add %c2, %c4: (!firrtl.uint<3>, !firrtl.uint<3>) -> !firrtl.uint<4>
-    %addtrunc = firrtl.bits %add 2 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<3>
+    %or = firrtl.or %c2, %c4 : !firrtl.uint<3>, !firrtl.uint<3>
+    %add = firrtl.add %c2, %c4 : !firrtl.uint<3>, !firrtl.uint<3>
+    %addtrunc = firrtl.bits %add 2 to 0 : !firrtl.uint<4>
 
     firrtl.matchingconnect %w_or, %or : !firrtl.uint<3>
     firrtl.matchingconnect %w_add, %addtrunc : !firrtl.uint<3>

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -17,7 +17,7 @@ firrtl.circuit "top" {
     %dead_reg_reset = firrtl.regreset %clock, %reset, %dead_reg  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.matchingconnect %dead_reg_reset, %dead_reg : !firrtl.uint<1>
 
-    %not = firrtl.not %dead_reg_reset : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %not = firrtl.not %dead_reg_reset : !firrtl.uint<1>
     firrtl.matchingconnect %dest, %not : !firrtl.uint<1>
   }
 
@@ -115,7 +115,7 @@ firrtl.circuit "UnusedOutput"  {
     // CHECK-NEXT: firrtl.matchingconnect %b, %[[c_wire]]
     firrtl.matchingconnect %b, %c : !firrtl.uint<1>
     // CHECK-NEXT: %[[not_a:.+]] = firrtl.not %a
-    %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.not %a : !firrtl.uint<1>
     // CHECK-NEXT: firrtl.matchingconnect %[[c_wire]], %[[not_a]]
     firrtl.matchingconnect %c, %0 : !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/infer-resets-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-resets-errors.mlir
@@ -209,9 +209,9 @@ firrtl.circuit "top" {
     // expected-error @+1 {{ExcludeFromFullResetAnnotation' cannot target port/wire/node; must target module instead}}
     %1 = firrtl.node %0 {annotations = [{class = "circt.ExcludeFromFullResetAnnotation"}]} : !firrtl.asyncreset
     // expected-error @+1 {{reset annotations must target module, port, or wire/node}}
-    %2 = firrtl.asUInt %0 {annotations = [{class = "circt.FullResetAnnotation", resetType = "async"}]} : (!firrtl.asyncreset) -> !firrtl.uint<1>
+    %2 = firrtl.asUInt %0 {annotations = [{class = "circt.FullResetAnnotation", resetType = "async"}]} : !firrtl.asyncreset
     // expected-error @+1 {{reset annotations must target module, port, or wire/node}}
-    %3 = firrtl.asUInt %0 {annotations = [{class = "circt.ExcludeFromFullResetAnnotation"}]} : (!firrtl.asyncreset) -> !firrtl.uint<1>
+    %3 = firrtl.asUInt %0 {annotations = [{class = "circt.ExcludeFromFullResetAnnotation"}]} : !firrtl.asyncreset
   }
 }
 

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -48,10 +48,10 @@ firrtl.module @MergeNetsTop(in %reset: !firrtl.asyncreset) {
 firrtl.module @CastingToOtherTypes(in %a: !firrtl.uint<1>, out %v: !firrtl.uint<1>, out %w: !firrtl.sint<1>, out %x: !firrtl.clock, out %y: !firrtl.asyncreset) {
   // CHECK: %r = firrtl.wire : !firrtl.uint<1>
   %r = firrtl.wire : !firrtl.reset
-  %0 = firrtl.asUInt %r : (!firrtl.reset) -> !firrtl.uint<1>
-  %1 = firrtl.asSInt %r : (!firrtl.reset) -> !firrtl.sint<1>
-  %2 = firrtl.asClock %r : (!firrtl.reset) -> !firrtl.clock
-  %3 = firrtl.asAsyncReset %r : (!firrtl.reset) -> !firrtl.asyncreset
+  %0 = firrtl.asUInt %r : !firrtl.reset
+  %1 = firrtl.asSInt %r : !firrtl.reset
+  %2 = firrtl.asClock %r : !firrtl.reset
+  %3 = firrtl.asAsyncReset %r : !firrtl.reset
   %4 = firrtl.resetCast %a : (!firrtl.uint<1>) -> !firrtl.reset
   firrtl.matchingconnect %r, %4 : !firrtl.reset
   firrtl.matchingconnect %v, %0 : !firrtl.uint<1>
@@ -267,7 +267,7 @@ firrtl.module @DontPropagateUpstreamAcrossCast(in %in0: !firrtl.asyncreset, in %
   %w = firrtl.wire : !firrtl.reset
   %invalid_reset = firrtl.invalidvalue : !firrtl.reset
   firrtl.matchingconnect %w, %invalid_reset : !firrtl.reset
-  %0 = firrtl.asAsyncReset %w : (!firrtl.reset) -> !firrtl.asyncreset
+  %0 = firrtl.asAsyncReset %w : !firrtl.reset
   firrtl.connect %out0, %0 : !firrtl.reset, !firrtl.asyncreset
   firrtl.matchingconnect %out1, %w : !firrtl.reset
   firrtl.connect %out0, %in0 : !firrtl.reset, !firrtl.asyncreset
@@ -602,8 +602,8 @@ firrtl.circuit "FullAsyncNested" {
     // CHECK: %io_out_REG_NO = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
     %io_out_REG_NO = firrtl.reg %clock {annotations = [{class = "sifive.enterprise.firrtl.ExcludeMemFromMemToRegOfVec"}]}: !firrtl.clock, !firrtl.uint<8>
     firrtl.matchingconnect %io_out_REG, %io_in : !firrtl.uint<8>
-    %0 = firrtl.add %io_out_REG, %inst_io_out : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<9>
-    %1 = firrtl.bits %0 7 to 0 : (!firrtl.uint<9>) -> !firrtl.uint<8>
+    %0 = firrtl.add %io_out_REG, %inst_io_out : !firrtl.uint<8>, !firrtl.uint<8>
+    %1 = firrtl.bits %0 7 to 0 : !firrtl.uint<9>
     firrtl.matchingconnect %io_out, %1 : !firrtl.uint<8>
   }
   // CHECK-LABEL: firrtl.module @FullAsyncNested
@@ -664,7 +664,7 @@ firrtl.circuit "WireShouldDominate" {
 firrtl.circuit "MovableNodeShouldDominate" {
   // CHECK-LABEL: firrtl.module @MovableNodeShouldDominate
   firrtl.module @MovableNodeShouldDominate(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
-    %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // does not block move of node
+    %0 = firrtl.asAsyncReset %ui1 : !firrtl.uint<1>
     %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
     %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "circt.FullResetAnnotation", resetType = "async"}]} : !firrtl.asyncreset
     // CHECK-NEXT: %0 = firrtl.asAsyncReset %ui1
@@ -683,7 +683,7 @@ firrtl.circuit "UnmovableNodeShouldDominate" {
   // CHECK-LABEL: firrtl.module @UnmovableNodeShouldDominate
   firrtl.module @UnmovableNodeShouldDominate(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
     %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
-    %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
+    %0 = firrtl.asAsyncReset %ui1 : !firrtl.uint<1>
     %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "circt.FullResetAnnotation", resetType = "async"}]} : !firrtl.asyncreset
     // CHECK-NEXT: %localReset = firrtl.wire sym @theReset
     // CHECK-NEXT: [[RV:%.+]] = firrtl.constant 0
@@ -701,7 +701,7 @@ firrtl.circuit "UnmovableForceableNodeShouldDominate" {
   // CHECK-LABEL: firrtl.module @UnmovableForceableNodeShouldDominate
   firrtl.module @UnmovableForceableNodeShouldDominate(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
     %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
-    %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
+    %0 = firrtl.asAsyncReset %ui1 : !firrtl.uint<1>
     %localReset, %ref = firrtl.node sym @theReset %0 forceable {annotations = [{class = "circt.FullResetAnnotation", resetType = "async"}]} : !firrtl.asyncreset
     // CHECK-NEXT: %localReset, %{{.+}} = firrtl.wire sym @theReset
     // CHECK-NEXT: [[RV:%.+]] = firrtl.constant 0
@@ -723,7 +723,7 @@ firrtl.circuit "MoveAcrossBlocks1" {
       %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
     }
     firrtl.when %ui1 : !firrtl.uint<1> {
-      %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
+      %0 = firrtl.asAsyncReset %ui1 : !firrtl.uint<1>
       %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "circt.FullResetAnnotation", resetType = "async"}]} : !firrtl.asyncreset
     }
     // CHECK-NEXT: %localReset = firrtl.wire
@@ -746,7 +746,7 @@ firrtl.circuit "MoveAcrossBlocks2" {
   firrtl.module @MoveAcrossBlocks2(in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
     // <-- should move reset here
     firrtl.when %ui1 : !firrtl.uint<1> {
-      %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
+      %0 = firrtl.asAsyncReset %ui1 : !firrtl.uint<1>
       %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "circt.FullResetAnnotation", resetType = "async"}]} : !firrtl.asyncreset
     }
     firrtl.when %ui1 : !firrtl.uint<1> {
@@ -773,7 +773,7 @@ firrtl.circuit "MoveAcrossBlocks3" {
     // <-- should move reset here
     %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
     firrtl.when %ui1 : !firrtl.uint<1> {
-      %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
+      %0 = firrtl.asAsyncReset %ui1 : !firrtl.uint<1>
       %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "circt.FullResetAnnotation", resetType = "async"}]} : !firrtl.asyncreset
     }
     // CHECK-NEXT: %localReset = firrtl.wire
@@ -796,7 +796,7 @@ firrtl.circuit "MoveAcrossBlocks4" {
     firrtl.when %ui1 : !firrtl.uint<1> {
       %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8> // gets wired to localReset
     }
-    %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset // blocks move of node
+    %0 = firrtl.asAsyncReset %ui1 : !firrtl.uint<1>
     %localReset = firrtl.node sym @theReset %0 {annotations = [{class = "circt.FullResetAnnotation", resetType = "async"}]} : !firrtl.asyncreset
     // CHECK-NEXT: %localReset = firrtl.wire
     // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
@@ -1233,7 +1233,7 @@ firrtl.circuit "MovableNodeShouldDominateInstance" {
     %child_clock = firrtl.instance child @Child(in clock: !firrtl.clock)
     firrtl.connect %child_clock, %clock : !firrtl.clock
     %ui1 = firrtl.constant 1 : !firrtl.uint<1>
-    %0 = firrtl.asAsyncReset %ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
+    %0 = firrtl.asAsyncReset %ui1 : !firrtl.uint<1>
     %localReset = firrtl.node %0 {annotations = [{class = "circt.FullResetAnnotation", resetType = "async"}]} : !firrtl.asyncreset
     // CHECK:       %localReset = firrtl.wire {annotations = [{class = "circt.FullResetAnnotation", resetType = "async"}]} : !firrtl.asyncreset
     // CHECK:       %child_localReset, %child_clock = firrtl.instance child @Child(in localReset: !firrtl.asyncreset, in clock: !firrtl.clock

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -5,11 +5,11 @@ firrtl.circuit "Foo" {
     // expected-error @+1 {{'firrtl.reg' op is constrained to be wider than itself}}
     %0 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
     // expected-note @+1 {{constrained width W >= W+3 here}}
-    %1 = firrtl.shl %0, 3 : (!firrtl.uint) -> !firrtl.uint
+    %1 = firrtl.shl %0, 3 : !firrtl.uint
     // expected-note @+1 {{constrained width W >= W+4 here}}
-    %2 = firrtl.shl %1, 1 : (!firrtl.uint) -> !firrtl.uint
+    %2 = firrtl.shl %1, 1 : !firrtl.uint
     // expected-note @+1 {{constrained width W >= 2W+4 here}}
-    %3 = firrtl.mul %0, %2 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %3 = firrtl.mul %0, %2 : !firrtl.uint, !firrtl.uint
     // expected-note @+1 {{constrained width W >= 2W+4 here}}
     firrtl.connect %0, %3 : !firrtl.uint, !firrtl.uint
   }
@@ -49,7 +49,7 @@ firrtl.circuit "Issue1255" {
     %tmp74 = firrtl.wire  : !firrtl.uint
     %c14972_ui = firrtl.constant 14972 : !firrtl.uint
     // expected-error @+1 {{amount must be less than or equal operand width}}
-    %0 = firrtl.tail %c14972_ui, 15 : (!firrtl.uint) -> !firrtl.uint
+    %0 = firrtl.tail %c14972_ui, 15 : !firrtl.uint
     firrtl.connect %tmp74, %0 : !firrtl.uint, !firrtl.uint
   }
 }
@@ -173,7 +173,7 @@ firrtl.circuit "MuxSelBackProp" {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     // expected-error @below {{uninferred width: wire is unconstrained}}
     %0 = firrtl.wire : !firrtl.uint
-    %1 = firrtl.mux(%0, %c1_ui1, %c1_ui1) : (!firrtl.uint, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.mux(%0, %c1_ui1, %c1_ui1) : !firrtl.uint, !firrtl.uint<1>, !firrtl.uint<1>
   }
 }
 
@@ -186,7 +186,7 @@ firrtl.circuit "MuxSelTooWide" {
     // expected-error @below {{uninferred width: wire cannot satisfy all width requirements}}
     %0 = firrtl.wire : !firrtl.uint
     // expected-note @below {{width is constrained to be at most 1 here:}}
-    %1 = firrtl.mux(%0, %c1_ui1, %c1_ui1) : (!firrtl.uint, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %1 = firrtl.mux(%0, %c1_ui1, %c1_ui1) : !firrtl.uint, !firrtl.uint<1>, !firrtl.uint<1>
     // expected-note @below {{width is constrained to be at least 2 here:}}
     firrtl.connect %0, %c2_ui2 : !firrtl.uint, !firrtl.uint<2>
   }

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -80,46 +80,34 @@ firrtl.circuit "Foo" {
 
   // CHECK-LABEL: @AddSubOp
   firrtl.module @AddSubOp() {
-    // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
-    // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
-    // CHECK: %2 = firrtl.add {{.*}} -> !firrtl.uint<4>
-    // CHECK: %3 = firrtl.sub {{.*}} -> !firrtl.uint<5>
-    %0 = firrtl.wire : !firrtl.uint
-    %1 = firrtl.wire : !firrtl.uint
-    %2 = firrtl.add %0, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %3 = firrtl.sub %0, %2 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-    %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
-    firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
-    firrtl.connect %1, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
+    %c1_ui2 = firrtl.constant 1 : !firrtl.uint
+    %c2_ui3 = firrtl.constant 2 : !firrtl.uint
+    %0 = firrtl.add %c1_ui2, %c2_ui3 : !firrtl.uint, !firrtl.uint
+    // CHECK: %1 = firrtl.node %0 : !firrtl.uint<4>
+    %1 = firrtl.node %0 : !firrtl.uint
+    %2 = firrtl.sub %c1_ui1, %2 : !firrtl.uint, !firrtl.uint
+    // CHECK: %3 = firrtl.node %2 : !firrtl.uint<5>
+    %3 = firrtl.node %2 : !firrtl.uint
   }
 
   // CHECK-LABEL: @MulDivRemOp
   firrtl.module @MulDivRemOp() {
-    // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
-    // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
-    // CHECK: %2 = firrtl.wire : !firrtl.sint<2>
-    // CHECK: %3 = firrtl.wire : !firrtl.sint<3>
-    // CHECK: %4 = firrtl.mul {{.*}} -> !firrtl.uint<5>
-    // CHECK: %5 = firrtl.div {{.*}} -> !firrtl.uint<3>
-    // CHECK: %6 = firrtl.div {{.*}} -> !firrtl.sint<4>
-    // CHECK: %7 = firrtl.rem {{.*}} -> !firrtl.uint<2>
-    %0 = firrtl.wire : !firrtl.uint
-    %1 = firrtl.wire : !firrtl.uint
-    %2 = firrtl.wire : !firrtl.sint
-    %3 = firrtl.wire : !firrtl.sint
-    %4 = firrtl.mul %1, %0 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %5 = firrtl.div %1, %0 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %6 = firrtl.div %3, %2 : (!firrtl.sint, !firrtl.sint) -> !firrtl.sint
-    %7 = firrtl.rem %1, %0 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
-    %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
-    %c1_si2 = firrtl.constant 1 : !firrtl.sint<2>
-    %c2_si3 = firrtl.constant 2 : !firrtl.sint<3>
-    firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
-    firrtl.connect %1, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
-    firrtl.connect %2, %c1_si2 : !firrtl.sint, !firrtl.sint<2>
-    firrtl.connect %3, %c2_si3 : !firrtl.sint, !firrtl.sint<3>
+    %c1_ui2 = firrtl.constant 1 : !firrtl.uint
+    %c2_ui3 = firrtl.constant 2 : !firrtl.uint
+    %c1_si2 = firrtl.constant 1 : !firrtl.sint
+    %c2_si3 = firrtl.constant 2 : !firrtl.sint
+    %0 = firrtl.mul %c2_ui3, %c1_ui2 : !firrtl.uint, !firrtl.uint
+    // CHECK: %1 = firrtl.node %0 : !firrtl.uint<5>
+    %1 = firrtl.node %0 : !firrtl.uint 
+    %2 = firrtl.div %c2_ui3, %c1_ui2 : !firrtl.uint, !firrtl.uint
+    // CHECK: %3 = firrtl.node %0 : !firrtl.uint<3>
+    %3 = firrtl.node %0 : !firrtl.uint 
+    %4 = firrtl.div %c2_si3, %c1_si2 : !firrtl.sint, !firrtl.sint
+    // CHECK: 5 = firrtl.node %0 : !firrtl.uint<4>
+    %5 = firrtl.node %0 : !firrtl.uint 
+    %6 = firrtl.rem %c2_ui3, %c1_ui2 : !firrtl.uint, !firrtl.uint
+    // CHECK: 7 = firrtl.node %0 : !firrtl.uint <2>
+    %7 = firrtl.node %0 : !firrtl.uint 
   }
 
   // CHECK-LABEL: @AndOrXorOp
@@ -131,9 +119,9 @@ firrtl.circuit "Foo" {
     // CHECK: %4 = firrtl.xor {{.*}} -> !firrtl.uint<3>
     %0 = firrtl.wire : !firrtl.uint
     %1 = firrtl.wire : !firrtl.uint
-    %2 = firrtl.and %0, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %3 = firrtl.or %0, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %4 = firrtl.xor %0, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %2 = firrtl.and %0, %1 : !firrtl.uint, !firrtl.uint
+    %3 = firrtl.or %0, %1 : !firrtl.uint, !firrtl.uint
+    %4 = firrtl.xor %0, %1 : !firrtl.uint, !firrtl.uint
     %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
     firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
@@ -148,12 +136,12 @@ firrtl.circuit "Foo" {
     // CHECK: %9 = firrtl.wire : !firrtl.uint<1>
     // CHECK: %10 = firrtl.wire : !firrtl.uint<1>
     // CHECK: %11 = firrtl.wire : !firrtl.uint<1>
-    %0 = firrtl.leq %a, %b : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
-    %1 = firrtl.lt %a, %b : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
-    %2 = firrtl.geq %a, %b : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
-    %3 = firrtl.gt %a, %b : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
-    %4 = firrtl.eq %a, %b : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
-    %5 = firrtl.neq %a, %b : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<1>
+    %0 = firrtl.leq %a, %b : !firrtl.uint<2>, !firrtl.uint<3>
+    %1 = firrtl.lt %a, %b : !firrtl.uint<2>, !firrtl.uint<3>
+    %2 = firrtl.geq %a, %b : !firrtl.uint<2>, !firrtl.uint<3>
+    %3 = firrtl.gt %a, %b : !firrtl.uint<2>, !firrtl.uint<3>
+    %4 = firrtl.eq %a, %b : !firrtl.uint<2>, !firrtl.uint<3>
+    %5 = firrtl.neq %a, %b : !firrtl.uint<2>, !firrtl.uint<3>
     %6 = firrtl.wire : !firrtl.uint
     %7 = firrtl.wire : !firrtl.uint
     %8 = firrtl.wire : !firrtl.uint
@@ -174,26 +162,18 @@ firrtl.circuit "Foo" {
     // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
     // CHECK: %2 = firrtl.wire : !firrtl.sint<2>
     // CHECK: %3 = firrtl.wire : !firrtl.sint<3>
-    // CHECK: %4 = firrtl.cat {{.*}} -> !firrtl.uint<5>
-    // CHECK: %5 = firrtl.cat {{.*}} -> !firrtl.uint<5>
-    // CHECK: %6 = firrtl.dshl {{.*}} -> !firrtl.uint<10>
-    // CHECK: %7 = firrtl.dshl {{.*}} -> !firrtl.sint<10>
-    // CHECK: %8 = firrtl.dshlw {{.*}} -> !firrtl.uint<3>
-    // CHECK: %9 = firrtl.dshlw {{.*}} -> !firrtl.sint<3>
-    // CHECK: %10 = firrtl.dshr {{.*}} -> !firrtl.uint<3>
-    // CHECK: %11 = firrtl.dshr {{.*}} -> !firrtl.sint<3>
     %0 = firrtl.wire : !firrtl.uint
     %1 = firrtl.wire : !firrtl.uint
     %2 = firrtl.wire : !firrtl.sint
     %3 = firrtl.wire : !firrtl.sint
-    %4 = firrtl.cat %0, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %5 = firrtl.cat %2, %3 : (!firrtl.sint, !firrtl.sint) -> !firrtl.uint
-    %6 = firrtl.dshl %1, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %7 = firrtl.dshl %3, %1 : (!firrtl.sint, !firrtl.uint) -> !firrtl.sint
-    %8 = firrtl.dshlw %1, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %9 = firrtl.dshlw %3, %1 : (!firrtl.sint, !firrtl.uint) -> !firrtl.sint
-    %10 = firrtl.dshr %1, %1 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
-    %11 = firrtl.dshr %3, %1 : (!firrtl.sint, !firrtl.uint) -> !firrtl.sint
+    %4 = firrtl.cat %0, %1 : !firrtl.uint, !firrtl.uint
+    %5 = firrtl.cat %2, %3 : !firrtl.sint, !firrtl.sint
+    %6 = firrtl.dshl %1, %1 : !firrtl.uint, !firrtl.uint
+    %7 = firrtl.dshl %3, %1 : !firrtl.sint, !firrtl.uint
+    %8 = firrtl.dshlw %1, %1 : !firrtl.uint, !firrtl.uint
+    %9 = firrtl.dshlw %3, %1 : !firrtl.sint, !firrtl.uint
+    %10 = firrtl.dshr %1, %1 : !firrtl.uint, !firrtl.uint
+    %11 = firrtl.dshr %3, %1 : !firrtl.sint, !firrtl.uint
     %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
     %c1_si2 = firrtl.constant 1 : !firrtl.sint<2>
@@ -209,18 +189,18 @@ firrtl.circuit "Foo" {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
     // CHECK: %1 = firrtl.wire : !firrtl.sint<3>
-    // CHECK: %4 = firrtl.asSInt {{.*}} -> !firrtl.sint<2>
-    // CHECK: %5 = firrtl.asUInt {{.*}} -> !firrtl.uint<3>
+    // CHECK: %4 = firrtl.asSInt {{.*}}
+    // CHECK: %5 = firrtl.asUInt {{.*}}
     %0 = firrtl.wire : !firrtl.uint
     %1 = firrtl.wire : !firrtl.sint
     %2 = firrtl.wire : !firrtl.clock
     %3 = firrtl.wire : !firrtl.asyncreset
-    %4 = firrtl.asSInt %0 : (!firrtl.uint) -> !firrtl.sint
-    %5 = firrtl.asUInt %1 : (!firrtl.sint) -> !firrtl.uint
-    %6 = firrtl.asUInt %2 : (!firrtl.clock) -> !firrtl.uint<1>
-    %7 = firrtl.asUInt %3 : (!firrtl.asyncreset) -> !firrtl.uint<1>
-    %8 = firrtl.asClock %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.clock
-    %9 = firrtl.asAsyncReset %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.asyncreset
+    %4 = firrtl.asSInt %0 : !firrtl.uint
+    %5 = firrtl.asUInt %1 : !firrtl.sint
+    %6 = firrtl.asUInt %2 : !firrtl.clock
+    %7 = firrtl.asUInt %3 : !firrtl.asyncreset
+    %8 = firrtl.asClock %c0_ui1 : !firrtl.uint<1>
+    %9 = firrtl.asAsyncReset %c0_ui1 : !firrtl.uint<1>
     %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
     %c2_si3 = firrtl.constant 2 : !firrtl.sint<3>
     firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
@@ -250,8 +230,8 @@ firrtl.circuit "Foo" {
     // CHECK: %3 = firrtl.cvt {{.*}} -> !firrtl.sint<3>
     %0 = firrtl.wire : !firrtl.uint
     %1 = firrtl.wire : !firrtl.sint
-    %2 = firrtl.cvt %0 : (!firrtl.uint) -> !firrtl.sint
-    %3 = firrtl.cvt %1 : (!firrtl.sint) -> !firrtl.sint
+    %2 = firrtl.cvt %0 : !firrtl.uint
+    %3 = firrtl.cvt %1 : !firrtl.sint
     %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
     %c2_si3 = firrtl.constant 2 : !firrtl.sint<3>
     firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
@@ -266,8 +246,8 @@ firrtl.circuit "Foo" {
     // CHECK: %3 = firrtl.neg {{.*}} -> !firrtl.sint<4>
     %0 = firrtl.wire : !firrtl.uint
     %1 = firrtl.wire : !firrtl.sint
-    %2 = firrtl.neg %0 : (!firrtl.uint) -> !firrtl.sint
-    %3 = firrtl.neg %1 : (!firrtl.sint) -> !firrtl.sint
+    %2 = firrtl.neg %0 : !firrtl.uint
+    %3 = firrtl.neg %1 : !firrtl.sint
     %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
     %c2_si3 = firrtl.constant 2 : !firrtl.sint<3>
     firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
@@ -278,12 +258,10 @@ firrtl.circuit "Foo" {
   firrtl.module @NotOp() {
     // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
     // CHECK: %1 = firrtl.wire : !firrtl.sint<3>
-    // CHECK: %2 = firrtl.not {{.*}} -> !firrtl.uint<2>
-    // CHECK: %3 = firrtl.not {{.*}} -> !firrtl.uint<3>
     %0 = firrtl.wire : !firrtl.uint
     %1 = firrtl.wire : !firrtl.sint
-    %2 = firrtl.not %0 : (!firrtl.uint) -> !firrtl.uint
-    %3 = firrtl.not %1 : (!firrtl.sint) -> !firrtl.uint
+    %2 = firrtl.not %0 : !firrtl.uint
+    %3 = firrtl.not %1 : !firrtl.sint
     %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
     %c2_si3 = firrtl.constant 2 : !firrtl.sint<3>
     firrtl.connect %0, %c1_ui2 : !firrtl.uint, !firrtl.uint<2>
@@ -295,16 +273,13 @@ firrtl.circuit "Foo" {
     // CHECK: %0 = firrtl.wire : !firrtl.uint<1>
     // CHECK: %1 = firrtl.wire : !firrtl.uint<1>
     // CHECK: %2 = firrtl.wire : !firrtl.uint<1>
-    // CHECK: %3 = firrtl.andr {{.*}} -> !firrtl.uint<1>
-    // CHECK: %4 = firrtl.orr {{.*}} -> !firrtl.uint<1>
-    // CHECK: %5 = firrtl.xorr {{.*}} -> !firrtl.uint<1>
     %c0_ui16 = firrtl.constant 0 : !firrtl.uint<16>
     %0 = firrtl.wire : !firrtl.uint
     %1 = firrtl.wire : !firrtl.uint
     %2 = firrtl.wire : !firrtl.uint
-    %3 = firrtl.andr %c0_ui16 : (!firrtl.uint<16>) -> !firrtl.uint<1>
-    %4 = firrtl.orr %c0_ui16 : (!firrtl.uint<16>) -> !firrtl.uint<1>
-    %5 = firrtl.xorr %c0_ui16 : (!firrtl.uint<16>) -> !firrtl.uint<1>
+    %3 = firrtl.andr %c0_ui16 : !firrtl.uint<16>
+    %4 = firrtl.orr %c0_ui16 : !firrtl.uint<16>
+    %5 = firrtl.xorr %c0_ui16 : !firrtl.uint<16>
     firrtl.connect %0, %3 : !firrtl.uint, !firrtl.uint<1>
     firrtl.connect %1, %4 : !firrtl.uint, !firrtl.uint<1>
     firrtl.connect %2, %5 : !firrtl.uint, !firrtl.uint<1>
@@ -316,12 +291,6 @@ firrtl.circuit "Foo" {
     // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
     // CHECK: %2 = firrtl.wire : !firrtl.uint<5>
     // CHECK: %3 = firrtl.wire : !firrtl.uint<5>
-    // CHECK: %8 = firrtl.tail {{.*}} -> !firrtl.uint<12>
-    // CHECK: %9 = firrtl.tail {{.*}} -> !firrtl.uint<12>
-    // CHECK: %10 = firrtl.pad {{.*}} -> !firrtl.uint<42>
-    // CHECK: %11 = firrtl.pad {{.*}} -> !firrtl.sint<42>
-    // CHECK: %12 = firrtl.pad {{.*}} -> !firrtl.uint<99>
-    // CHECK: %13 = firrtl.pad {{.*}} -> !firrtl.sint<99>
     %ui = firrtl.wire : !firrtl.uint
     %si = firrtl.wire : !firrtl.sint
     %0 = firrtl.wire : !firrtl.uint
@@ -329,16 +298,16 @@ firrtl.circuit "Foo" {
     %2 = firrtl.wire : !firrtl.uint
     %3 = firrtl.wire : !firrtl.uint
 
-    %4 = firrtl.bits %ui 3 to 1 : (!firrtl.uint) -> !firrtl.uint<3>
-    %5 = firrtl.bits %si 3 to 1 : (!firrtl.sint) -> !firrtl.uint<3>
-    %6 = firrtl.head %ui, 5 : (!firrtl.uint) -> !firrtl.uint<5>
-    %7 = firrtl.head %si, 5 : (!firrtl.sint) -> !firrtl.uint<5>
-    %8 = firrtl.tail %ui, 30 : (!firrtl.uint) -> !firrtl.uint
-    %9 = firrtl.tail %si, 30 : (!firrtl.sint) -> !firrtl.uint
-    %10 = firrtl.pad %ui, 13 : (!firrtl.uint) -> !firrtl.uint
-    %11 = firrtl.pad %si, 13 : (!firrtl.sint) -> !firrtl.sint
-    %12 = firrtl.pad %ui, 99 : (!firrtl.uint) -> !firrtl.uint
-    %13 = firrtl.pad %si, 99 : (!firrtl.sint) -> !firrtl.sint
+    %4 = firrtl.bits %ui 3 to 1 : !firrtl.uint
+    %5 = firrtl.bits %si 3 to 1 : !firrtl.sint
+    %6 = firrtl.head %ui, 5 : !firrtl.uint
+    %7 = firrtl.head %si, 5 : !firrtl.sint
+    %8 = firrtl.tail %ui, 30 : !firrtl.uint
+    %9 = firrtl.tail %si, 30 : !firrtl.sint
+    %10 = firrtl.pad %ui, 13 : !firrtl.uint
+    %11 = firrtl.pad %si, 13 : !firrtl.sint
+    %12 = firrtl.pad %ui, 99 : !firrtl.uint
+    %13 = firrtl.pad %si, 99 : !firrtl.sint
 
     firrtl.connect %0, %4 : !firrtl.uint, !firrtl.uint<3>
     firrtl.connect %1, %5 : !firrtl.uint, !firrtl.uint<3>
@@ -356,11 +325,10 @@ firrtl.circuit "Foo" {
     // CHECK: %0 = firrtl.wire : !firrtl.uint<2>
     // CHECK: %1 = firrtl.wire : !firrtl.uint<3>
     // CHECK: %2 = firrtl.wire : !firrtl.uint<0>
-    // CHECK: %3 = firrtl.mux{{.*}} -> !firrtl.uint<3>
     %0 = firrtl.wire : !firrtl.uint
     %1 = firrtl.wire : !firrtl.uint
     %2 = firrtl.wire : !firrtl.uint
-    %3 = firrtl.mux(%2, %0, %1) : (!firrtl.uint, !firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %3 = firrtl.mux(%2, %0, %1) : !firrtl.uint, !firrtl.uint, !firrtl.uint
     %c1_ui2 = firrtl.constant 1 : !firrtl.uint<2>
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
     %c0_ui0 = firrtl.constant 0 : !firrtl.uint<0>
@@ -377,8 +345,8 @@ firrtl.circuit "Foo" {
     %0 = firrtl.subfield %w[a] : !firrtl.bundle<a: uint>
     %1 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<8>>
     firrtl.connect %0, %1 : !firrtl.uint, !firrtl.uint<8>
-    // CHECK: %2 = firrtl.mux(%p, %a, %w) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>) -> !firrtl.bundle<a: uint<8>>
-    %2 = firrtl.mux(%p, %a, %w) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint>) -> !firrtl.bundle<a: uint>
+    // CHECK: %2 = firrtl.mux(%p, %a, %w) : !firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint<8>>
+    %2 = firrtl.mux(%p, %a, %w) : !firrtl.uint<1>, !firrtl.bundle<a: uint<8>>, !firrtl.bundle<a: uint>
     firrtl.connect %c, %2 : !firrtl.bundle<a: uint>, !firrtl.bundle<a: uint>
   }
 
@@ -393,12 +361,12 @@ firrtl.circuit "Foo" {
     %ui = firrtl.wire : !firrtl.uint
     %si = firrtl.wire : !firrtl.sint
 
-    %0 = firrtl.shl %ui, 3 : (!firrtl.uint) -> !firrtl.uint
-    %1 = firrtl.shl %si, 3 : (!firrtl.sint) -> !firrtl.sint
-    %2 = firrtl.shr %ui, 3 : (!firrtl.uint) -> !firrtl.uint
-    %3 = firrtl.shr %si, 3 : (!firrtl.sint) -> !firrtl.sint
-    %4 = firrtl.shr %ui, 9 : (!firrtl.uint) -> !firrtl.uint
-    %5 = firrtl.shr %si, 9 : (!firrtl.sint) -> !firrtl.sint
+    %0 = firrtl.shl %ui, 3 : !firrtl.uint
+    %1 = firrtl.shl %si, 3 : !firrtl.sint
+    %2 = firrtl.shr %ui, 3 : !firrtl.uint
+    %3 = firrtl.shr %si, 3 : !firrtl.sint
+    %4 = firrtl.shr %ui, 9 : !firrtl.uint
+    %5 = firrtl.shr %si, 9 : !firrtl.sint
 
     %c0_ui5 = firrtl.constant 0 : !firrtl.uint<5>
     %c0_si5 = firrtl.constant 0 : !firrtl.sint<5>
@@ -466,8 +434,8 @@ firrtl.circuit "Foo" {
   firrtl.module @Issue1088(out %y: !firrtl.sint<4>) {
     // CHECK: %x = firrtl.wire : !firrtl.sint<9>
     // CHECK: %c200_si9 = firrtl.constant 200 : !firrtl.sint<9>
-    // CHECK: %0 = firrtl.tail %x, 5 : (!firrtl.sint<9>) -> !firrtl.uint<4>
-    // CHECK: %1 = firrtl.asSInt %0 : (!firrtl.uint<4>) -> !firrtl.sint<4>
+    // CHECK: %0 = firrtl.tail %x, 5 : !firrtl.sint<9>
+    // CHECK: %1 = firrtl.asSInt %0 : !firrtl.uint<4>
     // CHECK: firrtl.connect %y, %1 : !firrtl.sint<4>
     // CHECK: firrtl.connect %x, %c200_si9 : !firrtl.sint<9>
     %x = firrtl.wire : !firrtl.sint
@@ -483,7 +451,7 @@ firrtl.circuit "Foo" {
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     firrtl.connect %w, %c1_ui1 : !firrtl.uint, !firrtl.uint<1>
     %w1 = firrtl.wire  : !firrtl.uint<0>
-    // CHECK: %0 = firrtl.tail %w, 1 : (!firrtl.uint<1>) -> !firrtl.uint<0>
+    // CHECK: %0 = firrtl.tail %w, 1 : !firrtl.uint<1>
     // CHECK: firrtl.connect %w1, %0 : !firrtl.uint<0>
     firrtl.connect %w1, %w : !firrtl.uint<0>, !firrtl.uint
   }
@@ -500,7 +468,7 @@ firrtl.circuit "Foo" {
   // CHECK-SAME: out %x: !firrtl.sint<13>
   firrtl.module @Issue1118(out %x: !firrtl.sint) {
     %c4232_ui = firrtl.constant 4232 : !firrtl.uint
-    %0 = firrtl.asSInt %c4232_ui : (!firrtl.uint) -> !firrtl.sint
+    %0 = firrtl.asSInt %c4232_ui : !firrtl.uint
     firrtl.connect %x, %0 : !firrtl.sint, !firrtl.sint
   }
 
@@ -511,7 +479,7 @@ firrtl.circuit "Foo" {
     %0 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
     %1 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
     %2 = firrtl.wire : !firrtl.uint
-    %3 = firrtl.xor %1, %2 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %3 = firrtl.xor %1, %2 : !firrtl.uint, !firrtl.uint
     firrtl.connect %0, %x : !firrtl.uint, !firrtl.uint<6>
     firrtl.connect %1, %3 : !firrtl.uint, !firrtl.uint
     firrtl.connect %2, %x : !firrtl.uint, !firrtl.uint<6>
@@ -523,8 +491,8 @@ firrtl.circuit "Foo" {
     // CHECK: %1 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint<6>
     %0 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
     %1 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
-    %2 = firrtl.shr %0, 0 : (!firrtl.uint) -> !firrtl.uint
-    %3 = firrtl.shr %1, 3 : (!firrtl.uint) -> !firrtl.uint
+    %2 = firrtl.shr %0, 0 : !firrtl.uint
+    %3 = firrtl.shr %1, 3 : !firrtl.uint
     firrtl.connect %0, %x : !firrtl.uint, !firrtl.uint<6>
     firrtl.connect %1, %x : !firrtl.uint, !firrtl.uint<6>
     firrtl.connect %0, %2 : !firrtl.uint, !firrtl.uint
@@ -537,11 +505,11 @@ firrtl.circuit "Foo" {
     %0 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
     %1 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
     %2 = firrtl.reg %clk : !firrtl.clock, !firrtl.uint
-    %3 = firrtl.shl %0, 0 : (!firrtl.uint) -> !firrtl.uint
-    %4 = firrtl.shl %1, 3 : (!firrtl.uint) -> !firrtl.uint
-    %5 = firrtl.shr %4, 3 : (!firrtl.uint) -> !firrtl.uint
-    %6 = firrtl.shr %1, 3 : (!firrtl.uint) -> !firrtl.uint
-    %7 = firrtl.shl %6, 3 : (!firrtl.uint) -> !firrtl.uint
+    %3 = firrtl.shl %0, 0 : !firrtl.uint
+    %4 = firrtl.shl %1, 3 : !firrtl.uint
+    %5 = firrtl.shr %4, 3 : !firrtl.uint
+    %6 = firrtl.shr %1, 3 : !firrtl.uint
+    %7 = firrtl.shl %6, 3 : !firrtl.uint
     firrtl.connect %0, %x : !firrtl.uint, !firrtl.uint<6>
     firrtl.connect %1, %x : !firrtl.uint, !firrtl.uint<6>
     firrtl.connect %2, %x : !firrtl.uint, !firrtl.uint<6>
@@ -567,7 +535,7 @@ firrtl.circuit "Foo" {
     %2:2 = firrtl.regreset %clk, %rst, %c0_ui17 forceable : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint, !firrtl.rwprobe<uint>
     %3 = firrtl.regreset %clk, %rst, %c0_ui17 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<17>, !firrtl.uint
     %4 = firrtl.wire : !firrtl.uint
-    %5 = firrtl.xor %1, %4 : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %5 = firrtl.xor %1, %4 : !firrtl.uint, !firrtl.uint
     firrtl.connect %0, %x : !firrtl.uint, !firrtl.uint<6>
     firrtl.connect %1, %5 : !firrtl.uint, !firrtl.uint
     firrtl.connect %2, %x : !firrtl.uint, !firrtl.uint<6>
@@ -583,12 +551,12 @@ firrtl.circuit "Foo" {
   // CHECK-SAME: in %in: !firrtl.uint<42>
   // CHECK-SAME: out %out: !firrtl.uint<44>
   firrtl.module @InterModuleSimpleFoo(in %in: !firrtl.uint, out %out: !firrtl.uint) {
-    %0 = firrtl.add %in, %in : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %0 = firrtl.add %in, %in : !firrtl.uint, !firrtl.uint
     firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
   }
   firrtl.module @InterModuleSimpleBar(in %in: !firrtl.uint<42>, out %out: !firrtl.uint) {
     %inst_in, %inst_out = firrtl.instance inst @InterModuleSimpleFoo(in in: !firrtl.uint, out out: !firrtl.uint)
-    %0 = firrtl.add %inst_out, %inst_out : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %0 = firrtl.add %inst_out, %inst_out : !firrtl.uint, !firrtl.uint
     firrtl.connect %inst_in, %in : !firrtl.uint, !firrtl.uint<42>
     firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
   }
@@ -602,13 +570,13 @@ firrtl.circuit "Foo" {
   // CHECK-SAME: in %in2: !firrtl.uint<42>
   // CHECK-SAME: out %out: !firrtl.uint<43>
   firrtl.module @InterModuleMultipleFoo(in %in: !firrtl.uint, out %out: !firrtl.uint) {
-    %0 = firrtl.add %in, %in : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %0 = firrtl.add %in, %in : !firrtl.uint, !firrtl.uint
     firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
   }
   firrtl.module @InterModuleMultipleBar(in %in1: !firrtl.uint<17>, in %in2: !firrtl.uint<42>, out %out: !firrtl.uint) {
     %inst1_in, %inst1_out = firrtl.instance inst1 @InterModuleMultipleFoo(in in: !firrtl.uint, out out: !firrtl.uint)
     %inst2_in, %inst2_out = firrtl.instance inst2 @InterModuleMultipleFoo(in in: !firrtl.uint, out out: !firrtl.uint)
-    %0 = firrtl.xor %inst1_out, %inst2_out : (!firrtl.uint, !firrtl.uint) -> !firrtl.uint
+    %0 = firrtl.xor %inst1_out, %inst2_out : !firrtl.uint, !firrtl.uint
     firrtl.connect %inst1_in, %in1 : !firrtl.uint, !firrtl.uint<17>
     firrtl.connect %inst2_in, %in2 : !firrtl.uint, !firrtl.uint<42>
     firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
@@ -821,7 +789,7 @@ firrtl.circuit "Foo" {
   // CHECK-SAME: in %in: !firrtl.uint<42>
   // CHECK-SAME: out %out: !firrtl.uint<39>
   firrtl.module @InterModuleGoodCycleFoo(in %in: !firrtl.uint, out %out: !firrtl.uint) {
-    %0 = firrtl.shr %in, 3 : (!firrtl.uint) -> !firrtl.uint
+    %0 = firrtl.shr %in, 3 : !firrtl.uint
     firrtl.connect %out, %0 : !firrtl.uint, !firrtl.uint
   }
   // CHECK-LABEL: @InterModuleGoodCycleBar
@@ -840,12 +808,12 @@ firrtl.circuit "Foo" {
     // CHECK: %c = firrtl.node %1  : !firrtl.uint<2>
     %a = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %0 = firrtl.add %a, %c0_ui1 : (!firrtl.uint, !firrtl.uint<1>) -> !firrtl.uint
+    %0 = firrtl.add %a, %c0_ui1 : !firrtl.uint, !firrtl.uint<1>
     %b = firrtl.node %0  : !firrtl.uint
-    %1 = firrtl.tail %b, 1 : (!firrtl.uint) -> !firrtl.uint
+    %1 = firrtl.tail %b, 1 : !firrtl.uint
     %c = firrtl.node %1  : !firrtl.uint
     %c0_ui2 = firrtl.constant 0 : !firrtl.uint<2>
-    %2 = firrtl.mux(%cond, %c0_ui2, %c) : (!firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint) -> !firrtl.uint
+    %2 = firrtl.mux(%cond, %c0_ui2, %c) : !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint
     firrtl.connect %a, %2 : !firrtl.uint, !firrtl.uint
   }
 
@@ -958,13 +926,13 @@ firrtl.circuit "Foo" {
     firrtl.connect %sel, %sel_0w : !firrtl.uint, !firrtl.uint<0>
     // CHECK: firrtl.int.mux2cell
     // CHECK-SAME: (!firrtl.uint<0>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %0 = firrtl.int.mux2cell(%sel, %c0_ui1, %c1) : (!firrtl.uint, !firrtl.uint<1>, !firrtl.uint) -> !firrtl.uint
+    %0 = firrtl.int.mux2cell(%sel, %c0_ui1, %c1) : !firrtl.uint, !firrtl.uint<1>, !firrtl.uint
     firrtl.connect %out1, %0: !firrtl.uint, !firrtl.uint
     %sel2 = firrtl.wire : !firrtl.uint
     firrtl.connect %sel2, %sel_1w : !firrtl.uint, !firrtl.uint<1>
     // CHECK: firrtl.int.mux4cell
     // CHECK-SAME: (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<3>, !firrtl.uint<1>) -> !firrtl.uint<3>
-    %1 = firrtl.int.mux4cell(%sel2, %c1_ui1, %c2_ui2, %c3_ui3, %c1) : (!firrtl.uint, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<3>, !firrtl.uint) -> !firrtl.uint
+    %1 = firrtl.int.mux4cell(%sel2, %c1_ui1, %c2_ui2, %c3_ui3, %c1) : !firrtl.uint, !firrtl.uint<1>, !firrtl.uint<2>, !firrtl.uint<3>, !firrtl.uint
     firrtl.connect %out2, %1: !firrtl.uint, !firrtl.uint
   }
 

--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -26,27 +26,27 @@ firrtl.circuit "TLRAM" {
       firrtl.connect %7, %data_0 : !firrtl.uint<8>, !firrtl.uint<8>
       %8 = firrtl.subfield %mem_0_MPORT_1[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<1>>
       firrtl.connect %8, %_T_29 : !firrtl.uint<1>, !firrtl.uint<1>
-      %9 = firrtl.not %wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+      %9 = firrtl.not %wen : !firrtl.uint<1>
       firrtl.connect %mem_MPORT_en, %9 : !firrtl.uint<1>, !firrtl.uint<1>
       %REG = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
       firrtl.connect %REG, %9 : !firrtl.uint<1>, !firrtl.uint<1>
       %r_0 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<8>
-      %10 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+      %10 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
       firrtl.connect %r_0, %10 : !firrtl.uint<8>, !firrtl.uint<8>
-      %11 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+      %11 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
       firrtl.connect %auto_0, %11 : !firrtl.uint<8>, !firrtl.uint<8>
 
 // CHECK: %mem_0_dbgs, %mem_0_rw = firrtl.mem  Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["dbgs", "rw"], prefix = "foo_", readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.probe<vector<uint<8>, 16>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
-// CHECK:  %[[v7:.+]] = firrtl.mux(%[[writeEnable:.+]], %[[writeAddr:.+]], %[[readAddr:.+]]) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+// CHECK:  %[[v7:.+]] = firrtl.mux(%[[writeEnable:.+]], %[[writeAddr:.+]], %[[readAddr:.+]]) : !firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK:  firrtl.matchingconnect %[[v0:.+]], %[[v7]] : !firrtl.uint<4>
-// CHECK:  %[[v8:.+]] = firrtl.or %[[readEnable:.+]], %[[writeEnable]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:  %[[v8:.+]] = firrtl.or %[[readEnable:.+]], %[[writeEnable]] : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK:  firrtl.matchingconnect %[[v1:.+]], %[[v8]] : !firrtl.uint<1>
 // CHECK:  firrtl.ref.define %dbg_0, %mem_0_dbgs : !firrtl.probe<vector<uint<8>, 16>>
 // CHECK:  firrtl.connect %[[readAddr]], %[[index2:.+]] : !firrtl.uint<4>
 // CHECK:  firrtl.connect %[[readEnable]], %mem_MPORT_en : !firrtl.uint<1>
 // CHECK:  firrtl.connect %[[writeAddr]], %index : !firrtl.uint<4>
 // CHECK:  firrtl.connect %[[writeEnable]], %wen : !firrtl.uint<1>
-// CHECK:  %[[v10:.+]] = firrtl.not %wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:  %[[v10:.+]] = firrtl.not %wen : !firrtl.uint<1>
 // CHECK:  firrtl.connect %mem_MPORT_en, %[[v10]] : !firrtl.uint<1>
 // CHECK:  firrtl.matchingconnect %[[v4:.+]], %wen : !firrtl.uint<1>
     }
@@ -72,8 +72,8 @@ firrtl.circuit "TLRAM" {
     firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %4, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %3, %io_dataIn : !firrtl.uint<32>, !firrtl.uint<32>
-    %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %10 = firrtl.mux(%9, %io_ren, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %9 = firrtl.not %io_wen : !firrtl.uint<1>
+    %10 = firrtl.mux(%9, %io_ren, %c0_ui1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %6, %10 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
     firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
@@ -88,9 +88,9 @@ firrtl.circuit "TLRAM" {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %mem__T_14, %mem__T_22 = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["_T_14", "_T_22"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>, !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
 // CHECK: %mem_rw = firrtl.mem Undefined  {depth = 2048 : i64, name = "mem", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
-// CHECK:   %[[v7:.+]] = firrtl.mux(%writeEnable, %writeAddr, %readAddr) : (!firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<11>) -> !firrtl.uint<11>
+// CHECK:   %[[v7:.+]] = firrtl.mux(%writeEnable, %writeAddr, %readAddr) : !firrtl.uint<1>, !firrtl.uint<11>, !firrtl.uint<11>
 // CHECK:   firrtl.matchingconnect %[[v0:.+]], %[[v7]]
-// CHECK:   %[[v8:.+]] = firrtl.or %readEnable, %writeEnable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK:   %[[v8:.+]] = firrtl.or %readEnable, %writeEnable : !firrtl.uint<1>, !firrtl.uint<1>
     %0 = firrtl.subfield %mem__T_14[addr] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     %1 = firrtl.subfield %mem__T_14[en] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     %2 = firrtl.subfield %mem__T_14[clk] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
@@ -100,16 +100,16 @@ firrtl.circuit "TLRAM" {
     %6 = firrtl.subfield %mem__T_22[en] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
     %7 = firrtl.subfield %mem__T_22[clk] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
     %8 = firrtl.subfield %mem__T_22[data] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
-    %9 = firrtl.and %io_valid, %io_write : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %10 = firrtl.not %io_write : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %11 = firrtl.and %io_valid, %10 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %9 = firrtl.and %io_valid, %io_write : !firrtl.uint<1>, !firrtl.uint<1>
+    %10 = firrtl.not %io_write : !firrtl.uint<1>
+    %11 = firrtl.and %io_valid, %10 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %0, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
     firrtl.connect %1, %9 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %4, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %3, %io_dataIn : !firrtl.uint<32>, !firrtl.uint<32>
-    %12 = firrtl.not %9 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %13 = firrtl.mux(%12, %11, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %12 = firrtl.not %9 : !firrtl.uint<1>
+    %13 = firrtl.mux(%12, %11, %c0_ui1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %6, %13 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
     firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
@@ -133,16 +133,16 @@ firrtl.circuit "TLRAM" {
     %6 = firrtl.subfield %mem__T_22[en] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
     %7 = firrtl.subfield %mem__T_22[clk] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
     %8 = firrtl.subfield %mem__T_22[data] : !firrtl.bundle<addr: uint<11>, en: uint<1>, clk: clock, data flip: uint<32>>
-    %9 = firrtl.and %io_valid, %io_write : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %10 = firrtl.not %io_write : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %11 = firrtl.and %io_valid, %10 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %9 = firrtl.and %io_valid, %io_write : !firrtl.uint<1>, !firrtl.uint<1>
+    %10 = firrtl.not %io_write : !firrtl.uint<1>
+    %11 = firrtl.and %io_valid, %10 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %0, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
     firrtl.connect %1, %9 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %4, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %3, %io_dataIn : !firrtl.uint<32>, !firrtl.uint<32>
-    %12 = firrtl.not %9 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %13 = firrtl.mux(%12, %11, %c1_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %12 = firrtl.not %9 : !firrtl.uint<1>
+    %13 = firrtl.mux(%12, %11, %c1_ui1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %6, %13 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
     firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
@@ -164,15 +164,15 @@ firrtl.circuit "TLRAM" {
     %6 = firrtl.subfield %mem_T_5[clk] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     %7 = firrtl.subfield %mem_T_5[data] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     %8 = firrtl.subfield %mem_T_5[mask] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
-    %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %10 = firrtl.and %io_en, %9 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %9 = firrtl.not %io_wen : !firrtl.uint<1>
+    %10 = firrtl.and %io_en, %9 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %1, %10 : !firrtl.uint<1>, !firrtl.uint<1>
-    %11 = firrtl.bits %io_raddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
+    %11 = firrtl.bits %io_raddr 6 to 0 : !firrtl.uint<8>
     firrtl.connect %0, %11 : !firrtl.uint<7>, !firrtl.uint<7>
     firrtl.connect %2, %clk1 : !firrtl.clock, !firrtl.clock
     firrtl.connect %io_rdata, %3 : !firrtl.uint<32>, !firrtl.uint<32>
-    %12 = firrtl.and %io_en, %io_wen : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %13 = firrtl.bits %io_waddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
+    %12 = firrtl.and %io_en, %io_wen : !firrtl.uint<1>, !firrtl.uint<1>
+    %13 = firrtl.bits %io_waddr 6 to 0 : !firrtl.uint<8>
     firrtl.connect %4, %13 : !firrtl.uint<7>, !firrtl.uint<7>
     firrtl.connect %5, %12 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %6, %clk2 : !firrtl.clock, !firrtl.clock
@@ -195,15 +195,15 @@ firrtl.circuit "TLRAM" {
     %6 = firrtl.subfield %mem_T_5[clk] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     %7 = firrtl.subfield %mem_T_5[data] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     %8 = firrtl.subfield %mem_T_5[mask] : !firrtl.bundle<addr: uint<7>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
-    %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %10 = firrtl.and %io_en, %9 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %9 = firrtl.not %io_wen : !firrtl.uint<1>
+    %10 = firrtl.and %io_en, %9 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %1, %10 : !firrtl.uint<1>, !firrtl.uint<1>
-    %11 = firrtl.bits %io_raddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
+    %11 = firrtl.bits %io_raddr 6 to 0 : !firrtl.uint<8>
     firrtl.connect %0, %11 : !firrtl.uint<7>, !firrtl.uint<7>
     firrtl.connect %2, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %io_rdata, %3 : !firrtl.uint<32>, !firrtl.uint<32>
-    %12 = firrtl.and %io_en, %io_wen : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    %13 = firrtl.bits %io_waddr 6 to 0 : (!firrtl.uint<8>) -> !firrtl.uint<7>
+    %12 = firrtl.and %io_en, %io_wen : !firrtl.uint<1>, !firrtl.uint<1>
+    %13 = firrtl.bits %io_waddr 6 to 0 : !firrtl.uint<8>
     firrtl.connect %4, %13 : !firrtl.uint<7>, !firrtl.uint<7>
     firrtl.connect %5, %12 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %6, %clock : !firrtl.clock, !firrtl.clock
@@ -235,8 +235,8 @@ firrtl.circuit "TLRAM" {
     firrtl.connect %xc, %clock : !firrtl.clock, !firrtl.clock
     firrtl.connect %4, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %3, %io_dataIn : !firrtl.uint<32>, !firrtl.uint<32>
-    %9 = firrtl.not %io_wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
-    %10 = firrtl.mux(%9, %io_ren, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    %9 = firrtl.not %io_wen : !firrtl.uint<1>
+    %10 = firrtl.mux(%9, %io_ren, %c0_ui1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %6, %10 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %5, %io_addr : !firrtl.uint<11>, !firrtl.uint<11>
     firrtl.connect %7, %clock : !firrtl.clock, !firrtl.clock
@@ -271,14 +271,14 @@ firrtl.circuit "TLRAM" {
       %8 = firrtl.subfield %mem_0_MPORT_1[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>
       %c1 = firrtl.constant 3 : !firrtl.uint<2>
       firrtl.connect %8, %c1 : !firrtl.uint<2>, !firrtl.uint<2>
-      %9 = firrtl.not %wen : (!firrtl.uint<1>) -> !firrtl.uint<1>
+      %9 = firrtl.not %wen : !firrtl.uint<1>
       firrtl.connect %mem_MPORT_en, %9 : !firrtl.uint<1>, !firrtl.uint<1>
       %REG = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
       firrtl.connect %REG, %9 : !firrtl.uint<1>, !firrtl.uint<1>
       %r_0 = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<8>
-      %10 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+      %10 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
       firrtl.connect %r_0, %10 : !firrtl.uint<8>, !firrtl.uint<8>
-      %11 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
+      %11 = firrtl.mux(%REG, %mem_MPORT_data_0, %r_0) : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
       firrtl.connect %auto_0, %11 : !firrtl.uint<8>, !firrtl.uint<8>
 
     }
@@ -286,7 +286,7 @@ firrtl.circuit "TLRAM" {
     // CHECK-LABEL: firrtl.module @SimplifyWMODE
     firrtl.module @SimplifyWMODE(in %rwPort_enable: !firrtl.uint<1>, in %rwPort_isWrite: !firrtl.uint<1>) attributes {} {
       %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-      %18 = firrtl.mux(%rwPort_enable, %rwPort_isWrite, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      %18 = firrtl.mux(%rwPort_enable, %rwPort_isWrite, %c0_ui1) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
       // CHECK: %[[c1_ui1:.+]] = firrtl.constant 1 : !firrtl.uint<1>
       // CHECK: %[[v7:.+]] = firrtl.mux(%[[c1_ui1]], %rwPort_isWrite, %c0_ui1)
       %mem_rwPort_readData_rw = firrtl.mem Undefined {depth = 64 : i64, name = "t", portNames = ["rw"], prefix = "", readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<6>, en: uint<1>, clk: clock, rdata flip: uint<10>, wmode: uint<1>, wdata: uint<10>, wmask: uint<5>>
@@ -311,13 +311,13 @@ firrtl.circuit "TLRAM" {
     %syncreadmem_singleport_readwritePortA_readData_rw_wmask_x = firrtl.wire : !firrtl.uint<1>
     %syncreadmem_singleport_readwritePortA_readData_rw_wmask_y = firrtl.wire : !firrtl.uint<1>
     %9 = firrtl.subfield %syncreadmem_singleport_readwritePortA_readData_rw[wmask] : !firrtl.bundle<addr: uint<6>, en: uint<1>, clk: clock, rdata flip: uint<10>, wmode: uint<1>, wdata: uint<10>, wmask: uint<5>>
-    %10 = firrtl.cat %syncreadmem_singleport_readwritePortA_readData_rw_wmask_y, %syncreadmem_singleport_readwritePortA_readData_rw_wmask_x : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-    %11 = firrtl.bits %10 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-    %12 = firrtl.cat %11, %11 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-    %13 = firrtl.cat %11, %12 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<3>
-    %14 = firrtl.bits %10 1 to 1 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-    %15 = firrtl.cat %14, %13 : (!firrtl.uint<1>, !firrtl.uint<3>) -> !firrtl.uint<4>
-    %16 = firrtl.cat %14, %15 : (!firrtl.uint<1>, !firrtl.uint<4>) -> !firrtl.uint<5>
+    %10 = firrtl.cat %syncreadmem_singleport_readwritePortA_readData_rw_wmask_y, %syncreadmem_singleport_readwritePortA_readData_rw_wmask_x : !firrtl.uint<1>, !firrtl.uint<1>
+    %11 = firrtl.bits %10 0 to 0 : !firrtl.uint<2>
+    %12 = firrtl.cat %11, %11 : !firrtl.uint<1>, !firrtl.uint<1>
+    %13 = firrtl.cat %11, %12 : !firrtl.uint<1>, !firrtl.uint<2>
+    %14 = firrtl.bits %10 1 to 1 : !firrtl.uint<2>
+    %15 = firrtl.cat %14, %13 : !firrtl.uint<1>, !firrtl.uint<3>
+    %16 = firrtl.cat %14, %15 : !firrtl.uint<1>, !firrtl.uint<4>
     firrtl.matchingconnect %9, %16 : !firrtl.uint<5>
     firrtl.connect %syncreadmem_singleport_readwritePortA_readData_rw_wmask_x, %readwritePortA_isWrite_2 : !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %syncreadmem_singleport_readwritePortA_readData_rw_wmask_y, %readwritePortA_isWrite_2 : !firrtl.uint<1>, !firrtl.uint<1>
@@ -339,7 +339,7 @@ firrtl.circuit "TLRAM" {
       // CHECK-SAME:   mask: uint<1>
       %0 = firrtl.subfield %mem_w[mask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<2>, mask: uint<2>>
       %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-      %1 = firrtl.cat %c1_ui1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+      %1 = firrtl.cat %c1_ui1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.matchingconnect %0, %1 : !firrtl.uint<2>
     }
   }

--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -182,9 +182,9 @@ firrtl.circuit "TestConnections" {
 firrtl.module @InlineMe0(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>,
                          out %out0: !firrtl.uint<4>, out %out1: !firrtl.uint<4>)
         attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
-  %0 = firrtl.and %in0, %in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %0 = firrtl.and %in0, %in1 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out0, %0 : !firrtl.uint<4>, !firrtl.uint<4>
-  %1 = firrtl.and %in0, %in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+  %1 = firrtl.and %in0, %in1 : !firrtl.uint<4>, !firrtl.uint<4>
   firrtl.connect %out1, %1 : !firrtl.uint<4>, !firrtl.uint<4>
 }
 firrtl.module @InlineMe1(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4>,
@@ -214,9 +214,9 @@ firrtl.module @TestConnections(in %in0: !firrtl.uint<4>, in %in1: !firrtl.uint<4
 // CHECK-NEXT:   %b_a_in1 = firrtl.wire  : !firrtl.uint<4>
 // CHECK-NEXT:   %b_a_out0 = firrtl.wire  : !firrtl.uint<4>
 // CHECK-NEXT:   %b_a_out1 = firrtl.wire  : !firrtl.uint<4>
-// CHECK-NEXT:   %0 = firrtl.and %b_a_in0, %b_a_in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+// CHECK-NEXT:   %0 = firrtl.and %b_a_in0, %b_a_in1 : !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK-NEXT:   firrtl.connect %b_a_out0, %0 : !firrtl.uint<4>
-// CHECK-NEXT:   %1 = firrtl.and %b_a_in0, %b_a_in1 : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
+// CHECK-NEXT:   %1 = firrtl.and %b_a_in0, %b_a_in1 : !firrtl.uint<4>, !firrtl.uint<4>
 // CHECK-NEXT:   firrtl.connect %b_a_out1, %1 : !firrtl.uint<4>
 // CHECK-NEXT:   firrtl.connect %b_a_in0, %b_in0 : !firrtl.uint<4>
 // CHECK-NEXT:   firrtl.connect %b_a_in1, %b_in1 : !firrtl.uint<4>
@@ -1327,7 +1327,7 @@ firrtl.circuit "MatchInline" attributes {enable_layers = [@I]} {
   firrtl.module private @MatchAgain(in %i: !firrtl.enum<Some: uint<8>, None: uint<0>>, out %o: !firrtl.uint<8>) attributes {annotations = [{class = "firrtl.passes.InlineAnnotation"}]} {
     firrtl.match %i : !firrtl.enum<Some: uint<8>, None: uint<0>> {
       case Some(%arg0) {
-        %not = firrtl.not %arg0 : (!firrtl.uint<8>) -> !firrtl.uint<8>
+        %not = firrtl.not %arg0 : !firrtl.uint<8>
         firrtl.matchingconnect %o, %not : !firrtl.uint<8>
       }
       case None(%arg0) {

--- a/test/Dialect/FIRRTL/layer-sink.mlir
+++ b/test/Dialect/FIRRTL/layer-sink.mlir
@@ -13,7 +13,7 @@ firrtl.circuit "SimpleSink" {
  firrtl.module @SimpleSink(in %a: !firrtl.uint<1>) {
    %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
    %node = firrtl.node %a : !firrtl.uint<1>
-   %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
+   %0 = firrtl.not %a : !firrtl.uint<1>
    // CHECK-NEXT: firrtl.layerblock @A
    firrtl.layerblock @A {
      // CHECK: %c0_ui1 = firrtl.constant

--- a/test/Dialect/FIRRTL/lint.mlir
+++ b/test/Dialect/FIRRTL/lint.mlir
@@ -3,7 +3,7 @@
 firrtl.circuit "lint_tests" {
   // CHECK: firrtl.module @lint_tests
   firrtl.module @lint_tests(in %en: !firrtl.uint<1>, in %pred: !firrtl.uint<1>, in %reset: !firrtl.reset, in %clock: !firrtl.clock) {
-    %0 = firrtl.asUInt %reset : (!firrtl.reset) -> !firrtl.uint<1>
+    %0 = firrtl.asUInt %reset : !firrtl.reset
     // CHECK: firrtl.assert
     firrtl.assert %clock, %pred, %en, "valid" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>  {eventControl = 0 : i32, isConcurrent = false}
     // CHECK: firrtl.assert
@@ -37,7 +37,7 @@ firrtl.circuit "assert_const" {
 firrtl.circuit "assert_reset" {
   // expected-note @below {{reset signal defined here}}
   firrtl.module @assert_reset(in %en: !firrtl.uint<1>, in %pred: !firrtl.uint<1>, in %reset: !firrtl.reset, in %reset_async: !firrtl.asyncreset, in %clock: !firrtl.clock) {
-    %0 = firrtl.asUInt %reset : (!firrtl.reset) -> !firrtl.uint<1>
+    %0 = firrtl.asUInt %reset : !firrtl.reset
     %true = firrtl.constant 1 : !firrtl.uint<1>
     %false = firrtl.constant 0 : !firrtl.uint<1>
     // expected-error @below {{op is guaranteed to fail simulation, as the predicate is a reset signal}}
@@ -61,7 +61,7 @@ firrtl.circuit "assert_const2" {
 firrtl.circuit "assert_reset2" {
   // expected-note @below {{reset signal defined here}}
   firrtl.module @assert_reset2(in %en: !firrtl.uint<1>, in %pred: !firrtl.uint<1>, in %reset: !firrtl.reset, in %reset_async: !firrtl.asyncreset, in %clock: !firrtl.clock) {
-    %0 = firrtl.asUInt %reset : (!firrtl.reset) -> !firrtl.uint<1>
+    %0 = firrtl.asUInt %reset : !firrtl.reset
     // expected-error @below {{op is guaranteed to fail simulation, as the predicate is a reset signal}}
     firrtl.int.verif.assert %0 : !firrtl.uint<1>
   }
@@ -73,7 +73,7 @@ firrtl.circuit "assert_reset3" {
 firrtl.layer @GroupFoo bind {}
   // expected-note @below {{reset signal defined here}}
   firrtl.module @assert_reset3(in %en: !firrtl.uint<1>, in %pred: !firrtl.uint<1>, in %reset: !firrtl.reset, in %reset_async: !firrtl.asyncreset, in %clock: !firrtl.clock) {
-    %0 = firrtl.asUInt %reset : (!firrtl.reset) -> !firrtl.uint<1>
+    %0 = firrtl.asUInt %reset : !firrtl.reset
     firrtl.layerblock @GroupFoo {
       // expected-error @below {{op is guaranteed to fail simulation, as the predicate is a reset signal}}
       firrtl.int.verif.assert %0 : !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -386,16 +386,16 @@ firrtl.circuit "IntegerArithmetic" {
 
   firrtl.class @IntegerArithmeticClass(in %in0: !firrtl.integer, in %in1: !firrtl.integer) {
     // CHECK: om.integer.add %in0, %in1 : !om.integer
-    %0 = firrtl.integer.add %in0, %in1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+    %0 = firrtl.integer.add %in0, %in1 : !firrtl.integer, !firrtl.integer
 
     // CHECK: om.integer.mul %in0, %in1 : !om.integer
-    %1 = firrtl.integer.mul %in0, %in1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+    %1 = firrtl.integer.mul %in0, %in1 : !firrtl.integer, !firrtl.integer
 
     // CHECK: om.integer.shr %in0, %in1 : !om.integer
-    %2 = firrtl.integer.shr %in0, %in1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+    %2 = firrtl.integer.shr %in0, %in1 : !firrtl.integer, !firrtl.integer
 
     // CHECK: om.integer.shl %in0, %in1 : !om.integer
-    %3 = firrtl.integer.shl %in0, %in1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+    %3 = firrtl.integer.shl %in0, %in1 : !firrtl.integer, !firrtl.integer
   }
 }
 

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -83,7 +83,7 @@ firrtl.circuit "Test" {
   //===--------------------------------------------------------------------===//
 
   // CHECK: firrtl.module private @[[A:.+]](in %[[x:.+]]: !firrtl.uint<1>, in %[[y:.+]]: !firrtl.uint<1>)
-  // CHECK:   %0 = firrtl.add %[[x]], %[[y]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+  // CHECK:   %0 = firrtl.add %[[x]], %[[y]] : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: }
   // CHECK: firrtl.module @CaptureHardware() {
   // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -96,7 +96,7 @@ firrtl.circuit "Test" {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
     firrtl.layerblock @A {
-      %0 = firrtl.add %c0_ui1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+      %0 = firrtl.add %c0_ui1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     }
   }
 
@@ -152,7 +152,7 @@ firrtl.circuit "Test" {
   }
 
   // CHECK: firrtl.module private @[[B:.+]](in %[[p:.+]]: !firrtl.uint<1>, in %[[q:.+]]: !firrtl.uint<1>)
-  // CHECK:   %0 = firrtl.add %[[p]], %[[q]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+  // CHECK:   %0 = firrtl.add %[[p]], %[[q]] : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: }
   // CHECK: firrtl.module private @[[A:.+]](out %[[p:.+]]: !firrtl.probe<uint<1>>, out %[[q:.+]]: !firrtl.probe<uint<1>>) attributes {
   // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -175,7 +175,7 @@ firrtl.circuit "Test" {
       %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
       %c1_ui1 = firrtl.constant 0 : !firrtl.uint<1>
       firrtl.layerblock @A::@B {
-        %0 = firrtl.add %c0_ui1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+        %0 = firrtl.add %c0_ui1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
       }
     }
   }
@@ -183,7 +183,7 @@ firrtl.circuit "Test" {
   // CHECK: firrtl.module private @[[A:.+]](in %[[p:.+]]: !firrtl.uint<1>)
   // CHECK:   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK:   firrtl.when %[[p]] : !firrtl.uint<1> {
-  // CHECK:     %0 = firrtl.add %[[p]], %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+  // CHECK:     %0 = firrtl.add %[[p]], %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK:   }
   // CHECK: }
   // CHECK: firrtl.module @WhenUnderLayer() {
@@ -196,7 +196,7 @@ firrtl.circuit "Test" {
     firrtl.layerblock @A {
       %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
       firrtl.when %c0_ui1 : !firrtl.uint<1> {
-        %0 = firrtl.add %c0_ui1, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+        %0 = firrtl.add %c0_ui1, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
       }
     }
   }
@@ -576,7 +576,7 @@ firrtl.circuit "CaptureHardwareMultipleTimes" {
   firrtl.extmodule @CaptureHardwareMultipleTimes ()
 
   // CHECK: firrtl.module private @[[A:.+]](in %[[p:.+]]: !firrtl.uint<1>)
-  // CHECK:   %0 = firrtl.add %[[p]], %[[p]] : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+  // CHECK:   %0 = firrtl.add %[[p]], %[[p]] : !firrtl.uint<1>, !firrtl.uint<1>
   // CHECK: }
   // CHECK: firrtl.module @CaptureSrcTwice() {
   // CHECK:   %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -586,7 +586,7 @@ firrtl.circuit "CaptureHardwareMultipleTimes" {
   firrtl.module @CaptureSrcTwice() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     firrtl.layerblock @A {
-      %0 = firrtl.add %c0_ui1, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+      %0 = firrtl.add %c0_ui1, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
     }
   }
 

--- a/test/Dialect/FIRRTL/lower-memory.mlir
+++ b/test/Dialect/FIRRTL/lower-memory.mlir
@@ -233,7 +233,7 @@ firrtl.circuit "inferUnmaskedMemory" {
     firrtl.connect %rw_mask, %wMask : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:  %[[MReadWrite_RW0_addr:.+]], %[[MReadWrite_RW0_en:.+]], %[[MReadWrite_RW0_clk:.+]], %[[MReadWrite_RW0_wmode:.+]], %[[MReadWrite_RW0_wdata:.+]], %[[MReadWrite_RW0_rdata:.+]] = firrtl.instance MReadWrite  @MReadWrite
     // CHECK:   firrtl.connect %[[MReadWrite_RW0_en]], %rEn : !firrtl.uint<1>
-    // CHECK:   %1 = firrtl.and %wMask, %wMode : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK:   %1 = firrtl.and %wMask, %wMode : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK:   firrtl.connect %[[MReadWrite_RW0_wmode]], %1 : !firrtl.uint<1>
   }
 }

--- a/test/Dialect/FIRRTL/lower-types-remat.mlir
+++ b/test/Dialect/FIRRTL/lower-types-remat.mlir
@@ -35,7 +35,7 @@ firrtl.circuit "Bar" {
 // ALL-NEXT: bundlecreate
 // ALL-NEXT: mux
   firrtl.module @Bar(in %a1: !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>, in %a2: !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>, in %cond: !firrtl.uint<1>, out %b: !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>) attributes {convention = #firrtl<convention scalarized>} {
-    %0 = firrtl.mux(%cond, %a1, %a2) : (!firrtl.uint<1>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>) -> !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
+    %0 = firrtl.mux(%cond, %a1, %a2) : !firrtl.uint<1>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>, !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
     firrtl.matchingconnect %b, %0 : !firrtl.bundle<a: vector<uint<1>, 2>, b: uint<2>>
   }
 }

--- a/test/Dialect/FIRRTL/lower-types.mlir
+++ b/test/Dialect/FIRRTL/lower-types.mlir
@@ -285,17 +285,17 @@ firrtl.circuit "TopLevel" {
 // Check that a non-bundled mux ops are untouched.
     // COMMON-LABEL: firrtl.module private @Mux
     firrtl.module private @Mux(in %p: !firrtl.uint<1>, in %a: !firrtl.uint<1>, in %b: !firrtl.uint<1>, out %c: !firrtl.uint<1>) {
-      // CHECK-NEXT: %0 = firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      // CHECK-NEXT: %0 = firrtl.mux(%p, %a, %b) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
       // CHECK-NEXT: firrtl.connect %c, %0 : !firrtl.uint<1>
-      %0 = firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      %0 = firrtl.mux(%p, %a, %b) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
       firrtl.connect %c, %0 : !firrtl.uint<1>, !firrtl.uint<1>
     }
     // COMMON-LABEL: firrtl.module private @MuxBundle
     firrtl.module private @MuxBundle(in %p: !firrtl.uint<1>, in %a: !firrtl.bundle<a: uint<1>>, in %b: !firrtl.bundle<a: uint<1>>, out %c: !firrtl.bundle<a: uint<1>>) {
-      // CHECK-NEXT: %0 = firrtl.mux(%p, %a_a, %b_a) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+      // CHECK-NEXT: %0 = firrtl.mux(%p, %a_a, %b_a) : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
       // CHECK-NEXT: firrtl.matchingconnect %c_a, %0 : !firrtl.uint<1>
-      // SIG:        firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>) -> !firrtl.bundle<a: uint<1>>
-      %0 = firrtl.mux(%p, %a, %b) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>) -> !firrtl.bundle<a: uint<1>>
+      // SIG:        firrtl.mux(%p, %a, %b) : !firrtl.uint<1>, !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
+      %0 = firrtl.mux(%p, %a, %b) : !firrtl.uint<1>, !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
       firrtl.connect %c, %0 : !firrtl.bundle<a: uint<1>>, !firrtl.bundle<a: uint<1>>
     }
 
@@ -791,12 +791,12 @@ firrtl.circuit "TopLevel" {
 // CHECK-NEXT:      firrtl.matchingconnect %a_0, %default_0 : !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.matchingconnect %a_1, %default_1 : !firrtl.uint<1>
 // CHECK-NEXT:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-// CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : !firrtl.uint<2>, !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %0 : !firrtl.uint<1> {
 // CHECK-NEXT:        firrtl.matchingconnect %a_0, %b : !firrtl.uint<1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-// CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : !firrtl.uint<2>, !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %1 : !firrtl.uint<1> {
 // CHECK-NEXT:        firrtl.matchingconnect %a_1, %b : !firrtl.uint<1>
 // CHECK-NEXT:      }
@@ -818,29 +818,29 @@ firrtl.circuit "TopLevel" {
   }
 // CHECK-LABEL:    firrtl.module private @multidimWrite(in %sel: !firrtl.uint<1>, in %b: !firrtl.uint<2>, out %a_0_0: !firrtl.uint<2>, out %a_0_1: !firrtl.uint<2>, out %a_1_0: !firrtl.uint<2>, out %a_1_1: !firrtl.uint<2>) {
 // CHECK-NEXT:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-// CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %0 : !firrtl.uint<1> {
 // CHECK-NEXT:        %c0_ui1_0 = firrtl.constant 0 : !firrtl.uint<1>
-// CHECK-NEXT:        %2 = firrtl.eq %sel, %c0_ui1_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:        %2 = firrtl.eq %sel, %c0_ui1_0 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:        firrtl.when %2 : !firrtl.uint<1> {
 // CHECK-NEXT:          firrtl.matchingconnect %a_0_0, %b : !firrtl.uint<2>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %c1_ui1_1 = firrtl.constant 1 : !firrtl.uint<1>
-// CHECK-NEXT:        %3 = firrtl.eq %sel, %c1_ui1_1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:        %3 = firrtl.eq %sel, %c1_ui1_1 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:        firrtl.when %3 : !firrtl.uint<1> {
 // CHECK-NEXT:          firrtl.matchingconnect %a_0_1, %b : !firrtl.uint<2>
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-// CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %1 : !firrtl.uint<1> {
 // CHECK-NEXT:        %c0_ui1_0 = firrtl.constant 0 : !firrtl.uint<1>
-// CHECK-NEXT:        %2 = firrtl.eq %sel, %c0_ui1_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:        %2 = firrtl.eq %sel, %c0_ui1_0 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:        firrtl.when %2 : !firrtl.uint<1> {
 // CHECK-NEXT:          firrtl.matchingconnect %a_1_0, %b : !firrtl.uint<2>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %c1_ui1_1 = firrtl.constant 1 : !firrtl.uint<1>
-// CHECK-NEXT:        %3 = firrtl.eq %sel, %c1_ui1_1 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:        %3 = firrtl.eq %sel, %c1_ui1_1 : !firrtl.uint<1>, !firrtl.uint<1>
 // CHECK-NEXT:        firrtl.when %3 : !firrtl.uint<1> {
 // CHECK-NEXT:          firrtl.matchingconnect %a_1_1, %b : !firrtl.uint<2>
 // CHECK-NEXT:        }
@@ -870,12 +870,12 @@ firrtl.circuit "TopLevel" {
 // CHECK-NEXT:      firrtl.matchingconnect %b_1_wo, %def_1_wo : !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.matchingconnect %b_1_valid, %def_1_valid : !firrtl.uint<2>
 // CHECK-NEXT:      %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-// CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:      %0 = firrtl.eq %sel, %c0_ui1 : !firrtl.uint<2>, !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %0 : !firrtl.uint<1> {
 // CHECK-NEXT:        firrtl.matchingconnect %b_0_wo, %a_wo : !firrtl.uint<1>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
-// CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : (!firrtl.uint<2>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:      %1 = firrtl.eq %sel, %c1_ui1 : !firrtl.uint<2>, !firrtl.uint<1>
 // CHECK-NEXT:      firrtl.when %1 : !firrtl.uint<1> {
 // CHECK-NEXT:        firrtl.matchingconnect %b_1_wo, %a_wo : !firrtl.uint<1>
 // CHECK-NEXT:      }
@@ -998,13 +998,13 @@ firrtl.module private @is1436_FOO() {
   firrtl.module private @BitCast1(out %o_0: !firrtl.uint<1>, out %o_1: !firrtl.uint<1>) {
     %a1 = firrtl.wire : !firrtl.uint<4>
     %b = firrtl.bitcast %a1 : (!firrtl.uint<4>) -> (!firrtl.vector<uint<2>, 2>)
-    // CHECK:  %[[v0:.+]] = firrtl.bits %a1 1 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
-    // CHECK-NEXT:  %[[v1:.+]] = firrtl.bits %a1 3 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<2>
-    // CHECK-NEXT:  %[[v2:.+]] = firrtl.cat %[[v1]], %[[v0]] : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
+    // CHECK:  %[[v0:.+]] = firrtl.bits %a1 1 to 0 : !firrtl.uint<4>
+    // CHECK-NEXT:  %[[v1:.+]] = firrtl.bits %a1 3 to 2 : !firrtl.uint<4>
+    // CHECK-NEXT:  %[[v2:.+]] = firrtl.cat %[[v1]], %[[v0]] : !firrtl.uint<2>, !firrtl.uint<2>
     %c = firrtl.bitcast %b : (!firrtl.vector<uint<2>, 2>) -> (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<2>>)
-    // CHECK-NEXT:  %[[v3:.+]] = firrtl.bits %[[v2]] 3 to 3 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-    // CHECK-NEXT:  %[[v4:.+]] = firrtl.bits %[[v2]] 2 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-    // CHECK-NEXT:  %[[v5:.+]] = firrtl.bits %[[v2]] 1 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
+    // CHECK-NEXT:  %[[v3:.+]] = firrtl.bits %[[v2]] 3 to 3 : !firrtl.uint<4>
+    // CHECK-NEXT:  %[[v4:.+]] = firrtl.bits %[[v2]] 2 to 2 : !firrtl.uint<4>
+    // CHECK-NEXT:  %[[v5:.+]] = firrtl.bits %[[v2]] 1 to 0 : !firrtl.uint<4>
     %d = firrtl.wire : !firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<2>>
     // CHECK-NEXT:  %d_valid = firrtl.wire  : !firrtl.uint<1>
     // CHECK-NEXT:  %d_ready = firrtl.wire  : !firrtl.uint<1>
@@ -1014,23 +1014,23 @@ firrtl.module private @is1436_FOO() {
     // CHECK-NEXT:  firrtl.matchingconnect %d_ready, %[[v4]] : !firrtl.uint<1>
     // CHECK-NEXT:  firrtl.matchingconnect %d_data, %[[v5]] : !firrtl.uint<2>
     %e = firrtl.bitcast %d : (!firrtl.bundle<valid: uint<1>, ready: uint<1>, data: uint<2>>) -> (!firrtl.bundle<addr: uint<2>, data : vector<uint<1>, 2>>)
-    // CHECK-NEXT:  %[[v6:.+]] = firrtl.cat %d_valid, %d_ready : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
-    // CHECK-NEXT:  %[[v7:.+]] = firrtl.cat %[[v6]], %d_data : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
-    // CHECK-NEXT:  %[[v8:.+]] = firrtl.bits %[[v7]] 3 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<2>
-    // CHECK-NEXT:  %[[v9:.+]] = firrtl.bits %[[v7]] 1 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<2>
+    // CHECK-NEXT:  %[[v6:.+]] = firrtl.cat %d_valid, %d_ready : !firrtl.uint<1>, !firrtl.uint<1>
+    // CHECK-NEXT:  %[[v7:.+]] = firrtl.cat %[[v6]], %d_data : !firrtl.uint<2>, !firrtl.uint<2>
+    // CHECK-NEXT:  %[[v8:.+]] = firrtl.bits %[[v7]] 3 to 2 : !firrtl.uint<4>
+    // CHECK-NEXT:  %[[v9:.+]] = firrtl.bits %[[v7]] 1 to 0 : !firrtl.uint<4>
   %o1 = firrtl.subfield %e[data] : !firrtl.bundle<addr: uint<2>, data : vector<uint<1>, 2>>
    %c2 = firrtl.bitcast %a1 : (!firrtl.uint<4>) -> (!firrtl.bundle<valid: bundle<re: bundle<a: uint<1>>, aa: uint<1>>, ready: uint<1>, data: uint<1>>)
     %d2 = firrtl.wire : !firrtl.bundle<valid: bundle<re: bundle<a: uint<1>>, aa: uint<1>>, ready: uint<1>, data: uint<1>>
     firrtl.connect %d2 , %c2: !firrtl.bundle<valid: bundle<re: bundle<a: uint<1>>, aa: uint<1>>, ready: uint<1>, data:
     uint<1>>, !firrtl.bundle<valid: bundle<re: bundle<a: uint<1>>, aa: uint<1>>, ready: uint<1>, data: uint<1>>
-   //CHECK: %[[v10:.+]] = firrtl.bits %[[v9]] 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-   //CHECK: %[[v11:.+]] = firrtl.bits %[[v9]] 1 to 1 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-   //CHECK: %[[v12:.+]] = firrtl.bits %a1 3 to 2 : (!firrtl.uint<4>) -> !firrtl.uint<2>
-   //CHECK: %[[v13:.+]] = firrtl.bits %[[v12]] 1 to 1 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-   //CHECK: %[[v14:.+]] = firrtl.bits %[[v13]] 0 to 0 : (!firrtl.uint<1>) -> !firrtl.uint<1>
-   //CHECK: %[[v15:.+]] = firrtl.bits %[[v12]] 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-   //CHECK: %[[v16:.+]] = firrtl.bits %a1 1 to 1 : (!firrtl.uint<4>) -> !firrtl.uint<1>
-   //CHECK: %[[v17:.+]] = firrtl.bits %a1 0 to 0 : (!firrtl.uint<4>) -> !firrtl.uint<1>
+   //CHECK: %[[v10:.+]] = firrtl.bits %[[v9]] 0 to 0 : !firrtl.uint<2>
+   //CHECK: %[[v11:.+]] = firrtl.bits %[[v9]] 1 to 1 : !firrtl.uint<2>
+   //CHECK: %[[v12:.+]] = firrtl.bits %a1 3 to 2 : !firrtl.uint<4>
+   //CHECK: %[[v13:.+]] = firrtl.bits %[[v12]] 1 to 1 : !firrtl.uint<2>
+   //CHECK: %[[v14:.+]] = firrtl.bits %[[v13]] 0 to 0 : !firrtl.uint<1>
+   //CHECK: %[[v15:.+]] = firrtl.bits %[[v12]] 0 to 0 : !firrtl.uint<2>
+   //CHECK: %[[v16:.+]] = firrtl.bits %a1 1 to 1 : !firrtl.uint<4>
+   //CHECK: %[[v17:.+]] = firrtl.bits %a1 0 to 0 : !firrtl.uint<4>
    //CHECK: %[[d2_valid_re_a:.+]] = firrtl.wire  : !firrtl.uint<1>
    //CHECK: %[[d2_valid_aa:.+]] = firrtl.wire  : !firrtl.uint<1>
    //CHECK: %[[d2_ready:.+]] = firrtl.wire  : !firrtl.uint<1>
@@ -1272,11 +1272,11 @@ firrtl.module private @is1436_FOO() {
 
   // COMMON-LABEL: firrtl.module @ElementWise
   firrtl.module @ElementWise(in %a: !firrtl.vector<uint<1>, 1>, in %b: !firrtl.vector<uint<1>, 1>, out %c_0: !firrtl.vector<uint<1>, 1>, out %c_1: !firrtl.vector<uint<1>, 1>, out %c_2: !firrtl.vector<uint<1>, 1>) {
-    // CHECK-NEXT: %0 = firrtl.or %a_0, %b_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK-NEXT: %0 = firrtl.or %a_0, %b_0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-NEXT: firrtl.matchingconnect %c_0_0, %0 : !firrtl.uint<1>
-    // CHECK-NEXT: %1 = firrtl.and %a_0, %b_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK-NEXT: %1 = firrtl.and %a_0, %b_0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-NEXT: firrtl.matchingconnect %c_1_0, %1 : !firrtl.uint<1>
-    // CHECK-NEXT: %2 = firrtl.xor %a_0, %b_0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK-NEXT: %2 = firrtl.xor %a_0, %b_0 : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK-NEXT: firrtl.matchingconnect %c_2_0, %2 : !firrtl.uint<1>
     // Check that elementwise_* are preserved.
     // AGGREGATE: firrtl.elementwise_or
@@ -1285,24 +1285,24 @@ firrtl.module private @is1436_FOO() {
     // SIG: firrtl.elementwise_or
     // SIG: firrtl.elementwise_and
     // SIG: firrtl.elementwise_xor
-    %0 = firrtl.elementwise_or %a, %b : (!firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>) -> !firrtl.vector<uint<1>, 1>
+    %0 = firrtl.elementwise_or %a, %b : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
     firrtl.matchingconnect %c_0, %0 : !firrtl.vector<uint<1>, 1>
-    %1 = firrtl.elementwise_and %a, %b : (!firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>) -> !firrtl.vector<uint<1>, 1>
+    %1 = firrtl.elementwise_and %a, %b : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
     firrtl.matchingconnect %c_1, %1 : !firrtl.vector<uint<1>, 1>
-    %2 = firrtl.elementwise_xor %a, %b : (!firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>) -> !firrtl.vector<uint<1>, 1>
+    %2 = firrtl.elementwise_xor %a, %b : !firrtl.vector<uint<1>, 1>, !firrtl.vector<uint<1>, 1>
     firrtl.matchingconnect %c_2, %2 : !firrtl.vector<uint<1>, 1>
   }
 
   // COMMON-LABEL: firrtl.module @MuxInt
   firrtl.module @MuxInt(in %sel1: !firrtl.uint<1>, in %sel2: !firrtl.uint<2>, in %v1: !firrtl.bundle<a: uint<5>>, in %v0: !firrtl.bundle<a: uint<5>>, out %out1: !firrtl.bundle<a: uint<5>>, out %out2: !firrtl.bundle<a: uint<5>>) {
-    // CHECK: firrtl.int.mux4cell(%sel2, %v1_a, %v0_a, %v1_a, %v0_a) : (!firrtl.uint<2>, !firrtl.uint<5>, !firrtl.uint<5>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-    %0 = firrtl.int.mux4cell(%sel2, %v1, %v0, %v1, %v0) : (!firrtl.uint<2>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>) -> !firrtl.bundle<a: uint<5>>
+    // CHECK: firrtl.int.mux4cell(%sel2, %v1_a, %v0_a, %v1_a, %v0_a) : !firrtl.uint<2>, !firrtl.uint<5>, !firrtl.uint<5>, !firrtl.uint<5>, !firrtl.uint<5>
+    %0 = firrtl.int.mux4cell(%sel2, %v1, %v0, %v1, %v0) : !firrtl.uint<2>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>
     firrtl.matchingconnect %out1, %0 : !firrtl.bundle<a: uint<5>>
-    // CHECK: firrtl.int.mux2cell(%sel1, %v1_a, %v0_a) : (!firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<5>
-    %1 = firrtl.int.mux2cell(%sel1, %v1, %v0) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>) -> !firrtl.bundle<a: uint<5>>
+    // CHECK: firrtl.int.mux2cell(%sel1, %v1_a, %v0_a) : !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<5>
+    %1 = firrtl.int.mux2cell(%sel1, %v1, %v0) : !firrtl.uint<1>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>
     firrtl.matchingconnect %out2, %0 : !firrtl.bundle<a: uint<5>>
-    // SIG: firrtl.int.mux4cell(%sel2, %v1, %v0, %v1, %v0) : (!firrtl.uint<2>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>) -> !firrtl.bundle<a: uint<5>>
-    // SIG: firrtl.int.mux2cell(%sel1, %v1, %v0) : (!firrtl.uint<1>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>) -> !firrtl.bundle<a: uint<5>>
+    // SIG: firrtl.int.mux4cell(%sel2, %v1, %v0, %v1, %v0) : !firrtl.uint<2>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>
+    // SIG: firrtl.int.mux2cell(%sel1, %v1, %v0) : !firrtl.uint<1>, !firrtl.bundle<a: uint<5>>, !firrtl.bundle<a: uint<5>>
   }
 
   // COMMON-LABEL: firrtl.module @Groups

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -133,62 +133,62 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %n1 = firrtl.node interesting_name %i8 : !firrtl.uint<8>
     node n1 = i8
 
-    ; CHECK: firrtl.add %reset, %reset : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<2>
+    ; CHECK: firrtl.add %reset, %reset : !firrtl.uint<1>, !firrtl.uint<1>
     node n2 = add(reset, reset)
 
-    ; CHECK: firrtl.asClock %reset : (!firrtl.uint<1>) -> !firrtl.clock
+    ; CHECK: firrtl.asClock %reset : !firrtl.uint<1>
     node n3 = asClock(reset)
 
-    ; CHECK: firrtl.asUInt %clock : (!firrtl.clock) -> !firrtl.uint<1>
+    ; CHECK: firrtl.asUInt %clock : !firrtl.clock
     node check_u0 = asUInt(clock)
-    ; CHECK: firrtl.asUInt %i8 : (!firrtl.uint<8>) -> !firrtl.uint<8>
+    ; CHECK: firrtl.asUInt %i8 : !firrtl.uint<8>
     node check_u1 = asUInt(i8)
-    ; CHECK: firrtl.asUInt %s8 : (!firrtl.sint<8>) -> !firrtl.uint<8>
+    ; CHECK: firrtl.asUInt %s8 : !firrtl.sint<8>
     node check_u2 = asUInt(s8)
-    ; CHECK: firrtl.asUInt %a8 : (!firrtl.analog<8>) -> !firrtl.uint<8>
+    ; CHECK: firrtl.asUInt %a8 : !firrtl.analog<8>
     node check_u3 = asUInt(a8)
-    ; CHECK: firrtl.asUInt %reset_abstract : (!firrtl.reset) -> !firrtl.uint<1>
+    ; CHECK: firrtl.asUInt %reset_abstract : !firrtl.reset
     node check_u5 = asUInt(reset_abstract)
-    ; CHECK: firrtl.asUInt %reset_async : (!firrtl.asyncreset) -> !firrtl.uint<1>
+    ; CHECK: firrtl.asUInt %reset_async : !firrtl.asyncreset
     node check_u6 = asUInt(reset_async)
 
-    ; CHECK: firrtl.asSInt %clock : (!firrtl.clock) -> !firrtl.sint<1>
+    ; CHECK: firrtl.asSInt %clock : !firrtl.clock
     node check_s0 = asSInt(clock)
-    ; CHECK: firrtl.asSInt %i8 : (!firrtl.uint<8>) -> !firrtl.sint<8>
+    ; CHECK: firrtl.asSInt %i8 : !firrtl.uint<8>
     node check_s1 = asSInt(i8)
-    ; CHECK: firrtl.asSInt %s8 : (!firrtl.sint<8>) -> !firrtl.sint<8>
+    ; CHECK: firrtl.asSInt %s8 : !firrtl.sint<8>
     node check_s2 = asSInt(s8)
-    ; CHECK: firrtl.asSInt %a8 : (!firrtl.analog<8>) -> !firrtl.sint<8>
+    ; CHECK: firrtl.asSInt %a8 : !firrtl.analog<8>
     node check_s3 = asSInt(a8)
-    ; CHECK: firrtl.asSInt %reset_abstract : (!firrtl.reset) -> !firrtl.sint<1>
+    ; CHECK: firrtl.asSInt %reset_abstract : !firrtl.reset
     node check_s5 = asSInt(reset_abstract)
-    ; CHECK: firrtl.asSInt %reset_async : (!firrtl.asyncreset) -> !firrtl.sint<1>
+    ; CHECK: firrtl.asSInt %reset_async : !firrtl.asyncreset
     node check_s6 = asSInt(reset_async)
 
-    ; CHECK: firrtl.asAsyncReset %clock : (!firrtl.clock) -> !firrtl.asyncreset
+    ; CHECK: firrtl.asAsyncReset %clock : !firrtl.clock
     node check_ar0 = asAsyncReset(clock)
-    ; CHECK: firrtl.asAsyncReset %reset : (!firrtl.uint<1>) -> !firrtl.asyncreset
+    ; CHECK: firrtl.asAsyncReset %reset : !firrtl.uint<1>
     node check_ar1 = asAsyncReset(reset)
-    ; CHECK: firrtl.asAsyncReset %s1 : (!firrtl.sint<1>) -> !firrtl.asyncreset
+    ; CHECK: firrtl.asAsyncReset %s1 : !firrtl.sint<1>
     node check_ar2 = asAsyncReset(s1)
-    ; CHECK: firrtl.asAsyncReset %a1 : (!firrtl.analog<1>) -> !firrtl.asyncreset
+    ; CHECK: firrtl.asAsyncReset %a1 : !firrtl.analog<1>
     node check_ar3 = asAsyncReset(a1)
-    ; CHECK: firrtl.asAsyncReset %reset_abstract : (!firrtl.reset) -> !firrtl.asyncreset
+    ; CHECK: firrtl.asAsyncReset %reset_abstract : !firrtl.reset
     node check_ar4 = asAsyncReset(reset_abstract)
-    ; CHECK: firrtl.asAsyncReset %reset_async : (!firrtl.asyncreset) -> !firrtl.asyncreset
+    ; CHECK: firrtl.asAsyncReset %reset_async : !firrtl.asyncreset
     node check_ar5 = asAsyncReset(reset_async)
 
-    ; CHECK: firrtl.asClock %clock : (!firrtl.clock) -> !firrtl.clock
+    ; CHECK: firrtl.asClock %clock : !firrtl.clock
     node check_c0 = asClock(clock)
-    ; CHECK: firrtl.asClock %reset : (!firrtl.uint<1>) -> !firrtl.clock
+    ; CHECK: firrtl.asClock %reset : !firrtl.uint<1>
     node check_c1 = asClock(reset)
-    ; CHECK: firrtl.asClock %s1 : (!firrtl.sint<1>) -> !firrtl.clock
+    ; CHECK: firrtl.asClock %s1 : !firrtl.sint<1>
     node check_c2 = asClock(s1)
-    ; CHECK: firrtl.asClock %a1 : (!firrtl.analog<1>) -> !firrtl.clock
+    ; CHECK: firrtl.asClock %a1 : !firrtl.analog<1>
     node check_c3 = asClock(a1)
-    ; CHECK: firrtl.asClock %reset_abstract : (!firrtl.reset) -> !firrtl.clock
+    ; CHECK: firrtl.asClock %reset_abstract : !firrtl.reset
     node check_c4 = asClock(reset_abstract)
-    ; CHECK: firrtl.asClock %reset_async : (!firrtl.asyncreset) -> !firrtl.clock
+    ; CHECK: firrtl.asClock %reset_async : !firrtl.asyncreset
     node check_c5 = asClock(reset_async)
 
     ; CHECK: firrtl.node interesting_name %auto : !firrtl.uint<1>
@@ -276,22 +276,22 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: firrtl.stop %clock, %reset, 42 {name = "stop_0"} : !firrtl.clock, !firrtl.uint<1>
     stop(clock, reset, 42) : stop_0
 
-    ; CHECK: firrtl.bits %i8 4 to 2 : (!firrtl.uint<8>) -> !firrtl.uint<3>
+    ; CHECK: firrtl.bits %i8 4 to 2 : !firrtl.uint<8>
     node n4 = bits(i8, 4, 2)
 
-    ; CHECK: firrtl.shl %i8, 4 : (!firrtl.uint<8>) -> !firrtl.uint<12>
-    ; CHECK: firrtl.shr %i8, 8 : (!firrtl.uint<8>) -> !firrtl.uint<0>
+    ; CHECK: firrtl.shl %i8, 4 : !firrtl.uint<8>
+    ; CHECK: firrtl.shr %i8, 8 : !firrtl.uint<8>
     node n5 = or(shl(i8, 4), shr(i8, 8))
 
-    ; CHECK: firrtl.dshl %i8, %{{.*}} : (!firrtl.uint<8>, !firrtl.const.uint<4>) -> !firrtl.uint<23>
+    ; CHECK: firrtl.dshl %i8, %{{.*}} : !firrtl.uint<8>, !firrtl.const.uint<4>
     node n6 = dshl(i8, UInt<4>(7))
-    ; CHECK: firrtl.dshlw %i8, %{{.*}} : (!firrtl.uint<8>, !firrtl.const.uint<4>) -> !firrtl.uint<8>
+    ; CHECK: firrtl.dshlw %i8, %{{.*}} : !firrtl.uint<8>, !firrtl.const.uint<4>
     node n6s = dshlw(i8, UInt<4>(7))
 
-    ; CHECK: firrtl.cat %{{.*}}, %{{.*}} : (!firrtl.uint<12>, !firrtl.uint<23>) -> !firrtl.uint<35>
+    ; CHECK: firrtl.cat %{{.*}}, %{{.*}} : !firrtl.uint<12>, !firrtl.uint<23>
     node n7 = cat(n5, n6)
 
-    ; CHECK: firrtl.mux(%reset, %i8, %{{.*}}) : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.const.uint) -> !firrtl.uint
+    ; CHECK: firrtl.mux(%reset, %i8, %{{.*}}) : !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.const.uint
     node n8 = mux(reset, i8, UInt(4))
 
     ; CHECK: %_t_2621 = firrtl.regreset interesting_name %clock, %reset, %{{.*}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.const.uint<4>, !firrtl.uint<4>
@@ -300,15 +300,15 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %_t_1601 = firrtl.regreset interesting_name %clock, %reset, %{{.*}} : !firrtl.clock, !firrtl.uint<1>, !firrtl.const.uint<2>, !firrtl.uint<2>
     regreset _t_1601 : UInt<2>, clock, reset, UInt<2>(0h00) @[Edges.scala 230:27]
 
-    ; CHECK: firrtl.div %i8, %{{.*}} : (!firrtl.uint<8>, !firrtl.const.uint<4>) -> !firrtl.uint<8>
+    ; CHECK: firrtl.div %i8, %{{.*}} : !firrtl.uint<8>, !firrtl.const.uint<4>
     node n9 = div(i8, UInt<4>(4))
 
-    ; CHECK: firrtl.tail %i8, 7 : (!firrtl.uint<8>) -> !firrtl.uint<1>
-    ; CHECK: firrtl.tail %i8, 0 : (!firrtl.uint<8>) -> !firrtl.uint<8>
-    ; CHECK: firrtl.head %i8, 4 : (!firrtl.uint<8>) -> !firrtl.uint<4>
+    ; CHECK: firrtl.tail %i8, 7 : !firrtl.uint<8>
+    ; CHECK: firrtl.tail %i8, 0 : !firrtl.uint<8>
+    ; CHECK: firrtl.head %i8, 4 : !firrtl.uint<8>
     node n10 = add(add(tail(i8, 7), tail(i8, 0)), head(i8, 4))
 
-    ; CHECK: firrtl.tail %{{.*}}, 3 : (!firrtl.sint<8>) -> !firrtl.uint<5>
+    ; CHECK: firrtl.tail %{{.*}}, 3 : !firrtl.sint<8>
     node n10s = tail(asSInt(i8), 3)
 
     ; CHECK: %_t_2622 = firrtl.reg interesting_name %clock : !firrtl.clock, !firrtl.uint<4>
@@ -316,7 +316,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
 
     ; CHECK: %xyz_in = firrtl.instance xyz interesting_name @circuit(in in: !firrtl.uint<80>)
     inst xyz of circuit
-    ; CHECK: [[PAD:%.*]] = firrtl.pad %i8, 80 : (!firrtl.uint<8>) -> !firrtl.uint<80>
+    ; CHECK: [[PAD:%.*]] = firrtl.pad %i8, 80 : !firrtl.uint<8>
     ; CHECK: firrtl.matchingconnect %xyz_in, [[PAD]] : !firrtl.uint<80>
     connect xyz.in, i8
 
@@ -359,13 +359,13 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: %testharness = chirrtl.seqmem interesting_name Undefined : !chirrtl.cmemory<vector<uint<8>, 16>, 2147483648>
     smem testharness : UInt<8>[16][2147483648], undefined
 
-    ; CHECK: firrtl.pad %i8, 10 : (!firrtl.uint<8>) -> !firrtl.uint<10>
+    ; CHECK: firrtl.pad %i8, 10 : !firrtl.uint<8>
     node n11 = pad(i8, 10)
 
-    ; CHECK: firrtl.andr %n11 : (!firrtl.uint<10>) -> !firrtl.uint<1>
+    ; CHECK: firrtl.andr %n11 : !firrtl.uint<10>
     node n12 = andr(n11)
 
-    ; CHECK: = firrtl.not %auto : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    ; CHECK: = firrtl.not %auto : !firrtl.uint<1>
     node n13 = not(auto)
 
 
@@ -453,7 +453,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
   ; CHECK-LABEL: firrtl.module private @oversize_shift(
   module oversize_shift :
     wire value : UInt<2>
-    ; CHECK: firrtl.shr %value, 5 : (!firrtl.uint<2>) -> !firrtl.uint<0>
+    ; CHECK: firrtl.shr %value, 5 : !firrtl.uint<2>
     node n = shr(value, 5)
 
   ; CHECK-LABEL: firrtl.module private @when_else_ambiguity(
@@ -863,9 +863,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     output c: UInt[1]
     output z: {u: UInt, v: UInt}
     ; CHECK: firrtl.mux(%sel, %a, %b)
-    ; CHECK-SAME: -> !firrtl.vector<uint<32>, 1>
     ; CHECK: firrtl.mux(%sel, %x, %y)
-    ; CHECK-SAME: -> !firrtl.bundle<u: uint<32>, v: uint<2>>
     connect c, mux(sel, a, b)
     connect z, mux(sel, x, y)
 
@@ -1889,7 +1887,7 @@ circuit Foo:
     connect foo.c, s_foo_c
     ; CHECK-NEXT: firrtl.matchingconnect %foo_data, %s_foo_data : !firrtl.uint<32>
     connect foo.data, s_foo_data
-    ; CHECK-NEXT: %0 = firrtl.eq %foo_out, %s_foo_data : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<1>
+    ; CHECK-NEXT: %0 = firrtl.eq %foo_out, %s_foo_data : !firrtl.uint<32>, !firrtl.uint<32>
     ; CHECK-NEXT: %1 = firrtl.int.generic "circt_ltl_implication"  %s_foo_c, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
     ; CHECK-NEXT: firrtl.int.generic "circt_verif_assert"  %1 : (!firrtl.uint<1>) -> ()
     intrinsic(circt_verif_assert, intrinsic(circt_ltl_implication : UInt<1>, s_foo_c, eq(foo.out, s_foo_data)))

--- a/test/Dialect/FIRRTL/parse-locations.fir
+++ b/test/Dialect/FIRRTL/parse-locations.fir
@@ -65,7 +65,7 @@ circuit MyModule :  @[CIRCUIT.scala 127]
 
     ; Make sure the locator is applied to all the subexpressions.
     ; CHECK:  %c0_ui1 = firrtl.constant 0 : !firrtl.const.uint<1> loc("Misc.scala":210:20)
-    ; CHECK:  %0 = firrtl.eq %mask_bit_2, %c0_ui1 : (!firrtl.uint<1>, !firrtl.const.uint<1>) -> !firrtl.uint<1> loc("Misc.scala":210:20)
+    ; CHECK:  %0 = firrtl.eq %mask_bit_2, %c0_ui1 : !firrtl.uint<1>, !firrtl.const.uint<1>
     ; CHECK:  %mask_nbit_2 = firrtl.node interesting_name %0  : !firrtl.uint<1> loc("Misc.scala":210:20)
 
 

--- a/test/Dialect/FIRRTL/register-optimizer.mlir
+++ b/test/Dialect/FIRRTL/register-optimizer.mlir
@@ -86,7 +86,7 @@ firrtl.circuit "invalidReg"   {
     // CHECK: firrtl.regreset
     %c0_ui3 = firrtl.constant 0 : !firrtl.uint<3>
     %r = firrtl.regreset %clock, %reset, %c0_ui3 : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<3>, !firrtl.uint<2>
-    %0 = firrtl.cat %r, %r : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
+    %0 = firrtl.cat %r, %r : !firrtl.uint<2>, !firrtl.uint<2>
     firrtl.matchingconnect %r, %r : !firrtl.uint<2>
     firrtl.matchingconnect %out, %0 : !firrtl.uint<4>
   }

--- a/test/Dialect/FIRRTL/remove-unused-ports.mlir
+++ b/test/Dialect/FIRRTL/remove-unused-ports.mlir
@@ -168,7 +168,7 @@ firrtl.circuit "UnusedOutput"  {
     // CHECK-NEXT: firrtl.matchingconnect %b, %[[c_wire]]
     firrtl.matchingconnect %b, %c : !firrtl.uint<1>
     // CHECK-NEXT: %[[not_a:.+]] = firrtl.not %a
-    %0 = firrtl.not %a : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.not %a : !firrtl.uint<1>
     // CHECK-NEXT: firrtl.matchingconnect %[[c_wire]], %[[not_a]]
     firrtl.matchingconnect %c, %0 : !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -14,8 +14,8 @@ firrtl.module @Top(in %arg0: !firrtl.uint<1>) attributes {portNames = [""]} {}
 
 // CHECK-LABEL: firrtl.module @Intrinsics
 firrtl.module @Intrinsics(in %ui : !firrtl.uint, in %clock: !firrtl.clock, in %ui1: !firrtl.uint<1>) {
-  // CHECK-NEXT: firrtl.int.sizeof %ui : (!firrtl.uint) -> !firrtl.uint<32>
-  %size = firrtl.int.sizeof %ui : (!firrtl.uint) -> !firrtl.uint<32>
+  // CHECK-NEXT: firrtl.int.sizeof %ui : !firrtl.uint
+  %size = firrtl.int.sizeof %ui : !firrtl.uint
 
   // CHECK-NEXT: firrtl.int.isX %ui : !firrtl.uint
   %isx = firrtl.int.isX %ui : !firrtl.uint
@@ -97,17 +97,17 @@ firrtl.module @PropertyArithmetic() {
   %0 = firrtl.integer 1
   %1 = firrtl.integer 2
 
-  // CHECK: firrtl.integer.add %0, %1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
-  %2 = firrtl.integer.add %0, %1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+  // CHECK: firrtl.integer.add %0, %1 : !firrtl.integer, !firrtl.integer
+  %2 = firrtl.integer.add %0, %1 : !firrtl.integer, !firrtl.integer
 
-  // CHECK: firrtl.integer.mul %0, %1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
-  %3 = firrtl.integer.mul %0, %1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+  // CHECK: firrtl.integer.mul %0, %1 : !firrtl.integer, !firrtl.integer
+  %3 = firrtl.integer.mul %0, %1 : !firrtl.integer, !firrtl.integer
 
-  // CHECK: firrtl.integer.shr %0, %1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
-  %4 = firrtl.integer.shr %0, %1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+  // CHECK: firrtl.integer.shr %0, %1 : !firrtl.integer, !firrtl.integer
+  %4 = firrtl.integer.shr %0, %1 : !firrtl.integer, !firrtl.integer
 
-  // CHECK: firrtl.integer.shl %0, %1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
-  %5 = firrtl.integer.shl %0, %1 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+  // CHECK: firrtl.integer.shl %0, %1 : !firrtl.integer, !firrtl.integer
+  %5 = firrtl.integer.shl %0, %1 : !firrtl.integer, !firrtl.integer
 }
 
 // CHECK-LABEL: firrtl.module @PropertyListOps

--- a/test/Dialect/FIRRTL/sfc-compat.mlir
+++ b/test/Dialect/FIRRTL/sfc-compat.mlir
@@ -98,7 +98,7 @@ firrtl.circuit "SFCCompatTests" {
   // A primitive operation should block invalid propagation.
   firrtl.module @InvalidPrimop(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %d: !firrtl.uint<1>, out %q: !firrtl.uint<1>) {
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
-    %0 = firrtl.not %invalid_ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %0 = firrtl.not %invalid_ui1 : !firrtl.uint<1>
     // CHECK: firrtl.regreset %clock
     %r = firrtl.regreset %clock, %reset, %0  : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.connect %r, %d : !firrtl.uint<1>, !firrtl.uint<1>
@@ -150,10 +150,10 @@ firrtl.circuit "SFCCompatTests" {
     firrtl.matchingconnect %r2_init, %inv_ui1 : !firrtl.uint<1>
     %r2 = firrtl.regreset %clock, %reset, %r2_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
 
-    %c0_si1 = firrtl.asSInt %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.sint<1>
-    %c0_clock = firrtl.asClock %c0_si1 : (!firrtl.sint<1>) -> !firrtl.clock
-    %c0_asyncreset = firrtl.asAsyncReset %c0_clock : (!firrtl.clock) -> !firrtl.asyncreset
-    %r3_init = firrtl.asUInt %c0_asyncreset : (!firrtl.asyncreset) -> !firrtl.uint<1>
+    %c0_si1 = firrtl.asSInt %c0_ui1 : !firrtl.uint<1>
+    %c0_clock = firrtl.asClock %c0_si1 : !firrtl.sint<1>
+    %c0_asyncreset = firrtl.asAsyncReset %c0_clock : !firrtl.clock
+    %r3_init = firrtl.asUInt %c0_asyncreset : !firrtl.asyncreset
     %r3 = firrtl.regreset %clock, %reset, %r3_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
 
     %agg_const = firrtl.aggregateconstant [1, 2, 1] : !firrtl.bundle<a: uint<8>, b: uint<5>, c: uint<1>>
@@ -164,8 +164,8 @@ firrtl.circuit "SFCCompatTests" {
   // CHECK-LABEL: firrtl.module @TailPrimOp
   firrtl.module @TailPrimOp(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
-    %0 = firrtl.pad %c0_ui1, 3 : (!firrtl.uint<1>) -> !firrtl.uint<3>
-    %1 = firrtl.tail %0, 2 : (!firrtl.uint<3>) -> !firrtl.uint<1>
+    %0 = firrtl.pad %c0_ui1, 3 : !firrtl.uint<1>
+    %1 = firrtl.tail %0, 2 : !firrtl.uint<3>
     %r0_init = firrtl.wire sym @r0_init : !firrtl.uint<1>
     firrtl.matchingconnect %r0_init, %1: !firrtl.uint<1>
     %r0 = firrtl.regreset %clock, %reset, %r0_init : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
@@ -188,7 +188,7 @@ firrtl.circuit "NonConstantAsyncReset_PrimOp" {
   firrtl.module @NonConstantAsyncReset_PrimOp(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset) {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
     // expected-note @+1 {{reset driver is here}}
-    %c1_ui1 = firrtl.not %c0_ui1 : (!firrtl.uint<1>) -> !firrtl.uint<1>
+    %c1_ui1 = firrtl.not %c0_ui1 : !firrtl.uint<1>
     // expected-error @below {{register "r0" has an async reset, but its reset value is not driven with a constant value through wires, nodes, or connects}}
     %r0 = firrtl.regreset %clock, %reset, %c1_ui1 : !firrtl.clock, !firrtl.asyncreset, !firrtl.uint<1>, !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/simplify-mems.mlir
+++ b/test/Dialect/FIRRTL/simplify-mems.mlir
@@ -238,19 +238,19 @@ firrtl.circuit "UnusedBits" {
     %read_clk = firrtl.subfield %Memory_read[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %read_clk, %clock : !firrtl.clock, !firrtl.clock
     %read_data = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
-    %read_data_slice = firrtl.bits %read_data 7 to 3 : (!firrtl.uint<42>) -> !firrtl.uint<5>
+    %read_data_slice = firrtl.bits %read_data 7 to 3 : !firrtl.uint<42>
     firrtl.connect %result_read, %read_data_slice : !firrtl.uint<5>, !firrtl.uint<5>
 
     // CHECK-DAG: [[RW_FIELD:%.+]] = firrtl.subfield %Memory_rw[wdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<10>, wmode: uint<1>, wdata: uint<10>, wmask: uint<1>>
-    // CHECK-DAG: [[RW_SLICE_LO:%.+]] = firrtl.bits %in_data 7 to 3 : (!firrtl.uint<42>) -> !firrtl.uint<5>
-    // CHECK-DAG: [[RW_SLICE_HI:%.+]] = firrtl.bits %in_data 24 to 20 : (!firrtl.uint<42>) -> !firrtl.uint<5>
-    // CHECK-DAG: [[RW_SLICE_JOIN:%.+]] = firrtl.cat [[RW_SLICE_HI]], [[RW_SLICE_LO]] : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<10>
+    // CHECK-DAG: [[RW_SLICE_LO:%.+]] = firrtl.bits %in_data 7 to 3 : !firrtl.uint<42>
+    // CHECK-DAG: [[RW_SLICE_HI:%.+]] = firrtl.bits %in_data 24 to 20 : !firrtl.uint<42>
+    // CHECK-DAG: [[RW_SLICE_JOIN:%.+]] = firrtl.cat [[RW_SLICE_HI]], [[RW_SLICE_LO]] : !firrtl.uint<5>, !firrtl.uint<5>
     // CHECK-DAG: firrtl.matchingconnect [[RW_FIELD]], [[RW_SLICE_JOIN]] : !firrtl.uint<10>
 
     // CHECK-DAG: [[W_FIELD:%.+]] = firrtl.subfield %Memory_write[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<10>, mask: uint<1>>
-    // CHECK-DAG: [[W_SLICE_LO:%.+]] = firrtl.bits %in_data 7 to 3 : (!firrtl.uint<42>) -> !firrtl.uint<5>
-    // CHECK-DAG: [[W_SLICE_HI:%.+]] = firrtl.bits %in_data 24 to 20 : (!firrtl.uint<42>) -> !firrtl.uint<5>
-    // CHECK-DAG: [[W_SLICE_JOIN:%.+]] = firrtl.cat [[W_SLICE_HI]], [[W_SLICE_LO]] : (!firrtl.uint<5>, !firrtl.uint<5>) -> !firrtl.uint<10>
+    // CHECK-DAG: [[W_SLICE_LO:%.+]] = firrtl.bits %in_data 7 to 3 : !firrtl.uint<42>
+    // CHECK-DAG: [[W_SLICE_HI:%.+]] = firrtl.bits %in_data 24 to 20 : !firrtl.uint<42>
+    // CHECK-DAG: [[W_SLICE_JOIN:%.+]] = firrtl.cat [[W_SLICE_HI]], [[W_SLICE_LO]] : !firrtl.uint<5>, !firrtl.uint<5>
     // CHECK-DAG: firrtl.matchingconnect [[W_FIELD]], [[W_SLICE_JOIN]] : !firrtl.uint<10>
 
     %rw_addr = firrtl.subfield %Memory_rw[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
@@ -260,7 +260,7 @@ firrtl.circuit "UnusedBits" {
     %rw_clk = firrtl.subfield %Memory_rw[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %rw_clk, %clock : !firrtl.clock, !firrtl.clock
     %rw_rdata = firrtl.subfield %Memory_rw[rdata] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
-    %rw_rdata_slice = firrtl.bits %rw_rdata 24 to 20 : (!firrtl.uint<42>) -> !firrtl.uint<5>
+    %rw_rdata_slice = firrtl.bits %rw_rdata 24 to 20 : !firrtl.uint<42>
     firrtl.connect %result_rw, %rw_rdata_slice : !firrtl.uint<5>, !firrtl.uint<5>
     %rw_wmode = firrtl.subfield %Memory_rw[wmode] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<42>, wmode: uint<1>, wdata: uint<42>, wmask: uint<1>>
     firrtl.connect %rw_wmode, %wmode_rw : !firrtl.uint<1>, !firrtl.uint<1>
@@ -317,10 +317,10 @@ firrtl.circuit "UnusedBitsAtEnd" {
     %read_clk = firrtl.subfield %Memory_read[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
     firrtl.connect %read_clk, %clock : !firrtl.clock, !firrtl.clock
     %read_data = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<42>>
-    %read_data_slice = firrtl.bits %read_data 41 to 37 : (!firrtl.uint<42>) -> !firrtl.uint<5>
+    %read_data_slice = firrtl.bits %read_data 41 to 37 : !firrtl.uint<42>
     firrtl.connect %result_read, %read_data_slice : !firrtl.uint<5>, !firrtl.uint<5>
 
-    // CHECK: firrtl.bits %in_data 41 to 37 : (!firrtl.uint<42>) -> !firrtl.uint<5>
+    // CHECK: firrtl.bits %in_data 41 to 37 : !firrtl.uint<42>
     %write_addr = firrtl.subfield %Memory_write[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
     firrtl.connect %write_addr, %addr : !firrtl.uint<4>, !firrtl.uint<4>
     %write_en = firrtl.subfield %Memory_write[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<42>, mask: uint<1>>
@@ -371,16 +371,16 @@ firrtl.circuit "OneAddressMasked" {
     %read_data = firrtl.subfield %Memory_read[data] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data flip: uint<32>>
     firrtl.connect %result_read, %read_data : !firrtl.uint<32>, !firrtl.uint<32>
 
-    // CHECK: [[DATA_0:%.+]] = firrtl.bits %in_data 15 to 0 : (!firrtl.uint<32>) -> !firrtl.uint<16>
-    // CHECK: [[NEXT_0:%.+]] = firrtl.bits %Memory 15 to 0 : (!firrtl.uint<32>) -> !firrtl.uint<16>
-    // CHECK: [[MASK_0:%.+]] = firrtl.bits %in_mask 0 to 0 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-    // CHECK: [[CHUNK_0:%.+]] = firrtl.mux([[MASK_0]], [[DATA_0]], [[NEXT_0]]) : (!firrtl.uint<1>, !firrtl.uint<16>, !firrtl.uint<16>) -> !firrtl.uint<16>
-    // CHECK: [[DATA_1:%.+]] = firrtl.bits %in_data 31 to 16 : (!firrtl.uint<32>) -> !firrtl.uint<16>
-    // CHECK: [[NEXT_1:%.+]] = firrtl.bits %Memory 31 to 16 : (!firrtl.uint<32>) -> !firrtl.uint<16>
-    // CHECK: [[MASK_1:%.+]] = firrtl.bits %in_mask 1 to 1 : (!firrtl.uint<2>) -> !firrtl.uint<1>
-    // CHECK: [[CHUNK_1:%.+]] = firrtl.mux([[MASK_1]], [[DATA_1]], [[NEXT_1]]) : (!firrtl.uint<1>, !firrtl.uint<16>, !firrtl.uint<16>) -> !firrtl.uint<16>
-    // CHECK: [[NEXT:%.+]] = firrtl.cat [[CHUNK_1]], [[CHUNK_0]] : (!firrtl.uint<16>, !firrtl.uint<16>) -> !firrtl.uint<32>
-    // CHECK: [[NEXT_EN:%.+]] = firrtl.mux(%in_wen, [[NEXT]], %Memory) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
+    // CHECK: [[DATA_0:%.+]] = firrtl.bits %in_data 15 to 0 : !firrtl.uint<32>
+    // CHECK: [[NEXT_0:%.+]] = firrtl.bits %Memory 15 to 0 : !firrtl.uint<32>
+    // CHECK: [[MASK_0:%.+]] = firrtl.bits %in_mask 0 to 0 : !firrtl.uint<2>
+    // CHECK: [[CHUNK_0:%.+]] = firrtl.mux([[MASK_0]], [[DATA_0]], [[NEXT_0]]) : !firrtl.uint<1>, !firrtl.uint<16>, !firrtl.uint<16>
+    // CHECK: [[DATA_1:%.+]] = firrtl.bits %in_data 31 to 16 : !firrtl.uint<32>
+    // CHECK: [[NEXT_1:%.+]] = firrtl.bits %Memory 31 to 16 : !firrtl.uint<32>
+    // CHECK: [[MASK_1:%.+]] = firrtl.bits %in_mask 1 to 1 : !firrtl.uint<2>
+    // CHECK: [[CHUNK_1:%.+]] = firrtl.mux([[MASK_1]], [[DATA_1]], [[NEXT_1]]) : !firrtl.uint<1>, !firrtl.uint<16>, !firrtl.uint<16>
+    // CHECK: [[NEXT:%.+]] = firrtl.cat [[CHUNK_1]], [[CHUNK_0]] : !firrtl.uint<16>, !firrtl.uint<16>
+    // CHECK: [[NEXT_EN:%.+]] = firrtl.mux(%in_wen, [[NEXT]], %Memory) : !firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>
     // CHECK: firrtl.matchingconnect %Memory, [[NEXT_EN]] : !firrtl.uint<32>
 
     %write_addr = firrtl.subfield %Memory_write[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<2>>
@@ -475,15 +475,15 @@ firrtl.circuit "OneAddressNoMask" {
     %rw_wmask = firrtl.subfield %Memory_rw[wmask] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, rdata flip: uint<32>, wmode: uint<1>, wdata: uint<32>, wmask: uint<1>>
     firrtl.connect %rw_wmask, %c1_ui1 : !firrtl.uint<1>, !firrtl.uint<1>
 
-    // CHECK: [[WRITING:%.+]] = firrtl.and %in_rwen, %wmode_rw : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+    // CHECK: [[WRITING:%.+]] = firrtl.and %in_rwen, %wmode_rw : !firrtl.uint<1>, !firrtl.uint<1>
     // CHECK: %Memory_rw_wen_0 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     // CHECK: firrtl.matchingconnect %Memory_rw_wen_0, [[WRITING]] : !firrtl.uint<1>
     // CHECK: %Memory_rw_wen_1 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     // CHECK: firrtl.matchingconnect %Memory_rw_wen_1, %Memory_rw_wen_0 : !firrtl.uint<1>
     // CHECK: %Memory_rw_wen_2 = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<1>
     // CHECK: firrtl.matchingconnect %Memory_rw_wen_2, %Memory_rw_wen_1 : !firrtl.uint<1>
-    // CHECK: [[WRITE_RW:%.+]] = firrtl.mux(%Memory_rw_wen_2, %Memory_rw_wdata_2, %Memory) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
-    // CHECK: [[WRITE_W:%.+]] = firrtl.mux(%Memory_write_en_2, %Memory_write_data_2, [[WRITE_RW]]) : (!firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
+    // CHECK: [[WRITE_RW:%.+]] = firrtl.mux(%Memory_rw_wen_2, %Memory_rw_wdata_2, %Memory) : !firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>
+    // CHECK: [[WRITE_W:%.+]] = firrtl.mux(%Memory_write_en_2, %Memory_write_data_2, [[WRITE_RW]]) : !firrtl.uint<1>, !firrtl.uint<32>, !firrtl.uint<32>
     // CHECK: firrtl.matchingconnect %Memory, [[WRITE_W]] : !firrtl.uint<32>
     %write_addr = firrtl.subfield %Memory_write[addr] : !firrtl.bundle<addr: uint<1>, en: uint<1>, clk: clock, data: uint<32>, mask: uint<1>>
     firrtl.connect %write_addr, %addr : !firrtl.uint<1>, !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/test.mlir
+++ b/test/Dialect/FIRRTL/test.mlir
@@ -62,11 +62,11 @@ firrtl.circuit "Top" {
                      in %b: !firrtl.uint<32>,
                      in %c: !firrtl.analog<13>,
                      in %d: !firrtl.uint<16>) {
-    %3 = firrtl.add %b, %d : (!firrtl.uint<32>, !firrtl.uint<16>) -> !firrtl.uint<33>
+    %3 = firrtl.add %b, %d : !firrtl.uint<32>, !firrtl.uint<16>
 
     %4 = firrtl.invalidvalue : !firrtl.analog<13>
     firrtl.attach %c, %4 : !firrtl.analog<13>, !firrtl.analog<13>
-    %5 = firrtl.add %3, %d : (!firrtl.uint<33>, !firrtl.uint<16>) -> !firrtl.uint<34>
+    %5 = firrtl.add %3, %d : !firrtl.uint<33>, !firrtl.uint<16>
 
     firrtl.connect %out, %5 : !firrtl.uint, !firrtl.uint<34>
   }
@@ -75,10 +75,10 @@ firrtl.circuit "Top" {
 // CHECK-LABEL: firrtl.circuit "Top" {
 // CHECK-NEXT:    firrtl.module @Top(out %out: !firrtl.uint,
 // CHECK:                            in %b: !firrtl.uint<32>, in %c: !firrtl.analog<13>, in %d: !firrtl.uint<16>) {
-// CHECK-NEXT:      %0 = firrtl.add %b, %d : (!firrtl.uint<32>, !firrtl.uint<16>) -> !firrtl.uint<33>
+// CHECK-NEXT:      %0 = firrtl.add %b, %d : !firrtl.uint<32>, !firrtl.uint<16>
 // CHECK-NEXT:      %invalid_analog13 = firrtl.invalidvalue : !firrtl.analog<13>
 // CHECK-NEXT:      firrtl.attach %c, %invalid_analog13 : !firrtl.analog<13>, !firrtl.analog<13>
-// CHECK-NEXT:      %1 = firrtl.add %0, %d : (!firrtl.uint<33>, !firrtl.uint<16>) -> !firrtl.uint<34>
+// CHECK-NEXT:      %1 = firrtl.add %0, %d : !firrtl.uint<33>, !firrtl.uint<16>
 // CHECK-NEXT:      firrtl.connect %out, %1 : !firrtl.uint, !firrtl.uint<34>
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
@@ -117,14 +117,14 @@ firrtl.module @ClockCast(in %clock: !firrtl.clock) {
 
 // CHECK-LABEL: @TestDshRL
 firrtl.module @TestDshRL(in %in1 : !firrtl.uint<2>, in %in2: !firrtl.uint<3>) {
-  // CHECK: %0 = firrtl.dshl %in1, %in2 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<9>
-  %0 = firrtl.dshl %in1, %in2 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<9>
+  // CHECK: %0 = firrtl.dshl %in1, %in2 : !firrtl.uint<2>, !firrtl.uint<3>
+  %0 = firrtl.dshl %in1, %in2 : !firrtl.uint<2>, !firrtl.uint<3>
 
-  // CHECK: %1 = firrtl.dshr %in1, %in2 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<2>
-  %1 = firrtl.dshr %in1, %in2 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<2>
+  // CHECK: %1 = firrtl.dshr %in1, %in2 : !firrtl.uint<2>, !firrtl.uint<3>
+  %1 = firrtl.dshr %in1, %in2 : !firrtl.uint<2>, !firrtl.uint<3>
 
-  // CHECK: %2 = firrtl.dshlw %in1, %in2 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<2>
-  %2 = firrtl.dshlw %in1, %in2 : (!firrtl.uint<2>, !firrtl.uint<3>) -> !firrtl.uint<2>
+  // CHECK: %2 = firrtl.dshlw %in1, %in2 : !firrtl.uint<2>, !firrtl.uint<3>
+  %2 = firrtl.dshlw %in1, %in2 : !firrtl.uint<2>, !firrtl.uint<3>
 }
 
 // We allow implicit truncation of a register's reset value.
@@ -163,10 +163,10 @@ firrtl.module @Parent() {
 firrtl.module @VerbatimExpr() {
   // CHECK: %[[TMP:.+]] = firrtl.verbatim.expr "FOO" : () -> !firrtl.uint<42>
   // CHECK: %[[TMP2:.+]] = firrtl.verbatim.expr "$bits({{[{][{]0[}][}]}})"(%[[TMP]]) : (!firrtl.uint<42>) -> !firrtl.uint<32>
-  // CHECK: firrtl.add %[[TMP]], %[[TMP2]] : (!firrtl.uint<42>, !firrtl.uint<32>) -> !firrtl.uint<43>
+  // CHECK: firrtl.add %[[TMP]], %[[TMP2]] : !firrtl.uint<42>, !firrtl.uint<32>
   %0 = firrtl.verbatim.expr "FOO" : () -> !firrtl.uint<42>
   %1 = firrtl.verbatim.expr "$bits({{0}})"(%0) : (!firrtl.uint<42>) -> !firrtl.uint<32>
-  %2 = firrtl.add %0, %1 : (!firrtl.uint<42>, !firrtl.uint<32>) -> !firrtl.uint<43>
+  %2 = firrtl.add %0, %1 : !firrtl.uint<42>, !firrtl.uint<32>
 }
 
 // CHECK-LABEL: @LowerToBind

--- a/test/Dialect/FIRRTL/vectorization.mlir
+++ b/test/Dialect/FIRRTL/vectorization.mlir
@@ -3,26 +3,26 @@
 firrtl.circuit "ElementWise" {
 // CHECK-LABEL: @ElementWise
 firrtl.module @ElementWise(in %a: !firrtl.vector<uint<1>, 2>, in %b: !firrtl.vector<uint<1>, 2>, out %c_0: !firrtl.vector<uint<1>, 2>, out %c_1: !firrtl.vector<uint<1>, 2>, out %c_2: !firrtl.vector<uint<1>, 2>) {
-  // CHECK-NEXT: %0 = firrtl.elementwise_or %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: %0 = firrtl.elementwise_or %a, %b : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   // CHECK-NEXT: firrtl.matchingconnect %c_0, %0 : !firrtl.vector<uint<1>, 2>
-  // CHECK-NEXT: %1 = firrtl.elementwise_and %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: %1 = firrtl.elementwise_and %a, %b : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   // CHECK-NEXT: firrtl.matchingconnect %c_1, %1 : !firrtl.vector<uint<1>, 2>
-  // CHECK-NEXT: %2 = firrtl.elementwise_xor %a, %b : (!firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>) -> !firrtl.vector<uint<1>, 2>
+  // CHECK-NEXT: %2 = firrtl.elementwise_xor %a, %b : !firrtl.vector<uint<1>, 2>, !firrtl.vector<uint<1>, 2>
   // CHECK-NEXT: firrtl.matchingconnect %c_2, %2 : !firrtl.vector<uint<1>, 2>
   %0 = firrtl.subindex %b[1] : !firrtl.vector<uint<1>, 2>
   %1 = firrtl.subindex %a[1] : !firrtl.vector<uint<1>, 2>
   %2 = firrtl.subindex %b[0] : !firrtl.vector<uint<1>, 2>
   %3 = firrtl.subindex %a[0] : !firrtl.vector<uint<1>, 2>
-  %4 = firrtl.or %3, %2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  %5 = firrtl.or %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %4 = firrtl.or %3, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  %5 = firrtl.or %1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   %6 = firrtl.vectorcreate %4, %5 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
   firrtl.matchingconnect %c_0, %6 : !firrtl.vector<uint<1>, 2>
-  %7 = firrtl.and %3, %2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  %8 = firrtl.and %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %7 = firrtl.and %3, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  %8 = firrtl.and %1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   %9 = firrtl.vectorcreate %7, %8 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
   firrtl.matchingconnect %c_1, %9 : !firrtl.vector<uint<1>, 2>
-  %10 = firrtl.xor %3, %2 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-  %11 = firrtl.xor %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  %10 = firrtl.xor %3, %2 : !firrtl.uint<1>, !firrtl.uint<1>
+  %11 = firrtl.xor %1, %0 : !firrtl.uint<1>, !firrtl.uint<1>
   %12 = firrtl.vectorcreate %10, %11 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.vector<uint<1>, 2>
   firrtl.matchingconnect %c_2, %12 : !firrtl.vector<uint<1>, 2>
 }

--- a/test/firtool/connect.fir
+++ b/test/firtool/connect.fir
@@ -3,7 +3,7 @@
 ; Ensure connect is demoted to partial connect in the presence of implicit truncation.
 
 ; CHECK-LABEL: @regularConnect
-; CHECK: %0 = firrtl.pad %b, 5 : (!firrtl.uint<3>) -> !firrtl.uint<5>
+; CHECK: %0 = firrtl.pad %b, 5 : !firrtl.uint<3>
 ; CHECK: firrtl.matchingconnect %a, %0 : !firrtl.uint<5>
 FIRRTL version 4.0.0
 circuit regularConnect :
@@ -15,7 +15,7 @@ circuit regularConnect :
 ; // -----
 
 ; CHECK-LABEL: @truncatingIntegerConnect
-; CHECK: %0 = firrtl.tail %b, 2 : (!firrtl.uint<5>) -> !firrtl.uint<3>
+; CHECK: %0 = firrtl.tail %b, 2 : !firrtl.uint<5>
 ; CHECK: firrtl.matchingconnect %a, %0 : !firrtl.uint<3>
 FIRRTL version 4.0.0
 circuit truncatingIntegerConnect :
@@ -29,11 +29,11 @@ circuit truncatingIntegerConnect :
 ; CHECK-LABEL: @regularBundleConnect
 ; CHECK: %0 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<5>, b: uint<3>>
 ; CHECK: %1 = firrtl.subfield %b[a] : !firrtl.bundle<a: uint<3>, b: uint<2>>
-; CHECK: %2 = firrtl.pad %1, 5 : (!firrtl.uint<3>) -> !firrtl.uint<5>
+; CHECK: %2 = firrtl.pad %1, 5 : !firrtl.uint<3>
 ; CHECK: firrtl.matchingconnect %0, %2 : !firrtl.uint<5>
 ; CHECK: %3 = firrtl.subfield %a[b] : !firrtl.bundle<a: uint<5>, b: uint<3>>
 ; CHECK: %4 = firrtl.subfield %b[b] : !firrtl.bundle<a: uint<3>, b: uint<2>>
-; CHECK: %5 = firrtl.pad %4, 3 : (!firrtl.uint<2>) -> !firrtl.uint<3>
+; CHECK: %5 = firrtl.pad %4, 3 : !firrtl.uint<2>
 ; CHECK: firrtl.matchingconnect %3, %5 : !firrtl.uint<3>
 FIRRTL version 4.0.0
 circuit regularBundleConnect :
@@ -47,11 +47,11 @@ circuit regularBundleConnect :
 ; CHECK-LABEL: @truncatingBundleConnect
 ; CHECK: %0 = firrtl.subfield %a[a] : !firrtl.bundle<a: uint<5>, b: uint<3>>
 ; CHECK: %1 = firrtl.subfield %b[a] : !firrtl.bundle<a: uint<6>, b: uint<1>>
-; CHECK: %2 = firrtl.tail %1, 1 : (!firrtl.uint<6>) -> !firrtl.uint<5>
+; CHECK: %2 = firrtl.tail %1, 1 : !firrtl.uint<6>
 ; CHECK: firrtl.matchingconnect %0, %2 : !firrtl.uint<5>
 ; CHECK: %3 = firrtl.subfield %a[b] : !firrtl.bundle<a: uint<5>, b: uint<3>>
 ; CHECK: %4 = firrtl.subfield %b[b] : !firrtl.bundle<a: uint<6>, b: uint<1>>
-; CHECK: %5 = firrtl.pad %4, 3 : (!firrtl.uint<1>) -> !firrtl.uint<3>
+; CHECK: %5 = firrtl.pad %4, 3 : !firrtl.uint<1>
 ; CHECK: firrtl.matchingconnect %3, %5 : !firrtl.uint<3>
 FIRRTL version 4.0.0
 circuit truncatingBundleConnect :

--- a/test/firtool/firtool.fir
+++ b/test/firtool/firtool.fir
@@ -116,12 +116,12 @@ circuit test_mod : %[[{"class": "circt.testNT", "data": "a"}]]
 ; MLIR-NEXT:    firrtl.matchingconnect %cat_c, %b : !firrtl.uint<2>
 ; MLIR-NEXT:    %implicitTrunc_inp_1, %implicitTrunc_inp_2, %implicitTrunc_out1, %implicitTrunc_out2 = firrtl.instance implicitTrunc @ImplicitTrunc(in inp_1: !firrtl.uint<1>, in inp_2: !firrtl.sint<5>, out out1: !firrtl.sint<3>, out out2: !firrtl.sint<3>)
 ; MLIR-NEXT:    firrtl.matchingconnect %implicitTrunc_inp_1, %a : !firrtl.uint<1>
-; MLIR-NEXT:    %0 = firrtl.asSInt %cat_d : (!firrtl.uint<6>) -> !firrtl.sint<6>
-; MLIR-NEXT:    %1 = firrtl.bits %0 4 to 0 : (!firrtl.sint<6>) -> !firrtl.uint<5>
-; MLIR-NEXT:    %2 = firrtl.asSInt %1 : (!firrtl.uint<5>) -> !firrtl.sint<5>
+; MLIR-NEXT:    %0 = firrtl.asSInt %cat_d : !firrtl.uint<6>
+; MLIR-NEXT:    %1 = firrtl.bits %0 4 to 0 : !firrtl.sint<6>
+; MLIR-NEXT:    %2 = firrtl.asSInt %1 : !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.matchingconnect %implicitTrunc_inp_2, %2 : !firrtl.sint<5>
 ; MLIR:         %prettifyExample_inp_1, %prettifyExample_inp_2, %prettifyExample_inp_3, %prettifyExample_out1, %prettifyExample_out2 = firrtl.instance prettifyExample @PrettifyExample(in inp_1: !firrtl.uint<5>, in inp_2: !firrtl.uint<5>, in inp_3: !firrtl.uint<5>, out out1: !firrtl.uint<10>, out out2: !firrtl.uint<10>)
-; MLIR-NEXT:    %3 = firrtl.bits %cat_d 4 to 0 : (!firrtl.uint<6>) -> !firrtl.uint<5>
+; MLIR-NEXT:    %3 = firrtl.bits %cat_d 4 to 0 : !firrtl.uint<6>
 ; MLIR-NEXT:    firrtl.matchingconnect %prettifyExample_inp_1, %3 : !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.matchingconnect %prettifyExample_inp_2, %3 : !firrtl.uint<5>
 ; MLIR-NEXT:    firrtl.matchingconnect %prettifyExample_inp_3, %3 : !firrtl.uint<5>


### PR DESCRIPTION
Many expressions in FIRRTL implement the InferTypesOpInterface, but we include an explicit result type in the assembly format.  This change removes the explicit result type in the asm format for many FIRRTL expressions, which means less typing.