### PR TITLE
[FIRRTL] Fix hasDontTouch crash on non-module block args

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -318,7 +318,9 @@ bool firrtl::hasDontTouch(Value value) {
   if (auto *op = value.getDefiningOp())
     return hasDontTouch(op);
   auto arg = dyn_cast<BlockArgument>(value);
-  auto module = cast<FModuleOp>(arg.getOwner()->getParentOp());
+  auto module = dyn_cast<FModuleOp>(arg.getOwner()->getParentOp());
+  if (!module)
+    return false;
   return (module.getPortSymbolAttr(arg.getArgNumber())) ||
          AnnotationSet::forPort(module, arg.getArgNumber()).hasDontTouch();
 }

--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -606,3 +606,17 @@ firrtl.circuit "FormalMarkerIsUse" {
   firrtl.formal @Test, @Foo {}
   "some_unknown_dialect.op"() { magic = @Bar, other = @Uninstantiated } : () -> ()
 }
+
+// -----
+
+// Block arguments on operations that aren't modules, e.g. contracts, must not
+// crash the `firrtl::hasDontTouch` query.
+// CHECK-LABEL: firrtl.circuit "NonModuleBlockArgsMustNotCrash"
+firrtl.circuit "NonModuleBlockArgsMustNotCrash" {
+  firrtl.module @NonModuleBlockArgsMustNotCrash(in %a: !firrtl.uint<42>, out %b: !firrtl.uint<42>) {
+    %0 = firrtl.contract %a : !firrtl.uint<42> {
+    ^bb0(%arg0: !firrtl.uint<42>):
+    }
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<42>
+  }
+}


### PR DESCRIPTION
Fix an issue in `firrtl::hasDontTouch` where the cast to `FModuleOp` would crash if the function was called on a block argument of an operation that is not a module, for example, a `ContractOp`. Such block arguments are considered to not be marked as "don't touch".