### PR TITLE
Make sv::IfDefOp's regions graph-regions

### DIFF
--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -12,6 +12,7 @@
 
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/RegionKindInterface.td"
 include "mlir/Interfaces/FunctionInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "circt/Dialect/Emit/EmitOpInterfaces.td"
@@ -43,10 +44,9 @@ def OrderedOutputOp : SVOp<"ordered", [SingleBlock, NoTerminator, NoRegionArgume
 }
 
 def IfDefOp : SVOp<"ifdef", [
-    SingleBlock,
-    NoTerminator,
     NoRegionArguments,
     NonProceduralOp,
+    GraphRegionNoTerminator,
     DeclareOpInterfaceMethods<SymbolUserOpInterface>
 ]> {
   let summary = "'ifdef MACRO' block";


### PR DESCRIPTION
Make the sv::IfDefOp use graph regions. There is a distinct "procedural" ifdef op which uses ssa regions. [GraphRegionNoTerminator](https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/IR/RegionKindInterface.td#L57-L62) is a trait-list which implies single-block, no-terminator, and graph regions.

Co-authored-by: @dtzSiFive