### PR TITLE
[AffineParallelOpUnparallelize][Calyx] Affine parallel loop unparallelize to nested for and parallel loop

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPasses.h
+++ b/include/circt/Dialect/Calyx/CalyxPasses.h
@@ -31,6 +31,7 @@ std::unique_ptr<mlir::Pass> createResetInsertionPass();
 std::unique_ptr<mlir::Pass> createGroupInvariantCodeMotionPass();
 std::unique_ptr<mlir::Pass> createAffineParallelUnrollPass();
 std::unique_ptr<mlir::Pass> createAffineToSCFPass();
+std::unique_ptr<mlir::Pass> createAffinePloopUnparallelizePass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -283,7 +283,7 @@ def AffinePloopUnparallelize : Pass<"affine-ploop-unparallelize", "::mlir::func:
           }
           default {}
         }
-      }
+      } {unparallelized}
       ```
   }];
 }

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -245,4 +245,47 @@ def AffineToSCF : Pass<"calyx-affine-to-scf", "::mlir::func::FuncOp"> {
   let constructor = "circt::calyx::createAffineToSCFPass()";
 }
 
+def AffinePloopUnparallelize : Pass<"affine-ploop-unparallelize", "::mlir::func::FuncOp"> {
+  let summary = "Unparallelize `affine.parallel` op to `affine.for`";
+  let dependentDialects = ["mlir::affine::AffineDialect"];
+  let constructor = "circt::calyx::createAffinePloopUnparallelizePass()";
+  let description = [{
+      Unparallelize `affine.parallel` op to `affine.for` by the factor
+      specified in the attribute.
+      An example:
+      ```
+      #map_mod = affine_map<d0 -> d0 mod 2>
+      affine.parallel (%ip) = (0) to (6) {
+        %mod = affine.apply #map_mod(%ip)
+        scf.index_switch %mod:
+        case 1 {
+          affine.store %cst, %mem0[%ip floordiv 2] : memref<3xf32>
+        }
+        case 0 {
+          affine.store %cst, %mem1[%ip floordiv 2] : memref<3xf32>
+        }
+        default {}
+      } {unparallelize.factor = 2}
+
+      =>
+
+      #map_sum = affine_map<(d0, d1) -> (d0 + d1)>
+      #map_mod = affine_map<d0 -> d0 mod 2>
+      affine.for %if = 0 to 6 step 2 {
+        affine.parallel (%ip) = (0) to (2) {
+          %i = affine.apply #map_sum(%if, %ip)
+          %mod = affine.apply #map_mod(%i)
+          scf.index_switch %mod:
+          case 0 {
+            affine.store %cst, %mem0[%i floordiv 2] : memref<3xf32>
+          }
+          case 1 {
+            affine.store %cst, %mem1[%i floordiv 2] : memref<3xf32>
+          }
+          default {}
+        }
+      }
+      ```
+  }];
+}
 #endif // CIRCT_DIALECT_CALYX_CALYXPASSES_TD

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -251,8 +251,7 @@ def AffinePloopUnparallelize : Pass<"affine-ploop-unparallelize", "::mlir::func:
   let constructor = "circt::calyx::createAffinePloopUnparallelizePass()";
   let description = [{
       Unparallelize `affine.parallel` op to `affine.for` by the factor
-      specified in the attribute.
-      An example:
+      specified in the attribute. For example:
       ```
       #map_mod = affine_map<d0 -> d0 mod 2>
       affine.parallel (%ip) = (0) to (6) {

--- a/lib/Dialect/Calyx/Transforms/AffinePloopUnparallelize.cpp
+++ b/lib/Dialect/Calyx/Transforms/AffinePloopUnparallelize.cpp
@@ -78,6 +78,7 @@ public:
     auto outerLoop = rewriter.create<affine::AffineForOp>(
         loc, lowerBound, rewriter.getDimIdentityMap(), upperBound,
         rewriter.getDimIdentityMap(), step * factor);
+    outerLoop->setAttr("unparallelized", rewriter.getUnitAttr());
 
     rewriter.setInsertionPointToStart(outerLoop.getBody());
     AffineMap lbMap = AffineMap::get(

--- a/lib/Dialect/Calyx/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Calyx/Transforms/CMakeLists.txt
@@ -9,6 +9,7 @@ add_circt_dialect_library(CIRCTCalyxTransforms
   CalyxLoweringUtils.cpp
   AffineParallelUnroll.cpp
   AffineToSCF.cpp
+  AffinePloopUnparallelize.cpp
 
   DEPENDS
   CIRCTCalyxTransformsIncGen

--- a/test/Dialect/Calyx/affine-ploop-unparallelize.mlir
+++ b/test/Dialect/Calyx/affine-ploop-unparallelize.mlir
@@ -9,7 +9,7 @@
 // CHECK:                 affine.store %[[VAL_1]], %[[VAL_0]]{{\[}}%[[VAL_2]] + %[[VAL_3]], %[[VAL_4]]] : memref<16x4xf32>
 // CHECK:               }
 // CHECK:             }
-// CHECK:           }
+// CHECK:           } {unparallelized}
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Dialect/Calyx/affine-ploop-unparallelize.mlir
+++ b/test/Dialect/Calyx/affine-ploop-unparallelize.mlir
@@ -38,9 +38,9 @@ module {
 // CHECK:                 affine.parallel (%[[VAL_5:.*]]) = (0) to (1) {
 // CHECK:                   affine.store %[[VAL_1]], %[[VAL_0]]{{\[}}%[[VAL_2]] + %[[VAL_3]], %[[VAL_4]] + %[[VAL_5]]] : memref<16x4xf32>
 // CHECK:                 }
-// CHECK:               }
+// CHECK:               } {unparallelized}
 // CHECK:             }
-// CHECK:           }
+// CHECK:           } {unparallelized}
 // CHECK:           return
 // CHECK:         }
 

--- a/test/Dialect/Calyx/affine-ploop-unparallelize.mlir
+++ b/test/Dialect/Calyx/affine-ploop-unparallelize.mlir
@@ -1,0 +1,26 @@
+// RUN: circt-opt --affine-ploop-unparallelize --canonicalize --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL:   func.func @main(
+// CHECK-SAME:                    %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<16x4xf32>) {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           affine.for %[[VAL_2:.*]] = 0 to 4 step 2 {
+// CHECK:             affine.parallel (%[[VAL_3:.*]]) = (0) to (2) {
+// CHECK:               affine.for %[[VAL_4:.*]] = 0 to 16 {
+// CHECK:                 affine.store %[[VAL_1]], %[[VAL_0]]{{\[}}%[[VAL_2]] + %[[VAL_3]], %[[VAL_4]]] : memref<16x4xf32>
+// CHECK:               }
+// CHECK:             } {unparallelized}
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+module {
+  func.func @main(%arg0: memref<16x4xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    affine.parallel (%arg2) = (0) to (4) {
+      affine.for %arg3 = 0 to 16 {
+        affine.store %c0, %arg0[%arg2, %arg3] : memref<16x4xf32>
+      }
+    } {unparallelize.factor=2}
+    return
+  }
+}

--- a/test/Dialect/Calyx/affine-ploop-unparallelize.mlir
+++ b/test/Dialect/Calyx/affine-ploop-unparallelize.mlir
@@ -8,7 +8,7 @@
 // CHECK:               affine.for %[[VAL_4:.*]] = 0 to 16 {
 // CHECK:                 affine.store %[[VAL_1]], %[[VAL_0]]{{\[}}%[[VAL_2]] + %[[VAL_3]], %[[VAL_4]]] : memref<16x4xf32>
 // CHECK:               }
-// CHECK:             } {unparallelized}
+// CHECK:             }
 // CHECK:           }
 // CHECK:           return
 // CHECK:         }
@@ -20,6 +20,37 @@ module {
       affine.for %arg3 = 0 to 16 {
         affine.store %c0, %arg0[%arg2, %arg3] : memref<16x4xf32>
       }
+    } {unparallelize.factor=2}
+    return
+  }
+}
+
+// -----
+
+// Test nested `affine.parallel`s
+
+// CHECK-LABEL:   func.func @main(
+// CHECK-SAME:                    %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<16x4xf32>) {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           affine.for %[[VAL_2:.*]] = 0 to 4 step 2 {
+// CHECK:             affine.parallel (%[[VAL_3:.*]]) = (0) to (2) {
+// CHECK:               affine.for %[[VAL_4:.*]] = 0 to 16 {
+// CHECK:                 affine.parallel (%[[VAL_5:.*]]) = (0) to (1) {
+// CHECK:                   affine.store %[[VAL_1]], %[[VAL_0]]{{\[}}%[[VAL_2]] + %[[VAL_3]], %[[VAL_4]] + %[[VAL_5]]] : memref<16x4xf32>
+// CHECK:                 }
+// CHECK:               }
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+module {
+  func.func @main(%arg0: memref<16x4xf32>) {
+    %c0 = arith.constant 0.0 : f32
+    affine.parallel (%arg2) = (0) to (4) {
+      affine.parallel (%arg3) = (0) to (16) {
+        affine.store %c0, %arg0[%arg2, %arg3] : memref<16x4xf32>
+      } {unparallelize.factor=1}
     } {unparallelize.factor=2}
     return
   }


### PR DESCRIPTION
This pass unparallelize `affine.parallel` op by `factor` (attached as the attribute).

We need this pass to coordinate with the memory banking pass for the Calyx dialect.
Suppose we have a memory `%alloc` banked to two: `%alloc_0` and `%alloc_1`, and suppose the program looks like:
```mlir
affine.parallel (%arg) = (0) to (8) {
  scf.index_switch %arg mod 2:
  case 1 {
    memref.store %cst, %alloc_0[%arg floordiv 2]
  }
  case 0 {
    memref.store %cst, %alloc_1[%arg floordiv 2]
  }
}
```

By running `--lower-scf-to-calyx` pass, the resulting program will have `calyx.par` with 8 arms; but there are only 2 banks. So the general issue is that, when `affine.parallel`'s total number of trip counts is greater than the number of banks, there will be memory access contention when we later lower to Calyx.