### PR TITLE
[SCFToCalyx] `memref::getGlobalOp` write to json using explicit toString for path to fix Windows failed test

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -330,7 +330,7 @@ public:
         std::ofstream outFile(outFileName);
 
         if (!outFile.is_open()) {
-          llvm::errs() << "Unable to open file: " << outFileName
+          llvm::errs() << "Unable to open file: " << outFileName.string()
                        << " for writing\n";
           return failure();
         }


### PR DESCRIPTION
hopefully it fixes the Windows test, going to merge it directly

cc @cgyurgyik 