### PR TITLE
[FIRRTL] Add a folder for `add` property op

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1393,6 +1393,8 @@ def IntegerAddOp : IntegerBinaryPrimOp<"integer.add", [Commutative]> {
                                          !firrtl.integer
     ```
   }];
+
+  let hasFolder = true;
 }
 
 def IntegerMulOp : IntegerBinaryPrimOp<"integer.mul", [Commutative]> {

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3576,19 +3576,28 @@ firrtl.module private @Issue7562(in %sel : !firrtl.uint<1>, in %a : !firrtl.cons
 }
 
 // CHECK-LABEL: firrtl.class @PropertyArithmetic
-firrtl.class @PropertyArithmetic(in %in: !firrtl.integer, out %out0: !firrtl.integer, out %out1: !firrtl.integer) {
+firrtl.class @PropertyArithmetic(in %in: !firrtl.integer, out %out0: !firrtl.integer, out %out1: !firrtl.integer, out %out2: !firrtl.integer, out %out3: !firrtl.integer) {
+  // CHECK: [[C3:%.+]] = firrtl.integer 3
   // CHECK: [[C4:%.+]] = firrtl.integer 4
   %0 = firrtl.integer 0
   %1 = firrtl.integer 1
   %2 = firrtl.integer 2
 
-  %3 = firrtl.integer.shl %1, %2 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
-  %4 = firrtl.integer.shl %in, %0 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+  %res0 = firrtl.integer.shl %1, %2 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+  %res1 = firrtl.integer.shl %in, %0 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
 
   // CHECK: firrtl.propassign %out0, [[C4]]
   // CHECK: firrtl.propassign %out1, %in
-  firrtl.propassign %out0, %3 : !firrtl.integer
-  firrtl.propassign %out1, %4 : !firrtl.integer
+  firrtl.propassign %out0, %res0 : !firrtl.integer
+  firrtl.propassign %out1, %res1 : !firrtl.integer
+
+  %res2 = firrtl.integer.add %1, %2 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+  %res3 = firrtl.integer.add %in, %0 : (!firrtl.integer, !firrtl.integer) -> !firrtl.integer
+
+  // CHECK: firrtl.propassign %out2, [[C3]]
+  // CHECK: firrtl.propassign %out3, %in
+  firrtl.propassign %out2, %res2 : !firrtl.integer
+  firrtl.propassign %out3, %res3 : !firrtl.integer
 }
 
 // CHECK-LABEL: firrtl.module private @LayerBlocks


### PR DESCRIPTION
Hi @mikeurbach,

This PR addresses https://github.com/llvm/circt/issues/6696.

It's a first-time contribution for me and these issues remained open for quite some time. I hope I didn't take anyone's assignment.

In `canonicalization.mlir` file I got an error when tried to reformat `firrtl.class @PropertyArithmetic...` line into multiple lines. Does `firrtl.class` support same format as `firrtl.module` in `mlir` files?

In a follow-up PR I can add other folding rules that were listed in aforementioned issues. Does `x + x -> x * 2` fold also makes sense here?