### PR TITLE
Migrate away from ArrayRef(std::nullopt_t)

### DIFF
--- a/include/circt/Dialect/Arc/ArcOps.td
+++ b/include/circt/Dialect/Arc/ArcOps.td
@@ -123,7 +123,7 @@ def OutputOp : ArcOp<"output", [
     attr-dict ($outputs^ `:` qualified(type($outputs)))?
   }];
   let builders = [OpBuilder<(ins), [{
-    build($_builder, $_state, std::nullopt);
+    build($_builder, $_state, mlir::ValueRange());
   }]>];
   let hasVerifier = 1;
 }

--- a/include/circt/Dialect/FSM/FSMOps.td
+++ b/include/circt/Dialect/FSM/FSMOps.td
@@ -240,7 +240,7 @@ def OutputOp : FSMOp<"output", [HasParent<"StateOp">, ReturnLike, Terminator]> {
 
   let arguments = (ins Variadic<AnyType>:$operands);
 
-  let builders = [ OpBuilder<(ins), "build($_builder, $_state, std::nullopt);"> ];
+  let builders = [ OpBuilder<(ins), "build($_builder, $_state, mlir::ValueRange());"> ];
 
   let assemblyFormat = [{ attr-dict ($operands^ `:` qualified(type($operands)))? }];
 

--- a/include/circt/Dialect/HW/HWStructure.td
+++ b/include/circt/Dialect/HW/HWStructure.td
@@ -572,7 +572,7 @@ def OutputOp : HWOp<"output", [Terminator, HasParent<"HWModuleOp">,
   let arguments = (ins Variadic<AnyType>:$outputs);
 
   let builders = [
-    OpBuilder<(ins), "build($_builder, $_state, std::nullopt);">
+    OpBuilder<(ins), "build($_builder, $_state, mlir::ValueRange());">
   ];
 
   let assemblyFormat = "attr-dict ($outputs^ `:` qualified(type($outputs)))?";

--- a/include/circt/Dialect/Interop/Interop.td
+++ b/include/circt/Dialect/Interop/Interop.td
@@ -204,7 +204,7 @@ def ReturnOp : InteropOp<"return", [
   let arguments = (ins Variadic<AnyType>:$returnValues);
 
   let builders = [OpBuilder<(ins), [{
-    build($_builder, $_state, std::nullopt);
+    build($_builder, $_state, mlir::ValueRange());
   }]>];
 
   let assemblyFormat = "attr-dict ($returnValues^ `:` type($returnValues))?";

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -94,7 +94,7 @@ def OutputOp : MooreOp<"output", [
 
   let arguments = (ins Variadic<AnyType>:$outputs);
   let builders = [
-    OpBuilder<(ins), [{ build($_builder, $_state, std::nullopt); }]>
+    OpBuilder<(ins), [{ build($_builder, $_state, mlir::ValueRange()); }]>
   ];
   let assemblyFormat = [{
     attr-dict ($outputs^ `:` type($outputs))?

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -235,7 +235,7 @@ def InterfaceInstanceOp : SVOp<"interface.instance", [
 
   let builders = [
     OpBuilder<(ins "::mlir::Type":$result), [{
-      return build($_builder, $_state, result, std::nullopt);
+      return build($_builder, $_state, result, mlir::ValueRange());
     }]>
   ];
 

--- a/include/circt/Dialect/Seq/SeqOps.td
+++ b/include/circt/Dialect/Seq/SeqOps.td
@@ -753,7 +753,7 @@ def YieldOp : SeqOp<"yield",
 
   let arguments = (ins Variadic<AnyType>:$operands);
   let builders = [
-    OpBuilder<(ins), "build($_builder, $_state, std::nullopt);">
+    OpBuilder<(ins), "build($_builder, $_state, mlir::ValueRange());">
   ];
 
   let assemblyFormat = "attr-dict ($operands^ `:` type($operands))?";

--- a/include/circt/Dialect/SystemC/SystemCStructure.td
+++ b/include/circt/Dialect/SystemC/SystemCStructure.td
@@ -447,7 +447,7 @@ def ReturnOp : SystemCOp<"cpp.return", [
   let arguments = (ins Variadic<AnyType>:$returnValues);
 
   let builders = [OpBuilder<(ins), [{
-    build($_builder, $_state, std::nullopt);
+    build($_builder, $_state, mlir::ValueRange());
   }]>];
 
   let assemblyFormat = "attr-dict ($returnValues^ `:` type($returnValues))?";

--- a/include/circt/Dialect/Verif/VerifOps.td
+++ b/include/circt/Dialect/Verif/VerifOps.td
@@ -308,7 +308,7 @@ def YieldOp : VerifOp<"yield", [
 
   let builders = [
     OpBuilder<(ins), [{
-      build($_builder, $_state, std::nullopt);
+      build($_builder, $_state, mlir::ValueRange());
     }]>,
   ];
 }

--- a/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
+++ b/lib/Conversion/ArcToLLVM/LowerArcToLLVM.cpp
@@ -505,7 +505,7 @@ struct SimStepOpLowering : public ModelAwarePattern<arc::SimStepOp> {
 
     StringAttr evalFunc =
         rewriter.getStringAttr(evalSymbolFromModelName(modelName));
-    rewriter.replaceOpWithNewOp<LLVM::CallOp>(op, std::nullopt, evalFunc,
+    rewriter.replaceOpWithNewOp<LLVM::CallOp>(op, mlir::TypeRange(), evalFunc,
                                               adaptor.getInstance());
 
     return success();


### PR DESCRIPTION
LLVM has deprecated ArrayRef(std::nullopt_t).  This CL migrates away
from that.
