### PR TITLE
[RTG][python] fix `populateDialectRTGTestSubmodule` namespacing

### DIFF
--- a/lib/Bindings/Python/RTGTestModule.cpp
+++ b/lib/Bindings/Python/RTGTestModule.cpp
@@ -20,8 +20,9 @@ namespace py = pybind11;
 using namespace circt;
 using namespace mlir::python::adaptors;
 
+namespace circt::python {
 /// Populate the rtgtest python module.
-void circt::python::populateDialectRTGTestSubmodule(py::module &m) {
+void populateDialectRTGTestSubmodule(py::module &m) {
   m.doc() = "RTGTest dialect Python native extension";
 
   mlir_type_subclass(m, "CPUType", rtgtestTypeIsACPU)
@@ -32,3 +33,4 @@ void circt::python::populateDialectRTGTestSubmodule(py::module &m) {
           },
           py::arg("self"), py::arg("ctxt") = nullptr);
 }
+} // namespace circt::python


### PR DESCRIPTION
If `CIRCT_INCLUDE_TESTS=OFF` but this source file is compiled (only to eventually be DCEd) `circt::python::populateDialectRTGTestSubmodule` is malformed. With explicit `namespace circt::python` it works both ways.