### PR TITLE
[AIG][AIGERRunner] Refactor AIG external solver passes and add continueOnFailure option

### DIFF
--- a/include/circt/Dialect/AIG/AIGPasses.td
+++ b/include/circt/Dialect/AIG/AIGPasses.td
@@ -29,7 +29,18 @@ def PrintLongestPathAnalysis : Pass<"aig-print-longest-path-analysis", "mlir::Mo
   ];
 }
 
-def AIGERRunner : Pass<"aig-runner", "hw::HWModuleOp"> {
+class ExternalSolverPass<string name> : Pass<name, "hw::HWModuleOp"> {
+  list<Option> baseOptions = [
+    Option<"continueOnFailure", "continue-on-failure", "bool", "false",
+           "Don't fail even if the AIGER exporter, external solver, or AIGER importer fail">,
+  ];
+
+  let dependentDialects = [
+    "circt::comb::CombDialect", "circt::hw::HWDialect", "circt::seq::SeqDialect"
+  ];
+}
+
+def AIGERRunner : ExternalSolverPass<"aig-runner"> {
   let summary = "Run external logic solvers on AIGER files";
   let description = [{
     This pass exports the current hardware module to AIGER format, runs an
@@ -45,18 +56,14 @@ def AIGERRunner : Pass<"aig-runner", "hw::HWModuleOp"> {
     solver. Hence if the user wants to use ABC, they should use ABCRunner instead
     of AIGERRunner.
   }];
-  let options = [
+  let options = baseOptions # [
     Option<"solverPath", "solver-path", "std::string", "",
            "Path to the external solver executable">,
     ListOption<"solverArgs", "solver-args", "std::string", "">
   ];
-
-  let dependentDialects = [
-    "circt::comb::CombDialect", "circt::hw::HWDialect", "circt::seq::SeqDialect"
-  ];
 }
 
-def ABCRunner : Pass<"abc-runner", "hw::HWModuleOp"> {
+def ABCRunner : ExternalSolverPass<"abc-runner"> {
   let summary = "Run ABC on AIGER files";
   let description = [{
     This pass runs ABC on AIGER files. It is a wrapper around AIGERRunner that
@@ -65,13 +72,9 @@ def ABCRunner : Pass<"abc-runner", "hw::HWModuleOp"> {
     - for each command in `abcCommands`, run `-q <command>`
     - `write <outputFile>`: Write the AIGER file
   }];
-  let options = [
+  let options =  baseOptions # [
     Option<"abcPath", "abc-path", "std::string", "", "Path to the ABC executable">,
-    ListOption<"abcCommands", "abc-commands", "std::string", "">
-  ];
-
-  let dependentDialects = [
-    "circt::comb::CombDialect", "circt::hw::HWDialect", "circt::seq::SeqDialect"
+    ListOption<"abcCommands", "abc-commands", "std::string", "">,
   ];
 }
 

--- a/lib/Dialect/AIG/Transforms/AIGERRunner.cpp
+++ b/lib/Dialect/AIG/Transforms/AIGERRunner.cpp
@@ -283,10 +283,10 @@ LogicalResult AIGERRunner::run(hw::HWModuleOp module) {
 
   Converter converter;
 
-  auto reportWarningOrError = [&](const Twine &warning) -> LogicalResult {
+  auto reportWarningOrError = [&](const Twine &message) -> LogicalResult {
     (continueOnFailure ? mlir::emitWarning(module.getLoc())
                        : mlir::emitError(module.getLoc()))
-        << warning << " on module " << module.getModuleNameAttr();
+        << message << " on module " << module.getModuleNameAttr();
     return success(continueOnFailure);
   };
 

--- a/lib/Dialect/AIG/Transforms/AIGERRunner.cpp
+++ b/lib/Dialect/AIG/Transforms/AIGERRunner.cpp
@@ -245,8 +245,10 @@ void Converter::notifyClock(Value value) { clock = value; }
 namespace {
 class AIGERRunner {
 public:
-  AIGERRunner(llvm::StringRef solverPath, SmallVector<std::string> solverArgs)
-      : solverPath(solverPath), solverArgs(std::move(solverArgs)) {}
+  AIGERRunner(llvm::StringRef solverPath, SmallVector<std::string> solverArgs,
+              bool continueOnFailure)
+      : solverPath(solverPath), solverArgs(std::move(solverArgs)),
+        continueOnFailure(continueOnFailure) {}
 
   LogicalResult run(hw::HWModuleOp module);
 
@@ -260,6 +262,7 @@ private:
                                 hw::HWModuleOp module);
   llvm::StringRef solverPath;
   SmallVector<std::string> solverArgs;
+  bool continueOnFailure;
 };
 
 } // namespace
@@ -280,21 +283,25 @@ LogicalResult AIGERRunner::run(hw::HWModuleOp module) {
 
   Converter converter;
 
+  auto reportWarningOrError = [&](const Twine &warning) -> LogicalResult {
+    (continueOnFailure ? mlir::emitWarning(module.getLoc())
+                       : mlir::emitError(module.getLoc()))
+        << warning << " on module " << module.getModuleNameAttr();
+    return success(continueOnFailure);
+  };
+
   // Export current module to AIGER format
   if (failed(exportToAIGER(converter, cast<hw::HWModuleOp>(module), inputPath)))
-    return emitError(module.getLoc(),
-                     "failed to export module to AIGER format for ")
-           << module.getModuleNameAttr();
+    return reportWarningOrError("failed to export module to AIGER format");
 
   // Run the external solver
   if (failed(runSolver(module, inputPath, outputPath)))
-    return emitError(module.getLoc(), "failed to run external solver");
+    return reportWarningOrError("failed to run external solver");
 
   // Import the results back
   if (failed(
           importFromAIGER(converter, outputPath, cast<hw::HWModuleOp>(module))))
-    return emitError(module.getLoc(),
-                     "failed to import results from AIGER format");
+    return reportWarningOrError("failed to import results from AIGER format");
 
   // If we get here, we succeeded. Clean up temporary files.
   if (llvm::sys::fs::remove(inputPath))
@@ -438,25 +445,8 @@ LogicalResult AIGERRunner::importFromAIGER(Converter &converter,
 namespace {
 class AIGERRunnerPass : public impl::AIGERRunnerBase<AIGERRunnerPass> {
 public:
-  AIGERRunnerPass() = default;
-  AIGERRunnerPass(const AIGERRunnerOptions &options) {
-    solverPath = options.solverPath;
-    solverArgs = options.solverArgs;
-  }
-
+  using AIGERRunnerBase<AIGERRunnerPass>::AIGERRunnerBase;
   void runOnOperation() override;
-
-private:
-  using AIGERRunnerBase::AIGERRunnerBase::solverArgs;
-  using AIGERRunnerBase::AIGERRunnerBase::solverPath;
-
-  // Helper methods
-  LogicalResult runSolver(hw::HWModuleOp module, StringRef inputPath,
-                          StringRef outputPath);
-  LogicalResult exportToAIGER(Converter &converter, hw::HWModuleOp module,
-                              StringRef outputPath);
-  LogicalResult importFromAIGER(Converter &converter, StringRef inputPath,
-                                hw::HWModuleOp module);
 };
 } // namespace
 
@@ -468,7 +458,7 @@ void AIGERRunnerPass::runOnOperation() {
   for (const auto &arg : solverArgs)
     solverArgsRef.push_back(arg);
 
-  AIGERRunner runner(solverPath, std::move(solverArgsRef));
+  AIGERRunner runner(solverPath, std::move(solverArgsRef), continueOnFailure);
   if (failed(runner.run(module)))
     signalPassFailure();
 }
@@ -480,12 +470,7 @@ void AIGERRunnerPass::runOnOperation() {
 namespace {
 class ABCRunnerPass : public impl::ABCRunnerBase<ABCRunnerPass> {
 public:
-  ABCRunnerPass() = default;
-  ABCRunnerPass(const ABCRunnerOptions &options) {
-    abcPath = options.abcPath;
-    abcCommands = options.abcCommands;
-  }
-
+  using ABCRunnerBase<ABCRunnerPass>::ABCRunnerBase;
   void runOnOperation() override;
 };
 } // namespace
@@ -514,7 +499,7 @@ void ABCRunnerPass::runOnOperation() {
   addABCCommand("write <outputFile>");
 
   // Execute the ABC optimization sequence
-  AIGERRunner abcRunner(abcPath, std::move(abcArguments));
+  AIGERRunner abcRunner(abcPath, std::move(abcArguments), continueOnFailure);
   if (failed(abcRunner.run(module)))
     signalPassFailure();
 }

--- a/test/Dialect/AIG/aiger-runner-error.mlir
+++ b/test/Dialect/AIG/aiger-runner-error.mlir
@@ -3,7 +3,7 @@
 
 // expected-error@below {{multiple clocks found in the module}}
 // expected-note@below {{previous clock is here}}
-// expected-error@below {{failed to export module to AIGER format for "multipleClock"}}
+// expected-error@below {{failed to export module to AIGER format on module "multipleClock"}}
 hw.module @multipleClock(in %c1: !seq.clock, in %c2: !seq.clock, in %a: i1, out out1: i1, out out2: i1) {
   %0 = seq.compreg %a, %c1 : i1
   %1 = seq.compreg %a, %c2 : i1

--- a/tools/circt-synth/circt-synth.cpp
+++ b/tools/circt-synth/circt-synth.cpp
@@ -120,6 +120,11 @@ static cl::opt<std::string> abcPath("abc-path", cl::desc("Path to ABC"),
                                     cl::value_desc("path"), cl::init("abc"),
                                     cl::cat(mainCategory));
 
+static cl::opt<bool>
+    continueOnFailure("ignore-abc-failures",
+                      cl::desc("Continue on ABC failure instead of aborting"),
+                      cl::init(false), cl::cat(mainCategory));
+
 //===----------------------------------------------------------------------===//
 // Main Tool Logic
 //===----------------------------------------------------------------------===//
@@ -177,6 +182,7 @@ static void populateSynthesisPipeline(PassManager &pm) {
       aig::ABCRunnerOptions options;
       options.abcPath = abcPath;
       options.abcCommands.assign(abcCommands.begin(), abcCommands.end());
+      options.continueOnFailure = continueOnFailure;
       mpm.addPass(aig::createABCRunner(options));
     }
     // TODO: Add balancing, rewriting, FRAIG conversion, etc.


### PR DESCRIPTION
This commit refactors and adds an option to AIGERRunner. 
1. Create ExternalSolverPass base class to reduce code duplication between AIGERRunner and ABCRunner passes, providing shared options and dependent dialects through inheritance.

2. Add --ignore-abc-failures command line option to circt-synth tool to enable continue-on-failure behavior for ABC optimization. Currently the pass fails if there are multiple clocks so it's convenient to just skip them.