### PR TITLE
[HWMemSimImpl] Avoid generation of 0 bit Value

### DIFF
--- a/test/Dialect/Seq/hw-memsim.mlir
+++ b/test/Dialect/Seq/hw-memsim.mlir
@@ -472,3 +472,16 @@ hw.module.generated @TestFragment, @FIRRTLMem(
 
 // CHECK-LABEL: hw.module private @TestFragment
 // CHECK-SAME:    emit.fragments = [@Fragment]
+
+// Test an i1 memory.
+ hw.module.generated @ram_2x1, @FIRRTLMem(in %R0_addr : i1, in %R0_en : i1, in %R0_clk : i1, out R0_data : i1, in %W0_addr : i1, in %W0_en : i1, in %W0_clk : i1, in %W0_data : i1) attributes {depth = 2 : i64, emit.fragments = [@RANDOM_INIT_REG_FRAGMENT, @RANDOM_INIT_MEM_FRAGMENT, @RANDOM_INIT_FRAGMENT], initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 1 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
+
+// CHECK-LABEL: hw.module private @ram_2x1
+// CHECK:        %[[c0_i6:.+]] = hw.constant 0 : i6
+// CHECK-NEXT:   %[[c_32_i6:.+]] = hw.constant -32 : i6
+// CHECK-NEXT:   %[[c_32_i6_0:.+]] = hw.constant -32 : i6
+// CHECK-NEXT:   sv.for %[[J:.+]] = %[[c0_i6]] to %[[c_32_i6]] step %[[c_32_i6_0]] : i6 {
+// CHECK-NEXT:     %[[RANDOM:.+]] = sv.macro.ref.expr.se @RANDOM() : () -> i32
+// CHECK-NEXT:     %false = hw.constant false
+// CHECK-NEXT:     %[[V7:.+]] = sv.indexed_part_select_inout %_RANDOM_MEM[%false : 32] : !hw.inout<i32>, i1
+// CHECK-NEXT:     sv.bpassign %[[V7]], %RANDOM : i32


### PR DESCRIPTION
`HWMemSimImpl` generates a zero bit result from `comb.extract` when the memory data is 1 bit width.
For example,
```
hw.module.generated @ram_2x1, @FIRRTLMem(in %R0_addr : i1, in %R0_en : i1, in %R0_clk : i1, out R0_data : i1, in %W0_addr : i1, in %W0_en : i1, in %W0_clk : i1, in %W0_data : i1) attributes {depth = 2 : i64, emit.fragments = [@RANDOM_INIT_REG_FRAGMENT, @RANDOM_INIT_MEM_FRAGMENT, @RANDOM_INIT_FRAGMENT], initFilename = "", initIsBinary = false, initIsInline = false, maskGran = 1 : ui32, numReadPorts = 1 : ui32, numReadWritePorts = 0 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 1 : ui32, writeClockIDs = [0 : i32], writeLatency = 1 : ui32, writeUnderWrite = 1 : i32}
```
generates the following extract  of i0
```
           sv.for %j = %c0_i6 to %c-32_i6 step %c-32_i6_0 : i6 {
              %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
              %7 = comb.extract %j from 0 : (i6) -> i0
              %8 = sv.indexed_part_select_inout %_RANDOM_MEM[%7 : 32] : !hw.inout<i32>, i0
              sv.bpassign %8, %RANDOM : i32
            }
```

This is a simple fix that creates a `c0_ui1` instead of the `comb.extract`.
Related to: https://github.com/llvm/circt/pull/8351
