### PR TITLE
[NFCI][HWToBTOR2] Avoid running HWToBTOR2 pass in parallel

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -582,7 +582,7 @@ def LowerHWToSV : Pass<"lower-hw-to-sv", "hw::HWModuleOp"> {
 // HWToBTOR2
 //===----------------------------------------------------------------------===//
 
-def ConvertHWToBTOR2 : Pass<"convert-hw-to-btor2", "hw::HWModuleOp"> {
+def ConvertHWToBTOR2 : Pass<"convert-hw-to-btor2", "mlir::ModuleOp"> {
   let summary = "Convert HW to BTOR2";
   let description = [{
     This pass converts a HW module into a state transition system that is then

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -421,7 +421,7 @@ LogicalResult firtool::populateHWToBTOR2(mlir::PassManager &pm,
   pm.addNestedPass<hw::HWModuleOp>(circt::createLowerLTLToCorePass());
   pm.addNestedPass<hw::HWModuleOp>(circt::verif::createPrepareForFormalPass());
   pm.addPass(circt::hw::createFlattenModulesPass());
-  pm.addNestedPass<hw::HWModuleOp>(circt::createConvertHWToBTOR2Pass(os));
+  pm.addPass(circt::createConvertHWToBTOR2Pass(os));
   return success();
 }
 


### PR DESCRIPTION
Change the base operation for the HWToBTOR2 pass from `hw::HWModuleOp` to `mlir::ModuleOp`.

Running this pass in parallel on HWModules will just produce garbled output on the provided output stream. It is also likely the cause for the current CI failures (#7852, #7859, #7863). Multiple pass instances get instantiated with the same `raw_ostream` singleton returned by `llvm::outs()`. I do not think it is thread safe (why would it be?) and the CI stack traces point  quite clearly to a race condition in `raw_ostream::write`.