### PR TITLE
[Calyx] LICM after Affine ParallelOp unrolling

### DIFF
--- a/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
+++ b/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
@@ -206,12 +206,7 @@ void MemoryBankConflictResolver::readOpHoistAnalysis(
     auto key = std::pair(memref, constIndices);
     // We do not hoist any read as long as it's being written in any parallel
     // region.
-    auto memrefIsWritten = [&](Value memref) {
-      return llvm::any_of(writtenMemRefs, [memref](const auto &entry) {
-        return entry == memref;
-      });
-    };
-    if (memrefIsWritten(memref))
+    if (writtenMemRefs.contains(memref))
       continue;
     constantReadOpCounts[key]++;
   }

--- a/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
+++ b/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
@@ -208,18 +208,6 @@ LogicalResult CalyxParLICM::run(AffineParallelOp affineParallelOp) {
 
   readOpHoistAnalysis(affineParallelOp, constantMemAccessIndices);
 
-  // Second, perform dependency analysis on each memOp:
-  //    1. If memOp is a load, we hoist it if:
-  //      - Its access indices are all constants;
-  //      - It occurs more than once throughout all scf.execute_region's (same
-  //      memref && same access indices);
-  //      - The same memref && access indices is not being stored within any
-  //      scf.execute_region.
-  //    2. If memOp is a store, we never hoist it; but raise exception if we
-  //    observe that:
-  //      - Its access are all constants;
-  //      - It occurs more than once throughout all scf.execute_region's.
-
   return success();
 }
 

--- a/test/Dialect/Calyx/affine-parallel-unroll.mlir
+++ b/test/Dialect/Calyx/affine-parallel-unroll.mlir
@@ -180,3 +180,55 @@ module {
     return
   }
 }
+
+// -----
+
+// CHECK-LABEL:   func.func @licm(
+// CHECK-SAME:                    %[[VAL_0:.*]]: memref<2xf32>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: memref<2xf32>) {
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_3:.*]] = memref.alloc() : memref<2xf32>
+// CHECK-DAG:           %[[VAL_4:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_2]]] : memref<2xf32>
+// CHECK-DAG:           %[[VAL_5:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<2xf32>
+// CHECK:           affine.parallel (%[[VAL_6:.*]]) = (0) to (1) {
+// CHECK:             scf.execute_region {
+// CHECK:               affine.for %[[VAL_7:.*]] = 0 to 2 {
+// CHECK:                 %[[VAL_8:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_7]]] : memref<2xf32>
+// CHECK:                 %[[VAL_9:.*]] = arith.mulf %[[VAL_4]], %[[VAL_5]] : f32
+// CHECK:                 %[[VAL_10:.*]] = arith.addf %[[VAL_8]], %[[VAL_9]] : f32
+// CHECK:                 affine.store %[[VAL_10]], %[[VAL_0]]{{\[}}%[[VAL_7]]] : memref<2xf32>
+// CHECK:               }
+// CHECK:               scf.yield
+// CHECK:             }
+// CHECK:             scf.execute_region {
+// CHECK:               affine.for %[[VAL_11:.*]] = 0 to 2 {
+// CHECK:                 %[[VAL_12:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_11]]] : memref<2xf32>
+// CHECK:                 %[[VAL_13:.*]] = arith.mulf %[[VAL_4]], %[[VAL_5]] : f32
+// CHECK:                 %[[VAL_14:.*]] = arith.addf %[[VAL_12]], %[[VAL_13]] : f32
+// CHECK:                 affine.store %[[VAL_14]], %[[VAL_0]]{{\[}}%[[VAL_11]]] : memref<2xf32>
+// CHECK:               }
+// CHECK:               scf.yield
+// CHECK:             }
+// CHECK:           } {calyx.unroll = true}
+// CHECK:           return
+// CHECK:         }
+
+#map = affine_map<(d0) -> (d0 floordiv 2)>
+module {
+  func.func @licm(%arg0: memref<2xf32>, %arg1: memref<2xf32>) {
+    %alloc = memref.alloc() : memref<2xf32>
+    affine.parallel (%arg2) = (0) to (2) {
+      %0 = affine.apply #map(%arg2)
+      affine.for %arg3 = 0 to 2 {
+        %1 = affine.load %arg0[%0] : memref<2xf32>
+        %2 = affine.load %arg1[%0] : memref<2xf32>
+        %3 = affine.load %alloc[%arg3] : memref<2xf32>
+        %4 = arith.mulf %1, %2 : f32
+        %5 = arith.addf %3, %4 : f32
+        affine.store %5, %arg0[%arg3] : memref<2xf32>
+      }
+    }
+    return
+  }
+}
+

