### PR TITLE
[MooreToCore] Convert SCF ops inside llhd.process to CF

### DIFF
--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -36,6 +36,9 @@ enum class OpCountEmissionFormat {
 
 #include "circt/Transforms/Passes.h.inc"
 
+void populateArithToCombPatterns(mlir::RewritePatternSet &patterns,
+                                 TypeConverter &typeConverter);
+
 std::unique_ptr<mlir::Pass> createMapArithToCombPass();
 std::unique_ptr<mlir::Pass> createFlattenMemRefPass();
 std::unique_ptr<mlir::Pass> createFlattenMemRefCallsPass();

--- a/lib/Conversion/MooreToCore/CMakeLists.txt
+++ b/lib/Conversion/MooreToCore/CMakeLists.txt
@@ -15,9 +15,11 @@ add_circt_conversion_library(CIRCTMooreToCore
   CIRCTMoore
   CIRCTSim
   CIRCTVerif
+  CIRCTTransforms
   MLIRControlFlowDialect
   MLIRFuncDialect
   MLIRSCFDialect
+  MLIRSCFToControlFlow
   MLIRSideEffectInterfaces
   MLIRTransforms
 )

--- a/lib/Transforms/MapArithToComb.cpp
+++ b/lib/Transforms/MapArithToComb.cpp
@@ -163,25 +163,7 @@ public:
     target.addIllegalDialect<arith::ArithDialect>();
     MapArithTypeConverter typeConverter;
     RewritePatternSet patterns(ctx);
-
-    patterns.insert<OneToOnePattern<arith::AddIOp, comb::AddOp>,
-                    OneToOnePattern<arith::SubIOp, comb::SubOp>,
-                    OneToOnePattern<arith::MulIOp, comb::MulOp>,
-                    OneToOnePattern<arith::DivSIOp, comb::DivSOp>,
-                    OneToOnePattern<arith::DivUIOp, comb::DivUOp>,
-                    OneToOnePattern<arith::RemSIOp, comb::ModSOp>,
-                    OneToOnePattern<arith::RemUIOp, comb::ModUOp>,
-                    OneToOnePattern<arith::AndIOp, comb::AndOp>,
-                    OneToOnePattern<arith::OrIOp, comb::OrOp>,
-                    OneToOnePattern<arith::XOrIOp, comb::XorOp>,
-                    OneToOnePattern<arith::ShLIOp, comb::ShlOp>,
-                    OneToOnePattern<arith::ShRSIOp, comb::ShrSOp>,
-                    OneToOnePattern<arith::ShRUIOp, comb::ShrUOp>,
-                    OneToOnePattern<arith::ConstantOp, hw::ConstantOp, true>,
-                    OneToOnePattern<arith::SelectOp, comb::MuxOp>,
-                    ExtSConversionPattern, ExtZConversionPattern,
-                    TruncateConversionPattern, CompConversionPattern>(
-        typeConverter, ctx);
+    populateArithToCombPatterns(patterns, typeConverter);
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns))))
@@ -190,6 +172,28 @@ public:
 };
 
 } // namespace
+
+void circt::populateArithToCombPatterns(mlir::RewritePatternSet &patterns,
+                                        TypeConverter &typeConverter) {
+  patterns.insert<OneToOnePattern<arith::AddIOp, comb::AddOp>,
+                  OneToOnePattern<arith::SubIOp, comb::SubOp>,
+                  OneToOnePattern<arith::MulIOp, comb::MulOp>,
+                  OneToOnePattern<arith::DivSIOp, comb::DivSOp>,
+                  OneToOnePattern<arith::DivUIOp, comb::DivUOp>,
+                  OneToOnePattern<arith::RemSIOp, comb::ModSOp>,
+                  OneToOnePattern<arith::RemUIOp, comb::ModUOp>,
+                  OneToOnePattern<arith::AndIOp, comb::AndOp>,
+                  OneToOnePattern<arith::OrIOp, comb::OrOp>,
+                  OneToOnePattern<arith::XOrIOp, comb::XorOp>,
+                  OneToOnePattern<arith::ShLIOp, comb::ShlOp>,
+                  OneToOnePattern<arith::ShRSIOp, comb::ShrSOp>,
+                  OneToOnePattern<arith::ShRUIOp, comb::ShrUOp>,
+                  OneToOnePattern<arith::ConstantOp, hw::ConstantOp, true>,
+                  OneToOnePattern<arith::SelectOp, comb::MuxOp>,
+                  ExtSConversionPattern, ExtZConversionPattern,
+                  TruncateConversionPattern, CompConversionPattern>(
+      typeConverter, patterns.getContext());
+}
 
 std::unique_ptr<mlir::Pass> circt::createMapArithToCombPass() {
   return std::make_unique<MapArithToCombPass>();

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1034,3 +1034,15 @@ func.func @PowSOp(%arg0: !moore.i32, %arg1: !moore.i32) {
   %0 = moore.pows %arg0, %arg1 : i32
   return
 }
+
+// CHECK-LABEL: @scfInsideProcess
+moore.module @scfInsideProcess(in %in0: !moore.i32, in %in1: !moore.i32) {
+  %var = moore.variable : <!moore.i32>
+  // CHECK: llhd.process
+  // CHECK-NOT: scf.for
+  moore.procedure initial {
+    %0 = moore.pows %in0, %in1 : !moore.i32
+    moore.blocking_assign %var, %0 : !moore.i32
+    moore.return
+  }
+}


### PR DESCRIPTION
While this would be legal, having everything in CF is more canonical than mixing them. Thus making it easier for passes further down the pipeline.