### PR TITLE
[circt-lec] Implement emit-smtlib functionality for circt-lec

### DIFF
--- a/include/circt/Tools/circt-lec/Passes.h
+++ b/include/circt/Tools/circt-lec/Passes.h
@@ -18,7 +18,7 @@
 namespace circt {
 
 namespace lec {
-enum InsertAdditionalModeEnum {
+enum class InsertAdditionalModeEnum {
   /// Don't insert any LLVM code.
   None,
 

--- a/include/circt/Tools/circt-lec/Passes.h
+++ b/include/circt/Tools/circt-lec/Passes.h
@@ -17,6 +17,19 @@
 
 namespace circt {
 
+namespace lec {
+enum InsertAdditionalModeEnum {
+  /// Don't insert any LLVM code.
+  None,
+
+  /// Insert LLVM code to report the LEC result from an SMT solver.
+  Reporting,
+
+  /// Insert a main function for AOT compilation.
+  Main,
+};
+}
+
 /// Generate the code for registering passes.
 #define GEN_PASS_DECL_CONSTRUCTLEC
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Tools/circt-lec/Passes.td
+++ b/include/circt/Tools/circt-lec/Passes.td
@@ -41,6 +41,9 @@ def ConstructLEC : Pass<"construct-lec", "::mlir::ModuleOp"> {
     Option<"insertMainFunc", "insert-main", "bool",
            /*default=*/"false",
            "Whether a main function should be inserted for AOT compilation.">,
+    Option<"insertReporting", "insert-report", "bool",
+           /*default=*/"true",
+           "Whether LLVM code should be inserted to report the result.">,
   ];
 
   let dependentDialects = [

--- a/include/circt/Tools/circt-lec/Passes.td
+++ b/include/circt/Tools/circt-lec/Passes.td
@@ -13,6 +13,7 @@
 #ifndef CIRCT_TOOLS_CIRCT_LEC_PASSES_TD
 #define CIRCT_TOOLS_CIRCT_LEC_PASSES_TD
 
+include "mlir/IR/EnumAttr.td"
 include "mlir/Pass/PassBase.td"
 include "mlir/Rewrite/PassUtil.td"
 
@@ -38,12 +39,17 @@ def ConstructLEC : Pass<"construct-lec", "::mlir::ModuleOp"> {
     Option<"secondModule", "second-module", "std::string",
            /*default=*/"",
            "Name of the second of the two modules to compare.">,
-    Option<"insertMainFunc", "insert-main", "bool",
-           /*default=*/"false",
-           "Whether a main function should be inserted for AOT compilation.">,
-    Option<"insertReporting", "insert-report", "bool",
-           /*default=*/"true",
-           "Whether LLVM code should be inserted to report the result.">,
+    Option<"insertMode", "insert-mode", "lec::InsertAdditionalModeEnum",
+           /*default=*/"lec::InsertAdditionalModeEnum::Reporting",           
+            "Select what additional code to add.",
+            [{::llvm::cl::values(
+             clEnumValN(lec::InsertAdditionalModeEnum::None,
+             "none", "Do not insert any additional code."),
+             clEnumValN(lec::InsertAdditionalModeEnum::Reporting,
+             "reporting", "Insert LLVM code to report LEC result."),
+             clEnumValN(lec::InsertAdditionalModeEnum::Main,
+             "main", "Insert main function for AOT compilation and reporting.")
+           )}]>,
   ];
 
   let dependentDialects = [

--- a/include/circt/Tools/circt-lec/Passes.td
+++ b/include/circt/Tools/circt-lec/Passes.td
@@ -13,7 +13,6 @@
 #ifndef CIRCT_TOOLS_CIRCT_LEC_PASSES_TD
 #define CIRCT_TOOLS_CIRCT_LEC_PASSES_TD
 
-include "mlir/IR/EnumAttr.td"
 include "mlir/Pass/PassBase.td"
 include "mlir/Rewrite/PassUtil.td"
 

--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -93,10 +93,12 @@ struct LogicEquivalenceCheckingOpConversion
       return success();
     }
 
+    auto unusedResult = op.use_empty();
+
     // Solver will only return a result when it is used to check the returned
     // value.
     smt::SolverOp solver;
-    if (op.use_empty())
+    if (unusedResult)
       solver = rewriter.create<smt::SolverOp>(loc, TypeRange{}, ValueRange{});
     else
       solver = rewriter.create<smt::SolverOp>(loc, rewriter.getI1Type(),
@@ -157,10 +159,11 @@ struct LogicEquivalenceCheckingOpConversion
     rewriter.create<smt::AssertOp>(loc, toAssert);
 
     // Fifth, check for satisfiablility and report the result back.
-    // If no operation uses the result of this solver, we leave our check operations empty.
-    // If the result is used, we create a check operation with the result type of
-    // the operation and yield the result of the check operation.
-    if (op.use_empty()) {
+    // If no operation uses the result of this solver, we leave our check
+    // operations empty. If the result is used, we create a check operation with
+    // the result type of the operation and yield the result of the check
+    // operation.
+    if (unusedResult) {
       auto checkOp = rewriter.create<smt::CheckOp>(loc, TypeRange{});
       rewriter.createBlock(&checkOp.getSatRegion());
       rewriter.create<smt::YieldOp>(loc);

--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -157,8 +157,8 @@ struct LogicEquivalenceCheckingOpConversion
     rewriter.create<smt::AssertOp>(loc, toAssert);
 
     // Fifth, check for satisfiablility and report the result back.
-    // For unused results, we create a check operation with empty regions.
-    // For used results, we create a check operation with the result type of
+    // If no operation uses the result of this solver, we leave our check operations empty.
+    // If the result is used, we create a check operation with the result type of
     // the operation and yield the result of the check operation.
     if (op.use_empty()) {
       auto checkOp = rewriter.create<smt::CheckOp>(loc, TypeRange{});

--- a/lib/Tools/circt-lec/ConstructLEC.cpp
+++ b/lib/Tools/circt-lec/ConstructLEC.cpp
@@ -70,8 +70,10 @@ void ConstructLECPass::runOnOperation() {
   OpBuilder builder = OpBuilder::atBlockEnd(getOperation().getBody());
   Location loc = getOperation()->getLoc();
 
-  assert(!(insertMainFunc && (!insertReporting)) &&
-         "cannot insert main without reporting");
+  if (insertMainFunc && (!insertReporting)) {
+    emitError(loc, "cannot insert main function without reporting");
+    return signalPassFailure();
+  }
 
   // Lookup the modules.
   auto moduleA = lookupModule(firstModule);

--- a/lib/Tools/circt-lec/ConstructLEC.cpp
+++ b/lib/Tools/circt-lec/ConstructLEC.cpp
@@ -156,7 +156,7 @@ void ConstructLECPass::runOnOperation() {
 
   builder.createBlock(&entryFunc.getBody());
 
-  // Create the miter circuit that return equivalence result.
+  // Create the miter circuit that returns equivalence result.
   auto areEquivalent = constructMiter(builder, loc, moduleA, moduleB);
 
   // TODO: we should find a more elegant way of reporting the result than

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -102,7 +102,6 @@ func.func @test_lec(%arg0: !smt.bv<1>) -> (i1, i1, i1) {
 
   // CHECK: return [[EQ]], [[EQ2]], %true
   return %1, %2, %3 : i1, i1, i1
-  // return %3, %3, %3 : i1, i1, i1
 }
 
 // CHECK-LABEL:  func.func @test_bmc() -> i1 {

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -83,8 +83,26 @@ func.func @test_lec(%arg0: !smt.bv<1>) -> (i1, i1, i1) {
     verif.yield
   }
 
+  %4 = verif.lec first {
+  ^bb0(%arg1: i32):
+    verif.yield %arg1 : i32
+  } second {
+  ^bb0(%arg2: i32):
+    verif.yield %arg2 : i32
+  }
+  // CHECK: smt.solver() : () -> () {
+  // CHECK:   [[V11:%.+]] = smt.declare_fun : !smt.bv<32>
+  // CHECK:   [[EQ3:%.+]] = smt.distinct [[V11]], [[V11]] : !smt.bv<32>
+  // CHECK:   smt.assert [[EQ3]]
+  // CHECK:   smt.check sat {
+  // CHECK:   } unknown {
+  // CHECK:   } unsat {
+  // CHECK:   }
+  // CHECK: }
+
   // CHECK: return [[EQ]], [[EQ2]], %true
   return %1, %2, %3 : i1, i1, i1
+  // return %3, %3, %3 : i1, i1, i1
 }
 
 // CHECK-LABEL:  func.func @test_bmc() -> i1 {

--- a/test/Tools/circt-lec/construct-lec.mlir
+++ b/test/Tools/circt-lec/construct-lec.mlir
@@ -60,15 +60,6 @@ hw.module @modB1() {
 
 // RUN: circt-opt --construct-lec="first-module=modA0 second-module=modB0 insert-mode=none" %s | FileCheck %s --check-prefix=CHECK2
 
-// CHECK2:   [[V0:%.+]] = verif.lec first {
-// CHECK2:   ^bb0([[ARG0:%.+]]: i32, [[ARG1:%.+]]: i32):
-// CHECK2:     [[V1:%.+]] = comb.add [[ARG0]], [[ARG1]]
-// CHECK2:     verif.yield [[V1]]
-// CHECK2:   } second {
-// CHECK2:   ^bb0([[ARG0:%.+]]: i32, [[ARG1:%.+]]: i32):
-// CHECK2:     [[V2:%.+]] = comb.mul [[ARG0]], [[ARG1]]
-// CHECK2:     verif.yield [[V2]]
-// CHECK2:   }
-
-// CHECK2-NOT: llvm.mlir.global private constant @"c1 == c2\0A"("c1 == c2\0A\00") {addr_space = 0 : i32}
-// CHECK2-NOT: llvm.mlir.global private constant @"c1 != c2\0A"("c1 != c2\0A\00") {addr_space = 0 : i32}
+// CHECK2-NOT: func.func
+// CHECK2: verif.lec
+// CHECK2-NOT: llvm.mlir.global

--- a/test/Tools/circt-lec/construct-lec.mlir
+++ b/test/Tools/circt-lec/construct-lec.mlir
@@ -57,3 +57,15 @@ hw.module @modB1() {
 // CHECK1:   llvm.call @printf([[V3]])
 // CHECK1:   return
 // CHECK1: }
+
+// RUN: circt-opt --construct-lec="first-module=modA0 second-module=modB0 insert-main=false insert-report=false" %s | FileCheck %s --check-prefix=CHECK2
+
+// CHECK2:   [[V0:%.+]] = verif.lec first {
+// CHECK2:   ^bb0([[ARG0:%.+]]: i32, [[ARG1:%.+]]: i32):
+// CHECK2:     [[V1:%.+]] = comb.add [[ARG0]], [[ARG1]]
+// CHECK2:     verif.yield [[V1]]
+// CHECK2:   } second {
+// CHECK2:   ^bb0([[ARG0:%.+]]: i32, [[ARG1:%.+]]: i32):
+// CHECK2:     [[V2:%.+]] = comb.mul [[ARG0]], [[ARG1]]
+// CHECK2:     verif.yield [[V2]]
+// CHECK2:   }

--- a/test/Tools/circt-lec/construct-lec.mlir
+++ b/test/Tools/circt-lec/construct-lec.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --construct-lec="first-module=modA0 second-module=modB0 insert-main=true" %s | FileCheck %s
+// RUN: circt-opt --construct-lec="first-module=modA0 second-module=modB0 insert-mode=main" %s | FileCheck %s
 
 hw.module @modA0(in %in0: i32, in %in1: i32, out out: i32) {
   %0 = comb.add %in0, %in1 : i32
@@ -35,9 +35,9 @@ hw.module @modB0(in %in0: i32, in %in1: i32, out out: i32) {
 // CHECK: llvm.mlir.global private constant @"c1 != c2\0A"("c1 != c2\0A\00") {addr_space = 0 : i32}
 
 
-// RUN: circt-opt --construct-lec="first-module=modA1 second-module=modB1 insert-main=false" %s | FileCheck %s --check-prefix=CHECK1
+// RUN: circt-opt --construct-lec="first-module=modA1 second-module=modB1 insert-mode=reporting" %s | FileCheck %s --check-prefix=CHECK1
 // Test that using the same module twice doesn't lead to a double free
-// RUN: circt-opt --construct-lec="first-module=modA1 second-module=modA1 insert-main=false" %s
+// RUN: circt-opt --construct-lec="first-module=modA1 second-module=modA1 insert-mode=reporting" %s
 
 hw.module @modA1() {
   hw.output
@@ -58,7 +58,7 @@ hw.module @modB1() {
 // CHECK1:   return
 // CHECK1: }
 
-// RUN: circt-opt --construct-lec="first-module=modA0 second-module=modB0 insert-main=false insert-report=false" %s | FileCheck %s --check-prefix=CHECK2
+// RUN: circt-opt --construct-lec="first-module=modA0 second-module=modB0 insert-mode=none" %s | FileCheck %s --check-prefix=CHECK2
 
 // CHECK2:   [[V0:%.+]] = verif.lec first {
 // CHECK2:   ^bb0([[ARG0:%.+]]: i32, [[ARG1:%.+]]: i32):
@@ -69,3 +69,6 @@ hw.module @modB1() {
 // CHECK2:     [[V2:%.+]] = comb.mul [[ARG0]], [[ARG1]]
 // CHECK2:     verif.yield [[V2]]
 // CHECK2:   }
+
+// CHECK2-NOT: llvm.mlir.global private constant @"c1 == c2\0A"("c1 == c2\0A\00") {addr_space = 0 : i32}
+// CHECK2-NOT: llvm.mlir.global private constant @"c1 != c2\0A"("c1 != c2\0A\00") {addr_space = 0 : i32}

--- a/test/Tools/circt-lec/generate-smtlib.mlir
+++ b/test/Tools/circt-lec/generate-smtlib.mlir
@@ -1,0 +1,22 @@
+// RUN: circt-lec %s --c1 foo1 --c2 foo2 --emit-smtlib | FileCheck %s
+
+hw.module @foo1(in %a : i8, in %b : i8, out c : i8) {
+  %add = comb.add %a, %b: i8
+  hw.output %add : i8
+}
+
+hw.module @foo2(in %a : i8, in %b : i8, out c : i8) {
+  %add = comb.add %b, %a: i8
+  hw.output %add : i8
+}
+
+
+// CHECK:      ; solver scope 0
+// CHECK-NEXT: (declare-const [[TMP:.+]] (_ BitVec 8))
+// CHECK-NEXT: (declare-const [[TMP0:.+]] (_ BitVec 8))
+// CHECK-NEXT: (assert (let (([[TMP1:.+]] (bvadd [[TMP0]] [[TMP]])))
+// CHECK-NEXT:         (let (([[TMP2:.+]] (bvadd tmp [[TMP0]])))
+// CHECK-NEXT:         (let (([[TMP3:.+]] (distinct [[TMP2]] [[TMP1]])))
+// CHECK-NEXT:         [[TMP3]]))))
+// CHECK-NEXT: (check-sat)
+// CHECK-NEXT: (reset)

--- a/tools/circt-lec/CMakeLists.txt
+++ b/tools/circt-lec/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(circt-lec
   MLIRLLVMToLLVMIRTranslation
   MLIRSMT
   MLIRTargetLLVMIRExport
+  MLIRExportSMTLIB
 
   ${CIRCT_LEC_JIT_DEPS}
 )

--- a/tools/circt-lec/circt-lec.cpp
+++ b/tools/circt-lec/circt-lec.cpp
@@ -41,6 +41,7 @@
 #include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
+#include "mlir/Target/SMTLIB/ExportSMTLIB.h"
 #include "mlir/Transforms/Passes.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
@@ -227,6 +228,8 @@ static LogicalResult executeLEC(MLIRContext &context) {
     ConstructLECOptions opts;
     opts.firstModule = firstModuleName;
     opts.secondModule = secondModuleName;
+    if (outputFormat == OutputSMTLIB)
+      opts.insertReporting = false;
     pm.addPass(createConstructLEC(opts));
   }
   pm.addPass(createConvertHWToSMT());
@@ -254,8 +257,12 @@ static LogicalResult executeLEC(MLIRContext &context) {
 
   if (outputFormat == OutputSMTLIB) {
     auto timer = ts.nest("Print SMT-LIB output");
-    llvm::errs() << "Printing SMT-LIB not yet supported!\n";
-    return failure();
+    auto smtModule =
+        mlir::smt::exportSMTLIB(module.get(), outputFile.value()->os());
+    if (failed(smtModule))
+      return failure();
+    outputFile.value()->keep();
+    return success();
   }
 
   if (outputFormat == OutputLLVM) {

--- a/tools/circt-lec/circt-lec.cpp
+++ b/tools/circt-lec/circt-lec.cpp
@@ -229,7 +229,7 @@ static LogicalResult executeLEC(MLIRContext &context) {
     opts.firstModule = firstModuleName;
     opts.secondModule = secondModuleName;
     if (outputFormat == OutputSMTLIB)
-      opts.insertReporting = false;
+      opts.insertMode = lec::InsertAdditionalModeEnum::None;
     pm.addPass(createConstructLEC(opts));
   }
   pm.addPass(createConvertHWToSMT());
@@ -257,9 +257,7 @@ static LogicalResult executeLEC(MLIRContext &context) {
 
   if (outputFormat == OutputSMTLIB) {
     auto timer = ts.nest("Print SMT-LIB output");
-    auto smtModule =
-        mlir::smt::exportSMTLIB(module.get(), outputFile.value()->os());
-    if (failed(smtModule))
+    if (failed(smt::exportSMTLIB(module.get(), outputFile.value()->os())))
       return failure();
     outputFile.value()->keep();
     return success();


### PR DESCRIPTION
To reuse the translate to smtlib MLIR backend and enable benchmark generation for alternative smt solvers, need to lower to and `smt.solver` which does not return any results. To handle this make the LLVM reporting code insertion optional and disable when emitting smtlib. Also in verif to smt lowering only return a result from the solver if the result will be used.