### PR TITLE
[HW] Add array element injection op

### DIFF
--- a/include/circt/Dialect/HW/CMakeLists.txt
+++ b/include/circt/Dialect/HW/CMakeLists.txt
@@ -17,6 +17,10 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls)
 add_public_tablegen_target(CIRCTHWTransformsIncGen)
 
+set(LLVM_TARGET_DEFINITIONS HWCanonicalization.td)
+mlir_tablegen(HWCanonicalization.cpp.inc -gen-rewriters)
+add_public_tablegen_target(CIRCTHWCanonicalizationIncGen)
+
 set(LLVM_TARGET_DEFINITIONS HWOpInterfaces.td)
 mlir_tablegen(HWOpInterfaces.h.inc -gen-op-interface-decls)
 mlir_tablegen(HWOpInterfaces.cpp.inc -gen-op-interface-defs)

--- a/include/circt/Dialect/HW/HWAggregates.td
+++ b/include/circt/Dialect/HW/HWAggregates.td
@@ -181,6 +181,33 @@ def ArrayGetOp : HWOp<"array_get", [
   let hasCanonicalizeMethod = 1;
 }
 
+def ArrayInjectOp : HWOp<"array_inject", [
+  AllTypesMatch<["input", "result"]>,
+  ArrayElementTypeConstraint<"element", "input">,
+  IndexBitWidthConstraint<"index", "input">,
+  Pure,
+]> {
+  let summary = "Inject an element into an array";
+  let description = [{
+    Takes an `input` array, changes the element at `index` to the given
+    `element` value, and returns the updated array value as a result. The index
+    must be exactly `ceil(log2(length(input)))` bits wide. The element type
+    must match the input array's element type.
+  }];
+  let arguments = (ins
+    ArrayType:$input,
+    HWIntegerType:$index,
+    AnyType:$element
+  );
+  let results = (outs ArrayType:$result);
+  let assemblyFormat = [{
+    $input `[` $index `]` `,` $element
+    attr-dict `:` type($input) `,` type($index)
+  }];
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // Structure Processing Operations
 //===----------------------------------------------------------------------===//

--- a/include/circt/Dialect/HW/HWCanonicalization.td
+++ b/include/circt/Dialect/HW/HWCanonicalization.td
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_HW_HWCANONICALIZATION_TD
+#define CIRCT_DIALECT_HW_HWCANONICALIZATION_TD
+
+include "mlir/IR/PatternBase.td"
+include "circt/Dialect/HW/HWOps.td"
+
+def NotEqual : Constraint<CPred<"$0 != $1">>;
+
+//===----------------------------------------------------------------------===//
+// ArrayInjectOp
+//===----------------------------------------------------------------------===//
+
+def ArrayInjectToSameIndex : Pat<
+  (ArrayInjectOp:$op (ArrayInjectOp $array, $index, $_), $index, $element),
+  (ArrayInjectOp $array, $index, $element),
+  [(NotEqual $op, $array)]
+>;
+
+#endif // CIRCT_DIALECT_HW_HWCANONICALIZATION_TD

--- a/lib/Dialect/HW/CMakeLists.txt
+++ b/lib/Dialect/HW/CMakeLists.txt
@@ -33,6 +33,7 @@ add_circt_dialect_library(CIRCTHW
   MLIRHWIncGen
   CIRCTHWAttrIncGen
   CIRCTHWEnumsIncGen
+  CIRCTHWCanonicalizationIncGen
 
   LINK_COMPONENTS
   Support

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -255,6 +255,14 @@ void HWModulePortAccessor::setOutput(StringRef name, Value v) {
 }
 
 //===----------------------------------------------------------------------===//
+// Declarative Canonicalization Patterns
+//===----------------------------------------------------------------------===//
+
+namespace {
+#include "circt/Dialect/HW/HWCanonicalization.cpp.inc"
+} // namespace
+
+//===----------------------------------------------------------------------===//
 // ConstantOp
 //===----------------------------------------------------------------------===//
 
@@ -2855,6 +2863,11 @@ OpFoldResult ArrayGetOp::fold(FoldAdaptor adaptor) {
                                        intTy.getIntOrFloatBitWidth()));
   }
 
