### PR TITLE
Add passes to strip OM and Emit dialect ops

### DIFF
--- a/include/circt/Dialect/Emit/CMakeLists.txt
+++ b/include/circt/Dialect/Emit/CMakeLists.txt
@@ -5,9 +5,6 @@
 ## SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ##
 ##===----------------------------------------------------------------------===//
-##
-##
-##===----------------------------------------------------------------------===//
 
 add_circt_dialect(Emit emit)
 add_circt_dialect_doc(Emit emit)
@@ -18,3 +15,8 @@ mlir_tablegen(EmitOpInterfaces.h.inc -gen-op-interface-decls)
 mlir_tablegen(EmitOpInterfaces.cpp.inc -gen-op-interface-defs)
 add_public_tablegen_target(CIRCTEmitOpInterfacesIncGen)
 add_dependencies(circt-headers CIRCTEmitOpInterfacesIncGen)
+
+set(LLVM_TARGET_DEFINITIONS EmitPasses.td)
+mlir_tablegen(EmitPasses.h.inc -gen-pass-decls)
+add_public_tablegen_target(CIRCTEmitTransformsIncGen)
+add_circt_doc(EmitPasses EmitPasses -gen-pass-doc)

--- a/include/circt/Dialect/Emit/EmitPasses.h
+++ b/include/circt/Dialect/Emit/EmitPasses.h
@@ -1,4 +1,4 @@
-//===- OMPasses.h - OM dialect passes -------------------------------------===//
+//===- EmitPasses.h - Emit dialect passes ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CIRCT_DIALECT_OM_OMPASSES_H
-#define CIRCT_DIALECT_OM_OMPASSES_H
+#ifndef CIRCT_DIALECT_EMIT_EMITPASSES_H
+#define CIRCT_DIALECT_EMIT_EMITPASSES_H
 
 #include "circt/Support/LLVM.h"
 #include "mlir/Pass/Pass.h"
@@ -18,18 +18,13 @@ class Pass;
 } // namespace mlir
 
 namespace circt {
-namespace om {
-
-std::unique_ptr<mlir::Pass> createOMLinkModulesPass();
-std::unique_ptr<mlir::Pass> createFreezePathsPass(
-    std::function<StringAttr(Operation *)> getOpNameFallback = {});
-std::unique_ptr<mlir::Pass> createVerifyObjectFieldsPass();
+namespace emit {
 
 #define GEN_PASS_DECL
 #define GEN_PASS_REGISTRATION
-#include "circt/Dialect/OM/OMPasses.h.inc"
+#include "circt/Dialect/Emit/EmitPasses.h.inc"
 
-} // namespace om
+} // namespace emit
 } // namespace circt
 
-#endif // CIRCT_DIALECT_OM_OMPASSES_H
+#endif // CIRCT_DIALECT_EMIT_EMITPASSES_H

--- a/include/circt/Dialect/Emit/EmitPasses.td
+++ b/include/circt/Dialect/Emit/EmitPasses.td
@@ -1,0 +1,17 @@
+//===- EmitPasses.td - Emit dialect passes -----------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+include "mlir/Pass/PassBase.td"
+
+def StripEmitPass : Pass<"strip-emit", "mlir::ModuleOp"> {
+  let summary = "Remove Emit dialect ops";
+  let description = [{
+    Removes all Emit dialect operations from the IR. Useful as a prepass in
+    pipelines that have to discard Emit operations.
+  }];
+}

--- a/include/circt/Dialect/OM/OMPasses.td
+++ b/include/circt/Dialect/OM/OMPasses.td
@@ -33,3 +33,11 @@ def VerifyObjectFields: Pass<"om-verify-object-fields"> {
   }];
   let constructor = "circt::om::createVerifyObjectFieldsPass()";
 }
+
+def StripOMPass : Pass<"strip-om", "mlir::ModuleOp"> {
+  let summary = "Remove OM information";
+  let description = [{
+    Removes all OM operations from the IR. Useful as a prepass in pipelines that
+    have to discard OM.
+  }];
+}

--- a/include/circt/InitAllPasses.h
+++ b/include/circt/InitAllPasses.h
@@ -22,6 +22,7 @@
 #include "circt/Dialect/Comb/CombPasses.h"
 #include "circt/Dialect/DC/DCPasses.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
+#include "circt/Dialect/Emit/EmitPasses.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/FSM/FSMPasses.h"
 #include "circt/Dialect/HW/HWPasses.h"
