### PR TITLE
[SCFToCalyx] buildLibraryOp cast floating point to integer types

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -62,9 +62,10 @@ bool noStoresToMemory(Value memoryReference);
 // Get the index'th output port of compOp.
 Value getComponentOutput(calyx::ComponentOp compOp, unsigned outPortIdx);
 
-// If the provided type is an index type, converts it to i32, else, returns the
-// unmodified type.
-Type convIndexType(OpBuilder &builder, Type type);
+// If the provided type is an index type, converts it to i32; else if the
+// provided is an integer of floating point, bitcasts to a signless integer
+// type; otherwise, returns the unmodified type.
+Type normalizeType(OpBuilder &builder, Type type);
 
 // Creates a new calyx::CombGroupOp or calyx::GroupOp group within compOp.
 template <typename TGroup>
@@ -837,6 +838,20 @@ struct PredicateInfo {
 };
 
 PredicateInfo getPredicateInfo(mlir::arith::CmpFPredicate pred);
+
+/// Performs a bit cast from a non-signless integer type value, such as a
+/// floating point value, to a signless integer type. Calyx treats everything as
+/// bit vectors, and leaves their interpretation to the respective operation
+/// using it. In CIRCT Calyx, we use signless `IntegerType` to represent a bit
+/// vector.
+template <typename T>
+Type toBitVector(T type) {
+  if (!type.isSignlessInteger()) {
+    unsigned bitWidth = cast<T>(type).getIntOrFloatBitWidth();
+    return IntegerType::get(type.getContext(), bitWidth);
+  }
+  return type;
+};
 
 } // namespace calyx
 } // namespace circt

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -63,7 +63,7 @@ bool noStoresToMemory(Value memoryReference);
 Value getComponentOutput(calyx::ComponentOp compOp, unsigned outPortIdx);
 
 // If the provided type is an index type, converts it to i32; else if the
-// provided is an integer of floating point, bitcasts to a signless integer
+// provided is an integer or floating point, bitcasts it to a signless integer
 // type; otherwise, returns the unmodified type.
 Type normalizeType(OpBuilder &builder, Type type);
 

--- a/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
+++ b/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
@@ -727,8 +727,8 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                      IndexCastOp op) const {
-  Type sourceType = calyx::convIndexType(rewriter, op.getOperand().getType());
-  Type targetType = calyx::convIndexType(rewriter, op.getResult().getType());
+  Type sourceType = calyx::normalizeType(rewriter, op.getOperand().getType());
+  Type targetType = calyx::normalizeType(rewriter, op.getResult().getType());
   unsigned targetBits = targetType.getIntOrFloatBitWidth();
   unsigned sourceBits = sourceType.getIntOrFloatBitWidth();
   LogicalResult res = success();
@@ -793,7 +793,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
         funcOpArgRewrites[arg.value()] = inPorts.size();
         inPorts.push_back(calyx::PortInfo{
             rewriter.getStringAttr(inName),
-            calyx::convIndexType(rewriter, arg.value().getType()),
+            calyx::normalizeType(rewriter, arg.value().getType()),
             calyx::Direction::Input,
             DictionaryAttr::get(rewriter.getContext(), {})});
       }
