### PR TITLE
[RTG] Add context resource attribute interface

### DIFF
--- a/include/circt-c/Dialect/RTGTest.h
+++ b/include/circt-c/Dialect/RTGTest.h
@@ -31,6 +31,20 @@ MLIR_CAPI_EXPORTED bool rtgtestTypeIsACPU(MlirType type);
 /// Creates an RTGTest CPU type in the context.
 MLIR_CAPI_EXPORTED MlirType rtgtestCPUTypeGet(MlirContext ctxt);
 
+//===----------------------------------------------------------------------===//
+// Attribute API.
+//===----------------------------------------------------------------------===//
+
+/// If the type is an RTGTest CPUAttr.
+MLIR_CAPI_EXPORTED bool rtgtestAttrIsACPU(MlirAttribute attr);
+
+/// Creates an RTGTest CPU attribute in the context.
+MLIR_CAPI_EXPORTED MlirAttribute rtgtestCPUAttrGet(MlirContext ctxt,
+                                                   unsigned id);
+
+/// Returns the core ID represented by the CPU attribute.
+MLIR_CAPI_EXPORTED unsigned rtgtestCPUAttrGetId(MlirAttribute attr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/circt/Dialect/RTG/IR/CMakeLists.txt
+++ b/include/circt/Dialect/RTG/IR/CMakeLists.txt
@@ -18,6 +18,11 @@ mlir_tablegen(RTGTypeInterfaces.cpp.inc -gen-type-interface-defs)
 add_public_tablegen_target(CIRCTRTGTypeInterfacesIncGen)
 add_dependencies(circt-headers CIRCTRTGTypeInterfacesIncGen)
 
+mlir_tablegen(RTGAttrInterfaces.h.inc -gen-attr-interface-decls)
+mlir_tablegen(RTGAttrInterfaces.cpp.inc -gen-attr-interface-defs)
+add_public_tablegen_target(CIRCTRTGAttrInterfacesIncGen)
+add_dependencies(circt-headers CIRCTRTGAttrInterfacesIncGen)
+
 set(LLVM_TARGET_DEFINITIONS RTGISAAssemblyInterfaces.td)
 mlir_tablegen(RTGISAAssemblyOpInterfaces.h.inc -gen-op-interface-decls)
 mlir_tablegen(RTGISAAssemblyOpInterfaces.cpp.inc -gen-op-interface-defs)

--- a/include/circt/Dialect/RTG/IR/RTGAttrInterfaces.h
+++ b/include/circt/Dialect/RTG/IR/RTGAttrInterfaces.h
@@ -1,0 +1,22 @@
+//===- RTGAttrInterfaces.h - Declare RTG attr interfaces --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares attr interfaces for the RTG Dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_RTG_IR_RTGATTRINTERFACES_H
+#define CIRCT_DIALECT_RTG_IR_RTGATTRINTERFACES_H
+
+#include "circt/Support/LLVM.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
+
+#include "circt/Dialect/RTG/IR/RTGAttrInterfaces.h.inc"
+
+#endif // CIRCT_DIALECT_RTG_IR_RTGATTRINTERFACES_H

--- a/include/circt/Dialect/RTG/IR/RTGInterfaces.td
+++ b/include/circt/Dialect/RTG/IR/RTGInterfaces.td
@@ -11,6 +11,7 @@
 
 include "mlir/IR/Interfaces.td"
 include "mlir/IR/OpBase.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
 
 def ContextResourceOpInterface : OpInterface<"ContextResourceOpInterface"> {
   let description = [{
@@ -46,6 +47,20 @@ def ContextResourceTypeInterface : TypeInterface<
     Any operation that creates a value of a type implementing this interface
     must implement the `ContextResourceOpInterface` (does not apply to
     operations that just forward a value of such type).
+  }];
+  let cppNamespace = "::circt::rtg";
+}
+
+def ContextResourceAttrInterface : AttrInterface<
+    "ContextResourceAttrInterface", [TypedAttrInterface]> {
+  let description = [{
+    This interface should be implemented by attributes that represent context
+    resources.
+    Any attribute implementing this interface must be of a type implementing
+    the `ContextResourceTypeInterface`.
+
+    TODO: properly verify this; unfortunately, we don't have a 'verify' field
+    here like the 'OpInterface' has.
   }];
   let cppNamespace = "::circt::rtg";
 }

--- a/include/circt/Dialect/RTG/IR/RTGOps.h
+++ b/include/circt/Dialect/RTG/IR/RTGOps.h
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_RTG_IR_RTGOPS_H
 #define CIRCT_DIALECT_RTG_IR_RTGOPS_H
 
+#include "circt/Dialect/RTG/IR/RTGAttrInterfaces.h"
 #include "circt/Dialect/RTG/IR/RTGDialect.h"
 #include "circt/Dialect/RTG/IR/RTGTypeInterfaces.h"
 #include "circt/Dialect/RTG/IR/RTGTypes.h"

--- a/include/circt/Dialect/RTGTest/IR/CMakeLists.txt
+++ b/include/circt/Dialect/RTGTest/IR/CMakeLists.txt
@@ -8,3 +8,7 @@ set(LLVM_TARGET_DEFINITIONS RTGTestAttributes.td)
 mlir_tablegen(RTGTestEnums.h.inc -gen-enum-decls)
 mlir_tablegen(RTGTestEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(CIRCTRTGTestEnumsIncGen)
+
+mlir_tablegen(RTGTestAttributes.h.inc -gen-attrdef-decls)
+mlir_tablegen(RTGTestAttributes.cpp.inc -gen-attrdef-defs)
+add_public_tablegen_target(CIRCTRTGTestAttributeIncGen)

--- a/include/circt/Dialect/RTGTest/IR/RTGTest.td
+++ b/include/circt/Dialect/RTGTest/IR/RTGTest.td
@@ -22,6 +22,7 @@ include "circt/Dialect/RTG/IR/RTGInterfaces.td"
 include "circt/Dialect/RTGTest/IR/RTGTestDialect.td"
 include "circt/Dialect/RTGTest/IR/RTGTestAttributes.td"
 include "circt/Dialect/RTGTest/IR/RTGTestTypes.td"
+include "circt/Dialect/RTGTest/IR/RTGTestAttributes.td"
 include "circt/Dialect/RTGTest/IR/RTGTestOps.td"
 
 #endif // CIRCT_DIALECT_RTGTEST_IR_RTGTEST_TD

--- a/include/circt/Dialect/RTGTest/IR/RTGTestAttributes.h
+++ b/include/circt/Dialect/RTGTest/IR/RTGTestAttributes.h
@@ -1,0 +1,21 @@
+//===- RTGTestAttributes.h - RTG Test dialect attributes --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_RTGTEST_IR_RTGTESTATTRIBUTES_H
+#define CIRCT_DIALECT_RTGTEST_IR_RTGTESTATTRIBUTES_H
+
+#include "circt/Dialect/RTGTest/IR/RTGTestTypes.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+
+#include "circt/Dialect/RTG/IR/RTGAttrInterfaces.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/RTGTest/IR/RTGTestAttributes.h.inc"
+
+#endif // CIRCT_DIALECT_RTGTEST_IR_RTGTESTATTRIBUTES_H

--- a/include/circt/Dialect/RTGTest/IR/RTGTestAttributes.td
+++ b/include/circt/Dialect/RTGTest/IR/RTGTestAttributes.td
@@ -13,6 +13,8 @@
 #ifndef CIRCT_DIALECT_RTGTEST_IR_RTGTESTATTRIBUTES_TD
 #define CIRCT_DIALECT_RTGTEST_IR_RTGTESTATTRIBUTES_TD
 
+include "circt/Dialect/RTGTest/IR/RTGTestDialect.td"
+include "circt/Dialect/RTG/IR/RTGInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
 
@@ -55,6 +57,23 @@ def RegisterAttr : I32EnumAttr<
     I32EnumAttrCase<"Virtual",  32>
   ]> {
   let cppNamespace = "::circt::rtgtest";
+}
+
+class RTGTestAttrDef<string name, list<Trait> traits = []> 
+  : AttrDef<RTGTestDialect, name, traits>;
+
+def CPUAttr : RTGTestAttrDef<"CPU", [ContextResourceAttrInterface]> {
+  let summary = "this attribute represents a CPU referred to by the core ID";
+
+  let parameters = (ins "size_t":$id);
+
+  let mnemonic = "cpu";
+  let assemblyFormat = "`<` $id `>`";
+
+  let extraClassDeclaration = [{
+    // TypedAttrInterface
+    Type getType() const;
+  }];
 }
 
 #endif // CIRCT_DIALECT_RTGTEST_IR_RTGTESTATTRIBUTES_TD

--- a/include/circt/Dialect/RTGTest/IR/RTGTestDialect.td
+++ b/include/circt/Dialect/RTGTest/IR/RTGTestDialect.td
@@ -26,9 +26,11 @@ def RTGTestDialect : Dialect {
   }];
 
   let useDefaultTypePrinterParser = 1;
