### PR TITLE
[AIG][NFC] Add a module to OutputPort data structure and refactor the name handling

### DIFF
--- a/include/circt/Dialect/AIG/Analysis/LongestPathAnalysis.h
+++ b/include/circt/Dialect/AIG/Analysis/LongestPathAnalysis.h
@@ -53,6 +53,8 @@ struct Object {
   Object &prependPaths(circt::igraph::InstancePathCache &cache,
                        circt::igraph::InstancePath path);
 
+  StringAttr getName() const;
+
   circt::igraph::InstancePath instancePath;
   Value value;
   size_t bitPos;
@@ -116,7 +118,7 @@ public:
   // FanOut can be either an internal circuit object or a module output port
   // This flexibility allows representing both closed paths
   // (register-to-register) and open paths (register-to-output) in a unified way
-  using OutputPort = std::pair<size_t, size_t>;
+  using OutputPort = std::tuple<hw::HWModuleOp, size_t, size_t>;
   using FanOutType = std::variant<Object, OutputPort>;
 
   // Constructor for paths with Object fanout (internal circuit nodes)
@@ -309,4 +311,5 @@ struct DenseMapInfo<circt::aig::Object> {
   }
 };
 } // namespace llvm
+
 #endif // CIRCT_ANALYSIS_AIG_ANALYSIS_H


### PR DESCRIPTION
This is a preparation commit for subsequent AIG python binding PR. 

 - Modified OutputPort type from pair to tuple to include module reference
 - Added getName() method to Object class for consistent name access
 - Updated JSON serialization to handle the new OutputPort structure