### PR TITLE
[Python] Add binding for OutputFileAttr filename.

### DIFF
--- a/include/circt-c/Dialect/HW.h
+++ b/include/circt-c/Dialect/HW.h
@@ -191,6 +191,8 @@ MLIR_CAPI_EXPORTED MlirAttribute hwParamVerbatimAttrGet(MlirAttribute text);
 MLIR_CAPI_EXPORTED bool hwAttrIsAOutputFileAttr(MlirAttribute);
 MLIR_CAPI_EXPORTED MlirAttribute hwOutputFileGetFromFileName(
     MlirAttribute text, bool excludeFromFileList, bool includeReplicatedOp);
+MLIR_CAPI_EXPORTED MlirStringRef
+hwOutputFileGetFileName(MlirAttribute outputFile);
 
 //===----------------------------------------------------------------------===//
 // InstanceGraph API.

--- a/integration_test/Bindings/Python/dialects/hw.py
+++ b/integration_test/Bindings/Python/dialects/hw.py
@@ -97,6 +97,7 @@ with Context() as ctx, Location.unknown():
 
   outfile = hw.OutputFileAttr.get_from_filename(StringAttr.get("file.txt"),
                                                 True, True)
+  assert outfile.filename == "file.txt"
   print(outfile)
   # CHECK: #hw.output_file<"file.txt", excludeFromFileList, includeReplicatedOps>
 

--- a/lib/Bindings/Python/HWModule.cpp
+++ b/lib/Bindings/Python/HWModule.cpp
@@ -236,12 +236,16 @@ void circt::python::populateDialectHWSubmodule(nb::module_ &m) {
       });
 
   mlir_attribute_subclass(m, "OutputFileAttr", hwAttrIsAOutputFileAttr)
-      .def_classmethod("get_from_filename", [](nb::object cls,
-                                               MlirAttribute fileName,
-                                               bool excludeFromFileList,
-                                               bool includeReplicatedOp) {
-        return cls(hwOutputFileGetFromFileName(fileName, excludeFromFileList,
-                                               includeReplicatedOp));
+      .def_classmethod(
+          "get_from_filename",
+          [](nb::object cls, MlirAttribute fileName, bool excludeFromFileList,
+             bool includeReplicatedOp) {
+            return cls(hwOutputFileGetFromFileName(
+                fileName, excludeFromFileList, includeReplicatedOp));
+          })
+      .def_property_readonly("filename", [](MlirAttribute self) {
+        MlirStringRef cStr = hwOutputFileGetFileName(self);
+        return std::string(cStr.data, cStr.length);
       });
 
   mlir_attribute_subclass(m, "InnerSymAttr", hwAttrIsAInnerSymAttr)

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -307,6 +307,11 @@ hwOutputFileGetFromFileName(MlirAttribute fileName, bool excludeFromFileList,
       excludeFromFileList, includeReplicatedOp));
 }
 
+MlirStringRef hwOutputFileGetFileName(MlirAttribute outputFile) {
+  auto outputFileAttr = cast<OutputFileAttr>(unwrap(outputFile));
+  return wrap(outputFileAttr.getFilename().getValue());
+}
+
 MLIR_CAPI_EXPORTED HWInstanceGraph hwInstanceGraphGet(MlirOperation operation) {
   return wrap(new InstanceGraph{unwrap(operation)});
 }


### PR DESCRIPTION
We already have a binding for the OutputFileAttr, but it didn't provide any useful accessor. This adds a safe, typed accessor to read out the filename as a string.