### PR TITLE
[SCFToCalyx] If op with sequential condition bug fix

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -405,9 +405,13 @@ public:
   /// Put the name of the callee and the instance of the call into map.
   void addInstance(StringRef calleeName, InstanceOp instanceOp);
 
-  bool isSeqGuardCmpLibOp(Operation *);
+  /// Returns if `op` is a compare operator that requires a register to hold the
+  /// value of its sequential guard computation.
+  bool isSeqGuardCmpLibOp(Operation *op);
 
-  void addSeqGuardCmpLibOp(Operation *);
+  /// Add `op` if it's a compare operator that requires a register to hold the
+  /// value of its sequential guard computation.
+  void addSeqGuardCmpLibOp(Operation *op);
 
   /// Returns the evaluating group or None if not found.
   template <typename TGroupOp = calyx::GroupInterface>
@@ -540,6 +544,8 @@ private:
   /// https://docs.calyxir.org/lang/data-format.html?highlight=json#the-data-format
   llvm::json::Value extMemData;
 
+  /// A set of compare operators that require registers to hold their sequential
+  /// guard computation.
   DenseSet<Operation *> seqGuardCmpLibOps;
 };
 

--- a/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
+++ b/include/circt/Dialect/Calyx/CalyxLoweringUtils.h
@@ -405,6 +405,10 @@ public:
   /// Put the name of the callee and the instance of the call into map.
   void addInstance(StringRef calleeName, InstanceOp instanceOp);
 
+  bool isSeqGuardCmpLibOp(Operation *);
+
+  void addSeqGuardCmpLibOp(Operation *);
+
   /// Returns the evaluating group or None if not found.
   template <typename TGroupOp = calyx::GroupInterface>
   std::optional<TGroupOp> findEvaluatingGroup(Value v) {
@@ -535,6 +539,8 @@ private:
   /// A json file to store external global memory data. See
   /// https://docs.calyxir.org/lang/data-format.html?highlight=json#the-data-format
   llvm::json::Value extMemData;
+
+  DenseSet<Operation *> seqGuardCmpLibOps;
 };
 
 /// An interface for conversion passes that lower Calyx programs. This handles

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -481,8 +481,11 @@ private:
 
     rewriter.setInsertionPointToEnd(groupOp.getBodyBlock());
     auto loc = cmpIOp.getLoc();
-    // `calyxOp` will be one of `EqLibOp`, `SleLibOp`, etc. The
-    // 2'th `result` corresponds to the output result of `calyxOp`.
+    assert(
+        (isa<calyx::EqLibOp, calyx::NeqLibOp, calyx::SleLibOp, calyx::SltLibOp,
+             calyx::LeLibOp, calyx::LtLibOp, calyx::GeLibOp, calyx::GtLibOp,
+             calyx::SgeLibOp, calyx::SgtLibOp>(calyxOp.getOperation())) &&
+        "Must be a Calyx comparison library operation.");
     int64_t outputIndex = 2;
     rewriter.create<calyx::AssignOp>(loc, condReg.getIn(),
                                      calyxOp.getResult(outputIndex));

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -446,14 +446,17 @@ private:
   // Sets up the necessary state and resources for a `CmpIOp` in
   // `buildLibraryBinaryPipeOp` if `cmpIOp` has sequential logic based on its
   // operands.
