### PR TITLE
[HW] Add a verifier for HWInstanceLike

### DIFF
--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -507,14 +507,6 @@ def HWInstanceLike : OpInterface<"HWInstanceLike", [
       "bool", "getDoNotPrint", (ins)
     >
   ];
-
-  let verify = [{
-    if (cast<circt::hw::HWInstanceLike>(op)
-            .getReferencedModuleNamesAttr()
-            .size())
-      return success();
-    return op->emitOpError("has empty list of referenced modules");
-  }];
 }
 
 def InnerRefNamespace : NativeOpTrait<"InnerRefNamespace">;

--- a/include/circt/Dialect/HW/HWOpInterfaces.td
+++ b/include/circt/Dialect/HW/HWOpInterfaces.td
@@ -507,6 +507,14 @@ def HWInstanceLike : OpInterface<"HWInstanceLike", [
       "bool", "getDoNotPrint", (ins)
     >
   ];
+
+  let verify = [{
+    if (cast<circt::hw::HWInstanceLike>(op)
+            .getReferencedModuleNamesAttr()
+            .size())
+      return success();
+    return op->emitOpError("has empty list of referenced modules");
+  }];
 }
 
 def InnerRefNamespace : NativeOpTrait<"InnerRefNamespace">;

--- a/include/circt/Support/InstanceGraphInterface.td
+++ b/include/circt/Support/InstanceGraphInterface.td
@@ -49,6 +49,14 @@ def InstanceGraphInstanceOpInterface : OpInterface<"InstanceOpInterface"> {
       return ::mlir::ArrayAttr::get(attr.getContext(), {attr});
     }]>,
   ];
+
+  let verify = [{
+    if (mlir::cast<ConcreteOp>($_op)
+            .getReferencedModuleNamesAttr()
+            .size())
+      return success();
+    return $_op->emitOpError("has empty list of referenced modules");
+  }];
 }
 
 def InstanceGraphModuleOpInterface : OpInterface<"ModuleOpInterface"> {

--- a/include/circt/Support/InstanceGraphInterface.td
+++ b/include/circt/Support/InstanceGraphInterface.td
@@ -55,7 +55,7 @@ def InstanceGraphInstanceOpInterface : OpInterface<"InstanceOpInterface"> {
             .getReferencedModuleNamesAttr()
             .size())
       return success();
-    return $_op->emitOpError("has empty list of referenced modules");
+    return $_op->emitOpError("expected a non-empty list of referenced modules");
   }];
 }
 


### PR DESCRIPTION
Add a verifier to `HWInstanceLike` to ensure the referenced modules list is non empty.