### PR TITLE
[PyCDE] Fix invalid `inputs` function

### DIFF
--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -661,11 +661,12 @@ class Module(_PyProxy, metaclass=ModuleLikeType):
     cls._builder.print(out)
 
   @classmethod
-  def inputs(cls) -> List[Tuple[str, Type]]:
-    """Get a dictionary of input port names to signals."""
-    if cls._builder.inputs is None:
-      return []
+  def inputs(cls) -> List[Input]:
     return cls._builder.inputs
+  
+  @classmethod
+  def outputs(cls) -> List[Output]:
+    return cls._builder.outputs
 
 
 class modparams:


### PR DESCRIPTION
This might just have been some outdated code.

The previous `inputs` function had an incorrect type annotation (i.e. it defers to the following code:
```python
  @property
  def inputs(self) -> List[Input]:
    return [p for p in self.ports if isinstance(p, Input)]
```
Might as well return that list instead of reducing it to a dictionary.

Secondly, also adds a (presumably) missing `outputs` method.