### PR TITLE
[ImportVerilog] Incorporate block names to variable/instance names

### DIFF
--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1869,6 +1869,43 @@ module GenerateConstructs;
   endgenerate
 endmodule
 
+// CHECK-LABEL: @UseGenerateBlockNameInVariables
+module UseGenerateBlockNameInVariables;
+  // CHECK: %x = moore.variable
+  int x;
+  begin : foo
+    // CHECK: %foo.y = moore.variable
+    int y;
+    for (genvar i = 2; i < 6; ++i) begin : bar
+      // CHECK: %foo.bar_2.z = moore.variable
+      // CHECK: %foo.bar_3.z = moore.variable
+      // CHECK: %foo.bar_4.z = moore.variable
+      // CHECK: %foo.bar_5.z = moore.variable
+      int z;
+    end
+  end
+endmodule
+
+// CHECK-LABEL: @UseGenerateBlockNameInInstances
+module UseGenerateBlockNameInInstances;
+  // CHECK: moore.instance "x" @Dummy
+  Dummy x();
+  begin : foo
+    // CHECK: moore.instance "foo.y" @Dummy
+    Dummy y();
+    for (genvar i = 2; i < 6; ++i) begin : bar
+      // CHECK: moore.instance "foo.bar_2.z" @Dummy
+      // CHECK: moore.instance "foo.bar_3.z" @Dummy
+      // CHECK: moore.instance "foo.bar_4.z" @Dummy
+      // CHECK: moore.instance "foo.bar_5.z" @Dummy
+      Dummy z();
+    end
+  end
+endmodule
+
+module Dummy;
+endmodule
+
 // Should accept and ignore empty packages.
 package Package;
   typedef logic [41:0] PackageType;


### PR DESCRIPTION
Use the names of surrounding generate blocks as a prefix for variable and instance names. This makes the names match up more closely with how existing EDA tools would label variables and instances embededded in generate blocks.

Consider the following Verilog input:

```systemverilog
module Top;
  int x;
  begin : foo
    int y;
    for (genvar i = 2; i < 6; ++i) begin : bar
      int z;
    end
  end
endmodule
```

The ImportVerilog conversion pass will now produce the following variables:

```mlir
%x = moore.variable : <i32>            // before: %x
%foo.y = moore.variable : <i32>        // before: %y
%foo.bar_2.z = moore.variable : <i32>  // before: %z
%foo.bar_3.z = moore.variable : <i32>  // before: %z_0
%foo.bar_4.z = moore.variable : <i32>  // before: %z_1
%foo.bar_5.z = moore.variable : <i32>  // before: %z_2
```

This closely matches names like `foo.bar[2].z` or `foo_bar_2_z` that would be generated by common EDA tools. Ideally we would be able to use a name like `foo.bar[2].z` directly, but ExportVerilog currently does not support escaped identifiers, causing the name to be sanitized to something like `foo_bar5B25D_z`.

By incorporating for-generate loop indices and block names into the variable name, logical equivalence checking should become easier and the signal names in Arcilator waveforms will match user expectations more closely.

Fixes #8679.