### PR TITLE
[VerifToSMT] Lower `verif.refines` to SMT

### DIFF
--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -222,6 +222,125 @@ struct LogicEquivalenceCheckingOpConversion
   }
 };
 
+struct RefinementCheckingOpConversion
+    : CircuitRelationCheckOpConversion<verif::RefinementCheckingOp> {
+  using CircuitRelationCheckOpConversion<
+      verif::RefinementCheckingOp>::CircuitRelationCheckOpConversion;
+
+  LogicalResult
+  matchAndRewrite(verif::RefinementCheckingOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    // Find non-deterministic values (free variables) in the LHS circuit.
+    SmallVector<Value> lhsNonDetValues;
+    bool onlyPrimitiveNd = true;
+    for (auto ndOp : op.getFirstCircuit().getOps<smt::DeclareFunOp>()) {
+      if (!isa<smt::IntType, smt::BoolType, smt::BitVectorType>(
+              ndOp.getType())) {
+        ndOp.emitError("Uninterpreted function of non-primitive type cannot be "
+                       "converted.");
+        onlyPrimitiveNd = false;
+      }
+      lhsNonDetValues.push_back(ndOp.getResult());
+    }
+    if (!onlyPrimitiveNd)
+      return failure();
+
+    if (lhsNonDetValues.empty()) {
+      // If there is no non-determinism in the LHS circuit, the refinement check
+      // becomes an equivalence check, which does not need quantified
+      // expressions.
+      auto eqOp = rewriter.create<verif::LogicEquivalenceCheckingOp>(
+          op.getLoc(), op.getNumResults() != 0);
+      rewriter.moveBlockBefore(&op.getFirstCircuit().front(),
+                               &eqOp.getFirstCircuit(),
+                               eqOp.getFirstCircuit().end());
+      rewriter.moveBlockBefore(&op.getSecondCircuit().front(),
+                               &eqOp.getSecondCircuit(),
+                               eqOp.getSecondCircuit().end());
+      rewriter.replaceOp(op, eqOp);
+      return success();
+    }
+
+    Location loc = op.getLoc();
+    auto *firstOutputs = adaptor.getFirstCircuit().front().getTerminator();
+    auto *secondOutputs = adaptor.getSecondCircuit().front().getTerminator();
+
+    if (firstOutputs->getNumOperands() == 0) {
+      // Trivially equivalent
+      Value trueVal =
+          rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(true));
+      rewriter.replaceOp(op, trueVal);
+      return success();
+    }
+
+    // Solver will only return a result when it is used to check the returned
+    // value.
+    smt::SolverOp solver;
+    auto hasNoResult = op.getNumResults() == 0;
+    if (hasNoResult)
+      solver = rewriter.create<smt::SolverOp>(loc, TypeRange{}, ValueRange{});
+    else
+      solver = rewriter.create<smt::SolverOp>(loc, rewriter.getI1Type(),
+                                              ValueRange{});
+    rewriter.createBlock(&solver.getBodyRegion());
+
+    // Convert the block arguments of the miter bodies.
+    if (failed(rewriter.convertRegionTypes(&adaptor.getFirstCircuit(),
+                                           *typeConverter)))
+      return failure();
+    if (failed(rewriter.convertRegionTypes(&adaptor.getSecondCircuit(),
+                                           *typeConverter)))
+      return failure();
+
+    // Create the symbolic values we replace the block arguments with
+    SmallVector<Value> inputs;
+    for (auto arg : adaptor.getFirstCircuit().getArguments())
+      inputs.push_back(rewriter.create<smt::DeclareFunOp>(loc, arg.getType()));
+
+    // Inline the blocks
+    rewriter.mergeBlocks(&adaptor.getSecondCircuit().front(), solver.getBody(),
+                         inputs);
+    rewriter.setInsertionPointToEnd(solver.getBody());
+
+    // Create the universally quantified expression containing the LHS circuit.
+    // Free variables in the circuit's body become bound variables.
+    auto forallOp = rewriter.create<smt::ForallOp>(
+        op.getLoc(), TypeRange(lhsNonDetValues),
+        [&](OpBuilder &builder, auto, ValueRange args) -> Value {
+          Block *body = builder.getBlock();
+          rewriter.mergeBlocks(&adaptor.getFirstCircuit().front(), body,
+                               inputs);
+          rewriter.setInsertionPointToEnd(body);
+
+          // Replace non-deterministic values with the quantifier's bound
+          // variables
+          for (auto [freeVar, boundVar] : llvm::zip(lhsNonDetValues, args))
+            rewriter.replaceOp(freeVar.getDefiningOp(), boundVar);
+
+          // Compare the output values
+          SmallVector<Value> outputsDifferent;
+          createOutputsDifferentOps(firstOutputs, secondOutputs, loc, rewriter,
+                                    outputsDifferent);
+          if (outputsDifferent.size() == 1)
+            return outputsDifferent[0];
+          else
+            return rewriter.createOrFold<smt::OrOp>(loc, outputsDifferent);
+        });
+
+    rewriter.eraseOp(firstOutputs);
+    rewriter.eraseOp(secondOutputs);
+
+    // Assert the quantified expression
+    rewriter.setInsertionPointAfter(forallOp);
+    rewriter.create<smt::AssertOp>(op.getLoc(), forallOp.getResult());
+
+    // Check for satisfiability and report the result back.
+    replaceOpWithSatCheck(op, loc, rewriter, solver);
+    return success();
+  }
+};
+
 /// Lower a verif::BMCOp operation to an MLIR program that performs the bounded
 /// model check
 struct VerifBoundedModelCheckingOpConversion
