### PR TITLE
[ExportVerilog] Back-annotate output file attributes during export.

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -6690,9 +6690,10 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
       file.addToFilelist = addToFilelist;
       file.isVerilog = outputPath.ends_with(".sv");
 
-      // Back-annotate the op with an OutputFileAttr if there wasn't one. This
-      // is so output files are explicit in the final MLIR after export.
-      if (!attr) {
+      // Back-annotate the op with an OutputFileAttr if there wasn't one. If it
+      // was a directory, back-annotate the final file path. This is so output
+      // files are explicit in the final MLIR after export.
+      if (!attr || attr.isDirectory()) {
         auto excludeFromFileListAttr =
             BoolAttr::get(op->getContext(), !addToFilelist);
         auto includeReplicatedOpsAttr =

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -6689,6 +6689,18 @@ void SharedEmitterState::gatherFiles(bool separateModules) {
       file.emitReplicatedOps = emitReplicatedOps;
       file.addToFilelist = addToFilelist;
       file.isVerilog = outputPath.ends_with(".sv");
+
+      // Back-annotate the op with an OutputFileAttr if there wasn't one. This
+      // is so output files are explicit in the final MLIR after export.
+      if (!attr) {
+        auto excludeFromFileListAttr =
+            BoolAttr::get(op->getContext(), !addToFilelist);
+        auto includeReplicatedOpsAttr =
+            BoolAttr::get(op->getContext(), emitReplicatedOps);
+        auto outputFileAttr = hw::OutputFileAttr::get(
+            destFile, excludeFromFileListAttr, includeReplicatedOpsAttr);
+        op->setAttr("output_file", outputFileAttr);
+      }
     };
 
     // Separate the operation into dedicated output file, or emit into the

--- a/test/Conversion/ExportVerilog/split-output-file.mlir
+++ b/test/Conversion/ExportVerilog/split-output-file.mlir
@@ -1,0 +1,16 @@
+// RUN: circt-opt %s --export-split-verilog='dir-name=%t' | FileCheck %s
+
+// COM: Check explicit output_file.
+// CHECK: hw.module @foo
+// CHECK-SAME: output_file = #hw.output_file<"alternate.sv", includeReplicatedOps>
+#fooFile = #hw.output_file<"alternate.sv", includeReplicatedOps>
+hw.module @foo(in %a: i1, out b: i1) attributes {output_file = #fooFile} {
+  hw.output %a : i1
+}
+
+// COM: Check back-annotated output_file.
+// CHECK: hw.module @bar
+// CHECK-SAME: output_file = #hw.output_file<"bar.sv", includeReplicatedOps>
+hw.module @bar(in %a: i1, out b: i1) {
+  hw.output %a : i1
+}

--- a/test/Conversion/ExportVerilog/split-output-file.mlir
+++ b/test/Conversion/ExportVerilog/split-output-file.mlir
@@ -17,7 +17,7 @@ hw.module @bar(in %a: i1, out b: i1) {
 
 // COM: Check back-annotated output_file for a path output_file.
 // CHECK: hw.module @baz
-// CHECK-SAME: output_file = #hw.output_file<"directory/baz.sv", includeReplicatedOps>
+// CHECK-SAME: output_file = #hw.output_file<"directory{{[/\]+}}baz.sv", includeReplicatedOps>
 #bazDir = #hw.output_file<"directory/", includeReplicatedOps>
 hw.module @baz(in %a: i1, out b: i1) attributes {output_file = #bazDir} {
   hw.output %a : i1

--- a/test/Conversion/ExportVerilog/split-output-file.mlir
+++ b/test/Conversion/ExportVerilog/split-output-file.mlir
@@ -14,3 +14,11 @@ hw.module @foo(in %a: i1, out b: i1) attributes {output_file = #fooFile} {
 hw.module @bar(in %a: i1, out b: i1) {
   hw.output %a : i1
 }
+
+// COM: Check back-annotated output_file for a path output_file.
+// CHECK: hw.module @baz
+// CHECK-SAME: output_file = #hw.output_file<"directory/baz.sv", includeReplicatedOps>
+#bazDir = #hw.output_file<"directory/", includeReplicatedOps>
+hw.module @baz(in %a: i1, out b: i1) attributes {output_file = #bazDir} {
+  hw.output %a : i1
+}


### PR DESCRIPTION
This adds an OutputFileAttr to any op that didn't already have one, to indicate the output path the op was ultimately exported to. The intent is to be able to query the final MLIR to know explicitly where every op was exported on disk when exporting split Verilog.