### PR TITLE
[ESI] Set mode before `connectImpl`

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Ports.cpp
@@ -46,8 +46,8 @@ void ReadChannelPort::connect(std::function<bool(MessageData)> callback,
   if (mode != Mode::Disconnected)
     throw std::runtime_error("Channel already connected");
   this->callback = callback;
-  connectImpl(bufferSize);
   mode = Mode::Callback;
+  connectImpl(bufferSize);
 }
 
 void ReadChannelPort::connect(std::optional<unsigned> bufferSize) {
@@ -70,8 +70,8 @@ void ReadChannelPort::connect(std::optional<unsigned> bufferSize) {
     }
     return true;
   };
-  connectImpl(bufferSize);
   mode = Mode::Polling;
+  connectImpl(bufferSize);
 }
 
 std::future<MessageData> ReadChannelPort::readAsync() {


### PR DESCRIPTION
`connectImpl` is shared across all connect functions. However, if `mode` is only set _after_ `connectImpl` returns, `connectImpl` doesn't have a direct way to check the connect mode (we could look for whether or not the callback has been assigned, but that's then also placing an assumption on the ordering of things in `Ports.cpp`).

Obviously we could also override the callback and non-callback connect functions, respectively, but i feel like that may be unnecessary complexity, in case `impl` functions share most of the code.