### PR TITLE
[ESI][BSP] Service implementation via selectable engine

### DIFF
--- a/frontends/PyCDE/src/pycde/bsp/__init__.py
+++ b/frontends/PyCDE/src/pycde/bsp/__init__.py
@@ -4,13 +4,15 @@
 
 from typing import Optional
 
-from .cosim import CosimBSP
+from .cosim import CosimBSP, CosimBSP_DMA
 from .xrt import XrtBSP
 
 
 def get_bsp(name: Optional[str] = None):
   if name is None or name == "cosim":
     return CosimBSP
+  elif name == "cosim_dma":
+    return CosimBSP_DMA
   elif name == "xrt":
     return XrtBSP
   elif name == "xrt_cosim":

--- a/frontends/PyCDE/src/pycde/bsp/xrt.py
+++ b/frontends/PyCDE/src/pycde/bsp/xrt.py
@@ -11,7 +11,8 @@ from ..support import clog2
 from ..types import Array, Bits, Channel, UInt
 from .. import esi
 
-from .common import ChannelHostMem, ChannelMMIO, Reset
+from .common import (ChannelEngineService, ChannelHostMem, ChannelMMIO,
+                     DummyFromHostEngine, DummyToHostEngine, Reset)
 
 import glob
 import pathlib
@@ -307,10 +308,14 @@ def XrtBSP(user_module):
     @generator
     def construct(ports):
       System.current().platform = "fpga"
+      clk = ports.ap_clk
       rst = ~ports.ap_resetn
 
       # Instantiate the user module.
       XrtChannelsTmplInst = XrtChannelTop(user_module)
+
+      ChannelEngineService(DummyToHostEngine, DummyFromHostEngine)(
+          None, appid=esi.AppID("__channel_engines"), clk=clk, rst=rst)
 
       # Set up the MMIO service and tie it to the AXI-lite channels.
       read_address, arready = Channel(

--- a/frontends/PyCDE/src/pycde/types.py
+++ b/frontends/PyCDE/src/pycde/types.py
@@ -469,6 +469,8 @@ class BitVectorType(Type):
 class Bits(BitVectorType):
 
   def __new__(cls, width: int):
+    if width < 0:
+      raise ValueError("Bits width must be non-negative")
     return super(Bits, cls).__new__(
         cls,
         ir.IntegerType.get_signless(width),


### PR DESCRIPTION
`ChannelEngineService` is a service implementation which services channels via selectable DMA engines.

In order to emulate (and test) DMA engines, adds a `cosim_dma` BSP. Involved a re-write of the CosimBSP since the builtin 'cosim' service implementation wants to service all of the outstanding client requests.