### PR TITLE
[sim] Add emission for plusargs for UPF simulations 

### DIFF
--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -129,8 +129,13 @@ public:
           });
         });
 
-    auto readf = rewriter.create<sv::ReadInOutOp>(loc, regf);
-    auto readv = rewriter.create<sv::ReadInOutOp>(loc, regv);
+    Value readf = rewriter.create<sv::ReadInOutOp>(loc, regf);
+    Value readv = rewriter.create<sv::ReadInOutOp>(loc, regv);
+
+    auto cstTrue = rewriter.create<hw::ConstantOp>(loc, APInt(1, 1));
+    readf = rewriter.create<comb::ICmpOp>(loc, comb::ICmpPredicate::ceq, readf,
+                                          cstTrue);
+
     rewriter.replaceOp(op, {readf, readv});
     return success();
   }

--- a/test/Conversion/SimToSV/plusargs.mlir
+++ b/test/Conversion/SimToSV/plusargs.mlir
@@ -26,21 +26,12 @@ hw.module @plusargs_value(out test: i1, out value: i5) {
   // CHECK-SAME:     emitAsComment
   // CHECK-NEXT:   sv.assign [[BAR_FOUND_DECL]], %false
   // CHECK-NEXT: } else {
-  // CHECK-NEXT:   sv.ifdef  @UPF_SIMULATION {
-  // CHECK-NEXT:     %c0_i5 = hw.constant 0 : i5
-  // CHECK-NEXT:     sv.assign [[BAR_VALUE_DECL]], %c0_i5 {sv.attributes = [
-  // CHECK-SAME:       #sv.attribute<"This dummy assignment exists to avoid undriven lint warnings
-  // CHECK-SAME:       emitAsComment
-  // CHECK-NEXT:     %false = hw.constant false
-  // CHECK-NEXT:     sv.assign [[BAR_FOUND_DECL]], %false
-  // CHECK-NEXT:   } else {
-  // CHECK-NEXT:     sv.initial {
-  // CHECK-NEXT:       %c0_i32 = hw.constant 0 : i32
-  // CHECK-NEXT:       [[BAR_STR:%.*]] = sv.constantStr "bar"
-  // CHECK-NEXT:       [[TMP:%.*]] = sv.system "value$plusargs"([[BAR_STR]], [[BAR_VALUE_DECL]])
-  // CHECK-NEXT:       [[TMP2:%.*]] = comb.icmp bin ne [[TMP]], %c0_i32
-  // CHECK-NEXT:       sv.bpassign [[BAR_FOUND_DECL]], [[TMP2]]
-  // CHECK-NEXT:     }
+  // CHECK-NEXT:   sv.initial {
+  // CHECK-NEXT:     %c0_i32 = hw.constant 0 : i32
+  // CHECK-NEXT:     [[BAR_STR:%.*]] = sv.constantStr "bar"
+  // CHECK-NEXT:     [[TMP:%.*]] = sv.system "value$plusargs"([[BAR_STR]], [[BAR_VALUE_DECL]])
+  // CHECK-NEXT:     [[TMP2:%.*]] = comb.icmp bin ne [[TMP]], %c0_i32
+  // CHECK-NEXT:     sv.bpassign [[BAR_FOUND_DECL]], [[TMP2]]
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
   // CHECK-NEXT: [[BAR_FOUND:%.*]] = sv.read_inout [[BAR_FOUND_DECL]]

--- a/test/Conversion/SimToSV/plusargs.mlir
+++ b/test/Conversion/SimToSV/plusargs.mlir
@@ -34,8 +34,10 @@ hw.module @plusargs_value(out test: i1, out value: i5) {
   // CHECK-NEXT:     sv.bpassign [[BAR_FOUND_DECL]], [[TMP2]]
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
-  // CHECK-NEXT: [[BAR_FOUND:%.*]] = sv.read_inout [[BAR_FOUND_DECL]]
+  // CHECK-NEXT: [[BAR_FOUND_READ:%.*]] = sv.read_inout [[BAR_FOUND_DECL]]
   // CHECK-NEXT: [[BAR_VALUE:%.*]] = sv.read_inout [[BAR_VALUE_DECL]]
+  // CHECK-NEXT: %true = hw.constant true
+  // CHECK-NEXT: [[BAR_FOUND:%.*]] = comb.icmp ceq [[BAR_FOUND_READ]], %true : i1
   // CHECK-NEXT: hw.output [[BAR_FOUND]], [[BAR_VALUE]] : i1, i5
   %0, %1 = sim.plusargs.value "bar" : i5
   hw.output %0, %1 : i1, i5

--- a/test/firtool/plusargs.fir
+++ b/test/firtool/plusargs.fir
@@ -36,7 +36,7 @@ circuit PlusArgTest:
     ; CHECK-NEXT:     sv.bpassign [[FOUND_BAR_REG]], [[FOUND_BAR_VAL]] : i1
     ; CHECK-NEXT:   }
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: [[FOUND_BAR:%.+]] = sv.read_inout [[FOUND_BAR_REG]] : !hw.inout<i1>
+    ; CHECK-NEXT: [[FOUND_BAR_READ:%.+]] = sv.read_inout [[FOUND_BAR_REG]] : !hw.inout<i1>
     ; CHECK-NEXT: [[RESULT_BAR:%.+]] = sv.read_inout [[RESULT_BAR_REG]] : !hw.inout<i32>
-
+    ; CHECK-NEXT: [[FOUND_BAR:%.+]] = comb.icmp ceq [[FOUND_BAR_READ]], %true : i1
     ; CHECK: [[FOUND_FOO]], [[FOUND_BAR]], [[RESULT_BAR]] : i1, i1, i32

--- a/test/firtool/plusargs.fir
+++ b/test/firtool/plusargs.fir
@@ -29,16 +29,11 @@ circuit PlusArgTest:
     ; CHECK-NEXT:   sv.assign [[RESULT_BAR_REG]], %z_i32 {sv.attributes = [#sv.attribute<"This dummy assignment exists to avoid undriven lint warnings (e.g., Verilator UNDRIVEN).", emitAsComment>]} : i32
     ; CHECK-NEXT:   sv.assign [[FOUND_BAR_REG]], %false : i1
     ; CHECK-NEXT: } else {
-    ; CHECK-NEXT:   sv.ifdef @UPF_SIMULATION {
-    ; CHECK-NEXT:     sv.assign [[RESULT_BAR_REG]], %c0_i32 {sv.attributes = [#sv.attribute<"This dummy assignment exists to avoid undriven lint warnings (e.g., Verilator UNDRIVEN).", emitAsComment>]} : i32
-    ; CHECK-NEXT:     sv.assign [[FOUND_BAR_REG]], %false : i1
-    ; CHECK-NEXT:   } else {
-    ; CHECK-NEXT:     sv.initial {
-    ; CHECK-NEXT:       [[FORMAT_BAR:%.+]] = sv.constantStr "foo=%d"
-    ; CHECK-NEXT:       [[TMP_BAR:%.+]] = sv.system "value$plusargs"([[FORMAT_BAR]], [[RESULT_BAR_REG]]) : (!hw.string, !hw.inout<i32>) -> i32
-    ; CHECK-NEXT:       [[FOUND_BAR_VAL:%.+]] = comb.icmp bin ne [[TMP_BAR]], %c0_i32 : i32
-    ; CHECK-NEXT:       sv.bpassign [[FOUND_BAR_REG]], [[FOUND_BAR_VAL]] : i1
-    ; CHECK-NEXT:     }
+    ; CHECK-NEXT:   sv.initial {
+    ; CHECK-NEXT:     [[FORMAT_BAR:%.+]] = sv.constantStr "foo=%d"
+    ; CHECK-NEXT:     [[TMP_BAR:%.+]] = sv.system "value$plusargs"([[FORMAT_BAR]], [[RESULT_BAR_REG]]) : (!hw.string, !hw.inout<i32>) -> i32
+    ; CHECK-NEXT:     [[FOUND_BAR_VAL:%.+]] = comb.icmp bin ne [[TMP_BAR]], %c0_i32 : i32
+    ; CHECK-NEXT:     sv.bpassign [[FOUND_BAR_REG]], [[FOUND_BAR_VAL]] : i1
     ; CHECK-NEXT:   }
     ; CHECK-NEXT: }
     ; CHECK-NEXT: [[FOUND_BAR:%.+]] = sv.read_inout [[FOUND_BAR_REG]] : !hw.inout<i1>


### PR DESCRIPTION
This change adds an alternative method of supporting plusargs in UPF
simulations by ensuring that the plusargs found variable is compared
with case-equals (`found === 1'h1`) to squash the `x` value to `0`.