### PR TITLE
[FIRRTL][IMDCE] Support operations with blocks

### DIFF
--- a/test/Dialect/FIRRTL/imdce.mlir
+++ b/test/Dialect/FIRRTL/imdce.mlir
@@ -613,10 +613,11 @@ firrtl.circuit "FormalMarkerIsUse" {
 // crash the `firrtl::hasDontTouch` query.
 // CHECK-LABEL: firrtl.circuit "NonModuleBlockArgsMustNotCrash"
 firrtl.circuit "NonModuleBlockArgsMustNotCrash" {
-  firrtl.module @NonModuleBlockArgsMustNotCrash(in %a: !firrtl.uint<42>, out %b: !firrtl.uint<42>) {
-    %0 = firrtl.contract %a : !firrtl.uint<42> {
-    ^bb0(%arg0: !firrtl.uint<42>):
+  firrtl.module @NonModuleBlockArgsMustNotCrash(in %a: !firrtl.uint<1>, out %b: !firrtl.uint<1>) {
+    %0 = firrtl.contract %a : !firrtl.uint<1> {
+    ^bb0(%arg0: !firrtl.uint<1>):
+      firrtl.int.verif.assert %arg0 : !firrtl.uint<1>
     }
-    firrtl.matchingconnect %b, %0 : !firrtl.uint<42>
+    firrtl.matchingconnect %b, %0 : !firrtl.uint<1>
   }
 }


### PR DESCRIPTION
Avoid a crash in IMDCE when encountering a block argument that is not defined by a module, but some other operation that has nested blocks, such as a contract. Additionally, when handling liveness of generic operations, conservatively mark any nested blocks executable.