### PR TITLE
[FIRRTL] Intrinsics: Add checkAndConvert, anchor vtable.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLIntrinsics.cpp
@@ -14,6 +14,9 @@
 using namespace circt;
 using namespace firrtl;
 
+// vtable anchor
+void IntrinsicConverter::anchor() {}
+
 //===----------------------------------------------------------------------===//
 // GenericIntrinsic
 //===----------------------------------------------------------------------===//
@@ -126,11 +129,10 @@ public:
     }
 
     auto &conv = *it->second;
-    if (conv.check(GenericIntrinsic(op)))
-      return failure();
-    conv.convert(GenericIntrinsic(op), adaptor, rewriter);
-    ++numConversions;
-    return success();
+    auto result = conv.checkAndConvert(GenericIntrinsic(op), adaptor, rewriter);
+    if (succeeded(result))
+      ++numConversions;
+    return result;
   }
 
 private:


### PR DESCRIPTION
Tweak IntrinsicConverter to allow one-shot check and convert which is useful especially when both check and convert require doing the same non-trivial processing work.