### PR TITLE
[Seq] Fix FIFO lowering to correct depth and pointer increments

### DIFF
--- a/include/circt/Dialect/Seq/SeqPasses.td
+++ b/include/circt/Dialect/Seq/SeqPasses.td
@@ -18,7 +18,11 @@ include "mlir/Pass/PassBase.td"
 def LowerSeqFIFO : Pass<"lower-seq-fifo", "hw::HWModuleOp"> {
   let summary = "Lower seq.fifo ops";
   let constructor = "circt::seq::createLowerSeqFIFOPass()";
-  let dependentDialects = ["circt::hw::HWDialect", "circt::comb::CombDialect"];
+  let dependentDialects = [
+    "circt::hw::HWDialect",
+    "circt::comb::CombDialect",
+    "circt::verif::VerifDialect"
+  ];
 }
 
 def LowerSeqHLMem: Pass<"lower-seq-hlmem", "hw::HWModuleOp"> {

--- a/integration_test/Dialect/Seq/fifo/fifo.mlir
+++ b/integration_test/Dialect/Seq/fifo/fifo.mlir
@@ -1,6 +1,6 @@
 // REQUIRES: iverilog,cocotb
 
-// RUN: circt-opt %s --lower-seq-fifo --lower-seq-hlmem --lower-seq-to-sv --sv-trace-iverilog --export-verilog -o %t.mlir > %t.sv
+// RUN: circt-opt %s --lower-seq-fifo --lower-seq-hlmem --lower-seq-to-sv --lower-verif-to-sv --sv-trace-iverilog --export-verilog -o %t.mlir > %t.sv
 // RUN: circt-cocotb-driver.py --objdir=%T --topLevel=fifo \
 // RUN:     --pythonModule=fifo --pythonFolder="%S,%S/.." %t.sv 2>&1
 
@@ -8,6 +8,6 @@
 // CHECK: ** TESTS=[[N:.*]] PASS=[[N]] FAIL=0 SKIP=0
 
 hw.module @fifo(in %clk : !seq.clock, in %rst : i1, in %inp : i32, in %rdEn : i1, in %wrEn : i1, out out: i32, out empty: i1, out full: i1, out almost_empty : i1, out almost_full : i1) {
-  %out, %full, %empty, %almostFull, %almostEmpty = seq.fifo depth 4 almost_full 2 almost_empty 1 in %inp rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
+  %out, %full, %empty, %almostFull, %almostEmpty = seq.fifo depth 6 almost_full 2 almost_empty 1 in %inp rdEn %rdEn wrEn %wrEn clk %clk rst %rst : i32
   hw.output %out, %empty, %full, %almostEmpty, %almostFull : i32, i1, i1, i1, i1
 }

--- a/lib/Dialect/Seq/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Seq/Transforms/CMakeLists.txt
@@ -15,6 +15,7 @@ add_circt_dialect_library(CIRCTSeqTransforms
   CIRCTSeq
   CIRCTSupport
   CIRCTSV
+  CIRCTVerif
   MLIRIR
   MLIRPass
   MLIRTransformUtils


### PR DESCRIPTION
Fixes two bugs:
- Incorrect depth constant led to FIFO never reaching capacity.
- Increment pointers only worked for depth which were powers of two.

Updates integration test to test for these two conditions.