### PR TITLE
[hlstool] Add option to use the DC lowering flow

### DIFF
--- a/tools/hlstool/CMakeLists.txt
+++ b/tools/hlstool/CMakeLists.txt
@@ -9,10 +9,14 @@ llvm_update_compile_flags(hlstool)
 target_link_libraries(hlstool
   PRIVATE
 
+  CIRCTDC
+  CIRCTDCTransforms
+  CIRCTDCToHW
   CIRCTESI
   CIRCTExportChiselInterface
   CIRCTExportVerilog
   CIRCTHandshake
+  CIRCTHandshakeToDC
   CIRCTHandshakeToHW
   CIRCTHandshakeTransforms
   CIRCTHW


### PR DESCRIPTION
Adds a `--dc` flag to use HandshakeToDC (and the DC lowering flow) instead of HandshakeToHW. Not enabling any tests since (AFAICT) none of them pass with this option.