### PR TITLE
[LoopScheduleToCalyx] Lower pipeline register to register writes.

### DIFF
--- a/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
+++ b/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
@@ -1077,8 +1077,11 @@ class BuildPipelineGroups : public calyx::FuncOpPartialLoweringPattern {
           state.findEvaluatingGroup(value);
       if (!evaluatingGroup.has_value()) {
         if (!state.isPipelineReg(value)) {
-          llvm::errs() << "unexpected: this is not a pipeline register and was "
-                          "not previously evaluated. Please open an issue.\n";
+          // We add this for any unhandled cases.
+          llvm::errs() << "unexpected: input value: " << value << ", in stage "
+                       << stage.getStageNumber() << " register " << i
+                       << " is not a pipeline register and was not previously "
+                          "evaluated in a Calyx group. Please open an issue.\n";
           return LogicalResult::failure();
         }
         // This is a pipeline register being written to another pipeline
@@ -1091,8 +1094,8 @@ class BuildPipelineGroups : public calyx::FuncOpPartialLoweringPattern {
         calyx::buildAssignmentsForRegisterWrite(
             rewriter, group, state.getComponentOp(), pipelineRegister, value);
       } else {
-        // Stitch the register in, depending on whether the group was
-        // combinational or sequential.
+        // This was previously evaluated. Stitch the register in, depending on
+        // whether the group was combinational or sequential.
         auto combGroup =
             dyn_cast<calyx::CombGroupOp>(evaluatingGroup->getOperation());
         group = combGroup == nullptr

--- a/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
+++ b/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
@@ -126,20 +126,6 @@ public:
     return pipelineRegs[stage];
   }
 
-  /// Returns whether this value is a pipeline register.
-  bool isPipelineReg(Value value) {
-    auto regOp = value.getDefiningOp<calyx::RegisterOp>();
-    if (regOp == nullptr)
-      return false;
-    for (const auto &[_, registers] : pipelineRegs) {
-      for (const auto &[_, r] : registers) {
-        if (r == regOp)
-          return true;
-      }
-    }
-    return false;
-  }
-
   /// Add a stage's groups to the pipeline prologue.
   void addPipelinePrologue(Operation *op, SmallVector<StringAttr> groupNames) {
     pipelinePrologue[op].push_back(groupNames);

--- a/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
+++ b/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
@@ -1080,8 +1080,8 @@ class BuildPipelineGroups : public calyx::FuncOpPartialLoweringPattern {
                           "evaluated in a Calyx group. Please open an issue.\n";
           return LogicalResult::failure();
         }
-        // This is a pipeline register being written to another pipeline
-        // register. We create a new group to build this assignment.
+        // This is a register's value being written to this pipeline register.
+        // We create a new group to build this assignment.
         std::string groupName = state.getUniqueName(
             loweringState().blockName(pipelineRegister->getBlock()));
         group = calyx::createGroup<calyx::GroupOp>(

--- a/test/Conversion/LoopScheduleToCalyx/convert_pipeline.mlir
+++ b/test/Conversion/LoopScheduleToCalyx/convert_pipeline.mlir
@@ -278,7 +278,7 @@ module {
 //CHECK-NEXT:      }
 //CHECK-NEXT:    }
 module {
-  func.func @gemm(%arg0: i32, %arg1: memref<30x30xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
+  func.func @foo(%arg0: i32, %arg1: memref<30x30xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
     %alloca = memref.alloca() : memref<30x30xi32>
     cf.br ^bb4
   ^bb4:

--- a/test/Conversion/LoopScheduleToCalyx/convert_pipeline.mlir
+++ b/test/Conversion/LoopScheduleToCalyx/convert_pipeline.mlir
@@ -271,12 +271,16 @@ module {
 
 // Pipeline register to pipeline register writes are valid.
 
-//CHECK:  calyx.group @bb0_3 {
-//CHECK-NEXT:        calyx.assign %stage_1_register_0_reg.in = %stage_0_register_0_reg.out : i32
-//CHECK-NEXT:        calyx.assign %stage_1_register_0_reg.write_en = %true : i1
-//CHECK-NEXT:        calyx.group_done %stage_1_register_0_reg.done : i1
-//CHECK-NEXT:      }
-//CHECK-NEXT:    }
+//CHECK:      calyx.group @bb0_3 {
+//CHECK-NEXT:   calyx.assign %stage_1_register_0_reg.in = %stage_0_register_0_reg.out : i32
+//CHECK-NEXT:   calyx.assign %stage_1_register_0_reg.write_en = %true : i1
+//CHECK-NEXT:   calyx.group_done %stage_1_register_0_reg.done : i1
+//CHECK-NEXT: }
+//CHECK-NEXT: calyx.group @bb0_4 {
+//CHECK-NEXT:   calyx.assign %stage_2_register_0_reg.in = %stage_1_register_0_reg.out : i32
+//CHECK-NEXT:   calyx.assign %stage_2_register_0_reg.write_en = %true : i1
+//CHECK-NEXT:   calyx.group_done %stage_2_register_0_reg.done : i1
+//CHECK-NEXT: }
 module {
   func.func @foo(%arg0: i32, %arg1: memref<30x30xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
     %alloca = memref.alloca() : memref<30x30xi32>
@@ -295,6 +299,9 @@ module {
       } : i32, index
       %7 = loopschedule.pipeline.stage start = 1 {
         loopschedule.register %6#0 : i32
+      } : i32
+      %8 = loopschedule.pipeline.stage start = 2 {
+        loopschedule.register %7 : i32
       } : i32
       loopschedule.terminator iter_args(%6#1), results() : (index) -> ()
     }


### PR DESCRIPTION
Lowers reads from a register to a pipeline register in the next stage. See the [Calyx Zulip discussion](https://calyx.zulipchat.com/#narrow/channel/423600-development/topic/hlstool/near/489718133).