### PR TITLE
[RTG] Add MemoryAllocation pass

### DIFF
--- a/include/circt/Dialect/RTG/IR/RTGTypes.td
+++ b/include/circt/Dialect/RTG/IR/RTGTypes.td
@@ -213,4 +213,6 @@ def MemoryBlockType : RTGISATypeDef<"MemoryBlock", "memory_block"> {
   let assemblyFormat = "`<` $addressWidth `>`";
 }
 
+def ISAMemory : AnyTypeOf<[MemoryType, ImmediateType, LabelType]>;
+
 #endif // CIRCT_DIALECT_RTG_IR_RTGTYPES_TD

--- a/include/circt/Dialect/RTG/Transforms/RTGPasses.td
+++ b/include/circt/Dialect/RTG/Transforms/RTGPasses.td
@@ -114,4 +114,24 @@ def LowerUniqueLabelsPass : Pass<"rtg-lower-unique-labels", "mlir::ModuleOp"> {
   ];
 }
 
+def MemoryAllocationPass : Pass<"rtg-memory-allocation", "rtg::TestOp"> {
+  let summary = "lower memories to immediates or labels";
+  let description = [{
+    This pass lowers 'memory_alloc' and other memory handling operations to
+    immediates or labels by computing offsets within memory blocks according to
+    the memory allocation's size and alignments.
+  }];
+
+  let options = [
+    Option<"useImmediates", "use-immediates", "bool", /*default=*/"true", [{
+        Whether the pass should lower memories to immediates instead of labels.
+      }]>,
+  ];
+
+  let statistics = [
+    Statistic<"numMemoriesAllocated", "num-memories-allocated",
+              "Number of memories allocated from memory blocks.">,
+  ];
+}
+
 #endif // CIRCT_DIALECT_RTG_TRANSFORMS_RTGPASSES_TD

--- a/include/circt/Dialect/RTGTest/IR/RTGTestOps.td
+++ b/include/circt/Dialect/RTGTest/IR/RTGTestOps.td
@@ -435,6 +435,35 @@ class InstFormatShiftOpBase<string mnemonic, int opcode7,
 
 //===- Instructions -------------------------------------------------------===//
 
+def RV32I_LA : RTGTestOp<"rv32i.la", [InstructionOpAdaptor]> {
+
+  let arguments = (ins IntegerRegisterType:$rd, ISAMemory:$mem);
+
+  let assemblyFormat = "$rd `,` $mem `:` type($mem) attr-dict";
+
+  let extraClassDefinition = [{
+    void $cppClass::printInstructionBinary(llvm::raw_ostream &os,
+                                           FoldAdaptor adaptor) {
+      assert(false && "binary not supported");
+    }
+
+    void $cppClass::printInstructionAssembly(llvm::raw_ostream &os,
+                                             FoldAdaptor adaptor) {
+      os << getOperationName().rsplit('.').second << " "
+         << cast<rtg::RegisterAttrInterface>(adaptor.getRd())
+              .getRegisterAssembly()
+         << ", ";
+
+      if (auto label = dyn_cast<StringAttr>(adaptor.getMem())) {
+        os << label.getValue();
+        return;
+      }
+      
+      os << cast<rtg::ImmediateAttr>(adaptor.getMem()).getValue();
+    }
+  }];
+}
+
 def RV32I_LUI       : InstFormatUOpBase<"lui",   0b0110111>;
 def RV32I_AUIPC     : InstFormatUOpBase<"auipc", 0b0010111>;
 def RV32I_JAL       : InstFormatJOpBase<"jal",   0b1101111>;

