### PR TITLE
[SMT][python] enable python bindings

### DIFF
--- a/include/circt-c/Dialect/SMT.h
+++ b/include/circt-c/Dialect/SMT.h
@@ -1,4 +1,4 @@
-//===- SMT.h - C interface for the SMT dialect ----------------*- C -*-===//
+//===- SMT.h - C interface for the SMT dialect --------------------*- C -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/include/circt-c/Dialect/SMT.h
+++ b/include/circt-c/Dialect/SMT.h
@@ -1,0 +1,24 @@
+//===- SMT.h - C interface for the SMT dialect ----------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_C_DIALECT_SMT_H
+#define CIRCT_C_DIALECT_SMT_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(SMT, smt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CIRCT_C_DIALECT_SMT_H

--- a/integration_test/Bindings/Python/dialects/smt.py
+++ b/integration_test/Bindings/Python/dialects/smt.py
@@ -1,0 +1,17 @@
+# REQUIRES: bindings_python
+# RUN: %PYTHON% %s | FileCheck %s
+
+import circt
+
+from circt.dialects import smt
+from circt.ir import Context, Location, Module, InsertionPoint
+
+with Context() as ctx, Location.unknown():
+  circt.register_dialects(ctx)
+  m = Module.create()
+  with InsertionPoint(m.body):
+    true = smt.constant(True)
+    false = smt.constant(False)
+  # CHECK: smt.constant true
+  # CHECK: smt.constant false
+  print(m)

--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -26,6 +26,7 @@
 #ifdef CIRCT_INCLUDE_TESTS
 #include "circt-c/Dialect/RTGTest.h"
 #endif
+#include "circt-c/Dialect/SMT.h"
 #include "circt-c/Dialect/SV.h"
 #include "circt-c/Dialect/Seq.h"
 #include "circt-c/Dialect/Verif.h"
@@ -135,6 +136,10 @@ PYBIND11_MODULE(_circt, m) {
         MlirDialectHandle verif = mlirGetDialectHandle__verif__();
         mlirDialectHandleRegisterDialect(verif, context);
         mlirDialectHandleLoadDialect(verif, context);
+
+        MlirDialectHandle smt = mlirGetDialectHandle__smt__();
+        mlirDialectHandleRegisterDialect(smt, context);
+        mlirDialectHandleLoadDialect(smt, context);
       },
       "Register CIRCT dialects on a PyMlirContext.");
 

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -45,6 +45,7 @@ set(PYTHON_BINDINGS_LINK_LIBS
   CIRCTCAPIRTG
   CIRCTCAPIRtgTool
   CIRCTCAPISeq
+  CIRCTCAPISMT
   CIRCTCAPISV
   CIRCTCAPIVerif
   MLIRCAPITransforms
@@ -211,6 +212,14 @@ declare_mlir_dialect_python_bindings(
   SOURCES
     dialects/verif.py
   DIALECT_NAME verif)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT CIRCTBindingsPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+  TD_FILE dialects/SMTOps.td
+  SOURCES
+    dialects/smt.py
+  DIALECT_NAME smt)
 
 declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT CIRCTBindingsPythonSources.Dialects

--- a/lib/Bindings/Python/dialects/SMTOps.td
+++ b/lib/Bindings/Python/dialects/SMTOps.td
@@ -1,0 +1,14 @@
+//===- SMTOps.td - Entry point for SMT bindings --------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef BINDINGS_PYTHON_SMT_OPS
+#define BINDINGS_PYTHON_SMT_OPS
+
+include "circt/Dialect/SMT/SMT.td"
+
+#endif

--- a/lib/Bindings/Python/dialects/SMTOps.td
+++ b/lib/Bindings/Python/dialects/SMTOps.td
@@ -1,4 +1,4 @@
-//===- SMTOps.td - Entry point for SMT bindings --------*- tablegen -*-===//
+//===- SMTOps.td - Entry point for SMT bindings ------------*- tablegen -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,4 +11,4 @@
 
 include "circt/Dialect/SMT/SMT.td"
 
-#endif
+#endif // BINDINGS_PYTHON_SMT_OPS

--- a/lib/Bindings/Python/dialects/smt.py
+++ b/lib/Bindings/Python/dialects/smt.py
@@ -1,0 +1,5 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._smt_ops_gen import *

--- a/lib/CAPI/Dialect/CMakeLists.txt
+++ b/lib/CAPI/Dialect/CMakeLists.txt
@@ -21,6 +21,7 @@ set(LLVM_OPTIONAL_SOURCES
   RTGTest.cpp
   SV.cpp
   Seq.cpp
+  SMT.cpp
   Verif.cpp
 )
 
@@ -223,4 +224,12 @@ add_circt_public_c_api_library(CIRCTCAPIEmit
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   CIRCTEmit
+)
+
+add_circt_public_c_api_library(CIRCTCAPISMT
+  SMT.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRCAPIIR
+  CIRCTSMT
 )

--- a/lib/CAPI/Dialect/SMT.cpp
+++ b/lib/CAPI/Dialect/SMT.cpp
@@ -1,4 +1,4 @@
-//===- SMT.cpp - C interface for the SMT dialect ----------------------===//
+//===- SMT.cpp - C interface for the SMT dialect --------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/CAPI/Dialect/SMT.cpp
+++ b/lib/CAPI/Dialect/SMT.cpp
@@ -1,0 +1,14 @@
+//===- SMT.cpp - C interface for the SMT dialect ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt-c/Dialect/SMT.h"
+#include "circt/Dialect/SMT/SMTDialect.h"
+
+#include "mlir/CAPI/Registration.h"
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(SMT, smt, circt::smt::SMTDialect)


### PR DESCRIPTION
This PR enables the python bindings for the `smt` dialect.

I'm not sure what y'alls approach is to testing these bindings since [PyCDE only tests the bindings it uses](https://github.com/llvm/circt/tree/main/frontends/PyCDE/test) and I don't see any other python bindings tests around...