### PR TITLE
[FIRRTL] Make IMDCE work for ops w/ regions/blocks

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -379,7 +379,8 @@ def LayerBlockOp : FIRRTLOp<
    ParentOneOf<[
      "firrtl::FModuleOp", "firrtl::LayerBlockOp",
      "firrtl::WhenOp", "firrtl::MatchOp"]>,
-   DeclareOpInterfaceMethods<SymbolUserOpInterface>]
+   DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+   RecursiveMemoryEffects, RecursivelySpeculatable]
 > {
   let summary = "A definition of a layer block";
   let description = [{


### PR DESCRIPTION
Fix a bug in FIRRTL's IMDCE Pass where it would not visit the blocks of operations.  This can result in crashes for blocks which contain users of FIRRTL modules, e.g., instances inside layerblocks of sv.ifdef.

This conceptually is two changes: (1) when marking a block live, the block needs to be recursively walked and (2) when erasing ops, a recursive walk is needed.