### PR TITLE
[AIG] Add slice indexing support to LongestPathCollection in AIG Pyth…

### DIFF
--- a/integration_test/Bindings/Python/dialects/aig.py
+++ b/integration_test/Bindings/Python/dialects/aig.py
@@ -75,10 +75,13 @@ with Context() as ctx, Location.unknown():
     # CHECK-NEXT: sum: 128
     print("sum: ", sum(p.delay for p in collection))
 
-    for p in list(collection)[:2]:
+    for p in collection[:2]:
       # CHECK-NEXT: delay 2 : out2[{{[0-9]+}}]
       # CHECK-NEXT: delay 2 : out2[{{[0-9]+}}]
       print("delay", p.delay, ":", p.fan_out)
+
+    # CHECK-NEXT: minus index slice: True
+    print("minus index slice:", len(collection[:-2]) == len(collection) - 2)
 
     # Test framegraph emission.
     # CHECK:      top:test_aig;a[7] 0

--- a/lib/Bindings/Python/dialects/aig.py
+++ b/lib/Bindings/Python/dialects/aig.py
@@ -290,14 +290,24 @@ class LongestPathCollection:
     """Get the number of paths in the collection."""
     return self.length
 
-  def __getitem__(self, index: int) -> DataflowPath:
+  def __getitem__(self, index):
     """
         Get a specific path from the collection by index.
-        Supports negative indexing. Results are cached to avoid expensive
-        JSON parsing on repeated access.
+        Supports both integer and slice indexing. Integer indices can be negative.
+        Results are cached to avoid expensive JSON parsing on repeated access.
+
         Args:
-            index: Index of the path to retrieve (0 = longest path)
+            index: Integer index or slice object to access paths
+
+        Returns:
+            DataflowPath or list of DataflowPaths for slice access
+
+        Raises:
+            IndexError: If index is out of range
         """
+    if isinstance(index, slice):
+      return [self[i] for i in range(*index.indices(len(self)))]
+
     # Handle negative indexing
     if index < 0:
       index += self.length


### PR DESCRIPTION
…on bindings

This commit implements slice indexing functionality for the LongestPathCollection class, allowing users to access multiple timing paths using Python's standard slice notation. The implementation handles all slice types including negative indices, step values, and empty slices through Python's built-in slice.indices() method.