### PR TITLE
[FIRRTL] Add "special substitutions" to printfs

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -13,8 +13,10 @@
 #ifndef CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_TD
 #define CIRCT_DIALECT_FIRRTL_FIRRTLATTRIBUTES_TD
 
+include "FIRRTLEnums.td"
 include "FIRRTLDialect.td"
 include "mlir/IR/BuiltinAttributeInterfaces.td"
+include "mlir/IR/EnumAttr.td"
 include "circt/Types.td"
 
 //===----------------------------------------------------------------------===//
@@ -186,6 +188,16 @@ def InternalPathAttr : AttrDef<FIRRTLDialect, "InternalPath"> {
 
 def InternalPathArrayAttr
   : TypedArrayAttrBase<InternalPathAttr, "InternalPath array attribute">;
+
+//===----------------------------------------------------------------------===//
+// Printf attributes
+//===----------------------------------------------------------------------===//
+
+def PrintfSubstitutionEnumAttr
+  : EnumAttr<FIRRTLDialect, PrintfSubstitutionEnum, "printfSubstitution">;
+
+def PrintfSubstitutionEnumArrayAttr
+  : TypedArrayAttrBase<PrintfSubstitutionEnumAttr, "Array of special printf substitutuions">;
 
 //===----------------------------------------------------------------------===//
 // Miscellaneous attributes

--- a/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLEnums.td
@@ -125,6 +125,22 @@ def Reference: I32EnumAttrCase<"Reference", 4, "reference">;
 def TargetKind : I32EnumAttr<"TargetKind", "object model target kind",
   [DontTouch, Instance, MemberInstance, MemberReference, Reference]>  {}
 
+//===----------------------------------------------------------------------===//
+// Printf Substitutions Attributes
+//===----------------------------------------------------------------------===//
+
+def PrintfSubstitutionEnum : I32EnumAttr<
+  "PrintfSubstitution",
+  "A special substitution for a FIRRTL printf",
+  [
+    I32EnumAttrCase<"SimulationTime", 0, "SimulationTime">
+  ]
+> {
+
+  let genSpecializedAttr = 0;
+
+}
+
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLENUMS_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -13,6 +13,7 @@
 #ifndef CIRCT_DIALECT_FIRRTL_FIRRTLSTATEMENTS_TD
 #define CIRCT_DIALECT_FIRRTL_FIRRTLSTATEMENTS_TD
 
+include "FIRRTLAttributes.td"
 include "FIRRTLDialect.td"
 include "FIRRTLEnums.td"
 include "FIRRTLOpInterfaces.td"
@@ -111,8 +112,10 @@ def RefDefineOp : FIRRTLOp<"ref.define", [SameTypeOperands, FConnectLike]> {
 def PrintFOp : FIRRTLOp<"printf"> {
   let summary = "Formatted Print Statement";
 
-  let arguments = (ins ClockType:$clock, UInt1Type:$cond, StrAttr:$formatString,
-                       Variadic<FIRRTLBaseType>:$substitutions, StrAttr:$name);
+  let arguments = (
+    ins ClockType:$clock, UInt1Type:$cond, StrAttr:$formatString,
+        Variadic<FIRRTLBaseType>:$substitutions, StrAttr:$name,
+        DefaultValuedAttr<PrintfSubstitutionEnumArrayAttr, "{}">:$specialSubstitutions);
   let results = (outs);
 
   let assemblyFormat = [{

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -5765,7 +5765,11 @@ static ParseResult parsePrintfAttrs(OpAsmParser &p,
 
 static void printPrintfAttrs(OpAsmPrinter &p, Operation *op,
                              DictionaryAttr attr) {
-  printElideEmptyName(p, op, attr, {"formatString"});
+  SmallVector<StringRef, 2> elides{"formatString"};
+  if (op->getAttrOfType<ArrayAttr>("specialSubstitutions").empty())
+    elides.push_back("specialSubstitutions");
+
+  printElideEmptyName(p, op, attr, elides);
 }
 
 static ParseResult parseStopAttrs(OpAsmParser &p, NamedAttrList &resultAttrs) {

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2023,3 +2023,21 @@ circuit Contracts:
     node u3 = u
     node v3 = v
     node w3 = w
+
+;// -----
+FIRRTL version 4.1.0
+circuit Foo:
+  public module Foo:
+    input clock: Clock
+    ; In FIRRTL versions < 4.2.0, the following is not a "special substitution".
+    ; CHECK{{LITERAL}}: firrtl.printf %clock, %c1_ui1, "[{{SimulationTime}}]: hello world "
+    printf(clock, UInt<1>(1), "[{{SimulationTime}}]: hello world")
+
+;// -----
+FIRRTL version 4.2.0
+circuit Foo:
+  public module Foo:
+    input clock: Clock
+    ; In FIRRTL versions >= 4.2.0, the following is not a "special substitution".
+    ; CHECK{{LITERAL}}: firrtl.printf %clock, %c1_ui1, "[{{}}]: hello world " {specialSubstitutions = [#firrtl<printfSubstitution SimulationTime>]}
+    printf(clock, UInt<1>(1), "[{{SimulationTime}}]: hello world")


### PR DESCRIPTION
Implement parsing/emission of a new substitution format for FIRRTL. This allows for special double curly brace quoted strings to be used to mean "special" substitutions. Currently, the only one supported is `SimulationTime`. We plan to add `HierarchicalName`, too.

E.g., this will parse the following differently if the FIRRTL version is 4.2.0:

``` firrtl
FIRRTL version 4.2.0
circuit Foo :
  public module Foo :
    input clock: Clock

    printf(clock, UInt<1>(1), "[{{SimulationTime}}]: hello world")
```

This becomes:

``` mlir
module {
  firrtl.circuit "Foo" {
    firrtl.module @Foo(in %clock: !firrtl.clock) attributes {convention = #firrtl<convention scalarized>} {
      %c1_ui1 = firrtl.constant 1 : !firrtl.const.uint<1>
      firrtl.printf %clock, %c1_ui1, "[{{}}]: hello world" {specialSubstitutions = [#firrtl<printfSubstitution SimulationTime>]}  : !firrtl.clock, !firrtl.const.uint<1>
    }
  }
}
```