### PR TITLE
[WIP] PrintHWModuleJsonPass

### DIFF
--- a/include/circt/Dialect/HW/HWPasses.h
+++ b/include/circt/Dialect/HW/HWPasses.h
@@ -27,6 +27,7 @@ namespace hw {
 std::unique_ptr<mlir::Pass> createPrintInstanceGraphPass();
 std::unique_ptr<mlir::Pass> createHWSpecializePass();
 std::unique_ptr<mlir::Pass> createPrintHWModuleGraphPass();
+std::unique_ptr<mlir::Pass> createPrintHWModuleJsonPass();
 std::unique_ptr<mlir::Pass> createFlattenIOPass(bool recursiveFlag = true,
                                                 bool flattenExternFlag = false,
                                                 char joinChar = '.');

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -30,6 +30,11 @@ def PrintHWModuleGraph : Pass<"hw-print-module-graph", "mlir::ModuleOp"> {
   ];
 }
 
+def PrintHWModuleJson : Pass<"hw-print-module-json", "mlir::ModuleOp"> {
+  let summary = "Print a JSON representation of the HWModule's within a top-level module.";
+  let constructor =  "circt::hw::createPrintHWModuleJsonPass()";
+}
+
 def FlattenIO : Pass<"hw-flatten-io", "mlir::ModuleOp"> {
   let summary = "Flattens hw::Structure typed in- and output ports.";
   let constructor =  "circt::hw::createFlattenIOPass()";

--- a/lib/Dialect/HW/Transforms/CMakeLists.txt
+++ b/lib/Dialect/HW/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_dialect_library(CIRCTHWTransforms
   HWPrintInstanceGraph.cpp
   HWSpecialize.cpp
   PrintHWModuleGraph.cpp
+  PrintHWModuleJson.cpp
   FlattenIO.cpp
   VerifyInnerRefNamespace.cpp
   FlattenModules.cpp

--- a/lib/Dialect/HW/Transforms/PrintHWModuleJson.cpp
+++ b/lib/Dialect/HW/Transforms/PrintHWModuleJson.cpp
@@ -1,0 +1,42 @@
+//===- PrintHWModuleJson.cpp - Print the instance graph --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//===----------------------------------------------------------------------===//
+//
+// Prints an HW module as a JSON graph compatible with Google's Model Explorer.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWPasses.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace circt {
+namespace hw {
+#define GEN_PASS_DEF_PRINTHWMODULEJSON
+#include "circt/Dialect/HW/Passes.h.inc"
+} // namespace hw
+} // namespace circt
+
+using namespace circt;
+using namespace hw;
+
+namespace {
+struct PrintHWModuleJsonPass
+    : public circt::hw::impl::PrintHWModuleJsonBase<PrintHWModuleJsonPass> {
+  PrintHWModuleJsonPass(raw_ostream &os) : os(os) {}
+  void runOnOperation() override {
+    getOperation().walk([&](hw::HWModuleOp module) {
+      os << "hello world\n";
+    });
+  }
+  raw_ostream &os;
+};
+} // end anonymous namespace
+
+std::unique_ptr<mlir::Pass> circt::hw::createPrintHWModuleJsonPass() {
+  return std::make_unique<PrintHWModuleJsonPass>(llvm::errs());
+}

--- a/test/Dialect/HW/print-instance-json.mlir
+++ b/test/Dialect/HW/print-instance-json.mlir
@@ -1,0 +1,18 @@
+// RUN: circt-opt -hw-print-instance-graph %s -o %t 2>&1 | FileCheck %s
+
+// TODO: write the tests
+
+hw.module @Top() {
+  hw.instance "alligator" @Alligator() -> ()
+  hw.instance "cat" @Cat() -> ()
+}
+
+hw.module private @Alligator() {
+  hw.instance "bear" @Bear() -> ()
+}
+
+hw.module private @Bear() {
+  hw.instance "cat" @Cat() -> ()
+}
+
+hw.module private @Cat() { }


### PR DESCRIPTION
This PR creates a new CIRCT pass, targeting the `hw` dialect, that serves as a counterpart to the `hw-print-module-graph` pass. The goal is to output a JSON representation that is compatible with Google's [model explorer](https://github.com/google-ai-edge/model-explorer).

- [ ] Implement the graph traversal and JSON output
- [ ] Write and pass the unit tests at `Dialect/HW/print-instance-json.mlir`
- [ ] Create Python bindings