### PR TITLE
[FIRRTL] Fix cat canonicalization to handle mixed signed/unsigned operands

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -1404,14 +1404,13 @@ public:
         worklist.push_back(operand);
     };
     pushOperands(cat);
-    bool existsSigned = false, existsUnsigned = false;
+    bool hasSigned = false, hasUnsigned = false;
     while (!worklist.empty()) {
       auto value = worklist.pop_back_val();
       auto catOp = value.getDefiningOp<CatPrimOp>();
       if (!catOp) {
         operands.push_back(value);
-        (type_isa<UIntType>(value.getType()) ? existsUnsigned : existsSigned) =
-            true;
+        (type_isa<UIntType>(value.getType()) ? hasUnsigned : hasSigned) = true;
         continue;
       }
 
@@ -1437,7 +1436,7 @@ public:
       return failure();
 
     // If types are mixed, cast all operands to unsigned.
-    if (existsSigned && existsUnsigned)
+    if (hasSigned && hasUnsigned)
       for (auto &operand : operands)
         operand = castToUIntIfSigned(operand);
 

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -1066,6 +1066,25 @@ firrtl.module @FlattenCatEdgeCases(in %a: !firrtl.uint<4>, out %out1: !firrtl.ui
   firrtl.matchingconnect %out2, %zero_cat2 : !firrtl.uint<8>
 }
 
+// Issue 8618
+// CHECK-LABEL: firrtl.module @FlattenCatDifferentSigns
+firrtl.module @FlattenCatDifferentSigns(in %a: !firrtl.uint<1>, in %b: !firrtl.sint<1>, in %c: !firrtl.sint<1>, out %d: !firrtl.uint<3>, out %e: !firrtl.uint<4>) {
+  // CHECK-NEXT: %[[AS_UINT1:.+]] = firrtl.asUInt %b : (!firrtl.sint<1>) -> !firrtl.uint<1>
+  // CHECK-NEXT: %[[AS_UINT2:.+]] = firrtl.asUInt %b : (!firrtl.sint<1>) -> !firrtl.uint<1>
+  // CHECK-NEXT: %[[CAT1:.+]] = firrtl.cat %a, %[[AS_UINT1]], %[[AS_UINT2]] : (!firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>) -> !firrtl.uint<3>
+  // CHECK-NEXT: firrtl.matchingconnect %d, %[[CAT1]]
+  %0 = firrtl.cat %b, %b : (!firrtl.sint<1>, !firrtl.sint<1>) -> !firrtl.uint<2>
+  %1 = firrtl.cat %a, %0 : (!firrtl.uint<1>, !firrtl.uint<2>) -> !firrtl.uint<3>
+  firrtl.matchingconnect %d, %1 : !firrtl.uint<3>
+
+  // CHECK-NEXT: %[[CAT2:.+]] = firrtl.cat %b, %c, %c, %b : (!firrtl.sint<1>, !firrtl.sint<1>, !firrtl.sint<1>, !firrtl.sint<1>) -> !firrtl.uint<4>
+  // CHECK-NEXT: firrtl.matchingconnect %e, %[[CAT2]]
+  %2 = firrtl.cat %b, %c : (!firrtl.sint<1>, !firrtl.sint<1>) -> !firrtl.uint<2>
+  %3 = firrtl.cat %c, %b : (!firrtl.sint<1>, !firrtl.sint<1>) -> !firrtl.uint<2>
+  %4 = firrtl.cat %2, %3 : (!firrtl.uint<2>, !firrtl.uint<2>) -> !firrtl.uint<4>
+  firrtl.matchingconnect %e, %4 : !firrtl.uint<4>
+}
+
 // CHECK-LABEL: firrtl.module @CatOfConstant
 firrtl.module @CatOfConstant(in %a: !firrtl.uint<4>, out %out1: !firrtl.uint<12>,
                             out %out2: !firrtl.uint<10>) {


### PR DESCRIPTION
This commit enhances the cat operation canonicalization in FIRRTLFolds.cpp to properly handle cases where operands have mixed signed and unsigned types.

The implementation now tracks whether signed and unsigned operands exist during cat flattening. When mixed types are present, it adds explicit casting of signed values to unsigned using AsUIntPrimOp. Single operand cases are also properly cast to unsigned if needed.

Fix #8618