### PR TITLE
[SMT] Add bv2int op

### DIFF
--- a/include/circt/Dialect/SMT/SMTBitVectorOps.td
+++ b/include/circt/Dialect/SMT/SMTBitVectorOps.td
@@ -238,4 +238,20 @@ def RepeatOp : SMTBVOp<"repeat", [Pure]> {
   }];
 }
 
+def BV2IntOp : SMTOp<"bv2int", [Pure]> {
+  let summary = "Convert an SMT bitvector to an SMT integer.";
+  let description = [{
+    Designed to lower directly to an operation of the same name in Z3. The Z3
+    C API describes the semantics as follows:
+    Create an integer from the bit-vector argument t1.
+    If is_signed is false, then the bit-vector t1 is treated as unsigned.
+    So the result is non-negative and in the range [0..2^N-1], where N are the
+    number of bits in t1. If is_signed is true, t1 is treated as a signed
+    bit-vector.
+  }];
+  let arguments = (ins BitVectorType:$input, BoolAttr:$is_signed);
+  let results = (outs IntType:$result);
+  let assemblyFormat = [{$input custom<KeywordBool>($is_signed, "\"signed\"", "\"unsigned\"") attr-dict `:` qualified(type($input))}];
+}
+
 #endif // CIRCT_DIALECT_SMT_SMTBITVECTOROPS_TD

--- a/include/circt/Dialect/SMT/SMTBitVectorOps.td
+++ b/include/circt/Dialect/SMT/SMTBitVectorOps.td
@@ -248,10 +248,9 @@ def BV2IntOp : SMTOp<"bv2int", [Pure]> {
     N are the number of bits in `input`. If `is_signed` is true, `input` is
     treated as a signed bit-vector.
   }];
-  let arguments = (ins BitVectorType:$input, BoolAttr:$is_signed);
+  let arguments = (ins BitVectorType:$input, UnitAttr:$is_signed);
   let results = (outs IntType:$result);
-  let assemblyFormat = [{$input custom<KeywordBool>($is_signed, "\"signed\"",
-    "\"unsigned\"") attr-dict `:` qualified(type($input))}];
+  let assemblyFormat = [{$input (`signed` $is_signed^)? attr-dict `:` qualified(type($input))}];
 }
 
 #endif // CIRCT_DIALECT_SMT_SMTBITVECTOROPS_TD

--- a/include/circt/Dialect/SMT/SMTBitVectorOps.td
+++ b/include/circt/Dialect/SMT/SMTBitVectorOps.td
@@ -239,19 +239,19 @@ def RepeatOp : SMTBVOp<"repeat", [Pure]> {
 }
 
 def BV2IntOp : SMTOp<"bv2int", [Pure]> {
-  let summary = "Convert an SMT bitvector to an SMT integer.";
+  let summary = "Convert an SMT bit-vector to an SMT integer.";
   let description = [{
-    Designed to lower directly to an operation of the same name in Z3. The Z3
-    C API describes the semantics as follows:
-    Create an integer from the bit-vector argument t1.
-    If is_signed is false, then the bit-vector t1 is treated as unsigned.
-    So the result is non-negative and in the range [0..2^N-1], where N are the
-    number of bits in t1. If is_signed is true, t1 is treated as a signed
-    bit-vector.
+    Adapted from the Z3 documentation:
+    Create an integer from the bit-vector argument `input`.
+    If `is_signed` is false, then the bit-vector `input` is treated as
+    unsigned. So the result is non-negative and in the range [0..2^N-1], where
+    N are the number of bits in `input`. If `is_signed` is true, `input` is
+    treated as a signed bit-vector.
   }];
   let arguments = (ins BitVectorType:$input, BoolAttr:$is_signed);
   let results = (outs IntType:$result);
-  let assemblyFormat = [{$input custom<KeywordBool>($is_signed, "\"signed\"", "\"unsigned\"") attr-dict `:` qualified(type($input))}];
+  let assemblyFormat = [{$input custom<KeywordBool>($is_signed, "\"signed\"",
+    "\"unsigned\"") attr-dict `:` qualified(type($input))}];
 }
 
 #endif // CIRCT_DIALECT_SMT_SMTBITVECTOROPS_TD

