### PR TITLE
[FIRRTL] Move all annotations in inject-dut-hier

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -9,10 +9,52 @@
 // Implementation of the SiFive transform InjectDUTHierarchy.  This moves all
 // the logic inside the DUT into a new module named using an annotation.
 //
+// As the terminology in this pass is a constant source of confusion, FIGURE 1
+// below, and the accompanying description of terms is provided to clarify what
+// is going on.
+//
+//         BEFORE                 AFTER
+//     +-------------+       +-------------+
+//     |     DUT     |       |     DUT     |
+//     |             |       | +---------+ |
+//     |             |       | | WRAPPER | |
+//     |             | ====> | |         | |
+//     |    LOGIC    |       | |  LOGIC  | |
+//     |             |       | +---------+ |
+//     +-------------+       +-------------+
+//
+// FIGURE 1: A graphical view of this pass
+//
+// In FIGURE 1, the DUT (design under test which roughly is the unit of
+// compilation excluding all testharness, testbenches, or tests) is the module
+// in the circuit which is annotated with a `MarkDUTAnnotation`.  Inside the
+// DUT, there exists some LOGIC.  This is the complete contents of all
+// operations inside the DUT module.  Logically, this pass takes the LOGIC and
+// puts it into a new MODULE, called the WRAPPER.
+//
+// This pass operates in two modes, moderated by a `moveDut` boolean parameter
+// on the controlling annotation.  When `moveDut=false`, the DUT in FIGURE 1 is
+// treated as the design under test.  When `moveDut=true`, the WRAPPER in FIGURE
+// 1 is treated as the design under test.  Mechanically, this means that
+// annotations on the DUT will be moved to the wrapper.
+//
+// The names of the WRAPPER and DUT change based on the mode.  If
+// `moveDut=false`, then the WRAPPER is named using the `name` field of the
+// controlling annotation and the DUT gets the name of the original DUT.  If
+// `moveDut=true`, then the DUT is named using the `name` field and the WRAPPER
+// gets the name of the original DUT.
+//
+// This pass is closely coupled to `ExtractInstances`.  This pass is intended to
+// be used to create a "space" where modules can be extracted or groups of
+// modules can be extracted to.  Commonly, the LOGIC will be extracted to the
+// WRAPPER, memories will be extracted to a MEMORIES module, and other things
+// (clock gates and blackboxes) will be extracted to other modules.
+//
 //===----------------------------------------------------------------------===//
 
 #include "circt/Analysis/FIRRTLInstanceInfo.h"
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
+#include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/NLATable.h"
@@ -45,21 +87,31 @@ struct InjectDUTHierarchy
 } // namespace
 
 /// Add an extra level of hierarchy to a hierarchical path that places the
-/// wrapper instance after the DUT.  E.g., this is converting:
+/// wrapper instance after the DUT.  This appends to the existing path
+/// immediately after the `dut`.
+///
+/// E.g., this is converting:
 ///
 ///   firrtl.hierpath [@Top::@dut, @DUT]
 ///
-/// Int:
+/// Into:
 ///
 ///   firrtl.hierpath [@Top::@dut, @DUT::@wrapper, @Wrapper]
