### PR TITLE
Add SitestBlackBoxLibrariesAnnotation; process in CreateSiFiveMetadataPass

### DIFF
--- a/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
+++ b/docs/Dialects/FIRRTL/FIRRTLAnnotations.md
@@ -782,9 +782,13 @@ Example:
 | filename   | string | The file to write to                                |
 
 This annotation triggers the creation of a file containing a JSON array of the
-names of all external modules in the device under test which are not imported
+`defname`s of all external modules in the device under test which are not imported
 or inlined blackbox modules. This will only collect modules which are
 instantiated under a module annotated with `MarkDUTAnnotation`.
+
+If any external modules (including imported and inlined blackboxes) have a
+`SitestBlackBoxLibrariesAnnotation`, the libraries specified in that annotation
+will be included in the output.
 
 Example:
 ```json
@@ -802,15 +806,41 @@ Example:
 | filename   | string | The file to write to                                           |
 
 This annotation triggers the creation of a file containing a JSON array of the
-names of all external modules in the test harness which are not imported or
+`defname`s of all external modules in the test harness which are not imported or
 inlined blackbox modules. This will only collect modules which are not
 instantiated under a module annotated with `MarkDUTAnnotation`.
+
+If any external modules (including imported and inlined blackboxes) have a
+`SitestBlackBoxLibrariesAnnotation`, the libraries specified in that annotation
+will also be included in the output.
 
 Example:
 ```json
 {
   "class":"sifive.enterprise.firrtl.SitestTestHarnessBlackBoxAnnotation",
   "filename":"./testharness_blackboxes.json"
+}
+```
+
+### SitestBlackBoxLibrariesAnnotation
+
+| Property   | Type   | Description                                                      |
+| ---------- | ------ | -------------                                                    |
+| class      | string | `sifive.enterprise.firrtl.SitestBlackBoxLibrariesAnnotation`     |
+| libraries  | array  | Array of library names to include in blackbox metadata           |
+
+This annotation is used to specify additional library names that should be
+included in the blackbox metadata for an external module. When applied to an
+external module, the specified libraries will be added to the blackbox resource
+list in the generated metadata. Both the `defname` and any libraries specified by
+this annotation will be included in the metadata for non-imported and non-inlined
+blackboxes.
+
+Example:
+```json
+{
+  "class":"sifive.enterprise.firrtl.SitestBlackBoxLibrariesAnnotation",
+  "libraries":["libmath", "libcrypto", "custom_lib"]
 }
 ```
 

--- a/include/circt/Dialect/FIRRTL/AnnotationDetails.h
+++ b/include/circt/Dialect/FIRRTL/AnnotationDetails.h
@@ -145,6 +145,8 @@ constexpr const char *sitestBlackBoxAnnoClass =
     "sifive.enterprise.firrtl.SitestBlackBoxAnnotation";
 constexpr const char *sitestTestHarnessBlackBoxAnnoClass =
     "sifive.enterprise.firrtl.SitestTestHarnessBlackBoxAnnotation";
+constexpr const char *sitestBlackBoxLibrariesAnnoClass =
+    "sifive.enterprise.firrtl.SitestBlackBoxLibrariesAnnotation";
 constexpr const char *dontObfuscateModuleAnnoClass =
     "sifive.enterprise.firrtl.DontObfuscateModuleAnnotation";
 constexpr const char *elaborationArtefactsDirectoryAnnoClass =

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -188,8 +188,13 @@ struct ObjectModelIR {
     // Create list of blackbox resources from the provided list
     SmallVector<Value> libValues;
     for (StringRef libName : libraries) {
-      auto libNameAttr = builderOM.create<StringConstantOp>(
-          builderOM.getStringAttr(libName));
+      Value libNameAttr;
+      if (libName == defName) {
+        libNameAttr = modEntry;
+      } else {
+        libNameAttr = builderOM.create<StringConstantOp>(
+            builderOM.getStringAttr(libName));
+      }
       libValues.push_back(libNameAttr);
     }
     auto blackBoxResourcesList = builderOM.create<ListCreateOp>(

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -165,7 +165,7 @@ struct ObjectModelIR {
     auto unknownLoc = mlir::UnknownLoc::get(context);
     auto builderOM = mlir::ImplicitLocOpBuilder::atBlockEnd(
         unknownLoc, circtOp.getBodyBlock());
-    Type classFieldTypes[] = {StringType::get(context), BoolType::get(context)};
+    Type classFieldTypes[] = {StringType::get(context), BoolType::get(context), ListType::get(context, cast<PropertyType>(StringType::get(context)))};
     blackBoxModulesSchemaClass =
         builderOM.create<ClassOp>("SitestBlackBoxModulesSchema",
                                   blackBoxModulesParamNames, classFieldTypes);
@@ -174,7 +174,7 @@ struct ObjectModelIR {
         builderOM.getStringAttr("SitestBlackBoxMetadata"), mports);
   }
 
-  void addBlackBoxModule(FExtModuleOp module, bool inDut) {
+  void addBlackBoxModule(FExtModuleOp module, bool inDut, ArrayRef<StringRef> libraries) {
     if (!blackBoxModulesSchemaClass)
       addBlackBoxModulesSchema();
     StringRef defName = *module.getDefname();
@@ -184,6 +184,18 @@ struct ObjectModelIR {
         module.getLoc(), blackBoxMetadataClass.getBodyBlock());
     auto modEntry = builderOM.create<StringConstantOp>(module.getDefnameAttr());
     auto inDutAttr = builderOM.create<BoolConstantOp>(inDut);
+
+    // Create list of blackbox resources from the provided list
+    SmallVector<Value> libValues;
+    for (StringRef libName : libraries) {
+      auto libNameAttr = builderOM.create<StringConstantOp>(
+          builderOM.getStringAttr(libName));
+      libValues.push_back(libNameAttr);
+    }
+    auto blackBoxResourcesList = builderOM.create<ListCreateOp>(
+        ListType::get(builderOM.getContext(), cast<PropertyType>(StringType::get(builderOM.getContext()))),
+        libValues);
+
     auto object = builderOM.create<ObjectOp>(blackBoxModulesSchemaClass,
                                              module.getModuleNameAttr());
 
@@ -191,6 +203,8 @@ struct ObjectModelIR {
     builderOM.create<PropAssignOp>(inPortModuleName, modEntry);
     auto inPortInDut = builderOM.create<ObjectSubfieldOp>(object, 2);
     builderOM.create<PropAssignOp>(inPortInDut, inDutAttr);
+    auto inPortBlackBoxResources = builderOM.create<ObjectSubfieldOp>(object, 4);
+    builderOM.create<PropAssignOp>(inPortBlackBoxResources, blackBoxResourcesList);
     auto portIndex = blackBoxMetadataClass.getNumPorts();
     SmallVector<std::pair<unsigned, PortInfo>> newPorts = {
         {portIndex,
@@ -463,7 +477,7 @@ struct ObjectModelIR {
       "readLatency",   "hierarchy",  "inDut",          "extraPorts",
       "preExtInstName"};
   StringRef retimeModulesParamNames[1] = {"moduleName"};
-  StringRef blackBoxModulesParamNames[2] = {"moduleName", "inDut"};
+  StringRef blackBoxModulesParamNames[3] = {"moduleName", "inDut", "libraries"};
   llvm::SmallDenseSet<StringRef> blackboxModules;
 }; // namespace
 
@@ -796,8 +810,8 @@ CreateSiFiveMetadataPass::emitRetimeModulesMetadata(ObjectModelIR &omir) {
 LogicalResult
 CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
 
-  // Any extmodule with these annotations should be excluded from the blackbox
-  // list.
+  // Any extmodule with these annotations should be excluded from the blackbox list
+  // if it doesn't declare any additional libraries.
   std::array<StringRef, 6> blackListedAnnos = {
       blackBoxAnnoClass, blackBoxInlineAnnoClass, blackBoxPathAnnoClass,
       dataTapsBlackboxClass, memTapBlackboxClass};
@@ -819,30 +833,49 @@ CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
   // Find all extmodules in the circuit. Check if they are black-listed from
   // being included in the list. If they are not, separate them into two
   // groups depending on if theyre in the DUT or the test harness.
-  SmallVector<StringRef> dutModules;
-  SmallVector<StringRef> testModules;
+  SmallVector<StringRef> dutLibs;
+  SmallVector<StringRef> testLibs;
+
   for (auto extModule : circuitOp.getBodyBlock()->getOps<FExtModuleOp>()) {
+    SmallVector<StringRef> libs;
+
     // If the module doesn't have a defname, then we can't record it properly.
     // Just skip it.
     if (!extModule.getDefname())
       continue;
 
-    // If its a generated blackbox, skip it.
     AnnotationSet annos(extModule);
-    if (llvm::any_of(blackListedAnnos, [&](auto blackListedAnno) {
-          return annos.hasAnnotation(blackListedAnno);
-        }))
-      continue;
 
-    // Record the defname of the module.
+    bool isBlacklistedBlackbox = llvm::any_of(blackListedAnnos, [&](auto blackListedAnno) {
+      return annos.hasAnnotation(blackListedAnno);
+    });
+
+    if (!isBlacklistedBlackbox)
+      libs.push_back(*extModule.getDefname());
+
+    bool hasLibs = false;
+    if (auto libsAnno = annos.getAnnotation(sitestBlackBoxLibrariesAnnoClass)) {
+      if (auto libsAttr = libsAnno.getMember<ArrayAttr>("libraries")) {
+        for (auto lib : libsAttr) {
+          if (auto libStr = dyn_cast<StringAttr>(lib)) {
+            libs.push_back(libStr.getValue());
+            hasLibs = true;
+          }
+        }
+      }
+    }
+
     bool inDut = false;
     if (instanceInfo->anyInstanceInEffectiveDesign(extModule)) {
       inDut = true;
-      dutModules.push_back(*extModule.getDefname());
+      for (StringRef lib : libs)
+        dutLibs.push_back(lib);
     } else {
-      testModules.push_back(*extModule.getDefname());
+      for (StringRef lib : libs)
+        testLibs.push_back(lib);
     }
-    omir.addBlackBoxModule(extModule, inDut);
+
+    omir.addBlackBoxModule(extModule, inDut, libs);
   }
 
   // This is a helper to create the verbatim output operation.
@@ -874,8 +907,8 @@ CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
     });
   };
 
-  createOutput(testModules, testFilename);
-  createOutput(dutModules, dutFilename);
+  createOutput(testLibs, testFilename);
+  createOutput(dutLibs, dutFilename);
 
   return success();
 }

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -877,7 +877,7 @@ CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
       }
     }
 
-    if (!libs.empty())
+    if (libs.empty())
       continue;
 
     bool inDut = false;

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -165,7 +165,9 @@ struct ObjectModelIR {
     auto unknownLoc = mlir::UnknownLoc::get(context);
     auto builderOM = mlir::ImplicitLocOpBuilder::atBlockEnd(
         unknownLoc, circtOp.getBodyBlock());
-    Type classFieldTypes[] = {StringType::get(context), BoolType::get(context), ListType::get(context, cast<PropertyType>(StringType::get(context)))};
+    Type classFieldTypes[] = {
+        StringType::get(context), BoolType::get(context),
+        ListType::get(context, cast<PropertyType>(StringType::get(context)))};
     blackBoxModulesSchemaClass =
         builderOM.create<ClassOp>("SitestBlackBoxModulesSchema",
                                   blackBoxModulesParamNames, classFieldTypes);
@@ -174,7 +176,8 @@ struct ObjectModelIR {
         builderOM.getStringAttr("SitestBlackBoxMetadata"), mports);
   }
 
-  void addBlackBoxModule(FExtModuleOp module, bool inDut, ArrayRef<StringRef> libraries) {
+  void addBlackBoxModule(FExtModuleOp module, bool inDut,
+                         ArrayRef<StringRef> libraries) {
     if (!blackBoxModulesSchemaClass)
       addBlackBoxModulesSchema();
     StringRef defName = *module.getDefname();
@@ -197,7 +200,9 @@ struct ObjectModelIR {
       libValues.push_back(libNameAttr);
     }
     auto blackBoxResourcesList = builderOM.create<ListCreateOp>(
-        ListType::get(builderOM.getContext(), cast<PropertyType>(StringType::get(builderOM.getContext()))),
+        ListType::get(
+            builderOM.getContext(),
+            cast<PropertyType>(StringType::get(builderOM.getContext()))),
         libValues);
 
     auto object = builderOM.create<ObjectOp>(blackBoxModulesSchemaClass,
@@ -207,8 +212,10 @@ struct ObjectModelIR {
     builderOM.create<PropAssignOp>(inPortModuleName, modEntry);
     auto inPortInDut = builderOM.create<ObjectSubfieldOp>(object, 2);
     builderOM.create<PropAssignOp>(inPortInDut, inDutAttr);
-    auto inPortBlackBoxResources = builderOM.create<ObjectSubfieldOp>(object, 4);
-    builderOM.create<PropAssignOp>(inPortBlackBoxResources, blackBoxResourcesList);
+    auto inPortBlackBoxResources =
+        builderOM.create<ObjectSubfieldOp>(object, 4);
+    builderOM.create<PropAssignOp>(inPortBlackBoxResources,
+                                   blackBoxResourcesList);
     auto portIndex = blackBoxMetadataClass.getNumPorts();
     SmallVector<std::pair<unsigned, PortInfo>> newPorts = {
         {portIndex,
@@ -814,8 +821,8 @@ CreateSiFiveMetadataPass::emitRetimeModulesMetadata(ObjectModelIR &omir) {
 LogicalResult
 CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
 
-  // Any extmodule with these annotations should be excluded from the blackbox list
-  // if it doesn't declare any additional libraries.
+  // Any extmodule with these annotations should be excluded from the blackbox
+  // list if it doesn't declare any additional libraries.
   std::array<StringRef, 6> blackListedAnnos = {
       blackBoxAnnoClass, blackBoxInlineAnnoClass, blackBoxPathAnnoClass,
       dataTapsBlackboxClass, memTapBlackboxClass};
@@ -850,9 +857,10 @@ CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
 
     AnnotationSet annos(extModule);
 
-    bool isBlacklistedBlackbox = llvm::any_of(blackListedAnnos, [&](auto blackListedAnno) {
-      return annos.hasAnnotation(blackListedAnno);
-    });
+    bool isBlacklistedBlackbox =
+        llvm::any_of(blackListedAnnos, [&](auto blackListedAnno) {
+          return annos.hasAnnotation(blackListedAnno);
+        });
 
     if (!isBlacklistedBlackbox)
       libs.push_back(*extModule.getDefname());

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -865,17 +865,19 @@ CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
       }
     }
 
-    bool inDut = false;
-    if (instanceInfo->anyInstanceInEffectiveDesign(extModule)) {
-      inDut = true;
-      for (StringRef lib : libs)
-        dutLibs.push_back(lib);
-    } else {
-      for (StringRef lib : libs)
-        testLibs.push_back(lib);
-    }
+    if (!libs.empty()) {
+      bool inDut = false;
+      if (instanceInfo->anyInstanceInEffectiveDesign(extModule)) {
+        inDut = true;
+        for (StringRef lib : libs)
+          dutLibs.push_back(lib);
+      } else {
+        for (StringRef lib : libs)
+          testLibs.push_back(lib);
+      }
 
-    omir.addBlackBoxModule(extModule, inDut, libs);
+      omir.addBlackBoxModule(extModule, inDut, libs);
+    }
   }
 
   // This is a helper to create the verbatim output operation.

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -870,19 +870,19 @@ CreateSiFiveMetadataPass::emitSitestBlackboxMetadata(ObjectModelIR &omir) {
       }
     }
 
-    if (!libs.empty()) {
-      bool inDut = false;
-      if (instanceInfo->anyInstanceInEffectiveDesign(extModule)) {
-        inDut = true;
-        for (StringRef lib : libs)
-          dutLibs.push_back(lib);
-      } else {
-        for (StringRef lib : libs)
-          testLibs.push_back(lib);
-      }
+    if (!libs.empty())
+      continue;
 
-      omir.addBlackBoxModule(extModule, inDut, libs);
-    }
+    bool inDut = false;
+    if (instanceInfo->anyInstanceInEffectiveDesign(extModule)) {
+      inDut = true;
+      for (StringRef lib : libs)
+        dutLibs.push_back(lib);
+    } else
+      for (StringRef lib : libs)
+        testLibs.push_back(lib);
+
+    omir.addBlackBoxModule(extModule, inDut, libs);
   }
 
   // This is a helper to create the verbatim output operation.

--- a/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CreateSiFiveMetadata.cpp
@@ -185,7 +185,6 @@ struct ObjectModelIR {
     auto modEntry = builderOM.create<StringConstantOp>(module.getDefnameAttr());
     auto inDutAttr = builderOM.create<BoolConstantOp>(inDut);
 
-    // Create list of blackbox resources from the provided list
     SmallVector<Value> libValues;
     for (StringRef libName : libraries) {
       Value libNameAttr;

--- a/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerAnnotations.cpp
@@ -630,6 +630,8 @@ static llvm::StringMap<AnnoRecord> annotationRecords{{
     {injectDUTHierarchyAnnoClass, NoTargetAnnotation},
     {convertMemToRegOfVecAnnoClass, NoTargetAnnotation},
     {sitestBlackBoxAnnoClass, NoTargetAnnotation},
+    {sitestBlackBoxLibrariesAnnoClass,
+     {stdResolve, applyWithoutTarget<false, FExtModuleOp>}},
     {enumComponentAnnoClass, {noResolve, drop}},
     {enumDefAnnoClass, {noResolve, drop}},
     {enumVecAnnoClass, {noResolve, drop}},

--- a/test/Dialect/FIRRTL/SFCTests/directories.fir
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir
@@ -135,20 +135,23 @@ circuit TestHarness:
 ; SITEST_NODUT:     FILE "testbench.sitest.json"
 ; SITEST_NODUT-NOT: FILE
 
-; MLIR_OUT:  om.class @SitestBlackBoxModulesSchema(%basepath: !om.basepath, %moduleName_in: !om.string, %inDut_in: i1) -> (moduleName: !om.string, inDut: i1) {
-; MLIR_OUT:    om.class.fields %moduleName_in, %inDut_in : !om.string, i1
+; MLIR_OUT:  om.class @SitestBlackBoxModulesSchema(%basepath: !om.basepath, %moduleName_in: !om.string, %inDut_in: i1, %libraries_in: !om.list<!om.string>) -> (moduleName: !om.string, inDut: i1, libraries: !om.list<!om.string>) {
+; MLIR_OUT:    om.class.fields %moduleName_in, %inDut_in, %libraries_in : !om.string, i1, !om.list<!om.string>
 ; MLIR_OUT:  }
 
 ; MLIR_OUT:  om.class @SitestBlackBoxMetadata(%basepath: !om.basepath) -> [[V1:.+]]: !om.class.type<@SitestBlackBoxModulesSchema>, [[V2:.+]]: !om.class.type<@SitestBlackBoxModulesSchema>, [[V3:.+]]: !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT-DAG:    [[STR1:%.+]] = om.constant "Foo_BlackBox" : !om.string
 ; MLIR_OUT-DAG:    [[DUT1:%.+]] = om.constant true
-; MLIR_OUT-DAG:    [[OBJ1:%.+]] = om.object @SitestBlackBoxModulesSchema(%basepath, [[STR1]], [[DUT1]]) : (!om.basepath, !om.string, i1) -> !om.class.type<@SitestBlackBoxModulesSchema>
+; MLIR_OUT-DAG:    [[LIBS1:%.+]] = om.list_create [[STR1]] : !om.string
+; MLIR_OUT-DAG:    [[OBJ1:%.+]] = om.object @SitestBlackBoxModulesSchema(%basepath, [[STR1]], [[DUT1]], [[LIBS1]]) : (!om.basepath, !om.string, i1, !om.list<!om.string>) -> !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT-DAG:    [[STR2:%.+]] = om.constant "Bar_BlackBox" : !om.string
 ; MLIR_OUT-DAG:    [[DUT2:%.+]] = om.constant true
-; MLIR_OUT-DAG:    [[OBJ2:%.+]] = om.object @SitestBlackBoxModulesSchema(%basepath, [[STR2]], [[DUT2]]) : (!om.basepath, !om.string, i1) -> !om.class.type<@SitestBlackBoxModulesSchema>
+; MLIR_OUT-DAG:    [[LIBS2:%.+]] = om.list_create [[STR2]] : !om.string
+; MLIR_OUT-DAG:    [[OBJ2:%.+]] = om.object @SitestBlackBoxModulesSchema(%basepath, [[STR2]], [[DUT2]], [[LIBS2]]) : (!om.basepath, !om.string, i1, !om.list<!om.string>) -> !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT-DAG:    [[STR3:%.+]] = om.constant "Baz_BlackBox" : !om.string
 ; MLIR_OUT-DAG:    [[DUT3:%.+]] = om.constant true
-; MLIR_OUT-DAG:    [[OBJ3:%.+]] = om.object @SitestBlackBoxModulesSchema(%basepath, [[STR3]], [[DUT3]]) : (!om.basepath, !om.string, i1) -> !om.class.type<@SitestBlackBoxModulesSchema>
+; MLIR_OUT-DAG:    [[LIBS3:%.+]] = om.list_create [[STR3]] : !om.string
+; MLIR_OUT-DAG:    [[OBJ3:%.+]] = om.object @SitestBlackBoxModulesSchema(%basepath, [[STR3]], [[DUT3]], [[LIBS3]]) : (!om.basepath, !om.string, i1, !om.list<!om.string>) -> !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT:    om.class.fields [[OBJ1]], [[OBJ2]], [[OBJ3]] : !om.class.type<@SitestBlackBoxModulesSchema>, !om.class.type<@SitestBlackBoxModulesSchema>, !om.class.type<@SitestBlackBoxModulesSchema>
 ; MLIR_OUT:  }
 

--- a/test/Dialect/FIRRTL/emit-metadata.mlir
+++ b/test/Dialect/FIRRTL/emit-metadata.mlir
@@ -306,10 +306,13 @@ firrtl.circuit "BasicBlackboxes" attributes {
 // CHECK-SAME:            in %[[moduleName_in:[^:]+]]: !firrtl.string,
 // CHECK-SAME:            out %moduleName: !firrtl.string,
 // CHECK-SAME:            in %[[inDut_in:[^:]+]]: !firrtl.bool,
-// CHECK-SAME:            out %inDut: !firrtl.bool
+// CHECK-SAME:            out %inDut: !firrtl.bool,
+// CHECK-SAME:            in %[[libraries_in:[^:]+]]: !firrtl.list<string>,
+// CHECK-SAME:            out %libraries: !firrtl.list<string>
 // CHECK-SAME:          ) {
 // CHECK-NEXT:            firrtl.propassign %moduleName, %[[moduleName_in]]
 // CHECK-NEXT:            firrtl.propassign %inDut, %[[inDut_in]]
+// CHECK-NEXT:            firrtl.propassign %libraries, %[[libraries_in]]
 // CHECK:               }
 //
 // CHECK:               firrtl.class @SitestBlackBoxMetadata(
@@ -322,47 +325,62 @@ firrtl.circuit "BasicBlackboxes" attributes {
 //
 // CHECK-NEXT:            %[[#defname:]] = firrtl.string "TestBlackbox"
 // CHECK-NEXT:            %[[#inDutVal:]] = firrtl.bool false
+// CHECK-NEXT:            %[[#libsList:]] = firrtl.list.create %[[#defname]] : !firrtl.list<string>
 // CHECK-NEXT:            %[[object:.+]] = firrtl.object @SitestBlackBoxModulesSchema
 // CHECK-NEXT:            %[[#moduleName:]] = firrtl.object.subfield %[[object]][moduleName_in]
 // CHECK-NEXT:            firrtl.propassign %[[#moduleName]], %[[#defname:]] : !firrtl.string
 // CHECK-NEXT:            %[[#inDut:]] = firrtl.object.subfield %[[object]][inDut_in]
 // CHECK-NEXT:            firrtl.propassign %[[#inDut]], %[[#inDutVal]] : !firrtl.bool
+// CHECK-NEXT:            %[[#libraries:]] = firrtl.object.subfield %[[object]][libraries_in]
+// CHECK-NEXT:            firrtl.propassign %[[#libraries]], %[[#libsList]] : !firrtl.list<string>
 // CHECK-NEXT:            firrtl.propassign %TestBlackbox_field, %[[object]]
 //
 // CHECK-NEXT:            %[[#defname:]] = firrtl.string "DUTBlackbox2"
 // CHECK-NEXT:            %[[#inDutVal:]] = firrtl.bool true
+// CHECK-NEXT:            %[[#libsList:]] = firrtl.list.create %[[#defname]] : !firrtl.list<string>
 // CHECK-NEXT:            %[[object:.+]] = firrtl.object @SitestBlackBoxModulesSchema
 // CHECK-NEXT:            %[[#moduleName:]] = firrtl.object.subfield %[[object]][moduleName_in]
 // CHECK-NEXT:            firrtl.propassign %[[#moduleName]], %[[#defname:]] : !firrtl.string
 // CHECK-NEXT:            %[[#inDut:]] = firrtl.object.subfield %[[object]][inDut_in]
 // CHECK-NEXT:            firrtl.propassign %[[#inDut]], %[[#inDutVal]] : !firrtl.bool
+// CHECK-NEXT:            %[[#libraries:]] = firrtl.object.subfield %[[object]][libraries_in]
+// CHECK-NEXT:            firrtl.propassign %[[#libraries]], %[[#libsList]] : !firrtl.list<string>
 // CHECK-NEXT:            firrtl.propassign %DUTBlackbox_0_field, %[[object]]
 //
 // CHECK-NEXT:            %[[#defname:]] = firrtl.string "DUTBlackbox1"
 // CHECK-NEXT:            %[[#inDutVal:]] = firrtl.bool true
+// CHECK-NEXT:            %[[#libsList:]] = firrtl.list.create %[[#defname]] : !firrtl.list<string>
 // CHECK-NEXT:            %[[object:.+]] = firrtl.object @SitestBlackBoxModulesSchema
 // CHECK-NEXT:            %[[#moduleName:]] = firrtl.object.subfield %[[object]][moduleName_in]
 // CHECK-NEXT:            firrtl.propassign %[[#moduleName]], %[[#defname:]] : !firrtl.string
 // CHECK-NEXT:            %[[#inDut:]] = firrtl.object.subfield %[[object]][inDut_in]
 // CHECK-NEXT:            firrtl.propassign %[[#inDut]], %[[#inDutVal]] : !firrtl.bool
+// CHECK-NEXT:            %[[#libraries:]] = firrtl.object.subfield %[[object]][libraries_in]
+// CHECK-NEXT:            firrtl.propassign %[[#libraries]], %[[#libsList]] : !firrtl.list<string>
 // CHECK-NEXT:            firrtl.propassign %DUTBlackbox_1_field, %[[object]]
 //
 // CHECK-NEXT:            %[[#defname:]] = firrtl.string "LayerBlackboxInDesign"
 // CHECK-NEXT:            %[[#inDutVal:]] = firrtl.bool true
+// CHECK-NEXT:            %[[#libsList:]] = firrtl.list.create %[[#defname]] : !firrtl.list<string>
 // CHECK-NEXT:            %[[object:.+]] = firrtl.object @SitestBlackBoxModulesSchema
 // CHECK-NEXT:            %[[#moduleName:]] = firrtl.object.subfield %[[object]][moduleName_in]
 // CHECK-NEXT:            firrtl.propassign %[[#moduleName]], %[[#defname:]] : !firrtl.string
 // CHECK-NEXT:            %[[#inDut:]] = firrtl.object.subfield %[[object]][inDut_in]
 // CHECK-NEXT:            firrtl.propassign %[[#inDut]], %[[#inDutVal]] : !firrtl.bool
+// CHECK-NEXT:            %[[#libraries:]] = firrtl.object.subfield %[[object]][libraries_in]
+// CHECK-NEXT:            firrtl.propassign %[[#libraries]], %[[#libsList]] : !firrtl.list<string>
 // CHECK-NEXT:            firrtl.propassign %LayerBlackboxInDesign_field, %[[object]]
 //
 // CHECK-NEXT:            %[[#defname:]] = firrtl.string "LayerBlackbox"
 // CHECK-NEXT:            %[[#inDutVal:]] = firrtl.bool false
+// CHECK-NEXT:            %[[#libsList:]] = firrtl.list.create %[[#defname]] : !firrtl.list<string>
 // CHECK-NEXT:            %[[object:.+]] = firrtl.object @SitestBlackBoxModulesSchema
 // CHECK-NEXT:            %[[#moduleName:]] = firrtl.object.subfield %[[object]][moduleName_in]
 // CHECK-NEXT:            firrtl.propassign %[[#moduleName]], %[[#defname:]] : !firrtl.string
 // CHECK-NEXT:            %[[#inDut:]] = firrtl.object.subfield %[[object]][inDut_in]
 // CHECK-NEXT:            firrtl.propassign %[[#inDut]], %[[#inDutVal]] : !firrtl.bool
+// CHECK-NEXT:            %[[#libraries:]] = firrtl.object.subfield %[[object]][libraries_in]
+// CHECK-NEXT:            firrtl.propassign %[[#libraries]], %[[#libsList]] : !firrtl.list<string>
 // CHECK-NEXT:            firrtl.propassign %LayerBlackbox_field, %[[object]]
 //
 // CHECK-NOT:             firrtl.object


### PR DESCRIPTION
This allows extmodules to be annotated with additional library names to be included in the blackbox metadata. Downstream tooling can consume this to determine additional libraries that should be compiled alongside extmodules.

- Add SitestBlackBoxLibrariesAnnotation; process in CreateSiFiveMetadataPass
- Update docs
- Update and add tests