+  let useDefaultAttributePrinterParser = 1;
   let cppNamespace = "::circt::rtgtest";
 
   let extraClassDeclaration = [{
+    void registerAttributes();
     void registerTypes();
   }];
 }

--- a/include/circt/Dialect/RTGTest/IR/RTGTestOps.h
+++ b/include/circt/Dialect/RTGTest/IR/RTGTestOps.h
@@ -16,6 +16,7 @@
 #include "circt/Dialect/RTG/IR/RTGISAAssemblyOpInterfaces.h"
 #include "circt/Dialect/RTG/IR/RTGOpInterfaces.h"
 #include "circt/Dialect/RTG/IR/RTGOps.h"
+#include "circt/Dialect/RTGTest/IR/RTGTestAttributes.h"
 #include "circt/Dialect/RTGTest/IR/RTGTestDialect.h"
 #include "circt/Dialect/RTGTest/IR/RTGTestTypes.h"
 #include "circt/Support/LLVM.h"

--- a/include/circt/Dialect/RTGTest/IR/RTGTestOps.td
+++ b/include/circt/Dialect/RTGTest/IR/RTGTestOps.td
@@ -22,7 +22,9 @@ class RTGTestOp<string mnemonic, list<Trait> traits = []> :
 
 def CPUDeclOp : RTGTestOp<"cpu_decl", [
   Pure,
+  ConstantLike,
   ContextResourceDefining,
+  FirstAttrDerivedResultType,
 ]> {
   let summary = "declare a CPU";
   let description = [{
@@ -30,10 +32,11 @@ def CPUDeclOp : RTGTestOp<"cpu_decl", [
     taking advantage of it.
   }];
 
-  let arguments = (ins IndexAttr:$id);
+  let arguments = (ins CPUAttr:$id);
   let results = (outs CPUType:$cpu);
 
   let assemblyFormat = "$id attr-dict";
+  let hasFolder = 1;
 }
 
 def ConstantTestOp : RTGTestOp<"constant_test", [

--- a/integration_test/Bindings/Python/dialects/rtg.py
+++ b/integration_test/Bindings/Python/dialects/rtg.py
@@ -19,16 +19,17 @@ with Context() as ctx, Location.unknown():
     target = rtg.TargetOp('target_name', TypeAttr.get(dictTy))
     targetBlock = Block.create_at_start(target.bodyRegion, [])
     with InsertionPoint(targetBlock):
-      cpu0 = rtgtest.CPUDeclOp(0)
-      cpu1 = rtgtest.CPUDeclOp(1)
+      cpuAttr = rtgtest.CPUAttr.get(0)
+      cpu0 = rtgtest.CPUDeclOp(cpuAttr)
+      cpu1 = rtgtest.CPUDeclOp(rtgtest.CPUAttr.get(cpuAttr.id + 1))
       rtg.YieldOp([cpu0, cpu1])
 
     test = rtg.TestOp('test_name', TypeAttr.get(dictTy))
     Block.create_at_start(test.bodyRegion, [cpuTy, cpuTy])
 
   # CHECK: rtg.target @target_name : !rtg.dict<cpu0: !rtgtest.cpu, cpu1: !rtgtest.cpu> {
-  # CHECK:   [[V0:%.+]] = rtgtest.cpu_decl 0
-  # CHECK:   [[V1:%.+]] = rtgtest.cpu_decl 1
+  # CHECK:   [[V0:%.+]] = rtgtest.cpu_decl <0>
+  # CHECK:   [[V1:%.+]] = rtgtest.cpu_decl <1>
   # CHECK:   rtg.yield [[V0]], [[V1]] : !rtgtest.cpu, !rtgtest.cpu
   # CHECK: }
   # CHECK: rtg.test @test_name : !rtg.dict<cpu0: !rtgtest.cpu, cpu1: !rtgtest.cpu> {

--- a/lib/Bindings/Python/RTGTestModule.cpp
+++ b/lib/Bindings/Python/RTGTestModule.cpp
@@ -31,4 +31,14 @@ void circt::python::populateDialectRTGTestSubmodule(py::module &m) {
             return cls(rtgtestCPUTypeGet(ctxt));
           },
           py::arg("self"), py::arg("ctxt") = nullptr);
+
+  mlir_attribute_subclass(m, "CPUAttr", rtgtestAttrIsACPU)
+      .def_classmethod(
+          "get",
+          [](py::object cls, unsigned id, MlirContext ctxt) {
+            return cls(rtgtestCPUAttrGet(ctxt, id));
+          },
+          py::arg("self"), py::arg("id"), py::arg("ctxt") = nullptr)
+      .def_property_readonly(
+          "id", [](MlirAttribute self) { return rtgtestCPUAttrGetId(self); });
 }

