### PR TITLE
[Transforms][HierarchicalRunner] Run passes only on HWModuleOp

### DIFF
--- a/lib/Transforms/HierarchicalRunner.cpp
+++ b/lib/Transforms/HierarchicalRunner.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Dialect/HW/HWOps.h"
 #include "circt/Support/InstanceGraph.h"
 #include "circt/Transforms/Passes.h"
 #include "mlir/IR/Operation.h"
@@ -88,7 +89,7 @@ void HierarchicalRunnerPass::runOnOperation() {
     auto *node = worklist.pop_back_val();
     assert(node && "node should not be null");
     auto op = node->getModule();
-    if (!op || !visited.insert(op))
+    if (!isa_and_nonnull<hw::HWModuleOp>(op) || !visited.insert(op))
       continue;
 
     // Ensure an analysis manager has been constructed for each of the nodes.

--- a/test/Transforms/hierarchical_runner.mlir
+++ b/test/Transforms/hierarchical_runner.mlir
@@ -11,10 +11,14 @@ hw.module @bound(out out: i8) {
     hw.output %add : i8
 }
 
+// CHECK-LABEL: hw.module.extern @extern
+hw.module.extern @extern()
+
 // CHECK-LABEL: hw.module @top
 hw.module @top(out out: i8) {
     %c1_i8 = hw.constant 1 : i8
     %add = comb.add %c1_i8, %c1_i8 : i8
+    hw.instance "extern" @extern() -> ()
     %0 = hw.instance "child" @child() -> (out: i8)
     // CHECK: hw.output %c2_i8
     hw.output %add : i8


### PR DESCRIPTION
This avoids crash due to passes being scheduled on HWMouleExtern op. 