### PR TITLE
[FIRRTL] Canonicalize Assert(clk, p, e) when p == e

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLCanonicalization.td
@@ -16,6 +16,7 @@
 include "FIRRTLDeclarations.td"
 include "FIRRTLExpressions.td"
 include "FIRRTLStatements.td"
+include "FIRRTLIntrinsics.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/PatternBase.td"
 
@@ -735,5 +736,12 @@ def CVTUnSigned : Pat<
       (PadPrimOp $x,
         (NativeCodeCall<"$_builder.getI32IntegerAttr(type_cast<SIntType>($0.getType()).getBitWidthOrSentinel())"> $old)))),
   [(UIntType $x), (KnownWidth $old)]>;
+
+def AssertXWhenX : Pattern<(AssertOp $_, $x, $x, $_, $_, $_, $_, $_), []>;
+
+def AssumeXWhenX : Pattern<(AssumeOp $_, $x, $x, $_, $_, $_, $_, $_), []>;
+
+def UnclockedAssumeIntrinsicXWhenX
+    : Pattern<(UnclockedAssumeIntrinsicOp $x, $x, $_, $_, $_), []>;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLCANONICALIZATION_TD

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -3204,16 +3204,19 @@ static LogicalResult canonicalizeImmediateVerifOp(Op op,
 void AssertOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                            MLIRContext *context) {
   results.add(canonicalizeImmediateVerifOp<AssertOp>);
+  results.add<patterns::AssertXWhenX>(context);
 }
 
 void AssumeOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                            MLIRContext *context) {
   results.add(canonicalizeImmediateVerifOp<AssumeOp>);
+  results.add<patterns::AssumeXWhenX>(context);
 }
 
 void UnclockedAssumeIntrinsicOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
   results.add(canonicalizeImmediateVerifOp<UnclockedAssumeIntrinsicOp>);
+  results.add<patterns::UnclockedAssumeIntrinsicXWhenX>(context);
 }
 
 void CoverOp::getCanonicalizationPatterns(RewritePatternSet &results,

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -2959,6 +2959,14 @@ firrtl.module @Verification(in %clock: !firrtl.clock, in %p: !firrtl.uint<1>, ou
   // CHECK-NOT: firrtl.int.isX
   %x = firrtl.int.isX %c0 : !firrtl.uint<1>
   firrtl.matchingconnect %o, %x : !firrtl.uint<1>
+
+  // Never fired when enabled.
+  // CHECK-NOT: firrtl.assert
+  firrtl.assert %clock, %p, %p, "assert1" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK-NOT: firrtl.assume
+  firrtl.assume %clock, %p, %p, "assume1" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
+  // CHECK-NOT: firrtl.int.unclocked_assume
+  firrtl.int.unclocked_assume %p, %p, "assume_edged1" : !firrtl.uint<1>, !firrtl.uint<1>
 }
 
 // COMMON-LABEL:  firrtl.module @MultibitMux

--- a/test/firtool/extract-test-code.fir
+++ b/test/firtool/extract-test-code.fir
@@ -40,7 +40,8 @@ circuit Top:
   module InputOnly:
     input clock : Clock
     input cond : UInt<1>
-    assert(clock, cond, cond, "Some assertion")
+    input en : UInt<1>
+    assert(clock, cond, en, "Some assertion")
 
   ; CHECK: module Top_assert(
   ; CHECK-NOT: endmodule
@@ -62,5 +63,6 @@ circuit Top:
     inst input_only of InputOnly
     connect input_only.clock, clock
     connect input_only.cond, cond
+    connect input_only.en, en
 
     intrinsic(circt_verif_assert<label="foo">, cond, en)

--- a/test/firtool/layer-merge-across-inlined-submodule.fir
+++ b/test/firtool/layer-merge-across-inlined-submodule.fir
@@ -23,24 +23,27 @@ circuit Top: %[[
 
   module Child:
     input p : UInt<1>
+    input e : UInt<1>
     input c : Clock
 
     layerblock Verification:
       layerblock Assert:
-        assert(c, p, p, "in child")
+        assert(c, p, e, "in child")
         
   public module Top:
     input p : UInt<1>
+    input e : UInt<1>
     input c : Clock
 
     layerblock Verification:
       layerblock Assert:
-        assert(c, p, p, "before child")
+        assert(c, p, e, "before child")
     
     inst child of Child
     connect child.p, p
+    connect child.e, e
     connect child.c, c
 
     layerblock Verification:
       layerblock Assert:
-        assert(c, p, p, "after child")
+        assert(c, p, e, "after child")


### PR DESCRIPTION
If the predicate and enable are the same expression, then the predicate must be true whenever the enable is true, so the assert cannot fire, and we can safetly remove the assert.