### PR TITLE
[CD] Install nanobind when building wheels.

### DIFF
--- a/lib/Bindings/Python/pyproject.toml
+++ b/lib/Bindings/Python/pyproject.toml
@@ -7,6 +7,7 @@ requires = [
     # MLIR build depends.
     "numpy",
     "pybind11>=2.11,<=2.12",
+    "nanobind==2.4.0",
     "PyYAML",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
We recently started supporting nanobind as a dependency in upstream MLIR. This is installed in our CI images, but not the Python wheel CI environment. This adds that dependency to the package used for the Python wheel build.