### PR TITLE
Bump LLVM to 9344b2196cbc36cdc577314bbb2b889606ba6820.

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -613,14 +613,12 @@ public:
         llvm::dbgs() << "\n node:" << getName(drivenBy[node.first].first)
                      << "=> probe:" << getName(drivenBy[node.second].first);
       }
-      for (auto i = rwProbeClasses.begin(), e = rwProbeClasses.end(); i != e;
-           ++i) { // Iterate over all of the equivalence sets.
+      for (const auto &i :
+           rwProbeClasses) { // Iterate over all of the equivalence sets.
         if (!i->isLeader())
           continue; // Ignore non-leader sets.
         // Print members in this set.
-        llvm::interleave(llvm::make_range(rwProbeClasses.member_begin(i),
-                                          rwProbeClasses.member_end()),
-                         llvm::dbgs(), "\n");
+        llvm::interleave(rwProbeClasses.members(*i), llvm::dbgs(), "\n");
         llvm::dbgs() << "\n dataflow at leader::" << i->getData() << "\n =>"
                      << rwProbeRefersTo[i->getData()];
         llvm::dbgs() << "\n Done\n"; // Finish set.
@@ -653,10 +651,7 @@ public:
             rwProbeClasses.getLeaderValue(getOrAddNode(defOp.getDataRef()));
         // For all the probes, that are in the same eqv class, i.e., refer to
         // the same value.
-        for (auto probe :
-             llvm::make_range(rwProbeClasses.member_begin(
-                                  rwProbeClasses.findValue(rwProbeNode)),
-                              rwProbeClasses.member_end())) {
+        for (auto probe : rwProbeClasses.members(rwProbeNode)) {
           auto probeVal = drivenBy[probe].first;
           // If the probe is a port, then record the path from the probe to the
           // input port.

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1028,12 +1028,10 @@ LogicalResult InferResetsPass::inferAndUpdateResets() {
     llvm::dbgs() << "\n";
     debugHeader("Infer reset types") << "\n\n";
   });
-  for (auto it = resetClasses.begin(), end = resetClasses.end(); it != end;
-       ++it) {
+  for (const auto &it : resetClasses) {
     if (!it->isLeader())
       continue;
-    ResetNetwork net = llvm::make_range(resetClasses.member_begin(it),
-                                        resetClasses.member_end());
+    ResetNetwork net = resetClasses.members(*it);
 
     // Infer whether this should be a sync or async reset.
     auto kind = inferReset(net);

--- a/test/Transforms/flatten_memref_calls.mlir
+++ b/test/Transforms/flatten_memref_calls.mlir
@@ -2,13 +2,14 @@
 
 // CHECK-LABEL:   func private @foo(memref<900xi32>) -> i32
 
-// CHECK-LABEL:   func @main() {
-// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : index
-// CHECK:           %[[VAL_1:.*]] = memref.alloca() : memref<30x30xi32>
-// CHECK:           %[[VAL_2:.*]] = memref.subview %[[VAL_1]][0, 0] [1, 900] [1, 1] : memref<30x30xi32> to memref<900xi32>
-// CHECK:           %[[VAL_3:.*]] = call @foo(%[[VAL_2]]) : (memref<900xi32>) -> i32
-// CHECK:           return
-// CHECK:         }
+// CHECK-LABEL:       func @main() {
+// CHECK:               %[[VAL_0:.*]] = arith.constant 0 : index
+// CHECK:               %[[VAL_1:.*]] = memref.alloca() : memref<30x30xi32>
+// CHECK:               %[[VAL_2:.*]] = memref.collapse_shape %[[VAL_1]]
+// CHECK-SAME{LITERAL}:   [[0, 1]] : memref<30x30xi32> into memref<900xi32>
+// CHECK:               %[[VAL_3:.*]] = call @foo(%[[VAL_2]]) : (memref<900xi32>) -> i32
+// CHECK:               return
+// CHECK:             }
 module  {
   func.func private @foo(memref<30x30xi32>) -> i32
   func.func @main() {


### PR DESCRIPTION
There were series of patches to llvm::EquivalenceClasses this week,
and we updated accordingly:

* There is no longer a template parameter for the comparator
* The idiom for iterating over EquivalenceClasses was updated
* The idiom for iterating over members was updated

There was a change to the InlinerUtils functions to now include a
required callback for ops that are cloned. To update our call sites,
this default constructs an InlinerConfig and uses the default
clone callback.

Finally, there was a change to the memref.subview verifier to actually
check bounds when statically possible. Since memref.subview is
technically supposed to "represent a reduced-size view of the
original memref", I think our previous lowering was technically
supposed to be interpreted as out of bound accesses.

See https://discourse.llvm.org/t/out-of-bounds-semantics-of-memref-subview/85293
for more info.

In any case, it seems this is the expected use for
memref.collapse_shape, so this was adopted instead of memref.subview
for this use case.