### PR TITLE
[FIRRTL] Add {{HierarchicalModuleName}} support

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -1705,4 +1705,27 @@ def TimeOp : FIRRTLOp<"fstring.time", [HasCustomSSAName, Pure]> {
 
 }
 
+def HierarchicalModuleNameOp :
+  FIRRTLOp<"fstring.hierarchicalmodulename", [HasCustomSSAName, Pure]> {
+
+  let summary = "an operation that represents the module name with its full path";
+  let description = [{
+
+    This operation represents the name of the current module with a
+    fully-qualified path in front of it.  It returns a format string type which
+    can only be used as a substitution inside a printf.  This operation is not
+    represented in the FIRRTL spec.
+
+    This operation is the FIRRTL Dialect representation of the special
+    substitution `{{HierarchicalModuleName}}`.
+  }];
+
+  let arguments = (ins);
+  let results = (outs FStringType:$result);
+  let assemblyFormat = [{
+    attr-dict `:` type($result)
+  }];
+
+}
+
 #endif // CIRCT_DIALECT_FIRRTL_FIRRTLEXPRESSIONS_TD

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -68,7 +68,7 @@ public:
             DoubleConstantOp, ListCreateOp, ListConcatOp, UnresolvedPathOp,
             PathOp, IntegerAddOp, IntegerMulOp, IntegerShrOp,
             // Format String expressions
-            TimeOp>([&](auto expr) -> ResultType {
+            TimeOp, HierarchicalModuleNameOp>([&](auto expr) -> ResultType {
           return thisCast->visitExpr(expr, args...);
         })
         .Default([&](auto expr) -> ResultType {
@@ -229,6 +229,7 @@ public:
 
   // Format string expressions
   HANDLE(TimeOp, Unhandled);
+  HANDLE(HierarchicalModuleNameOp, Unhandled);
 #undef HANDLE
 };
 

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -6378,6 +6378,11 @@ void TimeOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   setNameFn(getResult(), "time");
 }
 
+void HierarchicalModuleNameOp::getAsmResultNames(
+    OpAsmSetValueNameFn setNameFn) {
+  setNameFn(getResult(), "hierarchicalmodulename");
+}
+
 //===----------------------------------------------------------------------===//
 // TblGen Generated Logic.
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3038,6 +3038,8 @@ ParseResult FIRStmtParser::parsePrintf() {
         auto specialString = formatString.slice(start, i);
         if (specialString == "SimulationTime") {
           operands.push_back(builder.create<TimeOp>());
+        } else if (specialString == "HierarchicalModuleName") {
+          operands.push_back(builder.create<HierarchicalModuleNameOp>());
         } else {
           emitError(formatStringLoc)
               << "unknown printf substitution '" << specialString

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -385,7 +385,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:     sv.if [[AND]] {
     // CHECK-NEXT:       %PRINTF_FD_ = sv.macro.ref.expr @PRINTF_FD_() : () -> i32
     // CHECK-NEXT:       [[TIME:%.+]] = sv.system.time : i64
-    // CHECK-NEXT:       sv.fwrite %PRINTF_FD_, "[%0t]: %0d"([[TIME]], %a) : i64, i4
+    // CHECK-NEXT:       sv.fwrite %PRINTF_FD_, "[%0t]: %0d %m"([[TIME]], %a) : i64, i4
     // CHECK-NEXT:     }
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
@@ -406,7 +406,8 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.printf %clock, %reset, "Hi signed %d %d\0A"(%1, %d) : !firrtl.clock, !firrtl.uint<1>, !firrtl.sint<5>, !firrtl.sint<4>
 
     %time = firrtl.fstring.time : !firrtl.fstring
-    firrtl.printf %clock, %reset, "[{{}}]: %d" (%time, %a) : !firrtl.clock, !firrtl.uint<1>, !firrtl.fstring, !firrtl.uint<4>
+    %hierarchicalmodulename = firrtl.fstring.hierarchicalmodulename : !firrtl.fstring
+    firrtl.printf %clock, %reset, "[{{}}]: %d {{}}" (%time, %a, %hierarchicalmodulename) : !firrtl.clock, !firrtl.uint<1>, !firrtl.fstring, !firrtl.uint<4>, !firrtl.fstring
 
     firrtl.skip
 

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2061,8 +2061,8 @@ circuit Foo:
   public module Foo:
     input clock: Clock
     ; In FIRRTL versions < 4.2.0, the following is not a "special substitution".
-    ; CHECK{{LITERAL}}: firrtl.printf %clock, %c1_ui1, "[{{SimulationTime}}]: hello world "
-    printf(clock, UInt<1>(1), "[{{SimulationTime}}]: hello world")
+    ; CHECK{{LITERAL}}: firrtl.printf %clock, %c1_ui1, "[{{SimulationTime}}]: hello from {{HierarchicalModuleName}}"
+    printf(clock, UInt<1>(1), "[{{SimulationTime}}]: hello from {{HierarchicalModuleName}}")
 
 ;// -----
 FIRRTL version 5.0.0
@@ -2071,5 +2071,6 @@ circuit Foo:
     input clock: Clock
     ; In FIRRTL versions >= 4.2.0, the following is not a "special substitution".
     ; CHECK:            %time = firrtl.fstring.time : !firrtl.fstring
-    ; CHECK{{LITERAL}}: firrtl.printf %clock, %c1_ui1, "[{{}}]: hello world "(%time)
-    printf(clock, UInt<1>(1), "[{{SimulationTime}}]: hello world")
+    ; CHECK:            %hierarchicalmodulename = firrtl.fstring.hierarchicalmodulename : !firrtl.fstring
+    ; CHECK{{LITERAL}}: firrtl.printf %clock, %c1_ui1, "[{{}}]: hello world {{}}"(%time, %hierarchicalmodulename)
+    printf(clock, UInt<1>(1), "[{{SimulationTime}}]: hello from {{HierarchicalModuleName}}")

--- a/test/firtool/print.fir
+++ b/test/firtool/print.fir
@@ -1,6 +1,6 @@
 ; RUN: firtool %s | FileCheck %s
 
-FIRRTL version 5.1.0
+FIRRTL version 5.0.0
 circuit PrintTest:
   ; CHECK-LABEL: module PrintTest
   public module PrintTest :
@@ -23,3 +23,6 @@ circuit PrintTest:
 
     ; CHECK-NEXT: $fwrite(`PRINTF_FD_, "literals: %%\n");
     printf(clock, cond, "literals: %%\n")
+
+    ; CHECK-NEXT: $fwrite(`PRINTF_FD_, "[%0t]: %m\n", $time);
+    printf(clock, cond, "[{{SimulationTime}}]: {{HierarchicalModuleName}}\n")


### PR DESCRIPTION
Add support for the FIRRTL 5.0.0 printf substitution `{{HierarchicalModuleName}}`.  Support this in the FIRRTL Dialect with a new operation.  Add FIRRTL parsing, FIRRTL emission, and FIRRTL-to-HW lowering.