### PR TITLE
[SMT] Add reset op

### DIFF
--- a/include/circt/Dialect/SMT/SMTOps.td
+++ b/include/circt/Dialect/SMT/SMTOps.td
@@ -153,6 +153,11 @@ def AssertOp : SMTOp<"assert", []> {
   let assemblyFormat = "$input attr-dict";
 }
 
+def ResetOp : SMTOp<"reset", []> {
+  let summary = "reset the solver";
+  let assemblyFormat = "attr-dict";
+}
+
 def CheckOp : SMTOp<"check", [
   NoRegionArguments,
   SingleBlockImplicitTerminator<"smt::YieldOp">,

--- a/include/circt/Dialect/SMT/SMTVisitors.h
+++ b/include/circt/Dialect/SMT/SMTVisitors.h
@@ -44,7 +44,7 @@ public:
             // Variable/symbol declaration
             DeclareFunOp, ApplyFuncOp,
             // solver interaction
-            SolverOp, AssertOp, CheckOp,
+            SolverOp, AssertOp, ResetOp, CheckOp,
             // Boolean logic
             NotOp, AndOp, OrOp, XOrOp, ImpliesOp,
             // Arrays
@@ -124,6 +124,7 @@ public:
 
   HANDLE(SolverOp, Unhandled);
   HANDLE(AssertOp, Unhandled);
+  HANDLE(ResetOp, Unhandled);
   HANDLE(CheckOp, Unhandled);
 
   // Boolean logic operations

--- a/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
+++ b/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
@@ -1395,9 +1395,9 @@ void circt::populateSMTToZ3LLVMConversionPatterns(
   // Other lowering patterns. Refer to their implementation directly for more
   // information.
   patterns.add<BVConstantOpLowering, DeclareFunOpLowering, AssertOpLowering,
-               CheckOpLowering, SolverOpLowering, ApplyFuncOpLowering,
-               YieldOpLowering, RepeatOpLowering, ExtractOpLowering,
-               BoolConstantOpLowering, IntConstantOpLowering,
+               ResetOpLowering, CheckOpLowering, SolverOpLowering,
+               ApplyFuncOpLowering, YieldOpLowering, RepeatOpLowering,
+               ExtractOpLowering, BoolConstantOpLowering, IntConstantOpLowering,
                ArrayBroadcastOpLowering, BVCmpOpLowering, IntCmpOpLowering,
                IntAbsOpLowering, QuantifierLowering<ForallOp>,
                QuantifierLowering<ExistsOp>>(converter, patterns.getContext(),

--- a/lib/Target/ExportSMTLIB/ExportSMTLIB.cpp
+++ b/lib/Target/ExportSMTLIB/ExportSMTLIB.cpp
@@ -560,8 +560,6 @@ struct StatementVisitor
 
   LogicalResult visitSMTOp(ResetOp op, mlir::raw_indented_ostream &stream,
                            ValueMap &valueMap) {
-    if (op->getNumResults() != 0)
-      return op.emitError() << "must not have any result values";
     stream << "(reset)\n";
     return success();
   }

--- a/lib/Target/ExportSMTLIB/ExportSMTLIB.cpp
+++ b/lib/Target/ExportSMTLIB/ExportSMTLIB.cpp
@@ -558,6 +558,14 @@ struct StatementVisitor
     return success();
   }
 
+  LogicalResult visitSMTOp(ResetOp op, mlir::raw_indented_ostream &stream,
+                           ValueMap &valueMap) {
+    if (op->getNumResults() != 0)
+      return op.emitError() << "must not have any result values";
+    stream << "(reset)\n";
+    return success();
+  }
+
   LogicalResult visitSMTOp(CheckOp op, mlir::raw_indented_ostream &stream,
                            ValueMap &valueMap) {
     if (op->getNumResults() != 0)

--- a/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
+++ b/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
@@ -138,6 +138,9 @@ func.func @test(%arg0: i32) {
     // CHECK: llvm.call @Z3_solver_assert([[CTX]], [[S]], [[AND]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
     smt.assert %7
 
+      // CHECK: llvm.call @Z3_solver_reset([[CTX]], [[S]]) : (!llvm.ptr, !llvm.ptr) -> ()
+    smt.reset
+
     // CHECK-DEBUG: [[SOLVER_STR:%.+]] = llvm.call @Z3_solver_to_string({{.*}}, {{.*}}) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
     // CHECK-DEBUG: [[FMT_STR:%.+]] = llvm.mlir.addressof @str{{.*}} : !llvm.ptr
     // CHECK-DEBUG: llvm.call @printf([[FMT_STR]], [[SOLVER_STR]]) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, !llvm.ptr) -> i32

--- a/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
+++ b/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
@@ -138,7 +138,7 @@ func.func @test(%arg0: i32) {
     // CHECK: llvm.call @Z3_solver_assert([[CTX]], [[S]], [[AND]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
     smt.assert %7
 
-      // CHECK: llvm.call @Z3_solver_reset([[CTX]], [[S]]) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @Z3_solver_reset([[CTX]], [[S]]) : (!llvm.ptr, !llvm.ptr) -> ()
     smt.reset
 
     // CHECK-DEBUG: [[SOLVER_STR:%.+]] = llvm.call @Z3_solver_to_string({{.*}}, {{.*}}) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr

--- a/test/Dialect/SMT/basic.mlir
+++ b/test/Dialect/SMT/basic.mlir
@@ -26,6 +26,9 @@ func.func @core(%in: i8) {
   // CHECK: smt.assert %a {smt.some_attr}
   smt.assert %a {smt.some_attr}
 
+  // CHECK: smt.reset {smt.some_attr}
+  smt.reset {smt.some_attr}
+
   // CHECK: %{{.*}} = smt.solver(%{{.*}}) {smt.some_attr} : (i8) -> (i8, i32) {
   // CHECK: ^bb0(%{{.*}}: i8)
   // CHECK:   %{{.*}} = smt.check {smt.some_attr} sat {

--- a/test/Target/ExportSMTLIB/core.mlir
+++ b/test/Target/ExportSMTLIB/core.mlir
@@ -118,4 +118,8 @@ smt.solver () : () -> () {
 
   // CHECK: (reset)
   // CHECK-INLINED: (reset)
+  smt.reset
+
+  // CHECK: (reset)
+  // CHECK-INLINED: (reset)
 }


### PR DESCRIPTION
Adds the SMTLIB reset op that resets a solver to its initial state 