### PR TITLE
[Python] Declare a separate sub-target for support sources

### DIFF
--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -85,6 +85,11 @@ declare_mlir_python_sources(CIRCTBindingsPythonSources
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
   SOURCES
     __init__.py
+)
+
+declare_mlir_python_sources(CIRCTBindingsPythonSources.Support
+  ADD_TO_PARENT CIRCTBindingsPythonSources
+  SOURCES
     support.py
     rtgtool_support.py
 )


### PR DESCRIPTION
Makes it easier for sub-projects to only include parts of the python bindings