### PR TITLE
[SCFToCalyx] Lower floating point comparison logic fix

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -914,7 +914,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   case CombLogic::None: {
     // it's guaranteed to be either ORD or UNO
     outputValue = inputRegs[0].getOut();
-    doneValue = inputRegs[0].getOut();
+    doneValue = inputRegs[0].getDone();
     break;
   }
   case CombLogic::And: {

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -479,7 +479,7 @@ module {
 // CHECK-DAG:        calyx.assign %unordered_port_1_reg.write_en = %std_compareFN_1.done : i1
 // CHECK-DAG:        calyx.assign %unordered_port_1_reg.in = %std_compareFN_1.unordered : i1
 // CHECK-DAG:        calyx.assign %cmpf_1_reg.in = %unordered_port_1_reg.out : i1
-// CHECK-DAG:        calyx.assign %cmpf_1_reg.write_en = %unordered_port_1_reg.out : i1
+// CHECK-DAG:        calyx.assign %cmpf_1_reg.write_en = %unordered_port_1_reg.done : i1
 // CHECK-DAG:        %0 = comb.xor %std_compareFN_1.done, %true : i1
 // CHECK-DAG:        calyx.assign %std_compareFN_1.go = %0 ? %true : i1
 // CHECK-DAG:        calyx.group_done %cmpf_1_reg.done : i1

--- a/test/Conversion/SCFToCalyx/float_compare.mlir
+++ b/test/Conversion/SCFToCalyx/float_compare.mlir
@@ -334,7 +334,7 @@ module {
 // CHECK-DAG:         calyx.assign %std_not_0.in = %std_compareFN_0.unordered : i1
 // CHECK-DAG:         calyx.assign %unordered_port_0_reg.in = %std_not_0.out : i1
 // CHECK-DAG:         calyx.assign %cmpf_0_reg.in = %unordered_port_0_reg.out : i1
-// CHECK-DAG:         calyx.assign %cmpf_0_reg.write_en = %unordered_port_0_reg.out : i1
+// CHECK-DAG:         calyx.assign %cmpf_0_reg.write_en = %unordered_port_0_reg.done : i1
 // CHECK-DAG:         %0 = comb.xor %std_compareFN_0.done, %true : i1
 // CHECK-DAG:         calyx.assign %std_compareFN_0.go = %0 ? %true : i1
 // CHECK-DAG:         calyx.group_done %cmpf_0_reg.done : i1
@@ -643,7 +643,7 @@ module {
 // CHECK-DAG:         calyx.assign %unordered_port_0_reg.write_en = %std_compareFN_0.done : i1
 // CHECK-DAG:         calyx.assign %unordered_port_0_reg.in = %std_compareFN_0.unordered : i1
 // CHECK-DAG:         calyx.assign %cmpf_0_reg.in = %unordered_port_0_reg.out : i1
-// CHECK-DAG:         calyx.assign %cmpf_0_reg.write_en = %unordered_port_0_reg.out : i1
+// CHECK-DAG:         calyx.assign %cmpf_0_reg.write_en = %unordered_port_0_reg.done : i1
 // CHECK-DAG:         %0 = comb.xor %std_compareFN_0.done, %true : i1
 // CHECK-DAG:         calyx.assign %std_compareFN_0.go = %0 ? %true : i1
 // CHECK-DAG:         calyx.group_done %cmpf_0_reg.done : i1


### PR DESCRIPTION
This patch fixes the logic of assigning the `write_en` port of the `cmpf_reg`: it should be high when the input register is `done`.