### PR TITLE
[AIG] Use llvm::stable_sort to sort paths

### DIFF
--- a/integration_test/Bindings/Python/dialects/aig.py
+++ b/integration_test/Bindings/Python/dialects/aig.py
@@ -81,6 +81,6 @@ with Context() as ctx, Location.unknown():
       print("delay", p.delay, ":", p.fan_out)
 
     # Test framegraph emission.
-    # CHECK:      top:test_aig;a[7] 0
-    # CHECK-NEXT: top:test_aig;out2[7] 2
+    # CHECK:      top:test_aig;a[0] 0
+    # CHECK-NEXT: top:test_aig;out2[0] 2
     print(collection.longest_path.to_flamegraph())

--- a/lib/Bindings/Python/dialects/aig.py
+++ b/lib/Bindings/Python/dialects/aig.py
@@ -248,8 +248,7 @@ class DataflowPath:
 
     # Add the signal name with bit position if applicable
     signal_part = obj.name
-    if obj.bit_pos > 0:
-      signal_part += f"[{obj.bit_pos}]"
+    signal_part += f"[{obj.bit_pos}]"
     parts.append(signal_part)
 
     return ";".join(parts)

--- a/lib/Dialect/AIG/Analysis/LongestPathAnalysis.cpp
+++ b/lib/Dialect/AIG/Analysis/LongestPathAnalysis.cpp
@@ -1500,7 +1500,7 @@ ArrayRef<hw::HWModuleOp> LongestPathAnalysis::getTopModules() const {
 // ===----------------------------------------------------------------------===//
 
 void LongestPathCollection::sortInDescendingOrder() {
-  llvm::sort(paths, [](const DataflowPath &a, const DataflowPath &b) {
+  llvm::stable_sort(paths, [](const DataflowPath &a, const DataflowPath &b) {
     return a.getDelay() > b.getDelay();
   });
 }


### PR DESCRIPTION
since llvm::sort is non-determnisic it's not suitable for using it for user-facing API. Also fix inconsistent bit position emission. 