### PR TITLE
[tests] drop removed SMTLIB CAPI test from lit config

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -61,9 +61,9 @@ tools = [
     'arcilator', 'circt-as', 'circt-capi-ir-test', 'circt-capi-om-test',
     'circt-capi-firrtl-test', 'circt-capi-firtool-test',
     'circt-capi-rtg-pipelines-test', 'circt-capi-rtg-test',
-    'circt-capi-rtgtest-test', 'circt-capi-smtlib-test', 'circt-dis',
-    'circt-lec', 'circt-reduce', 'circt-synth', 'circt-test', 'circt-translate',
-    'firtool', 'hlstool', 'om-linker', 'kanagawatool'
+    'circt-capi-rtgtest-test', 'circt-dis', 'circt-lec', 'circt-reduce',
+    'circt-synth', 'circt-test', 'circt-translate', 'firtool', 'hlstool',
+    'om-linker', 'kanagawatool'
 ]
 
 if "CIRCT_OPT_CHECK_IR_ROUNDTRIP" in os.environ:


### PR DESCRIPTION
I was getting `llvm-lit: /home/bea/Research/circt-fork/llvm/llvm/utils/lit/lit/llvm/subst.py:126: note: Did not find circt-capi-smtlib-test in /home/bea/Research/circt-fork/build/bin::/home/bea/Research/circt-fork/llvm/build/./bin:/usr/bin` when running check-circt. Looks like that's because there's a test still in the lit config that was removed in #8424. This just drops that from the config.