### PR TITLE
[HW][CAPI] Add a function for getting port info from module

### DIFF
--- a/include/circt-c/Dialect/HW.h
+++ b/include/circt-c/Dialect/HW.h
@@ -124,6 +124,11 @@ MLIR_CAPI_EXPORTED MlirType hwModuleTypeGetOutputType(MlirType type,
 /// Get an HW module type's output name at a specific index.
 MLIR_CAPI_EXPORTED MlirStringRef hwModuleTypeGetOutputName(MlirType type,
                                                            intptr_t index);
+
+/// Get an HW module type's port info at a specific index.
+MLIR_CAPI_EXPORTED void hwModuleTypeGetPort(MlirType type, intptr_t index,
+                                            HWModulePort *ret);
+
 /// Creates an HW struct type in the context associated with the elements.
 MLIR_CAPI_EXPORTED MlirType hwStructTypeGet(MlirContext ctx,
                                             intptr_t numElements,

--- a/lib/CAPI/Dialect/HW.cpp
+++ b/lib/CAPI/Dialect/HW.cpp
@@ -129,6 +129,29 @@ MlirStringRef hwModuleTypeGetOutputName(MlirType type, intptr_t index) {
   return wrap(cast<ModuleType>(unwrap(type)).getOutputName(index));
 }
 
+void hwModuleTypeGetPort(MlirType type, intptr_t index, HWModulePort *ret) {
+  auto port = cast<ModuleType>(unwrap(type)).getPorts()[index];
+
+  HWModulePortDirection dir;
+  switch (port.dir) {
+  case ModulePort::Direction::Input:
+    dir = HWModulePortDirection::Input;
+    break;
+  case ModulePort::Direction::Output:
+    dir = HWModulePortDirection::Output;
+    break;
+  case ModulePort::Direction::InOut:
+    dir = HWModulePortDirection::InOut;
+    break;
+  default:
+    llvm_unreachable("unknown ModulePort::Direction");
+  }
+
+  ret->name = wrap(static_cast<Attribute>(port.name));
+  ret->type = wrap(port.type);
+  ret->dir = dir;
+}
+
 bool hwTypeIsAStructType(MlirType type) {
   return isa<StructType>(unwrap(type));
 }


### PR DESCRIPTION
This PR adds a new HW C-API function `hwModuleTypeGetPort` for getting the port info at a specific index from module.