### PR TITLE
[arcilator] Add missing install configuration for arcilator-runtime.h and arcilator-header-cpp.py

### DIFF
--- a/tools/arcilator/CMakeLists.txt
+++ b/tools/arcilator/CMakeLists.txt
@@ -50,13 +50,20 @@ mlir_check_all_link_libraries(arcilator)
 
 configure_file(arcilator-header-cpp.py
   ${CIRCT_TOOLS_DIR}/arcilator-header-cpp.py)
-add_custom_target(arcilator-header-cpp SOURCES
-  ${CIRCT_TOOLS_DIR}/arcilator-header-cpp.py)
 
 configure_file(arcilator-runtime.h
   ${CIRCT_TOOLS_DIR}/arcilator-runtime.h)
-add_custom_target(arcilator-runtime-header SOURCES
-  ${CIRCT_TOOLS_DIR}/arcilator-runtime.h)
+
+if(CIRCT_BUILD_TOOLS)
+  install(PROGRAMS arcilator-header-cpp.py
+    DESTINATION "${CIRCT_TOOLS_INSTALL_DIR}"
+    COMPONENT arcilator
+  )
+  install(FILES arcilator-runtime.h
+    DESTINATION include
+    COMPONENT arcilator
+  )
+endif()
 
 if(ARCILATOR_JIT_ENABLED)
   target_include_directories(arcilator PRIVATE


### PR DESCRIPTION
See #8212 
>The arcilator-runtime.h and python script are not installed and thus not included in pre-built releases.

I'm not entirely sure about the correct location for arcilator-runtime.h, but it seems that the header generated by arcilator-header-cpp.py expects arcilator-runtime.h to be located at the root of the `include/` directory.


Additionally, the add_custom_target command is unnecessary and has been removed.