### PR TITLE
[SMT] Add integration tests for `smt.reset`

### DIFF
--- a/integration_test/Dialect/SMT/basic.mlir
+++ b/integration_test/Dialect/SMT/basic.mlir
@@ -168,6 +168,21 @@ func.func @entry() {
     smt.yield
   }
 
+  // CHECK: unsat
+  // CHECK: Res: -1
+  // CHECK: sat
+  // CHECK: Res: 1
+  smt.solver () : () -> () {
+    %c3 = smt.int.constant 3
+    %c4 = smt.int.constant 4
+    %unsat_eq = smt.eq %c3, %c4 : !smt.int
+    func.call @check(%unsat_eq) : (!smt.bool) -> ()
+    smt.reset
+    %sat_eq = smt.eq %c3, %c3 : !smt.int
+    func.call @check(%sat_eq) : (!smt.bool) -> ()
+    smt.yield
+  }
+
   return
 }
 

--- a/integration_test/Target/ExportSMTLIB/basic.mlir
+++ b/integration_test/Target/ExportSMTLIB/basic.mlir
@@ -145,3 +145,30 @@ smt.solver () : () -> () {
 // CHECK-NOT: error
 // CHECK-NOT: unsat
 // CHECK: sat
+
+// Reset
+smt.solver () : () -> () {
+  %three = smt.int.constant 3
+  %four = smt.int.constant 4
+  %unsat_eq = smt.eq %three, %four : !smt.int
+  %sat_eq = smt.eq %three, %three : !smt.int
+
+  smt.assert %unsat_eq
+  smt.check sat {} unknown {} unsat {}
+  smt.reset
+  smt.assert %sat_eq
+  smt.check sat {} unknown {} unsat {}
+}
+
+// CHECK-NOT: WARNING
+// CHECK-NOT: warning
+// CHECK-NOT: ERROR
+// CHECK-NOT: error
+// CHECK-NOT: sat
+// CHECK: unsat
+// CHECK-NOT: WARNING
+// CHECK-NOT: warning
+// CHECK-NOT: ERROR
+// CHECK-NOT: error
+// CHECK-NOT: unsat
+// CHECK: sat


### PR DESCRIPTION
Small one, just belatedly adds some integration tests for the reset op added in #7791 - ~~I'll rebase this once I've merged #7873 as they'll conflict slightly~~ (done now)