### PR TITLE
[MemoryBanking] Memory banking supports multiple banking factors/dimensions config

### DIFF
--- a/include/circt/Transforms/Passes.h
+++ b/include/circt/Transforms/Passes.h
@@ -48,8 +48,8 @@ std::unique_ptr<mlir::Pass> createMaximizeSSAPass();
 std::unique_ptr<mlir::Pass> createInsertMergeBlocksPass();
 std::unique_ptr<mlir::Pass> createPrintOpCountPass();
 std::unique_ptr<mlir::Pass>
-createMemoryBankingPass(std::optional<unsigned> bankingFactor = std::nullopt,
-                        std::optional<int> bankingDimension = std::nullopt);
+createMemoryBankingPass(ArrayRef<unsigned> bankingFactors = {},
+                        ArrayRef<unsigned> bankingDimensions = {});
 std::unique_ptr<mlir::Pass> createIndexSwitchToIfPass();
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -132,7 +132,7 @@ def MemoryBanking : Pass<"memory-banking", "::mlir::func::FuncOp"> {
            "The elements specified in banking factors should be greater than 1;"
            "The elements specified in banking factors will be paired with the ones specified in banking dimensions."
            "In principle, the number of elements in banking factors should be equal to banking dimensions',"
-           "with the only exception that there is one banking factor with zero banking dimension.">,
+           "with a single exception case: there is one banking factor with zero banking dimensions.">,
     ListOption<"bankingDimensionsList", "dimensions", "unsigned",
            "The dimensions along which to bank the memory. If unspecified and"
            "there is only one factor, the innermost dimension with size > 1 is used.">

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -127,10 +127,11 @@ def MemoryBanking : Pass<"memory-banking", "::mlir::func::FuncOp"> {
   let summary = "Partition the memories used in affine parallel loops into banks";
   let constructor = "circt::createMemoryBankingPass()";
   let options = [
-    Option<"bankingFactor", "factor", "unsigned", /*default=*/"1",
+    ListOption<"bankingFactorsList", "factors", "unsigned",
            "Use this banking factor for all memories being partitioned">,
-    Option<"bankingDimension", "dimension", "int", /*default=*/"-1",
-           "The dimension along which to bank the memory. If -1, the innermost dimension with size > 1 is used.">
+    ListOption<"bankingDimensionsList", "dimensions", "unsigned",
+           "The dimension along which to bank the memory. If unspecified and"
+           "there is only one factor, the innermost dimension with size > 1 is used.">
   ];
   let dependentDialects = ["mlir::memref::MemRefDialect, mlir::scf::SCFDialect, mlir::affine::AffineDialect"];
 }

--- a/include/circt/Transforms/Passes.td
+++ b/include/circt/Transforms/Passes.td
@@ -128,9 +128,13 @@ def MemoryBanking : Pass<"memory-banking", "::mlir::func::FuncOp"> {
   let constructor = "circt::createMemoryBankingPass()";
   let options = [
     ListOption<"bankingFactorsList", "factors", "unsigned",
-           "Use this banking factor for all memories being partitioned">,
+           "Use banking factors to partition all memories that don't have banking attributes."
+           "The elements specified in banking factors should be greater than 1;"
+           "The elements specified in banking factors will be paired with the ones specified in banking dimensions."
+           "In principle, the number of elements in banking factors should be equal to banking dimensions',"
+           "with the only exception that there is one banking factor with zero banking dimension.">,
     ListOption<"bankingDimensionsList", "dimensions", "unsigned",
-           "The dimension along which to bank the memory. If unspecified and"
+           "The dimensions along which to bank the memory. If unspecified and"
            "there is only one factor, the innermost dimension with size > 1 is used.">
   ];
   let dependentDialects = ["mlir::memref::MemRefDialect, mlir::scf::SCFDialect, mlir::affine::AffineDialect"];

--- a/lib/Transforms/MemoryBanking.cpp
+++ b/lib/Transforms/MemoryBanking.cpp
@@ -355,33 +355,27 @@ unsigned getCurrBankingInfo(BankingConfigAttributes bankingConfigAttrs,
 Attribute getRemainingBankingInfo(MLIRContext *context,
                                   BankingConfigAttributes bankingConfigAttrs,
                                   StringRef attrName) {
-  if (attrName.str() == bankingFactorsStr) {
-    if (auto arrayAttr = dyn_cast<ArrayAttr>(bankingConfigAttrs.factors)) {
+  auto getRemainingElements = [context](Attribute attr) -> Attribute {
+    if (auto arrayAttr = dyn_cast<ArrayAttr>(attr)) {
       assert(!arrayAttr.empty() &&
-             "BankingConfig factors ArrayAttr should not be empty");
+             "BankingConfig ArrayAttr should not be empty");
       return arrayAttr.size() > 1
                  ? ArrayAttr::get(context, arrayAttr.getValue().take_back(
                                                arrayAttr.size() - 1))
                  : nullptr;
     }
-    auto intAttr = dyn_cast<IntegerAttr>(bankingConfigAttrs.factors);
-    assert(intAttr && "BankingConfig factor must be an integer");
+    assert(dyn_cast<IntegerAttr>(attr) &&
+           "BankingConfig attribute must be an integer");
     return nullptr;
+  };
+
+  if (attrName.str() == bankingFactorsStr) {
+    return getRemainingElements(bankingConfigAttrs.factors);
   }
 
   assert(attrName.str() == bankingDimensionsStr &&
          "BankingConfig only contains 'factors' and 'dimensions' attributes");
-  if (auto arrayAttr = dyn_cast<ArrayAttr>(bankingConfigAttrs.dimensions)) {
-    assert(!arrayAttr.empty() &&
-           "BankingConfig dimensions ArrayAttr should not be empty");
-    return arrayAttr.size() > 1
-               ? ArrayAttr::get(context, arrayAttr.getValue().take_back(
-                                             arrayAttr.size() - 1))
-               : nullptr;
-  }
-  auto intAttr = dyn_cast<IntegerAttr>(bankingConfigAttrs.dimensions);
-  assert(intAttr && "BankingConfig dimension must be an integer");
-  return nullptr;
+  return getRemainingElements(bankingConfigAttrs.dimensions);
 }
 
 SmallVector<Value, 4> MemoryBankingPass::createBanks(OpBuilder &builder,

--- a/test/Transforms/memory_banking.mlir
+++ b/test/Transforms/memory_banking.mlir
@@ -1,7 +1,7 @@
-// RUN: circt-opt %s -split-input-file -memory-banking="factor=2" | FileCheck %s --check-prefix UNROLL-BY-2
-// RUN: circt-opt %s -split-input-file -memory-banking="factor=1" | FileCheck %s --check-prefix UNROLL-BY-1
-// RUN: circt-opt %s -split-input-file -memory-banking="factor=8" | FileCheck %s --check-prefix UNROLL-BY-8
-// RUN: circt-opt %s -split-input-file -memory-banking="factor=2" | FileCheck %s --check-prefix ALLOC-UNROLL-2
+// RUN: circt-opt %s -split-input-file -memory-banking="factors=2" | FileCheck %s --check-prefix UNROLL-BY-2
+// RUN: circt-opt %s -split-input-file -memory-banking="factors=1" | FileCheck %s --check-prefix UNROLL-BY-1
+// RUN: circt-opt %s -split-input-file -memory-banking="factors=8" | FileCheck %s --check-prefix UNROLL-BY-8
+// RUN: circt-opt %s -split-input-file -memory-banking="factors=2" | FileCheck %s --check-prefix ALLOC-UNROLL-2
 
 // -----
 

--- a/test/Transforms/memory_banking_attrs.mlir
+++ b/test/Transforms/memory_banking_attrs.mlir
@@ -95,8 +95,8 @@
 // CHECK:         }
 
 module {
-  func.func @main(%arg0: memref<3x5xf32> {banking.factor=5, banking.dimension=1}, %arg1: memref<5x3xf32>{banking.factor=5, banking.dimension=0}) -> (memref<5x3xf32>) {
-    %mem = memref.alloc() {banking.factor=5, banking.dimension=0} : memref<5x3xf32>
+  func.func @main(%arg0: memref<3x5xf32> {banking.factors=5, banking.dimensions=1}, %arg1: memref<5x3xf32>{banking.factors=5, banking.dimensions=0}) -> (memref<5x3xf32>) {
+    %mem = memref.alloc() {banking.factors=5, banking.dimensions=0} : memref<5x3xf32>
     affine.parallel (%i) = (0) to (5) {
       affine.parallel (%j) = (0) to (3) {
         %1 = affine.load %arg0[%j, %i] : memref<3x5xf32>
@@ -201,7 +201,7 @@ module {
 // CHECK:         }
 
 module {
-  func.func @overwrite(%arg0: memref<8x3xf32>, %arg1: memref<8x6xf32> {banking.factor=6, banking.dimension=1}) -> (memref<8x6xf32>) {
+  func.func @overwrite(%arg0: memref<8x3xf32>, %arg1: memref<8x6xf32> {banking.factors=6, banking.dimensions=1}) -> (memref<8x6xf32>) {
     %mem = memref.alloc() : memref<8x6xf32>
     affine.parallel (%i) = (0) to (8) {
       affine.parallel (%j) = (0) to (6) {

--- a/test/Transforms/memory_banking_attrs.mlir
+++ b/test/Transforms/memory_banking_attrs.mlir
@@ -1,7 +1,6 @@
-// RUN: circt-opt %s -memory-banking="factor=3 dimension=1" --canonicalize --split-input-file | FileCheck %s
+// RUN: circt-opt %s -memory-banking="factors=3 dimensions=1" --canonicalize --split-input-file | FileCheck %s
 
 // CHECK: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0 mod 5)>
-// CHECK: #[[$ATTR_1:.+]] = affine_map<(d0) -> (d0 mod 3)>
 
 // CHECK-LABEL:   func.func @main(
 // CHECK-SAME:                    %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<3x1xf32>,
@@ -73,18 +72,26 @@
 // CHECK:                 scf.yield %[[VAL_10]] : f32
 // CHECK:               }
 // CHECK:               %[[VAL_32:.*]] = arith.mulf %[[VAL_19]], %[[VAL_26]] : f32
-// CHECK:               %[[VAL_33:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_16]])
+// CHECK:               %[[VAL_33:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_16]])
 // CHECK:               scf.index_switch %[[VAL_33]]
 // CHECK:               case 0 {
-// CHECK:                 affine.store %[[VAL_32]], %[[VAL_11]]{{\[}}%[[VAL_16]] floordiv 3, %[[VAL_17]]] : memref<1x3xf32>
+// CHECK:                 affine.store %[[VAL_32]], %[[VAL_11]]{{\[}}%[[VAL_16]] floordiv 5, %[[VAL_17]]] : memref<1x3xf32>
 // CHECK:                 scf.yield
 // CHECK:               }
 // CHECK:               case 1 {
-// CHECK:                 affine.store %[[VAL_32]], %[[VAL_12]]{{\[}}%[[VAL_16]] floordiv 3, %[[VAL_17]]] : memref<1x3xf32>
+// CHECK:                 affine.store %[[VAL_32]], %[[VAL_12]]{{\[}}%[[VAL_16]] floordiv 5, %[[VAL_17]]] : memref<1x3xf32>
 // CHECK:                 scf.yield
 // CHECK:               }
 // CHECK:               case 2 {
-// CHECK:                 affine.store %[[VAL_32]], %[[VAL_13]]{{\[}}%[[VAL_16]] floordiv 3, %[[VAL_17]]] : memref<1x3xf32>
+// CHECK:                 affine.store %[[VAL_32]], %[[VAL_13]]{{\[}}%[[VAL_16]] floordiv 5, %[[VAL_17]]] : memref<1x3xf32>
+// CHECK:                 scf.yield
+// CHECK:               }
+// CHECK:               case 3 {
+// CHECK:                 affine.store %[[VAL_32]], %[[VAL_14]]{{\[}}%[[VAL_16]] floordiv 5, %[[VAL_17]]] : memref<1x3xf32>
+// CHECK:                 scf.yield
+// CHECK:               }
+// CHECK:               case 4 {
+// CHECK:                 affine.store %[[VAL_32]], %[[VAL_15]]{{\[}}%[[VAL_16]] floordiv 5, %[[VAL_17]]] : memref<1x3xf32>
 // CHECK:                 scf.yield
 // CHECK:               }
 // CHECK:               default {

--- a/test/Transforms/memory_banking_invalid.mlir
+++ b/test/Transforms/memory_banking_invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s -split-input-file -memory-banking="factor=0" -verify-diagnostics
+// RUN: circt-opt %s -split-input-file -memory-banking="factors=0" -verify-diagnostics
 
 // expected-error@+1 {{banking factor must be greater than 1}}
 func.func @bank_one_dim_unroll0(%arg0: memref<8xf32>, %arg1: memref<8xf32>) -> (memref<8xf32>) {

--- a/test/Transforms/memory_banking_multi_config.mlir
+++ b/test/Transforms/memory_banking_multi_config.mlir
@@ -1,0 +1,168 @@
+// RUN: circt-opt %s -memory-banking="factors=2 dimensions=1" --canonicalize --split-input-file | FileCheck %s
+
+// CHECK: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0 mod 2)>
+// CHECK: #[[$ATTR_1:.+]] = affine_map<(d0) -> (d0 mod 3)>
+// CHECK: #[[$ATTR_2:.+]] = affine_map<(d0) -> (d0 mod 4)>
+
+// CHECK-LABEL:   func.func @multi_config(
+// CHECK-SAME:                            %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<4x2xf32>,
+// CHECK-SAME:                            %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<4x2xf32>,
+// CHECK-SAME:                            %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<4x2xf32>,
+// CHECK-SAME:                            %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<4x2xf32>,
+// CHECK-SAME:                            %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<4x2xf32>,
+// CHECK-SAME:                            %[[VAL_5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<4x2xf32>,
+// CHECK-SAME:                            %[[VAL_6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<8x3xf32>,
+// CHECK-SAME:                            %[[VAL_7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<8x3xf32>) -> (memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>) {
+// CHECK:           %[[VAL_8:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_9:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_11:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_12:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_13:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_14:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_15:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_16:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           affine.parallel (%[[VAL_17:.*]]) = (0) to (8) {
+// CHECK:             affine.parallel (%[[VAL_18:.*]]) = (0) to (6) {
+// CHECK:               %[[VAL_19:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_17]])
+// CHECK:               %[[VAL_20:.*]] = scf.index_switch %[[VAL_19]] -> f32
+// CHECK:               case 0 {
+// CHECK:                 %[[VAL_21:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_18]])
+// CHECK:                 %[[VAL_22:.*]] = scf.index_switch %[[VAL_21]] -> f32
+// CHECK:                 case 0 {
+// CHECK:                   %[[VAL_23:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_17]] floordiv 2, %[[VAL_18]] floordiv 3] : memref<4x2xf32>
+// CHECK:                   scf.yield %[[VAL_23]] : f32
+// CHECK:                 }
+// CHECK:                 case 1 {
+// CHECK:                   %[[VAL_24:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_17]] floordiv 2, %[[VAL_18]] floordiv 3] : memref<4x2xf32>
+// CHECK:                   scf.yield %[[VAL_24]] : f32
+// CHECK:                 }
+// CHECK:                 case 2 {
+// CHECK:                   %[[VAL_25:.*]] = affine.load %[[VAL_2]]{{\[}}%[[VAL_17]] floordiv 2, %[[VAL_18]] floordiv 3] : memref<4x2xf32>
+// CHECK:                   scf.yield %[[VAL_25]] : f32
+// CHECK:                 }
+// CHECK:                 default {
+// CHECK:                   scf.yield %[[VAL_8]] : f32
+// CHECK:                 }
+// CHECK:                 scf.yield %[[VAL_22]] : f32
+// CHECK:               }
+// CHECK:               case 1 {
+// CHECK:                 %[[VAL_26:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_18]])
+// CHECK:                 %[[VAL_27:.*]] = scf.index_switch %[[VAL_26]] -> f32
+// CHECK:                 case 0 {
+// CHECK:                   %[[VAL_28:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_17]] floordiv 2, %[[VAL_18]] floordiv 3] : memref<4x2xf32>
+// CHECK:                   scf.yield %[[VAL_28]] : f32
+// CHECK:                 }
+// CHECK:                 case 1 {
+// CHECK:                   %[[VAL_29:.*]] = affine.load %[[VAL_4]]{{\[}}%[[VAL_17]] floordiv 2, %[[VAL_18]] floordiv 3] : memref<4x2xf32>
+// CHECK:                   scf.yield %[[VAL_29]] : f32
+// CHECK:                 }
+// CHECK:                 case 2 {
+// CHECK:                   %[[VAL_30:.*]] = affine.load %[[VAL_5]]{{\[}}%[[VAL_17]] floordiv 2, %[[VAL_18]] floordiv 3] : memref<4x2xf32>
+// CHECK:                   scf.yield %[[VAL_30]] : f32
+// CHECK:                 }
+// CHECK:                 default {
+// CHECK:                   scf.yield %[[VAL_8]] : f32
+// CHECK:                 }
+// CHECK:                 scf.yield %[[VAL_27]] : f32
+// CHECK:               }
+// CHECK:               default {
+// CHECK:                 scf.yield %[[VAL_8]] : f32
+// CHECK:               }
+// CHECK:               %[[VAL_31:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_18]])
+// CHECK:               %[[VAL_32:.*]] = scf.index_switch %[[VAL_31]] -> f32
+// CHECK:               case 0 {
+// CHECK:                 %[[VAL_33:.*]] = affine.load %[[VAL_6]]{{\[}}%[[VAL_17]], %[[VAL_18]] floordiv 2] : memref<8x3xf32>
+// CHECK:                 scf.yield %[[VAL_33]] : f32
+// CHECK:               }
+// CHECK:               case 1 {
+// CHECK:                 %[[VAL_34:.*]] = affine.load %[[VAL_7]]{{\[}}%[[VAL_17]], %[[VAL_18]] floordiv 2] : memref<8x3xf32>
+// CHECK:                 scf.yield %[[VAL_34]] : f32
+// CHECK:               }
+// CHECK:               default {
+// CHECK:                 scf.yield %[[VAL_8]] : f32
+// CHECK:               }
+// CHECK:               %[[VAL_35:.*]] = arith.mulf %[[VAL_20]], %[[VAL_32]] : f32
+// CHECK:               %[[VAL_36:.*]] = affine.apply #[[$ATTR_2]](%[[VAL_17]])
+// CHECK:               scf.index_switch %[[VAL_36]]
+// CHECK:               case 0 {
+// CHECK:                 %[[VAL_37:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_18]])
+// CHECK:                 scf.index_switch %[[VAL_37]]
+// CHECK:                 case 0 {
+// CHECK:                   affine.store %[[VAL_35]], %[[VAL_9]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   scf.yield
+// CHECK:                 }
+// CHECK:                 case 1 {
+// CHECK:                   affine.store %[[VAL_35]], %[[VAL_10]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   scf.yield
+// CHECK:                 }
+// CHECK:                 default {
+// CHECK:                 }
+// CHECK:                 scf.yield
+// CHECK:               }
+// CHECK:               case 1 {
+// CHECK:                 %[[VAL_38:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_18]])
+// CHECK:                 scf.index_switch %[[VAL_38]]
+// CHECK:                 case 0 {
+// CHECK:                   affine.store %[[VAL_35]], %[[VAL_11]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   scf.yield
+// CHECK:                 }
+// CHECK:                 case 1 {
+// CHECK:                   affine.store %[[VAL_35]], %[[VAL_12]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   scf.yield
+// CHECK:                 }
+// CHECK:                 default {
+// CHECK:                 }
+// CHECK:                 scf.yield
+// CHECK:               }
+// CHECK:               case 2 {
+// CHECK:                 %[[VAL_39:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_18]])
+// CHECK:                 scf.index_switch %[[VAL_39]]
+// CHECK:                 case 0 {
+// CHECK:                   affine.store %[[VAL_35]], %[[VAL_13]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   scf.yield
+// CHECK:                 }
+// CHECK:                 case 1 {
+// CHECK:                   affine.store %[[VAL_35]], %[[VAL_14]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   scf.yield
+// CHECK:                 }
+// CHECK:                 default {
+// CHECK:                 }
+// CHECK:                 scf.yield
+// CHECK:               }
+// CHECK:               case 3 {
+// CHECK:                 %[[VAL_40:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_18]])
+// CHECK:                 scf.index_switch %[[VAL_40]]
+// CHECK:                 case 0 {
+// CHECK:                   affine.store %[[VAL_35]], %[[VAL_15]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   scf.yield
+// CHECK:                 }
+// CHECK:                 case 1 {
+// CHECK:                   affine.store %[[VAL_35]], %[[VAL_16]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   scf.yield
+// CHECK:                 }
+// CHECK:                 default {
+// CHECK:                 }
+// CHECK:                 scf.yield
+// CHECK:               }
+// CHECK:               default {
+// CHECK:               }
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return %[[VAL_9]], %[[VAL_10]], %[[VAL_11]], %[[VAL_12]], %[[VAL_13]], %[[VAL_14]], %[[VAL_15]], %[[VAL_16]] : memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>
+// CHECK:         }
+
+module {
+  func.func @multi_config(%arg0: memref<8x6xf32> {banking.factors=[2, 3], banking.dimensions=[0, 1]}, %arg1: memref<8x6xf32>) -> memref<8x6xf32> {
+    %mem = memref.alloc() {banking.factors=[4, 2], banking.dimensions=[0, 1]} : memref<8x6xf32>
+    affine.parallel (%i) = (0) to (8) {
+      affine.parallel (%j) = (0) to (6) {
+        %1 = affine.load %arg0[%i, %j] : memref<8x6xf32>
+        %2 = affine.load %arg1[%i, %j] : memref<8x6xf32>
+        %3 = arith.mulf %1, %2 : f32
+        affine.store %3, %mem[%i, %j] : memref<8x6xf32>
+      }
+    }
+    return %mem : memref<8x6xf32>
+  }
+}

--- a/test/Transforms/memory_banking_multi_config.mlir
+++ b/test/Transforms/memory_banking_multi_config.mlir
@@ -1,8 +1,9 @@
-// RUN: circt-opt %s -memory-banking="factors=2 dimensions=1" --canonicalize --split-input-file | FileCheck %s
+// RUN: circt-opt %s -memory-banking="factors=4,6 dimensions=0,1" --canonicalize --split-input-file | FileCheck %s
 
 // CHECK: #[[$ATTR_0:.+]] = affine_map<(d0) -> (d0 mod 2)>
 // CHECK: #[[$ATTR_1:.+]] = affine_map<(d0) -> (d0 mod 3)>
 // CHECK: #[[$ATTR_2:.+]] = affine_map<(d0) -> (d0 mod 4)>
+// CHECK: #[[$ATTR_3:.+]] = affine_map<(d0) -> (d0 mod 6)>
 
 // CHECK-LABEL:   func.func @multi_config(
 // CHECK-SAME:                            %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<4x2xf32>,
@@ -11,89 +12,231 @@
 // CHECK-SAME:                            %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<4x2xf32>,
 // CHECK-SAME:                            %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<4x2xf32>,
 // CHECK-SAME:                            %[[VAL_5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<4x2xf32>,
-// CHECK-SAME:                            %[[VAL_6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<8x3xf32>,
-// CHECK-SAME:                            %[[VAL_7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<8x3xf32>) -> (memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>) {
-// CHECK:           %[[VAL_8:.*]] = arith.constant 0.000000e+00 : f32
-// CHECK:           %[[VAL_9:.*]] = memref.alloc() : memref<2x3xf32>
-// CHECK:           %[[VAL_10:.*]] = memref.alloc() : memref<2x3xf32>
-// CHECK:           %[[VAL_11:.*]] = memref.alloc() : memref<2x3xf32>
-// CHECK:           %[[VAL_12:.*]] = memref.alloc() : memref<2x3xf32>
-// CHECK:           %[[VAL_13:.*]] = memref.alloc() : memref<2x3xf32>
-// CHECK:           %[[VAL_14:.*]] = memref.alloc() : memref<2x3xf32>
-// CHECK:           %[[VAL_15:.*]] = memref.alloc() : memref<2x3xf32>
-// CHECK:           %[[VAL_16:.*]] = memref.alloc() : memref<2x3xf32>
-// CHECK:           affine.parallel (%[[VAL_17:.*]]) = (0) to (8) {
-// CHECK:             affine.parallel (%[[VAL_18:.*]]) = (0) to (6) {
-// CHECK:               %[[VAL_19:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_17]])
-// CHECK:               %[[VAL_20:.*]] = scf.index_switch %[[VAL_19]] -> f32
+// CHECK-SAME:                            %[[VAL_6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_8:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_9:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_10:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_11:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_12:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_13:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_14:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_15:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_16:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_17:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_18:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_19:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_20:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_21:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_22:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_23:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_24:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_25:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_26:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_27:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_28:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>,
+// CHECK-SAME:                            %[[VAL_29:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x1xf32>) -> (memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>) {
+// CHECK:           %[[VAL_30:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_31:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_32:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_33:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_34:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_35:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_36:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_37:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           %[[VAL_38:.*]] = memref.alloc() : memref<2x3xf32>
+// CHECK:           affine.parallel (%[[VAL_39:.*]]) = (0) to (8) {
+// CHECK:             affine.parallel (%[[VAL_40:.*]]) = (0) to (6) {
+// CHECK:               %[[VAL_41:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_39]])
+// CHECK:               %[[VAL_42:.*]] = scf.index_switch %[[VAL_41]] -> f32
 // CHECK:               case 0 {
-// CHECK:                 %[[VAL_21:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_18]])
-// CHECK:                 %[[VAL_22:.*]] = scf.index_switch %[[VAL_21]] -> f32
+// CHECK:                 %[[VAL_43:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_40]])
+// CHECK:                 %[[VAL_44:.*]] = scf.index_switch %[[VAL_43]] -> f32
 // CHECK:                 case 0 {
-// CHECK:                   %[[VAL_23:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_17]] floordiv 2, %[[VAL_18]] floordiv 3] : memref<4x2xf32>
-// CHECK:                   scf.yield %[[VAL_23]] : f32
+// CHECK:                   %[[VAL_45:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_39]] floordiv 2, %[[VAL_40]] floordiv 3] : memref<4x2xf32>
+// CHECK:                   scf.yield %[[VAL_45]] : f32
 // CHECK:                 }
 // CHECK:                 case 1 {
-// CHECK:                   %[[VAL_24:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_17]] floordiv 2, %[[VAL_18]] floordiv 3] : memref<4x2xf32>
-// CHECK:                   scf.yield %[[VAL_24]] : f32
+// CHECK:                   %[[VAL_46:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_39]] floordiv 2, %[[VAL_40]] floordiv 3] : memref<4x2xf32>
+// CHECK:                   scf.yield %[[VAL_46]] : f32
 // CHECK:                 }
 // CHECK:                 case 2 {
-// CHECK:                   %[[VAL_25:.*]] = affine.load %[[VAL_2]]{{\[}}%[[VAL_17]] floordiv 2, %[[VAL_18]] floordiv 3] : memref<4x2xf32>
-// CHECK:                   scf.yield %[[VAL_25]] : f32
+// CHECK:                   %[[VAL_47:.*]] = affine.load %[[VAL_2]]{{\[}}%[[VAL_39]] floordiv 2, %[[VAL_40]] floordiv 3] : memref<4x2xf32>
+// CHECK:                   scf.yield %[[VAL_47]] : f32
 // CHECK:                 }
 // CHECK:                 default {
-// CHECK:                   scf.yield %[[VAL_8]] : f32
-// CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_22]] : f32
-// CHECK:               }
-// CHECK:               case 1 {
-// CHECK:                 %[[VAL_26:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_18]])
-// CHECK:                 %[[VAL_27:.*]] = scf.index_switch %[[VAL_26]] -> f32
-// CHECK:                 case 0 {
-// CHECK:                   %[[VAL_28:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_17]] floordiv 2, %[[VAL_18]] floordiv 3] : memref<4x2xf32>
-// CHECK:                   scf.yield %[[VAL_28]] : f32
-// CHECK:                 }
-// CHECK:                 case 1 {
-// CHECK:                   %[[VAL_29:.*]] = affine.load %[[VAL_4]]{{\[}}%[[VAL_17]] floordiv 2, %[[VAL_18]] floordiv 3] : memref<4x2xf32>
-// CHECK:                   scf.yield %[[VAL_29]] : f32
-// CHECK:                 }
-// CHECK:                 case 2 {
-// CHECK:                   %[[VAL_30:.*]] = affine.load %[[VAL_5]]{{\[}}%[[VAL_17]] floordiv 2, %[[VAL_18]] floordiv 3] : memref<4x2xf32>
 // CHECK:                   scf.yield %[[VAL_30]] : f32
 // CHECK:                 }
-// CHECK:                 default {
-// CHECK:                   scf.yield %[[VAL_8]] : f32
-// CHECK:                 }
-// CHECK:                 scf.yield %[[VAL_27]] : f32
-// CHECK:               }
-// CHECK:               default {
-// CHECK:                 scf.yield %[[VAL_8]] : f32
-// CHECK:               }
-// CHECK:               %[[VAL_31:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_18]])
-// CHECK:               %[[VAL_32:.*]] = scf.index_switch %[[VAL_31]] -> f32
-// CHECK:               case 0 {
-// CHECK:                 %[[VAL_33:.*]] = affine.load %[[VAL_6]]{{\[}}%[[VAL_17]], %[[VAL_18]] floordiv 2] : memref<8x3xf32>
-// CHECK:                 scf.yield %[[VAL_33]] : f32
+// CHECK:                 scf.yield %[[VAL_44]] : f32
 // CHECK:               }
 // CHECK:               case 1 {
-// CHECK:                 %[[VAL_34:.*]] = affine.load %[[VAL_7]]{{\[}}%[[VAL_17]], %[[VAL_18]] floordiv 2] : memref<8x3xf32>
-// CHECK:                 scf.yield %[[VAL_34]] : f32
+// CHECK:                 %[[VAL_48:.*]] = affine.apply #[[$ATTR_1]](%[[VAL_40]])
+// CHECK:                 %[[VAL_49:.*]] = scf.index_switch %[[VAL_48]] -> f32
+// CHECK:                 case 0 {
+// CHECK:                   %[[VAL_50:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_39]] floordiv 2, %[[VAL_40]] floordiv 3] : memref<4x2xf32>
+// CHECK:                   scf.yield %[[VAL_50]] : f32
+// CHECK:                 }
+// CHECK:                 case 1 {
+// CHECK:                   %[[VAL_51:.*]] = affine.load %[[VAL_4]]{{\[}}%[[VAL_39]] floordiv 2, %[[VAL_40]] floordiv 3] : memref<4x2xf32>
+// CHECK:                   scf.yield %[[VAL_51]] : f32
+// CHECK:                 }
+// CHECK:                 case 2 {
+// CHECK:                   %[[VAL_52:.*]] = affine.load %[[VAL_5]]{{\[}}%[[VAL_39]] floordiv 2, %[[VAL_40]] floordiv 3] : memref<4x2xf32>
+// CHECK:                   scf.yield %[[VAL_52]] : f32
+// CHECK:                 }
+// CHECK:                 default {
+// CHECK:                   scf.yield %[[VAL_30]] : f32
+// CHECK:                 }
+// CHECK:                 scf.yield %[[VAL_49]] : f32
 // CHECK:               }
 // CHECK:               default {
-// CHECK:                 scf.yield %[[VAL_8]] : f32
+// CHECK:                 scf.yield %[[VAL_30]] : f32
 // CHECK:               }
-// CHECK:               %[[VAL_35:.*]] = arith.mulf %[[VAL_20]], %[[VAL_32]] : f32
-// CHECK:               %[[VAL_36:.*]] = affine.apply #[[$ATTR_2]](%[[VAL_17]])
-// CHECK:               scf.index_switch %[[VAL_36]]
+// CHECK:               %[[VAL_53:.*]] = affine.apply #[[$ATTR_2]](%[[VAL_39]])
+// CHECK:               %[[VAL_54:.*]] = scf.index_switch %[[VAL_53]] -> f32
 // CHECK:               case 0 {
-// CHECK:                 %[[VAL_37:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_18]])
-// CHECK:                 scf.index_switch %[[VAL_37]]
+// CHECK:                 %[[VAL_55:.*]] = affine.apply #[[$ATTR_3]](%[[VAL_40]])
+// CHECK:                 %[[VAL_56:.*]] = scf.index_switch %[[VAL_55]] -> f32
 // CHECK:                 case 0 {
-// CHECK:                   affine.store %[[VAL_35]], %[[VAL_9]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   %[[VAL_57:.*]] = affine.load %[[VAL_6]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_57]] : f32
+// CHECK:                 }
+// CHECK:                 case 1 {
+// CHECK:                   %[[VAL_58:.*]] = affine.load %[[VAL_7]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_58]] : f32
+// CHECK:                 }
+// CHECK:                 case 2 {
+// CHECK:                   %[[VAL_59:.*]] = affine.load %[[VAL_8]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_59]] : f32
+// CHECK:                 }
+// CHECK:                 case 3 {
+// CHECK:                   %[[VAL_60:.*]] = affine.load %[[VAL_9]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_60]] : f32
+// CHECK:                 }
+// CHECK:                 case 4 {
+// CHECK:                   %[[VAL_61:.*]] = affine.load %[[VAL_10]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_61]] : f32
+// CHECK:                 }
+// CHECK:                 case 5 {
+// CHECK:                   %[[VAL_62:.*]] = affine.load %[[VAL_11]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_62]] : f32
+// CHECK:                 }
+// CHECK:                 default {
+// CHECK:                   scf.yield %[[VAL_30]] : f32
+// CHECK:                 }
+// CHECK:                 scf.yield %[[VAL_56]] : f32
+// CHECK:               }
+// CHECK:               case 1 {
+// CHECK:                 %[[VAL_63:.*]] = affine.apply #[[$ATTR_3]](%[[VAL_40]])
+// CHECK:                 %[[VAL_64:.*]] = scf.index_switch %[[VAL_63]] -> f32
+// CHECK:                 case 0 {
+// CHECK:                   %[[VAL_65:.*]] = affine.load %[[VAL_12]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_65]] : f32
+// CHECK:                 }
+// CHECK:                 case 1 {
+// CHECK:                   %[[VAL_66:.*]] = affine.load %[[VAL_13]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_66]] : f32
+// CHECK:                 }
+// CHECK:                 case 2 {
+// CHECK:                   %[[VAL_67:.*]] = affine.load %[[VAL_14]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_67]] : f32
+// CHECK:                 }
+// CHECK:                 case 3 {
+// CHECK:                   %[[VAL_68:.*]] = affine.load %[[VAL_15]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_68]] : f32
+// CHECK:                 }
+// CHECK:                 case 4 {
+// CHECK:                   %[[VAL_69:.*]] = affine.load %[[VAL_16]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_69]] : f32
+// CHECK:                 }
+// CHECK:                 case 5 {
+// CHECK:                   %[[VAL_70:.*]] = affine.load %[[VAL_17]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_70]] : f32
+// CHECK:                 }
+// CHECK:                 default {
+// CHECK:                   scf.yield %[[VAL_30]] : f32
+// CHECK:                 }
+// CHECK:                 scf.yield %[[VAL_64]] : f32
+// CHECK:               }
+// CHECK:               case 2 {
+// CHECK:                 %[[VAL_71:.*]] = affine.apply #[[$ATTR_3]](%[[VAL_40]])
+// CHECK:                 %[[VAL_72:.*]] = scf.index_switch %[[VAL_71]] -> f32
+// CHECK:                 case 0 {
+// CHECK:                   %[[VAL_73:.*]] = affine.load %[[VAL_18]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_73]] : f32
+// CHECK:                 }
+// CHECK:                 case 1 {
+// CHECK:                   %[[VAL_74:.*]] = affine.load %[[VAL_19]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_74]] : f32
+// CHECK:                 }
+// CHECK:                 case 2 {
+// CHECK:                   %[[VAL_75:.*]] = affine.load %[[VAL_20]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_75]] : f32
+// CHECK:                 }
+// CHECK:                 case 3 {
+// CHECK:                   %[[VAL_76:.*]] = affine.load %[[VAL_21]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_76]] : f32
+// CHECK:                 }
+// CHECK:                 case 4 {
+// CHECK:                   %[[VAL_77:.*]] = affine.load %[[VAL_22]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_77]] : f32
+// CHECK:                 }
+// CHECK:                 case 5 {
+// CHECK:                   %[[VAL_78:.*]] = affine.load %[[VAL_23]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_78]] : f32
+// CHECK:                 }
+// CHECK:                 default {
+// CHECK:                   scf.yield %[[VAL_30]] : f32
+// CHECK:                 }
+// CHECK:                 scf.yield %[[VAL_72]] : f32
+// CHECK:               }
+// CHECK:               case 3 {
+// CHECK:                 %[[VAL_79:.*]] = affine.apply #[[$ATTR_3]](%[[VAL_40]])
+// CHECK:                 %[[VAL_80:.*]] = scf.index_switch %[[VAL_79]] -> f32
+// CHECK:                 case 0 {
+// CHECK:                   %[[VAL_81:.*]] = affine.load %[[VAL_24]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_81]] : f32
+// CHECK:                 }
+// CHECK:                 case 1 {
+// CHECK:                   %[[VAL_82:.*]] = affine.load %[[VAL_25]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_82]] : f32
+// CHECK:                 }
+// CHECK:                 case 2 {
+// CHECK:                   %[[VAL_83:.*]] = affine.load %[[VAL_26]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_83]] : f32
+// CHECK:                 }
+// CHECK:                 case 3 {
+// CHECK:                   %[[VAL_84:.*]] = affine.load %[[VAL_27]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_84]] : f32
+// CHECK:                 }
+// CHECK:                 case 4 {
+// CHECK:                   %[[VAL_85:.*]] = affine.load %[[VAL_28]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_85]] : f32
+// CHECK:                 }
+// CHECK:                 case 5 {
+// CHECK:                   %[[VAL_86:.*]] = affine.load %[[VAL_29]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 6] : memref<2x1xf32>
+// CHECK:                   scf.yield %[[VAL_86]] : f32
+// CHECK:                 }
+// CHECK:                 default {
+// CHECK:                   scf.yield %[[VAL_30]] : f32
+// CHECK:                 }
+// CHECK:                 scf.yield %[[VAL_80]] : f32
+// CHECK:               }
+// CHECK:               default {
+// CHECK:                 scf.yield %[[VAL_30]] : f32
+// CHECK:               }
+// CHECK:               %[[VAL_87:.*]] = arith.mulf %[[VAL_42]], %[[VAL_54]] : f32
+// CHECK:               %[[VAL_88:.*]] = affine.apply #[[$ATTR_2]](%[[VAL_39]])
+// CHECK:               scf.index_switch %[[VAL_88]]
+// CHECK:               case 0 {
+// CHECK:                 %[[VAL_89:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_40]])
+// CHECK:                 scf.index_switch %[[VAL_89]]
+// CHECK:                 case 0 {
+// CHECK:                   affine.store %[[VAL_87]], %[[VAL_31]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 2] : memref<2x3xf32>
 // CHECK:                   scf.yield
 // CHECK:                 }
 // CHECK:                 case 1 {
-// CHECK:                   affine.store %[[VAL_35]], %[[VAL_10]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   affine.store %[[VAL_87]], %[[VAL_32]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 2] : memref<2x3xf32>
 // CHECK:                   scf.yield
 // CHECK:                 }
 // CHECK:                 default {
@@ -101,14 +244,14 @@
 // CHECK:                 scf.yield
 // CHECK:               }
 // CHECK:               case 1 {
-// CHECK:                 %[[VAL_38:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_18]])
-// CHECK:                 scf.index_switch %[[VAL_38]]
+// CHECK:                 %[[VAL_90:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_40]])
+// CHECK:                 scf.index_switch %[[VAL_90]]
 // CHECK:                 case 0 {
-// CHECK:                   affine.store %[[VAL_35]], %[[VAL_11]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   affine.store %[[VAL_87]], %[[VAL_33]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 2] : memref<2x3xf32>
 // CHECK:                   scf.yield
 // CHECK:                 }
 // CHECK:                 case 1 {
-// CHECK:                   affine.store %[[VAL_35]], %[[VAL_12]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   affine.store %[[VAL_87]], %[[VAL_34]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 2] : memref<2x3xf32>
 // CHECK:                   scf.yield
 // CHECK:                 }
 // CHECK:                 default {
@@ -116,14 +259,14 @@
 // CHECK:                 scf.yield
 // CHECK:               }
 // CHECK:               case 2 {
-// CHECK:                 %[[VAL_39:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_18]])
-// CHECK:                 scf.index_switch %[[VAL_39]]
+// CHECK:                 %[[VAL_91:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_40]])
+// CHECK:                 scf.index_switch %[[VAL_91]]
 // CHECK:                 case 0 {
-// CHECK:                   affine.store %[[VAL_35]], %[[VAL_13]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   affine.store %[[VAL_87]], %[[VAL_35]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 2] : memref<2x3xf32>
 // CHECK:                   scf.yield
 // CHECK:                 }
 // CHECK:                 case 1 {
-// CHECK:                   affine.store %[[VAL_35]], %[[VAL_14]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   affine.store %[[VAL_87]], %[[VAL_36]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 2] : memref<2x3xf32>
 // CHECK:                   scf.yield
 // CHECK:                 }
 // CHECK:                 default {
@@ -131,14 +274,14 @@
 // CHECK:                 scf.yield
 // CHECK:               }
 // CHECK:               case 3 {
-// CHECK:                 %[[VAL_40:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_18]])
-// CHECK:                 scf.index_switch %[[VAL_40]]
+// CHECK:                 %[[VAL_92:.*]] = affine.apply #[[$ATTR_0]](%[[VAL_40]])
+// CHECK:                 scf.index_switch %[[VAL_92]]
 // CHECK:                 case 0 {
-// CHECK:                   affine.store %[[VAL_35]], %[[VAL_15]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   affine.store %[[VAL_87]], %[[VAL_37]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 2] : memref<2x3xf32>
 // CHECK:                   scf.yield
 // CHECK:                 }
 // CHECK:                 case 1 {
-// CHECK:                   affine.store %[[VAL_35]], %[[VAL_16]]{{\[}}%[[VAL_17]] floordiv 4, %[[VAL_18]] floordiv 2] : memref<2x3xf32>
+// CHECK:                   affine.store %[[VAL_87]], %[[VAL_38]]{{\[}}%[[VAL_39]] floordiv 4, %[[VAL_40]] floordiv 2] : memref<2x3xf32>
 // CHECK:                   scf.yield
 // CHECK:                 }
 // CHECK:                 default {
@@ -149,7 +292,7 @@
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
-// CHECK:           return %[[VAL_9]], %[[VAL_10]], %[[VAL_11]], %[[VAL_12]], %[[VAL_13]], %[[VAL_14]], %[[VAL_15]], %[[VAL_16]] : memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>
+// CHECK:           return %[[VAL_31]], %[[VAL_32]], %[[VAL_33]], %[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]] : memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>, memref<2x3xf32>
 // CHECK:         }
 
 module {

--- a/test/Transforms/memory_banking_multi_dim.mlir
+++ b/test/Transforms/memory_banking_multi_dim.mlir
@@ -1,5 +1,5 @@
-// RUN: circt-opt %s -memory-banking="factor=2 dimension=1" | FileCheck %s --check-prefix RANK2-BANKDIM1
-// RUN: circt-opt %s -split-input-file -memory-banking="factor=2" | FileCheck %s --check-prefix GETGLOBAL
+// RUN: circt-opt %s -memory-banking="factors=2 dimensions=1" | FileCheck %s --check-prefix RANK2-BANKDIM1
+// RUN: circt-opt %s -split-input-file -memory-banking="factors=2" | FileCheck %s --check-prefix GETGLOBAL
 
 // RANK2-BANKDIM1: #[[$ATTR_0:.+]] = affine_map<(d0, d1) -> (d1 mod 2)>
 // RANK2-BANKDIM1: #[[$ATTR_1:.+]] = affine_map<(d0, d1) -> (d1 floordiv 2)>


### PR DESCRIPTION
This patch supports passing multiple `banking.factors/dimensions` to the command line options as well as attaching as attributes.