### PR TITLE
[FirParser] Add instance choice selection as circt attribute

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -55,6 +55,7 @@ struct FIRParserOptions {
   std::vector<std::string> enableLayers;
   std::vector<std::string> disableLayers;
   std::optional<LayerSpecialization> defaultLayerSpecialization;
+  std::vector<std::string> selectInstanceChoice;
 };
 
 mlir::OwningOpRef<mlir::ModuleOp> importFIRFile(llvm::SourceMgr &sourceMgr,

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -36,7 +36,8 @@ def CircuitOp : FIRRTLOp<"circuit",
     DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations,
     OptionalAttr<SymbolRefArrayAttr>:$enable_layers,
     OptionalAttr<SymbolRefArrayAttr>:$disable_layers,
-    OptionalAttr<LayerSpecializationAttr>:$default_layer_specialization
+    OptionalAttr<LayerSpecializationAttr>:$default_layer_specialization,
+    OptionalAttr<ArrayAttr>:$select_inst_choice
   );
   let results = (outs);
   let regions = (region SizedRegion<1>:$body);

--- a/test/firtool/instchoice.fir
+++ b/test/firtool/instchoice.fir
@@ -1,6 +1,7 @@
-; RUN: firtool %s --parse-only | FileCheck %s
+; RUN: firtool %s --parse-only --select-instance-choice=Platform=ASIC | FileCheck %s
 
 FIRRTL version 4.1.0
+; CHECK: firrtl.circuit "Foo" attributes {select_inst_choice = ["Platform=ASIC"]} {
 circuit Foo:
   ; CHECK: firrtl.option @Platform
   option Platform:
@@ -21,7 +22,7 @@ circuit Foo:
   public module Foo:
     input clock: Clock
 
-    ; CHECK: %inst_clock = firrtl.instance_choice inst interesting_name @DefaultTarget
+    ; CHECK:      %inst_clock = firrtl.instance_choice inst interesting_name @DefaultTarget
     ; CHECK-SAME: alternatives @Platform {
     ; CHECK-SAME:   @FPGA -> @FPGATarget,
     ; CHECK-SAME:   @ASIC -> @ASICTarget

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -275,6 +275,13 @@ static llvm::cl::opt<LayerSpecializationOpt> defaultLayerSpecialization{
                    "Layers are enabled")),
     cl::init(LayerSpecializationOpt::None), cl::cat(mainCategory)};
 
+/// Specify the select option for specializing instance choice. Currently
+/// firtool does not support partially specified instance choice.
+static cl::list<std::string> selectInstanceChoice(
+    "select-instance-choice",
+    cl::desc("Options to specialize instance choice, in option=case format"),
+    cl::MiscFlags::CommaSeparated, cl::cat(mainCategory));
+
 /// Check output stream before writing bytecode to it.
 /// Warn and return true if output is known to be displayed.
 static bool checkBytecodeOutputToConsole(raw_ostream &os) {
@@ -370,6 +377,7 @@ static LogicalResult processBuffer(
     options.scalarizeExtModules = scalarizeExtModules;
     options.enableLayers = enableLayers;
     options.disableLayers = disableLayers;
+    options.selectInstanceChoice = selectInstanceChoice;
 
     switch (defaultLayerSpecialization) {
     case LayerSpecializationOpt::None:


### PR DESCRIPTION
Add a select option to firtool for instance choice specialization.
The specified select is added as an attribute on the `CircuitOp`.
The attribute is an array of strings, each string specifies the selected specialization for each option.
The `SpecializeOptions` pass will perform the error checking for the select options specified as the argument.
This PR is split from https://github.com/llvm/circt/pull/7933