### PR TITLE
[PyRTG] Add type wrappers

### DIFF
--- a/frontends/PyRTG/src/pyrtg/__init__.py
+++ b/frontends/PyRTG/src/pyrtg/__init__.py
@@ -5,20 +5,20 @@
 from . import tests
 from . import core
 from .tests import test, embed_comment
-from .labels import Label
+from .labels import Label, LabelType
 from .rtg import rtg
 from .rtgtest import rtgtest
 from .scf import scf
 from .index import index
-from .sets import Set
-from .integers import Integer, Bool
-from .bags import Bag
-from .sequences import sequence, Sequence, RandomizedSequence
+from .sets import Set, SetType
+from .integers import Integer, IntegerType, Bool, BoolType
+from .bags import Bag, BagType
+from .sequences import sequence, Sequence, SequenceType, RandomizedSequence, RandomizedSequenceType
 from .configs import config, Param, Config
-from .immediates import Immediate
-from .resources import IntegerRegister
-from .arrays import Array
-from .contexts import CPUCore
+from .immediates import Immediate, ImmediateType
+from .resources import IntegerRegister, IntegerRegisterType
+from .arrays import Array, ArrayType
+from .contexts import CPUCore, CPUCoreType
 from .control_flow import If, Else, EndIf, For, Foreach
-from .tuples import Tuple
-from .memories import Memory, MemoryBlock
+from .tuples import Tuple, TupleType
+from .memories import Memory, MemoryType, MemoryBlock, MemoryBlockType

--- a/frontends/PyRTG/src/pyrtg/arrays.py
+++ b/frontends/PyRTG/src/pyrtg/arrays.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 from .base import ir
 from .rtg import rtg
 from .index import index
-from .core import Value
+from .core import Value, Type
 from .integers import Integer
+from .support import _FromCirctType
 
 from typing import Union
 
@@ -25,7 +26,7 @@ class Array(Value):
 
     self._value = value
 
-  def create(elements: list[Value], element_type: ir.Type) -> Array:
+  def create(elements: list[Value], element_type: Type) -> Array:
     """
     Create an array containing the provided values. All elements must have the
     same type.
@@ -35,7 +36,8 @@ class Array(Value):
       raise TypeError(
           "all elements of an RTG array must be of the specified element type")
 
-    return rtg.ArrayCreateOp(rtg.ArrayType.get(element_type), elements)
+    return rtg.ArrayCreateOp(rtg.ArrayType.get(element_type._codegen()),
+                             elements)
 
   def __getitem__(self, i) -> Value:
     """
@@ -68,13 +70,24 @@ class Array(Value):
   def _get_ssa_value(self) -> ir.Value:
     return self._value
 
-  def get_type(self) -> ir.Type:
-    return self._value.type
+  def get_type(self) -> Type:
+    return _FromCirctType(self._value.type)
 
-  @staticmethod
-  def ty(element_type: ir.Type) -> ir.Type:
-    """
-    Returns the array type for the given element type.
-    """
 
-    return rtg.ArrayType.get(element_type)
+class ArrayType(Type):
+  """
+  Represents the type of statically typed arrays.
+
+  Fields:
+    element_type: Type
+  """
+
+  def __init__(self, element_type: Type):
+    self.element_type = element_type
+
+  def __eq__(self, other) -> bool:
+    return isinstance(other,
+                      ArrayType) and self.element_type == other.element_type
+
+  def _codegen(self) -> ir.Type:
+    return rtg.ArrayType.get(self.element_type._codegen())

--- a/frontends/PyRTG/src/pyrtg/configs.py
+++ b/frontends/PyRTG/src/pyrtg/configs.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from .core import CodeGenRoot
+from .core import CodeGenRoot, Type
 from .base import ir
 from .rtg import rtg
 
@@ -47,7 +47,7 @@ class Param:
       raise AttributeError(
           "either the 'value' or 'loader' argument must be used but not both")
 
-  def get_type(self) -> ir.Type:
+  def get_type(self) -> Type:
     if not hasattr(self, "_value"):
       raise AttributeError(
           "type can only be accesses after the config has been loaded")
@@ -114,6 +114,6 @@ class Config(CodeGenRoot):
       params.sort(key=lambda param: param.get_name())
       rtg.YieldOp([param._value for param in params])
 
