### PR TITLE
[FIRRTL] FIRParser: support caching constants in match statements

### DIFF
--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -495,6 +495,7 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule"
   ; CHECK-LABEL: firrtl.module private @constant_implicit_cse(
   module constant_implicit_cse :
     input cond : UInt<1>
+    input enum : {|A|}
 
     ; CHECK: [[CST15:%.+]] = firrtl.constant 15 : !firrtl.const.uint<4>
     ; CHECK: %a = firrtl.node interesting_name [[CST15]]
@@ -520,6 +521,15 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule"
     ; CHECK:  %f = firrtl.node interesting_name [[CST15]]
     node f = UInt<4>(15)
     node g = UInt<4>(7)
+
+    ; Should be able to use the constant cache under a match without crashing.
+    ; CHECK: [[CST8:%.+]] = firrtl.constant 8 : !firrtl.const.uint<4>
+    match enum:
+      A:
+        ; CHECK:  %h = firrtl.node interesting_name [[CST7]]
+        node h = UInt<4>(7)
+         ; CHECK: %i = firrtl.node interesting_name [[CST8]]
+        node i = UInt<4>(8)
 
   ; CHECK-LABEL: firrtl.module private @subfield_implicit_cse
   module subfield_implicit_cse :


### PR DESCRIPTION
This fixes a long standing bug when parsing match statements which contain numeric constants.

The FIRParser has a contant cache so that we can reuse any constant operation created as we parse, by inserting them into the top-level body of the module.  To find the top level block, we were searching upwards from the current insertion point.

In general, when creating any operation, we are required to know how many regions the operation has; it is impossible to add more regions after creating the operation. Due to this, when parsing the arms of a match statement, the expressions are inserted into a region which is not attached to any operation.  This means we can not search upwards from the insertion point to find the top level block. When operations do not have this problem as they always have space 2 regions.

This change passes in the top level block when creating the FIRModuleContext.  If it turns out that the region we are inserting into is not underneath the module, then we can insert the constant at the end of the module's block.

This change also makes the cache itself a private member, and removes a bit of code which was unnecessarily directly accessing the cache.