### PR TITLE
[RTG] Populate pipeline with new passes

### DIFF
--- a/include/circt-c/RtgTool.h
+++ b/include/circt-c/RtgTool.h
@@ -56,7 +56,7 @@ circtRtgToolOptionsSetVerbosePassExecution(CirctRtgToolOptions options,
 
 MLIR_CAPI_EXPORTED void circtRtgToolOptionsSetUnsupportedInstructions(
     CirctRtgToolOptions options, unsigned numInstr,
-    const char **unsupportedInstructions);
+    const void **unsupportedInstructions);
 
 MLIR_CAPI_EXPORTED void circtRtgToolOptionsAddUnsupportedInstruction(
     CirctRtgToolOptions options, const char *unsupportedInstruction);
@@ -64,6 +64,12 @@ MLIR_CAPI_EXPORTED void circtRtgToolOptionsAddUnsupportedInstruction(
 MLIR_CAPI_EXPORTED void
 circtRtgToolOptionsSetUnsupportedInstructionsFile(CirctRtgToolOptions options,
                                                   const char *filename);
+
+MLIR_CAPI_EXPORTED void
+circtRtgToolOptionsSetSplitOutput(CirctRtgToolOptions options, bool enable);
+
+MLIR_CAPI_EXPORTED void
+circtRtgToolOptionsSetOutputPath(CirctRtgToolOptions options, const char *path);
 
 //===----------------------------------------------------------------------===//
 // Pipeline Population API.

--- a/include/circt/Tools/rtgtool/RtgToolOptions.h
+++ b/include/circt/Tools/rtgtool/RtgToolOptions.h
@@ -73,6 +73,18 @@ public:
     return unsupportedInstructionsFile;
   }
 
+  RtgToolOptions &setSplitOutput(bool enable) {
+    splitOutput = enable;
+    return *this;
+  }
+  bool getSplitOutput() const { return splitOutput; }
+
+  RtgToolOptions &setOutputPath(StringRef path) {
+    outputPath = path;
+    return *this;
+  }
+  std::string getOutputPath() const { return outputPath; }
+
 private:
   OutputFormat outputFormat = OutputFormat::ElaboratedMLIR;
   unsigned seed;
@@ -80,6 +92,8 @@ private:
   bool verbosePassExecution = false;
   SmallVector<std::string> unsupportedInstructions;
   std::string unsupportedInstructionsFile;
+  bool splitOutput = false;
+  std::string outputPath;
 };
 
 /// Populates the passes necessary to lower IR with RTG randomization operations

--- a/integration_test/Bindings/Python/rtg_pipeline.py
+++ b/integration_test/Bindings/Python/rtg_pipeline.py
@@ -1,0 +1,41 @@
+# REQUIRES: bindings_python
+# RUN: %PYTHON% %s %T && FileCheck %s --input-file=%T/test0.s --check-prefix=TEST0 && FileCheck %s --input-file=%T/test1.s --check-prefix=TEST1
+
+import sys
+import circt
+
+from circt.dialects import rtg, rtgtest
+from circt.ir import Context, Location, Module, InsertionPoint, Block, TypeAttr
+from circt.passmanager import PassManager
+from circt import rtgtool_support as rtgtool
+
+# Tests the split_file option and that the strings of unsupported instructions
+# are passed properly to the emission pass.
+with Context() as ctx, Location.unknown():
+  circt.register_dialects(ctx)
+  m = Module.create()
+  with InsertionPoint(m.body):
+    test = rtg.TestOp('test0', TypeAttr.get(rtg.DictType.get()))
+    block = Block.create_at_start(test.bodyRegion, [])
+    with InsertionPoint(block):
+      rtgtest.rv32i_ebreak()
+
+    test = rtg.TestOp('test1', TypeAttr.get(rtg.DictType.get()))
+    block = Block.create_at_start(test.bodyRegion, [])
+    with InsertionPoint(block):
+      rtgtest.rv32i_ecall()
+
+  pm = PassManager()
+  options = rtgtool.Options(seed=0,
+                            output_format=rtgtool.OutputFormat.ASM,
+                            split_output=True,
+                            unsupported_instructions=['rtgtest.rv32i.ebreak'],
+                            output_path=sys.argv[1])
+  rtgtool.populate_randomizer_pipeline(pm, options)
+  pm.run(m.operation)
+
+  # TEST0: ebreak
+  # TEST0: .word 0x
+
+  # TEST1: ecall
+  print(m)

--- a/lib/CAPI/RtgTool/RtgTool.cpp
+++ b/lib/CAPI/RtgTool/RtgTool.cpp
@@ -64,10 +64,11 @@ void circtRtgToolOptionsSetVerbosePassExecution(CirctRtgToolOptions options,
 
 void circtRtgToolOptionsSetUnsupportedInstructions(
     CirctRtgToolOptions options, unsigned numInstr,
-    const char **unsupportedInstructions) {
+    const void **unsupportedInstructions) {
   SmallVector<std::string> instr;
   for (unsigned i = 0; i < numInstr; ++i)
-    instr.push_back(std::string(unsupportedInstructions[i]));
+    instr.push_back(
+        reinterpret_cast<std::string *>(unsupportedInstructions)[i]);
   unwrap(options)->setUnsupportedInstructions(std::move(instr));
 }
 
@@ -80,6 +81,16 @@ void circtRtgToolOptionsAddUnsupportedInstruction(
 void circtRtgToolOptionsSetUnsupportedInstructionsFile(
     CirctRtgToolOptions options, const char *filename) {
   unwrap(options)->setUnsupportedInstructionsFile(std::string(filename));
+}
+
+void circtRtgToolOptionsSetSplitOutput(CirctRtgToolOptions options,
+                                       bool enable) {
+  unwrap(options)->setSplitOutput(enable);
+}
+
+void circtRtgToolOptionsSetOutputPath(CirctRtgToolOptions options,
+                                      const char *path) {
+  unwrap(options)->setOutputPath(std::string(path));
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Tools/rtgtool/CMakeLists.txt
+++ b/lib/Tools/rtgtool/CMakeLists.txt
@@ -2,6 +2,8 @@ add_circt_library(CIRCTRtgToolLib
   RtgToolOptions.cpp
 
   LINK_LIBS PUBLIC
+  CIRCTRTGDialect
+  CIRCTRTGTransforms
   CIRCTSupport
 
   MLIRIR


### PR DESCRIPTION
Add the new passes to the pipeline and pass their options through to the frontend. Also fixes a bug with the existing unsupported instructions option.