### PR TITLE
[circt-synth] Lower comb.add to Parallel-Prefix Adder 

### DIFF
--- a/integration_test/circt-synth/comb-lowering-large-lec.mlir
+++ b/integration_test/circt-synth/comb-lowering-large-lec.mlir
@@ -1,0 +1,17 @@
+// REQUIRES: libz3
+// REQUIRES: circt-lec-jit
+
+// RUN: circt-opt %s --hw-aggregate-to-comb --convert-comb-to-aig --convert-aig-to-comb -o %t.mlir
+// RUN: circt-lec %t.mlir %s -c1=add16 -c2=add16 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_16
+// COMB_ADD_16: c1 == c2
+hw.module @add16(in %arg0: i16, in %arg1: i16, in %arg2: i16,  out add: i16) {
+  %0 = comb.add %arg0, %arg1, %arg2 : i16
+  hw.output %0 : i16
+}
+
+// RUN: circt-lec %t.mlir %s -c1=add33 -c2=add33 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_33
+// COMB_ADD_33: c1 == c2
+hw.module @add33(in %arg0: i33, in %arg1: i33, in %arg2: i33,  out add: i33) {
+  %0 = comb.add %arg0, %arg1, %arg2 : i33
+  hw.output %0 : i33
+}

--- a/integration_test/circt-synth/comb-lowering-lec.mlir
+++ b/integration_test/circt-synth/comb-lowering-lec.mlir
@@ -21,11 +21,25 @@ hw.module @parity(in %arg0: i4, out out: i1) {
   hw.output %0 : i1
 }
 
