### PR TITLE
[MooreToCore] Lower exponentiation to math.ipowi (PowUOpConversion)

### DIFF
--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1111,11 +1111,9 @@ func.func @Conversions(%arg0: !moore.i16, %arg1: !moore.l16) {
 
 // CHECK-LABEL: func.func @PowUOp
 func.func @PowUOp(%arg0: !moore.l32, %arg1: !moore.l32) {
-  // CHECK: %{{.*}} = scf.for %{{.*}} = %{{.*}} to %arg1 step %{{.*}} iter_args([[VAR:%.+]] = %{{.*}}) -> (i32)  : i32 {
-  // CHECK: [[MUL:%.+]] = comb.mul %arg0, [[VAR]] : i32
-  // CHECK: scf.yield [[MUL]] : i32
-  %0 = moore.powu %arg0, %arg1 : l32
-  return
+  // CHECK: %[[RES:.*]] = math.ipowi %arg0, %arg1 : i32
+    %0 = moore.powu %arg0, %arg1 : l32
+    return
 }
 
 // CHECK-LABEL: func.func @PowSOp


### PR DESCRIPTION
This pull request addresses part of issue #8476, and is related to PR #8574. Similar to the signed integer conversion, I have removed the SCF dialect for-loop logic and replaced it directly with `math.ipowi` from MLIR's Math dialect. 

Initially, it was suggested to zero extend the inputs (would this require `mlir.llvm` dialect?), and to ensure this conversion is secure I can reevaluate my changes to reflect this suggestion. However, I submit this PR now due to tests currently passing in this state.
