### PR TITLE
[Python] Update wheels we build in CI/CD.

### DIFF
--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -23,13 +23,9 @@ jobs:
       matrix:
         config:
           - os: ubuntu-20.04
-            cibw_build: cp38-manylinux_x86_64
-          - os: ubuntu-20.04
             cibw_build: cp310-manylinux_x86_64
-          - os: macos-13
-            cibw_build: cp38-macosx_x86_64
-          - os: macos-13
-            cibw_build: cp310-macosx_x86_64
+          - os: ubuntu-20.04
+            cibw_build: cp313-manylinux_x86_64
 
     steps:
       - name: Get CIRCT
@@ -46,7 +42,7 @@ jobs:
         uses: actions/setup-python@v3
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.22.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse ./lib/Bindings/Python


### PR DESCRIPTION
This removes MacOS, which has been failing, and no one seems to care about anyway. This also adds a newer Python 3.13 wheel for a more modern Python version. I have not yet removed the Python 3.8 wheel, but that is EOL, and we can consider removing that in a follow up.