### PR TITLE
[ESI] Add a transaction snoop operation

### DIFF
--- a/frontends/PyCDE/src/pycde/signals.py
+++ b/frontends/PyCDE/src/pycde/signals.py
@@ -772,6 +772,12 @@ class ChannelSignal(Signal):
     snoop = esi.SnoopValidReadyOp(self.value)
     return snoop[0], snoop[1], snoop[2]
 
+  def snoop_xact(self) -> Tuple[Bits(1), Type]:
+    """Combinationally snoop on the internal signals of a channel."""
+    from .dialects import esi
+    snoop = esi.SnoopTransactionOp(self.value)
+    return snoop[0], snoop[1]
+
   def transform(self, transform: Callable[[Signal], Signal]) -> ChannelSignal:
     """Transform the data in the channel using the provided function. Said
     function must be combinational so it is intended for wire and simple type

--- a/frontends/PyCDE/test/test_esi.py
+++ b/frontends/PyCDE/test/test_esi.py
@@ -229,9 +229,10 @@ class RecvBundleTest(Module):
 
 # CHECK-LABEL:  hw.module @ChannelTransform(in %s1_in : !esi.channel<i32>, out s2_out : !esi.channel<i8>)
 # CHECK-NEXT:     %valid, %ready, %data = esi.snoop.vr %s1_in : !esi.channel<i32>
-# CHECK-NEXT:     %rawOutput, %valid_0 = esi.unwrap.vr %s1_in, %ready_1 : i32
+# CHECK-NEXT:     %transaction, %{{.+}} = esi.snoop.xact %s1_in : !esi.channel<i32>
+# CHECK-NEXT:     %rawOutput, [[VALID2:%.+]] = esi.unwrap.vr %s1_in, [[READY2:%.+]] : i32
 # CHECK-NEXT:     [[R0:%.+]] = comb.extract %rawOutput from 0 : (i32) -> i8
-# CHECK-NEXT:     %chanOutput, %ready_1 = esi.wrap.vr [[R0]], %valid_0 : i8
+# CHECK-NEXT:     %chanOutput, [[READY2]] = esi.wrap.vr [[R0]], [[VALID2]] : i8
 # CHECK-NEXT:     hw.output %chanOutput : !esi.channel<i8>
 @unittestmodule()
 class ChannelTransform(Module):
@@ -241,6 +242,7 @@ class ChannelTransform(Module):
   @generator
   def build(self):
     valid, ready, data = self.s1_in.snoop()
+    xact, _ = self.s1_in.snoop_xact()
     self.s2_out = self.s1_in.transform(lambda x: x[0:8])
 
 

--- a/include/circt/Dialect/ESI/ESIChannels.td
+++ b/include/circt/Dialect/ESI/ESIChannels.td
@@ -99,7 +99,8 @@ def ChannelTypeImpl : ESI_Type<"Channel"> {
 }
 
 //===----------------------------------------------------------------------===//
-// Snoop operations reveal the internal signals of a channel.
+// Operations which reveal the internal signals of a channel. They hang off
+// channels but don't count towards its user count.
 //===----------------------------------------------------------------------===//
 
 def SnoopValidReadyOp : ESI_Physical_Op<"snoop.vr", [InferTypeOpInterface]> {
@@ -113,6 +114,36 @@ def SnoopValidReadyOp : ESI_Physical_Op<"snoop.vr", [InferTypeOpInterface]> {
 
   let arguments = (ins ChannelType:$input);
   let results = (outs I1:$valid, I1:$ready, AnyType:$data);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $input attr-dict `:` qualified(type($input))
+  }];
+
+  let extraClassDeclaration = [{
+    /// Infer the return types of this operation.
+    static LogicalResult inferReturnTypes(MLIRContext *context,
+                                          std::optional<Location> loc,
+                                          ValueRange operands,
+                                          DictionaryAttr attrs,
+                                          mlir::OpaqueProperties properties,
+                                          mlir::RegionRange regions,
+                                          SmallVectorImpl<Type> &results);
+  }];
+}
+
+def SnoopTransactionOp : ESI_Physical_Op<"snoop.xact", [InferTypeOpInterface]> {
+  let summary = "Get the data and transaction signal from a channel";
+  let description = [{
+    A snoop that observes when a transaction occurs on a channel and provides
+    the data being transmitted. The transaction signal indicates when data is
+    actually being transferred on the channel, regardless of the underlying
+    signaling protocol (ValidReady or FIFO). Like other snoop operations, this
+    does not count as another user of the channel. Useful for monitoring data
+    flow and debugging.
+  }];
+
+  let arguments = (ins ChannelType:$input);
+  let results = (outs I1:$transaction, AnyType:$data);
   let hasVerifier = 1;
   let assemblyFormat = [{
     $input attr-dict `:` qualified(type($input))

--- a/lib/Dialect/ESI/ESIOps.cpp
+++ b/lib/Dialect/ESI/ESIOps.cpp
@@ -65,6 +65,23 @@ LogicalResult SnoopValidReadyOp::inferReturnTypes(
   return success();
 }
 
+LogicalResult SnoopTransactionOp::verify() {
+  ChannelType type = getInput().getType();
+  if (type.getInner() != getData().getType())
+    return emitOpError("input and output types must match");
+  return success();
+}
+
+LogicalResult SnoopTransactionOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
+    DictionaryAttr attrs, mlir::OpaqueProperties properties,
+    mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
+  auto i1 = IntegerType::get(context, 1);
+  results.push_back(i1);
+  results.push_back(cast<ChannelType>(operands[0].getType()).getInner());
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // FIFO functions.
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/ESI/ESITypes.cpp
+++ b/lib/Dialect/ESI/ESITypes.cpp
@@ -29,7 +29,7 @@ AnyType AnyType::get(MLIRContext *context) { return Base::get(context); }
 /// which is lazily constructed.
 static auto getChannelConsumers(mlir::TypedValue<ChannelType> chan) {
   return llvm::make_filter_range(chan.getUses(), [](auto &use) {
-    return !isa<SnoopValidReadyOp>(use.getOwner());
+    return !isa<SnoopValidReadyOp, SnoopTransactionOp>(use.getOwner());
   });
 }
 SmallVector<std::reference_wrapper<OpOperand>, 4>


### PR DESCRIPTION
Adds a new transaction‐level snoop operation (`snoop.xact`) to the ESI dialect, lowers it to hardware, and wires it through the Python front end.

- Introduce `SnoopTransactionOp` in ESIChannels.td with `verify` and `inferReturnTypes` in ESIOps.cpp  
- Extend the HW lowering pass to remove `snoop.xact` via `RemoveSnoopTransactionOp`  
- Update MLIR tests and the PyCDE API (`snoop_xact`) to exercise the new operation