### PR TITLE
Add the BLIF dialect.

### DIFF
--- a/include/circt/Dialect/BLIF/BLIF.td
+++ b/include/circt/Dialect/BLIF/BLIF.td
@@ -1,0 +1,21 @@
+//===- BLIF.td - BLIF dialect definition -------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This is the top level file for the BLIF dialect.  This dialect represents
+// the (extended) Berkely Logic Interchange Format 
+// [http://bear.ces.cwru.edu/eecs_cad/sis_blif.pdf].
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_BLIF_BLIF_TD
+#define CIRCT_DIALECT_BLIF_BLIF_TD
+
+include "circt/Dialect/BLIF/BLIFDialect.td"
+include "circt/Dialect/BLIF/BLIFOps.td"
+
+#endif // CIRCT_DIALECT_BLIF_BLIF_TD

--- a/include/circt/Dialect/BLIF/BLIFDialect.h
+++ b/include/circt/Dialect/BLIF/BLIFDialect.h
@@ -1,0 +1,23 @@
+//===- BLIFDialect.h - BLIF dialect declaration -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines an BLIF MLIR dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_BLIF_BLIFDIALECT_H
+#define CIRCT_DIALECT_BLIF_BLIFDIALECT_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Dialect.h"
+
+// Pull in the dialect definition.
+#include "circt/Dialect/BLIF/BLIFDialect.h.inc"
+
+#endif // CIRCT_DIALECT_BLIF_BLIFDIALECT_H

--- a/include/circt/Dialect/BLIF/BLIFDialect.td
+++ b/include/circt/Dialect/BLIF/BLIFDialect.td
@@ -1,0 +1,33 @@
+//===- BLIFDialect.td - BLIF dialect definition ------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This contains the BLIFDialect definition to be included in other files.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_BLIF_BLIFDIALECT
+#define CIRCT_DIALECT_BLIF_BLIFDIALECT
+
+include "mlir/IR/OpBase.td"
+
+def BLIFDialect : Dialect {
+  let name = "blif";
+  let cppNamespace = "::circt::blif";
+
+  let summary = "Types and operations for the BLIF format dialect";
+  let description = [{
+    This dialect defines the `BLIF` dialect, which is a representation of
+    the Berkely Logic Interchange Format.
+  }];
+}
+
+// Base class for the operation in this dialect.
+class BLIFOp<string mnemonic, list<Trait> traits = []> :
+    Op<BLIFDialect, mnemonic, traits>;
+
+#endif // CIRCT_DIALECT_BLIF_BLIFDIALECT

--- a/include/circt/Dialect/BLIF/BLIFOps.h
+++ b/include/circt/Dialect/BLIF/BLIFOps.h
@@ -1,0 +1,23 @@
+//===- BLIFOps.h - Declare BLIF dialect operations --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the operation classes for the BLIF dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_BLIF_BLIFOPS_H
+#define CIRCT_DIALECT_BLIF_BLIFOPS_H
+
+#include "circt/Dialect/BLIF/BLIFDialect.h"
+#include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/IR/OpImplementation.h"
+
+#define GET_OP_CLASSES
+#include "circt/Dialect/BLIF/BLIF.h.inc"
+
+#endif // CIRCT_DIALECT_BLIF_BLIFOPS_H

--- a/include/circt/Dialect/BLIF/BLIFOps.td
+++ b/include/circt/Dialect/BLIF/BLIFOps.td
@@ -1,0 +1,53 @@
+//===- BLIFOps.td - BLIF ops ============-------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This defines the BLIF ops.  This defines module-like operations, connections,
+// and logic.
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_BLIF_BLIFOPS_TD
+#define CIRCT_DIALECT_BLIF_BLIFOPS_TD
+
+include "circt/Dialect/BLIF/BLIFDialect.td"
+include "circt/Dialect/HW/HWTypes.td"
+include "mlir/IR/RegionKindInterface.td"
+
+def ModelOp : BLIFOp<"model", [IsolatedFromAbove, RegionKindInterface, SingleBlockImplicitTerminator<"OutputOp">]> {
+  let summary = "A model, which is a module";
+  let description = [{
+    The basic container.  Is like a module.
+  }];
+
+  let arguments = (ins SymbolNameAttr:$sym_name,
+                       TypeAttrOf<ModuleType>:$module_type);
+  let results = (outs);
+  let regions = (region SizedRegion<1>:$body);
+}
+
+def OutputOp : BLIFOp<"output", [Terminator]> {
+  let arguments = (ins Variadic<I1>:$inputs);
+}
+
+def I8Property : IntProperty<"int8_t">;
+
+def LogicGate: BLIFOp<"logic_gate", []> {
+  let summary = "Combinatorial logic";
+  let description = [{
+    A logic gate represents a logic function in sum-of-products
+    form.  Each entry in $func is a vector applied to the inputs
+    where 0 means invert the input, 1 means use the input, and 2 
+    means don't use the input.
+  }];
+  
+  let arguments = (ins ArrayProperty<ArrayProperty<I8Property>>:$func,
+                       Variadic<I1>:$inputs);
+  let results = (outs I1:$result);
+}
+
+
+#endif // CIRCT_DIALECT_BLIF_BLIFOPS_TD

--- a/include/circt/Dialect/BLIF/CMakeLists.txt
+++ b/include/circt/Dialect/BLIF/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_circt_dialect(BLIF blif)
+
+set(LLVM_TARGET_DEFINITIONS BLIF.td)

--- a/include/circt/Dialect/CMakeLists.txt
+++ b/include/circt/Dialect/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_subdirectory(AIG)
 add_subdirectory(Arc)
+add_subdirectory(BLIF)
 add_subdirectory(Calyx)
 add_subdirectory(Comb)
 add_subdirectory(DC)


### PR DESCRIPTION
The BLIF dialect implements the extended berkely logic interchange format.  This is a format used by some OSS tools, such as some place-and-route tools.  This is the format used by yosys to interchange with nextpnr.