### PR TITLE
[HWToBTOR2] Use APInt value directly in constant generation

### DIFF
--- a/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
+++ b/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
@@ -221,7 +221,7 @@ private:
   }
 
   // Generates a constant declaration given a value, a width and a name.
-  void genConst(int64_t value, size_t width, Operation *op) {
+  void genConst(APInt value, size_t width, Operation *op) {
     // For now we're going to assume that the name isn't taken, given that hw
     // is already in SSA form
     size_t opLID = getOpLID(op);
@@ -626,8 +626,7 @@ public:
 
     // Prepare for for const generation by extracting the const value and
     // generting the btor2 string
-    int64_t value = op.getValue().getSExtValue();
-    genConst(value, w, op);
+    genConst(op.getValue(), w, op);
   }
 
   // Wires should have been removed in PrepareForFormal

--- a/test/Conversion/HWToBTOR2/comb.mlir
+++ b/test/Conversion/HWToBTOR2/comb.mlir
@@ -6,6 +6,10 @@ module {
   hw.module @inc(in %a : i32, in %clk : !seq.clock, out pred : i1) {
     %0 = seq.from_clock %clk
 
+    // CHECK:   [[BIGSORT:[0-9]+]] sort bitvec 100
+    // CHECK:   [[BIGCONST:[0-9]+]] constd [[BIGSORT]] 111111111111111111111111111
+    %bigConst = hw.constant 111111111111111111111111111 : i100
+
     // CHECK:   [[NID2:[0-9]+]] constd [[NID0]] 0
     %c0_i32 = hw.constant 0 : i32
 


### PR DESCRIPTION
Currently creating a constant with any value that won't fit in an i64 will break HWToBTOR2 as it tries to fetch the value from an APInt and place it in an int64_t - not ideal if you have wires wider than 64 bits.

Breaking example:
```
hw.module @top() {
    hw.constant 111111111111111111111111111 : i100
}
```

This just swaps to using the APInt directly to print the value - AFAICT this will still yield correct BTOR2.