### PR TITLE
[ESI][BSP] Bunch of small fixes and changes

### DIFF
--- a/frontends/PyCDE/integration_test/test_software/esi_test.py
+++ b/frontends/PyCDE/integration_test/test_software/esi_test.py
@@ -56,9 +56,6 @@ mmio14 = d.ports[esi.AppID("mmio_client", 14)]
 read_offset(mmio14, 0, 14)
 read_offset(mmio14, 13, 14)
 
-assert mmio14.descriptor.base == 196608
-assert mmio14.descriptor.size == 65536
-
 ################################################################################
 # MMIOReadWriteClient tests
 ################################################################################
@@ -78,7 +75,7 @@ add_amt = 137
 mmio_rw.write(8, add_amt)
 read_offset_check(0, add_amt)
 read_offset_check(12, add_amt)
-read_offset_check(0x1400, add_amt)
+read_offset_check(0x140, add_amt)
 
 ################################################################################
 # Manifest tests

--- a/frontends/PyCDE/src/pycde/bsp/Makefile.xrt.mk
+++ b/frontends/PyCDE/src/pycde/bsp/Makefile.xrt.mk
@@ -92,7 +92,7 @@ $(XCL_OUT): $(LINK_OUT)
 # Generate configuration for use with hw_emu mode
 emconfig: $(BUILD)/emconfig.json
 $(BUILD)/emconfig.json:
-	emconfigutil --platform $(PLATFORM) --od $(BUILD)
+	$(XILINX_VITIS)/bin/emconfigutil --platform $(PLATFORM) --od $(BUILD)
 
 clean:
 	rm -rf $(BUILD) temp_kernel .Xil vivado* kernel *.jou *.log *.wdb *.wcfg *.protoinst *.csv

--- a/frontends/PyCDE/src/pycde/constructs.py
+++ b/frontends/PyCDE/src/pycde/constructs.py
@@ -273,7 +273,7 @@ def Counter(width: int):
                   clk=ports.clk,
                   rst=ports.rst,
                   rst_value=0,
-                  ce=ports.increment)
+                  ce=ports.increment | ports.clear)
       next = (count + 1).as_uint(width)
       count.assign(Mux(ports.clear, next, UInt(width)(0)))
       ports.out = count

--- a/frontends/PyCDE/test/test_xrt.py
+++ b/frontends/PyCDE/test/test_xrt.py
@@ -143,5 +143,5 @@ s.package()
 # CHTOP:  Main Main (
 # CHTOP:  MMIOAxiReadWriteMux MMIOAxiReadWriteMux (
 # CHTOP:  MMIOAxiReadWriteDemux MMIOAxiReadWriteDemux (
-# CHTOP:  HeaderMMIO_manifest_loc65536 HeaderMMIO (
+# CHTOP:  HeaderMMIO_manifest_loc4096 HeaderMMIO (
 # CHTOP:  ESI_Manifest_ROM_Wrapper ESI_Manifest_ROM_Wrapper (

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Common.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Common.h
@@ -147,6 +147,7 @@ std::ostream &operator<<(std::ostream &, const esi::AppID &);
 //===----------------------------------------------------------------------===//
 
 namespace esi {
+std::string toHex(void *val);
 std::string toHex(uint64_t val);
 } // namespace esi
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/Common.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Common.cpp
@@ -34,6 +34,10 @@ std::string MessageData::toHex() const {
   return ss.str();
 }
 
