### PR TITLE
Bump LLVM to 289b17635958d986b74683c932df6b1d12f37b70.

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -237,6 +237,16 @@ def StateOp : ArcOp<"state", [
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
       (*this)->setAttr(getArcAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
+
+    /// Stub implementations for ArgumentAttributesMethods. If desired,
+    /// implement these by defining arg_attrs and res_attrs as arguments to the
+    /// operation as OptionalAttr<DictArrayAttr>.
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
   }];
 }
 
@@ -278,6 +288,16 @@ def CallOp : ArcOp<"call", [
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
       (*this)->setAttr(getArcAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
+
+    /// Stub implementations for ArgumentAttributesMethods. If desired,
+    /// implement these by defining arg_attrs and res_attrs as arguments to the
+    /// operation as OptionalAttr<DictArrayAttr>.
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
   }];
 }
 
@@ -367,6 +387,16 @@ def MemoryWritePortOp : ArcOp<"memory_write_port", [
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
       (*this)->setAttr(getArcAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
+
+    /// Stub implementations for ArgumentAttributesMethods. If desired,
+    /// implement these by defining arg_attrs and res_attrs as arguments to the
+    /// operation as OptionalAttr<DictArrayAttr>.
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
   }];
 }
 

--- a/include/circt/Dialect/Handshake/HandshakeOps.td
+++ b/include/circt/Dialect/Handshake/HandshakeOps.td
@@ -186,6 +186,16 @@ def ESIInstanceOp : Op<Handshake_Dialect, "esi_instance", [
     MutableOperandRange getArgOperandsMutable() {
       return getOpOperandsMutable();
     }
+
+    /// Stub implementations for ArgumentAttributesMethods. If desired,
+    /// implement these by defining arg_attrs and res_attrs as arguments to the
+    /// operation as OptionalAttr<DictArrayAttr>.
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
   }];
 }
 
@@ -263,6 +273,15 @@ def InstanceOp : Handshake_Op<"instance", [
       return getOpOperandsMutable();
     }
 
+    /// Stub implementations for ArgumentAttributesMethods. If desired,
+    /// implement these by defining arg_attrs and res_attrs as arguments to the
+    /// operation as OptionalAttr<DictArrayAttr>.
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
   }];
 
   let assemblyFormat = [{

--- a/include/circt/Dialect/Kanagawa/KanagawaOps.td
+++ b/include/circt/Dialect/Kanagawa/KanagawaOps.td
@@ -464,6 +464,16 @@ def CallOp : KanagawaOp<"call", [
 
     /// Return the callee of this operation.
     MethodOp getTarget(const hw::InnerRefNamespace &symbolTable);
+
+    /// Stub implementations for ArgumentAttributesMethods. If desired,
+    /// implement these by defining arg_attrs and res_attrs as arguments to the
+    /// operation as OptionalAttr<DictArrayAttr>.
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
   }];
 
   let assemblyFormat = [{

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -1002,6 +1002,16 @@ def FuncOp : SVOp<"func",
     void getAsmBlockArgumentNames(mlir::Region &region,
                                           mlir::OpAsmSetValueNameFn setNameFn);
     SmallVector<hw::PortInfo> getPortList(bool excludeExplicitReturn);
+
+    /// Stub implementations for ArgumentAttributesMethods. If desired,
+    /// implement these by defining arg_attrs and res_attrs as arguments to the
+    /// operation as OptionalAttr<DictArrayAttr>.
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
   }];
   let extraClassDefinition = [{
     hw::ModuleType $cppClass::getHWModuleType() {
@@ -1066,6 +1076,16 @@ class SVFuncCallBase<string mnemonic, list<Trait> traits = []>: SVOp<mnemonic,
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
       (*this)->setAttr(getCalleeAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
+
+    /// Stub implementations for ArgumentAttributesMethods. If desired,
+    /// implement these by defining arg_attrs and res_attrs as arguments to the
+    /// operation as OptionalAttr<DictArrayAttr>.
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
   }];
 }
 

--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -95,6 +95,16 @@ def DPIFuncOp : SimOp<"func.dpi",
     ArrayRef<Type> getResultTypes() { return getFunctionType().getResults(); }
 
     ::mlir::Region *getCallableRegion() { return nullptr; }
+
+    /// Stub implementations for ArgumentAttributesMethods. If desired,
+    /// implement these by defining arg_attrs and res_attrs as arguments to the
+    /// operation as OptionalAttr<DictArrayAttr>.
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
   }];
 }
 
