### PR TITLE
[FIRRTL] Do not allow uninferred widths or rests in enums

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -2374,9 +2374,15 @@ LogicalResult FEnumType::verify(function_ref<InFlightDiagnostic()> emitErrorFn,
   for (auto &elt : elements) {
     auto r = elt.type.getRecursiveTypeProperties();
     if (!r.isPassive)
-      return emitErrorFn() << "enum field '" << elt.name << "' not passive";
+      return emitErrorFn() << "enum field " << elt.name << " not passive";
     if (r.containsAnalog)
-      return emitErrorFn() << "enum field '" << elt.name << "' contains analog";
+      return emitErrorFn() << "enum field " << elt.name << " contains analog";
+    if (r.hasUninferredWidth)
+      return emitErrorFn() << "enum field " << elt.name
+                           << " has uninferred width";
+    if (r.hasUninferredReset)
+      return emitErrorFn() << "enum field " << elt.name
+                           << " has uninferred reset";
     if (r.containsConst && !isConst)
       return emitErrorFn() << "enum with 'const' elements must be 'const'";
     // Ensure that each tag has a unique name.

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -862,6 +862,18 @@ ParseResult FIRParser::parseEnumType(FIRRTLType &result) {
         }
         types.push_back(type);
 
+        auto r = type.getRecursiveTypeProperties();
+        if (!r.isPassive)
+          return emitError(fieldLoc) << "enum field " << name << " not passive";
+        if (r.containsAnalog)
+          return emitError(fieldLoc)
+                 << "enum field " << name << " contains analog";
+        if (r.hasUninferredWidth)
+          return emitError(fieldLoc)
+                 << "enum field " << name << " has uninferred width";
+        if (r.hasUninferredReset)
+          return emitError(fieldLoc)
+                 << "enum field " << name << " has uninferred reset";
         return success();
       }))
     return failure();

