### PR TITLE
[FIRRTL] Bump nextFIRVersion to 4.0.0 in the parser

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -114,9 +114,29 @@ struct FIRVersion {
   uint16_t patch;
 };
 
+/// The current minimum version of FIRRTL that the parser supports.
 constexpr FIRVersion minimumFIRVersion(2, 0, 0);
-constexpr FIRVersion nextFIRVersion(3, 3, 0);
-constexpr FIRVersion exportFIRVersion(4, 0, 0);
+
+/// The next version of FIRRTL that is not yet released.
+///
+/// Features use this version if they have been landed on the main branch of
+/// `chipsalliance/firrtl-spec`, but have not been part of a release yet. Once a
+/// new version of the spec is released, all uses of `nextFIRVersion` in the
+/// parser are replaced with the concrete version `{x, y, z}`, and this
+/// declaration here is bumped to the next probable version number.
+constexpr FIRVersion nextFIRVersion(4, 0, 0);
+
+/// A marker for parser features that are currently missing from the spec.
+///
+/// Features use this version if they have _not_ been added to the documentation
+/// in the `chipsalliance/firrtl-spec` repository. This allows us to distinguish
+/// features that are released in the next version of the spec and features that
+/// are still missing from the spec.
+constexpr FIRVersion missingSpecFIRVersion = nextFIRVersion;
+
+/// The version of FIRRTL that the exporter produces. This is always the next
+/// version, since it contains any new developments.
+constexpr FIRVersion exportFIRVersion = nextFIRVersion;
 
 template <typename T>
 T &operator<<(T &os, FIRVersion version) {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -890,7 +890,7 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
     break;
 
   case FIRToken::kw_Inst: {
-    if (requireFeature(nextFIRVersion, "Inst types"))
+    if (requireFeature(missingSpecFIRVersion, "Inst types"))
       return failure();
 
     consumeToken(FIRToken::kw_Inst);
@@ -918,7 +918,7 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
   }
 
   case FIRToken::kw_AnyRef: {
-    if (requireFeature(nextFIRVersion, "AnyRef types"))
+    if (requireFeature(missingSpecFIRVersion, "AnyRef types"))
       return failure();
 
     consumeToken(FIRToken::kw_AnyRef);
@@ -1103,19 +1103,19 @@ ParseResult FIRParser::parseType(FIRRTLType &result, const Twine &message) {
     result = FIntegerType::get(getContext());
     break;
   case FIRToken::kw_Bool:
-    if (requireFeature(nextFIRVersion, "Bools"))
+    if (requireFeature(missingSpecFIRVersion, "Bools"))
       return failure();
     consumeToken(FIRToken::kw_Bool);
     result = BoolType::get(getContext());
     break;
   case FIRToken::kw_Double:
-    if (requireFeature(nextFIRVersion, "Doubles"))
+    if (requireFeature(missingSpecFIRVersion, "Doubles"))
       return failure();
     consumeToken(FIRToken::kw_Double);
     result = DoubleType::get(getContext());
     break;
   case FIRToken::kw_Path:
-    if (requireFeature(nextFIRVersion, "Paths"))
+    if (requireFeature(missingSpecFIRVersion, "Paths"))
       return failure();
     consumeToken(FIRToken::kw_Path);
     result = PathType::get(getContext());
@@ -1976,7 +1976,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
   case FIRToken::lp_integer_mul:
   case FIRToken::lp_integer_shr:
   case FIRToken::lp_integer_shl:
-    if (requireFeature({4, 0, 0}, "Integer arithmetic expressions"))
+    if (requireFeature(nextFIRVersion, "Integer arithmetic expressions"))
       return failure();
     break;
   default:
@@ -2056,7 +2056,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
     break;
   }
   case FIRToken::kw_Bool: {
-    if (requireFeature(nextFIRVersion, "Bools"))
+    if (requireFeature(missingSpecFIRVersion, "Bools"))
       return failure();
     locationProcessor.setLoc(getToken().getLoc());
     consumeToken(FIRToken::kw_Bool);
@@ -2077,7 +2077,7 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
     break;
   }
   case FIRToken::kw_Double: {
-    if (requireFeature(nextFIRVersion, "Doubles"))
+    if (requireFeature(missingSpecFIRVersion, "Doubles"))
       return failure();
     locationProcessor.setLoc(getToken().getLoc());
     consumeToken(FIRToken::kw_Double);
@@ -2120,12 +2120,12 @@ ParseResult FIRStmtParser::parseExpImpl(Value &result, const Twine &message,
   case FIRToken::lp_path:
     if (isLeadingStmt)
       return emitError("unexpected path() as start of statement");
-    if (requireFeature(nextFIRVersion, "paths") || parsePathExp(result))
+    if (requireFeature(missingSpecFIRVersion, "Paths") || parsePathExp(result))
       return failure();
     break;
 
   case FIRToken::lp_intrinsic:
-    if (requireFeature({4, 0, 0}, "generic intrinsics") ||
+    if (requireFeature(nextFIRVersion, "generic intrinsics") ||
         parseIntrinsicExp(result))
       return failure();
     break;
@@ -2666,15 +2666,15 @@ ParseResult FIRStmtParser::parseSimpleStmtImpl(unsigned stmtIndent) {
     return parseRefReleaseInitial();
   case FIRToken::kw_group:
     if (requireFeature({3, 2, 0}, "optional groups") ||
-        removedFeature({4, 0, 0}, "optional groups"))
+        removedFeature(nextFIRVersion, "optional groups"))
       return failure();
     return parseLayerBlockOrGroup(stmtIndent);
   case FIRToken::kw_layerblock:
-    if (requireFeature({4, 0, 0}, "layers"))
+    if (requireFeature(nextFIRVersion, "layers"))
       return failure();
     return parseLayerBlockOrGroup(stmtIndent);
   case FIRToken::lp_intrinsic:
-    if (requireFeature({4, 0, 0}, "generic intrinsics"))
+    if (requireFeature(nextFIRVersion, "generic intrinsics"))
       return failure();
     return parseIntrinsicStmt();
   default: {
@@ -4086,7 +4086,7 @@ ParseResult FIRStmtParser::parseInstanceChoice() {
   if (auto isExpr = parseExpWithLeadingKeyword(startTok))
     return *isExpr;
 
-  if (requireFeature({4, 0, 0}, "option groups/instance choices"))
+  if (requireFeature(nextFIRVersion, "option groups/instance choices"))
     return failure();
 
   StringRef id;
@@ -4197,7 +4197,7 @@ ParseResult FIRStmtParser::parseObject() {
   if (auto isExpr = parseExpWithLeadingKeyword(startTok))
     return *isExpr;
 
-  if (requireFeature(nextFIRVersion, "object statements"))
+  if (requireFeature(missingSpecFIRVersion, "object statements"))
     return failure();
 
   StringRef id;
@@ -4818,7 +4818,7 @@ ParseResult FIRCircuitParser::parseOptionalEnabledLayers(ArrayAttr &result) {
     return success();
   }
 
-  if (requireFeature({4, 0, 0}, "modules with layers enabled"))
+  if (requireFeature(nextFIRVersion, "modules with layers enabled"))
     return failure();
 
   SmallVector<Attribute> layers;
@@ -4914,7 +4914,7 @@ ParseResult FIRCircuitParser::parseRefList(ArrayRef<PortInfo> portList,
 
   // Ref statements were removed in 4.0.0, check.
   if (getToken().is(FIRToken::kw_ref) &&
-      removedFeature({4, 0, 0}, "ref statements"))
+      removedFeature(nextFIRVersion, "ref statements"))
     return failure();
 
   // Parse the ref statements.
@@ -5055,7 +5055,7 @@ ParseResult FIRCircuitParser::parseClass(CircuitOp circuit, unsigned indent) {
   SmallVector<SMLoc> portLocs;
   LocWithInfo info(getToken().getLoc(), this);
 
-  if (requireFeature(nextFIRVersion, "classes"))
+  if (requireFeature(missingSpecFIRVersion, "classes"))
     return failure();
 
   consumeToken(FIRToken::kw_class);
@@ -5093,7 +5093,7 @@ ParseResult FIRCircuitParser::parseExtClass(CircuitOp circuit,
   SmallVector<SMLoc> portLocs;
   LocWithInfo info(getToken().getLoc(), this);
 
-  if (requireFeature(nextFIRVersion, "classes"))
+  if (requireFeature(missingSpecFIRVersion, "classes"))
     return failure();
 
   consumeToken(FIRToken::kw_extclass);
@@ -5150,7 +5150,7 @@ ParseResult FIRCircuitParser::parseExtModule(CircuitOp circuit,
   if (parseParameterList(parameters) || parseRefList(portList, internalPaths))
     return failure();
 
-  if (version >= FIRVersion{4, 0, 0}) {
+  if (version >= nextFIRVersion) {
     for (auto [pi, loc] : llvm::zip_equal(portList, portLocs)) {
       if (auto ftype = type_dyn_cast<FIRRTLType>(pi.type)) {
         if (ftype.hasUninferredWidth())
@@ -5231,12 +5231,13 @@ ParseResult FIRCircuitParser::parseModule(CircuitOp circuit, bool isPublic,
 
   // The main module is implicitly public.
   if (name == circuit.getName()) {
-    if (!isPublic && removedFeature({4, 0, 0}, "private main modules", modLoc))
+    if (!isPublic &&
+        removedFeature(nextFIRVersion, "private main modules", modLoc))
       return failure();
     isPublic = true;
   }
 
-  if (isPublic && version >= FIRVersion{4, 0, 0}) {
+  if (isPublic && version >= nextFIRVersion) {
     for (auto [pi, loc] : llvm::zip_equal(portList, portLocs)) {
       if (auto ftype = type_dyn_cast<FIRRTLType>(pi.type)) {
         if (ftype.hasUninferredWidth())
@@ -5313,7 +5314,7 @@ ParseResult FIRCircuitParser::parseToplevelDefinition(CircuitOp circuit,
     return parseClass(circuit, indent);
   case FIRToken::kw_declgroup:
     if (requireFeature({3, 2, 0}, "optional groups") ||
-        removedFeature({4, 0, 0}, "optional groups"))
+        removedFeature(nextFIRVersion, "optional groups"))
       return failure();
     return parseLayer(circuit);
   case FIRToken::kw_extclass:
@@ -5321,21 +5322,21 @@ ParseResult FIRCircuitParser::parseToplevelDefinition(CircuitOp circuit,
   case FIRToken::kw_extmodule:
     return parseExtModule(circuit, indent);
   case FIRToken::kw_formal:
-    if (requireFeature({4, 0, 0}, "inline formal tests"))
+    if (requireFeature(nextFIRVersion, "inline formal tests"))
       return failure();
     return parseFormal(circuit, indent);
   case FIRToken::kw_intmodule:
-    if (removedFeature({4, 0, 0}, "intrinsic modules"))
+    if (removedFeature(nextFIRVersion, "intrinsic modules"))
       return failure();
     return parseIntModule(circuit, indent);
   case FIRToken::kw_layer:
-    if (requireFeature({4, 0, 0}, "layers"))
+    if (requireFeature(nextFIRVersion, "layers"))
       return failure();
     return parseLayer(circuit);
   case FIRToken::kw_module:
     return parseModule(circuit, /*isPublic=*/false, indent);
   case FIRToken::kw_public:
-    if (requireFeature({4, 0, 0}, "public modules"))
+    if (requireFeature(nextFIRVersion, "public modules"))
       return failure();
     consumeToken();
     if (getToken().getKind() == FIRToken::kw_module)
@@ -5344,7 +5345,7 @@ ParseResult FIRCircuitParser::parseToplevelDefinition(CircuitOp circuit,
   case FIRToken::kw_type:
     return parseTypeDecl();
   case FIRToken::kw_option:
-    if (requireFeature({4, 0, 0}, "option groups/instance choices"))
+    if (requireFeature(nextFIRVersion, "option groups/instance choices"))
       return failure();
     return parseOptionDecl(circuit);
   default:

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1449,9 +1449,9 @@ circuit Layers:
 
 ;// -----
 ; CHECK-LABEL: firrtl.circuit "BasicProps"
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit BasicProps :
-  module BasicProps :
+  public module BasicProps :
   ; CHECK-LABEL: module private @Integer
   module Integer :
     ; CHECK-SAME: out %a: !firrtl.integer
@@ -1655,13 +1655,13 @@ circuit WireOfProbesAndNames:
     wire probe : Probe<UInt<1>>
 
 ;// -----
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 
 ; CHECK-LABEL: circuit "AnyRef"
 circuit AnyRef:
   class Foo:
     skip
-  module AnyRef:
+  public module AnyRef:
     input x : AnyRef
     ; CHECK: !firrtl.anyref
     output y : AnyRef

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -196,10 +196,10 @@ circuit invalid_inst :
 
 ;// -----
 
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit class_inst :
   class some_class :
-  module class_inst :
+  public module class_inst :
     ; expected-error @below {{cannot create instance of class 'some_class', did you mean object?}}
     inst xyz of some_class
 
@@ -966,32 +966,32 @@ circuit LayerEmptyOutputDir:
 
 ;// -----
 
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit Top:
   ; expected-error @below {{class cannot be the top of a circuit}}
   class Top:
 
 ;// -----
 
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit Top:
   ; expected-error @below {{extclass cannot be the top of a circuit}}
   extclass Top:
 
 ;// -----
 
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit Top:
-  module Top:
+  public module Top:
   class Foo:
     ;; expected-error @below {{ports on classes must be properties}}
     input a: UInt<8>
 
 ;// -----
 
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit Top:
-  module Top:
+  public module Top:
   extclass Foo:
     ;; expected-error @below {{ports on extclasses must be properties}}
     input a: UInt<8>
@@ -1095,29 +1095,29 @@ circuit Top :
     propassign c, list_concat()
 
 ;// -----
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 
 circuit Top:
-  module Top:
+  public module Top:
     ; expected-error @below {{unknown class 'Missing'}}
     input in : Inst<Missing>
 
 ;// -----
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 
 circuit Top:
-  module Top:
+  public module Top:
     ; expected-error @below {{use of undefined class name 'Missing' in object}}
     object x of Missing
 
 ;// -----
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 
 circuit Top:
   class MyClass:
     skip
 
-  module Top:
+  public module Top:
     output str : String
     object x of MyClass
     ; expected-error @below {{unknown field 'missing' in type '!firrtl.class<@MyClass()>'}}
@@ -1127,7 +1127,7 @@ circuit Top:
 FIRRTL version 3.0.0
 
 circuit Top:
-  ; expected-error @below {{classes are a FIRRTL 3.3.0+ feature, but the specified FIRRTL version was 3.0.0}}
+  ; expected-error @below {{classes are a FIRRTL 4.0.0+ feature, but the specified FIRRTL version was 3.0.0}}
   class MyClass:
     skip
 
@@ -1139,7 +1139,7 @@ FIRRTL version 3.0.0
 
 circuit Top:
   module Top:
-    ; expected-error @below {{object statements are a FIRRTL 3.3.0+ feature, but the specified FIRRTL version was 3.0.0}}
+    ; expected-error @below {{object statements are a FIRRTL 4.0.0+ feature, but the specified FIRRTL version was 3.0.0}}
     object x of MyClass
 
 ;// -----
@@ -1147,7 +1147,7 @@ FIRRTL version 3.0.0
 
 circuit Top:
   module Top:
-    ; expected-error @below {{Inst types are a FIRRTL 3.3.0+ feature, but the specified FIRRTL version was 3.0.0}}
+    ; expected-error @below {{Inst types are a FIRRTL 4.0.0+ feature, but the specified FIRRTL version was 3.0.0}}
     output o: Inst<MyClass>
 
 ;// -----
@@ -1155,38 +1155,38 @@ circuit Top:
 FIRRTL version 3.1.0
 circuit ListOfInt:
    module ListOfInt:
-     ; expected-error @below {{Lists are a FIRRTL 3.3.0+ feature}}
+     ; expected-error @below {{Lists are a FIRRTL 4.0.0+ feature}}
      output a : List<Integer>
 
 ;// -----
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit ListOfUInt:
-   module ListOfUInt:
+   public module ListOfUInt:
      ; expected-error @below {{expected property type}}
      output a : List<UInt>
 
 ;// -----
 ; Wrong type of elements in List expression.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit ListOfUInt:
-   module ListOfUInt:
+   public module ListOfUInt:
      output a : List<String>
      ; expected-error @below {{unexpected expression of type '!firrtl.integer' in List expression of type '!firrtl.string'}}
      propassign a, List<String>(Integer(5))
 
 ;// -----
 ; List should not be leading a statement.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit LeadingList:
-  module LeadingList:
+  public module LeadingList:
     ; expected-error @below {{unexpected List<>() as start of statement}}
     List<String>()
 
 ;// -----
 ; Path should not be leading a statement.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit LeadingPath:
-  module LeadingPath:
+  public module LeadingPath:
     ; expected-error @below {{unexpected path() as start of statement}}
     path("")
 
@@ -1194,33 +1194,33 @@ circuit LeadingPath:
 FIRRTL version 3.1.0
 circuit PathVersion:
   module PathVersion:
-    ; expected-error @below {{Paths are a FIRRTL 3.3.0+ feature, but the specified FIRRTL version was 3.1.0}}
+    ; expected-error @below {{Paths are a FIRRTL 4.0.0+ feature, but the specified FIRRTL version was 3.1.0}}
     output path : Path
     propassign path, path("")
 
 ;// -----
 ; Path operation should have a single string argument.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit BadPathExpr:
-  module BadPathExp:
+  public module BadPathExp:
     output path : Path
     ; expected-error @below {{expected target string in path expression}}
     propassign path, path()
 
 ;// -----
 ; Path operation should have a single string argument.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit BadPathExpr:
-  module BadPathExp:
+  public module BadPathExp:
     output path : Path
     ; expected-error @below {{expected ')' in path expression}}
     propassign path, path("hello", "goodbye")
 
 ;// -----
 ; Path operation should have a single string argument.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit BadPathExpr:
-  module BadPathExp:
+  public module BadPathExp:
     output path : Path
     ; expected-error @below {{expected target string in path expression}}
     propassign path, path(UInt<1>(1))
@@ -1231,27 +1231,27 @@ FIRRTL version 3.0.0
 
 circuit Top:
   module Top:
-    ; expected-error @below {{Bools are a FIRRTL 3.3.0+ feature, but the specified FIRRTL version was 3.0.0}}
+    ; expected-error @below {{Bools are a FIRRTL 4.0.0+ feature, but the specified FIRRTL version was 3.0.0}}
     input in : Bool
     output out : Bool
     propassign out, in
 
 ;// -----
 ; Bool literal must be true or false.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 
 circuit Top:
-  module Top:
+  public module Top:
     output out : Bool
     ; expected-error @below {{expected true or false in Bool expression}}
     propassign out, Bool(0)
 
 ;// -----
 ; Properties can't be const.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 
 circuit Top:
-  module Top:
+  public module Top:
     ; expected-error @below {{only hardware types can be 'const'}}
     output out : const Bool
 
@@ -1260,34 +1260,34 @@ circuit Top:
 FIRRTL version 3.1.0
 circuit AnyRef:
    module AnyRef:
-     ; expected-error @below {{AnyRef types are a FIRRTL 3.3.0+ feature}}
+     ; expected-error @below {{AnyRef types are a FIRRTL 4.0.0+ feature}}
      output a : AnyRef
 
 ;// -----
 ; Only objects are valid as AnyRef
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit AnyRef:
-  module AnyRef:
+  public module AnyRef:
     output out : AnyRef
     ; expected-error @below {{cannot propassign non-equivalent type '!firrtl.integer' to '!firrtl.anyref'}}
     propassign out, Integer(5)
 
 ;// -----
 ; Only objects are valid as AnyRef in Lists
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit AnyRefList:
-  module AnyRefList:
+  public module AnyRefList:
     output list : List<AnyRef>
     ; expected-error @below {{unexpected expression of type '!firrtl.integer' in List expression of type '!firrtl.anyref'}}
     propassign list, List<AnyRef>(Integer(5))
 
 ;// -----
 ; Not Covariant.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit NotCovariant:
   class Class:
 
-  module NotCovariant:
+  public module NotCovariant:
     output list : List<AnyRef>
 
     object obj of Class
@@ -1296,11 +1296,11 @@ circuit NotCovariant:
 
 ;// -----
 ; Not Contravariant.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit NotContravariant:
   class Class:
 
-  module NotContravariant:
+  public module NotContravariant:
     output list : List<Inst<Class>>
 
     object obj of Class
@@ -1309,54 +1309,54 @@ circuit NotContravariant:
 
 ;// -----
 ; Double: must have digit before point.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit DoubleNegPeriod:
-  module DoubleNegPeriod:
+  public module DoubleNegPeriod:
     output d : Double
     ; expected-error @below {{unexpected character after sign}}
     propassign d, Double(-.5)
 
 ;// -----
 ; Double: must have digit after point.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit DoublePeriodEnd:
-  module DoublePeriodEnd:
+  public module DoublePeriodEnd:
     output d : Double
     ; expected-error @below {{expected floating point in Double expression}}
     propassign d, Double(0.)
 
 ;// -----
 ; Double: Not an integer.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit DoubleInteger:
-  module DoubleInteger:
+  public module DoubleInteger:
     output d : Double
     ; expected-error @below {{expected floating point in Double expression}}
     propassign d, Double(0)
 
 ;// -----
 ; Double: don't support NaN or inf.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit DoubleNaN:
-  module DoubleNaN:
+  public module DoubleNaN:
     output d : Double
     ; expected-error @below {{expected floating point in Double expression}}
     propassign d, Double(NaN)
 
 ;// -----
 ; Double: Don't support hex.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit DoubleHex:
-  module DoubleHex:
+  public module DoubleHex:
     output d : Double
     ; expected-error @below {{expected floating point in Double expression}}
     propassign d, Double(0x0)
 
 ;// -----
 ; Double: Don't suuport FIRRTL-y radix.
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 circuit DoubleRadix:
-  module DoubleRadix:
+  public module DoubleRadix:
     output d : Double
     ; expected-error @below {{expected floating point in Double expression}}
     propassign d, Double(0hABC)

--- a/test/firtool/classes-dedupe.fir
+++ b/test/firtool/classes-dedupe.fir
@@ -1,6 +1,6 @@
 ; RUN: firtool %s -ir-verilog | FileCheck %s
 
-FIRRTL version 3.3.0
+FIRRTL version 4.0.0
 
 circuit Test : %[[
 {
@@ -10,7 +10,7 @@ circuit Test : %[[
 ]]
   ; CHECK: hw.hierpath private [[NLA1:@.+]] [@CPU_1::[[SYM1:@.+]]]
   ; CHECK: hw.hierpath private [[NLA2:@.+]] [@CPU_1::[[SYM2:@.+]], @Fetch_1::[[SYM3:@.+]]]
-  module Test :
+  public module Test :
     input in : UInt<1>
     output out_1 : UInt<1>
     output out_2 : UInt<1>


### PR DESCRIPTION
Mark all parser features that were part of FIRRTL spec 3.3.0 [1] as requiring version `{3, 3, 0}` instead of `nextFIRVersion`. Bump the `nextFIRVersion` to be 4.0.0, matching the `exportFIRVersion` as it used to be the case earlier. Note that specifically the "List concat" feature was not part of 3.3.0 and is therefore still marked as `nextFIRVersion`.

Also add a `missingSpecFIRVersion` to mark the features in the parser that have not been added to the spec yet. This avoids accidental replacement of the version during the next spec release.

This change requires a few tweaks to the regression tests, where a few features like `class`, `Bool`, `Double`, `Inst`, `path`, and more, were tested under FIRRTL 3.3.0, assuming they would be released as part of the spec in that version. But the features have never made their way into the spec, so all of these tests now have to point at the next spec version.

[1]: https://github.com/chipsalliance/firrtl-spec/releases/tag/v3.3.0