@@ -145,6 +155,16 @@ def DPICallOp : SimOp<"func.dpi.call",
     void setCalleeFromCallable(mlir::CallInterfaceCallable callee) {
       (*this)->setAttr(getCalleeAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
+
+    /// Stub implementations for ArgumentAttributesMethods. If desired,
+    /// implement these by defining arg_attrs and res_attrs as arguments to the
+    /// operation as OptionalAttr<DictArrayAttr>.
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
   }];
 
 }

--- a/include/circt/Dialect/SystemC/SystemCStatements.td
+++ b/include/circt/Dialect/SystemC/SystemCStatements.td
@@ -286,6 +286,15 @@ def CallIndirectOp : SystemCOp<"cpp.call_indirect", [
       abort();
     }
 
+    /// Stub implementations for ArgumentAttributesMethods. If desired,
+    /// implement these by defining arg_attrs and res_attrs as arguments to the
+    /// operation as OptionalAttr<DictArrayAttr>.
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
   }];
 
   let assemblyFormat = [{
@@ -364,6 +373,15 @@ def CallOp : SystemCOp<"cpp.call", [
       (*this)->setAttr(getCalleeAttrName(), llvm::cast<mlir::SymbolRefAttr>(callee));
     }
 
+    /// Stub implementations for ArgumentAttributesMethods. If desired,
+    /// implement these by defining arg_attrs and res_attrs as arguments to the
+    /// operation as OptionalAttr<DictArrayAttr>.
+    mlir::ArrayAttr getArgAttrsAttr() { return nullptr; }
+    mlir::ArrayAttr getResAttrsAttr() { return nullptr; }
+    void setArgAttrsAttr(mlir::ArrayAttr args) {}
+    void setResAttrsAttr(mlir::ArrayAttr args) {}
+    mlir::Attribute removeArgAttrsAttr() { return nullptr; }
+    mlir::Attribute removeResAttrsAttr() { return nullptr; }
   }];
 
   let assemblyFormat = [{

--- a/integration_test/CMakeLists.txt
+++ b/integration_test/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CIRCT_INTEGRATION_TEST_DEPENDS
   )
 
 if (MLIR_ENABLE_EXECUTION_ENGINE)
-  list(APPEND CIRCT_INTEGRATION_TEST_DEPENDS mlir-cpu-runner)
+  list(APPEND CIRCT_INTEGRATION_TEST_DEPENDS mlir-runner)
 endif()
 
 # If Python bindings are available to build then enable the tests.

--- a/integration_test/Dialect/SMT/basic.mlir
+++ b/integration_test/Dialect/SMT/basic.mlir
@@ -1,13 +1,13 @@
 // RUN: circt-opt %s --lower-smt-to-z3-llvm --canonicalize | \
-// RUN: mlir-cpu-runner -e entry -entry-point-result=void --shared-libs=%libz3 | \
+// RUN: mlir-runner -e entry -entry-point-result=void --shared-libs=%libz3 | \
 // RUN: FileCheck %s
 
 // RUN: circt-opt %s --lower-smt-to-z3-llvm=debug=true --canonicalize | \
-// RUN: mlir-cpu-runner -e entry -entry-point-result=void --shared-libs=%libz3 | \
+// RUN: mlir-runner -e entry -entry-point-result=void --shared-libs=%libz3 | \
 // RUN: FileCheck %s
 
 // REQUIRES: libz3
-// REQUIRES: mlir-cpu-runner
+// REQUIRES: mlir-runner
 
 func.func @entry() {
   %false = llvm.mlir.constant(0 : i1) : i1

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -217,12 +217,12 @@ if config.z3_library != "":
   tools.append(ToolSubst(f"%libz3", config.z3_library))
   config.available_features.add('libz3')
 
-# Add mlir-cpu-runner if the execution engine is built.
+# Add mlir-runner if the execution engine is built.
 if config.mlir_enable_execution_engine:
-  config.available_features.add('mlir-cpu-runner')
+  config.available_features.add('mlir-runner')
   config.available_features.add('circt-lec-jit')
   config.available_features.add('circt-bmc-jit')
-  tools.append('mlir-cpu-runner')
+  tools.append('mlir-runner')
 
 # Add circt-verilog if the Slang frontend is enabled.
 if config.slang_frontend_enabled:

--- a/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
+++ b/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
@@ -149,9 +149,11 @@ protected:
       auto module =
           builder.getBlock()->getParent()->getParentOfType<ModuleOp>();
       builder.setInsertionPointToEnd(module.getBody());
-      funcOp = LLVM::lookupOrCreateFn(module, name, funcType.getParams(),
-                                      funcType.getReturnType(),
-                                      funcType.getVarArg());
+      auto funcOpResult = LLVM::lookupOrCreateFn(
+          module, name, funcType.getParams(), funcType.getReturnType(),
+          funcType.getVarArg());
+      assert(succeeded(funcOpResult) && "expected to lookup or create printf");
+      funcOp = funcOpResult.value();
     }
     return builder.create<LLVM::CallOp>(loc, funcOp, args);
   }

