### PR TITLE
[ExternalizeRegisters][NFC] Clean up initial value fetching

### DIFF
--- a/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
+++ b/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
@@ -98,8 +98,7 @@ void ExternalizeRegistersPass::runOnOperation() {
           if (auto initVal = regOp.getInitialValue()) {
             // Find the constant op that defines the reset value in an initial
             // block (if it exists)
-            if (isa<BlockArgument>(initVal) ||
-                !isa<seq::InitialOp>(initVal.getDefiningOp())) {
+            if (!initVal.getDefiningOp<seq::InitialOp>()) {
               regOp.emitError("registers with initial values not directly "
                               "defined by a seq.initial op not yet supported");
               return signalPassFailure();

--- a/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
+++ b/lib/Tools/circt-bmc/ExternalizeRegisters.cpp
@@ -96,22 +96,16 @@ void ExternalizeRegistersPass::runOnOperation() {
           }
           mlir::Attribute initState;
           if (auto initVal = regOp.getInitialValue()) {
-            // Find the seq.initial op where the initial value is defined and
-            // fetch the operation inside that defines the value
-            auto initialOp =
-                regOp.getInitialValue().getDefiningOp<seq::InitialOp>();
-            if (!initialOp) {
+            // Find the constant op that defines the reset value in an initial
+            // block (if it exists)
+            if (isa<BlockArgument>(initVal) ||
+                !isa<seq::InitialOp>(initVal.getDefiningOp())) {
               regOp.emitError("registers with initial values not directly "
                               "defined by a seq.initial op not yet supported");
               return signalPassFailure();
             }
-            auto index = cast<OpResult>(initVal).getResultNumber();
-            auto initValDef =
-                initialOp->getRegion(0).front().getTerminator()->getOperand(
-                    index);
-            // If it's defined by a constant op then just fetch the constant
-            // value - otherwise unsupported
-            if (auto constantOp = initValDef.getDefiningOp<hw::ConstantOp>()) {
+            if (auto constantOp = circt::seq::unwrapImmutableValue(initVal)
+                                      .getDefiningOp<hw::ConstantOp>()) {
               // Fetch value from constant op - leave removing the dead op to
               // DCE
               initState = constantOp.getValueAttr();


### PR DESCRIPTION
Just a cleanup commit that reuses `unwrapImmutableValue` instead of pretty much reimplementing it as I only just found out it existed - thanks for including this @uenoku!