### PR TITLE
[LLHD] Embed procedural ops within modules into llhd.combinational ops

### DIFF
--- a/include/circt/Dialect/LLHD/Transforms/LLHDPasses.td
+++ b/include/circt/Dialect/LLHD/Transforms/LLHDPasses.td
@@ -185,4 +185,24 @@ def CombineDrivesPass : Pass<"llhd-combine-drives", "hw::HWModuleOp"> {
   ];
 }
 
+def WrapProceduralOpsPass : Pass<"llhd-wrap-procedural-ops", "hw::HWModuleOp"> {
+  let summary = "Wrap procedural ops in modules to make them inlinable";
+  let description = [{
+    Operations such as `func.call` or `scf.if` may appear in an `hw.module` body
+    directly. They cannot be inlined into the module though, since the inlined
+    function or result of converting the SCF ops to the CF dialect may create
+    control-flow operations with multiple blocks. This pass wraps such
+    operations in `llhd.combinational` ops to give them an SSACFG region to
+    inline into.
+  }];
+  let dependentDialects = [
+    "llhd::LLHDDialect",
+  ];
+  let statistics = [
+    Statistic<
+      "numOpsWrapped", "ops-wrapped", "Number of procedural ops wrapped"
+    >,
+  ];
+}
+
 #endif // CIRCT_DIALECT_LLHD_TRANSFORMS_PASSES

--- a/lib/Dialect/LLHD/Transforms/CMakeLists.txt
+++ b/lib/Dialect/LLHD/Transforms/CMakeLists.txt
@@ -13,6 +13,7 @@ add_circt_dialect_library(CIRCTLLHDTransforms
   Sig2RegPass.cpp
   TemporalCodeMotionPass.cpp
   TemporalRegions.cpp
+  WrapProceduralOps.cpp
 
   DEPENDS
   CIRCTLLHDTransformsIncGen

--- a/lib/Dialect/LLHD/Transforms/WrapProceduralOps.cpp
+++ b/lib/Dialect/LLHD/Transforms/WrapProceduralOps.cpp
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/LLHD/IR/LLHDOps.h"
+#include "circt/Dialect/LLHD/Transforms/LLHDPasses.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+namespace circt {
+namespace llhd {
+#define GEN_PASS_DEF_WRAPPROCEDURALOPSPASS
+#include "circt/Dialect/LLHD/Transforms/LLHDPasses.h.inc"
+} // namespace llhd
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+using namespace circt::llhd;
+
+namespace {
+struct WrapProceduralOpsPass
+    : public llhd::impl::WrapProceduralOpsPassBase<WrapProceduralOpsPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void WrapProceduralOpsPass::runOnOperation() {
+  for (auto &op : llvm::make_early_inc_range(getOperation().getOps())) {
+    if (!isa<scf::SCFDialect>(op.getDialect()) && !isa<func::CallOp>(op))
+      continue;
+    auto builder = OpBuilder(&op);
+    auto wrapperOp =
+        builder.create<llhd::CombinationalOp>(op.getLoc(), op.getResultTypes());
+    op.replaceAllUsesWith(wrapperOp);
+    builder.createBlock(&wrapperOp.getBody());
+    auto yieldOp = builder.create<llhd::YieldOp>(op.getLoc(), op.getResults());
+    op.moveBefore(yieldOp);
+    ++numOpsWrapped;
+  }
+}

--- a/test/Dialect/LLHD/Transforms/wrap-procedural-ops.mlir
+++ b/test/Dialect/LLHD/Transforms/wrap-procedural-ops.mlir
@@ -1,0 +1,33 @@
+// RUN: circt-opt --llhd-wrap-procedural-ops %s | FileCheck %s
+
+func.func private @someFunc(%arg0: i42, %arg1: i9001) -> (i43, i9002)
+
+// CHECK-LABEL: @Calls(
+hw.module @Calls(in %a: i42, in %b: i9001, out u: i43, out v: i9002) {
+  // CHECK-NEXT: [[TMP1:%.+]]:2 = llhd.combinational -> i43, i9002 {
+  // CHECK-NEXT:   [[TMP2:%.+]]:2 = func.call @someFunc
+  // CHECK-NEXT:   llhd.yield [[TMP2]]#0, [[TMP2]]#1
+  // CHECK-NEXT: }
+  // CHECK-NEXT: hw.output [[TMP1]]#0, [[TMP1]]#1
+  %0:2 = func.call @someFunc(%a, %b) : (i42, i9001) -> (i43, i9002)
+  hw.output %0#0, %0#1 : i43, i9002
+}
+
+// CHECK-LABEL: @Ifs(
+hw.module @Ifs(in %a: i42, in %b: i42, in %c: i1, out z: i42) {
+  // CHECK-NEXT: [[TMP1:%.+]] = llhd.combinational -> i42 {
+  // CHECK-NEXT:   [[TMP2:%.+]] = scf.if %c -> (i42) {
+  // CHECK-NEXT:     scf.yield %a
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT:     scf.yield %b
+  // CHECK-NEXT:   }
+  // CHECK-NEXT:   llhd.yield [[TMP2]]
+  // CHECK-NEXT: }
+  // CHECK-NEXT: hw.output [[TMP1]]
+  %0 = scf.if %c -> (i42) {
+    scf.yield %a : i42
+  } else {
+    scf.yield %b : i42
+  }
+  hw.output %0 : i42
+}

--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -27,6 +27,7 @@
 #include "circt/Dialect/Verif/VerifDialect.h"
 #include "circt/Support/Passes.h"
 #include "circt/Support/Version.h"
+#include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -318,6 +319,9 @@ static void populateMooreToCoreLowering(PassManager &pm) {
 
 /// Convert LLHD dialect IR into core dialect IR
 static void populateLLHDLowering(PassManager &pm) {
+  pm.addNestedPass<hw::HWModuleOp>(llhd::createWrapProceduralOpsPass());
+  pm.addPass(mlir::createSCFToControlFlowPass());
+
   auto &modulePM = pm.nest<hw::HWModuleOp>();
   // modulePM.addPass(mlir::createSROA());
   modulePM.addPass(llhd::createMem2RegPass());


### PR DESCRIPTION
Add the WrapProceduralOps pass that takes operations such as `func.call` or `scf.if` in HW module body and wraps them inside `llhd.combinational` ops. This allows those operations to be inlined or lowered to the CF dialect since the `llhd.combinational` op provides an SSACFG region.

Add the pass to the circt-verilog pipeline, alongside a lowering from SCF to CF. This makes the core dialect output of circt-verilog more regular, and will allow us to fully inline function calls and fully unroll loops in the future.