### PR TITLE
[circt-verilog-lsp] Add hover support

### DIFF
--- a/include/circt/Tools/circt-verilog-lsp-server/CirctVerilogLspServerMain.h
+++ b/include/circt/Tools/circt-verilog-lsp-server/CirctVerilogLspServerMain.h
@@ -34,13 +34,18 @@ namespace circt {
 namespace lsp {
 struct VerilogServerOptions {
   VerilogServerOptions(const std::vector<std::string> &libDirs,
-                       const std::vector<std::string> &extraSourceLocationDirs)
-      : libDirs(libDirs), extraSourceLocationDirs(extraSourceLocationDirs) {}
+                       const std::vector<std::string> &extraSourceLocationDirs,
+                       int32_t hoverContextLineCount)
+      : libDirs(libDirs), extraSourceLocationDirs(extraSourceLocationDirs),
+        hoverContextLineCount(hoverContextLineCount) {}
   /// Additional list of RTL directories to search.
   const std::vector<std::string> &libDirs;
 
   /// Additional list of external source directories to search.
   const std::vector<std::string> &extraSourceLocationDirs;
+
+  /// Number of lines to include in the hover documentation.
+  const int32_t hoverContextLineCount;
 };
 // namespace lsp
 

--- a/lib/Tools/circt-verilog-lsp-server/Utils/LSPUtils.cpp
+++ b/lib/Tools/circt-verilog-lsp-server/Utils/LSPUtils.cpp
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "LSPUtils.h"
+#include "mlir/Support/IndentedOstream.h"
 #include "mlir/Tools/lsp-server-support/Logging.h"
-
 void circt::lsp::Logger::error(Twine message) {
   mlir::lsp::Logger::error("{}", message);
 }
@@ -23,4 +23,9 @@ void circt::lsp::Logger::info(Twine message) {
 
 void circt::lsp::Logger::debug(Twine message) {
   mlir::lsp::Logger::debug("{}", message);
+}
+
+void circt::lsp::printReindented(llvm::raw_ostream &os, StringRef content) {
+  mlir::raw_indented_ostream indentedOs(os);
+  indentedOs.printReindented(content);
 }

--- a/lib/Tools/circt-verilog-lsp-server/Utils/LSPUtils.h
+++ b/lib/Tools/circt-verilog-lsp-server/Utils/LSPUtils.h
@@ -13,6 +13,8 @@ void error(Twine message);
 void info(Twine message);
 void debug(Twine message);
 } // namespace Logger
+
+void printReindented(llvm::raw_ostream &os, StringRef content);
 } // namespace lsp
 } // namespace circt
 #endif // CIRCT_SUPPORT_LSPUTILS_H

--- a/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/VerilogServer.h
+++ b/lib/Tools/circt-verilog-lsp-server/VerilogServerImpl/VerilogServer.h
@@ -29,6 +29,7 @@ struct TextDocumentContentChangeEvent;
 struct Range;
 struct InlayHint;
 class URIForFile;
+struct Hover;
 } // namespace lsp
 } // namespace mlir
 
@@ -79,6 +80,10 @@ public:
 
   void putInlayHintsOnObjects(
       const std::vector<circt::lsp::VerilogUserProvidedInlayHint> &params);
+
+  /// Get the hover information for the given position.
+  std::optional<mlir::lsp::Hover> findHover(const URIForFile &uri,
+                                            const mlir::lsp::Position &pos);
 
 private:
   struct Impl;

