### PR TITLE
[Docs][HW] Missing formatting in docs

### DIFF
--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -314,10 +314,12 @@ def HWGeneratorSchemaOp : HWOp<"generator.schema",
     multiple external tools might exist which can process it.  Generator nodes
     list attributes required by hw.module.generated instances.
 
-    For example:
+    Example:
+    ```mlir
     generator.schema @MEMORY, "Simple-Memory", ["ports", "write_latency", "read_latency"]
     module.generated @mymem, @MEMORY(ports)
       -> (ports) {write_latency=1, read_latency=1, ports=["read","write"]}
+    ```
   }];
 
   let arguments = (ins SymbolNameAttr:$sym_name, StrAttr:$descriptor,


### PR DESCRIPTION
Not sure if I could just push this to main, made a tiny PR just in case.
Added missing code formatting in docs that made the example hard to parse on the website.