### PR TITLE
[LLHD] Fix deseq poisoning comb ops that don't depend on triggers

### DIFF
--- a/lib/Dialect/LLHD/Transforms/Deseq.cpp
+++ b/lib/Dialect/LLHD/Transforms/Deseq.cpp
@@ -514,7 +514,8 @@ TruthTable Deseq::computeBoolean(OpResult value) {
         if (!operand.getType().isSignlessInteger(1))
           return false;
         auto result = computeBoolean(operand);
-        return result.isPoison() || result != getUnknownBoolean();
+        return result.isPoison() || (result != getUnknownBoolean() &&
+                                     !result.isTrue() && !result.isFalse());
       }))
     return getPoisonBoolean();
   return getUnknownBoolean();


### PR DESCRIPTION
Fix an issue in the Deseq pass where operations like `comb.icmp ne %false, %false` get mistakenly marked as poison. This was due to a missing check whether the operands are constant true or false. This cause any comb op not supported in Deseq's truth table mapping to be mistakenly poisoned if the op contained any `i1` operands that were constant true or false.

Fixes #8512