### PR TITLE
[MemoryBanking] Bank memref::copy logically using memref::subView

### DIFF
--- a/lib/Transforms/MemoryBanking.cpp
+++ b/lib/Transforms/MemoryBanking.cpp
@@ -410,24 +410,22 @@ private:
 };
 
 struct BankMemrefCopyPattern : public OpRewritePattern<memref::CopyOp> {
-  BankMemrefCopyPattern(MLIRContext *ctx,
-                        uint64_t bankingFactor,
+  BankMemrefCopyPattern(MLIRContext *ctx, uint64_t bankingFactor,
                         unsigned bankingDimension,
                         DenseMap<Value, SmallVector<Value>> &memoryToBanks)
-      : OpRewritePattern<memref::CopyOp>(ctx),
-        bankingFactor(bankingFactor),
-        bankingDimension(bankingDimension),
-        memoryToBanks(memoryToBanks) {}
+      : OpRewritePattern<memref::CopyOp>(ctx), bankingFactor(bankingFactor),
+        bankingDimension(bankingDimension), memoryToBanks(memoryToBanks) {}
 
   LogicalResult matchAndRewrite(memref::CopyOp copyOp,
                                 PatternRewriter &rewriter) const override {
     Value srcMem = copyOp.getSource();
     Value dstMem = copyOp.getTarget();
-    
+
     bool srcIsBanked = memoryToBanks.count(srcMem) != 0;
     bool dstIsBanked = memoryToBanks.count(dstMem) != 0;
     if (!srcIsBanked && !dstIsBanked) {
-      copyOp.emitError("At least one of the source and destination memory reference should be banked");
+      copyOp.emitError("At least one of the source and destination memory "
+                       "reference should be banked");
       return failure();
     }
 
@@ -442,14 +440,14 @@ struct BankMemrefCopyPattern : public OpRewritePattern<memref::CopyOp> {
         rewriter.create<memref::CopyOp>(loc, srcBanks[i], dstBanks[i]);
     } else if (srcIsBanked) {
       auto &srcBanks = memoryToBanks.find(srcMem)->second;
-      if (failed(copyFromBanksToUnbanked(rewriter, loc,
-                                         srcBanks, dstMem,
+      if (failed(copyFromBanksToUnbanked(rewriter, loc, srcBanks, dstMem,
                                          bankingFactor, bankingDimension))) {
         return failure();
       }
     } else {
       auto &dstBanks = memoryToBanks.find(dstMem)->second;
-      if (failed(copyFromUnbankedToBanks(rewriter, loc, srcMem, dstBanks, bankingFactor, bankingDimension)))
+      if (failed(copyFromUnbankedToBanks(rewriter, loc, srcMem, dstBanks,
+                                         bankingFactor, bankingDimension)))
         return failure();
     }
 
@@ -462,37 +460,45 @@ private:
   uint64_t bankingFactor;
   unsigned bankingDimension;
   DenseMap<Value, SmallVector<Value>> &memoryToBanks;
-/// Helper function to create a subview with round-robin partitioning.
-/// Generates offsets, sizes, and strides for a specific bank and creates the subview.
-Value createRoundRobinSubview(PatternRewriter &rewriter, Location loc, Value mem,
-                              ArrayRef<int64_t> shape, size_t bankIndex,
-                              uint64_t bankingFactor, unsigned bankingDimension) const {
-  int64_t rank = shape.size();
-      // Initialize SubView offsets, sizes, strides for each dimension with default values.
-  SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
-  SmallVector<OpFoldResult> sizes(rank);
-  SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
+  /// Helper function to create a subview with round-robin partitioning.
+  /// Generates offsets, sizes, and strides for a specific bank and creates the
+  /// subview.
+  Value createRoundRobinSubview(PatternRewriter &rewriter, Location loc,
+                                Value mem, ArrayRef<int64_t> shape,
+                                size_t bankIndex, uint64_t bankingFactor,
+                                unsigned bankingDimension) const {
+    int64_t rank = shape.size();
+    // Initialize SubView offsets, sizes, strides for each dimension with
+    // default values.
+    SmallVector<OpFoldResult> offsets(rank, rewriter.getIndexAttr(0));
+    SmallVector<OpFoldResult> sizes(rank);
+    SmallVector<OpFoldResult> strides(rank, rewriter.getIndexAttr(1));
 
-  for (int64_t d = 0; d < rank; ++d) {
-    int64_t dimSize = shape[d];
-    if (d == bankingDimension) {
-      // Round-robin partition: offset = bankIndex, size = chunkSize, stride = bankingFactor
-      int64_t chunkSize = dimSize / (int64_t)bankingFactor;
-      offsets[d] = rewriter.getIndexAttr(bankIndex);
-      sizes[d] = rewriter.getIndexAttr(chunkSize);
-      strides[d] = rewriter.getIndexAttr(bankingFactor);
-    } else {
-      // Non-banked dimension: copy the entire range, unit stride
-      offsets[d] = rewriter.getIndexAttr(0);
-      sizes[d] = rewriter.getIndexAttr(dimSize);
-      strides[d] = rewriter.getIndexAttr(1);
+    for (int64_t d = 0; d < rank; ++d) {
+      int64_t dimSize = shape[d];
+      if (d == bankingDimension) {
+        // Round-robin partition: offset = bankIndex, size = chunkSize, stride =
+        // bankingFactor
+        int64_t chunkSize = dimSize / (int64_t)bankingFactor;
+        offsets[d] = rewriter.getIndexAttr(bankIndex);
+        sizes[d] = rewriter.getIndexAttr(chunkSize);
+        strides[d] = rewriter.getIndexAttr(bankingFactor);
+      } else {
+        // Non-banked dimension: copy the entire range, unit stride
+        offsets[d] = rewriter.getIndexAttr(0);
+        sizes[d] = rewriter.getIndexAttr(dimSize);
+        strides[d] = rewriter.getIndexAttr(1);
+      }
     }
+
+    return rewriter.create<memref::SubViewOp>(loc, mem, offsets, sizes,
+                                              strides);
   }
 
-  return rewriter.create<memref::SubViewOp>(loc, mem, offsets, sizes, strides);
-}
-
-  /// Copy from source memory reference to destination memory reference when the source memory is banked into `srcBanks` and `dstMem` is unbanked. All `srcBanks` have the same MemRefType; the unbanked `dstMem` has the same shape as the source's "original" shape.
+  /// Copy from source memory reference to destination memory reference when the
+  /// source memory is banked into `srcBanks` and `dstMem` is unbanked. All
+  /// `srcBanks` have the same MemRefType; the unbanked `dstMem` has the same
+  /// shape as the source's "original" shape.
   LogicalResult copyFromBanksToUnbanked(PatternRewriter &rewriter, Location loc,
                                         ArrayRef<Value> srcBanks, Value dstMem,
                                         uint64_t bankingFactor,
@@ -506,42 +512,46 @@ Value createRoundRobinSubview(PatternRewriter &rewriter, Location loc, Value mem
     if (chunkSize <= 0)
       return failure();
 
-  // For each bank i in [0..bankingFactor), create a subview of the source
-  //    that picks out the "i-th round-robin slice" along the banking dimension.
-  for (size_t i = 0; i < bankingFactor; ++i) {
-    auto subView = createRoundRobinSubview(rewriter, loc, dstMem, dstShape, i, bankingFactor, bankingDimension);
-    rewriter.create<memref::CopyOp>(loc, srcBanks[i], subView);
-  }
+    // For each bank i in [0..bankingFactor), create a subview of the source
+    //    that picks out the "i-th round-robin slice" along the banking
+    //    dimension.
+    for (size_t i = 0; i < bankingFactor; ++i) {
+      auto subView = createRoundRobinSubview(rewriter, loc, dstMem, dstShape, i,
+                                             bankingFactor, bankingDimension);
+      rewriter.create<memref::CopyOp>(loc, srcBanks[i], subView);
+    }
 
     return success();
   }
 
-/// Copy from unbanked source memref `srcMem` to destination memory references
-/// `dstBanks`, where each bank has the same MemRefType, and `srcMem` has the
-/// shape of the "original" unbanked array.
-LogicalResult copyFromUnbankedToBanks(PatternRewriter &rewriter, Location loc,
-                                      Value srcMem, ArrayRef<Value> dstBanks,
-                                      uint64_t bankingFactor,
-                                      unsigned bankingDimension) const {
-  auto srcType = dyn_cast<MemRefType>(srcMem.getType());
-  if (!srcType || srcType.getRank() <= bankingDimension)
-    return failure();
+  /// Copy from unbanked source memref `srcMem` to destination memory references
+  /// `dstBanks`, where each bank has the same MemRefType, and `srcMem` has the
+  /// shape of the "original" unbanked array.
+  LogicalResult copyFromUnbankedToBanks(PatternRewriter &rewriter, Location loc,
+                                        Value srcMem, ArrayRef<Value> dstBanks,
+                                        uint64_t bankingFactor,
+                                        unsigned bankingDimension) const {
+    auto srcType = dyn_cast<MemRefType>(srcMem.getType());
+    if (!srcType || srcType.getRank() <= bankingDimension)
+      return failure();
 
-  ArrayRef<int64_t> srcShape = srcType.getShape();
-  // We'll assume static shapes and exact divisibility.
-  int64_t chunkSize = srcShape[bankingDimension] / (int64_t)bankingFactor;
-  if (chunkSize <= 0)
-    return failure();
+    ArrayRef<int64_t> srcShape = srcType.getShape();
+    // We'll assume static shapes and exact divisibility.
+    int64_t chunkSize = srcShape[bankingDimension] / (int64_t)bankingFactor;
+    if (chunkSize <= 0)
+      return failure();
 
-  // For each bank i in [0..bankingFactor), create a subview of the source
-  //    that picks out the "i-th round-robin slice" along the banking dimension.
-  for (size_t i = 0; i < bankingFactor; ++i) {
-    auto subView = createRoundRobinSubview(rewriter, loc, srcMem, srcShape, i, bankingFactor, bankingDimension);
-    rewriter.create<memref::CopyOp>(loc, subView, dstBanks[i]);
+    // For each bank i in [0..bankingFactor), create a subview of the source
+    //    that picks out the "i-th round-robin slice" along the banking
+    //    dimension.
+    for (size_t i = 0; i < bankingFactor; ++i) {
+      auto subView = createRoundRobinSubview(rewriter, loc, srcMem, srcShape, i,
+                                             bankingFactor, bankingDimension);
+      rewriter.create<memref::CopyOp>(loc, subView, dstBanks[i]);
+    }
+
+    return success();
   }
-
-  return success();
-}
 };
 
 // Replace the original return operation with newly created memory banks
@@ -662,7 +672,7 @@ void MemoryBankingPass::runOnOperation() {
   patterns.add<BankAffineStorePattern>(ctx, bankingFactor, bankingDimension,
                                        memoryToBanks, opsToErase, processedOps,
                                        oldMemRefVals);
-  patterns.add<BankMemrefCopyPattern>(ctx, bankingFactor, bankingDimension, 
+  patterns.add<BankMemrefCopyPattern>(ctx, bankingFactor, bankingDimension,
                                       memoryToBanks);
   patterns.add<BankReturnPattern>(ctx, memoryToBanks);
 

--- a/test/Transforms/memory_banking_multi_dim.mlir
+++ b/test/Transforms/memory_banking_multi_dim.mlir
@@ -1,5 +1,6 @@
 // RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2 dimension=1" | FileCheck %s --check-prefix RANK2-BANKDIM1
 // RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2" | FileCheck %s --check-prefix GETGLOBAL
+// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2 dimension=1" | FileCheck %s --check-prefix MEMCOPY
 
 // RANK2-BANKDIM1: #[[$ATTR_0:.+]] = affine_map<(d0, d1) -> (d1 mod 2)>
 // RANK2-BANKDIM1: #[[$ATTR_1:.+]] = affine_map<(d0, d1) -> (d1 floordiv 2)>
@@ -72,6 +73,39 @@ func.func @rank_two_bank_dim1(%arg0: memref<8x6xf32>, %arg1: memref<8x6xf32>) ->
     }
   }
   return %mem : memref<8x6xf32>
+}
+
+// -----
+
+// MEMCOPY: #[[$ATTR_0:.+]] = affine_map<(d0, d1, d2) -> (d1 mod 2)>
+// MEMCOPY: #[[$ATTR_1:.+]] = affine_map<(d0, d1, d2) -> (d1 floordiv 2)>
+
+// MEMCOPY-LABEL:   func.func @main(
+// MEMCOPY:                    %[[VAL_0:arg0]]: memref<8x2x4xf32>,
+// MEMCOPY:                    %[[VAL_1:arg1]]: memref<8x2x4xf32>,
+// MEMCOPY:                    %[[VAL_2:arg2]]: memref<8x4x4xf32>) {
+// MEMCOPY:           %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f32
+// MEMCOPY:           %[[VAL_4:.*]] = memref.alloc() : memref<8x2x4xf32>
+// MEMCOPY:           %[[VAL_5:.*]] = memref.alloc() : memref<8x2x4xf32>
+// MEMCOPY:           %[[VAL_16:.*]] = memref.subview %[[VAL_2]][0, 0, 0] [8, 2, 4] [1, 2, 1] : memref<8x4x4xf32> to memref<8x2x4xf32, strided<[16, 8, 1]>>
+// MEMCOPY:           memref.copy %[[VAL_4]], %[[VAL_16]] : memref<8x2x4xf32> to memref<8x2x4xf32, strided<[16, 8, 1]>>
+// MEMCOPY:           %[[VAL_17:.*]] = memref.subview %[[VAL_2]][0, 1, 0] [8, 2, 4] [1, 2, 1] : memref<8x4x4xf32> to memref<8x2x4xf32, strided<[16, 8, 1], offset: 4>>
+// MEMCOPY:           memref.copy %[[VAL_5]], %[[VAL_17]] : memref<8x2x4xf32> to memref<8x2x4xf32, strided<[16, 8, 1], offset: 4>>
+// MEMCOPY:           return
+// MEMCOPY:         }
+
+func.func @main(%arg0: memref<8x4x4xf32>, %arg1: memref<8x4x4xf32>) {
+  %alloc = memref.alloc() : memref<8x4x4xf32>
+  affine.parallel (%arg2) = (0) to (8) {
+    affine.parallel (%arg3) = (0) to (4) {
+      affine.parallel (%arg4) = (0) to (4) {
+        %1 = affine.load %arg0[%arg2, %arg3, %arg4] : memref<8x4x4xf32>
+        affine.store %1, %alloc[%arg2, %arg3, %arg4] : memref<8x4x4xf32>
+      }
+    }
+  }
+  memref.copy %alloc, %arg1 : memref<8x4x4xf32> to memref<8x4x4xf32>
+  return
 }
 
 // -----


### PR DESCRIPTION
This patch banks `memref::copy` op logically when the operation is not used in parallel ops (which implies that we don't need to create new physical memories) by using `memref::subView` op.