### PR TITLE
[FIRRTL] Avoid interface cast in inject-dut-hier

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/InjectDUTHierarchy.cpp
@@ -245,7 +245,7 @@ void InjectDUTHierarchy::runOnOperation() {
     // The DUT name has changed.  Rewrite instances to use the new DUT name.
     InstanceGraph &instanceGraph = getAnalysis<InstanceGraph>();
     for (auto *use : instanceGraph.lookup(wrapper.getNameAttr())->uses()) {
-      auto instanceOp = dyn_cast<InstanceOp>(use->getInstance());
+      auto instanceOp = use->getInstance<InstanceOp>();
       if (!instanceOp) {
         use->getInstance().emitOpError()
             << "instantiates the design-under-test, but "


### PR DESCRIPTION
Fix a nightly failure observed with gcc release builds due to a cast of an
interface to an operation.  This is known to be problematic.

Testing via manual trigger here: https://github.com/llvm/circt/actions/runs/15947527423

This is intended to fix this failure: https://github.com/llvm/circt/actions/runs/15943909376/job/44975510792#step:6:6782