### PR TITLE
Bump LLVM to ebc7efbab5c58b46f7215d63be6d0208cb588192.

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -235,7 +235,7 @@ def StateOp : ArcOp<"state", [
 
     /// Set the callee for this operation.
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
-      (*this)->setAttr(getArcAttrName(), callee.get<mlir::SymbolRefAttr>());
+      (*this)->setAttr(getArcAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
   }];
 }
@@ -276,7 +276,7 @@ def CallOp : ArcOp<"call", [
 
     /// Set the callee for this operation.
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
-      (*this)->setAttr(getArcAttrName(), callee.get<mlir::SymbolRefAttr>());
+      (*this)->setAttr(getArcAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
   }];
 }
@@ -365,7 +365,7 @@ def MemoryWritePortOp : ArcOp<"memory_write_port", [
 
     /// Set the callee for this operation.
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
-      (*this)->setAttr(getArcAttrName(), callee.get<mlir::SymbolRefAttr>());
+      (*this)->setAttr(getArcAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
   }];
 }

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -180,7 +180,7 @@ def ESIInstanceOp : Op<Handshake_Dialect, "esi_instance", [
 
     /// Set the callee for this operation.
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
-      (*this)->setAttr(getModuleAttrName(), callee.get<mlir::SymbolRefAttr>());
+      (*this)->setAttr(getModuleAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
 
     MutableOperandRange getArgOperandsMutable() {
@@ -251,7 +251,7 @@ def InstanceOp : Handshake_Op<"instance", [
 
     /// Set the callee for this operation.
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
-      (*this)->setAttr(getModuleAttrName(), callee.get<mlir::SymbolRefAttr>());
+      (*this)->setAttr(getModuleAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
 
     /// Get the control operand of this instance op

--- a/include/circt/Dialect/Kanagawa/KanagawaOps.td
+++ b/include/circt/Dialect/Kanagawa/KanagawaOps.td
@@ -459,7 +459,7 @@ def CallOp : KanagawaOp<"call", [
 
     /// Set the callee for this operation.
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
-      (*this)->setAttr(getCalleeAttrName(), callee.get<mlir::SymbolRefAttr>());
+      (*this)->setAttr(getCalleeAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
 
     /// Return the callee of this operation.

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -1064,7 +1064,7 @@ class SVFuncCallBase<string mnemonic, list<Trait> traits = []>: SVOp<mnemonic,
 
     /// Set the callee for this operation.
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
-      (*this)->setAttr(getCalleeAttrName(), callee.get<mlir::SymbolRefAttr>());
+      (*this)->setAttr(getCalleeAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
   }];
 }

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -143,7 +143,7 @@ def DPICallOp : SimOp<"func.dpi.call",
 
     /// Set the callee for this operation.
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
-      (*this)->setAttr(getCalleeAttrName(), callee.get<mlir::SymbolRefAttr>());
+      (*this)->setAttr(getCalleeAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
   }];
 

--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -361,7 +361,7 @@ def CallOp : SystemCOp<"cpp.call", [
 
     /// Set the callee for this operation.
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
-      (*this)->setAttr(getCalleeAttrName(), callee.get<mlir::SymbolRefAttr>());
+      (*this)->setAttr(getCalleeAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
 
   }];

--- a/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
+++ b/lib/Conversion/ConvertToArcs/ConvertToArcs.cpp
@@ -357,7 +357,7 @@ LogicalResult Converter::absorbRegs(HWModuleOp module) {
       rewriter.setInsertionPoint(callOp);
       arc = rewriter.replaceOpWithNewOp<StateOp>(
           callOp.getOperation(),
-          callOp.getCallableForCallee().get<SymbolRefAttr>(),
+          llvm::cast<SymbolRefAttr>(callOp.getCallableForCallee()),
           callOp->getResultTypes(), clock, Value{}, 1, callOp.getArgOperands());
     }
 

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -309,7 +309,8 @@ public:
 
   /// This method transforms the entry from an operation to a string value.
   void setString(StringRef value) {
-    assert(pointerData.is<Operation *>() && "shouldn't already be a string");
+    assert(llvm::isa<Operation *>(pointerData) &&
+           "shouldn't already be a string");
     length = value.size();
     void *data = malloc(length);
     memcpy(data, value.data(), length);

--- a/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
+++ b/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
@@ -282,7 +282,8 @@ LogicalResult canonicalizePassthoughCall(mlir::CallOpInterface callOp,
                                          SymbolHandler &symbolCache,
                                          PatternRewriter &rewriter) {
   auto defOp = cast<DefineOp>(symbolCache.getDefinition(
-      callOp.getCallableForCallee().get<SymbolRefAttr>().getLeafReference()));
+      llvm::cast<SymbolRefAttr>(callOp.getCallableForCallee())
+          .getLeafReference()));
   if (defOp.isPassthrough()) {
     symbolCache.removeUser(defOp, callOp);
     rewriter.replaceOp(callOp, callOp.getArgOperands());

--- a/lib/Dialect/Arc/Transforms/LowerLUT.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerLUT.cpp
@@ -203,7 +203,7 @@ LogicalResult LutCalculator::computeTableEntries(LutOp lut) {
       for (int j = (1U << bw) - 1; j >= 0; j--) {
         Attribute foldAttr;
         if (!(foldAttr = dyn_cast<Attribute>(results[j][i])))
-          foldAttr = vals[results[j][i].get<Value>()][j];
+          foldAttr = vals[llvm::cast<Value>(results[j][i])][j];
         ref[j] = foldAttr;
       }
     }

--- a/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerClasses.cpp
@@ -2107,7 +2107,7 @@ static void populateTypeConverter(TypeConverter &converter) {
 
   // Convert FIRRTL double type to OM.
   converter.addConversion(
-      [](DoubleType type) { return FloatType::getF64(type.getContext()); });
+      [](DoubleType type) { return Float64Type::get(type.getContext()); });
 
   // Add a target materialization such that the conversion does not fail when a
   // type conversion could not be reconciled automatically by the framework.

--- a/lib/Dialect/HW/Transforms/FlattenModules.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenModules.cpp
@@ -85,6 +85,11 @@ struct PrefixingInliner : public InlinerInterface {
       op->setAttr("names", ArrayAttr::get(namesAttr.getContext(), names));
     }
   }
+
+  bool allowSingleBlockOptimization(
+      iterator_range<Region::iterator> inlinedBlocks) const final {
+    return true;
+  }
 };
 } // namespace
 

--- a/lib/Support/JSON.cpp
+++ b/lib/Support/JSON.cpp
@@ -101,7 +101,7 @@ Attribute circt::convertJSONToAttribute(MLIRContext *context,
 
   // Float
   if (auto a = value.getAsNumber())
-    return FloatAttr::get(mlir::FloatType::getF64(context), *a);
+    return FloatAttr::get(mlir::Float64Type::get(context), *a);
 
   // Boolean
   if (auto a = value.getAsBoolean())

--- a/unittests/Support/JSONTest.cpp
+++ b/unittests/Support/JSONTest.cpp
@@ -32,7 +32,7 @@ TEST(JSONTest, RoundTripTypes) {
 
   NamedAttrList mapping;
 
-  auto floatAttr = FloatAttr::get(FloatType::getF64(&context), 123.4);
+  auto floatAttr = FloatAttr::get(Float64Type::get(&context), 123.4);
   mapping.append("float", floatAttr);
 
   auto intAttr = IntegerAttr::get(i64ty, 567);


### PR DESCRIPTION
This is a relatively straightforward LLVM bump, but there were a few
things updated here.

https://github.com/llvm/llvm-project/commit/abba01a

This updated PointerUnion to deprecate get and is in favor of
llvm::cast and llvm::isa, so this PR updates the relevant callsites.

https://github.com/llvm/llvm-project/commit/f023da1

This updated FloatType to remove the helpers like getF64. FloatType
was previously turned into a TypeInterface, and the helpers are now
static get methods on the concrete FloatType implementations, so this
PR updates FloatType::getF64 to Float64Type::get.

https://github.com/llvm/llvm-project/commit/b39c5cb6

This updated InlinerInterface to add a new
allowSingleBlockOptimization method. We need to define that on our
PrefixInliner, or else we will hit the new assertion.