### PR TITLE
[circt-verilog] Support MLIR and MLIRBC input files

### DIFF
--- a/test/circt-verilog/basic.mlir
+++ b/test/circt-verilog/basic.mlir
@@ -1,0 +1,7 @@
+// RUN: circt-verilog %s | FileCheck %s
+// RUN: cat %s | circt-verilog --format mlir | FileCheck %s
+
+// CHECK: hw.module @Foo() {
+// CHECK: }
+moore.module @Foo() {
+}

--- a/tools/circt-verilog/CMakeLists.txt
+++ b/tools/circt-verilog/CMakeLists.txt
@@ -1,13 +1,28 @@
-add_circt_tool(circt-verilog
-  circt-verilog.cpp
-)
-
-llvm_update_compile_flags(circt-verilog)
-
-target_link_libraries(circt-verilog PRIVATE
+set(libs
+  CIRCTComb
+  CIRCTDebug
+  CIRCTHW
   CIRCTImportVerilog
+  CIRCTLLHD
+  CIRCTMoore
   CIRCTMooreToCore
   CIRCTMooreTransforms
+  CIRCTSeq
+  CIRCTSim
   CIRCTSupport
+  CIRCTVerif
+  MLIRBytecodeReader
+  MLIRControlFlowDialect
+  MLIRFuncDialect
   MLIRIR
+  MLIRParser
+  MLIRSCFDialect
+  MLIRSCFDialect
+  MLIRSupport
 )
+
+add_circt_tool(circt-verilog circt-verilog.cpp DEPENDS ${libs})
+target_link_libraries(circt-verilog PRIVATE ${libs})
+
+llvm_update_compile_flags(circt-verilog)
+mlir_check_all_link_libraries(circt-verilog)

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -14,11 +14,23 @@
 
 #include "circt/Conversion/ImportVerilog.h"
 #include "circt/Conversion/MooreToCore.h"
+#include "circt/Dialect/Comb/CombDialect.h"
+#include "circt/Dialect/Debug/DebugDialect.h"
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/LLHD/IR/LLHDDialect.h"
+#include "circt/Dialect/Moore/MooreDialect.h"
 #include "circt/Dialect/Moore/MoorePasses.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Sim/SimDialect.h"
+#include "circt/Dialect/Verif/VerifDialect.h"
 #include "circt/Support/Passes.h"
 #include "circt/Support/Version.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Transforms/Passes.h"
@@ -26,6 +38,7 @@
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
+#include "llvm/Support/WithColor.h"
 
 using namespace llvm;
 using namespace mlir;
@@ -36,6 +49,11 @@ using namespace circt;
 //===----------------------------------------------------------------------===//
 
 namespace {
+enum class Format {
+  SV,
+  MLIR,
+};
+
 enum class LoweringMode {
   OnlyPreprocess,
   OnlyLint,
@@ -47,6 +65,13 @@ enum class LoweringMode {
 
 struct CLOptions {
   cl::OptionCategory cat{"Verilog Frontend Options"};
+
+  cl::opt<Format> format{
+      "format", cl::desc("Input file format (auto-detected by default)"),
+      cl::values(
+          clEnumValN(Format::SV, "sv", "Parse as SystemVerilog files"),
+          clEnumValN(Format::MLIR, "mlir", "Parse as MLIR or MLIRBC file")),
+      cl::cat(cat)};
 
   cl::list<std::string> inputFilenames{cl::Positional,
                                        cl::desc("<input files>"), cl::cat(cat)};
@@ -330,29 +355,44 @@ static LogicalResult executeWithSources(MLIRContext *context,
   std::string errorMessage;
   auto outputFile = openOutputFile(opts.outputFilename, &errorMessage);
   if (!outputFile) {
-    llvm::errs() << errorMessage << "\n";
+    WithColor::error() << errorMessage << "\n";
     return failure();
   }
 
-  // If the user requested for the files to be only preprocessed, do so and
-  // print the results to the configured output file.
-  if (opts.loweringMode == LoweringMode::OnlyPreprocess) {
-    auto result =
-        preprocessVerilog(sourceMgr, context, ts, outputFile->os(), &options);
-    if (succeeded(result))
-      outputFile->keep();
-    return result;
+  // Parse the input as SystemVerilog or MLIR file.
+  OwningOpRef<ModuleOp> module;
+  switch (opts.format) {
+  case Format::SV: {
+    auto parserTimer = ts.nest("SystemVerilog Parser");
+
+    // If the user requested for the files to be only preprocessed, do so and
+    // print the results to the configured output file.
+    if (opts.loweringMode == LoweringMode::OnlyPreprocess) {
+      auto result =
+          preprocessVerilog(sourceMgr, context, ts, outputFile->os(), &options);
+      if (succeeded(result))
+        outputFile->keep();
+      return result;
+    }
+
+    // Parse the Verilog input into an MLIR module.
+    module = ModuleOp::create(UnknownLoc::get(context));
+    if (failed(importVerilog(sourceMgr, context, ts, module.get(), &options)))
+      return failure();
+
+    // If the user requested for the files to be only linted, the module remains
+    // empty and there is nothing left to do.
+    if (opts.loweringMode == LoweringMode::OnlyLint)
+      return success();
+  } break;
+
+  case Format::MLIR: {
+    auto parserTimer = ts.nest("MLIR Parser");
+    module = parseSourceFile<ModuleOp>(sourceMgr, context);
+  } break;
   }
-
-  // Parse the Verilog input into an MLIR module.
-  OwningOpRef<ModuleOp> module(ModuleOp::create(UnknownLoc::get(context)));
-  if (failed(importVerilog(sourceMgr, context, ts, module.get(), &options)))
+  if (!module)
     return failure();
-
-  // If the user requested for the files to be only linted, the module remains
-  // empty and there is nothing left to do.
-  if (opts.loweringMode == LoweringMode::OnlyLint)
-    return success();
 
   // If the user requested anything besides simply parsing the input, run the
   // appropriate transformation passes according to the command line options.
@@ -367,19 +407,50 @@ static LogicalResult executeWithSources(MLIRContext *context,
   }
 
   // Print the final MLIR.
+  auto outputTimer = ts.nest("MLIR Printer");
   module->print(outputFile->os());
   outputFile->keep();
   return success();
 }
 
 static LogicalResult execute(MLIRContext *context) {
+  // Default to reading from stdin if no files were provided.
+  if (opts.inputFilenames.empty())
+    opts.inputFilenames.push_back("-");
+
+  // Auto-detect the input format if it was not explicitly specified.
+  if (opts.format.getNumOccurrences() == 0) {
+    std::optional<Format> detectedFormat = std::nullopt;
+    for (const auto &inputFilename : opts.inputFilenames) {
+      std::optional<Format> format = std::nullopt;
+      auto name = StringRef(inputFilename);
+      if (name.ends_with(".v") || name.ends_with(".sv") ||
+          name.ends_with(".vh") || name.ends_with(".svh"))
+        format = Format::SV;
+      else if (name.ends_with(".mlir") || name.ends_with(".mlirbc"))
+        format = Format::MLIR;
+      if (!format)
+        continue;
+      if (detectedFormat && format != detectedFormat) {
+        detectedFormat = std::nullopt;
+        break;
+      }
+      detectedFormat = format;
+    }
+    if (!detectedFormat) {
+      WithColor::error() << "cannot auto-detect input format; use --format\n";
+      return failure();
+    }
+    opts.format = *detectedFormat;
+  }
+
   // Open the input files.
   llvm::SourceMgr sourceMgr;
   for (const auto &inputFilename : opts.inputFilenames) {
     std::string errorMessage;
     auto buffer = openInputFile(inputFilename, &errorMessage);
     if (!buffer) {
-      llvm::errs() << errorMessage << "\n";
+      WithColor::error() << errorMessage << "\n";
       return failure();
     }
     sourceMgr.AddNewSourceBuffer(std::move(buffer), llvm::SMLoc());
@@ -420,7 +491,25 @@ int main(int argc, char **argv) {
   cl::ParseCommandLineOptions(argc, argv,
                               "Verilog and SystemVerilog frontend\n");
 
+  // Register the dialects.
+  // clang-format off
+  DialectRegistry registry;
+  registry.insert<
+    cf::ControlFlowDialect,
+    comb::CombDialect,
+    debug::DebugDialect,
+    func::FuncDialect,
+    hw::HWDialect,
+    llhd::LLHDDialect,
+    moore::MooreDialect,
+    scf::SCFDialect,
+    seq::SeqDialect,
+    sim::SimDialect,
+    verif::VerifDialect
+  >();
+  // clang-format on
+
   // Perform the actual work and use "exit" to avoid slow context teardown.
-  MLIRContext context;
+  MLIRContext context(registry);
   exit(failed(execute(&context)));
 }


### PR DESCRIPTION
Add a `--format` option to circt-verilog that allows it to read SV and MLIR input files. Being able to read MLIR files is useful for debugging or when developing new transformation passes.

Also makes error message use the `WithColor::error()` prefix for somewhat nicer readability.