### PR TITLE
[FIRRTL] TagExtract: make type inference parser friendly

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLExpressions.td
@@ -540,6 +540,21 @@ def TagExtractOp : FIRRTLExprOp<"tagextract", [InferTypeOpInterface]> {
   let arguments = (ins FEnumType:$input);
   let results = (outs UIntType:$result);
   let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
+
+  let inferTypeDecl = [{
+    static FIRRTLType inferReturnType(FIRRTLType input,
+                                      std::optional<Location> loc);
+
+    static FIRRTLType inferReturnType(ValueRange operands,
+                                      DictionaryAttr attrs,
+                                      OpaqueProperties properties,
+                                      mlir::RegionRange regions,
+                                      std::optional<Location> loc) {
+      Adaptor adaptor(operands, attrs, properties, regions);
+      auto input = firrtl::type_cast<FIRRTLType>(adaptor.getInput().getType());
+      return inferReturnType(input, loc);
+    }
+  }];
 }
 
 def MultibitMuxOp : FIRRTLExprOp<"multibit_mux"> {

--- a/lib/Dialect/FIRRTL/FIRRTLOps.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLOps.cpp
@@ -4860,13 +4860,9 @@ FIRRTLType SubaccessOp::inferReturnType(Type inType, Type indexType,
                                inType);
 }
 
-FIRRTLType TagExtractOp::inferReturnType(ValueRange operands,
-                                         DictionaryAttr attrs,
-                                         OpaqueProperties properties,
-                                         mlir::RegionRange regions,
+FIRRTLType TagExtractOp::inferReturnType(FIRRTLType input,
                                          std::optional<Location> loc) {
-  Adaptor adaptor(operands, attrs, properties, regions);
-  auto inType = type_cast<FEnumType>(adaptor.getInput().getType());
+  auto inType = type_cast<FEnumType>(input);
   auto i = llvm::Log2_32_Ceil(inType.getNumElements());
   return UIntType::get(inType.getContext(), i);
 }


### PR DESCRIPTION
This also changes TagExtract to use the simpler type inference signatures used by other primitive operations, which will be used when parsing this operation from fir files.