### PR TITLE
[firrtl] Drop directory in layer include files

### DIFF
--- a/test/firtool/lower-layers.fir
+++ b/test/firtool/lower-layers.fir
@@ -75,7 +75,7 @@ circuit Foo: %[[
   ; CHECK: FILE "testbench{{[/\]}}layers-Foo-Verification.sv"
   ; CHECK: `ifndef layers_Foo_Verification
   ; CHECK:   `define layers_Foo_Verification
-  ; CHECK:   `include "testbench{{[/\]}}layers-Bar-Verification.sv"
+  ; CHECK:   `include "layers-Bar-Verification.sv"
   ; CHECK: `endif // not def layers_Foo_Verification
 
 ; // -----
@@ -308,7 +308,7 @@ circuit Foo:
     inst bar of Bar
 
 ; CHECK: FILE "A{{[/\]}}layers-Foo-A.sv"
-; CHECK: `include "A{{[/\]}}layers-Bar-A.sv"
+; CHECK: `include "layers-Bar-A.sv"
 
 ; CHECK: FILE "B{{[/\]}}layers-Foo-B.sv"
-; CHECK: `include "B{{[/\]}}layers-Bar-B.sv"
+; CHECK: `include "layers-Bar-B.sv"


### PR DESCRIPTION
This reverts a suggestion [[1]] I made on #8458.  This changes
the (undocumented) ABI of FIRRTL layers to _not_ include any directory
information in the `` `include `` directives used to enable layers.  The
reason for this is that using the full paths (relative to the root output
directory) prevents rearranaging directories after compilation.

The downside to this is that users must include more `+incdir` command
line options to include _all_ directories in a design.  However, I think
this is reasonable.

I do think that we can roll this back to use the original behavior in the
future in a backwards-compatible way.  I.e., making the change from not
including the full path to including the full path won't break any
downstream tools as these will just be including _too many_ `+incdir`s.

[1]: https://github.com/llvm/circt/pull/8458#pullrequestreview-2816208428
