### PR TITLE
SimToSV: Keep plusargs non-synth === under !SYNTHESIS block

### DIFF
--- a/test/Conversion/SimToSV/plusargs.mlir
+++ b/test/Conversion/SimToSV/plusargs.mlir
@@ -16,29 +16,33 @@ hw.module @plusargs_test(out test: i1) {
 
 // CHECK-LABEL: hw.module @plusargs_value
 hw.module @plusargs_value(out test: i1, out value: i5) {
-  // CHECK-NEXT: [[BAR_VALUE_DECL:%.*]] = sv.reg : !hw.inout<i5>
-  // CHECK-NEXT: [[BAR_FOUND_DECL:%.*]] = sv.reg : !hw.inout<i1>
+  // CHECK-NEXT: [[BAR_VALUE:%.*]] = sv.wire : !hw.inout<i5>
+  // CHECK-NEXT: [[BAR_FOUND:%.*]] = sv.wire : !hw.inout<i1>
   // CHECK-NEXT: sv.ifdef @SYNTHESIS {
   // CHECK-NEXT:   %false = hw.constant false
   // CHECK-NEXT:   %z_i5 = sv.constantZ : i5
-  // CHECK-NEXT:   sv.assign [[BAR_VALUE_DECL]], %z_i5
+  // CHECK-NEXT:   sv.assign [[BAR_VALUE]], %z_i5
   // CHECK-SAME:     #sv.attribute<"This dummy assignment exists to avoid undriven lint warnings
   // CHECK-SAME:     emitAsComment
-  // CHECK-NEXT:   sv.assign [[BAR_FOUND_DECL]], %false
+  // CHECK-NEXT:   sv.assign [[BAR_FOUND]], %false
   // CHECK-NEXT: } else {
+  // CHECK-NEXT:   [[FOUND_REG:%.*]] = sv.reg : !hw.inout<i32>
+  // CHECK-NEXT:   [[VALUE_REG:%.*]] = sv.reg : !hw.inout<i5>
   // CHECK-NEXT:   sv.initial {
-  // CHECK-NEXT:     %c0_i32 = hw.constant 0 : i32
   // CHECK-NEXT:     [[BAR_STR:%.*]] = sv.constantStr "bar"
-  // CHECK-NEXT:     [[TMP:%.*]] = sv.system "value$plusargs"([[BAR_STR]], [[BAR_VALUE_DECL]])
-  // CHECK-NEXT:     [[TMP2:%.*]] = comb.icmp bin ne [[TMP]], %c0_i32
-  // CHECK-NEXT:     sv.bpassign [[BAR_FOUND_DECL]], [[TMP2]]
+  // CHECK-NEXT:     [[PLUSARG_FOUND:%.*]] = sv.system "value$plusargs"([[BAR_STR]], [[VALUE_REG]])
+  // CHECK-NEXT:     sv.bpassign [[FOUND_REG]], [[PLUSARG_FOUND]]
   // CHECK-NEXT:   }
+  // CHECK-NEXT:   [[FOUND_READ:%.*]] = sv.read_inout [[FOUND_REG]] : !hw.inout<i32>
+  // CHECK-NEXT:   [[VALUE_READ:%.*]] = sv.read_inout [[VALUE_REG]] : !hw.inout<i5>
+  // CHECK-NEXT:   %c1_i32 = hw.constant 1 : i32
+  // CHECK-NEXT:   [[FOUND:%.*]] = comb.icmp ceq [[FOUND_READ]], %c1_i32 : i32
+  // CHECK-NEXT:   sv.assign [[BAR_FOUND]], [[FOUND]] : i1
+  // CHECK-NEXT:   sv.assign [[BAR_VALUE]], [[VALUE_READ]] : i5
   // CHECK-NEXT: }
-  // CHECK-NEXT: [[BAR_FOUND_READ:%.*]] = sv.read_inout [[BAR_FOUND_DECL]]
-  // CHECK-NEXT: [[BAR_VALUE:%.*]] = sv.read_inout [[BAR_VALUE_DECL]]
-  // CHECK-NEXT: %true = hw.constant true
-  // CHECK-NEXT: [[BAR_FOUND:%.*]] = comb.icmp ceq [[BAR_FOUND_READ]], %true : i1
-  // CHECK-NEXT: hw.output [[BAR_FOUND]], [[BAR_VALUE]] : i1, i5
+  // CHECK-NEXT: [[BAR_FOUND_READ:%.*]] = sv.read_inout [[BAR_FOUND]]
+  // CHECK-NEXT: [[BAR_VALUE_READ:%.*]] = sv.read_inout [[BAR_VALUE]]
+  // CHECK-NEXT: hw.output [[BAR_FOUND_READ]], [[BAR_VALUE_READ]] : i1, i5
   %0, %1 = sim.plusargs.value "bar" : i5
   hw.output %0, %1 : i1, i5
 }

--- a/test/firtool/plusargs.fir
+++ b/test/firtool/plusargs.fir
@@ -22,21 +22,26 @@ circuit PlusArgTest:
     ; CHECK-NEXT: }
     ; CHECK-NEXT: [[FOUND_FOO:%.+]] = sv.read_inout [[FOUND_FOO_REG]] : !hw.inout<i1>
 
