### PR TITLE
[circt-reduce] Add bytecode import/export

### DIFF
--- a/include/circt/Reduce/Tester.h
+++ b/include/circt/Reduce/Tester.h
@@ -37,7 +37,7 @@ class TestCase;
 class Tester {
 public:
   Tester(llvm::StringRef testScript, llvm::ArrayRef<std::string> testScriptArgs,
-         bool testMustFail);
+         bool testMustFail, bool emitBytecode);
 
   /// Runs the interestingness testing script on a MLIR test case file. Returns
   /// true if the interesting behavior is present in the test case or false
@@ -52,6 +52,9 @@ public:
 
   /// Create a new test case for the given file already on disk.
   TestCase get(llvm::Twine filepath) const;
+
+  /// If true, use MLIR bytecode on-disk.  Otherwise, use MLIR text.
+  const bool emitBytecode;
 
 private:
   /// The binary to execute in order to check a reduction attempt for

--- a/lib/Reduce/CMakeLists.txt
+++ b/lib/Reduce/CMakeLists.txt
@@ -6,6 +6,7 @@ add_circt_library(CIRCTReduceLib
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRBytecodeWriter
   MLIRSupport
   MLIRTransforms
   MLIRReduceLib

--- a/lib/Reduce/Tester.cpp
+++ b/lib/Reduce/Tester.cpp
@@ -136,19 +136,21 @@ void TestCase::ensureFileOnDisk() {
     if (tester.emitBytecode) {
       if (failed(writeBytecodeToFile(
               module, file->os(),
-              mlir::BytecodeWriterConfig(getCirctVersion()))))
+              mlir::BytecodeWriterConfig(getCirctVersion())))) {
+        file->os().close();
         llvm::report_fatal_error(
             llvm::Twine("Error emitting the IR to file `") + filepath + "`",
             false);
-      file->os().close();
+      }
     } else {
       module.print(file->os());
-      file->os().close();
-      if (file->os().has_error())
-        llvm::report_fatal_error(
-            llvm::Twine("Error emitting the IR to file `") + filepath + "`",
-            false);
     }
+
+    file->os().close();
+    if (file->os().has_error())
+      llvm::report_fatal_error(llvm::Twine("Error emitting the IR to file `") +
+                                   filepath + "`",
+                               false);
 
     // Update the file size.
     size = file->os().tell();

--- a/lib/Reduce/Tester.cpp
+++ b/lib/Reduce/Tester.cpp
@@ -26,8 +26,8 @@ using namespace circt;
 
 Tester::Tester(StringRef testScript, ArrayRef<std::string> testScriptArgs,
                bool testMustFail, bool emitBytecode)
-    : testScript(testScript), testScriptArgs(testScriptArgs),
-      testMustFail(testMustFail), emitBytecode(emitBytecode) {}
+    : emitBytecode(emitBytecode), testScript(testScript),
+      testScriptArgs(testScriptArgs), testMustFail(testMustFail) {}
 
 std::pair<bool, size_t> Tester::isInteresting(ModuleOp module) const {
   auto test = get(module);
@@ -140,6 +140,7 @@ void TestCase::ensureFileOnDisk() {
         llvm::report_fatal_error(
             llvm::Twine("Error emitting the IR to file `") + filepath + "`",
             false);
+      file->os().close();
     } else {
       module.print(file->os());
       file->os().close();

--- a/tools/circt-reduce/CMakeLists.txt
+++ b/tools/circt-reduce/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBS
   CIRCTFIRRTLReductions
   CIRCTReduceLib
   MLIRIR
+  MLIRBytecodeWriter
   MLIRParser
   MLIRSupport
   MLIRTransforms

--- a/tools/circt-reduce/circt-reduce.cpp
+++ b/tools/circt-reduce/circt-reduce.cpp
@@ -202,7 +202,7 @@ static LogicalResult execute(MLIRContext &context) {
     for (auto &arg : testerArgs)
       llvm::errs() << "  with argument `" << arg << "`\n";
   });
-  Tester tester(testerCommand, testerArgs, testMustFail);
+  Tester tester(testerCommand, testerArgs, testMustFail, emitBytecode);
   auto initialTest = tester.get(module.get());
   if (!skipInitial && !initialTest.isInteresting()) {
     mlir::emitError(UnknownLoc::get(&context), "input is not interesting");

--- a/tools/circt-reduce/circt-reduce.cpp
+++ b/tools/circt-reduce/circt-reduce.cpp
@@ -157,8 +157,9 @@ static LogicalResult writeOutput(ModuleOp module) {
           << outputFilename << "\n";
       return failure();
     }
-  } else
+  } else {
     module.print(output->os());
+  }
 
   output->keep();
   return success();

--- a/tools/circt-reduce/circt-reduce.cpp
+++ b/tools/circt-reduce/circt-reduce.cpp
@@ -148,11 +148,18 @@ static LogicalResult writeOutput(ModuleOp module) {
         << outputFilename << "\": " << errorMessage << "\n";
     return failure();
   }
-  if (emitBytecode)
-    return writeBytecodeToFile(module, output->os(),
-                               mlir::BytecodeWriterConfig(getCirctVersion()));
+  if (emitBytecode) {
+    if (failed(writeBytecodeToFile(
+            module, output->os(),
+            mlir::BytecodeWriterConfig(getCirctVersion())))) {
+      mlir::emitError(UnknownLoc::get(module.getContext()),
+                      "failed to emit bytecode to file \"")
+          << outputFilename << "\n";
+      return failure();
+    }
+  } else
+    module.print(output->os());
 
-  module.print(output->os());
   output->keep();
   return success();
 }

--- a/tools/circt-reduce/circt-reduce.cpp
+++ b/tools/circt-reduce/circt-reduce.cpp
@@ -19,6 +19,7 @@
 #include "circt/Reduce/GenericReductions.h"
 #include "circt/Reduce/Tester.h"
 #include "circt/Support/Version.h"
+#include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -63,6 +64,11 @@ static cl::opt<bool>
     keepBest("keep-best", cl::init(true),
              cl::desc("Keep overwriting the output with better reductions"),
              cl::cat(mainCategory));
+
+static cl::opt<bool>
+    emitBytecode("emit-bytecode",
+                 cl::desc("Emit bytecode when generating MLIR output"),
+                 cl::init(false), cl::cat(mainCategory));
 
 static cl::opt<bool>
     skipInitial("skip-initial", cl::init(false),
@@ -142,6 +148,10 @@ static LogicalResult writeOutput(ModuleOp module) {
         << outputFilename << "\": " << errorMessage << "\n";
     return failure();
   }
+  if (emitBytecode)
+    return writeBytecodeToFile(module, output->os(),
+                               mlir::BytecodeWriterConfig(getCirctVersion()));
+
   module.print(output->os());
   output->keep();
   return success();


### PR DESCRIPTION
Add the ability to read and write bytecode for `circt-reduce`.  This is intended to help with very large MLIR files to avoid wasting all of `circt-reduce`'s time on printing/parsing.