### PR TITLE
[HWToSMT] Add ArrayInject lowering to HWToSMT

### DIFF
--- a/test/Conversion/HWToSMT/hw-to-smt.mlir
+++ b/test/Conversion/HWToSMT/hw-to-smt.mlir
@@ -25,3 +25,15 @@ hw.module @modB(in %in: i32, out out: i32) {
   // CHECK-NEXT: return [[V]] : !smt.bv<32>
   hw.output %0 : i32
 }
+
+// CHECK-LABEL: func.func @inject
+// CHECK-SAME: (%[[ARR:.+]]: !smt.array<[!smt.bv<2> -> !smt.bv<8>]>, %[[IDX:.+]]: !smt.bv<2>, %[[VAL:.+]]: !smt.bv<8>)
+hw.module @inject(in %arr: !hw.array<3xi8>, in %index: i2, in %v: i8, out out: !hw.array<3xi8>) {
+  // CHECK-NEXT: %[[C2:.+]] = smt.bv.constant #smt.bv<-2> : !smt.bv<2>
+  // CHECK-NEXT: %[[CMP:.+]] = smt.bv.cmp ule %[[IDX]], %[[C2]] : !smt.bv<2>
+  // CHECK-NEXT: %[[STORED:.+]] = smt.array.store %[[ARR]][%[[IDX]]], %[[VAL]] : !smt.array<[!smt.bv<2> -> !smt.bv<8>]>
+  // CHECK-NEXT: %[[RESULT:.+]] = smt.ite %[[CMP]], %[[STORED]], %[[ARR]] : !smt.array<[!smt.bv<2> -> !smt.bv<8>]>
+  // CHECK-NEXT: return %[[RESULT]] : !smt.array<[!smt.bv<2> -> !smt.bv<8>]>
+  %arr_injected = hw.array_inject %arr[%index], %v : !hw.array<3xi8>, i2
+  hw.output %arr_injected : !hw.array<3xi8>
+}


### PR DESCRIPTION
This commit implements the lowering of hw.array_inject operations to SMT expressions using smt.array.store operations. The lowering creates a new array with the specified element injected at the given index, with proper bounds checking to handle out-of-bounds accesses gracefully.

The implementation includes bounds checking that compares the index against the maximum valid index (numElements - 1) and uses smt.ite to return either the updated array (if in bounds) or the original array (if out of bounds).