### PR TITLE
[FIRRTL][LowerToHW] Lower contract ops

### DIFF
--- a/test/Conversion/FIRRTLToHW/intrinsics.mlir
+++ b/test/Conversion/FIRRTLToHW/intrinsics.mlir
@@ -124,7 +124,7 @@ firrtl.circuit "Intrinsics" {
     // CHECK-NEXT: verif.assert %a : i1
     firrtl.int.verif.ensure %a : !firrtl.uint<1>
     // CHECK-NEXT: verif.contract
-    verif.contract {
+    firrtl.contract {
       // CHECK-NEXT: verif.require %a : i1
       firrtl.int.verif.require %a : !firrtl.uint<1>
       // CHECK-NEXT: verif.require %a label "hello" : i1

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -1731,3 +1731,30 @@ firrtl.circuit "Foo" {
   // CHECK-NEXT: hw.instance "Foo" @Foo(a: [[A]]: i42) -> (z: i42)
   firrtl.formal @MyTest2, @Foo {world = "abc"}
 }
+
+// -----
+
+firrtl.circuit "Foo" {
+  // CHECK-LABEL: hw.module @Foo
+  firrtl.module @Foo(in %a: !firrtl.uint<42>, in %b: !firrtl.uint<1337>) {
+    // CHECK: verif.contract {
+    // CHECK-NEXT: }
+    firrtl.contract {
+    }
+
+    // CHECK: [[TMP:%.+]]:2 = verif.contract %a, %b : i42, i1337 {
+    // CHECK-NEXT:   dbg.variable "c2", [[TMP]]#0 : i42
+    // CHECK-NEXT:   dbg.variable "d2", [[TMP]]#1 : i1337
+    // CHECK-NEXT: }
+    %c, %d = firrtl.contract %a, %b : !firrtl.uint<42>, !firrtl.uint<1337> {
+    ^bb0(%c2: !firrtl.uint<42>, %d2: !firrtl.uint<1337>):
+      dbg.variable "c2", %c2 : !firrtl.uint<42>
+      dbg.variable "d2", %d2 : !firrtl.uint<1337>
+    }
+
+    // CHECK: dbg.variable "c", [[TMP]]#0 : i42
+    // CHECK: dbg.variable "d", [[TMP]]#1 : i1337
+    dbg.variable "c", %c : !firrtl.uint<42>
+    dbg.variable "d", %d : !firrtl.uint<1337>
+  }
+}


### PR DESCRIPTION
Lower `firrtl.contract` to `verif.contract` ops. The lowering itself is pretty straightforward, since the ops are basically equivalent. The only exception are block arguments in FIRRTL that get replaced with op results in Verif due to the switch from an SSACFG region with dominance to a graph region.

The block arguments require a slight change to how nested operations are handled by the pass. Currently, a post-order walk over the operations is used. This is problematic since the parent operation does not get an opportunity to lower its block arguments before its child operations are lowered, which may need access to those block arguments. Switching to a pre-order walk does not work, since that wouldn't allow us to modify the operations during the walk, which we obviously do during the lowering. This commit therefore adds a worklist that tracks operation ranges that are yet to be lowered. The worklist allows parent operations to lower themselves and any of their block arguments, and then add the nested regions, blocks, or operations onto the worklist for lowering. It's basically a pre-walk with the ability to mutate the parent operation before children are lowered.

Block arguments are also no longer automatically assumed to be already lowered. This was only valid for modules, since we lower the module ports before we lower the module body. In case of ops like contracts, the block arguments still need to be lowered. To fix this, modules push a 1-1 mapping of their block arguments into the map of lowered values, which allows other ops to provide some other lowering for their block arguments.