### PR TITLE
[Calyx] Canonicalization should exclude parallel as well

### DIFF
--- a/lib/Dialect/Calyx/Transforms/ExcludeExecuteRegionCanonicalize.cpp
+++ b/lib/Dialect/Calyx/Transforms/ExcludeExecuteRegionCanonicalize.cpp
@@ -53,7 +53,8 @@ void ExcludeExecuteRegionCanonicalizePass::runOnOperation() {
 
   // Add op-specific canonicalization patterns
   for (const RegisteredOperationName &op : ctx->getRegisteredOperations()) {
-    if (op.getStringRef() == "scf.execute_region")
+    if (op.getStringRef() == "scf.execute_region" ||
+        op.getStringRef() == "scf.parallel")
       continue;
 
     op.getCanonicalizationPatterns(patterns, ctx);


### PR DESCRIPTION
https://github.com/llvm/circt/pull/8358 forgets exclude `scf.parallel`