### PR TITLE
Bump LLVM to c6c2e21028cadef854cf22f6ecaa5eb9d224b76d.

### DIFF
--- a/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
+++ b/lib/Conversion/LoopScheduleToCalyx/LoopScheduleToCalyx.cpp
@@ -1544,10 +1544,10 @@ public:
     // will only be established later in the conversion process, so ensure
     // that rewriter optimizations (especially DCE) are disabled.
     GreedyRewriteConfig config;
-    config.enableRegionSimplification =
-        mlir::GreedySimplifyRegionLevel::Disabled;
+    config.setRegionSimplificationLevel(
+        mlir::GreedySimplifyRegionLevel::Disabled);
     if (runOnce)
-      config.maxIterations = 1;
+      config.setMaxIterations(1);
 
     /// Can't return applyPatternsGreedily. Root isn't
     /// necessarily erased so it will always return failed(). Instead,

--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -2693,10 +2693,10 @@ public:
     // will only be established later in the conversion process, so ensure
     // that rewriter optimizations (especially DCE) are disabled.
     GreedyRewriteConfig config;
-    config.enableRegionSimplification =
-        mlir::GreedySimplifyRegionLevel::Disabled;
+    config.setRegionSimplificationLevel(
+        mlir::GreedySimplifyRegionLevel::Disabled);
     if (runOnce)
-      config.maxIterations = 1;
+      config.setMaxIterations(1);
 
     /// Can't return applyPatternsGreedily. Root isn't
     /// necessarily erased so it will always return failed(). Instead,

