### PR TITLE
[AIG] Enhance longest path analysis with detailed timing statistics and JSON output

### DIFF
--- a/include/circt/Dialect/AIG/AIGPasses.td
+++ b/include/circt/Dialect/AIG/AIGPasses.td
@@ -21,11 +21,25 @@ def LowerWordToBits : Pass<"aig-lower-word-to-bits", "hw::HWModuleOp"> {
 }
 
 def PrintLongestPathAnalysis : Pass<"aig-print-longest-path-analysis", "mlir::ModuleOp"> {
-  let summary = "Print longest path analysis";
+  let summary = "Print longest path analysis results with detailed timing statistics";
+  let description = [{
+    This pass performs longest path analysis on AIG circuits and outputs detailed
+    timing information including:
+    - Delay distribution statistics showing timing levels and path counts
+    - Critical path details for the top N fanout points
+    - Path history with intermediate debug points for detailed analysis
+
+    The analysis considers each AIG and-inverter operation to have unit delay and
+    computes maximum delays through combinational paths across module hierarchies.
+  }];
   let options = [
-    Option<"outputFile", "output-file", "std::string", "\"-\"", "Output file">,
-    Option<"test", "test", "bool", "false", "Emit longest paths to the diagnostics.">,
-    Option<"showTopKPercent", "show-top-k-percent", "int", "5", "The size of the longest paths to show.">
+    Option<"outputFile", "output-file", "std::string", "\"-\"",
+           "Output file for analysis results (use '-' for stdout)">,
+    Option<"test", "test", "bool", "false",
+           "Emit longest paths as diagnostic remarks for testing">,
+    Option<"showTopKPercent", "show-top-k-percent", "int", "5", "The size of the longest paths to show.">,
+    Option<"emitJSON", "emit-json", "bool", "false",
+           "Output analysis results in JSON format">
   ];
 }
 

--- a/include/circt/Dialect/AIG/Analysis/LongestPathAnalysis.h
+++ b/include/circt/Dialect/AIG/Analysis/LongestPathAnalysis.h
@@ -23,6 +23,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/ImmutableList.h"
+#include "llvm/Support/JSON.h"
 #include <variant>
 
 namespace mlir {
@@ -133,11 +134,11 @@ public:
   const OutputPort &getFanOutAsPort() const {
     return std::get<OutputPort>(fanOut);
   }
-  hw::HWModuleOp getRoot() { return root; }
+  hw::HWModuleOp getRoot() const { return root; }
   const llvm::ImmutableList<DebugPoint> &getHistory() const {
     return path.history;
   }
-  const OpenPath &getPath() { return path; }
+  const OpenPath &getPath() const { return path; }
 
   // Get source location for the fanout point (for diagnostics)
   Location getFanOutLoc();
@@ -159,6 +160,9 @@ private:
   OpenPath path;       // The actual timing path with history
   hw::HWModuleOp root; // Root module for this path
 };
