### PR TITLE
[AIG][Python] Add Python bindings for LongestPathAnalysis

### DIFF
--- a/integration_test/Bindings/Python/dialects/aig.py
+++ b/integration_test/Bindings/Python/dialects/aig.py
@@ -4,7 +4,7 @@
 import circt
 from circt.dialects import aig, hw
 from circt.ir import Context, Location, Module, InsertionPoint, IntegerType
-from circt.dialects.aig import LongestPathAnalysis, LongestPathCollection
+from circt.dialects.aig import LongestPathAnalysis, LongestPathCollection, DataflowPath
 
 with Context() as ctx, Location.unknown():
   circt.register_dialects(ctx)
@@ -56,6 +56,14 @@ with Context() as ctx, Location.unknown():
     # CHECK-NEXT: index -1 delay: 1
     print("index 1 delay:", collection[1].delay)
     print("index -1 delay:", collection[-1].delay)
+    # CHECK-NEXT: collection.get_path(5) == collection[5]: True
+    print(
+        "collection.get_path(5) == collection[5]:",
+        DataflowPath.from_json_string(
+            collection.collection.get_path(5)) == collection[5])
+    # Check that len and get_size are the same
+    # CHECK-NEXT: 96 96
+    print(len(collection), collection.collection.get_size())
 
     try:
       print(collection[96])

--- a/lib/Bindings/Python/AIGModule.cpp
+++ b/lib/Bindings/Python/AIGModule.cpp
@@ -47,15 +47,14 @@ void circt::python::populateDialectAIGSubmodule(nb::module_ &m) {
              MlirStringRef moduleNameRef =
                  mlirStringRefCreateFromCString(moduleName.c_str());
 
-             if (aigLongestPathCollectionIsNull(
-                     aigLongestPathAnalysisGetAllPaths(*self, moduleNameRef,
-                                                       elaboratePaths)))
-               throw nb::value_error(
-                   "Failed to get all paths, see previous error(s).");
-
              auto collection =
                  AIGLongestPathCollection(aigLongestPathAnalysisGetAllPaths(
                      *self, moduleNameRef, elaboratePaths));
+
+             if (aigLongestPathCollectionIsNull(collection))
+               throw nb::value_error(
+                   "Failed to get all paths, see previous error(s).");
+
              return collection;
            });
 

--- a/lib/Bindings/Python/dialects/aig.py
+++ b/lib/Bindings/Python/dialects/aig.py
@@ -334,6 +334,7 @@ class LongestPathCollection:
         Returns:
             DataflowPath at the specified position ratio
         """
+    assert ratio >= 0.0 and ratio <= 1.0, "Ratio must be between 0.0 and 1.0"
     index = int(len(self) * (1 - ratio))
     return self[index]
 


### PR DESCRIPTION
This commit adds comprehensive Python bindings for AIG timing analysis, providing a high-level interface for critical path analysis

- LongestPathAnalysis class for performing timing analysis on AIG circuits
- LongestPathCollection with efficient caching and statistical methods
- Dataclasses (DataflowPath, Object, DebugPoint, OpenPath) for structured path representation with full type annotations
- Flamegraph generation for visualization
- Statistical analysis methods (percentiles, delay distribution)

The Python API builds on the C API, providing JSON deserialization into structured Python objects with caching for performance. The flamegraph output format enables visualization of critical timing paths through the circuit hierarchy.

Usage example:
```python
  analysis = LongestPathAnalysis(module)
  collection = analysis.get_all_paths("module_name")
  collection.print_summary()
  print(collection.longest_path.to_flamegraph())
````
