### PR TITLE
[FIRRTL] Lint XMRs in the "design"

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -198,9 +198,6 @@ std::unique_ptr<mlir::Pass>
 createLinkCircuitsPass(mlir::StringRef baseCircuitName = "",
                        bool noMangle = false);
 
-std::unique_ptr<mlir::Pass> createLintingPass(bool lintStaticAsserts = true,
-                                              bool lintXmrsInDesign = true);
-
 std::unique_ptr<mlir::Pass> createProbesToSignalsPass();
 
 std::unique_ptr<mlir::Pass> createSpecializeLayersPass();

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -198,7 +198,7 @@ std::unique_ptr<mlir::Pass>
 createLinkCircuitsPass(mlir::StringRef baseCircuitName = "",
                        bool noMangle = false);
 
-std::unique_ptr<mlir::Pass> createLintingPass();
+std::unique_ptr<mlir::Pass> createLintingPass(bool lintStaticAsserts = true);
 
 std::unique_ptr<mlir::Pass> createProbesToSignalsPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.h
+++ b/include/circt/Dialect/FIRRTL/Passes.h
@@ -198,7 +198,8 @@ std::unique_ptr<mlir::Pass>
 createLinkCircuitsPass(mlir::StringRef baseCircuitName = "",
                        bool noMangle = false);
 
-std::unique_ptr<mlir::Pass> createLintingPass(bool lintStaticAsserts = true);
+std::unique_ptr<mlir::Pass> createLintingPass(bool lintStaticAsserts = true,
+                                              bool lintXmrsInDesign = true);
 
 std::unique_ptr<mlir::Pass> createProbesToSignalsPass();
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -863,7 +863,9 @@ def Lint :
   let constructor = "circt::firrtl::createLintingPass()";
   let options = [
     Option<"lintStaticAsserts", "lint-static-asserts", "bool", "",
-      "enable linting of static assertions">
+      "enable linting of static assertions">,
+    Option<"lintXmrsInDesign", "lint-xmrs-in-design", "bool", "",
+      "enable linting of XMRs that exist in the design">
   ];
 }
 

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -861,6 +861,10 @@ def Lint :
     inferred to be false. The pass emits error on such failing ops.
   }];
   let constructor = "circt::firrtl::createLintingPass()";
+  let options = [
+    Option<"lintStaticAsserts", "lint-static-asserts", "bool", "",
+      "enable linting of static assertions">
+  ];
 }
 
 def SpecializeLayers : Pass<"firrtl-specialize-layers", "firrtl::CircuitOp"> {

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -853,7 +853,7 @@ def LinkCircuits : Pass<"firrtl-link-circuits", "mlir::ModuleOp"> {
 }
 
 def Lint :
-    Pass<"firrtl-lint", "firrtl::FModuleOp"> {
+    Pass<"firrtl-lint", "firrtl::CircuitOp"> {
   let summary = "An analysis pass to detect static simulation failures.";
   let description = [{
     This pass detects operations that will trivially fail any simulation.

--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -860,11 +860,10 @@ def Lint :
     Currently it detects assertions whose predicate condition can be statically
     inferred to be false. The pass emits error on such failing ops.
   }];
-  let constructor = "circt::firrtl::createLintingPass()";
   let options = [
-    Option<"lintStaticAsserts", "lint-static-asserts", "bool", "",
+    Option<"lintStaticAsserts", "lint-static-asserts", "bool", "true",
       "enable linting of static assertions">,
-    Option<"lintXmrsInDesign", "lint-xmrs-in-design", "bool", "",
+    Option<"lintXmrsInDesign", "lint-xmrs-in-design", "bool", "true",
       "enable linting of XMRs that exist in the design">
   ];
 }

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -143,6 +143,8 @@ public:
   }
   bool shouldDisableWireElimination() const { return disableWireElimination; }
 
+  bool getLintStaticAsserts() const { return lintStaticAsserts; }
+
   // Setters, used by the CAPI
   FirtoolOptions &setOutputFilename(StringRef name) {
     outputFilename = name;
@@ -392,6 +394,11 @@ public:
     return *this;
   }
 
+  FirtoolOptions &setLintStaticAsserts(bool value) {
+    lintStaticAsserts = value;
+    return *this;
+  }
+
 private:
   std::string outputFilename;
   bool disableAnnotationsUnknown;
@@ -443,6 +450,7 @@ private:
   bool selectDefaultInstanceChoice;
   verif::SymbolicValueLowering symbolicValueLowering;
   bool disableWireElimination;
+  bool lintStaticAsserts;
 };
 
 void registerFirtoolCLOptions();

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -145,6 +145,8 @@ public:
 
   bool getLintStaticAsserts() const { return lintStaticAsserts; }
 