+  template <typename TCalyxLibOp>
   void setupCmpIOp(PatternRewriter &rewriter, CmpIOp cmpIOp, Operation *group,
                    calyx::RegisterOp &condReg, calyx::RegisterOp &resReg,
-                   bool &isSeqCondCheck) const {
+                   bool &isSeqCondCheck, TCalyxLibOp calyxOp) const {
     bool lhsIsSeqOp = calyx::parentIsSeqCell(cmpIOp.getLhs());
     bool rhsIsSeqOp = calyx::parentIsSeqCell(cmpIOp.getRhs());
 
-    isSeqCondCheck =
-        (lhsIsSeqOp || rhsIsSeqOp) && isa<scf::IfOp>(cmpIOp->getParentOp());
+    bool isIfOpGuard =
+        std::any_of(cmpIOp->getUsers().begin(), cmpIOp->getUsers().end(),
+                    [](auto op) { return isa<scf::IfOp>(op); });
+    isSeqCondCheck = (lhsIsSeqOp || rhsIsSeqOp) && isIfOpGuard;
     if (!isSeqCondCheck)
       return;
 
@@ -473,25 +476,39 @@ private:
     assert(
         lhsIsSeqOp != rhsIsSeqOp &&
         "unexpected sequential operation on both sides; please open an issue");
-    Operation *seqOp = calyx::parentIsSeqCell(cmpIOp.getLhs())
-                           ? cmpIOp.getLhs().getDefiningOp()
-                           : cmpIOp.getRhs().getDefiningOp();
-    condReg = getState<ComponentLoweringState>().getSeqResReg(seqOp);
+    // If `cmpIOp`'s lhs/rhs operand is the result of a sequential operation,
+    // its result will be stored in a register.
+    resReg = cast<calyx::RegisterOp>(calyx::parentIsSeqCell(cmpIOp.getLhs())
+                                         ? cmpIOp.getLhs().getDefiningOp()
+                                         : cmpIOp.getRhs().getDefiningOp());
 
     auto groupOp = cast<calyx::GroupOp>(group);
     getState<ComponentLoweringState>().addBlockScheduleable(cmpIOp->getBlock(),
                                                             groupOp);
 
-    buildAssignmentsForRegisterWrite(
-        rewriter, groupOp, getState<ComponentLoweringState>().getComponentOp(),
-        resReg, condReg.getOut());
+    rewriter.setInsertionPointToEnd(groupOp.getBodyBlock());
+    auto loc = cmpIOp.getLoc();
+    rewriter.create<calyx::AssignOp>(
+        loc, condReg.getIn(),
+        calyxOp.getResult(
+            2)); // `calyxOp` will be one of `EqLibOp`, `SleLibOp`, etc. The
+                 // 2'th `result` corresponds to the output result of `calyxOp`.
+    rewriter.create<calyx::AssignOp>(
+        loc, condReg.getWriteEn(),
+        createConstant(loc, rewriter,
+                       getState<ComponentLoweringState>().getComponentOp(), 1,
+                       1));
+    rewriter.create<calyx::GroupDoneOp>(loc, condReg.getDone());
+
+    getState<ComponentLoweringState>().addSeqGuardCmpLibOp(cmpIOp);
   }
 
   template <typename CmpILibOp>
   LogicalResult buildCmpIOpHelper(PatternRewriter &rewriter, CmpIOp op) const {
-    bool isSeqCondCheck = isa<scf::IfOp>(op->getParentOp()) &&
-                          (calyx::parentIsSeqCell(op.getLhs()) ||
-                           calyx::parentIsSeqCell(op.getRhs()));
+    bool isIfOpGuard = std::any_of(op->getUsers().begin(), op->getUsers().end(),
+                                   [](auto op) { return isa<scf::IfOp>(op); });
+    bool isSeqCondCheck = isIfOpGuard && (calyx::parentIsSeqCell(op.getLhs()) ||
+                                          calyx::parentIsSeqCell(op.getRhs()));
 
     if (isSeqCondCheck)
       return buildLibraryOp<calyx::GroupOp, CmpILibOp>(rewriter, op);
@@ -535,7 +552,8 @@ private:
     calyx::RegisterOp condReg = nullptr, resReg = nullptr;
     if (isa<CmpIOp>(op)) {
       auto cmpIOp = cast<CmpIOp>(op);
-      setupCmpIOp(rewriter, cmpIOp, group, condReg, resReg, isSeqCondCheck);
+      setupCmpIOp(rewriter, cmpIOp, group, condReg, resReg, isSeqCondCheck,
+                  calyxOp);
     }
 
     rewriter.setInsertionPointToEnd(group.getBodyBlock());
@@ -551,7 +569,7 @@ private:
     for (auto res : enumerate(opOutputPorts)) {
       getState<ComponentLoweringState>().registerEvaluatingGroup(res.value(),
                                                                  group);
-      auto dstOp = isSeqCondCheck ? resReg.getOut() : res.value();
+      auto dstOp = isSeqCondCheck ? condReg.getOut() : res.value();
       op->getResult(res.index()).replaceAllUsesWith(dstOp);
     }
 

--- a/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
+++ b/lib/Dialect/Calyx/Transforms/CalyxLoweringUtils.cpp
@@ -458,6 +458,14 @@ void ComponentLoweringStateInterface::addInstance(StringRef calleeName,
   instanceMap[calleeName] = instanceOp;
 }
 
+bool ComponentLoweringStateInterface::isSeqGuardCmpLibOp(Operation *op) {
+  return seqGuardCmpLibOps.contains(op);
+}
+
+void ComponentLoweringStateInterface::addSeqGuardCmpLibOp(Operation *op) {
+  seqGuardCmpLibOps.insert(op);
+}
+
 //===----------------------------------------------------------------------===//
 // CalyxLoweringState
 //===----------------------------------------------------------------------===//
@@ -716,6 +724,10 @@ void InlineCombGroups::recurseInlineCombGroups(
             calyx::IntToFpOpIEEE754, calyx::DivSqrtOpIEEE754>(
             src.getDefiningOp()))
       continue;
+
+    if (state.isSeqGuardCmpLibOp(src.getDefiningOp())) {
+      continue;
+    }
 
     auto srcCombGroup = dyn_cast<calyx::CombGroupOp>(
         state.getEvaluatingGroup(src).getOperation());

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -829,24 +829,6 @@ module {
 
 // Test if ops with sequential condition check.
 
-// CHECK-LABEL:   calyx.component @main(
-// CHECK-SAME:                          %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
-// CHECK-SAME:                          %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {clk},
-// CHECK-SAME:                          %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {reset},
-// CHECK-SAME:                          %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {go}) -> (
-// CHECK-SAME:                          %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {done}) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = calyx.seq_mem @mem_1 <[120] x 32> [7] {external = true} : i7, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.seq_mem @mem_0 <[120] x 32> [7] {external = true} : i7, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.instance @main_1_instance of @main_1 : i32, i1, i1, i1, i1
-// CHECK:           calyx.wires {
-// CHECK:           }
-// CHECK:           calyx.control {
-// CHECK:             calyx.seq {
-// CHECK:               calyx.invoke @main_1_instance[arg_mem_0 = mem_0, arg_mem_1 = mem_1](%[[VAL_21]] = %[[VAL_0]]) -> (i32)
-// CHECK:             }
-// CHECK:           }
-// CHECK:         } {toplevel}
-
 // CHECK-LABEL:   calyx.component @main_1(
 // CHECK-SAME:                            %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
 // CHECK-SAME:                            %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {clk},
@@ -858,46 +840,51 @@ module {
 // CHECK:           %[[VAL_7:.*]] = hw.constant 1 : i32
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_1 : i32, i7
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_0 : i32, i7
-// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.std_eq @std_eq_0 : i32, i32, i1
-// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.register @remui_0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]] = calyx.std_remu_pipe @std_remu_pipe_0 : i1, i1, i1, i32, i32, i32, i1
-// CHECK:           %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]] = calyx.seq_mem @arg_mem_1 <[120] x 32> [7] : i7, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_36:.*]], %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]] = calyx.seq_mem @arg_mem_0 <[120] x 32> [7] : i7, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.register @cmpi_0_reg : i1, i1, i1, i1, i1, i1
+// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.std_eq @std_eq_0 : i32, i32, i1
+// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]] = calyx.register @remui_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]] = calyx.std_remu_pipe @std_remu_pipe_0 : i1, i1, i1, i32, i32, i32, i1
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]] = calyx.seq_mem @arg_mem_1 <[120] x 32> [7] : i7, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]], %[[VAL_46:.*]], %[[VAL_47:.*]], %[[VAL_48:.*]], %[[VAL_49:.*]] = calyx.seq_mem @arg_mem_0 <[120] x 32> [7] : i7, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.group @bb0_0 {
-// CHECK:               calyx.assign %[[VAL_24]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_25]] = %[[VAL_6]] : i32
-// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_26]] : i32
-// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_27]] : i1
-// CHECK:               %[[VAL_44:.*]] = comb.xor %[[VAL_27]], %[[VAL_5]] : i1
-// CHECK:               calyx.assign %[[VAL_23]] = %[[VAL_44]] ? %[[VAL_5]] : i1
-// CHECK:               calyx.group_done %[[VAL_20]] : i1
+// CHECK:               calyx.assign %[[VAL_30]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_31]] = %[[VAL_6]] : i32
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_32]] : i32
+// CHECK:               calyx.assign %[[VAL_22]] = %[[VAL_33]] : i1
+// CHECK:               %[[VAL_50:.*]] = comb.xor %[[VAL_33]], %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_50]] ? %[[VAL_5]] : i1
+// CHECK:               calyx.group_done %[[VAL_26]] : i1
 // CHECK:             }
