### PR TITLE
[circt-verilog] Fix negative Rest timing

### DIFF
--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -363,8 +363,6 @@ static LogicalResult executeWithSources(MLIRContext *context,
   OwningOpRef<ModuleOp> module;
   switch (opts.format) {
   case Format::SV: {
-    auto parserTimer = ts.nest("SystemVerilog Parser");
-
     // If the user requested for the files to be only preprocessed, do so and
     // print the results to the configured output file.
     if (opts.loweringMode == LoweringMode::OnlyPreprocess) {


### PR DESCRIPTION
In the pass timing summary there is usually a negative amount for Rest which is the result of measuring the verilog parsing and preprocessing twice