### PR TITLE
[HW][circt-synth] Implement AggregateToComb pass and add to circt-synth pipeline

### DIFF
--- a/include/circt/Dialect/Comb/CombOps.h
+++ b/include/circt/Dialect/Comb/CombOps.h
@@ -57,6 +57,15 @@ Value createOrFoldNot(Location loc, Value value, OpBuilder &builder,
 Value createOrFoldNot(Value value, ImplicitLocOpBuilder &builder,
                       bool twoState = false);
 
+/// Extract bits from a value.
+void extractBits(OpBuilder &builder, Value val, SmallVectorImpl<Value> &bits);
+
+/// Construct a mux tree for given leaf nodes. `selectors` is the selector for
+/// each level of the tree. Currently the selector is tested from MSB to LSB.
+Value constructMuxTree(OpBuilder &builder, Location loc,
+                       ArrayRef<Value> selectors, ArrayRef<Value> leafNodes,
+                       Value outOfBoundsValue);
+
 } // namespace comb
 } // namespace circt
 

--- a/include/circt/Dialect/HW/HWPasses.h
+++ b/include/circt/Dialect/HW/HWPasses.h
@@ -33,6 +33,7 @@ std::unique_ptr<mlir::Pass> createFlattenIOPass(bool recursiveFlag = true,
 std::unique_ptr<mlir::Pass> createVerifyInnerRefNamespacePass();
 std::unique_ptr<mlir::Pass> createFlattenModulesPass();
 std::unique_ptr<mlir::Pass> createFooWiresPass();
+std::unique_ptr<mlir::Pass> createHWAggregateToCombPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -95,6 +95,10 @@ def HWAggregateToComb : Pass<"hw-aggregate-to-comb", "hw::HWModuleOp"> {
     This pass lowers aggregate *operations* to comb operations within modules.
     Note that this pass does not lower ports. Ports lowering is handled
     by FlattenIO.
+
+    This pass will change the behavior of out-of-bounds access of arrays,
+    specifically the last element of the array is used as a value for
+    out-of-bounds access.
   }];
   let dependentDialects = ["comb::CombDialect"];
 }

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -93,8 +93,8 @@ def HWAggregateToComb : Pass<"hw-aggregate-to-comb", "hw::HWModuleOp"> {
 
   let description = [{
     This pass lowers aggregate *operations* to comb operations within modules.
-    This pass does not lower ports, as ports are handled by FlattenIO. This pass
-    will also change the behavior of out-of-bounds access of arrays.
+    Note that this pass does not lower ports. Ports lowering is handled
+    by FlattenIO.
   }];
   let dependentDialects = ["comb::CombDialect"];
 }

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -87,4 +87,16 @@ def FooWires : Pass<"hw-foo-wires", "hw::HWModuleOp"> {
   let constructor = "circt::hw::createFooWiresPass()";
 }
 
+def HWAggregateToComb : Pass<"hw-aggregate-to-comb", "hw::HWModuleOp"> {
+  let summary = "Lower aggregate operations to comb operations";
+  let constructor = "circt::hw::createHWAggregateToCombPass()";
+
+  let description = [{
+    This pass lowers aggregate *operations* to comb operations within modules.
+    This pass does not lower ports, as ports are handled by FlattenIO. This pass
+    will also change the behavior of out-of-bounds access of arrays.
+  }];
+  let dependentDialects = ["comb::CombDialect"];
+}
+
 #endif // CIRCT_DIALECT_HW_PASSES_TD

--- a/integration_test/circt-synth/comb-lowering-lec.mlir
+++ b/integration_test/circt-synth/comb-lowering-lec.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: libz3
 // REQUIRES: circt-lec-jit
 
