### PR TITLE
[FIRRTL] LowerLayers: Update innerrefs in extracted verbatim's

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -704,16 +704,18 @@ LogicalResult LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
     }
 
     // Update verbatims that target operations extracted alongside.
-    mlir::AttrTypeReplacer replacer;
-    replacer.addReplacement(
-        [&innerRefMap](hw::InnerRefAttr ref) -> std::optional<Attribute> {
-          auto it = innerRefMap.find(ref);
-          if (it != innerRefMap.end())
-            return hw::InnerRefAttr::get(it->second.second, ref.getName());
-          return std::nullopt;
-        });
-    for (auto verbatim : verbatims)
-      replacer.replaceElementsIn(verbatim);
+    if (!verbatims.empty()) {
+      mlir::AttrTypeReplacer replacer;
+      replacer.addReplacement(
+          [&innerRefMap](hw::InnerRefAttr ref) -> std::optional<Attribute> {
+            auto it = innerRefMap.find(ref);
+            if (it != innerRefMap.end())
+              return hw::InnerRefAttr::get(it->second.second, ref.getName());
+            return std::nullopt;
+          });
+      for (auto verbatim : verbatims)
+        replacer.replaceElementsIn(verbatim);
+    }
 
     // Connect instance ports to values.
     assert(ports.size() == connectValues.size() &&

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -763,3 +763,24 @@ firrtl.circuit "RWTH" {
     }
   }
 }
+
+// -----
+
+// Check sv.verbatim inner refs are updated, as occurs with views under layers.
+// CHECK-LABEL: circuit "Verbatim"
+firrtl.circuit "Verbatim" {
+  firrtl.layer @ViewLayer  bind { }
+  firrtl.module @Verbatim() {
+    firrtl.layerblock @ViewLayer {
+      %c1_ui10 = firrtl.constant 1 : !firrtl.uint<10>
+      %n = firrtl.node sym @node %c1_ui10 : !firrtl.uint<10>
+      sv.verbatim "// node: {{0}}, {{1}}"(%n) : !firrtl.uint<10> {symbols = [#hw.innerNameRef<@Verbatim::@node>]}
+    }
+  }
+}
+// CHECK:        firrtl.module private @[[VL:.+]]() {
+// CHECK-NEXT:     firrtl.constant 1
+// CHECK-NEXT:     firrtl.node sym @node
+// CHECK-NEXT:     sv.verbatim 
+// CHECK-SAME:     !firrtl.uint<10> {symbols = [#hw.innerNameRef<@[[VL]]::@node>]}
+// CHECK-NEXT:   }


### PR DESCRIPTION
This continues to not address lack of global updating, but fixes use of verbatims that are extracted along with their targets.