### PR TITLE
[FIRRTL] Extract instances above DUT w/ moveDut

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ExtractInstances.cpp
@@ -166,6 +166,11 @@ struct ExtractInstancesPass
   /// create a path to the instance
   DenseMap<InnerRefAttr, InstanceOp> innerRefToInstances;
   Type stringType, pathType;
+
+  /// If set, this indicates that the `InjectDUTHierarchy` pass ran with the
+  /// `moveDut` parameter enabled.  If true, then extraction continues outside
+  /// the DUT even when extraction annotations have a wrapper module specified.
+  bool moveDut;
 };
 } // end anonymous namespace
 
@@ -190,6 +195,7 @@ void ExtractInstancesPass::runOnOperation() {
   auto *context = circuitOp->getContext();
   stringType = StringType::get(context);
   pathType = PathType::get(context);
+  moveDut = false;
 
   // Walk the IR and gather all the annotations relevant for extraction that
   // appear on instances and the instantiated modules.
@@ -232,6 +238,23 @@ static bool isAnnoInteresting(Annotation anno) {
 /// populates the corresponding lists and maps of the pass.
 void ExtractInstancesPass::collectAnnos() {
   CircuitOp circuit = getOperation();
+
+  // Find an optional `InjectDUTHierarchyAnnotation`.  If it exists, inspect the
+  // `moveDut` field.  If this is `true`, then we moved the DUT from the
+  // original DUT to the wrapper.  If this occurred, then this affecst the
+  // behavior of whether or not we stop at the DUT (now the wrapper) when we
+  // extract instances.
+  //
+  // TODO: This is tech debt.  This was accepted on condition that work is done
+  // to remove this pass.
+  AnnotationSet::removeAnnotations(circuit, [&](Annotation anno) {
+    if (!anno.isClass(injectDUTHierarchyAnnoClass))
+      return false;
+
+    if (auto moveDutAnnoAttr = anno.getMember<BoolAttr>("moveDut"))
+      moveDut = moveDutAnnoAttr.getValue();
+    return true;
+  });
 
   // Grab the clock gate extraction annotation on the circuit.
   StringRef clkgateFileName;
@@ -367,7 +390,6 @@ void ExtractInstancesPass::collectAnnos() {
       info.traceFilename = clkgateFileName;
       info.prefix = "clock_gate"; // TODO: Don't hardcode this
       info.wrapperModule = clkgateWrapperModule;
-      info.stopAtDUT = !info.wrapperModule.empty();
       for (auto *instRecord : instanceGraph->lookup(module)->uses()) {
         if (auto inst = dyn_cast<InstanceOp>(*instRecord->getInstance())) {
           LLVM_DEBUG(llvm::dbgs()
@@ -400,7 +422,6 @@ void ExtractInstancesPass::collectAnnos() {
       info.traceFilename = memoryFileName;
       info.prefix = "mem_wiring"; // TODO: Don't hardcode this
       info.wrapperModule = memoryWrapperModule;
-      info.stopAtDUT = !info.wrapperModule.empty();
       for (auto *instRecord : instanceGraph->lookup(module)->uses()) {
         if (auto inst = dyn_cast<InstanceOp>(*instRecord->getInstance())) {
           LLVM_DEBUG(llvm::dbgs()
@@ -445,7 +466,6 @@ void ExtractInstancesPass::collectAnno(InstanceOp inst, Annotation anno) {
     // CAVEAT: If the instance has a wrapper module configured then extraction
     // should stop at the DUT module instead of extracting past the DUT into the
     // surrounding test harness. This is all very ugly and hacky.
-    info.stopAtDUT = !info.wrapperModule.empty();
 
     extractionWorklist.push_back({inst, info});
     return;
@@ -512,6 +532,10 @@ void ExtractInstancesPass::extractInstances() {
       prefix = prefixSlot;
     }
 
+    /// Return true if this extraction should stop at the DUT or if it should
+    /// continue beyond it.
+    bool stopAtDUT = !moveDut && !info.wrapperModule.empty();
+
     // If the instance is already in the right place (outside the DUT, already
     // in the root module, or has hit a layer), there's nothing left for us to
     // do.  Otherwise we proceed to bubble it up one level in the hierarchy and
@@ -519,7 +543,7 @@ void ExtractInstancesPass::extractInstances() {
     if (inst->getParentOfType<LayerBlockOp>() ||
         !instanceInfo->anyInstanceInDesign(parent) ||
         instanceGraph->lookup(parent)->noUses() ||
-        (info.stopAtDUT && instanceInfo->isDut(parent))) {
+        (stopAtDUT && instanceInfo->isDut(parent))) {
       LLVM_DEBUG(llvm::dbgs() << "\nNo need to further move " << inst << "\n");
       extractedInstances.push_back({inst, info});
       continue;

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -60,6 +60,10 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
       opt.shouldSelectDefaultInstanceChoice()));
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createLowerSignaturesPass());
 
+  // This pass is _not_ idempotent.  It preserves its controlling annotation for
+  // use by ExtractInstances.  This pass should be run before ExtractInstances.
+  //
+  // TODO: This pass should be deleted.
   pm.nest<firrtl::CircuitOp>().addPass(firrtl::createInjectDUTHierarchyPass());
 
   if (!opt.shouldDisableOptimization()) {
@@ -182,6 +186,9 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
       opt.shouldReplaceSequentialMemories(),
       opt.getReplaceSequentialMemoriesFile()));
 
+  // This pass must be run after InjectDUTHierarchy.
+  //
+  // TODO: This pass should be deleted along with InjectDUTHierarchy.
   pm.addNestedPass<firrtl::CircuitOp>(firrtl::createExtractInstancesPass());
 
   // Run SymbolDCE as late as possible, but before InnerSymbolDCE. This is for

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
@@ -229,3 +229,49 @@ firrtl.circuit "Properties" attributes {
     %dut_in, %dut_out = firrtl.instance dut sym @dut @DUT(in in: !firrtl.integer, out out: !firrtl.integer)
   }
 }
+
+// -----
+
+firrtl.circuit "PublicMoveDutFalse" attributes {
+  annotations = [
+    {
+      class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation",
+      name = "Foo",
+      moveDut = false
+    }
+  ]
+} {
+  // CHECK: firrtl.module private @Foo()
+  // CHECK: firrtl.module @DUT()
+  firrtl.module @DUT() attributes {
+    annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
+    ]
+  } {}
+  firrtl.module @PublicMoveDutFalse() {
+    firrtl.instance dut @DUT()
+  }
+}
+
+// -----
+
+firrtl.circuit "PublicMoveDutFalse" attributes {
+  annotations = [
+    {
+      class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation",
+      name = "Foo",
+      moveDut = true
+    }
+  ]
+} {
+  // CHECK: firrtl.module @Foo()
+  // CHECK: firrtl.module private @DUT()
+  firrtl.module @DUT() attributes {
+    annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
+    ]
+  } {}
+  firrtl.module @PublicMoveDutFalse() {
+    firrtl.instance dut @DUT()
+  }
+}

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
@@ -1,6 +1,7 @@
 // RUN: circt-opt -pass-pipeline='builtin.module(firrtl.circuit(firrtl-inject-dut-hier))' -split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: firrtl.circuit "Top"
+// CHECK-SAME:    {class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Foo"}
 firrtl.circuit "Top" attributes {
     annotations = [{class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Foo"}]
   } {

--- a/test/firtool/extract-instances.fir
+++ b/test/firtool/extract-instances.fir
@@ -1,0 +1,254 @@
+; RUN: firtool -split-input-file %s | FileCheck %s
+
+; End-to-end tests of instance extraction.  This tests combinations of the
+; `moveDut` behavior along with whether or not a grouping module is specified.
+; This only tests blackboxes (not clock gates or memories) as this keeps the
+; test terser.  This assumes that this generalizes to memories and clock gates
+; correctly.
+
+FIRRTL version 5.1.0
+circuit Top: %[[
+  {
+    "class": "sifive.enterprise.firrtl.TestBenchDirAnnotation",
+    "dirname": "testbench"
+  },
+  {
+    "class":"sifive.enterprise.firrtl.MarkDUTAnnotation",
+    "target":"~|Foo"
+  },
+  {
+    "class":"sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation",
+    "name":"Logic",
+    "moveDut": false
+    },
+  {
+    "class": "sifive.enterprise.firrtl.ExtractBlackBoxAnnotation",
+    "target": "~|BlackBox",
+    "filename": "BlackBoxes.txt",
+    "prefix": "bb",
+    "dest": "BlackBoxes"
+  }
+]]
+
+  extmodule BlackBox:
+    output a: UInt<1>
+
+  module Bar:
+    output a: UInt<1>
+
+    inst blackbox of BlackBox
+    connect a, blackbox.a
+
+  module Foo:
+    output a: UInt<1>
+
+    inst bar of Bar
+    connect a, bar.a
+
+  public module Top:
+    output a: UInt<1>
+
+    inst foo of Foo
+    connect a, foo.a
+
+; CHECK-NOT:   FILE "testbench{{.*}}Logic.sv"
+; CHECK-LABEL: module Logic(
+; CHECK-NOT:   module
+; CHECK:         Bar bar (
+
+; CHECK-NOT:   FILE "testbench{{.*}}BlackBoxes.sv"
+; CHECK-LABEL: module BlackBoxes(
+; CHECK-NOT:   module
+; CHECK:         BlackBox blackbox (
+
+; CHECK-NOT:   FILE "testbench{{.*}}Foo.sv"
+; CHECK-LABEL: module Foo(
+; CHECK-NOT:   module
+; CHECK:         BlackBoxes BlackBoxes (
+; CHECK-NOT:   module
+; CHECK:         Logic Logic
+
+; // -----
+
+FIRRTL version 5.1.0
+circuit Top: %[[
+  {
+    "class": "sifive.enterprise.firrtl.TestBenchDirAnnotation",
+    "dirname": "testbench"
+  },
+  {
+    "class":"sifive.enterprise.firrtl.MarkDUTAnnotation",
+    "target":"~|Foo"
+  },
+  {
+    "class":"sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation",
+    "name":"Logic",
+    "moveDut": true
+    },
+  {
+    "class": "sifive.enterprise.firrtl.ExtractBlackBoxAnnotation",
+    "target": "~|BlackBox",
+    "filename": "BlackBoxes.txt",
+    "prefix": "bb",
+    "dest": "BlackBoxes"
+  }
+]]
+
+  extmodule BlackBox:
+    output a: UInt<1>
+
+  module Bar:
+    output a: UInt<1>
+
+    inst blackbox of BlackBox
+    connect a, blackbox.a
+
+  module Foo:
+    output a: UInt<1>
+
+    inst bar of Bar
+    connect a, bar.a
+
+  public module Top:
+    output a: UInt<1>
+
+    inst foo of Foo
+    connect a, foo.a
+
+; CHECK-NOT:   FILE "testbench{{.*}}Logic.sv"
+; CHECK-LABEL: module Logic(
+; CHECK-NOT:   module
+; CHECK:         Bar bar (
+
+; CHECK:       FILE "testbench{{.*}}BlackBoxes.sv"
+; CHECK-LABEL: module BlackBoxes(
+; CHECK-NOT:   module
+; CHECK:         BlackBox blackbox (
+
+; CHECK:       FILE "testbench{{.*}}Foo.sv"
+; CHECK-LABEL: module Foo(
+; CHECK-NOT:   module
+; CHECK:         BlackBoxes BlackBoxes (
+; CHECK-NOT:   module
+; CHECK:         Logic Logic
+
+; // -----
+
+FIRRTL version 5.1.0
+circuit Top: %[[
+  {
+    "class": "sifive.enterprise.firrtl.TestBenchDirAnnotation",
+    "dirname": "testbench"
+  },
+  {
+    "class":"sifive.enterprise.firrtl.MarkDUTAnnotation",
+    "target":"~|Foo"
+  },
+  {
+    "class":"sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation",
+    "name":"Logic",
+    "moveDut": false
+    },
+  {
+    "class": "sifive.enterprise.firrtl.ExtractBlackBoxAnnotation",
+    "target": "~|BlackBox",
+    "filename": "BlackBoxes.txt",
+    "prefix": "bb"
+  }
+]]
+
+  extmodule BlackBox:
+    output a: UInt<1>
+
+  module Bar:
+    output a: UInt<1>
+
+    inst blackbox of BlackBox
+    connect a, blackbox.a
+
+  module Foo:
+    output a: UInt<1>
+
+    inst bar of Bar
+    connect a, bar.a
+
+  public module Top:
+    output a: UInt<1>
+
+    inst foo of Foo
+    connect a, foo.a
+
+; CHECK-NOT:   FILE "testbench{{.*}}Logic.sv"
+; CHECK-LABEL: module Logic(
+; CHECK-NOT:   module
+; CHECK:         Bar bar (
+
+; CHECK-NOT:   FILE "testbench{{.*}}Foo.sv"
+; CHECK-LABEL: module Foo(
+; CHECK-NOT:   module
+; CHECK:         Logic Logic
+
+; CHECK:       FILE "testbench{{.*}}Top.sv"
+; CHECK-LABEL: module Top(
+; CHECK-NOT:   module
+; CHECK:         Foo foo (
+; CHECK-NOT:   module
+; CHECK:         BlackBox blackbox (
+
+; // -----
+
+FIRRTL version 5.1.0
+circuit Top: %[[
+  {
+    "class": "sifive.enterprise.firrtl.TestBenchDirAnnotation",
+    "dirname": "testbench"
+  },
+  {
+    "class":"sifive.enterprise.firrtl.MarkDUTAnnotation",
+    "target":"~|Foo"
+  },
+  {
+    "class":"sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation",
+    "name":"Logic",
+    "moveDut": true
+    },
+  {
+    "class": "sifive.enterprise.firrtl.ExtractBlackBoxAnnotation",
+    "target": "~|BlackBox",
+    "filename": "BlackBoxes.txt",
+    "prefix": "bb"
+  }
+]]
+
+  extmodule BlackBox:
+    output a: UInt<1>
+
+  module Bar:
+    output a: UInt<1>
+
+    inst blackbox of BlackBox
+    connect a, blackbox.a
+
+  module Foo:
+    output a: UInt<1>
+
+    inst bar of Bar
+    connect a, bar.a
+
+  public module Top:
+    output a: UInt<1>
+
+    inst foo of Foo
+    connect a, foo.a
+
+; CHECK-NOT:   FILE "testbench{{.*}}Logic.sv"
+; CHECK-LABEL: module Logic(
+; CHECK-NOT:   module
+; CHECK:         Bar bar (
+
+; CHECK:       FILE "testbench{{.*}}Foo.sv"
+; CHECK-LABEL: module Foo(
+; CHECK-NOT:   module
+; CHECK:         Logic Logic (
+; CHECK-NOT:   module
+; CHECK:         BlackBox blackbox (


### PR DESCRIPTION
Preserve the controlling annotation for FIRRTL's hierarchy injection pass.
This will be used to augment the behavior of FIRRTL's instance extraction
pass.  Note: this removes the idempotent property of hierarchy injection.

Modify newly added behavior related to the `moveDut` parameter added to
`InjectDUTHierarchyAnnotation` [[1]].  Change the behavior so, when the
`moveDut` parameter in the newly preserved annotation, instances will be
extracted one level above the newly _moved_ DUT.

This adds tech debt as it repurposes instance extraction to allow for both
hierarchy injection and extraction beyond the DUT.  Previously, these were
intended to be mutually exclusive.

The tech debt is acceptable because @mwachs5 is planning to remove this
flow entirely.

[1]: 91d94336afb65330a3b9f265aa2ad3d463a19a07
