### PR TITLE
[CI] Only use ccache for Release builds in nightly integration tests

### DIFF
--- a/.github/workflows/nightlyIntegrationTests.yml
+++ b/.github/workflows/nightlyIntegrationTests.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
+        # Cache only when build type is release
+        if: matrix.build-type == 'Release'
         with:
           max-size: 300M
           key: nightly-${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}


### PR DESCRIPTION
This patch modifies the nightly integration tests workflow to only use ccache when the build type is Release. This helps optimize CI resources by avoiding unnecessary caching for debug builds, which have shown cache hit rates of less than 0.5% (shown below). Cache for Nightly debug build actually consumes 4~5 GB of cache storage (I don't know why it takes so much even when max-size=300MB is specified). With this change cache for window and short-integration should be able to survive for a few days. 


https://github.com/llvm/circt/actions/runs/15732253051/job/44335935098
```
/usr/bin/ccache -s
  Cacheable calls:   3399 / 4001 (84.9[5](https://github.com/llvm/circt/actions/runs/15732253051/job/44335935098#step:14:5)%)
    Hits:              14 / 3399 ( 0.41%)
      Direct:          11 /   14 (78.57%)
      Preprocessed:     3 /   14 (21.43%)
    Misses:          3385 / 3399 (99.59%)
  Uncacheable calls:  [6](https://github.com/llvm/circt/actions/runs/15732253051/job/44335935098#step:14:6)02 / 4001 (15.05%)
  Local storage:
    Cache size (GB):  0.3 /  0.3 (100.2%)
    Cleanups:        228[7](https://github.com/llvm/circt/actions/runs/15732253051/job/44335935098#step:14:7)
    Hits:              14 / 3399 ( 0.41%)
    Misses:          33[8](https://github.com/llvm/circt/actions/runs/15732253051/job/44335935098#step:14:8)5 / 3399 (99.59%)
```

https://github.com/llvm/circt/actions/runs/15732253051/job/44335935155
```
ccache stats
  /usr/bin/ccache -s
  Cacheable calls:   3399 / 3575 (95.08%)
    Hits:              13 / 3399 ( 0.38%)
      Direct:          10 /   13 (76.92%)
      Preprocessed:     3 /   13 (23.08%)
    Misses:          3386 / 3399 (99.62%)
  Uncacheable calls:  176 / 3575 ( [4](https://github.com/llvm/circt/actions/runs/15732253051/job/44335935155#step:14:4).92%)
  Local storage:
    Cache size (GB):  0.3 /  0.3 (102.4%)
    Cleanups:        2331
    Hits:              13 / 3399 ( 0.38%)
    Misses:          338[6](https://github.com/llvm/circt/actions/runs/15732253051/job/44335935155#step:14:6) / 3399 (99.62%)
```