### PR TITLE
Drop unneeded headers

### DIFF
--- a/include/circt/Dialect/Emit/EmitOps.h
+++ b/include/circt/Dialect/Emit/EmitOps.h
@@ -18,8 +18,6 @@
 #include "mlir/IR/SymbolTable.h"
 
 #include "circt/Dialect/Emit/EmitDialect.h"
-#include "circt/Dialect/Seq/SeqDialect.h"
-#include "circt/Dialect/Seq/SeqTypes.h"
 #include "circt/Support/BuilderUtils.h"
 
 #define GET_OP_CLASSES

--- a/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
+++ b/lib/Conversion/HWToBTOR2/HWToBTOR2.cpp
@@ -14,7 +14,6 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/Comb/CombVisitors.h"
 #include "circt/Dialect/HW/HWAttributes.h"
-#include "circt/Dialect/HW/HWModuleGraph.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Dialect/HW/HWTypes.h"

--- a/lib/Dialect/Emit/EmitDialect.cpp
+++ b/lib/Dialect/Emit/EmitDialect.cpp
@@ -12,7 +12,6 @@
 
 #include "circt/Dialect/Emit/EmitDialect.h"
 #include "circt/Dialect/Emit/EmitOps.h"
-#include "circt/Dialect/HW/HWOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectImplementation.h"

--- a/lib/Dialect/Emit/EmitOpInterfaces.cpp
+++ b/lib/Dialect/Emit/EmitOpInterfaces.cpp
@@ -17,6 +17,5 @@
 
 using namespace mlir;
 using namespace llvm;
-using namespace circt::seq;
 
 #include "circt/Dialect/Emit/EmitOpInterfaces.cpp.inc"

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/HW/HWOps.h"
-#include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/CustomDirectiveImpl.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWInstanceImplementation.h"

--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -12,7 +12,6 @@
 
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Dialect/HW/HWOps.h"
-#include "circt/Dialect/Sim/SimTypes.h"
 #include "circt/Support/CustomDirectiveImpl.h"
 #include "circt/Support/FoldUtils.h"
 #include "mlir/Analysis/TopologicalSortUtils.h"

--- a/lib/Dialect/Verif/Transforms/VerifyClockedAssertLike.cpp
+++ b/lib/Dialect/Verif/Transforms/VerifyClockedAssertLike.cpp
@@ -10,7 +10,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/HW/HWAttributes.h"
-#include "circt/Dialect/HW/HWModuleGraph.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/HW/HWPasses.h"
 #include "circt/Dialect/HW/HWTypes.h"


### PR DESCRIPTION
I was trying to figure out the dependencies between dialects and these headers created unexpected dependencies between dialects but weren't needed (it seem). I don't know if there is already a dependency diagram between these.