### PR TITLE
[FIRRTL] Lower registers under ifdefs

### DIFF
--- a/include/circt/Support/Utils.h
+++ b/include/circt/Support/Utils.h
@@ -16,8 +16,10 @@
 #include "circt/Support/LLVM.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
+#include "llvm/Support/Parallel.h"
 
 namespace circt {
+
 /// Return true if a Value is created "underneath" an operation.  This is
 /// frequently useful when negated as that indicates that a Value is defined
 /// "outside" the region of an Operation and that the Operation is thereby
@@ -25,6 +27,39 @@ namespace circt {
 inline bool isAncestorOfValueOwner(Operation *op, Value value) {
   return op->isAncestor(value.getParentBlock()->getParentOp());
 }
+
+//===----------------------------------------------------------------------===//
+// Parallel utilities
+//===----------------------------------------------------------------------===//
+
+/// Wrapper for llvm::parallelTransformReduce that performs the transform_reduce
+/// serially when MLIR multi-threading is disabled.
+/// Does not add a ParallelDiagnosticHandler like mlir::parallelFor.
+template <class IterTy, class ResultTy, class ReduceFuncTy,
+          class TransformFuncTy>
+static ResultTy transformReduce(MLIRContext *context, IterTy begin, IterTy end,
+                                ResultTy init, ReduceFuncTy reduce,
+                                TransformFuncTy transform) {
+  // Parallel when enabled
+  if (context->isMultithreadingEnabled())
+    return llvm::parallelTransformReduce(begin, end, init, reduce, transform);
+
+  // Serial fallback (from llvm::parallelTransformReduce)
+  for (IterTy i = begin; i != end; ++i)
+    init = reduce(std::move(init), transform(*i));
+  return std::move(init);
+}
+
+/// Range wrapper
+template <class RangeTy, class ResultTy, class ReduceFuncTy,
+          class TransformFuncTy>
+static ResultTy transformReduce(MLIRContext *context, RangeTy &&r,
+                                ResultTy init, ReduceFuncTy reduce,
+                                TransformFuncTy transform) {
+  return transformReduce(context, std::begin(r), std::end(r), init, reduce,
+                         transform);
+}
+
 } // namespace circt
 
 #endif // CIRCT_SUPPORT_UTILS_H

--- a/lib/Conversion/SeqToSV/FirRegLowering.cpp
+++ b/lib/Conversion/SeqToSV/FirRegLowering.cpp
@@ -8,6 +8,7 @@
 
 #include "FirRegLowering.h"
 #include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Support/Utils.h"
 #include "mlir/IR/Threading.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/DenseSet.h"

--- a/lib/Conversion/SeqToSV/FirRegLowering.cpp
+++ b/lib/Conversion/SeqToSV/FirRegLowering.cpp
@@ -23,6 +23,13 @@ using llvm::MapVector;
 
 #define DEBUG_TYPE "lower-seq-firreg"
 
+/// Immediately before the terminator, if present. Otherwise, the block's end.
+static Block::iterator getBlockEnd(Block *block) {
+  if (block->mightHaveTerminator())
+    return Block::iterator(block->getTerminator());
+  return block->end();
+}
+
 std::function<bool(const Operation *op)> OpUserInfo::opAllowsReachability =
     [](const Operation *op) -> bool {
   return (isa<comb::MuxOp, ArrayGetOp, ArrayCreateOp>(op));
@@ -108,53 +115,271 @@ void FirRegLowering::addToIfBlock(OpBuilder &builder, Value cond,
   }
 }
 
+/// Attach an inner-sym to field-id 0 of the given register, or use an existing
+/// inner-sym, if present.
+static StringAttr getInnerSymFor(InnerSymbolNamespace &innerSymNS,
+                                 seq::FirRegOp reg) {
+  auto attr = reg.getInnerSymAttr();
+
+  // If we have an inner sym attribute already, and if there exists a symbol for
+  // field-id 0, then just return that.
+  if (attr)
+    if (auto sym = attr.getSymIfExists(0))
+      return sym;
+
+  // Otherwise, we have to create a new inner sym.
+  auto *context = reg->getContext();
+
+  auto hint = reg.getName();
+
+  // Create our new property for field 0.
+  auto sym = StringAttr::get(context, innerSymNS.newName(hint));
+  auto property = hw::InnerSymPropertiesAttr::get(sym);
+
+  // Build the new list of inner sym properties. Since properties are sorted by
+  // field ID, our new property is first.
+  SmallVector<hw::InnerSymPropertiesAttr> properties = {property};
+  if (attr)
+    llvm::append_range(properties, attr.getProps());
+
+  // Build the new InnerSymAttr and attach it to the op.
+  attr = hw::InnerSymAttr::get(context, properties);
+  reg.setInnerSymAttr(attr);
+
+  // Return the name of the new inner sym.
+  return sym;
+}
+
+static InnerRefAttr getInnerRefTo(StringAttr mod, InnerSymbolNamespace &isns,
+                                  seq::FirRegOp reg) {
+  auto tgt = getInnerSymFor(isns, reg);
+  return hw::InnerRefAttr::get(mod, tgt);
+}
+
+namespace {
+/// A pair of a register, and an inner-ref attribute.
+struct BuriedFirReg {
+  FirRegOp reg;
+  InnerRefAttr ref;
+};
+} // namespace
+
+/// Locate the registers under the given HW module, which are not at the
+/// top-level of the module body. These registers will be initialized through an
+/// NLA. Put an inner symbol on each, and return a list of the buried registers
+/// and their inner-symbols.
+static std::vector<BuriedFirReg> getBuriedRegs(HWModuleOp module) {
+  auto name = SymbolTable::getSymbolName(module);
+  InnerSymbolNamespace isns(module);
+  std::vector<BuriedFirReg> result;
+  for (auto &op : *module.getBodyBlock()) {
+    for (auto &region : op.getRegions()) {
+      region.walk([&](FirRegOp reg) {
+        auto ref = getInnerRefTo(name, isns, reg);
+        result.push_back({reg, ref});
+      });
+    }
+  }
+  return result;
+}
+
+/// Locate all registers which are not at the top-level of their parent HW
+/// module. These registers will be initialized through an NLA. Put an inner
+/// symbol on each, and return a list of the buried registers and their
+/// inner-symbols.
+static std::vector<BuriedFirReg> getAllBuriedRegs(ModuleOp top) {
+  auto *context = top.getContext();
+  std::vector<BuriedFirReg> init;
+  auto ms = top.getOps<HWModuleOp>();
+  const std::vector<HWModuleOp> modules(ms.begin(), ms.end());
+  const auto reduce =
+      [](std::vector<BuriedFirReg> acc,
+         std::vector<BuriedFirReg> &&xs) -> std::vector<BuriedFirReg> {
+    acc.insert(acc.end(), xs.begin(), xs.end());
+    return acc;
+  };
+  return transformReduce(context, modules, init, reduce, getBuriedRegs);
+}
+
+/// Construct a hierarchical path op that targets the given register.
+static hw::HierPathOp getHierPathTo(OpBuilder &builder, Namespace &ns,
+                                    BuriedFirReg entry) {
+  auto modName = entry.ref.getModule().getValue();
+  auto symName = entry.ref.getName().getValue();
+  auto name = ns.newName(Twine(modName) + "_" + symName);
+
+  // Insert the HierPathOp immediately before the parent HWModuleOp, for style.
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPoint(entry.reg->getParentOfType<HWModuleOp>());
+
+  auto path = builder.getArrayAttr({entry.ref});
+  return builder.create<hw::HierPathOp>(entry.reg.getLoc(), name, path);
+}
+
+FirRegLowering::PathTable FirRegLowering::createPaths(mlir::ModuleOp top) {
+  auto builder = OpBuilder::atBlockBegin(top.getBody());
+  PathTable result;
+  Namespace ns;
+  ns.add(top);
+  for (auto entry : getAllBuriedRegs(top))
+    result[entry.reg] = getHierPathTo(builder, ns, entry);
+  return result;
+}
+
 FirRegLowering::FirRegLowering(TypeConverter &typeConverter,
                                hw::HWModuleOp module,
+                               const PathTable &pathTable,
                                bool disableRegRandomization,
                                bool emitSeparateAlwaysBlocks)
-    : typeConverter(typeConverter), module(module),
+    : pathTable(pathTable), typeConverter(typeConverter), module(module),
       disableRegRandomization(disableRegRandomization),
       emitSeparateAlwaysBlocks(emitSeparateAlwaysBlocks) {
-
   reachableMuxes = std::make_unique<ReachableMuxes>(module);
 }
 
 void FirRegLowering::lower() {
-  // Find all registers to lower in the module.
-  auto regs = module.getOps<seq::FirRegOp>();
-  if (regs.empty())
-    return;
+  lowerInBlock(module.getBodyBlock());
+  createInitialBlock();
+  module->removeAttr("firrtl.random_init_width");
+}
 
-  // Lower the regs to SV regs. Group them by initializer and reset kind.
-  SmallVector<RegLowerInfo> randomInit, presetInit;
-  llvm::MapVector<Value, SmallVector<RegLowerInfo>> asyncResets;
-  for (auto reg : llvm::make_early_inc_range(regs)) {
-    auto svReg = lower(reg);
-    if (svReg.preset)
-      presetInit.push_back(svReg);
-    else if (!disableRegRandomization)
-      randomInit.push_back(svReg);
+// NOLINTNEXTLINE(misc-no-recursion)
+void FirRegLowering::lowerUnderIfDef(sv::IfDefOp ifDefOp) {
+  auto cond = ifDefOp.getCond();
 
-    if (svReg.asyncResetSignal)
-      asyncResets[svReg.asyncResetSignal].emplace_back(svReg);
+  conditions.emplace_back(RegCondition::IfDefThen, cond);
+  lowerInBlock(ifDefOp.getThenBlock());
+  conditions.pop_back();
+
+  if (ifDefOp.hasElse()) {
+    conditions.emplace_back(RegCondition::IfDefElse, cond);
+    lowerInBlock(ifDefOp.getElseBlock());
+    conditions.pop_back();
   }
+}
 
+// NOLINTNEXTLINE(misc-no-recursion)
+void FirRegLowering::lowerInBlock(Block *block) {
+  for (auto &op : llvm::make_early_inc_range(*block)) {
+    if (auto ifDefOp = dyn_cast<sv::IfDefOp>(op)) {
+      lowerUnderIfDef(ifDefOp);
+      continue;
+    }
+    if (auto regOp = dyn_cast<seq::FirRegOp>(op)) {
+      lowerReg(regOp);
+      continue;
+    }
+    for (auto &region : op.getRegions())
+      for (auto &block : region.getBlocks())
+        lowerInBlock(&block);
+  }
+}
+
+SmallVector<Value> FirRegLowering::createRandomizationVector(OpBuilder &builder,
+                                                             Location loc) {
   // Compute total width of random space.  Place non-chisel registers at the end
   // of the space.  The Random space is unique to the initial block, due to
   // verilog thread rules, so we can drop trailing random calls if they are
   // unused.
   uint64_t maxBit = 0;
-  for (auto reg : randomInit)
+  for (auto reg : randomInitRegs)
     if (reg.randStart >= 0)
       maxBit = std::max(maxBit, (uint64_t)reg.randStart + reg.width);
 
-  for (auto &reg : randomInit) {
+  for (auto &reg : randomInitRegs) {
     if (reg.randStart == -1) {
       reg.randStart = maxBit;
       maxBit += reg.width;
     }
   }
 
+  // Create randomization vector
+  SmallVector<Value> randValues;
+  auto numRandomCalls = (maxBit + 31) / 32;
+  auto logic = builder.create<sv::LogicOp>(
+      loc,
+      hw::UnpackedArrayType::get(builder.getIntegerType(32), numRandomCalls),
+      "_RANDOM");
+  // Indvar's width must be equal to `ceil(log2(numRandomCalls +
+  // 1))` to avoid overflow.
+  auto inducionVariableWidth = llvm::Log2_64_Ceil(numRandomCalls + 1);
+  auto arrayIndexWith = llvm::Log2_64_Ceil(numRandomCalls);
+  auto lb = getOrCreateConstant(loc, APInt::getZero(inducionVariableWidth));
+  auto ub =
+      getOrCreateConstant(loc, APInt(inducionVariableWidth, numRandomCalls));
+  auto step = getOrCreateConstant(loc, APInt(inducionVariableWidth, 1));
+  auto forLoop = builder.create<sv::ForOp>(
+      loc, lb, ub, step, "i", [&](BlockArgument iter) {
+        auto rhs = builder.create<sv::MacroRefExprSEOp>(
+            loc, builder.getIntegerType(32), "RANDOM");
+        Value iterValue = iter;
+        if (!iter.getType().isInteger(arrayIndexWith))
+          iterValue = builder.create<comb::ExtractOp>(loc, iterValue, 0,
+                                                      arrayIndexWith);
+        auto lhs = builder.create<sv::ArrayIndexInOutOp>(loc, logic, iterValue);
+        builder.create<sv::BPAssignOp>(loc, lhs, rhs);
+      });
+  builder.setInsertionPointAfter(forLoop);
+  for (uint64_t x = 0; x < numRandomCalls; ++x) {
+    auto lhs = builder.create<sv::ArrayIndexInOutOp>(
+        loc, logic, getOrCreateConstant(loc, APInt(arrayIndexWith, x)));
+    randValues.push_back(lhs.getResult());
+  }
+
+  return randValues;
+}
+
+void FirRegLowering::createRandomInitialization(ImplicitLocOpBuilder &builder) {
+  auto randInitRef =
+      sv::MacroIdentAttr::get(builder.getContext(), "RANDOMIZE_REG_INIT");
+
+  if (!randomInitRegs.empty()) {
+    builder.create<sv::IfDefProceduralOp>("INIT_RANDOM_PROLOG_", [&] {
+      builder.create<sv::VerbatimOp>("`INIT_RANDOM_PROLOG_");
+    });
+
+    builder.create<sv::IfDefProceduralOp>(randInitRef, [&] {
+      auto randValues = createRandomizationVector(builder, builder.getLoc());
+      for (auto &svReg : randomInitRegs)
+        initialize(builder, svReg, randValues);
+    });
+  }
+}
+
+void FirRegLowering::createPresetInitialization(ImplicitLocOpBuilder &builder) {
+  for (auto &svReg : presetInitRegs) {
+    auto loc = svReg.reg.getLoc();
+    auto elemTy = svReg.reg.getType().getElementType();
+    auto cst = getOrCreateConstant(loc, svReg.preset.getValue());
+
+    Value rhs;
+    if (cst.getType() == elemTy)
+      rhs = cst;
+    else
+      rhs = builder.create<hw::BitcastOp>(loc, elemTy, cst);
+
+    builder.create<sv::BPAssignOp>(loc, svReg.reg, rhs);
+  }
+}
+
+// If a register is async reset, we need to insert extra initialization in
+// post-randomization so that we can set the reset value to register if the
+// reset signal is enabled.
+void FirRegLowering::createAsyncResetInitialization(
+    ImplicitLocOpBuilder &builder) {
+  for (auto &reset : asyncResets) {
+    //  if (reset) begin
+    //    ..
+    //  end
+    builder.create<sv::IfOp>(reset.first, [&] {
+      for (auto &reg : reset.second)
+        builder.create<sv::BPAssignOp>(reg.reg.getLoc(), reg.reg,
+                                       reg.asyncResetValue);
+    });
+  }
+}
+
+void FirRegLowering::createInitialBlock() {
   // Create an initial block at the end of the module where random
   // initialisation will be inserted.  Create two builders into the two
   // `ifdef` ops where the registers will be placed.
@@ -167,15 +392,12 @@ void FirRegLowering::lower() {
   //     `INIT_RANDOM_PROLOG_
   //     ... initBuilder ..
   // `endif
-  if (randomInit.empty() && presetInit.empty() && asyncResets.empty())
+  if (randomInitRegs.empty() && presetInitRegs.empty() && asyncResets.empty())
     return;
 
   needsRandom = true;
 
   auto loc = module.getLoc();
-  MLIRContext *context = module.getContext();
-  auto randInitRef = sv::MacroIdentAttr::get(context, "RANDOMIZE_REG_INIT");
-
   auto builder =
       ImplicitLocOpBuilder::atBlockTerminator(loc, module.getBodyBlock());
 
@@ -186,86 +408,9 @@ void FirRegLowering::lower() {
       });
 
       builder.create<sv::InitialOp>([&] {
-        if (!randomInit.empty()) {
-          builder.create<sv::IfDefProceduralOp>("INIT_RANDOM_PROLOG_", [&] {
-            builder.create<sv::VerbatimOp>("`INIT_RANDOM_PROLOG_");
-          });
-          builder.create<sv::IfDefProceduralOp>(randInitRef, [&] {
-            // Create randomization vector
-            SmallVector<Value> randValues;
-            auto numRandomCalls = (maxBit + 31) / 32;
-            auto logic = builder.create<sv::LogicOp>(
-                loc,
-                hw::UnpackedArrayType::get(builder.getIntegerType(32),
-                                           numRandomCalls),
-                "_RANDOM");
-            // Indvar's width must be equal to `ceil(log2(numRandomCalls +
-            // 1))` to avoid overflow.
-            auto inducionVariableWidth = llvm::Log2_64_Ceil(numRandomCalls + 1);
-            auto arrayIndexWith = llvm::Log2_64_Ceil(numRandomCalls);
-            auto lb =
-                getOrCreateConstant(loc, APInt::getZero(inducionVariableWidth));
-            auto ub = getOrCreateConstant(
-                loc, APInt(inducionVariableWidth, numRandomCalls));
-            auto step =
-                getOrCreateConstant(loc, APInt(inducionVariableWidth, 1));
-            auto forLoop = builder.create<sv::ForOp>(
-                loc, lb, ub, step, "i", [&](BlockArgument iter) {
-                  auto rhs = builder.create<sv::MacroRefExprSEOp>(
-                      loc, builder.getIntegerType(32), "RANDOM");
-                  Value iterValue = iter;
-                  if (!iter.getType().isInteger(arrayIndexWith))
-                    iterValue = builder.create<comb::ExtractOp>(
-                        loc, iterValue, 0, arrayIndexWith);
-                  auto lhs = builder.create<sv::ArrayIndexInOutOp>(loc, logic,
-                                                                   iterValue);
-                  builder.create<sv::BPAssignOp>(loc, lhs, rhs);
-                });
-            builder.setInsertionPointAfter(forLoop);
-            for (uint64_t x = 0; x < numRandomCalls; ++x) {
-              auto lhs = builder.create<sv::ArrayIndexInOutOp>(
-                  loc, logic,
-                  getOrCreateConstant(loc, APInt(arrayIndexWith, x)));
-              randValues.push_back(lhs.getResult());
-            }
-
-            // Create initialisers for all registers.
-            for (auto &svReg : randomInit)
-              initialize(builder, svReg, randValues);
-          });
-        }
-
-        if (!presetInit.empty()) {
-          for (auto &svReg : presetInit) {
-            auto loc = svReg.reg.getLoc();
-            auto elemTy = svReg.reg.getType().getElementType();
-            auto cst = getOrCreateConstant(loc, svReg.preset.getValue());
-
-            Value rhs;
-            if (cst.getType() == elemTy)
-              rhs = cst;
-            else
-              rhs = builder.create<hw::BitcastOp>(loc, elemTy, cst);
-
-            builder.create<sv::BPAssignOp>(loc, svReg.reg, rhs);
-          }
-        }
-
-        if (!asyncResets.empty()) {
-          // If the register is async reset, we need to insert extra
-          // initialization in post-randomization so that we can set the
-          // reset value to register if the reset signal is enabled.
-          for (auto &reset : asyncResets) {
-            //  if (reset) begin
-            //    ..
-            //  end
-            builder.create<sv::IfOp>(reset.first, [&] {
-              for (auto &reg : reset.second)
-                builder.create<sv::BPAssignOp>(reg.reg.getLoc(), reg.reg,
-                                               reg.asyncResetValue);
-            });
-          }
-        }
+        createRandomInitialization(builder);
+        createPresetInitialization(builder);
+        createAsyncResetInitialization(builder);
       });
 
       builder.create<sv::IfDefOp>("FIRRTL_AFTER_INITIAL", [&] {
@@ -273,8 +418,6 @@ void FirRegLowering::lower() {
       });
     });
   });
-
-  module->removeAttr("firrtl.random_init_width");
 }
 
 // Return true if two arguments are equivalent, or if both of them are the same
