### PR TITLE
[CalyxEmitter] Negative, infinite, and NaN floating point values emitted as bitvectors

### DIFF
--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -1104,6 +1104,21 @@ void Emitter::emitAssignment(AssignOp op) {
     emitValue(op.getGuard(), /*isIndented=*/false);
     os << questionMark();
   }
+  if (auto constantOp =
+          dyn_cast_or_null<calyx::ConstantOp>(op.getSrc().getDefiningOp())) {
+    TypedAttr attr = constantOp.getValueAttr();
+    assert(isa<FloatAttr>(attr) && "must be a floating point constant");
+    auto fltAttr = cast<FloatAttr>(attr);
+    APFloat value = fltAttr.getValue();
+    if (value.isInfinity() || value.isNaN() || value.isNegative()) {
+      SmallString<8> str;
+      auto intValue = value.bitcastToAPInt();
+      intValue.toStringUnsigned(str, /*Radix=*/2);
+      os << std::to_string(intValue.getBitWidth()) << apostrophe() << "b" << str
+         << semicolonEndL();
+      return;
+    }
+  }
   emitValue(op.getSrc(), /*isIndented=*/false);
   os << semicolonEndL();
 }

--- a/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
+++ b/lib/Dialect/Calyx/Export/CalyxEmitter.cpp
@@ -1108,7 +1108,8 @@ void Emitter::emitAssignment(AssignOp op) {
           dyn_cast_or_null<calyx::ConstantOp>(op.getSrc().getDefiningOp())) {
     TypedAttr attr = constantOp.getValueAttr();
     assert(isa<FloatAttr>(attr) && "must be a floating point constant");
-    auto fltAttr = cast<FloatAttr>(attr);
+    auto fltAttr = dyn_cast<FloatAttr>(attr);
+    assert(attr != nullptr && "must be a floating point constant");
     APFloat value = fltAttr.getValue();
     if (value.isInfinity() || value.isNaN() || value.isNegative()) {
       SmallString<8> str;

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -617,30 +617,77 @@ module attributes {calyx.entrypoint = "main"} {
 
 // -----
 
-// Emit negative floating point values
+// Emit negative, NaN, and infinite floating point values
 
 module attributes {calyx.entrypoint = "main"} {
   calyx.component @main(%clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
     %true = hw.constant true
-    %cst = calyx.constant @cst_0 <-4.200000e+00 : f32> : i32
+    %false = hw.constant false
+    %cst = calyx.constant @cst_2 <0xFF800000 : f32> : i32
+    %cst_0 = calyx.constant @cst_1 <0x7FC00000 : f32> : i32
+    %cst_1 = calyx.constant @cst_0 <-4.200000e+00 : f32> : i32
     %c0_i32 = hw.constant 0 : i32
+    %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i1
     %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i1
+    %std_mux_0.cond, %std_mux_0.tru, %std_mux_0.fal, %std_mux_0.out = calyx.std_mux @std_mux_0 : i1, i32, i32, i32
+    %std_and_0.left, %std_and_0.right, %std_and_0.out = calyx.std_and @std_and_0 : i1, i1, i1
+    %std_or_0.left, %std_or_0.right, %std_or_0.out = calyx.std_or @std_or_0 : i1, i1, i1
+    %unordered_port_0_reg.in, %unordered_port_0_reg.write_en, %unordered_port_0_reg.clk, %unordered_port_0_reg.reset, %unordered_port_0_reg.out, %unordered_port_0_reg.done = calyx.register @unordered_port_0_reg : i1, i1, i1, i1, i1, i1
+    %compare_port_0_reg.in, %compare_port_0_reg.write_en, %compare_port_0_reg.clk, %compare_port_0_reg.reset, %compare_port_0_reg.out, %compare_port_0_reg.done = calyx.register @compare_port_0_reg : i1, i1, i1, i1, i1, i1
+    %cmpf_0_reg.in, %cmpf_0_reg.write_en, %cmpf_0_reg.clk, %cmpf_0_reg.reset, %cmpf_0_reg.out, %cmpf_0_reg.done = calyx.register @cmpf_0_reg : i1, i1, i1, i1, i1, i1
+    %std_compareFN_0.clk, %std_compareFN_0.reset, %std_compareFN_0.go, %std_compareFN_0.left, %std_compareFN_0.right, %std_compareFN_0.signaling, %std_compareFN_0.lt, %std_compareFN_0.eq, %std_compareFN_0.gt, %std_compareFN_0.unordered, %std_compareFN_0.exceptionalFlags, %std_compareFN_0.done = calyx.ieee754.compare @std_compareFN_0 : i1, i1, i1, i32, i32, i1, i1, i1, i1, i1, i5, i1
+    %load_0_reg.in, %load_0_reg.write_en, %load_0_reg.clk, %load_0_reg.reset, %load_0_reg.out, %load_0_reg.done = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
     %mem_0.addr0, %mem_0.clk, %mem_0.reset, %mem_0.content_en, %mem_0.write_en, %mem_0.write_data, %mem_0.read_data, %mem_0.done = calyx.seq_mem @mem_0 <[1] x 32> [1] {external = true} : i1, i1, i1, i1, i1, i32, i32, i1
     calyx.wires {
       calyx.group @bb0_0 {
+        calyx.assign %std_slice_1.in = %c0_i32 : i32
+        calyx.assign %mem_0.addr0 = %std_slice_1.out : i1
+        calyx.assign %mem_0.content_en = %true : i1
+        calyx.assign %mem_0.write_en = %false : i1
+        calyx.assign %load_0_reg.in = %mem_0.read_data : i32
+        calyx.assign %load_0_reg.write_en = %mem_0.done : i1
+        calyx.group_done %load_0_reg.done : i1
+      }
+      calyx.group @bb0_1 {
+        calyx.assign %std_compareFN_0.left = %load_0_reg.out : i32
+        // CHECK: std_compareFN_0.right = 32'b11111111100000000000000000000000;
+        calyx.assign %std_compareFN_0.right = %cst : i32
+        calyx.assign %std_compareFN_0.signaling = %true : i1
+        calyx.assign %compare_port_0_reg.write_en = %std_compareFN_0.done : i1
+        calyx.assign %compare_port_0_reg.in = %std_compareFN_0.gt : i1
+        calyx.assign %unordered_port_0_reg.write_en = %std_compareFN_0.done : i1
+        calyx.assign %unordered_port_0_reg.in = %std_compareFN_0.unordered : i1
+        calyx.assign %std_or_0.left = %compare_port_0_reg.out : i1
+        calyx.assign %std_or_0.right = %unordered_port_0_reg.out : i1
+        calyx.assign %std_and_0.left = %compare_port_0_reg.done : i1
+        calyx.assign %std_and_0.right = %unordered_port_0_reg.done : i1
+        calyx.assign %cmpf_0_reg.in = %std_or_0.out : i1
+        calyx.assign %cmpf_0_reg.write_en = %std_and_0.out : i1
+        %0 = comb.xor %std_compareFN_0.done, %true : i1
+        calyx.assign %std_compareFN_0.go = %0 ? %true : i1
+        calyx.group_done %cmpf_0_reg.done : i1
+      }
+      calyx.group @bb0_3 {
         calyx.assign %std_slice_0.in = %c0_i32 : i32
         calyx.assign %mem_0.addr0 = %std_slice_0.out : i1
-        // CHECK:     mem_0.write_data = 32'b11000000100001100110011001100110;
-        calyx.assign %mem_0.write_data = %cst : i32
+        calyx.assign %mem_0.write_data = %std_mux_0.out : i32
         calyx.assign %mem_0.write_en = %true : i1
         calyx.assign %mem_0.content_en = %true : i1
+        calyx.assign %std_mux_0.cond = %cmpf_0_reg.out : i1
+        // CHECK: std_mux_0.tru = 32'b11000000100001100110011001100110;
+        calyx.assign %std_mux_0.tru = %cst_1 : i32
+        // CHECK: std_mux_0.fal = 32'b1111111110000000000000000000000;
+        calyx.assign %std_mux_0.fal = %cst_0 : i32
         calyx.group_done %mem_0.done : i1
       }
     }
     calyx.control {
       calyx.seq {
         calyx.enable @bb0_0
+        calyx.enable @bb0_1
+        calyx.enable @bb0_3
       }
     }
   } {toplevel}
 }
+

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -614,3 +614,33 @@ module attributes {calyx.entrypoint = "main"} {
     }
   } {toplevel}
 }
+
+// -----
+
+// Emit negative floating point values
+
+module attributes {calyx.entrypoint = "main"} {
+  calyx.component @main(%clk: i1 {clk}, %reset: i1 {reset}, %go: i1 {go}) -> (%done: i1 {done}) {
+    %true = hw.constant true
+    %cst = calyx.constant @cst_0 <-4.200000e+00 : f32> : i32
+    %c0_i32 = hw.constant 0 : i32
+    %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i1
+    %mem_0.addr0, %mem_0.clk, %mem_0.reset, %mem_0.content_en, %mem_0.write_en, %mem_0.write_data, %mem_0.read_data, %mem_0.done = calyx.seq_mem @mem_0 <[1] x 32> [1] {external = true} : i1, i1, i1, i1, i1, i32, i32, i1
+    calyx.wires {
+      calyx.group @bb0_0 {
+        calyx.assign %std_slice_0.in = %c0_i32 : i32
+        calyx.assign %mem_0.addr0 = %std_slice_0.out : i1
+        // CHECK:     mem_0.write_data = 32'b11000000100001100110011001100110;
+        calyx.assign %mem_0.write_data = %cst : i32
+        calyx.assign %mem_0.write_en = %true : i1
+        calyx.assign %mem_0.content_en = %true : i1
+        calyx.group_done %mem_0.done : i1
+      }
+    }
+    calyx.control {
+      calyx.seq {
+        calyx.enable @bb0_0
+      }
+    }
+  } {toplevel}
+}


### PR DESCRIPTION
This patch emits negative, infinite, and NaN floating point values as bitvectors because Calyx native compiler does not support parsing negative values like `std_float_const(32, -4.2)` nor any non-digits like `std_float_const(32, inf)`.