### PR TITLE
[FIRRTL] Support Paths that target ports of extmodules.

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -817,7 +817,7 @@ StringAttr circt::firrtl::getOrAddInnerSym(
     const hw::InnerSymTarget &target,
     llvm::function_ref<hw::InnerSymbolNamespace &()> getNamespace) {
   if (target.isPort()) {
-    if (auto mod = dyn_cast<FModuleOp>(target.getOp())) {
+    if (auto mod = dyn_cast<FModuleLike>(target.getOp())) {
       auto portIdx = target.getPort();
       assert(portIdx < mod.getNumPorts());
       auto [attr, sym] =
@@ -837,7 +837,7 @@ StringAttr circt::firrtl::getOrAddInnerSym(
     }
   }
 
-  assert(0 && "target must be port of FModuleOp or InnerSymbol");
+  assert(0 && "target must be port of FModuleLike or InnerSymbol");
   return {};
 }
 
@@ -860,10 +860,10 @@ StringAttr circt::firrtl::getOrAddInnerSym(const hw::InnerSymTarget &target,
 hw::InnerRefAttr
 circt::firrtl::getInnerRefTo(const hw::InnerSymTarget &target,
                              GetNamespaceCallback getNamespace) {
-  auto mod = target.isPort() ? dyn_cast<FModuleOp>(target.getOp())
+  auto mod = target.isPort() ? dyn_cast<FModuleLike>(target.getOp())
                              : target.getOp()->getParentOfType<FModuleOp>();
   assert(mod &&
-         "must be an operation inside an FModuleOp or port of FModuleOp");
+         "must be an operation inside an FModuleOp or port of FModuleLike");
   return hw::InnerRefAttr::get(SymbolTable::getSymbolName(mod),
                                getOrAddInnerSym(target, getNamespace));
 }

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -168,6 +168,7 @@ firrtl.circuit "PathModule" {
   // CHECK: hw.hierpath private [[INST_PATH:@.+]] [@PathModule::@child]
   // CHECK: hw.hierpath private [[LOCAL_PATH:@.+]] [@Child]
   // CHECK: hw.hierpath private [[MODULE_PATH:@.+]] [@PathModule::@child, @Child::[[NONLOCAL_SYM:@.+]]]
+  // CHECK: hw.hierpath private [[EXT_PORT_PATH:@.+]] [@ExtChild::[[EXT_PORT_SYM:@.+]]]
 
   // CHECK: firrtl.module @PathModule(in %in: !firrtl.uint<1> sym [[PORT_SYM]]) {
   firrtl.module @PathModule(in %in : !firrtl.uint<1> [{class = "circt.tracker", id = distinct[0]<>}]) {
@@ -178,6 +179,8 @@ firrtl.circuit "PathModule" {
     // CHECK: firrtl.instance child sym @child @Child()
     firrtl.instance child sym @child {annotations = [{class = "circt.tracker", id = distinct[4]<>}]} @Child()
 
+    firrtl.instance ext_child @ExtChild(in foo: !firrtl.uint<1>)
+
     %path_test = firrtl.object @PathTest()
   }
   // CHECK: hw.hierpath private [[NONLOCAL_PATH:@.+]] [@PathModule::@child, @Child]
@@ -187,6 +190,10 @@ firrtl.circuit "PathModule" {
     // CHECK: %non_local = firrtl.wire sym [[NONLOCAL_SYM]] : !firrtl.uint<8>
     %non_local = firrtl.wire {annotations = [{circt.nonlocal = @NonLocal, class = "circt.tracker", id = distinct[3]<>}]} : !firrtl.uint<8>
   }
+
+  // CHECK: firrtl.extmodule private @ExtChild(in foo: !firrtl.uint<1> sym [[EXT_PORT_SYM]])
+  firrtl.extmodule private @ExtChild(in foo: !firrtl.uint<1> [{class = "circt.tracker", id = distinct[6]<>}])
+
   // CHECK: om.class @PathModule_Class(%basepath: !om.basepath) {
   // CHECK:   om.basepath_create %basepath
   // CHECK:   om.object @Child_Class
@@ -224,6 +231,9 @@ firrtl.circuit "PathModule" {
     %instance = firrtl.path instance distinct[4]<>
 
     %module_path = firrtl.path reference distinct[5]<>
+
+    // CHECK: om.path_create reference %basepath [[EXT_PORT_PATH]]
+    %ext_port_path = firrtl.path reference distinct[6]<>
   }
   // CHECK: -> (propOut: !om.list<!om.integer>)
   firrtl.module @ListCreate(in %propIn: !firrtl.integer, out %propOut: !firrtl.list<integer>) attributes {convention = #firrtl<convention scalarized>} {


### PR DESCRIPTION
Existing target support was built up asserting that only ports of FModuleOps are targeted. But there isn't anything really fundamental here, it looks like we have everything in we need in the FModuleLike interface and inner symbol infrastructure to put targets on ports of FExtModuleOps in exactly the same manner.

Fixes https://github.com/llvm/circt/issues/8417.