### PR TITLE
[RTG] Add immediate concat and slice operations

### DIFF
--- a/include/circt/Dialect/RTG/IR/RTGOps.td
+++ b/include/circt/Dialect/RTG/IR/RTGOps.td
@@ -866,6 +866,43 @@ def IntToImmediateOp : RTGISAOp<"int_to_immediate", [Pure]> {
   let assemblyFormat = "$input `:` qualified(type($result)) attr-dict";
 }
 
+def ConcatImmediateOp : RTGISAOp<"concat_immediate", [
+  Pure,
+  DeclareOpInterfaceMethods<InferTypeOpInterface>,
+]> {
+  let summary = "concatenate immediates";
+  let description = [{
+    This operation concatenates a variadic number of immediates into a single
+    immediate. The operands are concatenated in order, with the first operand
+    becoming the most significant bits of the result.
+  }];
+
+  let arguments = (ins Variadic<ImmediateType>:$operands);
+  let results = (outs ImmediateType:$result);
+
+  let assemblyFormat = "$operands `:` qualified(type($operands)) attr-dict";
+}
+
+def SliceImmediateOp : RTGISAOp<"slice_immediate", [Pure]> {
+  let summary = "extract a slice from an immediate";
+  let description = [{
+    This operation extracts a contiguous slice of bits from an immediate value.
+    The slice is specified by a low bit index (inclusive) and the width of the
+    slice is determined by the result type. The slice must fit within the input
+    immediate's width.
+  }];
+
+  let arguments = (ins ImmediateType:$input, I32Attr:$lowBit);
+  let results = (outs ImmediateType:$result);
+
+  let assemblyFormat = [{
+    $input `from` $lowBit `:`
+    qualified(type($input)) `->` qualified(type($result)) attr-dict
+  }];
+  
+  let hasVerifier = 1;
+}
+
 //===- ISA Memory Block Operations ----------------------------------------===//
 
 def MemoryBlockDeclareOp : RTGISAOp<"memory_block_declare", [

--- a/include/circt/Dialect/RTG/IR/RTGVisitors.h
+++ b/include/circt/Dialect/RTG/IR/RTGVisitors.h
@@ -58,7 +58,7 @@ public:
             // Tuples
             TupleCreateOp, TupleExtractOp,
             // Immediates
-            IntToImmediateOp,
+            IntToImmediateOp, ConcatImmediateOp, SliceImmediateOp,
             // Memories
             MemoryAllocOp, MemoryBaseAddressOp, MemorySizeOp,
             // Memory Blocks
@@ -136,6 +136,8 @@ public:
   HANDLE(FixedRegisterOp, Unhandled);
   HANDLE(VirtualRegisterOp, Unhandled);
   HANDLE(IntToImmediateOp, Unhandled);
+  HANDLE(ConcatImmediateOp, Unhandled);
+  HANDLE(SliceImmediateOp, Unhandled);
   HANDLE(MemoryBlockDeclareOp, Unhandled);
   HANDLE(MemoryAllocOp, Unhandled);
   HANDLE(MemoryBaseAddressOp, Unhandled);

--- a/test/Dialect/RTG/IR/basic.mlir
+++ b/test/Dialect/RTG/IR/basic.mlir
@@ -236,3 +236,14 @@ rtg.test @validation() {
   // CHECK: rtg.validate [[V0]], [[V1]], "some_id" ([[V1]], [[V1]] else [[V1]], [[V1]] : !rtg.isa.immediate<32>, !rtg.isa.immediate<32>) : !rtgtest.ireg -> !rtg.isa.immediate<32>
   %5:3 = rtg.validate %0, %1, "some_id" (%1, %1 else %1, %1 : !rtg.isa.immediate<32>, !rtg.isa.immediate<32>) : !rtgtest.ireg -> !rtg.isa.immediate<32>
 }
+// CHECK-LABEL: @immediateOps
+rtg.test @immediateOps() {
+  // CHECK: rtg.isa.concat_immediate {{.*}}, {{.*}} : !rtg.isa.immediate<4>, !rtg.isa.immediate<8>
+  %0 = rtg.constant #rtg.isa.immediate<4, 15>
+  %1 = rtg.constant #rtg.isa.immediate<8, 175>
+  %2 = rtg.isa.concat_immediate %0, %1 : !rtg.isa.immediate<4>, !rtg.isa.immediate<8>
+
+  // CHECK: rtg.isa.slice_immediate {{.*}} from 4 : !rtg.isa.immediate<8> -> !rtg.isa.immediate<2>
+  %3 = rtg.constant #rtg.isa.immediate<8, 175>
+  %4 = rtg.isa.slice_immediate %3 from 4 : !rtg.isa.immediate<8> -> !rtg.isa.immediate<2>
+}

--- a/test/Dialect/RTG/IR/errors.mlir
+++ b/test/Dialect/RTG/IR/errors.mlir
@@ -297,3 +297,35 @@ rtg.test @validate() {
   // expected-error @below {{result type must be a valid content type for the ref value}}
   %2 = rtg.validate %0, %0 : !rtgtest.ireg -> !rtgtest.ireg
 }
+
+// -----
+
+rtg.test @sliceImmediateLowBitTooLarge() {
+  %0 = rtg.constant #rtg.isa.immediate<4, 5>
+  // expected-error @below {{from bit too large for input (got 4, but input width is 4)}}
+  %1 = rtg.isa.slice_immediate %0 from 4 : !rtg.isa.immediate<4> -> !rtg.isa.immediate<2>
+}
+
+// -----
+
+rtg.test @sliceImmediateSliceDoesNotFit() {
+  %0 = rtg.constant #rtg.isa.immediate<4, 5>
+  // expected-error @below {{slice does not fit in input (trying to extract 3 bits starting at index 2, but only 2 bits are available)}}
+  %1 = rtg.isa.slice_immediate %0 from 2 : !rtg.isa.immediate<4> -> !rtg.isa.immediate<3>
+}
+
+// -----
+
+rtg.test @concatImmediateNoOperands() {
+  // expected-error @below {{at least one operand must be provided}}
+  // expected-error @below {{failed to infer returned types}}
+  %0 = "rtg.isa.concat_immediate"() : () -> !rtg.isa.immediate<0>
+}
+
+// -----
+
+rtg.test @concatImmediateNonImmediateOperand() {
+  %0 = index.constant 42
+  // expected-error @below {{all operands must be of immediate type}}
+  %1 = rtg.isa.concat_immediate %0 : index
+}

--- a/test/Dialect/RTG/Transform/elaboration.mlir
+++ b/test/Dialect/RTG/Transform/elaboration.mlir
@@ -15,6 +15,8 @@ func.func @dummy12(%arg0: !rtg.bag<index>) -> () {return}
 func.func @dummy13(%arg0: !rtg.isa.memory_block<32>) -> () {return}
 func.func @dummy14(%arg0: !rtg.isa.memory<32>) -> () {return}
 func.func @dummy15(%arg0: !rtg.isa.immediate<32>) -> () {return}
+func.func @dummy16(%arg0: !rtg.isa.immediate<12>) -> () {return}
+func.func @dummy17(%arg0: !rtg.isa.immediate<3>) -> () {return}
 
 rtg.target @singletonTarget : !rtg.dict<singleton: index> {
   %0 = index.constant 0
@@ -760,6 +762,22 @@ rtg.test @validateOp(singleton = %none: index) {
   func.call @dummy15(%1#0) : (!rtg.isa.immediate<32>) -> ()
   func.call @dummy15(%1#1) : (!rtg.isa.immediate<32>) -> ()
   func.call @dummy15(%1#2) : (!rtg.isa.immediate<32>) -> ()
+}
+
+// CHECK-LABEL: @immediateOps
+rtg.test @immediateOps(singleton = %none: index) {
+  // CHECK-NEXT: [[V0:%.+]] = rtg.constant #rtg.isa.immediate<12, -81>
+  // CHECK-NEXT: func.call @dummy16([[V0]]) : (!rtg.isa.immediate<12>) -> ()
+  %0 = rtg.constant #rtg.isa.immediate<4, 15>
+  %1 = rtg.constant #rtg.isa.immediate<8, 175>
+  %2 = rtg.isa.concat_immediate %0, %1 : !rtg.isa.immediate<4>, !rtg.isa.immediate<8>
+  func.call @dummy16(%2) : (!rtg.isa.immediate<12>) -> ()
+
+  // CHECK-NEXT: [[V1:%.+]] = rtg.constant #rtg.isa.immediate<2, -2>
+  // CHECK-NEXT: func.call @dummy6([[V1]]) : (!rtg.isa.immediate<2>) -> ()
+  %3 = rtg.constant #rtg.isa.immediate<8, 175>
+  %4 = rtg.isa.slice_immediate %3 from 4 : !rtg.isa.immediate<8> -> !rtg.isa.immediate<2>
+  func.call @dummy6(%4) : (!rtg.isa.immediate<2>) -> ()
 }
 
 // -----


### PR DESCRIPTION
This allows passing immediates around instead of two integers (one with the value, one with the bitwidth) and then split it, e.g., for loading that immediate into a register since there is no instruction that can load a 64bit or even 32bit immediate in one go.