### PR TITLE
Add a few mux-of-const and reg-of-and/or canonicalizers.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -656,6 +656,38 @@ def MuxNEQ : Pat<
   (MoveNameHint $old, (MuxPrimOp (EQPrimOp $a, $b), $y, $x)),
   [(EqualTypes $x, $y), (KnownWidth $x)]>;
 
+// mux(cond, 0, b) -> and(~cond, b)
+def MuxLHS0 : Pat<
+  (MuxPrimOp:$old $cond, (ConstantOp:$a $_), $b),
+  (MoveNameHint $old, (AndPrimOp (NotPrimOp $cond), $b)),
+  [(ZeroConstantOp $a),
+   (EqualTypes $cond, $a),
+   (EqualTypes $cond, $b)]>;
+
+// mux(cond, 1, b) -> or(cond, b)
+def MuxLHS1 : Pat<
+  (MuxPrimOp:$old $cond, (ConstantOp:$a $_), $b),
+  (MoveNameHint $old, (OrPrimOp $cond, $b)),
+  [(OneConstantOp $a),
+   (EqualTypes $cond, $a),
+   (EqualTypes $cond, $b)]>;
+
+// mux(cond, a, 0) -> and(cond, a)
+def MuxRHS0 : Pat<
+  (MuxPrimOp:$old $cond, $a, (ConstantOp:$b $_)),
+  (MoveNameHint $old, (AndPrimOp $cond, $a)),
+  [(ZeroConstantOp $b),
+   (EqualTypes $cond, $a),
+   (EqualTypes $cond, $b)]>;
+
+// mux(cond, a, 1) -> or(~cond, a)
+def MuxRHS1 : Pat<
+  (MuxPrimOp:$old $cond, $a, (ConstantOp:$b $_)),
+  (MoveNameHint $old, (OrPrimOp (NotPrimOp $cond), $a)),
+  [(OneConstantOp $b),
+   (EqualTypes $cond, $a),
+   (EqualTypes $cond, $b)]>;
+
 // mux(cond : u0, a, b) -> mux(0 : u1, a, b)
 def MuxPadSel : Pat<
   (MuxPrimOp:$old $cond, $a, $b),

--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -657,7 +657,7 @@ def MuxNEQ : Pat<
   [(EqualTypes $x, $y), (KnownWidth $x)]>;
 
 // mux(cond, 0, b) -> and(~cond, b)
-def MuxLHS0 : Pat<
+def MuxLhsZero : Pat<
   (MuxPrimOp:$old $cond, (ConstantOp:$a $_), $b),
   (MoveNameHint $old, (AndPrimOp (NotPrimOp $cond), $b)),
   [(ZeroConstantOp $a),
@@ -665,7 +665,7 @@ def MuxLHS0 : Pat<
    (EqualTypes $cond, $b)]>;
 
 // mux(cond, 1, b) -> or(cond, b)
-def MuxLHS1 : Pat<
+def MuxLhsOne : Pat<
   (MuxPrimOp:$old $cond, (ConstantOp:$a $_), $b),
   (MoveNameHint $old, (OrPrimOp $cond, $b)),
   [(OneConstantOp $a),
@@ -673,7 +673,7 @@ def MuxLHS1 : Pat<
    (EqualTypes $cond, $b)]>;
 
 // mux(cond, a, 0) -> and(cond, a)
-def MuxRHS0 : Pat<
+def MuxRhsZero : Pat<
   (MuxPrimOp:$old $cond, $a, (ConstantOp:$b $_)),
   (MoveNameHint $old, (AndPrimOp $cond, $a)),
   [(ZeroConstantOp $b),
@@ -681,7 +681,7 @@ def MuxRHS0 : Pat<
    (EqualTypes $cond, $b)]>;
 
 // mux(cond, a, 1) -> or(~cond, a)
