### PR TITLE
[CI] Bump docker images

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -14,7 +14,7 @@ jobs:
     name: Sanity Check
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/circt/images/circt-ci-build:20240213211952
+      image: ghcr.io/circt/images/circt-ci-build:20250515145637
     steps:
       # Clone the CIRCT repo and its submodules. Do shallow clone to save clone
       # time.
@@ -134,7 +134,7 @@ jobs:
     # John and re-run the job.
     runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
     container:
-      image: ghcr.io/circt/images/circt-ci-build:20240213211952
+      image: ghcr.io/circt/images/circt-ci-build:20250515145637
       volumes:
         - /mnt:/__w/circt
     strategy:

--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -19,7 +19,7 @@ jobs:
     # John and re-run the job.
     runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
     container:
-      image: ghcr.io/circt/images/circt-integration-test:v18.2
+      image: ghcr.io/circt/images/circt-integration-test:v19
       volumes:
         - /mnt:/__w/circt
     strategy:

--- a/.github/workflows/shortIntegrationTests.yml
+++ b/.github/workflows/shortIntegrationTests.yml
@@ -29,7 +29,7 @@ jobs:
     # John and re-run the job.
     runs-on: ["self-hosted", "1ES.Pool=1ES-CIRCT-builds", "linux"]
     container:
-      image: ghcr.io/circt/images/circt-integration-test:v18.2
+      image: ghcr.io/circt/images/circt-integration-test:v19
       volumes:
         - /mnt:/__w/circt
     strategy:


### PR DESCRIPTION
Making a separate pull request with CI changes per the request in https://github.com/llvm/circt/pull/7792#discussion_r1884662217.

Bump to images based on ubuntu 24 images.

Some of the features used by `slang` requires newer default compiler versions than what's provided by the current images, as discussed in https://github.com/llvm/circt/pull/7792.