### PR TITLE
Place black boxes with the design, if instantiated there

### DIFF
--- a/test/firtool/blackbox-directories.fir
+++ b/test/firtool/blackbox-directories.fir
@@ -347,3 +347,38 @@ circuit BlackBoxLCA: %[[
     layerblock B:
       inst bar of Bar
       connect bar.a, a
+
+; // -----
+
+; When a black box module is instantiated under both the design and the
+; testbench, the black box must be placed in the design (the testbench can refer
+; to modules in the design, but the design must not depend on the testbench).
+
+FIRRTL version 4.0.0
+
+circuit TestHarness: %[[
+  {
+    "class": "firrtl.transforms.BlackBoxInlineAnno",
+    "target": "~TestHarness|BlackBox",
+    "name": "BlackBox.sv",
+    "text": "module BlackBox();\nendmodule"
+  },
+  {
+    "class": "sifive.enterprise.firrtl.MarkDUTAnnotation",
+    "target": "~TestHarness|Component"
+  },
+  {
+    "class": "sifive.enterprise.firrtl.TestBenchDirAnnotation",
+    "dirname": "testbench"
+  }
+]]
+  ;; CHECK: FILE ".{{/|\\}}BlackBox.sv"
+  extmodule BlackBox:
+    defname = BlackBox
+
+  public module Component:
+    inst black_box of BlackBox
+  
+  public module TestHarness:
+    inst component of Component
+    inst black_box of BlackBox


### PR DESCRIPTION
The BlackBoxReaderPass has its own logic for deciding if the output file of a black box module should be under the design, or testbench, based on how it is instantiated. This PR changes this logic, so that if a black-box module is instantiated at all under the effective design, then it will be placed in the design directory. Otherwise, it will be placed in the test bench directory. This reflects the principle that, the testbench may depend on the design, but the design must not depend on the testbench. Before this PR, the logic was: if there are any instances outside of the design, then the black-box module is placed in the testbench.
