### PR TITLE
[AffineParallelUnroll] A more general approach to hoist memory reads across `scf.execute_region`s

### DIFF
--- a/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
+++ b/lib/Dialect/Calyx/Transforms/AffineParallelUnroll.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Affine/IR/AffineMemoryOpInterfaces.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OperationSupport.h"
@@ -36,6 +37,43 @@ using namespace mlir;
 using namespace mlir::affine;
 using namespace mlir::arith;
 
+// A shared interface to store affine memory accesses.
+struct AffineAccessExpr {
+  Value memref;
+  AffineMap map;
+  SmallVector<Value, 4> operands;
+
+  bool operator==(const AffineAccessExpr &other) const {
+    return memref == other.memref && map == other.map &&
+           operands == other.operands;
+  }
+};
+
+namespace llvm {
+template <>
+struct DenseMapInfo<AffineAccessExpr> {
+  static AffineAccessExpr getEmptyKey() {
+    return {DenseMapInfo<Value>::getEmptyKey(), {}, {}};
+  }
+
+  static AffineAccessExpr getTombstoneKey() {
+    return {DenseMapInfo<Value>::getTombstoneKey(), {}, {}};
+  }
+
+  static unsigned getHashValue(const AffineAccessExpr &expr) {
+    unsigned h = DenseMapInfo<Value>::getHashValue(expr.memref);
+    h = llvm::hash_combine(h, DenseMapInfo<AffineMap>::getHashValue(expr.map));
+    for (Value operand : expr.operands)
+      h = llvm::hash_combine(h, DenseMapInfo<Value>::getHashValue(operand));
+    return h;
+  }
+
+  static bool isEqual(const AffineAccessExpr &a, const AffineAccessExpr &b) {
+    return a == b;
+  }
+};
+} // namespace llvm
+
 namespace {
 // This pass tries to prevent potential memory banking contention by hoisting
 // memory reads after AffineParallelUnroll. It only hoists memory reads
@@ -45,67 +83,42 @@ namespace {
 struct MemoryBankConflictResolver {
   LogicalResult run(AffineParallelOp affineParallelOp);
 
-  // Computes and collects all memory accesses (read/write) that have constant
-  // access indices.
-  DenseMap<Operation *, SmallVector<int64_t, 4>>
-  computeConstMemAccessIndices(AffineParallelOp affineParallelOp);
-
   // Performs memory contention analysis on memory write operations, returning
   // `failure` if the pass identifies two write operations write to the same
   // memory reference at the same access indices in different parallel regions.
-  LogicalResult
-  writeOpAnalysis(DenseMap<Operation *, SmallVector<int64_t, 4>> &,
-                  AffineParallelOp affineParallelOp);
+  LogicalResult writeOpAnalysis(AffineParallelOp affineParallelOp);
 
   // Tries to hoist memory read operations that will cause memory access
   // contention, such as reading from the same memory reference with the same
   // access indices in different parallel regions.
-  void readOpHoistAnalysis(AffineParallelOp affineParallelOp,
-                           DenseMap<Operation *, SmallVector<int64_t, 4>> &);
+  LogicalResult readOpAnalysis(AffineParallelOp affineParallelOp);
 
-  // Stores the mapping from memory writes and their associated constant access
-  // indices to the parallel region.
-  DenseMap<std::pair<Value, SmallVector<int64_t, 4>>, scf::ExecuteRegionOp>
-      constantWriteOpIndices;
+  // Returns if `readOp`'s access indices are invariant with respect to
+  // `affineParallelOp`.
+  bool isInvariantToAffineParallel(AffineReadOpInterface readOp,
+                                   AffineParallelOp affineParallelOp);
 
-  // Counts the total number of each memory reads and their associated constant
-  // access indices across all parallel regions.
-  DenseMap<std::pair<Value, SmallVector<int64_t, 4>>, int> constantReadOpCounts;
+  // Accumulate all memory reads and writes to the fields.
+  void accumulateReadWriteOps(AffineParallelOp affineParallelOp);
+
+  // Stores all memory reads in current `affineParallelOp`.
+  DenseSet<AffineReadOpInterface> allReadOps;
+  // Stores all memory writes in current `affineParallelOp`.
+  DenseSet<AffineWriteOpInterface> allWriteOps;
+  // Stores the memory references across all `scf.execute_region` ops under
+  // current `affineParallelOp`.
+  DenseMap<Value, scf::ExecuteRegionOp> writtenMemRefs;
+  // Counts the number of reads across all `scf.execute_region` ops under
+  // current `affineParallelOp`.
+  DenseMap<AffineAccessExpr, int> readOpCounts;
+  // Records the memory reads that are already hoisted outside current
+  // `affineParallelOp`.
+  DenseMap<AffineAccessExpr, Value> hoistedReads;
 };
 } // end anonymous namespace
 
-namespace llvm {
-template <>
-struct DenseMapInfo<std::pair<Value, SmallVector<int64_t, 4>>> {
-  using PairType = std::pair<Value, SmallVector<int64_t, 4>>;
-
-  static inline PairType getEmptyKey() {
-    return {DenseMapInfo<Value>::getEmptyKey(), {}};
-  }
-
-  static inline PairType getTombstoneKey() {
-    return {DenseMapInfo<Value>::getTombstoneKey(), {}};
-  }
-
-  static unsigned getHashValue(const PairType &pair) {
-    unsigned hash = DenseMapInfo<Value>::getHashValue(pair.first);
-    for (const auto &v : pair.second)
-      hash = llvm::hash_combine(hash, DenseMapInfo<int64_t>::getHashValue(v));
-    return hash;
-  }
-
-  static bool isEqual(const PairType &lhs, const PairType &rhs) {
-    return lhs.first == rhs.first && lhs.second == rhs.second;
-  }
-};
-} // namespace llvm
-
-DenseMap<Operation *, SmallVector<int64_t, 4>>
-MemoryBankConflictResolver::computeConstMemAccessIndices(
+void MemoryBankConflictResolver::accumulateReadWriteOps(
     AffineParallelOp affineParallelOp) {
-  DenseMap<Operation *, SmallVector<int64_t, 4>> constantMemAccessIndices;
-
-  MLIRContext *ctx = affineParallelOp->getContext();
   auto executeRegionOps =
       affineParallelOp.getBody()->getOps<scf::ExecuteRegionOp>();
   for (auto executeRegionOp : executeRegionOps) {
@@ -113,133 +126,108 @@ MemoryBankConflictResolver::computeConstMemAccessIndices(
       if (!isa<AffineReadOpInterface, AffineWriteOpInterface>(op))
         return WalkResult::advance();
 
-      auto read = dyn_cast<AffineReadOpInterface>(op);
-      AffineMap map = read ? read.getAffineMap()
-                           : cast<AffineWriteOpInterface>(op).getAffineMap();
-      ValueRange mapOperands =
-          read ? read.getMapOperands()
-               : cast<AffineWriteOpInterface>(op).getMapOperands();
+      if (auto read = dyn_cast<AffineReadOpInterface>(op)) {
+        allReadOps.insert(read);
 
-      SmallVector<Attribute> operandConsts;
-      for (Value operand : mapOperands) {
-        if (auto constOp =
-                operand.template getDefiningOp<arith::ConstantIndexOp>()) {
-          operandConsts.push_back(
-              IntegerAttr::get(IndexType::get(ctx), constOp.value()));
-        } else {
-          return WalkResult::advance();
-        }
+        AffineAccessExpr key{read.getMemRef(), read.getAffineMap(),
+                             read.getMapOperands()};
+        readOpCounts[key]++;
+      } else {
+        allWriteOps.insert(cast<AffineWriteOpInterface>(op));
       }
-
-      SmallVector<int64_t, 4> evaluatedIndices, foldedResults;
-      bool hasPoison = false;
-      map.partialConstantFold(operandConsts, &foldedResults, &hasPoison);
-      if (!(hasPoison || foldedResults.empty()))
-        constantMemAccessIndices[op] = foldedResults;
 
       return WalkResult::advance();
     });
   }
-
-  return constantMemAccessIndices;
 }
 
-LogicalResult MemoryBankConflictResolver::writeOpAnalysis(
-    DenseMap<Operation *, SmallVector<int64_t, 4>> &constantMemAccessIndices,
-    AffineParallelOp affineParallelOp) {
-  auto executeRegionOps =
-      affineParallelOp.getBody()->getOps<scf::ExecuteRegionOp>();
-  WalkResult result;
-  for (auto executeRegionOp : executeRegionOps) {
-    auto walkResult = executeRegionOp.walk([&](Operation *op) {
-      if (!isa<AffineWriteOpInterface>(op))
-        return WalkResult::advance();
+LogicalResult
+MemoryBankConflictResolver::writeOpAnalysis(AffineParallelOp affineParallelOp) {
+  for (auto writeOp : allWriteOps) {
+    scf::ExecuteRegionOp parentExecuteRegion =
+        writeOp->getParentOfType<scf::ExecuteRegionOp>();
+    auto memref = writeOp.getMemRef();
 
-      auto writeOp = cast<AffineWriteOpInterface>(op);
-
-      auto constIndicesIt = constantMemAccessIndices.find(op);
-      if (constIndicesIt == constantMemAccessIndices.end())
-        // Currently, we give up all write op analysis whose write indices are
-        // non-constants.
-        return WalkResult::advance();
-
-      auto parentExecuteRegionOp =
-          writeOp->getParentOfType<scf::ExecuteRegionOp>();
-      auto key = std::pair(writeOp.getMemRef(), constIndicesIt->second);
-      auto [writeOpIndicesIt, emplaced] =
-          constantWriteOpIndices.try_emplace(key, parentExecuteRegionOp);
-      if (!emplaced && writeOpIndicesIt->second != parentExecuteRegionOp) {
-        // Cannot write to the same memory reference at the same indices more
-        // than once in different parallel regions (but it's okay to write twice
-        // within the same parallel region because everything is sequential),
-        // because it will result in write contention.
-        return WalkResult::interrupt();
-      }
-      return WalkResult::advance();
-    });
-
-    if (walkResult.wasInterrupted())
+    auto it = writtenMemRefs.find(memref);
+    if (it != writtenMemRefs.end() && it->second != parentExecuteRegion) {
+      writeOp.emitError("Multiple writes to the same memory reference");
       return failure();
+    }
+
+    writtenMemRefs[memref] = parentExecuteRegion;
   }
 
   return success();
 }
 
-void MemoryBankConflictResolver::readOpHoistAnalysis(
-    AffineParallelOp affineParallelOp,
-    DenseMap<Operation *, SmallVector<int64_t, 4>> &constantMemAccessIndices) {
-  for (auto &[memOp, constIndices] : constantMemAccessIndices) {
-    auto readOp = dyn_cast<AffineReadOpInterface>(memOp);
-    if (!readOp)
-      continue;
+bool MemoryBankConflictResolver::isInvariantToAffineParallel(
+    AffineReadOpInterface readOp, AffineParallelOp affineParallelOp) {
+  // Check if any operand depends on loop IVs
+  for (Value iv : affineParallelOp.getIVs()) {
+    for (Value operand : readOp.getMapOperands()) {
+      if (operand == iv)
+        return false;
 
-    auto memref = readOp.getMemRef();
-    auto key = std::pair(memref, constIndices);
-    // We do not hoist any read as long as it's being written in any parallel
-    // region.
-    if (llvm::any_of(memref.getUsers(), [&](Operation *user) {
-          return affineParallelOp->isAncestor(user) &&
-                 hasEffect<MemoryEffects::Write>(user, memref);
-        })) {
-      continue;
-    }
-    constantReadOpCounts[key]++;
-  }
-
-  bool shouldHoist = llvm::any_of(
-      constantReadOpCounts, [](const auto &entry) { return entry.second > 1; });
-  if (!shouldHoist)
-    return;
-
-  OpBuilder builder(affineParallelOp);
-  DenseMap<std::pair<Value, SmallVector<int64_t, 4>>, ValueRange> hoistedReads;
-  for (auto &[memOp, constIndices] : constantMemAccessIndices) {
-    auto readOp = dyn_cast<AffineReadOpInterface>(memOp);
-    if (!readOp)
-      continue;
-
-    auto key = std::pair(readOp.getMemRef(), constIndices);
-    if (constantReadOpCounts[key] > 1) {
-      if (hoistedReads.find(key) == hoistedReads.end()) {
-        builder.setInsertionPoint(affineParallelOp);
-        Operation *clonedRead = builder.clone(*readOp.getOperation());
-        hoistedReads[key] = clonedRead->getOpResults();
+      // Walk through defining operation chains, such as `affine.apply`s.
+      if (Operation *def = operand.getDefiningOp()) {
+        if (affineParallelOp->isAncestor(def) && !isa<arith::ConstantOp>(def)) {
+          // Operand is computed inside the loop, not invariant
+          return false;
+        }
       }
-      readOp->replaceAllUsesWith(hoistedReads[key]);
     }
   }
+
+  // Check if memref is written in loop
+  Value memref = readOp.getMemRef();
+  for (Operation *user : memref.getUsers()) {
+    if (user == readOp.getOperation())
+      continue;
+
+    if (affineParallelOp->isAncestor(user) &&
+        hasEffect<MemoryEffects::Write>(user, memref))
+      return false;
+  }
+
+  return true;
+}
+
+LogicalResult
+MemoryBankConflictResolver::readOpAnalysis(AffineParallelOp affineParallelOp) {
+  OpBuilder builder(affineParallelOp);
+  for (auto readOp : allReadOps) {
+    AffineAccessExpr key{readOp.getMemRef(), readOp.getAffineMap(),
+                         readOp.getMapOperands()};
+    auto it = readOpCounts.find(key);
+    if (it == readOpCounts.end() || it->second <= 1 ||
+        !isInvariantToAffineParallel(readOp, affineParallelOp))
+      continue;
+
+    // Only hoist once per unique access
+    if (!hoistedReads.contains(key)) {
+      builder.setInsertionPoint(affineParallelOp);
+      Operation *cloned = builder.clone(*readOp.getOperation());
+      hoistedReads[key] = cloned->getResult(0);
+    }
+
+    readOp->getResult(0).replaceAllUsesWith(hoistedReads[key]);
+    readOp.getOperation()->erase();
+  }
+
+  return success();
 }
 
 LogicalResult
 MemoryBankConflictResolver::run(AffineParallelOp affineParallelOp) {
-  auto constantMemAccessIndices =
-      computeConstMemAccessIndices(affineParallelOp);
+  accumulateReadWriteOps(affineParallelOp);
 
-  if (failed(writeOpAnalysis(constantMemAccessIndices, affineParallelOp))) {
+  if (failed(writeOpAnalysis(affineParallelOp))) {
     return failure();
   }
 
-  readOpHoistAnalysis(affineParallelOp, constantMemAccessIndices);
+  if (failed(readOpAnalysis(affineParallelOp))) {
+    return failure();
+  }
 
   return success();
 }
@@ -355,6 +343,7 @@ struct AffineParallelUnrollPass
           AffineParallelUnrollPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<mlir::scf::SCFDialect>();
+    registry.insert<mlir::memref::MemRefDialect>();
   }
   void runOnOperation() override;
 };
@@ -376,11 +365,12 @@ void AffineParallelUnrollPass::runOnOperation() {
   // `AffineParallelUnroll` pattern introduces constant values, so running
   // `canonicalizePatterns` before `MemoryBankConflictResolver` will help ease
   // the analysis in `MemoryBankConflictResolver`.
-  RewritePatternSet canonicalizePatterns(ctx);
-  scf::IndexSwitchOp::getCanonicalizationPatterns(canonicalizePatterns, ctx);
-  if (failed(applyPatternsGreedily(getOperation(),
-                                   std::move(canonicalizePatterns)))) {
-    getOperation()->emitError("Failed to apply canonicalization.");
+  PassManager pm(ctx);
+  pm.addPass(calyx::createExcludeExecuteRegionCanonicalizePass());
+
+  if (failed(pm.run(getOperation()))) {
+    getOperation()->emitError("Nested PassManager failed when running "
+                              "ExcludeExecuteRegionCanonicalize pass.");
     signalPassFailure();
   }
 

--- a/test/Dialect/Calyx/affine-parallel-unroll.mlir
+++ b/test/Dialect/Calyx/affine-parallel-unroll.mlir
@@ -184,26 +184,26 @@ module {
 // -----
 
 // CHECK-LABEL:   func.func @licm(
-// CHECK-SAME:                    %[[VAL_0:.*]]: memref<2xf32>,
-// CHECK-SAME:                    %[[VAL_1:.*]]: memref<2xf32>) {
-// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-SAME:                    %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2xf32>,
+// CHECK-SAME:                    %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2xf32>,
+// CHECK-SAME:                    %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2xf32>) {
 // CHECK:           %[[VAL_3:.*]] = memref.alloc() : memref<2xf32>
-// CHECK-DAG:           %[[VAL_4:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<2xf32>
-// CHECK-DAG:           %[[VAL_5:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_2]]] : memref<2xf32>
+// CHECK-DAG:           %[[VAL_4:.*]] = affine.load %[[VAL_0]][0] : memref<2xf32>
+// CHECK-DAG:           %[[VAL_5:.*]] = affine.load %[[VAL_1]][0] : memref<2xf32>
 // CHECK:           affine.parallel (%[[VAL_6:.*]]) = (0) to (1) {
 // CHECK:             scf.execute_region {
 // CHECK:               affine.for %[[VAL_7:.*]] = 0 to 2 {
-// CHECK:                 %[[VAL_8:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_7]]] : memref<2xf32>
-// CHECK:                 %[[VAL_9:.*]] = arith.mulf %[[VAL_5]], %[[VAL_4]] : f32
+// CHECK:                 %[[VAL_8:.*]] = affine.load %[[VAL_2]]{{\[}}%[[VAL_7]]] : memref<2xf32>
+// CHECK:                 %[[VAL_9:.*]] = arith.mulf %[[VAL_4]], %[[VAL_5]] : f32
 // CHECK:                 %[[VAL_10:.*]] = arith.addf %[[VAL_8]], %[[VAL_9]] : f32
-// CHECK:                 affine.store %[[VAL_10]], %[[VAL_3]]{{\[}}%[[VAL_7]]] : memref<2xf32>
+// CHECK:                 affine.store %[[VAL_10]], %[[VAL_2]]{{\[}}%[[VAL_7]]] : memref<2xf32>
 // CHECK:               }
 // CHECK:               scf.yield
 // CHECK:             }
 // CHECK:             scf.execute_region {
 // CHECK:               affine.for %[[VAL_11:.*]] = 0 to 2 {
 // CHECK:                 %[[VAL_12:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_11]]] : memref<2xf32>
-// CHECK:                 %[[VAL_13:.*]] = arith.mulf %[[VAL_5]], %[[VAL_4]] : f32
+// CHECK:                 %[[VAL_13:.*]] = arith.mulf %[[VAL_4]], %[[VAL_5]] : f32
 // CHECK:                 %[[VAL_14:.*]] = arith.addf %[[VAL_12]], %[[VAL_13]] : f32
 // CHECK:                 affine.store %[[VAL_14]], %[[VAL_3]]{{\[}}%[[VAL_11]]] : memref<2xf32>
 // CHECK:               }
@@ -215,19 +215,42 @@ module {
 
 #map = affine_map<(d0) -> (d0 floordiv 2)>
 module {
-  func.func @licm(%arg0: memref<2xf32>, %arg1: memref<2xf32>) {
+  func.func @licm(%arg0: memref<2xf32>, %arg1: memref<2xf32>, %arg2: memref<2xf32>) {
     %alloc = memref.alloc() : memref<2xf32>
-    affine.parallel (%arg2) = (0) to (2) {
-      %0 = affine.apply #map(%arg2)
-      affine.for %arg3 = 0 to 2 {
+    %cst = arith.constant 0.0 : f32
+    affine.parallel (%iv_par) = (0) to (2) {
+      %0 = affine.apply #map(%iv_par)
+      affine.for %iv_for = 0 to 2 {
         // The following load will be hoisted.
         %1 = affine.load %arg0[%0] : memref<2xf32>
         // The following load will be hoisted.
         %2 = affine.load %arg1[%0] : memref<2xf32>
-        %3 = affine.load %alloc[%arg3] : memref<2xf32>
+        %3 = scf.index_switch %iv_par -> f32
+        case 0 {
+          %loaded = affine.load %alloc[%iv_for] : memref<2xf32>
+          scf.yield %loaded : f32
+        }
+        case 1 {
+          %loaded = affine.load %arg2[%iv_for] : memref<2xf32>
+          scf.yield %loaded : f32
+        }
+        default {
+          scf.yield %cst : f32
+        }
         %4 = arith.mulf %1, %2 : f32
         %5 = arith.addf %3, %4 : f32
-        affine.store %5, %alloc[%arg3] : memref<2xf32>
+        scf.index_switch %iv_par
+        case 0 {
+          affine.store %5, %alloc[%iv_for] : memref<2xf32>
+          scf.yield
+        }
+        case 1 {
+          affine.store %5, %arg2[%iv_for] : memref<2xf32>
+          scf.yield
+        }
+        default {
+          scf.yield
+        }
       }
     }
     return
@@ -239,24 +262,25 @@ module {
 // We do not hoist a constant-indices load when there is a write in the parallel region
 
 // CHECK-LABEL:   func.func @war(
-// CHECK-SAME:                   %[[VAL_0:.*]]: memref<2xf32>,
-// CHECK-SAME:                   %[[VAL_1:.*]]: memref<2xf32>) {
-// CHECK:           %[[VAL_2:.*]] = arith.constant 4.200000e+01 : f32
-// CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
-// CHECK:           affine.parallel (%[[VAL_4:.*]]) = (0) to (1) {
+// CHECK-SAME:                   %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2xf32>,
+// CHECK-SAME:                   %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2xf32>,
+// CHECK-SAME:                   %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2xf32>,
+// CHECK-SAME:                   %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2xf32>) {
+// CHECK:           %[[VAL_4:.*]] = arith.constant 4.200000e+01 : f32
+// CHECK:           affine.parallel (%[[VAL_5:.*]]) = (0) to (1) {
 // CHECK:             scf.execute_region {
-// CHECK:               affine.for %[[VAL_5:.*]] = 0 to 2 {
-// CHECK:                 affine.store %[[VAL_2]], %[[VAL_0]]{{\[}}%[[VAL_5]]] : memref<2xf32>
-// CHECK:                 %[[VAL_6:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_3]]] : memref<2xf32>
-// CHECK:                 affine.store %[[VAL_6]], %[[VAL_1]]{{\[}}%[[VAL_5]]] : memref<2xf32>
+// CHECK:               affine.for %[[VAL_6:.*]] = 0 to 2 {
+// CHECK:                 affine.store %[[VAL_4]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<2xf32>
+// CHECK:                 %[[VAL_7:.*]] = affine.load %[[VAL_0]][0] : memref<2xf32>
+// CHECK:                 affine.store %[[VAL_7]], %[[VAL_3]]{{\[}}%[[VAL_6]]] : memref<2xf32>
 // CHECK:               }
 // CHECK:               scf.yield
 // CHECK:             }
 // CHECK:             scf.execute_region {
-// CHECK:               affine.for %[[VAL_7:.*]] = 0 to 2 {
-// CHECK:                 affine.store %[[VAL_2]], %[[VAL_0]]{{\[}}%[[VAL_7]]] : memref<2xf32>
-// CHECK:                 %[[VAL_8:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_3]]] : memref<2xf32>
-// CHECK:                 affine.store %[[VAL_8]], %[[VAL_1]]{{\[}}%[[VAL_7]]] : memref<2xf32>
+// CHECK:               affine.for %[[VAL_8:.*]] = 0 to 2 {
+// CHECK:                 affine.store %[[VAL_4]], %[[VAL_0]]{{\[}}%[[VAL_8]]] : memref<2xf32>
+// CHECK:                 %[[VAL_9:.*]] = affine.load %[[VAL_0]][0] : memref<2xf32>
+// CHECK:                 affine.store %[[VAL_9]], %[[VAL_2]]{{\[}}%[[VAL_8]]] : memref<2xf32>
 // CHECK:               }
 // CHECK:               scf.yield
 // CHECK:             }
@@ -265,17 +289,26 @@ module {
 // CHECK:         }
 
 module {
-  func.func @war(%arg0: memref<2xf32>, %arg1: memref<2xf32>) {
-    %fortytwo = arith.constant 42.0 : f32
-    %zeroidx = arith.constant 0 : index
-    affine.parallel (%arg2) = (0) to (2) {
-      affine.for %arg3 = 0 to 2 {
-        affine.store %fortytwo, %arg0[%arg3] : memref<2xf32>
-        // The following load should not be hoisted.
-        %0 = affine.load %arg0[%zeroidx] : memref<2xf32>
-        affine.store %0, %arg1[%arg3] : memref<2xf32>
+  func.func @war(%arg0: memref<2xf32>, %arg1: memref<2xf32>, %arg2: memref<2xf32>, %arg3: memref<2xf32>) {
+    %cst = arith.constant 4.200000e+01 : f32
+    affine.parallel (%arg4) = (0) to (1) {
+      scf.execute_region {
+        affine.for %arg5 = 0 to 2 {
+          affine.store %cst, %arg1[%arg5] : memref<2xf32>
+          %0 = affine.load %arg0[0] : memref<2xf32>
+          affine.store %0, %arg3[%arg5] : memref<2xf32>
+        }
+        scf.yield
       }
-    }
+      scf.execute_region {
+        affine.for %arg5 = 0 to 2 {
+          affine.store %cst, %arg0[%arg5] : memref<2xf32>
+          %0 = affine.load %arg0[0] : memref<2xf32>
+          affine.store %0, %arg2[%arg5] : memref<2xf32>
+        }
+        scf.yield
+      }
+    } {calyx.unroll = true}
     return
   }
 }
@@ -285,28 +318,26 @@ module {
 // Test non-conflicting constant writes after canonicalizing `scf.index_switch`
 
 // CHECK-LABEL:   func.func @const_writes(
-// CHECK-SAME:                   %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<1x1xf32>,
-// CHECK-SAME:                   %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<1x1xf32>) {
-// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
-// CHECK:           %[[VAL_3:.*]] = arith.constant 1 : index
-// CHECK:           %[[VAL_4:.*]] = arith.constant 4.200000e+01 : f32
-// CHECK:           %[[VAL_5:.*]] = memref.alloc() : memref<1x1xf32>
-// CHECK:           %[[VAL_6:.*]] = memref.alloc() : memref<1x1xf32>
-// CHECK:           affine.parallel (%[[VAL_7:.*]]) = (0) to (1) {
+// CHECK-SAME:                            %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<1x1xf32>,
+// CHECK-SAME:                            %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<1x1xf32>) {
+// CHECK:           %[[VAL_2:.*]] = arith.constant 4.200000e+01 : f32
+// CHECK:           %[[VAL_3:.*]] = memref.alloc() : memref<1x1xf32>
+// CHECK:           %[[VAL_4:.*]] = memref.alloc() : memref<1x1xf32>
+// CHECK:           affine.parallel (%[[VAL_5:.*]]) = (0) to (1) {
 // CHECK:             scf.execute_region {
-// CHECK:               affine.store %[[VAL_4]], %[[VAL_6]]{{\[}}%[[VAL_3]] floordiv 2, %[[VAL_3]] floordiv 2] : memref<1x1xf32>
+// CHECK:               affine.store %[[VAL_2]], %[[VAL_4]][0, 0] : memref<1x1xf32>
 // CHECK:               scf.yield
 // CHECK:             }
 // CHECK:             scf.execute_region {
-// CHECK:               affine.store %[[VAL_4]], %[[VAL_1]]{{\[}}%[[VAL_3]] floordiv 2, %[[VAL_2]] floordiv 2] : memref<1x1xf32>
+// CHECK:               affine.store %[[VAL_2]], %[[VAL_1]][0, 0] : memref<1x1xf32>
 // CHECK:               scf.yield
 // CHECK:             }
 // CHECK:             scf.execute_region {
-// CHECK:               affine.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_2]] floordiv 2, %[[VAL_3]] floordiv 2] : memref<1x1xf32>
+// CHECK:               affine.store %[[VAL_2]], %[[VAL_3]][0, 0] : memref<1x1xf32>
 // CHECK:               scf.yield
 // CHECK:             }
 // CHECK:             scf.execute_region {
-// CHECK:               affine.store %[[VAL_4]], %[[VAL_0]]{{\[}}%[[VAL_2]] floordiv 2, %[[VAL_2]] floordiv 2] : memref<1x1xf32>
+// CHECK:               affine.store %[[VAL_2]], %[[VAL_0]][0, 0] : memref<1x1xf32>
 // CHECK:               scf.yield
 // CHECK:             }
 // CHECK:           } {calyx.unroll = true}
@@ -360,3 +391,128 @@ module {
     return
   }
 }
+
+// -----
+
+// Test hosting read when the access indices depend on outer nested for-loops.
+
+// CHECK-LABEL:   func.func @hoist_read(
+// CHECK-SAME:                          %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x2xf32>,
+// CHECK-SAME:                          %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x2xf32>,
+// CHECK-SAME:                          %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x2xf32>,
+// CHECK-SAME:                          %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x2xf32>,
+// CHECK-SAME:                          %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x2xf32>,
+// CHECK-SAME:                          %[[VAL_5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x2xf32>,
+// CHECK-SAME:                          %[[VAL_6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x2xf32>,
+// CHECK-SAME:                          %[[VAL_7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x2xf32>,
+// CHECK-SAME:                          %[[VAL_8:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: f32) {
+// CHECK:           affine.for %[[VAL_9:.*]] = 0 to 4 {
+// CHECK:             affine.for %[[VAL_10:.*]] = 0 to 2 {
+// CHECK-DAG:               %[[VAL_11:.*]] = affine.load %[[VAL_4]]{{\[}}%[[VAL_10]], %[[VAL_9]] floordiv 2] : memref<2x2xf32>
+// CHECK-DAG:               %[[VAL_12:.*]] = affine.load %[[VAL_5]]{{\[}}%[[VAL_10]], %[[VAL_9]] floordiv 2] : memref<2x2xf32>
+// CHECK:               affine.parallel (%[[VAL_13:.*]]) = (0) to (1) {
+// CHECK:                 scf.execute_region {
+// CHECK:                   %[[VAL_14:.*]] = arith.mulf %[[VAL_11]], %[[VAL_8]] : f32
+// CHECK:                   affine.store %[[VAL_14]], %[[VAL_3]]{{\[}}%[[VAL_10]], %[[VAL_9]] floordiv 2] : memref<2x2xf32>
+// CHECK:                   scf.yield
+// CHECK:                 }
+// CHECK:                 scf.execute_region {
+// CHECK:                   %[[VAL_15:.*]] = arith.mulf %[[VAL_12]], %[[VAL_8]] : f32
+// CHECK:                   affine.store %[[VAL_15]], %[[VAL_2]]{{\[}}%[[VAL_10]], %[[VAL_9]] floordiv 2] : memref<2x2xf32>
+// CHECK:                   scf.yield
+// CHECK:                 }
+// CHECK:                 scf.execute_region {
+// CHECK:                   %[[VAL_16:.*]] = arith.mulf %[[VAL_12]], %[[VAL_8]] : f32
+// CHECK:                   affine.store %[[VAL_16]], %[[VAL_1]]{{\[}}%[[VAL_10]], %[[VAL_9]] floordiv 2] : memref<2x2xf32>
+// CHECK:                   scf.yield
+// CHECK:                 }
+// CHECK:                 scf.execute_region {
+// CHECK:                   %[[VAL_17:.*]] = arith.mulf %[[VAL_11]], %[[VAL_8]] : f32
+// CHECK:                   affine.store %[[VAL_17]], %[[VAL_0]]{{\[}}%[[VAL_10]], %[[VAL_9]] floordiv 2] : memref<2x2xf32>
+// CHECK:                   scf.yield
+// CHECK:                 }
+// CHECK:               } {calyx.unroll = true}
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+
+module {
+  func.func @hoist_read(%arg0: memref<2x2xf32>, %arg1: memref<2x2xf32>, %arg2: memref<2x2xf32>, %arg3: memref<2x2xf32>, %arg4: memref<2x2xf32>, %arg5: memref<2x2xf32>, %arg6: memref<2x2xf32>, %arg7: memref<2x2xf32>, %arg8: f32) {
+    %cst = arith.constant 0.000000e+00 : f32
+    affine.for %arg9 = 0 to 4 {
+      affine.for %arg10 = 0 to 2 {
+        affine.parallel (%arg11, %arg12) = (0, 0) to (2, 2) {
+          %0 = scf.index_switch %arg11 -> f32
+          case 0 {
+            %2 = scf.index_switch %arg12 -> f32
+            case 0 {
+              %3 = affine.load %arg4[%arg10 + %arg11 floordiv 2, %arg9 floordiv 2] : memref<2x2xf32>
+              scf.yield %3 : f32
+            }
+            case 1 {
+              %3 = affine.load %arg5[%arg10 + %arg11 floordiv 2, %arg9 floordiv 2] : memref<2x2xf32>
+              scf.yield %3 : f32
+            }
+            default {
+              scf.yield %cst : f32
+            }
+            scf.yield %2 : f32
+          }
+          case 1 {
+            %2 = scf.index_switch %arg12 -> f32
+            case 0 {
+              %3 = affine.load %arg5[%arg10 + %arg11 floordiv 2, %arg9 floordiv 2] : memref<2x2xf32>
+              scf.yield %3 : f32
+            }
+            case 1 {
+              %3 = affine.load %arg4[%arg10 + %arg11 floordiv 2, %arg9 floordiv 2] : memref<2x2xf32>
+              scf.yield %3 : f32
+            }
+            default {
+              scf.yield %cst : f32
+            }
+            scf.yield %2 : f32
+          }
+          default {
+            scf.yield %cst : f32
+          }
+          %1 = arith.mulf %0, %arg8 : f32
+          scf.index_switch %arg11
+          case 0 {
+            scf.index_switch %arg12
+            case 0 {
+              affine.store %1, %arg0[%arg10 + %arg11 floordiv 2, %arg9 floordiv 2] : memref<2x2xf32>
+              scf.yield
+            }
+            case 1 {
+              affine.store %1, %arg1[%arg10 + %arg11 floordiv 2, %arg9 floordiv 2] : memref<2x2xf32>
+              scf.yield
+            }
+            default {
+            }
+            scf.yield
+          }
+          case 1 {
+            scf.index_switch %arg12
+            case 0 {
+              affine.store %1, %arg2[%arg10 + %arg11 floordiv 2, %arg9 floordiv 2] : memref<2x2xf32>
+              scf.yield
+            }
+            case 1 {
+              affine.store %1, %arg3[%arg10 + %arg11 floordiv 2, %arg9 floordiv 2] : memref<2x2xf32>
+              scf.yield
+            }
+            default {
+            }
+            scf.yield
+          }
+          default {
+          }
+        }
+      }
+    }
+    return
+  }
+}
+

--- a/test/Dialect/Calyx/affine-parallel-unroll.mlir
+++ b/test/Dialect/Calyx/affine-parallel-unroll.mlir
@@ -394,7 +394,7 @@ module {
 
 // -----
 
-// Test hosting read when the access indices depend on outer nested for-loops.
+// Test hoisting read when the access indices depend on outer nested for-loops.
 
 // CHECK-LABEL:   func.func @hoist_read(
 // CHECK-SAME:                          %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: memref<2x2xf32>,

--- a/test/Dialect/Calyx/affine-parallel-unroll.mlir
+++ b/test/Dialect/Calyx/affine-parallel-unroll.mlir
@@ -447,6 +447,7 @@ module {
           case 0 {
             %2 = scf.index_switch %arg12 -> f32
             case 0 {
+              // This load will be hoisted after unrolling and simplifying the access indices.
               %3 = affine.load %arg4[%arg10 + %arg11 floordiv 2, %arg9 floordiv 2] : memref<2x2xf32>
               scf.yield %3 : f32
             }
@@ -462,6 +463,7 @@ module {
           case 1 {
             %2 = scf.index_switch %arg12 -> f32
             case 0 {
+              // This load will be hoisted after unrolling and simplifying the access indices.
               %3 = affine.load %arg5[%arg10 + %arg11 floordiv 2, %arg9 floordiv 2] : memref<2x2xf32>
               scf.yield %3 : f32
             }


### PR DESCRIPTION
This patch supports a more general approach (previously only considering memory accesses with constant indices) to hoist memory reads out from the `scf.execute_region`s under an `affine.parallel` to prevent memory read access conflict.