### PR TITLE
[ImportVerilog] Fix assertion with constant folding

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -489,7 +489,7 @@ def ConstantOp : MooreOp<"constant", [Pure, ConstantLike]> {
   let builders = [
     OpBuilder<(ins "IntType":$type, "const FVInt &":$value)>,
     OpBuilder<(ins "IntType":$type, "const APInt &":$value)>,
-    OpBuilder<(ins "IntType":$type, "int64_t":$value)>,
+    OpBuilder<(ins "IntType":$type, "int64_t":$value, CArg<"bool", "true">:$isSigned)>,
   ];
 }
 

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -623,9 +623,9 @@ void ConstantOp::build(OpBuilder &builder, OperationState &result, IntType type,
 /// folding because it only works with values that can be expressed in an
 /// `int64_t`.
 void ConstantOp::build(OpBuilder &builder, OperationState &result, IntType type,
-                       int64_t value) {
+                       int64_t value, bool isSigned) {
   build(builder, result, type,
-        APInt(type.getWidth(), (uint64_t)value, /*isSigned=*/true));
+        APInt(type.getWidth(), (uint64_t)value, isSigned));
 }
 
 OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) {

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -2344,3 +2344,28 @@ function int AssignFuncArgs2(int x, int y);
   // CHECK: [[ADD:%.+]] = moore.add [[READ_X]], [[READ_Y]] : i32
   return x+y;
 endfunction
+
+// CHECK-LABEL: moore.module @RangeElementSelection(
+module RangeElementSelection(
+    input reg [3:0] a [0:2],
+    output reg [3:0] b,
+    input reg [1:0] c);
+    // CHECK: [[A:%.+]] = moore.variable name "a" : <uarray<3 x l4>
+    // CHECK: [[C:%.+]] = moore.variable name "c" : <l2>
+
+    always_comb begin
+      // CHECK: [[READ_A:%.+]] = moore.read [[A]] : <uarray<3 x l4>>
+      // CHECK: [[READ_C:%.+]] = moore.read [[C]] : <l2>
+      // CHECK: [[M2:%.+]] = moore.constant -2 : l2
+      // CHECK: [[SUB_1:%.+]] = moore.sub [[M2]], [[READ_C]] : l2
+      // CHECK: [[DYN_EXT_1:%.+]] = moore.dyn_extract [[READ_A]] from [[SUB_1]] : uarray<3 x l4>, l2 -> l4
+      // CHECK: [[READ_B:%.+]] = moore.read %b : <l4>
+      // CHECK: [[READ_C_1:%.+]] = moore.read [[C]] : <l2>
+      // CHECK: [[EXTRACT:%.+]] = moore.extract [[READ_C_1]] from 0 : l2 -> l1
+      // CHECK: [[ONE:%.+]] = moore.constant 1 : l1
+      // CHECK: [[SUB_2:%.+]] = moore.sub [[EXTRACT]], [[ONE]] : l1
+      // CHECK: [[DYN_EXT_2:%.+]] = moore.dyn_extract [[READ_B]] from [[SUB_2]] : l4, l1 -> l2
+      b = a[c];
+      b[3:0] = b[c[0]-:2];
+    end
+endmodule


### PR DESCRIPTION
This PR fixes cases when selector maximum or minimum values do not fit into the range of the type for the folding `Moore` constant. 

CIRCT debug build fails with an [assertion](https://github.com/llvm/llvm-project/blob/aa580c2ec5eb4217c945a47a561181be7e7b1032/llvm/include/llvm/ADT/APInt.h#L120): 

```console
circt/llvm/llvm/include/llvm/ADT/APInt.h:120: llvm::APInt::APInt(unsigned int, uint64_t, bool, bool):
Assertion llvm::isIntN(BitWidth, val) && "Value is not an N-bit signed value"' failed.
```

With this test:
```verilog
module RangeElementSelection(
    input reg [3:0] a [0:2],
    output reg [3:0] b,
    input reg [1:0] c);
  
    always_comb begin
      b = a[c]; // Assertion here
      b[3:0] = b[c[0]-:2]; // Assertion here
    end
endmodule
```

This can be fixed by increasing `intType` size by `1` (which passed to `ConstantOp` builder) in order to include both maximum and minimum positive and negative numbers or making a builder sensitive to signedness.