### PR TITLE
[MooreToCore] Lower exponentiation to math.ipowi (PowSOpConversion)

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -533,6 +533,7 @@ def ConvertMooreToCore : Pass<"convert-moore-to-core", "mlir::ModuleOp"> {
     "llhd::LLHDDialect",
     "mlir::cf::ControlFlowDialect",
     "mlir::scf::SCFDialect",
+    "mlir::math::MathDialect",
     "sim::SimDialect",
     "verif::VerifDialect",
   ];

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/Iterators.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -22,8 +22,8 @@
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/Iterators.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
@@ -1359,8 +1359,10 @@ struct PowSOpConversion : public OpConversionPattern<PowSOp> {
     Type resultType = typeConverter->convertType(op.getResult().getType());
 
     Location loc = op.getLoc();
-    // utilize MLIR math dialect's math.ipowi to handle the exponentiation of expression
-    Value result = rewriter.create<mlir::math::IPowIOp>(loc, adaptor.getLhs(), adaptor.getRhs());
+    // utilize MLIR math dialect's math.ipowi to handle the exponentiation of
+    // expression
+    Value result = rewriter.create<mlir::math::IPowIOp>(loc, adaptor.getLhs(),
+                                                        adaptor.getRhs());
 
     rewriter.replaceOp(op, result);
 

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1361,13 +1361,8 @@ struct PowSOpConversion : public OpConversionPattern<PowSOp> {
     Location loc = op.getLoc();
     // utilize MLIR math dialect's math.ipowi to handle the exponentiation of
     // expression
-    Value result = rewriter.create<mlir::math::IPowIOp>(loc, adaptor.getLhs(),
-                                                        adaptor.getRhs());
-    // cast the result back to MooreToCore i32 type; result is originally
-    // math.ipowi regular i32 so we need to revert it back
-    Value castedResult = rewriter.create<ConversionOp>(loc, resultType, result);
-
-    rewriter.replaceOp(op, castedResult);
+    rewriter.replaceOpWithNewOp<mlir::math::IPowIOp>(
+        op, resultType, adaptor.getLhs(), adaptor.getRhs());
     return success();
   }
 };

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1363,9 +1363,11 @@ struct PowSOpConversion : public OpConversionPattern<PowSOp> {
     // expression
     Value result = rewriter.create<mlir::math::IPowIOp>(loc, adaptor.getLhs(),
                                                         adaptor.getRhs());
+    // cast the result back to MooreToCore i32 type; result is originally
+    // math.ipowi regular i32 so we need to revert it back
+    Value castedResult = rewriter.create<ConversionOp>(loc, resultType, result);
 
-    rewriter.replaceOp(op, result);
-
+    rewriter.replaceOp(op, castedResult);
     return success();
   }
 };
@@ -1609,6 +1611,7 @@ static void populateLegality(ConversionTarget &target,
   target.addLegalDialect<hw::HWDialect>();
   target.addLegalDialect<llhd::LLHDDialect>();
   target.addLegalDialect<mlir::BuiltinDialect>();
+  target.addLegalDialect<mlir::math::MathDialect>();
   target.addLegalDialect<sim::SimDialect>();
   target.addLegalDialect<verif::VerifDialect>();
 

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1120,13 +1120,7 @@ func.func @PowUOp(%arg0: !moore.l32, %arg1: !moore.l32) {
 
 // CHECK-LABEL: func.func @PowSOp
 func.func @PowSOp(%arg0: !moore.i32, %arg1: !moore.i32) {
-  // CHECK: [[COND:%.+]] = comb.icmp slt %arg1, %{{.*}} : i32
-  // CHECK: [[BASE:%.+]] = comb.mux [[COND]], %{{.*}}, %arg0 : i32
-  // CHECK: [[EXP:%.+]] = comb.mux [[COND]], %{{.*}}, %arg1 : i32
-
-  // CHECK: %{{.*}} = scf.for %{{.*}} = %{{.*}} to [[EXP]] step %{{.*}} iter_args([[VAR:%.+]] = %{{.*}}) -> (i32)  : i32 {
-  // CHECK: [[MUL:%.+]] = comb.mul [[BASE]], [[VAR]] : i32
-  // CHECK: scf.yield [[MUL]] : i32
+  // CHECK: %[[RES:.*]] = math.ipowi %arg0, %arg1 : i32
   %0 = moore.pows %arg0, %arg1 : i32
   return
 }

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1143,15 +1143,9 @@ moore.module @blockArgAsObservedValue(in %in0: !moore.i32, in %in1: !moore.i32) 
   // CHECK: [[PRB:%.+]] = llhd.prb %var : !hw.inout<i32>
   // CHECK: llhd.process
   moore.procedure always_comb {
-    // CHECK: ^bb1:  // 2 preds: ^bb0, ^bb5
-      // CHECK: [[COND:%.+]] = comb.icmp slt %in1, %{{.*}} : i32
-      // CHECK: comb.mux [[COND]], %{{.*}}, %in0 : i32
-      // CHECK: comb.mux [[COND]], %{{.*}}, %in1 : i32
-    %0 = moore.pows %in0, %in1 : !moore.i32
-    moore.blocking_assign %var, %0 : !moore.i32
-    
-    // CHECK: ^bb5:  // pred: ^bb4
-    // CHECK:   llhd.wait (%in0, %in1, [[PRB]] : i32, i32, i32), ^bb1
-    moore.return
+      %0 = moore.add %in0, %in1 : !moore.i32
+      moore.blocking_assign %var, %0 : !moore.i32
+      // CHECK:   llhd.wait (%in0, %in1, [[PRB]] : i32, i32, i32), ^bb1
+      moore.return
   }
 }


### PR DESCRIPTION
This pull request addresses part of #8476. I have removed the for-loop logic from the signed integer conversion and replaced it directly with `math.ipowi` from MLIR's Math dialect, which handles the exponentiation logic for us. I also included the `mlir.math` dialect header in the MooreToCore.cpp conversion file.

I have some concerns, however this might be related to my lack of experience with the codebase (and admittedly MLIR as a whole).
- The code builds, however the tests (test/Conversion/MooreToCore/basic.mlir) fail. This may be due to a type discrepancy in what the original logic returns and what `math.ipowi` returns.
-  If there is a type discrepancy, I am unsure if I was supposed to maybe convert the result back to the original type, and also not sure of how to change the tests to reflect the changes I have made here.

Any feedback helps, thank you for your time!