### PR TITLE
[SCFToCalyx] Modify top-level function in place and propagate external memory allocations

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -31,7 +31,6 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_os_ostream.h"
-#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
@@ -2602,7 +2601,10 @@ public:
       }
     }
 
-    return modifyTopLevelFuncInPlace(moduleOp, topLevelFunction);
+    if (failed(modifyTopLevelFuncInPlace(moduleOp, topLevelFunction)))
+      return failure();
+
+    return propagateExternalMemToTopLevelFunc(moduleOp, topLevelFunction);
   }
 
   struct LoweringPattern {
@@ -2700,151 +2702,6 @@ private:
   LogicalResult partialPatternRes;
   std::shared_ptr<calyx::CalyxLoweringState> loweringState = nullptr;
 
-  /// Creates a new new top-level function based on `baseName`.
-  FuncOp createNewTopLevelFn(ModuleOp moduleOp, std::string &baseName) {
-    std::string newName = "main";
-
-    if (auto *existingMainOp = SymbolTable::lookupSymbolIn(moduleOp, newName)) {
-      auto existingMainFunc = dyn_cast<FuncOp>(existingMainOp);
-      if (existingMainFunc == nullptr) {
-        moduleOp.emitError() << "Symbol 'main' exists but is not a function";
-        return nullptr;
-      }
-      unsigned counter = 0;
-      std::string newOldName = baseName;
-      while (SymbolTable::lookupSymbolIn(moduleOp, newOldName))
-        newOldName = llvm::join_items("_", baseName, std::to_string(++counter));
-      existingMainFunc.setName(newOldName);
-      if (baseName == "main")
-        baseName = newOldName;
-    }
-
-    // Create the new "main" function
-    OpBuilder builder(moduleOp.getContext());
-    builder.setInsertionPointToStart(moduleOp.getBody());
-
-    FunctionType funcType = builder.getFunctionType({}, {});
-
-    if (auto newFunc =
-            builder.create<FuncOp>(moduleOp.getLoc(), newName, funcType))
-      return newFunc;
-
-    return nullptr;
-  }
-
-  /// Insert a call from the newly created top-level function/`caller` to the
-  /// old top-level function/`callee`; and create `memref.alloc`s inside the new
-  /// top-level function for arguments with `memref` types and for the
-  /// `memref.alloc`s inside `callee`.
-  void insertCallFromNewTopLevel(OpBuilder &builder, FuncOp caller,
-                                 FuncOp callee) {
-    if (caller.getBody().empty()) {
-      caller.addEntryBlock();
-    }
-
-    Block *callerEntryBlock = &caller.getBody().front();
-    builder.setInsertionPointToStart(callerEntryBlock);
-
-    // For those non-memref arguments passing to the original top-level
-    // function, we need to copy them to the new top-level function.
-    SmallVector<Type, 4> nonMemRefCalleeArgTypes;
-    for (auto arg : callee.getArguments()) {
-      if (!isa<MemRefType>(arg.getType())) {
-        nonMemRefCalleeArgTypes.push_back(arg.getType());
-      }
-    }
-
-    for (Type type : nonMemRefCalleeArgTypes) {
-      callerEntryBlock->addArgument(type, caller.getLoc());
-    }
-
-    FunctionType callerFnType = caller.getFunctionType();
-    SmallVector<Type, 4> updatedCallerArgTypes(
-        caller.getFunctionType().getInputs());
-    updatedCallerArgTypes.append(nonMemRefCalleeArgTypes.begin(),
-                                 nonMemRefCalleeArgTypes.end());
-    caller.setType(FunctionType::get(caller.getContext(), updatedCallerArgTypes,
-                                     callerFnType.getResults()));
-
-    Block *calleeFnBody = &callee.getBody().front();
-    unsigned originalCalleeArgNum = callee.getArguments().size();
-
-    SmallVector<Value, 4> extraMemRefArgs;
-    SmallVector<Type, 4> extraMemRefArgTypes;
-    SmallVector<Value, 4> extraMemRefOperands;
-    SmallVector<Operation *, 4> opsToModify;
-    for (auto &op : callee.getBody().getOps()) {
-      if (isa<memref::AllocaOp, memref::AllocOp, memref::GetGlobalOp>(op))
-        opsToModify.push_back(&op);
-    }
-
-    // Replace `alloc`/`getGlobal` in the original top-level with new
-    // corresponding operations in the new top-level.
-    builder.setInsertionPointToEnd(callerEntryBlock);
-    for (auto *op : opsToModify) {
-      // TODO (https://github.com/llvm/circt/issues/7764)
-      Value newOpRes;
-      TypeSwitch<Operation *>(op)
-          .Case<memref::AllocaOp>([&](memref::AllocaOp allocaOp) {
-            newOpRes = builder.create<memref::AllocaOp>(callee.getLoc(),
-                                                        allocaOp.getType());
-          })
-          .Case<memref::AllocOp>([&](memref::AllocOp allocOp) {
-            newOpRes = builder.create<memref::AllocOp>(callee.getLoc(),
-                                                       allocOp.getType());
-          })
-          .Case<memref::GetGlobalOp>([&](memref::GetGlobalOp getGlobalOp) {
-            newOpRes = builder.create<memref::GetGlobalOp>(
-                caller.getLoc(), getGlobalOp.getType(), getGlobalOp.getName());
-          })
-          .Default([&](Operation *defaultOp) {
-            llvm::report_fatal_error("Unsupported operation in TypeSwitch");
-          });
-      extraMemRefOperands.push_back(newOpRes);
-
-      calleeFnBody->addArgument(newOpRes.getType(), callee.getLoc());
-      BlockArgument newBodyArg = calleeFnBody->getArguments().back();
-      op->getResult(0).replaceAllUsesWith(newBodyArg);
-      op->erase();
-      extraMemRefArgs.push_back(newBodyArg);
-      extraMemRefArgTypes.push_back(newBodyArg.getType());
-    }
-
-    SmallVector<Type, 4> updatedCalleeArgTypes(
-        callee.getFunctionType().getInputs());
-    updatedCalleeArgTypes.append(extraMemRefArgTypes.begin(),
-                                 extraMemRefArgTypes.end());
-    callee.setType(FunctionType::get(callee.getContext(), updatedCalleeArgTypes,
-                                     callee.getFunctionType().getResults()));
-
-    unsigned otherArgsCount = 0;
-    SmallVector<Value, 4> calleeArgFnOperands;
-    builder.setInsertionPointToStart(callerEntryBlock);
-    for (auto arg : callee.getArguments().take_front(originalCalleeArgNum)) {
-      if (isa<MemRefType>(arg.getType())) {
-        auto memrefType = cast<MemRefType>(arg.getType());
-        auto allocOp =
-            builder.create<memref::AllocOp>(callee.getLoc(), memrefType);
-        calleeArgFnOperands.push_back(allocOp);
-      } else {
-        auto callerArg = callerEntryBlock->getArgument(otherArgsCount++);
-        calleeArgFnOperands.push_back(callerArg);
-      }
-    }
-
-    SmallVector<Value, 4> fnOperands;
-    fnOperands.append(calleeArgFnOperands.begin(), calleeArgFnOperands.end());
-    fnOperands.append(extraMemRefOperands.begin(), extraMemRefOperands.end());
-    auto calleeName =
-        SymbolRefAttr::get(builder.getContext(), callee.getSymName());
-    auto resultTypes = callee.getResultTypes();
-
-    builder.setInsertionPointToEnd(callerEntryBlock);
-    builder.create<CallOp>(caller.getLoc(), calleeName, resultTypes,
-                           fnOperands);
-    builder.create<ReturnOp>(caller.getLoc());
-  }
-
   /// Modifies the top-level function in-place if it has `memref` function
   /// arguments. Concretely, we convert those arguments to `memref.alloc`s in
   /// the function body.
@@ -2897,42 +2754,146 @@ private:
     return success();
   }
 
