### PR TITLE
[PyRTG] Codegen sequences lazily

### DIFF
--- a/frontends/PyRTG/src/pyrtg/core.py
+++ b/frontends/PyRTG/src/pyrtg/core.py
@@ -2,19 +2,57 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+from __future__ import annotations
+
 from .base import ir
 
 
-class CodeGenRoot:
+class CodeGenObject:
+  """
+  This is the base class for classes that have to be visited during
+  codegen. Not all such objects have to be root objects but codegen may depend
+  on other objects having been visited.
+  """
+
+  _registry: list[CodeGenObject] = []
+
+  def register(self) -> None:
+    CodeGenObject._registry.append(self)
+
+  def codegen_depends_on(self) -> list[CodeGenObject]:
+    return []
+
+  @classmethod
+  def _codegen_all_instances(cls) -> None:
+    processed: set[CodeGenObject] = set()
+
+    def do_codegen(obj):
+      for dependent in obj.codegen_depends_on():
+        if dependent not in processed:
+          do_codegen(dependent)
+          processed.add(dependent)
+
+      if obj not in processed:
+        obj._codegen()
+        processed.add(obj)
+
+    for obj in cls._registry:
+      do_codegen(obj)
+
+  def _codegen(self):
+    assert False, "must be implemented by the subclass"
+
+
+class CodeGenRoot(CodeGenObject):
   """
   This is the base class for classes that have to be visited by the RTG tool
   during codegen.
   """
 
-  _already_generated: bool = False
-
-  def _codegen(self):
-    assert False, "must be implemented by the subclass"
+  def __new__(cls, *args, **kwargs):
+    inst = super().__new__(cls)
+    inst.register()
+    return inst
 
 
 class Type:

--- a/frontends/PyRTG/src/pyrtg/sequences.py
+++ b/frontends/PyRTG/src/pyrtg/sequences.py
@@ -4,13 +4,13 @@
 
 from __future__ import annotations
 
-from .core import CodeGenRoot, Value, Type
+from .core import CodeGenObject, Value, Type
 from .support import _FromCirctValue, _FromCirctType
-from .base import ir, support
+from .base import ir
 from .rtg import rtg
 
 
-class SequenceDeclaration(CodeGenRoot):
+class SequenceDeclaration(CodeGenObject):
   """
   This class is responsible for managing and generating RTG sequences. It
   encapsulates the sequence function, its argument types, and the source
@@ -32,6 +32,7 @@ class SequenceDeclaration(CodeGenRoot):
     functions.
     """
 
+    self.register()
     return Sequence(self._get_ssa_value())
 
   def substitute(self, *args: Value) -> Sequence:
@@ -67,8 +68,6 @@ class SequenceDeclaration(CodeGenRoot):
     self.get()(*args)
 
   def _codegen(self) -> None:
-    self._already_generated = True
-
     mlir_arg_types = [arg._codegen() for arg in self.arg_types]
     seq = rtg.SequenceOp(self.name,
                          ir.TypeAttr.get(rtg.SequenceType.get(mlir_arg_types)))

--- a/frontends/PyRTG/src/pyrtg/tests.py
+++ b/frontends/PyRTG/src/pyrtg/tests.py
@@ -3,7 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .base import ir
-from .core import CodeGenRoot
+from .core import CodeGenRoot, CodeGenObject
 from .rtg import rtg
 from .support import _FromCirctValue
 
@@ -19,17 +19,14 @@ class Test(CodeGenRoot):
     self.test_func = test_func
     self.config = config
 
+  def codegen_depends_on(self) -> list[CodeGenObject]:
+    return [self.config]
+
   @property
   def name(self) -> str:
     return self.test_func.__name__
 
   def _codegen(self):
-    # The config the test is referring to must be codegen'd first because only then we have guaranteed access to the param types.
-    if not self.config._already_generated:
-      self.config._codegen()
-
-    self._already_generated = True
-
     # Sort arguments by name
     params_sorted = self.config.get_params()
     params_sorted.sort(key=lambda param: param.get_name())

