### PR TITLE
[FIRRTL] Add doNotPrint flag to InstanceOp

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -64,61 +64,57 @@ def InstanceOp : HardwareDeclOp<"instance", [
     ```
   }];
 
-  let arguments = (ins FlatSymbolRefAttr:$moduleName, StrAttr:$name, NameKindAttr:$nameKind,
-                       DenseBoolArrayAttr:$portDirections, StrArrayAttr:$portNames,
-                       AnnotationArrayAttr:$annotations,
-                       PortAnnotationsAttr:$portAnnotations,
-                       LayerArrayAttr:$layers,
-                       UnitAttr:$lowerToBind,
-                       OptionalAttr<InnerSymAttr>:$inner_sym);
+  let arguments = (ins FlatSymbolRefAttr:$moduleName, StrAttr:$name,
+      NameKindAttr:$nameKind, DenseBoolArrayAttr:$portDirections,
+      StrArrayAttr:$portNames, AnnotationArrayAttr:$annotations,
+      PortAnnotationsAttr:$portAnnotations, LayerArrayAttr:$layers,
+      UnitAttr:$lowerToBind, UnitAttr:$doNotPrint,
+      OptionalAttr<InnerSymAttr>:$inner_sym);
 
   let results = (outs Variadic<AnyType>:$results);
 
   let hasCustomAssemblyFormat = 1;
 
-  let builders = [
-    OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
-                   "::mlir::StringRef":$moduleName,
-                   "::mlir::StringRef":$name,
-                   "::circt::firrtl::NameKindEnum":$nameKind,
-                   "::mlir::ArrayRef<Direction>":$portDirections,
-                   "::mlir::ArrayRef<Attribute>":$portNames,
-                   CArg<"ArrayRef<Attribute>", "{}">:$annotations,
-                   CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
-                   CArg<"::mlir::ArrayRef<Attribute>", "{}">:$layers,
-                   CArg<"bool","false">:$lowerToBind,
-                   CArg<"StringAttr", "StringAttr()">:$innerSym)>,
-    OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
-                   "::mlir::StringRef":$moduleName,
-                   "::mlir::StringRef":$name,
-                   "::circt::firrtl::NameKindEnum":$nameKind,
-                   "::mlir::ArrayRef<Direction>":$portDirections,
-                   "::mlir::ArrayRef<Attribute>":$portNames,
-                   "ArrayRef<Attribute>":$annotations,
-                   "ArrayRef<Attribute>":$portAnnotations,
-                   "::mlir::ArrayRef<Attribute>":$layers,
-                   "bool":$lowerToBind,
-                   "hw::InnerSymAttr":$innerSym)>,
+  let builders =
+      [OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
+           "::mlir::StringRef":$moduleName, "::mlir::StringRef":$name,
+           "::circt::firrtl::NameKindEnum":$nameKind,
+           "::mlir::ArrayRef<Direction>":$portDirections,
+           "::mlir::ArrayRef<Attribute>":$portNames,
+           CArg<"ArrayRef<Attribute>", "{}">:$annotations,
+           CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
+           CArg<"::mlir::ArrayRef<Attribute>", "{}">:$layers,
+           CArg<"bool", "false">:$lowerToBind,
+           CArg<"bool", "false">:$doNotPrint,
+           CArg<"StringAttr", "StringAttr()">:$innerSym)>,
+       OpBuilder<(ins "::mlir::TypeRange":$resultTypes,
+           "::mlir::StringRef":$moduleName, "::mlir::StringRef":$name,
+           "::circt::firrtl::NameKindEnum":$nameKind,
+           "::mlir::ArrayRef<Direction>":$portDirections,
+           "::mlir::ArrayRef<Attribute>":$portNames,
+           "ArrayRef<Attribute>":$annotations,
+           "ArrayRef<Attribute>":$portAnnotations,
+           "::mlir::ArrayRef<Attribute>":$layers, "bool":$lowerToBind,
+           "bool":$doNotPrint, "hw::InnerSymAttr":$innerSym)>,
 
-    /// Constructor when you have the target module in hand.
-    OpBuilder<(ins "FModuleLike":$module,
-                   "mlir::StringRef":$name,
-                   CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
-                   CArg<"ArrayRef<Attribute>", "{}">:$annotations,
-                   CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
-                   CArg<"bool","false">:$lowerToBind,
-                   CArg<"hw::InnerSymAttr", "hw::InnerSymAttr()">:$innerSym)>,
+       /// Constructor when you have the target module in hand.
+       OpBuilder<(ins "FModuleLike":$module, "mlir::StringRef":$name,
+           CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
+           CArg<"ArrayRef<Attribute>", "{}">:$annotations,
+           CArg<"ArrayRef<Attribute>", "{}">:$portAnnotations,
+           CArg<"bool", "false">:$lowerToBind,
+           CArg<"bool", "false">:$doNotPrint,
+           CArg<"hw::InnerSymAttr", "hw::InnerSymAttr()">:$innerSym)>,
 
-    /// Constructor when you have a port info list in hand.
-    OpBuilder<(ins "ArrayRef<PortInfo>":$ports,
-                   "::mlir::StringRef":$moduleName,
-                   "mlir::StringRef":$name,
-                   CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
-                   CArg<"ArrayRef<Attribute>", "{}">:$annotations,
-                   CArg<"ArrayRef<Attribute>", "{}">:$layers,
-                   CArg<"bool","false">:$lowerToBind,
-                   CArg<"hw::InnerSymAttr", "hw::InnerSymAttr()">:$innerSym)>
-  ];
+       /// Constructor when you have a port info list in hand.
+       OpBuilder<(ins "ArrayRef<PortInfo>":$ports,
+           "::mlir::StringRef":$moduleName, "mlir::StringRef":$name,
+           CArg<"NameKindEnum", "NameKindEnum::DroppableName">:$nameKind,
+           CArg<"ArrayRef<Attribute>", "{}">:$annotations,
+           CArg<"ArrayRef<Attribute>", "{}">:$layers,
+           CArg<"bool", "false">:$lowerToBind,
+           CArg<"bool", "false">:$doNotPrint,
+           CArg<"hw::InnerSymAttr", "hw::InnerSymAttr()">:$innerSym)>];
 
   let extraClassDeclaration = [{
     /// Return the port direction for the specified result number.

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -140,10 +140,13 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
           attributes.underDut.mergeIn(parentAttrs.underDut);
 
         // Update underLayer.
-        auto instanceOp = useIt->getInstance();
-        bool underLayer = (isa<InstanceOp>(instanceOp) &&
-                           cast<InstanceOp>(instanceOp).getLowerToBind()) ||
-                          instanceOp->getParentOfType<LayerBlockOp>();
+        bool underLayer = false;
+        if (auto instanceOp = useIt->getInstance<InstanceOp>()) {
+          if (instanceOp.getLowerToBind() || instanceOp.getDoNotPrint() ||
+              instanceOp->getParentOfType<LayerBlockOp>())
+            underLayer = true;
+        }
+
         if (!isGCCompanion) {
           if (underLayer)
             attributes.underLayer.mergeIn(true);

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -249,14 +249,13 @@ struct CircuitLoweringState {
     // Pre-populate the dutModules member with a list of all modules that are
     // determined to be under the DUT.
     auto inDUT = [&](igraph::ModuleOpInterface child) {
-      auto isBind = [](igraph::InstanceRecord *instRec) {
-        auto inst = instRec->getInstance();
-        if (auto *finst = dyn_cast<InstanceOp>(&inst))
-          return finst->getLowerToBind();
+      auto isPhony = [](igraph::InstanceRecord *instRec) {
+        if (auto inst = instRec->getInstance<InstanceOp>())
+          return inst.getLowerToBind() || inst.getDoNotPrint();
         return false;
       };
       if (auto parent = dyn_cast<igraph::ModuleOpInterface>(*dut))
-        return getInstanceGraph().isAncestor(child, parent, isBind);
+        return getInstanceGraph().isAncestor(child, parent, isPhony);
       return dut == child;
     };
     circuitOp->walk([&](FModuleLike moduleOp) {
@@ -3397,7 +3396,7 @@ LogicalResult FIRRTLLowering::visitDecl(InstanceOp oldInstance) {
   auto newInstance = builder.create<hw::InstanceOp>(
       newModule, oldInstance.getNameAttr(), operands, parameters, innerSym);
 
-  if (oldInstance.getLowerToBind())
+  if (oldInstance.getLowerToBind() || oldInstance.getDoNotPrint())
     newInstance.setDoNotPrintAttr(builder.getUnitAttr());
 
   if (newInstance.getInnerSymAttr())

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -4132,7 +4132,7 @@ ParseResult FIRStmtParser::parseInstance() {
   hw::InnerSymAttr sym = {};
   auto result = builder.create<InstanceOp>(
       referencedModule, id, NameKindEnum::InterestingName,
-      annotations.getValue(), portAnnotations, false, sym);
+      annotations.getValue(), portAnnotations, false, false, sym);
 
   // Since we are implicitly unbundling the instance results, we need to keep
   // track of the mapping from bundle fields to results in the unbundledValues

--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -969,7 +969,7 @@ void ExtractInstancesPass::groupInstances() {
         wrapper.getLoc(), wrapper, wrapperName, NameKindEnum::DroppableName,
         ArrayRef<Attribute>{},
         /*portAnnotations=*/ArrayRef<Attribute>{}, /*lowerToBind=*/false,
-        hw::InnerSymAttr::get(wrapperInstName));
+        /*doNotPrint=*/false, hw::InnerSymAttr::get(wrapperInstName));
     unsigned portIdx = 0;
     for (auto inst : insts)
       for (auto result : inst.getResults())

--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -177,7 +177,7 @@ void InjectDUTHierarchy::runOnOperation() {
   auto wrapperInst =
       b.create<InstanceOp>(b.getUnknownLoc(), wrapper, wrapper.getModuleName(),
                            NameKindEnum::DroppableName, ArrayRef<Attribute>{},
-                           ArrayRef<Attribute>{}, false,
+                           ArrayRef<Attribute>{}, false, false,
                            hw::InnerSymAttr::get(b.getStringAttr(
                                dutNS.newName(wrapper.getModuleName()))));
   for (const auto &pair : llvm::enumerate(wrapperInst.getResults())) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -652,6 +652,7 @@ LogicalResult LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
         instanceName, NameKindEnum::DroppableName,
         /*annotations=*/ArrayRef<Attribute>{},
         /*portAnnotations=*/ArrayRef<Attribute>{}, /*lowerToBind=*/true,
+        /*doNotPrint=*/false,
         /*innerSym=*/
         (innerSyms.empty() ? hw::InnerSymAttr{}
                            : hw::InnerSymAttr::get(builder.getStringAttr(

--- a/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerMemory.cpp
@@ -497,7 +497,7 @@ InstanceOp LowerMemoryPass::emitMemoryInstance(MemOp op, FModuleOp module,
       /*annotations=*/ArrayRef<Attribute>(),
       /*portAnnotations=*/ArrayRef<Attribute>(),
       /*layers=*/ArrayRef<Attribute>(), /*lowerToBind=*/false,
-      op.getInnerSymAttr());
+      /*doNotPrint=*/false, op.getInnerSymAttr());
 
   // Update all users of the result of read ports
   for (auto [subfield, result] : returnHolder) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerSignatures.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerSignatures.cpp
@@ -404,7 +404,7 @@ static void lowerModuleBody(FModuleOp mod,
     auto newOp = theBuilder.create<InstanceOp>(
         instPorts, inst.getModuleName(), inst.getName(), inst.getNameKind(),
         annos.getValue(), inst.getLayers(), inst.getLowerToBind(),
-        inst.getInnerSymAttr());
+        inst.getDoNotPrint(), inst.getInnerSymAttr());
 
     auto oldDict = inst->getDiscardableAttrDictionary();
     auto newDict = newOp->getDiscardableAttrDictionary();

--- a/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerTypes.cpp
@@ -1508,7 +1508,7 @@ bool TypeLoweringVisitor::visitDecl(InstanceOp op) {
       op.getNameKindAttr(), direction::packAttribute(context, newDirs),
       builder->getArrayAttr(newNames), op.getAnnotations(),
       builder->getArrayAttr(newPortAnno), op.getLayersAttr(),
-      op.getLowerToBindAttr(),
+      op.getLowerToBindAttr(), op.getDoNotPrintAttr(),
       sym ? hw::InnerSymAttr::get(sym) : hw::InnerSymAttr());
 
   newInstance->setDiscardableAttrs(op->getDiscardableAttrDictionary());

--- a/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SpecializeOption.cpp
@@ -85,7 +85,7 @@ struct SpecializeOptionPass
                 inst.getNameKindAttr(), inst.getPortDirectionsAttr(),
                 inst.getPortNamesAttr(), inst.getAnnotationsAttr(),
                 inst.getPortAnnotationsAttr(), builder.getArrayAttr({}),
-                UnitAttr{}, inst.getInnerSymAttr());
+                UnitAttr{}, UnitAttr{}, inst.getInnerSymAttr());
             inst.replaceAllUsesWith(newInst);
             inst.erase();
 

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -650,6 +650,11 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.connect %qux, %dummy : !firrtl.uint<1>, !firrtl.uint<1>
   }
 
+  // CHECK-LABEL: hw.module @DoNotPrintTest()
+  firrtl.module @DoNotPrintTest() {
+    // CHECK: hw.instance "foo" @foo() -> () {doNotPrint}
+    firrtl.instance foo {doNotPrint} @foo()
+  }
 
   // CHECK-LABEL: hw.module private @attributes_preservation
   // CHECK-SAME: firrtl.foo = "bar"


### PR DESCRIPTION
This flag acts the same as doNotPrint in hardware. When lowering an instance to the hw dialect, copy the doNotPrint attribute over.

I am preparing to add a bind op to the firrtl dialect (not the frontend language), which will pair with this flag. My goal is to allow lower-layers to place the bind op for layerblocks into the body of a bind file, which is represented by an emit.file op.