### PR TITLE
[Pipeline] Add cross-block canonicalization break op

### DIFF
--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -244,6 +244,25 @@ def ScheduledPipelineOp : PipelineBase<"scheduled"> {
   }];
 }
 
+def SourceOp : Op<Pipeline_Dialect, "src", [
+  Pure,
+  TypesMatchWith<"input and result types are equivalent", "input", "output", "$_self">,
+  HasParent<"ScheduledPipelineOp">,
+  ]> {
+  let summary = "Pipeline source operation";
+  let description = [{
+    The `pipeline.src` operation represents a source operation in a scheduled,
+    non-register materialized pipeline.
+    It is used as a canonicalization barrier to prevent cross-block canonicalization
+    of operations that are not allowed to be moved or mutated across pipeline
+    stages (i.e. MLIR blocks).
+  }];
+  let arguments = (ins AnyType:$input);
+  let results = (outs AnyType:$output);
+  let assemblyFormat = [{
+    $input `:` type($input) attr-dict
+  }];
+}
 
 def StageOp : Op<Pipeline_Dialect, "stage", [
     AttrSizedOperandSegments,

--- a/include/circt/Dialect/Pipeline/PipelineOps.td
+++ b/include/circt/Dialect/Pipeline/PipelineOps.td
@@ -245,7 +245,6 @@ def ScheduledPipelineOp : PipelineBase<"scheduled"> {
 }
 
 def SourceOp : Op<Pipeline_Dialect, "src", [
-  Pure,
   TypesMatchWith<"input and result types are equivalent", "input", "output", "$_self">,
   HasParent<"ScheduledPipelineOp">,
   ]> {
@@ -256,6 +255,8 @@ def SourceOp : Op<Pipeline_Dialect, "src", [
     It is used as a canonicalization barrier to prevent cross-block canonicalization
     of operations that are not allowed to be moved or mutated across pipeline
     stages (i.e. MLIR blocks).
+
+    To facilitate this, the operation is _not_ marked as `Pure`.
   }];
   let arguments = (ins AnyType:$input);
   let results = (outs AnyType:$output);

--- a/integration_test/Dialect/Pipeline/nonstallable/test1/nonstallable_test1.mlir
+++ b/integration_test/Dialect/Pipeline/nonstallable/test1/nonstallable_test1.mlir
@@ -24,7 +24,8 @@ hw.module @nonstallable_test1(in %arg0: i32, in %go: i1, in %clock: !seq.clock, 
   ^bb4(%s4_enable: i1):
     pipeline.stage ^bb5
   ^bb5(%s5_enable: i1):
-    pipeline.return %a0 : i32
+    %a0_bb5 = pipeline.src %a0 : i32
+    pipeline.return %a0_bb5 : i32
   }
   hw.output %out, %done : i32, i1
 }

--- a/integration_test/Dialect/Pipeline/nonstallable/test2/nonstallable_test2.mlir
+++ b/integration_test/Dialect/Pipeline/nonstallable/test2/nonstallable_test2.mlir
@@ -24,7 +24,8 @@ hw.module @nonstallable_test2(in %arg0: i32, in %go: i1, in %clock: !seq.clock, 
   ^bb4(%s4_enable: i1):
     pipeline.stage ^bb5
   ^bb5(%s5_enable: i1):
-    pipeline.return %a0 : i32
+    %a0_bb5 = pipeline.src %a0 : i32
+    pipeline.return %a0_bb5 : i32
   }
   hw.output %out, %done : i32, i1
 }

--- a/integration_test/Dialect/Pipeline/simple/simple.mlir
+++ b/integration_test/Dialect/Pipeline/simple/simple.mlir
@@ -26,11 +26,15 @@ hw.module @simple(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clock : !seq.
       pipeline.stage ^bb1
 
     ^bb1(%s1_enable : i1):
-      %add1 = comb.add %add0, %a0 : i32
+      %add0_bb1 = pipeline.src %add0 : i32
+      %a0_bb1 = pipeline.src %a0 : i32
+      %add1 = comb.add %add0_bb1, %a0_bb1 : i32
       pipeline.stage ^bb2
 
     ^bb2(%s2_enable : i1):
-      %add2 = comb.add %add1, %add0 : i32
+      %add0_bb2 = pipeline.src %add0 : i32
+      %add1_bb2 = pipeline.src %add1 : i32
+      %add2 = comb.add %add1_bb2, %add0_bb2 : i32
       pipeline.return %add2 : i32
   }
   hw.output %out, %done : i32, i1

