### PR TITLE
[Seq] Remove redundant enable mux in front of compreg.ce

### DIFF
--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -117,6 +117,7 @@ def CompRegClockEnabledOp : SeqOp<"compreg.ce",
     custom<OptionalImmutableTypeMatch>(ref(type($data)), ref($initialValue), type($initialValue))
   }];
   let hasVerifier = 1;
+  let hasCanonicalizeMethod = 1;
 
   let builders = [
     OpBuilder<(ins "Value":$input, "Value":$clk, "Value":$ce,

--- a/lib/Dialect/Seq/CMakeLists.txt
+++ b/lib/Dialect/Seq/CMakeLists.txt
@@ -29,7 +29,9 @@ add_circt_dialect_library(CIRCTSeq
   Support
 
   LINK_LIBS PUBLIC
+  CIRCTComb
   CIRCTHW
+  MLIRArithDialect
   MLIRIR
   MLIRPass
   MLIRTransforms

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -296,3 +296,14 @@ hw.module @clock_inv(in %clock : !seq.clock, out clock_true : !seq.clock, out cl
   hw.output %clk_inv_low, %clk_inv_high, %clk_orig : !seq.clock, !seq.clock, !seq.clock
 
 }
+
+// CHECK-LABEL: @CompRegClockEnabled(
+hw.module @CompRegClockEnabled(in %clock: !seq.clock, in %d: i42, in %x: i42, in %en: i1, out q0: i42, out q1: i42) {
+  // CHECK-NEXT: seq.compreg.ce %d, %clock, %en
+  // CHECK-NEXT: seq.compreg.ce %d, %clock, %en
+  %0 = comb.mux %en, %d, %x : i42
+  %1 = seq.compreg.ce %0, %clock, %en : i42
+  %2 = arith.select %en, %d, %x : i42
+  %3 = seq.compreg.ce %2, %clock, %en : i42
+  hw.output %1, %3 : i42, i42
+}


### PR DESCRIPTION
Add a canonicalizer that removes `comb.mux` and `arith.select` ops on the data input of the register if those ops use the register's enable as select operand. For example:

    %0 = comb.mux %enable, %a, %b
    seq.compreg.ce %0, %clock, %enable

gets canonicalized to

    seq.compreg.ce %a, %clock, %enable