### PR TITLE
[HWToBTOR2] Generate register initial constant before state declaration

### DIFF
--- a/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
+++ b/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
@@ -885,9 +885,9 @@ public:
     // btor2
     auto init = reg.getInitialValue();
 
-    // Generate state instruction (represents the register declaration)
-    genState(reg, w, regName);
-
+    // If there's an initial value, we need to generate a constant for the
+    // initial value, then declare the state, then generate the init statement
+    // (BTOR2 parsers are picky about it being in this order)
     if (init) {
       if (!init.getDefiningOp<seq::InitialOp>()) {
         reg->emitError(
@@ -906,8 +906,14 @@ public:
       // Add it to the list of visited operations
       handledOps.insert(initialConstant);
 
+      // Now we can declare the state
+      genState(reg, w, regName);
+
       // Finally generate the init statement
       genInit(reg, initialConstant, w);
+    } else {
+      // Just generate state instruction (represents the register declaration)
+      genState(reg, w, regName);
     }
 
     // Record the operation for future `next` instruction generation

--- a/test/Conversion/HWToBTOR2/compreg.mlir
+++ b/test/Conversion/HWToBTOR2/compreg.mlir
@@ -8,8 +8,8 @@ module {
     %0 = seq.from_clock %clock
     // Registers are all emitted before any other operation
     //CHECK:    [[NID6:[0-9]+]] sort bitvec 32
-    //CHECK:    [[NID12:[0-9]+]] state [[NID6]] count
     //CHECK:    [[INITCONST:[0-9]+]] constd [[NID6]] 0
+    //CHECK:    [[NID12:[0-9]+]] state [[NID6]] count
     //CHECK:    [[INIT:[0-9]+]] init [[NID6]] [[NID12]] [[INITCONST]]
     //CHECK:    [[REG2NID:[0-9]+]] state [[NID6]] count2
     //CHECK-NOT: [[INITCONST]] constd [[NID6]] 0

--- a/test/Conversion/HWToBTOR2/init.mlir
+++ b/test/Conversion/HWToBTOR2/init.mlir
@@ -4,10 +4,10 @@ module {
   //CHECK:    [[NID0:[0-9]+]] sort bitvec 1
   //CHECK:    [[NID1:[0-9]+]] input [[NID0]] reset
   hw.module @test(in %clock : !seq.clock, in %reset : i1) {
-    // Register states get pregenerated
-    //CHECK:    [[NID2:[0-9]+]] state [[NID0]] reg
     %0 = seq.from_clock %clock 
     //CHECK:    [[NID3:[0-9]+]] constd [[NID0]] 0
+    // Register states get pregenerated
+    //CHECK:    [[NID2:[0-9]+]] state [[NID0]] reg
     %false = hw.constant false
     //CHECK:    [[INIT:[0-9]+]] init [[NID0]] [[NID2]] [[NID3]]
     %init = seq.initial() {

--- a/test/firtool/btor2-assertproperty.fir
+++ b/test/firtool/btor2-assertproperty.fir
@@ -24,9 +24,9 @@ circuit Counter :
 ; CHECK:  2 input 1 reset
 ; CHECK:  3 sort bitvec 32
 ; CHECK:  4 state 3 count
-; CHECK:  5 state 1 hbr
-; CHECK:  6 constd 1 0
-; CHECK:  7 init 1 5 6
+; CHECK:  5 constd 1 0
+; CHECK:  6 state 1 hbr
+; CHECK:  7 init 1 6 5
 ; CHECK:  8 constd 3 1
 ; CHECK:  9 constd 3 10
 ; CHECK:  10 constd 3 22
@@ -36,12 +36,12 @@ circuit Counter :
 ; CHECK:  14 ite 3 12 11 13
 ; CHECK:  15 neq 1 4 9
 ; CHECK:  16 constd 1 -1
-; CHECK:  17 or 1 2 5
+; CHECK:  17 or 1 2 6
 ; CHECK:  18 xor 1 2 16
-; CHECK:  19 and 1 5 18
+; CHECK:  19 and 1 6 18
 ; CHECK:  20 implies 1 19 15
 ; CHECK:  21 not 1 20
 ; CHECK:  22 bad 21
 ; CHECK:  23 ite 3 2 11 14
 ; CHECK:  24 next 3 4 23
-; CHECK:  25 next 1 5 17
+; CHECK:  25 next 1 6 17


### PR DESCRIPTION
The BTOR2 parser in btor2tools (which seems to be the standard implementation) requires that in an init statement, the ID of the state must be higher than the ID of the initial value. Currently we don't adhere to this, so we generate BTOR2 that's not digestible by most tools.

E.g. we currently emit 

```
hw.module @breaks(in %clk: !seq.clock, in %in: i32) {
    %c0_i32 = seq.initial() {
        %0 = hw.constant 0 : i32
        seq.yield %0 : i32
    } : () -> !seq.immutable<i32>
    %reg = seq.compreg %input, %clk initial %c0_i32 : i32
    %input = comb.add %in, %in : i32
}
```

as 

```
1 sort bitvec 1
2 input 1 reset
3 state 1 reg
4 constd 1 0
5 init 1 3 4
6 constd 1 0
7 eq 1 3 6
8 not 1 7
9 bad 8
10 ite 1 2 6 6
11 next 1 3 10
```

and btormc throws the error `btormc: parse error in 'breaking.btor2' line 5: state id must be greater than id of second operand`. After this PR we generate 

```
1 sort bitvec 1
2 input 1 reset
3 constd 1 0
4 state 1 reg
5 init 1 4 3
6 constd 1 0
7 eq 1 4 6
8 not 1 7
9 bad 8
10 ite 1 2 6 6
11 next 1 4 10
```

which parses fine. This breaks a couple of tests that the PR also fixes (might be worth swapping the firtool BTOR2 tests to the normal regexed format at some point to make changes like this less painful).