### PR TITLE
[RTG][Elaboration] Add support for 'scf.if' and 'scf.for'

### DIFF
--- a/lib/Dialect/RTG/Transforms/CMakeLists.txt
+++ b/lib/Dialect/RTG/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_dialect_library(CIRCTRTGTransforms
   LINK_LIBS PRIVATE
   CIRCTRTGDialect
   MLIRIndexDialect
+  MLIRSCFDialect
   MLIRIR
   MLIRPass
 )


### PR DESCRIPTION
Did a quick profile of the following input:
```
func.func @dummy(%arg0: index) -> () {return}

rtg.test @test : !rtg.dict<> {
  %0 = index.constant 0
  %1 = index.constant 1
  %2 = index.constant 10000000
  %3 = index.constant 2
  %4 = scf.for %i = %0 to %2 step %1 iter_args(%a = %0) -> (index) {
    %5 = index.add %a, %3
    scf.yield %5 : index
  }
  func.call @dummy(%4) : (index) -> ()
}
```

Currently takes ~5.4 sec on my machine, with most of the time spent internalizing the intermediate integers.
Will follow-up with a PR that refactors the ElaboratorValue to only internalize complex values such as sets and bags, but not primitive integers.