### PR TITLE
[DC] Add unused fork result elimination canonicalizer

### DIFF
--- a/lib/Dialect/DC/DCOps.cpp
+++ b/lib/Dialect/DC/DCOps.cpp
@@ -138,7 +138,7 @@ public:
 
         // We have a fork feeding into another fork. Replace the output fork by
         // adding more outputs to the current fork.
-        size_t totalForks = fork.getNumResults() + userFork.getNumResults() - 1;
+        size_t totalForks = fork.getNumResults() + userFork.getNumResults();
 
         auto newFork = rewriter.create<dc::ForkOp>(fork.getLoc(),
                                                    fork.getToken(), totalForks);

--- a/lib/Dialect/DC/DCOps.cpp
+++ b/lib/Dialect/DC/DCOps.cpp
@@ -188,7 +188,7 @@ struct EliminateUnusedForkResultsPattern : mlir::OpRewritePattern<ForkOp> {
     std::set<unsigned> unusedIndexes;
 
     for (auto res : llvm::enumerate(op.getResults()))
-      if (res.value().getUses().empty())
+      if (res.value().use_empty())
         unusedIndexes.insert(res.index());
 
     if (unusedIndexes.empty())

--- a/test/Dialect/DC/canonicalization.mlir
+++ b/test/Dialect/DC/canonicalization.mlir
@@ -80,12 +80,11 @@ func.func @csePack(%a: !dc.token, %b : i32) -> (!dc.value<i32>, !dc.value<i32>) 
 }
 
 
-// TODO: I'm 90% sure this canonicalizer and test are broken. Investigate.
 // CHECK-LABEL:   func.func @forkToFork(
 // CHECK-SAME:                          %[[VAL_0:.*]]: !dc.token) -> (!dc.token, !dc.token, !dc.token) {
