### PR TITLE
[FIRRTL][Inliner] Don't remove modules with symbol uses

### DIFF
--- a/test/Dialect/FIRRTL/inliner.mlir
+++ b/test/Dialect/FIRRTL/inliner.mlir
@@ -1413,3 +1413,16 @@ firrtl.circuit "InlineBlocks" {
     firrtl.ref.define %o, %c_p : !firrtl.probe<uint<8>, @I::@J>
   }
 }
+
+// -----
+
+// The inliner must not delete modules which are still referenced, even in unknown ops.
+firrtl.circuit "FormalMarkerIsUse" {
+  firrtl.extmodule @FormalMarkerIsUse()
+  firrtl.formal @Test, @Foo {}
+  "some_unknown_dialect.op"() { magic = @Bar } : () -> ()
+  firrtl.module private @Foo() {}
+  firrtl.module private @Bar() {}
+  // CHECK: firrtl.module private @Foo
+  // CHECK: firrtl.module private @Bar
+}


### PR DESCRIPTION
Fix an issue in the FIRRTL inliner where modules would be removed even if some other top-level operations still had references to their symbol name.