--- a/lib/Dialect/RTG/Transforms/CMakeLists.txt
+++ b/lib/Dialect/RTG/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_circt_dialect_library(CIRCTRTGTransforms
   InlineSequencesPass.cpp
   LinearScanRegisterAllocationPass.cpp
   LowerUniqueLabelsPass.cpp
+  MemoryAllocationPass.cpp
 
   DEPENDS
   CIRCTRTGTransformsIncGen

--- a/lib/Dialect/RTG/Transforms/MemoryAllocationPass.cpp
+++ b/lib/Dialect/RTG/Transforms/MemoryAllocationPass.cpp
@@ -1,0 +1,173 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/RTG/IR/RTGAttributes.h"
+#include "circt/Dialect/RTG/IR/RTGOps.h"
+#include "circt/Dialect/RTG/Transforms/RTGPasses.h"
+#include "mlir/Dialect/Index/IR/IndexOps.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace circt {
+namespace rtg {
+#define GEN_PASS_DEF_MEMORYALLOCATIONPASS
+#include "circt/Dialect/RTG/Transforms/RTGPasses.h.inc"
+} // namespace rtg
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace circt::rtg;
+
+//===----------------------------------------------------------------------===//
+// Memory Allocation Pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct AllocationInfo {
+  APInt nextFree;
+  APInt maxAddr;
+};
+
+/// Helper function to adjust APInt width and check for truncation errors.
+LogicalResult adjustAPIntWidth(APInt &value, unsigned targetBitWidth,
+                               Location loc) {
+  if (value.getBitWidth() > targetBitWidth && !value.isIntN(targetBitWidth))
+    return mlir::emitError(
+        loc, "cannot truncate APInt because value is too big to fit");
+
+  if (value.getBitWidth() < targetBitWidth) {
+    value = value.zext(targetBitWidth);
+    return success();
+  }
+
+  value = value.trunc(targetBitWidth);
+  return success();
+}
+
+struct MemoryAllocationPass
+    : public rtg::impl::MemoryAllocationPassBase<MemoryAllocationPass> {
+  using Base::Base;
+
+  void runOnOperation() override;
+};
+} // namespace
+
+void MemoryAllocationPass::runOnOperation() {
+  auto testOp = getOperation();
+  DenseMap<Value, AllocationInfo> nextFreeMap;
+
+  if (!useImmediates) {
+    testOp->emitError("label mode not yet supported");
+    return signalPassFailure();
+  }
+
+  // Collect memory block declarations in target.
+  auto target = testOp.getTargetAttr();
+  if (!target)
+    return;
+
+  SymbolTable table(testOp->getParentOfType<ModuleOp>());
+  auto targetOp = table.lookupNearestSymbolFrom<TargetOp>(testOp, target);
+
+  for (auto &op : *targetOp.getBody()) {
+    auto memBlock = dyn_cast<MemoryBlockDeclareOp>(&op);
+    if (!memBlock)
+      continue;
+
+    auto &slot = nextFreeMap[memBlock.getResult()];
+    slot.nextFree = memBlock.getBaseAddress();
+    slot.maxAddr = memBlock.getEndAddress();
+  }
+
+  // Propagate memory block declarations from target to test.
+  auto targetYields = targetOp.getBody()->getTerminator()->getOperands();
+  auto targetEntries = targetOp.getTarget().getEntries();
+  auto testEntries = testOp.getTargetType().getEntries();
+  auto testArgs = testOp.getBody()->getArguments();
+
+  size_t targetIdx = 0;
+  for (auto [testEntry, testArg] : llvm::zip(testEntries, testArgs)) {
+    while (targetIdx < targetEntries.size() &&
+           targetEntries[targetIdx].name.getValue() < testEntry.name.getValue())
+      targetIdx++;
+
+    if (targetIdx < targetEntries.size() &&
+        targetEntries[targetIdx].name.getValue() == testEntry.name.getValue()) {
+      auto targetYield = targetYields[targetIdx];
+      auto it = nextFreeMap.find(targetYield);
+      if (it != nextFreeMap.end())
+        nextFreeMap[testArg] = it->second;
+    }
+  }
+
+  // Iterate through the test and allocate memory for each 'memory_alloc'
+  // operation.
+  for (auto &op : llvm::make_early_inc_range(*testOp.getBody())) {
+    auto mem = dyn_cast<MemoryAllocOp>(&op);
+    if (!mem)
+      continue;
+
+    auto iter = nextFreeMap.find(mem.getMemoryBlock());
+    if (iter == nextFreeMap.end()) {
+      mem->emitError("memory block not found");
+      return signalPassFailure();
+    }
+
+    auto sizeOp = mem.getSize().getDefiningOp<index::ConstantOp>();
+    if (!sizeOp) {
+      mem->emitError("could not determine memory allocation size");
+      return signalPassFailure();
+    }
+
+    auto alignOp = mem.getAlignment().getDefiningOp<index::ConstantOp>();
+    if (!alignOp) {
+      mem->emitError("could not determine memory allocation alignment");
+      return signalPassFailure();
+    }
+
+    APInt size = sizeOp.getValue();
+    APInt alignment = alignOp.getValue();
+
+    if (size.isZero()) {
+      mem->emitError(
+          "memory allocation size must be greater than zero (was 0)");
+      return signalPassFailure();
+    }
+
+    if (!alignment.isPowerOf2()) {
+      mem->emitError("memory allocation alignment must be a power of two (was ")
+          << alignment.getZExtValue() << ")";
+      return signalPassFailure();
+    }
+
+    auto &memBlock = iter->getSecond();
+    APInt nextFree = memBlock.nextFree;
+    unsigned bitWidth = nextFree.getBitWidth();
+
+    if (failed(adjustAPIntWidth(size, bitWidth, mem.getLoc())) ||
+        failed(adjustAPIntWidth(alignment, bitWidth, mem.getLoc())))
+      return signalPassFailure();
+
+    // Calculate aligned address
+    APInt bias(bitWidth, !nextFree.isZero());
+    APInt ceilDiv = (nextFree - bias).udiv(alignment) + bias;
+    APInt nextFreeAligned = ceilDiv * alignment;
+
+    memBlock.nextFree = nextFreeAligned + size;
+    if (memBlock.nextFree.ugt(memBlock.maxAddr)) {
+      mem->emitError("memory block not large enough to fit all allocations");
+      return signalPassFailure();
+    }
+
+    ++numMemoriesAllocated;
+
+    IRRewriter builder(mem);
+    builder.replaceOpWithNewOp<ConstantOp>(
+        mem, ImmediateAttr::get(builder.getContext(), nextFreeAligned));
+  }
+}