@@ -64,24 +65,25 @@ inline void registerAllPasses() {
   calyx::registerPasses();
   comb::registerPasses();
   dc::registerPasses();
+  emit::registerPasses();
   esi::registerESIPasses();
   firrtl::registerPasses();
   fsm::registerPasses();
+  handshake::registerPasses();
+  hw::registerPasses();
+  kanagawa::registerPasses();
   llhd::registerPasses();
+  moore::registerPasses();
   msft::registerPasses();
   om::registerPasses();
-  seq::registerPasses();
-  sv::registerPasses();
-  handshake::registerPasses();
-  kanagawa::registerPasses();
-  rtg::registerPasses();
-  hw::registerPasses();
   pipeline::registerPasses();
+  rtg::registerPasses();
+  seq::registerPasses();
   sim::registerPasses();
   ssp::registerPasses();
+  sv::registerPasses();
   systemc::registerPasses();
   verif::registerPasses();
-  moore::registerPasses();
 }
 
 } // namespace circt

--- a/lib/Dialect/Arc/Transforms/StripSV.cpp
+++ b/lib/Dialect/Arc/Transforms/StripSV.cpp
@@ -9,8 +9,6 @@
 #include "circt/Dialect/Arc/ArcOps.h"
 #include "circt/Dialect/Arc/ArcPasses.h"
 #include "circt/Dialect/Comb/CombOps.h"
-#include "circt/Dialect/Emit/EmitDialect.h"
-#include "circt/Dialect/OM/OMDialect.h"
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
@@ -75,11 +73,6 @@ void StripSVPass::runOnOperation() {
   }
   LLVM_DEBUG(llvm::dbgs() << "Found " << clockGateModuleNames.size()
                           << " clock gates\n");
