### PR TITLE
[AIG] Add AIGER runner passes for external logic solver integration

### DIFF
--- a/include/circt/Dialect/AIG/AIGPasses.td
+++ b/include/circt/Dialect/AIG/AIGPasses.td
@@ -29,4 +29,50 @@ def PrintLongestPathAnalysis : Pass<"aig-print-longest-path-analysis", "mlir::Mo
   ];
 }
 
+def AIGERRunner : Pass<"aig-runner", "hw::HWModuleOp"> {
+  let summary = "Run external logic solvers on AIGER files";
+  let description = [{
+    This pass exports the current hardware module to AIGER format, runs an
+    external logic solver on the exported file, and imports the optimized
+    results back into the MLIR module.
+
+    The solver command arguments must contain placeholder tokens that are
+    replaced at runtime:
+    - `<inputFile>`: Replaced with the path to the temporary AIGER input file
+    - `<outputFile>`: Replaced with the path where the solver should write results.
+
+    ABCRunner is a wrapper around AIGERRunner that uses ABC as the external
+    solver. Hence if the user wants to use ABC, they should use ABCRunner instead
+    of AIGERRunner.
+  }];
+  let options = [
+    Option<"solverPath", "solver-path", "std::string", "",
+           "Path to the external solver executable">,
+    ListOption<"solverArgs", "solver-args", "std::string", "">
+  ];
+
+  let dependentDialects = [
+    "circt::comb::CombDialect", "circt::hw::HWDialect", "circt::seq::SeqDialect"
+  ];
+}
+
+def ABCRunner : Pass<"abc-runner", "hw::HWModuleOp"> {
+  let summary = "Run ABC on AIGER files";
+  let description = [{
+    This pass runs ABC on AIGER files. It is a wrapper around AIGERRunner that
+    uses ABC as the external solver. It runs the following ABC commands:
+    - `read <inputFile>`: Read the AIGER file
+    - for each command in `abcCommands`, run `-q <command>`
+    - `write <outputFile>`: Write the AIGER file
+  }];
+  let options = [
+    Option<"abcPath", "abc-path", "std::string", "", "Path to the ABC executable">,
+    ListOption<"abcCommands", "abc-commands", "std::string", "">
+  ];
+
+  let dependentDialects = [
+    "circt::comb::CombDialect", "circt::hw::HWDialect", "circt::seq::SeqDialect"
+  ];
+}
+
 #endif // CIRCT_DIALECT_AIG_AIGPASSES_TD

--- a/integration_test/circt-synth/abc.mlir
+++ b/integration_test/circt-synth/abc.mlir
@@ -1,0 +1,19 @@
+// REQUIRES: yosys
+// RUN: circt-synth %s -abc-path %yosys-abc -abc-commands "balance" -top balanceTest | FileCheck %s
+// RUN: circt-opt %s --pass-pipeline='builtin.module(hw.module(abc-runner{abc-path=%yosys-abc abc-commands="balance"}))' | FileCheck %s
+
+// Test that aig commands work
+hw.module @balanceTest(in %a: i1, in %b: i1, in %c: i1, in %d: i1, out out: i1) {
+  // Create an unbalanced chain: ((a & b) & c) & d
+  // Balance should restructure this to reduce depth
+  // CHECK-LABEL: hw.module @balanceTest(in %a : i1, in %b : i1, in %c : i1, in %d : i1, out out : i1) {
+  // CHECK-NEXT:    %[[AND_INV_0:.+]] = aig.and_inv %b, %a : i1
+  // CHECK-NEXT:    %[[AND_INV_1:.+]] = aig.and_inv %d, %c : i1
+  // CHECK-NEXT:    %[[AND_INV_2:.+]] = aig.and_inv %[[AND_INV_1]], %[[AND_INV_0]] : i1
+  // CHECK-NEXT:    hw.output %[[AND_INV_2]] : i1
+  // CHECK-NEXT:  }
+  %0 = aig.and_inv %a, %b : i1
+  %1 = aig.and_inv %0, %c : i1
+  %2 = aig.and_inv %1, %d : i1
+  hw.output %2 : i1
+}

--- a/integration_test/lit.cfg.py
+++ b/integration_test/lit.cfg.py
@@ -93,8 +93,11 @@ if config.python_executable != "":
 
 # Enable yosys if it has been detected.
 if config.yosys_path != "":
-  tool_dirs.append(os.path.dirname(config.yosys_path))
+  yosys_dir = os.path.dirname(config.yosys_path)
+  tool_dirs.append(yosys_dir)
   tools.append('yosys')
