### PR TITLE
[circt-verilog] Add updated LLHD passes to the pipeline

### DIFF
--- a/test/circt-verilog/registers.sv
+++ b/test/circt-verilog/registers.sv
@@ -1,0 +1,64 @@
+// RUN: circt-verilog %s | FileCheck %s
+// REQUIRES: slang
+
+// CHECK-LABEL: hw.module @ClockPosEdgeAlwaysFF(
+module ClockPosEdgeAlwaysFF(input logic clock, input int d, output int q);
+  // CHECK: [[CLK:%.+]] = seq.to_clock %clock
+  // CHECK: [[REG:%.+]] = seq.compreg %d, [[CLK]] : i32
+  // CHECK: hw.output [[REG]]
+  always_ff @(posedge clock) q <= d;
+endmodule
+
+// CHECK-LABEL: hw.module @ClockPosEdge(
+module ClockPosEdge(input logic clock, input int d, output int q);
+  // CHECK: [[CLK:%.+]] = seq.to_clock %clock
+  // CHECK: [[REG:%.+]] = seq.compreg %d, [[CLK]] : i32
+  // CHECK: hw.output [[REG]]
+  always @(posedge clock) q <= d;
+endmodule
+
+// CHECK-LABEL: hw.module @ClockNegEdge(
+module ClockNegEdge(input logic clock, input int d, output int q);
+  // CHECK: [[CLK:%.+]] = seq.to_clock %clock
+  // CHECK: [[CLK_INV:%.+]] = seq.clock_inv [[CLK]]
+  // CHECK: [[REG:%.+]] = seq.compreg %d, [[CLK_INV]] : i32
+  // CHECK: hw.output [[REG]]
+  always @(negedge clock) q <= d;
+endmodule
+
+// CHECK-LABEL: hw.module @ActiveHighReset(
+module ActiveHighReset(input logic clock, input logic reset, input int d1, input int d2, output int q1, output int q2);
+  // CHECK: [[CLK:%.+]] = seq.to_clock %clock
+  // CHECK: [[REG1:%.+]] = seq.compreg %d1, [[CLK]] reset %reset, %c42_i32 : i32
+  // CHECK: [[REG2:%.+]] = seq.compreg %d2, [[CLK]] reset %reset, %c42_i32 : i32
+  // CHECK: hw.output [[REG1]], [[REG2]]
+  always @(posedge clock, posedge reset) if (reset) q1 <= 42; else q1 <= d1;
+  always @(posedge clock, posedge reset) q2 <= reset ? 42 : d2;
+endmodule
+
+// CHECK-LABEL: hw.module @ActiveLowReset(
+module ActiveLowReset(input logic clock, input logic reset, input int d1, input int d2, output int q1, output int q2);
+  // CHECK: [[CLK:%.+]] = seq.to_clock %clock
+  // CHECK: [[RST_INV:%.+]] = comb.xor %reset, %true
+  // CHECK: [[REG1:%.+]] = seq.compreg %d1, [[CLK]] reset [[RST_INV]], %c42_i32 : i32
+  // CHECK: [[REG2:%.+]] = seq.compreg %d2, [[CLK]] reset [[RST_INV]], %c42_i32 : i32
+  // CHECK: hw.output [[REG1]], [[REG2]]
+  always @(posedge clock, negedge reset) if (!reset) q1 <= 42; else q1 <= d1;
+  always @(posedge clock, negedge reset) q2 <= !reset ? 42 : d2;
+endmodule
+
+// CHECK-LABEL: hw.module @Enable(
+module Enable(input logic clock, input logic enable, input int d, output int q);
+  // CHECK: [[CLK:%.+]] = seq.to_clock %clock
+  // CHECK: [[REG:%.+]] = seq.compreg.ce %d, [[CLK]], %enable : i32
+  // CHECK: hw.output [[REG]]
+  always @(posedge clock) if (enable) q <= d;
+endmodule
+
+// CHECK-LABEL: hw.module @ResetAndEnable(
+module ResetAndEnable(input logic clock, input logic reset, input logic enable, input int d, output int q);
+  // CHECK: [[CLK:%.+]] = seq.to_clock %clock
+  // CHECK: [[REG:%.+]] = seq.compreg.ce %d, [[CLK]], %enable reset %reset, %c42_i32 : i32
+  // CHECK: hw.output [[REG]]
+  always @(posedge clock, posedge reset) if (reset) q <= 42; else if (enable) q <= d;
+endmodule


### PR DESCRIPTION
Enable the LLHD passes that have been updated in the past few months in circt-verilog's pass pipeline. This contains revised versions of the Mem2Reg, Deseq, and LowerProcesses passes, alongside a new HoistSignals pass and the CombineDrives pass factored out of Sig2Reg.

This also disables the SROA pass on LLHD, moving it to only operate on Moore modules. @maerhart has been looking into fixing an upstream bug in SROA when it's used on operations in graph regions. Until that is fixed, we can just skip SROA on HW modules for now.

Also add an end-to-end test for circt-verilog to ensure that the basic forms of registers get detected and lowered properly.