### PR TITLE
[firtool] Bump "next" FIRRTL version to 5.1.0

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRParser.h
+++ b/include/circt/Dialect/FIRRTL/FIRParser.h
@@ -124,7 +124,7 @@ constexpr FIRVersion minimumFIRVersion(2, 0, 0);
 /// new version of the spec is released, all uses of `nextFIRVersion` in the
 /// parser are replaced with the concrete version `{x, y, z}`, and this
 /// declaration here is bumped to the next probable version number.
-constexpr FIRVersion nextFIRVersion(4, 3, 0);
+constexpr FIRVersion nextFIRVersion(5, 1, 0);
 
 /// A marker for parser features that are currently missing from the spec.
 ///

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -12,7 +12,7 @@
 // Check if printing with very short line length, removing info locators (@[...]), no line is longer than 5x line length.
 // RUN: circt-translate --export-firrtl %s --target-line-length=10 | sed -e 's/ @\[.*\]//' | FileCheck %s --implicit-check-not "{{^(.{50})}}" --check-prefix PRETTY
 
-// CHECK-LABEL: FIRRTL version 4.3.0
+// CHECK-LABEL: FIRRTL version 5.1.0
 // CHECK-LABEL: circuit Foo :
 // PRETTY-LABEL: circuit Foo :
 firrtl.circuit "Foo" {

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1449,7 +1449,7 @@ circuit Layers:
 
 ;// -----
 ; CHECK-LABEL: firrtl.circuit "BasicProps"
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit BasicProps :
   public module BasicProps :
   ; CHECK-LABEL: module private @Integer
@@ -1655,7 +1655,7 @@ circuit WireOfProbesAndNames:
     wire probe : Probe<UInt<1>>
 
 ;// -----
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 
 ; CHECK-LABEL: circuit "AnyRef"
 circuit AnyRef:
@@ -1890,7 +1890,7 @@ circuit Foo:
     d_map = {a = 42, b = "hello", c = [9001], d = {foo = 1337}}
 
 ;// -----
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 ; CHECK-LABEL: circuit "Foo"
 circuit Foo:
 
@@ -2007,7 +2007,7 @@ circuit Foo:
     b <= a
 
 ;// -----
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 ; CHECK-LABEL: firrtl.circuit "Contracts"
 circuit Contracts:
   ; CHECK-LABEL: firrtl.module @Contracts(

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -196,7 +196,7 @@ circuit invalid_inst :
 
 ;// -----
 
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit class_inst :
   class some_class :
   public module class_inst :
@@ -966,21 +966,21 @@ circuit LayerEmptyOutputDir:
 
 ;// -----
 
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit Top:
   ; expected-error @below {{class cannot be the top of a circuit}}
   class Top:
 
 ;// -----
 
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit Top:
   ; expected-error @below {{extclass cannot be the top of a circuit}}
   extclass Top:
 
 ;// -----
 
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit Top:
   public module Top:
   class Foo:
@@ -989,7 +989,7 @@ circuit Top:
 
 ;// -----
 
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit Top:
   public module Top:
   extclass Foo:
@@ -1095,7 +1095,7 @@ circuit Top :
     propassign c, list_concat()
 
 ;// -----
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 
 circuit Top:
   public module Top:
@@ -1103,7 +1103,7 @@ circuit Top:
     input in : Inst<Missing>
 
 ;// -----
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 
 circuit Top:
   public module Top:
@@ -1111,7 +1111,7 @@ circuit Top:
     object x of Missing
 
 ;// -----
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 
 circuit Top:
   class MyClass:
@@ -1127,7 +1127,7 @@ circuit Top:
 FIRRTL version 3.0.0
 
 circuit Top:
-  ; expected-error @below {{classes are a FIRRTL 4.3.0+ feature}}
+  ; expected-error @below {{classes are a FIRRTL 5.1.0+ feature}}
   class MyClass:
     skip
 
@@ -1139,7 +1139,7 @@ FIRRTL version 3.0.0
 
 circuit Top:
   module Top:
-    ; expected-error @below {{object statements are a FIRRTL 4.3.0+ feature}}
+    ; expected-error @below {{object statements are a FIRRTL 5.1.0+ feature}}
     object x of MyClass
 
 ;// -----
@@ -1147,7 +1147,7 @@ FIRRTL version 3.0.0
 
 circuit Top:
   module Top:
-    ; expected-error @below {{Inst types are a FIRRTL 4.3.0+ feature}}
+    ; expected-error @below {{Inst types are a FIRRTL 5.1.0+ feature}}
     output o: Inst<MyClass>
 
 ;// -----
@@ -1194,13 +1194,13 @@ circuit LeadingPath:
 FIRRTL version 3.1.0
 circuit PathVersion:
   module PathVersion:
-    ; expected-error @below {{Paths are a FIRRTL 4.3.0+ feature}}
+    ; expected-error @below {{Paths are a FIRRTL 5.1.0+ feature}}
     output path : Path
     propassign path, path("")
 
 ;// -----
 ; Path operation should have a single string argument.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit BadPathExpr:
   public module BadPathExp:
     output path : Path
@@ -1209,7 +1209,7 @@ circuit BadPathExpr:
 
 ;// -----
 ; Path operation should have a single string argument.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit BadPathExpr:
   public module BadPathExp:
     output path : Path
@@ -1218,7 +1218,7 @@ circuit BadPathExpr:
 
 ;// -----
 ; Path operation should have a single string argument.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit BadPathExpr:
   public module BadPathExp:
     output path : Path
@@ -1231,14 +1231,14 @@ FIRRTL version 3.0.0
 
 circuit Top:
   module Top:
-    ; expected-error @below {{Bools are a FIRRTL 4.3.0+ feature}}
+    ; expected-error @below {{Bools are a FIRRTL 5.1.0+ feature}}
     input in : Bool
     output out : Bool
     propassign out, in
 
 ;// -----
 ; Bool literal must be true or false.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 
 circuit Top:
   public module Top:
@@ -1248,7 +1248,7 @@ circuit Top:
 
 ;// -----
 ; Properties can't be const.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 
 circuit Top:
   public module Top:
@@ -1260,12 +1260,12 @@ circuit Top:
 FIRRTL version 3.1.0
 circuit AnyRef:
    module AnyRef:
-     ; expected-error @below {{AnyRef types are a FIRRTL 4.3.0+ feature}}
+     ; expected-error @below {{AnyRef types are a FIRRTL 5.1.0+ feature}}
      output a : AnyRef
 
 ;// -----
 ; Only objects are valid as AnyRef
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit AnyRef:
   public module AnyRef:
     output out : AnyRef
@@ -1274,7 +1274,7 @@ circuit AnyRef:
 
 ;// -----
 ; Only objects are valid as AnyRef in Lists
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit AnyRefList:
   public module AnyRefList:
     output list : List<AnyRef>
@@ -1283,7 +1283,7 @@ circuit AnyRefList:
 
 ;// -----
 ; Not Covariant.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit NotCovariant:
   class Class:
 
@@ -1296,7 +1296,7 @@ circuit NotCovariant:
 
 ;// -----
 ; Not Contravariant.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit NotContravariant:
   class Class:
 
@@ -1309,7 +1309,7 @@ circuit NotContravariant:
 
 ;// -----
 ; Double: must have digit before point.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit DoubleNegPeriod:
   public module DoubleNegPeriod:
     output d : Double
@@ -1318,7 +1318,7 @@ circuit DoubleNegPeriod:
 
 ;// -----
 ; Double: must have digit after point.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit DoublePeriodEnd:
   public module DoublePeriodEnd:
     output d : Double
@@ -1327,7 +1327,7 @@ circuit DoublePeriodEnd:
 
 ;// -----
 ; Double: Not an integer.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit DoubleInteger:
   public module DoubleInteger:
     output d : Double
@@ -1336,7 +1336,7 @@ circuit DoubleInteger:
 
 ;// -----
 ; Double: don't support NaN or inf.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit DoubleNaN:
   public module DoubleNaN:
     output d : Double
@@ -1345,7 +1345,7 @@ circuit DoubleNaN:
 
 ;// -----
 ; Double: Don't support hex.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit DoubleHex:
   public module DoubleHex:
     output d : Double
@@ -1354,7 +1354,7 @@ circuit DoubleHex:
 
 ;// -----
 ; Double: Don't suuport FIRRTL-y radix.
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit DoubleRadix:
   public module DoubleRadix:
     output d : Double
@@ -1392,7 +1392,7 @@ circuit RWProbeExprOOB :
 
 FIRRTL version 3.9.0
 circuit Foo:
-  ; expected-error @below {{option groups/instance choices are a FIRRTL 4.3.0+ feature}}
+  ; expected-error @below {{option groups/instance choices are a FIRRTL 5.1.0+ feature}}
   option Platform:
     FPGA
     ASIC
@@ -1403,14 +1403,14 @@ FIRRTL version 3.9.0
 circuit Foo:
 
   module Foo:
-    ; expected-error @below {{option groups/instance choices are a FIRRTL 4.3.0+ feature}}
+    ; expected-error @below {{option groups/instance choices are a FIRRTL 5.1.0+ feature}}
     instchoice inst of DefaultTarget Platform :
       FPGA => FPGATarget
       ASIC => ASICTarget
 
 ;// -----
 
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit Foo:
   option Platform:
     FPGA
@@ -1428,7 +1428,7 @@ circuit Foo:
 
 ;// -----
 
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit Foo:
   option Platform:
     FPGA
@@ -1446,7 +1446,7 @@ circuit Foo:
 
 ;// -----
 
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit Foo:
   option Platform:
     FPGA
@@ -1461,7 +1461,7 @@ circuit Foo:
 
 ;// -----
 
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit Foo:
   module DefaultTarget:
   module FPGATarget:
@@ -1473,7 +1473,7 @@ circuit Foo:
 
 ;// -----
 
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 circuit Foo:
   ; expected-error @below {{duplicate option case definition 'FPGA'}}
   option Platform:
@@ -1665,5 +1665,5 @@ circuit Foo:
 FIRRTL version 4.1.0
 circuit Top:
   public module Top:
-    ; expected-error @below {{contracts are a FIRRTL 4.3.0+ feature}}
+    ; expected-error @below {{contracts are a FIRRTL 5.1.0+ feature}}
     contract:

--- a/test/firtool/classes-dedupe.fir
+++ b/test/firtool/classes-dedupe.fir
@@ -1,6 +1,6 @@
 ; RUN: firtool %s -ir-verilog | FileCheck %s
 
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 
 circuit Test : %[[
 {

--- a/test/firtool/instchoice.fir
+++ b/test/firtool/instchoice.fir
@@ -2,7 +2,7 @@
 ; RUN: firtool %s --ir-hw --disable-opt --select-instance-choice=Platform=ASIC | FileCheck %s --check-prefix=ASIC
 ; RUN: firtool %s --ir-hw --disable-opt --select-default-for-unspecified-instance-choice | FileCheck %s --check-prefixes=DEFAULT
 
-FIRRTL version 4.3.0
+FIRRTL version 5.1.0
 ; CHECK: firrtl.circuit "Foo" attributes {select_inst_choice = ["Platform=ASIC"]} {
 circuit Foo:
   ; CHECK: firrtl.option @Platform


### PR DESCRIPTION
Bump the next FIRRTL version to 5.1.0.  This is because we want to start using the 5.0.0 feature of `{{SimulationTime}}` substitutions.  However, we also have unsupported features that exist like all the un-spec'd property types.