### PR TITLE
[AffineParallelUnroll] Remove unnecessary unparallelized attribute

### DIFF
--- a/include/circt/Dialect/Calyx/CalyxPasses.td
+++ b/include/circt/Dialect/Calyx/CalyxPasses.td
@@ -283,7 +283,7 @@ def AffinePloopUnparallelize : Pass<"affine-ploop-unparallelize", "::mlir::func:
           }
           default {}
         }
-      } {unparallelized}
+      }
       ```
   }];
 }

--- a/lib/Dialect/Calyx/Transforms/AffinePloopUnparallelize.cpp
+++ b/lib/Dialect/Calyx/Transforms/AffinePloopUnparallelize.cpp
@@ -82,7 +82,6 @@ public:
     auto outerLoop = rewriter.create<affine::AffineForOp>(
         loc, lowerBound, rewriter.getDimIdentityMap(), upperBound,
         rewriter.getDimIdentityMap(), step * factor);
-    outerLoop->setAttr("unparallelized", rewriter.getUnitAttr());
 
     rewriter.setInsertionPointToStart(outerLoop.getBody());
     AffineMap lbMap = AffineMap::get(

--- a/test/Dialect/Calyx/affine-ploop-unparallelize.mlir
+++ b/test/Dialect/Calyx/affine-ploop-unparallelize.mlir
@@ -9,7 +9,7 @@
 // CHECK:                 affine.store %[[VAL_1]], %[[VAL_0]]{{\[}}%[[VAL_2]] + %[[VAL_3]], %[[VAL_4]]] : memref<16x4xf32>
 // CHECK:               }
 // CHECK:             }
-// CHECK:           } {unparallelized}
+// CHECK:           }
 // CHECK:           return
 // CHECK:         }
 
@@ -38,9 +38,9 @@ module {
 // CHECK:                 affine.parallel (%[[VAL_5:.*]]) = (0) to (1) {
 // CHECK:                   affine.store %[[VAL_1]], %[[VAL_0]]{{\[}}%[[VAL_2]] + %[[VAL_3]], %[[VAL_4]] + %[[VAL_5]]] : memref<16x4xf32>
 // CHECK:                 }
-// CHECK:               } {unparallelized}
+// CHECK:               }
 // CHECK:             }
-// CHECK:           } {unparallelized}
+// CHECK:           }
 // CHECK:           return
 // CHECK:         }
 
@@ -112,9 +112,9 @@ module {
 // CHECK:                   default {
 // CHECK:                   }
 // CHECK:                 }
-// CHECK:               } {unparallelized}
+// CHECK:               }
 // CHECK:             }
-// CHECK:           } {unparallelized}
+// CHECK:           }
 // CHECK:           return
 // CHECK:         }
 


### PR DESCRIPTION
The `unparallelized` attribute was meant to exist for a downstream new pass that simplifies `scf.index_switch` operations and having an attribute is helpful to identify the existence of those `scf.index_switch` ops; but now this pass is being piggybacked in https://github.com/llvm/circt/pull/8401