--- a/frontends/PyRTG/src/rtgtool/rtgtool.py
+++ b/frontends/PyRTG/src/rtgtool/rtgtool.py
@@ -120,21 +120,18 @@ def frontend_codegen(args: argparse.Namespace) -> ir.Module:
   processing.
   """
 
-  # If we get MLIR direclty, just read the file and parse the MLIR
+  # If we get MLIR directly, just read the file and parse the MLIR
   if args.input_format == InputFormat.MLIR:
     with open(args.file, 'r') as f:
       return ir.Module.parse(f.read())
 
   # Otherwise, codegen the MLIR from the python file
   if args.input_format == InputFormat.PYTHON:
-    file = import_module_from_path(Path(args.file))
+    import_module_from_path(Path(args.file))
 
     module = ir.Module.create()
     with ir.InsertionPoint(module.body):
-      for _, obj in inspect.getmembers(file):
-        if isinstance(obj,
-                      pyrtg.core.CodeGenRoot) and not obj._already_generated:
-          obj._codegen()
+      pyrtg.core.CodeGenRoot._codegen_all_instances()
     return module
 
   assert False, "input format must be one of the above"

--- a/frontends/PyRTG/test/basic.py
+++ b/frontends/PyRTG/test/basic.py
@@ -87,29 +87,6 @@ class Tgt4(Config):
       1)], IntegerType()).set(1, Integer(3)).size())
 
 
-# MLIR-LABEL: rtg.sequence @seq0
-# MLIR-SAME: ([[SET:%.+]]: !rtg.set<!rtg.isa.label>)
-# MLIR-NEXT: [[LABEL:%.+]] = rtg.set_select_random [[SET]]
-# MLIR-NEXT: rtg.label local [[LABEL]]
-# MLIR-NEXT: }
-
-
-@sequence([SetType(LabelType())])
-def seq0(set: Set):
-  set.get_random().place()
-
-
-# MLIR-LABEL: rtg.sequence @seq1
-# MLIR-NEXT: [[LABEL:%.+]] = rtg.label_decl "s1"
-# MLIR-NEXT: rtg.label local [[LABEL]]
-# MLIR-NEXT: }
-
-
-@sequence([])
-def seq1():
-  Label.declare("s1").place()
-
-
 @sequence([SetType(TupleType([IntegerType(), BoolType()]))])
 def seq2(set):
   pass
@@ -469,3 +446,26 @@ def test91_sets(config):
   seq2(Set.cartesian_product(config.a, config.b))
   int_consumer(config.c.to_set().get_random())
   int_consumer(config.a.to_bag().get_random())
+
+
+# MLIR-LABEL: rtg.sequence @seq0
+# MLIR-SAME: ([[SET:%.+]]: !rtg.set<!rtg.isa.label>)
+# MLIR-NEXT: [[LABEL:%.+]] = rtg.set_select_random [[SET]]
+# MLIR-NEXT: rtg.label local [[LABEL]]
+# MLIR-NEXT: }
+
+
+@sequence([SetType(LabelType())])
+def seq0(set: Set):
+  set.get_random().place()
+
+
+# MLIR-LABEL: rtg.sequence @seq1
+# MLIR-NEXT: [[LABEL:%.+]] = rtg.label_decl "s1"
+# MLIR-NEXT: rtg.label local [[LABEL]]
+# MLIR-NEXT: }
+
+
+@sequence([])
+def seq1():
+  Label.declare("s1").place()

--- a/frontends/PyRTG/test/test_contexts.py
+++ b/frontends/PyRTG/test/test_contexts.py
@@ -28,11 +28,8 @@ class Tgt0(Config):
   cpu0 = Param(loader=lambda: CPUCore(0))
   cpu1 = Param(loader=lambda: CPUCore(1))
 
-  @classmethod
-  def load(cls):
-    config = cls()
-    CPUCore.register_switch(CPUCore.any(), CPUCore(0), switch)
-    return config
+  def load(self):
+    CPUCore.register_switch(CPUCore.any(), CPUCore(0), switch.get())
 
 
 # CHECK-LABEL: rtg.test @test0_context_args


### PR DESCRIPTION
Don't generate IR for sequences that are not used in any of the tests in the input file.