### PR TITLE
[SCFToCalyx] Insert scf::reduce op at the end of the newly create scf::par op

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1953,6 +1953,9 @@ private:
         break;
     }
 
+    rewriter.setInsertionPointToEnd(newParOp.getBody());
+    rewriter.create<scf::ReduceOp>(newParOp.getLoc());
+
     rewriter.replaceOp(scfParOp, newParOp);
     return success();
   }


### PR DESCRIPTION
This patch inserts `scf::ReduceOp` at the end of the newly created `scf::parallelOp` for canonicalization.