-    ; CHECK:      [[RESULT_BAR_REG:%.+]] = sv.reg : !hw.inout<i32>
-    ; CHECK-NEXT: [[FOUND_BAR_REG:%.+]] = sv.reg : !hw.inout<i1>
+    ; CHECK:      [[BAR_VALUE:%.+]] = sv.wire : !hw.inout<i32>
+    ; CHECK-NEXT: [[BAR_FOUND:%.+]] = sv.wire : !hw.inout<i1>
     ; CHECK-NEXT: sv.ifdef @SYNTHESIS {
     ; CHECK-NEXT:   %z_i32 = sv.constantZ : i32
-    ; CHECK-NEXT:   sv.assign [[RESULT_BAR_REG]], %z_i32 {sv.attributes = [#sv.attribute<"This dummy assignment exists to avoid undriven lint warnings (e.g., Verilator UNDRIVEN).", emitAsComment>]} : i32
-    ; CHECK-NEXT:   sv.assign [[FOUND_BAR_REG]], %false : i1
+    ; CHECK-NEXT:   sv.assign [[BAR_VALUE]], %z_i32 {sv.attributes = [#sv.attribute<"This dummy assignment exists to avoid undriven lint warnings (e.g., Verilator UNDRIVEN).", emitAsComment>]} : i32
+    ; CHECK-NEXT:   sv.assign [[BAR_FOUND]], %false : i1
     ; CHECK-NEXT: } else {
+    ; CHECK-NEXT:   [[FOUND_REG:%.*]] = sv.reg : !hw.inout<i32>
+    ; CHECK-NEXT:   [[VALUE_REG:%.*]] = sv.reg : !hw.inout<i32>
     ; CHECK-NEXT:   sv.initial {
     ; CHECK-NEXT:     [[FORMAT_BAR:%.+]] = sv.constantStr "foo=%d"
-    ; CHECK-NEXT:     [[TMP_BAR:%.+]] = sv.system "value$plusargs"([[FORMAT_BAR]], [[RESULT_BAR_REG]]) : (!hw.string, !hw.inout<i32>) -> i32
-    ; CHECK-NEXT:     [[FOUND_BAR_VAL:%.+]] = comb.icmp bin ne [[TMP_BAR]], %c0_i32 : i32
-    ; CHECK-NEXT:     sv.bpassign [[FOUND_BAR_REG]], [[FOUND_BAR_VAL]] : i1
+    ; CHECK-NEXT:     [[PLUSARG_FOUND:%.+]] = sv.system "value$plusargs"([[FORMAT_BAR]], [[VALUE_REG]]) : (!hw.string, !hw.inout<i32>) -> i32
+    ; CHECK-NEXT:     sv.bpassign [[FOUND_REG]], [[PLUSARG_FOUND]]
     ; CHECK-NEXT:   }
+    ; CHECK-NEXT:   [[FOUND_READ:%.*]] = sv.read_inout [[FOUND_REG]] : !hw.inout<i32>
+    ; CHECK-NEXT:   [[VALUE_READ:%.*]] = sv.read_inout [[VALUE_REG]] : !hw.inout<i32>
+    ; CHECK-NEXT:   [[FOUND:%.*]] = comb.icmp ceq [[FOUND_READ]], %c1_i32 : i32
+    ; CHECK-NEXT:   sv.assign [[BAR_FOUND]], [[FOUND]] : i1
+    ; CHECK-NEXT:   sv.assign [[BAR_VALUE]], [[VALUE_READ]] : i32
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: [[FOUND_BAR_READ:%.+]] = sv.read_inout [[FOUND_BAR_REG]] : !hw.inout<i1>
-    ; CHECK-NEXT: [[RESULT_BAR:%.+]] = sv.read_inout [[RESULT_BAR_REG]] : !hw.inout<i32>
-    ; CHECK-NEXT: [[FOUND_BAR:%.+]] = comb.icmp ceq [[FOUND_BAR_READ]], %true : i1
-    ; CHECK: [[FOUND_FOO]], [[FOUND_BAR]], [[RESULT_BAR]] : i1, i1, i32
+    ; CHECK-NEXT: [[BAR_FOUND_READ:%.*]] = sv.read_inout [[BAR_FOUND]]
+    ; CHECK-NEXT: [[BAR_VALUE_READ:%.*]] = sv.read_inout [[BAR_VALUE]]
+    ; CHECK: [[FOUND_FOO]], [[BAR_FOUND_READ]], [[BAR_VALUE_READ]] : i1, i1, i32


### PR DESCRIPTION
This changes the lowering of plusargs to make sure that the X-squashing === is underneath the !SYNTHESIS block, which fixes a warning produced by synthesis tools.