@@ -534,8 +653,9 @@ void circt::populateVerifToSMTConversionPatterns(TypeConverter &converter,
                                                  Namespace &names,
                                                  bool risingClocksOnly) {
   patterns.add<VerifAssertOpConversion, VerifAssumeOpConversion,
-               LogicEquivalenceCheckingOpConversion>(converter,
-                                                     patterns.getContext());
+               LogicEquivalenceCheckingOpConversion,
+               RefinementCheckingOpConversion>(converter,
+                                               patterns.getContext());
   patterns.add<VerifBoundedModelCheckingOpConversion>(
       converter, patterns.getContext(), names, risingClocksOnly);
 }

--- a/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt-errors.mlir
@@ -168,3 +168,23 @@ func.func @wrong_initial_type() -> (i1) {
   }
   func.return %bmc : i1
 }
+
+// -----
+
+func.func @refines_non_primitive_free_var() -> () {
+  // expected-error @below {{failed to legalize operation 'verif.refines' that was explicitly marked illegal}}
+  verif.refines first {
+  ^bb0(%arg0: !smt.bv<4>):
+    // expected-error @below {{Uninterpreted function of non-primitive type cannot be converted.}}
+    %nondetar = smt.declare_fun : !smt.array<[!smt.bv<4> -> !smt.bv<32>]>
+    %sel = smt.array.select %nondetar[%arg0] : !smt.array<[!smt.bv<4> -> !smt.bv<32>]>
+    %cc = builtin.unrealized_conversion_cast %sel : !smt.bv<32> to i32
+    verif.yield %cc : i32
+  } second {
+  ^bb0(%arg0: !smt.bv<4>):
+    %const = smt.bv.constant #smt.bv<0> : !smt.bv<32>
+    %cc = builtin.unrealized_conversion_cast %const : !smt.bv<32> to i32
+    verif.yield %cc : i32
+  }
+  return
+}

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -267,6 +267,17 @@ func.func @test_refines_noreturn() -> () {
   ^bb0(%arg1: i32):
     verif.yield %arg1 : i32
   }
+
+  // CHECK-NOT: smt.solver
+  // CHECK:     return
+  verif.refines first {
+  ^bb0():
+    verif.yield
+  } second {
+  ^bb0():
+    verif.yield
+  }
+
   return
 }
 
