### PR TITLE
Bump LLVM to 3cc852ece438a63e7b09d1c84a81d21598454e1a.

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -19,7 +19,7 @@ jobs:
     # John and re-run the job.
     runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
     container:
-      image: ghcr.io/circt/images/circt-integration-test:v13.1
+      image: ghcr.io/circt/images/circt-integration-test:v17.0
       volumes:
         - /mnt:/__w/circt
     strategy:

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -29,7 +29,7 @@ jobs:
     # John and re-run the job.
     runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
     container:
-      image: ghcr.io/circt/images/circt-integration-test:v13.1
+      image: ghcr.io/circt/images/circt-integration-test:v17.0
       volumes:
         - /mnt:/__w/circt
     strategy:

--- a/integration_test/Dialect/Handshake/multiple_loops/multiple_loops.py
+++ b/integration_test/Dialect/Handshake/multiple_loops/multiple_loops.py
@@ -29,8 +29,8 @@ async def sendMultiple(dut):
   res0 = [i * (i + 1) / 2 for i in range(N)]
   res1 = [math.factorial(i) for i in range(N)]
 
-  out0Check = cocotb.start_soon(out0.checkOutputs(res0))
-  out1Check = cocotb.start_soon(out1.checkOutputs(res1))
+  out0Check = cocotb.start_soon(out0.checkOutputs(res0, converter=float))
+  out1Check = cocotb.start_soon(out1.checkOutputs(res1, converter=float))
 
   for i in range(N):
     in0Send = cocotb.start_soon(in0.send(i))

--- a/integration_test/Dialect/Handshake/nested_loops/nested_loops.py
+++ b/integration_test/Dialect/Handshake/nested_loops/nested_loops.py
@@ -26,7 +26,7 @@ async def sendMultiple(dut):
   # sum_{i = 0}^n (sum_{j=0}^i i) = 1/6 * (n^3 + 3n^2 + 2n)
   res = [(1 / 6) * (n**3 + 3 * n**2 + 2 * n) for n in range(N)]
 
-  out0Check = cocotb.start_soon(out0.checkOutputs(res))
+  out0Check = cocotb.start_soon(out0.checkOutputs(res, converter=float))
 
   for i in range(N):
     in0Send = cocotb.start_soon(in0.send(i))

--- a/lib/Bindings/Python/pyproject.toml
+++ b/lib/Bindings/Python/pyproject.toml
@@ -6,8 +6,7 @@ requires = [
     "cmake>=3.12",
     # MLIR build depends.
     "numpy",
-    # Pybind11 2.10 has a bug relating to binding enums.
-    "pybind11>=2.9,!=2.10",
+    "pybind11>=2.11,<=2.12",
     "PyYAML",
 ]
 build-backend = "setuptools.build_meta"

