### PR TITLE
[FIRRTL][IMCP] Overdefine ports of modules with unknown symbol uses

### DIFF
--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -200,11 +200,30 @@ public:
   InstanceGraph(const InstanceGraph &) = delete;
   virtual ~InstanceGraph() = default;
 
-  /// Look up an InstanceGraphNode for a module.
-  InstanceGraphNode *lookup(ModuleOpInterface op);
+  /// Lookup an module by name. Returns null if no module with the given name
+  /// exists in the instance graph.
+  InstanceGraphNode *lookupOrNull(StringAttr name);
 
-  /// Lookup an module by name.
-  InstanceGraphNode *lookup(StringAttr name);
+  /// Look up an InstanceGraphNode for a module. Returns null if the module has
+  /// not been added to the instance graph.
+  InstanceGraphNode *lookupOrNull(ModuleOpInterface op) {
+    return lookup(op.getModuleNameAttr());
+  }
+
+  /// Look up an InstanceGraphNode for a module. Aborts if the module does not
+  /// exist.
+  InstanceGraphNode *lookup(ModuleOpInterface op) {
+    auto *node = lookupOrNull(op);
+    assert(node != nullptr && "Module not in InstanceGraph!");
+    return node;
+  }
+
+  /// Lookup an module by name. Aborts if the module does not exist.
+  InstanceGraphNode *lookup(StringAttr name) {
+    auto *node = lookupOrNull(name);
+    assert(node != nullptr && "Module not in InstanceGraph!");
+    return node;
+  }
 
   /// Lookup an InstanceGraphNode for a module.
   InstanceGraphNode *operator[](ModuleOpInterface op) { return lookup(op); }

--- a/lib/Support/InstanceGraph.cpp
+++ b/lib/Support/InstanceGraph.cpp
@@ -106,14 +106,11 @@ void InstanceGraph::erase(InstanceGraphNode *node) {
   nodes.erase(node);
 }
 
-InstanceGraphNode *InstanceGraph::lookup(StringAttr name) {
+InstanceGraphNode *InstanceGraph::lookupOrNull(StringAttr name) {
   auto it = nodeMap.find(name);
-  assert(it != nodeMap.end() && "Module not in InstanceGraph!");
+  if (it == nodeMap.end())
+    return nullptr;
   return it->second;
-}
-
-InstanceGraphNode *InstanceGraph::lookup(ModuleOpInterface op) {
-  return lookup(cast<ModuleOpInterface>(op).getModuleNameAttr());
 }
 
 void InstanceGraph::replaceInstance(InstanceOpInterface inst,


### PR DESCRIPTION
If a module is referenced from an unknown top-level operation, i.e. an operation that is not an `hw.hierpath`, mark the module's inputs as overdefined. IMCP cannot reason about how the module is used by such an unknown operation, and therefore should assume that the operation might instantiate the module and apply arbitrary values to its input.

As an example, the `firrtl.formal` operation may refer to a private module as to be executed as a formal test, applying symbolic values to the module's inputs. While IMCP could simply special-case the `firrtl.formal` operation, it feels cleaner to make the pass defensive in the presence of _any_ operation which it does not explicitly know how to deal with.