### PR TITLE
[MooreToCore] Lower the unpacked array type to `hw.array`

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1447,6 +1447,16 @@ static void populateTypeConversion(TypeConverter &typeConverter) {
     return {};
   });
 
+  // FIXME: Unpacked arrays support more element types than their packed
+  // variants, and as such, mapping them to hw::Array is somewhat naive. See
+  // also the analogous note below concerning unpacked struct type conversion.
+  typeConverter.addConversion(
+      [&](UnpackedArrayType type) -> std::optional<Type> {
+        if (auto elementType = typeConverter.convertType(type.getElementType()))
+          return hw::ArrayType::get(elementType, type.getSize());
+        return {};
+      });
+
   typeConverter.addConversion([&](StructType type) -> std::optional<Type> {
     SmallVector<hw::StructType::FieldInfo> fields;
     for (auto field : type.getMembers()) {

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -434,15 +434,20 @@ moore.module @UnpackedArray(in %arr : !moore.uarray<2 x i32>, in %sel : !moore.i
   // CHECK: hw.array_get %arr[[[TRUE]]] : !hw.array<2xi32>, i1
   %1 = moore.extract %arr from 1 : !moore.uarray<2 x i32> -> !moore.i32
 
-  // CHECK: [[C0:%.+]] = hw.constant 0 : i128
-  // CHECK: [[INIT:%.+]] = hw.bitcast [[C0]] : (i128) -> !hw.array<4xi32>
-  // CHECK: [[SIG:%.+]] = llhd.sig [[INIT]] : !hw.array<4xi32>
+  // CHECK: [[C0_128:%.+]] = hw.constant 0 : i128
+  // CHECK: [[INIT:%.+]] = hw.bitcast [[C0_128]] : (i128) -> !hw.array<4xi32>
+  // CHECK: [[SIG_0:%.+]] = llhd.sig [[INIT]] : !hw.array<4xi32>
   %2 = moore.variable : <uarray<4 x i32>>
 
   // CHECK: [[C1:%.+]] = hw.constant 1 : i2
-  // CHECK: llhd.sig.array_get [[SIG]][[[C1]]] : !hw.inout<array<4xi32>>
+  // CHECK: llhd.sig.array_get [[SIG_0]][[[C1]]] : !hw.inout<array<4xi32>>
   %3 = moore.extract_ref %2 from 1 : !moore.ref<!moore.uarray<4 x i32>> -> !moore.ref<!moore.i32>
   moore.assign %3, %0 : i32
+
+  // CHECK: [[C0_1024:%.+]] = hw.constant 0 : i1024
+  // CHECK: [[INIT:%.+]] = hw.bitcast [[C0_1024]] : (i1024) -> !hw.array<4xarray<8xarray<8xi4>>>
+  // CHECK: [[SIG_1:%.+]] = llhd.sig [[INIT]] : !hw.array<4xarray<8xarray<8xi4>>>
+  %4 = moore.variable : <uarray<4 x uarray<8 x array<8 x i4>>>>
 
   moore.output %0 : !moore.i32
 }

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -425,6 +425,28 @@ moore.module @Net() {
   moore.assign %a, %3 : i32
 }
 
+// CHECK-LABEL: hw.module @UnpackedArray
+moore.module @UnpackedArray(in %arr : !moore.uarray<2 x i32>, in %sel : !moore.i1, out c : !moore.i32) {
+  // CHECK: hw.array_get %arr[%sel] : !hw.array<2xi32>, i1
+  %0 = moore.dyn_extract %arr from %sel : !moore.uarray<2 x i32>, !moore.i1 -> !moore.i32
+
+  // CHECK: [[TRUE:%.+]] = hw.constant true
+  // CHECK: hw.array_get %arr[[[TRUE]]] : !hw.array<2xi32>, i1
+  %1 = moore.extract %arr from 1 : !moore.uarray<2 x i32> -> !moore.i32
+
+  // CHECK: [[C0:%.+]] = hw.constant 0 : i128
+  // CHECK: [[INIT:%.+]] = hw.bitcast [[C0]] : (i128) -> !hw.array<4xi32>
+  // CHECK: [[SIG:%.+]] = llhd.sig [[INIT]] : !hw.array<4xi32>
+  %2 = moore.variable : <uarray<4 x i32>>
+
+  // CHECK: [[C1:%.+]] = hw.constant 1 : i2
+  // CHECK: llhd.sig.array_get [[SIG]][[[C1]]] : !hw.inout<array<4xi32>>
+  %3 = moore.extract_ref %2 from 1 : !moore.ref<!moore.uarray<4 x i32>> -> !moore.ref<!moore.i32>
+  moore.assign %3, %0 : i32
+
+  moore.output %0 : !moore.i32
+}
+
 // CHECK-LABEL: hw.module @Struct
 moore.module @Struct(in %a : !moore.i32, in %b : !moore.i32, in %arg0 : !moore.struct<{exp_bits: i32, man_bits: i32}>, in %arg1 : !moore.ref<!moore.struct<{exp_bits: i32, man_bits: i32}>>, out a : !moore.i32, out b : !moore.struct<{exp_bits: i32, man_bits: i32}>, out c : !moore.struct<{exp_bits: i32, man_bits: i32}>) {
   // CHECK: hw.struct_extract %arg0["exp_bits"] : !hw.struct<exp_bits: i32, man_bits: i32>


### PR DESCRIPTION
This add a type conversion for unpacked arrays, mapping them to `hw.array`. The approach is analogous to how unpacked structs are currently handled.

As far as I understand, `hw.uarray` would be more appropriate in the future, especially once it's moved to SV. However, no operation accepts this type yet. I'm not sure what the consensus is as to whether the operation set should be extended to accommodate unpacked arrays (by adding new operations or "overloading" existing ones that deal with `hw.array`s). Using packed arrays for the time being sidesteps this question.