### PR TITLE
[LLHD][TCM] Ignore processes with CFG loops within a TR

### DIFF
--- a/lib/Dialect/LLHD/Transforms/TemporalRegions.cpp
+++ b/lib/Dialect/LLHD/Transforms/TemporalRegions.cpp
@@ -91,6 +91,11 @@ void llhd::TemporalRegionAnalysis::recalculate(Operation *operation) {
       // If at least one predecessor has a wait terminator or at least one
       // predecessor has an unknown temporal region or not all predecessors have
       // the same TR, create a new TR
+      // FIXME: `!allPredecessorTRsKnown` is a problem when there are CFG loops
+      // in the process. If there is no wait op along any of the CFG edges of
+      // such a loop we don't want to assign a new temporal region. However, we
+      // also cannot just assume here that we can just assign the same TR, so
+      // this might require a bigger change to the algorithm.
     } else if (!allPredecessorTRsKnown(block, workDone) ||
                anyPredecessorHasWait(block) ||
                !(std::adjacent_find(block->pred_begin(), block->pred_end(),

--- a/test/Dialect/LLHD/Transforms/temporal-code-motion.mlir
+++ b/test/Dialect/LLHD/Transforms/temporal-code-motion.mlir
@@ -205,3 +205,18 @@ hw.module @more_than_one_TR_wait_terminator(in %cond: i1) {
     cf.br ^bb1
   }
 }
+
+// CHECK-LABEL: @unsupportedLoop
+hw.module @unsupportedLoop() {
+  // CHECK-NEXT: llhd.process {
+  // CHECK-NEXT:   cf.br ^bb
+  // CHECK-NEXT: ^bb
+  // CHECK-NEXT:   llhd.wait ^bb
+  // CHECK-NEXT: }
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    llhd.wait ^bb1
+  }
+  hw.output
+}


### PR DESCRIPTION
Ignore loops for now and basically assume full loop unrolling was performed before this pass. This was an implicit assumption until now. This PR explicitly checks for it and ignores the process in that case.