### PR TITLE
[sim] Add emission for plusargs for UPF simulations

### DIFF
--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -41,6 +41,7 @@ namespace {
 struct SimConversionState {
   hw::HWModuleOp module;
   bool usedSynthesisMacro = false;
+  bool usedUPFSimMacro = false;
   SetVector<StringAttr> dpiCallees;
 };
 
@@ -99,6 +100,7 @@ public:
                                            rewriter.getStringAttr("_pargs_f"));
 
     state.usedSynthesisMacro = true;
+    state.usedUPFSimMacro = true;
     rewriter.create<sv::IfDefOp>(
         loc, "SYNTHESIS",
         [&]() {
@@ -115,18 +117,38 @@ public:
           rewriter.create<sv::AssignOp>(loc, regf, cstFalse);
         },
         [&]() {
-          rewriter.create<sv::InitialOp>(loc, [&] {
-            auto zero32 = rewriter.create<hw::ConstantOp>(loc, APInt(32, 0));
-            auto tmpResultType = rewriter.getIntegerType(32);
-            auto str =
-                rewriter.create<sv::ConstantStrOp>(loc, op.getFormatString());
-            auto call = rewriter.create<sv::SystemFunctionOp>(
-                loc, tmpResultType, "value$plusargs",
-                ArrayRef<Value>{str, regv});
-            auto test = rewriter.create<comb::ICmpOp>(
-                loc, comb::ICmpPredicate::ne, call, zero32, true);
-            rewriter.create<sv::BPAssignOp>(loc, regf, test);
-          });
+          rewriter.create<sv::IfDefOp>(
+              loc, "UPF_SIMULATION",
+              [&]() {
+                auto zero = rewriter.create<hw::ConstantOp>(
+                    loc, APInt(type.getIntOrFloatBitWidth(), 0));
+                auto assign = rewriter.create<sv::AssignOp>(loc, regv, zero);
+                circt::sv::setSVAttributes(
+                    assign,
+                    sv::SVAttributeAttr::get(
+                        rewriter.getContext(),
+                        "This dummy assignment exists to avoid undriven lint "
+                        "warnings (e.g., Verilator UNDRIVEN).",
+                        /*emitAsComment=*/true));
+                auto cstFalse =
+                    rewriter.create<hw::ConstantOp>(loc, APInt(1, 0));
+                rewriter.create<sv::AssignOp>(loc, regf, cstFalse);
+              },
+              [&]() {
+                rewriter.create<sv::InitialOp>(loc, [&] {
+                  auto zero32 =
+                      rewriter.create<hw::ConstantOp>(loc, APInt(32, 0));
+                  auto tmpResultType = rewriter.getIntegerType(32);
+                  auto str = rewriter.create<sv::ConstantStrOp>(
+                      loc, op.getFormatString());
+                  auto call = rewriter.create<sv::SystemFunctionOp>(
+                      loc, tmpResultType, "value$plusargs",
+                      ArrayRef<Value>{str, regv});
+                  auto test = rewriter.create<comb::ICmpOp>(
+                      loc, comb::ICmpPredicate::ne, call, zero32, true);
+                  rewriter.create<sv::BPAssignOp>(loc, regf, test);
+                });
+              });
         });
 
     auto readf = rewriter.create<sv::ReadInOutOp>(loc, regf);
@@ -316,6 +338,7 @@ struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
       lowerDPIFunc.lower(func);
 
     std::atomic<bool> usedSynthesisMacro = false;
+    std::atomic<bool> usedUPFSimMacro = false;
     auto lowerModule = [&](hw::HWModuleOp module) {
       SimConversionState state;
       ConversionTarget target(*context);
@@ -343,6 +366,8 @@ struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
 
       if (state.usedSynthesisMacro)
         usedSynthesisMacro = true;
+      if (state.usedUPFSimMacro)
+        usedUPFSimMacro = true;
       return result;
     };
 
@@ -361,6 +386,20 @@ struct SimToSVPass : public circt::impl::LowerSimToSVBase<SimToSVPass> {
         auto builder = ImplicitLocOpBuilder::atBlockBegin(
             UnknownLoc::get(context), circuit.getBody());
         builder.create<sv::MacroDeclOp>("SYNTHESIS");
+      }
+    }
+
+    if (usedUPFSimMacro) {
+      Operation *op = circuit.lookupSymbol("UPF_SIMULATION");
+      if (op) {
+        if (!isa<sv::MacroDeclOp>(op)) {
+          op->emitOpError("should be a macro declaration");
+          return signalPassFailure();
+        }
+      } else {
+        auto builder = ImplicitLocOpBuilder::atBlockBegin(
+            UnknownLoc::get(context), circuit.getBody());
+        builder.create<sv::MacroDeclOp>("UPF_SIMULATION");
       }
     }
   }