--- a/test/Tools/circt-verilog-lsp-server/hover.test
+++ b/test/Tools/circt-verilog-lsp-server/hover.test
@@ -1,0 +1,77 @@
+// RUN: circt-verilog-lsp-server -lit-test  --source-location-include-dir=%S  < %s | FileCheck %s
+// REQUIRES: slang
+// UNSUPPORTED: valgrind
+{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":123,"rootPath":"verilog","capabilities":{},"trace":"off"}}
+// -----
+{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{
+  "uri":"test:///foo.sv",
+  "languageId":"verilog",
+  "version":1,
+  "text":"module test(// @[include/test.mlir:2:5]\noutput out// @[include/test.mlir:2:{24,25}]\n); assign out = 1'h1; // @[include/test.mlir:3:14, :4:9]\nendmodule"
+}}}
+// -----
+// Find hover of `out`
+{"jsonrpc":"2.0","id":1,"method":"textDocument/hover","params":{
+  "textDocument":{"uri":"test:///foo.sv"},
+  "position":{"line":2,"character":10}
+}}
+// CHECK:       "id": 1,
+// CHECK-NEXT:  "jsonrpc": "2.0",
+// CHECK-NEXT:  "result": {
+// CHECK-NEXT:    "contents": {
+// CHECK-NEXT:      "kind": "markdown",
+// CHECK-NEXT:      "value":
+// CHECK-SAME:        "### Type
+// CHECK-SAME:        `logic`
+// CHESK-SAME:        ***
+// CHECK-SAME:        ### Definition
+// CHECK-SAME:        ```verilog\n
+// CHECK-SAME:        output out// @[include/test.mlir:2:{24,25}]\n
+// CHECK-SAME:        ```\n
+// CHECK-SAME:        [Go To Definition](test:///foo.sv#L2)\n
+// CHECK-SAME:        ***\n"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    "range": {
+// CHECK-NEXT:      "end": {
+// CHECK-NEXT:        "character": 14,
+// CHECK-NEXT:        "line": 2
+// CHECK-NEXT:      },
+// CHECK-NEXT:      "start": {
+// CHECK-NEXT:        "character": 10,
+// CHECK-NEXT:        "line": 2
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// -----
+// Find definition of `include/test.mlir:2:5`
+{"jsonrpc":"2.0","id":2,"method":"textDocument/hover","params":{
+  "textDocument":{"uri":"test:///foo.sv"},
+  "position":{"line":0,"character":20}
+}}
+// CHECK:       "id": 2,
+// CHECK-NEXT:  "jsonrpc": "2.0",
+// CHECK-NEXT:  "result": {
+// CHECK-NEXT:    "contents": {
+// CHECK-NEXT:      "kind": "markdown",
+// CHECK-NEXT:      "value":
+// CHECK-SAME:        "### External Source\n
+// CHECK-SAME:        ```mlir\n
+// CHECK-SAME:        module {\n
+// CHECK-SAME:            hw.module @test(out out: i1) {\n
+// CHECK-SAME:                %0 = hw.constant true\n
+// CHECK-SAME:        ```\n
+// CHECK-SAME:        [Go To External Source]({{.*}}test.mlir#L1)"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    "range": {
+// CHECK-NEXT:      "end": {
+// CHECK-NEXT:        "character": 38,
+// CHECK-NEXT:        "line": 0
+// CHECK-NEXT:      },
+// CHECK-NEXT:      "start": {
+// CHECK-NEXT:        "character": 17,
+// CHECK-NEXT:        "line": 0
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// -----
+{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+// -----
+{"jsonrpc":"2.0","method":"exit"}

--- a/test/Tools/circt-verilog-lsp-server/initialize-params.test
+++ b/test/Tools/circt-verilog-lsp-server/initialize-params.test
@@ -7,6 +7,7 @@
 // CHECK-NEXT:  "result": {
 // CHECK-NEXT:    "capabilities": {
 // CHECK-NEXT:      "definitionProvider": true,
+// CHECK-NEXT:      "hoverProvider": true,
 // CHECK-NEXT:      "inlayHintProvider": {
 // CHECK-NEXT:        "refreshSupport": true,
 // CHECK-NEXT:        "resolveSupport": true

--- a/tools/circt-verilog-lsp-server/circt-verilog-lsp-server.cpp
+++ b/tools/circt-verilog-lsp-server/circt-verilog-lsp-server.cpp
@@ -68,6 +68,16 @@ int main(int argc, char **argv) {
       llvm::cl::value_desc("directory"), llvm::cl::Prefix);
 
   //===--------------------------------------------------------------------===//
+  // Hover Context
+  //===--------------------------------------------------------------------===//
+
+  llvm::cl::opt<int32_t> hoverLineContext{
+      "hover-line-context",
+      llvm::cl::desc("Number of lines to include in the hover context"),
+      llvm::cl::init(3),
+  };
+
+  //===--------------------------------------------------------------------===//
   // Testing
   //===--------------------------------------------------------------------===//
 
@@ -101,6 +111,7 @@ int main(int argc, char **argv) {
                                      prettyPrint);
 
   // Configure the servers and start the main language server.
-  circt::lsp::VerilogServerOptions options(libDirs, sourceLocationIncludeDirs);
+  circt::lsp::VerilogServerOptions options(libDirs, sourceLocationIncludeDirs,
+                                           hoverLineContext);
   return failed(circt::lsp::CirctVerilogLspServerMain(options, transport));
 }


### PR DESCRIPTION
Add hover functionality to the CIRCT Verilog LSP server. This includes hover provider capability in server initialization and hover context line configuration option.

The implementation adds hover support for Verilog symbols showing type information, definition location with source code, and links to source locations. It also implements hover for external source locations showing context-aware source code snippets and links to external files.

The hover feature provides rich information when hovering over Verilog symbols (showing type and definition) and source location annotations (showing external source contents such as MLIR and scala).