### PR TITLE
[README] Fix badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="docs/includes/img/circt-logo.svg"/></p>
 
-[![](https://github.com/llvm/circt/workflows/Build%20and%20Test/badge.svg?event=push)](https://github.com/llvm/circt/actions?query=workflow%3A%22Build+and+Test%22)
+[![](https://github.com/llvm/circt/actions/workflows/buildAndTest.yml/badge.svg?event=push)](https://github.com/llvm/circt/actions?query=workflow%3A%22Build+and+Test%22)
 [![Nightly integration tests](https://github.com/llvm/circt/workflows/Nightly%20integration%20tests/badge.svg)](https://github.com/llvm/circt/actions?query=workflow%3A%22Nightly+integration+tests%22)
 
 # ⚡️ "CIRCT" / Circuit IR Compilers and Tools


### PR DESCRIPTION
See https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name

Old(broken): https://github.com/llvm/circt/workflows/Build%20and%20Test/badge.svg?event=push
New: https://github.com/llvm/circt/actions/workflows/buildAndTest.yml/badge.svg?event=push