### PR TITLE
[Seq] Add a canonicalization to remove read-only memory

### DIFF
--- a/lib/Dialect/Seq/SeqOps.cpp
+++ b/lib/Dialect/Seq/SeqOps.cpp
@@ -874,9 +874,9 @@ LogicalResult FirMemOp::canonicalize(FirMemOp op, PatternRewriter &rewriter) {
     return success();
   }
 
-  if (readOnly) {
+  if (readOnly && !op.getInit()) {
     // Replace all read ports with a constant 0.
-    for (auto *user : op->getUsers()) {
+    for (auto *user : llvm::make_early_inc_range(op->getUsers())) {
       auto readOp = cast<FirMemReadOp>(user);
       Value zero = rewriter.create<hw::ConstantOp>(
           readOp.getLoc(), APInt::getZero(hw::getBitWidth(readOp.getType())));

--- a/test/Dialect/Seq/canonicalization.mlir
+++ b/test/Dialect/Seq/canonicalization.mlir
@@ -336,7 +336,7 @@ hw.module @FirMemCanonicalization(in %addr : i4, in %clock : !seq.clock, in %dat
   %mem_with_symbol = seq.firmem sym @memSym 0, 1, undefined, undefined : <16 x 32>
   seq.firmem.write_port %mem_with_symbol[%addr] = %data, clock %clock enable %true : <16 x 32>
 
-  // Test 4: Mixed read/write memory should be preserved
+  // Mixed read/write memory should be preserved
   // CHECK: %mixed_mem = seq.firmem
   // CHECK-NEXT: %[[MIXED_READ:.*]] = seq.firmem.read_port %mixed_mem
   // CHECK-NEXT: seq.firmem.write_port %mixed_mem
@@ -344,7 +344,7 @@ hw.module @FirMemCanonicalization(in %addr : i4, in %clock : !seq.clock, in %dat
   %mixed_read = seq.firmem.read_port %mixed_mem[%addr], clock %clock enable %true : <16 x 32>
   seq.firmem.write_port %mixed_mem[%addr] = %data, clock %clock enable %true : <16 x 32>
 
-  // Test 5: Memory with read-write port (read-only case)
+  // Memory with read-write port (read-only case)
   // CHECK-NOT: %rw_read_only_mem
   // CHECK-NOT: seq.firmem.read_write_port {{.*}} %rw_read_only_mem
   %rw_read_only_mem = seq.firmem 0, 1, undefined, undefined : <16 x 32>


### PR DESCRIPTION
This commit implements FirMemOp canonicalization that eliminates dead memories:
- Read-only memories are replaced with constant 0

Previously only write-only memory was handled. Also it fixes an issue that write port was eliminated even when the memory has an inner symbol.  