### PR TITLE
[FIRRTL] Fix Grand Central companion not-in-design

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/GrandCentral.cpp
@@ -2131,6 +2131,13 @@ void GrandCentralPass::runOnOperation() {
                 }
               }
 
+              // If the companion is instantiated above the DUT, then don't
+              // extract it.
+              if (!instanceInfo->allInstancesUnderEffectiveDut(op)) {
+                ++numAnnosRemoved;
+                return true;
+              }
+
               // Look for any modules/extmodules _only_ instantiated by the
               // companion.  If these have no output file attribute, then mark
               // them as being extracted into the Grand Central directory.

--- a/test/Dialect/FIRRTL/grand-central.mlir
+++ b/test/Dialect/FIRRTL/grand-central.mlir
@@ -1146,3 +1146,56 @@ firrtl.circuit "MultiplyInstantiated" attributes {
 // CHECK-NOT:      output_file
 //
 // CHECK:      sv.interface
+
+// -----
+
+firrtl.circuit "CompanionInTestharness" attributes {
+  annotations = [
+    {class = "sifive.enterprise.grandcentral.AugmentedBundleType",
+     defName = "View",
+     elements = [
+       {class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+        id = 42 : i64,
+        name = "field"}],
+     id = 0 : i64},
+    {class = "sifive.enterprise.grandcentral.ExtractGrandCentralAnnotation",
+     directory = "gct-dir",
+     filename = "gct-dir/bindings.sv"},
+    {class = "sifive.enterprise.grandcentral.GrandCentralHierarchyFileAnnotation",
+     filename = "gct.yaml"},
+    {class = "sifive.enterprise.firrtl.TestBenchDirAnnotation", dirname = "testbench"}]} {
+  firrtl.layer @A bind {}
+  firrtl.module private @View_companion() attributes {
+    annotations = [
+      {class = "sifive.enterprise.grandcentral.ViewAnnotation.companion",
+       defName = "Companion",
+       id = 0 : i64,
+       name = "View"}]} {
+    %0 = firrtl.constant 0 :!firrtl.uint<1>
+    %zero = firrtl.node  %0  {
+      annotations = [
+        {
+          class = "sifive.enterprise.grandcentral.AugmentedGroundType",
+          id = 42 : i64
+        }
+      ]
+    } : !firrtl.uint<1>
+  }
+  firrtl.module public @DUT() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {
+  }
+  firrtl.module @CompanionInTestharness() {
+    firrtl.instance dut @DUT()
+    firrtl.instance foo @View_companion()
+  }
+}
+
+// CHECK:     firrtl.module private @View_companion()
+// CHECK-NOT: output_file
+//
+// CHECK:     firrtl.module public @DUT()


### PR DESCRIPTION
Fix a regression introduced in 88f5d5a56 where a Grand Central companion
instantiated only under the test harness would cause the companion to be
instantiated in the Grand Central directory and not under the test harness
directory.  An early exit if no instances are in the design was
incorrectly dropped.
