### PR TITLE
[FIRRTL][SV] Support substitutions in fprintf output file name. Add sv.sformatf. 

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -122,7 +122,7 @@ def PrintFOp : FIRRTLOp<"printf"> {
   }];
 }
 
-def FPrintFOp : FIRRTLOp<"fprintf"> {
+def FPrintFOp : FIRRTLOp<"fprintf", [AttrSizedOperandSegments]> {
   let summary = "Formatted File Print Statement";
 
   let description = [{
@@ -131,12 +131,16 @@ def FPrintFOp : FIRRTLOp<"fprintf"> {
   }];
 
   let arguments = (ins ClockType:$clock, UInt1Type:$cond, StrAttr:$outputFile,
+                       // Use FStringType instead of PrintfOperandType to reject hardware types.
+                       Variadic<FStringType>:$outputFileSubstitutions,
                        StrAttr:$formatString, Variadic<PrintfOperandType>:$substitutions,
                        StrAttr:$name);
   let results = (outs);
 
+  let hasVerifier = 1;
+
   let assemblyFormat = [{
-    $clock `,` $cond `,` $outputFile `,` $formatString ``
+    $clock `,` $cond `,` $outputFile (` ` `(` $outputFileSubstitutions^ `)`)? `,` $formatString ``
     custom<FPrintfAttrs>(attr-dict) ` ` (`(` $substitutions^ `)`)? `:`
     type($clock) `,` type($cond) (`,` qualified(type($substitutions))^)?
   }];

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -131,19 +131,11 @@ def FPrintFOp : FIRRTLOp<"fprintf", [AttrSizedOperandSegments]> {
   }];
 
   let arguments = (ins ClockType:$clock, UInt1Type:$cond, StrAttr:$outputFile,
-                       // Use FStringType instead of PrintfOperandType to reject hardware types.
-                       Variadic<FStringType>:$outputFileSubstitutions,
+                       Variadic<PrintfOperandType>:$outputFileSubstitutions,
                        StrAttr:$formatString, Variadic<PrintfOperandType>:$substitutions,
                        StrAttr:$name);
   let results = (outs);
-
-  let hasVerifier = 1;
-
-  let assemblyFormat = [{
-    $clock `,` $cond `,` $outputFile (` ` `(` $outputFileSubstitutions^ `)`)? `,` $formatString ``
-    custom<FPrintfAttrs>(attr-dict) ` ` (`(` $substitutions^ `)`)? `:`
-    type($clock) `,` type($cond) (`,` qualified(type($substitutions))^)?
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 def SkipOp : FIRRTLOp<"skip", [Pure]> {

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -201,6 +201,18 @@ def ConstantStrOp : SVOp<"constantStr", [Pure]> {
   let assemblyFormat = " $str attr-dict";
 }
 
+def SFormatFOp : SVOp<"sformatf", [Pure]> {
+  let summary = "sformatf";
+  let description = [{
+    This operation produces a constant string literal.
+  }];
+
+  let arguments = (ins StrAttr: $format_string, Variadic<AnyType>:$substitutions);
+  let results = (outs HWStringType:$result);
+  let assemblyFormat =
+    "$format_string attr-dict (`(` $substitutions^ `)` `:` qualified(type($substitutions)))?";
+}
+
 def LocalParamOp : SVOp<"localparam",
       [FirstAttrDerivedResultType, Pure, HasCustomSSAName]> {
   let summary = "Declare a localparam";

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -202,9 +202,12 @@ def ConstantStrOp : SVOp<"constantStr", [Pure]> {
 }
 
 def SFormatFOp : SVOp<"sformatf", [Pure]> {
-  let summary = "sformatf";
+  let summary = "'$sformatf' task";
   let description = [{
-    This operation produces a constant string literal.
+    This operations represents `$sformatf` task that produces a string from
+    a format string and substitutions.
+
+    See section 21.3.3 of 1800-2023 for more details.
   }];
 
   let arguments = (ins StrAttr: $format_string, Variadic<AnyType>:$substitutions);

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -32,6 +32,7 @@ public:
             IndexedPartSelectInOutOp, IndexedPartSelectOp, StructFieldInOutOp,
             ConstantXOp, ConstantZOp, ConstantStrOp, MacroRefExprOp,
             MacroRefExprSEOp, UnpackedArrayCreateOp, UnpackedOpenArrayCastOp,
+            SFormatFOp,
             // Declarations.
             RegOp, WireOp, LogicOp, LocalParamOp, XMROp, XMRRefOp,
             // Control flow.
@@ -113,6 +114,7 @@ public:
   HANDLE(MacroRefExprSEOp, Unhandled);
   HANDLE(UnpackedArrayCreateOp, Unhandled);
   HANDLE(UnpackedOpenArrayCastOp, Unhandled);
+  HANDLE(SFormatFOp, Unhandled);
 
   // Control flow.
   HANDLE(OrderedOutputOp, Unhandled);

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -3235,7 +3235,7 @@ SubExprInfo ExprEmitter::visitSV(SFormatFOp op) {
     ps.writeQuotedEscaped(op.getFormatString());
     // TODO: if any of these breaks, it'd be "nice" to break
     // after the comma, instead of:
-    // $fwrite(5, "...", a + b,
+    // $sformatf("...", a + b,
     //         longexpr_goes
     //         + here, c);
     // (without forcing breaking between all elements, like braced list)

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -863,7 +863,8 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
 
   // Helper function to emit #ifndef guard.
   auto emitGuard = [&](const char *guard, llvm::function_ref<void(void)> body) {
-    b.create<sv::IfDefOp>(guard, []() {}, body);
+    b.create<sv::IfDefOp>(
+        guard, []() {}, body);
   };
 
   if (state.usedFileDescriptorLib) {
@@ -1621,7 +1622,6 @@ struct FIRRTLLowering : public FIRRTLVisitor<FIRRTLLowering, LogicalResult> {
   Value getLoweredNonClockValue(Value value);
   Value getLoweredAndExtendedValue(Value value, Type destType);
   Value getLoweredAndExtOrTruncValue(Value value, Type destType);
-
   LogicalResult setLowering(Value orig, Value result);
   LogicalResult setPossiblyFoldedLowering(Value orig, Value result);
   template <typename ResultOpType, typename... CtorArgTypes>

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -202,7 +202,8 @@ static void tryCopyName(Operation *dst, Operation *src) {
 namespace {
 
 // A helper strutc to hold information about output file descriptor.
-struct FileDescriptorInfo {
+class FileDescriptorInfo {
+public:
   FileDescriptorInfo(StringAttr outputFileName, mlir::ValueRange substitutions)
       : outputFileFormat(outputFileName), substitutions(substitutions) {
     assert(outputFileName ||

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -220,15 +220,15 @@ struct FileDescriptorInfo {
 
   FileDescriptorInfo() = default;
 
-  StringAttr getOutputFileFormat() const { return outputFileFormat; }
-
-  bool isDynamicOutputFileName() const { return isDynamicFileName; }
-
+  // Substitution is required if substitution oprends are not empty.
   bool isSubstitutionRequired() const { return !substitutions.empty(); }
 
-  mlir::ValueRange getSubst() const { return substitutions; }
-
+  // If the output file is not specified, the default file descriptor is used.
   bool isDefaultFd() const { return !outputFileFormat; }
+
+  StringAttr getOutputFileFormat() const { return outputFileFormat; }
+  mlir::ValueRange getSubstitutions() const { return substitutions; }
+  bool isDynamicOutputFileName() const { return isDynamicFileName; }
 
 private:
   // Set true if the file name is dynamic, i.e. $time or normal hardware value
@@ -2731,7 +2731,7 @@ FIRRTLLowering::callFileDescriptorLib(const FileDescriptorInfo &info) {
   Value fileName;
   if (info.isSubstitutionRequired()) {
     SmallVector<Value> fileNameOperands;
-    if (failed(loweredFmtOperands(info.getSubst(), fileNameOperands)))
+    if (failed(loweredFmtOperands(info.getSubstitutions(), fileNameOperands)))
       return failure();
 
     fileName = builder

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -950,20 +950,20 @@ void Emitter::emitStatement(FPrintFOp op) {
     SmallVector<Value, 4> outputFileSubstitutions;
     emitFormatString(op, op.getOutputFile(), op.getOutputFileSubstitutions(),
                      outputFileSubstitutions);
-    for (auto operand : outputFileSubstitutions) {
+    if (!outputFileSubstitutions.empty()) {
       ps << "," << PP::space;
-      emitExpression(operand);
+      interleaveComma(outputFileSubstitutions);
     }
 
     ps << "," << PP::space;
-
     SmallVector<Value, 4> substitutions;
     emitFormatString(op, op.getFormatString(), op.getSubstitutions(),
                      substitutions);
-    for (auto operand : substitutions) {
+    if (!substitutions.empty()) {
       ps << "," << PP::space;
-      emitExpression(operand);
+      interleaveComma(substitutions);
     }
+
     ps << ")" << PP::end;
     if (!op.getName().empty()) {
       ps << PP::space << ": " << PPExtString(legalize(op.getNameAttr()));

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -914,21 +914,14 @@ void Emitter::emitFormatString(Operation *op, StringRef origFormatString,
   ps.writeQuotedEscaped(formatString);
 }
 
-template <class OpTy>
-void Emitter::emitPrintfLike(OpTy op, StringAttr fileName) {
+void Emitter::emitStatement(PrintFOp op) {
   startStatement();
   ps.scopedBox(PP::ibox2, [&]() {
-    if (fileName)
-      ps << "f";
     ps << "printf(" << PP::ibox0;
     emitExpression(op.getClock());
     ps << "," << PP::space;
     emitExpression(op.getCond());
     ps << "," << PP::space;
-    if (fileName) {
-      ps.writeQuotedEscaped(fileName.getValue());
-      ps << "," << PP::space;
-    }
 
     SmallVector<Value, 4> substitutions;
     emitFormatString(op, op.getFormatString(), op.getSubstitutions(),
@@ -945,10 +938,38 @@ void Emitter::emitPrintfLike(OpTy op, StringAttr fileName) {
   emitLocationAndNewLine(op);
 }
 
-void Emitter::emitStatement(PrintFOp op) { emitPrintfLike(op, {}); }
-
 void Emitter::emitStatement(FPrintFOp op) {
-  emitPrintfLike(op, op.getOutputFileAttr());
+  startStatement();
+  ps.scopedBox(PP::ibox2, [&]() {
+    ps << "fprintf(" << PP::ibox0;
+    emitExpression(op.getClock());
+    ps << "," << PP::space;
+    emitExpression(op.getCond());
+    ps << "," << PP::space;
+
+    SmallVector<Value, 4> outputFileSubstitutions;
+    emitFormatString(op, op.getOutputFile(), op.getOutputFileSubstitutions(),
+                     outputFileSubstitutions);
+    for (auto operand : outputFileSubstitutions) {
+      ps << "," << PP::space;
+      emitExpression(operand);
+    }
+
+    ps << "," << PP::space;
+
+    SmallVector<Value, 4> substitutions;
+    emitFormatString(op, op.getFormatString(), op.getSubstitutions(),
+                     substitutions);
+    for (auto operand : substitutions) {
+      ps << "," << PP::space;
+      emitExpression(operand);
+    }
+    ps << ")" << PP::end;
+    if (!op.getName().empty()) {
+      ps << PP::space << ": " << PPExtString(legalize(op.getNameAttr()));
+    }
+  });
+  emitLocationAndNewLine(op);
 }
 
 template <class T>

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -5852,7 +5852,18 @@ static ParseResult parseFPrintfAttrs(OpAsmParser &p,
 
 static void printFPrintfAttrs(OpAsmPrinter &p, Operation *op,
                               DictionaryAttr attr) {
-  printElideEmptyName(p, op, attr, {"formatString", "outputFile"});
+  printElideEmptyName(p, op, attr,
+                      {"formatString", "outputFile", "operandSegmentSizes"});
+}
+
+LogicalResult FPrintFOp::verify() {
+  for (auto operand : getOutputFileSubstitutions())
+    if (!operand.getDefiningOp<firrtl::HierarchicalModuleNameOp>())
+      return mlir::emitError(operand.getLoc())
+             << "Only a hierarchical module name can be used as a substitution "
+                "for fprintf output file name";
+
+  return success();
 }
 
 static ParseResult parseStopAttrs(OpAsmParser &p, NamedAttrList &resultAttrs) {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -5856,16 +5856,6 @@ static void printFPrintfAttrs(OpAsmPrinter &p, Operation *op,
                       {"formatString", "outputFile", "operandSegmentSizes"});
 }
 
-LogicalResult FPrintFOp::verify() {
-  for (auto operand : getOutputFileSubstitutions())
-    if (!operand.getDefiningOp<firrtl::HierarchicalModuleNameOp>())
-      return mlir::emitError(operand.getLoc())
-             << "Only a hierarchical module name can be used as a substitution "
-                "for fprintf output file name";
-
-  return success();
-}
-
 static ParseResult parseStopAttrs(OpAsmParser &p, NamedAttrList &resultAttrs) {
   return parseElideEmptyName(p, resultAttrs);
 }
@@ -6413,6 +6403,110 @@ void TimeOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
 void HierarchicalModuleNameOp::getAsmResultNames(
     OpAsmSetValueNameFn setNameFn) {
   setNameFn(getResult(), "hierarchicalmodulename");
+}
+
+ParseResult FPrintFOp::parse(::mlir::OpAsmParser &parser,
+                             ::mlir::OperationState &result) {
+  // Parse required clock and condition operands
+  OpAsmParser::UnresolvedOperand clock, cond;
+  if (parser.parseOperand(clock) || parser.parseComma() ||
+      parser.parseOperand(cond) || parser.parseComma())
+    return failure();
+
+  auto parseFormatString =
+      [&parser](llvm::SMLoc &loc, StringAttr &result,
+                SmallVectorImpl<OpAsmParser::UnresolvedOperand> &operands)
+      -> ParseResult {
+    loc = parser.getCurrentLocation();
+    // NOTE: Don't use parseAttribute. "format_string" : !firrtl.clock is
+    // considered as a typed attr.
+    std::string resultStr;
+    if (parser.parseString(&resultStr))
+      return failure();
+    result = parser.getBuilder().getStringAttr(resultStr);
+
+    // This is an optional
+    if (parser.parseOperandList(operands, AsmParser::Delimiter::OptionalParen))
+      return failure();
+    return success();
+  };
+
+  // Parse output file and format string substitutions
+  SmallVector<OpAsmParser::UnresolvedOperand> outputFileSubstitutions,
+      substitutions;
+  llvm::SMLoc outputFileLoc, formatStringLoc;
+
+  if (parseFormatString(
+          outputFileLoc,
+          result.getOrAddProperties<FPrintFOp::Properties>().outputFile,
+          outputFileSubstitutions) ||
+      parser.parseComma() ||
+      parseFormatString(
+          formatStringLoc,
+          result.getOrAddProperties<FPrintFOp::Properties>().formatString,
+          substitutions))
+    return failure();
+
+  if (parseFPrintfAttrs(parser, result.attributes))
+    return failure();
+
+  // Parse types
+  Type clockType, condType;
+  SmallVector<Type> restTypes;
+
+  if (parser.parseColon() || parser.parseType(clockType) ||
+      parser.parseComma() || parser.parseType(condType))
+    return failure();
+
+  if (succeeded(parser.parseOptionalComma())) {
+    if (parser.parseTypeList(restTypes))
+      return failure();
+  }
+
+  // Set operand segment sizes
+  result.getOrAddProperties<FPrintFOp::Properties>().operandSegmentSizes = {
+      1, 1, static_cast<int32_t>(outputFileSubstitutions.size()),
+      static_cast<int32_t>(substitutions.size())};
+
+  // Resolve all operands
+  if (parser.resolveOperand(clock, clockType, result.operands) ||
+      parser.resolveOperand(cond, condType, result.operands) ||
+      parser.resolveOperands(
+          outputFileSubstitutions,
+          ArrayRef(restTypes).take_front(outputFileSubstitutions.size()),
+          outputFileLoc, result.operands) ||
+      parser.resolveOperands(
+          substitutions,
+          ArrayRef(restTypes).drop_front(outputFileSubstitutions.size()),
+          formatStringLoc, result.operands))
+    return failure();
+
+  return success();
+}
+
+void FPrintFOp::print(OpAsmPrinter &p) {
+  p << " " << getClock() << ", " << getCond() << ", ";
+  p.printAttributeWithoutType(getOutputFileAttr());
+  if (!getOutputFileSubstitutions().empty()) {
+    p << "(";
+    p.printOperands(getOutputFileSubstitutions());
+    p << ")";
+  }
+  p << ", ";
+  p.printAttributeWithoutType(getFormatStringAttr());
+  printFPrintfAttrs(p, *this, (*this)->getAttrDictionary());
+  if (!getSubstitutions().empty()) {
+    p << "(";
+    p.printOperands(getSubstitutions());
+    p << ")";
+  }
+  p << " : " << getClock().getType() << ", " << getCond().getType();
+  if (!getOutputFileSubstitutions().empty() || !getSubstitutions().empty()) {
+    for (auto type : getOperands().drop_front(2).getTypes()) {
+      p << ", ";
+      p.printType(type);
+    }
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -3105,9 +3105,18 @@ ParseResult FIRStmtParser::parseFPrintf() {
       parseToken(FIRToken::string, "expected output file in fprintf"))
     return failure();
 
+  SmallVector<Value, 4> outputFileSpecOperands;
+  while (consumeIf(FIRToken::comma)) {
+    // Stop parsing operands when we see the format string.
+    if (getToken().getKind() == FIRToken::string)
+      break;
+    outputFileSpecOperands.push_back({});
+    if (parseExp(outputFileSpecOperands.back(), "expected operand in fprintf"))
+      return failure();
+  }
+
   auto formatStringLoc = getToken().getLoc();
-  if (parseToken(FIRToken::comma, "expected ','") ||
-      parseGetSpelling(formatString) ||
+  if (parseGetSpelling(formatString) ||
       parseToken(FIRToken::string, "expected format string in printf"))
     return failure();
 
@@ -3127,7 +3136,7 @@ ParseResult FIRStmtParser::parseFPrintf() {
 
   StringAttr outputFileNameStrUnescaped;
   SmallVector<Value> outputFileOperands;
-  if (parseFormatString(outputFileLoc, outputFile, {},
+  if (parseFormatString(outputFileLoc, outputFile, outputFileSpecOperands,
                         outputFileNameStrUnescaped, outputFileOperands))
     return failure();
 

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -1902,6 +1902,15 @@ hw.module @intrinsic(in %clk: i1, out io1: i1, out io2: i1, out io3: i1, out io4
   hw.output %0, %2, %4, %3 : i1, i1, i1, i5
 }
 
+// CHECK-LABEL: module sformatf
+hw.module @sformatf(in %a: i1, out o: i1) {
+  // CHECK: assign o = $test$plusargs($sformatf("test%d", a))
+  %0 = sv.sformatf "test%d" (%a) : i1
+  %1 = sv.system "test$plusargs"(%0) : (!hw.string) -> i1
+
+  hw.output %1 : i1
+}
+
 hw.module @bindInMod() {
   sv.bind #hw.innerNameRef<@remoteInstDut::@bindInst>
   sv.bind #hw.innerNameRef<@remoteInstDut::@bindInst3>

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -9,7 +9,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   // CHECK:     sv.func private @"__circt_lib_logging::FileDescriptor::get"(in %name : !hw.string, out fd : i32 {sv.func.explicitly_returned})
   // CHECK-SAME: attributes {verilogName = "__circt_lib_logging::FileDescriptor::get"}
   // CHECK-NEXT: sv.macro.decl @__CIRCT_LIB_LOGGING
-  // CHECK-NEXT: emit.fragment @FPRINTF_FD_FRAGMENT {
+  // CHECK-NEXT: emit.fragment @CIRCT_LIB_LOGGING_FRAGMENT {
   // CHECK-NEXT:   sv.ifdef  @__CIRCT_LIB_LOGGING {
   // CHECK-NEXT:   } else {
   // CHECK-NEXT:     sv.verbatim "// CIRCT Logging Library
@@ -350,7 +350,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 //    printf(clock, reset, "Hi signed %d %0d\n", add(c, c), d)
 
   // CHECK-LABEL: hw.module private @Print
-  // CHECK-SAME: attributes {emit.fragments = [@PRINTF_FD_FRAGMENT, @PRINTF_COND_FRAGMENT, @FPRINTF_FD_FRAGMENT]}
+  // CHECK-SAME: attributes {emit.fragments = [@PRINTF_COND_FRAGMENT, @PRINTF_FD_FRAGMENT, @CIRCT_LIB_LOGGING_FRAGMENT]}
   firrtl.module private @Print(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>,
                                in %a: !firrtl.uint<4>, in %b: !firrtl.uint<4>,
                                in %c: !firrtl.sint<4>, in %d: !firrtl.sint<4>) {

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -361,11 +361,15 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     // CHECK:      sv.ifdef @SYNTHESIS {
     // CHECK-NEXT: } else  {
-    // CHECK-NEXT:   %fd_file.txt = sv.reg : !hw.inout<i32>
+    // CHECK-NEXT:   %[[FD_0:.+]] = sv.reg : !hw.inout<i32>
+    // CHECK-NEXT:   %[[FD_1:.+]] = sv.reg name "fd_%m%c.txt" : !hw.inout<i32>
     // CHECK-NEXT:   sv.initial {
-    // CHECK-NEXT:     %[[FD:.+]] = sv.constantStr "file.txt"
-    // CHECK-NEXT:     %[[FD_RESULT:.+]] = sv.func.call.procedural @"__circt_lib_logging::FileDescriptor::get"(%[[FD]]) : (!hw.string) -> i32
-    // CHECK-NEXT:     sv.bpassign %fd_file.txt, %[[FD_RESULT]] : i32
+    // CHECK-NEXT:     %[[FILE_NAME:.+]] = sv.constantStr "file.txt"
+    // CHECK-NEXT:     %[[FD_RESULT:.+]] = sv.func.call.procedural @"__circt_lib_logging::FileDescriptor::get"(%[[FILE_NAME]]) : (!hw.string) -> i32
+    // CHECK-NEXT:     sv.bpassign %[[FD_0]], %[[FD_RESULT]] : i32
+    // CHECK-NEXT:     %[[FILE_NAME:.+]] = sv.sformatf "%m%c.txt"(%c97_i8)
+    // CHECK-NEXT:     %[[FD_RESULT:.+]] = sv.func.call.procedural @"__circt_lib_logging::FileDescriptor::get"(%[[FILE_NAME]]) : (!hw.string) -> i32
+    // CHECK-NEXT:     sv.bpassign %[[FD_1]], %[[FD_RESULT]] : i32
     // CHECK-NEXT:   }
     // CHECK-NEXT:   sv.always posedge [[CLOCK]] {
     // CHECK-NEXT:     %[[PRINTF_COND:.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
@@ -420,6 +424,22 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT:       [[TIME:%.+]] = sv.system.time : i64
     // CHECK-NEXT:       sv.fwrite %[[FPRINTF_FD_]], "[%0t]: %d %m"([[TIME]], %a) : i64, i4
     // CHECK-NEXT:     }
+    // CHECK-NEXT:     [[COND:%.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin [[COND]], %reset : i1
+    // CHECK-NEXT:     sv.if [[AND]] {
+    // CHECK-NEXT:       [[FD_STATIC:%.+]] = sv.read_inout %[[FD_1]] : !hw.inout<i32>
+    // CHECK-NEXT:       [[TIME:%.+]] = sv.system.time : i64
+    // CHECK-NEXT:       sv.fwrite [[FD_STATIC]], "[%0t]: static file name (w/ substitution)\0A"([[TIME]]) : i64
+    // CHECK-NEXT:     }
+    // CHECK-NEXT:     [[COND:%.+]] = sv.macro.ref.expr @PRINTF_COND_() : () -> i1
+    // CHECK-NEXT:     [[AND:%.+]] = comb.and bin [[COND]], %reset : i1
+    // CHECK-NEXT:     sv.if [[AND]] {
+    // CHECK-NEXT:       [[TIME:%.+]] = sv.system.time : i64
+    // CHECK-NEXT:       [[FNAME:%.+]] = sv.sformatf "%0t%d.txt"([[TIME]], %a) : i64, i4
+    // CHECK-NEXT:       [[FD_DYN:%.+]] = sv.func.call.procedural @"__circt_lib_logging::FileDescriptor::get"([[FNAME]]) : (!hw.string) -> i32
+    // CHECK-NEXT:       [[TIME:%.+]] = sv.system.time : i64
+    // CHECK-NEXT:       sv.fwrite [[FD_DYN]], "[%0t]: dynamic file name\0A"([[TIME]]) : i64
+    // CHECK-NEXT:     }
     // CHECK-NEXT:   }
     // CHECK-NEXT: }
     firrtl.printf %clock, %reset, "No operands and literal: %%\0A" : !firrtl.clock, !firrtl.uint<1>
@@ -443,8 +463,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.printf %clock, %reset, "[{{}}]: %d {{}}" (%time, %a, %hierarchicalmodulename) : !firrtl.clock, !firrtl.uint<1>, !firrtl.fstring, !firrtl.uint<4>, !firrtl.fstring
 
     firrtl.fprintf %clock, %reset, "file.txt", "[{{}}]: %d {{}}" (%time, %a, %hierarchicalmodulename) : !firrtl.clock, !firrtl.uint<1>, !firrtl.fstring, !firrtl.uint<4>, !firrtl.fstring
-
-
+    %c97_ui8 = firrtl.constant 97 : !firrtl.uint<8>
+    firrtl.fprintf %clock, %reset, "{{}}%c.txt"(%hierarchicalmodulename, %c97_ui8), "[{{}}]: static file name (w/ substitution)\0A"(%time) : !firrtl.clock, !firrtl.uint<1>, !firrtl.fstring, !firrtl.uint<8>, !firrtl.fstring
+    firrtl.fprintf %clock, %reset, "{{}}%d.txt"(%time, %a), "[{{}}]: dynamic file name\0A"(%time) : !firrtl.clock, !firrtl.uint<1>, !firrtl.fstring, !firrtl.uint<4>, !firrtl.fstring
     firrtl.skip
 
     // CHECK: hw.output

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -116,8 +116,8 @@ firrtl.circuit "Foo" {
     firrtl.skip
     // CHECK: printf(someClock, ui1, "some\n magic\"stuff\"") : foo
     firrtl.printf %someClock, %ui1, "some\n magic\"stuff\"" {name = "foo"} (%ui1, %someReset) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.reset
-    // CHECK: fprintf(someClock, ui1, "test.txt", "some\n magic\"stuff\"") : foo
-    firrtl.fprintf %someClock, %ui1, "test.txt"(%ui1), "some\n magic\"stuff\"" (%ui1, %someReset) {name = "foo"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.reset
+    // CHECK: fprintf(someClock, ui1, "test%d.txt", ui1, "some\n magic\"stuff\"") : foo
+    firrtl.fprintf %someClock, %ui1, "test%d.txt"(%ui1), "some\n magic\"stuff\"" (%ui1, %someReset) {name = "foo"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.reset
     // CHECK: assert(someClock, ui1, ui1, "msg") : foo
     // CHECK: assume(someClock, ui1, ui1, "msg") : foo
     // CHECK: cover(someClock, ui1, ui1, "msg") : foo

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -117,7 +117,7 @@ firrtl.circuit "Foo" {
     // CHECK: printf(someClock, ui1, "some\n magic\"stuff\"") : foo
     firrtl.printf %someClock, %ui1, "some\n magic\"stuff\"" {name = "foo"} (%ui1, %someReset) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.reset
     // CHECK: fprintf(someClock, ui1, "test.txt", "some\n magic\"stuff\"") : foo
-    firrtl.fprintf %someClock, %ui1, "test.txt", "some\n magic\"stuff\"" {name = "foo"} (%ui1, %someReset) : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.reset
+    firrtl.fprintf %someClock, %ui1, "test.txt"(%ui1), "some\n magic\"stuff\"" (%ui1, %someReset) {name = "foo"} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.reset
     // CHECK: assert(someClock, ui1, ui1, "msg") : foo
     // CHECK: assume(someClock, ui1, ui1, "msg") : foo
     // CHECK: cover(someClock, ui1, ui1, "msg") : foo

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2083,10 +2083,19 @@ FIRRTL version 5.1.0
 circuit Foo:
   public module Foo:
     input clock: Clock
-    ; CHECK:            %[[TIME:.+]] = firrtl.fstring.time : !firrtl.fstring
-    ; CHECK:            %[[HIERARCHICALMODULENAME:.+]] = firrtl.fstring.hierarchicalmodulename : !firrtl.fstring
-    ; CHECK{{LITERAL}}: firrtl.fprintf %clock, %c1_ui1, "test.txt", "[{{}}]: hello world {{}}"(%[[TIME]], %[[HIERARCHICALMODULENAME]])
-    fprintf(clock, UInt<1>(1), "test.txt", "[{{SimulationTime}}]: hello from {{HierarchicalModuleName}}")
+    ; CHECK:            %[[HIERARCHICALMODULENAME_0:.+]] = firrtl.fstring.hierarchicalmodulename : !firrtl.fstring
+    ; CHECK-NEXT:       %[[TIME:.+]] = firrtl.fstring.time : !firrtl.fstring
+    ; CHECK-NEXT:       %[[HIERARCHICALMODULENAME_1:.+]] = firrtl.fstring.hierarchicalmodulename : !firrtl.fstring
+    ; CHECK{{LITERAL}}: firrtl.fprintf %clock, %c1_ui1, "{{}}.txt" (%[[HIERARCHICALMODULENAME_0]]), "[{{}}]: hello world {{}}"(%[[TIME]], %[[HIERARCHICALMODULENAME_1]])
+    fprintf(clock, UInt<1>(1), "{{HierarchicalModuleName}}.txt", "[{{SimulationTime}}]: hello from {{HierarchicalModuleName}}")
+
+;// -----
+FIRRTL version 5.1.0
+circuit Foo:
+  public module Foo:
+    input clock: Clock
+    ; expected-error @+1 {{Only a hierarchical module name can be used as a substitution for fprintf output file name}}
+    fprintf(clock, UInt<1>(1), "{{SimulationTime}}.txt", "hello")
 
 ;// -----
 FIRRTL version 5.0.0

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2083,19 +2083,14 @@ FIRRTL version 5.1.0
 circuit Foo:
   public module Foo:
     input clock: Clock
+    input c: UInt<8>
     ; CHECK:            %[[HIERARCHICALMODULENAME_0:.+]] = firrtl.fstring.hierarchicalmodulename : !firrtl.fstring
-    ; CHECK-NEXT:       %[[TIME:.+]] = firrtl.fstring.time : !firrtl.fstring
+    ; CHECK-NEXT:       %[[TIME_0:.+]] = firrtl.fstring.time : !firrtl.fstring
+    ; CHECK-NEXT:       %[[TIME_1:.+]] = firrtl.fstring.time : !firrtl.fstring
     ; CHECK-NEXT:       %[[HIERARCHICALMODULENAME_1:.+]] = firrtl.fstring.hierarchicalmodulename : !firrtl.fstring
-    ; CHECK{{LITERAL}}: firrtl.fprintf %clock, %c1_ui1, "{{}}.txt" (%[[HIERARCHICALMODULENAME_0]]), "[{{}}]: hello world {{}}"(%[[TIME]], %[[HIERARCHICALMODULENAME_1]])
-    fprintf(clock, UInt<1>(1), "{{HierarchicalModuleName}}.txt", "[{{SimulationTime}}]: hello from {{HierarchicalModuleName}}")
-
-;// -----
-FIRRTL version 5.1.0
-circuit Foo:
-  public module Foo:
-    input clock: Clock
-    ; expected-error @+1 {{Only a hierarchical module name can be used as a substitution for fprintf output file name}}
-    fprintf(clock, UInt<1>(1), "{{SimulationTime}}.txt", "hello")
+    ; CHECK{{LITERAL}}:      firrtl.fprintf %clock, %c1_ui1, "{{}}{{}}%d.txt" (%[[HIERARCHICALMODULENAME_0]], %[[TIME_0]], %c),
+    ; CHECK-SAME{{LITERAL}}:   "[{{}}]: hello world {{}}"(%[[TIME_1]], %[[HIERARCHICALMODULENAME_1]])
+    fprintf(clock, UInt<1>(1), "{{HierarchicalModuleName}}{{SimulationTime}}%d.txt", c, "[{{SimulationTime}}]: hello from {{HierarchicalModuleName}}")
 
 ;// -----
 FIRRTL version 5.0.0

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -430,3 +430,9 @@ hw.module @test_open_array(in %clock : i1, in %in_0 : i8, in %in_1 : i8) {
     sv.func.call.procedural @open_array(%1) : (!sv.open_uarray<i8>) -> ()
   }
 }
+
+// CHECK-LABEL: hw.module @test_sformatf(in %a : i8) {
+// CHECK-NEXT:  sv.sformatf "foo%d"(%a) : i8
+hw.module @test_sformatf(in %a : i8) {
+  %0 = sv.sformatf "foo%d"(%a) : i8
+}

--- a/test/firtool/print.fir
+++ b/test/firtool/print.fir
@@ -55,7 +55,7 @@ circuit PrintTest:
     fprintf(clock, cond, "test.txt", "[{{SimulationTime}}]: {{HierarchicalModuleName}}\n")
 
     ; CHECK-NEXT: $fwrite([[FD_0]], "static file name (w/o substitution)\n");
-    fprintf(clock, cond, "test.txt", a, "static file name (w/o substitution)\n")
+    fprintf(clock, cond, "test.txt", "static file name (w/o substitution)\n")
 
     node c = UInt<8>(97)
     ; CHECK-NEXT: $fwrite([[FD_1]], "[%0t]: static file name (w/ substitution)\n", $time);

--- a/test/firtool/print.fir
+++ b/test/firtool/print.fir
@@ -23,8 +23,10 @@ circuit PrintTest:
     input a : UInt<8>
 
     ; CHECK:       reg [31:0] fd_test_txt;
+    ; CHECK-NEXT:  reg [31:0] fd_25m_txt;
     ; CHECK-NEXT:  initial begin
     ; CHECK-NEXT:    fd_test_txt = __circt_lib_logging::FileDescriptor::get("test.txt");
+    ; CHECK-NEXT:    fd_25m_txt = __circt_lib_logging::FileDescriptor::get($sformatf("%m.txt"));
     ; CHECK-NEXT:  end
 
     ; CHECK: $fwrite(`PRINTF_FD_, "binary: %b %0b %8b\n", a, a, a);
@@ -48,5 +50,7 @@ circuit PrintTest:
     ; CHECK-NEXT: $fwrite(fd_test_txt, "hello");
     fprintf(clock, cond, "test.txt", "hello")
 
-    ; CHECK-NEXT:         $fwrite(fd_test_txt, "[%0t]: %m\n", $time);
+    ; CHECK-NEXT: $fwrite(fd_test_txt, "[%0t]: %m\n", $time);
     fprintf(clock, cond, "test.txt", "[{{SimulationTime}}]: {{HierarchicalModuleName}}\n")
+    ; CHECK-NEXT: $fwrite(fd_25m_txt, "[%0t]: %m\n", $time);
+    fprintf(clock, cond, "{{HierarchicalModuleName}}.txt", "[{{SimulationTime}}]: {{HierarchicalModuleName}}\n")

--- a/test/firtool/print.fir
+++ b/test/firtool/print.fir
@@ -22,11 +22,12 @@ circuit PrintTest:
     input cond : UInt<1>
     input a : UInt<8>
 
-    ; CHECK:       reg [31:0] fd_test_txt;
-    ; CHECK-NEXT:  reg [31:0] fd_25m_txt;
+    ; CHECK:       reg [31:0] [[FD_0:[a-zA-Z0-9_]+]];
+    ; CHECK-NEXT:  reg [31:0] [[FD_1:[a-zA-Z0-9_]+]];
     ; CHECK-NEXT:  initial begin
-    ; CHECK-NEXT:    fd_test_txt = __circt_lib_logging::FileDescriptor::get("test.txt");
-    ; CHECK-NEXT:    fd_25m_txt = __circt_lib_logging::FileDescriptor::get($sformatf("%m.txt"));
+    ; CHECK-NEXT:    [[FD_0]] = __circt_lib_logging::FileDescriptor::get("test.txt");
+    ; CHECK-NEXT:    [[FD_1]] = __circt_lib_logging::FileDescriptor::get($sformatf("%m%c.txt",
+    ; CHECK-NEXT:                    8'h61));
     ; CHECK-NEXT:  end
 
     ; CHECK: $fwrite(`PRINTF_FD_, "binary: %b %0b %8b\n", a, a, a);
@@ -47,10 +48,22 @@ circuit PrintTest:
     ; CHECK-NEXT: $fwrite(`PRINTF_FD_, "[%0t]: %m\n", $time);
     printf(clock, cond, "[{{SimulationTime}}]: {{HierarchicalModuleName}}\n")
     
-    ; CHECK-NEXT: $fwrite(fd_test_txt, "hello");
+    ; CHECK-NEXT: $fwrite([[FD_0]], "hello");
     fprintf(clock, cond, "test.txt", "hello")
 
-    ; CHECK-NEXT: $fwrite(fd_test_txt, "[%0t]: %m\n", $time);
+    ; CHECK-NEXT: $fwrite([[FD_0]], "[%0t]: %m\n", $time);
     fprintf(clock, cond, "test.txt", "[{{SimulationTime}}]: {{HierarchicalModuleName}}\n")
-    ; CHECK-NEXT: $fwrite(fd_25m_txt, "[%0t]: %m\n", $time);
-    fprintf(clock, cond, "{{HierarchicalModuleName}}.txt", "[{{SimulationTime}}]: {{HierarchicalModuleName}}\n")
+
+    ; CHECK-NEXT: $fwrite([[FD_0]], "static file name (w/o substitution)\n");
+    fprintf(clock, cond, "test.txt", a, "static file name (w/o substitution)\n")
+
+    node c = UInt<8>(97)
+    ; CHECK-NEXT: $fwrite([[FD_1]], "[%0t]: static file name (w/ substitution)\n", $time);
+    fprintf(clock, cond, "{{HierarchicalModuleName}}%c.txt", c, "[{{SimulationTime}}]: static file name (w/ substitution)\n")
+
+    ; CHECK-NEXT: [[FD_2:[a-zA-Z0-9_]+]] = __circt_lib_logging::FileDescriptor::get($sformatf("%0t%d.txt",
+    ; CHECK-NEXT:                          $time,
+    ; CHECK-NEXT:                          a));
+    ; CHECK-NEXT: $fwrite([[FD_2]],
+    ; CHECK-NEXT:         "[%0t]: dynamic file name\n", $time);
+    fprintf(clock, cond, "{{SimulationTime}}%d.txt", a, "[{{SimulationTime}}]: dynamic file name\n")


### PR DESCRIPTION
Add a new SFormatFOp operation to handle string formatting in SystemVerilog.
This operation produces a constant string literal and supports variable
substitutions. Also enhance FIRRTL fprintf operation by:
- Support dynamic file names in FIRRTL fprintf operations
- Replace FStringType with PrintfOperandType for output file substitutions
- Add SystemVerilog sformatf lowering for formatted file names
- Update file descriptor handling in emitter

It implements micro-optimization regarding FD creation. If the file is known to be static, the fd is initialized in initial block but for dynamic file name it opens fd just before its uses. 

```scala
FIRRTL version 5.1.0

circuit PrintTest:
  public module PrintTest :
    input clock : Clock
    input cond : UInt<1>
    input a : UInt<8>

    fprintf(clock, cond, "test.txt", "static file name (w/o substitution)\n")

    node c = UInt<8>(97)
    fprintf(clock, cond, "{{HierarchicalModuleName}}%c.txt", c, "[{{SimulationTime}}]: static file name (w/ substitution)\n")

    fprintf(clock, cond, "{{SimulationTime}}%d.txt", a, "[{{SimulationTime}}]: dynamic file name\n")
```

```verilog
module PrintTest(
  input       clock,
              cond,
  input [7:0] a
);

  logic [31:0] ___circt_lib_logging3A3AFileDescriptor3A3Aget_0;
  `ifndef SYNTHESIS
    reg [31:0] fd_test_txt;
    reg [31:0] fd_25m25c_txt;
    initial begin
      fd_test_txt = __circt_lib_logging::FileDescriptor::get("test.txt");
      fd_25m25c_txt = __circt_lib_logging::FileDescriptor::get($sformatf("%m%c.txt",
                                                                         8'h61));
    end // initial
    always @(posedge clock) begin
      if ((`PRINTF_COND_) & cond) begin
        $fwrite(fd_test_txt, "static file name (w/o substitution)\n");
        $fwrite(fd_25m25c_txt, "[%0t]: static file name (w/ substitution)\n", $time);
        ___circt_lib_logging3A3AFileDescriptor3A3Aget_0 = __circt_lib_logging::FileDescriptor::get($sformatf("%0t%d.txt",
                                                                                                             $time,
                                                                                                             a));
        $fwrite(___circt_lib_logging3A3AFileDescriptor3A3Aget_0,
                "[%0t]: dynamic file name\n", $time);
      end
    end // always @(posedge)
  `endif // not def SYNTHESIS
endmodule
```