### PR TITLE
[FIRRTL] Move LowerLayers after ExtractInstances

### DIFF
--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -183,9 +183,9 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
       opt.shouldReplaceSequentialMemories(),
       opt.getReplaceSequentialMemoriesFile()));
 
-  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerLayersPass());
-
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createExtractInstancesPass());
+
+  pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerLayersPass());
 
   // Run passes to resolve Grand Central features.  This should run before
   // BlackBoxReader because Grand Central needs to inform BlackBoxReader where


### PR DESCRIPTION
Now that `ExtractInstances` supports layers [[1]], we can move `LowerLayers` after it in the pass pipeline.  This commit works towards moving `LowerLayers` to the end of the FIRRTL pipeline in order to allow inline layers to be compiled and support forcing out of layers.

[1]: cc3fecf18eeb06abb3cb31dcd935adf02ba7b0a1