### PR TITLE
[Verif] Change simulation exit code to success boolean

### DIFF
--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -379,14 +379,10 @@ def SimulationOp : VerifOp<"simulation", [
     0-to-1 transition of the clock after the init signal has dropped to 0. No
     additional clock toggles occur once done has been sampled as 1.
 
-    The second operand is an "exit code" signal which may be of any integer
-    type. It indicates success of a test as 0, or failure as any non-zero
-    integer. The exit code is sampled at the same time as the done signal. Only
-    the zero versus non-zero value distinction is relevant to indicate
-    simulation success and must be preserved. The exact non-zero value is for
-    informational purposes only and may not be reproduced accurately by
-    simulators. Simulators may in the worst case map all non-zero values to 1,
-    reducing the exit code to a single bit indicating failure or success.
+    The second operand is a "success" signal of type `i1` which indicates the
+    success of a test as 1, or failure as 0. The signal is sampled at the same
+    time as the done signal. Simulators must signal failure to the operating
+    system through a non-zero exit code.
 
     ### Schedule
 
@@ -424,12 +420,12 @@ def SimulationOp : VerifOp<"simulation", [
 
       // Check results and track failures.
       %4 = comb.add %1, %2 : i42
-      %5 = comb.icmp ne %3, %4 : i42
-      %false = hw.constant false
-      %failure = seq.compreg %6, %clock reset %init, %false : i1
-      %6 = comb.or %failure, %5 : i1
+      %5 = comb.icmp eq %3, %4 : i42
+      %true = hw.constant true
+      %success = seq.compreg %6, %clock reset %init, %true : i1
+      %6 = comb.and %success, %5 : i1
 
-      verif.yield %done, %failure : i1, i1
+      verif.yield %done, %success : i1, i1
     }
     ```
   }];

--- a/lib/Dialect/Verif/VerifOps.cpp
+++ b/lib/Dialect/Verif/VerifOps.cpp
@@ -167,17 +167,17 @@ LogicalResult SimulationOp::verifyRegions() {
   if (getBody()->getNumArguments() != 2)
     return emitOpError() << "must have two block arguments";
   if (!isa<seq::ClockType>(getBody()->getArgument(0).getType()))
-    return emitOpError() << "block argument #0 must be a `!seq.clock`";
+    return emitOpError() << "block argument #0 must be of type `!seq.clock`";
   if (!getBody()->getArgument(1).getType().isSignlessInteger(1))
-    return emitOpError() << "block argument #1 must be a `i1`";
+    return emitOpError() << "block argument #1 must be of type `i1`";
 
   auto *yieldOp = getBody()->getTerminator();
   if (yieldOp->getNumOperands() != 2)
     return yieldOp->emitOpError() << "must have two operands";
   if (!yieldOp->getOperand(0).getType().isSignlessInteger(1))
-    return yieldOp->emitOpError() << "operand #0 must be an `i1`";
-  if (!isa<IntegerType>(yieldOp->getOperand(1).getType()))
-    return yieldOp->emitOpError() << "operand #1 must be an integer";
+    return yieldOp->emitOpError() << "operand #0 must be of type `i1`";
+  if (!yieldOp->getOperand(1).getType().isSignlessInteger(1))
+    return yieldOp->emitOpError() << "operand #1 must be of type `i1`";
 
   return success();
 }

--- a/test/Dialect/Arc/lower-verif-simulations.mlir
+++ b/test/Dialect/Arc/lower-verif-simulations.mlir
@@ -6,16 +6,19 @@
 // CHECK-SAME: in %clock : !seq.clock
 // CHECK-SAME: in %init : i1
 // CHECK-SAME: out done : i1
-// CHECK-SAME: out exit_code : i32
+// CHECK-SAME: out success : i1
 verif.simulation @Foo {} {
 ^bb0(%clock: !seq.clock, %init: i1):
-  // CHECK: [[TMP1:%.+]] = hw.constant true
-  // CHECK: [[TMP2:%.+]] = hw.constant 0 : i32
-  // CHECK: hw.output [[TMP1]], [[TMP2]] : i1, i32
-  %true = hw.constant true
-  %c0_i32 = hw.constant 0 : i32
-  verif.yield %true, %c0_i32 : i1, i32
+  // CHECK: [[TMP1:%.+]] = func.call @generateDone()
+  // CHECK: [[TMP2:%.+]] = func.call @generateSuccess()
+  // CHECK: hw.output [[TMP1]], [[TMP2]] : i1, i1
+  %done = func.call @generateDone() : () -> (i1)
+  %success = func.call @generateSuccess() : () -> (i1)
+  verif.yield %done, %success : i1, i1
 }
+
+func.func private @generateDone() -> i1
+func.func private @generateSuccess() -> i1
 
 // CHECK-LABEL: func.func @Foo()
 // CHECK: [[I0:%.+]] = hw.constant false
@@ -35,49 +38,18 @@ verif.simulation @Foo {} {
 // CHECK:     cf.br [[LOOP:\^.+]]
 // CHECK:   [[LOOP]]:
 // CHECK:     [[DONE:%.+]] = arc.sim.get_port [[A]], "done" : i1
-// CHECK:     [[CODE:%.+]] = arc.sim.get_port [[A]], "exit_code" : i32
+// CHECK:     [[SUCCESS:%.+]] = arc.sim.get_port [[A]], "success" : i1
 // CHECK:     arc.sim.set_input [[A]], "clock" = [[C1]]
 // CHECK:     arc.sim.step [[A]]
 // CHECK:     arc.sim.set_input [[A]], "clock" = [[C0]]
 // CHECK:     arc.sim.step [[A]]
 // CHECK:     cf.cond_br [[DONE]], [[EXIT:\^.+]], [[LOOP]]
 // CHECK:   [[EXIT]]:
-// CHECK:     [[TMP1:%.+]] = hw.constant 0 : i32
-// CHECK:     [[TMP2:%.+]] = arith.cmpi ne, [[CODE]], [[TMP1]] : i32
+// CHECK:     [[TMP1:%.+]] = hw.constant true
+// CHECK:     [[TMP2:%.+]] = arith.xori [[SUCCESS]], [[TMP1]] : i1
 // CHECK:     [[TMP3:%.+]] = arith.extui [[TMP2]] : i1 to i32
-// CHECK:     [[TMP4:%.+]] = arith.ori [[CODE]], [[TMP3]] : i32
-// CHECK:     func.call @exit([[TMP4]]) : (i32) -> ()
+// CHECK:     func.call @exit([[TMP3]]) : (i32) -> ()
 // CHECK:     scf.yield
 // CHECK:   }
 // CHECK: }
 // CHECK: return
-
-// CHECK-LABEL: func.func @NarrowExit()
-// CHECK: [[CODE:%.+]] = arc.sim.get_port {{%.+}}, "exit_code" : i19
-// CHECK: [[TMP1:%.+]] = hw.constant 0 : i19
-// CHECK: [[TMP2:%.+]] = arith.cmpi ne, [[CODE]], [[TMP1]] : i19
-// CHECK: [[TMP3:%.+]] = arith.extui [[TMP2]] : i1 to i32
-// CHECK: [[TMP4:%.+]] = arith.extui [[CODE]] : i19 to i32
-// CHECK: [[TMP5:%.+]] = arith.ori [[TMP4]], [[TMP3]] : i32
-// CHECK: func.call @exit([[TMP5]]) : (i32) -> ()
-verif.simulation @NarrowExit {} {
-^bb0(%clock: !seq.clock, %init: i1):
-  %true = hw.constant true
-  %c0_i19 = hw.constant 0 : i19
-  verif.yield %true, %c0_i19 : i1, i19
-}
-
-// CHECK-LABEL: func.func @WideExit()
-// CHECK: [[CODE:%.+]] = arc.sim.get_port {{%.+}}, "exit_code" : i42
-// CHECK: [[TMP1:%.+]] = hw.constant 0 : i42
-// CHECK: [[TMP2:%.+]] = arith.cmpi ne, [[CODE]], [[TMP1]] : i42
-// CHECK: [[TMP3:%.+]] = arith.extui [[TMP2]] : i1 to i32
-// CHECK: [[TMP4:%.+]] = arith.trunci [[CODE]] : i42 to i32
-// CHECK: [[TMP5:%.+]] = arith.ori [[TMP4]], [[TMP3]] : i32
-// CHECK: func.call @exit([[TMP5]]) : (i32) -> ()
-verif.simulation @WideExit {} {
-^bb0(%clock: !seq.clock, %init: i1):
-  %true = hw.constant true
-  %c0_i42 = hw.constant 0 : i42
-  verif.yield %true, %c0_i42 : i1, i42
-}

--- a/test/Dialect/Verif/basic.mlir
+++ b/test/Dialect/Verif/basic.mlir
@@ -71,8 +71,7 @@ verif.formal @FormalTestBody {} {
 verif.simulation @EmptySimulationTest {} {
 ^bb0(%clock: !seq.clock, %init: i1):
   %0 = hw.constant true
-  %1 = hw.constant 9001 : i42
-  verif.yield %0, %1 : i1, i42
+  verif.yield %0, %0 : i1, i1
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Verif/errors.mlir
+++ b/test/Dialect/Verif/errors.mlir
@@ -193,7 +193,7 @@ verif.simulation @foo {} {
 
 // -----
 
-// expected-error @below {{op block argument #0 must be a `!seq.clock`}}
+// expected-error @below {{op block argument #0 must be of type `!seq.clock`}}
 verif.simulation @foo {} {
 ^bb0(%arg0: i1, %arg1: i1):
   verif.yield %arg0, %arg1 : i1, i1
@@ -201,7 +201,7 @@ verif.simulation @foo {} {
 
 // -----
 
-// expected-error @below {{op block argument #1 must be a `i1`}}
+// expected-error @below {{op block argument #1 must be of type `i1`}}
 verif.simulation @foo {} {
 ^bb0(%arg0: !seq.clock, %arg1: i42):
   %true = hw.constant true
@@ -220,7 +220,7 @@ verif.simulation @foo {} {
 
 verif.simulation @foo {} {
 ^bb0(%arg0: !seq.clock, %arg1: i1):
-  // expected-error @below {{op operand #0 must be an `i1`}}
+  // expected-error @below {{op operand #0 must be of type `i1`}}
   verif.yield %arg0, %arg1 : !seq.clock, i1
 }
 
@@ -228,6 +228,6 @@ verif.simulation @foo {} {
 
 verif.simulation @foo {} {
 ^bb0(%arg0: !seq.clock, %arg1: i1):
-  // expected-error @below {{op operand #1 must be an integer}}
+  // expected-error @below {{op operand #1 must be of type `i1`}}
   verif.yield %arg1, %arg0 : i1, !seq.clock
 }


### PR DESCRIPTION
After some discussions on `verif.simulation`, the consensus seems to be that an arbitrary integer exit code that has no guarantee of being preserved properly by simulators, besides the zero vs non-zero distinction, is virtually useless in practice. Instead, simulations can be made simpler by generating a simple `i1` success result indicating whether the test passed or failed. Simulators can then map this to an appropriate exit code. The operating system's potential truncation of exit codes to fewer bits (e.g. 7 or 8 bits on Linux) is no longer an issue.