### PR TITLE
[Verif] disambiguate ctor

### DIFF
--- a/lib/Conversion/VerifToSV/VerifToSV.cpp
+++ b/lib/Conversion/VerifToSV/VerifToSV.cpp
@@ -44,8 +44,8 @@ struct PrintOpConversionPattern : public OpConversionPattern<PrintOp> {
                   ConversionPatternRewriter &rewriter) const override {
 
     // Printf's will be emitted to stdout (32'h8000_0001 in IEEE Std 1800-2012).
-    Value fdStdout = rewriter.create<hw::ConstantOp>(
-        op.getLoc(), APInt(32, 0x80000001, false));
+    Value fdStdout =
+        rewriter.create<hw::ConstantOp>(op.getLoc(), APInt(32, 0x80000001));
 
     auto fstrOp =
         dyn_cast_or_null<FormatVerilogStringOp>(op.getString().getDefiningOp());


### PR DESCRIPTION
`clang-tidy` reports this ctor call as ambiguous and in fact it fails on Windows with `clang-cl` with 

```
  D:\a\circt\circt\lib\Conversion\VerifToSV\VerifToSV.cpp(48,22): error: call to constructor of 'APInt' is ambiguous
     48 |         op.getLoc(), APInt(32, 0x80000001, false));
        |                      ^     ~~~~~~~~~~~~~~~~~~~~~
  D:\a\circt\circt\llvm\llvm\include\llvm/ADT/APInt.h(157,3): note: candidate constructor
    157 |   APInt(unsigned numBits, unsigned numWords, const uint64_t bigVal[]);
        |   ^
  D:\a\circt\circt\llvm\llvm\include\llvm/ADT/APInt.h(111,3): note: candidate constructor
    111 |   APInt(unsigned numBits, uint64_t val, bool isSigned = false,
        |   ^
  1 error generated.
```