### PR TITLE
[PyRTG] Support Python config parameters

### DIFF
--- a/frontends/PyRTG/src/pyrtg/__init__.py
+++ b/frontends/PyRTG/src/pyrtg/__init__.py
@@ -14,7 +14,7 @@ from .sets import Set, SetType
 from .integers import Integer, IntegerType, Bool, BoolType
 from .bags import Bag, BagType
 from .sequences import sequence, Sequence, SequenceType, RandomizedSequence, RandomizedSequenceType
-from .configs import config, Param, Config
+from .configs import config, Param, PythonParam, Config
 from .immediates import Immediate, ImmediateType
 from .resources import IntegerRegister, IntegerRegisterType
 from .arrays import Array, ArrayType

--- a/frontends/PyRTG/src/pyrtg/tests.py
+++ b/frontends/PyRTG/src/pyrtg/tests.py
@@ -6,6 +6,8 @@ from .base import ir
 from .core import CodeGenRoot, CodeGenObject
 from .rtg import rtg
 from .support import _FromCirctValue
+from .configs import PythonParam
+from .labels import Label
 
 from types import SimpleNamespace
 
@@ -42,7 +44,9 @@ class Test(CodeGenRoot):
         [param.get_type()._codegen() for param in params_sorted])
     new_config = []
     for param, arg in zip(params_sorted, block.arguments):
-      new_config.append((param.get_name(), _FromCirctValue(arg)))
+      new_config.append(
+          (param.get_original_name(), param.get_value() if isinstance(
+              param, PythonParam) else _FromCirctValue(arg)))
 
     with ir.InsertionPoint(block):
       self.test_func(SimpleNamespace(new_config))

--- a/frontends/PyRTG/test/basic.py
+++ b/frontends/PyRTG/test/basic.py
@@ -2,7 +2,7 @@
 # RUN: %rtgtool% %s --seed=0 --output-format=elaborated | FileCheck %s --check-prefix=ELABORATED
 # RUN: %rtgtool% %s --seed=0 -o %t --output-format=asm && FileCheck %s --input-file=%t --check-prefix=ASM
 
-from pyrtg import test, sequence, config, Config, Param, rtg, Label, LabelType, Set, SetType, Integer, IntegerType, Bag, rtgtest, Immediate, IntegerRegister, Array, ArrayType, Bool, BoolType, Tuple, TupleType, embed_comment, MemoryBlock, Memory
+from pyrtg import test, sequence, config, Config, Param, PythonParam, rtg, Label, LabelType, Set, SetType, Integer, IntegerType, Bag, rtgtest, Immediate, IntegerRegister, Array, ArrayType, Bool, BoolType, Tuple, TupleType, embed_comment, MemoryBlock, Memory
 
 # MLIR-LABEL: rtg.target @Singleton : !rtg.dict<>
 # MLIR-NEXT: }
@@ -446,6 +446,26 @@ def test91_sets(config):
   seq2(Set.cartesian_product(config.a, config.b))
   int_consumer(config.c.to_set().get_random())
   int_consumer(config.a.to_bag().get_random())
+
+
+# MLIR-LABEL: rtg.target @PythonParams : !rtg.dict<xlen_64: !rtg.tuple>
+# MLIR-NEXT: [[TUP:%.+]] = rtg.tuple_create
+# MLIR-NEXT: rtg.yield [[TUP]] : !rtg.tuple
+
+
+@config
+class PythonParams(Config):
+  xlen = PythonParam(64)
+
+
+# MLIR-LABEL: rtg.test @test92_python_params
+# MLIR-NEXT: [[LBL:%.+]] = rtg.label_decl "python_64"
+# MLIR-NEXT: rtg.label local [[LBL]]
+
+
+@test(PythonParams)
+def test92_python_params(config):
+  Label.declare("python_" + str(config.xlen)).place()
 
 
 # MLIR-LABEL: rtg.sequence @seq0


### PR DESCRIPTION
Allows parameterization of information that is static in the IR such as the xlen.
The plan is to add a mechanism to codegen each test for each config providing such an xlen parameter, e.g., the following should produce two tests, one for each config (possibly by introducing a common parent class and using that as the test decorator argument). But that will be added in a future PR.

```py
@config
class RV64(Config):
  xlen = PythonParam(64)

@config
class RV32(Config):
  xlen = PythonParam(32)

@test(RV64)
def test(config):
  # do something with 'config.xlen'
```