### PR TITLE
[RTG] Add LowerValidateToLabels pass

### DIFF
--- a/include/circt/Dialect/RTG/Transforms/RTGPasses.td
+++ b/include/circt/Dialect/RTG/Transforms/RTGPasses.td
@@ -172,4 +172,12 @@ def EmbedValidationValuesPass : Pass<"rtg-embed-validation-values",
   ];
 }
 
+def LowerValidateToLabelsPass : Pass<"rtg-lower-validate-to-labels"> {
+  let summary = "lower validation operations to intrinsic labels";
+  let description = [{
+    Lowers the 'rtg.validate' operations to special intrinsic labels understood
+    by the target simulator to print the register contents.
+  }];
+}
+
 #endif // CIRCT_DIALECT_RTG_TRANSFORMS_RTGPASSES_TD

--- a/lib/Dialect/RTG/Transforms/CMakeLists.txt
+++ b/lib/Dialect/RTG/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ add_circt_dialect_library(CIRCTRTGTransforms
   InlineSequencesPass.cpp
   LinearScanRegisterAllocationPass.cpp
   LowerUniqueLabelsPass.cpp
+  LowerValidateToLabelsPass.cpp
   MemoryAllocationPass.cpp
   UniqueValidateOpsPass.cpp
 

--- a/lib/Dialect/RTG/Transforms/LowerValidateToLabelsPass.cpp
+++ b/lib/Dialect/RTG/Transforms/LowerValidateToLabelsPass.cpp
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/RTG/IR/RTGOps.h"
+#include "circt/Dialect/RTG/Transforms/RTGPasses.h"
+#include "circt/Support/UnusedOpPruner.h"
+
+namespace circt {
+namespace rtg {
+#define GEN_PASS_DEF_LOWERVALIDATETOLABELSPASS
+#include "circt/Dialect/RTG/Transforms/RTGPasses.h.inc"
+} // namespace rtg
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+
+//===----------------------------------------------------------------------===//
+// Lower Validate To Labels Pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct LowerValidateToLabelsPass
+    : public rtg::impl::LowerValidateToLabelsPassBase<
+          LowerValidateToLabelsPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void LowerValidateToLabelsPass::runOnOperation() {
+  auto *rootOp = getOperation();
+  UnusedOpPruner pruner;
+
+  auto result = rootOp->walk([&](rtg::ValidateOp validateOp) -> WalkResult {
+    Location loc = validateOp.getLoc();
+    auto regOp = validateOp.getRef().getDefiningOp<rtg::FixedRegisterOp>();
+    if (!regOp)
+      return validateOp->emitError("could not determine register");
+
+    if (!validateOp.getId().has_value())
+      return validateOp.emitError("expected ID to be set");
+
+    OpBuilder builder(validateOp);
+    auto intrinsicLabel = validateOp.getRef().getType().getIntrinsicLabel(
+        regOp.getReg(), validateOp.getId().value());
+    Value lbl = builder.create<rtg::LabelDeclOp>(
+        loc, StringAttr::get(&getContext(), intrinsicLabel), ValueRange());
+    builder.create<rtg::LabelOp>(loc, rtg::LabelVisibility::global, lbl);
+    validateOp.getValue().replaceAllUsesWith(validateOp.getDefaultValue());
+
+    pruner.eraseNow(validateOp);
+    return WalkResult::advance();
+  });
+
+  if (result.wasInterrupted())
+    return signalPassFailure();
+
+  pruner.eraseNow();
+}

--- a/test/Dialect/RTG/Transform/lower-validate-to-labels.mlir
+++ b/test/Dialect/RTG/Transform/lower-validate-to-labels.mlir
@@ -1,0 +1,33 @@
+// RUN: circt-opt --rtg-lower-validate-to-labels --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: rtg.test @basic
+rtg.test @basic() {
+  // CHECK-NEXT: [[REG:%.+]] = rtg.fixed_reg #rtgtest.t1
+  // CHECK-NEXT: [[IMM:%.+]] = rtg.constant #rtg.isa.immediate<32, 0>
+  // CHECK-NEXT: [[LBL:%.+]] = rtg.label_decl "spike.pre.printreg.x5.id1"
+  // CHECK-NEXT: rtg.label global [[LBL]]
+  // CHECK-NEXT: rtgtest.rv32i.lui [[REG]], [[IMM]] : !rtg.isa.immediate<32>
+  %0 = rtg.fixed_reg #rtgtest.t0
+  %1 = rtg.fixed_reg #rtgtest.t1
+  %2 = rtg.constant #rtg.isa.immediate<32, 0>
+  %3 = rtg.validate %0, %2, "id1" : !rtgtest.ireg -> !rtg.isa.immediate<32>
+  rtgtest.rv32i.lui %1, %3 : !rtg.isa.immediate<32>
+}
+
+// -----
+
+rtg.test @no_id() {
+  %0 = rtg.fixed_reg #rtgtest.t0
+  %1 = rtg.constant #rtg.isa.immediate<32, 0>
+  // expected-error @below {{expected ID to be set}}
+  %2 = rtg.validate %0, %1 : !rtgtest.ireg -> !rtg.isa.immediate<32>
+}
+
+// -----
+
+rtg.test @no_reg() {
+  %0 = rtg.virtual_reg [#rtgtest.t0, #rtgtest.t1]
+  %1 = rtg.constant #rtg.isa.immediate<32, 0>
+  // expected-error @below {{could not determine register}}
+  %2 = rtg.validate %0, %1 : !rtgtest.ireg -> !rtg.isa.immediate<32>
+}


### PR DESCRIPTION
The pass to be run in the first compilation run to generate sideband command labels understood by the ISA simulator (e.g. Spike).