### PR TITLE
[circt-bmc] add rising clocks only mode

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -723,6 +723,12 @@ def ConvertVerifToSMT : Pass<"convert-verif-to-smt", "mlir::ModuleOp"> {
     "mlir::scf::SCFDialect",
     "mlir::func::FuncDialect"
   ];
+  let options = [
+    Option<"risingClocksOnly", "rising-clocks-only", "bool",
+           /*default=*/"false",
+           "When lowering verif.bmc ops, only consider the circuit and property"
+           "on rising clock edges.">,
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/circt/Conversion/VerifToSMT.h
+++ b/include/circt/Conversion/VerifToSMT.h
@@ -21,7 +21,8 @@ class Namespace;
 /// Get the Verif to SMT conversion patterns.
 void populateVerifToSMTConversionPatterns(TypeConverter &converter,
                                           RewritePatternSet &patterns,
-                                          Namespace &names);
+                                          Namespace &names,
+                                          bool risingClocksOnly);
 
 } // namespace circt
 

--- a/include/circt/Tools/circt-bmc/Passes.td
+++ b/include/circt/Tools/circt-bmc/Passes.td
@@ -28,6 +28,9 @@ def LowerToBMC : Pass<"lower-to-bmc", "::mlir::ModuleOp"> {
     Option<"insertMainFunc", "insert-main", "bool",
            /*default=*/"false",
            "Whether a main function should be inserted for AOT compilation.">,
+    Option<"risingClocksOnly", "rising-clocks-only", "bool",
+           /*default=*/"false",
+           "Only consider the circuit and property on rising clock edges.">,
   ];
 
   let dependentDialects = [

--- a/integration_test/circt-bmc/rising-clocks-only.mlir
+++ b/integration_test/circt-bmc/rising-clocks-only.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: libz3
 // REQUIRES: circt-bmc-jit
 
-//  Test with two bounds - one that doesn't run long enough for the counter to reach 3, and one that does
+//  Check that in rising clock mode, we never see a low clock.
 //  RUN: circt-bmc %s -b 4 --module InputProp --shared-libs=%libz3 | FileCheck %s --check-prefix=ALLEDGES
 //  ALLEDGES: Assertion can be violated!
 //  RUN: circt-bmc %s -b 4 --module InputProp --shared-libs=%libz3 --rising-clocks-only | FileCheck %s --check-prefix=RISINGEDGES

--- a/integration_test/circt-bmc/rising-clocks-only.mlir
+++ b/integration_test/circt-bmc/rising-clocks-only.mlir
@@ -1,0 +1,13 @@
+// REQUIRES: libz3
+// REQUIRES: circt-bmc-jit
+
+//  Test with two bounds - one that doesn't run long enough for the counter to reach 3, and one that does
+//  RUN: circt-bmc %s -b 4 --module InputProp --shared-libs=%libz3 | FileCheck %s --check-prefix=ALLEDGES
+//  ALLEDGES: Assertion can be violated!
+//  RUN: circt-bmc %s -b 4 --module InputProp --shared-libs=%libz3 --rising-clocks-only | FileCheck %s --check-prefix=RISINGEDGES
+//  RISINGEDGES: Bound reached with no violations!
+
+hw.module @InputProp(in %clk: !seq.clock) {
+  %fromclk = seq.from_clock %clk
+  verif.assert %fromclk : i1
+}

--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -367,33 +367,38 @@ struct VerifBoundedModelCheckingOpConversion
           // TODO: this will also need changing with multiple clocks - currently
           // it only accounts for the one clock case.
           if (clockIndexes.size() == 1) {
-            auto clockIndex = clockIndexes[0];
-            auto oldClock = iterArgs[clockIndex];
-            // The clock is necessarily the first value returned by the loop
-            // region
-            auto newClock = loopVals[0];
-            auto oldClockLow = builder.create<smt::BVNotOp>(loc, oldClock);
-            auto isPosedgeBV =
-                builder.create<smt::BVAndOp>(loc, oldClockLow, newClock);
-            // Convert posedge bv<1> to bool
-            auto trueBV = builder.create<smt::BVConstantOp>(loc, 1, 1);
-            auto isPosedge =
-                builder.create<smt::EqOp>(loc, isPosedgeBV, trueBV);
-            auto regStates =
-                iterArgs.take_front(circuitFuncOp.getNumArguments())
-                    .take_back(numRegs);
-            auto regInputs = circuitCallOuts.take_back(numRegs);
-            SmallVector<Value> nextRegStates;
-            for (auto [regState, regInput] : llvm::zip(regStates, regInputs)) {
-              // Create an ITE to calculate the next reg state
-              // TODO: we create a lot of ITEs here that will slow things down -
-              // these could be avoided by making init/loop regions concrete
-              nextRegStates.push_back(
-                  risingClocksOnly ? regInput
-                                   : builder.create<smt::IteOp>(
-                                         loc, isPosedge, regInput, regState));
+            SmallVector<Value> regInputs = circuitCallOuts.take_back(numRegs);
+            if (risingClocksOnly) {
+              // In rising clocks only mode we don't need to worry about whether
+              // there was a posedge
+              newDecls.append(regInputs);
+            } else {
+              auto clockIndex = clockIndexes[0];
+              auto oldClock = iterArgs[clockIndex];
+              // The clock is necessarily the first value returned by the loop
+              // region
+              auto newClock = loopVals[0];
+              auto oldClockLow = builder.create<smt::BVNotOp>(loc, oldClock);
+              auto isPosedgeBV =
+                  builder.create<smt::BVAndOp>(loc, oldClockLow, newClock);
+              // Convert posedge bv<1> to bool
+              auto trueBV = builder.create<smt::BVConstantOp>(loc, 1, 1);
+              auto isPosedge =
+                  builder.create<smt::EqOp>(loc, isPosedgeBV, trueBV);
+              auto regStates =
+                  iterArgs.take_front(circuitFuncOp.getNumArguments())
+                      .take_back(numRegs);
+              SmallVector<Value> nextRegStates;
+              for (auto [regState, regInput] :
+                   llvm::zip(regStates, regInputs)) {
+                // Create an ITE to calculate the next reg state
+                // TODO: we create a lot of ITEs here that will slow things down
+                // - these could be avoided by making init/loop regions concrete
+                nextRegStates.push_back(builder.create<smt::IteOp>(
+                    loc, isPosedge, regInput, regState));
+              }
+              newDecls.append(nextRegStates);
             }
-            newDecls.append(nextRegStates);
           }
 
           // Add the rest of the loop state args

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -158,6 +158,15 @@ func.func @test_lec(%arg0: !smt.bv<1>) -> (i1, i1, i1) {
 // CHECK:    return [[C9]], [[C10]], [[ARG3]], [[ARG4]]
 // CHECK:  }
 
+// RUN: circt-opt %s --convert-verif-to-smt="rising-clocks-only=true" --reconcile-unrealized-casts -allow-unregistered-dialect | FileCheck %s --check-prefix=CHECK1
+// CHECK1-LABEL:  func.func @test_bmc() -> i1 {
+// CHECK1:        [[CIRCUIT:%.+]]:4 = func.call @bmc_circuit(
+// CHECK1:        [[SMTCHECK:%.+]] = smt.check
+// CHECK1:        [[ORI:%.+]] = arith.ori [[SMTCHECK]], {{%.*}}
+// CHECK1:        [[LOOP:%.+]]:2 = func.call @bmc_loop({{%.*}}, {{%.*}})
+// CHECK1:        [[F:%.+]] = smt.declare_fun : !smt.bv<32>
+// CHECK1:        scf.yield [[LOOP]]#0, [[F]], [[CIRCUIT]]#1, [[CIRCUIT]]#2, [[CIRCUIT]]#3, [[LOOP]]#1, [[ORI]]
+
 func.func @test_bmc() -> (i1) {
   %bmc = verif.bmc bound 10 num_regs 3 initial_values [unit, 42, unit]
   init {

--- a/test/Tools/circt-bmc/lower-to-bmc.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc.mlir
@@ -63,6 +63,9 @@ hw.module @comb(in %in0: i32, in %in1: i32, out out: i32) attributes {num_regs =
 // CHECKRISING-NEXT:      [[FALSE:%.+]] = hw.constant true
 // CHECKRISING-NEXT:      [[INIT_CLK:%.+]] = seq.to_clock [[FALSE]]
 // CHECKRISING-NEXT:      verif.yield [[INIT_CLK]]
+// CHECKRISING-NEXT:    } loop {
+// CHECKRISING-NEXT:    ^bb0([[CLK:%.+]]: !seq.clock):
+// CHECKRISING-NEXT:      verif.yield [[CLK]]
 
 hw.module @seq(in %clk : !seq.clock, in %in0 : i32, in %in1 : i32, in %reg_state : i32, out out : i32, out reg_input : i32) attributes {num_regs = 1 : i32, initial_values = [unit]} {
   %0 = comb.add %in0, %in1 : i32

--- a/test/Tools/circt-bmc/lower-to-bmc.mlir
+++ b/test/Tools/circt-bmc/lower-to-bmc.mlir
@@ -57,6 +57,13 @@ hw.module @comb(in %in0: i32, in %in1: i32, out out: i32) attributes {num_regs =
 // CHECK1:  }
 // CHECK1:  llvm.mlir.global private constant [[SSTR]]("Bound reached with no violations!\0A\00") {addr_space = 0 : i32}
 // CHECK1:  llvm.mlir.global private constant [[FSTR]]("Assertion can be violated!\0A\00") {addr_space = 0 : i32}
+
+// RUN: circt-opt --lower-to-bmc="top-module=seq bound=10 rising-clocks-only=true" %s | FileCheck %s --check-prefix=CHECKRISING
+// CHECKRISING:    [[BMC:%.+]] = verif.bmc bound 10 num_regs 1 initial_values [unit] init {
+// CHECKRISING-NEXT:      [[FALSE:%.+]] = hw.constant true
+// CHECKRISING-NEXT:      [[INIT_CLK:%.+]] = seq.to_clock [[FALSE]]
+// CHECKRISING-NEXT:      verif.yield [[INIT_CLK]]
+
 hw.module @seq(in %clk : !seq.clock, in %in0 : i32, in %in1 : i32, in %reg_state : i32, out out : i32, out reg_input : i32) attributes {num_regs = 1 : i32, initial_values = [unit]} {
   %0 = comb.add %in0, %in1 : i32
   %1 = comb.icmp eq %0, %in0 : i32


### PR DESCRIPTION
Most of the time (maybe all of the time?) you don't care about negedges when you're model checking, so half of the cycles explored by circt-bmc are irrelevant since the clock has just been inverted. This mode skips those cycles by halving the bound, getting rid of the posedge checks and always keeping the clock as 1.