### PR TITLE
[Arc][NFC] Make `arc.state` summary clearer

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -138,7 +138,7 @@ def StateOp : ArcOp<"state", [
     CPred<[{getInitials().empty() ||
               llvm::equal(getInitials().getType(), getResults().getType())}]>>
 ]> {
-  let summary = "State transfer arc";
+  let summary = "Instantiates a state element with input from a transfer arc";
 
   let arguments = (ins
     FlatSymbolRefAttr:$arc,


### PR DESCRIPTION
Tiny change, just makes the summary for `arc.state` a bit clearer as it's a bit opaque at the moment