### PR TITLE
[FIRRTL] FlattenMemories: handle memories with enums

### DIFF
--- a/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLTypes.cpp
@@ -813,7 +813,7 @@ FIRRTLBaseType FIRRTLBaseType::getAllConstDroppedType() {
 FIRRTLBaseType FIRRTLBaseType::getMaskType() {
   return TypeSwitch<FIRRTLBaseType, FIRRTLBaseType>(*this)
       .Case<ClockType, ResetType, AsyncResetType, SIntType, UIntType,
-            AnalogType>([&](Type) {
+            AnalogType, FEnumType>([&](Type) {
         return UIntType::get(this->getContext(), 1, this->isConst());
       })
       .Case<BundleType>([&](BundleType bundleType) {

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -215,9 +215,13 @@ private:
                 return false;
             return true;
           })
-          .Case<IntType>([&](auto iType) {
-            results.push_back({iType});
-            return iType.getWidth().has_value();
+          .Case<IntType>([&](IntType type) {
+            results.push_back(type);
+            return type.getWidth().has_value();
+          })
+          .Case<FEnumType>([&](FEnumType type) {
+            results.emplace_back(type);
+            return true;
           })
           .Default([&](auto) { return false; });
     };

--- a/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/FlattenMemory.cpp
@@ -34,30 +34,25 @@ using namespace firrtl;
 namespace {
 struct FlattenMemoryPass
     : public circt::firrtl::impl::FlattenMemoryBase<FlattenMemoryPass> {
+
+  /// Returns true if the the memory has annotations on a subfield of any of the
+  /// ports.
+  static bool hasSubAnno(MemOp op) {
+    for (size_t portIdx = 0, e = op.getNumResults(); portIdx < e; ++portIdx)
+      for (auto attr : op.getPortAnnotation(portIdx))
+        if (cast<DictionaryAttr>(attr).get("circt.fieldID"))
+          return true;
+    return false;
+  };
+
   /// This pass flattens the aggregate data of memory into a UInt, and inserts
   /// appropriate bitcasts to access the data.
   void runOnOperation() override {
     LLVM_DEBUG(llvm::dbgs() << "\n Running lower memory on module:"
                             << getOperation().getName());
     SmallVector<Operation *> opsToErase;
-    auto hasSubAnno = [&](MemOp op) -> bool {
-      for (size_t portIdx = 0, e = op.getNumResults(); portIdx < e; ++portIdx)
-        for (auto attr : op.getPortAnnotation(portIdx))
-          if (cast<DictionaryAttr>(attr).get("circt.fieldID"))
-            return true;
-
-      return false;
-    };
     getOperation().getBodyBlock()->walk([&](MemOp memOp) {
       LLVM_DEBUG(llvm::dbgs() << "\n Memory:" << memOp);
-      // The vector of leaf elements type after flattening the data.
-      SmallVector<IntType> flatMemType;
-      // MaskGranularity : how many bits each mask bit controls.
-      size_t maskGran = 1;
-      // Total mask bitwidth after flattening.
-      uint32_t totalmaskWidths = 0;
-      // How many mask bits each field type requires.
-      SmallVector<unsigned> maskWidths;
 
       // Cannot flatten a memory if it has debug ports, because debug port
       // implies a memtap and we cannot transform the datatype for a memory that
@@ -65,36 +60,51 @@ struct FlattenMemoryPass
       for (auto res : memOp.getResults())
         if (isa<RefType>(res.getType()))
           return;
+
       // If subannotations present on aggregate fields, we cannot flatten the
       // memory. It must be split into one memory per aggregate field.
       // Do not overwrite the pass flag!
-      if (hasSubAnno(memOp) || !flattenType(memOp.getDataType(), flatMemType))
+      if (hasSubAnno(memOp))
         return;
 
-      SmallVector<Operation *, 8> flatData;
-      SmallVector<int32_t> memWidths;
+      // The vector of leaf elements type after flattening the data. If any of
+      // the datatypes cannot be flattened, then we cannot flatten the memory.
+      SmallVector<FIRRTLBaseType> flatMemType;
+      if (!flattenType(memOp.getDataType(), flatMemType))
+        return;
+
+      // Calculate the width of the memory data type, and the width of
+      // each individual aggregate leaf elements.
       size_t memFlatWidth = 0;
-      // Get the width of individual aggregate leaf elements.
+      SmallVector<int32_t> memWidths;
       for (auto f : flatMemType) {
         LLVM_DEBUG(llvm::dbgs() << "\n field type:" << f);
-        auto w = *f.getWidth();
+        auto w = f.getBitWidthOrSentinel();
         memWidths.push_back(w);
         memFlatWidth += w;
       }
       // If all the widths are zero, ignore the memory.
       if (!memFlatWidth)
         return;
-      maskGran = memWidths[0];
-      // Compute the GCD of all data bitwidths.
-      for (auto w : memWidths) {
+
+      // Calculate the mask granularity of this memory, which is how many bits
+      // of the data each mask bit controls. This is the greatest common
+      // denominator of the widths of the flattened data types.
+      auto maskGran = memWidths.front();
+      for (auto w : ArrayRef(memWidths).drop_front())
         maskGran = std::gcd(maskGran, w);
-      }
+
+      // Total mask bitwidth after flattening.
+      uint32_t totalmaskWidths = 0;
+      // How many mask bits each field type requires.
+      SmallVector<unsigned> maskWidths;
       for (auto w : memWidths) {
         // How many mask bits required for each flattened field.
         auto mWidth = w / maskGran;
         maskWidths.push_back(mWidth);
         totalmaskWidths += mWidth;
       }
+
       // Now create a new memory of type flattened data.
       // ----------------------------------------------
       SmallVector<Type, 8> ports;
@@ -102,25 +112,29 @@ struct FlattenMemoryPass
 
       auto *context = memOp.getContext();
       ImplicitLocOpBuilder builder(memOp.getLoc(), memOp);
-      // Create a new memoty data type of unsigned and computed width.
+      // Create a new memory data type of unsigned and computed width.
       auto flatType = UIntType::get(context, memFlatWidth);
-      auto opPorts = memOp.getPorts();
-      for (size_t portIdx = 0, e = opPorts.size(); portIdx < e; ++portIdx) {
-        auto port = opPorts[portIdx];
+      for (auto port : memOp.getPorts()) {
         ports.push_back(MemOp::getTypeForPort(memOp.getDepth(), flatType,
                                               port.second, totalmaskWidths));
         portNames.push_back(port.first);
       }
 
+      // Create the new flattened memory.
       auto flatMem = builder.create<MemOp>(
           ports, memOp.getReadLatency(), memOp.getWriteLatency(),
           memOp.getDepth(), memOp.getRuw(), builder.getArrayAttr(portNames),
           memOp.getNameAttr(), memOp.getNameKind(), memOp.getAnnotations(),
           memOp.getPortAnnotations(), memOp.getInnerSymAttr(),
           memOp.getInitAttr(), memOp.getPrefixAttr());
+
       // Hook up the new memory to the wires the old memory was replaced with.
       for (size_t index = 0, rend = memOp.getNumResults(); index < rend;
            ++index) {
+
+        // Create a wire with the original type, and replace all uses of the old
+        // memory with the wire.  We will be reconstructing the original type
+        // in the wire from the bitvector of the flattened memory.
         auto result = memOp.getResult(index);
         auto wire = builder
                         .create<WireOp>(result.getType(),
@@ -134,7 +148,7 @@ struct FlattenMemoryPass
         auto rType = type_cast<BundleType>(result.getType());
         for (size_t fieldIndex = 0, fend = rType.getNumElements();
              fieldIndex != fend; ++fieldIndex) {
-          auto name = rType.getElement(fieldIndex).name.getValue();
+          auto name = rType.getElement(fieldIndex).name;
           auto oldField = builder.create<SubfieldOp>(result, fieldIndex);
           FIRRTLBaseValue newField =
               builder.create<SubfieldOp>(newResult, fieldIndex);
@@ -153,7 +167,6 @@ struct FlattenMemoryPass
             // Write the aggregate read data.
             emitConnect(builder, realOldField, castField);
           } else {
-            // Cast the input aggregate write data to flat type.
             // Cast the input aggregate write data to flat type.
             auto newFieldType = newField.getType();
             auto oldFieldBitWidth = getBitWidth(oldField.getType());
@@ -197,10 +210,11 @@ struct FlattenMemoryPass
   }
 
 private:
-  // Convert an aggregate type into a flat list of fields.
-  // This is used to flatten the aggregate memory datatype.
-  // Recursively populate the results with each ground type field.
-  static bool flattenType(FIRRTLType type, SmallVectorImpl<IntType> &results) {
+  // Convert an aggregate type into a flat list of fields. This is used to
+  // flatten the aggregate memory datatype. Recursively populate the results
+  // with each ground type field.
+  static bool flattenType(FIRRTLType type,
+                          SmallVectorImpl<FIRRTLBaseType> &results) {
     std::function<bool(FIRRTLType)> flatten = [&](FIRRTLType type) -> bool {
       return FIRRTLTypeSwitch<FIRRTLType, bool>(type)
           .Case<BundleType>([&](auto bundle) {
@@ -226,9 +240,7 @@ private:
           .Default([&](auto) { return false; });
     };
     // Return true only if this is an aggregate with more than one element.
-    if (flatten(type) && results.size() > 1)
-      return true;
-    return false;
+    return flatten(type) && results.size() > 1;
   }
 
   Value getSubWhatever(ImplicitLocOpBuilder *builder, Value val, size_t index) {

--- a/test/Dialect/FIRRTL/flatten-memory.mlir
+++ b/test/Dialect/FIRRTL/flatten-memory.mlir
@@ -2,31 +2,31 @@
 
 
 firrtl.circuit "Mem" {
-  firrtl.module public  @Mem(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.bundle<a: uint<8>, b: uint<8>>, in %wAddr: !firrtl.uint<4>, in %wEn: !firrtl.uint<1>, in %wMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, in %wData: !firrtl.bundle<a: uint<8>, b: uint<8>>) {
-    %memory_r, %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    %0 = firrtl.subfield %memory_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
+  firrtl.module public  @Mem(in %clock: !firrtl.clock, in %rAddr: !firrtl.uint<4>, in %rEn: !firrtl.uint<1>, out %rData: !firrtl.bundle<a: uint<8>, b: enum<A = 128>>, in %wAddr: !firrtl.uint<4>, in %wEn: !firrtl.uint<1>, in %wMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, in %wData: !firrtl.bundle<a: uint<8>, b: enum<A = 128>>) {
+    %memory_r, %memory_w = firrtl.mem Undefined {depth = 16 : i64, name = "memory", portNames = ["r", "w"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: enum<A = 128>>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: enum<A = 128>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    %0 = firrtl.subfield %memory_r[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: enum<A = 128>>>
     firrtl.matchingconnect %0, %clock : !firrtl.clock
-    %1 = firrtl.subfield %memory_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
+    %1 = firrtl.subfield %memory_r[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: enum<A = 128>>>
     firrtl.matchingconnect %1, %rEn : !firrtl.uint<1>
-    %2 = firrtl.subfield %memory_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
+    %2 = firrtl.subfield %memory_r[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: enum<A = 128>>>
     firrtl.matchingconnect %2, %rAddr : !firrtl.uint<4>
-    %3 = firrtl.subfield %memory_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
-    firrtl.matchingconnect %rData, %3 : !firrtl.bundle<a: uint<8>, b: uint<8>>
-    %4 = firrtl.subfield %memory_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    %3 = firrtl.subfield %memory_r[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: enum<A = 128>>>
+    firrtl.matchingconnect %rData, %3 : !firrtl.bundle<a: uint<8>, b: enum<A = 128>>
+    %4 = firrtl.subfield %memory_w[clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: enum<A = 128>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.matchingconnect %4, %clock : !firrtl.clock
-    %5 = firrtl.subfield %memory_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    %5 = firrtl.subfield %memory_w[en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: enum<A = 128>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.matchingconnect %5, %wEn : !firrtl.uint<1>
-    %6 = firrtl.subfield %memory_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    %6 = firrtl.subfield %memory_w[addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: enum<A = 128>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.matchingconnect %6, %wAddr : !firrtl.uint<4>
-    %7 = firrtl.subfield %memory_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    %7 = firrtl.subfield %memory_w[mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: enum<A = 128>>, mask: bundle<a: uint<1>, b: uint<1>>>
     firrtl.matchingconnect %7, %wMask : !firrtl.bundle<a: uint<1>, b: uint<1>>
-    %8 = firrtl.subfield %memory_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    firrtl.matchingconnect %8, %wData : !firrtl.bundle<a: uint<8>, b: uint<8>>
+    %8 = firrtl.subfield %memory_w[data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: enum<A = 128>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    firrtl.matchingconnect %8, %wData : !firrtl.bundle<a: uint<8>, b: enum<A = 128>>
     // ---------------------------------------------------------------------------------
     // After flattenning the memory data
     // CHECK: %[[memory_r:.+]], %[[memory_w:.+]] = firrtl.mem Undefined  {depth = 16 : i64, name = "memory", portNames = ["r", "w"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32}
     // CHECK-SAME: !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: uint<16>>, !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: uint<16>, mask: uint<2>>
-    // CHECK: %[[memory_r_0:.+]] = firrtl.wire  {name = "memory_r"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
+    // CHECK: %[[memory_r_0:.+]] = firrtl.wire {name = "memory_r"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: enum<A = 128>>>
     // CHECK: %[[v0:.+]] = firrtl.subfield %[[memory_r]][addr]
     // CHECK: firrtl.matchingconnect %[[v0]], %[[memory_r_addr:.+]] :
     // CHECK: %[[v1:.+]] = firrtl.subfield %[[memory_r]][en]
@@ -37,13 +37,13 @@ firrtl.circuit "Mem" {
     //
     // ---------------------------------------------------------------------------------
     // Read ports
-    // CHECK:  %[[v4:.+]] = firrtl.bitcast %[[v3]] : (!firrtl.uint<16>) -> !firrtl.bundle<a: uint<8>, b: uint<8>>
+    // CHECK:  %[[v4:.+]] = firrtl.bitcast %[[v3]] : (!firrtl.uint<16>) -> !firrtl.bundle<a: uint<8>, b: enum<A = 128>
     // CHECK:  firrtl.matchingconnect %[[memory_r_data:.+]], %[[v4]] :
     // --------------------------------------------------------------------------------
     // Write Ports
-    // CHECK:  %[[memory_w_1:.+]] = firrtl.wire  {name = "memory_w"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    // CHECK:  %[[memory_w_1:.+]] = firrtl.wire  {name = "memory_w"} : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: enum<A = 128>>, mask: bundle<a: uint<1>, b: uint<1>>
     // CHECK:  %[[v9:.+]] = firrtl.subfield %[[memory_w]][data]
-    // CHECK:  %[[v17:.+]] = firrtl.bitcast %[[v15:.+]] : (!firrtl.bundle<a: uint<8>, b: uint<8>>) -> !firrtl.uint<16>
+    // CHECK:  %[[v17:.+]] = firrtl.bitcast %[[v15:.+]] : (!firrtl.bundle<a: uint<8>, b: enum<A = 128>>) -> !firrtl.uint<16>
     // CHECK:  firrtl.matchingconnect %[[v9]], %[[v17]]
     //
     // --------------------------------------------------------------------------------
@@ -53,24 +53,24 @@ firrtl.circuit "Mem" {
     //  CHECK: firrtl.matchingconnect %[[v11]], %[[v12]]
     // --------------------------------------------------------------------------------
     // Connections to module ports
-    // CHECK:  %[[v21:.+]] = firrtl.subfield %[[memory_r_0]][clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
+    // CHECK:  %[[v21:.+]] = firrtl.subfield %[[memory_r_0]][clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: enum<A = 128>>
     // CHECK:  firrtl.matchingconnect %[[v21]], %clock :
-    // CHECK:  %[[v22:.+]]  = firrtl.subfield %[[memory_r_0]][en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
+    // CHECK:  %[[v22:.+]]  = firrtl.subfield %[[memory_r_0]][en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: enum<A = 128>>>
     // CHECK:  firrtl.matchingconnect %[[v22]], %rEn : !firrtl.uint<1>
-    // CHECK:  %[[v23:.+]]  = firrtl.subfield %[[memory_r_0]][addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
+    // CHECK:  %[[v23:.+]]  = firrtl.subfield %[[memory_r_0]][addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: enum<A = 128>>>
     // CHECK:  firrtl.matchingconnect %[[v23]], %rAddr : !firrtl.uint<4>
-    // CHECK:  %[[v24:.+]]  = firrtl.subfield %[[memory_r_0]][data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: uint<8>>>
-    // CHECK:  firrtl.matchingconnect %rData, %[[v24]] : !firrtl.bundle<a: uint<8>, b: uint<8>>
-    // CHECK:  %[[v25:.+]]  = firrtl.subfield %[[memory_w_1]][clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    // CHECK:  %[[v24:.+]]  = firrtl.subfield %[[memory_r_0]][data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data flip: bundle<a: uint<8>, b: enum<A = 128>>>
+    // CHECK:  firrtl.matchingconnect %rData, %[[v24]] : !firrtl.bundle<a: uint<8>, b: enum<A = 128>>
+    // CHECK:  %[[v25:.+]]  = firrtl.subfield %[[memory_w_1]][clk] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: enum<A = 128>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  firrtl.matchingconnect %[[v25]], %clock : !firrtl.clock
-    // CHECK:  %[[v26:.+]]  = firrtl.subfield %[[memory_w_1]][en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    // CHECK:  %[[v26:.+]]  = firrtl.subfield %[[memory_w_1]][en] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: enum<A = 128>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  firrtl.matchingconnect %[[v26]], %wEn : !firrtl.uint<1>
-    // CHECK:  %[[v27:.+]]  = firrtl.subfield %[[memory_w_1]][addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    // CHECK:  %[[v27:.+]]  = firrtl.subfield %[[memory_w_1]][addr] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: enum<A = 128>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  firrtl.matchingconnect %[[v27]], %wAddr : !firrtl.uint<4>
-    // CHECK:  %[[v28:.+]]  = firrtl.subfield %[[memory_w_1]][mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    // CHECK:  %[[v28:.+]]  = firrtl.subfield %[[memory_w_1]][mask] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: enum<A = 128>>, mask: bundle<a: uint<1>, b: uint<1>>>
     // CHECK:  firrtl.matchingconnect %[[v28]], %wMask : !firrtl.bundle<a: uint<1>, b: uint<1>>
-    // CHECK:  %[[v29:.+]]  = firrtl.subfield %[[memory_w_1]][data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: uint<8>>, mask: bundle<a: uint<1>, b: uint<1>>>
-    // CHECK:  firrtl.matchingconnect %[[v29]], %wData : !firrtl.bundle<a: uint<8>, b: uint<8>>
+    // CHECK:  %[[v29:.+]]  = firrtl.subfield %[[memory_w_1]][data] : !firrtl.bundle<addr: uint<4>, en: uint<1>, clk: clock, data: bundle<a: uint<8>, b: enum<A = 128>>, mask: bundle<a: uint<1>, b: uint<1>>>
+    // CHECK:  firrtl.matchingconnect %[[v29]], %wData : !firrtl.bundle<a: uint<8>, b: enum<A = 128>>
   }
 
 firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>, in %rwMode: !firrtl.uint<1>, in %rwAddr: !firrtl.uint<4>, in %rwMask: !firrtl.bundle<a: uint<1>, b: uint<1>>, in %rwDataIn: !firrtl.bundle<a: uint<8>, b: uint<9>>, out %rwDataOut: !firrtl.bundle<a: uint<8>, b: uint<9>>) {
@@ -118,9 +118,7 @@ firrtl.module @MemoryRWSplit(in %clock: !firrtl.clock, in %rwEn: !firrtl.uint<1>
   // Ensure 0 bit fields are handled properly.
   %ram_MPORT = firrtl.mem Undefined  {depth = 4 : i64, name = "ram", portNames = ["MPORT"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: bundle<entry: bundle<a: uint<0>, b: uint<1>, c: uint<2>>>, mask: bundle<entry: bundle<a: uint<1>, b: uint<1>, c: uint<1>>>>
   // CHECK: %ram_MPORT = firrtl.mem Undefined  {depth = 4 : i64, name = "ram", portNames = ["MPORT"], prefix = "foo_", readLatency = 0 : i32, writeLatency = 1 : i32} : !firrtl.bundle<addr: uint<2>, en: uint<1>, clk: clock, data: uint<3>, mask: uint<3>>
-
 }
-
 
   firrtl.module @ZeroBitMasks(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, in %io: !firrtl.bundle<a: uint<0>, b: uint<20>>) {
     %invalid = firrtl.invalidvalue : !firrtl.bundle<a: uint<1>, b: uint<1>>


### PR DESCRIPTION
This adds support to flatten memories with enumeration in them. Enumerations are treated as non-aggregate types, and so they get a single bit mask to control the whole value.