### PR TITLE
[FIRRTL] Dedup: dedup wires when only one has a symbol

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -109,15 +109,15 @@ struct StructuralHasherSharedConstants {
   explicit StructuralHasherSharedConstants(MLIRContext *context) {
     portTypesAttr = StringAttr::get(context, "portTypes");
     moduleNameAttr = StringAttr::get(context, "moduleName");
-    innerSymAttr = StringAttr::get(context, "inner_sym");
-    portSymbolsAttr = StringAttr::get(context, "portSymbols");
     portNamesAttr = StringAttr::get(context, "portNames");
     nonessentialAttributes.insert(StringAttr::get(context, "annotations"));
     nonessentialAttributes.insert(StringAttr::get(context, "convention"));
+    nonessentialAttributes.insert(StringAttr::get(context, "inner_sym"));
     nonessentialAttributes.insert(StringAttr::get(context, "name"));
     nonessentialAttributes.insert(StringAttr::get(context, "portAnnotations"));
-    nonessentialAttributes.insert(StringAttr::get(context, "portNames"));
     nonessentialAttributes.insert(StringAttr::get(context, "portLocations"));
+    nonessentialAttributes.insert(StringAttr::get(context, "portNames"));
+    nonessentialAttributes.insert(StringAttr::get(context, "portSymbols"));
     nonessentialAttributes.insert(StringAttr::get(context, "sym_name"));
     nonessentialAttributes.insert(StringAttr::get(context, "sym_visibility"));
   };
@@ -127,12 +127,6 @@ struct StructuralHasherSharedConstants {
 
   // This is a cached "moduleName" string attr.
   StringAttr moduleNameAttr;
-
-  // This is a cached "inner_sym" string attr.
-  StringAttr innerSymAttr;
-
-  // This is a cached "portSymbols" string attr.
-  StringAttr portSymbolsAttr;
 
   // This is a cached "portNames" string attr.
   StringAttr portNamesAttr;
@@ -146,11 +140,35 @@ struct StructuralHasher {
       : constants(constants) {}
 
   ModuleInfo getModuleInfo(FModuleLike module) {
+    populateInnerSymIDTable(module);
     update(&(*module));
     return {sha.final(), std::move(referredModuleNames)};
   }
 
 private:
+  /// Find all the ports and operations which may define an inner symbol
+  /// operations and give each a unique id.  If the port/operation does define
+  /// an inner symbol, map the symbol name to a pair of the id and the symbol's
+  /// field id. When we hash (local) references to this inner symbol, we will
+  /// hash in the id and the the field id.
+  void populateInnerSymIDTable(FModuleLike module) {
+    // Add port symbols. If no port has a symbol defined, the port symbol array
+    // will be totally empty.
+    for (auto [index, innerSym] : llvm::enumerate(module.getPortSymbols())) {
+      for (auto prop : cast<hw::InnerSymAttr>(innerSym))
+        innerSymIDTable[prop.getName()] = std::pair(index, prop.getFieldID());
+    }
+    // Add operation symbols.
+    size_t index = module.getNumPorts();
+    module.walk([&](hw::InnerSymbolOpInterface innerSymOp) {
+      if (auto innerSym = innerSymOp.getInnerSymAttr()) {
+        for (auto prop : innerSym)
+          innerSymIDTable[prop.getName()] = std::pair(index, prop.getFieldID());
+      }
+      ++index;
+    });
+  }
+
   // Get the identifier for an object. The identifier is assigned on first use.
   unsigned getID(void *object) {
     auto [it, inserted] = idTable.try_emplace(object, nextID);
@@ -169,11 +187,8 @@ private:
     return id;
   }
 
-  unsigned getInnerSymID(StringAttr name) {
-    auto [it, inserted] = innerSymIDTable.try_emplace(name, nextInnerSymID);
-    if (inserted)
-      ++nextInnerSymID;
-    return it->second;
+  std::pair<size_t, size_t> getInnerSymID(StringAttr name) {
+    return innerSymIDTable.at(name);
   }
 
   void update(OpOperand &operand) {
@@ -201,6 +216,12 @@ private:
   void update(size_t value) {
     auto *addr = reinterpret_cast<const uint8_t *>(&value);
     sha.update(ArrayRef<uint8_t>(addr, sizeof value));
+  }
+
+  template <typename T, typename U>
+  void update(const std::pair<T, U> &pair) {
+    update(pair.first);
+    update(pair.second);
   }
 
   void update(TypeID typeID) { update(typeID.getAsOpaquePointer()); }
@@ -257,31 +278,6 @@ private:
         continue;
       }
 
-      // Special case the InnerSymbols to ignore the symbol names.
-      if (name == constants.portSymbolsAttr) {
-        if (op->getNumRegions() != 1)
-          continue;
-        auto &region = op->getRegion(0);
-        if (region.getBlocks().empty())
-          continue;
-        for (auto sym : cast<ArrayAttr>(value).getAsRange<hw::InnerSymAttr>()) {
-          for (auto property : sym) {
-            update(property.getFieldID());
-            update(getInnerSymID(property.getName()));
-          }
-        }
-        continue;
-      }
-
-      if (name == constants.innerSymAttr) {
-        auto innerSym = cast<hw::InnerSymAttr>(value);
-        for (auto property : innerSym) {
-          update(property.getFieldID());
-          update(getInnerSymID(property.getName()));
-        }
-        continue;
-      }
-
       // For instance op, don't use `moduleName` attributes since they might be
       // replaced by dedup. Record the names and lazily combine their hashes.
       // It is assumed that module names are hashed only through instance ops;
@@ -298,10 +294,14 @@ private:
         continue;
 
       // If this is an symbol reference, we need to perform name erasure.
-      if (auto innerRef = dyn_cast<hw::InnerRefAttr>(value))
+      if (auto innerRef = dyn_cast<hw::InnerRefAttr>(value)) {
         update(getInnerSymID(innerRef.getName()));
-      else
-        update(value.getAsOpaquePointer());
+        continue;
+      }
+
+      // We don't need to handle this attribute specially, so hash its unique
+      // address.
+      update(value.getAsOpaquePointer());
     }
   }
 
@@ -362,8 +362,7 @@ private:
   unsigned nextID = 0;
 
   // A map from an inner symbol, to its identifier.
-  DenseMap<StringAttr, unsigned> innerSymIDTable;
-  unsigned nextInnerSymID = 0;
+  DenseMap<StringAttr, std::pair<size_t, size_t>> innerSymIDTable;
 
   // This keeps track of module names in the order of the appearance.
   std::vector<StringAttr> referredModuleNames;

--- a/test/Dialect/FIRRTL/dedup.mlir
+++ b/test/Dialect/FIRRTL/dedup.mlir
@@ -158,6 +158,16 @@ firrtl.circuit "Annotations" {
     // Subannotations should be handled correctly.
     // CHECK: %g = firrtl.wire {annotations = [{circt.fieldID = 1 : i32, circt.nonlocal = @annos_nla2, class = "subanno"}]}
     %g = firrtl.wire {annotations = [{circt.fieldID = 1 : i32, class = "subanno"}]} : !firrtl.bundle<a: uint<1>>
+    
+    // Should deduplicate wires where only one has a symbol
+    // CHECK: %h = firrtl.wire sym @h : !firrtl.uint
+    // CHECK: %i = firrtl.wire sym @sym : !firrtl.uint
+    %h = firrtl.wire sym @h : !firrtl.uint
+    %i = firrtl.wire : !firrtl.uint
+
+    // Should merge multiple different symbols.
+    // CHECK: %j = firrtl.wire sym [<@sym_0,0,public>, <@j,1,private>]
+    %j = firrtl.wire sym [<@j, 1, private>] : !firrtl.bundle<a: uint<1>>
   }
   // CHECK-NOT: firrtl.module private @Annotations1
   firrtl.module private @Annotations1() attributes {annotations = [{class = "one"}]} {
@@ -168,6 +178,9 @@ firrtl.circuit "Annotations" {
     %l = firrtl.wire {annotations = [{class = "both"}]} : !firrtl.uint<1>
     %m = firrtl.wire {annotations = [{class = "firrtl.transforms.DontTouchAnnotation"}]} : !firrtl.uint<1>
     %n = firrtl.wire : !firrtl.bundle<a: uint<1>>
+    %o = firrtl.wire : !firrtl.uint
+    %p = firrtl.wire sym @p : !firrtl.uint
+    %q = firrtl.wire sym [<@q, 0, private>] : !firrtl.bundle<a: uint<1>>
   }
   firrtl.module @Annotations() {
     // CHECK: firrtl.instance annotations0 sym @annotations0  @Annotations0()


### PR DESCRIPTION
[FIRRTL] Dedup: dedup wires when only one has a symbol
This change allows deduplication of wires when only one of them has an inner symbol.  Before, when hashing an operation we would include the index/id of the inner symbol in the wire's hash, which was done to make sure that local inner symbol references were targeting the same declaration between two modules.  Now, we preprocess the inner symbols inside a module, and with a stable identity of inner symbols we can confidently use the index of an innersymbol when hashing an inner symbol reference.  With this change, we don't have to include the inner symbol on the declaration operation, meaning that if there are no references to the symbol, the fact that an declaration has an inner symbol does not matter at all.

[FIRRTL] Dedup: properly merge inner symbols
When we deduplicate modules, we allow operations with different inner
symbol definitions to deduplicate with each other. Unfortunately the
operation merging procedure could only handle inner symbols with field
id 0, i.e. inner symbols which targeted the entire operation. If an
operation with a field-specific inner symbol was merged into another
operation, we would end up dropping the inner symbol. This change
properly handles inner symbols with many symbol definitions when merging
operations by properly merging the inner symbol property list.
