### PR TITLE
[circt-verilog-lsp] Add inlay hints support for Verilog LSP server

### DIFF
--- a/docs/VerilogLSP.md
+++ b/docs/VerilogLSP.md
@@ -1,0 +1,69 @@
+# CIRCT Verilog LSP
+This document describes the custom commands for the Verilog LSP server.
+
+## Custom Commands
+
+### `verilog/putInlayHintsOnObjects`
+
+This is a custom protocol that allows clients to provide inlay hints for specific objects in Verilog source files. These hints will be displayed inline in the editor.
+
+Example Verilog code where hints can be applied:
+```verilog
+module test();
+    wire foo;  // hint will appear here
+endmodule
+```
+
+The command accepts the following interface for hint specifications:
+```typescript
+interface VerilogUserProvidedInlayHint {
+  // Required: Path to the object (e.g., signal name)
+  path: string;
+  
+  // Required: The hint text to display
+  value: string;
+  
+  // Optional: Root module name containing the object.
+  root?: string;
+  
+  // Optional: Group name for organizing hints. Hints with the same group
+  // can be updated together - new hints will replace old ones in the same group
+  group?: string;
+}
+
+interface VerilogUserProvidedInlayHintParams {
+  hints: VerilogUserProvidedInlayHint[];
+}
+```
+
+Example JSON-RPC request:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "verilog/putInlayHintsOnObjects",
+  "params": {
+    "hints": [
+      {
+        "path": "foo",
+        "root": "test",
+        "value": "hint for foo",
+        "group": "simulation"
+      }
+    ]
+  }
+}
+```
+
+When processed, this will display "hint for foo" as an inlay hint next to the `foo` wire declaration in the `test` module.
+
+The `group` field allows for dynamic updating of hints. When new hints are sent with the same group name, they will replace any existing hints in that group. This is useful for updating hints based on changing conditions, such as simulation values or analysis results. Hints without a group are treated as permanent and won't be replaced by subsequent hint updates.
+
+For example, if the client sends the following hints, the hint for `foo` will be updated to "new hint for foo".
+```json
+{
+  "hints": [
+    { "path": "foo", "value": "new hint for foo", "group": "simulation" }
+  ]
+}
+```

--- a/lib/Tools/circt-verilog-lsp-server/CMakeLists.txt
+++ b/lib/Tools/circt-verilog-lsp-server/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(VerilogServerImpl)
 add_circt_library(CIRCTVerilogLspServerLib
   CirctVerilogLspServerMain.cpp
   LSPServer.cpp
+  Protocol.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/circt/Tools/circt-verilog-lsp-server

--- a/lib/Tools/circt-verilog-lsp-server/LSPServer.h
+++ b/lib/Tools/circt-verilog-lsp-server/LSPServer.h
@@ -10,7 +10,6 @@
 #define LIB_CIRCT_TOOLS_CIRCT_VERILOG_LSP_LSPSERVER_H
 
 #include <memory>
-
 namespace llvm {
 struct LogicalResult;
 } // namespace llvm

--- a/lib/Tools/circt-verilog-lsp-server/Protocol.cpp
+++ b/lib/Tools/circt-verilog-lsp-server/Protocol.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the serialization code for the Verilog specific LSP
+// structs.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Protocol.h"
+#include "llvm/Support/JSON.h"
+
+using namespace circt::lsp;
+
+//===----------------------------------------------------------------------===//
+// VerilogUserProvidedInlayHintParams
+//===----------------------------------------------------------------------===//
+
+bool circt::lsp::fromJSON(const llvm::json::Value &value,
+                          VerilogUserProvidedInlayHint &result,
+                          llvm::json::Path path) {
+  llvm::json::ObjectMapper o(value, path);
+  if (!o)
+    return false;
+
+  if (!o.map("path", result.path) || !o.map("value", result.value))
+    return false;
+
+  (void)o.map("root", result.root);
+  (void)o.map("group", result.group);
+  return true;
+}
+
+bool circt::lsp::fromJSON(const llvm::json::Value &value,
+                          VerilogUserProvidedInlayHintParams &result,
+                          llvm::json::Path path) {
+  llvm::json::ObjectMapper o(value, path);
+  return o && o.map("hints", result.hints);
+}

--- a/lib/Tools/circt-verilog-lsp-server/Protocol.h
+++ b/lib/Tools/circt-verilog-lsp-server/Protocol.h
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains structs for LSP commands that are specific to the Verilog
+// server.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LIB_CIRCT_TOOLS_CIRCTVERILOGSPLSERVER_PROTOCOL_H_
+#define LIB_CIRCT_TOOLS_CIRCTVERILOGSPLSERVER_PROTOCOL_H_
+
+#include "llvm/Support/JSON.h"
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace circt {
+namespace lsp {
+
+//===----------------------------------------------------------------------===//
+// VerilogUserProvidedInlayHint
+//===----------------------------------------------------------------------===//
+
+struct VerilogUserProvidedInlayHint {
+  // The object path to the value.
+  std::string path;
+
+  // The value.
+  std::string value;
+
+  // The root module name (optional).
+  std::optional<std::string> root;
+
+  // The optional id of the hint.
+  std::optional<std::string> group;
+};
+
+/// Add support for JSON serialization.
+bool fromJSON(const llvm::json::Value &value,
+              VerilogUserProvidedInlayHint &result, llvm::json::Path path);
+
+struct VerilogUserProvidedInlayHintParams {
+  std::vector<VerilogUserProvidedInlayHint> hints;
+};
+
+/// Add support for JSON serialization.
+bool fromJSON(const llvm::json::Value &value,
+              VerilogUserProvidedInlayHintParams &result,
+              llvm::json::Path path);
+
+} // namespace lsp
+} // namespace circt
+
+#endif

--- a/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/VerilogServer.h
+++ b/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/VerilogServer.h
@@ -26,6 +26,8 @@ struct Diagnostic;
 struct Position;
 struct Location;
 struct TextDocumentContentChangeEvent;
+struct Range;
+struct InlayHint;
 class URIForFile;
 } // namespace lsp
 } // namespace mlir
@@ -37,6 +39,7 @@ using TextDocumentContentChangeEvent =
     mlir::lsp::TextDocumentContentChangeEvent;
 using URIForFile = mlir::lsp::URIForFile;
 using Diagnostic = mlir::lsp::Diagnostic;
+struct VerilogUserProvidedInlayHint;
 
 /// This class implements all of the Verilog related functionality necessary for
 /// a language server. This class allows for keeping the Verilog specific logic
@@ -69,6 +72,13 @@ public:
   /// Find all references of the object pointed at by the given position.
   void findReferencesOf(const URIForFile &uri, const mlir::lsp::Position &pos,
                         std::vector<mlir::lsp::Location> &references);
+
+  /// Get the inlay hints for the range within the given file.
+  void getInlayHints(const URIForFile &uri, const mlir::lsp::Range &range,
+                     std::vector<mlir::lsp::InlayHint> &inlayHints);
+
+  void putInlayHintsOnObjects(
+      const std::vector<circt::lsp::VerilogUserProvidedInlayHint> &params);
 
 private:
   struct Impl;

--- a/test/Tools/circt-verilog-lsp-server/initialize-params.test
+++ b/test/Tools/circt-verilog-lsp-server/initialize-params.test
@@ -7,6 +7,10 @@
 // CHECK-NEXT:  "result": {
 // CHECK-NEXT:    "capabilities": {
 // CHECK-NEXT:      "definitionProvider": true,
+// CHECK-NEXT:      "inlayHintProvider": {
+// CHECK-NEXT:        "refreshSupport": true,
+// CHECK-NEXT:        "resolveSupport": true
+// CHECK-NEXT:      },
 // CHECK-NEXT:      "referencesProvider": true,
 // CHECK-NEXT:      "textDocumentSync": {
 // CHECK-NEXT:        "change": 2,

--- a/test/Tools/circt-verilog-lsp-server/inlay-hints-instance-call.test
+++ b/test/Tools/circt-verilog-lsp-server/inlay-hints-instance-call.test
@@ -1,0 +1,68 @@
+// RUN: circt-verilog-lsp-server -lit-test  --source-location-include-dir=%S  < %s | FileCheck %s
+// REQUIRES: slang
+// Test inlay hints for the module instantiation and function call.
+{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":123,"rootPath":"verilog","capabilities":{},"trace":"off"}}
+// -----
+{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{
+  "uri":"test:///foo.sv",
+  "languageId":"verilog",
+  "version":1,
+  "text":"module child (input a, output b);\n assign b = a;\nendmodule\nfunction void foo(input [2:0] a, output bar);\n assign bar = a[0];\nendfunction\nmodule t(output o1);\n reg o;\n initial begin foo(1, o); end\n child c(o, o1);\nendmodule"
+}}}
+// -----
+// Get inlay hint`
+{"jsonrpc":"2.0","id":1,"method":"textDocument/inlayHint","params":{
+  "textDocument":{"uri":"test:///foo.sv"},
+  "range": {
+    "start": {"line":3,"character":0},
+    "end": {"line":10,"character":0}
+  }
+}}
+// CHECK:        "id": 1,
+// CHECK-NEXT:   "jsonrpc": "2.0",
+// CHECK-NEXT:   "result": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "kind": 1,
+// CHECK-NEXT:       "label": "a: in logic[2:0]:",
+// CHECK-NEXT:       "paddingLeft": false,
+// CHECK-NEXT:       "paddingRight": true,
+// CHECK-NEXT:       "position": {
+// CHECK-NEXT:         "character": 19,
+// CHECK-NEXT:         "line": 8
+// CHECK-NEXT:       }
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "kind": 1,
+// CHECK-NEXT:       "label": "bar: out logic:",
+// CHECK-NEXT:       "paddingLeft": false,
+// CHECK-NEXT:       "paddingRight": true,
+// CHECK-NEXT:       "position": {
+// CHECK-NEXT:         "character": 22,
+// CHECK-NEXT:         "line": 8
+// CHECK-NEXT:       }
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "kind": 1,
+// CHECK-NEXT:       "label": "in logic:",
+// CHECK-NEXT:       "paddingLeft": false,
+// CHECK-NEXT:       "paddingRight": true,
+// CHECK-NEXT:       "position": {
+// CHECK-NEXT:         "character": 9,
+// CHECK-NEXT:         "line": 9
+// CHECK-NEXT:       }
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "kind": 1,
+// CHECK-NEXT:       "label": "out logic:",
+// CHECK-NEXT:       "paddingLeft": false,
+// CHECK-NEXT:       "paddingRight": true,
+// CHECK-NEXT:       "position": {
+// CHECK-NEXT:         "character": 12,
+// CHECK-NEXT:         "line": 9
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ]
+// -----
+{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+// -----
+{"jsonrpc":"2.0","method":"exit"}

--- a/test/Tools/circt-verilog-lsp-server/inlay-hints-user-provided-hints.test
+++ b/test/Tools/circt-verilog-lsp-server/inlay-hints-user-provided-hints.test
@@ -1,0 +1,117 @@
+// RUN: circt-verilog-lsp-server -lit-test  --source-location-include-dir=%S  < %s | FileCheck %s
+// REQUIRES: slang
+{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":123,"rootPath":"verilog","capabilities":{},"trace":"off"}}
+// -----
+{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{
+  "uri":"test:///foo.sv",
+  "languageId":"verilog",
+  "version":1,
+  "text":"module test(); wire foo; reg bar; endmodule"
+}}}
+// -----
+// Find definition of `out`
+{"jsonrpc":"2.0","id":1,"method":"verilog/putInlayHintsOnObjects","params":{
+  "textDocument":{"uri":"test:///foo.sv"},
+  "hints": [
+    {
+      "path": "foo",
+      "value": "hint for foo",
+      "root": "test"
+    },
+    {
+      "path": "bar",
+      "value": "hint for bar",
+      "root": "test",
+      "group": "A"
+    }
+  ]
+}}
+// CHECK:      "id": "refresh_inlay_hints_0",
+// CHECK-NEXT: "jsonrpc": "2.0",
+// CHECK-NEXT: "method": "workspace/inlayHint/refresh",
+// CHECK-NEXT: "params": null
+
+// -----
+{"jsonrpc":"2.0","id":2,"method":"textDocument/inlayHint","params":{
+  "textDocument":{"uri":"test:///foo.sv"},
+  "range": {
+    "start": {"line":0,"character":0},
+    "end": {"line":0,"character":35}
+  }
+}}
+// CHECK:      "id": 2,
+// CHECK-NEXT: "jsonrpc": "2.0",
+// CHECK-NEXT: "result": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": 2,
+// CHECK-NEXT:     "label": "hint for foo",
+// CHECK-NEXT:     "paddingLeft": true,
+// CHECK-NEXT:     "paddingRight": false,
+// CHECK-NEXT:     "position": {
+// CHECK-NEXT:       "character": 23,
+// CHECK-NEXT:       "line": 0
+// CHECK-NEXT:     }
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": 2,
+// CHECK-NEXT:     "label": "hint for bar",
+// CHECK-NEXT:     "paddingLeft": true,
+// CHECK-NEXT:     "paddingRight": false,
+// CHECK-NEXT:     "position": {
+// CHECK-NEXT:       "character": 32,
+// CHECK-NEXT:      "line": 0
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// CHECK-NEXT: ]
+// -----
+{"jsonrpc":"2.0","id":3,"method":"verilog/putInlayHintsOnObjects","params":{
+  "textDocument":{"uri":"test:///foo.sv"},
+  "hints": [
+    {
+      "path": "foo",
+      "value": "additional hint for foo",
+      "root": "test"
+    },
+    {
+      "path": "bar",
+      "value": "new hint for bar",
+      "root": "test",
+      "group": "A"
+    }
+  ]
+}}
+// -----
+{"jsonrpc":"2.0","id":4,"method":"textDocument/inlayHint","params":{
+  "textDocument":{"uri":"test:///foo.sv"},
+  "range": {
+    "start": {"line":0,"character":0},
+    "end": {"line":0,"character":35}
+  }
+}}
+// CHECK:      "id": 4,
+// CHECK-NEXT: "jsonrpc": "2.0",
+// CHECK-NEXT: "result": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": 2,
+// CHECK-NEXT:     "label": "hint for foo/additional hint for foo",
+// CHECK-NEXT:     "paddingLeft": true,
+// CHECK-NEXT:     "paddingRight": false,
+// CHECK-NEXT:     "position": {
+// CHECK-NEXT:       "character": 23,
+// CHECK-NEXT:       "line": 0
+// CHECK-NEXT:     }
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": 2,
+// CHECK-NEXT:     "label": "new hint for bar",
+// CHECK-NEXT:     "paddingLeft": true,
+// CHECK-NEXT:     "paddingRight": false,
+// CHECK-NEXT:     "position": {
+// CHECK-NEXT:       "character": 32,
+// CHECK-NEXT:       "line": 0
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// -----
+{"jsonrpc":"2.0","id":5,"method":"shutdown"}
+// -----
+{"jsonrpc":"2.0","method":"exit"}

--- a/utils/vscode/package.json
+++ b/utils/vscode/package.json
@@ -92,6 +92,11 @@
           "type": "array",
           "description": "A list of include directories for the verilog files processed by the server."
         },
+        "circt-verilog-lsp.verilog_static_inlay_hint_files": {
+          "scope": "resource",
+          "type": "array",
+          "description": "A list of files for adding inlay hints to objects"
+        },
         "circt-verilog-lsp.onSettingsChanged": {
           "type": "string",
           "default": "restart",


### PR DESCRIPTION
This commit adds inlay hint support to the Verilog LSP server. It currently supports two ways of displaying inlay hints:

1. Built-in inlay hints for function calls and module instantiations, showing port types and directions (in/out/inout).

2. User-provided inlay hints through a custom LSP extension method "verilog/putUserProvidedInlayHints", allowing clients to add contextual information to Verilog symbols.

The implementation includes:
- Protocol extensions for user-provided inlay hints
- Visitor pattern for traversing the AST to find hint locations
- Support for refreshing hints when they are updated