### PR TITLE
[Calyx] Avoid using designated initializers

### DIFF
--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -849,107 +849,76 @@ PredicateInfo getPredicateInfo(CmpFPredicate pred) {
   PredicateInfo info;
   switch (pred) {
   case CmpFPredicate::OEQ: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = CombLogic::And;
-    predInfo.inputPorts = {{Port::Eq, /*inverted=*/false},
-                           {Port::Unordered, /*inverted=*/true}};
-    return predInfo;
+    info.logic = CombLogic::And;
+    info.inputPorts = {{Port::Eq, /*inverted=*/false},
+                       {Port::Unordered, /*inverted=*/true}};
   }
   case CmpFPredicate::OGT: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::And;
-    predInfo.inputPorts = {{Port::Gt, /*inverted=*/false},
-                           {Port::Unordered, /*inverted=*/true}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::And;
+    info.inputPorts = {{Port::Gt, /*inverted=*/false},
+                       {Port::Unordered, /*inverted=*/true}};
   }
   case CmpFPredicate::OGE: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::And;
-    predInfo.inputPorts = {{Port::Lt, /*inverted=*/true},
-                           {Port::Unordered, /*inverted=*/true}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::And;
+    info.inputPorts = {{Port::Lt, /*inverted=*/true},
+                       {Port::Unordered, /*inverted=*/true}};
   }
   case CmpFPredicate::OLT: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::And;
-    predInfo.inputPorts = {{Port::Lt, /*inverted=*/false},
-                           {Port::Unordered, /*inverted=*/true}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::And;
+    info.inputPorts = {{Port::Lt, /*inverted=*/false},
+                       {Port::Unordered, /*inverted=*/true}};
   }
   case CmpFPredicate::OLE: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::And;
-    predInfo.inputPorts = {{Port::Gt, /*inverted=*/true},
-                           {Port::Unordered, /*inverted=*/true}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::And;
+    info.inputPorts = {{Port::Gt, /*inverted=*/true},
+                       {Port::Unordered, /*inverted=*/true}};
   }
   case CmpFPredicate::ONE: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::And;
-    predInfo.inputPorts = {{Port::Eq, /*inverted=*/true},
-                           {Port::Unordered, /*inverted=*/true}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::And;
+    info.inputPorts = {{Port::Eq, /*inverted=*/true},
+                       {Port::Unordered, /*inverted=*/true}};
   }
   case CmpFPredicate::ORD: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::None;
-    predInfo.inputPorts = {{Port::Unordered, /*inverted=*/true}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::None;
+    info.inputPorts = {{Port::Unordered, /*inverted=*/true}};
   }
   case CmpFPredicate::UEQ: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::Or;
-    predInfo.inputPorts = {{Port::Eq, /*inverted=*/false},
-                           {Port::Unordered, /*inverted=*/false}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::Or;
+    info.inputPorts = {{Port::Eq, /*inverted=*/false},
+                       {Port::Unordered, /*inverted=*/false}};
   }
   case CmpFPredicate::UGT: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::Or;
-    predInfo.inputPorts = {{Port::Gt, /*inverted=*/false},
-                           {Port::Unordered, /*inverted=*/false}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::Or;
+    info.inputPorts = {{Port::Gt, /*inverted=*/false},
+                       {Port::Unordered, /*inverted=*/false}};
   }
   case CmpFPredicate::UGE: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::Or;
-    predInfo.inputPorts = {{Port::Lt, /*inverted=*/true},
-                           {Port::Unordered, /*inverted=*/false}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::Or;
+    info.inputPorts = {{Port::Lt, /*inverted=*/true},
+                       {Port::Unordered, /*inverted=*/false}};
   }
   case CmpFPredicate::ULT: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::Or;
-    predInfo.inputPorts = {{Port::Lt, /*inverted=*/false},
-                           {Port::Unordered, /*inverted=*/false}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::Or;
+    info.inputPorts = {{Port::Lt, /*inverted=*/false},
+                       {Port::Unordered, /*inverted=*/false}};
   }
   case CmpFPredicate::ULE: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::Or;
-    predInfo.inputPorts = {{Port::Gt, /*inverted=*/true},
-                           {Port::Unordered, /*inverted=*/false}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::Or;
+    info.inputPorts = {{Port::Gt, /*inverted=*/true},
+                       {Port::Unordered, /*inverted=*/false}};
   }
   case CmpFPredicate::UNE: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::Or;
-    predInfo.inputPorts = {{Port::Eq, /*inverted=*/true},
-                           {Port::Unordered, /*inverted=*/false}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::Or;
+    info.inputPorts = {{Port::Eq, /*inverted=*/true},
+                       {Port::Unordered, /*inverted=*/false}};
   }
   case CmpFPredicate::UNO: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::None;
-    predInfo.inputPorts = {{Port::Unordered, /*inverted=*/false}};
-    return predInfo;
+    info.logic = PredicateInfo::CombLogic::None;
+    info.inputPorts = {{Port::Unordered, /*inverted=*/false}};
   }
   case CmpFPredicate::AlwaysTrue:
