### PR TITLE
[OM] Fix tuple_get operation in OMEvaluator

### DIFF
--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -171,6 +171,9 @@ FailureOr<evaluator::EvaluatorValuePtr> circt::om::Evaluator::getOrCreateValue(
                       ObjectFieldOp>([&](auto op) {
                   return getPartiallyEvaluatedValue(op.getType(), loc);
                 })
+                .Case<TupleGetOp>([&](auto op) {
+                  return evaluateTupleGet(op, actualParams, loc);
+                })
                 .Case<ObjectOp>([&](auto op) {
                   return getPartiallyEvaluatedValue(op.getType(), op.getLoc());
                 })


### PR DESCRIPTION
The Evaluator will call `getOrCreateValue` when instantiating an Object, which this function lacks the evaluation of the `tuple_get' operation.

~~Further tests will be added later.~~
Done.