### PR TITLE
[circt-verilog] Enable SROA again

### DIFF
--- a/tools/circt-verilog/circt-verilog.cpp
+++ b/tools/circt-verilog/circt-verilog.cpp
@@ -329,7 +329,7 @@ static void populateLLHDLowering(PassManager &pm) {
   // Simplify processes, replace signals with process results, and detect
   // registers.
   auto &modulePM = pm.nest<hw::HWModuleOp>();
-  // modulePM.addPass(mlir::createSROA());
+  modulePM.addPass(mlir::createSROA());
   modulePM.addPass(llhd::createMem2RegPass());
   modulePM.addPass(llhd::createHoistSignalsPass());
   modulePM.addPass(llhd::createDeseqPass());


### PR DESCRIPTION
Enable SROA again since the stackoverflow bug upstream is resolved now.