### PR TITLE
[FIRRTL] Refactor class lowering to avoid unnecessary cloning

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -1151,12 +1151,17 @@ void LowerClassesPass::lowerClass(om::ClassOp classOp, FModuleLike moduleLike,
     mapping.map(inputValue, parameterValue);
   }
 
-  // Clone the property ops from the FIRRTL Class or Module to the OM Class.
-  SmallVector<Operation *> opsToErase;
-  OpBuilder builder = OpBuilder::atBlockBegin(classOp.getBodyBlock());
-  llvm::SmallVector<mlir::Location> fieldLocs;
-  llvm::SmallVector<mlir::Value> fieldValues;
-  for (auto &op : moduleLike->getRegion(0).getOps()) {
+  // Clone over the body block from the module like to the OM class. This
+  // actually lands the body into the OM class as a second block, which we then
+  // manually splice into the entry block and remove later.
+  moduleLike->getRegion(0).cloneInto(&classOp->getRegion(0),
+                                     classOp->getRegion(0).end(), mapping);
+  classBody->getOperations().splice(
+      classBody->end(), classOp->getRegion(0).back().getOperations());
+
+  // Helper to check if an op is a property op, which should be removed in the
+  // module like, or kept in the OM class.
+  auto isPropertyOp = [&](Operation &op) {
     // Check if any operand is a property.
     auto propertyOperands = llvm::any_of(op.getOperandTypes(), [](Type type) {
       return isa<PropertyType>(type);
@@ -1169,28 +1174,24 @@ void LowerClassesPass::lowerClass(om::ClassOp classOp, FModuleLike moduleLike,
     auto propertyResults = llvm::any_of(
         op.getResultTypes(), [](Type type) { return isa<PropertyType>(type); });
 
-    // If there are no properties here, move along.
-    if (!needsClone && !propertyOperands && !propertyResults)
-      continue;
+    return needsClone || propertyOperands || propertyResults;
+  };
 
-    bool isField = false;
+  llvm::SmallVector<mlir::Location> fieldLocs;
+  llvm::SmallVector<mlir::Value> fieldValues;
+  for (Operation &op :
+       llvm::make_early_inc_range(classOp.getBodyBlock()->getOperations())) {
+    if (!isPropertyOp(op))
+      op.erase();
+
     if (auto propAssign = dyn_cast<PropAssignOp>(op)) {
       if (isa<BlockArgument>(propAssign.getDest())) {
         // Store any output property assignments into fields op inputs.
         fieldLocs.push_back(op.getLoc());
-        fieldValues.push_back(mapping.lookup(propAssign.getSrc()));
-        isField = true;
+        fieldValues.push_back(mapping.lookupOrDefault(propAssign.getSrc()));
+        propAssign.erase();
       }
     }
-
-    if (!isField)
-      // Clone the op over to the OM Class.
-      builder.clone(op, mapping);
-
-    // In case this is a Module, remember to erase this op, unless it is an
-    // instance. Instances are handled later in updateInstances.
-    if (!isa<InstanceOp>(op))
-      opsToErase.push_back(&op);
   }
 
   // If there is a 'containingModule', add an argument for 'ports', and a field.
@@ -1201,14 +1202,25 @@ void LowerClassesPass::lowerClass(om::ClassOp classOp, FModuleLike moduleLike,
     fieldValues.push_back(argumentValue);
   }
 
+  OpBuilder builder = OpBuilder::atBlockEnd(classOp.getBodyBlock());
   classOp.addNewFieldsOp(builder, fieldLocs, fieldValues);
+
+  // Now that we've finished the Class body block, clean out the block where the
+  // module like region was landed.
+  classOp->getRegion(0).back().erase();
 
   // If the module-like is a Class, it will be completely erased later.
   // Otherwise, erase just the property ports and ops.
   if (!isa<firrtl::ClassLike>(moduleLike.getOperation())) {
     // Erase ops in use before def order, thanks to FIRRTL's SSA regions.
-    for (auto *op : llvm::reverse(opsToErase))
-      op->erase();
+    for (auto &op :
+         llvm::make_early_inc_range(llvm::reverse(moduleLike.getOperation()
+                                                      ->getRegion(0)
+                                                      .getBlocks()
+                                                      .front()
+                                                      .getOperations())))
+      if (isPropertyOp(op) && !isa<InstanceOp>(op))
+        op.erase();
 
     // Erase property typed ports.
     moduleLike.erasePorts(portsToErase);


### PR DESCRIPTION
Simplify the class lowering logic by directly moving or cloning operations
instead of cloning the entire module body. This change:

- Removes the need to clone the entire module region
- Only clones instance operations that need to be preserved
- Directly moves property operations to the OM class
- Removes redundant block cleanup