### PR TITLE
[FIRRTL] Dedup: record less indices when hashing

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -316,7 +316,13 @@ private:
 
   // NOLINTNEXTLINE(misc-no-recursion)
   void update(Operation *op) {
-    record(op);
+    if (op->getNumResults())
+      record(op);
+    else if (auto innerSym = dyn_cast<hw::InnerSymbolOpInterface>(op))
+      if (auto attr = innerSym.getInnerSymAttr())
+        if (!attr.empty())
+          record(op);
+
     update(op->getName());
 
     // Hash the operands.


### PR DESCRIPTION
We map operations to their index as they appear in the IR, so that we can use the index when hashing their uses as operands and inner-symbol references. We only need to bother assigning indices to operations which actually have results or an inner-symbol.  Technically we can do a little better, the result or symbol has to actually have a user, but we we don't have many trivially dead expressions on our input.