### PR TITLE
[LowerToHW] Lower PrintfOp w/ TimeOp

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -627,6 +627,10 @@ bool isInDesign(hw::HWSymbolCache &symCache, Operation *op,
   if (op->getNumRegions() > 0)
     return false;
 
+  // Special case some operations which we want to clone.
+  if (isa<TimeOp>(op))
+    return false;
+
   // Otherwise, operations with memory effects as a part design.
   return !mlir::isMemoryEffectFree(op);
 }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -338,8 +338,6 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK: [[ADD:%.+]] = comb.add
 
     // CHECK: [[ADDSIGNED:%.+]] = comb.add
-    // CHECK: [[SUMSIGNED:%.+]] = sv.system "signed"([[ADDSIGNED]])
-    // CHECK: [[DSIGNED:%.+]] = sv.system "signed"(%d)
 
     // CHECK:      sv.ifdef @SYNTHESIS {
     // CHECK-NEXT: } else  {
@@ -360,7 +358,16 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND__1, %reset : i1
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       %PRINTF_FD_ = sv.macro.ref.expr @PRINTF_FD_() : () -> i32
+    // CHECK-NEXT:       [[SUMSIGNED:%.+]] = sv.system "signed"([[ADDSIGNED]])
+    // CHECK-NEXT:       [[DSIGNED:%.+]] = sv.system "signed"(%d)
     // CHECK-NEXT:       sv.fwrite %PRINTF_FD_, "Hi signed %d %d\0A"([[SUMSIGNED]], [[DSIGNED]]) : i5, i4
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:     %PRINTF_COND__2 = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND__2, %reset : i1
+    // CHECK-NEXT:     sv.if [[AND]] {
+    // CHECK-NEXT:       %PRINTF_FD_ = sv.macro.ref.expr @PRINTF_FD_() : () -> i32
+    // CHECK-NEXT:       [[TIME:%.+]] = sv.system.time : i64
+    // CHECK-NEXT:       sv.fwrite %PRINTF_FD_, "[%0t]: %d"([[TIME]], %a) : i64, i4
     // CHECK-NEXT:     }
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
@@ -373,6 +380,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     %1 = firrtl.add %c, %c : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.sint<5>
 
     firrtl.printf %clock, %reset, "Hi signed %d %d\0A"(%1, %d) : !firrtl.clock, !firrtl.uint<1>, !firrtl.sint<5>, !firrtl.sint<4>
+
+    %time = firrtl.fstring.time : !firrtl.fstring
+    firrtl.printf %clock, %reset, "[{{}}]: %d" (%time, %a) : !firrtl.clock, !firrtl.uint<1>, !firrtl.fstring, !firrtl.uint<4>
 
     firrtl.skip
 


### PR DESCRIPTION
Add a lowering for PrintfOps which use TimeOps for substitutions.  A TimeOp used by a PrintfOp will be lowered to an sv::TimeOp that is co-located with the Verilog FWriteOp.  (This helps to avoid problems where the system function `$time` could get spilled to a wire.  This is sunk into the same procedural region as the fwrite to avoid this.)

Practically, this is the last piece needed to compile FIRRTL that includes the `{{SimulationTime}}` special substitution all the way to Verilog.

This is stacked on #8342.


#### Example

The following FIRRTL includes the lone supported special substitution `{{SimulationTime}}`:

``` firrtl
FIRRTL version 4.2.0
circuit Foo :
  public module Foo :
    input clock: Clock
    input a: UInt<1>

    printf(clock, UInt<1>(1), "[{{SimulationTime}}]: %d", a)
```

Compiled to Verilog using `firtool Foo.fir`, this becomes:

``` verilog
// Generated by CIRCT firtool-1.109.0-23-ge68c0327e-dirty

// Users can define 'PRINTF_FD' to add a specified fd to prints.
`ifndef PRINTF_FD_
  `ifdef PRINTF_FD
    `define PRINTF_FD_ (`PRINTF_FD)
  `else  // PRINTF_FD
    `define PRINTF_FD_ 32'h80000002
  `endif // PRINTF_FD
`endif // not def PRINTF_FD_

// Users can define 'PRINTF_COND' to add an extra gate to prints.
`ifndef PRINTF_COND_
  `ifdef PRINTF_COND
    `define PRINTF_COND_ (`PRINTF_COND)
  `else  // PRINTF_COND
    `define PRINTF_COND_ 1
  `endif // PRINTF_COND
`endif // not def PRINTF_COND_
module Foo(
  input clock,
        a
);

  `ifndef SYNTHESIS
    always @(posedge clock) begin
      if ((`PRINTF_COND_) & 1'h1)
        $fwrite(`PRINTF_FD_, "[%t]: %d", $time, a);
    end // always @(posedge)
  `endif // not def SYNTHESIS
endmodule
```

For completeness, this is parsed into the following FIRRTL Dialect:

``` mlir
module {
  firrtl.circuit "Foo" {
    firrtl.module @Foo(in %clock: !firrtl.clock, in %a: !firrtl.uint<1>) attributes {convention = #firrtl<convention scalarized>} {
      %c1_ui1 = firrtl.constant 1 : !firrtl.const.uint<1>
      %time = firrtl.fstring.time : !firrtl.fstring.time
      firrtl.printf %clock, %c1_ui1, "[{{}}]: %d" (%time, %a) : !firrtl.clock, !firrtl.const.uint<1>, !firrtl.fstring.time, !firrtl.uint<1>
    }
  }
}
```

And is lowered to the following by `LowerToHW`:

``` mlir
module {
  sv.macro.decl @SYNTHESIS
  sv.macro.decl @PRINTF_FD
  sv.macro.decl @PRINTF_FD_
  emit.fragment @PRINTF_FD_FRAGMENT {
    sv.verbatim "\0A// Users can define 'PRINTF_FD' to add a specified fd to prints."
    sv.ifdef  @PRINTF_FD_ {
    } else {
      sv.ifdef  @PRINTF_FD {
        sv.macro.def @PRINTF_FD_ "(`PRINTF_FD)"
      } else {
        sv.macro.def @PRINTF_FD_ "32'h80000002"
      }
    }
  }
  sv.macro.decl @PRINTF_COND
  sv.macro.decl @PRINTF_COND_
  emit.fragment @PRINTF_COND_FRAGMENT {
    sv.verbatim "\0A// Users can define 'PRINTF_COND' to add an extra gate to prints."
    sv.ifdef  @PRINTF_COND_ {
    } else {
      sv.ifdef  @PRINTF_COND {
        sv.macro.def @PRINTF_COND_ "(`PRINTF_COND)"
      } else {
        sv.macro.def @PRINTF_COND_ "1"
      }
    }
  }
  hw.module @Foo(in %clock : !seq.clock, in %a : i1) attributes {emit.fragments = [@PRINTF_FD_FRAGMENT, @PRINTF_COND_FRAGMENT]} {
    %true = hw.constant true
    %0 = seq.from_clock %clock
    sv.ifdef  @SYNTHESIS {
    } else {
      sv.always posedge %0 {
        %PRINTF_COND_ = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
        %1 = comb.and bin %PRINTF_COND_, %true : i1
        sv.if %1 {
          %PRINTF_FD_ = sv.macro.ref.expr @PRINTF_FD_() : () -> i32
          %2 = sv.system.time : i64
          sv.fwrite %PRINTF_FD_, "[%t]: %d"(%2, %a) : i64, i1
        }
      }
    }
    hw.output
  }
  om.class @Foo_Class(%basepath: !om.basepath) {
    om.class.fields
  }
}
```