### PR TITLE
[HW] Resolve ambiguous array_slice documentation

### DIFF
--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -129,12 +129,6 @@ def ArraySliceOp : HWOp<"array_slice", [Pure]> {
         (!hw.array<1024xi8>) -> !hw.array<16xi8>
     ```
 
-    Would translate to the following SystemVerilog:
-
-    ```
-    logic [7:0][15:0] subArray = largerArray[offset +: 16];
-    ```
-
     Width of 'idx' is defined to be the precise number of bits required to
     index the 'input' array. More precisely: for an input array of size M,
     the width of 'idx' is ceil(log2(M)). Lower and upper bound indexes which


### PR DESCRIPTION
The documentation explicitly states that an OOB access is UB, but also says that it is equivalent to the verilog example. However, OOB in verilog would return the default value of the type (e.g., 0 for 2-state) AFAIU, so it has different semantics. Also, I think it's better to keep Verilog analogies out of the core dialect documentation in general