### PR TITLE
[FIRRTL] Run canonicalizer again after IMCP

### DIFF
--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -212,6 +212,8 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
     // Re-run IMConstProp to propagate constants produced by register
     // optimizations.
     pm.nest<firrtl::CircuitOp>().addPass(firrtl::createIMConstPropPass());
+    pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
+        createSimpleCanonicalizerPass());
     pm.addPass(firrtl::createIMDeadCodeElimPass());
   }
 

--- a/test/firtool/canonicalize-away-assert-under-layer.fir
+++ b/test/firtool/canonicalize-away-assert-under-layer.fir
@@ -1,0 +1,39 @@
+; RUN: firtool %s | FileCheck %s
+FIRRTL version 4.0.0
+
+; This test relies on IM const prop to propagate a constant predicate down
+; to an assertion, which then will allow the assertion canonicalizer to erase
+; the assertion.
+;
+; However, lower layers will pull the assertion out into a new module
+; (corresponding to the surrounding layerblock), which undoes the IMCP work, and
+; will block the assertion from being canonicalized away.
+;
+; This test ensures that IMCP and canonicalizers are run together, and that
+; dead assertions under layerblocks will be removed.
+
+; CHECK-NOT: MYASSERT
+; CHECK-NOT: MYLABEL
+; CHECK-NOT: $error
+
+circuit Top:
+  layer Verification, bind:
+    layer Assert, bind:
+
+  module DoAssert:
+    input c : Clock
+    input r : UInt<1>
+    input p : UInt<1>
+    layerblock Verification:
+      layerblock Assert:
+        node x = asUInt(r)
+        node y = eq(x, UInt<1>(0h0))
+        intrinsic(circt_chisel_ifelsefatal<format = "MYASSERT", label = "MYLABEL">, c, p, y)
+
+  public module Top:
+    input c : Clock
+    input r : UInt<1>
+    inst do_assert of DoAssert
+    connect do_assert.c, c
+    connect do_assert.r, r
+    connect do_assert.p, UInt<1>(1)


### PR DESCRIPTION
IMCP propagates constants across modules, which should enable more
canonicalization.  However, lower-layers, which runs between IMCP and
canonicalization, takes layerblocks and outlines them into their own module.
This effectively undoes the work of IMCP, and prevents us from canonicalizing
as well as we should under layers. This PR adds an additional run of the canonicalizer
immediately after the second run of IMCP, so that we have a better shot at
canonicalization.

In particular, we want to ensure that we are able to canonicalize away dead
assertions and assumptions under layerblocks.