### PR TITLE
[CI/CD] Update upload-artifacts and download-artifcats.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -97,7 +97,7 @@ jobs:
       # Upload the format patches to an artifact (zip'd) associated
       # with the workflow run. Only run this on a failure.
       - name: Upload format patches
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         if: ${{ failure() }}
         with:
@@ -285,7 +285,7 @@ jobs:
       # Upload the tidy patches to an artifact (zip'd) associated
       # with the workflow run. Only run this on a failure.
       - name: Upload tidy patches
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         if: ${{ failure() }}
         with:

--- a/.github/workflows/unifiedBuildTestAndInstall.yml
+++ b/.github/workflows/unifiedBuildTestAndInstall.yml
@@ -265,14 +265,14 @@ jobs:
 
 # Upload build artifacts
       - name: Upload Binary (Non-Tag)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: inputs.install && github.ref_type != 'tag'
         with:
           name: ${{ steps.name_archive.outputs.name }}
           path: ${{ steps.name_archive.outputs.name }}
           retention-days: 7
       - name: Upload SHA256 (Non-Tag)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: inputs.install && github.ref_type != 'tag'
         with:
           name: ${{ steps.name_archive.outputs.name }}.sha256

--- a/.github/workflows/uploadWheels.yml
+++ b/.github/workflows/uploadWheels.yml
@@ -53,9 +53,9 @@ jobs:
           SETUPTOOLS_SCM_DEBUG: True
 
       - name: Upload (stage) wheels as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-${{ matrix.config.cibw_build }}
           path: ./wheelhouse/*.whl
           retention-days: 7
           if-no-files-found: error
@@ -73,9 +73,10 @@ jobs:
 
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: python-wheels
+          pattern: python-wheels-*
+          merge-multiple: true
           path: ./wheelhouse/
 
       - name: List downloaded wheels


### PR DESCRIPTION
The v3 of these actions is deprecated:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/.

While GitHub has indicated this will stop working on January 30, we seem to have already hit a failure related to this: https://github.com/llvm/circt/actions/runs/12815228763/job/35733456176?pr=8089#step:1:25.

This updates to use the v4 version of these actions where we were on v3, and in the Python wheel building specifically, it makes one small tweak following the migration guide:
https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/#compatibility.