### PR TITLE
[FIRRTL] GrandCentral: set iface output_file based on parent.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -2565,6 +2565,8 @@ void GrandCentralPass::runOnOperation() {
     numXMRs += xmrElems.size();
 
     sv::InterfaceOp topIface;
+    auto containingOutputFileAttr =
+        viewParentMod->getAttrOfType<hw::OutputFileAttr>("output_file");
     for (const auto &ifaceBuilder : interfaceBuilder) {
       auto builder = OpBuilder::atBlockEnd(getOperation().getBodyBlock());
       auto loc = getOperation().getLoc();
@@ -2573,6 +2575,11 @@ void GrandCentralPass::runOnOperation() {
       if (!topIface)
         topIface = iface;
       ++numInterfaces;
+
+      // Propagate output_file information from parent to the interface.
+      // Require/expect "AssignOutputDirs" ran before this.
+      if (containingOutputFileAttr)
+        iface->setAttr("output_file", containingOutputFileAttr);
 
       iface.setCommentAttr(builder.getStringAttr("VCS coverage exclude_file"));
       builder.setInsertionPointToEnd(

--- a/test/Dialect/FIRRTL/grand-central-view.mlir
+++ b/test/Dialect/FIRRTL/grand-central-view.mlir
@@ -551,15 +551,15 @@ firrtl.circuit "SetOutputDir" {
 // CHECK-NEXT: !sv.interface<@[[OUTSYM_2:.+]]>
 
 // CHECK: sv.interface @[[OUTSYM_1]]
-// CHECK-SAME: output_file = #hw.output_file<"path/">
+// CHECK-SAME: output_file = #hw.output_file<"path{{/|\\\\}}">
 // CHECK: sv.verbatim "[[SUB_1:.+]] sub();"
 
 // CHECK: sv.interface @[[SUB_1]]
-// CHECK-SAME: output_file = #hw.output_file<"path/">
+// CHECK-SAME: output_file = #hw.output_file<"path{{/|\\\\}}">
 
 // CHECK: sv.interface @[[OUTSYM_2]]
-// CHECK-SAME: output_file = #hw.output_file<"other/", excludeFromFileList>
+// CHECK-SAME: output_file = #hw.output_file<"other{{/|\\\\}}", excludeFromFileList>
 // CHECK: sv.verbatim "[[SUB_2:.+]] sub();"
 
 // CHECK: sv.interface @[[SUB_2]]
-// CHECK-SAME: output_file = #hw.output_file<"other/", excludeFromFileList>
+// CHECK-SAME: output_file = #hw.output_file<"other{{/|\\\\}}", excludeFromFileList>

--- a/test/Dialect/FIRRTL/grand-central-view.mlir
+++ b/test/Dialect/FIRRTL/grand-central-view.mlir
@@ -511,3 +511,55 @@ firrtl.circuit "NoInterfaces" attributes {
 // CHECK-LABEL: module {
 // CHECK:         sv.verbatim
 // CHECK-SAME:      []
+
+// -----
+
+firrtl.circuit "SetOutputDir" {
+  firrtl.module @SetOutputDir() attributes {output_file = #hw.output_file<"path/">} {
+    firrtl.view "view", <{
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "MyViewInterface",
+      elements = [{
+        class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+        defName = "SubInterface",
+        name = "sub",
+        elements = []
+      }]
+    }>
+  }
+
+  firrtl.module @ExcludeFromFileList() attributes {output_file = #hw.output_file<"other/", excludeFromFileList>} {
+    firrtl.view "view", <{
+      class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+      defName = "MyViewInterface",
+      elements = [{
+        class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+        defName = "SubInterface",
+        name = "sub",
+        elements = []
+      }]
+    }>
+  }
+}
+
+// CHECK-LABEL: "SetOutputDir"
+
+// CHECK: module @SetOutputDir()
+// CHECK-NEXT: !sv.interface<@[[OUTSYM_1:.+]]>
+
+// CHECK: module @ExcludeFromFileList()
+// CHECK-NEXT: !sv.interface<@[[OUTSYM_2:.+]]>
+
+// CHECK: sv.interface @[[OUTSYM_1]]
+// CHECK-SAME: output_file = #hw.output_file<"path/">
+// CHECK: sv.verbatim "[[SUB_1:.+]] sub();"
+
+// CHECK: sv.interface @[[SUB_1]]
+// CHECK-SAME: output_file = #hw.output_file<"path/">
+
+// CHECK: sv.interface @[[OUTSYM_2]]
+// CHECK-SAME: output_file = #hw.output_file<"other/", excludeFromFileList>
+// CHECK: sv.verbatim "[[SUB_2:.+]] sub();"
+
+// CHECK: sv.interface @[[SUB_2]]
+// CHECK-SAME: output_file = #hw.output_file<"other/", excludeFromFileList>


### PR DESCRIPTION
Simply propagate the "output_file" information entirely to any generated sv.interface created during lowering.

cc #8112 .

No change of behavior for annotation-based views.