### PR TITLE
[LLHD] Don't implement BranchOpInterface for WaitOp

### DIFF
--- a/include/circt/Dialect/LLHD/IR/LLHDStructureOps.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDStructureOps.td
@@ -111,7 +111,6 @@ def WaitOp : LLHDOp<"wait", [
     Terminator,
     AttrSizedOperandSegments,
     HasParent<"ProcessOp">,
-    DeclareOpInterfaceMethods<BranchOpInterface>
   ]> {
   let summary = "Suspends execution of a process.";
   let description = [{

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -479,16 +479,6 @@ DrvOp::ensureOnlySafeAccesses(const MemorySlot &slot,
 }
 
 //===----------------------------------------------------------------------===//
-// WaitOp
-//===----------------------------------------------------------------------===//
-
-// Implement this operation for the BranchOpInterface
-SuccessorOperands llhd::WaitOp::getSuccessorOperands(unsigned index) {
-  assert(index == 0 && "invalid successor index");
-  return SuccessorOperands(getDestOpsMutable());
-}
-
-//===----------------------------------------------------------------------===//
 // ConnectOp
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
BranchOpInterface requries the control-flow edges to be side-effect free. However, WaitOp suspends execution and once execution is resumed, values on signals are expected to have changed from outside the process