+  bool getLintXmrsInDesign() const { return lintXmrsInDesign; }
+
   // Setters, used by the CAPI
   FirtoolOptions &setOutputFilename(StringRef name) {
     outputFilename = name;
@@ -399,6 +401,11 @@ public:
     return *this;
   }
 
+  FirtoolOptions &setLintXmrsInDesign(bool value) {
+    lintXmrsInDesign = value;
+    return *this;
+  }
+
 private:
   std::string outputFilename;
   bool disableAnnotationsUnknown;
@@ -451,6 +458,7 @@ private:
   verif::SymbolicValueLowering symbolicValueLowering;
   bool disableWireElimination;
   bool lintStaticAsserts;
+  bool lintXmrsInDesign;
 };
 
 void registerFirtoolCLOptions();

--- a/lib/Analysis/FIRRTLInstanceInfo.cpp
+++ b/lib/Analysis/FIRRTLInstanceInfo.cpp
@@ -16,6 +16,7 @@
 #include "circt/Analysis/FIRRTLInstanceInfo.h"
 #include "circt/Dialect/FIRRTL/AnnotationDetails.h"
 #include "circt/Dialect/FIRRTL/FIRRTLInstanceGraph.h"
+#include "circt/Dialect/SV/SVOps.h"
 #include "circt/Support/Debug.h"
 #include "circt/Support/InstanceGraph.h"
 #include "llvm/ADT/PostOrderIterator.h"
@@ -143,7 +144,8 @@ InstanceInfo::InstanceInfo(Operation *op, mlir::AnalysisManager &am) {
         bool underLayer = false;
         if (auto instanceOp = useIt->getInstance<InstanceOp>()) {
           if (instanceOp.getLowerToBind() || instanceOp.getDoNotPrint() ||
-              instanceOp->getParentOfType<LayerBlockOp>())
+              instanceOp->getParentOfType<LayerBlockOp>() ||
+              instanceOp->getParentOfType<sv::IfDefOp>())
             underLayer = true;
         }
 

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -294,8 +294,7 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().addPass(om::createVerifyObjectFieldsPass());
 
   // Check for static asserts.
-  pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
-      circt::firrtl::createLintingPass());
+  pm.nest<firrtl::CircuitOp>().addPass(circt::firrtl::createLintingPass());
 
   pm.addPass(createLowerFIRRTLToHWPass(opt.shouldEnableAnnotationWarning(),
                                        opt.getVerificationFlavor()));

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -294,9 +294,9 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().addPass(om::createVerifyObjectFieldsPass());
 
   // Check for static asserts.
-  pm.nest<firrtl::CircuitOp>().addPass(circt::firrtl::createLintingPass(
-      /*lintStaticAsserts=*/opt.getLintStaticAsserts(),
-      /*lintXmrsInDesign=*/opt.getLintXmrsInDesign()));
+  pm.nest<firrtl::CircuitOp>().addPass(circt::firrtl::createLint(
+      {/*lintStaticAsserts=*/opt.getLintStaticAsserts(),
+       /*lintXmrsInDesign=*/opt.getLintXmrsInDesign()}));
 
   pm.addPass(createLowerFIRRTLToHWPass(opt.shouldEnableAnnotationWarning(),
                                        opt.getVerificationFlavor()));

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -294,8 +294,9 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().addPass(om::createVerifyObjectFieldsPass());
 
   // Check for static asserts.
-  pm.nest<firrtl::CircuitOp>().addPass(
-      circt::firrtl::createLintingPass(opt.getLintStaticAsserts()));
+  pm.nest<firrtl::CircuitOp>().addPass(circt::firrtl::createLintingPass(
+      /*lintStaticAsserts=*/opt.getLintStaticAsserts(),
+      /*lintXmrsInDesign=*/opt.getLintXmrsInDesign()));
 
   pm.addPass(createLowerFIRRTLToHWPass(opt.shouldEnableAnnotationWarning(),
                                        opt.getVerificationFlavor()));
@@ -781,8 +782,15 @@ struct FirtoolCmdOptions {
       "disable-wire-elimination", llvm::cl::desc("Disable wire elimination"),
       llvm::cl::init(false)};
 
+  //===----------------------------------------------------------------------===
+  // Lint options
+  //===----------------------------------------------------------------------===
+
   llvm::cl::opt<bool> lintStaticAsserts{
       "lint-static-asserts", llvm::cl::desc("Lint static assertions"),
+      llvm::cl::init(true)};
+  llvm::cl::opt<bool> lintXmrsInDesign{
+      "lint-xmrs-in-design", llvm::cl::desc("Lint XMRs in the design"),
       llvm::cl::init(true)};
 };
 } // namespace