-  case CmpFPredicate::AlwaysFalse: {
-    auto predInfo = PredicateInfo();
-    predInfo.logic = PredicateInfo::CombLogic::None;
-    return predInfo;
-  }
+  case CmpFPredicate::AlwaysFalse:
+    info.logic = PredicateInfo::CombLogic::None;
   }
 
   return info;

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -849,78 +849,107 @@ PredicateInfo getPredicateInfo(CmpFPredicate pred) {
   PredicateInfo info;
   switch (pred) {
   case CmpFPredicate::OEQ: {
-    return PredicateInfo{.logic = CombLogic::And,
-                         .inputPorts = {{Port::Eq, /*inverted=*/false},
-                                        {Port::Unordered, /*inverted=*/true}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = CombLogic::And;
+    predInfo.inputPorts = {{Port::Eq, /*inverted=*/false},
+                           {Port::Unordered, /*inverted=*/true}};
+    return predInfo;
   }
   case CmpFPredicate::OGT: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::And,
-                         .inputPorts = {{Port::Gt, /*inverted=*/false},
-                                        {Port::Unordered, /*inverted=*/true}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::And;
+    predInfo.inputPorts = {{Port::Gt, /*inverted=*/false},
+                           {Port::Unordered, /*inverted=*/true}};
+    return predInfo;
   }
   case CmpFPredicate::OGE: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::And,
-                         .inputPorts = {{Port::Lt, /*inverted=*/true},
-                                        {Port::Unordered, /*inverted=*/true}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::And;
+    predInfo.inputPorts = {{Port::Lt, /*inverted=*/true},
+                           {Port::Unordered, /*inverted=*/true}};
+    return predInfo;
   }
   case CmpFPredicate::OLT: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::And,
-                         .inputPorts = {{Port::Lt, /*inverted=*/false},
-                                        {Port::Unordered, /*inverted=*/true}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::And;
+    predInfo.inputPorts = {{Port::Lt, /*inverted=*/false},
+                           {Port::Unordered, /*inverted=*/true}};
+    return predInfo;
   }
   case CmpFPredicate::OLE: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::And,
-                         .inputPorts = {{Port::Gt, /*inverted=*/true},
-                                        {Port::Unordered, /*inverted=*/true}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::And;
+    predInfo.inputPorts = {{Port::Gt, /*inverted=*/true},
+                           {Port::Unordered, /*inverted=*/true}};
+    return predInfo;
   }
   case CmpFPredicate::ONE: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::And,
-                         .inputPorts = {{Port::Eq, /*inverted=*/true},
-                                        {Port::Unordered, /*inverted=*/true}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::And;
+    predInfo.inputPorts = {{Port::Eq, /*inverted=*/true},
+                           {Port::Unordered, /*inverted=*/true}};
+    return predInfo;
   }
   case CmpFPredicate::ORD: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::None,
-                         .inputPorts = {{Port::Unordered, /*inverted=*/true}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::None;
+    predInfo.inputPorts = {{Port::Unordered, /*inverted=*/true}};
+    return predInfo;
   }
   case CmpFPredicate::UEQ: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::Or,
-                         .inputPorts = {{Port::Eq, /*inverted=*/false},
-                                        {Port::Unordered, /*inverted=*/false}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::Or;
+    predInfo.inputPorts = {{Port::Eq, /*inverted=*/false},
+                           {Port::Unordered, /*inverted=*/false}};
+    return predInfo;
   }
   case CmpFPredicate::UGT: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::Or,
-                         .inputPorts = {{Port::Gt, /*inverted=*/false},
-                                        {Port::Unordered, /*inverted=*/false}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::Or;
+    predInfo.inputPorts = {{Port::Gt, /*inverted=*/false},
+                           {Port::Unordered, /*inverted=*/false}};
+    return predInfo;
   }
   case CmpFPredicate::UGE: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::Or,
-                         .inputPorts = {{Port::Lt, /*inverted=*/true},
-                                        {Port::Unordered, /*inverted=*/false}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::Or;
+    predInfo.inputPorts = {{Port::Lt, /*inverted=*/true},
+                           {Port::Unordered, /*inverted=*/false}};
+    return predInfo;
   }
   case CmpFPredicate::ULT: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::Or,
-                         .inputPorts = {{Port::Lt, /*inverted=*/false},
-                                        {Port::Unordered, /*inverted=*/false}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::Or;
+    predInfo.inputPorts = {{Port::Lt, /*inverted=*/false},
+                           {Port::Unordered, /*inverted=*/false}};
+    return predInfo;
   }
   case CmpFPredicate::ULE: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::Or,
-                         .inputPorts = {{Port::Gt, /*inverted=*/true},
-                                        {Port::Unordered, /*inverted=*/false}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::Or;
+    predInfo.inputPorts = {{Port::Gt, /*inverted=*/true},
+                           {Port::Unordered, /*inverted=*/false}};
+    return predInfo;
   }
   case CmpFPredicate::UNE: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::Or,
-                         .inputPorts = {{Port::Eq, /*inverted=*/true},
-                                        {Port::Unordered, /*inverted=*/false}}};
-    break;
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::Or;
+    predInfo.inputPorts = {{Port::Eq, /*inverted=*/true},
+                           {Port::Unordered, /*inverted=*/false}};
+    return predInfo;
   }
   case CmpFPredicate::UNO: {
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::None,
-                         .inputPorts = {{Port::Unordered, /*inverted=*/false}}};
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::None;
+    predInfo.inputPorts = {{Port::Unordered, /*inverted=*/false}};
+    return predInfo;
   }
   case CmpFPredicate::AlwaysTrue:
-  case CmpFPredicate::AlwaysFalse:
-    return PredicateInfo{.logic = PredicateInfo::CombLogic::None};
-    break;
+  case CmpFPredicate::AlwaysFalse: {
+    auto predInfo = PredicateInfo();
+    predInfo.logic = PredicateInfo::CombLogic::None;
+    return predInfo;
+  }
   }
 
   return info;

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -852,73 +852,88 @@ PredicateInfo getPredicateInfo(CmpFPredicate pred) {
     info.logic = CombLogic::And;
     info.inputPorts = {{Port::Eq, /*inverted=*/false},
                        {Port::Unordered, /*inverted=*/true}};
+    break;
   }
   case CmpFPredicate::OGT: {
     info.logic = PredicateInfo::CombLogic::And;
     info.inputPorts = {{Port::Gt, /*inverted=*/false},
                        {Port::Unordered, /*inverted=*/true}};
+    break;
   }
   case CmpFPredicate::OGE: {
     info.logic = PredicateInfo::CombLogic::And;
     info.inputPorts = {{Port::Lt, /*inverted=*/true},
                        {Port::Unordered, /*inverted=*/true}};
+    break;
   }
   case CmpFPredicate::OLT: {
     info.logic = PredicateInfo::CombLogic::And;
     info.inputPorts = {{Port::Lt, /*inverted=*/false},
                        {Port::Unordered, /*inverted=*/true}};
+    break;
   }
   case CmpFPredicate::OLE: {
     info.logic = PredicateInfo::CombLogic::And;
     info.inputPorts = {{Port::Gt, /*inverted=*/true},
                        {Port::Unordered, /*inverted=*/true}};
+    break;
   }
   case CmpFPredicate::ONE: {
     info.logic = PredicateInfo::CombLogic::And;
     info.inputPorts = {{Port::Eq, /*inverted=*/true},
                        {Port::Unordered, /*inverted=*/true}};
+    break;
   }
   case CmpFPredicate::ORD: {
     info.logic = PredicateInfo::CombLogic::None;
     info.inputPorts = {{Port::Unordered, /*inverted=*/true}};
+    break;
   }
   case CmpFPredicate::UEQ: {
     info.logic = PredicateInfo::CombLogic::Or;
     info.inputPorts = {{Port::Eq, /*inverted=*/false},
                        {Port::Unordered, /*inverted=*/false}};
+    break;
   }
   case CmpFPredicate::UGT: {
     info.logic = PredicateInfo::CombLogic::Or;
     info.inputPorts = {{Port::Gt, /*inverted=*/false},
                        {Port::Unordered, /*inverted=*/false}};
+    break;
   }
   case CmpFPredicate::UGE: {
     info.logic = PredicateInfo::CombLogic::Or;
     info.inputPorts = {{Port::Lt, /*inverted=*/true},
                        {Port::Unordered, /*inverted=*/false}};
+    break;
   }
   case CmpFPredicate::ULT: {
     info.logic = PredicateInfo::CombLogic::Or;
     info.inputPorts = {{Port::Lt, /*inverted=*/false},
                        {Port::Unordered, /*inverted=*/false}};
+    break;
   }
   case CmpFPredicate::ULE: {
     info.logic = PredicateInfo::CombLogic::Or;
     info.inputPorts = {{Port::Gt, /*inverted=*/true},
                        {Port::Unordered, /*inverted=*/false}};
+    break;
   }
   case CmpFPredicate::UNE: {
     info.logic = PredicateInfo::CombLogic::Or;
     info.inputPorts = {{Port::Eq, /*inverted=*/true},
                        {Port::Unordered, /*inverted=*/false}};
+    break;
   }
   case CmpFPredicate::UNO: {
     info.logic = PredicateInfo::CombLogic::None;
     info.inputPorts = {{Port::Unordered, /*inverted=*/false}};
+    break;
   }
   case CmpFPredicate::AlwaysTrue:
   case CmpFPredicate::AlwaysFalse:
     info.logic = PredicateInfo::CombLogic::None;
+    break;
   }
 
   return info;


### PR DESCRIPTION
#7860 broke Windows CI as it uses designated initializers which are c++ 20 - this just reformats the bits where they were used.