### PR TITLE
[Support] Add concatPath method to InstancePathCache

### DIFF
--- a/include/circt/Support/InstanceGraph.h
+++ b/include/circt/Support/InstanceGraph.h
@@ -370,6 +370,9 @@ struct InstancePathCache {
   /// Prepend an instance to a path.
   InstancePath prependInstance(InstanceOpInterface inst, InstancePath path);
 
+  /// Concatenate two paths.
+  InstancePath concatPath(InstancePath path1, InstancePath path2);
+
 private:
   using PathsCache = DenseMap<Operation *, ArrayRef<InstancePath>>;
   ArrayRef<InstancePath> getPaths(ModuleOpInterface op, InstanceGraphNode *top,

--- a/lib/Support/InstanceGraph.cpp
+++ b/lib/Support/InstanceGraph.cpp
@@ -329,6 +329,15 @@ InstancePath InstancePathCache::prependInstance(InstanceOpInterface inst,
   return InstancePath(ArrayRef(newPath, n));
 }
 
+InstancePath InstancePathCache::concatPath(InstancePath path1,
+                                           InstancePath path2) {
+  size_t n = path1.size() + path2.size();
+  auto *newPath = allocator.Allocate<InstanceOpInterface>(n);
+  std::copy(path1.begin(), path1.end(), newPath);
+  std::copy(path2.begin(), path2.end(), newPath + path1.size());
+  return InstancePath(ArrayRef(newPath, n));
+}
+
 void InstancePathCache::replaceInstance(InstanceOpInterface oldOp,
                                         InstanceOpInterface newOp) {
 

--- a/unittests/Dialect/HW/InstancePathTest.cpp
+++ b/unittests/Dialect/HW/InstancePathTest.cpp
@@ -57,7 +57,7 @@ TEST(InstancePathTest, RelativePath) {
   EXPECT_EQ("cat", catToAlligatorPaths[0][1].getInstanceName());
 }
 
-TEST(InstancePathTest, AppendPrependInstance) {
+TEST(InstancePathTest, AppendPrependConcatInstance) {
   MLIRContext context;
   ModuleOp circuit = fixtures::createModule(&context);
   hw::InstanceGraph graph(circuit);
@@ -91,6 +91,13 @@ TEST(InstancePathTest, AppendPrependInstance) {
   ASSERT_EQ(2ull, appended.size());
   EXPECT_EQ(breakfast, appended[0]);
   EXPECT_EQ(kitty, appended[1]);
+
+  auto concatenated =
+      pathCache.concatPath(pathCache.appendInstance(empty, breakfast),
+                           pathCache.appendInstance(empty, kitty));
+  ASSERT_EQ(2ull, concatenated.size());
+  EXPECT_EQ(breakfast, concatenated[0]);
+  EXPECT_EQ(kitty, concatenated[1]);
 }
 
 TEST(InstancePathTest, Hash) {


### PR DESCRIPTION
Add a new method to InstancePathCache that concatenates two instance paths. This complements the existing prependInstance and appendInstance methods, providing a more complete API for manipulating instance paths.