### PR TITLE
[Calyx] Lower SCF parallel op to Calyx

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1529,7 +1529,7 @@ class BuildParGroups : public calyx::FuncOpPartialLoweringPattern {
   }
 
 private:
-  // Partially evaluate/pre-compute all blocks being executed in parall by
+  // Partially evaluate/pre-compute all blocks being executed in parallel by
   // statically generate loop indices combinations
   LogicalResult partialEval(PatternRewriter &rewriter,
                             scf::ParallelOp scfParOp) const {

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -257,3 +257,122 @@ module {
     return %1 : f32
   }
 }
+
+// -----
+
+// Test parallel op lowering
+
+// CHECK:    calyx.wires {
+// CHECK-DAG:      calyx.group @bb0_0 {
+// CHECK-DAG:        calyx.assign %std_slice_7.in = %c0_i32 : i32
+// CHECK-DAG:        calyx.assign %mem_1.addr0 = %std_slice_7.out : i3
+// CHECK-DAG:        calyx.assign %mem_1.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_1.write_en = %false : i1
+// CHECK-DAG:        calyx.assign %load_0_reg.in = %mem_1.read_data : i32
+// CHECK-DAG:        calyx.assign %load_0_reg.write_en = %mem_1.done : i1
+// CHECK-DAG:        calyx.group_done %load_0_reg.done : i1
+// CHECK-DAG:      }
+// CHECK-DAG:      calyx.group @bb0_1 {
+// CHECK-DAG:        calyx.assign %std_slice_6.in = %c0_i32 : i32
+// CHECK-DAG:        calyx.assign %mem_0.addr0 = %std_slice_6.out : i3
+// CHECK-DAG:        calyx.assign %mem_0.write_data = %load_0_reg.out : i32
+// CHECK-DAG:        calyx.assign %mem_0.write_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_0.content_en = %true : i1
+// CHECK-DAG:        calyx.group_done %mem_0.done : i1
+// CHECK-DAG:      }
+// CHECK-DAG:      calyx.group @bb1_0 {
+// CHECK-DAG:        calyx.assign %std_slice_5.in = %c4_i32 : i32
+// CHECK-DAG:        calyx.assign %mem_1.addr0 = %std_slice_5.out : i3
+// CHECK-DAG:        calyx.assign %mem_1.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_1.write_en = %false : i1
+// CHECK-DAG:        calyx.assign %load_1_reg.in = %mem_1.read_data : i32
+// CHECK-DAG:        calyx.assign %load_1_reg.write_en = %mem_1.done : i1
+// CHECK-DAG:        calyx.group_done %load_1_reg.done : i1
+// CHECK-DAG:      }
+// CHECK-DAG:      calyx.group @bb1_1 {
+// CHECK-DAG:        calyx.assign %std_slice_4.in = %c1_i32 : i32
+// CHECK-DAG:        calyx.assign %mem_0.addr0 = %std_slice_4.out : i3
+// CHECK-DAG:        calyx.assign %mem_0.write_data = %load_1_reg.out : i32
+// CHECK-DAG:        calyx.assign %mem_0.write_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_0.content_en = %true : i1
+// CHECK-DAG:        calyx.group_done %mem_0.done : i1
+// CHECK-DAG:      }
+// CHECK-DAG:      calyx.group @bb2_0 {
+// CHECK-DAG:        calyx.assign %std_slice_3.in = %c2_i32 : i32
+// CHECK-DAG:        calyx.assign %mem_1.addr0 = %std_slice_3.out : i3
+// CHECK-DAG:        calyx.assign %mem_1.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_1.write_en = %false : i1
+// CHECK-DAG:        calyx.assign %load_2_reg.in = %mem_1.read_data : i32
+// CHECK-DAG:        calyx.assign %load_2_reg.write_en = %mem_1.done : i1
+// CHECK-DAG:        calyx.group_done %load_2_reg.done : i1
+// CHECK-DAG:      }
+// CHECK-DAG:      calyx.group @bb2_1 {
+// CHECK-DAG:        calyx.assign %std_slice_2.in = %c4_i32 : i32
+// CHECK-DAG:        calyx.assign %mem_0.addr0 = %std_slice_2.out : i3
+// CHECK-DAG:        calyx.assign %mem_0.write_data = %load_2_reg.out : i32
+// CHECK-DAG:        calyx.assign %mem_0.write_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_0.content_en = %true : i1
+// CHECK-DAG:        calyx.group_done %mem_0.done : i1
+// CHECK-DAG:      }
+// CHECK-DAG:      calyx.group @bb3_0 {
+// CHECK-DAG:        calyx.assign %std_slice_1.in = %c6_i32 : i32
+// CHECK-DAG:        calyx.assign %mem_1.addr0 = %std_slice_1.out : i3
+// CHECK-DAG:        calyx.assign %mem_1.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_1.write_en = %false : i1
+// CHECK-DAG:        calyx.assign %load_3_reg.in = %mem_1.read_data : i32
+// CHECK-DAG:        calyx.assign %load_3_reg.write_en = %mem_1.done : i1
+// CHECK-DAG:        calyx.group_done %load_3_reg.done : i1
+// CHECK-DAG:      }
+// CHECK-DAG:      calyx.group @bb3_1 {
+// CHECK-DAG:        calyx.assign %std_slice_0.in = %c5_i32 : i32
+// CHECK-DAG:        calyx.assign %mem_0.addr0 = %std_slice_0.out : i3
+// CHECK-DAG:        calyx.assign %mem_0.write_data = %load_3_reg.out : i32
+// CHECK-DAG:        calyx.assign %mem_0.write_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_0.content_en = %true : i1
+// CHECK-DAG:        calyx.group_done %mem_0.done : i1
+// CHECK-DAG:      }
+// CHECK-DAG:    }
+// CHECK-DAG:    calyx.control {
+// CHECK-DAG:      calyx.seq {
+// CHECK-DAG:        calyx.par {
+// CHECK-DAG:          calyx.seq {
+// CHECK-DAG:            calyx.enable @bb0_0
+// CHECK-DAG:            calyx.enable @bb0_1
+// CHECK-DAG:          }
+// CHECK-DAG:          calyx.seq {
+// CHECK-DAG:            calyx.enable @bb1_0
+// CHECK-DAG:            calyx.enable @bb1_1
+// CHECK-DAG:          }
+// CHECK-DAG:          calyx.seq {
+// CHECK-DAG:            calyx.enable @bb2_0
+// CHECK-DAG:            calyx.enable @bb2_1
+// CHECK-DAG:          }
+// CHECK-DAG:          calyx.seq {
+// CHECK-DAG:            calyx.enable @bb3_0
+// CHECK-DAG:            calyx.enable @bb3_1
+// CHECK-DAG:          }
+// CHECK-DAG:        }
+// CHECK-DAG:      }
+// CHECK-DAG:    }
+
+module {
+  func.func @main() {
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %c3 = arith.constant 3 : index
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<6xi32>
+    %alloc_1 = memref.alloc() : memref<6xi32>
+    scf.parallel (%arg2, %arg3) = (%c0, %c0) to (%c3, %c2) step (%c2, %c1) {
+      %4 = arith.shli %arg3, %c2 : index
+      %5 = arith.addi %4, %arg2 : index
+      %6 = memref.load %alloc_1[%5] : memref<6xi32>
+      %7 = arith.shli %arg2, %c1 : index
+      %8 = arith.addi %7, %arg3 : index
+      memref.store %6, %alloc[%8] : memref<6xi32>
+      scf.reduce 
+    }
+    return
+  }
+}
+

