### PR TITLE
[LowerToBMC] Add `comb` as a dialect dependency

### DIFF
--- a/include/circt/Tools/circt-bmc/Passes.td
+++ b/include/circt/Tools/circt-bmc/Passes.td
@@ -32,7 +32,7 @@ def LowerToBMC : Pass<"lower-to-bmc", "::mlir::ModuleOp"> {
 
   let dependentDialects = [
     "mlir::func::FuncDialect", "mlir::LLVM::LLVMDialect",
-    "circt::verif::VerifDialect"
+    "circt::verif::VerifDialect", "circt::comb::CombDialect"
   ];
 }
 

--- a/test/Tools/circt-bmc/lower-to-bmc-no-comb.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc-no-comb.mlir
@@ -1,0 +1,7 @@
+// RUN: circt-opt --lower-to-bmc="top-module=NoComb bound=10" %s | FileCheck %s
+
+// CHECK:  func.func @NoComb() {
+hw.module @NoComb(in %clk: !seq.clock) attributes {num_regs = 0 : i32, initial_values = []} {
+  %true = hw.constant true
+  verif.assert %true : i1
+}


### PR DESCRIPTION
`comb` is currently missing as a dependency of `LowerToBMC`, which means it's not loaded on designs with no comb ops in them and crashes. Regression test included.