### PR TITLE
[FIRRTL] Allow duplicate tracker annotations in LowerClasses.

### DIFF
--- a/test/Dialect/FIRRTL/lower-classes-errors.mlir
+++ b/test/Dialect/FIRRTL/lower-classes-errors.mlir
@@ -32,6 +32,9 @@ firrtl.circuit "PathIllegalHierpath" {
 
 firrtl.circuit "PathDuplicateID" {
   firrtl.module @PathDuplicateID() {
+    // Duplicate ID is only an error if something actually refers to that ID. Dedup can create dead, duplicate IDs.
+    %path = firrtl.path reference distinct[0]<>
+
     // expected-error @below {{path identifier already found, paths must resolve to a unique target}}
     %a = firrtl.wire {annotations = [{class = "circt.tracker", id = distinct[0]<>}]} : !firrtl.uint<8>
     // expected-note @below {{other path identifier here}}

--- a/test/Dialect/FIRRTL/lower-classes.mlir
+++ b/test/Dialect/FIRRTL/lower-classes.mlir
@@ -573,3 +573,17 @@ firrtl.circuit "RTLPorts" {
   // CHECK-NEXT: om.class.fields %ref, %direction, %width : !om.path, !om.string, !om.integer
 
 }
+
+// CHECK-LABEL: firrtl.circuit "DuplicateButEqualTrackers"
+firrtl.circuit "DuplicateButEqualTrackers" {
+  // CHECK: hw.hierpath private [[NLA:@.+]] [@DuplicateButEqualTrackers]
+  firrtl.module @DuplicateButEqualTrackers() attributes {
+    annotations = [
+      {class = "circt.tracker", id = distinct[0]<>},
+      {class = "circt.tracker", id = distinct[0]<>}
+    ]
+  } {
+    // CHECK: om.path_create reference %basepath [[NLA]]
+    firrtl.path reference distinct[0]<>
+  }
+}


### PR DESCRIPTION
Historically, we would assert that every tracker was used exactly once. However, with certain combinations of multiple instantiation and dedup, we can run into duplicate trackers. Specifically, like in the test case, if there are two modules that dedup, but they are instantiated multiple times in modules that do not dedup, we can end up with duplicate trackers that point to the same thing. When dedup is working, the paths are distinct, and it is only at the end that we realize they are pointing to the same thing.

This handles that case, by actually checking the path associated with duplicated trackers. If the trackers ultimately ended up pointing to the same thing, this is now allowed. It is still an error to have the same tracker pointing to multiple different paths through the hierarchy.

Finally, this removed the sentinel PathInfoTableEntry objects we would create simply to check uniqueness. Now that we are actually using the paths to confirm uniqueness or lack thereof, we don't need the sigil, and putting in a PathInfoTableEntry without a path means we can't perform the new check. These only existed for unused paths, which the situation described above in dedup can create. Since they're dead, we can now safely just skip them.