### PR TITLE
[SMT] expand Z3 library check in integration tests

### DIFF
--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -213,7 +213,7 @@ if config.z3_path != "":
   config.available_features.add('z3')
 
 # Enable libz3 if it has been detected.
-if config.z3_library != "":
+if config.z3_library not in ("", "Z3_LIBRARIES-NOTFOUND"):
   tools.append(ToolSubst(f"%libz3", config.z3_library))
   config.available_features.add('libz3')
 


### PR DESCRIPTION
I managed to recreate the issue reported in #8231, and upon some poking around found out that the issue was that, on my system at least, the Z3 library is set to `Z3_LIBRARIES-NOTFOUND` by the code that searches for a Z3 installation when there is no available Z3 library, rather than being left as an empty string. This expands the check to check if it's either an empty string or `Z3_LIBRARIES-NOTFOUND`. Hopefully this also fixes it for you @mikeurbach - if not then I'd be curious to know what is assigned to `config.z3_library` in your `build/integration_test/lit.site.cfg.py`