### PR TITLE
[ESI] Simple FromHost DMA engine

### DIFF
--- a/frontends/PyCDE/src/pycde/bsp/common.py
+++ b/frontends/PyCDE/src/pycde/bsp/common.py
@@ -912,9 +912,13 @@ def ChannelEngineService(
           mmio_appid = esi.AppID(idbase + ".mmio")
           eng_inputs["mmio"] = esi.MMIO.read_write(mmio_appid)
           eng_details["mmio"] = mmio_appid
-        if hasattr(engine_mod, "hostmem"):
-          eng_inputs["hostmem"] = esi.HostMem.write_from_bundle(
-              esi.AppID(idbase + ".hostmem"), engine_mod.hostmem.type)
+        if hasattr(engine_mod, "hostmem_write"):
+          eng_inputs["hostmem_write"] = esi.HostMem.write_from_bundle(
+              esi.AppID(idbase + ".hostmem_write"),
+              engine_mod.hostmem_write.type)
+        if hasattr(engine_mod, "hostmem_read"):
+          eng_inputs["hostmem_read"] = esi.HostMem.read_from_bundle(
+              esi.AppID(idbase + ".hostmem_read"), engine_mod.hostmem_read.type)
         engine = engine_mod(appid=eng_appid, **eng_inputs)
         engine_rec = bundles.emit_engine(engine, details=eng_details)
         engine_rec.add_record(bundle, {bc.name: {}})

--- a/frontends/PyCDE/src/pycde/bsp/cosim.py
+++ b/frontends/PyCDE/src/pycde/bsp/cosim.py
@@ -13,9 +13,8 @@ from ..types import (Bits, Bundle, BundledChannel, Channel, ChannelDirection,
 from ..constructs import ControlReg, NamedWire, Reg, Wire
 from .. import esi
 
-from .common import (ChannelEngineService, ChannelHostMem, ChannelMMIO,
-                     DummyFromHostEngine, DummyToHostEngine)
-from .dma import OneItemBuffersToHost
+from .common import (ChannelEngineService, ChannelHostMem, ChannelMMIO)
+from .dma import OneItemBuffersFromHost, OneItemBuffersToHost
 
 from ..circt import ir
 from ..circt.dialects import esi as raw_esi
@@ -52,7 +51,7 @@ def CosimBSP(user_module: Type[Module], emulate_dma: bool = False) -> Module:
     def build(ports):
       user_module(clk=ports.clk, rst=ports.rst)
       if emulate_dma:
-        ChannelEngineService(OneItemBuffersToHost, DummyFromHostEngine)(
+        ChannelEngineService(OneItemBuffersToHost, OneItemBuffersFromHost)(
             None,
             appid=esi.AppID("__channel_engines"),
             clk=ports.clk,

--- a/frontends/PyCDE/src/pycde/bsp/dma.py
+++ b/frontends/PyCDE/src/pycde/bsp/dma.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from ..common import Clock, Input, InputChannel, Reset
+from ..common import Clock, Input, InputChannel, OutputChannel, Reset
 from ..constructs import Mux, NamedWire, Wire
 from ..module import modparams, generator
 from ..types import Bits, Channel, StructType, Type, UInt
@@ -40,7 +40,7 @@ def OneItemBuffersToHost(client_type: Type):
     mmio = Input(esi.MMIO.read_write.type)
     xfer_data_type = StructType([("valid", Bits(8)),
                                  ("client_data", client_type)])
-    hostmem = Input(esi.HostMem.write_req_bundle_type(xfer_data_type))
+    hostmem_write = Input(esi.HostMem.write_req_bundle_type(xfer_data_type))
 
     @generator
     def build(ports):
@@ -98,6 +98,114 @@ def OneItemBuffersToHost(client_type: Type):
               "client_data": joined.b
           },
       }))
-      ports.hostmem.unpack(req=hostwr)
+      ports.hostmem_write.unpack(req=hostwr)
 
   return OneItemBuffersToHost
