### PR TITLE
[FIRRTL] Allow layers to RWProbe into the design

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -6260,30 +6260,10 @@ LogicalResult RWProbeOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
     }
     return success();
   };
-
-  auto checkLayers = [&](Location loc) -> LogicalResult {
-    auto dstLayers = getAmbientLayersAt(target.getOp());
-    auto srcLayers = getLayersFor(getResult());
-    SmallVector<SymbolRefAttr> missingLayers;
-    if (!isLayerSetCompatibleWith(srcLayers, dstLayers, missingLayers)) {
-      auto diag = emitOpError("target has insufficient layer requirements");
-      auto &note = diag.attachNote(loc);
-      note << "target is missing layer requirements: ";
-      llvm::interleaveComma(missingLayers, note);
-      return failure();
-    }
-    return success();
-  };
-  auto checks = [&](auto type, Location loc) {
-    if (failed(checkLayers(loc)))
-      return failure();
-    return checkFinalType(type, loc);
-  };
-
   if (target.isPort()) {
     auto mod = cast<FModuleLike>(target.getOp());
-    return checks(mod.getPortType(target.getPort()),
-                  mod.getPortLocation(target.getPort()));
+    return checkFinalType(mod.getPortType(target.getPort()),
+                          mod.getPortLocation(target.getPort()));
   }
   hw::InnerSymbolOpInterface symOp =
       cast<hw::InnerSymbolOpInterface>(target.getOp());
@@ -6297,7 +6277,7 @@ LogicalResult RWProbeOp::verifyInnerRefs(hw::InnerRefNamespace &ns) {
     return emitOpError("is not dominated by target")
         .attachNote(symOp.getLoc())
         .append("target here");
-  return checks(symOp.getTargetResult().getType(), symOp.getLoc());
+  return checkFinalType(symOp.getTargetResult().getType(), symOp.getLoc());
 }
 
 LogicalResult XMRRefOp::verifySymbolUses(SymbolTableCollection &symbolTable) {

--- a/test/Dialect/FIRRTL/advanced-layer-sink.mlir
+++ b/test/Dialect/FIRRTL/advanced-layer-sink.mlir
@@ -817,3 +817,22 @@ firrtl.circuit "SinkRefs" {
     }
   }
 }
+
+firrtl.circuit "SinkRWProbe" {
+  firrtl.layer @A bind {}
+
+  firrtl.module public @SinkRWProbe(out %p: !firrtl.rwprobe<uint<1>, @A>) {
+    %w = firrtl.wire sym @sym : !firrtl.uint<1>
+    %0 = firrtl.ref.rwprobe <@SinkRWProbe::@sym> : !firrtl.rwprobe<uint<1>>
+    %1 = firrtl.ref.cast %0 : (!firrtl.rwprobe<uint<1>>) -> !firrtl.rwprobe<uint<1>, @A>
+    // CHECK:      %w = firrtl.wire sym @sym : !firrtl.uint<1>
+    // CHECK-NEXT: firrtl.layerblock @A {
+    // CHECK-NEXT:   %0 = firrtl.ref.rwprobe <@SinkRWProbe::@sym> : !firrtl.rwprobe<uint<1>>
+    // CHECK-NEXT:   %1 = firrtl.ref.cast %0 : (!firrtl.rwprobe<uint<1>>) -> !firrtl.rwprobe<uint<1>, @A>
+    // CHECK-NEXT:   firrtl.ref.define %p, %1 : !firrtl.rwprobe<uint<1>, @A>
+    // CHECK-NEXT: }
+    firrtl.layerblock @A {
+      firrtl.ref.define %p, %1 : !firrtl.rwprobe<uint<1>, @A>
+    }
+  }
+}

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -2057,20 +2057,6 @@ firrtl.circuit "RWProbeUseDef" {
 
 // -----
 
-firrtl.circuit "RWProbeLayerRequirements" {
-  firrtl.layer @A bind { }
-  firrtl.module @RWProbeLayerRequirements(in %cond : !firrtl.uint<1>) {
-    // expected-note @below {{target is missing layer requirements: @A}}
-    %w = firrtl.wire sym @x : !firrtl.uint<1>
-    firrtl.layerblock @A {
-      // expected-error @below {{target has insufficient layer requirements}}
-      %rw = firrtl.ref.rwprobe <@RWProbeLayerRequirements::@x> : !firrtl.rwprobe<uint<1>>
-    }
-  }
-}
-
-// -----
-
 firrtl.circuit "MissingClassForObjectPortInModule" {
   // expected-error @below {{'firrtl.module' op references unknown class @Missing}}
   firrtl.module @MissingClassForObjectPortInModule(out %o: !firrtl.class<@Missing()>) {}

--- a/test/Dialect/FIRRTL/layers.mlir
+++ b/test/Dialect/FIRRTL/layers.mlir
@@ -242,16 +242,4 @@ firrtl.circuit "Test" {
       firrtl.propassign %foo_in, %str : !firrtl.string
     }
   }
-
-  //===--------------------------------------------------------------------===//
-  // RWProbe under Layer
-  //===--------------------------------------------------------------------===//
-
-  firrtl.module @RWProbeInLayer() {
-    firrtl.layerblock @A {
-      %w = firrtl.wire sym @sym : !firrtl.uint<1>
-      %rwp = firrtl.ref.rwprobe <@RWProbeInLayer::@sym> : !firrtl.rwprobe<uint<1>>
-    }
-  }
-
 }


### PR DESCRIPTION
An old verifier for the RWPRobe op asserted that the target was under at least the same conditions as the probe op itself, ensuring that we could not create a forceable probe from within a layer, to something outside of that layer. This verifier helped ensure that "enabling a layer cannot change the behaviour of the design". We no longer have nor want this restriction, so this PR is removing the verifier.

This fixes an issue with advanced layer sink, where ALS will sink rwprobe ops into a layer and trigger this verification check.

Fixes: #8640