### PR TITLE
Revert "Use MLIR python detection environment (#8037)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,8 +514,11 @@ option(CIRCT_BINDINGS_PYTHON_ENABLED "Enables CIRCT Python bindings." OFF)
 if(CIRCT_BINDINGS_PYTHON_ENABLED)
   message(STATUS "CIRCT Python bindings are enabled.")
   set(MLIR_DISABLE_CONFIGURE_PYTHON_DEV_PACKAGES 0)
-  include(MLIRDetectPythonEnv)
-  mlir_configure_python_dev_packages()
+  mlir_detect_pybind11_install()
+  # Prime the search like mlir_configure_python_dev_modules
+  find_package(Python3 3.8 COMPONENTS Interpreter Development)
+  find_package(Python3 3.8 COMPONENTS Interpreter Development.Module)
+  find_package(pybind11 2.10 CONFIG REQUIRED)
 else()
   message(STATUS "CIRCT Python bindings are disabled.")
   # Lookup python either way as some integration tests use python without the


### PR DESCRIPTION
This reverts commit ab5dc6c797583e2d292aaa8366531177de8d1bd4.