### PR TITLE
[FIRRTL] Add circt_view intrinsic lowering to firrtl.view

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
+++ b/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
@@ -341,7 +341,7 @@ Example:
 | Property   | Type   | Description                                          |
 | ---------- | ------ | -------------                                        |
 | class      | string | `sifive.enterprise.grandcentral.AugmentedVectorType` |
-| elements   | array  | List of augmented types.
+| elements   | array  | List of augmented types. |
 
 Creates a SystemVerilog unpacked array.
 

--- a/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
+++ b/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
@@ -289,3 +289,94 @@ always @(posedge clock) begin
   end
 end
 ```
+
+### circt_view
+
+This will become a SystemVerilog Interface that is driven by its arguments.
+This is _not_ a true SystemVerilog Interface, it is only lowered to one.
+
+
+| Parameter     | Type   | Description                                         |
+| ------------- | ------ | --------------------------------------------------- |
+| name          | string | Instance name of the view.                          |
+| view          | string | JSON encoding the view structure.                   |
+
+| Port       | Direction | Type     | Description                         |
+| ---------- | --------- | -------- | ----------------------------------- |
+| ...        | input     | Ground   | Leaf ground values for the view     |
+
+The structure of the view is encoded using JSON, with the top-level object
+required to be an `AugmentedBundleType`.
+
+The intrinsic operands correspond to the `AugmentedGroundType` leaves,
+and must be of ground type.
+
+This encoding is a trimmed version of what's used for the old GrandCentral View
+annotation.
+
+These views do not interact with any GrandCentral annotations or options governing
+the behavior of the annotation-based views.
+
+Output directory behavior is a work in progress presently.
+
+#### AugmentedGroundType
+
+| Property   | Type   | Description                                          |
+| ---------- | ------ | -------------                                        |
+| class      | string | `sifive.enterprise.grandcentral.AugmentedGroundType` |
+
+Creates a SystemVerilog logic type.
+
+Each ground type corresponds to an operand to the view intrinsic.
+
+Example:
+```json
+{
+  "class": "sifive.enterprise.grandcentral.AugmentedGroundType"
+}
+```
+
+#### AugmentedVectorType
+
+| Property   | Type   | Description                                          |
+| ---------- | ------ | -------------                                        |
+| class      | string | `sifive.enterprise.grandcentral.AugmentedVectorType` |
+| elements   | array  | List of augmented types.
+
+Creates a SystemVerilog unpacked array.
+
+Example:
+```json
+{
+  "class": "sifive.enterprise.grandcentral.AugmentedVectorType",
+  "elements": [
+    {
+      "class": "sifive.enterprise.grandcentral.AugmentedGroundType"
+    },
+    {
+      "class": "sifive.enterprise.grandcentral.AugmentedGroundType"
+    }
+  ]
+}
+```
+
+#### AugmentedField
+
+| Property    | Type   | Description                        |
+| ----------  | ------ | -------------                      |
+| name        | string | Name of the field                  |
+| description | string | A textual description of this type |
+| tpe         | string | A nested augmented type            |
+
+A field in an augmented bundle type.  This can provide a small description of
+what the field in the bundle is.
+
+#### AugmentedBundleType
+
+| Property   | Type   | Description                                               |
+| ---------- | ------ | -------------                                             |
+| class      | string | sifive.enterprise.grandcentral.AugmentedBundleType        |
+| defName    | string | The name of the SystemVerilog interface.  May be renamed. |
+| elements   | array  | List of AugmentedFields                                   |
+
+Creates a SystemVerilog interface for each bundle type.

--- a/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
+++ b/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
@@ -314,11 +314,6 @@ and must be of ground type.
 This encoding is a trimmed version of what's used for the old GrandCentral View
 annotation.
 
-These views do not interact with any GrandCentral annotations or options governing
-the behavior of the annotation-based views.
-
-Output directory behavior is a work in progress presently.
-
 #### AugmentedGroundType
 
 | Property   | Type   | Description                                          |

--- a/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
+++ b/docs/Dialects/FIRRTL/FIRRTLIntrinsics.md
@@ -299,7 +299,7 @@ This is _not_ a true SystemVerilog Interface, it is only lowered to one.
 | Parameter     | Type   | Description                                         |
 | ------------- | ------ | --------------------------------------------------- |
 | name          | string | Instance name of the view.                          |
-| view          | string | JSON encoding the view structure.                   |
+| info          | string | JSON encoding the view structure.                   |
 
 | Port       | Direction | Type     | Description                         |
 | ---------- | --------- | -------- | ----------------------------------- |
@@ -313,6 +313,43 @@ and must be of ground type.
 
 This encoding is a trimmed version of what's used for the old GrandCentral View
 annotation.
+
+Example usage:
+```firrtl
+circuit ViewExample:
+  public module ViewExample:
+    input in : { x : UInt<2>, y : { z : UInt<3>[2] } }
+    intrinsic(circt_view<name="view", info="{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\",\"defName\":\"ViewName\",\"elements\":[{\"description\":\"X marks the spot\",\"name\":\"x\",\"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"}},{\"description\":\"y bundle\",\"name\":\"y\",\"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\",\"defName\":\"YView\",\"elements\":[{\"name\":\"z\",\"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedVectorType\",\"elements\":[{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"},{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"}]}}]}}]}">, in.x, in.y.z[0], in.y.z[1])
+```
+
+Example Output:
+```systemverilog
+module ViewExample(
+  input [1:0] in_x,
+  input [2:0] in_y_z_0,
+              in_y_z_1
+);
+
+  ViewName view();
+  assign view.x = in_x;
+  assign view.y.z[0] = in_y_z_0;
+  assign view.y.z[1] = in_y_z_1;
+endmodule
+
+// VCS coverage exclude_file
+interface ViewName;
+  // X marks the spot
+  logic [1:0] x;
+  // y bundle
+  YView y();
+endinterface
+
+// VCS coverage exclude_file
+interface YView;
+  logic [2:0] z[0:1];
+endinterface
+
+```
 
 #### AugmentedGroundType
 

--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -100,6 +100,8 @@ constexpr const char *augmentedGroundTypeClass =
     "sifive.enterprise.grandcentral.AugmentedGroundType"; // not an annotation
 constexpr const char *augmentedBundleTypeClass =
     "sifive.enterprise.grandcentral.AugmentedBundleType"; // not an annotation
+constexpr const char *augmentedVectorTypeClass =
+    "sifive.enterprise.grandcentral.AugmentedVectorType"; // not an annotation
 constexpr const char *dataTapsClass =
     "sifive.enterprise.grandcentral.DataTapsAnnotation";
 constexpr const char *dataTapsBlackboxClass =

--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -384,43 +384,52 @@ LogicalResult applyWiring(const AnnoPathValue &target, DictionaryAttr anno,
 /// Implements the same behavior as DictionaryAttr::getAs<A> to return the
 /// value of a specific type associated with a key in a dictionary. However,
 /// this is specialized to print a useful error message, specific to custom
-/// annotation process, on failure.
+/// processing, on failure.
 template <typename A>
-A tryGetAs(DictionaryAttr &dict, const Attribute &root, StringRef key,
-           Location loc, Twine className, Twine path = Twine()) {
+A tryGetAsBase(DictionaryAttr dict, Attribute root, StringRef key, Location loc,
+               Twine whatSpecific, Twine whatFull, Twine path = Twine()) {
+  SmallString<128> msg;
   // Check that the key exists.
   auto value = dict.get(key);
   if (!value) {
-    SmallString<128> msg;
     if (path.isTriviallyEmpty())
-      msg = ("Annotation '" + className + "' did not contain required key '" +
-             key + "'.")
-                .str();
+      (whatSpecific + " did not contain required key '" + key + "'.")
+          .toVector(msg);
     else
-      msg = ("Annotation '" + className + "' with path '" + path +
-             "' did not contain required key '" + key + "'.")
-                .str();
+      (whatSpecific + " with path '" + path +
+       "' did not contain required key '" + key + "'.")
+          .toVector(msg);
     mlir::emitError(loc, msg).attachNote()
-        << "The full Annotation is reproduced here: " << root << "\n";
+        << "The full " << whatFull << " is reproduced here: " << root;
     return nullptr;
   }
   // Check that the value has the correct type.
-  auto valueA = dyn_cast_or_null<A>(value);
+  auto valueA = dyn_cast<A>(value);
   if (!valueA) {
-    SmallString<128> msg;
     if (path.isTriviallyEmpty())
-      msg = ("Annotation '" + className +
-             "' did not contain the correct type for key '" + key + "'.")
-                .str();
+      (whatSpecific + " did not contain the correct type for key '" + key +
+       "'.")
+          .toVector(msg);
     else
-      msg = ("Annotation '" + className + "' with path '" + path +
-             "' did not contain the correct type for key '" + key + "'.")
-                .str();
+      (whatSpecific + " with path '" + path +
+       "' did not contain the correct type for key '" + key + "'.")
+          .toVector(msg);
     mlir::emitError(loc, msg).attachNote()
-        << "The full Annotation is reproduced here: " << root << "\n";
+        << "The full " << whatFull << " is reproduced here: " << root;
     return nullptr;
   }
   return valueA;
+}
+
+/// Implements the same behavior as DictionaryAttr::getAs<A> to return the
+/// value of a specific type associated with a key in a dictionary. However,
+/// this is specialized to print a useful error message, specific to custom
+/// annotation process, on failure.
+template <typename A>
+A tryGetAs(DictionaryAttr dict, Attribute root, StringRef key, Location loc,
+           Twine clazz, Twine path = Twine()) {
+  return tryGetAsBase<A>(dict, root, key, loc, "Annotation '" + clazz + "'",
+                         "Annotation", path);
 }
 
 /// Add ports to the module and all its instances and return the clone for

--- a/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
@@ -30,3 +30,77 @@ firrtl.circuit "MissingParam" {
     }
 }
 
+// -----
+
+firrtl.circuit "ViewNotBundle" {
+  firrtl.module public @ViewNotBundle() {
+    // expected-error @below {{'info' must be augmented bundle}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_view" <name: none = "view", info: none = "{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"}"> : () -> ()
+  }
+}
+
+// -----
+
+firrtl.circuit "ViewNotJSON" {
+  firrtl.module public @ViewNotJSON() {
+    // expected-error @below {{error parsing view JSON}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_view" <name: none = "view", info: none = "boop"> : () -> ()
+  }
+}
+
+// -----
+
+firrtl.circuit "ViewNoDefname" {
+  firrtl.module public @ViewNoDefname() {
+    // expected-error @below {{View 'info' did not contain required key 'defName'}}
+    // expected-note @below {{The full 'info' attribute is reproduced here: {class = "sifive.enterprise.grandcentral.AugmentedBundleType"}}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_view" <name: none = "view", info: none = "{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\"}"> : () -> ()
+  }
+}
+
+// -----
+
+firrtl.circuit "ViewDefnameNotString" {
+  firrtl.module public @ViewDefnameNotString() {
+    // expected-error @below {{View 'info' did not contain the correct type for key 'defName'}}
+    // expected-note @below {{The full 'info' attribute is reproduced here:}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_view" <name: none = "view", info: none = "{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\", \"defName\": 5}"> : () -> ()
+  }
+}
+
+// -----
+
+firrtl.circuit "ViewNoElementsField" {
+  firrtl.module public @ViewNoElementsField() {
+    // expected-error @below {{View 'info' did not contain required key 'elements'}}
+    // expected-note @below {{The full 'info' attribute is reproduced here:}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_view" <name: none = "view", info: none = "{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\", \"defName\": \"MyView\"}"> : () -> ()
+  }
+}
+
+// -----
+
+firrtl.circuit "ViewInvalidElement" {
+  firrtl.module public @ViewInvalidElement() {
+    // expected-error @below {{View 'info' attribute with path '.elements[0]' contained an unexpected type (expected a DictionaryAttr)}}
+    // expected-note @below {{The received element was: 5 : i64}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_view" <name: none = "view", info: none = "{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\", \"defName\": \"MyView\", \"elements\": [5]}"> : () -> ()
+  }
+}
+
+// -----
+
+firrtl.circuit "ViewElementEmptyDict" {
+  firrtl.module public @ViewElementEmptyDict() {
+    // expected-error @below {{View 'info' with path '.elements[0]' did not contain required key 'name'}}
+    // expected-note @below {{The full 'info' attribute is reproduced here:}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_view" <name: none = "view", info: none = "{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\", \"defName\": \"MyView\", \"elements\": [{}]}"> : () -> ()
+  }
+}

--- a/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
@@ -104,3 +104,41 @@ firrtl.circuit "ViewElementEmptyDict" {
     firrtl.int.generic "circt_view" <name: none = "view", info: none = "{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\", \"defName\": \"MyView\", \"elements\": [{}]}"> : () -> ()
   }
 }
+
+// -----
+
+firrtl.circuit "ViewElementGroundNoType" {
+  firrtl.module public @ViewElementGroundNoType() {
+    // expected-error @below {{View 'info' with path '.elements[0]' did not contain required key 'tpe'}}
+    // expected-note @below {{The full 'info' attribute is reproduced here:}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_view" <name: none = "view", info: none = "{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\", \"defName\": \"MyView\", \"elements\": [{\"name\": \"foo\"}]}"> : () -> ()
+  }
+}
+
+// -----
+
+firrtl.circuit "ViewOperandNotGround" {
+  firrtl.module public @ViewOperandNotGround(in %vec : !firrtl.vector<uint<1>, 2>) {
+    // expected-error @below {{circt_view input 0 must be ground type}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_view" <name: none = "view", info: none = ""> %vec : (!firrtl.vector<uint<1>, 2>) -> ()
+  }
+}
+
+// -----
+
+firrtl.circuit "ViewWrongOperandCount" {
+  firrtl.module public @ViewWrongOperandCount() {
+    // expected-error @below {{View 'info' with path '.elements[0]' did not contain required key 'tpe'}}
+    // expected-note @below {{The full 'info' attribute is reproduced here:}}
+    // expected-error @below {{failed to legalize}}
+    firrtl.int.generic "circt_view" <name: none = "view", info: none = "{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\", \"defName\": \"MyView\", \"elements\": [{\"name\": \"foo\", \"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"}}]}"> : () -> ()
+  }
+}
+
+//
+
+// TODO:
+// Field names conflict
+// too many/too few operands

--- a/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics-errors.mlir
@@ -130,15 +130,8 @@ firrtl.circuit "ViewOperandNotGround" {
 
 firrtl.circuit "ViewWrongOperandCount" {
   firrtl.module public @ViewWrongOperandCount() {
-    // expected-error @below {{View 'info' with path '.elements[0]' did not contain required key 'tpe'}}
-    // expected-note @below {{The full 'info' attribute is reproduced here:}}
+    // expected-error @below {{circt_view has 0 operands but view 'info' has 1 leaf elements}}
     // expected-error @below {{failed to legalize}}
     firrtl.int.generic "circt_view" <name: none = "view", info: none = "{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\", \"defName\": \"MyView\", \"elements\": [{\"name\": \"foo\", \"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"}}]}"> : () -> ()
   }
 }
-
-//
-
-// TODO:
-// Field names conflict
-// too many/too few operands

--- a/test/Dialect/FIRRTL/lower-intrinsics.mlir
+++ b/test/Dialect/FIRRTL/lower-intrinsics.mlir
@@ -164,4 +164,65 @@ firrtl.circuit "Foo" {
     // CHECK-NEXT:  %1 = firrtl.int.dpi.call "unclocked_result"(%in1, %in2) enable %enable : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
     %1 = firrtl.int.generic "circt_dpi_call" <isClocked: ui32 = 0, functionName: none = "unclocked_result"> %enable, %in1, %in2 : (!firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<8>
   }
+
+  // CHECK-LABEL: firrtl.module private @ViewIntrinsicTest
+  firrtl.module private @ViewIntrinsicTest(in %in: !firrtl.vector<uint<1>, 5>) attributes {convention = #firrtl<convention scalarized>} {
+    %0 = firrtl.subindex %in[4] : !firrtl.vector<uint<1>, 5>
+    %1 = firrtl.subindex %in[3] : !firrtl.vector<uint<1>, 5>
+    %2 = firrtl.subindex %in[2] : !firrtl.vector<uint<1>, 5>
+    %3 = firrtl.subindex %in[1] : !firrtl.vector<uint<1>, 5>
+    %4 = firrtl.subindex %in[0] : !firrtl.vector<uint<1>, 5>
+
+    // Taken from old test, these descriptions don't really apply anymore but leaving as-is for now.
+    firrtl.int.generic "circt_view" <name: none = "view", info: none = "{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\",\"defName\":\"ViewName\",\"elements\":[{\"description\":\"the register in GCTInterface\",\"name\":\"register\",\"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\",\"defName\":\"Register\",\"elements\":[{\"name\":\"_2\",\"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedVectorType\",\"elements\":[{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"},{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"}]}},{\"name\":\"_0_inst\",\"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedBundleType\",\"defName\":\"_0_def\",\"elements\":[{\"name\":\"_1\",\"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"}},{\"name\":\"_0\",\"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"}}]}}]}},{\"description\":\"the port 'a' in GCTInterface\",\"name\":\"port\",\"tpe\":{\"class\":\"sifive.enterprise.grandcentral.AugmentedGroundType\"}}]}"> %4, %3, %2, %1, %0 : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> ()
+
+    // CHECK: firrtl.view "view", <{
+    // CHECK-SAME:   class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+    // CHECK-SAME:   defName = "ViewName",
+    // CHECK-SAME:   elements = [
+    // CHECK-SAME:      {
+    // CHECK-SAME:        class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+    // CHECK-SAME:        defName = "Register",
+    // CHECK-SAME:        description = "the register in GCTInterface",
+    // CHECK-SAME:        elements = [
+    // CHECK-SAME:          {
+    // CHECK-SAME:            class = "sifive.enterprise.grandcentral.AugmentedVectorType",
+    // CHECK-SAME:            elements = [
+    // CHECK-SAME:              {
+    // CHECK-SAME:                class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+    // CHECK-SAME:                name = "_2"
+    // CHECK-SAME:              }, {
+    // CHECK-SAME:                class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+    // CHECK-SAME:                name = "_2
+    // CHECK-SAME:              }
+    // CHECK-SAME:            ],
+    // CHECK-SAME:            name = "_2"
+    // CHECK-SAME:          }, {
+    // CHECK-SAME:            class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+    // CHECK-SAME:            defName = "_0_def",
+    // CHECK-SAME:            elements = [
+    // CHECK-SAME:              {
+    // CHECK-SAME:                class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+    // CHECK-SAME:                name = "_1"
+    // CHECK-SAME:              }, {
+    // CHECK-SAME:                class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+    // CHECK-SAME:                name = "_0"
+    // CHECK-SAME:              }
+    // CHECK-SAME:            ],
+    // CHECK-SAME:            name = "_0_inst"
+    // CHECK-SAME:          }
+    // CHECK-SAME:        ],
+    // CHECK-SAME:        name = "register"
+    // CHECK-SAME:     }, {
+    // CHECK-SAME:       class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+    // CHECK-SAME:       description = "the port 'a' in GCTInterface",
+    // CHECK-SAME:       name = "port"
+    // CHECK-SAME:     }
+    // CHECK-SAME:   ],
+    // This is copied in, for better or for worse.
+    // CHECK-SAME:   name = "view"
+    // CHECK-SAME: }>,
+    // Check operands and types.
+    // CHECK-SAME: %4, %3, %2, %1, %0 : !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+  }
 }


### PR DESCRIPTION
Implement "circt_view" intrinsic, lower to `firrtl.view`.

Add documentation to `FIRRTLIntrinsics.md`.

JSON encoding for view information is kept from the annotation format for the "view" specifically but without auto-tapping (or "ref" information) or parent/companion module notions.
This JSON is a string parameter to the intrinsic, which is processed into Attributes and Augmented attributes using a copied and modified version of `parseAugmentedType`.

The goal is to move to an intrinsic with minimal disruption.  In the future (once it's load-bearing as a replacement) we can delete support for the old format and change this as we'd like.