### PR TITLE
[FIRRTL] FoldUnusedBits: Cast compressed data back to signed integer

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -2849,6 +2849,15 @@ struct FoldUnusedBits : public mlir::RewritePattern {
           catOfSlices = slice;
         }
       }
+
+      // If the original memory held a signed integer, then the compressed
+      // memory will be signed too. Since the catOfSlices is always unsigned,
+      // cast the data to a signed integer if needed before connecting back to
+      // the memory.
+      if (type.isSigned())
+        catOfSlices =
+            rewriter.createOrFold<AsSIntPrimOp>(writeOp.getLoc(), catOfSlices);
+
       rewriter.replaceOpWithNewOp<MatchingConnectOp>(writeOp, writeOp.getDest(),
                                                      catOfSlices);
     }


### PR DESCRIPTION
The FoldUnusedBits folder will, when it sees a memory with obviously unused bits (all readers are bitselect ops), will compress that memory to a smaller integer. The data written to the memory has to be compressed to just the relevant bits, which is done using a sequence of bit-select and bit-concat ops on the data. The result of these ops is unsigned. If the memory itself stores a signed integer, then we need to cast this data back to a signed value.