### PR TITLE
[FIRRTL] Prevent name propagation for register

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -41,6 +41,17 @@ static Value dropWrite(PatternRewriter &rewriter, OpResult old,
   return passthrough;
 }
 
+// Return true if it is OK to propagate the name to the operation.
+// Non-pure operations such as instances, registers, and memories are not
+// allowed to update names for name stabilities and LEC reasons.
+static bool isOkToPropagateName(Operation *op) {
+  // Conservatively disallow operations with regions to prevent performance
+  // regression due to recursive calls to sub-regions in mlir::isPure.
+  if (op->getNumRegions() != 0)
+    return false;
+  return mlir::isPure(op) || isa<NodeOp, WireOp>(op);
+}
+
 // Move a name hint from a soon to be deleted operation to a new operation.
 // Pass through the new operation to make patterns easier to write.  This cannot
 // move a name to a port (block argument), doing so would require rewriting all
@@ -52,7 +63,7 @@ static Value moveNameHint(OpResult old, Value passthrough) {
   assert(op && "passthrough must be an operation");
   Operation *oldOp = old.getOwner();
   auto name = oldOp->getAttrOfType<StringAttr>("name");
-  if (name && !name.getValue().empty())
+  if (name && !name.getValue().empty() && isOkToPropagateName(op))
     op->setAttr("name", name);
   return passthrough;
 }
@@ -91,9 +102,9 @@ static bool isUInt1(Type type) {
 static void updateName(PatternRewriter &rewriter, Operation *op,
                        StringAttr name) {
   // Should never rename InstanceOp
-  assert(!isa<InstanceOp>(op));
-  if (!name || name.getValue().empty())
+  if (!name || name.getValue().empty() || !isOkToPropagateName(op))
     return;
+  assert((!isa<InstanceOp, RegOp, RegResetOp>(op)) && "Should never rename");
   auto newName = name.getValue(); // old name is interesting
   auto newOpName = op->getAttrOfType<StringAttr>("name");
   // new name might not be interesting
@@ -1942,8 +1953,7 @@ struct FoldNodeName : public mlir::RewritePattern {
         !AnnotationSet(node).empty() || node.isForceable())
       return failure();
     auto *newOp = node.getInput().getDefiningOp();
-    // Best effort, do not rename InstanceOp
-    if (newOp && !isa<InstanceOp>(newOp))
+    if (newOp)
       updateName(rewriter, newOp, name);
     rewriter.replaceOp(node, node.getInput());
     return success();

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -3618,4 +3618,21 @@ firrtl.module private @LayerBlocks() {
   // CHECK-NOT: firrtl.layerblock @A
   firrtl.layerblock @A {}
 }
+
+// CHECK-LABEL: firrtl.module @name_prop
+firrtl.module @name_prop(in %clock: !firrtl.clock, in %next: !firrtl.uint<8>, out %out_b: !firrtl.uint<8>) {
+  // CHECK: %reg = firrtl.reg %clock : !firrtl.clock, !firrtl.uint<8>
+  %reg = firrtl.reg droppable_name %clock : !firrtl.clock, !firrtl.uint<8>
+  // CHECK-NOT: firrtl.node
+  firrtl.connect %reg, %next : !firrtl.uint<8>, !firrtl.uint<8>
+  %n = firrtl.node %reg : !firrtl.uint<8>
+  firrtl.connect %out_b, %n : !firrtl.uint<8>, !firrtl.uint<8>
+
+  // CHECK: %m = firrtl.wire
+  %wire = firrtl.wire droppable_name : !firrtl.uint<8>
+  // CHECK-NOT: firrtl.node
+  firrtl.connect %wire, %reg : !firrtl.uint<8>, !firrtl.uint<8>
+  %m = firrtl.node %wire : !firrtl.uint<8>
+  firrtl.connect %out_b, %m : !firrtl.uint<8>, !firrtl.uint<8>
+}
 }


### PR DESCRIPTION
This patch enhances the name preservation logic in FIRRTL canonicalization patterns to be more selective about which operations can have their names updated. Previously, the code was too permissive, allowing names to be updated on registers where name stability is important