-// RUN: circt-opt %s --convert-comb-to-aig --convert-aig-to-comb -o %t.mlir
+// RUN: circt-opt %s --hw-aggregate-to-comb --convert-comb-to-aig --convert-aig-to-comb -o %t.mlir
 // RUN: circt-lec %t.mlir %s -c1=bit_logical -c2=bit_logical --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_BIT_LOGICAL
 // COMB_BIT_LOGICAL: c1 == c2
 hw.module @bit_logical(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i32,
@@ -77,4 +77,20 @@ hw.module @shift5(in %lhs: i5, in %rhs: i5, out out_shl: i5, out out_shr: i5, ou
   %1 = comb.shru %lhs, %rhs : i5
   %2 = comb.shrs %lhs, %rhs : i5
   hw.output %0, %1, %2 : i5, i5, i5
+}
+
+// RUN: circt-lec %t.mlir %s -c1=array -c2=array --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ARRAY
+// COMB_ARRAY: c1 == c2
+hw.module @array(in %arg0: i2, in %arg1: i2, in %arg2: i2, in %arg3: i2, in %sel1: i2, in %sel2: i2, out out1: i2, out out2: i2) {
+  %0 = hw.array_create %arg0, %arg1, %arg2, %arg3 : i2
+  %1 = hw.array_get %0[%sel1] : !hw.array<4xi2>, i2
+  %2 = hw.array_create %arg0, %arg1, %arg2 : i2
+  %c3_i2 = hw.constant 3 : i2
+  // NOTE: If the index is out of bounds, the result value is undefined.
+  // In LEC such value is lowered into unbounded SMT variable and cause
+  // the LEC to fail. So just asssume that the index is in bounds.
+  %inbound = comb.icmp ult %sel2, %c3_i2 : i2
+  verif.assume %inbound : i1
+  %3 = hw.array_get %2[%sel2] : !hw.array<3xi2>, i2
+  hw.output %1, %3 : i2, i2
 }

--- a/lib/Dialect/HW/Transforms/CMakeLists.txt
+++ b/lib/Dialect/HW/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_dialect_library(CIRCTHWTransforms
+  HWAggregateToComb.cpp
   HWPrintInstanceGraph.cpp
   HWSpecialize.cpp
   PrintHWModuleGraph.cpp

--- a/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
+++ b/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
@@ -11,7 +11,6 @@
 #include "circt/Dialect/HW/HWPasses.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "llvm/ADT/TypeSwitch.h"
 
 namespace circt {
 namespace hw {

--- a/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
+++ b/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
@@ -1,0 +1,187 @@
+//===- HWAggregateToComb.cpp - HW aggregate to comb -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWPasses.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace circt {
+namespace hw {
+#define GEN_PASS_DEF_HWAGGREGATETOCOMB
+#include "circt/Dialect/HW/Passes.h.inc"
+} // namespace hw
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+
+namespace {
+template <typename OpTy>
+struct HWArrayCreateLikeOpConversion : OpConversionPattern<OpTy> {
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+  using OpAdaptor = typename OpConversionPattern<OpTy>::OpAdaptor;
+  LogicalResult
+  matchAndRewrite(OpTy op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Lower to concat.
+    auto inputs = adaptor.getInputs();
+    SmallVector<Value> results;
+    for (auto input : inputs)
+      results.push_back(rewriter.getRemappedValue(input));
+    rewriter.replaceOpWithNewOp<comb::ConcatOp>(op, results);
+    return success();
+  }
+};
+
+struct HWAggregateConstantOpConversion
+    : OpConversionPattern<hw::AggregateConstantOp> {
+  using OpConversionPattern<hw::AggregateConstantOp>::OpConversionPattern;
+
+  static LogicalResult peelAttribute(Location loc, Attribute attr,
+                                     ConversionPatternRewriter &rewriter,
+                                     SmallVector<Value> &results) {
+    SmallVector<Attribute> worklist;
+    worklist.push_back(attr);
+
+    while (!worklist.empty()) {
+      auto current = worklist.pop_back_val();
+      if (auto innerArray = dyn_cast<ArrayAttr>(current)) {
+        for (auto elem : llvm::reverse(innerArray))
+          worklist.push_back(elem);
+        continue;
+      }
+
+      if (auto intAttr = dyn_cast<IntegerAttr>(current)) {
+        results.push_back(rewriter.create<hw::ConstantOp>(loc, intAttr));
+        continue;
+      }
+
+      return failure();
+    }
+
+    return success();
+  }
+
+  LogicalResult
+  matchAndRewrite(hw::AggregateConstantOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Lower to concat.
+    SmallVector<Value> results;
+    if (failed(peelAttribute(op.getLoc(), adaptor.getFieldsAttr(), rewriter,
+                             results)))
+      return failure();
+    rewriter.replaceOpWithNewOp<comb::ConcatOp>(op, results);
+    return success();
+  }
+};
+
+struct HWArrayGetOpConversion : OpConversionPattern<hw::ArrayGetOp> {
+  using OpConversionPattern<hw::ArrayGetOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(hw::ArrayGetOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Value> results;
+    auto arrayType = cast<hw::ArrayType>(op.getInput().getType());
+    auto elemType = arrayType.getElementType();
+    auto numElements = arrayType.getNumElements();
+    auto elemWidth = hw::getBitWidth(elemType);
+    if (elemWidth < 0)
+      return rewriter.notifyMatchFailure(op.getLoc(), "unknown element width");
+
+    auto lowered = rewriter.getRemappedValue(op.getInput());
+    if (!lowered)
+      return failure();
+
+    for (size_t i = 0; i < numElements; ++i)
+      results.push_back(rewriter.createOrFold<comb::ExtractOp>(
+          op.getLoc(), lowered, i * elemWidth, elemWidth));
+
+    SmallVector<Value> bits;
+    comb::extractBits(rewriter, op.getIndex(), bits);
+    auto result = comb::constructMuxTree(rewriter, op.getLoc(), bits, results,
+                                         results.back());
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+/// A type converter is needed to perform the in-flight materialization of
+/// aggregate types to integer types.
+class AggregateTypeConverter : public TypeConverter {
+public:
+  AggregateTypeConverter() {
+    addConversion([](Type type) -> Type { return type; });
+    addConversion([](hw::ArrayType t) -> Type {
+      return IntegerType::get(t.getContext(), hw::getBitWidth(t));
+    });
+    addTargetMaterialization([](mlir::OpBuilder &builder, mlir::Type resultType,
+                                mlir::ValueRange inputs,
+                                mlir::Location loc) -> mlir::Value {
+      if (inputs.size() != 1)
+        return Value();
+
+      return builder.create<hw::BitcastOp>(loc, resultType, inputs[0])
+          ->getResult(0);
+    });
+
+    addSourceMaterialization([](mlir::OpBuilder &builder, mlir::Type resultType,
+                                mlir::ValueRange inputs,
+                                mlir::Location loc) -> mlir::Value {
+      if (inputs.size() != 1)
+        return Value();
+
+      return builder.create<hw::BitcastOp>(loc, resultType, inputs[0])
+          ->getResult(0);
+    });
+  }
+};
+} // namespace
+
+static void populateHWAggregateToCombOpConversionPatterns(
+    RewritePatternSet &patterns, AggregateTypeConverter &typeConverter) {
+  patterns.add<HWArrayGetOpConversion,
+               HWArrayCreateLikeOpConversion<hw::ArrayCreateOp>,
+               HWArrayCreateLikeOpConversion<hw::ArrayConcatOp>,
+               HWAggregateConstantOpConversion>(typeConverter,
+                                                patterns.getContext());
+}
+
+namespace {
+struct HWAggregateToCombPass
+    : public hw::impl::HWAggregateToCombBase<HWAggregateToCombPass> {
+  void runOnOperation() override;
+  using HWAggregateToCombBase<HWAggregateToCombPass>::HWAggregateToCombBase;
+};
+} // namespace
+
+void HWAggregateToCombPass::runOnOperation() {
+  ConversionTarget target(getContext());
+
+  // TODO: Add structs.
+  target.addIllegalOp<hw::ArrayGetOp, hw::ArrayCreateOp, hw::ArrayConcatOp,
+                      hw::AggregateConstantOp>();
+
+  target.addLegalDialect<hw::HWDialect, comb::CombDialect>();
+
+  RewritePatternSet patterns(&getContext());
+  AggregateTypeConverter typeConverter;
+  populateHWAggregateToCombOpConversionPatterns(patterns, typeConverter);
+
+  if (failed(mlir::applyPartialConversion(getOperation(), target,
+                                          std::move(patterns))))
+    return signalPassFailure();
+}
+
+std::unique_ptr<Pass> circt::hw::createHWAggregateToCombPass() {
+  return std::make_unique<HWAggregateToCombPass>();
+}

--- a/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
+++ b/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
@@ -81,7 +81,7 @@ struct HWAggregateConstantOpConversion
     if (failed(peelAttribute(op.getLoc(), adaptor.getFieldsAttr(), rewriter,
                              intVal)))
       return failure();
-    rewriter.replaceOpWithNewOp<hw::ConstantOp>(op,  intVal);
+    rewriter.replaceOpWithNewOp<hw::ConstantOp>(op, intVal);
     return success();
   }
 };

--- a/test/Conversion/CombToAIG/comb-to-aig-arith.mlir
+++ b/test/Conversion/CombToAIG/comb-to-aig-arith.mlir
@@ -173,3 +173,4 @@ hw.module @shift2(in %lhs: i2, in %rhs: i2, out out_shl: i2, out out_shr: i2, ou
   // ALLOW_ICMP-NEXT: hw.output %[[L_SHIFT_WITH_BOUND_CHECK]], %[[R_SHIFT_WITH_BOUND_CHECK]], %[[R_SIGNED_SHIFT]]
   hw.output %0, %1, %2 : i2, i2, i2
 }
+

--- a/test/Dialect/HW/hw-aggregate-to-comb.mlir
+++ b/test/Dialect/HW/hw-aggregate-to-comb.mlir
@@ -1,0 +1,61 @@
+// RUN: circt-opt %s -hw-aggregate-to-comb | FileCheck %s
+
+
+// CHECK-LABEL: @agg_const
+hw.module @agg_const(out out: !hw.array<4xi4>) {
+  // CHECK:      %[[CONST:.+]] = comb.concat %c0_i4, %c1_i4, %c-2_i4, %c-1_i4 : i4, i4, i4, i4
+  // CHECK-NEXT: %[[BITCAST:.+]] = hw.bitcast %[[CONST]] : (i16) -> !hw.array<4xi4>
+  // CHECK-NEXT: hw.output %[[BITCAST]] : !hw.array<4xi4>
+  %0 = hw.aggregate_constant [0 : i4, 1 : i4, -2 : i4, -1 : i4] : !hw.array<4xi4>
+  hw.output %0 : !hw.array<4xi4>
+}
+
+// CHECK-LABEL: @array_get_for_port
+hw.module @array_get_for_port(in %in: !hw.array<5xi4>, out out: i4) {
+  %c_i2 = hw.constant 3 : i3
+  // CHECK-NEXT: %[[BITCAST_IN:.+]] = hw.bitcast %in : (!hw.array<5xi4>) -> i20
+  // CHECK:      %[[EXTRACT:.+]] = comb.extract %[[BITCAST_IN]] from 12 : (i20) -> i4
+  // CHECK:      hw.output %[[EXTRACT]] : i4
+  %1 = hw.array_get %in[%c_i2] : !hw.array<5xi4>, i3
+  hw.output %1 : i4
+}
+
+// CHECK-LABEL: @array_concat
+hw.module @array_concat(in %lhs: !hw.array<2xi4>, in %rhs: !hw.array<3xi4>, out out: i4) {
+  %0 = hw.array_concat %lhs, %rhs : !hw.array<2xi4>, !hw.array<3xi4>
+  %c_i2 = hw.constant 3 : i3
+  // CHECK-NEXT: %[[BITCAST_RHS:.+]] = hw.bitcast %rhs : (!hw.array<3xi4>) -> i12
+  // CHECK-NEXT: %[[BITCAST_LHS:.+]] = hw.bitcast %lhs : (!hw.array<2xi4>) -> i8
+  // CHECK-NEXT: %[[CONCAT:.+]] = comb.concat %[[BITCAST_LHS]], %[[BITCAST_RHS]] : i8, i12
+  // CHECK:      %[[EXTRACT:.+]] = comb.extract %[[CONCAT]] from 12 : (i20) -> i4
+  // CHECK:      hw.output %[[EXTRACT]] : i4
+  %1 = hw.array_get %0[%c_i2] : !hw.array<5xi4>, i3
+  hw.output %1 : i4
+}
+
+hw.module.extern @foo(in %in: !hw.array<4xi2>, out out: !hw.array<4xi2>)
+// CHECK-LABEL: @array_instance(
+hw.module @array_instance(in %in: !hw.array<4xi2>, out out: !hw.array<4xi2>) {
+  // CHECK-NEXT: hw.instance "foo" @foo(in: %in: !hw.array<4xi2>) -> (out: !hw.array<4xi2>)
+  %0 = hw.instance "foo" @foo(in: %in: !hw.array<4xi2>) -> (out: !hw.array<4xi2>)
+  hw.output %0 : !hw.array<4xi2>
+}
+
+// CHECK-LABEL: @array(
+hw.module @array(in %arg0: i2, in %arg1: i2, in %arg2: i2, in %arg3: i2, out out: !hw.array<4xi2>, in %sel: i2, out out_get: i2) {
+  %0 = hw.array_create %arg0, %arg1, %arg2, %arg3 : i2
+  %1 = hw.array_get %0[%sel] : !hw.array<4xi2>, i2
+  // CHECK-NEXT: %[[CONCAT:.+]] = comb.concat %arg0, %arg1, %arg2, %arg3 : i2, i2, i2, i2
+  // CHECK-NEXT: %[[BITCAST:.+]] = hw.bitcast %[[CONCAT]] : (i8) -> !hw.array<4xi2>
+  // CHECK-NEXT: %[[EXTRACT_0:.+]] = comb.extract %[[CONCAT]] from 0 : (i8) -> i2
+  // CHECK-NEXT: %[[EXTRACT_2:.+]] = comb.extract %[[CONCAT]] from 2 : (i8) -> i2
+  // CHECK-NEXT: %[[EXTRACT_4:.+]] = comb.extract %[[CONCAT]] from 4 : (i8) -> i2
+  // CHECK-NEXT: %[[EXTRACT_6:.+]] = comb.extract %[[CONCAT]] from 6 : (i8) -> i2
+  // CHECK-NEXT: %[[EXTRACT_SEL:.+]] = comb.extract %sel from 0
+  // CHECK-NEXT: %[[EXTRACT_SEL_1:.+]] = comb.extract %sel from 1
+  // CHECK-NEXT: %[[MUX_0:.+]] = comb.mux %[[EXTRACT_SEL]], %[[EXTRACT_6]], %[[EXTRACT_4]]
+  // CHECK-NEXT: %[[MUX_1:.+]] = comb.mux %[[EXTRACT_SEL]], %[[EXTRACT_2]], %[[EXTRACT_0]]
+  // CHECK-NEXT: %[[MUX_2:.+]] = comb.mux %[[EXTRACT_SEL_1]], %[[MUX_0]], %[[MUX_1]]
+  // CHECK-NEXT: hw.output %[[BITCAST]], %[[MUX_2]]
+  hw.output %0, %1 : !hw.array<4xi2>, i2
+}

--- a/test/Dialect/HW/hw-aggregate-to-comb.mlir
+++ b/test/Dialect/HW/hw-aggregate-to-comb.mlir
@@ -3,7 +3,7 @@
 
 // CHECK-LABEL: @agg_const
 hw.module @agg_const(out out: !hw.array<4xi4>) {
-  // CHECK:      %[[CONST:.+]] = comb.concat %c0_i4, %c1_i4, %c-2_i4, %c-1_i4 : i4, i4, i4, i4
+  // CHECK:      %[[CONST:.+]] = hw.constant 495 : i16
   // CHECK-NEXT: %[[BITCAST:.+]] = hw.bitcast %[[CONST]] : (i16) -> !hw.array<4xi4>
   // CHECK-NEXT: hw.output %[[BITCAST]] : !hw.array<4xi4>
   %0 = hw.aggregate_constant [0 : i4, 1 : i4, -2 : i4, -1 : i4] : !hw.array<4xi4>
@@ -21,16 +21,14 @@ hw.module @array_get_for_port(in %in: !hw.array<5xi4>, out out: i4) {
 }
 
 // CHECK-LABEL: @array_concat
-hw.module @array_concat(in %lhs: !hw.array<2xi4>, in %rhs: !hw.array<3xi4>, out out: i4) {
+hw.module @array_concat(in %lhs: !hw.array<2xi4>, in %rhs: !hw.array<3xi4>, out out: !hw.array<5xi4>) {
   %0 = hw.array_concat %lhs, %rhs : !hw.array<2xi4>, !hw.array<3xi4>
-  %c_i2 = hw.constant 3 : i3
   // CHECK-NEXT: %[[BITCAST_RHS:.+]] = hw.bitcast %rhs : (!hw.array<3xi4>) -> i12
   // CHECK-NEXT: %[[BITCAST_LHS:.+]] = hw.bitcast %lhs : (!hw.array<2xi4>) -> i8
   // CHECK-NEXT: %[[CONCAT:.+]] = comb.concat %[[BITCAST_LHS]], %[[BITCAST_RHS]] : i8, i12
-  // CHECK:      %[[EXTRACT:.+]] = comb.extract %[[CONCAT]] from 12 : (i20) -> i4
-  // CHECK:      hw.output %[[EXTRACT]] : i4
-  %1 = hw.array_get %0[%c_i2] : !hw.array<5xi4>, i3
-  hw.output %1 : i4
+  // CHECK-NEXT: %[[BITCAST_OUT:.+]] = hw.bitcast %[[CONCAT]] : (i20) -> !hw.array<5xi4>
+  // CHECK:      hw.output %[[BITCAST_OUT]]
+  hw.output %0 : !hw.array<5xi4>
 }
 
 hw.module.extern @foo(in %in: !hw.array<4xi2>, out out: !hw.array<4xi2>)

--- a/tools/circt-synth/CMakeLists.txt
+++ b/tools/circt-synth/CMakeLists.txt
@@ -7,6 +7,7 @@ target_link_libraries(circt-synth
   CIRCTComb
   CIRCTCombToAIG
   CIRCTHW
+  CIRCTHWTransforms
   CIRCTSupport
   MLIRIR
   MLIRParser

--- a/tools/circt-synth/circt-synth.cpp
+++ b/tools/circt-synth/circt-synth.cpp
@@ -18,6 +18,7 @@
 #include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Support/Passes.h"
 #include "circt/Support/Version.h"
 #include "mlir/IR/Diagnostics.h"
@@ -107,6 +108,7 @@ static void populateSynthesisPipeline(PassManager &pm) {
   });
 
   auto &mpm = pm.nest<hw::HWModuleOp>();
+  mpm.addPass(circt::hw::createHWAggregateToCombPass());
   mpm.addPass(circt::createConvertCombToAIG());
   mpm.addPass(createCSEPass());
   if (untilReached(UntilAIGLowering))


### PR DESCRIPTION
This PR adds a new pass `HWAggregateToComb` that lowers array operations to comb operations. The pass converts:

- `hw.array_get` to a mux tree using comb operations
- `hw.array_create` and `hw.array_concat` to `comb.concat`
- `hw.aggregate_constant` to `comb.concat` of individual constants

The PR also moves two utility functions from CombToAIG to the Comb dialect:
- `extractBits`: Extracts individual bits from a value
- `constructMuxTree`: Builds a multiplexer tree from selectors and leaf nodes

The pass is required to run before CombToAIG to ensure array operations are
properly lowered to AIG. Strictly speaking other than array_get operations can be preserved
but array values prevent optimizations at AIG level.  So for the simplicity, I think it's reasonable
to lower array operations within circt-synth pipeline. 

I currently added the pass under `HW/Transforms` considering `FlattenIO` is very similar but the pass might better belong to Conversion.

