### PR TITLE
[ESI] Add get_cmake_dir to package

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/__init__.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/__init__.py
@@ -12,11 +12,12 @@ __all__ = [
     "ArrayType", "StructType", "BitsType", "UIntType", "SIntType"
 ]
 
+
 def get_cmake_dir():
-    """
+  """
     Returns the directory where the CMake files for the ESI runtime are located.
     """
-    import os
-    from pathlib import Path
-    
-    return os.path.join(os.path.dirname(__file__), "cmake")
+  import os
+  from pathlib import Path
+
+  return os.path.join(os.path.dirname(__file__), "cmake")

--- a/lib/Dialect/ESI/runtime/python/esiaccel/__init__.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/__init__.py
@@ -11,3 +11,12 @@ __all__ = [
     "AcceleratorConnection", "AppID", "Type", "BundleType", "ChannelType",
     "ArrayType", "StructType", "BitsType", "UIntType", "SIntType"
 ]
+
+def get_cmake_dir():
+    """
+    Returns the directory where the CMake files for the ESI runtime are located.
+    """
+    import os
+    from pathlib import Path
+    
+    return os.path.join(os.path.dirname(__file__), "cmake")


### PR DESCRIPTION
Just as with PyBind, this helps massively with making it easier to locate the CMake files for the ESI runtime, when we're distributing it as a pip package.
