### PR TITLE
[ESI Runtime] Color output formatting

### DIFF
--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -74,6 +74,12 @@ else()
   endif()
 endif()
 
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt
+  GIT_TAG        11.1.4)
+FetchContent_MakeAvailable(fmt)
+
 # In a Python wheel build, we need to install libraries to different places.
 option(WHEEL_BUILD "Set up the build for a Python wheel." OFF)
 if (WHEEL_BUILD)
@@ -166,6 +172,7 @@ endif()
 target_link_libraries(ESICppRuntime PUBLIC
   ${ZLIB_LIBRARY}
   nlohmann_json::nlohmann_json
+  fmt::fmt-header-only
 )
 if(NOT MSVC)
   target_link_libraries(ESICppRuntime PRIVATE

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Context.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Context.h
@@ -30,7 +30,7 @@ class AcceleratorConnection;
 /// context. It owns all the types, uniquifying them.
 class Context {
 public:
-  Context() : logger(std::make_unique<NullLogger>()) {}
+  Context() : logger(std::make_unique<ConsoleLogger>(Logger::Level::Warning)) {}
   Context(std::unique_ptr<Logger> logger) : logger(std::move(logger)) {}
 
   /// Create a context with a specific logger type.

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Logging.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Logging.h
@@ -165,6 +165,20 @@ private:
   std::ostream &errorStream;
 };
 
+/// A logger that writes to the console. Includes color support.
+class ConsoleLogger : public TSLogger {
+public:
+  /// Create a stream logger that logs to stdout, stderr.
+  ConsoleLogger(Level minLevel);
+  void logImpl(Level level, const std::string &subsystem,
+               const std::string &msg,
+               const std::map<std::string, std::any> *details) override;
+
+private:
+  /// The minimum log level to emit.
+  Level minLevel;
+};
+
 /// A logger that does nothing.
 class NullLogger : public Logger {
 public:

--- a/lib/Dialect/ESI/runtime/cpp/tools/esiquery.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/tools/esiquery.cpp
@@ -63,7 +63,7 @@ int main(int argc, const char *argv[]) {
     }
     return 0;
   } catch (std::exception &e) {
-    std::cerr << "Error: " << e.what() << std::endl;
+    ctxt.getLogger().error("esiquery", e.what());
     return -1;
   }
 }


### PR DESCRIPTION
Adds a `ConsoleLogger` which uses the `fmt` library to add colors to the output when logging to the console. Make it the default logger.