### PR TITLE
[FIRRTL] InferRW: copy all attributes of masked memeories

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferReadWrite.cpp
@@ -556,11 +556,11 @@ private:
 
       // Copy everything from old memory, except the result type.
       auto newMem = builder.create<MemOp>(
-          resultTypes, memOp.getReadLatency(), memOp.getWriteLatency(),
-          memOp.getDepth(), memOp.getRuw(), memOp.getPortNames().getValue(),
-          memOp.getNameAttr(), memOp.getNameKind(),
-          memOp.getAnnotations().getValue(),
-          memOp.getPortAnnotations().getValue(), memOp.getInnerSymAttr());
+          resultTypes, memOp.getReadLatencyAttr(), memOp.getWriteLatencyAttr(),
+          memOp.getDepthAttr(), memOp.getRuwAttr(), memOp.getPortNamesAttr(),
+          memOp.getNameAttr(), memOp.getNameKindAttr(),
+          memOp.getAnnotationsAttr(), memOp.getPortAnnotationsAttr(),
+          memOp.getInnerSymAttr(), memOp.getInitAttr(), memOp.getPrefixAttr());
       // Now replace the result of old memory with the new one.
       for (const auto &portIt : llvm::enumerate(memOp.getResults())) {
         // Old result.

--- a/test/Dialect/FIRRTL/inferRW.mlir
+++ b/test/Dialect/FIRRTL/inferRW.mlir
@@ -246,9 +246,9 @@ firrtl.circuit "TLRAM" {
     firrtl.module @constMask(in %clock: !firrtl.clock, in %reset: !firrtl.asyncreset, in %index: !firrtl.uint<4>, in %index2: !firrtl.uint<4>, in %data_0: !firrtl.uint<8>, in %wen: !firrtl.uint<1>, in %_T_29: !firrtl.uint<1>, out %auto_0: !firrtl.uint<8>) {
       %mem_MPORT_en = firrtl.wire  : !firrtl.uint<1>
       %mem_MPORT_data_0 = firrtl.wire  : !firrtl.uint<8>
-      %mem_0_MPORT, %mem_0_MPORT_1 = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["MPORT", "MPORT_1"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>
+      %mem_0_MPORT, %mem_0_MPORT_1 = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["MPORT", "MPORT_1"], prefix = "Foo_", readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<8>, mask: uint<2>>
 
-      // CHECK: %mem_0_rw = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["rw"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
+      // CHECK: %mem_0_rw = firrtl.mem Undefined  {depth = 16 : i64, name = "mem_0", portNames = ["rw"], prefix = "Foo_", readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
       // CHECK: %[[v6:.+]] = firrtl.subfield %mem_0_rw[wmask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, rdata flip: uint<8>, wmode: uint<1>, wdata: uint<8>, wmask: uint<1>>
       // CHECK: %[[c1_ui1:.+]] = firrtl.constant 1 : !firrtl.uint<1>
       // CHECK: firrtl.matchingconnect %[[v6]], %[[c1_ui1]]


### PR DESCRIPTION
The InferRW pass, which simplifies memory ports, was not correctly copying all attributes from the old memory to the new simplified memory when the memory was not masked.

Fixes #7788