### PR TITLE
[circt-opt][FSMToSV] Fix bug of operations not being cloned in transition region in FSMToSV Conversion

### DIFF
--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -670,8 +670,8 @@ MachineOpConverter::convertState(StateOp state) {
     if (auto transOp = dyn_cast<TransitionOp>(op)) {
       transitions.push_back(transOp);
     } else {
-      // Clone operations which are inside `transitions` region but outside `guard`
-      // region.
+      // Clone operations which are inside `transitions` region but outside
+      // `guard` region.
       auto opClone = b.clone(op);
       for (auto [i, res] : llvm::enumerate(op.getResults()))
         res.replaceAllUsesWith(opClone->getResult(i));

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -664,7 +664,17 @@ MachineOpConverter::convertState(StateOp state) {
     OutputOp outputOp = cast<fsm::OutputOp>(*outputOpRes);
     res.outputs = outputOp.getOperands(); // 3.2
   }
-
+  // Clone operations which are inside `transitions` region but outside `guard` region.
+  SmallVector<TransitionOp> transitions;
+  for (auto &op : state.getTransitions().getOps()) {
+    if (auto transOp = dyn_cast<TransitionOp>(op)) {
+      transitions.push_back(transOp);
+    } else {
+      auto opClone = b.clone(op);
+      for (auto [i, res] : llvm::enumerate(op.getResults()))
+        res.replaceAllUsesWith(opClone->getResult(i));
+    }
+  }
   auto transitions = llvm::SmallVector<TransitionOp>(
       state.getTransitions().getOps<TransitionOp>());
   // 3.3, 3.4) Convert the transitions and record the next-state value

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -664,13 +664,14 @@ MachineOpConverter::convertState(StateOp state) {
     OutputOp outputOp = cast<fsm::OutputOp>(*outputOpRes);
     res.outputs = outputOp.getOperands(); // 3.2
   }
-  // Clone operations which are inside `transitions` region but outside `guard`
-  // region.
+
   SmallVector<TransitionOp> transitions;
   for (auto &op : state.getTransitions().getOps()) {
     if (auto transOp = dyn_cast<TransitionOp>(op)) {
       transitions.push_back(transOp);
     } else {
+      // Clone operations which are inside `transitions` region but outside `guard`
+      // region.
       auto opClone = b.clone(op);
       for (auto [i, res] : llvm::enumerate(op.getResults()))
         res.replaceAllUsesWith(opClone->getResult(i));

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -664,19 +664,17 @@ MachineOpConverter::convertState(StateOp state) {
     OutputOp outputOp = cast<fsm::OutputOp>(*outputOpRes);
     res.outputs = outputOp.getOperands(); // 3.2
   }
-  // Clone operations which are inside `transitions` region but outside `guard` region.
   SmallVector<TransitionOp> transitions;
   for (auto &op : state.getTransitions().getOps()) {
     if (auto transOp = dyn_cast<TransitionOp>(op)) {
       transitions.push_back(transOp);
     } else {
+      // Clone operations which are inside `transitions` region but outside `guard` region.
       auto opClone = b.clone(op);
       for (auto [i, res] : llvm::enumerate(op.getResults()))
         res.replaceAllUsesWith(opClone->getResult(i));
     }
   }
-  auto transitions = llvm::SmallVector<TransitionOp>(
-      state.getTransitions().getOps<TransitionOp>());
   // 3.3, 3.4) Convert the transitions and record the next-state value
   // derived from the transitions being selected in a priority-encoded manner.
   auto nextStateRes = convertTransitions(state, transitions);

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -664,12 +664,13 @@ MachineOpConverter::convertState(StateOp state) {
     OutputOp outputOp = cast<fsm::OutputOp>(*outputOpRes);
     res.outputs = outputOp.getOperands(); // 3.2
   }
+  // Clone operations which are inside `transitions` region but outside `guard`
+  // region.
   SmallVector<TransitionOp> transitions;
   for (auto &op : state.getTransitions().getOps()) {
     if (auto transOp = dyn_cast<TransitionOp>(op)) {
       transitions.push_back(transOp);
     } else {
-      // Clone operations which are inside `transitions` region but outside `guard` region.
       auto opClone = b.clone(op);
       for (auto [i, res] : llvm::enumerate(op.getResults()))
         res.replaceAllUsesWith(opClone->getResult(i));

--- a/test/Conversion/FSMToSV/test_basic.mlir
+++ b/test/Conversion/FSMToSV/test_basic.mlir
@@ -192,24 +192,42 @@ module {
   }
 }
 
+
+// -----
+
 // Test the usage of operations defined inside `transition` region but outside `guard region`
+// CHECK-LABEL: hw.module @OpsInTransition(in %in0 : i1, out out0 : i1, in %clk : !seq.clock, in %rst : i1) attributes {emit.fragments = [@FSM_ENUM_TYPEDEFS]} {
+// CHECK:   sv.alwayscomb {
+// CHECK-NEXT:     sv.case %state_reg : !hw.typealias<@fsm_enum_typedecls::@OpsInTransition_state_t, !hw.enum<State1, State2>>
+// CHECK-NEXT:     case State1: {
+// CHECK-NEXT:       sv.bpassign %state_next, %0 : !hw.typealias<@fsm_enum_typedecls::@OpsInTransition_state_t, !hw.enum<State1, State2>>
+// CHECK-NEXT:       sv.bpassign %output_0, %false_0 : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     case State2: {
+// CHECK-NEXT:       sv.bpassign %state_next, %3 : !hw.typealias<@fsm_enum_typedecls::@OpsInTransition_state_t, !hw.enum<State1, State2>>
+// CHECK-NEXT:       sv.bpassign %output_0, %false : i1
+// CHECK-NEXT:     }
+// CHECK-NEXT:     default: {
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   %4 = sv.read_inout %output_0 : !hw.inout<i1>
+// CHECK-NEXT:   hw.output %4 : i1
+// CHECK-NEXT: }
+
 module {
-  fsm.machine @mbx_fsm(%arg0: i1) -> (i1) attributes {initialState = "MbxIdle"} {
+  fsm.machine @OpsInTransition(%arg0: i1) -> (i1) attributes {initialState = "State1"} {
     %false = hw.constant false
-    fsm.state @MbxIdle output {
+    fsm.state @State1 output {
       %false_0 = hw.constant false
       fsm.output %false_0: i1
     }
-    fsm.state @MbxWaitFinalWord output {
+    fsm.state @State2 output {
       fsm.output %false : i1
     } transitions {
       %false_0 = hw.constant false
-      fsm.transition @MbxError guard {
+      fsm.transition @State1 guard {
         fsm.return %false_0
       }
-    }
-    fsm.state @MbxError output {
-      fsm.output %false : i1
     }
   }
 }

--- a/test/Conversion/FSMToSV/test_basic.mlir
+++ b/test/Conversion/FSMToSV/test_basic.mlir
@@ -196,38 +196,33 @@ module {
 // -----
 
 // Test the usage of operations defined inside `transition` region but outside `guard region`
-// CHECK-LABEL: hw.module @OpsInTransition(in %in0 : i1, out out0 : i1, in %clk : !seq.clock, in %rst : i1) attributes {emit.fragments = [@FSM_ENUM_TYPEDEFS]} {
+// CHECK-LABEL:  hw.module @OpsInTransition(in %clk : !seq.clock, in %rst : i1) attributes {emit.fragments = [@FSM_ENUM_TYPEDEFS]} {
 // CHECK:   sv.alwayscomb {
-// CHECK-NEXT:     sv.case %state_reg : !hw.typealias<@fsm_enum_typedecls::@OpsInTransition_state_t, !hw.enum<State1, State2>>
+// CHECK-NEXT:     sv.case %[[R:.*]] : !hw.typealias<@fsm_enum_typedecls::@OpsInTransition_state_t, !hw.enum<State1, State2>>
 // CHECK-NEXT:     case State1: {
-// CHECK-NEXT:       sv.bpassign %state_next, %0 : !hw.typealias<@fsm_enum_typedecls::@OpsInTransition_state_t, !hw.enum<State1, State2>>
-// CHECK-NEXT:       sv.bpassign %output_0, %false_0 : i1
+// CHECK-NEXT:       sv.bpassign %[[STATE_NEXT:.*]], %[[B:.*]] : !hw.typealias<@fsm_enum_typedecls::@OpsInTransition_state_t, !hw.enum<State1, State2>>
 // CHECK-NEXT:     }
 // CHECK-NEXT:     case State2: {
-// CHECK-NEXT:       sv.bpassign %state_next, %3 : !hw.typealias<@fsm_enum_typedecls::@OpsInTransition_state_t, !hw.enum<State1, State2>>
-// CHECK-NEXT:       sv.bpassign %output_0, %false : i1
+// CHECK-NEXT:       sv.bpassign %[[STATE_NEXT:.*]], %[[A:.*]] : !hw.typealias<@fsm_enum_typedecls::@OpsInTransition_state_t, !hw.enum<State1, State2>>
 // CHECK-NEXT:     }
 // CHECK-NEXT:     default: {
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   %4 = sv.read_inout %output_0 : !hw.inout<i1>
-// CHECK-NEXT:   hw.output %4 : i1
+// CHECK-NEXT:   hw.output
 // CHECK-NEXT: }
 
 module {
-  fsm.machine @OpsInTransition(%arg0: i1) -> (i1) attributes {initialState = "State1"} {
-    %false = hw.constant false
+  fsm.machine @OpsInTransition() -> () attributes {initialState = "State1"} {
     fsm.state @State1 output {
-      %false_0 = hw.constant false
-      fsm.output %false_0: i1
+      fsm.output
+    } transitions {
+      %false = hw.constant false
+      fsm.transition @State1 guard {
+        fsm.return %false
+      }
     }
     fsm.state @State2 output {
-      fsm.output %false : i1
-    } transitions {
-      %false_0 = hw.constant false
-      fsm.transition @State1 guard {
-        fsm.return %false_0
-      }
+      fsm.output
     }
   }
 }

--- a/test/Conversion/FSMToSV/test_basic.mlir
+++ b/test/Conversion/FSMToSV/test_basic.mlir
@@ -191,3 +191,25 @@ module {
     }
   }
 }
+
+// Test the usage of operations defined inside `transition` region but outside `guard region`
+module {
+  fsm.machine @mbx_fsm(%arg0: i1) -> (i1) attributes {initialState = "MbxIdle"} {
+    %false = hw.constant false
+    fsm.state @MbxIdle output {
+      %false_0 = hw.constant false
+      fsm.output %false_0: i1
+    }
+    fsm.state @MbxWaitFinalWord output {
+      fsm.output %false : i1
+    } transitions {
+      %false_0 = hw.constant false
+      fsm.transition @MbxError guard {
+        fsm.return %false_0
+      }
+    }
+    fsm.state @MbxError output {
+      fsm.output %false : i1
+    }
+  }
+}


### PR DESCRIPTION
Previously, the conversion FSMToSV would crash on operations that were in the transition region but outside the guard region.

Example: Consider the following program in the FSM dialect of CIRCT

```mlir
module {
  fsm.machine @OpsInTransition(%arg0: i1) -> (i1) attributes {initialState = "State1"} {
    %false = hw.constant false
    fsm.state @State1 output {
      %false_0 = hw.constant false
      fsm.output %false_0: i1
    }
    fsm.state @State2 output {
      fsm.output %false : i1
    } transitions {
      %false_0 = hw.constant false
      fsm.transition @State1 guard {
        fsm.return %false_0
      }
    }
  }
}
```



behavior before:

```bash
ak2518@autobot:/local/scratch/ak2518/circt$ circt-opt --convert-fsm-to-sv --split-input-file ../RTL-to-FSM-extractor/weird.mlir
within split at ../RTL-to-FSM-extractor/weird.mlir:1 offset :11:18: error: 'hw.constant' op operation destroyed but still has uses
      %false_0 = hw.constant false
                 ^
within split at ../RTL-to-FSM-extractor/weird.mlir:1 offset :11:18: note: see current operation: %0 = "hw.constant"() <{value = false}> : () -> i1
within split at ../RTL-to-FSM-extractor/weird.mlir:1 offset :12:7: note: - use: %11 = "comb.mux"(<<UNKNOWN SSA VALUE>>, %2, %5) : (i1, !hw.typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>, !hw.typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>) -> !hw.typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>

      fsm.transition @State1 guard {
      ^
LLVM ERROR: operation destroyed but still has uses
PLEASE submit a bug report to https://github.com/llvm/circt and include the crash backtrace.
Stack dump:
0.      Program arguments: circt-opt --convert-fsm-to-sv --split-input-file ../RTL-to-FSM-extractor/weird.mlir
 #0 0x00005c56b3fd3a82 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) /local/scratch/ak2518/circt/llvm/llvm/lib/Support/Unix/Signals.inc:834:22
 #1 0x00005c56b3fd3f0b PrintStackTraceSignalHandler(void*) /local/scratch/ak2518/circt/llvm/llvm/lib/Support/Unix/Signals.inc:918:1
 #2 0x00005c56b3fd107b llvm::sys::RunSignalHandlers() /local/scratch/ak2518/circt/llvm/llvm/lib/Support/Signals.cpp:104:20
 #3 0x00005c56b3fd32bf SignalHandler(int, siginfo_t*, void*) /local/scratch/ak2518/circt/llvm/llvm/lib/Support/Unix/Signals.inc:426:14
 #4 0x0000713c28445330 (/lib/x86_64-linux-gnu/libc.so.6+0x45330)
 #5 0x0000713c2849eb2c __pthread_kill_implementation ./nptl/pthread_kill.c:44:76
 #6 0x0000713c2849eb2c __pthread_kill_internal ./nptl/pthread_kill.c:78:10
 #7 0x0000713c2849eb2c pthread_kill ./nptl/pthread_kill.c:89:10
 #8 0x0000713c2844527e raise ./signal/../sysdeps/posix/raise.c:27:6
 #9 0x0000713c284288ff abort ./stdlib/abort.c:81:7
#10 0x00005c56b3f3d6fa llvm::report_fatal_error(llvm::Twine const&, bool) /local/scratch/ak2518/circt/llvm/llvm/lib/Support/ErrorHandling.cpp:137:9
#11 0x00005c56b3f3d4d5 llvm::report_fatal_error(llvm::StringRef, bool) /local/scratch/ak2518/circt/llvm/llvm/lib/Support/ErrorHandling.cpp:99:68
#12 0x00005c56b6fac496 mlir::Operation::~Operation() /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Operation.cpp:192:7
#13 0x00005c56b6fac670 mlir::Operation::destroy() /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Operation.cpp:213:7
#14 0x00005c56b6fad90e llvm::ilist_traits<mlir::Operation>::deleteNode(mlir::Operation*) /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Operation.cpp:492:1
#15 0x00005c56b59726b9 llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation>>::erase(llvm::ilist_iterator<llvm::ilist_detail::node_options<mlir::Operation, true, false, void, false, void>, false, false>) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:206:12
#16 0x00005c56b5971578 llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation>>::pop_back() /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:258:3
#17 0x00005c56b597124a mlir::Block::clear() /local/scratch/ak2518/circt/llvm/mlir/include/mlir/IR/Block.h:44:18
#18 0x00005c56b6e0770a mlir::Block::~Block() /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Block.cpp:23:28
#19 0x00005c56b4286600 llvm::ilist_alloc_traits<mlir::Block>::deleteNode(mlir::Block*) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:42:39
#20 0x00005c56b4285eb1 llvm::iplist_impl<llvm::simple_ilist<mlir::Block>, llvm::ilist_traits<mlir::Block>>::erase(llvm::ilist_iterator<llvm::ilist_detail::node_options<mlir::Block, true, false, void, false, void>, false, false>) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:206:12
#21 0x00005c56b4285541 llvm::iplist_impl<llvm::simple_ilist<mlir::Block>, llvm::ilist_traits<mlir::Block>>::erase(llvm::ilist_iterator<llvm::ilist_detail::node_options<mlir::Block, true, false, void, false, void>, false, false>, llvm::ilist_iterator<llvm::ilist_detail::node_options<mlir::Block, true, false, void, false, void>, false, false>) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:242:20
#22 0x00005c56b42846ff llvm::iplist_impl<llvm::simple_ilist<mlir::Block>, llvm::ilist_traits<mlir::Block>>::clear() /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:246:41
#23 0x00005c56b6fd32de llvm::iplist_impl<llvm::simple_ilist<mlir::Block>, llvm::ilist_traits<mlir::Block>>::~iplist_impl() /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:147:29
#24 0x00005c56b6fd303c llvm::iplist<mlir::Block>::~iplist() /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:327:7
#25 0x00005c56b6fd1a72 mlir::Region::~Region() /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Region.cpp:20:1
#26 0x00005c56b6fac5c3 mlir::Operation::~Operation() /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Operation.cpp:200:3
#27 0x00005c56b6fac670 mlir::Operation::destroy() /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Operation.cpp:213:7
#28 0x00005c56b6fad90e llvm::ilist_traits<mlir::Operation>::deleteNode(mlir::Operation*) /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Operation.cpp:492:1
#29 0x00005c56b59726b9 llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation>>::erase(llvm::ilist_iterator<llvm::ilist_detail::node_options<mlir::Operation, true, false, void, false, void>, false, false>) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:206:12
#30 0x00005c56b5971578 llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation>>::pop_back() /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:258:3
#31 0x00005c56b597124a mlir::Block::clear() /local/scratch/ak2518/circt/llvm/mlir/include/mlir/IR/Block.h:44:18
#32 0x00005c56b6e0770a mlir::Block::~Block() /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Block.cpp:23:28
#33 0x00005c56b4286600 llvm::ilist_alloc_traits<mlir::Block>::deleteNode(mlir::Block*) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:42:39
#34 0x00005c56b4285eb1 llvm::iplist_impl<llvm::simple_ilist<mlir::Block>, llvm::ilist_traits<mlir::Block>>::erase(llvm::ilist_iterator<llvm::ilist_detail::node_options<mlir::Block, true, false, void, false, void>, false, false>) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:206:12
#35 0x00005c56b4285541 llvm::iplist_impl<llvm::simple_ilist<mlir::Block>, llvm::ilist_traits<mlir::Block>>::erase(llvm::ilist_iterator<llvm::ilist_detail::node_options<mlir::Block, true, false, void, false, void>, false, false>, llvm::ilist_iterator<llvm::ilist_detail::node_options<mlir::Block, true, false, void, false, void>, false, false>) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:242:20
#36 0x00005c56b42846ff llvm::iplist_impl<llvm::simple_ilist<mlir::Block>, llvm::ilist_traits<mlir::Block>>::clear() /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:246:41
#37 0x00005c56b6fd32de llvm::iplist_impl<llvm::simple_ilist<mlir::Block>, llvm::ilist_traits<mlir::Block>>::~iplist_impl() /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:147:29
#38 0x00005c56b6fd303c llvm::iplist<mlir::Block>::~iplist() /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:327:7
#39 0x00005c56b6fd1a72 mlir::Region::~Region() /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Region.cpp:20:1
#40 0x00005c56b6fac5c3 mlir::Operation::~Operation() /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Operation.cpp:200:3
#41 0x00005c56b6fac670 mlir::Operation::destroy() /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Operation.cpp:213:7
#42 0x00005c56b6fad90e llvm::ilist_traits<mlir::Operation>::deleteNode(mlir::Operation*) /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Operation.cpp:492:1
#43 0x00005c56b59726b9 llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation>>::erase(llvm::ilist_iterator<llvm::ilist_detail::node_options<mlir::Operation, true, false, void, false, void>, false, false>) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:206:12
#44 0x00005c56b6fb7665 llvm::iplist_impl<llvm::simple_ilist<mlir::Operation>, llvm::ilist_traits<mlir::Operation>>::erase(mlir::Operation*) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/ilist.h:209:60
#45 0x00005c56b6fadaeb mlir::Operation::erase() /local/scratch/ak2518/circt/llvm/mlir/lib/IR/Operation.cpp:543:1
#46 0x00005c56b42a5949 mlir::OpState::erase() /local/scratch/ak2518/circt/llvm/mlir/include/mlir/IR/OpDefinition.h:135:34
#47 0x00005c56b684bf3b (anonymous namespace)::MachineOpConverter::dispatch() /local/scratch/ak2518/circt/lib/Conversion/FSMToSV/FSMToSV.cpp:591:17
#48 0x00005c56b684cdec (anonymous namespace)::FSMToSVPass::runOnOperation() /local/scratch/ak2518/circt/lib/Conversion/FSMToSV/FSMToSV.cpp:727:15
#49 0x00005c56b8d2918f mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int)::'lambda'()::operator()() const /local/scratch/ak2518/circt/llvm/mlir/lib/Pass/Pass.cpp:554:22
#50 0x00005c56b8d2cf2a void llvm::function_ref<void ()>::callback_fn<mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int)::'lambda'()>(long) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/STLFunctionalExtras.h:47:40
#51 0x00005c56b3f104c4 llvm::function_ref<void ()>::operator()() const /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/STLFunctionalExtras.h:69:62
#52 0x00005c56b8d33cbb void mlir::MLIRContext::executeAction<mlir::PassExecutionAction, mlir::Pass&>(llvm::function_ref<void ()>, llvm::ArrayRef<mlir::IRUnit>, mlir::Pass&) /local/scratch/ak2518/circt/llvm/mlir/include/mlir/IR/MLIRContext.h:281:3
#53 0x00005c56b8d295ba mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) /local/scratch/ak2518/circt/llvm/mlir/lib/Pass/Pass.cpp:559:23
#54 0x00005c56b8d29898 mlir::detail::OpToOpPassAdaptor::runPipeline(mlir::OpPassManager&, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) /local/scratch/ak2518/circt/llvm/mlir/lib/Pass/Pass.cpp:619:15
#55 0x00005c56b8d2b762 mlir::PassManager::runPasses(mlir::Operation*, mlir::AnalysisManager) /local/scratch/ak2518/circt/llvm/mlir/lib/Pass/Pass.cpp:933:40
#56 0x00005c56b8d2b5b9 mlir::PassManager::run(mlir::Operation*) /local/scratch/ak2518/circt/llvm/mlir/lib/Pass/Pass.cpp:913:69
#57 0x00005c56b79ddd58 performActions(llvm::raw_ostream&, std::shared_ptr<llvm::SourceMgr> const&, mlir::MLIRContext*, mlir::MlirOptMainConfig const&) /local/scratch/ak2518/circt/llvm/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:477:13
#58 0x00005c56b79de47f processBuffer(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, mlir::MlirOptMainConfig const&, mlir::DialectRegistry&, llvm::ThreadPoolInterface*) /local/scratch/ak2518/circt/llvm/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:545:26
#59 0x00005c56b79dea55 mlir::MlirOptMain(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, mlir::DialectRegistry&, mlir::MlirOptMainConfig const&)::'lambda'(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)::operator()(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&) const /local/scratch/ak2518/circt/llvm/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:629:25
#60 0x00005c56b79dfc45 llvm::LogicalResult llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>::callback_fn<mlir::MlirOptMain(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, mlir::DialectRegistry&, mlir::MlirOptMainConfig const&)::'lambda'(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>(long, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/STLFunctionalExtras.h:46:52
#61 0x00005c56b7a41101 llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>::operator()(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&) const /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/STLFunctionalExtras.h:69:12
#62 0x00005c56b7a40856 mlir::splitAndProcessBuffer(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>, llvm::raw_ostream&, llvm::StringRef, llvm::StringRef)::'lambda'(llvm::StringRef)::operator()(llvm::StringRef) const /local/scratch/ak2518/circt/llvm/mlir/lib/Support/ToolUtilities.cpp:86:15
#63 0x00005c56b7a4104a void llvm::interleave<llvm::StringRef const*, mlir::splitAndProcessBuffer(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>, llvm::raw_ostream&, llvm::StringRef, llvm::StringRef)::'lambda'(llvm::StringRef), void llvm::interleave<llvm::SmallVector<llvm::StringRef, 8u>, mlir::splitAndProcessBuffer(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>, llvm::raw_ostream&, llvm::StringRef, llvm::StringRef)::'lambda'(llvm::StringRef), llvm::raw_ostream, llvm::StringRef>(llvm::SmallVector<llvm::StringRef, 8u> const&, llvm::raw_ostream&, mlir::splitAndProcessBuffer(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>, llvm::raw_ostream&, llvm::StringRef, llvm::StringRef)::'lambda'(llvm::StringRef), llvm::StringRef const&)::'lambda'(), void>(llvm::SmallVector<llvm::StringRef, 8u>, llvm::SmallVector<llvm::StringRef, 8u>, mlir::splitAndProcessBuffer(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>, llvm::raw_ostream&, llvm::StringRef, llvm::StringRef)::'lambda'(llvm::StringRef), llvm::raw_ostream) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/STLExtras.h:2217:3
#64 0x00005c56b7a40ffc void llvm::interleave<llvm::SmallVector<llvm::StringRef, 8u>, mlir::splitAndProcessBuffer(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>, llvm::raw_ostream&, llvm::StringRef, llvm::StringRef)::'lambda'(llvm::StringRef), llvm::raw_ostream, llvm::StringRef>(llvm::SmallVector<llvm::StringRef, 8u> const&, llvm::raw_ostream&, mlir::splitAndProcessBuffer(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>, llvm::raw_ostream&, llvm::StringRef, llvm::StringRef)::'lambda'(llvm::StringRef), llvm::StringRef const&) /local/scratch/ak2518/circt/llvm/llvm/include/llvm/ADT/STLExtras.h:2238:13
#65 0x00005c56b7a40ed7 mlir::splitAndProcessBuffer(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<llvm::LogicalResult (std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>, llvm::raw_ostream&, llvm::StringRef, llvm::StringRef) /local/scratch/ak2518/circt/llvm/mlir/lib/Support/ToolUtilities.cpp:89:19
#66 0x00005c56b79debee mlir::MlirOptMain(llvm::raw_ostream&, std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer>>, mlir::DialectRegistry&, mlir::MlirOptMainConfig const&) /local/scratch/ak2518/circt/llvm/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:632:31
#67 0x00005c56b79deee7 mlir::MlirOptMain(int, char**, llvm::StringRef, llvm::StringRef, mlir::DialectRegistry&) /local/scratch/ak2518/circt/llvm/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:673:13
#68 0x00005c56b79df0de mlir::MlirOptMain(int, char**, llvm::StringRef, mlir::DialectRegistry&) /local/scratch/ak2518/circt/llvm/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp:689:21
#69 0x00005c56b3e709cd main /local/scratch/ak2518/circt/tools/circt-opt/circt-opt.cpp:84:0
#70 0x0000713c2842a1ca __libc_start_call_main ./csu/../sysdeps/nptl/libc_start_call_main.h:74:3
#71 0x0000713c2842a28b call_init ./csu/../csu/libc-start.c:128:20
#72 0x0000713c2842a28b __libc_start_main ./csu/../csu/libc-start.c:347:5
#73 0x00005c56b3e70515 _start (/local/scratch/ak2518/circt/build/bin/circt-opt+0x1801515)
Aborted (core dumped)
```



Behavior after:

```
ak2518@autobot:/local/scratch/ak2518/circt$ circt-opt --convert-fsm-to-sv --split-input-file ../RTL-to-FSM-extractor/weird.mlir
module {
  hw.type_scope @fsm_enum_typedecls {
    hw.typedecl @mbx_fsm_state_t : !hw.enum<State1, State2>
  }
  emit.file "fsm_enum_typedefs.sv" {
    emit.ref @fsm_enum_typedecls
  }
  emit.fragment @FSM_ENUM_TYPEDEFS {
    sv.verbatim "`include \22fsm_enum_typedefs.sv\22"
  }
  hw.module @mbx_fsm(in %in0 : i1, out out0 : i1, in %clk : !seq.clock, in %rst : i1) attributes {emit.fragments = [@FSM_ENUM_TYPEDEFS]} {
    %State1 = hw.enum.constant State1 : !hw.typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>
    %to_State1 = sv.reg sym @State1 : !hw.inout<typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>>
    sv.assign %to_State1, %State1 : !hw.typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>
    %0 = sv.read_inout %to_State1 : !hw.inout<typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>>
    %State2 = hw.enum.constant State2 : !hw.typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>
    %to_State2 = sv.reg sym @State2 : !hw.inout<typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>>
    sv.assign %to_State2, %State2 : !hw.typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>
    %1 = sv.read_inout %to_State2 : !hw.inout<typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>>
    %state_next = sv.reg : !hw.inout<typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>>
    %2 = sv.read_inout %state_next : !hw.inout<typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>>
    %state_reg = seq.compreg sym @state_reg %2, %clk reset %rst, %0 : !hw.typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>
    %false = hw.constant false
    %false_0 = hw.constant false
    %false_1 = hw.constant false
    %3 = comb.mux %false_1, %0, %1 : !hw.typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>
    %output_0 = sv.reg : !hw.inout<i1>
    sv.alwayscomb {
      sv.case %state_reg : !hw.typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>
      case State1: {
        sv.bpassign %state_next, %0 : !hw.typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>
        sv.bpassign %output_0, %false_0 : i1
      }
      case State2: {
        sv.bpassign %state_next, %3 : !hw.typealias<@fsm_enum_typedecls::@mbx_fsm_state_t, !hw.enum<State1, State2>>
        sv.bpassign %output_0, %false : i1
      }
      default: {
      }
    }
    %4 = sv.read_inout %output_0 : !hw.inout<i1>
    hw.output %4 : i1
  }
}
```

This PR fixes this bug and adds a test with filecheck.



