### PR TITLE
[LowerToBMC] Topologically sort module body before inlining to BMC op

### DIFF
--- a/lib/Tools/circt-bmc/LowerToBMC.cpp
+++ b/lib/Tools/circt-bmc/LowerToBMC.cpp
@@ -61,7 +61,10 @@ void LowerToBMCPass::runOnOperation() {
     return signalPassFailure();
   }
 
-  sortTopologically(&hwModule.getBodyRegion().front());
+  if (!sortTopologically(&hwModule.getBodyRegion().front())) {
+    hwModule->emitError("could not resolve cycles in module");
+    return signalPassFailure();
+  }
 
   // Create necessary function declarations and globals
   auto *ctx = &getContext();

--- a/lib/Tools/circt-bmc/LowerToBMC.cpp
+++ b/lib/Tools/circt-bmc/LowerToBMC.cpp
@@ -15,6 +15,7 @@
 #include "circt/Support/LLVM.h"
 #include "circt/Support/Namespace.h"
 #include "circt/Tools/circt-bmc/Passes.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -59,6 +60,8 @@ void LowerToBMCPass::runOnOperation() {
     hwModule.emitError("no property provided to check in module");
     return signalPassFailure();
   }
+
+  sortTopologically(&hwModule.getBodyRegion().front());
 
   // Create necessary function declarations and globals
   auto *ctx = &getContext();

--- a/test/Tools/circt-bmc/lower-to-bmc-errors.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc-errors.mlir
@@ -79,3 +79,15 @@ hw.module @testModule(in %clk0 : !seq.clock, in %clkStruct : !hw.struct<clk: !se
   verif.assert %1 : i1
   hw.output %0, %in0, %in1 : i32, i32, i32
 }
+
+// -----
+
+// expected-error @below {{could not resolve cycles in module}}
+hw.module @testModule(in %in0 : i32) attributes {num_regs = 0 : i32, initial_values = []} {
+  %add = comb.add %in0, %or : i32
+  %or = comb.or %in0, %add : i32
+  // Dummy property
+  %true = hw.constant true
+  verif.assert %true : i1
+  hw.output
+}


### PR DESCRIPTION
Allows circt-bmc to support modules that contain non-dominance but can be topologically sorted. Doesn't cover every edge case (i.e. when modules get involved and there may be cycles), but I've run into needing this a few times so it's probably useful to have upstream.