### PR TITLE
[firtool] Add an option to disable CSE in classes

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -218,6 +218,10 @@ MLIR_CAPI_EXPORTED void
 circtFirtoolOptionsSetStripDebugInfo(CirctFirtoolFirtoolOptions options,
                                      bool value);
 
+MLIR_CAPI_EXPORTED void
+circtFirtoolOptionsSetDisableCSEinClasses(CirctFirtoolFirtoolOptions options,
+                                          bool value);
+
 //===----------------------------------------------------------------------===//
 // Populate API.
 //===----------------------------------------------------------------------===//

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -131,6 +131,7 @@ public:
   bool shouldExtractTestCode() const { return extractTestCode; }
   bool shouldFixupEICGWrapper() const { return fixupEICGWrapper; }
   bool shouldAddCompanionAssume() const { return addCompanionAssume; }
+  bool shouldDisableCSEinClasses() const { return disableCSEinClasses; }
 
   // Setters, used by the CAPI
   FirtoolOptions &setOutputFilename(StringRef name) {
@@ -356,6 +357,11 @@ public:
     return *this;
   }
 
+  FirtoolOptions &setDisableCSEinClasses(bool value) {
+    disableCSEinClasses = value;
+    return *this;
+  }
+
 private:
   std::string outputFilename;
   bool disableAnnotationsUnknown;
@@ -402,6 +408,7 @@ private:
   bool stripDebugInfo;
   bool fixupEICGWrapper;
   bool addCompanionAssume;
+  bool disableCSEinClasses;
 };
 
 void registerFirtoolCLOptions();

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -311,6 +311,12 @@ void circtFirtoolOptionsSetStripDebugInfo(CirctFirtoolFirtoolOptions options,
   unwrap(options)->setStripDebugInfo(value);
 }
 
+void circtFirtoolOptionsSetDisableCSEinClasses(
+    CirctFirtoolFirtoolOptions options, bool value) {
+
+  unwrap(options)->setDisableCSEinClasses(value);
+}
+
 //===----------------------------------------------------------------------===//
 // Populate API.
 //===----------------------------------------------------------------------===//

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -59,8 +59,13 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
 
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInjectDUTHierarchyPass());
 
-  if (!opt.shouldDisableOptimization())
-    pm.nest<firrtl::CircuitOp>().nestAny().addPass(mlir::createCSEPass());
+  if (!opt.shouldDisableOptimization()) {
+    if (opt.shouldDisableCSEinClasses())
+      pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
+          mlir::createCSEPass());
+    else
+      pm.nest<firrtl::CircuitOp>().nestAny().addPass(mlir::createCSEPass());
+  }
 
   pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
       firrtl::createPassiveWiresPass());
@@ -764,8 +769,8 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       ckgModuleName("EICG_wrapper"), ckgInputName("in"), ckgOutputName("out"),
       ckgEnableName("en"), ckgTestEnableName("test_en"), ckgInstName("ckg"),
       exportModuleHierarchy(false), stripFirDebugInfo(true),
-      stripDebugInfo(false), fixupEICGWrapper(false),
-      addCompanionAssume(false) {
+      stripDebugInfo(false), fixupEICGWrapper(false), addCompanionAssume(false),
+      disableCSEinClasses(false) {
   if (!clOptions.isConstructed())
     return;
   outputFilename = clOptions->outputFilename;


### PR DESCRIPTION
This PR adds the option to run CSE only on `firrtl.module`, and ignore everything else.
There are some tools, that are not able to handle CSE of `firrtl.object` in `firrtl.class`. 
Specifically, the reuse of `firrtl.object` is not modeled properly.
This is a temporary workaround to disable the CSE of operations inside `firrtl.class`, which can be removed once the actual issue in the tool is fixed.