### PR TITLE
[ESI] Disallow calls on an unconnected `FuncService::Function`

### DIFF
--- a/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
+++ b/lib/Dialect/ESI/runtime/cpp/include/esi/Services.h
@@ -284,6 +284,7 @@ public:
     std::mutex callMutex;
     WriteChannelPort *arg;
     ReadChannelPort *result;
+    bool connected = false;
   };
 
 private:

--- a/lib/Dialect/ESI/runtime/cpp/lib/Services.cpp
+++ b/lib/Dialect/ESI/runtime/cpp/lib/Services.cpp
@@ -200,16 +200,21 @@ FuncService::Function *FuncService::Function::get(AppID id, BundleType *type,
 }
 
 void FuncService::Function::connect() {
+  if (connected)
+    throw std::runtime_error("Function is already connected");
   if (channels.size() != 2)
     throw std::runtime_error("FuncService must have exactly two channels");
   arg = &getRawWrite("arg");
   arg->connect();
   result = &getRawRead("result");
   result->connect();
+  connected = true;
 }
 
 std::future<MessageData>
 FuncService::Function::call(const MessageData &argData) {
+  if (!connected)
+    throw std::runtime_error("Function must be 'connect'ed before calling");
   std::scoped_lock<std::mutex> lock(callMutex);
   arg->write(argData);
   return result->readAsync();


### PR DESCRIPTION
because currently, that'll result in segfaults.