### PR TITLE
[CI] Bump integration test image to 18.0

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -19,7 +19,7 @@ jobs:
     # John and re-run the job.
     runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
     container:
-      image: ghcr.io/circt/images/circt-integration-test:v17.0
+      image: ghcr.io/circt/images/circt-integration-test:v18.0
       volumes:
         - /mnt:/__w/circt
     strategy:

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -29,7 +29,7 @@ jobs:
     # John and re-run the job.
     runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
     container:
-      image: ghcr.io/circt/images/circt-integration-test:v17.0
+      image: ghcr.io/circt/images/circt-integration-test:v18.0
       volumes:
         - /mnt:/__w/circt
     strategy:


### PR DESCRIPTION
This image includes an up-to-date build of Yosys and SymbiYosys, useful for testing the new circt-test formal flows.