### PR TITLE
[Seq] Fix width errors in HWMemSimImpl

### DIFF
--- a/lib/Dialect/Seq/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/Seq/Transforms/HWMemSimImpl.cpp
@@ -602,7 +602,7 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
           // ```
           //   for (int i = 0; i < mem.depth; i++) begin
           //     for (int j = 0; j < randomMeg.size; j += 32)
-          //       randomMem[j+31:j] = `RANDOM
+          //       randomMem[j[mem.width-1: +: 32] = `RANDOM
           //     Memory[i] = randomMem[mem.dataWidth - 1: 0];
           // ```
           b.create<sv::ForOp>(
@@ -613,8 +613,10 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
                     "j", [&](BlockArgument innerIndVar) {
                       auto rhs = b.create<sv::MacroRefExprSEOp>(
                           b.getIntegerType(randomWidth), "RANDOM");
+                      auto truncInnerIndVar = b.createOrFold<comb::ExtractOp>(
+                          innerIndVar, 0, llvm::Log2_64_Ceil(mem.dataWidth));
                       auto lhs = b.create<sv::IndexedPartSelectInOutOp>(
-                          randomMemReg, innerIndVar, randomWidth, false);
+                          randomMemReg, truncInnerIndVar, randomWidth, false);
                       b.create<sv::BPAssignOp>(lhs, rhs);
                     });
 

--- a/test/Dialect/Seq/hw-memsim.mlir
+++ b/test/Dialect/Seq/hw-memsim.mlir
@@ -131,7 +131,8 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(in %ro_addr_0: i4
 //CHECK:             sv.for %i = %c0_i4 to %c-6_i4 step %c1_i4 : i4 {
 //CHECK:               sv.for %j = %c0_i6 to %c-32_i6 step %c-32_i6_2 : i6 {
 //CHECK:                 %RANDOM = sv.macro.ref.expr.se @RANDOM
-//CHECK:                 %[[PART_SELECT:.+]] = sv.indexed_part_select_inout %_RANDOM_MEM[%j : 32] : !hw.inout<i32>, i6
+//CHECK:                 %[[TRUNCATE_J:.+]] = comb.extract %j from 0 : (i6) -> i4
+//CHECK:                 %[[PART_SELECT:.+]] = sv.indexed_part_select_inout %_RANDOM_MEM[%[[TRUNCATE_J]] : 32] : !hw.inout<i32>, i4
 //CHECK:                 sv.bpassign %[[PART_SELECT]], %RANDOM : i32
 //CHECK:               }
 //CHECK:               %[[MEM_INDEX:.+]] = sv.array_index_inout %Memory[%i] : !hw.inout<uarray<10xi16>>, i4


### PR DESCRIPTION
Fix some width errors which could occur in the HWMemSimImpl pass.  The problem is that a loop variable may need to be sized one bit larger than what is used for its address in order for it to hit its loop bound. However, if this is sized large enough to ever reach the loop bound, it is too large for the index.

Fixes #8350.