### PR TITLE
Bump LLVM to ace1c838ca91c83c7a271d9378b86ea56051e83f.

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1254,7 +1254,7 @@ LogicalResult BuildOpGroups::buildOp(PatternRewriter &rewriter,
   uint64_t signBit = 1ULL << (bitwidth - 1);
   uint64_t absMask = ~signBit & ((1ULL << bitwidth) - 1); // clear sign bit
 
-  Value maskOp = rewriter.create<arith::ConstantIntOp>(loc, absMask, intTy);
+  Value maskOp = rewriter.create<arith::ConstantIntOp>(loc, intTy, absMask);
 
   auto combGroup = createGroupForOp<calyx::CombGroupOp>(rewriter, absFOp);
   rewriter.setInsertionPointToStart(combGroup.getBodyBlock());

--- a/lib/Dialect/SystemC/SystemCOps.cpp
+++ b/lib/Dialect/SystemC/SystemCOps.cpp
@@ -857,7 +857,7 @@ void FuncOp::build(OpBuilder &odsBuilder, OperationState &odsState,
   assert(type.getNumInputs() == argAttrs.size());
   mlir::call_interface_impl::addArgAndResultAttrs(
       odsBuilder, odsState, argAttrs,
-      /*resultAttrs=*/std::nullopt, FuncOp::getArgAttrsAttrName(odsState.name),
+      /*resultAttrs=*/{}, FuncOp::getArgAttrsAttrName(odsState.name),
       FuncOp::getResAttrsAttrName(odsState.name));
 }
 

--- a/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
+++ b/unittests/Dialect/OM/Evaluator/EvaluatorTests.cpp
@@ -1470,7 +1470,7 @@ TEST(EvaluatorTests, ListAttrConcat) {
 
   auto listVal =
       llvm::cast<evaluator::ListValue>(fieldValue.get())->getElements();
-  ASSERT_EQ(4, listVal.size());
+  ASSERT_EQ(4UL, listVal.size());
   auto checkEq = [](evaluator::EvaluatorValue *val, const char *str) {
     ASSERT_EQ(str, llvm::cast<evaluator::AttributeValue>(val)
                        ->getAs<StringAttr>()


### PR DESCRIPTION
This is mostly a clean bump, but I did clean up a couple warnings that the fresh compile revealed.

The one minor breaking change was a change to argument order in ConstantIntOp::build, which was added in:

https://github.com/llvm/llvm-project/commit/a45fda6

This just swaps the order.