### PR TITLE
[CI] Enable Windows builds for PRs

### DIFF
--- a/.github/workflows/buildAndTestWindows.yml
+++ b/.github/workflows/buildAndTestWindows.yml
@@ -1,11 +1,11 @@
 name: Windows build and test
 
-# Run on main (after PRs land) to ensure that they aren't heinously breaking the
-# Windows build.
 on:
   push:
     branches:
       - main
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
As discussed in #7970, try enabling it to detect Windows-only bugs before merging.