### PR TITLE
[Arc] Don't let LowerState delete instantiated external modules

### DIFF
--- a/test/Dialect/Arc/lower-state-errors.mlir
+++ b/test/Dialect/Arc/lower-state-errors.mlir
@@ -9,3 +9,10 @@ hw.module @CombLoop(in %a: i42, out z: i42) {
   // expected-remark @below {{computing new phase here}}
   hw.output %0 : i42
 }
+
+// -----
+
+// expected-error @+1 {{Failed to remove external module because it is still referenced/instantiated}}
+hw.module.extern @myModule()
+
+hw.instance "alligator" @myModule() -> ()


### PR DESCRIPTION
There's a part of LowerState that deletes any `hw.module.extern` operations - however, this produces invalid IR if there's an external module whose name is still referenced by e.g. an instance. This just adds a check to made sure that the symbol containing the module's name has no remaining references.

P.S. how come this pass needs to erase all external modules? CC: @fabianschuiki as per git blame