@@ -298,6 +309,25 @@ func.func @test_refines_withreturn() -> i1 {
   } second {
   ^bb0(%arg1: i32):
     verif.yield %arg1 : i32
+  }
+  return %0 : i1
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_refines_trivialreturn
+
+// CHECK-NOT: smt.solver
+// CHECK: [[CST:%.+]] = arith.constant true
+// CHECK: return [[CST]] : i1
+
+func.func @test_refines_trivialreturn() -> i1 {
+  %0 = verif.refines : i1 first {
+  ^bb0():
+    verif.yield
+  } second {
+  ^bb0():
+    verif.yield
   }
   return %0 : i1
 }

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -247,19 +247,19 @@ func.func @large_initial_value() -> (i1) {
 
 // -----
 
-// CHECK-LABEL: func @test_refines
+// CHECK-LABEL: func @test_refines_noreturn
+
+// CHECK:     smt.solver() : () -> () {
+// CHECK:       [[V0:%.+]] = smt.declare_fun : !smt.bv<32>
+// CHECK:       [[V1:%.+]] = smt.distinct [[V0]], [[V0]] : !smt.bv<32>
+// CHECK:       smt.assert [[V1]]
+// CHECK:       smt.check sat {
+// CHECK-NEXT:   } unknown {
+// CHECK-NEXT:   } unsat {
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
 func.func @test_refines_noreturn() -> () {
-
-  // CHECK:     smt.solver() : () -> () {
-  // CHECK:       [[V0:%.+]] = smt.declare_fun : !smt.bv<32>
-  // CHECK:       [[V1:%.+]] = smt.distinct [[V0]], [[V0]] : !smt.bv<32>
-  // CHECK:       smt.assert [[V1]]
-  // CHECK:       smt.check sat {
-  // CHECK-NEXT:   } unknown {
-  // CHECK-NEXT:   } unsat {
-  // CHECK-NEXT:   }
-  // CHECK-NEXT: }
-
   verif.refines first {
   ^bb0(%arg1: i32):
     verif.yield %arg1 : i32
@@ -267,29 +267,31 @@ func.func @test_refines_noreturn() -> () {
   ^bb0(%arg1: i32):
     verif.yield %arg1 : i32
   }
-
   return
 }
 
 // -----
 
-func.func @test_refines_withreturn() -> i1 {
-  // CHECK:     [[RT0:%.+]] = smt.solver() : () -> i1 {
-  // CHECK:       [[V0:%.+]] = smt.declare_fun : !smt.bv<32>
-  // CHECK:       [[V1:%.+]] = smt.distinct [[V0]], [[V0]] : !smt.bv<32>
-  // CHECK:       smt.assert [[V1]]
-  // CHECK-DAG:   [[TRUE:%.+]]  = arith.constant true
-  // CHECK-DAG:   [[FALSE:%.+]] = arith.constant false
-  // CHECK:       [[V2:%.+]] = smt.check sat {
-  // CHECK-NEXT:     smt.yield [[FALSE]]
-  // CHECK-NEXT:   } unknown {
-  // CHECK-NEXT:     smt.yield [[FALSE]]
-  // CHECK-NEXT:   } unsat {
-  // CHECK-NEXT:     smt.yield [[TRUE]]
-  // CHECK-NEXT:   }
-  // CHECK-NEXT:   smt.yield [[V2]]
-  // CHECK-NEXT: }
+// CHECK-LABEL: func.func @test_refines_withreturn
 
+// CHECK:     [[RT0:%.+]] = smt.solver() : () -> i1 {
+// CHECK:       [[V0:%.+]] = smt.declare_fun : !smt.bv<32>
+// CHECK:       [[V1:%.+]] = smt.distinct [[V0]], [[V0]] : !smt.bv<32>
+// CHECK:       smt.assert [[V1]]
+// CHECK-DAG:   [[TRUE:%.+]]  = arith.constant true
+// CHECK-DAG:   [[FALSE:%.+]] = arith.constant false
+// CHECK:       [[V2:%.+]] = smt.check sat {
+// CHECK-NEXT:     smt.yield [[FALSE]]
+// CHECK-NEXT:   } unknown {
+// CHECK-NEXT:     smt.yield [[FALSE]]
+// CHECK-NEXT:   } unsat {
+// CHECK-NEXT:     smt.yield [[TRUE]]
+// CHECK-NEXT:   }
+// CHECK-NEXT:   smt.yield [[V2]]
+// CHECK-NEXT: }
+// CHECK: return [[RT0]] : i1
+
+func.func @test_refines_withreturn() -> i1 {
   %0 = verif.refines : i1 first {
   ^bb0(%arg1: i32):
     verif.yield %arg1 : i32
@@ -297,12 +299,14 @@ func.func @test_refines_withreturn() -> i1 {
   ^bb0(%arg1: i32):
     verif.yield %arg1 : i32
   }
-
-  // CHECK: return [[RT0]] : i1
   return %0 : i1
 }
 
 // -----
+
+// Source circuit non-deterministic
+
+// CHECK-LABEL: func.func @nondet_to_det
 
 // CHECK:     smt.solver()
 // CHECK:       [[BVCST:%.+]] = smt.bv.constant #smt.bv<0> : !smt.bv<32>
@@ -314,23 +318,27 @@ func.func @test_refines_withreturn() -> i1 {
 // CHECK-NEXT:  smt.assert [[ALLQ]]
 // CHECK-NEXT:  smt.check
 
-// First circuit non-deterministic
 
-verif.refines first {
-^bb0():
-  %nondet = smt.declare_fun : !smt.bv<32>
-  %cc = builtin.unrealized_conversion_cast %nondet : !smt.bv<32> to i32
-  verif.yield %cc : i32
-} second {
-^bb0():
-  %const = smt.bv.constant #smt.bv<0> : !smt.bv<32>
-  %cc = builtin.unrealized_conversion_cast %const : !smt.bv<32> to i32
-  verif.yield %cc : i32
+func.func @nondet_to_det() -> () {
+  verif.refines first {
+  ^bb0():
+    %nondet = smt.declare_fun : !smt.bv<32>
+    %cc = builtin.unrealized_conversion_cast %nondet : !smt.bv<32> to i32
+    verif.yield %cc : i32
+  } second {
+  ^bb0():
+    %const = smt.bv.constant #smt.bv<0> : !smt.bv<32>
+    %cc = builtin.unrealized_conversion_cast %const : !smt.bv<32> to i32
+    verif.yield %cc : i32
+  }
+  return
 }
 
 // -----
 
-// Second circuit non-deterministic
+// Target circuit non-deterministic
+
+// CHECK-LABEL: func.func @det_to_nondet
 
 // CHECK:     smt.solver()
 // CHECK-DAG:   [[BVCST:%.+]] = smt.bv.constant #smt.bv<0> : !smt.bv<32>
@@ -339,20 +347,25 @@ verif.refines first {
 // CHECK-NEXT:  smt.assert [[V0]]
 // CHECK-NEXT:  smt.check
 
-verif.refines first {
-^bb0():
-  %const = smt.bv.constant #smt.bv<0> : !smt.bv<32>
-  %cc = builtin.unrealized_conversion_cast %const : !smt.bv<32> to i32
-  verif.yield %cc : i32
-} second {
-^bb0():
-  %nondet = smt.declare_fun : !smt.bv<32>
-  %cc = builtin.unrealized_conversion_cast %nondet : !smt.bv<32> to i32
-  verif.yield %cc : i32
+func.func @det_to_nondet() -> () {
+  verif.refines first {
+  ^bb0():
+    %const = smt.bv.constant #smt.bv<0> : !smt.bv<32>
+    %cc = builtin.unrealized_conversion_cast %const : !smt.bv<32> to i32
+    verif.yield %cc : i32
+  } second {
+  ^bb0():
+    %nondet = smt.declare_fun : !smt.bv<32>
+    %cc = builtin.unrealized_conversion_cast %nondet : !smt.bv<32> to i32
+    verif.yield %cc : i32
+  }
+  return
 }
 // -----
 
 // Both circuits non-deterministic
+
+// CHECK-LABEL: func.func @nondet_to_nondet
 
 // CHECK:     smt.solver()
 // CHECK:       [[FREEVAR:%.+]] = smt.declare_fun : !smt.bv<32>
@@ -364,22 +377,26 @@ verif.refines first {
 // CHECK-NEXT:  smt.assert [[ALLQ]]
 // CHECK-NEXT:  smt.check
 
-verif.refines first {
-^bb0():
-  %nondet = smt.declare_fun : !smt.bv<32>
-  %cc = builtin.unrealized_conversion_cast %nondet : !smt.bv<32> to i32
-  verif.yield %cc : i32
-} second {
-^bb0():
-  %nondet = smt.declare_fun : !smt.bv<32>
-  %cc = builtin.unrealized_conversion_cast %nondet : !smt.bv<32> to i32
-  verif.yield %cc : i32
+func.func @nondet_to_nondet() -> () {
+  verif.refines first {
+  ^bb0():
+    %nondet = smt.declare_fun : !smt.bv<32>
+    %cc = builtin.unrealized_conversion_cast %nondet : !smt.bv<32> to i32
+    verif.yield %cc : i32
+  } second {
+  ^bb0():
+    %nondet = smt.declare_fun : !smt.bv<32>
+    %cc = builtin.unrealized_conversion_cast %nondet : !smt.bv<32> to i32
+    verif.yield %cc : i32
+  }
+  return
 }
 
 // -----
 
-// Multiple non-deterministic values in the first circuit
+// Multiple non-deterministic values in the source circuit
 
+// CHECK-LABEL: func.func @multi_nondet
 // CHECK:     smt.solver()
 // CHECK:       [[FREEVAR:%.+]] = smt.declare_fun : !smt.bv<32>
 // CHECK:       [[ALLQ:%.+]] = smt.forall {
@@ -392,16 +409,19 @@ verif.refines first {
 // CHECK-NEXT:  smt.assert [[ALLQ]]
 // CHECK-NEXT:  smt.check
 
-verif.refines first {
-^bb0():
-  %nondet0 = smt.declare_fun : !smt.bv<32>
-  %cc0 = builtin.unrealized_conversion_cast %nondet0 : !smt.bv<32> to i32
-  %nondet1 = smt.declare_fun : !smt.bv<32>
-  %cc1 = builtin.unrealized_conversion_cast %nondet1 : !smt.bv<32> to i32
-  verif.yield %cc0, %cc1 : i32, i32
-} second {
-^bb0():
-  %nondet = smt.declare_fun : !smt.bv<32>
-  %cc = builtin.unrealized_conversion_cast %nondet : !smt.bv<32> to i32
-  verif.yield %cc, %cc : i32, i32
+func.func @multi_nondet() -> () {
+  verif.refines first {
+  ^bb0():
+    %nondet0 = smt.declare_fun : !smt.bv<32>
+    %cc0 = builtin.unrealized_conversion_cast %nondet0 : !smt.bv<32> to i32
+    %nondet1 = smt.declare_fun : !smt.bv<32>
+    %cc1 = builtin.unrealized_conversion_cast %nondet1 : !smt.bv<32> to i32
+    verif.yield %cc0, %cc1 : i32, i32
+  } second {
+  ^bb0():
+    %nondet = smt.declare_fun : !smt.bv<32>
+    %cc = builtin.unrealized_conversion_cast %nondet : !smt.bv<32> to i32
+    verif.yield %cc, %cc : i32, i32
+  }
+  return
 }


### PR DESCRIPTION
Implement a conversion pattern for the `verif.refines` operation to the SMT dialect.

Following the current definition of the `RefinmentCheckingOp`, the second (target) circuit is a refinement of the first (source) circuit iff for any given input assignment the set of possible outputs of the target circuit is a subset of the source circuit's possible outputs. The conversion assumes all `smt.declare_fun` operations in the circuit body to be sources of non-determinism, as they are created by the lowering of the division (by zero) and (out of bounds) array get operations. The expression we are checking for is:
_For all_ inputs: _For all_ non-deterministic choices in the target circuit: _Exists_ a non-deterministic choice in the source circuit leading to identical outputs?

Since we are trying to find a counter example, we produce the inverted expression:
_Exists_ an input and _exists_ a non-deterministic choice in the target circuit so that _for all_ non-deterministic choices in the source circuit the outputs are _not_ equal.

As we are checking for the existence of a satisfying interpretation, the outer existential quantifiers don't need to be modeled explicitly. Thus, the free variables in the target circuit stay free variables in the miter. If there are _no_ free variables in the source circuit the refinement check becomes an equivalence check. If there _are_ free variables in  the source circuit, they are bound by the universal quantifier.

This should generally match the way Alive2 handles non-determinism.