--- a/lib/Dialect/FSM/FSMOps.cpp
+++ b/lib/Dialect/FSM/FSMOps.cpp
@@ -44,7 +44,7 @@ void MachineOp::build(OpBuilder &builder, OperationState &state, StringRef name,
   if (argAttrs.empty())
     return;
   assert(type.getNumInputs() == argAttrs.size());
-  function_interface_impl::addArgAndResultAttrs(
+  call_interface_impl::addArgAndResultAttrs(
       builder, state, argAttrs,
       /*resultAttrs=*/std::nullopt, MachineOp::getArgAttrsAttrName(state.name),
       MachineOp::getResAttrsAttrName(state.name));

--- a/lib/Dialect/Handshake/HandshakeOps.cpp
+++ b/lib/Dialect/Handshake/HandshakeOps.cpp
@@ -550,7 +550,7 @@ parseFuncOpArgs(OpAsmParser &parser,
                 SmallVectorImpl<Type> &resTypes,
                 SmallVectorImpl<DictionaryAttr> &resAttrs) {
   bool isVariadic;
-  if (mlir::function_interface_impl::parseFunctionSignature(
+  if (mlir::function_interface_impl::parseFunctionSignatureWithArguments(
           parser, /*allowVariadic=*/true, entryArgs, isVariadic, resTypes,
           resAttrs)
           .failed())
@@ -641,7 +641,7 @@ ParseResult FuncOp::parse(OpAsmParser &parser, OperationState &result) {
                              result.attributes) ||
       parseFuncOpArgs(parser, args, resTypes, resAttributes))
     return failure();
-  mlir::function_interface_impl::addArgAndResultAttrs(
+  mlir::call_interface_impl::addArgAndResultAttrs(
       builder, result, args, resAttributes,
       handshake::FuncOp::getArgAttrsAttrName(result.name),
       handshake::FuncOp::getResAttrsAttrName(result.name));

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -171,7 +171,7 @@ ParseResult SCModuleOp::parse(OpAsmParser &parser, OperationState &result) {
   result.addAttribute(SCModuleOp::getFunctionTypeAttrName(result.name),
                       functionType);
 
-  mlir::function_interface_impl::addArgAndResultAttrs(
+  mlir::call_interface_impl::addArgAndResultAttrs(
       parser.getBuilder(), result, entryArgs, resultAttrs,
       SCModuleOp::getArgAttrsAttrName(result.name),
       SCModuleOp::getResAttrsAttrName(result.name));
@@ -855,7 +855,7 @@ void FuncOp::build(OpBuilder &odsBuilder, OperationState &odsState,
   if (argAttrs.empty())
     return;
   assert(type.getNumInputs() == argAttrs.size());
-  mlir::function_interface_impl::addArgAndResultAttrs(
+  mlir::call_interface_impl::addArgAndResultAttrs(
       odsBuilder, odsState, argAttrs,
       /*resultAttrs=*/std::nullopt, FuncOp::getArgAttrsAttrName(odsState.name),
       FuncOp::getResAttrsAttrName(odsState.name));
@@ -893,7 +893,7 @@ ParseResult FuncOp::parse(OpAsmParser &parser, OperationState &result) {
   // Parse the function signature.
   mlir::SMLoc signatureLocation = parser.getCurrentLocation();
   bool isVariadic = false;
-  if (mlir::function_interface_impl::parseFunctionSignature(
+  if (mlir::function_interface_impl::parseFunctionSignatureWithArguments(
           parser, false, entryArgs, isVariadic, resultTypes, resultAttrs))
     return failure();
 
@@ -935,7 +935,7 @@ ParseResult FuncOp::parse(OpAsmParser &parser, OperationState &result) {
 
   // Add the attributes to the function arguments.
   assert(resultAttrs.size() == resultTypes.size());
-  mlir::function_interface_impl::addArgAndResultAttrs(
+  mlir::call_interface_impl::addArgAndResultAttrs(
       builder, result, entryArgs, resultAttrs,
       FuncOp::getArgAttrsAttrName(result.name),
       FuncOp::getResAttrsAttrName(result.name));

--- a/lib/Tools/circt-lec/ConstructLEC.cpp
+++ b/lib/Tools/circt-lec/ConstructLEC.cpp
@@ -75,6 +75,10 @@ void ConstructLECPass::runOnOperation() {
   // Lookup or declare printf function.
   auto printfFunc =
       LLVM::lookupOrCreateFn(getOperation(), "printf", ptrTy, voidTy, true);
+  if (failed(printfFunc)) {
+    getOperation()->emitError("failed to lookup or create printf");
+    return signalPassFailure();
+  }
 
   // Lookup the modules.
   auto moduleA = lookupModule(firstModule);
@@ -144,7 +148,8 @@ void ConstructLECPass::runOnOperation() {
       lookupOrCreateStringGlobal(builder, getOperation(), "c1 != c2\n");
   Value formatString = builder.create<LLVM::SelectOp>(
       loc, areEquivalent, eqFormatString, neqFormatString);
-  builder.create<LLVM::CallOp>(loc, printfFunc, ValueRange{formatString});
+  builder.create<LLVM::CallOp>(loc, printfFunc.value(),
+                               ValueRange{formatString});
 
   builder.create<func::ReturnOp>(loc, ValueRange{});
 }

--- a/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
+++ b/test/Conversion/ArcToLLVM/lower-arc-to-llvm.mlir
@@ -164,7 +164,7 @@ func.func @funcCallOp(%arg0: i32) -> (i32, i32) {
   // CHECK-NEXT: [[V1:%.+]] = llvm.extractvalue [[V0]][0] : !llvm.struct<(i32, i32)>
   // CHECK-NEXT: [[V2:%.+]] = llvm.extractvalue [[V0]][1] : !llvm.struct<(i32, i32)>
   %0:2 = func.call @dummyFuncCallee(%arg0) : (i32) -> (i32, i32)
-  // CHECK-NEXT: [[V3:%.+]] = llvm.mlir.undef : !llvm.struct<(i32, i32)>
+  // CHECK-NEXT: [[V3:%.+]] = llvm.mlir.poison : !llvm.struct<(i32, i32)>
   // CHECK-NEXT: [[V4:%.+]] = llvm.insertvalue [[V1]], [[V3]][0] : !llvm.struct<(i32, i32)>
   // CHECK-NEXT: [[V5:%.+]] = llvm.insertvalue [[V2]], [[V4]][1] : !llvm.struct<(i32, i32)>
   // CHECK-NEXT: llvm.return [[V5]] :


### PR DESCRIPTION
This picked up a few breaking changes.

https://github.com/llvm/llvm-project/commit/327d6270

This added new required methods to CallOpInterface and CallableOpInterface. These methods are related to arrays of dictionary attributes for each argument and result, and are normally implemented upstream by simply defining the right arg_attrs and res_attrs arguments on the operations. This allows some of the common utilities upstream to work with the attributes.

However, we seem to have actually moved away from arrays of per-argument or per-result attributes in most cases, and handle this ourselves when we want to. I opted to stub out the methods in the tablegen definitions of our operations, rather than adding optional attributes and setting them to null in builders and builder callsites like was done upstream.

There were also some accompanying name changes to a couple helper functions, which we were able to simply apply without needing to add new optional attributes everywhere.

https://github.com/llvm/llvm-project/commit/e84f6b6a

This updated several LLVM dialect helper functions related to lookupOrCreateFn to return FailureOr<LLVM::LLVMFuncOp>. In most cases, we simply check for the error case and return it or signal pass failure. There was one function in the SMT to Z3 conversion that assumes this always succeeds and in this function I made an assertion rather than changing the function to also potentially return failure.

https://github.com/llvm/llvm-project/commit/f4e3b878

Looks like upstream is simply moving from undef to poison in many cases, so this required us to update one test case.