### PR TITLE
[MooreToCore] Preserve module port order

### DIFF
--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -81,14 +81,13 @@ static hw::ModulePortInfo getModulePortInfo(const TypeConverter &typeConverter,
   size_t inputNum = 0;
   size_t resultNum = 0;
   auto moduleTy = op.getModuleType();
-  SmallVector<hw::PortInfo> inputs, outputs;
-  inputs.reserve(moduleTy.getNumInputs());
-  outputs.reserve(moduleTy.getNumOutputs());
+  SmallVector<hw::PortInfo> ports;
+  ports.reserve(moduleTy.getNumPorts());
 
   for (auto port : moduleTy.getPorts()) {
     Type portTy = typeConverter.convertType(port.type);
     if (auto ioTy = dyn_cast_or_null<hw::InOutType>(portTy)) {
-      inputs.push_back(hw::PortInfo(
+      ports.push_back(hw::PortInfo(
           {{port.name, ioTy.getElementType(), hw::ModulePort::InOut},
            inputNum++,
            {}}));
@@ -96,7 +95,7 @@ static hw::ModulePortInfo getModulePortInfo(const TypeConverter &typeConverter,
     }
 
     if (port.dir == hw::ModulePort::Direction::Output) {
-      outputs.push_back(
+      ports.push_back(
           hw::PortInfo({{port.name, portTy, port.dir}, resultNum++, {}}));
     } else {
       // FIXME: Once we support net<...>, ref<...> type to represent type of
@@ -104,12 +103,12 @@ static hw::ModulePortInfo getModulePortInfo(const TypeConverter &typeConverter,
       // port. It can change to generate corresponding types for direction of
       // port or do specified operation to it. Now inout and ref port is treated
       // as input port.
-      inputs.push_back(
+      ports.push_back(
           hw::PortInfo({{port.name, portTy, port.dir}, inputNum++, {}}));
     }
   }
 
-  return hw::ModulePortInfo(inputs, outputs);
+  return hw::ModulePortInfo(ports);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -425,6 +425,26 @@ moore.module private @SubModule_0(in %a : !moore.l1, in %b : !moore.l1, out c : 
   moore.output %0 : !moore.l1
 }
 
+// CHECK-LABEL: hw.module @PreservePortOrderTop(
+// CHECK-SAME:    out a : i42,
+// CHECK-SAME:    in %b : i42
+// CHECK-SAME:  ) {
+moore.module @PreservePortOrderTop(out a: !moore.i42, in %b: !moore.i42) {
+  // CHECK: [[TMP:%.+]] = hw.instance "inst" @PreservePortOrder(x: %b: i42, z: %b: i42) -> (y: i42)
+  // CHECK: hw.output [[TMP]] : i42
+  %0 = moore.instance "inst" @PreservePortOrder(x: %b: !moore.i42, z: %b: !moore.i42) -> (y: !moore.i42)
+  moore.output %0 : !moore.i42
+}
+
+// CHECK-LABEL: hw.module private @PreservePortOrder(
+// CHECK-SAME:    in %x : i42,
+// CHECK-SAME:    out y : i42,
+// CHECK-SAME:    in %z : i42
+// CHECK-SAME:  ) {
+moore.module private @PreservePortOrder(in %x: !moore.i42, out y: !moore.i42, in %z: !moore.i42) {
+  moore.output %x : !moore.i42
+}
+
 // CHECK-LABEL: hw.module @Variable
 moore.module @Variable() {
   // CHECK: [[TMP0:%.+]] = hw.constant 0 : i32


### PR DESCRIPTION
Preserve the order of module ports when converting from `moore.module` to `hw.module`. The current implementation populates separate input and output vectors, which makes all inputs appear before all outputs. The updated version just populates a single array of ports, which preserves order. This makes it easier to round-trip Verilog through circt-verilog, and makes the output of circt-verilog more predictable.