### PR TITLE
[FIRRTL] Clock gate extraction work w/ prefixing

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -862,9 +862,9 @@ Example:
 | group       | string | Name of an optional wrapper module under which to group extracted instances |
 
 This annotation causes the `ExtractInstances` pass to move instances of
-extmodules with defname `EICG_wrapper` upwards in the hierarchy, either out of
-the DUT if `group` is omitted or empty, or into a submodule of the DUT with the
-name given in `group`. The wiring prefix is hard-coded to `clock_gate`.
+extmodules whose defnames end in `EICG_wrapper` upwards in the hierarchy, either
+out of the DUT if `group` is omitted or empty, or into a submodule of the DUT
+with the name given in `group`. The wiring prefix is hard-coded to `clock_gate`.
 
 Applies to the circuit.
 

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -352,14 +352,15 @@ void ExtractInstancesPass::collectAnnos() {
     collectAnno(inst, instAnnos[0]);
   });
 
-  // If clock gate extraction is requested, find instances of extmodules with
-  // the corresponding `defname` and mark them as to be extracted.
-  // TODO: This defname really shouldn't be hardcoded here. Make this at least
-  // somewhat configurable.
+  // If clock gate extraction is requested, find instances of extmodules which
+  // have a defname that ends with "EICG_wrapper".  This also allows this to
+  // compose with Chisel-time module prefixing.
+  //
+  // TODO: This defname matching is a terrible hack and should be replaced with
+  // something better.
   if (!clkgateFileName.empty()) {
-    auto clkgateDefNameAttr = StringAttr::get(&getContext(), "EICG_wrapper");
     for (auto module : circuit.getOps<FExtModuleOp>()) {
-      if (module.getDefnameAttr() != clkgateDefNameAttr)
+      if (!module.getDefnameAttr().getValue().ends_with("EICG_wrapper"))
         continue;
       LLVM_DEBUG(llvm::dbgs()
                  << "Clock gate `" << module.getModuleName() << "`\n");


### PR DESCRIPTION
Weaken the check used by the `ExtractInstances` pass to determine what is a clock gate.  Change this from requiring that the defname of an external module is exactly "EICG_wrapper" to instead only needing to end with "EICG_wrapper".  This is done so that this will work with Chisel-time prefixing and that we would actually _like_ to prefix these clock gates.

Commentary: this string matching is terrible.  I realize that.  However, this is a legacy API that is intending to be replaced.