### PR TITLE
[ImportVerilog] Support for sized unpacked arrays in 'inside' expressions

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -554,19 +554,35 @@ struct RvalueExprVisitor {
         // Handle expressions.
         if (!listExpr->type->isSimpleBitVector()) {
           if (listExpr->type->isUnpackedArray()) {
+            if (listExpr->type->isFixedSize()) {
+              const auto &uaType =
+                  listExpr->type->as<slang::ast::FixedSizeUnpackedArrayType>();
+              auto value = context.convertRvalueExpression(*listExpr);
+              if (!value)
+                return {};
+              context.collectConditionsForUnpackedArray(uaType, value,
+                                                        conditions, lhs, loc);
+              cond = conditions.back();
+              conditions
+                  .pop_back(); // avoiding repetition of cond in the vector
+            } else {
+              mlir::emitError(loc, "unsized unpacked arrays in 'inside' "
+                                   "expressions not supported");
+              return {};
+            }
+          } else {
             mlir::emitError(
-                loc, "unpacked arrays in 'inside' expressions not supported");
+                loc,
+                "only simple bit vectors supported in 'inside' expressions");
             return {};
           }
-          mlir::emitError(
-              loc, "only simple bit vectors supported in 'inside' expressions");
-          return {};
+        } else {
+          auto value = context.convertToSimpleBitVector(
+              context.convertRvalueExpression(*listExpr));
+          if (!value)
+            return {};
+          cond = builder.create<moore::WildcardEqOp>(loc, lhs, value);
         }
-        auto value = context.convertToSimpleBitVector(
-            context.convertRvalueExpression(*listExpr));
-        if (!value)
-          return {};
-        cond = builder.create<moore::WildcardEqOp>(loc, lhs, value);
       }
       conditions.push_back(cond);
     }
