### PR TITLE
[SCFToCalyx] Re-initialize IRMapping at the start of each loop

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1894,7 +1894,6 @@ private:
     OpBuilder insideBuilder(newParOp);
     Block *currBlock = nullptr;
     auto &region = newParOp.getRegion();
-    IRMapping operandMap;
 
     // extract lower bounds, upper bounds, and steps as integer index values
     SmallVector<int64_t> lbVals, ubVals, stepVals;
@@ -1920,6 +1919,11 @@ private:
     SmallVector<int64_t> indices = lbVals;
 
     while (true) {
+      // Each iteration starts with a fresh mapping, so each new block’s
+      // argument of a region-based operation (such as `scf.for`) get re-mapped
+      // independently.
+      IRMapping operandMap;
+
       // Create a new block in the region for the current combination of indices
       currBlock = &region.emplaceBlock();
       insideBuilder.setInsertionPointToEnd(currBlock);

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -530,3 +530,54 @@ module {
     return %res : si32
   }
 }
+
+// Test parallel op lowering when it has region-based nested ops, such as `scf.for`
+
+// -----
+
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.par {
+// CHECK:                 calyx.seq {
+// CHECK:                   calyx.enable @init_for_0_induction_var
+// CHECK:                   calyx.repeat 2 {
+// CHECK:                     calyx.seq {
+// CHECK:                       calyx.enable @bb0_0
+// CHECK:                       calyx.enable @bb0_1
+// CHECK:                       calyx.enable @incr_for_0_induction_var
+// CHECK:                     }
+// CHECK:                   }
+// CHECK:                 }
+// CHECK:                 calyx.seq {
+// CHECK:                   calyx.enable @init_for_1_induction_var
+// CHECK:                   calyx.repeat 2 {
+// CHECK:                     calyx.seq {
+// CHECK:                       calyx.enable @bb0_2
+// CHECK:                       calyx.enable @bb0_3
+// CHECK:                       calyx.enable @incr_for_1_induction_var
+// CHECK:                     }
+// CHECK:                   }
+// CHECK:                 }
+// CHECK:               }
+// CHECK:             }
+// CHECK:           }
+// CHECK:         } {toplevel}
+
+module {
+  func.func @main() {
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<6xi32>
+    %alloc_1 = memref.alloc() : memref<6xi32>
+    scf.parallel (%arg2) = (%c0) to (%c2) step (%c1) {
+      scf.for %arg3 = %c0 to %c2 step %c1 {
+        %1 = memref.load %alloc_1[%arg3] : memref<6xi32>
+        %2 = arith.shli %arg2, %c1 : index
+        memref.store %1, %alloc[%2] : memref<6xi32>
+      }
+      scf.reduce
+    }
+    return
+  }
+}


### PR DESCRIPTION
This patch addresses the issue with `IRMapping` when unrolling the parallel loop during the SCFToCalyx pass. If there are region-based operations, such as `scf.for` inside `scf.parallel`, the block arguments weren't cloned correctly because if we keep reusing the old `IRMapping`, the `IRMapping` will already have the entries from previous iterations that overshadows new ones. To fix it, we need to re-initialize the `IRMapping` every iteration.