### PR TITLE
    [CombToAIG] Add a lowering for Add/Sub

### DIFF
--- a/include/circt/Conversion/CombToAIG.h
+++ b/include/circt/Conversion/CombToAIG.h
@@ -10,7 +10,9 @@
 #define CIRCT_CONVERSION_COMBTOAIG_H
 
 #include "circt/Support/LLVM.h"
+#include "llvm/ADT/SmallVector.h"
 #include <memory>
+#include <string>
 
 namespace circt {
 

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -813,6 +813,11 @@ def ConvertCombToAIG: Pass<"convert-comb-to-aig",  "hw::HWModuleOp"> {
     "circt::comb::CombDialect",
     "circt::aig::AIGDialect",
   ];
+
+  let options = [
+    ListOption<"additionalLegalOps", "additional-legal-ops", "std::string",
+               "Sepify additional legal ops for testing">,
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -816,7 +816,7 @@ def ConvertCombToAIG: Pass<"convert-comb-to-aig",  "hw::HWModuleOp"> {
 
   let options = [
     ListOption<"additionalLegalOps", "additional-legal-ops", "std::string",
-               "Sepify additional legal ops for testing">,
+               "Specify additional legal ops for testing">,
   ];
 }
 

--- a/integration_test/circt-synth/comb-lowering-lec.mlir
+++ b/integration_test/circt-synth/comb-lowering-lec.mlir
@@ -1,0 +1,15 @@
+// REQUIRES: libz3
+// REQUIRES: circt-lec-jit
+
+// RUN: circt-opt %s --convert-comb-to-aig --convert-aig-to-comb -o %t.mlir
+// RUN: circt-lec %t.mlir %s -c1=bit_logical -c2=bit_logical --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_BIT_LOGICAL
+// COMB_BIT_LOGICAL: c1 == c2
+hw.module @bit_logical(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32,
+                in %cond: i1, out out0: i32, out out1: i32, out out2: i32, out out3: i32) {
+  %0 = comb.or %arg0, %arg1 : i32
+  %1 = comb.and %arg0, %arg1 : i32
+  %2 = comb.xor %arg0, %arg1 : i32
+  %3 = comb.mux %cond, %arg0, %arg1 : i32
+
+  hw.output %0, %1, %2, %3 : i32, i32, i32, i32
+}

--- a/integration_test/circt-synth/comb-lowering-lec.mlir
+++ b/integration_test/circt-synth/comb-lowering-lec.mlir
@@ -13,3 +13,17 @@ hw.module @bit_logical(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i3
 
   hw.output %0, %1, %2, %3 : i32, i32, i32, i32
 }
+
+// RUN: circt-lec %t.mlir %s -c1=add -c2=add --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD
+// COMB_ADD: c1 == c2
+hw.module @add(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4) {
+  %0 = comb.add %arg0, %arg1, %arg2 : i4
+  hw.output %0 : i4
+}
+
+// RUN: circt-lec %t.mlir %s -c1=sub -c2=sub --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_SUB
+// COMB_SUB: c1 == c2
+hw.module @sub(in %lhs: i4, in %rhs: i4, out out: i4) {
+  %0 = comb.sub %lhs, %rhs : i4
+  hw.output %0 : i4
+}

--- a/integration_test/circt-synth/comb-lowering-lec.mlir
+++ b/integration_test/circt-synth/comb-lowering-lec.mlir
@@ -6,9 +6,9 @@
 // COMB_BIT_LOGICAL: c1 == c2
 hw.module @bit_logical(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32,
                 in %cond: i1, out out0: i32, out out1: i32, out out2: i32, out out3: i32) {
-  %0 = comb.or %arg0, %arg1 : i32
-  %1 = comb.and %arg0, %arg1 : i32
-  %2 = comb.xor %arg0, %arg1 : i32
+  %0 = comb.or %arg0, %arg1, %arg2, %arg3 : i32
+  %1 = comb.and %arg0, %arg1, %arg2, %arg3 : i32
+  %2 = comb.xor %arg0, %arg1, %arg2, %arg3 : i32
   %3 = comb.mux %cond, %arg0, %arg1 : i32
 
   hw.output %0, %1, %2, %3 : i32, i32, i32, i32

--- a/test/Conversion/CombToAIG/comb-to-aig-arith.mlir
+++ b/test/Conversion/CombToAIG/comb-to-aig-arith.mlir
@@ -1,0 +1,29 @@
+// RUN: circt-opt %s --pass-pipeline="builtin.module(hw.module(convert-comb-to-aig{additional-legal-ops=comb.xor,comb.or,comb.and,comb.mux}))" | FileCheck %s
+// RUN: circt-opt %s --pass-pipeline="builtin.module(hw.module(convert-comb-to-aig{additional-legal-ops=comb.xor,comb.or,comb.and,comb.mux,comb.add}))" | FileCheck %s --check-prefix=ALLOW_ADD
+
+
+// CHECK-LABEL: @add
+hw.module @add(in %lhs: i2, in %rhs: i2, out out: i2) {
+  // CHECK:      %[[lhs0:.*]] = comb.extract %lhs from 0 : (i2) -> i1
+  // CHECK-NEXT: %[[lhs1:.*]] = comb.extract %lhs from 1 : (i2) -> i1
+  // CHECK-NEXT: %[[rhs0:.*]] = comb.extract %rhs from 0 : (i2) -> i1
+  // CHECK-NEXT: %[[rhs1:.*]] = comb.extract %rhs from 1 : (i2) -> i1
+  // CHECK-NEXT: %[[sum0:.*]] = comb.xor bin %[[lhs0]], %[[rhs0]] : i1
+  // CHECK-NEXT: %[[carry0:.*]] = comb.and bin %[[lhs0]], %[[rhs0]] : i1
+  // CHECK-NEXT: %[[sum1:.*]] = comb.xor bin %[[lhs1]], %[[rhs1]], %[[carry0]] : i1
+  // CHECK-NEXT: %[[concat:.*]] = comb.concat %[[sum1]], %[[sum0]] : i1, i1
+  // CHECK-NEXT: hw.output %[[concat]] : i2
+  %0 = comb.add %lhs, %rhs : i2
+  hw.output %0 : i2
+}
+
+// CHECK-LABEL: @sub
+// ALLOW_ADD-LABEL: @sub
+// ALLOW_ADD-NEXT: %[[NOT_RHS:.+]] = aig.and_inv not %rhs 
+// ALLOW_ADD-NEXT: %[[CONST:.+]] = hw.constant 1 : i4
+// ALLOW_ADD-NEXT: %[[ADD:.+]] = comb.add bin %lhs, %[[NOT_RHS]], %[[CONST]]
+// ALLOW_ADD-NEXT: hw.output %[[ADD]]
+hw.module @sub(in %lhs: i4, in %rhs: i4, out out: i4) {
+  %0 = comb.sub %lhs, %rhs : i4
+  hw.output %0 : i4
+}

--- a/test/Conversion/CombToAIG/comb-to-aig-arith.mlir
+++ b/test/Conversion/CombToAIG/comb-to-aig-arith.mlir
@@ -19,7 +19,7 @@ hw.module @add(in %lhs: i2, in %rhs: i2, out out: i2) {
 
 // CHECK-LABEL: @sub
 // ALLOW_ADD-LABEL: @sub
-// ALLOW_ADD-NEXT: %[[NOT_RHS:.+]] = aig.and_inv not %rhs 
+// ALLOW_ADD-NEXT: %[[NOT_RHS:.+]] = aig.and_inv not %rhs
 // ALLOW_ADD-NEXT: %[[CONST:.+]] = hw.constant 1 : i4
 // ALLOW_ADD-NEXT: %[[ADD:.+]] = comb.add bin %lhs, %[[NOT_RHS]], %[[CONST]]
 // ALLOW_ADD-NEXT: hw.output %[[ADD]]

--- a/test/Conversion/CombToAIG/comb-to-aig.mlir
+++ b/test/Conversion/CombToAIG/comb-to-aig.mlir
@@ -1,18 +1,27 @@
 // RUN: circt-opt %s --convert-comb-to-aig | FileCheck %s
 
 // CHECK-LABEL: @test
-hw.module @test(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32, out out0: i32, out out1: i32, out out2: i32) {
+hw.module @test(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32, out out0: i32, out out1: i32) {
   // CHECK-NEXT: %[[OR_TMP:.+]] = aig.and_inv not %arg0, not %arg1, not %arg2, not %arg3 : i32
   // CHECK-NEXT: %[[OR:.+]] = aig.and_inv not %0 : i32
   // CHECK-NEXT: %[[AND:.+]] = aig.and_inv %arg0, %arg1, %arg2, %arg3 : i32
-  // CHECK-NEXT: %[[XOR_NOT_AND:.+]] = aig.and_inv not %arg0, not %arg1 : i32
-  // CHECK-NEXT: %[[XOR_AND:.+]] = aig.and_inv %arg0, %arg1 : i32
-  // CHECK-NEXT: %[[XOR:.+]] = aig.and_inv not %[[XOR_NOT_AND]], not %[[XOR_AND]] : i32
-  // CHECK-NEXT: hw.output %[[OR]], %[[AND]], %[[XOR]] : i32, i32, i32
+  // CHECK-NEXT: hw.output %[[OR]], %[[AND]] : i32, i32
   %0 = comb.or %arg0, %arg1, %arg2, %arg3 : i32
   %1 = comb.and %arg0, %arg1, %arg2, %arg3 : i32
-  %2 = comb.xor %arg0, %arg1 : i32
-  hw.output %0, %1, %2 : i32, i32, i32
+  hw.output %0, %1 : i32, i32
+}
+
+// CHECK-LABEL: @xor
+hw.module @xor(in %arg0: i32, in %arg1: i32, in %arg2: i32, out out0: i32) {
+  // CHECK-NEXT: %[[RHS_NOT_AND:.+]] = aig.and_inv not %arg1, not %arg2 : i32
+  // CHECK-NEXT: %[[RHS_AND:.+]] = aig.and_inv %arg1, %arg2 : i32
+  // CHECK-NEXT: %[[RHS_XOR:.+]] = aig.and_inv not %[[RHS_NOT_AND]], not %[[RHS_AND]] : i32
+  // CHECK-NEXT: %[[NOT_AND:.+]] = aig.and_inv not %arg0, not %[[RHS_XOR]] : i32
+  // CHECK-NEXT: %[[AND:.+]] = aig.and_inv %arg0, %[[RHS_XOR]] : i32
+  // CHECK-NEXT: %[[RESULT:.+]] = aig.and_inv not %[[NOT_AND]], not %[[AND]] : i32
+  // CHECK-NEXT: hw.output %[[RESULT]]
+  %0 = comb.xor %arg0, %arg1, %arg2 : i32
+  hw.output %0 : i32
 }
 
 // CHECK-LABEL: @pass

--- a/test/Conversion/CombToAIG/comb-to-aig.mlir
+++ b/test/Conversion/CombToAIG/comb-to-aig.mlir
@@ -28,3 +28,18 @@ hw.module @pass(in %arg0: i32, in %arg1: i1, out out: i2) {
   %3 = comb.and %0, %1, %2 : i2
   hw.output %3 : i2
 }
+
+// CHECK-LABEL: @mux
+hw.module @mux(in %cond: i1, in %high: !hw.array<2xi4>, in %low: !hw.array<2xi4>, out out: !hw.array<2xi4>) {
+  // CHECK-NEXT: %[[HIGH:.+]] = hw.bitcast %high : (!hw.array<2xi4>) -> i8
+  // CHECK-NEXT: %[[LOW:.+]] = hw.bitcast %low : (!hw.array<2xi4>) -> i8
+  // CHECK-NEXT: %[[COND:.+]] = comb.replicate %cond : (i1) -> i8
+  // CHECK-NEXT: %[[LHS:.+]] = aig.and_inv %[[COND]], %[[HIGH]] : i8
+  // CHECK-NEXT: %[[RHS:.+]] = aig.and_inv not %[[COND]], %[[LOW]] : i8
+  // CHECK-NEXT: %[[NAND:.+]] = aig.and_inv not %[[LHS]], not %[[RHS]] : i8
+  // CHECK-NEXT: %[[NOT:.+]] = aig.and_inv not %[[NAND]] : i8
+  // CHECK-NEXT: %[[RESULT:.+]] = hw.bitcast %[[NOT]] : (i8) -> !hw.array<2xi4>
+  // CHECK-NEXT: hw.output %[[RESULT]] : !hw.array<2xi4>
+  %0 = comb.mux %cond, %high, %low : !hw.array<2xi4>
+  hw.output %0 : !hw.array<2xi4>
+}


### PR DESCRIPTION
 This implements a pattern to lower AddOp to a naive ripple-carry adder.
 Pattern for sub is also added since we can easily compute subtraction from addition.
    
 This PR also adds a test-only option to `additional-legal-ops` to test
 complicated lowering pattern.