### PR TITLE
[LowerSCFToCalyx] Lower Arith SubFOp

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -307,7 +307,7 @@ public:
                              AndIOp, XOrIOp, OrIOp, ExtUIOp, ExtSIOp, TruncIOp,
                              MulIOp, DivUIOp, DivSIOp, RemUIOp, RemSIOp,
                              /// floating point
-                             AddFOp, MulFOp, CmpFOp,
+                             AddFOp, SubFOp, MulFOp, CmpFOp,
                              /// others
                              SelectOp, IndexCastOp, CallOp>(
                   [&](auto op) { return buildOp(rewriter, op).succeeded(); })
@@ -365,6 +365,7 @@ private:
   LogicalResult buildOp(PatternRewriter &rewriter, RemUIOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, RemSIOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, AddFOp op) const;
+  LogicalResult buildOp(PatternRewriter &rewriter, SubFOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, MulFOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, CmpFOp op) const;
   LogicalResult buildOp(PatternRewriter &rewriter, ShRUIOp op) const;
@@ -785,6 +786,22 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
               {one, one, one, one, one, width, width, three, width, five, one});
   return buildLibraryBinaryPipeOp<calyx::AddFOpIEEE754>(rewriter, addf, addFOp,
                                                         addFOp.getOut());
+}
+
+LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
+                                     SubFOp subf) const {
+  Location loc = subf.getLoc();
+  IntegerType one = rewriter.getI1Type(), three = rewriter.getIntegerType(3),
+              five = rewriter.getIntegerType(5),
+              width = rewriter.getIntegerType(
+                  subf.getType().getIntOrFloatBitWidth());
+  auto subFOp =
+      getState<ComponentLoweringState>()
+          .getNewLibraryOpInstance<calyx::AddFOpIEEE754>(
+              rewriter, loc,
+              {one, one, one, one, one, width, width, three, width, five, one});
+  return buildLibraryBinaryPipeOp<calyx::AddFOpIEEE754>(rewriter, subf, subFOp,
+                                                        subFOp.getOut());
 }
 
 LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
@@ -2397,7 +2414,7 @@ public:
                       ShRSIOp, AndIOp, XOrIOp, OrIOp, ExtUIOp, TruncIOp,
                       CondBranchOp, BranchOp, MulIOp, DivUIOp, DivSIOp, RemUIOp,
                       RemSIOp, ReturnOp, arith::ConstantOp, IndexCastOp, FuncOp,
-                      ExtSIOp, CallOp, AddFOp, MulFOp, CmpFOp>();
+                      ExtSIOp, CallOp, AddFOp, SubFOp, MulFOp, CmpFOp>();
 
     RewritePatternSet legalizePatterns(&getContext());
     legalizePatterns.add<DummyPattern>(&getContext());

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -290,6 +290,35 @@ module {
 
 // -----
 
+// Test floating point sub
+
+// CHECK:             calyx.group @bb0_0 {
+// CHECK-DAG:               calyx.assign %std_addFN_0.left = %in0 : i32
+// CHECK-DAG:               calyx.assign %std_addFN_0.right = %cst : i32
+// CHECK-DAG:               calyx.assign %subf_0_reg.in = %std_addFN_0.out : i32
+// CHECK-DAG:               calyx.assign %subf_0_reg.write_en = %std_addFN_0.done : i1
+// CHECK-DAG:               %0 = comb.xor %std_addFN_0.done, %true : i1
+// CHECK-DAG:               calyx.assign %std_addFN_0.go = %0 ? %true : i1
+// CHECK-DAG:               calyx.assign %std_addFN_0.subOp = %true : i1
+// CHECK-DAG:               calyx.group_done %subf_0_reg.done : i1
+// CHECK-DAG:             }
+// CHECK:      calyx.group @ret_assign_0 {
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.in = %subf_0_reg.out : i32
+// CHECK-DAG:        calyx.assign %ret_arg0_reg.write_en = %true : i1
+// CHECK-DAG:        calyx.group_done %ret_arg0_reg.done : i1
+// CHECK-DAG:      }
+
+module {
+  func.func @main(%arg0 : f32) -> f32 {
+    %0 = arith.constant 4.2 : f32
+    %1 = arith.subf %arg0, %0 : f32
+
+    return %1 : f32
+  }
+}
+
+// -----
+
 // Test floating point mul
 
 // CHECK:        %cst = calyx.constant @cst_0 <4.200000e+00 : f32> : i32


### PR DESCRIPTION
This patch lowers `arith.subf` in `-lower-scf-to-calyx`.