### PR TITLE
add support for String literal operations

### DIFF
--- a/lib/Conversion/ImportVerilog/FormatStrings.cpp
+++ b/lib/Conversion/ImportVerilog/FormatStrings.cpp
@@ -137,6 +137,10 @@ struct FormatStringParser {
                  << "string format specifier with width not supported";
         emitLiteral(lit->getValue());
         return success();
+      }else if(auto nvexp = arg.as_if<slang::ast::NamedValueExpression>()) {
+        auto ops = builder.create<moore::ConversionOp>(loc, moore::FormatStringType::get(context.builder.getContext()), context.convertLvalueExpression(arg));
+        fragments.push_back(ops);
+        return success();
       }
       return mlir::emitError(argLoc)
              << "expression cannot be formatted as string";


### PR DESCRIPTION
https://chipsalliance.github.io/sv-tests-results/tests/chapter-11/11.10.1--string_compare.sv.html
add support like display(a) and $display(":assert:('%s' == 'testtesttesttest')", str);
string is available to be used in display function