### PR TITLE
[Python] Switch CIRCT Python extension and dialects to nanobind.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,11 +514,11 @@ option(CIRCT_BINDINGS_PYTHON_ENABLED "Enables CIRCT Python bindings." OFF)
 if(CIRCT_BINDINGS_PYTHON_ENABLED)
   message(STATUS "CIRCT Python bindings are enabled.")
   set(MLIR_DISABLE_CONFIGURE_PYTHON_DEV_PACKAGES 0)
-  mlir_detect_pybind11_install()
+  mlir_detect_nanobind_install()
   # Prime the search like mlir_configure_python_dev_modules
   find_package(Python3 3.8 COMPONENTS Interpreter Development)
   find_package(Python3 3.8 COMPONENTS Interpreter Development.Module)
-  find_package(pybind11 2.10 CONFIG REQUIRED)
+  find_package(nanobind 2.4.0 CONFIG REQUIRED)
 else()
   message(STATUS "CIRCT Python bindings are disabled.")
   # Lookup python either way as some integration tests use python without the

--- a/integration_test/Bindings/Python/dialects/esi.py
+++ b/integration_test/Bindings/Python/dialects/esi.py
@@ -31,7 +31,7 @@ with Context() as ctx:
   assert (not bundle_type.resettable)
   for bchan in bundle_type.channels:
     print(bchan)
