### PR TITLE
[Pass] Remove unnecessary OperationPass<mlir::ModuleOp>

### DIFF
--- a/include/circt/Conversion/CombToArith.h
+++ b/include/circt/Conversion/CombToArith.h
@@ -20,7 +20,7 @@ namespace circt {
 void populateCombToArithConversionPatterns(TypeConverter &converter,
                                            RewritePatternSet &patterns);
 
-std::unique_ptr<OperationPass<ModuleOp>> createConvertCombToArithPass();
+std::unique_ptr<Pass> createConvertCombToArithPass();
 } // namespace circt
 
 #endif // CIRCT_CONVERSION_COMBTOARITH_H

--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -683,7 +683,7 @@ def ConvertToArcs : Pass<"convert-to-arcs", "mlir::ModuleOp"> {
 // ConvertCombToArith
 //===----------------------------------------------------------------------===//
 
-def ConvertCombToArith : Pass<"convert-comb-to-arith", "mlir::ModuleOp"> {
+def ConvertCombToArith : Pass<"convert-comb-to-arith"> {
   let summary = "Convert combinational ops and constants into arith ops";
   let constructor = "circt::createConvertCombToArithPass()";
   let dependentDialects = ["mlir::arith::ArithDialect"];
@@ -693,7 +693,7 @@ def ConvertCombToArith : Pass<"convert-comb-to-arith", "mlir::ModuleOp"> {
 // ConvertCombToSMT
 //===----------------------------------------------------------------------===//
 
-def ConvertCombToSMT : Pass<"convert-comb-to-smt", "mlir::ModuleOp"> {
+def ConvertCombToSMT : Pass<"convert-comb-to-smt"> {
   let summary = "Convert combinational ops and constants to SMT ops";
   // Need to depend on HWDialect because some 'comb' canonicalization patterns
   // build 'hw.constant' operations.

--- a/include/circt/Dialect/Comb/Passes.td
+++ b/include/circt/Dialect/Comb/Passes.td
@@ -11,7 +11,7 @@
 
 include "mlir/Pass/PassBase.td"
 
-def LowerComb : Pass<"lower-comb", "mlir::ModuleOp"> {
+def LowerComb : Pass<"lower-comb"> {
   let summary = "Lowers the some of the comb ops";
   let description = [{
     Some operations in the comb dialect (e.g. `comb.truth_table`) are not

--- a/lib/Conversion/CombToArith/CombToArith.cpp
+++ b/lib/Conversion/CombToArith/CombToArith.cpp
@@ -340,6 +340,6 @@ void ConvertCombToArithPass::runOnOperation() {
     signalPassFailure();
 }
 
-std::unique_ptr<OperationPass<ModuleOp>> circt::createConvertCombToArithPass() {
+std::unique_ptr<Pass> circt::createConvertCombToArithPass() {
   return std::make_unique<ConvertCombToArithPass>();
 }

--- a/lib/Dialect/Comb/Transforms/LowerComb.cpp
+++ b/lib/Dialect/Comb/Transforms/LowerComb.cpp
@@ -75,7 +75,7 @@ public:
 } // namespace
 
 void LowerCombPass::runOnOperation() {
-  ModuleOp module = getOperation();
+  auto module = getOperation();
 
   ConversionTarget target(getContext());
   RewritePatternSet patterns(&getContext());


### PR DESCRIPTION
This commit replaces `OperationPass<mlir::ModuleOp>` with `Pass`.

CombToArith, CombToSMT and LowerComb were restricted to run on `mlir::ModuleOp` but as far as I see they are all implemented with Conversion framework and only perform local mutations (no change in func.func or hw.module). Please correct me if I'm wrong but we can remove the restriction.