--- a/lib/Dialect/AIG/Transforms/LowerWordToBits.cpp
+++ b/lib/Dialect/AIG/Transforms/LowerWordToBits.cpp
@@ -95,7 +95,7 @@ void LowerWordToBitsPass::runOnOperation() {
   mlir::FrozenRewritePatternSet frozenPatterns(std::move(patterns));
   mlir::GreedyRewriteConfig config;
   // Use top-down traversal to reuse bits from `comb.concat`.
-  config.useTopDownTraversal = true;
+  config.setUseTopDownTraversal(true);
 
   if (failed(
           mlir::applyPatternsGreedily(getOperation(), frozenPatterns, config)))

--- a/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
+++ b/lib/Dialect/Arc/Transforms/ArcCanonicalizer.cpp
@@ -789,11 +789,12 @@ void ArcCanonicalizerPass::runOnOperation() {
   DenseMap<StringAttr, StringAttr> arcMapping;
 
   mlir::GreedyRewriteConfig config;
-  config.enableRegionSimplification = mlir::GreedySimplifyRegionLevel::Disabled;
-  config.maxIterations = 10;
-  config.useTopDownTraversal = true;
+  config.setRegionSimplificationLevel(
+      mlir::GreedySimplifyRegionLevel::Disabled);
+  config.setMaxIterations(10);
+  config.setUseTopDownTraversal(true);
   ArcListener listener(&cache);
-  config.listener = &listener;
+  config.setListener(&listener);
 
   PatternStatistics statistics;
   RewritePatternSet symbolPatterns(&getContext());

--- a/lib/Dialect/Calyx/Transforms/AffinePloopUnparallelize.cpp
+++ b/lib/Dialect/Calyx/Transforms/AffinePloopUnparallelize.cpp
@@ -196,7 +196,7 @@ void AffinePloopUnparallelizePass::runOnOperation() {
   RewritePatternSet patterns(ctx);
   patterns.add<AffinePloopUnparallelize>(ctx);
   GreedyRewriteConfig config;
-  config.strictMode = GreedyRewriteStrictness::ExistingOps;
+  config.setStrictness(GreedyRewriteStrictness::ExistingOps);
   if (failed(
           applyPatternsGreedily(getOperation(), std::move(patterns), config))) {
     signalPassFailure();

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaPassPipelines.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaPassPipelines.cpp
@@ -20,8 +20,9 @@ using namespace kanagawa;
 /// Create a simple canonicalizer pass.
 static std::unique_ptr<Pass> createSimpleCanonicalizerPass() {
   mlir::GreedyRewriteConfig config;
-  config.useTopDownTraversal = true;
-  config.enableRegionSimplification = mlir::GreedySimplifyRegionLevel::Disabled;
+  config.setUseTopDownTraversal(true);
+  config.setRegionSimplificationLevel(
+      mlir::GreedySimplifyRegionLevel::Disabled);
   return mlir::createCanonicalizerPass(config);
 }
 

--- a/lib/Reduce/GenericReductions.cpp
+++ b/lib/Reduce/GenericReductions.cpp
@@ -48,8 +48,9 @@ struct OperationPruner : public Reduction {
 
 static std::unique_ptr<Pass> createSimpleCanonicalizerPass() {
   GreedyRewriteConfig config;
-  config.useTopDownTraversal = true;
-  config.enableRegionSimplification = mlir::GreedySimplifyRegionLevel::Disabled;
+  config.setUseTopDownTraversal(true);
+  config.setRegionSimplificationLevel(
+      mlir::GreedySimplifyRegionLevel::Disabled);
   return createCanonicalizerPass(config);
 }
 

--- a/lib/Support/Passes.cpp
+++ b/lib/Support/Passes.cpp
@@ -14,7 +14,8 @@ using namespace circt;
 
 std::unique_ptr<Pass> circt::createSimpleCanonicalizerPass() {
   mlir::GreedyRewriteConfig config;
-  config.useTopDownTraversal = true;
-  config.enableRegionSimplification = mlir::GreedySimplifyRegionLevel::Disabled;
+  config.setUseTopDownTraversal(true);
+  config.setRegionSimplificationLevel(
+      mlir::GreedySimplifyRegionLevel::Disabled);
   return mlir::createCanonicalizerPass(config);
 }

--- a/lib/Transforms/MemoryBanking.cpp
+++ b/lib/Transforms/MemoryBanking.cpp
@@ -936,7 +936,7 @@ LogicalResult MemoryBankingPass::applyMemoryBanking(Operation *operation,
   patterns.add<BankReturnPattern>(ctx, memoryToBanks);
 
   GreedyRewriteConfig config;
-  config.strictMode = GreedyRewriteStrictness::ExistingOps;
+  config.setStrictness(GreedyRewriteStrictness::ExistingOps);
   if (failed(applyPatternsGreedily(operation, std::move(patterns), config))) {
     return failure();
   }

--- a/tools/hlstool/hlstool.cpp
+++ b/tools/hlstool/hlstool.cpp
@@ -239,8 +239,9 @@ static cl::opt<std::string> topLevelFunction("top-level-function",
 /// Create a simple canonicalizer pass.
 static std::unique_ptr<Pass> createSimpleCanonicalizerPass() {
   mlir::GreedyRewriteConfig config;
-  config.useTopDownTraversal = true;
-  config.enableRegionSimplification = mlir::GreedySimplifyRegionLevel::Disabled;
+  config.setUseTopDownTraversal(true);
+  config.setRegionSimplificationLevel(
+      mlir::GreedySimplifyRegionLevel::Disabled);
   return mlir::createCanonicalizerPass(config);
 }
 

--- a/tools/kanagawatool/kanagawatool.cpp
+++ b/tools/kanagawatool/kanagawatool.cpp
@@ -146,8 +146,9 @@ static LoweringOptionsOption loweringOptions(mainCategory);
 /// Create a simple canonicalizer pass.
 static std::unique_ptr<Pass> createSimpleCanonicalizerPass() {
   mlir::GreedyRewriteConfig config;
-  config.useTopDownTraversal = true;
-  config.enableRegionSimplification = mlir::GreedySimplifyRegionLevel::Disabled;
+  config.setUseTopDownTraversal(true);
+  config.setRegionSimplificationLevel(
+      mlir::GreedySimplifyRegionLevel::Disabled);
   return mlir::createCanonicalizerPass(config);
 }
 


### PR DESCRIPTION
The only change was to adapt to new GreedyRewriteConfig APIs.

This is a straightforward mapping after GreedyRewriteConfig was given
a more fluent API, with some minor naming changes applied in:

https://github.com/llvm/llvm-project/commit/0c61b24