### PR TITLE
Bump LLVM to 4d5a963eaf6ad209487a321dee7f0cd2a0f98477.

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLDeclarations.td
@@ -407,6 +407,14 @@ def RegOp : HardwareDeclOp<"reg", [Forceable, DeclareOpInterfaceMethods<CombData
       assert(resultTypes.size() >= 1u && "mismatched number of return types");
       odsState.addTypes(resultTypes);
     }]>,
+    OpBuilder<(ins "::mlir::TypeRange":$resultTypes, "::mlir::ValueRange":$operands,
+                   CArg<"const Properties &","{}">:$properties), [{
+      assert(operands.size() == 1u && "mismatched number of parameters");
+      odsState.addOperands(operands);
+      odsState.useProperties(const_cast<Properties &>(properties));
+      assert(resultTypes.size() >= 1u && "mismatched number of return types");
+      odsState.addTypes(resultTypes);
+    }]>,
     OpBuilder<(ins "::mlir::Type":$elementType,
                    "::mlir::Value":$clockVal,
                    "::mlir::StringAttr":$name,


### PR DESCRIPTION
This is almost a clean bump.

After https://github.com/llvm/llvm-project/commit/f3e5594, DRR
patterns will now generate calls to builders that use Properties, for
dialects that use Properties. Since we skip default builders for
RegOp, we need a builder that accepts Properties, since the DRR
patterns assume such a builder exists.