### PR TITLE
[Arcilator] Allow running verif.simulation ops

### DIFF
--- a/include/circt/Dialect/Arc/ArcPasses.td
+++ b/include/circt/Dialect/Arc/ArcPasses.td
@@ -266,6 +266,20 @@ def LowerVectorizations : Pass<"arc-lower-vectorizations", "mlir::ModuleOp"> {
   ];
 }
 
+def LowerVerifSimulationsPass : Pass<"arc-lower-verif-simulations",
+                                     "mlir::ModuleOp"> {
+  let summary = "Lower verif.simulation ops to main functions";
+  let dependentDialects = [
+    "arc::ArcDialect",
+    "hw::HWDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::cf::ControlFlowDialect",
+    "mlir::func::FuncDialect",
+    "mlir::scf::SCFDialect",
+    "seq::SeqDialect",
+  ];
+}
+
 def MakeTables : Pass<"arc-make-tables", "mlir::ModuleOp"> {
   let summary = "Transform appropriate arc logic into lookup tables";
   let constructor = "circt::arc::createMakeTablesPass()";

--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -376,8 +376,8 @@ def SimulationOp : VerifOp<"simulation", [
 
     The first operand is a "done" signal of type `i1` which indicates the end of
     the simulation. The simulation stops when the done signal is 1 during a
-    0-to-1 transition of the clock. No additional clock toggles occur once done
-    has been sampled as 1.
+    0-to-1 transition of the clock after the init signal has dropped to 0. No
+    additional clock toggles occur once done has been sampled as 1.
 
     The second operand is an "exit code" signal which may be of any integer
     type. It indicates success of a test as 0, or failure as any non-zero

--- a/integration_test/arcilator/JIT/verif-simulation.mlir
+++ b/integration_test/arcilator/JIT/verif-simulation.mlir
@@ -1,0 +1,86 @@
+// RUN: arcilator --run --jit-entry=AdderTest %s | FileCheck %s
+// REQUIRES: arcilator-jit
+
+// CHECK: simulation started
+// CHECK: simulation passed
+
+verif.simulation @AdderTest {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  // Count the first 9001 simulation cycles.
+  %c0_i19 = hw.constant 0 : i19
+  %c1_i19 = hw.constant 1 : i19
+  %c9001_i19 = hw.constant 9001 : i19
+  %count = seq.compreg %0, %clock reset %init, %c0_i19 : i19
+  %done = comb.icmp eq %count, %c9001_i19 : i19
+  %0 = comb.add %count, %c1_i19 : i19
+
+  // Generate inputs to the adder.
+  %1, %2 = sim.func.dpi.call @generateAdderInputs(%count) : (i19) -> (i42, i42)
+  %3 = hw.instance "dut" @Adder(a: %1: i42, b: %2: i42) -> (c: i42)
+
+  // Check results and track failures.
+  %4 = comb.add %1, %2 : i42
+  %5 = comb.icmp ne %3, %4 : i42
+  %false = hw.constant false
+  %failure = seq.compreg %6, %clock reset %init, %false : i1
+  %6 = comb.or %failure, %5 : i1
+
+  // Print some statistics about the test.
+  sim.func.dpi.call @printStart() clock %clock enable %init : () -> ()
+  sim.func.dpi.call @printFailure(%1, %2, %3, %4) clock %clock enable %failure : (i42, i42, i42, i42) -> ()
+  sim.func.dpi.call @printDone(%failure) clock %clock enable %done : (i1) -> ()
+
+  verif.yield %done, %failure : i1, i1
+}
+
+hw.module private @Adder(in %a: i42, in %b: i42, out c: i42) {
+  %0 = comb.add %a, %b : i42
+  hw.output %0 : i42
+}
+
+sim.func.dpi @generateAdderInputs(in %idx: i19, out a: i42, out b: i42) attributes {verilogName = "generateAdderInputs.impl"}
+func.func private @generateAdderInputs.impl(%arg0: i19, %arg1: !llvm.ptr, %arg2: !llvm.ptr) {
+  %c4224496855063_i42 = arith.constant 4224496855063 : i42
+  %c1_i42 = arith.constant 1 : i42
+  %0 = arith.extui %arg0 : i19 to i42
+  %1 = arith.addi %0, %c1_i42 : i42
+  %a = arith.muli %0, %c4224496855063_i42 : i42
+  %b = arith.muli %1, %c4224496855063_i42 : i42
+  llvm.store %a, %arg1 : i42, !llvm.ptr
+  llvm.store %b, %arg2 : i42, !llvm.ptr
+  return
+}
+
+sim.func.dpi @printStart() attributes {verilogName = "printStart.impl"}
+sim.func.dpi @printDone(in %failure: i1) attributes {verilogName = "printDone.impl"}
+sim.func.dpi @printFailure(in %a: i42, in %b: i42, in %c_act: i42, in %c_exp: i42) attributes {verilogName = "printFailure.impl"}
+
+func.func private @printStart.impl() {
+  %0 = llvm.mlir.addressof @str.start : !llvm.ptr
+  call @puts(%0) : (!llvm.ptr) -> ()
+  return
+}
+
+func.func private @printFailure.impl(%a: i42, %b: i42, %c_act: i42, %c_exp: i42) {
+  %0 = llvm.mlir.addressof @str.mismatch : !llvm.ptr
+  call @puts(%0) : (!llvm.ptr) -> ()
+  arc.sim.emit "a", %a : i42
+  arc.sim.emit "b", %b : i42
+  arc.sim.emit "c_act", %c_act : i42
+  arc.sim.emit "c_exp", %c_exp : i42
+  return
+}
+
+func.func private @printDone.impl(%failure: i1) {
+  %0 = llvm.mlir.addressof @str.pass : !llvm.ptr
+  %1 = llvm.mlir.addressof @str.fail : !llvm.ptr
+  %2 = llvm.select %failure, %1, %0 : i1, !llvm.ptr
+  call @puts(%2) : (!llvm.ptr) -> ()
+  return
+}
+
+func.func private @puts(%arg0: !llvm.ptr)
+llvm.mlir.global constant @str.start("simulation started\00")
+llvm.mlir.global constant @str.pass("simulation passed\00")
+llvm.mlir.global constant @str.fail("simulation failed\00")
+llvm.mlir.global constant @str.mismatch("----- MISMATCH -----\00")

--- a/lib/Dialect/Arc/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Arc/Transforms/CMakeLists.txt
@@ -14,6 +14,7 @@ add_circt_dialect_library(CIRCTArcTransforms
   LowerLUT.cpp
   LowerState.cpp
   LowerVectorizations.cpp
+  LowerVerifSimulations.cpp
   MakeTables.cpp
   MergeIfs.cpp
   MuxToControlFlow.cpp
@@ -34,15 +35,16 @@ add_circt_dialect_library(CIRCTArcTransforms
   CIRCTHW
   CIRCTLLHD
   CIRCTOM
-  CIRCTSV
   CIRCTSeq
   CIRCTSim
   CIRCTSupport
+  CIRCTSV
+  CIRCTVerif
   MLIRFuncDialect
-  MLIRLLVMDialect
-  MLIRSCFDialect
-  MLIRVectorDialect
   MLIRIR
+  MLIRLLVMDialect
   MLIRPass
+  MLIRSCFDialect
   MLIRTransformUtils
+  MLIRVectorDialect
 )

--- a/lib/Dialect/Arc/Transforms/LowerVerifSimulations.cpp
+++ b/lib/Dialect/Arc/Transforms/LowerVerifSimulations.cpp
@@ -1,0 +1,209 @@
+//===- LowerVerifSimulations.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Arc/ArcOps.h"
+#include "circt/Dialect/Arc/ArcPasses.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Verif/VerifOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "arc-lower-verif-simulations"
+
+using namespace mlir;
+using namespace circt;
+using namespace arc;
+
+using hw::PortInfo;
+
+namespace circt {
+namespace arc {
+#define GEN_PASS_DEF_LOWERVERIFSIMULATIONSPASS
+#include "circt/Dialect/Arc/ArcPasses.h.inc"
+} // namespace arc
+} // namespace circt
+
+namespace {
+struct LowerVerifSimulationsPass
+    : public arc::impl::LowerVerifSimulationsPassBase<
+          LowerVerifSimulationsPass> {
+  void runOnOperation() override;
+  void lowerSimulation(verif::SimulationOp op, SymbolTable &symbolTable);
+};
+} // namespace
+
+void LowerVerifSimulationsPass::runOnOperation() {
+  SymbolTableCollection symbolTables;
+
+  // Declare the `exit` function if it does not yet exist.
+  auto builder = OpBuilder::atBlockBegin(getOperation().getBody());
+  auto exitFuncType = builder.getFunctionType({builder.getI32Type()}, {});
+  auto &symbolTable = symbolTables.getSymbolTable(getOperation());
+  if (auto *exitOp = symbolTable.lookup("exit")) {
+    auto func = dyn_cast<func::FuncOp>(exitOp);
+    if (!func) {
+      exitOp->emitOpError() << "expected to be a `func.func`";
+      return signalPassFailure();
+    }
+    if (func.getFunctionType() != exitFuncType) {
+      func.emitOpError() << "expected to have function type " << exitFuncType
+                         << ", got " << func.getFunctionType() << " instead";
+      return signalPassFailure();
+    }
+  } else {
+    auto func = builder.create<func::FuncOp>(
+        getOperation().getLoc(), builder.getStringAttr("exit"), exitFuncType);
+    SymbolTable::setSymbolVisibility(func, SymbolTable::Visibility::Private);
+  }
+
+  getOperation().walk([&](verif::SimulationOp op) {
+    auto *symbolTableOp = SymbolTable::getNearestSymbolTable(op);
+    assert(symbolTableOp);
+    lowerSimulation(op, symbolTables.getSymbolTable(symbolTableOp));
+  });
+}
+
+void LowerVerifSimulationsPass::lowerSimulation(verif::SimulationOp op,
+                                                SymbolTable &symbolTable) {
+  LLVM_DEBUG(llvm::dbgs() << "Lowering " << op.getSymName() << "\n");
+  auto *context = &getContext();
+  auto i1Type = IntegerType::get(context, 1);
+
+  // Assemble the ports of the implementation module.
+  auto &body = *op.getBody();
+  auto *yieldOp = body.getTerminator();
+  std::array<PortInfo, 4> implPorts;
+
+  auto clockName = StringAttr::get(context, "clock");
+  implPorts[0].name = clockName;
+  implPorts[0].type = seq::ClockType::get(context);
+  implPorts[0].dir = PortInfo::Input;
+  implPorts[0].loc = body.getArgument(0).getLoc();
+
+  auto initName = StringAttr::get(context, "init");
+  implPorts[1].name = initName;
+  implPorts[1].type = i1Type;
+  implPorts[1].dir = PortInfo::Input;
+  implPorts[1].loc = body.getArgument(1).getLoc();
+
+  auto doneName = StringAttr::get(context, "done");
+  implPorts[2].name = doneName;
+  implPorts[2].type = i1Type;
+  implPorts[2].dir = PortInfo::Output;
+  implPorts[2].loc = yieldOp->getOperand(0).getLoc();
+
+  auto exitCodeName = StringAttr::get(context, "exit_code");
+  auto exitCodeType = yieldOp->getOperand(1).getType();
+  implPorts[3].name = exitCodeName;
+  implPorts[3].type = exitCodeType;
+  implPorts[3].dir = PortInfo::Output;
+  implPorts[3].loc = yieldOp->getOperand(1).getLoc();
+
+  // Replace the `verif.yield` operation with an `hw.output`.
+  OpBuilder builder(yieldOp);
+  builder.create<hw::OutputOp>(yieldOp->getLoc(), yieldOp->getOperands());
+  yieldOp->erase();
+
+  // Move the body of the simulation into a separate HW module.
+  builder.setInsertionPoint(op);
+  auto implName = StringAttr::get(context, Twine("verif.simulation.impl.") +
+                                               op.getSymName());
+  auto loc = op.getLoc();
+  auto implOp = builder.create<hw::HWModuleOp>(loc, implName, implPorts);
+  symbolTable.insert(implOp);
+  implOp.getBody().takeBody(op.getBodyRegion());
+
+  // Create a new function for the verification op.
+  auto funcType = builder.getFunctionType({}, {});
+  auto funcOp =
+      builder.create<func::FuncOp>(loc, op.getSymNameAttr(), funcType);
+  auto *funcBody = builder.createBlock(&funcOp.getBody());
+
+  auto falseOp = builder.create<hw::ConstantOp>(loc, i1Type, 0);
+  auto trueOp = builder.create<hw::ConstantOp>(loc, i1Type, 1);
+  auto lowOp = builder.create<seq::ToClockOp>(loc, falseOp);
+  auto highOp = builder.create<seq::ToClockOp>(loc, trueOp);
+
+  // Instantiate the implementation module.
+  auto instType = SimModelInstanceType::get(
+      context, FlatSymbolRefAttr::get(implOp.getSymNameAttr()));
+  auto instOp = builder.create<SimInstantiateOp>(loc);
+  auto *instBody =
+      builder.createBlock(&instOp.getBody(), {}, {instType}, {loc});
+  auto instArg = instBody->getArgument(0);
+
+  // Create an `scf.execute_region` op inside such that we can use simple
+  // control flow in the `arc.sim.instantiate` op body. This is simpler than
+  // setting up an `scf.while` op.
+  auto execOp = builder.create<scf::ExecuteRegionOp>(loc, TypeRange{});
+  builder.setInsertionPointToEnd(&execOp.getRegion().emplaceBlock());
+
+  // Apply the initial clock tick to the design.
+  builder.create<SimSetInputOp>(loc, instArg, clockName, lowOp);
+  builder.create<SimSetInputOp>(loc, instArg, initName, trueOp);
+  builder.create<SimStepOp>(loc, instArg);
+  builder.create<SimSetInputOp>(loc, instArg, clockName, highOp);
+  builder.create<SimStepOp>(loc, instArg);
+  builder.create<SimSetInputOp>(loc, instArg, clockName, lowOp);
+  builder.create<SimSetInputOp>(loc, instArg, initName, falseOp);
+  builder.create<SimStepOp>(loc, instArg);
+
+  // Create the block that will perform a single clock tick.
+  auto &loopBlock = execOp.getRegion().emplaceBlock();
+  builder.create<cf::BranchOp>(loc, &loopBlock);
+  builder.setInsertionPointToEnd(&loopBlock);
+
+  // Sample the done and exit code signals.
+  auto doneSample =
+      builder.create<SimGetPortOp>(loc, i1Type, instArg, doneName);
+  auto exitCodeSample =
+      builder.create<SimGetPortOp>(loc, exitCodeType, instArg, exitCodeName);
+
+  // Apply a full clock cycle to the design.
+  builder.create<SimSetInputOp>(loc, instArg, clockName, highOp);
+  builder.create<SimStepOp>(loc, instArg);
+  builder.create<SimSetInputOp>(loc, instArg, clockName, lowOp);
+  builder.create<SimStepOp>(loc, instArg);
+
+  // If done, exit the loop.
+  auto &exitBlock = execOp.getRegion().emplaceBlock();
+  builder.create<cf::CondBranchOp>(loc, doneSample, &exitBlock, &loopBlock);
+  builder.setInsertionPointToEnd(&exitBlock);
+
+  // Compute `exit_code | (exit_code != 0)` as a way of guaranteeing that
+  // the exit code will be non-zero even if bits are truncated by the operating
+  // system.
+  auto i32Type = builder.getI32Type();
+  auto nonZeroI32 = builder.create<arith::ExtUIOp>(
+      loc, i32Type,
+      builder.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::ne, exitCodeSample,
+          builder.create<hw::ConstantOp>(loc, exitCodeType, 0)));
+
+  Value codeI32 = exitCodeSample;
+  if (exitCodeType.getIntOrFloatBitWidth() < 32)
+    codeI32 = builder.create<arith::ExtUIOp>(loc, i32Type, codeI32);
+  else if (exitCodeType.getIntOrFloatBitWidth() > 32)
+    codeI32 = builder.create<arith::TruncIOp>(loc, i32Type, codeI32);
+  codeI32 = builder.create<arith::OrIOp>(loc, codeI32, nonZeroI32);
+
+  // Call exit with the computed exit code.
+  builder.create<func::CallOp>(loc, TypeRange{}, builder.getStringAttr("exit"),
+                               ValueRange{codeI32});
+  builder.create<scf::YieldOp>(loc);
+
+  // Create the final function return.
+  builder.setInsertionPointToEnd(funcBody);
+  builder.create<func::ReturnOp>(loc);
+
+  // Get rid of the original simulation op.
+  op.erase();
+}

--- a/test/Dialect/Arc/lower-verif-simulations-error.mlir
+++ b/test/Dialect/Arc/lower-verif-simulations-error.mlir
@@ -1,0 +1,9 @@
+// RUN: circt-opt --arc-lower-verif-simulations --verify-diagnostics --split-input-file %s
+
+// expected-error @below {{op expected to be a `func.func`}}
+hw.module @exit() {}
+
+// -----
+
+// expected-error @below {{op expected to have function type '(i32) -> ()', got '(i42) -> i9001' instead}}
+func.func private @exit(%arg0: i42) -> (i9001)

--- a/test/Dialect/Arc/lower-verif-simulations.mlir
+++ b/test/Dialect/Arc/lower-verif-simulations.mlir
@@ -1,0 +1,83 @@
+// RUN: circt-opt --arc-lower-verif-simulations %s | FileCheck %s
+
+// CHECK: func.func private @exit(i32)
+
+// CHECK-LABEL: hw.module @verif.simulation.impl.Foo(
+// CHECK-SAME: in %clock : !seq.clock
+// CHECK-SAME: in %init : i1
+// CHECK-SAME: out done : i1
+// CHECK-SAME: out exit_code : i32
+verif.simulation @Foo {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  // CHECK: [[TMP1:%.+]] = hw.constant true
+  // CHECK: [[TMP2:%.+]] = hw.constant 0 : i32
+  // CHECK: hw.output [[TMP1]], [[TMP2]] : i1, i32
+  %true = hw.constant true
+  %c0_i32 = hw.constant 0 : i32
+  verif.yield %true, %c0_i32 : i1, i32
+}
+
+// CHECK-LABEL: func.func @Foo()
+// CHECK: [[I0:%.+]] = hw.constant false
+// CHECK: [[I1:%.+]] = hw.constant true
+// CHECK: [[C0:%.+]] = seq.to_clock [[I0]]
+// CHECK: [[C1:%.+]] = seq.to_clock [[I1]]
+// CHECK: arc.sim.instantiate @verif.simulation.impl.Foo as [[A:%.+]] {
+// CHECK:   scf.execute_region {
+// CHECK:     arc.sim.set_input [[A]], "clock" = [[C0]]
+// CHECK:     arc.sim.set_input [[A]], "init" = [[I1]]
+// CHECK:     arc.sim.step [[A]]
+// CHECK:     arc.sim.set_input [[A]], "clock" = [[C1]]
+// CHECK:     arc.sim.step [[A]]
+// CHECK:     arc.sim.set_input [[A]], "clock" = [[C0]]
+// CHECK:     arc.sim.set_input [[A]], "init" = [[I0]]
+// CHECK:     arc.sim.step [[A]]
+// CHECK:     cf.br [[LOOP:\^.+]]
+// CHECK:   [[LOOP]]:
+// CHECK:     [[DONE:%.+]] = arc.sim.get_port [[A]], "done" : i1
+// CHECK:     [[CODE:%.+]] = arc.sim.get_port [[A]], "exit_code" : i32
+// CHECK:     arc.sim.set_input [[A]], "clock" = [[C1]]
+// CHECK:     arc.sim.step [[A]]
+// CHECK:     arc.sim.set_input [[A]], "clock" = [[C0]]
+// CHECK:     arc.sim.step [[A]]
+// CHECK:     cf.cond_br [[DONE]], [[EXIT:\^.+]], [[LOOP]]
+// CHECK:   [[EXIT]]:
+// CHECK:     [[TMP1:%.+]] = hw.constant 0 : i32
+// CHECK:     [[TMP2:%.+]] = arith.cmpi ne, [[CODE]], [[TMP1]] : i32
+// CHECK:     [[TMP3:%.+]] = arith.extui [[TMP2]] : i1 to i32
+// CHECK:     [[TMP4:%.+]] = arith.ori [[CODE]], [[TMP3]] : i32
+// CHECK:     func.call @exit([[TMP4]]) : (i32) -> ()
+// CHECK:     scf.yield
+// CHECK:   }
+// CHECK: }
+// CHECK: return
+
+// CHECK-LABEL: func.func @NarrowExit()
+// CHECK: [[CODE:%.+]] = arc.sim.get_port {{%.+}}, "exit_code" : i19
+// CHECK: [[TMP1:%.+]] = hw.constant 0 : i19
+// CHECK: [[TMP2:%.+]] = arith.cmpi ne, [[CODE]], [[TMP1]] : i19
+// CHECK: [[TMP3:%.+]] = arith.extui [[TMP2]] : i1 to i32
+// CHECK: [[TMP4:%.+]] = arith.extui [[CODE]] : i19 to i32
+// CHECK: [[TMP5:%.+]] = arith.ori [[TMP4]], [[TMP3]] : i32
+// CHECK: func.call @exit([[TMP5]]) : (i32) -> ()
+verif.simulation @NarrowExit {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  %true = hw.constant true
+  %c0_i19 = hw.constant 0 : i19
+  verif.yield %true, %c0_i19 : i1, i19
+}
+
+// CHECK-LABEL: func.func @WideExit()
+// CHECK: [[CODE:%.+]] = arc.sim.get_port {{%.+}}, "exit_code" : i42
+// CHECK: [[TMP1:%.+]] = hw.constant 0 : i42
+// CHECK: [[TMP2:%.+]] = arith.cmpi ne, [[CODE]], [[TMP1]] : i42
+// CHECK: [[TMP3:%.+]] = arith.extui [[TMP2]] : i1 to i32
+// CHECK: [[TMP4:%.+]] = arith.trunci [[CODE]] : i42 to i32
+// CHECK: [[TMP5:%.+]] = arith.ori [[TMP4]], [[TMP3]] : i32
+// CHECK: func.call @exit([[TMP5]]) : (i32) -> ()
+verif.simulation @WideExit {} {
+^bb0(%clock: !seq.clock, %init: i1):
+  %true = hw.constant true
+  %c0_i42 = hw.constant 0 : i42
+  verif.yield %true, %c0_i42 : i1, i42
+}

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -257,6 +257,7 @@ static void populateHwModuleToArcPipeline(PassManager &pm) {
   pm.addPass(om::createStripOMPass());
   pm.addPass(emit::createStripEmitPass());
   pm.addPass(createLowerFirMemPass());
+  pm.addPass(createLowerVerifSimulationsPass());
   {
     arc::AddTapsOptions opts;
     opts.tapPorts = observePorts;


### PR DESCRIPTION
Add the `LowerVerifSimulations` pass to the Arc dialect. This pass converts any `verif.simulation` ops in the input into a test harness module and a `func.func` that instantiates the module and applies the necessary stimulus to it using `arc.sim.*` ops.

Also add the pass to the arcilator pipeline. This allows the user to run any `verif.simulation` ops in the input design by specifying the `--run --jit-entry=<simulation-name>` command line options. We may want to streamline this in the future.

Also add an integration test which verifies an adder circuit and prints the simulation results.