### PR TITLE
[SMT] Parse SMT bitvector width as signed

### DIFF
--- a/include/circt/Dialect/SMT/SMTTypes.td
+++ b/include/circt/Dialect/SMT/SMTTypes.td
@@ -39,7 +39,7 @@ def BitVectorType : SMTTypeDef<"BitVector"> {
     The bit-width must be strictly greater than zero.
   }];
 
-  let parameters = (ins "uint64_t":$width);
+  let parameters = (ins "int64_t":$width);
   let assemblyFormat = "`<` $width `>`";
 
   let genVerifyDecl = true;

--- a/lib/Dialect/SMT/SMTTypes.cpp
+++ b/lib/Dialect/SMT/SMTTypes.cpp
@@ -41,7 +41,7 @@ bool smt::isAnySMTValueType(Type type) {
 
 LogicalResult
 BitVectorType::verify(function_ref<InFlightDiagnostic()> emitError,
-                      uint64_t width) {
+                      int64_t width) {
   if (width <= 0U)
     return emitError() << "bit-vector must have at least a width of one";
   return success();

--- a/test/Dialect/SMT/bitvector-errors.mlir
+++ b/test/Dialect/SMT/bitvector-errors.mlir
@@ -7,6 +7,13 @@ func.func @at_least_size_one(%arg0: !smt.bv<0>) {
 
 // -----
 
+// expected-error @below {{bit-vector must have at least a width of one}}
+func.func @at_least_size_one(%arg0: !smt.bv<-1>) {
+  return
+}
+
+// -----
+
 func.func @attr_type_and_return_type_match() {
   // expected-error @below {{inferred type(s) '!smt.bv<1>' are incompatible with return type(s) of operation '!smt.bv<32>'}}
   // expected-error @below {{failed to infer returned types}}
@@ -89,8 +96,8 @@ func.func @repeat_count_too_large(%arg0: !smt.bv<32>) {
 
 // -----
 
-func.func @repeat_result_type_bitwidth_too_large(%arg0: !smt.bv<18446744073709551612>) {
-  // expected-error @below {{result bit-width (provided integer times bit-width of the input type) must fit into 64 bits}}
-  smt.bv.repeat 2 times %arg0 : !smt.bv<18446744073709551612>
+// expected-error @below {{integer value too large}}
+// expected-error @below {{failed to parse BitVectorType parameter 'width' which is to be a `int64_t`}}
+func.func @bitwidth_too_large(%arg0: !smt.bv<18446744073709551612>) {
   return
 }


### PR DESCRIPTION
Fixes an issue where SMT bitvector widths being parsed as unsigned meant that e.g. !smt.bv<-1> would wrap around and be interpreted as a 18446744073709551615-wide bitvector. The downside of this fix is that the error messages for bitvectors that are too wide become a little less clear (see the updated test) - does this still look like an ok fix to you @maerhart? Let me know if I should also drop the code that's emitting that error in the RepeatOp verifier, don't think it can be triggered after this but I may have missed a case.