### PR TITLE
[Calyx] Unroll Affine ParallelOp to multiple SCF ExecuteRegionOps

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPasses.h
+++ b/include/circt/Dialect/Calyx/CalyxPasses.h
@@ -29,6 +29,7 @@ std::unique_ptr<mlir::Pass> createRemoveGroupsPass();
 std::unique_ptr<mlir::Pass> createClkInsertionPass();
 std::unique_ptr<mlir::Pass> createResetInsertionPass();
 std::unique_ptr<mlir::Pass> createGroupInvariantCodeMotionPass();
+std::unique_ptr<mlir::Pass> createAffineParallelUnrollPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -185,4 +185,53 @@ def GoInsertion : Pass<"calyx-go-insertion", "calyx::ComponentOp"> {
   let constructor = "circt::calyx::createGoInsertionPass()";
 }
 
+def AffineParallelUnroll : Pass<"affine-parallel-unroll", "::mlir::func::FuncOp"> {
+  let summary = "Unrolls affine.parallel operations in a way suitable for Calyx.";
+  let description = [{
+    This pass unrolls `affine.parallel` operations completely and wrap each unrolled body
+    with `scf.execute_region` operations to better align with `calyx.par`'s representation.
+    Moreover, the newly created `affine.parallel` will be attached with attributes to 
+    indicate that this is different from normal `affine.parallel`. Behavior is undefined if
+    there is a data race or memory banking contention.
+    An example:
+    ```
+    affine.parallel (%x, %y) from (0, 0) to (2, 2) {
+      %0 = memref.load %alloc_0[%x, %y] : memref<2x2xf32>
+      %1 = memref.load %alloc_1[%x, %y] : memref<2x2xf32>
+      %2 = arith.addf %0, %1 : f32
+      memref.store %2, %alloc_2[%x, %y] : memref<2x2xf32>
+    }
+    =>
+    affine.parallel _ from 0 to 1 {
+      scf.execute_region {
+        %0 = memref.load %alloc_0[%c0, %c0] : memref<2x2xf32>
+        %1 = memref.load %alloc_1[%c0, %c0] : memref<2x2xf32>
+        %2 = arith.addf %0, %1 : f32
+        memref.store %2, %alloc_2[%c0, %c0] : memref<2x2xf32>
+      }
+      scf.execute_region {
+        %0 = memref.load %alloc_0[%c0, %c1] : memref<2x2xf32>
+        %1 = memref.load %alloc_1[%c0, %c1] : memref<2x2xf32>
+        %2 = arith.addf %0, %1 : f32
+        memref.store %2, %alloc_2[%c0, %c1] : memref<2x2xf32>
+      }
+      scf.execute_region {
+        %0 = memref.load %alloc_0[%c1, %c0] : memref<2x2xf32>
+        %1 = memref.load %alloc_1[%c1, %c0] : memref<2x2xf32>
+        %2 = arith.addf %0, %1 : f32
+        memref.store %2, %alloc_2[%c1, %c0] : memref<2x2xf32>
+      }
+      scf.execute_region {
+        %0 = memref.load %alloc_0[%c1, %c1] : memref<2x2xf32>
+        %1 = memref.load %alloc_1[%c1, %c1] : memref<2x2xf32>
+        %2 = arith.addf %0, %1 : f32
+        memref.store %2, %alloc_2[%c1, %c1] : memref<2x2xf32>
+      }
+    } {calyx.parallel = true}
+    ```
+  }];
+  let dependentDialects = ["mlir::affine::AffineDialect"];
+  let constructor = "circt::calyx::createAffineParallelUnrollPass()";
+}
+
 #endif // CIRCT_DIALECT_CALYX_CALYXPASSES_TD

