### PR TITLE
[SMT] Add SMTLIB lowering for push & pop operations

### DIFF
--- a/include/circt/Dialect/SMT/SMTVisitors.h
+++ b/include/circt/Dialect/SMT/SMTVisitors.h
@@ -44,7 +44,7 @@ public:
             // Variable/symbol declaration
             DeclareFunOp, ApplyFuncOp,
             // solver interaction
-            SolverOp, AssertOp, ResetOp, CheckOp,
+            SolverOp, AssertOp, ResetOp, PushOp, PopOp, CheckOp,
             // Boolean logic
             NotOp, AndOp, OrOp, XOrOp, ImpliesOp,
             // Arrays
@@ -125,6 +125,8 @@ public:
   HANDLE(SolverOp, Unhandled);
   HANDLE(AssertOp, Unhandled);
   HANDLE(ResetOp, Unhandled);
+  HANDLE(PushOp, Unhandled);
+  HANDLE(PopOp, Unhandled);
   HANDLE(CheckOp, Unhandled);
 
   // Boolean logic operations

--- a/integration_test/Target/ExportSMTLIB/basic.mlir
+++ b/integration_test/Target/ExportSMTLIB/basic.mlir
@@ -117,3 +117,31 @@ smt.solver () : () -> () {
 // CHECK-NOT: error
 // CHECK-NOT: unsat
 // CHECK: sat
+
+// Push and pop
+smt.solver () : () -> () {
+  %three = smt.int.constant 3
+  %four = smt.int.constant 4
+  %unsat_eq = smt.eq %three, %four : !smt.int
+  %sat_eq = smt.eq %three, %three : !smt.int
+
+  smt.push 1
+  smt.assert %unsat_eq
+  smt.check sat {} unknown {} unsat {}
+  smt.pop 1
+  smt.assert %sat_eq
+  smt.check sat {} unknown {} unsat {}
+}
+
+// CHECK-NOT: WARNING
+// CHECK-NOT: warning
+// CHECK-NOT: ERROR
+// CHECK-NOT: error
+// CHECK-NOT: sat
+// CHECK: unsat
+// CHECK-NOT: WARNING
+// CHECK-NOT: warning
+// CHECK-NOT: ERROR
+// CHECK-NOT: error
+// CHECK-NOT: unsat
+// CHECK: sat

--- a/lib/Target/ExportSMTLIB/ExportSMTLIB.cpp
+++ b/lib/Target/ExportSMTLIB/ExportSMTLIB.cpp
@@ -564,6 +564,18 @@ struct StatementVisitor
     return success();
   }
 
+  LogicalResult visitSMTOp(PushOp op, mlir::raw_indented_ostream &stream,
+                           ValueMap &valueMap) {
+    stream << "(push " << op.getCount() << ")\n";
+    return success();
+  }
+
+  LogicalResult visitSMTOp(PopOp op, mlir::raw_indented_ostream &stream,
+                           ValueMap &valueMap) {
+    stream << "(pop " << op.getCount() << ")\n";
+    return success();
+  }
+
   LogicalResult visitSMTOp(CheckOp op, mlir::raw_indented_ostream &stream,
                            ValueMap &valueMap) {
     if (op->getNumResults() != 0)

--- a/test/Target/ExportSMTLIB/core.mlir
+++ b/test/Target/ExportSMTLIB/core.mlir
@@ -120,6 +120,14 @@ smt.solver () : () -> () {
   // CHECK-INLINED: (reset)
   smt.reset
 
+  // CHECK: (push 1)
+  // CHECK-INLINED: (push 1)
+  smt.push 1
+
+  // CHECK: (pop 1)
+  // CHECK-INLINED: (pop 1)
+  smt.pop 1
+
   // CHECK: (reset)
   // CHECK-INLINED: (reset)
 }


### PR DESCRIPTION
Just adds an SMTLIB export for push/pop ops added in #7865 