### PR TITLE
[FIRRTL] check bundles have unique field names

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
+++ b/include/circt/Dialect/FIRRTL/FIRRTLTypesImpl.td
@@ -279,6 +279,7 @@ class BaseBundleTypeImpl<string name, string ElementType, list<Trait> traits = [
 
 def BundleImpl : BaseBundleTypeImpl<"Bundle","::circt::firrtl::FIRRTLBaseType"> {
   let typeName = "firrtl.bundle";
+  let genVerifyDecl = 1;
   let firrtlExtraClassDeclaration = [{
     /// Return this type with any flip types recursively removed from itself.
     FIRRTLBaseType getPassiveType();

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -1816,6 +1816,22 @@ firrtl.circuit "ConstOpenVector" {
 }
 
 // -----
+// No duplicate fields within.
+
+firrtl.circuit "DupFieldsBundle" {
+  // expected-error @below {{duplicate field name "a" in bundle}}
+  firrtl.extmodule @DupFieldsBundle(out out : !firrtl.bundle<a: uint<1>, a: uint<1>>)
+}
+
+// -----
+// No duplicate fields within.
+
+firrtl.circuit "DupFieldsOpenBundle" {
+  // expected-error @below {{duplicate field name "a" in openbundle}}
+  firrtl.extmodule @DupFieldsOpenBundle(out out : !firrtl.openbundle<a: uint<1>, a: uint<1>>)
+}
+
+// -----
 // No const with probes within.
 
 firrtl.circuit "ConstOpenBundle" {

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -335,6 +335,13 @@ circuit circuit:
 FIRRTL version 4.0.0
 circuit circuit:
   public module circuit :
+    input in: {a: UInt, a: UInt} ; expected-error {{duplicate field name in bundle: a}}
+
+;// -----
+
+FIRRTL version 4.0.0
+circuit circuit:
+  public module circuit :
     input in: UInt<80>
     inst xyz of circuit
     node n = xyz.foo   ; expected-error {{use of invalid field name 'foo' on bundle value}}


### PR DESCRIPTION
This adds MLIR type verifiers for BundleType and OpenBundleType, and adds the same check to the FIRParser, which will assert if it creates a bad type.