### PR TITLE
[InstanceChoice] Add a default override for unspecified options

### DIFF
--- a/include/circt-c/Firtool/Firtool.h
+++ b/include/circt-c/Firtool/Firtool.h
@@ -222,6 +222,9 @@ MLIR_CAPI_EXPORTED void
 circtFirtoolOptionsSetDisableCSEinClasses(CirctFirtoolFirtoolOptions options,
                                           bool value);
 
+MLIR_CAPI_EXPORTED void circtFirtoolOptionsSetSelectDefaultInstanceChoice(
+    CirctFirtoolFirtoolOptions options, bool value);
+
 //===----------------------------------------------------------------------===//
 // Populate API.
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -200,7 +200,8 @@ std::unique_ptr<mlir::Pass> createProbesToSignalsPass();
 
 std::unique_ptr<mlir::Pass> createSpecializeLayersPass();
 
-std::unique_ptr<mlir::Pass> createSpecializeOptionPass();
+std::unique_ptr<mlir::Pass>
+createSpecializeOptionPass(bool selectDefault = false);
 
 std::unique_ptr<mlir::Pass> createCreateCompanionAssume();
 

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -201,7 +201,7 @@ std::unique_ptr<mlir::Pass> createProbesToSignalsPass();
 std::unique_ptr<mlir::Pass> createSpecializeLayersPass();
 
 std::unique_ptr<mlir::Pass>
-createSpecializeOptionPass(bool selectDefault = false);
+createSpecializeOptionPass(bool selectDefaultInstanceChoice = false);
 
 std::unique_ptr<mlir::Pass> createCreateCompanionAssume();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -876,6 +876,10 @@ def SpecializeOption : Pass<"firrtl-specialize-option", "firrtl::CircuitOp"> {
   }];
   let constructor = "circt::firrtl::createSpecializeOptionPass()";
 