--- a/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
+++ b/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
@@ -1,0 +1,166 @@
+//===- AffineParallelUnroll.cpp - Unroll AffineParallelOp ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Unroll AffineParallelOp to facilitate lowering to Calyx ParOp.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Calyx/CalyxPasses.h"
+#include "circt/Support/LLVM.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace circt {
+namespace calyx {
+#define GEN_PASS_DEF_AFFINEPARALLELUNROLL
+#include "circt/Dialect/Calyx/CalyxPasses.h.inc"
+} // namespace calyx
+} // namespace circt
+
+using namespace circt;
+using namespace mlir;
+using namespace mlir::affine;
+using namespace mlir::arith;
+
+namespace {
+
+struct AffineParallelUnroll : public OpRewritePattern<AffineParallelOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(AffineParallelOp affineParallelOp,
+                                PatternRewriter &rewriter) const override {
+    if (affineParallelOp->hasAttr("calyx.parallel"))
+      // We assume that having "calyx.parallel" attribute means that it has
+      // already been unrolled.
+      return failure();
+
+    if (!affineParallelOp.getResults().empty()) {
+      affineParallelOp.emitError(
+          "affine.parallel with reductions is not supported yet");
+      return failure();
+    }
+
+    Location loc = affineParallelOp.getLoc();
+
+    rewriter.setInsertionPointAfter(affineParallelOp);
+    // Create a single-iteration parallel loop op and mark its special by
+    // setting the "calyx.parallel" attribute.
+    AffineMap lbMap = AffineMap::get(0, 0, rewriter.getAffineConstantExpr(0),
+                                     rewriter.getContext());
+    AffineMap ubMap = AffineMap::get(0, 0, rewriter.getAffineConstantExpr(1),
+                                     rewriter.getContext());
+    auto newParallelOp = rewriter.create<AffineParallelOp>(
+        loc, /*resultTypes=*/TypeRange(),
+        /*reductions=*/SmallVector<arith::AtomicRMWKind>(),
+        /*lowerBoundsMap=*/lbMap, /*lowerBoundsOperands=*/SmallVector<Value>(),
+        /*upperBoundsMap=*/ubMap, /*upperBoundsOperands=*/SmallVector<Value>(),
+        /*steps=*/SmallVector<int64_t>({1}));
+    newParallelOp->setAttr("calyx.parallel", rewriter.getBoolAttr(true));
+
+    SmallVector<int64_t> pLoopLowerBounds =
+        affineParallelOp.getLowerBoundsMap().getConstantResults();
+    if (pLoopLowerBounds.empty()) {
+      affineParallelOp.emitError(
+          "affine.parallel must have constant lower bounds");
+      return failure();
+    }
+    SmallVector<int64_t> pLoopUpperBounds =
+        affineParallelOp.getUpperBoundsMap().getConstantResults();
+    if (pLoopUpperBounds.empty()) {
+      affineParallelOp.emitError(
+          "affine.parallel must have constant upper bounds");
+      return failure();
+    }
+    SmallVector<int64_t, 8> pLoopSteps = affineParallelOp.getSteps();
+
+    Block *pLoopBody = affineParallelOp.getBody();
+    MutableArrayRef<BlockArgument> pLoopIVs = affineParallelOp.getIVs();
+
+    OpBuilder insideBuilder(newParallelOp);
+    SmallVector<int64_t> indices = pLoopLowerBounds;
+    while (true) {
+      insideBuilder.setInsertionPointToStart(newParallelOp.getBody());
+      // Create an `scf.execute_region` to wrap each unrolled block since
+      // `affine.parallel` requires only one block in the body region.
+      auto executeRegionOp =
+          insideBuilder.create<scf::ExecuteRegionOp>(loc, TypeRange{});
+      Region &executeRegionRegion = executeRegionOp.getRegion();
+      Block *executeRegionBlock = &executeRegionRegion.emplaceBlock();
+
+      OpBuilder regionBuilder(executeRegionOp);
+      // Each iteration starts with a fresh mapping, so each new block’s
+      // argument of a region-based operation (such as `affine.for`) get
+      // re-mapped independently.
+      IRMapping operandMap;
+      regionBuilder.setInsertionPointToEnd(executeRegionBlock);
+      // Map induction variables to constant indices
+      for (unsigned i = 0; i < indices.size(); ++i) {
+        Value ivConstant =
+            regionBuilder.create<arith::ConstantIndexOp>(loc, indices[i]);
+        operandMap.map(pLoopIVs[i], ivConstant);
+      }
+
+      for (auto it = pLoopBody->begin(); it != std::prev(pLoopBody->end());
+           ++it)
+        regionBuilder.clone(*it, operandMap);
+
+      // A terminator should always be inserted in `scf.execute_region`'s block.
+      regionBuilder.create<scf::YieldOp>(loc);
+
+      // Increment indices using `step`.
+      bool done = false;
+      for (int dim = indices.size() - 1; dim >= 0; --dim) {
+        indices[dim] += pLoopSteps[dim];
+        if (indices[dim] < pLoopUpperBounds[dim])
+          break;
+        indices[dim] = pLoopLowerBounds[dim];
+        if (dim == 0)
+          // All combinations have been generated
+          done = true;
+      }
+      if (done)
+        break;
+    }
+
+    rewriter.replaceOp(affineParallelOp, newParallelOp);
+
+    return success();
+  }
+};
+
+struct AffineParallelUnrollPass
+    : public circt::calyx::impl::AffineParallelUnrollBase<
+          AffineParallelUnrollPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<mlir::scf::SCFDialect>();
+  }
+  void runOnOperation() override;
+};
+
+} // end anonymous namespace
+
+void AffineParallelUnrollPass::runOnOperation() {
+  auto *ctx = &getContext();
+  ConversionTarget target(*ctx);
+
+  RewritePatternSet patterns(ctx);
+  patterns.add<AffineParallelUnroll>(ctx);
+
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<mlir::Pass> circt::calyx::createAffineParallelUnrollPass() {
+  return std::make_unique<AffineParallelUnrollPass>();
+}

--- a/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
+++ b/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
@@ -40,8 +40,8 @@ struct AffineParallelUnroll : public OpRewritePattern<AffineParallelOp> {
 
   LogicalResult matchAndRewrite(AffineParallelOp affineParallelOp,
                                 PatternRewriter &rewriter) const override {
-    if (affineParallelOp->hasAttr("calyx.parallel"))
-      // We assume that having "calyx.parallel" attribute means that it has
+    if (affineParallelOp->hasAttr("calyx.unroll"))
+      // We assume that having "calyx.unroll" attribute means that it has
       // already been unrolled.
       return failure();
 
@@ -55,7 +55,7 @@ struct AffineParallelUnroll : public OpRewritePattern<AffineParallelOp> {
 
     rewriter.setInsertionPointAfter(affineParallelOp);
     // Create a single-iteration parallel loop op and mark its special by
-    // setting the "calyx.parallel" attribute.
+    // setting the "calyx.unroll" attribute.
     AffineMap lbMap = AffineMap::get(0, 0, rewriter.getAffineConstantExpr(0),
                                      rewriter.getContext());
     AffineMap ubMap = AffineMap::get(0, 0, rewriter.getAffineConstantExpr(1),
@@ -66,7 +66,7 @@ struct AffineParallelUnroll : public OpRewritePattern<AffineParallelOp> {
         /*lowerBoundsMap=*/lbMap, /*lowerBoundsOperands=*/SmallVector<Value>(),
         /*upperBoundsMap=*/ubMap, /*upperBoundsOperands=*/SmallVector<Value>(),
         /*steps=*/SmallVector<int64_t>({1}));
-    newParallelOp->setAttr("calyx.parallel", rewriter.getBoolAttr(true));
+    newParallelOp->setAttr("calyx.unroll", rewriter.getBoolAttr(true));
 
     SmallVector<int64_t> pLoopLowerBounds =
         affineParallelOp.getLowerBoundsMap().getConstantResults();

--- a/lib/Dialect/Calyx/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Calyx/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_circt_dialect_library(CIRCTCalyxTransforms
   RemoveCombGroups.cpp
   CalyxHelpers.cpp
   CalyxLoweringUtils.cpp
+  AffineParallelUnroll.cpp
 
   DEPENDS
   CIRCTCalyxTransformsIncGen

--- a/test/Dialect/Calyx/affine-parallel-unroll.mlir
+++ b/test/Dialect/Calyx/affine-parallel-unroll.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --affine-parallel-unroll --verify-diagnostics %s | FileCheck %s
+// RUN: circt-opt --affine-parallel-unroll --split-input-file --verify-diagnostics %s | FileCheck %s
 
 // CHECK-LABEL:   func.func @main(
 // CHECK-SAME:                    %[[VAL_0:.*]]: memref<2x2xf32>,
@@ -47,6 +47,54 @@ module {
       %1 = memref.load %alloc[%i, %j] : memref<2x2xf32>
       %2 = arith.addf %0, %1 : f32
       memref.store %2, %arg1[%i, %j] : memref<2x2xf32>
+    }
+    return
+  }
+}
+
+// -----
+
+// Test parallel op lowering when it has region-based nested ops, such as `affine.for`
+
+// CHECK-LABEL:   func.func @main(
+// CHECK-SAME:                    %[[VAL_0:.*]]: memref<2x2xf32>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: memref<2x2xf32>) {
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_4:.*]] = memref.alloc() : memref<2x2xf32>
+// CHECK:           affine.parallel (%[[VAL_5:.*]]) = (0) to (1) {
+// CHECK:             scf.execute_region {
+// CHECK:               affine.for %[[VAL_6:.*]] = 0 to 2 {
+// CHECK:                 %[[VAL_7:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_3]], %[[VAL_6]]] : memref<2x2xf32>
+// CHECK:                 %[[VAL_8:.*]] = memref.load %[[VAL_4]]{{\[}}%[[VAL_3]], %[[VAL_6]]] : memref<2x2xf32>
+// CHECK:                 %[[VAL_9:.*]] = arith.addf %[[VAL_7]], %[[VAL_8]] : f32
+// CHECK:                 memref.store %[[VAL_9]], %[[VAL_1]]{{\[}}%[[VAL_3]], %[[VAL_6]]] : memref<2x2xf32>
+// CHECK:               }
+// CHECK:               scf.yield
+// CHECK:             }
+// CHECK:             scf.execute_region {
+// CHECK:               affine.for %[[VAL_10:.*]] = 0 to 2 {
+// CHECK:                 %[[VAL_11:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_2]], %[[VAL_10]]] : memref<2x2xf32>
+// CHECK:                 %[[VAL_12:.*]] = memref.load %[[VAL_4]]{{\[}}%[[VAL_2]], %[[VAL_10]]] : memref<2x2xf32>
+// CHECK:                 %[[VAL_13:.*]] = arith.addf %[[VAL_11]], %[[VAL_12]] : f32
+// CHECK:                 memref.store %[[VAL_13]], %[[VAL_1]]{{\[}}%[[VAL_2]], %[[VAL_10]]] : memref<2x2xf32>
+// CHECK:               }
+// CHECK:               scf.yield
+// CHECK:             }
+// CHECK:           } {calyx.parallel = true}
+// CHECK:           return
+// CHECK:         }
+
+module {
+  func.func @main(%arg0: memref<2x2xf32>, %arg1: memref<2x2xf32>) {
+    %alloc = memref.alloc() : memref<2x2xf32>
+    affine.parallel (%i) = (0) to (2) {
+      affine.for %j = 0 to 2 {
+        %0 = memref.load %arg0[%i, %j] : memref<2x2xf32>
+        %1 = memref.load %alloc[%i, %j] : memref<2x2xf32>
+        %2 = arith.addf %0, %1 : f32
+        memref.store %2, %arg1[%i, %j] : memref<2x2xf32>
+      }
     }
     return
   }

--- a/test/Dialect/Calyx/affine-parallel-unroll.mlir
+++ b/test/Dialect/Calyx/affine-parallel-unroll.mlir
@@ -1,0 +1,53 @@
+// RUN: circt-opt --affine-parallel-unroll --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL:   func.func @main(
+// CHECK-SAME:                    %[[VAL_0:.*]]: memref<2x2xf32>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: memref<2x2xf32>) {
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_3:.*]] = arith.constant 1 : index
+// CHECK:           %[[VAL_4:.*]] = memref.alloc() : memref<2x2xf32>
+// CHECK:           affine.parallel (%[[VAL_5:.*]]) = (0) to (1) {
+// CHECK:             scf.execute_region {
+// CHECK:               %[[VAL_6:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_3]], %[[VAL_3]]] : memref<2x2xf32>
+// CHECK:               %[[VAL_7:.*]] = memref.load %[[VAL_4]]{{\[}}%[[VAL_3]], %[[VAL_3]]] : memref<2x2xf32>
+// CHECK:               %[[VAL_8:.*]] = arith.addf %[[VAL_6]], %[[VAL_7]] : f32
+// CHECK:               memref.store %[[VAL_8]], %[[VAL_1]]{{\[}}%[[VAL_3]], %[[VAL_3]]] : memref<2x2xf32>
+// CHECK:               scf.yield
+// CHECK:             }
+// CHECK:             scf.execute_region {
+// CHECK:               %[[VAL_9:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_3]], %[[VAL_2]]] : memref<2x2xf32>
+// CHECK:               %[[VAL_10:.*]] = memref.load %[[VAL_4]]{{\[}}%[[VAL_3]], %[[VAL_2]]] : memref<2x2xf32>
+// CHECK:               %[[VAL_11:.*]] = arith.addf %[[VAL_9]], %[[VAL_10]] : f32
+// CHECK:               memref.store %[[VAL_11]], %[[VAL_1]]{{\[}}%[[VAL_3]], %[[VAL_2]]] : memref<2x2xf32>
+// CHECK:               scf.yield
+// CHECK:             }
+// CHECK:             scf.execute_region {
+// CHECK:               %[[VAL_12:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_2]], %[[VAL_3]]] : memref<2x2xf32>
+// CHECK:               %[[VAL_13:.*]] = memref.load %[[VAL_4]]{{\[}}%[[VAL_2]], %[[VAL_3]]] : memref<2x2xf32>
+// CHECK:               %[[VAL_14:.*]] = arith.addf %[[VAL_12]], %[[VAL_13]] : f32
+// CHECK:               memref.store %[[VAL_14]], %[[VAL_1]]{{\[}}%[[VAL_2]], %[[VAL_3]]] : memref<2x2xf32>
+// CHECK:               scf.yield
+// CHECK:             }
+// CHECK:             scf.execute_region {
+// CHECK:               %[[VAL_15:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_2]], %[[VAL_2]]] : memref<2x2xf32>
+// CHECK:               %[[VAL_16:.*]] = memref.load %[[VAL_4]]{{\[}}%[[VAL_2]], %[[VAL_2]]] : memref<2x2xf32>
+// CHECK:               %[[VAL_17:.*]] = arith.addf %[[VAL_15]], %[[VAL_16]] : f32
+// CHECK:               memref.store %[[VAL_17]], %[[VAL_1]]{{\[}}%[[VAL_2]], %[[VAL_2]]] : memref<2x2xf32>
+// CHECK:               scf.yield
+// CHECK:             }
+// CHECK:           } {calyx.parallel = true}
+// CHECK:           return
+// CHECK:         }
+
+module {
+  func.func @main(%arg0: memref<2x2xf32>, %arg1: memref<2x2xf32>) {
+    %alloc = memref.alloc() : memref<2x2xf32>
+    affine.parallel (%i, %j) = (0, 0) to (2, 2) {
+      %0 = memref.load %arg0[%i, %j] : memref<2x2xf32>
+      %1 = memref.load %alloc[%i, %j] : memref<2x2xf32>
+      %2 = arith.addf %0, %1 : f32
+      memref.store %2, %arg1[%i, %j] : memref<2x2xf32>
+    }
+    return
+  }
+}


### PR DESCRIPTION
This patch unrolls `affine.parallel` op to multiple `scf.execute_region` ops for easier lowering to `calyx.par` op so that we can do more higher-level optimizations and we can make the lowering of `scf.parallel` in the SCFToCalyx` pass trivial.