### PR TITLE
[ExportVerilog] Fix ifdef of macro w/ Verilog name

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -866,6 +866,12 @@ def MacroDeclOp : SVOp<"macro.decl", [Symbol]> {
   let assemblyFormat = [{
     $sym_name (`[` $verilogName^ `]`)? (`(` $args^ `)`)?  attr-dict
   }];
+
+  let extraClassDeclaration = [{
+    // Return the Verilog "text macro identifier".  This will be either the
+    // Verilog name, if one was provided or the symbol name.
+    StringRef getMacroIdentifier();
+  }];
 }
 
 
@@ -931,7 +937,7 @@ def FuncOp : SVOp<"func",
      [IsolatedFromAbove, Symbol, OpAsmOpInterface, ProceduralRegion,
       DeclareOpInterfaceMethods<HWModuleLike>,
       DeclareOpInterfaceMethods<PortList>,
-      FunctionOpInterface, HasParent<"mlir::ModuleOp">, 
+      FunctionOpInterface, HasParent<"mlir::ModuleOp">,
       HWEmittableModuleLike]> {
   let summary = "A SystemVerilog function";
   let description = [{

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -5007,7 +5007,9 @@ LogicalResult StmtEmitter::emitIfDef(Operation *op, MacroIdentAttr cond) {
   if (hasSVAttributes(op))
     emitError(op, "SV attributes emission is unimplemented for the op");
 
-  auto ident = PPExtString(cond.getName());
+  auto ident = PPExtString(
+      cast<MacroDeclOp>(state.symbolCache.getDefinition(cond.getIdent()))
+          .getMacroIdentifier());
 
   startStatement();
   bool hasEmptyThen = op->getRegion(0).front().empty();

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -203,6 +203,14 @@ LogicalResult MacroRefOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
+// MacroDeclOp
+//===----------------------------------------------------------------------===//
+
+StringRef MacroDeclOp::getMacroIdentifier() {
+  return getVerilogName().value_or(getSymName());
+}
+
+//===----------------------------------------------------------------------===//
 // ConstantXOp / ConstantZOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -771,6 +771,20 @@ hw.module @W422_Foo() {
   hw.output
 }
 
+sv.macro.decl @MacroWithoutVerilogName
+sv.macro.decl @MacroWithVerilogName["A"]
+// CHECK-LABEL: module ModuleUsingMacroWithVerilogName(
+hw.module @ModuleUsingMacroWithVerilogName(in %a : i1) {
+  // CHECK: `ifdef MacroWithoutVerilogName
+  sv.ifdef @MacroWithoutVerilogName {
+    %b = hw.wire %a : i1
+  }
+  // CHECK: `ifdef A
+  sv.ifdef @MacroWithVerilogName {
+    %b = hw.wire %a : i1
+  }
+}
+
 hw.module @BindInterface() {
   %bar = sv.interface.instance sym @__Interface__ {doNotPrint} : !sv.interface<@Interface>
   hw.output


### PR DESCRIPTION
Add a utility function to `sv.macro.decl` that can be used to get its
Verilog textual macro identifier name.  This is added for convenience to
avoid having to repeat the patter of getting its optional Verilog name or
symbol name.

This is done to fix an issue related to lowering of FIRRTL inline layers
where the `LowerLayers` pass generates new `sv.macro.decl` symbols that
will replace existing `firrtl.layer` symbols.  However, it relies on a
namespace to generate these and will result in suffixed symbol names.  (It
could obviously do more work to conserve symbols or generate in-pass
invalid IR with duplicate symbols.)  Nonetheless, the real bug here is
that the `ExportVerilog` conversion is not doing the right thing with the
Verilog name attribute.