### PR TITLE
[llvm] Revert LLVM de-bump

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1060,7 +1060,8 @@ static LogicalResult buildAllocOp(ComponentLoweringState &componentState,
       // value's precision handling.
       value = bit_cast<double>(bitValue);
     } else {
-      APInt apInt(/*numBits=*/elmTyBitWidth, bitValue, isSigned);
+      APInt apInt(/*numBits=*/elmTyBitWidth, bitValue, isSigned,
+                  /*implicitTrunc=*/true);
       // The conditional ternary operation will cause the `value` to interpret
       // the underlying data as unsigned regardless `isSigned` or not.
       if (isSigned)


### PR DESCRIPTION
Revert an LLVM de-bump accidentally introduced in an unrelated change [[1]].  This effectively re-applies the original bump [[2]].

[1]: 58665c5921c78d7407fdf3a834b5af28fdd0fd3f
[2]: 02823af1a68ad623de52673749f364e74644ec8f