### PR TITLE
[ImportVerilog] Convert the unpacked array to a simple bit vector

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1272,6 +1272,14 @@ Value Context::convertToSimpleBitVector(Value value) {
                                                  value);
     }
   }
+  if (auto unpacked = dyn_cast<moore::UnpackedType>(value.getType())) {
+    if (auto bits = unpacked.getBitSize()) {
+      auto sbvType =
+          moore::IntType::get(value.getContext(), *bits, unpacked.getDomain());
+      return builder.create<moore::ConversionOp>(value.getLoc(), sbvType,
+                                                 value);
+    }
+  }
 
   mlir::emitError(value.getLoc()) << "expression of type " << value.getType()
                                   << " cannot be cast to a simple bit vector";

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -709,6 +709,10 @@ module Expressions;
   bit [1:0][31:0] arrayInt;
   // CHECK: %uarrayInt = moore.variable : <uarray<2 x i32>>
   bit [31:0] uarrayInt [2];
+  // CHECK: %arr1 = moore.variable : <uarray<2 x i32>
+  bit [31:0] arr1 [2];
+  // CHECK: %arr2 = moore.variable : <uarray<2 x i32>
+  bit [31:0] arr2 [2];
   // CHECK: %m = moore.variable : <l4>
   logic [3:0] m;
 
@@ -1119,6 +1123,22 @@ module Expressions;
     // CHECK: [[TMP2:%.+]] = moore.read %e
     // CHECK: moore.eq [[TMP1]], [[TMP2]] : l32 -> l1
     y = d == e;
+
+    // CHECK: [[TMP0:%.+]] = moore.constant 43
+    // CHECK: [[TMP1:%.+]] = moore.constant 9002
+    // CHECK: moore.array_create [[TMP0]], [[TMP1]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
+    arr1 = '{43, 9002};
+    // CHECK: [[TMP0:%.+]] = moore.constant 43
+    // CHECK: [[TMP1:%.+]] = moore.constant 9002
+    // CHECK: moore.array_create [[TMP0]], [[TMP1]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
+    arr2 = '{43, 9002};
+    // CHECK: [[TMP1:%.+]] = moore.read %arr1  : <uarray<2 x i32>>
+    // CHECK: [[TMP2:%.+]] = moore.read %arr2  : <uarray<2 x i32>>
+    // CHECK: [[TMP3:%.+]] = moore.conversion [[TMP1:%.+]] : !moore.uarray<2 x i32> -> !moore.i64
+    // CHECK: [[TMP4:%.+]] = moore.conversion [[TMP2:%.+]] : !moore.uarray<2 x i32> -> !moore.i64
+    // CHECK: [[TMP4:%.+]] = moore.eq [[TMP3:%.+]], [[TMP4:%.+]] : i64 -> i1
+    x = arr1 == arr2;
+
     // CHECK: [[TMP1:%.+]] = moore.read %a
     // CHECK: [[TMP2:%.+]] = moore.read %b
     // CHECK: moore.ne [[TMP1]], [[TMP2]] : i32 -> i1


### PR DESCRIPTION
With these changes, ImportVerilog can now convert unpacked arrays to simple bit vectors and pass this [test](https://chipsalliance.github.io/sv-tests-results/?v=circt_verilog+7.4.3+operations-on-unpacked-arrays-equality).