@@ -802,7 +802,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
       funcOpResultMapping[res.index()] = outPorts.size();
       outPorts.push_back(calyx::PortInfo{
           rewriter.getStringAttr("out" + std::to_string(res.index())),
-          calyx::convIndexType(rewriter, res.value()), calyx::Direction::Output,
+          calyx::normalizeType(rewriter, res.value()), calyx::Direction::Output,
           DictionaryAttr::get(rewriter.getContext(), {})});
     }
 

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -396,9 +396,19 @@ private:
   template <typename TGroupOp, typename TCalyxLibOp, typename TSrcOp>
   LogicalResult buildLibraryOp(PatternRewriter &rewriter, TSrcOp op,
                                TypeRange srcTypes, TypeRange dstTypes) const {
+    auto castToInteger = [](Type type) -> Type {
+      if (isa<FloatType>(type)) {
+        unsigned bitWidth = cast<FloatType>(type).getWidth();
+        return IntegerType::get(type.getContext(), bitWidth);
+      }
+      return type;
+    };
+
     SmallVector<Type> types;
-    llvm::append_range(types, srcTypes);
-    llvm::append_range(types, dstTypes);
+    for (Type srcType : srcTypes)
+      types.push_back(castToInteger(srcType));
+    for (Type dstType : dstTypes)
+      types.push_back(castToInteger(dstType));
 
     auto calyxOp =
         getState<ComponentLoweringState>().getNewLibraryOpInstance<TCalyxLibOp>(

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -396,19 +396,11 @@ private:
   template <typename TGroupOp, typename TCalyxLibOp, typename TSrcOp>
   LogicalResult buildLibraryOp(PatternRewriter &rewriter, TSrcOp op,
                                TypeRange srcTypes, TypeRange dstTypes) const {
-    auto castToInteger = [](Type type) -> Type {
-      if (isa<FloatType>(type)) {
-        unsigned bitWidth = cast<FloatType>(type).getWidth();
-        return IntegerType::get(type.getContext(), bitWidth);
-      }
-      return type;
-    };
-
     SmallVector<Type> types;
     for (Type srcType : srcTypes)
-      types.push_back(castToInteger(srcType));
+      types.push_back(calyx::toBitVector(srcType));
     for (Type dstType : dstTypes)
-      types.push_back(castToInteger(dstType));
+      types.push_back(calyx::toBitVector(dstType));
 
     auto calyxOp =
         getState<ComponentLoweringState>().getNewLibraryOpInstance<TCalyxLibOp>(
@@ -1397,8 +1389,8 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                      IndexCastOp op) const {
-  Type sourceType = calyx::convIndexType(rewriter, op.getOperand().getType());
-  Type targetType = calyx::convIndexType(rewriter, op.getResult().getType());
+  Type sourceType = calyx::normalizeType(rewriter, op.getOperand().getType());
+  Type targetType = calyx::normalizeType(rewriter, op.getResult().getType());
   unsigned targetBits = targetType.getIntOrFloatBitWidth();
   unsigned sourceBits = sourceType.getIntOrFloatBitWidth();
   LogicalResult res = success();
@@ -1587,7 +1579,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
         funcOpArgRewrites[arg.value()] = inPorts.size();
         inPorts.push_back(calyx::PortInfo{
             rewriter.getStringAttr(inName),
-            calyx::convIndexType(rewriter, arg.value().getType()),
+            calyx::normalizeType(rewriter, arg.value().getType()),
             calyx::Direction::Input,
             DictionaryAttr::get(rewriter.getContext(), {})});
       }
@@ -1603,7 +1595,7 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
 
       outPorts.push_back(calyx::PortInfo{
           rewriter.getStringAttr(resName),
-          calyx::convIndexType(rewriter, res.value()), calyx::Direction::Output,
+          calyx::normalizeType(rewriter, res.value()), calyx::Direction::Output,
           DictionaryAttr::get(rewriter.getContext(), {})});
     }
 

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -438,3 +438,72 @@ module {
   }
 }
 
+// -----
+
+// Test lowering SelectOp with floating point operands
+
+// CHECK:    %std_mux_1.cond, %std_mux_1.tru, %std_mux_1.fal, %std_mux_1.out = calyx.std_mux @std_mux_1 : i1, i64, i64, i64
+// CHECK-DAG:    %unordered_port_1_reg.in, %unordered_port_1_reg.write_en, %unordered_port_1_reg.clk, %unordered_port_1_reg.reset, %unordered_port_1_reg.out, %unordered_port_1_reg.done = calyx.register @unordered_port_1_reg : i1, i1, i1, i1, i1, i1
+// CHECK-DAG:    %cmpf_1_reg.in, %cmpf_1_reg.write_en, %cmpf_1_reg.clk, %cmpf_1_reg.reset, %cmpf_1_reg.out, %cmpf_1_reg.done = calyx.register @cmpf_1_reg : i1, i1, i1, i1, i1, i1
+// CHECK-DAG:    %std_compareFN_1.clk, %std_compareFN_1.reset, %std_compareFN_1.go, %std_compareFN_1.left, %std_compareFN_1.right, %std_compareFN_1.signaling, %std_compareFN_1.lt, %std_compareFN_1.eq, %std_compareFN_1.gt, %std_compareFN_1.unordered, %std_compareFN_1.exceptionalFlags, %std_compareFN_1.done = calyx.ieee754.compare @std_compareFN_1 : i1, i1, i1, i64, i64, i1, i1, i1, i1, i1, i5, i1
+// CHECK-DAG:    %std_mux_0.cond, %std_mux_0.tru, %std_mux_0.fal, %std_mux_0.out = calyx.std_mux @std_mux_0 : i1, i64, i64, i64
+// CHECK-DAG:    %std_and_0.left, %std_and_0.right, %std_and_0.out = calyx.std_and @std_and_0 : i1, i1, i1
+// CHECK-DAG:    %std_or_0.left, %std_or_0.right, %std_or_0.out = calyx.std_or @std_or_0 : i1, i1, i1
+// CHECK-DAG:    %unordered_port_0_reg.in, %unordered_port_0_reg.write_en, %unordered_port_0_reg.clk, %unordered_port_0_reg.reset, %unordered_port_0_reg.out, %unordered_port_0_reg.done = calyx.register @unordered_port_0_reg : i1, i1, i1, i1, i1, i1
+// CHECK-DAG:    %compare_port_0_reg.in, %compare_port_0_reg.write_en, %compare_port_0_reg.clk, %compare_port_0_reg.reset, %compare_port_0_reg.out, %compare_port_0_reg.done = calyx.register @compare_port_0_reg : i1, i1, i1, i1, i1, i1
+// CHECK-DAG:    %cmpf_0_reg.in, %cmpf_0_reg.write_en, %cmpf_0_reg.clk, %cmpf_0_reg.reset, %cmpf_0_reg.out, %cmpf_0_reg.done = calyx.register @cmpf_0_reg : i1, i1, i1, i1, i1, i1
+// CHECK-DAG:    %std_compareFN_0.clk, %std_compareFN_0.reset, %std_compareFN_0.go, %std_compareFN_0.left, %std_compareFN_0.right, %std_compareFN_0.signaling, %std_compareFN_0.lt, %std_compareFN_0.eq, %std_compareFN_0.gt, %std_compareFN_0.unordered, %std_compareFN_0.exceptionalFlags, %std_compareFN_0.done = calyx.ieee754.compare @std_compareFN_0 : i1, i1, i1, i64, i64, i1, i1, i1, i1, i1, i5, i1
+// CHECK:    calyx.wires {
+// CHECK:      calyx.group @bb0_0 {
+// CHECK-DAG:        calyx.assign %std_compareFN_0.left = %in0 : i64
+// CHECK-DAG:        calyx.assign %std_compareFN_0.right = %in1 : i64
+// CHECK-DAG:        calyx.assign %std_compareFN_0.signaling = %true : i1
+// CHECK-DAG:        calyx.assign %compare_port_0_reg.write_en = %std_compareFN_0.done : i1
+// CHECK-DAG:        calyx.assign %compare_port_0_reg.in = %std_compareFN_0.gt : i1
+// CHECK-DAG:        calyx.assign %unordered_port_0_reg.write_en = %std_compareFN_0.done : i1
+// CHECK-DAG:        calyx.assign %unordered_port_0_reg.in = %std_compareFN_0.unordered : i1
+// CHECK-DAG:        calyx.assign %std_or_0.left = %compare_port_0_reg.out : i1
+// CHECK-DAG:        calyx.assign %std_or_0.right = %unordered_port_0_reg.out : i1
+// CHECK-DAG:        calyx.assign %std_and_0.left = %compare_port_0_reg.done : i1
+// CHECK-DAG:        calyx.assign %std_and_0.right = %unordered_port_0_reg.done : i1
+// CHECK-DAG:        calyx.assign %cmpf_0_reg.in = %std_or_0.out : i1
+// CHECK-DAG:        calyx.assign %cmpf_0_reg.write_en = %std_and_0.out : i1
+// CHECK-DAG:        %0 = comb.xor %std_compareFN_0.done, %true : i1
+// CHECK-DAG:        calyx.assign %std_compareFN_0.go = %0 ? %true : i1
+// CHECK-DAG:        calyx.group_done %cmpf_0_reg.done : i1
+// CHECK-DAG:      }
+// CHECK:      calyx.group @bb0_2 {
+// CHECK-DAG:        calyx.assign %std_compareFN_1.left = %in1 : i64
+// CHECK-DAG:        calyx.assign %std_compareFN_1.right = %in1 : i64
+// CHECK-DAG:        calyx.assign %std_compareFN_1.signaling = %false : i1
+// CHECK-DAG:        calyx.assign %unordered_port_1_reg.write_en = %std_compareFN_1.done : i1
+// CHECK-DAG:        calyx.assign %unordered_port_1_reg.in = %std_compareFN_1.unordered : i1
+// CHECK-DAG:        calyx.assign %cmpf_1_reg.in = %unordered_port_1_reg.out : i1
+// CHECK-DAG:        calyx.assign %cmpf_1_reg.write_en = %unordered_port_1_reg.out : i1
+// CHECK-DAG:        %0 = comb.xor %std_compareFN_1.done, %true : i1
+// CHECK-DAG:        calyx.assign %std_compareFN_1.go = %0 ? %true : i1
+// CHECK-DAG:        calyx.group_done %cmpf_1_reg.done : i1
+// CHECK-DAG:      }
+// CHECK:      calyx.group @ret_assign_0 {
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.in = %std_mux_1.out : i64
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-DAG:        calyx.assign %std_mux_1.cond = %cmpf_1_reg.out : i1
+// CHECK-DAG:        calyx.assign %std_mux_1.tru = %in1 : i64
+// CHECK-DAG:        calyx.assign %std_mux_1.fal = %std_mux_0.out : i64
+// CHECK-DAG:        calyx.assign %std_mux_0.cond = %cmpf_0_reg.out : i1
+// CHECK-DAG:        calyx.assign %std_mux_0.tru = %in0 : i64
+// CHECK-DAG:        calyx.assign %std_mux_0.fal = %in1 : i64
+// CHECK-DAG:        calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-DAG:      }
+// CHECK-DAG:    }
+
+module {
+  func.func @main(%arg0: f64, %arg1: f64) -> f64 {
+    %0 = arith.cmpf ugt, %arg0, %arg1 : f64
+    %1 = arith.select %0, %arg0, %arg1 : f64
+    %2 = arith.cmpf uno, %arg1, %arg1 : f64
+    %3 = arith.select %2, %arg1, %1 : f64
+    return %3 : f64
+  }
+}
+

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -440,7 +440,7 @@ module {
 
 // -----
 
-// Test lowering SelectOp with floating point operands
+// Test lowering SelectOp and CmpFOp with floating point operands
 
 // CHECK:    %std_mux_1.cond, %std_mux_1.tru, %std_mux_1.fal, %std_mux_1.out = calyx.std_mux @std_mux_1 : i1, i64, i64, i64
 // CHECK-DAG:    %unordered_port_1_reg.in, %unordered_port_1_reg.write_en, %unordered_port_1_reg.clk, %unordered_port_1_reg.reset, %unordered_port_1_reg.out, %unordered_port_1_reg.done = calyx.register @unordered_port_1_reg : i1, i1, i1, i1, i1, i1
@@ -507,3 +507,26 @@ module {
   }
 }
 
+// Test SelectOp with signed integer type to signless integer type
+
+// -----
+
+// CHECK:    %std_mux_0.cond, %std_mux_0.tru, %std_mux_0.fal, %std_mux_0.out = calyx.std_mux @std_mux_0 : i1, i32, i32, i32
+// CHECK-DAG:    %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:    calyx.wires {
+// CHECK:      calyx.group @ret_assign_0 {
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.in = %std_mux_0.out : i32
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-DAG:        calyx.assign %std_mux_0.cond = %in2 : i1
+// CHECK-DAG:        calyx.assign %std_mux_0.tru = %in0 : i32
+// CHECK-DAG:        calyx.assign %std_mux_0.fal = %in1 : i32
+// CHECK-DAG:        calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-DAG:      }
+// CHECK-DAG:    }
+
+module {
+  func.func @main(%true : si32, %false: si32, %cond: i1) -> si32 {
+    %res = "arith.select" (%cond, %true, %false) : (i1, si32, si32) -> si32
+    return %res : si32
+  }
+}


### PR DESCRIPTION
In `buildLibraryOp`, we cast floating point types to integer types with the same width, as discussed here: https://github.com/llvm/circt/pull/7762

The testing case is just the result of running the `-arith-expand` pass on the following input:
```mlir
module {
  func.func @main(%b: f64, %c: f64) -> f64 {
    %a = arith.maximumf %b, %c : f64
    return %a : f64
  }
}
```