### PR TITLE
[FIRRTL] Lower firrtl.formal to verif.formal

### DIFF
--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1699,3 +1699,24 @@ firrtl.circuit "Directories" attributes {
     firrtl.instance dut_A @Directories_A()
   }
 }
+
+// -----
+
+firrtl.circuit "Foo" {
+  // CHECK-LABEL: hw.module @Foo
+  // CHECK-SAME:    in %a : i42
+  // CHECK-SAME:    out z : i42
+  firrtl.module @Foo(in %a: !firrtl.uint<42>, out %z: !firrtl.uint<42>) {
+    firrtl.connect %z, %a : !firrtl.uint<42>
+  }
+  // CHECK: verif.formal @MyTest1
+  // CHECK-SAME: {hello = 42 : i64} {
+  // CHECK-NEXT: [[A:%.+]] = verif.symbolic_value : i42
+  // CHECK-NEXT: hw.instance "Foo" @Foo(a: [[A]]: i42) -> (z: i42)
+  firrtl.formal @MyTest1, @Foo {hello = 42 : i64}
+  // CHECK: verif.formal @MyTest2
+  // CHECK-SAME: {world = "abc"} {
+  // CHECK-NEXT: [[A:%.+]] = verif.symbolic_value : i42
+  // CHECK-NEXT: hw.instance "Foo" @Foo(a: [[A]]: i42) -> (z: i42)
+  firrtl.formal @MyTest2, @Foo {world = "abc"}
+}


### PR DESCRIPTION
Add a lowering from `firrtl.formal` to `verif.formal` in the FIRRTL-to-HW conversion. The lowering creates a `verif.formal` op that simply instantiates the module pointed to by `firrtl.formal`, with symbolic values providing the inputs to the module. We may want to inline the instance in the future, but that is purely cosmetic.

This now allows FIR files to contain `formal` unti tests that can be lowered to HW through `firtool` and then executed using `circt-test`.