-  /// Conditionally creates an optional new top-level function; and inserts a
-  /// call from the new top-level function to the old top-level function if we
-  /// did create one
-  LogicalResult createOptNewTopLevelFn(ModuleOp moduleOp,
-                                       std::string &topLevelFunction) {
-    auto hasMemrefArguments = [](FuncOp func) {
-      return std::any_of(
-          func.getArguments().begin(), func.getArguments().end(),
-          [](BlockArgument arg) { return isa<MemRefType>(arg.getType()); });
-    };
+  std::optional<SmallVector<Operation *, 4>>
+  extractExternalMemoryAllocs(FuncOp funcOp) {
+    SmallVector<Operation *, 4> externalMemoryAllocs;
+    funcOp.walk([&](Operation *op) {
+      if (isa<memref::AllocOp, memref::AllocaOp, memref::GetGlobalOp>(op))
+        externalMemoryAllocs.push_back(op);
+    });
 
-    /// We only create a new top-level function and call the original top-level
-    /// function from the new one if the original top-level has `memref` in its
-    /// argument
-    auto funcOps = moduleOp.getOps<FuncOp>();
-    bool hasMemrefArgsInTopLevel =
-        std::any_of(funcOps.begin(), funcOps.end(), [&](auto funcOp) {
-          return funcOp.getName() == topLevelFunction &&
-                 hasMemrefArguments(funcOp);
-        });
+    if (externalMemoryAllocs.empty())
+      return std::nullopt;
+    return externalMemoryAllocs;
+  }
 
-    if (hasMemrefArgsInTopLevel) {
-      auto newTopLevelFunc = createNewTopLevelFn(moduleOp, topLevelFunction);
-      if (!newTopLevelFunc)
-        return failure();
+  /// Find the unique CallOp that calls `funcOp`. Fails if there is none or
+  /// multiple.
+  FailureOr<std::pair<CallOp, FuncOp>> findUniqueCaller(ModuleOp moduleOp,
+                                                        FuncOp funcOp) {
+    SmallVector<CallOp, 2> callOps;
+    moduleOp.walk([&](CallOp callOp) {
+      if (callOp.getCallee() == funcOp.getSymName())
+        callOps.push_back(callOp);
+    });
 
-      OpBuilder builder(moduleOp.getContext());
-      Operation *oldTopLevelFuncOp =
-          SymbolTable::lookupSymbolIn(moduleOp, topLevelFunction);
-      if (auto oldTopLevelFunc = dyn_cast<FuncOp>(oldTopLevelFuncOp))
-        insertCallFromNewTopLevel(builder, newTopLevelFunc, oldTopLevelFunc);
-      else {
-        moduleOp.emitOpError("Original top-level function not found!");
-        return failure();
+    if (callOps.empty()) {
+      funcOp.emitError("Function has no callers.");
+      return failure();
+    }
+
+    if (callOps.size() > 1) {
+      funcOp.emitError(
+          "Currently do not support a callee called by multiple callers.");
+      return failure();
+    }
+
+    return std::make_pair(callOps.front(),
+                          callOps.front()->getParentOfType<FuncOp>());
+  }
+
+  /// Propagates `externalMemoryAllocs` from `callee` to the caller and modifies
+  /// the corresponding `CallOp`. If the caller is top-level function, we move
+  /// `externalMemoryAllocs` to it; otherwise, we propagate through function
+  /// arguments.
+  LogicalResult propagateExternalMemToTopLevelFuncHelper(
+      ModuleOp moduleOp, FuncOp callee, std::pair<CallOp, FuncOp> callOpCaller,
+      const std::string &topLevelFunction,
+      SmallVector<Operation *, 4> &externalMemoryAllocs) {
+    auto callOp = callOpCaller.first;
+    auto caller = callOpCaller.second;
+    Block &callerEntryBlock = caller.getFunctionBody().front();
+    SmallVector<Value, 4> externalMemoryValues;
+    bool isTopLevelCaller = (caller.getSymName() == topLevelFunction);
+    for (auto *externalMemory : externalMemoryAllocs) {
+      Value memResult = externalMemory->getResult(0);
+      Type externalMemoryType = memResult.getType();
+      if (isTopLevelCaller) {
+        // Track the order of memory allocations so that it's easier to identify
+        // the corresponding one in the JSON file that will be written to.
+        Operation *lastAllocOp = nullptr;
+        for (Operation &op : callOp->getBlock()->getOperations()) {
+          if (&op == callOp.getOperation())
+            break;
+
+          if (isa<memref::AllocOp, memref::AllocaOp, memref::GetGlobalOp>(&op))
+            lastAllocOp = &op;
+        }
+
+        if (lastAllocOp)
+          externalMemory->moveBefore(lastAllocOp->getBlock(),
+                                     std::next(lastAllocOp->getIterator()));
+        else
+          externalMemory->moveBefore(callOp->getBlock(),
+                                     std::next(callOp->getIterator()));
+
+        externalMemoryValues.push_back(memResult);
+      } else {
+        // Non-top-level: propagate by function arguments
+        externalMemoryValues.push_back(
+            callerEntryBlock.addArgument(externalMemoryType, caller.getLoc()));
       }
-      topLevelFunction = "main";
+      // Add a corresponding function argument to `callee`.
+      auto memArg = callee.getFunctionBody().front().addArgument(
+          externalMemoryType, caller.getLoc());
+      SmallVector<Type, 4> updatedCalleeArgTypes(
+          callee.getFunctionType().getInputs());
+      updatedCalleeArgTypes.push_back(externalMemoryType);
+      callee.setType(FunctionType::get(callee.getContext(),
+                                       updatedCalleeArgTypes,
+                                       callee.getFunctionType().getResults()));
+      memResult.replaceAllUsesWith(memArg);
+    }
+
+    SmallVector<Value, 4> newOperands(callOp.getOperands().begin(),
+                                      callOp.getOperands().end());
+    newOperands.append(externalMemoryValues.begin(),
+                       externalMemoryValues.end());
+    callOp.getOperation()->setOperands(newOperands);
+
+    // If not top-level, recursively propagate further.
+    if (!isTopLevelCaller) {
+      auto callerLookup = findUniqueCaller(moduleOp, caller);
+
+      if (failed(callerLookup))
+        return failure();
+
+      auto [callerCallOp, callerCallerFunc] = *callerLookup;
+
+      if (auto newExternalMemoryAllocs = extractExternalMemoryAllocs(caller))
+        externalMemoryAllocs.append(newExternalMemoryAllocs->begin(),
+                                    newExternalMemoryAllocs->end());
+
+      if (failed(propagateExternalMemToTopLevelFuncHelper(
+              moduleOp, caller, {callerCallOp, callerCallerFunc},
+              topLevelFunction, externalMemoryAllocs)))
+        return failure();
+    }
+
+    return success();
+  }
+
+  /// Propagates external memory allocations from non-top-level functions to the
+  /// top-level function.
+  LogicalResult
+  propagateExternalMemToTopLevelFunc(ModuleOp moduleOp,
+                                     const std::string &topLevelFunction) {
+    for (auto funcOp : moduleOp.getOps<FuncOp>()) {
+      if (funcOp.getSymName().str() == topLevelFunction)
+        // We don't need to propagate anymore.
+        return success();
+
+      if (auto externalMemoryAllocs = extractExternalMemoryAllocs(funcOp)) {
+        auto callerLookup = findUniqueCaller(moduleOp, funcOp);
+        if (failed(callerLookup))
+          return failure();
+
+        auto [callOp, callerFunc] = *callerLookup;
+        if (failed(propagateExternalMemToTopLevelFuncHelper(
+                moduleOp, funcOp, {callOp, callerFunc}, topLevelFunction,
+                *externalMemoryAllocs)))
+          return failure();
+      }
     }
 
     return success();

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -760,20 +760,20 @@ module {
 // -----
 
 module {
-// CHECK-LABEL:   calyx.component @main_1(
-// CHECK-SAME:                            %[[VAL_0:in0]]: i32,
-// CHECK-SAME:                            %[[VAL_1:in1]]: i32,
-// CHECK-SAME:                            %[[VAL_2:.*]]: i1 {clk},
-// CHECK-SAME:                            %[[VAL_3:.*]]: i1 {reset},
-// CHECK-SAME:                            %[[VAL_4:.*]]: i1 {go}) -> (
-// CHECK-SAME:                            %[[VAL_5:.*]]: i1 {done}) {
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {done}) {
 // CHECK:           %[[VAL_6:.*]] = hw.constant true
 // CHECK:           %[[VAL_7:.*]] = hw.constant 0 : i32
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_1 : i32, i1
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_0 : i32, i1
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
 // CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.std_slt @std_slt_0 : i32, i32, i1
-// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.seq_mem @mem_0 <[1] x 32> [1] {external = true} : i1, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.comb_group @bb0_0 {
 // CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_0]] : i32
@@ -811,7 +811,7 @@ module {
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
-// CHECK:         }
+// CHECK:         } {toplevel}
   func.func @main(%arg0: i32, %arg1: i32, %arg2: memref<1xi32>) {
     %c0 = arith.constant 0 : index
     %0 = arith.cmpi slt, %arg0, %arg1 : i32
@@ -829,27 +829,27 @@ module {
 
 // Test if ops with sequential condition check.
 
-// CHECK-LABEL:   calyx.component @main_1(
-// CHECK-SAME:                            %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
-// CHECK-SAME:                            %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {clk},
-// CHECK-SAME:                            %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {reset},
-// CHECK-SAME:                            %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {go}) -> (
-// CHECK-SAME:                            %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {done}) {
+// CHECK-LABEL:   calyx.component @main(
+// CHECK-SAME:                          %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {done}) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
-// CHECK:           %[[VAL_6:.*]] = hw.constant 2 : i32
-// CHECK:           %[[VAL_7:.*]] = hw.constant 1 : i32
+// CHECK:           %[[VAL_6:.*]] = hw.constant 1 : i32
+// CHECK:           %[[VAL_7:.*]] = hw.constant 2 : i32
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_1 : i32, i7
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_0 : i32, i7
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.register @cmpi_0_reg : i1, i1, i1, i1, i1, i1
 // CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.std_eq @std_eq_0 : i32, i32, i1
 // CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]] = calyx.register @remui_0_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]] = calyx.std_remu_pipe @std_remu_pipe_0 : i1, i1, i1, i32, i32, i32, i1
-// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]] = calyx.seq_mem @arg_mem_1 <[120] x 32> [7] : i7, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]], %[[VAL_46:.*]], %[[VAL_47:.*]], %[[VAL_48:.*]], %[[VAL_49:.*]] = calyx.seq_mem @arg_mem_0 <[120] x 32> [7] : i7, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]] = calyx.seq_mem @mem_1 <[120] x 32> [7] {external = true} : i7, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]], %[[VAL_46:.*]], %[[VAL_47:.*]], %[[VAL_48:.*]], %[[VAL_49:.*]] = calyx.seq_mem @mem_0 <[120] x 32> [7] {external = true} : i7, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.group @bb0_0 {
 // CHECK:               calyx.assign %[[VAL_30]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_31]] = %[[VAL_6]] : i32
+// CHECK:               calyx.assign %[[VAL_31]] = %[[VAL_7]] : i32
 // CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_32]] : i32
 // CHECK:               calyx.assign %[[VAL_22]] = %[[VAL_33]] : i1
 // CHECK:               %[[VAL_50:.*]] = comb.xor %[[VAL_33]], %[[VAL_5]] : i1
@@ -864,7 +864,7 @@ module {
 // CHECK:               calyx.group_done %[[VAL_17]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_2 {
-// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_6]] : i32
 // CHECK:               calyx.assign %[[VAL_34]] = %[[VAL_9]] : i7
 // CHECK:               calyx.assign %[[VAL_39]] = %[[VAL_0]] : i32
 // CHECK:               calyx.assign %[[VAL_38]] = %[[VAL_5]] : i1
@@ -872,7 +872,7 @@ module {
 // CHECK:               calyx.group_done %[[VAL_41]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_3 {
-// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_6]] : i32
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_7]] : i32
 // CHECK:               calyx.assign %[[VAL_42]] = %[[VAL_11]] : i7
 // CHECK:               calyx.assign %[[VAL_47]] = %[[VAL_25]] : i32
 // CHECK:               calyx.assign %[[VAL_46]] = %[[VAL_5]] : i1
@@ -895,7 +895,7 @@ module {
 // CHECK:               }
 // CHECK:             }
 // CHECK:           }
-// CHECK:         }
+// CHECK:         } {toplevel}
 
 module {
   func.func @main(%arg0 : i32, %arg1: memref<120xi32>) {

--- a/test/Conversion/SCFToCalyx/convert_func.mlir
+++ b/test/Conversion/SCFToCalyx/convert_func.mlir
@@ -90,3 +90,27 @@ module {
     return %ret1 : i32
   }
 }
+
+// -----
+
+// Test non-top-level function has external memory allocation.
+
+// CHECK:           calyx.control {
+// CHECK:             calyx.seq {
+// CHECK:               calyx.invoke @callee_instance[arg_mem_0 = mem_0, arg_mem_1 = mem_1]() -> ()
+// CHECK:             }
+// CHECK:           }
+
+module {
+  func.func @callee(%arg0 : memref<5xi32>) {
+    %idx = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<6xi32>
+    %val = memref.load %alloc[%idx] : memref<6xi32>
+    memref.store %val, %arg0[%idx] : memref<5xi32>
+    return
+  }
+  func.func @main(%arg0: memref<5xi32>) {
+    func.call @callee(%arg0) : (memref<5xi32>) -> ()
+    return
+  }
+}

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -373,33 +373,15 @@ module {
 
 module {
 // CHECK-LABEL:   calyx.component @main(
-// CHECK-SAME:                            %[[VAL_0:in0]]: i32,
-// CHECK-SAME:                            %[[VAL_1:in1]]: i32,
-// CHECK-SAME:                            %[[VAL_2:.*]]: i1 {clk},
-// CHECK-SAME:                            %[[VAL_3:.*]]: i1 {reset},
-// CHECK-SAME:                            %[[VAL_4:.*]]: i1 {go}) -> (
-// CHECK-SAME:                            %[[VAL_5:.*]]: i1 {done}) {
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.instance @main_1_instance of @main_1 : i32, i32, i1, i1, i1, i1
-// CHECK:           calyx.wires {
-// CHECK:           }
-// CHECK:           calyx.control {
-// CHECK:             calyx.seq {
-// CHECK:               calyx.invoke @main_1_instance[arg_mem_0 = mem_0](%[[VAL_15]] = %[[VAL_0]], %[[VAL_16]] = %[[VAL_1]]) -> (i32, i32)
-// CHECK:             }
-// CHECK:           }
-// CHECK:         } {toplevel}
-
-// CHECK-LABEL:   calyx.component @main_1(
-// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
-// CHECK-SAME:                          %[[VAL_1:in2]]: i32,
-// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {clk},
-// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {reset},
-// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {go}) -> (
-// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {done}) {
+// CHECK-SAME:                          %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {done}) {
 // CHECK:           %[[VAL_6:.*]] = hw.constant true
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = calyx.std_slice @std_slice_0 : i32, i3
-// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.group @bb0_0 {
 // CHECK:               calyx.assign %[[VAL_7]] = %[[VAL_1]] : i32
@@ -415,7 +397,7 @@ module {
 // CHECK:               calyx.enable @bb0_0
 // CHECK:             }
 // CHECK:           }
-// CHECK:         }  
+// CHECK:         } {toplevel}
   func.func @main(%arg0 : i32, %mem0 : memref<8xi32>, %i : index) {
     memref.store %arg0, %mem0[%i] : memref<8xi32>
     return
@@ -428,47 +410,30 @@ module {
 
 module {
 // CHECK-LABEL:   calyx.component @main(
-// CHECK-SAME:                            %[[VAL_0:.*]]: i32,
-// CHECK-SAME:                            %[[VAL_1:.*]]: i1 {clk},
-// CHECK-SAME:                            %[[VAL_2:.*]]: i1 {reset},
-// CHECK-SAME:                            %[[VAL_3:.*]]: i1 {go}) -> (
-// CHECK-SAME:                            %[[VAL_4:.*]]: i1 {done}) {
-// CHECK:           %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.instance @main_1_instance of @main_1 : i32, i1, i1, i1, i32, i1
-// CHECK:           calyx.wires {
-// CHECK:           }
-// CHECK:           calyx.control {
-// CHECK:             calyx.seq {
-// CHECK:               calyx.invoke @main_1_instance[arg_mem_0 = mem_0](%[[VAL_14]] = %[[VAL_0]]) -> (i32)
-// CHECK:             }
-// CHECK:           }
-// CHECK:         } {toplevel}
-
-// CHECK-LABEL:   calyx.component @main_1(
-// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
-// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {clk},
-// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {reset},
-// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {go}) -> (
-// CHECK-SAME:                          %[[VAL_4:.*]]: i32,
-// CHECK-SAME:                          %[[VAL_5:.*]]: i1 {done}) {
+// CHECK-SAME:                          %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {done}) {
 // CHECK:           %[[VAL_6:.*]] = hw.constant false
 // CHECK:           %[[VAL_7:.*]] = hw.constant true
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_0 : i32, i3
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_14]] : i32
+// CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_22]] : i32
 // CHECK:             calyx.group @bb0_0 {
 // CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_9]] : i3
-// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_7]] : i1
-// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_6]] : i1
-// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_9]] : i3
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_7]] : i1
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_17]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @ret_assign_0 {
-// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_22]] : i32
-// CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_7]] : i1
-// CHECK:               calyx.group_done %[[VAL_15]] : i1
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_16]] : i32
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_7]] : i1
+// CHECK:               calyx.group_done %[[VAL_23]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {
@@ -477,7 +442,7 @@ module {
 // CHECK:               calyx.enable @ret_assign_0
 // CHECK:             }
 // CHECK:           }
-// CHECK:         }
+// CHECK:         } {toplevel}
   func.func @main(%i : index, %mem0 : memref<8xi32>) -> i32 {
     %0 = memref.load %mem0[%i] : memref<8xi32>
     return %0 : i32
@@ -490,68 +455,50 @@ module {
 
 module {
 // CHECK-LABEL:   calyx.component @main(
-// CHECK-SAME:                            %[[VAL_0:in0]]: i32,
-// CHECK-SAME:                            %[[VAL_1:in1]]: i32,
-// CHECK-SAME:                            %[[VAL_2:.*]]: i1 {clk},
-// CHECK-SAME:                            %[[VAL_3:.*]]: i1 {reset},
-// CHECK-SAME:                            %[[VAL_4:.*]]: i1 {go}) -> (
-// CHECK-SAME:                            %[[VAL_5:.*]]: i1 {done}) {
-// CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]] = calyx.instance @main_1_instance of @main_1 : i32, i32, i1, i1, i1, i32, i32, i1
-// CHECK:           calyx.wires {
-// CHECK:           }
-// CHECK:           calyx.control {
-// CHECK:             calyx.seq {
-// CHECK:               calyx.invoke @main_1_instance[arg_mem_0 = mem_0](%[[VAL_15]] = %[[VAL_0]], %[[VAL_16]] = %[[VAL_1]]) -> (i32, i32)
-// CHECK:             }
-// CHECK:           }
-// CHECK:         } {toplevel}
-
-// CHECK-LABEL:   calyx.component @main_1(
-// CHECK-SAME:                          %[[VAL_0:in0]]: i32,
-// CHECK-SAME:                          %[[VAL_1:in1]]: i32,
-// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {clk},
-// CHECK-SAME:                          %[[VAL_3:.*]]: i1 {reset},
-// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {go}) -> (
-// CHECK-SAME:                          %[[VAL_5:out0]]: i32,
-// CHECK-SAME:                          %[[VAL_6:out1]]: i32,
-// CHECK-SAME:                          %[[VAL_7:.*]]: i1 {done}) {
+// CHECK-SAME:                          %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_5:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_6:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_7:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {done}) {
 // CHECK:           %[[VAL_8:.*]] = hw.constant true
 // CHECK:           %[[VAL_9:.*]] = hw.constant false
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_1 : i32, i3
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]] = calyx.std_slice @std_slice_0 : i32, i3
 // CHECK:           %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]] = calyx.register @load_1_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]] = calyx.register @ret_arg1_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]] = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]] = calyx.seq_mem @mem_0 <[8] x 32> [3] {external = true} : i3, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]] = calyx.register @ret_arg1_reg : i32, i1, i1, i1, i32, i1
+// CHECK:           %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.assign %[[VAL_6]] = %[[VAL_30]] : i32
-// CHECK:             calyx.assign %[[VAL_5]] = %[[VAL_36]] : i32
+// CHECK:             calyx.assign %[[VAL_6]] = %[[VAL_38]] : i32
+// CHECK:             calyx.assign %[[VAL_5]] = %[[VAL_44]] : i32
 // CHECK:             calyx.group @bb0_0 {
 // CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_0]] : i32
-// CHECK:               calyx.assign %[[VAL_38]] = %[[VAL_11]] : i3
-// CHECK:               calyx.assign %[[VAL_41]] = %[[VAL_8]] : i1
-// CHECK:               calyx.assign %[[VAL_42]] = %[[VAL_9]] : i1
-// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_44]] : i32
-// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_45]] : i1
+// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_11]] : i3
+// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_8]] : i1
+// CHECK:               calyx.assign %[[VAL_30]] = %[[VAL_9]] : i1
+// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_32]] : i32
+// CHECK:               calyx.assign %[[VAL_21]] = %[[VAL_33]] : i1
 // CHECK:               calyx.group_done %[[VAL_25]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_1 {
 // CHECK:               calyx.assign %[[VAL_12]] = %[[VAL_1]] : i32
-// CHECK:               calyx.assign %[[VAL_38]] = %[[VAL_13]] : i3
-// CHECK:               calyx.assign %[[VAL_41]] = %[[VAL_8]] : i1
-// CHECK:               calyx.assign %[[VAL_42]] = %[[VAL_9]] : i1
-// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_44]] : i32
-// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_45]] : i1
+// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_13]] : i3
+// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_8]] : i1
+// CHECK:               calyx.assign %[[VAL_30]] = %[[VAL_9]] : i1
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_32]] : i32
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_33]] : i1
 // CHECK:               calyx.group_done %[[VAL_19]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @ret_assign_0 {
-// CHECK:               calyx.assign %[[VAL_32]] = %[[VAL_24]] : i32
-// CHECK:               calyx.assign %[[VAL_33]] = %[[VAL_8]] : i1
-// CHECK:               calyx.assign %[[VAL_26]] = %[[VAL_18]] : i32
-// CHECK:               calyx.assign %[[VAL_27]] = %[[VAL_8]] : i1
-// CHECK:               %[[VAL_46:.*]] = comb.and %[[VAL_31]], %[[VAL_37]] : i1
+// CHECK:               calyx.assign %[[VAL_40]] = %[[VAL_24]] : i32
+// CHECK:               calyx.assign %[[VAL_41]] = %[[VAL_8]] : i1
+// CHECK:               calyx.assign %[[VAL_34]] = %[[VAL_18]] : i32
+// CHECK:               calyx.assign %[[VAL_35]] = %[[VAL_8]] : i1
+// CHECK:               %[[VAL_46:.*]] = comb.and %[[VAL_39]], %[[VAL_45]] : i1
 // CHECK:               calyx.group_done %[[VAL_46]] ? %[[VAL_8]] : i1
 // CHECK:             }
 // CHECK:           }
@@ -562,7 +509,7 @@ module {
 // CHECK:               calyx.enable @ret_assign_0
 // CHECK:             }
 // CHECK:           }
-// CHECK:         }
+// CHECK:         } {toplevel}
   func.func @main(%i0 : index, %i1 : index, %mem0 : memref<8xi32>) -> (i32, i32) {
     %0 = memref.load %mem0[%i0] : memref<8xi32>
     %1 = memref.load %mem0[%i1] : memref<8xi32>
@@ -638,46 +585,30 @@ module {
 
 module {
 // CHECK-LABEL:   calyx.component @main(
-// CHECK-SAME:                            %[[VAL_0:.*]]: i1 {clk},
-// CHECK-SAME:                            %[[VAL_1:.*]]: i1 {reset},
-// CHECK-SAME:                            %[[VAL_2:.*]]: i1 {go}) -> (
-// CHECK-SAME:                            %[[VAL_3:.*]]: i1 {done}) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = calyx.seq_mem @mem_0 <[33] x 32> [6] {external = true} : i6, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.instance @main_1_instance of @main_1 : i1, i1, i1, i32, i1
-// CHECK:           calyx.wires {
-// CHECK:           }
-// CHECK:           calyx.control {
-// CHECK:             calyx.seq {
-// CHECK:               calyx.invoke @main_1_instance[arg_mem_0 = mem_0]() -> ()
-// CHECK:             }
-// CHECK:           }
-// CHECK:         } {toplevel}
-
-// CHECK-LABEL:   calyx.component @main_1(
-// CHECK-SAME:                          %[[VAL_0:.*]]: i1 {clk},
-// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {reset},
-// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {go}) -> (
-// CHECK-SAME:                          %[[VAL_3:.*]]: i32,
-// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {done}) {
+// CHECK-SAME:                          %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {done}) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant false
 // CHECK:           %[[VAL_6:.*]] = hw.constant true
 // CHECK:           %[[VAL_7:.*]] = hw.constant 0 : i32
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_0 : i32, i6
-// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.seq_mem @arg_mem_0 <[33] x 32> [6] : i6, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.seq_mem @mem_0 <[33] x 32> [6] {external = true} : i6, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.assign %[[VAL_3]] = %[[VAL_14]] : i32
+// CHECK:             calyx.assign %[[VAL_3]] = %[[VAL_22]] : i32
 // CHECK:             calyx.group @bb0_0 {
 // CHECK:               calyx.assign %[[VAL_8]] = %[[VAL_7]] : i32
-// CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_9]] : i6
-// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_6]] : i1
-// CHECK:               calyx.assign %[[VAL_20]] = %[[VAL_5]] : i1
-// CHECK:               calyx.group_done %[[VAL_23]] : i1
+// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_9]] : i6
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_14]] = %[[VAL_5]] : i1
+// CHECK:               calyx.group_done %[[VAL_17]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @ret_assign_0 {
-// CHECK:               calyx.assign %[[VAL_10]] = %[[VAL_22]] : i32
-// CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_6]] : i1
-// CHECK:               calyx.group_done %[[VAL_15]] : i1
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_16]] : i32
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_23]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {
@@ -686,7 +617,7 @@ module {
 // CHECK:               calyx.enable @ret_assign_0
 // CHECK:             }
 // CHECK:           }
-// CHECK:         }
+// CHECK:         } {toplevel}
   func.func @main(%mem : memref<33xi32>) -> i32 {
     %c0 = arith.constant 0 : index
     %0 = memref.load %mem[%c0] : memref<33xi32>
@@ -787,72 +718,55 @@ module {
 // Original top-level function's alloc-memories should be passed by reference
 module {
 // CHECK-LABEL:   calyx.component @main(
-// CHECK-SAME:                            %[[VAL_0:.*]]: i1 {clk},
-// CHECK-SAME:                            %[[VAL_1:.*]]: i1 {reset},
-// CHECK-SAME:                            %[[VAL_2:.*]]: i1 {go}) -> (
-// CHECK-SAME:                            %[[VAL_3:.*]]: i1 {done}) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]] = calyx.seq_mem @mem_1 <[1] x 32> [1] {external = true} : i1, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.seq_mem @mem_0 <[1] x 32> [1] {external = true} : i1, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.instance @main_1_instance of @main_1 : i1, i1, i1, i32, i1
-// CHECK:           calyx.wires {
-// CHECK:           }
-// CHECK:           calyx.control {
-// CHECK:             calyx.seq {
-// CHECK:               calyx.invoke @main_1_instance[arg_mem_0 = mem_0, arg_mem_1 = mem_1]() -> ()
-// CHECK:             }
-// CHECK:           }
-// CHECK:         } {toplevel}
-
-// CHECK-LABEL:   calyx.component @main_1(
-// CHECK-SAME:                          %[[VAL_0:.*]]: i1 {clk},
-// CHECK-SAME:                          %[[VAL_1:.*]]: i1 {reset},
-// CHECK-SAME:                          %[[VAL_2:.*]]: i1 {go}) -> (
-// CHECK-SAME:                          %[[VAL_3:.*]]: i32,
-// CHECK-SAME:                          %[[VAL_4:.*]]: i1 {done}) {
+// CHECK-SAME:                          %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {clk},
+// CHECK-SAME:                          %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {reset},
+// CHECK-SAME:                          %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {go}) -> (
+// CHECK-SAME:                          %[[VAL_3:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i32,
+// CHECK-SAME:                          %[[VAL_4:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: i1 {done}) {
 // CHECK:           %[[VAL_5:.*]] = hw.constant true
 // CHECK:           %[[VAL_6:.*]] = hw.constant false
-// CHECK:           %[[VAL_7:.*]] = hw.constant 1 : i32
-// CHECK:           %[[VAL_8:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_7:.*]] = hw.constant 0 : i32
+// CHECK:           %[[VAL_8:.*]] = hw.constant 1 : i32
 // CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]] = calyx.std_slice @std_slice_2 : i32, i1
 // CHECK:           %[[VAL_11:.*]], %[[VAL_12:.*]] = calyx.std_slice @std_slice_1 : i32, i1
 // CHECK:           %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.std_slice @std_slice_0 : i32, i1
 // CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
 // CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]] = calyx.seq_mem @arg_mem_1 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]] = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]] = calyx.seq_mem @mem_1 <[1] x 32> [1] {external = true} : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]] = calyx.seq_mem @mem_0 <[1] x 32> [1] {external = true} : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           calyx.wires {
-// CHECK:             calyx.assign %[[VAL_3]] = %[[VAL_28]] : i32
+// CHECK:             calyx.assign %[[VAL_3]] = %[[VAL_44]] : i32
 // CHECK:             calyx.group @bb0_0 {
-// CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_8]] : i32
-// CHECK:               calyx.assign %[[VAL_38]] = %[[VAL_10]] : i1
-// CHECK:               calyx.assign %[[VAL_41]] = %[[VAL_5]] : i1
-// CHECK:               calyx.assign %[[VAL_42]] = %[[VAL_6]] : i1
-// CHECK:               calyx.group_done %[[VAL_45]] : i1
+// CHECK:               calyx.assign %[[VAL_9]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_32]] = %[[VAL_10]] : i1
+// CHECK:               calyx.assign %[[VAL_35]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_36]] = %[[VAL_6]] : i1
+// CHECK:               calyx.group_done %[[VAL_39]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_1 {
-// CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_8]] : i32
-// CHECK:               calyx.assign %[[VAL_30]] = %[[VAL_12]] : i1
-// CHECK:               calyx.assign %[[VAL_35]] = %[[VAL_7]] : i32
-// CHECK:               calyx.assign %[[VAL_34]] = %[[VAL_5]] : i1
-// CHECK:               calyx.assign %[[VAL_33]] = %[[VAL_5]] : i1
-// CHECK:               calyx.group_done %[[VAL_37]] : i1
+// CHECK:               calyx.assign %[[VAL_11]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_24]] = %[[VAL_12]] : i1
+// CHECK:               calyx.assign %[[VAL_29]] = %[[VAL_8]] : i32
+// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_27]] = %[[VAL_5]] : i1
+// CHECK:               calyx.group_done %[[VAL_31]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @bb0_2 {
-// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_8]] : i32
-// CHECK:               calyx.assign %[[VAL_30]] = %[[VAL_14]] : i1
-// CHECK:               calyx.assign %[[VAL_33]] = %[[VAL_5]] : i1
-// CHECK:               calyx.assign %[[VAL_34]] = %[[VAL_6]] : i1
-// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_36]] : i32
-// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_37]] : i1
+// CHECK:               calyx.assign %[[VAL_13]] = %[[VAL_7]] : i32
+// CHECK:               calyx.assign %[[VAL_24]] = %[[VAL_14]] : i1
+// CHECK:               calyx.assign %[[VAL_27]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_28]] = %[[VAL_6]] : i1
+// CHECK:               calyx.assign %[[VAL_18]] = %[[VAL_30]] : i32
+// CHECK:               calyx.assign %[[VAL_19]] = %[[VAL_31]] : i1
 // CHECK:               calyx.group_done %[[VAL_23]] : i1
 // CHECK:             }
 // CHECK:             calyx.group @ret_assign_0 {
-// CHECK:               calyx.assign %[[VAL_24]] = %[[VAL_17]] : i32
-// CHECK:               calyx.assign %[[VAL_25]] = %[[VAL_5]] : i1
-// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_44]] : i32
+// CHECK:               calyx.assign %[[VAL_40]] = %[[VAL_17]] : i32
+// CHECK:               calyx.assign %[[VAL_41]] = %[[VAL_5]] : i1
+// CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_38]] : i32
 // CHECK:               calyx.assign %[[VAL_16]] = %[[VAL_22]] : i32
-// CHECK:               calyx.group_done %[[VAL_29]] : i1
+// CHECK:               calyx.group_done %[[VAL_45]] : i1
 // CHECK:             }
 // CHECK:           }
 // CHECK:           calyx.control {
@@ -863,7 +777,7 @@ module {
 // CHECK:               calyx.enable @ret_assign_0
 // CHECK:             }
 // CHECK:           }
-// CHECK:         }
+// CHECK:         } {toplevel}
   func.func @main(%arg0 : memref<1xi32>) -> (i32) {
     %0 = arith.constant 0 : index
     %one = arith.constant 1 : i32

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -356,59 +356,59 @@ module {
 // CHECK:    calyx.wires {
 // CHECK-DAG:      calyx.group @bb0_0 {
 // CHECK-DAG:        calyx.assign %std_slice_5.in = %c1_i32 : i32
-// CHECK-DAG:        calyx.assign %arg_mem_0.addr0 = %std_slice_5.out : i1
-// CHECK-DAG:        calyx.assign %arg_mem_0.content_en = %true : i1
-// CHECK-DAG:        calyx.assign %arg_mem_0.write_en = %false : i1
-// CHECK-DAG:        calyx.assign %load_0_reg.in = %arg_mem_0.read_data : i32
-// CHECK-DAG:        calyx.assign %load_0_reg.write_en = %arg_mem_0.done : i1
+// CHECK-DAG:        calyx.assign %mem_0.addr0 = %std_slice_5.out : i1
+// CHECK-DAG:        calyx.assign %mem_0.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_0.write_en = %false : i1
+// CHECK-DAG:        calyx.assign %load_0_reg.in = %mem_0.read_data : i32
+// CHECK-DAG:        calyx.assign %load_0_reg.write_en = %mem_0.done : i1
 // CHECK-DAG:        calyx.group_done %load_0_reg.done : i1
 // CHECK-DAG:      }
 // CHECK-DAG:      calyx.group @bb0_1 {
 // CHECK-DAG:        calyx.assign %std_slice_4.in = %c1_i32 : i32
-// CHECK-DAG:        calyx.assign %arg_mem_2.addr0 = %std_slice_4.out : i1
-// CHECK-DAG:        calyx.assign %arg_mem_2.content_en = %true : i1
-// CHECK-DAG:        calyx.assign %arg_mem_2.write_en = %false : i1
-// CHECK-DAG:        calyx.assign %load_1_reg.in = %arg_mem_2.read_data : i32
-// CHECK-DAG:        calyx.assign %load_1_reg.write_en = %arg_mem_2.done : i1
+// CHECK-DAG:        calyx.assign %mem_2.addr0 = %std_slice_4.out : i1
+// CHECK-DAG:        calyx.assign %mem_2.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_2.write_en = %false : i1
+// CHECK-DAG:        calyx.assign %load_1_reg.in = %mem_2.read_data : i32
+// CHECK-DAG:        calyx.assign %load_1_reg.write_en = %mem_2.done : i1
 // CHECK-DAG:        calyx.group_done %load_1_reg.done : i1
 // CHECK-DAG:      }
 // CHECK-DAG:      calyx.group @bb0_3 {
 // CHECK-DAG:        calyx.assign %std_slice_3.in = %c1_i32 : i32
-// CHECK-DAG:        calyx.assign %arg_mem_1.addr0 = %std_slice_3.out : i1
-// CHECK-DAG:        calyx.assign %arg_mem_1.write_data = %std_add_0.out : i32
-// CHECK-DAG:        calyx.assign %arg_mem_1.write_en = %true : i1
-// CHECK-DAG:        calyx.assign %arg_mem_1.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_1.addr0 = %std_slice_3.out : i1
+// CHECK-DAG:        calyx.assign %mem_1.write_data = %std_add_0.out : i32
+// CHECK-DAG:        calyx.assign %mem_1.write_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_1.content_en = %true : i1
 // CHECK-DAG:        calyx.assign %std_add_0.left = %load_0_reg.out : i32
 // CHECK-DAG:        calyx.assign %std_add_0.right = %load_1_reg.out : i32
-// CHECK-DAG:        calyx.group_done %arg_mem_1.done : i1
+// CHECK-DAG:        calyx.group_done %mem_1.done : i1
 // CHECK-DAG:      }
 // CHECK-DAG:      calyx.group @bb0_4 {
 // CHECK-DAG:        calyx.assign %std_slice_2.in = %c0_i32 : i32
-// CHECK-DAG:        calyx.assign %arg_mem_0.addr0 = %std_slice_2.out : i1
-// CHECK-DAG:        calyx.assign %arg_mem_0.content_en = %true : i1
-// CHECK-DAG:        calyx.assign %arg_mem_0.write_en = %false : i1
-// CHECK-DAG:        calyx.assign %load_2_reg.in = %arg_mem_0.read_data : i32
-// CHECK-DAG:        calyx.assign %load_2_reg.write_en = %arg_mem_0.done : i1
+// CHECK-DAG:        calyx.assign %mem_0.addr0 = %std_slice_2.out : i1
+// CHECK-DAG:        calyx.assign %mem_0.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_0.write_en = %false : i1
+// CHECK-DAG:        calyx.assign %load_2_reg.in = %mem_0.read_data : i32
+// CHECK-DAG:        calyx.assign %load_2_reg.write_en = %mem_0.done : i1
 // CHECK-DAG:        calyx.group_done %load_2_reg.done : i1
 // CHECK-DAG:      }
 // CHECK-DAG:      calyx.group @bb0_5 {
 // CHECK-DAG:        calyx.assign %std_slice_1.in = %c0_i32 : i32
-// CHECK-DAG:        calyx.assign %arg_mem_2.addr0 = %std_slice_1.out : i1
-// CHECK-DAG:        calyx.assign %arg_mem_2.content_en = %true : i1
-// CHECK-DAG:        calyx.assign %arg_mem_2.write_en = %false : i1
-// CHECK-DAG:        calyx.assign %load_3_reg.in = %arg_mem_2.read_data : i32
-// CHECK-DAG:        calyx.assign %load_3_reg.write_en = %arg_mem_2.done : i1
+// CHECK-DAG:        calyx.assign %mem_2.addr0 = %std_slice_1.out : i1
+// CHECK-DAG:        calyx.assign %mem_2.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_2.write_en = %false : i1
+// CHECK-DAG:        calyx.assign %load_3_reg.in = %mem_2.read_data : i32
+// CHECK-DAG:        calyx.assign %load_3_reg.write_en = %mem_2.done : i1
 // CHECK-DAG:        calyx.group_done %load_3_reg.done : i1
 // CHECK-DAG:      }
 // CHECK-DAG:      calyx.group @bb0_7 {
 // CHECK-DAG:        calyx.assign %std_slice_0.in = %c0_i32 : i32
-// CHECK-DAG:        calyx.assign %arg_mem_1.addr0 = %std_slice_0.out : i1
-// CHECK-DAG:        calyx.assign %arg_mem_1.write_data = %std_add_1.out : i32
-// CHECK-DAG:        calyx.assign %arg_mem_1.write_en = %true : i1
-// CHECK-DAG:        calyx.assign %arg_mem_1.content_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_1.addr0 = %std_slice_0.out : i1
+// CHECK-DAG:        calyx.assign %mem_1.write_data = %std_add_1.out : i32
+// CHECK-DAG:        calyx.assign %mem_1.write_en = %true : i1
+// CHECK-DAG:        calyx.assign %mem_1.content_en = %true : i1
 // CHECK-DAG:        calyx.assign %std_add_1.left = %load_2_reg.out : i32
 // CHECK-DAG:        calyx.assign %std_add_1.right = %load_3_reg.out : i32
-// CHECK-DAG:        calyx.group_done %arg_mem_1.done : i1
+// CHECK-DAG:        calyx.group_done %mem_1.done : i1
 // CHECK-DAG:      }
 // CHECK-DAG:    }
 // CHECK-DAG:    calyx.control {


### PR DESCRIPTION
This patch refactors the logic when there are `memref` type function arguments in the top-level function. We used to create a new top-level function, which does nothing but `invoke`ing the old top-level function. This approach is fine semantically, but recently @ayakayorihiro discovered that this prevents the static inference from inferencing the number of cycles in the Calyx project: https://github.com/calyxir/calyx/issues/2452. As a solution, we can just modify the top-level function in-place by moving those `memref` function arguments to explicit `memref.alloc`s in the function body.

Moreover, this patch also supports propagating external memory allocations from non-top-level functions to the top-level function because of the constraint in the Calyx project: https://github.com/calyxir/calyx/blob/50f817f9991df4fa87f2178222ba45a026aba549/calyx/opt/src/passes/well_formed.rs#L185