### PR TITLE
[ESI] Add hostmem write support to cosim

### DIFF
--- a/frontends/PyCDE/src/pycde/bsp/cosim.py
+++ b/frontends/PyCDE/src/pycde/bsp/cosim.py
@@ -72,6 +72,12 @@ def CosimBSP(user_module: Type[Module]) -> Module:
                                   resp_wire.type)
       resp_wire.assign(data)
 
+      ack_wire = Wire(Channel(UInt(8)))
+      write_req = hostmem.write.unpack(ackTag=ack_wire)['req']
+      ack_tag = esi.CallService.call(esi.AppID("__cosim_hostmem_write"),
+                                     write_req, UInt(8))
+      ack_wire.assign(ack_tag)
+
   class ESI_Cosim_Top(Module):
     clk = Clock()
     rst = Input(Bits(1))

--- a/frontends/PyCDE/src/pycde/signals.py
+++ b/frontends/PyCDE/src/pycde/signals.py
@@ -809,8 +809,9 @@ class BundleSignal(Signal):
       raise ValueError(
           f"Missing channel values for {', '.join(from_channels.keys())}")
 
-    unpack_op = esi.UnpackBundleOp([bc.channel._type for bc in to_channels],
-                                   self.value, operands)
+    with get_user_loc():
+      unpack_op = esi.UnpackBundleOp([bc.channel._type for bc in to_channels],
+                                     self.value, operands)
 
     to_channels_results = unpack_op.toChannels
     ret = {

--- a/frontends/PyCDE/src/pycde/types.py
+++ b/frontends/PyCDE/src/pycde/types.py
@@ -858,9 +858,10 @@ class Bundle(Type):
     if len(to_channels) > 0:
       raise ValueError(f"Missing channels: {', '.join(to_channels.keys())}")
 
-    pack_op = esi.PackBundleOp(self._type,
-                               [bc.channel._type for bc in from_channels],
-                               operands)
+    with get_user_loc():
+      pack_op = esi.PackBundleOp(self._type,
+                                 [bc.channel._type for bc in from_channels],
+                                 operands)
 
     return BundleSignal(pack_op.bundle, self), Bundle.PackSignalResults(
         [_FromCirctValue(c) for c in pack_op.fromChannels], self)

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -308,8 +308,8 @@ class MMIOReq(Module):
 # CHECK-NEXT:     [[R5:%.+]] = hwarith.constant 0 : ui256
 # CHECK-NEXT:     [[R6:%.+]] = hw.struct_create ([[R0]], [[R4]], [[R5]]) : !hw.struct<address: ui64, tag: ui8, data: ui256>
 # CHECK-NEXT:     %chanOutput_0, %ready_1 = esi.wrap.vr [[R6]], %false : !hw.struct<address: ui64, tag: ui8, data: ui256>
-# CHECK-NEXT:     [[R7:%.+]] = esi.service.req <@_HostMem::@write>(#esi.appid<"host_mem_write_req">) : !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, data: !esi.any>> from "req", !esi.channel<ui8> to "ackTag"]>
-# CHECK-NEXT:     %ackTag = esi.bundle.unpack %chanOutput_0 from [[R7]] : !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, data: !esi.any>> from "req", !esi.channel<ui8> to "ackTag"]>
+# CHECK-NEXT:     [[R7:%.+]] = esi.service.req <@_HostMem::@write>(#esi.appid<"host_mem_write_req">) : !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, data: ui256>> from "req", !esi.channel<ui8> to "ackTag"]>
+# CHECK-NEXT:     %ackTag = esi.bundle.unpack %chanOutput_0 from [[R7]] : !esi.bundle<[!esi.channel<!hw.struct<address: ui64, tag: ui8, data: ui256>> from "req", !esi.channel<ui8> to "ackTag"]>
 # CHECK:        esi.service.std.hostmem @_HostMem
 @unittestmodule(esi_sys=True)
 class HostMemReq(Module):

--- a/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
@@ -103,11 +103,12 @@ void dmaTest(AcceleratorConnection *conn, Accelerator *acc) {
   // Enable the host memory service.
   auto hostmem = conn->getService<services::HostMem>();
   hostmem->start();
+  auto scratchRegion = hostmem->allocate(8, /*memOpts=*/{});
+  uint64_t *dataPtr = static_cast<uint64_t *>(scratchRegion->getPtr());
 
   // Initiate a test read.
   auto *readMem =
       acc->getPorts().at(AppID("ReadMem")).getAs<services::MMIO::MMIORegion>();
-  uint64_t *dataPtr = new uint64_t;
   *dataPtr = 0x12345678;
   readMem->write(8, (uint64_t)dataPtr);
 
@@ -121,5 +122,19 @@ void dmaTest(AcceleratorConnection *conn, Accelerator *acc) {
     std::this_thread::sleep_for(std::chrono::microseconds(100));
   }
   if (val != *dataPtr)
-    throw std::runtime_error("DMA test failed");
+    throw std::runtime_error("DMA read test failed");
+
+  // Initiate a test write.
+  auto *writeMem =
+      acc->getPorts().at(AppID("WriteMem")).getAs<services::MMIO::MMIORegion>();
+  *dataPtr = 0;
+  writeMem->write(0, (uint64_t)dataPtr);
+  // Wait for the accelerator to write. Timeout and fail after 10ms.
+  for (int i = 0; i < 100; ++i) {
+    if (*dataPtr != 0)
+      break;
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
+  }
+  if (*dataPtr == 0)
+    throw std::runtime_error("DMA write test failed");
 }


### PR DESCRIPTION
Adds cosim support to both the cosim BSP in PyCDE and the corresponding support in the runtime. As with hostmem reads, write only supports one client and no gearboxing.