### PR TITLE
Bump LLVM to 6bfedfa0ba31a8ac8fd7fcfd2d33afaa5eabe0e5.

### DIFF
--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -241,7 +241,7 @@ static void loadDHLSPipeline(OpPassManager &pm) {
   pm.addPass(circt::createFlattenMemRefPass());
   pm.nest<func::FuncOp>().addPass(
       circt::handshake::createHandshakeLegalizeMemrefsPass());
-  pm.addPass(mlir::createConvertSCFToCFPass());
+  pm.addPass(mlir::createSCFToControlFlowPass());
   pm.nest<handshake::FuncOp>().addPass(createSimpleCanonicalizerPass());
 
   // DHLS conversion
@@ -325,7 +325,7 @@ static LogicalResult doHLSFlowDynamic(
   // Software lowering
   addIRLevel(IRLevel::PreCompile, [&]() {
     pm.addPass(mlir::createLowerAffinePass());
-    pm.addPass(mlir::createConvertSCFToCFPass());
+    pm.addPass(mlir::createSCFToControlFlowPass());
   });
 
   addIRLevel(IRLevel::Core, [&]() { loadDHLSPipeline(pm); });

--- a/tools/kanagawatool/kanagawatool.cpp
+++ b/tools/kanagawatool/kanagawatool.cpp
@@ -153,7 +153,7 @@ static std::unique_ptr<Pass> createSimpleCanonicalizerPass() {
 
 static void loadHighLevelControlflowTransformsPipeline(OpPassManager &pm) {
   pm.addPass(mlir::createLowerAffinePass());
-  pm.addPass(mlir::createConvertSCFToCFPass());
+  pm.addPass(mlir::createSCFToControlFlowPass());
   pm.addPass(createSimpleCanonicalizerPass());
 }
 


### PR DESCRIPTION
This is mostly a straightforward bump.

One change we had to incorporate is MLIR is generally moving towards auto-generated pass constructor functions. For more info, see: https://github.com/llvm/llvm-project/commit/d25beca.

This shows up for us as a few pass constructors we use from upstream getting renamed. We just need to apply the same renames as upstream: https://github.com/llvm/llvm-project/commit/c1a2292.