### PR TITLE
[VerifToSMT] Fix lowering of initial integer values for BMC

### DIFF
--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -312,7 +312,7 @@ struct VerifBoundedModelCheckingOpConversion
           const auto &cstInt = initIntAttr.getValue();
           assert(cstInt.getBitWidth() ==
                      cast<smt::BitVectorType>(newTy).getWidth() &&
-                 "With mismatch between initial value and target type");
+                 "Width mismatch between initial value and target type");
           inputDecls.push_back(rewriter.create<smt::BVConstantOp>(loc, cstInt));
           continue;
         }

--- a/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
@@ -145,3 +145,26 @@ func.func @multiple_clocks() -> (i1) {
   }
   func.return %bmc : i1
 }
+
+// -----
+
+func.func @wrong_initial_type() -> (i1) {
+  // expected-error @below {{type of initial value does not match type of initialized register}}
+  %bmc = verif.bmc bound 10 num_regs 1 initial_values [-1 : i7]
+  init {
+    %c0_i1 = hw.constant 0 : i1
+    %clk = seq.to_clock %c0_i1
+    verif.yield %clk : !seq.clock
+  }
+  loop {
+    ^bb0(%clk: !seq.clock):
+    verif.yield %clk: !seq.clock
+  }
+  circuit {
+  ^bb0(%clk: !seq.clock, %arg0: i8):
+    %true = hw.constant true
+    verif.assert %true : i1
+    verif.yield %arg0 : i8
+  }
+  func.return %bmc : i1
+}

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --convert-verif-to-smt --reconcile-unrealized-casts -allow-unregistered-dialect | FileCheck %s
+// RUN: circt-opt %s --convert-verif-to-smt --reconcile-unrealized-casts -allow-unregistered-dialect --split-input-file | FileCheck %s
 
 // CHECK: func.func @lower_assert([[ARG0:%.+]]: i1)
 // CHECK:   [[CAST:%.+]] = builtin.unrealized_conversion_cast [[ARG0]] : i1 to !smt.bv<1>
@@ -186,7 +186,7 @@ func.func @test_lec(%arg0: !smt.bv<1>) -> (i1, i1, i1) {
 // CHECK1:        scf.yield [[LOOP]]#0, [[F]], [[CIRCUIT]]#1, [[CIRCUIT]]#2, [[CIRCUIT]]#3, [[LOOP]]#1, [[ORI]]
 
 func.func @test_bmc() -> (i1) {
-  %bmc = verif.bmc bound 10 num_regs 3 initial_values [unit, 42, unit]
+  %bmc = verif.bmc bound 10 num_regs 3 initial_values [unit, 42 : i32, unit]
   init {
     %c0_i1 = hw.constant 0 : i1
     %clk = seq.to_clock %c0_i1
@@ -208,6 +208,31 @@ func.func @test_bmc() -> (i1) {
     // %state0 is the result of a seq.compreg taking %0 as input
     %2 = comb.xor %state0, %c-1_i32 : i32
     verif.yield %2, %0, %state1, %state2 : i32, i32, i32, !hw.array<2xi32>
+  }
+  func.return %bmc : i1
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @large_initial_value
+// CHECK:         %[[CST:.+]] = smt.bv.constant #smt.bv<-1> : !smt.bv<65>
+// CHECK:         iter_args({{.+}}, %arg2 = %[[CST]],{{.+}})
+func.func @large_initial_value() -> (i1) {
+  %bmc = verif.bmc bound 1 num_regs 1 initial_values [-1 : i65]
+  init {
+    %c0_i1 = hw.constant 0 : i1
+    %clk = seq.to_clock %c0_i1
+    verif.yield %clk : !seq.clock
+  }
+  loop {
+    ^bb0(%clk: !seq.clock):
+    verif.yield %clk: !seq.clock
+  }
+  circuit {
+  ^bb0(%clk: !seq.clock, %arg0: i65):
+    %true = hw.constant true
+    verif.assert %true : i1
+    verif.yield %arg0 : i65
   }
   func.return %bmc : i1
 }


### PR DESCRIPTION
Fixes a problem during VerifToSMT lowering when creating the `smt::BVConstantOp`s for initial integer values of registers in the BMC operation. The current implementation calls `getSExtValue()` on the `APInt` provided by the initial value attribute. This causes a crash in either of the following situations:
- The initial value type is lager than 64 bits
- The initial value type is smaller than 64 bits and the MSB of the value is set. By sign-extending to 64 bits, the resulting integer value exceeds the width of the created BitVector.
 
This is fixed by passing the `APInt` directly to the builder of `smt::BVConstantOp` and adding a check beforehand ensuring that the types of the initial attribute and the initialized register match.