### PR TITLE
[firtool] initialize the disableLayerSink flag

### DIFF
--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -527,10 +527,9 @@ struct FirtoolCmdOptions {
                                   "release", "Compile with optimizations")),
       llvm::cl::init(firtool::FirtoolOptions::BuildModeDefault)};
 
-  llvm::cl::opt<bool> disableLayerSink{
-      "disable-layer-sink",
-      llvm::cl::desc("Disable layer sink"),
-  };
+  llvm::cl::opt<bool> disableLayerSink{"disable-layer-sink",
+                                       llvm::cl::desc("Disable layer sink"),
+                                       cl::init(false)};
 
   llvm::cl::opt<bool> disableOptimization{
       "disable-opt",
@@ -770,9 +769,10 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       allowAddingPortsOnPublic(false), probesToSignals(false),
       preserveAggregate(firrtl::PreserveAggregate::None),
       preserveMode(firrtl::PreserveValues::None), enableDebugInfo(false),
-      buildMode(BuildModeRelease), disableOptimization(false),
-      exportChiselInterface(false), chiselInterfaceOutDirectory(""),
-      vbToBV(false), noDedup(false), companionMode(firrtl::CompanionMode::Bind),
+      buildMode(BuildModeRelease), disableLayerSink(false),
+      disableOptimization(false), exportChiselInterface(false),
+      chiselInterfaceOutDirectory(""), vbToBV(false), noDedup(false),
+      companionMode(firrtl::CompanionMode::Bind),
       disableAggressiveMergeConnections(false), advancedLayerSink(false),
       lowerMemories(false), blackBoxRootPath(""), replSeqMem(false),
       replSeqMemFile(""), extractTestCode(false), ignoreReadEnableMem(false),


### PR DESCRIPTION
When this option was added to the FirtoolOptions struct it was not given an initial value, which could later be read.  This change also sets the initial value of the CL option flag.