+  let options = [
+    Option<"selectDefault", "specialize-to-default-if-no-override", "bool", "false",
+      "Specialize instance choice to default, if no option selected.">,
+  ];
   let statistics = [
     Statistic<"numInstances", "num-instances",
       "Number of instances specialized">

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -877,7 +877,7 @@ def SpecializeOption : Pass<"firrtl-specialize-option", "firrtl::CircuitOp"> {
   let constructor = "circt::firrtl::createSpecializeOptionPass()";
 
   let options = [
-    Option<"selectDefault", "specialize-to-default-if-no-override", "bool", "false",
+    Option<"selectDefaultInstanceChoice", "select-default-for-unspecified-instance-choice", "bool", "false",
       "Specialize instance choice to default, if no option selected.">,
   ];
   let statistics = [

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -132,6 +132,9 @@ public:
   bool shouldFixupEICGWrapper() const { return fixupEICGWrapper; }
   bool shouldAddCompanionAssume() const { return addCompanionAssume; }
   bool shouldDisableCSEinClasses() const { return disableCSEinClasses; }
+  bool shouldSelectDefaultInstanceChoice() const {
+    return selectDefaultInstanceChoice;
+  }
 
   // Setters, used by the CAPI
   FirtoolOptions &setOutputFilename(StringRef name) {
@@ -362,6 +365,11 @@ public:
     return *this;
   }
 
+  FirtoolOptions &setSelectDefaultInstanceChoice(bool value) {
+    selectDefaultInstanceChoice = value;
+    return *this;
+  }
+
 private:
   std::string outputFilename;
   bool disableAnnotationsUnknown;
@@ -409,6 +417,7 @@ private:
   bool fixupEICGWrapper;
   bool addCompanionAssume;
   bool disableCSEinClasses;
+  bool selectDefaultInstanceChoice;
 };
 
 void registerFirtoolCLOptions();

--- a/lib/CAPI/Firtool/Firtool.cpp
+++ b/lib/CAPI/Firtool/Firtool.cpp
@@ -317,6 +317,11 @@ void circtFirtoolOptionsSetDisableCSEinClasses(
   unwrap(options)->setDisableCSEinClasses(value);
 }
 
+void circtFirtoolOptionsSetSelectDefaultInstanceChoice(
+    CirctFirtoolFirtoolOptions options, bool value) {
+  unwrap(options)->setSelectDefaultInstanceChoice(value);
+}
+
 //===----------------------------------------------------------------------===//
 // Populate API.
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
@@ -27,7 +27,7 @@ namespace {
 struct SpecializeOptionPass
     : public circt::firrtl::impl::SpecializeOptionBase<SpecializeOptionPass> {
   using SpecializeOptionBase::numInstances;
-  using SpecializeOptionBase::selectDefault;
+  using SpecializeOptionBase::selectDefaultInstanceChoice;
 
   void runOnOperation() override {
     auto circuit = getOperation();
@@ -69,7 +69,7 @@ struct SpecializeOptionPass
             auto it = selected.find(inst.getOptionNameAttr());
             FlatSymbolRefAttr target;
             if (it == selected.end()) {
-              if (!selectDefault) {
+              if (!selectDefaultInstanceChoice) {
                 inst.emitError("missing specialization for option ")
                     << inst.getOptionNameAttr();
                 failed = true;
@@ -107,8 +107,9 @@ struct SpecializeOptionPass
 };
 } // namespace
 
-std::unique_ptr<Pass> firrtl::createSpecializeOptionPass(bool selectDefault) {
+std::unique_ptr<Pass>
+firrtl::createSpecializeOptionPass(bool selectDefaultInstanceChoice) {
   auto pass = std::make_unique<SpecializeOptionPass>();
-  pass->selectDefault = selectDefault;
+  pass->selectDefaultInstanceChoice = selectDefaultInstanceChoice;
   return pass;
 }

--- a/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
@@ -27,6 +27,7 @@ namespace {
 struct SpecializeOptionPass
     : public circt::firrtl::impl::SpecializeOptionBase<SpecializeOptionPass> {
   using SpecializeOptionBase::numInstances;
+  using SpecializeOptionBase::selectDefault;
 
   void runOnOperation() override {
     auto circuit = getOperation();
@@ -66,20 +67,25 @@ struct SpecializeOptionPass
         &getContext(), circuit.getOps<FModuleOp>(), [&](auto module) {
           module.walk([&](firrtl::InstanceChoiceOp inst) {
             auto it = selected.find(inst.getOptionNameAttr());
+            FlatSymbolRefAttr target;
             if (it == selected.end()) {
-              inst.emitError("missing specialization for option ")
-                  << inst.getOptionNameAttr();
-              failed = true;
-              return;
-            }
+              if (!selectDefault) {
+                inst.emitError("missing specialization for option ")
+                    << inst.getOptionNameAttr();
+                failed = true;
+                return;
+              }
+              target = inst.getDefaultTargetAttr();
+            } else
+              target = inst.getTargetOrDefaultAttr(it->second);
 
             ImplicitLocOpBuilder builder(inst.getLoc(), inst);
             auto newInst = builder.create<InstanceOp>(
-                inst->getResultTypes(), inst.getTargetOrDefaultAttr(it->second),
-                inst.getNameAttr(), inst.getNameKindAttr(),
-                inst.getPortDirectionsAttr(), inst.getPortNamesAttr(),
-                inst.getAnnotationsAttr(), inst.getPortAnnotationsAttr(),
-                builder.getArrayAttr({}), UnitAttr{}, inst.getInnerSymAttr());
+                inst->getResultTypes(), target, inst.getNameAttr(),
+                inst.getNameKindAttr(), inst.getPortDirectionsAttr(),
+                inst.getPortNamesAttr(), inst.getAnnotationsAttr(),
+                inst.getPortAnnotationsAttr(), builder.getArrayAttr({}),
+                UnitAttr{}, inst.getInnerSymAttr());
             inst.replaceAllUsesWith(newInst);
             inst.erase();
 
@@ -101,6 +107,8 @@ struct SpecializeOptionPass
 };
 } // namespace
 
-std::unique_ptr<Pass> firrtl::createSpecializeOptionPass() {
-  return std::make_unique<SpecializeOptionPass>();
+std::unique_ptr<Pass> firrtl::createSpecializeOptionPass(bool selectDefault) {
+  auto pass = std::make_unique<SpecializeOptionPass>();
+  pass->selectDefault = selectDefault;
+  return pass;
 }

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -133,7 +133,8 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
 
   // Must run the specialize instance-choice and layers passes after all
   // diagnostic passes have run, otherwise it can hide errors.
-  pm.addNestedPass<firrtl::CircuitOp>(firrtl::createSpecializeOptionPass());
+  pm.addNestedPass<firrtl::CircuitOp>(firrtl::createSpecializeOptionPass(
+      opt.shouldSelectDefaultInstanceChoice()));
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createSpecializeLayersPass());
 
   // Run after inference, layer specialization.
@@ -733,6 +734,12 @@ struct FirtoolCmdOptions {
       "add-companion-assume",
       llvm::cl::desc("Add companion assumes to assertions"),
       llvm::cl::init(false)};
+
+  llvm::cl::opt<bool> selectDefaultInstanceChoice{
+      "specialize-to-default-if-no-override",
+      llvm::cl::desc(
+          "Specialize instance choice to default, if no option selected"),
+      llvm::cl::init(false)};
 };
 } // namespace
 
@@ -769,7 +776,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       ckgEnableName("en"), ckgTestEnableName("test_en"), ckgInstName("ckg"),
       exportModuleHierarchy(false), stripFirDebugInfo(true),
       stripDebugInfo(false), fixupEICGWrapper(false), addCompanionAssume(false),
-      disableCSEinClasses(false) {
+      disableCSEinClasses(false), selectDefaultInstanceChoice(false) {
   if (!clOptions.isConstructed())
     return;
   outputFilename = clOptions->outputFilename;
@@ -818,4 +825,5 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   stripDebugInfo = clOptions->stripDebugInfo;
   fixupEICGWrapper = clOptions->fixupEICGWrapper;
   addCompanionAssume = clOptions->addCompanionAssume;
+  selectDefaultInstanceChoice = clOptions->selectDefaultInstanceChoice;
 }

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -736,7 +736,7 @@ struct FirtoolCmdOptions {
       llvm::cl::init(false)};
 
   llvm::cl::opt<bool> selectDefaultInstanceChoice{
-      "specialize-to-default-if-no-override",
+      "select-default-for-unspecified-instance-choice",
       llvm::cl::desc(
           "Specialize instance choice to default, if no option selected"),
       llvm::cl::init(false)};

--- a/test/firtool/instchoice.fir
+++ b/test/firtool/instchoice.fir
@@ -1,6 +1,6 @@
 ; RUN: firtool %s --parse-only --select-instance-choice=Platform=ASIC | FileCheck %s
 ; RUN: firtool %s --ir-hw --disable-opt --select-instance-choice=Platform=ASIC | FileCheck %s --check-prefix=ASIC
-; RUN: firtool %s --ir-hw --disable-opt --specialize-to-default-if-no-override | FileCheck %s --check-prefixes=DEFAULT
+; RUN: firtool %s --ir-hw --disable-opt --select-default-for-unspecified-instance-choice | FileCheck %s --check-prefixes=DEFAULT
 
 FIRRTL version 4.1.0
 ; CHECK: firrtl.circuit "Foo" attributes {select_inst_choice = ["Platform=ASIC"]} {

--- a/test/firtool/instchoice.fir
+++ b/test/firtool/instchoice.fir
@@ -1,5 +1,6 @@
 ; RUN: firtool %s --parse-only --select-instance-choice=Platform=ASIC | FileCheck %s
 ; RUN: firtool %s --ir-hw --disable-opt --select-instance-choice=Platform=ASIC | FileCheck %s --check-prefix=ASIC
+; RUN: firtool %s --ir-hw --disable-opt --specialize-to-default-if-no-override | FileCheck %s --check-prefixes=DEFAULT
 
 FIRRTL version 4.1.0
 ; CHECK: firrtl.circuit "Foo" attributes {select_inst_choice = ["Platform=ASIC"]} {
@@ -28,7 +29,8 @@ circuit Foo:
     ; CHECK-SAME:   @FPGA -> @FPGATarget,
     ; CHECK-SAME:   @ASIC -> @ASICTarget
     ; CHECK-SAME: } (in clock: !firrtl.clock)
-    ; ASIC: hw.instance "inst" @ASICTarget(clock: %clock: !seq.clock) -> ()
+    ; ASIC: hw.instance "inst" @ASICTarget
+    ; DEFAULT: hw.instance "inst" @DefaultTarget
     instchoice inst of DefaultTarget, Platform :
       FPGA => FPGATarget
       ASIC => ASICTarget


### PR DESCRIPTION
Add an override that, instead of emitting an error, selects the default target to specialize an instance choice when the option is unspecified.
By default a partially specified instance choice is not allowed. But we can override the error and select the default target, by using `--specialize-to-default-if-no-override` with `firtool`.
This enables a user to specialize the instance choice for a particular build flow, and fall-back to the default for all others.
Relevant discussion: https://github.com/llvm/circt/pull/7933