@@ -481,7 +624,8 @@ void FirRegLowering::createTree(OpBuilder &builder, Value reg, Value term,
       }
       // Compat fix for GCC12's libstdc++, cannot use
       // llvm::enumerate(llvm::reverse(OperandRange)).  See #4900.
-      // SmallVector<Value> reverseOpValues(llvm::reverse(array.getOperands()));
+      // SmallVector<Value>
+      // reverseOpValues(llvm::reverse(array.getOperands()));
       for (auto [idx, value] : llvm::enumerate(array.getOperands())) {
         idx = array.getOperands().size() - idx - 1;
         // Create an index constant.
@@ -515,12 +659,18 @@ void FirRegLowering::createTree(OpBuilder &builder, Value reg, Value term,
   }
 }
 
-FirRegLowering::RegLowerInfo FirRegLowering::lower(FirRegOp reg) {
+void FirRegLowering::lowerReg(FirRegOp reg) {
   Location loc = reg.getLoc();
   Type regTy = typeConverter.convertType(reg.getType());
 
+  HierPathOp path;
+  auto lookup = pathTable.find(reg);
+  if (lookup != pathTable.end())
+    path = lookup->second;
+
   ImplicitLocOpBuilder builder(reg.getLoc(), reg);
-  RegLowerInfo svReg{nullptr, reg.getPresetAttr(), nullptr, nullptr, -1, 0};
+  RegLowerInfo svReg{nullptr, path, reg.getPresetAttr(), nullptr, nullptr,
+                     -1,      0};
   svReg.reg = builder.create<sv::RegOp>(loc, regTy, reg.getNameAttr());
   svReg.width = hw::getBitWidth(regTy);
 
@@ -540,7 +690,7 @@ FirRegLowering::RegLowerInfo FirRegLowering::lower(FirRegOp reg) {
 
   if (reg.hasReset()) {
     addToAlwaysBlock(
-        module.getBodyBlock(), sv::EventControl::AtPosEdge, reg.getClk(),
+        reg->getBlock(), sv::EventControl::AtPosEdge, reg.getClk(),
         [&](OpBuilder &b) {
           // If this is an AsyncReset, ensure that we emit a self connect to
           // avoid erroneously creating a latch construct.
@@ -560,14 +710,29 @@ FirRegLowering::RegLowerInfo FirRegLowering::lower(FirRegOp reg) {
     }
   } else {
     addToAlwaysBlock(
-        module.getBodyBlock(), sv::EventControl::AtPosEdge, reg.getClk(),
+        reg->getBlock(), sv::EventControl::AtPosEdge, reg.getClk(),
         [&](OpBuilder &b) { createTree(b, svReg.reg, reg, reg.getNext()); });
   }
 
+  // Record information required later on to build the initialization code for
+  // this register. All initialization is grouped together in a single initial
+  // block at the back of the module.
+  if (svReg.preset)
+    presetInitRegs.push_back(svReg);
+  else if (!disableRegRandomization)
+    randomInitRegs.push_back(svReg);
+
+  if (svReg.asyncResetSignal)
+    asyncResets[svReg.asyncResetSignal].emplace_back(svReg);
+
+  // Remember the ifdef conditions surrounding this register, if present. We
+  // will need to place this register's initialization code under the same
+  // ifdef conditions.
+  if (!conditions.empty())
+    regConditionTable.emplace_or_assign(svReg.reg, conditions);
+
   reg.replaceAllUsesWith(regVal.getResult());
   reg.erase();
-
-  return svReg;
 }
 
 // Initialize registers by assigning each element recursively instead of
@@ -604,12 +769,60 @@ void FirRegLowering::initializeRegisterElements(Location loc,
 }
 // NOLINTEND(misc-no-recursion)
 
+void FirRegLowering::buildRegConditions(OpBuilder &b, sv::RegOp reg) {
+  // If there are no conditions, just return the current insertion point.
+  auto lookup = regConditionTable.find(reg);
+  if (lookup == regConditionTable.end())
+    return;
+
+  // Recreate the conditions under which the register was declared.
+  auto &conditions = lookup->second;
+  for (auto &condition : conditions) {
+    auto kind = condition.getKind();
+    if (kind == RegCondition::IfDefThen) {
+      auto ifDef = b.create<sv::IfDefProceduralOp>(
+          reg.getLoc(), condition.getMacro(), []() {});
+      b.setInsertionPointToEnd(ifDef.getThenBlock());
+      continue;
+    }
+    if (kind == RegCondition::IfDefElse) {
+      auto ifDef = b.create<sv::IfDefProceduralOp>(
+          reg.getLoc(), condition.getMacro(), []() {}, []() {});
+
+      b.setInsertionPointToEnd(ifDef.getElseBlock());
+      continue;
+    }
+    llvm_unreachable("unknown reg condition type");
+  }
+}
+
+static Value buildXMRTo(OpBuilder &builder, HierPathOp path, Location loc,
+                        Type type) {
+  auto name = path.getSymNameAttr();
+  auto ref = mlir::FlatSymbolRefAttr::get(name);
+  return builder.create<sv::XMRRefOp>(loc, type, ref);
+}
+
 void FirRegLowering::initialize(OpBuilder &builder, RegLowerInfo reg,
                                 ArrayRef<Value> rands) {
   auto loc = reg.reg.getLoc();
   SmallVector<Value> nibbles;
   if (reg.width == 0)
     return;
+
+  OpBuilder::InsertionGuard guard(builder);
+
+  // If the register was defined under ifdefs, we have to guard the
+  // initialization code under the same ifdefs. The builder's insertion point
+  // will be left inside the guards.
+  buildRegConditions(builder, reg.reg);
+
+  // If the register is not located in the toplevel body of the module, we must
+  // refer to the register by (local) XMR, since the register will not dominate
+  // the initialization block.
+  Value target = reg.reg;
+  if (reg.path)
+    target = buildXMRTo(builder, reg.path, reg.reg.getLoc(), reg.reg.getType());
 
   uint64_t width = reg.width;
   uint64_t offset = reg.randStart;
@@ -627,7 +840,7 @@ void FirRegLowering::initialize(OpBuilder &builder, RegLowerInfo reg,
   auto concat = builder.createOrFold<comb::ConcatOp>(loc, nibbles);
   unsigned pos = reg.width;
   // Initialize register elements.
-  initializeRegisterElements(loc, builder, reg.reg, concat, pos);
+  initializeRegisterElements(loc, builder, target, concat, pos);
 }
 
 void FirRegLowering::addToAlwaysBlock(
@@ -636,7 +849,7 @@ void FirRegLowering::addToAlwaysBlock(
     sv::EventControl resetEdge, Value reset,
     const std::function<void(OpBuilder &)> &resetBody) {
   auto loc = clock.getLoc();
-  auto builder = ImplicitLocOpBuilder::atBlockTerminator(loc, block);
+  ImplicitLocOpBuilder builder(loc, block, getBlockEnd(block));
   AlwaysKeyType key{builder.getBlock(), clockEdge, clock,
                     resetStyle,         resetEdge, reset};
 

--- a/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ModuleInliner.cpp
@@ -23,6 +23,7 @@
 #include "circt/Dialect/HW/InnerSymbolNamespace.h"
 #include "circt/Support/Debug.h"
 #include "circt/Support/LLVM.h"
+#include "circt/Support/Utils.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/BitVector.h"

--- a/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/ResolveTraces.cpp
@@ -20,6 +20,7 @@
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/SV/SVOps.h"
+#include "circt/Support/Utils.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/TypeSwitch.h"

--- a/lib/Dialect/FIRRTL/Transforms/SpecializeLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/SpecializeLayers.cpp
@@ -8,10 +8,10 @@
 
 #include "circt/Dialect/FIRRTL/FIRRTLAnnotations.h"
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
-#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Dialect/HW/HWAttributes.h"
 #include "circt/Dialect/HW/HWOps.h"
+#include "circt/Support/Utils.h"
 #include "mlir/IR/Threading.h"
 #include "llvm/ADT/STLExtras.h"
 #include <optional>

--- a/test/firtool/reg-under-inline-layer.fir
+++ b/test/firtool/reg-under-inline-layer.fir
@@ -1,0 +1,128 @@
+; RUN: firtool %s --split-input-file --strip-debug-info | FileCheck %s
+
+; Test for register under inline layer.
+
+FIRRTL version 5.0.0
+
+circuit RegUnderInlineLayer:
+  layer A, inline:
+
+  public module RegUnderInlineLayer:
+    input reset: UInt<1>
+    input clock: Clock
+    input data: UInt<1>
+    output probe: Probe<UInt<1>, A>
+
+    ; CHECK: `ifdef layer_RegUnderInlineLayer$A
+    ; CHECK:   reg  myreg;
+    ; CHECK:   wire myreg_probe = myreg;
+    ; CHECK:   always @(posedge clock) begin
+    ; CHECK:     if (reset)
+    ; CHECK:       myreg <= 1'h0;
+    ; CHECK:     else
+    ; CHECK:       myreg <= data;
+    ; CHECK:   end // always @(posedge)
+    ; CHECK: `endif // layer_RegUnderInlineLayer$A
+
+    ; CHECK: initial begin
+    ; CHECK:   automatic logic [31:0] _RANDOM[0:0];
+    ; CHECK:   _RANDOM[/*Zero width*/ 1'b0] = `RANDOM;
+    ; CHECK:   `ifdef layer_RegUnderInlineLayer$A
+    ; CHECK:     RegUnderInlineLayer.myreg = _RANDOM[/*Zero width*/ 1'b0][0];
+    ; CHECK:   `endif // layer_RegUnderInlineLayer$A
+    ; CHECK:    end // initial
+    layerblock A:
+      regreset myreg : UInt<1>, clock, reset, UInt<1>(0)
+      connect myreg, data
+      define probe = probe(myreg)
+
+; // -----
+
+; Test for register under nested inline layer.
+
+FIRRTL version 5.0.0
+
+circuit RegUnderInlineLayer:
+  layer A, inline:
+    layer B, inline:
+
+  public module RegUnderInlineLayer:
+    input reset: UInt<1>
+    input clock: Clock
+    input data: UInt<1>
+    output probe: Probe<UInt<1>, A.B>
+
+    ; CHECK: `ifdef layer_RegUnderInlineLayer$A
+    ; CHECK:   `ifdef layer_RegUnderInlineLayer$A$B
+    ; CHECK:     reg  myreg;
+    ; CHECK:     wire myreg_probe = myreg;
+    ; CHECK:     always @(posedge clock) begin
+    ; CHECK:       if (reset)
+    ; CHECK:         myreg <= 1'h0;
+    ; CHECK:       else
+    ; CHECK:         myreg <= data;
+    ; CHECK:     end // always @(posedge)
+    ; CHECK:   `endif // layer_RegUnderInlineLayer$A$B
+    ; CHECK: `endif // layer_RegUnderInlineLayer$A
+
+    ; CHECK: initial begin
+    ; CHECK:   automatic logic [31:0] _RANDOM[0:0];
+    ; CHECK:   _RANDOM[/*Zero width*/ 1'b0] = `RANDOM;
+    ; CHECK:   `ifdef layer_RegUnderInlineLayer$A
+    ; CHECK:     `ifdef layer_RegUnderInlineLayer$A$B
+    ; CHECK:       RegUnderInlineLayer.myreg = _RANDOM[/*Zero width*/ 1'b0][0];
+    ; CHECK:     `endif // layer_RegUnderInlineLayer$A$B
+    ; CHECK:   `endif // layer_RegUnderInlineLayer$A
+    ; CHECK:    end // initial
+    layerblock A:
+      layerblock B:
+        regreset myreg : UInt<1>, clock, reset, UInt<1>(0)
+        connect myreg, data
+        define probe = probe(myreg)
+
+; // -----
+
+; Test for register under inline layer, which is under a bind layer.
+
+FIRRTL version 5.0.0
+
+circuit RegUnderInlineLayer:
+  layer A, bind:
+    layer B, inline:
+
+  ; Within the extracted bind-layer, there is an ifdef for layer b, guarding
+  ; the register and its initialization.
+
+  ; CHECK: module RegUnderInlineLayer_A();
+  ; CHECK:   `ifdef layer_RegUnderInlineLayer$A$B
+  ; CHECK:     reg  myreg;
+  ; CHECK:     wire myreg_probe = myreg;
+  ; CHECK:     always @(posedge RegUnderInlineLayer.clock) begin
+  ; CHECK:       if (RegUnderInlineLayer.reset)
+  ; CHECK:         myreg <= 1'h0;
+  ; CHECK:       else
+  ; CHECK:         myreg <= RegUnderInlineLayer.data;
+  ; CHECK:     end // always @(posedge)
+  ; CHECK:   `endif // layer_RegUnderInlineLayer$A$B
+  ; CHECK:     initial begin
+  ; CHECK:       automatic logic [31:0] _RANDOM[0:0];
+  ; CHECK:       `ifdef RANDOMIZE_REG_INIT
+  ; CHECK:         _RANDOM[/*Zero width*/ 1'b0] = `RANDOM;
+  ; CHECK:         `ifdef layer_RegUnderInlineLayer$A$B
+  ; CHECK:           RegUnderInlineLayer_A.myreg = _RANDOM[/*Zero width*/ 1'b0][0];
+  ; CHECK:         `endif // layer_RegUnderInlineLayer$A$B
+  ; CHECK:       `endif // RANDOMIZE_REG_INIT
+  ; CHECK:     end // initial
+  ; CHECK: endmodule
+
+  public module RegUnderInlineLayer:
+    input reset: UInt<1>
+    input clock: Clock
+    input data: UInt<1>
+    output probe: Probe<UInt<1>, A.B>
+
+    layerblock A:
+      layerblock B:
+        regreset myreg : UInt<1>, clock, reset, UInt<1>(0)
+        connect myreg, data
+        define probe = probe(myreg)


### PR DESCRIPTION
In seq-to-sv, we transform seq FirRegOps to sv RegOps. This is done using a helper called FirRegLowering. This PR changes FirRegLowering to correctly lower registers under ifdef blocks.

The initialization of registers is placed in an initial block at the footer of the enclosing HWModuleOp. In order to initialize registers buried under ifdefs, we have to refer to these registers by a local XMR, because the buried registers will not dominate the initial block. We build these in a prepass over the MLIR module, returning a "PathTable" sending buried FirRegOps to their HierPathOps.

The main FirRegLowering procedure operates in parallel on each HWModuleOp. Each invocation is now handed a const reference to the path table, which allows us to produce an XMRRefOp as needed while emitting the register initialization code at the footer of the HWModule.

The initialization code for a register has to be guarded under the same ifdef conditions as the register itself. To do this, while lowering registers, we record the conditions under which the register is defined, and recreate them to guard the initialization code.

When we lower a register, we attempt to transform any input mux tree into an SV if-else tree of connects. This PR modifies the if-else generation to co-locate the if-else with the register. So if a register is guarded under an ifdef, then the if-else structure driving it will also be under the same ifdef.

Fixes: #8461
