### PR TITLE
[SCFToCalyx] Insert terminator at the end of the newly created func op

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -2648,6 +2648,7 @@ private:
     builder.setInsertionPointToEnd(callerEntryBlock);
     builder.create<CallOp>(caller.getLoc(), calleeName, resultTypes,
                            fnOperands);
+    builder.create<ReturnOp>(caller.getLoc());
   }
 
   /// Conditionally creates an optional new top-level function; and inserts a


### PR DESCRIPTION
This patch inserts a terminator op (`ReturnOp`) at the end of the newly created `FuncOp`