### PR TITLE
[PyCDE] Improving support for Any type

### DIFF
--- a/include/circt-c/Dialect/ESI.h
+++ b/include/circt-c/Dialect/ESI.h
@@ -39,6 +39,8 @@ MLIR_CAPI_EXPORTED void circtESIAppendMlirFile(MlirModule,
 MLIR_CAPI_EXPORTED MlirOperation circtESILookup(MlirModule,
                                                 MlirStringRef symbol);
 
+MLIR_CAPI_EXPORTED bool circtESICheckInnerTypeMatch(MlirType to, MlirType from);
+
 //===----------------------------------------------------------------------===//
 // Channel bundles
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/ESI/ESIOps.h
+++ b/include/circt/Dialect/ESI/ESIOps.h
@@ -33,7 +33,7 @@ struct ServicePortInfo {
   ChannelBundleType type;
 };
 
-// Check that the channels on two bundles match allowing for AnyType.
+// Check that two types match, allowing for AnyType in 'expected'.
 // NOLINTNEXTLINE(misc-no-recursion)
 LogicalResult checkInnerTypeMatch(Type expected, Type actual);
 /// Check that the channels on two bundles match allowing for AnyType in the

--- a/lib/Bindings/Python/ESIModule.cpp
+++ b/lib/Bindings/Python/ESIModule.cpp
@@ -221,6 +221,10 @@ void circt::python::populateDialectESISubmodule(py::module &m) {
       .def("__len__", &circtESIAppIDAttrPathGetNumComponents)
       .def("__getitem__", &circtESIAppIDAttrPathGetComponent);
 
+  m.def("check_inner_type_match", &circtESICheckInnerTypeMatch,
+        "Check that two types match, allowing for AnyType in 'expected'.",
+        py::arg("expected"), py::arg("actual"));
+
   py::class_<PyAppIDIndex>(m, "AppIDIndex")
       .def(py::init<MlirOperation>(), py::arg("root"))
       .def("get_child_appids_of", &PyAppIDIndex::getChildAppIDsOf,

--- a/lib/CAPI/Dialect/ESI.cpp
+++ b/lib/CAPI/Dialect/ESI.cpp
@@ -70,6 +70,10 @@ MlirType circtESIListTypeGetElementType(MlirType list) {
   return wrap(cast<ListType>(unwrap(list)).getElementType());
 }
 
+bool circtESICheckInnerTypeMatch(MlirType to, MlirType from) {
+  return succeeded(checkInnerTypeMatch(unwrap(to), unwrap(from)));
+}
+
 void circtESIAppendMlirFile(MlirModule cMod, MlirStringRef filename) {
   ModuleOp modOp = unwrap(cMod);
   auto loadedMod =


### PR DESCRIPTION
- Adds a `castable` method to Type which passes through to the `checkInnerTypeMatch` C++ function.
- Use that method to type check the results of BundleSignal.unpack.