### PR TITLE
[SMT] Add set_logic operation

### DIFF
--- a/include/circt/Dialect/SMT/SMTOps.td
+++ b/include/circt/Dialect/SMT/SMTOps.td
@@ -147,6 +147,12 @@ def SolverOp : SMTOp<"solver", [
   let hasRegionVerifier = true;
 }
 
+def SetLogicOp : SMTOp<"set_logic", []> {
+  let summary = "set the logic for the SMT solver";
+  let arguments = (ins StrAttr:$logic);
+  let assemblyFormat = "$logic attr-dict";
+}
+
 def AssertOp : SMTOp<"assert", []> {
   let summary = "assert that a boolean expression holds";
   let arguments = (ins BoolType:$input);

--- a/include/circt/Dialect/SMT/SMTVisitors.h
+++ b/include/circt/Dialect/SMT/SMTVisitors.h
@@ -44,7 +44,7 @@ public:
             // Variable/symbol declaration
             DeclareFunOp, ApplyFuncOp,
             // solver interaction
-            SolverOp, AssertOp, ResetOp, PushOp, PopOp, CheckOp,
+            SolverOp, AssertOp, ResetOp, PushOp, PopOp, CheckOp, SetLogicOp,
             // Boolean logic
             NotOp, AndOp, OrOp, XOrOp, ImpliesOp,
             // Arrays
@@ -128,6 +128,7 @@ public:
   HANDLE(PushOp, Unhandled);
   HANDLE(PopOp, Unhandled);
   HANDLE(CheckOp, Unhandled);
+  HANDLE(SetLogicOp, Unhandled);
 
   // Boolean logic operations
   HANDLE(NotOp, Unhandled);

--- a/integration_test/Target/ExportSMTLIB/basic.mlir
+++ b/integration_test/Target/ExportSMTLIB/basic.mlir
@@ -172,3 +172,20 @@ smt.solver () : () -> () {
 // CHECK-NOT: error
 // CHECK-NOT: unsat
 // CHECK: sat
+
+smt.solver () : () -> () {
+  smt.set_logic "HORN"
+  %c = smt.declare_fun : !smt.int
+  %c4 = smt.int.constant 4
+  %eq = smt.eq %c, %c4 : !smt.int
+  smt.assert %eq
+  smt.check sat {} unknown {} unsat {}
+}
+
+// CHECK-NOT: WARNING
+// CHECK-NOT: warning
+// CHECK-NOT: ERROR
+// CHECK-NOT: error
+// CHECK-NOT: unsat
+// CHECK-NOT: sat
+// CHECK: unknown

--- a/lib/Target/ExportSMTLIB/ExportSMTLIB.cpp
+++ b/lib/Target/ExportSMTLIB/ExportSMTLIB.cpp
@@ -592,6 +592,12 @@ struct StatementVisitor
     return success();
   }
 
+  LogicalResult visitSMTOp(SetLogicOp op, mlir::raw_indented_ostream &stream,
+                           ValueMap &valueMap) {
+    stream << "(set-logic " << op.getLogic() << ")\n";
+    return success();
+  }
+
   LogicalResult visitUnhandledSMTOp(Operation *op,
                                     mlir::raw_indented_ostream &stream,
                                     ValueMap &valueMap) {

--- a/test/Dialect/SMT/basic.mlir
+++ b/test/Dialect/SMT/basic.mlir
@@ -65,6 +65,13 @@ func.func @core(%in: i8) {
   // CHECK-NEXT: }
   smt.solver() : () -> () { }
 
+  // CHECK: smt.solver() : () -> () {
+  // CHECK-NEXT: smt.set_logic "AUFLIA"
+  // CHECK-NEXT: }
+  smt.solver() : () -> () {
+    smt.set_logic "AUFLIA"
+  }
+
   //      CHECK: smt.check sat {
   // CHECK-NEXT: } unknown {
   // CHECK-NEXT: } unsat {

--- a/test/Target/ExportSMTLIB/core.mlir
+++ b/test/Target/ExportSMTLIB/core.mlir
@@ -128,6 +128,10 @@ smt.solver () : () -> () {
   // CHECK-INLINED: (pop 1)
   smt.pop 1
 
+  // CHECK: (set-logic AUFLIA)
+  // CHECK-INLINED: (set-logic AUFLIA)
+  smt.set_logic "AUFLIA"
+
   // CHECK: (reset)
   // CHECK-INLINED: (reset)
 }


### PR DESCRIPTION
Adds an operation to set the logic to be used by the SMT solver. I'll put the lowering to Z3 in a follow-up PR after this one since it requires some extra checks due to limitations on what Z3 allows so it has a larger diff.