-      dict_entries = [(ir.StringAttr.get(param.get_name()), param.get_type())
-                      for param in params]
+      dict_entries = [(ir.StringAttr.get(param.get_name()),
+                       param.get_type()._codegen()) for param in params]
       target_op.target = ir.TypeAttr.get(rtg.DictType.get(dict_entries))

--- a/frontends/PyRTG/src/pyrtg/contexts.py
+++ b/frontends/PyRTG/src/pyrtg/contexts.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from .rtg import rtg
 from .rtgtest import rtgtest
-from .core import Value
+from .core import Value, Type
 from .base import ir
 from .support import _FromCirctValue, _collect_values_recursively
 from .sequences import Sequence
@@ -83,7 +83,7 @@ class CPUCore(Value):
     while curr.name != 'builtin.module':
       curr = curr.parent
 
-    arg_types = [arg.get_type() for arg in args]
+    arg_types = [arg.get_type()._codegen() for arg in args]
     # TODO: we currently just assume "_context_seq" is a reserved prefix, would
     # be good to do proper name uniquing in the future
     seq_name = "_context_seq_" + _get_next_seq_num()
@@ -146,9 +146,20 @@ class CPUCore(Value):
       self = rtg.ConstantOp(self._value)
     return self._value
 
-  def get_type(self) -> ir.Type:
-    return rtgtest.CPUType.get()
+  def get_type(self) -> Type:
+    return CPUCoreType()
 
-  @staticmethod
-  def ty(*args) -> ir.Type:
+
+class CPUCoreType(Type):
+  """
+  Represents the type of CPU cores in the test environment.
+
+  This type is used for values that represent CPU cores, which can be
+  specified by hardware thread ID or represent all available cores.
+  """
+
+  def __eq__(self, other) -> bool:
+    return isinstance(other, CPUCoreType)
+
+  def _codegen(self) -> ir.Type:
     return rtgtest.CPUType.get()

--- a/frontends/PyRTG/src/pyrtg/control_flow.py
+++ b/frontends/PyRTG/src/pyrtg/control_flow.py
@@ -94,7 +94,7 @@ class If:
     # the region in its constructor.
     hasElse = self._hasElse or len(else_list) > 0
     new_if = scf.IfOp(self._cond._get_ssa_value(),
-                      [v.get_type() for v in then_list],
+                      [v.get_type()._codegen() for v in then_list],
                       hasElse=hasElse)
     for op in self._op.then_block.operations:
       new_if.operation.regions[0].blocks[0].append(op)

--- a/frontends/PyRTG/src/pyrtg/core.py
+++ b/frontends/PyRTG/src/pyrtg/core.py
@@ -17,6 +17,18 @@ class CodeGenRoot:
     assert False, "must be implemented by the subclass"
 
 
+class Type:
+  """
+  This is the base class for classes representing types of 'Value's.
+  Those are essentially wrappers around corresponding MLIR types and allow
+  constructing types and querying type properties without having an MLIR
+  context registered.
+  """
+
+  def _codegen(self) -> ir.Type:
+    assert False, "must be implemented by subclass"
+
+
 class Value:
   """
   This class wraps around MLIR SSA values to provide a more Python native
@@ -27,11 +39,7 @@ class Value:
   integer and automatically building a ConstantOp in MLIR).
   """
 
-  def get_type(self) -> ir.Type:
-    assert False, "must be implemented by subclass"
-
-  @staticmethod
-  def ty(*args: ir.Type) -> ir.Type:
+  def get_type(self) -> Type:
     assert False, "must be implemented by subclass"
 
   def _get_ssa_value(self) -> ir.Value:

--- a/frontends/PyRTG/src/pyrtg/immediates.py
+++ b/frontends/PyRTG/src/pyrtg/immediates.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from .rtg import rtg
-from .core import Value
+from .core import Value, Type
 from .base import ir
 from .integers import Integer
 
@@ -37,9 +37,23 @@ class Immediate(Value):
                                   self._value)
     return self._value
 
-  def get_type(self) -> ir.Type:
-    return rtg.ImmediateType.get(self._width)
+  def get_type(self) -> Type:
+    return ImmediateType(self._width)
 