--- a/lib/Conversion/DCToHW/DCToHW.cpp
+++ b/lib/Conversion/DCToHW/DCToHW.cpp
@@ -237,7 +237,8 @@ struct RTLBuilder {
   }
 
   Value constant(unsigned width, int64_t value, StringRef name = {}) {
-    return constant(APInt(width, value));
+    return constant(
+        APInt(width, value, /*isSigned=*/false, /*implicitTrunc=*/true));
   }
   std::pair<Value, Value> wrap(Value data, Value valid, StringRef name = {}) {
     auto wrapOp = b.create<esi::WrapValidReadyOp>(loc, data, valid);

--- a/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
+++ b/lib/Conversion/HandshakeToHW/HandshakeToHW.cpp
@@ -484,7 +484,8 @@ struct RTLBuilder {
 
   Value constant(unsigned width, int64_t value,
                  std::optional<StringRef> name = {}) {
-    return constant(APInt(width, value));
+    return constant(
+        APInt(width, value, /*isSigned=*/false, /*implicitTrunc=*/true));
   }
   std::pair<Value, Value> wrap(Value data, Value valid,
                                std::optional<StringRef> name = {}) {

--- a/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
+++ b/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
@@ -446,7 +446,8 @@ ICMPCanonicalizer::matchAndRewrite(comb::ICmpOp op,
           }
           rewriter.replaceOpWithNewOp<comb::ICmpOp>(
               op, op.getPredicate(), andOp,
-              getConstant(APInt(*optionalWidth, rhs.getZExtValue())),
+              getConstant(APInt(*optionalWidth, rhs.getZExtValue(),
+                                /*isSigned=*/false, /*implicitTrunc=*/true)),
               op.getTwoState());
           return success();
         }
@@ -464,7 +465,8 @@ ICMPCanonicalizer::matchAndRewrite(comb::ICmpOp op,
           }
           rewriter.replaceOpWithNewOp<comb::ICmpOp>(
               op, op.getPredicate(), orOp,
-              getConstant(APInt(*optionalWidth, rhs.getZExtValue())),
+              getConstant(APInt(*optionalWidth, rhs.getZExtValue(),
+                                /*isSigned=*/false, /*implicitTrunc=*/true)),
               op.getTwoState());
           return success();
         }

--- a/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxHelpers.cpp
@@ -32,8 +32,8 @@ hw::ConstantOp createConstant(Location loc, OpBuilder &builder,
                               size_t value) {
   OpBuilder::InsertionGuard g(builder);
   builder.setInsertionPointToStart(component.getBodyBlock());
-  return builder.create<hw::ConstantOp>(loc,
-                                        APInt(width, value, /*unsigned=*/true));
+  return builder.create<hw::ConstantOp>(
+      loc, APInt(width, value, /*isSigned=*/false));
 }
 
 calyx::InstanceOp createInstance(Location loc, OpBuilder &builder,

--- a/lib/Dialect/Calyx/Transforms/RemoveCombGroups.cpp
+++ b/lib/Dialect/Calyx/Transforms/RemoveCombGroups.cpp
@@ -140,7 +140,7 @@ struct RemoveCombGroupsPattern : public OpRewritePattern<calyx::CombGroupOp> {
 
     rewriter.setInsertionPointToStart(group.getBodyBlock());
     auto oneConstant = rewriter.create<hw::ConstantOp>(
-        group.getLoc(), APInt(1, 1, /*isSigned=*/true));
+        group.getLoc(), APInt(1, 1, /*isSigned=*/true, /*implicitTrunc=*/true));
 
     // Maintain the set of cell results which have already been assigned to
     // its register within this group.

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -188,7 +188,8 @@ IntegerAttr circt::firrtl::getIntZerosAttr(Type type) {
 /// type. This handles both the known width and unknown width case.
 IntegerAttr circt::firrtl::getIntOnesAttr(Type type) {
   int32_t width = abs(type_cast<IntType>(type).getWidthOrSentinel());
-  return getIntAttr(type, APInt(width, -1));
+  return getIntAttr(
+      type, APInt(width, -1, /*isSigned=*/false, /*implicitTrunc=*/true));
 }
 
 /// Return the single assignment to a Property value. It is assumed that the

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -309,7 +309,9 @@ void ConstantOp::build(OpBuilder &builder, OperationState &result,
 void ConstantOp::build(OpBuilder &builder, OperationState &result, Type type,
                        int64_t value) {
   auto numBits = cast<IntegerType>(type).getWidth();
-  build(builder, result, APInt(numBits, (uint64_t)value, /*isSigned=*/true));
+  build(builder, result,
+        APInt(numBits, (uint64_t)value, /*isSigned=*/true,
+              /*implicitTrunc=*/true));
 }
 
 void ConstantOp::getAsmResultNames(

--- a/tools/handshake-runner/Simulation.cpp
+++ b/tools/handshake-runner/Simulation.cpp
@@ -89,13 +89,13 @@ Any readValueWithType(mlir::Type type, std::stringstream &arg) {
     int64_t x;
     arg >> x;
     int64_t width = INDEX_WIDTH;
-    APInt aparg(width, x);
+    APInt aparg(width, x, /*isSigned=*/false, /*implicitTrunc=*/true);
     return aparg;
   } else if (isa<mlir::IntegerType>(type)) {
     int64_t x;
     arg >> x;
     int64_t width = type.getIntOrFloatBitWidth();
-    APInt aparg(width, x);
+    APInt aparg(width, x, /*isSigned=*/false, /*implicitTrunc=*/true);
     return aparg;
   } else if (type.isF32()) {
     float x;


### PR DESCRIPTION
The main difference was in changes related to the APInt constructor.

This was needed when
https://github.com/llvm/llvm-project/commit/3494ee95902cef62f767489802e469c58a13ea04
landed.

Similar changes were made upstream here:
https://github.com/llvm/llvm-project/pull/80309/files.

Basically, we now expect the width and value arguments to the APInt
constructor to be consistent. There is some implicit extension or
truncation depending on the signedness of the value, and now a flag to
opt into it.

With this change I've simply opted into the flag where necessary,
rather than thinking hard about how to compute the correct width given
the value.

In places where the `isSigned` flag took the default value of false, I
kept that when I had to explicitly set that flag.

There was exactly one place (CalyxHelpers.cpp), where I actually
flipped the value of `isSigned`. The comment in the code made me think
this erroneously thought the flag was "isUnsigned".