### PR TITLE
[circt-synth] Add `-emit-bytecode` option

### DIFF
--- a/test/circt-synth/basic.mlir
+++ b/test/circt-synth/basic.mlir
@@ -1,5 +1,6 @@
 // RUN: circt-synth %s | FileCheck %s
 // RUN: circt-synth %s --top and | FileCheck %s --check-prefixes=TOP,CHECK
+// RUN: circt-synth %s --top and --emit-bytecode -f | circt-opt | FileCheck %s --check-prefix=CHECK
 // RUN: circt-synth %s --until-before aig-lowering | FileCheck %s --check-prefix=AIG
 // RUN: circt-synth %s --until-before aig-lowering --convert-to-comb | FileCheck %s --check-prefix=COMB
 

--- a/tools/circt-synth/CMakeLists.txt
+++ b/tools/circt-synth/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(circt-synth
   CIRCTSV
   CIRCTTransforms
   CIRCTVerif
+  MLIRBytecodeWriter
   MLIRIR
   MLIRParser
   LLVMSupport


### PR DESCRIPTION
This PR adds `emit-bytecode` option to circt-synth following firtool or circt-dis tool driver. 