-
-  // Remove OM and Emit dialect nodes.
-  for (auto &op : llvm::make_early_inc_range(*mlirModule.getBody()))
-    if (isa<emit::EmitDialect, om::OMDialect>(op.getDialect()))
-      op.erase();
 
   // Remove `sv.*` operation attributes.
   mlirModule.walk([](Operation *op) {

--- a/lib/Dialect/Emit/CMakeLists.txt
+++ b/lib/Dialect/Emit/CMakeLists.txt
@@ -1,11 +1,8 @@
-##===- CMakeLists.txt - build definitions for Emit ------------*- cmake -*-===//
+##===- CMakeLists.txt - Emit dialect build definitions --------------------===//
 ##
 ## Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 ## See https://llvm.org/LICENSE.txt for license information.
 ## SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-##
-##===----------------------------------------------------------------------===//
-##
 ##
 ##===----------------------------------------------------------------------===//
 
@@ -29,3 +26,5 @@ add_circt_dialect_library(CIRCTEmit
   MLIRPass
   MLIRTransforms
 )
+
+add_subdirectory(Transforms)

--- a/lib/Dialect/Emit/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Emit/Transforms/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_circt_dialect_library(CIRCTEmitTransforms
+  StripEmit.cpp
+
+  DEPENDS
+  CIRCTEmitTransformsIncGen
+
+  LINK_LIBS PUBLIC
+  CIRCTEmit
+  CIRCTSupport
+  MLIRIR
+  MLIRPass
+  MLIRTransformUtils
+)

--- a/lib/Dialect/Emit/Transforms/StripEmit.cpp
+++ b/lib/Dialect/Emit/Transforms/StripEmit.cpp
@@ -1,0 +1,36 @@
+//===- StripEmit.cpp ------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Emit/EmitOps.h"
+#include "circt/Dialect/Emit/EmitPasses.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/Debug.h"
+
+namespace circt {
+namespace emit {
+#define GEN_PASS_DEF_STRIPEMITPASS
+#include "circt/Dialect/Emit/EmitPasses.h.inc"
+} // namespace emit
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+
+namespace {
+struct StripEmitPass : public emit::impl::StripEmitPassBase<StripEmitPass> {
+  void runOnOperation() override {
+    for (auto &op : llvm::make_early_inc_range(getOperation().getOps())) {
+      if (isa_and_nonnull<emit::EmitDialect>(op.getDialect())) {
+        op.erase();
+        continue;
+      }
+      op.removeAttr("emit.fragments");
+    }
+  }
+};
+} // namespace

--- a/lib/Dialect/OM/Transforms/CMakeLists.txt
+++ b/lib/Dialect/OM/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_dialect_library(CIRCTOMTransforms
   FreezePaths.cpp
   LinkModules.cpp
+  StripOM.cpp
   VerifyObjectFields.cpp
 
   DEPENDS

--- a/lib/Dialect/OM/Transforms/StripOM.cpp
+++ b/lib/Dialect/OM/Transforms/StripOM.cpp
@@ -1,0 +1,32 @@
+//===- StripOM.cpp --------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/OM/OMOps.h"
+#include "circt/Dialect/OM/OMPasses.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/Debug.h"
+
+namespace circt {
+namespace om {
+#define GEN_PASS_DEF_STRIPOMPASS
+#include "circt/Dialect/OM/OMPasses.h.inc"
+} // namespace om
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+
+namespace {
+struct StripOMPass : public om::impl::StripOMPassBase<StripOMPass> {
+  void runOnOperation() override {
+    for (auto &op : llvm::make_early_inc_range(getOperation().getOps()))
+      if (isa_and_nonnull<om::OMDialect>(op.getDialect()))
+        op.erase();
+  }
+};
+} // namespace

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CIRCT_TEST_DEPENDS
   circt-capi-rtg-test
   circt-capi-rtgtest-test
   circt-as
+  circt-bmc
   circt-dis
   circt-lec
   circt-opt

--- a/test/Dialect/Emit/strip-emit.mlir
+++ b/test/Dialect/Emit/strip-emit.mlir
@@ -1,0 +1,19 @@
+// RUN: circt-opt --strip-emit --allow-unregistered-dialect %s | FileCheck %s
+
+// CHECK-NOT: emit.file
+emit.file "foo.sv" {}
+
+// CHECK-NOT: emit.fragment
+emit.fragment @Bar {}
+
+// CHECK-NOT: emit.file_list
+emit.file_list "baz.f", []
+
+// CHECK: "some_unknown_dialect.op"
+"some_unknown_dialect.op"() {} : () -> ()
+
+// CHECK: hw.module @Baz
+// CHECK-NOT: emit.fragments
+hw.module @Baz() attributes {emit.fragments = [@Bar]} {
+  hw.output
+}

--- a/test/Dialect/OM/strip-om.mlir
+++ b/test/Dialect/OM/strip-om.mlir
@@ -1,0 +1,12 @@
+// RUN: circt-opt --strip-om --allow-unregistered-dialect %s | FileCheck %s
+
+// CHECK-NOT: om.class
+om.class @Foo() {
+  om.class.fields
+}
+
+// CHECK-NOT: om.class.extern
+om.class.extern @Bar() {}
+
+// CHECK: "some_unknown_dialect.op"
+"some_unknown_dialect.op"() {} : () -> ()

--- a/test/Tools/circt-bmc/commandline.mlir
+++ b/test/Tools/circt-bmc/commandline.mlir
@@ -1,0 +1,3 @@
+// RUN: circt-bmc --help | FileCheck %s
+
+// CHECK: OVERVIEW: circt-bmc - bounded model checker

--- a/test/Tools/circt-lec/commandline.mlir
+++ b/test/Tools/circt-lec/commandline.mlir
@@ -1,0 +1,3 @@
+// RUN: circt-lec --help | FileCheck %s
+
+// CHECK: OVERVIEW: circt-lec - logical equivalence checker

--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -9,21 +9,21 @@ set(LLVM_LINK_COMPONENTS Support ${ARCILATOR_JIT_LLVM_COMPONENTS})
 
 set(libs
   CIRCTArc
-  CIRCTHWTransforms
   CIRCTArcToLLVM
   CIRCTArcTransforms
   CIRCTCombToArith
   CIRCTConvertToArcs
-  CIRCTEmit
+  CIRCTEmitTransforms
   CIRCTExportArc
-  CIRCTOM
+  CIRCTHWTransforms
   CIRCTLLHD
-  CIRCTVerif
+  CIRCTOMTransforms
   CIRCTSeqToSV
   CIRCTSeqTransforms
   CIRCTSimTransforms
   CIRCTSupport
   CIRCTTransforms
+  CIRCTVerif
   MLIRArithDialect
   MLIRBuiltinToLLVMIRTranslation
   MLIRControlFlowDialect

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -23,9 +23,11 @@
 #include "circt/Dialect/Arc/ModelInfoExport.h"
 #include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/Emit/EmitDialect.h"
+#include "circt/Dialect/Emit/EmitPasses.h"
 #include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Dialect/LLHD/IR/LLHDDialect.h"
 #include "circt/Dialect/OM/OMDialect.h"
+#include "circt/Dialect/OM/OMPasses.h"
 #include "circt/Dialect/SV/SVDialect.h"
 #include "circt/Dialect/Seq/SeqPasses.h"
 #include "circt/Dialect/Sim/SimDialect.h"
@@ -252,6 +254,8 @@ static void populateHwModuleToArcPipeline(PassManager &pm) {
   // represented as intrinsic ops.
   if (untilReached(UntilPreprocessing))
     return;
+  pm.addPass(om::createStripOMPass());
+  pm.addPass(emit::createStripEmitPass());
   pm.addPass(createLowerFirMemPass());
   {
     arc::AddTapsOptions opts;

--- a/tools/circt-bmc/CMakeLists.txt
+++ b/tools/circt-bmc/CMakeLists.txt
@@ -13,25 +13,27 @@ add_circt_tool(circt-bmc circt-bmc.cpp)
 target_link_libraries(circt-bmc
   PRIVATE
   CIRCTBMCTransforms
-  CIRCTSMTToZ3LLVM
-  CIRCTHWToSMT
-  CIRCTCombToSMT
-  CIRCTVerifToSMT
   CIRCTComb
+  CIRCTCombToSMT
+  CIRCTEmitTransforms
   CIRCTHW
+  CIRCTHWToSMT
+  CIRCTOMTransforms
   CIRCTSeq
   CIRCTSMT
-  CIRCTVerif
+  CIRCTSMTToZ3LLVM
   CIRCTSupport
-  MLIRIR
-  MLIRFuncDialect
+  CIRCTVerif
+  CIRCTVerifToSMT
+  LLVMSupport
   MLIRArithDialect
+  MLIRBuiltinToLLVMIRTranslation
+  MLIRFuncDialect
+  MLIRFuncInlinerExtension
+  MLIRIR
   MLIRLLVMIRTransforms
   MLIRLLVMToLLVMIRTranslation
   MLIRTargetLLVMIRExport
-  MLIRFuncInlinerExtension
-  MLIRBuiltinToLLVMIRTranslation
-  LLVMSupport
 
   ${CIRCT_BMC_JIT_DEPS}
 )

--- a/tools/circt-lec/CMakeLists.txt
+++ b/tools/circt-lec/CMakeLists.txt
@@ -12,26 +12,28 @@ set(LLVM_LINK_COMPONENTS Support ${CIRCT_LEC_JIT_LLVM_COMPONENTS})
 add_circt_tool(circt-lec circt-lec.cpp)
 target_link_libraries(circt-lec
   PRIVATE
-  CIRCTLECTransforms
-  CIRCTSMTToZ3LLVM
-  CIRCTHWToSMT
-  CIRCTCombToSMT
-  CIRCTVerifToSMT
   CIRCTComb
+  CIRCTCombToSMT
+  CIRCTEmitTransforms
   CIRCTHW
+  CIRCTHWToSMT
+  CIRCTLECTransforms
+  CIRCTOMTransforms
   CIRCTSMT
+  CIRCTSMTToZ3LLVM
   CIRCTSupport
   CIRCTVerif
-  MLIRIR
-  MLIRFuncDialect
+  CIRCTVerifToSMT
+  LLVMSupport
   MLIRArithDialect
+  MLIRBuiltinToLLVMIRTranslation
+  MLIRFuncDialect
+  MLIRFuncInlinerExtension
+  MLIRIR
   MLIRLLVMIRTransforms
   MLIRLLVMToLLVMIRTranslation
-  MLIRTargetLLVMIRExport
-  MLIRFuncInlinerExtension
-  MLIRBuiltinToLLVMIRTranslation
   MLIRLLVMToLLVMIRTranslation
-  LLVMSupport
+  MLIRTargetLLVMIRExport
 
   ${CIRCT_LEC_JIT_DEPS}
 )


### PR DESCRIPTION
Several tools in CIRCT do not process the OM and Emit dialects at all, for example, arcilator, circt-bmc, and circt-lec. Since these tools do a full lowering to LLVM internally, they have to discard all OM and Emit ops at some point in the pipeline. Arcilator currently does this in its StripSV pass; circt-bmc and circt-lec simply error out.

This commit adds a `StripOM` pass to the OM dialect and a `StripEmit` pass to the Emit dialect which remove any OM and Emit ops from the IR, respectively. These passes are added to the arcilator, circt-bmc, and circt-lec pipelines in order to discard OM and Emit from the input.

The commit also includes a few boilerplate changes and alphabetical ordering of dialects and dependencies.

@uenoku Maybe this is useful for `circt-synth` as well?