### PR TITLE
[ESI][Runtime] Improvements / fixes to utilities/build

### DIFF
--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -136,6 +136,7 @@ set(ESICppRuntimeHeaders
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/Common.h
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/Context.h
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/Design.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/Engines.h
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/Logging.h
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/Manifest.h
   ${CMAKE_CURRENT_SOURCE_DIR}/cpp/include/esi/Types.h

--- a/lib/Dialect/ESI/runtime/cosim_dpi_server/esi-cosim.py
+++ b/lib/Dialect/ESI/runtime/cosim_dpi_server/esi-cosim.py
@@ -115,6 +115,7 @@ class Simulator:
     with (self.run_dir / "compile_stdout.log").open("w") as stdout, (
         self.run_dir / "compile_stderr.log").open("w") as stderr:
       for cmd in cmds:
+        stderr.write(" ".join(cmd) + "\n")
         cp = subprocess.run(cmd,
                             env=Simulator.get_env(),
                             capture_output=True,
@@ -157,8 +158,9 @@ class Simulator:
       simEnv = Simulator.get_env()
       if self.debug:
         simEnv["COSIM_DEBUG_FILE"] = "cosim_debug.log"
-        # Slow the simulation down to one tick per millisecond.
-        simEnv["DEBUG_PERIOD"] = "1"
+        if "DEBUG_PERIOD" not in simEnv:
+          # Slow the simulation down to one tick per millisecond.
+          simEnv["DEBUG_PERIOD"] = "1"
       simProc = subprocess.Popen(self.run_command(gui),
                                  stdout=simStdout,
                                  stderr=simStderr,
@@ -232,6 +234,8 @@ class Verilator(Simulator):
         "--top-module",
         self.sources.top,
         "-DSIMULATION",
+        "-Wno-TIMESCALEMOD",
+        "-Wno-fatal",
         "-sv",
         "--build",
         "--exe",

--- a/lib/Dialect/ESI/runtime/cpp/cmake/esiaccelConfig.cmake
+++ b/lib/Dialect/ESI/runtime/cpp/cmake/esiaccelConfig.cmake
@@ -10,6 +10,6 @@ if(WIN32)
   )
 else()
   set_target_properties(esiaccel::ESICppRuntime PROPERTIES
-    IMPORTED_LOCATION "${CMAKE_CURRENT_LIST_DIR}/../lib/ESICppRuntime.so"
+    IMPORTED_LOCATION "${CMAKE_CURRENT_LIST_DIR}/../python/esiaccel/libESICppRuntime.so"
   )
 endif()


### PR DESCRIPTION
- Updates the IMPORTED_LOCATION for the ESICppRuntime shared library.
- esi-cosim.py:
  - Adds logging of compile commands and introduces warning suppression flags in compile commands.
  - Slow down the simulation to one tick per millisecond if the DEBUG_PERIOD environment variable is not set if debug mode is used.
- Adds the inclusion of the Engines header to the list of runtime headers.
