### PR TITLE
[CombToAIG] Add a pattern for lowering varidaic operations

### DIFF
--- a/integration_test/circt-synth/comb-lowering-lec.mlir
+++ b/integration_test/circt-synth/comb-lowering-lec.mlir
@@ -6,9 +6,9 @@
 // COMB_BIT_LOGICAL: c1 == c2
 hw.module @bit_logical(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32,
                 in %cond: i1, out out0: i32, out out1: i32, out out2: i32, out out3: i32) {
-  %0 = comb.or %arg0, %arg1 : i32
-  %1 = comb.and %arg0, %arg1 : i32
-  %2 = comb.xor %arg0, %arg1 : i32
+  %0 = comb.or %arg0, %arg1, %arg2, %arg3 : i32
+  %1 = comb.and %arg0, %arg1, %arg2, %arg3 : i32
+  %2 = comb.xor %arg0, %arg1, %arg2, %arg3 : i32
   %3 = comb.mux %cond, %arg0, %arg1 : i32
 
   hw.output %0, %1, %2, %3 : i32, i32, i32, i32

--- a/test/Conversion/CombToAIG/comb-to-aig.mlir
+++ b/test/Conversion/CombToAIG/comb-to-aig.mlir
@@ -1,18 +1,27 @@
 // RUN: circt-opt %s --convert-comb-to-aig | FileCheck %s
 
 // CHECK-LABEL: @test
-hw.module @test(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32, out out0: i32, out out1: i32, out out2: i32) {
+hw.module @test(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32, out out0: i32, out out1: i32) {
   // CHECK-NEXT: %[[OR_TMP:.+]] = aig.and_inv not %arg0, not %arg1, not %arg2, not %arg3 : i32
   // CHECK-NEXT: %[[OR:.+]] = aig.and_inv not %0 : i32
   // CHECK-NEXT: %[[AND:.+]] = aig.and_inv %arg0, %arg1, %arg2, %arg3 : i32
-  // CHECK-NEXT: %[[XOR_NOT_AND:.+]] = aig.and_inv not %arg0, not %arg1 : i32
-  // CHECK-NEXT: %[[XOR_AND:.+]] = aig.and_inv %arg0, %arg1 : i32
-  // CHECK-NEXT: %[[XOR:.+]] = aig.and_inv not %[[XOR_NOT_AND]], not %[[XOR_AND]] : i32
-  // CHECK-NEXT: hw.output %[[OR]], %[[AND]], %[[XOR]] : i32, i32, i32
+  // CHECK-NEXT: hw.output %[[OR]], %[[AND]] : i32, i32
   %0 = comb.or %arg0, %arg1, %arg2, %arg3 : i32
   %1 = comb.and %arg0, %arg1, %arg2, %arg3 : i32
-  %2 = comb.xor %arg0, %arg1 : i32
-  hw.output %0, %1, %2 : i32, i32, i32
+  hw.output %0, %1 : i32, i32
+}
+
+// CHECK-LABEL: @xor
+hw.module @xor(in %arg0: i32, in %arg1: i32, in %arg2: i32, out out0: i32) {
+  // CHECK-NEXT: %[[RHS_NOT_AND:.+]] = aig.and_inv not %arg1, not %arg2 : i32
+  // CHECK-NEXT: %[[RHS_AND:.+]] = aig.and_inv %arg1, %arg2 : i32
+  // CHECK-NEXT: %[[RHS_XOR:.+]] = aig.and_inv not %[[RHS_NOT_AND]], not %[[RHS_AND]] : i32
+  // CHECK-NEXT: %[[NOT_AND:.+]] = aig.and_inv not %arg0, not %[[RHS_XOR]] : i32
+  // CHECK-NEXT: %[[AND:.+]] = aig.and_inv %arg0, %[[RHS_XOR]] : i32
+  // CHECK-NEXT: %[[RESULT:.+]] = aig.and_inv not %[[NOT_AND]], not %[[AND]] : i32
+  // CHECK-NEXT: hw.output %[[RESULT]]
+  %0 = comb.xor %arg0, %arg1, %arg2 : i32
+  hw.output %0 : i32
 }
 
 // CHECK-LABEL: @pass


### PR DESCRIPTION
Some variadic operations (xor, add, mul etc) cannot directly lowered into varidic AIG operations. So this adds a pattern to pre-lower variadic operations.