### PR TITLE
[Support] Add relative path caching to InstancePathCache

### DIFF
--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -355,7 +355,7 @@ struct InstancePathCache {
   // Return all absolute paths from the top-level node to the given module.
   ArrayRef<InstancePath> getAbsolutePaths(ModuleOpInterface op);
 
-  // Return all relative paths from the to the given node.
+  // Return all relative paths from the given node to the given module.
   ArrayRef<InstancePath> getRelativePaths(ModuleOpInterface op,
                                           InstanceGraphNode *node);
 

--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -352,12 +352,12 @@ struct InstancePathCache {
   explicit InstancePathCache(InstanceGraph &instanceGraph)
       : instanceGraph(instanceGraph) {}
 
-  // Return all absolute paths from the top-level module to the given module.
+  // Return all absolute paths from the top-level node to the given module.
   ArrayRef<InstancePath> getAbsolutePaths(ModuleOpInterface op);
 
-  // Return all relative paths from the given module to the given top node.
+  // Return all relative paths from the to the given node.
   ArrayRef<InstancePath> getRelativePaths(ModuleOpInterface op,
-                                          InstanceGraphNode *top);
+                                          InstanceGraphNode *node);
 
   /// Replace an InstanceOp. This is required to keep the cache updated.
   void replaceInstance(InstanceOpInterface oldOp, InstanceOpInterface newOp);

--- a/lib/Support/InstanceGraph.cpp
+++ b/lib/Support/InstanceGraph.cpp
@@ -231,10 +231,10 @@ InstancePathCache::getAbsolutePaths(ModuleOpInterface op) {
 
 ArrayRef<InstancePath>
 InstancePathCache::getRelativePaths(ModuleOpInterface op,
-                                    InstanceGraphNode *top) {
-  if (top == instanceGraph.getTopLevelNode())
+                                    InstanceGraphNode *node) {
+  if (node == instanceGraph.getTopLevelNode())
     return getAbsolutePaths(op);
-  return getPaths(op, top, relativePathsCache[top]);
+  return getPaths(op, node, relativePathsCache[node]);
 }
 
 // NOLINTBEGIN(misc-no-recursion)

--- a/unittests/Dialect/HW/InstancePathTest.cpp
+++ b/unittests/Dialect/HW/InstancePathTest.cpp
@@ -49,10 +49,6 @@ TEST(InstancePathTest, RelativePath) {
   auto cat = cast<HWModuleOp>(*circuit.getBody()->rbegin());
   auto alligator = cast<HWModuleOp>(*std::next(circuit.getBody()->begin()));
   auto catToAlligatorPaths = pathCache.getRelativePaths(cat, graph[alligator]);
-  for (auto p : catToAlligatorPaths) {
-    p.print(llvm::errs());
-    llvm::errs() << "\n";
-  }
 
   ASSERT_EQ(1ull, catToAlligatorPaths.size());
 

--- a/unittests/Dialect/HW/InstancePathTest.cpp
+++ b/unittests/Dialect/HW/InstancePathTest.cpp
@@ -40,6 +40,27 @@ TEST(InstancePathTest, Enumerate) {
   ASSERT_EQ(1ull, topPaths.size());
 }
 
+TEST(InstancePathTest, RelativePath) {
+  MLIRContext context;
+  ModuleOp circuit = fixtures::createModule(&context);
+  hw::InstanceGraph graph(circuit);
+  igraph::InstancePathCache pathCache(graph);
+
+  auto cat = cast<HWModuleOp>(*circuit.getBody()->rbegin());
+  auto alligator = cast<HWModuleOp>(*std::next(circuit.getBody()->begin()));
+  auto catToAlligatorPaths = pathCache.getRelativePaths(cat, graph[alligator]);
+  for (auto p : catToAlligatorPaths) {
+    p.print(llvm::errs());
+    llvm::errs() << "\n";
+  }
+
+  ASSERT_EQ(1ull, catToAlligatorPaths.size());
+
+  ASSERT_EQ(2ull, catToAlligatorPaths[0].size());
+  EXPECT_EQ("bear", catToAlligatorPaths[0][0].getInstanceName());
+  EXPECT_EQ("cat", catToAlligatorPaths[0][1].getInstanceName());
+}
+
 TEST(InstancePathTest, AppendPrependInstance) {
   MLIRContext context;
   ModuleOp circuit = fixtures::createModule(&context);


### PR DESCRIPTION
This commit adds infrastructure for caching relative instance paths between modules in the InstanceGraph. It adds a relativePathsCache field to InstancePathCache to store paths between arbitrary module pairs.