-  @staticmethod
-  def ty(width: int) -> ir.Type:
-    return rtg.ImmediateType.get(width)
+
+class ImmediateType(Type):
+  """
+  Represents the type of immediate values with a specific bit width.
+
+  Fields:
+    width: int - The bit width of the immediate value
+  """
+
+  def __init__(self, width: int):
+    self.width = width
+
+  def __eq__(self, other) -> bool:
+    return isinstance(other, ImmediateType) and self.width == other.width
+
+  def _codegen(self) -> ir.Type:
+    return rtg.ImmediateType.get(self.width)

--- a/frontends/PyRTG/src/pyrtg/integers.py
+++ b/frontends/PyRTG/src/pyrtg/integers.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from .base import ir
-from .core import Value
+from .core import Value, Type
 from .index import index
 from .rtg import rtg
 
@@ -73,8 +73,8 @@ class Integer(Value):
   def __ge__(self, other: Integer) -> Bool:
     return index.CmpOp("uge", self._get_ssa_value(), other._get_ssa_value())
 
-  def get_type(self) -> ir.Type:
-    return ir.IndexType.get()
+  def get_type(self) -> Type:
+    return IntegerType()
 
   def _get_ssa_value(self) -> ir.Value:
     if isinstance(self._value, int):
@@ -82,12 +82,16 @@ class Integer(Value):
 
     return self._value
 
-  @staticmethod
-  def ty() -> ir.Type:
-    """
-    Returns the index type.
-    """
 
+class IntegerType(Type):
+  """
+  Represents the type of integer values.
+  """
+
+  def __eq__(self, other) -> bool:
+    return isinstance(other, IntegerType)
+
+  def _codegen(self) -> ir.Type:
     return ir.IndexType.get()
 
 
@@ -105,8 +109,8 @@ class Bool(Value):
 
     self._value = value
 
-  def get_type(self) -> ir.Type:
-    return ir.IntegerType.get_signless(1)
+  def get_type(self) -> Type:
+    return BoolType()
 
   def _get_ssa_value(self) -> ir.Value:
     if isinstance(self._value, bool):
@@ -114,10 +118,14 @@ class Bool(Value):
 
     return self._value
 
-  @staticmethod
-  def ty() -> ir.Type:
-    """
-    Returns the 'i1' type representing a boolean.
-    """
 
+class BoolType(Type):
+  """
+  Represents the type of boolean values.
+  """
+
+  def __eq__(self, other) -> bool:
+    return isinstance(other, BoolType)
+
+  def _codegen(self) -> ir.Type:
     return ir.IntegerType.get_signless(1)

--- a/frontends/PyRTG/src/pyrtg/labels.py
+++ b/frontends/PyRTG/src/pyrtg/labels.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from .base import ir
-from .core import Value
+from .core import Value, Type
 from .rtg import rtg
 from .integers import Integer
 
@@ -56,17 +56,20 @@ class Label(Value):
 
     return rtg.LabelOp(rtg.LabelVisibilityAttr.get(visibility), self._value)
 
-  def get_type(self) -> ir.Type:
-    return rtg.LabelType.get()
+  def get_type(self) -> Type:
+    return LabelType()
 
   def _get_ssa_value(self) -> ir.Value:
     return self._value
 
-  @staticmethod
-  def ty(*args: ir.Type) -> ir.Type:
-    """
-    Returns the label type.
-    """
 
-    assert len(args) == 0, "Label type does not take type arguments"
+class LabelType(Type):
+  """
+  Represents the type of label values.
+  """
+
+  def __eq__(self, other) -> bool:
+    return isinstance(other, LabelType)
+
+  def _codegen(self) -> ir.Type:
     return rtg.LabelType.get()

--- a/frontends/PyRTG/src/pyrtg/memories.py
+++ b/frontends/PyRTG/src/pyrtg/memories.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from .core import Value
+from .core import Value, Type
 from .base import ir
 from .index import index
 from .rtg import rtg
 from .integers import Integer
 from .immediates import Immediate
+from .support import _FromCirctType
 
 from typing import Union
 
@@ -40,12 +41,27 @@ class MemoryBlock(Value):
   def _get_ssa_value(self) -> ir.Value:
     return self._value
 
