### PR TITLE
[ESI] Expose accelerator through AcceleratorConnection py api

### DIFF
--- a/lib/Dialect/ESI/runtime/python/esiaccel/accelerator.py
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/accelerator.py
@@ -41,6 +41,13 @@ class AcceleratorConnection:
   def get_service_hostmem(self) -> cpp.HostMem:
     return self.cpp_accel.get_service_hostmem()
 
+  def get_accelerator(self) -> "Accelerator":
+    """
+    Return an accelerator that may be owned by this accelerator connection.
+    If no accelerator is owned, will throw.
+    """
+    return Accelerator(self.cpp_accel.get_accelerator())
+
 
 from .esiCppAccel import HostMemOptions
 

--- a/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
+++ b/lib/Dialect/ESI/runtime/python/esiaccel/esiCppAccel.cpp
@@ -402,7 +402,9 @@ PYBIND11_MODULE(esiCppAccel, m) {
           [](AcceleratorConnection &acc) {
             return acc.getService<services::HostMem>({});
           },
-          py::return_value_policy::reference);
+          py::return_value_policy::reference)
+      .def("get_accelerator", &AcceleratorConnection::getAccelerator,
+           py::return_value_policy::reference);
 
   py::class_<Manifest>(m, "Manifest")
       .def(py::init<Context &, std::string>())


### PR DESCRIPTION
It is possible that the `AcceleratorConnection` that is instantiated has handed ownership of a constructed accelerator through ` `AcceleratorConnection::takeOwnership`. In that case, it should be possible to retrieve a handle to the given accelerator through the python API. That is this PR.