### PR TITLE
[FIRRTL] LowerLayers: do not emit duplicate bindfile includes

### DIFF
--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -688,3 +688,24 @@ firrtl.circuit "Top" {
   // CHECK-NOT: emit.file "layers-Top-Bound-Inline.sv"
   firrtl.module @Top() {}
 }
+
+// -----
+
+// Check that no duplicate include statements are generated.
+firrtl.circuit "Top" {
+  firrtl.layer @Layer bind {}
+
+  firrtl.module @Component() {
+    firrtl.layerblock @Layer {}
+  }
+
+  // There should only be one include statement.
+  // CHECK:     emit.file "layers-Top-Layer.sv"
+  // CHECK:     sv.include  local "layers-Component-Layer.sv"
+  // CHECK-NOT: sv.include  local "layers-Component-Layer.sv"
+  firrtl.module @Top() {
+    firrtl.instance component1 @Component()
+    firrtl.instance component2 @Component()
+  }
+}
+


### PR DESCRIPTION
When emitting bindfiles for a module, that bindfile will include the bindfiles of any module instantiated directly under it.

If a module is instantiated multiple times, we'll emit duplicate include statements. This PR modifies the bindfile creation code to avoid emitting duplicate include statements.

Fixes: #8519