### PR TITLE
[RTG] Add int_to_immediate op

### DIFF
--- a/frontends/PyRTG/src/pyrtg/resources.py
+++ b/frontends/PyRTG/src/pyrtg/resources.py
@@ -8,19 +8,24 @@ from .rtg import rtg
 from .rtgtest import rtgtest
 from .core import Value
 from .circt import ir
+from .integers import Integer
 
 from typing import Union
 
 
 class Immediate(Value):
 
-  def __init__(self, width: int, value: Union[ir.Value, int]) -> Immediate:
+  def __init__(self, width: int, value: Union[ir.Value, int,
+                                              Integer]) -> Immediate:
     self._width = width
     self._value = value
 
   def _get_ssa_value(self) -> ir.Value:
     if isinstance(self._value, int):
       self = rtg.ConstantOp(rtg.ImmediateAttr.get(self._width, self._value))
+    if isinstance(self._value, Integer):
+      self = rtg.IntToImmediateOp(rtg.ImmediateType.get(self._width),
+                                  self._value)
     return self._value
 
   def get_type(self) -> ir.Type:

--- a/frontends/PyRTG/test/basic.py
+++ b/frontends/PyRTG/test/basic.py
@@ -77,32 +77,32 @@ def test0():
   pass
 
 
-# MLIR-LABEL: rtg.test @test_args
+# MLIR-LABEL: rtg.test @test1_args
 # MLIR-SAME: (entry0 = [[SET:%.+]]: !rtg.set<index>)
 # MLIR-NEXT: [[RAND:%.+]] = rtg.set_select_random [[SET]] : !rtg.set<index>
 # MLIR-NEXT: rtg.label_decl "L_{{[{][{]0[}][}]}}", [[RAND]]
 # MLIR-NEXT: rtg.label local
 # MLIR-NEXT: }
 
-# ELABORATED-LABEL: rtg.test @test_args_Tgt0
+# ELABORATED-LABEL: rtg.test @test1_args_Tgt0
 # CHECK: rtg.label_decl "L_0"
 # CHECK-NEXT: rtg.label local
 # CHECK-NEXT: }
 
-# ASM-LABEL: Begin of test_args
+# ASM-LABEL: Begin of test1_args
 # ASM-EMPTY:
 # ASM-NEXT: L_0:
 # ASM-EMPTY:
-# ASM: End of test_args
+# ASM: End of test1_args
 
 
 @test(("entry0", Set.type(Integer.type())))
-def test_args(set: Set):
+def test1_args(set: Set):
   i = set.get_random()
   Label.declare(r"L_{{0}}", i).place()
 
 
-# MLIR-LABEL: rtg.test @test_labels
+# MLIR-LABEL: rtg.test @test2_labels
 # MLIR-NEXT: index.constant 5
 # MLIR-NEXT: index.constant 3
 # MLIR-NEXT: index.constant 2
@@ -158,7 +158,7 @@ def test_args(set: Set):
 
 # MLIR-NEXT: }
 
-# ELABORATED-LABEL: rtg.test @test_labels
+# ELABORATED-LABEL: rtg.test @test2_labels
 # ELABORATED-NEXT: [[L0:%.+]] = rtg.label_decl "l0"
 # ELABORATED-NEXT: rtg.label global [[L0]]
 # ELABORATED-NEXT: [[L1:%.+]] = rtg.label_decl "l1_0"
@@ -188,7 +188,7 @@ def test_args(set: Set):
 
 # ELABORATED-NEXT: }
 
-# ASM-LABEL: Begin of test_labels
+# ASM-LABEL: Begin of test2_labels
 # ASM-EMPTY:
 # ASM-NEXT: .global l0
 # ASM-NEXT: l0:
@@ -211,11 +211,11 @@ def test_args(set: Set):
 # ASM-NEXT: s1:
 
 # ASM-EMPTY:
-# ASM: End of test_labels
+# ASM: End of test2_labels
 
 
 @test()
-def test_labels():
+def test2_labels():
   l0 = Label.declare("l0")
   l1 = Label.declare_unique("l1")
   l2 = Label.declare_unique("l1")
@@ -260,7 +260,7 @@ def test_labels():
   seq1()
 
 
-# MLIR-NEXT: rtg.test @test_registers_and_immediates()
+# MLIR-LABEL: rtg.test @test3_registers_and_immediates()
 # MLIR-NEXT: [[IMM32:%.+]] = rtg.constant #rtg.isa.immediate<32, 32>
 # MLIR-NEXT: [[IMM21:%.+]] = rtg.constant #rtg.isa.immediate<21, 16>
 # MLIR-NEXT: [[IMM13:%.+]] = rtg.constant #rtg.isa.immediate<13, 9>
@@ -279,7 +279,7 @@ def test_labels():
 
 
 @test()
-def test_registers_and_immediates():
+def test3_registers_and_immediates():
   vreg = IntegerRegister.virtual()
   imm12 = Immediate(12, 8)
   rtgtest.ADDI(vreg, IntegerRegister.t0(), imm12)
@@ -287,3 +287,16 @@ def test_registers_and_immediates():
   rtgtest.BEQ(vreg, IntegerRegister.t2(), Immediate(13, 9))
   rtgtest.JAL(vreg, Immediate(21, 16))
   rtgtest.AUIPC(vreg, Immediate(32, 32))
