### PR TITLE
[circt-opt][Calyx] Integrate the Math to `circt-opt` and lower `math.sqrt` to Calyx

### DIFF
--- a/lib/Conversion/SCFToCalyx/CMakeLists.txt
+++ b/lib/Conversion/SCFToCalyx/CMakeLists.txt
@@ -20,4 +20,5 @@ add_circt_conversion_library(CIRCTSCFToCalyx
   MLIRTransforms
   MLIRAffineToStandard
   MLIRSCFDialect
+  MLIRMathDialect
 )

--- a/test/Conversion/SCFToCalyx/convert_simple.mlir
+++ b/test/Conversion/SCFToCalyx/convert_simple.mlir
@@ -637,3 +637,26 @@ module {
     return %1 : f32
   }
 }
+
+// -----
+
+// Test floating point square root
+
+// CHECK:    %sqrt_0_reg.in, %sqrt_0_reg.write_en, %sqrt_0_reg.clk, %sqrt_0_reg.reset, %sqrt_0_reg.out, %sqrt_0_reg.done = calyx.register @sqrt_0_reg : i32, i1, i1, i1, i32, i1
+// CHECK-DAG:    %std_divSqrtFN_0.clk, %std_divSqrtFN_0.reset, %std_divSqrtFN_0.go, %std_divSqrtFN_0.control, %std_divSqrtFN_0.sqrtOp, %std_divSqrtFN_0.left, %std_divSqrtFN_0.right, %std_divSqrtFN_0.roundingMode, %std_divSqrtFN_0.out, %std_divSqrtFN_0.exceptionalFlags, %std_divSqrtFN_0.done = calyx.ieee754.divSqrt @std_divSqrtFN_0 : i1, i1, i1, i1, i1, i32, i32, i3, i32, i5, i1
+// CHECK:      calyx.group @bb0_0 {
+// CHECK-DAG:        calyx.assign %std_divSqrtFN_0.left = %in0 : i32
+// CHECK-DAG:        calyx.assign %sqrt_0_reg.in = %std_divSqrtFN_0.out : i32
+// CHECK-DAG:        calyx.assign %sqrt_0_reg.write_en = %std_divSqrtFN_0.done : i1
+// CHECK-DAG:        %0 = comb.xor %std_divSqrtFN_0.done, %true : i1
+// CHECK-DAG:        calyx.assign %std_divSqrtFN_0.go = %0 ? %true : i1
+// CHECK-DAG:        calyx.assign %std_divSqrtFN_0.sqrtOp = %true : i1
+// CHECK-DAG:        calyx.group_done %sqrt_0_reg.done : i1
+// CHECK-DAG:      }
+
+module {
+  func.func @main(%arg0: f32) -> f32 {
+    %result = math.sqrt %arg0 : f32
+    return %result : f32
+  }
+}

--- a/tools/circt-opt/circt-opt.cpp
+++ b/tools/circt-opt/circt-opt.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -48,6 +49,7 @@ int main(int argc, char **argv) {
 
   // Register MLIR stuff
   registry.insert<mlir::affine::AffineDialect>();
+  registry.insert<mlir::math::MathDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::func::FuncDialect>();


### PR DESCRIPTION
After discussing with @fabianschuiki over the CIRCT Discord, we both agree that integrating the Math dialect can be helpful to both Calyx and Moore dialect. So I just initiate the integration by bundling with the Calyx use case.