### PR TITLE
[ESI] Make RAM delarations' addresses unsigned

### DIFF
--- a/frontends/PyCDE/integration_test/test_software/esi_ram.py
+++ b/frontends/PyCDE/integration_test/test_software/esi_ram.py
@@ -36,7 +36,7 @@ assert dummy_info is not None
 
 
 def read(addr: int) -> bytearray:
-  mem_read_addr.write([addr])
+  mem_read_addr.write(addr)
   resp = cast(bytearray, mem_read_data.read())
   print(f"resp: {resp}")
   return resp
@@ -45,7 +45,7 @@ def read(addr: int) -> bytearray:
 # The contents of address 3 are continuously updated to the contents of address
 # 2 by the accelerator.
 data = bytearray([random.randint(0, 2**8 - 1) for _ in range(8)])
-mem_write.write({"address": [2], "data": data})
+mem_write.write({"address": 2, "data": data})
 resp = read(2)
 try_count = 0
 
@@ -64,6 +64,6 @@ assert resp == data
 # Check this by writing to address 3 and reading from it. Shouldn't have
 # changed.
 zeros = bytearray([0] * 8)
-mem_write.write({"address": [3], "data": zeros})
+mem_write.write({"address": 3, "data": zeros})
 resp = read(3)
 assert resp == data