--- a/test/Dialect/Calyx/affine-parallel-unroll.mlir
+++ b/test/Dialect/Calyx/affine-parallel-unroll.mlir
@@ -188,24 +188,24 @@ module {
 // CHECK-SAME:                    %[[VAL_1:.*]]: memref<2xf32>) {
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_3:.*]] = memref.alloc() : memref<2xf32>
-// CHECK-DAG:           %[[VAL_4:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_2]]] : memref<2xf32>
-// CHECK-DAG:           %[[VAL_5:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<2xf32>
+// CHECK-DAG:           %[[VAL_4:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<2xf32>
+// CHECK-DAG:           %[[VAL_5:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_2]]] : memref<2xf32>
 // CHECK:           affine.parallel (%[[VAL_6:.*]]) = (0) to (1) {
 // CHECK:             scf.execute_region {
 // CHECK:               affine.for %[[VAL_7:.*]] = 0 to 2 {
 // CHECK:                 %[[VAL_8:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_7]]] : memref<2xf32>
-// CHECK:                 %[[VAL_9:.*]] = arith.mulf %[[VAL_4]], %[[VAL_5]] : f32
+// CHECK:                 %[[VAL_9:.*]] = arith.mulf %[[VAL_5]], %[[VAL_4]] : f32
 // CHECK:                 %[[VAL_10:.*]] = arith.addf %[[VAL_8]], %[[VAL_9]] : f32
-// CHECK:                 affine.store %[[VAL_10]], %[[VAL_0]]{{\[}}%[[VAL_7]]] : memref<2xf32>
+// CHECK:                 affine.store %[[VAL_10]], %[[VAL_3]]{{\[}}%[[VAL_7]]] : memref<2xf32>
 // CHECK:               }
 // CHECK:               scf.yield
 // CHECK:             }
 // CHECK:             scf.execute_region {
 // CHECK:               affine.for %[[VAL_11:.*]] = 0 to 2 {
 // CHECK:                 %[[VAL_12:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_11]]] : memref<2xf32>
-// CHECK:                 %[[VAL_13:.*]] = arith.mulf %[[VAL_4]], %[[VAL_5]] : f32
+// CHECK:                 %[[VAL_13:.*]] = arith.mulf %[[VAL_5]], %[[VAL_4]] : f32
 // CHECK:                 %[[VAL_14:.*]] = arith.addf %[[VAL_12]], %[[VAL_13]] : f32
-// CHECK:                 affine.store %[[VAL_14]], %[[VAL_0]]{{\[}}%[[VAL_11]]] : memref<2xf32>
+// CHECK:                 affine.store %[[VAL_14]], %[[VAL_3]]{{\[}}%[[VAL_11]]] : memref<2xf32>
 // CHECK:               }
 // CHECK:               scf.yield
 // CHECK:             }
@@ -225,7 +225,7 @@ module {
         %3 = affine.load %alloc[%arg3] : memref<2xf32>
         %4 = arith.mulf %1, %2 : f32
         %5 = arith.addf %3, %4 : f32
-        affine.store %5, %arg0[%arg3] : memref<2xf32>
+        affine.store %5, %alloc[%arg3] : memref<2xf32>
       }
     }
     return

--- a/test/Dialect/Calyx/affine-parallel-unroll.mlir
+++ b/test/Dialect/Calyx/affine-parallel-unroll.mlir
@@ -220,7 +220,9 @@ module {
     affine.parallel (%arg2) = (0) to (2) {
       %0 = affine.apply #map(%arg2)
       affine.for %arg3 = 0 to 2 {
+        // The following load will be hoisted.
         %1 = affine.load %arg0[%0] : memref<2xf32>
+        // The following load will be hoisted.
         %2 = affine.load %arg1[%0] : memref<2xf32>
         %3 = affine.load %alloc[%arg3] : memref<2xf32>
         %4 = arith.mulf %1, %2 : f32


### PR DESCRIPTION
This patch does LICM after unrolling `affine.parallel` operations in order to prevent potential memory access contentions.