### PR TITLE
[LLHD] Add pass to hoist probes out of processes

### DIFF
--- a/include/circt/Dialect/LLHD/Transforms/LLHDPasses.td
+++ b/include/circt/Dialect/LLHD/Transforms/LLHDPasses.td
@@ -151,4 +151,8 @@ def Desequentialization : Pass<"llhd-desequentialize", "hw::HWModuleOp"> {
   ];
 }
 
+def HoistSignalsPass : Pass<"llhd-hoist-signals"> {
+  let summary = "Hoist probes and promote drives to process results";
+}
+
 #endif // CIRCT_DIALECT_LLHD_TRANSFORMS_PASSES

--- a/lib/Dialect/LLHD/Transforms/CMakeLists.txt
+++ b/lib/Dialect/LLHD/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_circt_dialect_library(CIRCTLLHDTransforms
   DesequentializationPass.cpp
   EarlyCodeMotionPass.cpp
   FunctionEliminationPass.cpp
+  HoistSignals.cpp
   Mem2Reg.cpp
   MemoryToBlockArgumentPass.cpp
   ProcessLoweringPass.cpp

--- a/lib/Dialect/LLHD/Transforms/HoistSignals.cpp
+++ b/lib/Dialect/LLHD/Transforms/HoistSignals.cpp
@@ -1,0 +1,193 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/LLHD/IR/LLHDOps.h"
+#include "circt/Dialect/LLHD/Transforms/LLHDPasses.h"
+#include "mlir/Analysis/Liveness.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "llhd-hoist-signals"
+
+namespace circt {
+namespace llhd {
+#define GEN_PASS_DEF_HOISTSIGNALSPASS
+#include "circt/Dialect/LLHD/Transforms/LLHDPasses.h.inc"
+} // namespace llhd
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace llhd;
+
+//===----------------------------------------------------------------------===//
+// Probe Hoisting
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// The struct performing the hoisting in a single region.
+struct Hoister {
+  Hoister(Region &region) : region(region) {}
+  void hoist();
+
+  void findValuesLiveAcrossWait(Liveness &liveness);
+  void hoistProbes();
+
+  /// The region we are hoisting ops out of.
+  Region &region;
+
+  /// The set of values that are alive across wait ops themselves, or that have
+  /// transitive users that are live across wait ops.
+  DenseSet<Value> liveAcrossWait;
+
+  /// A lookup table of probes we have already hoisted, for deduplication.
+  DenseMap<Value, PrbOp> hoistedProbes;
+};
+} // namespace
+
+void Hoister::hoist() {
+  Liveness liveness(region.getParentOp());
+  findValuesLiveAcrossWait(liveness);
+  hoistProbes();
+}
+
+/// Find all values in the region that are alive across `llhd.wait` operations,
+/// or that have transitive uses that are alive across waits. We can only hoist
+/// probes that do not feed data flow graphs that are alive across such wait
+/// ops. Since control flow edges in `cf.br` and `cf.cond_br` ops are
+/// side-effect free, we have no guarantee that moving a probe out of a process
+/// could potentially cause other ops to become eligible for a move out of the
+/// process. Therefore, if such ops are moved outside of the process, they are
+/// effectively moved across the waits and thus sample their operands at
+/// different points in time. Only values that are explicitly carried across
+/// `llhd.wait`, where the LLHD dialect has control over the control flow
+/// semantics, may have probes in their fan-in cone hoisted out.
+void Hoister::findValuesLiveAcrossWait(Liveness &liveness) {
+  // First find all values that are live across `llhd.wait` operations. We are
+  // only interested in values defined in the current region.
+  SmallVector<Value> worklist;
+  for (auto &block : region)
+    if (isa<WaitOp>(block.getTerminator()))
+      for (auto value : liveness.getLiveOut(&block))
+        if (value.getParentRegion() == &region)
+          if (liveAcrossWait.insert(value).second)
+            worklist.push_back(value);
+
+  // Propagate liveness information along the use-def chain and across control
+  // flow. This will allow us to check `liveAcrossWait` to know if a value
+  // escapes across a wait along its use-def chain that isn't an explicit
+  // successor operand of the wait op.
+  while (!worklist.empty()) {
+    auto value = worklist.pop_back_val();
+    if (auto *defOp = value.getDefiningOp()) {
+      for (auto operand : defOp->getOperands())
+        if (operand.getParentRegion() == &region)
+          if (liveAcrossWait.insert(operand).second)
+            worklist.push_back(operand);
+    } else {
+      auto blockArg = cast<BlockArgument>(value);
+      for (auto &use : blockArg.getOwner()->getUses()) {
+        auto branch = dyn_cast<BranchOpInterface>(use.getOwner());
+        if (!branch)
+          continue;
+        auto operand = branch.getSuccessorOperands(
+            use.getOperandNumber())[blockArg.getArgNumber()];
+        if (operand.getParentRegion() == &region)
+          if (liveAcrossWait.insert(operand).second)
+            worklist.push_back(operand);
+      }
+    }
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << liveAcrossWait.size()
+                          << " values live across wait\n");
+}
+
+/// Hoist any probes at the beginning of resuming blocks out of the process if
+/// their values do not leak across wait ops. Resuming blocks are blocks where
+/// all predecessors are `llhd.wait` ops, and the entry block. Only waits
+/// without any side-effecting op in between themselves and the beginning of the
+/// block can be hoisted.
+void Hoister::hoistProbes() {
+  for (auto &block : region) {
+    // We can only hoist probes in blocks where all predecessors have wait
+    // terminators.
+    if (!llvm::all_of(block.getPredecessors(), [](auto *predecessor) {
+          return isa<WaitOp>(predecessor->getTerminator());
+        }))
+      continue;
+
+    for (auto &op : llvm::make_early_inc_range(block)) {
+      auto probeOp = dyn_cast<PrbOp>(op);
+
+      // We can only hoist probes that have no side-effecting ops between
+      // themselves and the beginning of a block. If we see a side-effecting op,
+      // give up on this block.
+      if (!probeOp) {
+        if (isMemoryEffectFree(&op))
+          continue;
+        else
+          break;
+      }
+
+      // Only hoist probes that don't leak across wait ops.
+      if (liveAcrossWait.contains(probeOp)) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "- Skipping (live across wait) " << probeOp << "\n");
+        continue;
+      }
+
+      // We can only hoist probes of signals that are declared outside the
+      // process.
+      if (!probeOp.getSignal().getParentRegion()->isProperAncestor(&region)) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "- Skipping (local signal) " << probeOp << "\n");
+        continue;
+      }
+
+      // Move the probe out of the process, trying to reuse any previous probe
+      // that we've already hoisted.
+      auto &hoistedOp = hoistedProbes[probeOp.getSignal()];
+      if (hoistedOp) {
+        LLVM_DEBUG(llvm::dbgs() << "- Replacing " << probeOp << "\n");
+        probeOp.replaceAllUsesWith(hoistedOp.getResult());
+        probeOp.erase();
+      } else {
+        LLVM_DEBUG(llvm::dbgs() << "- Hoisting " << probeOp << "\n");
+        probeOp->moveBefore(region.getParentOp());
+        hoistedOp = probeOp;
+      }
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Pass Infrastructure
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct HoistSignalsPass
+    : public llhd::impl::HoistSignalsPassBase<HoistSignalsPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void HoistSignalsPass::runOnOperation() {
+  SmallVector<Region *> regions;
+  getOperation()->walk<WalkOrder::PreOrder>([&](Operation *op) {
+    if (isa<ProcessOp, FinalOp>(op)) {
+      auto &region = op->getRegion(0);
+      if (!region.empty())
+        regions.push_back(&region);
+      return WalkResult::skip();
+    }
+    return WalkResult::advance();
+  });
+  for (auto *region : regions)
+    Hoister(*region).hoist();
+}

