### PR TITLE
Convert to CF before running LLHD inline.

### DIFF
--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -322,9 +322,9 @@ static void populateMooreToCoreLowering(PassManager &pm) {
 static void populateLLHDLowering(PassManager &pm) {
   // Inline function calls and lower SCF to CF.
   pm.addNestedPass<hw::HWModuleOp>(llhd::createWrapProceduralOpsPass());
+  pm.addPass(mlir::createSCFToControlFlowPass());
   pm.addPass(llhd::createInlineCallsPass());
   pm.addPass(mlir::createSymbolDCEPass());
-  pm.addPass(mlir::createSCFToControlFlowPass());
 
   // Simplify processes, replace signals with process results, and detect
   // registers.


### PR DESCRIPTION
The LLHD inliner doesn't check if the parent op only supports single block regions when inlining a call (while the function body of the call may already be multiblock). This flips the lowering to CF to before LLHD inline to avoid a common variant of this (inlining into SCF ops).