### PR TITLE
[circt-test] fix lit config for circt-bmc

### DIFF
--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -79,8 +79,9 @@ tool_dirs = [
 ]
 tools = [
     'arcilator', 'circt-opt', 'circt-translate', 'firtool', 'circt-rtl-sim.py',
-    'equiv-rtl.sh', 'handshake-runner', 'hlstool', 'kanagawatool', 'circt-lec',
-    'circt-bmc', 'circt-test', 'circt-test-runner-sby.py'
+    'equiv-rtl.sh', 'handshake-runner', 'hlstool', 'ibistool', 'circt-lec',
+    'circt-bmc', 'circt-test', 'circt-test-runner-sby.py',
+    'circt-test-runner-circt-bmc.py'
 ]
 
 # Enable python if its path was configured
@@ -230,6 +231,7 @@ if config.arcilator_jit_enabled:
   config.available_features.add('arcilator-jit')
 
 config.substitutions.append(('%driver', f'{config.driver}'))
+config.substitutions.append(('%circt-tools-dir', f'{config.circt_tools_dir}'))
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
 # cocotb availability


### PR DESCRIPTION
#7857 introduces a Python script to test `circt-bmc`, but there are two problems:
1. We need to add the script to the substitution list in `lit.cfg.py` so that lit can correctly substitute the path in the test.
2. The script invokes `circt-opt` but the executable is not in the PATH variable causing python cannot find it. This PR simply adds `circt_tool_dir` to PATH to resolve it, but I think a better way is to get rid of the python script and allow lit to substitute the path.