### PR TITLE
[Calyx] virtual dtor to properly destruct derived classes

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -340,7 +340,7 @@ class ComponentLoweringStateInterface {
 public:
   ComponentLoweringStateInterface(calyx::ComponentOp component);
 
-  ~ComponentLoweringStateInterface();
+  virtual ~ComponentLoweringStateInterface();
 
   /// Returns the calyx::ComponentOp associated with this lowering state.
   calyx::ComponentOp getComponentOp();


### PR DESCRIPTION
ASAN caught new/delete type mismatch error.