### PR TITLE
[ESI] BSP: implement hostmem read path arbiter

### DIFF
--- a/frontends/PyCDE/integration_test/esitester.py
+++ b/frontends/PyCDE/integration_test/esitester.py
@@ -182,10 +182,9 @@ class EsiTesterTop(Module):
   @generator
   def construct(ports):
     PrintfExample(clk=ports.clk, rst=ports.rst)
-    # Once I get read muxing working, enable all three.
-    # ReadMem(32)(clk=ports.clk, rst=ports.rst)
-    # ReadMem(64)(clk=ports.clk, rst=ports.rst)
-    ReadMem(96)(clk=ports.clk, rst=ports.rst)
+    ReadMem(32)(appid=esi.AppID("readmem", 32), clk=ports.clk, rst=ports.rst)
+    ReadMem(64)(appid=esi.AppID("readmem", 64), clk=ports.clk, rst=ports.rst)
+    ReadMem(96)(appid=esi.AppID("readmem", 96), clk=ports.clk, rst=ports.rst)
     WriteMem(clk=ports.clk, rst=ports.rst)
 
 

--- a/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
@@ -99,16 +99,15 @@ void registerCallbacks(AcceleratorConnection *conn, Accelerator *accel) {
   }
 }
 
-void dmaTest(AcceleratorConnection *conn, Accelerator *acc) {
-  // Enable the host memory service.
-  auto hostmem = conn->getService<services::HostMem>();
-  hostmem->start();
-  auto scratchRegion = hostmem->allocate(16, /*memOpts=*/{});
-  uint64_t *dataPtr = static_cast<uint64_t *>(scratchRegion->getPtr());
+void dmaTest(Accelerator *acc, uint64_t *dataPtr, uint32_t width) {
+  std::cout << "Running DMA test with width " << width << std::endl;
 
   // Initiate a test read.
-  auto *readMem =
-      acc->getPorts().at(AppID("ReadMem")).getAs<services::MMIO::MMIORegion>();
+  auto *readMem = acc->getChildren()
+                      .at(AppID("readmem", width))
+                      ->getPorts()
+                      .at(AppID("ReadMem"))
+                      .getAs<services::MMIO::MMIORegion>();
 
   for (size_t i = 0; i < 8; ++i) {
     dataPtr[0] = 0x12345678 << i;
@@ -118,15 +117,19 @@ void dmaTest(AcceleratorConnection *conn, Accelerator *acc) {
     // Wait for the accelerator to read the correct value. Timeout and fail
     // after 10ms.
     uint64_t val = 0;
+    uint64_t expected = dataPtr[0];
+    if (width < 64)
+      expected &= ((1ull << width) - 1);
     for (int i = 0; i < 100; ++i) {
       val = readMem->read(0);
-      if (val == *dataPtr)
+      if (val == expected)
         break;
       std::this_thread::sleep_for(std::chrono::microseconds(100));
     }
-    if (val != *dataPtr)
+
+    if (val != expected)
       throw std::runtime_error("DMA read test failed. Expected " +
-                               std::to_string(*dataPtr) + ", got " +
+                               std::to_string(expected) + ", got " +
                                std::to_string(val));
   }
 
@@ -143,4 +146,16 @@ void dmaTest(AcceleratorConnection *conn, Accelerator *acc) {
   }
   if (*dataPtr == 0)
     throw std::runtime_error("DMA write test failed");
+}
+
+void dmaTest(AcceleratorConnection *conn, Accelerator *acc) {
+  // Enable the host memory service.
+  auto hostmem = conn->getService<services::HostMem>();
+  hostmem->start();
+  auto scratchRegion = hostmem->allocate(/*size(bytes)=*/32, /*memOpts=*/{});
+  uint64_t *dataPtr = static_cast<uint64_t *>(scratchRegion->getPtr());
+
+  dmaTest(acc, dataPtr, 32);
+  dmaTest(acc, dataPtr, 64);
+  dmaTest(acc, dataPtr, 96);
 }


### PR DESCRIPTION
Implements a mux / demux on the hostmem service read path. Allows up to 256 clients.