### PR TITLE
[FIRRTL] Emitting EICG wrapper warning only once

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
@@ -61,6 +61,7 @@ void LowerIntmodulesPass::runOnOperation() {
   auto &ig = getAnalysis<InstanceGraph>();
 
   bool changed = false;
+  bool warningEmittedOnce = false;
 
   // Convert to int ops.
   for (auto op :
@@ -158,8 +159,11 @@ void LowerIntmodulesPass::runOnOperation() {
       //        it causes an error with `fixupEICGWrapper`. For now drop the
       //        annotation until we fully migrate into EICG intrinsic.
       if (AnnotationSet::removeAnnotations(op, firrtl::dedupGroupAnnoClass))
-        op.emitWarning() << "Annotation " << firrtl::dedupGroupAnnoClass
-                         << " on EICG_wrapper is dropped";
+        if (!warningEmittedOnce) {
+          op.emitWarning() << "Annotation " << firrtl::dedupGroupAnnoClass
+                           << " on EICG_wrapper is dropped";
+          warningEmittedOnce = true;
+        }
 
       if (failed(checkModForAnnotations(op, eicgName)))
         return signalPassFailure();

--- a/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerIntmodules.cpp
@@ -61,7 +61,7 @@ void LowerIntmodulesPass::runOnOperation() {
   auto &ig = getAnalysis<InstanceGraph>();
 
   bool changed = false;
-  bool warningEmittedOnce = false;
+  bool warnEICGwrapperDropsDedupAnno = false;
 
   // Convert to int ops.
   for (auto op :
@@ -159,10 +159,10 @@ void LowerIntmodulesPass::runOnOperation() {
       //        it causes an error with `fixupEICGWrapper`. For now drop the
       //        annotation until we fully migrate into EICG intrinsic.
       if (AnnotationSet::removeAnnotations(op, firrtl::dedupGroupAnnoClass))
-        if (!warningEmittedOnce) {
+        if (!warnEICGwrapperDropsDedupAnno) {
           op.emitWarning() << "Annotation " << firrtl::dedupGroupAnnoClass
                            << " on EICG_wrapper is dropped";
-          warningEmittedOnce = true;
+          warnEICGwrapperDropsDedupAnno = true;
         }
 
       if (failed(checkModForAnnotations(op, eicgName)))


### PR DESCRIPTION
The EICG wrapper warning is be emitted unless the switchover to the intrinsic is made.
There are some designs where we have hundreds of clock gates, the warning clogs up the stdout for such cases.
This commit, ensures the warning is emitted only once.
