### PR TITLE
[HWToBTOR2] Fix crashes on initial value corner cases

### DIFF
--- a/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
+++ b/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
@@ -594,8 +594,8 @@ public:
   void visit(hw::PortInfo &port) {
     // Separate the inputs from outputs and generate the first btor2 lines for
     // input declaration We only consider ports with an explicit bit-width (so
-    // ignore clocks)
-    if (port.isInput() && !isa<seq::ClockType>(port.type)) {
+    // ignore clocks and immutables)
+    if (port.isInput() && !isa<seq::ClockType, seq::ImmutableType>(port.type)) {
       // Generate the associated btor declaration for the inputs
       StringRef iName = port.getName();
 
@@ -880,6 +880,12 @@ public:
     genState(reg, w, regName);
 
     if (init) {
+      if (init && (isa<BlockArgument>(init) ||
+                   !isa<seq::InitialOp>(init.getDefiningOp()))) {
+        reg->emitError(
+            "Initial value must be emitted directly by a seq.initial op");
+        return;
+      }
       // Check that the initial value is a non-null constant
       auto initialConstant = circt::seq::unwrapImmutableValue(init)
                                  .getDefiningOp<hw::ConstantOp>();

--- a/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
+++ b/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
@@ -880,8 +880,7 @@ public:
     genState(reg, w, regName);
 
     if (init) {
-      if (init && (isa<BlockArgument>(init) ||
-                   !isa<seq::InitialOp>(init.getDefiningOp()))) {
+      if (!init.getDefiningOp<seq::InitialOp>()) {
         reg->emitError(
             "Initial value must be emitted directly by a seq.initial op");
         return;

--- a/test/Conversion/HWToBTOR2/errors.mlir
+++ b/test/Conversion/HWToBTOR2/errors.mlir
@@ -1,0 +1,25 @@
+// RUN: circt-opt %s --convert-hw-to-btor2 --verify-diagnostics --split-input-file -o tmp.mlir
+
+hw.module @init_emitter(out out: !seq.immutable<i32>) {
+  %init = seq.initial () {
+    %c0_i32 = hw.constant 0 : i32
+    seq.yield %c0_i32 : i32
+  } : () -> !seq.immutable<i32>
+  hw.output %init : !seq.immutable<i32>
+}
+
+hw.module @reg_with_instance_initial(in %clk: !seq.clock, in %in: i32, out out: i32) {
+  // expected-error @below {{'hw.instance' op not supported in BTOR2 conversion}}
+  %init = hw.instance "foo" @init_emitter () -> (out: !seq.immutable<i32>)
+  // expected-error @below {{Initial value must be emitted directly by a seq.initial op}}
+  %1 = seq.compreg %in, %clk initial %init : i32
+  hw.output %1 : i32
+}
+
+// -----
+
+hw.module @reg_with_argument_initial(in %clk: !seq.clock, in %in: i32, in %init: !seq.immutable<i32>, out out: i32) {
+  // expected-error @below {{Initial value must be emitted directly by a seq.initial op}}
+  %1 = seq.compreg %in, %clk initial %init : i32
+  hw.output %1 : i32
+}


### PR DESCRIPTION
Currently HWToBTOR2 crashes on both of the included error cases:

1. `unwrapImmutableValue` throws an assert whenever it's given a value that wasn't defined by an initialOp, so I've added a check for that. While the first error case isn't technically legal anyway as instance ops aren't allowed in HWToBTOR2, the pass currently crashes before it gets to that point.
2. Initial values given as a block argument will throw an error in requireSort as they don't have a queriable width. Pretty unlikely edge case, but can't hurt to have it covered! I've added it to the list of sorts ignored by requireSort, and it'll now get mopped up by the same check as point 1 rather than crashing