### PR TITLE
[RTG] Redefine RandomNumberInRangeOp upper bound to be inclusive

### DIFF
--- a/frontends/PyRTG/src/pyrtg/immediates.py
+++ b/frontends/PyRTG/src/pyrtg/immediates.py
@@ -27,7 +27,19 @@ class Immediate(Value):
     """
 
     # Note that the upper limit is exclusive
-    return Immediate(width, Integer.random(0, 2**width))
+    return Immediate(width, Integer.random(0, 2**width - 1))
+
+  @staticmethod
+  def umax(width: int) -> Immediate:
+    """
+    An immediate of the provided width with the maximum unsigned value it can
+    hold.
+    """
+
+    return Immediate(width, 2**width - 1)
+
+  def __repr__(self) -> str:
+    return f"Immediate<{self._width}, {self._value}>"
 
   def _get_ssa_value(self) -> ir.Value:
     if isinstance(self._value, int):
@@ -54,6 +66,9 @@ class ImmediateType(Type):
 
   def __eq__(self, other) -> bool:
     return isinstance(other, ImmediateType) and self.width == other.width
+
+  def __repr__(self) -> str:
+    return f"ImmediateType<{self.width}>"
 
   def _codegen(self) -> ir.Type:
     return rtg.ImmediateType.get(self.width)

--- a/include/circt/Dialect/RTG/IR/RTGOps.td
+++ b/include/circt/Dialect/RTG/IR/RTGOps.td
@@ -629,16 +629,16 @@ def RandomNumberInRangeOp : RTGOp<"random_number_in_range", []> {
   let summary = "returns a number uniformly at random within the given range";
   let description = [{
     This operation computes a random number based on a uniform distribution
-    within the given range. The lower bound is inclusive while the upper bound
-    is exclusive. If the range is empty, compilation will fail.
-    This is (obviously) more performant than inserting all legal numbers into a
-    set and using 'set_select_random', but yields the same behavior.
+    within the given range. Both the lower and upper bounds are inclusive. If
+    the range is empty, compilation will fail. This is (obviously) more
+    performant than inserting all legal numbers into a set and using
+    'set_select_random', but yields the same behavior.
   }];
 
   let arguments = (ins Index:$lowerBound, Index:$upperBound);
   let results = (outs Index:$result);
 
-  let assemblyFormat = "` ` `[` $lowerBound `,` $upperBound `)` attr-dict";
+  let assemblyFormat = "` ` `[` $lowerBound `,` $upperBound `]` attr-dict";
 }
 
 //===- Misc Operations ----------------------------------------------------===//

--- a/lib/Dialect/RTG/Transforms/ElaborationPass.cpp
+++ b/lib/Dialect/RTG/Transforms/ElaborationPass.cpp
@@ -1549,7 +1549,7 @@ public:
 
   FailureOr<DeletionKind> visitOp(RandomNumberInRangeOp op) {
     size_t lower = get<size_t>(op.getLowerBound());
-    size_t upper = get<size_t>(op.getUpperBound()) - 1;
+    size_t upper = get<size_t>(op.getUpperBound());
     if (lower > upper)
       return op->emitError("cannot select a number from an empty range");
 

--- a/test/Dialect/RTG/IR/basic.mlir
+++ b/test/Dialect/RTG/IR/basic.mlir
@@ -154,8 +154,8 @@ rtg.test @test1(num_cpus = %a: i32, num_modes = %b: i32) { }
 
 // CHECK-LABEL: rtg.sequence @integerHandlingOps
 rtg.sequence @integerHandlingOps(%arg0: index, %arg1: index) {
-  // CHECK: rtg.random_number_in_range [%arg0, %arg1)
-  rtg.random_number_in_range [%arg0, %arg1)
+  // CHECK: rtg.random_number_in_range [%arg0, %arg1]
+  rtg.random_number_in_range [%arg0, %arg1]
 }
 
 // CHECK-LABEL: rtg.test @interleaveSequences

--- a/test/Dialect/RTG/Transform/elaboration.mlir
+++ b/test/Dialect/RTG/Transform/elaboration.mlir
@@ -478,13 +478,13 @@ rtg.test @labels(singleton = %none: index) {
 // CHECK-LABEL: rtg.test @randomIntegers
 rtg.test @randomIntegers(singleton = %none: index) {
   %lower = index.constant 5
-  %upper = index.constant 10
-  %0 = rtg.random_number_in_range [%lower, %upper) {rtg.elaboration_custom_seed=0}
+  %upper = index.constant 9
+  %0 = rtg.random_number_in_range [%lower, %upper] {rtg.elaboration_custom_seed=0}
   // CHECK-NEXT: [[V0:%.+]] = index.constant 5
   // CHECK-NEXT: func.call @dummy2([[V0]])
   func.call @dummy2(%0) : (index) -> ()
 
-  %1 = rtg.random_number_in_range [%lower, %upper) {rtg.elaboration_custom_seed=3}
+  %1 = rtg.random_number_in_range [%lower, %upper] {rtg.elaboration_custom_seed=3}
   // CHECK-NEXT: [[V1:%.+]] = index.constant 8
   // CHECK-NEXT: func.call @dummy2([[V1]])
   func.call @dummy2(%1) : (index) -> ()
@@ -799,9 +799,10 @@ rtg.target @singletonTarget : !rtg.dict<singleton: index> {
 func.func @dummy2(%arg0: index) -> () {return}
 
 rtg.test @randomIntegers(singleton = %none: index) {
+  %c4 = index.constant 4
   %c5 = index.constant 5
   // expected-error @below {{cannot select a number from an empty range}}
-  %0 = rtg.random_number_in_range [%c5, %c5)
+  %0 = rtg.random_number_in_range [%c5, %c4]
   func.call @dummy2(%0) : (index) -> ()
 }
 


### PR DESCRIPTION
When we want to be able to get all possible numbers that fit in a 64 bit register, we would need a 65 bit number as the upper bound. However, an iindex typed attribute uses an APInt with 64 bits and would thus make this complicated.