### PR TITLE
[FIRRTL] Dedup: dedup private modules into public ones

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -51,14 +51,23 @@ using hw::InnerRefAttr;
 // Utility function for classifying a Symbol's dedup-ability.
 //===----------------------------------------------------------------------===//
 
+/// Returns true if the module can be removed.
 static bool checkVisibility(mlir::SymbolOpInterface symbol) {
-  // If module has symbol (name) that must be preserved even if unused,
-  // skip it. All symbol uses must be supported, which is not true if
-  // non-private.
-  // Special handling for class-like's and if symbol reports cannot be
-  // discarded.
-  return symbol.isPrivate() &&
-         (symbol.canDiscardOnUseEmpty() || isa<ClassLike>(*symbol));
+  // If the symbol is not private, it cannot be removed.
+  if (!symbol.isPrivate())
+    return false;
+  // Classes may be referenced in object types, so can not normally be removed
+  // if we can't find any symbol uses. Since we know that dedup will update the
+  // types of instances appropriately, we can ignore that and return true here.
+  if (isa<ClassLike>(*symbol))
+    return true;
+  // If module can not be removed even if no uses can be found, we can not
+  // delete it. The implication is that there are hidden symbol uses that dedup
+  // will not properly update.
+  if (!symbol.canDiscardOnUseEmpty())
+    return false;
+  // The module can be deleted.
+  return true;
 }
 
 //===----------------------------------------------------------------------===//
@@ -108,11 +117,13 @@ struct StructuralHasherSharedConstants {
     portSymbolsAttr = StringAttr::get(context, "portSymbols");
     portNamesAttr = StringAttr::get(context, "portNames");
     nonessentialAttributes.insert(StringAttr::get(context, "annotations"));
+    nonessentialAttributes.insert(StringAttr::get(context, "convention"));
     nonessentialAttributes.insert(StringAttr::get(context, "name"));
     nonessentialAttributes.insert(StringAttr::get(context, "portAnnotations"));
     nonessentialAttributes.insert(StringAttr::get(context, "portNames"));
     nonessentialAttributes.insert(StringAttr::get(context, "portLocations"));
     nonessentialAttributes.insert(StringAttr::get(context, "sym_name"));
+    nonessentialAttributes.insert(StringAttr::get(context, "sym_visibility"));
   };
 
   // This is a cached "portTypes" string attr.
@@ -1741,9 +1752,9 @@ class DedupPass : public circt::firrtl::impl::DedupBase<DedupPass> {
 
         // If the current module is public, and the original is private, we
         // want to dedup the private module into the public one.
-        if (module.isPublic()) {
+        if (!checkVisibility(module)) {
           // If both modules are public, then we can't dedup anything.
-          if (original.isPublic())
+          if (!checkVisibility(original))
             continue;
           // Swap the canonical module in the dedup map.
           for (auto &[originalName, dedupedName] : dedupMap)

--- a/test/Dialect/FIRRTL/dedup-errors.mlir
+++ b/test/Dialect/FIRRTL/dedup-errors.mlir
@@ -656,30 +656,3 @@ firrtl.circuit "InstOfEquivPublic" attributes {annotations = [{
     firrtl.instance test1p @Test1Parent()
   }
 }
-
-// -----
-
-// Modules instantiating mixed public/private do not dedup.
-// Check diagnostic.
-// expected-error @below {{module "Test1Parent" not deduplicated with "Test0Parent"}}
-// expected-note @below {{in instance "test0" of "Test0", and instance "test1" of "Test1"}}
-firrtl.circuit "InstOfPublicPrivate" attributes {annotations = [{
-      class = "firrtl.transforms.MustDeduplicateAnnotation",
-      modules = ["~InstOfPublicPrivate|Test0Parent", "~InstOfPublicPrivate|Test1Parent"]
-    }]} {
-  firrtl.module private @Test0() { }
-  // expected-note @below {{module is public}}
-  firrtl.module public @Test1() { }
-
-  firrtl.module private @Test0Parent() {
-    firrtl.instance test0 @Test0()
-  }
-  firrtl.module private @Test1Parent() {
-    firrtl.instance test1 @Test1()
-  }
-
-  firrtl.module @InstOfPublicPrivate() {
-    firrtl.instance test0p @Test0Parent()
-    firrtl.instance test1p @Test1Parent()
-  }
-}

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -37,6 +37,36 @@ firrtl.circuit "Simple" {
   }
 }
 
+// CHECK-LABEL: "PrivateModulesDifferentConventionsDedup"
+firrtl.circuit "PrivateModulesDifferentConventionsDedup" {
+  firrtl.module private @A() attributes {convention = #firrtl<convention scalarized>} { }
+  firrtl.module private @B() attributes { } { }
+  firrtl.module @PrivateModulesDifferentConventionsDedup() {
+    // CHECK: firrtl.instance a @A()
+    // CHECK: firrtl.instance b @A()
+    firrtl.instance a @A()
+    firrtl.instance b @B()
+  }
+}
+
+
+firrtl.circuit "PublicAndPrivateModulesDedup" {
+  // CHECK-NOT: @A
+  firrtl.module private @A() { }
+  // CHECK:     @B()
+  firrtl.module @B() { }
+  // CHECK-NOT: @C
+  firrtl.module private @C() { }
+  firrtl.module @PublicAndPrivateModulesDedup() {
+    // CHECK: firrtl.instance a @B()
+    // CHECK: firrtl.instance b @B()
+    // CHECK: firrtl.instance c @B()
+    firrtl.instance a @A()
+    firrtl.instance b @B()
+    firrtl.instance c @C()
+  }
+}
+
 // CHECK-LABEL: firrtl.circuit "PrimOps"
 firrtl.circuit "PrimOps" {
   // CHECK: firrtl.module private @PrimOps0


### PR DESCRIPTION
This change allows private modules to deduplicate in to public modules.  It does this by swapping a private canonical module with a public module when found.  Future public modules will not deduplicate into this group, as public modules can not dedup with other public modules in general.  This also begins ignoring the convention of private modules, as it doesn't really carry any meaning.  In the future we might want to disallow conventions to be specified on private modules.