### PR TITLE
[FIRRTL] Add VersionAttr, put on Circuit, use to parse FIRRTL 6 Annotations

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAnnotationHelper.h
@@ -236,10 +236,11 @@ private:
 /// Return an input \p target string in canonical form.  This converts a Legacy
 /// Annotation (e.g., A.B.C) into a modern annotation (e.g., ~A|B>C).  Trailing
 /// subfield/subindex references are preserved.
-std::string canonicalizeTarget(StringRef target);
+std::string canonicalizeTarget(StringRef target, VersionAttr version);
 
 /// Parse a FIRRTL annotation path into its constituent parts.
-std::optional<TokenAnnoTarget> tokenizePath(StringRef origTarget);
+std::optional<TokenAnnoTarget> tokenizePath(StringRef origTarget,
+                                            VersionAttr version);
 
 /// Convert a parsed target string to a resolved target structure.  This
 /// resolves all names and aggregates from a parsed target.

--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -188,6 +188,82 @@ def InternalPathArrayAttr
   : TypedArrayAttrBase<InternalPathAttr, "InternalPath array attribute">;
 
 //===----------------------------------------------------------------------===//
+// Circuit version attribute
+//===----------------------------------------------------------------------===//
+
+def VersionAttr : AttrDef<FIRRTLDialect, "Version"> {
+  let summary = "A FIRRTL version";
+  let description = [{
+    This attribute records a specific version of the FIRRTL specification.
+
+    This consists of a major, minor, and patch version.
+  }];
+
+  let mnemonic = "version";
+  let parameters = (ins "uint16_t":$major, "uint16_t":$minor, "uint16_t":$patch);
+  let assemblyFormat = [{
+    `<` struct($major, $minor, $patch) `>`
+  }];
+
+  let extraClassDeclaration = [{
+    explicit constexpr operator uint64_t() const {
+      return uint64_t(getMajor()) << 32 | uint64_t(getMinor()) << 16 | uint64_t(getPatch());
+    }
+
+    constexpr bool operator<(VersionAttr other) const {
+      return uint64_t(*this) < uint64_t(other);
+    }
+
+    constexpr bool operator>(VersionAttr other) const {
+      return uint64_t(*this) > uint64_t(other);
+    }
+
+    constexpr bool operator<=(VersionAttr other) const {
+      return uint64_t(*this) <= uint64_t(other);
+    }
+
+    constexpr bool operator>=(VersionAttr other) const {
+      return uint64_t(*this) >= uint64_t(other);
+    }
+
+    /// The minimum FIRRTL version supported by CIRCT.
+    static VersionAttr getMinimumVersion(::mlir::MLIRContext *context) {
+      return get(context, 2, 0, 0);
+    }
+
+    /// The next version of FIRRTL that is not yet released.
+    ///
+    /// Features use this version if they have been landed on the main branch of
+    /// `chipsalliance/firrtl-spec`, but have not been part of a release
+    /// yet. Once a new version of the spec is released, all uses of
+    /// `nextFIRVersion` in the parser are replaced with the concrete version
+    /// `{x, y, z}`, and this declaration here is bumped to the next probable
+    /// version number.
+    static VersionAttr getNextVersion(::mlir::MLIRContext *context) {
+      return get(context, 5, 1, 0);
+    }
+
+    /// A marker for parser features that are currently missing from the spec.
+    ///
+    /// Features use this version if they have _not_ been added to the
+    /// documentation in the `chipsalliance/firrtl-spec` repository. This allows
+    /// us to distinguish features that are released in the next version of the
+    /// spec and features that are still missing from the spec.
+    static VersionAttr getMissingVersion(::mlir::MLIRContext *context) {
+      return getNextVersion(context);
+    }
+
+    /// The version of FIRRTL that the exporter produces. This is always the
+    /// next version, since it contains any new developments.
+    static VersionAttr getExportVersion(::mlir::MLIRContext *context) {
+      return getNextVersion(context);
+    }
+
+  }];
+}
+
+
+//===----------------------------------------------------------------------===//
 // Miscellaneous attributes
 //===----------------------------------------------------------------------===//
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -206,23 +206,23 @@ def VersionAttr : AttrDef<FIRRTLDialect, "Version"> {
   }];
 
   let extraClassDeclaration = [{
-    constexpr operator uint64_t() const {
+    operator uint64_t() const {
       return uint64_t(getMajor()) << 32 | uint64_t(getMinor()) << 16 | uint64_t(getPatch());
     }
 
-    constexpr bool operator<(VersionAttr other) const {
+    bool operator<(VersionAttr other) const {
       return uint64_t(*this) < uint64_t(other);
     }
 
-    constexpr bool operator>(VersionAttr other) const {
+    bool operator>(VersionAttr other) const {
       return uint64_t(*this) > uint64_t(other);
     }
 
-    constexpr bool operator<=(VersionAttr other) const {
+    bool operator<=(VersionAttr other) const {
       return uint64_t(*this) <= uint64_t(other);
     }
 
-    constexpr bool operator>=(VersionAttr other) const {
+    bool operator>=(VersionAttr other) const {
       return uint64_t(*this) >= uint64_t(other);
     }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLAttributes.td
@@ -206,7 +206,7 @@ def VersionAttr : AttrDef<FIRRTLDialect, "Version"> {
   }];
 
   let extraClassDeclaration = [{
-    explicit constexpr operator uint64_t() const {
+    constexpr operator uint64_t() const {
       return uint64_t(getMajor()) << 32 | uint64_t(getMinor()) << 16 | uint64_t(getPatch());
     }
 

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -34,6 +34,7 @@ def CircuitOp : FIRRTLOp<"circuit",
   let arguments = (ins
     StrAttr:$name,
     DefaultValuedAttr<AnnotationArrayAttr, "{}">:$annotations,
+    OptionalAttr<VersionAttr>:$version,
     OptionalAttr<SymbolRefArrayAttr>:$enable_layers,
     OptionalAttr<SymbolRefArrayAttr>:$disable_layers,
     OptionalAttr<LayerSpecializationAttr>:$default_layer_specialization,
@@ -45,7 +46,7 @@ def CircuitOp : FIRRTLOp<"circuit",
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "StringAttr":$name,
-               CArg<"ArrayAttr","ArrayAttr()">:$annotations)>
+                   CArg<"ArrayAttr","ArrayAttr()">:$annotations)>
   ];
 
   let extraClassDeclaration = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStructure.td
@@ -58,6 +58,10 @@ def CircuitOp : FIRRTLOp<"circuit",
 
     /// Return body of this circuit.
     Block *getBodyBlock();
+
+    VersionAttr getVersionOrDefault() {
+      return getVersion().value_or(VersionAttr::getNextVersion(getContext()));
+    }
   }];
 
   let assemblyFormat = "$name `` custom<CircuitOpAttrs>(attr-dict) $body";

--- a/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLAnnotationHelper.cpp
@@ -746,8 +746,8 @@ LogicalResult circt::firrtl::applyGCTMemTaps(const AnnoPathValue &target,
   if (!sourceAttr)
     return failure();
 
-  auto sourceTargetStr =
-      canonicalizeTarget(sourceAttr.getValue(), state.circuit.getVersionOrDefault());
+  auto sourceTargetStr = canonicalizeTarget(
+      sourceAttr.getValue(), state.circuit.getVersionOrDefault());
   std::optional<AnnoPathValue> srcTarget = resolvePath(
       sourceTargetStr, state.circuit, state.symTbl, state.targetCaches);
   if (!srcTarget)

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -5963,7 +5963,8 @@ ParseResult FIRCircuitParser::parseCircuit(
 
   // Create the top-level circuit op in the MLIR module.
   OpBuilder b(mlirModule.getBodyRegion());
-  auto circuit = b.create<CircuitOp>(info.getLoc(), name);
+  auto circuit = b.create<CircuitOp>(
+      info.getLoc(), name, /*annotations=*/getConstants().emptyArrayAttr);
 
   // A timer to get execution time of annotation parsing.
   auto parseAnnotationTimer = ts.nest("Parse annotations");

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -150,10 +150,11 @@ static std::optional<AnnoPathValue> noResolve(DictionaryAttr anno,
 /// resolves it.
 static std::optional<AnnoPathValue> stdResolveImpl(StringRef rawPath,
                                                    ApplyState &state) {
-  auto pathStr = canonicalizeTarget(rawPath);
+  auto pathStr =
+      canonicalizeTarget(rawPath, state.circuit.getVersionOrDefault());
   StringRef path{pathStr};
 
-  auto tokens = tokenizePath(path);
+  auto tokens = tokenizePath(path, state.circuit.getVersionOrDefault());
   if (!tokens) {
     mlir::emitError(state.circuit.getLoc())
         << "Cannot tokenize annotation path " << rawPath;

--- a/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolvePaths.cpp
@@ -143,7 +143,7 @@ struct PathResolver {
     if (!target.consume_front(":"))
       return emitError(loc, "expected ':' in target string");
 
-    auto token = tokenizePath(target);
+    auto token = tokenizePath(target, circuit.getVersionOrDefault());
     if (!token)
       return emitError(loc)
              << "cannot tokenize annotation path \"" << target << "\"";

--- a/test/Dialect/FIRRTL/annotations-errors.mlir
+++ b/test/Dialect/FIRRTL/annotations-errors.mlir
@@ -570,3 +570,75 @@ firrtl.circuit "Top" attributes {
   // expected-error @below {{circt.OutputDirAnnotation target already has an output file}}
   firrtl.module @Top() {}
 }
+
+// -----
+// A FIRRTL version 6 annotation is rejected in versions < 6
+// expected-error @+2 {{circuit name doesn't match annotation}}
+// expected-error @+1 {{Unable to resolve target of annotation}}
+firrtl.circuit "Foo" attributes {
+  rawAnnotations = [
+    {
+      class = "circt.test",
+      target = "Foo>a"
+    }
+  ],
+  version = #firrtl.version<major = 5, minor = 1, patch = 0>
+} {
+  firrtl.module @Foo() {
+    %a = firrtl.wire : !firrtl.uint<1>
+  }
+}
+
+// -----
+// A FIRRTL version 5 annotation is rejected in version 6
+// expected-error @+2 {{Cannot tokenize annotation path ~Foo|Foo>a}}
+// expected-error @+1 {{Unable to resolve target of annotation}}
+firrtl.circuit "Foo" attributes {
+  rawAnnotations = [
+    {
+      class = "circt.test",
+      target = "~Foo|Foo>a"
+    }
+  ],
+  version = #firrtl.version<major = 6, minor = 0, patch = 0>
+} {
+  firrtl.module @Foo() {
+    %a = firrtl.wire : !firrtl.uint<1>
+  }
+}
+
+// -----
+// A FIRRTL version 5 annotation is rejected in version 6
+// expected-error @+2 {{Cannot tokenize annotation path Foo.Foo}}
+// expected-error @+1 {{Unable to resolve target of annotation}}
+firrtl.circuit "Foo" attributes {
+  rawAnnotations = [
+    {
+      class = "circt.test",
+      target = "Foo.Foo"
+    }
+  ],
+  version = #firrtl.version<major = 6, minor = 0, patch = 0>
+} {
+  firrtl.module @Foo() {
+    %a = firrtl.wire : !firrtl.uint<1>
+  }
+}
+
+// -----
+// A FIRRTL version 5 annotation is rejected in version 6
+// expected-error @+2 {{Cannot tokenize annotation path Foo.Foo.a}}
+// expected-error @+1 {{Unable to resolve target of annotation}}
+firrtl.circuit "Foo" attributes {
+  rawAnnotations = [
+    {
+      class = "circt.test",
+      target = "Foo.Foo.a"
+    }
+  ],
+  version = #firrtl.version<major = 6, minor = 0, patch = 0>
+} {
+  firrtl.module @Foo() {
+    %a = firrtl.wire : !firrtl.uint<1>
+  }
+}

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -27,7 +27,8 @@ firrtl.circuit "Foo" attributes {
       data = "CircuitName",
       target = "Foo"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Foo() {}
 }
@@ -55,7 +56,8 @@ firrtl.circuit "Foo" attributes {
       data = "ExtModule Target",
       target = "~Foo|Blackbox"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK:      firrtl.module @Foo
   // CHECK-SAME:   annotations =
@@ -92,7 +94,8 @@ firrtl.circuit "Foo" attributes {
       data = "c",
       target = "~Foo|Foo/bar:Bar"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK-NEXT: firrtl.module @Bar()
   // CHECK-SAME:   annotations =
@@ -145,7 +148,8 @@ firrtl.circuit "Foo" attributes {
       data = 4,
       target = "Foo.Foo.bar.c"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK-NEXT: firrtl.module @Bar
   // CHECK-SAME:   in %a
@@ -194,7 +198,8 @@ firrtl.circuit "Foo"  attributes {
       data = "b",
       target = "Foo.Foo.bar"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK: firrtl.module @Foo
   firrtl.module @Foo() {
@@ -223,7 +228,8 @@ firrtl.circuit "Foo" attributes {
       data = "b",
       target = "Foo.Foo.bar"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK: firrtl.module @Foo
   firrtl.module @Foo() {
@@ -268,7 +274,8 @@ firrtl.circuit "Foo" attributes {
       data = "d",
       target = "~Foo|Foo>bar.w.data.qux"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK: firrtl.module @Foo
   firrtl.module @Foo() {
@@ -305,7 +312,8 @@ firrtl.circuit "Foo" attributes {
       data = "b",
       target = "Foo.Foo.baz"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Foo(
     in %clock: !firrtl.clock,
@@ -345,7 +353,8 @@ firrtl.circuit "Foo" attributes {
       data = "b",
       target = "Foo.Foo.bar"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Foo() {
     %bar = firrtl.wire : !firrtl.uint<1>
@@ -372,7 +381,8 @@ firrtl.circuit "Foo" attributes {
       data = "b",
       target = "Foo.Foo.baz"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Foo(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>) {
     %bar = firrtl.reg %clock  : !firrtl.clock, !firrtl.uint<1>
@@ -403,7 +413,8 @@ firrtl.circuit "Foo" attributes {
       data = "b",
       target = "Foo.Foo.bar"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Foo() {
     %bar = chirrtl.seqmem Undefined : !chirrtl.cmemory<uint<1>, 8>
@@ -430,7 +441,8 @@ firrtl.circuit "Foo" attributes {
       data = "two",
       target = "~Foo|Foo>bar[1].baz"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Foo() {
     %bar = firrtl.wire : !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
@@ -458,7 +470,8 @@ firrtl.circuit "Foo" attributes {
       target = "~Foo|Foo>bar[1].baz",
       data = "two"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Foo(in %clock: !firrtl.clock) {
     %bar = firrtl.reg %clock : !firrtl.clock, !firrtl.vector<bundle<baz: uint<1>, qux: uint<1>>, 2>
@@ -482,7 +495,8 @@ firrtl.circuit "Foo" attributes {
       data = "a",
       target = "~Foo|Foo>w[9]"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Foo() {
     %w = firrtl.wire  : !firrtl.vector<uint<1>, 18>
@@ -510,7 +524,8 @@ firrtl.circuit "Foo" attributes {
       data = "b",
       target = "Foo.Foo.foo"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.extmodule @Bar(in bar: !firrtl.uint<1>)
   firrtl.module @Foo(in %foo: !firrtl.uint<1>) {
@@ -535,7 +550,8 @@ firrtl.circuit "Foo" attributes {
       class = "circt.test",
       target = "~Foo|Foo/Foo:Example"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Example() {}
   firrtl.module @Foo() {
@@ -565,7 +581,8 @@ firrtl.circuit "Foo" attributes {
       data = "b",
       target = "~Foo|Foo/bar:Bar/baz:Baz"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Baz() {}
   firrtl.module @Bar() {
@@ -592,7 +609,8 @@ firrtl.circuit "memportAnno"  attributes {
       class = "circt.test",
       target = "~memportAnno|memportAnno/foo:Foo>memory.w"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @memportAnno() {
     firrtl.instance foo @Foo()
@@ -608,7 +626,7 @@ firrtl.circuit "memportAnno"  attributes {
   }
 }
 
-// CHECK-LABEL: firrtl.circuit "memportAnno"  {
+// CHECK-LABEL: firrtl.circuit "memportAnno"
 // CHECK:        hw.hierpath private @nla [@memportAnno::@[[FOO_SYM:.+]], @Foo]
 // CHECK: firrtl.instance foo sym @[[FOO_SYM]] @Foo
 // CHECK:        %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portAnnotations
@@ -624,7 +642,8 @@ firrtl.circuit "instportAnno" attributes {
       class = "circt.test",
       target = "~instportAnno|instportAnno/bar:Bar>baz.a"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Baz(out %a: !firrtl.uint<1>) {
     %invalid_ui1 = firrtl.invalidvalue : !firrtl.uint<1>
@@ -658,7 +677,8 @@ firrtl.circuit "Aggregates" attributes {
       class = "circt.test",
       target = "~Aggregates|Aggregates>bundle.a.b.c"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Aggregates() {
     // CHECK: {annotations = [{circt.fieldID = 14 : i32, class = "circt.test"}]}
@@ -703,7 +723,8 @@ firrtl.circuit "FooNL"  attributes {
       nl = "nl3",
       target = "~FooNL|FooL>w3"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 }  {
   firrtl.module @BarNL() {
     %w = firrtl.wire  sym @w : !firrtl.uint
@@ -740,7 +761,8 @@ firrtl.circuit "MemPortsNL" attributes {
       nl = "nl",
       target = "~MemPortsNL|MemPortsNL/child:Child>bar.r"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 }  {
   firrtl.module @Child() {
     %bar_r = firrtl.mem Undefined  {depth = 16 : i64, name = "bar", portNames = ["r"], readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<8>>
@@ -759,7 +781,8 @@ firrtl.circuit "Test" attributes {
       class = "circt.test",
       target = "~Test|PortTest>in"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @PortTest(in %in : !firrtl.uint<1>) {}
   firrtl.module @Test() {
@@ -776,7 +799,8 @@ firrtl.circuit "Test" attributes {
       class = "circt.test",
       target = "~Test|PortTest>in.a"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK: firrtl.module @PortTest(in %in: !firrtl.bundle<a: uint<1>> [{circt.fieldID = 1 : i32, class = "circt.test"}])
   firrtl.module @PortTest(in %in : !firrtl.bundle<a: uint<1>>) {}
@@ -793,7 +817,8 @@ firrtl.circuit "Test" attributes {
       class = "circt.test",
       target = "~Test|Test>exttest"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK: hw.hierpath private @nla [@Test::@[[EXTTEST:.+]], @ExtTest]
   // CHECK: firrtl.extmodule @ExtTest() attributes {annotations = [{circt.nonlocal = @nla, class = "circt.test"}]}
@@ -814,7 +839,8 @@ firrtl.circuit "Test" attributes {
       class = "circt.test",
       target = "~Test|Test>exttest.in"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK: hw.hierpath private @nla [@Test::@[[EXTTEST:.+]], @ExtTest]
   // CHECK: firrtl.extmodule @ExtTest(in in: !firrtl.uint<1> [{circt.nonlocal = @nla, class = "circt.test"}])
@@ -841,7 +867,8 @@ firrtl.circuit "Test" attributes {
       convention = "scalarized",
       includeHierarchy = false
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK: attributes {body_type_lowering = #firrtl<convention scalarized>, convention = #firrtl<convention scalarized>}
   firrtl.module @Test() attributes {convention = #firrtl<convention internal>} {}
@@ -862,7 +889,8 @@ firrtl.circuit "Test" attributes {
       convention = "scalarized",
       includeHierarchy = true
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK: @Test() attributes {body_type_lowering = #firrtl<convention scalarized>, convention = #firrtl<convention scalarized>}
   firrtl.module @Test() attributes {convention = #firrtl<convention internal>} {
@@ -895,7 +923,8 @@ firrtl.circuit "Test" attributes {
       target = "~Test|Test>mem",
       prefix = "Prefix_"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @Test() {
     // CHECK: %comb = chirrtl.combmem {prefix = "Prefix_"} : !chirrtl.cmemory<vector<uint<1>, 2>, 256>
@@ -957,7 +986,8 @@ firrtl.circuit "Foo"  attributes {
       class = "firrtl.transforms.DontTouchAnnotation",
       target = "~Foo|Foo/bar:Bar>_T.a"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK:      hw.hierpath private @nla [@Foo::@[[BAR_SYM:.+]], @Bar]
   // CHECK-NEXT: firrtl.module @Foo
@@ -1202,7 +1232,8 @@ firrtl.circuit "GCTInterface"  attributes {
           ]
         }
       }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module private @view_companion() {
     firrtl.skip
@@ -1365,7 +1396,8 @@ firrtl.circuit "GCTDataTap" attributes {
         }
       ]
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.extmodule private @BlackBox(out probe: !firrtl.rwprobe<uint<5>>) attributes {defname = "BlackBox"}
   firrtl.module private @InnerMod() {
@@ -1437,7 +1469,8 @@ firrtl.circuit "GCTMemTap" attributes {
         "~GCTMemTap|GCTMemTap>mem[1]"
       ]
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @GCTMemTap() {
     %mem = chirrtl.combmem  : !chirrtl.cmemory<uint<1>, 2>
@@ -1556,7 +1589,8 @@ firrtl.circuit "GrandCentralViewsBundle"  attributes {
           ]
         }
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK:      firrtl.module @Companion
   // CHECK-SAME:   in %[[port_0:[a-zA-Z0-9_]+]]: !firrtl.uint<1>
@@ -1608,9 +1642,10 @@ firrtl.circuit "Top"  attributes {
         }
       ]
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
-  // CHECK-LABEL: firrtl.circuit "Top"  {
+  // CHECK-LABEL: firrtl.circuit "Top"
   // CHECK-NOT:   "sifive.enterprise.grandcentral.DataTapsAnnotation"
   // CHECK:  firrtl.module private @Bar(out %inv__bore: !firrtl.probe<uint<1>>)
   firrtl.module private @Bar() {
@@ -1655,7 +1690,8 @@ firrtl.circuit "Top"  attributes {
         }
       ]
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.extmodule private @ExtBar()
   // CHECK: firrtl.extmodule private @ExtBar(out random_something_external: !firrtl.probe<uint<1>>)
@@ -1747,7 +1783,8 @@ firrtl.circuit "GrandCentralParentIsNotLCA"  attributes {
           ]
         }
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK:        firrtl.module @Bar
   // CHECK-SAME:     out %[[a_refPort:[a-zA-Z0-9_]+]]: !firrtl.probe<uint<1>>
@@ -1848,7 +1885,8 @@ firrtl.circuit "GrandCentralViewInsideCompanion" attributes {
         ]
       }
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK:      firrtl.module @Companion
   firrtl.module @Companion(out %b: !firrtl.uint<2>) {
@@ -1896,7 +1934,8 @@ firrtl.circuit "TraceNameAnnotation" attributes {
       chiselTarget = "~TraceNameAnnotation|TraceNameAnnotation>w",
       target = "~TraceNameAnnotation|TraceNameAnnotation>w"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   // CHECK:      firrtl.extmodule @Foo()
   // CHECK-SAME:   {chiselTarget = "~TraceNameAnnotation|Foo"
@@ -1932,7 +1971,8 @@ firrtl.circuit "Top"  attributes {
         }
       ]
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module private @Foo() {
     %sum = firrtl.wire : !firrtl.uint
@@ -1962,7 +2002,8 @@ firrtl.circuit "Top"  attributes {
         }
       ]
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.extmodule private @BlackBox() attributes {defname = "BlackBox"}
   // CHECK:  firrtl.extmodule private @BlackBox
@@ -2021,7 +2062,8 @@ firrtl.circuit "MemoryInitializationAnnotations" attributes {
       hexOrBinary = "h",
       target = "~MemoryInitializationAnnotations|MemoryInitializationAnnotations>m6"
     }
-  ]
+  ],
+  version = #firrtl.version<major = 5, minor = 0, patch = 0>
 } {
   firrtl.module @MemoryInitializationAnnotations() {
     // CHECK:      %m1_r = firrtl.mem
@@ -2061,7 +2103,8 @@ firrtl.circuit "Top" attributes {
     {
       class = "sifive.enterprise.firrtl.MarkDUTAnnotation",
       target = "~Top|DUT"
-    }]
+    }],
+    version = #firrtl.version<major = 5, minor = 0, patch = 0>
   } {
   // CHECK-LABEL: firrtl.module
   // CHECK-NOT:     private
@@ -2085,7 +2128,8 @@ firrtl.circuit "Top" attributes {
       class = "circt.OutputDirAnnotation",
       dirname = "foobarbaz",
       target = "~Top|Top"
-    }]
+    }],
+    version = #firrtl.version<major = 5, minor = 0, patch = 0>
   } {
   // CHECK-LABEL: firrtl.module @Top
   // CHECK-SAME:  attributes {output_file = #hw.output_file<"foobarbaz{{/|\\\\}}">}
@@ -2101,7 +2145,8 @@ firrtl.circuit "Top" attributes {
       class = "circt.OutputDirAnnotation",
       dirname = "foobarbaz/",
       target = "~Top|Top"
-    }]
+    }],
+    version = #firrtl.version<major = 5, minor = 0, patch = 0>
   } {
   // CHECK-LABEL: firrtl.module @Top
   // CHECK-SAME:  attributes {output_file = #hw.output_file<"foobarbaz{{/|\\\\}}">}
@@ -2117,7 +2162,8 @@ firrtl.circuit "Top" attributes {
       class = "circt.OutputDirAnnotation",
       dirname = "foobarbaz/qux",
       target = "~Top|Top"
-    }]
+    }],
+    version = #firrtl.version<major = 5, minor = 0, patch = 0>
   } {
   // CHECK-LABEL: firrtl.module @Top
   // CHECK-SAME:  attributes {output_file = #hw.output_file<"foobarbaz{{/|\\\\}}qux{{/|\\\\}}">}
@@ -2132,7 +2178,8 @@ firrtl.circuit "Top" attributes {
     {
       class = "sifive.enterprise.firrtl.FullAsyncResetAnnotation",
       target = "~Top|Top>reset"
-    }]
+    }],
+    version = #firrtl.version<major = 5, minor = 0, patch = 0>
   } {
   // CHECK-LABEL: firrtl.module @Top
   // CHECK-SAME: (in %reset: !firrtl.asyncreset [{class = "circt.FullResetAnnotation", resetType = "async"}])
@@ -2148,7 +2195,8 @@ firrtl.circuit "Top" attributes {
     {
       class = "sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation",
       target = "~Top|Top"
-    }]
+    }],
+    version = #firrtl.version<major = 5, minor = 0, patch = 0>
   } {
   // CHECK-LABEL: firrtl.module @Top
   // CHECK-SAME: (in %reset: !firrtl.asyncreset) attributes {annotations = [{class = "circt.ExcludeFromFullResetAnnotation"}]}

--- a/test/Dialect/FIRRTL/annotations.mlir
+++ b/test/Dialect/FIRRTL/annotations.mlir
@@ -2203,3 +2203,29 @@ firrtl.circuit "Top" attributes {
   // expected-warning @+1 {{'sifive.enterprise.firrtl.IgnoreFullAsyncResetAnnotation' is deprecated, use 'circt.ExcludeFromFullResetAnnotation' instead}}
   firrtl.module @Top(in %reset: !firrtl.asyncreset) {}
 }
+
+// -----
+// FIRRTL version 6 annotation targets parse
+firrtl.circuit "Foo" attributes {
+  rawAnnotations = [
+    {
+      class = "circt.test",
+      target = "Foo",
+      data = "module"
+    },
+    {
+      class = "circt.test",
+      target = "Foo>a",
+      data = "wire"
+    }
+  ],
+  version = #firrtl.version<major = 6, minor = 0, patch = 0>
+} {
+  // CHECK-LABEL: firrtl.module @Foo
+   // CHECK-SAME:   annotations = [{class = "circt.test", data = "module"}]
+  firrtl.module @Foo() {
+    // CHECK:      %a = firrtl.wire
+    // CHECK-SAME:   annotations = [{class = "circt.test", data = "wire"}]
+    %a = firrtl.wire : !firrtl.uint<1>
+  }
+}

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -887,7 +887,7 @@ FIRRTL version 3.0.0
 circuit UnsupportedStringEncodedIntegerLiterals:
   module UnsupportedStringEncodedIntegerLiterals:
     output foo: UInt<8>
-    ; expected-error @below {{String-encoded integer literals are unsupported after FIRRTL 3.0.0}}
+    ; expected-error @below {{String-encoded integer literals were removed in FIRRTL 3.0.0, but the specified FIRRTL version was 3.0.0}}
     connect foo, UInt("h2a")
 
 ;// -----


### PR DESCRIPTION
This adds a new `VersionAttr` which is made an optional attribute on FIRRTL circuits.  This is used to determine which version of the annotation format should be used in the `LowerAnnotations` pass.  This can additionally be used in the future if we ever get into a hard situation where we need to support a legacy behavior in the FIRRTL spec as opposed to just syntax differences or new features.

See individual commits for more information.