--- a/frontends/PyCDE/src/pycde/esi.py
+++ b/frontends/PyCDE/src/pycde/esi.py
@@ -465,7 +465,7 @@ def DeclareRandomAccessMemory(inner_type: Type,
   class DeclareRandomAccessMemory(ServiceDecl):
     __name__ = name
     address_width = (depth - 1).bit_length()
-    address_type = Bits(address_width)
+    address_type = UInt(address_width)
     write_struct = StructType([('address', address_type), ('data', inner_type)])
 
     read = Bundle([

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -366,11 +366,11 @@ def Writer(type):
 
 # CHECK:  hw.module @Ram1(in %clk : !seq.clock, in %rst : i1)
 # CHECK:    esi.service.instance #esi.appid<"ram"> svc @ram impl as "sv"(%clk, %rst) : (!seq.clock, i1) -> ()
-# CHECK:    [[WR:%.+]] = esi.service.req <@ram::@write>(#esi.appid<"ram_writer"[0]>) : !esi.bundle<[!esi.channel<!hw.struct<address: i3, data: i32>> from "req", !esi.channel<i0> to "ack"]>
+# CHECK:    [[WR:%.+]] = esi.service.req <@ram::@write>(#esi.appid<"ram_writer"[0]>) : !esi.bundle<[!esi.channel<!hw.struct<address: ui3, data: i32>> from "req", !esi.channel<i0> to "ack"]>
 # CHECK:    %rawOutput, %valid = esi.unwrap.vr %req, %ready : !hw.struct<address: ui3, data: ui32>
-# CHECK:    [[CASTED:%.+]] = hw.bitcast %rawOutput : (!hw.struct<address: ui3, data: ui32>) -> !hw.struct<address: i3, data: i32>
-# CHECK:    %chanOutput, %ready = esi.wrap.vr [[CASTED]], %valid : !hw.struct<address: i3, data: i32>
-# CHECK:    %ack = esi.bundle.unpack %chanOutput from [[WR]] : !esi.bundle<[!esi.channel<!hw.struct<address: i3, data: i32>> from "req", !esi.channel<i0> to "ack"]>
+# CHECK:    [[CASTED:%.+]] = hw.bitcast %rawOutput : (!hw.struct<address: ui3, data: ui32>) -> !hw.struct<address: ui3, data: i32>
+# CHECK:    %chanOutput, %ready = esi.wrap.vr [[CASTED]], %valid : !hw.struct<address: ui3, data: i32>
+# CHECK:    %ack = esi.bundle.unpack %chanOutput from [[WR]] : !esi.bundle<[!esi.channel<!hw.struct<address: ui3, data: i32>> from "req", !esi.channel<i0> to "ack"]>
 # CHECK:    %bundle, %req = esi.bundle.pack %ack : !esi.bundle<[!esi.channel<!hw.struct<address: ui3, data: ui32>> from "req", !esi.channel<i0> to "ack"]>
 # CHECK:    hw.instance "Writer" sym @Writer @Writer(clk: %clk: !seq.clock, rst: %rst: i1, cmd: %bundle: !esi.bundle<[!esi.channel<!hw.struct<address: ui3, data: ui32>> from "req", !esi.channel<i0> to "ack"]>) -> ()
 

--- a/integration_test/Dialect/ESI/runtime/loopback.mlir
+++ b/integration_test/Dialect/ESI/runtime/loopback.mlir
@@ -93,7 +93,7 @@ hw.module @LoopbackArray() {
 }
 
 esi.mem.ram @MemA i64 x 20
-!write = !hw.struct<address: i5, data: i64>
+!write = !hw.struct<address: ui5, data: i64>
 !writeBundle = !esi.bundle<[!esi.channel<!write> from "req", !esi.channel<i0> to "ack"]>
 
 hw.module @MemoryAccess1(in %clk : !seq.clock, in %rst : i1) {

--- a/lib/Dialect/ESI/ESIStdServices.cpp
+++ b/lib/Dialect/ESI/ESIStdServices.cpp
@@ -39,7 +39,9 @@ static ServicePortInfo createReqResp(StringAttr sym, Twine name,
 
 ServicePortInfo RandomAccessMemoryDeclOp::writePortInfo() {
   auto *ctxt = getContext();
-  auto addressType = IntegerType::get(ctxt, llvm::Log2_64_Ceil(getDepth()));
+  auto addressType =
+      IntegerType::get(ctxt, llvm::Log2_64_Ceil(getDepth()),
+                       IntegerType::SignednessSemantics::Unsigned);
 
   // Write port
   hw::StructType writeType = hw::StructType::get(
@@ -53,7 +55,9 @@ ServicePortInfo RandomAccessMemoryDeclOp::writePortInfo() {
 
 ServicePortInfo RandomAccessMemoryDeclOp::readPortInfo() {
   auto *ctxt = getContext();
-  auto addressType = IntegerType::get(ctxt, llvm::Log2_64_Ceil(getDepth()));
+  auto addressType =
+      IntegerType::get(ctxt, llvm::Log2_64_Ceil(getDepth()),
+                       IntegerType::SignednessSemantics::Unsigned);
 
   return createReqResp(getSymNameAttr(), "read", "address", addressType, "data",
                        getInnerType());

--- a/test/Dialect/Handshake/lower-extmem-esi.mlir
+++ b/test/Dialect/Handshake/lower-extmem-esi.mlir
@@ -27,10 +27,10 @@
 // CHECK-SAME: in %reset : i1,
 // CHECK-SAME: out out0 : !esi.channel<i0>
 // CHECK-SAME: ) {
-//CHECK-NEXT:   [[B0:%.+]] = esi.service.req <@mem::@read>(#esi.appid<"load"[1]>) : !esi.bundle<[!esi.channel<i4> from "address", !esi.channel<i32> to "data"]>
-//CHECK-NEXT:   %data = esi.bundle.unpack %main.mem_ld0.addr from [[B0]] : !esi.bundle<[!esi.channel<i4> from "address", !esi.channel<i32> to "data"]>
-//CHECK-NEXT:   [[B1:%.+]] = esi.service.req <@mem::@write>(#esi.appid<"store"[2]>) : !esi.bundle<[!esi.channel<!hw.struct<address: i4, data: i32>> from "req", !esi.channel<i0> to "ack"]>
-//CHECK-NEXT:   %ack = esi.bundle.unpack %main.mem_st0 from [[B1]] : !esi.bundle<[!esi.channel<!hw.struct<address: i4, data: i32>> from "req", !esi.channel<i0> to "ack"]>
+//CHECK-NEXT:   [[B0:%.+]] = esi.service.req <@mem::@read>(#esi.appid<"load"[1]>) : !esi.bundle<[!esi.channel<ui4> from "address", !esi.channel<i32> to "data"]>
+//CHECK-NEXT:   %data = esi.bundle.unpack %main.mem_ld0.addr from [[B0]] : !esi.bundle<[!esi.channel<ui4> from "address", !esi.channel<i32> to "data"]>
+//CHECK-NEXT:   [[B1:%.+]] = esi.service.req <@mem::@write>(#esi.appid<"store"[2]>) : !esi.bundle<[!esi.channel<!hw.struct<address: ui4, data: i32>> from "req", !esi.channel<i0> to "ack"]>
+//CHECK-NEXT:   %ack = esi.bundle.unpack %main.mem_st0 from [[B1]] : !esi.bundle<[!esi.channel<!hw.struct<address: ui4, data: i32>> from "req", !esi.channel<i0> to "ack"]>
 //CHECK-NEXT:   %main.out0, %main.mem_ld0.addr, %main.mem_st0 = hw.instance "main" @__main_hw(arg0: %arg0: !esi.channel<i64>, arg1: %arg1: !esi.channel<i64>, v: %v: !esi.channel<i32>, mem_ld0.data: %data: !esi.channel<i32>, mem_st0.done: %ack: !esi.channel<i0>, argCtrl: %argCtrl: !esi.channel<i0>, clock: %clock: !seq.clock, reset: %reset: i1) -> (out0: !esi.channel<i0>, mem_ld0.addr: !esi.channel<i4>, mem_st0: !esi.channel<!hw.struct<address: i4, data: i32>>)
 //CHECK-NEXT:   hw.output %main.out0 : !esi.channel<i0>
 //CHECK-NEXT: }


### PR DESCRIPTION
Using signless ints as the address was just wrong. It was probably done to avoid incomplete lowerings, which have been addressed.