### PR TITLE
[circt-verilog] Add register-to-memory pass to pipeline

### DIFF
--- a/test/circt-verilog/memories.sv
+++ b/test/circt-verilog/memories.sv
@@ -1,0 +1,34 @@
+// RUN: circt-verilog %s | FileCheck %s --check-prefixes=CHECK,MEMON
+// RUN: circt-verilog --detect-memories=1 %s | FileCheck %s --check-prefixes=CHECK,MEMON
+// RUN: circt-verilog --detect-memories=0 %s | FileCheck %s --check-prefixes=CHECK,MEMOFF
+// REQUIRES: slang
+// Internal issue in Slang v3 about jump depending on uninitialised value.
+// UNSUPPORTED: valgrind
+
+// CHECK-LABEL: hw.module @Memory(
+module Memory(
+  input  bit clock,
+  input  bit [3:0] waddr,
+  input  bit [41:0] wdata,
+  input  bit wenable,
+  input  bit [3:0] raddr,
+  output bit [41:0] rdata
+);
+  // CHECK-DAG: [[CLK:%.+]] = seq.to_clock %clock
+
+  // MEMON-DAG: [[MEM:%.+]] = seq.firmem 0, 1, undefined, undefined : <16 x 42, mask 1>
+  // MEMON-DAG: [[RDATA:%.+]] = seq.firmem.read_port [[MEM]][%raddr]
+  // MEMON-DAG: seq.firmem.write_port %mem[%waddr] = %wdata, clock [[CLK]] enable %wenable
+
+  // MEMOFF-DAG: [[REG:%.+]] = seq.firreg [[NEXT:%.+]] clock [[CLK]] : !hw.array<16xi42>
+  // MEMOFF-DAG: [[TMP:%.+]] = hw.array_inject [[REG]][%waddr], %wdata
+  // MEMOFF-DAG: [[NEXT]] = comb.mux bin %wenable, [[TMP]], [[REG]]
+  // MEMOFF-DAG: [[RDATA:%.+]] = hw.array_get [[REG]][%raddr]
+
+  // CHECK: hw.output [[RDATA]]
+  bit [41:0] storage [15:0];
+  always_ff @(posedge clock)
+    if (wenable)
+      storage[waddr] <= wdata;
+  assign rdata = storage[raddr];
+endmodule

--- a/tools/circt-verilog/CMakeLists.txt
+++ b/tools/circt-verilog/CMakeLists.txt
@@ -9,6 +9,7 @@ set(libs
   CIRCTMooreToCore
   CIRCTMooreTransforms
   CIRCTSeq
+  CIRCTSeqTransforms
   CIRCTSim
   CIRCTSupport
   CIRCTTransforms


### PR DESCRIPTION
Add the new RegOfVecToMem pass to the circt-verilog pipeline. This will detect memories described as `always` blocks and map them from the current `seq.firreg` representation to the correpsonding `seq.firmem`. This allows later parts of the pipeline to reason about memories more easily and transform them if needed.