### PR TITLE
[CMake] enable install C API objects

### DIFF
--- a/cmake/modules/AddCIRCT.cmake
+++ b/cmake/modules/AddCIRCT.cmake
@@ -14,6 +14,9 @@ function(add_circt_public_c_api_library name)
   add_mlir_public_c_api_library(${ARGV} DISABLE_INSTALL)
   add_dependencies(circt-capi ${name})
   add_circt_library_install(${name})
+  if(TARGET "obj.${name}" AND MLIR_INSTALL_AGGREGATE_OBJECTS)
+    add_circt_library_install(obj.${name})
+  endif()
 endfunction()
 
 # Additional parameters are forwarded to tablegen.

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -24,6 +24,9 @@ set(PYTHON_BINDINGS_SOURCES
   SeqModule.cpp
   SupportModule.cpp
   SVModule.cpp
+  # Headers must be included explicitly so they are installed.
+  CIRCTModules.h
+  PybindUtils.h
 )
 
 set(PYTHON_BINDINGS_LINK_LIBS


### PR DESCRIPTION
I would like to build CIRCT Python bindings *downstream of CIRCT*. For this to work you need to have the so-called "aggregate objects" [installed](https://github.com/llvm/llvm-project/blob/3318a7248ae464af0abd0bea5515fa58c962b890/mlir/cmake/modules/AddMLIR.cmake#L424-L425).  

`add_circt_public_c_api_library` does `DISABLE_INSTALL` in order to prevent `add_mlir_public_c_api_library` from generating install targets that collide with those generated by `add_circt_library_install` but in doing so skips the install of the object file `obj.${name}`. So we just put that back.

EDIT: headers need to be installed too...