-// RUN: circt-lec %t.mlir %s -c1=add -c2=add --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD
-// COMB_ADD: c1 == c2
-hw.module @add(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4) {
+// RUN: circt-lec %t.mlir %s -c1=add -c2=add --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_4
+// COMB_ADD_4: c1 == c2
+hw.module @add4(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4) {
   %0 = comb.add %arg0, %arg1, %arg2 : i4
   hw.output %0 : i4
+}
+
+// RUN: circt-lec %t.mlir %s -c1=add16 -c2=add16 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_16
+// COMB_ADD_16: c1 == c2
+hw.module @add16(in %arg0: i16, in %arg1: i16, in %arg2: i16,  out add: i16) {
+  %0 = comb.add %arg0, %arg1, %arg2 : i16
+  hw.output %0 : i16
+}
+
+// RUN: circt-lec %t.mlir %s -c1=add33 -c2=add33 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_33
+// COMB_ADD_33: c1 == c2
+hw.module @add33(in %arg0: i33, in %arg1: i33, in %arg2: i33,  out add: i33) {
+  %0 = comb.add %arg0, %arg1, %arg2 : i33
+  hw.output %0 : i33
 }
 
 // RUN: circt-lec %t.mlir %s -c1=sub -c2=sub --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_SUB

--- a/integration_test/circt-synth/comb-lowering-lec.mlir
+++ b/integration_test/circt-synth/comb-lowering-lec.mlir
@@ -21,25 +21,11 @@ hw.module @parity(in %arg0: i4, out out: i1) {
   hw.output %0 : i1
 }
 
-// RUN: circt-lec %t.mlir %s -c1=add -c2=add --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_4
-// COMB_ADD_4: c1 == c2
-hw.module @add4(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4) {
+// RUN: circt-lec %t.mlir %s -c1=add -c2=add --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD
+// COMB_ADD: c1 == c2
+hw.module @add(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4) {
   %0 = comb.add %arg0, %arg1, %arg2 : i4
   hw.output %0 : i4
-}
-
-// RUN: circt-lec %t.mlir %s -c1=add16 -c2=add16 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_16
-// COMB_ADD_16: c1 == c2
-hw.module @add16(in %arg0: i16, in %arg1: i16, in %arg2: i16,  out add: i16) {
-  %0 = comb.add %arg0, %arg1, %arg2 : i16
-  hw.output %0 : i16
-}
-
-// RUN: circt-lec %t.mlir %s -c1=add33 -c2=add33 --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD_33
-// COMB_ADD_33: c1 == c2
-hw.module @add33(in %arg0: i33, in %arg1: i33, in %arg2: i33,  out add: i33) {
-  %0 = comb.add %arg0, %arg1, %arg2 : i33
-  hw.output %0 : i33
 }
 
 // RUN: circt-lec %t.mlir %s -c1=sub -c2=sub --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_SUB

--- a/lib/Conversion/CombToAIG/CombToAIG.cpp
+++ b/lib/Conversion/CombToAIG/CombToAIG.cpp
@@ -530,7 +530,8 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
  
     // Step 2: Brent-Kung parallel prefix computation
     // First, compute prefix for adjacent pairs (distance 1)
-    for (unsigned stride = 1; stride < width; stride *= 2) {
+    unsigned stride = 1;
+    for (; stride < width; stride *= 2) {
       for (unsigned i = stride * 2 - 1; i < width; i += stride * 2) {
         unsigned j = i - stride;
 
@@ -545,7 +546,7 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
     }
 
     // Step 3: Back propagation phase - distribute prefix computations
-    for (unsigned stride = width / 4; stride > 0; stride /= 2) {
+    for (; stride > 0; stride /= 2) {
       for (unsigned i = stride * 3 - 1; i < width; i += stride * 2) {
           unsigned j = i - stride;
 
@@ -588,7 +589,7 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
     }
 
     unsigned stage = 0;
-    for (unsigned stride = 1; stride < width; stride *= 2) {
+    for (stride = 1; stride < width; stride *= 2) {
       LLVM_DEBUG(llvm::dbgs()
                  << "--------------------------------------- Stage " << stage
                  << "\n");
@@ -609,7 +610,7 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
     }
 
     // Step 3: Back propagation phase - distribute prefix computations
-    for (unsigned stride = width / 4; stride > 0; stride /= 2) {
+    for (; stride > 0; stride /= 2) {
       LLVM_DEBUG(llvm::dbgs()
                  << "--------------------------------------- Back Propagation "
                     "Stage "

--- a/lib/Conversion/CombToAIG/CombToAIG.cpp
+++ b/lib/Conversion/CombToAIG/CombToAIG.cpp
@@ -17,6 +17,9 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "comb-to-aig"
 
 namespace circt {
 #define GEN_PASS_DEF_CONVERTCOMBTOAIG
@@ -390,6 +393,94 @@ struct CombAddOpConversion : OpConversionPattern<AddOp> {
       return success();
     }
 
+    if (width < 8) 
+      return LowerRippleCarryAdder(op, inputs, rewriter);
+    else
+      return LowerKoggeStoneAdder(op, inputs, rewriter);
+  }
+    
+  // Implement the Kogge-Stone adder as a separate method
+  LogicalResult LowerKoggeStoneAdder(
+    comb::AddOp op, ValueRange inputs,
+    ConversionPatternRewriter &rewriter) const { 
+    auto width = op.getType().getIntOrFloatBitWidth(); 
+    
+    Value carry;
+
+    auto aBits = extractBits(rewriter, inputs[0]);
+    auto bBits = extractBits(rewriter, inputs[1]);
+    // Stage 1: Construct propagate (p) and generate (g) signals
+    SmallVector<Value> p, g;
+    p.resize(width); g.resize(width);
+  
+    for (unsigned i = 0; i < width; i++) {
+      // p_i = a_i XOR b_i
+      p[i] = rewriter.create<comb::XorOp>(op.getLoc(), aBits[i], bBits[i]);
+      // g_i = a_i AND b_i
+      g[i] = rewriter.create<comb::AndOp>(op.getLoc(), aBits[i], bBits[i]);
+    }
+
+    // Stage 2: Kogge-Stone prefix computation
+    // This implements the parallel prefix computation with log2(width) stages
+  
+    // Create copies of p and g for the prefix computation
+    SmallVector<Value> pPrefix = p;
+    SmallVector<Value> gPrefix = g;
+    
+    // For each stage in the prefix network
+    for (unsigned stage = 0; (1u << stage) < width; stage++) {
+      unsigned gap = 1 << stage;
+
+      SmallVector<Value> pNew = pPrefix;
+      SmallVector<Value> gNew = gPrefix;
+
+      for (unsigned i = gap; i < width; i++) {
+        // Group propagate: p_i:j = p_i:k AND p_k-1:j
+        pNew[i] = rewriter.create<comb::AndOp>(op.getLoc(), pPrefix[i], pPrefix[i - gap]);
+        
+        // Group generate: g_i:j = g_i:k OR (p_i:k AND g_k-1:j)
+        Value andTerm = rewriter.create<comb::AndOp>(op.getLoc(), pPrefix[i], gPrefix[i - gap]);
+        gNew[i] = rewriter.create<comb::OrOp>(op.getLoc(), gPrefix[i], andTerm);
+        
+      }
+
+      pPrefix = pNew;
+      gPrefix = gNew;
+    }
+    for (unsigned stage = 0; (1u << stage) < width; stage++) {
+      LLVM_DEBUG(llvm::dbgs() << "--------------------------------------- Stage " << stage << "\n");
+      unsigned gap = 1 << stage;
+      for (unsigned i = gap; i < width; i++) {
+        // Group propagate: p_i:j = p_i:k AND p_k-1:j
+        LLVM_DEBUG(llvm::dbgs() << "P" << stage+1 << i << " = P"<<stage<<i<< " AND P"<<stage<<i-gap<< "\n");
+        // Group generate: g_i:j = g_i:k OR (p_i:k AND g_k-1:j)
+        LLVM_DEBUG(llvm::dbgs() << "G" << stage+1 << i << " = G"<<stage<<i
+                                                    << " OR (P"<<stage<<i<<" AND G"<<stage<<i-gap<<")\n");
+      }
+    }
+
+    // Stage 3: Generate sum bits
+    // NOTE: The result is stored in reverse order.
+    SmallVector<Value> results;
+    results.resize(width);
+    // Sum bit 0 is just p[0] since carry_in = 0
+    results[width-1] = p[0];
+
+    // For remaining bits, sum_i = p_i XOR c_(i-1)
+    for (unsigned i = 1; i < width; i++) {
+      // The carry into position i is the group generate from position i-1
+      results[width-1-i] = rewriter.create<comb::XorOp>(op.getLoc(), p[i], gPrefix[i-1]);
+    }
+
+    rewriter.replaceOpWithNewOp<comb::ConcatOp>(op, results);
+    return success();
+  }
+
+  // Implement a basic ripple-carry adder for small bitwidths.
+  LogicalResult LowerRippleCarryAdder(
+    comb::AddOp op, ValueRange inputs,
+    ConversionPatternRewriter &rewriter) const { 
+    auto width = op.getType().getIntOrFloatBitWidth(); 
     // Implement a naive Ripple-carry full adder.
     Value carry;
 

--- a/test/Conversion/CombToAIG/comb-to-aig-arith.mlir
+++ b/test/Conversion/CombToAIG/comb-to-aig-arith.mlir
@@ -29,6 +29,24 @@ hw.module @add(in %lhs: i2, in %rhs: i2, out out: i2) {
   hw.output %0 : i2
 }
 
+// CHECK-LABEL: @add_17
+hw.module @add_17(in %lhs: i17, in %rhs: i17, out out: i17) {
+  %0 = comb.add %lhs, %rhs : i17
+  hw.output %0 : i17
+}
+
+// CHECK-LABEL: @add_35
+hw.module @add_35(in %lhs: i35, in %rhs: i35, out out: i35) {
+  %0 = comb.add %lhs, %rhs : i35
+  hw.output %0 : i35
+}
+
+// CHECK-LABEL: @add_64
+hw.module @add_64(in %lhs: i64, in %rhs: i64, out out: i64) {
+  %0 = comb.add %lhs, %rhs : i64
+  hw.output %0 : i64
+}
+
 // CHECK-LABEL: @sub
 // ALLOW_ADD-LABEL: @sub
 // ALLOW_ADD-NEXT: %[[NOT_RHS:.+]] = aig.and_inv not %rhs


### PR DESCRIPTION
## Summary
An addition to the CombToAIG pass, reducing adders of width greater than 8 to a parallel-prefix adder. Currently implemented two flavours of parallel-prefix reduction tree.

## Architecture
- Width < 8 -> Ripple Carry Adder - minimal area
- 8 <=Width < 32 -> Parallel-Prefix Adder using Kogge-Stone tree - better delay, worse wiring congestion and area than Brent-Kung
- 32 <= Width -> Parallel-Prefix Adder using Brent-Kung tree - better area and wiring congestion, one additional logic level than Kogge-Stone

## Testing
Verified using circt-lec the correctness of the implementation for adders of width=1,2,...,64.

Included separate integration tests for adders of width 16 and 33. Expanding the test-suite here can quickly lead to timeouts given the increasing complexity of the verification challenge. Worth a discussion on future testing plans as more complex component architectures are added.