@@ -823,7 +831,8 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       stripDebugInfo(false), fixupEICGWrapper(false), addCompanionAssume(false),
       disableCSEinClasses(false), selectDefaultInstanceChoice(false),
       symbolicValueLowering(verif::SymbolicValueLowering::ExtModule),
-      disableWireElimination(false), lintStaticAsserts(true) {
+      disableWireElimination(false), lintStaticAsserts(true),
+      lintXmrsInDesign(true) {
   if (!clOptions.isConstructed())
     return;
   outputFilename = clOptions->outputFilename;
@@ -877,4 +886,5 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   symbolicValueLowering = clOptions->symbolicValueLowering;
   disableWireElimination = clOptions->disableWireElimination;
   lintStaticAsserts = clOptions->lintStaticAsserts;
+  lintXmrsInDesign = clOptions->lintXmrsInDesign;
 }

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -294,7 +294,8 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
   pm.nest<firrtl::CircuitOp>().addPass(om::createVerifyObjectFieldsPass());
 
   // Check for static asserts.
-  pm.nest<firrtl::CircuitOp>().addPass(circt::firrtl::createLintingPass());
+  pm.nest<firrtl::CircuitOp>().addPass(
+      circt::firrtl::createLintingPass(opt.getLintStaticAsserts()));
 
   pm.addPass(createLowerFIRRTLToHWPass(opt.shouldEnableAnnotationWarning(),
                                        opt.getVerificationFlavor()));
@@ -779,6 +780,10 @@ struct FirtoolCmdOptions {
   llvm::cl::opt<bool> disableWireElimination{
       "disable-wire-elimination", llvm::cl::desc("Disable wire elimination"),
       llvm::cl::init(false)};
+
+  llvm::cl::opt<bool> lintStaticAsserts{
+      "lint-static-asserts", llvm::cl::desc("Lint static assertions"),
+      llvm::cl::init(true)};
 };
 } // namespace
 
@@ -818,7 +823,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       stripDebugInfo(false), fixupEICGWrapper(false), addCompanionAssume(false),
       disableCSEinClasses(false), selectDefaultInstanceChoice(false),
       symbolicValueLowering(verif::SymbolicValueLowering::ExtModule),
-      disableWireElimination(false) {
+      disableWireElimination(false), lintStaticAsserts(true) {
   if (!clOptions.isConstructed())
     return;
   outputFilename = clOptions->outputFilename;
@@ -871,4 +876,5 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   selectDefaultInstanceChoice = clOptions->selectDefaultInstanceChoice;
   symbolicValueLowering = clOptions->symbolicValueLowering;
   disableWireElimination = clOptions->disableWireElimination;
+  lintStaticAsserts = clOptions->lintStaticAsserts;
 }

--- a/test/Dialect/FIRRTL/lint-noerror.mlir
+++ b/test/Dialect/FIRRTL/lint-noerror.mlir
@@ -1,0 +1,100 @@
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-lint))' %s
+
+// This test checks that the linter does _not_ error for certain patterns.
+
+firrtl.circuit "XmrNoDut" {
+  hw.hierpath private @xmrPath [@XmrNoDut::@sym]
+  firrtl.module @XmrNoDut() {
+    %a = firrtl.wire sym @sym : !firrtl.uint<1>
+    %0 = firrtl.xmr.deref @xmrPath : !firrtl.uint<1>
+    %b = firrtl.node %0 : !firrtl.uint<1>
+  }
+}
+
+firrtl.circuit "XmrInTestHarness" {
+  hw.hierpath private @xmrPath [@XmrInTestHarness::@sym]
+  firrtl.module @Dut() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {
+  }
+  firrtl.module @XmrInTestHarness() {
+    firrtl.instance dut @Dut()
+    %a = firrtl.wire sym @sym : !firrtl.uint<1>
+    %0 = firrtl.xmr.deref @xmrPath : !firrtl.uint<1>
+    %b = firrtl.node %0 : !firrtl.uint<1>
+  }
+}
+
+firrtl.circuit "XmrInLayer" {
+  hw.hierpath private @xmrPath [@XmrInLayer::@sym]
+  firrtl.layer @A bind {}
+  firrtl.module @XmrInLayer() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {
+    firrtl.layerblock @A {
+      %a = firrtl.wire sym @sym : !firrtl.uint<1>
+      %0 = firrtl.xmr.deref @xmrPath : !firrtl.uint<1>
+      %b = firrtl.node %0 : !firrtl.uint<1>
+    }
+  }
+}
+
+firrtl.circuit "XmrInLayer_lowered_Bind" {
+  hw.hierpath private @xmrPath [@Foo::@sym]
+  firrtl.module @Foo() {
+    %a = firrtl.wire sym @sym : !firrtl.uint<1>
+    %0 = firrtl.xmr.deref @xmrPath : !firrtl.uint<1>
+    %b = firrtl.node %0 : !firrtl.uint<1>
+  }
+  firrtl.module @XmrInLayer_lowered_Bind() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {
+    firrtl.instance a sym @a {
+      doNotPrint
+    } @Foo()
+  }
+}
+
+firrtl.circuit "XmrInLayer_lowered_IfDef" {
+  hw.hierpath private @xmrPath [@XmrInLayer_lowered_IfDef::@sym]
+  sv.macro.decl @layer
+  firrtl.module @XmrInLayer_lowered_IfDef() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {
+    sv.ifdef @layer {
+      %a = firrtl.wire sym @sym : !firrtl.uint<1>
+      %0 = firrtl.xmr.deref @xmrPath : !firrtl.uint<1>
+      %b = firrtl.node %0 : !firrtl.uint<1>
+    }
+  }
+}
+
+firrtl.circuit "XMRInDesignNoUsers" {
+  hw.hierpath private @xmrPath [@XMRInDesignNoUsers::@sym]
+  firrtl.module @XMRInDesignNoUsers() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {
+    %a = firrtl.wire sym @sym : !firrtl.uint<1>
+    %0 = firrtl.xmr.deref @xmrPath : !firrtl.uint<1>
+  }
+}

