### PR TITLE
[VerifToSMT] Fix lowering of no output, no result LEC op

### DIFF
--- a/lib/Conversion/VerifToSMT/VerifToSMT.cpp
+++ b/lib/Conversion/VerifToSMT/VerifToSMT.cpp
@@ -150,18 +150,23 @@ struct LogicEquivalenceCheckingOpConversion
     auto *firstOutputs = adaptor.getFirstCircuit().front().getTerminator();
     auto *secondOutputs = adaptor.getSecondCircuit().front().getTerminator();
 
+    auto hasNoResult = op.getNumResults() == 0;
+
     if (firstOutputs->getNumOperands() == 0) {
       // Trivially equivalent
-      Value trueVal =
-          rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(true));
-      rewriter.replaceOp(op, trueVal);
+      if (hasNoResult) {
+        rewriter.eraseOp(op);
+      } else {
+        Value trueVal =
+            rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(true));
+        rewriter.replaceOp(op, trueVal);
+      }
       return success();
     }
 
     // Solver will only return a result when it is used to check the returned
     // value.
     smt::SolverOp solver;
-    auto hasNoResult = op.getNumResults() == 0;
     if (hasNoResult)
       solver = rewriter.create<smt::SolverOp>(loc, TypeRange{}, ValueRange{});
     else

--- a/test/Conversion/VerifToSMT/verif-to-smt.mlir
+++ b/test/Conversion/VerifToSMT/verif-to-smt.mlir
@@ -85,6 +85,14 @@ func.func @test_lec(%arg0: !smt.bv<1>) -> (i1, i1, i1) {
 
   verif.lec first {
   ^bb0(%arg1: i32):
+    verif.yield
+  } second {
+  ^bb0(%arg1: i32):
+    verif.yield
+  }
+
+  verif.lec first {
+  ^bb0(%arg1: i32):
     verif.yield %arg1 : i32
   } second {
   ^bb0(%arg2: i32):


### PR DESCRIPTION
#8701 made the result of the `verif.lec` operation optional. In case of a trivial `LogicEquivalenceCheckingOp` without any outputs, VerifToSMT would always attempt to replace the result without checking that it exists.

Thanks to @maerhart for spotting this.