### PR TITLE
[OM] Ensure every sublist is finished in ListConcatOp evaluation.

### DIFF
--- a/lib/Dialect/OM/Evaluator/Evaluator.cpp
+++ b/lib/Dialect/OM/Evaluator/Evaluator.cpp
@@ -619,8 +619,12 @@ circt::om::Evaluator::evaluateListConcat(ListConcatOp op,
     if (!result.value()->isFullyEvaluated())
       return list;
 
-    // Append each EvaluatorValue from the sublist.
+    // Extract this sublist and ensure it's done evaluating.
     evaluator::ListValue *subList = extractList(result.value().get());
+    if (!subList->isFullyEvaluated())
+      return list;
+
+    // Append each EvaluatorValue from the sublist.
     for (auto subValue : subList->getElements())
       values.push_back(subValue);
   }

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -1267,21 +1267,23 @@ TEST(EvaluatorTests, ListConcatPartialCycle) {
       "  %1 = om.list_create %field_in : !om.any"
       "  om.class.fields %1 : !om.list<!om.any>"
       "}"
-      "om.class @Leaf() -> () {"
-      "  om.class.fields"
+      "om.class @Leaf(%id_in: !om.integer) -> (id: !om.integer) {"
+      "  om.class.fields %id_in : !om.integer"
       "}"
       "om.class @ListConcatPartialCycle() -> (result: !om.list<!om.any>){"
-      "  %0 = om.object @Child(%6) : (!om.any) -> !om.class.type<@Child>"
+      "  %0 = om.object @Child(%7) : (!om.any) -> !om.class.type<@Child>"
       "  %1 = om.object.field %0, [@field] : (!om.class.type<@Child>) -> "
       "!om.list<!om.any>"
-      "  %2 = om.object @Child(%8) : (!om.any) -> !om.class.type<@Child>"
+      "  %2 = om.object @Child(%10) : (!om.any) -> !om.class.type<@Child>"
       "  %3 = om.object.field %2, [@field] : (!om.class.type<@Child>) -> "
       "!om.list<!om.any>"
       "  %4 = om.list_concat %1, %3 : <!om.any>"
-      "  %5 = om.object @Leaf() : () -> !om.class.type<@Leaf>"
-      "  %6 = om.any_cast %5 : (!om.class.type<@Leaf>) -> !om.any"
-      "  %7 = om.object @Leaf() : () -> !om.class.type<@Leaf>"
-      "  %8 = om.any_cast %7 : (!om.class.type<@Leaf>) -> !om.any"
+      "  %5 = om.constant #om.integer<1 : i64>"
+      "  %6 = om.object @Leaf(%5) : (!om.integer) -> !om.class.type<@Leaf>"
+      "  %7 = om.any_cast %6 : (!om.class.type<@Leaf>) -> !om.any"
+      "  %8 = om.constant #om.integer<2 : i64>"
+      "  %9 = om.object @Leaf(%8) : (!om.integer) -> !om.class.type<@Leaf>"
+      "  %10 = om.any_cast %9 : (!om.class.type<@Leaf>) -> !om.any"
       "  om.class.fields %4 : !om.list<!om.any>"
       "}";
 
@@ -1309,6 +1311,16 @@ TEST(EvaluatorTests, ListConcatPartialCycle) {
       llvm::cast<evaluator::ListValue>(fieldValue.get())->getElements();
 
   ASSERT_EQ(2U, finalList.size());
+
+  auto obj1 = llvm::cast<evaluator::ObjectValue>(finalList[0].get());
+  auto id1 =
+      llvm::cast<evaluator::AttributeValue>(obj1->getField("id").value().get());
+  ASSERT_EQ(1U, id1->getAs<circt::om::IntegerAttr>().getValue().getValue());
+
+  auto obj2 = llvm::cast<evaluator::ObjectValue>(finalList[1].get());
+  auto id2 =
+      llvm::cast<evaluator::AttributeValue>(obj2->getField("id").value().get());
+  ASSERT_EQ(2U, id2->getAs<circt::om::IntegerAttr>().getValue().getValue());
 }
 
 TEST(EvaluatorTests, TupleGet) {


### PR DESCRIPTION
We would previously check if the value corresponding to each operand of the ListConcatOp was finished evaluating, but in the case where the operand is a ReferenceValue, the reference may be done evaluating before while the underlying ListValue is not.

To handle this, a check was added that the result of extractList is fully evaluated, and the evaluation of the ListConcatOp doesn't proceed until that is true.

A small unit test shows this scenario, where there are object references in lists passed as field references to a ListConcatOp.