--- a/include/circt/Dialect/SMT/SMTVisitors.h
+++ b/include/circt/Dialect/SMT/SMTVisitors.h
@@ -36,7 +36,7 @@ public:
             // Bit-vector bitwise
             BVNotOp, BVAndOp, BVOrOp, BVXOrOp,
             // Other bit-vector ops
-            ConcatOp, ExtractOp, RepeatOp, BVCmpOp,
+            ConcatOp, ExtractOp, RepeatOp, BVCmpOp, BV2IntOp,
             // Int arithmetic
             IntAddOp, IntMulOp, IntSubOp, IntDivOp, IntModOp, IntCmpOp,
             Int2BVOp,
@@ -106,6 +106,7 @@ public:
   HANDLE(ExtractOp, Unhandled);
   HANDLE(RepeatOp, Unhandled);
   HANDLE(BVCmpOp, Unhandled);
+  HANDLE(BV2IntOp, Unhandled);
 
   // Int arithmetic
   HANDLE(IntAddOp, Unhandled);

--- a/integration_test/Dialect/SMT/basic.mlir
+++ b/integration_test/Dialect/SMT/basic.mlir
@@ -210,7 +210,7 @@ func.func @entry() {
   smt.solver () : () -> () {
     %c4 = smt.int.constant 4
     %c4_bv16 = smt.bv.constant #smt.bv<4> : !smt.bv<16>
-    %bv2int = smt.bv2int %c4_bv16 unsigned : !smt.bv<16>
+    %bv2int = smt.bv2int %c4_bv16 : !smt.bv<16>
     %eq = smt.distinct %c4, %bv2int : !smt.int
     func.call @check(%eq) : (!smt.bool) -> ()
     smt.yield
@@ -233,7 +233,7 @@ func.func @entry() {
   smt.solver () : () -> () {
     %c-4 = smt.int.constant -4
     %c-4_bv16 = smt.bv.constant #smt.bv<-4> : !smt.bv<16>
-    %bv2int = smt.bv2int %c-4_bv16 unsigned : !smt.bv<16>
+    %bv2int = smt.bv2int %c-4_bv16 : !smt.bv<16>
     %eq = smt.eq %c-4, %bv2int : !smt.int
     func.call @check(%eq) : (!smt.bool) -> ()
     smt.yield

--- a/integration_test/Dialect/SMT/basic.mlir
+++ b/integration_test/Dialect/SMT/basic.mlir
@@ -205,6 +205,40 @@ func.func @entry() {
     smt.yield
   }
 
+  // CHECK: unsat
+  // CHECK: Res: -1
+  smt.solver () : () -> () {
+    %c4 = smt.int.constant 4
+    %c4_bv16 = smt.bv.constant #smt.bv<4> : !smt.bv<16>
+    %bv2int = smt.bv2int %c4_bv16 unsigned : !smt.bv<16>
+    %eq = smt.distinct %c4, %bv2int : !smt.int
+    func.call @check(%eq) : (!smt.bool) -> ()
+    smt.yield
+  }
+
+  // CHECK: unsat
+  // CHECK: Res: -1
+  smt.solver () : () -> () {
+    %c-4 = smt.int.constant -4
+    %c-4_bv16 = smt.bv.constant #smt.bv<-4> : !smt.bv<16>
+    %bv2int = smt.bv2int %c-4_bv16 signed : !smt.bv<16>
+    %eq = smt.distinct %c-4, %bv2int : !smt.int
+    func.call @check(%eq) : (!smt.bool) -> ()
+    smt.yield
+  }
+
+  // Check that unsigned conversion actually produces unsigned result
+  // CHECK: unsat
+  // CHECK: Res: -1
+  smt.solver () : () -> () {
+    %c-4 = smt.int.constant -4
+    %c-4_bv16 = smt.bv.constant #smt.bv<-4> : !smt.bv<16>
+    %bv2int = smt.bv2int %c-4_bv16 unsigned : !smt.bv<16>
+    %eq = smt.eq %c-4, %bv2int : !smt.int
+    func.call @check(%eq) : (!smt.bool) -> ()
+    smt.yield
+  }
+
   return
 }
 

--- a/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
+++ b/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
@@ -1221,6 +1221,8 @@ struct BV2IntOpLowering : public SMTLoweringPattern<BV2IntOp> {
   LogicalResult
   matchAndRewrite(BV2IntOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
+    // FIXME: ideally we don't want to use i1 here, since bools can sometimes be
+    // compiled to wider widths in LLVM
     Value isSignedConst = rewriter.create<LLVM::ConstantOp>(
         op->getLoc(), rewriter.getI1Type(), op.getIsSigned());
     rewriter.replaceOp(op,

--- a/lib/Dialect/SMT/CMakeLists.txt
+++ b/lib/Dialect/SMT/CMakeLists.txt
@@ -16,6 +16,7 @@ add_circt_dialect_library(CIRCTSMT
   Support
 
   LINK_LIBS PUBLIC
+  CIRCTSupport
   MLIRIR
   MLIRInferTypeOpInterface
   MLIRSideEffectInterfaces

--- a/lib/Dialect/SMT/SMTOps.cpp
+++ b/lib/Dialect/SMT/SMTOps.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/SMT/SMTOps.h"
+#include "circt/Support/CustomDirectiveImpl.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
 #include "llvm/ADT/APSInt.h"

--- a/lib/Target/ExportSMTLIB/ExportSMTLIB.cpp
+++ b/lib/Target/ExportSMTLIB/ExportSMTLIB.cpp
@@ -602,9 +602,9 @@ struct StatementVisitor
                                     mlir::raw_indented_ostream &stream,
                                     ValueMap &valueMap) {
     // Ignore operations which are handled in the Expression Visitor.
-    if (isa<smt::Int2BVOp>(op))
+    if (isa<smt::Int2BVOp, BV2IntOp>(op))
       return op->emitError(
-          "int2bv operations are not supported for SMTLIB emission");
+          "int2bv and bv2int operations are not supported for SMTLIB emission");
 
     return success();
   }

--- a/lib/Target/ExportSMTLIB/ExportSMTLIB.cpp
+++ b/lib/Target/ExportSMTLIB/ExportSMTLIB.cpp
@@ -603,8 +603,7 @@ struct StatementVisitor
                                     ValueMap &valueMap) {
     // Ignore operations which are handled in the Expression Visitor.
     if (isa<smt::Int2BVOp, BV2IntOp>(op))
-      return op->emitError(
-          "int2bv and bv2int operations are not supported for SMTLIB emission");
+      return op->emitError("operation not supported for SMTLIB emission");
 
     return success();
   }

--- a/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
+++ b/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
@@ -384,6 +384,13 @@ func.func @test(%arg0: i32) {
     // CHECK: llvm.call @Z3_mk_int2bv({{%[0-9a-zA-Z_]+}}, [[WIDTHCONST]], [[C123]]) : (!llvm.ptr, i32, !llvm.ptr) -> !llvm.ptr
     smt.int2bv %10 : !smt.bv<4>
 
+    // CHECK: [[SIGNEDCONST:%.+]] = llvm.mlir.constant(true) : i1
+    // CHECK: llvm.call @Z3_mk_bv2int({{%[0-9a-zA-Z_]+}}, [[BV0]], [[SIGNEDCONST]]) : (!llvm.ptr, !llvm.ptr, i1) -> !llvm.ptr
+    smt.bv2int %c0_bv4 signed : !smt.bv<4>
+    // CHECK: [[UNSIGNEDCONST:%.+]] = llvm.mlir.constant(false) : i1
+    // CHECK: llvm.call @Z3_mk_bv2int({{%[0-9a-zA-Z_]+}}, [[BV0]], [[UNSIGNEDCONST]]) : (!llvm.ptr, !llvm.ptr, i1) -> !llvm.ptr
+    smt.bv2int %c0_bv4 unsigned : !smt.bv<4>
+
     // CHECK: [[C0:%.+]] = llvm.mlir.constant(0 : i32)
     // CHECK: [[C2:%.+]] = llvm.mlir.constant(2 : i32)
     // CHECK: [[ZERO:%.+]] = llvm.mlir.zero : !llvm.ptr

--- a/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
+++ b/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
@@ -384,12 +384,12 @@ func.func @test(%arg0: i32) {
     // CHECK: llvm.call @Z3_mk_int2bv({{%[0-9a-zA-Z_]+}}, [[WIDTHCONST]], [[C123]]) : (!llvm.ptr, i32, !llvm.ptr) -> !llvm.ptr
     smt.int2bv %10 : !smt.bv<4>
 
+    // CHECK: [[UNSIGNEDCONST:%.+]] = llvm.mlir.constant(false) : i1
+    // CHECK: llvm.call @Z3_mk_bv2int({{%[0-9a-zA-Z_]+}}, [[BV0]], [[UNSIGNEDCONST]]) : (!llvm.ptr, !llvm.ptr, i1) -> !llvm.ptr
+    smt.bv2int %c0_bv4 : !smt.bv<4>
     // CHECK: [[SIGNEDCONST:%.+]] = llvm.mlir.constant(true) : i1
     // CHECK: llvm.call @Z3_mk_bv2int({{%[0-9a-zA-Z_]+}}, [[BV0]], [[SIGNEDCONST]]) : (!llvm.ptr, !llvm.ptr, i1) -> !llvm.ptr
     smt.bv2int %c0_bv4 signed : !smt.bv<4>
-    // CHECK: [[UNSIGNEDCONST:%.+]] = llvm.mlir.constant(false) : i1
-    // CHECK: llvm.call @Z3_mk_bv2int({{%[0-9a-zA-Z_]+}}, [[BV0]], [[UNSIGNEDCONST]]) : (!llvm.ptr, !llvm.ptr, i1) -> !llvm.ptr
-    smt.bv2int %c0_bv4 unsigned : !smt.bv<4>
 
     // CHECK: [[C0:%.+]] = llvm.mlir.constant(0 : i32)
     // CHECK: [[C2:%.+]] = llvm.mlir.constant(2 : i32)

--- a/test/Dialect/SMT/bitvector-errors.mlir
+++ b/test/Dialect/SMT/bitvector-errors.mlir
@@ -94,3 +94,21 @@ func.func @repeat_result_type_bitwidth_too_large(%arg0: !smt.bv<1844674407370955
   smt.bv.repeat 2 times %arg0 : !smt.bv<18446744073709551612>
   return
 }
+
+// -----
+
+func.func @no_bv2int_signedness() {
+  %c5_bv32 = smt.bv.constant #smt.bv<5> : !smt.bv<32>
+  // expected-error @below {{custom op 'smt.bv2int' expected keyword "signed" or "unsigned"}}
+  %bv2int = smt.bv2int %c5_bv32 : !smt.bv<32>
+  return
+}
+
+// -----
+
+func.func @invalid_bv2int_signedness() {
+  %c5_bv32 = smt.bv.constant #smt.bv<5> : !smt.bv<32>
+  // expected-error @below {{custom op 'smt.bv2int' expected keyword "signed" or "unsigned"}}
+  %bv2int = smt.bv2int %c5_bv32 maybe_signed : !smt.bv<32>
+  return
+}

--- a/test/Dialect/SMT/bitvector-errors.mlir
+++ b/test/Dialect/SMT/bitvector-errors.mlir
@@ -97,18 +97,9 @@ func.func @repeat_result_type_bitwidth_too_large(%arg0: !smt.bv<1844674407370955
 
 // -----
 
-func.func @no_bv2int_signedness() {
-  %c5_bv32 = smt.bv.constant #smt.bv<5> : !smt.bv<32>
-  // expected-error @below {{custom op 'smt.bv2int' expected keyword "signed" or "unsigned"}}
-  %bv2int = smt.bv2int %c5_bv32 : !smt.bv<32>
-  return
-}
-
-// -----
-
 func.func @invalid_bv2int_signedness() {
   %c5_bv32 = smt.bv.constant #smt.bv<5> : !smt.bv<32>
-  // expected-error @below {{custom op 'smt.bv2int' expected keyword "signed" or "unsigned"}}
-  %bv2int = smt.bv2int %c5_bv32 maybe_signed : !smt.bv<32>
+  // expected-error @below {{expected ':'}}
+  %bv2int = smt.bv2int %c5_bv32 unsigned : !smt.bv<32>
   return
 }

--- a/test/Dialect/SMT/bitvectors.mlir
+++ b/test/Dialect/SMT/bitvectors.mlir
@@ -72,10 +72,10 @@ func.func @bitvectors() {
   // CHECK: %{{.*}} = smt.bv.repeat 2 times [[C0]] {smt.some_attr} : !smt.bv<32>
   %27 = smt.bv.repeat 2 times %c {smt.some_attr} : !smt.bv<32>
 
+  // CHECK: %{{.*}} = smt.bv2int [[C0]] {smt.some_attr} : !smt.bv<32>
+  %29 = smt.bv2int %c {smt.some_attr} : !smt.bv<32>
   // CHECK: %{{.*}} = smt.bv2int [[C0]] signed {smt.some_attr} : !smt.bv<32>
   %28 = smt.bv2int %c signed {smt.some_attr} : !smt.bv<32>
-  // CHECK: %{{.*}} = smt.bv2int [[C0]] unsigned {smt.some_attr} : !smt.bv<32>
-  %29 = smt.bv2int %c unsigned {smt.some_attr} : !smt.bv<32>
 
   return
 }

--- a/test/Dialect/SMT/bitvectors.mlir
+++ b/test/Dialect/SMT/bitvectors.mlir
@@ -72,5 +72,10 @@ func.func @bitvectors() {
   // CHECK: %{{.*}} = smt.bv.repeat 2 times [[C0]] {smt.some_attr} : !smt.bv<32>
   %27 = smt.bv.repeat 2 times %c {smt.some_attr} : !smt.bv<32>
 
+  // CHECK: %{{.*}} = smt.bv2int [[C0]] signed {smt.some_attr} : !smt.bv<32>
+  %28 = smt.bv2int %c signed {smt.some_attr} : !smt.bv<32>
+  // CHECK: %{{.*}} = smt.bv2int [[C0]] unsigned {smt.some_attr} : !smt.bv<32>
+  %29 = smt.bv2int %c unsigned {smt.some_attr} : !smt.bv<32>
+
   return
 }

--- a/test/Target/ExportSMTLIB/bitvector-errors.mlir
+++ b/test/Target/ExportSMTLIB/bitvector-errors.mlir
@@ -2,6 +2,6 @@
 
 smt.solver () : () -> () {
   %0 = smt.bv.constant #smt.bv<5> : !smt.bv<16>
-  // expected-error @below {{int2bv and bv2int operations are not supported for SMTLIB emission}}
+  // expected-error @below {{operation not supported for SMTLIB emission}}
   %1 = smt.bv2int %0 signed : !smt.bv<16>
 }

--- a/test/Target/ExportSMTLIB/bitvector-errors.mlir
+++ b/test/Target/ExportSMTLIB/bitvector-errors.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-translate --export-smtlib %s --split-input-file --verify-diagnostics
 
 smt.solver () : () -> () {
-  %0 = smt.int.constant 5
+  %0 = smt.bv.constant #smt.bv<5> : !smt.bv<16>
   // expected-error @below {{int2bv and bv2int operations are not supported for SMTLIB emission}}
-  %1 = smt.int2bv %0 : !smt.bv<4>
+  %1 = smt.bv2int %0 signed : !smt.bv<16>
 }

--- a/test/Target/ExportSMTLIB/integer-errors.mlir
+++ b/test/Target/ExportSMTLIB/integer-errors.mlir
@@ -2,6 +2,6 @@
 
 smt.solver () : () -> () {
   %0 = smt.int.constant 5
-  // expected-error @below {{int2bv and bv2int operations are not supported for SMTLIB emission}}
+  // expected-error @below {{operation not supported for SMTLIB emission}}
   %1 = smt.int2bv %0 : !smt.bv<4>
 }


### PR DESCRIPTION
Adds an operation to convert between SMT bitvectors and SMT integers. As discussed further in #8041, support for these operations varies between solvers - technically this one is outlined in the SMTLIB spec but AFAIU only to describe the semantics of other operations, rather than as something solvers are expected to implement, so I've made ExportSMTLIB error out on this one too since it's not _really_ part of the spec for the language itself.