### PR TITLE
[hlstool] add top-level-function option for calyx flow

### DIFF
--- a/include/circt/Conversion/SCFToCalyx.h
+++ b/include/circt/Conversion/SCFToCalyx.h
@@ -31,7 +31,8 @@ static constexpr std::string_view sPortNameAttr = "calyx.port_name";
 } // namespace scfToCalyx
 
 /// Create an SCF to Calyx conversion pass.
-std::unique_ptr<OperationPass<ModuleOp>> createSCFToCalyxPass();
+std::unique_ptr<OperationPass<ModuleOp>>
+createSCFToCalyxPass(std::string topLevelFunction = "");
 
 } // namespace circt
 

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -2574,8 +2574,10 @@ using namespace circt::scftocalyx;
 //===----------------------------------------------------------------------===//
 class SCFToCalyxPass : public circt::impl::SCFToCalyxBase<SCFToCalyxPass> {
 public:
-  SCFToCalyxPass()
-      : SCFToCalyxBase<SCFToCalyxPass>(), partialPatternRes(success()) {}
+  SCFToCalyxPass(std::string topLevelFunction)
+      : SCFToCalyxBase<SCFToCalyxPass>(), partialPatternRes(success()) {
+    this->topLevelFunctionOpt = topLevelFunction;
+  }
   void runOnOperation() override;
 
   LogicalResult setTopLevelFunction(mlir::ModuleOp moduleOp,
@@ -3038,8 +3040,9 @@ void SCFToCalyxPass::runOnOperation() {
 // Pass initialization
 //===----------------------------------------------------------------------===//
 
-std::unique_ptr<OperationPass<ModuleOp>> createSCFToCalyxPass() {
-  return std::make_unique<SCFToCalyxPass>();
+std::unique_ptr<OperationPass<ModuleOp>>
+createSCFToCalyxPass(std::string topLevelFunction) {
+  return std::make_unique<SCFToCalyxPass>(topLevelFunction);
 }
 
 } // namespace circt

--- a/test/hlstool/commandline.mlir
+++ b/test/hlstool/commandline.mlir
@@ -5,3 +5,4 @@
 // CHECK: Generic Options
 // CHECK: hlstool Options
 // CHECK: --lowering-options=
+// CHECK: --top-level-function=

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -225,6 +225,14 @@ static cl::opt<bool> withDC("dc", cl::desc("Use the DC flow"), cl::init(false),
 static LoweringOptionsOption loweringOptions(mainCategory);
 
 // --------------------------------------------------------------------------
+// Calyx options
+// --------------------------------------------------------------------------
+static cl::opt<std::string> topLevelFunction("top-level-function",
+                                             cl::desc("Top level function"),
+                                             cl::init(""),
+                                             cl::cat(mainCategory));
+
+// --------------------------------------------------------------------------
 // (Configurable) pass pipelines
 // --------------------------------------------------------------------------
 
@@ -412,8 +420,9 @@ static LogicalResult doHLSFlowCalyx(
   });
 
   // Lower to Calyx
-  addIRLevel(IRLevel::Core,
-             [&]() { pm.addPass(circt::createSCFToCalyxPass()); });
+  addIRLevel(IRLevel::Core, [&]() {
+    pm.addPass(circt::createSCFToCalyxPass(topLevelFunction));
+  });
 
   // Run Calyx transforms
   addIRLevel(IRLevel::PostCompile, [&]() {


### PR DESCRIPTION
Exposing the `--top-level-function` in `hlstool` for calyx lowering