### PR TITLE
[LowerToHW] Emit an error when $fopen failed for FD lowering

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -908,8 +908,11 @@ package __circt_lib_logging;
   class FileDescriptor;
     static int global_id [string];
     static function int get(string name);
-      if (global_id.exists(name) == 32'h0)
+      if (global_id.exists(name) == 32'h0) begin
         global_id[name] = $fopen(name);
+        if (global_id[name] == 32'h0)
+          $error("Failed to open file %s", name);
+      end
       return global_id[name];
     endfunction
   endclass

--- a/test/firtool/print.fir
+++ b/test/firtool/print.fir
@@ -8,8 +8,11 @@ FIRRTL version 5.1.0
 ; CHECK-NEXT:     class FileDescriptor;
 ; CHECK-NEXT:       static int global_id [string];
 ; CHECK-NEXT:       static function int get(string name);
-; CHECK-NEXT:         if (global_id.exists(name) == 32'h0)
+; CHECK-NEXT:         if (global_id.exists(name) == 32'h0) begin
 ; CHECK-NEXT:           global_id[name] = $fopen(name);
+; CHECK-NEXT:           if (global_id[name] == 32'h0)
+; CHECK-NEXT:             $error("Failed to open file %s", name);
+; CHECK-NEXT:         end
 ; CHECK-NEXT:         return global_id[name];
 ; CHECK-NEXT:       endfunction
 ; CHECK-NEXT:     endclass


### PR DESCRIPTION
Some simulators silently return 0 when $fopen failed to open a file. This PR changes the FileDescriptor::get to emit $error explicitly. 