+
+
+def OneItemBuffersFromHost(client_type: Type):
+  """Create a simple, non-performant DMA-base from host communication channel.
+
+  1) Host sends address of buffer address via MMIO write to register 0x08.
+  2) Host sends address of completion address via MMIO write to register 0x10.
+  3) Device reads data from said buffer and sends down the channel. Only
+     initiates the transfer if the output channel is ready so as to not cause
+     contention / deadlock in the HostMem service. This feature should probably
+     be implemented by HostMem.
+  4) Device writes '1' to the first byte of the completion buffer to signal that
+     the transfer is done.
+  """
+
+  class OneItemBuffersFromHost(esi.EngineModule):
+
+    @property
+    def TypeName(self):
+      return "OneItemBuffersFromHost"
+
+    clk = Clock()
+    rst = Reset()
+
+    # The channel whose messages we are sending to the host.
+    output_channel = OutputChannel(client_type)
+
+    # Since we cannot produce service requests (shortcoming of the ESI
+    # compiler), the module (usually a service implementation) must issue the
+    # service requests for us then connect the input ports.
+    mmio = Input(esi.MMIO.read_write.type)
+    xfer_data_type = Bits(8)
+    hostmem_write = Input(esi.HostMem.write_req_bundle_type(xfer_data_type))
+    hostmem_read = Input(esi.HostMem.read_bundle_type(client_type))
+
+    @generator
+    def build(ports):
+      clk = ports.clk
+      rst = ports.rst
+
+      # Set up the MMIO interface to receive the buffer locations.
+      mmio_resp_chan = Wire(Channel(Bits(64)))
+      mmio_rw = ports.mmio
+      mmio_cmd_chan_raw = mmio_rw.unpack(data=mmio_resp_chan)['cmd']
+      mmio_cmd_chan, mmio_cmd_fork_resp = mmio_cmd_chan_raw.fork(clk, rst)
+
+      # Create a response channel which always responds with 0.
+      mmio_resp_data = NamedWire(Bits(64)(0), "mmio_resp_data")
+      mmio_resp_chan.assign(
+          mmio_cmd_fork_resp.transform(lambda _: mmio_resp_data))
+
+      # Route the MMIO command
+      _, _, mmio_cmd = mmio_cmd_chan.snoop()
+      mailbox_names = ["null", "buffer_loc", "completion_addr"]
+      num_sinks = len(mailbox_names)
+      mmio_offset_words = NamedWire((mmio_cmd.offset.as_bits()[3:]).as_uint(),
+                                    "mmio_offset_words")
+      addr_above = mmio_offset_words >= UInt(32)(num_sinks)
+      addr_is_zero = mmio_offset_words == UInt(32)(0)
+      force_to_null = NamedWire(addr_above | ~addr_is_zero | mmio_cmd.write,
+                                "force_to_null")
+      cmd_sink_sel = Mux(force_to_null,
+                         Bits(clog2(num_sinks))(0),
+                         mmio_offset_words.as_bits()[:clog2(num_sinks)])
+      mmio_data_only_chan = mmio_cmd_chan.transform(lambda m: m.data)
+      demuxed = esi.ChannelDemux(mmio_data_only_chan, cmd_sink_sel, num_sinks)
+      mailbox_mod = esi.Mailbox(Bits(64))
+      mailboxes = [
+          mailbox_mod(clk=clk,
+                      rst=rst,
+                      input=c,
+                      instance_name="mailbox_" + name)
+          for name, c in zip(mailbox_names, demuxed)
+      ]
+      [_, buffer_loc, completion_loc] = mailboxes
+      buffer_loc_for_read = buffer_loc.output
+
+      output_chan = Wire(Channel(client_type))
+      ports.output_channel = output_chan
+
+      # Only issue a read request if the output channel is ready. (And the
+      # buffer location has been written.)
+      read_req = buffer_loc_for_read.wait_for_ready(output_chan).transform(
+          lambda m: esi.HostMem.ReadReqType({
+              "address": m.as_uint(),
+              "tag": 0,
+          }))
+      # Issue the read data while getting the trigger signal for the completion
+      # write.
+      read_resp = ports.hostmem_read.unpack(req=read_req)['resp']
+      read_resp_for_out, read_resp_write_trigger = read_resp.fork(clk, rst)
+      output_chan.assign(read_resp_for_out.transform(lambda d: d.data))
+
+      # Issue the completion write request once the data has been read.
+      write_ch_type = esi.HostMem.write_req_channel_type(
+          OneItemBuffersFromHost.xfer_data_type)
+      completion_write = Channel.join(completion_loc.output,
+                                      read_resp_write_trigger)
+      write_done_chan = completion_write.transform(lambda m: write_ch_type({
+          "address": m.a.as_uint(),
+          "tag": 0,
+          "data": Bits(8)(1)
+      }))
+
+      # Unpack the write port, but ignore the write confirmation.
+      ports.hostmem_write.unpack(req=write_done_chan)
+
+  return OneItemBuffersFromHost