--- a/test/Dialect/LLHD/Transforms/hoist-signals.mlir
+++ b/test/Dialect/LLHD/Transforms/hoist-signals.mlir
@@ -1,0 +1,101 @@
+// RUN: circt-opt --llhd-hoist-signals %s | FileCheck %s
+
+// CHECK-LABEL: @Simple
+hw.module @Simple() {
+  %c0_i42 = hw.constant 0 : i42
+  %a = llhd.sig %c0_i42 : i42
+  // CHECK: llhd.sig
+  // CHECK-NEXT: [[A:%.+]] = llhd.prb %a
+  // CHECK-NEXT: llhd.process
+  llhd.process {
+    // CHECK-NOT: llhd.prb
+    %0 = llhd.prb %a : !hw.inout<i42>
+    // CHECK-NEXT: call @use_i42([[A]])
+    func.call @use_i42(%0) : (i42) -> ()
+    llhd.wait ^bb1
+  ^bb1:
+    // CHECK: ^bb1:
+    // CHECK-NOT: llhd.prb
+    %1 = llhd.prb %a : !hw.inout<i42>
+    // CHECK-NEXT: call @use_i42([[A]])
+    func.call @use_i42(%1) : (i42) -> ()
+    llhd.halt
+  }
+}
+
+// CHECK-LABEL: @DontHoistAcrossSideEffects
+hw.module @DontHoistAcrossSideEffects() {
+  %0 = llhd.constant_time <0ns, 0d, 1e>
+  %c0_i42 = hw.constant 0 : i42
+  %a = llhd.sig %c0_i42 : i42
+  // CHECK: llhd.process
+  llhd.process {
+    // CHECK-NEXT: llhd.drv
+    llhd.drv %a, %c0_i42 after %0 : !hw.inout<i42>
+    // CHECK-NEXT: llhd.prb %a
+    llhd.prb %a : !hw.inout<i42>
+    cf.br ^bb1
+  ^bb1:
+    // CHECK: ^bb1:
+    // CHECK-NEXT: llhd.prb %a
+    llhd.prb %a : !hw.inout<i42>
+    llhd.wait ^bb2
+  ^bb2:
+    // CHECK: ^bb2:
+    // CHECK-NEXT: call @maybe_side_effecting
+    func.call @maybe_side_effecting() : () -> ()
+    // CHECK-NEXT: llhd.prb %a
+    llhd.prb %a : !hw.inout<i42>
+    llhd.halt
+  }
+}
+
+// CHECK-LABEL: @DontHoistIfLeakingAcrossWait
+hw.module @DontHoistIfLeakingAcrossWait() {
+  %c0_i42 = hw.constant 0 : i42
+  %a = llhd.sig %c0_i42 : i42
+  // CHECK: llhd.process
+  llhd.process {
+    // CHECK-NEXT: [[A:%.+]] = llhd.prb %a
+    %0 = llhd.prb %a : !hw.inout<i42>
+    llhd.wait ^bb1
+  ^bb1:
+    // CHECK: ^bb1:
+    // CHECK-NEXT: call @use_i42([[A]])
+    func.call @use_i42(%0) : (i42) -> ()
+    llhd.halt
+  }
+  // CHECK: llhd.process
+  llhd.process {
+    // CHECK-NEXT: llhd.prb %a
+    %0 = llhd.prb %a : !hw.inout<i42>
+    cf.br ^bb1(%0 : i42)
+  ^bb1(%1: i42):
+    // CHECK: ^bb1([[A:%.+]]: i42):
+    llhd.wait ^bb2
+  ^bb2:
+    // CHECK: ^bb2:
+    // CHECK-NEXT: call @use_i42([[A]])
+    func.call @use_i42(%1) : (i42) -> ()
+    llhd.halt
+  }
+}
+
+// CHECK-LABEL: @DontHoistLocalSignals
+hw.module @DontHoistLocalSignals() {
+  %0 = llhd.constant_time <0ns, 0d, 1e>
+  %c0_i42 = hw.constant 0 : i42
+  // CHECK: llhd.process
+  llhd.process {
+    %a = llhd.sig %c0_i42 : i42
+    llhd.wait ^bb1
+  ^bb1:
+    // CHECK: ^bb1:
+    // CHECK-NEXT: llhd.prb %a
+    llhd.prb %a : !hw.inout<i42>
+    llhd.halt
+  }
+}
+
+func.func private @use_i42(%arg0: i42)
+func.func private @maybe_side_effecting()


### PR DESCRIPTION
Add the HoistSignals pass which is intended to hoist probes and drives out of processes. Currently only probe hoisting is implemented. Probes that immediately follow resumption points, i.e. the entry block and blocks after `llhd.wait`, can be hoisted out of the process if their result is not live across any wait ops. Almost all probes left after the Mem2Reg pass can be hoisted.

In the future, this pass should also hoist drives out of processes and promote the driven value to process results. This will remove all drives from combinational processes, such that only drives encoding register/latch behaviour remain.