### PR TITLE
[VerifToSMT] Exit early after too many clocks error

### DIFF
--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -445,6 +445,7 @@ void ConvertVerifToSMTPass::runOnOperation() {
             op->emitError(
                 "only modules with one or zero clocks are currently supported");
             signalPassFailure();
+            return WalkResult::interrupt();
           }
           SmallVector<mlir::Operation *> worklist;
           int numAssertions = 0;

--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -444,7 +444,6 @@ void ConvertVerifToSMTPass::runOnOperation() {
           if (numClockArgs > 1) {
             op->emitError(
                 "only modules with one or zero clocks are currently supported");
-            signalPassFailure();
             return WalkResult::interrupt();
           }
           SmallVector<mlir::Operation *> worklist;


### PR DESCRIPTION
Tiny change, just makes it so VerifToSMT exits early after throwing the too many clocks error (rather than still trying to apply the pass).