### PR TITLE
Revert "[FIRRTL] Don't force non-local trackers in Dedup."

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -114,8 +114,7 @@ std::unique_ptr<mlir::Pass> createVBToBVPass();
 
 std::unique_ptr<mlir::Pass> createAddSeqMemPortsPass();
 
-std::unique_ptr<mlir::Pass>
-createDedupPass(bool disableLocalAnnotations = false);
+std::unique_ptr<mlir::Pass> createDedupPass();
 
 std::unique_ptr<mlir::Pass> createEliminateWiresPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -269,11 +269,6 @@ def Dedup : Pass<"firrtl-dedup", "firrtl::CircuitOp"> {
     Statistic<"erasedModules", "num-erased-modules",
       "Number of modules which were erased by deduplication">
   ];
-  let options = [
-    Option<"disableLocalAnnotations", "disable-local-annotations", "bool",
-           "false", "Disable local annotations and revert to legacy behavior " #
-	            "of making annotations non-local">
-  ];
   let constructor = "circt::firrtl::createDedupPass()";
 }
 

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -101,7 +101,6 @@ public:
   bool shouldAdvancedLayerSink() const { return advancedLayerSink; }
   bool shouldLowerMemories() const { return lowerMemories; }
   bool shouldDedup() const { return !noDedup; }
-  bool shouldDisableLocalAnnotations() const { return disableLocalAnnotations; }
   bool shouldEnableDebugInfo() const { return enableDebugInfo; }
   bool shouldIgnoreReadEnableMemories() const { return ignoreReadEnableMem; }
   bool shouldEmitOMIR() const { return emitOMIR; }
@@ -210,11 +209,6 @@ public:
 
   FirtoolOptions &setNoDedup(bool value) {
     noDedup = value;
-    return *this;
-  }
-
-  FirtoolOptions &setDisableLocalAnnotations(bool value) {
-    disableLocalAnnotations = value;
     return *this;
   }
 
@@ -390,7 +384,6 @@ private:
   std::string chiselInterfaceOutDirectory;
   bool vbToBV;
   bool noDedup;
-  bool disableLocalAnnotations;
   firrtl::CompanionMode companionMode;
   bool disableAggressiveMergeConnections;
   bool emitOMIR;

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -540,12 +540,6 @@ struct FirtoolCmdOptions {
       llvm::cl::desc("Disable deduplication of structurally identical modules"),
       llvm::cl::init(false)};
 
-  llvm::cl::opt<bool> disableLocalAnnotations{
-      "disable-local-annotations",
-      llvm::cl::desc("Disable local annotations and revert to legacy behavior "
-                     "of making annotations non-local in internal passes"),
-      llvm::cl::init(false)};
-
   llvm::cl::opt<firrtl::CompanionMode> companionMode{
       "grand-central-companion-mode",
       llvm::cl::desc("Specifies the handling of Grand Central companions"),
@@ -761,8 +755,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       preserveMode(firrtl::PreserveValues::None), enableDebugInfo(false),
       buildMode(BuildModeRelease), disableOptimization(false),
       exportChiselInterface(false), chiselInterfaceOutDirectory(""),
-      vbToBV(false), noDedup(false), disableLocalAnnotations(false),
-      companionMode(firrtl::CompanionMode::Bind),
+      vbToBV(false), noDedup(false), companionMode(firrtl::CompanionMode::Bind),
       disableAggressiveMergeConnections(false), emitOMIR(true), omirOutFile(""),
       advancedLayerSink(false), lowerMemories(false), blackBoxRootPath(""),
       replSeqMem(false), replSeqMemFile(""), extractTestCode(false),
@@ -795,7 +788,6 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   chiselInterfaceOutDirectory = clOptions->chiselInterfaceOutDirectory;
   vbToBV = clOptions->vbToBV;
   noDedup = clOptions->noDedup;
-  disableLocalAnnotations = clOptions->disableLocalAnnotations;
   companionMode = clOptions->companionMode;
   disableAggressiveMergeConnections =
       clOptions->disableAggressiveMergeConnections;

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -1,5 +1,4 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-dedup))' %s | FileCheck %s
-// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-dedup{disable-local-annotations=true}))' %s | FileCheck --check-prefix=DISABLE-LOCAL %s
 
 // CHECK-LABEL: firrtl.circuit "Empty"
 firrtl.circuit "Empty" {
@@ -773,37 +772,4 @@ firrtl.circuit "NoDedupPublic" {
   }
   firrtl.module @DUTLike() {}
   firrtl.module @NotDUT() {}
-}
-
-// CHECK-LABEL: "AllowLocalTrackers"
-// If the user requested local trackers, don't make them non-local.
-firrtl.circuit "AllowLocalTrackers" {
-  firrtl.module @AllowLocalTrackers() {
-    firrtl.instance foo0 @Foo0()
-    firrtl.instance foo1 @Foo1()
-    firrtl.instance foo2 @Foo2()
-  }
-
-  // CHECK-NOT: hw.hierpath
-
-  // DISABLE-LOCAL-COUNT-3: hw.hierpath
-
-  // CHECK: firrtl.module private @Foo0
-  // CHECK: firrtl.mem
-  // CHECK-SAME: {class = "circt.tracker", id = distinct[0]<>}
-  // CHECK-SAME: {class = "circt.tracker", id = distinct[1]<>}
-  // CHECK-NOT: {class = "circt.tracker", id = distinct[1]<>}
-  firrtl.module private @Foo0() {
-      %mem_RW0 = firrtl.mem Undefined {annotations = [{class = "circt.tracker", id = distinct[0]<>}], depth = 24 : i64, name = "mem", portNames = ["RW0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, rdata flip: uint<72>, wmode: uint<1>, wdata: uint<72>, wmask: uint<1>>
-  }
-
-  // CHECK-NOT: @Foo1
-  firrtl.module private @Foo1() {
-      %mem_RW0 = firrtl.mem Undefined {annotations = [{class = "circt.tracker", id = distinct[1]<>}], depth = 24 : i64, name = "mem", portNames = ["RW0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, rdata flip: uint<72>, wmode: uint<1>, wdata: uint<72>, wmask: uint<1>>
-  }
-
-  // CHECK-NOT: @Foo2
-  firrtl.module private @Foo2() {
-      %mem_RW0 = firrtl.mem Undefined {annotations = [{class = "circt.tracker", id = distinct[1]<>}], depth = 24 : i64, name = "mem", portNames = ["RW0"], readLatency = 1 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<5>, en: uint<1>, clk: clock, rdata flip: uint<72>, wmode: uint<1>, wdata: uint<72>, wmask: uint<1>>
-  }
 }


### PR DESCRIPTION
Reverts llvm/circt#7709

There were some post-commit questions about this approach, and I'm also not positive we even need the changes any more. If we do, we can either re-land this in its current form, with its warts, or we can solve the problem with more intelligent logic in LowerClasses.