### PR TITLE
[FIRRTL][SV] Add fflush operation

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -138,6 +138,30 @@ def FPrintFOp : FIRRTLOp<"fprintf", [AttrSizedOperandSegments]> {
   let hasCustomAssemblyFormat = 1;
 }
 
+def FFlushOp : FIRRTLOp<"fflush"> {
+  let summary = "FFlush statement";
+  let description = [{
+    This operation flushes the output buffer of the specified file descriptor. If
+    no file descriptor is specified, the output buffer of the default output
+    file descriptor is flushed.
+  }];
+
+  let arguments = (ins ClockType:$clock, UInt1Type:$cond, OptionalAttr<StrAttr>: $outputFile,
+                       Variadic<PrintfOperandType>:$outputFileSubstitutions);
+  let results = (outs);
+
+  let assemblyFormat = [{
+      $clock `,` $cond (`,` $outputFile `(` $outputFileSubstitutions^ `)`)?
+      attr-dict `:` type($clock) `,` type($cond) (`,` qualified(type($outputFileSubstitutions))^)?
+  }];
+  let hasVerifier = 1;
+  let builders = [
+    OpBuilder<(ins "Value":$clock, "Value":$cond), [{
+      build(odsBuilder, odsState, clock, cond, {}, ValueRange{});
+    }]>
+  ];
+}
+
 def SkipOp : FIRRTLOp<"skip", [Pure]> {
   let summary = "Skip statement";
   let description = [{

--- a/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLStatements.td
@@ -146,13 +146,15 @@ def FFlushOp : FIRRTLOp<"fflush"> {
     file descriptor is flushed.
   }];
 
-  let arguments = (ins ClockType:$clock, UInt1Type:$cond, OptionalAttr<StrAttr>: $outputFile,
+  let arguments = (ins ClockType:$clock, UInt1Type:$cond,
+                       OptionalAttr<StrAttr>: $outputFile,
                        Variadic<PrintfOperandType>:$outputFileSubstitutions);
   let results = (outs);
 
   let assemblyFormat = [{
       $clock `,` $cond (`,` $outputFile `(` $outputFileSubstitutions^ `)`)?
-      attr-dict `:` type($clock) `,` type($cond) (`,` qualified(type($outputFileSubstitutions))^)?
+      attr-dict `:` type($clock) `,` type($cond)
+      (`,` qualified(type($outputFileSubstitutions))^)?
   }];
   let hasVerifier = 1;
   let builders = [

--- a/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLVisitors.h
@@ -242,16 +242,17 @@ public:
     auto *thisCast = static_cast<ConcreteType *>(this);
     return TypeSwitch<Operation *, ResultType>(op)
         .template Case<AttachOp, ConnectOp, MatchingConnectOp, RefDefineOp,
-                       ForceOp, PrintFOp, FPrintFOp, SkipOp, StopOp, WhenOp,
-                       AssertOp, AssumeOp, CoverOp, PropAssignOp, RefForceOp,
-                       RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp,
-                       FPGAProbeIntrinsicOp, VerifAssertIntrinsicOp,
-                       VerifAssumeIntrinsicOp, UnclockedAssumeIntrinsicOp,
-                       VerifCoverIntrinsicOp, VerifRequireIntrinsicOp,
-                       VerifEnsureIntrinsicOp, LayerBlockOp, MatchOp,
-                       ViewIntrinsicOp, BindOp>([&](auto opNode) -> ResultType {
-          return thisCast->visitStmt(opNode, args...);
-        })
+                       ForceOp, PrintFOp, FPrintFOp, FFlushOp, SkipOp, StopOp,
+                       WhenOp, AssertOp, AssumeOp, CoverOp, PropAssignOp,
+                       RefForceOp, RefForceInitialOp, RefReleaseOp,
+                       RefReleaseInitialOp, FPGAProbeIntrinsicOp,
+                       VerifAssertIntrinsicOp, VerifAssumeIntrinsicOp,
+                       UnclockedAssumeIntrinsicOp, VerifCoverIntrinsicOp,
+                       VerifRequireIntrinsicOp, VerifEnsureIntrinsicOp,
+                       LayerBlockOp, MatchOp, ViewIntrinsicOp, BindOp>(
+            [&](auto opNode) -> ResultType {
+              return thisCast->visitStmt(opNode, args...);
+            })
         .Default([&](auto expr) -> ResultType {
           return thisCast->visitInvalidStmt(op, args...);
         });
@@ -281,6 +282,7 @@ public:
   HANDLE(ForceOp);
   HANDLE(PrintFOp);
   HANDLE(FPrintFOp);
+  HANDLE(FFlushOp);
   HANDLE(SkipOp);
   HANDLE(StopOp);
   HANDLE(WhenOp);

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -519,6 +519,24 @@ def FWriteOp : SVOp<"fwrite", [ProceduralOp]> {
   }];
 }
 
+def FFlushOp : SVOp<"fflush", [ProceduralOp]> {
+  let summary = "'$fflush' statement";
+
+  let description = [{
+    The $fflush system task flushes the output buffer of the specified file
+    descriptor. If no file descriptor is specified, all open files are flushed.
+
+    See IEEE 1800-2023 Section 21.3.6.
+  }];
+
+  let arguments = (ins Optional<I32>:$fd);
+  let results = (outs);
+
+  let assemblyFormat = [{
+     (`fd` $fd^)? attr-dict
+  }];
+}
+
 def VerbatimOp : SVOp<"verbatim"> {
   let summary = "Verbatim opaque text emitted inline.";
   let description = [{

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -40,8 +40,8 @@ public:
             AlwaysCombOp, AlwaysFFOp, InitialOp, CaseOp,
             // Other Statements.
             AssignOp, BPAssignOp, PAssignOp, ForceOp, ReleaseOp, AliasOp,
-            FWriteOp, SystemFunctionOp, VerbatimOp, MacroRefOp, FuncCallOp,
-            FuncCallProceduralOp, ReturnOp, IncludeOp,
+            FWriteOp, FFlushOp, SystemFunctionOp, VerbatimOp, MacroRefOp,
+            FuncCallOp, FuncCallProceduralOp, ReturnOp, IncludeOp,
             // Type declarations.
             InterfaceOp, InterfaceSignalOp, InterfaceModportOp,
             InterfaceInstanceOp, GetModportOp, AssignInterfaceSignalOp,
@@ -135,6 +135,7 @@ public:
   HANDLE(ReleaseOp, Unhandled);
   HANDLE(AliasOp, Unhandled);
   HANDLE(FWriteOp, Unhandled);
+  HANDLE(FFlushOp, Unhandled);
   HANDLE(SystemFunctionOp, Unhandled);
   HANDLE(FuncCallProceduralOp, Unhandled);
   HANDLE(FuncCallOp, Unhandled);

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -87,6 +87,7 @@ struct Emitter {
   void emitPrintfLike(T op, StringAttr fileName);
   void emitStatement(PrintFOp op);
   void emitStatement(FPrintFOp op);
+  void emitStatement(FFlushOp op);
   void emitStatement(ConnectOp op);
   void emitStatement(MatchingConnectOp op);
   void emitStatement(PropAssignOp op);
@@ -713,12 +714,12 @@ void Emitter::emitStatementsInBlock(Block &block) {
       continue;
     TypeSwitch<Operation *>(&bodyOp)
         .Case<WhenOp, WireOp, RegOp, RegResetOp, NodeOp, StopOp, SkipOp,
-              PrintFOp, FPrintFOp, AssertOp, AssumeOp, CoverOp, ConnectOp,
-              MatchingConnectOp, PropAssignOp, InstanceOp, InstanceChoiceOp,
-              AttachOp, MemOp, InvalidValueOp, SeqMemOp, CombMemOp,
-              MemoryPortOp, MemoryDebugPortOp, MemoryPortAccessOp, RefDefineOp,
-              RefForceOp, RefForceInitialOp, RefReleaseOp, RefReleaseInitialOp,
-              LayerBlockOp, GenericIntrinsicOp>(
+              PrintFOp, FPrintFOp, FFlushOp, AssertOp, AssumeOp, CoverOp,
+              ConnectOp, MatchingConnectOp, PropAssignOp, InstanceOp,
+              InstanceChoiceOp, AttachOp, MemOp, InvalidValueOp, SeqMemOp,
+              CombMemOp, MemoryPortOp, MemoryDebugPortOp, MemoryPortAccessOp,
+              RefDefineOp, RefForceOp, RefForceInitialOp, RefReleaseOp,
+              RefReleaseInitialOp, LayerBlockOp, GenericIntrinsicOp>(
             [&](auto op) { emitStatement(op); })
         .Default([&](auto op) {
           startStatement();
@@ -968,6 +969,28 @@ void Emitter::emitStatement(FPrintFOp op) {
     if (!op.getName().empty()) {
       ps << PP::space << ": " << PPExtString(legalize(op.getNameAttr()));
     }
+  });
+  emitLocationAndNewLine(op);
+}
+
+void Emitter::emitStatement(FFlushOp op) {
+  startStatement();
+  ps.scopedBox(PP::ibox2, [&]() {
+    ps << "fflush(" << PP::ibox0;
+    emitExpression(op.getClock());
+    ps << "," << PP::space;
+    emitExpression(op.getCond());
+    if (op.getOutputFileAttr()) {
+      ps << "," << PP::space;
+      SmallVector<Value, 4> substitutions;
+      emitFormatString(op, op.getOutputFileAttr(),
+                       op.getOutputFileSubstitutions(), substitutions);
+      for (auto operand : substitutions) {
+        ps << "," << PP::space;
+        emitExpression(operand);
+      }
+    }
+    ps << ")" << PP::end;
   });
   emitLocationAndNewLine(op);
 }

--- a/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
+++ b/lib/Dialect/FIRRTL/Export/FIREmitter.cpp
@@ -985,9 +985,9 @@ void Emitter::emitStatement(FFlushOp op) {
       SmallVector<Value, 4> substitutions;
       emitFormatString(op, op.getOutputFileAttr(),
                        op.getOutputFileSubstitutions(), substitutions);
-      for (auto operand : substitutions) {
+      if (!substitutions.empty()) {
         ps << "," << PP::space;
-        emitExpression(operand);
+        interleaveComma(substitutions);
       }
     }
     ps << ")" << PP::end;

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -6510,6 +6510,16 @@ void FPrintFOp::print(OpAsmPrinter &p) {
 }
 
 //===----------------------------------------------------------------------===//
+// FFlushOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult FFlushOp::verify() {
+  if (!getOutputFileAttr() && !getOutputFileSubstitutions().empty())
+    return emitOpError("substitutions without output file are not allowed");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // BindOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
+++ b/lib/Dialect/FIRRTL/Import/FIRTokenKinds.def
@@ -169,6 +169,7 @@ TOK_KEYWORD(write)
 // FIRToken::lp_foo enums.
 TOK_LPKEYWORD(printf)
 TOK_LPKEYWORD(fprintf)
+TOK_LPKEYWORD(fflush)
 TOK_LPKEYWORD(stop)
 TOK_LPKEYWORD(assert)
 TOK_LPKEYWORD(assume)

--- a/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExpandWhens.cpp
@@ -532,6 +532,7 @@ public:
   void visitStmt(ModuleOp op);
   void visitStmt(PrintFOp op);
   void visitStmt(FPrintFOp op);
+  void visitStmt(FFlushOp op);
   void visitStmt(StopOp op);
   void visitStmt(WhenOp op);
   void visitStmt(LayerBlockOp op);
@@ -642,6 +643,10 @@ void WhenOpVisitor::visitStmt(PrintFOp op) {
 }
 
 void WhenOpVisitor::visitStmt(FPrintFOp op) {
+  op.getCondMutable().assign(andWithCondition(op, op.getCond()));
+}
+
+void WhenOpVisitor::visitStmt(FFlushOp op) {
   op.getCondMutable().assign(andWithCondition(op, op.getCond()));
 }
 

--- a/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferWidths.cpp
@@ -1596,7 +1596,7 @@ LogicalResult InferenceMapping::mapOperation(Operation *op) {
       })
 
       // Handle the no-ops that don't interact with width inference.
-      .Case<PrintFOp, SkipOp, StopOp, WhenOp, AssertOp, AssumeOp,
+      .Case<PrintFOp, FFlushOp, SkipOp, StopOp, WhenOp, AssertOp, AssumeOp,
             UnclockedAssumeIntrinsicOp, CoverOp>([&](auto) {})
 
       // Handle instances of other modules.

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -273,6 +273,10 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
       // CHECK-NEXT: `INIT_RANDOM(val, val, val)
       sv.macro.ref @INIT_RANDOM (%val, %val, %val) : i8, i8, i8
 
+      // CHECK-NEXT: $fflush();
+      sv.fflush
+      // CHECK-NEXT: $fflush(32'h80000002);
+      sv.fflush fd %fd
     }// CHECK-NEXT:   {{end$}}
   } {sv.attributes = [#sv.attribute<"sv attr">]}
   // CHECK-NEXT:  end // initial

--- a/test/Dialect/FIRRTL/emit-basic.mlir
+++ b/test/Dialect/FIRRTL/emit-basic.mlir
@@ -921,6 +921,12 @@ firrtl.circuit "Foo" {
 
     // CHECK: fprintf(clock, UInt<1>(1), "test.txt", "%%")
     firrtl.fprintf %clock, %c1_ui1, "test.txt", "%%" : !firrtl.clock, !firrtl.const.uint<1>
-  }
 
+    // CHECK: fflush(clock, UInt<1>(1))
+    firrtl.fflush %clock, %c1_ui1 : !firrtl.clock, !firrtl.const.uint<1>
+
+    // CHECK{LITERAL}: fflush(clock, UInt<1>(1), "test%d{{SimulationTime}}.txt", UInt<1>(1))
+    %time = firrtl.fstring.time : !firrtl.fstring
+    firrtl.fflush %clock, %c1_ui1, "test%d{{}}.txt"(%c1_ui1, %time) : !firrtl.clock, !firrtl.const.uint<1>, !firrtl.const.uint<1>, !firrtl.fstring
+  }
 }

--- a/test/Dialect/FIRRTL/expand-whens.mlir
+++ b/test/Dialect/FIRRTL/expand-whens.mlir
@@ -39,6 +39,7 @@ firrtl.module @simulation(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, in
   firrtl.when %p : !firrtl.uint<1> {
     firrtl.printf %clock, %enable, "CIRCT Rocks!" : !firrtl.clock, !firrtl.uint<1>
     firrtl.fprintf %clock, %enable, "test.txt", "CIRCT Rocks!" : !firrtl.clock, !firrtl.uint<1>
+    firrtl.fflush %clock, %enable : !firrtl.clock, !firrtl.uint<1>
     firrtl.stop %clock, %enable, 0 : !firrtl.clock, !firrtl.uint<1>
     firrtl.assert %clock, %p, %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.assume %clock, %p, %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
@@ -47,6 +48,7 @@ firrtl.module @simulation(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, in
   } else {
     firrtl.printf %clock, %reset, "CIRCT Rocks!" : !firrtl.clock, !firrtl.uint<1>
     firrtl.fprintf %clock, %enable, "test.txt", "CIRCT Rocks!" : !firrtl.clock, !firrtl.uint<1>
+    firrtl.fflush %clock, %enable : !firrtl.clock, !firrtl.uint<1>
     firrtl.stop %clock, %enable, 1 : !firrtl.clock, !firrtl.uint<1>
     firrtl.assert %clock, %p, %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
     firrtl.assume %clock, %p, %enable, "" : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>
@@ -59,6 +61,8 @@ firrtl.module @simulation(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, in
 // CHECK-NEXT:   firrtl.printf %clock, %[[PRINT_ENABLE]], "CIRCT Rocks!"  : !firrtl.clock, !firrtl.uint<1>
 // CHECK-NEXT:   %[[FPRINTF_ENABLE:.+]] = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.fprintf %clock, %[[FPRINTF_ENABLE]], "test.txt", "CIRCT Rocks!" : !firrtl.clock, !firrtl.uint<1>
+// CHECK-NEXT:   %[[FFLUSH_ENABLE:.+]] = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   firrtl.fflush %clock, %[[FFLUSH_ENABLE]] : !firrtl.clock, !firrtl.uint<1>
 // CHECK-NEXT:   %[[STOP_ENABLE:.+]] = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.stop %clock, %[[STOP_ENABLE]], 0 : !firrtl.clock, !firrtl.uint<1>
 // CHECK-NEXT:   %[[ASSERT_ENABLE:.+]] = firrtl.and %p, %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
@@ -74,6 +78,8 @@ firrtl.module @simulation(in %clock : !firrtl.clock, in %p : !firrtl.uint<1>, in
 // CHECK-NEXT:   firrtl.printf %clock, %[[ELSE_PRINT_ENABLE]], "CIRCT Rocks!"  : !firrtl.clock, !firrtl.uint<1>
 // CHECK-NEXT:   %[[ELSE_FPRINT_ENABLE:.+]] = firrtl.and %[[NOT_P]], %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.fprintf %clock, %[[ELSE_FPRINT_ENABLE]], "test.txt", "CIRCT Rocks!"  : !firrtl.clock, !firrtl.uint<1>
+// CHECK-NEXT:   %[[ELSE_FFLUSH_ENABLE:.+]] = firrtl.and %[[NOT_P]], %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
+// CHECK-NEXT:   firrtl.fflush %clock, %[[ELSE_FFLUSH_ENABLE]] : !firrtl.clock, !firrtl.uint<1>
 // CHECK-NEXT:   %[[ELSE_STOP_ENABLE:.+]] = firrtl.and %[[NOT_P]], %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>
 // CHECK-NEXT:   firrtl.stop %clock, %[[ELSE_STOP_ENABLE]], 1 : !firrtl.clock, !firrtl.uint<1>
 // CHECK-NEXT:   %[[ELSE_ASSERT_ENABLE:.+]] = firrtl.and %[[NOT_P]], %enable : (!firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<1>

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -2099,3 +2099,22 @@ circuit Foo:
     input clock: Clock
     ; expected-error @+1 {{fprintf are a FIRRTL 5.1.0+ feature, but the specified FIRRTL version was 5.0.0}}
     fprintf(clock, UInt<1>(1), "test.txt", "[{{SimulationTime}}]: hello from {{HierarchicalModuleName}}")
+
+;// -----
+FIRRTL version 5.1.0
+circuit Foo:
+  public module Foo:
+    input clock: Clock
+    ; CHECK: firrtl.fflush %clock, %c1_ui1
+    fflush(clock, UInt<1>(1))
+    ; CHECK: firrtl.fflush %clock, %c1_ui1
+    ; CHECK-SAME{{LITERAL}}: "{{}}{{}}%d.txt"(%hierarchicalmodulename, %time, %c), "[{{}}]: hello from {{}}"(%time_0, %hierarchicalmodulename_1) : !firrtl.clock, !firrtl.const.uint<1>, !firrtl.fstring, !firrtl.fstring, !firrtl.uint<8>, !firrtl.fstring, !firrtl.fstring
+    fflush(clock, UInt<1>(1), "foo%d{{HierarchicalModuleName}}.txt", UInt<1>(1))
+
+;// -----
+FIRRTL version 5.0.0
+circuit Foo:
+  public module Foo:
+    input clock: Clock
+    ; expected-error @+1 {{fflush are a FIRRTL 5.1.0+ feature, but the specified FIRRTL version was 5.0.0}}
+    fflush(clock, UInt<1>(1))

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -436,3 +436,13 @@ hw.module @test_open_array(in %clock : i1, in %in_0 : i8, in %in_1 : i8) {
 hw.module @test_sformatf(in %a : i8) {
   %0 = sv.sformatf "foo%d"(%a) : i8
 }
+
+// CHECK-LABEL: hw.module @test_fflush(in %a : i32) {
+// CHECK: sv.fflush
+// CHECK-NEXT: sv.fflush fd %a
+hw.module @test_fflush(in %a : i32) {
+  sv.initial {
+    sv.fflush
+    sv.fflush fd %a
+  }
+}

--- a/test/firtool/print.fir
+++ b/test/firtool/print.fir
@@ -67,3 +67,12 @@ circuit PrintTest:
     ; CHECK-NEXT: $fwrite([[FD_2]],
     ; CHECK-NEXT:         "[%0t]: dynamic file name\n", $time);
     fprintf(clock, cond, "{{SimulationTime}}%d.txt", a, "[{{SimulationTime}}]: dynamic file name\n")
+
+    ; CHECK-NEXT: $fflush(`PRINTF_FD_);
+    fflush(clock, cond)
+
+    ; CHECK-NEXT: [[FD_3:[a-zA-Z0-9_]+]] = __circt_lib_logging::FileDescriptor::get($sformatf("%0t%d.txt",
+    ; CHECK-NEXT:                          $time,
+    ; CHECK-NEXT:                          a));
+    ; CHECK-NEXT: $fflush([[FD_3]]);
+    fflush(clock, cond, "{{SimulationTime}}%d.txt", a);


### PR DESCRIPTION
Add support for fflush operation in FIRRTL and SV dialects. This operation maps to SystemVerilog's $fflush system task, which flushes buffered output to files.

The implementation adds FFlushOp to FIRRTL dialect with clock, condition operands and optional filename with substitutions, adds FFlushOp to SystemVerilog dialect with optional file descriptor, implements lowering from FIRRTL to SystemVerilog, guards fflush with #ifndef SYNTHESIS like other simulation constructs, and adds visitor pattern support in both dialects.

Similar to StopOp in implementation pattern and behavior.

```scala
circuit PrintTest:
  public module PrintTest :
    input clock : Clock
    input cond : UInt<1>
    input a : UInt<8>
    node c = UInt<8>(97)
    fflush(clock, cond)

    fflush(clock, cond, "{{SimulationTime}}%d.txt", a)
```

```verilog
module PrintTest(
  input       clock,
              cond,
  input [7:0] a
);

  logic [31:0] ___circt_lib_logging3A3AFileDescriptor3A3Aget_0;
  `ifndef SYNTHESIS
    always @(posedge clock) begin
      if ((`PRINTF_COND_) & cond) begin
        $fflush(`PRINTF_FD_);
        ___circt_lib_logging3A3AFileDescriptor3A3Aget_0 = __circt_lib_logging::FileDescriptor::get($sformatf("%0t%d.txt",
                                                                                                             $time,
                                                                                                             a));
        $fflush(___circt_lib_logging3A3AFileDescriptor3A3Aget_0);
      end
    end // always @(posedge)
  `endif // not def SYNTHESIS
endmodule
```