### PR TITLE
[FIRRTL] Update blackbox metadata to include "in DUT" logic.

### DIFF
--- a/test/Dialect/FIRRTL/SFCTests/directories.fir
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir
@@ -135,17 +135,20 @@ circuit TestHarness:
 ; SITEST_NODUT:     FILE "testbench.sitest.json"
 ; SITEST_NODUT-NOT: FILE
 
-; MLIR_OUT:  om.class @SitestBlackBoxModulesSchema(%basepath: !om.basepath, %moduleName_in: !om.string) -> (moduleName: !om.string) {
-; MLIR_OUT:    om.class.fields %moduleName_in : !om.string
+; MLIR_OUT:  om.class @SitestBlackBoxModulesSchema(%basepath: !om.basepath, %moduleName_in: !om.string, %inDut_in: i1) -> (moduleName: !om.string, inDut: i1) {
+; MLIR_OUT:    om.class.fields %moduleName_in, %inDut_in : !om.string, i1
 ; MLIR_OUT:  }
 
 ; MLIR_OUT:  om.class @SitestBlackBoxMetadata(%basepath: !om.basepath) -> [[V1:.+]]: !om.class.type<@SitestBlackBoxModulesSchema>, [[V2:.+]]: !om.class.type<@SitestBlackBoxModulesSchema>, [[V3:.+]]: !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT-DAG:    [[STR1:%.+]] = om.constant "Foo_BlackBox" : !om.string
-; MLIR_OUT-DAG:    [[OBJ1:%.+]] = om.object @SitestBlackBoxModulesSchema(%basepath, [[STR1]]) : (!om.basepath, !om.string) -> !om.class.type<@SitestBlackBoxModulesSchema>
+; MLIR_OUT-DAG:    [[DUT1:%.+]] = om.constant true
+; MLIR_OUT-DAG:    [[OBJ1:%.+]] = om.object @SitestBlackBoxModulesSchema(%basepath, [[STR1]], [[DUT1]]) : (!om.basepath, !om.string, i1) -> !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT-DAG:    [[STR2:%.+]] = om.constant "Bar_BlackBox" : !om.string
-; MLIR_OUT-DAG:    [[OBJ2:%.+]] = om.object @SitestBlackBoxModulesSchema(%basepath, [[STR2]]) : (!om.basepath, !om.string) -> !om.class.type<@SitestBlackBoxModulesSchema>
+; MLIR_OUT-DAG:    [[DUT2:%.+]] = om.constant true
+; MLIR_OUT-DAG:    [[OBJ2:%.+]] = om.object @SitestBlackBoxModulesSchema(%basepath, [[STR2]], [[DUT2]]) : (!om.basepath, !om.string, i1) -> !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT-DAG:    [[STR3:%.+]] = om.constant "Baz_BlackBox" : !om.string
-; MLIR_OUT-DAG:    [[OBJ3:%.+]] = om.object @SitestBlackBoxModulesSchema(%basepath, [[STR3]]) : (!om.basepath, !om.string) -> !om.class.type<@SitestBlackBoxModulesSchema>
+; MLIR_OUT-DAG:    [[DUT3:%.+]] = om.constant true
+; MLIR_OUT-DAG:    [[OBJ3:%.+]] = om.object @SitestBlackBoxModulesSchema(%basepath, [[STR3]], [[DUT3]]) : (!om.basepath, !om.string, i1) -> !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT:    om.class.fields [[OBJ1]], [[OBJ2]], [[OBJ3]] : !om.class.type<@SitestBlackBoxModulesSchema>, !om.class.type<@SitestBlackBoxModulesSchema>, !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT:  }
 

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -303,10 +303,13 @@ firrtl.circuit "BasicBlackboxes" attributes {
 // (1) Class-based metadata ----------------------------------------------------
 //
 // CHECK:               firrtl.class @SitestBlackBoxModulesSchema(
-// CHECK-SAME:            in %[[moduleName_in:.+]]: !firrtl.string,
-// CHECK-SAME:            out %moduleName: !firrtl.string
+// CHECK-SAME:            in %[[moduleName_in:[^:]+]]: !firrtl.string,
+// CHECK-SAME:            out %moduleName: !firrtl.string,
+// CHECK-SAME:            in %[[inDut_in:[^:]+]]: !firrtl.bool,
+// CHECK-SAME:            out %inDut: !firrtl.bool
 // CHECK-SAME:          ) {
 // CHECK-NEXT:            firrtl.propassign %moduleName, %[[moduleName_in]]
+// CHECK-NEXT:            firrtl.propassign %inDut, %[[inDut_in]]
 // CHECK:               }
 //
 // CHECK:               firrtl.class @SitestBlackBoxMetadata(
@@ -318,33 +321,48 @@ firrtl.circuit "BasicBlackboxes" attributes {
 // CHECK-NOT:             !firrtl.class<@SitestBlackBoxModulesSchema(
 //
 // CHECK-NEXT:            %[[#defname:]] = firrtl.string "TestBlackbox"
+// CHECK-NEXT:            %[[#inDutVal:]] = firrtl.bool false
 // CHECK-NEXT:            %[[object:.+]] = firrtl.object @SitestBlackBoxModulesSchema
 // CHECK-NEXT:            %[[#moduleName:]] = firrtl.object.subfield %[[object]][moduleName_in]
 // CHECK-NEXT:            firrtl.propassign %[[#moduleName]], %[[#defname:]] : !firrtl.string
+// CHECK-NEXT:            %[[#inDut:]] = firrtl.object.subfield %[[object]][inDut_in]
+// CHECK-NEXT:            firrtl.propassign %[[#inDut]], %[[#inDutVal]] : !firrtl.bool
 // CHECK-NEXT:            firrtl.propassign %TestBlackbox_field, %[[object]]
 //
 // CHECK-NEXT:            %[[#defname:]] = firrtl.string "DUTBlackbox2"
+// CHECK-NEXT:            %[[#inDutVal:]] = firrtl.bool true
 // CHECK-NEXT:            %[[object:.+]] = firrtl.object @SitestBlackBoxModulesSchema
 // CHECK-NEXT:            %[[#moduleName:]] = firrtl.object.subfield %[[object]][moduleName_in]
 // CHECK-NEXT:            firrtl.propassign %[[#moduleName]], %[[#defname:]] : !firrtl.string
+// CHECK-NEXT:            %[[#inDut:]] = firrtl.object.subfield %[[object]][inDut_in]
+// CHECK-NEXT:            firrtl.propassign %[[#inDut]], %[[#inDutVal]] : !firrtl.bool
 // CHECK-NEXT:            firrtl.propassign %DUTBlackbox_0_field, %[[object]]
 //
 // CHECK-NEXT:            %[[#defname:]] = firrtl.string "DUTBlackbox1"
+// CHECK-NEXT:            %[[#inDutVal:]] = firrtl.bool true
 // CHECK-NEXT:            %[[object:.+]] = firrtl.object @SitestBlackBoxModulesSchema
 // CHECK-NEXT:            %[[#moduleName:]] = firrtl.object.subfield %[[object]][moduleName_in]
 // CHECK-NEXT:            firrtl.propassign %[[#moduleName]], %[[#defname:]] : !firrtl.string
+// CHECK-NEXT:            %[[#inDut:]] = firrtl.object.subfield %[[object]][inDut_in]
+// CHECK-NEXT:            firrtl.propassign %[[#inDut]], %[[#inDutVal]] : !firrtl.bool
 // CHECK-NEXT:            firrtl.propassign %DUTBlackbox_1_field, %[[object]]
 //
 // CHECK-NEXT:            %[[#defname:]] = firrtl.string "LayerBlackboxInDesign"
+// CHECK-NEXT:            %[[#inDutVal:]] = firrtl.bool true
 // CHECK-NEXT:            %[[object:.+]] = firrtl.object @SitestBlackBoxModulesSchema
 // CHECK-NEXT:            %[[#moduleName:]] = firrtl.object.subfield %[[object]][moduleName_in]
 // CHECK-NEXT:            firrtl.propassign %[[#moduleName]], %[[#defname:]] : !firrtl.string
+// CHECK-NEXT:            %[[#inDut:]] = firrtl.object.subfield %[[object]][inDut_in]
+// CHECK-NEXT:            firrtl.propassign %[[#inDut]], %[[#inDutVal]] : !firrtl.bool
 // CHECK-NEXT:            firrtl.propassign %LayerBlackboxInDesign_field, %[[object]]
 //
 // CHECK-NEXT:            %[[#defname:]] = firrtl.string "LayerBlackbox"
+// CHECK-NEXT:            %[[#inDutVal:]] = firrtl.bool false
 // CHECK-NEXT:            %[[object:.+]] = firrtl.object @SitestBlackBoxModulesSchema
 // CHECK-NEXT:            %[[#moduleName:]] = firrtl.object.subfield %[[object]][moduleName_in]
 // CHECK-NEXT:            firrtl.propassign %[[#moduleName]], %[[#defname:]] : !firrtl.string
+// CHECK-NEXT:            %[[#inDut:]] = firrtl.object.subfield %[[object]][inDut_in]
+// CHECK-NEXT:            firrtl.propassign %[[#inDut]], %[[#inDutVal]] : !firrtl.bool
 // CHECK-NEXT:            firrtl.propassign %LayerBlackbox_field, %[[object]]
 //
 // CHECK-NOT:             firrtl.object


### PR DESCRIPTION
We are porting this metadata from a JSON output to use the FIRRTL object operations. As part of this, we need to distinguish if each object represents a blackbox that is used in the DUT or not, using the same logic to split the blackboxes into two different output files in the old JSON version.