### PR TITLE
[ESI][Runtime] Fix wheel builds

### DIFF
--- a/.github/workflows/esiRuntimePublish.yml
+++ b/.github/workflows/esiRuntimePublish.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: ubuntu-20.04
+          - os: ubuntu-20.04:20241006.1.0
             cibw_build: cp38-manylinux_x86_64
           - os: ubuntu-20.04
             cibw_build: cp39-manylinux_x86_64

--- a/.github/workflows/esiRuntimePublish.yml
+++ b/.github/workflows/esiRuntimePublish.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: ubuntu-20.04:20241006.1.0
+          - os: ubuntu-20.04
             cibw_build: cp38-manylinux_x86_64
           - os: ubuntu-20.04
             cibw_build: cp39-manylinux_x86_64

--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -54,10 +54,10 @@ if(ESI_STATIC_RUNTIME)
 endif()
 
 # We need zlib to uncompress the manifest.
-find_package(ZLIB)
-if(ZLIB_FOUND)
-  set(ZLIB_LIBRARY ZLIB::ZLIB)
-else()
+# find_package(ZLIB)
+# if(ZLIB_FOUND)
+#   set(ZLIB_LIBRARY ZLIB::ZLIB)
+# else()
   message("-- zlib not found, pulling down zlib from git")
   set(ZLIB_BUILD_EXAMPLES OFF)
   FetchContent_Declare(
@@ -72,7 +72,7 @@ else()
   else()
     set(ZLIB_LIBRARY zlib)
   endif()
-endif()
+# endif()
 
 # In a Python wheel build, we need to install libraries to different places.
 option(WHEEL_BUILD "Set up the build for a Python wheel." OFF)

--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -54,10 +54,10 @@ if(ESI_STATIC_RUNTIME)
 endif()
 
 # We need zlib to uncompress the manifest.
-# find_package(ZLIB)
-# if(ZLIB_FOUND)
-#   set(ZLIB_LIBRARY ZLIB::ZLIB)
-# else()
+find_package(ZLIB)
+if(ZLIB_FOUND)
+  set(ZLIB_LIBRARY ZLIB::ZLIB)
+else()
   message("-- zlib not found, pulling down zlib from git")
   set(ZLIB_BUILD_EXAMPLES OFF)
   FetchContent_Declare(
@@ -72,7 +72,7 @@ endif()
   else()
     set(ZLIB_LIBRARY zlib)
   endif()
-# endif()
+endif()
 
 # In a Python wheel build, we need to install libraries to different places.
 option(WHEEL_BUILD "Set up the build for a Python wheel." OFF)
@@ -189,18 +189,18 @@ install(TARGETS ESICppRuntime
   COMPONENT ESIRuntime
 )
 
-if(NOT ESI_STATIC_RUNTIME)
-  install(IMPORTED_RUNTIME_ARTIFACTS ESICppRuntime
-    RUNTIME_DEPENDENCY_SET ESICppRuntime_RUNTIME_DEPS
-    COMPONENT ESIRuntime
-  )
-endif()
-install(RUNTIME_DEPENDENCY_SET ESICppRuntime_RUNTIME_DEPS
-  DESTINATION ${LIB_DIR}
-  PRE_EXCLUDE_REGEXES .*
-  PRE_INCLUDE_REGEXES zlibd zlib
-  COMPONENT ESIRuntime
-)
+# if(NOT ESI_STATIC_RUNTIME)
+#   install(IMPORTED_RUNTIME_ARTIFACTS ESICppRuntime
+#     RUNTIME_DEPENDENCY_SET ESICppRuntime_RUNTIME_DEPS
+#     COMPONENT ESIRuntime
+#   )
+# endif()
+# install(RUNTIME_DEPENDENCY_SET ESICppRuntime_RUNTIME_DEPS
+#   DESTINATION ${LIB_DIR}
+#   PRE_EXCLUDE_REGEXES .*
+#   PRE_INCLUDE_REGEXES zlibd zlib
+#   COMPONENT ESIRuntime
+# )
 install(FILES ${ESICppRuntimeHeaders}
   DESTINATION include/esi
   COMPONENT ESIRuntime

--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -186,21 +186,12 @@ else()
 endif()
 install(TARGETS ESICppRuntime
   DESTINATION ${PYLIBDIR}
+  RUNTIME_DEPENDENCIES
+    PRE_EXCLUDE_REGEXES .*
+    PRE_INCLUDE_REGEXES zlibd zlib libz
   COMPONENT ESIRuntime
 )
 
-# if(NOT ESI_STATIC_RUNTIME)
-#   install(IMPORTED_RUNTIME_ARTIFACTS ESICppRuntime
-#     RUNTIME_DEPENDENCY_SET ESICppRuntime_RUNTIME_DEPS
-#     COMPONENT ESIRuntime
-#   )
-# endif()
-# install(RUNTIME_DEPENDENCY_SET ESICppRuntime_RUNTIME_DEPS
-#   DESTINATION ${LIB_DIR}
-#   PRE_EXCLUDE_REGEXES .*
-#   PRE_INCLUDE_REGEXES zlibd zlib
-#   COMPONENT ESIRuntime
-# )
 install(FILES ${ESICppRuntimeHeaders}
   DESTINATION include/esi
   COMPONENT ESIRuntime

--- a/lib/Dialect/ESI/runtime/pyproject.toml
+++ b/lib/Dialect/ESI/runtime/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
 requires = [
-  "packaging==24.1",
   "setuptools>=68",
   "setuptools_scm>=8.0",
   "wheel",
-  "cmake>=3.20",
+  "cmake>=3.31",
   "pybind11>=2.9",
   "pybind11_stubgen",
 ]

--- a/lib/Dialect/ESI/runtime/pyproject.toml
+++ b/lib/Dialect/ESI/runtime/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = [
+  "packaging==24.1",
   "setuptools>=68",
   "setuptools_scm>=8.0",
   "wheel",

--- a/lib/Dialect/ESI/runtime/setup.py
+++ b/lib/Dialect/ESI/runtime/setup.py
@@ -107,6 +107,7 @@ class CMakeBuild(build_py):
 
     # Finally run the cmake configure.
     subprocess.check_call(["cmake", src_dir] + cmake_args, cwd=cmake_build_dir)
+    print(" ".join(["cmake", src_dir] + cmake_args))
 
     # Run the build.
     subprocess.check_call([


### PR DESCRIPTION
CMake 3.31 changed the behavior of `install(IMPORTED_RUNTIME_ARTIFACTS` to actually install them instead of merely adding them to the list. This ended up pulling in _all_ of the shared libs (including system libraries like `libm`, `libgcc`, etc.) instead of respecting the filters given in `install(RUNTIME_DEPENDENCY_SET`. As a result, auditwheel was failing. Happened over the weekend when a new version of the `cmake` package was published to PyPI.