### PR TITLE
[FIRRTL] Add layer support to ExtractInstances

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -10,6 +10,15 @@
 // `ExtractBlackBoxes`, `ExtractClockGates`, and `ExtractSeqMems` passes in the
 // Scala FIRRTL implementation.
 //
+// This pass will make no modifications if the circuit does not contain no
+// design-under-test (DUT).  I.e., this pass does not use the "effecctive" DUT.
+// If a DUT exists, then anything in the design is extracted.  Using the
+// standard interpretation of passes like this, layers are not in the design.
+// If a situation arise where a module is instantiated inside and outside the
+// design that needs to be extracted, then it will be extracted in both up to
+// the point where it no longer needs to be further extracted.  See the tests
+// for examples of this.
+//
 //===----------------------------------------------------------------------===//
 
 #include "circt/Analysis/FIRRTLInstanceInfo.h"
@@ -359,7 +368,7 @@ void ExtractInstancesPass::collectAnnos() {
         continue;
       LLVM_DEBUG(llvm::dbgs()
                  << "Clock gate `" << module.getModuleName() << "`\n");
-      if (!instanceInfo->anyInstanceUnderDut(module)) {
+      if (!instanceInfo->anyInstanceInDesign(module)) {
         LLVM_DEBUG(llvm::dbgs() << "- Ignored (outside DUT)\n");
         continue;
       }
@@ -392,7 +401,7 @@ void ExtractInstancesPass::collectAnnos() {
 
     for (auto module : circuit.getOps<FMemModuleOp>()) {
       LLVM_DEBUG(llvm::dbgs() << "Memory `" << module.getModuleName() << "`\n");
-      if (!instanceInfo->anyInstanceUnderDut(module)) {
+      if (!instanceInfo->anyInstanceInDesign(module)) {
         LLVM_DEBUG(llvm::dbgs() << "- Ignored (outside DUT)\n");
         continue;
       }
@@ -492,6 +501,14 @@ void ExtractInstancesPass::extractInstances() {
     InstanceOp inst;
     ExtractionInfo info;
     std::tie(inst, info) = extractionWorklist.pop_back_val();
+
+    // Stop extraction if the instance is inside a layer.  This has the effect
+    // of bubbling up instances to just inside a layer block.  However, this
+    // will only happen if the module is instantiated inside and outside a
+    // layer.
+    if (inst->getParentOfType<LayerBlockOp>())
+      continue;
+
     auto parent = inst->getParentOfType<FModuleOp>();
 
     // Figure out the wiring prefix to use for this instance. If we are supposed
@@ -514,7 +531,7 @@ void ExtractInstancesPass::extractInstances() {
     // in the root module), there's nothing left for us to do. Otherwise we
     // proceed to bubble it up one level in the hierarchy and add the resulting
     // instances back to the worklist.
-    if (!instanceInfo->anyInstanceUnderDut(parent) ||
+    if (!instanceInfo->anyInstanceInDesign(parent) ||
         instanceGraph->lookup(parent)->noUses() ||
         (info.stopAtDUT && instanceInfo->isDut(parent))) {
       LLVM_DEBUG(llvm::dbgs() << "\nNo need to further move " << inst << "\n");
@@ -1101,7 +1118,7 @@ void ExtractInstancesPass::createTraceFiles(ClassOp &sifiveMetadataClass) {
       // from the path and make the path look like it's rooted at the first DUT
       // module (so `TestHarness.dut.foo.bar` becomes `DUTModule.foo.bar`).
       while (!path.empty() &&
-             !instanceInfo->anyInstanceUnderDut(cast<igraph::ModuleOpInterface>(
+             !instanceInfo->anyInstanceInDesign(cast<igraph::ModuleOpInterface>(
                  symbolTable->lookup(path.back().getModule())))) {
         LLVM_DEBUG(llvm::dbgs()
                    << "    - Dropping non-DUT segment " << path.back() << "\n");

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -10,7 +10,7 @@
 // `ExtractBlackBoxes`, `ExtractClockGates`, and `ExtractSeqMems` passes in the
 // Scala FIRRTL implementation.
 //
-// This pass will make no modifications if the circuit does not contain no
+// This pass will make no modifications if the circuit does not contain a
 // design-under-test (DUT).  I.e., this pass does not use the "effecctive" DUT.
 // If a DUT exists, then anything in the design is extracted.  Using the
 // standard interpretation of passes like this, layers are not in the design.

--- a/test/Dialect/FIRRTL/extract-instances.mlir
+++ b/test/Dialect/FIRRTL/extract-instances.mlir
@@ -298,6 +298,174 @@ firrtl.circuit "ExtractBlackBoxesIntoDUTSubmodule"  {
 }
 
 //===----------------------------------------------------------------------===//
+// ExtractBlackBoxes Custom Tests
+//
+// These are tests that were not derived from legacy custom SFC tests.
+//===----------------------------------------------------------------------===//
+
+// Test all possible combinations of extraction for modules that are: (1)
+// exclusively under the design, (2) exclusively not under the design, and (3)
+// both under and not under the design.  Modules can be not under the design if
+// they are outside the design or if they are under a layer.
+//
+// Note: this pass does not do any deduplication, so a module that is of type
+// (3) needs to cause extraction outside the design up to the point that it is
+// no longer necessary to do more extraction.
+firrtl.circuit "CombinationsTest" {
+  firrtl.layer @A bind {}
+  firrtl.extmodule @bbox_Foo() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.ExtractBlackBoxAnnotation",
+        filename = "BlackBoxes.txt",
+        prefix = ""
+      }
+    ],
+    defname = "bbox_Foo"
+  }
+  firrtl.module @Foo() {
+    firrtl.instance bbox_Foo @bbox_Foo()
+  }
+  firrtl.extmodule @bbox_Bar() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.ExtractBlackBoxAnnotation",
+        filename = "BlackBoxes.txt",
+        prefix = ""
+      }
+    ],
+    defname = "bbox_Bar"
+  }
+  firrtl.module @Bar() {
+    firrtl.instance bbox_Bar @bbox_Bar()
+  }
+  firrtl.extmodule @bbox_Baz() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.ExtractBlackBoxAnnotation",
+        filename = "BlackBoxes.txt",
+        prefix = ""
+      }
+    ],
+    defname = "bbox_Baz"
+  }
+  firrtl.module @Baz() {
+    firrtl.instance bbox_Baz @bbox_Baz()
+  }
+  firrtl.extmodule @bbox_Qux() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.ExtractBlackBoxAnnotation",
+        filename = "BlackBoxes.txt",
+        prefix = ""
+      }
+    ],
+    defname = "bbox_Qux"
+  }
+  firrtl.module @Qux() {
+    firrtl.instance bbox_Qux @bbox_Qux()
+  }
+  firrtl.extmodule @bbox_Quz() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.ExtractBlackBoxAnnotation",
+        filename = "BlackBoxes.txt",
+        prefix = ""
+      }
+    ],
+    defname = "bbox_Quz"
+  }
+  firrtl.module @Quz() {
+    firrtl.instance bbox_Quz @bbox_Quz()
+  }
+  firrtl.module @DUT() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {
+    firrtl.instance foo @Foo()
+    firrtl.instance baz @Baz()
+    firrtl.instance quz1 @Quz()
+    firrtl.layerblock @A {
+      firrtl.instance qux @Qux()
+      firrtl.instance quz2 @Quz()
+    }
+  }
+  firrtl.module @Wrapper() {
+    firrtl.instance dut @DUT()
+    firrtl.instance bar @Bar()
+    firrtl.instance baz @Baz()
+  }
+  firrtl.module @CombinationsTest() {
+    firrtl.instance wrapper @Wrapper()
+    // %sifive_metadata = firrtl.object @SiFive_Metadata()
+  }
+  // firrtl.class @SiFive_Metadata() {}
+}
+
+// CHECK-LABEL: firrtl.circuit "CombinationsTest"
+
+// CHECK-LABEL: firrtl.module @Foo()
+// CHECK-NOT:     firrtl.instance bbox_Foo @bbox_Foo
+
+// CHECK-LABEL: firrtl.module @Bar()
+// CHECK-NEXT:    firrtl.instance bbox_Bar @bbox_Bar
+
+// CHECK-LABEL: firrtl.module @Baz()
+// CHECK-NOT:     firrtl.instance bbox_Baz @bbox_Baz
+
+// CHECK-LABEL: firrtl.module @Qux()
+// CHECK:         firrtl.instance bbox_Qux @bbox_Qux
+
+// CHECK-LABEL: firrtl.module @Quz()
+// CHECK-NOT:     firrtl.instance bbox_Quz @bbox_Quz
+
+// CHECK-LABEL: firrtl.module @DUT()
+//
+// CHECK:         firrtl.layerblock @A {
+// CHECK-NEXT:      firrtl.instance qux @Qux()
+// CHECK-NEXT:      firrtl.instance quz2 {{.*}}@Quz()
+// CHECK-NEXT:      firrtl.instance bbox_Quz {{.*}}@bbox_Quz()
+
+// CHECK-LABEL: firrtl.module @Wrapper()
+// CHECK-NEXT:    firrtl.instance dut {{.*}}@DUT()
+// CHECK-NEXT:    firrtl.instance bbox_Foo {{.*}}@bbox_Foo()
+// CHECK-NEXT:    firrtl.instance bbox_Baz {{.*}}@bbox_Baz()
+// CHECK-NEXT:    firrtl.instance bbox_Quz {{.*}}@bbox_Quz()
+//
+// CHECK-NEXT:    firrtl.instance bar @Bar()
+//
+// CHECK-NEXT:    firrtl.instance baz {{.*}}@Baz()
+// CHECK-NEXT:    firrtl.instance bbox_Baz {{.*}}@bbox_Baz()
+
+// Test that a circuit without a design-under-test has no extraction.
+firrtl.circuit "NoDutBehavior" {
+
+  firrtl.extmodule @bbox_Foo() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.ExtractBlackBoxAnnotation",
+        filename = "BlackBoxes.txt",
+        prefix = ""
+      }
+    ],
+    defname = "bbox_Foo"
+  }
+  firrtl.module @Foo() {
+    firrtl.instance bbox_Foo @bbox_Foo()
+  }
+
+  firrtl.module @NoDutBehavior() {
+    firrtl.instance foo @Foo()
+  }
+}
+
+// CHECK-LABEL: firrtl.module @Foo
+// CHECK-NEXT:    firrtl.instance bbox_Foo @bbox_Foo()
+
+//===----------------------------------------------------------------------===//
 // ExtractClockGates Simple
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Update the `ExtractInstances` pass to not extract modules which are instantiated under layers.  For situations where a module is both in the design and under a layer, the module will be extracted up to the point where the instance is outside the design.  This is the same behavior that the pass does if a module is instantiated by both the test harness and the design.