### PR TITLE
[ExportVerilog] Add support for hw.array_inject

### DIFF
--- a/include/circt/Dialect/HW/HWVisitors.h
+++ b/include/circt/Dialect/HW/HWVisitors.h
@@ -30,6 +30,7 @@ public:
         .template Case<ConstantOp, AggregateConstantOp,
                        // Array operations
                        ArraySliceOp, ArrayCreateOp, ArrayConcatOp, ArrayGetOp,
+                       ArrayInjectOp,
                        // Struct operations
                        StructCreateOp, StructExtractOp, StructInjectOp,
                        // Union operations
@@ -76,6 +77,7 @@ public:
   HANDLE(ArrayGetOp, Unhandled);
   HANDLE(ArrayCreateOp, Unhandled);
   HANDLE(ArrayConcatOp, Unhandled);
+  HANDLE(ArrayInjectOp, Unhandled);
   HANDLE(EnumCmpOp, Unhandled);
   HANDLE(EnumConstantOp, Unhandled);
 #undef HANDLE

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -743,7 +743,8 @@ static bool isExpressionUnableToInline(Operation *op,
 
   // StructCreateOp needs to be assigning to a named temporary so that types
   // are inferred properly by verilog
-  if (isa<StructCreateOp, UnionCreateOp, UnpackedArrayCreateOp>(op))
+  if (isa<StructCreateOp, UnionCreateOp, UnpackedArrayCreateOp, ArrayInjectOp>(
+          op))
     return true;
 
   // Aggregate literal syntax only works in an assignment expression, where
@@ -768,7 +769,7 @@ static bool isExpressionUnableToInline(Operation *op,
     //     assign bar = {{a}, {b}, {c}, {d}}[idx];
     //
     // To handle these, we push the subexpression into a temporary.
-    if (isa<ExtractOp, ArraySliceOp, ArrayGetOp, StructExtractOp,
+    if (isa<ExtractOp, ArraySliceOp, ArrayGetOp, ArrayInjectOp, StructExtractOp,
             UnionExtractOp, IndexedPartSelectOp>(user))
       if (use.getOperandNumber() == 0 && // ignore index operands.
           !isOkToBitSelectFrom(use.get()))

--- a/test/Conversion/ExportVerilog/disallow-local-vars.mlir
+++ b/test/Conversion/ExportVerilog/disallow-local-vars.mlir
@@ -260,3 +260,20 @@ hw.module @hoist_reg(in %dummy : i32, out out : i17) {
   %res_reg_data = sv.read_inout %res_reg : !hw.inout<i17>
   hw.output %res_reg_data : i17
 }
+
+// DISALLOW-LABEL: module ArrayInjectProcedural(
+hw.module @ArrayInjectProcedural(in %a: !hw.array<4xi42>, in %b: i42, in %i: i2) {
+  // DISALLOW: reg [3:0][41:0] z;
+  %z = sv.reg : !hw.inout<array<4xi42>>
+  // DISALLOW-NEXT: reg [3:0][41:0] [[TMP:.+]];
+  // DISALLOW-NEXT: always_comb begin
+  // DISALLOW-NEXT:   [[TMP]] = a;
+  // DISALLOW-NEXT:   [[TMP]][i] = b;
+  // DISALLOW-NEXT: end // always_comb
+  // DISALLOW-NEXT: always_comb
+  // DISALLOW-NEXT:   z = [[TMP]];
+  sv.alwayscomb {
+    %0 = hw.array_inject %a[%i], %b : !hw.array<4xi42>, i2
+    sv.bpassign %z, %0 : !hw.array<4xi42>
+  }
+}


### PR DESCRIPTION
Extend the PrepareForEmission part of ExportVerilog to lower `hw.array_inject` into a bit of procedural Verilog code that overwrites the injected array index:

```systemverilog
// %b = hw.array_inject %a[%i], %v
logic [N-1:0] b;
always_comb begin
  b = a;
  b[i] = v;
end
```

Unfortunately assignment patterns like `'{0: x, 1: y, 2: z}` only support constant expressions for the array indices. The only options to mutate a single array entry that I am aware of are the procedural style implement in this commit, and creating a separate mux/ternary op for each index separately, which feels like total overkill.