### PR TITLE
[firrtl] Improve LowerLayer XMR naming

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -333,8 +333,8 @@ LogicalResult LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
   DenseMap<Value, Operation *> nameableCache;
 
   // Get or create a node op for a value captured by a layer block.
-  auto getOrCreateNodeOp =
-      [&](Value operand, ImplicitLocOpBuilder &builder) -> Operation * {
+  auto getOrCreateNodeOp = [&](Value operand,
+                               ImplicitLocOpBuilder &builder) -> Operation * {
     // Use the cache hit.
     auto it = nameableCache.find(operand);
     if (it != nameableCache.end())

--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -342,7 +342,7 @@ LogicalResult LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
 
     // Create a new node.  Put it in the cache and use it.
     OpBuilder::InsertionGuard guard(builder);
-    builder.setInsertionPointAfter(operand.getDefiningOp());
+    builder.setInsertionPointAfterValue(operand);
     SmallString<16> nameHint;
     // Try to generate a "good" name hint to use for the node.
     if (auto *definingOp = operand.getDefiningOp()) {

--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -330,13 +330,13 @@ LogicalResult LowerLayersPass::runOnModuleBody(FModuleOp moduleOp,
   hw::InnerSymbolNamespace ns(moduleOp);
 
   // A cache of values to nameable ops that can be used
-  DenseMap<Value, Operation *> nameableCache;
+  DenseMap<Value, Operation *> nodeCache;
 
   // Get or create a node op for a value captured by a layer block.
   auto getOrCreateNodeOp = [&](Value operand,
                                ImplicitLocOpBuilder &builder) -> Operation * {
     // Use the cache hit.
-    auto *nodeOp = nameableCache.lookup(operand);
+    auto *nodeOp = nodeCache.lookup(operand);
     if (nodeOp)
       return nodeOp;
 

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -118,7 +118,8 @@ firrtl.circuit "Test" {
   // CHECK-NEXT:   firrtl.connect %b, %[[a]] : !firrtl.uint<1>
   // CHECK-NEXT: }
   // CHECK-NEXT: firrtl.module @CaptureConnect() {
-  // CHECK-NEXT:   %a = firrtl.wire sym @[[CaptureConnect_a_sym]] : !firrtl.uint<1>
+  // CHECK-NEXT:   %a = firrtl.wire : !firrtl.uint<1>
+  // CHECK-NEXT:   %a_0 = firrtl.node sym @[[CaptureConnect_a_sym]] %a {name = "a"} : !firrtl.uint<1>
   // CHECK-NEXT:   firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers-Test-A.sv", excludeFromFileList>} @CaptureConnect_A()
   // CHECK-NEXT: }
   firrtl.module @CaptureConnect() {
@@ -151,7 +152,8 @@ firrtl.circuit "Test" {
   // CHECK-NEXT:   %1 = firrtl.node %0 : !firrtl.uint<1>
   // CHECK-NEXT: }
   // CHECK-NEXT: firrtl.module private @NestedCapture_A() {
-  // CHECK-NEXT:   %x = firrtl.wire sym @[[NestedCapture_a_sym]] : !firrtl.uint<1>
+  // CHECK-NEXT:   %x = firrtl.wire : !firrtl.uint<1>
+  // CHECK-NEXT:   %x_0 = firrtl.node sym @[[NestedCapture_a_sym]] %x {name = "x"}
   // CHECK-NEXT: }
   // CHECK-NEXT: firrtl.module @NestedCapture() {
   // CHECK-NEXT:   firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers-Test-A-B.sv", excludeFromFileList>} @NestedCapture_A_B()
@@ -175,7 +177,8 @@ firrtl.circuit "Test" {
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
   // CHECK-NEXT: firrtl.module @WhenUnderLayer() {
-  // CHECK-NEXT:   %x = firrtl.wire sym @[[WhenUnderLayer_x_sym]] : !firrtl.uint<1>
+  // CHECK-NEXT:   %x = firrtl.wire : !firrtl.uint<1>
+  // CHECK-NEXT:   %x_0 = firrtl.node sym @[[WhenUnderLayer_x_sym]] %x {name = "x"}
   // CHECK-NEXT:   firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers-Test-A.sv", excludeFromFileList>} @WhenUnderLayer_A
   // CHECK-NEXT: }
   firrtl.module @WhenUnderLayer() {
@@ -200,7 +203,8 @@ firrtl.circuit "Test" {
   // CHECK-NEXT:   %0 = firrtl.subaccess %a[%b]
   // CHECK-NEXT:   %1 = firrtl.subindex %0[0]
   // CHECK-NEXT:   %2 = firrtl.subfield %1[a]
-  // CHECK-NEXT:   %3 = firrtl.node sym @[[SubOpsInLayerBlock_sub_sym]] %2 :
+  // CHECK-NEXT:   %3 = firrtl.node %2 :
+  // CHECK-NEXT:   %_layer_probe = firrtl.node sym @[[SubOpsInLayerBlock_sub_sym]] %3
   firrtl.module @SubOpsInLayerBlock(
     in %a: !firrtl.vector<vector<bundle<a: uint<1>, b flip: uint<2>>, 2>, 2>,
     in %b: !firrtl.uint<1>
@@ -223,7 +227,8 @@ firrtl.circuit "Test" {
   // CHECK-NEXT:     %b = firrtl.node %1
 
   // CHECK:      firrtl.module @CaptureWhen2(
-  // CHECK-NEXT:   %a = firrtl.wire {{.*}}
+  // CHECK-NEXT:   %a = firrtl.wire
+  // CHECK-NEXT:   %a_0 = firrtl.node {{.*}} %a
   // CHECK-NEXT:   firrtl.instance a
   firrtl.module @CaptureWhen2(in %cond: !firrtl.uint<1>) {
     %a = firrtl.wire : !firrtl.uint<1>
@@ -263,8 +268,8 @@ firrtl.circuit "Test" {
   //
   // CHECK:      firrtl.module @InstancePortCapture() {
   // CHECK-NEXT:   %ext_a, %ext_b = firrtl.instance ext @InstancePortCapture_ext
-  // CHECK-NEXT:   %ext_b_probe = firrtl.node sym @[[InstancePortCapture_ext_b_sym]] %ext_b
-  // CHECK-NEXT:   %ext_a_probe = firrtl.node sym @[[InstancePortCapture_ext_a_sym]] %ext_a
+  // CHECK-NEXT:   %ext_b_0 = firrtl.node sym @[[InstancePortCapture_ext_b_sym]] %ext_b {name = "ext_b"}
+  // CHECK-NEXT:   %ext_a_1 = firrtl.node sym @[[InstancePortCapture_ext_a_sym]] %ext_a {name = "ext_a"}
   // CHECK-NEXT:   firrtl.instance {{.*}}
   // CHECK-NEXT: }
   firrtl.extmodule @InstancePortCapture_ext(
@@ -422,7 +427,8 @@ firrtl.circuit "Simple" {
 // CHECK-NEXT:   %0 = firrtl.xmr.deref @[[Simple_A_c_path]]
 // CHECK-NEXT:   %1 = firrtl.xmr.deref @[[Simple_b_path]]
 // CHECK-NEXT:   %bb = firrtl.node %1
-// CHECK-NEXT:   %cc = firrtl.node sym @[[Simple_A_B_cc_sym]] %0
+// CHECK-NEXT:   %cc = firrtl.node %0
+// CHECK-NEXT:   %cc_0 = firrtl.node sym @[[Simple_A_B_cc_sym]] %cc {name = "cc"}
 // CHECK-NEXT: }
 //
 // CHECK: hw.hierpath private @[[Simple_a_path:.+]] [@Simple::@[[Simple_a_sym:.+]]]
@@ -430,12 +436,15 @@ firrtl.circuit "Simple" {
 // CHECK:      firrtl.module private @Simple_A() {
 // CHECK-NEXT:   %0 = firrtl.xmr.deref @[[Simple_a_path]]
 // CHECK-NEXT:   %aa = firrtl.node %0
-// CHECK-NEXT:   %c = firrtl.wire sym @[[Simple_A_c_sym]]
+// CHECK-NEXT:   %c = firrtl.wire
+// CHECK-NEXT:   %c_0 = firrtl.node sym @[[Simple_A_c_sym]] %c {name = "c"}
 // CHECK-NEXT: }
 //
 // CHECK:      firrtl.module @Simple() {
-// CHECK-NEXT:   %a = firrtl.wire sym @[[Simple_a_sym]]
-// CHECK-NEXT:   %b = firrtl.wire sym @[[Simple_b_sym]]
+// CHECK-NEXT:   %a = firrtl.wire
+// CHECK-NEXT:   %a_0 = firrtl.node sym @[[Simple_a_sym]] %a {name = "a"}
+// CHECK-NEXT:   %b = firrtl.wire
+// CHECK-NEXT:   %b_1 = firrtl.node sym @[[Simple_b_sym]] %b {name = "b"}
 // CHECK-NEXT:   firrtl.instance a_b_c {{.*}}
 // CHECK-NEXT:   firrtl.instance a_b {{.*}}
 // CHECK-NEXT:   firrtl.instance a {{.*}}

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -118,8 +118,7 @@ firrtl.circuit "Test" {
   // CHECK-NEXT:   firrtl.connect %b, %[[a]] : !firrtl.uint<1>
   // CHECK-NEXT: }
   // CHECK-NEXT: firrtl.module @CaptureConnect() {
-  // CHECK-NEXT:   %a = firrtl.wire : !firrtl.uint<1>
-  // CHECK-NEXT:   %_layer_probe = firrtl.node sym @[[CaptureConnect_a_sym]] %a
+  // CHECK-NEXT:   %a = firrtl.wire sym @[[CaptureConnect_a_sym]] : !firrtl.uint<1>
   // CHECK-NEXT:   firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers-Test-A.sv", excludeFromFileList>} @CaptureConnect_A()
   // CHECK-NEXT: }
   firrtl.module @CaptureConnect() {
@@ -152,8 +151,7 @@ firrtl.circuit "Test" {
   // CHECK-NEXT:   %1 = firrtl.node %0 : !firrtl.uint<1>
   // CHECK-NEXT: }
   // CHECK-NEXT: firrtl.module private @NestedCapture_A() {
-  // CHECK-NEXT:   %x = firrtl.wire : !firrtl.uint<1>
-  // CHECK-NEXT:   %_layer_probe = firrtl.node sym @[[NestedCapture_a_sym]] %x
+  // CHECK-NEXT:   %x = firrtl.wire sym @[[NestedCapture_a_sym]] : !firrtl.uint<1>
   // CHECK-NEXT: }
   // CHECK-NEXT: firrtl.module @NestedCapture() {
   // CHECK-NEXT:   firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers-Test-A-B.sv", excludeFromFileList>} @NestedCapture_A_B()
@@ -177,8 +175,7 @@ firrtl.circuit "Test" {
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
   // CHECK-NEXT: firrtl.module @WhenUnderLayer() {
-  // CHECK-NEXT:   %x = firrtl.wire : !firrtl.uint<1>
-  // CHECK-NEXT:   %_layer_probe = firrtl.node sym @[[WhenUnderLayer_x_sym]] %x
+  // CHECK-NEXT:   %x = firrtl.wire sym @[[WhenUnderLayer_x_sym]] : !firrtl.uint<1>
   // CHECK-NEXT:   firrtl.instance {{.+}} {lowerToBind, output_file = #hw.output_file<"layers-Test-A.sv", excludeFromFileList>} @WhenUnderLayer_A
   // CHECK-NEXT: }
   firrtl.module @WhenUnderLayer() {
@@ -203,8 +200,7 @@ firrtl.circuit "Test" {
   // CHECK-NEXT:   %0 = firrtl.subaccess %a[%b]
   // CHECK-NEXT:   %1 = firrtl.subindex %0[0]
   // CHECK-NEXT:   %2 = firrtl.subfield %1[a]
-  // CHECK-NEXT:   %3 = firrtl.node %2 :
-  // CHECK-NEXT:   %_layer_probe = firrtl.node sym @[[SubOpsInLayerBlock_sub_sym]] %3
+  // CHECK-NEXT:   %3 = firrtl.node sym @[[SubOpsInLayerBlock_sub_sym]] %2 :
   firrtl.module @SubOpsInLayerBlock(
     in %a: !firrtl.vector<vector<bundle<a: uint<1>, b flip: uint<2>>, 2>, 2>,
     in %b: !firrtl.uint<1>
@@ -227,8 +223,7 @@ firrtl.circuit "Test" {
   // CHECK-NEXT:     %b = firrtl.node %1
 
   // CHECK:      firrtl.module @CaptureWhen2(
-  // CHECK-NEXT:   %a = firrtl.wire
-  // CHECK-NEXT:   %_layer_probe = firrtl.node {{.*}} %a
+  // CHECK-NEXT:   %a = firrtl.wire {{.*}}
   // CHECK-NEXT:   firrtl.instance a
   firrtl.module @CaptureWhen2(in %cond: !firrtl.uint<1>) {
     %a = firrtl.wire : !firrtl.uint<1>
@@ -268,8 +263,8 @@ firrtl.circuit "Test" {
   //
   // CHECK:      firrtl.module @InstancePortCapture() {
   // CHECK-NEXT:   %ext_a, %ext_b = firrtl.instance ext @InstancePortCapture_ext
-  // CHECK-NEXT:   %_layer_probe = firrtl.node sym @[[InstancePortCapture_ext_b_sym]] %ext_b
-  // CHECK-NEXT:   %_layer_probe_0 = firrtl.node sym @[[InstancePortCapture_ext_a_sym]] %ext_a
+  // CHECK-NEXT:   %ext_b_probe = firrtl.node sym @[[InstancePortCapture_ext_b_sym]] %ext_b
+  // CHECK-NEXT:   %ext_a_probe = firrtl.node sym @[[InstancePortCapture_ext_a_sym]] %ext_a
   // CHECK-NEXT:   firrtl.instance {{.*}}
   // CHECK-NEXT: }
   firrtl.extmodule @InstancePortCapture_ext(
@@ -427,8 +422,7 @@ firrtl.circuit "Simple" {
 // CHECK-NEXT:   %0 = firrtl.xmr.deref @[[Simple_A_c_path]]
 // CHECK-NEXT:   %1 = firrtl.xmr.deref @[[Simple_b_path]]
 // CHECK-NEXT:   %bb = firrtl.node %1
-// CHECK-NEXT:   %cc = firrtl.node %0
-// CHECK-NEXT:   %_layer_probe = firrtl.node sym @[[Simple_A_B_cc_sym]] %cc
+// CHECK-NEXT:   %cc = firrtl.node sym @[[Simple_A_B_cc_sym]] %0
 // CHECK-NEXT: }
 //
 // CHECK: hw.hierpath private @[[Simple_a_path:.+]] [@Simple::@[[Simple_a_sym:.+]]]
@@ -436,15 +430,12 @@ firrtl.circuit "Simple" {
 // CHECK:      firrtl.module private @Simple_A() {
 // CHECK-NEXT:   %0 = firrtl.xmr.deref @[[Simple_a_path]]
 // CHECK-NEXT:   %aa = firrtl.node %0
-// CHECK-NEXT:   %c = firrtl.wire
-// CHECK-NEXT:   %_layer_probe = firrtl.node sym @[[Simple_A_c_sym]] %c
+// CHECK-NEXT:   %c = firrtl.wire sym @[[Simple_A_c_sym]]
 // CHECK-NEXT: }
 //
 // CHECK:      firrtl.module @Simple() {
-// CHECK-NEXT:   %a = firrtl.wire
-// CHECK-NEXT:   %_layer_probe = firrtl.node sym @[[Simple_a_sym]] %a
-// CHECK-NEXT:   %b = firrtl.wire
-// CHECK-NEXT:   %_layer_probe_0 = firrtl.node sym @[[Simple_b_sym]] %b
+// CHECK-NEXT:   %a = firrtl.wire sym @[[Simple_a_sym]]
+// CHECK-NEXT:   %b = firrtl.wire sym @[[Simple_b_sym]]
 // CHECK-NEXT:   firrtl.instance a_b_c {{.*}}
 // CHECK-NEXT:   firrtl.instance a_b {{.*}}
 // CHECK-NEXT:   firrtl.instance a {{.*}}

--- a/test/firtool/layers.fir
+++ b/test/firtool/layers.fir
@@ -38,16 +38,17 @@ circuit Foo: %[[
             assert(clock, cond, enable, "Test")
 
 ; CHECK-LABEL: module Foo_A_B();
-; CHECK:         wire y = Foo.a.x;
-; CHECK:         wire z = Foo.a.x;
+; CHECK:         wire y = Foo.a.x_0;
+; CHECK:         wire z = Foo.a.x_0;
 ; CHECK:         always @(posedge Foo.clock) begin
-; CHECK-NEXT:      if (Foo.cond & Foo.a.x & Foo.enable)
+; CHECK-NEXT:      if (Foo.cond & Foo.a.x_0 & Foo.enable)
 ; CHECK-NEXT:        assert(Foo.cond) else $error("Test");
 ; CHECK-NEXT:    end // always @(posedge)
 ; CHECK-NEXT:  endmodule
 
 ; CHECK-LABEL: module Foo_A();
 ; CHECK-NEXT:    wire x = Foo.in;
+; CHECK-NEXT:    wire x_0 = x;
 ; CHECK-NEXT:  endmodule
 
 ; CHECK-LABEL: FILE "layers-Foo-A-B.sv"

--- a/test/firtool/layers.fir
+++ b/test/firtool/layers.fir
@@ -38,17 +38,16 @@ circuit Foo: %[[
             assert(clock, cond, enable, "Test")
 
 ; CHECK-LABEL: module Foo_A_B();
-; CHECK:         wire y = Foo.a._layer_probe;
-; CHECK:         wire z = Foo.a._layer_probe;
+; CHECK:         wire y = Foo.a.x;
+; CHECK:         wire z = Foo.a.x;
 ; CHECK:         always @(posedge Foo.clock) begin
-; CHECK-NEXT:      if (Foo.cond & Foo.a._layer_probe & Foo.enable)
+; CHECK-NEXT:      if (Foo.cond & Foo.a.x & Foo.enable)
 ; CHECK-NEXT:        assert(Foo.cond) else $error("Test");
 ; CHECK-NEXT:    end // always @(posedge)
 ; CHECK-NEXT:  endmodule
 
 ; CHECK-LABEL: module Foo_A();
-; CHECK:         wire x = Foo.in;
-; CHECK-NEXT:    wire _layer_probe = x;
+; CHECK-NEXT:    wire x = Foo.in;
 ; CHECK-NEXT:  endmodule
 
 ; CHECK-LABEL: FILE "layers-Foo-A-B.sv"


### PR DESCRIPTION
Improve the naming of values captured by the `LowerLayers` pass.  Change
the logic used when a node is created.  Try to use the underlying value if
possible.  If unable to do this, then create a node, but use a saner name
for it.

Fixes #8465.
Fixes #8426.
