### PR TITLE
[firtool] Add an option to emit HW MLIR into file

### DIFF
--- a/test/firtool/firtool.mlir
+++ b/test/firtool/firtool.mlir
@@ -2,24 +2,29 @@
 // RUN: firtool %s --format=mlir --ir-fir --emit-bytecode | circt-opt | FileCheck %s --check-prefix=MLIR
 // RUN: circt-opt %s --emit-bytecode | firtool --ir-fir | circt-opt | FileCheck %s --check-prefix=MLIR
 // RUN: firtool %s --format=mlir -verilog | FileCheck %s --check-prefix=VERILOG
-// RUN: firtool %s --format=mlir -verilog -output-final-mlir=%t | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
-// RUN: firtool %s --format=mlir -verilog -output-final-mlir=%t.mlirbc -emit-bytecode | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
+// RUN: firtool %s --format=mlir -verilog -output-final-mlir=%t -output-hw-mlir=%t.hw.mlir | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
+// RUN: firtool %s --format=mlir -verilog -output-final-mlir=%t.mlirbc -output-hw-mlir=%t.hw.mlirbc -emit-bytecode | FileCheck %s --check-prefix=VERILOG-WITH-MLIR
 // RUN: FileCheck %s --input-file=%t --check-prefix=VERILOG-WITH-MLIR-OUT
 // RUN: circt-opt %t.mlirbc | FileCheck %s --check-prefix=VERILOG-WITH-MLIR-OUT
 // RUN: not diff %t %t.mlirbc
+// RUN: FileCheck %s --input-file=%t.hw.mlir --check-prefix=VERILOG-WITH-HW-MLIR-OUT
+// RUN: circt-opt %t.hw.mlirbc | FileCheck %s --check-prefix=VERILOG-WITH-HW-MLIR-OUT
+// RUN: not diff %t.hw.mlir %t.hw.mlirbc
+
 
 firrtl.circuit "Top" {
-  firrtl.module @Top(in %in : !firrtl.uint<8>,
+  firrtl.module @Top(in %clock: !firrtl.clock, in %in : !firrtl.uint<8>,
                      out %out : !firrtl.uint<8>) {
     firrtl.connect %out, %in : !firrtl.uint<8>, !firrtl.uint<8>
   }
 }
 
-// MLIR-LABEL: firrtl.module @Top(in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
+// MLIR-LABEL: firrtl.module @Top(in %clock: !firrtl.clock, in %in: !firrtl.uint<8>, out %out: !firrtl.uint<8>) {
 // MLIR-NEXT:    firrtl.matchingconnect %out, %in : !firrtl.uint<8>
 // MLIR-NEXT:  }
 
 // VERILOG-LABEL: module Top(
+// VERILOG-NEXT:    input clock,
 // VERILOG-NEXT:    input  [7:0] in,
 // VERILOG-NEXT:    output [7:0] out
 // VERILOG-NEXT:    );
@@ -28,6 +33,7 @@ firrtl.circuit "Top" {
 // VERILOG-NEXT:  endmodule
 
 // VERILOG-WITH-MLIR-LABEL: module Top(
+// VERILOG-WITH-MLIR-NEXT:    input clock,
 // VERILOG-WITH-MLIR-NEXT:    input  [7:0] in,
 // VERILOG-WITH-MLIR-NEXT:    output [7:0] out
 // VERILOG-WITH-MLIR-NEXT:  );
@@ -35,6 +41,11 @@ firrtl.circuit "Top" {
 // VERILOG-WITH-MLIR-NEXT:    assign out = in;
 // VERILOG-WITH-MLIR-NEXT:  endmodule
 
-// VERILOG-WITH-MLIR-OUT-LABEL: hw.module @Top(in %in : i8, out out : i8) {
+// VERILOG-WITH-MLIR-OUT-LABEL: hw.module @Top(in %clock : i1, in %in : i8, out out : i8) {
 // VERILOG-WITH-MLIR-OUT-NEXT:    hw.output %in : i8
 // VERILOG-WITH-MLIR-OUT-NEXT:  }
+
+// Check there is !seq.clock
+// VERILOG-WITH-HW-MLIR-OUT-LABEL: hw.module @Top(in %clock : !seq.clock, in %in : i8, out out : i8) {
+// VERILOG-WITH-HW-MLIR-OUT-NEXT:    hw.output %in : i8
+// VERILOG-WITH-HW-MLIR-OUT-NEXT:  }

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -495,7 +495,7 @@ static LogicalResult processBuffer(
                                             (*outputFile)->os())))
         return failure();
 
-    // If requseted, emit the HW IR to hwOutFile.
+    // If requested, emit the HW IR to hwOutFile.
     if (!hwOutFile.empty())
       pm.addPass(std::make_unique<DumpIRPass>(hwOutFile.getValue()));
 

--- a/tools/firtool/firtool.cpp
+++ b/tools/firtool/firtool.cpp
@@ -207,6 +207,12 @@ static cl::list<std::string> inputAnnotationFilenames(
     cl::CommaSeparated, cl::value_desc("filename"), cl::cat(mainCategory));
 
 static cl::opt<std::string>
+    hwOutFile("output-hw-mlir",
+              cl::desc("Optional file name to output the HW IR into, in "
+                       "addition to the output requested by -o"),
+              cl::init(""), cl::value_desc("filename"), cl::cat(mainCategory));
+
+static cl::opt<std::string>
     mlirOutFile("output-final-mlir",
                 cl::desc("Optional file name to output the final MLIR into, in "
                          "addition to the output requested by -o"),
@@ -336,6 +342,38 @@ struct EmitSplitHGLDDPass
   }
 };
 
