### PR TITLE
[FIRRTL] Remove circuit from macro used by inline layers

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/LowerLayers.cpp
@@ -160,8 +160,7 @@ static SmallString<32> guardMacroNameForLayer(StringRef moduleName,
 static SmallString<32>
 macroNameForLayer(StringRef circuitName,
                   ArrayRef<FlatSymbolRefAttr> layerName) {
-  SmallString<32> result("layer_");
-  result.append(circuitName);
+  SmallString<32> result("layer");
   for (auto part : layerName)
     appendName(part, result, /*toLower=*/false,
                /*delimiter=*/Delimiter::InlineMacro);

--- a/test/Dialect/FIRRTL/lower-layers.mlir
+++ b/test/Dialect/FIRRTL/lower-layers.mlir
@@ -329,9 +329,9 @@ firrtl.circuit "Test" {
   // Inline Layers
   //===--------------------------------------------------------------------===//
 
-  // CHECK:      sv.macro.decl @layer_Test$Inline
-  // CHECK-NEXT: sv.macro.decl @layer_Test$Inline$Inline
-  // CHECK-NEXT: sv.macro.decl @layer_Test$Bound$Inline
+  // CHECK:      sv.macro.decl @layer$Inline
+  // CHECK-NEXT: sv.macro.decl @layer$Inline$Inline
+  // CHECK-NEXT: sv.macro.decl @layer$Bound$Inline
   firrtl.layer @Inline inline {
     firrtl.layer @Inline inline {}
   }
@@ -342,15 +342,15 @@ firrtl.circuit "Test" {
 
   // CHECK:      firrtl.module private @ModuleWithInlineLayerBlocks_Bound() {
   // CHECK-NEXT:   %w3 = firrtl.wire
-  // CHECK-NEXT:   sv.ifdef @layer_Test$Bound$Inline {
+  // CHECK-NEXT:   sv.ifdef @layer$Bound$Inline {
   // CHECK-NEXT:     %w4 = firrtl.wire
   // CHECK-NEXT:   }
   // CHECK-NEXT: }
 
   // CHECK-NEXT: firrtl.module @ModuleWithInlineLayerBlocks() {
-  // CHECK-NEXT:   sv.ifdef @layer_Test$Inline {
+  // CHECK-NEXT:   sv.ifdef @layer$Inline {
   // CHECK-NEXT:     %w1 = firrtl.wire
-  // CHECK-NEXT:     sv.ifdef @layer_Test$Inline$Inline {
+  // CHECK-NEXT:     sv.ifdef @layer$Inline$Inline {
   // CHECK-NEXT:       %w2 = firrtl.wire
   // CHECK-NEXT:     }
   // CHECK-NEXT:   }

--- a/test/firtool/reg-under-inline-layer.fir
+++ b/test/firtool/reg-under-inline-layer.fir
@@ -13,7 +13,7 @@ circuit RegUnderInlineLayer:
     input data: UInt<1>
     output probe: Probe<UInt<1>, A>
 
-    ; CHECK: `ifdef layer_RegUnderInlineLayer$A
+    ; CHECK: `ifdef layer$A
     ; CHECK:   reg  myreg;
     ; CHECK:   wire myreg_probe = myreg;
     ; CHECK:   always @(posedge clock) begin
@@ -22,14 +22,14 @@ circuit RegUnderInlineLayer:
     ; CHECK:     else
     ; CHECK:       myreg <= data;
     ; CHECK:   end // always @(posedge)
-    ; CHECK: `endif // layer_RegUnderInlineLayer$A
+    ; CHECK: `endif // layer$A
 
     ; CHECK: initial begin
     ; CHECK:   automatic logic [31:0] _RANDOM[0:0];
     ; CHECK:   _RANDOM[/*Zero width*/ 1'b0] = `RANDOM;
-    ; CHECK:   `ifdef layer_RegUnderInlineLayer$A
+    ; CHECK:   `ifdef layer$A
     ; CHECK:     RegUnderInlineLayer.myreg = _RANDOM[/*Zero width*/ 1'b0][0];
-    ; CHECK:   `endif // layer_RegUnderInlineLayer$A
+    ; CHECK:   `endif // layer$A
     ; CHECK:    end // initial
     layerblock A:
       regreset myreg : UInt<1>, clock, reset, UInt<1>(0)
@@ -52,8 +52,8 @@ circuit RegUnderInlineLayer:
     input data: UInt<1>
     output probe: Probe<UInt<1>, A.B>
 
-    ; CHECK: `ifdef layer_RegUnderInlineLayer$A
-    ; CHECK:   `ifdef layer_RegUnderInlineLayer$A$B
+    ; CHECK: `ifdef layer$A
+    ; CHECK:   `ifdef layer$A$B
     ; CHECK:     reg  myreg;
     ; CHECK:     wire myreg_probe = myreg;
     ; CHECK:     always @(posedge clock) begin
@@ -62,17 +62,17 @@ circuit RegUnderInlineLayer:
     ; CHECK:       else
     ; CHECK:         myreg <= data;
     ; CHECK:     end // always @(posedge)
-    ; CHECK:   `endif // layer_RegUnderInlineLayer$A$B
-    ; CHECK: `endif // layer_RegUnderInlineLayer$A
+    ; CHECK:   `endif // layer$A$B
+    ; CHECK: `endif // layer$A
 
     ; CHECK: initial begin
     ; CHECK:   automatic logic [31:0] _RANDOM[0:0];
     ; CHECK:   _RANDOM[/*Zero width*/ 1'b0] = `RANDOM;
-    ; CHECK:   `ifdef layer_RegUnderInlineLayer$A
-    ; CHECK:     `ifdef layer_RegUnderInlineLayer$A$B
+    ; CHECK:   `ifdef layer$A
+    ; CHECK:     `ifdef layer$A$B
     ; CHECK:       RegUnderInlineLayer.myreg = _RANDOM[/*Zero width*/ 1'b0][0];
-    ; CHECK:     `endif // layer_RegUnderInlineLayer$A$B
-    ; CHECK:   `endif // layer_RegUnderInlineLayer$A
+    ; CHECK:     `endif // layer$A$B
+    ; CHECK:   `endif // layer$A
     ; CHECK:    end // initial
     layerblock A:
       layerblock B:
@@ -94,7 +94,7 @@ circuit RegUnderInlineLayer:
   ; the register and its initialization.
 
   ; CHECK: module RegUnderInlineLayer_A();
-  ; CHECK:   `ifdef layer_RegUnderInlineLayer$A$B
+  ; CHECK:   `ifdef layer$A$B
   ; CHECK:     reg  myreg;
   ; CHECK:     wire myreg_probe = myreg;
   ; CHECK:     always @(posedge RegUnderInlineLayer.clock) begin
@@ -103,14 +103,14 @@ circuit RegUnderInlineLayer:
   ; CHECK:       else
   ; CHECK:         myreg <= RegUnderInlineLayer.data;
   ; CHECK:     end // always @(posedge)
-  ; CHECK:   `endif // layer_RegUnderInlineLayer$A$B
+  ; CHECK:   `endif // layer$A$B
   ; CHECK:     initial begin
   ; CHECK:       automatic logic [31:0] _RANDOM[0:0];
   ; CHECK:       `ifdef RANDOMIZE_REG_INIT
   ; CHECK:         _RANDOM[/*Zero width*/ 1'b0] = `RANDOM;
-  ; CHECK:         `ifdef layer_RegUnderInlineLayer$A$B
+  ; CHECK:         `ifdef layer$A$B
   ; CHECK:           RegUnderInlineLayer_A.myreg = _RANDOM[/*Zero width*/ 1'b0][0];
-  ; CHECK:         `endif // layer_RegUnderInlineLayer$A$B
+  ; CHECK:         `endif // layer$A$B
   ; CHECK:       `endif // RANDOMIZE_REG_INIT
   ; CHECK:     end // initial
   ; CHECK: endmodule


### PR DESCRIPTION
We want to use the same macro for an inline layer across all compilation units (circuits) in a design.  Remove the circuit name from the macro name.

This requires a change to the FIRRTL ABI, here:
https://github.com/chipsalliance/firrtl-spec/pull/313
