### PR TITLE
Remove single state restriction on FSM to SV

### DIFF
--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -410,8 +410,6 @@ void MachineOpConverter::buildStateCaseMux(
 LogicalResult MachineOpConverter::dispatch() {
   b.setInsertionPoint(machineOp);
   auto loc = machineOp.getLoc();
-  if (machineOp.getNumStates() < 2)
-    return machineOp.emitOpError() << "expected at least 2 states.";
 
   // Clone all referenced constants into the machine body - constants may have
   // been moved to the machine parent due to the lack of IsolationFromAbove.

--- a/test/Conversion/FSMToSV/single_state.mlir
+++ b/test/Conversion/FSMToSV/single_state.mlir
@@ -1,0 +1,20 @@
+// RUN: circt-opt -convert-fsm-to-sv %s | FileCheck %s
+
+// CHECK:      case A:
+// CHECK-NEXT: sv.bpassign
+// CHECK-SAME: !hw.typealias<@fsm_enum_typedecls::@FSM_state_t, !hw.enum<A>>
+
+fsm.machine @FSM(%arg0: i1, %arg1: i1) -> (i8) attributes {initialState = "A"} {
+  %c_0 = hw.constant 0 : i8
+  fsm.state @A output  {
+    fsm.output %c_0 : i8
+  } transitions {
+    fsm.transition @A
+  }
+}
+
+hw.module @top(in %arg0: i1, in %arg1: i1, in %clk : !seq.clock, in %rst : i1, out out: i8) {
+    %out = fsm.hw_instance "fsm_inst" @FSM(%arg0, %arg1), clock %clk, reset %rst : (i1, i1) -> (i8)
+    hw.output %out : i8
+}
+


### PR DESCRIPTION
The conversion seems to work and gets to Verilog. It seems correct, if not most efficient lowered form if there is only one state. Not sure if there was a different reason for this restriction (beyond, this would be better as just HWModule, although didn't see a pattern that would do that).