-// CHECKx:           %[[VAL_1:.*]]:3 = dc.fork [3] %[[VAL_0]]
-// CHECKx:           return %[[VAL_1]]#1, %[[VAL_1]]#1, %[[VAL_1]]#2 : !dc.token, !dc.token, !dc.token
-// CHECKx:         }
+// CHECK:           %[[VAL_1:.*]]:3 = dc.fork [3] %[[VAL_0]]
+// CHECK:           return %[[VAL_1]]#0, %[[VAL_1]]#1, %[[VAL_1]]#2 : !dc.token, !dc.token, !dc.token
+// CHECK:         }
 func.func @forkToFork(%a: !dc.token) -> (!dc.token, !dc.token, !dc.token) {
     %0, %1 = dc.fork [2] %a
     %2, %3 = dc.fork [2] %0

--- a/test/Dialect/DC/canonicalization.mlir
+++ b/test/Dialect/DC/canonicalization.mlir
@@ -1,5 +1,4 @@
 // RUN: circt-opt %s --canonicalize --cse --canonicalize | FileCheck %s
-// XFAIL: *
 // Waiting on: https://github.com/llvm/llvm-project/issues/64280
 
 // CHECK-LABEL:   func.func @staggeredJoin1(
@@ -14,11 +13,12 @@ func.func @staggeredJoin1(%a: !dc.token, %b : !dc.token) -> (!dc.token) {
     return %1 : !dc.token
 }
 
+// TODO: For some reason, the canonicalizer no longer combines the two joins. Investigate.
 // CHECK-LABEL:   func.func @staggeredJoin2(
 // CHECK-SAME:           %[[VAL_0:.*]]: !dc.token, %[[VAL_1:.*]]: !dc.token, %[[VAL_2:.*]]: !dc.token, %[[VAL_3:.*]]: !dc.token) -> !dc.token {
-// CHECK:           %[[VAL_4:.*]] = dc.join %[[VAL_2]], %[[VAL_3]], %[[VAL_0]], %[[VAL_1]]
-// CHECK:           return %[[VAL_4]] : !dc.token
-// CHECK:         }
+// CHECKx:           %[[VAL_4:.*]] = dc.join %[[VAL_2]], %[[VAL_3]], %[[VAL_0]], %[[VAL_1]]
+// CHECKx:           return %[[VAL_4]] : !dc.token
+// CHECKx:         }
 func.func @staggeredJoin2(%a: !dc.token, %b : !dc.token, %c : !dc.token, %d : !dc.token) -> (!dc.token) {
     %0 = dc.join %a, %b
     %1 = dc.join %c, %0, %d
@@ -80,11 +80,12 @@ func.func @csePack(%a: !dc.token, %b : i32) -> (!dc.value<i32>, !dc.value<i32>) 
 }
 
 
+// TODO: I'm 90% sure this canonicalizer and test are broken. Investigate.
 // CHECK-LABEL:   func.func @forkToFork(
 // CHECK-SAME:                          %[[VAL_0:.*]]: !dc.token) -> (!dc.token, !dc.token, !dc.token) {
-// CHECK:           %[[VAL_1:.*]]:3 = dc.fork [3] %[[VAL_0]]
-// CHECK:           return %[[VAL_1]]#1, %[[VAL_1]]#1, %[[VAL_1]]#2 : !dc.token, !dc.token, !dc.token
-// CHECK:         }
+// CHECKx:           %[[VAL_1:.*]]:3 = dc.fork [3] %[[VAL_0]]
+// CHECKx:           return %[[VAL_1]]#1, %[[VAL_1]]#1, %[[VAL_1]]#2 : !dc.token, !dc.token, !dc.token
+// CHECKx:         }
 func.func @forkToFork(%a: !dc.token) -> (!dc.token, !dc.token, !dc.token) {
     %0, %1 = dc.fork [2] %a
     %2, %3 = dc.fork [2] %0
@@ -102,11 +103,13 @@ func.func @forkToFork2(%a: !dc.token) -> (!dc.token, !dc.token, !dc.token) {
     return %0, %2, %3 : !dc.token, !dc.token, !dc.token
 }
 
+// TODO: For some reason, the canonicalizer no longer simplifies this redundant
+// triangle pattern. Investigate.
 // CHECK-LABEL:   func.func @merge(
 // CHECK-SAME:                     %[[VAL_0:.*]]: !dc.value<i1>) -> !dc.token {
-// CHECK:           %[[VAL_1:.*]], %[[VAL_2:.*]] = dc.unpack %[[VAL_0]] : !dc.value<i1>
-// CHECK:           return %[[VAL_1]] : !dc.token
-// CHECK:         }
+// CHECKx:           %[[VAL_1:.*]], %[[VAL_2:.*]] = dc.unpack %[[VAL_0]] : !dc.value<i1>
+// CHECKx:           return %[[VAL_1]] : !dc.token
+// CHECKx:         }
 func.func @merge(%sel : !dc.value<i1>) -> (!dc.token) {
     // Canonicalize away a merge that is fed by a branch with the same select
     // input.
@@ -115,12 +118,14 @@ func.func @merge(%sel : !dc.value<i1>) -> (!dc.token) {
     return %0 : !dc.token
 }
 
+// TODO: For some reason, the canonicalizer no longer removes the source->join
+// pattern. Investigate.
 // CHECK-LABEL:   func.func @joinOnSource(
 // CHECK-SAME:                            %[[VAL_0:.*]]: !dc.token,
 // CHECK-SAME:                            %[[VAL_1:.*]]: !dc.token) -> !dc.token {
-// CHECK:           %[[VAL_2:.*]] = dc.join %[[VAL_0]], %[[VAL_1]]
-// CHECK:           return %[[VAL_2]] : !dc.token
-// CHECK:         }
+// CHECKx:           %[[VAL_2:.*]] = dc.join %[[VAL_0]], %[[VAL_1]]
+// CHECKx:           return %[[VAL_2]] : !dc.token
+// CHECKx:         }
 func.func @joinOnSource(%a : !dc.token, %b : !dc.token) -> (!dc.token) {
     %0 = dc.source
     %out = dc.join %a, %0, %b
@@ -135,4 +140,18 @@ func.func @forkOfSource() -> (!dc.token, !dc.token) {
     %0 = dc.source
     %1:2 = dc.fork [2] %0
     return %1#0, %1#1 : !dc.token, !dc.token
+}
+
+// CHECK-LABEL:  hw.module @TestForkCanonicalization(in %arg0 : !dc.token, out out0 : !dc.token, out out1 : !dc.token) {
+// CHECK-NEXT:       [[R0:%.+]]:2 = dc.fork [2] %arg0
+// CHECK-NEXT:       [[R1:%.+]] = dc.buffer[4] [[R0]]#0 : !dc.token
+// CHECK-NEXT:       [[R2:%.+]] = dc.buffer[4] [[R0]]#1 : !dc.token
+// CHECK-NEXT:       hw.output [[R1]], [[R2]] : !dc.token, !dc.token
+
+hw.module @TestForkCanonicalization(in %arg0: !dc.token, out out0: !dc.token, out out1: !dc.token) {
+  %0:3 = dc.fork [3] %arg0
+  %1 = dc.buffer [4] %0#1 : !dc.token
+  %2 = dc.buffer [4] %0#2 : !dc.token
+  dc.sink %0#2
+  hw.output %1, %2 : !dc.token, !dc.token
 }


### PR DESCRIPTION
Adding a canonicalizer to remove unused results from forks. Required to get valid post-canonicalization IR. Also, narrow the scope of "XFAIL"s in canonicalizer test to add new one.