+/// Wrapper pass to dump IR.
+struct DumpIRPass
+    : public PassWrapper<DumpIRPass, OperationPass<mlir::ModuleOp>> {
+  DumpIRPass(const std::string &outputFile)
+      : PassWrapper<DumpIRPass, OperationPass<mlir::ModuleOp>>() {
+    this->outputFile.setValue(outputFile);
+  }
+
+  DumpIRPass(const DumpIRPass &other) : PassWrapper(other) {
+    outputFile.setValue(other.outputFile.getValue());
+  }
+
+  void runOnOperation() override {
+    assert(!outputFile.empty());
+
+    std::string error;
+    auto mlirFile = openOutputFile(outputFile.getValue(), &error);
+    if (!mlirFile) {
+      errs() << error;
+      return signalPassFailure();
+    }
+
+    if (failed(printOp(getOperation(), mlirFile->os())))
+      return signalPassFailure();
+    mlirFile->keep();
+    markAllAnalysesPreserved();
+  }
+
+  Pass::Option<std::string> outputFile{*this, "output-file",
+                                       cl::desc("filename"), cl::init("-")};
+};
+
 /// Process a single buffer of the input.
 static LogicalResult processBuffer(
     MLIRContext &context, firtool::FirtoolOptions &firtoolOptions,
@@ -456,6 +494,11 @@ static LogicalResult processBuffer(
       if (failed(firtool::populateHWToBTOR2(pm, firtoolOptions,
                                             (*outputFile)->os())))
         return failure();
+
+    // If requseted, emit the HW IR to hwOutFile.
+    if (!hwOutFile.empty())
+      pm.addPass(std::make_unique<DumpIRPass>(hwOutFile.getValue()));
+
     if (outputFormat != OutputIRHW)
       if (failed(firtool::populateHWToSV(pm, firtoolOptions)))
         return failure();
@@ -504,11 +547,15 @@ static LogicalResult processBuffer(
       break;
     }
 
-    // Run final IR mutations to clean it up after ExportVerilog and before
-    // emitting the final MLIR.
-    if (!mlirOutFile.empty())
+    // If requested, print the final MLIR into mlirOutFile.
+    if (!mlirOutFile.empty()) {
+      // Run final IR mutations to clean it up after ExportVerilog and before
+      // emitting the final MLIR.
       if (failed(firtool::populateFinalizeIR(pm, firtoolOptions)))
         return failure();
+
+      pm.addPass(std::make_unique<DumpIRPass>(mlirOutFile.getValue()));
+    }
   }
 
   if (failed(pm.run(module.get())))
@@ -519,20 +566,6 @@ static LogicalResult processBuffer(
     auto outputTimer = ts.nest("Print .mlir output");
     if (failed(printOp(*module, (*outputFile)->os())))
       return failure();
-  }
-
-  // If requested, print the final MLIR into mlirOutFile.
-  if (!mlirOutFile.empty()) {
-    std::string mlirOutError;
-    auto mlirFile = openOutputFile(mlirOutFile, &mlirOutError);
-    if (!mlirFile) {
-      llvm::errs() << mlirOutError;
-      return failure();
-    }
-
-    if (failed(printOp(*module, mlirFile->os())))
-      return failure();
-    mlirFile->keep();
   }
 
   // We intentionally "leak" the Module into the MLIRContext instead of


### PR DESCRIPTION
This PR adds `-output-hw-mlir` option to firtool which emits HW IR into file in a similar way to `-output-final-mlir`. 

This PR adds `DumpIR` pass to simplify the emission. It's currently not exposed to other tool as it's very specific to firtool pipeline (actually the pass indirectly uses cl options defined in firtool.cpp)  