+
+
+# MLIR-LABEL: rtg.test @test4_integer_to_immediate()
+# MLIR-NEXT: [[V0:%.+]] = rtg.fixed_reg
+# MLIR-NEXT: [[V1:%.+]] = index.constant 2
+# MLIR-NEXT: [[V2:%.+]] = rtg.isa.int_to_immediate [[V1]] : !rtg.isa.immediate<12>
+# MLIR-NEXT: rtgtest.rv32i.addi [[V0]], [[V0]], [[V2]]
+
+
+@test()
+def test4_integer_to_immediate():
+  rtgtest.ADDI(IntegerRegister.t0(), IntegerRegister.t0(),
+               Immediate(12, Integer(2)))

--- a/include/circt/Dialect/RTG/IR/RTGOps.td
+++ b/include/circt/Dialect/RTG/IR/RTGOps.td
@@ -588,3 +588,26 @@ def YieldOp : RTGOp<"yield", [Pure, Terminator]> {
 
   let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
 }
+
+//===----------------------------------------------------------------------===//
+// ISA Target Operations
+//===----------------------------------------------------------------------===//
+
+class RTGISAOp<string mnemonic, list<Trait> traits = []> :
+    Op<RTGDialect, "isa." # mnemonic, traits>;
+
+//===- ISA Immediate Handling Operations ----------------------------------===//
+
+def IntToImmediateOp : RTGISAOp<"int_to_immediate", [Pure]> {
+  let summary = "construct an immediate from an integer";
+  let description = [{
+    Create an immediate of static bit-width from the provided integer. If the
+    integer does not fit in the specified bit-width, an error shall be emitted
+    when executing this operation.
+  }];
+
+  let arguments = (ins Index:$input);
+  let results = (outs ImmediateType:$result);
+
+  let assemblyFormat = "$input `:` qualified(type($result)) attr-dict";
+}

--- a/include/circt/Dialect/RTG/IR/RTGVisitors.h
+++ b/include/circt/Dialect/RTG/IR/RTGVisitors.h
@@ -52,7 +52,9 @@ public:
             RandomizeSequenceOp, EmbedSequenceOp, InterleaveSequencesOp,
             // Sets
             SetCreateOp, SetSelectRandomOp, SetDifferenceOp, SetUnionOp,
-            SetSizeOp>([&](auto expr) -> ResultType {
+            SetSizeOp,
+            // Immediates
+            IntToImmediateOp>([&](auto expr) -> ResultType {
           return thisCast->visitOp(expr, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -112,6 +114,7 @@ public:
   HANDLE(YieldOp, Unhandled);
   HANDLE(FixedRegisterOp, Unhandled);
   HANDLE(VirtualRegisterOp, Unhandled);
+  HANDLE(IntToImmediateOp, Unhandled);
 #undef HANDLE
 };
 

--- a/test/Dialect/RTG/IR/basic.mlir
+++ b/test/Dialect/RTG/IR/basic.mlir
@@ -4,6 +4,11 @@
 rtg.test @constants() {
   // CHECK-NEXT: rtg.constant #rtg.isa.immediate<2, -1> : !rtg.isa.immediate<2>
   %0 = rtg.constant #rtg.isa.immediate<2, -1>
+
+  // CHECK-NEXT: [[V0:%.+]] = index.constant 5
+  // CHECK-NEXT: rtg.isa.int_to_immediate [[V0]] : !rtg.isa.immediate<32>
+  %1 = index.constant 5
+  %2 = rtg.isa.int_to_immediate %1 : !rtg.isa.immediate<32>
 }
 
 // CHECK-LABEL: rtg.sequence @ranomizedSequenceType

--- a/test/Dialect/RTG/Transform/elaboration.mlir
+++ b/test/Dialect/RTG/Transform/elaboration.mlir
@@ -7,12 +7,18 @@ func.func @dummy4(%arg0: index, %arg1: index, %arg2: !rtg.bag<index>, %arg3: !rt
 func.func @dummy5(%arg0: i1) -> () {return}
 func.func @dummy6(%arg0: !rtg.isa.immediate<2>) -> () {return}
 
-// CHECK-LABEL: @constantImmediate
-rtg.test @constantImmediate() {
+// CHECK-LABEL: @immediates
+rtg.test @immediates() {
   // CHECK-NEXT: [[V0:%.+]] = rtg.constant #rtg.isa.immediate<2, -1>
   // CHECK-NEXT: func.call @dummy6([[V0]]) : (!rtg.isa.immediate<2>) -> ()
   %0 = rtg.constant #rtg.isa.immediate<2, -1>
   func.call @dummy6(%0) : (!rtg.isa.immediate<2>) -> ()
+
+  // CHECK-NEXT: [[V1:%.+]] = rtg.constant #rtg.isa.immediate<2, 1>
+  // CHECK-NEXT: func.call @dummy6([[V1]]) : (!rtg.isa.immediate<2>) -> ()
+  %1 = index.constant 1
+  %2 = rtg.isa.int_to_immediate %1 : !rtg.isa.immediate<2>
+  func.call @dummy6(%2) : (!rtg.isa.immediate<2>) -> ()
 }
 
 // Test the set operations and passing a sequence to another one via argument
@@ -596,4 +602,15 @@ rtg.test @emptyBagSelect() {
   // expected-error @below {{cannot select from an empty bag}}
   %1 = rtg.bag_select_random %0 : !rtg.bag<!rtg.isa.label>
   rtg.label local %1
+}
+
+// -----
+
+func.func @dummy6(%arg0: !rtg.isa.immediate<2>) -> () {return}
+
+rtg.test @integerTooBig() {
+  %1 = index.constant 8
+  // expected-error @below {{cannot represent 8 with 2 bits}}
+  %2 = rtg.isa.int_to_immediate %1 : !rtg.isa.immediate<2>
+  func.call @dummy6(%2) : (!rtg.isa.immediate<2>) -> ()
 }


### PR DESCRIPTION
This is, e.g., useful when creating an immediate from a for loop iteration index var.