### PR TITLE
[FIRRTL] Fix inject-dut-hier deleting new top

### DIFF
--- a/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
+++ b/test/Dialect/FIRRTL/inject-dut-hierarchy.mlir
@@ -347,3 +347,25 @@ firrtl.circuit "PublicMoveDutTrue" attributes {
     firrtl.instance dut @DUT()
   }
 }
+
+// -----
+
+// CHECK: firrtl.circuit "Foo"
+firrtl.circuit "MoveDutMainModule" attributes{
+  annotations = [
+    {
+      class = "sifive.enterprise.firrtl.InjectDUTHierarchyAnnotation",
+      name = "Foo",
+      moveDut = true
+    }
+  ]
+} {
+  // CHECK: firrtl.module @MoveDutMainModule()
+  firrtl.module @MoveDutMainModule() attributes {
+    annotations = [
+      {class = "sifive.enterprise.firrtl.MarkDUTAnnotation"}
+    ]
+  } {}
+  // CHECK:      firrtl.module @Foo() {
+  // CHECK-NEXT:   firrtl.instance MoveDutMainModule {{.*}} @MoveDutMainModule()
+}


### PR DESCRIPTION
Fix an issue with the `moveDut=true` behavior of the `InjectDUTHierarchy`
pass that would occur if the design-under-test (DUT) was the main module
in a circuit.  If this happens, this would create a new wrapper module
above the DUT, mark it private, and keep the main module of the circuit
pointing at the wrapper.  This would then cause the new DUT to be deleted
as it was a private module.

This is not FIRRTL ABI compatible as it will create a new public module
and cause things like additional ref files to be created.

CC: @azidar
