### PR TITLE
[ImportVerilog] add real literal support, refine real type, and add real format support

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -508,6 +508,24 @@ def StringConstantOp : MooreOp<"string_constant", [Pure]> {
   let assemblyFormat = "$value attr-dict `:` type($result)";
 }
 
+def RealLiteralOp : MooreOp<"real_constant", [Pure]> {
+  let summary = "Produce a constant real value";
+  let description = [{
+    Produces a constant value of real type.
+
+    Example:
+    ```mlir
+    %0 = moore.real_constant 1.23
+    ```
+
+    The default type for fixed-point format (e.g., 1.2), and exponent format (e.g., 2.0e10) shall be real.
+    See IEEE 1800-2017 § 5.7.2 "Real literal constants".
+  }];
+  let arguments = (ins F64Attr:$value);
+  let results = (outs RealType:$result);
+  let assemblyFormat = "$value attr-dict `:` type($result)";
+}
+
 //===----------------------------------------------------------------------===//
 // Casting and Resizing
 //===----------------------------------------------------------------------===//
@@ -1494,6 +1512,24 @@ def FormatIntOp : MooreOp<"fmt.int", [Pure]> {
     attr-dict `:` type($value)
   }];
 }
+
+def FormatFloatOp : MooreOp<"fmt.float", [Pure]> {
+  let summary = "Format an float value";
+  let description = [{
+    Format an float value as a string according to the specified format.
+
+    See IEEE 1800-2017 § 21.2.1.2 "Format specifications".
+  }];
+  let arguments = (ins
+    FloatType:$value
+  );
+  let results = (outs FormatStringType:$result);
+  let assemblyFormat = [{
+    $value `,`
+    attr-dict `:` type($value)
+  }];
+}
+
 
 //===----------------------------------------------------------------------===//
 // Builtin System Tasks and Functions

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -701,8 +701,8 @@ def BoolCastOp : MooreOp<"bool_cast", [
 
 class BinaryOpBase<string mnemonic, list<Trait> traits = []> :
     MooreOp<mnemonic, traits # [Pure, SameOperandsAndResultType]> {
-  let arguments = (ins SimpleBitVectorType:$lhs, SimpleBitVectorType:$rhs);
-  let results = (outs SimpleBitVectorType:$result);
+  let arguments = (ins NumericType:$lhs, NumericType:$rhs);
+  let results = (outs NumericType:$result);
   let assemblyFormat = [{
     $lhs `,` $rhs attr-dict `:` type($result)
   }];

--- a/include/circt/Dialect/Moore/MooreTypes.h
+++ b/include/circt/Dialect/Moore/MooreTypes.h
@@ -83,7 +83,7 @@ enum class Domain {
 class UnpackedType : public Type {
 public:
   static bool classof(Type type) {
-    return llvm::isa<PackedType, StringType, ChandleType, EventType, RealType, ShortRealType,
+    return llvm::isa<PackedType, StringType, ChandleType, EventType,
                      UnpackedArrayType, OpenUnpackedArrayType, AssocArrayType,
                      QueueType, UnpackedStructType, UnpackedUnionType>(type);
   }
@@ -134,7 +134,7 @@ protected:
 class PackedType : public UnpackedType {
 public:
   static bool classof(Type type) {
-    return llvm::isa<VoidType, IntType, ArrayType, OpenArrayType, StructType,
+    return llvm::isa<VoidType, IntType, ArrayType, OpenArrayType, StructType, RealType, ShortRealType,
                      UnionType>(type);
   }
 

--- a/include/circt/Dialect/Moore/MooreTypes.h
+++ b/include/circt/Dialect/Moore/MooreTypes.h
@@ -34,6 +34,7 @@ class OpenUnpackedArrayType;
 class PackedType;
 class QueueType;
 class RealType;
+class ShortRealType;
 class StringType;
 class StructType;
 class UnionType;
@@ -82,7 +83,7 @@ enum class Domain {
 class UnpackedType : public Type {
 public:
   static bool classof(Type type) {
-    return llvm::isa<PackedType, StringType, ChandleType, EventType, RealType,
+    return llvm::isa<PackedType, StringType, ChandleType, EventType, RealType, ShortRealType,
                      UnpackedArrayType, OpenUnpackedArrayType, AssocArrayType,
                      QueueType, UnpackedStructType, UnpackedUnionType>(type);
   }

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -97,7 +97,7 @@ def IntType : MooreTypeDef<"Int", [], "moore::PackedType"> {
 // RealType
 //===----------------------------------------------------------------------===//
 
-def RealType : MooreTypeDef<"Real", [], "moore::UnpackedType"> {
+def RealType : MooreTypeDef<"Real", [], "moore::PackedType"> {
   let mnemonic = "real";
   let summary = "a SystemVerilog real type";
   let description = [{
@@ -113,7 +113,7 @@ def RealType : MooreTypeDef<"Real", [], "moore::UnpackedType"> {
   }];
 }
 
-def ShortRealType : MooreTypeDef<"ShortReal", [], "moore::UnpackedType"> {
+def ShortRealType : MooreTypeDef<"ShortReal", [], "moore::PackedType"> {
   let mnemonic = "shortreal";
   let summary = "a SystemVerilog short real type";
   let description = [{
@@ -426,7 +426,9 @@ def BitType : MooreType<CPred<[{
   }];
 }
 
-def FloatType : MooreType<Or<[RealType.predicate, ShortRealType.predicate]>, "float point type in moore", "moore::UnpackedType">;
+def FloatType : MooreType<Or<[RealType.predicate, ShortRealType.predicate]>, "float point type in moore", "moore::PackedType">;
+
+def NumericType : MooreType<Or<[FloatType.predicate, SimpleBitVectorType.predicate]>, "numeric type in moore", "moore::PackedType">;
 
 /// A packed or unpacked array type with a fixed size.
 def AnyStaticArrayType : MooreType<

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -101,18 +101,23 @@ def RealType : MooreTypeDef<"Real", [], "moore::UnpackedType"> {
   let mnemonic = "real";
   let summary = "a SystemVerilog real type";
   let description = [{
-    This type represents the SystemVerilog real type. Since the Moore dialect
-    does not fully handle real-valued expressions properly yet, we coalesce the
-    `shortreal`, `real`, and `realtime` types in the SystemVerilgo standard to
-    this common `!moore.real` type. The standard specifies these types to be of
-    at least 32, 64, and 64 bits, respectively. The `!moore.real` type is 64
-    bits wide.
+    SystemVerilog real type. The real data type is the same as a C double.
+    The realtime declarations shall be treated synonymously with real 
+    declarations and can be used interchangeably.
 
-    | Verilog     | Moore Dialect |
-    |-------------|---------------|
-    | `shortreal` | `!moore.real` |
-    | `real`      | `!moore.real` |
-    | `realtime`  | `!moore.real` |
+    | Verilog     |   Moore Dialect    |
+    |-------------|--------------------|
+    | `shortreal` | `!moore.shortreal` |
+    | `real`      | `!moore.real`      |
+    | `realtime`  | `!moore.real`      |
+  }];
+}
+
+def ShortRealType : MooreTypeDef<"ShortReal", [], "moore::UnpackedType"> {
+  let mnemonic = "shortreal";
+  let summary = "a SystemVerilog short real type";
+  let description = [{
+    The shortreal data type is the same as a C float.
   }];
 }
 
@@ -420,6 +425,8 @@ def BitType : MooreType<CPred<[{
     IntType::getInt($_builder.getContext(), 1)
   }];
 }
+
+def FloatType : MooreType<Or<[RealType.predicate, ShortRealType.predicate]>, "float point type in moore", "moore::UnpackedType">;
 
 /// A packed or unpacked array type with a fixed size.
 def AnyStaticArrayType : MooreType<

--- a/include/circt/Dialect/Sim/SimOps.h
+++ b/include/circt/Dialect/Sim/SimOps.h
@@ -43,6 +43,8 @@ static inline mlir::Value getFormattedValue(mlir::Operation *fmtOp) {
     return fmt.getValue();
   if (auto fmt = llvm::dyn_cast_or_null<circt::sim::FormatCharOp>(fmtOp))
     return fmt.getValue();
+  if (auto fmt = llvm::dyn_cast_or_null<circt::sim::FormatFloatOp>(fmtOp))
+    return fmt.getValue();
   return {};
 }
 

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -278,6 +278,20 @@ def FormatCharOp : SimOp<"fmt.char", [Pure]> {
   let assemblyFormat = "$value attr-dict `:` qualified(type($value))";
 }
 
+def FormatFloatOp : SimOp<"fmt.float", [Pure]> {
+  let summary = "Float format specifier";
+  let description = [{
+  }];
+
+  let arguments = (ins AnyFloat:$value);
+  let results = (outs FormatStringType:$result);
+
+  let hasFolder = true;
+
+  let assemblyFormat = "$value attr-dict `:` qualified(type($value))";
+}
+
+
 def FormatStringConcatOp : SimOp<"fmt.concat", [Pure]> {
   let summary = "Concatenate format strings";
   let description = [{

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -879,6 +879,10 @@ struct RvalueExprVisitor {
     return builder.create<moore::ConcatOp>(loc, slicedOperands);
   }
 
+  Value visit(const slang::ast::RealLiteral &expr) {
+    return builder.create<moore::RealLiteralOp>(loc, builder.getF64FloatAttr(expr.getValue()));
+  }
+
   /// Emit an error for all other expressions.
   template <typename T>
   Value visit(T &&node) {

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1268,6 +1268,9 @@ Value Context::materializeConversion(Type type, Value value, bool isSigned,
     return value;
   auto dstPacked = dyn_cast<moore::PackedType>(type);
   auto srcPacked = dyn_cast<moore::PackedType>(value.getType());
+  if(isa<moore::RealType>(type) || isa<moore::ShortRealType>(type)) {
+    return builder.create<moore::ConversionOp>(value.getLoc(), type, value);
+  }
 
   // Resize the value if needed.
   if (dstPacked && srcPacked && dstPacked.getBitSize() &&

--- a/lib/Conversion/ImportVerilog/FormatStrings.cpp
+++ b/lib/Conversion/ImportVerilog/FormatStrings.cpp
@@ -141,6 +141,9 @@ struct FormatStringParser {
       return mlir::emitError(argLoc)
              << "expression cannot be formatted as string";
 
+    case 'f':
+      return emitFloat(arg, options);
+
     default:
       return mlir::emitError(loc)
              << "unsupported format specifier `" << fullSpecifier << "`";
@@ -179,6 +182,13 @@ struct FormatStringParser {
 
     fragments.push_back(builder.create<moore::FormatIntOp>(
         loc, value, format, width, alignment, padding));
+    return success();
+  }
+
+  LogicalResult emitFloat(const slang::ast::Expression &arg, const FormatOptions &options) {
+    auto value = context.convertRvalueExpression(arg);
+    
+    fragments.push_back(builder.create<moore::FormatFloatOp>(loc, value));
     return success();
   }
 

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "ImportVerilogInternals.h"
+#include "circt/Dialect/Moore/MooreTypes.h"
+#include "slang/ast/types/AllTypes.h"
 #include "slang/syntax/AllSyntax.h"
 
 using namespace circt;
@@ -36,7 +38,15 @@ struct TypeVisitor {
   }
 
   Type visit(const slang::ast::FloatingType &type) {
-    return moore::RealType::get(context.getContext());
+    switch(type.floatKind) {
+    case slang::ast::FloatingType::ShortReal:
+      return moore::ShortRealType::get(context.getContext());
+    case slang::ast::FloatingType::Real:
+    case slang::ast::FloatingType::RealTime:
+      return moore::RealType::get(context.getContext());
+    default:
+      return {};
+    }
   }
 
   Type visit(const slang::ast::PredefinedIntegerType &type) {

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1477,6 +1477,18 @@ struct FormatIntOpConversion : public OpConversionPattern<FormatIntOp> {
   }
 };
 
+struct FormatFloatOpConversion : public OpConversionPattern<FormatFloatOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(FormatFloatOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // TODO: These should honor the width, alignment, and padding.
+    return success();
+  }
+};
+
+
 struct DisplayBIOpConversion : public OpConversionPattern<DisplayBIOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -1730,6 +1742,7 @@ static void populateOpConversion(RewritePatternSet &patterns,
     FormatLiteralOpConversion,
     FormatConcatOpConversion,
     FormatIntOpConversion,
+    FormatFloatOpConversion,
     DisplayBIOpConversion
   >(typeConverter, context);
   // clang-format on

--- a/lib/Dialect/Moore/MooreTypes.cpp
+++ b/lib/Dialect/Moore/MooreTypes.cpp
@@ -103,6 +103,8 @@ Domain PackedType::getDomain() const {
       .Case<IntType>([&](auto type) { return type.getDomain(); })
       .Case<ArrayType, OpenArrayType>(
           [&](auto type) { return type.getElementType().getDomain(); })
+      .Case<ShortRealType>([](auto) { return Domain::TwoValued;})
+      .Case<RealType>([](auto) { return Domain::TwoValued; })
       .Case<StructType, UnionType>([](auto type) {
         for (const auto &member : type.getMembers())
           if (member.type.getDomain() == Domain::FourValued)
@@ -143,6 +145,8 @@ std::optional<unsigned> PackedType::getBitSize() const {
         }
         return size;
       })
+      .Case<ShortRealType>([](auto) { return 32; })
+      .Case<RealType>([](auto) { return 64; })
       .Default([](auto) { return std::nullopt; });
 }
 

--- a/lib/Dialect/Sim/SimOps.cpp
+++ b/lib/Dialect/Sim/SimOps.cpp
@@ -183,6 +183,17 @@ OpFoldResult FormatCharOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
+OpFoldResult FormatFloatOp::fold(FoldAdaptor adaptor) {
+  if (auto floatAttr = llvm::dyn_cast_or_null<FloatAttr>(adaptor.getValue())) {
+    SmallVector<char, 32> strBuf;
+    floatAttr.getValue().toString(strBuf);
+    return StringAttr::get(getContext(), Twine(strBuf));
+  }
+
+  return {};
+}
+
+
 static StringAttr concatLiterals(MLIRContext *ctxt, ArrayRef<StringRef> lits) {
   assert(!lits.empty() && "No literals to concatenate");
   if (lits.size() == 1)

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -672,6 +672,12 @@ module Expressions;
   // CHECK: %r1 = moore.variable : <real>
   // CHECK: %r2 = moore.variable : <real>
   real r1,r2;
+  // CHECK: %sr1 = moore.variable : <shortreal>
+  // CHECK: %sr2 = moore.variable : <shortreal>
+  shortreal sr1, sr2;
+  // CHECK: %rt1 = moore.variable : <real>
+  // CHECK: %rt2 = moore.variable : <real>
+  realtime rt1, rt2;
   // CHECK: %arrayInt = moore.variable : <array<2 x i32>>
   bit [1:0][31:0] arrayInt;
   // CHECK: %uarrayInt = moore.variable : <uarray<2 x i32>>
@@ -1394,6 +1400,57 @@ module Expressions;
     // CHECK: [[TMP3:%.+]] = moore.struct_create [[TMP0]], [[TMP1]] : !moore.i32, !moore.i32 -> struct<{a: i32, b: i32}>
     // CHECK: moore.struct_create [[TMP2]], [[TMP3]] : !moore.struct<{a: i32, b: i32}>, !moore.struct<{a: i32, b: i32}> -> struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>
     struct1 = '{c: '{a: 1, b: 2}, d: '{a: 3, b: 4}};
+
+    // CHECK: %[[R1_INIT:.*]] = moore.real_constant 3.140000e+00 : real
+    // CHECK: moore.blocking_assign %r1, %[[R1_INIT]] : real
+    r1 = 3.14;
+    // CHECK: %[[R2_INIT:.*]] = moore.real_constant 2.710000e+00 : real
+    // CHECK: moore.blocking_assign %r2, %[[R2_INIT]] : real
+    r2 = 2.71;
+    // CHECK: %[[SR1_INIT_REAL:.*]] = moore.real_constant 1.410000e+00 : real
+    // CHECK: %[[SR1_INIT:.*]] = moore.conversion %[[SR1_INIT_REAL]] : !moore.real -> !moore.shortreal
+    // CHECK: moore.blocking_assign %sr1, %[[SR1_INIT]] : shortreal
+    sr1 = 1.41;
+    // CHECK: %[[READ_R1_1:.*]] = moore.read %r1 : <real>
+    // CHECK: %[[READ_SR1_1:.*]] = moore.read %sr1 : <shortreal>
+    // CHECK: %[[SR1_TO_REAL_1:.*]] = moore.conversion %[[READ_SR1_1]] : !moore.shortreal -> !moore.real
+    // CHECK: %[[ADD_1:.*]] = moore.add %[[READ_R1_1]], %[[SR1_TO_REAL_1]] : real
+    // CHECK: %[[ADD_1_SHORT:.*]] = moore.conversion %[[ADD_1]] : !moore.real -> !moore.shortreal
+    // CHECK: moore.blocking_assign %sr2, %[[ADD_1_SHORT]] : shortreal
+    sr2 = r1 + sr1;
+    // CHECK: %[[READ_SR1_2:.*]] = moore.read %sr1 : <shortreal>
+    // CHECK: %[[SR1_TO_REAL_2:.*]] = moore.conversion %[[READ_SR1_2]] : !moore.shortreal -> !moore.real
+    // CHECK: moore.blocking_assign %rt1, %[[SR1_TO_REAL_2]] : real
+    rt1 = sr1;
+    // CHECK: %[[READ_SR1_3:.*]] = moore.read %sr1 : <shortreal>
+    // CHECK: %[[SR1_TO_REAL_3:.*]] = moore.conversion %[[READ_SR1_3]] : !moore.shortreal -> !moore.real
+    // CHECK: %[[READ_SR2:.*]] = moore.read %sr2 : <shortreal>
+    // CHECK: %[[SR2_TO_REAL:.*]] = moore.conversion %[[READ_SR2]] : !moore.shortreal -> !moore.real
+    // CHECK: %[[SUB_1:.*]] = moore.sub %[[SR1_TO_REAL_3]], %[[SR2_TO_REAL]] : real
+    // CHECK: moore.blocking_assign %rt2, %[[SUB_1]] : real
+    rt2 = sr1 - sr2;
+    // CHECK: %[[READ_R1_2:.*]] = moore.read %r1 : <real>
+    // CHECK: %[[READ_SR1_4:.*]] = moore.read %sr1 : <shortreal>
+    // CHECK: %[[SR1_TO_REAL_4:.*]] = moore.conversion %[[READ_SR1_4]] : !moore.shortreal -> !moore.real
+    // CHECK: %[[ADD_2:.*]] = moore.add %[[READ_R1_2]], %[[SR1_TO_REAL_4]] : real
+    // CHECK: %[[ADD_2_I64:.*]] = moore.conversion %[[ADD_2]] : !moore.real -> !moore.i64
+    // CHECK: %[[TRUNC_1:.*]] = moore.trunc %[[ADD_2_I64]] : i64 -> i32
+    // CHECK: moore.blocking_assign %a, %[[TRUNC_1]] : i32
+    a = r1 + sr1;
+    // CHECK: %[[READ_A:.*]] = moore.read %a : <i32>
+    // CHECK: %[[A_TO_REAL:.*]] = moore.conversion %[[READ_A]] : !moore.i32 -> !moore.real
+    // CHECK: %[[READ_SR1_5:.*]] = moore.read %sr1 : <shortreal>
+    // CHECK: %[[SR1_TO_REAL_5:.*]] = moore.conversion %[[READ_SR1_5]] : !moore.shortreal -> !moore.real
+    // CHECK: %[[ADD_3:.*]] = moore.add %[[A_TO_REAL]], %[[SR1_TO_REAL_5]] : real
+    // CHECK: moore.blocking_assign %r1, %[[ADD_3]] : real
+    r1 = a + sr1;
+    // CHECK: %[[READ_A_2:.*]] = moore.read %a : <i32>
+    // CHECK: %[[A_TO_REAL_2:.*]] = moore.conversion %[[READ_A_2]] : !moore.i32 -> !moore.real
+    // CHECK: %[[READ_R1_3:.*]] = moore.read %r1 : <real>
+    // CHECK: %[[ADD_4:.*]] = moore.add %[[A_TO_REAL_2]], %[[READ_R1_3]] : real
+    // CHECK: %[[ADD_4_SHORT:.*]] = moore.conversion %[[ADD_4]] : !moore.real -> !moore.shortreal
+    // CHECK: moore.blocking_assign %sr1, %[[ADD_4_SHORT]] : shortreal
+    sr1 = a + r1;
 
     // CHECK: [[TMP0:%.+]] = moore.constant 42
     // CHECK: [[TMP1:%.+]] = moore.constant 9001


### PR DESCRIPTION
This PR is aimed to support systemverilog real, shortreal, realtime, and there conversion and operation.

One thing I'm not so sure about is that

```mlir
class BinaryOpBase<string mnemonic, list<Trait> traits = []> :
    MooreOp<mnemonic, traits # [Pure, SameOperandsAndResultType]> {
  let arguments = (ins SimpleBitVectorType:$lhs, SimpleBitVectorType:$rhs);
  let results = (outs SimpleBitVectorType:$result);
  let assemblyFormat = [{
    $lhs `,` $rhs attr-dict `:` type($result)
  }];
}
```

why this opbase just support SimpleBitVectorType? is there any shortcoming to just convert it to a UnpackedType? I also want to use this OpBase support float point operation.