### PR TITLE
[FIRRTL] Add printf widths, reject unknown

### DIFF
--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -869,18 +869,29 @@ void Emitter::emitStatement(PrintFOp op) {
       switch (c) {
       case '%': {
         formatString.push_back(c);
+
+        // Parse the width specifier.
+        SmallString<6> width;
         c = origFormatString[++i];
+        while (isdigit(c)) {
+          width.push_back(c);
+          c = origFormatString[++i];
+        }
+
+        // Parse the radix.
         switch (c) {
         case 'b':
-        case 'c':
         case 'd':
         case 'x':
+          if (!width.empty())
+            formatString.append(width);
+          [[fallthrough]];
+        case 'c':
           substitutions.push_back(op.getSubstitutions()[opIdx++]);
-          break;
+          [[fallthrough]];
         default:
-          break;
+          formatString.push_back(c);
         }
-        formatString.push_back(c);
         break;
       }
       case '{':

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -332,8 +332,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK-LABEL: hw.module private @Print
   // CHECK-SAME: attributes {emit.fragments = [@PRINTF_FD_FRAGMENT, @PRINTF_COND_FRAGMENT]}
   firrtl.module private @Print(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
-                       in %a: !firrtl.uint<4>, in %b: !firrtl.uint<4>,
-                       in %c: !firrtl.sint<4>, in %d: !firrtl.sint<4>) {
+                               in %a: !firrtl.uint<4>, in %b: !firrtl.uint<4>,
+                               in %c: !firrtl.sint<4>, in %d: !firrtl.sint<4>) {
     // CHECK: [[CLOCK:%.+]] = seq.from_clock %clock
     // CHECK: [[ADD:%.+]] = comb.add
 
@@ -342,28 +342,46 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK:      sv.ifdef @SYNTHESIS {
     // CHECK-NEXT: } else  {
     // CHECK-NEXT:   sv.always posedge [[CLOCK]] {
-    // CHECK-NEXT:     %PRINTF_COND_ = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
-    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND_, %reset
+    // CHECK-NEXT:     %[[PRINTF_COND:.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %[[PRINTF_COND]], %reset
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       %PRINTF_FD_ = sv.macro.ref.expr @PRINTF_FD_() : () -> i32
-    // CHECK-NEXT:       sv.fwrite %PRINTF_FD_, "No operands!\0A"
+    // CHECK-NEXT:       sv.fwrite %PRINTF_FD_, "No operands and literal: %%\0A"
     // CHECK-NEXT:     }
-    // CHECK-NEXT:     %PRINTF_COND__0 = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
-    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND__0, %reset : i1
+    // CHECK-NEXT:     %[[PRINTF_COND_:.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %[[PRINTF_COND_]], %reset : i1
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       %PRINTF_FD_ = sv.macro.ref.expr @PRINTF_FD_() : () -> i32
-    // CHECK-NEXT:       sv.fwrite %PRINTF_FD_, "Hi %0x %0x\0A"([[ADD]], %b) : i5, i4
+    // CHECK-NEXT:       sv.fwrite %PRINTF_FD_, "Binary: %0b %0b %4b\0A"([[ADD]], %b, [[ADD]]) : i5, i4, i5
     // CHECK-NEXT:     }
-    // CHECK-NEXT:     %PRINTF_COND__1 = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
-    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND__1, %reset : i1
+    // CHECK-NEXT:     %[[PRINTF_COND_:.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %[[PRINTF_COND_]], %reset : i1
+    // CHECK-NEXT:     sv.if [[AND]] {
+    // CHECK-NEXT:       %PRINTF_FD_ = sv.macro.ref.expr @PRINTF_FD_() : () -> i32
+    // CHECK-NEXT:       sv.fwrite %PRINTF_FD_, "Decimal: %0d %0d %4d\0A"([[ADD]], %b, [[ADD]]) : i5, i4, i5
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:     %[[PRINTF_COND_:.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %[[PRINTF_COND_]], %reset : i1
+    // CHECK-NEXT:     sv.if [[AND]] {
+    // CHECK-NEXT:       %PRINTF_FD_ = sv.macro.ref.expr @PRINTF_FD_() : () -> i32
+    // CHECK-NEXT:       sv.fwrite %PRINTF_FD_, "Hexadecimal: %0x %0x %4x\0A"([[ADD]], %b, [[ADD]]) : i5, i4, i5
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:     %[[PRINTF_COND_:.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %[[PRINTF_COND_]], %reset : i1
+    // CHECK-NEXT:     sv.if [[AND]] {
+    // CHECK-NEXT:       %PRINTF_FD_ = sv.macro.ref.expr @PRINTF_FD_() : () -> i32
+    // CHECK-NEXT:       sv.fwrite %PRINTF_FD_, "ASCII Character: %c\0A"([[ADD]]) : i5
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:     %[[PRINTF_COND_:.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %[[PRINTF_COND_]], %reset : i1
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       %PRINTF_FD_ = sv.macro.ref.expr @PRINTF_FD_() : () -> i32
     // CHECK-NEXT:       [[SUMSIGNED:%.+]] = sv.system "signed"([[ADDSIGNED]])
     // CHECK-NEXT:       [[DSIGNED:%.+]] = sv.system "signed"(%d)
     // CHECK-NEXT:       sv.fwrite %PRINTF_FD_, "Hi signed %0d %0d\0A"([[SUMSIGNED]], [[DSIGNED]]) : i5, i4
     // CHECK-NEXT:     }
-    // CHECK-NEXT:     %PRINTF_COND__2 = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
-    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %PRINTF_COND__2, %reset : i1
+    // CHECK-NEXT:     %[[PRINTF_COND_:.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin %[[PRINTF_COND_]], %reset : i1
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       %PRINTF_FD_ = sv.macro.ref.expr @PRINTF_FD_() : () -> i32
     // CHECK-NEXT:       [[TIME:%.+]] = sv.system.time : i64
@@ -371,11 +389,17 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:     }
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
-    firrtl.printf %clock, %reset, "No operands!\0A" : !firrtl.clock, !firrtl.uint<1>
+    firrtl.printf %clock, %reset, "No operands and literal: %%\0A" : !firrtl.clock, !firrtl.uint<1>
 
     %0 = firrtl.add %a, %a : (!firrtl.uint<4>, !firrtl.uint<4>) -> !firrtl.uint<5>
 
-    firrtl.printf %clock, %reset, "Hi %x %x\0A"(%0, %b) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<4>
+    firrtl.printf %clock, %reset, "Binary: %b %0b %4b\0A"(%0, %b, %0) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<4>, !firrtl.uint<5>
+
+    firrtl.printf %clock, %reset, "Decimal: %d %0d %4d\0A"(%0, %b, %0) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<4>, !firrtl.uint<5>
+
+    firrtl.printf %clock, %reset, "Hexadecimal: %x %0x %4x\0A"(%0, %b, %0) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<5>, !firrtl.uint<4>, !firrtl.uint<5>
+
+    firrtl.printf %clock, %reset, "ASCII Character: %c\0A"(%0) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<5>
 
     %1 = firrtl.add %c, %c : (!firrtl.sint<4>, !firrtl.sint<4>) -> !firrtl.sint<5>
 
@@ -387,9 +411,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.skip
 
     // CHECK: hw.output
-   }
-
-
+  }
 
 // module Stop3 :
 //    input clock1: Clock

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -899,4 +899,23 @@ firrtl.circuit "Foo" {
     out done: !firrtl.uint<1>,
     out success: !firrtl.uint<1>
   )
+
+  // CHECK-LABEL: module Printf
+  firrtl.module @Printf(in %clock: !firrtl.clock, in %i8: !firrtl.uint<8>) attributes {convention = #firrtl<convention scalarized>} {
+    %c1_ui1 = firrtl.constant 1 : !firrtl.const.uint<1>
+
+    // CHECK: printf(clock, UInt<1>(1), "%b, %0b, %8b", i8, i8, i8)
+    firrtl.printf %clock, %c1_ui1, "%b, %0b, %8b" (%i8, %i8, %i8) : !firrtl.clock, !firrtl.const.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK: printf(clock, UInt<1>(1), "%d, %0d, %8d", i8, i8, i8)
+    firrtl.printf %clock, %c1_ui1, "%d, %0d, %8d" (%i8, %i8, %i8) : !firrtl.clock, !firrtl.const.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>, !firrtl.uint<8>
+    // CHECK: printf(clock, UInt<1>(1), "%x, %0x, %8x", i8, i8, i8)
+    firrtl.printf %clock, %c1_ui1, "%x, %0x, %8x" (%i8, %i8, %i8) : !firrtl.clock, !firrtl.const.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>, !firrtl.uint<8>
+
+    // CHECK: printf(clock, UInt<1>(1), "%c", i8)
+    firrtl.printf %clock, %c1_ui1, "%c" (%i8) : !firrtl.clock, !firrtl.const.uint<1>, !firrtl.uint<8>
+
+    // CHECK: printf(clock, UInt<1>(1), "%%")
+    firrtl.printf %clock, %c1_ui1, "%%" : !firrtl.clock, !firrtl.const.uint<1>
+  }
+
 }

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -1182,6 +1182,24 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule" {
     ; CHECK-NEXT: firrtl.matchingconnect %nonconst_w, [[CAST]] : !firrtl.sint<4>
     connect nonconst_w, s4
 
+  ; CHECK-LABEL: firrtl.module @Printf
+  public module Printf:
+    input clock: Clock
+    input i8: UInt<8>
+
+    ; CHECK:      firrtl.printf %clock, %c1_ui1, "%b, %0b, %8b" (%i8, %i8, %i8) : !firrtl.clock, !firrtl.const.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>, !firrtl.uint<8>
+    printf(clock, UInt<1>(1), "%b, %0b, %8b", i8, i8, i8)
+    ; CHECK-NEXT: firrtl.printf %clock, %c1_ui1, "%d, %0d, %8d" (%i8, %i8, %i8) : !firrtl.clock, !firrtl.const.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>, !firrtl.uint<8>
+    printf(clock, UInt<1>(1), "%d, %0d, %8d", i8, i8, i8)
+    ; CHECK-NEXT: firrtl.printf %clock, %c1_ui1, "%x, %0x, %8x" (%i8, %i8, %i8) : !firrtl.clock, !firrtl.const.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>, !firrtl.uint<8>
+    printf(clock, UInt<1>(1), "%x, %0x, %8x", i8, i8, i8)
+
+    ; CHECK-NEXT: firrtl.printf %clock, %c1_ui1, "%c" (%i8) : !firrtl.clock, !firrtl.const.uint<1>, !firrtl.uint<8>
+    printf(clock, UInt<1>(1), "%c", i8)
+
+    ; CHECK-NEXT: firrtl.printf %clock, %c1_ui1, "%%" : !firrtl.clock, !firrtl.const.uint<1>
+    printf(clock, UInt<1>(1), "%%")
+
 ;// -----
 
 ; CHECK-LABEL: firrtl.circuit "Foo_v3p0p0"

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -369,6 +369,30 @@ circuit PrintfExpr:
 
 ;// -----
 
+FIRRTL version 5.1.0
+circuit PrintfUnknownFormatSpecifier:
+  public module PrintfUnknownFormatSpecifier:
+    input clock: Clock
+    printf(clock, UInt<1>(1), "%m") ; expected-error {{unknown printf substitution '%m'}}
+
+;// -----
+
+FIRRTL version 5.1.0
+circuit PrintfIllegalCharWidth:
+  public module PrintfIllegalCharWidth:
+    input clock: Clock
+    printf(clock, UInt<1>(1), "%42c") ; expected-error {{ASCII character format specifiers ('%c') may not specify a width}}
+
+;// -----
+
+FIRRTL version 5.1.0
+circuit PrintfPercentWithWidth:
+  public module PrintfPercentWithWidth:
+    input clock: Clock
+    printf(clock, UInt<1>(1), "%42%") ; expected-error {{literal percents ('%%') may not specify a width}}
+
+;// -----
+
 FIRRTL version 4.0.0
 circuit ProbeFlipType:
   public module ProbeFlipType:

--- a/test/firtool/print.fir
+++ b/test/firtool/print.fir
@@ -1,22 +1,25 @@
-; RUN: firtool %s --format=fir --ir-sv | FileCheck %s
+; RUN: firtool %s | FileCheck %s
 
-FIRRTL version 4.0.0
+FIRRTL version 5.1.0
 circuit PrintTest:
-  ; CHECK-LABEL: @PrintTest
+  ; CHECK-LABEL: module PrintTest
   public module PrintTest :
     input clock : Clock
     input cond : UInt<1>
-    input var : UInt<32>
-    printf(clock, cond, "test %b %c %d %x\n", var, var, var, var)
+    input a : UInt<8>
 
-    ; CHECK:      sv.ifdef  @SYNTHESIS {
-    ; CHECK-NEXT: } else {
-    ; CHECK-NEXT:   sv.always posedge %clock {
-    ; CHECK-NEXT:     [[PRINTF_COND:%.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
-    ; CHECK-NEXT:     [[COND:%.+]] = comb.and bin [[PRINTF_COND]], %cond : i1
-    ; CHECK-NEXT:     sv.if [[COND]] {
-    ; CHECK-NEXT:       [[PRINTF_FD:%.+]] = sv.macro.ref.expr @PRINTF_FD_() : () -> i32
-    ; CHECK-NEXT:       sv.fwrite [[PRINTF_FD]], "test %0b %c %0d %0x\0A"(%var, %var, %var, %var) : i32
-    ; CHECK-NEXT:     }
-    ; CHECK-NEXT:   }
-    ; CHECK-NEXT: }
+
+    ; CHECK: $fwrite(`PRINTF_FD_, "binary: %0b %0b %8b\n", a, a, a);
+    printf(clock, cond, "binary: %b %0b %8b\n", a, a, a)
+
+    ; CHECK-NEXT: $fwrite(`PRINTF_FD_, "decimal: %0d %0d %3d\n", a, a, a);
+    printf(clock, cond, "decimal: %d %0d %3d\n", a, a, a)
+
+    ; CHECK-NEXT: $fwrite(`PRINTF_FD_, "hexadecimal: %0x %0x %2x\n", a, a, a);
+    printf(clock, cond, "hexadecimal: %x %0x %2x\n", a, a, a)
+
+    ; CHECK-NEXT: $fwrite(`PRINTF_FD_, "ASCII character: %c\n", a);
+    printf(clock, cond, "ASCII character: %c\n", a)
+
+    ; CHECK-NEXT: $fwrite(`PRINTF_FD_, "literals: %%\n");
+    printf(clock, cond, "literals: %%\n")


### PR DESCRIPTION
Add width specifiers to FIRRTL printfs.  This will allow for width specifiers on printf format strings which take a radix (binary, decimal, or hexadecimal).  Additionally, enshrine that `%%` is a literal `%` and will be treated as such.

`firtool` will now reject unknown width specifiers.  E.g., this closes the `%m` loophole.