### PR TITLE
[CombToAIG] Populate legal ops

### DIFF
--- a/lib/Conversion/CombToAIG/CombToAIG.cpp
+++ b/lib/Conversion/CombToAIG/CombToAIG.cpp
@@ -112,6 +112,8 @@ static void populateCombToAIGConversionPatterns(RewritePatternSet &patterns) {
 void ConvertCombToAIGPass::runOnOperation() {
   ConversionTarget target(getContext());
   target.addIllegalDialect<comb::CombDialect>();
+  // Keep data movement operations like Extract, Concat and Replicate.
+  target.addLegalOp<comb::ExtractOp, comb::ConcatOp, comb::ReplicateOp>();
   target.addLegalDialect<aig::AIGDialect>();
 
   RewritePatternSet patterns(&getContext());

--- a/test/Conversion/CombToAIG/comb-to-aig.mlir
+++ b/test/Conversion/CombToAIG/comb-to-aig.mlir
@@ -14,3 +14,17 @@ hw.module @test(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32, out 
   %2 = comb.xor %arg0, %arg1 : i32
   hw.output %0, %1, %2 : i32, i32, i32
 }
+
+// CHECK-LABEL: @pass
+hw.module @pass(in %arg0: i32, in %arg1: i1, out out: i2) {
+  // CHECK-NEXT: %[[EXTRACT:.*]] = comb.extract %arg0 from 2 : (i32) -> i2
+  // CHECK-NEXT: %[[REPLICATE:.*]] = comb.replicate %arg1 : (i1) -> i2
+  // CHECK-NEXT: %[[CONCAT:.*]] = comb.concat %arg1, %arg1 : i1, i1
+  // CHECK-NEXT: %[[AND3:.*]] = aig.and_inv %[[EXTRACT]], %[[REPLICATE]], %[[CONCAT]] : i2
+  // CHECK-NEXT: hw.output %[[AND3]] : i2
+  %0 = comb.extract %arg0 from 2 : (i32) -> i2
+  %1 = comb.replicate %arg1 : (i1) -> i2
+  %2 = comb.concat %arg1, %arg1 : i1, i1
+  %3 = comb.and %0, %1, %2 : i2
+  hw.output %3 : i2
+}


### PR DESCRIPTION
Static data-movement operations (extarct, concat and replicate) are legal in AIG level so just allow them.
