### PR TITLE
[SMT] Require SolverOp parent for SetLogicOp

### DIFF
--- a/include/circt/Dialect/SMT/SMTOps.td
+++ b/include/circt/Dialect/SMT/SMTOps.td
@@ -147,7 +147,9 @@ def SolverOp : SMTOp<"solver", [
   let hasRegionVerifier = true;
 }
 
-def SetLogicOp : SMTOp<"set_logic", []> {
+def SetLogicOp : SMTOp<"set_logic", [
+  HasParent<"smt::SolverOp">,
+]> {
   let summary = "set the logic for the SMT solver";
   let arguments = (ins StrAttr:$logic);
   let assemblyFormat = "$logic attr-dict";

--- a/test/Dialect/SMT/core-errors.mlir
+++ b/test/Dialect/SMT/core-errors.mlir
@@ -487,3 +487,11 @@ func.func @negative_pop() {
   smt.pop -1
   return
 }
+
+// -----
+
+func.func @set_logic_outside_solver() {
+  // expected-error @below {{'smt.set_logic' op expects parent op 'smt.solver'}}
+  smt.set_logic "AUFLIA"
+  return
+}


### PR DESCRIPTION
Just adds a HasParent<SolverOp> requirement to SetLogicOp