### PR TITLE
Use MLIR python detection environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,11 +514,8 @@ option(CIRCT_BINDINGS_PYTHON_ENABLED "Enables CIRCT Python bindings." OFF)
 if(CIRCT_BINDINGS_PYTHON_ENABLED)
   message(STATUS "CIRCT Python bindings are enabled.")
   set(MLIR_DISABLE_CONFIGURE_PYTHON_DEV_PACKAGES 0)
-  mlir_detect_pybind11_install()
-  # Prime the search like mlir_configure_python_dev_modules
-  find_package(Python3 3.8 COMPONENTS Interpreter Development)
-  find_package(Python3 3.8 COMPONENTS Interpreter Development.Module)
-  find_package(pybind11 2.10 CONFIG REQUIRED)
+  include(MLIRDetectPythonEnv)
+  mlir_configure_python_dev_packages()
 else()
   message(STATUS "CIRCT Python bindings are disabled.")
   # Lookup python either way as some integration tests use python without the


### PR DESCRIPTION
This PR make CIRCT to relay on the very MLIR cmake python detection macros.

It now [properly picks](https://github.com/llvm/llvm-project/blob/ea14bdb0356cdda727ac032470f6a0a2102d1281/mlir/cmake/modules/MLIRDetectPythonEnv.cmake#L4-L48) up ```python``` components including ```pybind11``` and the recently introduced ```nanobind```.

Here is how this [is used upstream](https://github.com/llvm/llvm-project/blob/3b19e787fc5da27dfcc9ac6552b06a763f12ea03/mlir/examples/standalone/CMakeLists.txt#L35) .

---

Here is the cmake process output:

```
{...}
-- CIRCT Python bindings are enabled.
-- Found Python3: /usr/bin/python3.13 (found version "3.13.1") found components: Interpreter Development.Module
-- Found Python: /usr/bin/python3.13 (found version "3.13.1") found components: Interpreter Development.Module
-- Found python include dirs: /usr/include/python3.13
-- Found python libraries: 
-- Found numpy v: 
-- Checking for pybind11 in python path...
-- found (/usr/share/cmake/pybind11)
-- Performing Test HAS_FLTO
-- Performing Test HAS_FLTO - Success
-- Found pybind11: /usr/include (found version "2.13.6")
-- Found pybind11 v2.13.6: /usr/include
-- Python prefix = '', suffix = '', extension = '.cpython-313-x86_64-linux-gnu.so
-- Checking for nanobind in python path...
-- found (/usr/lib/python3.13/site-packages/nanobind/cmake)
-- Found nanobind v2.4.0: 
-- Python prefix = '', suffix = '', extension = '.cpython-313-x86_64-linux-gnu.so
{...}
```

Thank you !