### PR TITLE
[hw] Convert HW Passes to use ODS constructors

### DIFF
--- a/include/circt/Dialect/HW/HWPasses.h
+++ b/include/circt/Dialect/HW/HWPasses.h
@@ -15,25 +15,12 @@
 
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
-#include <memory>
-#include <optional>
 
 namespace circt {
 namespace hw {
 
 #define GEN_PASS_DECL
 #include "circt/Dialect/HW/Passes.h.inc"
-
-std::unique_ptr<mlir::Pass> createPrintInstanceGraphPass();
-std::unique_ptr<mlir::Pass> createHWSpecializePass();
-std::unique_ptr<mlir::Pass> createPrintHWModuleGraphPass();
-std::unique_ptr<mlir::Pass> createFlattenIOPass(bool recursiveFlag = true,
-                                                bool flattenExternFlag = false,
-                                                char joinChar = '.');
-std::unique_ptr<mlir::Pass> createVerifyInnerRefNamespacePass();
-std::unique_ptr<mlir::Pass> createFlattenModulesPass();
-std::unique_ptr<mlir::Pass> createFooWiresPass();
-std::unique_ptr<mlir::Pass> createHWAggregateToCombPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/circt/Dialect/HW/Passes.td
+++ b/include/circt/Dialect/HW/Passes.td
@@ -17,13 +17,10 @@ include "mlir/Pass/PassBase.td"
 
 def PrintInstanceGraph : Pass<"hw-print-instance-graph", "mlir::ModuleOp"> {
   let summary = "Print a DOT graph of the module hierarchy.";
-  let constructor =  "circt::hw::createPrintInstanceGraphPass()";
 }
 
 def PrintHWModuleGraph : Pass<"hw-print-module-graph", "mlir::ModuleOp"> {
   let summary = "Print a DOT graph of the HWModule's within a top-level module.";
-  let constructor =  "circt::hw::createPrintHWModuleGraphPass()";
-  
   let options = [
     Option<"verboseEdges", "verbose-edges", "bool", "false",
       "Print information on SSA edges (types, operand #, ...)">,
@@ -32,8 +29,6 @@ def PrintHWModuleGraph : Pass<"hw-print-module-graph", "mlir::ModuleOp"> {
 
 def FlattenIO : Pass<"hw-flatten-io", "mlir::ModuleOp"> {
   let summary = "Flattens hw::Structure typed in- and output ports.";
-  let constructor =  "circt::hw::createFlattenIOPass()";
-  
   let options = [
     Option<"recursive", "recursive", "bool", "true",
       "Recursively flatten nested structs.">,
@@ -48,18 +43,16 @@ def FlattenModules : Pass<"hw-flatten-modules", "mlir::ModuleOp"> {
   let summary = "Eagerly inline private modules";
   let description = [{
     This pass eagerly inlines private HW modules into their instantiation sites.
-    This is necessary for verification purposes, as model checking backends do not 
-    require or support the use of module hierarchy. For simulation, module hierarchies 
+    This is necessary for verification purposes, as model checking backends do not
+    require or support the use of module hierarchy. For simulation, module hierarchies
     degenerate into a purely cosmetic construct, at which point it is beneficial
-    to fully flatten the module hierarchy to simplify further analysis and 
+    to fully flatten the module hierarchy to simplify further analysis and
     optimization of state transfer arcs.
   }];
-  let constructor = "circt::hw::createFlattenModulesPass()";
 }
 
 def HWSpecialize : Pass<"hw-specialize", "mlir::ModuleOp"> {
   let summary = "Specializes instances of parametric hw.modules";
-  let constructor = "circt::hw::createHWSpecializePass()";
   let description = [{
     Any `hw.instance` operation instantiating a parametric `hw.module` will
     trigger a specialization procedure which resolves all parametric types and
@@ -72,7 +65,6 @@ def HWSpecialize : Pass<"hw-specialize", "mlir::ModuleOp"> {
 
 def VerifyInnerRefNamespace : Pass<"hw-verify-irn"> {
   let summary = "Verify InnerRefNamespaceLike operations, if not self-verifying.";
-  let constructor =  "circt::hw::createVerifyInnerRefNamespacePass()";
 }
 
 /**
@@ -84,13 +76,10 @@ def FooWires : Pass<"hw-foo-wires", "hw::HWModuleOp"> {
     Very basic pass that numbers all of the wires in a given module.
     The wires' names are then all converte to foo_<that number>.
   }];
-  let constructor = "circt::hw::createFooWiresPass()";
 }
 
 def HWAggregateToComb : Pass<"hw-aggregate-to-comb", "hw::HWModuleOp"> {
   let summary = "Lower aggregate operations to comb operations";
-  let constructor = "circt::hw::createHWAggregateToCombPass()";
-
   let description = [{
     This pass lowers aggregate *operations* to comb operations within modules.
     Note that this pass does not lower ports. Ports lowering is handled

--- a/lib/Dialect/HW/Transforms/FlattenIO.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenIO.cpp
@@ -544,13 +544,9 @@ static bool flattenIO(ModuleOp module, bool recursive,
 namespace {
 
 class FlattenIOPass : public circt::hw::impl::FlattenIOBase<FlattenIOPass> {
-public:
-  FlattenIOPass(bool recursiveFlag, bool flattenExternFlag, char join) {
-    recursive = recursiveFlag;
-    flattenExtern = flattenExternFlag;
-    joinChar = join;
-  }
+  using Base::Base;
 
+public:
   void runOnOperation() override {
     ModuleOp module = getOperation();
     if (!flattenExtern) {
@@ -573,14 +569,3 @@ private:
   StringSet<> externModules;
 };
 } // namespace
-
-//===----------------------------------------------------------------------===//
-// Pass initialization
-//===----------------------------------------------------------------------===//
-
-std::unique_ptr<Pass> circt::hw::createFlattenIOPass(bool recursiveFlag,
-                                                     bool flattenExternFlag,
-                                                     char joinChar) {
-  return std::make_unique<FlattenIOPass>(recursiveFlag, flattenExternFlag,
-                                         joinChar);
-}

--- a/lib/Dialect/HW/Transforms/FlattenModules.cpp
+++ b/lib/Dialect/HW/Transforms/FlattenModules.cpp
@@ -151,7 +151,3 @@ void FlattenModulesPass::runOnOperation() {
     }
   }
 }
-
-std::unique_ptr<Pass> circt::hw::createFlattenModulesPass() {
-  return std::make_unique<FlattenModulesPass>();
-}

--- a/lib/Dialect/HW/Transforms/FooWires.cpp
+++ b/lib/Dialect/HW/Transforms/FooWires.cpp
@@ -38,7 +38,3 @@ void FooWiresPass::runOnOperation() {
         wire.setName("foo_" + std::to_string(nWires++)); // Rename said wire
       });
 }
-
-std::unique_ptr<mlir::Pass> circt::hw::createFooWiresPass() {
-  return std::make_unique<FooWiresPass>();
-}

--- a/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
+++ b/lib/Dialect/HW/Transforms/HWAggregateToComb.cpp
@@ -181,7 +181,3 @@ void HWAggregateToCombPass::runOnOperation() {
                                           std::move(patterns))))
     return signalPassFailure();
 }
-
-std::unique_ptr<Pass> circt::hw::createHWAggregateToCombPass() {
-  return std::make_unique<HWAggregateToCombPass>();
-}

--- a/lib/Dialect/HW/Transforms/HWPrintInstanceGraph.cpp
+++ b/lib/Dialect/HW/Transforms/HWPrintInstanceGraph.cpp
@@ -29,7 +29,7 @@ using namespace hw;
 namespace {
 struct PrintInstanceGraphPass
     : public circt::hw::impl::PrintInstanceGraphBase<PrintInstanceGraphPass> {
-  PrintInstanceGraphPass(raw_ostream &os) : os(os) {}
+  PrintInstanceGraphPass() : os(llvm::errs()) {}
   void runOnOperation() override {
     InstanceGraph &instanceGraph = getAnalysis<InstanceGraph>();
     llvm::WriteGraph(os, &instanceGraph, /*ShortNames=*/false);
@@ -38,7 +38,3 @@ struct PrintInstanceGraphPass
   raw_ostream &os;
 };
 } // end anonymous namespace
-
-std::unique_ptr<mlir::Pass> circt::hw::createPrintInstanceGraphPass() {
-  return std::make_unique<PrintInstanceGraphPass>(llvm::errs());
-}

--- a/lib/Dialect/HW/Transforms/HWSpecialize.cpp
+++ b/lib/Dialect/HW/Transforms/HWSpecialize.cpp
@@ -434,7 +434,3 @@ void HWSpecializePass::runOnOperation() {
 }
 
 } // namespace
-
-std::unique_ptr<Pass> circt::hw::createHWSpecializePass() {
-  return std::make_unique<HWSpecializePass>();
-}

--- a/lib/Dialect/HW/Transforms/PrintHWModuleGraph.cpp
+++ b/lib/Dialect/HW/Transforms/PrintHWModuleGraph.cpp
@@ -29,7 +29,8 @@ using namespace hw;
 namespace {
 struct PrintHWModuleGraphPass
     : public circt::hw::impl::PrintHWModuleGraphBase<PrintHWModuleGraphPass> {
-  PrintHWModuleGraphPass(raw_ostream &os) : os(os) {}
+  using Base::Base;
+
   void runOnOperation() override {
     getOperation().walk([&](hw::HWModuleOp module) {
       // We don't really have any other way of forwarding draw arguments to the
@@ -38,13 +39,8 @@ struct PrintHWModuleGraphPass
       module->setAttr("dot_verboseEdges",
                       BoolAttr::get(module.getContext(), verboseEdges));
 
-      llvm::WriteGraph(os, module, /*ShortNames=*/false);
+      llvm::WriteGraph(llvm::errs(), module, /*ShortNames=*/false);
     });
   }
-  raw_ostream &os;
 };
 } // end anonymous namespace
-
-std::unique_ptr<mlir::Pass> circt::hw::createPrintHWModuleGraphPass() {
-  return std::make_unique<PrintHWModuleGraphPass>(llvm::errs());
-}

--- a/lib/Dialect/HW/Transforms/VerifyInnerRefNamespace.cpp
+++ b/lib/Dialect/HW/Transforms/VerifyInnerRefNamespace.cpp
@@ -46,7 +46,3 @@ public:
 };
 
 } // namespace
-
-std::unique_ptr<mlir::Pass> circt::hw::createVerifyInnerRefNamespacePass() {
-  return std::make_unique<VerifyInnerRefNamespacePass>();
-}

--- a/lib/Dialect/Kanagawa/Transforms/KanagawaPassPipelines.cpp
+++ b/lib/Dialect/Kanagawa/Transforms/KanagawaPassPipelines.cpp
@@ -30,9 +30,9 @@ void circt::kanagawa::loadKanagawaLowLevelPassPipeline(mlir::PassManager &pm) {
   // Inner ref: We create an inner ref verification pass to initially validate
   // the IR, as well as after all structure-changing passes.
   // In the future, could consider hiding this behind a flag to reduce overhead.
-  pm.addPass(hw::createVerifyInnerRefNamespacePass());
+  pm.addPass(hw::createVerifyInnerRefNamespace());
   pm.nest<kanagawa::DesignOp>().addPass(createContainerizePass());
-  pm.addPass(hw::createVerifyInnerRefNamespacePass());
+  pm.addPass(hw::createVerifyInnerRefNamespace());
 
   // This pass ensures that duplicate get_port calls are removed before we
   // start tunneling - no reason to tunnel the same thing twice.
@@ -41,7 +41,7 @@ void circt::kanagawa::loadKanagawaLowLevelPassPipeline(mlir::PassManager &pm) {
 
   pm.nest<DesignOp>().addPass(
       createTunnelingPass(KanagawaTunnelingOptions{"", ""}));
-  pm.addPass(hw::createVerifyInnerRefNamespacePass());
+  pm.addPass(hw::createVerifyInnerRefNamespace());
   pm.addPass(createPortrefLoweringPass());
   pm.addPass(createSimpleCanonicalizerPass());
   // Run this again as some of the above passes may create redundant ops.
@@ -49,7 +49,7 @@ void circt::kanagawa::loadKanagawaLowLevelPassPipeline(mlir::PassManager &pm) {
       createEliminateRedundantOpsPass());
   pm.nest<DesignOp>().addPass(createCleanSelfdriversPass());
   pm.addPass(createContainersToHWPass());
-  pm.addPass(hw::createVerifyInnerRefNamespacePass());
+  pm.addPass(hw::createVerifyInnerRefNamespace());
 }
 
 void circt::kanagawa::loadKanagawaHighLevelPassPipeline(mlir::PassManager &pm) {

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -306,7 +306,7 @@ LogicalResult firtool::populateLowFIRRTLToHW(mlir::PassManager &pm,
   }
 
   // Check inner symbols and inner refs.
-  pm.addPass(hw::createVerifyInnerRefNamespacePass());
+  pm.addPass(hw::createVerifyInnerRefNamespace());
 
   // Check OM object fields.
   pm.addPass(om::createVerifyObjectFieldsPass());
@@ -364,7 +364,7 @@ LogicalResult firtool::populateHWToSV(mlir::PassManager &pm,
   }
 
   // Check inner symbols and inner refs.
-  pm.addPass(hw::createVerifyInnerRefNamespacePass());
+  pm.addPass(hw::createVerifyInnerRefNamespace());
 
   // Check OM object fields.
   pm.addPass(om::createVerifyObjectFieldsPass());
@@ -403,7 +403,7 @@ populatePrepareForExportVerilog(mlir::PassManager &pm,
     pm.addPass(sv::createHWExportModuleHierarchyPass());
 
   // Check inner symbols and inner refs.
-  pm.addPass(hw::createVerifyInnerRefNamespacePass());
+  pm.addPass(hw::createVerifyInnerRefNamespace());
 
   // Check OM object fields.
   pm.addPass(om::createVerifyObjectFieldsPass());
@@ -455,7 +455,7 @@ LogicalResult firtool::populateHWToBTOR2(mlir::PassManager &pm,
                                          llvm::raw_ostream &os) {
   pm.addNestedPass<hw::HWModuleOp>(circt::createLowerLTLToCorePass());
   pm.addNestedPass<hw::HWModuleOp>(circt::verif::createPrepareForFormalPass());
-  pm.addPass(circt::hw::createFlattenModulesPass());
+  pm.addPass(circt::hw::createFlattenModules());
   pm.addPass(circt::createConvertHWToBTOR2Pass(os));
   return success();
 }

--- a/lib/Synthesis/SynthesisPipeline.cpp
+++ b/lib/Synthesis/SynthesisPipeline.cpp
@@ -50,7 +50,7 @@ void circt::synthesis::buildAIGLoweringPipeline(OpPassManager &pm) {
   pm.addPass(createCSEPass());
   pm.addPass(createSimpleCanonicalizerPass());
 
-  pm.addPass(circt::hw::createHWAggregateToCombPass());
+  pm.addPass(circt::hw::createHWAggregateToComb());
   pm.addPass(circt::createConvertCombToAIG());
   pm.addPass(createCSEPass());
   pm.addPass(createSimpleCanonicalizerPass());

--- a/tools/arcilator/arcilator.cpp
+++ b/tools/arcilator/arcilator.cpp
@@ -281,7 +281,7 @@ static void populateHwModuleToArcPipeline(PassManager &pm) {
   }
   if (shouldDedup)
     pm.addPass(arc::createDedupPass());
-  pm.addPass(hw::createFlattenModulesPass());
+  pm.addPass(hw::createFlattenModules());
   pm.addPass(createCSEPass());
   pm.addPass(arc::createArcCanonicalizerPass());
 


### PR DESCRIPTION
Change all HW passes to use ODS consturctors as opposed to hand-rolling
them.  The hand-rolled constructors aren't necessary and add a bunch of
boilerplate.

Note: a number of these passes do not have users and hence may break out
of tree users.  The out of tree users are likely @teqdruid and @mortbopet.
