### PR TITLE
[ESI] Add missing include and change link type

### DIFF
--- a/lib/Dialect/ESI/runtime/CMakeLists.txt
+++ b/lib/Dialect/ESI/runtime/CMakeLists.txt
@@ -195,7 +195,7 @@ if(NOT MSVC)
   target_link_libraries(ESICppRuntime PRIVATE
     dl
   )
-  target_link_options(ESICppRuntime PRIVATE
+  target_link_options(ESICppRuntime PUBLIC
     -pthread
   )
 endif()

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
@@ -15,8 +15,8 @@
 
 #include "esi/backends/Cosim.h"
 
-#include <sstream>
 #include <ranges>
+#include <sstream>
 
 // pybind11 includes
 #include <pybind11/pybind11.h>

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
@@ -16,6 +16,7 @@
 #include "esi/backends/Cosim.h"
 
 #include <sstream>
+#include <ranges>
 
 // pybind11 includes
 #include <pybind11/pybind11.h>


### PR DESCRIPTION
Linking `-pthread` as private doesn't seem to do it for my build (w/ `ESI_STATIC_RUNTIME`). Switched to public, and things work.