-def MuxRHS1 : Pat<
+def MuxRhsOne : Pat<
   (MuxPrimOp:$old $cond, $a, (ConstantOp:$b $_)),
   (MoveNameHint $old, (OrPrimOp (NotPrimOp $cond), $a)),
   [(OneConstantOp $b),

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1472,12 +1472,12 @@ public:
 
 void MuxPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                             MLIRContext *context) {
-  results
-      .add<MuxPad, MuxSharedCond, patterns::MuxEQOperands,
-           patterns::MuxEQOperandsSwapped, patterns::MuxNEQ, patterns::MuxNot,
-           patterns::MuxSameTrue, patterns::MuxSameFalse,
-           patterns::NarrowMuxLHS, patterns::NarrowMuxRHS, patterns::MuxPadSel>(
-          context);
+  results.add<MuxPad, MuxSharedCond, patterns::MuxEQOperands,
+              patterns::MuxEQOperandsSwapped, patterns::MuxNEQ,
+              patterns::MuxNot, patterns::MuxSameTrue, patterns::MuxSameFalse,
+              patterns::NarrowMuxLHS, patterns::NarrowMuxRHS,
+              patterns::MuxPadSel, patterns::MuxLHS0, patterns::MuxLHS1,
+              patterns::MuxRHS0, patterns::MuxRHS1>(context);
 }
 
 void Mux2CellIntrinsicOp::getCanonicalizationPatterns(

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1476,8 +1476,8 @@ void MuxPrimOp::getCanonicalizationPatterns(RewritePatternSet &results,
               patterns::MuxEQOperandsSwapped, patterns::MuxNEQ,
               patterns::MuxNot, patterns::MuxSameTrue, patterns::MuxSameFalse,
               patterns::NarrowMuxLHS, patterns::NarrowMuxRHS,
-              patterns::MuxPadSel, patterns::MuxLHS0, patterns::MuxLHS1,
-              patterns::MuxRHS0, patterns::MuxRHS1>(context);
+              patterns::MuxPadSel, patterns::MuxLhsZero, patterns::MuxLhsOne,
+              patterns::MuxRhsZero, patterns::MuxRhsOne>(context);
 }
 
 void Mux2CellIntrinsicOp::getCanonicalizationPatterns(
@@ -2256,6 +2256,73 @@ struct FoldResetMux : public mlir::RewritePattern {
 };
 } // namespace
 
+namespace {
+// This canonicalizer provides the following patterns:
+//
+// - and(reg, x) -> 0 if reset is 0
+// - or(reg, x)  -> 1 if reset is 1
+//
+// Justification: if we assume the register currently has the value of its
+// reset, and if that means the next value of the register is unchanged, then we
+// can assume the register will always have its reset value.
+struct FoldResetAndOr : public mlir::OpRewritePattern<RegResetOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(RegResetOp op,
+                                PatternRewriter &rewriter) const override {
+    // Do not fold the register away if it is important.
+    if (hasDontTouch(op.getOperation()) || !AnnotationSet(op).empty() ||
+        op.isForceable())
+      return failure();
+
+    // This canonicalization only applies when the register holds 1 bit.
+    auto type = dyn_cast<UIntType>(op.getResult().getType());
+    if (!type || type.getWidthOrSentinel() != 1)
+      return failure();
+
+    // This canonicalization only applies when the reset is a constant.
+    auto reset =
+        dyn_cast_or_null<ConstantOp>(op.getResetValue().getDefiningOp());
+    if (!reset)
+      return failure();
+
+    auto value = reset.getValue();
+
+    // Find the one true connect, or bail.
+    auto connect = getSingleConnectUserOf(op.getResult());
+    if (!connect)
+      return failure();
+
+    auto *src = connect.getSrc().getDefiningOp();
+    if (!src)
+      return failure();
+
+    if (value == 0) {
+      if (auto srcAnd = dyn_cast<AndPrimOp>(src)) {
+        if (srcAnd.getLhs().getDefiningOp() == op ||
+            srcAnd.getRhs().getDefiningOp() == op) {
+          rewriter.eraseOp(connect);
+          replaceOpAndCopyName(rewriter, op, reset.getResult());
+          return success();
+        }
+      }
+    }
+
+    if (value == 1) {
+      if (auto srcOr = dyn_cast<OrPrimOp>(src)) {
+        if (srcOr.getLhs().getDefiningOp() == op ||
+            srcOr.getRhs().getDefiningOp() == op) {
+          rewriter.eraseOp(connect);
+          replaceOpAndCopyName(rewriter, op, reset.getResult());
+          return success();
+        }
+      }
+    }
+
+    return failure();
+  }
+};
+} // namespace
+
 static bool isDefinedByOneConstantOp(Value v) {
   if (auto c = v.getDefiningOp<ConstantOp>())
     return c.getValue().isOne();
@@ -2279,7 +2346,8 @@ canonicalizeRegResetWithOneReset(RegResetOp reg, PatternRewriter &rewriter) {
 
 void RegResetOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.add<patterns::RegResetWithZeroReset, FoldResetMux>(context);
+  results.add<patterns::RegResetWithZeroReset, FoldResetMux, FoldResetAndOr>(
+      context);
   results.add(canonicalizeRegResetWithOneReset);
   results.add(demoteForceableIfUnused<RegResetOp>);
 }
@@ -3156,10 +3224,57 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
   return success();
 }
 
