### PR TITLE
[DOC] Add missing passes

### DIFF
--- a/docs/Passes.md
+++ b/docs/Passes.md
@@ -4,6 +4,10 @@ This document describes the available CIRCT passes and their contracts.
 
 [TOC]
 
+## General Passes
+
+[include "CIRCTGeneralPasses.md"]
+
 ## Conversion Passes
 
 [include "CIRCTConversionPasses.md"]
@@ -79,3 +83,11 @@ This document describes the available CIRCT passes and their contracts.
 ## SystemC Dialect Passes
 
 [include "SystemCPasses.md"]
+
+## LEC (logical equivalence checking) Passes
+
+[include "CIRCTLECPasses.md"]
+
+## BMC (bounded model checking) Passes
+
+[include "CIRCTBMCPasses.md"]

--- a/include/circt/Tools/circt-bmc/CMakeLists.txt
+++ b/include/circt/Tools/circt-bmc/CMakeLists.txt
@@ -4,4 +4,4 @@ mlir_tablegen(BMCTransforms.capi.h.inc -gen-pass-capi-header --prefix BMCTransfo
 mlir_tablegen(BMCTransforms.capi.cpp.inc -gen-pass-capi-impl --prefix BMCTransforms)
 add_public_tablegen_target(CIRCTBMCTransformsIncGen)
 
-add_mlir_doc(Passes CIRCTBMCPasses ./ -gen-pass-doc)
+add_circt_doc(Passes CIRCTBMCPasses -gen-pass-doc)

--- a/include/circt/Tools/circt-lec/CMakeLists.txt
+++ b/include/circt/Tools/circt-lec/CMakeLists.txt
@@ -4,4 +4,4 @@ mlir_tablegen(LECTransforms.capi.h.inc -gen-pass-capi-header --prefix LECTransfo
 mlir_tablegen(LECTransforms.capi.cpp.inc -gen-pass-capi-impl --prefix LECTransforms)
 add_public_tablegen_target(CIRCTLECTransformsIncGen)
 
-add_mlir_doc(Passes CIRCTLECPasses ./ -gen-pass-doc)
+add_circt_doc(Passes CIRCTLECPasses -gen-pass-doc)

--- a/include/circt/Transforms/CMakeLists.txt
+++ b/include/circt/Transforms/CMakeLists.txt
@@ -5,4 +5,4 @@ mlir_tablegen(Transforms.capi.h.inc -gen-pass-capi-header --prefix CIRCTTransfor
 mlir_tablegen(Transforms.capi.cpp.inc -gen-pass-capi-impl --prefix CIRCTTransforms)
 add_public_tablegen_target(CIRCTTransformsPassIncGen)
 
-add_mlir_doc(Passes CIRCTGeneralPasses ./ -gen-pass-doc)
+add_circt_doc(Passes CIRCTGeneralPasses -gen-pass-doc)


### PR DESCRIPTION
The documentation for some of the "general" passes was missing.

AFAICT @mortbopet and @mikeurbach accidentally added it as `add_mlir_doc` instead of `add_circt_doc` in https://github.com/llvm/circt/commit/fe32c20d965dd2e61420a5a6d309015f9be6b0e6
everything else was already switched over in https://github.com/llvm/circt/commit/77f9520ea156b093e2de0a4ad73cbb6592484cb5

The same applies for the BMC and LEC passes.

(the changed arguments come from https://github.com/llvm/circt/commit/68280a14263239ad6a2001d33310decb1fc2f698)