### PR TITLE
[Moore] Add explicit truncation and zero/sign-extension

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -36,6 +36,11 @@ class ResultIsSingleBitMatchingInputDomain<string result, string input> :
       llvm::cast<UnpackedType>($_self).getDomain())
   }]>;
 
+class TypeDomainsMatch<list<string> values> :
+  AllMatchSameOperatorTrait<values, [{
+    cast<moore::UnpackedType>($_self.getType()).getDomain()
+  }], "domain">;
+
 //===----------------------------------------------------------------------===//
 // Structure
 //===----------------------------------------------------------------------===//
@@ -504,7 +509,7 @@ def StringConstantOp : MooreOp<"string_constant", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
-// Expressions
+// Casting and Resizing
 //===----------------------------------------------------------------------===//
 
 def ConversionOp : MooreOp<"conversion", [Pure]> {
@@ -537,6 +542,61 @@ def ConversionOp : MooreOp<"conversion", [Pure]> {
   }];
   let hasFolder = 1;
 }
+
+def TruncOp : MooreOp<"trunc", [
+  Pure,
+  TypeDomainsMatch<["input", "result"]>,
+  PredOpTrait<"result width must be smaller than input width", CPred<[{
+    cast<moore::IntType>($result.getType()).getBitSize() <
+      cast<moore::IntType>($input.getType()).getBitSize()
+  }]>>,
+]> {
+  let summary = "Truncate a value";
+  let description = [{
+    Reduce the bit width of a value by removing some of its most significant
+    bits. This can only change the bit width of an integer type.
+  }];
+  let arguments = (ins IntType:$input);
+  let results = (outs IntType:$result);
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input) `->` type($result)
+  }];
+}
+
+class ExtOpBase<string mnemonic> : MooreOp<mnemonic, [
+  Pure,
+  TypeDomainsMatch<["input", "result"]>,
+  PredOpTrait<"result width must be larger than input width", CPred<[{
+    cast<moore::IntType>($result.getType()).getBitSize() >
+      cast<moore::IntType>($input.getType()).getBitSize()
+  }]>>,
+]> {
+  let arguments = (ins IntType:$input);
+  let results = (outs IntType:$result);
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input) `->` type($result)
+  }];
+}
+
+def ZExtOp : ExtOpBase<"zext"> {
+  let summary = "Zero-extend a value";
+  let description = [{
+    Increase the bit width of a value by inserting additional zero most
+    significant bits. This keeps the unsigned value constant.
+  }];
+}
+
+def SExtOp : ExtOpBase<"sext"> {
+  let summary = "Sign-extend a value";
+  let description = [{
+    Increase the bit width of a value by replicating its most significant bit.
+    This keeps the signed value constant.
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Expressions
+//===----------------------------------------------------------------------===//
 
 def NegOp : MooreOp<"neg", [Pure, SameOperandsAndResultType]> {
   let summary = "Arithmetic negation";

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -121,6 +121,11 @@ struct Context {
   /// if the given value is null.
   Value convertToSimpleBitVector(Value value);
 
+  /// Helper function to insert the necessary operations to cast a value from
+  /// one type to another.
+  Value materializeConversion(Type type, Value value, bool isSigned,
+                              Location loc);
+
   /// Helper function to materialize an `SVInt` as an SSA value.
   Value materializeSVInt(const slang::SVInt &svint,
                          const slang::ast::Type &type, Location loc);

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -65,18 +65,6 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
   moore.constant 12 : !moore.i32
   moore.constant 3 : !moore.i6
 
-  moore.conversion %arg0 : !moore.i1 -> !moore.l1
-  // CHECK-NEXT: [[V0:%.+]] = hw.constant 0 : i2 
-  // CHECK-NEXT: comb.concat [[V0]], %arg2 : i2, i6 
-  moore.conversion %arg2 : !moore.i6 -> !moore.l8
-  // CHECK-NEXT: [[V0:%.+]] = comb.extract %arg2 from 4 : (i6) -> i2
-  // CHECK-NEXT: [[V1:%.+]] = hw.constant 0 : i2
-  // CHECK-NEXT: [[V2:%.+]] = comb.icmp eq [[V0]], [[V1]] : i2
-  // CHECK-NEXT: [[V3:%.+]] = comb.extract %arg2 from 0 : (i6) -> i4
-  // CHECK-NEXT: [[V4:%.+]] = hw.constant -1 : i4
-  // CHECK-NEXT: comb.mux [[V2]], [[V3]], [[V4]] : i4
-  moore.conversion %arg2 : !moore.i6 -> !moore.l4
-
   // CHECK-NEXT: [[V0:%.+]] = hw.constant 0 : i5
   // CHECK-NEXT: [[V1:%.+]] = comb.concat [[V0]], %arg0 : i5, i1
   // CHECK-NEXT: comb.shl %arg2, [[V1]] : i6
@@ -878,4 +866,35 @@ moore.module @StringConstant() {
     %str_empty = moore.string_constant "" : i0
     moore.return
   }
+}
+
+// CHECK-LABEL: func.func @Conversions
+func.func @Conversions(%arg0: !moore.i16, %arg1: !moore.l16) {
+  // CHECK: [[TMP:%.+]] = comb.extract %arg0 from 0 : (i16) -> i8
+  // CHECK: dbg.variable "trunc", [[TMP]]
+  %0 = moore.trunc %arg0 : i16 -> i8
+  dbg.variable "trunc", %0 : !moore.i8
+
+  // CHECK: [[ZEXT:%.+]] = hw.constant 0 : i16
+  // CHECK: [[TMP:%.+]] = comb.concat [[ZEXT]], %arg0 : i16, i16
+  // CHECK: dbg.variable "zext", [[TMP]]
+  %1 = moore.zext %arg0 : i16 -> i32
+  dbg.variable "zext", %1 : !moore.i32
+
+  // CHECK: [[SIGN:%.+]] = comb.extract %arg0 from 15 : (i16) -> i1
+  // CHECK: [[SEXT:%.+]] = comb.replicate [[SIGN]] : (i1) -> i16
+  // CHECK: [[TMP:%.+]] = comb.concat [[SEXT]], %arg0 : i16, i16
+  // CHECK: dbg.variable "sext", [[TMP]]
+  %2 = moore.sext %arg0 : i16 -> i32
+  dbg.variable "sext", %2 : !moore.i32
+
+  // CHECK: dbg.variable "i2l", %arg0 : i16
+  %3 = moore.conversion %arg0 : !moore.i16 -> !moore.l16
+  dbg.variable "i2l", %3 : !moore.l16
+
+  // CHECK: dbg.variable "l2i", %arg1 : i16
+  %4 = moore.conversion %arg1 : !moore.l16 -> !moore.i16
+  dbg.variable "l2i", %4 : !moore.i16
+
+  return
 }


### PR DESCRIPTION
Add the `moore.trunc` operation to explicitly truncate the bit width of `IntType` values, and `moore.zext` and `moore.sext` to explicitly extend such a value with zeroes or its sign bit.

This requires tweaking the way how ImportVerilog generates conversion ops. Currently `moore.conversion` is used as a catch-all operation that expresses any kind of type conversion. In the future, we'll want to split this up into multiple dedicated operations. These width adjustment ops are the first step in that direction.

Making sign-extension explicit also fixes a long-standing issue where a `$signed` or `signed'(x)` expression would be erroneously converted into a zero-extension.