### PR TITLE
[FIRRTL] Don't strip layers in LowerXMR

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerXMR.cpp
@@ -330,9 +330,6 @@ class LowerXMRPass : public circt::firrtl::impl::LowerXMRBase<LowerXMRPass> {
         if (result.wasInterrupted())
           return signalPassFailure();
 
-        // Clear any enabled layers.
-        module.setLayersAttr(ArrayAttr::get(module.getContext(), {}));
-
         // Since we walk operations pre-order and not along dataflow edges,
         // ref.sub may not be resolvable when we encounter them (they're not
         // just unification). This can happen when refs go through an output

--- a/test/firtool/lower-layers.fir
+++ b/test/firtool/lower-layers.fir
@@ -252,3 +252,28 @@ circuit Foo: %[[
   public module Foo:
     inst forceOutOfLayer of ForceOutOfLayer
     inst forceIntoSubmodule of ForceIntoSubmodule
+
+; // -----
+
+; LowerXMR and LowerLayers should work with nested enablelayers.  Just test that
+; this doesn't error.
+
+FIRRTL version 5.1.0
+circuit Foo:
+
+  layer A, bind:
+
+  module Bar enablelayer A:
+    input a: UInt<1>
+    output b: UInt<1>
+
+    connect b, a
+
+  ; CHECK: module Foo(
+  public module Foo enablelayer A:
+    input a: UInt<1>
+    output b: UInt<1>
+
+    inst bar of Bar
+    connect bar.a, a
+    connect b, bar.b


### PR DESCRIPTION
Now that LowerLayers is moved _after_ LowerXMR, there is no need for
LowerXMR to be stripping enabled layers from modules.

This fixes a bug where LowerXMR would only strip layers from modules, but
not instances.  Add a test to lock in the fix.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>
