### PR TITLE
[CalyxEmitter] Emit negative integer values as bitvectors

### DIFF
--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -495,11 +495,19 @@ private:
           // A constant is defined as <bit-width>'<base><value>, where the base
           // is `b` (binary), `o` (octal), `h` hexadecimal, or `d` (decimal).
           APInt value = op.getValue();
+          auto &stream = isIndented ? indent() : os;
+          bool isNegative = value.isNegative();
+          StringRef base = isNegative ? "b" : "d";
 
-          (isIndented ? indent() : os)
-              << std::to_string(value.getBitWidth()) << apostrophe() << "d";
-          // We currently default to the decimal representation.
-          value.print(os, /*isSigned=*/false);
+          stream << std::to_string(value.getBitWidth()) << apostrophe() << base;
+
+          if (isNegative) {
+            SmallString<8> str;
+            value.toStringUnsigned(str, /*Radix=*/2);
+            stream << str;
+          } else {
+            value.print(stream, /*isSigned=*/false);
+          }
         })
         .Case<comb::AndOp>([&](auto op) { emitCombinationalValue(op, "&"); })
         .Case<comb::OrOp>([&](auto op) { emitCombinationalValue(op, "|"); })

--- a/test/Dialect/Calyx/emit-comb-component.mlir
+++ b/test/Dialect/Calyx/emit-comb-component.mlir
@@ -14,7 +14,7 @@ module attributes {calyx.entrypoint = "main"} {
       calyx.assign %1#0 = %in : i32
       // CHECK: add0.right = 32'd1;
       calyx.assign %1#1 = %0 : i32
-      // CHECK: mux0.cond = 1'd1;
+      // CHECK: mux0.cond = 1'b1;
       calyx.assign %2#0 = %3 : i1
       // CHECK: out = add0.out;
       calyx.assign %out = %1#2 : i32
@@ -27,7 +27,7 @@ module attributes {calyx.entrypoint = "main"} {
     %A.in, %A.out = calyx.instance @A_0 of @A : i32, i32
 
     calyx.wires {
-      // CHECK: done = 1'd1;
+      // CHECK: done = 1'b1;
       calyx.assign %done = %c1_1 : i1
       // CHECK: A_0.in = in;
       calyx.assign %A.in = %in : i32

--- a/test/Dialect/Calyx/emit-custom-primitives.mlir
+++ b/test/Dialect/Calyx/emit-custom-primitives.mlir
@@ -19,7 +19,7 @@ module attributes {calyx.entrypoint = "A"} {
     %prim.in, %prim.out = calyx.primitive @prim_0 of @prim : i32, i32
 
     calyx.wires {
-      // CHECK: done = 1'd1;
+      // CHECK: done = 1'b1;
       calyx.assign %done = %c1_1 : i1
       // CHECK: params_0.in = in_0;
       calyx.assign %params.in = %in_0 : i32
@@ -48,7 +48,7 @@ module attributes {calyx.entrypoint = "A"} {
     %params.in, %params.clk, %params.go, %params.out, %params.done = calyx.primitive @params_0 of @params<WIDTH: i32 = 32> : i32, i1, i1, i32, i1
 
     calyx.wires {
-      // CHECK: done = 1'd1;
+      // CHECK: done = 1'b1;
       calyx.assign %done = %c1_1 : i1
       // CHECK: params_0.in = in_0;
       calyx.assign %params.in = %in_0 : i32

--- a/test/Dialect/Calyx/emit-static.mlir
+++ b/test/Dialect/Calyx/emit-static.mlir
@@ -16,7 +16,7 @@ module attributes {calyx.entrypoint = "main"} {
         calyx.assign %incr.left = %p.out : i3
         calyx.assign %incr.right = %c1_3 : i3
         calyx.assign %p.in = %incr.out : i3
-        // CHECK: p.write_en = %0 ? 1'd1;
+        // CHECK: p.write_en = %0 ? 1'b1;
         %0 = calyx.cycle 0
         calyx.assign %p.write_en = %0 ? %c1_1 : i1
       }
@@ -49,7 +49,7 @@ module attributes {calyx.entrypoint = "main"} {
         calyx.assign %incr.left = %p.out : i3
         calyx.assign %incr.right = %c1_3 : i3
         calyx.assign %p.in = %incr.out : i3
-        // CHECK: p.write_en = %0 ? 1'd1;
+        // CHECK: p.write_en = %0 ? 1'b1;
         %0 = calyx.cycle 0
         calyx.assign %p.write_en = %0 ? %c1_1 : i1
       }
@@ -82,11 +82,11 @@ module attributes {calyx.entrypoint = "main"} {
       calyx.static_group latency<2> @A {
         calyx.assign %a.in = %c0_2 : i2
         %0 = calyx.cycle 0
-        // CHECK: a.write_en = %0 ? 1'd1;
+        // CHECK: a.write_en = %0 ? 1'b1;
         calyx.assign %a.write_en = %0 ? %c1_1 : i1
         calyx.assign %b.in = %c1_2 : i2
         %1 = calyx.cycle 1
-        // CHECK: b.write_en = %1 ? 1'd1;
+        // CHECK: b.write_en = %1 ? 1'b1;
         calyx.assign %b.write_en = %1 ? %c1_1 : i1
       }
 
@@ -94,7 +94,7 @@ module attributes {calyx.entrypoint = "main"} {
       calyx.static_group latency<1> @C {
         calyx.assign %c.in = %c2_2 : i2
         %0 = calyx.cycle 0
-        // CHECK: c.write_en = %0 ? 1'd1;
+        // CHECK: c.write_en = %0 ? 1'b1;
         calyx.assign %c.write_en = %0 ? %c1_1 : i1
       }
     }
@@ -123,14 +123,14 @@ module attributes {calyx.entrypoint = "main"} {
       // CHECK: static<1> group A {
       calyx.static_group latency<1> @A {
         calyx.assign %a.in = %c0_2  : i2
-        // CHECK: a.write_en = %0 ? 1'd1;
+        // CHECK: a.write_en = %0 ? 1'b1;
         %0 = calyx.cycle 0
         calyx.assign %a.write_en = %0 ? %c1_1 : i1
       }
       // CHECK: static<1> group B {
       calyx.static_group latency<1> @B {
         calyx.assign %b.in =%c2_2  : i2
-        // CHECK: b.write_en = %0 ? 1'd1;
+        // CHECK: b.write_en = %0 ? 1'b1;
         %0 = calyx.cycle 0
         calyx.assign %b.write_en = %0 ? %c1_1 : i1
       }
@@ -162,7 +162,7 @@ module attributes {calyx.entrypoint = "main"} {
       // CHECK: static<1> group C {
       calyx.static_group latency<1> @C {
         calyx.assign %c.in = %c0_2 : i2
-        // CHECK: c.write_en = %0 ? 1'd1;
+        // CHECK: c.write_en = %0 ? 1'b1;
         %0 = calyx.cycle 0
         calyx.assign %c.write_en = %0 ? %c1_1 : i1
       }
@@ -170,7 +170,7 @@ module attributes {calyx.entrypoint = "main"} {
       // CHECK: static<1> group D {
       calyx.static_group latency<1> @D {
         calyx.assign %d.in = %c1_2 : i2
-        // CHECK: d.write_en = %0 ? 1'd1;
+        // CHECK: d.write_en = %0 ? 1'b1;
         %0 = calyx.cycle 0
         calyx.assign %d.write_en = %0 ? %c1_1 : i1
       }

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -9,7 +9,7 @@ module attributes {calyx.metadata = ["location1", "location2"], calyx.entrypoint
     %c1_1 = hw.constant 1 : i1
 
     calyx.wires {
-      // CHECK: done = 1'd1;
+      // CHECK: done = 1'b1;
       calyx.assign %done = %c1_1 : i1
     }
     calyx.control {}
@@ -34,8 +34,8 @@ module attributes {calyx.metadata = ["location1", "location2"], calyx.entrypoint
     // CHECK-LABEL: group DivRemWrite {
     // CHECK-NEXT:   s1.in = divs.out_quotient;
     // CHECK-NEXT:   s2.in = remu.out_remainder;
-    // CHECK-NEXT:   s1.write_en = 1'd1;
-    // CHECK-NEXT:   s2.write_en = 1'd1;
+    // CHECK-NEXT:   s1.write_en = 1'b1;
+    // CHECK-NEXT:   s2.write_en = 1'b1;
     // CHECK-NEXT:   DivRemWrite[done] = s1.done;
     // CHECK-NEXT: }
       calyx.group @DivRemWrite {
@@ -54,7 +54,7 @@ module attributes {calyx.metadata = ["location1", "location2"], calyx.entrypoint
       // CHECK-LABEL: group MultWrite
       // CHECK-NEXT: mu.left = 32'd4;
       // CHECK-NEXT: mu.right = 32'd4;
-      // CHECK-NEXT: mu.go = 1'd1;
+      // CHECK-NEXT: mu.go = 1'b1;
       // CHECK-NEXT: s1.write_en = mu.done;
       // CHECK-NEXT: s1.in = mu.out;
       // CHECK-NEXT: MultWrite[done] = s1.done;
@@ -113,7 +113,7 @@ module attributes {calyx.metadata = ["location1", "location2"], calyx.entrypoint
     calyx.wires {
       // CHECK-NEXT: group Group1<"static"=1,> {
       // CHECK-NEXT:    s0.in = a0.out;
-      // CHECK-NEXT:    m0.addr0 = 1'd1;
+      // CHECK-NEXT:    m0.addr0 = 1'b1;
       // CHECK-NEXT:    a0.left = m0.read_data;
       // CHECK-NEXT:    a0.right = 32'd1;
       // CHECK-NEXT:    Group1[go] = 1'd0;
@@ -129,7 +129,7 @@ module attributes {calyx.metadata = ["location1", "location2"], calyx.entrypoint
         calyx.group_done %c0.done : i1
       } {static = 1}
       // CHECK-LABEL: comb group Group2 {
-      // CHECK-NEXT:     c1.in = (c1.out | (c1.out & 1'd1 & !c1.out)) ? c1.out;
+      // CHECK-NEXT:     c1.in = (c1.out | (c1.out & 1'b1 & !c1.out)) ? c1.out;
       calyx.comb_group @Group2 {
         %not = comb.xor %c1.out, %c1 : i1
         %and = comb.and %c1.out, %c1, %not : i1
@@ -138,7 +138,7 @@ module attributes {calyx.metadata = ["location1", "location2"], calyx.entrypoint
       }
       // CHECK-LABEL: group Group3 {
       // CHECK-NEXT:     r.in = s0.out;
-      // CHECK-NEXT:     r.write_en = 1'd1;
+      // CHECK-NEXT:     r.write_en = 1'b1;
       // CHECK-NEXT:     Group3[done] = r.done;
       calyx.group @Group3 {
         calyx.assign %r.in = %s0.out : i8
@@ -258,10 +258,10 @@ module attributes {calyx.entrypoint = "main"} {
 
       // CHECK-LABEL: group ret_assign_0 {
       // CHECK-NEXT:    ret_arg0_reg.in = 32'd42;
-      // CHECK-NEXT:    ret_arg0_reg.write_en = 1'd1;
+      // CHECK-NEXT:    ret_arg0_reg.write_en = 1'b1;
       // CHECK-NEXT:    ret_arg1_reg.in = cst_0.out;
-      // CHECK-NEXT:    ret_arg1_reg.write_en = 1'd1;
-      // CHECK-NEXT:    ret_assign_0[done] = (ret_arg1_reg.done & ret_arg0_reg.done) ? 1'd1;
+      // CHECK-NEXT:    ret_arg1_reg.write_en = 1'b1;
+      // CHECK-NEXT:    ret_assign_0[done] = (ret_arg1_reg.done & ret_arg0_reg.done) ? 1'b1;
       // CHECK-NEXT:  }
       calyx.group @ret_assign_0 {
         calyx.assign %ret_arg0_reg.in = %c42_i32 : i32
@@ -303,7 +303,7 @@ module attributes {calyx.entrypoint = "main"} {
       // CHECK-NEXT:    std_addFN_0.right = cst_0.out;
       // CHECK-NEXT:    addf_0_reg.in = std_addFN_0.out;
       // CHECK-NEXT:    addf_0_reg.write_en = std_addFN_0.done;
-      // CHECK-NEXT:    std_addFN_0.go = !std_addFN_0.done ? 1'd1;
+      // CHECK-NEXT:    std_addFN_0.go = !std_addFN_0.done ? 1'b1;
       // CHECK-NEXT:    std_addFN_0.subOp = 1'd0;
       // CHECK-NEXT:    bb0_0[done] = addf_0_reg.done;
       // CHECK-NEXT:  }
@@ -355,7 +355,7 @@ module attributes {calyx.entrypoint = "main"} {
       // CHECK-NEXT:      std_mulFN_0.right = cst_0.out;
       // CHECK-NEXT:      mulf_0_reg.in = std_mulFN_0.out;
       // CHECK-NEXT:      mulf_0_reg.write_en = std_mulFN_0.done;
-      // CHECK-NEXT:      std_mulFN_0.go = !std_mulFN_0.done ? 1'd1;
+      // CHECK-NEXT:      std_mulFN_0.go = !std_mulFN_0.done ? 1'b1;
       // CHECK-NEXT:      bb0_0[done] = mulf_0_reg.done;
       // CHECK-NEXT:     }
       calyx.group @bb0_0 {
@@ -407,14 +407,14 @@ module attributes {calyx.entrypoint = "main"} {
       // CHECK-NEXT:      compare_port_0_reg.write_en = std_compareFN_0.done;
       // CHECK-NEXT:      compare_port_0_reg.in = std_compareFN_0.eq;
       // CHECK-NEXT:      unordered_port_0_reg.write_en = std_compareFN_0.done;
-      // CHECK-NEXT:      unordered_port_0_reg.in = !std_compareFN_0.unordered ? 1'd1;
+      // CHECK-NEXT:      unordered_port_0_reg.in = !std_compareFN_0.unordered ? 1'b1;
       // CHECK-NEXT:      std_and_0.left = compare_port_0_reg.out;
       // CHECK-NEXT:      std_and_0.right = unordered_port_0_reg.out;
       // CHECK-NEXT:      std_and_1.left = compare_port_0_reg.done;
       // CHECK-NEXT:      std_and_1.right = unordered_port_0_reg.done;
       // CHECK-NEXT:      cmpf_0_reg.in = std_and_0.out;
       // CHECK-NEXT:      cmpf_0_reg.write_en = std_and_1.out;
-      // CHECK-NEXT:      std_compareFN_0.go = !std_compareFN_0.done ? 1'd1;
+      // CHECK-NEXT:      std_compareFN_0.go = !std_compareFN_0.done ? 1'b1;
       // CHECK-NEXT:      bb0_0[done] = cmpf_0_reg.done;
       // CHECK-NEXT:    }
       calyx.group @bb0_0 {
@@ -466,8 +466,8 @@ module attributes {calyx.entrypoint = "main"} {
       calyx.assign %out0 = %ret_arg0_reg.out : i64
       // CHECK-LABEL:    group bb0_0 {
       // CHECK-NEXT:      std_fptointFN_0.in = in0;
-      // CHECK-NEXT:      std_fptointFN_0.signedOut = 1'd1;
-      // CHECK-NEXT:      std_fptointFN_0.go = !std_fptointFN_0.done ? 1'd1;
+      // CHECK-NEXT:      std_fptointFN_0.signedOut = 1'b1;
+      // CHECK-NEXT:      std_fptointFN_0.go = !std_fptointFN_0.done ? 1'b1;
       // CHECK-NEXT:      bb0_0[done] = fptosi_0_reg.done;
       // CHECK-NEXT:    }
       calyx.group @bb0_0 {
@@ -508,8 +508,8 @@ module attributes {calyx.entrypoint = "main"} {
       calyx.assign %out0 = %ret_arg0_reg.out : i32
         // CHECK-LABEL:    group bb0_0 {
         // CHECK-NEXT:      std_intToFpFN_0.in = in0;
-        // CHECK-NEXT:      std_intToFpFN_0.signedIn = 1'd1;
-        // CHECK-NEXT:      std_intToFpFN_0.go = !std_intToFpFN_0.done ? 1'd1;
+        // CHECK-NEXT:      std_intToFpFN_0.signedIn = 1'b1;
+        // CHECK-NEXT:      std_intToFpFN_0.go = !std_intToFpFN_0.done ? 1'b1;
         // CHECK-NEXT:      bb0_0[done] = sitofp_0_reg.done;
         // CHECK-NEXT:    }
       calyx.group @bb0_0 {
@@ -555,7 +555,7 @@ module attributes {calyx.entrypoint = "main"} {
       // CHECK-NEXT:      std_divSqrtFN_0.right = cst_0.out;
       // CHECK-NEXT:      divf_0_reg.in = std_divSqrtFN_0.out;
       // CHECK-NEXT:      divf_0_reg.write_en = std_divSqrtFN_0.done;
-      // CHECK-NEXT:      std_divSqrtFN_0.go = !std_divSqrtFN_0.done ? 1'd1;
+      // CHECK-NEXT:      std_divSqrtFN_0.go = !std_divSqrtFN_0.done ? 1'b1;
       // CHECK-NEXT:      std_divSqrtFN_0.sqrtOp = 1'd0;
       // CHECK-NEXT:      bb0_0[done] = divf_0_reg.done;
       // CHECK-NEXT:    }
@@ -581,6 +581,35 @@ module attributes {calyx.entrypoint = "main"} {
           calyx.enable @bb0_0
           calyx.enable @ret_assign_0
         }
+      }
+    }
+  } {toplevel}
+}
+
+// -----
+
+// Emit negative integer values as bitvectors
+
+module attributes {calyx.entrypoint = "main"} {
+  calyx.component @main(%in0: i32, %clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%out0: i32, %done: i1 {done}) {
+    %c-2147483648_i32 = hw.constant -2147483648 : i32
+    %true = hw.constant true
+    %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
+    %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
+    calyx.wires {
+      calyx.assign %out0 = %ret_arg0_reg.out : i32
+      calyx.group @ret_assign_0 {
+        calyx.assign %ret_arg0_reg.in = %std_add_0.out : i32
+        calyx.assign %ret_arg0_reg.write_en = %true : i1
+        calyx.assign %std_add_0.left = %in0 : i32
+        // CHECK: std_add_0.right = 32'b10000000000000000000000000000000;
+        calyx.assign %std_add_0.right = %c-2147483648_i32 : i32
+        calyx.group_done %ret_arg0_reg.done : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.enable @ret_assign_0
       }
     }
   } {toplevel}


### PR DESCRIPTION
This patch supports the Calyx emitter to emit negative integer values as bitvectors.