--- a/frontends/PyCDE/src/pycde/bsp/xrt.py
+++ b/frontends/PyCDE/src/pycde/bsp/xrt.py
@@ -12,8 +12,8 @@ from ..types import Array, Bits, Channel, UInt
 from .. import esi
 
 from .common import (ChannelEngineService, ChannelHostMem, ChannelMMIO,
-                     DummyFromHostEngine, MMIOIndirection, Reset)
-from .dma import OneItemBuffersToHost
+                     MMIOIndirection, Reset)
+from .dma import OneItemBuffersFromHost, OneItemBuffersToHost
 
 import glob
 import pathlib
@@ -264,7 +264,7 @@ def XrtBSP(user_module):
       clk = ports.ap_clk
       rst = ~ports.ap_resetn
 
-      ChannelEngineService(OneItemBuffersToHost, DummyFromHostEngine)(
+      ChannelEngineService(OneItemBuffersToHost, OneItemBuffersFromHost)(
           None, appid=esi.AppID("__channel_engines"), clk=clk, rst=rst)
 
       # Set up the MMIO service and tie it to the AXI-lite channels.
@@ -347,7 +347,7 @@ def XrtBSP(user_module):
       # TODO: Test reads > HostMemDataWidthBytes. I'm pretty sure this is wrong
       # for lengths >512bits but initially we won't be transferring >512 bits.
       ports.m_axi_gmem_ARSIZE = clog2(HostMemDataWidthBytes)
-      ports.m_axi_gmem_ARLEN = (read_req_data.length /
+      ports.m_axi_gmem_ARLEN = ((read_req_data.length - 1) /
                                 HostMemDataWidthBytes).as_uint(8)
       ports.m_axi_gmem_ARBURST = Bits(2)(1)  # INCR
 

--- a/frontends/PyCDE/src/pycde/signals.py
+++ b/frontends/PyCDE/src/pycde/signals.py
@@ -788,6 +788,19 @@ class ChannelSignal(Signal):
     both_ready.assign(a_rdy & b_rdy)
     return abuf, bbuf
 
+  def wait_for_ready(self, other: ChannelSignal) -> ChannelSignal:
+    """Return a channel which doesn't issue valid unless some other channel is
+    ready to recieve data."""
+    from .constructs import Wire
+    from .types import Bits
+    _, other_ready, _ = other.snoop()
+    ready_wire = Wire(Bits(1))
+    data, valid = self.unwrap(ready_wire)
+    out_valid = valid & other_ready
+    out_chan, ready = self.type.wrap(data, out_valid)
+    ready_wire.assign(ready)
+    return out_chan
+
 
 class BundleSignal(Signal):
   """Signal for types.Bundle."""

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/CLI.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/CLI.h
@@ -28,7 +28,8 @@ namespace esi {
 /// Common options and code for ESI runtime tools.
 class CliParser : public CLI::App {
 public:
-  CliParser(const std::string &toolName) : CLI::App(toolName) {
+  CliParser(const std::string &toolName)
+      : CLI::App(toolName), debug(false), verbose(false) {
     add_option("backend", backend, "Backend to use for connection")->required();
     add_option("connection", connStr,
                "Connection string to use for accelerator communication")

--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Engines.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Engines.h
@@ -110,9 +110,11 @@ struct RegisterEngine {
   RegisterEngine(const char *name) { registerEngine(name, &TEngine::create); }
 };
 
+#define CONCAT_(prefix, suffix) prefix##suffix
+#define CONCAT(prefix, suffix) CONCAT_(prefix, suffix)
 #define REGISTER_ENGINE(Name, TEngine)                                         \
-  static ::esi::registry::internal::RegisterEngine<TEngine>                    \
-  __register_engine____LINE__(Name)
+  static ::esi::registry::internal::RegisterEngine<TEngine> CONCAT(            \
+      __register_engine__, __LINE__)(Name)
 
 } // namespace internal
 } // namespace registry


### PR DESCRIPTION
A simple, non-performant DMA-based from host communication channel.

  1) Host sends address of buffer address via MMIO write to register 0x08.
  2) Host sends address of completion address via MMIO write to register 0x10.
  3) Device reads data from said buffer and sends down the channel.
  4) Device writes '1' to the first byte of the completion buffer to signal that
     the transfer is done.
  5) Goto 1.