### PR TITLE
[ESI Runtime] Pluggable channel engines

### DIFF
--- a/include/circt/Dialect/ESI/ESIInterfaces.td
+++ b/include/circt/Dialect/ESI/ESIInterfaces.td
@@ -64,7 +64,7 @@ def IsManifestData : OpInterface<"IsManifestData"> {
   }];
 
   let methods = [
-    StaticInterfaceMethod<
+    InterfaceMethod<
       "Get the class name for this op.",
       "StringRef", "getManifestClass", (ins)
     >,

--- a/include/circt/Dialect/ESI/ESIManifest.td
+++ b/include/circt/Dialect/ESI/ESIManifest.td
@@ -99,6 +99,7 @@ def ServiceImplRecordOp : ESI_Op<"manifest.service_impl", [
   }];
 
   let arguments = (ins AppIDAttr:$appID,
+                       DefaultValuedAttr<UnitAttr, "false">:$isEngine,
                        OptionalAttr<FlatSymbolRefAttr>:$service,
                        OptionalAttr<StrAttr>:$stdService,
                        StrAttr:$serviceImplName,
@@ -106,7 +107,7 @@ def ServiceImplRecordOp : ESI_Op<"manifest.service_impl", [
   let regions = (region SizedRegion<1>:$reqDetails);
   let assemblyFormat = [{
     qualified($appID) (`svc` $service^)? (`std` $stdService^)?
-   `by` $serviceImplName `with` $implDetails
+   `by` $serviceImplName (`engine` $isEngine^)? `with` $implDetails
     attr-dict-with-keyword custom<ServiceImplRecordReqDetails>($reqDetails)
   }];
 

--- a/integration_test/Dialect/ESI/runtime/loopback.mlir
+++ b/integration_test/Dialect/ESI/runtime/loopback.mlir
@@ -143,8 +143,6 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // QUERY-HIER: * Instance:top
 // QUERY-HIER: * Ports:
 // QUERY-HIER:     internal_write:
-// QUERY-HIER:       ack: !esi.channel<i0>
-// QUERY-HIER:       req: !esi.channel<!hw.struct<address: i5, data: i64>>
 // QUERY-HIER:     func1: function i16(i16)
 // QUERY-HIER:     structFunc: function !hw.struct<x: si8, y: si8>(!hw.struct<a: ui16, b: si8>)
 // QUERY-HIER:     arrayFunc: function !hw.array<2xsi8>(!hw.array<1xsi8>)

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -768,7 +768,9 @@ void ESIPureModuleOp::setHWModuleType(hw::ModuleType type) {
 // Manifest ops.
 //===----------------------------------------------------------------------===//
 
-StringRef ServiceImplRecordOp::getManifestClass() { return "service"; }
+StringRef ServiceImplRecordOp::getManifestClass() {
+  return getIsEngine() ? "engine" : "service";
+}
 
 void ServiceImplRecordOp::getDetails(SmallVectorImpl<NamedAttribute> &results) {
   auto *ctxt = getContext();

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -58,6 +58,7 @@ instantiateCosimEndpointOps(ServiceImplementReqOp implReq,
   }
 
   Block &connImplBlock = implRecord.getReqDetails().front();
+  implRecord.setIsEngine(true);
   OpBuilder implRecords = OpBuilder::atBlockEnd(&connImplBlock);
 
   // Assemble the name to use for an endpoint.
@@ -300,8 +301,9 @@ ServiceGeneratorDispatcher::generate(ServiceImplementReqOp req,
   // the generator for possible modification.
   OpBuilder b(req);
   auto implRecord = b.create<ServiceImplRecordOp>(
-      req.getLoc(), req.getAppID(), req.getServiceSymbolAttr(),
-      req.getStdServiceAttr(), req.getImplTypeAttr(), b.getDictionaryAttr({}));
+      req.getLoc(), req.getAppID(), /*isEngine=*/false,
+      req.getServiceSymbolAttr(), req.getStdServiceAttr(),
+      req.getImplTypeAttr(), b.getDictionaryAttr({}));
   implRecord.getReqDetails().emplaceBlock();
 
   return genF->second(req, decl, implRecord);

--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -100,6 +100,7 @@ set(ESICppRuntimeSources
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Context.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Common.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Design.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Engines.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Logging.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Manifest.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/lib/Services.cpp

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Accelerator.h
@@ -23,6 +23,7 @@
 
 #include "esi/Context.h"
 #include "esi/Design.h"
+#include "esi/Engines.h"
 #include "esi/Manifest.h"
 #include "esi/Ports.h"
 #include "esi/Services.h"
@@ -92,11 +93,6 @@ public:
   // each level of the tree.
   using ServiceTable = std::map<std::string, services::Service *>;
 
-  /// Request the host side channel ports for a particular instance (identified
-  /// by the AppID path). For convenience, provide the bundle type.
-  virtual std::map<std::string, ChannelPort &>
-  requestChannelsFor(AppIDPath, const BundleType *, const ServiceTable &) = 0;
-
   /// Return a pointer to the accelerator 'service' thread (or threads). If the
   /// thread(s) are not running, they will be started when this method is
   /// called. `std::thread` is used. If users don't want the runtime to spin up
@@ -126,7 +122,23 @@ public:
   /// accelerator to this connection. Returns a raw pointer to the object.
   Accelerator *takeOwnership(std::unique_ptr<Accelerator> accel);
 
+  /// Create a new engine for channel communication with the accelerator. The
+  /// default is to call the global `createEngine` to get an engine which has
+  /// registered itself. Individual accelerator connection backends can override
+  /// this to customize behavior.
+  virtual void createEngine(const std::string &engineTypeName, AppIDPath idPath,
+                            const ServiceImplDetails &details,
+                            const HWClientDetails &clients);
+  virtual const BundleEngineMap &getEngineMapFor(AppIDPath id) {
+    return clientEngines[id];
+  }
+
 protected:
+  /// If `createEngine` is overridden, this method should be called to register
+  /// the engine and all of the channels it services.
+  void registerEngine(AppIDPath idPath, std::unique_ptr<Engine> engine,
+                      const HWClientDetails &clients);
+
   /// Called by `getServiceImpl` exclusively. It wraps the pointer returned by
   /// this in a unique_ptr and caches it. Separate this from the
   /// wrapping/caching since wrapping/caching is an implementation detail.
@@ -134,6 +146,11 @@ protected:
                                  std::string implName,
                                  const ServiceImplDetails &details,
                                  const HWClientDetails &clients) = 0;
+
+  /// Collection of owned engines.
+  std::map<AppIDPath, std::unique_ptr<Engine>> ownedEngines;
+  /// Mapping of clients to their servicing engines.
+  std::map<AppIDPath, BundleEngineMap> clientEngines;
 
 private:
   /// ESI accelerator context.

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Engines.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Engines.h
@@ -1,0 +1,117 @@
+//===- Engines.h - Implement port communication -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// DO NOT EDIT!
+// This file is distributed as part of an ESI package. The source for this file
+// should always be modified within CIRCT.
+//
+//===----------------------------------------------------------------------===//
+//
+// Engines (as in DMA engine) implement the actual communication between the
+// host and the accelerator. They are low level of the ESI runtime API and are
+// not intended to be used directly by users.
+//
+// They are called "engines" rather than "DMA engines" since communication need
+// not be implemented via DMA.
+//
+//===----------------------------------------------------------------------===//
+
+// NOLINTNEXTLINE(llvm-header-guard)
+#ifndef ESI_ENGINGES_H
+#define ESI_ENGINGES_H
+
+#include "esi/Common.h"
+#include "esi/Ports.h"
+#include "esi/Services.h"
+#include "esi/Utils.h"
+
+#include <cassert>
+#include <future>
+
+namespace esi {
+
+/// Engines implement the actual channel communication between the host and the
+/// accelerator. Engines can support multiple channels. They are low level of
+/// the ESI runtime API and are not intended to be used directly by users.
+class Engine {
+public:
+  virtual ~Engine() = default;
+  /// Start the engine, if applicable.
+  virtual void connect(){};
+  /// Stop the engine, if applicable.
+  virtual void disconnect(){};
+  /// Get a port for a channel, from the cache if it exists or create it. An
+  /// engine may override this method if different behavior is desired.
+  virtual ChannelPort &requestPort(AppIDPath idPath,
+                                   const std::string &channelName,
+                                   BundleType::Direction dir, const Type *type);
+
+protected:
+  /// Each engine needs to know how to create a ports. This method is called if
+  /// a port doesn't exist in the engine cache.
+  virtual std::unique_ptr<ChannelPort>
+  createPort(AppIDPath idPath, const std::string &channelName,
+             BundleType::Direction dir, const Type *type) = 0;
+
+private:
+  std::map<std::pair<AppIDPath, std::string>, std::unique_ptr<ChannelPort>>
+      ownedPorts;
+};
+
+/// Since engines can support multiple channels BUT not necessarily all of the
+/// channels in a bundle, a mapping from bundle channels to engines is needed.
+class BundleEngineMap {
+  friend class AcceleratorConnection;
+
+public:
+  /// Request ports for all the channels in a bundle. If the engine doesn't
+  /// exist for a particular channel, skip said channel.
+  PortMap requestPorts(const AppIDPath &idPath,
+                       const BundleType *bundleType) const;
+
+private:
+  /// Set a particlar engine for a particular channel. Should only be called by
+  /// AcceleratorConnection while registering engines.
+  void setEngine(const std::string &channelName, Engine *engine);
+  std::map<std::string, Engine *> bundleEngineMap;
+};
+
+namespace registry {
+
+/// Create an engine by name. This is the primary way to create engines for
+/// "normal" backends.
+std::unique_ptr<Engine> createEngine(AcceleratorConnection &conn,
+                                     const std::string &dmaEngineName,
+                                     AppIDPath idPath,
+                                     const ServiceImplDetails &details,
+                                     const HWClientDetails &clients);
+
+namespace internal {
+
+/// Engines can register themselves for pluggable functionality.
+using EngineCreate = std::function<std::unique_ptr<Engine>(
+    AcceleratorConnection &conn, AppIDPath idPath,
+    const ServiceImplDetails &details, const HWClientDetails &clients)>;
+void registerEngine(const std::string &name, EngineCreate create);
+
+/// Helper struct to register engines.
+template <typename TEngine>
+struct RegisterEngine {
+  RegisterEngine(const char *name) { registerEngine(name, &TEngine::create); }
+};
+
+#define REGISTER_ENGINE(Name, TEngine)                                         \
+  static ::esi::registry::internal::RegisterEngine<TEngine>                    \
+  __register_engine____LINE__(Name)
+
+} // namespace internal
+} // namespace registry
+
+} // namespace esi
+
+#endif // ESI_PORTS_H

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Ports.h
@@ -25,6 +25,9 @@
 
 namespace esi {
 
+class ChannelPort;
+using PortMap = std::map<std::string, ChannelPort &>;
+
 /// Unidirectional channels are the basic communication primitive between the
 /// host and accelerator. A 'ChannelPort' is the host side of a channel. It can
 /// be either read or write but not both. At this level, channels are untyped --
@@ -190,7 +193,7 @@ public:
   }
 
   /// Construct a port.
-  BundlePort(AppID id, std::map<std::string, ChannelPort &> channels);
+  BundlePort(AppID id, const BundleType *type, PortMap channels);
   virtual ~BundlePort() = default;
 
   /// Get the ID of the port.
@@ -202,9 +205,7 @@ public:
   /// ordinary users should not use. You have been warned.
   WriteChannelPort &getRawWrite(const std::string &name) const;
   ReadChannelPort &getRawRead(const std::string &name) const;
-  const std::map<std::string, ChannelPort &> &getChannels() const {
-    return channels;
-  }
+  const PortMap &getChannels() const { return channels; }
 
   /// Cast this Bundle port to a subclass which is actually useful. Returns
   /// nullptr if the cast fails.
@@ -224,9 +225,10 @@ public:
     return result;
   }
 
-private:
+protected:
   AppID id;
-  std::map<std::string, ChannelPort &> channels;
+  const BundleType *type;
+  PortMap channels;
 };
 
 } // namespace esi

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
@@ -28,6 +28,7 @@
 
 namespace esi {
 class AcceleratorConnection;
+class Engine;
 namespace services {
 
 /// Add a custom interface to a service client at a particular point in the
@@ -45,6 +46,7 @@ public:
 class Service {
 public:
   using Type = const std::type_info &;
+  Service(AcceleratorConnection &conn) : conn(conn) {}
   virtual ~Service() = default;
 
   virtual std::string getServiceSymbol() const = 0;
@@ -56,19 +58,21 @@ public:
   /// calling the `getService` method on `AcceleratorConnection` to get the
   /// global service, implying that the child service does not need to use the
   /// service it is replacing.
-  virtual Service *getChildService(AcceleratorConnection *conn,
-                                   Service::Type service, AppIDPath id = {},
+  virtual Service *getChildService(Service::Type service, AppIDPath id = {},
                                    std::string implName = {},
                                    ServiceImplDetails details = {},
                                    HWClientDetails clients = {});
 
   /// Get specialized port for this service to attach to the given appid path.
   /// Null returns mean nothing to attach.
-  virtual ServicePort *getPort(AppIDPath id, const BundleType *type,
-                               const std::map<std::string, ChannelPort &> &,
-                               AcceleratorConnection &) const {
+  virtual BundlePort *getPort(AppIDPath id, const BundleType *type) const {
     return nullptr;
   }
+
+  AcceleratorConnection &getConnection() const { return conn; }
+
+protected:
+  AcceleratorConnection &conn;
 };
 
 /// A service for which there are no standard services registered. Requires
@@ -76,13 +80,16 @@ public:
 /// the ones in StdServices.h.
 class CustomService : public Service {
 public:
-  CustomService(AppIDPath idPath, const ServiceImplDetails &details,
+  CustomService(AppIDPath idPath, AcceleratorConnection &,
+                const ServiceImplDetails &details,
                 const HWClientDetails &clients);
   virtual ~CustomService() = default;
 
   virtual std::string getServiceSymbol() const override {
     return serviceSymbol;
   }
+  virtual BundlePort *getPort(AppIDPath id,
+                              const BundleType *type) const override;
 
 protected:
   std::string serviceSymbol;
@@ -92,6 +99,7 @@ protected:
 /// Information about the Accelerator system.
 class SysInfo : public Service {
 public:
+  using Service::Service;
   virtual ~SysInfo() = default;
 
   virtual std::string getServiceSymbol() const override;
@@ -116,9 +124,7 @@ public:
     uint32_t size;
   };
 
-  MMIO(Context &ctxt, AppIDPath idPath, std::string implName,
-       const ServiceImplDetails &details, const HWClientDetails &clients);
-  MMIO() = default;
+  MMIO(AcceleratorConnection &, const HWClientDetails &clients);
   virtual ~MMIO() = default;
 
   /// Read a 64-bit value from the global MMIO space.
@@ -133,8 +139,7 @@ public:
 
   /// If the service is a MMIO service, return a region of the MMIO space which
   /// peers into ours.
-  virtual Service *getChildService(AcceleratorConnection *conn,
-                                   Service::Type service, AppIDPath id = {},
+  virtual Service *getChildService(Service::Type service, AppIDPath id = {},
                                    std::string implName = {},
                                    ServiceImplDetails details = {},
                                    HWClientDetails clients = {}) override;
@@ -142,9 +147,8 @@ public:
   virtual std::string getServiceSymbol() const override;
 
   /// Get a MMIO region port for a particular region descriptor.
-  virtual ServicePort *getPort(AppIDPath id, const BundleType *type,
-                               const std::map<std::string, ChannelPort &> &,
-                               AcceleratorConnection &) const override;
+  virtual BundlePort *getPort(AppIDPath id,
+                              const BundleType *type) const override;
 
 private:
   /// MMIO base address table.
@@ -195,6 +199,7 @@ class HostMem : public Service {
 public:
   static constexpr std::string_view StdName = "esi.service.std.hostmem";
 
+  using Service::Service;
   virtual ~HostMem() = default;
   virtual std::string getServiceSymbol() const override;
 
@@ -246,22 +251,20 @@ public:
 /// Service for calling functions.
 class FuncService : public Service {
 public:
-  FuncService(AcceleratorConnection *acc, AppIDPath id,
-              const std::string &implName, ServiceImplDetails details,
+  FuncService(AppIDPath id, AcceleratorConnection &, ServiceImplDetails details,
               HWClientDetails clients);
 
   virtual std::string getServiceSymbol() const override;
-  virtual ServicePort *getPort(AppIDPath id, const BundleType *type,
-                               const std::map<std::string, ChannelPort &> &,
-                               AcceleratorConnection &) const override;
+  virtual BundlePort *getPort(AppIDPath id,
+                              const BundleType *type) const override;
 
   /// A function call which gets attached to a service port.
   class Function : public ServicePort {
     friend class FuncService;
-    Function(AppID id, const std::map<std::string, ChannelPort &> &channels);
+    using ServicePort::ServicePort;
 
   public:
-    static Function *get(AppID id, WriteChannelPort &arg,
+    static Function *get(AppID id, BundleType *type, WriteChannelPort &arg,
                          ReadChannelPort &result);
 
     void connect();
@@ -269,16 +272,18 @@ public:
 
     virtual std::optional<std::string> toString() const override {
       const esi::Type *argType =
-          dynamic_cast<const ChannelType *>(arg.getType())->getInner();
+          dynamic_cast<const ChannelType *>(type->findChannel("arg").first)
+              ->getInner();
       const esi::Type *resultType =
-          dynamic_cast<const ChannelType *>(result.getType())->getInner();
+          dynamic_cast<const ChannelType *>(type->findChannel("result").first)
+              ->getInner();
       return "function " + resultType->getID() + "(" + argType->getID() + ")";
     }
 
   private:
     std::mutex callMutex;
-    WriteChannelPort &arg;
-    ReadChannelPort &result;
+    WriteChannelPort *arg;
+    ReadChannelPort *result;
   };
 
 private:
@@ -288,22 +293,21 @@ private:
 /// Service for servicing function calls from the accelerator.
 class CallService : public Service {
 public:
-  CallService(AcceleratorConnection *acc, AppIDPath id, std::string implName,
-              ServiceImplDetails details, HWClientDetails clients);
+  CallService(AcceleratorConnection &acc, AppIDPath id,
+              ServiceImplDetails details);
 
   virtual std::string getServiceSymbol() const override;
-  virtual ServicePort *getPort(AppIDPath id, const BundleType *type,
-                               const std::map<std::string, ChannelPort &> &,
-                               AcceleratorConnection &) const override;
+  virtual BundlePort *getPort(AppIDPath id,
+                              const BundleType *type) const override;
 
   /// A function call which gets attached to a service port.
   class Callback : public ServicePort {
     friend class CallService;
-    Callback(AcceleratorConnection &acc, AppID id,
-             const std::map<std::string, ChannelPort &> &channels);
+    Callback(AcceleratorConnection &acc, AppID id, const BundleType *,
+             PortMap channels);
 
   public:
-    static Callback *get(AcceleratorConnection &acc, AppID id,
+    static Callback *get(AcceleratorConnection &acc, AppID id, BundleType *type,
                          WriteChannelPort &result, ReadChannelPort &arg);
 
     /// Connect a callback to code which will be executed when the accelerator
@@ -315,15 +319,17 @@ public:
 
     virtual std::optional<std::string> toString() const override {
       const esi::Type *argType =
-          dynamic_cast<const ChannelType *>(arg.getType())->getInner();
+          dynamic_cast<const ChannelType *>(type->findChannel("arg").first)
+              ->getInner();
       const esi::Type *resultType =
-          dynamic_cast<const ChannelType *>(result.getType())->getInner();
+          dynamic_cast<const ChannelType *>(type->findChannel("result").first)
+              ->getInner();
       return "callback " + resultType->getID() + "(" + argType->getID() + ")";
     }
 
   private:
-    ReadChannelPort &arg;
-    WriteChannelPort &result;
+    ReadChannelPort *arg;
+    WriteChannelPort *result;
     AcceleratorConnection &acc;
   };
 

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Types.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Types.h
@@ -16,8 +16,8 @@
 #ifndef ESI_TYPES_H
 #define ESI_TYPES_H
 
-#include <map>
 #include <cstdint>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -53,6 +53,13 @@ public:
 
   const ChannelVector &getChannels() const { return channels; }
   std::ptrdiff_t getBitWidth() const override { return -1; };
+
+  std::pair<const Type *, Direction> findChannel(std::string name) const {
+    for (auto [channelName, dir, type] : channels)
+      if (channelName == name)
+        return std::make_pair(type, dir);
+    throw std::runtime_error("Channel '" + name + "' not found in bundle");
+  }
 
 protected:
   ChannelVector channels;

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Trace.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Trace.h
@@ -64,14 +64,13 @@ public:
 
   /// Internal implementation.
   struct Impl;
-
-  /// Request the host side channel ports for a particular instance (identified
-  /// by the AppID path). For convenience, provide the bundle type.
-  std::map<std::string, ChannelPort &>
-  requestChannelsFor(AppIDPath, const BundleType *,
-                     const ServiceTable &) override;
+  Impl &getImpl();
 
 protected:
+  void createEngine(const std::string &engineTypeName, AppIDPath idPath,
+                    const ServiceImplDetails &details,
+                    const HWClientDetails &clients) override;
+
   virtual Service *createService(Service::Type service, AppIDPath idPath,
                                  std::string implName,
                                  const ServiceImplDetails &details,

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Xrt.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/backends/Xrt.h
@@ -37,13 +37,6 @@ public:
   static std::unique_ptr<AcceleratorConnection>
   connect(Context &, std::string connectionString);
 
-  /// Request the host side channel ports for a particular instance (identified
-  /// by the AppID path). For convenience, provide the bundle type and direction
-  /// of the bundle port.
-  std::map<std::string, ChannelPort &>
-  requestChannelsFor(AppIDPath, const BundleType *,
-                     const ServiceTable &) override;
-
 protected:
   virtual Service *createService(Service::Type service, AppIDPath path,
                                  std::string implName,

--- a/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
@@ -1,0 +1,73 @@
+//===- Engines.cpp --------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// DO NOT EDIT!
+// This file is distributed as part of an ESI package. The source for this file
+// should always be modified within CIRCT (lib/dialect/ESI/runtime/cpp/).
+//
+//===----------------------------------------------------------------------===//
+
+#include "esi/Engines.h"
+
+using namespace esi;
+
+ChannelPort &Engine::requestPort(AppIDPath idPath,
+                                 const std::string &channelName,
+                                 BundleType::Direction dir, const Type *type) {
+  auto portIter = ownedPorts.find(std::make_pair(idPath, channelName));
+  if (portIter != ownedPorts.end())
+    return *portIter->second;
+  std::unique_ptr<ChannelPort> port =
+      createPort(idPath, channelName, dir, type);
+  ChannelPort &ret = *port;
+  ownedPorts.emplace(std::make_pair(idPath, channelName), std::move(port));
+  return ret;
+}
+
+PortMap BundleEngineMap::requestPorts(const AppIDPath &idPath,
+                                      const BundleType *bundleType) const {
+  PortMap ports;
+  for (auto [channelName, dir, type] : bundleType->getChannels()) {
+    auto engineIter = bundleEngineMap.find(channelName);
+    if (engineIter == bundleEngineMap.end())
+      continue;
+
+    ports.emplace(channelName, engineIter->second->requestPort(
+                                   idPath, channelName, dir, type));
+  }
+  return ports;
+}
+
+void BundleEngineMap::setEngine(const std::string &channelName,
+                                Engine *engine) {
+  auto [it, inserted] = bundleEngineMap.try_emplace(channelName, engine);
+  if (!inserted)
+    throw std::runtime_error("Channel already exists in engine map");
+}
+
+namespace {
+std::map<std::string, registry::internal::EngineCreate> engineRegistry;
+}
+
+std::unique_ptr<Engine>
+registry::createEngine(AcceleratorConnection &conn,
+                       const std::string &dmaEngineName, AppIDPath idPath,
+                       const ServiceImplDetails &details,
+                       const HWClientDetails &clients) {
+  auto it = engineRegistry.find(dmaEngineName);
+  if (it == engineRegistry.end())
+    throw std::runtime_error("Unknown engine: " + dmaEngineName);
+  return it->second(conn, idPath, details, clients);
+}
+
+void registry::internal::registerEngine(const std::string &name,
+                                        EngineCreate create) {
+  auto tried = engineRegistry.try_emplace(name, create);
+  if (!tried.second)
+    throw std::runtime_error("Engine already exists in registry");
+}

--- a/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
@@ -19,8 +19,8 @@
 
 using namespace esi;
 
-BundlePort::BundlePort(AppID id, std::map<std::string, ChannelPort &> channels)
-    : id(id), channels(channels) {}
+BundlePort::BundlePort(AppID id, const BundleType *type, PortMap channels)
+    : id(id), type(type), channels(channels) {}
 
 WriteChannelPort &BundlePort::getRawWrite(const std::string &name) const {
   auto f = channels.find(name);

--- a/lib/Dialect/ESI/runtime/cpp/lib/Services.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Services.cpp
@@ -15,6 +15,7 @@
 
 #include "esi/Services.h"
 #include "esi/Accelerator.h"
+#include "esi/Engines.h"
 
 #include "zlib.h"
 
@@ -24,12 +25,11 @@
 using namespace esi;
 using namespace esi::services;
 
-Service *Service::getChildService(AcceleratorConnection *conn,
-                                  Service::Type service, AppIDPath id,
+Service *Service::getChildService(Service::Type service, AppIDPath id,
                                   std::string implName,
                                   ServiceImplDetails details,
                                   HWClientDetails clients) {
-  return conn->getService(service, id, implName, details, clients);
+  return conn.getService(service, id, implName, details, clients);
 }
 
 std::string SysInfo::getServiceSymbol() const { return "__builtin_SysInfo"; }
@@ -53,8 +53,8 @@ std::string SysInfo::getJsonManifest() const {
 // MMIO class implementations.
 //===----------------------------------------------------------------------===//
 
-MMIO::MMIO(Context &ctxt, AppIDPath idPath, std::string implName,
-           const ServiceImplDetails &details, const HWClientDetails &clients) {
+MMIO::MMIO(AcceleratorConnection &conn, const HWClientDetails &clients)
+    : Service(conn) {
   for (const HWClientDetail &client : clients) {
     auto offsetIter = client.implOptions.find("offset");
     if (offsetIter == client.implOptions.end())
@@ -79,9 +79,7 @@ MMIO::MMIO(Context &ctxt, AppIDPath idPath, std::string implName,
 std::string MMIO::getServiceSymbol() const {
   return std::string(MMIO::StdName);
 }
-ServicePort *MMIO::getPort(AppIDPath id, const BundleType *type,
-                           const std::map<std::string, ChannelPort &> &,
-                           AcceleratorConnection &conn) const {
+BundlePort *MMIO::getPort(AppIDPath id, const BundleType *type) const {
   auto regionIter = regions.find(id);
   if (regionIter == regions.end())
     return nullptr;
@@ -92,10 +90,8 @@ ServicePort *MMIO::getPort(AppIDPath id, const BundleType *type,
 namespace {
 class MMIOPassThrough : public MMIO {
 public:
-  MMIOPassThrough(Context &ctxt, AppIDPath idPath, std::string implName,
-                  const ServiceImplDetails &details,
-                  const HWClientDetails &clients, MMIO *parent)
-      : MMIO(ctxt, idPath, implName, details, clients), parent(parent) {}
+  MMIOPassThrough(const HWClientDetails &clients, MMIO *parent)
+      : MMIO(parent->getConnection(), clients), parent(parent) {}
   uint64_t read(uint32_t addr) const override { return parent->read(addr); }
   void write(uint32_t addr, uint64_t data) override {
     parent->write(addr, data);
@@ -106,15 +102,12 @@ private:
 };
 } // namespace
 
-Service *MMIO::getChildService(AcceleratorConnection *conn,
-                               Service::Type service, AppIDPath id,
+Service *MMIO::getChildService(Service::Type service, AppIDPath id,
                                std::string implName, ServiceImplDetails details,
                                HWClientDetails clients) {
   if (service != typeid(MMIO))
-    return Service::getChildService(conn, service, id, implName, details,
-                                    clients);
-  return new MMIOPassThrough(conn->getCtxt(), id, implName, details, clients,
-                             this);
+    return Service::getChildService(service, id, implName, details, clients);
+  return new MMIOPassThrough(clients, this);
 }
 
 //===----------------------------------------------------------------------===//
@@ -122,7 +115,7 @@ Service *MMIO::getChildService(AcceleratorConnection *conn,
 //===----------------------------------------------------------------------===//
 
 MMIO::MMIORegion::MMIORegion(AppID id, MMIO *parent, RegionDescriptor desc)
-    : ServicePort(id, {}), parent(parent), desc(desc) {}
+    : ServicePort(id, nullptr, {}), parent(parent), desc(desc) {}
 uint64_t MMIO::MMIORegion::read(uint32_t addr) const {
   if (addr >= desc.size)
     throw std::runtime_error("MMIO read out of bounds: " + toHex(addr));
@@ -134,7 +127,8 @@ void MMIO::MMIORegion::write(uint32_t addr, uint64_t data) {
   parent->write(desc.base + addr, data);
 }
 
-MMIOSysInfo::MMIOSysInfo(const MMIO *mmio) : mmio(mmio) {}
+MMIOSysInfo::MMIOSysInfo(const MMIO *mmio)
+    : SysInfo(mmio->getConnection()), mmio(mmio) {}
 
 uint32_t MMIOSysInfo::getEsiVersion() const {
   uint64_t reg;
@@ -165,10 +159,10 @@ std::vector<uint8_t> MMIOSysInfo::getCompressedManifest() const {
 
 std::string HostMem::getServiceSymbol() const { return "__builtin_HostMem"; }
 
-CustomService::CustomService(AppIDPath idPath,
+CustomService::CustomService(AppIDPath idPath, AcceleratorConnection &conn,
                              const ServiceImplDetails &details,
                              const HWClientDetails &clients)
-    : id(idPath) {
+    : Service(conn), id(idPath) {
   if (auto f = details.find("service"); f != details.end()) {
     serviceSymbol = std::any_cast<std::string>(f->second);
     // Strip off initial '@'.
@@ -176,9 +170,15 @@ CustomService::CustomService(AppIDPath idPath,
   }
 }
 
-FuncService::FuncService(AcceleratorConnection *acc, AppIDPath idPath,
-                         const std::string &implName,
-                         ServiceImplDetails details, HWClientDetails clients) {
+BundlePort *CustomService::getPort(AppIDPath id, const BundleType *type) const {
+  return new BundlePort(id.back(), type,
+                        conn.getEngineMapFor(id).requestPorts(id, type));
+}
+
+FuncService::FuncService(AppIDPath idPath, AcceleratorConnection &conn,
+                         ServiceImplDetails details, HWClientDetails clients)
+    : Service(conn) {
+
   if (auto f = details.find("service"); f != details.end())
     // Strip off initial '@'.
     symbol = std::any_cast<std::string>(f->second).substr(1);
@@ -186,42 +186,38 @@ FuncService::FuncService(AcceleratorConnection *acc, AppIDPath idPath,
 
 std::string FuncService::getServiceSymbol() const { return symbol; }
 
-ServicePort *
-FuncService::getPort(AppIDPath id, const BundleType *type,
-                     const std::map<std::string, ChannelPort &> &channels,
-                     AcceleratorConnection &acc) const {
-  return new Function(id.back(), channels);
+BundlePort *FuncService::getPort(AppIDPath id, const BundleType *type) const {
+  return new Function(id.back(), type,
+                      conn.getEngineMapFor(id).requestPorts(id, type));
 }
 
-FuncService::Function::Function(
-    AppID id, const std::map<std::string, ChannelPort &> &channels)
-    : ServicePort(id, channels),
-      arg(dynamic_cast<WriteChannelPort &>(channels.at("arg"))),
-      result(dynamic_cast<ReadChannelPort &>(channels.at("result"))) {
-  assert(channels.size() == 2 && "FuncService must have exactly two channels");
-}
-
-FuncService::Function *FuncService::Function::get(AppID id,
+FuncService::Function *FuncService::Function::get(AppID id, BundleType *type,
                                                   WriteChannelPort &arg,
                                                   ReadChannelPort &result) {
-  return new Function(id, {{"arg", arg}, {"result", result}});
+  return new Function(
+      id, type, {{std::string("arg"), arg}, {std::string("result"), result}});
+  return nullptr;
 }
 
 void FuncService::Function::connect() {
-  arg.connect();
-  result.connect();
+  if (channels.size() != 2)
+    throw std::runtime_error("FuncService must have exactly two channels");
+  arg = &getRawWrite("arg");
+  arg->connect();
+  result = &getRawRead("result");
+  result->connect();
 }
 
 std::future<MessageData>
 FuncService::Function::call(const MessageData &argData) {
   std::scoped_lock<std::mutex> lock(callMutex);
-  arg.write(argData);
-  return result.readAsync();
+  arg->write(argData);
+  return result->readAsync();
 }
 
-CallService::CallService(AcceleratorConnection *acc, AppIDPath idPath,
-                         std::string implName, ServiceImplDetails details,
-                         HWClientDetails clients) {
+CallService::CallService(AcceleratorConnection &acc, AppIDPath idPath,
+                         ServiceImplDetails details)
+    : Service(acc) {
   if (auto f = details.find("service"); f != details.end())
     // Strip off initial '@'.
     symbol = std::any_cast<std::string>(f->second).substr(1);
@@ -229,63 +225,46 @@ CallService::CallService(AcceleratorConnection *acc, AppIDPath idPath,
 
 std::string CallService::getServiceSymbol() const { return symbol; }
 
-ServicePort *
-CallService::getPort(AppIDPath id, const BundleType *type,
-                     const std::map<std::string, ChannelPort &> &channels,
-                     AcceleratorConnection &acc) const {
-  return new Callback(acc, id.back(), channels);
+BundlePort *CallService::getPort(AppIDPath id, const BundleType *type) const {
+  return new Callback(conn, id.back(), type,
+                      conn.getEngineMapFor(id).requestPorts(id, type));
 }
 
-ReadChannelPort &getRead(const std::map<std::string, ChannelPort &> &channels,
-                         const std::string &name) {
-  auto f = channels.find(name);
-  if (f == channels.end())
-    throw std::runtime_error("CallService must have an '" + name + "' channel");
-  return dynamic_cast<ReadChannelPort &>(f->second);
-}
-
-WriteChannelPort &getWrite(const std::map<std::string, ChannelPort &> &channels,
-                           const std::string &name) {
-  auto f = channels.find(name);
-  if (f == channels.end())
-    throw std::runtime_error("CallService must have an '" + name + "' channel");
-  return dynamic_cast<WriteChannelPort &>(f->second);
-}
-
-CallService::Callback::Callback(
-    AcceleratorConnection &acc, AppID id,
-    const std::map<std::string, ChannelPort &> &channels)
-    : ServicePort(id, channels), arg(getRead(channels, "arg")),
-      result(getWrite(channels, "result")), acc(acc) {
+CallService::Callback::Callback(AcceleratorConnection &acc, AppID id,
+                                const BundleType *type, PortMap channels)
+    : ServicePort(id, type, channels), acc(acc) {
   if (channels.size() != 2)
     throw std::runtime_error("CallService must have exactly two channels");
 }
 
 CallService::Callback *CallService::Callback::get(AcceleratorConnection &acc,
-                                                  AppID id,
+                                                  AppID id, BundleType *type,
                                                   WriteChannelPort &result,
                                                   ReadChannelPort &arg) {
-  return new Callback(acc, id, {{"arg", arg}, {"result", result}});
+  return new Callback(acc, id, type, {{"arg", arg}, {"result", result}});
 }
 
 void CallService::Callback::connect(
     std::function<MessageData(const MessageData &)> callback, bool quick) {
-  result.connect();
+  if (channels.size() != 2)
+    throw std::runtime_error("CallService must have exactly two channels");
+  result = &getRawWrite("result");
+  result->connect();
+  arg = &getRawRead("arg");
   if (quick) {
     // If it's quick, we can just call the callback directly.
-    arg.connect([this, callback](MessageData argMsg) -> bool {
+    arg->connect([this, callback](MessageData argMsg) -> bool {
       MessageData resultMsg = callback(std::move(argMsg));
-      this->result.write(std::move(resultMsg));
+      this->result->write(std::move(resultMsg));
       return true;
     });
   } else {
     // If it's not quick, we need to use the service thread.
-    arg.connect();
+    arg->connect();
     acc.getServiceThread()->addListener(
-        {&arg},
-        [this, callback](ReadChannelPort *, MessageData argMsg) -> void {
+        {arg}, [this, callback](ReadChannelPort *, MessageData argMsg) -> void {
           MessageData resultMsg = callback(std::move(argMsg));
-          this->result.write(std::move(resultMsg));
+          this->result->write(std::move(resultMsg));
         });
   }
 }
@@ -297,9 +276,11 @@ Service *ServiceRegistry::createService(AcceleratorConnection *acc,
                                         HWClientDetails clients) {
   // TODO: Add a proper registration mechanism.
   if (svcType == typeid(FuncService))
-    return new FuncService(acc, id, implName, details, clients);
+    return new FuncService(id, *acc, details, clients);
   if (svcType == typeid(CallService))
-    return new CallService(acc, id, implName, details, clients);
+    return new CallService(*acc, id, details);
+  if (svcType == typeid(CustomService))
+    return new CustomService(id, *acc, details, clients);
   return nullptr;
 }
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
@@ -33,12 +33,17 @@ constexpr uint32_t ESIVersion = 0;
 
 namespace {
 class TraceChannelPort;
-}
+class TraceEngine;
+} // namespace
+
+TraceAccelerator::Impl &TraceAccelerator::getImpl() { return *impl; }
 
 struct esi::backends::trace::TraceAccelerator::Impl {
+  friend class TraceAccelerator;
   Impl(Mode mode, std::filesystem::path manifestJson,
        std::filesystem::path traceFile)
       : manifestJson(manifestJson), traceFile(traceFile) {
+    engine = std::make_unique<TraceEngine>(*this);
     if (!std::filesystem::exists(manifestJson))
       throw std::runtime_error("manifest file '" + manifestJson.string() +
                                "' does not exist");
@@ -63,15 +68,9 @@ struct esi::backends::trace::TraceAccelerator::Impl {
     }
   }
 
-  Service *createService(Service::Type svcType, AppIDPath idPath,
-                         const ServiceImplDetails &details,
+  Service *createService(TraceAccelerator &conn, Service::Type svcType,
+                         AppIDPath idPath, const ServiceImplDetails &details,
                          const HWClientDetails &clients);
-
-  /// Request the host side channel ports for a particular instance (identified
-  /// by the AppID path). For convenience, provide the bundle type and direction
-  /// of the bundle port.
-  std::map<std::string, ChannelPort &> requestChannelsFor(AppIDPath,
-                                                          const BundleType *);
 
   void adoptChannelPort(ChannelPort *port) { channels.emplace_back(port); }
 
@@ -89,6 +88,7 @@ private:
   std::filesystem::path manifestJson;
   std::filesystem::path traceFile;
   std::vector<std::unique_ptr<ChannelPort>> channels;
+  std::unique_ptr<TraceEngine> engine;
 };
 
 void TraceAccelerator::Impl::write(const AppIDPath &id,
@@ -146,17 +146,11 @@ TraceAccelerator::TraceAccelerator(Context &ctxt, Mode mode,
 }
 TraceAccelerator::~TraceAccelerator() { disconnect(); }
 
-Service *TraceAccelerator::createService(Service::Type svcType,
-                                         AppIDPath idPath, std::string implName,
-                                         const ServiceImplDetails &details,
-                                         const HWClientDetails &clients) {
-  return impl->createService(svcType, idPath, details, clients);
-}
 namespace {
 class TraceSysInfo : public SysInfo {
 public:
-  TraceSysInfo(std::filesystem::path manifestJson)
-      : manifestJson(manifestJson) {}
+  TraceSysInfo(AcceleratorConnection &conn, std::filesystem::path manifestJson)
+      : SysInfo(conn), manifestJson(manifestJson) {}
 
   uint32_t getEsiVersion() const override { return ESIVersion; }
 
@@ -232,39 +226,39 @@ private:
 } // namespace
 
 namespace {
-class TraceCustomService : public CustomService {
+class TraceEngine : public Engine {
 public:
-  TraceCustomService(TraceAccelerator::Impl &impl, AppIDPath idPath,
-                     const ServiceImplDetails &details,
-                     const HWClientDetails &clients)
-      : CustomService(idPath, details, clients) {}
+  TraceEngine(TraceAccelerator::Impl &impl) : impl(impl) {}
+
+  std::unique_ptr<ChannelPort> createPort(AppIDPath idPath,
+                                          const std::string &channelName,
+                                          BundleType::Direction dir,
+                                          const Type *type) override {
+    std::unique_ptr<ChannelPort> port;
+    if (BundlePort::isWrite(dir))
+      port = std::make_unique<WriteTraceChannelPort>(impl, type, idPath,
+                                                     channelName);
+    else
+      port = std::make_unique<ReadTraceChannelPort>(impl, type);
+    return port;
+  }
+
+private:
+  TraceAccelerator::Impl &impl;
 };
 } // namespace
 
-std::map<std::string, ChannelPort &>
-TraceAccelerator::Impl::requestChannelsFor(AppIDPath idPath,
-                                           const BundleType *bundleType) {
-  std::map<std::string, ChannelPort &> channels;
-  for (auto [name, dir, type] : bundleType->getChannels()) {
-    ChannelPort *port;
-    if (BundlePort::isWrite(dir))
-      port = new WriteTraceChannelPort(*this, type, idPath, name);
-    else
-      port = new ReadTraceChannelPort(*this, type);
-    channels.emplace(name, *port);
-    adoptChannelPort(port);
-  }
-  return channels;
-}
-
-std::map<std::string, ChannelPort &> TraceAccelerator::requestChannelsFor(
-    AppIDPath idPath, const BundleType *bundleType, const ServiceTable &) {
-  return impl->requestChannelsFor(idPath, bundleType);
+void TraceAccelerator::createEngine(const std::string &dmaEngineName,
+                                    AppIDPath idPath,
+                                    const ServiceImplDetails &details,
+                                    const HWClientDetails &clients) {
+  registerEngine(idPath, std::make_unique<TraceEngine>(getImpl()), clients);
 }
 
 class TraceMMIO : public MMIO {
 public:
-  TraceMMIO(TraceAccelerator::Impl &impl) : impl(impl) {}
+  TraceMMIO(TraceAccelerator &conn, const HWClientDetails &clients)
+      : MMIO(conn, clients), impl(conn.getImpl()) {}
 
   virtual uint64_t read(uint32_t addr) const override {
     uint64_t data = rand();
@@ -286,7 +280,7 @@ private:
 
 class TraceHostMem : public HostMem {
 public:
-  TraceHostMem(TraceAccelerator::Impl &impl) : impl(impl) {}
+  TraceHostMem(TraceAccelerator &conn) : HostMem(conn), impl(conn.getImpl()) {}
 
   struct TraceHostMemRegion : public HostMemRegion {
     TraceHostMemRegion(std::size_t size, TraceAccelerator::Impl &impl)
@@ -338,18 +332,16 @@ private:
   TraceAccelerator::Impl &impl;
 };
 
-Service *
-TraceAccelerator::Impl::createService(Service::Type svcType, AppIDPath idPath,
-                                      const ServiceImplDetails &details,
-                                      const HWClientDetails &clients) {
+Service *TraceAccelerator::createService(Service::Type svcType,
+                                         AppIDPath idPath, std::string implName,
+                                         const ServiceImplDetails &details,
+                                         const HWClientDetails &clients) {
   if (svcType == typeid(SysInfo))
-    return new TraceSysInfo(manifestJson);
+    return new TraceSysInfo(*this, getImpl().manifestJson);
   if (svcType == typeid(MMIO))
-    return new TraceMMIO(*this);
+    return new TraceMMIO(*this, clients);
   if (svcType == typeid(HostMem))
     return new TraceHostMem(*this);
-  if (svcType == typeid(CustomService))
-    return new TraceCustomService(*this, idPath, details, clients);
   return nullptr;
 }
 

--- a/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esitester.cpp
@@ -101,6 +101,11 @@ void registerCallbacks(AcceleratorConnection *conn, Accelerator *accel) {
             return MessageData();
           },
           true);
+    else
+      std::cerr << "PrintfExample port is not a CallService::Callback"
+                << std::endl;
+  } else {
+    std::cerr << "No PrintfExample port found" << std::endl;
   }
 }
 

--- a/test/Dialect/ESI/manifest.mlir
+++ b/test/Dialect/ESI/manifest.mlir
@@ -55,7 +55,7 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 
 // HIER-LABEL:  esi.manifest.compressed <"{{.+}}">
 // HIER-LABEL:  esi.manifest.hier_root @top {
-// HIER-NEXT:     esi.manifest.service_impl #esi.appid<"cosim"> svc @HostComms by "cosim" with {} {
+// HIER-NEXT:     esi.manifest.service_impl #esi.appid<"cosim"> svc @HostComms by "cosim" engine with {} {
 // HIER-NEXT:       esi.manifest.impl_conn [#esi.appid<"loopback_inst"[0]>, #esi.appid<"loopback_tohw">] req <@HostComms::@Recv>(!esi.bundle<[!esi.channel<i8> to "recv"]>) channels {recv = {name = "loopback_inst[0].loopback_tohw.recv", type = "cosim"}}
 // HIER-NEXT:       esi.manifest.impl_conn [#esi.appid<"loopback_inst"[0]>, #esi.appid<"loopback_fromhw">] req <@HostComms::@Send>(!esi.bundle<[!esi.channel<i8> from "send"]>) channels {send = {name = "loopback_inst[0].loopback_fromhw.send", type = "cosim"}}
 // HIER-NEXT:       esi.manifest.impl_conn [#esi.appid<"loopback_inst"[0]>, #esi.appid<"loopback_fromhw_i0">] req <@HostComms::@SendI0>(!esi.bundle<[!esi.channel<i0> from "send"]>) channels {send = {name = "loopback_inst[0].loopback_fromhw_i0.send", type = "cosim"}}
@@ -111,7 +111,7 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 // CHECK-NEXT:        }
 // CHECK-NEXT:      ],
 
-// CHECK-LABEL:     "services": [
+// CHECK-LABEL:     "engines": [
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "appID": {
 // CHECK-NEXT:            "name": "cosim"

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -106,7 +106,7 @@ hw.module @InOutLoopback (in %clk: !seq.clock) {
 // CONN-LABEL:  esi.pure_module @LoopbackCosimPure {
 // CONN-NEXT:     [[clk:%.+]] = esi.pure_module.input "clk" : !seq.clock
 // CONN-NEXT:     [[rst:%.+]] = esi.pure_module.input "rst" : i1
-// CONN-NEXT:     esi.manifest.service_impl #esi.appid<"cosim"> svc @HostComms by "cosim" with {} {
+// CONN-NEXT:     esi.manifest.service_impl #esi.appid<"cosim"> svc @HostComms by "cosim" engine with {} {
 // CONN-NEXT:       esi.manifest.impl_conn [#esi.appid<"loopback_inout">] req <@HostComms::@ReqResp>(!esi.bundle<[!esi.channel<i16> to "req", !esi.channel<i8> from "resp"]>) channels {req = {name = "loopback_inout.req", type = "cosim"}, resp = {name = "loopback_inout.resp", type = "cosim"}}
 // CONN-NEXT:     }
 // CONN-NEXT:     [[r2:%.+]] = esi.cosim.from_host [[clk]], [[rst]], "loopback_inout.req" : !esi.channel<i16>
@@ -194,7 +194,7 @@ hw.module @CallableFunc1() {
 
 // CONN-LABEL:   hw.module @CallableAccel1(in %clk : !seq.clock, in %rst : i1) {
 // CONN-NEXT:      hw.instance "func1" @CallableFunc1(func1: %bundle: !esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>) -> ()
-// CONN-NEXT:      esi.manifest.service_impl #esi.appid<"funcComms"> svc @funcs std "esi.service.std.func" by "cosim" with {} {
+// CONN-NEXT:      esi.manifest.service_impl #esi.appid<"funcComms"> svc @funcs std "esi.service.std.func" by "cosim" engine with {} {
 // CONN-NEXT:        esi.manifest.impl_conn [#esi.appid<"func1">] req <@funcs::@call>(!esi.bundle<[!esi.channel<i16> to "arg", !esi.channel<i16> from "result"]>) channels {arg = {name = "func1.arg", type = "cosim"}, result = {name = "func1.result", type = "cosim"}}
 // CONN-NEXT:      }
 // CONN-NEXT:      %0 = esi.cosim.from_host %clk, %rst, "func1.arg" : !esi.channel<i16>


### PR DESCRIPTION
Introduces the concept of 'engines' -- things which are responsible for transmitting/recieving messages over a channel. Since this is a new concept (and was previously done only in cosim), add a new section to the manifest.

Re-use a bunch of stuff which supports services. Hacky, but it works. The entire manifest thing could use a re-think and second iteration. It is, however, make-it-work time.