### PR TITLE
[Transform] Create memory banks for memories used inside affine parallel loops

### DIFF
--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -45,7 +45,7 @@ std::unique_ptr<mlir::Pass> createMaximizeSSAPass();
 std::unique_ptr<mlir::Pass> createInsertMergeBlocksPass();
 std::unique_ptr<mlir::Pass> createPrintOpCountPass();
 std::unique_ptr<mlir::Pass> createMemoryBankingPass(
-    int bankingFactor = -1,
+    std::optional<unsigned> bankingFactor = std::nullopt,
     const std::function<unsigned(mlir::affine::AffineParallelOp)>
         &getBankingFactor = nullptr);
 

--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -44,10 +44,8 @@ std::unique_ptr<mlir::Pass> createStripDebugInfoWithPredPass(
 std::unique_ptr<mlir::Pass> createMaximizeSSAPass();
 std::unique_ptr<mlir::Pass> createInsertMergeBlocksPass();
 std::unique_ptr<mlir::Pass> createPrintOpCountPass();
-std::unique_ptr<mlir::Pass> createMemoryBankingPass(
-    std::optional<unsigned> bankingFactor = std::nullopt,
-    const std::function<unsigned(mlir::affine::AffineParallelOp)>
-        &getBankingFactor = nullptr);
+std::unique_ptr<mlir::Pass>
+createMemoryBankingPass(std::optional<unsigned> bankingFactor = std::nullopt);
 
 //===----------------------------------------------------------------------===//
 // Utility functions.

--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -14,6 +14,7 @@
 #define CIRCT_TRANSFORMS_PASSES_H
 
 #include "circt/Dialect/HW/HWOpInterfaces.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include <limits>
@@ -43,6 +44,10 @@ std::unique_ptr<mlir::Pass> createStripDebugInfoWithPredPass(
 std::unique_ptr<mlir::Pass> createMaximizeSSAPass();
 std::unique_ptr<mlir::Pass> createInsertMergeBlocksPass();
 std::unique_ptr<mlir::Pass> createPrintOpCountPass();
+std::unique_ptr<mlir::Pass> createMemoryBankingPass(
+    int bankingFactor = -1,
+    const std::function<unsigned(mlir::affine::AffineParallelOp)>
+        &getBankingFactor = nullptr);
 
 //===----------------------------------------------------------------------===//
 // Utility functions.

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -123,4 +123,14 @@ def PrintOpCount : Pass<"print-op-count", "::mlir::ModuleOp"> {
   ];
 }
 
+def MemoryBanking : Pass<"memory-banking", "::mlir::func::FuncOp"> {
+  let summary = "Partition the memories used in affine parallel loops into banks";
+  let constructor = "circt::createMemoryBankingPass()";
+  let options = [
+    Option<"bankingFactor", "banking-factor", "unsigned", /*default=*/"1",
+           "Use this banking factor for all memories being partitioned">
+  ];
+  let dependentDialects = ["mlir::memref::MemRefDialect, mlir::scf::SCFDialect, mlir::affine::AffineDialect"];
+}
+
 #endif // CIRCT_TRANSFORMS_PASSES

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -123,7 +123,7 @@ def PrintOpCount : Pass<"print-op-count", "::mlir::ModuleOp"> {
   ];
 }
 