--- a/test/Conversion/SimToSV/plusargs.mlir
+++ b/test/Conversion/SimToSV/plusargs.mlir
@@ -26,12 +26,21 @@ hw.module @plusargs_value(out test: i1, out value: i5) {
   // CHECK-SAME:     emitAsComment
   // CHECK-NEXT:   sv.assign [[BAR_FOUND_DECL]], %false
   // CHECK-NEXT: } else {
-  // CHECK-NEXT:   sv.initial {
-  // CHECK-NEXT:     %c0_i32 = hw.constant 0 : i32
-  // CHECK-NEXT:     [[BAR_STR:%.*]] = sv.constantStr "bar"
-  // CHECK-NEXT:     [[TMP:%.*]] = sv.system "value$plusargs"([[BAR_STR]], [[BAR_VALUE_DECL]])
-  // CHECK-NEXT:     [[TMP2:%.*]] = comb.icmp bin ne [[TMP]], %c0_i32
-  // CHECK-NEXT:     sv.bpassign [[BAR_FOUND_DECL]], [[TMP2]]
+  // CHECK-NEXT:   sv.ifdef  @UPF_SIMULATION {
+  // CHECK-NEXT:     %c0_i5 = hw.constant 0 : i5
+  // CHECK-NEXT:     sv.assign [[BAR_VALUE_DECL]], %c0_i5 {sv.attributes = [
+  // CHECK-SAME:       #sv.attribute<"This dummy assignment exists to avoid undriven lint warnings
+  // CHECK-SAME:       emitAsComment
+  // CHECK-NEXT:     %false = hw.constant false
+  // CHECK-NEXT:     sv.assign [[BAR_FOUND_DECL]], %false
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT:     sv.initial {
+  // CHECK-NEXT:       %c0_i32 = hw.constant 0 : i32
+  // CHECK-NEXT:       [[BAR_STR:%.*]] = sv.constantStr "bar"
+  // CHECK-NEXT:       [[TMP:%.*]] = sv.system "value$plusargs"([[BAR_STR]], [[BAR_VALUE_DECL]])
+  // CHECK-NEXT:       [[TMP2:%.*]] = comb.icmp bin ne [[TMP]], %c0_i32
+  // CHECK-NEXT:       sv.bpassign [[BAR_FOUND_DECL]], [[TMP2]]
+  // CHECK-NEXT:     }
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
   // CHECK-NEXT: [[BAR_FOUND:%.*]] = sv.read_inout [[BAR_FOUND_DECL]]

--- a/test/firtool/plusargs.fir
+++ b/test/firtool/plusargs.fir
@@ -29,11 +29,16 @@ circuit PlusArgTest:
     ; CHECK-NEXT:   sv.assign [[RESULT_BAR_REG]], %z_i32 {sv.attributes = [#sv.attribute<"This dummy assignment exists to avoid undriven lint warnings (e.g., Verilator UNDRIVEN).", emitAsComment>]} : i32
     ; CHECK-NEXT:   sv.assign [[FOUND_BAR_REG]], %false : i1
     ; CHECK-NEXT: } else {
-    ; CHECK-NEXT:   sv.initial {
-    ; CHECK-NEXT:     [[FORMAT_BAR:%.+]] = sv.constantStr "foo=%d"
-    ; CHECK-NEXT:     [[TMP_BAR:%.+]] = sv.system "value$plusargs"([[FORMAT_BAR]], [[RESULT_BAR_REG]]) : (!hw.string, !hw.inout<i32>) -> i32
-    ; CHECK-NEXT:     [[FOUND_BAR_VAL:%.+]] = comb.icmp bin ne [[TMP_BAR]], %c0_i32 : i32
-    ; CHECK-NEXT:     sv.bpassign [[FOUND_BAR_REG]], [[FOUND_BAR_VAL]] : i1
+    ; CHECK-NEXT:   sv.ifdef @UPF_SIMULATION {
+    ; CHECK-NEXT:     sv.assign [[RESULT_BAR_REG]], %c0_i32 {sv.attributes = [#sv.attribute<"This dummy assignment exists to avoid undriven lint warnings (e.g., Verilator UNDRIVEN).", emitAsComment>]} : i32
+    ; CHECK-NEXT:     sv.assign [[FOUND_BAR_REG]], %false : i1
+    ; CHECK-NEXT:   } else {
+    ; CHECK-NEXT:     sv.initial {
+    ; CHECK-NEXT:       [[FORMAT_BAR:%.+]] = sv.constantStr "foo=%d"
+    ; CHECK-NEXT:       [[TMP_BAR:%.+]] = sv.system "value$plusargs"([[FORMAT_BAR]], [[RESULT_BAR_REG]]) : (!hw.string, !hw.inout<i32>) -> i32
+    ; CHECK-NEXT:       [[FOUND_BAR_VAL:%.+]] = comb.icmp bin ne [[TMP_BAR]], %c0_i32 : i32
+    ; CHECK-NEXT:       sv.bpassign [[FOUND_BAR_REG]], [[FOUND_BAR_VAL]] : i1
+    ; CHECK-NEXT:     }
     ; CHECK-NEXT:   }
     ; CHECK-NEXT: }
     ; CHECK-NEXT: [[FOUND_BAR:%.+]] = sv.read_inout [[FOUND_BAR_REG]] : !hw.inout<i1>


### PR DESCRIPTION
For UPF simulations, we want to disable plusargs but drive the output wires with 0 instead of z.  We want this to be able to enable this mode of operation while also enabling assertions, so we add another macro UPF_SIM to control this behaviour.