### PR TITLE
[FIRRTL] Dedup: MustDedup support merging of pub+priv modules

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/Dedup.cpp
@@ -813,13 +813,10 @@ struct Equivalence {
     }
     auto aSymbol = cast<mlir::SymbolOpInterface>(a);
     auto bSymbol = cast<mlir::SymbolOpInterface>(b);
-    if (!canRemoveModule(aSymbol)) {
+    if (!canRemoveModule(aSymbol) && !canRemoveModule(bSymbol)) {
       diag.attachNote(a->getLoc())
           << "module is "
           << (aSymbol.isPrivate() ? "private but not discardable" : "public");
-      return;
-    }
-    if (!canRemoveModule(bSymbol)) {
       diag.attachNote(b->getLoc())
           << "module is "
           << (bSymbol.isPrivate() ? "private but not discardable" : "public");

--- a/test/Dialect/FIRRTL/dedup-errors.mlir
+++ b/test/Dialect/FIRRTL/dedup-errors.mlir
@@ -666,9 +666,9 @@ firrtl.circuit "InstOfEquivPublic" attributes {annotations = [{
 // expected-error @below {{module "Test1" not deduplicated with "Test0"}}
 firrtl.circuit "VisibilityDoesNotBlockDedup" attributes {annotations = [{
       class = "firrtl.transforms.MustDeduplicateAnnotation",
-      modules = ["~VisibilityDoesNotBlockDedup|Test0", "~VisibilityDoesNotBlockDedup|Test1"]
+      modules = ["~|Test0", "~|Test1"]
     }]} {
-  firrtl.module private @Test0() {
+  firrtl.module @Test0() {
     // expected-note @below {{operation result types don't match, first type is '!firrtl.uint<1>'}}
     %wire = firrtl.wire : !firrtl.uint<1>
   }

--- a/test/Dialect/FIRRTL/dedup-errors.mlir
+++ b/test/Dialect/FIRRTL/dedup-errors.mlir
@@ -643,6 +643,7 @@ firrtl.circuit "InstOfEquivPublic" attributes {annotations = [{
     }]} {
   // expected-note @below {{module is public}}
   firrtl.module public @Test0() { }
+  // expected-note @below {{module is public}}
   firrtl.module public @Test1() { }
   firrtl.module private @Test0Parent() {
     firrtl.instance test0 @Test0()
@@ -654,5 +655,29 @@ firrtl.circuit "InstOfEquivPublic" attributes {annotations = [{
   firrtl.module @InstOfEquivPublic() {
     firrtl.instance test0p @Test0Parent()
     firrtl.instance test1p @Test1Parent()
+  }
+}
+
+// -----
+
+// When comparing two modules, if one is private and the other public, we should
+// not report that as the difference, we should examine the bodies of the 
+// modules.
+// expected-error @below {{module "Test1" not deduplicated with "Test0"}}
+firrtl.circuit "VisibilityDoesNotBlockDedup" attributes {annotations = [{
+      class = "firrtl.transforms.MustDeduplicateAnnotation",
+      modules = ["~VisibilityDoesNotBlockDedup|Test0", "~VisibilityDoesNotBlockDedup|Test1"]
+    }]} {
+  firrtl.module private @Test0() {
+    // expected-note @below {{operation result types don't match, first type is '!firrtl.uint<1>'}}
+    %wire = firrtl.wire : !firrtl.uint<1>
+  }
+  firrtl.module private @Test1() {
+    // expected-note @below {{second type is '!firrtl.uint<2>'}}
+    %wire = firrtl.wire : !firrtl.uint<2>
+  }
+  firrtl.module @VisibilityDoesNotBlockDedup() {
+    firrtl.instance test0 @Test0()
+    firrtl.instance test1 @Test1()
   }
 }


### PR DESCRIPTION
We upgraded dedup to be able to merge modules where one is public, as long as the other modules were private.  The MustDedup error message was not updated to handle this change in behaviour, and still assumed that it was impossible to merge any public module with other modules.  This changes MustDedup to only detect this as a difference if neither module is marked as private.