### PR TITLE
[FIRRTL] Drop ExcludeMemFromMemToRegOfVec, unused

### DIFF
--- a/docs/Dialects/FIRRTL/RationaleFIRRTL.md
+++ b/docs/Dialects/FIRRTL/RationaleFIRRTL.md
@@ -742,9 +742,7 @@ appropriately.
 
 The `AsyncReset` pass runs right after the `MemToRegOfVec`.  It will transform
 the memory registers to async registers if the corresponding annotations are
-present.  Only if a `MemOp` had
-`sifive.enterprise.firrtl.ExcludeMemFromMemToRegOfVec`, annotation, then it is
-not converted to an async reset register.
+present.
 
 #### `firrtl.mem` Attributes
 

--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -166,8 +166,6 @@ constexpr const char *ignoreFullAsyncResetAnnoClass =
 // MemToRegOfVec Annotations
 constexpr const char *convertMemToRegOfVecAnnoClass =
     "sifive.enterprise.firrtl.ConvertMemToRegOfVecAnnotation$";
-constexpr const char *excludeMemToRegAnnoClass =
-    "sifive.enterprise.firrtl.ExcludeMemFromMemToRegOfVec";
 
 // Instance Extraction
 constexpr const char *extractBlackBoxAnnoClass =

--- a/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InferResets.cpp
@@ -1877,9 +1877,6 @@ void InferResetsPass::implementFullReset(Operation *op, FModuleOp module,
 
   // Handle reset-less registers.
   if (auto regOp = dyn_cast<RegOp>(op)) {
-    if (AnnotationSet::removeAnnotations(regOp, excludeMemToRegAnnoClass))
-      return;
-
     LLVM_DEBUG(llvm::dbgs() << "- Adding full reset to " << regOp << "\n");
     auto zero = createZeroValue(builder, regOp.getResult().getType());
     auto newRegOp = builder.create<RegResetOp>(

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -629,8 +629,6 @@ static llvm::StringMap<AnnoRecord> annotationRecords{{
     {extractSeqMemsAnnoClass, NoTargetAnnotation},
     {injectDUTHierarchyAnnoClass, NoTargetAnnotation},
     {convertMemToRegOfVecAnnoClass, NoTargetAnnotation},
-    {excludeMemToRegAnnoClass,
-     {stdResolve, applyWithoutTarget<true, MemOp, CombMemOp>}},
     {sitestBlackBoxAnnoClass, NoTargetAnnotation},
     {enumComponentAnnoClass, {noResolve, drop}},
     {enumDefAnnoClass, {noResolve, drop}},

--- a/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/MemToRegOfVec.cpp
@@ -62,8 +62,6 @@ struct MemToRegOfVecPass
 
     mod.getBodyBlock()->walk([&](MemOp memOp) {
       LLVM_DEBUG(llvm::dbgs() << "\n Memory op:" << memOp);
-      if (AnnotationSet::removeAnnotations(memOp, excludeMemToRegAnnoClass))
-        return;
 
       auto firMem = memOp.getSummary();
       // Ignore if the memory is candidate for macro replacement.

--- a/test/Dialect/FIRRTL/infer-resets.mlir
+++ b/test/Dialect/FIRRTL/infer-resets.mlir
@@ -414,7 +414,7 @@ firrtl.circuit "Top" {
     firrtl.matchingconnect %1, %in : !firrtl.uint<8>
 
     // Factoring of sync reset into mux works through subaccess op.
-    // CHECK: %reg6 = firrtl.regreset %clock, %extraReset, %14 
+    // CHECK: %reg6 = firrtl.regreset %clock, %extraReset, %14
     // CHECK: %16 = firrtl.mux(%init, %reset6, %reg6)
     // CHECK: firrtl.matchingconnect %reg6, %16
     // CHECK: %17 = firrtl.subaccess %reset6[%in]
@@ -577,8 +577,6 @@ firrtl.circuit "FullAsyncNested" {
     firrtl.matchingconnect %inst_io_in, %io_in : !firrtl.uint<8>
     // CHECK: %io_out_REG = firrtl.regreset %clock, %reset, %c0_ui8
     %io_out_REG = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
-    // CHECK: %io_out_REG_NO = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
-    %io_out_REG_NO = firrtl.reg %clock {annotations = [{class = "sifive.enterprise.firrtl.ExcludeMemFromMemToRegOfVec"}]}: !firrtl.clock, !firrtl.uint<8>
     firrtl.matchingconnect %io_out_REG, %io_in : !firrtl.uint<8>
     %0 = firrtl.add %io_out_REG, %inst_io_out : (!firrtl.uint<8>, !firrtl.uint<8>) -> !firrtl.uint<9>
     %1 = firrtl.bits %0 7 to 0 : (!firrtl.uint<9>) -> !firrtl.uint<8>
@@ -733,7 +731,7 @@ firrtl.circuit "MoveAcrossBlocks2" {
     // CHECK-NEXT: %localReset = firrtl.wire
     // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
     // CHECK-NEXT:   [[TMP:%.+]] = firrtl.asAsyncReset %ui1
-    // CHECK-NEXT:   [[TMP2:%.+]] = firrtl.node [[TMP]] : !firrtl.asyncreset 
+    // CHECK-NEXT:   [[TMP2:%.+]] = firrtl.node [[TMP]] : !firrtl.asyncreset
     // CHECK-NEXT:   firrtl.matchingconnect %localReset, [[TMP2]]
     // CHECK-NEXT: }
     // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
@@ -759,7 +757,7 @@ firrtl.circuit "MoveAcrossBlocks3" {
     // CHECK-NEXT: %reg = firrtl.regreset %clock, %localReset, [[RV]]
     // CHECK-NEXT: firrtl.when %ui1 : !firrtl.uint<1> {
     // CHECK-NEXT:   [[TMP:%.+]] = firrtl.asAsyncReset %ui1
-    // CHECK-NEXT:   [[TMP2:%.+]] = firrtl.node [[TMP]] : !firrtl.asyncreset 
+    // CHECK-NEXT:   [[TMP2:%.+]] = firrtl.node [[TMP]] : !firrtl.asyncreset
     // CHECK-NEXT:   firrtl.matchingconnect %localReset, [[TMP2]]
     // CHECK-NEXT: }
   }
@@ -1016,7 +1014,7 @@ firrtl.circuit "RefResetBundle" {
   // CHECK-LABEL: firrtl.module @RefResetBundle
   // CHECK-NOT: firrtl.reset
   firrtl.module @RefResetBundle(in %driver: !firrtl.asyncreset, out %out: !firrtl.bundle<a: reset, b: reset>) {
-  %r = firrtl.wire : !firrtl.bundle<a: reset, b flip: reset> 
+  %r = firrtl.wire : !firrtl.bundle<a: reset, b flip: reset>
   %ref_r = firrtl.ref.send %r : !firrtl.bundle<a: reset, b flip: reset>
   %reset = firrtl.ref.resolve %ref_r : !firrtl.probe<bundle<a: reset, b: reset>>
   firrtl.matchingconnect %out, %reset : !firrtl.bundle<a: reset, b: reset>
@@ -1037,7 +1035,7 @@ firrtl.circuit "RefResetSub" {
   // CHECK-LABEL: firrtl.module @RefResetSub
   // CHECK-NOT: firrtl.reset
   firrtl.module @RefResetSub(in %driver: !firrtl.asyncreset, out %out_a : !firrtl.reset, out %out_b: !firrtl.vector<reset,2>) {
-  %r = firrtl.wire : !firrtl.bundle<a: reset, b flip: vector<reset, 2>> 
+  %r = firrtl.wire : !firrtl.bundle<a: reset, b flip: vector<reset, 2>>
   %ref_r = firrtl.ref.send %r : !firrtl.bundle<a: reset, b flip: vector<reset, 2>>
   %ref_r_a = firrtl.ref.sub %ref_r[0] : !firrtl.probe<bundle<a: reset, b : vector<reset, 2>>>
   %reset_a = firrtl.ref.resolve %ref_r_a : !firrtl.probe<reset>

--- a/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
+++ b/test/Dialect/FIRRTL/mem-to-reg-of-vec.mlir
@@ -191,18 +191,6 @@ firrtl.circuit "WriteMask" attributes {annotations = [
     // CHECK:           firrtl.when %[[v16]] : !firrtl.uint<1> {
     // CHECK:             firrtl.matchingconnect %[[v14]], %[[v15]] : !firrtl.uint<8>
     // CHECK:           }
-    %mem_read1, %mem_write1 = firrtl.mem Undefined {
-      annotations = [
-        {class = "sifive.enterprise.firrtl.ExcludeMemFromMemToRegOfVec"}
-      ],
-      depth = 8 : i64,
-      name = "mem",
-      portNames = ["read", "write"],
-      readLatency = 0 : i32,
-      writeLatency = 1 : i32
-    } : !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data flip: vector<uint<8>, 2>>,
-        !firrtl.bundle<addr: uint<3>, en: uint<1>, clk: clock, data: vector<uint<8>, 2>, mask: vector<uint<1>, 2>>
-    // CHECK: %mem_read_0, %mem_write_1 = firrtl.mem Undefined {depth = 8 :
   }
 }
 


### PR DESCRIPTION
Drop an annotation-backed feature that had no users from the FIRRTL:
ExcludeMemFromMemToRegOfVec.  I deleted this internally as it had no
users.  This appears to have been created when the original pass was
ported from the SFC.
