### PR TITLE
[SCFToCalyx] Lower `scf.if` op when it yields nothing

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1117,7 +1117,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                            rewriter, forOp.getLoc(), types);
 
       auto directions = addOp.portDirections();
-      // For an add operation, we expect two input ports and one output port
+      // For an add operation, we expect two input ports and one output port.
       SmallVector<Value, 2> opInputPorts;
       Value opOutputPort;
       for (auto dir : enumerate(directions)) {
@@ -1166,7 +1166,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
       return success();
     }
     if (auto ifOp = dyn_cast<scf::IfOp>(yieldOp->getParentOp()))
-      // Empty yield inside ifOp, essentially a no-op
+      // Empty yield inside ifOp, essentially a no-op.
       return success();
     return yieldOp.getOperation()->emitError()
            << "Unsupported empty yieldOp outside ForOp or IfOp.";
@@ -2107,7 +2107,7 @@ private:
           return res;
 
         // `thenGroup`s won't be created in the first place if there's no
-        // yielded results for this `ifOp`
+        // yielded results for this `ifOp`.
         if (!ifOp.getResults().empty()) {
           rewriter.setInsertionPointToEnd(thenSeqOpBlock);
           calyx::GroupOp thenGroup =

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -2129,11 +2129,13 @@ private:
           if (res.failed())
             return res;
 
-          rewriter.setInsertionPointToEnd(elseSeqOpBlock);
-          calyx::GroupOp elseGroup =
-              getState<ComponentLoweringState>().getElseGroup(ifOp);
-          rewriter.create<calyx::EnableOp>(elseGroup.getLoc(),
-                                           elseGroup.getName());
+          if (!ifOp.getResults().empty()) {
+            rewriter.setInsertionPointToEnd(elseSeqOpBlock);
+            calyx::GroupOp elseGroup =
+                getState<ComponentLoweringState>().getElseGroup(ifOp);
+            rewriter.create<calyx::EnableOp>(elseGroup.getLoc(),
+                                             elseGroup.getName());
+          }
         }
       } else if (auto *callSchedPtr = std::get_if<CallScheduleable>(&group)) {
         auto instanceOp = callSchedPtr->instanceOp;

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1102,70 +1102,74 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                      scf::YieldOp yieldOp) const {
   if (yieldOp.getOperands().empty()) {
-    // If yield operands are empty, we assume we have a for loop.
-    auto forOp = dyn_cast<scf::ForOp>(yieldOp->getParentOp());
-    assert(forOp && "Empty yieldOps should only be located within ForOps");
-    ScfForOp forOpInterface(forOp);
+    if (auto forOp = dyn_cast<scf::ForOp>(yieldOp->getParentOp())) {
+      ScfForOp forOpInterface(forOp);
 
-    // Get the ForLoop's Induction Register.
-    auto inductionReg =
-        getState<ComponentLoweringState>().getForLoopIterReg(forOpInterface, 0);
+      // Get the ForLoop's Induction Register.
+      auto inductionReg = getState<ComponentLoweringState>().getForLoopIterReg(
+          forOpInterface, 0);
 
-    Type regWidth = inductionReg.getOut().getType();
-    // Adder should have same width as the inductionReg.
-    SmallVector<Type> types(3, regWidth);
-    auto addOp = getState<ComponentLoweringState>()
-                     .getNewLibraryOpInstance<calyx::AddLibOp>(
-                         rewriter, forOp.getLoc(), types);
+      Type regWidth = inductionReg.getOut().getType();
+      // Adder should have same width as the inductionReg.
+      SmallVector<Type> types(3, regWidth);
+      auto addOp = getState<ComponentLoweringState>()
+                       .getNewLibraryOpInstance<calyx::AddLibOp>(
+                           rewriter, forOp.getLoc(), types);
 
-    auto directions = addOp.portDirections();
-    // For an add operation, we expect two input ports and one output port
-    SmallVector<Value, 2> opInputPorts;
-    Value opOutputPort;
-    for (auto dir : enumerate(directions)) {
-      switch (dir.value()) {
-      case calyx::Direction::Input: {
-        opInputPorts.push_back(addOp.getResult(dir.index()));
-        break;
+      auto directions = addOp.portDirections();
+      // For an add operation, we expect two input ports and one output port
+      SmallVector<Value, 2> opInputPorts;
+      Value opOutputPort;
+      for (auto dir : enumerate(directions)) {
+        switch (dir.value()) {
+        case calyx::Direction::Input: {
+          opInputPorts.push_back(addOp.getResult(dir.index()));
+          break;
+        }
+        case calyx::Direction::Output: {
+          opOutputPort = addOp.getResult(dir.index());
+          break;
+        }
+        }
       }
-      case calyx::Direction::Output: {
-        opOutputPort = addOp.getResult(dir.index());
-        break;
-      }
-      }
+
+      // "Latch Group" increments inductionReg by forLoop's step value.
+      calyx::ComponentOp componentOp =
+          getState<ComponentLoweringState>().getComponentOp();
+      SmallVector<StringRef, 4> groupIdentifier = {
+          "incr", getState<ComponentLoweringState>().getUniqueName(forOp),
+          "induction", "var"};
+      auto groupOp = calyx::createGroup<calyx::GroupOp>(
+          rewriter, componentOp, forOp.getLoc(),
+          llvm::join(groupIdentifier, "_"));
+      rewriter.setInsertionPointToEnd(groupOp.getBodyBlock());
+
+      // Assign inductionReg.out to the left port of the adder.
+      Value leftOp = opInputPorts.front();
+      rewriter.create<calyx::AssignOp>(forOp.getLoc(), leftOp,
+                                       inductionReg.getOut());
+      // Assign forOp.getConstantStep to the right port of the adder.
+      Value rightOp = opInputPorts.back();
+      rewriter.create<calyx::AssignOp>(
+          forOp.getLoc(), rightOp,
+          createConstant(forOp->getLoc(), rewriter, componentOp,
+                         regWidth.getIntOrFloatBitWidth(),
+                         forOp.getConstantStep().value().getSExtValue()));
+      // Assign adder's output port to inductionReg.
+      buildAssignmentsForRegisterWrite(rewriter, groupOp, componentOp,
+                                       inductionReg, opOutputPort);
+      // Set group as For Loop's "latch" group.
+      getState<ComponentLoweringState>().setForLoopLatchGroup(forOpInterface,
+                                                              groupOp);
+      getState<ComponentLoweringState>().registerEvaluatingGroup(opOutputPort,
+                                                                 groupOp);
+      return success();
     }
-
-    // "Latch Group" increments inductionReg by forLoop's step value.
-    calyx::ComponentOp componentOp =
-        getState<ComponentLoweringState>().getComponentOp();
-    SmallVector<StringRef, 4> groupIdentifier = {
-        "incr", getState<ComponentLoweringState>().getUniqueName(forOp),
-        "induction", "var"};
-    auto groupOp = calyx::createGroup<calyx::GroupOp>(
-        rewriter, componentOp, forOp.getLoc(),
-        llvm::join(groupIdentifier, "_"));
-    rewriter.setInsertionPointToEnd(groupOp.getBodyBlock());
-
-    // Assign inductionReg.out to the left port of the adder.
-    Value leftOp = opInputPorts.front();
-    rewriter.create<calyx::AssignOp>(forOp.getLoc(), leftOp,
-                                     inductionReg.getOut());
-    // Assign forOp.getConstantStep to the right port of the adder.
-    Value rightOp = opInputPorts.back();
-    rewriter.create<calyx::AssignOp>(
-        forOp.getLoc(), rightOp,
-        createConstant(forOp->getLoc(), rewriter, componentOp,
-                       regWidth.getIntOrFloatBitWidth(),
-                       forOp.getConstantStep().value().getSExtValue()));
-    // Assign adder's output port to inductionReg.
-    buildAssignmentsForRegisterWrite(rewriter, groupOp, componentOp,
-                                     inductionReg, opOutputPort);
-    // Set group as For Loop's "latch" group.
-    getState<ComponentLoweringState>().setForLoopLatchGroup(forOpInterface,
-                                                            groupOp);
-    getState<ComponentLoweringState>().registerEvaluatingGroup(opOutputPort,
-                                                               groupOp);
-    return success();
+    if (auto ifOp = dyn_cast<scf::IfOp>(yieldOp->getParentOp()))
+      // Empty yield inside ifOp, essentially a no-op
+      return success();
+    return yieldOp.getOperation()->emitError()
+           << "Unsupported empty yieldOp outside ForOp or IfOp.";
   }
   // If yieldOp for a for loop is not empty, then we do not transform for loop.
   if (dyn_cast<scf::ForOp>(yieldOp->getParentOp())) {
@@ -1822,6 +1826,12 @@ class BuildIfGroups : public calyx::FuncOpPartialLoweringPattern {
 
       auto scfIfOp = cast<scf::IfOp>(op);
 
+      // There is no need to build `thenGroup` and `elseGroup` if `scfIfOp`
+      // doesn't yield any result since these groups are created for managing
+      // the result values.
+      if (scfIfOp.getResults().empty())
+        return WalkResult::advance();
+
       calyx::ComponentOp componentOp =
           getState<ComponentLoweringState>().getComponentOp();
 
@@ -2096,11 +2106,15 @@ private:
         if (res.failed())
           return res;
 
-        rewriter.setInsertionPointToEnd(thenSeqOpBlock);
-        calyx::GroupOp thenGroup =
-            getState<ComponentLoweringState>().getThenGroup(ifOp);
-        rewriter.create<calyx::EnableOp>(thenGroup.getLoc(),
-                                         thenGroup.getName());
+        // `thenGroup`s won't be created in the first place if there's no
+        // yielded results for this `ifOp`
+        if (!ifOp.getResults().empty()) {
+          rewriter.setInsertionPointToEnd(thenSeqOpBlock);
+          calyx::GroupOp thenGroup =
+              getState<ComponentLoweringState>().getThenGroup(ifOp);
+          rewriter.create<calyx::EnableOp>(thenGroup.getLoc(),
+                                           thenGroup.getName());
+        }
 
         if (!ifOp.getElseRegion().empty()) {
           rewriter.setInsertionPointToEnd(ifCtrlOp.getElseBody());

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -754,3 +754,58 @@ module {
     return %0 : i32
   }
 }
+
+// Test if op without return value
+
+// -----
+
+module {
+// CHECK-LABEL:   calyx.component @main_1(
+// CHECK-SAME:                            %[[VAL_0:in0]]: i32,
+// CHECK-SAME:                            %[[VAL_1:in1]]: i32,
+// CHECK-SAME:                            %[[VAL_2:.*]]: i1 {clk},
+// CHECK-SAME:                            %[[VAL_3:.*]]: i1 {reset},
+// CHECK-SAME:                            %[[VAL_4:.*]]: i1 {go}) -> (
+// CHECK-SAME:                            %[[VAL_5:.*]]: i1 {done}) {
+// CHECK:           %[[VAL_6:.*]] = hw.constant true
+// CHECK:           %[[VAL_7:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_0 : i32, i1
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]] = calyx.std_slt @std_slt_0 : i32, i32, i1
+// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           calyx.wires {
+// CHECK:             calyx.comb_group @bb0_0 {
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_1]] : i32
+// CHECK:             }
+// CHECK:             calyx.group @bb0_2 {
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_9]] : i1
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_12]] : i32
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_1]] : i32
+// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:             }
+// CHECK:           }
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.if %[[VAL_15]] with @bb0_0 {
+// CHECK:                 calyx.seq {
+// CHECK:                   calyx.enable @bb0_2
+// CHECK:                 }
+// CHECK:               }
+// CHECK:             }
+// CHECK:           }
+// CHECK:         }
+  func.func @main(%arg0: i32, %arg1: i32, %arg2: memref<1xi32>) {
+    %c0 = arith.constant 0 : index
+    %0 = arith.cmpi slt, %arg0, %arg1 : i32
+    %1 = arith.addi %arg0, %arg1 : i32
+    scf.if %0 {
+      memref.store %1, %arg2[%c0] : memref<1xi32>
+    }
+    return
+  }
+}

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -769,31 +769,44 @@ module {
 // CHECK-SAME:                            %[[VAL_5:.*]]: i1 {done}) {
 // CHECK:           %[[VAL_6:.*]] = hw.constant true
 // CHECK:           %[[VAL_7:.*]] = hw.constant 0 : i32
-// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_0 : i32, i1
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
-// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]] = calyx.std_slt @std_slt_0 : i32, i32, i1
-// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_1 : i32, i1
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_0 : i32, i1
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.std_slt @std_slt_0 : i32, i32, i1
+// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.comb_group @bb0_0 {
-// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_1]] : i32
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_1]] : i32
 // CHECK:             }
 // CHECK:             calyx.group @bb0_2 {
 // CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_7]] : i32
-// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_9]] : i1
-// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_12]] : i32
-// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_6]] : i1
-// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_6]] : i1
-// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_1]] : i32
-// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_9]] : i1
+// CHECK:               calyx.assign %[[VAL_23]] = %[[VAL_14]] : i32
+// CHECK:               calyx.assign %[[VAL_22]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_1]] : i32
+// CHECK:               calyx.group_done %[[VAL_25]] : i1
+// CHECK:             }
+// CHECK:             calyx.group @bb0_3 {
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_11]] : i1
+// CHECK:               calyx.assign %[[VAL_23]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_22]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_25]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {
 // CHECK:             calyx.seq {
-// CHECK:               calyx.if %[[VAL_15]] with @bb0_0 {
+// CHECK:               calyx.if %[[VAL_17]] with @bb0_0 {
 // CHECK:                 calyx.seq {
 // CHECK:                   calyx.enable @bb0_2
+// CHECK:                 }
+// CHECK:               } else {
+// CHECK:                 calyx.seq {
+// CHECK:                   calyx.enable @bb0_3
 // CHECK:                 }
 // CHECK:               }
 // CHECK:             }
@@ -805,6 +818,8 @@ module {
     %1 = arith.addi %arg0, %arg1 : i32
     scf.if %0 {
       memref.store %1, %arg2[%c0] : memref<1xi32>
+    } else {
+      memref.store %arg0, %arg2[%c0] : memref<1xi32>
     }
     return
   }


### PR DESCRIPTION
This patch lowers `scf.ifOp` when it has an empty yield/does not return any value.