-  # CHECK: ('i16chan', <ChannelDirection.TO: 1>, Type(!esi.channel<i16>))
+  # CHECK: ('i16chan', ChannelDirection.TO, Type(!esi.channel<i16>))
   print()
 
   bundle_type = esi.BundleType.get(

--- a/lib/Bindings/Python/CIRCTModule.cpp
+++ b/lib/Bindings/Python/CIRCTModule.cpp
@@ -1,4 +1,4 @@
-//===- CIRCTModule.cpp - Main pybind module -------------------------------===//
+//===- CIRCTModule.cpp - Main nanobind module -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -35,14 +35,14 @@
 #include "mlir-c/Bindings/Python/Interop.h"
 #include "mlir-c/IR.h"
 #include "mlir-c/Transforms.h"
-#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "mlir/Bindings/Python/NanobindAdaptors.h"
 
 #include "llvm-c/ErrorHandling.h"
 #include "llvm/Support/Signals.h"
 
-#include "PybindUtils.h"
-#include <pybind11/pybind11.h>
-namespace py = pybind11;
+#include "NanobindUtils.h"
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
 
 static void registerPasses() {
   registerArcPasses();
@@ -59,7 +59,7 @@ static void registerPasses() {
   mlirRegisterTransformsCSE();
 }
 
-PYBIND11_MODULE(_circt, m) {
+NB_MODULE(_circt, m) {
   m.doc() = "CIRCT Python Native Extension";
   registerPasses();
   llvm::sys::PrintStackTraceOnErrorSignal(/*argv=*/"");
@@ -67,7 +67,7 @@ PYBIND11_MODULE(_circt, m) {
 
   m.def(
       "register_dialects",
-      [](py::object capsule) {
+      [](nb::object capsule) {
         // Get the MlirContext capsule from PyMlirContext capsule.
         auto wrappedCapsule = capsule.attr(MLIR_PYTHON_CAPI_PTR_ATTR);
         MlirContext context = mlirPythonCapsuleToContext(wrappedCapsule.ptr());
@@ -145,9 +145,9 @@ PYBIND11_MODULE(_circt, m) {
       },
       "Register CIRCT dialects on a PyMlirContext.");
 
-  m.def("export_verilog", [](MlirModule mod, py::object fileObject) {
+  m.def("export_verilog", [](MlirModule mod, nb::object fileObject) {
     circt::python::PyFileAccumulator accum(fileObject, false);
-    py::gil_scoped_release();
+    nb::gil_scoped_release();
     mlirExportVerilog(mod, accum.getCallback(), accum.getUserData());
   });
 
@@ -156,26 +156,26 @@ PYBIND11_MODULE(_circt, m) {
     mlirExportSplitVerilog(mod, cDirectory);
   });
 
-  py::module esi = m.def_submodule("_esi", "ESI API");
+  nb::module_ esi = m.def_submodule("_esi", "ESI API");
   circt::python::populateDialectESISubmodule(esi);
-  py::module msft = m.def_submodule("_msft", "MSFT API");
+  nb::module_ msft = m.def_submodule("_msft", "MSFT API");
   circt::python::populateDialectMSFTSubmodule(msft);
-  py::module hw = m.def_submodule("_hw", "HW API");
+  nb::module_ hw = m.def_submodule("_hw", "HW API");
   circt::python::populateDialectHWSubmodule(hw);
-  py::module seq = m.def_submodule("_seq", "Seq API");
+  nb::module_ seq = m.def_submodule("_seq", "Seq API");
   circt::python::populateDialectSeqSubmodule(seq);
-  py::module om = m.def_submodule("_om", "OM API");
+  nb::module_ om = m.def_submodule("_om", "OM API");
   circt::python::populateDialectOMSubmodule(om);
-  py::module rtg = m.def_submodule("_rtg", "RTG API");
+  nb::module_ rtg = m.def_submodule("_rtg", "RTG API");
   circt::python::populateDialectRTGSubmodule(rtg);
-  py::module rtgtool = m.def_submodule("_rtgtool", "RTGTool API");
+  nb::module_ rtgtool = m.def_submodule("_rtgtool", "RTGTool API");
   circt::python::populateDialectRTGToolSubmodule(rtgtool);
 #ifdef CIRCT_INCLUDE_TESTS
-  py::module rtgtest = m.def_submodule("_rtgtest", "RTGTest API");
+  nb::module_ rtgtest = m.def_submodule("_rtgtest", "RTGTest API");
   circt::python::populateDialectRTGTestSubmodule(rtgtest);
 #endif
-  py::module sv = m.def_submodule("_sv", "SV API");
+  nb::module_ sv = m.def_submodule("_sv", "SV API");
   circt::python::populateDialectSVSubmodule(sv);
-  py::module support = m.def_submodule("_support", "CIRCT support");
+  nb::module_ support = m.def_submodule("_support", "CIRCT support");
   circt::python::populateSupportSubmodule(support);
 }

--- a/lib/Bindings/Python/CIRCTModules.h
+++ b/lib/Bindings/Python/CIRCTModules.h
@@ -13,23 +13,23 @@
 #ifndef CIRCT_BINDINGS_PYTHON_CIRCTMODULES_H
 #define CIRCT_BINDINGS_PYTHON_CIRCTMODULES_H
 
-#include <pybind11/pybind11.h>
+#include <nanobind/nanobind.h>
 
 namespace circt {
 namespace python {
 
-void populateDialectESISubmodule(pybind11::module &m);
-void populateDialectHWSubmodule(pybind11::module &m);
-void populateDialectMSFTSubmodule(pybind11::module &m);
-void populateDialectOMSubmodule(pybind11::module &m);
-void populateDialectRTGSubmodule(pybind11::module &m);
-void populateDialectRTGToolSubmodule(pybind11::module &m);
+void populateDialectESISubmodule(nanobind::module_ &m);
+void populateDialectHWSubmodule(nanobind::module_ &m);
+void populateDialectMSFTSubmodule(nanobind::module_ &m);
+void populateDialectOMSubmodule(nanobind::module_ &m);
+void populateDialectRTGSubmodule(nanobind::module_ &m);
+void populateDialectRTGToolSubmodule(nanobind::module_ &m);
 #ifdef CIRCT_INCLUDE_TESTS
-void populateDialectRTGTestSubmodule(pybind11::module &m);
+void populateDialectRTGTestSubmodule(nanobind::module_ &m);
 #endif
-void populateDialectSeqSubmodule(pybind11::module &m);
-void populateDialectSVSubmodule(pybind11::module &m);
-void populateSupportSubmodule(pybind11::module &m);
+void populateDialectSeqSubmodule(nanobind::module_ &m);
+void populateDialectSVSubmodule(nanobind::module_ &m);
+void populateSupportSubmodule(nanobind::module_ &m);
 
 } // namespace python
 } // namespace circt

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -26,7 +26,7 @@ set(PYTHON_BINDINGS_SOURCES
   SVModule.cpp
   # Headers must be included explicitly so they are installed.
   CIRCTModules.h
-  PybindUtils.h
+  NanobindUtils.h
 )
 
 set(PYTHON_BINDINGS_LINK_LIBS
@@ -70,6 +70,8 @@ declare_mlir_python_extension(CIRCTBindingsPythonExtension
     ${PYTHON_BINDINGS_LINK_LIBS}
   PRIVATE_LINK_LIBS
     LLVMSupport
+  PYTHON_BINDINGS_LIBRARY
+    nanobind
 )
 
 add_dependencies(CIRCTBindingsPythonExtension circt-headers)

--- a/lib/Bindings/Python/HWModule.cpp
+++ b/lib/Bindings/Python/HWModule.cpp
@@ -1,4 +1,4 @@
-//===- HWModule.cpp - HW API pybind module --------------------------------===//
+//===- HWModule.cpp - HW API nanobind module ------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,29 +11,27 @@
 #include "circt-c/Dialect/HW.h"
 
 #include "mlir-c/BuiltinAttributes.h"
-#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "mlir/Bindings/Python/NanobindAdaptors.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include "PybindUtils.h"
+#include "NanobindUtils.h"
 #include "mlir-c/Support.h"
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
 
 using namespace circt;
-using namespace mlir::python::adaptors;
+using namespace mlir::python::nanobind_adaptors;
 
 /// Populate the hw python module.
-void circt::python::populateDialectHWSubmodule(py::module &m) {
+void circt::python::populateDialectHWSubmodule(nb::module_ &m) {
   m.doc() = "HW dialect Python native extension";
 
   m.def("get_bitwidth", &hwGetBitWidth);
 
   mlir_type_subclass(m, "InOutType", hwTypeIsAInOut)
       .def_classmethod("get",
-                       [](py::object cls, MlirType innerType) {
+                       [](nb::object cls, MlirType innerType) {
                          return cls(hwInOutTypeGet(innerType));
                        })
       .def_property_readonly("element_type", [](MlirType self) {
@@ -42,7 +40,7 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
 
   mlir_type_subclass(m, "ArrayType", hwTypeIsAArrayType)
       .def_classmethod("get",
-                       [](py::object cls, MlirType elementType, intptr_t size) {
+                       [](nb::object cls, MlirType elementType, intptr_t size) {
                          return cls(hwArrayTypeGet(elementType, size));
                        })
       .def_property_readonly(
@@ -51,31 +49,31 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
       .def_property_readonly(
           "size", [](MlirType self) { return hwArrayTypeGetSize(self); });
 
-  py::enum_<HWModulePortDirection>(m, "ModulePortDirection")
+  nb::enum_<HWModulePortDirection>(m, "ModulePortDirection")
       .value("INPUT", HWModulePortDirection::Input)
       .value("OUTPUT", HWModulePortDirection::Output)
       .value("INOUT", HWModulePortDirection::InOut)
       .export_values();
 
-  py::class_<HWModulePort>(m, "ModulePort")
-      .def(py::init<MlirAttribute, MlirType, HWModulePortDirection>());
+  nb::class_<HWModulePort>(m, "ModulePort")
+      .def(nb::init<MlirAttribute, MlirType, HWModulePortDirection>());
 
   mlir_type_subclass(m, "ModuleType", hwTypeIsAModuleType)
       .def_classmethod(
           "get",
-          [](py::object cls, py::list pyModulePorts, MlirContext ctx) {
+          [](nb::object cls, nb::list pyModulePorts, MlirContext ctx) {
             std::vector<HWModulePort> modulePorts;
             for (auto pyModulePort : pyModulePorts)
-              modulePorts.push_back(pyModulePort.cast<HWModulePort>());
+              modulePorts.push_back(nb::cast<HWModulePort>(pyModulePort));
 
             return cls(
                 hwModuleTypeGet(ctx, modulePorts.size(), modulePorts.data()));
           },
-          py::arg("cls"), py::arg("ports"), py::arg("context") = py::none())
+          nb::arg("cls"), nb::arg("ports"), nb::arg("context") = nb::none())
       .def_property_readonly(
           "input_types",
           [](MlirType self) {
-            py::list inputTypes;
+            nb::list inputTypes;
             intptr_t numInputs = hwModuleTypeGetNumInputs(self);
             for (intptr_t i = 0; i < numInputs; ++i)
               inputTypes.append(hwModuleTypeGetInputType(self, i));
@@ -95,7 +93,7 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
       .def_property_readonly(
           "output_types",
           [](MlirType self) {
-            py::list outputTypes;
+            nb::list outputTypes;
             intptr_t numOutputs = hwModuleTypeGetNumOutputs(self);
             for (intptr_t i = 0; i < numOutputs; ++i)
               outputTypes.append(hwModuleTypeGetOutputType(self, i));
@@ -114,7 +112,7 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
   mlir_type_subclass(m, "ParamIntType", hwTypeIsAIntType)
       .def_classmethod(
           "get_from_param",
-          [](py::object cls, MlirContext ctx, MlirAttribute param) {
+          [](nb::object cls, MlirContext ctx, MlirAttribute param) {
             return cls(hwParamIntTypeGet(param));
           })
       .def_property_readonly("width", [](MlirType self) {
@@ -124,7 +122,7 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
   mlir_type_subclass(m, "StructType", hwTypeIsAStructType)
       .def_classmethod(
           "get",
-          [](py::object cls, py::list pyFieldInfos) {
+          [](nb::object cls, nb::list pyFieldInfos) {
             llvm::SmallVector<HWStructFieldInfo> mlirFieldInfos;
             MlirContext ctx;
 
@@ -132,10 +130,10 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
             // copy them into a temporary vector to give them all new addresses.
             llvm::SmallVector<llvm::SmallString<8>> names;
             for (size_t i = 0, e = pyFieldInfos.size(); i < e; ++i) {
-              auto tuple = pyFieldInfos[i].cast<py::tuple>();
-              auto type = tuple[1].cast<MlirType>();
+              auto tuple = nb::cast<nb::tuple>(pyFieldInfos[i]);
+              auto type = nb::cast<MlirType>(tuple[1]);
               ctx = mlirTypeGetContext(type);
-              names.emplace_back(tuple[0].cast<std::string>());
+              names.emplace_back(nb::cast<std::string>(tuple[0]));
               auto nameStringRef =
                   mlirStringRefCreate(names[i].data(), names[i].size());
               mlirFieldInfos.push_back(HWStructFieldInfo{
@@ -156,19 +154,19 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
            })
       .def("get_fields", [](MlirType self) {
         intptr_t num_fields = hwStructTypeGetNumFields(self);
-        py::list fields;
+        nb::list fields;
         for (intptr_t i = 0; i < num_fields; ++i) {
           auto field = hwStructTypeGetFieldNum(self, i);
           auto fieldName = mlirIdentifierStr(field.name);
           std::string name(fieldName.data, fieldName.length);
-          fields.append(py::make_tuple(name, field.type));
+          fields.append(nb::make_tuple(name, field.type));
         }
         return fields;
       });
 
   mlir_type_subclass(m, "TypeAliasType", hwTypeIsATypeAliasType)
       .def_classmethod("get",
-                       [](py::object cls, std::string scope, std::string name,
+                       [](nb::object cls, std::string scope, std::string name,
                           MlirType innerType) {
                          return cls(hwTypeAliasTypeGet(
                              mlirStringRefCreateFromCString(scope.c_str()),
@@ -195,13 +193,13 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
   mlir_attribute_subclass(m, "ParamDeclAttr", hwAttrIsAParamDeclAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, std::string name, MlirType type,
+          [](nb::object cls, std::string name, MlirType type,
              MlirAttribute value) {
             return cls(hwParamDeclAttrGet(
                 mlirStringRefCreateFromCString(name.c_str()), type, value));
           })
       .def_classmethod("get_nodefault",
-                       [](py::object cls, std::string name, MlirType type) {
+                       [](nb::object cls, std::string name, MlirType type) {
                          return cls(hwParamDeclAttrGet(
                              mlirStringRefCreateFromCString(name.c_str()), type,
                              MlirAttribute{nullptr}));
@@ -220,7 +218,7 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
   mlir_attribute_subclass(m, "ParamDeclRefAttr", hwAttrIsAParamDeclRefAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, MlirContext ctx, std::string name) {
+          [](nb::object cls, MlirContext ctx, std::string name) {
             return cls(hwParamDeclRefAttrGet(
                 ctx, mlirStringRefCreateFromCString(name.c_str())));
           })
@@ -233,12 +231,12 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
       });
 
   mlir_attribute_subclass(m, "ParamVerbatimAttr", hwAttrIsAParamVerbatimAttr)
-      .def_classmethod("get", [](py::object cls, MlirAttribute text) {
+      .def_classmethod("get", [](nb::object cls, MlirAttribute text) {
         return cls(hwParamVerbatimAttrGet(text));
       });
 
   mlir_attribute_subclass(m, "OutputFileAttr", hwAttrIsAOutputFileAttr)
-      .def_classmethod("get_from_filename", [](py::object cls,
+      .def_classmethod("get_from_filename", [](nb::object cls,
                                                MlirAttribute fileName,
                                                bool excludeFromFileList,
                                                bool includeReplicatedOp) {
@@ -248,7 +246,7 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
 
   mlir_attribute_subclass(m, "InnerSymAttr", hwAttrIsAInnerSymAttr)
       .def_classmethod("get",
-                       [](py::object cls, MlirAttribute symName) {
+                       [](nb::object cls, MlirAttribute symName) {
                          return cls(hwInnerSymAttrGet(symName));
                        })
       .def_property_readonly("symName", [](MlirAttribute self) {
@@ -258,7 +256,7 @@ void circt::python::populateDialectHWSubmodule(py::module &m) {
   mlir_attribute_subclass(m, "InnerRefAttr", hwAttrIsAInnerRefAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, MlirAttribute moduleName, MlirAttribute innerSym) {
+          [](nb::object cls, MlirAttribute moduleName, MlirAttribute innerSym) {
             return cls(hwInnerRefAttrGet(moduleName, innerSym));
           })
       .def_property_readonly(

--- a/lib/Bindings/Python/MSFTModule.cpp
+++ b/lib/Bindings/Python/MSFTModule.cpp
@@ -1,4 +1,4 @@
-//===- MSFTModule.cpp - MSFT API pybind module ----------------------------===//
+//===- MSFTModule.cpp - MSFT API nanobind module --------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,22 +11,19 @@
 #include "circt-c/Dialect/MSFT.h"
 #include "circt/Dialect/MSFT/MSFTDialect.h"
 
-#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "mlir/Bindings/Python/NanobindAdaptors.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Support.h"
 
-#include "PybindUtils.h"
-#include <pybind11/functional.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include "NanobindUtils.h"
+namespace nb = nanobind;
 
 // using namespace circt;
 // using namespace circt::msft;
-using namespace mlir::python::adaptors;
+using namespace mlir::python::nanobind_adaptors;
 
-static py::handle getPhysLocationAttr(MlirAttribute attr) {
-  return py::module::import("circt.dialects.msft")
+static nb::handle getPhysLocationAttr(MlirAttribute attr) {
+  return nb::module_::import_("circt.dialects.msft")
       .attr("PhysLocationAttr")(attr)
       .release();
 }
@@ -68,21 +65,22 @@ public:
   MlirOperation getInstanceAt(MlirAttribute loc) {
     return circtMSFTPlacementDBGetInstanceAt(db, loc);
   }
-  py::handle getNearestFreeInColumn(CirctMSFTPrimitiveType prim,
-                                    uint64_t column, uint64_t nearestToY) {
+  nb::handle getNearestFreeInColumn(PrimitiveType prim, uint64_t column,
+                                    uint64_t nearestToY) {
+    auto cPrim = static_cast<CirctMSFTPrimitiveType>(prim);
     MlirAttribute nearest = circtMSFTPlacementDBGetNearestFreeInColumn(
-        db, prim, column, nearestToY);
+        db, cPrim, column, nearestToY);
     if (!nearest.ptr)
-      return py::none();
+      return nb::none();
     return getPhysLocationAttr(nearest);
   }
   void walkPlacements(
-      py::function pycb,
-      std::tuple<py::object, py::object, py::object, py::object> bounds,
-      py::object prim, py::object walkOrder) {
+      nb::callable pycb,
+      std::tuple<nb::object, nb::object, nb::object, nb::object> bounds,
+      nb::object prim, nb::object walkOrder) {
 
-    auto handleNone = [](py::object o) {
-      return o.is_none() ? -1 : o.cast<int64_t>();
+    auto handleNone = [](nb::object o) {
+      return o.is_none() ? -1 : nb::cast<int64_t>(o);
     };
     int64_t cBounds[4] = {
         handleNone(std::get<0>(bounds)), handleNone(std::get<1>(bounds)),
@@ -91,11 +89,11 @@ public:
     if (prim.is_none())
       cPrim = -1;
     else
-      cPrim = prim.cast<CirctMSFTPrimitiveType>();
+      cPrim = nb::cast<CirctMSFTPrimitiveType>(prim);
 
     CirctMSFTWalkOrder cWalkOrder;
     if (!walkOrder.is_none())
-      cWalkOrder = walkOrder.cast<CirctMSFTWalkOrder>();
+      cWalkOrder = nb::cast<CirctMSFTWalkOrder>(walkOrder);
     else
       cWalkOrder = CirctMSFTWalkOrder{CirctMSFTDirection::NONE,
                                       CirctMSFTDirection::NONE};
@@ -103,8 +101,8 @@ public:
     circtMSFTPlacementDBWalkPlacements(
         db,
         [](MlirAttribute loc, MlirOperation locOp, void *userData) {
-          py::gil_scoped_acquire gil;
-          py::function pycb = *((py::function *)(userData));
+          nb::gil_scoped_acquire gil;
+          nb::callable pycb = *((nb::callable *)(userData));
           pycb(loc, locOp);
         },
         cBounds, cPrim, cWalkOrder, &pycb);
@@ -130,14 +128,13 @@ public:
 
   std::optional<MlirAttribute> dunderNext() {
     if (nextIndex >= circtMSFTLocationVectorAttrGetNumElements(attr)) {
-      throw py::stop_iteration();
+      throw nb::stop_iteration();
     }
     return getItem(attr, nextIndex++);
   }
 
-  static void bind(py::module &m) {
-    py::class_<PyLocationVecIterator>(m, "LocationVectorAttrIterator",
-                                      py::module_local())
+  static void bind(nb::module_ &m) {
+    nb::class_<PyLocationVecIterator>(m, "LocationVectorAttrIterator")
         .def("__iter__", &PyLocationVecIterator::dunderIter)
         .def("__next__", &PyLocationVecIterator::dunderNext);
   }
@@ -148,20 +145,20 @@ private:
 };
 
 /// Populate the msft python module.
-void circt::python::populateDialectMSFTSubmodule(py::module &m) {
+void circt::python::populateDialectMSFTSubmodule(nb::module_ &m) {
   mlirMSFTRegisterPasses();
 
   m.doc() = "MSFT dialect Python native extension";
 
   m.def("replaceAllUsesWith", &circtMSFTReplaceAllUsesWith);
 
-  py::enum_<PrimitiveType>(m, "PrimitiveType")
+  nb::enum_<PrimitiveType>(m, "PrimitiveType")
       .value("M20K", PrimitiveType::M20K)
       .value("DSP", PrimitiveType::DSP)
       .value("FF", PrimitiveType::FF)
       .export_values();
 
-  py::enum_<CirctMSFTDirection>(m, "Direction")
+  nb::enum_<CirctMSFTDirection>(m, "Direction")
       .value("NONE", CirctMSFTDirection::NONE)
       .value("ASC", CirctMSFTDirection::ASC)
       .value("DESC", CirctMSFTDirection::DESC)
@@ -171,14 +168,14 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
                           circtMSFTAttributeIsAPhysLocationAttribute)
       .def_classmethod(
           "get",
-          [](py::object cls, PrimitiveType devType, uint64_t x, uint64_t y,
+          [](nb::object cls, PrimitiveType devType, uint64_t x, uint64_t y,
              uint64_t num, MlirContext ctxt) {
             return cls(circtMSFTPhysLocationAttrGet(ctxt, (uint64_t)devType, x,
                                                     y, num));
           },
-          "Create a physical location attribute", py::arg(),
-          py::arg("dev_type"), py::arg("x"), py::arg("y"), py::arg("num"),
-          py::arg("ctxt") = py::none())
+          "Create a physical location attribute", nb::arg(),
+          nb::arg("dev_type"), nb::arg("x"), nb::arg("y"), nb::arg("num"),
+          nb::arg("ctxt") = nb::none())
       .def_property_readonly(
           "devtype",
           [](MlirAttribute self) {
@@ -201,21 +198,21 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
                           circtMSFTAttributeIsAPhysicalBoundsAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, uint64_t xMin, uint64_t xMax, uint64_t yMin,
+          [](nb::object cls, uint64_t xMin, uint64_t xMax, uint64_t yMin,
              uint64_t yMax, MlirContext ctxt) {
             auto physicalBounds =
                 circtMSFTPhysicalBoundsAttrGet(ctxt, xMin, xMax, yMin, yMax);
             return cls(physicalBounds);
           },
-          "Create a PhysicalBounds attribute", py::arg("cls"), py::arg("xMin"),
-          py::arg("xMax"), py::arg("yMin"), py::arg("yMax"),
-          py::arg("context") = py::none());
+          "Create a PhysicalBounds attribute", nb::arg("cls"), nb::arg("xMin"),
+          nb::arg("xMax"), nb::arg("yMin"), nb::arg("yMax"),
+          nb::arg("context") = nb::none());
 
   mlir_attribute_subclass(m, "LocationVectorAttr",
                           circtMSFTAttributeIsALocationVectorAttribute)
       .def_classmethod(
           "get",
-          [](py::object cls, MlirType type, std::vector<py::handle> pylocs,
+          [](nb::object cls, MlirType type, std::vector<nb::handle> pylocs,
              MlirContext ctxt) {
             // Get a LocationVector being sensitive to None in the list of
             // locations.
@@ -229,38 +226,38 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
             return cls(circtMSFTLocationVectorAttrGet(ctxt, type, locs.size(),
                                                       locs.data()));
           },
-          "Create a LocationVector attribute", py::arg("cls"), py::arg("type"),
-          py::arg("locs"), py::arg("context") = py::none())
+          "Create a LocationVector attribute", nb::arg("cls"), nb::arg("type"),
+          nb::arg("locs"), nb::arg("context") = nb::none())
       .def("reg_type", &circtMSFTLocationVectorAttrGetType)
       .def("__len__", &circtMSFTLocationVectorAttrGetNumElements)
       .def("__getitem__", &PyLocationVecIterator::getItem,
-           "Get the location at the specified position", py::arg("pos"))
+           "Get the location at the specified position", nb::arg("pos"))
       .def("__iter__",
            [](MlirAttribute arr) { return PyLocationVecIterator(arr); });
   PyLocationVecIterator::bind(m);
 
-  py::class_<PrimitiveDB>(m, "PrimitiveDB")
-      .def(py::init<MlirContext>(), py::arg("ctxt") = py::none())
+  nb::class_<PrimitiveDB>(m, "PrimitiveDB")
+      .def(nb::init<MlirContext>(), nb::arg("ctxt") = nb::none())
       .def("add_primitive", &PrimitiveDB::addPrimitive,
-           "Inform the DB about a new placement.", py::arg("loc_and_prim"))
+           "Inform the DB about a new placement.", nb::arg("loc_and_prim"))
       .def("is_valid_location", &PrimitiveDB::isValidLocation,
            "Query the DB as to whether or not a primitive exists.",
-           py::arg("loc"));
+           nb::arg("loc"));
 
-  py::class_<PlacementDB>(m, "PlacementDB")
-      .def(py::init<MlirModule, PrimitiveDB *>(), py::arg("top"),
-           py::arg("seed") = nullptr)
+  nb::class_<PlacementDB>(m, "PlacementDB")
+      .def(nb::init<MlirModule, PrimitiveDB *>(), nb::arg("top"),
+           nb::arg("seed") = nullptr)
       .def("place", &PlacementDB::place, "Place a dynamic instance.",
-           py::arg("dyn_inst"), py::arg("location"), py::arg("subpath"),
-           py::arg("src_location") = py::none())
+           nb::arg("dyn_inst"), nb::arg("location"), nb::arg("subpath"),
+           nb::arg("src_location") = nb::none())
       .def("remove_placement", &PlacementDB::removePlacement,
-           "Remove a placement.", py::arg("location"))
+           "Remove a placement.", nb::arg("location"))
       .def("move_placement", &PlacementDB::movePlacement,
-           "Move a placement to another location.", py::arg("old_location"),
-           py::arg("new_location"))
+           "Move a placement to another location.", nb::arg("old_location"),
+           nb::arg("new_location"))
       .def("get_nearest_free_in_column", &PlacementDB::getNearestFreeInColumn,
            "Find the nearest free primitive location in column.",
-           py::arg("prim_type"), py::arg("column"), py::arg("nearest_to_y"))
+           nb::arg("prim_type"), nb::arg("column"), nb::arg("nearest_to_y"))
       .def("get_instance_at", &PlacementDB::getInstanceAt,
            "Get the instance at location. Returns None if nothing exists "
            "there. Otherwise, returns (path, subpath, op) of the instance "
@@ -268,14 +265,14 @@ void circt::python::populateDialectMSFTSubmodule(py::module &m) {
       .def("walk_placements", &PlacementDB::walkPlacements,
            "Walk the placements, with possible bounds. Bounds are (xmin, xmax, "
            "ymin, ymax) with 'None' being unbounded.",
-           py::arg("callback"),
-           py::arg("bounds") =
-               std::make_tuple(py::none(), py::none(), py::none(), py::none()),
-           py::arg("prim_type") = py::none(),
-           py::arg("walk_order") = py::none());
+           nb::arg("callback"),
+           nb::arg("bounds") =
+               std::make_tuple(nb::none(), nb::none(), nb::none(), nb::none()),
+           nb::arg("prim_type") = nb::none(),
+           nb::arg("walk_order") = nb::none());
 
-  py::class_<CirctMSFTWalkOrder>(m, "WalkOrder")
-      .def(py::init<CirctMSFTDirection, CirctMSFTDirection>(),
-           py::arg("columns") = CirctMSFTDirection::NONE,
-           py::arg("rows") = CirctMSFTDirection::NONE);
+  nb::class_<CirctMSFTWalkOrder>(m, "WalkOrder")
+      .def(nb::init<CirctMSFTDirection, CirctMSFTDirection>(),
+           nb::arg("columns") = CirctMSFTDirection::NONE,
+           nb::arg("rows") = CirctMSFTDirection::NONE);
 }

--- a/lib/Bindings/Python/NanobindUtils.h
+++ b/lib/Bindings/Python/NanobindUtils.h
@@ -1,4 +1,4 @@
-//===- PybindUtils.h - Utilities for interop with python ------------------===//
+//===- NanobindUtils.h - Utilities for interop with python ----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -15,9 +15,7 @@
 
 #include <string>
 
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
-#include <pybind11/stl.h>
+#include <nanobind/nanobind.h>
 
 #include "mlir-c/Bindings/Python/Interop.h"
 #include "mlir-c/IR.h"
@@ -25,31 +23,29 @@
 
 #include <optional>
 
-namespace py = pybind11;
-
 namespace circt {
 namespace python {
 
-/// Taken from PybindUtils.h in MLIR.
+/// Taken from NanobindUtils.h in MLIR.
 /// Accumulates into a python file-like object, either writing text (default)
 /// or binary.
 class PyFileAccumulator {
 public:
-  PyFileAccumulator(pybind11::object fileObject, bool binary)
+  PyFileAccumulator(nanobind::object fileObject, bool binary)
       : pyWriteFunction(fileObject.attr("write")), binary(binary) {}
 
   void *getUserData() { return this; }
 
   MlirStringCallback getCallback() {
     return [](MlirStringRef part, void *userData) {
-      pybind11::gil_scoped_acquire();
+      nanobind::gil_scoped_acquire();
       PyFileAccumulator *accum = static_cast<PyFileAccumulator *>(userData);
       if (accum->binary) {
         // Note: Still has to copy and not avoidable with this API.
-        pybind11::bytes pyBytes(part.data, part.length);
+        nanobind::bytes pyBytes(part.data, part.length);
         accum->pyWriteFunction(pyBytes);
       } else {
-        pybind11::str pyStr(part.data,
+        nanobind::str pyStr(part.data,
                             part.length); // Decodes as UTF-8 by default.
         accum->pyWriteFunction(pyStr);
       }
@@ -57,37 +53,37 @@ public:
   }
 
 private:
-  pybind11::object pyWriteFunction;
+  nanobind::object pyWriteFunction;
   bool binary;
 };
 } // namespace python
 } // namespace circt
 
-namespace pybind11 {
+namespace nanobind {
 
 /// Raises a python exception with the given message.
 /// Correct usage:
 //   throw RaiseValueError(PyExc_ValueError, "Foobar'd");
-inline pybind11::error_already_set raisePyError(PyObject *exc_class,
-                                                const char *message) {
+inline nanobind::python_error raisePyError(PyObject *exc_class,
+                                           const char *message) {
   PyErr_SetString(exc_class, message);
-  return pybind11::error_already_set();
+  return nanobind::python_error();
 }
 
 /// Raises a value error with the given message.
 /// Correct usage:
 ///   throw RaiseValueError("Foobar'd");
-inline pybind11::error_already_set raiseValueError(const char *message) {
+inline nanobind::python_error raiseValueError(const char *message) {
   return raisePyError(PyExc_ValueError, message);
 }
 
 /// Raises a value error with the given message.
 /// Correct usage:
 ///   throw RaiseValueError(message);
-inline pybind11::error_already_set raiseValueError(const std::string &message) {
+inline nanobind::python_error raiseValueError(const std::string &message) {
   return raisePyError(PyExc_ValueError, message.c_str());
 }
 
-} // namespace pybind11
+} // namespace nanobind
 
 #endif // CIRCT_BINDINGS_PYTHON_PYBINDUTILS_H

--- a/lib/Bindings/Python/RTGModule.cpp
+++ b/lib/Bindings/Python/RTGModule.cpp
@@ -1,4 +1,4 @@
-//===- RTGModule.cpp - RTG API pybind module ------------------------------===//
+//===- RTGModule.cpp - RTG API nanobind module ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,56 +10,55 @@
 
 #include "circt-c/Dialect/RTG.h"
 
-#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "mlir/Bindings/Python/NanobindAdaptors.h"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
 
 using namespace circt;
-using namespace mlir::python::adaptors;
+using namespace mlir::python::nanobind_adaptors;
 
 /// Populate the rtg python module.
-void circt::python::populateDialectRTGSubmodule(py::module &m) {
+void circt::python::populateDialectRTGSubmodule(nb::module_ &m) {
   m.doc() = "RTG dialect Python native extension";
 
   mlir_type_subclass(m, "SequenceType", rtgTypeIsASequence)
       .def_classmethod(
           "get",
-          [](py::object cls, MlirContext ctxt) {
+          [](nb::object cls, MlirContext ctxt) {
             return cls(rtgSequenceTypeGet(ctxt));
           },
-          py::arg("self"), py::arg("ctxt") = nullptr);
+          nb::arg("self"), nb::arg("ctxt") = nullptr);
 
   mlir_type_subclass(m, "LabelType", rtgTypeIsALabel)
       .def_classmethod(
           "get",
-          [](py::object cls, MlirContext ctxt) {
+          [](nb::object cls, MlirContext ctxt) {
             return cls(rtgLabelTypeGet(ctxt));
           },
-          py::arg("self"), py::arg("ctxt") = nullptr);
+          nb::arg("self"), nb::arg("ctxt") = nullptr);
 
   mlir_type_subclass(m, "SetType", rtgTypeIsASet)
       .def_classmethod(
           "get",
-          [](py::object cls, MlirType elementType) {
+          [](nb::object cls, MlirType elementType) {
             return cls(rtgSetTypeGet(elementType));
           },
-          py::arg("self"), py::arg("element_type"));
+          nb::arg("self"), nb::arg("element_type"));
 
   mlir_type_subclass(m, "BagType", rtgTypeIsABag)
       .def_classmethod(
           "get",
-          [](py::object cls, MlirType elementType) {
+          [](nb::object cls, MlirType elementType) {
             return cls(rtgBagTypeGet(elementType));
           },
-          py::arg("self"), py::arg("element_type"));
+          nb::arg("self"), nb::arg("element_type"));
 
   mlir_type_subclass(m, "DictType", rtgTypeIsADict)
       .def_classmethod(
           "get",
-          [](py::object cls, MlirContext ctxt,
+          [](nb::object cls, MlirContext ctxt,
              const std::vector<std::pair<MlirAttribute, MlirType>> &entries) {
             std::vector<MlirAttribute> names;
             std::vector<MlirType> types;
@@ -70,7 +69,7 @@ void circt::python::populateDialectRTGSubmodule(py::module &m) {
             return cls(
                 rtgDictTypeGet(ctxt, types.size(), names.data(), types.data()));
           },
-          py::arg("self"), py::arg("ctxt") = nullptr,
-          py::arg("entries") =
+          nb::arg("self"), nb::arg("ctxt") = nullptr,
+          nb::arg("entries") =
               std::vector<std::pair<MlirAttribute, MlirType>>());
 }

--- a/lib/Bindings/Python/RTGTestModule.cpp
+++ b/lib/Bindings/Python/RTGTestModule.cpp
@@ -1,4 +1,4 @@
-//===- RTGTestModule.cpp - RTGTest API pybind module ----------------------===//
+//===- RTGTestModule.cpp - RTGTest API nanobind module --------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,35 +10,33 @@
 
 #include "circt-c/Dialect/RTGTest.h"
 
-#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "mlir/Bindings/Python/NanobindAdaptors.h"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
 
 using namespace circt;
-using namespace mlir::python::adaptors;
+using namespace mlir::python::nanobind_adaptors;
 
 /// Populate the rtgtest python module.
-void circt::python::populateDialectRTGTestSubmodule(py::module &m) {
+void circt::python::populateDialectRTGTestSubmodule(nb::module_ &m) {
   m.doc() = "RTGTest dialect Python native extension";
 
   mlir_type_subclass(m, "CPUType", rtgtestTypeIsACPU)
       .def_classmethod(
           "get",
-          [](py::object cls, MlirContext ctxt) {
+          [](nb::object cls, MlirContext ctxt) {
             return cls(rtgtestCPUTypeGet(ctxt));
           },
-          py::arg("self"), py::arg("ctxt") = nullptr);
+          nb::arg("self"), nb::arg("ctxt") = nullptr);
 
   mlir_attribute_subclass(m, "CPUAttr", rtgtestAttrIsACPU)
       .def_classmethod(
           "get",
-          [](py::object cls, unsigned id, MlirContext ctxt) {
+          [](nb::object cls, unsigned id, MlirContext ctxt) {
             return cls(rtgtestCPUAttrGet(ctxt, id));
           },
-          py::arg("self"), py::arg("id"), py::arg("ctxt") = nullptr)
+          nb::arg("self"), nb::arg("id"), nb::arg("ctxt") = nullptr)
       .def_property_readonly(
           "id", [](MlirAttribute self) { return rtgtestCPUAttrGetId(self); });
 }

--- a/lib/Bindings/Python/RTGToolModule.cpp
+++ b/lib/Bindings/Python/RTGToolModule.cpp
@@ -1,4 +1,4 @@
-//===- RTGToolModule.cpp - RTG Tool API pybind module ---------------------===//
+//===- RTGToolModule.cpp - RTG Tool API nanobind module -------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,12 +10,10 @@
 
 #include "circt-c/RtgTool.h"
 
-#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "mlir/Bindings/Python/NanobindAdaptors.h"
 
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
 
 using namespace circt;
 
@@ -75,48 +73,48 @@ private:
 } // namespace
 
 /// Populate the rtgtool python module.
-void circt::python::populateDialectRTGToolSubmodule(py::module &m) {
+void circt::python::populateDialectRTGToolSubmodule(nb::module_ &m) {
   m.doc() = "RTGTool Python native extension";
 
-  py::enum_<CirctRtgToolOutputFormat>(m, "OutputFormat")
+  nb::enum_<CirctRtgToolOutputFormat>(m, "OutputFormat")
       .value("MLIR", CIRCT_RTGTOOL_OUTPUT_FORMAT_MLIR)
       .value("ELABORATED_MLIR", CIRCT_RTGTOOL_OUTPUT_FORMAT_ELABORATED_MLIR)
       .value("ASM", CIRCT_RTGTOOL_OUTPUT_FORMAT_ASM);
 
-  py::class_<PyRtgToolOptions>(m, "Options")
-      .def(py::init<unsigned, CirctRtgToolOutputFormat, bool, bool,
+  nb::class_<PyRtgToolOptions>(m, "Options")
+      .def(nb::init<unsigned, CirctRtgToolOutputFormat, bool, bool,
                     const std::vector<const char *> &, const std::string &>(),
-           py::arg("seed"),
-           py::arg("output_format") = CIRCT_RTGTOOL_OUTPUT_FORMAT_ASM,
-           py::arg("verify_passes") = true,
-           py::arg("verbose_pass_execution") = false,
-           py::arg("unsupported_instructions") = std::vector<const char *>(),
-           py::arg("unsupported_instructions_file") = "")
+           nb::arg("seed"),
+           nb::arg("output_format") = CIRCT_RTGTOOL_OUTPUT_FORMAT_ASM,
+           nb::arg("verify_passes") = true,
+           nb::arg("verbose_pass_execution") = false,
+           nb::arg("unsupported_instructions") = std::vector<const char *>(),
+           nb::arg("unsupported_instructions_file") = "")
       .def("set_output_format", &PyRtgToolOptions::setOutputFormat,
-           "Specify the output format of the tool", py::arg("format"))
+           "Specify the output format of the tool", nb::arg("format"))
       .def("set_seed", &PyRtgToolOptions::setSeed,
-           "Specify the seed for all RNGs used in the tool", py::arg("seed"))
+           "Specify the seed for all RNGs used in the tool", nb::arg("seed"))
       .def("set_verify_passes", &PyRtgToolOptions::setVerifyPasses,
            "Specify whether the verifiers should be run after each pass",
-           py::arg("enable"))
+           nb::arg("enable"))
       .def("set_verbose_pass_execution",
            &PyRtgToolOptions::setVerbosePassExecution,
            "Specify whether passes should run in verbose mode",
-           py::arg("enable"))
+           nb::arg("enable"))
       .def("set_unsupported_instructions",
            &PyRtgToolOptions::setUnsupportedInstructions,
            "Set the list of of instructions unsupported by the assembler",
-           py::arg("instructions"))
+           nb::arg("instructions"))
       .def("add_unsupported_instruction",
            &PyRtgToolOptions::addUnsupportedInstruction,
            "Add the instruction given by name to the list of instructions not "
            "supported by the assembler",
-           py::arg("instruction_name"))
+           nb::arg("instruction_name"))
       .def("set_unsupported_instructions_file",
            &PyRtgToolOptions::setUnsupportedInstructionsFile,
            "Register a file containing a comma-separated list of instruction "
            "names which are not supported by the assembler.",
-           py::arg("filename"));
+           nb::arg("filename"));
 
   m.def("populate_randomizer_pipeline",
         [](MlirPassManager pm, const PyRtgToolOptions &options) {

--- a/lib/Bindings/Python/SVModule.cpp
+++ b/lib/Bindings/Python/SVModule.cpp
@@ -1,4 +1,4 @@
-//===- SVModule.cpp - SV API pybind module --------------------------------===//
+//===- SVModule.cpp - SV API nanobind module ------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,55 +11,60 @@
 #include "circt-c/Dialect/SV.h"
 #include "mlir-c/Bindings/Python/Interop.h"
 
-#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "mlir/Bindings/Python/NanobindAdaptors.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Support.h"
 
 #include "llvm/ADT/SmallVector.h"
 
-#include "PybindUtils.h"
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-namespace py = pybind11;
+#include "NanobindUtils.h"
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+namespace nb = nanobind;
 
-using namespace mlir::python::adaptors;
+using namespace mlir::python::nanobind_adaptors;
 
-void circt::python::populateDialectSVSubmodule(py::module &m) {
+void circt::python::populateDialectSVSubmodule(nb::module_ &m) {
   m.doc() = "SV Python Native Extension";
 
   mlir_attribute_subclass(m, "SVAttributeAttr", svAttrIsASVAttributeAttr)
       .def_classmethod(
           "get",
-          [](py::object cls, std::string name, py::object expressionObj,
-             bool emitAsComment, MlirContext ctxt) {
+          [](nb::object cls, std::string name, nb::object expressionObj,
+             nb::object emitAsCommentObj, MlirContext ctxt) {
+            // Set emitAsComment from optional boolean flag.
+            bool emitAsComment = false;
+            if (!emitAsCommentObj.is_none())
+              emitAsComment = nb::cast<bool>(emitAsCommentObj);
+
             // Need temporary storage for casted string.
             std::string expr;
             MlirStringRef expression = {nullptr, 0};
             if (!expressionObj.is_none()) {
-              expr = expressionObj.cast<std::string>();
+              expr = nb::cast<std::string>(expressionObj);
               expression = mlirStringRefCreateFromCString(expr.c_str());
             }
             return cls(svSVAttributeAttrGet(
                 ctxt, mlirStringRefCreateFromCString(name.c_str()), expression,
                 emitAsComment));
           },
-          "Create a SystemVerilog attribute", py::arg(), py::arg("name"),
-          py::arg("expression") = py::none(),
-          py::arg("emit_as_comment") = py::none(), py::arg("ctxt") = py::none())
+          "Create a SystemVerilog attribute", nb::arg(), nb::arg("name"),
+          nb::arg("expression") = nb::none(),
+          nb::arg("emit_as_comment") = nb::none(), nb::arg("ctxt") = nb::none())
       .def_property_readonly("name",
                              [](MlirAttribute self) {
                                MlirStringRef name =
                                    svSVAttributeAttrGetName(self);
                                return std::string(name.data, name.length);
                              })
-      .def_property_readonly(
-          "expression",
-          [](MlirAttribute self) -> py::object {
-            MlirStringRef name = svSVAttributeAttrGetExpression(self);
-            if (name.data == nullptr)
-              return py::none();
-            return py::str(std::string(name.data, name.length));
-          })
+      .def_property_readonly("expression",
+                             [](MlirAttribute self) -> nb::object {
+                               MlirStringRef name =
+                                   svSVAttributeAttrGetExpression(self);
+                               if (name.data == nullptr)
+                                 return nb::none();
+                               return nb::str(name.data, name.length);
+                             })
       .def_property_readonly("emit_as_comment", [](MlirAttribute self) {
         return svSVAttributeAttrGetEmitAsComment(self);
       });

--- a/lib/Bindings/Python/SeqModule.cpp
+++ b/lib/Bindings/Python/SeqModule.cpp
@@ -1,4 +1,4 @@
-//===- SeqModule.cpp - Seq API pybind module ------------------------------===//
+//===- SeqModule.cpp - Seq API nanobind module ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,34 +9,32 @@
 #include "CIRCTModules.h"
 
 #include "circt-c/Dialect/Seq.h"
-#include "mlir/Bindings/Python/PybindAdaptors.h"
+#include "mlir/Bindings/Python/NanobindAdaptors.h"
 
-#include "PybindUtils.h"
+#include "NanobindUtils.h"
 #include "mlir-c/Support.h"
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
-#include <pybind11/stl.h>
+#include <nanobind/nanobind.h>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 using namespace circt;
-using namespace mlir::python::adaptors;
+using namespace mlir::python::nanobind_adaptors;
 
 /// Populate the seq python module.
-void circt::python::populateDialectSeqSubmodule(py::module &m) {
+void circt::python::populateDialectSeqSubmodule(nb::module_ &m) {
   m.doc() = "Seq dialect Python native extension";
 
   mlir_type_subclass(m, "ClockType", seqTypeIsAClock)
       .def_classmethod(
           "get",
-          [](py::object cls, MlirContext ctx) {
+          [](nb::object cls, MlirContext ctx) {
             return cls(seqClockTypeGet(ctx));
           },
-          py::arg("cls"), py::arg("context") = py::none());
+          nb::arg("cls"), nb::arg("context") = nb::none());
 
   mlir_type_subclass(m, "ImmutableType", seqTypeIsAImmutable)
       .def_classmethod("get",
-                       [](py::object cls, MlirType innerType) {
+                       [](nb::object cls, MlirType innerType) {
                          return cls(seqImmutableTypeGet(innerType));
                        })
       .def_property_readonly("inner_type", [](MlirType self) {


### PR DESCRIPTION
This follows the general nanobind porting guide and the upstream MLIR changes in the same vein. For the most part, this is a very direct migration accomplished with sed.

There were a couple minor differences.

Nanobind is more strict about implicit casting, which popped up in a couple places:

* In MSFTModule, getNearestFreeInColumn was expecting a CIRCTMSFTPrimitiveType (int), but was actually being passed PrimitiveType enums at the call sites. Nanobind refused to automatically cast enum to int, so it was done manually.
* In SVModule, SVAttributeAttr.get was expecting a bool for emitAsComment, even though it was declared as having a default of None. Nanobind refused to automatically cast None to bool, so it was done manually, with a default of false.

Nanobind also prints enums slightly differently, so one FileCheck test had to be updated for ESI.

Otherwise, the changes were purely mechanical.