### PR TITLE
[FIRRTL] Add FormatStringType

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1698,7 +1698,7 @@ def TimeOp : FIRRTLOp<"fstring.time", [HasCustomSSAName, Pure]> {
   }];
 
   let arguments = (ins);
-  let results = (outs FStringTimeType:$result);
+  let results = (outs FStringType:$result);
   let assemblyFormat = [{
     attr-dict `:` type($result)
   }];

--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1681,4 +1681,28 @@ def LTLClockIntrinsicOp : LTLIntrinsicOp<"clock"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Format String Expression operations
+//===----------------------------------------------------------------------===//
+
+def TimeOp : FIRRTLOp<"fstring.time", [HasCustomSSAName, Pure]> {
+
+  let summary = "an operation that represents the current simulation time";
+  let description = [{
+    This operation represents the current simulation time.  It returns a format
+    string type which can only be used as a substitution inside a printf.  This
+    operation is not represented in the FIRRTL spec.
+
+    This operation is the FIRRTL Dialect representation of the special
+    substitution `{{SimulationTime}}`.
+  }];
+
+  let arguments = (ins);
+  let results = (outs FStringTimeType:$result);
+  let assemblyFormat = [{
+    attr-dict `:` type($result)
+  }];
+
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLEXPRESSIONS_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -112,7 +112,7 @@ def PrintFOp : FIRRTLOp<"printf"> {
   let summary = "Formatted Print Statement";
 
   let arguments = (ins ClockType:$clock, UInt1Type:$cond, StrAttr:$formatString,
-                       Variadic<FIRRTLBaseType>:$substitutions, StrAttr:$name);
+                       Variadic<PrintfOperandType>:$substitutions, StrAttr:$name);
   let results = (outs);
 
   let assemblyFormat = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -62,7 +62,7 @@ class PathType;
 class BoolType;
 class DoubleType;
 class BaseTypeAliasType;
-class FStringTimeType;
+class FStringType;
 
 /// A collection of bits indicating the recursive properties of a type.
 struct RecursiveTypeProperties {
@@ -186,7 +186,7 @@ public:
   static bool classof(Type type) {
     return llvm::isa<FIRRTLDialect>(type.getDialect()) &&
            !llvm::isa<PropertyType, RefType, LHSType, OpenBundleType,
-                      OpenVectorType, FStringTimeType>(type);
+                      OpenVectorType, FStringType>(type);
   }
 
   /// Returns true if this is a non-const "passive" that which is not analog.

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.h
@@ -62,6 +62,7 @@ class PathType;
 class BoolType;
 class DoubleType;
 class BaseTypeAliasType;
+class FStringTimeType;
 
 /// A collection of bits indicating the recursive properties of a type.
 struct RecursiveTypeProperties {
@@ -185,7 +186,7 @@ public:
   static bool classof(Type type) {
     return llvm::isa<FIRRTLDialect>(type.getDialect()) &&
            !llvm::isa<PropertyType, RefType, LHSType, OpenBundleType,
-                      OpenVectorType>(type);
+                      OpenVectorType, FStringTimeType>(type);
   }
 
   /// Returns true if this is a non-const "passive" that which is not analog.

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -91,11 +91,11 @@ def PassiveType : FIRRTLDialectType<
 
 def SizedType : FIRRTLDialectType<CPred<"type_isa<FIRRTLBaseType>($_self) && "
     "!type_cast<FIRRTLBaseType>($_self).hasUninferredWidth()">,
-    "a sized type (contains no uninferred widths)", 
+    "a sized type (contains no uninferred widths)",
     "::circt::firrtl::FIRRTLBaseType">;
 def SizedOrForeignType : AnyTypeOf<[SizedType, ForeignType]>;
 def SizedPassiveType : FIRRTLDialectType<And<[SizedType.predicate,PassiveType.predicate]>,
-    "a sized passive base type (contains no uninferred widths, or flips)", 
+    "a sized passive base type (contains no uninferred widths, or flips)",
     "::circt::firrtl::FIRRTLBaseType">;
 def SizedPassiveOrForeignType : AnyTypeOf<[SizedPassiveType, ForeignType]>;
 
@@ -235,5 +235,19 @@ def DoubleType : FIRRTLDialectTypeHelper<"DoubleType", "double type">,
 
 def PathType : FIRRTLDialectTypeHelper<"PathType", "path type">,
   BuildableType<"::circt::firrtl::PathType::get($_builder.getContext())">;
+
+//===----------------------------------------------------------------------===//
+// Format String Types
+//===----------------------------------------------------------------------===//
+
+def FStringTimeType :
+  FIRRTLDialectTypeHelper<"FStringTimeType",
+    "a format string type that represents the current simulation time">,
+  BuildableType<"::circt::firrtl::FStringTimeType::get($_builder.getContext())">;
+
+def PrintfOperandType : FIRRTLDialectType<
+  CPred<"type_isa<FIRRTLBaseType, FStringTimeType>($_self)">,
+    "a printf operand type (a FIRRTL base type or a format string type)",
+    "::circt::firrtl::FIRRTLType">;
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPES_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypes.td
@@ -240,13 +240,16 @@ def PathType : FIRRTLDialectTypeHelper<"PathType", "path type">,
 // Format String Types
 //===----------------------------------------------------------------------===//
 
-def FStringTimeType :
-  FIRRTLDialectTypeHelper<"FStringTimeType",
-    "a format string type that represents the current simulation time">,
-  BuildableType<"::circt::firrtl::FStringTimeType::get($_builder.getContext())">;
+def FStringType :
+  FIRRTLDialectTypeHelper<"FStringType",
+    "a format string type">,
+  BuildableType<"::circt::firrtl::FStringType::get($_builder.getContext())">;
 
+// TODO: Migrate off of this by making the operands for `PrintfOp` use only
+// `FStringType`.  This requires conversion ops that convert from
+// `FIRRTLBaseType` to `FStringType`.
 def PrintfOperandType : FIRRTLDialectType<
-  CPred<"type_isa<FIRRTLBaseType, FStringTimeType>($_self)">,
+  CPred<"type_isa<FIRRTLBaseType, FStringType>($_self)">,
     "a printf operand type (a FIRRTL base type or a format string type)",
     "::circt::firrtl::FIRRTLType">;
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -578,4 +578,11 @@ def DoubleImpl : PropImplType<"Double"> {
   let typeName = "firrtl.propDouble";
 }
 
+def FStringTimeImpl : FIRRTLImplType<"FStringTime", [], "::circt::firrtl::FIRRTLType" > {
+  let summary = "A format string type that represents the current simulatoin time";
+  let parameters = (ins);
+  let genStorageClass = true;
+  let typeName = "firrtl.fstring.time";
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPESIMPL_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -578,11 +578,11 @@ def DoubleImpl : PropImplType<"Double"> {
   let typeName = "firrtl.propDouble";
 }
 
-def FStringTimeImpl : FIRRTLImplType<"FStringTime", [], "::circt::firrtl::FIRRTLType" > {
-  let summary = "A format string type that represents the current simulatoin time";
+def FStringImpl : FIRRTLImplType<"FString", [], "::circt::firrtl::FIRRTLType" > {
+  let summary = "A format string type";
   let parameters = (ins);
   let genStorageClass = true;
-  let typeName = "firrtl.fstring.time";
+  let typeName = "firrtl.fstring";
 }
 
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLTYPESIMPL_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -66,10 +66,11 @@ public:
             // Property expressions.
             StringConstantOp, FIntegerConstantOp, BoolConstantOp,
             DoubleConstantOp, ListCreateOp, ListConcatOp, UnresolvedPathOp,
-            PathOp, IntegerAddOp, IntegerMulOp, IntegerShrOp>(
-            [&](auto expr) -> ResultType {
-              return thisCast->visitExpr(expr, args...);
-            })
+            PathOp, IntegerAddOp, IntegerMulOp, IntegerShrOp,
+            // Format String expressions
+            TimeOp>([&](auto expr) -> ResultType {
+          return thisCast->visitExpr(expr, args...);
+        })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidExpr(op, args...);
         });
@@ -225,6 +226,9 @@ public:
   HANDLE(IntegerAddOp, Unhandled);
   HANDLE(IntegerMulOp, Unhandled);
   HANDLE(IntegerShrOp, Unhandled);
+
+  // Format string expressions
+  HANDLE(TimeOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -857,6 +857,7 @@ void Emitter::emitStatement(PrintFOp op) {
         c = origFormatString[++i];
         switch (c) {
         case 'b':
+        case 'c':
         case 'd':
         case 'x':
           substitutions.push_back(op.getSubstitutions()[substitutionIdx++]);

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -146,6 +146,8 @@ struct Emitter {
   void emitExpression(ShlPrimOp op) { emitPrimExpr("shl", op, op.getAmount()); }
   void emitExpression(ShrPrimOp op) { emitPrimExpr("shr", op, op.getAmount()); }
 
+  void emitExpression(TimeOp op){};
+
   // Funnel all ops without attrs into `emitPrimExpr`.
 #define HANDLE(OPTYPE, MNEMONIC)                                               \
   void emitExpression(OPTYPE op) { emitPrimExpr(MNEMONIC, op); }
@@ -372,7 +374,7 @@ private:
     SymbolTable symbolTable;
     hw::InnerSymbolTableCollection istc;
     hw::InnerRefNamespace irn{symbolTable, istc};
-    SymInfos(Operation *op) : symbolTable(op), istc(op) {};
+    SymInfos(Operation *op) : symbolTable(op), istc(op){};
   };
   std::optional<std::reference_wrapper<SymInfos>> symInfos;
 
@@ -834,8 +836,59 @@ void Emitter::emitStatement(PrintFOp op) {
     ps << "," << PP::space;
     emitExpression(op.getCond());
     ps << "," << PP::space;
-    ps.writeQuotedEscaped(op.getFormatString());
-    for (auto operand : op.getSubstitutions()) {
+
+    // Replace the generic "{{}}" special substitutions with their attributes.
+    // E.g.:
+    //
+    //     "hello {{}} world"(%time)
+    //
+    // Becomes:
+    //
+    //     "hello {{SimulationTime}} world"
+    SmallString<64> formatString;
+    auto origFormatString = op.getFormatString();
+    auto substitutionIdx = 0;
+    SmallVector<Value, 4> substitutions;
+    for (size_t i = 0, e = origFormatString.size(); i != e; ++i) {
+      auto c = origFormatString[i];
+      switch (c) {
+      case '%': {
+        formatString.push_back(c);
+        c = origFormatString[++i];
+        switch (c) {
+        case 'b':
+        case 'd':
+        case 'x':
+          substitutions.push_back(op.getSubstitutions()[substitutionIdx++]);
+          break;
+        default:
+          break;
+        }
+        formatString.push_back(c);
+        break;
+      }
+      case '{':
+        if (origFormatString.slice(i, i + 4) == "{{}}") {
+          formatString.append("{{");
+          FIRRTLTypeSwitch<FIRRTLType>(
+              type_cast<FIRRTLType>(
+                  op.getSubstitutions()[substitutionIdx++].getType()))
+              .Case<FStringTimeType>(
+                  [&](auto) { formatString.append("SimulationTime"); })
+              .Default([&](auto) {
+                emitError(op, "unsupported fstring substitution type");
+              });
+          formatString.append("}}");
+        }
+        i += 3;
+        break;
+      default:
+        formatString.push_back(c);
+      }
+    }
+    ps.writeQuotedEscaped(formatString);
+
+    for (auto operand : substitutions) {
       ps << "," << PP::space;
       emitExpression(operand);
     }
@@ -884,7 +937,8 @@ void Emitter::emitStatement(ConnectOp op) {
   } else {
     auto emitLHS = [&]() { emitExpression(op.getDest()); };
     if (op.getSrc().getDefiningOp<InvalidValueOp>()) {
-      emitAssignLike(emitLHS, [&]() { ps << "invalid"; }, PPExtString("is"));
+      emitAssignLike(
+          emitLHS, [&]() { ps << "invalid"; }, PPExtString("is"));
     } else {
       emitAssignLike(
           emitLHS, [&]() { emitExpression(op.getSrc()); }, PPExtString("<="));
@@ -910,7 +964,8 @@ void Emitter::emitStatement(MatchingConnectOp op) {
   } else {
     auto emitLHS = [&]() { emitExpression(op.getDest()); };
     if (op.getSrc().getDefiningOp<InvalidValueOp>()) {
-      emitAssignLike(emitLHS, [&]() { ps << "invalid"; }, PPExtString("is"));
+      emitAssignLike(
+          emitLHS, [&]() { ps << "invalid"; }, PPExtString("is"));
     } else {
       emitAssignLike(
           emitLHS, [&]() { emitExpression(op.getSrc()); }, PPExtString("<="));
@@ -1228,10 +1283,11 @@ void Emitter::emitExpression(Value value) {
           FIntegerConstantOp, BoolConstantOp, DoubleConstantOp, ListCreateOp,
           UnresolvedPathOp, GenericIntrinsicOp,
           // Reference expressions
-          RefSendOp, RefResolveOp, RefSubOp, RWProbeOp, RefCastOp>(
-          [&](auto op) {
-            ps.scopedBox(PP::ibox0, [&]() { emitExpression(op); });
-          })
+          RefSendOp, RefResolveOp, RefSubOp, RWProbeOp, RefCastOp,
+          // Format String expressions
+          TimeOp>([&](auto op) {
+        ps.scopedBox(PP::ibox0, [&]() { emitExpression(op); });
+      })
       .Default([&](auto op) {
         emitOpError(op, "not supported as expression");
         ps << "<unsupported-expr-" << PPExtString(op->getName().stripDialect())

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -870,14 +870,11 @@ void Emitter::emitStatement(PrintFOp op) {
       case '{':
         if (origFormatString.slice(i, i + 4) == "{{}}") {
           formatString.append("{{");
-          FIRRTLTypeSwitch<FIRRTLType>(
-              type_cast<FIRRTLType>(
-                  op.getSubstitutions()[substitutionIdx++].getType()))
-              .Case<FStringTimeType>(
-                  [&](auto) { formatString.append("SimulationTime"); })
-              .Default([&](auto) {
-                emitError(op, "unsupported fstring substitution type");
-              });
+          if (isa<TimeOp>(
+                  op.getSubstitutions()[substitutionIdx++].getDefiningOp()))
+            formatString.append("SimulationTime");
+          else
+            emitError(op, "unsupported fstring substitution type");
           formatString.append("}}");
         }
         i += 3;

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -847,9 +847,8 @@ void Emitter::emitStatement(PrintFOp op) {
     //     "hello {{SimulationTime}} world"
     SmallString<64> formatString;
     auto origFormatString = op.getFormatString();
-    auto substitutionIdx = 0;
     SmallVector<Value, 4> substitutions;
-    for (size_t i = 0, e = origFormatString.size(); i != e; ++i) {
+    for (size_t i = 0, e = origFormatString.size(), opIdx = 0; i != e; ++i) {
       auto c = origFormatString[i];
       switch (c) {
       case '%': {
@@ -860,7 +859,7 @@ void Emitter::emitStatement(PrintFOp op) {
         case 'c':
         case 'd':
         case 'x':
-          substitutions.push_back(op.getSubstitutions()[substitutionIdx++]);
+          substitutions.push_back(op.getSubstitutions()[opIdx++]);
           break;
         default:
           break;
@@ -871,8 +870,7 @@ void Emitter::emitStatement(PrintFOp op) {
       case '{':
         if (origFormatString.slice(i, i + 4) == "{{}}") {
           formatString.append("{{");
-          if (isa<TimeOp>(
-                  op.getSubstitutions()[substitutionIdx++].getDefiningOp()))
+          if (isa<TimeOp>(op.getSubstitutions()[opIdx++].getDefiningOp()))
             formatString.append("SimulationTime");
           else
             emitError(op, "unsupported fstring substitution type");

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -6305,6 +6305,18 @@ LayerBlockOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 }
 
 //===----------------------------------------------------------------------===//
+// Format Sring operations
+//===----------------------------------------------------------------------===//
+
+// FIRRTLType TimeOp::inferReturnType(mlir::MLIRContext *context) {
+//   return FormatStringType::get(context);
+// }
+
+void TimeOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  setNameFn(getResult(), "time");
+}
+
+//===----------------------------------------------------------------------===//
 // TblGen Generated Logic.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -6308,10 +6308,6 @@ LayerBlockOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 // Format Sring operations
 //===----------------------------------------------------------------------===//
 
-// FIRRTLType TimeOp::inferReturnType(mlir::MLIRContext *context) {
-//   return FormatStringType::get(context);
-// }
-
 void TimeOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   setNameFn(getResult(), "time");
 }

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -139,6 +139,8 @@ static LogicalResult customTypePrinter(Type type, AsmPrinter &os) {
         os << ">";
       })
       .Case<AnyRefType>([&](AnyRefType type) { os << "anyref"; })
+      .Case<FStringTimeType>(
+          [&](FStringTimeType type) { os << "fstring.time"; })
       .Default([&](auto) { anyFailed = true; });
   return failure(anyFailed);
 }
@@ -466,6 +468,9 @@ static OptionalParseResult customTypeParser(AsmParser &parser, StringRef name,
                BaseTypeAliasType::get(StringAttr::get(context, name), type),
            success();
   }
+  if (name == "fstring.time") {
+    return result = FStringTimeType::get(context), success();
+  }
 
   return {};
 }
@@ -675,6 +680,10 @@ RecursiveTypeProperties FIRRTLType::getRecursiveTypeProperties() const {
       })
       .Case<LHSType>(
           [](auto type) { return type.getType().getRecursiveTypeProperties(); })
+      .Case<FStringTimeType>([](auto type) {
+        return RecursiveTypeProperties{true,  false, false, false,
+                                       false, false, false};
+      })
       .Default([](Type) {
         llvm_unreachable("unknown FIRRTL type");
         return RecursiveTypeProperties{};

--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -139,8 +139,7 @@ static LogicalResult customTypePrinter(Type type, AsmPrinter &os) {
         os << ">";
       })
       .Case<AnyRefType>([&](AnyRefType type) { os << "anyref"; })
-      .Case<FStringTimeType>(
-          [&](FStringTimeType type) { os << "fstring.time"; })
+      .Case<FStringType>([&](auto) { os << "fstring"; })
       .Default([&](auto) { anyFailed = true; });
   return failure(anyFailed);
 }
@@ -468,8 +467,8 @@ static OptionalParseResult customTypeParser(AsmParser &parser, StringRef name,
                BaseTypeAliasType::get(StringAttr::get(context, name), type),
            success();
   }
-  if (name == "fstring.time") {
-    return result = FStringTimeType::get(context), success();
+  if (name == "fstring") {
+    return result = FStringType::get(context), success();
   }
 
   return {};
@@ -680,7 +679,7 @@ RecursiveTypeProperties FIRRTLType::getRecursiveTypeProperties() const {
       })
       .Case<LHSType>(
           [](auto type) { return type.getType().getRecursiveTypeProperties(); })
-      .Case<FStringTimeType>([](auto type) {
+      .Case<FStringType>([](auto type) {
         return RecursiveTypeProperties{true,  false, false, false,
                                        false, false, false};
       })

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2961,6 +2961,7 @@ ParseResult FIRStmtParser::parsePrintf() {
         c = formatString[++i];
         switch (c) {
         case 'b':
+        case 'c':
         case 'd':
         case 'x':
           operands.push_back(specOperands[opIdx++]);

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -2942,12 +2942,12 @@ ParseResult FIRStmtParser::parsePrintf() {
   locationProcessor.setLoc(startTok.getLoc());
 
   // Validate the format string and remove any "special" substitutions.  Only do
-  // this for FIRRTL versions >= 4.2.0.  If at a different FIRRTL version, then
+  // this for FIRRTL versions > 5.0.0.  If at a different FIRRTL version, then
   // just parse this as if it was a string.
   SmallVector<Attribute, 4> specialSubstitutions;
   SmallString<64> validatedFormatString;
   SmallVector<Value, 4> operands;
-  if (version < missingSpecFIRVersion) {
+  if (version < FIRVersion(5, 0, 0)) {
     validatedFormatString = formatString;
     operands.append(specOperands);
   } else {

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -16,6 +16,7 @@
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/CHIRRTLDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLAttributes.h"
+#include "circt/Dialect/FIRRTL/FIRRTLDialect.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Import/FIRAnnotations.h"
@@ -1902,6 +1903,7 @@ private:
                             SymbolRefAttr layerSym);
   ParseResult parseAttach();
   ParseResult parseMemPort(MemDirAttr direction);
+  ParseResult parseFormatString();
   ParseResult parsePrintf();
   ParseResult parseSkip();
   ParseResult parseStop();
@@ -2913,15 +2915,18 @@ ParseResult FIRStmtParser::parsePrintf() {
   if (parseExp(clock, "expected clock expression in printf") ||
       parseToken(FIRToken::comma, "expected ','") ||
       parseExp(condition, "expected condition in printf") ||
-      parseToken(FIRToken::comma, "expected ','") ||
-      parseGetSpelling(formatString) ||
+      parseToken(FIRToken::comma, "expected ','"))
+    return failure();
+
+  auto formatStringLoc = getToken().getLoc();
+  if (parseGetSpelling(formatString) ||
       parseToken(FIRToken::string, "expected format string in printf"))
     return failure();
 
-  SmallVector<Value, 4> operands;
+  SmallVector<Value, 4> specOperands;
   while (consumeIf(FIRToken::comma)) {
-    operands.push_back({});
-    if (parseExp(operands.back(), "expected operand in printf"))
+    specOperands.push_back({});
+    if (parseExp(specOperands.back(), "expected operand in printf"))
       return failure();
   }
   if (parseToken(FIRToken::r_paren, "expected ')'"))
@@ -2936,7 +2941,78 @@ ParseResult FIRStmtParser::parsePrintf() {
 
   locationProcessor.setLoc(startTok.getLoc());
 
-  auto formatStrUnescaped = FIRToken::getStringValue(formatString);
+  // Validate the format string and remove any "special" substitutions.  Only do
+  // this for FIRRTL versions >= 4.2.0.  If at a different FIRRTL version, then
+  // just parse this as if it was a string.
+  SmallVector<Attribute, 4> specialSubstitutions;
+  SmallString<64> validatedFormatString;
+  SmallVector<Value, 4> operands;
+  if (version < missingSpecFIRVersion) {
+    validatedFormatString = formatString;
+    operands.append(specOperands);
+  } else {
+    for (size_t i = 0, e = formatString.size(), opIdx = 0; i != e; ++i) {
+      auto c = formatString[i];
+      switch (c) {
+      // FIRRTL percent format strings.  If this is actually a format string,
+      // then grab one of the "spec" operands.
+      case '%': {
+        validatedFormatString.push_back(c);
+        c = formatString[++i];
+        switch (c) {
+        case 'b':
+        case 'd':
+        case 'x':
+          operands.push_back(specOperands[opIdx++]);
+          break;
+        // Let anything we don't know about through.  This allows for wildcat
+        // use of `%m` if a user wants.
+        default:
+          break;
+        }
+        validatedFormatString.push_back(c);
+        break;
+      }
+      // FIRRTL special format strings.  If this is a special format string,
+      // then create an operation for it and put its result in the operand list.
+      // This will cause the operands to interleave with the spec operands.
+      // Replace any special format string with the generic '{{}}' placeholder.
+      case '{': {
+        if (formatString[i + 1] != '{') {
+          validatedFormatString.push_back(c);
+          break;
+        }
+        // Handle a special substitution.
+        i += 2;
+        size_t start = i;
+        while (formatString[i] != '}')
+          ++i;
+        if (formatString[i] != '}') {
+          llvm::errs() << "expected '}' to terminate special substitution";
+          return failure();
+        }
+
+        auto specialString = formatString.slice(start, i);
+        if (specialString == "SimulationTime") {
+          operands.push_back(builder.create<TimeOp>());
+        } else {
+          emitError(formatStringLoc)
+              << "unknown printf substitution '" << specialString
+              << "' (did you misspell it?)";
+          return failure();
+        }
+
+        validatedFormatString.append("{{}}");
+        ++i;
+        break;
+      }
+      default:
+        validatedFormatString.push_back(c);
+      }
+    }
+  }
+
+  auto formatStrUnescaped = FIRToken::getStringValue(validatedFormatString);
   builder.create<PrintFOp>(clock, condition,
                            builder.getStringAttr(formatStrUnescaped), operands,
                            name);

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -114,8 +114,8 @@ firrtl.circuit "Foo" {
     firrtl.stop %someClock, %ui1, 42 {name = "foo"} : !firrtl.clock, !firrtl.uint<1>
     // CHECK: skip
     firrtl.skip
-    // CHECK: printf(someClock, ui1, "some\n magic\"stuff\"", ui1, someReset) : foo
-    firrtl.printf %someClock, %ui1, "some\n magic\"stuff\"" {name = "foo"} (%ui1, %someReset) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.reset
+    // CHECK: printf(someClock, ui1, "some\n magic\"stuff\" %d %x", ui1, someReset) : foo
+    firrtl.printf %someClock, %ui1, "some\n magic\"stuff\" %d %x" {name = "foo"} (%ui1, %someReset) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.reset
     // CHECK: assert(someClock, ui1, ui1, "msg") : foo
     // CHECK: assume(someClock, ui1, ui1, "msg") : foo
     // CHECK: cover(someClock, ui1, ui1, "msg") : foo

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2023,3 +2023,22 @@ circuit Contracts:
     node u3 = u
     node v3 = v
     node w3 = w
+
+;// -----
+FIRRTL version 4.1.0
+circuit Foo:
+  public module Foo:
+    input clock: Clock
+    ; In FIRRTL versions < 4.2.0, the following is not a "special substitution".
+    ; CHECK{{LITERAL}}: firrtl.printf %clock, %c1_ui1, "[{{SimulationTime}}]: hello world "
+    printf(clock, UInt<1>(1), "[{{SimulationTime}}]: hello world")
+
+;// -----
+FIRRTL version 4.2.0
+circuit Foo:
+  public module Foo:
+    input clock: Clock
+    ; In FIRRTL versions >= 4.2.0, the following is not a "special substitution".
+    ; CHECK:            %time = firrtl.fstring.time : !firrtl.fstring.time
+    ; CHECK{{LITERAL}}: firrtl.printf %clock, %c1_ui1, "[{{}}]: hello world "(%time)
+    printf(clock, UInt<1>(1), "[{{SimulationTime}}]: hello world")

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2034,7 +2034,7 @@ circuit Foo:
     printf(clock, UInt<1>(1), "[{{SimulationTime}}]: hello world")
 
 ;// -----
-FIRRTL version 4.2.0
+FIRRTL version 5.0.0
 circuit Foo:
   public module Foo:
     input clock: Clock

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2039,6 +2039,6 @@ circuit Foo:
   public module Foo:
     input clock: Clock
     ; In FIRRTL versions >= 4.2.0, the following is not a "special substitution".
-    ; CHECK:            %time = firrtl.fstring.time : !firrtl.fstring.time
+    ; CHECK:            %time = firrtl.fstring.time : !firrtl.fstring
     ; CHECK{{LITERAL}}: firrtl.printf %clock, %c1_ui1, "[{{}}]: hello world "(%time)
     printf(clock, UInt<1>(1), "[{{SimulationTime}}]: hello world")

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -180,8 +180,8 @@ firrtl.module @Contracts(in %a: !firrtl.uint<42>, in %b: !firrtl.bundle<x: uint<
 // CHECK-LABEL: firrtl.module @FormatString
 firrtl.module @FormatString() {
 
-  // CHECK-NEXT: %time = firrtl.fstring.time : !firrtl.fstring.time
-  %time = firrtl.fstring.time : !firrtl.fstring.time
+  // CHECK-NEXT: %time = firrtl.fstring.time : !firrtl.fstring
+  %time = firrtl.fstring.time : !firrtl.fstring
 
 }
 

--- a/test/Dialect/FIRRTL/round-trip.mlir
+++ b/test/Dialect/FIRRTL/round-trip.mlir
@@ -176,4 +176,13 @@ firrtl.module @Contracts(in %a: !firrtl.uint<42>, in %b: !firrtl.bundle<x: uint<
   }
 }
 
+// Format string support
+// CHECK-LABEL: firrtl.module @FormatString
+firrtl.module @FormatString() {
+
+  // CHECK-NEXT: %time = firrtl.fstring.time : !firrtl.fstring.time
+  %time = firrtl.fstring.time : !firrtl.fstring.time
+
+}
+
 }


### PR DESCRIPTION
Add a format string type.  This is intended to be used to improve the way we capture format strings and extend this to capturing more advanced concepts like "time" via attributes as opposed to resorting to enums and attributes.