### PR TITLE
[SMT] Add push/pop operations

### DIFF
--- a/include/circt/Dialect/SMT/SMTOps.td
+++ b/include/circt/Dialect/SMT/SMTOps.td
@@ -158,6 +158,18 @@ def ResetOp : SMTOp<"reset", []> {
   let assemblyFormat = "attr-dict";
 }
 
+def PushOp : SMTOp<"push", []> {
+  let summary = "push a given number of levels onto the assertion stack";
+  let arguments = (ins ConfinedAttr<I32Attr, [IntNonNegative]>:$count);
+  let assemblyFormat = "$count attr-dict";
+}
+
+def PopOp : SMTOp<"pop", []> {
+  let summary = "pop a given number of levels from the assertion stack";
+  let arguments = (ins ConfinedAttr<I32Attr, [IntNonNegative]>:$count);
+  let assemblyFormat = "$count attr-dict";
+}
+
 def CheckOp : SMTOp<"check", [
   NoRegionArguments,
   SingleBlockImplicitTerminator<"smt::YieldOp">,

--- a/integration_test/Dialect/SMT/basic.mlir
+++ b/integration_test/Dialect/SMT/basic.mlir
@@ -152,6 +152,22 @@ func.func @entry() {
     smt.yield
   }
 
+  // CHECK: unsat
+  // CHECK: Res: -1
+  // CHECK: sat
+  // CHECK: Res: 1
+  smt.solver () : () -> () {
+    %c3 = smt.int.constant 3
+    %c4 = smt.int.constant 4
+    %unsat_eq = smt.eq %c3, %c4 : !smt.int
+    smt.push 1
+    func.call @check(%unsat_eq) : (!smt.bool) -> ()
+    smt.pop 1
+    %sat_eq = smt.eq %c3, %c3 : !smt.int
+    func.call @check(%sat_eq) : (!smt.bool) -> ()
+    smt.yield
+  }
+
   return
 }
 

--- a/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
+++ b/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
@@ -141,6 +141,22 @@ func.func @test(%arg0: i32) {
     // CHECK: llvm.call @Z3_solver_reset([[CTX]], [[S]]) : (!llvm.ptr, !llvm.ptr) -> ()
     smt.reset
 
+    // CHECK: llvm.call @Z3_solver_push([[CTX]], [[S]]) : (!llvm.ptr, !llvm.ptr) -> ()
+    smt.push 1
+
+    // CHECK: llvm.call @Z3_solver_push([[CTX]], [[S]]) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @Z3_solver_push([[CTX]], [[S]]) : (!llvm.ptr, !llvm.ptr) -> ()
+    // CHECK: llvm.call @Z3_solver_push([[CTX]], [[S]]) : (!llvm.ptr, !llvm.ptr) -> ()
+    smt.push 3
+
+    // CHECK: [[CONST1:%.+]] = llvm.mlir.constant(1 : i32)
+    // CHECK: llvm.call @Z3_solver_pop([[CTX]], [[S]], [[CONST1]]) : (!llvm.ptr, !llvm.ptr, i32) -> ()
+    smt.pop 1
+
+    // CHECK: [[CONST5:%.+]] = llvm.mlir.constant(5 : i32)
+    // CHECK: llvm.call @Z3_solver_pop([[CTX]], [[S]], [[CONST5]]) : (!llvm.ptr, !llvm.ptr, i32) -> ()
+    smt.pop 5
+
     // CHECK-DEBUG: [[SOLVER_STR:%.+]] = llvm.call @Z3_solver_to_string({{.*}}, {{.*}}) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
     // CHECK-DEBUG: [[FMT_STR:%.+]] = llvm.mlir.addressof @str{{.*}} : !llvm.ptr
     // CHECK-DEBUG: llvm.call @printf([[FMT_STR]], [[SOLVER_STR]]) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, !llvm.ptr) -> i32

--- a/test/Dialect/SMT/basic.mlir
+++ b/test/Dialect/SMT/basic.mlir
@@ -29,6 +29,12 @@ func.func @core(%in: i8) {
   // CHECK: smt.reset {smt.some_attr}
   smt.reset {smt.some_attr}
 
+  // CHECK: smt.push 1 {smt.some_attr}
+  smt.push 1 {smt.some_attr}
+
+  // CHECK: smt.pop 1 {smt.some_attr}
+  smt.pop 1 {smt.some_attr}
+
   // CHECK: %{{.*}} = smt.solver(%{{.*}}) {smt.some_attr} : (i8) -> (i8, i32) {
   // CHECK: ^bb0(%{{.*}}: i8)
   // CHECK:   %{{.*}} = smt.check {smt.some_attr} sat {

--- a/test/Dialect/SMT/core-errors.mlir
+++ b/test/Dialect/SMT/core-errors.mlir
@@ -471,3 +471,19 @@ func.func @func_range_no_smt_type(%arg0: !smt.func<(!smt.bool) !smt.bool>) {
 func.func @sort_type_no_smt_type(%arg0: !smt.sort<"sortname"[i32]>) {
   return
 }
+
+// -----
+
+func.func @negative_push() {
+  // expected-error @below {{smt.push' op attribute 'count' failed to satisfy constraint: 32-bit signless integer attribute whose value is non-negative}}
+  smt.push -1
+  return
+}
+
+// -----
+
+func.func @negative_pop() {
+  // expected-error @below {{smt.pop' op attribute 'count' failed to satisfy constraint: 32-bit signless integer attribute whose value is non-negative}}
+  smt.pop -1
+  return
+}


### PR DESCRIPTION
Adds push and pop ops to add/remove assertions from the assertion stack as per SMTLIB.

Unfortunately SMTLIB specifies that each of them takes a number of levels to push/pop but the Z3 API only provides such an argument for pop, so we have to make multiple calls for a big push (but I can't imagine that this will ever really be used in practice).