### PR TITLE
[DC] Add + re-enable canonicalization patterns

### DIFF
--- a/include/circt/Dialect/DC/DCOps.td
+++ b/include/circt/Dialect/DC/DCOps.td
@@ -94,6 +94,7 @@ def JoinOp : DCOp<"join", [Commutative]> {
 
   let assemblyFormat = "$tokens attr-dict";
   let hasFolder = 1;
+  let hasCanonicalizer = 1;
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "mlir::ValueRange":$ins), [{


### PR DESCRIPTION
Various canonicalization patterns were implemented as fold methods. However, these had been turned off a while ago, due to an MLIR bug.

This PR moves the fold methods to actual canonicalization patterns, adds a new one (join on branch), and re-enables previously disabled tests.