### PR TITLE
[RTG][Elaboration] Improve how tests are matched with targets

### DIFF
--- a/frontends/PyRTG/src/pyrtg/tests.py
+++ b/frontends/PyRTG/src/pyrtg/tests.py
@@ -24,7 +24,7 @@ class Test(CodeGenRoot):
 
   def _codegen(self):
     test = rtg.TestOp(
-        self.name,
+        self.name, self.name,
         ir.TypeAttr.get(
             rtg.DictType.get([
                 (ir.StringAttr.get(name), ty)

--- a/frontends/PyRTG/test/basic.mlir
+++ b/frontends/PyRTG/test/basic.mlir
@@ -30,3 +30,5 @@ rtg.test @test0() {
   %1 = rtg.randomize_sequence %0
   rtg.embed_sequence %1
 }
+
+rtg.target @singleton : !rtg.dict<> {}

--- a/frontends/PyRTG/test/basic.py
+++ b/frontends/PyRTG/test/basic.py
@@ -4,6 +4,15 @@
 
 from pyrtg import test, sequence, target, entry, rtg, Label, Set, Integer, Bag, rtgtest, Immediate, IntegerRegister, Array, Bool, Tuple, embed_comment, MemoryBlock, Memory
 
+# MLIR-LABEL: rtg.target @Singleton : !rtg.dict<>
+# MLIR-NEXT: }
+
+
+@target
+class Singleton:
+  pass
+
+
 # MLIR-LABEL: rtg.target @Tgt0 : !rtg.dict<entry0: !rtg.set<index>>
 # MLIR-NEXT: [[C0:%.+]] = index.constant 0
 # MLIR-NEXT: [[C1:%.+]] = index.constant 1

--- a/include/circt/Dialect/RTG/IR/RTGOps.td
+++ b/include/circt/Dialect/RTG/IR/RTGOps.td
@@ -697,7 +697,8 @@ def TestOp : RTGOp<"test", [
   SingleBlock,
   NoTerminator,
   DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmBlockArgumentNames"]>,
-  HasParent<"mlir::ModuleOp">
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  HasParent<"mlir::ModuleOp">,
 ]> {
   let summary = "the root of a test";
   let description = [{
@@ -711,8 +712,15 @@ def TestOp : RTGOp<"test", [
     with that target.
 
     By default each test can be matched with all targets that fulfill its
-    requirements, but the user should be able to specify more constraints on the
-    matching procedure.
+    requirements, but the user can also directly provide a target via the
+    'target' attribute. In that case, the test will only be randomized against
+    that target.
+
+    The 'templateName' attribute specifies the name of the original test
+    template (mostly for result reporting purposes). This is because a test
+    (template) can be matched against many targets and during this process one
+    test per match is created, but all of them preserve the same test template
+    name.
 
     The body of this operation shall be processed the same way as an
     `rtg.sequence`'s body with the exception of the block arguments.
@@ -721,12 +729,13 @@ def TestOp : RTGOp<"test", [
     referenced by an `rtg.get_sequence` operation.
   }];
 
-  let arguments = (ins SymbolNameAttr:$sym_name,
-                       TypeAttrOf<DictType>:$target);
+  let arguments = (ins SymbolNameAttr:$sym_name, StrAttr:$templateName,
+      TypeAttrOf<DictType>:$targetType, OptionalAttr<SymbolNameAttr>:$target);
   let regions = (region SizedRegion<1>:$bodyRegion);
 
   let hasCustomAssemblyFormat = 1;
   let hasRegionVerifier = 1;
+  let hasVerifier = 1;
 }
 
 def TargetOp : RTGOp<"target", [

--- a/include/circt/Dialect/RTG/Transforms/RTGPasses.td
+++ b/include/circt/Dialect/RTG/Transforms/RTGPasses.td
@@ -24,9 +24,12 @@ def ElaborationPass : Pass<"rtg-elaborate", "mlir::ModuleOp"> {
     anymore.
   }];
 
-  let options = [
-    Option<"seed", "seed", "unsigned", /*default=*/"",
-      "The seed for any RNG constructs used in the pass.">,
+  let options = [Option<"seed", "seed", "unsigned", /*default=*/"",
+                        "The seed for any RNG constructs used in the pass.">,
+                 Option<
+                     "deleteUnmatchedTests", "delete-unmatched-tests", "bool",
+                     /*default=*/"true",
+                     "Delete tests that could not be matched with a target.">,
   ];
 
   let dependentDialects = ["mlir::index::IndexDialect"];

--- a/integration_test/Bindings/Python/rtg_pipeline.py
+++ b/integration_test/Bindings/Python/rtg_pipeline.py
@@ -1,5 +1,5 @@
 # REQUIRES: bindings_python
-# RUN: %PYTHON% %s %T && FileCheck %s --input-file=%T/test0.s --check-prefix=TEST0 && FileCheck %s --input-file=%T/test1.s --check-prefix=TEST1
+# RUN: %PYTHON% %s %T && FileCheck %s --input-file=%T/test0_target.s --check-prefix=TEST0 && FileCheck %s --input-file=%T/test1_target.s --check-prefix=TEST1
 
 import sys
 import circt
@@ -15,15 +15,20 @@ with Context() as ctx, Location.unknown():
   circt.register_dialects(ctx)
   m = Module.create()
   with InsertionPoint(m.body):
-    test = rtg.TestOp('test0', TypeAttr.get(rtg.DictType.get()))
+    test = rtg.TestOp('test0', 'test0', TypeAttr.get(rtg.DictType.get()))
     block = Block.create_at_start(test.bodyRegion, [])
     with InsertionPoint(block):
       rtgtest.rv32i_ebreak()
 
-    test = rtg.TestOp('test1', TypeAttr.get(rtg.DictType.get()))
+    test = rtg.TestOp('test1', 'test1', TypeAttr.get(rtg.DictType.get()))
     block = Block.create_at_start(test.bodyRegion, [])
     with InsertionPoint(block):
       rtgtest.rv32i_ecall()
+
+    target = rtg.TargetOp('target', TypeAttr.get(rtg.DictType.get()))
+    block = Block.create_at_start(target.bodyRegion, [])
+    with InsertionPoint(block):
+      rtg.YieldOp([])
 
   pm = PassManager()
   options = rtgtool.Options(seed=0,

--- a/test/CAPI/rtg-pipelines.c
+++ b/test/CAPI/rtg-pipelines.c
@@ -23,6 +23,9 @@ int main(int argc, char **argv) {
                "}\n"
                "rtg.test @test() {\n"
                "  %0 = rtg.get_sequence @seq : !rtg.sequence\n"
+               "}\n"
+               "rtg.target @target : !rtg.dict<> {\n"
+               "  rtg.yield\n"
                "}\n"));
   if (mlirModuleIsNull(moduleOp)) {
     printf("ERROR: Could not parse.\n");

--- a/test/Dialect/RTG/IR/basic.mlir
+++ b/test/Dialect/RTG/IR/basic.mlir
@@ -211,3 +211,6 @@ rtg.target @memoryBlocks : !rtg.dict<mem_base_address: !rtg.isa.immediate<32>, m
   
   rtg.yield %2, %0, %3 : !rtg.isa.immediate<32>, !rtg.isa.memory_block<32>, index
 }
+
+// CHECK-LABEL: rtg.test @template() template "temp_name" target @target {
+rtg.test @template() template "temp_name" target @target { }

--- a/test/Dialect/RTG/IR/errors.mlir
+++ b/test/Dialect/RTG/IR/errors.mlir
@@ -96,7 +96,42 @@ rtg.target @target : !rtg.dict<a: i32> {
 // -----
 
 // expected-error @below {{argument types must match dict entry types}}
-"rtg.test"() <{sym_name="test", target=!rtg.dict<a: i32>}> ({^bb0(%b: i8):}) : () -> ()
+"rtg.test"() <{sym_name="test", templateName="test", targetType=!rtg.dict<a: i32>}> ({^bb0(%b: i8):}) : () -> ()
+
+// -----
+
+// expected-error @below {{template name must not be empty}}
+"rtg.test"() <{sym_name="test", templateName="", targetType=!rtg.dict<>}> ({^bb0:}) : () -> ()
+
+// -----
+
+// expected-error @below {{'target' does not reference a valid 'rtg.target' operation}}
+rtg.test @test(a = %a: i32) target @target {
+}
+
+// -----
+
+rtg.target @target : !rtg.dict<> { }
+
+// expected-error @below {{referenced 'rtg.target' op's type is invalid: missing entry called 'a' of type 'i32'}}
+rtg.test @test(a = %a: i32) target @target {
+}
+
+// -----
+
+rtg.target @target : !rtg.dict<a: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
+// expected-error @below {{referenced 'rtg.target' op's type is invalid: missing entry called 'a' of type 'i32'}}
+rtg.test @test(a = %a: i32) target @target {
+}
+
+// -----
+
+// expected-error @below {{template name must not be empty}}
+rtg.test @test() template "" {}
 
 // -----
 

--- a/test/Dialect/RTG/Transform/elaboration.mlir
+++ b/test/Dialect/RTG/Transform/elaboration.mlir
@@ -12,9 +12,15 @@ func.func @dummy9(%arg0: !rtg.set<tuple<index, i1, !rtgtest.ireg>>) -> () {retur
 func.func @dummy10(%arg0: !rtg.set<tuple<index>>) -> () {return}
 func.func @dummy11(%arg0: !rtg.set<index>) -> () {return}
 func.func @dummy12(%arg0: !rtg.bag<index>) -> () {return}
+func.func @dummy13(%arg0: !rtg.isa.memory_block<32>) -> () {return}
+
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
 
 // CHECK-LABEL: @immediates
-rtg.test @immediates() {
+rtg.test @immediates(singleton = %none: index) {
   // CHECK-NEXT: [[V0:%.+]] = rtg.constant #rtg.isa.immediate<2, -1>
   // CHECK-NEXT: func.call @dummy6([[V0]]) : (!rtg.isa.immediate<2>) -> ()
   %0 = rtg.constant #rtg.isa.immediate<2, -1>
@@ -29,7 +35,7 @@ rtg.test @immediates() {
 
 // Test the set operations and passing a sequence to another one via argument
 // CHECK-LABEL: rtg.test @setOperations
-rtg.test @setOperations() {
+rtg.test @setOperations(singleton = %none: index) {
   // CHECK-NEXT: [[V0:%.+]] = index.constant 2
   // CHECK-NEXT: [[V1:%.+]] = index.constant 3
   // CHECK-NEXT: [[V2:%.+]] = index.constant 4
@@ -56,7 +62,7 @@ rtg.test @setOperations() {
 }
 
 // CHECK-LABEL: rtg.test @setCartesianProduct
-rtg.test @setCartesianProduct() {
+rtg.test @setCartesianProduct(singleton = %none: index) {
   %idx0 = index.constant 0
   %idx1 = index.constant 1
   %0 = rtg.set_create %idx0, %idx1 : index
@@ -101,7 +107,7 @@ rtg.test @setCartesianProduct() {
 }
 
 // CHECK-LABEL: rtg.test @bagOperations
-rtg.test @bagOperations() {
+rtg.test @bagOperations(singleton = %none: index) {
   // CHECK-NEXT: [[V0:%.+]] = index.constant 2
   // CHECK-NEXT: [[V1:%.+]] = index.constant 8
   // CHECK-NEXT: [[V2:%.+]] = index.constant 3
@@ -132,7 +138,7 @@ rtg.test @bagOperations() {
 }
 
 // CHECK-LABEL: rtg.test @setSize
-rtg.test @setSize() {
+rtg.test @setSize(singleton = %none: index) {
   // CHECK-NEXT: [[C:%.+]] = index.constant 1
   // CHECK-NEXT: func.call @dummy2([[C]])
   // CHECK-NEXT: }
@@ -143,7 +149,7 @@ rtg.test @setSize() {
 }
 
 // CHECK-LABEL: rtg.test @bagSize
-rtg.test @bagSize() {
+rtg.test @bagSize(singleton = %none: index) {
   // CHECK-NEXT: [[C:%.+]] = index.constant 1
   // CHECK-NEXT: func.call @dummy2([[C]])
   // CHECK-NEXT: }
@@ -185,7 +191,7 @@ rtg.sequence @seq0(%arg0: index) {
 }
 
 // CHECK-LABEL: rtg.test @sequenceSubstitution
-rtg.test @sequenceSubstitution() {
+rtg.test @sequenceSubstitution(singleton = %none: index) {
   // CHECK-NEXT: [[V0:%.+]] = rtg.get_sequence @seq0{{.*}} : !rtg.sequence{{$}}
   // CHECK-NEXT: [[V1:%.+]] = rtg.randomize_sequence [[V0]]
   // CHECK-NEXT: rtg.embed_sequence [[V1]]
@@ -197,7 +203,7 @@ rtg.test @sequenceSubstitution() {
 }
 
 // CHECK-LABEL: rtg.test @sameSequenceDifferentArgs
-rtg.test @sameSequenceDifferentArgs() {
+rtg.test @sameSequenceDifferentArgs(singleton = %none: index) {
   // CHECK-NEXT: [[V0:%.*]] = rtg.get_sequence @seq0_1 : !rtg.sequence
   // CHECK-NEXT: [[V1:%.*]] = rtg.randomize_sequence [[V0]]
   // CHECK-NEXT: rtg.embed_sequence [[V1]]
@@ -217,7 +223,7 @@ rtg.test @sameSequenceDifferentArgs() {
 }
 
 // CHECK-LABEL: rtg.test @sequenceClosureFixesRandomization
-rtg.test @sequenceClosureFixesRandomization() {
+rtg.test @sequenceClosureFixesRandomization(singleton = %none: index) {
   // CHECK-NEXT: [[V0:%.+]] = rtg.get_sequence @seq3_0 : !rtg.sequence
   // CHECK-NEXT: [[V1:%.+]] = rtg.randomize_sequence [[V0]]
   // CHECK-NEXT: rtg.embed_sequence [[V1]]
@@ -254,7 +260,7 @@ rtg.sequence @seq3(%arg0: !rtg.set<index>) {
 }
 
 // CHECK-LABEL: @indexOps
-rtg.test @indexOps() {
+rtg.test @indexOps(singleton = %none: index) {
   // CHECK: [[C:%.+]] = index.constant 2
   %0 = index.constant 1
 
@@ -294,7 +300,7 @@ rtg.test @indexOps() {
 }
 
 // CHECK-LABEL: @scfIf
-rtg.test @scfIf() {
+rtg.test @scfIf(singleton = %none: index) {
   %0 = index.bool.constant true
   %1 = index.bool.constant false
 
@@ -338,7 +344,7 @@ rtg.test @scfIf() {
 }
 
 // CHECK-LABEL: @scfFor
-rtg.test @scfFor() {
+rtg.test @scfFor(singleton = %none: index) {
   // CHECK-NEXT: [[C0:%.+]] = index.constant 0
   // CHECK-NEXT: func.call @dummy2([[C0]])
   // CHECK-NEXT: [[C1:%.+]] = index.constant 1
@@ -378,7 +384,7 @@ rtg.test @scfFor() {
 }
 
 // CHECK-LABEL: @fixedRegisters
-rtg.test @fixedRegisters() {
+rtg.test @fixedRegisters(singleton = %none: index) {
   // CHECK-NEXT: [[RA:%.+]] = rtg.fixed_reg #rtgtest.ra
   // CHECK-NEXT: [[SP:%.+]] = rtg.fixed_reg #rtgtest.sp
   // CHECK-NEXT: [[IMM:%.+]] = rtg.constant #rtg.isa.immediate<12, 0>
@@ -390,7 +396,7 @@ rtg.test @fixedRegisters() {
 }
 
 // CHECK-LABEL: @virtualRegisters
-rtg.test @virtualRegisters() {
+rtg.test @virtualRegisters(singleton = %none: index) {
   // CHECK-NEXT: [[R0:%.+]] = rtg.virtual_reg [#rtgtest.a0 : !rtgtest.ireg, #rtgtest.a1 : !rtgtest.ireg]
   // CHECK-NEXT: [[R1:%.+]] = rtg.virtual_reg [#rtgtest.s0 : !rtgtest.ireg, #rtgtest.s1 : !rtgtest.ireg]
   // CHECK-NEXT: [[IMM:%.+]] = rtg.constant #rtg.isa.immediate<12, 0>
@@ -419,7 +425,7 @@ rtg.test @virtualRegisters() {
 // CHECK: rtgtest.rv32i.jalr %arg0, %arg0
 // CHECK: rtgtest.rv32i.jalr %arg1, %arg2
 
-// CHECK-LABEL:  rtg.test @valuesWithIdentity() {
+// CHECK-LABEL:  rtg.test @valuesWithIdentity
 // CHECK: [[VREG0:%.+]] = rtg.virtual_reg [#rtgtest.a0 : !rtgtest.ireg, #rtgtest.a1 : !rtgtest.ireg]
 // CHECK: [[VREG1:%.+]] = rtg.virtual_reg [#rtgtest.a0 : !rtgtest.ireg, #rtgtest.a1 : !rtgtest.ireg]
 // CHECK: rtgtest.rv32i.jalr [[VREG0]], [[VREG1]]
@@ -434,7 +440,7 @@ rtg.sequence @valuesWithIdentitySeq(%imm: !rtg.isa.immediate<12>, %reg: !rtgtest
   rtgtest.rv32i.jalr %r0, %r1, %imm
 }
 
-rtg.test @valuesWithIdentity() {
+rtg.test @valuesWithIdentity(singleton = %none: index) {
   %r0 = rtg.virtual_reg [#rtgtest.a0, #rtgtest.a1]
   %r1 = rtg.virtual_reg [#rtgtest.a0, #rtgtest.a1]
   %r2 = rtg.virtual_reg [#rtgtest.a0, #rtgtest.a1]
@@ -450,7 +456,7 @@ rtg.test @valuesWithIdentity() {
 }
 
 // CHECK-LABEL: @labels
-rtg.test @labels() {
+rtg.test @labels(singleton = %none: index) {
   // CHECK-NEXT: [[L0:%.+]] = rtg.label_unique_decl "label0"
   // CHECK-NEXT: rtg.label local [[L0]]
   // CHECK-NEXT: [[L1:%.+]] = rtg.label_decl "label0"
@@ -468,7 +474,7 @@ rtg.test @labels() {
 }
 
 // CHECK-LABEL: rtg.test @randomIntegers
-rtg.test @randomIntegers() {
+rtg.test @randomIntegers(singleton = %none: index) {
   %lower = index.constant 5
   %upper = index.constant 10
   %0 = rtg.random_number_in_range [%lower, %upper) {rtg.elaboration_custom_seed=0}
@@ -602,8 +608,8 @@ rtg.sequence @interleaveSequencesSeq1() {
   rtgtest.rv32i.ecall
 }
 
-// CHECK-LABEL: @interleaveSequences()
-rtg.test @interleaveSequences() {
+// CHECK-LABEL: rtg.test @interleaveSequences
+rtg.test @interleaveSequences(singleton = %none: index) {
   // CHECK-NEXT: [[V0:%.+]] = rtg.get_sequence @interleaveSequencesSeq0_0 : !rtg.sequence
   // CHECK-NEXT: [[V2:%.+]] = rtg.randomize_sequence [[V0]]
   // CHECK-NEXT: [[V1:%.+]] = rtg.get_sequence @interleaveSequencesSeq1_0 : !rtg.sequence
@@ -623,7 +629,7 @@ rtg.test @interleaveSequences() {
 }
 
 // CHECK-LABEL: rtg.test @arrays
-rtg.test @arrays() {
+rtg.test @arrays(singleton = %none: index) {
   // CHECK-NEXT: [[V0:%.+]] = rtg.array_create : index
   // CHECK-NEXT: func.call @dummy7([[V0]]) : (!rtg.array<index>) -> ()
   %0 = rtg.array_create : index
@@ -648,7 +654,7 @@ rtg.test @arrays() {
 }
 
 // CHECK-LABEL: rtg.test @arithOps
-rtg.test @arithOps() {
+rtg.test @arithOps(singleton = %none: index) {
   // CHECK-NEXT: [[V0:%.+]] = index.constant 6
   // CHECK-NEXT: func.call @dummy2([[V0]])
 
@@ -663,7 +669,7 @@ rtg.test @arithOps() {
 }
 
 // CHECK-LABEL: rtg.test @tuples
-rtg.test @tuples() {
+rtg.test @tuples(singleton = %none: index) {
   %idx0 = index.constant 0
   %idx1 = index.constant 1
   %0 = rtg.tuple_create %idx1, %idx0 : index, index
@@ -700,28 +706,55 @@ rtg.target @memoryBlocks : !rtg.dict<mem_block: !rtg.isa.memory_block<32>> {
 
 // CHECK-LABEL: @memoryBlockTest_memoryBlocks
 rtg.test @memoryBlockTest(mem_block = %arg0: !rtg.isa.memory_block<32>) {
+  func.call @dummy13(%arg0) : (!rtg.isa.memory_block<32>) -> ()
+  // CHECK-NEXT: func.call @dummy13(%mem_block)
   // CHECK-NEXT: }
+}
+
+rtg.target @subtypeTarget : !rtg.dict<a: index, b: index> {
+  %0 = index.constant 0
+  rtg.yield %0, %0 : index, index 
+}
+
+// CHECK: rtg.test @subtypeMatching_subtypeTarget(
+rtg.test @subtypeMatching(b = %b: index) {
+  func.call @dummy2(%b) : (index) -> ()
 }
 
 // -----
 
-rtg.test @nestedRegionsNotSupported() {
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
+rtg.test @nestedRegionsNotSupported(singleton = %none: index) {
   // expected-error @below {{ops with nested regions must be elaborated away}}
   scf.execute_region { scf.yield }
 }
 
 // -----
 
-rtg.test @untypedAttributes() {
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
+rtg.test @untypedAttributes(singleton = %none: index) {
   // expected-error @below {{only typed attributes supported for constant-like operations}}
   %0 = rtgtest.constant_test index {value = [10 : index]}
 }
 
 // -----
 
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
 func.func @dummy(%arg0: index) {return}
 
-rtg.test @untypedAttributes() {
+rtg.test @untypedAttributes(singleton = %none: index) {
   %0 = rtgtest.constant_test index {value = "str"}
   // expected-error @below {{materializer of dialect 'builtin' unable to materialize value for attribute '"str"'}}
   // expected-note @below {{while materializing value for operand#0}}
@@ -730,9 +763,14 @@ rtg.test @untypedAttributes() {
 
 // -----
 
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
 func.func @dummy2(%arg0: index) -> () {return}
 
-rtg.test @randomIntegers() {
+rtg.test @randomIntegers(singleton = %none: index) {
   %c5 = index.constant 5
   // expected-error @below {{cannot select a number from an empty range}}
   %0 = rtg.random_number_in_range [%c5, %c5)
@@ -783,7 +821,12 @@ rtg.test @contextSwitchNotAvailable(cpu = %cpu: !rtgtest.cpu) {
 
 // -----
 
-rtg.test @emptySetSelect() {
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
+rtg.test @emptySetSelect(singleton = %none: index) {
   %0 = rtg.set_create : !rtg.isa.label
   // expected-error @below {{cannot select from an empty set}}
   %1 = rtg.set_select_random %0 : !rtg.set<!rtg.isa.label>
@@ -792,7 +835,12 @@ rtg.test @emptySetSelect() {
 
 // -----
 
-rtg.test @emptyBagSelect() {
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
+rtg.test @emptyBagSelect(singleton = %none: index) {
   %0 = rtg.bag_create : !rtg.isa.label
   // expected-error @below {{cannot select from an empty bag}}
   %1 = rtg.bag_select_random %0 : !rtg.bag<!rtg.isa.label>
@@ -801,9 +849,14 @@ rtg.test @emptyBagSelect() {
 
 // -----
 
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
 func.func @dummy6(%arg0: !rtg.isa.immediate<2>) -> () {return}
 
-rtg.test @integerTooBig() {
+rtg.test @integerTooBig(singleton = %none: index) {
   %1 = index.constant 8
   // expected-error @below {{cannot represent 8 with 2 bits}}
   %2 = rtg.isa.int_to_immediate %1 : !rtg.isa.immediate<2>
@@ -812,9 +865,14 @@ rtg.test @integerTooBig() {
 
 // -----
 
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
 func.func @dummy6(%arg0: index) -> () {return}
 
-rtg.test @oobArrayAccess() {
+rtg.test @oobArrayAccess(singleton = %none: index) {
   %0 = index.constant 0
   %1 = rtg.array_create : index
   // expected-error @below {{invalid to access index 0 of an array with 0 elements}}
@@ -824,9 +882,14 @@ rtg.test @oobArrayAccess() {
 
 // -----
 
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
 func.func @dummy6(%arg0: !rtg.array<index>) -> () {return}
 
-rtg.test @oobArrayAccess() {
+rtg.test @oobArrayAccess(singleton = %none: index) {
   %0 = index.constant 0
   %1 = rtg.array_create : index
   // expected-error @below {{invalid to access index 0 of an array with 0 elements}}
@@ -836,7 +899,12 @@ rtg.test @oobArrayAccess() {
 
 // -----
 
-rtg.test @arith_invalid_type() {
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
+rtg.test @arith_invalid_type(singleton = %none: index) {
   %0 = arith.constant 3 : i32
   // expected-error @below {{only index operands supported}}
   %1 = arith.addi %0, %0 : i32
@@ -844,7 +912,12 @@ rtg.test @arith_invalid_type() {
 
 // -----
 
-rtg.test @arith_invalid_type() {
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
+rtg.test @arith_invalid_type(singleton = %none: index) {
   %0 = arith.constant 3 : i32
   // expected-error @below {{only 'i1' operands supported}}
   %1 = arith.andi %0, %0 : i32
@@ -852,7 +925,12 @@ rtg.test @arith_invalid_type() {
 
 // -----
 
-rtg.test @arith_invalid_type() {
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
+rtg.test @arith_invalid_type(singleton = %none: index) {
   %0 = arith.constant 3 : i32
   // expected-error @below {{only 'i1' operands supported}}
   %1 = arith.xori %0, %0 : i32
@@ -860,7 +938,12 @@ rtg.test @arith_invalid_type() {
 
 // -----
 
-rtg.test @arith_invalid_type() {
+rtg.target @singletonTarget : !rtg.dict<singleton: index> {
+  %0 = index.constant 0
+  rtg.yield %0 : index
+}
+
+rtg.test @arith_invalid_type(singleton = %none: index) {
   %0 = arith.constant 3 : i32
   // expected-error @below {{only 'i1' operands supported}}
   %1 = arith.ori %0, %0 : i32


### PR DESCRIPTION
* Tests can now carry a string identifying the original test name because a test can be cloned to test multiple targets. This is useful for result reporting
* Tests can now specify a fixed target. Before elaboration it acts as a restriction to only be elaborated against that target, after elaboration it specifies for which target the test was elaborated.
* The body of a target is not copied into the tests anymore. This allows us to materialize operations that are only legal in targets and keep them until later in the pipeline.
* The test <-> target matching now supports a kind of 'subtyping'
* Remove the special casing for tests without requirements.