### PR TITLE
[MemoryBanking] Adjust default dimension

### DIFF
--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -44,9 +44,9 @@ std::unique_ptr<mlir::Pass> createStripDebugInfoWithPredPass(
 std::unique_ptr<mlir::Pass> createMaximizeSSAPass();
 std::unique_ptr<mlir::Pass> createInsertMergeBlocksPass();
 std::unique_ptr<mlir::Pass> createPrintOpCountPass();
-std::unique_ptr<mlir::Pass> createMemoryBankingPass(
-    std::optional<unsigned> bankingFactor = std::nullopt,
-    std::optional<unsigned> bankingDimension = std::nullopt);
+std::unique_ptr<mlir::Pass>
+createMemoryBankingPass(std::optional<unsigned> bankingFactor = std::nullopt,
+                        std::optional<int> bankingDimension = std::nullopt);
 std::unique_ptr<mlir::Pass> createIndexSwitchToIfPass();
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -127,10 +127,10 @@ def MemoryBanking : Pass<"memory-banking", "::mlir::func::FuncOp"> {
   let summary = "Partition the memories used in affine parallel loops into banks";
   let constructor = "circt::createMemoryBankingPass()";
   let options = [
-    Option<"bankingFactor", "banking-factor", "unsigned", /*default=*/"1",
+    Option<"bankingFactor", "factor", "unsigned", /*default=*/"1",
            "Use this banking factor for all memories being partitioned">,
-    Option<"bankingDimension", "dimension", "unsigned", /*default=*/"0",
-           "The dimension along which to bank the memory. For rank=1, must be 0.">
+    Option<"bankingDimension", "dimension", "int", /*default=*/"-1",
+           "The dimension along which to bank the memory. If -1, the innermost dimension with size > 1 is used.">
   ];
   let dependentDialects = ["mlir::memref::MemRefDialect, mlir::scf::SCFDialect, mlir::affine::AffineDialect"];
 }

--- a/test/Transforms/memory_banking.mlir
+++ b/test/Transforms/memory_banking.mlir
@@ -1,7 +1,7 @@
-// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2" | FileCheck %s --check-prefix UNROLL-BY-2
-// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=1" | FileCheck %s --check-prefix UNROLL-BY-1
-// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=8" | FileCheck %s --check-prefix UNROLL-BY-8
-// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2" | FileCheck %s --check-prefix ALLOC-UNROLL-2
+// RUN: circt-opt %s -split-input-file -memory-banking="factor=2" | FileCheck %s --check-prefix UNROLL-BY-2
+// RUN: circt-opt %s -split-input-file -memory-banking="factor=1" | FileCheck %s --check-prefix UNROLL-BY-1
+// RUN: circt-opt %s -split-input-file -memory-banking="factor=8" | FileCheck %s --check-prefix UNROLL-BY-8
+// RUN: circt-opt %s -split-input-file -memory-banking="factor=2" | FileCheck %s --check-prefix ALLOC-UNROLL-2
 
 // -----
 

--- a/test/Transforms/memory_banking_invalid.mlir
+++ b/test/Transforms/memory_banking_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=0" -verify-diagnostics
+// RUN: circt-opt %s -split-input-file -memory-banking="factor=0" -verify-diagnostics
 
 // expected-error@+1 {{banking factor must be greater than 1}}
 func.func @bank_one_dim_unroll0(%arg0: memref<8xf32>, %arg1: memref<8xf32>) -> (memref<8xf32>) {

--- a/test/Transforms/memory_banking_multi_dim.mlir
+++ b/test/Transforms/memory_banking_multi_dim.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2 dimension=1" | FileCheck %s --check-prefix RANK2-BANKDIM1
+// RUN: circt-opt %s -memory-banking="banking-factor=2 dimension=1" | FileCheck %s --check-prefix RANK2-BANKDIM1
 // RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2" | FileCheck %s --check-prefix GETGLOBAL
 
 // RANK2-BANKDIM1: #[[$ATTR_0:.+]] = affine_map<(d0, d1) -> (d1 mod 2)>
@@ -76,10 +76,10 @@ func.func @rank_two_bank_dim1(%arg0: memref<8x6xf32>, %arg1: memref<8x6xf32>) ->
 
 // -----
 
-// GETGLOBAL-LABEL:         memref.global "private" constant @__constant_4x8xf32_bank_0 : memref<2x8xf32> = dense<{{\[\[}}8.000000e+00, -2.000000e+00, -2.000000e+00, -1.000000e+00, -3.000000e+00, -2.000000e+00, 3.000000e+00, 6.000000e+00], [9.000000e+00, -1.000000e+00, -2.000000e+00, -2.000000e+00, -2.000000e+00, -2.000000e+00, -1.000000e+00, -2.000000e+00]]>
-// GETGLOBAL:         memref.global "private" constant @__constant_4x8xf32_bank_1 : memref<2x8xf32> = dense<{{\[\[}}1.000000e+00, -3.000000e+00, -2.000000e+00, -1.000000e+00, 5.000000e+00, -3.000000e+00, -1.000000e+00, -2.000000e+00], [2.000000e+00, -7.000000e+00, 3.000000e+00, 1.000000e+00, -2.000000e+00, 2.000000e+00, -9.000000e+00, -1.000000e+00]]>
-// GETGLOBAL:         memref.global "private" constant @__constant_8x6xf32_bank_0 : memref<4x6xf32> = dense<{{\[\[}}2.000000e+00, -2.000000e+00, -4.000000e+00, -1.000000e+00, -3.000000e+00, 3.000000e+00], [2.000000e+00, -2.000000e+00, 1.000000e+00, -1.000000e+00, 1.000000e+00, -8.000000e+00], [3.000000e+00, -3.000000e+00, -4.000000e+00, -3.000000e+00, -2.000000e+00, 1.000000e+00], [2.000000e+00, -9.000000e+00, 2.000000e+00, -3.000000e+00, -2.000000e+00, 1.000000e+00]]>
-// GETGLOBAL:         memref.global "private" constant @__constant_8x6xf32_bank_1 : memref<4x6xf32> = dense<{{\[\[}}1.000000e+00, 1.000000e+00, 1.000000e+00, -7.000000e+00, 3.000000e+00, -2.000000e+00], [3.000000e+00, -2.000000e+00, -2.000000e+00, -2.000000e+00, 3.000000e+00, 1.000000e+00], [1.000000e+00, 3.000000e+00, -2.000000e+00, -2.000000e+00, 2.000000e+00, -1.000000e+00], [8.000000e+00, -1.000000e+00, 2.000000e+00, 2.000000e+00, -2.000000e+00, -2.000000e+00]]>
+// GETGLOBAL-LABEL:         memref.global "private" constant @__constant_4x8xf32_bank_0 : memref<4x4xf32> = dense<{{\[\[}}8.000000e+00, -2.000000e+00, -3.000000e+00, 3.000000e+00], [1.000000e+00, -2.000000e+00, 5.000000e+00, -1.000000e+00], [9.000000e+00, -2.000000e+00, -2.000000e+00, -1.000000e+00], [2.000000e+00, 3.000000e+00, -2.000000e+00, -9.000000e+00]]>
+// GETGLOBAL:         memref.global "private" constant @__constant_4x8xf32_bank_1 : memref<4x4xf32> = dense<{{\[\[}}-2.000000e+00, -1.000000e+00, -2.000000e+00, 6.000000e+00], [-3.000000e+00, -1.000000e+00, -3.000000e+00, -2.000000e+00], [-1.000000e+00, -2.000000e+00, -2.000000e+00, -2.000000e+00], [-7.000000e+00, 1.000000e+00, 2.000000e+00, -1.000000e+00]]>
+// GETGLOBAL:         memref.global "private" constant @__constant_8x1xf32_bank_0 : memref<4x1xf32> = dense<{{\[\[}}2.000000e+00], [-1.000000e+00], [3.000000e+00], [2.000000e+00]]>
+// GETGLOBAL:         memref.global "private" constant @__constant_8x1xf32_bank_1 : memref<4x1xf32> = dense<{{\[\[}}-7.000000e+00], [3.000000e+00], [1.000000e+00], [8.000000e+00]]>
 
 module {
   memref.global "private" constant @__constant_4x8xf32 : memref<4x8xf32> = dense<[
@@ -88,25 +88,18 @@ module {
     [9.0,  -1.0, -2.0, -2.0, -2.0, -2.0, -1.0, -2.0],
     [2.0,  -7.0,  3.0,  1.0, -2.0,  2.0, -9.0, -1.0]
   ]>
-  memref.global "private" constant @__constant_8x6xf32 : memref<8x6xf32> = dense<[
-    [2.0,  -2.0, -4.0, -1.0, -3.0,  3.0],
-    [1.0,   1.0,  1.0, -7.0,  3.0, -2.0],
-    [2.0,  -2.0,  1.0, -1.0,  1.0, -8.0],
-    [3.0,  -2.0, -2.0, -2.0,  3.0,  1.0],
-    [3.0,  -3.0, -4.0, -3.0, -2.0,  1.0],
-    [1.0,   3.0, -2.0, -2.0,  2.0, -1.0],
-    [2.0,  -9.0,  2.0, -3.0, -2.0,  1.0],
-    [8.0,  -1.0,  2.0,  2.0, -2.0, -2.0]
+  memref.global "private" constant @__constant_8x1xf32 : memref<8x1xf32> = dense<[
+    [2.0], [-7.0], [-1.0], [3.0], [3.0], [1.0], [2.0], [8.0]
   ]>
   func.func @main() {
     %cst = arith.constant 0.000000e+00 : f32
-    %0 = memref.get_global @__constant_8x6xf32 : memref<8x6xf32>
+    %0 = memref.get_global @__constant_8x1xf32 : memref<8x1xf32>
     %2 = memref.get_global @__constant_4x8xf32 : memref<4x8xf32>
-    %alloc = memref.alloc() : memref<6x8xf32>
-    affine.parallel (%arg2) = (0) to (6) {
+    %alloc = memref.alloc() : memref<1x8xf32>
+    affine.parallel (%arg2) = (0) to (1) {
       affine.parallel (%arg3) = (0) to (8) {
-        %4 = affine.load %0[%arg3, %arg2] : memref<8x6xf32>
-        affine.store %4, %alloc[%arg2, %arg3] : memref<6x8xf32>
+        %4 = affine.load %0[%arg3, %arg2] : memref<8x1xf32>
+        affine.store %4, %alloc[%arg2, %arg3] : memref<1x8xf32>
       }
     }
     %alloc_5 = memref.alloc() : memref<8x4xf32>

--- a/test/Transforms/memory_banking_multi_dim.mlir
+++ b/test/Transforms/memory_banking_multi_dim.mlir
@@ -1,5 +1,5 @@
-// RUN: circt-opt %s -memory-banking="banking-factor=2 dimension=1" | FileCheck %s --check-prefix RANK2-BANKDIM1
-// RUN: circt-opt %s -split-input-file -memory-banking="banking-factor=2" | FileCheck %s --check-prefix GETGLOBAL
+// RUN: circt-opt %s -memory-banking="factor=2 dimension=1" | FileCheck %s --check-prefix RANK2-BANKDIM1
+// RUN: circt-opt %s -split-input-file -memory-banking="factor=2" | FileCheck %s --check-prefix GETGLOBAL
 
 // RANK2-BANKDIM1: #[[$ATTR_0:.+]] = affine_map<(d0, d1) -> (d1 mod 2)>
 // RANK2-BANKDIM1: #[[$ATTR_1:.+]] = affine_map<(d0, d1) -> (d1 floordiv 2)>


### PR DESCRIPTION
This patch adjusts the default dimension for banking. It used be the outer most dimension (=0), but I think it makes more sense to default to the innermost dimension. For example, if we have:
```mlir
memref.global @__constant_4x2_i32 [[1, 2], [3, 4], [5, 6], [7, 8]] : memref<4x2xi32>
```
if we bank with factor = 2 in a round-robin way, it makes more sense to be:
```mlir
memref.global @__constant_4x2_i32_bank0 [[1], [3], [5], [7]] : memref<4x1xi32>
memref.global @__constant_4x2_i32_bank1 [[2], [4], [6], [8]] : memref<4x1xi32>
```
since it'll preserve the same order as the banking result after flattening to a 1-d array.

Additionally, we further require it to be the innermost dimension that has _shape not equals to 1_. It's not uncommon to have memrefs like:
```mlir
memref.global @__constant_4x1_i32 [[1], [2], [3], [4]] : memref<4x1xi32>
```
if we have a case above, the banked results are:
```mlir
memref.global @__constant_2x1_i32_bank0 [[1], [3]] : memref<2x1xi32>
memref.global @__constant_2x1_i32_bank1 [[2], [4]] : memref<2x1xi32>
```

The story behind this requirement is we can only specify a single `banking-factor` and `dimension` via `circt-opt` command line option for all `memref`s across the program. It is possible that all multi-dim `memref`s have all of their dimensions' shapes > 1 but one or two with shapes like `memref<4x1>`. So instead of having those few special `memref`s disable the entire transformation pass by triggering the assertion failure: https://github.com/llvm/circt/blob/0cea50e9e7d28044485a0e9547de013049b70ecd/lib/Transforms/MemoryBanking.cpp#L82, we adjust the default bahavior.

I hope this understanding makes sense.