### PR TITLE
[RTG] Generate separate doc files for ops and types

### DIFF
--- a/include/circt/Dialect/RTG/IR/CMakeLists.txt
+++ b/include/circt/Dialect/RTG/IR/CMakeLists.txt
@@ -1,8 +1,6 @@
 add_circt_dialect(RTG rtg)
-
-set(LLVM_TARGET_DEFINITIONS RTG.td)
-
-add_circt_dialect_doc(RTG rtg)
+add_circt_doc(RTG Dialects/RTGOps -gen-op-doc)
+add_circt_doc(RTG Dialects/RTGTypes -gen-typedef-doc -dialect rtg)
 
 set(LLVM_TARGET_DEFINITIONS RTGInterfaces.td)
 mlir_tablegen(RTGOpInterfaces.h.inc -gen-op-interface-decls)


### PR DESCRIPTION
This makes it properly includable in the rationale file. Overlooked this in the fix for https://github.com/llvm/circt/issues/7932. Sorry.