-// CHECK:             calyx.comb_group @bb0_1 {
-// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_19]] : i32
+// CHECK:             calyx.group @bb0_1 {
+// CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_20]] : i1
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_25]] : i32
+// CHECK:               calyx.group_done %[[VAL_17]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_2 {
 // CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_7]] : i32
-// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_9]] : i7
-// CHECK:               calyx.assign %[[VAL_33]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_32]] = %[[VAL_5]] : i1
-// CHECK:               calyx.assign %[[VAL_31]] = %[[VAL_5]] : i1
-// CHECK:               calyx.group_done %[[VAL_35]] : i1
+// CHECK:               calyx.assign %[[VAL_34]] = %[[VAL_9]] : i7
+// CHECK:               calyx.assign %[[VAL_39]] = %[[VAL_0]] : i32
+// CHECK:               calyx.assign %[[VAL_38]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_37]] = %[[VAL_5]] : i1
+// CHECK:               calyx.group_done %[[VAL_41]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_3 {
 // CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_6]] : i32
-// CHECK:               calyx.assign %[[VAL_36]] = %[[VAL_11]] : i7
-// CHECK:               calyx.assign %[[VAL_41]] = %[[VAL_19]] : i32
-// CHECK:               calyx.assign %[[VAL_40]] = %[[VAL_5]] : i1
-// CHECK:               calyx.assign %[[VAL_39]] = %[[VAL_5]] : i1
-// CHECK:               calyx.group_done %[[VAL_43]] : i1
+// CHECK:               calyx.assign %[[VAL_42]] = %[[VAL_11]] : i7
+// CHECK:               calyx.assign %[[VAL_47]] = %[[VAL_25]] : i32
+// CHECK:               calyx.assign %[[VAL_46]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_45]] = %[[VAL_5]] : i1
+// CHECK:               calyx.group_done %[[VAL_49]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {
 // CHECK:             calyx.seq {
 // CHECK:               calyx.enable @bb0_0
-// CHECK:               calyx.if %[[VAL_14]] with @bb0_1 {
+// CHECK:               calyx.enable @bb0_1
+// CHECK:               calyx.if %[[VAL_16]] {
 // CHECK:                 calyx.seq {
 // CHECK:                   calyx.enable @bb0_2
 // CHECK:                 }


### PR DESCRIPTION
This patch fixes a logic bug that checks if an `scf.if` op's condition needs a register to hold the result of sequential computation