### PR TITLE
[SharedResourcesProblem] [Simplex Scheduler] Simplex scheduler deals with multiple resource constraints

### DIFF
--- a/include/circt/Dialect/SSP/SSPAttributes.td
+++ b/include/circt/Dialect/SSP/SSPAttributes.td
@@ -134,8 +134,8 @@ in {
   }
 }
 
-// SharedOperatorsProblem
+// SharedResourcesProblem
 def LimitProp : ResourceTypeProperty<SSPDialect,
-  "Limit", "unsigned", "::circt::scheduling::SharedOperatorsProblem"> {
+  "Limit", "unsigned", "::circt::scheduling::SharedResourcesProblem"> {
   let mnemonic = "limit";
 }

--- a/include/circt/Dialect/SSP/Utilities.h
+++ b/include/circt/Dialect/SSP/Utilities.h
@@ -630,7 +630,7 @@ struct Default<scheduling::ChainingProblem> {
 };
 
 template <>
-struct Default<scheduling::SharedOperatorsProblem> {
+struct Default<scheduling::SharedResourcesProblem> {
   static constexpr auto operationProperties =
       Default<scheduling::Problem>::operationProperties;
   static constexpr auto operatorTypeProperties =
@@ -647,9 +647,9 @@ struct Default<scheduling::ModuloProblem> {
   static constexpr auto operationProperties =
       Default<scheduling::Problem>::operationProperties;
   static constexpr auto operatorTypeProperties =
-      Default<scheduling::SharedOperatorsProblem>::operatorTypeProperties;
+      Default<scheduling::SharedResourcesProblem>::operatorTypeProperties;
   static constexpr auto resourceTypeProperties =
-      Default<scheduling::SharedOperatorsProblem>::resourceTypeProperties;
+      Default<scheduling::SharedResourcesProblem>::resourceTypeProperties;
   static constexpr auto dependenceProperties =
       Default<scheduling::CyclicProblem>::dependenceProperties;
   static constexpr auto instanceProperties =

--- a/include/circt/Scheduling/Algorithms.h
+++ b/include/circt/Scheduling/Algorithms.h
@@ -38,11 +38,11 @@ LogicalResult scheduleSimplex(Problem &prob, Operation *lastOp);
 /// \p prob does not include \p lastOp.
 LogicalResult scheduleSimplex(CyclicProblem &prob, Operation *lastOp);
 
-/// Solve the acyclic problem with shared operators using a linear
+/// Solve the acyclic problem with shared resources using a linear
 /// programming-based heuristic. The approach tries to minimize the start time
 /// of the given \p lastOp, but optimality is not guaranteed. Fails if the
 /// dependence graph contains cycles, or \p prob does not include \p lastOp.
-LogicalResult scheduleSimplex(SharedOperatorsProblem &prob, Operation *lastOp);
+LogicalResult scheduleSimplex(SharedResourcesProblem &prob, Operation *lastOp);
 
 /// Solve the modulo scheduling problem using a linear programming-based
 /// heuristic. The approach tries to determine the smallest feasible initiation
@@ -87,11 +87,11 @@ LogicalResult scheduleLP(Problem &prob, Operation *lastOp);
 /// \p lastOp.
 LogicalResult scheduleLP(CyclicProblem &prob, Operation *lastOp);
 
-/// Solve the acyclic problem with shared operators using constraint programming
+/// Solve the acyclic problem with shared resources using constraint programming
 /// and an external SAT solver. The objective is to minimize the start time of
 /// the given \p lastOp. Fails if the dependence graph contains cycles, or \p
 /// prob does not include \p lastOp.
-LogicalResult scheduleCPSAT(SharedOperatorsProblem &prob, Operation *lastOp);
+LogicalResult scheduleCPSAT(SharedResourcesProblem &prob, Operation *lastOp);
 
 } // namespace scheduling
 } // namespace circt

--- a/include/circt/Scheduling/Problems.h
+++ b/include/circt/Scheduling/Problems.h
@@ -480,16 +480,16 @@ public:
 /// accept new operands (coming from a distinct operation) in each time step.
 ///
 /// A solution to this problem is feasible iff the number of operations that use
-/// a certain limited operator type, and start in the same time step, does not
-/// exceed the operator type's limit. These constraints do not apply to operator
+/// a certain limited resource type, and start in the same time step, does not
+/// exceed the resource type's limit. These constraints do not apply to resource
 /// types without a limit (not set, or 0).
-class SharedOperatorsProblem : public virtual Problem {
+class SharedResourcesProblem : public virtual Problem {
 public:
-  static constexpr auto name = "SharedOperatorsProblem";
+  static constexpr auto name = "SharedResourcesProblem";
   using Problem::Problem;
 
 protected:
-  SharedOperatorsProblem() = default;
+  SharedResourcesProblem() = default;
 
 private:
   ResourceTypeProperty<unsigned> limit;
@@ -526,7 +526,7 @@ public:
 ///      and start in the same congruence class (= start time *mod* II), does
 ///      not exceed the operator type's limit.
 class ModuloProblem : public virtual CyclicProblem,
-                      public virtual SharedOperatorsProblem {
+                      public virtual SharedResourcesProblem {
 public:
   static constexpr auto name = "ModuloProblem";
   using CyclicProblem::CyclicProblem;

--- a/lib/Dialect/SSP/Transforms/Print.cpp
+++ b/lib/Dialect/SSP/Transforms/Print.cpp
@@ -55,8 +55,8 @@ void PrintPass::runOnOperation() {
       printInstance<CyclicProblem>(instOp, os);
     else if (probName == "ChainingProblem")
       printInstance<ChainingProblem>(instOp, os);
-    else if (probName == "SharedOperatorsProblem")
-      printInstance<SharedOperatorsProblem>(instOp, os);
+    else if (probName == "SharedResourcesProblem")
+      printInstance<SharedResourcesProblem>(instOp, os);
     else if (probName == "ModuloProblem")
       printInstance<ModuloProblem>(instOp, os);
     else if (probName == "ChainingCyclicProblem")

--- a/lib/Dialect/SSP/Transforms/Roundtrip.cpp
+++ b/lib/Dialect/SSP/Transforms/Roundtrip.cpp
@@ -50,8 +50,8 @@ static InstanceOp roundtrip(InstanceOp instOp, bool check, bool verify,
     return roundtripAs<Problem>(instOp, check, verify, builder);
   if (problemName == "CyclicProblem")
     return roundtripAs<CyclicProblem>(instOp, check, verify, builder);
-  if (problemName == "SharedOperatorsProblem")
-    return roundtripAs<SharedOperatorsProblem>(instOp, check, verify, builder);
+  if (problemName == "SharedResourcesProblem")
+    return roundtripAs<SharedResourcesProblem>(instOp, check, verify, builder);
   if (problemName == "ModuloProblem")
     return roundtripAs<ModuloProblem>(instOp, check, verify, builder);
   if (problemName == "ChainingProblem")

--- a/lib/Dialect/SSP/Transforms/Schedule.cpp
+++ b/lib/Dialect/SSP/Transforms/Schedule.cpp
@@ -138,8 +138,8 @@ static InstanceOp scheduleWithSimplex(InstanceOp instOp, StringRef options,
     return scheduleProblemTWithSimplex<Problem>(instOp, lastOp, builder);
   if (problemName == "CyclicProblem")
     return scheduleProblemTWithSimplex<CyclicProblem>(instOp, lastOp, builder);
-  if (problemName == "SharedOperatorsProblem")
-    return scheduleProblemTWithSimplex<SharedOperatorsProblem>(instOp, lastOp,
+  if (problemName == "SharedResourcesProblem")
+    return scheduleProblemTWithSimplex<SharedResourcesProblem>(instOp, lastOp,
                                                                builder);
   if (problemName == "ModuloProblem")
     return scheduleProblemTWithSimplex<ModuloProblem>(instOp, lastOp, builder);
@@ -219,13 +219,13 @@ static InstanceOp scheduleWithCPSAT(InstanceOp instOp, StringRef options,
   }
 
   auto problemName = instOp.getProblemName();
-  if (problemName != "SharedOperatorsProblem") {
+  if (problemName != "SharedResourcesProblem") {
     llvm::errs() << "ssp-schedule: Unsupported problem '" << problemName
                  << "' for CPSAT scheduler\n";
     return {};
   }
 
-  auto prob = loadProblem<SharedOperatorsProblem>(instOp);
+  auto prob = loadProblem<SharedResourcesProblem>(instOp);
   if (failed(prob.check()) || failed(scheduling::scheduleCPSAT(prob, lastOp)) ||
       failed(prob.verify()))
     return {};

--- a/lib/Scheduling/CPSATSchedulers.cpp
+++ b/lib/Scheduling/CPSATSchedulers.cpp
@@ -38,7 +38,7 @@ using llvm::format;
 /// https://github.com/google/or-tools/blob/stable/examples/python/rcpsp_sat.py
 /// but a gentler introduction (though with differing formulation) is
 /// https://python-mip.readthedocs.io/en/latest/examples.html
-LogicalResult scheduling::scheduleCPSAT(SharedOperatorsProblem &prob,
+LogicalResult scheduling::scheduleCPSAT(SharedResourcesProblem &prob,
                                         Operation *lastOp) {
   Operation *containingOp = prob.getContainingOp();
   if (!prob.hasOperation(lastOp))
@@ -123,7 +123,7 @@ LogicalResult scheduling::scheduleCPSAT(SharedOperatorsProblem &prob,
           (Twine("demand_") + Twine(i) + Twine("_") +
            Twine(resource.getAttr().strref()))
               .str());
-      // Conventional formulation for SharedOperatorsProblem;
+      // Conventional formulation for SharedResourcesProblem;
       // interval during which the resource is occupied has size 1.
       IntervalVar start =
           cpModel.NewFixedSizeIntervalVar(taskInterval.StartExpr(), 1);

--- a/lib/Scheduling/Problems.cpp
+++ b/lib/Scheduling/Problems.cpp
@@ -330,18 +330,18 @@ LogicalResult ChainingProblem::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// SharedOperatorsProblem
+// SharedResourcesProblem
 //===----------------------------------------------------------------------===//
 
 Problem::PropertyStringVector
-SharedOperatorsProblem::getProperties(ResourceType rsrc) {
+SharedResourcesProblem::getProperties(ResourceType rsrc) {
   auto psv = Problem::getProperties(rsrc);
   if (auto limit = getLimit(rsrc))
     psv.emplace_back("limit", std::to_string(*limit));
   return psv;
 }
 
-LogicalResult SharedOperatorsProblem::checkLatency(Operation *op) {
+LogicalResult SharedResourcesProblem::checkLatency(Operation *op) {
   if (failed(Problem::checkLatency(op)))
     return failure();
 
@@ -364,7 +364,7 @@ LogicalResult SharedOperatorsProblem::checkLatency(Operation *op) {
   return success();
 }
 
-LogicalResult SharedOperatorsProblem::verifyUtilization(ResourceType rsrc) {
+LogicalResult SharedResourcesProblem::verifyUtilization(ResourceType rsrc) {
   auto limit = getLimit(rsrc);
   if (!limit)
     return success();
@@ -393,7 +393,7 @@ LogicalResult SharedOperatorsProblem::verifyUtilization(ResourceType rsrc) {
   return success();
 }
 
-LogicalResult SharedOperatorsProblem::verify() {
+LogicalResult SharedResourcesProblem::verify() {
   if (failed(Problem::verify()))
     return failure();
 
@@ -442,7 +442,7 @@ LogicalResult ModuloProblem::verify() {
   if (failed(CyclicProblem::verify()))
     return failure();
 
-  // Don't call SharedOperatorsProblem::verify() here to prevent redundant
+  // Don't call SharedResourcesProblem::verify() here to prevent redundant
   // verification of the base problem.
   for (auto rsrc : getResourceTypes())
     if (failed(verifyUtilization(rsrc)))

--- a/lib/Scheduling/SimplexSchedulers.cpp
+++ b/lib/Scheduling/SimplexSchedulers.cpp
@@ -218,17 +218,17 @@ public:
   LogicalResult schedule() override;
 };
 
-// This class solves acyclic, resource-constrained `SharedOperatorsProblem` with
+// This class solves acyclic, resource-constrained `SharedResourcesProblem` with
 // a simplified version of the iterative heuristic presented in [2].
-class SharedOperatorsSimplexScheduler : public SimplexSchedulerBase {
+class SharedResourcesSimplexScheduler : public SimplexSchedulerBase {
 private:
-  SharedOperatorsProblem &prob;
+  SharedResourcesProblem &prob;
 
 protected:
   Problem &getProblem() override { return prob; }
 
 public:
-  SharedOperatorsSimplexScheduler(SharedOperatorsProblem &prob,
+  SharedResourcesSimplexScheduler(SharedResourcesProblem &prob,
                                   Operation *lastOp)
       : SimplexSchedulerBase(lastOp), prob(prob) {}
   LogicalResult schedule() override;
@@ -870,10 +870,10 @@ LogicalResult CyclicSimplexScheduler::schedule() {
 }
 
 //===----------------------------------------------------------------------===//
-// SharedOperatorsSimplexScheduler
+// SharedResourcesSimplexScheduler
 //===----------------------------------------------------------------------===//
 
-static bool isLimited(Operation *op, SharedOperatorsProblem &prob) {
+static bool isLimited(Operation *op, SharedResourcesProblem &prob) {
   auto maybeRsrcs = prob.getLinkedResourceTypes(op);
   if (!maybeRsrcs)
     return false;
@@ -882,7 +882,7 @@ static bool isLimited(Operation *op, SharedOperatorsProblem &prob) {
   });
 }
 
-LogicalResult SharedOperatorsSimplexScheduler::schedule() {
+LogicalResult SharedResourcesSimplexScheduler::schedule() {
   if (failed(checkLastOp()))
     return failure();
 
@@ -1384,9 +1384,9 @@ LogicalResult scheduling::scheduleSimplex(CyclicProblem &prob,
   return simplex.schedule();
 }
 
-LogicalResult scheduling::scheduleSimplex(SharedOperatorsProblem &prob,
+LogicalResult scheduling::scheduleSimplex(SharedResourcesProblem &prob,
                                           Operation *lastOp) {
-  SharedOperatorsSimplexScheduler simplex(prob, lastOp);
+  SharedResourcesSimplexScheduler simplex(prob, lastOp);
   return simplex.schedule();
 }
 

--- a/test/Dialect/SSP/roundtrip.mlir
+++ b/test/Dialect/SSP/roundtrip.mlir
@@ -164,7 +164,7 @@ ssp.instance @mco_outgoing_delays of "ChainingProblem" {
   }
 }
 
-// CHECK: ssp.instance @multiple_oprs of "SharedOperatorsProblem" {
+// CHECK: ssp.instance @multiple_oprs of "SharedResourcesProblem" {
 // CHECK:   library {
 // CHECK:     operator_type @slowAdd [latency<3>]
 // CHECK:     operator_type @fastAdd [latency<1>]
@@ -185,7 +185,7 @@ ssp.instance @mco_outgoing_delays of "ChainingProblem" {
 // CHECK:     operation<@_1>() [t<10>]
 // CHECK:   }
 // CHECK: }
-ssp.instance @multiple_oprs of "SharedOperatorsProblem" {
+ssp.instance @multiple_oprs of "SharedResourcesProblem" {
   library {
     operator_type @slowAdd [latency<3>]
     operator_type @fastAdd [latency<1>]

--- a/test/Scheduling/shared-operators-problems.mlir
+++ b/test/Scheduling/shared-operators-problems.mlir
@@ -69,3 +69,26 @@ ssp.instance @multiple of "SharedOperatorsProblem" {
     operation<@_1> @last(%5) [t<11>]
   }
 }
+
+// CHECK-LABEL: if_else
+ssp.instance @if_else_exclusive of "SharedOperatorsProblem" {
+  library {
+    operator_type @ThenOperator [latency<2>]
+    operator_type @ElseOperator [latency<3>]
+    operator_type @_1 [latency<2>]
+  }
+  resource {
+    resource_type @adder_then_br [limit<1>]
+    resource_type @mem_port_then_br [limit<1>]
+    resource_type @adder_else_br [limit<1>]
+    resource_type @mem_port_else_br [limit<1>]
+  }
+  graph {
+    %0 = operation<@ThenOperator> @compute_then_br() uses[@adder_then_br, @mem_port_then_br] [t<0>]
+    %1 = operation<@ElseOperator> @compute_else_br() uses[@adder_else_br, @mem_port_else_br] [t<0>]
+    %2 = operation<@_1>(%0, %1) [t<4>]
+    // SIMPLEX: @last(%{{.*}}) [t<5>]
+    // CPSAT: @last(%{{.*}}) [t<5>]
+    operation<@_1> @last(%2) [t<7>]
+  }
+}

--- a/test/Scheduling/shared-resources-problem-errors.mlir
+++ b/test/Scheduling/shared-resources-problem-errors.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt %s -ssp-roundtrip=verify -verify-diagnostics -split-input-file
 
 // expected-error@+1 {{Operator type 'limited' using limited resource 'limited_rsrc' has zero latency.}}
-ssp.instance @limited_but_zero_latency of "SharedOperatorsProblem" {
+ssp.instance @limited_but_zero_latency of "SharedResourcesProblem" {
   library {
     operator_type @limited [latency<0>]
   }
@@ -16,7 +16,7 @@ ssp.instance @limited_but_zero_latency of "SharedOperatorsProblem" {
 // -----
 
 // expected-error@+1 {{Resource type 'limited_rsrc' is oversubscribed}}
-ssp.instance @oversubscribed of "SharedOperatorsProblem" {
+ssp.instance @oversubscribed of "SharedResourcesProblem" {
   library {
     operator_type @limited [latency<1>]
   }

--- a/test/Scheduling/shared-resources-problems.mlir
+++ b/test/Scheduling/shared-resources-problems.mlir
@@ -3,7 +3,7 @@
 // RUN: %if or-tools %{ circt-opt %s -ssp-schedule=scheduler=cpsat | FileCheck %s -check-prefixes=CHECK,CPSAT %} 
 
 // CHECK-LABEL: full_load
-ssp.instance @full_load of "SharedOperatorsProblem" {
+ssp.instance @full_load of "SharedResourcesProblem" {
   library {
     operator_type @L1_3 [latency<3>]
     operator_type @_1 [latency<1>]
@@ -25,7 +25,7 @@ ssp.instance @full_load of "SharedOperatorsProblem" {
 }
 
 // CHECK-LABEL: partial_load
-ssp.instance @partial_load of "SharedOperatorsProblem" {
+ssp.instance @partial_load of "SharedResourcesProblem" {
   library {
     operator_type @L3_3 [latency<3>]
     operator_type @_1 [latency<1>]
@@ -47,7 +47,7 @@ ssp.instance @partial_load of "SharedOperatorsProblem" {
 }
 
 // CHECK-LABEL: multiple
-ssp.instance @multiple of "SharedOperatorsProblem" {
+ssp.instance @multiple of "SharedResourcesProblem" {
   library {
     operator_type @L3_2 [latency<3>]
     operator_type @L1_1 [latency<1>]
@@ -71,7 +71,7 @@ ssp.instance @multiple of "SharedOperatorsProblem" {
 }
 
 // CHECK-LABEL: if_else
-ssp.instance @if_else_exclusive of "SharedOperatorsProblem" {
+ssp.instance @if_else_exclusive of "SharedResourcesProblem" {
   library {
     operator_type @ThenOperator [latency<2>]
     operator_type @ElseOperator [latency<3>]


### PR DESCRIPTION
This patch:

1. Renames SharedOperators to SharedResources to reflect the new changes in https://github.com/llvm/circt/pull/8444;
2. It supports the simplex scheduler to deal with multiple resource constraints.