-  def get_type(self) -> ir.Type:
-    return self._value.type
+  def get_type(self) -> Type:
+    return _FromCirctType(self._value.type)
 
-  @staticmethod
-  def ty(address_width: int) -> ir.Type:
-    return rtg.MemoryBlockType.get(address_width)
+
+class MemoryBlockType(Type):
+  """
+  Represents the type of memory blocks.
+
+  Fields:
+    address_width: int
+  """
+
+  def __init__(self, address_width: int):
+    self.address_width = address_width
+
+  def __eq__(self, other) -> bool:
+    return isinstance(
+        other, MemoryBlockType) and self.address_width == other.address_width
+
+  def _codegen(self):
+    return rtg.MemoryBlockType.get(self.address_width)
 
 
 class Memory(Value):
@@ -91,9 +107,24 @@ class Memory(Value):
   def _get_ssa_value(self) -> ir.Value:
     return self._value
 
-  def get_type(self) -> ir.Type:
-    return self._value.type
+  def get_type(self) -> Type:
+    return _FromCirctType(self._value.type)
 
-  @staticmethod
-  def ty(address_width: int) -> ir.Type:
-    return rtg.MemoryType.get(address_width)
+
+class MemoryType(Type):
+  """
+  Represents the type of memory allocations.
+
+  Fields:
+    address_width: int
+  """
+
+  def __init__(self, address_width: int):
+    self.address_width = address_width
+
+  def __eq__(self, other) -> bool:
+    return isinstance(other,
+                      MemoryType) and self.address_width == other.address_width
+
+  def _codegen(self):
+    return rtg.MemoryType.get(self.address_width)

--- a/frontends/PyRTG/src/pyrtg/resources.py
+++ b/frontends/PyRTG/src/pyrtg/resources.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from .rtg import rtg
 from .rtgtest import rtgtest
-from .core import Value
+from .core import Value, Type
 from .base import ir
 
 
@@ -160,9 +160,17 @@ class IntegerRegister(Value):
   def _get_ssa_value(self) -> ir.Value:
     return self._value
 
-  def get_type(self) -> ir.Type:
-    return rtgtest.IntegerRegisterType.get()
+  def get_type(self) -> Type:
+    return IntegerRegisterType()
 
-  @staticmethod
-  def ty(*args) -> ir.Type:
+
+class IntegerRegisterType(Type):
+  """
+  Represents the type of integer registers.
+  """
+
+  def __eq__(self, other) -> bool:
+    return isinstance(other, IntegerRegisterType)
+
+  def _codegen(self):
     return rtgtest.IntegerRegisterType.get()

--- a/frontends/PyRTG/src/pyrtg/sequences.py
+++ b/frontends/PyRTG/src/pyrtg/sequences.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
-from .core import CodeGenRoot, Value
-from .support import _FromCirctValue
+from .core import CodeGenRoot, Value, Type
+from .support import _FromCirctValue, _FromCirctType
 from .base import ir, support
 from .rtg import rtg
 
@@ -17,7 +17,7 @@ class SequenceDeclaration(CodeGenRoot):
   location where it was defined.
   """
 
-  def __init__(self, sequence_func, arg_types: list[ir.Type]):
+  def __init__(self, sequence_func, arg_types: list[Type]):
     self.sequence_func = sequence_func
     self.arg_types = arg_types
 
@@ -69,30 +69,31 @@ class SequenceDeclaration(CodeGenRoot):
   def _codegen(self) -> None:
     self._already_generated = True
 
+    mlir_arg_types = [arg._codegen() for arg in self.arg_types]
     seq = rtg.SequenceOp(self.name,
-                         ir.TypeAttr.get(rtg.SequenceType.get(self.arg_types)))
-    block = ir.Block.create_at_start(seq.bodyRegion, self.arg_types)
+                         ir.TypeAttr.get(rtg.SequenceType.get(mlir_arg_types)))
+    block = ir.Block.create_at_start(seq.bodyRegion, mlir_arg_types)
     with ir.InsertionPoint(block):
       self.sequence_func(*[_FromCirctValue(arg) for arg in block.arguments])
 
   def _get_ssa_value(self) -> ir.Value:
-    return rtg.GetSequenceOp(rtg.SequenceType.get(self.arg_types),
+    return rtg.GetSequenceOp(self.get_type()._codegen(),
                              self.name)._get_ssa_value()
 
-  def get_type(self):
-    return rtg.SequenceType.get(self.arg_types)
+  def get_type(self) -> Type:
+    return SequenceType(self.arg_types)
 
 
-def sequence(*args: ir.Type, **kwargs):
+def sequence(args: list[Type], **kwargs):
   """
   Decorator for defining RTG sequence functions.
 
   Args:
-    *args: The types of the sequence's parameters.
+    args: The types of the sequence's parameters.
   """
 
   def wrapper(func):
-    return SequenceDeclaration(func, list(args))
+    return SequenceDeclaration(func, args)
 
   return wrapper
 
@@ -120,13 +121,17 @@ class Sequence(Value):
     """
 
     element_types = self.element_types
-    assert len(args) > 0, "At least one argument must be provided"
-    assert len(args) <= len(
-        element_types
-    ), f"Expected at most {len(element_types)} arguments, got {len(args)}"
+    if len(args) == 0:
+      raise ValueError("At least one argument must be provided")
+
+    if len(args) > len(element_types):
+      raise ValueError(
+          f"Expected at most {len(element_types)} arguments, got {len(args)}")
+
     for arg, expected_type in zip(args, element_types):
-      assert arg.get_type(
-      ) == expected_type, f"Expected argument of type {expected_type}, got {arg.get_type()}"
+      if arg.get_type() != expected_type:
+        raise TypeError(
+            f"Expected argument of type {expected_type}, got {arg.get_type()}")
 
     return rtg.SubstituteSequenceOp(self, args)
 
@@ -142,12 +147,15 @@ class Sequence(Value):
     value = self
     element_types = self.element_types
     if len(element_types) > 0:
-      assert len(args) == len(
-          element_types
-      ), f"Expected {len(element_types)} arguments, got {len(args)}"
+      if len(args) != len(element_types):
+        raise TypeError(
+            f"Expected {len(element_types)} arguments, got {len(args)}")
+
       for arg, expected_type in zip(args, element_types):
-        assert arg.get_type(
-        ) == expected_type, f"Expected argument of type {expected_type}, got {arg.get_type()}"
+        if arg.get_type() != expected_type:
+          raise TypeError(
+              f"Expected argument of type {expected_type}, got {arg.get_type()}"
+          )
 
       value = self.substitute(*args)
 
@@ -158,34 +166,44 @@ class Sequence(Value):
     Convenience method to substitute, randomize, and embed this sequence in one
     go.
     