--- a/test/Dialect/RTG/Transform/elaboration.mlir
+++ b/test/Dialect/RTG/Transform/elaboration.mlir
@@ -13,6 +13,7 @@ func.func @dummy10(%arg0: !rtg.set<tuple<index>>) -> () {return}
 func.func @dummy11(%arg0: !rtg.set<index>) -> () {return}
 func.func @dummy12(%arg0: !rtg.bag<index>) -> () {return}
 func.func @dummy13(%arg0: !rtg.isa.memory_block<32>) -> () {return}
+func.func @dummy14(%arg0: !rtg.isa.memory<32>) -> () {return}
 
 rtg.target @singletonTarget : !rtg.dict<singleton: index> {
   %0 = index.constant 0
@@ -708,6 +709,20 @@ rtg.target @memoryBlocks : !rtg.dict<mem_block: !rtg.isa.memory_block<32>> {
 rtg.test @memoryBlockTest(mem_block = %arg0: !rtg.isa.memory_block<32>) {
   func.call @dummy13(%arg0) : (!rtg.isa.memory_block<32>) -> ()
   // CHECK-NEXT: func.call @dummy13(%mem_block)
+
+  // CHECK-NEXT: [[IDX8:%.+]] = index.constant 8 
+  // CHECK-NEXT: [[IDX4:%.+]] = index.constant 4
+  // CHECK-NEXT: [[MEM:%.+]] = rtg.isa.memory_alloc %mem_block, [[IDX8]], [[IDX4]] : !rtg.isa.memory_block<32>
+  // CHECK-NEXT: func.call @dummy14([[MEM]])
+  %idx4 = index.constant 4
+  %idx8 = index.constant 8 
+  %0 = rtg.isa.memory_alloc %arg0, %idx8, %idx4 : !rtg.isa.memory_block<32>
+  func.call @dummy14(%0) : (!rtg.isa.memory<32>) -> ()
+
+  // CHECK-NEXT: func.call @dummy2([[IDX8]])
+  %1 = rtg.isa.memory_size %0 : !rtg.isa.memory<32> 
+  func.call @dummy2(%1) : (index) -> ()
+
   // CHECK-NEXT: }
 }
 

--- a/test/Dialect/RTG/Transform/emit-rtg-isa-assembly-labels.mlir
+++ b/test/Dialect/RTG/Transform/emit-rtg-isa-assembly-labels.mlir
@@ -8,6 +8,8 @@ rtg.test @test0() {
   %rs = rtg.fixed_reg #rtgtest.s0
   %label = rtg.label_decl "label_name"
 
+  // CHECK-NEXT:    la ra, label_name
+  rtgtest.rv32i.la %rd, %label : !rtg.isa.label
   // CHECK-NEXT:    beq ra, s0, label_name
   rtgtest.rv32i.beq %rd, %rs, %label : !rtg.isa.label
   // CHECK-NEXT:label_name:

--- a/test/Dialect/RTG/Transform/emit-rtg-isa-assembly.mlir
+++ b/test/Dialect/RTG/Transform/emit-rtg-isa-assembly.mlir
@@ -16,6 +16,10 @@ rtg.test @test0() {
   %neg_imm = rtg.constant #rtg.isa.immediate<12, 4080>
   %imm13 = rtg.constant #rtg.isa.immediate<13, 6144>
 
+  // CHECK-ALLOWED-NEXT:    la ra, 0
+  // CHECK-NEXT:    la ra, 0
+  rtgtest.rv32i.la %rd, %imm32 : !rtg.isa.immediate<32>
+
   // CHECK-ALLOWED-NEXT:    jalr ra, -16(s0)
   // CHECK-NEXT:    # jalr ra, -16(s0)
   // CHECK-NEXT:    .word 0xFF0400E7

--- a/test/Dialect/RTG/Transform/memory-allocation.mlir
+++ b/test/Dialect/RTG/Transform/memory-allocation.mlir
@@ -1,0 +1,180 @@
+// RUN: circt-opt --rtg-memory-allocation --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// Test proper alignment computation.
+rtg.target @target : !rtg.dict<mem_blk: !rtg.isa.memory_block<32>> {
+  %0 = rtg.isa.memory_block_declare [0 - 31] : !rtg.isa.memory_block<32>
+  rtg.yield %0 : !rtg.isa.memory_block<32>
+}
+
+// CHECK-LABEL: rtg.test @test
+rtg.test @test(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) target @target {
+  // CHECK: [[IMM0:%.+]] = rtg.constant #rtg.isa.immediate<32, 0>
+  // CHECK: [[REG:%.+]] = rtg.fixed_reg
+  // CHECK: rtgtest.rv32i.la [[REG]], [[IMM0]] : !rtg.isa.immediate<32>
+  %idx4 = index.constant 4
+  %idx7 = index.constant 7
+  %0 = rtg.isa.memory_alloc %mem_blk, %idx7, %idx4 : !rtg.isa.memory_block<32>
+  %reg = rtg.fixed_reg #rtgtest.t0
+  rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
+
+  // CHECK: [[IMM1:%.+]] = rtg.constant #rtg.isa.immediate<32, 8>
+  // CHECK: rtgtest.rv32i.la [[REG]], [[IMM1]] : !rtg.isa.immediate<32>
+  %1 = rtg.isa.memory_alloc %mem_blk, %idx7, %idx4 : !rtg.isa.memory_block<32>
+  rtgtest.rv32i.la %reg, %1 : !rtg.isa.memory<32>
+}
+
+// -----
+
+rtg.target @target : !rtg.dict<mem_blk: !rtg.isa.memory_block<32>> {
+  %0 = rtg.isa.memory_block_declare [0 - 31] : !rtg.isa.memory_block<32>
+  rtg.yield %0 : !rtg.isa.memory_block<32>
+}
+
+func.func @passthrough(%mem_blk: !rtg.isa.memory_block<32>) -> !rtg.isa.memory_block<32> {
+  return %mem_blk : !rtg.isa.memory_block<32>
+}
+
+rtg.test @test_missing_block(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) target @target {
+  %idx4 = index.constant 4
+  %idx7 = index.constant 7
+  %mem_block_unknown = func.call @passthrough(%mem_blk) : (!rtg.isa.memory_block<32>) -> !rtg.isa.memory_block<32>
+  // expected-error @below {{memory block not found}}
+  %0 = rtg.isa.memory_alloc %mem_block_unknown, %idx7, %idx4 : !rtg.isa.memory_block<32>
+  %reg = rtg.fixed_reg #rtgtest.t0
+  rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
+}
+
+// -----
+
+rtg.target @target_unknown_size : !rtg.dict<mem_blk: !rtg.isa.memory_block<32>> {
+  %0 = rtg.isa.memory_block_declare [0 - 31] : !rtg.isa.memory_block<32>
+  rtg.yield %0 : !rtg.isa.memory_block<32>
+}
+
+func.func @const() -> index {
+  %0 = index.constant 0
+  return %0 : index
+}
+
+rtg.test @test_unknown_size(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) target @target_unknown_size {
+  %unknown = func.call @const() : () -> index
+  %idx4 = index.constant 4
+  // expected-error @below {{could not determine memory allocation size}}
+  %0 = rtg.isa.memory_alloc %mem_blk, %unknown, %idx4 : !rtg.isa.memory_block<32>
+  %reg = rtg.fixed_reg #rtgtest.t0
+  rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
+}
+
+// -----
+
+rtg.target @target_unknown_align : !rtg.dict<mem_blk: !rtg.isa.memory_block<32>> {
+  %0 = rtg.isa.memory_block_declare [0 - 31] : !rtg.isa.memory_block<32>
+  rtg.yield %0 : !rtg.isa.memory_block<32>
+}
+
+func.func @const() -> index {
+  %0 = index.constant 0
+  return %0 : index
+}
+
+rtg.test @test_unknown_align(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) target @target_unknown_align {
+  %idx7 = index.constant 7
+  %unknown = func.call @const() : () -> index
+  // expected-error @below {{could not determine memory allocation alignment}}
+  %0 = rtg.isa.memory_alloc %mem_blk, %idx7, %unknown : !rtg.isa.memory_block<32>
+  %reg = rtg.fixed_reg #rtgtest.t0
+  rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
+}
+
+// -----
+
+rtg.target @target_zero_size : !rtg.dict<mem_blk: !rtg.isa.memory_block<32>> {
+  %0 = rtg.isa.memory_block_declare [0 - 31] : !rtg.isa.memory_block<32>
+  rtg.yield %0 : !rtg.isa.memory_block<32>
+}
+
+rtg.test @test_zero_size(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) target @target_zero_size {
+  %idx0 = index.constant 0
+  %idx4 = index.constant 4
+  // expected-error @below {{memory allocation size must be greater than zero (was 0)}}
+  %0 = rtg.isa.memory_alloc %mem_blk, %idx0, %idx4 : !rtg.isa.memory_block<32>
+  %reg = rtg.fixed_reg #rtgtest.t0
+  rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
+}
+
+// -----
+
+rtg.target @target_non_pow2_align : !rtg.dict<mem_blk: !rtg.isa.memory_block<32>> {
+  %0 = rtg.isa.memory_block_declare [0 - 31] : !rtg.isa.memory_block<32>
+  rtg.yield %0 : !rtg.isa.memory_block<32>
+}
+
+rtg.test @test_non_pow2_align(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) target @target_non_pow2_align {
+  %idx7 = index.constant 7
+  %idx3 = index.constant 3
+  // expected-error @below {{memory allocation alignment must be a power of two (was 3)}}
+  %0 = rtg.isa.memory_alloc %mem_blk, %idx7, %idx3 : !rtg.isa.memory_block<32>
+  %reg = rtg.fixed_reg #rtgtest.t0
+  rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
+}
+
+// -----
+
+rtg.target @target_exceed_size : !rtg.dict<mem_blk: !rtg.isa.memory_block<32>> {
+  %0 = rtg.isa.memory_block_declare [0 - 7] : !rtg.isa.memory_block<32>
+  rtg.yield %0 : !rtg.isa.memory_block<32>
+}
+
+rtg.test @test_exceed_size(mem_blk = %mem_blk: !rtg.isa.memory_block<32>) target @target_exceed_size {
+  %idx16 = index.constant 16
+  %idx4 = index.constant 4
+  // expected-error @below {{memory block not large enough to fit all allocations}}
+  %0 = rtg.isa.memory_alloc %mem_blk, %idx16, %idx4 : !rtg.isa.memory_block<32>
+  %reg = rtg.fixed_reg #rtgtest.t0
+  rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
+}
+
+// -----
+
+rtg.target @target_truncate_error : !rtg.dict<mem_blk: !rtg.isa.memory_block<8>> {
+  %0 = rtg.isa.memory_block_declare [0 - 31] : !rtg.isa.memory_block<8>
+  rtg.yield %0 : !rtg.isa.memory_block<8>
+}
+
+rtg.test @test_truncate_error(mem_blk = %mem_blk: !rtg.isa.memory_block<8>) target @target_truncate_error {
+  %idx256 = index.constant 256
+  %idx4 = index.constant 4
+  // expected-error @below {{cannot truncate APInt because value is too big to fit}}
+  %0 = rtg.isa.memory_alloc %mem_blk, %idx256, %idx4 : !rtg.isa.memory_block<8>
+  %reg = rtg.fixed_reg #rtgtest.t0
+  rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<8>
+}
+
+// -----
+
+// Test for proper matching of target entries to test arguments by name.
+rtg.target @target_multiple_entries : !rtg.dict<mem_a: !rtg.isa.memory_block<32>, mem_b: !rtg.isa.memory_block<32>, mem_c: !rtg.isa.memory_block<32>> {
+  %mem_a = rtg.isa.memory_block_declare [0 - 31] : !rtg.isa.memory_block<32>
+  %mem_b = rtg.isa.memory_block_declare [100 - 131] : !rtg.isa.memory_block<32>
+  %mem_c = rtg.isa.memory_block_declare [200 - 231] : !rtg.isa.memory_block<32>
+
+  rtg.yield %mem_a, %mem_b, %mem_c : !rtg.isa.memory_block<32>, !rtg.isa.memory_block<32>, !rtg.isa.memory_block<32>
+}
+
+// CHECK-LABEL: rtg.test @test_entry_matching
+rtg.test @test_entry_matching(
+  mem_a = %mem_a: !rtg.isa.memory_block<32>,
+  mem_c = %mem_c: !rtg.isa.memory_block<32>
+) target @target_multiple_entries {
+  %idx8 = index.constant 8
+  %idx4 = index.constant 4
+  %reg = rtg.fixed_reg #rtgtest.t0
+
+  // CHECK: [[MEM_A:%.+]] = rtg.constant #rtg.isa.immediate<32, 0>
+  %0 = rtg.isa.memory_alloc %mem_a, %idx8, %idx4 : !rtg.isa.memory_block<32>
+  rtgtest.rv32i.la %reg, %0 : !rtg.isa.memory<32>
+
+  // CHECK: [[MEM_C:%.+]] = rtg.constant #rtg.isa.immediate<32, 200>
+  %2 = rtg.isa.memory_alloc %mem_c, %idx8, %idx4 : !rtg.isa.memory_block<32>
+  rtgtest.rv32i.la %reg, %2 : !rtg.isa.memory<32>
+}


### PR DESCRIPTION
This is a basic version of the pass and will be improved upon in later PRs (refer to memories via labels, assign the same/overlapping address range to multiple allocations if their liveness doesn't overlap, etc.)
Also make sure memories are properly retained during elaboration and add a load address instruction to rtgtest.