### PR TITLE
[Pipeline] Make `reset` signal optional

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -41,7 +41,8 @@ class PipelineBase<string mnemonic, list<Trait> traits = []> :
       "TypeRange":$dataOutputs,
       "ValueRange":$inputs,
       "ArrayAttr":$inputNames, "ArrayAttr":$outputNames,
-      "Value":$clock, "Value":$reset, "Value":$go,
+      "Value":$clock, "Value":$go,
+      CArg<"Value", "{}">:$reset,
       CArg<"Value", "{}">:$stall,
       CArg<"StringAttr", "{}">:$name,
       CArg<"ArrayAttr", "{}">:$stallability
@@ -58,7 +59,7 @@ class PipelineBase<string mnemonic, list<Trait> traits = []> :
   // 1. Inputs
   // 2. Stall (opt)
   // 3. Clock
-  // 4. Reset
+  // 4. Reset (opt)
   // 5. Go
   let extraClassDeclaration = extraModuleClassDeclaration # [{
     // Returns the entry stage of this pipeline.
@@ -70,6 +71,11 @@ class PipelineBase<string mnemonic, list<Trait> traits = []> :
     // Returns true if this pipeline has a stall signal.
     bool hasStall() {
       return static_cast<bool>(getStall());
+    }
+
+    // Returns true if this pipeline has a reset signal.
+    bool hasReset() {
+      return static_cast<bool>(getReset());
     }
 
     mlir::Block::BlockArgListType getInnerInputs() {
@@ -125,7 +131,7 @@ def UnscheduledPipelineOp : PipelineBase<"unscheduled", [
 
   let arguments = (ins
     OptionalAttr<StrAttr>:$name, Variadic<AnyType>:$inputs, Optional<I1>:$stall,
-    ClockType:$clock, I1:$reset, I1:$go, StrArrayAttr:$inputNames,
+    ClockType:$clock, Optional<I1>:$reset, I1:$go, StrArrayAttr:$inputNames,
     StrArrayAttr:$outputNames
   );
   let regions = (region SizedRegion<1>: $body);
@@ -179,7 +185,7 @@ def ScheduledPipelineOp : PipelineBase<"scheduled"> {
     OptionalAttr<StrAttr>:$name,
     Variadic<AnyType>:$inputs,
     Optional<I1>:$stall,
-    ClockType:$clock, I1:$reset, I1:$go,
+    ClockType:$clock, Optional<I1>:$reset, I1:$go,
     StrArrayAttr:$inputNames, StrArrayAttr:$outputNames,
     OptionalAttr<BoolArrayAttr>:$stallability
   );

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -361,12 +361,15 @@ public:
         vInput.replaceAllUsesWith(vArg);
     }
 
-    // Build stage enable register. The enable register is always reset to 0.
-    // The stage enable register takes the previous-stage combinational valid
-    // output and determines whether this stage is active or not in the next
-    // cycle.
-    // A non-stallable stage always registers the incoming enable signal,
-    // whereas other stages register based on the current stall state.
+    // Build stage enable register. The enable register is reset to 0 iff a
+    // reset signal is available. We here rely on the compreg builders, which
+    // accept reset signal/reset value mlir::Value's that are null.
+    //
+    // The stage enable register takes the
+    // previous-stage combinational valid output and determines whether this
+    // stage is active or not in the next cycle. A non-stallable stage always
+    // registers the incoming enable signal, whereas other stages register based
+    // on the current stall state.
     StageKind stageKind = pipeline.getStageKind(stageIndex);
     Value stageEnabled;
     if (stageIndex == 0) {
@@ -374,8 +377,12 @@ public:
     } else {
       auto stageRegPrefix = getStagePrefix(stageIndex);
       auto enableRegName = (stageRegPrefix.strref() + "_enable").str();
-      hw::ConstantOp enableRegResetVal =
-          builder.create<hw::ConstantOp>(loc, APInt(1, 0, false));
+
+      Value enableRegResetVal;
+      if (args.reset) {
+        enableRegResetVal =
+            builder.create<hw::ConstantOp>(loc, APInt(1, 0, false)).getResult();
+      }
 
       switch (stageKind) {
       case StageKind::Continuous:
@@ -407,8 +414,10 @@ public:
         llvm::TypeSwitch<Operation *, void>(stageEnabled.getDefiningOp())
             .Case<seq::CompRegOp, seq::CompRegClockEnabledOp>([&](auto op) {
               op.getInitialValueMutable().assign(
-                  circt::seq::createConstantInitialValue(builder,
-                                                         enableRegResetVal));
+                  circt::seq::createConstantInitialValue(
+                      builder, loc,
+                      builder.getIntegerAttr(builder.getI1Type(),
+                                             APInt(1, 0, false))));
             });
       }
     }