+  // array_get(array_inject(_, index, element), index) -> element
+  if (auto inject = getInput().getDefiningOp<ArrayInjectOp>())
+    if (getIndex() == inject.getIndex())
+      return inject.getElement();
+
   auto inputCreate = getInput().getDefiningOp<ArrayCreateOp>();
   if (!inputCreate)
     return {};
@@ -2937,6 +2950,34 @@ LogicalResult ArrayGetOp::canonicalize(ArrayGetOp op,
   }
 
   return failure();
+}
+
+//===----------------------------------------------------------------------===//
+// ArrayInjectOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult ArrayInjectOp::fold(FoldAdaptor adaptor) {
+  auto inputAttr = dyn_cast_or_null<ArrayAttr>(adaptor.getInput());
+  auto indexAttr = dyn_cast_or_null<IntegerAttr>(adaptor.getIndex());
+  auto elementAttr = adaptor.getElement();
+
+  // inject(constant[xs, y, zs], iy, a) -> constant[x, a, z]
+  if (inputAttr && indexAttr && elementAttr) {
+    if (auto index = indexAttr.getValue().tryZExtValue()) {
+      if (*index < inputAttr.size()) {
+        SmallVector<Attribute> elements(inputAttr.getValue());
+        elements[inputAttr.size() - 1 - *index] = elementAttr;
+        return ArrayAttr::get(getContext(), elements);
+      }
+    }
+  }
+
+  return {};
+}
+
+void ArrayInjectOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
+                                                MLIRContext *context) {
+  patterns.add<ArrayInjectToSameIndex>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -145,6 +145,11 @@ hw.module @test1(in %arg0: i3, in %arg1: i1, in %arg2: !hw.array<1000xi8>, out r
 }
 // CHECK-NEXT:  }
 
+func.func @ArrayOps(%a: !hw.array<1000xi42>, %i: i10, %v: i42) {
+  hw.array_inject %a[%i], %v : !hw.array<1000xi42>, i10
+  return
+}
+
 hw.module @UnionOps(in %a: !hw.union<foo: i1, bar: i3>, out x: i3, out z: !hw.union<bar: i3, baz: i8>) {
   %x = hw.union_extract %a["bar"] : !hw.union<foo: i1, bar: i3>
   %z = hw.union_create "bar", %x : !hw.union<bar: i3, baz: i8>

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -539,3 +539,10 @@ hw.module @elementTypeError() {
 %1 = hw.constant 0 : i9
 // expected-error @below {{index bit width equals ceil(log2(length(input))), or 0 or 1 if input contains only one element}}
 hw.array_get %0[%1] : !hw.array<1000xi42>, i9
+
+// -----
+%0 = unrealized_conversion_cast to !hw.array<1000xi42>
+%1 = hw.constant 0 : i9
+%2 = hw.constant 0 : i42
+// expected-error @below {{index bit width equals ceil(log2(length(input))), or 0 or 1 if input contains only one element}}
+hw.array_inject %0[%1], %2 : !hw.array<1000xi42>, i9


### PR DESCRIPTION
Add a new `hw.array_inject` operation which updates a single element in an array value and returns the updated array. This fills in a gap where structs had a `struct_extract` and `struct_inject` op available, but arrays only had `array_get` without the complementary `array_inject`.

This commit also adds a `HWCanonicalization.td` file for any canonicalization rewrite patterns on HW ops. It is overkill for just the new `array_inject` operation, but my hope is that we'll fill this in as time progresses and we may even be able to migrate some existing patterns from C++ to the declarative format. The `ArithCanonicalization.td` file has a lot of nice inspiration.

In the future we may want to add patterns that can fold injects directly into an `array_create` operation, and patterns that reorder injects and collapse adjacent injects into an `array_create`, `array_slice`, and `array_concat`.