### PR TITLE
[SCFToCalyx] `buildLibraryBinaryPipeOp` source operation result replacement

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -422,8 +422,6 @@ private:
     StringRef opName = TSrcOp::getOperationName().split(".").second;
     Location loc = op.getLoc();
     Type width = op.getResult().getType();
-    // Pass the result from the Operation to the Calyx primitive.
-    op.getResult().replaceAllUsesWith(out);
     auto reg = createRegister(
         op.getLoc(), rewriter, getComponent(), width.getIntOrFloatBitWidth(),
         getState<ComponentLoweringState>().getUniqueName(opName));
@@ -449,6 +447,10 @@ private:
         comb::createOrFoldNot(group.getLoc(), opPipe.getDone(), builder));
     // The group is done when the register write is complete.
     rewriter.create<calyx::GroupDoneOp>(loc, reg.getDone());
+
+    // Pass the result from the source operation to register holding the resullt
+    // from the Calyx primitive.
+    op.getResult().replaceAllUsesWith(reg.getOut());
 
     if (isa<calyx::AddFOpIEEE754>(opPipe)) {
       auto opFOp = cast<calyx::AddFOpIEEE754>(opPipe);

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -88,6 +88,11 @@ module {
 // CHECK-DAG:    calyx.assign %std_mult_pipe_0.go = %0 ? %true : i1
 // CHECK-DAG:    calyx.group_done %muli_0_reg.done : i1
 // CHECK-NEXT:  }
+// CHECK:      calyx.group @ret_assign_0 {
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.in = %muli_0_reg.out : i32
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-DAG:        calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-DAG:      }
     %0 = arith.muli %a0, %a1 : i32
     return %0 : i32
   }
@@ -106,6 +111,11 @@ module {
 // CHECK-DAG:    calyx.assign %std_divu_pipe_0.go = %0 ? %true : i1
 // CHECK-DAG:    calyx.group_done %divui_0_reg.done : i1
 // CHECK-NEXT:  }
+// CHECK:      calyx.group @ret_assign_0 {
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.in = %divui_0_reg.out : i32
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-DAG:        calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-DAG:      }
     %0 = arith.divui %a0, %a1 : i32
     return %0 : i32
   }
@@ -124,6 +134,11 @@ module {
 // CHECK-DAG:    calyx.assign %std_remu_pipe_0.go = %0 ? %true : i1
 // CHECK-DAG:    calyx.group_done %remui_0_reg.done : i1
 // CHECK-NEXT:  }
+// CHECK:      calyx.group @ret_assign_0 {
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.in = %remui_0_reg.out : i32
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-DAG:        calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-DAG:      }
     %0 = arith.remui %a0, %a1 : i32
     return %0 : i32
   }
@@ -142,6 +157,11 @@ module {
 // CHECK-DAG:    calyx.assign %std_divs_pipe_0.go = %0 ? %true : i1
 // CHECK-DAG:    calyx.group_done %divsi_0_reg.done : i1
 // CHECK-NEXT:  }
+// CHECK:      calyx.group @ret_assign_0 {
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.in = %divsi_0_reg.out : i32
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-DAG:        calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-DAG:      }
     %0 = arith.divsi %a0, %a1 : i32
     return %0 : i32
   }
@@ -160,6 +180,11 @@ module {
 // CHECK-DAG:    calyx.assign %std_rems_pipe_0.go = %0 ? %true : i1
 // CHECK-DAG:    calyx.group_done %remsi_0_reg.done : i1
 // CHECK-NEXT:  }
+// CHECK:      calyx.group @ret_assign_0 {
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.in = %remsi_0_reg.out : i32
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-DAG:        calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-DAG:      }
     %0 = arith.remsi %a0, %a1 : i32
     return %0 : i32
   }
@@ -248,6 +273,11 @@ module {
 // CHECK-DAG:               calyx.assign %std_addFN_0.subOp = %false : i1
 // CHECK-DAG:               calyx.group_done %addf_0_reg.done : i1
 // CHECK-DAG:             }
+// CHECK:      calyx.group @ret_assign_0 {
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.in = %addf_0_reg.out : i32
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-DAG:        calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-DAG:      }
 
 module {
   func.func @main(%arg0 : f32) -> f32 {
@@ -275,6 +305,11 @@ module {
 // CHECK-DAG:        %0 = comb.xor %std_mulFN_0.done, %true : i1
 // CHECK-DAG:        calyx.assign %std_mulFN_0.go = %0 ? %true : i1
 // CHECK-DAG:        calyx.group_done %mulf_0_reg.done : i1
+// CHECK-DAG:      }
+// CHECK:      calyx.group @ret_assign_0 {
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.in = %mulf_0_reg.out : i32
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-DAG:        calyx.group_done %ret_arg0_reg.done : i1
 // CHECK-DAG:      }
 module {
   func.func @main(%arg0 : f32) -> f32 {


### PR DESCRIPTION
This patch fixes https://github.com/llvm/circt/issues/7861.