### PR TITLE
[HW] MaterializeConstant: check for null block

### DIFF
--- a/lib/Dialect/HW/HWDialect.cpp
+++ b/lib/Dialect/HW/HWDialect.cpp
@@ -102,7 +102,10 @@ Operation *HWDialect::materializeConstant(OpBuilder &builder, Attribute value,
   }
 
   // Parameter expressions materialize into hw.param.value.
-  auto parentOp = builder.getBlock()->getParentOp();
+  Block *block = builder.getBlock();
+  if (!block)
+    return nullptr;
+  auto parentOp = block->getParentOp();
   auto curModule = dyn_cast<HWModuleOp>(parentOp);
   if (!curModule)
     curModule = parentOp->getParentOfType<HWModuleOp>();

--- a/unittests/Dialect/HW/CMakeLists.txt
+++ b/unittests/Dialect/HW/CMakeLists.txt
@@ -3,6 +3,7 @@ add_circt_unittest(CIRCTHWTests
   HWModuleTest.cpp
   InstanceGraphTest.cpp
   InstancePathTest.cpp
+  MaterializerTest.cpp
 )
 
 target_link_libraries(CIRCTHWTests

--- a/unittests/Dialect/HW/MaterializerTest.cpp
+++ b/unittests/Dialect/HW/MaterializerTest.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/HW/HWDialect.h"
+#include "mlir/IR/Builders.h"
+#include "gtest/gtest.h"
+
+using namespace circt;
+using namespace hw;
+
+namespace {
+
+TEST(MaterializerTest, ImmediateAttr) {
+  MLIRContext context;
+  context.loadDialect<HWDialect>();
+  Location loc(UnknownLoc::get(&context));
+  OpBuilder builder(&context);
+
+  // Check that we don't crash on non-sensical materializations.
+  auto attr = builder.getI8IntegerAttr(42);
+  auto type = builder.getF64Type();
+  context.getLoadedDialect<HWDialect>()->materializeConstant(builder, attr,
+                                                             type, loc);
+}
+
+} // namespace


### PR DESCRIPTION
Builders don't always specify the block. If it doesn't, this function segfaults.