### PR TITLE
[importverilog] Lvalue RangelSelect and ElementSelect to use range.

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -1006,12 +1006,42 @@ struct LvalueExprVisitor {
     return builder.create<moore::ConcatRefOp>(loc, operands);
   }
 
+  Value getSelectIndex(Value index, const slang::ConstantRange &range) const {
+    auto indexType = cast<moore::UnpackedType>(index.getType());
+    auto bw = std::max(llvm::Log2_32_Ceil(std::max(std::abs(range.lower()),
+                                                   std::abs(range.upper()))),
+                       indexType.getBitSize().value());
+    auto intType =
+        moore::IntType::get(index.getContext(), bw, indexType.getDomain());
+
+    if (range.isLittleEndian()) {
+      if (range.lower() == 0)
+        return index;
+
+      Value newIndex =
+          builder.createOrFold<moore::ConversionOp>(loc, intType, index);
+      Value offset = builder.create<moore::ConstantOp>(
+          loc, intType, range.lower(), /*isSigned = */ range.lower() < 0);
+      return builder.createOrFold<moore::SubOp>(loc, newIndex, offset);
+    }
+
+    if (range.upper() == 0)
+      return builder.createOrFold<moore::NegOp>(loc, index);
+
+    Value newIndex =
+        builder.createOrFold<moore::ConversionOp>(loc, intType, index);
+    Value offset = builder.create<moore::ConstantOp>(
+        loc, intType, range.upper(), /* isSigned = */ range.upper() < 0);
+    return builder.createOrFold<moore::SubOp>(loc, offset, newIndex);
+  }
+
   // Handle single bit selections.
   Value visit(const slang::ast::ElementSelectExpression &expr) {
     auto type = context.convertType(*expr.type);
     auto value = context.convertLvalueExpression(expr.value());
     if (!type || !value)
       return {};
+    auto range = expr.value().type->getFixedRange();
     if (auto *constValue = expr.selector().constant) {
       assert(!constValue->hasUnknown());
       assert(constValue->size() <= 32);
@@ -1019,14 +1049,14 @@ struct LvalueExprVisitor {
       auto lowBit = constValue->integer().as<uint32_t>().value();
       return builder.create<moore::ExtractRefOp>(
           loc, moore::RefType::get(cast<moore::UnpackedType>(type)), value,
-          lowBit);
+          range.translateIndex(lowBit));
     }
     auto lowBit = context.convertRvalueExpression(expr.selector());
     if (!lowBit)
       return {};
     return builder.create<moore::DynExtractRefOp>(
         loc, moore::RefType::get(cast<moore::UnpackedType>(type)), value,
-        lowBit);
+        getSelectIndex(lowBit, range));
   }
 
   // Handle range bits selections.
@@ -1089,13 +1119,14 @@ struct LvalueExprVisitor {
       else
         dynLowBit = context.convertRvalueExpression(expr.left());
     }
+    auto range = expr.value().type->getFixedRange();
     if (leftConst && rightConst)
       return builder.create<moore::ExtractRefOp>(
           loc, moore::RefType::get(cast<moore::UnpackedType>(type)), value,
-          constLowBit);
+          range.translateIndex(constLowBit));
     return builder.create<moore::DynExtractRefOp>(
         loc, moore::RefType::get(cast<moore::UnpackedType>(type)), value,
-        dynLowBit);
+        getSelectIndex(dynLowBit, range));
   }
 
   Value visit(const slang::ast::StreamingConcatenationExpression &expr) {


### PR DESCRIPTION
This makes it uniform with how the RvalueExprVisitor handles it (copied getSelectIndex verbatim, could also make utility function shared between visitors).

Let me know how best to test this, I could do a simple Verilog import/export FileCheck test.

Resolves: #8657