### PR TITLE
[FIRRTL] Accept list of parameters for `formal` construct

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -41,42 +41,38 @@ class HardwareDeclOp<string mnemonic, list <Trait> traits = []> :
       "firrtl::WhenOp", "firrtl::MatchOp", "sv::IfDefOp"]>]> {}
 
 def FormalOp : FIRRTLOp<"formal", [
-    HasParent<"firrtl::CircuitOp">,
-    DeclareOpInterfaceMethods<Symbol>,
-    DeclareOpInterfaceMethods<SymbolUserOpInterface>
+  HasParent<"firrtl::CircuitOp">,
+  DeclareOpInterfaceMethods<Symbol>,
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
 ]> {
-  let summary = "A formal test definition.";
+  let summary = "Define a formal unit test";
   let description = [{
-    The `firrtl.formal` operation defines a formal verification problem in the same 
-    context as the rest of the design. This problem is solved using bounded model 
-    checking and should be given a bound k, which represents the number of cycles considered 
-    during model checking. This definition marks a test harness defined as an internal module to 
-    be verified using bounded model checking.
+    The `firrtl.formal` operation defines a formal verification unit test. The
+    defines a unique symbol name that can be used to refer to it. The design to
+    be tested and any necessary test harness is defined by the separate
+    `firrtl.module` op referenced by `moduleName`. Additional parameters may be
+    specified for the unit test. Input ports of the target module are considered
+    to be symbolic values during the test; output ports are ignored.
+
+    This operation may be used to mark unit tests in a FIRRTL design, which
+    other tools may later pick up and run automatically. It is intended to lower
+    to the `verif.formal` operation. See `verif.formal` for more details.
 
     Example:
     ```mlir
-    // DUT
-    firrtl.module @Foo(in %bar: !firrtl.uint<8>, out %out: !firrtl.uint<8>) { ... }
-
-    // Test harness
-    firrtl.module @FooTest(in %bar_s: !firrtl.uint<8>) {
-      %bar, %out = firrtl.instance foo @Foo(in bar: %bar_s: !firrtl.uint<8>, out out: !firrtl.uint<8>) 
-      %c42_8 = firrtl.constant 42 : !firrtl.uint<8>
-      firrtl.connect %bar, %c42_8: !firrtl.uint<8>, !firrtl.uint<8>
-      %c69_8 = firrtl.constant 69 : !firrtl.uint<8>
-      %cond = firrtl.eq %c69_8, %out : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<1>
-      firrtl.assert %cond
-    }
-
-    // Mark test harness as formal test
-    firrtl.formal @formal1 of @FooTest bound 20
+    firrtl.module @MyTest(in %a: !firrtl.uint<42>) {}
+    firrtl.formal @myTestA, @MyTest {bound = 42}
+    firrtl.formal @myTestB, @MyTest {mode = "induction", userAttr = 9001}
     ```
   }];
 
-  let arguments = (ins SymbolNameAttr:$sym_name, FlatSymbolRefAttr:$moduleName, UI64Attr:$bound);
-  let results = (outs);
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    FlatSymbolRefAttr:$moduleName,
+    DictionaryAttr:$parameters
+  );
   let assemblyFormat = [{
-    $sym_name `of` $moduleName `bound` $bound attr-dict
+    $sym_name `,` $moduleName $parameters attr-dict-with-keyword
   }];
 }
 

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -65,6 +65,8 @@ struct Emitter {
 
   void emitParamAssign(ParamDeclAttr param, Operation *op,
                        std::optional<PPExtString> wordBeforeLHS = std::nullopt);
+  void emitParamValue(Attribute value, Operation *op);
+
   void emitGenericIntrinsic(GenericIntrinsicOp op);
 
   // Statement emission
@@ -433,7 +435,11 @@ void Emitter::emitParamAssign(ParamDeclAttr param, Operation *op,
     ps << *wordBeforeLHS << PP::nbsp;
   }
   ps << PPExtString(param.getName().strref()) << PP::nbsp << "=" << PP::nbsp;
-  TypeSwitch<Attribute>(param.getValue())
+  emitParamValue(param.getValue(), op);
+}
+
+void Emitter::emitParamValue(Attribute value, Operation *op) {
+  TypeSwitch<Attribute>(value)
       .Case<IntegerAttr>([&](auto attr) { ps.addAsString(attr.getValue()); })
       .Case<FloatAttr>([&](auto attr) {
         SmallString<16> str;
@@ -442,6 +448,24 @@ void Emitter::emitParamAssign(ParamDeclAttr param, Operation *op,
       })
       .Case<StringAttr>(
           [&](auto attr) { ps.writeQuotedEscaped(attr.getValue()); })
+      .Case<ArrayAttr>([&](auto attr) {
+        ps.scopedBox(PP::bbox2, [&]() {
+          ps << "[";
+          interleaveComma(attr.getValue(),
+                          [&](auto element) { emitParamValue(element, op); });
+          ps << "]";
+        });
+      })
+      .Case<DictionaryAttr>([&](auto attr) {
+        ps.scopedBox(PP::bbox2, [&]() {
+          ps << "{";
+          interleaveComma(attr.getValue(), [&](auto field) {
+            ps << PPExtString(field.getName()) << PP::nbsp << "=" << PP::nbsp;
+            emitParamValue(field.getValue(), op);
+          });
+          ps << "}";
+        });
+      })
       .Default([&](auto attr) {
         emitOpError(op, "with unsupported parameter attribute: ") << attr;
         ps << "<unsupported-attr ";
@@ -628,16 +652,21 @@ void Emitter::emitDeclaration(OptionOp op) {
 /// Emit a formal test definition.
 void Emitter::emitDeclaration(FormalOp op) {
   startStatement();
-  ps << "formal " << PPExtString(op.getSymName()) << " of "
-     << PPExtString(op.getModuleName()) << ", bound = ";
-  ps.addAsString(op.getBound());
+  ps.cbox(4, IndentStyle::Block);
+  ps << "formal " << PPExtString(legalize(op.getSymNameAttr()));
+  ps << " of " << PPExtString(legalize(op.getModuleNameAttr().getAttr()));
+  ps << PP::nbsp << ":" << PP::end;
+  emitLocation(op);
 
-  if (auto outputFile = op->getAttrOfType<hw::OutputFileAttr>("output_file")) {
-    ps << ", ";
-    ps.writeQuotedEscaped(outputFile.getFilename().getValue());
-  }
-
-  emitLocationAndNewLine(op);
+  ps.scopedBox(PP::bbox2, [&]() {
+    setPendingNewline();
+    for (auto param : op.getParameters()) {
+      startStatement();
+      ps << PPExtString(param.getName()) << PP::nbsp << "=" << PP::nbsp;
+      emitParamValue(param.getValue(), op);
+      setPendingNewline();
+    }
+  });
 }
 
 /// Check if an operation is inlined into the emission of their users. For

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -868,4 +868,16 @@ firrtl.circuit "Foo" {
     %8 = firrtl.int.generic "circt_isX"  %7 : (!firrtl.uint<1>) -> !firrtl.uint<1>
     firrtl.int.generic "circt_verif_assert"  %8 : (!firrtl.uint<1>) -> ()
   }
+
+  // CHECK-LABEL: formal someTestName of Foo :
+  // CHECK-NEXT: a_int = 42
+  // CHECK-NEXT: b_string = "hello"
+  // CHECK-NEXT: c_array = [42, "hello", [9001], {foo = 1337}]
+  // CHECK-NEXT: d_map = {a = 42, b = "hello", c = [9001], d = {foo = 1337}}
+  firrtl.formal @someTestName, @Foo {
+    a_int = 42,
+    b_string = "hello",
+    c_array = [42, "hello", [9001], {foo = 1337}],
+    d_map = {a = 42, b = "hello", c = [9001], d = {foo = 1337}}
+  }
 }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1866,36 +1866,28 @@ FIRRTL version 4.0.0
 ; CHECK-LABEL: circuit "Foo"
 circuit Foo:
 
-  ; CHECK-LABEL: firrtl.module @Foo(in %data: !firrtl.uint<32>, in %c: !firrtl.uint<1>, out %out: !firrtl.uint<32>)
+  ; CHECK-LABEL: firrtl.module @Foo()
   public module Foo:
-    input data : UInt<32>
-    input c : UInt<1>
-    output out : UInt<32>
+    skip
 
-    when c:
-      node add1 = add(data, UInt<32>(1))
-      connect out, add1
-    else:
-      connect out, data
+  ; CHECK-LABEL: firrtl.module @Bar(in %a: !firrtl.uint<42>)
+  public module Bar:
+    input a: UInt<42>
 
-  ; CHECK-LABEL: firrtl.module @FooTest(in %s_foo_c: !firrtl.uint<1>, in %s_foo_data: !firrtl.uint<32>)
-  public module FooTest:
-    input s_foo_c : UInt<1>
-    input s_foo_data : UInt<32>
+  ; CHECK: firrtl.formal @someNameA, @Foo {bound = 20 : i32}
+  formal someNameA of Foo, bound = 20
 
-    ; CHECK-NEXT: %foo_data, %foo_c, %foo_out = firrtl.instance foo interesting_name @Foo(in data: !firrtl.uint<32>, in c: !firrtl.uint<1>, out out: !firrtl.uint<32>)
-    inst foo of Foo
-    ; CHECK-NEXT: firrtl.matchingconnect %foo_c, %s_foo_c : !firrtl.uint<1>
-    connect foo.c, s_foo_c
-    ; CHECK-NEXT: firrtl.matchingconnect %foo_data, %s_foo_data : !firrtl.uint<32>
-    connect foo.data, s_foo_data
-    ; CHECK-NEXT: %0 = firrtl.eq %foo_out, %s_foo_data : (!firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<1>
-    ; CHECK-NEXT: %1 = firrtl.int.generic "circt_ltl_implication"  %s_foo_c, %0 : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
-    ; CHECK-NEXT: firrtl.int.generic "circt_verif_assert"  %1 : (!firrtl.uint<1>) -> ()
-    intrinsic(circt_verif_assert, intrinsic(circt_ltl_implication : UInt<1>, s_foo_c, eq(foo.out, s_foo_data)))
-
-  ; CHECK: firrtl.formal @testFormal of @FooTest bound 20
-  formal testFormal of FooTest, bound = 20
+  ; CHECK: firrtl.formal @someNameB, @Bar {
+  ; CHECK-SAME: a_int = 42
+  ; CHECK-SAME: b_string = "hello"
+  ; CHECK-SAME: c_array = [42 : ui32, "hello", [9001 : ui32], {foo = 1337 : ui32}]
+  ; CHECK-SAME: d_map = {a = 42 : ui32, b = "hello", c = [9001 : ui32], d = {foo = 1337 : ui32}}
+  ; CHECK-SAME: }
+  formal someNameB of Bar:
+    a_int = 42
+    b_string = "hello"
+    c_array = [42, "hello", [9001], {foo = 1337}]
+    d_map = {a = 42, b = "hello", c = [9001], d = {foo = 1337}}
 
 ;// -----
 FIRRTL version 3.9.0

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -126,4 +126,11 @@ firrtl.module @PropertyListOps() {
   %concat = firrtl.list.concat %l0, %l1 : !firrtl.list<integer>
 }
 
+// CHECK: firrtl.formal @myTestA, @Top {}
+firrtl.formal @myTestA, @Top {}
+// CHECK: firrtl.formal @myTestB, @Top {bound = 42 : i19}
+firrtl.formal @myTestB, @Top {bound = 42 : i19}
+// CHECK: firrtl.formal @myTestC, @Top {} attributes {foo}
+firrtl.formal @myTestC, @Top {} attributes {foo}
+
 }


### PR DESCRIPTION
Adjust the syntax for the FIRRTL `formal` construct such that it no longer expects a single `bound = <N>` parameter, but accepts a list of user-defined integer, string, array, or dictionary parameters. The syntax now looks like

```
formal someTest of SomeModule:
  a_int = 42
  b_string = "hello"
  c_array = [42, "hello", [9001], {foo = 1337}]
  d_map = {a = 42, b = "hello", c = [9001], d = {foo = 1337}}
```

instead of the previous

```
formal someTest of SomeModule, bound = 42
```

The previous syntax is still supported until the corresponding change to the FIRRTL spec lands. Since it is not yet entirely clear what the list of necessary or well-understood parameters for formal tests is, the presence of `bounds` is no longer enforced. The rationale here being that this might turn out to be just a default setting in the formal test runner, which the user may not want to explicitly state. Once we have a clearer picture of which parameters are necessary, we can extend the parser to enforce parameters to be of specific types, and for specific parameters to be always defined.

This is the first time we allow for arrays and dictionaries to be specified as parameters. To avoid code duplication, this commit extends the `parseParameter` function with an `allowAggregates` option that enables parsing of `[...]` arrays and `{...}` dictionaries. The function now returns an untyped attribute, and places which want to turn this into a `ParamDeclAttr` now cast the result to a `TypedAttr` themselves. Parsing of the values is split out into a separate `parseParameterValue` function, which allows for the parsing of nested arrays and dictionaries. A similar adjustment exists in the emitter.

This commit is the first step towards lowering `formal` constructs in FIRRTL inputs to `verif.formal` core dialect ops, and running them with `circt-test`. The ability to specify parameters will help us build out the testing infrastructure without requiring spec changes for every single parameter adjustment.