### PR TITLE
[Verif] Add pass to lower symbolic values

### DIFF
--- a/include/circt/Dialect/Verif/Passes.td
+++ b/include/circt/Dialect/Verif/Passes.td
@@ -63,6 +63,33 @@ def LowerContractsPass : Pass<"lower-contracts", "mlir::ModuleOp"> {
   }];
 }
 
+def LowerSymbolicValuesPass : Pass<"verif-lower-symbolic-values",
+                                   "mlir::ModuleOp"> {
+  let summary = "Lower symbolic values to blackbox instances or wires";
+  let description = [{
+    Converts `verif.symbolic_value` ops into one of the following
+    representations that formal tools can work with:
+
+    - Instances of an external module, which most formal tools can treat as an
+      internal port boundary with symbolic values assigned to the module
+      outputs.
+    - Wire declarations marked with `(* anyseq *)`, which Yosys treats like a
+      top-level input port.
+  }];
+  let options = [
+    Option<
+      "mode", "mode",
+      "SymbolicValueLowering", "SymbolicValueLowering::ExtModule",
+      "Control how symbolic values are lowered",
+      "symbolicValueLoweringCLValues()"
+    >,
+  ];
+  let dependentDialects = [
+    "hw::HWDialect",
+    "sv::SVDialect",
+  ];
+}
+
 def SimplifyAssumeEqPass : Pass<"simplify-assume-eq", "hw::HWModuleOp"> {
   let summary = "Use assume equal statements to simplify symbolic values";
   let description = [{

--- a/include/circt/Dialect/Verif/VerifPasses.h
+++ b/include/circt/Dialect/Verif/VerifPasses.h
@@ -14,6 +14,8 @@
 #ifndef CIRCT_DIALECT_VERIF_VERIFPASSES_H
 #define CIRCT_DIALECT_VERIF_VERIFPASSES_H
 
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/SV/SVDialect.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 #include <memory>
@@ -22,11 +24,24 @@ namespace circt {
 namespace verif {
 class FormalOp;
 class RequireLike;
-} // namespace verif
-} // namespace circt
 
-namespace circt {
-namespace verif {
+/// Ways to lower symbolic values.
+enum class SymbolicValueLowering {
+  /// Lower to instances of an external module.
+  ExtModule,
+  /// Lower to wire declarations with a `(* anyseq *)` attribute.
+  Yosys,
+};
+
+/// Construct the command line options to pick one of the symbolic value
+/// lowerings.
+static inline llvm::cl::ValuesClass symbolicValueLoweringCLValues() {
+  return llvm::cl::values(
+      clEnumValN(SymbolicValueLowering::ExtModule, "extmodule",
+                 "Lower to instances of an external module"),
+      clEnumValN(SymbolicValueLowering::Yosys, "yosys",
+                 "Lower to `(* anyseq *)` wire declarations"));
+}
 
 #define GEN_PASS_DECL
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -16,6 +16,7 @@
 #include "circt/Conversion/Passes.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/Seq/SeqPasses.h"
+#include "circt/Dialect/Verif/VerifPasses.h"
 #include "circt/Support/LLVM.h"
 #include "mlir/Pass/PassManager.h"
 #include "llvm/Support/CommandLine.h"
@@ -135,6 +136,10 @@ public:
   bool shouldDisableCSEinClasses() const { return disableCSEinClasses; }
   bool shouldSelectDefaultInstanceChoice() const {
     return selectDefaultInstanceChoice;
+  }
+
+  verif::SymbolicValueLowering getSymbolicValueLowering() const {
+    return symbolicValueLowering;
   }
 
   // Setters, used by the CAPI
@@ -376,6 +381,11 @@ public:
     return *this;
   }
 
+  FirtoolOptions &setSymbolicValueLowering(verif::SymbolicValueLowering mode) {
+    symbolicValueLowering = mode;
+    return *this;
+  }
+
 private:
   std::string outputFilename;
   bool disableAnnotationsUnknown;
@@ -425,6 +435,7 @@ private:
   bool addCompanionAssume;
   bool disableCSEinClasses;
   bool selectDefaultInstanceChoice;
+  verif::SymbolicValueLowering symbolicValueLowering;
 };
 
 void registerFirtoolCLOptions();

--- a/lib/Dialect/Verif/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Verif/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_dialect_library(CIRCTVerifTransforms
   LowerContracts.cpp
   LowerFormalToHW.cpp
+  LowerSymbolicValues.cpp
   PrepareForFormal.cpp
   SimplifyAssumeEq.cpp
   StripContracts.cpp
@@ -10,10 +11,11 @@ add_circt_dialect_library(CIRCTVerifTransforms
   CIRCTVerifTransformsIncGen
 
   LINK_LIBS PUBLIC
-  CIRCTVerif
-  CIRCTLTL
   CIRCTHW
+  CIRCTLTL
   CIRCTSupport
+  CIRCTSV
+  CIRCTVerif
   MLIRIR
   MLIRPass
   MLIRTransforms

--- a/lib/Dialect/Verif/Transforms/LowerSymbolicValues.cpp
+++ b/lib/Dialect/Verif/Transforms/LowerSymbolicValues.cpp
@@ -1,0 +1,115 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/Verif/VerifOps.h"
+#include "circt/Dialect/Verif/VerifPasses.h"
+
+using namespace circt;
+using namespace mlir;
+using namespace verif;
+using namespace hw;
+
+namespace circt {
+namespace verif {
+#define GEN_PASS_DEF_LOWERSYMBOLICVALUESPASS
+#include "circt/Dialect/Verif/Passes.h.inc"
+} // namespace verif
+} // namespace circt
+
+namespace {
+struct LowerSymbolicValuesPass
+    : verif::impl::LowerSymbolicValuesPassBase<LowerSymbolicValuesPass> {
+  using LowerSymbolicValuesPassBase::LowerSymbolicValuesPassBase;
+  void runOnOperation() override;
+  LogicalResult lowerToExtModule();
+  void lowerToAnySeqWire();
+};
+} // namespace
+
+void LowerSymbolicValuesPass::runOnOperation() {
+  switch (mode) {
+  case SymbolicValueLowering::ExtModule:
+    if (failed(lowerToExtModule()))
+      signalPassFailure();
+    break;
+  case SymbolicValueLowering::Yosys:
+    lowerToAnySeqWire();
+    break;
+  }
+}
+
+/// Replace all `SymbolicValueOp`s with instances of corresponding extmodules.
+/// This allows tools to treat the modules as blackboxes, or definitions of the
+/// modules may be provided later by the user.
+LogicalResult LowerSymbolicValuesPass::lowerToExtModule() {
+  auto &symbolTable = getAnalysis<SymbolTable>();
+  DenseMap<Type, HWModuleExternOp> extmoduleOps;
+  auto result = getOperation().walk([&](SymbolicValueOp op) -> WalkResult {
+    // Determine the number of bits needed for the symbolic value.
+    auto numBits = hw::getBitWidth(op.getType());
+    if (numBits < 0)
+      return op.emitError() << "symbolic value bit width unknown";
+
+    // If we don't already have an extmodule for this number of bits, create
+    // one.
+    auto builder = OpBuilder::atBlockEnd(getOperation().getBody());
+    auto flatType = builder.getIntegerType(numBits);
+    auto &extmoduleOp = extmoduleOps[flatType];
+    if (!extmoduleOp) {
+      extmoduleOp = builder.create<HWModuleExternOp>(
+          op.getLoc(),
+          builder.getStringAttr(Twine("circt.symbolic_value.") +
+                                Twine(numBits)),
+          PortInfo{{builder.getStringAttr("z"), flatType, ModulePort::Output}},
+          "circt_symbolic_value",
+          builder.getArrayAttr(ParamDeclAttr::get(
+              builder.getContext(), builder.getStringAttr("WIDTH"),
+              builder.getI32Type(), Attribute())));
+      symbolTable.insert(extmoduleOp);
+    }
+
+    // Instantiate the extmodule as a means of generating a symbolic value with
+    // the correct number of bits.
+    builder.setInsertionPoint(op);
+    auto instOp = builder.create<InstanceOp>(
+        op.getLoc(), extmoduleOp, builder.getStringAttr("symbolic_value"),
+        ArrayRef<Value>{},
+        builder.getArrayAttr(ParamDeclAttr::get(
+            builder.getContext(), builder.getStringAttr("WIDTH"),
+            builder.getI32Type(), builder.getI32IntegerAttr(numBits))));
+    Value value = instOp.getResult(0);
+
+    // Insert a bit cast if needed to obtain the original symbolic value's type.
+    if (op.getType() != value.getType())
+      value = builder.create<BitcastOp>(op.getLoc(), op.getType(), value);
+
+    // Replace the `verif.symbolic_value` op.
+    op.replaceAllUsesWith(value);
+    op.erase();
+    return success();
+  });
+  return failure(result.wasInterrupted());
+}
+
+/// Replace `SymbolicValueOp`s with an `(* anyseq *)` wire declaration.
+void LowerSymbolicValuesPass::lowerToAnySeqWire() {
+  getOperation().walk([&](SymbolicValueOp op) {
+    // Create a replacement wire declaration with a `(* anyseq *)` Verilog
+    // attribute.
+    OpBuilder builder(op);
+    auto wireOp = builder.create<sv::WireOp>(op.getLoc(), op.getType());
+    sv::addSVAttributes(wireOp,
+                        sv::SVAttributeAttr::get(&getContext(), "anyseq"));
+
+    // Create a read from the wire and replace the `verif.symbolic_value` op.
+    Value value = builder.create<sv::ReadInOutOp>(op.getLoc(), wireOp);
+    op.replaceAllUsesWith(value);
+    op.erase();
+  });
+}

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -306,6 +306,8 @@ LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
                                       const FirtoolOptions &opt) {
   pm.nestAny().addPass(verif::createStripContractsPass());
   pm.addPass(verif::createLowerFormalToHWPass());
+  pm.addPass(
+      verif::createLowerSymbolicValuesPass({opt.getSymbolicValueLowering()}));
 
   if (opt.shouldExtractTestCode())
     pm.addPass(sv::createSVExtractTestCodePass(
@@ -752,6 +754,12 @@ struct FirtoolCmdOptions {
       llvm::cl::desc(
           "Specialize instance choice to default, if no option selected"),
       llvm::cl::init(false)};
+
+  llvm::cl::opt<verif::SymbolicValueLowering> symbolicValueLowering{
+      "symbolic-values",
+      llvm::cl::desc("Control how symbolic values are lowered"),
+      llvm::cl::init(verif::SymbolicValueLowering::ExtModule),
+      verif::symbolicValueLoweringCLValues()};
 };
 } // namespace
 
@@ -840,4 +848,5 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   fixupEICGWrapper = clOptions->fixupEICGWrapper;
   addCompanionAssume = clOptions->addCompanionAssume;
   selectDefaultInstanceChoice = clOptions->selectDefaultInstanceChoice;
+  symbolicValueLowering = clOptions->symbolicValueLowering;
 }

--- a/test/Dialect/Verif/lower-symbolic-values-errors.mlir
+++ b/test/Dialect/Verif/lower-symbolic-values-errors.mlir
@@ -1,0 +1,6 @@
+// RUN: circt-opt --verif-lower-symbolic-values=mode=extmodule --split-input-file --verify-diagnostics %s
+
+hw.module @Foo() {
+  // expected-error @below {{symbolic value bit width unknown}}
+  verif.symbolic_value : !hw.string
+}

--- a/test/Dialect/Verif/lower-symbolic-values.mlir
+++ b/test/Dialect/Verif/lower-symbolic-values.mlir
@@ -1,0 +1,46 @@
+// RUN: circt-opt --verif-lower-symbolic-values=mode=extmodule %s | FileCheck --check-prefixes=CHECK,CHECK-EXTMODULE %s
+// RUN: circt-opt --verif-lower-symbolic-values=mode=yosys %s | FileCheck --check-prefixes=CHECK,CHECK-YOSYS %s
+
+// CHECK-LABEL: hw.module @Foo
+hw.module @Foo() {
+  // CHECK-EXTMODULE-NOT: verif.symbolic_value
+  // CHECK-YOSYS-NOT: verif.symbolic_value
+
+  // CHECK-EXTMODULE: [[SYM:%.+]] = hw.instance {{.*}} @circt.symbolic_value.42<WIDTH: i32 = 42>
+  // CHECK-YOSYS: [[TMP:%.+]] = sv.wire {sv.attributes = [#sv.attribute<"anyseq">]} : !hw.inout<i42>
+  // CHECK-YOSYS: [[SYM:%.+]] = sv.read_inout [[TMP]]
+  // CHECK: dbg.variable "x0", [[SYM]] : i42
+  %0 = verif.symbolic_value : i42
+  dbg.variable "x0", %0 : i42
+
+  // CHECK-EXTMODULE: [[TMP:%.+]] = hw.instance {{.*}} @circt.symbolic_value.12<WIDTH: i32 = 12>
+  // CHECK-EXTMODULE: [[SYM:%.+]] = hw.bitcast [[TMP]] : (i12) -> !hw.array<4xi3>
+  // CHECK-YOSYS: [[TMP:%.+]] = sv.wire {sv.attributes = [#sv.attribute<"anyseq">]} : !hw.inout<array<4xi3>>
+  // CHECK-YOSYS: [[SYM:%.+]] = sv.read_inout [[TMP]]
+  // CHECK: dbg.variable "x1", [[SYM]] : !hw.array<4xi3>
+  %1 = verif.symbolic_value : !hw.array<4xi3>
+  dbg.variable "x1", %1 : !hw.array<4xi3>
+
+  // Reuse existing extmodule for same i42 type.
+  // CHECK-EXTMODULE: [[SYM:%.+]] = hw.instance {{.*}} @circt.symbolic_value.42<WIDTH: i32 = 42>
+  // CHECK-YOSYS: [[TMP:%.+]] = sv.wire {sv.attributes = [#sv.attribute<"anyseq">]} : !hw.inout<i42>
+  // CHECK-YOSYS: [[SYM:%.+]] = sv.read_inout [[TMP]]
+  // CHECK: dbg.variable "x2", [[SYM]] : i42
+  %2 = verif.symbolic_value : i42
+  dbg.variable "x2", %2 : i42
+
+  // Reuse existing extmodule for same 42 bit types, cast to array<6 x i7>.
+  // CHECK-EXTMODULE: [[TMP:%.+]] = hw.instance {{.*}} @circt.symbolic_value.42<WIDTH: i32 = 42>
+  // CHECK-EXTMODULE: [[SYM:%.+]] = hw.bitcast [[TMP]] : (i42) -> !hw.array<6xi7>
+  // CHECK-YOSYS: [[TMP:%.+]] = sv.wire {sv.attributes = [#sv.attribute<"anyseq">]} : !hw.inout<array<6xi7>>
+  // CHECK-YOSYS: [[SYM:%.+]] = sv.read_inout [[TMP]]
+  // CHECK: dbg.variable "x3", [[SYM]] : !hw.array<6xi7>
+  %3 = verif.symbolic_value : !hw.array<6xi7>
+  dbg.variable "x3", %3 : !hw.array<6xi7>
+}
+
+// CHECK-EXTMODULE: hw.module.extern @circt.symbolic_value.42<WIDTH: i32>
+// CHECK-EXTMODULE-SAME: verilogName = "circt_symbolic_value"
+
+// CHECK-EXTMODULE: hw.module.extern @circt.symbolic_value.12<WIDTH: i32>
+// CHECK-EXTMODULE-SAME: verilogName = "circt_symbolic_value"

--- a/tools/circt-test/circt-test.cpp
+++ b/tools/circt-test/circt-test.cpp
@@ -94,6 +94,11 @@ struct Options {
       cl::desc("Do not use contracts to simplify and parallelize tests"),
       cl::init(false), cl::cat(cat)};
 
+  cl::opt<verif::SymbolicValueLowering> symbolicValueLowering{
+      "symbolic-values", cl::desc("Control how symbolic values are lowered"),
+      cl::init(verif::SymbolicValueLowering::ExtModule),
+      verif::symbolicValueLoweringCLValues(), cl::cat(cat)};
+
   cl::opt<bool> emitIR{"ir", cl::desc("Emit IR after initial lowering"),
                        cl::init(false), cl::cat(cat)};
 
@@ -492,6 +497,8 @@ static LogicalResult executeWithHandler(MLIRContext *context,
   PassManager pm(context);
   pm.enableVerifier(opts.verifyPasses);
   pm.addPass(verif::createLowerFormalToHWPass());
+  pm.addPass(
+      verif::createLowerSymbolicValuesPass({opts.symbolicValueLowering}));
   pm.addPass(createLowerSimToSVPass());
   pm.addPass(createLowerSeqToSVPass());
   pm.addNestedPass<hw::HWModuleOp>(createLowerVerifToSVPass());


### PR DESCRIPTION
Add the `LowerSymbolicValues` pass which converts `verif.symbolic_value` ops either to a black box instance or to a wire declaration with a `(* anyseq *)` attribute. The former is useful since most formal tools have a way of treating black boxes as internal port boundaries, such that black box output ports behave the same as top-level input ports. The latter is useful for interoperability with Yosys which has a custom Verilog attribute "anyseq" that marks a wire declaration as a symbolic value.