-   Args:
+    Args:
       *args: Values to substitute for the sequence's parameters.
     """
 
     self.randomize(*args).embed()
 
-  def _get_ssa_value(self) -> ir.Value:
-    return self._value
-
   @property
-  def element_types(self) -> list[ir.Type]:
+  def element_types(self) -> list[Type]:
     """
     Returns the list of elements types for this sequence.
     """
 
-    type = support.type_to_pytype(self.get_type())
-    return [type.get_element(i) for i in range(type.num_elements)]
+    return self.get_type().element_types
 
-  def get_type(self) -> ir.Type:
-    return self._value.type
+  def _get_ssa_value(self) -> ir.Value:
+    return self._value
 
-  @staticmethod
-  def ty(*args: ir.Type) -> ir.Type:
-    """
-    Returns the sequence type with the given argument types.
-    """
+  def get_type(self) -> Type:
+    return _FromCirctType(self._value.type)
 
-    return rtg.SequenceType.get(list(args))
+
+class SequenceType(Type):
+  """
+  Represents the type of statically typed sequences.
+
+  Fields:
+    element_types: list[Type]
+  """
+
+  def __init__(self, element_types: list[Type]):
+    self.element_types = element_types
+
+  def __eq__(self, other) -> bool:
+    return isinstance(
+        other, SequenceType) and self.element_types == other.element_types
+
+  def _codegen(self):
+    return rtg.SequenceType.get([ty._codegen() for ty in self.element_types])
 
 
 class RandomizedSequence(Value):
@@ -224,15 +242,17 @@ class RandomizedSequence(Value):
   def _get_ssa_value(self) -> ir.Value:
     return self._value
 
-  def get_type(self) -> ir.Type:
-    return self._value.type
+  def get_type(self) -> Type:
+    return _FromCirctType(self._value.type)
 
-  @staticmethod
-  def ty(*args: ir.Type) -> ir.Type:
-    """
-    Returns the randomized sequence type.
-    """
 
-    assert len(
-        args) == 0, "RandomizedSequence type does not take type arguments"
+class RandomizedSequenceType(Type):
+  """
+  Represents the type of randomized sequences.
+  """
+
+  def __eq__(self, other) -> bool:
+    return isinstance(other, RandomizedSequenceType)
+
+  def _codegen(self) -> ir.Type:
     return rtg.RandomizedSequenceType.get()

--- a/frontends/PyRTG/src/pyrtg/support.py
+++ b/frontends/PyRTG/src/pyrtg/support.py
@@ -3,7 +3,9 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .base import support, ir
-from .core import Value
+from .core import Value, Type
+
+from typing import Union
 
 
 def _FromCirctValue(value: ir.Value) -> Value:
@@ -55,6 +57,61 @@ def _FromCirctValue(value: ir.Value) -> Value:
   assert False, "Unsupported value"
 
 
+def _FromCirctType(type: Union[ir.Type, Type]) -> Type:
+  if isinstance(type, Type):
+    return type
+
+  type = support.type_to_pytype(type)
+
+  from .rtg import rtg
+  from .rtgtest import rtgtest
+  if isinstance(type, rtg.ArrayType):
+    from .arrays import ArrayType
+    return ArrayType(_FromCirctType(type.element_type))
+  if isinstance(type, rtg.BagType):
+    from .bags import BagType
+    return BagType(_FromCirctType(type.element_type))
+  if isinstance(type, rtg.SetType):
+    from .sets import SetType
+    return SetType(_FromCirctType(type.element_type))
+  if isinstance(type, rtg.ImmediateType):
+    from .immediates import ImmediateType
+    return ImmediateType(type.width)
+  if isinstance(type, ir.IntegerType) and type.is_signless and type.width == 1:
+    from .integers import BoolType
+    return BoolType()
+  if isinstance(type, ir.IndexType):
+    from .integers import IntegerType
+    return IntegerType()
+  if isinstance(type, rtg.LabelType):
+    from .labels import LabelType
+    return LabelType()
+  if isinstance(type, rtg.SequenceType):
+    from .sequences import SequenceType
+    return SequenceType(
+        [_FromCirctType(type.get_element(i)) for i in range(type.num_elements)])
+  if isinstance(type, rtg.RandomizedSequenceType):
+    from .sequences import RandomizedSequenceType
+    return RandomizedSequenceType()
+  if isinstance(type, rtgtest.IntegerRegisterType):
+    from .resources import IntegerRegisterType
+    return IntegerRegisterType()
+  if isinstance(type, rtgtest.CPUType):
+    from .contexts import CPUCoreType
+    return CPUCoreType()
+  if isinstance(type, ir.TupleType):
+    from .tuples import TupleType
+    return TupleType(
+        [_FromCirctType(type.get_type(i)) for i in range(type.num_types)])
+  if isinstance(type, rtg.MemoryType):
+    from .memories import MemoryType
+    return MemoryType(type.address_width)
+  if isinstance(type, rtg.MemoryBlockType):
+    from .memories import MemoryBlockType
+    return MemoryBlockType(type.address_width)
+  raise ValueError("unsupported type")
+
+
 def _collect_values_recursively(obj, path, args, arg_names, visited):
   if obj is None or id(obj) in visited:
     return args, arg_names
@@ -101,6 +158,8 @@ def wrap_opviews_with_values(dialect, module_name, excluded=[]):
             from .sequences import SequenceDeclaration
             if isinstance(arg, (Value, SequenceDeclaration)):
               return arg._get_ssa_value()
+            if isinstance(arg, Type):
+              return arg._codegen()
             if isinstance(arg, (list, tuple)):
               return [to_circt(a) for a in arg]
             return arg

--- a/frontends/PyRTG/src/pyrtg/tests.py
+++ b/frontends/PyRTG/src/pyrtg/tests.py
@@ -38,9 +38,11 @@ class Test(CodeGenRoot):
         self.name, self.name,
         ir.TypeAttr.get(
             rtg.DictType.get([(ir.StringAttr.get(param.get_name()),
-                               param.get_type()) for param in params_sorted])))
+                               param.get_type()._codegen())
+                              for param in params_sorted])))
     block = ir.Block.create_at_start(
-        test.bodyRegion, [param.get_type() for param in params_sorted])
+        test.bodyRegion,
+        [param.get_type()._codegen() for param in params_sorted])
     new_config = []
     for param, arg in zip(params_sorted, block.arguments):
       new_config.append((param.get_name(), _FromCirctValue(arg)))

--- a/frontends/PyRTG/src/pyrtg/tuples.py
+++ b/frontends/PyRTG/src/pyrtg/tuples.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 from .base import ir
 from .rtg import rtg
-from .core import Value
+from .core import Value, Type
+from .support import _FromCirctType
 
 
 class Tuple(Value):
@@ -28,7 +29,9 @@ class Tuple(Value):
     element must be provided. Each element can be of a different type.
     """
 
