### PR TITLE
[LLHD] Make probes side-effect-free in graph regions

### DIFF
--- a/include/circt/Dialect/LLHD/IR/LLHDSignalOps.td
+++ b/include/circt/Dialect/LLHD/IR/LLHDSignalOps.td
@@ -52,6 +52,7 @@ def SignalOp : LLHDOp<"sig", [
 def PrbOp : LLHDOp<"prb", [
     DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
     DeclareOpInterfaceMethods<SafeMemorySlotAccessOpInterface>,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
     TypesMatchWith<
       "type of 'result' and underlying type of 'signal' have to match.",
       "signal", "result", "llvm::cast<hw::InOutType>($_self).getElementType()">
@@ -60,7 +61,9 @@ def PrbOp : LLHDOp<"prb", [
   let description = [{
     This operation probes a signal and returns the value it
     currently carries as a new SSA operand. The result type is always
-    the type carried by the signal.
+    the type carried by the signal. In SSACFG regions, the operation has a read
+    side effect on the signal operand. In graph regions, the operation is
+    memory-effect free.
 
     Example:
 
@@ -71,9 +74,8 @@ def PrbOp : LLHDOp<"prb", [
     ```
   }];
 
-  let arguments = (ins Arg<InOutType, "the signal to probe from",
-                           [MemRead]>: $signal);
-  let results = (outs HWValueType: $result);
+  let arguments = (ins InOutType:$signal);
+  let results = (outs HWValueType:$result);
 
   let assemblyFormat = "$signal attr-dict `:` qualified(type($signal))";
 }

--- a/lib/Dialect/LLHD/IR/LLHDOps.cpp
+++ b/lib/Dialect/LLHD/IR/LLHDOps.cpp
@@ -413,6 +413,13 @@ PrbOp::ensureOnlySafeAccesses(const MemorySlot &slot,
   return success();
 }
 
+void PrbOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  if (mayHaveSSADominance(*getOperation()->getParentRegion()))
+    effects.emplace_back(MemoryEffects::Read::get(), &getSignalMutable());
+}
+
 //===----------------------------------------------------------------------===//
 // DrvOp
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Make `llhd.prb` ops only have read side effects if used in an SSACFG region. This works around an issue where CSE would not move or eliminate probes across drives and other processes, even though that would be legal in a graph region. In graph regions, a probe acts like a pure op dereferencing a signal and the exact order of operations, especially the order with respect to drives and other ops interacting with the signal do not matter.