### PR TITLE
[HWToLLVM] Add lowering support for 'hw.array_inject' op

### DIFF
--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -148,7 +148,7 @@ struct ArrayInjectOpConversion
   matchAndRewrite(hw::ArrayInjectOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto inputType = cast<hw::ArrayType>(op.getInput().getType());
-    auto oldArrTy = typeConverter->convertType(inputType);
+    auto oldArrTy = adaptor.getInput().getType();
     auto newArrTy = oldArrTy;
     const size_t arrElems = inputType.getNumElements();
 

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -64,66 +64,58 @@ func.func @convertArray(%arg0 : i1, %arg1: !hw.array<2xi32>, %arg2: i32, %arg3: 
   // CHECK-NEXT: [[V10:%.*]] = llvm.insertvalue %arg2, [[V9]][3] : !llvm.array<4 x i32>
   %3 = hw.array_create %arg2, %arg3, %arg4, %arg5 : i32
 
-  // CHECK-NEXT: %[[ONE2:.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT: %[[ALLOCA2:.*]] = llvm.alloca %[[ONE2]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST0]], %[[ALLOCA2]] : !llvm.array<2 x i32>, !llvm.ptr
-  // CHECK-NEXT: %[[ZEXT:.*]] = llvm.zext %arg0 : i1 to i2
-  // CHECK-NEXT: %[[GEP2:.*]] = llvm.getelementptr %[[ALLOCA2]][0, %[[ZEXT]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
-  // CHECK-NEXT: llvm.store %arg2, %[[GEP2]] : i32, !llvm.ptr
-  // CHECK-NEXT: llvm.load %[[ALLOCA2]] : !llvm.ptr -> !llvm.array<2 x i32>
-  %4 = hw.array_inject %arg1[%arg0], %arg2 : !hw.array<2xi32>, i1
-
   return
 }
 
 // CHECK-LABEL: @convertArrayInject
 func.func @convertArrayInject(
   %arg0: !hw.array<0xi32>, %arg1: !hw.array<1xi32>, %arg2: !hw.array<2xi32>, %arg3: !hw.array<5xi32>,
-  %arg4: i32, %arg5: i64, %arg6: i1, %arg7: i3) {
+  %arg4: i32, %arg5: i64, %arg6: i1, %arg7: i3, %arg8: i64) {
   // CHECK-DAG: %[[CAST0:.*]] = builtin.unrealized_conversion_cast %arg0 : !hw.array<0xi32> to !llvm.array<0 x i32>
   // CHECK-DAG: %[[CAST1:.*]] = builtin.unrealized_conversion_cast %arg1 : !hw.array<1xi32> to !llvm.array<1 x i32>
   // CHECK-DAG: %[[CAST2:.*]] = builtin.unrealized_conversion_cast %arg2 : !hw.array<2xi32> to !llvm.array<2 x i32>
   // CHECK-DAG: %[[CAST3:.*]] = builtin.unrealized_conversion_cast %arg3 : !hw.array<5xi32> to !llvm.array<5 x i32>
 
-  // CHECK-NEXT: %[[ONE0:.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT: %[[ALLOCA0:.*]] = llvm.alloca %[[ONE0]] x !llvm.array<0 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST0]], %[[ALLOCA0]] : !llvm.array<0 x i32>, !llvm.ptr
-  // CHECK-NEXT: %[[ZEXT0:.*]] = llvm.zext %arg5 : i64 to i65
-  // CHECK-NEXT: %[[GEP0:.*]] = llvm.getelementptr %[[ALLOCA0]][0, %[[ZEXT0]]] : (!llvm.ptr, i65) -> !llvm.ptr, !llvm.array<0 x i32>
-  // CHECK-NEXT: llvm.store %arg4, %[[GEP0]] : i32, !llvm.ptr
-  // CHECK-NEXT: llvm.load %[[ALLOCA0]] : !llvm.ptr -> !llvm.array<0 x i32>
   %0 = hw.array_inject %arg0[%arg5], %arg4 : !hw.array<0xi32>, i64
 
   // CHECK-NEXT: %[[ONE1:.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT: %[[ALLOCA1:.*]] = llvm.alloca %[[ONE1]] x !llvm.array<1 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST1]], %[[ALLOCA1]] : !llvm.array<1 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[ZEXT1:.*]] = llvm.zext %arg6 : i1 to i2
-  // CHECK-NEXT: %[[MAX1:.*]] = llvm.mlir.constant(0 : i32) : i2
+  // CHECK-NEXT: %[[MAX1:.*]] = llvm.mlir.constant(1 : i32) : i2
   // CHECK-NEXT: %[[UMIN1:.*]] = llvm.intr.umin(%[[ZEXT1]], %[[MAX1]]) : (i2, i2) -> i2
-  // CHECK-NEXT: %[[GEP1:.*]] = llvm.getelementptr %[[ALLOCA1]][0, %[[UMIN1]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<1 x i32>
+  // CHECK-NEXT: %[[ALLOCA1:.*]] = llvm.alloca %[[ONE1]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
+  // CHECK-NEXT: llvm.store %[[CAST1]], %[[ALLOCA1]] : !llvm.array<1 x i32>, !llvm.ptr
+  // CHECK-NEXT: %[[GEP1:.*]] = llvm.getelementptr %[[ALLOCA1]][0, %[[UMIN1]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.store %arg4, %[[GEP1]] : i32, !llvm.ptr
   // CHECK-NEXT: llvm.load %[[ALLOCA1]] : !llvm.ptr -> !llvm.array<1 x i32>
   %1 = hw.array_inject %arg1[%arg6], %arg4 : !hw.array<1xi32>, i1
 
   // CHECK-NEXT: %[[ONE2:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT: %[[ZEXT2:.*]] = llvm.zext %arg6 : i1 to i2
   // CHECK-NEXT: %[[ALLOCA2:.*]] = llvm.alloca %[[ONE2]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
   // CHECK-NEXT: llvm.store %[[CAST2]], %[[ALLOCA2]] : !llvm.array<2 x i32>, !llvm.ptr
-  // CHECK-NEXT: %[[ZEXT2:.*]] = llvm.zext %arg6 : i1 to i2
   // CHECK-NEXT: %[[GEP2:.*]] = llvm.getelementptr %[[ALLOCA2]][0, %[[ZEXT2]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.store %arg4, %[[GEP2]] : i32, !llvm.ptr
   // CHECK-NEXT: llvm.load %[[ALLOCA2]] : !llvm.ptr -> !llvm.array<2 x i32>
   %2 = hw.array_inject %arg2[%arg6], %arg4 : !hw.array<2xi32>, i1
 
   // CHECK-NEXT: %[[ONE3:.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT: %[[ALLOCA3:.*]] = llvm.alloca %[[ONE3]] x !llvm.array<5 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[CAST3]], %[[ALLOCA3]] : !llvm.array<5 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[ZEXT3:.*]] = llvm.zext %arg7 : i3 to i4
-  // CHECK-NEXT: %[[MAX3:.*]] = llvm.mlir.constant(4 : i32) : i4
+  // CHECK-NEXT: %[[MAX3:.*]] = llvm.mlir.constant(5 : i32) : i4
   // CHECK-NEXT: %[[UMIN3:.*]] = llvm.intr.umin(%[[ZEXT3]], %[[MAX3]]) : (i4, i4) -> i4
-  // CHECK-NEXT: %[[GEP3:.*]] = llvm.getelementptr %[[ALLOCA3]][0, %[[UMIN3]]] : (!llvm.ptr, i4) -> !llvm.ptr, !llvm.array<5 x i32>
+  // CHECK-NEXT: %[[ALLOCA3:.*]] = llvm.alloca %[[ONE3]] x !llvm.array<6 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
+  // CHECK-NEXT: llvm.store %[[CAST3]], %[[ALLOCA3]] : !llvm.array<5 x i32>, !llvm.ptr
+  // CHECK-NEXT: %[[GEP3:.*]] = llvm.getelementptr %[[ALLOCA3]][0, %[[UMIN3]]] : (!llvm.ptr, i4) -> !llvm.ptr, !llvm.array<6 x i32>
   // CHECK-NEXT: llvm.store %arg4, %[[GEP3]] : i32, !llvm.ptr
   // CHECK-NEXT: llvm.load %[[ALLOCA3]] : !llvm.ptr -> !llvm.array<5 x i32>
   %3 = hw.array_inject %arg3[%arg7], %arg4 : !hw.array<5xi32>, i3
+
+  // CHECK-NEXT: %[[ONE4:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT: %[[ALLOCA4:.*]] = llvm.alloca %[[ONE4]] x !llvm.array<0 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
+  // CHECK-NEXT: llvm.store %[[CAST0]], %[[ALLOCA4]] : !llvm.array<0 x i32>, !llvm.ptr
+  // CHECK-NEXT: %[[ZEXT4:.*]] = llvm.zext %arg8 : i64 to i65
+  // CHECK-NEXT: %[[GEP4:.*]] = llvm.getelementptr %[[ALLOCA4]][0, %[[ZEXT4]]] : (!llvm.ptr, i65) -> !llvm.ptr, !llvm.array<0 x i32>
+  // CHECK-NEXT: llvm.load %[[GEP4]] : !llvm.ptr -> i32
+  %4 = hw.array_get %0[%arg8] : !hw.array<0xi32>, i64
 
   return
 }
@@ -178,12 +170,12 @@ func.func @convertConstArray(%arg0 : i1, %arg1 : i32) {
   %4 = hw.aggregate_constant [[0 : i32, 1 : i1], [2 : i32, 0 : i1]] : !hw.array<2x!hw.struct<a: i32, b: i1>>
 
   // CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
-  // CHECK-NEXT: %[[ALLOCA:.*]] = llvm.alloca %[[ONE]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
-  // CHECK-NEXT: llvm.store %[[VAL_3]], %[[ALLOCA]] : !llvm.array<2 x i32>, !llvm.ptr
-  // CHECK-NEXT: %[[VAL_10:.*]] = llvm.zext %arg0 : i1 to i2
-  // CHECK-NEXT: %[[VAL_11:.*]] = llvm.getelementptr %[[ALLOCA]][0, %[[VAL_10]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
-  // CHECK-NEXT: llvm.store %arg1, %[[VAL_11]] : i32, !llvm.ptr
-  // CHECK-NEXT: %{{.+}} = llvm.load %[[ALLOCA]] : !llvm.ptr -> !llvm.array<2 x i32>
+  // CHECK-NEXT: %[[ZEXT0:.*]] = llvm.zext %arg0 : i1 to i2
+  // CHECK-NEXT: %[[ALLOCA0:.*]] = llvm.alloca %[[ONE]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
+  // CHECK-NEXT: llvm.store %[[VAL_3]], %[[ALLOCA0]] : !llvm.array<2 x i32>, !llvm.ptr
+  // CHECK-NEXT: %[[GEP0:.*]] = llvm.getelementptr %[[ALLOCA0]][0, %[[ZEXT0]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
+  // CHECK-NEXT: llvm.store %arg1, %[[GEP0]] : i32, !llvm.ptr
+  // CHECK-NEXT: %{{.+}} = llvm.load %[[ALLOCA0]] : !llvm.ptr -> !llvm.array<2 x i32>
   %5 = hw.array_inject %0[%arg0], %arg1 : !hw.array<2xi32>, i1
 
   return

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -125,10 +125,13 @@ func.func @convertConstArray(%arg0 : i1, %arg1 : i32) {
   // CHECK-NEXT: {{%.+}} = llvm.load %[[VAL_9]] : !llvm.ptr -> !llvm.array<2 x struct<(i1, i32)>>
   %4 = hw.aggregate_constant [[0 : i32, 1 : i1], [2 : i32, 0 : i1]] : !hw.array<2x!hw.struct<a: i32, b: i1>>
 
+  // CHECK-NEXT: %[[ONE:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT: %[[ALLOCA:.*]] = llvm.alloca %[[ONE]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
+  // CHECK-NEXT: llvm.store %[[VAL_3]], %[[ALLOCA]] : !llvm.array<2 x i32>, !llvm.ptr
   // CHECK-NEXT: %[[VAL_10:.*]] = llvm.zext %arg0 : i1 to i2
-  // CHECK-NEXT: %[[VAL_11:.*]] = llvm.getelementptr %[[VAL_2]][0, %[[VAL_10]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
+  // CHECK-NEXT: %[[VAL_11:.*]] = llvm.getelementptr %[[ALLOCA]][0, %[[VAL_10]]] : (!llvm.ptr, i2) -> !llvm.ptr, !llvm.array<2 x i32>
   // CHECK-NEXT: llvm.store %arg1, %[[VAL_11]] : i32, !llvm.ptr
-  // CHECK-NEXT: %{{.+}} = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.array<2 x i32>
+  // CHECK-NEXT: %{{.+}} = llvm.load %[[ALLOCA]] : !llvm.ptr -> !llvm.array<2 x i32>
   %5 = hw.array_inject %0[%arg0], %arg1 : !hw.array<2xi32>, i1
 
   return


### PR DESCRIPTION
This adds lowering support for the `hw.array_inject` operation into `llvm` dialect.