--- a/test/Conversion/SCFToCalyx/errors.mlir
+++ b/test/Conversion/SCFToCalyx/errors.mlir
@@ -63,7 +63,7 @@ module {
     %c0 = arith.constant 0 : index
     %cinit = arith.constant 0 : i32
     %alloc = memref.alloc() : memref<6xi32>
-    // expected-error @+1 {{Currently don't support reduce operation}}
+    // expected-error @+1 {{Reduce operations in scf.parallel is not supported yet}}
     %r:1 = scf.parallel (%arg2) = (%c0) to (%c3) step (%c1) init (%cinit) -> i32 {
       %6 = memref.load %alloc[%arg2] : memref<6xi32>
       scf.reduce(%6 : i32) {

--- a/test/Conversion/SCFToCalyx/errors.mlir
+++ b/test/Conversion/SCFToCalyx/errors.mlir
@@ -54,3 +54,25 @@ module {
   }
 }
 
+// -----
+
+module {
+  func.func @main() -> i32 {
+    %c1 = arith.constant 1 : index
+    %c3 = arith.constant 3 : index
+    %c0 = arith.constant 0 : index
+    %cinit = arith.constant 0 : i32
+    %alloc = memref.alloc() : memref<6xi32>
+    // expected-error @+1 {{Currently don't support reduce operation}}
+    %r:1 = scf.parallel (%arg2) = (%c0) to (%c3) step (%c1) init (%cinit) -> i32 {
+      %6 = memref.load %alloc[%arg2] : memref<6xi32>
+      scf.reduce(%6 : i32) {
+        ^bb0(%lhs : i32, %rhs: i32):
+          %res = arith.addi %lhs, %rhs : i32
+          scf.reduce.return %res : i32
+      }
+    }
+    return %r : i32
+  }
+}
+


### PR DESCRIPTION
This patch lowers `scf::parallel` to Calyx, assuming that all induction variables can be statically derived and that `scf::reduce` does not have operands.