### PR TITLE
[FIRRTL] Sink fstring.time in LowerLayers

### DIFF
--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -322,6 +322,22 @@ firrtl.circuit "Test" {
     }
   }
 
+  // An FString operation is outside the layer block.  This needs to be cloned.
+  //
+  // CHECK: firrtl.module private @[[A:.+]]() {
+  // CHECK:   %time = firrtl.fstring.time
+  // CHECK:   firrtl.printf %clock, %c1_ui1, "{{.*}}" (%time)
+  // CHECK: }
+  // CHECK: firrtl.module @FStringOp
+  firrtl.module @FStringOp() {
+    %time = firrtl.fstring.time : !firrtl.fstring
+    firrtl.layerblock @A {
+       %clock = firrtl.wire : !firrtl.clock
+      %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
+      firrtl.printf %clock, %c1_ui1, "{{}}" (%time) : !firrtl.clock, !firrtl.uint<1>, !firrtl.fstring
+    }
+  }
+
   //===--------------------------------------------------------------------===//
   // Resolving Colored Probes
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
Avoid an error when trying to create ports of `fstring` type.  We currently only have one operation which can create these, `fstring.time`, which has simple semantics.  When we see an op like this, if it is not already in the right layer block, then clone it.