-def MemoryBanking : Pass<"memory-banking", "::mlir::ModuleOp"> {
+def MemoryBanking : Pass<"memory-banking", "::mlir::func::FuncOp"> {
   let summary = "Partition the memories used in affine parallel loops into banks";
   let constructor = "circt::createMemoryBankingPass()";
   let options = [

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -123,7 +123,7 @@ def PrintOpCount : Pass<"print-op-count", "::mlir::ModuleOp"> {
   ];
 }
 
-def MemoryBanking : Pass<"memory-banking", "::mlir::func::FuncOp"> {
+def MemoryBanking : Pass<"memory-banking", "::mlir::ModuleOp"> {
   let summary = "Partition the memories used in affine parallel loops into banks";
   let constructor = "circt::createMemoryBankingPass()";
   let options = [

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -22,6 +22,7 @@ add_circt_library(CIRCTTransforms
   MLIRSupport
   MLIRTransforms
   MLIRAffineDialect
+  MLIRSCFDialect
 
   DEPENDS
   CIRCTTransformsPassIncGen

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_circt_library(CIRCTTransforms
   MaximizeSSA.cpp
   InsertMergeBlocks.cpp
   PrintOpCount.cpp
+  MemoryBanking.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Transforms
@@ -20,6 +21,7 @@ add_circt_library(CIRCTTransforms
   MLIRMemRefDialect
   MLIRSupport
   MLIRTransforms
+  MLIRAffineDialect
 
   DEPENDS
   CIRCTTransformsPassIncGen

--- a/lib/Transforms/MemoryBanking.cpp
+++ b/lib/Transforms/MemoryBanking.cpp
@@ -356,7 +356,7 @@ LogicalResult cleanUpOldMemRefs(DenseSet<Value> &oldMemRefVals,
 }
 
 void MemoryBankingPass::runOnOperation() {
-  if (bankingFactor == 1)
+  if (getOperation().isExternal() || bankingFactor == 1)
     return;
 
   if (bankingFactor == 0) {

--- a/lib/Transforms/MemoryBanking.cpp
+++ b/lib/Transforms/MemoryBanking.cpp
@@ -1,0 +1,379 @@
+//===- MemoryBanking.cpp - Code to perform memory bnaking in parallel loops
+//--------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements parallel loop memory banking.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Transforms/Passes.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/LoopUtils.h"
+#include "mlir/Dialect/Affine/Passes.h"
+#include "mlir/Dialect/Affine/Utils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace circt {
+#define GEN_PASS_DEF_MEMORYBANKING
+#include "circt/Transforms/Passes.h.inc"
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+
+namespace {
+
+/// Partition memories used in `affine.parallel` operation by the
+/// `bankingFactor` throughout the program.
+struct MemoryBankingPass
+    : public circt::impl::MemoryBankingBase<MemoryBankingPass> {
+  const std::function<unsigned(mlir::affine::AffineParallelOp)>
+      getBankingFactor;
+  MemoryBankingPass() : getBankingFactor(nullptr) {}
+  MemoryBankingPass(const MemoryBankingPass &other) = default;
+  explicit MemoryBankingPass(
+      std::optional<unsigned> bankingFactor = std::nullopt,
+      const std::function<unsigned(mlir::affine::AffineParallelOp)>
+          &getBankingFactor = nullptr)
+      : getBankingFactor(getBankingFactor) {
+    if (bankingFactor)
+      this->bankingFactor = *bankingFactor;
+  }
+
+  void runOnOperation() override;
+  LogicalResult parallelBankingByFactor(mlir::affine::AffineParallelOp parOp,
+                                        uint64_t bankingFactor);
+
+private:
+  // map from original memory definition to newly allocated banks
+  DenseMap<Value, SmallVector<Value>> memoryToBanks;
+};
+} // namespace
+
+// Collect all memref in the `parOp`'s region'
+DenseSet<Value> collectMemRefs(mlir::affine::AffineParallelOp parOp) {
+  DenseSet<Value> memrefVals;
+  parOp.walk([&](Operation *op) {
+    for (auto operand : op->getOperands()) {
+      if (isa<MemRefType>(operand.getType()))
+        memrefVals.insert(operand);
+    }
+    return WalkResult::advance();
+  });
+  return memrefVals;
+}
+
+MemRefType computeBankedMemRefType(MemRefType originalType,
+                                   uint64_t bankingFactor) {
+  ArrayRef<int64_t> originalShape = originalType.getShape();
+  assert(!originalShape.empty() && "memref shape should not be empty");
+  assert(originalType.getRank() == 1 &&
+         "currently only support one dimension memories");
+  SmallVector<int64_t, 4> newShape(originalShape.begin(), originalShape.end());
+  assert(newShape.front() % bankingFactor == 0 &&
+         "memref shape must be divided by the banking factor");
+  newShape.front() /= bankingFactor;
+  MemRefType newMemRefType =
+      MemRefType::get(newShape, originalType.getElementType(),
+                      originalType.getLayout(), originalType.getMemorySpace());
+
+  return newMemRefType;
+}
+
+SmallVector<Value, 4> createBanks(Value originalMem, uint64_t bankingFactor) {
+  MemRefType originalMemRefType = cast<MemRefType>(originalMem.getType());
+  MemRefType newMemRefType =
+      computeBankedMemRefType(originalMemRefType, bankingFactor);
+  SmallVector<Value, 4> banks;
+  if (auto blockArgMem = dyn_cast<BlockArgument>(originalMem)) {
+    Block *block = blockArgMem.getOwner();
+    unsigned blockArgNum = blockArgMem.getArgNumber();
+
+    SmallVector<Type> banksType;
+    for (unsigned i = 0; i < bankingFactor; ++i) {
+      block->insertArgument(blockArgNum + 1 + i, newMemRefType,
+                            blockArgMem.getLoc());
+    }
+
+    auto blockArgs =
+        block->getArguments().slice(blockArgNum + 1, bankingFactor);
+    banks.append(blockArgs.begin(), blockArgs.end());
+  } else {
+    Operation *originalDef = originalMem.getDefiningOp();
+    Location loc = originalDef->getLoc();
+    OpBuilder builder(originalDef);
+    builder.setInsertionPointAfter(originalDef);
+    TypeSwitch<Operation *>(originalDef)
+        .Case<memref::AllocOp>([&](memref::AllocOp allocOp) {
+          for (uint bankCnt = 0; bankCnt < bankingFactor; bankCnt++) {
+            auto bankAllocOp =
+                builder.create<memref::AllocOp>(loc, newMemRefType);
+            banks.push_back(bankAllocOp);
+          }
+        })
+        .Case<memref::AllocaOp>([&](memref::AllocaOp allocaOp) {
+          for (uint bankCnt = 0; bankCnt < bankingFactor; bankCnt++) {
+            auto bankAllocaOp =
+                builder.create<memref::AllocaOp>(loc, newMemRefType);
+            banks.push_back(bankAllocaOp);
+          }
+        })
+        .Default([](Operation *) {
+          llvm_unreachable("Unhandled memory operation type");
+        });
+  }
+  return banks;
+}
+
+struct BankAffineLoadPattern
+    : public OpRewritePattern<mlir::affine::AffineLoadOp> {
+  BankAffineLoadPattern(MLIRContext *context, uint64_t bankingFactor,
+                        DenseMap<Value, SmallVector<Value>> &memoryToBanks)
+      : OpRewritePattern<mlir::affine::AffineLoadOp>(context),
+        bankingFactor(bankingFactor), memoryToBanks(memoryToBanks) {}
+
+  LogicalResult matchAndRewrite(mlir::affine::AffineLoadOp loadOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = loadOp.getLoc();
+    auto banks = memoryToBanks[loadOp.getMemref()];
+    Value loadIndex = loadOp.getIndices().front();
+    auto modMap =
+        AffineMap::get(1, 0, {rewriter.getAffineDimExpr(0) % bankingFactor});
+    auto divMap = AffineMap::get(
+        1, 0, {rewriter.getAffineDimExpr(0).floorDiv(bankingFactor)});
+
+    Value bankIndex = rewriter.create<affine::AffineApplyOp>(
+        loc, modMap, loadIndex); // assuming one-dim
+    Value offset =
+        rewriter.create<affine::AffineApplyOp>(loc, divMap, loadIndex);
+
+    SmallVector<Type> resultTypes = {loadOp.getResult().getType()};
+
+    SmallVector<int64_t, 4> caseValues;
+    for (unsigned i = 0; i < bankingFactor; ++i)
+      caseValues.push_back(i);
+
+    rewriter.setInsertionPoint(loadOp);
+    scf::IndexSwitchOp switchOp = rewriter.create<scf::IndexSwitchOp>(
+        loc, resultTypes, bankIndex, caseValues,
+        /*numRegions=*/bankingFactor);
+
+    for (unsigned i = 0; i < bankingFactor; ++i) {
+      Region &caseRegion = switchOp.getCaseRegions()[i];
+      rewriter.setInsertionPointToStart(&caseRegion.emplaceBlock());
+      Value bankedLoad =
+          rewriter.create<mlir::affine::AffineLoadOp>(loc, banks[i], offset);
+      rewriter.create<scf::YieldOp>(loc, bankedLoad);
+    }
+
+    Region &defaultRegion = switchOp.getDefaultRegion();
+    assert(defaultRegion.empty() && "Default region should be empty");
+    rewriter.setInsertionPointToStart(&defaultRegion.emplaceBlock());
+
+    TypedAttr zeroAttr =
+        cast<TypedAttr>(rewriter.getZeroAttr(loadOp.getType()));
+    auto defaultValue = rewriter.create<arith::ConstantOp>(loc, zeroAttr);
+    rewriter.create<scf::YieldOp>(loc, defaultValue.getResult());
+
+    loadOp.getResult().replaceAllUsesWith(switchOp.getResult(0));
+
+    rewriter.eraseOp(loadOp);
+    return success();
+  }
+
+private:
+  uint64_t bankingFactor;
+  DenseMap<Value, SmallVector<Value>> &memoryToBanks;
+};
+
+struct BankAffineStorePattern
+    : public OpRewritePattern<mlir::affine::AffineStoreOp> {
+  BankAffineStorePattern(MLIRContext *context, uint64_t bankingFactor,
+                         DenseMap<Value, SmallVector<Value>> &memoryToBanks)
+      : OpRewritePattern<mlir::affine::AffineStoreOp>(context),
+        bankingFactor(bankingFactor), memoryToBanks(memoryToBanks) {}
+
+  LogicalResult matchAndRewrite(mlir::affine::AffineStoreOp storeOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = storeOp.getLoc();
+    auto banks = memoryToBanks[storeOp.getMemref()];
+    Value storeIndex = storeOp.getIndices().front();
+
+    auto modMap =
+        AffineMap::get(1, 0, {rewriter.getAffineDimExpr(0) % bankingFactor});
+    auto divMap = AffineMap::get(
+        1, 0, {rewriter.getAffineDimExpr(0).floorDiv(bankingFactor)});
+
+    Value bankIndex = rewriter.create<affine::AffineApplyOp>(
+        loc, modMap, storeIndex); // assuming one-dim
+    Value offset =
+        rewriter.create<affine::AffineApplyOp>(loc, divMap, storeIndex);
+
+    SmallVector<Type> resultTypes = {};
+
+    SmallVector<int64_t, 4> caseValues;
+    for (unsigned i = 0; i < bankingFactor; ++i)
+      caseValues.push_back(i);
+
+    rewriter.setInsertionPoint(storeOp);
+    scf::IndexSwitchOp switchOp = rewriter.create<scf::IndexSwitchOp>(
+        loc, resultTypes, bankIndex, caseValues,
+        /*numRegions=*/bankingFactor);
+
+    for (unsigned i = 0; i < bankingFactor; ++i) {
+      Region &caseRegion = switchOp.getCaseRegions()[i];
+      rewriter.setInsertionPointToStart(&caseRegion.emplaceBlock());
+      rewriter.create<mlir::affine::AffineStoreOp>(
+          loc, storeOp.getValueToStore(), banks[i], offset);
+      rewriter.create<scf::YieldOp>(loc);
+    }
+
+    Region &defaultRegion = switchOp.getDefaultRegion();
+    assert(defaultRegion.empty() && "Default region should be empty");
+    rewriter.setInsertionPointToStart(&defaultRegion.emplaceBlock());
+
+    rewriter.create<scf::YieldOp>(loc);
+
+    rewriter.eraseOp(storeOp);
+    return success();
+  }
+
+private:
+  uint64_t bankingFactor;
+  DenseMap<Value, SmallVector<Value>> &memoryToBanks;
+};
+
+struct BankReturnPattern : public OpRewritePattern<func::ReturnOp> {
+  BankReturnPattern(MLIRContext *context,
+                    DenseMap<Value, SmallVector<Value>> &memoryToBanks)
+      : OpRewritePattern<func::ReturnOp>(context),
+        memoryToBanks(memoryToBanks) {}
+
+  LogicalResult matchAndRewrite(func::ReturnOp returnOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = returnOp.getLoc();
+    SmallVector<Value, 4> newReturnOperands;
+    bool allOrigMemsUsedByReturn = true;
+    for (auto operand : returnOp.getOperands()) {
+      if (!memoryToBanks.contains(operand)) {
+        newReturnOperands.push_back(operand);
+        continue;
+      }
+      if (operand.hasOneUse())
+        allOrigMemsUsedByReturn = false;
+      auto banks = memoryToBanks[operand];
+      newReturnOperands.append(banks.begin(), banks.end());
+    }
+
+    func::FuncOp funcOp = returnOp.getParentOp();
+    rewriter.setInsertionPointToEnd(&funcOp.getBlocks().front());
+    auto newReturnOp =
+        rewriter.create<func::ReturnOp>(loc, ValueRange(newReturnOperands));
+    TypeRange newReturnType = TypeRange(newReturnOperands);
+    FunctionType newFuncType =
+        FunctionType::get(funcOp.getContext(),
+                          funcOp.getFunctionType().getInputs(), newReturnType);
+    funcOp.setType(newFuncType);
+
+    if (allOrigMemsUsedByReturn)
+      rewriter.replaceOp(returnOp, newReturnOp);
+
+    return success();
+  }
+
+private:
+  DenseMap<Value, SmallVector<Value>> &memoryToBanks;
+};
+
+LogicalResult cleanUpOldMemRefs(DenseSet<Value> &oldMemRefVals) {
+  DenseSet<func::FuncOp> funcsToModify;
+  for (auto &memrefVal : oldMemRefVals) {
+    if (!memrefVal.use_empty())
+      continue;
+    if (auto blockArg = dyn_cast<BlockArgument>(memrefVal)) {
+      Block *block = blockArg.getOwner();
+      block->eraseArgument(blockArg.getArgNumber());
+      if (auto funcOp = dyn_cast<func::FuncOp>(block->getParentOp()))
+        funcsToModify.insert(funcOp);
+    } else
+      memrefVal.getDefiningOp()->erase();
+  }
+
+  // Modify the function type accordingly
+  for (auto funcOp : funcsToModify) {
+    SmallVector<Type, 4> newArgTypes;
+    for (BlockArgument arg : funcOp.getArguments()) {
+      newArgTypes.push_back(arg.getType());
+    }
+    FunctionType newFuncType =
+        FunctionType::get(funcOp.getContext(), newArgTypes,
+                          funcOp.getFunctionType().getResults());
+    funcOp.setType(newFuncType);
+  }
+  return success();
+}
+
+void MemoryBankingPass::runOnOperation() {
+  if (getOperation().isExternal()) {
+    return;
+  }
+
+  getOperation().walk([&](mlir::affine::AffineParallelOp parOp) {
+    DenseSet<Value> memrefsInPar = collectMemRefs(parOp);
+
+    for (auto memrefVal : memrefsInPar) {
+      SmallVector<Value> banks = createBanks(memrefVal, bankingFactor);
+      memoryToBanks[memrefVal] = banks;
+    }
+  });
+
+  auto *ctx = &getContext();
+  RewritePatternSet patterns(ctx);
+
+  patterns.add<BankAffineLoadPattern>(ctx, bankingFactor, memoryToBanks);
+  patterns.add<BankAffineStorePattern>(ctx, bankingFactor, memoryToBanks);
+  patterns.add<BankReturnPattern>(ctx, memoryToBanks);
+
+  GreedyRewriteConfig config;
+  config.strictMode = GreedyRewriteStrictness::ExistingOps;
+
+  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
+                                          config))) {
+    signalPassFailure();
+  }
+
+  // Clean up the old memref values
+  DenseSet<Value> oldMemRefVals;
+  for (const auto &pair : memoryToBanks)
+    oldMemRefVals.insert(pair.first);
+
+  if (failed(cleanUpOldMemRefs(oldMemRefVals))) {
+    signalPassFailure();
+  }
+}
+
+namespace circt {
+std::unique_ptr<mlir::Pass> createMemoryBankingPass(
+    int bankingFactor,
+    const std::function<unsigned(mlir::affine::AffineParallelOp)>
+        &getBankingFactor) {
+  return std::make_unique<MemoryBankingPass>(
+      bankingFactor == -1 ? std::nullopt
+                          : std::optional<unsigned>(bankingFactor),
+      getBankingFactor);
+}
+} // namespace circt

--- a/lib/Transforms/MemoryBanking.cpp
+++ b/lib/Transforms/MemoryBanking.cpp
@@ -44,15 +44,9 @@ namespace {
 /// `bankingFactor` throughout the program.
 struct MemoryBankingPass
     : public circt::impl::MemoryBankingBase<MemoryBankingPass> {
-  const std::function<unsigned(mlir::affine::AffineParallelOp)>
-      getBankingFactor;
-  MemoryBankingPass() : getBankingFactor(nullptr) {}
   MemoryBankingPass(const MemoryBankingPass &other) = default;
   explicit MemoryBankingPass(
-      std::optional<unsigned> bankingFactor = std::nullopt,
-      const std::function<unsigned(mlir::affine::AffineParallelOp)>
-          &getBankingFactor = nullptr)
-      : getBankingFactor(getBankingFactor) {}
+      std::optional<unsigned> bankingFactor = std::nullopt) {}
 
   void runOnOperation() override;
 
@@ -399,10 +393,8 @@ void MemoryBankingPass::runOnOperation() {
 }
 
 namespace circt {
-std::unique_ptr<mlir::Pass> createMemoryBankingPass(
-    std::optional<unsigned> bankingFactor,
-    const std::function<unsigned(mlir::affine::AffineParallelOp)>
-        &getBankingFactor) {
-  return std::make_unique<MemoryBankingPass>(bankingFactor, getBankingFactor);
+std::unique_ptr<mlir::Pass>
+createMemoryBankingPass(std::optional<unsigned> bankingFactor) {
+  return std::make_unique<MemoryBankingPass>(bankingFactor);
 }
 } // namespace circt

--- a/test/Transforms/memory_bank_invalid.mlir
+++ b/test/Transforms/memory_bank_invalid.mlir
@@ -1,0 +1,14 @@
+// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=0" -verify-diagnostics
+
+// expected-error@+1 {{banking factor must be greater than 1}}
+func.func @bank_one_dim_unroll0(%arg0: memref<8xf32>, %arg1: memref<8xf32>) -> (memref<8xf32>) {
+  %mem = memref.alloc() : memref<8xf32>
+  affine.parallel (%i) = (0) to (8) {
+    %1 = affine.load %arg0[%i] : memref<8xf32>
+    %2 = affine.load %arg1[%i] : memref<8xf32>
+    %3 = arith.mulf %1, %2 : f32
+    affine.store %3, %mem[%i] : memref<8xf32>
+  }
+  return %mem : memref<8xf32>
+}
+

--- a/test/Transforms/memory_banking.mlir
+++ b/test/Transforms/memory_banking.mlir
@@ -1,0 +1,69 @@
+// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2" | FileCheck %s
+
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0 mod 2)>
+// CHECK: #[[$ATTR_1:.+]] = affine_map<(d0) -> (d0 floordiv 2)>
+
+// CHECK-LABEL:   func.func @bank_one_dim(
+// CHECK:                       %[[VAL_0:arg0]]: memref<4xf32>,
+// CHECK:                       %[[VAL_1:arg1]]: memref<4xf32>,
+// CHECK:                       %[[VAL_2:arg2]]: memref<4xf32>,
+// CHECK:                       %[[VAL_3:arg3]]: memref<4xf32>) -> (memref<4xf32>, memref<4xf32>) {
+// CHECK:           %[[VAL_4:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_5:.*]] = memref.alloc() : memref<4xf32>
+// CHECK:           %[[VAL_6:.*]] = memref.alloc() : memref<4xf32>
+// CHECK:           affine.parallel (%[[VAL_7:.*]]) = (0) to (8) {
+// CHECK:             %[[VAL_8:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_7]])
+// CHECK:             %[[VAL_9:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_7]])
+// CHECK:             %[[VAL_10:.*]] = scf.index_switch %[[VAL_8]] -> f32
+// CHECK:             case 0 {
+// CHECK:               %[[VAL_11:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_9]]] : memref<4xf32>
+// CHECK:               scf.yield %[[VAL_11]] : f32
+// CHECK:             }
+// CHECK:             case 1 {
+// CHECK:               %[[VAL_12:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_9]]] : memref<4xf32>
+// CHECK:               scf.yield %[[VAL_12]] : f32
+// CHECK:             }
+// CHECK:             default {
+// CHECK:               scf.yield %[[VAL_4]] : f32
+// CHECK:             }
+// CHECK:             %[[VAL_13:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_7]])
+// CHECK:             %[[VAL_14:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_7]])
+// CHECK:             %[[VAL_15:.*]] = scf.index_switch %[[VAL_13]] -> f32
+// CHECK:             case 0 {
+// CHECK:               %[[VAL_16:.*]] = affine.load %[[VAL_2]]{{\[}}%[[VAL_14]]] : memref<4xf32>
+// CHECK:               scf.yield %[[VAL_16]] : f32
+// CHECK:             }
+// CHECK:             case 1 {
+// CHECK:               %[[VAL_17:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_14]]] : memref<4xf32>
+// CHECK:               scf.yield %[[VAL_17]] : f32
+// CHECK:             }
+// CHECK:             default {
+// CHECK:               scf.yield %[[VAL_4]] : f32
+// CHECK:             }
+// CHECK:             %[[VAL_18:.*]] = arith.mulf %[[VAL_10]], %[[VAL_15]] : f32
+// CHECK:             %[[VAL_19:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_7]])
+// CHECK:             %[[VAL_20:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_7]])
+// CHECK:             scf.index_switch %[[VAL_19]]
+// CHECK:             case 0 {
+// CHECK:               affine.store %[[VAL_18]], %[[VAL_5]]{{\[}}%[[VAL_20]]] : memref<4xf32>
+// CHECK:               scf.yield
+// CHECK:             }
+// CHECK:             case 1 {
+// CHECK:               affine.store %[[VAL_18]], %[[VAL_6]]{{\[}}%[[VAL_20]]] : memref<4xf32>
+// CHECK:               scf.yield
+// CHECK:             }
+// CHECK:             default {
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return %[[VAL_5]], %[[VAL_6]] : memref<4xf32>, memref<4xf32>
+// CHECK:         }
+func.func @bank_one_dim(%arg0: memref<8xf32>, %arg1: memref<8xf32>) -> (memref<8xf32>) {
+  %mem = memref.alloc() : memref<8xf32>
+  affine.parallel (%i) = (0) to (8) {
+    %1 = affine.load %arg0[%i] : memref<8xf32>
+    %2 = affine.load %arg1[%i] : memref<8xf32>
+    %3 = arith.mulf %1, %2 : f32
+    affine.store %3, %mem[%i] : memref<8xf32>
+  }
+  return %mem : memref<8xf32>
+}

--- a/test/Transforms/memory_banking.mlir
+++ b/test/Transforms/memory_banking.mlir
@@ -1,63 +1,249 @@
-// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2" | FileCheck %s
+// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2" | FileCheck %s --check-prefix UNROLL-BY-2
+// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=1" | FileCheck %s --check-prefix UNROLL-BY-1
+// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=8" | FileCheck %s --check-prefix UNROLL-BY-8
 
-// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0 mod 2)>
-// CHECK: #[[$ATTR_1:.+]] = affine_map<(d0) -> (d0 floordiv 2)>
+// UNROLL-BY-2: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0 mod 2)>
+// UNROLL-BY-2: #[[$ATTR_1:.+]] = affine_map<(d0) -> (d0 floordiv 2)>
 
-// CHECK-LABEL:   func.func @bank_one_dim(
-// CHECK:                       %[[VAL_0:arg0]]: memref<4xf32>,
-// CHECK:                       %[[VAL_1:arg1]]: memref<4xf32>,
-// CHECK:                       %[[VAL_2:arg2]]: memref<4xf32>,
-// CHECK:                       %[[VAL_3:arg3]]: memref<4xf32>) -> (memref<4xf32>, memref<4xf32>) {
-// CHECK:           %[[VAL_4:.*]] = arith.constant 0.000000e+00 : f32
-// CHECK:           %[[VAL_5:.*]] = memref.alloc() : memref<4xf32>
-// CHECK:           %[[VAL_6:.*]] = memref.alloc() : memref<4xf32>
-// CHECK:           affine.parallel (%[[VAL_7:.*]]) = (0) to (8) {
-// CHECK:             %[[VAL_8:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_7]])
-// CHECK:             %[[VAL_9:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_7]])
-// CHECK:             %[[VAL_10:.*]] = scf.index_switch %[[VAL_8]] -> f32
-// CHECK:             case 0 {
-// CHECK:               %[[VAL_11:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_9]]] : memref<4xf32>
-// CHECK:               scf.yield %[[VAL_11]] : f32
-// CHECK:             }
-// CHECK:             case 1 {
-// CHECK:               %[[VAL_12:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_9]]] : memref<4xf32>
-// CHECK:               scf.yield %[[VAL_12]] : f32
-// CHECK:             }
-// CHECK:             default {
-// CHECK:               scf.yield %[[VAL_4]] : f32
-// CHECK:             }
-// CHECK:             %[[VAL_13:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_7]])
-// CHECK:             %[[VAL_14:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_7]])
-// CHECK:             %[[VAL_15:.*]] = scf.index_switch %[[VAL_13]] -> f32
-// CHECK:             case 0 {
-// CHECK:               %[[VAL_16:.*]] = affine.load %[[VAL_2]]{{\[}}%[[VAL_14]]] : memref<4xf32>
-// CHECK:               scf.yield %[[VAL_16]] : f32
-// CHECK:             }
-// CHECK:             case 1 {
-// CHECK:               %[[VAL_17:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_14]]] : memref<4xf32>
-// CHECK:               scf.yield %[[VAL_17]] : f32
-// CHECK:             }
-// CHECK:             default {
-// CHECK:               scf.yield %[[VAL_4]] : f32
-// CHECK:             }
-// CHECK:             %[[VAL_18:.*]] = arith.mulf %[[VAL_10]], %[[VAL_15]] : f32
-// CHECK:             %[[VAL_19:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_7]])
-// CHECK:             %[[VAL_20:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_7]])
-// CHECK:             scf.index_switch %[[VAL_19]]
-// CHECK:             case 0 {
-// CHECK:               affine.store %[[VAL_18]], %[[VAL_5]]{{\[}}%[[VAL_20]]] : memref<4xf32>
-// CHECK:               scf.yield
-// CHECK:             }
-// CHECK:             case 1 {
-// CHECK:               affine.store %[[VAL_18]], %[[VAL_6]]{{\[}}%[[VAL_20]]] : memref<4xf32>
-// CHECK:               scf.yield
-// CHECK:             }
-// CHECK:             default {
-// CHECK:             }
-// CHECK:           }
-// CHECK:           return %[[VAL_5]], %[[VAL_6]] : memref<4xf32>, memref<4xf32>
-// CHECK:         }
-func.func @bank_one_dim(%arg0: memref<8xf32>, %arg1: memref<8xf32>) -> (memref<8xf32>) {
+// UNROLL-BY-2-LABEL:   func.func @bank_one_dim_unroll2(
+// UNROLL-BY-2-SAME:                                %[[VAL_0:arg0]]: memref<4xf32>,
+// UNROLL-BY-2-SAME:                                %[[VAL_1:arg1]]: memref<4xf32>,
+// UNROLL-BY-2-SAME:                                %[[VAL_2:arg2]]: memref<4xf32>,
+// UNROLL-BY-2-SAME:                                %[[VAL_3:arg3]]: memref<4xf32>) -> (memref<4xf32>, memref<4xf32>) {
+// UNROLL-BY-2:           %[[VAL_4:.*]] = arith.constant 0.000000e+00 : f32
+// UNROLL-BY-2:           %[[VAL_5:.*]] = memref.alloc() : memref<4xf32>
+// UNROLL-BY-2:           %[[VAL_6:.*]] = memref.alloc() : memref<4xf32>
+// UNROLL-BY-2:           affine.parallel (%[[VAL_7:.*]]) = (0) to (8) {
+// UNROLL-BY-2:             %[[VAL_8:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_7]])
+// UNROLL-BY-2:             %[[VAL_9:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_7]])
+// UNROLL-BY-2:             %[[VAL_10:.*]] = scf.index_switch %[[VAL_8]] -> f32
+// UNROLL-BY-2:             case 0 {
+// UNROLL-BY-2:               %[[VAL_11:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_9]]] : memref<4xf32>
+// UNROLL-BY-2:               scf.yield %[[VAL_11]] : f32
+// UNROLL-BY-2:             }
+// UNROLL-BY-2:             case 1 {
+// UNROLL-BY-2:               %[[VAL_12:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_9]]] : memref<4xf32>
+// UNROLL-BY-2:               scf.yield %[[VAL_12]] : f32
+// UNROLL-BY-2:             }
+// UNROLL-BY-2:             default {
+// UNROLL-BY-2:               scf.yield %[[VAL_4]] : f32
+// UNROLL-BY-2:             }
+// UNROLL-BY-2:             %[[VAL_13:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_7]])
+// UNROLL-BY-2:             %[[VAL_14:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_7]])
+// UNROLL-BY-2:             %[[VAL_15:.*]] = scf.index_switch %[[VAL_13]] -> f32
+// UNROLL-BY-2:             case 0 {
+// UNROLL-BY-2:               %[[VAL_16:.*]] = affine.load %[[VAL_2]]{{\[}}%[[VAL_14]]] : memref<4xf32>
+// UNROLL-BY-2:               scf.yield %[[VAL_16]] : f32
+// UNROLL-BY-2:             }
+// UNROLL-BY-2:             case 1 {
+// UNROLL-BY-2:               %[[VAL_17:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_14]]] : memref<4xf32>
+// UNROLL-BY-2:               scf.yield %[[VAL_17]] : f32
+// UNROLL-BY-2:             }
+// UNROLL-BY-2:             default {
+// UNROLL-BY-2:               scf.yield %[[VAL_4]] : f32
+// UNROLL-BY-2:             }
+// UNROLL-BY-2:             %[[VAL_18:.*]] = arith.mulf %[[VAL_10]], %[[VAL_15]] : f32
+// UNROLL-BY-2:             %[[VAL_19:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_7]])
+// UNROLL-BY-2:             %[[VAL_20:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_7]])
+// UNROLL-BY-2:             scf.index_switch %[[VAL_19]]
+// UNROLL-BY-2:             case 0 {
+// UNROLL-BY-2:               affine.store %[[VAL_18]], %[[VAL_5]]{{\[}}%[[VAL_20]]] : memref<4xf32>
+// UNROLL-BY-2:               scf.yield
+// UNROLL-BY-2:             }
+// UNROLL-BY-2:             case 1 {
+// UNROLL-BY-2:               affine.store %[[VAL_18]], %[[VAL_6]]{{\[}}%[[VAL_20]]] : memref<4xf32>
+// UNROLL-BY-2:               scf.yield
+// UNROLL-BY-2:             }
+// UNROLL-BY-2:             default {
+// UNROLL-BY-2:             }
+// UNROLL-BY-2:           }
+// UNROLL-BY-2:           return %[[VAL_5]], %[[VAL_6]] : memref<4xf32>, memref<4xf32>
+// UNROLL-BY-2:         }
+
+func.func @bank_one_dim_unroll2(%arg0: memref<8xf32>, %arg1: memref<8xf32>) -> (memref<8xf32>) {
+  %mem = memref.alloc() : memref<8xf32>
+  affine.parallel (%i) = (0) to (8) {
+    %1 = affine.load %arg0[%i] : memref<8xf32>
+    %2 = affine.load %arg1[%i] : memref<8xf32>
+    %3 = arith.mulf %1, %2 : f32
+    affine.store %3, %mem[%i] : memref<8xf32>
+  }
+  return %mem : memref<8xf32>
+}
+
+// UNROLL-BY-1-LABEL:   func.func @bank_one_dim_unroll1(
+// UNROLL-BY-1-SAME:                                    %[[VAL_0:.*]]: memref<8xf32>,
+// UNROLL-BY-1-SAME:                                    %[[VAL_1:.*]]: memref<8xf32>) -> memref<8xf32> {
+// UNROLL-BY-1:           %[[VAL_2:.*]] = memref.alloc() : memref<8xf32>
+// UNROLL-BY-1:           affine.parallel (%[[VAL_3:.*]]) = (0) to (8) {
+// UNROLL-BY-1:             %[[VAL_4:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_3]]] : memref<8xf32>
+// UNROLL-BY-1:             %[[VAL_5:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_3]]] : memref<8xf32>
+// UNROLL-BY-1:             %[[VAL_6:.*]] = arith.mulf %[[VAL_4]], %[[VAL_5]] : f32
+// UNROLL-BY-1:             affine.store %[[VAL_6]], %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<8xf32>
+// UNROLL-BY-1:           }
+// UNROLL-BY-1:           return %[[VAL_2]] : memref<8xf32>
+// UNROLL-BY-1:         }
+
+func.func @bank_one_dim_unroll1(%arg0: memref<8xf32>, %arg1: memref<8xf32>) -> (memref<8xf32>) {
+  %mem = memref.alloc() : memref<8xf32>
+  affine.parallel (%i) = (0) to (8) {
+    %1 = affine.load %arg0[%i] : memref<8xf32>
+    %2 = affine.load %arg1[%i] : memref<8xf32>
+    %3 = arith.mulf %1, %2 : f32
+    affine.store %3, %mem[%i] : memref<8xf32>
+  }
+  return %mem : memref<8xf32>
+}
+
+// UNROLL-BY-8: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0 mod 8)>
+// UNROLL-BY-8: #[[$ATTR_1:.+]] = affine_map<(d0) -> (d0 floordiv 8)>
+
+// UNROLL-BY-8-LABEL:   func.func @bank_one_dim_unroll8(
+// UNROLL-BY-8-SAME:                                    %[[VAL_0:arg0]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_1:arg1]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_2:arg2]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_3:arg3]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_4:arg4]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_5:arg5]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_6:arg6]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_7:arg7]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_8:arg8]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_9:arg9]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_10:arg10]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_11:arg11]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_12:arg12]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_13:arg13]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_14:arg14]]: memref<1xf32>,
+// UNROLL-BY-8-SAME:                                    %[[VAL_15:arg15]]: memref<1xf32>) -> (memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>) {
+// UNROLL-BY-8:           %[[VAL_16:.*]] = arith.constant 0.000000e+00 : f32
+// UNROLL-BY-8:           %[[VAL_17:.*]] = memref.alloc() : memref<1xf32>
+// UNROLL-BY-8:           %[[VAL_18:.*]] = memref.alloc() : memref<1xf32>
+// UNROLL-BY-8:           %[[VAL_19:.*]] = memref.alloc() : memref<1xf32>
+// UNROLL-BY-8:           %[[VAL_20:.*]] = memref.alloc() : memref<1xf32>
+// UNROLL-BY-8:           %[[VAL_21:.*]] = memref.alloc() : memref<1xf32>
+// UNROLL-BY-8:           %[[VAL_22:.*]] = memref.alloc() : memref<1xf32>
+// UNROLL-BY-8:           %[[VAL_23:.*]] = memref.alloc() : memref<1xf32>
+// UNROLL-BY-8:           %[[VAL_24:.*]] = memref.alloc() : memref<1xf32>
+// UNROLL-BY-8:           affine.parallel (%[[VAL_25:.*]]) = (0) to (8) {
+// UNROLL-BY-8:             %[[VAL_26:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_25]])
+// UNROLL-BY-8:             %[[VAL_27:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_25]])
+// UNROLL-BY-8:             %[[VAL_28:.*]] = scf.index_switch %[[VAL_26]] -> f32
+// UNROLL-BY-8:             case 0 {
+// UNROLL-BY-8:               %[[VAL_29:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_27]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_29]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 1 {
+// UNROLL-BY-8:               %[[VAL_30:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_27]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_30]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 2 {
+// UNROLL-BY-8:               %[[VAL_31:.*]] = affine.load %[[VAL_2]]{{\[}}%[[VAL_27]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_31]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 3 {
+// UNROLL-BY-8:               %[[VAL_32:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_27]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_32]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 4 {
+// UNROLL-BY-8:               %[[VAL_33:.*]] = affine.load %[[VAL_4]]{{\[}}%[[VAL_27]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_33]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 5 {
+// UNROLL-BY-8:               %[[VAL_34:.*]] = affine.load %[[VAL_5]]{{\[}}%[[VAL_27]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_34]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 6 {
+// UNROLL-BY-8:               %[[VAL_35:.*]] = affine.load %[[VAL_6]]{{\[}}%[[VAL_27]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_35]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 7 {
+// UNROLL-BY-8:               %[[VAL_36:.*]] = affine.load %[[VAL_7]]{{\[}}%[[VAL_27]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_36]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             default {
+// UNROLL-BY-8:               scf.yield %[[VAL_16]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             %[[VAL_37:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_25]])
+// UNROLL-BY-8:             %[[VAL_38:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_25]])
+// UNROLL-BY-8:             %[[VAL_39:.*]] = scf.index_switch %[[VAL_37]] -> f32
+// UNROLL-BY-8:             case 0 {
+// UNROLL-BY-8:               %[[VAL_40:.*]] = affine.load %[[VAL_8]]{{\[}}%[[VAL_38]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_40]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 1 {
+// UNROLL-BY-8:               %[[VAL_41:.*]] = affine.load %[[VAL_9]]{{\[}}%[[VAL_38]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_41]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 2 {
+// UNROLL-BY-8:               %[[VAL_42:.*]] = affine.load %[[VAL_10]]{{\[}}%[[VAL_38]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_42]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 3 {
+// UNROLL-BY-8:               %[[VAL_43:.*]] = affine.load %[[VAL_11]]{{\[}}%[[VAL_38]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_43]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 4 {
+// UNROLL-BY-8:               %[[VAL_44:.*]] = affine.load %[[VAL_12]]{{\[}}%[[VAL_38]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_44]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 5 {
+// UNROLL-BY-8:               %[[VAL_45:.*]] = affine.load %[[VAL_13]]{{\[}}%[[VAL_38]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_45]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 6 {
+// UNROLL-BY-8:               %[[VAL_46:.*]] = affine.load %[[VAL_14]]{{\[}}%[[VAL_38]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_46]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 7 {
+// UNROLL-BY-8:               %[[VAL_47:.*]] = affine.load %[[VAL_15]]{{\[}}%[[VAL_38]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield %[[VAL_47]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             default {
+// UNROLL-BY-8:               scf.yield %[[VAL_16]] : f32
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             %[[VAL_48:.*]] = arith.mulf %[[VAL_28]], %[[VAL_39]] : f32
+// UNROLL-BY-8:             %[[VAL_49:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_25]])
+// UNROLL-BY-8:             %[[VAL_50:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_25]])
+// UNROLL-BY-8:             scf.index_switch %[[VAL_49]]
+// UNROLL-BY-8:             case 0 {
+// UNROLL-BY-8:               affine.store %[[VAL_48]], %[[VAL_17]]{{\[}}%[[VAL_50]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 1 {
+// UNROLL-BY-8:               affine.store %[[VAL_48]], %[[VAL_18]]{{\[}}%[[VAL_50]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 2 {
+// UNROLL-BY-8:               affine.store %[[VAL_48]], %[[VAL_19]]{{\[}}%[[VAL_50]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 3 {
+// UNROLL-BY-8:               affine.store %[[VAL_48]], %[[VAL_20]]{{\[}}%[[VAL_50]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 4 {
+// UNROLL-BY-8:               affine.store %[[VAL_48]], %[[VAL_21]]{{\[}}%[[VAL_50]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 5 {
+// UNROLL-BY-8:               affine.store %[[VAL_48]], %[[VAL_22]]{{\[}}%[[VAL_50]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 6 {
+// UNROLL-BY-8:               affine.store %[[VAL_48]], %[[VAL_23]]{{\[}}%[[VAL_50]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             case 7 {
+// UNROLL-BY-8:               affine.store %[[VAL_48]], %[[VAL_24]]{{\[}}%[[VAL_50]]] : memref<1xf32>
+// UNROLL-BY-8:               scf.yield
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:             default {
+// UNROLL-BY-8:             }
+// UNROLL-BY-8:           }
+// UNROLL-BY-8:           return %[[VAL_17]], %[[VAL_18]], %[[VAL_19]], %[[VAL_20]], %[[VAL_21]], %[[VAL_22]], %[[VAL_23]], %[[VAL_24]] : memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>, memref<1xf32>
+// UNROLL-BY-8:         }
+
+func.func @bank_one_dim_unroll8(%arg0: memref<8xf32>, %arg1: memref<8xf32>) -> (memref<8xf32>) {
   %mem = memref.alloc() : memref<8xf32>
   affine.parallel (%i) = (0) to (8) {
     %1 = affine.load %arg0[%i] : memref<8xf32>

--- a/test/Transforms/memory_banking.mlir
+++ b/test/Transforms/memory_banking.mlir
@@ -2,6 +2,8 @@
 // RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=1" | FileCheck %s --check-prefix UNROLL-BY-1
 // RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=8" | FileCheck %s --check-prefix UNROLL-BY-8
 
+// -----
+
 // UNROLL-BY-2: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0 mod 2)>
 // UNROLL-BY-2: #[[$ATTR_1:.+]] = affine_map<(d0) -> (d0 floordiv 2)>
 
@@ -71,6 +73,8 @@ func.func @bank_one_dim_unroll2(%arg0: memref<8xf32>, %arg1: memref<8xf32>) -> (
   return %mem : memref<8xf32>
 }
 
+// -----
+
 // UNROLL-BY-1-LABEL:   func.func @bank_one_dim_unroll1(
 // UNROLL-BY-1-SAME:                                    %[[VAL_0:.*]]: memref<8xf32>,
 // UNROLL-BY-1-SAME:                                    %[[VAL_1:.*]]: memref<8xf32>) -> memref<8xf32> {
@@ -94,6 +98,8 @@ func.func @bank_one_dim_unroll1(%arg0: memref<8xf32>, %arg1: memref<8xf32>) -> (
   }
   return %mem : memref<8xf32>
 }
+
+// -----
 
 // UNROLL-BY-8: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0 mod 8)>
 // UNROLL-BY-8: #[[$ATTR_1:.+]] = affine_map<(d0) -> (d0 floordiv 8)>


### PR DESCRIPTION
This patch partition memories used inside affine parallel loops into even banks and replace the old memrefs with new ones throughout the program.