+std::string esi::toHex(void *val) {
+  return toHex(reinterpret_cast<uint64_t>(val));
+}
+
 std::string esi::toHex(uint64_t val) {
   std::ostringstream ss;
   ss << std::hex << val;

--- a/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Engines.cpp
@@ -80,24 +80,37 @@ void BundleEngineMap::setEngine(const std::string &channelName,
     throw std::runtime_error("Channel already exists in engine map");
 }
 
+//===----------------------------------------------------------------------===//
+// Registry
+//===----------------------------------------------------------------------===//
 namespace {
-std::map<std::string, registry::internal::EngineCreate> engineRegistry;
-}
+class EngineRegistry {
+public:
+  static std::map<std::string, registry::internal::EngineCreate> &get() {
+    static EngineRegistry instance;
+    return instance.engineRegistry;
+  }
+
+private:
+  std::map<std::string, registry::internal::EngineCreate> engineRegistry;
+};
+} // namespace
 
 std::unique_ptr<Engine>
 registry::createEngine(AcceleratorConnection &conn,
                        const std::string &dmaEngineName, AppIDPath idPath,
                        const ServiceImplDetails &details,
                        const HWClientDetails &clients) {
-  auto it = engineRegistry.find(dmaEngineName);
-  if (it == engineRegistry.end())
+  auto &reg = EngineRegistry::get();
+  auto it = reg.find(dmaEngineName);
+  if (it == reg.end())
     return std::make_unique<UnknownEngine>(conn, dmaEngineName);
   return it->second(conn, idPath, details, clients);
 }
 
 void registry::internal::registerEngine(const std::string &name,
                                         EngineCreate create) {
-  auto tried = engineRegistry.try_emplace(name, create);
+  auto tried = EngineRegistry::get().try_emplace(name, create);
   if (!tried.second)
     throw std::runtime_error("Engine already exists in registry");
 }

--- a/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
@@ -45,13 +45,12 @@ void ReadChannelPort::connect(std::function<bool(MessageData)> callback,
                               std::optional<unsigned> bufferSize) {
   if (mode != Mode::Disconnected)
     throw std::runtime_error("Channel already connected");
-  mode = Mode::Callback;
   this->callback = callback;
   connectImpl(bufferSize);
+  mode = Mode::Callback;
 }
 
 void ReadChannelPort::connect(std::optional<unsigned> bufferSize) {
-  mode = Mode::Polling;
   maxDataQueueMsgs = DefaultMaxDataQueueMsgs;
   this->callback = [this](MessageData data) {
     std::scoped_lock<std::mutex> lock(pollingM);
@@ -72,6 +71,7 @@ void ReadChannelPort::connect(std::optional<unsigned> bufferSize) {
     return true;
   };
   connectImpl(bufferSize);
+  mode = Mode::Polling;
 }
 
 std::future<MessageData> ReadChannelPort::readAsync() {

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Trace.cpp
@@ -43,7 +43,6 @@ struct esi::backends::trace::TraceAccelerator::Impl {
   Impl(Mode mode, std::filesystem::path manifestJson,
        std::filesystem::path traceFile)
       : manifestJson(manifestJson), traceFile(traceFile) {
-    engine = std::make_unique<TraceEngine>(*this);
     if (!std::filesystem::exists(manifestJson))
       throw std::runtime_error("manifest file '" + manifestJson.string() +
                                "' does not exist");
@@ -88,7 +87,6 @@ private:
   std::filesystem::path manifestJson;
   std::filesystem::path traceFile;
   std::vector<std::unique_ptr<ChannelPort>> channels;
-  std::unique_ptr<TraceEngine> engine;
 };
 
 void TraceAccelerator::Impl::write(const AppIDPath &id,


### PR DESCRIPTION
- Fix path to emconfigutil in XRT makefile
- Reduce MMIO register space allocation
- Fix gearbox client validity bug
- Fix gearbox valid_bytes padding bug
- Fix gearbox output type bug
- When instantiating an engine which has mmio and/or hostmem ports, connect them to a service request.
  - To workaround a deficiency in ESI services which doesn't detect new service requests in instances produced by a service generator.
- Add toHex function for pointers.
- Fix the location of engine registry storage so we don't crash when registering one.
- Set the mode in read ports after at the end of the connect function so that isConnected doesn't prematurely report true.
- Remove unnecessary engine creation in Trace.

Since these were required for the DMA engine in an upcoming PR, they will be tested by that PR.