### PR TITLE
[OM] Preserve non-OM operations in OM LinkModules

### DIFF
--- a/test/Dialect/OM/link-modules.mlir
+++ b/test/Dialect/OM/link-modules.mlir
@@ -2,7 +2,7 @@
 
 module {
   // CHECK-LABEL: module
-  // CHECK-NOT:   module
+  // CHECK-NEXT:   module
   // CHECK-NOT:   om.class.extern
   // CHECK-LABEL: om.class @A
   // CHECK-LABEL: om.class @Conflict_A
@@ -61,12 +61,12 @@ module {
 
 // -----
 
-// Check that OM ops are deleted.  Make the "delete-me" op a landmine that will
-// cause a symbol collision if it is _not_ deleted.
+// Check that OM ops are not deleted.  Make the "dont-delete-me" op a landmine that will
+// cause a symbol collision if it is moved to the top level.
 module {
   module {
-    // CHECK-NOT: delete-me
-    "delete-me"() {sym_name = "Bar"} : () -> ()
+    // CHECK: dont-delete-me
+    "dont-delete-me"() {sym_name = "Bar"} : () -> ()
     om.class @Foo() {
       om.class.fields
     }

--- a/test/om-linker/Inputs/a.mlir
+++ b/test/om-linker/Inputs/a.mlir
@@ -5,4 +5,5 @@ module {
   om.class @Conflict(){
     om.class.fields
   }
+  hw.module @hello() {}
 }

--- a/test/om-linker/Inputs/b.mlir
+++ b/test/om-linker/Inputs/b.mlir
@@ -6,4 +6,5 @@ module {
   om.class @Conflict(){
     om.class.fields
   }
+  hw.module.extern @hello()
 }

--- a/test/om-linker/link.mlir
+++ b/test/om-linker/link.mlir
@@ -1,5 +1,20 @@
 // RUN: om-linker %S/Inputs/a.mlir %S/Inputs/b.mlir %S/Inputs/other.mlir | FileCheck %s
 // CHECK:      module {
+// CHECK-NEXT:   module attributes {om.namespace = "a"} {
+// CHECK-NEXT:     hw.module @hello() {
+// CHECK-NEXT:       hw.output
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   module attributes {om.namespace = "b"} {
+// CHECK-NEXT:     hw.module.extern @hello()
+// CHECK-NEXT:   }
+// CHECK-NEXT:   module attributes {om.namespace = "other"} {
+// CHECK-NEXT:     hw.module @HW(in %a : i1, out b : i1) {
+// CHECK:            hw.output
+// CHECK-NEXT:     }
+// CHECK-NEXT:     emit.file "foo.sv" sym @Emit {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
 // CHECK-NEXT:   om.class @A(%arg: i1) {
 // CHECK-NEXT:     om.class.fields
 // CHECK-NEXT:   }


### PR DESCRIPTION
This PR changes OM LinkModule pass to preserve non-OM operations. Orthogonally we shouldn't use builtin.module for the container of nested hw modules and instead use hw.design in the long term but it should be ok for now. 

h/t @dtzSiFive for original idea to keep non-OM operations in artifact. 