### PR TITLE
[FIRRTL] Fix: Enforce flat namespace for modules

### DIFF
--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -211,20 +211,6 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK: }
     when reset : connect _t, _t_2 else : connect _t, _t_2
 
-    ; CHECK: firrtl.when %reset : !firrtl.uint<1> {
-    ; CHECK:   [[N4A:%.+]] = firrtl.node interesting_name %_t_2
-    ; CHECK:   firrtl.matchingconnect %_t, [[N4A]]
-    ; CHECK: } else {
-    ; CHECK:   [[N4B:%.+]] = firrtl.node interesting_name %_t_2
-    ; CHECK:   firrtl.matchingconnect %_t, [[N4B]]
-    ; CHECK: }
-    when reset :
-      node n4 = _t_2
-      connect _t, n4
-    else :
-      node n4 = _t_2   ; 'n4' name is in unique scopes.
-      connect _t, n4
-
     ; CHECK: [[TMP:%.+]] = firrtl.constant 4
     ; CHECK: [[COND:%.+]] = firrtl.lt %reset, [[TMP]]
     ; CHECK: firrtl.when [[COND]] : !firrtl.uint<1> {

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -1667,3 +1667,49 @@ circuit Top:
   public module Top:
     ; expected-error @below {{contracts are a FIRRTL 4.2.0+ feature}}
     contract:
+
+// -----
+FIRRTL version 4.0.0
+circuit DuplicateWhenElse:
+  public module DuplicateWhenElse:
+    input reset: UInt<1>
+    output _t: UInt<1>
+    wire _t_2: UInt<1>
+
+    when reset :
+      node n4 = _t_2
+      connect _t, n4
+    else :
+      ; expected-error @+1 {{redefinition of name 'n4' - FIRRTL has flat namespace and requires all declarations in a module to have unique names}}
+      node n4 = _t_2   ; 'n4' is duplicated across scopes
+      connect _t, n4
+
+// -----
+FIRRTL version 4.0.0
+circuit SameScopeRedef:
+  public module SameScopeRedef:
+    input reset: UInt<1>
+    output _t: UInt<1>
+    wire _t_2: UInt<1>
+
+    ; expected-note @+1 {{previous definition here}}
+    node x = _t_2
+    ; expected-error @+1 {{redefinition of name 'x'}}
+    node x = _t_2   ; 'x' is duplicated in same scope
+    connect _t, x
+
+// -----
+FIRRTL version 4.0.0
+circuit NestedWhenRedef:
+  public module NestedWhenRedef:
+    input reset: UInt<1>
+    output _t: UInt<1>
+    wire _t_2: UInt<1>
+
+    when reset :
+      ; expected-note @+1 {{previous definition here}}
+      node val = _t_2
+      when reset :
+        ; expected-error @+1 {{redefinition of name 'val'}}
+        node val = _t_2   ; 'val' is duplicated in nested when
+      connect _t, val


### PR DESCRIPTION
Fix for #7773 and  #1537.
- Added a check for duplicates in the symbolTable. Added and removed tests for the same. 
- Made changes in parseContract to avoid re-declaration error 
  -  I'm deleting the symbol for contract body before adding the results to the symbolTable (I'm guessing it's no longer used, since its marked as invalid)
  - or is there a better way to do this, by updating the moduleContext with the results before its being given to ContextScope, so we can avoid calling addSymbolEntry twice ? (not sure about this)
 

Let me know if this works, or if this breaks something I don't understand.
Feedback is appreciated.  @fabianschuiki 
