### PR TITLE
[RTG][Elaboration] Treat randomized sequences as regular identity values

### DIFF
--- a/test/Dialect/RTG/Transform/elaboration.mlir
+++ b/test/Dialect/RTG/Transform/elaboration.mlir
@@ -742,7 +742,7 @@ rtg.test @randomIntegers() {
 // -----
 
 rtg.sequence @seq0(%seq: !rtg.randomized_sequence) {
-  // expected-error @below {{attempting to place sequence seq1_0 derived from seq1 under context #rtgtest.cpu<0> : !rtgtest.cpu, but it was previously randomized for context 'default'}}
+  // expected-error @below {{attempting to place sequence derived from seq1 under context #rtgtest.cpu<0> : !rtgtest.cpu, but it was previously randomized for context 'default'}}
   rtg.embed_sequence %seq
 }
 rtg.sequence @seq1() { }


### PR DESCRIPTION
Currently we special-case randomized sequences. This PR changes them to be values with identity. This has the advantage that we don't need to generate a new, unique name for each randomizes sequence from the start, i.e., if we randomize 1000 sequences, put them in a set and only select 1 at random and embed it, then we only need to generate 1 name after this PR instead of 1000. This name uniquification made up a considerable chunk of runtime in some previous profiling. On the negative side, we now pass randomized sequence values as block arguments to nested sequences which makes life a bit more difficult for sequence inlining. Not sure if avoiding this is worth the special-casing.