### PR TITLE
[LLHD] Update LowerProcesses pass to work with process results

### DIFF
--- a/include/circt/Dialect/LLHD/Transforms/LLHDPasses.td
+++ b/include/circt/Dialect/LLHD/Transforms/LLHDPasses.td
@@ -155,4 +155,11 @@ def HoistSignalsPass : Pass<"llhd-hoist-signals"> {
   let summary = "Hoist probes and promote drives to process results";
 }
 
+def LowerProcessesPass : Pass<"llhd-lower-processes", "hw::HWModuleOp"> {
+  let summary = "Convert combinational LLHD processes to SCF execute regions";
+  let dependentDialects = [
+    "mlir::scf::SCFDialect",
+  ];
+}
+
 #endif // CIRCT_DIALECT_LLHD_TRANSFORMS_PASSES

--- a/lib/Dialect/LLHD/Transforms/CMakeLists.txt
+++ b/lib/Dialect/LLHD/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_dialect_library(CIRCTLLHDTransforms
   EarlyCodeMotionPass.cpp
   FunctionEliminationPass.cpp
   HoistSignals.cpp
+  LowerProcesses.cpp
   Mem2Reg.cpp
   MemoryToBlockArgumentPass.cpp
   ProcessLoweringPass.cpp
@@ -21,5 +22,6 @@ add_circt_dialect_library(CIRCTLLHDTransforms
   MLIRControlFlowDialect
   MLIRFuncDialect
   MLIRIR
+  MLIRSCFDialect
   MLIRTransformUtils
 )

--- a/lib/Dialect/LLHD/Transforms/LowerProcesses.cpp
+++ b/lib/Dialect/LLHD/Transforms/LowerProcesses.cpp
@@ -1,0 +1,280 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/LLHD/IR/LLHDOps.h"
+#include "circt/Dialect/LLHD/Transforms/LLHDPasses.h"
+#include "mlir/Analysis/Liveness.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "llhd-lower-processes"
+
+namespace circt {
+namespace llhd {
+#define GEN_PASS_DEF_LOWERPROCESSESPASS
+#include "circt/Dialect/LLHD/Transforms/LLHDPasses.h.inc"
+} // namespace llhd
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace llhd;
+using llvm::SmallDenseSet;
+using llvm::SmallSetVector;
+
+namespace {
+struct Lowering {
+  Lowering(ProcessOp processOp) : processOp(processOp) {}
+  void lower();
+  bool matchControlFlow();
+  void markObservedValues();
+  bool allOperandsObserved();
+  bool isObserved(Value value);
+
+  ProcessOp processOp;
+  WaitOp waitOp;
+  SmallDenseSet<Value> observedValues;
+};
+} // namespace
+
+void Lowering::lower() {
+  // Ensure that the process describes combinational logic.
+  if (!matchControlFlow())
+    return;
+  markObservedValues();
+  if (!allOperandsObserved())
+    return;
+  LLVM_DEBUG(llvm::dbgs() << "Lowering process " << processOp.getLoc() << "\n");
+
+  // Replace the process.
+  OpBuilder builder(processOp);
+  auto executeOp = builder.create<scf::ExecuteRegionOp>(
+      processOp.getLoc(), processOp.getResultTypes());
+  executeOp.getRegion().takeBody(processOp.getBody());
+  processOp.replaceAllUsesWith(executeOp);
+  processOp.erase();
+  processOp = {};
+
+  // Replace the `llhd.wait` with an `scf.yield`.
+  builder.setInsertionPoint(waitOp);
+  builder.create<scf::YieldOp>(waitOp.getLoc(), waitOp.getYieldOperands());
+  waitOp.erase();
+
+  // Simplify the execute op body region since disconnecting the control flow
+  // loop through the wait op has potentially created unreachable blocks.
+  IRRewriter rewriter(builder);
+  (void)simplifyRegions(rewriter, executeOp->getRegions());
+}
+
+/// Check that the process' entry block trivially joins a control flow loop
+/// immediately after the wait op.
+bool Lowering::matchControlFlow() {
+  // Ensure that there is only a single wait op in the process and that it has
+  // no destination operands.
+  for (auto &block : processOp.getBody()) {
+    if (auto op = dyn_cast<WaitOp>(block.getTerminator())) {
+      if (waitOp) {
+        LLVM_DEBUG(llvm::dbgs() << "Skipping process " << processOp.getLoc()
+                                << ": multiple wait ops\n");
+        return false;
+      }
+      waitOp = op;
+    }
+  }
+  if (!waitOp) {
+    LLVM_DEBUG(llvm::dbgs() << "Skipping process " << processOp.getLoc()
+                            << ": no wait op\n");
+    return false;
+  }
+  if (!waitOp.getDestOperands().empty()) {
+    LLVM_DEBUG(llvm::dbgs() << "Skipping process " << processOp.getLoc()
+                            << ": wait op has destination operands\n");
+    return false;
+  }
+
+  // Helper function to skip across empty blocks with only a single successor.
+  auto skipToMergePoint = [&](Block *block) -> std::pair<Block *, ValueRange> {
+    ValueRange operands;
+    while (auto branchOp = dyn_cast<cf::BranchOp>(block->getTerminator())) {
+      if (!block->without_terminator().empty())
+        break;
+      block = branchOp.getDest();
+      operands = branchOp.getDestOperands();
+      if (std::distance(block->pred_begin(), block->pred_end()) > 1)
+        break;
+      if (!operands.empty())
+        break;
+    }
+    return {block, operands};
+  };
+
+  // Ensure that the entry block and wait op converge on the same block and with
+  // the same block arguments.
+  auto &entry = processOp.getBody().front();
+  auto [entryMergeBlock, entryMergeArgs] = skipToMergePoint(&entry);
+  auto [waitMergeBlock, waitMergeArgs] = skipToMergePoint(waitOp.getDest());
+  if (entryMergeBlock != waitMergeBlock) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Skipping process " << processOp.getLoc()
+               << ": control from entry and wait does not converge\n");
+    return false;
+  }
+  if (entryMergeArgs != waitMergeArgs) {
+    LLVM_DEBUG(llvm::dbgs() << "Skipping process " << processOp.getLoc()
+                            << ": control from entry and wait converges with "
+                               "different block arguments\n");
+    return false;
+  }
+
+  // Ensure that no values are live across the wait op.
+  Liveness liveness(processOp);
+  for (auto value : liveness.getLiveOut(waitOp->getBlock())) {
+    if (value.getParentRegion()->isProperAncestor(&processOp.getBody()))
+      continue;
+    LLVM_DEBUG({
+      llvm::dbgs() << "Skipping process " << processOp.getLoc() << ": value ";
+      value.print(llvm::dbgs(), OpPrintingFlags().skipRegions());
+      llvm::dbgs() << " live across wait\n";
+    });
+    return false;
+  }
+
+  return true;
+}
+
+/// Mark values the process observes that are defined outside the process.
+void Lowering::markObservedValues() {
+  SmallVector<Value> worklist;
+  auto markObserved = [&](Value value) {
+    if (observedValues.insert(value).second)
+      worklist.push_back(value);
+  };
+
+  for (auto value : waitOp.getObserved())
+    if (value.getParentRegion()->isProperAncestor(&processOp.getBody()))
+      markObserved(value);
+
+  while (!worklist.empty()) {
+    auto value = worklist.pop_back_val();
+    auto *op = value.getDefiningOp();
+    if (!op)
+      continue;
+
+    // Look through probe ops to mark the probe signal as well, just in case
+    // there may be multiple probes of the same signal.
+    if (auto probeOp = dyn_cast<PrbOp>(op))
+      markObserved(probeOp.getSignal());
+
+    // Look through operations that simply reshape incoming values into an
+    // aggregate form from which any changes remain apparent.
+    if (isa<hw::ArrayCreateOp, hw::StructCreateOp, comb::ConcatOp,
+            hw::BitcastOp>(op))
+      for (auto operand : op->getOperands())
+        markObserved(operand);
+  }
+}
+
+/// Ensure that any value defined outside the process that is used inside the
+/// process is derived entirely from an observed value.
+bool Lowering::allOperandsObserved() {
+  // Collect all ancestor regions such that we can easily check if a value is
+  // defined outside the process.
+  SmallPtrSet<Region *, 4> properAncestors;
+  for (auto *region = processOp->getParentRegion(); region;
+       region = region->getParentRegion())
+    properAncestors.insert(region);
+
+  // Walk all operations under the process and check each operand.
+  auto walkResult = processOp.walk([&](Operation *op) {
+    for (auto operand : op->getOperands()) {
+      // We only care about values defined outside the process.
+      if (!properAncestors.count(operand.getParentRegion()))
+        continue;
+
+      // If the value is observed, all is well.
+      if (isObserved(operand))
+        continue;
+
+      // Otherwise complain and abort.
+      LLVM_DEBUG({
+        llvm::dbgs() << "Skipping process " << processOp.getLoc()
+                     << ": unobserved value ";
+        operand.print(llvm::dbgs(), OpPrintingFlags().skipRegions());
+        llvm::dbgs() << "\n";
+      });
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return !walkResult.wasInterrupted();
+}
+
+/// Check if a value is observed by the wait op, or all its operands are only
+/// derived from observed values.
+bool Lowering::isObserved(Value value) {
+  // Check if the value is trivially observed.
+  if (observedValues.contains(value))
+    return true;
+
+  // Otherwise get the operation that defines it such that we can check if the
+  // value is derived from purely observed values. If it isn't define by an op,
+  // the value is unobserved.
+  auto *defOp = value.getDefiningOp();
+  if (!defOp)
+    return false;
+
+  // Otherwise visit all ops in the fan-in cone and ensure that they are
+  // observed. If any value is unobserved, immediately return false.
+  SmallDenseSet<Operation *> seenOps;
+  SmallVector<Operation *> worklist;
+  seenOps.insert(defOp);
+  worklist.push_back(defOp);
+  while (!worklist.empty()) {
+    auto *op = worklist.pop_back_val();
+
+    // Give up on ops with nested regions.
+    if (op->getNumRegions() != 0)
+      return false;
+
+    // Otherwise check that all operands are observed. If we haven't seen an
+    // operand before, and it is not a signal, add it to the worklist to be
+    // checked.
+    for (auto operand : op->getOperands()) {
+      if (observedValues.contains(operand))
+        continue;
+      if (isa<hw::InOutType>(operand.getType()))
+        return false;
+      auto *defOp = operand.getDefiningOp();
+      if (!defOp || !isMemoryEffectFree(defOp))
+        return false;
+      if (seenOps.insert(defOp).second)
+        worklist.push_back(defOp);
+    }
+  }
+
+  // If we arrive at this point, we weren't able to reach an unobserved value.
+  // Therefore we consider this value derived from only observed values.
+  observedValues.insert(value);
+  return true;
+}
+
+namespace {
+struct LowerProcessesPass
+    : public llhd::impl::LowerProcessesPassBase<LowerProcessesPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void LowerProcessesPass::runOnOperation() {
+  SmallVector<ProcessOp> processOps(getOperation().getOps<ProcessOp>());
+  for (auto processOp : processOps)
+    Lowering(processOp).lower();
+}

--- a/test/Dialect/LLHD/Transforms/lower-processes.mlir
+++ b/test/Dialect/LLHD/Transforms/lower-processes.mlir
@@ -1,0 +1,204 @@
+// RUN: circt-opt --llhd-lower-processes %s | FileCheck %s
+
+// CHECK-LABEL: @Trivial(
+hw.module @Trivial() {
+  // CHECK:      scf.execute_region {
+  // CHECK-NEXT:   cf.br ^bb1
+  // CHECK-NEXT: ^bb1:
+  // CHECK-NEXT:   scf.yield
+  // CHECK-NEXT: }
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    llhd.wait ^bb1
+  }
+}
+
+// CHECK-LABEL: @BlockArgs(
+hw.module @BlockArgs(in %a: i42, in %b: i42) {
+  // CHECK:      scf.execute_region {
+  // CHECK-NEXT:   cf.br ^bb1
+  // CHECK-NEXT: ^bb1:
+  // CHECK-NEXT:   cf.br ^bb2
+  // CHECK-NEXT: ^bb2:
+  // CHECK-NEXT:   scf.yield
+  // CHECK-NEXT: }
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    cf.br ^bb4(%a : i42)
+  ^bb2:
+    cf.br ^bb3
+  ^bb3:
+    cf.br ^bb4(%a : i42)
+  ^bb4(%0: i42):
+    llhd.wait (%a : i42), ^bb2
+  }
+}
+
+// CHECK-LABEL: @SupportYieldOperands(
+hw.module @SupportYieldOperands(in %a: i42) {
+  // CHECK:      scf.execute_region -> i42 {
+  // CHECK-NEXT:   cf.br ^bb1
+  // CHECK-NEXT: ^bb1:
+  // CHECK-NEXT:   scf.yield %a : i42
+  // CHECK-NEXT: }
+  llhd.process -> i42 {
+    cf.br ^bb1
+  ^bb1:
+    llhd.wait yield (%a : i42), (%a : i42), ^bb1
+  }
+}
+
+// CHECK-LABEL: @SupportSeparateProbesOfSameValue(
+hw.module @SupportSeparateProbesOfSameValue() {
+  %c0_i42 = hw.constant 0 : i42
+  %a = llhd.sig %c0_i42 : i42
+  %0 = llhd.prb %a : !hw.inout<i42>
+  %1 = llhd.prb %a : !hw.inout<i42>
+  // CHECK: scf.execute_region
+  llhd.process -> i42 {
+    cf.br ^bb1
+  ^bb1:
+    llhd.wait yield (%0 : i42), (%1 : i42), ^bb1
+  }
+}
+
+// CHECK-LABEL: @SupportObservedArrays(
+hw.module @SupportObservedArrays(in %a: i42, in %b: i42) {
+  // CHECK: scf.execute_region
+  %0 = hw.array_create %a, %b : i42
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    comb.add %a, %b : i42
+    llhd.wait (%0 : !hw.array<2xi42>), ^bb1
+  }
+}
+
+// CHECK-LABEL: @SupportObservedStructs(
+hw.module @SupportObservedStructs(in %a: i42, in %b: i42) {
+  // CHECK: scf.execute_region
+  %0 = hw.struct_create (%a, %b) : !hw.struct<a: i42, b: i42>
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    comb.add %a, %b : i42
+    llhd.wait (%0 : !hw.struct<a: i42, b: i42>), ^bb1
+  }
+}
+
+// CHECK-LABEL: @SupportObservedConcats(
+hw.module @SupportObservedConcats(in %a: i42, in %b: i42) {
+  // CHECK: scf.execute_region
+  %0 = comb.concat %a, %b : i42, i42
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    comb.add %a, %b : i42
+    llhd.wait (%0 : i84), ^bb1
+  }
+}
+
+// CHECK-LABEL: @SupportObservedBitcasts(
+hw.module @SupportObservedBitcasts(in %a: i42, in %b: i42) {
+  // CHECK: scf.execute_region
+  %0 = hw.bitcast %a : (i42) -> !hw.array<2xi21>
+  %1 = hw.bitcast %b : (i42) -> !hw.array<3xi14>
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    comb.add %a, %b : i42
+    llhd.wait (%0, %1 : !hw.array<2xi21>, !hw.array<3xi14>), ^bb1
+  }
+}
+
+// CHECK-LABEL: @CommonPattern1(
+hw.module @CommonPattern1(in %a: i42, in %b: i42, in %c: i1) {
+  // CHECK:      scf.execute_region -> i42 {
+  // CHECK-NEXT:   cf.br ^bb1
+  // CHECK-NEXT: ^bb1:
+  // CHECK-NEXT:   cf.cond_br %c, ^bb2(%a : i42), ^bb2(%b : i42)
+  // CHECK-NEXT: ^bb2([[ARG:%.+]]: i42):
+  // CHECK-NEXT:   scf.yield [[ARG]] : i42
+  // CHECK-NEXT: }
+  %0 = llhd.process -> i42 {
+    cf.br ^bb2(%a, %b : i42, i42)
+  ^bb1:
+    cf.br ^bb2(%a, %b : i42, i42)
+  ^bb2(%1: i42, %2: i42):
+    cf.cond_br %c, ^bb3(%1 : i42), ^bb3(%2 : i42)
+  ^bb3(%3: i42):
+    llhd.wait yield (%3 : i42), (%a, %b, %c, %0 : i42, i42, i1, i42), ^bb1
+  }
+}
+
+// CHECK-LABEL: @SkipIfMultipleWaits(
+hw.module @SkipIfMultipleWaits() {
+  // CHECK: llhd.process
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    llhd.wait ^bb2
+  ^bb2:
+    llhd.wait ^bb1
+  }
+}
+
+// CHECK-LABEL: @SkipIfNoWaits(
+hw.module @SkipIfNoWaits() {
+  // CHECK: llhd.process
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    llhd.halt
+  }
+}
+
+// CHECK-LABEL: @SkipIfWaitHasDestinationOperands(
+hw.module @SkipIfWaitHasDestinationOperands(in %a: i42) {
+  // CHECK: llhd.process
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    llhd.wait ^bb2(%a : i42)
+  ^bb2(%0: i42):
+    cf.br ^bb1
+  }
+}
+
+// CHECK-LABEL: @SkipIfEntryAndWaitConvergeInWrongSpot(
+hw.module @SkipIfEntryAndWaitConvergeInWrongSpot(in %a: i42) {
+  // CHECK: llhd.process
+  llhd.process {
+    cf.br ^bb2  // skip logic after wait
+  ^bb1:
+    %0 = comb.add %a, %a : i42
+    cf.br ^bb2
+  ^bb2:
+    llhd.wait ^bb1
+  }
+}
+
+// CHECK-LABEL: @SkipIfEntryAndWaitConvergeWithDifferentBlockArgs(
+hw.module @SkipIfEntryAndWaitConvergeWithDifferentBlockArgs(in %a: i42, in %b: i42) {
+  // CHECK: llhd.process
+  llhd.process {
+    cf.br ^bb2(%a : i42)
+  ^bb1:
+    cf.br ^bb2(%b : i42)
+  ^bb2(%0: i42):
+    llhd.wait ^bb1
+  }
+}
+
+// CHECK-LABEL: @SkipIfValueUnobserved(
+hw.module @SkipIfValueUnobserved(in %a: i42) {
+  // CHECK: llhd.process
+  llhd.process {
+    cf.br ^bb1
+  ^bb1:
+    %0 = comb.add %a, %a : i42
+    llhd.wait ^bb1
+  }
+}


### PR DESCRIPTION
Add an update version of the process lowering pass. This new version expects all probes and drives to have been hoisted out of processes. The pass then converts an `llhd.process` op to an `scf.execute_region` if the process

- has a single wait op;
- has a simple control flow loop through that single wait op;
- has no destination operands on the wait op; and
- has all operands that are used in the process but defined outside of the process observed by the wait op.

This essentially lowers any combinational LLHD processes with a CFG loop through a wait op which triggers when any of the inputs change into a simple SCF execute region without the CFG loop. The assumption here is that the execute region will be re-evaluated if any of the values used within it change.

Life would be a lot easier if we didn't have to chase through the observed values of the wait op for this lowering. Ideally LLHD would have a simplified version of a process that we can canonicalize to early on.