### PR TITLE
[ESI] Also publish releases on workflow_dispatch

### DIFF
--- a/.github/workflows/esiRuntimePublish.yml
+++ b/.github/workflows/esiRuntimePublish.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload wheels to pypi
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.repository == 'llvm/circt' && (github.ref_type == 'tag' || github.event_name == 'schedule')
+        if: github.repository == 'llvm/circt' && (github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         with:
           packages-dir: wheelhouse/
           verify-metadata: false


### PR DESCRIPTION
Minor bugfixes _during development_ doesn't always warrant a new ESI tag. Allow the `esiRuntimePublish` pipeline to publish `dev` packages upon manual CI runs (`workflow_dispatch`).