### PR TITLE
[Moore] Adding `moore.uarray_cmp` Op

### DIFF
--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -614,6 +614,15 @@ def SExtOp : ExtOpBase<"sext"> {
 // Expressions
 //===----------------------------------------------------------------------===//
 
+def Moore_UArrayCmpPredicateAttr : I64EnumAttr<
+    "UArrayCmpPredicate", "",
+    [
+      I64EnumAttrCase<"eq", 0>,
+      I64EnumAttrCase<"ne", 1>
+    ]> {
+  let cppNamespace = "circt::moore";
+}
+
 def NegOp : MooreOp<"neg", [Pure, SameOperandsAndResultType]> {
   let summary = "Arithmetic negation";
   let description = [{
@@ -890,9 +899,9 @@ def ShrOp : ShiftOpBase<"shr"> { let summary = "Logical right shift"; }
 def AShrOp : ShiftOpBase<"ashr"> { let summary = "Arithmetic right shift"; }
 
 def Moore_UArrayCmpOp : MooreOp<"uarray_cmp", [
-  Pure, 
+  Pure,
   Commutative,
-  SameTypeOperands, 
+  SameTypeOperands,
   ]> {
   let description = [{
     Performs an elementwise comparison of two unpacked arrays
@@ -906,7 +915,11 @@ def Moore_UArrayCmpOp : MooreOp<"uarray_cmp", [
 
     The result is `1` if the comparison is true and `0` otherwise.
   }];
-  let arguments = (ins Moore_UArrayCmpPredicateAttr:$predicate, UnpackedArrayType:$lhs, UnpackedArrayType:$rhs);
+  let arguments = (ins 
+  Moore_UArrayCmpPredicateAttr:$predicate,
+  UnpackedArrayType:$lhs,
+  UnpackedArrayType:$rhs
+  );
   let results = (outs BitType:$result);
   let assemblyFormat = [{
     $predicate $lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -614,7 +614,7 @@ def SExtOp : ExtOpBase<"sext"> {
 // Expressions
 //===----------------------------------------------------------------------===//
 
-def Moore_UArrayCmpPredicateAttr : I64EnumAttr<
+def UArrayCmpPredicateAttr : I64EnumAttr<
     "UArrayCmpPredicate", "",
     [
       I64EnumAttrCase<"eq", 0>,
@@ -898,11 +898,11 @@ def ShlOp : ShiftOpBase<"shl"> { let summary = "Logical left shift"; }
 def ShrOp : ShiftOpBase<"shr"> { let summary = "Logical right shift"; }
 def AShrOp : ShiftOpBase<"ashr"> { let summary = "Arithmetic right shift"; }
 
-def Moore_UArrayCmpOp : MooreOp<"uarray_cmp", [
+def UArrayCmpOp : MooreOp<"uarray_cmp", [
   Pure,
   Commutative,
   SameTypeOperands,
-  ]> {
+]> {
   let description = [{
     Performs an elementwise comparison of two unpacked arrays
     using the specified predicate (for example, "eq" for equality or "ne" for inequality)
@@ -916,9 +916,9 @@ def Moore_UArrayCmpOp : MooreOp<"uarray_cmp", [
     The result is `1` if the comparison is true and `0` otherwise.
   }];
   let arguments = (ins 
-  Moore_UArrayCmpPredicateAttr:$predicate,
-  UnpackedArrayType:$lhs,
-  UnpackedArrayType:$rhs
+    UArrayCmpPredicateAttr:$predicate,
+    UnpackedArrayType:$lhs,
+    UnpackedArrayType:$rhs
   );
   let results = (outs BitType:$result);
   let assemblyFormat = [{

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -889,6 +889,30 @@ def ShlOp : ShiftOpBase<"shl"> { let summary = "Logical left shift"; }
 def ShrOp : ShiftOpBase<"shr"> { let summary = "Logical right shift"; }
 def AShrOp : ShiftOpBase<"ashr"> { let summary = "Arithmetic right shift"; }
 
+def Moore_UArrayCmpOp : MooreOp<"uarray_cmp", [
+  Pure, 
+  Commutative,
+  SameTypeOperands, 
+  ]> {
+  let description = [{
+    Performs an elementwise comparison of two unpacked arrays
+    using the specified predicate (for example, "eq" for equality or "ne" for inequality)
+    and returns a single bit result.
+    Its first argument is an attribute that defines which type of comparison is
+    performed. The following comparisons are supported:
+
+    -   equal (mnemonic: `"eq"`; integer value: `0`)
+    -   not equal (mnemonic: `"ne"`; integer value: `1`)
+
+    The result is `1` if the comparison is true and `0` otherwise.
+  }];
+  let arguments = (ins Moore_UArrayCmpPredicateAttr:$predicate, UnpackedArrayType:$lhs, UnpackedArrayType:$rhs);
+  let results = (outs BitType:$result);
+  let assemblyFormat = [{
+    $predicate $lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)
+  }];  
+}
+
 class LogicalEqOpBase<string mnemonic> : MooreOp<mnemonic, [
   Pure,
   Commutative,

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -272,6 +272,15 @@ def QueueType : MooreTypeDef<"Queue", [], "moore::UnpackedType"> {
   ];
 }
 
+def Moore_UArrayCmpPredicateAttr : I64EnumAttr<
+    "UArrayCmpPredicate", "",
+    [
+      I64EnumAttrCase<"eq", 0>,
+      I64EnumAttrCase<"ne", 1>
+    ]> {
+  let cppNamespace = "::circt::moore";
+}
+
 
 //===----------------------------------------------------------------------===//
 // Structs

--- a/include/circt/Dialect/Moore/MooreTypes.td
+++ b/include/circt/Dialect/Moore/MooreTypes.td
@@ -272,16 +272,6 @@ def QueueType : MooreTypeDef<"Queue", [], "moore::UnpackedType"> {
   ];
 }
 
-def Moore_UArrayCmpPredicateAttr : I64EnumAttr<
-    "UArrayCmpPredicate", "",
-    [
-      I64EnumAttrCase<"eq", 0>,
-      I64EnumAttrCase<"ne", 1>
-    ]> {
-  let cppNamespace = "::circt::moore";
-}
-
-
 //===----------------------------------------------------------------------===//
 // Structs
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -290,13 +290,13 @@ struct RvalueExprVisitor {
     }
 
     case BinaryOperator::Equality:
-      if (dyn_cast<moore::UnpackedArrayType>(lhs.getType()))
+      if (isa<moore::UnpackedArrayType>(lhs.getType()))
         return builder.create<moore::UArrayCmpOp>(
             loc, circt::moore::UArrayCmpPredicate::eq, lhs, rhs);
       else
         return createBinary<moore::EqOp>(lhs, rhs);
     case BinaryOperator::Inequality:
-      if (dyn_cast<moore::UnpackedArrayType>(lhs.getType()))
+      if (isa<moore::UnpackedArrayType>(lhs.getType()))
         return builder.create<moore::UArrayCmpOp>(
             loc, circt::moore::UArrayCmpPredicate::ne, lhs, rhs);
       else

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -292,13 +292,13 @@ struct RvalueExprVisitor {
     case BinaryOperator::Equality:
       if (isa<moore::UnpackedArrayType>(lhs.getType()))
         return builder.create<moore::UArrayCmpOp>(
-            loc, circt::moore::UArrayCmpPredicate::eq, lhs, rhs);
+            loc, moore::UArrayCmpPredicate::eq, lhs, rhs);
       else
         return createBinary<moore::EqOp>(lhs, rhs);
     case BinaryOperator::Inequality:
       if (isa<moore::UnpackedArrayType>(lhs.getType()))
         return builder.create<moore::UArrayCmpOp>(
-            loc, circt::moore::UArrayCmpPredicate::ne, lhs, rhs);
+            loc, moore::UArrayCmpPredicate::ne, lhs, rhs);
       else
         return createBinary<moore::NeOp>(lhs, rhs);
     case BinaryOperator::CaseEquality:

--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -290,9 +290,17 @@ struct RvalueExprVisitor {
     }
 
     case BinaryOperator::Equality:
-      return createBinary<moore::EqOp>(lhs, rhs);
+      if (dyn_cast<moore::UnpackedArrayType>(lhs.getType()))
+        return builder.create<moore::UArrayCmpOp>(
+            loc, circt::moore::UArrayCmpPredicate::eq, lhs, rhs);
+      else
+        return createBinary<moore::EqOp>(lhs, rhs);
     case BinaryOperator::Inequality:
-      return createBinary<moore::NeOp>(lhs, rhs);
+      if (dyn_cast<moore::UnpackedArrayType>(lhs.getType()))
+        return builder.create<moore::UArrayCmpOp>(
+            loc, circt::moore::UArrayCmpPredicate::ne, lhs, rhs);
+      else
+        return createBinary<moore::NeOp>(lhs, rhs);
     case BinaryOperator::CaseEquality:
       return createBinary<moore::CaseEqOp>(lhs, rhs);
     case BinaryOperator::CaseInequality:

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1144,9 +1144,9 @@ module Expressions;
     // CHECK: [[TMP2:%.+]] = moore.read %arr2
     // CHECK: moore.uarray_cmp eq [[TMP1]], [[TMP2]] : <2 x i32> -> i1
     x = arr1 == arr2;
-    // CHECK: [[TMP1:%.+]] = moore.read %arr1
-    // CHECK: [[TMP2:%.+]] = moore.read %arr2
-    // CHECK: moore.uarray_cmp ne [[TMP1]], [[TMP2]] : <2 x i32> -> i1
+    // CHECK: [[TMP3:%.+]] = moore.read %arr1
+    // CHECK: [[TMP4:%.+]] = moore.read %arr2
+    // CHECK: moore.uarray_cmp ne [[TMP3]], [[TMP4]] : <2 x i32> -> i1
     x = arr1 != arr2;
 
     // CHECK: [[TMP1:%.+]] = moore.read %a

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1144,6 +1144,10 @@ module Expressions;
     // CHECK: [[TMP2:%.+]] = moore.read %arr2
     // CHECK: moore.uarray_cmp eq [[TMP1]], [[TMP2]] : <2 x i32> -> i1
     x = arr1 == arr2;
+    // CHECK: [[TMP1:%.+]] = moore.read %arr1
+    // CHECK: [[TMP2:%.+]] = moore.read %arr2
+    // CHECK: moore.uarray_cmp ne [[TMP1]], [[TMP2]] : <2 x i32> -> i1
+    x = arr1 != arr2;
 
     // CHECK: [[TMP1:%.+]] = moore.read %a
     // CHECK: [[TMP2:%.+]] = moore.read %b

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -709,6 +709,10 @@ module Expressions;
   bit [1:0][31:0] arrayInt;
   // CHECK: %uarrayInt = moore.variable : <uarray<2 x i32>>
   bit [31:0] uarrayInt [2];
+  // CHECK: %arr1 = moore.variable : <uarray<2 x i32>
+  bit [31:0] arr1 [2];
+  // CHECK: %arr2 = moore.variable : <uarray<2 x i32>
+  bit [31:0] arr2 [2];
   // CHECK: %m = moore.variable : <l4>
   logic [3:0] m;
 
@@ -1127,6 +1131,20 @@ module Expressions;
     // CHECK: [[TMP2:%.+]] = moore.read %e
     // CHECK: moore.eq [[TMP1]], [[TMP2]] : l32 -> l1
     y = d == e;
+
+    // CHECK: [[TMP0:%.+]] = moore.constant 43
+    // CHECK: [[TMP1:%.+]] = moore.constant 9002
+    // CHECK: moore.array_create [[TMP0]], [[TMP1]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
+    arr1 = '{43, 9002};
+    // CHECK: [[TMP0:%.+]] = moore.constant 43
+    // CHECK: [[TMP1:%.+]] = moore.constant 9002
+    // CHECK: moore.array_create [[TMP0]], [[TMP1]] : !moore.i32, !moore.i32 -> uarray<2 x i32>
+    arr2 = '{43, 9002};
+    // CHECK: [[TMP1:%.+]] = moore.read %arr1
+    // CHECK: [[TMP2:%.+]] = moore.read %arr2
+    // CHECK: moore.uarray_cmp eq [[TMP1]], [[TMP2]] : <2 x i32> -> i1
+    x = arr1 == arr2;
+
     // CHECK: [[TMP1:%.+]] = moore.read %a
     // CHECK: [[TMP2:%.+]] = moore.read %b
     // CHECK: moore.ne [[TMP1]], [[TMP2]] : i32 -> i1

--- a/test/Dialect/Moore/basic.mlir
+++ b/test/Dialect/Moore/basic.mlir
@@ -214,10 +214,14 @@ moore.module @Expressions(
 
   // CHECK: moore.eq [[A]], [[B]] : i32 -> i1
   moore.eq %a, %b : i32 -> i1
+  // CHECK: moore.uarray_cmp eq [[ARRAY1]], [[ARRAY1]] : <4 x i8> -> i1
+  moore.uarray_cmp eq %array1, %array1 : <4 x i8> -> i1
   // CHECK: moore.ne [[A]], [[B]] : i32 -> i1
   moore.ne %a, %b : i32 -> i1
   // CHECK: moore.ne [[C]], [[D]] : l32 -> l1
   moore.ne %c, %d : l32 -> l1
+  // CHECK: moore.uarray_cmp ne [[ARRAY1]], [[ARRAY1]] : <4 x i8> -> i1
+  moore.uarray_cmp ne %array1, %array1 : <4 x i8> -> i1
   // CHECK: moore.case_eq [[A]], [[B]] : i32
   moore.case_eq %a, %b : i32
   // CHECK: moore.case_ne [[A]], [[B]] : i32


### PR DESCRIPTION
Adding a new Op to handle the comparison of unpacked arrays. These changes also help in passing this Chipsalliance [test](https://chipsalliance.github.io/sv-tests-results/?v=circt_verilog+7.4.3+operations-on-unpacked-arrays-equality).
@fabianschuiki, can you please review this? 
Also, I have a doubt: currently, I've added just two predicates for `!moore.uarray` comparisons: `eq` and `ne`. Do we need other predicates similar to the ones in `arith.cmpi`? I understand their use in comparing numbers, but why do we need them for comparing arrays?