--- a/test/Dialect/FIRRTL/lint.mlir
+++ b/test/Dialect/FIRRTL/lint.mlir
@@ -82,3 +82,48 @@ firrtl.layer @GroupFoo bind {}
     }
   }
 }
+
+// -----
+
+firrtl.circuit "XMRInDesign" {
+  hw.hierpath private @xmrPath [@XMRInDesign::@sym]
+  // expected-note @below {{op is instantiated in this module}}
+  firrtl.module @XMRInDesign() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {
+    %a = firrtl.wire sym @sym : !firrtl.uint<1>
+    // expected-error @below {{is in the design. (Did you forget to put it under a layer?)}}
+    %0 = firrtl.xmr.deref @xmrPath : !firrtl.uint<1>
+    %b = firrtl.node %0 : !firrtl.uint<1>
+  }
+}
+
+// -----
+
+firrtl.circuit "XMRInDesignAndTestHarness" {
+  hw.hierpath private @xmrPath [@Foo::@sym]
+  // expected-note @below {{op is instantiated in this module}}
+  firrtl.module @Foo() {
+    %a = firrtl.wire sym @sym : !firrtl.uint<1>
+    // expected-error @below {{is in the design. (Did you forget to put it under a layer?)}}
+    %0 = firrtl.xmr.deref @xmrPath : !firrtl.uint<1>
+    %b = firrtl.node %0 : !firrtl.uint<1>
+  }
+  firrtl.module @DUT() attributes {
+    annotations = [
+      {
+        class = "sifive.enterprise.firrtl.MarkDUTAnnotation"
+      }
+    ]
+  } {
+    firrtl.instance foo @Foo()
+  }
+  firrtl.module @XMRInDesignAndTestHarness()  {
+    firrtl.instance dut @DUT()
+    firrtl.instance foo @Foo()
+  }
+}

--- a/test/Dialect/FIRRTL/lint.mlir
+++ b/test/Dialect/FIRRTL/lint.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl.module(firrtl-lint)))' --verify-diagnostics --split-input-file %s | FileCheck %s
+// RUN: circt-opt --pass-pipeline='builtin.module(firrtl.circuit(firrtl-lint))' --verify-diagnostics --split-input-file %s | FileCheck %s
 
 firrtl.circuit "lint_tests" {
   // CHECK: firrtl.module @lint_tests


### PR DESCRIPTION
Add an option to FIRRTL's linter (and expose it up to `firtool`) that will
lint (error) if any XMRs exist in the "design".  This is intended to catch
problems where downstream consumers of CIRCT-generated Verilog (e.g.,
Physical Design teams) get unexpected unsynthesizable XMRs in the design.
This is almost _never_ what you want.

Unfortunately, this is highly error prone.  It's difficult to tell what
is/is not the "design".  This relies on the InstanceInfo analysis and
intentionally uses its notion of "design" and not "effective design".  In
other words, this will only trigger this kind of linting if there is an
explicit `MarkDUTAnnotation`.  It will not assume that the main module has
an implicit `MarkDUTAnnotation`.  This is intended to avoid false
positives.

In order to make this work, there is a lot of prequisite work batched in
this PR.  A new pass, which only exists to run the `InstanceInfo` analysis
(and thereby cache it) is created.  This allows for use of the
`getCachedParentAnalysis` function and guaranteeing that it will succeed.
(This is a pattern borrowed from IREE.)  Options are added for the
singular, existing lint check as well.

This PR is best reviewed as individual commits.  I am intending to land
this as individual commits as well.
