### PR TITLE
[Calyx] Canonicalizations that skip scf.execute_regions

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPasses.h
+++ b/include/circt/Dialect/Calyx/CalyxPasses.h
@@ -32,6 +32,7 @@ std::unique_ptr<mlir::Pass> createGroupInvariantCodeMotionPass();
 std::unique_ptr<mlir::Pass> createAffineParallelUnrollPass();
 std::unique_ptr<mlir::Pass> createAffineToSCFPass();
 std::unique_ptr<mlir::Pass> createAffinePloopUnparallelizePass();
+std::unique_ptr<mlir::Pass> createExcludeExecuteRegionCanonicalizePass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -287,4 +287,21 @@ def AffinePloopUnparallelize : Pass<"affine-ploop-unparallelize", "::mlir::func:
       ```
   }];
 }
+
+def ExcludeExecuteRegionCanonicalize : Pass<"exclude-exec-region-canonicalize", "::mlir::func::FuncOp"> {
+  let summary = "Canonicalize all legal operations except `scf.execute_region`";
+  let dependentDialects = [
+     "mlir::memref::MemRefDialect",
+     "mlir::scf::SCFDialect",
+     "mlir::arith::ArithDialect",
+     "mlir::affine::AffineDialect"];
+  let constructor = "circt::calyx::createExcludeExecuteRegionCanonicalizePass()";
+  let description = [{
+    The AffineParallelUnroll pass unrolls the body of `affine.parallel`
+    to multiple copies of `scf.execute_region`s. Since the semantics
+    of those `scf.execute_region` has deviated from the original MLIR
+    definition, a new canonicalization pass that does not operate on
+    those `scf.execute_region` is needed.
+  }];
+}
 #endif // CIRCT_DIALECT_CALYX_CALYXPASSES_TD

--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -294,14 +294,15 @@ def ExcludeExecuteRegionCanonicalize : Pass<"exclude-exec-region-canonicalize", 
      "mlir::memref::MemRefDialect",
      "mlir::scf::SCFDialect",
      "mlir::arith::ArithDialect",
-     "mlir::affine::AffineDialect"];
+     "mlir::affine::AffineDialect"
+  ];
   let constructor = "circt::calyx::createExcludeExecuteRegionCanonicalizePass()";
   let description = [{
     The AffineParallelUnroll pass unrolls the body of `affine.parallel`
     to multiple copies of `scf.execute_region`s. Since the semantics
     of those `scf.execute_region` has deviated from the original MLIR
     definition, a new canonicalization pass that does not operate on
-    those `scf.execute_region` is needed.
+    `scf.execute_region` is needed.
   }];
 }
 #endif // CIRCT_DIALECT_CALYX_CALYXPASSES_TD

--- a/lib/Dialect/Calyx/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Calyx/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ add_circt_dialect_library(CIRCTCalyxTransforms
   AffineParallelUnroll.cpp
   AffineToSCF.cpp
   AffinePloopUnparallelize.cpp
+  ExcludeExecuteRegionCanonicalize.cpp
 
   DEPENDS
   CIRCTCalyxTransformsIncGen

--- a/lib/Dialect/Calyx/Transforms/ExcludeExecuteRegionCanonicalize.cpp
+++ b/lib/Dialect/Calyx/Transforms/ExcludeExecuteRegionCanonicalize.cpp
@@ -1,0 +1,75 @@
+//===- ExcludeExecuteRegion.cpp
+//----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Calyx/CalyxPasses.h"
+#include "mlir/Dialect/Affine/Utils.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace circt {
+namespace calyx {
+#define GEN_PASS_DEF_EXCLUDEEXECUTEREGIONCANONICALIZE
+#include "circt/Dialect/Calyx/CalyxPasses.h.inc"
+} // namespace calyx
+} // namespace circt
+
+using namespace mlir;
+using namespace mlir::arith;
+using namespace mlir::memref;
+using namespace mlir::scf;
+using namespace mlir::func;
+using namespace mlir::affine;
+using namespace circt;
+
+namespace {
+class ExcludeExecuteRegionCanonicalizePass
+    : public circt::calyx::impl::ExcludeExecuteRegionCanonicalizeBase<
+          ExcludeExecuteRegionCanonicalizePass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void ExcludeExecuteRegionCanonicalizePass::runOnOperation() {
+  MLIRContext *ctx = &getContext();
+  RewritePatternSet patterns(ctx);
+
+  // Add dialect-level canonicalization patterns
+  for (Dialect *dialect : ctx->getLoadedDialects())
+    dialect->getCanonicalizationPatterns(patterns);
+
+  // Add op-specific canonicalization patterns
+  for (const RegisteredOperationName &op : ctx->getRegisteredOperations()) {
+    if (op.getStringRef() == "scf.execute_region")
+      continue;
+
+    op.getCanonicalizationPatterns(patterns, ctx);
+  }
+
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+    getOperation()->emitError("Failed to apply canonicalization.");
+    signalPassFailure();
+  }
+
+  ConversionTarget target(*ctx);
+  target.addLegalDialect<arith::ArithDialect, memref::MemRefDialect,
+                         scf::SCFDialect, affine::AffineDialect>();
+}
+
+std::unique_ptr<mlir::Pass>
+circt::calyx::createExcludeExecuteRegionCanonicalizePass() {
+  return std::make_unique<ExcludeExecuteRegionCanonicalizePass>();
+}

--- a/test/Dialect/Calyx/exclude-exec-region-canonicalize.mlir
+++ b/test/Dialect/Calyx/exclude-exec-region-canonicalize.mlir
@@ -1,0 +1,43 @@
+// RUN: circt-opt --exclude-exec-region-canonicalize --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL:   func.func @main(
+// CHECK-SAME:                    %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<4xi32>) {
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK:           scf.execute_region {
+// CHECK:             memref.store %[[VAL_1]], %[[VAL_0]]{{\[}}%[[VAL_2]]] : memref<4xi32>
+// CHECK:             scf.yield
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+module {
+  func.func @main(%arg0 : memref<4xi32>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %idx = arith.constant 0 : index
+    %true = arith.constant true
+    %false = arith.constant false
+
+    %val = scf.if %true -> i32 {
+      %0 = arith.addi %c1, %c1 : i32
+      scf.yield %0 : i32
+    } else {
+      %0 = arith.addi %c0, %c0 : i32
+      scf.yield %0 : i32
+    }
+
+    scf.execute_region {
+      scf.if %false {
+        %0 = arith.addi %val, %c1 : i32
+        memref.store %0, %arg0[%idx] : memref<4xi32>
+      } else {
+        %0 = arith.addi %c0, %c0 : i32
+        memref.store %0, %arg0[%idx] : memref<4xi32>
+      }
+      scf.yield
+    }
+
+    return
+  }
+}


### PR DESCRIPTION
This patch runs all canonicalization passes of legal dialects, skipping `scf.execute_region`. This pass is intended to be run after `-affine-parallel-unroll` and before lowering to Calyx.