### PR TITLE
[Transforms][circt-synth] Add HierarchicalRunner pass

### DIFF
--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -51,6 +51,10 @@ std::unique_ptr<mlir::Pass>
 createMemoryBankingPass(std::optional<unsigned> bankingFactor = std::nullopt,
                         std::optional<int> bankingDimension = std::nullopt);
 std::unique_ptr<mlir::Pass> createIndexSwitchToIfPass();
+std::unique_ptr<mlir::Pass> createHierarchicalRunner(
+    const std::string &topName,
+    llvm::function_ref<void(mlir::OpPassManager &)> pipeline,
+    bool includeBoundInstances = false);
 
 //===----------------------------------------------------------------------===//
 // Utility functions.

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -166,4 +166,23 @@ def IndexSwitchToIf : Pass<"switch-to-if", "::mlir::ModuleOp"> {
   let dependentDialects = ["mlir::scf::SCFDialect"];
 }
 
+def HierarchicalRunner : Pass<"hierarchical-runner", "::mlir::ModuleOp"> {
+  let summary = "Run passes under hierarchy";
+  let description = [{
+    This pass runs a specified pipeline of passes on the hierarchy of modules
+    starting from a given top-level module. It allows for hierarchical
+    application of transformations, which can be useful for targeting specific
+    parts of a design or for applying different optimizations at different
+    levels of the module hierarchy.
+  }];
+  let options = [
+    Option<"pipelineStr", "pipeline", "std::string", "",
+           "The pipeline to run under hierarchy">,
+    Option<"topName", "top-name", "std::string", "",
+           "The name of the top-level module to run the pass on">,
+    Option<"includeBoundInstances", "include-bound-instances", "bool", "false",
+           "Whether to include bound instances in the hierarchy">
+  ];
+}
+
 #endif // CIRCT_TRANSFORMS_PASSES

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_circt_library(CIRCTTransforms
   FlattenMemRefs.cpp
+  HierarchicalRunner.cpp
   IndexSwitchToIf.cpp
   InsertMergeBlocks.cpp
   MapArithToComb.cpp

--- a/lib/Transforms/HierarchicalRunner.cpp
+++ b/lib/Transforms/HierarchicalRunner.cpp
@@ -86,8 +86,7 @@ void HierarchicalRunnerPass::runOnOperation() {
   auto am = getAnalysisManager();
   while (!worklist.empty()) {
     auto *node = worklist.pop_back_val();
-    if (!node)
-      continue;
+    assert(node && "node should not be null");
     auto op = node->getModule();
     if (!op || !visited.insert(op))
       continue;

--- a/lib/Transforms/HierarchicalRunner.cpp
+++ b/lib/Transforms/HierarchicalRunner.cpp
@@ -1,0 +1,146 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the HierarchicalRunner pass which runs a pass pipeline
+// on specific hierarchichy.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Support/InstanceGraph.h"
+#include "circt/Transforms/Passes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Threading.h"
+#include "mlir/Pass/AnalysisManager.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace circt;
+using namespace mlir;
+
+namespace circt {
+#define GEN_PASS_DEF_HIERARCHICALRUNNER
+#include "circt/Transforms/Passes.h.inc"
+} // namespace circt
+
+namespace {
+struct HierarchicalRunnerPass
+    : public circt::impl::HierarchicalRunnerBase<HierarchicalRunnerPass> {
+  using circt::impl::HierarchicalRunnerBase<
+      HierarchicalRunnerPass>::HierarchicalRunnerBase;
+  void runOnOperation() override;
+  HierarchicalRunnerPass(const std::string &topName,
+                         llvm::function_ref<void(OpPassManager &)> populateFunc,
+                         bool includeBoundInstances) {
+    this->topName = topName;
+    this->includeBoundInstances = includeBoundInstances;
+
+    // Populate the pipeline and set the text format to the option string.
+    populateFunc(dynamicPM);
+    llvm::raw_string_ostream os(pipelineStr);
+    dynamicPM.printAsTextualPipeline(os);
+  }
+
+  LogicalResult initializeOptions(
+      StringRef options,
+      function_ref<LogicalResult(const Twine &)> errorHandler) override {
+    if (failed(
+            HierarchicalRunnerBase::initializeOptions(options, errorHandler)))
+      return failure();
+
+    if (failed(parsePassPipeline(pipelineStr, dynamicPM)))
+      return errorHandler("Failed to parse composite pass pipeline");
+
+    return success();
+  }
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    dynamicPM.getDependentDialects(registry);
+  }
+
+private:
+  OpPassManager dynamicPM;
+};
+} // namespace
+
+void HierarchicalRunnerPass::runOnOperation() {
+  auto &instanceGraph = getAnalysis<circt::igraph::InstanceGraph>();
+
+  auto name = mlir::StringAttr::get(getOperation()->getContext(), topName);
+  auto *top = instanceGraph.lookupOrNull(name);
+  if (!top) {
+    mlir::emitError(mlir::UnknownLoc::get(&getContext()))
+        << "top module not found in instance graph " << topName;
+    return signalPassFailure();
+  }
+
+  SmallVector<igraph::InstanceGraphNode *> worklist;
+  llvm::SetVector<Operation *> visited;
+  worklist.push_back(top);
+
+  auto am = getAnalysisManager();
+  while (!worklist.empty()) {
+    auto *node = worklist.pop_back_val();
+    if (!node)
+      continue;
+    auto op = node->getModule();
+    if (!op || !visited.insert(op))
+      continue;
+
+    // Ensure an analysis manager has been constructed for each of the nodes.
+    // This prevents thread races when running the nested pipelines.
+    am.nest(op);
+
+    for (auto *child : *node) {
+      auto childOp = child->getInstance();
+      if (!childOp ||
+          (!includeBoundInstances && childOp->hasAttr("doNotPrint")))
+        continue;
+
+      worklist.push_back(child->getTarget());
+    }
+  }
+
+  // We must maintain a fixed pool of pass managers which is at least as large
+  // as the maximum parallelism of the failableParallelForEach below.
+  // Note: The number of pass managers here needs to remain constant
+  // to prevent issues with pass instrumentations that rely on having the same
+  // pass manager for the main thread.
+  size_t numThreads = getContext().getNumThreads();
+
+  llvm::SmallVector<OpPassManager> pipelines(numThreads, dynamicPM);
+
+  // An atomic failure variable for the async executors.
+  std::vector<std::atomic<bool>> activePMs(pipelines.size());
+  std::fill(activePMs.begin(), activePMs.end(), false);
+  auto result = mlir::failableParallelForEach(
+      &getContext(), visited, [&](Operation *node) -> LogicalResult {
+        // Find a pass manager for this operation.
+        auto it = llvm::find_if(activePMs, [](std::atomic<bool> &isActive) {
+          bool expectedInactive = false;
+          return isActive.compare_exchange_strong(expectedInactive, true);
+        });
+        assert(it != activePMs.end() &&
+               "could not find inactive pass manager for thread");
+        unsigned pmIndex = it - activePMs.begin();
+        auto result = runPipeline(pipelines[pmIndex], node);
+        // Reset the active bit for this pass manager.
+        activePMs[pmIndex].store(false);
+        return result;
+      });
+  if (failed(result))
+    return signalPassFailure();
+}
+
+std::unique_ptr<mlir::Pass> circt::createHierarchicalRunner(
+    const std::string &topName,
+    llvm::function_ref<void(mlir::OpPassManager &)> pipeline,
+    bool includeBoundInstances) {
+  return std::make_unique<HierarchicalRunnerPass>(topName, pipeline,
+                                                  includeBoundInstances);
+}

--- a/test/Transforms/hierarchical_runner.mlir
+++ b/test/Transforms/hierarchical_runner.mlir
@@ -1,0 +1,39 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(hierarchical-runner{top-name=top pipeline=canonicalize})' %s | FileCheck %s --check-prefixes=CHECK,EXCLUDE_BOUND
+// RUN: circt-opt --pass-pipeline='builtin.module(hierarchical-runner{top-name=top pipeline=canonicalize include-bound-instances=true})' %s | FileCheck %s --check-prefixes=CHECK,INCLUDE_BOUND
+
+// CHECK-LABEL: hw.module @bound
+hw.module @bound(out out: i8) {
+    %c1_i8 = hw.constant 1 : i8
+    %add = comb.add %c1_i8, %c1_i8 : i8
+    // EXCLUDE_BOUND: %[[ADD:.+]] = comb.add %c1_i8, %c1_i8
+    // EXCLUDE_BOUND-NEXT:  hw.output %[[ADD]] : i8
+    // INCLUDE_BOUND: hw.output %c2_i8
+    hw.output %add : i8
+}
+
+// CHECK-LABEL: hw.module @top
+hw.module @top(out out: i8) {
+    %c1_i8 = hw.constant 1 : i8
+    %add = comb.add %c1_i8, %c1_i8 : i8
+    %0 = hw.instance "child" @child() -> (out: i8)
+    // CHECK: hw.output %c2_i8
+    hw.output %add : i8
+}
+
+// CHECK-LABEL: hw.module @child
+hw.module @child(out out: i8) {
+    %c1_i8 = hw.constant 1 : i8
+    %add = comb.add %c1_i8, %c1_i8 : i8
+    %0 = hw.instance "bound" @bound() -> (out: i8) {doNotPrint}
+    // CHECK: hw.output %c2_i8
+    hw.output %add : i8
+}
+
+// CHECK-LABEL: hw.module @notIncluded
+hw.module @notIncluded(out out: i8) {
+    %c1_i8 = hw.constant 1 : i8
+    %add = comb.add %c1_i8, %c1_i8 : i8
+    // CHECK: %[[ADD:.+]] = comb.add %c1_i8, %c1_i8
+    // CHECK-NEXT:  hw.output %[[ADD]] : i8
+    hw.output %add : i8
+}

--- a/test/circt-synth/basic.mlir
+++ b/test/circt-synth/basic.mlir
@@ -1,4 +1,5 @@
 // RUN: circt-synth %s | FileCheck %s
+// RUN: circt-synth %s --top and | FileCheck %s --check-prefixes=TOP,CHECK
 // RUN: circt-synth %s --until-before aig-lowering | FileCheck %s --check-prefix=AIG
 // RUN: circt-synth %s --until-before aig-lowering --convert-to-comb | FileCheck %s --check-prefix=COMB
 
@@ -22,5 +23,12 @@ hw.module @and(in %a: i2, in %b: i2, in %c: i2, out and: i2) {
   // CHECK-NEXT: hw.output %[[CONCAT]] : i2
   // COMB-NOT: aig.and_inv
   %0 = comb.and %a, %b, %c : i2
+  hw.output %0 : i2
+}
+
+// TOP-LABEL: hw.module @unrelated
+// TOP-NEXT: comb.add %a, %b
+hw.module @unrelated(in %a: i2, in %b: i2, out and: i2) {
+  %0 = comb.add %a, %b : i2
   hw.output %0 : i2
 }

--- a/tools/circt-synth/CMakeLists.txt
+++ b/tools/circt-synth/CMakeLists.txt
@@ -9,6 +9,7 @@ target_link_libraries(circt-synth
   CIRCTHW
   CIRCTHWTransforms
   CIRCTSupport
+  CIRCTTransforms
   MLIRIR
   MLIRParser
   LLVMSupport

--- a/tools/circt-synth/circt-synth.cpp
+++ b/tools/circt-synth/circt-synth.cpp
@@ -21,6 +21,7 @@
 #include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Support/Passes.h"
 #include "circt/Support/Version.h"
+#include "circt/Transforms/Passes.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/Parser/Parser.h"
@@ -85,6 +86,10 @@ static cl::opt<bool>
                   cl::desc("Convert AIG to Comb at the end of the pipeline"),
                   cl::init(false), cl::cat(mainCategory));
 
+static cl::opt<std::string> topName("top", cl::desc("Top module name"),
+                                    cl::value_desc("name"), cl::init(""),
+                                    cl::cat(mainCategory));
+
 //===----------------------------------------------------------------------===//
 // Main Tool Logic
 //===----------------------------------------------------------------------===//
@@ -98,34 +103,38 @@ static bool untilReached(Until until) {
 //===----------------------------------------------------------------------===//
 
 static void populateSynthesisPipeline(PassManager &pm) {
-  // Add the AIG to Comb at the scope exit if requested.
-  auto addAIGToComb = llvm::make_scope_exit([&]() {
-    if (convertToComb) {
-      auto &mpm = pm.nest<hw::HWModuleOp>();
-      mpm.addPass(circt::createConvertAIGToComb());
-      mpm.addPass(createCSEPass());
-    }
-  });
+  auto pipeline = [](OpPassManager &mpm) {
+    // Add the AIG to Comb at the scope exit if requested.
+    auto addAIGToComb = llvm::make_scope_exit([&]() {
+      if (convertToComb) {
+        mpm.addPass(circt::createConvertAIGToComb());
+        mpm.addPass(createCSEPass());
+      }
+    });
+    mpm.addPass(circt::hw::createHWAggregateToCombPass());
+    mpm.addPass(circt::createConvertCombToAIG());
+    mpm.addPass(createCSEPass());
+    if (untilReached(UntilAIGLowering))
+      return;
+    mpm.addPass(createSimpleCanonicalizerPass());
+    mpm.addPass(createCSEPass());
+    mpm.addPass(aig::createLowerVariadic());
+    // TODO: LowerWordToBits is not scalable for large designs. Change to
+    // conditionally enable the pass once the rest of the pipeline was able
+    // to handle multibit operands properly.
+    mpm.addPass(aig::createLowerWordToBits());
+    mpm.addPass(createCSEPass());
+    mpm.addPass(createSimpleCanonicalizerPass());
+    // TODO: Add balancing, rewriting, FRAIG conversion, etc.
+    if (untilReached(UntilEnd))
+      return;
+  };
 
-  auto &mpm = pm.nest<hw::HWModuleOp>();
-  mpm.addPass(circt::hw::createHWAggregateToCombPass());
-  mpm.addPass(circt::createConvertCombToAIG());
-  mpm.addPass(createCSEPass());
-  if (untilReached(UntilAIGLowering))
-    return;
-  mpm.addPass(createSimpleCanonicalizerPass());
-  mpm.addPass(createCSEPass());
-  mpm.addPass(aig::createLowerVariadic());
-  // TODO: LowerWordToBits is not scalable for large designs. Change to
-  // conditionally enable the pass once the rest of the pipeline was able to
-  // handle multibit operands properly.
-  mpm.addPass(aig::createLowerWordToBits());
-  mpm.addPass(createCSEPass());
-  mpm.addPass(createSimpleCanonicalizerPass());
-  // TODO: Add balancing, rewriting, FRAIG conversion, etc.
-  if (untilReached(UntilEnd))
-    return;
-
+  if (topName.empty()) {
+    pipeline(pm.nest<hw::HWModuleOp>());
+  } else {
+    pm.addPass(circt::createHierarchicalRunner(topName, pipeline));
+  }
   // TODO: Add LUT mapping, etc.
 }
 


### PR DESCRIPTION
Add a new pass that allows running passes under hierarchy. This is useful when we want to run synthesis passes only on real designs.

This implementation is based on MLIR's upstream [CompositePass](https://github.com/llvm/llvm-project/blob/0afe2bd21b06bed4d48eb88a99d13a768426359c/mlir/lib/Transforms/CompositePass.cpp#L30-L52) and [Inliner utilities](https://github.com/llvm/llvm-project/blob/0afe2bd21b06bed4d48eb88a99d13a768426359c/mlir/lib/Transforms/Utils/Inliner.cpp#L541-L560). The pass takes a pipeline string and runs it on modules in the design hierarchy. It supports configurable options including the pipeline to run under hierarchy, the name of the top-level module, and whether to include bound instances in the hierarchy traversal.

The implementation updates circt-synth tool with the required library dependencies and necessary dialect and pass headers.