### PR TITLE
[LowerSMTToZ3LLVM] Change printf type provided to lookupOrCreateFn

### DIFF
--- a/integration_test/Dialect/SMT/basic.mlir
+++ b/integration_test/Dialect/SMT/basic.mlir
@@ -247,26 +247,26 @@ func.func @check(%expr: !smt.bool) {
   smt.assert %expr
   %0 = smt.check sat {
     %1 = llvm.mlir.addressof @sat : !llvm.ptr
-    llvm.call @printf(%1) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr) -> i32
+    llvm.call @printf(%1) vararg(!llvm.func<void (ptr, ...)>) : (!llvm.ptr) -> ()
     %c1 = llvm.mlir.constant(1 : i32) : i32
     smt.yield %c1 : i32
   } unknown {
     %1 = llvm.mlir.addressof @unknown : !llvm.ptr
-    llvm.call @printf(%1) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr) -> i32
+    llvm.call @printf(%1) vararg(!llvm.func<void (ptr, ...)>) : (!llvm.ptr) -> ()
     %c0 = llvm.mlir.constant(0 : i32) : i32
     smt.yield %c0 : i32
   } unsat {
     %1 = llvm.mlir.addressof @unsat : !llvm.ptr
-    llvm.call @printf(%1) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr) -> i32
+    llvm.call @printf(%1) vararg(!llvm.func<void (ptr, ...)>) : (!llvm.ptr) -> ()
     %c-1 = llvm.mlir.constant(-1 : i32) : i32
     smt.yield %c-1 : i32
   } -> i32
   %1 = llvm.mlir.addressof @res : !llvm.ptr
-  llvm.call @printf(%1, %0) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, i32) -> i32
+  llvm.call @printf(%1, %0) vararg(!llvm.func<void (ptr, ...)>) : (!llvm.ptr, i32) -> ()
   return
 }
 
-llvm.func @printf(!llvm.ptr, ...) -> i32
+llvm.func @printf(!llvm.ptr, ...) -> ()
 llvm.mlir.global private constant @res("Res: %d\n\00") {addr_space = 0 : i32}
 llvm.mlir.global private constant @sat("sat\n\00") {addr_space = 0 : i32}
 llvm.mlir.global private constant @unsat("unsat\n\00") {addr_space = 0 : i32}

--- a/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
+++ b/lib/Conversion/SMTToZ3LLVM/LowerSMTToZ3LLVM.cpp
@@ -796,8 +796,8 @@ struct CheckOpLowering : public SMTLoweringPattern<CheckOp> {
                   ConversionPatternRewriter &rewriter) const final {
     Location loc = op.getLoc();
     auto ptrTy = LLVM::LLVMPointerType::get(rewriter.getContext());
-    auto printfType =
-        LLVM::LLVMFunctionType::get(rewriter.getI32Type(), {ptrTy}, true);
+    auto printfType = LLVM::LLVMFunctionType::get(
+        LLVM::LLVMVoidType::get(rewriter.getContext()), {ptrTy}, true);
 
     auto getHeaderString = [](const std::string &title) {
       unsigned titleSize = title.size() + 2; // Add a space left and right

--- a/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
+++ b/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
@@ -178,7 +178,7 @@ func.func @test(%arg0: i32) {
 
     // CHECK-DEBUG: [[SOLVER_STR:%.+]] = llvm.call @Z3_solver_to_string({{.*}}, {{.*}}) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
     // CHECK-DEBUG: [[FMT_STR:%.+]] = llvm.mlir.addressof @str{{.*}} : !llvm.ptr
-    // CHECK-DEBUG: llvm.call @printf([[FMT_STR]], [[SOLVER_STR]]) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, !llvm.ptr) -> i32
+    // CHECK-DEBUG: llvm.call @printf([[FMT_STR]], [[SOLVER_STR]]) vararg(!llvm.func<void (ptr, ...)>) : (!llvm.ptr, !llvm.ptr) -> ()
     // CHECK:   [[CHECK:%.+]] = llvm.call @Z3_solver_check([[CTX]], [[S]]) : (!llvm.ptr, !llvm.ptr) -> i32
     // CHECK:   [[C1:%.+]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK:   [[IS_SAT:%.+]] = llvm.icmp "eq" [[CHECK]], [[C1]] : i32
@@ -189,7 +189,7 @@ func.func @test(%arg0: i32) {
     // CHECK-DEBUG: [[MODEL:%.+]] = llvm.call @Z3_solver_get_model([[CTX0]], {{.*}}) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
     // CHECK-DEBUG: [[MODEL_STR:%.+]] = llvm.call @Z3_model_to_string([[CTX0]], [[MODEL]]) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
     // CHECK-DEBUG: [[FMT_STR:%.+]] = llvm.mlir.addressof @str{{.*}} : !llvm.ptr
-    // CHECK-DEBUG: llvm.call @printf([[FMT_STR]], [[MODEL_STR]]) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, !llvm.ptr) -> i32
+    // CHECK-DEBUG: llvm.call @printf([[FMT_STR]], [[MODEL_STR]]) vararg(!llvm.func<void (ptr, ...)>) : (!llvm.ptr, !llvm.ptr) -> ()
     // CHECK:   [[C1:%.+]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK:   llvm.br ^[[BB7:.+]]([[C1]] : i32)
     // CHECK: ^[[BB2]]:
@@ -202,7 +202,7 @@ func.func @test(%arg0: i32) {
     // CHECK-DEBUG: [[PROOF:%.+]] = llvm.call @Z3_solver_get_proof([[CTX1]], {{.*}}) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
     // CHECK-DEBUG: [[PROOF_STR:%.+]] = llvm.call @Z3_ast_to_string([[CTX1]], [[PROOF]]) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
     // CHECK-DEBUG: [[FMT_STR:%.+]] = llvm.mlir.addressof @str{{.*}} : !llvm.ptr
-    // CHECK-DEBUG: llvm.call @printf([[FMT_STR]], [[PROOF_STR]]) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, !llvm.ptr) -> i32
+    // CHECK-DEBUG: llvm.call @printf([[FMT_STR]], [[PROOF_STR]]) vararg(!llvm.func<void (ptr, ...)>) : (!llvm.ptr, !llvm.ptr) -> ()
     // CHECK:   [[CNEG1:%.+]] = llvm.mlir.constant(-1 : i32) : i32
     // CHECK:   llvm.br ^[[BB5:.+]]([[CNEG1:%.+]] : i32)
     // CHECK: ^[[BB4]]:


### PR DESCRIPTION
Looks like the debug mode of `LowerSMTToZ3LLVM` (which is used when `--print-solver-output` is passed to circt-bmc) broke in https://github.com/llvm/circt/pull/8225 - there was [a commit in LLVM](https://github.com/llvm/llvm-project/pull/123378) that added some extra checks on the result type passed to `lookupOrCreateFn`, and it looks like it's expecting a void type rather than an i32. I don't know too much about this side of things so LMK if this isn't the preferred fix.