### PR TITLE
[RTG] Add a pass to print a list of tests

### DIFF
--- a/include/circt/Dialect/RTG/Transforms/RTGPasses.td
+++ b/include/circt/Dialect/RTG/Transforms/RTGPasses.td
@@ -180,4 +180,21 @@ def LowerValidateToLabelsPass : Pass<"rtg-lower-validate-to-labels"> {
   }];
 }
 
+def PrintTestNamesPass : Pass<"rtg-print-test-names", "mlir::ModuleOp"> {
+  let summary = "print the names of all tests to the given file";
+  let description = [{
+    Prints the names of all tests in the module to the given file.
+    A CSV format is used with the first column being the properly uniqued name
+    of the test and the second column being the original name of the test as it
+    appeared in the frontend. The original name of a test may occur several
+    times because the test might have been duplicated for multiple targets or
+    because multiple elaborations of the same test/target pair were requested.
+  }];
+
+  let options = [
+    Option<"filename", "filename", "std::string", "\"-\"",
+           "The file to print the test names to.">,
+  ];
+}
+
 #endif // CIRCT_DIALECT_RTG_TRANSFORMS_RTGPASSES_TD

--- a/include/circt/Support/Path.h
+++ b/include/circt/Support/Path.h
@@ -15,6 +15,7 @@
 #define CIRCT_SUPPORT_PATH_H
 
 #include "circt/Support/LLVM.h"
+#include "llvm/Support/ToolOutputFile.h"
 
 namespace circt {
 
@@ -24,6 +25,14 @@ namespace circt {
 /// respectively.
 void appendPossiblyAbsolutePath(llvm::SmallVectorImpl<char> &base,
                                 const llvm::Twine &suffix);
+
+/// Creates an output file with the given filename in the specified directory.
+/// The function will create any parent directories as needed. If an error
+/// occurs during file or directory creation, it will use the provided emitError
+/// callback to report the error and return an empty unique_ptr.
+std::unique_ptr<llvm::ToolOutputFile>
+createOutputFile(StringRef filename, StringRef dirname,
+                 function_ref<InFlightDiagnostic()> emitError);
 
 } // namespace circt
 

--- a/lib/Dialect/RTG/Transforms/CMakeLists.txt
+++ b/lib/Dialect/RTG/Transforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_circt_dialect_library(CIRCTRTGTransforms
   LowerUniqueLabelsPass.cpp
   LowerValidateToLabelsPass.cpp
   MemoryAllocationPass.cpp
+  PrintTestNamesPass.cpp
   RTGPassPipelines.cpp
   UniqueValidateOpsPass.cpp
 

--- a/lib/Dialect/RTG/Transforms/EmitRTGISAAssemblyPass.cpp
+++ b/lib/Dialect/RTG/Transforms/EmitRTGISAAssemblyPass.cpp
@@ -178,30 +178,6 @@ parseUnsupportedInstructionsFile(MLIRContext *ctxt,
   }
 }
 
-static std::unique_ptr<llvm::ToolOutputFile>
-createOutputFile(StringRef filename, StringRef dirname,
-                 function_ref<InFlightDiagnostic()> emitError) {
-  // Determine the output path from the output directory and filename.
-  SmallString<128> outputFilename(dirname);
-  appendPossiblyAbsolutePath(outputFilename, filename);
-  auto outputDir = llvm::sys::path::parent_path(outputFilename);
-
-  // Create the output directory if needed.
-  std::error_code error = llvm::sys::fs::create_directories(outputDir);
-  if (error) {
-    emitError() << "cannot create output directory \"" << outputDir
-                << "\": " << error.message();
-    return {};
-  }
-
-  // Open the output file.
-  std::string errorMessage;
-  auto output = mlir::openOutputFile(outputFilename, &errorMessage);
-  if (!output)
-    emitError() << errorMessage;
-  return output;
-}
-
 //===----------------------------------------------------------------------===//
 // EmitRTGISAAssemblyPass
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/RTG/Transforms/PrintTestNamesPass.cpp
+++ b/lib/Dialect/RTG/Transforms/PrintTestNamesPass.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/RTG/IR/RTGOps.h"
+#include "circt/Dialect/RTG/Transforms/RTGPasses.h"
+#include "circt/Support/Path.h"
+
+namespace circt {
+namespace rtg {
+#define GEN_PASS_DEF_PRINTTESTNAMESPASS
+#include "circt/Dialect/RTG/Transforms/RTGPasses.h.inc"
+} // namespace rtg
+} // namespace circt
+
+using namespace mlir;
+using namespace circt;
+
+//===----------------------------------------------------------------------===//
+// Print Test Names Pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct PrintTestNamesPass
+    : public rtg::impl::PrintTestNamesPassBase<PrintTestNamesPass> {
+  using Base::Base;
+  void runOnOperation() override;
+};
+} // namespace
+
+void PrintTestNamesPass::runOnOperation() {
+  auto output = createOutputFile(filename, "", [&]() {
+    return mlir::emitError(UnknownLoc::get(&getContext()));
+  });
+  if (!output)
+    return signalPassFailure();
+
+  llvm::raw_ostream &os = output->os();
+
+  for (auto testOp : getOperation().getOps<rtg::TestOp>())
+    os << testOp.getSymName() << "," << testOp.getTemplateName() << "\n";
+
+  output->keep();
+  markAllAnalysesPreserved();
+}

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -27,6 +27,7 @@ add_circt_library(CIRCTSupport
 
   LINK_LIBS PUBLIC
   MLIRIR
+  MLIRSupport
   MLIRTransforms
   MLIRTransformUtils
   )

--- a/test/Dialect/RTG/Transform/print-test-names.mlir
+++ b/test/Dialect/RTG/Transform/print-test-names.mlir
@@ -1,0 +1,11 @@
+// RUN: circt-opt %s --rtg-print-test-names=filename=%t/out.csv && FileCheck %s --input-file=%t/out.csv
+
+// CHECK: test1_config1,test1{{$}}
+// CHECK: test1_config2,test1{{$}}
+// CHECK: test3_config3,test3{{$}}
+// CHECK: test_without_template,test_without_template{{$}}
+
+rtg.test @test1_config1() template "test1" { }
+rtg.test @test1_config2() template "test1" { }
+rtg.test @test3_config3() template "test3" { }
+rtg.test @test_without_template() {}


### PR DESCRIPTION
This pass prints the names of the tests in the IR. Since tests can be duplicated and elaborated differently during compilation, it prints both the newly uniqued name and the original name as specified by the user in the frontend.

In the future this could be extended to print additional information about tests post-elaboration.