### PR TITLE
[circt-bmc] Drop outdated integration test

### DIFF
--- a/integration_test/circt-bmc/seq.mlir
+++ b/integration_test/circt-bmc/seq.mlir
@@ -1,22 +1,7 @@
 // REQUIRES: libz3
 // REQUIRES: circt-bmc-jit
 
-//  RUN: circt-bmc %s -b 10 --module ClkProp --shared-libs=%libz3 | FileCheck %s --check-prefix=CLKPROP
-//  CLKPROP: Bound reached with no violations!
-
-hw.module @ClkProp(in %clk: !seq.clock, in %i0: i1) {
-  %reg = seq.compreg %i0, %clk : i1
-  // Condition (equivalent to %clk -> %reg == %i0)
-  %c-1_i1 = hw.constant -1 : i1
-  %clk_i1 = seq.from_clock %clk
-  %nclk = comb.xor bin %clk_i1, %c-1_i1 : i1
-  %eq = comb.icmp bin eq %i0, %reg : i1
-  %imp = comb.or bin %nclk, %eq : i1
-  verif.assert %imp : i1
-}
-
 // Check propagation of state through comb ops
-
 //  RUN: circt-bmc %s -b 10 --module StateProp --shared-libs=%libz3 | FileCheck %s --check-prefix=STATEPROP
 //  STATEPROP: Bound reached with no violations!
 


### PR DESCRIPTION
This test was made for an outdated version of circt-bmc and only passes now because of a bug (fix incoming!)