--- a/test/Dialect/FIRRTL/errors.mlir
+++ b/test/Dialect/FIRRTL/errors.mlir
@@ -975,20 +975,6 @@ firrtl.circuit "MismatchedRegister" {
 
 // -----
 
-firrtl.circuit "DupVarNameEnum" {
-  // expected-error @+1 {{duplicate variant name "a" in enum}}
-  firrtl.module @DupVarNameEnum(in %enum : !firrtl.enum<a, a>) { }
-}
-
-// -----
-
-firrtl.circuit "DupVarValueEnum" {
-  // expected-error @+1 {{enum variant "b" has value 0 : ui0 which is not greater than previous variant 0 : ui0}}
-  firrtl.module @DupVarNameEnum(in %enum : !firrtl.enum<a, b=0>) { }
-}
-
-// -----
-
 firrtl.circuit "EnumOutOfRange" {
   firrtl.module @EnumSameCase(in %enum : !firrtl.enum<a : uint<8>>) {
     // expected-error @+1 {{the tag index 1 is out of the range of valid tags in '!firrtl.enum<a: uint<8>>'}}
@@ -1799,7 +1785,7 @@ firrtl.module @ConstEnumCreateNonConstOperands(in %a: !firrtl.uint<1>) {
 
 // Enum types must be passive
 firrtl.circuit "EnumNonPassive" {
-  // expected-error @+1 {{enum field '"a"' not passive}}
+  // expected-error @+1 {{enum field "a" not passive}}
   firrtl.module @EnumNonPassive(in %a : !firrtl.enum<a: bundle<a flip: uint<1>>>) {
   }
 }
@@ -1808,9 +1794,23 @@ firrtl.circuit "EnumNonPassive" {
 
 // Enum types must not contain analog
 firrtl.circuit "EnumAnalog" {
-  // expected-error @+1 {{enum field '"a"' contains analog}}
+  // expected-error @+1 {{enum field "a" contains analog}}
   firrtl.module @EnumAnalog(in %a : !firrtl.enum<a: analog<1>>) {
   }
+}
+
+// -----
+
+firrtl.circuit "EnumUninferredWidth" {
+  // expected-error @+1 {{enum field "a" has uninferred width}}
+  firrtl.module @EnumUninferredWidth(in %enum : !firrtl.enum<a: uint>) { }
+}
+
+// -----
+
+firrtl.circuit "EnumUninferredReset" {
+  // expected-error @+1 {{enum field "a" has uninferred reset}}
+  firrtl.module @EnumUninferredReset(in %enum : !firrtl.enum<a: reset>) { }
 }
 
 // -----
@@ -1819,6 +1819,20 @@ firrtl.circuit "EnumAnalog" {
 firrtl.circuit "NonConstEnumConstElements" {
 // expected-error @+1 {{enum with 'const' elements must be 'const'}}
 firrtl.module @NonConstEnumConstElements(in %a: !firrtl.enum<None: uint<0>, Some: const.uint<1>>) {}
+}
+
+// -----
+
+firrtl.circuit "EnumDupVarName" {
+  // expected-error @+1 {{duplicate variant name "a" in enum}}
+  firrtl.module @EnumDupVarName(in %enum : !firrtl.enum<a, a>) { }
+}
+
+// -----
+
+firrtl.circuit "EnumDupVarValue" {
+  // expected-error @+1 {{enum variant "b" has value 0 : ui0 which is not greater than previous variant 0 : ui0}}
+  firrtl.module @EnumDupVarValue(in %enum : !firrtl.enum<a, b=0>) { }
 }
 
 // -----

--- a/test/Dialect/FIRRTL/infer-widths-errors.mlir
+++ b/test/Dialect/FIRRTL/infer-widths-errors.mlir
@@ -158,15 +158,6 @@ firrtl.circuit "Foo" {
 }
 
 // -----
-// https://github.com/llvm/circt/issues/5324
-
-firrtl.circuit "NoWidthEnum" {
-  // expected-error @below {{uninferred width: port "o.Some" is unconstrained}}
-  firrtl.module @NoWidthEnum(out %o: !firrtl.enum<Some: uint>) {
-  }
-}
-
-// -----
 
 firrtl.circuit "MuxSelBackProp" {
   firrtl.module @MuxSelBackProp() {

--- a/test/Dialect/FIRRTL/infer-widths.mlir
+++ b/test/Dialect/FIRRTL/infer-widths.mlir
@@ -40,11 +40,9 @@ firrtl.circuit "Foo" {
     // CHECK: firrtl.invalidvalue : !firrtl.uint<0>
     // CHECK: firrtl.invalidvalue : !firrtl.bundle<x: uint<0>>
     // CHECK: firrtl.invalidvalue : !firrtl.vector<uint<0>, 2>
-    // CHECK: firrtl.invalidvalue : !firrtl.enum<a>
     %invalid_0 = firrtl.invalidvalue : !firrtl.uint
     %invalid_1 = firrtl.invalidvalue : !firrtl.bundle<x: uint>
     %invalid_2 = firrtl.invalidvalue : !firrtl.vector<uint, 2>
-    %invalid_3 = firrtl.invalidvalue : !firrtl.enum<a: uint>
   }
 
   // CHECK-LABEL: @InferOutput
@@ -693,15 +691,6 @@ firrtl.circuit "Foo" {
     %w_a = firrtl.subfield %w[b] : !firrtl.bundle<a: vector<uint<10>, 10>, b: uint>
     %c2_ui3 = firrtl.constant 2 : !firrtl.uint<3>
     firrtl.connect %w_a, %c2_ui3 : !firrtl.uint, !firrtl.uint<3>
-  }
-
-  // CHECK-LABEL: @InferEnum
-  firrtl.module @InferEnum(in %in : !firrtl.enum<a: uint<3>>) {
-    // CHECK: %w = firrtl.wire : !firrtl.enum<a: uint<3>>
-    %w = firrtl.wire : !firrtl.enum<a: uint>
-    firrtl.connect %w, %in : !firrtl.enum<a: uint>, !firrtl.enum<a: uint<3>>
-    // CHECK: %0 = firrtl.subtag %w[a] : !firrtl.enum<a: uint<3>>
-    %0 = firrtl.subtag %w[a] : !firrtl.enum<a: uint>
   }
 
   // CHECK-LABEL: InferComplexBundles

--- a/test/Dialect/FIRRTL/parse-basic.fir
+++ b/test/Dialect/FIRRTL/parse-basic.fir
@@ -959,14 +959,6 @@ circuit MyModule :     ; CHECK: firrtl.circuit "MyModule"
       None:
         invalidate o
 
-  ; CHECK-LABEL: firrtl.module private @EnumInfer(
-  module EnumInfer:
-    input i : {| A: UInt<8>, None |}
-    output o : {| A: UInt, None |}
-
-    ; CHECK: connect %o, %i
-    connect o, i
-
   ; CHECK-LABEL: firrtl.module private @TagExtract
   module TagExtract:
     input i : {|A, B, C|}

--- a/test/Dialect/FIRRTL/parse-errors.fir
+++ b/test/Dialect/FIRRTL/parse-errors.fir
@@ -351,6 +351,34 @@ circuit circuit:
 FIRRTL version 5.1.0
 circuit circuit:
   public module circuit :
+    input in: {|A : {flip a: UInt<1>}|} ; expected-error {{enum field "A" not passive}}
+
+;// -----
+
+FIRRTL version 5.1.0
+circuit circuit:
+  public module circuit :
+    input in: {|A : Analog|} ; expected-error {{enum field "A" contains analog}}
+
+;// -----
+
+FIRRTL version 5.1.0
+circuit circuit:
+  public module circuit :
+    input in: {|A : UInt|} ; expected-error {{enum field "A" has uninferred width}}
+
+;// -----
+
+FIRRTL version 5.1.0
+circuit circuit:
+  public module circuit :
+    input in: {|A : Reset|} ; expected-error {{enum field "A" has uninferred reset}}
+
+;// -----
+
+FIRRTL version 5.1.0
+circuit circuit:
+  public module circuit :
     input in: {|A, A|} ; expected-error {{duplicate variant name in enum: A}}
 
 ;// -----


### PR DESCRIPTION
This adds verifiers to the FIRRTL parser and to the FEnumType to prevent having uninferred widths and resets inside enumerations.  It seems like the trickiness to implement these features would be hard to take advantage of in practice, making it not worth it.  This also fixes the error messages produced by the type verifier that had extraneous quotes around the field name, and rearranges some tests to be co-located in the test file.