### PR TITLE
[RTG] Add context resource interfaces

### DIFF
--- a/include/circt/Dialect/RTG/IR/CMakeLists.txt
+++ b/include/circt/Dialect/RTG/IR/CMakeLists.txt
@@ -3,3 +3,14 @@ add_circt_dialect(RTG rtg)
 set(LLVM_TARGET_DEFINITIONS RTG.td)
 
 add_circt_dialect_doc(RTG rtg)
+
+set(LLVM_TARGET_DEFINITIONS RTGInterfaces.td)
+mlir_tablegen(RTGOpInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(RTGOpInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(CIRCTRTGOpInterfacesIncGen)
+add_dependencies(circt-headers CIRCTRTGOpInterfacesIncGen)
+
+mlir_tablegen(RTGTypeInterfaces.h.inc -gen-type-interface-decls)
+mlir_tablegen(RTGTypeInterfaces.cpp.inc -gen-type-interface-defs)
+add_public_tablegen_target(CIRCTRTGTypeInterfacesIncGen)
+add_dependencies(circt-headers CIRCTRTGTypeInterfacesIncGen)

--- a/include/circt/Dialect/RTG/IR/RTGInterfaces.td
+++ b/include/circt/Dialect/RTG/IR/RTGInterfaces.td
@@ -1,0 +1,46 @@
+//===- RTGInterfaces.td - Interfaces used in RTG -----------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_RTG_RTGINTERFACES_TD
+#define CIRCT_DIALECT_RTG_RTGINTERFACES_TD
+
+include "mlir/IR/Interfaces.td"
+
+def ContextResourceOpInterface : OpInterface<"ContextResourceOpInterface"> {
+  let description = [{
+    This interface should be implemented by operations that define
+    context resources. The operation should define at least one SSA value of a type
+    implementing the `ContextResourceTypeInterface`.
+  }];
+  let cppNamespace = "::circt::rtg";
+
+  let methods = [
+    InterfaceMethod<[{
+        Provides a unique identifier for the defined context resource at `idx`
+        (not counting op results that are not of a type implementing the
+        `ContextResourceTypeInterface`).
+        For example, if the context resource are CPUs it could be the core ID.
+      }],
+      "size_t", "getIdentifier", (ins "size_t":$idx)>,
+  ];
+}
+
+def ContextResourceTypeInterface : TypeInterface<
+    "ContextResourceTypeInterface"> {
+  let description = [{
+    This interface should be implemented by types that represent context
+    resources. The `on_context` operation takes an operand of a type
+    implementing this interface or a set of such a type.
+    Any operation that creates a value of a type implementing this interface
+    must implement the `ContextResourceOpInterface` (does not apply to
+    operations that just forward a value of such type).
+  }];
+  let cppNamespace = "::circt::rtg";
+}
+
+#endif // CIRCT_DIALECT_RTG_RTGINTERFACES_TD

--- a/include/circt/Dialect/RTG/IR/RTGOpInterfaces.h
+++ b/include/circt/Dialect/RTG/IR/RTGOpInterfaces.h
@@ -1,0 +1,21 @@
+//===- RTGOpInterfaces.h - Declare RTG op interfaces ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares op interfaces for the RTG Dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_RTG_IR_RTGOPINTERFACES_H
+#define CIRCT_DIALECT_RTG_IR_RTGOPINTERFACES_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/OpDefinition.h"
+
+#include "circt/Dialect/RTG/IR/RTGOpInterfaces.h.inc"
+
+#endif // CIRCT_DIALECT_RTG_IR_RTGOPINTERFACES_H

--- a/include/circt/Dialect/RTG/IR/RTGOps.h
+++ b/include/circt/Dialect/RTG/IR/RTGOps.h
@@ -14,6 +14,7 @@
 #define CIRCT_DIALECT_RTG_IR_RTGOPS_H
 
 #include "circt/Dialect/RTG/IR/RTGDialect.h"
+#include "circt/Dialect/RTG/IR/RTGTypeInterfaces.h"
 #include "circt/Dialect/RTG/IR/RTGTypes.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/Bytecode/BytecodeOpInterface.h"

--- a/include/circt/Dialect/RTG/IR/RTGOps.td
+++ b/include/circt/Dialect/RTG/IR/RTGOps.td
@@ -16,6 +16,7 @@ include "mlir/IR/Properties.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "circt/Dialect/RTG/IR/RTGInterfaces.td"
 
 // Base class for the operation in this dialect.
 class RTGOp<string mnemonic, list<Trait> traits = []> :

--- a/include/circt/Dialect/RTG/IR/RTGTypeInterfaces.h
+++ b/include/circt/Dialect/RTG/IR/RTGTypeInterfaces.h
@@ -1,0 +1,21 @@
+//===- RTGTypeInterfaces.h - Declare RTG type interfaces --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares type interfaces for the RTG Dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_RTG_IR_RTGTYPEINTERFACES_H
+#define CIRCT_DIALECT_RTG_IR_RTGTYPEINTERFACES_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/Types.h"
+
+#include "circt/Dialect/RTG/IR/RTGTypeInterfaces.h.inc"
+
+#endif // CIRCT_DIALECT_RTG_IR_RTGTYPEINTERFACES_H

--- a/lib/Dialect/RTG/IR/CMakeLists.txt
+++ b/lib/Dialect/RTG/IR/CMakeLists.txt
@@ -1,13 +1,17 @@
 add_circt_dialect_library(CIRCTRTGDialect
   RTGDialect.cpp
+  RTGOpInterfaces.cpp
   RTGOps.cpp
   RTGTypes.cpp
+  RTGTypeInterfaces.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/RTG/IR
 
   DEPENDS
   MLIRRTGIncGen
+  CIRCTRTGOpInterfacesIncGen
+  CIRCTRTGTypeInterfacesIncGen
     
   LINK_LIBS PUBLIC
   MLIRIR

--- a/lib/Dialect/RTG/IR/RTGOpInterfaces.cpp
+++ b/lib/Dialect/RTG/IR/RTGOpInterfaces.cpp
@@ -1,0 +1,19 @@
+//===- RTGOpInterfaces.cpp - Implement the RTG op interfaces --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the RTG op interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/RTG/IR/RTGOpInterfaces.h"
+
+//===----------------------------------------------------------------------===//
+// TableGen generated logic.
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/RTG/IR/RTGOpInterfaces.cpp.inc"

--- a/lib/Dialect/RTG/IR/RTGTypeInterfaces.cpp
+++ b/lib/Dialect/RTG/IR/RTGTypeInterfaces.cpp
@@ -1,0 +1,19 @@
+//===- RTGTypeInterfaces.cpp - Implement the RTG type interfaces ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the RTG type interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/RTG/IR/RTGTypeInterfaces.h"
+
+//===----------------------------------------------------------------------===//
+// TableGen generated logic.
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/RTG/IR/RTGTypeInterfaces.cpp.inc"


### PR DESCRIPTION
Add the interfaces needed to add the `on_context` operation and the RTG test dialect in future PRs.