### PR TITLE
[FIRRTL] Add moveDut field for inject DUT hier

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -595,10 +595,11 @@ Example:
 
 ### InjectDUTHierarchyAnnotation
 
-| Property | Type   | Description                                             |
-|----------|--------|---------------------------------------------------------|
-| class    | string | `sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation` |
-| name     | string | The name of the module containing original DUT logic    |
+| Property | Type    | Description                                                                                       |
+|----------|---------|---------------------------------------------------------------------------------------------------|
+| class    | string  | `sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation`                                           |
+| name     | string  | The name of the module containing original DUT logic                                              |
+| moveDut  | boolean | Optional: if true, then treat the newly created module as the DUT. If unset, then treat as false. |
 
 This annotation can be used to add an extra level of hierarchy in the design
 under the DUT (indicated with a `MarkDUTAnnotation`).  All logic in the original
@@ -607,13 +608,19 @@ used in combination with `ExtractBlackBoxAnnotation` (or with passes that add
 these annotations to extract components like clock gates or memories) to not
 intermix the original DUT contents with extracted module instantiations.
 
+If the `moveDut` field is true, then the newly created module with the specified
+`name` will be treated as the design-under-test.  The `MarkDUTAnnotation` will
+be moved to this module.  If this field is false, then the design-under-test
+will not be changed.
+
 This annotation should only appear zero or once.
 
 Example:
 ``` json
 {
   "class": "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation",
-  "name": "Logic"
+  "name": "Logic",
+  "moveDutAnno": false
 }
 ```
 

--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -620,7 +620,7 @@ Example:
 {
   "class": "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation",
   "name": "Logic",
-  "moveDutAnno": false
+  "moveDut": false
 }
 ```
 

--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -184,9 +184,7 @@ void InjectDUTHierarchy::runOnOperation() {
     // Finish setting up the DUT.  Strip the `MarkDUTAnnotation` is we are in
     // "moveDut" mode.
     if (moveDut)
-      AnnotationSet::removeAnnotations(dut, [&](Annotation anno) {
-        return anno.isClass(dutAnnoClass) && moveDut;
-      });
+      AnnotationSet::removeAnnotations(dut, dutAnnoClass);
   }
 
   // Instantiate the wrapper inside the DUT and wire it up.

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
@@ -22,6 +22,27 @@ firrtl.circuit "Top" attributes {
 
 // -----
 
+firrtl.circuit "Top" attributes {
+    annotations = [{class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Foo", moveDut = true}]
+  } {
+  // CHECK:      firrtl.module private @Foo()
+  // CHECK-SAME:   class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+  //
+  // CHECK:      firrtl.module private @DUT
+  //
+  // CHECK-NEXT:   firrtl.instance Foo {{.+}} @Foo()
+  // CHECK-NEXT: }
+  firrtl.module private @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
+
+  // CHECK:      firrtl.module @Top
+  // CHECK-NEXT:   firrtl.instance dut @DUT
+  firrtl.module @Top() {
+    firrtl.instance dut @DUT()
+  }
+}
+
+// -----
+
 // CHECK-LABEL: firrtl.circuit "NLARenaming"
 firrtl.circuit "NLARenaming" attributes {
     annotations = [{class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Foo"}]


### PR DESCRIPTION
Add a new field to the `InjectDUTHierarchyAnnotation` called `moveDut`.
This is used to control the placement of the `MarkDUTAnnotation` after the
pass runs.  This is done becasue we are exploring an internal flow which
wants to change the behavior of this pass to work this way.  We would like
to make this the default behavior, but will initially guard it with this
annotaiton option.

This patch is backwards compatible.  It will default to the old behavior
if it does not see the new field in the annotation.

This makes no changes to the placement of _other_ annotations.  I.e., if
there are annotations that were originally on the DUT, then those will
still be moved.  I went back and forth on this.  However, it shouldn't
really matter where _other_ annotations are nor should it matter where
NLAs are rooted so long as they are information preserving.  This
additionally makes the pass easier to maintain as it doesn't require
having different NLA movement logic for different annotation settings.

CC: @azidar
