### PR TITLE
[ESI][BSP] Gearboxing the hostmem write path

### DIFF
--- a/frontends/PyCDE/src/pycde/signals.py
+++ b/frontends/PyCDE/src/pycde/signals.py
@@ -550,6 +550,8 @@ class ArraySignal(Signal):
     _validate_idx(self.type.size, idx)
     from .dialects import hw
     with get_user_loc():
+      if isinstance(idx, UIntSignal):
+        idx = idx.as_bits()
       v = hw.ArrayGetOp(self.value, idx)
       if self.name and isinstance(idx, int):
         v.name = self.name + f"__{idx}"
@@ -560,6 +562,8 @@ class ArraySignal(Signal):
     idxs = s.indices(len(self))
     if idxs[2] != 1:
       raise ValueError("Array slices do not support steps")
+    if not isinstance(idxs[0], int) or not isinstance(idxs[1], int):
+      raise ValueError("Array slices must be constant ints")
 
     from .types import types
     from .dialects import hw

--- a/lib/Dialect/ESI/runtime/cosim_dpi_server/esi-cosim.py
+++ b/lib/Dialect/ESI/runtime/cosim_dpi_server/esi-cosim.py
@@ -242,7 +242,9 @@ class Verilator(Simulator):
         "-DTOP_MODULE=" + self.sources.top,
     ]
     if self.debug:
-      cmd += ["--trace", "--trace-params", "--trace-structs"]
+      cmd += [
+          "--trace", "--trace-params", "--trace-structs", "--trace-underscore"
+      ]
       cflags.append("-DTRACE")
     if len(cflags) > 0:
       cmd += ["-CFLAGS", " ".join(cflags)]


### PR DESCRIPTION
Take client data and gearbox it up or down to the underlying host connection width. In the case where we must gearbox down, creates multiple hostmem write transactions.