+  yosys_abc_path = os.path.join(yosys_dir, "yosys-abc")
+  config.substitutions.append(('%yosys-abc', f'"{yosys_abc_path}"'))
   config.available_features.add('yosys')
 
 # Enable Icarus Verilog as a fallback if no other ieee-sim was detected.

--- a/lib/Dialect/AIG/Transforms/AIGERRunner.cpp
+++ b/lib/Dialect/AIG/Transforms/AIGERRunner.cpp
@@ -1,4 +1,4 @@
-//===- AIGERRunner.cpp - Run external logic solvers on AIGER files --------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -340,7 +340,7 @@ LogicalResult AIGERRunner::runSolver(hw::HWModuleOp module, StringRef inputPath,
   std::string executionError;
   auto solverProgram = llvm::sys::findProgramByName(solverPath);
   if (auto e = solverProgram.getError())
-    return emitError(module.getLoc(), "Failed to find solver program: ")
+    return emitError(module.getLoc(), "failed to find solver program: ")
            << solverPath.str() << ": " << e.message();
 
   // Build complete command line with program name and arguments
@@ -356,7 +356,7 @@ LogicalResult AIGERRunner::runSolver(hw::HWModuleOp module, StringRef inputPath,
 
   // Check for execution failure
   if (executionResult != 0)
-    return emitError(module.getLoc(), "Solver execution failed for module ")
+    return emitError(module.getLoc(), "solver execution failed for module ")
            << module.getModuleNameAttr() << " with error: " << executionError;
 
   return success();
@@ -369,7 +369,7 @@ LogicalResult AIGERRunner::exportToAIGER(Converter &converter,
   // Open output file for writing AIGER data
   auto outputFile = mlir::openOutputFile(outputPath);
   if (!outputFile)
-    return emitError(module.getLoc(), "Failed to open AIGER output file: ")
+    return emitError(module.getLoc(), "failed to open AIGER output file: ")
            << outputPath.str();
 
   LLVM_DEBUG(llvm::dbgs() << "Exporting module " << module.getModuleNameAttr()
@@ -398,7 +398,7 @@ LogicalResult AIGERRunner::importFromAIGER(Converter &converter,
   auto inputFile = mlir::openInputFile(inputPath);
   if (!inputFile)
     return emitError(originalModule.getLoc(),
-                     "Failed to open AIGER input file: ")
+                     "failed to open AIGER input file: ")
            << inputPath.str();
 
   // Add the file buffer to the source manager
@@ -416,7 +416,7 @@ LogicalResult AIGERRunner::importFromAIGER(Converter &converter,
   if (failed(circt::aiger::importAIGER(sourceMgr, originalModule->getContext(),
                                        timingScope, temporaryModule)))
     return emitError(originalModule.getLoc(),
-                     "Failed to import optimized AIGER file");
+                     "failed to import optimized AIGER file");
 
   // Extract the hardware module from the imported content
   auto optimizedModule =

--- a/lib/Dialect/AIG/Transforms/AIGERRunner.cpp
+++ b/lib/Dialect/AIG/Transforms/AIGERRunner.cpp
@@ -1,0 +1,520 @@
+//===- AIGERRunner.cpp - Run external logic solvers on AIGER files --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a pass that runs external logic solvers
+// (ABC/Yosys/mockturtle) on AIGER files by exporting the current module to
+// AIGER format, running the solver, and importing the results back.
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Conversion/ExportAIGER.h"
+#include "circt/Conversion/ImportAIGER.h"
+#include "circt/Dialect/AIG/AIGPasses.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/HW/HWTypes.h"
+#include "circt/Dialect/Seq/SeqTypes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/FileUtilities.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/Timing.h"
+#include "mlir/Transforms/InliningUtils.h"
+#include "mlir/Transforms/RegionUtils.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Program.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/ToolOutputFile.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace circt;
+using namespace circt::aig;
+
+#define DEBUG_TYPE "aig-runner"
+
+namespace circt {
+namespace aig {
+#define GEN_PASS_DEF_AIGERRUNNER
+#define GEN_PASS_DEF_ABCRUNNER
+#include "circt/Dialect/AIG/AIGPasses.h.inc"
+} // namespace aig
+} // namespace circt
+
+//===----------------------------------------------------------------------===//
+// Converter
+//===----------------------------------------------------------------------===//
+
+namespace {
+class Converter : public circt::aiger::ExportAIGERHandler {
+public:
+  void cleanup(hw::HWModuleOp module);
+  void integrateOptimizedModule(hw::HWModuleOp originalModule,
+                                hw::HWModuleOp optimizedModule);
+
+private:
+  Value clock;
+  // Map from operand to AIGER outputs.
+  llvm::MapVector<std::pair<Operation *, size_t>, SmallVector<int>> operandMap;
+
+  // Map from result to AIGER inputs
+  llvm::MapVector<Value, SmallVector<int>> valueMap;
+
+  llvm::SetVector<Operation *> willBeErased;
+
+  bool operandCallback(OpOperand &op, size_t bitPos,
+                       size_t outputIndex) override;
+  bool valueCallback(Value value, size_t bitPos, size_t inputIndex) override;
+  void notifyEmitted(Operation *op) override;
+  void notifyClock(Value value) override;
+};
+
+} // namespace
+
+/// Callback invoked during AIGER export for each operand bit.
+/// Maps each bit position of an operand to its corresponding AIGER output
+/// index.
+bool Converter::operandCallback(OpOperand &op, size_t bitPos,
+                                size_t outputIndex) {
+  // Create a unique key for this operand (owner operation + operand number)
+  auto operandKey = std::make_pair(op.getOwner(), op.getOperandNumber());
+  assert(op.get().getType().isInteger() && "operand is not an integer");
+
+  // Find or create entry in the operand map
+  auto *mapIterator = operandMap.find(operandKey);
+  if (mapIterator == operandMap.end()) {
+    // Initialize with -1 for all bit positions (indicating unmapped)
+    auto bitWidth = hw::getBitWidth(op.get().getType());
+    mapIterator =
+        operandMap.insert({operandKey, SmallVector<int>(bitWidth, -1)}).first;
+  }
+
+  // Map this specific bit position to the AIGER output index
+  mapIterator->second[bitPos] = outputIndex;
+  return true;
+}
+
+/// Callback invoked during AIGER export for each value bit.
+/// Maps each bit position of a value to its corresponding AIGER input index.
+bool Converter::valueCallback(Value value, size_t bitPos, size_t inputIndex) {
+  assert(value.getType().isInteger() && "value is not an integer");
+
+  // Find or create entry in the value map
+  auto *mapIterator = valueMap.find(value);
+  if (mapIterator == valueMap.end()) {
+    // Initialize with -1 for all bit positions (indicating unmapped)
+    auto bitWidth = hw::getBitWidth(value.getType());
+    mapIterator =
+        valueMap.insert({value, SmallVector<int>(bitWidth, -1)}).first;
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "Mapping value: " << value << " bitPos: " << bitPos
+                          << " inputIndex: " << inputIndex << "\n");
+
+  // Map this specific bit position to the AIGER input index
+  mapIterator->second[bitPos] = inputIndex;
+  return true;
+}
+
+/// Clean up operations marked for erasure during the conversion process.
+/// This method replaces marked operations with unrealized conversion casts
+/// and then runs dead code elimination to remove unused operations.
+void Converter::cleanup(hw::HWModuleOp module) {
+  SetVector<Operation *> operationsToErase;
+
+  // Replace all operations marked for erasure with unrealized conversion casts
+  // This allows DCE to determine if they're actually unused
+  mlir::IRRewriter rewriter(module);
+  while (!willBeErased.empty()) {
+    auto *operationToReplace = willBeErased.pop_back_val();
+    rewriter.setInsertionPoint(operationToReplace);
+
+    // Create an unrealized conversion cast as a placeholder
+    auto conversionCast =
+        rewriter.replaceOpWithNewOp<mlir::UnrealizedConversionCastOp>(
+            operationToReplace, operationToReplace->getResultTypes(),
+            ValueRange{});
+    (void)conversionCast;
+
+#ifdef DEBUG
+    // Mark the cast for verification that it gets eliminated
+    conversionCast->setAttr("aig.runner.must_be_dead", rewriter.getUnitAttr());
+#endif
+  }
+
+  // Run dead code elimination to remove unused operations
+  (void)mlir::runRegionDCE(rewriter, module->getRegions());
+
+#ifdef DEBUG
+  // Verify that all marked operations were actually eliminated
+  module.walk([&](mlir::UnrealizedConversionCastOp castOp) {
+    assert(!castOp->hasAttr("aig.runner.must_be_dead") &&
+           "Operation marked for deletion was not eliminated by DCE");
+  });
+#endif
+}
+
+/// Integrate the optimized module from AIGER import into the original module.
+/// This method handles the complex process of reconnecting multi-bit values
+/// that were decomposed during AIGER export/import.
+void Converter::integrateOptimizedModule(hw::HWModuleOp originalModule,
+                                         hw::HWModuleOp optimizedModule) {
+  mlir::IRRewriter builder(originalModule->getContext());
+  builder.setInsertionPointToStart(originalModule.getBodyBlock());
+
+  auto *optimizedTerminator = optimizedModule.getBodyBlock()->getTerminator();
+  auto *originalTerminator = originalModule.getBodyBlock()->getTerminator();
+
+  // Reconnect multi-bit operands by concatenating their individual bits
+  for (const auto &[operandKey, bitOutputIndices] : operandMap) {
+    auto [operationOwner, operandIndex] = operandKey;
+    SmallVector<Value> bitsToConcat;
+    builder.setInsertionPoint(operationOwner);
+    bitsToConcat.reserve(bitOutputIndices.size());
+
+    // Collect the optimized values for each bit (in reverse order for concat)
+    for (auto outputIndex : llvm::reverse(bitOutputIndices)) {
+      assert(outputIndex != -1 && "Unmapped output index found");
+      bitsToConcat.push_back(optimizedTerminator->getOperand(outputIndex));
+    }
+
+    // Create single value or concatenate multiple bits
+    if (bitsToConcat.size() == 1) {
+      operationOwner->setOperand(operandIndex, bitsToConcat.front());
+    } else {
+      auto concatenatedValue = builder.createOrFold<comb::ConcatOp>(
+          operationOwner->getLoc(), bitsToConcat);
+      operationOwner->setOperand(operandIndex, concatenatedValue);
+    }
+  }
+
+  // Prepare arguments for the optimized module by extracting bits from values
+  SmallVector<Value> moduleArguments(
+      optimizedModule.getBodyBlock()->getNumArguments());
+  for (const auto &[originalValue, bitInputIndices] : valueMap) {
+    builder.setInsertionPointAfterValue(originalValue);
+
+    // Extract each bit from the multi-bit value
+    for (auto [bitPosition, argumentIndex] : llvm::enumerate(bitInputIndices)) {
+      // TODO: Consider caching extract operations for efficiency
+      auto extractedBit = builder.createOrFold<comb::ExtractOp>(
+          originalValue.getLoc(), originalValue, bitPosition, 1);
+      moduleArguments[argumentIndex] = extractedBit;
+    }
+  }
+
+  // Handle clock signal if present (always the last argument)
+  auto arguments = optimizedModule.getBodyBlock()->getArguments();
+  if (arguments.size() > 0 && isa<seq::ClockType>(arguments.back().getType())) {
+    assert(clock && "Clock signal not found");
+    moduleArguments.back() = clock;
+  }
+
+  // Verify all arguments are properly mapped
+  assert(llvm::all_of(moduleArguments, [](Value v) { return v; }) &&
+         "Some module arguments were not properly mapped");
+
+  // Inline the optimized module into the original module
+  builder.inlineBlockBefore(optimizedModule.getBodyBlock(),
+                            originalModule.getBodyBlock(),
+                            originalTerminator->getIterator(), moduleArguments);
+  optimizedTerminator->erase();
+}
+
+/// Callback invoked when an operation is emitted during AIGER export.
+/// Marks the operation for potential cleanup since it may become unused
+/// after the optimization process replaces it with optimized equivalents.
+void Converter::notifyEmitted(Operation *op) { willBeErased.insert(op); }
+
+/// Callback to notify about the clock signal during AIGER export.
+/// Stores the clock value for later use when reconnecting the optimized module.
+void Converter::notifyClock(Value value) { clock = value; }
+
+//===----------------------------------------------------------------------===//
+// AIGERRunner
+//===----------------------------------------------------------------------===//
+
+namespace {
+class AIGERRunner {
+public:
+  AIGERRunner(llvm::StringRef solverPath, SmallVector<std::string> solverArgs)
+      : solverPath(solverPath), solverArgs(std::move(solverArgs)) {}
+
+  LogicalResult run(hw::HWModuleOp module);
+
+private:
+  // Helper methods
+  LogicalResult runSolver(hw::HWModuleOp module, StringRef inputPath,
+                          StringRef outputPath);
+  LogicalResult exportToAIGER(Converter &converter, hw::HWModuleOp module,
+                              StringRef outputPath);
+  LogicalResult importFromAIGER(Converter &converter, StringRef inputPath,
+                                hw::HWModuleOp module);
+  llvm::StringRef solverPath;
+  SmallVector<std::string> solverArgs;
+};
+
+} // namespace
+
+LogicalResult AIGERRunner::run(hw::HWModuleOp module) {
+
+  // Create temporary files for AIGER input/output
+  SmallString<128> tempDir;
+  if (auto error =
+          llvm::sys::fs::createUniqueDirectory("aiger-runner", tempDir))
+    return emitError(module.getLoc(), "failed to create temporary directory: ")
+           << error.message();
+
+  SmallString<128> inputPath(tempDir);
+  llvm::sys::path::append(inputPath, "input.aig");
+  SmallString<128> outputPath(tempDir);
+  llvm::sys::path::append(outputPath, "output.aig");
+
+  Converter converter;
+
+  // Export current module to AIGER format
+  if (failed(exportToAIGER(converter, cast<hw::HWModuleOp>(module), inputPath)))
+    return emitError(module.getLoc(),
+                     "failed to export module to AIGER format for ")
+           << module.getModuleNameAttr();
+
+  // Run the external solver
+  if (failed(runSolver(module, inputPath, outputPath)))
+    return emitError(module.getLoc(), "failed to run external solver");
+
+  // Import the results back
+  if (failed(
+          importFromAIGER(converter, outputPath, cast<hw::HWModuleOp>(module))))
+    return emitError(module.getLoc(),
+                     "failed to import results from AIGER format");
+
+  // If we get here, we succeeded. Clean up temporary files.
+  if (llvm::sys::fs::remove(inputPath))
+    return emitError(module.getLoc(), "failed to remove input file: ")
+           << inputPath.str();
+  if (llvm::sys::fs::remove(outputPath))
+    return emitError(module.getLoc(), "failed to remove output file: ")
+           << outputPath.str();
+  if (llvm::sys::fs::remove(tempDir))
+    return emitError(module.getLoc(), "failed to remove temporary directory: ")
+           << tempDir.str();
+
+  return llvm::success();
+}
+
+/// Execute the external solver (ABC, Yosys, etc.) on the AIGER file.
+/// Replaces placeholder tokens in solver arguments with actual file paths.
+LogicalResult AIGERRunner::runSolver(hw::HWModuleOp module, StringRef inputPath,
+                                     StringRef outputPath) {
+  // Prepare command line arguments for the solver
+  SmallVector<StringRef> commandArgs;
+  std::vector<std::string> processedSolverArgs;
+
+  // Helper function to replace all occurrences of a substring
+  auto replaceAll = [](std::string str, StringRef from, StringRef to) {
+    size_t pos = 0;
+    while ((pos = str.find(from.str(), pos)) != std::string::npos) {
+      str.replace(pos, from.size(), to.str());
+      pos += to.size();
+    }
+    return str;
+  };
+
+  // Process all solver arguments, replacing placeholders with actual paths
+  for (const auto &solverArg : solverArgs) {
+    std::string processedArg =
+        replaceAll(replaceAll(solverArg, "<inputFile>", inputPath),
+                   "<outputFile>", outputPath);
+    processedSolverArgs.push_back(std::move(processedArg));
+  }
+
+  // Find the solver program in the system PATH
+  std::string executionError;
+  auto solverProgram = llvm::sys::findProgramByName(solverPath);
+  if (auto e = solverProgram.getError())
+    return emitError(module.getLoc(), "Failed to find solver program: ")
+           << solverPath.str() << ": " << e.message();
+
+  // Build complete command line with program name and arguments
+  commandArgs.push_back(*solverProgram);
+  for (auto &processedArg : processedSolverArgs)
+    commandArgs.push_back(processedArg);
+
+  // Execute the solver
+  int executionResult = llvm::sys::ExecuteAndWait(
+      solverProgram.get(), commandArgs,
+      /*Env=*/std::nullopt, /*Redirects=*/{},
+      /*SecondsToWait=*/0, /*MemoryLimit=*/0, &executionError);
+
+  // Check for execution failure
+  if (executionResult != 0)
+    return emitError(module.getLoc(), "Solver execution failed for module ")
+           << module.getModuleNameAttr() << " with error: " << executionError;
+
+  return success();
+}
+
+/// Export the hardware module to AIGER format for external solver processing.
+LogicalResult AIGERRunner::exportToAIGER(Converter &converter,
+                                         hw::HWModuleOp module,
+                                         StringRef outputPath) {
+  // Open output file for writing AIGER data
+  auto outputFile = mlir::openOutputFile(outputPath);
+  if (!outputFile)
+    return emitError(module.getLoc(), "Failed to open AIGER output file: ")
+           << outputPath.str();
+
+  LLVM_DEBUG(llvm::dbgs() << "Exporting module " << module.getModuleNameAttr()
+                          << " to AIGER format\n");
+
+  circt::aiger::ExportAIGEROptions exportOptions;
+  exportOptions.binaryFormat = true;       // Use binary format for efficiency
+  exportOptions.includeSymbolTable = true; // Include names for debugging
+
+  // Perform the actual AIGER export
+  auto exportResult = circt::aiger::exportAIGER(module, outputFile->os(),
+                                                &exportOptions, &converter);
+
+  // Ensure the file is properly written to disk
+  outputFile->keep();
+  return exportResult;
+}
+
+/// Import the optimized AIGER file back into MLIR format.
+/// Creates a new module from the AIGER data and replaces the original module.
+LogicalResult AIGERRunner::importFromAIGER(Converter &converter,
+                                           StringRef inputPath,
+                                           hw::HWModuleOp originalModule) {
+  // Set up source manager for file parsing
+  llvm::SourceMgr sourceMgr;
+  auto inputFile = mlir::openInputFile(inputPath);
+  if (!inputFile)
+    return emitError(originalModule.getLoc(),
+                     "Failed to open AIGER input file: ")
+           << inputPath.str();
+
+  // Add the file buffer to the source manager
+  sourceMgr.AddNewSourceBuffer(std::move(inputFile), llvm::SMLoc());
+
+  // Create a temporary module to hold the imported AIGER content
+  mlir::TimingScope timingScope;
+  mlir::Block temporaryBlock;
+  mlir::OpBuilder builder(originalModule->getContext());
+  builder.setInsertionPointToStart(&temporaryBlock);
+  auto temporaryModule =
+      builder.create<mlir::ModuleOp>(builder.getUnknownLoc());
+
+  // Import the AIGER file into the temporary module
+  if (failed(circt::aiger::importAIGER(sourceMgr, originalModule->getContext(),
+                                       timingScope, temporaryModule)))
+    return emitError(originalModule.getLoc(),
+                     "Failed to import optimized AIGER file");
+
+  // Extract the hardware module from the imported content
+  auto optimizedModule =
+      cast<hw::HWModuleOp>(temporaryModule.getBody()->front());
+
+  // Integrate the optimized module into the original module structure
+  converter.integrateOptimizedModule(originalModule, optimizedModule);
+
+  // Clean up any operations that became unused during the replacement
+  converter.cleanup(originalModule);
+
+  return llvm::success();
+}
+
+//===----------------------------------------------------------------------===//
+// AIGERRunnerPass
+//===----------------------------------------------------------------------===//
+
+namespace {
+class AIGERRunnerPass : public impl::AIGERRunnerBase<AIGERRunnerPass> {
+public:
+  AIGERRunnerPass() = default;
+  AIGERRunnerPass(const AIGERRunnerOptions &options) {
+    solverPath = options.solverPath;
+    solverArgs = options.solverArgs;
+  }
+
+  void runOnOperation() override;
+
+private:
+  using AIGERRunnerBase::AIGERRunnerBase::solverArgs;
+  using AIGERRunnerBase::AIGERRunnerBase::solverPath;
+
+  // Helper methods
+  LogicalResult runSolver(hw::HWModuleOp module, StringRef inputPath,
+                          StringRef outputPath);
+  LogicalResult exportToAIGER(Converter &converter, hw::HWModuleOp module,
+                              StringRef outputPath);
+  LogicalResult importFromAIGER(Converter &converter, StringRef inputPath,
+                                hw::HWModuleOp module);
+};
+} // namespace
+
+void AIGERRunnerPass::runOnOperation() {
+  auto module = getOperation();
+
+  // Convert pass options to the format expected by AIGERRunner
+  SmallVector<std::string> solverArgsRef;
+  for (const auto &arg : solverArgs)
+    solverArgsRef.push_back(arg);
+
+  AIGERRunner runner(solverPath, std::move(solverArgsRef));
+  if (failed(runner.run(module)))
+    signalPassFailure();
+}
+
+//===----------------------------------------------------------------------===//
+// ABCRunnerPass
+//===----------------------------------------------------------------------===//
+
+namespace {
+class ABCRunnerPass : public impl::ABCRunnerBase<ABCRunnerPass> {
+public:
+  ABCRunnerPass() = default;
+  ABCRunnerPass(const ABCRunnerOptions &options) {
+    abcPath = options.abcPath;
+    abcCommands = options.abcCommands;
+  }
+
+  void runOnOperation() override;
+};
+} // namespace
+
+/// Run ABC optimization commands on the current hardware module.
+/// Builds a command sequence to read AIGER, run optimizations, and write back.
+void ABCRunnerPass::runOnOperation() {
+  auto module = getOperation();
+
+  SmallVector<std::string> abcArguments;
+
+  // Helper to add ABC commands with quiet flag
+  auto addABCCommand = [&](const std::string &command) {
+    abcArguments.push_back("-q"); // Run ABC in quiet mode
+    abcArguments.push_back(command);
+  };
+
+  // Start with reading the input AIGER file
+  addABCCommand("read <inputFile>");
+
+  // Add all user-specified optimization commands
+  for (const auto &optimizationCmd : abcCommands)
+    addABCCommand(optimizationCmd);
+
+  // Finish by writing the optimized result
+  addABCCommand("write <outputFile>");
+
+  // Execute the ABC optimization sequence
+  AIGERRunner abcRunner(abcPath, std::move(abcArguments));
+  if (failed(abcRunner.run(module)))
+    signalPassFailure();
+}

--- a/lib/Dialect/AIG/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIG/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_circt_dialect_library(CIRCTAIGTransforms
+  AIGERRunner.cpp
   LowerVariadic.cpp
   LowerWordToBits.cpp
 
@@ -8,5 +9,8 @@ add_circt_dialect_library(CIRCTAIGTransforms
   LINK_LIBS PUBLIC
   CIRCTAIG
   CIRCTComb
+  CIRCTExportAIGER
   CIRCTHW
+  CIRCTImportAIGER
+  CIRCTSeq
 )

--- a/test/Dialect/AIG/aiger-runner-error.mlir
+++ b/test/Dialect/AIG/aiger-runner-error.mlir
@@ -1,0 +1,12 @@
+// Run cp as a round-trip test.
+// RUN: circt-opt %s --pass-pipeline='builtin.module(hw.module(aig-runner{solver-path="cp" solver-args="<inputFile>" solver-args="<outputFile>"}))' --verify-diagnostics
+
+// expected-error@below {{multiple clocks found in the module}}
+// expected-note@below {{previous clock is here}}
+// expected-error@below {{failed to export module to AIGER format for "multipleClock"}}
+hw.module @multipleClock(in %c1: !seq.clock, in %c2: !seq.clock, in %a: i1, out out1: i1, out out2: i1) {
+  %0 = seq.compreg %a, %c1 : i1
+  %1 = seq.compreg %a, %c2 : i1
+  hw.output %0, %1 : i1, i1
+}
+

--- a/test/Dialect/AIG/aiger-runner.mlir
+++ b/test/Dialect/AIG/aiger-runner.mlir
@@ -1,0 +1,37 @@
+// Run cp as a round-trip test.
+// RUN: circt-opt %s --pass-pipeline='builtin.module(hw.module(aig-runner{solver-path="cp" solver-args="<inputFile>" solver-args="<outputFile>"}))' | FileCheck %s
+
+// CHECK-LABEL: hw.module @test(in %a : i1, in %b : i1, out out : i1)
+// CHECK-NEXT: %0 = aig.and_inv %b, %a : i1
+// CHECK-NEXT: hw.output %0 : i1 
+hw.module @test(in %a: i1, in %b: i1, out out: i1) {
+  %0 = aig.and_inv %b, %a : i1
+  hw.output %0 : i1
+}
+
+// Make sure that the unknown operation are properly handled.
+// CHECK-LABEL: hw.module @unknownOperation(in %a : i2, in %b : i2, out out : i2) {
+// CHECK-NEXT: %[[B_0:.+]] = comb.extract %b from 0 : (i2) -> i1
+// CHECK-NEXT: %[[B_1:.+]] = comb.extract %b from 1 : (i2) -> i1
+// CHECK-NEXT: %[[A_0:.+]] = comb.extract %a from 0 : (i2) -> i1
+// CHECK-NEXT: %[[A_1:.+]] = comb.extract %a from 1 : (i2) -> i1
+// CHECK-NEXT: %[[CONCAT:.+]] = comb.concat %[[AND_INV_0:.+]], %[[AND_INV_1:.+]] : i1, i1
+// CHECK-NEXT: dbg.variable "test", %[[CONCAT:.+]] : i2
+// CHECK-NEXT: %[[A:.+]] = comb.concat %[[A_1]], %[[A_0]] : i1, i1
+// CHECK-NEXT: %[[B:.+]] = comb.concat %[[B_1]], %[[B_0]] : i1, i1
+// CHECK-NEXT: %[[ADD:.+]] = comb.add %[[A]], %[[B]] : i2
+// CHECK-NEXT: %[[ADD_0:.+]] = comb.extract %[[ADD]] from 0
+// CHECK-NEXT: %[[ADD_1:.+]] = comb.extract %[[ADD]] from 1
+// CHECK-NEXT: %[[CONCAT:.+]] = comb.concat %[[AND_INV_4:.+]], %[[AND_INV_3:.+]] : i1, i1
+// CHECK-NEXT: %[[AND_INV_0:.+]] = aig.and_inv %[[B_0]], %[[A_0]] : i1
+// CHECK-NEXT: %[[AND_INV_1:.+]] = aig.and_inv %[[B_1]], %[[A_1]] : i1
+// CHECK-NEXT: %[[AND_INV_2:.+]] = aig.and_inv %[[ADD_0]], %[[A_0]] : i1
+// CHECK-NEXT: %[[AND_INV_3:.+]] = aig.and_inv %[[ADD_1]], %[[A_1]] : i1
+// CHECK-NEXT: hw.output %[[CONCAT:.+]] : i2
+hw.module @unknownOperation(in %a: i2, in %b: i2, out out: i2) {
+  %0 = aig.and_inv %b, %a : i2
+  dbg.variable "test", %0 : i2
+  %1 = comb.add %a, %b : i2
+  %2 = aig.and_inv %1, %a : i2
+  hw.output %2 : i2
+}

--- a/tools/circt-synth/circt-synth.cpp
+++ b/tools/circt-synth/circt-synth.cpp
@@ -112,6 +112,14 @@ static cl::opt<std::string> topName("top", cl::desc("Top module name"),
                                     cl::value_desc("name"), cl::init(""),
                                     cl::cat(mainCategory));
 
+static cl::list<std::string> abcCommands("abc-commands",
+                                         cl::desc("ABC passes to run"),
+                                         cl::CommaSeparated,
+                                         cl::cat(mainCategory));
+static cl::opt<std::string> abcPath("abc-path", cl::desc("Path to ABC"),
+                                    cl::value_desc("path"), cl::init("abc"),
+                                    cl::cat(mainCategory));
+
 //===----------------------------------------------------------------------===//
 // Main Tool Logic
 //===----------------------------------------------------------------------===//
@@ -165,6 +173,12 @@ static void populateSynthesisPipeline(PassManager &pm) {
     mpm.addPass(aig::createLowerWordToBits());
     mpm.addPass(createCSEPass());
     mpm.addPass(createSimpleCanonicalizerPass());
+    if (!abcCommands.empty()) {
+      aig::ABCRunnerOptions options;
+      options.abcPath = abcPath;
+      options.abcCommands.assign(abcCommands.begin(), abcCommands.end());
+      mpm.addPass(aig::createABCRunner(options));
+    }
     // TODO: Add balancing, rewriting, FRAIG conversion, etc.
     if (untilReached(UntilEnd))
       return;


### PR DESCRIPTION
This commit introduces a new infrastructure for running external logic synthesis tools (ABC, Yosys, etc.) on AIG modules through AIGER format export/import.

The implementation provides two new passes, AIGERRunner and ABCRunner, that export modules to AIGER format, run external solvers, and import optimized results back to MLIR. The system includes sophisticated multi-bit value handling with automatic decomposition during export and reconstruction during import. The pass integrates seamlessly with the circt-synth tool to support ABC optimization commands.

The core Converter class tracks bit-level mappings between MLIR and AIGER representations, enabling accurate reconstruction of multi-bit values after optimization. String placeholder replacement provides flexible solver command configuration, supporting various external tools with different command-line interfaces.

For testing purpose yosys-abc is mainly used. 

ABCRunner is added to circt-synth and  we can run abc through `abc-commands`, e.g.: `circt-synth -abc-commands=balance,rewrite,"rewrite -z",balance,"rewrite -z",balance`