### PR TITLE
[LLHD] Make Deseq pass emit seq.firreg instead of seq.compreg

### DIFF
--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -239,7 +239,6 @@ def FirRegOp : SeqOp<"firreg",
   );
   let results = (outs AnyType:$data);
 
-  let skipDefaultBuilders = 1;
   let hasCanonicalizeMethod = true;
   let hasFolder = true;
   let builders = [

--- a/lib/Dialect/LLHD/Transforms/Deseq.cpp
+++ b/lib/Dialect/LLHD/Transforms/Deseq.cpp
@@ -1004,13 +1004,13 @@ void Deseq::implementRegisters() {
     implementRegister(drive);
 }
 
-/// Implement the conditional behavior of a drive with a `seq.compreg` or
-/// `seq.compreg.ce` op, and make the drive unconditional. This function pulls
-/// the analyzed clock and reset from the given `DriveInfo` and creates the
-/// necessary ops outside the process represent the behavior as a register. It
-/// also calls `specializeValue` and `specializeProcess` to convert the
-/// sequential `llhd.process` into a purely combinational `llhd.combinational`
-/// that is simplified by assuming that the clock edge occurs.
+/// Implement the conditional behavior of a drive with a `seq.firreg` op and
+/// make the drive unconditional. This function pulls the analyzed clock and
+/// reset from the given `DriveInfo` and creates the necessary ops outside the
+/// process represent the behavior as a register. It also calls
+/// `specializeValue` and `specializeProcess` to convert the sequential
+/// `llhd.process` into a purely combinational `llhd.combinational` that is
+/// simplified by assuming that the clock edge occurs.
 void Deseq::implementRegister(DriveInfo &drive) {
   OpBuilder builder(drive.op);
   auto loc = drive.op.getLoc();
@@ -1096,16 +1096,26 @@ void Deseq::implementRegister(DriveInfo &drive) {
   if (enable)
     enable = specializeValue(enable, fixedValues);
 
+  // Try to guess a name for the register.
+  StringAttr name;
+  if (auto sigOp = drive.op.getSignal().getDefiningOp<llhd::SignalOp>())
+    name = sigOp.getNameAttr();
+  if (!name)
+    name = builder.getStringAttr("");
+
   // Create the register op.
-  Value reg;
-  if (enable)
-    reg = builder.create<seq::CompRegClockEnabledOp>(
-        loc, value, clock, enable, StringAttr{}, reset, resetValue, Value{},
-        hw::InnerSymAttr{});
-  else
-    reg =
-        builder.create<seq::CompRegOp>(loc, value, clock, StringAttr{}, reset,
-                                       resetValue, Value{}, hw::InnerSymAttr{});
+  auto reg =
+      builder.create<seq::FirRegOp>(loc, value, clock, name, hw::InnerSymAttr{},
+                                    /*preset=*/IntegerAttr{}, reset, resetValue,
+                                    /*isAsync=*/reset != Value{});
+
+  // If the register has an enable, insert a self-mux in front of the register.
+  if (enable) {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPoint(reg);
+    reg.getNextMutable().assign(builder.create<comb::MuxOp>(
+        loc, enable, reg.getNext(), reg.getResult()));
+  }
 
   // Make the original `llhd.drv` drive the register value unconditionally.
   drive.op.getValueMutable().assign(reg);

--- a/test/circt-verilog/registers.sv
+++ b/test/circt-verilog/registers.sv
@@ -6,7 +6,7 @@
 // CHECK-LABEL: hw.module @ClockPosEdgeAlwaysFF(
 module ClockPosEdgeAlwaysFF(input logic clock, input int d, output int q);
   // CHECK: [[CLK:%.+]] = seq.to_clock %clock
-  // CHECK: [[REG:%.+]] = seq.compreg %d, [[CLK]] : i32
+  // CHECK: [[REG:%.+]] = seq.firreg %d clock [[CLK]] : i32
   // CHECK: hw.output [[REG]]
   always_ff @(posedge clock) q <= d;
 endmodule
@@ -14,7 +14,7 @@ endmodule
 // CHECK-LABEL: hw.module @ClockPosEdge(
 module ClockPosEdge(input logic clock, input int d, output int q);
   // CHECK: [[CLK:%.+]] = seq.to_clock %clock
-  // CHECK: [[REG:%.+]] = seq.compreg %d, [[CLK]] : i32
+  // CHECK: [[REG:%.+]] = seq.firreg %d clock [[CLK]] : i32
   // CHECK: hw.output [[REG]]
   always @(posedge clock) q <= d;
 endmodule
@@ -23,7 +23,7 @@ endmodule
 module ClockNegEdge(input logic clock, input int d, output int q);
   // CHECK: [[CLK:%.+]] = seq.to_clock %clock
   // CHECK: [[CLK_INV:%.+]] = seq.clock_inv [[CLK]]
-  // CHECK: [[REG:%.+]] = seq.compreg %d, [[CLK_INV]] : i32
+  // CHECK: [[REG:%.+]] = seq.firreg %d clock [[CLK_INV]] : i32
   // CHECK: hw.output [[REG]]
   always @(negedge clock) q <= d;
 endmodule
@@ -31,8 +31,8 @@ endmodule
 // CHECK-LABEL: hw.module @ActiveHighReset(
 module ActiveHighReset(input logic clock, input logic reset, input int d1, input int d2, output int q1, output int q2);
   // CHECK: [[CLK:%.+]] = seq.to_clock %clock
-  // CHECK: [[REG1:%.+]] = seq.compreg %d1, [[CLK]] reset %reset, %c42_i32 : i32
-  // CHECK: [[REG2:%.+]] = seq.compreg %d2, [[CLK]] reset %reset, %c42_i32 : i32
+  // CHECK: [[REG1:%.+]] = seq.firreg %d1 clock [[CLK]] reset async %reset, %c42_i32 : i32
+  // CHECK: [[REG2:%.+]] = seq.firreg %d2 clock [[CLK]] reset async %reset, %c42_i32 : i32
   // CHECK: hw.output [[REG1]], [[REG2]]
   always @(posedge clock, posedge reset) if (reset) q1 <= 42; else q1 <= d1;
   always @(posedge clock, posedge reset) q2 <= reset ? 42 : d2;
@@ -42,8 +42,8 @@ endmodule
 module ActiveLowReset(input logic clock, input logic reset, input int d1, input int d2, output int q1, output int q2);
   // CHECK: [[CLK:%.+]] = seq.to_clock %clock
   // CHECK: [[RST_INV:%.+]] = comb.xor %reset, %true
-  // CHECK: [[REG1:%.+]] = seq.compreg %d1, [[CLK]] reset [[RST_INV]], %c42_i32 : i32
-  // CHECK: [[REG2:%.+]] = seq.compreg %d2, [[CLK]] reset [[RST_INV]], %c42_i32 : i32
+  // CHECK: [[REG1:%.+]] = seq.firreg %d1 clock [[CLK]] reset async [[RST_INV]], %c42_i32 : i32
+  // CHECK: [[REG2:%.+]] = seq.firreg %d2 clock [[CLK]] reset async [[RST_INV]], %c42_i32 : i32
   // CHECK: hw.output [[REG1]], [[REG2]]
   always @(posedge clock, negedge reset) if (!reset) q1 <= 42; else q1 <= d1;
   always @(posedge clock, negedge reset) q2 <= !reset ? 42 : d2;
@@ -52,7 +52,8 @@ endmodule
 // CHECK-LABEL: hw.module @Enable(
 module Enable(input logic clock, input logic enable, input int d, output int q);
   // CHECK: [[CLK:%.+]] = seq.to_clock %clock
-  // CHECK: [[REG:%.+]] = seq.compreg.ce %d, [[CLK]], %enable : i32
+  // CHECK: [[MUX:%.+]] = comb.mux %enable, %d, [[REG:%.+]] : i32
+  // CHECK: [[REG]] = seq.firreg [[MUX]] clock [[CLK]] : i32
   // CHECK: hw.output [[REG]]
   always @(posedge clock) if (enable) q <= d;
 endmodule
@@ -60,7 +61,8 @@ endmodule
 // CHECK-LABEL: hw.module @ResetAndEnable(
 module ResetAndEnable(input logic clock, input logic reset, input logic enable, input int d, output int q);
   // CHECK: [[CLK:%.+]] = seq.to_clock %clock
-  // CHECK: [[REG:%.+]] = seq.compreg.ce %d, [[CLK]], %enable reset %reset, %c42_i32 : i32
+  // CHECK: [[MUX:%.+]] = comb.mux %enable, %d, [[REG:%.+]] : i32
+  // CHECK: [[REG]] = seq.firreg [[MUX]] clock [[CLK]] reset async %reset, %c42_i32 : i32
   // CHECK: hw.output [[REG]]
   always @(posedge clock, posedge reset) if (reset) q <= 42; else if (enable) q <= d;
 endmodule


### PR DESCRIPTION
The LLHD Deseq pass detects clocks and optional asynchronous resets. It currently, mistakenly, creates `seq.compreg` ops with those clocks and resets. The `seq.compreg` op turns out to have a _synchronous_ reset though, making the lowering invalid. Use the `seq.firreg` op instead, as it allows the reset type to be specified explicitly. This requries an additional `comb.mux` to be created for potential enable signals, which `seq.firreg` does not support directly.

We should really nail down the semantics of `seq.compreg` in a follow-up commit. The documentation is very vague, and Deseq is likely not the last pass mistakenly assuming the explicit reset of `seq.compreg` is assumed to be asynchronous.