### PR TITLE
[FIRRTL] Emit a bindfile for each public module

### DIFF
--- a/include/circt/Dialect/Emit/EmitOps.td
+++ b/include/circt/Dialect/Emit/EmitOps.td
@@ -49,9 +49,9 @@ def FileOp : EmitOp<"file", [
     // Creates a file with a callback. While the callback is executed, the
     // insertion point of the builder is moved inside the body of the file op.
     OpBuilder<(ins "StringRef":$fileName, "StringRef":$symName,
-                    CArg<"llvm::function_ref<void()>">:$bodyCtor)>,
+                    CArg<"llvm::function_ref<void()>", "{}">:$bodyCtor)>,
     OpBuilder<(ins "StringAttr":$fileName,
-                    CArg<"llvm::function_ref<void()>">:$bodyCtor)>,
+                    CArg<"llvm::function_ref<void()>", "{}">:$bodyCtor)>,
     OpBuilder<(ins "const Twine &":$fileName,
                     CArg<"llvm::function_ref<void()>", "{}">:$bodyCtor), [{
       return build($_builder, $_state, $_builder.getStringAttr(fileName), bodyCtor);

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -791,7 +791,7 @@ def LowerLayers : Pass<"firrtl-lower-layers", "firrtl::CircuitOp"> {
     pass, all layer blocks and layers are removed.
   }];
   let constructor = "circt::firrtl::createLowerLayersPass()";
-  let dependentDialects = ["sv::SVDialect"];
+  let dependentDialects = ["sv::SVDialect", "emit::EmitDialect"];
 }
 
 def LayerMerge : Pass<"firrtl-layer-merge", "firrtl::FModuleOp"> {

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -917,9 +917,15 @@ def MacroDefOp : SVOp<"macro.def",
   let results = (outs);
 
   let builders = [
-    OpBuilder<(ins "StringRef":$macroName, "StringRef":$format_string),
-                "build($_builder, $_state, macroName, format_string,"
-                "odsBuilder.getArrayAttr({}));">
+    OpBuilder<(ins "FlatSymbolRefAttr":$macroName), [{
+      auto formatString = StringAttr::get($_builder.getContext());
+      auto symbols = $_builder.getArrayAttr({});
+      build($_builder, $_state, macroName, formatString, symbols);
+    }]>,
+    OpBuilder<(ins "StringRef":$macroName, "StringRef":$formatString), [{
+      auto symbols = $_builder.getArrayAttr({});
+      build($_builder, $_state, macroName, formatString, symbols);
+    }]>
   ];
 
   let assemblyFormat = [{

--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/Emit/EmitOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Namespace.h"
@@ -18,6 +20,7 @@
 #include "circt/Dialect/SV/SVOps.h"
 #include "circt/Support/Utils.h"
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Mutex.h"
 
@@ -57,7 +60,6 @@ enum class Delimiter { BindModule = '_', BindFile = '-', InlineMacro = '$' };
 /// use to create names in the global namespace.  This is allocated per-layer
 /// block.
 struct LayerBlockGlobals {
-
   /// If the layer needs to create a module, use this name.
   StringRef moduleName;
 
@@ -130,15 +132,26 @@ static SmallString<32> instanceNameForLayer(SymbolRefAttr layerName) {
   return result;
 }
 
-/// For all layerblocks `@A::@B::@C` in a circuit called Circuit,
-/// the output filename is `layers-Circuit-A-B-C.sv`.
-static SmallString<32> fileNameForLayer(StringRef circuitName,
+/// For all layerblocks `@A::@B::@C` in a module called Module,
+/// the output filename is `layers-Module-A-B-C.sv`.
+static SmallString<32> fileNameForLayer(StringRef moduleName,
                                         SymbolRefAttr layerName) {
   SmallString<32> result;
   result.append("layers");
-  appendName(circuitName, result);
+  appendName(moduleName, result);
   appendName(layerName, result);
   result.append(".sv");
+  return result;
+}
+
+/// For all layerblocks `@A::@B::@C` in a module called Module,
+/// the include-guard macro is `layers_Module_A_B_C`.
+static SmallString<32> guardMacroNameForLayer(StringRef moduleName,
+                                              SymbolRefAttr layerName) {
+  SmallString<32> result;
+  result.append("layers");
+  appendName(moduleName, result, false, Delimiter::BindModule);
+  appendName(layerName, result, false, Delimiter::BindModule);
   return result;
 }
 
@@ -158,6 +171,19 @@ macroNameForLayer(StringRef circuitName,
 // LowerLayersPass
 //===----------------------------------------------------------------------===//
 
+namespace {
+/// Information about each bind file we are emitting. During a prepass, we walk
+/// the modules to find layerblocks, creating an emit::FileOp for each bound
+/// layer used under each module. As we do this, we build a table of these info
+/// objects for quick lookup later.
+struct BindFileInfo {
+  /// The path of the bind file.
+  StringAttr path;
+  /// Where to insert bind statements into the bind file.
+  Block *body;
+};
+} // namespace
+
 class LowerLayersPass
     : public circt::firrtl::impl::LowerLayersBase<LowerLayersPass> {
   hw::OutputFileAttr getOutputFile(SymbolRefAttr layerName) {
@@ -167,15 +193,15 @@ class LowerLayersPass
     return layer->getAttrOfType<hw::OutputFileAttr>("output_file");
   }
 
-  hw::OutputFileAttr outputFileForLayer(StringRef circuitName,
+  hw::OutputFileAttr outputFileForLayer(StringRef moduleName,
                                         SymbolRefAttr layerName) {
     if (auto file = getOutputFile(layerName))
       return hw::OutputFileAttr::getFromDirectoryAndFilename(
           &getContext(), file.getDirectory(),
-          fileNameForLayer(circuitName, layerName),
+          fileNameForLayer(moduleName, layerName),
           /*excludeFromFileList=*/true);
     return hw::OutputFileAttr::getFromFilename(
-        &getContext(), fileNameForLayer(circuitName, layerName),
+        &getContext(), fileNameForLayer(moduleName, layerName),
         /*excludeFromFileList=*/true);
   }
 
@@ -199,13 +225,22 @@ class LowerLayersPass
   /// Lower an inline layerblock to an ifdef block.
   void lowerInlineLayerBlock(LayerOp layer, LayerBlockOp layerBlock);
 
-  /// Preprocess layers to build macro declarations and cache information about
-  /// the layers so that this can be quired later.
+  /// Build macro declarations and cache information about the layers.
   void preprocessLayers(CircuitNamespace &ns, OpBuilder &b, LayerOp layer,
                         StringRef circuitName,
                         SmallVector<FlatSymbolRefAttr> &stack);
-  void preprocessLayers(CircuitNamespace &ns, LayerOp layer,
-                        StringRef circuitName);
+  void preprocessLayers(CircuitNamespace &ns);
+
+  /// For each module, build a bindfile for each bound-layer, if needed.
+  void preprocessModules(CircuitNamespace &ns, InstanceGraph &ig);
+
+  /// Build the bindfile skeletons for each module. Set up a table which tells
+  /// us for each module/layer pair, where to insert the bind operations.
+  void preprocessModule(CircuitNamespace &ns, InstanceGraphNode *node);
+
+  /// Build a bindfile skeleton for a particular module and layer.
+  void buildBindFile(CircuitNamespace &ns, InstanceGraphNode *node,
+                     OpBuilder &b, SymbolRefAttr layerName, LayerOp layer);
 
   /// Entry point for the function.
   void runOnOperation() override;
@@ -220,11 +255,17 @@ class LowerLayersPass
   /// A map from inline layers to their macro names.
   DenseMap<LayerOp, FlatSymbolRefAttr> macroNames;
 
-  /// A mapping of symbol name to layer operation.
-  DenseMap<SymbolRefAttr, LayerOp> symbolToLayer;
+  /// A mapping of symbol name to layer operation. This also serves as an
+  /// iterable list of all layers declared in a circuit. We use a map vector so
+  /// that the iteration order matches the order of declaration in the circuit.
+  /// This order is not required for correctness, it helps with legibility.
+  llvm::MapVector<SymbolRefAttr, LayerOp> symbolToLayer;
 
   /// Utility for creating hw::HierPathOp.
   hw::HierPathCache *hierPathCache;
+
+  /// A mapping from module*layer to bindfile name.
+  DenseMap<Operation *, DenseMap<LayerOp, BindFileInfo>> bindFiles;
 };
 
 /// Multi-process safe function to build a module in the circuit and return it.
@@ -325,8 +366,6 @@ void LowerLayersPass::lowerInlineLayerBlock(LayerOp layer,
 
 LogicalResult LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
                                                InnerRefMap &innerRefMap) {
-  CircuitOp circuitOp = moduleOp->getParentOfType<CircuitOp>();
-  StringRef circuitName = circuitOp.getName();
   hw::InnerSymbolNamespace ns(moduleOp);
 
   // A cache of values to nameable ops that can be used
@@ -656,23 +695,27 @@ LogicalResult LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
     // parent layer.
     builder.setInsertionPointAfter(layerBlock);
     auto instanceName = instanceNameForLayer(layerBlock.getLayerName());
+    auto innerSym =
+        hw::InnerSymAttr::get(builder.getStringAttr(ns.newName(instanceName)));
+
     auto instanceOp = builder.create<InstanceOp>(
         layerBlock.getLoc(), /*moduleName=*/newModule,
         /*name=*/
         instanceName, NameKindEnum::DroppableName,
         /*annotations=*/ArrayRef<Attribute>{},
-        /*portAnnotations=*/ArrayRef<Attribute>{}, /*lowerToBind=*/true,
-        /*doNotPrint=*/false,
-        /*innerSym=*/
-        (innerSyms.empty() ? hw::InnerSymAttr{}
-                           : hw::InnerSymAttr::get(builder.getStringAttr(
-                                 ns.newName(instanceName)))));
+        /*portAnnotations=*/ArrayRef<Attribute>{}, /*lowerToBind=*/false,
+        /*doNotPrint=*/true, innerSym);
 
-    auto outputFile =
-        outputFileForLayer(circuitName, layerBlock.getLayerName());
+    auto outputFile = outputFileForLayer(moduleOp.getModuleNameAttr(),
+                                         layerBlock.getLayerName());
     instanceOp->setAttr("output_file", outputFile);
 
     createdInstances.try_emplace(instanceOp, newModule);
+
+    // create the bind op.
+    OpBuilder::atBlockEnd(bindFiles[moduleOp][layer].body)
+        .create<BindOp>(layerBlock.getLoc(), moduleOp.getModuleNameAttr(),
+                        instanceOp.getInnerSymAttr().getSymName());
 
     LLVM_DEBUG(llvm::dbgs() << "        moved inner refs:\n");
     for (hw::InnerSymAttr innerSym : innerSyms) {
@@ -734,11 +777,160 @@ void LowerLayersPass::preprocessLayers(CircuitNamespace &ns, OpBuilder &b,
   stack.pop_back();
 }
 
-void LowerLayersPass::preprocessLayers(CircuitNamespace &ns, LayerOp layer,
-                                       StringRef circuitName) {
-  OpBuilder b(layer);
-  SmallVector<FlatSymbolRefAttr> stack;
-  preprocessLayers(ns, b, layer, circuitName, stack);
+void LowerLayersPass::preprocessLayers(CircuitNamespace &ns) {
+  auto circuit = getOperation();
+  auto circuitName = circuit.getName();
+  for (auto layer : circuit.getOps<LayerOp>()) {
+    OpBuilder b(layer);
+    SmallVector<FlatSymbolRefAttr> stack;
+    preprocessLayers(ns, b, layer, circuitName, stack);
+  }
+}
+
+void LowerLayersPass::buildBindFile(CircuitNamespace &ns,
+                                    InstanceGraphNode *node, OpBuilder &b,
+                                    SymbolRefAttr layerName, LayerOp layer) {
+  assert(layer.getConvention() == LayerConvention::Bind);
+  auto module = node->getModule<FModuleOp>();
+  auto loc = module.getLoc();
+
+  // Compute the include guard macro name.
+  auto macroName = guardMacroNameForLayer(module.getModuleName(), layerName);
+  auto macroSymbol = ns.newName(macroName);
+  auto macroNameAttr = StringAttr::get(&getContext(), macroName);
+  auto macroSymbolAttr = StringAttr::get(&getContext(), macroSymbol);
+  auto macroSymbolRefAttr = FlatSymbolRefAttr::get(macroSymbolAttr);
+
+  // Compute the base name for the bind file.
+  auto bindFileName = fileNameForLayer(module.getName(), layerName);
+
+  // Build the full output path using the filename of the bindfile and the
+  // output directory of the layer, if any.
+  auto dir = layer->getAttrOfType<hw::OutputFileAttr>("output_file");
+  StringAttr path;
+  if (dir)
+    path = StringAttr::get(&getContext(),
+                           Twine(dir.getDirectory()) + bindFileName);
+  else
+    path = StringAttr::get(&getContext(), bindFileName);
+
+  // Declare the macro for the include guard.
+  b.create<sv::MacroDeclOp>(loc, macroSymbolAttr, ArrayAttr{}, macroNameAttr);
+
+  // Create the emit op.
+  auto bindFile = b.create<emit::FileOp>(loc, path);
+  OpBuilder::InsertionGuard _(b);
+  b.setInsertionPointToEnd(bindFile.getBody());
+
+  // Create the #ifndef for the include guard.
+  auto includeGuard = b.create<sv::IfDefOp>(loc, macroSymbolRefAttr);
+  b.createBlock(&includeGuard.getElseRegion());
+
+  // Create the #define for the include guard.
+  b.create<sv::MacroDefOp>(loc, macroSymbolRefAttr);
+
+  // Create IR to enable any parent layers.
+  auto parent = layer->getParentOfType<LayerOp>();
+  while (parent) {
+    // If the parent is bound-in, we enable it by including the bindfile.
+    // The parent bindfile will enable all ancestors.
+    if (parent.getConvention() == LayerConvention::Bind) {
+      auto target = bindFiles[module][parent].path;
+      b.create<sv::IncludeOp>(loc, IncludeStyle::Local, target);
+      break;
+    }
+
+    // If the parent layer is inline, we enable it by defining a macro.
+    // We will also have to manually enable any subsequent ancestors.
+    auto parentMacroSymbol = macroNames[parent];
+    b.create<sv::MacroDefOp>(loc, parentMacroSymbol);
+    parent = layer->getParentOfType<LayerOp>();
+  }
+
+  // Create IR to include bind files for child modules.
+  for (auto *record : *node) {
+    auto *child = record->getTarget()->getModule().getOperation();
+    auto files = bindFiles[child];
+    auto lookup = files.find(layer);
+    if (lookup != files.end())
+      b.create<sv::IncludeOp>(loc, IncludeStyle::Local, lookup->second.path);
+  }
+
+  // Save the bind file information for later.
+  auto &info = bindFiles[module][layer];
+  info.path = path;
+  info.body = includeGuard.getElseBlock();
+}
+
+void LowerLayersPass::preprocessModule(CircuitNamespace &ns,
+                                       InstanceGraphNode *node) {
+  auto *op = node->getModule().getOperation();
+  if (!op)
+    return;
+
+  auto module = dyn_cast<FModuleOp>(op);
+  if (!module)
+    return;
+
+  OpBuilder b(&getContext());
+  b.setInsertionPointAfter(module);
+
+  // Create a bind file only if the layer is used under the module.
+  llvm::SmallDenseSet<LayerOp> layersRequiringBindFiles;
+
+  // If the module is public, create a bind file for all layers.
+  if (module.isPublic())
+    for (auto [_, layer] : symbolToLayer)
+      if (layer.getConvention() == LayerConvention::Bind)
+        layersRequiringBindFiles.insert(layer);
+
+  // Handle layers used directly in this module.
+  module->walk([&](LayerBlockOp layerBlock) {
+    auto layer = symbolToLayer[layerBlock.getLayerNameAttr()];
+    if (layer.getConvention() == LayerConvention::Inline)
+      return;
+
+    // Create a bindfile for any layer directly used in the module.
+    layersRequiringBindFiles.insert(layer);
+
+    // Determine names for all modules that will be created.
+    auto moduleName = module.getModuleName();
+    auto layerName = layerBlock.getLayerName();
+
+    // A name hint for the module created from this layerblock.
+    auto layerBlockModuleName = moduleNameForLayer(moduleName, layerName);
+
+    // A name hint for the hier-path-op which targets the bound-in instance of
+    // the module created from this layerblock.
+    auto layerBlockHierPathName = hierPathNameForLayer(moduleName, layerName);
+
+    LayerBlockGlobals globals;
+    globals.moduleName = ns.newName(layerBlockModuleName);
+    globals.hierPathName = ns.newName(layerBlockHierPathName);
+    layerBlockGlobals.insert({layerBlock, globals});
+  });
+
+  // Create a bindfile for layers used indirectly under this module.
+  for (auto *record : *node) {
+    auto *child = record->getTarget()->getModule().getOperation();
+    for (auto [layer, _] : bindFiles[child])
+      layersRequiringBindFiles.insert(layer);
+  }
+
+  // Build the bindfiles for any layer seen under this module. The bindfiles are
+  // emitted in the order which they are declared, for readability.
+  for (auto [sym, layer] : symbolToLayer)
+    if (layersRequiringBindFiles.contains(layer))
+      buildBindFile(ns, node, b, sym, layer);
+}
+
+/// Create the bind file skeleton for each layer, for each module.
+void LowerLayersPass::preprocessModules(CircuitNamespace &ns,
+                                        InstanceGraph &ig) {
+  DenseSet<InstanceGraphNode *> visited;
+  for (auto *root : ig)
+    for (auto *node : llvm::post_order_ext(root, visited))
+      preprocessModule(ns, node);
 }
 
 /// Process a circuit to remove all layer blocks in each module and top-level
@@ -748,39 +940,20 @@ void LowerLayersPass::runOnOperation() {
       llvm::dbgs() << "==----- Running LowerLayers "
                       "-------------------------------------------------===\n");
   CircuitOp circuitOp = getOperation();
-  StringRef circuitName = circuitOp.getName();
 
   // Initialize members which cannot be initialized automatically.
   llvm::sys::SmartMutex<true> mutex;
   circuitMutex = &mutex;
 
+  auto *ig = &getAnalysis<InstanceGraph>();
   CircuitNamespace ns(circuitOp);
   hw::HierPathCache hpc(
       &ns, OpBuilder::InsertPoint(getOperation().getBodyBlock(),
                                   getOperation().getBodyBlock()->begin()));
   hierPathCache = &hpc;
 
-  for (auto &op : *circuitOp.getBodyBlock()) {
-    // Determine names for all modules that will be created.  Do this serially
-    // to avoid non-determinism from creating these in the parallel region.
-    if (auto moduleOp = dyn_cast<FModuleOp>(op)) {
-      moduleOp->walk([&](LayerBlockOp layerBlockOp) {
-        auto moduleName = moduleNameForLayer(moduleOp.getModuleName(),
-                                             layerBlockOp.getLayerName());
-        auto hierPathName = hierPathNameForLayer(moduleOp.getModuleName(),
-                                                 layerBlockOp.getLayerName());
-        layerBlockGlobals.insert(
-            {layerBlockOp, {ns.newName(moduleName), ns.newName(hierPathName)}});
-      });
-      continue;
-    }
-    // Build verilog macro declarations for each inline layer declarations.
-    // Cache layer symbol refs for lookup later.
-    if (auto layerOp = dyn_cast<LayerOp>(op)) {
-      preprocessLayers(ns, layerOp, circuitName);
-      continue;
-    }
-  }
+  preprocessLayers(ns);
+  preprocessModules(ns, *ig);
 
   auto mergeMaps = [](auto &&a, auto &&b) {
     if (failed(a))
@@ -838,94 +1011,18 @@ void LowerLayersPass::runOnOperation() {
           ArrayAttr::get(circuitOp.getContext(), newNamepath));
   }
 
-  // Generate the header and footer of each bindings file.  The body will be
-  // populated later when binds are exported to Verilog.  This produces text
-  // like:
-  //
-  //     `include "layers-A.sv"
-  //     `include "layers-A-B.sv"
-  //     `ifndef layers_A_B_C
-  //     `define layers_A_B_C
-  //     <body>
-  //     `endif // layers_A_B_C
-  //
-  // TODO: This would be better handled without the use of verbatim ops.
-  OpBuilder builder(circuitOp);
-  SmallVector<std::pair<LayerOp, StringAttr>> layers;
-  circuitOp.walk<mlir::WalkOrder::PreOrder>([&](LayerOp layerOp) {
-    auto parentOp = layerOp->getParentOfType<LayerOp>();
-    while (!layers.empty() && parentOp != layers.back().first)
-      layers.pop_back();
-
-    if (layerOp.getConvention() == LayerConvention::Inline) {
-      layers.emplace_back(layerOp, nullptr);
-      return;
-    }
-
-    builder.setInsertionPointToStart(circuitOp.getBodyBlock());
-
-    // Save the "layers-<circuit>-<group>" and "layers_<circuit>_<group>" string
-    // as this is reused a bunch.
-    SmallString<32> prefixFile("layers-"), prefixMacro("layers_");
-    prefixFile.append(circuitName);
-    prefixFile.append("-");
-    prefixMacro.append(circuitName);
-    prefixMacro.append("_");
-    for (auto [layer, _] : layers) {
-      prefixFile.append(layer.getSymName());
-      prefixFile.append("-");
-      prefixMacro.append(layer.getSymName());
-      prefixMacro.append("_");
-    }
-    prefixFile.append(layerOp.getSymName());
-    prefixMacro.append(layerOp.getSymName());
-
-    SmallString<128> includes;
-    for (auto [_, strAttr] : layers) {
-      if (!strAttr)
-        continue;
-      includes.append(strAttr);
-      includes.append("\n");
-    }
-
-    hw::OutputFileAttr bindFile;
-    if (auto outputFile =
-            layerOp->getAttrOfType<hw::OutputFileAttr>("output_file")) {
-      auto dir = outputFile.getDirectory();
-      bindFile = hw::OutputFileAttr::getFromDirectoryAndFilename(
-          &getContext(), dir, prefixFile + ".sv",
-          /*excludeFromFileList=*/true);
-    } else {
-      bindFile = hw::OutputFileAttr::getFromFilename(
-          &getContext(), prefixFile + ".sv", /*excludeFromFileList=*/true);
-    }
-
-    // Write header to a verbatim.
-    auto header = builder.create<sv::VerbatimOp>(
-        layerOp.getLoc(),
-        includes + "`ifndef " + prefixMacro + "\n" + "`define " + prefixMacro);
-    header->setAttr("output_file", bindFile);
-
-    // Write footer to a verbatim.
-    builder.setInsertionPointToEnd(circuitOp.getBodyBlock());
-    auto footer = builder.create<sv::VerbatimOp>(layerOp.getLoc(),
-                                                 "`endif // " + prefixMacro);
-    footer->setAttr("output_file", bindFile);
-
-    if (!layerOp.getBody().getOps<LayerOp>().empty())
-      layers.emplace_back(
-          layerOp,
-          builder.getStringAttr("`include \"" +
-                                bindFile.getFilename().getValue() + "\""));
-  });
-
   // All layers definitions can now be deleted.
   for (auto layerOp :
        llvm::make_early_inc_range(circuitOp.getBodyBlock()->getOps<LayerOp>()))
     layerOp.erase();
 
   // Cleanup state.
+  circuitMutex = nullptr;
+  layerBlockGlobals.clear();
+  macroNames.clear();
+  symbolToLayer.clear();
   hierPathCache = nullptr;
+  bindFiles.clear();
 }
 
 std::unique_ptr<mlir::Pass> circt::firrtl::createLowerLayersPass() {

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -87,7 +87,7 @@ firrtl.circuit "Test" {
   // CHECK-NEXT:   %[[c0_ui1_node:.+]] = firrtl.node sym @[[CaptureHardware_c0_ui1_sym]] %c0_ui1
   // CHECK-NEXT:   %c1_ui1 = firrtl.constant 1 : !firrtl.uint<1>
   // CHECK-NEXT:   %[[c1_ui1_node:.+]] = firrtl.node sym @[[CaptureHardware_c1_ui1_sym]] %c1_ui1
-  // CHECK-NEXT:   firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers-Test-A.sv", excludeFromFileList>} @CaptureHardware_A()
+  // CHECK-NEXT:   firrtl.instance {{.+}} {doNotPrint, output_file = #hw.output_file<"layers-CaptureHardware-A.sv", excludeFromFileList>} @CaptureHardware_A()
   // CHECK-NEXT: }
   firrtl.module @CaptureHardware() {
     %c0_ui1 = firrtl.constant 0 : !firrtl.uint<1>
@@ -103,7 +103,7 @@ firrtl.circuit "Test" {
   // CHECK:   %x = firrtl.node %[[port]] : !firrtl.uint<1>
   // CHECK: }
   // CHECK: firrtl.module @CapturePort(in %in: !firrtl.uint<1> sym @[[CapturePort_port_sym]]) {
-  // CHECK:   firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers-Test-A.sv", excludeFromFileList>} @CapturePort_A
+  // CHECK:   firrtl.instance {{.+}} {doNotPrint, output_file = #hw.output_file<"layers-CapturePort-A.sv", excludeFromFileList>} @CapturePort_A
   // CHECK: }
   firrtl.module @CapturePort(in %in: !firrtl.uint<1>){
     firrtl.layerblock @A {
@@ -120,7 +120,7 @@ firrtl.circuit "Test" {
   // CHECK-NEXT: firrtl.module @CaptureConnect() {
   // CHECK-NEXT:   %a = firrtl.wire : !firrtl.uint<1>
   // CHECK-NEXT:   %a_0 = firrtl.node sym @[[CaptureConnect_a_sym]] %a {name = "a"} : !firrtl.uint<1>
-  // CHECK-NEXT:   firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers-Test-A.sv", excludeFromFileList>} @CaptureConnect_A()
+  // CHECK-NEXT:   firrtl.instance {{.+}} sym @{{.+}} {doNotPrint, output_file = #hw.output_file<"layers-CaptureConnect-A.sv", excludeFromFileList>} @CaptureConnect_A()
   // CHECK-NEXT: }
   firrtl.module @CaptureConnect() {
     %a = firrtl.wire : !firrtl.uint<1>
@@ -136,7 +136,7 @@ firrtl.circuit "Test" {
   // CHECK-NEXT: firrtl.module @CaptureProbeSrc() {
   // CHECK-NEXT:   %w = firrtl.wire : !firrtl.uint<1>
   // CHECK-NEXT:   %w_probe = firrtl.node sym @sym interesting_name %w : !firrtl.uint<1>
-  // CHECK-NEXT:   firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers-Test-A.sv", excludeFromFileList>} @CaptureProbeSrc_A
+  // CHECK-NEXT:   firrtl.instance {{.+}} {doNotPrint, output_file = #hw.output_file<"layers-CaptureProbeSrc-A.sv", excludeFromFileList>} @CaptureProbeSrc_A
   // CHECK-NEXT: }
   firrtl.module @CaptureProbeSrc() {
     %w = firrtl.wire : !firrtl.uint<1>
@@ -156,8 +156,8 @@ firrtl.circuit "Test" {
   // CHECK-NEXT:   %x_0 = firrtl.node sym @[[NestedCapture_a_sym]] %x {name = "x"}
   // CHECK-NEXT: }
   // CHECK-NEXT: firrtl.module @NestedCapture() {
-  // CHECK-NEXT:   firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers-Test-A-B.sv", excludeFromFileList>} @NestedCapture_A_B()
-  // CHECK-NEXT:   firrtl.instance {{.+}} sym @[[inst]] {lowerToBind, output_file = #hw.output_file<"layers-Test-A.sv", excludeFromFileList>} @NestedCapture_A()
+  // CHECK-NEXT:   firrtl.instance {{.+}} {doNotPrint, output_file = #hw.output_file<"layers-NestedCapture-A-B.sv", excludeFromFileList>} @NestedCapture_A_B()
+  // CHECK-NEXT:   firrtl.instance {{.+}} sym @[[inst]] {doNotPrint, output_file = #hw.output_file<"layers-NestedCapture-A.sv", excludeFromFileList>} @NestedCapture_A()
   // CHECK-NEXT: }
   firrtl.module @NestedCapture() {
     firrtl.layerblock @A {
@@ -179,7 +179,7 @@ firrtl.circuit "Test" {
   // CHECK-NEXT: firrtl.module @WhenUnderLayer() {
   // CHECK-NEXT:   %x = firrtl.wire : !firrtl.uint<1>
   // CHECK-NEXT:   %x_0 = firrtl.node sym @[[WhenUnderLayer_x_sym]] %x {name = "x"}
-  // CHECK-NEXT:   firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers-Test-A.sv", excludeFromFileList>} @WhenUnderLayer_A
+  // CHECK-NEXT:   firrtl.instance {{.+}} sym @{{.+}} {doNotPrint, output_file = #hw.output_file<"layers-WhenUnderLayer-A.sv", excludeFromFileList>} @WhenUnderLayer_A
   // CHECK-NEXT: }
   firrtl.module @WhenUnderLayer() {
     %x = firrtl.wire : !firrtl.uint<1>
@@ -400,19 +400,6 @@ firrtl.circuit "Simple" {
 
 // CHECK-LABEL: firrtl.circuit "Simple"
 //
-// CHECK:      sv.verbatim "`include \22layers-Simple-A.sv\22\0A
-// CHECK-SAME:   `include \22layers-Simple-A-B.sv\22\0A
-// CHECK-SAME:   `ifndef layers_Simple_A_B_C\0A
-// CHECK-SAME:   define layers_Simple_A_B_C"
-// CHECK-SAME:   output_file = #hw.output_file<"layers-Simple-A-B-C.sv", excludeFromFileList>
-// CHECK:      sv.verbatim "`include \22layers-Simple-A.sv\22\0A
-// CHECK-SAME:   `ifndef layers_Simple_A_B\0A
-// CHECK-SAME:   define layers_Simple_A_B"
-// CHECK-SAME:   output_file = #hw.output_file<"layers-Simple-A-B.sv", excludeFromFileList>
-// CHECK:      sv.verbatim "`ifndef layers_Simple_A\0A
-// CHECK-SAME:   define layers_Simple_A"
-// CHECK-SAME:   output_file = #hw.output_file<"layers-Simple-A.sv", excludeFromFileList>
-//
 // CHECK: hw.hierpath private @[[Simple_A_B_cc_path:.+]] [@Simple::@a_b, @Simple_A_B::@[[Simple_A_B_cc_sym:.+]]]
 //
 // CHECK:      firrtl.module private @Simple_A_B_C() {
@@ -445,15 +432,37 @@ firrtl.circuit "Simple" {
 // CHECK-NEXT:   %a_0 = firrtl.node sym @[[Simple_a_sym]] %a {name = "a"}
 // CHECK-NEXT:   %b = firrtl.wire
 // CHECK-NEXT:   %b_1 = firrtl.node sym @[[Simple_b_sym]] %b {name = "b"}
-// CHECK-NEXT:   firrtl.instance a_b_c {{.*}}
-// CHECK-NEXT:   firrtl.instance a_b {{.*}}
-// CHECK-NEXT:   firrtl.instance a {{.*}}
+// CHECK-NEXT:   firrtl.instance a_b_c sym @a_b_c {doNotPrint, output_file = #hw.output_file<"layers-Simple-A-B-C.sv", excludeFromFileList>} @Simple_A_B_C()
+// CHECK-NEXT:   firrtl.instance a_b sym @a_b {doNotPrint, output_file = #hw.output_file<"layers-Simple-A-B.sv", excludeFromFileList>} @Simple_A_B()
+// CHECK-NEXT:   firrtl.instance a sym @a {doNotPrint, output_file = #hw.output_file<"layers-Simple-A.sv", excludeFromFileList>} @Simple_A()
 // CHECK-NEXT: }
-//
-// CHECK-DAG:  sv.verbatim "`endif // layers_Simple_A"
-// CHECK-SAME:   output_file = #hw.output_file<"layers-Simple-A.sv", excludeFromFileList>
-// CHECK-DAG:  sv.verbatim "`endif // layers_Simple_A_B"
-// CHECK-SAME:   output_file = #hw.output_file<"layers-Simple-A-B.sv", excludeFromFileList>
+
+// CHECK:      sv.macro.decl @layers_Simple_A["layers_Simple_A"]
+// CHECK-NEXT: emit.file "layers-Simple-A.sv" {
+// CHECK-NEXT:   sv.ifdef  @layers_Simple_A {
+// CHECK-NEXT:   } else {
+// CHECK-NEXT:     sv.macro.def @layers_Simple_A ""
+// CHECK-NEXT:     firrtl.bind <@Simple::@a>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: sv.macro.decl @layers_Simple_A_B["layers_Simple_A_B"]
+// CHECK-NEXT: emit.file "layers-Simple-A-B.sv" {
+// CHECK-NEXT:   sv.ifdef  @layers_Simple_A_B {
+// CHECK-NEXT:   } else {
+// CHECK-NEXT:     sv.macro.def @layers_Simple_A_B ""
+// CHECK-NEXT:     sv.include  local "layers-Simple-A.sv"
+// CHECK-NEXT:     firrtl.bind <@Simple::@a_b>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: sv.macro.decl @layers_Simple_A_B_C["layers_Simple_A_B_C"]
+// CHECK-NEXT: emit.file "layers-Simple-A-B-C.sv" {
+// CHECK-NEXT:   sv.ifdef  @layers_Simple_A_B_C {
+// CHECK-NEXT:   } else {
+// CHECK-NEXT:     sv.macro.def @layers_Simple_A_B_C ""
+// CHECK-NEXT:     sv.include  local "layers-Simple-A-B.sv"
+// CHECK-NEXT:     firrtl.bind <@Simple::@a_b_c>
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 
 // -----
 
@@ -477,7 +486,7 @@ firrtl.circuit "ModuleNameConflict" {
 // CHECK:       firrtl.module @ModuleNameConflict()
 // CHECK-NOT:   firrtl.module
 // CHECK:         firrtl.instance foo @ModuleNameConflict_A()
-// CHECK-NEXT:    firrtl.instance {{[_a-zA-Z0-9]+}} {lowerToBind,
+// CHECK-NEXT:    firrtl.instance {{.+}} sym @{{.+}} {doNotPrint, {{.*}}}
 // CHECK-SAME:      @[[groupModule]](
 
 // -----
@@ -521,7 +530,7 @@ firrtl.circuit "HierPathOps" {
   hw.hierpath @nla1 [@Foo::@foo_A]
   hw.hierpath @nla2 [@Foo::@bar, @Bar]
   hw.hierpath private @nla3 [@Foo::@baz]
-  firrtl.layer @A  bind {}
+  firrtl.layer @A bind {}
   firrtl.module @Bar() {}
   firrtl.module @Foo() {
     %0 = firrtl.wire sym @foo_A : !firrtl.uint<1>
@@ -558,7 +567,7 @@ firrtl.circuit "Foo" attributes {
     }
   ]
 } {
-  firrtl.layer @A  bind attributes {output_file = #hw.output_file<"testbench/", excludeFromFileList>} {}
+  firrtl.layer @A bind attributes {output_file = #hw.output_file<"testbench/", excludeFromFileList>} {}
   firrtl.module @Bar() attributes {
     annotations = [
       {
@@ -579,17 +588,11 @@ firrtl.circuit "Foo" attributes {
 
 // CHECK-LABEL: firrtl.circuit "Foo"
 //
-// CHECK:       sv.verbatim
-// CHECK-SAME:    #hw.output_file<"testbench{{/|\\\\}}layers-Foo-A.sv", excludeFromFileList>
-//
 // CHECK:       firrtl.module {{.*}} @Bar_A
 // CHECK-SAME:    #hw.output_file<"testbench{{/|\\\\}}", excludeFromFileList>
 // CHECK:       firrtl.module {{.*}} @Foo_A
 // CHECK-SAME:    #hw.output_file<"testbench{{/|\\\\}}", excludeFromFileList>
-//
-// CHECK:       sv.verbatim
-// CHECK-SAME:    #hw.output_file<"testbench{{/|\\\\}}layers-Foo-A.sv", excludeFromFileList>
-
+// CHECK:       emit.file "testbench{{/|\\\\}}layers-Foo-A.sv"
 
 // -----
 // Check that we correctly implement the verilog header and footer for B.
@@ -602,11 +605,12 @@ firrtl.circuit "Foo" {
   firrtl.module @Foo() {}
 }
 
-// CHECK: firrtl.circuit "Foo" {
-// CHECK:   sv.verbatim "`ifndef layers_Foo_B\0A`define layers_Foo_B" {output_file = #hw.output_file<"layers-Foo-B.sv", excludeFromFileList>}
-// CHECK:   firrtl.module @Foo() {
+// CHECK: sv.macro.decl @layers_Foo_B["layers_Foo_B"]
+// CHECK: emit.file "layers-Foo-B.sv" {
+// CHECK:   sv.ifdef  @layers_Foo_B {
+// CHECK:   } else {
+// CHECK:     sv.macro.def @layers_Foo_B ""
 // CHECK:   }
-// CHECK:   sv.verbatim "`endif // layers_Foo_B" {output_file = #hw.output_file<"layers-Foo-B.sv", excludeFromFileList>}
 // CHECK: }
 
 // -----
@@ -614,7 +618,7 @@ firrtl.circuit "Foo" {
 // Check sv.verbatim inner refs are updated, as occurs with views under layers.
 // CHECK-LABEL: circuit "Verbatim"
 firrtl.circuit "Verbatim" {
-  firrtl.layer @ViewLayer  bind { }
+  firrtl.layer @ViewLayer bind { }
   firrtl.module @Verbatim() {
     firrtl.layerblock @ViewLayer {
       %c1_ui10 = firrtl.constant 1 : !firrtl.uint<10>
@@ -629,3 +633,58 @@ firrtl.circuit "Verbatim" {
 // CHECK-NEXT:     sv.verbatim
 // CHECK-SAME:     !firrtl.uint<10> {symbols = [#hw.innerNameRef<@[[VL]]::@node>]}
 // CHECK-NEXT:   }
+
+// -----
+
+// Check that for public modules, bindfiles are generated for all known layers.
+firrtl.circuit "Test" {
+  firrtl.layer @A bind { }
+  firrtl.layer @B bind { }
+  firrtl.module public @Test() {}
+  firrtl.module public @Test2() {}
+}
+// CHECK: emit.file "layers-Test-A.sv"
+// CHECK: emit.file "layers-Test-B.sv"
+// CHECK: emit.file "layers-Test2-A.sv"
+// CHECK: emit.file "layers-Test2-B.sv"
+
+// -----
+
+// Check that for private modules, bindfiles files are only generated if they are used.
+firrtl.circuit "Top" {
+firrtl.layer @A bind { }
+  firrtl.layer @B bind { }
+
+  // CHECK:     emit.file "layers-Bottom-A.sv"
+  // CHECK-NOT: emit.file "layers-Bottom-B.sv"
+  firrtl.module private @Bottom() {
+    firrtl.layerblock @A {}
+  }
+
+  // CHECK:     emit.file "layers-Middle-A.sv"
+  // CHECK-NOT: emit.file "layers-Middle-B.sv"
+  firrtl.module private @Middle() {
+    firrtl.instance bottom @Bottom()
+  }
+
+  // CHECK:     emit.file "layers-Top-A.sv"
+  // CHECK:     emit.file "layers-Top-B.sv"
+  firrtl.module public @Top() {
+    firrtl.instance middle @Middle()
+  }
+}
+
+// -----
+
+// Check that no bindfiles are created for inline layers.
+firrtl.circuit "Top" {
+  firrtl.layer @Inline inline {}
+
+  firrtl.layer @Bound bind {
+    firrtl.layer @Inline inline {}
+  }
+
+  // CHECK-NOT: emit.file "layers-Top-Inline.sv"
+  // CHECK-NOT: emit.file "layers-Top-Bound-Inline.sv"
+  firrtl.module @Top() {}
+}

--- a/test/firtool/layers.fir
+++ b/test/firtool/layers.fir
@@ -51,15 +51,15 @@ circuit Foo: %[[
 ; CHECK-NEXT:    wire x_0 = x;
 ; CHECK-NEXT:  endmodule
 
-; CHECK-LABEL: FILE "layers-Foo-A-B.sv"
-; CHECK:       `include "layers-Foo-A.sv"
-; CHECK-NEXT:  `ifndef layers_Foo_A_B
-; CHECK-NEXT:  `define layers_Foo_A_B
-; CHECK-NEXT:  bind Foo Foo_A_B a_b ();
-; CHECK-NEXT:  `endif // layers_Foo_A_B
-
 ; CHECK-LABEL: FILE "layers-Foo-A.sv"
 ; CHECK:       `ifndef layers_Foo_A
-; CHECK-NEXT:  `define layers_Foo_A
-; CHECK-NEXT:   bind Foo Foo_A a ();
-; CHECK-NEXT:  `endif // layers_Foo_A
+; CHECK-NEXT:    `define layers_Foo_A
+; CHECK-NEXT:     bind Foo Foo_A a ();
+; CHECK-NEXT:  `endif // not def layers_Foo_A
+
+; CHECK-LABEL: FILE "layers-Foo-A-B.sv"
+; CHECK:       `ifndef layers_Foo_A_B
+; CHECK-NEXT:    `define layers_Foo_A_B
+; CHECK-NEXT:    `include "layers-Foo-A.sv"
+; CHECK-NEXT:    bind Foo Foo_A_B a_b ();
+; CHECK-NEXT:  `endif // not def layers_Foo_A_B

--- a/test/firtool/lower-layers.fir
+++ b/test/firtool/lower-layers.fir
@@ -46,12 +46,6 @@ circuit Foo: %[[
   ; CHECK: );
   ; CHECK: endmodule
 
-  ; CHECK: FILE "testbench{{[/\]}}layers-Foo-Verification.sv"
-  ; CHECK: `ifndef layers_Foo_Verification
-  ; CHECK: `define layers_Foo_Verification
-  ; CHECK: bind Bar Bar_Verification verification ();
-  ; CHECK: `endif // layers_Foo_Verification
-
   ; CHECK: FILE "testbench{{[/\]}}VerificationHelper.sv"
   ; CHECK: module VerificationHelper();
   ; CHECK:   wire w = 1'h0;
@@ -61,7 +55,14 @@ circuit Foo: %[[
   ; CHECK: module Bar_Verification();
   ; CHECK:   wire c = 1'h0;
   ; CHECK:   wire c_probe = c;
+  ; CHECK:   VerificationHelper helper ();
   ; CHECK: endmodule
+
+  ; CHECK FILE "testbench{{[/\]}}layers-Bar-Verification.sv"
+  ; CHECK: `ifndef layers_Bar_Verification
+  ; CHECK:   `define layers_Bar_Verification
+  ; CHECK:   bind Bar Bar_Verification verification ();
+  ; CHECK: `endif // not def layers_Bar_Verification
 
   ; CHECK: FILE "testbench{{[/\]}}Foo.sv"
   ; CHECK: module Foo();
@@ -70,6 +71,12 @@ circuit Foo: %[[
   ; CHECK:   .a (d)
   ; CHECK:   );
   ; CHECK: endmodule
+
+  ; CHECK: FILE "testbench{{[/\]}}layers-Foo-Verification.sv"
+  ; CHECK: `ifndef layers_Foo_Verification
+  ; CHECK:   `define layers_Foo_Verification
+  ; CHECK:   `include "testbench{{[/\]}}layers-Bar-Verification.sv"
+  ; CHECK: `endif // not def layers_Foo_Verification
 
 ; // -----
 
@@ -157,12 +164,18 @@ circuit TestHarness:
     layerblock Verification:
       printf(clock, reset, "The last PC was: %x", read(dut.trace))
 
+; CHECK: FILE "layers-DUT-Verification.sv
+; CHECK: `ifndef layers_DUT_Verification
+; CHECK:   `define layers_DUT_Verification
+; CHECK:   bind DUT DUT_Verification verification ();
+; CHECK: `endif // not def layers_DUT_Verification
+
 ; CHECK: FILE "layers-TestHarness-Verification.sv"
 ; CHECK: `ifndef layers_TestHarness_Verification
-; CHECK: `define layers_TestHarness_Verification
-; CHECK: bind DUT DUT_Verification verification ();
-; CHECK: bind TestHarness TestHarness_Verification verification ();
-; CHECK: `endif // layers_TestHarness_Verification
+; CHECK:   `define layers_TestHarness_Verification
+; CHECK:   `include "layers-DUT-Verification.sv"
+; CHECK:   bind TestHarness TestHarness_Verification verification ();
+; CHECK: `endif // not def layers_TestHarness_Verification
 
 ; // -----
 
@@ -277,3 +290,25 @@ circuit Foo:
     inst bar of Bar
     connect bar.a, a
     connect b, bar.b
+
+; // -----
+
+; Check that when bindfiles include eachother, the include directive uses a path
+; relative to the output directory (or absolute).
+
+FIRRTL version 5.1.0
+circuit Foo:
+
+  layer A, bind, "A":
+  layer B, bind, "B":
+
+  public module Bar:
+
+  public module Foo:
+    inst bar of Bar
+
+; CHECK: FILE "A{{[/\]}}layers-Foo-A.sv"
+; CHECK: `include "A{{[/\]}}layers-Bar-A.sv"
+
+; CHECK: FILE "B{{[/\]}}layers-Foo-B.sv"
+; CHECK: `include "B{{[/\]}}layers-Bar-B.sv"


### PR DESCRIPTION
According to the FIRRTL ABI, we should be emitting a bindfile for each layer × public-module combination. Currently, we only emit one bindfile per layer, which enables the layer for the entire circuit.

This PR updates lower layers to correctly implement the FIRRTL ABI by emitting bindfiles for each public module.