--- a/integration_test/Dialect/Pipeline/stall/stallTest.mlir
+++ b/integration_test/Dialect/Pipeline/stall/stallTest.mlir
@@ -26,11 +26,15 @@ hw.module @stallTest(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %stall : i1
       pipeline.stage ^bb1
 
     ^bb1(%s1_enable : i1):
-      %add1 = comb.add %add0, %a0 : i32
+      %add0_bb1 = pipeline.src %add0 : i32
+      %a0_bb1 = pipeline.src %a0 : i32
+      %add1 = comb.add %add0_bb1, %a0_bb1 : i32
       pipeline.stage ^bb2
 
     ^bb2(%s2_enable : i1):
-      %add2 = comb.add %add1, %add0 : i32
+      %add0_bb2 = pipeline.src %add0 : i32
+      %add1_bb2 = pipeline.src %add1 : i32
+      %add2 = comb.add %add1_bb2, %add0_bb2 : i32
       pipeline.return %add2 : i32
   }
   hw.output %out, %done : i32, i1

--- a/lib/Dialect/Pipeline/PipelineOps.cpp
+++ b/lib/Dialect/Pipeline/PipelineOps.cpp
@@ -548,12 +548,12 @@ static bool useDefinedInStage(Block *stage, OpOperand &use) {
   Block *useBlock = use.getOwner()->getBlock();
   Block *definingBlock = use.get().getParentBlock();
 
-  if (useBlock == definingBlock)
+  // Common-case checks...
+  if (useBlock == definingBlock || stage == definingBlock)
     return true;
 
-  if (stage == definingBlock)
-    return true;
-
+  // Else, recurse upwards from the defining block to see if we can find the
+  // stage.
   Block *currBlock = definingBlock;
   while (currBlock) {
     currBlock = currBlock->getParentOp()->getBlock();

--- a/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
@@ -204,14 +204,10 @@ void ExplicitRegsPass::runOnPipeline(ScheduledPipelineOp pipeline) {
         // reference operands from other stages.
         SourceOp srcOp =
             llvm::dyn_cast_or_null<pipeline::SourceOp>(operand.getOwner());
-        if (!srcOp) {
-          operand.getOwner()->emitError()
-              << "Only pipeline.srcOp's are allowed to reference values "
-                 "outside of this block. Verifiers should have caught this";
-          assert(srcOp && "Only pipeline.srcOp's should be allowed to "
-                          "reference values outside of "
-                          "this block. Verifiers should have caught this");
-        }
+        assert(
+            srcOp &&
+            "Only pipeline.srcOp's should be allowed to reference "
+            "values outside of this block. Verifiers should have caught this");
 
         Value reroutedValue = routeThroughStage(operand.get(), stage);
         if (reroutedValue != operand.get())

--- a/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ExplicitRegs.cpp
@@ -199,6 +199,20 @@ void ExplicitRegsPass::runOnPipeline(ScheduledPipelineOp pipeline) {
           // resides within the current pipeline stage. No routing needed.
           continue;
         }
+
+        // At this point, only `pipeline.src` operations are legally allowed to
+        // reference operands from other stages.
+        SourceOp srcOp =
+            llvm::dyn_cast_or_null<pipeline::SourceOp>(operand.getOwner());
+        if (!srcOp) {
+          operand.getOwner()->emitError()
+              << "Only pipeline.srcOp's are allowed to reference values "
+                 "outside of this block. Verifiers should have caught this";
+          assert(srcOp && "Only pipeline.srcOp's should be allowed to "
+                          "reference values outside of "
+                          "this block. Verifiers should have caught this");
+        }
+
         Value reroutedValue = routeThroughStage(operand.get(), stage);
         if (reroutedValue != operand.get())
           op->setOperand(operand.getOperandNumber(), reroutedValue);
@@ -290,6 +304,12 @@ void ExplicitRegsPass::runOnPipeline(ScheduledPipelineOp pipeline) {
 
   // Clear internal state. See https://github.com/llvm/circt/issues/3235
   stageRegOrPassMap.clear();
+
+  // Finally, erase all of the pipeline.src ops now that they've become no-ops.
+  for (auto srcOp : llvm::make_early_inc_range(pipeline.getOps<SourceOp>())) {
+    srcOp.getResult().replaceAllUsesWith(srcOp.getInput());
+    srcOp.erase();
+  }
 }
 
 void ExplicitRegsPass::runOnOperation() {

--- a/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
+++ b/lib/Dialect/Pipeline/Transforms/ScheduleLinearPipeline.cpp
@@ -201,7 +201,7 @@ ScheduleLinearPipelinePass::schedulePipeline(UnscheduledPipelineOp pipeline) {
 
     // Caching of SourceOp passthrough values defined in this stage.
     mlir::DenseMap<Value, Value> sourceOps;
-    auto getOrCreateSourceOp = [&](OpOperand &opOperand) {
+    auto getOrCreateSourceOp = [&](OpOperand &opOperand) -> Value {
       Value v = opOperand.get();
       auto it = sourceOps.find(v);
       if (it == sourceOps.end()) {

--- a/test/Dialect/Kanagawa/Transforms/schedule_pipeline.mlir
+++ b/test/Dialect/Kanagawa/Transforms/schedule_pipeline.mlir
@@ -16,32 +16,39 @@
 // CHECK:           operator_type @comb.shrs [latency<1>]
 // CHECK:         }
 
-// CHECK-LABEL:   kanagawa.class sym @SchedulePipeline {
-// CHECK:           kanagawa.method.df @foo(%[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) -> i32 {
-// CHECK:             %[[VAL_3:.*]] = kanagawa.sblock.isolated (%[[VAL_4:.*]] : i32 = %[[VAL_1]], %[[VAL_5:.*]] : i32 = %[[VAL_2]]) -> i32 {
-// CHECK:               %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]], %[[VAL_9:.*]] = kanagawa.pipeline.header
-// CHECK:               %[[VAL_10:.*]], %[[VAL_11:.*]] = pipeline.scheduled(%[[VAL_12:.*]] : i32 = %[[VAL_4]], %[[VAL_13:.*]] : i32 = %[[VAL_5]]) stall(%[[VAL_9]]) clock(%[[VAL_6]]) reset(%[[VAL_7]]) go(%[[VAL_8]]) entryEn(%[[VAL_14:.*]])  -> (out0 : i32) {
-// CHECK:                 %[[VAL_15:.*]] = comb.mul %[[VAL_12]], %[[VAL_13]] {ssp.operator_type = @comb.mul} : i32
-// CHECK:                 pipeline.stage ^bb1
-// CHECK:               ^bb1(%[[VAL_16:.*]]: i1):
-// CHECK:                 %[[VAL_17:.*]] = comb.add %[[VAL_12]], %[[VAL_13]] {ssp.operator_type = @comb.add} : i32
-// CHECK:                 pipeline.stage ^bb2
-// CHECK:               ^bb2(%[[VAL_18:.*]]: i1):
-// CHECK:                 %[[VAL_19:.*]] = comb.sub %[[VAL_17]], %[[VAL_15]] {ssp.operator_type = @comb.sub} : i32
-// CHECK:                 pipeline.stage ^bb3
-// CHECK:               ^bb3(%[[VAL_20:.*]]: i1):
-// CHECK:                 %[[VAL_21:.*]] = comb.mul %[[VAL_19]], %[[VAL_17]] {ssp.operator_type = @comb.mul} : i32
-// CHECK:                 pipeline.stage ^bb4
-// CHECK:               ^bb4(%[[VAL_22:.*]]: i1):
-// CHECK:                 pipeline.stage ^bb5
-// CHECK:               ^bb5(%[[VAL_23:.*]]: i1):
-// CHECK:                 pipeline.return %[[VAL_21]] : i32
+// CHECK:           kanagawa.class sym @SchedulePipeline {
+// CHECK:             kanagawa.method.df @foo(%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32)  -> i32 {
+// CHECK:               %[[VAL_2:.*]] = kanagawa.sblock.isolated (%[[VAL_3:.*]] : i32 = %[[VAL_0]], %[[VAL_4:.*]] : i32 = %[[VAL_1]]) -> i32 {
+// CHECK:                 %[[VAL_5:.*]], %[[VAL_6:.*]], %[[VAL_7:.*]], %[[VAL_8:.*]] = kanagawa.pipeline.header
+// CHECK:                 %[[VAL_9:.*]], %[[VAL_10:.*]] = pipeline.scheduled(%[[VAL_11:.*]] : i32 = %[[VAL_3]], %[[VAL_12:.*]] : i32 = %[[VAL_4]]) stall(%[[VAL_8]]) clock(%[[VAL_5]]) reset(%[[VAL_6]]) go(%[[VAL_7]]) entryEn(%[[VAL_13:.*]])  -> (out0 : i32) {
+// CHECK:                   %[[VAL_14:.*]] = comb.mul %[[VAL_11]], %[[VAL_12]] {ssp.operator_type = @comb.mul} : i32
+// CHECK:                   pipeline.stage ^bb1
+// CHECK:                 ^bb1(%[[VAL_15:.*]]: i1):
+// CHECK:                   %[[VAL_16:.*]] = pipeline.src %[[VAL_11]] : i32
+// CHECK:                   %[[VAL_17:.*]] = pipeline.src %[[VAL_12]] : i32
+// CHECK:                   %[[VAL_18:.*]] = comb.add %[[VAL_16]], %[[VAL_17]] {ssp.operator_type = @comb.add} : i32
+// CHECK:                   pipeline.stage ^bb2
+// CHECK:                 ^bb2(%[[VAL_19:.*]]: i1):
+// CHECK:                   %[[VAL_20:.*]] = pipeline.src %[[VAL_18]] : i32
+// CHECK:                   %[[VAL_21:.*]] = pipeline.src %[[VAL_14]] : i32
+// CHECK:                   %[[VAL_22:.*]] = comb.sub %[[VAL_20]], %[[VAL_21]] {ssp.operator_type = @comb.sub} : i32
+// CHECK:                   pipeline.stage ^bb3
+// CHECK:                 ^bb3(%[[VAL_23:.*]]: i1):
+// CHECK:                   %[[VAL_24:.*]] = pipeline.src %[[VAL_22]] : i32
+// CHECK:                   %[[VAL_25:.*]] = pipeline.src %[[VAL_18]] : i32
+// CHECK:                   %[[VAL_26:.*]] = comb.mul %[[VAL_24]], %[[VAL_25]] {ssp.operator_type = @comb.mul} : i32
+// CHECK:                   pipeline.stage ^bb4
+// CHECK:                 ^bb4(%[[VAL_27:.*]]: i1):
+// CHECK:                   pipeline.stage ^bb5
+// CHECK:                 ^bb5(%[[VAL_28:.*]]: i1):
+// CHECK:                   %[[VAL_29:.*]] = pipeline.src %[[VAL_26]] : i32
+// CHECK:                   pipeline.return %[[VAL_29]] : i32
+// CHECK:                 }
+// CHECK:                 kanagawa.sblock.return %[[VAL_30:.*]] : i32
 // CHECK:               }
-// CHECK:               kanagawa.sblock.return %[[VAL_24:.*]] : i32
+// CHECK:               kanagawa.return %[[VAL_2]] : i32
 // CHECK:             }
-// CHECK:             kanagawa.return %[[VAL_3]] : i32
 // CHECK:           }
-// CHECK:         }
 
 kanagawa.design @foo {
 kanagawa.class sym @SchedulePipeline {

--- a/test/Dialect/Pipeline/Transforms/schedule-linear-pipeline.mlir
+++ b/test/Dialect/Pipeline/Transforms/schedule-linear-pipeline.mlir
@@ -1,27 +1,32 @@
 // RUN: circt-opt --pass-pipeline='builtin.module(any(pipeline-schedule-linear))' %s | FileCheck %s
 
-// CHECK-LABEL:   hw.module @pipeline(
-// CHECK-SAME:          in %[[VAL_0:.*]] : i32, in %[[VAL_1:.*]] : i32, in %[[GO:.*]] : i1, in %[[CLOCK:.*]] : !seq.clock, in %[[RESET:.*]] : i1, out out : i32) {
-// CHECK:           %[[VAL_5:.*]], %[[VAL_6:.*]] = pipeline.scheduled(%[[VAL_7:.*]] : i32 = %[[VAL_0]], %[[VAL_8:.*]] : i32 = %[[VAL_1]]) clock(%[[CLOCK]]) reset(%[[RESET]]) go(%[[GO]]) entryEn(%[[VAL_9:.*]]) -> (out : i32) {
-// CHECK:             %[[VAL_10:.*]] = comb.add %[[VAL_7]], %[[VAL_8]] {ssp.operator_type = @add1} : i32
-// CHECK:             %[[VAL_11:.*]] = comb.add %[[VAL_8]], %[[VAL_7]] {ssp.operator_type = @add1} : i32
+// CHECK-LABEL:   hw.module @pipeline(in 
+// CHECK-SAME:      %[[ARG0:.*]] : i32, in %[[ARG1:.*]] : i32, in %[[GO:.*]] : i1, in %[[CLK:.*]] : !seq.clock, in %[[RST:.*]] : i1, out out : i32) {
+// CHECK:           %[[VAL_0:.*]], %[[VAL_1:.*]] = pipeline.scheduled(%[[VAL_2:.*]] : i32 = %[[ARG0]], %[[VAL_3:.*]] : i32 = %[[ARG1]]) clock(%[[CLK]]) reset(%[[RST]]) go(%[[GO]]) entryEn(%[[VAL_4:.*]])  -> (out : i32) {
+// CHECK:             %[[VAL_5:.*]] = comb.add %[[VAL_2]], %[[VAL_3]] {ssp.operator_type = @add1} : i32
+// CHECK:             %[[VAL_6:.*]] = comb.add %[[VAL_3]], %[[VAL_2]] {ssp.operator_type = @add1} : i32
 // CHECK:             pipeline.stage ^bb1
-// CHECK:           ^bb1(%[[VAL_12:.*]]: i1):
+// CHECK:           ^bb1(%[[VAL_7:.*]]: i1):
 // CHECK:             pipeline.stage ^bb2
-// CHECK:           ^bb2(%[[VAL_13:.*]]: i1):
-// CHECK:             %[[VAL_14:.*]] = comb.mul %[[VAL_7]], %[[VAL_10]] {ssp.operator_type = @mul2} : i32
+// CHECK:           ^bb2(%[[VAL_8:.*]]: i1):
+// CHECK:             %[[VAL_9:.*]] = pipeline.src %[[VAL_2]] : i32
+// CHECK:             %[[VAL_10:.*]] = pipeline.src %[[VAL_5]] : i32
+// CHECK:             %[[VAL_11:.*]] = comb.mul %[[VAL_9]], %[[VAL_10]] {ssp.operator_type = @mul2} : i32
 // CHECK:             pipeline.stage ^bb3
-// CHECK:           ^bb3(%[[VAL_15:.*]]: i1):
+// CHECK:           ^bb3(%[[VAL_12:.*]]: i1):
 // CHECK:             pipeline.stage ^bb4
-// CHECK:           ^bb4(%[[VAL_16:.*]]: i1):
+// CHECK:           ^bb4(%[[VAL_13:.*]]: i1):
 // CHECK:             pipeline.stage ^bb5
-// CHECK:           ^bb5(%[[VAL_17:.*]]: i1):
-// CHECK:             %[[VAL_18:.*]] = comb.add %[[VAL_14]], %[[VAL_11]] {ssp.operator_type = @add1} : i32
+// CHECK:           ^bb5(%[[VAL_14:.*]]: i1):
+// CHECK:             %[[VAL_15:.*]] = pipeline.src %[[VAL_11]] : i32
+// CHECK:             %[[VAL_16:.*]] = pipeline.src %[[VAL_6]] : i32
+// CHECK:             %[[VAL_17:.*]] = comb.add %[[VAL_15]], %[[VAL_16]] {ssp.operator_type = @add1} : i32
 // CHECK:             pipeline.stage ^bb6
-// CHECK:           ^bb6(%[[VAL_19:.*]]: i1):
+// CHECK:           ^bb6(%[[VAL_18:.*]]: i1):
 // CHECK:             pipeline.stage ^bb7
-// CHECK:           ^bb7(%[[VAL_20:.*]]: i1):
-// CHECK:             pipeline.return %[[VAL_18]] : i32
+// CHECK:           ^bb7(%[[VAL_19:.*]]: i1):
+// CHECK:             %[[VAL_20:.*]] = pipeline.src %[[VAL_17]] : i32
+// CHECK:             pipeline.return %[[VAL_20]] : i32
 // CHECK:           }
 // CHECK:           hw.output %[[VAL_21:.*]] : i32
 // CHECK:         }

--- a/test/Dialect/Pipeline/errors.mlir
+++ b/test/Dialect/Pipeline/errors.mlir
@@ -210,3 +210,16 @@ hw.module @unmaterialized_latency_with_missing_src(in %arg0 : i32, in %arg1 : i3
   }
   hw.output %0 : i32
 }
+
+// -----
+
+hw.module @invalid_pipeline_src(in %arg : i32, in %go : i1, in %clk : !seq.clock, in %rst : i1) {
+  %res, %done = pipeline.scheduled(%a0 : i32 = %arg) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
+     pipeline.stage ^bb1 regs(%a0 : i32)
+   ^bb1(%0 : i32, %s1_enable : i1):
+      // expected-error @below {{'pipeline.src' op Pipeline is in register materialized mode - pipeline.src operations are not allowed}}
+      %a0_bb1 = pipeline.src %a0 : i32
+      pipeline.return %0 : i32
+  }
+  hw.output
+}

--- a/test/Dialect/Pipeline/errors.mlir
+++ b/test/Dialect/Pipeline/errors.mlir
@@ -27,7 +27,8 @@ hw.module @unterminated(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clk : !
     %0 = comb.add %a0, %a1 : i32
 
   ^bb1(%s1_enable : i1):
-    pipeline.stage ^bb2 regs(%0 : i32)
+    %bb1_0 = pipeline.src %0 : i32
+    pipeline.stage ^bb2 regs(%bb1_0 : i32)
 
   ^bb2(%s2_s0 : i32, %s2_enable : i1):
     pipeline.return %s2_s0 : i32
@@ -43,7 +44,7 @@ hw.module @mixed_stages(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clk : !
     pipeline.stage ^bb1
 
   ^bb1(%s1_enable : i1):
-  // expected-error @+1 {{'pipeline.stage' op Pipeline is in register materialized mode - operand 0 is defined in a different stage, which is illegal.}}
+  // expected-error @+1 {{'pipeline.stage' op operand 0 is defined in a different stage. Value should have been passed through block arguments}}
     pipeline.stage ^bb2 regs(%0: i32)
 
   ^bb2(%s2_s0 : i32, %s2_enable : i1):
@@ -100,42 +101,13 @@ hw.module @earlyAccess(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk : !seq.
     }
     pipeline.stage ^bb1
   ^bb1(%s1_enable : i1):
-    // expected-note@+1 {{use was operand 0. The result is available 1 stages later than this use.}}
-    pipeline.return %1 : i32
+    // expected-note@below {{use was operand 0. The result is available 1 stages later than this use.}}
+    %bb1_1 = pipeline.src %1 : i32
+    pipeline.return %bb1_1 : i32
   }
   hw.output %0#0 : i32
 }
 
-// -----
-
-// Test which verifies that the values referenced within the body of a
-// latency operation also adhere to the latency constraints.
-hw.module @earlyAccess2(in %arg0: i32, in %arg1: i32, in %go: i1, in %clk : !seq.clock, in %rst: i1, out out: i32) {
-  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
-    // expected-error @+1 {{'pipeline.latency' op result 0 is used before it is available.}}
-    %1 = pipeline.latency 2 -> (i32) {
-      %res = comb.add %a0, %a0 : i32
-      pipeline.latency.return %res : i32
-    }
-    pipeline.stage ^bb1
-
-  ^bb1(%s1_enable : i1):
-    %2 = pipeline.latency 2 -> (i32) {
-      %c1_i32 = hw.constant 1 : i32
-      // expected-note@+1 {{use was operand 0. The result is available 1 stages later than this use.}}
-      %res2 = comb.add %1, %c1_i32 : i32
-      pipeline.latency.return %res2 : i32
-    }
-    pipeline.stage ^bb2
-
-  ^bb2(%s2_enable : i1):
-    pipeline.stage ^bb3
-
-  ^bb3(%s3_enable : i1):
-    pipeline.return %2 : i32
-  }
-  hw.output %0#0 : i32
-}
 
 // -----
 
@@ -194,7 +166,8 @@ hw.module @noStallSignalWithStallability(in %arg0 : i32, in %go : i1, in %clk : 
    ^bb2(%s2_enable : i1):
     pipeline.stage ^bb3
    ^bb3(%s3_enable : i1):
-    pipeline.return %a0 : i32
+    %bb3_a0 = pipeline.src %a0 : i32
+    pipeline.return %bb3_a0 : i32
   }
   hw.output %0 : i32
 }
@@ -212,7 +185,28 @@ hw.module @incorrectStallabilitySize(in %arg0 : i32, in %go : i1, in %clk : !seq
    ^bb2(%s2_enable : i1):
     pipeline.stage ^bb3
    ^bb3(%s3_enable : i1):
-    pipeline.return %a0 : i32
+    %a0_bb3 = pipeline.src %a0 : i32
+    pipeline.return %a0_bb3 : i32
+  }
+  hw.output %0 : i32
+}
+
+// -----
+
+hw.module @unmaterialized_latency_with_missing_src(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clk : !seq.clock, in %rst : i1, out out: i32) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
+    %0 = comb.add %a0, %a1 : i32
+    pipeline.stage ^bb1
+   ^bb1(%s1_enable : i1):
+    %1 = pipeline.latency 1 -> (i32) {
+      // expected-error @below {{'comb.add' op operand 0 is defined in a different stage. Value should have been passed through a `pipeline.src` op}}
+      %2 = comb.add %0, %0 : i32
+      pipeline.latency.return %2 : i32
+    }
+    pipeline.stage ^bb2
+  ^bb2(%s2_enable : i1):
+    %bb2_1 = pipeline.src %1 : i32
+    pipeline.return %bb2_1 : i32
   }
   hw.output %0 : i32
 }

--- a/test/Dialect/Pipeline/round-trip.mlir
+++ b/test/Dialect/Pipeline/round-trip.mlir
@@ -1,15 +1,5 @@
-// RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
+// RUN: circt-opt %s --verify-roundtrip
 
-// CHECK-LABEL:  hw.module @unscheduled1
-// CHECK-NEXT:    %out, %done = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable)  -> (out : i32) {
-// CHECK-NEXT:      %0 = pipeline.latency 2 -> (i32) {
-// CHECK-NEXT:        %1 = comb.add %a0, %a1 : i32
-// CHECK-NEXT:        pipeline.latency.return %1 : i32
-// CHECK-NEXT:      }
-// CHECK-NEXT:      pipeline.return %0 : i32
-// CHECK-NEXT:    }
-// CHECK-NEXT:    hw.output %out : i32
-// CHECK-NEXT:  }
 hw.module @unscheduled1(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clk : !seq.clock, in %rst : i1, out out: i32) {
   %0:2 = pipeline.unscheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %0 = pipeline.latency 2 -> (i32) {
@@ -21,36 +11,39 @@ hw.module @unscheduled1(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clk : !
   hw.output %0 : i32
 }
 
-// CHECK-LABEL:  hw.module @scheduled1
-// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
-// CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
-// CHECK-NEXT:      pipeline.stage ^bb1
-// CHECK-NEXT:    ^bb1(%s1_enable: i1):  // pred: ^bb0
-// CHECK-NEXT:      pipeline.return %0 : i32
-// CHECK-NEXT:    }
-// CHECK-NEXT:    hw.output %out : i32
-// CHECK-NEXT:  }
+
 hw.module @scheduled1(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clk : !seq.clock, in %rst : i1, out out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
     pipeline.stage ^bb1
 
    ^bb1(%s1_enable : i1):
-    pipeline.return %0 : i32
+    %bb1_0 = pipeline.src %0 : i32
+    pipeline.return %bb1_0 : i32
+  }
+  hw.output %0 : i32
+}
+
+hw.module @scheduled_with_latency(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clk : !seq.clock, in %rst : i1, out out: i32) {
+  %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
+    %0 = comb.add %a0, %a1 : i32
+    pipeline.stage ^bb1
+   ^bb1(%s1_enable : i1):
+    %bb1_0 = pipeline.src %0 : i32
+    %1 = pipeline.latency 1 -> (i32) {
+      %2 = comb.add %bb1_0, %bb1_0 : i32
+      pipeline.latency.return %2 : i32
+    }
+    pipeline.stage ^bb2
+  ^bb2(%s2_enable : i1):
+    %bb2_1 = pipeline.src %1 : i32
+    pipeline.return %bb2_1 : i32
   }
   hw.output %0 : i32
 }
 
 
-// CHECK-LABEL:  hw.module @scheduled2
-// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
-// CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
-// CHECK-NEXT:      pipeline.stage ^bb1 regs(%0 : i32)
-// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_enable: i1):  // pred: ^bb0
-// CHECK-NEXT:      pipeline.return %s1_reg0 : i32
-// CHECK-NEXT:    }
-// CHECK-NEXT:    hw.output %out : i32
-// CHECK-NEXT:  }
+
 hw.module @scheduled2(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clk : !seq.clock, in %rst : i1, out out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     %0 = comb.add %a0, %a1 : i32
@@ -62,15 +55,7 @@ hw.module @scheduled2(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clk : !se
   hw.output %0 : i32
 }
 
-// CHECK-LABEL:  hw.module @scheduledWithPassthrough
-// CHECK-NEXT:    %out0, %out1, %done = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out0 : i32, out1 : i32) {
-// CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
-// CHECK-NEXT:      pipeline.stage ^bb1 regs(%0 : i32) pass(%a1 : i32)
-// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_pass0: i32, %s1_enable: i1):  // pred: ^bb0
-// CHECK-NEXT:      pipeline.return %s1_reg0, %s1_pass0 : i32, i32
-// CHECK-NEXT:    }
-// CHECK-NEXT:    hw.output %out0 : i32
-// CHECK-NEXT:  }
+
 hw.module @scheduledWithPassthrough(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clk : !seq.clock, in %rst : i1, out out: i32) {
   %0:3 = pipeline.scheduled(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out0: i32, out1: i32) {
     %0 = comb.add %a0, %a1 : i32
@@ -82,12 +67,7 @@ hw.module @scheduledWithPassthrough(in %arg0 : i32, in %arg1 : i32, in %go : i1,
   hw.output %0#0 : i32
 }
 
-// CHECK-LABEL:  hw.module @withStall
-// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
-// CHECK-NEXT:      pipeline.return %a0 : i32
-// CHECK-NEXT:    }
-// CHECK-NEXT:    hw.output %out : i32
-// CHECK-NEXT:  }
+
 hw.module @withStall(in %arg0 : i32, in %stall : i1, in %go : i1, in %clk : !seq.clock, in %rst : i1, out out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     pipeline.return %a0 : i32
@@ -95,14 +75,7 @@ hw.module @withStall(in %arg0 : i32, in %stall : i1, in %go : i1, in %clk : !seq
   hw.output %0 : i32
 }
 
-// CHECK-LABEL:  hw.module @withMultipleRegs
-// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
-// CHECK-NEXT:      pipeline.stage ^bb1 regs(%a0 : i32, %a0 : i32)
-// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_reg1: i32, %s1_enable: i1):  // pred: ^bb0
-// CHECK-NEXT:      pipeline.return %s1_reg0 : i32
-// CHECK-NEXT:    }
-// CHECK-NEXT:    hw.output %out : i32
-// CHECK-NEXT:  }
+
 hw.module @withMultipleRegs(in %arg0 : i32, in %stall : i1, in %go : i1, in %clk : !seq.clock, in %rst : i1, out out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     pipeline.stage ^bb1 regs(%a0 : i32, %a0 : i32)
@@ -113,17 +86,7 @@ hw.module @withMultipleRegs(in %arg0 : i32, in %stall : i1, in %go : i1, in %clk
   hw.output %0 : i32
 }
 
-// CHECK-LABEL:  hw.module @withClockGates
-// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
-// CHECK-NEXT:      %true = hw.constant true
-// CHECK-NEXT:      %true_0 = hw.constant true
-// CHECK-NEXT:      %true_1 = hw.constant true
-// CHECK-NEXT:      pipeline.stage ^bb1 regs(%a0 : i32 gated by [%true], %a0 : i32, %a0 : i32 gated by [%true_0, %true_1])
-// CHECK-NEXT:    ^bb1(%s1_reg0: i32, %s1_reg1: i32, %s1_reg2: i32, %s1_enable: i1):  // pred: ^bb0
-// CHECK-NEXT:      pipeline.return %s1_reg0 : i32
-// CHECK-NEXT:    }
-// CHECK-NEXT:    hw.output %out : i32
-// CHECK-NEXT:  }
+
 hw.module @withClockGates(in %arg0 : i32, in %stall : i1, in %go : i1, in %clk : !seq.clock, in %rst : i1, out out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     %true1 = hw.constant true
@@ -137,15 +100,7 @@ hw.module @withClockGates(in %arg0 : i32, in %stall : i1, in %go : i1, in %clk :
   hw.output %0 : i32
 }
 
-// CHECK-LABEL:  hw.module @withNames
-// CHECK-NEXT:    %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out : i32) {
-// CHECK-NEXT:      %0 = comb.add %a0, %a1 : i32
-// CHECK-NEXT:      pipeline.stage ^bb1 regs("myAdd" = %0 : i32, %0 : i32, "myOtherAdd" = %0 : i32)
-// CHECK-NEXT:    ^bb1(%myAdd: i32, %s1_reg1: i32, %myOtherAdd: i32, %s1_enable: i1):  // pred: ^bb0
-// CHECK-NEXT:      pipeline.return %myAdd : i32
-// CHECK-NEXT:    }
-// CHECK-NEXT:    hw.output %out : i32
-// CHECK-NEXT:  }
+
 hw.module @withNames(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clk : !seq.clock, in %rst : i1, out out: i32) {
   %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0, %a1 : i32 = %arg1) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32){
     %0 = comb.add %a0, %a1 : i32
@@ -157,8 +112,6 @@ hw.module @withNames(in %arg0 : i32, in %arg1 : i32, in %go : i1, in %clk : !seq
   hw.output %0 : i32
 }
 
-// CHECK-LABEL:   hw.module @withStallability
-// CHECK:           %out, %done = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) {stallability = [true, false, true]} -> (out : i32)
 hw.module @withStallability(in %arg0 : i32, in %go : i1, in %clk : !seq.clock, in %rst : i1, in %stall : i1, out out: i32) {
   %0:2 = pipeline.scheduled "MyPipeline"(%a0 : i32 = %arg0) stall(%stall) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable)
     {stallability = [true, false, true]}
@@ -169,27 +122,19 @@ hw.module @withStallability(in %arg0 : i32, in %go : i1, in %clk : !seq.clock, i
    ^bb2(%s2_enable : i1):
     pipeline.stage ^bb3
    ^bb3(%s3_enable : i1):
-    pipeline.return %a0 : i32
+    %bb3_0 = pipeline.src %a0 : i32
+    pipeline.return %bb3_0 : i32
   }
   hw.output %0 : i32
 }
 
-// CHECK-LABEL:  hw.module @withoutReset(in %arg0 : i32, in %stall : i1, in %go : i1, in %clk : !seq.clock, out out : i32) {
-// CHECK-NEXT:    %out, %done = pipeline.scheduled(%a0 : i32 = %arg0) clock(%clk) go(%go) entryEn(%s0_enable)  -> (out : i32) {
-// CHECK-NEXT:      pipeline.stage ^bb1  
-// CHECK-NEXT:    ^bb1(%s1_enable: i1):  // pred: ^bb0
-// CHECK-NEXT:      pipeline.return %a0 : i32
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %out_0, %done_1 = pipeline.unscheduled(%a0 : i32 = %arg0) stall(%stall) clock(%clk) go(%go) entryEn(%s0_enable)  -> (out : i32) {
-// CHECK-NEXT:      pipeline.return %a0 : i32
-// CHECK-NEXT:    }
-// CHECK-NEXT:    hw.output %out : i32
-// CHECK-NEXT:  }
+
 hw.module @withoutReset(in %arg0 : i32, in %stall : i1, in %go : i1, in %clk : !seq.clock, out out: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%clk) go(%go) entryEn(%s0_enable) -> (out: i32) {
     pipeline.stage ^bb1
    ^bb1(%s1_enable : i1):
-    pipeline.return %a0 : i32
+    %bb1_0 = pipeline.src %a0 : i32
+    pipeline.return %bb1_0 : i32
   }
 
   %1:2 = pipeline.unscheduled (%a0 : i32 = %arg0) stall (%stall) clock (%clk) go (%go) entryEn (%s0_enable) -> (out: i32) {


### PR DESCRIPTION
In anticipation of the upcoming removal of the cross-block canonicalization guards in the `comb` canonicalizers, we're introducing a `pipeline.src` operation to the pipeline dialect.

This operation is intended to alleviate the case of unintentional cross-block canonicalization when a scheduled pipeline has not yet had its registers materialized.

This operation, `pipeline.src`, effectively acts as a canonicalization boundary, creating an in-block reference to a value that is defined in a predecessor block.

This means that we can keep our existing structure for unmaterialized, scheduled pipelines - values can be referenced from _any_ predecessor op through the `pipeline.src` operation, which still allows for said values to be easily moved across stages in a retiming scenario.
Upon register materialization, these `pipeline.src` operations are trivially removed, effectively becoming the block arguments of the pipeline stages.