+
+// JSON serialization for DataflowPath
+llvm::json::Value toJSON(const circt::aig::DataflowPath &path);
 
 // Options for the longest path analysis.
 struct LongestPathAnalysisOption {

--- a/lib/Dialect/AIG/Analysis/PrintLongestPathAnalysis.cpp
+++ b/lib/Dialect/AIG/Analysis/PrintLongestPathAnalysis.cpp
@@ -17,8 +17,13 @@
 #include "circt/Support/LLVM.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LLVM.h"
+#include "llvm/ADT/DenseMapInfoVariant.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/raw_ostream.h"
+#include <memory>
 
 #define DEBUG_TYPE "aig-longest-path-analysis"
 using namespace circt;
@@ -38,13 +43,27 @@ namespace aig {
 namespace {
 struct PrintLongestPathAnalysisPass
     : public impl::PrintLongestPathAnalysisBase<PrintLongestPathAnalysisPass> {
-  using PrintLongestPathAnalysisBase::outputFile;
-  using PrintLongestPathAnalysisBase::PrintLongestPathAnalysisBase;
-  using PrintLongestPathAnalysisBase::showTopKPercent;
   void runOnOperation() override;
+  using impl::PrintLongestPathAnalysisBase<
+      PrintLongestPathAnalysisPass>::PrintLongestPathAnalysisBase;
   LogicalResult printAnalysisResult(const LongestPathAnalysis &analysis,
                                     igraph::InstancePathCache &pathCache,
-                                    hw::HWModuleOp top, llvm::raw_ostream &os);
+                                    hw::HWModuleOp top, llvm::raw_ostream *os,
+                                    llvm::json::OStream *jsonOS);
+
+private:
+  /// Print timing level statistics showing delay distribution
+  void printTimingLevelStatistics(SmallVectorImpl<DataflowPath> &allTimingPaths,
+                                  llvm::raw_ostream *os,
+                                  llvm::json::OStream *jsonOS);
+
+  /// Print detailed information for the top K critical paths
+  void printTopKPathDetails(SmallVectorImpl<DataflowPath> &allTimingPaths,
+                            hw::HWModuleOp top, llvm::raw_ostream *os,
+                            llvm::json::OStream *jsonOS);
+
+  /// Print detailed history of a timing path showing intermediate debug points
+  void printPathHistory(const OpenPath &timingPath, llvm::raw_ostream &os);
 };
 
 } // namespace
@@ -52,13 +71,12 @@ struct PrintLongestPathAnalysisPass
 /// Main method to print comprehensive longest path analysis results.
 LogicalResult PrintLongestPathAnalysisPass::printAnalysisResult(
     const LongestPathAnalysis &analysis, igraph::InstancePathCache &pathCache,
-    hw::HWModuleOp top, llvm::raw_ostream &os) {
+    hw::HWModuleOp top, llvm::raw_ostream *os, llvm::json::OStream *jsonOS) {
   SmallVector<DataflowPath> results;
   auto moduleName = top.getModuleNameAttr();
 
   // Get all timing paths with full hierarchical elaboration
-  if (failed(
-          analysis.getAllPaths(moduleName, results, /*elaboratedPaths=*/true)))
+  if (failed(analysis.getAllPaths(moduleName, results, true)))
     return failure();
 
   // Emit diagnostics if testing is enabled (for regression testing)
@@ -73,18 +91,200 @@ LogicalResult PrintLongestPathAnalysisPass::printAnalysisResult(
     }
   }
 
-  // Print analysis header
-  os << "# Longest Path Analysis result for " << top.getModuleNameAttr() << "\n"
-     << "Found " << results.size() << " paths\n";
-
-  if (!results.empty()) {
-    llvm::sort(results, [](const DataflowPath &a, const DataflowPath &b) {
-      return a.getDelay() > b.getDelay();
-    });
-    os << "Maximum path delay: " << results.front().getDelay() << "\n";
+  // Deduplicate paths by fanout point, keeping only the worst-case delay per
+  // fanout This gives us the critical delay for each fanout point in the design
+  SmallVector<DataflowPath> longestPathForEachFanOut;
+  llvm::DenseMap<DataflowPath::FanOutType, size_t> index;
+  for (auto &path : results) {
+    assert(path.getFanIn().value);
+    auto [it, inserted] =
+        index.try_emplace(path.getFanOut(), longestPathForEachFanOut.size());
+    if (inserted)
+      longestPathForEachFanOut.push_back(path);
+    else if (longestPathForEachFanOut[it->second].getDelay() < path.getDelay())
+      longestPathForEachFanOut[it->second] =
+          path; // Keep the path with higher delay
   }
 
+  // Sort all timing paths by delay value (ascending order for statistics)
+  llvm::sort(longestPathForEachFanOut, [&](const auto &lhs, const auto &rhs) {
+    return lhs.getDelay() < rhs.getDelay();
+  });
+
+  // Print analysis header
+  if (os) {
+    *os << "# Longest Path Analysis result for " << top.getModuleNameAttr()
+        << "\n"
+        << "Found " << results.size() << " paths\n"
+        << "Found " << longestPathForEachFanOut.size()
+        << " unique fanout points\n"
+        << "Maximum path delay: "
+        << (longestPathForEachFanOut.empty()
+                ? 0
+                : longestPathForEachFanOut.back().getDelay())
+        << "\n";
+
+    *os << "## Showing Levels\n";
+  }
+
+  // Handle JSON output.
+  if (jsonOS) {
+    jsonOS->objectBegin();
+    jsonOS->attribute("module_name", top.getModuleNameAttr().getValue());
+  }
+
+  auto deferClose = llvm::make_scope_exit([&]() {
+    if (jsonOS)
+      jsonOS->objectEnd();
+  });
+
+  // Print timing distribution statistics (histogram of delay levels)
+  printTimingLevelStatistics(longestPathForEachFanOut, os, jsonOS);
+
+  // Print detailed information for top K critical paths if requested
+  if (showTopKPercent.getValue() > 0)
+    printTopKPathDetails(longestPathForEachFanOut, top, os, jsonOS);
+
   return success();
+}
+
+/// Print timing level statistics showing delay distribution across all paths.
+/// This provides a histogram-like view of timing levels in the design, showing
+/// how many paths exist at each delay level and the cumulative percentage.
+/// This is useful for understanding the overall timing characteristics of the
+/// design.
+void PrintLongestPathAnalysisPass::printTimingLevelStatistics(
+    SmallVectorImpl<DataflowPath> &allTimingPaths, llvm::raw_ostream *os,
+    llvm::json::OStream *jsonOS) {
+
+  int64_t totalTimingPoints = allTimingPaths.size();
+  int64_t cumulativeCount = 0;
+
+  if (jsonOS) {
+    jsonOS->attributeBegin("timing_levels");
+    jsonOS->arrayBegin();
+  }
+  auto closeJson = llvm::make_scope_exit([&]() {
+    if (jsonOS) {
+      jsonOS->arrayEnd();
+      jsonOS->attributeEnd();
+    }
+  });
+
+  // Process paths grouped by delay level (paths are already sorted by delay)
+  for (size_t index = 0; index < allTimingPaths.size();) {
+    int64_t oldIndex = index;
+    auto currentDelay = allTimingPaths[index++].getDelay();
+
+    // Count all paths with the same delay value to create histogram bins
+    while (index < allTimingPaths.size() &&
+           allTimingPaths[index].getDelay() == currentDelay)
+      index++;
+
+    int64_t pathsWithSameDelay = index - oldIndex;
+
+    cumulativeCount += pathsWithSameDelay;
+
+    // Calculate cumulative percentage to show timing distribution
+    double cumulativePercentage =
+        (double)cumulativeCount / totalTimingPoints * 100.0;
+
+    // Print formatted timing level statistics in tabular format
+    // Format: Level = delay_value . Count = path_count . percentage%
+    if (os)
+      *os << llvm::format("Level = %-10d. Count = %-10d. %-10.2f%%\n",
+                          currentDelay, pathsWithSameDelay,
+                          cumulativePercentage);
+    if (jsonOS) {
+      jsonOS->objectBegin();
+      jsonOS->attribute("level", currentDelay);
+      jsonOS->attribute("count", pathsWithSameDelay);
+      jsonOS->attribute("percentage", cumulativePercentage);
+      jsonOS->objectEnd();
+    }
+  }
+}
+
+/// Print detailed information for the top K critical paths.
+/// This shows the most critical timing paths in the design, providing detailed
+/// information about each path including fanout/fanin points and path history.
+void PrintLongestPathAnalysisPass::printTopKPathDetails(
+    SmallVectorImpl<DataflowPath> &allTimingPaths, hw::HWModuleOp top,
+    llvm::raw_ostream *os, llvm::json::OStream *jsonOS) {
+
+  auto topKCount = static_cast<uint64_t>(allTimingPaths.size()) *
+                   std::clamp(showTopKPercent.getValue(), 0, 100) / 100;
+
+  if (os)
+    *os << "## Top " << topKCount << " (out of " << allTimingPaths.size()
+        << ") fan-out points\n\n";
+
+  if (jsonOS) {
+    jsonOS->attributeBegin("top_paths");
+    jsonOS->arrayBegin();
+  }
+  auto closeJson = llvm::make_scope_exit([&]() {
+    if (jsonOS) {
+      jsonOS->arrayEnd();
+      jsonOS->attributeEnd();
+    }
+  });
+
+  // Process paths from highest delay to lowest (reverse order since paths are
+  // sorted ascending)
+  for (size_t i = 0; i < std::min<size_t>(topKCount, allTimingPaths.size());
+       ++i) {
+    auto &path = allTimingPaths[allTimingPaths.size() - i - 1];
+    if (jsonOS)
+      jsonOS->value(toJSON(path));
+
+    if (!os)
+      continue;
+    // Print path header with ranking and delay information
+    *os << "==============================================\n"
+        << "#" << i + 1 << ": Distance=" << path.getDelay() << "\n";
+
+    // Print fanout point (where the critical path starts)
+    *os << "FanOut=";
+    path.printFanOut(*os);
+
+    // Print fanin point (where the critical path ends)
+    *os << "\n"
+        << "FanIn=";
+    path.getFanIn().print(*os);
+    *os << "\n";
+
+    // Print detailed path history showing intermediate logic stages
+    printPathHistory(path.getPath(), *os);
+  }
+}
+
+/// Print detailed history of a timing path showing intermediate debug points.
+/// This traces the path from fanout to fanin, showing each logic stage and
+/// the delay contribution of each stage. This is crucial for understanding
+/// where delay is being accumulated along the critical path and identifying
+/// optimization opportunities.
+void PrintLongestPathAnalysisPass::printPathHistory(const OpenPath &timingPath,
+                                                    llvm::raw_ostream &os) {
+  int64_t remainingDelay = timingPath.getDelay();
+
+  if (!timingPath.getHistory().isEmpty()) {
+    os << "== History Start (closer to fanout) ==\n";
+
+    // Walk through debug points in order from fanout to fanin
+    for (auto &debugPoint : timingPath.getHistory()) {
+      // Calculate delay contribution of this logic stage
+      int64_t stepDelay = remainingDelay - debugPoint.delay;
+      remainingDelay = debugPoint.delay;
+
+      // Show the delay contribution and the debug point information
+      os << "<--- (logic delay " << stepDelay << ") ---\n";
+      debugPoint.print(os);
+      os << "\n";
+    }
+
+    os << "== History End (closer to fanin) ==\n";
+  }
 }
 
 void PrintLongestPathAnalysisPass::runOnOperation() {
@@ -100,8 +300,21 @@ void PrintLongestPathAnalysisPass::runOnOperation() {
     return signalPassFailure();
   }
 
+  auto &os = file->os();
+  std::unique_ptr<llvm::json::OStream> jsonOS;
+  if (emitJSON.getValue()) {
+    jsonOS = std::make_unique<llvm::json::OStream>(os);
+    jsonOS->arrayBegin();
+  }
+
+  auto closeJson = llvm::make_scope_exit([&]() {
+    if (jsonOS)
+      jsonOS->arrayEnd();
+  });
+
   for (auto top : analysis.getTopModules())
-    if (failed(printAnalysisResult(analysis, pathCache, top, file->os())))
+    if (failed(printAnalysisResult(analysis, pathCache, top,
+                                   jsonOS ? nullptr : &os, jsonOS.get())))
       return signalPassFailure();
   file->keep();
   return markAllAnalysesPreserved();

--- a/lib/Dialect/AIG/Analysis/PrintLongestPathAnalysis.cpp
+++ b/lib/Dialect/AIG/Analysis/PrintLongestPathAnalysis.cpp
@@ -44,8 +44,7 @@ namespace {
 struct PrintLongestPathAnalysisPass
     : public impl::PrintLongestPathAnalysisBase<PrintLongestPathAnalysisPass> {
   void runOnOperation() override;
-  using impl::PrintLongestPathAnalysisBase<
-      PrintLongestPathAnalysisPass>::PrintLongestPathAnalysisBase;
+  using PrintLongestPathAnalysisBase::PrintLongestPathAnalysisBase;
   LogicalResult printAnalysisResult(const LongestPathAnalysis &analysis,
                                     igraph::InstancePathCache &pathCache,
                                     hw::HWModuleOp top, llvm::raw_ostream *os,

--- a/test/Dialect/AIG/longest-paths-report.mlir
+++ b/test/Dialect/AIG/longest-paths-report.mlir
@@ -1,0 +1,56 @@
+// RUN: circt-opt %s --split-input-file --pass-pipeline='builtin.module(aig-print-longest-path-analysis{output-file="-" show-top-k-percent=100})' | FileCheck %s
+// RUN: circt-opt %s --split-input-file --pass-pipeline='builtin.module(aig-print-longest-path-analysis{output-file="-" show-top-k-percent=100 emit-json=true})' | FileCheck %s --check-prefix JSON
+
+// CHECK:      # Longest Path Analysis result for "parent"
+// CHECK-NEXT: Found 4 paths
+// CHECK-NEXT: Found 2 unique fanout points
+// CHECK-NEXT: Maximum path delay: 2
+// CHECK-NEXT: ## Showing Levels
+// CHECK-NEXT: Level = 1         . Count = 1         . 50.00     %
+// CHECK-NEXT: Level = 2         . Count = 1         . 100.00    %
+// CHECK-NEXT: ## Top 2 (out of 2) fan-out points
+// CHECK:      ==============================================
+// CHECK-NEXT: #1: Distance=2
+// CHECK-NEXT: FanOut=Object($root.y[0])
+// CHECK-NEXT: FanIn=Object($root.a[0])
+// CHECK-NEXT: == History Start (closer to fanout) ==
+// CHECK-NEXT: <--- (logic delay 0) ---
+// CHECK-NEXT: Object($root.c2.x[0], delay=2, comment="output port")
+// CHECK-NEXT: <--- (logic delay 0) ---
+// CHECK-NEXT: Object($root/c2:child.r[0], delay=2, comment="namehint")
+// CHECK-NEXT: <--- (logic delay 1) ---
+// CHECK-NEXT: Object($root/c2:child.a[0], delay=1, comment="input port")
+// CHECK-NEXT: <--- (logic delay 0) ---
+// CHECK-NEXT: Object($root.c1.x[0], delay=1, comment="output port")
+// CHECK-NEXT: <--- (logic delay 0) ---
+// CHECK-NEXT: Object($root/c1:child.r[0], delay=1, comment="namehint")
+// CHECK-NEXT: <--- (logic delay 1) ---
+// CHECK-NEXT: Object($root/c1:child.a[0], delay=0, comment="input port")
+// CHECK-NEXT: <--- (logic delay 0) ---
+// CHECK-NEXT: Object($root.a[0], delay=0, comment="input port")
+// CHECK-NEXT: == History End (closer to fanin) ==
+// CHECK-NEXT: ==============================================
+// Make sure the second path is reported.
+// CHECK-NEXT: #2: Distance=1
+// JSON:               [{"module_name":"parent",
+// JSON-SAME{LITERAL}:   "timing_levels":
+// JSON-SAME{LITERAL}:    [{"level":1,"count":1,"percentage":50},
+// JSON-SAME{LITERAL}:     {"level":2,"count":1,"percentage":100}]
+// JSON-SAME{LITERAL}:    "top_paths":[
+// JSON-SAME{LITERAL}:     {"fan_out":{"bit_pos":0,"instance_path":[],"name":"y"},
+// JSON-SAME{LITERAL}:      "path":{"delay":2,"fan_in":{"bit_pos":0,"instance_path":[],"name":"a"},
+// JSON-SAME{LITERAL}:      "history":[{"comment":"output port","delay":2,"object":{"bit_pos":0,"instance_path":[],"name":"c2.x"}},
+// JSON-SAME{LITERAL}:      "root":"parent"},
+// Make sure the second path is reported.
+// JSON-SAME{LITERAL}:     {"fan_out":{"bit_pos":0,"instance_path":[],"name":"x"},
+
+hw.module private @child(in %a : i1, in %b : i1, out x : i1) {
+  %r = aig.and_inv %a, %b {sv.namehint = "r"} : i1 // r[0] := max(a[0], b[0]) + 1 = 1
+  hw.output %r : i1
+}
+
+hw.module private @parent(in %a : i1, in %b : i1, out x : i1, out y : i1) {
+  %0 = hw.instance "c1" @child(a: %a: i1, b: %b: i1) -> (x: i1)
+  %1 = hw.instance "c2" @child(a: %0: i1, b: %b: i1) -> (x: i1)
+  hw.output %0, %1 : i1, i1
+}

--- a/test/circt-synth/path-e2e.mlir
+++ b/test/circt-synth/path-e2e.mlir
@@ -1,7 +1,14 @@
-// RUN: circt-synth %s -output-longest-path=%t -top counter && cat %t | FileCheck %s
+// RUN: circt-synth %s -output-longest-path=- -top counter | FileCheck %s
+// RUN: circt-synth %s -output-longest-path=- -top counter -output-longest-path-json | FileCheck %s --check-prefix JSON
+
 // CHECK-LABEL: # Longest Path Analysis result for "counter"
 // CHECK-NEXT: Found 189 paths
+// CHECK-NEXT: Found 32 unique fanout points
 // CHECK-NEXT: Maximum path delay: 48
+// Don't test detailed reports as they are not stable.
+
+// Make sure json is emitted.
+// JSON: {"module_name":"counter","timing_levels":[
 hw.module @counter(in %a: i16, in %clk: !seq.clock, out result: i16) {
     %reg = seq.compreg %add, %clk : i16
     %add = comb.mul %reg, %a : i16

--- a/tools/circt-synth/circt-synth.cpp
+++ b/tools/circt-synth/circt-synth.cpp
@@ -108,6 +108,17 @@ static cl::opt<std::string>
                                "if file name is specified"),
                       cl::init(""), cl::cat(mainCategory));
 
+static cl::opt<bool>
+    outputLongestPathJSON("output-longest-path-json",
+                          cl::desc("Output longest path analysis results in "
+                                   "JSON format"),
+                          cl::init(false), cl::cat(mainCategory));
+static cl::opt<int>
+    outputLongestPathTopKPercent("output-longest-path-top-k-percent",
+                                 cl::desc("Output top K percent of longest "
+                                          "paths in the analysis results"),
+                                 cl::init(5), cl::cat(mainCategory));
+
 static cl::opt<std::string> topName("top", cl::desc("Top module name"),
                                     cl::value_desc("name"), cl::init(""),
                                     cl::cat(mainCategory));
@@ -199,7 +210,8 @@ static void populateSynthesisPipeline(PassManager &pm) {
   if (!outputLongestPath.empty()) {
     circt::aig::PrintLongestPathAnalysisOptions options;
     options.outputFile = outputLongestPath;
-    options.showTopKPercent = 5;
+    options.showTopKPercent = outputLongestPathTopKPercent;
+    options.emitJSON = outputLongestPathJSON;
     pm.addPass(circt::aig::createPrintLongestPathAnalysis(options));
   }
 


### PR DESCRIPTION
This patch improves the AIG longest path analysis pass with:
- Detailed timing level statistics showing delay distribution
- Critical path details for top K fanout points
- Path history with intermediate debug points
- JSON output format option for machine-readable results
- Improved documentation and command-line options

The enhanced analysis provides more comprehensive timing information for debugging and optimizing AIG circuits, with both human-readable and machine-parseable output formats. Human-readable output is align with ABC's print_level output to make it easy to compare results with ABC.