### PR TITLE
[circt-synth] Partially lower Comb operations and run canonicalizations

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -821,7 +821,7 @@ def ConvertCombToAIG: Pass<"convert-comb-to-aig",  "hw::HWModuleOp"> {
 
   let options = [
     ListOption<"additionalLegalOps", "additional-legal-ops", "std::string",
-               "Specify additional legal ops for testing">,
+               "Specify additional legal ops to partially legalize Comb to AIG">,
     Option<"maxEmulationUnknownBits", "max-emulation-unknown-bits", "uint32_t", "10",
            "Maximum number of unknown bits to emulate in a table lookup">
   ];

--- a/lib/Conversion/CombToAIG/CombToAIG.cpp
+++ b/lib/Conversion/CombToAIG/CombToAIG.cpp
@@ -895,7 +895,7 @@ void ConvertCombToAIGPass::runOnOperation() {
   // AIG is target dialect.
   target.addLegalDialect<aig::AIGDialect>();
 
-  // This is a test only option to add logical ops.
+  // If additional legal ops are specified, add them to the target.
   if (!additionalLegalOps.empty())
     for (const auto &opName : additionalLegalOps)
       target.addLegalOp(OperationName(opName, &getContext()));


### PR DESCRIPTION
Previously CombToAIG lowers every comb operations into AIG operations
in a single pass. The issue is the size of IR lowered from Comb is
very large, and it heavily relies on AIG canonicalizations clean up.
This is some times very inefficient, and it's much better to clean up
at Comb level.

So this commits adds another run of CombToAIG that paratially lowers
Comb operations, specifically arithmetic operations (add, sub, mul, shift etc).