### PR TITLE
[circt-test] Allow tests to filter according to test runners

### DIFF
--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -304,6 +304,33 @@ def FormalOp : VerifOp<"formal", [
       verif.assert %4 : i1
     }
     ```
+
+    ### Parameters
+    The following parameters have a predefined meaning and are interpreted by
+    tools such as `circt-test` to guide execution of tests:
+
+    - `ignore`: Indicates whether the test should be ignored and skipped. This
+      can be useful for temporarily disabling tests without having to remove
+      them from the input. Must be a _boolean_ value.
+      ```mlir
+      verif.formal @Foo {ignore = true}
+      ```
+
+    - `require_runners`: A list of test runners that may be used to execute this
+      test. This option may be used to force a test to run using one of a few
+      known-good runners, acting like a whitelist. Must be an _array_ of
+      _strings_.
+      ```mlir
+      verif.formal @Foo {require_runners = ["sby", "circt-bmc"]}
+      ```
+
+    - `exclude_runners`: A list of test runners that must not be used to execute
+      this test. This option may be used to exclude a few known-bad runners from
+      executing this test, acting like a blacklist. Must be an _array_ of
+      _strings_.
+      ```mlir
+      verif.formal @Foo {exclude_runners = ["sby", "circt-bmc"]}
+      ```
   }];
   let arguments = (ins
     SymbolNameAttr:$sym_name,

--- a/integration_test/circt-test/basic.mlir
+++ b/integration_test/circt-test/basic.mlir
@@ -1,7 +1,7 @@
 // See other `basic-*.mlir` files for run lines.
 // RUN: true
 
-// CHECK: 1 tests FAILED, 6 passed, 1 ignored
+// CHECK: 1 tests FAILED, 9 passed, 1 ignored, 3 unsupported
 
 hw.module @FullAdder(in %a: i1, in %b: i1, in %ci: i1, out s: i1, out co: i1) {
   %0 = comb.xor %a, %b : i1
@@ -148,4 +148,34 @@ verif.formal @ALUFailure {depth = 3} {
   // Check the two don't match (should fail).
   %ne = comb.icmp ne %z0, %z1 : i4
   verif.assert %ne : i1
+}
+
+verif.formal @RunnerRequireEither {require_runners = ["sby", "circt-bmc"]} {
+  %0 = hw.constant true
+  verif.assert %0 : i1
+}
+
+verif.formal @RunnerRequireSby {require_runners = ["sby"]} {
+  %0 = hw.constant true
+  verif.assert %0 : i1
+}
+
+verif.formal @RunnerRequireCirctBmc {require_runners = ["circt-bmc"]} {
+  %0 = hw.constant true
+  verif.assert %0 : i1
+}
+
+verif.formal @RunnerExcludeEither {exclude_runners = ["sby", "circt-bmc"]} {
+  %0 = hw.constant true
+  verif.assert %0 : i1
+}
+
+verif.formal @RunnerExcludeSby {exclude_runners = ["sby"]} {
+  %0 = hw.constant true
+  verif.assert %0 : i1
+}
+
+verif.formal @RunnerExcludeCirctBmc {exclude_runners = ["circt-bmc"]} {
+  %0 = hw.constant true
+  verif.assert %0 : i1
 }

--- a/test/circt-test/errors.mlir
+++ b/test/circt-test/errors.mlir
@@ -1,0 +1,20 @@
+// RUN: circt-test --verify-diagnostics --split-input-file %s
+
+// expected-error @below {{`ignore` attribute of test "Foo" must be a boolean}}
+verif.formal @Foo {ignore = "hello"} {}
+
+// -----
+// expected-error @below {{`require_runners` attribute of test "Foo" must be an array}}
+verif.formal @Foo {require_runners = "hello"} {}
+
+// -----
+// expected-error @below {{`exclude_runners` attribute of test "Foo" must be an array}}
+verif.formal @Foo {exclude_runners = "hello"} {}
+
+// -----
+// expected-error @below {{element of `require_runners` array of test "Foo" must be a string}}
+verif.formal @Foo {require_runners = [42]} {}
+
+// -----
+// expected-error @below {{element of `exclude_runners` array of test "Foo" must be a string}}
+verif.formal @Foo {exclude_runners = [42]} {}


### PR DESCRIPTION
Interpret the `require_runners` and `exclude_runners` attributes on formal tests as a filter for the potential runners that can execute a test. If the set of required runners is not empty, a runner from this set is picked. Tests for which no runner is available report as "unsupported", for example if none of the available runners match the filter.