### PR TITLE
[SeqToSV] Do not use `always_ff` for compreg with initializer

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -766,7 +766,7 @@ def LowerSeqToSV: Pass<"lower-seq-to-sv",  "mlir::ModuleOp"> {
     Option<"emitSeparateAlwaysBlocks", "emit-separate-always-blocks", "bool", "false",
            "Emit assigments to registers in separate always blocks">,
     Option<"lowerToAlwaysFF", "lower-to-always-ff", "bool", "true",
-           "Place assignments to registers into `always_ff` blocks">
+           "Place assignments to registers into `always_ff` blocks if possible">
   ];
   let statistics = [
     Statistic<"numSubaccessRestored", "num-subaccess-restored",

--- a/lib/Conversion/SeqToSV/SeqToSV.cpp
+++ b/lib/Conversion/SeqToSV/SeqToSV.cpp
@@ -177,8 +177,13 @@ public:
       rewriter.create<sv::PAssignOp>(loc, svReg, adaptor.getResetValue());
     };
 
+    // Registers written in an `always_ff` process may not have any assignments
+    // outside of that process.
+    // For some tools this also prohibits inititalization.
+    bool mayLowerToAlwaysFF = lowerToAlwaysFF && !reg.getInitialValue();
+
     if (adaptor.getReset() && adaptor.getResetValue()) {
-      if (lowerToAlwaysFF) {
+      if (mayLowerToAlwaysFF) {
         rewriter.create<sv::AlwaysFFOp>(
             loc, sv::EventControl::AtPosEdge, adaptor.getClk(),
             sv::ResetType::SyncReset, sv::EventControl::AtPosEdge,
@@ -191,7 +196,7 @@ public:
             });
       }
     } else {
-      if (lowerToAlwaysFF) {
+      if (mayLowerToAlwaysFF) {
         rewriter.create<sv::AlwaysFFOp>(loc, sv::EventControl::AtPosEdge,
                                         adaptor.getClk(), assignValue);
       } else {

--- a/test/Conversion/SeqToSV/compreg.mlir
+++ b/test/Conversion/SeqToSV/compreg.mlir
@@ -1,0 +1,35 @@
+// RUN: circt-opt %s --lower-seq-to-sv=lower-to-always-ff | FileCheck %s
+
+// CHECK-LABEL: hw.module @basic(in %clk : i1, in %d : i8, out q : i8) {
+// CHECK:         %[[REG:.*]] = sv.reg : !hw.inout<i8>
+// CHECK:         %[[RD:.*]] = sv.read_inout %[[REG]] : !hw.inout<i8>
+// CHECK:         sv.alwaysff(posedge %clk) {
+// CHECK-NEXT:      sv.passign %[[REG]], %d : i8
+// CHECK-NEXT:    }
+// CHECK-NEXT:    hw.output %[[RD]] : i8
+// CHECK-NEXT:  }
+hw.module @basic(in %clk: !seq.clock, in %d: i8, out q: i8) {
+  %q = seq.compreg %d, %clk : i8
+  hw.output %q : i8
+}
+
+// CHECK-LABEL: hw.module @basicWithInit(in %clk : i1, in %d : i8, out q : i8) {
+// CHECK:         sv.initial {
+// CHECK:         }
+// CHECK:         %[[CST:.*]] = hw.constant 19 : i8
+// CHECK:         %[[REG:.*]] = sv.reg init %[[CST]] : !hw.inout<i8>
+// CHECK:         %[[RD:.*]] = sv.read_inout %[[REG]] : !hw.inout<i8>
+// CHECK:         sv.always posedge %clk {
+// CHECK-NEXT:      sv.passign %[[REG]], %d : i8
+// CHECK-NEXT:    }
+// CHECK-NEXT:    hw.output %[[RD]] : i8
+// CHECK-NEXT:  }
+hw.module @basicWithInit(in %clk: !seq.clock, in %d: i8, out q: i8) {
+  %init = seq.initial () {
+    %cst = hw.constant 19 : i8
+    seq.yield %cst : i8
+  } : () -> !seq.immutable<i8>
+
+  %q = seq.compreg %d, %clk initial %init : i8
+  hw.output %q : i8
+}


### PR DESCRIPTION
By default SeqToSV uses `always_ff` processes to lower `seq.compreg` ops. This prohibits any other assignments to the register/variable in another process. [Apparently, some simulators consider an initializer at the declaration to be a process.](https://stackoverflow.com/questions/74392350/the-multiple-driver-error-when-writing-always-ff) Other simulators don't, and it  is also not how I would interpret the SV spec, but what do I know?

I think dodging a simulator error is more important than having the `always_ff`. So, this PR changes the lowering to use `always` instead of `always_ff` in the presence of an initializer, even if the `lower-to-always-ff` flag is set.