### PR TITLE
[FIRRTL][IMCP] Mark DPI calls as overdefined

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/IMConstProp.cpp
@@ -312,6 +312,7 @@ struct IMConstPropPass
   void markBlockExecutable(Block *block);
   void markWireOp(WireOp wireOrReg);
   void markMemOp(MemOp mem);
+  void markDPICallIntrinsicOp(DPICallIntrinsicOp dpi);
 
   void markInvalidValueOp(InvalidValueOp invalid);
   void markAggregateConstantOp(AggregateConstantOp constant);
@@ -516,6 +517,8 @@ void IMConstPropPass::markBlockExecutable(Block *block) {
         .Case<MemOp>([&](auto mem) { markMemOp(mem); })
         .Case<LayerBlockOp>(
             [&](auto layer) { markBlockExecutable(layer.getBody(0)); })
+        .Case<DPICallIntrinsicOp>(
+            [&](auto dpi) { markDPICallIntrinsicOp(dpi); })
         .Default([&](auto _) {
           if (isa<mlir::UnrealizedConversionCastOp, VerbatimExprOp,
                   VerbatimWireOp, SubaccessOp>(op) ||
@@ -583,6 +586,11 @@ void IMConstPropPass::markWireOp(WireOp wire) {
 
 void IMConstPropPass::markMemOp(MemOp mem) {
   for (auto result : mem.getResults())
+    markOverdefined(result);
+}
+
+void IMConstPropPass::markDPICallIntrinsicOp(DPICallIntrinsicOp dpi) {
+  if (auto result = dpi.getResult())
     markOverdefined(result);
 }
 


### PR DESCRIPTION
Mark `DPICallIntrinsicOp`s as over-defined in the FIRRTL IMConstProp pass to prevent connections to the call's result from being removed. 

Running this Chisel 7 snippet through `firtool`
```Scala
class DPITest extends Module {
  val out = IO(Output(Bool()))
  val bar = Wire(Bool())
  val foo = RawClockedNonVoidFunctionCall("foo", Bool())(this.clock, true.B, bar)
  bar := RawClockedNonVoidFunctionCall("bar", Bool())(this.clock, true.B, foo)
  out := bar
}
```
incorrectly produces
```SystemVerilog
[...]
  always @(posedge clock) begin
    foo(1'bz, _foo_0); 
    bar(_GEN, _bar_0);  
    _GEN_0 <= _bar_0; 
  end // always @(posedge)
  assign out = 1'bz; 
endmodule
```

The DPI call intrinsics ale initialized as `Unknown` in the constant propagation lattice and due to their cyclic dependency, this never gets resolved. This eventually leads to the connection to the `bar` wire being removed `IMConstProp.cpp:1091`:
```C++
if (isDeletableWireOrRegOrNode(destOp) &&
                !isOverdefined(fieldRef)) {
              connect.erase();
              ++numErasedOp;
            }
```
Initializing the call results to `Overdefined` prevents this. 

I'm not familiar with this pass, but the ` !isOverdefined(fieldRef)` check before deleting a connection looks a bit too optimistic to me. Is it an invariant at this point that every value is known to be either constant or overdefined? If so, this should probably get an `assert`, right?