### PR TITLE
[ESI][BSP] Adding byte enables to cosim hostmem

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Common.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Common.h
@@ -147,7 +147,7 @@ std::ostream &operator<<(std::ostream &, const esi::AppID &);
 //===----------------------------------------------------------------------===//
 
 namespace esi {
-std::string toHex(uint32_t val);
+std::string toHex(uint64_t val);
 } // namespace esi
 
 #endif // ESI_COMMON_H

--- a/lib/Dialect/ESI/runtime/cpp/lib/Common.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Common.cpp
@@ -34,7 +34,7 @@ std::string MessageData::toHex() const {
   return ss.str();
 }
 
-std::string esi::toHex(uint32_t val) {
+std::string esi::toHex(uint64_t val) {
   std::ostringstream ss;
   ss << std::hex << val;
   return ss.str();

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Cosim.cpp
@@ -428,6 +428,7 @@ struct HostMemReadResp {
 };
 
 struct HostMemWriteReq {
+  uint8_t valid_bytes;
   uint64_t data;
   uint8_t tag;
   uint64_t address;
@@ -540,10 +541,13 @@ public:
             std::unique_ptr<std::map<std::string, std::any>> &details) {
           subsystem = "HostMem";
           msg = "Write request: addr=0x" + toHex(req->address) + " data=0x" +
-                toHex(req->data) + " tag=" + std::to_string(req->tag);
+                toHex(req->data) +
+                " valid_bytes=" + std::to_string(req->valid_bytes) +
+                " tag=" + std::to_string(req->tag);
         });
-    uint64_t *dataPtr = reinterpret_cast<uint64_t *>(req->address);
-    *dataPtr = req->data;
+    uint8_t *dataPtr = reinterpret_cast<uint8_t *>(req->address);
+    for (uint8_t i = 0; i < req->valid_bytes; ++i)
+      dataPtr[i] = (req->data >> (i * 8)) & 0xFF;
     HostMemWriteResp resp = req->tag;
     return MessageData::from(resp);
   }


### PR DESCRIPTION
Writes can happen at less than the granularity of the width of the upstream port, so we must support writing part of the data width.