### PR TITLE
[CombToAIG] Add shl/shru/shrs lowering

### DIFF
--- a/integration_test/circt-synth/comb-lowering-lec.mlir
+++ b/integration_test/circt-synth/comb-lowering-lec.mlir
@@ -69,3 +69,12 @@ hw.module @icmp_signed_compare(in %lhs: i3, in %rhs: i3, out out_sgt: i1, out ou
   %sle = comb.icmp sle %lhs, %rhs : i3
   hw.output %sgt, %sge, %slt, %sle : i1, i1, i1, i1
 }
+
+// RUN: circt-lec %t.mlir %s -c1=shift5 -c2=shift5 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_SHIFT
+// COMB_SHIFT: c1 == c2
+hw.module @shift5(in %lhs: i5, in %rhs: i5, out out_shl: i5, out out_shr: i5, out out_shrs: i5) {
+  %0 = comb.shl %lhs, %rhs : i5
+  %1 = comb.shru %lhs, %rhs : i5
+  %2 = comb.shrs %lhs, %rhs : i5
+  hw.output %0, %1, %2 : i5, i5, i5
+}

--- a/test/Conversion/CombToAIG/comb-to-aig-arith.mlir
+++ b/test/Conversion/CombToAIG/comb-to-aig-arith.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s --pass-pipeline="builtin.module(hw.module(convert-comb-to-aig{additional-legal-ops=comb.xor,comb.or,comb.and,comb.mux},cse))" | FileCheck %s
 // RUN: circt-opt %s --pass-pipeline="builtin.module(hw.module(convert-comb-to-aig{additional-legal-ops=comb.xor,comb.or,comb.and,comb.mux,comb.add},cse))" | FileCheck %s --check-prefix=ALLOW_ADD
-
+// RUN: circt-opt %s --pass-pipeline="builtin.module(hw.module(convert-comb-to-aig{additional-legal-ops=comb.xor,comb.or,comb.and,comb.mux,comb.icmp},cse))" | FileCheck %s --check-prefix=ALLOW_ICMP
 
 // CHECK-LABEL: @parity
 hw.module @parity(in %arg0: i4, out out: i1) {
@@ -130,4 +130,31 @@ hw.module @icmp_signed_compare(in %lhs: i2, in %rhs: i2, out out_sgt: i1, out ou
   // CHECK-NEXT:   hw.output %[[SGT]], %[[SGE]], %[[SLT]], %[[SLE]]
   // CHECK-NEXT: }
   hw.output %sgt, %sge, %slt, %sle : i1, i1, i1, i1
+}
+
+// CHECK-LABEL: @shift2
+// ALLOW_ICMP-LABEL: @shift2
+hw.module @shift2(in %lhs: i2, in %rhs: i2, out out_shl: i2, out out_shr: i2, out out_shrs: i2) {
+  %0 = comb.shl %lhs, %rhs : i2
+  %1 = comb.shru %lhs, %rhs : i2
+  %2 = comb.shrs %lhs, %rhs : i2
+  // ALLOW_ICMP-NEXT: %[[RHS_0:.+]] = comb.extract %rhs from 0 : (i2) -> i1
+  // ALLOW_ICMP-NEXT: %[[C0_I2:.+]] = hw.constant 0
+  // ALLOW_ICMP-NEXT: %[[LHS_0:.+]] = comb.extract %lhs from 0 : (i2) -> i1
+  // ALLOW_ICMP-NEXT: %[[FALSE:.+]] = hw.constant false
+  // ALLOW_ICMP-NEXT: %[[L_SHIFT_BY_1:.+]] = comb.concat %[[LHS_0]], %[[FALSE]]
+  // ALLOW_ICMP-NEXT: %[[L_SHIFT:.+]] = comb.mux %[[RHS_0]], %[[L_SHIFT_BY_1]], %lhs
+  // ALLOW_ICMP-NEXT: %[[C3_I2:.+]] = hw.constant -2
+  // ALLOW_ICMP-NEXT: %[[ICMP:.+]] = comb.icmp ult %rhs, %[[C3_I2]]
+  // ALLOW_ICMP-NEXT: %[[L_SHIFT_WITH_BOUND_CHECK:.+]] = comb.mux %[[ICMP]], %[[L_SHIFT]], %[[C0_I2]]
+  // ALLOW_ICMP-NEXT: %[[LHS_1:.+]] = comb.extract %lhs from 1 : (i2) -> i1
+  // ALLOW_ICMP-NEXT: %[[R_SHIFT_BY_1:.+]] = comb.concat %false, %[[LHS_1]]
+  // ALLOW_ICMP-NEXT: %[[R_SHIFT:.+]] = comb.mux %[[RHS_0]], %[[R_SHIFT_BY_1]], %lhs
+  // ALLOW_ICMP-NEXT: %[[R_SHIFT_WITH_BOUND_CHECK:.+]] = comb.mux %[[ICMP]], %[[R_SHIFT]], %[[C0_I2]]
+  // ALLOW_ICMP-NEXT: %[[SIGN_REPLICATE:.+]] = comb.replicate %[[LHS_1]]
+  // ALLOW_ICMP-NEXT: %[[R_SIGNED_SHIFT_BY_1:.*]] = comb.concat %[[LHS_1]], %[[LHS_0]]
+  // ALLOW_ICMP-NEXT: %[[R_SIGNED_SHIFT:.*]] = comb.mux %[[RHS_0]], %[[SIGN_REPLICATE]], %[[R_SIGNED_SHIFT_BY_1]]
+  // ALLOW_ICMP-NEXT: %[[R_SIGNED_SHIFT_WITH_BOUND_CHECK:.*]] = comb.mux %[[ICMP]], %[[R_SIGNED_SHIFT]], %[[SIGN_REPLICATE]]
+  // ALLOW_ICMP-NEXT: hw.output %[[L_SHIFT_WITH_BOUND_CHECK]], %[[R_SHIFT_WITH_BOUND_CHECK]], %[[R_SIGNED_SHIFT_WITH_BOUND_CHECK]]
+  hw.output %0, %1, %2 : i2, i2, i2
 }


### PR DESCRIPTION
This commit implements lowering for shift operations. They are currently lowered into mux-trees.