### PR TITLE
[Verif] Make verif.formal parameters an ODS property

### DIFF
--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -295,7 +295,7 @@ def FormalOp : VerifOp<"formal", [
 
     ### Example
     ```
-    verif.formal @AdderTest {
+    verif.formal @AdderTest {myParam = 42, myTag = "hello"} {
       %0 = verif.symbolic_value : i42
       %1 = verif.symbolic_value : i42
       %2 = hw.instance "dut" @Adder(a: %0: i42, b: %1: i42) -> (c: i42)
@@ -305,9 +305,12 @@ def FormalOp : VerifOp<"formal", [
     }
     ```
   }];
-  let arguments = (ins SymbolNameAttr:$sym_name);
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    DictionaryAttr:$parameters
+  );
   let regions = (region SizedRegion<1>:$body);
-  let assemblyFormat = "$sym_name attr-dict-with-keyword $body";
+  let assemblyFormat = "$sym_name $parameters attr-dict-with-keyword $body";
   let extraClassDeclaration = [{
     static RegionKind getRegionKind(unsigned index) { 
       return RegionKind::Graph;

--- a/integration_test/circt-test/basic.mlir
+++ b/integration_test/circt-test/basic.mlir
@@ -35,7 +35,7 @@ hw.module @CustomAdder(in %a: i4, in %b: i4, out z: i4) {
   hw.output %z : i4
 }
 
-verif.formal @ZeroLhs {
+verif.formal @ZeroLhs {} {
   %c0_i4 = hw.constant 0 : i4
   %x = verif.symbolic_value : i4
   %z = hw.instance "dut" @CustomAdder(a: %c0_i4: i4, b: %x: i4) -> (z: i4)
@@ -43,7 +43,7 @@ verif.formal @ZeroLhs {
   verif.assert %eq : i1
 }
 
-verif.formal @ZeroRhs {
+verif.formal @ZeroRhs {} {
   %c0_i4 = hw.constant 0 : i4
   %x = verif.symbolic_value : i4
   %z = hw.instance "dut" @CustomAdder(a: %x: i4, b: %c0_i4: i4) -> (z: i4)
@@ -51,7 +51,7 @@ verif.formal @ZeroRhs {
   verif.assert %eq : i1
 }
 
-verif.formal @CustomAdderWorks {
+verif.formal @CustomAdderWorks {} {
   %a = verif.symbolic_value : i4
   %b = verif.symbolic_value : i4
 
@@ -76,7 +76,7 @@ hw.module @ALU(in %a: i4, in %b: i4, in %sub: i1, out z: i4) {
   hw.output %z : i4
 }
 
-verif.formal @ALUCanAdd {
+verif.formal @ALUCanAdd {} {
   %a = verif.symbolic_value : i4
   %b = verif.symbolic_value : i4
   %false = hw.constant false
@@ -86,7 +86,7 @@ verif.formal @ALUCanAdd {
   verif.assert %eq : i1
 }
 
-verif.formal @ALUCanSub attributes {mode = "cover,induction"} {
+verif.formal @ALUCanSub {mode = "cover,induction"} {
   %a = verif.symbolic_value : i4
   %b = verif.symbolic_value : i4
   %true = hw.constant true
@@ -96,7 +96,7 @@ verif.formal @ALUCanSub attributes {mode = "cover,induction"} {
   verif.assert %eq : i1
 }
 
-verif.formal @ALUWorks attributes {mode = "cover,bmc", depth = 5} {
+verif.formal @ALUWorks {mode = "cover,bmc", depth = 5} {
   %a = verif.symbolic_value : i4
   %b = verif.symbolic_value : i4
   %sub = verif.symbolic_value : i1
@@ -114,7 +114,7 @@ verif.formal @ALUWorks attributes {mode = "cover,bmc", depth = 5} {
   verif.assert %eq : i1
 }
 
-verif.formal @ALUIgnoreFailure attributes {ignore = true} {
+verif.formal @ALUIgnoreFailure {ignore = true} {
   %a = verif.symbolic_value : i4
   %b = verif.symbolic_value : i4
   %sub = verif.symbolic_value : i1
@@ -132,7 +132,7 @@ verif.formal @ALUIgnoreFailure attributes {ignore = true} {
   verif.assert %ne : i1
 }
 
-verif.formal @ALUFailure attributes {depth = 3} {
+verif.formal @ALUFailure {depth = 3} {
   %a = verif.symbolic_value : i4
   %b = verif.symbolic_value : i4
   %sub = verif.symbolic_value : i1

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -676,8 +676,8 @@ void FIRRTLModuleLowering::runOnOperation() {
             .Case<FormalOp>([&](auto oldFormalOp) {
               auto builder = OpBuilder::atBlockEnd(topLevelModule);
               auto newFormalOp = builder.create<verif::FormalOp>(
-                  oldFormalOp.getLoc(), oldFormalOp.getNameAttr());
-              newFormalOp->setDiscardableAttrs(oldFormalOp.getParametersAttr());
+                  oldFormalOp.getLoc(), oldFormalOp.getNameAttr(),
+                  oldFormalOp.getParametersAttr());
               newFormalOp.getBody().emplaceBlock();
               state.recordModuleMapping(oldFormalOp, newFormalOp);
               formalOpsToProcess.push_back(newFormalOp);

--- a/test/Dialect/Verif/basic.mlir
+++ b/test/Dialect/Verif/basic.mlir
@@ -40,11 +40,11 @@ verif.cover %p : !ltl.property
 //===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: verif.formal @EmptyFormalTest
-verif.formal @EmptyFormalTest {
+verif.formal @EmptyFormalTest {} {
 }
 
 // CHECK-LABEL: verif.formal @FormalTestWithAttrs
-verif.formal @FormalTestWithAttrs attributes {
+verif.formal @FormalTestWithAttrs {
   // CHECK-SAME: a,
   a,
   // CHECK-SAME: b = "hello"
@@ -59,7 +59,7 @@ verif.formal @FormalTestWithAttrs attributes {
 }
 
 // CHECK-LABEL: verif.formal @FormalTestBody
-verif.formal @FormalTestBody {
+verif.formal @FormalTestBody {} {
   // CHECK: {{%.+}} = verif.symbolic_value : i42
   %0 = verif.symbolic_value : i42
 }

--- a/test/Dialect/Verif/lower-formal-to-hw.mlir
+++ b/test/Dialect/Verif/lower-formal-to-hw.mlir
@@ -3,7 +3,7 @@
 hw.module @Foo(in %bar : i32, in %baz : i16, in %clk : !seq.clock) {}
 
 // CHECK-LABEL: hw.module @FormalTop(in %symbolic_value_0 : i32, in %symbolic_value_1 : i16)
-verif.formal @FormalTop {
+verif.formal @FormalTop {} {
   %0 = verif.symbolic_value : i32
   %1 = verif.symbolic_value : i16
   // CHECK: [[CLK:%[0-9]+]] = seq.const_clock high

--- a/test/circt-test/basic.mlir
+++ b/test/circt-test/basic.mlir
@@ -15,8 +15,8 @@
 // JSON-NEXT: }
 // CHECK: Some.TestA formal {}
 // CHECK: Some.TestB formal {}
-verif.formal @Some.TestA {}
-verif.formal @Some.TestB {}
+verif.formal @Some.TestA {} {}
+verif.formal @Some.TestB {} {}
 
 // JSON-NEXT: {
 // JSON-NEXT:   "name": "Attrs"
@@ -34,7 +34,7 @@ verif.formal @Some.TestB {}
 // JSON-NEXT:   }
 // JSON-NEXT: }
 // CHECK: Attrs formal {awesome = true, engine = "bmc", ignore = false, offset = 42 : i64, tags = ["sby", "induction"], wow = false}
-verif.formal @Attrs attributes {
+verif.formal @Attrs {
     awesome = true,
     engine = "bmc",
     offset = 42 : i64,
@@ -46,7 +46,7 @@ verif.formal @Attrs attributes {
 // CHECK-NOT: "name": "Ignore"
 // JSON-NOT: "name": "Ignore"
 // CHECK-WITH-IGNORED: Ignore formal {another = "attr", ignore = true}
-verif.formal @Ignore attributes {
+verif.formal @Ignore {
     ignore = true,
     another = "attr"
 } {}

--- a/tools/circt-test/circt-test.cpp
+++ b/tools/circt-test/circt-test.cpp
@@ -149,11 +149,11 @@ void TestSuite::discoverInModule(ModuleOp module) {
     test.name = op.getSymNameAttr();
     test.kind = TestKind::Formal;
     test.loc = op.getLoc();
-    if (auto boolAttr = op->getAttrOfType<BoolAttr>("ignore"))
+    test.attrs = op.getParametersAttr();
+    if (auto boolAttr = test.attrs.getAs<BoolAttr>("ignore"))
       test.ignore = boolAttr.getValue();
     else
       test.ignore = false;
-    test.attrs = op->getDiscardableAttrDictionary();
     tests.push_back(std::move(test));
   });
 }


### PR DESCRIPTION
Instead of using the discardable attributes dictionary of `verif.formal` as vessel for user-defined test parameters, add a dedicated `parameters` field to the op itself. This makes the parameters non-discardable and a proper part of the test.