### PR TITLE
[ExportVerilog] localparam should always print bitwidths

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -5907,6 +5907,11 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
   auto type = value.getType();
   auto word = getVerilogDeclWord(op, emitter);
   auto isZeroBit = isZeroBitType(type);
+
+  // LocalParams always need the bitwidth, otherwise they are considered to have
+  // an unknown size.
+  bool singleBitDefaultType = !isa<LocalParamOp>(op);
+
   ps.scopedBox(isZeroBit ? PP::neverbox : PP::ibox2, [&]() {
     unsigned targetColumn = 0;
     unsigned column = 0;
@@ -5930,7 +5935,8 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
     {
       llvm::raw_svector_ostream stringStream(typeString);
       emitter.printPackedType(stripUnpackedTypes(type), stringStream,
-                              op->getLoc());
+                              op->getLoc(), /*optionalAliasType=*/{},
+                              /*implicitIntType=*/true, singleBitDefaultType);
     }
     // Emit the type.
     if (maxTypeWidth > 0)

--- a/test/Conversion/ExportVerilog/name-legalize.mlir
+++ b/test/Conversion/ExportVerilog/name-legalize.mlir
@@ -57,7 +57,7 @@ hw.module @parametersNameConflict<p2: i42 = 17, wire: i1>(in %p1: i8) {
 
   // CHECK: `ifdef SOMEMACRO
   sv.ifdef @SOMEMACRO {
-    // CHECK: localparam local_0 = wire_0;
+    // CHECK: localparam [0:0] local_0 = wire_0;
     %local = sv.localparam { value = #hw.param.decl.ref<"wire">: i1 } : i1
 
     // CHECK: assign myWire = wire_0;


### PR DESCRIPTION
We are currently printing 1-bit localparams without a size, which causes verilator to complain that it does not have a known bitwidth when used in some expressions.  This changes ExportVerilog to always print the bitwidth of localparams, which is something we already do for parameters.