+///
+/// The `oldDutNameAttr` parameter controls the insertion point.  I.e., this is
+/// the location of a module wehre an insertion will happen.  By separating this
+/// from the `dut` paramter, this allows this function to work for both the
+/// `moveDut=false` and `moveDut=true` cases.  In the `moveDut=false` case the
+/// `dut` and `oldDutNameAttr` refer to the same module.
 static void addHierarchy(hw::HierPathOp path, FModuleOp dut,
-                         InstanceOp wrapperInst) {
+                         InstanceOp wrapperInst, StringAttr oldDutNameAttr) {
+
   auto namepath = path.getNamepath().getValue();
 
   size_t nlaIdx = 0;
   SmallVector<Attribute> newNamepath;
   newNamepath.reserve(namepath.size() + 1);
-  while (path.modPart(nlaIdx) != dut.getNameAttr())
+  while (path.modPart(nlaIdx) != oldDutNameAttr)
     newNamepath.push_back(namepath[nlaIdx++]);
   newNamepath.push_back(hw::InnerRefAttr::get(dut.getModuleNameAttr(),
                                               getInnerSymName(wrapperInst)));
@@ -160,12 +212,20 @@ void InjectDUTHierarchy::runOnOperation() {
   b.setInsertionPointAfter(dut);
 
   // After this, he original DUT module is now the "wrapper".  The new module we
-  // just created becomse the "DUT".
+  // just created becomes the "DUT".
+  auto oldDutNameAttr = dut.getNameAttr();
   wrapper = dut;
-  dut = b.create<FModuleOp>(dut.getLoc(), dut.getNameAttr(),
-                            dut.getConventionAttr(), dut.getPorts(),
-                            dut.getAnnotationsAttr());
+  dut = b.create<FModuleOp>(dut.getLoc(), oldDutNameAttr,
+                            dut.getConventionAttr(), dut.getPorts());
 
+  // Finish setting up the DUT and the Wrapper.  This depends on if we are in
+  // `moveDut` mode or not.  If `moveDut=false` (the normal, legacy behavior),
+  // then the wrapper is a wrapper of logic inside the original DUT.  The newly
+  // created module to instantiate the wrapper becomes the DUT.  In this mode,
+  // we need to move all annotations over to the new DUT.  If `moveDut=true`,
+  // then we need to move all the annotations/information from the wrapper onto
+  // the DUT.
+  //
   // This pass shouldn't create new public modules.  It should only preserve the
   // existing public modules.  In "moveDut" mode, then the wrapper is the new
   // DUT and we should move the publicness from the old DUT to the wrapper.
@@ -176,23 +236,33 @@ void InjectDUTHierarchy::runOnOperation() {
   // outside the specification, this workflow is allowed even though it violates
   // the FIRRTL ABI.  The mid-term plan is to remove this pass to avoid the tech
   // debt that it creates.
+  auto emptyArray = b.getArrayAttr({});
+  auto name = circuitNS.newName(wrapperName.getValue());
   if (moveDut) {
     dut.setPrivate();
-    AnnotationSet::removeAnnotations(dut, dutAnnoClass);
+    dut.setPortAnnotationsAttr(emptyArray);
+    dut.setName(b.getStringAttr(name));
+    // The DUT name has changed.  Rewrite instances to use the new DUT name.
+    InstanceGraph &instanceGraph = getAnalysis<InstanceGraph>();
+    for (auto *use : instanceGraph.lookup(wrapper.getNameAttr())->uses()) {
+      auto instanceOp = dyn_cast<InstanceOp>(use->getInstance());
+      if (!instanceOp) {
+        use->getInstance().emitOpError()
+            << "instantiates the design-under-test, but "
+               "is not a 'firrtl.instance'";
+        return signalPassFailure();
+      }
+      instanceOp.setModuleNameAttr(FlatSymbolRefAttr::get(dut.getNameAttr()));
+    }
   } else {
     dut.setVisibility(wrapper.getVisibility());
+    dut.setAnnotationsAttr(wrapper.getAnnotationsAttr());
+    dut.setPortAnnotationsAttr(wrapper.getPortAnnotationsAttr());
     wrapper.setPrivate();
+    wrapper.setAnnotationsAttr(emptyArray);
+    wrapper.setPortAnnotationsAttr(emptyArray);
+    wrapper.setName(name);
   }
-  wrapper.setName(b.getStringAttr(circuitNS.newName(wrapperName.getValue())));
-
-  // Finish setting up the wrapper.  Strip the `MarkDUTAnnotation` if we are in
-  // "moveDut" mode.
-  wrapper.setPortAnnotationsAttr(b.getArrayAttr({}));
-  AnnotationSet::removeAnnotations(wrapper, [&](Annotation anno) {
-    if (anno.isClass(dutAnnoClass))
-      return !moveDut;
-    return true;
-  });
 
   // Instantiate the wrapper inside the DUT and wire it up.
   b.setInsertionPointToStart(dut.getBodyBlock());
@@ -240,8 +310,10 @@ void InjectDUTHierarchy::runOnOperation() {
 
   // Update NLAs involving the DUT.
   //
-  // NOTE: the _DUT_ is the new DUT and all the original DUT contents are put
-  // inside the DUT in the _wrapper_.
+  // In the `moveDut=true` case, the WRAPPER will have the `MarkDUTAnnotation`
+  // moved onto it and this will be the "design-under-test" from the perspective
+  // of later passes.  In the `moveDut=false` case, the DUT will be the
+  // "design-under-test.
   //
   // There are three cases to consider:
   //   1. The DUT or a DUT port is a leaf ref.  Do nothing.
@@ -251,13 +323,19 @@ void InjectDUTHierarchy::runOnOperation() {
   LLVM_DEBUG(llvm::dbgs() << "Processing hierarchical paths:\n");
   auto &nlaTable = getAnalysis<NLATable>();
   DenseMap<StringAttr, hw::HierPathOp> dutRenames;
-  for (auto nla : llvm::make_early_inc_range(nlaTable.lookup(dut))) {
+  for (auto nla : llvm::make_early_inc_range(nlaTable.lookup(oldDutNameAttr))) {
     LLVM_DEBUG(llvm::dbgs() << "  - " << nla << "\n");
     auto namepath = nla.getNamepath().getValue();
 
     // The DUT is the root module.  Just update the root module to point at the
     // wrapper.
-    if (nla.root() == dut.getNameAttr()) {
+    //
+    // TODO: It _may_ be desirable to only do this in the `moveDut=true` case.
+    // In the `moveDut=false` case, this will change the semantic of the
+    // annotation if the annotation user is assuming that the annotation root is
+    // locked to the DUT.  However, annotations are not supposed to have
+    // semantics like this.
+    if (nla.root() == oldDutNameAttr) {
       assert(namepath.size() > 1 && "namepath size must be greater than one");
       SmallVector<Attribute> newNamepath{hw::InnerRefAttr::get(
           wrapper.getNameAttr(),
@@ -275,13 +353,14 @@ void InjectDUTHierarchy::runOnOperation() {
     // NOTE: the _DUT_ is the new DUT and all the original DUT contents are put
     // inside the DUT in the _wrapper_.
     //
-    //   1. Reference path on port.  Do nothing.
+    //   1. Reference path on DUT port.  Do nothing.
     //   2. Reference path on component.  Add hierarchy
     //   3. Module path on DUT/DUT port.  Clone path, add hier to original path.
-    //   4. Module path on component.  Ad dhierarchy.
+    //   4. Module path on component.  Add hierarchy.
     //
-    if (nla.leafMod() == dut.getNameAttr()) {
-      // Case (1): ref path targeting a port.  Do nothing.
+    if (nla.leafMod() == oldDutNameAttr) {
+      // Case (1): ref path targeting a DUT port.  Do nothing.  When
+      // `moveDut=true`, this is always false.
       if (nla.isComponent() && dutPortSyms.count(nla.ref()))
         continue;
 
@@ -300,7 +379,7 @@ void InjectDUTHierarchy::runOnOperation() {
       // Cases (2), (3), and (4): fallthrough to add hierarchy to original path.
     }
 
-    addHierarchy(nla, dut, wrapperInst);
+    addHierarchy(nla, dut, wrapperInst, oldDutNameAttr);
   }
 
   SmallVector<Annotation> newAnnotations;

--- a/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
@@ -26,17 +26,16 @@ firrtl.circuit "Top" attributes {
 firrtl.circuit "Top" attributes {
     annotations = [{class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Foo", moveDut = true}]
   } {
-  // CHECK:      firrtl.module private @Foo()
+  // CHECK:      firrtl.module private @DUT()
   // CHECK-SAME:   class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
   //
-  // CHECK:      firrtl.module private @DUT
-  //
-  // CHECK-NEXT:   firrtl.instance Foo {{.+}} @Foo()
+  // CHECK:      firrtl.module private @Foo
+  // CHECK-NEXT:   firrtl.instance DUT {{.+}} @DUT()
   // CHECK-NEXT: }
   firrtl.module private @DUT() attributes {annotations = [{class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}]} {}
 
   // CHECK:      firrtl.module @Top
-  // CHECK-NEXT:   firrtl.instance dut @DUT
+  // CHECK-NEXT:   firrtl.instance dut @Foo
   firrtl.module @Top() {
     firrtl.instance dut @DUT()
   }
@@ -44,60 +43,9 @@ firrtl.circuit "Top" attributes {
 
 // -----
 
-// CHECK-LABEL: firrtl.circuit "NLARenaming"
-firrtl.circuit "NLARenaming" attributes {
-    annotations = [{class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Foo"}]
-  } {
-  // An NLA that is rooted at the DUT moves to the wrapper.
-  //
-  // CHECK:      hw.hierpath private @nla_DUTRoot [@Foo::@sub, @Sub::@a]
-  hw.hierpath private @nla_DUTRoot [@DUT::@sub, @Sub::@a]
-
-  // NLAs that end at the DUT or a DUT port are unmodified.
-  //
-  // CHECK-NEXT: hw.hierpath private @[[nla_DUTLeafModule_clone:.+]] [@NLARenaming::@dut, @DUT]
-  // CHECK-NEXT: hw.hierpath private @nla_DUTLeafModule [@NLARenaming::@dut, @DUT::@Foo, @Foo]
-  // CHECK-NEXT: hw.hierpath private @nla_DUTLeafPort [@NLARenaming::@dut, @DUT::@in]
-  hw.hierpath private @nla_DUTLeafModule [@NLARenaming::@dut, @DUT]
-  hw.hierpath private @nla_DUTLeafPort [@NLARenaming::@dut, @DUT::@in]
-
-  // NLAs that end inside the DUT get an extra level of hierarchy.
-  //
-  // CHECK-NEXT: hw.hierpath private @nla_DUTLeafWire [@NLARenaming::@dut, @DUT::@[[inst_sym:.+]], @Foo::@w]
-  hw.hierpath private @nla_DUTLeafWire [@NLARenaming::@dut, @DUT::@w]
-
-  // An NLA that passes through the DUT gets an extra level of hierarchy.
-  //
-  // CHECK-NEXT: hw.hierpath private @nla_DUTPassthrough [@NLARenaming::@dut, @DUT::@[[inst_sym:.+]], @Foo::@sub, @Sub]
-  hw.hierpath private @nla_DUTPassthrough [@NLARenaming::@dut, @DUT::@sub, @Sub]
-  firrtl.module private @Sub() attributes {annotations = [{circt.nonlocal = @nla_DUTPassthrough, class = "nla_DUTPassthrough"}]} {
-    %a = firrtl.wire sym @a : !firrtl.uint<1>
-  }
-
-  // CHECK:      firrtl.module private @Foo
-  // CHECK:      firrtl.module private @DUT
-  // CHECK-SAME:   {circt.nonlocal = @[[nla_DUTLeafModule_clone]], class = "nla_DUTLeafModule"}
-  // CHECK-NEXT:    firrtl.instance Foo sym @[[inst_sym]]
-  firrtl.module private @DUT(
-    in %in: !firrtl.uint<1> sym @in [{circt.nonlocal = @nla_DUTLeafPort, class = "nla_DUTLeafPort"}]
-  ) attributes {
-    annotations = [
-      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"},
-      {circt.nonlocal = @nla_DUTLeafModule, class = "nla_DUTLeafModule"}]}
-  {
-    %w = firrtl.wire sym @w {
-      annotations = [
-        {circt.nonlocal = @nla_DUTPassthrough, class = "nla_DUT_LeafWire"}]
-    } : !firrtl.uint<1>
-    firrtl.instance sub sym @sub @Sub()
-  }
-  firrtl.module @NLARenaming() {
-    %dut_in = firrtl.instance dut sym @dut @DUT(in in: !firrtl.uint<1>)
-  }
-}
-
-// -----
-
+// Test renaming when `moveDut=false`.  (This is the default behavior and
+// doesn't need to be explicitly specified in the annotation.)
+//
 // CHECK-LABEL: firrtl.circuit "NLARenamingNewNLAs"
 firrtl.circuit "NLARenamingNewNLAs" attributes {
     annotations = [{class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation", name = "Foo"}]
@@ -156,6 +104,130 @@ firrtl.circuit "NLARenamingNewNLAs" attributes {
   firrtl.module @NLARenamingNewNLAs() {
     %dut_in = firrtl.instance dut sym @dut @DUT(in in: !firrtl.uint<1>)
   }
+}
+
+// -----
+
+// Test renaming when `moveDut=true`.  This test is a copy of the one above it.
+//
+// CHECK-LABEL: firrtl.circuit "NLARenamingMoveDutTrue"
+firrtl.circuit "NLARenamingMoveDutTrue" attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation",
+        name = "Foo",
+        moveDut = true
+      }
+    ]
+  } {
+  // An NLA that is rooted at the DUT moves to the WRAPPER.  However, because
+  // the WRAPPER is renamed to the name of the DUT, these NLAs do not change.
+  //
+  // CHECK:      hw.hierpath private @nla_DUTRoot [@DUT::@sub, @Sub]
+  // CHECK:      hw.hierpath private @nla_DUTRootRef [@DUT::@sub, @Sub::@a]
+  hw.hierpath private @nla_DUTRoot [@DUT::@sub, @Sub]
+  hw.hierpath private @nla_DUTRootRef [@DUT::@sub, @Sub::@a]
+
+  // NLAs that end at the DUT or a DUT port are changed to end on the WRAPPER.
+  // The WRAPPER takes the original DUT name.
+  //
+  // CHECK-NEXT: hw.hierpath private @nla_DUTLeafModule [@NLARenamingMoveDutTrue::@dut, @Foo::@DUT, @DUT]
+  // CHECK-NEXT: hw.hierpath private @nla_DUTLeafPort [@NLARenamingMoveDutTrue::@dut, @Foo::@DUT, @DUT]
+  hw.hierpath private @nla_DUTLeafModule [@NLARenamingMoveDutTrue::@dut, @DUT]
+  hw.hierpath private @nla_DUTLeafPort [@NLARenamingMoveDutTrue::@dut, @DUT]
+
+  // NLAs that end inside the DUT are moved to end inside the WRAPPER.  The
+  // WRAPPER takes the original DUT name.
+  //
+  // CHECK-NEXT: hw.hierpath private @nla_DUTLeafWire [@NLARenamingMoveDutTrue::@dut, @Foo::@[[inst_sym:.+]], @DUT]
+  hw.hierpath private @nla_DUTLeafWire [@NLARenamingMoveDutTrue::@dut, @DUT]
+
+  // An NLA that passes through the DUT gets an extra level of hierarchy that
+  // includes the WRAPPER.
+  //
+  // CHECK-NEXT: hw.hierpath private @nla_DUTPassthrough [@NLARenamingMoveDutTrue::@dut, @Foo::@[[inst_sym]], @DUT::@sub, @Sub]
+  hw.hierpath private @nla_DUTPassthrough [@NLARenamingMoveDutTrue::@dut, @DUT::@sub, @Sub]
+  firrtl.module private @Sub() attributes {annotations = [{circt.nonlocal = @nla_DUTPassthrough, class = "nla_DUTPassthrough"}]} {
+    %a = firrtl.wire sym @a : !firrtl.uint<1>
+  }
+
+  // CHECK:      firrtl.module private @DUT
+  // CHECK-SAME:   in %in{{.+}} [{circt.nonlocal = @nla_DUTLeafPort, class = "nla_DUTLeafPort"}]
+  // CHECK-NEXT:   %w = firrtl.wire
+  // CHECK-SAME:     {annotations = [{circt.nonlocal = @nla_DUTLeafWire, class = "nla_DUT_LeafWire"}]}
+
+  // CHECK:      firrtl.module private @Foo
+  // CHECK-NOT:    annotation
+  // CHECK-NEXT:   firrtl.instance DUT sym @[[inst_sym]]
+  firrtl.module private @DUT(
+    in %in: !firrtl.uint<1> [{circt.nonlocal = @nla_DUTLeafPort, class = "nla_DUTLeafPort"}]
+  ) attributes {
+    annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"},
+      {circt.nonlocal = @nla_DUTLeafModule, class = "nla_DUTLeafModule"}]}
+  {
+    %w = firrtl.wire {
+      annotations = [
+        {circt.nonlocal = @nla_DUTLeafWire, class = "nla_DUT_LeafWire"}]
+    } : !firrtl.uint<1>
+    firrtl.instance sub sym @sub @Sub()
+  }
+  firrtl.module @NLARenamingMoveDutTrue() {
+    %dut_in = firrtl.instance dut sym @dut @DUT(in in: !firrtl.uint<1>)
+
+    firrtl.path reference distinct[0]<>
+  }
+}
+
+// -----
+
+// Test that an object model path is updated to point at the new DUT when in
+// `moveDut=true` mode.  This test is redundant with "NLARenamingNLA
+//
+// CHECK-LABEL: firrtl.circuit "ObjectModelDUT"
+firrtl.circuit "ObjectModelDUT" attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation",
+        name = "Foo",
+        moveDut = true
+      }
+    ]
+  } {
+
+  // CHECK: hw.hierpath private @nla [@ObjectModelDUT::@dut, @Foo::@[[wrapperSym:.+]], @DUT]
+  hw.hierpath private @nla [@ObjectModelDUT::@dut, @DUT]
+
+  // CHECK:      firrtl.module private @DUT()
+  // CHECK-SAME:   {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
+  // CHECK-SAME:   {circt.nonlocal = @nla, class = "circt.tracker", id = distinct[0]<>}
+
+  // CHECK:     firrtl.module private @Foo()
+  // CHECK-NOT:   "sifive.enterprise.firrtl.MarkDUTAnnotation"
+  // CHECK-NOT:   circt.nonlocal
+  // CHECK-NOT: firrtl.module
+  // CHECK:       firrtl.instance {{.*}} sym @[[wrapperSym]] @DUT()
+  firrtl.module private @DUT() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      },
+      {
+        circt.nonlocal = @nla,
+        class = "circt.tracker",
+        id = distinct[0]<>
+      }
+    ]
+  } {}
+
+  // CHECK:     firrtl.module @ObjectModelDUT()
+  // CHECK-NOT: firrtl.module
+  // CHECK:       firrtl.path reference distinct[0]<>
+  firrtl.module @ObjectModelDUT() {
+    firrtl.instance dut sym @dut @DUT()
+    firrtl.path reference distinct[0]<>
+  }
+
 }
 
 // -----
@@ -264,8 +336,8 @@ firrtl.circuit "PublicMoveDutFalse" attributes {
     }
   ]
 } {
-  // CHECK: firrtl.module @Foo()
-  // CHECK: firrtl.module private @DUT()
+  // CHECK: firrtl.module @DUT()
+  // CHECK: firrtl.module private @Foo()
   firrtl.module @DUT() attributes {
     annotations = [
       {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}

--- a/test/firtool/extract-instances.fir
+++ b/test/firtool/extract-instances.fir
@@ -115,8 +115,8 @@ circuit Top: %[[
     inst foo of Foo
     connect a, foo.a
 
-; CHECK-NOT:   FILE "testbench{{.*}}Logic.sv"
-; CHECK-LABEL: module Logic(
+; CHECK-NOT:   FILE "testbench{{.*}}Foo.sv"
+; CHECK-LABEL: module Foo(
 ; CHECK-NOT:   module
 ; CHECK:         Bar bar (
 
@@ -125,12 +125,12 @@ circuit Top: %[[
 ; CHECK-NOT:   module
 ; CHECK:         BlackBox blackbox (
 
-; CHECK:       FILE "testbench{{.*}}Foo.sv"
-; CHECK-LABEL: module Foo(
+; CHECK:       FILE "testbench{{.*}}Logic.sv"
+; CHECK-LABEL: module Logic(
 ; CHECK-NOT:   module
 ; CHECK:         BlackBoxes BlackBoxes (
 ; CHECK-NOT:   module
-; CHECK:         Logic Logic
+; CHECK:         Foo Foo
 
 ; // -----
 
@@ -241,14 +241,14 @@ circuit Top: %[[
     inst foo of Foo
     connect a, foo.a
 
-; CHECK-NOT:   FILE "testbench{{.*}}Logic.sv"
-; CHECK-LABEL: module Logic(
+; CHECK-NOT:   FILE "testbench{{.*}}Foo.sv"
+; CHECK-LABEL: module Foo(
 ; CHECK-NOT:   module
 ; CHECK:         Bar bar (
 
-; CHECK:       FILE "testbench{{.*}}Foo.sv"
-; CHECK-LABEL: module Foo(
+; CHECK:       FILE "testbench{{.*}}Logic.sv"
+; CHECK-LABEL: module Logic(
 ; CHECK-NOT:   module
-; CHECK:         Logic Logic (
+; CHECK:         Foo Foo (
 ; CHECK-NOT:   module
 ; CHECK:         BlackBox blackbox (


### PR DESCRIPTION
Change FIRRTL's inject-dut-hier pass to move all annotations onto the
wrapper [^1] when in `moveDut=true` mode.  Previously, this would only move
the `MarkDUTAnnotation`.  This fixes an internal issue where Object Model
paths were not being updated when using this pass in `moveDut=true` mode.

[^1]: This is using the terminology of the pass which views this as taking
all the logic inside the original DUT and shoving it into a wrapper
instantiated inside the DUT.  When in `moveDut=true` mode, it is more
natural to think of the pass as creating a wrapper around the original
DUT.  However, to adopt this alternative terminology would be modal.
I.e., "wrapper" would mean something different when in `movedDut=true`
mode which would be confusing.

Other NFC chagnes:

1. Refactor the InjectDUTHierarchy pass to not introduce the notion of a
   `newDUT` variable.  This only confuses things.  Instead setup the DUT and its
   internal wrapper immediately and then reuse these terms in all places.
2. Rename a test which is now the main test of non-local annotation (NLA)
   behavior inside FIRRTL's inject-dut-hier pass.  Previously this was the "new"
   test which duplicated a now deleted test.
3. Remove a test of non-local annotation (NLA) handling in the inject-dut-hier
   FIRRTL pass.  This test started out as the original test, then a copy of it
   was created that used a different NLA format, then the test became a true
   duplicate.