--- a/lib/Conversion/PipelineToHW/PipelineToHW.cpp
+++ b/lib/Conversion/PipelineToHW/PipelineToHW.cpp
@@ -379,10 +379,9 @@ public:
       auto enableRegName = (stageRegPrefix.strref() + "_enable").str();
 
       Value enableRegResetVal;
-      if (args.reset) {
+      if (args.reset)
         enableRegResetVal =
             builder.create<hw::ConstantOp>(loc, APInt(1, 0, false)).getResult();
-      }
 
       switch (stageKind) {
       case StageKind::Continuous:

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaPrepareScheduling.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaPrepareScheduling.cpp
@@ -71,7 +71,7 @@ PrepareSchedulingPass::prepareSBlock(IsolatedStaticBlockOp sblock) {
 
   auto pipeline = b.create<pipeline::UnscheduledPipelineOp>(
       loc, retTypes, bodyBlock->getArguments(), b.getArrayAttr(inNames),
-      b.getArrayAttr(outNames), ph.getClock(), ph.getReset(), ph.getGo(),
+      b.getArrayAttr(outNames), ph.getClock(), ph.getGo(), ph.getReset(),
       ph.getStall());
   b.setInsertionPointToEnd(pipeline.getEntryStage());
 

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -210,10 +210,8 @@ static ParseResult parsePipelineOp(mlir::OpAsmParser &parser,
   if (parser.resolveOperand(clockOperand, clkType, result.operands))
     return failure();
 
-  if (withReset) {
-    if (parser.resolveOperand(resetOperand, i1, result.operands))
-      return failure();
-  }
+  if (withReset && parser.resolveOperand(resetOperand, i1, result.operands))
+    return failure();
 
   if (parser.resolveOperand(goOperand, i1, result.operands))
     return failure();

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -142,9 +142,11 @@ static ParseResult parsePipelineOp(mlir::OpAsmParser &parser,
   result.addAttribute("inputNames", inputNames);
 
   Type i1 = parser.getBuilder().getI1Type();
+
+  OpAsmParser::UnresolvedOperand stallOperand, clockOperand, resetOperand,
+      goOperand;
+
   // Parse optional 'stall (%stallArg)'
-  OpAsmParser::Argument stallArg;
-  OpAsmParser::UnresolvedOperand stallOperand;
   bool withStall = false;
   if (succeeded(parser.parseOptionalKeyword("stall"))) {
     if (parser.parseLParen() || parser.parseOperand(stallOperand) ||
@@ -154,10 +156,19 @@ static ParseResult parsePipelineOp(mlir::OpAsmParser &parser,
   }
 
   // Parse clock, reset, and go.
-  OpAsmParser::UnresolvedOperand clockOperand, resetOperand, goOperand;
-  if (parseKeywordAndOperand(parser, "clock", clockOperand) ||
-      parseKeywordAndOperand(parser, "reset", resetOperand) ||
-      parseKeywordAndOperand(parser, "go", goOperand))
+  if (parseKeywordAndOperand(parser, "clock", clockOperand))
+    return failure();
+
+  // Parse optional 'reset (%resetArg)'
+  bool withReset = false;
+  if (succeeded(parser.parseOptionalKeyword("reset"))) {
+    if (parser.parseLParen() || parser.parseOperand(resetOperand) ||
+        parser.parseRParen())
+      return failure();
+    withReset = true;
+  }
+
+  if (parseKeywordAndOperand(parser, "go", goOperand))
     return failure();
 
   // Parse entry stage enable block argument.
@@ -196,9 +207,15 @@ static ParseResult parsePipelineOp(mlir::OpAsmParser &parser,
   }
 
   Type clkType = seq::ClockType::get(parser.getContext());
-  if (parser.resolveOperand(clockOperand, clkType, result.operands) ||
-      parser.resolveOperand(resetOperand, i1, result.operands) ||
-      parser.resolveOperand(goOperand, i1, result.operands))
+  if (parser.resolveOperand(clockOperand, clkType, result.operands))
+    return failure();
+
+  if (withReset) {
+    if (parser.resolveOperand(resetOperand, i1, result.operands))
+      return failure();
+  }
+
+  if (parser.resolveOperand(goOperand, i1, result.operands))
     return failure();
 
   // Assemble the body region block arguments - this is where the magic happens
@@ -216,13 +233,13 @@ static ParseResult parsePipelineOp(mlir::OpAsmParser &parser,
   if (parser.parseRegion(*body, regionArgs))
     return failure();
 
-  result.addAttribute(
-      "operandSegmentSizes",
-      parser.getBuilder().getDenseI32ArrayAttr(
-          {static_cast<int32_t>(inputTypes.size()),
-           static_cast<int32_t>(withStall ? 1 : 0),
-           /*clock*/ static_cast<int32_t>(1),
-           /*reset*/ static_cast<int32_t>(1), /*go*/ static_cast<int32_t>(1)}));
+  result.addAttribute("operandSegmentSizes",
+                      parser.getBuilder().getDenseI32ArrayAttr(
+                          {static_cast<int32_t>(inputTypes.size()),
+                           static_cast<int32_t>(withStall ? 1 : 0),
+                           /*clock*/ static_cast<int32_t>(1),
+                           /*reset*/ static_cast<int32_t>(withReset ? 1 : 0),
+                           /*go*/ static_cast<int32_t>(1)}));
 
   return success();
 }
@@ -246,16 +263,17 @@ static void printPipelineOp(OpAsmPrinter &p, TPipelineOp op) {
 
   // Print the optional stall.
   if (op.hasStall()) {
-    p << "stall(";
-    p.printOperand(op.getStall());
-    p << ") ";
+    printKeywordOperand(p, "stall", op.getStall());
+    p << " ";
   }
 
   // Print the clock, reset, and go.
   printKeywordOperand(p, "clock", op.getClock());
   p << " ";
-  printKeywordOperand(p, "reset", op.getReset());
-  p << " ";
+  if (op.hasReset()) {
+    printKeywordOperand(p, "reset", op.getReset());
+    p << " ";
+  }
   printKeywordOperand(p, "go", op.getGo());
   p << " ";
 
@@ -290,7 +308,7 @@ static void printPipelineOp(OpAsmPrinter &p, TPipelineOp op) {
 static void buildPipelineLikeOp(OpBuilder &odsBuilder, OperationState &odsState,
                                 TypeRange dataOutputs, ValueRange inputs,
                                 ArrayAttr inputNames, ArrayAttr outputNames,
-                                Value clock, Value reset, Value go, Value stall,
+                                Value clock, Value go, Value reset, Value stall,
                                 StringAttr name, ArrayAttr stallability) {
   odsState.addOperands(inputs);
   if (stall)
@@ -432,11 +450,11 @@ void UnscheduledPipelineOp::build(OpBuilder &odsBuilder,
                                   OperationState &odsState,
                                   TypeRange dataOutputs, ValueRange inputs,
                                   ArrayAttr inputNames, ArrayAttr outputNames,
-                                  Value clock, Value reset, Value go,
+                                  Value clock, Value go, Value reset,
                                   Value stall, StringAttr name,
                                   ArrayAttr stallability) {
   buildPipelineLikeOp(odsBuilder, odsState, dataOutputs, inputs, inputNames,
-                      outputNames, clock, reset, go, stall, name, stallability);
+                      outputNames, clock, go, reset, stall, name, stallability);
 }
 
 //===----------------------------------------------------------------------===//
@@ -453,10 +471,10 @@ ParseResult ScheduledPipelineOp::parse(OpAsmParser &parser,
 void ScheduledPipelineOp::build(OpBuilder &odsBuilder, OperationState &odsState,
                                 TypeRange dataOutputs, ValueRange inputs,
                                 ArrayAttr inputNames, ArrayAttr outputNames,
-                                Value clock, Value reset, Value go, Value stall,
+                                Value clock, Value go, Value reset, Value stall,
                                 StringAttr name, ArrayAttr stallability) {
   buildPipelineLikeOp(odsBuilder, odsState, dataOutputs, inputs, inputNames,
-                      outputNames, clock, reset, go, stall, name, stallability);
+                      outputNames, clock, go, reset, stall, name, stallability);
 }
 
 Block *ScheduledPipelineOp::addStage() {

--- a/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
@@ -151,7 +151,7 @@ ScheduleLinearPipelinePass::schedulePipeline(UnscheduledPipelineOp pipeline) {
   auto schedPipeline = b.template create<pipeline::ScheduledPipelineOp>(
       pipeline.getLoc(), pipeline.getDataOutputs().getTypes(),
       pipeline.getInputs(), pipeline.getInputNames(), pipeline.getOutputNames(),
-      pipeline.getClock(), pipeline.getReset(), pipeline.getGo(),
+      pipeline.getClock(), pipeline.getGo(), pipeline.getReset(),
       pipeline.getStall(), pipeline.getNameAttr());
 
   Block *currentStage = schedPipeline.getStage(0);

--- a/test/Conversion/PipelineToHW/test_basic.mlir
+++ b/test/Conversion/PipelineToHW/test_basic.mlir
@@ -289,3 +289,20 @@ hw.module @testAnonymous(in %arg0: i1, in %clk: !seq.clock, in %rst: i1, out out
   hw.output %0#0 : i1
 }
 
+
+// -----
+
+// CHECK-LABEL:   hw.module @testNoReset(in 
+// CHECK-SAME:                              %[[VAL_0:.*]] : i1, in %[[VAL_1:.*]] : !seq.clock, out out : i1) {
+// CHECK:           %[[VAL_2:.*]] = seq.compreg sym @stage0_reg0 %[[VAL_0]], %[[VAL_1]] : i1
+// CHECK:           %[[VAL_3:.*]] = seq.compreg sym @stage1_enable %[[VAL_0]], %[[VAL_1]] : i1
+// CHECK:           hw.output %[[VAL_2]] : i1
+// CHECK:         }
+hw.module @testNoReset(in %arg0: i1, in %clk: !seq.clock, out out : i1) {
+  %0:2 = pipeline.scheduled ""(%a0 : i1 = %arg0) clock(%clk) go(%arg0) entryEn(%s0_enable) -> (out : i1) {
+    pipeline.stage ^bb1 regs(%a0 : i1)
+  ^bb1(%a0_0: i1, %s1_enable: i1):
+    pipeline.return %a0_0 : i1
+  }
+  hw.output %0#0 : i1
+}

--- a/test/Conversion/PipelineToHW/test_poweron.mlir
+++ b/test/Conversion/PipelineToHW/test_poweron.mlir
@@ -25,3 +25,27 @@ hw.module @testinitial(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk: !seq.c
   }
   hw.output %0#0, %0#1 : i32, i1
 }
+
+// CHECK-LABEL:   hw.module @testNoReset(in 
+// CHECK-SAME:                              %[[VAL_0:.*]] : i32, in %[[VAL_1:.*]] : i32, in %[[VAL_2:.*]] : i1, in %[[VAL_3:.*]] : !seq.clock, out out0 : i32, out out1 : i1) {
+// CHECK:           %[[VAL_4:.*]] = comb.sub %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_5:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_4]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_6:.*]] = seq.compreg sym @p0_stage0_reg1 %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_7:.*]] = seq.compreg sym @p0_stage1_enable %[[VAL_2]], %[[VAL_3]] initial %[[VAL_8:.*]] : i1
+// CHECK:           %[[VAL_8]] = seq.initial() {
+// CHECK:             %[[VAL_9:.*]] = hw.constant false
+// CHECK:             seq.yield %[[VAL_9]] : i1
+// CHECK:           } : () -> !seq.immutable<i1>
+// CHECK:           %[[VAL_10:.*]] = comb.add %[[VAL_5]], %[[VAL_6]] : i32
+// CHECK:           hw.output %[[VAL_10]], %[[VAL_7]] : i32, i1
+// CHECK:         }
+hw.module @testNoReset(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk: !seq.clock, out out0: i32, out out1: i1) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) go(%go) entryEn(%s0_enable) -> (out: i32){
+    %1 = comb.sub %a0,%a1 : i32
+    pipeline.stage ^bb1 regs(%1 : i32, %a0 : i32)
+  ^bb1(%6: i32, %7: i32, %s1_enable : i1):  // pred: ^bb1
+    %8 = comb.add %6, %7 : i32
+    pipeline.return %8 : i32
+  }
+  hw.output %0#0, %0#1 : i32, i1
+}

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -173,3 +173,27 @@ hw.module @withStallability(in %arg0 : i32, in %go : i1, in %clk : !seq.clock, i
   }
   hw.output %0 : i32
 }
+
+// CHECK-LABEL:  hw.module @withoutReset(in %arg0 : i32, in %stall : i1, in %go : i1, in %clk : !seq.clock, out out : i32) {
+// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) clock(%clk) go(%go) entryEn(%s0_enable)  -> (out : i32) {
+// CHECK-NEXT:      pipeline.stage ^bb1  
+// CHECK-NEXT:    ^bb1(%s1_enable: i1):  // pred: ^bb0
+// CHECK-NEXT:      pipeline.return %a0 : i32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %out_0, %done_1 = pipeline.unscheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) go(%go) entryEn(%s0_enable)  -> (out : i32) {
+// CHECK-NEXT:      pipeline.return %a0 : i32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    hw.output %out : i32
+// CHECK-NEXT:  }
+hw.module @withoutReset(in %arg0 : i32, in %stall : i1, in %go : i1, in %clk : !seq.clock, out out: i32) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%clk) go(%go) entryEn(%s0_enable) -> (out: i32) {
+    pipeline.stage ^bb1
+   ^bb1(%s1_enable : i1):
+    pipeline.return %a0 : i32
+  }
+
+  %1:2 = pipeline.unscheduled (%a0 : i32 = %arg0) stall (%stall) clock (%clk) go (%go) entryEn (%s0_enable) -> (out: i32) {
+    pipeline.return %a0 : i32
+  }
+  hw.output %0 : i32
+}


### PR DESCRIPTION
In some usecases, having a reset signal to a pipeline may do more harm than good in terms of synthetis/routing overhead. Instead, users can reset pipelines in other ways - e.g. by holder `go` low for `N stages` cycles. This, in turn, will set the pipeline stage enable registers to a deterministic state.

Allow for this by making the top-level `reset` signal optional.