### PR TITLE
[Arc] Fix arc inliner deleting arcs that still have calls

### DIFF
--- a/lib/Dialect/Arc/Transforms/InlineArcs.cpp
+++ b/lib/Dialect/Arc/Transforms/InlineArcs.cpp
@@ -286,6 +286,12 @@ void InlineArcsAnalysis::notifyInlinedCallInto(mlir::CallOpInterface callOp,
   --usersPerArc[calledArcName];
   ++statistics.numInlinedArcs;
 
+  for (auto calleeName : callsInArcBody[calledArcName]) {
+    if (!usersPerArc.contains(calleeName))
+      continue;
+    ++usersPerArc[calleeName];
+  }
+
   auto arc = dyn_cast<DefineOp>(region->getParentOp());
   if (!arc)
     return;
@@ -301,8 +307,6 @@ void InlineArcsAnalysis::notifyInlinedCallInto(mlir::CallOpInterface callOp,
   for (auto calleeName : callsInArcBody[calledArcName]) {
     if (!usersPerArc.contains(calleeName))
       continue;
-
-    ++usersPerArc[calleeName];
     callsInArcBody[arcName].push_back(calleeName);
   }
 }


### PR DESCRIPTION
Hit a very niche breaking case in InlineArcs in my optimization travels - currently if the inliner inlines `arcA` which calls `arcB`, it will only acknowledge the additional user of `arcB` if `arcA` is inlined into another define. Most of the time this flies under the radar, however, if `arcB` is prevented from being inlined by another user that is eventually deleted, the inliner will think that `arcB` has no users even though it still has a call where `arcA` was inlined. Breaking example added as a filecheck test.