@@ -1100,4 +1116,40 @@ Value Context::materializeConversion(Type type, Value value, bool isSigned,
   if (value.getType() != type)
     value = builder.create<moore::ConversionOp>(loc, type, value);
   return value;
+}
+
+void Context::collectConditionsForUnpackedArray(
+    const slang::ast::FixedSizeUnpackedArrayType &slangType,
+    Value upackedArrayValue, SmallVector<Value> &conditions, Value lhs,
+    Location loc) {
+  Value cond;
+  auto type = convertType(slangType);
+  if (!type) {
+    mlir::emitError(loc, "can't convert slang::ast::FixedSizeUnpackedArrayType "
+                         "to moore::UnpackedArrayType");
+  }
+  auto mooreType = dyn_cast<moore::UnpackedArrayType>(type);
+  const auto &elementType = slangType.elementType;
+  for (slang::int32_t i = slangType.getFixedRange().lower();
+       i <= slangType.getFixedRange().upper(); i++) {
+    auto elemValue = builder.create<moore::ExtractOp>(
+        loc, mooreType.getElementType(), upackedArrayValue, i);
+    if (elementType.isUnpackedArray()) {
+      collectConditionsForUnpackedArray(
+          elementType.as<slang::ast::FixedSizeUnpackedArrayType>(), elemValue,
+          conditions, lhs, loc);
+    } else if (elementType.isSingular()) {
+      if (elementType.isIntegral()) {
+        cond = builder.create<moore::WildcardEqOp>(loc, lhs, elemValue);
+      } else {
+        cond = builder.create<moore::EqOp>(loc, lhs, elemValue);
+      }
+      conditions.push_back(cond);
+    } else {
+      mlir::emitError(loc,
+                      "only singular values and fixed-size unpacked arrays "
+                      "allowed as elements of unpacked arrays in 'inside' "
+                      "expressions");
+    }
+  }
 }

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -135,6 +135,13 @@ struct Context {
   Value materializeConstant(const slang::ConstantValue &constant,
                             const slang::ast::Type &type, Location loc);
 
+  /// Helper function to construct conditions for a fixed-size unpacked array in
+  /// an `inside` expression.
+  void collectConditionsForUnpackedArray(
+      const slang::ast::FixedSizeUnpackedArrayType &slangType,
+      Value upackedArrayValue, SmallVector<Value> &conditions, Value lhs,
+      Location loc);
+
   /// Convert a list of string literal arguments with formatting specifiers and
   /// arguments to be interpolated into a `!moore.format_string` value. Returns
   /// failure if an error occurs. Returns a null value if the formatted string

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -657,6 +657,10 @@ module Expressions;
   bit [31:0] uarrayInt [2];
   // CHECK: %m = moore.variable : <l4>
   logic [3:0] m;
+  // CHECK: %ua = moore.variable : <uarray<3 x i32>>
+  int ua[3];
+  // CHECK: %ua2d = moore.variable : <uarray<2 x uarray<2 x i32>>>
+  int ua2d[2][2];
 
   initial begin
     // CHECK: moore.constant 0 : i32
@@ -1075,6 +1079,35 @@ module Expressions;
     // CHECK: [[TMP11:%.+]] = moore.or [[TMP5]], [[TMP10]] : i1
     // CHECK: moore.or [[TMP3]], [[TMP11]] : i1
     c = a inside { a, b, [a:b] };
+
+    // CHECK: [[TMP1:%.+]] = moore.read %a : <i32>
+    // CHECK: [[TMP2:%.+]] = moore.read %ua : <uarray<3 x i32>>
+    // CHECK: [[TMP3:%.+]] = moore.extract [[TMP2]] from 0 : uarray<3 x i32> -> i32
+    // CHECK: [[TMP4:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP3]] : i32 -> i1
+    // CHECK: [[TMP5:%.+]] = moore.extract [[TMP2]] from 1 : uarray<3 x i32> -> i32
+    // CHECK: [[TMP6:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP5]] : i32 -> i1
+    // CHECK: [[TMP7:%.+]] = moore.extract [[TMP2]] from 2 : uarray<3 x i32> -> i32
+    // CHECK: [[TMP8:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP7]] : i32 -> i1
+    // CHECK: [[TMP9:%.+]] = moore.or [[TMP6]], [[TMP8]] : i1
+    // CHECK: [[TMP10:%.+]] = moore.or [[TMP4]], [[TMP9]] : i1
+    c = a inside { ua };
+
+    // CHECK: [[TMP1:%.+]] = moore.read %a : <i32>
+    // CHECK: [[TMP2:%.+]] = moore.read %ua2d : <uarray<2 x uarray<2 x i32>>>
+    // CHECK: [[TMP3:%.+]] = moore.extract [[TMP2]] from 0 : uarray<2 x uarray<2 x i32>> -> uarray<2 x i32>
+    // CHECK: [[TMP4:%.+]] = moore.extract [[TMP3]] from 0 : uarray<2 x i32> -> i32
+    // CHECK: [[TMP5:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP4]] : i32 -> i1
+    // CHECK: [[TMP6:%.+]] = moore.extract [[TMP3]] from 1 : uarray<2 x i32> -> i32
+    // CHECK: [[TMP7:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP6]] : i32 -> i1
+    // CHECK: [[TMP8:%.+]] = moore.extract [[TMP2]] from 1 : uarray<2 x uarray<2 x i32>> -> uarray<2 x i32>
+    // CHECK: [[TMP9:%.+]] = moore.extract [[TMP8]] from 0 : uarray<2 x i32> -> i32
+    // CHECK: [[TMP10:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP9]] : i32 -> i1
+    // CHECK: [[TMP11:%.+]] = moore.extract [[TMP8]] from 1 : uarray<2 x i32> -> i32
+    // CHECK: [[TMP12:%.+]] = moore.wildcard_eq [[TMP1]], [[TMP11]] : i32 -> i1
+    // CHECK: [[TMP13:%.+]] = moore.or [[TMP10]], [[TMP12]] : i1
+    // CHECK: [[TMP14:%.+]] = moore.or [[TMP7]], [[TMP13]] : i1
+    // CHECK: [[TMP15:%.+]] = moore.or [[TMP5]], [[TMP14]] : i1
+    c = a inside { ua2d };
 
     //===------------------------------------------------------------------===//
     // Conditional operator

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -68,8 +68,8 @@ endmodule
 
 // -----
 module Foo;
-  int a, b[3];
-  // expected-error @below {{unpacked arrays in 'inside' expressions not supported}}
+  int a, b[];
+  // expected-error @below {{unsized unpacked arrays in 'inside' expressions not supported}}
   int c = a inside { b };
 endmodule
 


### PR DESCRIPTION
Support for sized unpacked arrays in 'inside' expressions. Implementation recursively traverses the array to find the singular value and compares all found ones with the lhs, adding the condition results to the original conditions vector.