### PR TITLE
[SCFToCalyx] std_fptoint/inttofpFN should write its result to a register

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -698,6 +698,9 @@ private:
     }
     op.getResult().replaceAllUsesWith(reg.getOut());
 
+    rewriter.create<calyx::AssignOp>(loc, reg.getIn(), calyxOp.getOut());
+    rewriter.create<calyx::AssignOp>(loc, reg.getWriteEn(), c1);
+
     rewriter.create<calyx::AssignOp>(
         loc, calyxOp.getGo(), c1,
         comb::createOrFoldNot(loc, calyxOp.getDone(), builder));

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -554,6 +554,8 @@ module {
 // CHECK-DAG:        calyx.assign %std_fpToIntFN_0.in = %in0 : i32
 // CHECK-DAG:        calyx.assign %std_fpToIntFN_0.signedOut = %true : i1
 // CHECK-DAG:        %0 = comb.xor %std_fpToIntFN_0.done, %true : i1
+// CHECK-DAG:        calyx.assign %fptosi_0_reg.in = %std_fpToIntFN_0.out : i64
+// CHECK-DAG:        calyx.assign %fptosi_0_reg.write_en = %true : i1
 // CHECK-DAG:        calyx.assign %std_fpToIntFN_0.go = %0 ? %true : i1
 // CHECK-DAG:        calyx.group_done %fptosi_0_reg.done : i1
 // CHECK-DAG:      }
@@ -573,6 +575,8 @@ module {
 // CHECK:      calyx.group @bb0_0 {
 // CHECK-DAG:        calyx.assign %std_intToFpFN_0.in = %in0 : i64
 // CHECK-DAG:        calyx.assign %std_intToFpFN_0.signedIn = %true : i1
+// CHECK-DAG:        calyx.assign %sitofp_0_reg.in = %std_intToFpFN_0.out : i32
+// CHECK-DAG:        calyx.assign %sitofp_0_reg.write_en = %true : i1
 // CHECK-DAG:        %0 = comb.xor %std_intToFpFN_0.done, %true : i1
 // CHECK-DAG:        calyx.assign %std_intToFpFN_0.go = %0 ? %true : i1
 // CHECK-DAG:        calyx.group_done %sitofp_0_reg.done : i1

--- a/test/Dialect/Calyx/emit.mlir
+++ b/test/Dialect/Calyx/emit.mlir
@@ -467,12 +467,16 @@ module attributes {calyx.entrypoint = "main"} {
       // CHECK-LABEL:    group bb0_0 {
       // CHECK-NEXT:      std_fptointFN_0.in = in0;
       // CHECK-NEXT:      std_fptointFN_0.signedOut = 1'b1;
+      // CHECK-NEXT:      fptosi_0_reg.in = std_fptointFN_0.out;
+      // CHECK-NEXT:      fptosi_0_reg.write_en = 1'b1;
       // CHECK-NEXT:      std_fptointFN_0.go = !std_fptointFN_0.done ? 1'b1;
       // CHECK-NEXT:      bb0_0[done] = fptosi_0_reg.done;
       // CHECK-NEXT:    }
       calyx.group @bb0_0 {
         calyx.assign %std_fptointFN_0.in = %in0 : i32
         calyx.assign %std_fptointFN_0.signedOut = %true : i1
+        calyx.assign %fptosi_0_reg.in = %std_fptointFN_0.out : i64
+        calyx.assign %fptosi_0_reg.write_en = %true : i1
         %0 = comb.xor %std_fptointFN_0.done, %true : i1
         calyx.assign %std_fptointFN_0.go = %0 ? %true : i1
         calyx.group_done %fptosi_0_reg.done : i1
@@ -509,12 +513,16 @@ module attributes {calyx.entrypoint = "main"} {
         // CHECK-LABEL:    group bb0_0 {
         // CHECK-NEXT:      std_intToFpFN_0.in = in0;
         // CHECK-NEXT:      std_intToFpFN_0.signedIn = 1'b1;
+        // CHECK-NEXT:      sitofp_0_reg.in = std_intToFpFN_0.out;
+        // CHECK-NEXT:      sitofp_0_reg.write_en = 1'b1;
         // CHECK-NEXT:      std_intToFpFN_0.go = !std_intToFpFN_0.done ? 1'b1;
         // CHECK-NEXT:      bb0_0[done] = sitofp_0_reg.done;
         // CHECK-NEXT:    }
       calyx.group @bb0_0 {
         calyx.assign %std_intToFpFN_0.in = %in0 : i64
         calyx.assign %std_intToFpFN_0.signedIn = %true : i1
+        calyx.assign %sitofp_0_reg.in = %std_intToFpFN_0.out : i32
+        calyx.assign %sitofp_0_reg.write_en = %true : i1
         %0 = comb.xor %std_intToFpFN_0.done, %true : i1
         calyx.assign %std_intToFpFN_0.go = %0 ? %true : i1
         calyx.group_done %sitofp_0_reg.done : i1


### PR DESCRIPTION
This patch fixes a bug that `std_fptoint/inttofpFN` didn't write its result to a register.