+/// If a register latches to a constant, replace the register with a constant.
+/// Recognizes the following and/or structures:
+/// - connect(reg, and(x, reg)) -> 0
+/// - connect(reg, and(reg, x)) -> 0
+/// - connect(reg, or(x, reg))  -> 1
+/// - connect(reg, or(reg, x))  -> 1
+static LogicalResult foldAndOrLatch(RegOp reg, PatternRewriter &rewriter) {
+  // This canonicalization only applies when the register holds 1 bit.
+  auto type = dyn_cast<UIntType>(reg.getResult().getType());
+  if (!type || type.getWidthOrSentinel() != 1)
+    return failure();
+  
+  // Find the one true connect, or bail.
+  auto connect = getSingleConnectUserOf(reg.getResult());
+  if (!connect)
+    return failure();
+
+  auto *src = connect.getSrc().getDefiningOp();
+  if (!src)
+    return failure();
+
+  if (auto srcAnd = dyn_cast<AndPrimOp>(src)) {
+    if (srcAnd.getLhs().getDefiningOp() == reg ||
+        srcAnd.getRhs().getDefiningOp() == reg) {
+      auto attr = getIntAttr(type, APInt(1, 0));
+      replaceOpWithNewOpAndCopyName<ConstantOp>(rewriter, reg, type, attr);
+      connect->erase();
+      return success();
+    }
+  }
+
+  if (auto srcOr = dyn_cast<OrPrimOp>(src)) {
+    if (srcOr.getLhs().getDefiningOp() == reg ||
+        srcOr.getRhs().getDefiningOp() == reg) {
+      auto attr = getIntAttr(type, APInt(1, 1));
+      replaceOpWithNewOpAndCopyName<ConstantOp>(rewriter, reg, type, attr);
+      connect->erase();
+      return success();
+    }
+  }
+
+  return failure();
+}
+
 LogicalResult RegOp::canonicalize(RegOp op, PatternRewriter &rewriter) {
-  if (!hasDontTouch(op.getOperation()) && !op.isForceable() &&
-      succeeded(foldHiddenReset(op, rewriter)))
-    return success();
+  if (!hasDontTouch(op.getOperation()) && !op.isForceable()) {
+    if (succeeded(foldHiddenReset(op, rewriter)))
+      return success();
+    if (succeeded(foldAndOrLatch(op, rewriter)))
+      return success();
+  }
 
   if (succeeded(demoteForceableIfUnused(op, rewriter)))
     return success();

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -571,7 +571,11 @@ firrtl.module @Mux(in %in: !firrtl.uint<4>,
                    out %out3: !firrtl.uint<1>,
                    out %out4: !firrtl.uint<4>,
                    out %out5: !firrtl.uint<1>,
-                   out %out6: !firrtl.uint<1>) {
+                   out %out6: !firrtl.uint<1>,
+                   out %out7: !firrtl.uint<1>,
+                   out %out8: !firrtl.uint<1>,
+                   out %out9: !firrtl.uint<1>,
+                   out %out10: !firrtl.uint<1>) {
   // CHECK: firrtl.matchingconnect %out, %in
   %0 = firrtl.int.mux2cell (%cond, %in, %in) : (!firrtl.uint<1>, !firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<4>
   firrtl.connect %out, %0 : !firrtl.uint<4>, !firrtl.uint<4>
@@ -634,6 +638,32 @@ firrtl.module @Mux(in %in: !firrtl.uint<4>,
   // CHECK-NEXT: mux4cell(%[[SEL]],
   %17 = firrtl.int.mux4cell (%val1, %val1, %val2, %val1, %val2) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
   firrtl.matchingconnect %out6, %17 : !firrtl.uint<1>
+
+  // mux(cond, 0, x) -> and(~cond, x)
+  // CHECK: [[V1:%.+]] = firrtl.not %cond
+  // CHECK-NEXT: [[V2:%.+]] = firrtl.and [[V1]], %val1
+  // CHECK-NEXT: firrtl.matchingconnect %out7, [[V2]]
+  %18 = firrtl.mux (%cond, %c0_ui1, %val1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out7, %18 : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // mux(cond, 1, x) -> or(cond, x)
+  // CHECK: [[V:%.+]] = firrtl.or %cond, %val1
+  // CHECK-NEXT: firrtl.matchingconnect %out8, [[V]]
+  %19 = firrtl.mux (%cond, %c1_ui1, %val1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out8, %19 : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // mux(cond, x, 0) -> and(cond, x)
+  // CHECK: [[V:%.+]] = firrtl.and %cond, %val1
+  // CHECK-NEXT: firrtl.matchingconnect %out9, [[V]]
+  %20 = firrtl.mux (%cond, %val1, %c0_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out9, %20 : !firrtl.uint<1>, !firrtl.uint<1>
+
+  // mux(cond, x, 1) -> or(~cond, x)
+  // CHECK: [[V1:%.+]] = firrtl.not %cond
+  // CHECK-NEXT: [[V2:%.+]] = firrtl.or [[V1]], %val1
+  // CHECK-NEXT: firrtl.matchingconnect %out10, [[V2]]
+  %21 = firrtl.mux (%cond, %val1, %c1_ui1) : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+  firrtl.connect %out10, %21 : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // CHECK-LABEL: firrtl.module @Pad


### PR DESCRIPTION
This PR adds four new canonicalization patterns to FIRRTL. 

```
mux(c, 0, x) ==> ~c && x
mux(c, 1, x) ==>  c && x
mux(c, x, 0) ==>  c || x
mux(c, x, 1) ==> ~c || x
```

These canonicalizations are already present for the comb dialect, but we want to run these canonicalizers before lowering layers, which can obscure constant ops behind ports, so I am porting them to the firrtl dialect.

The problem with these canonicalizers is, they interfere with preexisting canonicalizers for registers of this style:

```
connect reg, mux(reset, constant, reg) --> reg ==> 0
``` 

To get this behaviour back, this PR adds four additional canonicalizations for registers:

```
connect reg, reg && x --> reg ==> 0
connect reg, x && reg --> reg ==> 0
connect reg, reg || x --> reg ==> 1
connect reg, x || reg --> reg ==> 1
```

... and for regresets:

```
reset(reg) = 0 --> connect reg, reg && x --> reg ==> 0
reset(reg) = 0 --> connect reg, x && reg --> reg ==> 0
reset(reg) = 1 --> connect reg, reg || x --> reg ==> 1
reset(reg) = 1 --> connect reg, x || reg --> reg ==> 1
```