--- a/lib/CAPI/Dialect/RTGTest.cpp
+++ b/lib/CAPI/Dialect/RTGTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt-c/Dialect/RTGTest.h"
+#include "circt/Dialect/RTGTest/IR/RTGTestAttributes.h"
 #include "circt/Dialect/RTGTest/IR/RTGTestDialect.h"
 #include "circt/Dialect/RTGTest/IR/RTGTestTypes.h"
 
@@ -29,4 +30,20 @@ bool rtgtestTypeIsACPU(MlirType type) { return isa<CPUType>(unwrap(type)); }
 
 MlirType rtgtestCPUTypeGet(MlirContext ctxt) {
   return wrap(CPUType::get(unwrap(ctxt)));
+}
+
+//===----------------------------------------------------------------------===//
+// Attribute API.
+//===----------------------------------------------------------------------===//
+
+bool rtgtestAttrIsACPU(MlirAttribute attr) {
+  return isa<CPUAttr>(unwrap(attr));
+}
+
+MlirAttribute rtgtestCPUAttrGet(MlirContext ctxt, unsigned id) {
+  return wrap(CPUAttr::get(unwrap(ctxt), id));
+}
+
+unsigned rtgtestCPUAttrGetId(MlirAttribute attr) {
+  return cast<CPUAttr>(unwrap(attr)).getId();
 }

