### PR TITLE
[Comb][AIG] Move rewriter helpers to support and use it for AIG

### DIFF
--- a/include/circt/Support/Naming.h
+++ b/include/circt/Support/Naming.h
@@ -10,6 +10,7 @@
 #define CIRCT_SUPPORT_NAMING_H
 
 #include "circt/Support/LLVM.h"
+#include "mlir/IR/PatternMatch.h"
 
 namespace circt {
 
@@ -26,6 +27,28 @@ StringAttr chooseName(StringAttr a, StringAttr b);
 /// Choose the better name between two ops. Picks the "name" attribute as first
 /// preference, using "sv.namehint" as an alternative.
 StringAttr chooseName(Operation *a, Operation *b);
+
+/// A wrapper of `PatternRewriter::replaceOp` to propagate "sv.namehint"
+/// attribute. If a replaced op has a "sv.namehint" attribute, this function
+/// propagates the name to the new value.
+void replaceOpAndCopyNamehint(PatternRewriter &rewriter, Operation *op,
+                              Value newValue);
+
+/// A wrapper of `PatternRewriter::replaceOpWithNewOp` to propagate
+/// "sv.namehint" attribute. If a replaced op has a "sv.namehint" attribute,
+/// this function propagates the name to the new value.
+template <typename OpTy, typename... Args>
+static OpTy replaceOpWithNewOpAndCopyNamehint(PatternRewriter &rewriter,
+                                              Operation *op, Args &&...args) {
+  auto name = op->getAttrOfType<StringAttr>("sv.namehint");
+  auto newOp =
+      rewriter.replaceOpWithNewOp<OpTy>(op, std::forward<Args>(args)...);
+  if (name && !newOp->hasAttr("sv.namehint"))
+    rewriter.modifyOpInPlace(newOp,
+                             [&] { newOp->setAttr("sv.namehint", name); });
+
+  return newOp;
+}
 
 } // namespace circt
 

--- a/test/Conversion/CombToAIG/comb-to-aig-arith.mlir
+++ b/test/Conversion/CombToAIG/comb-to-aig-arith.mlir
@@ -51,10 +51,10 @@ hw.module @add_64(in %lhs: i64, in %rhs: i64, out out: i64) {
 // ALLOW_ADD-LABEL: @sub
 // ALLOW_ADD-NEXT: %[[NOT_RHS:.+]] = aig.and_inv not %rhs
 // ALLOW_ADD-NEXT: %[[CONST:.+]] = hw.constant 1 : i4
-// ALLOW_ADD-NEXT: %[[ADD:.+]] = comb.add bin %lhs, %[[NOT_RHS]], %[[CONST]]
+// ALLOW_ADD-NEXT: %[[ADD:.+]] = comb.add bin %lhs, %[[NOT_RHS]], %[[CONST]] {sv.namehint = "sub"}
 // ALLOW_ADD-NEXT: hw.output %[[ADD]]
 hw.module @sub(in %lhs: i4, in %rhs: i4, out out: i4) {
-  %0 = comb.sub %lhs, %rhs : i4
+  %0 = comb.sub %lhs, %rhs {sv.namehint = "sub"} : i4
   hw.output %0 : i4
 }
 


### PR DESCRIPTION
Move name propagation helpers from CombFolds to Support/Naming.h and rename them to better reflect their purpose of propagating "sv.namehint" attributes. Update all callers. No functional change for Comb. 