-    assert len(elements) > 0, "at least one element must be present"
+    if len(elements) == 0:
+      raise ValueError("at least one element must be present")
+
     return rtg.TupleCreateOp(elements)
 
   def __getitem__(self, i) -> Value:
@@ -36,19 +39,32 @@ class Tuple(Value):
     Access an element in the tuple at the specified index (read-only).
     """
 
-    assert isinstance(i, int), "index must be a python int"
+    if not isinstance(i, int):
+      raise TypeError("index must be a python int")
+
     return rtg.TupleExtractOp(self, i)
 
   def _get_ssa_value(self) -> ir.Value:
     return self._value
 
-  def get_type(self) -> ir.Type:
-    return self._value.type
+  def get_type(self) -> Type:
+    return _FromCirctType(self._value.type)
 
-  @staticmethod
-  def ty(*args) -> ir.Type:
-    """
-    Returns the tuple type for the given element types.
-    """
 
-    return ir.TupleType.get_tuple(args)
+class TupleType(Type):
+  """
+  Represents the type of statically typed tuples.
+
+  Fields:
+    element_types: list[Type]
+  """
+
+  def __init__(self, element_types: list[Type]):
+    self.element_types = element_types
+
+  def __eq__(self, other) -> bool:
+    return isinstance(other,
+                      TupleType) and self.element_types == other.element_types
+
+  def _codegen(self) -> ir.Type:
+    return ir.TupleType.get_tuple([ty._codegen() for ty in self.element_types])

--- a/frontends/PyRTG/test/basic.py
+++ b/frontends/PyRTG/test/basic.py
@@ -2,7 +2,7 @@
 # RUN: %rtgtool% %s --seed=0 --output-format=elaborated | FileCheck %s --check-prefix=ELABORATED
 # RUN: %rtgtool% %s --seed=0 -o %t --output-format=asm && FileCheck %s --input-file=%t --check-prefix=ASM
 
-from pyrtg import test, sequence, config, Config, Param, rtg, Label, Set, Integer, Bag, rtgtest, Immediate, IntegerRegister, Array, Bool, Tuple, embed_comment, MemoryBlock, Memory
+from pyrtg import test, sequence, config, Config, Param, rtg, Label, LabelType, Set, SetType, Integer, IntegerType, Bag, rtgtest, Immediate, IntegerRegister, Array, ArrayType, Bool, BoolType, Tuple, TupleType, embed_comment, MemoryBlock, Memory
 
 # MLIR-LABEL: rtg.target @Singleton : !rtg.dict<>
 # MLIR-NEXT: }
@@ -77,14 +77,14 @@ class Tgt2(Config):
 class Tgt4(Config):
 
   arr0 = Param(loader=lambda: Array.create([Integer(
-      1), Integer(2), Integer(3)], Integer.ty())[2])
-  arr1 = Param(loader=lambda: Array.create([], Array.ty(Integer.ty())))
+      1), Integer(2), Integer(3)], IntegerType())[2])
+  arr1 = Param(loader=lambda: Array.create([], ArrayType(IntegerType())))
   arr2 = Param(loader=lambda: Array.create([
-      Array.create([Integer(y * 10 + x) for x in range(3)], Integer.ty()) for y
+      Array.create([Integer(y * 10 + x) for x in range(3)], IntegerType()) for y
       in range(2)
-  ], Array.ty(Integer.ty())))
-  arr3 = Param(loader=lambda: Array.create([Integer(2), Integer(1)], Integer.ty(
-  )).set(1, Integer(3)).size())
+  ], ArrayType(IntegerType())))
+  arr3 = Param(loader=lambda: Array.create([Integer(2), Integer(
+      1)], IntegerType()).set(1, Integer(3)).size())
 
 
 # MLIR-LABEL: rtg.sequence @seq0
@@ -94,7 +94,7 @@ class Tgt4(Config):
 # MLIR-NEXT: }
 
 
-@sequence(Set.ty(Label.ty()))
+@sequence([SetType(LabelType())])
 def seq0(set: Set):
   set.get_random().place()
 
@@ -105,12 +105,12 @@ def seq0(set: Set):
 # MLIR-NEXT: }
 
 
-@sequence()
+@sequence([])
 def seq1():
   Label.declare("s1").place()
 
 
-@sequence(Set.ty(Tuple.ty(Integer.ty(), Bool.ty())))
+@sequence([SetType(TupleType([IntegerType(), BoolType()]))])
 def seq2(set):
   pass
 
@@ -400,7 +400,7 @@ class TwoIntegers(Config):
   b = Param(loader=lambda: Integer(1))
 
 
-@sequence(Bool.ty())
+@sequence([BoolType()])
 def consumer(b):
   pass
 
@@ -421,7 +421,7 @@ def test7_bools(config):
 # MLIR-NEXT: rtg.random_number_in_range [%a, %b)
 
 
-@sequence(Integer.ty())
+@sequence([IntegerType()])
 def int_consumer(b):
   pass
 

--- a/frontends/PyRTG/test/test_contexts.py
+++ b/frontends/PyRTG/test/test_contexts.py
@@ -1,14 +1,14 @@
 # RUN: %rtgtool% %s --seed=0 --output-format=mlir | FileCheck %s
 
-from pyrtg import test, sequence, Integer, CPUCore, Sequence, config, Param, Config
+from pyrtg import test, sequence, Integer, IntegerType, CPUCore, CPUCoreType, SequenceType, config, Param, Config
 
 
-@sequence(Integer.ty())
+@sequence([IntegerType()])
 def consumer(arg):
   pass
 
 
-@sequence(CPUCore.ty(), CPUCore.ty(), Sequence.ty())
+@sequence([CPUCoreType(), CPUCoreType(), SequenceType([])])
 def switch(from_ctxt, to_ctxt, seq):
   pass
 

--- a/frontends/PyRTG/test/test_control_flow.py
+++ b/frontends/PyRTG/test/test_control_flow.py
@@ -1,9 +1,9 @@
 # RUN: %rtgtool% %s --seed=0 --output-format=mlir | FileCheck %s
 
-from pyrtg import test, sequence, Integer, Array, Bool, If, Else, EndIf, For, Foreach, config, Config, Param
+from pyrtg import test, sequence, Integer, IntegerType, Array, Bool, If, Else, EndIf, For, Foreach, config, Config, Param
 
 
-@sequence(Integer.ty())
+@sequence([IntegerType()])
 def consumer(arg):
   pass
 
@@ -149,7 +149,7 @@ def test2_for(config):
 @config
 class Config2(Config):
 
-  arr0 = Param(loader=lambda: Array.create([Integer(0)], Integer.ty()))
+  arr0 = Param(loader=lambda: Array.create([Integer(0)], IntegerType()))
 
 
 @test(Config2)
@@ -157,6 +157,6 @@ def test2_foreach(config):
   v = Integer(0)
   with Foreach(config.arr0,
                Array.create([Integer(1) for _ in range(3)],
-                            Integer.ty())) as (i, a0, a1):
+                            IntegerType())) as (i, a0, a1):
     v += a0 + a1 + i
   consumer(v)


### PR DESCRIPTION
Add python classes to represent the type of values such that the construction of MLIR types can be delayed until an MLIR context is created.