--- a/lib/Dialect/RTG/IR/CMakeLists.txt
+++ b/lib/Dialect/RTG/IR/CMakeLists.txt
@@ -1,20 +1,22 @@
 add_circt_dialect_library(CIRCTRTGDialect
+  RTGAttrInterfaces.cpp
   RTGDialect.cpp
   RTGISAAssemblyOpInterfaces.cpp
   RTGOpInterfaces.cpp
   RTGOps.cpp
-  RTGTypes.cpp
   RTGTypeInterfaces.cpp
+  RTGTypes.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/RTG/IR
 
   DEPENDS
-  MLIRRTGIncGen
+  CIRCTRTGAttrInterfacesIncGen
   CIRCTRTGEnumsIncGen
-  CIRCTRTGOpInterfacesIncGen
   CIRCTRTGISAAssemblyOpInterfacesIncGen
+  CIRCTRTGOpInterfacesIncGen
   CIRCTRTGTypeInterfacesIncGen
+  MLIRRTGIncGen
     
   LINK_LIBS PUBLIC
   MLIRIR

--- a/lib/Dialect/RTG/IR/RTGAttrInterfaces.cpp
+++ b/lib/Dialect/RTG/IR/RTGAttrInterfaces.cpp
@@ -1,0 +1,19 @@
+//===- RTGAttrInterfaces.cpp - Implement the RTG attr interfaces ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the RTG attr interfaces.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/RTG/IR/RTGAttrInterfaces.h"
+
+//===----------------------------------------------------------------------===//
+// TableGen generated logic.
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/RTG/IR/RTGAttrInterfaces.cpp.inc"

--- a/lib/Dialect/RTGTest/IR/CMakeLists.txt
+++ b/lib/Dialect/RTGTest/IR/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_dialect_library(CIRCTRTGTestDialect
+  RTGTestAttributes.cpp
   RTGTestDialect.cpp
   RTGTestOps.cpp
   RTGTestTypes.cpp
@@ -9,6 +10,7 @@ add_circt_dialect_library(CIRCTRTGTestDialect
   DEPENDS
   MLIRRTGTestIncGen
   CIRCTRTGTestEnumsIncGen
+  CIRCTRTGTestAttributeIncGen
   
   LINK_LIBS PUBLIC
   MLIRIR

--- a/lib/Dialect/RTGTest/IR/RTGTestAttributes.cpp
+++ b/lib/Dialect/RTGTest/IR/RTGTestAttributes.cpp
@@ -1,0 +1,36 @@
+//===- RTGTestAttributes.cpp ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/RTGTest/IR/RTGTestAttributes.h"
+#include "circt/Dialect/RTGTest/IR/RTGTestDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace circt;
+using namespace rtgtest;
+
+//===----------------------------------------------------------------------===//
+// CPUAttr
+//===----------------------------------------------------------------------===//
+
+Type CPUAttr::getType() const { return rtgtest::CPUType::get(getContext()); }
+
+//===----------------------------------------------------------------------===//
+// TableGen generated logic.
+//===----------------------------------------------------------------------===//
+
+void RTGTestDialect::registerAttributes() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "circt/Dialect/RTGTest/IR/RTGTestAttributes.cpp.inc"
+      >();
+}
+
+#define GET_ATTRDEF_CLASSES
+#include "circt/Dialect/RTGTest/IR/RTGTestAttributes.cpp.inc"

--- a/lib/Dialect/RTGTest/IR/RTGTestDialect.cpp
+++ b/lib/Dialect/RTGTest/IR/RTGTestDialect.cpp
@@ -26,6 +26,7 @@ using namespace rtgtest;
 
 void RTGTestDialect::initialize() {
   registerTypes();
+  registerAttributes();
   // Register operations.
   addOperations<
 #define GET_OP_LIST

--- a/lib/Dialect/RTGTest/IR/RTGTestOps.cpp
+++ b/lib/Dialect/RTGTest/IR/RTGTestOps.cpp
@@ -21,7 +21,9 @@ using namespace rtgtest;
 // CPUDeclOp
 //===----------------------------------------------------------------------===//
 
-size_t CPUDeclOp::getIdentifier(size_t idx) { return getId().getZExtValue(); }
+size_t CPUDeclOp::getIdentifier(size_t idx) { return getId().getId(); }
+
+mlir::OpFoldResult CPUDeclOp::fold(FoldAdaptor adaptor) { return getId(); }
 
 //===----------------------------------------------------------------------===//
 // ConstantTestOp

--- a/test/CAPI/rtgtest.c
+++ b/test/CAPI/rtgtest.c
@@ -21,11 +21,23 @@ static void testCPUType(MlirContext ctx) {
   mlirTypeDump(cpuTy);
 }
 
+static void testCPUAttr(MlirContext ctx) {
+  MlirAttribute cpuAttr = rtgtestCPUAttrGet(ctx, 3);
+
+  // CHECK: is_cpu
+  fprintf(stderr, rtgtestAttrIsACPU(cpuAttr) ? "is_cpu\n" : "isnot_cpu\n");
+  // CHECK: 3
+  fprintf(stderr, "%u\n", rtgtestCPUAttrGetId(cpuAttr));
+  // CHECK: #rtgtest.cpu<3>
+  mlirAttributeDump(cpuAttr);
+}
+
 int main(int argc, char **argv) {
   MlirContext ctx = mlirContextCreate();
   mlirDialectHandleLoadDialect(mlirGetDialectHandle__rtgtest__(), ctx);
 
   testCPUType(ctx);
+  testCPUAttr(ctx);
 
   mlirContextDestroy(ctx);
 

--- a/test/Dialect/RTGTest/IR/basic.mlir
+++ b/test/Dialect/RTGTest/IR/basic.mlir
@@ -3,8 +3,8 @@
 // CHECK-LABEL: @cpus
 // CHECK-SAME: !rtgtest.cpu
 rtg.target @cpus : !rtg.dict<cpu: !rtgtest.cpu> {
-  // CHECK: rtgtest.cpu_decl 0
-  %0 = rtgtest.cpu_decl 0
+  // CHECK: rtgtest.cpu_decl <0>
+  %0 = rtgtest.cpu_decl <0>
   rtg.yield %0 : !rtgtest.cpu
 }
 


### PR DESCRIPTION
Provides a way to specify context resources with an attribute that works well in combination with the ContextResourceTypeInterface. Currently, the `cpu_decl` operation has an index attr but returns a ContextResourceTypeInterface type, which makes folding difficult (and thus declaring it ConstantLike).
Further down the line, we could consider removing the `ContextResourceOpInterface` in favour of a single op in the RTG dialect.