### PR TITLE
[FIRRTL] Fold regreset to its reset value iff the type matches

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -2269,10 +2269,14 @@ canonicalizeRegResetWithOneReset(RegResetOp reg, PatternRewriter &rewriter) {
   if (!isDefinedByOneConstantOp(reg.getResetSignal()))
     return failure();
 
+  auto resetValue = reg.getResetValue();
+  if (reg.getType(0) != resetValue.getType())
+    return failure();
+
   // Ignore 'passthrough'.
   (void)dropWrite(rewriter, reg->getResult(0), {});
   replaceOpWithNewOpAndCopyName<NodeOp>(
-      rewriter, reg, reg.getResetValue(), reg.getNameAttr(), reg.getNameKind(),
+      rewriter, reg, resetValue, reg.getNameAttr(), reg.getNameKind(),
       reg.getAnnotationsAttr(), reg.getInnerSymAttr(), reg.getForceable());
   return success();
 }


### PR DESCRIPTION
If the regreset has a constantly-high reset, then we can replace the register with its reset value. However, if the reset value's type does not match the type of the register, we cannot do the replacement.

This commit adds a check to an old canonicalizer, to ensure the reset value's type matches, before doing the replacement.

Fixes: #8348