### PR TITLE
[SV][ETC] Quick fix for extraction involving $signed/$unsigned.

### DIFF
--- a/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
+++ b/lib/Dialect/SV/Transforms/SVExtractTestCode.cpp
@@ -631,6 +631,11 @@ bool isInDesign(hw::HWSymbolCache &symCache, Operation *op,
   if (isa<TimeOp, sv::FuncCallProceduralOp>(op))
     return false;
 
+  if (auto system = dyn_cast<SystemFunctionOp>(op);
+      system &&
+      (system.getFnName() == "signed" || system.getFnName() == "unsigned"))
+    return false;
+
   // Otherwise, operations with memory effects as a part design.
   return !mlir::isMemoryEffectFree(op);
 }


### PR DESCRIPTION
Just check for these specifically in the classification logic.

Fixes #8771.