### PR TITLE
[Arc] Make `isInput` in `ImportedValue` (in SplitLoops) a bool

### DIFF
--- a/lib/Dialect/Arc/Transforms/SplitLoops.cpp
+++ b/lib/Dialect/Arc/Transforms/SplitLoops.cpp
@@ -41,7 +41,7 @@ struct ImportedValue {
   /// Indicates where this value originates from. If true, the value is an input
   /// of the original arc. If false the value is exported from a different
   /// split.
-  unsigned isInput : 1;
+  bool isInput : 1;
   /// The original arc's input number, or the result number of the split that
   /// exports this value.
   unsigned index : 15;


### PR DESCRIPTION
`isInput` is defined as an unsigned, but is documented as if it's a bool and is only ever written or read as a bool. Guessing this is not deliberate, but let me know if it is!