### PR TITLE
[MooreToCore] Properly deal with OOB access in dyn_extract

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1123,7 +1123,7 @@ def ExtractOp : MooreOp<"extract", [Pure]> {
 def DynExtractOp : MooreOp<"dyn_extract", [Pure]> {
   let description = [{
     It's similar with extract, but it's used to select from a value
-    with a dynamic low bit.
+    with a dynamic low bit. The `lowBit` operand is always interpreted as unsigned.
   }];
   let arguments = (ins UnpackedType:$input, UnpackedType:$lowBit);
   let results = (outs UnpackedType:$result);

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -199,7 +199,11 @@ func.func @Expressions(%arg0: !moore.i1, %arg1: !moore.l1, %arg2: !moore.i6, %ar
   // CHECK-NEXT: [[V23:%.+]] = comb.extract %c2_i32 from 0 : (i32) -> i3
   // CHECK-NEXT: [[MAX:%.+]] = hw.constant -1 : i3
   // CHECK-NEXT: [[V24:%.+]] = comb.mux [[V22]], [[V23]], [[MAX]] : i3
-  // CHECK-NEXT: hw.array_get %arg5[[[V24]]] : !hw.array<5xi32>
+  // CHECK-NEXT: [[C5:%.+]] = hw.constant 5 : i32 
+  // CHECK-NEXT: [[V25:%.+]] = comb.icmp uge %c2_i32, [[C5]] : i32 
+  // CHECK-NEXT: [[V26:%.+]] = hw.array_get %arg5[[[V24]]] : !hw.array<5xi32>
+  // CHECK-NEXT: [[C0:%.+]] = hw.constant 0 : i32 
+  // CHECK-NEXT: [[V27:%.+]] = comb.mux [[V25]], [[C0]], [[V26]] : i32 
   moore.dyn_extract %arg5 from %2 : !moore.array<5 x i32>, !moore.i32 -> !moore.i32
 
   // CHECK-NEXT: [[V21:%.+]] = comb.extract %c0_i32 from 0 : (i32) -> i32


### PR DESCRIPTION
The array slice case is not fixed yet. I couldn't really find a part in the SV standard about signed/unsigned indexing. I assume always interpreting the index operand as unsigned is fine.