### PR TITLE
[PyCDE] Support for importing Kanagawa

### DIFF
--- a/frontends/PyCDE/src/pycde/common.py
+++ b/frontends/PyCDE/src/pycde/common.py
@@ -158,7 +158,7 @@ class _PyProxy:
   """Parent class for a Python object which has a corresponding IR op (i.e. a
   proxy class)."""
 
-  __slots__ = ["name"]
+  __slots__ = ["name", "__weakref__"]
 
   def __init__(self, name: str):
     self.name = name

--- a/frontends/PyCDE/src/pycde/module.py
+++ b/frontends/PyCDE/src/pycde/module.py
@@ -743,19 +743,10 @@ class ImportedModSpec(ModuleBuilder):
   # Creation callback that just moves the already build module into the System's
   # ModuleOp and returns it.
   def create_op(self, sys, symbol: str):
-    hw_module = self.modcls.hw_module
-
-    # TODO: deal with symbolrefs to this (potentially renamed) module symbol.
-    sys.mod.body.append(hw_module)
-
-    # Need to clear out the reference to ourselves so that we can release the
-    # raw reference to `hw_module`. It's safe to do so since unlike true PyCDE
-    # modules, this can only be run once during the import_mlir.
-    self.modcls.hw_module = None
-    return hw_module
+    assert False, "ImportedModSpec should not be used on imported modules."
 
 
-def import_hw_module(sys, hw_module: hw.HWModuleOp):
+def import_hw_module(sys, hw_module: hw.HWModuleOp) -> type[Module]:
   """Import a CIRCT module into PyCDE. Returns a standard Module subclass which
   operates just like an external PyCDE module.
 
@@ -773,7 +764,6 @@ def import_hw_module(sys, hw_module: hw.HWModuleOp):
                                       mod_type.output_types):
     modattrs[output_name] = Output(_FromCirctType(output_type), output_name)
   modattrs["BuilderType"] = ImportedModSpec
-  modattrs["hw_module"] = hw_module
 
   modattrs["add_metadata"] = staticmethod(
       lambda meta, sys=sys: add_metadata(sys, name, meta))
@@ -781,6 +771,8 @@ def import_hw_module(sys, hw_module: hw.HWModuleOp):
   # Use the name and ports to construct a class object like what externmodule
   # would wrap.
   cls = type(name, (Module,), modattrs)
+  cls._builder = cls.BuilderType(cls, modattrs, hw_module.location)
+  cls._builder.go()
 
   def add_metadata(sys, symbol: str, meta: Optional[Metadata]):
     return cls._builder.add_metadata(sys, symbol, meta)

--- a/frontends/PyCDE/test/test_kanagawa.py
+++ b/frontends/PyCDE/test/test_kanagawa.py
@@ -1,0 +1,60 @@
+# RUN: %PYTHON% %s | FileCheck %s
+
+from pycde import Module, System, generator
+from pycde.common import Clock, Output, Reset
+from pycde.types import Bits
+
+from typing import Dict, Type
+
+# Simple Kanagawa IR for basic test
+basic_kanagawa_ir = """
+kanagawa.design @test {
+  kanagawa.container sym @basic_test {
+    %out_port = kanagawa.port.output "out" sym @test_out : i32
+    %c0_i32 = hw.constant 0 : i32
+    kanagawa.port.write %out_port, %c0_i32 : !kanagawa.portref<out i32>
+  }
+}
+"""
+
+
+class TestKanagawaBasic(Module):
+  """A simple Kanagawa module for testing."""
+
+  clk = Clock()
+  rst = Reset()
+  out = Output(Bits(32))
+
+  kanagawa_modules: Dict[str, Type[Module]]
+
+  @generator
+  def build(ports):
+    kng_basic_mod = TestKanagawaBasic.kanagawa_modules["test_basic_test"]
+    kng_basic_inst = kng_basic_mod()
+    ports.out = kng_basic_inst.out
+
+
+def test_kanagawa_basic():
+  """Test basic Kanagawa IR import and lowering."""
+  sys = System(TestKanagawaBasic)
+
+  # Import the Kanagawa IR and run Kanagawa lowering passes from System class
+  TestKanagawaBasic.kanagawa_modules = sys.import_mlir(
+      basic_kanagawa_ir,
+      name="kng_test",
+      lowering=System.KANAGAWA_DIALECT_PASSES)
+  sys.generate()
+  sys.run_passes()
+  print(sys.mod)
+
+
+test_kanagawa_basic()
+
+# CHECK-LABEL:  hw.module @TestKanagawaBasic(in %clk : i1, in %rst : i1, out out : i32) attributes {output_file = #hw.output_file<"TestKanagawaBasic.sv", includeReplicatedOps>} {
+# CHECK-NEXT:     %test_basic_test.out = hw.instance "test_basic_test" sym @test_basic_test @test_basic_test() -> (out: i32)
+# CHECK-NEXT:     hw.output %test_basic_test.out : i32
+# CHECK-NEXT:   }
+# CHECK-LABEL:  hw.module @test_basic_test(out out : i32) {
+# CHECK-NEXT:     %c0_i32 = hw.constant 0 : i32
+# CHECK-NEXT:     hw.output %c0_i32 : i32
+# CHECK-NEXT:   }


### PR DESCRIPTION
This PR adds support for importing Kanagawa IR into PyCDE and improves the overall pass management and proxy caching in the system.

- Added a new test file for Kanagawa IR import and lowering.
- Updated the System and _OpCache functionality to change type hints and weak reference handling.
- Revised the imported module creation and pass-phase execution logic.