### PR TITLE
[firtool] Add an optoin to dump MLIR erros to a json file

### DIFF
--- a/test/firtool/error-dumper.fir
+++ b/test/firtool/error-dumper.fir
@@ -1,0 +1,17 @@
+; `verify-diagnostics` does not work with external locators so use `not`
+; RUN: not firtool %s  --output-error-diagnostics=- --split-input-file -fuse-info-locators | FileCheck %s
+FIRRTL
+; CHECK: [{"location":[{"column":1,"file":"{{.+}}","line":{{[0-9]+}}}],"message":"expected version after 'FIRRTL'"}]
+circuit test :
+  module test :
+    skip
+
+; // -----
+; Expand when
+; CHECK:      [{"location":[{"column":1,"file":"test.scala","line":1},{"column":12,"file":"{{.+}}","line":{{[0-9]+}}}],"message":"port \"a\" not fully initialized in \"test\""},{
+; CHECK-SAME:   "location":[{"column":12,"file":"{{.+}}","line":{{[0-9]+}}}],"message":"port \"b\" not fully initialized in \"test\""}]
+FIRRTL version 5.0.0
+circuit test :
+  public module test :
+    output a : UInt<1> @[test.scala 1:1]
+    output b : UInt<1>


### PR DESCRIPTION
This patch adds a new command-line option to firtool that allows outputting error diagnostics in JSON format. The implementation includes a new `-output-error-diagnostics` option to specify the output file and an `ErrorDiagnosticDumper` class that captures MLIR diagnostics and converts them to JSON format.