### PR TITLE
[Comb] Fix excessive const shifts causing crashes and invalid IR

### DIFF
--- a/lib/Dialect/Comb/CombFolds.cpp
+++ b/lib/Dialect/Comb/CombFolds.cpp
@@ -307,14 +307,13 @@ static Attribute constFoldBinaryOp(ArrayRef<Attribute> operands,
 
 OpFoldResult ShlOp::fold(FoldAdaptor adaptor) {
   if (auto rhs = dyn_cast_or_null<IntegerAttr>(adaptor.getRhs())) {
-    unsigned shift = rhs.getValue().getZExtValue();
-    unsigned width = getType().getIntOrFloatBitWidth();
-    if (shift == 0)
+    if (rhs.getValue().isZero())
       return getOperand(0);
-    if (width <= shift)
+
+    unsigned width = getType().getIntOrFloatBitWidth();
+    if (rhs.getValue().uge(width))
       return getIntAttr(APInt::getZero(width), getContext());
   }
-
   return constFoldBinaryOp(adaptor.getOperands(), hw::PEO::Shl);
 }
 
@@ -325,6 +324,8 @@ LogicalResult ShlOp::canonicalize(ShlOp op, PatternRewriter &rewriter) {
     return failure();
 
   unsigned width = cast<IntegerType>(op.getLhs().getType()).getWidth();
+  if (value.ugt(width))
+    value = width;
   unsigned shift = value.getZExtValue();
 
   // This case is handled by fold.
@@ -344,12 +345,11 @@ LogicalResult ShlOp::canonicalize(ShlOp op, PatternRewriter &rewriter) {
 
 OpFoldResult ShrUOp::fold(FoldAdaptor adaptor) {
   if (auto rhs = dyn_cast_or_null<IntegerAttr>(adaptor.getRhs())) {
-    unsigned shift = rhs.getValue().getZExtValue();
-    if (shift == 0)
+    if (rhs.getValue().isZero())
       return getOperand(0);
 
     unsigned width = getType().getIntOrFloatBitWidth();
-    if (width <= shift)
+    if (rhs.getValue().uge(width))
       return getIntAttr(APInt::getZero(width), getContext());
   }
   return constFoldBinaryOp(adaptor.getOperands(), hw::PEO::ShrU);
@@ -362,6 +362,8 @@ LogicalResult ShrUOp::canonicalize(ShrUOp op, PatternRewriter &rewriter) {
     return failure();
 
   unsigned width = cast<IntegerType>(op.getLhs().getType()).getWidth();
+  if (value.ugt(width))
+    value = width;
   unsigned shift = value.getZExtValue();
 
   // This case is handled by fold.
@@ -380,10 +382,9 @@ LogicalResult ShrUOp::canonicalize(ShrUOp op, PatternRewriter &rewriter) {
 }
 
 OpFoldResult ShrSOp::fold(FoldAdaptor adaptor) {
-  if (auto rhs = dyn_cast_or_null<IntegerAttr>(adaptor.getRhs())) {
-    if (rhs.getValue().getZExtValue() == 0)
+  if (auto rhs = dyn_cast_or_null<IntegerAttr>(adaptor.getRhs()))
+    if (rhs.getValue().isZero())
       return getOperand(0);
-  }
   return constFoldBinaryOp(adaptor.getOperands(), hw::PEO::ShrS);
 }
 
@@ -394,13 +395,15 @@ LogicalResult ShrSOp::canonicalize(ShrSOp op, PatternRewriter &rewriter) {
     return failure();
 
   unsigned width = cast<IntegerType>(op.getLhs().getType()).getWidth();
+  if (value.ugt(width))
+    value = width;
   unsigned shift = value.getZExtValue();
 
   auto topbit =
       rewriter.createOrFold<ExtractOp>(op.getLoc(), op.getLhs(), width - 1, 1);
   auto sext = rewriter.createOrFold<ReplicateOp>(op.getLoc(), topbit, shift);
 
-  if (width <= shift) {
+  if (width == shift) {
     replaceOpAndCopyNamehint(rewriter, op, {sext});
     return success();
   }

--- a/test/Dialect/Comb/canonicalization.mlir
+++ b/test/Dialect/Comb/canonicalization.mlir
@@ -1714,3 +1714,90 @@ func.func @dontAssumeMuxCondIfOperandIsOtherwiseObservable(%arg0: i1, %arg1: i1)
   %2 = comb.mux %arg0, %0, %1 : i1
   return %2 : i1
 }
+
+// See https://github.com/llvm/circt/issues/8695
+// CHECK-LABEL: @ShlTotalShiftOut
+hw.module @ShlTotalShiftOut(in %a: i4, out y: i4) {
+  // CHECK: [[TMP1:%.+]] = hw.constant 0
+  // CHECK: hw.output [[TMP1]]
+  %0 = hw.constant 7 : i4
+  %1 = comb.shl %a, %0 : i4
+  hw.output %1 : i4
+}
+
+// See https://github.com/llvm/circt/issues/8695
+// CHECK-LABEL: @ShrUTotalShiftOut
+hw.module @ShrUTotalShiftOut(in %a: i4, out y: i4) {
+  // CHECK: [[TMP1:%.+]] = hw.constant 0
+  // CHECK: hw.output [[TMP1]]
+  %0 = hw.constant 7 : i4
+  %1 = comb.shru %a, %0 : i4
+  hw.output %1 : i4
+}
+
+// See https://github.com/llvm/circt/issues/8695
+// CHECK-LABEL: @ShrSTotalShiftOut
+hw.module @ShrSTotalShiftOut(in %a: i4, out y: i4) {
+  // CHECK: [[TMP1:%.+]] = comb.extract %a from 3
+  // CHECK: [[TMP2:%.+]] = comb.replicate [[TMP1]] : (i1) -> i4
+  %0 = hw.constant 7 : i4
+  %1 = comb.shrs %a, %0 : i4
+  hw.output %1 : i4
+}
+
+// See https://github.com/llvm/circt/issues/8695
+// CHECK-LABEL: @ShlExcessiveShiftConst
+hw.module @ShlExcessiveShiftConst(in %a: i1000, out y: i1000) {
+  // CHECK: [[TMP1:%.+]] = hw.constant 0
+  // CHECK: hw.output [[TMP1]]
+  %0 = hw.constant -1 : i1000
+  %1 = comb.shl %a, %0 : i1000
+  hw.output %1 : i1000
+}
+
+// See https://github.com/llvm/circt/issues/8695
+// CHECK-LABEL: @ShrUExcessiveShiftConst
+hw.module @ShrUExcessiveShiftConst(in %a: i1000, out y: i1000) {
+  // CHECK: [[TMP1:%.+]] = hw.constant 0
+  // CHECK: hw.output [[TMP1]]
+  %0 = hw.constant -1 : i1000
+  %1 = comb.shru %a, %0 : i1000
+  hw.output %1 : i1000
+}
+
+// See https://github.com/llvm/circt/issues/8695
+// CHECK-LABEL: @ShrSExcessiveShiftConst
+hw.module @ShrSExcessiveShiftConst(in %a: i1000, out y: i1000) {
+  // CHECK: [[TMP1:%.+]] = comb.extract %a from 999
+  // CHECK: [[TMP2:%.+]] = comb.replicate [[TMP1]] : (i1) -> i1000
+  %0 = hw.constant -1 : i1000
+  %1 = comb.shrs %a, %0 : i1000
+  hw.output %1 : i1000
+}
+
+// See https://github.com/llvm/circt/issues/8695
+// CHECK-LABEL: @ShlWideZeroShift
+hw.module @ShlWideZeroShift(in %a: i1000, out y: i1000) {
+  // CHECK: hw.output %a
+  %0 = hw.constant 0 : i1000
+  %1 = comb.shl %a, %0 : i1000
+  hw.output %1 : i1000
+}
+
+// See https://github.com/llvm/circt/issues/8695
+// CHECK-LABEL: @ShrUWideZeroShift
+hw.module @ShrUWideZeroShift(in %a: i1000, out y: i1000) {
+  // CHECK: hw.output %a
+  %0 = hw.constant 0 : i1000
+  %1 = comb.shru %a, %0 : i1000
+  hw.output %1 : i1000
+}
+
+// See https://github.com/llvm/circt/issues/8695
+// CHECK-LABEL: @ShrSWideZeroShift
+hw.module @ShrSWideZeroShift(in %a: i1000, out y: i1000) {
+  // CHECK: hw.output %a
+  %0 = hw.constant 0 : i1000
+  %1 = comb.shrs %a, %0 : i1000
+  hw.output %1 : i1000
+}


### PR DESCRIPTION
The folders and canonicalizers for `comb.shl`, `comb.shru`, and `comb.shrs` perform unchecked `getZExtValue()` calls which can crash if the shift amount does not fit into 64 bits. The shift amount is also not clamped to the width of the result, which causes the shift to be replaced with ops that have a different type.

Found with [VlogHammer], which turns out to be a very handy tool!

Fixes #8694.
Fixes #8695.

[VlogHammer]: https://github.com/YosysHQ/VlogHammer