### PR TITLE
[ESI][XRT] Implement "Indirect MMIO"

### DIFF
--- a/frontends/PyCDE/src/pycde/bsp/xrt.py
+++ b/frontends/PyCDE/src/pycde/bsp/xrt.py
@@ -12,7 +12,8 @@ from ..types import Array, Bits, Channel, UInt
 from .. import esi
 
 from .common import (ChannelEngineService, ChannelHostMem, ChannelMMIO,
-                     DummyFromHostEngine, DummyToHostEngine, Reset)
+                     DummyFromHostEngine, DummyToHostEngine, MMIOIndirection,
+                     Reset)
 
 import glob
 import pathlib
@@ -197,11 +198,15 @@ def XrtChannelTop(user_module):
       cmd, froms = esi.MMIO.read_write.type.pack(cmd=rw_mux.cmd)
       data.assign(froms["data"])
 
+      indirect_mmio = MMIOIndirection(clk=ports.clk,
+                                      rst=ports.rst,
+                                      upstream=cmd)
+
       ChannelMMIO(esi.MMIO,
                   appid=esi.AppID("__xrt_mmio"),
                   clk=ports.clk,
                   rst=ports.rst,
-                  cmd=cmd)
+                  cmd=indirect_mmio.downstream)
 
   return XrtChannelTop
 

--- a/frontends/PyCDE/src/pycde/bsp/xrt_package.tcl
+++ b/frontends/PyCDE/src/pycde/bsp/xrt_package.tcl
@@ -50,25 +50,33 @@ ipx::associate_bus_interfaces -busif s_axi_control -clock ap_clk $core
 set mem_map     [::ipx::add_memory_map "s_axi_control" $core]
 set addr_block  [::ipx::add_address_block "reg0" $mem_map]
 
-set_property range 0x100000 $addr_block
+set_property range 0x1000 $addr_block
 set_property range_resolve_type "immediate" $addr_block
-set_property range_minimum 0x100000 $addr_block
+set_property range_minimum 0x1000 $addr_block
 
-set reg      [::ipx::add_register "EsiMagicNumberLow" $addr_block]
+set reg      [::ipx::add_register "IndirectionMagicNumberLow" $addr_block]
+  set_property address_offset  8  $reg
+  set_property size           32 $reg
+
+set reg      [::ipx::add_register "IndirectionMagicNumberHigh" $addr_block]
+  set_property address_offset 12  $reg
+  set_property size           32 $reg
+
+set reg      [::ipx::add_register "IndirectionVersionNumber" $addr_block]
   set_property address_offset 16  $reg
   set_property size           32 $reg
 
-set reg      [::ipx::add_register "EsiMagicNumberHigh" $addr_block]
-  set_property address_offset 20  $reg
+set reg [::ipx::add_register "IndirectionLocation" $addr_block]
+  set_property address_offset 24 $reg
   set_property size           32 $reg
 
-set reg      [::ipx::add_register "EsiVersionNumber" $addr_block]
-  set_property address_offset 24  $reg
-  set_property size           32 $reg
-
-set reg [::ipx::add_register "EsiManifestLoc" $addr_block]
+set reg [::ipx::add_register "IndirectionRegLow" $addr_block]
   set_property address_offset 32 $reg
-  set_property size 32 $reg
+  set_property size           32 $reg
+
+set reg [::ipx::add_register "IndirectionRegHigh" $addr_block]
+  set_property address_offset 36 $reg
+  set_property size           32 $reg
 
 set_property slave_memory_map_ref "s_axi_control" [::ipx::get_bus_interfaces -of $core "s_axi_control"]
 

--- a/lib/Dialect/ESI/runtime/cpp/lib/backends/Xrt.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/backends/Xrt.cpp
@@ -95,17 +95,47 @@ XrtAccelerator::XrtAccelerator(Context &ctxt, std::string xclbin,
 XrtAccelerator::~XrtAccelerator() { disconnect(); }
 
 namespace {
+/// Implementation of MMIO for XRT. Uses an indirect register to access a
+/// virtual MMIO space since Vivado/Vitis don't support large enough MMIO
+/// spaces.
 class XrtMMIO : public MMIO {
+
+  // Physical register to write the virtual address.
+  constexpr static uint32_t IndirectLocation = 0x18;
+  // Physical register to read/write the virtual MMIO address stored at
+  // `IndirectLocation`.
+  constexpr static uint32_t IndirectMMIOReg = 0x20;
+
 public:
   XrtMMIO(XrtAccelerator &conn, ::xrt::ip &ip, const HWClientDetails &clients)
       : MMIO(conn, clients), ip(ip) {}
 
   uint64_t read(uint32_t addr) const override {
+    // Write the address to the indirect location register.
+    xrt_write(IndirectLocation, addr);
+    // Read from the indirect register.
+    uint64_t ret = xrt_read(IndirectMMIOReg);
+    conn.getLogger().debug("xrt",
+                           "MMIO[0x" + toHex(addr) + "] = 0x" + toHex(ret));
+    return ret;
+  }
+  void write(uint32_t addr, uint64_t data) override {
+    // Write the address to the indirect location register.
+    xrt_write(IndirectLocation, addr);
+    // Write to the indirect register.
+    xrt_write(IndirectMMIOReg, data);
+    conn.getLogger().debug("xrt",
+                           "MMIO[0x" + toHex(addr) + "] <- 0x" + toHex(data));
+  }
+
+  /// Read a physical register.
+  uint64_t xrt_read(uint32_t addr) const {
     auto lo = static_cast<uint64_t>(ip.read_register(addr));
     auto hi = static_cast<uint64_t>(ip.read_register(addr + 0x4));
     return (hi << 32) | lo;
   }
-  void write(uint32_t addr, uint64_t data) override {
+  /// Write a physical register.
+  void xrt_write(uint32_t addr, uint64_t data) const {
     ip.write_register(addr, data);
     ip.write_register(addr + 0x4, data >> 32);
   }


### PR DESCRIPTION
Vivado 2022.1 has a 4k MMIO space limit. 2032.1 has one as well, though it's likely larger but undocumented. To get around this, we introduce a layer of indirection wherein one writes the desired location in a "virtual" MMIO space then does the read/write from/to another register.