### PR TITLE
[CMake] Copy the CMake modules to CIRCT_CMAKE_DIR

### DIFF
--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -49,6 +49,17 @@ set(CIRCT_CONFIG_TOOLS_DIR)
 set(CIRCT_CONFIG_INCLUDE_EXPORTS)
 set(CIRCT_CONFIG_INCLUDE_DIRS)
 
+# For compatibility with projects that add '<build>/lib/cmake/circt' to
+# their CMAKE_MODULE_PATH, place API modules next to it.
+# Copy without source permissions because the source could be read-only,
+# but we need to write into the copied folder.
+file(COPY .
+  DESTINATION ${circt_cmake_builddir}
+  NO_SOURCE_PERMISSIONS
+  FILES_MATCHING PATTERN *.cmake
+  PATTERN CMakeFiles EXCLUDE
+)
+
 # Generate CIRCTConfig.cmake for the install tree.
 set(CIRCT_CONFIG_CODE "
 # Compute the installation prefix from this CIRCTConfig.cmake file location.


### PR DESCRIPTION
In the current version of CIRCT, the module files in `cmake/modules` are not copied to `CIRCT_CMAKE_DIR`, which causes issues for out-of-tree external projects that depend on CIRCT.

```CMake
find_package(CIRCT REQUIRED CONFIG)
list(APPEND CMAKE_MODULE_PATH ${CIRCT_CMAKE_DIR})
include(AddCIRCT) # Error: include could not find requested file: AddCIRCT
```

This patch ensures that the files in `cmake/modules` are copied into `CIRCT_CMAKE_DIR`.
(It follows the approach used in MLIR’s CMake configuration [here](https://github.com/llvm/llvm-project/blob/af28c9c65a23806a09d7929792df5ed2e9bdf946/mlir/cmake/modules/CMakeLists.txt#L82))

The following code is an example `CMakeLists.txt` file for a standalone out-of-tree project.

```cmake
# Modified from https://github.com/llvm/llvm-project/tree/main/mlir/examples/standalone

cmake_minimum_required(VERSION 3.20)
project(myproj)
set(CMAKE_CXX_STANDARD 17)

set(CIRCT_DIR "${CMAKE_CURRENT_BINARY_DIR}/../circt/build/lib/cmake/circt")
set(LLVM_DIR "${CMAKE_CURRENT_BINARY_DIR}/../circt/llvm/build/lib/cmake/llvm")
set(MLIR_DIR "${CMAKE_CURRENT_BINARY_DIR}/../circt/llvm/build/lib/cmake/mlir")

find_package(CIRCT REQUIRED CONFIG)

set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})

list(APPEND CMAKE_MODULE_PATH ${CIRCT_CMAKE_DIR})
list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
list(APPEND CMAKE_MODULE_PATH ${MLIR_CMAKE_DIR})

include(TableGen)
include(AddCIRCT)
include(AddLLVM)
include(AddMLIR)
include(HandleLLVMOptions)

include_directories(${CIRCT_INCLUDE_DIRS})
include_directories(${LLVM_INCLUDE_DIRS})
include_directories(${MLIR_INCLUDE_DIRS})
include_directories(${PROJECT_SOURCE_DIR}/include)
include_directories(${PROJECT_BINARY_DIR}/include)
link_directories(${LLVM_BUILD_LIBRARY_DIR})
add_definitions(${LLVM_DEFINITIONS})
```