### PR TITLE
[SCFToCalyx] Update the lowering of SCF ParallelOp after AffineParallelUnroll pass

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -54,6 +54,8 @@ namespace circt {
 class ComponentLoweringStateInterface;
 namespace scftocalyx {
 
+static constexpr std::string_view unrolledParallelAttr = "calyx.unroll";
+
 //===----------------------------------------------------------------------===//
 // Utility types
 //===----------------------------------------------------------------------===//
@@ -1472,7 +1474,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                      scf::ParallelOp parOp) const {
-  if (!parOp->hasAttr("calyx.unroll")) {
+  if (!parOp->hasAttr(unrolledParallelAttr)) {
     parOp.emitError(
         "AffineParallelUnroll must be run in order to lower scf.parallel");
     return failure();
@@ -1529,7 +1531,7 @@ class InlineExecuteRegionOpPattern
                                 PatternRewriter &rewriter) const override {
     if (auto parOp = dyn_cast_or_null<scf::ParallelOp>(execOp->getParentOp())) {
       if (auto boolAttr =
-              dyn_cast_or_null<mlir::BoolAttr>(parOp->getAttr("calyx.unroll")))
+              dyn_cast_or_null<mlir::BoolAttr>(parOp->getAttr(unrolledParallelAttr)))
         // If the `ExecuteRegionOp` was inserted when running the
         // `AffineParallelUnrollPass` (indicated by having `calyx.unroll`
         // attribute), we should skip inline.

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1530,8 +1530,8 @@ class InlineExecuteRegionOpPattern
   LogicalResult matchAndRewrite(scf::ExecuteRegionOp execOp,
                                 PatternRewriter &rewriter) const override {
     if (auto parOp = dyn_cast_or_null<scf::ParallelOp>(execOp->getParentOp())) {
-      if (auto boolAttr =
-              dyn_cast_or_null<mlir::BoolAttr>(parOp->getAttr(unrolledParallelAttr)))
+      if (auto boolAttr = dyn_cast_or_null<mlir::BoolAttr>(
+              parOp->getAttr(unrolledParallelAttr)))
         // If the `ExecuteRegionOp` was inserted when running the
         // `AffineParallelUnrollPass` (indicated by having `calyx.unroll`
         // attribute), we should skip inline.

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1472,7 +1472,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                      scf::ParallelOp parOp) const {
-  if (!parOp->hasAttr("calyx.parallel")) {
+  if (!parOp->hasAttr("calyx.unroll")) {
     parOp.emitError(
         "AffineParallelUnroll must be run in order to lower scf.parallel");
     return failure();
@@ -1528,10 +1528,10 @@ class InlineExecuteRegionOpPattern
   LogicalResult matchAndRewrite(scf::ExecuteRegionOp execOp,
                                 PatternRewriter &rewriter) const override {
     if (auto parOp = dyn_cast_or_null<scf::ParallelOp>(execOp->getParentOp())) {
-      if (auto boolAttr = dyn_cast_or_null<mlir::BoolAttr>(
-              parOp->getAttr("calyx.parallel")))
+      if (auto boolAttr =
+              dyn_cast_or_null<mlir::BoolAttr>(parOp->getAttr("calyx.unroll")))
         // If the `ExecuteRegionOp` was inserted when running the
-        // `AffineParallelUnrollPass` (indicated by having `calyx.parallel`
+        // `AffineParallelUnrollPass` (indicated by having `calyx.unroll`
         // attribute), we should skip inline.
         return success();
     }

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1171,6 +1171,10 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
     if (auto ifOp = dyn_cast<scf::IfOp>(yieldOp->getParentOp()))
       // Empty yield inside ifOp, essentially a no-op.
       return success();
+    if (auto executeRegionOp =
+            dyn_cast<scf::ExecuteRegionOp>(yieldOp->getParentOp()))
+      // Empty yield inside an `ExecuteRegionOp` acts as the terminator op.
+      return success();
     return yieldOp.getOperation()->emitError()
            << "Unsupported empty yieldOp outside ForOp or IfOp.";
   }
@@ -1468,6 +1472,11 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
 
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
                                      scf::ParallelOp parOp) const {
+  if (!parOp->hasAttr("calyx.parallel")) {
+    parOp.emitError(
+        "AffineParallelUnroll must be run in order to lower scf.parallel");
+    return failure();
+  }
   getState<ComponentLoweringState>().addBlockScheduleable(
       parOp.getOperation()->getBlock(), ParScheduleable{parOp});
   return success();
@@ -1518,6 +1527,14 @@ class InlineExecuteRegionOpPattern
 
   LogicalResult matchAndRewrite(scf::ExecuteRegionOp execOp,
                                 PatternRewriter &rewriter) const override {
+    if (auto parOp = dyn_cast_or_null<scf::ParallelOp>(execOp->getParentOp())) {
+      if (auto boolAttr = dyn_cast_or_null<mlir::BoolAttr>(
+              parOp->getAttr("calyx.parallel")))
+        // If the `ExecuteRegionOp` was inserted when running the
+        // `AffineParallelUnrollPass` (indicated by having `calyx.parallel`
+        // attribute), we should skip inline.
+        return success();
+    }
     /// Determine type of "yield" operations inside the ERO.
     TypeRange yieldTypes = execOp.getResultTypes();
 
@@ -1873,140 +1890,6 @@ class BuildIfGroups : public calyx::FuncOpPartialLoweringPattern {
       return WalkResult::advance();
     });
     return res;
-  }
-};
-
-class BuildParGroups : public calyx::FuncOpPartialLoweringPattern {
-  using FuncOpPartialLoweringPattern::FuncOpPartialLoweringPattern;
-
-  LogicalResult
-  partiallyLowerFuncToComp(FuncOp funcOp,
-                           PatternRewriter &rewriter) const override {
-    WalkResult walkResult = funcOp.walk([&](scf::ParallelOp scfParOp) {
-      if (!scfParOp.getResults().empty()) {
-        scfParOp.emitError(
-            "Reduce operations in scf.parallel is not supported yet");
-        return WalkResult::interrupt();
-      }
-
-      if (failed(partialEval(rewriter, scfParOp)))
-        return WalkResult::interrupt();
-
-      return WalkResult::advance();
-    });
-
-    return walkResult.wasInterrupted() ? failure() : success();
-  }
-
-private:
-  // Partially evaluate/pre-compute all blocks being executed in parallel by
-  // statically generate loop indices combinations
-  LogicalResult partialEval(PatternRewriter &rewriter,
-                            scf::ParallelOp scfParOp) const {
-    assert(scfParOp.getLoopSteps() && "Parallel loop must have steps");
-    auto *body = scfParOp.getBody();
-    auto parOpIVs = scfParOp.getInductionVars();
-    auto steps = scfParOp.getStep();
-    auto lowerBounds = scfParOp.getLowerBound();
-    auto upperBounds = scfParOp.getUpperBound();
-    rewriter.setInsertionPointAfter(scfParOp);
-    scf::ParallelOp newParOp = scfParOp.cloneWithoutRegions();
-    auto loc = newParOp.getLoc();
-    rewriter.insert(newParOp);
-    OpBuilder insideBuilder(newParOp);
-    auto &region = newParOp.getRegion();
-    auto *newParBodyBlock = &region.emplaceBlock();
-
-    // extract lower bounds, upper bounds, and steps as integer index values
-    SmallVector<int64_t> lbVals, ubVals, stepVals;
-    for (auto lb : lowerBounds) {
-      auto lbOp = lb.getDefiningOp<arith::ConstantIndexOp>();
-      assert(lbOp &&
-             "Lower bound must be a statically computable constant index");
-      lbVals.push_back(lbOp.value());
-    }
-    for (auto ub : upperBounds) {
-      auto ubOp = ub.getDefiningOp<arith::ConstantIndexOp>();
-      assert(ubOp &&
-             "Upper bound must be a statically computable constant index");
-      ubVals.push_back(ubOp.value());
-    }
-    for (auto step : steps) {
-      auto stepOp = step.getDefiningOp<arith::ConstantIndexOp>();
-      assert(stepOp && "Step must be a statically computable constant index");
-      stepVals.push_back(stepOp.value());
-    }
-
-    // Initialize indices with lower bounds
-    SmallVector<int64_t> indices = lbVals;
-
-    while (true) {
-      insideBuilder.setInsertionPointToEnd(newParBodyBlock);
-      // Create an `scf.execute_region` to wrap each unrolled block since
-      // `scf.parallel` requires only one block in the body region.
-      auto execRegionOp =
-          insideBuilder.create<scf::ExecuteRegionOp>(loc, TypeRange{});
-      auto &execRegion = execRegionOp.getRegion();
-      Block *execBlock = &execRegion.emplaceBlock();
-      OpBuilder regionBuilder(execRegionOp);
-      // Each iteration starts with a fresh mapping, so each new block’s
-      // argument of a region-based operation (such as `scf.for`) get re-mapped
-      // independently.
-      IRMapping operandMap;
-
-      regionBuilder.setInsertionPointToEnd(execBlock);
-      // Map induction variables to constant indices
-      for (unsigned i = 0; i < indices.size(); ++i) {
-        Value ivConstant =
-            regionBuilder.create<arith::ConstantIndexOp>(loc, indices[i]);
-        operandMap.map(parOpIVs[i], ivConstant);
-      }
-
-      for (auto it = body->begin(); it != std::prev(body->end()); ++it)
-        regionBuilder.clone(*it, operandMap);
-
-      // A terminator should always be inserted in `scf.execute_region`'s block.
-      regionBuilder.create<scf::ReduceOp>(loc);
-      // Increment indices using `step`
-      bool done = false;
-      for (int dim = indices.size() - 1; dim >= 0; --dim) {
-        indices[dim] += stepVals[dim];
-        if (indices[dim] < ubVals[dim])
-          break;
-        indices[dim] = lbVals[dim];
-        if (dim == 0)
-          // All combinations have been generated
-          done = true;
-      }
-      if (done)
-        break;
-    }
-
-    rewriter.setInsertionPointToEnd(newParOp.getBody());
-    rewriter.create<scf::ReduceOp>(newParOp.getLoc());
-
-    rewriter.replaceOp(scfParOp, newParOp);
-
-    auto containsIfOp = [](scf::ParallelOp parOp) -> bool {
-      bool hasIfOp = false;
-      parOp.walk([&](scf::IfOp ifOp) {
-        hasIfOp = true;
-        return WalkResult::interrupt();
-      });
-      return hasIfOp;
-    };
-    if (containsIfOp(newParOp)) {
-      auto *context = newParOp.getContext();
-      RewritePatternSet patterns(newParOp.getContext());
-      scf::IfOp::getCanonicalizationPatterns(patterns, context);
-      if (failed(
-              applyPatternsGreedily(newParOp->getParentOfType<func::FuncOp>(),
-                                    std::move(patterns)))) {
-        return failure();
-      }
-    }
-
-    return success();
   }
 };
 
@@ -2796,11 +2679,6 @@ void SCFToCalyxPass::runOnOperation() {
 
   /// This pass inlines scf.ExecuteRegionOp's by adding control-flow.
   addGreedyPattern<InlineExecuteRegionOpPattern>(loweringPatterns);
-
-  /// Partial evaluate the scf.ParallelOp and apply the scf.IfOp
-  /// canonicalization optionally.
-  addOncePattern<BuildParGroups>(loweringPatterns, patternState, funcMap,
-                                 *loweringState);
 
   /// This pattern converts all index typed values to an i32 integer.
   addOncePattern<calyx::ConvertIndexTypes>(loweringPatterns, patternState,

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -326,72 +326,60 @@ module {
 
 // CHECK:    calyx.wires {
 // CHECK-DAG:      calyx.group @bb0_0 {
-// CHECK-DAG:        calyx.assign %std_slice_7.in = %c0_i32 : i32
-// CHECK-DAG:        calyx.assign %mem_1.addr0 = %std_slice_7.out : i3
-// CHECK-DAG:        calyx.assign %mem_1.content_en = %true : i1
-// CHECK-DAG:        calyx.assign %mem_1.write_en = %false : i1
-// CHECK-DAG:        calyx.assign %load_0_reg.in = %mem_1.read_data : i32
-// CHECK-DAG:        calyx.assign %load_0_reg.write_en = %mem_1.done : i1
+// CHECK-DAG:        calyx.assign %std_slice_5.in = %c1_i32 : i32
+// CHECK-DAG:        calyx.assign %arg_mem_0.addr0 = %std_slice_5.out : i1
+// CHECK-DAG:        calyx.assign %arg_mem_0.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %arg_mem_0.write_en = %false : i1
+// CHECK-DAG:        calyx.assign %load_0_reg.in = %arg_mem_0.read_data : i32
+// CHECK-DAG:        calyx.assign %load_0_reg.write_en = %arg_mem_0.done : i1
 // CHECK-DAG:        calyx.group_done %load_0_reg.done : i1
 // CHECK-DAG:      }
 // CHECK-DAG:      calyx.group @bb0_1 {
-// CHECK-DAG:        calyx.assign %std_slice_6.in = %c0_i32 : i32
-// CHECK-DAG:        calyx.assign %mem_0.addr0 = %std_slice_6.out : i3
-// CHECK-DAG:        calyx.assign %mem_0.write_data = %load_0_reg.out : i32
-// CHECK-DAG:        calyx.assign %mem_0.write_en = %true : i1
-// CHECK-DAG:        calyx.assign %mem_0.content_en = %true : i1
-// CHECK-DAG:        calyx.group_done %mem_0.done : i1
-// CHECK-DAG:      }
-// CHECK-DAG:      calyx.group @bb0_2 {
-// CHECK-DAG:        calyx.assign %std_slice_5.in = %c4_i32 : i32
-// CHECK-DAG:        calyx.assign %mem_1.addr0 = %std_slice_5.out : i3
-// CHECK-DAG:        calyx.assign %mem_1.content_en = %true : i1
-// CHECK-DAG:        calyx.assign %mem_1.write_en = %false : i1
-// CHECK-DAG:        calyx.assign %load_1_reg.in = %mem_1.read_data : i32
-// CHECK-DAG:        calyx.assign %load_1_reg.write_en = %mem_1.done : i1
+// CHECK-DAG:        calyx.assign %std_slice_4.in = %c1_i32 : i32
+// CHECK-DAG:        calyx.assign %arg_mem_2.addr0 = %std_slice_4.out : i1
+// CHECK-DAG:        calyx.assign %arg_mem_2.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %arg_mem_2.write_en = %false : i1
+// CHECK-DAG:        calyx.assign %load_1_reg.in = %arg_mem_2.read_data : i32
+// CHECK-DAG:        calyx.assign %load_1_reg.write_en = %arg_mem_2.done : i1
 // CHECK-DAG:        calyx.group_done %load_1_reg.done : i1
 // CHECK-DAG:      }
 // CHECK-DAG:      calyx.group @bb0_3 {
-// CHECK-DAG:        calyx.assign %std_slice_4.in = %c1_i32 : i32
-// CHECK-DAG:        calyx.assign %mem_0.addr0 = %std_slice_4.out : i3
-// CHECK-DAG:        calyx.assign %mem_0.write_data = %load_1_reg.out : i32
-// CHECK-DAG:        calyx.assign %mem_0.write_en = %true : i1
-// CHECK-DAG:        calyx.assign %mem_0.content_en = %true : i1
-// CHECK-DAG:        calyx.group_done %mem_0.done : i1
+// CHECK-DAG:        calyx.assign %std_slice_3.in = %c1_i32 : i32
+// CHECK-DAG:        calyx.assign %arg_mem_1.addr0 = %std_slice_3.out : i1
+// CHECK-DAG:        calyx.assign %arg_mem_1.write_data = %std_add_0.out : i32
+// CHECK-DAG:        calyx.assign %arg_mem_1.write_en = %true : i1
+// CHECK-DAG:        calyx.assign %arg_mem_1.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %std_add_0.left = %load_0_reg.out : i32
+// CHECK-DAG:        calyx.assign %std_add_0.right = %load_1_reg.out : i32
+// CHECK-DAG:        calyx.group_done %arg_mem_1.done : i1
 // CHECK-DAG:      }
 // CHECK-DAG:      calyx.group @bb0_4 {
-// CHECK-DAG:        calyx.assign %std_slice_3.in = %c2_i32 : i32
-// CHECK-DAG:        calyx.assign %mem_1.addr0 = %std_slice_3.out : i3
-// CHECK-DAG:        calyx.assign %mem_1.content_en = %true : i1
-// CHECK-DAG:        calyx.assign %mem_1.write_en = %false : i1
-// CHECK-DAG:        calyx.assign %load_2_reg.in = %mem_1.read_data : i32
-// CHECK-DAG:        calyx.assign %load_2_reg.write_en = %mem_1.done : i1
+// CHECK-DAG:        calyx.assign %std_slice_2.in = %c0_i32 : i32
+// CHECK-DAG:        calyx.assign %arg_mem_0.addr0 = %std_slice_2.out : i1
+// CHECK-DAG:        calyx.assign %arg_mem_0.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %arg_mem_0.write_en = %false : i1
+// CHECK-DAG:        calyx.assign %load_2_reg.in = %arg_mem_0.read_data : i32
+// CHECK-DAG:        calyx.assign %load_2_reg.write_en = %arg_mem_0.done : i1
 // CHECK-DAG:        calyx.group_done %load_2_reg.done : i1
 // CHECK-DAG:      }
 // CHECK-DAG:      calyx.group @bb0_5 {
-// CHECK-DAG:        calyx.assign %std_slice_2.in = %c4_i32 : i32
-// CHECK-DAG:        calyx.assign %mem_0.addr0 = %std_slice_2.out : i3
-// CHECK-DAG:        calyx.assign %mem_0.write_data = %load_2_reg.out : i32
-// CHECK-DAG:        calyx.assign %mem_0.write_en = %true : i1
-// CHECK-DAG:        calyx.assign %mem_0.content_en = %true : i1
-// CHECK-DAG:        calyx.group_done %mem_0.done : i1
-// CHECK-DAG:      }
-// CHECK-DAG:      calyx.group @bb0_6 {
-// CHECK-DAG:        calyx.assign %std_slice_1.in = %c6_i32 : i32
-// CHECK-DAG:        calyx.assign %mem_1.addr0 = %std_slice_1.out : i3
-// CHECK-DAG:        calyx.assign %mem_1.content_en = %true : i1
-// CHECK-DAG:        calyx.assign %mem_1.write_en = %false : i1
-// CHECK-DAG:        calyx.assign %load_3_reg.in = %mem_1.read_data : i32
-// CHECK-DAG:        calyx.assign %load_3_reg.write_en = %mem_1.done : i1
+// CHECK-DAG:        calyx.assign %std_slice_1.in = %c0_i32 : i32
+// CHECK-DAG:        calyx.assign %arg_mem_2.addr0 = %std_slice_1.out : i1
+// CHECK-DAG:        calyx.assign %arg_mem_2.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %arg_mem_2.write_en = %false : i1
+// CHECK-DAG:        calyx.assign %load_3_reg.in = %arg_mem_2.read_data : i32
+// CHECK-DAG:        calyx.assign %load_3_reg.write_en = %arg_mem_2.done : i1
 // CHECK-DAG:        calyx.group_done %load_3_reg.done : i1
 // CHECK-DAG:      }
 // CHECK-DAG:      calyx.group @bb0_7 {
-// CHECK-DAG:        calyx.assign %std_slice_0.in = %c5_i32 : i32
-// CHECK-DAG:        calyx.assign %mem_0.addr0 = %std_slice_0.out : i3
-// CHECK-DAG:        calyx.assign %mem_0.write_data = %load_3_reg.out : i32
-// CHECK-DAG:        calyx.assign %mem_0.write_en = %true : i1
-// CHECK-DAG:        calyx.assign %mem_0.content_en = %true : i1
-// CHECK-DAG:        calyx.group_done %mem_0.done : i1
+// CHECK-DAG:        calyx.assign %std_slice_0.in = %c0_i32 : i32
+// CHECK-DAG:        calyx.assign %arg_mem_1.addr0 = %std_slice_0.out : i1
+// CHECK-DAG:        calyx.assign %arg_mem_1.write_data = %std_add_1.out : i32
+// CHECK-DAG:        calyx.assign %arg_mem_1.write_en = %true : i1
+// CHECK-DAG:        calyx.assign %arg_mem_1.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %std_add_1.left = %load_2_reg.out : i32
+// CHECK-DAG:        calyx.assign %std_add_1.right = %load_3_reg.out : i32
+// CHECK-DAG:        calyx.group_done %arg_mem_1.done : i1
 // CHECK-DAG:      }
 // CHECK-DAG:    }
 // CHECK-DAG:    calyx.control {
@@ -400,17 +388,11 @@ module {
 // CHECK-DAG:          calyx.seq {
 // CHECK-DAG:            calyx.enable @bb0_0
 // CHECK-DAG:            calyx.enable @bb0_1
-// CHECK-DAG:          }
-// CHECK-DAG:          calyx.seq {
-// CHECK-DAG:            calyx.enable @bb0_2
 // CHECK-DAG:            calyx.enable @bb0_3
 // CHECK-DAG:          }
 // CHECK-DAG:          calyx.seq {
 // CHECK-DAG:            calyx.enable @bb0_4
 // CHECK-DAG:            calyx.enable @bb0_5
-// CHECK-DAG:          }
-// CHECK-DAG:          calyx.seq {
-// CHECK-DAG:            calyx.enable @bb0_6
 // CHECK-DAG:            calyx.enable @bb0_7
 // CHECK-DAG:          }
 // CHECK-DAG:        }
@@ -418,22 +400,26 @@ module {
 // CHECK-DAG:    }
 
 module {
-  func.func @main() {
-    %c2 = arith.constant 2 : index
-    %c1 = arith.constant 1 : index
-    %c3 = arith.constant 3 : index
+  func.func @main(%arg0: memref<2xi32>, %arg1: memref<2xi32>) {
     %c0 = arith.constant 0 : index
-    %alloc = memref.alloc() : memref<6xi32>
-    %alloc_1 = memref.alloc() : memref<6xi32>
-    scf.parallel (%arg2, %arg3) = (%c0, %c0) to (%c3, %c2) step (%c2, %c1) {
-      %4 = arith.shli %arg3, %c2 : index
-      %5 = arith.addi %4, %arg2 : index
-      %6 = memref.load %alloc_1[%5] : memref<6xi32>
-      %7 = arith.shli %arg2, %c1 : index
-      %8 = arith.addi %7, %arg3 : index
-      memref.store %6, %alloc[%8] : memref<6xi32>
-      scf.reduce 
-    }
+    %c1 = arith.constant 1 : index
+    %alloc = memref.alloc() : memref<2xi32>
+    scf.parallel (%arg2) = (%c0) to (%c1) step (%c1) {
+      scf.execute_region {
+        %0 = memref.load %arg0[%c1] : memref<2xi32>
+        %1 = memref.load %alloc[%c1] : memref<2xi32>
+        %2 = arith.addi %0, %1 : i32
+        memref.store %2, %arg1[%c1] : memref<2xi32>
+        scf.yield
+      }
+      scf.execute_region {
+        %0 = memref.load %arg0[%c0] : memref<2xi32>
+        %1 = memref.load %alloc[%c0] : memref<2xi32>
+        %2 = arith.addi %0, %1 : i32
+        memref.store %2, %arg1[%c0] : memref<2xi32>
+        scf.yield
+      }
+    } {calyx.parallel = true}
     return
   }
 }
@@ -531,102 +517,3 @@ module {
   }
 }
 
-// Test parallel op lowering when it has region-based nested ops, such as `scf.for`
-
-// -----
-
-// CHECK:           calyx.control {
-// CHECK:             calyx.seq {
-// CHECK:               calyx.par {
-// CHECK:                 calyx.seq {
-// CHECK:                   calyx.enable @init_for_0_induction_var
-// CHECK:                   calyx.repeat 2 {
-// CHECK:                     calyx.seq {
-// CHECK:                       calyx.enable @bb0_0
-// CHECK:                       calyx.enable @bb0_1
-// CHECK:                       calyx.enable @incr_for_0_induction_var
-// CHECK:                     }
-// CHECK:                   }
-// CHECK:                 }
-// CHECK:                 calyx.seq {
-// CHECK:                   calyx.enable @init_for_1_induction_var
-// CHECK:                   calyx.repeat 2 {
-// CHECK:                     calyx.seq {
-// CHECK:                       calyx.enable @bb0_2
-// CHECK:                       calyx.enable @bb0_3
-// CHECK:                       calyx.enable @incr_for_1_induction_var
-// CHECK:                     }
-// CHECK:                   }
-// CHECK:                 }
-// CHECK:               }
-// CHECK:             }
-// CHECK:           }
-// CHECK:         } {toplevel}
-
-module {
-  func.func @main() {
-    %c2 = arith.constant 2 : index
-    %c1 = arith.constant 1 : index
-    %c0 = arith.constant 0 : index
-    %alloc = memref.alloc() : memref<6xi32>
-    %alloc_1 = memref.alloc() : memref<6xi32>
-    scf.parallel (%arg2) = (%c0) to (%c2) step (%c1) {
-      scf.for %arg3 = %c0 to %c2 step %c1 {
-        %1 = memref.load %alloc_1[%arg3] : memref<6xi32>
-        %2 = arith.shli %arg2, %c1 : index
-        memref.store %1, %alloc[%2] : memref<6xi32>
-      }
-      scf.reduce
-    }
-    return
-  }
-}
-
-// Test lower scf.parallel when there is a nested scf.if that can be
-// canonicalized. See: https://github.com/llvm/circt/issues/8086
-
-// -----
-
-// CHECK:           calyx.control {
-// CHECK:             calyx.seq {
-// CHECK:               calyx.par {
-// CHECK:                 calyx.seq {
-// CHECK:                   calyx.enable @bb0_0
-// CHECK:                   calyx.enable @bb0_1
-// CHECK:                 }
-// CHECK:                 calyx.seq {
-// CHECK:                   calyx.enable @bb0_2
-// CHECK:                   calyx.enable @bb0_3
-// CHECK:                 }
-// CHECK:                 calyx.seq {
-// CHECK:                   calyx.enable @bb0_4
-// CHECK:                   calyx.enable @bb0_5
-// CHECK:                 }
-// CHECK:               }
-// CHECK:             }
-// CHECK:           }
-// CHECK:         }
-
-module {
-  func.func @main(%arg0 : memref<6xi32>, %arg1 : memref<6xi32>) {
-    %c2 = arith.constant 2 : index
-    %c1 = arith.constant 1 : index
-    %c3 = arith.constant 3 : index
-    %c0 = arith.constant 0 : index
-    scf.parallel (%arg2, %arg3) = (%c0, %c0) to (%c3, %c2) step (%c1, %c1) {
-      %4 = arith.shli %arg3, %c2 : index
-      %5 = arith.addi %4, %arg2 : index
-      %6 = memref.load %arg0[%5] : memref<6xi32>
-      %7 = arith.shli %arg2, %c1 : index
-      %8 = arith.addi %7, %arg3 : index
-      %9 = arith.remui %8, %c2 : index
-      %10 = arith.cmpi eq, %9, %c0 : index
-      scf.if %10 {
-        memref.store %6, %arg1[%8] : memref<6xi32>
-        scf.yield
-      }
-      scf.reduce 
-    }
-    return
-  }
-}

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -419,7 +419,7 @@ module {
         memref.store %2, %arg1[%c0] : memref<2xi32>
         scf.yield
       }
-    } {calyx.parallel = true}
+    } {calyx.unroll = true}
     return
   }
 }

--- a/test/Conversion/SCFToCalyx/errors.mlir
+++ b/test/Conversion/SCFToCalyx/errors.mlir
@@ -57,22 +57,18 @@ module {
 // -----
 
 module {
-  func.func @main() -> i32 {
+  func.func @main(%arg0: i32) {
     %c1 = arith.constant 1 : index
-    %c3 = arith.constant 3 : index
     %c0 = arith.constant 0 : index
-    %cinit = arith.constant 0 : i32
     %alloc = memref.alloc() : memref<6xi32>
-    // expected-error @+1 {{Reduce operations in scf.parallel is not supported yet}}
-    %r:1 = scf.parallel (%arg2) = (%c0) to (%c3) step (%c1) init (%cinit) -> i32 {
-      %6 = memref.load %alloc[%arg2] : memref<6xi32>
-      scf.reduce(%6 : i32) {
-        ^bb0(%lhs : i32, %rhs: i32):
-          %res = arith.addi %lhs, %rhs : i32
-          scf.reduce.return %res : i32
+    // expected-error @+1{{AffineParallelUnroll must be run in order to lower scf.parallel}}
+    scf.parallel (%arg2) = (%c0) to (%c1) step (%c1) {
+      scf.execute_region {
+        memref.store %arg0, %alloc[%arg2] : memref<6xi32>
+        scf.yield
       }
     }
-    return %r : i32
+    return
   }
 }
 


### PR DESCRIPTION
This patch adjusts the lowering of `scf.parallel` accordingly after https://github.com/llvm/circt/pull/8248 and https://github.com/llvm/circt/pull/8249.