### PR TITLE
[OM] Add missing CAPI omTypeIsAMapType

### DIFF
--- a/lib/CAPI/Dialect/OM.cpp
+++ b/lib/CAPI/Dialect/OM.cpp
@@ -87,6 +87,9 @@ MlirType omStringTypeGet(MlirContext ctx) {
   return wrap(StringType::get(unwrap(ctx)));
 }
 
+/// Is the Type a MapType.
+bool omTypeIsAMapType(MlirType type) { return isa<MapType>(unwrap(type)); }
+
 /// Return a key type of a map.
 MlirType omMapTypeGetKeyType(MlirType type) {
   return wrap(cast<MapType>(unwrap(type)).getKeyType());


### PR DESCRIPTION
This API exists in OM.h but is missing an implementation.