### PR TITLE
[NFC] Output unused test results to `/dev/null`

### DIFF
--- a/test/Conversion/ExportVerilog/hw-enums.mlir
+++ b/test/Conversion/ExportVerilog/hw-enums.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --test-apply-lowering-options='options=emittedLineLength=100,emitBindComments' -export-verilog -split-input-file -o %t.mlir | FileCheck %s
+// RUN: circt-opt %s --test-apply-lowering-options='options=emittedLineLength=100,emitBindComments' -export-verilog -split-input-file -o /dev/null | FileCheck %s
 
 // CHECK: typedef enum bit [0:0] {enum0_T} enum0;
 // CHECK: // typedef enum bit [0:0] {} enum1;

--- a/test/Conversion/HWToBTOR2/errors.mlir
+++ b/test/Conversion/HWToBTOR2/errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --convert-hw-to-btor2 --verify-diagnostics --split-input-file -o %t
+// RUN: circt-opt %s --convert-hw-to-btor2 --verify-diagnostics --split-input-file -o /dev/null
 
 hw.module @init_emitter(out out: !seq.immutable<i32>) {
   %init = seq.initial () {


### PR DESCRIPTION
See #7852.

The CI failed on 2d416afa8326e3ceaab2e96606f50ed3084df0a3 :
```
RUN: at line 1: /__w/circt/circt/build/bin/circt-opt /__w/circt/circt/test/Conversion/HWToBTOR2/errors.mlir --convert-hw-to-btor2 --verify-diagnostics --split-input-file -o /__w/circt/circt/build/tools/circt/test/Conversion/HWToBTOR2/Output/errors.mlir.tmp
+ /__w/circt/circt/build/bin/circt-opt /__w/circt/circt/test/Conversion/HWToBTOR2/errors.mlir --convert-hw-to-btor2 --verify-diagnostics --split-input-file -o /__w/circt/circt/build/tools/circt/test/Conversion/HWToBTOR2/Output/errors.mlir.tmp
circt-opt: /__w/circt/circt/llvm/llvm/lib/Support/raw_ostream.cpp:115: void llvm::raw_ostream::SetBufferAndMode(char *, size_t, BufferKind): Assertion `GetNumBytesInBuffer() == 0 && "Current buffer is non-empty!"' failed.
```

There seems to be a race condition on the output file buffer. I blame `-split-input-file` for it (although I've wrongfully blamed it for another error in the past). In upstream, if `-split-input-file` and `-o` are used in conjunction, the output file seems to either be `/dev/null/` or stdout. So, let's follow that pattern and hope it fixes the problem.

Why hasn't this failed on the `hw-enums.mlir` test before? ... I do not know. But maybe the timing of the newly added HWToBTOR2 test is just particularly prone to run into this race condition.