### PR TITLE
[MemoryBanking] Support memory banking for`GetGlobalOp`

### DIFF
--- a/lib/Transforms/MemoryBanking.cpp
+++ b/lib/Transforms/MemoryBanking.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/FormatVariadic.h"
+#include <numeric>
 
 namespace circt {
 #define GEN_PASS_DEF_MEMORYBANKING
@@ -113,14 +114,8 @@ SmallVector<SmallVector<Attribute>> sliceSubBlock(ArrayRef<Attribute> allAttrs,
                                                   ArrayRef<int64_t> memShape,
                                                   unsigned bankingDimension,
                                                   unsigned bankingFactor) {
-  auto totalSize = [](auto &&shape) {
-    size_t prod = 1;
-    for (auto s : shape)
-      prod *= s;
-    return prod;
-  };
-
-  size_t numElements = totalSize(memShape);
+  size_t numElements = std::reduce(memShape.begin(), memShape.end(), 1,
+                                   std::multiplies<size_t>());
   // `bankingFactor` number of flattened attributes that store the information
   // in the original globalOp
   SmallVector<SmallVector<Attribute>> subBlocks;

--- a/lib/Transforms/MemoryBanking.cpp
+++ b/lib/Transforms/MemoryBanking.cpp
@@ -172,7 +172,7 @@ SmallVector<Value, 4> handleGetGlobalOp(memref::GetGlobalOp getGlobalOp,
     // Prepare relevant information to create a new GlobalOp
     auto newMemRefTy = MemRefType::get(newShape, globalOpTy.getElementType());
     auto newTypeAttr = TypeAttr::get(newMemRefTy);
-    std::string newNameStr =
+    std::string newName =
         llvm::formatv("{0}_{1}_{2}_{3}", globalOp.getConstantAttrName(),
                       llvm::join(llvm::map_range(newShape,
                                                  [](int64_t dim) {
@@ -186,7 +186,7 @@ SmallVector<Value, 4> handleGetGlobalOp(memref::GetGlobalOp getGlobalOp,
 
     builder.restoreInsertionPoint(globalOpsInsertPt);
     auto newGlobalOp = builder.create<memref::GlobalOp>(
-        globalOp.getLoc(), builder.getStringAttr(newNameStr),
+        globalOp.getLoc(), builder.getStringAttr(newName),
         globalOp.getSymVisibilityAttr(), newTypeAttr, newInitValue,
         globalOp.getConstantAttr(), globalOp.getAlignmentAttr());
     builder.setInsertionPointAfter(newGlobalOp);

--- a/lib/Transforms/MemoryBanking.cpp
+++ b/lib/Transforms/MemoryBanking.cpp
@@ -240,6 +240,7 @@ SmallVector<Value, 4> createBanks(Value originalMem, uint64_t bankingFactor,
 
             banks.push_back(newGetGlobalOp);
           }
+          globalOp.erase();
         })
         .Default([](Operation *) {
           llvm_unreachable("Unhandled memory operation type");

--- a/lib/Transforms/MemoryBanking.cpp
+++ b/lib/Transforms/MemoryBanking.cpp
@@ -25,7 +25,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/FormatVariadic.h"
-#include "llvm/Support/raw_ostream.h"
 
 namespace circt {
 #define GEN_PASS_DEF_MEMORYBANKING

--- a/test/Transforms/memory_banking_multi_dim.mlir
+++ b/test/Transforms/memory_banking_multi_dim.mlir
@@ -1,4 +1,5 @@
 // RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2 dimension=1" | FileCheck %s --check-prefix RANK2-BANKDIM1
+// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2" | FileCheck %s --check-prefix GETGLOBAL
 
 // RANK2-BANKDIM1: #[[$ATTR_0:.+]] = affine_map<(d0, d1) -> (d1 mod 2)>
 // RANK2-BANKDIM1: #[[$ATTR_1:.+]] = affine_map<(d0, d1) -> (d1 floordiv 2)>
@@ -71,5 +72,50 @@ func.func @rank_two_bank_dim1(%arg0: memref<8x6xf32>, %arg1: memref<8x6xf32>) ->
     }
   }
   return %mem : memref<8x6xf32>
+}
+
+// -----
+
+// GETGLOBAL-LABEL:   memref.global "private" constant @constant_2x8_f32_0 : memref<2x8xf32> = dense<{{\[\[}}8.000000e+00, -2.000000e+00, -2.000000e+00, -1.000000e+00, -3.000000e+00, -2.000000e+00, 3.000000e+00, 6.000000e+00], [9.000000e+00, -1.000000e+00, -2.000000e+00, -2.000000e+00, -2.000000e+00, -2.000000e+00, -1.000000e+00, -2.000000e+00]]>
+// GETGLOBAL:         memref.global "private" constant @constant_2x8_f32_1 : memref<2x8xf32> = dense<{{\[\[}}1.000000e+00, -3.000000e+00, -2.000000e+00, -1.000000e+00, 5.000000e+00, -3.000000e+00, -1.000000e+00, -2.000000e+00], [2.000000e+00, -7.000000e+00, 3.000000e+00, 1.000000e+00, -2.000000e+00, 2.000000e+00, -9.000000e+00, -1.000000e+00]]>
+// GETGLOBAL:         memref.global "private" constant @constant_4x6_f32_0 : memref<4x6xf32> = dense<{{\[\[}}2.000000e+00, -2.000000e+00, -4.000000e+00, -1.000000e+00, -3.000000e+00, 3.000000e+00], [2.000000e+00, -2.000000e+00, 1.000000e+00, -1.000000e+00, 1.000000e+00, -8.000000e+00], [3.000000e+00, -3.000000e+00, -4.000000e+00, -3.000000e+00, -2.000000e+00, 1.000000e+00], [2.000000e+00, -9.000000e+00, 2.000000e+00, -3.000000e+00, -2.000000e+00, 1.000000e+00]]>
+// GETGLOBAL:         memref.global "private" constant @constant_4x6_f32_1 : memref<4x6xf32> = dense<{{\[\[}}1.000000e+00, 1.000000e+00, 1.000000e+00, -7.000000e+00, 3.000000e+00, -2.000000e+00], [3.000000e+00, -2.000000e+00, -2.000000e+00, -2.000000e+00, 3.000000e+00, 1.000000e+00], [1.000000e+00, 3.000000e+00, -2.000000e+00, -2.000000e+00, 2.000000e+00, -1.000000e+00], [8.000000e+00, -1.000000e+00, 2.000000e+00, 2.000000e+00, -2.000000e+00, -2.000000e+00]]>
+module {
+  memref.global "private" constant @__constant_4x8xf32 : memref<4x8xf32> = dense<[
+    [8.0,  -2.0, -2.0, -1.0, -3.0, -2.0,  3.0,  6.0],
+    [1.0,  -3.0, -2.0, -1.0,  5.0, -3.0, -1.0, -2.0],
+    [9.0,  -1.0, -2.0, -2.0, -2.0, -2.0, -1.0, -2.0],
+    [2.0,  -7.0,  3.0,  1.0, -2.0,  2.0, -9.0, -1.0]
+  ]>
+  memref.global "private" constant @__constant_8x6xf32 : memref<8x6xf32> = dense<[
+    [2.0,  -2.0, -4.0, -1.0, -3.0,  3.0],
+    [1.0,   1.0,  1.0, -7.0,  3.0, -2.0],
+    [2.0,  -2.0,  1.0, -1.0,  1.0, -8.0],
+    [3.0,  -2.0, -2.0, -2.0,  3.0,  1.0],
+    [3.0,  -3.0, -4.0, -3.0, -2.0,  1.0],
+    [1.0,   3.0, -2.0, -2.0,  2.0, -1.0],
+    [2.0,  -9.0,  2.0, -3.0, -2.0,  1.0],
+    [8.0,  -1.0,  2.0,  2.0, -2.0, -2.0]
+  ]>
+  func.func @main() {
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = memref.get_global @__constant_8x6xf32 : memref<8x6xf32>
+    %2 = memref.get_global @__constant_4x8xf32 : memref<4x8xf32>
+    %alloc = memref.alloc() : memref<6x8xf32>
+    affine.parallel (%arg2) = (0) to (6) {
+      affine.parallel (%arg3) = (0) to (8) {
+        %4 = affine.load %0[%arg3, %arg2] : memref<8x6xf32>
+        affine.store %4, %alloc[%arg2, %arg3] : memref<6x8xf32>
+      }
+    }
+    %alloc_5 = memref.alloc() : memref<8x4xf32>
+    affine.parallel (%arg2) = (0) to (8) {
+      affine.parallel (%arg3) = (0) to (4) {
+        %4 = affine.load %2[%arg3, %arg2] : memref<4x8xf32>
+        affine.store %4, %alloc_5[%arg2, %arg3] : memref<8x4xf32>
+      }
+    }
+    return
+  }
 }
 


### PR DESCRIPTION
This patch supports memory banking for multi-dimensional `GetGlobalOp`s and restructure the data in their corresponding `GlobalOp`s by the banking scheme (such as the banking factor and the dimension).