### PR TITLE
[ESI] Fix wrap op canonicalizers

### DIFF
--- a/lib/Dialect/ESI/ESIDialect.cpp
+++ b/lib/Dialect/ESI/ESIDialect.cpp
@@ -41,14 +41,11 @@ void ESIDialect::initialize() {
 
 Operation *ESIDialect::materializeConstant(OpBuilder &builder, Attribute value,
                                            Type type, Location loc) {
-  // Integer constants.
-  if (auto intType = dyn_cast<IntegerType>(type))
-    if (auto attrValue = dyn_cast<IntegerAttr>(value))
-      return builder.create<hw::ConstantOp>(loc, attrValue.getType(),
-                                            attrValue);
   if (isa<mlir::UnitAttr>(value))
     return builder.create<hw::ConstantOp>(loc, builder.getI1Type(), 1);
-  return nullptr;
+  return builder.getContext()
+      ->getOrLoadDialect<hw::HWDialect>()
+      ->materializeConstant(builder, value, type, loc);
 }
 
 // Provide implementations for the enums we use.

--- a/test/Dialect/ESI/canonicalizers.mlir
+++ b/test/Dialect/ESI/canonicalizers.mlir
@@ -1,0 +1,15 @@
+// RUN: circt-opt %s --canonicalize | FileCheck %s
+
+// CHECK-LABEL:  hw.module @TestDanglingFIFO() {
+// CHECK-NEXT:     hw.output
+hw.module @TestDanglingFIFO() {
+  %c0 = hw.constant 0 : i1
+  %chanOutput, %ready = esi.wrap.fifo %c0, %c0 : !esi.channel<i1, FIFO>
+}
+
+// CHECK-LABEL:  hw.module @TestDanglingValidReady() {
+// CHECK-NEXT:     hw.output
+hw.module @TestDanglingValidReady() {
+  %c0 = hw.constant 0 : i1
+  %chanOutput, %ready = esi.wrap.vr %c0, %c0 : i1
+}


### PR DESCRIPTION
Fixes the canonicalizers for wrap operations in the ESI dialect by replacing problematic attribute-based folding with proper operation creation and improving pattern matching logic.

- Updates `WrapValidReadyOp` and `WrapFIFOOp` fold methods to create `NullSourceOp` operations instead of using attributes
- Improves the `WrapFIFOOp` canonicalize method with better error handling and more robust user checking
- Delegates constant materialization to the HW dialect for better consistency